### PR TITLE
Update/site logo constrain image

### DIFF
--- a/packages/block-library/src/site-logo/style.scss
+++ b/packages/block-library/src/site-logo/style.scss
@@ -11,6 +11,12 @@
 		height: auto;
 	}
 
+	// Constrain the image to its container.
+	img {
+		height: auto;
+		max-width: 100%;
+	}
+
 	// Inherit border radius from style variations.
 	a,
 	img {


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
This forces images inside the Site Logo block to be constrained to their parent container. Closes https://github.com/WordPress/gutenberg/issues/41115

## Why?
This seems to match user expectation. It prevents larger images from flowing offscreen.

## How?
We set the height of the image to `auto` and set a `max-width: 100%` which is the same trick the image block uses to achieve this effect.

## Testing Instructions
- Add a site logo block
- Set the image width to be large
- Preview in the browser
- Check that the image resizes with the window

## Screenshots or screencast <!-- if applicable -->
https://user-images.githubusercontent.com/275961/170196592-1bfc093e-9d90-4bbb-99e5-7a647420498b.mov

## Limitations
This CSS doesn't take effect in the editor, as the resizeable box allows the logo to expand wider than its container. I'm not sure how we get round this, but the same is true of the image block.