### PR TITLE
Components: refactor `ColorPalette` to disable `exhaustive-deps` check for now

### DIFF
--- a/packages/components/src/color-palette/index.native.js
+++ b/packages/components/src/color-palette/index.native.js
@@ -92,6 +92,9 @@ function ColorPalette( {
 				scrollViewRef.current.scrollTo( { x: 0, y: 0 } );
 			}
 		}
+		// Temporarily disabling exhuastive-deps until the component can be refactored and updated safely.
+		// Please see https://github.com/WordPress/gutenberg/pull/41253 for discussion and details.
+		// eslint-disable-next-line react-hooks/exhaustive-deps
 	}, [ currentSegment ] );
 
 	function isSelectedCustom() {


### PR DESCRIPTION
## What?
Updates the `ColorPalette` component to satisfy the `exhaustive-deps` eslint rule

## Why?
Part of the effort in https://github.com/WordPress/gutenberg/pull/41166 to apply `exhuastive-deps` to the Components package

## How?
- adds `isSelectedCustom` to the `useEffect` dependency array
- wrap`isSelectedCustom` in `useCallback` to allow for a stable reference between renders, rather than having the function get redeclared each time.

## Testing Instructions
1. Rebase this PR on top of https://github.com/WordPress/gutenberg/pull/41166, OR manually set
`'react-hooks/color-palette': 'warn'` in your local eslint file
2. From your local Gutenberg directory, run `npx eslint packages/components/src/color-palette`
3. Confirm that the linter returns no errors
4. Launch Storybook
5. Test the component, any stories, and its docs to ensure everything still works as expected.


