### PR TITLE
RNMobile - Update expected html for file block

### DIFF
--- a/packages/react-native-editor/__device-tests__/helpers/test-data.js
+++ b/packages/react-native-editor/__device-tests__/helpers/test-data.js
@@ -135,7 +135,7 @@ exports.coverHeightWithRemUnit = `<!-- wp:cover {"customOverlayColor":"#ffffff",
 <!-- /wp:cover -->`;
 
 exports.fileBlockPlaceholder = `<!-- wp:file {"id":3,"href":"https://wordpress.org/latest.zip"} -->
-<div class="wp-block-file"><a href="https://wordpress.org/latest.zip">WordPress.zip</a><a href="https://wordpress.org/latest.zip" class="wp-block-file__button" download>Download</a></div>
+<div class="wp-block-file"><a href="https://wordpress.org/latest.zip">WordPress.zip</a><a href="https://wordpress.org/latest.zip" class="wp-block-file__button wp-element-button" download>Download</a></div>
 <!-- /wp:file -->`;
 
 exports.audioBlockPlaceholder = `<!-- wp:audio {"id":5} -->


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
One test `Gutenberg Editor File Block tests should be able to add a file block and a file to it` is failing because the expected HTML no longer matches what is returned (e.g. [here](https://app.circleci.com/pipelines/github/wordpress-mobile/gutenberg-mobile/17554/workflows/2d63199b-7498-43a1-8982-95c8d59c56a7/jobs/95939))

## Why?
To fix the above failure for the test case.

## How?
Updating the expected data to match what is currently returned by the app. 

## Testing Instructions
Ensure that tests pass in CI

## Screenshots or screencast <!-- if applicable -->
