### PR TITLE
Fix: List split bugs if the one of the splits is empty.

### DIFF
--- a/packages/block-library/src/list-item/hooks/use-split.js
+++ b/packages/block-library/src/list-item/hooks/use-split.js
@@ -1,23 +1,32 @@
 /**
  * WordPress dependencies
  */
-import { useCallback } from '@wordpress/element';
+import { useCallback, useRef } from '@wordpress/element';
 import { useSelect } from '@wordpress/data';
 import { store as blockEditorStore } from '@wordpress/block-editor';
-import { cloneBlock } from '@wordpress/blocks';
+import { cloneBlock, createBlock } from '@wordpress/blocks';
 
 export default function useSplit( clientId ) {
+	// We can not rely on the isAfterOriginal parameter of the callback,
+	// because if the value after the split is empty isAfterOriginal is false
+	// while the value is in fact after the original. So to avoid that issue we use
+	// a flag where the first execution of the callback is false (it is the before value)
+	// and the second execution is true, it is the after value.
+	const isAfter = useRef( false );
 	const { getBlock } = useSelect( blockEditorStore );
 	return useCallback(
-		( value, isAfterOriginal ) => {
+		( value ) => {
 			const block = getBlock( clientId );
-			return cloneBlock(
-				block,
-				{
+			if ( isAfter.current ) {
+				return cloneBlock( block, {
 					content: value,
-				},
-				isAfterOriginal ? [] : block.innerBlocks
-			);
+				} );
+			}
+			isAfter.current = true;
+			return createBlock( block.name, {
+				...block.attributes,
+				content: value,
+			} );
 		},
 		[ clientId, getBlock ]
 	);


### PR DESCRIPTION
Fixes some list split bugs where one of the splits is empty.
We can not rely on isAfterOriginal because it has some logic where it is false if the value after the split is empty.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

## Testing Instructions
I tried to split non-empty list items, empty list items at the begging, empty list items at the end, with and without nested items, and verified in all the cases things worked as expected.

## Screenshots or screencast <!-- if applicable -->
Before:
![May-24-2022 16-51-09](https://user-images.githubusercontent.com/11271197/170078878-4f6849a7-4995-4678-954e-42ee720374c4.gif)

After:
![May-24-2022 16-54-02](https://user-images.githubusercontent.com/11271197/170079365-7370cb0b-1b93-4579-bb59-492b2ac87947.gif)

