### PR TITLE
Copy plain text variant of blocks

### DIFF
--- a/packages/block-editor/src/components/block-settings-menu/block-settings-dropdown.js
+++ b/packages/block-editor/src/components/block-settings-menu/block-settings-dropdown.js
@@ -16,7 +16,7 @@ import {
 	useCallback,
 	useRef,
 } from '@wordpress/element';
-import { __, sprintf } from '@wordpress/i18n';
+import { __, _n, sprintf } from '@wordpress/i18n';
 import { store as keyboardShortcutsStore } from '@wordpress/keyboard-shortcuts';
 import { useCopyToClipboard } from '@wordpress/compose';
 

--- a/packages/block-editor/src/components/block-settings-menu/block-settings-dropdown.js
+++ b/packages/block-editor/src/components/block-settings-menu/block-settings-dropdown.js
@@ -42,7 +42,7 @@ const POPOVER_PROPS = {
 
 function CopyMenuItem( { blocks, onCopy } ) {
 	const ref = useCopyToClipboard( () => serialize( blocks ), onCopy );
-	return <MenuItem ref={ ref }>{ __( 'Copy' ) }</MenuItem>;
+	return <MenuItem ref={ ref }>{ __( 'Copy block' ) }</MenuItem>;
 }
 
 export function BlockSettingsDropdown( {

--- a/packages/block-editor/src/components/block-settings-menu/block-settings-dropdown.js
+++ b/packages/block-editor/src/components/block-settings-menu/block-settings-dropdown.js
@@ -42,8 +42,7 @@ const POPOVER_PROPS = {
 
 function CopyMenuItem( { blocks, onCopy } ) {
 	const ref = useCopyToClipboard( () => serialize( blocks ), onCopy );
-	const copyMenuItemLabel =
-		blocks.length > 1 ? __( 'Copy blocks' ) : __( 'Copy block' );
+	const copyMenuItemLabel = _n( 'Copy block', 'Copy blocks', blocks.length );
 	return <MenuItem ref={ ref }>{ copyMenuItemLabel }</MenuItem>;
 }
 

--- a/packages/block-editor/src/components/block-settings-menu/block-settings-dropdown.js
+++ b/packages/block-editor/src/components/block-settings-menu/block-settings-dropdown.js
@@ -42,7 +42,9 @@ const POPOVER_PROPS = {
 
 function CopyMenuItem( { blocks, onCopy } ) {
 	const ref = useCopyToClipboard( () => serialize( blocks ), onCopy );
-	return <MenuItem ref={ ref }>{ __( 'Copy block' ) }</MenuItem>;
+	const copyMenuItemLabel =
+		blocks.length > 1 ? __( 'Copy blocks' ) : __( 'Copy block' );
+	return <MenuItem ref={ ref }>{ copyMenuItemLabel }</MenuItem>;
 }
 
 export function BlockSettingsDropdown( {

--- a/packages/block-editor/src/components/copy-handler/README.md
+++ b/packages/block-editor/src/components/copy-handler/README.md
@@ -8,8 +8,13 @@ Concretely, it handles the display of success messages and takes care of copying
 
 ## Table of contents
 
-1. [Development guidelines](#development-guidelines)
-2. [Related components](#related-components)
+- [Copy Handler](#copy-handler)
+	- [Table of contents](#table-of-contents)
+	- [Development guidelines](#development-guidelines)
+		- [Usage](#usage)
+		- [Props](#props)
+		- [`children`](#children)
+	- [Related components](#related-components)
 
 ## Development guidelines
 

--- a/packages/block-editor/src/components/copy-handler/index.js
+++ b/packages/block-editor/src/components/copy-handler/index.js
@@ -96,8 +96,6 @@ export function useClipboardHandler() {
 	return useRefEffect( ( node ) => {
 		function handler( event ) {
 			const selectedBlockClientIds = getSelectedBlockClientIds();
-			const removeConsecutiveLineBreaks = ( string ) =>
-				string.replace( /\n\n+/g, '\n\n' );
 
 			if ( selectedBlockClientIds.length === 0 ) {
 				return;
@@ -161,7 +159,7 @@ export function useClipboardHandler() {
 
 					event.clipboardData.setData(
 						'text/plain',
-						removeConsecutiveLineBreaks( stripHTML( serialized ) )
+						toPlainText( serialized )
 					);
 					event.clipboardData.setData( 'text/html', serialized );
 				}
@@ -216,6 +214,23 @@ export function useClipboardHandler() {
 
 function CopyHandler( { children } ) {
 	return <div ref={ useClipboardHandler() }>{ children }</div>;
+}
+
+/**
+ * Given a string of HTML representing serialized blocks, returns the plain
+ * text extracted after stripping the HTML of any tags and fixing line breaks.
+ *
+ * @param {string} html Serialized blocks.
+ * @return {string} The plain-text content with any html removed.
+ */
+function toPlainText( html ) {
+	// Manually handle BR tags as line breaks prior to `stripHTML` call
+	html = html.replace( /<br>/g, '\n' );
+
+	const plainText = stripHTML( html ).trim();
+
+	// Merge any consecutive line breaks
+	return plainText.replace( /\n\n+/g, '\n\n' );
 }
 
 /**

--- a/packages/block-editor/src/components/copy-handler/index.js
+++ b/packages/block-editor/src/components/copy-handler/index.js
@@ -10,6 +10,7 @@ import {
 import {
 	documentHasSelection,
 	documentHasUncollapsedSelection,
+	__unstableStripHTML as stripHTML,
 } from '@wordpress/dom';
 import { useDispatch, useSelect } from '@wordpress/data';
 import { __, _n, sprintf } from '@wordpress/i18n';
@@ -156,7 +157,10 @@ export function useClipboardHandler() {
 					}
 					const serialized = serialize( blocks );
 
-					event.clipboardData.setData( 'text/plain', serialized );
+					event.clipboardData.setData(
+						'text/plain',
+						stripHTML( serialized )
+					);
 					event.clipboardData.setData( 'text/html', serialized );
 				}
 			}

--- a/packages/block-editor/src/components/copy-handler/index.js
+++ b/packages/block-editor/src/components/copy-handler/index.js
@@ -96,6 +96,8 @@ export function useClipboardHandler() {
 	return useRefEffect( ( node ) => {
 		function handler( event ) {
 			const selectedBlockClientIds = getSelectedBlockClientIds();
+			const removeConsecutiveLineBreaks = ( string ) =>
+				string.replace( /\n\n+/g, '\n\n' );
 
 			if ( selectedBlockClientIds.length === 0 ) {
 				return;
@@ -159,7 +161,7 @@ export function useClipboardHandler() {
 
 					event.clipboardData.setData(
 						'text/plain',
-						stripHTML( serialized )
+						removeConsecutiveLineBreaks( stripHTML( serialized ) )
 					);
 					event.clipboardData.setData( 'text/html', serialized );
 				}

--- a/packages/edit-post/src/plugins/copy-content-menu-item/index.js
+++ b/packages/edit-post/src/plugins/copy-content-menu-item/index.js
@@ -25,5 +25,5 @@ export default function CopyContentMenuItem() {
 
 	const ref = useCopyToClipboard( getText, onSuccess );
 
-	return <MenuItem ref={ ref }>{ __( 'Copy all block content' ) }</MenuItem>;
+	return <MenuItem ref={ ref }>{ __( 'Copy all blocks' ) }</MenuItem>;
 }

--- a/packages/edit-post/src/plugins/copy-content-menu-item/index.js
+++ b/packages/edit-post/src/plugins/copy-content-menu-item/index.js
@@ -25,5 +25,5 @@ export default function CopyContentMenuItem() {
 
 	const ref = useCopyToClipboard( getText, onSuccess );
 
-	return <MenuItem ref={ ref }>{ __( 'Copy all content' ) }</MenuItem>;
+	return <MenuItem ref={ ref }>{ __( 'Copy all block content' ) }</MenuItem>;
 }

--- a/packages/edit-site/src/components/header/more-menu/copy-content-menu-item.js
+++ b/packages/edit-site/src/components/header/more-menu/copy-content-menu-item.js
@@ -48,5 +48,5 @@ export default function CopyContentMenuItem() {
 
 	const ref = useCopyToClipboard( getText, onSuccess );
 
-	return <MenuItem ref={ ref }>{ __( 'Copy all block content' ) }</MenuItem>;
+	return <MenuItem ref={ ref }>{ __( 'Copy all blocks' ) }</MenuItem>;
 }

--- a/packages/edit-site/src/components/header/more-menu/copy-content-menu-item.js
+++ b/packages/edit-site/src/components/header/more-menu/copy-content-menu-item.js
@@ -48,5 +48,5 @@ export default function CopyContentMenuItem() {
 
 	const ref = useCopyToClipboard( getText, onSuccess );
 
-	return <MenuItem ref={ ref }>{ __( 'Copy all content' ) }</MenuItem>;
+	return <MenuItem ref={ ref }>{ __( 'Copy all block content' ) }</MenuItem>;
 }

--- a/test/e2e/specs/editor/various/__snapshots__/Copy-cut-paste-should-paste-plain-text-in-plain-text-context-when-cross-block-selection-is-copied-1-chromium.txt
+++ b/test/e2e/specs/editor/various/__snapshots__/Copy-cut-paste-should-paste-plain-text-in-plain-text-context-when-cross-block-selection-is-copied-1-chromium.txt
@@ -1,0 +1,7 @@
+<!-- wp:heading -->
+<h2>Heading</h2>
+<!-- /wp:heading -->
+
+<!-- wp:paragraph -->
+<p>Paragraph</p>
+<!-- /wp:paragraph -->

--- a/test/e2e/specs/editor/various/__snapshots__/Copy-cut-paste-should-paste-plain-text-in-plain-text-context-when-cross-block-selection-is-copied-2-chromium.txt
+++ b/test/e2e/specs/editor/various/__snapshots__/Copy-cut-paste-should-paste-plain-text-in-plain-text-context-when-cross-block-selection-is-copied-2-chromium.txt
@@ -1,0 +1,15 @@
+<!-- wp:heading -->
+<h2>Heading</h2>
+<!-- /wp:heading -->
+
+<!-- wp:paragraph -->
+<p>Paragraph</p>
+<!-- /wp:paragraph -->
+
+<!-- wp:code -->
+<pre class="wp-block-code"><code>
+ading
+
+Paragra
+</code></pre>
+<!-- /wp:code -->

--- a/test/e2e/specs/editor/various/__snapshots__/Copy-cut-paste-should-paste-plain-text-in-plain-text-context-when-cross-block-selection-is-copied-2-chromium.txt
+++ b/test/e2e/specs/editor/various/__snapshots__/Copy-cut-paste-should-paste-plain-text-in-plain-text-context-when-cross-block-selection-is-copied-2-chromium.txt
@@ -7,9 +7,7 @@
 <!-- /wp:paragraph -->
 
 <!-- wp:code -->
-<pre class="wp-block-code"><code>
-ading
+<pre class="wp-block-code"><code>ading
 
-Paragra
-</code></pre>
+Paragra</code></pre>
 <!-- /wp:code -->

--- a/test/e2e/specs/editor/various/copy-cut-paste.spec.js
+++ b/test/e2e/specs/editor/various/copy-cut-paste.spec.js
@@ -371,4 +371,30 @@ test.describe( 'Copy/cut/paste', () => {
 		await pageUtils.pressKeyWithModifier( 'primary', 'v' );
 		expect( await editor.getEditedPostContent() ).toMatchSnapshot();
 	} );
+
+	test( 'should paste plain text in plain text context when cross block selection is copied ', async ( {
+		editor,
+		page,
+		pageUtils,
+	} ) => {
+		await editor.insertBlock( { name: 'core/heading' } );
+		await page.keyboard.type( 'Heading' );
+		await page.keyboard.press( 'Enter' );
+		await page.keyboard.type( 'Paragraph' );
+		expect( await editor.getEditedPostContent() ).toMatchSnapshot();
+		// Partial select from outer blocks.
+		await pageUtils.pressKeyTimes( 'ArrowLeft', 2 );
+		await pageUtils.pressKeyWithModifier( 'shift', 'ArrowUp' );
+		await pageUtils.pressKeyWithModifier( 'primary', 'c' );
+		await pageUtils.pressKeyWithModifier( 'primary', 'ArrowLeft' );
+		// Sometimes the caret has not moved to the correct position before pressing Enter.
+		// @see https://github.com/WordPress/gutenberg/issues/40303#issuecomment-1109434887
+		await page.waitForFunction(
+			() => window.getSelection().type === 'Caret'
+		);
+		// Create a new code block to paste there.
+		await editor.insertBlock( { name: 'core/code' } );
+		await pageUtils.pressKeyWithModifier( 'primary', 'v' );
+		expect( await editor.getEditedPostContent() ).toMatchSnapshot();
+	} );
 } );


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->
This PR strips the HTML from copied block markup for the text/plain version of the clipboard.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

Pasting into plain text editors should only paste the text we see on screen not the whole underlying 
markup.

This is an improvement in the experience of writing in a different app rather than in the 
WordPress editor itself, and then bringing over the content. Since one could move text content back 
and forth a few times, pasting block markup is annoying if not even prone to introducing problems.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

By fixing what seems to be a problem anyway: stripping HTML out of serialized data in the copy 
handler before placing it in the `text/plain` version.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->

1. Switch to this PR
2. Create a post
3. Copy the post content
4. Paste in a plain text editor such as Notepat or Textedit (for Textedit make sure to use Format > 
Make plain text before pasting)
5. Notice there is no block markup pasted

## Screenshots or screencast <!-- if applicable -->

### Before

https://user-images.githubusercontent.com/107534/170446904-30d7883c-8449-40cc-b86e-89711a7bbd57.mp4

### After

https://user-images.githubusercontent.com/107534/170446592-01c3df9b-7e3f-4a80-a844-b99b135add2c.mp4


