### PR TITLE
Use wp_query when the query is set to inherited

### DIFF
--- a/packages/block-library/src/post-template/index.php
+++ b/packages/block-library/src/post-template/index.php
@@ -49,18 +49,10 @@ function render_block_core_post_template( $attributes, $content, $block ) {
 	$use_global_query = ( isset( $block->context['query']['inherit'] ) && $block->context['query']['inherit'] );
 	if ( $use_global_query ) {
 		global $wp_query;
-		if ( $wp_query && isset( $wp_query->query_vars ) && is_array( $wp_query->query_vars ) ) {
-			// Unset `offset` because if is set, $wp_query overrides/ignores the paged parameter and breaks pagination.
-			unset( $query_args['offset'] );
-			$query_args = wp_parse_args( $wp_query->query_vars, $query_args );
-
-			if ( empty( $query_args['post_type'] ) && is_singular() ) {
-				$query_args['post_type'] = get_post_type( get_the_ID() );
-			}
-		}
+		$query = $wp_query;
+    }else{
+		$query = new WP_Query( $query_args );
 	}
-
-	$query = new WP_Query( $query_args );
 
 	if ( ! $query->have_posts() ) {
 		return '';


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->
Use the actual wp_query when 'inherit query' in the query block is set.

Ps. I think this can't be merged as [these lines](https://github.com/WordPress/gutenberg/blob/trunk/packages/block-library/src/post-template/index.php#L52-L60) are there probably for a reason. So maybe it should be fixed an other way.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
When setting 'inherit query' in the query block it's not using the actual wp_query. This gives problems in some cases. For example `current_post` is not inherited and showing as -1.

Maybe fixing this too:
https://github.com/WordPress/gutenberg/issues/39285

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->
1. Use Twenty Twenty-Two + Gutenberg plugin
2. Make a page and set it as 'Posts page' in settings > reading. Add the Query Loop Block with 'inherit query' set to the page.
3. Add this to functions.php:

```
add_filter('render_block', function(string $block_content, array $block, WP_Block $instance) {
	// PS. is using empty($instance->context) the right way to target the actual post items?
	if ('core/post-template' === $block['blockName'] && empty($instance->context)) {
		global $wp_query;
		$block_content .= 'current_post: '.$wp_query->current_post;
	}

	return $block_content;
}, 20, 3);
```
4. Watch output.

## Screenshots or screencast <!-- if applicable -->
--