### PR TITLE
[WIP] Add block elements interactivity states

### DIFF
--- a/lib/block-supports/elements.php
+++ b/lib/block-supports/elements.php
@@ -15,6 +15,8 @@ function gutenberg_get_elements_class_name( $block ) {
 	return 'wp-elements-' . md5( serialize( $block ) );
 }
 
+
+
 /**
  * Update the block content with elements class names.
  *
@@ -29,9 +31,9 @@ function gutenberg_render_elements_support( $block_content, $block ) {
 
 	$block_type                    = WP_Block_Type_Registry::get_instance()->get_registered( $block['blockName'] );
 	$skip_link_color_serialization = gutenberg_should_skip_block_supports_serialization( $block_type, 'color', 'link' );
-	$skip_link_color_serialization = gutenberg_should_skip_block_supports_serialization( $block_type, 'color', 'link:hover' );
+	$skip_link_hover_color_serialization = gutenberg_should_skip_block_supports_serialization( $block_type, 'color', 'link:hover' );
 
-	if ( $skip_link_color_serialization && $skip_link_color_serialization ) {
+	if ( $skip_link_color_serialization && $skip_link_hover_color_serialization ) {
 		return $block_content;
 	}
 
@@ -99,6 +101,7 @@ function gutenberg_render_elements_support( $block_content, $block ) {
 function gutenberg_render_elements_support_styles( $pre_render, $block ) {
 	$block_type           = WP_Block_Type_Registry::get_instance()->get_registered( $block['blockName'] );
 	$element_block_styles = isset( $block['attrs']['style']['elements'] ) ? $block['attrs']['style']['elements'] : null;
+
 
 	/*
 	* For now we only care about link color and link hover color.

--- a/lib/compat/wordpress-6.1/class-wp-theme-json-6-1.php
+++ b/lib/compat/wordpress-6.1/class-wp-theme-json-6-1.php
@@ -17,8 +17,15 @@
 class WP_Theme_JSON_6_1 extends WP_Theme_JSON_6_0 {
 	const __EXPERIMENTAL_ELEMENT_BUTTON_CLASS_NAME = 'wp-element-button';
 
+	/**
+	 * The valid elements that can be found under styles.
+	 *
+	 * @since 5.8.0
+	 * @var string[]
+	 */
 	const ELEMENTS = array(
 		'link'   => 'a',
+		'link:hover' => 'a:hover',
 		'h1'     => 'h1',
 		'h2'     => 'h2',
 		'h3'     => 'h3',

--- a/lib/compat/wordpress-6.1/get-global-styles-and-settings.php
+++ b/lib/compat/wordpress-6.1/get-global-styles-and-settings.php
@@ -12,7 +12,11 @@ function wp_add_global_styles_for_blocks() {
 	$tree = WP_Theme_JSON_Resolver_Gutenberg::get_merged_data();
 	// TODO some nodes dont have a name...
 	$block_nodes = $tree->get_styles_block_nodes();
+
 	foreach ( $block_nodes as $metadata ) {
+		if ( empty( $metadata['name'] ) ) {
+			continue;
+		}
 		$block_css  = $tree->get_styles_for_block( $metadata );
 		$block_name = str_replace( 'core/', '', $metadata['name'] );
 		// These block styles are added on block_render.

--- a/lib/compat/wordpress-6.1/get-global-styles-and-settings.php
+++ b/lib/compat/wordpress-6.1/get-global-styles-and-settings.php
@@ -14,9 +14,6 @@ function wp_add_global_styles_for_blocks() {
 	$block_nodes = $tree->get_styles_block_nodes();
 
 	foreach ( $block_nodes as $metadata ) {
-		if ( empty( $metadata['name'] ) ) {
-			continue;
-		}
 		$block_css  = $tree->get_styles_for_block( $metadata );
 		$block_name = str_replace( 'core/', '', $metadata['name'] );
 		// These block styles are added on block_render.

--- a/lib/compat/wordpress-6.1/get-global-styles-and-settings.php
+++ b/lib/compat/wordpress-6.1/get-global-styles-and-settings.php
@@ -12,7 +12,6 @@ function wp_add_global_styles_for_blocks() {
 	$tree = WP_Theme_JSON_Resolver_Gutenberg::get_merged_data();
 	// TODO some nodes dont have a name...
 	$block_nodes = $tree->get_styles_block_nodes();
-
 	foreach ( $block_nodes as $metadata ) {
 		$block_css  = $tree->get_styles_for_block( $metadata );
 		$block_name = str_replace( 'core/', '', $metadata['name'] );

--- a/packages/block-editor/src/hooks/color.js
+++ b/packages/block-editor/src/hooks/color.js
@@ -238,6 +238,9 @@ export function addSaveProps( props, blockType, attributes ) {
 			'has-background': serializeHasBackground && hasBackground,
 			'has-link-color':
 				shouldSerialize( 'link' ) && style?.elements?.link?.color,
+			'has-link-hover-color':
+				shouldSerialize( 'link:hover' ) &&
+				style?.elements?.[ 'link:hover' ]?.color,
 		}
 	);
 	props.className = newClassName ? newClassName : undefined;

--- a/packages/block-editor/src/hooks/color.js
+++ b/packages/block-editor/src/hooks/color.js
@@ -110,6 +110,13 @@ const resetAllLinkFilter = ( attributes ) => ( {
 	),
 } );
 
+const resetAllLinkHoverFilter = ( attributes ) => ( {
+	style: clearColorFromStyles(
+		[ 'elements', 'link:hover', 'color', 'text' ],
+		attributes.style
+	),
+} );
+
 /**
  * Clears all background color related properties including gradients from
  * supplied block attributes.
@@ -216,7 +223,6 @@ export function addSaveProps( props, blockType, attributes ) {
 		backgroundColor ||
 		style?.color?.background ||
 		( hasGradient && ( gradient || style?.color?.gradient ) );
-
 	const newClassName = classnames(
 		props.className,
 		textClass,
@@ -284,6 +290,10 @@ const getLinkColorFromAttributeValue = ( colors, value ) => {
  */
 export function ColorEdit( props ) {
 	const { name: blockName, attributes } = props;
+
+	if ( blockName === 'core/paragraph' ) {
+		// debugger;
+	}
 	// Some color settings have a special handling for deprecated flags in `useSetting`,
 	// so we can't unwrap them by doing const { ... } = useSetting('color')
 	// until https://github.com/WordPress/gutenberg/issues/37094 is fixed.
@@ -443,6 +453,26 @@ export function ColorEdit( props ) {
 		};
 	};
 
+	const onChangeLinkHoverColor = ( value ) => {
+		const colorObject = getColorObjectByColorValue( allSolids, value );
+		const newLinkColorValue = colorObject?.slug
+			? `var:preset|color|${ colorObject.slug }`
+			: value;
+
+		const newStyle = cleanEmptyObject(
+			immutableSet(
+				localAttributes.current?.style,
+				[ 'elements', 'link:hover', 'color', 'text' ],
+				newLinkColorValue
+			)
+		);
+		props.setAttributes( { style: newStyle } );
+		localAttributes.current = {
+			...localAttributes.current,
+			...{ style: newStyle },
+		};
+	};
+
 	const enableContrastChecking =
 		Platform.OS === 'web' && ! gradient && ! style?.color?.gradient;
 
@@ -507,6 +537,20 @@ export function ColorEdit( props ) {
 									?.text,
 								isShownByDefault: defaultColorControls?.link,
 								resetAllFilter: resetAllLinkFilter,
+							},
+							{
+								label: __( 'Link Hover' ),
+								onColorChange: onChangeLinkHoverColor,
+								colorValue: getLinkColorFromAttributeValue(
+									allSolids,
+									style?.elements?.[ 'link:hover' ]?.color
+										?.text
+								),
+								clearable: !! style?.elements?.[ 'link:hover' ]
+									?.color?.text,
+								isShownByDefault:
+									defaultColorControls?.[ 'link:hover' ],
+								resetAllFilter: resetAllLinkHoverFilter,
 							},
 					  ]
 					: [] ),

--- a/packages/block-editor/src/hooks/color.js
+++ b/packages/block-editor/src/hooks/color.js
@@ -294,9 +294,6 @@ const getLinkColorFromAttributeValue = ( colors, value ) => {
 export function ColorEdit( props ) {
 	const { name: blockName, attributes } = props;
 
-	if ( blockName === 'core/paragraph' ) {
-		// debugger;
-	}
 	// Some color settings have a special handling for deprecated flags in `useSetting`,
 	// so we can't unwrap them by doing const { ... } = useSetting('color')
 	// until https://github.com/WordPress/gutenberg/issues/37094 is fixed.

--- a/packages/blocks/src/api/constants.js
+++ b/packages/blocks/src/api/constants.js
@@ -183,6 +183,7 @@ export const __EXPERIMENTAL_STYLE_PROPERTY = {
 
 export const __EXPERIMENTAL_ELEMENTS = {
 	link: 'a',
+	'link:hover': 'a:hover',
 	h1: 'h1',
 	h2: 'h2',
 	h3: 'h3',

--- a/packages/edit-site/src/components/global-styles/screen-link-color.js
+++ b/packages/edit-site/src/components/global-styles/screen-link-color.js
@@ -14,6 +14,7 @@ import {
 	useStyle,
 	useColorsPerOrigin,
 } from './hooks';
+import Subtitle from './subtitle';
 
 function ScreenLinkColor( { name } ) {
 	const supports = getSupportedGlobalStylesPanels( name );
@@ -39,6 +40,16 @@ function ScreenLinkColor( { name } ) {
 		'user'
 	);
 
+	const [ linkHoverColor, setLinkHoverColor ] = useStyle(
+		'elements.link:hover.color.text',
+		name
+	);
+	const [ userLinkHoverColor ] = useStyle(
+		'elements.link:hover.color.text',
+		name,
+		'user'
+	);
+
 	if ( ! hasLinkColor ) {
 		return null;
 	}
@@ -51,6 +62,7 @@ function ScreenLinkColor( { name } ) {
 					'Set the default color used for links across the site.'
 				) }
 			/>
+			<Subtitle>{ __( 'General' ) }</Subtitle>
 			<ColorGradientControl
 				className="edit-site-screen-link-color__control"
 				colors={ colorsPerOrigin }
@@ -62,6 +74,19 @@ function ScreenLinkColor( { name } ) {
 				colorValue={ linkColor }
 				onColorChange={ setLinkColor }
 				clearable={ linkColor === userLinkColor }
+			/>
+			<Subtitle>{ __( 'Hover' ) }</Subtitle>
+			<ColorGradientControl
+				className="edit-site-screen-link-color__control"
+				colors={ colorsPerOrigin }
+				disableCustomColors={ ! areCustomSolidsEnabled }
+				__experimentalHasMultipleOrigins
+				showTitle={ false }
+				enableAlpha
+				__experimentalIsRenderedInSidebar
+				colorValue={ linkHoverColor }
+				onColorChange={ setLinkHoverColor }
+				clearable={ linkColor === userLinkHoverColor }
 			/>
 		</>
 	);


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->
<img width="515" alt="Screen Shot 2022-05-26 at 21 02 06" src="https://user-images.githubusercontent.com/444434/170569034-0938b0f7-2fdf-4a3d-aa6f-369f134825d2.png">

Exploratory PR to add basic interactivity states to links via the block UI. Builds on great work from @draganescu in https://github.com/WordPress/gutenberg/pull/41331 and long term it will look to close https://github.com/WordPress/gutenberg/issues/27075 (or at least address some part of it) and ultimately also https://github.com/WordPress/gutenberg/issues/38277.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

We need to explore whether the proposed elements syntax of 

```
"link:hover": {
	"color": {
		"text": "red"
	}
}
```

...is going to be the most appropriate. We also need to stress test the limitations of the current system to check how much work is involved in getting this feature to land.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

This is currently a lot of copy/paste to get

- UI controls (i.e. a way to set the `:hover` state on a link using the UI).
- Persisting of save props
- Rendering of corresponding front end styles.

Currently it's very basic and we'd need to do some refactoring to make the code more generic and robust.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->

- New Post
- Add paragraph block and add a link inside it.
- Use the paragraph block inspector controls to set link and link:hover colors via the UI.
- Check that mouseover on the anchor produces the expected color on `:hover`.
- Publish.
- Check the same thing happens on the front of the site.

## Screenshots or screencast <!-- if applicable -->

https://user-images.githubusercontent.com/444434/170567059-5abeb167-cc69-439f-b7b0-2e0ad3809e51.mov


