### PR TITLE
get_style_nodes should be compatible with parent method.

### DIFF
--- a/lib/compat/wordpress-6.1/class-wp-theme-json-6-1.php
+++ b/lib/compat/wordpress-6.1/class-wp-theme-json-6-1.php
@@ -122,7 +122,7 @@ class WP_Theme_JSON_6_1 extends WP_Theme_JSON_6_0 {
 	 * @param array $selectors  List of selectors per block.
 	 * @return array
 	 */
-	protected static function get_style_nodes( $theme_json, $selectors = array()  ) {
+	protected static function get_style_nodes( $theme_json, $selectors = array() ) {
 		$nodes = array();
 		if ( ! isset( $theme_json['styles'] ) ) {
 			return $nodes;

--- a/lib/compat/wordpress-6.1/class-wp-theme-json-6-1.php
+++ b/lib/compat/wordpress-6.1/class-wp-theme-json-6-1.php
@@ -118,7 +118,7 @@ class WP_Theme_JSON_6_1 extends WP_Theme_JSON_6_0 {
 	 *
 	 * @since 5.8.0
 	 *
-	 * @param array $theme_json     The tree to extract style nodes from.
+	 * @param array $theme_json The tree to extract style nodes from.
 	 * @param array $selectors  List of selectors per block.
 	 * @return array
 	 */
@@ -216,7 +216,7 @@ class WP_Theme_JSON_6_1 extends WP_Theme_JSON_6_0 {
 	/**
 	 * Gets the CSS rules for a particular block from theme.json.
 	 *
-	 * @param array $block_metadata Meta data about the block to get styles for.
+	 * @param array $block_metadata Metadata about the block to get styles for.
 	 *
 	 * @return string Styles for the block.
 	 */

--- a/lib/compat/wordpress-6.1/class-wp-theme-json-6-1.php
+++ b/lib/compat/wordpress-6.1/class-wp-theme-json-6-1.php
@@ -148,7 +148,7 @@ class WP_Theme_JSON_6_1 extends WP_Theme_JSON_6_0 {
 			return $nodes;
 		}
 
-		$nodes = array_merge( $nodes, static::get_block_nodes( $theme_json ) );
+		$nodes = array_merge( $nodes, static::get_block_nodes( $theme_json, $selectors ) );
 
 		// This filter allows us to modify the output of WP_Theme_JSON so that we can do things like loading block CSS independently.
 		return apply_filters( 'gutenberg_get_style_nodes', $nodes );
@@ -167,11 +167,12 @@ class WP_Theme_JSON_6_1 extends WP_Theme_JSON_6_0 {
 	 * An internal method to get the block nodes from a theme.json file.
 	 *
 	 * @param array $theme_json The theme.json converted to an array.
+	 * @param array $selectors  Optional list of selectors per block.
 	 *
 	 * @return array The block nodes in theme.json.
 	 */
-	private static function get_block_nodes( $theme_json ) {
-		$selectors = static::get_blocks_metadata();
+	private static function get_block_nodes( $theme_json, $selectors = array() ) {
+		$selectors = empty( $selectors ) ? static::get_blocks_metadata() : $selectors;
 		$nodes     = array();
 		if ( ! isset( $theme_json['styles'] ) ) {
 			return $nodes;

--- a/lib/compat/wordpress-6.1/class-wp-theme-json-6-1.php
+++ b/lib/compat/wordpress-6.1/class-wp-theme-json-6-1.php
@@ -119,9 +119,10 @@ class WP_Theme_JSON_6_1 extends WP_Theme_JSON_6_0 {
 	 * @since 5.8.0
 	 *
 	 * @param array $theme_json     The tree to extract style nodes from.
+	 * @param array $selectors  List of selectors per block.
 	 * @return array
 	 */
-	protected static function get_style_nodes( $theme_json ) {
+	protected static function get_style_nodes( $theme_json, $selectors = array()  ) {
 		$nodes = array();
 		if ( ! isset( $theme_json['styles'] ) ) {
 			return $nodes;
@@ -217,7 +218,7 @@ class WP_Theme_JSON_6_1 extends WP_Theme_JSON_6_0 {
 	 *
 	 * @param array $block_metadata Meta data about the block to get styles for.
 	 *
-	 * @return array Styles for the block.
+	 * @return string Styles for the block.
 	 */
 	public function get_styles_for_block( $block_metadata ) {
 		$node         = _wp_array_get( $this->theme_json, $block_metadata['path'], array() );


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?

Fix the following errors and fix phpdoc comment for get_styles_for_block.
 
> Warning: Declaration of WP_Theme_JSON_6_1::get_style_nodes($theme_json) should be compatible with WP_Theme_JSON_5_9::get_style_nodes($theme_json, $selectors = Array) in /var/www/html/wp-content/plugins/gutenberg/lib/compat/wordpress-6.1/class-wp-theme-json-6-1.php on line 124

## Testing Instructions
1. npm run wp-env start 
2. show  http://localhost:8888/

