### PR TITLE
Make text/number inputs of `ColorPicker` keep draft values while focused

### DIFF
--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Bug Fix
+
+-   Fix `InputControl` blocking undo/redo while focused. ([#40518](https://github.com/WordPress/gutenberg/pull/40518))
+
 ### Enhancements
 
 -   `BorderControl` now only displays the reset button in its popover when selections have already been made. ([#40917](https://github.com/WordPress/gutenberg/pull/40917))

--- a/packages/components/src/color-picker/hex-input.tsx
+++ b/packages/components/src/color-picker/hex-input.tsx
@@ -7,7 +7,6 @@ import { colord, Colord } from 'colord';
  * WordPress dependencies
  */
 import { __ } from '@wordpress/i18n';
-import { useEffect, useRef, useState } from '@wordpress/element';
 
 /**
  * Internal dependencies
@@ -17,6 +16,7 @@ import { Spacer } from '../spacer';
 import { space } from '../ui/utils/space';
 import { ColorHexInputControl } from './styles';
 import { COLORS } from '../utils/colors-values';
+import { useDraft } from './use-draft';
 
 interface HexInputProps {
 	color: Colord;
@@ -24,39 +24,16 @@ interface HexInputProps {
 	enableAlpha: boolean;
 }
 
-type DraftState = {
-	value?: string;
-	isStale?: boolean;
-};
-
 export const HexInput = ( { color, onChange, enableAlpha }: HexInputProps ) => {
 	const formattedValue = color.toHex().slice( 1 ).toUpperCase();
-	const refPreviousFormattedValue = useRef( formattedValue );
-	const [ draft, setDraft ] = useState< DraftState >( {} );
-	const usedValue = draft.value !== undefined ? draft.value : formattedValue;
 
-	// Determines when to discard the draft value to restore controlled status.
-	// To do so, it tracks the previous formatted value and marks the draft
-	// value as stale after each render.
-	useEffect( () => {
-		const { current: previousFormattedValue } = refPreviousFormattedValue;
-		refPreviousFormattedValue.current = formattedValue;
-		if ( draft.value !== undefined && ! draft.isStale )
-			setDraft( { ...draft, isStale: true } );
-		else if ( draft.isStale && formattedValue !== previousFormattedValue )
-			setDraft( {} );
-	}, [ formattedValue, draft.isStale, draft.value ] );
-
-	const handleChange = ( nextValue: string | undefined ) => {
-		if ( ! nextValue ) return;
-		nextValue = nextValue.replace( /^#/, '' );
-		// Mutates the draft value to avoid an extra render and effect run.
-		setDraft( ( current ) =>
-			Object.assign( current, { value: nextValue, isStale: false } )
-		);
-		onChange( colord( '#' + nextValue ) );
-	};
-	const handleBlur = () => setDraft( {} );
+	const draftHookProps = useDraft( {
+		value: formattedValue,
+		onChange: ( nextValue ) => {
+			nextValue = nextValue.replace( /^#/, '' );
+			onChange( colord( '#' + nextValue ) );
+		},
+	} );
 
 	return (
 		<ColorHexInputControl
@@ -70,9 +47,7 @@ export const HexInput = ( { color, onChange, enableAlpha }: HexInputProps ) => {
 					#
 				</Spacer>
 			}
-			value={ usedValue }
-			onBlur={ handleBlur }
-			onChange={ handleChange }
+			{ ...draftHookProps }
 			maxLength={ enableAlpha ? 9 : 7 }
 			label={ __( 'Hex color' ) }
 			hideLabelFromVision

--- a/packages/components/src/color-picker/input-with-slider.tsx
+++ b/packages/components/src/color-picker/input-with-slider.tsx
@@ -7,6 +7,7 @@ import { Spacer } from '../spacer';
 import { space } from '../ui/utils/space';
 import { RangeControl, NumberControlWrapper } from './styles';
 import { COLORS } from '../utils/colors-values';
+import { useDraft } from './use-draft';
 
 interface InputWithSliderProps {
 	min: number;
@@ -25,6 +26,11 @@ export const InputWithSlider = ( {
 	onChange,
 	value,
 }: InputWithSliderProps ) => {
+	const draftHookProps = useDraft( {
+		value: `${ value }`,
+		onChange: ( nextValue ) => onChange( parseFloat( nextValue ) ),
+	} );
+
 	return (
 		<Spacer as={ HStack } spacing={ 4 }>
 			<NumberControlWrapper
@@ -32,8 +38,7 @@ export const InputWithSlider = ( {
 				max={ max }
 				label={ label }
 				hideLabelFromVision
-				value={ value }
-				onChange={ onChange }
+				{ ...draftHookProps }
 				prefix={
 					<Spacer
 						as={ Text }

--- a/packages/components/src/color-picker/use-draft.ts
+++ b/packages/components/src/color-picker/use-draft.ts
@@ -1,0 +1,52 @@
+/**
+ * External dependencies
+ */
+import type { FocusEventHandler } from 'react';
+
+/**
+ * WordPress dependencies
+ */
+import { useEffect, useRef, useState } from '@wordpress/element';
+
+type DraftHookProps = {
+	value: string;
+	onBlur?: FocusEventHandler;
+	onChange: ( next: string ) => void;
+};
+
+type DraftState = {
+	value?: string;
+	isStale?: boolean;
+};
+
+export const useDraft = ( props: DraftHookProps ) => {
+	const refPreviousValue = useRef( props.value );
+	const [ draft, setDraft ] = useState< DraftState >( {} );
+	const value = draft.value !== undefined ? draft.value : props.value;
+
+	// Determines when to discard the draft value to restore controlled status.
+	// To do so, it tracks the previous value and marks the draft value as stale
+	// after each render.
+	useEffect( () => {
+		const { current: previousValue } = refPreviousValue;
+		refPreviousValue.current = props.value;
+		if ( draft.value !== undefined && ! draft.isStale )
+			setDraft( { ...draft, isStale: true } );
+		else if ( draft.isStale && props.value !== previousValue )
+			setDraft( {} );
+	}, [ props.value, draft ] );
+
+	const onChange = ( nextValue: string ) => {
+		// Mutates the draft value to avoid an extra render and effect run.
+		setDraft( ( current ) =>
+			Object.assign( current, { value: nextValue, isStale: false } )
+		);
+		props.onChange( nextValue );
+	};
+	const onBlur: FocusEventHandler = ( event ) => {
+		setDraft( {} );
+		props.onBlur?.( event );
+	};
+
+	return { value, onBlur, onChange };
+};

--- a/packages/components/src/input-control/input-field.tsx
+++ b/packages/components/src/input-control/input-field.tsx
@@ -24,7 +24,6 @@ import type { WordPressComponentProps } from '../ui/context';
 import { useDragCursor } from './utils';
 import { Input } from './styles/input-control-styles';
 import { useInputControlStateReducer } from './reducer/reducer';
-import { useUpdateEffect } from '../utils';
 import type { InputFieldProps } from './types';
 
 function InputField(
@@ -67,39 +66,20 @@ function InputField(
 		pressEnter,
 		pressUp,
 		reset,
-	} = useInputControlStateReducer( stateReducer, {
-		isDragEnabled,
-		value: valueProp,
-		isPressEnterToChange,
-	} );
+	} = useInputControlStateReducer(
+		stateReducer,
+		{
+			isDragEnabled,
+			value: valueProp,
+			isPressEnterToChange,
+		},
+		onChange
+	);
 
-	const { _event, value, isDragging, isDirty } = state;
+	const { value, isDragging, isDirty } = state;
 	const wasDirtyOnBlur = useRef( false );
 
 	const dragCursor = useDragCursor( isDragging, dragDirection );
-
-	/*
-	 * Handles synchronization of external and internal value state.
-	 * If not focused and did not hold a dirty value[1] on blur
-	 * updates the value from the props. Otherwise if not holding
-	 * a dirty value[1] propagates the value and event through onChange.
-	 * [1] value is only made dirty if isPressEnterToChange is true
-	 */
-	useUpdateEffect( () => {
-		if ( valueProp === value ) {
-			return;
-		}
-		if ( ! isFocused && ! wasDirtyOnBlur.current ) {
-			commit( valueProp, _event as SyntheticEvent );
-		} else if ( ! isDirty ) {
-			onChange( value, {
-				event: _event as
-					| ChangeEvent< HTMLInputElement >
-					| PointerEvent< HTMLInputElement >,
-			} );
-			wasDirtyOnBlur.current = false;
-		}
-	}, [ value, isDirty, isFocused, valueProp ] );
 
 	const handleOnBlur = ( event: FocusEvent< HTMLInputElement > ) => {
 		onBlur( event );

--- a/packages/components/src/input-control/reducer/actions.ts
+++ b/packages/components/src/input-control/reducer/actions.ts
@@ -20,7 +20,7 @@ export const PRESS_UP = 'PRESS_UP';
 export const RESET = 'RESET';
 
 interface EventPayload {
-	event?: SyntheticEvent;
+	event: SyntheticEvent;
 }
 
 interface Action< Type, ExtraPayload = {} > {

--- a/packages/components/src/input-control/reducer/state.ts
+++ b/packages/components/src/input-control/reducer/state.ts
@@ -9,22 +9,24 @@ import type { Reducer } from 'react';
 import type { InputAction } from './actions';
 
 export interface InputState {
-	_event: Event | {};
 	error: unknown;
-	initialValue?: string;
+	initialValue: string;
 	isDirty: boolean;
 	isDragEnabled: boolean;
 	isDragging: boolean;
 	isPressEnterToChange: boolean;
-	value?: string;
+	value: string;
 }
 
-export type StateReducer = Reducer< InputState, InputAction >;
+export type StateReducer = Reducer<
+	InputState,
+	InputAction | Partial< InputState >
+>;
+export type SecondaryReducer = Reducer< InputState, InputAction >;
 
 export const initialStateReducer: StateReducer = ( state: InputState ) => state;
 
 export const initialInputControlState: InputState = {
-	_event: {},
 	error: null,
 	initialValue: '',
 	isDirty: false,

--- a/packages/components/src/input-control/types.ts
+++ b/packages/components/src/input-control/types.ts
@@ -65,7 +65,7 @@ interface BaseProps {
 export type InputChangeCallback<
 	E = ChangeEvent< HTMLInputElement > | PointerEvent< HTMLInputElement >,
 	P = {}
-> = ( nextValue: string | undefined, extra: { event: E } & P ) => void;
+> = ( nextValue: string, extra: { event: E } & P ) => void;
 
 export interface InputFieldProps extends BaseProps {
 	/**

--- a/packages/components/src/range-control/index.js
+++ b/packages/components/src/range-control/index.js
@@ -18,8 +18,8 @@ import { useInstanceId } from '@wordpress/compose';
 import BaseControl from '../base-control';
 import Button from '../button';
 import Icon from '../icon';
-import { COLORS } from '../utils';
-import { floatClamp, useControlledRangeValue } from './utils';
+import { COLORS, useControlledState } from '../utils';
+import { useUnimpededRangedNumberEntry } from './utils';
 import InputRange from './input-range';
 import RangeRail from './rail';
 import SimpleTooltip from './tooltip';
@@ -70,13 +70,10 @@ function RangeControl(
 	},
 	ref
 ) {
-	const [ value, setValue ] = useControlledRangeValue( {
-		min,
-		max,
-		value: valueProp,
-		initial: initialPosition,
-	} );
 	const isResetPendent = useRef( false );
+	const [ value, setValue ] = useControlledState( valueProp, {
+		fallback: null,
+	} );
 
 	if ( step === 'any' ) {
 		// The tooltip and number input field are hidden when the step is "any"
@@ -102,15 +99,15 @@ function RangeControl(
 	const isThumbFocused = ! disabled && isFocused;
 
 	const isValueReset = value === null;
-	const currentValue = value !== undefined ? value : currentInput;
+	const usedValue = isValueReset
+		? resetFallbackValue ?? initialPosition
+		: value ?? currentInput;
 
-	const inputSliderValue = isValueReset ? '' : currentValue;
-
-	const rangeFillValue = isValueReset ? ( max - min ) / 2 + min : value;
-
-	const calculatedFillValue = ( ( value - min ) / ( max - min ) ) * 100;
-	const fillValue = isValueReset ? 50 : calculatedFillValue;
-	const fillValueOffset = `${ clamp( fillValue, 0, 100 ) }%`;
+	const fillPercent = `${
+		usedValue === null || usedValue === undefined
+			? 50
+			: ( ( clamp( usedValue, min, max ) - min ) / ( max - min ) ) * 100
+	}%`;
 
 	const classes = classnames( 'components-range-control', className );
 
@@ -129,23 +126,20 @@ function RangeControl(
 		onChange( nextValue );
 	};
 
-	const handleOnChange = ( nextValue ) => {
-		nextValue = parseFloat( nextValue );
-		setValue( nextValue );
-		/*
-		 * Calls onChange only when nextValue is numeric
-		 * otherwise may queue a reset for the blur event.
-		 */
-		if ( ! isNaN( nextValue ) ) {
-			if ( nextValue < min || nextValue > max ) {
-				nextValue = floatClamp( nextValue, min, max );
+	const someNumberInputProps = useUnimpededRangedNumberEntry( {
+		max,
+		min,
+		value: usedValue ?? '',
+		onChange: ( nextValue ) => {
+			if ( ! isNaN( nextValue ) ) {
+				setValue( nextValue );
+				onChange( nextValue );
+				isResetPendent.current = false;
+			} else if ( allowReset ) {
+				isResetPendent.current = true;
 			}
-			onChange( nextValue );
-			isResetPendent.current = false;
-		} else if ( allowReset ) {
-			isResetPendent.current = true;
-		}
-	};
+		},
+	} );
 
 	const handleOnInputNumberBlur = () => {
 		if ( isResetPendent.current ) {
@@ -155,30 +149,20 @@ function RangeControl(
 	};
 
 	const handleOnReset = () => {
-		let resetValue = parseFloat( resetFallbackValue );
-		let onChangeResetValue = resetValue;
+		const resetValue = parseFloat( resetFallbackValue );
 
 		if ( isNaN( resetValue ) ) {
-			resetValue = null;
-			onChangeResetValue = undefined;
+			setValue( null );
+			/*
+			 * If the value is reset without a resetFallbackValue, the onChange
+			 * callback receives undefined as that was the behavior when the
+			 * component was stablized.
+			 */
+			onChange( undefined );
+		} else {
+			setValue( resetValue );
+			onChange( resetValue );
 		}
-
-		setValue( resetValue );
-
-		/**
-		 * Previously, this callback would always receive undefined as
-		 * an argument. This behavior is unexpected, specifically
-		 * when resetFallbackValue is defined.
-		 *
-		 * The value of undefined is not ideal. Passing it through
-		 * to internal <input /> elements would change it from a
-		 * controlled component to an uncontrolled component.
-		 *
-		 * For now, to minimize unexpected regressions, we're going to
-		 * preserve the undefined callback argument, except when a
-		 * resetFallbackValue is defined.
-		 */
-		onChange( onChangeResetValue );
 	};
 
 	const handleShowTooltip = () => setShowTooltip( true );
@@ -197,7 +181,7 @@ function RangeControl(
 	};
 
 	const offsetStyle = {
-		[ isRTL() ? 'right' : 'left' ]: fillValueOffset,
+		[ isRTL() ? 'right' : 'left' ]: fillPercent,
 	};
 
 	return (
@@ -235,7 +219,7 @@ function RangeControl(
 						onMouseLeave={ onMouseLeave }
 						ref={ setRef }
 						step={ step }
-						value={ inputSliderValue }
+						value={ usedValue ?? '' }
 					/>
 					<RangeRail
 						aria-hidden={ true }
@@ -245,13 +229,13 @@ function RangeControl(
 						min={ min }
 						railColor={ railColor }
 						step={ step }
-						value={ rangeFillValue }
+						value={ usedValue }
 					/>
 					<Track
 						aria-hidden={ true }
 						className="components-range-control__track"
 						disabled={ disabled }
-						style={ { width: fillValueOffset } }
+						style={ { width: fillPercent } }
 						trackColor={ trackColor }
 					/>
 					<ThumbWrapper style={ offsetStyle } disabled={ disabled }>
@@ -285,13 +269,10 @@ function RangeControl(
 						disabled={ disabled }
 						inputMode="decimal"
 						isShiftStepEnabled={ isShiftStepEnabled }
-						max={ max }
-						min={ min }
 						onBlur={ handleOnInputNumberBlur }
-						onChange={ handleOnChange }
 						shiftStep={ shiftStep }
 						step={ step }
-						value={ inputSliderValue }
+						{ ...someNumberInputProps }
 					/>
 				) }
 				{ allowReset && (

--- a/packages/components/src/range-control/index.js
+++ b/packages/components/src/range-control/index.js
@@ -139,14 +139,13 @@ function RangeControl(
 				isResetPendent.current = true;
 			}
 		},
+		onBlur: () => {
+			if ( isResetPendent.current ) {
+				handleOnReset();
+				isResetPendent.current = false;
+			}
+		},
 	} );
-
-	const handleOnInputNumberBlur = () => {
-		if ( isResetPendent.current ) {
-			handleOnReset();
-			isResetPendent.current = false;
-		}
-	};
 
 	const handleOnReset = () => {
 		const resetValue = parseFloat( resetFallbackValue );
@@ -269,7 +268,6 @@ function RangeControl(
 						disabled={ disabled }
 						inputMode="decimal"
 						isShiftStepEnabled={ isShiftStepEnabled }
-						onBlur={ handleOnInputNumberBlur }
 						shiftStep={ shiftStep }
 						step={ step }
 						{ ...someNumberInputProps }

--- a/packages/components/src/range-control/rail.js
+++ b/packages/components/src/range-control/rail.js
@@ -16,7 +16,7 @@ export default function RangeRail( {
 	min = 0,
 	max = 100,
 	step = 1,
-	value = 0,
+	value,
 	...restProps
 } ) {
 	return (
@@ -29,7 +29,7 @@ export default function RangeRail( {
 					min={ min }
 					max={ max }
 					step={ step }
-					value={ value }
+					value={ value ?? ( max - min ) / 2 + min }
 				/>
 			) }
 		</>

--- a/packages/components/src/range-control/utils.js
+++ b/packages/components/src/range-control/utils.js
@@ -16,11 +16,18 @@ import { useCallback, useRef, useEffect, useState } from '@wordpress/element';
  * @param {number|null}            props.value    Incoming value.
  * @param {number}                 props.max      Maximum valid value.
  * @param {number}                 props.min      Minimum valid value.
+ * @param {(event: Event) => void} props.onBlur   Callback for blur events.
  * @param {(next: number) => void} props.onChange Callback for changes.
  *
  * @return {Object} Assorted props for the input.
  */
-export function useUnimpededRangedNumberEntry( { max, min, onChange, value } ) {
+export function useUnimpededRangedNumberEntry( {
+	max,
+	min,
+	onBlur,
+	onChange,
+	value,
+} ) {
 	const ref = useRef();
 	const isDiverging = useRef( false );
 	/** @type {import('../input-control/types').InputChangeCallback}*/
@@ -31,6 +38,10 @@ export function useUnimpededRangedNumberEntry( { max, min, onChange, value } ) {
 			next = Math.max( min, Math.min( max, next ) );
 		}
 		onChange( next );
+	};
+	const blurHandler = ( event ) => {
+		isDiverging.current = false;
+		onBlur?.( event );
 	};
 	// When the value entered in the input is out of range then a clamped value
 	// is sent through onChange and that goes on to update the input. In such
@@ -48,7 +59,14 @@ export function useUnimpededRangedNumberEntry( { max, min, onChange, value } ) {
 		}
 	}, [ value ] );
 
-	return { max, min, ref, value, onChange: changeHandler };
+	return {
+		max,
+		min,
+		ref,
+		value,
+		onBlur: blurHandler,
+		onChange: changeHandler,
+	};
 }
 
 /**

--- a/packages/components/src/unit-control/index.tsx
+++ b/packages/components/src/unit-control/index.tsx
@@ -34,7 +34,7 @@ import {
 } from './utils';
 import { useControlledState } from '../utils/hooks';
 import type { UnitControlProps, UnitControlOnChangeCallback } from './types';
-import type { StateReducer } from '../input-control/reducer/state';
+import type { SecondaryReducer } from '../input-control/reducer/state';
 
 function UnforwardedUnitControl(
 	unitControlProps: WordPressComponentProps<
@@ -206,7 +206,7 @@ function UnforwardedUnitControl(
 	 * @param  action Action triggering state change
 	 * @return The updated state to apply to InputControl
 	 */
-	const unitControlStateReducer: StateReducer = ( state, action ) => {
+	const unitControlStateReducer: SecondaryReducer = ( state, action ) => {
 		const nextState = { ...state };
 
 		/*
@@ -226,7 +226,7 @@ function UnforwardedUnitControl(
 		return nextState;
 	};
 
-	let stateReducer: StateReducer = unitControlStateReducer;
+	let stateReducer: SecondaryReducer = unitControlStateReducer;
 	if ( stateReducerProp ) {
 		stateReducer = ( state, action ) => {
 			const baseState = unitControlStateReducer( state, action );

--- a/packages/components/src/unit-control/index.tsx
+++ b/packages/components/src/unit-control/index.tsx
@@ -179,7 +179,7 @@ function UnforwardedUnitControl(
 			const changeProps = { event, data };
 
 			// The `onChange` callback already gets called, no need to call it explicitely.
-			onUnitChange?.( validParsedUnit, changeProps );
+			onUnitChange?.( validParsedUnit ?? '', changeProps );
 
 			setUnit( validParsedUnit );
 		}


### PR DESCRIPTION
## What?
In support of the changes to `InputControl` in #40518 this ensures the text and number inputs of `ColorPicker` will keep a "drafted" value while the input is focused (like they do in trunk but without relying on the current `InputControl` behavior).

## Why?
To avoid interference with typing a value in the input and preserve instant updates during entry.

## How?
Adds logic (in a hook) to prefer a draft value over the state while focused yet restore control to props after if a change comes in that wasn't initiated from the input (e.g. global undo).

## Testing Instructions
1. Open a Post or Page.
2. Insert a Heading Block.
3. Open the Text color settings for the block.
4. Open the Custom Color Picker.
5. Show the detailed inputs.
6. Clear the input.
7. Enter a color value.
8. Verify that the value entered is kept as is and the visible color changes as different values are entered.
9. Enter a shorthand value with a letter e.g. `c03`.
10. Click outside the input.
11. Verify that the value becomes the longhand form and its letters are changed to uppercase.
12. Focus the input.
13. Press the keyboard shortcut for undo.
14. Verify that the actual selected color in the parent dialog reverts to what it was before any value changes*

*The result of the last step can be confusing because the color picker itself will revert to its last local state and instead of the editor’s revision as can be seen in its parent dialog . This is an existing issue with the component and an edge case besides.

## Screenshots or screencast

### Issue with the hex input of `ColorPicker` from #40518
https://user-images.githubusercontent.com/9000376/169936732-ac9304f3-f73e-41bf-bbe4-cd1467e3cae1.mp4

### The hex input on this branch
https://user-images.githubusercontent.com/9000376/169936875-14c8afe8-2766-41d0-8679-7f18197ea761.mp4

While I recorded a different set of actions they both include typing into the hex input so this demonstrates the fix. It also demonstrates the undo works (aside from the caveat mentioned in testing instructions) even while the input is focused.

### Issue with `InputWithSlider` of `ColorPicker` from #40518 
https://user-images.githubusercontent.com/9000376/170106420-141339bd-d1f6-41ca-9ecc-1fc7943f213d.mp4

This is the same issue with the hex input but isn't likely to be as commonly encountered. What is also seen in the screen recording is a very related but separate issue with these controls #36703.

### `InputWithSlider` on this branch
https://user-images.githubusercontent.com/9000376/170107232-5f808854-82ae-4305-866b-9ed1d41ac20f.mp4



