### PR TITLE
jest-console: Add types directory to "files"

### DIFF
--- a/packages/jest-console/package.json
+++ b/packages/jest-console/package.json
@@ -25,7 +25,8 @@
 	},
 	"files": [
 		"build",
-		"build-module"
+		"build-module",
+		"types"
 	],
 	"main": "build/index.js",
 	"module": "build-module/index.js",


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Includes the `types` directory in the list of files that are published to npm.

## Why?
So that third parties can see the TypeScript definitions included in `jest-console`. Right now nothing appears:

https://unpkg.com/browse/@wordpress/jest-console@5.1.0/

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->

## Screenshots or screencast <!-- if applicable -->
