### PR TITLE
[Site Editor]: Update `single` default template copy

### DIFF
--- a/lib/compat/wordpress-6.1/block-template-utils.php
+++ b/lib/compat/wordpress-6.1/block-template-utils.php
@@ -26,4 +26,4 @@ function gutenberg_get_default_block_template_types( $default_template_types ) {
 	}
 	return $default_template_types;
 }
-add_filter( 'default_template_types', 'gutenberg_get_default_block_template_types', 10, 2 );
+add_filter( 'default_template_types', 'gutenberg_get_default_block_template_types', 10 );

--- a/lib/compat/wordpress-6.1/block-template-utils.php
+++ b/lib/compat/wordpress-6.1/block-template-utils.php
@@ -1,0 +1,29 @@
+<?php
+/**
+ * Temporary compatibility shims for features present in Gutenberg.
+ * This file should be removed when WordPress 6.1.0 becomes the lowest
+ * supported version by this plugin.
+ *
+ * @package gutenberg
+ */
+
+/**
+ * Updates the list of default template types, containing their
+ * localized titles and descriptions.
+ *
+ * We will only need to update `get_default_block_template_types` function.
+ *
+ * @param array $default_template_types The default template types.
+ *
+ * @return array The default template types.
+ */
+function gutenberg_get_default_block_template_types( $default_template_types ) {
+	if ( isset( $default_template_types['single'] ) ) {
+		$default_template_types['single'] = array(
+			'title'       => _x( 'Single', 'Template name', 'gutenberg' ),
+			'description' => __( 'The default template for displaying any single post or attachment.', 'gutenberg' ),
+		);
+	}
+	return $default_template_types;
+}
+add_filter( 'default_template_types', 'gutenberg_get_default_block_template_types', 10, 2 );

--- a/lib/load.php
+++ b/lib/load.php
@@ -126,6 +126,7 @@ require __DIR__ . '/compat/wordpress-6.1/persisted-preferences.php';
 require __DIR__ . '/compat/wordpress-6.1/get-global-styles-and-settings.php';
 require __DIR__ . '/compat/wordpress-6.1/script-loader.php';
 require __DIR__ . '/compat/wordpress-6.1/class-wp-theme-json-6-1.php';
+require __DIR__ . '/compat/wordpress-6.1/block-template-utils.php';
 
 // Experimental features.
 remove_action( 'plugins_loaded', '_wp_theme_json_webfonts_handler' ); // Turns off WP 6.0's stopgap handler for Webfonts API.


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Part of: https://github.com/WordPress/gutenberg/issues/37407
Needed for: https://github.com/WordPress/gutenberg/pull/41189

In order to add more template types we need to update some copy from the current default templates provided. 

This PR intents to update the `single` template copy as it's needed to clear up ambiguity between the `single` template that is the fallback for any custom post type(including `post`) and the menu item to be added in the linked PR, that will allow the creation the `single-post` template and any `single_$post_type` template.

<!-- In a few words, what is the PR actually doing? -->


## Testing Instructions
1. In site editor go to templates list
2. Click the `Add new` button to create a new template
3. Observe that the previous `Single Post` menu item has new copy

**Important** Everything else should work as expected without any regression. This includes the existing themes/templates, creation flow, resolution of templates, etc..




