### PR TITLE
Group: Check variation is registered before displaying it in the toolbar

### DIFF
--- a/packages/block-editor/src/components/convert-to-group-buttons/toolbar.js
+++ b/packages/block-editor/src/components/convert-to-group-buttons/toolbar.js
@@ -2,7 +2,7 @@
  * WordPress dependencies
  */
 import { useDispatch, useSelect } from '@wordpress/data';
-import { switchToBlockType } from '@wordpress/blocks';
+import { switchToBlockType, store as blocksStore } from '@wordpress/blocks';
 import { ToolbarButton, ToolbarGroup } from '@wordpress/components';
 import { group, row, stack } from '@wordpress/icons';
 import { _x } from '@wordpress/i18n';
@@ -28,14 +28,20 @@ function BlockGroupToolbar() {
 	} = useConvertToGroupButtonProps();
 	const { replaceBlocks } = useDispatch( blockEditorStore );
 
-	const { canRemove } = useSelect(
+	const { canRemove, variations } = useSelect(
 		( select ) => {
 			const { canRemoveBlocks } = select( blockEditorStore );
+			const { getBlockVariations } = select( blocksStore );
+
 			return {
 				canRemove: canRemoveBlocks( clientIds ),
+				variations: getBlockVariations(
+					groupingBlockName,
+					'transform'
+				),
 			};
 		},
-		[ clientIds ]
+		[ clientIds, groupingBlockName ]
 	);
 
 	const onConvertToGroup = ( layout = 'group' ) => {
@@ -63,6 +69,13 @@ function BlockGroupToolbar() {
 		return null;
 	}
 
+	const canInsertRow = !! variations.find(
+		( { name } ) => name === 'group-row'
+	);
+	const canInsertStack = !! variations.find(
+		( { name } ) => name === 'group-stack'
+	);
+
 	return (
 		<ToolbarGroup>
 			<ToolbarButton
@@ -70,16 +83,20 @@ function BlockGroupToolbar() {
 				label={ _x( 'Group', 'verb' ) }
 				onClick={ onConvertToGroup }
 			/>
-			<ToolbarButton
-				icon={ row }
-				label={ _x( 'Row', 'single horizontal line' ) }
-				onClick={ onConvertToRow }
-			/>
-			<ToolbarButton
-				icon={ stack }
-				label={ _x( 'Stack', 'verb' ) }
-				onClick={ onConvertToStack }
-			/>
+			{ canInsertRow && (
+				<ToolbarButton
+					icon={ row }
+					label={ _x( 'Row', 'single horizontal line' ) }
+					onClick={ onConvertToRow }
+				/>
+			) }
+			{ canInsertStack && (
+				<ToolbarButton
+					icon={ stack }
+					label={ _x( 'Stack', 'verb' ) }
+					onClick={ onConvertToStack }
+				/>
+			) }
 		</ToolbarGroup>
 	);
 }


### PR DESCRIPTION
## What?
Closes #41192.

PR updates `BlockGroupToolbar` to only display Row/Stack variation buttons if they're registered.

## Why?
When variations aren't registered, we shouldn't transform blocks into them.

## Testing Instructions
1. Open a Post or Page.
2. Unregister Group block variations.
3. Insert a few blocks.
4. Select multiple blocks to display Group toolbar actions.
5. Confirm that Row/Stack variation buttons aren't displayed.

```js
wp.blocks.unregisterBlockVariation('core/group', 'group-row');
wp.blocks.unregisterBlockVariation('core/group', 'group-stack');
```

## Screenshots or screencast <!-- if applicable -->

https://user-images.githubusercontent.com/240569/170226484-4225574f-3ae5-4cbc-b684-3d72c1ad7ffd.mp4


