### PR TITLE
Image: Reflect media deletion in the editor

### DIFF
--- a/packages/block-editor/src/components/media-placeholder/index.js
+++ b/packages/block-editor/src/components/media-placeholder/index.js
@@ -70,6 +70,7 @@ export function MediaPlaceholder( {
 	onError,
 	onSelect,
 	onCancel,
+	onClose = noop,
 	onSelectURL,
 	onDoubleClick,
 	onFilesPreUpload = noop,
@@ -327,6 +328,7 @@ export function MediaPlaceholder( {
 				gallery={ multiple && onlyAllowsImages() }
 				multiple={ multiple }
 				onSelect={ onSelect }
+				onClose={ onClose }
 				allowedTypes={ allowedTypes }
 				mode={ 'browse' }
 				value={

--- a/packages/block-editor/src/components/media-replace-flow/index.js
+++ b/packages/block-editor/src/components/media-replace-flow/index.js
@@ -48,6 +48,7 @@ const MediaReplaceFlow = ( {
 	onError,
 	onSelect,
 	onSelectURL,
+	onCloseModal = noop,
 	onToggleFeaturedImage,
 	useFeaturedImage,
 	onFilesUpload = noop,
@@ -58,6 +59,7 @@ const MediaReplaceFlow = ( {
 	multiple = false,
 	addToGallery,
 	handleUpload = true,
+	buttonVariant,
 } ) => {
 	const [ mediaURLValue, setMediaURLValue ] = useState( mediaURL );
 	const mediaUpload = useSelect( ( select ) => {
@@ -153,6 +155,7 @@ const MediaReplaceFlow = ( {
 					aria-haspopup="true"
 					onClick={ onToggle }
 					onKeyDown={ openOnArrowDown }
+					variant={ buttonVariant }
 				>
 					{ name }
 				</ToolbarButton>
@@ -170,6 +173,7 @@ const MediaReplaceFlow = ( {
 									selectMedia( media, onClose )
 								}
 								allowedTypes={ allowedTypes }
+								onClose={ onCloseModal }
 								render={ ( { open } ) => (
 									<MenuItem
 										icon={ mediaIcon }

--- a/packages/block-library/src/image/edit.js
+++ b/packages/block-library/src/image/edit.js
@@ -109,14 +109,14 @@ export function isMediaDestroyed( id ) {
 /**
  * A placeholder component that displays if an image has been deleted or cannot be loaded.
  *
- * @param {Object} props Component props.
- * @param {number} props.id The attachment id.
- * @param {string} props.url Image url.
- * @param {Function} props.onClear Clears the image attributes.
- * @param {Function} props.onSelect Callback for <MediaReplaceFlow /> when an image is selected.
- * @param {Function} props.onSelectURL Callback for <MediaReplaceFlow /> when an image URL is selected.
+ * @param {Object}   props               Component props.
+ * @param {number}   props.id            The attachment id.
+ * @param {string}   props.url           Image url.
+ * @param {Function} props.onClear       Clears the image attributes.
+ * @param {Function} props.onSelect      Callback for <MediaReplaceFlow /> when an image is selected.
+ * @param {Function} props.onSelectURL   Callback for <MediaReplaceFlow /> when an image URL is selected.
  * @param {Function} props.onUploadError Callback for <MediaReplaceFlow /> when an upload fails.
- * @param {Function} props.onCloseModal Callback for <MediaReplaceFlow /> when the media library overlay is closed.
+ * @param {Function} props.onCloseModal  Callback for <MediaReplaceFlow /> when the media library overlay is closed.
  *
  * @return {boolean} Whether the image has been destroyed.
  */
@@ -134,41 +134,39 @@ const ImageErrorPlaceholder = ( {
 		icon={ icon }
 		label={ __( 'This image could not be loaded' ) }
 	>
-		<>
-			<p>{ url }</p>
-			<p>
-				{ __(
-					'This might be due to a network error, or the image may have been deleted.'
-				) }
-			</p>
-			<HStack justify="flex-start" spacing={ 2 }>
-				<MediaReplaceFlow
-					mediaId={ id }
-					mediaURL={ url }
-					allowedTypes={ ALLOWED_MEDIA_TYPES }
-					accept="image/*"
-					onSelect={ ( media ) => {
-						onClear();
-						onSelect( media );
-					} }
-					onSelectURL={ ( selectedUrl ) => {
-						onClear();
-						onSelectURL( selectedUrl );
-					} }
-					onError={ onUploadError }
-					onCloseModal={ onCloseModal }
-					buttonVariant="primary"
-				/>
-				<Button
-					className="wp-block-image__error-placeholder__button"
-					title={ __( 'Clear and replace image' ) }
-					variant="secondary"
-					onClick={ onClear }
-				>
-					{ __( 'Clear' ) }
-				</Button>
-			</HStack>
-		</>
+		<p>{ url }</p>
+		<p>
+			{ __(
+				'This might be due to a network error, or the image may have been deleted.'
+			) }
+		</p>
+		<HStack justify="flex-start" spacing={ 2 }>
+			<MediaReplaceFlow
+				mediaId={ id }
+				mediaURL={ url }
+				allowedTypes={ ALLOWED_MEDIA_TYPES }
+				accept="image/*"
+				onSelect={ ( media ) => {
+					onClear();
+					onSelect( media );
+				} }
+				onSelectURL={ ( selectedUrl ) => {
+					onClear();
+					onSelectURL( selectedUrl );
+				} }
+				onError={ onUploadError }
+				onCloseModal={ onCloseModal }
+				buttonVariant="primary"
+			/>
+			<Button
+				className="wp-block-image__error-placeholder__button"
+				title={ __( 'Clear and replace image' ) }
+				variant="secondary"
+				onClick={ onClear }
+			>
+				{ __( 'Clear' ) }
+			</Button>
+		</HStack>
 	</Placeholder>
 );
 
@@ -224,16 +222,19 @@ export function ImageEdit( {
 	function clearImageAttributes() {
 		setHasImageLoadError( false );
 		setAttributes( {
-			url: undefined,
+			src: undefined,
 			id: undefined,
+			url: undefined,
 		} );
 	}
 
-	/*
-		 Runs an error callback if the image does not load.
-		 If the error callback is triggered, we infer that that image
-		 has been deleted.
-	*/
+	/**
+	 * Runs an error callback if the image does not load.
+	 * If the error callback is triggered, we infer that that image
+	 * has been deleted.
+	 *
+	 * @param {boolean} isReplaced Whether the image has been replaced.
+	 */
 	function onImageError( isReplaced = false ) {
 		// If the image block was not replaced with an embed,
 		// and it's not an external image,

--- a/packages/block-library/src/image/edit.js
+++ b/packages/block-library/src/image/edit.js
@@ -26,6 +26,7 @@ import { image as icon } from '@wordpress/icons';
  * Internal dependencies
  */
 import Image from './image';
+import { isMediaFileDeleted } from './utils';
 
 /**
  * Module constants
@@ -85,6 +86,20 @@ function hasDefaultSize( image, defaultSize ) {
 	);
 }
 
+/**
+ * Checks if a media attachment object has been "destroyed",
+ * that is, removed from the media library. The core Media Library
+ * adds a `destroyed` property to a deleted attachment object in the media collection.
+ *
+ * @param {number} id The attachment id.
+ *
+ * @return {boolean} Whether the image has been destroyed.
+ */
+export function isMediaDestroyed( id ) {
+	const attachment = window?.wp?.media?.attachment( id ) || {};
+	return attachment.destroyed;
+}
+
 export function ImageEdit( {
 	attributes,
 	setAttributes,
@@ -124,6 +139,48 @@ export function ImageEdit( {
 		const { getSettings } = select( blockEditorStore );
 		return pick( getSettings(), [ 'imageDefaultSize', 'mediaUpload' ] );
 	}, [] );
+
+	// A callback passed to MediaUpload,
+	// fired when the media modal closes.
+	function onCloseModal() {
+		if ( isMediaDestroyed( attributes?.id ) ) {
+			setAttributes( {
+				url: undefined,
+				id: undefined,
+			} );
+		}
+	}
+
+	/*
+		 Runs an error callback if the image does not load.
+		 If the error callback is triggered, we infer that that image
+		 has been deleted.
+	*/
+	function onImageError( isReplaced = false ) {
+		noticeOperations.removeAllNotices();
+		noticeOperations.createErrorNotice(
+			sprintf(
+				/* translators: %s url or missing image */
+				__( 'Error loading image: %s' ),
+				url
+			)
+		);
+
+		// If the image block was not replaced with an embed,
+		// and it's not an external image,
+		// and it's been deleted from the database,
+		// clear the attributes and trigger the placeholder.
+		if ( id && ! isReplaced && ! isExternalImage( id, url ) ) {
+			isMediaFileDeleted( id ).then( ( isFileDeleted ) => {
+				if ( isFileDeleted ) {
+					setAttributes( {
+						url: undefined,
+						id: undefined,
+					} );
+				}
+			} );
+		}
+	}
 
 	function onUploadError( message ) {
 		noticeOperations.removeAllNotices();
@@ -323,6 +380,8 @@ export function ImageEdit( {
 					containerRef={ ref }
 					context={ context }
 					clientId={ clientId }
+					onCloseModal={ onCloseModal }
+					onImageLoadError={ onImageError }
 				/>
 			) }
 			{ ! url && (
@@ -339,6 +398,7 @@ export function ImageEdit( {
 				onSelectURL={ onSelectURL }
 				notices={ noticeUI }
 				onError={ onUploadError }
+				onClose={ onCloseModal }
 				accept="image/*"
 				allowedTypes={ ALLOWED_MEDIA_TYPES }
 				value={ { id, src } }

--- a/packages/block-library/src/image/edit.js
+++ b/packages/block-library/src/image/edit.js
@@ -20,7 +20,7 @@ import {
 	BlockControls,
 	BlockIcon,
 	MediaPlaceholder,
-	//MediaReplaceFlow,
+	MediaReplaceFlow,
 	useBlockProps,
 	store as blockEditorStore,
 } from '@wordpress/block-editor';
@@ -106,14 +106,28 @@ export function isMediaDestroyed( id ) {
 	return attachment.destroyed;
 }
 
+/**
+ * A placeholder component that displays if an image has been deleted or cannot be loaded.
+ *
+ * @param {Object} props Component props.
+ * @param {number} props.id The attachment id.
+ * @param {string} props.url Image url.
+ * @param {Function} props.onClear Clears the image attributes.
+ * @param {Function} props.onSelect Callback for <MediaReplaceFlow /> when an image is selected.
+ * @param {Function} props.onSelectURL Callback for <MediaReplaceFlow /> when an image URL is selected.
+ * @param {Function} props.onUploadError Callback for <MediaReplaceFlow /> when an upload fails.
+ * @param {Function} props.onCloseModal Callback for <MediaReplaceFlow /> when the media library overlay is closed.
+ *
+ * @return {boolean} Whether the image has been destroyed.
+ */
 const ImageErrorPlaceholder = ( {
-	// id,
+	id,
 	url,
 	onClear,
-	// onSelect,
-	// onSelectURL,
-	// onError,
-	// onCloseModal,
+	onSelect,
+	onSelectURL,
+	onUploadError,
+	onCloseModal,
 } ) => (
 	<Placeholder
 		className="wp-block-image__error-placeholder"
@@ -127,28 +141,31 @@ const ImageErrorPlaceholder = ( {
 					'This might be due to a network error, or the image may have been deleted.'
 				) }
 			</p>
-			<HStack justify="flex-start">
-				{
-					// Hiding this for now until I can get it to work :)
-				 }
-				{ /*<MediaReplaceFlow*/ }
-				{ /*	mediaId={ id }*/ }
-				{ /*	mediaURL={ url }*/ }
-				{ /*	allowedTypes={ ALLOWED_MEDIA_TYPES }*/ }
-				{ /*	accept="image/*"*/ }
-				{ /*	onSelect={ onSelect }*/ }
-				{ /*	onSelectURL={ onSelectURL }*/ }
-				{ /*	onError={ onError }*/ }
-				{ /*	onCloseModal={ onCloseModal }*/ }
-				{ /*	buttonVariant="primary"*/ }
-				{ /*/>*/ }
+			<HStack justify="flex-start" spacing={ 2 }>
+				<MediaReplaceFlow
+					mediaId={ id }
+					mediaURL={ url }
+					allowedTypes={ ALLOWED_MEDIA_TYPES }
+					accept="image/*"
+					onSelect={ ( media ) => {
+						onClear();
+						onSelect( media );
+					} }
+					onSelectURL={ ( selectedUrl ) => {
+						onClear();
+						onSelectURL( selectedUrl );
+					} }
+					onError={ onUploadError }
+					onCloseModal={ onCloseModal }
+					buttonVariant="primary"
+				/>
 				<Button
 					className="wp-block-image__error-placeholder__button"
 					title={ __( 'Clear and replace image' ) }
 					variant="secondary"
 					onClick={ onClear }
 				>
-					{ __( 'Clear and replace image' ) }
+					{ __( 'Clear' ) }
 				</Button>
 			</HStack>
 		</>
@@ -423,7 +440,7 @@ export function ImageEdit( {
 					onClear={ clearImageAttributes }
 					onSelect={ onSelectImage }
 					onSelectURL={ onSelectURL }
-					onError={ onUploadError }
+					onUploadError={ onUploadError }
 					onCloseModal={ onCloseModal }
 				/>
 			) }

--- a/packages/block-library/src/image/editor.scss
+++ b/packages/block-library/src/image/editor.scss
@@ -140,5 +140,5 @@ figure.wp-block-image:not(.wp-block) {
 }
 
 .wp-block-image__error-placeholder .wp-block-image__error-placeholder__button {
-	margin: 0;
+	margin: 0 0 0 $grid-unit-10;
 }

--- a/packages/block-library/src/image/editor.scss
+++ b/packages/block-library/src/image/editor.scss
@@ -138,3 +138,7 @@ figure.wp-block-image:not(.wp-block) {
 		padding-right: 0;
 	}
 }
+
+.wp-block-image__error-placeholder .wp-block-image__error-placeholder__button {
+	margin: 0;
+}

--- a/packages/block-library/src/image/image.js
+++ b/packages/block-library/src/image/image.js
@@ -47,7 +47,7 @@ import { store as coreStore } from '@wordpress/core-data';
  */
 import { createUpgradedEmbedBlock } from '../embed/util';
 import useClientWidth from './use-client-width';
-import { isExternalImage } from './edit';
+import { isExternalImage, isMediaDestroyed } from './edit';
 
 /**
  * Module constants
@@ -76,9 +76,11 @@ export default function Image( {
 	isSelected,
 	insertBlocksAfter,
 	onReplace,
+	onCloseModal,
 	onSelectImage,
 	onSelectURL,
 	onUploadError,
+	onImageLoadError,
 	containerRef,
 	context,
 	clientId,
@@ -216,10 +218,13 @@ export default function Image( {
 		// Check if there's an embed block that handles this URL, e.g., instagram URL.
 		// See: https://github.com/WordPress/gutenberg/pull/11472
 		const embedBlock = createUpgradedEmbedBlock( { attributes: { url } } );
+		const shouldReplace = undefined !== embedBlock;
 
-		if ( undefined !== embedBlock ) {
+		if ( shouldReplace ) {
 			onReplace( embedBlock );
 		}
+
+		onImageLoadError( shouldReplace );
 	}
 
 	function onSetHref( props ) {
@@ -291,6 +296,9 @@ export default function Image( {
 		if ( ! isSelected ) {
 			setIsEditingImage( false );
 		}
+		if ( isSelected && isMediaDestroyed( id ) ) {
+			onImageLoadError();
+		}
 	}, [ isSelected ] );
 
 	const canEditImage = id && naturalWidth && naturalHeight && imageEditing;
@@ -354,6 +362,7 @@ export default function Image( {
 						onSelect={ onSelectImage }
 						onSelectURL={ onSelectURL }
 						onError={ onUploadError }
+						onCloseModal={ onCloseModal }
 					/>
 				</BlockControls>
 			) }

--- a/packages/block-library/src/image/utils.js
+++ b/packages/block-library/src/image/utils.js
@@ -4,6 +4,11 @@
 import { isEmpty, get } from 'lodash';
 
 /**
+ * WordPress dependencies
+ */
+import apiFetch from '@wordpress/api-fetch';
+
+/**
  * Internal dependencies
  */
 import { NEW_TAB_REL } from './constants';
@@ -71,4 +76,22 @@ export function getImageSizeAttributes( image, size ) {
 	}
 
 	return {};
+}
+
+/**
+ * Performs a GET request on an image file to confirm whether it has been deleted from the database.
+ *
+ * @param {number=} mediaId The id of the image.
+ * @return {Promise} Media Object Promise.
+ */
+export async function isMediaFileDeleted( mediaId ) {
+	try {
+		const response = await apiFetch( {
+			path: `/wp/v2/media/${ mediaId }`,
+		} );
+		const isMediaFileAvailable = response && response?.id === mediaId;
+		return ! isMediaFileAvailable;
+	} catch ( err ) {
+		return true;
+	}
 }


### PR DESCRIPTION
## What?
Another take at https://github.com/WordPress/gutenberg/pull/35973 and https://github.com/WordPress/gutenberg/pull/40982, which were reverted due to issues reported in https://github.com/WordPress/gutenberg/issues/41161

Revert PR: https://github.com/WordPress/gutenberg/pull/41221

This time, if the image block was not replaced with an embed, **and** it's not an external image, **and** it's been deleted from the database, we trigger a custom placeholder.

<img width="904" alt="Screen Shot 2022-06-23 at 1 24 53 pm" src="https://user-images.githubusercontent.com/6458278/175202326-c16b88b1-430b-42fc-91af-85382c84d06d.png">

This gives the user the opportunity to:

1. Replace the image via the media upload flow.
2. Clear the image, which will display the default block placeholder.
3. Leave the image in case it's caused by a temporary network outage.

Original issues:
- https://github.com/WordPress/gutenberg/issues/23262
- https://github.com/WordPress/gutenberg/issues/28914 

## Why?
The previous attempt was clearing the image automatically and did not take into account images external or otherwise that might be _temporarily_ unavailable.

See the issue: https://github.com/WordPress/gutenberg/issues/41161

props @eriktorsner

## How?
Testing the suggestion, or my understanding of it, in https://github.com/WordPress/gutenberg/issues/41161#issuecomment-1132828340 from @danielbachhuber 

## Testing Instructions

### For images that have been deleted

1. Insert a single Image Block and select an image from your media library. Or upload a new image. All good. Add a caption as well.
4. Open the Media Modal by clicking Replace
5. Delete the image you inserted.
6. Close the modal
7. The temporary replace/clear placeholder should show.
8. Now refresh the page. Don't save. Just refresh.
9. The Image Block placeholder should still show.
10. Try replacing the image and saving the page.
11. Repeat steps and select "Clear". You should see the default placeholder.

<img width="282" alt="Screen Shot 2022-06-23 at 1 29 15 pm" src="https://user-images.githubusercontent.com/6458278/175202845-4c986067-7b06-441b-93f8-dbd459e2cb45.png">

### For images that haven't been deleted

1. Add an Image block and select an image from your media library
2. In the code view change the url of the image, and then switch back to the editor view
3. Check that the image placeholder **does not show**. This is because the editor has the original image URL and tests whether it's available.
<img width="307" alt="Screen Shot 2022-06-23 at 1 28 55 pm" src="https://user-images.githubusercontent.com/6458278/175202788-a56b9063-1607-42f3-b662-7a7461e730dc.png">

### For external images

1. Add an Image block and insert an image via external URL
2. In the code view change the url of the image, and then switch back to the editor view
3. Check that the image placeholder **does not show**

cc @danielbachhuber whose [idea](https://github.com/WordPress/gutenberg/issues/41161#issuecomment-1132828340) I half-implemented 😄 
