### PR TITLE
Fix customizer block toolbar after popover refactor

### DIFF
--- a/packages/customize-widgets/src/components/sidebar-block-editor/style.scss
+++ b/packages/customize-widgets/src/components/sidebar-block-editor/style.scss
@@ -13,6 +13,14 @@
 }
 
 .customize-control-sidebar_block_editor .block-editor-block-list__block-popover {
+	// FloatingUI library used in Popover component forces us to have an "absolute" inline style.
+	// We need to override this in the customizer.
 	position: fixed !important;
 	z-index: z-index(".customize-widgets__block-toolbar");
+}
+
+.customize-widgets-popover .components-popover {
+	// FloatingUI library used in Popover component forces us to have an "absolute" inline style.
+	// We need to override this in the customizer.
+	position: fixed !important;
 }

--- a/packages/customize-widgets/src/components/sidebar-block-editor/style.scss
+++ b/packages/customize-widgets/src/components/sidebar-block-editor/style.scss
@@ -13,6 +13,6 @@
 }
 
 .customize-control-sidebar_block_editor .block-editor-block-list__block-popover {
-	position: fixed;
+	position: fixed !important;
 	z-index: z-index(".customize-widgets__block-toolbar");
 }

--- a/test/e2e/specs/widgets/customizing-widgets.spec.js
+++ b/test/e2e/specs/widgets/customizing-widgets.spec.js
@@ -52,6 +52,11 @@ test.describe( 'Widgets Customizer', () => {
 			)
 		).toBeVisible();
 
+		// Clear block selection, so the block toolbar isn't visible.
+		await page.evaluate( () => {
+			window.wp.data.dispatch( 'core/block-editor' ).clearSelectedBlock();
+		} );
+
 		await widgetsCustomizerPage.addBlock( 'Heading' );
 		await page.keyboard.type( 'My Heading' );
 


### PR DESCRIPTION
closes #35496 

## What?

The block toolbar popover was being "cut" in the customizer sidebar (widgets). This PR fixes it.

## How?

As recommended by floatingui, the Popover component now renders the "position" as inline style (after the refactor in #40740 ) which was overriding the "fixed" position override we had for block popover in the customizer. This PR just forces the fixed position in that case.

This should probably fixed the flaky e2e test we have right now.

## Testing Instructions

1- Pick the 2019 theme
2- Go to the widgets sidebar in the customizer
3- Select blocks
4- the block toolbar should be shown entirely (not cut)
