### PR TITLE
Plugin: Updates tested up to with 6.0 version

### DIFF
--- a/packages/create-block-tutorial-template/plugin-templates/$slug.php.mustache
+++ b/packages/create-block-tutorial-template/plugin-templates/$slug.php.mustache
@@ -8,7 +8,7 @@
  * Description:       {{description}}
 {{/description}}
  * Version:           {{version}}
- * Requires at least: 5.8
+ * Requires at least: 5.9
  * Requires PHP:      7.0
 {{#author}}
  * Author:            {{author}}

--- a/packages/create-block-tutorial-template/plugin-templates/readme.txt.mustache
+++ b/packages/create-block-tutorial-template/plugin-templates/readme.txt.mustache
@@ -3,7 +3,7 @@
 Contributors:      {{author}}
 {{/author}}
 Tags:              block
-Tested up to:      5.9
+Tested up to:      6.0
 Stable tag:        {{version}}
 {{#license}}
 License:           {{license}}

--- a/packages/create-block/lib/templates/plugin/$slug.php.mustache
+++ b/packages/create-block/lib/templates/plugin/$slug.php.mustache
@@ -7,7 +7,7 @@
 {{#description}}
  * Description:       {{description}}
 {{/description}}
- * Requires at least: 5.8
+ * Requires at least: 5.9
  * Requires PHP:      7.0
  * Version:           {{version}}
 {{#author}}

--- a/packages/create-block/lib/templates/plugin/readme.txt.mustache
+++ b/packages/create-block/lib/templates/plugin/readme.txt.mustache
@@ -3,7 +3,7 @@
 Contributors:      {{author}}
 {{/author}}
 Tags:              block
-Tested up to:      5.9
+Tested up to:      6.0
 Stable tag:        {{version}}
 {{#license}}
 License:           {{license}}

--- a/readme.txt
+++ b/readme.txt
@@ -1,6 +1,6 @@
 === Gutenberg ===
 Contributors: matveb, joen, karmatosed
-Tested up to: 5.9
+Tested up to: 6.0
 Stable tag: V.V.V
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Let's update 'Tested up to' to WordPress 6.0.

Similar to #38162 for WordPress 5.9.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

WordPress 6.0 release is scheduled for later today. 

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
- Update the tested up to version in the readme file.
- Update the tested up to version in the create block templates.
- Update the tested up to version in the create block tutorial template

I also bumped the minimum required WordPress version in Create block templates to WordPress 5.9.