### PR TITLE
Components: refactor `ColorPicker` to pass `exhaustive-deps`

### DIFF
--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -10,6 +10,7 @@
 -   `Spacer`: Complete TypeScript migration ([#42013](https://github.com/WordPress/gutenberg/pull/42013)).
 -   `TreeSelect`: Refactor away from `_.repeat()` ([#42070](https://github.com/WordPress/gutenberg/pull/42070/)).
 -   `FocalPointPicker` updated to satisfy `react/exhuastive-deps` eslint rule ([#41520](https://github.com/WordPress/gutenberg/pull/41520)).
+-   `ColorPicker` updated to satisfy `react/exhuastive-deps` eslint rule ([#41294](https://github.com/WordPress/gutenberg/pull/41294)).
 
 ## 19.14.0 (2022-06-29)
 

--- a/packages/components/src/color-picker/index.native.js
+++ b/packages/components/src/color-picker/index.native.js
@@ -91,7 +91,7 @@ function ColorPicker( {
 		setColor( currentColor );
 	}, [ currentColor, setColor ] );
 
-	const { current: bottomSheetInitializer } = useRef( () => {
+	useEffect( () => {
 		shouldEnableBottomSheetMaxHeight( false );
 		onHandleClosingBottomSheet( () => {
 			if ( savedColor ) {
@@ -104,8 +104,12 @@ function ColorPicker( {
 		if ( onHandleHardwareButtonPress ) {
 			onHandleHardwareButtonPress( onButtonPress );
 		}
-	} );
-	useEffect( bottomSheetInitializer, [ bottomSheetInitializer ] );
+		// TODO: Revisit this to discover if there's a good reason for omitting
+		// the hook’s dependencies and running it a single time. Ideally there
+		// may be a way to refactor and obviate the disabled lint rule. If not,
+		// this comment should be replaced by one that explains the reasoning.
+		// eslint-disable-next-line react-hooks/exhaustive-deps
+	}, [] );
 
 	function onHuePickerChange( { hue: h } ) {
 		setHue( h );

--- a/packages/components/src/color-picker/index.native.js
+++ b/packages/components/src/color-picker/index.native.js
@@ -76,22 +76,16 @@ function ColorPicker( {
 		styles.footerDark
 	);
 
-	const currentColor = colord( {
-		h: hue,
-		s: sat * 100,
-		v: val * 100,
-	} ).toHex();
+	const combineToHex = ( h = hue, s = sat, v = val ) =>
+		colord( { h, s: s * 100, v: v * 100 } ).toHex();
+
+	const currentColor = combineToHex();
 
 	const updateColor = ( { hue: h, saturation: s, value: v } ) => {
 		if ( h !== undefined ) setHue( h );
 		if ( s !== undefined ) setSaturation( s );
 		if ( v !== undefined ) setValue( v );
-		const nextColor = colord( {
-			h: h ?? hue,
-			s: s ?? sat * 100,
-			v: v ?? val * 100,
-		} ).toHex();
-		setColor( nextColor );
+		setColor( combineToHex( h, s, v ) );
 	};
 
 	useEffect( () => {

--- a/packages/components/src/color-picker/index.native.js
+++ b/packages/components/src/color-picker/index.native.js
@@ -83,9 +83,9 @@ function ColorPicker( {
 	} ).toHex();
 
 	const updateColor = ( { hue: h, saturation: s, value: v } ) => {
-		if ( h ) setHue( h );
-		if ( s ) setSaturation( s );
-		if ( v ) setValue( v );
+		if ( h !== undefined ) setHue( h );
+		if ( s !== undefined ) setSaturation( s );
+		if ( v !== undefined ) setValue( v );
 		const nextColor = colord( {
 			h: h ?? hue,
 			s: s ?? sat * 100,

--- a/packages/components/src/color-picker/index.native.js
+++ b/packages/components/src/color-picker/index.native.js
@@ -89,9 +89,9 @@ function ColorPicker( {
 			return;
 		}
 		setColor( currentColor );
-	}, [ currentColor ] );
+	}, [ currentColor, setColor ] );
 
-	useEffect( () => {
+	const { current: bottomSheetInitializer } = useRef( () => {
 		shouldEnableBottomSheetMaxHeight( false );
 		onHandleClosingBottomSheet( () => {
 			if ( savedColor ) {
@@ -104,7 +104,8 @@ function ColorPicker( {
 		if ( onHandleHardwareButtonPress ) {
 			onHandleHardwareButtonPress( onButtonPress );
 		}
-	}, [] );
+	} );
+	useEffect( bottomSheetInitializer, [ bottomSheetInitializer ] );
 
 	function onHuePickerChange( { hue: h } ) {
 		setHue( h );

--- a/packages/components/src/color-picker/index.native.js
+++ b/packages/components/src/color-picker/index.native.js
@@ -8,7 +8,7 @@ import namesPlugin from 'colord/plugins/names';
 /**
  * WordPress dependencies
  */
-import { useState, useEffect, useRef } from '@wordpress/element';
+import { useState, useEffect } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import { BottomSheet } from '@wordpress/components';
 import { usePreferredColorSchemeStyle } from '@wordpress/compose';
@@ -33,7 +33,6 @@ function ColorPicker( {
 	onHandleHardwareButtonPress,
 	bottomLabelText,
 } ) {
-	const didMount = useRef( false );
 	const isIOS = Platform.OS === 'ios';
 	const hitSlop = { top: 22, bottom: 22, left: 22, right: 22 };
 	const {
@@ -83,13 +82,17 @@ function ColorPicker( {
 		v: val * 100,
 	} ).toHex();
 
-	useEffect( () => {
-		if ( ! didMount.current ) {
-			didMount.current = true;
-			return;
-		}
-		setColor( currentColor );
-	}, [ currentColor, setColor ] );
+	const updateColor = ( { hue: h, saturation: s, value: v } ) => {
+		if ( h ) setHue( h );
+		if ( s ) setSaturation( s );
+		if ( v ) setValue( v );
+		const nextColor = colord( {
+			h: h ?? hue,
+			s: s ?? sat * 100,
+			v: v ?? val * 100,
+		} ).toHex();
+		setColor( nextColor );
+	};
 
 	useEffect( () => {
 		shouldEnableBottomSheetMaxHeight( false );
@@ -111,15 +114,6 @@ function ColorPicker( {
 		// eslint-disable-next-line react-hooks/exhaustive-deps
 	}, [] );
 
-	function onHuePickerChange( { hue: h } ) {
-		setHue( h );
-	}
-
-	function onSatValPickerChange( { saturation: s, value: v } ) {
-		setSaturation( s );
-		setValue( v );
-	}
-
 	function onButtonPress( action ) {
 		onNavigationBack();
 		onHandleClosingBottomSheet( null );
@@ -134,16 +128,16 @@ function ColorPicker( {
 		<>
 			<HsvColorPicker
 				huePickerHue={ hue }
-				onHuePickerDragMove={ onHuePickerChange }
+				onHuePickerDragMove={ updateColor }
 				onHuePickerPress={
-					! isBottomSheetContentScrolling && onHuePickerChange
+					! isBottomSheetContentScrolling && updateColor
 				}
 				satValPickerHue={ hue }
 				satValPickerSaturation={ sat }
 				satValPickerValue={ val }
-				onSatValPickerDragMove={ onSatValPickerChange }
+				onSatValPickerDragMove={ updateColor }
 				onSatValPickerPress={
-					! isBottomSheetContentScrolling && onSatValPickerChange
+					! isBottomSheetContentScrolling && updateColor
 				}
 				onSatValPickerDragStart={ () => {
 					shouldEnableBottomSheetScroll( false );

--- a/packages/components/src/color-picker/use-deprecated-props.ts
+++ b/packages/components/src/color-picker/use-deprecated-props.ts
@@ -107,30 +107,24 @@ const transformColorStringToLegacyColor = memoize(
 export function useDeprecatedProps(
 	props: LegacyProps | ColorPickerProps
 ): ColorPickerProps {
-	const isUsingLegacy = isLegacyProps( props );
 	const { onChangeComplete } = props as LegacyProps;
-	const { onChange: onChangeProp } = props as ColorPickerProps;
 	const legacyChangeHandler = useCallback(
 		( color: string ) => {
 			onChangeComplete( transformColorStringToLegacyColor( color ) );
 		},
 		[ onChangeComplete ]
 	);
-	const onChange = isUsingLegacy ? legacyChangeHandler : onChangeProp;
-
-	const { color: colorProp } = props;
-	const color = isUsingLegacy
-		? getColorFromLegacyProps( colorProp )
-		: ( colorProp as ColorPickerProps[ 'color' ] );
-
-	const { disableAlpha } = props as LegacyProps;
-	const { enableAlpha: enableAlphaProp } = props as ColorPickerProps;
-	const enableAlpha = isUsingLegacy ? ! disableAlpha : enableAlphaProp;
-
+	if ( isLegacyProps( props ) ) {
+		return {
+			color: getColorFromLegacyProps( props.color ),
+			enableAlpha: ! props.disableAlpha,
+			onChange: legacyChangeHandler,
+		};
+	}
 	return {
-		...( isUsingLegacy ? {} : props ),
-		onChange,
-		color,
-		enableAlpha,
+		...props,
+		color: props.color as ColorPickerProps[ 'color' ],
+		enableAlpha: ( props as ColorPickerProps ).enableAlpha,
+		onChange: ( props as ColorPickerProps ).onChange,
 	};
 }

--- a/packages/components/src/color-picker/use-deprecated-props.ts
+++ b/packages/components/src/color-picker/use-deprecated-props.ts
@@ -16,7 +16,7 @@ import memoize from 'memize';
 /**
  * WordPress dependencies
  */
-import { useCallback, useMemo } from '@wordpress/element';
+import { useCallback } from '@wordpress/element';
 
 /**
  * Internal dependencies
@@ -124,17 +124,13 @@ export function useDeprecatedProps(
 	);
 
 	const { color: colorProp } = props;
-	const color = useMemo( () => {
-		return isUsingLegacy
-			? getColorFromLegacyProps( colorProp )
-			: ( colorProp as ColorPickerProps[ 'color' ] );
-	}, [ colorProp, isUsingLegacy ] );
+	const color = isUsingLegacy
+		? getColorFromLegacyProps( colorProp )
+		: ( colorProp as ColorPickerProps[ 'color' ] );
 
 	const { disableAlpha } = props as LegacyProps;
 	const { enableAlpha: enableAlphaProp } = props as ColorPickerProps;
-	const enableAlpha = useMemo( () => {
-		return isUsingLegacy ? ! disableAlpha : enableAlphaProp;
-	}, [ disableAlpha, enableAlphaProp, isUsingLegacy ] );
+	const enableAlpha = isUsingLegacy ? ! disableAlpha : enableAlphaProp;
 
 	return {
 		...( isUsingLegacy ? {} : props ),

--- a/packages/components/src/color-picker/use-deprecated-props.ts
+++ b/packages/components/src/color-picker/use-deprecated-props.ts
@@ -110,18 +110,13 @@ export function useDeprecatedProps(
 	const isUsingLegacy = isLegacyProps( props );
 	const { onChangeComplete } = props as LegacyProps;
 	const { onChange: onChangeProp } = props as ColorPickerProps;
-	const onChange = useCallback(
+	const legacyChangeHandler = useCallback(
 		( color: string ) => {
-			if ( isUsingLegacy ) {
-				return onChangeComplete(
-					transformColorStringToLegacyColor( color )
-				);
-			}
-
-			return onChangeProp?.( color );
+			onChangeComplete( transformColorStringToLegacyColor( color ) );
 		},
-		[ onChangeComplete, onChangeProp, isUsingLegacy ]
+		[ onChangeComplete ]
 	);
+	const onChange = isUsingLegacy ? legacyChangeHandler : onChangeProp;
 
 	const { color: colorProp } = props;
 	const color = isUsingLegacy


### PR DESCRIPTION
## What?
Updates the `ColorPicker` component to satisfy the `exhaustive-deps` eslint rule

## Why?
Part of the effort in #41166 to apply `exhuastive-deps` to the Components package

## How?
### in `useDeprecatedProps`
- Refactored to remove `props` from within a callback hook
- Removed two memo hooks.
- Moved "complex expressions" out of the dependencies of a callback hook.

### in native component
- Removed an effect hook used to call `setColor` passed by props in favor of calling from event handlers.
- Disabled the `react-hooks/exhaustive-deps` rule for an effect hook and left a TODO comment about revisiting it.

## Testing Instructions
1. Checkout this branch
2. From your local Gutenberg directory, run `npx eslint --rule 'react-hooks/exhaustive-deps: warn' packages/components/src/color-picker`
3. Confirm that the linter returns no warnings or errors
4. Launch Storybook
5. Test the component, any stories, and its docs to ensure everything still works as expected.
6. Test the native component to ensure everything still works as expected.

## What's missing?
A changelog entry but I've left that out for now in case this requires some more time.
