### PR TITLE
[Site Editor]: Persist new template's description on creation

### DIFF
--- a/packages/edit-site/src/components/add-new-template/new-template.js
+++ b/packages/edit-site/src/components/add-new-template/new-template.js
@@ -99,7 +99,7 @@ export default function NewTemplate( { postType } ) {
 				'postType',
 				'wp_template',
 				{
-					excerpt: description,
+					description,
 					// Slugs need to be strings, so this is for template `404`
 					slug: slug.toString(),
 					status: 'publish',


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Discovered while working on https://github.com/WordPress/gutenberg/pull/41189.

Currently when we create a new template in site editor the description is not persisted. This is because we handle `post_excerpt` internally and we need to pass `description` property at the REST request.

In general I see that we don't have a single source of truth for template info(default templates client side, default templates server side, persisted template post type)  and this results in inconsistencies. For example when you edit one these templates in the site editor, the description seemed to be working as expected, but it was not picked up by template post type.

## Testing instructions
1. In site editor create a missing default template like `Front Page`(depends on the theme you use and `Empty` is a good one to test with).
2. Observe that in the list of the available templates the description is there, in contrary to what happens in trunk(empty). 

#### Before

https://user-images.githubusercontent.com/16275880/170073967-9f92cded-a161-4a23-852c-989a4e22268c.mov

#### After


https://user-images.githubusercontent.com/16275880/170074004-ebcf34a0-fb91-4263-abf8-986defd61f7f.mov


