### PR TITLE
Global Styles: Button Element: update button element selector

### DIFF
--- a/lib/compat/wordpress-6.1/class-wp-theme-json-6-1.php
+++ b/lib/compat/wordpress-6.1/class-wp-theme-json-6-1.php
@@ -25,7 +25,7 @@ class WP_Theme_JSON_6_1 extends WP_Theme_JSON_6_0 {
 		'h4'     => 'h4',
 		'h5'     => 'h5',
 		'h6'     => 'h6',
-		'button' => '.wp-element-button, .wp-block-button, button', // We have the .wp-block-button class so that this will target older buttons that have been serialized.
+		'button' => '.wp-element-button, .wp-block-button__link', // We have the .wp-block-button__link class so that this will target older buttons that have been serialized.
 	);
 	/**
 	 * Returns the metadata for each block.


### PR DESCRIPTION
## What?
This updates the selector for button elements. I thought I'd done this on https://github.com/WordPress/gutenberg/pull/40260 but it seems to have been lost.

## Why?
1. We don't want to target _all_ button elements.
2. We only want to target the links inside a button block, not the whole block

## Testing Instructions
- Checkout https://github.com/Automattic/themes/pull/5849 and switch to Archeo
- Add a button block
- Confirm that the styles only apply to the link inside the block, not the wrapper.


## Screenshots or screencast <!-- if applicable -->
Before:
<img width="646" alt="Screenshot 2022-05-23 at 13 51 22" src="https://user-images.githubusercontent.com/275961/169823257-cb9a4022-1d3a-43ac-a79a-2129a98875d4.png">

After:
<img width="729" alt="Screenshot 2022-05-23 at 13 51 09" src="https://user-images.githubusercontent.com/275961/169823298-9e081f5f-e0fe-44d6-a2d1-8d7c59c6ab2e.png">

@WordPress/block-themers 