### PR TITLE
Update wordpress/data documentation in order to prefer store object instead of store name to access the store

### DIFF
--- a/packages/data/README.md
+++ b/packages/data/README.md
@@ -481,7 +481,8 @@ _Returns_
 
 ### dispatch
 
-Given the name of a registered store, returns an object of the store's action creators.
+Given a store descriptor (also supports legacy calling convention accepting the name of a
+registered store), returns an object of the store's action creators.
 Calling an action creator will cause it to be dispatched, updating the state value accordingly.
 
 Note: Action creators returned by the dispatch will return a promise when
@@ -607,10 +608,10 @@ example.
 
 ### resolveSelect
 
-Given the name of a registered store, returns an object containing the store's
-selectors pre-bound to state so that you only need to supply additional arguments,
-and modified so that they return promises that resolve to their eventual values,
-after any resolvers have ran.
+Given a store descriptor (also supports legacy calling convention accepting the name of a
+registered store), returns an object containing the store's selectors pre-bound to state
+so that you only need to supply additional arguments, and modified so that they return promises
+that resolve to their eventual values, after any resolvers have ran.
 
 _Usage_
 
@@ -631,8 +632,9 @@ _Returns_
 
 ### select
 
-Given the name or descriptor of a registered store, returns an object of the store's selectors.
-The selector functions are been pre-bound to pass the current state automatically.
+Given a store descriptor (also supports legacy calling convention accepting the name of a
+registered store), returns an object of the store's selectors. The selector functions are
+been pre-bound to pass the current state automatically.
 As a consumer, you need only pass arguments of the selector, if applicable.
 
 _Usage_
@@ -678,9 +680,10 @@ _Parameters_
 
 ### suspendSelect
 
-Given the name of a registered store, returns an object containing the store's
-selectors pre-bound to state so that you only need to supply additional arguments,
-and modified so that they throw promises in case the selector is not resolved yet.
+Given a store descriptor (also supports legacy calling convention accepting the name of a
+registered store), returns an object containing the store's selectors pre-bound to state so
+that you only need to supply additional arguments, and modified so that they throw promises
+in case the selector is not resolved yet.
 
 _Parameters_
 

--- a/packages/data/README.md
+++ b/packages/data/README.md
@@ -278,10 +278,11 @@ _Usage_
 
 ```js
 import { useSelect, AsyncModeProvider } from '@wordpress/data';
+import { store as blockEditorStore } from '@wordpress/block-editor';
 
 function BlockCount() {
 	const count = useSelect( ( select ) => {
-		return select( 'core/block-editor' ).getBlockCount();
+		return select( blockEditorStore ).getBlockCount();
 	}, [] );
 
 	return count;
@@ -446,15 +447,18 @@ that supports also selecting from other registered stores.
 _Usage_
 
 ```js
+import { store as coreStore } from '@wordpress/core-data';
+import { store as editorStore } from '@wordpress/editor';
+
 const getCurrentPostId = createRegistrySelector( ( select ) => ( state ) => {
-	return select( 'core/editor' ).getCurrentPostId();
+	return select( editorStore ).getCurrentPostId();
 } );
 
 const getPostEdits = createRegistrySelector( ( select ) => ( state ) => {
 	// calling another registry selector just like any other function
 	const postType = getCurrentPostType( state );
 	const postId = getCurrentPostId( state );
-	return select( 'core' ).getEntityRecordEdits(
+	return select( coreStore ).getEntityRecordEdits(
 		'postType',
 		postType,
 		postId
@@ -488,7 +492,7 @@ _Usage_
 ```js
 import { dispatch } from '@wordpress/data';
 
-dispatch( 'my-shop' ).setPrice( 'hammer', 9.75 );
+dispatch( store ).setPrice( 'hammer', 9.75 );
 ```
 
 _Parameters_
@@ -612,7 +616,7 @@ _Usage_
 ```js
 import { resolveSelect } from '@wordpress/data';
 
-resolveSelect( 'my-shop' ).getPrice( 'hammer' ).then( console.log );
+resolveSelect( store ).getPrice( 'hammer' ).then( console.log );
 ```
 
 _Parameters_
@@ -634,7 +638,7 @@ _Usage_
 ```js
 import { select } from '@wordpress/data';
 
-select( 'my-shop' ).getPrice( 'hammer' );
+select( store ).getPrice( 'hammer' );
 ```
 
 _Parameters_
@@ -720,10 +724,10 @@ function Button( { onClick, children } ) {
 
 const SaleButton = ( { children } ) => {
 	const { stockNumber } = useSelect(
-		( select ) => select( 'my-shop' ).getStockNumber(),
+		( select ) => select( store ).getStockNumber(),
 		[]
 	);
-	const { startSale } = useDispatch( 'my-shop' );
+	const { startSale } = useDispatch( store );
 	const onClick = useCallback( () => {
 		const discountPercent = stockNumber > 50 ? 10 : 20;
 		startSale( discountPercent );
@@ -799,7 +803,7 @@ import { useSelect } from '@wordpress/data';
 function HammerPriceDisplay( { currency } ) {
 	const price = useSelect(
 		( select ) => {
-			return select( 'my-shop' ).getPrice( 'hammer', currency );
+			return select( store ).getPrice( 'hammer', currency );
 		},
 		[ currency ]
 	);
@@ -830,7 +834,7 @@ function because your component won't re-render on a data change.**
 import { useSelect } from '@wordpress/data';
 
 function Paste( { children } ) {
-	const { getSettings } = useSelect( 'my-shop' );
+	const { getSettings } = useSelect( store );
 	function onPaste() {
 		// Do something with the settings.
 		const settings = getSettings();
@@ -881,7 +885,7 @@ function Button( { onClick, children } ) {
 import { withDispatch } from '@wordpress/data';
 
 const SaleButton = withDispatch( ( dispatch, ownProps ) => {
-	const { startSale } = dispatch( 'my-shop' );
+	const { startSale } = dispatch( store );
 	const { discountPercent } = ownProps;
 
 	return {
@@ -922,8 +926,8 @@ import { withDispatch } from '@wordpress/data';
 
 const SaleButton = withDispatch( ( dispatch, ownProps, { select } ) => {
 	// Stock number changes frequently.
-	const { getStockNumber } = select( 'my-shop' );
-	const { startSale } = dispatch( 'my-shop' );
+	const { getStockNumber } = select( store );
+	const { startSale } = dispatch( store );
 	return {
 		onClick() {
 			const discountPercent = getStockNumber() > 50 ? 10 : 20;
@@ -980,7 +984,7 @@ function PriceDisplay( { price, currency } ) {
 }
 
 const HammerPriceDisplay = withSelect( ( select, ownProps ) => {
-	const { getPrice } = select( 'my-shop' );
+	const { getPrice } = select( store );
 	const { currency } = ownProps;
 
 	return {

--- a/packages/data/README.md
+++ b/packages/data/README.md
@@ -481,8 +481,7 @@ _Returns_
 
 ### dispatch
 
-Given a store descriptor (also supports legacy calling convention accepting the name of a
-registered store), returns an object of the store's action creators.
+Given a store descriptor, returns an object of the store's action creators.
 Calling an action creator will cause it to be dispatched, updating the state value accordingly.
 
 Note: Action creators returned by the dispatch will return a promise when
@@ -499,7 +498,7 @@ dispatch( myCustomStore ).setPrice( 'hammer', 9.75 );
 
 _Parameters_
 
--   _storeNameOrDescriptor_ `string|StoreDescriptor`: Unique namespace identifier for the store or the store descriptor.
+-   _storeNameOrDescriptor_ `StoreDescriptor|string`: Store descriptor (Object returned from `createReduxStore`). The legacy calling convention of passing the store name is also supported.
 
 _Returns_
 
@@ -608,8 +607,7 @@ example.
 
 ### resolveSelect
 
-Given a store descriptor (also supports legacy calling convention accepting the name of a
-registered store), returns an object containing the store's selectors pre-bound to state
+Given a store descriptor, returns an object containing the store's selectors pre-bound to state
 so that you only need to supply additional arguments, and modified so that they return promises
 that resolve to their eventual values, after any resolvers have ran.
 
@@ -624,7 +622,7 @@ resolveSelect( myCustomStore ).getPrice( 'hammer' ).then( console.log );
 
 _Parameters_
 
--   _storeNameOrDescriptor_ `string|StoreDescriptor`: Unique namespace identifier for the store or the store descriptor.
+-   _storeNameOrDescriptor_ `StoreDescriptor|string`: Store descriptor (Object returned from `createReduxStore`). The legacy calling convention of passing the store name is also supported.
 
 _Returns_
 
@@ -632,9 +630,8 @@ _Returns_
 
 ### select
 
-Given a store descriptor (also supports legacy calling convention accepting the name of a
-registered store), returns an object of the store's selectors. The selector functions are
-been pre-bound to pass the current state automatically.
+Given a store descriptor, returns an object of the store's selectors.
+The selector functions are been pre-bound to pass the current state automatically.
 As a consumer, you need only pass arguments of the selector, if applicable.
 
 _Usage_
@@ -648,7 +645,7 @@ select( myCustomStore ).getPrice( 'hammer' );
 
 _Parameters_
 
--   _storeNameOrDescriptor_ `string|StoreDescriptor`: Unique namespace identifier for the store or the store descriptor.
+-   _storeNameOrDescriptor_ `StoreDescriptor|string`: Store descriptor (Object returned from `createReduxStore`). The legacy calling convention of passing the store name is also supported.
 
 _Returns_
 
@@ -680,14 +677,13 @@ _Parameters_
 
 ### suspendSelect
 
-Given a store descriptor (also supports legacy calling convention accepting the name of a
-registered store), returns an object containing the store's selectors pre-bound to state so
-that you only need to supply additional arguments, and modified so that they throw promises
+Given a store descriptor, returns an object containing the store's selectors pre-bound to state
+so that you only need to supply additional arguments, and modified so that they throw promises
 in case the selector is not resolved yet.
 
 _Parameters_
 
--   _storeNameOrDescriptor_ `string|StoreDescriptor`: Unique namespace identifier for the store or the store descriptor.
+-   _storeNameOrDescriptor_ `StoreDescriptor|string`: Store descriptor (Object returned from `createReduxStore`). The legacy calling convention of passing the store name is also supported.
 
 _Returns_
 

--- a/packages/data/README.md
+++ b/packages/data/README.md
@@ -498,7 +498,7 @@ dispatch( myCustomStore ).setPrice( 'hammer', 9.75 );
 
 _Parameters_
 
--   _storeNameOrDescriptor_ `StoreDescriptor|string`: Store descriptor (Object returned from `createReduxStore`). The legacy calling convention of passing the store name is also supported.
+-   _storeNameOrDescriptor_ `StoreDescriptor|string`: The store descriptor. The legacy calling convention of passing the store name is also supported.
 
 _Returns_
 
@@ -622,7 +622,7 @@ resolveSelect( myCustomStore ).getPrice( 'hammer' ).then( console.log );
 
 _Parameters_
 
--   _storeNameOrDescriptor_ `StoreDescriptor|string`: Store descriptor (Object returned from `createReduxStore`). The legacy calling convention of passing the store name is also supported.
+-   _storeNameOrDescriptor_ `StoreDescriptor|string`: The store descriptor. The legacy calling convention of passing the store name is also supported.
 
 _Returns_
 
@@ -645,7 +645,7 @@ select( myCustomStore ).getPrice( 'hammer' );
 
 _Parameters_
 
--   _storeNameOrDescriptor_ `StoreDescriptor|string`: Store descriptor (Object returned from `createReduxStore`). The legacy calling convention of passing the store name is also supported.
+-   _storeNameOrDescriptor_ `StoreDescriptor|string`: The store descriptor. The legacy calling convention of passing the store name is also supported.
 
 _Returns_
 
@@ -683,7 +683,7 @@ in case the selector is not resolved yet.
 
 _Parameters_
 
--   _storeNameOrDescriptor_ `StoreDescriptor|string`: Store descriptor (Object returned from `createReduxStore`). The legacy calling convention of passing the store name is also supported.
+-   _storeNameOrDescriptor_ `StoreDescriptor|string`: The store descriptor. The legacy calling convention of passing the store name is also supported.
 
 _Returns_
 

--- a/packages/data/README.md
+++ b/packages/data/README.md
@@ -491,8 +491,9 @@ _Usage_
 
 ```js
 import { dispatch } from '@wordpress/data';
+import { store as myCustomStore } from 'my-custom-store';
 
-dispatch( store ).setPrice( 'hammer', 9.75 );
+dispatch( myCustomStore ).setPrice( 'hammer', 9.75 );
 ```
 
 _Parameters_
@@ -615,8 +616,9 @@ _Usage_
 
 ```js
 import { resolveSelect } from '@wordpress/data';
+import { store as myCustomStore } from 'my-custom-store';
 
-resolveSelect( store ).getPrice( 'hammer' ).then( console.log );
+resolveSelect( myCustomStore ).getPrice( 'hammer' ).then( console.log );
 ```
 
 _Parameters_
@@ -637,8 +639,9 @@ _Usage_
 
 ```js
 import { select } from '@wordpress/data';
+import { store as myCustomStore } from 'my-custom-store';
 
-select( store ).getPrice( 'hammer' );
+select( myCustomStore ).getPrice( 'hammer' );
 ```
 
 _Parameters_
@@ -713,6 +716,7 @@ action.
 ```jsx
 import { useDispatch, useSelect } from '@wordpress/data';
 import { useCallback } from '@wordpress/element';
+import { store as myCustomStore } from 'my-custom-store';
 
 function Button( { onClick, children } ) {
 	return (
@@ -724,10 +728,10 @@ function Button( { onClick, children } ) {
 
 const SaleButton = ( { children } ) => {
 	const { stockNumber } = useSelect(
-		( select ) => select( store ).getStockNumber(),
+		( select ) => select( myCustomStore ).getStockNumber(),
 		[]
 	);
-	const { startSale } = useDispatch( store );
+	const { startSale } = useDispatch( myCustomStore );
 	const onClick = useCallback( () => {
 		const discountPercent = stockNumber > 50 ? 10 : 20;
 		startSale( discountPercent );
@@ -799,11 +803,12 @@ _Usage_
 
 ```js
 import { useSelect } from '@wordpress/data';
+import { store as myCustomStore } from 'my-custom-store';
 
 function HammerPriceDisplay( { currency } ) {
 	const price = useSelect(
 		( select ) => {
-			return select( store ).getPrice( 'hammer', currency );
+			return select( myCustomStore ).getPrice( 'hammer', currency );
 		},
 		[ currency ]
 	);
@@ -832,9 +837,10 @@ function because your component won't re-render on a data change.**
 
 ```js
 import { useSelect } from '@wordpress/data';
+import { store as myCustomStore } from 'my-custom-store';
 
 function Paste( { children } ) {
-	const { getSettings } = useSelect( store );
+	const { getSettings } = useSelect( myCustomStore );
 	function onPaste() {
 		// Do something with the settings.
 		const settings = getSettings();
@@ -883,9 +889,10 @@ function Button( { onClick, children } ) {
 }
 
 import { withDispatch } from '@wordpress/data';
+import { store as myCustomStore } from 'my-custom-store';
 
 const SaleButton = withDispatch( ( dispatch, ownProps ) => {
-	const { startSale } = dispatch( store );
+	const { startSale } = dispatch( myCustomStore );
 	const { discountPercent } = ownProps;
 
 	return {
@@ -923,11 +930,12 @@ function Button( { onClick, children } ) {
 }
 
 import { withDispatch } from '@wordpress/data';
+import { store as myCustomStore } from 'my-custom-store';
 
 const SaleButton = withDispatch( ( dispatch, ownProps, { select } ) => {
 	// Stock number changes frequently.
-	const { getStockNumber } = select( store );
-	const { startSale } = dispatch( store );
+	const { getStockNumber } = select( myCustomStore );
+	const { startSale } = dispatch( myCustomStore );
 	return {
 		onClick() {
 			const discountPercent = getStockNumber() > 50 ? 10 : 20;
@@ -975,6 +983,7 @@ _Usage_
 
 ```js
 import { withSelect } from '@wordpress/data';
+import { store as myCustomStore } from 'my-custom-store';
 
 function PriceDisplay( { price, currency } ) {
 	return new Intl.NumberFormat( 'en-US', {
@@ -984,7 +993,7 @@ function PriceDisplay( { price, currency } ) {
 }
 
 const HammerPriceDisplay = withSelect( ( select, ownProps ) => {
-	const { getPrice } = select( store );
+	const { getPrice } = select( myCustomStore );
 	const { currency } = ownProps;
 
 	return {

--- a/packages/data/src/components/async-mode-provider/context.js
+++ b/packages/data/src/components/async-mode-provider/context.js
@@ -17,10 +17,11 @@ export const AsyncModeConsumer = Consumer;
  *
  * ```js
  * import { useSelect, AsyncModeProvider } from '@wordpress/data';
+ * import { store as blockEditorStore } from '@wordpress/block-editor';
  *
  * function BlockCount() {
  *   const count = useSelect( ( select ) => {
- *     return select( 'core/block-editor' ).getBlockCount()
+ *     return select( blockEditorStore ).getBlockCount()
  *   }, [] );
  *
  *   return count;

--- a/packages/data/src/components/use-dispatch/use-dispatch.js
+++ b/packages/data/src/components/use-dispatch/use-dispatch.js
@@ -25,6 +25,7 @@ import useRegistry from '../registry-provider/use-registry';
  * ```jsx
  * import { useDispatch, useSelect } from '@wordpress/data';
  * import { useCallback } from '@wordpress/element';
+ * import { store as myCustomStore } from 'my-custom-store';
  *
  * function Button( { onClick, children } ) {
  *   return <button type="button" onClick={ onClick }>{ children }</button>
@@ -32,10 +33,10 @@ import useRegistry from '../registry-provider/use-registry';
  *
  * const SaleButton = ( { children } ) => {
  *   const { stockNumber } = useSelect(
- *     ( select ) => select( 'my-shop' ).getStockNumber(),
+ *     ( select ) => select( myCustomStore ).getStockNumber(),
  *     []
  *   );
- *   const { startSale } = useDispatch( 'my-shop' );
+ *   const { startSale } = useDispatch( myCustomStore );
  *   const onClick = useCallback( () => {
  *     const discountPercent = stockNumber > 50 ? 10: 20;
  *     startSale( discountPercent );

--- a/packages/data/src/components/use-select/index.js
+++ b/packages/data/src/components/use-select/index.js
@@ -54,10 +54,11 @@ const renderQueue = createQueue();
  * @example
  * ```js
  * import { useSelect } from '@wordpress/data';
+ * import { store as myCustomStore } from 'my-custom-store';
  *
  * function HammerPriceDisplay( { currency } ) {
  *   const price = useSelect( ( select ) => {
- *     return select( 'my-shop' ).getPrice( 'hammer', currency )
+ *     return select( myCustomStore ).getPrice( 'hammer', currency );
  *   }, [ currency ] );
  *   return new Intl.NumberFormat( 'en-US', {
  *     style: 'currency',
@@ -84,9 +85,10 @@ const renderQueue = createQueue();
  *
  * ```js
  * import { useSelect } from '@wordpress/data';
+ * import { store as myCustomStore } from 'my-custom-store';
  *
  * function Paste( { children } ) {
- *   const { getSettings } = useSelect( 'my-shop' );
+ *   const { getSettings } = useSelect( myCustomStore );
  *   function onPaste() {
  *     // Do something with the settings.
  *     const settings = getSettings();

--- a/packages/data/src/components/with-dispatch/index.js
+++ b/packages/data/src/components/with-dispatch/index.js
@@ -26,9 +26,10 @@ import { useDispatchWithMap } from '../use-dispatch';
  * }
  *
  * import { withDispatch } from '@wordpress/data';
+ * import { store as myCustomStore } from 'my-custom-store';
  *
  * const SaleButton = withDispatch( ( dispatch, ownProps ) => {
- *     const { startSale } = dispatch( 'my-shop' );
+ *     const { startSale } = dispatch( myCustomStore );
  *     const { discountPercent } = ownProps;
  *
  *     return {
@@ -63,11 +64,12 @@ import { useDispatchWithMap } from '../use-dispatch';
  * }
  *
  * import { withDispatch } from '@wordpress/data';
+ * import { store as myCustomStore } from 'my-custom-store';
  *
  * const SaleButton = withDispatch( ( dispatch, ownProps, { select } ) => {
  *    // Stock number changes frequently.
- *    const { getStockNumber } = select( 'my-shop' );
- *    const { startSale } = dispatch( 'my-shop' );
+ *    const { getStockNumber } = select( myCustomStore );
+ *    const { startSale } = dispatch( myCustomStore );
  *    return {
  *        onClick() {
  *            const discountPercent = getStockNumber() > 50 ? 10 : 20;

--- a/packages/data/src/components/with-select/index.js
+++ b/packages/data/src/components/with-select/index.js
@@ -19,6 +19,7 @@ import useSelect from '../use-select';
  * @example
  * ```js
  * import { withSelect } from '@wordpress/data';
+ * import { store as myCustomStore } from 'my-custom-store';
  *
  * function PriceDisplay( { price, currency } ) {
  * 	return new Intl.NumberFormat( 'en-US', {
@@ -28,7 +29,7 @@ import useSelect from '../use-select';
  * }
  *
  * const HammerPriceDisplay = withSelect( ( select, ownProps ) => {
- * 	const { getPrice } = select( 'my-shop' );
+ * 	const { getPrice } = select( myCustomStore );
  * 	const { currency } = ownProps;
  *
  * 	return {

--- a/packages/data/src/factory.js
+++ b/packages/data/src/factory.js
@@ -13,15 +13,18 @@
  *
  * @example
  * ```js
+ * import { store as coreStore } from '@wordpress/core-data';
+ * import { store as editorStore } from '@wordpress/editor';
+ *
  * const getCurrentPostId = createRegistrySelector( ( select ) => ( state ) => {
- *   return select( 'core/editor' ).getCurrentPostId();
+ *   return select( editorStore ).getCurrentPostId();
  * } );
  *
  * const getPostEdits = createRegistrySelector( ( select ) => ( state ) => {
  *   // calling another registry selector just like any other function
  *   const postType = getCurrentPostType( state );
  *   const postId = getCurrentPostId( state );
- *	 return select( 'core' ).getEntityRecordEdits( 'postType', postType, postId );
+ *	 return select( coreStore ).getEntityRecordEdits( 'postType', postType, postId );
  * } );
  * ```
  *

--- a/packages/data/src/index.js
+++ b/packages/data/src/index.js
@@ -90,8 +90,9 @@ export { combineReducers };
  * @example
  * ```js
  * import { select } from '@wordpress/data';
+ * import { store as myCustomStore } from 'my-custom-store';
  *
- * select( 'my-shop' ).getPrice( 'hammer' );
+ * select( myCustomStore ).getPrice( 'hammer' );
  * ```
  *
  * @return {Object} Object containing the store's selectors.
@@ -110,8 +111,9 @@ export const select = defaultRegistry.select;
  * @example
  * ```js
  * import { resolveSelect } from '@wordpress/data';
+ * import { store as myCustomStore } from 'my-custom-store';
  *
- * resolveSelect( 'my-shop' ).getPrice( 'hammer' ).then(console.log)
+ * resolveSelect( myCustomStore ).getPrice( 'hammer' ).then(console.log)
  * ```
  *
  * @return {Object} Object containing the store's promise-wrapped selectors.
@@ -143,8 +145,9 @@ export const suspendSelect = defaultRegistry.suspendSelect;
  * @example
  * ```js
  * import { dispatch } from '@wordpress/data';
+ * import { store as myCustomStore } from 'my-custom-store';
  *
- * dispatch( 'my-shop' ).setPrice( 'hammer', 9.75 );
+ * dispatch( myCustomStore ).setPrice( 'hammer', 9.75 );
  * ```
  * @return {Object} Object containing the action creators.
  */

--- a/packages/data/src/index.js
+++ b/packages/data/src/index.js
@@ -80,8 +80,9 @@ export { plugins };
 export { combineReducers };
 
 /**
- * Given the name or descriptor of a registered store, returns an object of the store's selectors.
- * The selector functions are been pre-bound to pass the current state automatically.
+ * Given a store descriptor (also supports legacy calling convention accepting the name of a
+ * registered store), returns an object of the store's selectors. The selector functions are
+ * been pre-bound to pass the current state automatically.
  * As a consumer, you need only pass arguments of the selector, if applicable.
  *
  * @param {string|StoreDescriptor} storeNameOrDescriptor Unique namespace identifier for the store
@@ -100,10 +101,10 @@ export { combineReducers };
 export const select = defaultRegistry.select;
 
 /**
- * Given the name of a registered store, returns an object containing the store's
- * selectors pre-bound to state so that you only need to supply additional arguments,
- * and modified so that they return promises that resolve to their eventual values,
- * after any resolvers have ran.
+ * Given a store descriptor (also supports legacy calling convention accepting the name of a
+ * registered store), returns an object containing the store's selectors pre-bound to state
+ * so that you only need to supply additional arguments, and modified so that they return promises
+ * that resolve to their eventual values, after any resolvers have ran.
  *
  * @param {string|StoreDescriptor} storeNameOrDescriptor Unique namespace identifier for the store
  *                                                       or the store descriptor.
@@ -121,9 +122,10 @@ export const select = defaultRegistry.select;
 export const resolveSelect = defaultRegistry.resolveSelect;
 
 /**
- * Given the name of a registered store, returns an object containing the store's
- * selectors pre-bound to state so that you only need to supply additional arguments,
- * and modified so that they throw promises in case the selector is not resolved yet.
+ * Given a store descriptor (also supports legacy calling convention accepting the name of a
+ * registered store), returns an object containing the store's selectors pre-bound to state so
+ * that you only need to supply additional arguments, and modified so that they throw promises
+ * in case the selector is not resolved yet.
  *
  * @param {string|StoreDescriptor} storeNameOrDescriptor Unique namespace identifier for the store
  *                                                       or the store descriptor.
@@ -133,7 +135,8 @@ export const resolveSelect = defaultRegistry.resolveSelect;
 export const suspendSelect = defaultRegistry.suspendSelect;
 
 /**
- * Given the name of a registered store, returns an object of the store's action creators.
+ * Given a store descriptor (also supports legacy calling convention accepting the name of a
+ * registered store), returns an object of the store's action creators.
  * Calling an action creator will cause it to be dispatched, updating the state value accordingly.
  *
  * Note: Action creators returned by the dispatch will return a promise when

--- a/packages/data/src/index.js
+++ b/packages/data/src/index.js
@@ -80,13 +80,14 @@ export { plugins };
 export { combineReducers };
 
 /**
- * Given a store descriptor (also supports legacy calling convention accepting the name of a
- * registered store), returns an object of the store's selectors. The selector functions are
- * been pre-bound to pass the current state automatically.
+ * Given a store descriptor, returns an object of the store's selectors.
+ * The selector functions are been pre-bound to pass the current state automatically.
  * As a consumer, you need only pass arguments of the selector, if applicable.
  *
- * @param {string|StoreDescriptor} storeNameOrDescriptor Unique namespace identifier for the store
- *                                                       or the store descriptor.
+ * @param {StoreDescriptor|string} storeNameOrDescriptor Store descriptor (Object returned from
+ *                                                       `createReduxStore`). The legacy calling
+ *                                                       convention of passing the store name is
+ *                                                       also supported.
  *
  * @example
  * ```js
@@ -101,13 +102,14 @@ export { combineReducers };
 export const select = defaultRegistry.select;
 
 /**
- * Given a store descriptor (also supports legacy calling convention accepting the name of a
- * registered store), returns an object containing the store's selectors pre-bound to state
+ * Given a store descriptor, returns an object containing the store's selectors pre-bound to state
  * so that you only need to supply additional arguments, and modified so that they return promises
  * that resolve to their eventual values, after any resolvers have ran.
  *
- * @param {string|StoreDescriptor} storeNameOrDescriptor Unique namespace identifier for the store
- *                                                       or the store descriptor.
+ * @param {StoreDescriptor|string} storeNameOrDescriptor Store descriptor (Object returned from
+ *                                                       `createReduxStore`). The legacy calling
+ *                                                       convention of passing the store name is
+ *                                                       also supported.
  *
  * @example
  * ```js
@@ -122,28 +124,30 @@ export const select = defaultRegistry.select;
 export const resolveSelect = defaultRegistry.resolveSelect;
 
 /**
- * Given a store descriptor (also supports legacy calling convention accepting the name of a
- * registered store), returns an object containing the store's selectors pre-bound to state so
- * that you only need to supply additional arguments, and modified so that they throw promises
+ * Given a store descriptor, returns an object containing the store's selectors pre-bound to state
+ * so that you only need to supply additional arguments, and modified so that they throw promises
  * in case the selector is not resolved yet.
  *
- * @param {string|StoreDescriptor} storeNameOrDescriptor Unique namespace identifier for the store
- *                                                       or the store descriptor.
+ * @param {StoreDescriptor|string} storeNameOrDescriptor Store descriptor (Object returned from
+ *                                                       `createReduxStore`). The legacy calling
+ *                                                       convention of passing the store name is
+ *                                                       also supported.
  *
  * @return {Object} Object containing the store's suspense-wrapped selectors.
  */
 export const suspendSelect = defaultRegistry.suspendSelect;
 
 /**
- * Given a store descriptor (also supports legacy calling convention accepting the name of a
- * registered store), returns an object of the store's action creators.
+ * Given a store descriptor, returns an object of the store's action creators.
  * Calling an action creator will cause it to be dispatched, updating the state value accordingly.
  *
  * Note: Action creators returned by the dispatch will return a promise when
  * they are called.
  *
- * @param {string|StoreDescriptor} storeNameOrDescriptor Unique namespace identifier for the store
- *                                                       or the store descriptor.
+ * @param {StoreDescriptor|string} storeNameOrDescriptor Store descriptor (Object returned from
+ *                                                       `createReduxStore`). The legacy calling
+ *                                                       convention of passing the store name is
+ *                                                       also supported.
  *
  * @example
  * ```js

--- a/packages/data/src/index.js
+++ b/packages/data/src/index.js
@@ -84,8 +84,7 @@ export { combineReducers };
  * The selector functions are been pre-bound to pass the current state automatically.
  * As a consumer, you need only pass arguments of the selector, if applicable.
  *
- * @param {StoreDescriptor|string} storeNameOrDescriptor Store descriptor (Object returned from
- *                                                       `createReduxStore`). The legacy calling
+ * @param {StoreDescriptor|string} storeNameOrDescriptor The store descriptor. The legacy calling
  *                                                       convention of passing the store name is
  *                                                       also supported.
  *
@@ -106,8 +105,7 @@ export const select = defaultRegistry.select;
  * so that you only need to supply additional arguments, and modified so that they return promises
  * that resolve to their eventual values, after any resolvers have ran.
  *
- * @param {StoreDescriptor|string} storeNameOrDescriptor Store descriptor (Object returned from
- *                                                       `createReduxStore`). The legacy calling
+ * @param {StoreDescriptor|string} storeNameOrDescriptor The store descriptor. The legacy calling
  *                                                       convention of passing the store name is
  *                                                       also supported.
  *
@@ -128,8 +126,7 @@ export const resolveSelect = defaultRegistry.resolveSelect;
  * so that you only need to supply additional arguments, and modified so that they throw promises
  * in case the selector is not resolved yet.
  *
- * @param {StoreDescriptor|string} storeNameOrDescriptor Store descriptor (Object returned from
- *                                                       `createReduxStore`). The legacy calling
+ * @param {StoreDescriptor|string} storeNameOrDescriptor The store descriptor. The legacy calling
  *                                                       convention of passing the store name is
  *                                                       also supported.
  *
@@ -144,8 +141,7 @@ export const suspendSelect = defaultRegistry.suspendSelect;
  * Note: Action creators returned by the dispatch will return a promise when
  * they are called.
  *
- * @param {StoreDescriptor|string} storeNameOrDescriptor Store descriptor (Object returned from
- *                                                       `createReduxStore`). The legacy calling
+ * @param {StoreDescriptor|string} storeNameOrDescriptor The store descriptor. The legacy calling
  *                                                       convention of passing the store name is
  *                                                       also supported.
  *

--- a/packages/data/src/registry.js
+++ b/packages/data/src/registry.js
@@ -110,8 +110,7 @@ export function createRegistry( storeConfigs = {}, parent = null ) {
 	 * state so that you only need to supply additional arguments, and modified so that they return
 	 * promises that resolve to their eventual values, after any resolvers have ran.
 	 *
-	 * @param {StoreDescriptor|string} storeNameOrDescriptor Store descriptor (Object returned from
-	 *                                                       `createReduxStore`). The legacy calling
+	 * @param {StoreDescriptor|string} storeNameOrDescriptor The store descriptor. The legacy calling
 	 *                                                       convention of passing the store name is
 	 *                                                       also supported.
 	 *
@@ -135,8 +134,7 @@ export function createRegistry( storeConfigs = {}, parent = null ) {
 	 * state so that you only need to supply additional arguments, and modified so that they throw
 	 * promises in case the selector is not resolved yet.
 	 *
-	 * @param {StoreDescriptor|string} storeNameOrDescriptor Store descriptor (Object returned from
-	 *                                                       `createReduxStore`). The legacy calling
+	 * @param {StoreDescriptor|string} storeNameOrDescriptor The store descriptor. The legacy calling
 	 *                                                       convention of passing the store name is
 	 *                                                       also supported.
 	 *

--- a/packages/data/src/registry.js
+++ b/packages/data/src/registry.js
@@ -106,10 +106,10 @@ export function createRegistry( storeConfigs = {}, parent = null ) {
 	}
 
 	/**
-	 * Given the name of a registered store, returns an object containing the store's
-	 * selectors pre-bound to state so that you only need to supply additional arguments,
-	 * and modified so that they return promises that resolve to their eventual values,
-	 * after any resolvers have ran.
+	 * Given a store descriptor (also supports legacy calling convention accepting the name of a
+	 * registered store), returns an object containing the store's selectors pre-bound to state
+	 * so that you only need to supply additional arguments, and modified so that they return
+	 * promises that resolve to their eventual values, after any resolvers have ran.
 	 *
 	 * @param {string|StoreDescriptor} storeNameOrDescriptor Unique namespace identifier for the store
 	 *                                                       or the store descriptor.
@@ -130,9 +130,10 @@ export function createRegistry( storeConfigs = {}, parent = null ) {
 	}
 
 	/**
-	 * Given the name of a registered store, returns an object containing the store's
-	 * selectors pre-bound to state so that you only need to supply additional arguments,
-	 * and modified so that they throw promises in case the selector is not resolved yet.
+	 * Given a store descriptor (also supports legacy calling convention accepting the name of a
+	 * registered store), returns an object containing the store's selectors pre-bound to state so
+	 * that you only need to supply additional arguments, and modified so that they throw promises
+	 * in case the selector is not resolved yet.
 	 *
 	 * @param {string|StoreDescriptor} storeNameOrDescriptor Unique namespace identifier for the store
 	 *                                                       or the store descriptor.

--- a/packages/data/src/registry.js
+++ b/packages/data/src/registry.js
@@ -106,13 +106,14 @@ export function createRegistry( storeConfigs = {}, parent = null ) {
 	}
 
 	/**
-	 * Given a store descriptor (also supports legacy calling convention accepting the name of a
-	 * registered store), returns an object containing the store's selectors pre-bound to state
-	 * so that you only need to supply additional arguments, and modified so that they return
+	 * Given a store descriptor, returns an object containing the store's selectors pre-bound to
+	 * state so that you only need to supply additional arguments, and modified so that they return
 	 * promises that resolve to their eventual values, after any resolvers have ran.
 	 *
-	 * @param {string|StoreDescriptor} storeNameOrDescriptor Unique namespace identifier for the store
-	 *                                                       or the store descriptor.
+	 * @param {StoreDescriptor|string} storeNameOrDescriptor Store descriptor (Object returned from
+	 *                                                       `createReduxStore`). The legacy calling
+	 *                                                       convention of passing the store name is
+	 *                                                       also supported.
 	 *
 	 * @return {Object} Each key of the object matches the name of a selector.
 	 */
@@ -130,13 +131,14 @@ export function createRegistry( storeConfigs = {}, parent = null ) {
 	}
 
 	/**
-	 * Given a store descriptor (also supports legacy calling convention accepting the name of a
-	 * registered store), returns an object containing the store's selectors pre-bound to state so
-	 * that you only need to supply additional arguments, and modified so that they throw promises
-	 * in case the selector is not resolved yet.
+	 * Given a store descriptor, returns an object containing the store's selectors pre-bound to
+	 * state so that you only need to supply additional arguments, and modified so that they throw
+	 * promises in case the selector is not resolved yet.
 	 *
-	 * @param {string|StoreDescriptor} storeNameOrDescriptor Unique namespace identifier for the store
-	 *                                                       or the store descriptor.
+	 * @param {StoreDescriptor|string} storeNameOrDescriptor Store descriptor (Object returned from
+	 *                                                       `createReduxStore`). The legacy calling
+	 *                                                       convention of passing the store name is
+	 *                                                       also supported.
 	 *
 	 * @return {Object} Object containing the store's suspense-wrapped selectors.
 	 */


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

It updates part of the documentation (@wordpress/data) to use store object instead of store names when accessing the stores through the `select` and `dispatch` functions.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

It's a new [standard](https://make.wordpress.org/core/2021/02/22/changes-in-wordpress-data-api/). The other way should be considered as a legacy way only for backward compatibility.

## Next

There are many other documentation pages still using store names that we should also update.