### PR TITLE
ColorPicker: Strip hash from pasted hex values in ColorPicker

### DIFF
--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Enhancements
 
 -   `SelectControl`: Add `__nextHasNoMarginBottom` prop for opting into the new margin-free styles ([#41269](https://github.com/WordPress/gutenberg/pull/41269)).
+-   `ColorPicker`: Strip leading hash character from hex values pasted into input. ([#41223](https://github.com/WordPress/gutenberg/pull/41223))
 
 ### Internal
 

--- a/packages/components/src/color-picker/hex-input.tsx
+++ b/packages/components/src/color-picker/hex-input.tsx
@@ -16,6 +16,7 @@ import { Spacer } from '../spacer';
 import { space } from '../ui/utils/space';
 import { ColorHexInputControl } from './styles';
 import { COLORS } from '../utils/colors-values';
+import type { StateReducer } from '../input-control/reducer/state';
 
 interface HexInputProps {
 	color: Colord;
@@ -31,6 +32,20 @@ export const HexInput = ( { color, onChange, enableAlpha }: HexInputProps ) => {
 			: '#' + nextValue;
 
 		onChange( colord( hexValue ) );
+	};
+
+	const stateReducer: StateReducer = ( state, action ) => {
+		const nativeEvent = action.payload?.event?.nativeEvent as InputEvent;
+
+		if ( 'insertFromPaste' !== nativeEvent?.inputType ) {
+			return { ...state };
+		}
+
+		const value = state.value?.startsWith( '#' )
+			? state.value.slice( 1 ).toUpperCase()
+			: state.value?.toUpperCase();
+
+		return { ...state, value };
 	};
 
 	return (
@@ -50,6 +65,7 @@ export const HexInput = ( { color, onChange, enableAlpha }: HexInputProps ) => {
 			maxLength={ enableAlpha ? 9 : 7 }
 			label={ __( 'Hex color' ) }
 			hideLabelFromVision
+			__unstableStateReducer={ stateReducer }
 		/>
 	);
 };


### PR DESCRIPTION
Related:
- https://github.com/WordPress/gutenberg/issues/37981

## What?

Strips leading `#` character from hex values pasted into the `ColorPicker`'s hex input field.

## Why?

The leading `#` on pasted values persists in the input field until the value is committed. This lead to confusion as to whether the color value was invalid or not.

## How?

Leveraged `InputControl`'s `__unstableStateReducer` to process pasted values, stripping any leading `#` from the value.

## Testing Instructions

1. Ensure the existing unit tests still pass: `npm run test-unit  packages/components/src/color-picker/test`
2. Fire up Storybook, visit the [ColorPicker page](http://localhost:50240/?path=/story/components-colorpicker--default), and attempt to paste complete hex values into the hex input field.
3. Test pasting hex values into ColorPicker instances within the editor.

## Screenshots or screencast <!-- if applicable -->

| Before | After |
|---|---|
| <video src="https://user-images.githubusercontent.com/60436221/169750560-e6887628-0364-4adc-9939-4182539879b6.mp4" /> | <video src="https://user-images.githubusercontent.com/60436221/169750566-d381c7e8-a6ad-4c1a-9b08-b0c85e5bfb06.mp4" /> |



