### PR TITLE
Adds example state to link element

### DIFF
--- a/lib/compat/wordpress-6.1/class-wp-theme-json-6-1.php
+++ b/lib/compat/wordpress-6.1/class-wp-theme-json-6-1.php
@@ -17,8 +17,15 @@
 class WP_Theme_JSON_6_1 extends WP_Theme_JSON_6_0 {
 	const __EXPERIMENTAL_ELEMENT_BUTTON_CLASS_NAME = 'wp-element-button';
 
+	/**
+	 * The valid elements that can be found under styles.
+	 *
+	 * @since 5.8.0
+	 * @var string[]
+	 */
 	const ELEMENTS = array(
 		'link'   => 'a',
+		'link:hover' => 'a:hover',
 		'h1'     => 'h1',
 		'h2'     => 'h2',
 		'h3'     => 'h3',

--- a/packages/blocks/src/api/constants.js
+++ b/packages/blocks/src/api/constants.js
@@ -183,6 +183,7 @@ export const __EXPERIMENTAL_STYLE_PROPERTY = {
 
 export const __EXPERIMENTAL_ELEMENTS = {
 	link: 'a',
+	'link:hover': 'a:hover',
 	h1: 'h1',
 	h2: 'h2',
 	h3: 'h3',


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->
Exploration start for #38277
## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
We should have a way to define via `theme.json` state based styles for elements (and blocks?).
## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
Just adding a state as a selector mapping to `WP_Theme_JSON::ELEMENTS`
## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->

1. Check out this PR
2. Set TwentyTwentyTwo as the theme
3. Edit the `theme.json` in TwentyTwentyTwo by adding the code below under styles > elements:

```
"link:hover": {
	"color": {
		"text": "red"
	}
}
```

4. Make a link in a post and confirm it is red on hover.

## Screenshots or screencast <!-- if applicable -->


https://user-images.githubusercontent.com/107534/170287500-29334900-9a47-4df9-beb2-96f6d65156b1.mp4


