### PR TITLE
Post Navigation Link: add design controls (color, text decoration, and font family)

### DIFF
--- a/docs/reference-guides/core-blocks.md
+++ b/docs/reference-guides/core-blocks.md
@@ -563,7 +563,7 @@ Displays the next or previous post link that is adjacent to the current post. ([
 
 -	**Name:** core/post-navigation-link
 -	**Category:** theme
--	**Supports:** typography (fontSize, lineHeight), ~~html~~, ~~reusable~~
+-	**Supports:** color (background, link, text), typography (fontSize, lineHeight), ~~html~~, ~~reusable~~
 -	**Attributes:** label, linkLabel, showTitle, textAlign, type
 
 ## Post Template

--- a/packages/block-library/src/post-navigation-link/block.json
+++ b/packages/block-library/src/post-navigation-link/block.json
@@ -29,12 +29,17 @@
 	"supports": {
 		"reusable": false,
 		"html": false,
+		"color": {
+			"link": true
+		},
 		"typography": {
 			"fontSize": true,
 			"lineHeight": true,
+			"__experimentalFontFamily": true,
 			"__experimentalFontStyle": true,
 			"__experimentalFontWeight": true,
 			"__experimentalLetterSpacing": true,
+			"__experimentalTextDecoration": true,
 			"__experimentalTextTransform": true,
 			"__experimentalDefaultControls": {
 				"fontSize": true

--- a/packages/block-library/src/post-navigation-link/block.json
+++ b/packages/block-library/src/post-navigation-link/block.json
@@ -39,7 +39,6 @@
 			"__experimentalFontStyle": true,
 			"__experimentalFontWeight": true,
 			"__experimentalLetterSpacing": true,
-			"__experimentalTextDecoration": true,
 			"__experimentalTextTransform": true,
 			"__experimentalDefaultControls": {
 				"fontSize": true


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Adds experimental controls for link color, text decoration, and font family to the Post Navigation Link block.

## Why?
It would be useful to control these style attributes via the editor. Text decoration is maybe questionable, but I think the link color and font family are additions whose use cases should be evident.

## How?
Updates the theme's block.json

## Testing Instructions
1. Activate a theme whose "settings" > "appearanceTools" > true, for example emptytheme.
2. Go to the site editor, add a post navigation link. 
3. Verify you can set its link color, font family, and text decoration:

## Screenshots or screencast <!-- if applicable -->

 <img width="280" alt="Screen Shot 2022-05-26 at 1 01 52 PM" src="https://user-images.githubusercontent.com/5375500/170538187-7562081c-fcaa-4a54-9fab-70dae73b6675.png">

cc @WordPress/block-themers 