### PR TITLE
Plugin: Try API for making experiments limited to WordPress codebase

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17102,6 +17102,7 @@
 				"@wordpress/html-entities": "file:packages/html-entities",
 				"@wordpress/i18n": "file:packages/i18n",
 				"@wordpress/icons": "file:packages/icons",
+				"@wordpress/interface": "file:packages/interface",
 				"@wordpress/is-shallow-equal": "file:packages/is-shallow-equal",
 				"@wordpress/keyboard-shortcuts": "file:packages/keyboard-shortcuts",
 				"@wordpress/keycodes": "file:packages/keycodes",

--- a/packages/block-editor/package.json
+++ b/packages/block-editor/package.json
@@ -48,6 +48,7 @@
 		"@wordpress/html-entities": "file:../html-entities",
 		"@wordpress/i18n": "file:../i18n",
 		"@wordpress/icons": "file:../icons",
+		"@wordpress/interface": "file:../interface",
 		"@wordpress/is-shallow-equal": "file:../is-shallow-equal",
 		"@wordpress/keyboard-shortcuts": "file:../keyboard-shortcuts",
 		"@wordpress/keycodes": "file:../keycodes",

--- a/packages/block-editor/src/index.js
+++ b/packages/block-editor/src/index.js
@@ -1,4 +1,9 @@
 /**
+ * WordPress dependencies
+ */
+import { createExperiments } from '@wordpress/interface';
+
+/**
  * Internal dependencies
  */
 import './hooks';
@@ -17,3 +22,12 @@ export * from './elements';
 export * from './utils';
 export { storeConfig, store } from './store';
 export { SETTINGS_DEFAULTS } from './store/defaults';
+
+const __experiments = createExperiments( {
+	test( name ) {
+		// eslint-disable-next-line no-console
+		console.log( `Executed with "${ name }".` );
+	},
+} );
+
+export { __experiments };

--- a/packages/edit-post/src/index.js
+++ b/packages/edit-post/src/index.js
@@ -6,6 +6,8 @@ import {
 	registerCoreBlocks,
 	__experimentalRegisterExperimentalCoreBlocks,
 } from '@wordpress/block-library';
+import { __experiments } from '@wordpress/block-editor';
+import { secretKey } from '@wordpress/interface';
 import { render, unmountComponentAtNode } from '@wordpress/element';
 import { dispatch, select } from '@wordpress/data';
 import { addFilter } from '@wordpress/hooks';
@@ -80,6 +82,10 @@ export function initializeEditor(
 	settings,
 	initialEdits
 ) {
+	const test = __experiments( 'test', secretKey );
+
+	test( 'hello world' );
+
 	// Prevent adding template part in the post editor.
 	// Only add the filter when the post editor is initialized, not imported.
 	addFilter(

--- a/packages/interface/src/index.js
+++ b/packages/interface/src/index.js
@@ -1,2 +1,13 @@
 export * from './components';
 export { store } from './store';
+
+export const secretKey = process.env.WP_SECRET_KEY;
+
+export function createExperiments( experiments ) {
+	return function ( name, key ) {
+		if ( secretKey !== key ) {
+			throw new Error( 'Experiments are not supported.' );
+		}
+		return experiments[ name ];
+	};
+}

--- a/tools/webpack/shared.js
+++ b/tools/webpack/shared.js
@@ -69,6 +69,7 @@ const plugins = [
 		// Inject the `IS_GUTENBERG_PLUGIN` global, used for feature flagging.
 		'process.env.IS_GUTENBERG_PLUGIN':
 			process.env.npm_package_config_IS_GUTENBERG_PLUGIN,
+		'process.env.WP_SECRET_KEY': JSON.stringify( new Date() ),
 	} ),
 	mode === 'production' && new ReadableJsAssetsWebpackPlugin(),
 ];


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Based on the discussion from https://github.com/WordPress/gutenberg/issues/40316.

Builds on the idea shared by @noisysocks in https://github.com/WordPress/gutenberg/issues/40316#issuecomment-1123214937:

> One idea maybe worth investigating: Could we make it so that experimental functions and components can only be accessed via an `import ... from '@wordpress/...';` statement? That is, they won't appear in the wp global. This is already how WordPress code is written so it shouldn't affect Core features. Adventurous third parties can use the experimental APIs but only by adding the `@wordpress` package to their `package.json` and therefore vendoring the code. When the experimental code is eventually deleted from Core it will continue to exist in the plugin's node_modules until the plugin is updated.

I went for a simpler solution, for now, to explore how we can build a formal API that makes it possible to use all experimental APIs inside the Gutenberg plugin and WordPress core without exposing them to plugins and themes.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

To make experimental APIs limited to usage only in WordPress codebase.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

I use one of the existing packages that are used internally - `@wordpress/interface`. It's a less important part at the moment where to put the code. What matters is that the `secretKey` is not available to everyone through `wp` global. The value assigned to the `secretKey` gets generated on every build. In practice, it means it will change with every new public release for WordPress so developers won't be able to hardcode this version. We can think about an even more elaborate approach if a stable key for a single WP release version is still a concern.

<img width="1287" alt="Screenshot 2022-05-24 at 11 58 18" src="https://user-images.githubusercontent.com/699132/170005362-762db7e3-af1a-4593-a8be-c056ea788344.png">

For the Gutenberg plugin we can use a predictable `secrectKey`, for example: `GUTENBERG` to allow plugins to use experimental APIs only with the Gutenberg plugin installed.

### Defining experiments in the package

With that, we have a formal API to define an experiment (example for `@wordpress/block-editor` package):

```js
const __experiments = createExperiments( {
 	test( name ) {
 		// eslint-disable-next-line no-console
 		console.log( `Executed with "${ name }".` );
 	},
 } );

 export { __experiments };
```

which currently would be code as:

```js
export function __experimentalTest( name ) {
 	// eslint-disable-next-line no-console
	console.log( `Executed with "${ name }".` );
}
```

### Consuming experiments

To use the experimental method we need to access the exposed `__experiments` helper function and combine it with a secret key that is available only internally in the bundled code:

```js
import { __experiments } from '@wordpress/block-editor';
import { secretKey } from '@wordpress/interface';

const test = __experiments( 'test', secretKey );

test( 'hello world' );
```

which is equivalent to the usage today:


```js
import { __experimenalTest as test } from '@wordpress/block-editor';

test( 'hello world' );
```