### PR TITLE
[Mobile] - Add E2E tests for the Drag & Drop blocks feature

### DIFF
--- a/packages/react-native-editor/__device-tests__/gutenberg-editor-drag-and-drop.test.js
+++ b/packages/react-native-editor/__device-tests__/gutenberg-editor-drag-and-drop.test.js
@@ -3,16 +3,18 @@
  */
 import { blockNames } from './pages/editor-page';
 import {
+	clearClipboard,
 	clickElementOutsideOfTextInput,
 	dragAndDropAfterElement,
 	isAndroid,
+	setClipboard,
 	tapPasteAboveElement,
 } from './helpers/utils';
 import testData from './helpers/test-data';
 
 describe( 'Gutenberg Editor Drag & Drop blocks tests', () => {
 	beforeEach( async () => {
-		await editorPage.driver.setClipboard( '', 'plaintext' );
+		await clearClipboard( editorPage.driver );
 	} );
 
 	it( 'should be able to drag & drop a block', async () => {
@@ -59,10 +61,7 @@ describe( 'Gutenberg Editor Drag & Drop blocks tests', () => {
 		);
 
 		// Set clipboard text
-		const base64String = Buffer.from( testData.shortText ).toString(
-			'base64'
-		);
-		await editorPage.driver.setClipboard( base64String, 'plaintext' );
+		await setClipboard( editorPage.driver, testData.shortText );
 
 		// Dismiss auto-suggestion popup
 		if ( isAndroid() ) {
@@ -91,10 +90,7 @@ describe( 'Gutenberg Editor Drag & Drop blocks tests', () => {
 		);
 
 		// Set clipboard text
-		const base64String = Buffer.from( testData.shortText ).toString(
-			'base64'
-		);
-		await editorPage.driver.setClipboard( base64String, 'plaintext' );
+		await setClipboard( editorPage.driver, testData.shortText );
 
 		// Dismiss auto-suggestion popup
 		if ( isAndroid() ) {

--- a/packages/react-native-editor/__device-tests__/gutenberg-editor-drag-and-drop.test.js
+++ b/packages/react-native-editor/__device-tests__/gutenberg-editor-drag-and-drop.test.js
@@ -58,7 +58,7 @@ describe( 'Gutenberg Editor Drag & Drop blocks tests', () => {
 			blockNames.paragraph
 		);
 
-		// Set cliboard text
+		// Set clipboard text
 		const base64String = Buffer.from( testData.shortText ).toString(
 			'base64'
 		);
@@ -90,7 +90,7 @@ describe( 'Gutenberg Editor Drag & Drop blocks tests', () => {
 			blockNames.shortcode
 		);
 
-		// Set cliboard text
+		// Set clipboard text
 		const base64String = Buffer.from( testData.shortText ).toString(
 			'base64'
 		);

--- a/packages/react-native-editor/__device-tests__/gutenberg-editor-drag-and-drop.test.js
+++ b/packages/react-native-editor/__device-tests__/gutenberg-editor-drag-and-drop.test.js
@@ -1,0 +1,157 @@
+/**
+ * Internal dependencies
+ */
+import { blockNames } from './pages/editor-page';
+import {
+	clickElementOutsideOfTextInput,
+	dragAndDropAfterElement,
+	isAndroid,
+	tapPasteAboveElement,
+} from './helpers/utils';
+import testData from './helpers/test-data';
+
+describe( 'Gutenberg Editor Drag & Drop blocks tests', () => {
+	beforeEach( async () => {
+		await editorPage.driver.setClipboard( '', 'plaintext' );
+	} );
+
+	it( 'should be able to drag & drop a block', async () => {
+		// Initialize the editor with a Spacer and Paragraph block
+		await editorPage.setHtmlContent(
+			[ testData.spacerBlock, testData.paragraphBlockShortText ].join(
+				'\n\n'
+			)
+		);
+
+		// Get elements for both blocks
+		const spacerBlock = await editorPage.getBlockAtPosition(
+			blockNames.spacer
+		);
+		const paragraphBlock = await editorPage.getParagraphBlockWrapperAtPosition(
+			2
+		);
+
+		// Drag & drop the Spacer block after the Paragraph block
+		await dragAndDropAfterElement(
+			editorPage.driver,
+			spacerBlock,
+			paragraphBlock
+		);
+
+		// Get the first block, in this case the Paragraph block
+		// and check the text value is the expected one
+		const firstBlockText = await editorPage.getTextForParagraphBlockAtPosition(
+			1
+		);
+		expect( firstBlockText ).toMatch( testData.shortText );
+
+		// Remove the blocks
+		await spacerBlock.click();
+		await editorPage.removeBlockAtPosition( blockNames.spacer, 2 );
+		await editorPage.removeBlockAtPosition( blockNames.paragraph, 1 );
+	} );
+
+	it( 'should be able to long-press on a text-based block to paste a text in a focused textinput', async () => {
+		// Add a Paragraph block
+		await editorPage.addNewBlock( blockNames.paragraph );
+		const paragraphBlockElement = await editorPage.getTextBlockAtPosition(
+			blockNames.paragraph
+		);
+
+		// Set cliboard text
+		const base64String = Buffer.from( testData.shortText ).toString(
+			'base64'
+		);
+		await editorPage.driver.setClipboard( base64String, 'plaintext' );
+
+		// Dismiss auto-suggestion popup
+		if ( isAndroid() ) {
+			// On Andrdoid 10 a new auto-suggestion popup is appearing to let the user paste text recently put in the clipboard. Let's dismiss it.
+			await editorPage.dismissAndroidClipboardSmartSuggestion();
+		}
+
+		// Paste into the Paragraph block
+		await tapPasteAboveElement( editorPage.driver, paragraphBlockElement );
+		const paragraphText = await editorPage.getTextForParagraphBlockAtPosition(
+			1
+		);
+
+		// Expect to have the pasted text in the Paragraph block
+		expect( paragraphText ).toMatch( testData.shortText );
+
+		// Remove the block
+		await editorPage.removeBlockAtPosition( blockNames.paragraph );
+	} );
+
+	it( 'should be able to long-press on a text-based block using the PlainText component to paste a text in a focused textinput', async () => {
+		// Add a Shortcode block
+		await editorPage.addNewBlock( blockNames.shortcode );
+		const shortcodeBlockElement = await editorPage.getShortBlockTextInputAtPosition(
+			blockNames.shortcode
+		);
+
+		// Set cliboard text
+		const base64String = Buffer.from( testData.shortText ).toString(
+			'base64'
+		);
+		await editorPage.driver.setClipboard( base64String, 'plaintext' );
+
+		// Dismiss auto-suggestion popup
+		if ( isAndroid() ) {
+			// On Andrdoid 10 a new auto-suggestion popup is appearing to let the user paste text recently put in the clipboard. Let's dismiss it.
+			await editorPage.dismissAndroidClipboardSmartSuggestion();
+		}
+
+		// Paste into the Shortcode block
+		await tapPasteAboveElement( editorPage.driver, shortcodeBlockElement );
+		const shortcodeText = await shortcodeBlockElement.text();
+
+		// Expect to have the pasted text in the Shortcode block
+		expect( shortcodeText ).toMatch( testData.shortText );
+
+		// Remove the block
+		await editorPage.removeBlockAtPosition( blockNames.shortcode );
+	} );
+
+	it( 'should be able to drag & drop a text-based block when the textinput is not focused', async () => {
+		// Initialize the editor with two Paragraph blocks
+		await editorPage.setHtmlContent(
+			[
+				testData.paragraphBlockShortText,
+				testData.paragraphBlockEmpty,
+			].join( '\n\n' )
+		);
+
+		// Get elements for both blocks
+		const firstParagraphBlock = await editorPage.getParagraphBlockWrapperAtPosition(
+			1
+		);
+		const secondParagraphBlock = await editorPage.getParagraphBlockWrapperAtPosition(
+			2
+		);
+
+		// Tap on the first Paragraph block outside of the textinput
+		await clickElementOutsideOfTextInput(
+			editorPage.driver,
+			firstParagraphBlock
+		);
+
+		// Drag & drop the first Paragraph block after the second Paragraph block
+		await dragAndDropAfterElement(
+			editorPage.driver,
+			firstParagraphBlock,
+			secondParagraphBlock
+		);
+
+		// Get the current second Paragraph block in the editor after dragging & dropping
+		const secondBlockText = await editorPage.getTextForParagraphBlockAtPosition(
+			2
+		);
+
+		// Expect the second Paragraph block to have the expected content
+		expect( secondBlockText ).toMatch( testData.shortText );
+
+		// Remove the block
+		await editorPage.removeBlockAtPosition( blockNames.paragraph );
+	} );
+} );

--- a/packages/react-native-editor/__device-tests__/gutenberg-editor-paste.test.js
+++ b/packages/react-native-editor/__device-tests__/gutenberg-editor-paste.test.js
@@ -3,6 +3,7 @@
  */
 import { blockNames } from './pages/editor-page';
 import {
+	clearClipboard,
 	longPressMiddleOfElement,
 	tapSelectAllAboveElement,
 	tapCopyAboveElement,
@@ -21,7 +22,7 @@ describe( 'Gutenberg Editor paste tests', () => {
 	}
 
 	beforeAll( async () => {
-		await editorPage.driver.setClipboard( '', 'plaintext' );
+		await clearClipboard( editorPage.driver );
 	} );
 
 	it( 'copies plain text from one paragraph block and pastes in another', async () => {

--- a/packages/react-native-editor/__device-tests__/gutenberg-editor-paste.test.js
+++ b/packages/react-native-editor/__device-tests__/gutenberg-editor-paste.test.js
@@ -58,10 +58,6 @@ describe( 'Gutenberg Editor paste tests', () => {
 		);
 
 		// Paste into second paragraph block.
-		await longPressMiddleOfElement(
-			editorPage.driver,
-			paragraphBlockElement2
-		);
 		await tapPasteAboveElement( editorPage.driver, paragraphBlockElement2 );
 
 		const text = await editorPage.getTextForParagraphBlockAtPosition( 2 );
@@ -101,10 +97,6 @@ describe( 'Gutenberg Editor paste tests', () => {
 		);
 
 		// Paste into second paragraph block.
-		await longPressMiddleOfElement(
-			editorPage.driver,
-			paragraphBlockElement2
-		);
 		await tapPasteAboveElement( editorPage.driver, paragraphBlockElement2 );
 
 		// Check styled text by verifying html contents.

--- a/packages/react-native-editor/__device-tests__/helpers/test-data.js
+++ b/packages/react-native-editor/__device-tests__/helpers/test-data.js
@@ -166,6 +166,10 @@ exports.paragraphBlockEmpty = `<!-- wp:paragraph -->
 <p></p>
 <!-- /wp:paragraph -->`;
 
+exports.paragraphBlockShortText = `<!-- wp:paragraph -->
+<p>Rock music approaches at high velocity.</p>
+<!-- /wp:paragraph -->`;
+
 exports.multiLinesParagraphBlock = `<!-- wp:paragraph -->
 <p>multiple lines<br>multiple lines<br>multiple lines</p>
 <!-- /wp:paragraph -->`;
@@ -177,3 +181,7 @@ exports.unknownElementParagraphBlock = `<!-- wp:paragraph -->
 exports.lettersInParagraphBlock = `<!-- wp:paragraph -->
 <p>ABCD</p>
 <!-- /wp:paragraph -->`;
+
+exports.spacerBlock = `<!-- wp:spacer -->
+<div style="height:100px" aria-hidden="true" class="wp-block-spacer"></div>
+<!-- /wp:spacer -->`;

--- a/packages/react-native-editor/__device-tests__/helpers/utils.js
+++ b/packages/react-native-editor/__device-tests__/helpers/utils.js
@@ -310,9 +310,7 @@ const clickElementOutsideOfTextInput = async ( driver, element ) => {
 	const y = isAndroid() ? location.y - blockEdgeToContent : location.y;
 	const x = isAndroid() ? location.x - blockEdgeToContent : location.x;
 
-	const action = await new wd.TouchAction( driver );
-	action.press( { x, y } );
-	action.release();
+	const action = new wd.TouchAction( driver ).press( { x, y } ).release();
 	await action.perform();
 };
 
@@ -321,13 +319,12 @@ const longPressMiddleOfElement = async ( driver, element ) => {
 	const location = await element.getLocation();
 	const size = await element.getSize();
 
-	const action = await new wd.TouchAction( driver );
 	const x = location.x + size.width / 2;
 	const y = location.y + size.height / 2;
-	action.press( { x, y } );
-	// Setting to wait a bit longer because this is failing more frequently on the CI
-	action.wait( 5000 );
-	action.release();
+	const action = new wd.TouchAction( driver )
+		.press( { x, y } )
+		.wait( 5000 ) // Setting to wait a bit longer because this is failing more frequently on the CI
+		.release();
 	await action.perform();
 };
 
@@ -453,13 +450,12 @@ const dragAndDropAfterElement = async ( driver, element, nextElement ) => {
 		? elementLocation.y + nextElementLocation.y + nextElementSize.height
 		: nextElementLocation.y + nextElementSize.height;
 
-	const action = new wd.TouchAction( driver );
-	await action
+	const action = new wd.TouchAction( driver )
 		.press( { x, y } )
 		.wait( 5000 )
 		.moveTo( { x, y: nextYPosition } )
-		.release()
-		.perform();
+		.release();
+	await action.perform();
 };
 
 const toggleHtmlMode = async ( driver, toggleOn ) => {

--- a/packages/react-native-editor/__device-tests__/helpers/utils.js
+++ b/packages/react-native-editor/__device-tests__/helpers/utils.js
@@ -618,8 +618,38 @@ const waitIfAndroid = async () => {
 	}
 };
 
+/**
+ * Content type definitions.
+ * Note: Android only supports plaintext.
+ *
+ * @typedef {"plaintext" | "image" | "url"} ClipboardContentType
+ */
+
+/**
+ * Helper to set content in the clipboard.
+ *
+ * @param {Object}               driver      Driver
+ * @param {string}               content     Content to set in the clipboard
+ * @param {ClipboardContentType} contentType Type of the content
+ */
+const setClipboard = async ( driver, content, contentType = 'plaintext' ) => {
+	const base64String = Buffer.from( content ).toString( 'base64' );
+	await driver.setClipboard( base64String, contentType );
+};
+
+/**
+ * Helper to clear the clipboard
+ *
+ * @param {Object}               driver      Driver
+ * @param {ClipboardContentType} contentType Type of the content
+ */
+const clearClipboard = async ( driver, contentType = 'plaintext' ) => {
+	await driver.setClipboard( '', contentType );
+};
+
 module.exports = {
 	backspace,
+	clearClipboard,
 	clickBeginningOfElement,
 	clickElementOutsideOfTextInput,
 	clickIfClickable,
@@ -631,6 +661,7 @@ module.exports = {
 	isElementVisible,
 	isLocalEnvironment,
 	longPressMiddleOfElement,
+	setClipboard,
 	setupDriver,
 	stopDriver,
 	swipeDown,

--- a/packages/react-native-editor/__device-tests__/helpers/utils.js
+++ b/packages/react-native-editor/__device-tests__/helpers/utils.js
@@ -322,7 +322,7 @@ const longPressMiddleOfElement = async ( driver, element ) => {
 	const x = location.x + size.width / 2;
 	const y = location.y + size.height / 2;
 	const action = new wd.TouchAction( driver )
-		.press( { x, y } )
+		.longPress( { x, y } )
 		.wait( 5000 ) // Setting to wait a bit longer because this is failing more frequently on the CI
 		.release();
 	await action.perform();

--- a/packages/react-native-editor/__device-tests__/helpers/utils.js
+++ b/packages/react-native-editor/__device-tests__/helpers/utils.js
@@ -365,10 +365,8 @@ const tapPasteAboveElement = async ( driver, element ) => {
 		action.release();
 		await action.perform();
 	} else {
-		const pasteButton = driver.elementByXPath(
-			'//XCUIElementTypeMenuItem[@name="Paste"]'
-		);
-		await pasteButton.click();
+		const pasteButtonLocator = '//XCUIElementTypeMenuItem[@name="Paste"]';
+		await clickIfClickable( driver, pasteButtonLocator );
 		await driver.sleep( 3000 ); // Wait for paste notification to disappear.
 	}
 };

--- a/packages/react-native-editor/__device-tests__/pages/editor-page.js
+++ b/packages/react-native-editor/__device-tests__/pages/editor-page.js
@@ -7,6 +7,7 @@ const {
 	isEditorVisible,
 	isElementVisible,
 	longPressMiddleOfElement,
+	setClipboard,
 	setupDriver,
 	stopDriver,
 	swipeDown,
@@ -227,9 +228,7 @@ class EditorPage {
 	async setHtmlContent( html ) {
 		await toggleHtmlMode( this.driver, true );
 
-		const base64String = Buffer.from( html ).toString( 'base64' );
-
-		await this.driver.setClipboard( base64String, 'plaintext' );
+		await setClipboard( this.driver, html );
 
 		const htmlContentView = await this.getTextViewForHtmlViewContent();
 

--- a/packages/react-native-editor/__device-tests__/pages/editor-page.js
+++ b/packages/react-native-editor/__device-tests__/pages/editor-page.js
@@ -500,6 +500,15 @@ class EditorPage {
 	// Paragraph Block functions
 	// =========================
 
+	async getParagraphBlockWrapperAtPosition( position = 1 ) {
+		// iOS needs a click to get the text element
+		const blockLocator = isAndroid()
+			? `//android.view.ViewGroup[contains(@content-desc, "Paragraph Block. Row ${ position }")]`
+			: `(//XCUIElementTypeButton[contains(@name, "Paragraph Block. Row ${ position }")])`;
+
+		return await waitForVisible( this.driver, blockLocator );
+	}
+
 	async sendTextToParagraphBlock( position, text, clear ) {
 		const paragraphs = text.split( '\n' );
 		for ( let i = 0; i < paragraphs.length; i++ ) {
@@ -777,6 +786,29 @@ class EditorPage {
 	async sauceJobStatus( allPassed ) {
 		await this.driver.sauceJobStatus( allPassed );
 	}
+
+	// =========================
+	// Shortcode Block functions
+	// =========================
+
+	async getShortBlockTextInputAtPosition( blockName, position = 1 ) {
+		// iOS needs a click to get the text element
+		if ( ! isAndroid() ) {
+			const textBlockLocator = `(//XCUIElementTypeButton[contains(@name, "Shortcode Block. Row ${ position }")])`;
+
+			const textBlock = await waitForVisible(
+				this.driver,
+				textBlockLocator
+			);
+			await textBlock.click();
+		}
+
+		const blockLocator = isAndroid()
+			? `//android.view.ViewGroup[@content-desc="Shortcode Block. Row ${ position }"]/android.view.ViewGroup/android.view.ViewGroup/android.widget.EditText`
+			: `//XCUIElementTypeButton[contains(@name, "Shortcode Block. Row ${ position }")]//XCUIElementTypeTextView`;
+
+		return await waitForVisible( this.driver, blockLocator );
+	}
 }
 
 const blockNames = {
@@ -796,6 +828,7 @@ const blockNames = {
 	separator: 'Separator',
 	spacer: 'Spacer',
 	verse: 'Verse',
+	shortcode: 'Shortcode',
 };
 
 module.exports = { initializeEditorPage, blockNames };


### PR DESCRIPTION
Closes https://github.com/wordpress-mobile/gutenberg-mobile/issues/4882

- `Gutenberg Mobile PR` -> https://github.com/wordpress-mobile/gutenberg-mobile/pull/4901

## What?
This PR adds some basic E2E tests for the Drag & Drop blocks functionality, mostly focused on the interaction with text-based blocks and long-pressing events.

## Why?
Since some parts of the Drag & drop blocks functionality rely on the native implementation and the behavior between iOS/Android and Aztec, some E2E tests are needed to cover these cases.

## How?

It adds the following tests:

- Drag & drop a block (Spacer block)
- Long-pressing on a text-based block (Paragraph), focusing on the text input, and pasting some text from the clipboard.
- Long-pressing on a text-based block that uses the `PlainText` component, focusing on the text input and pasting some text from the clipboard.
- Drag & drop a text-based block when the text input is not focused.

This PR also adds two new helpers related to the clipboard to use as wrappers to simplify their usage:

- setClipboard
- clearClipboard

## Testing Instructions

Check the full E2E tests pass in the [Gutenberg mobile PR](https://github.com/wordpress-mobile/gutenberg-mobile/pull/4901).

**Note**: There is some flakiness happening with the E2E tests so let's focus on the Drag & drop tests to pass.

## Screenshots or screencast <!-- if applicable -->

https://user-images.githubusercontent.com/4885740/171022462-83a4e8da-1993-4863-a83c-e72a97dc8ee6.mov

https://user-images.githubusercontent.com/4885740/171022525-5e727cb8-069f-411b-81a8-77490f8141a2.mov
