### PR TITLE
Components: refactor `Autocomplete` to pass `exhaustive-deps`

### DIFF
--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -26,6 +26,7 @@
 -   `TextareaControl`: Convert to TypeScript ([#41215](https://github.com/WordPress/gutenberg/pull/41215)).
 -   `BoxControl`: Update unit tests to use `@testing-library/user-event` ([#41422](https://github.com/WordPress/gutenberg/pull/41422)).
 -   `Surface`: Convert to TypeScript ([#41212](https://github.com/WordPress/gutenberg/pull/41212)).
+-   `Autocomplete` updated to satisfy `react/exhuastive-deps` eslint rule ([#41382](https://github.com/WordPress/gutenberg/pull/41382))
 
 ### Experimental
 

--- a/packages/components/src/autocomplete/autocompleter-ui.js
+++ b/packages/components/src/autocomplete/autocompleter-ui.js
@@ -39,7 +39,7 @@ export function getAutoCompleterUI( autocompleter ) {
 
 		useLayoutEffect( () => {
 			onChangeOptions( items );
-		}, [ items ] );
+		}, [ onChangeOptions, items ] );
 
 		if ( ! items.length > 0 ) {
 			return null;

--- a/packages/components/src/autocomplete/autocompleter-ui.native.js
+++ b/packages/components/src/autocomplete/autocompleter-ui.native.js
@@ -71,7 +71,7 @@ export function getAutoCompleterUI( autocompleter ) {
 			} else if ( isVisible && text.length === 0 ) {
 				startAnimation( false );
 			}
-		}, [ items, isVisible, text ] );
+		}, [ onChangeOptions, items, isVisible, text, startAnimation ] );
 
 		const activeItemStyles = usePreferredColorSchemeStyle(
 			styles[ 'components-autocomplete__item-active' ],
@@ -111,7 +111,7 @@ export function getAutoCompleterUI( autocompleter ) {
 					}
 				} );
 			},
-			[ isVisible ]
+			[ animationValue, isVisible, reset ]
 		);
 
 		const contentStyles = {

--- a/packages/components/src/autocomplete/index.js
+++ b/packages/components/src/autocomplete/index.js
@@ -375,7 +375,14 @@ function useAutocomplete( {
 				: AutocompleterUI
 		);
 		setFilterValue( query );
-	}, [ textContent ] );
+	}, [
+		textContent,
+		AutocompleterUI,
+		autocompleter,
+		completers,
+		record,
+		filteredOptions.length,
+	] );
 
 	const { key: selectedKey = '' } = filteredOptions[ selectedIndex ] || {};
 	const { className } = autocompleter || {};


### PR DESCRIPTION
## What?
Updates the `Autoomplete` component to satisfy the `exhaustive-deps` eslint rule

## Why?
Part of the effort in https://github.com/WordPress/gutenberg/pull/41166 to apply `exhuastive-deps` to the Components package

## How?

**AutocompleterUI**
- add `onChangeOptions` to the `useEffect` dependency array

**AutocompleterUI native.js**
- add `onChangeOptions` and `startAnimation` to the `useEffect` dependency array
- add `animationValue` and `reset` to `startAnimation`'s `useCallback`

**useAutoComplete**
- add `AutocompleterUI`, `autocompleter`, `completers`, `record` and `filteredOptions.length` to the `useEffect` dependency array

## Testing Instructions
1. From your local Gutenberg directory, run `npx eslint --rule 'react-hooks/exhaustive-deps: warn' packages/components/src/autocomplete`
2. Confirm that the linter returns no errors
3. Confirm e2e tests still pass


