### PR TITLE
Change 'author' to 'category' in onCategoryChange

### DIFF
--- a/packages/components/src/query-controls/README.md
+++ b/packages/components/src/query-controls/README.md
@@ -179,7 +179,7 @@ A function that receives the new author value. If this is not specified, the aut
 
 #### onCategoryChange
 
-A function that receives the new author value. If this is not specified, the category controls are not included.
+A function that receives the new category value. If this is not specified, the category controls are not included.
 
 -   Type: `Function`
 -   Required: No


### PR DESCRIPTION
## What?
Small typographical mistake inside the onCategoryChange section. The word 'author' needs to be changed to 'category'.

## Why?
To make the documentation correct.

## How?
The word 'author' changed to 'category' in proposed correction.
![w1](https://user-images.githubusercontent.com/11784237/170200177-060df510-373e-4159-b4c1-3e988ccad7a3.png)
