### PR TITLE
Columns: Try adding a columnsOnTablet attribute to control tablet breakpoint

### DIFF
--- a/docs/reference-guides/core-blocks.md
+++ b/docs/reference-guides/core-blocks.md
@@ -105,7 +105,7 @@ Display content in multiple columns, with blocks added to each column. ([Source]
 -	**Name:** core/columns
 -	**Category:** design
 -	**Supports:** align (full, wide), anchor, color (background, gradients, link, text), spacing (blockGap, margin, padding), ~~html~~
--	**Attributes:** isStackedOnMobile, verticalAlignment
+-	**Attributes:** columnsOnTablet, isStackedOnMobile, verticalAlignment
 
 ## Comment Author Avatar (deprecated)
 

--- a/packages/block-library/src/columns/block.json
+++ b/packages/block-library/src/columns/block.json
@@ -7,6 +7,10 @@
 	"description": "Display content in multiple columns, with blocks added to each column.",
 	"textdomain": "default",
 	"attributes": {
+		"columnsOnTablet": {
+			"type": "number",
+			"default": 1
+		},
 		"verticalAlignment": {
 			"type": "string"
 		},

--- a/packages/block-library/src/columns/edit.js
+++ b/packages/block-library/src/columns/edit.js
@@ -59,7 +59,11 @@ function ColumnsEditContainer( {
 	updateColumns,
 	clientId,
 } ) {
-	const { isStackedOnMobile, verticalAlignment } = attributes;
+	const {
+		columnsOnTablet,
+		isStackedOnMobile,
+		verticalAlignment,
+	} = attributes;
 
 	const { count } = useSelect(
 		( select ) => {
@@ -73,6 +77,7 @@ function ColumnsEditContainer( {
 	const classes = classnames( {
 		[ `are-vertically-aligned-${ verticalAlignment }` ]: verticalAlignment,
 		[ `is-not-stacked-on-mobile` ]: ! isStackedOnMobile,
+		[ `tablet-columns-${ columnsOnTablet || 1 }` ]: !! isStackedOnMobile,
 	} );
 
 	const blockProps = useBlockProps( {
@@ -107,6 +112,17 @@ function ColumnsEditContainer( {
 								'This column count exceeds the recommended amount and may cause visual breakage.'
 							) }
 						</Notice>
+					) }
+					{ isStackedOnMobile && (
+						<RangeControl
+							label={ __( 'Columns at tablet screen sizes' ) }
+							value={ columnsOnTablet || 1 }
+							onChange={ ( value ) =>
+								setAttributes( { columnsOnTablet: value } )
+							}
+							min={ 1 }
+							max={ count } // Ensure user can't select more columns than there are.
+						/>
 					) }
 					<ToggleControl
 						label={ __( 'Stack on mobile' ) }

--- a/packages/block-library/src/columns/save.js
+++ b/packages/block-library/src/columns/save.js
@@ -9,11 +9,16 @@ import classnames from 'classnames';
 import { useInnerBlocksProps, useBlockProps } from '@wordpress/block-editor';
 
 export default function save( { attributes } ) {
-	const { isStackedOnMobile, verticalAlignment } = attributes;
+	const {
+		columnsOnTablet,
+		isStackedOnMobile,
+		verticalAlignment,
+	} = attributes;
 
 	const className = classnames( {
 		[ `are-vertically-aligned-${ verticalAlignment }` ]: verticalAlignment,
 		[ `is-not-stacked-on-mobile` ]: ! isStackedOnMobile,
+		[ `tablet-columns-${ columnsOnTablet || 1 }` ]: !! isStackedOnMobile,
 	} );
 
 	const blockProps = useBlockProps.save( { className } );

--- a/packages/block-library/src/columns/style.scss
+++ b/packages/block-library/src/columns/style.scss
@@ -29,29 +29,46 @@
 		align-items: flex-end;
 	}
 
-	&:not(.is-not-stacked-on-mobile) > .wp-block-column {
-		@media (max-width: #{ ($break-medium - 1) }) {
-			// Responsiveness: Show at most one columns on mobile. This must be
-			// important since the Column assigns its own width as an inline style.
-			flex-basis: 100% !important;
+	&:not(.is-not-stacked-on-mobile) {
+		@media (max-width: #{ ($break-small - 1) }) {
+			> .wp-block-column {
+				// Responsiveness: Show at most one columns on mobile. This must be
+				// important since the Column assigns its own width as an inline style.
+				flex-basis: 100% !important;
+			}
+		}
+
+		// Between mobile and large viewports (tablet), allow specific number of columns.
+		@media (min-width: #{ ($break-small) }) and (max-width: #{ ($break-medium - 1) }) {
+
+			@for $i from 1 through 6 {
+				&.tablet-columns-#{ $i } {
+					> .wp-block-column {
+						// width: calc((100% / #{ $i }) - 1.25em + (1.25em / #{ $i }));
+						flex-basis: calc((100% / #{ $i }) - calc(var(--wp--style--block-gap, 2em) + var(--wp--style--unstable-columns-gap, 0em) / 2)) !important;
+					}
+				}
+			}
 		}
 
 		// At large viewports, show all columns horizontally.
 		@include break-medium() {
-			// Available space should be divided equally amongst columns without an
-			// assigned width. This is achieved by assigning a flex basis that is
-			// consistent (equal), would not cause the sum total of column widths to
-			// exceed 100%, and which would cede to a column with an assigned width.
-			// The `flex-grow` allows columns to maximally and equally occupy space
-			// remaining after subtracting the space occupied by columns with
-			// explicit widths (if any exist).
-			flex-basis: 0;
-			flex-grow: 1;
+			> .wp-block-column {
+				// Available space should be divided equally amongst columns without an
+				// assigned width. This is achieved by assigning a flex basis that is
+				// consistent (equal), would not cause the sum total of column widths to
+				// exceed 100%, and which would cede to a column with an assigned width.
+				// The `flex-grow` allows columns to maximally and equally occupy space
+				// remaining after subtracting the space occupied by columns with
+				// explicit widths (if any exist).
+				flex-basis: 0;
+				flex-grow: 1;
 
-			// Columns with an explicitly-assigned width should maintain their
-			// `flex-basis` width and not grow.
-			&[style*="flex-basis"] {
-				flex-grow: 0;
+				// Columns with an explicitly-assigned width should maintain their
+				// `flex-basis` width and not grow.
+				&[style*="flex-basis"] {
+					flex-grow: 0;
+				}
 			}
 		}
 	}


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

🚧 🚧 🚧 ___Note: This is an exploratory PR / idea — it very well may not even be a good idea to pursue!___ 🚧 🚧 🚧

Explore adding in a `columnsOnTablet` attribute to the `Columns` block, and a slider to control how many columns to collapse down to at tablet viewport sizes.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

As discussed / raised in https://github.com/WordPress/gutenberg/pull/41123#issuecomment-1134016889 there are competing use cases for the "Stack on mobile" feature of the Columns block. On the one hand, some layouts (e.g. those involving a sidebar) should collapse down to a single column. On the other, some layouts (e.g. columns with images) might appear far too large at tablet viewports if they collapse down to a single column.

While the ideal solution is probably more in the direction of being able to set min / max widths on individual columns and have that logically collapse down based on intrinsic content sizes, I thought I'd at least explore what it'd look like if we had a Columns at tablet screen sizes control in the Columns UI.

⚠️ Note: I strongly prefer the idea of min / max width columns to the idea in this PR. As mentioned in https://github.com/WordPress/gutenberg/pull/41123#issuecomment-1136677609, it'd be really cool if we could have, say a 4 column layout on desktop, that collapses down to 2 columns on mobile based on a max 50% rule, for example. Still, this PR at least demonstrates what a UI control for columns on tablet might look like.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

* Conditionally show a Columns at tablet screen sizes slider in the Columns settings if Stack on mobile is selected
* Output CSS for

***Note: the gaps / widths aren't yet being calculated correctly. If the approach in this PR winds up being viable, we'd likely want to copy over the server-side implementation from #41123***

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->

1. Add a columns block with some columns and content in each of the columns
2. Try switching on the Stack on mobile feature and selecting a number of columns for tablet screen sizes — it should collapse to equal width columns at that viewport size

## Screenshots or screencast <!-- if applicable -->

| Screengrab | Screenshot |
| --- | --- |
| ![2022-05-25 12 50 05](https://user-images.githubusercontent.com/14988353/170171460-bf257480-6ba2-4c0f-906b-74ed4b74ca7d.gif) | <img width="1191" alt="image" src="https://user-images.githubusercontent.com/14988353/170171546-795f7fe0-104e-4fc9-8f5b-f348aa672e4d.png"> |