### PR TITLE
Popover, CustomGradientPicker, Dropdown: Fix positioning of popover when used in a dropdown

### DIFF
--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Bug Fix
+
+-   `Popover`, `Dropdown`, `CustomGradientPicker`: Fix dropdown positioning by always targeting the rendered toggle, and switch off width in the Popover size middleware to stop reducing the width of the popover. ([#41361](https://github.com/WordPress/gutenberg/pull/41361))
+
 ### Enhancements
 
 -   `SelectControl`: Add `__nextHasNoMarginBottom` prop for opting into the new margin-free styles ([#41269](https://github.com/WordPress/gutenberg/pull/41269)).

--- a/packages/components/src/custom-gradient-picker/utils.js
+++ b/packages/components/src/custom-gradient-picker/utils.js
@@ -75,7 +75,7 @@ export function getGradientAstWithControlPoints(
 			return {
 				length: {
 					type: '%',
-					value: position.toString(),
+					value: position?.toString(),
 				},
 				type: a < 1 ? 'rgba' : 'rgb',
 				value: a < 1 ? [ r, g, b, a ] : [ r, g, b ],

--- a/packages/components/src/dropdown/index.js
+++ b/packages/components/src/dropdown/index.js
@@ -108,7 +108,11 @@ export default function Dropdown( props ) {
 					// This value is used to ensure that the dropdowns
 					// align with the editor header by default.
 					offset={ 13 }
-					anchorRef={ ! hasAnchorRef ? containerRef : undefined }
+					anchorRef={
+						! hasAnchorRef
+							? containerRef?.current?.firstChild // Anchor to the rendered toggle.
+							: undefined
+					}
 					{ ...popoverProps }
 					className={ classnames(
 						'components-dropdown__content',

--- a/packages/components/src/popover/index.js
+++ b/packages/components/src/popover/index.js
@@ -180,11 +180,11 @@ const Popover = (
 		__unstableForcePosition
 			? undefined
 			: size( {
-					apply( { width, height } ) {
+					apply( sizeProps ) {
+						const { height } = sizeProps;
 						if ( ! refs.floating.current ) return;
-
+						// Reduce the height of the popover to the available space.
 						Object.assign( refs.floating.current.firstChild.style, {
-							maxWidth: `${ width }px`,
 							maxHeight: `${ height }px`,
 							overflow: 'auto',
 						} );
@@ -194,6 +194,7 @@ const Popover = (
 		shift( {
 			crossAxis: true,
 			limiter: limitShift(),
+			padding: 1, // Necessary to avoid flickering at the edge of the viewport.
 		} ),
 		hasArrow ? arrow( { element: arrowRef } ) : undefined,
 	].filter( ( m ) => !! m );


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Fixes: https://github.com/WordPress/gutenberg/issues/41353

Fix positioning of the Popover when used in dropdowns and the custom gradient picker. Also, fix the issue where the width of the Popover was being reduced when it appears close to the edge of the viewport.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

As reported in #41353 there were a few issues with the Popover positions when used in the custom gradient bar. The issues appeared to be the following:

* The position of the Popover was incorrect due to the Dropdown component using the parent Dropdown node as the reference for where to position the popover, as opposed to the toggle button, which is where we'd expect it to be attached.
* The `size` [middleware in the Popover](https://floating-ui.com/docs/size) reduces the size of the popover by looking at the amount of space between the anchor and the edge of the viewport — this is likely not what we want for the horizontal axis, as it reduces the Popover when the Popover is right at the edge of the screen, and also appears to be the root cause of one of the issues in https://github.com/WordPress/gutenberg/pull/41268 (Tooltip issues).

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

* Remove the `maxWidth` setting from the `size` middleware used in the Popover
* Force the Dropdown to use the first child of the Dropdown (the rendered toggle) as the anchor point for the Popover when no anchor ref is provided

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->

1. In Storybook, follow the issue in #41353 and check that the popover displays correctly.
2. In the editor, add a custom gradient to a Group block and ensure the Popover is still positioned at the right of the area (and doesn't change position based on where you click on the gradient bar)
3. Hover over the Settings icon at the top right of the editor — you should see that the Tooltip no longer gets cut off

***Note***: clicking on the control points in the gradient bar is a little glitchy at the moment, too — I think some adjustments need to be made there, too, but that's outside the scope of this PR.

## Screenshots or screencast <!-- if applicable -->

| Before | After |
| --- | --- |
| ![2022-05-26 17 00 36](https://user-images.githubusercontent.com/14988353/170435527-c08e5a92-2182-433c-be15-35161a20e8d2.gif) | ![2022-05-26 16 57 21](https://user-images.githubusercontent.com/14988353/170435000-a5cd4fc4-3e1d-479c-8d4c-1956ddf7310a.gif) |
| <img width="78" src="https://user-images.githubusercontent.com/14988353/170433700-0638af02-afb8-4c6f-ab61-528f2fb0b223.png" /> | <img width="78" alt="image" src="https://user-images.githubusercontent.com/14988353/170433823-129c069d-bdc5-4e55-81ff-61b1bcf75e4f.png"> |
