### PR TITLE
Post Comments: Make the button an element button

### DIFF
--- a/packages/block-library/src/post-comments-form/form.js
+++ b/packages/block-library/src/post-comments-form/form.js
@@ -1,7 +1,13 @@
 /**
+ * External dependencies
+ */
+import classnames from 'classnames';
+
+/**
  * WordPress dependencies
  */
 import { __ } from '@wordpress/i18n';
+import { __experimentalElementButtonClassName } from '@wordpress/block-editor';
 import { useDisabled, useInstanceId } from '@wordpress/compose';
 
 const CommentsForm = () => {
@@ -27,7 +33,11 @@ const CommentsForm = () => {
 					<input
 						name="submit"
 						type="submit"
-						className="submit wp-block-button__link"
+						className={ classnames(
+							'submit',
+							'wp-block-button__link',
+							__experimentalElementButtonClassName
+						) }
 						label={ __( 'Post Comment' ) }
 						value={ __( 'Post Comment' ) }
 					/>

--- a/packages/block-library/src/post-comments-form/index.php
+++ b/packages/block-library/src/post-comments-form/index.php
@@ -72,7 +72,7 @@ add_action( 'init', 'register_block_core_post_comments_form' );
  */
 function post_comments_form_block_form_defaults( $fields ) {
 	if ( wp_is_block_theme() ) {
-		$fields['submit_button'] = '<input name="%1$s" type="submit" id="%2$s" class="%3$s wp-block-button__link" value="%4$s" />';
+		$fields['submit_button'] = '<input name="%1$s" type="submit" id="%2$s" class="%3$s wp-block-button__link ' . WP_Theme_JSON_Gutenberg::__EXPERIMENTAL_ELEMENT_BUTTON_CLASS_NAME . '" value="%4$s" />';
 		$fields['submit_field']  = '<p class="form-submit wp-block-button">%1$s %2$s</p>';
 	}
 

--- a/packages/block-library/src/post-comments/index.php
+++ b/packages/block-library/src/post-comments/index.php
@@ -78,7 +78,7 @@ add_action( 'init', 'register_block_core_post_comments' );
  */
 function post_comments_block_form_defaults( $fields ) {
 	if ( wp_is_block_theme() ) {
-		$fields['submit_button'] = '<input name="%1$s" type="submit" id="%2$s" class="%3$s wp-block-button__link" value="%4$s" />';
+		$fields['submit_button'] = '<input name="%1$s" type="submit" id="%2$s" class="%3$s wp-block-button__link ' . WP_Theme_JSON_Gutenberg::__EXPERIMENTAL_ELEMENT_BUTTON_CLASS_NAME . '" value="%4$s" />';
 		$fields['submit_field']  = '<p class="form-submit wp-block-button">%1$s %2$s</p>';
 	}
 


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
This makes the button in the comments for an element button. Closes https://github.com/WordPress/gutenberg/issues/27740

## Why?
This will mean that themes can style all buttons using theme.json.

## How?
Adds the `wp-element-button` class name to the Post Comment button.

## Testing Instructions
- Use this PR: https://github.com/Automattic/themes/pull/5849
- Switch to Archeo
- Open the single post template in the Site Editor
- Check that the comment form buttons have the `wp-element-button` class.
- Check that the button is also output on the front end.

## Screenshots or screencast <!-- if applicable -->
<img width="743" alt="Screenshot 2022-05-23 at 17 47 27" src="https://user-images.githubusercontent.com/275961/169868836-06884586-8f01-4ec5-bf5d-b27ca0b5fcaf.png">

@WordPress/block-themers 