### PR TITLE
Handle no variation case in the block transform menu

### DIFF
--- a/packages/block-editor/src/components/block-variation-transforms/index.js
+++ b/packages/block-editor/src/components/block-variation-transforms/index.js
@@ -121,6 +121,9 @@ function __experimentalBlockVariationTransforms( { blockClientId } ) {
 	// Check if each variation has a unique icon.
 	const hasUniqueIcons = useMemo( () => {
 		const variationIcons = new Set();
+		if ( ! variations ) {
+			return true;
+		}
 		variations.forEach( ( variation ) => {
 			if ( variation.icon ) {
 				variationIcons.add( variation.icon );

--- a/packages/block-editor/src/components/block-variation-transforms/index.js
+++ b/packages/block-editor/src/components/block-variation-transforms/index.js
@@ -122,7 +122,7 @@ function __experimentalBlockVariationTransforms( { blockClientId } ) {
 	const hasUniqueIcons = useMemo( () => {
 		const variationIcons = new Set();
 		if ( ! variations ) {
-			return true;
+			return false;
 		}
 		variations.forEach( ( variation ) => {
 			if ( variation.icon ) {


### PR DESCRIPTION
closes #41321 

## What?

If you insert the classic block while the sidebar is open, you'll see the editor break.

## Testing Instructions

1- Open the editor sidebar
2- Insert a classic block
3- The editor shouldn't break.
