### PR TITLE
Components: refactor `BorderControl` to pass `exhaustive-deps`

### DIFF
--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -5,7 +5,9 @@
 ### Internal
 
 -   `AlignmentMatrixControl` updated to satisfy `react/exhuastive-deps` eslint rule ([#41167](https://github.com/WordPress/gutenberg/pull/41167))
+-   `BorderControl` updated to satisfy `react/exhuastive-deps` eslint rule ([#41259](https://github.com/WordPress/gutenberg/pull/41259))
 -   `CheckboxControl`: Add unit tests ([#41165](https://github.com/WordPress/gutenberg/pull/41165)).
+
 
 ## 19.11.0 (2022-05-18)
 

--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -8,7 +8,6 @@
 -   `BorderControl` updated to satisfy `react/exhuastive-deps` eslint rule ([#41259](https://github.com/WordPress/gutenberg/pull/41259))
 -   `CheckboxControl`: Add unit tests ([#41165](https://github.com/WordPress/gutenberg/pull/41165)).
 
-
 ## 19.11.0 (2022-05-18)
 
 ### Enhancements

--- a/packages/components/src/border-control/border-control/hook.ts
+++ b/packages/components/src/border-control/border-control/hook.ts
@@ -56,7 +56,7 @@ export function useBorderControl(
 
 			onChange( newBorder );
 		},
-		[ onChange, shouldSanitizeBorder, sanitizeBorder ]
+		[ onChange, shouldSanitizeBorder ]
 	);
 
 	const onWidthChange = useCallback(
@@ -97,7 +97,13 @@ export function useBorderControl(
 
 			onBorderChange( updatedBorder );
 		},
-		[ border, hadPreviousZeroWidth, onBorderChange ]
+		[
+			border,
+			hadPreviousZeroWidth,
+			colorSelection,
+			styleSelection,
+			onBorderChange,
+		]
 	);
 
 	const onSliderChange = useCallback(


### PR DESCRIPTION
## What?
Updates the `BorderControl` component to satisfy the `exhaustive-deps` eslint rule

## Why?
Part of the effort in https://github.com/WordPress/gutenberg/pull/41166 to apply `exhuastive-deps` to the Components package

## How?
- remove `sanitizeBorder` from dependency array. `sanitizeBorder` isn't a prop, and mutating it doesn't rerender the component so it's not a valid dependency
- add `colorSelection` and `styleSelection` to dependency array

## Testing Instructions
1. Rebase this PR on top of https://github.com/WordPress/gutenberg/pull/41166, OR manually set
`'react-hooks/exhaustive-deps': 'warn'` in your local eslint file
2. From your local Gutenberg directory, run `npx eslint packages/components/src/border-control`
3. Confirm that the linter returns no errors
4. Launch Storybook
5. Test the component, any stories, and its docs to ensure everything still works as expected.


