### PR TITLE
wp-scripts: add condition to avoid creating `.` directory while running `plugin-zip`

### DIFF
--- a/bin/test-create-block.sh
+++ b/bin/test-create-block.sh
@@ -98,4 +98,4 @@ cd zip-folder
 unzip example-static.zip
 
 status "Printing the content of directory..."
-ls -al
+ls -alR

--- a/bin/test-create-block.sh
+++ b/bin/test-create-block.sh
@@ -84,3 +84,18 @@ status "Linting JavaScript files..."
 
 status "Creating a plugin zip file..."
 ../node_modules/.bin/wp-scripts plugin-zip
+
+status "Printing the current working directory..."
+pwd
+
+status "Checking if unzip command exists or not..."
+unzip --help
+
+status "Trying to unzip example-static.zip file..."
+mkdir zip-folder
+cp example-static.zip zip-folder
+cd zip-folder
+unzip example-static.zip
+
+status "Printing the content of directory..."
+ls -al


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->

## Screenshots or screencast <!-- if applicable -->
