### PR TITLE
[RNMobile] Ensure post title gets focused when is notified from native side

### DIFF
--- a/packages/edit-post/src/editor.native.js
+++ b/packages/edit-post/src/editor.native.js
@@ -92,6 +92,9 @@ class Editor extends Component {
 			() => {
 				if ( this.postTitleRef ) {
 					this.postTitleRef.focus();
+				} else {
+					// If the post title ref is not available, we postpone setting focus to when it's available.
+					this.focusTitleWhenAvailable = true;
 				}
 			}
 		);
@@ -122,6 +125,11 @@ class Editor extends Component {
 	}
 
 	setTitleRef( titleRef ) {
+		if ( this.focusTitleWhenAvailable && ! this.postTitleRef ) {
+			this.focusTitleWhenAvailable = false;
+			titleRef.focus();
+		}
+
 		this.postTitleRef = titleRef;
 	}
 


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Right after the editor initialization, the native side notifies [via the `setFocusOnTitle` event to](https://github.com/WordPress/gutenberg/blob/c225a4bc65c43225a40e6c72cc58912843424961/packages/react-native-bridge/index.js#L53-L55) the editor when the post title should be focused. This PR ensures that this is done even when the post title reference is not ready at the time the notification is received.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

This PR fixes a bug identified as a regression issue in version `1.76.0`.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

If the editor receives the `setFocusOnTitle` notification and the post title reference is not ready, it sets `focusTitleWhenAvailable` to `true`. This way, when the post title reference is set in `setTitleRef` function, it checks the value of `focusTitleWhenAvailable` and in case it's `true`, it focuses the post title.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->
1. Create a new post/page.
2. Observe that the post title is automatically focused.
3. Open a post/page that already contains some content.
4. Observe that the post title is not automatically focused.

**NOTE:** The original issue was identified on Android but it would be great to test the changes on both platforms.

## Screenshots or screencast <!-- if applicable -->
