### PR TITLE
Navigation: Remove unnecessary 'role' attribute

### DIFF
--- a/packages/block-library/src/query-pagination/index.php
+++ b/packages/block-library/src/query-pagination/index.php
@@ -20,7 +20,6 @@ function render_block_core_query_pagination( $attributes, $content ) {
 
 	$wrapper_attributes = get_block_wrapper_attributes(
 		array(
-			'role'       => 'navigation',
 			'aria-label' => __( 'Pagination' ),
 		)
 	);


### PR DESCRIPTION
## What?
Resolves #41350.

PR removes the unnecessary 'role' attribute for the `nav` element.

## Why?
[According to MDN](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Roles/navigation_role#best_practices):
> Using the [`<nav>`](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/nav) element will automatically communicate a section has a role of navigation. If at all possible, prefer using it instead.

## Testing Instructions
Using the TT2 theme open page with a Navigation block, confirm that the `role` attribute is removed.
