### PR TITLE
Theme JSON: adding optional argument to get_style_nodes()

### DIFF
--- a/lib/compat/wordpress-6.1/class-wp-theme-json-6-1.php
+++ b/lib/compat/wordpress-6.1/class-wp-theme-json-6-1.php
@@ -118,10 +118,11 @@ class WP_Theme_JSON_6_1 extends WP_Theme_JSON_6_0 {
 	 *
 	 * @since 5.8.0
 	 *
-	 * @param array $theme_json     The tree to extract style nodes from.
+	 * @param array $theme_json The tree to extract style nodes from.
+	 * @param array $selectors  List of selectors per block.
 	 * @return array
 	 */
-	protected static function get_style_nodes( $theme_json ) {
+	protected static function get_style_nodes( $theme_json, $selectors = array() ) {
 		$nodes = array();
 		if ( ! isset( $theme_json['styles'] ) ) {
 			return $nodes;
@@ -147,7 +148,7 @@ class WP_Theme_JSON_6_1 extends WP_Theme_JSON_6_0 {
 			return $nodes;
 		}
 
-		$nodes = array_merge( $nodes, static::get_block_nodes( $theme_json ) );
+		$nodes = array_merge( $nodes, static::get_block_nodes( $theme_json, $selectors ) );
 
 		// This filter allows us to modify the output of WP_Theme_JSON so that we can do things like loading block CSS independently.
 		return apply_filters( 'gutenberg_get_style_nodes', $nodes );
@@ -166,12 +167,14 @@ class WP_Theme_JSON_6_1 extends WP_Theme_JSON_6_0 {
 	 * An internal method to get the block nodes from a theme.json file.
 	 *
 	 * @param array $theme_json The theme.json converted to an array.
+	 * @param array $selectors  Optional list of selectors per block.
 	 *
 	 * @return array The block nodes in theme.json.
 	 */
-	private static function get_block_nodes( $theme_json ) {
-		$selectors = static::get_blocks_metadata();
+	private static function get_block_nodes( $theme_json, $selectors = array() ) {
+		$selectors = empty( $selectors ) ? static::get_blocks_metadata() : $selectors;
 		$nodes     = array();
+
 		if ( ! isset( $theme_json['styles'] ) ) {
 			return $nodes;
 		}
@@ -215,9 +218,9 @@ class WP_Theme_JSON_6_1 extends WP_Theme_JSON_6_0 {
 	/**
 	 * Gets the CSS rules for a particular block from theme.json.
 	 *
-	 * @param array $block_metadata Meta data about the block to get styles for.
+	 * @param array $block_metadata Metadata about the block to get styles for.
 	 *
-	 * @return array Styles for the block.
+	 * @return string Styles for the block.
 	 */
 	public function get_styles_for_block( $block_metadata ) {
 		$node         = _wp_array_get( $this->theme_json, $block_metadata['path'], array() );

--- a/lib/compat/wordpress-6.1/script-loader.php
+++ b/lib/compat/wordpress-6.1/script-loader.php
@@ -19,6 +19,9 @@
  * @return array A filtered array of style nodes.
  */
 function filter_out_block_nodes( $nodes ) {
+	if ( ! is_array( $nodes ) ) {
+		return array();
+	}
 	return array_filter(
 		$nodes,
 		function( $node ) {


### PR DESCRIPTION
## What?

Adding an optional, second `$selectors` argument to `get_style_nodes()` to match the original function signature in 5.9.

Props to @torounit, who discovered the bug and came up with the original fix in https://github.com/WordPress/gutenberg/pull/41217

This PR includes an additional type check in `filter_out_block_nodes()` to avoid the PHPCodeSniffer error:

```bash
Fatal error: Uncaught TypeError: vsprintf(): Argument #2 ($values) must be of type array, string given in /app/vendor/squizlabs/php_codesniffer/src/Files/File.php:1056
```

## Why?

https://github.com/WordPress/gutenberg/pull/41160 refactored `get_style_nodes()` so that the `$selectors` argument was no longer required. This was incompatible with the original method in 5.9. 

## How?
Adding an optional `$selectors` argument to keep the linters happy.

## Testing Instructions
Fire up this branch and run through the testing scenarios in https://github.com/WordPress/gutenberg/pull/41160

Ensure you don't encounter the error:

> Warning: Declaration of WP_Theme_JSON_6_1::get_style_nodes($theme_json) should be compatible with WP_Theme_JSON_5_9::get_style_nodes($theme_json, $selectors = Array) in /var/www/html/wp-content/plugins/gutenberg/lib/compat/wordpress-6.1/class-wp-theme-json-6-1.php on line 124
