### PR TITLE
Theme JSON: migrate get_style_nodes to 6.1

### DIFF
--- a/lib/compat/wordpress-6.1/class-wp-theme-json-6-1.php
+++ b/lib/compat/wordpress-6.1/class-wp-theme-json-6-1.php
@@ -162,17 +162,12 @@ class WP_Theme_JSON_6_1 extends WP_Theme_JSON_6_0 {
 	 * @return array Sanitized structure.
 	 */
 	public static function remove_insecure_properties( $theme_json ) {
-		$sanitized = array();
-
-		$theme_json = WP_Theme_JSON_Schema::migrate( $theme_json );
-
+		$sanitized           = array();
+		$theme_json          = WP_Theme_JSON_Schema::migrate( $theme_json );
 		$valid_block_names   = array_keys( static::get_blocks_metadata() );
 		$valid_element_names = array_keys( static::ELEMENTS );
-
-		$theme_json = static::sanitize( $theme_json, $valid_block_names, $valid_element_names );
-
-		$blocks_metadata = static::get_blocks_metadata();
-		$style_nodes     = static::get_style_nodes( $theme_json );
+		$theme_json          = static::sanitize( $theme_json, $valid_block_names, $valid_element_names );
+		$style_nodes         = static::get_style_nodes( $theme_json );
 
 		foreach ( $style_nodes as $metadata ) {
 			$input = _wp_array_get( $theme_json, $metadata['path'], array() );


### PR DESCRIPTION
## What?
Migrates WP_Theme_JSON methods that call `get_style_nodes()` from WP_Theme_JSON_5_9 to WP_Theme_JSON_6_1.

## Why?
After #41160, the `$selectors` argument `get_style_nodes()` is longer required. See @oandregal's comments in https://github.com/WordPress/gutenberg/pull/41217#issuecomment-1134831790

## How?
This commit reverts https://github.com/WordPress/gutenberg/pull/41217 and migrates WP_Theme_JSON methods that call `get_style_nodes()` from WP_Theme_JSON_5_9 to WP_Theme_JSON_6_1.

## Testing Instructions

Run this branch, ensure the site and post editors work as well as the frontend. 

`npm run test-unit-php`

