### PR TITLE
ToC: Fix list block check

### DIFF
--- a/packages/block-library/src/table-of-contents/edit.js
+++ b/packages/block-library/src/table-of-contents/edit.js
@@ -13,7 +13,7 @@ import {
 	store as blockEditorStore,
 	useBlockProps,
 } from '@wordpress/block-editor';
-import { createBlock, store as blocksStore } from '@wordpress/blocks';
+import { createBlock } from '@wordpress/blocks';
 import {
 	PanelBody,
 	Placeholder,
@@ -57,9 +57,16 @@ export default function TableOfContentsEdit( {
 	const blockProps = useBlockProps();
 	const disabledRef = useDisabled();
 
-	const listBlockExists = useSelect(
-		( select ) => !! select( blocksStore ).getBlockType( 'core/list' ),
-		[]
+	const canInsertList = useSelect(
+		( select ) => {
+			const { getBlockRootClientId, canInsertBlockType } = select(
+				blockEditorStore
+			);
+			const rootClientId = getBlockRootClientId( clientId );
+
+			return canInsertBlockType( 'core/list', rootClientId );
+		},
+		[ clientId ]
 	);
 
 	const {
@@ -222,7 +229,7 @@ export default function TableOfContentsEdit( {
 
 	const headingTree = linearToNestedHeadingList( headings );
 
-	const toolbarControls = listBlockExists && (
+	const toolbarControls = canInsertList && (
 		<BlockControls>
 			<ToolbarGroup>
 				<ToolbarButton


### PR DESCRIPTION
## What?
PR updates `core/list` block check to use `canInsertBlockType` selector.

## Why
The `canInsertBlockType` selector covers more cases when a user cannot insert a block.

## Testing Instructions
1. Open a Post or Page.
2. Insert ToC and a Heading Blocks.
3. Go to Preferences -> Blocks and disable the List block.
4. Confirm that the "Convert to static list" toolbar button isn't displayed.

## Screenshots or screencast <!-- if applicable -->

https://user-images.githubusercontent.com/240569/170347078-857b6596-bb54-4011-9782-6b895c8885b8.mp4


