### PR TITLE
File, Search Blocks: Lower CSS specificity 

### DIFF
--- a/packages/block-library/src/file/style.scss
+++ b/packages/block-library/src/file/style.scss
@@ -10,19 +10,23 @@
 		text-align: right;
 	}
 
-	.wp-block-file__embed {
-		margin-bottom: 1em;
+	* + .wp-block-file__button {
+		margin-left: 0.75em;
 	}
+}
 
-	.wp-block-file__button {
-		background: #32373c;
-		border-radius: 2em;
-		color: $white;
-		font-size: 0.8em;
-		padding: 0.5em 1em;
-	}
+.wp-block-file__embed {
+	margin-bottom: 1em;
+}
 
-	a.wp-block-file__button {
+.wp-block-file__button {
+	background: #32373c;
+	border-radius: 2em;
+	color: $white;
+	font-size: 0.8em;
+	padding: 0.5em 1em;
+
+	&:is(a) {
 		text-decoration: none;
 
 		&:hover,
@@ -34,9 +38,5 @@
 			opacity: 0.85;
 			text-decoration: none;
 		}
-	}
-
-	* + .wp-block-file__button {
-		margin-left: 0.75em;
 	}
 }

--- a/packages/block-library/src/file/style.scss
+++ b/packages/block-library/src/file/style.scss
@@ -19,6 +19,7 @@
 	margin-bottom: 1em;
 }
 
+//This needs a low specificity so it won't override the rules from the button element if defined in theme.json.
 .wp-block-file__button {
 	background: #32373c;
 	border-radius: 2em;

--- a/packages/block-library/src/search/style.scss
+++ b/packages/block-library/src/search/style.scss
@@ -47,7 +47,7 @@
 	}
 }
 
-.wp-block-search.wp-block-search__button-inside .wp-block-search__inside-wrapper {
+:where(.wp-block-search__button-inside) :where(.wp-block-search__inside-wrapper) {
 	padding: 4px;
 	border: 1px solid #949494;
 
@@ -61,7 +61,7 @@
 		}
 	}
 
-	.wp-block-search__button {
+	:where(.wp-block-search__button) {
 		padding: 0.125em 0.5em;
 	}
 }

--- a/packages/block-library/src/search/style.scss
+++ b/packages/block-library/src/search/style.scss
@@ -47,6 +47,7 @@
 	}
 }
 
+// We are lowering the specificity so that the button element can override the rule for the button inside the search block.
 :where(.wp-block-search__button-inside .wp-block-search__inside-wrapper) {
 	padding: 4px;
 	border: 1px solid #949494;

--- a/packages/block-library/src/search/style.scss
+++ b/packages/block-library/src/search/style.scss
@@ -47,7 +47,7 @@
 	}
 }
 
-:where(.wp-block-search__button-inside) :where(.wp-block-search__inside-wrapper) {
+:where(.wp-block-search__button-inside .wp-block-search__inside-wrapper) {
 	padding: 4px;
 	border: 1px solid #949494;
 
@@ -61,7 +61,7 @@
 		}
 	}
 
-	:where(.wp-block-search__button) {
+	.wp-block-search__button {
 		padding: 0.125em 0.5em;
 	}
 }


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Lowers the CSS specificity for the File and Search Block selectors

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

The high specificity of these selectors are overriding the newest addition to the elements API (the buttons), pointed out [here](https://github.com/WordPress/gutenberg/pull/40260#issuecomment-1138289624) and [here](https://github.com/WordPress/gutenberg/pull/41239#issuecomment-1138409634).

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

I'm trying to remove unneeded selectors and used :where when I wasn't sure about what I could remove without breaking other stuff

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->

I've tested this using emptytheme, with the following markup:

```
<!-- wp:buttons -->
<div class="wp-block-buttons"><!-- wp:button -->
<div class="wp-block-button"><a class="wp-block-button__link wp-element-button">Fill Button</a></div>
<!-- /wp:button -->

<!-- wp:button {"className":"is-style-outline"} -->
<div class="wp-block-button is-style-outline"><a class="wp-block-button__link wp-element-button">Outline Button</a></div>
<!-- /wp:button --></div>
<!-- /wp:buttons -->

<!-- wp:search {"label":"Search","buttonText":"Search"} /-->

<!-- wp:search {"label":"Search","buttonText":"Search","buttonUseIcon":true} /-->

<!-- wp:search {"label":"Search","buttonText":"Search","buttonPosition":"button-inside"} /-->

<!-- wp:search {"label":"Search","buttonText":"Search","buttonPosition":"button-inside","buttonUseIcon":true} /-->

<!-- wp:file {"id":23,"href":"http://maggie.local/wp-content/uploads/2022/05/Screenshot-2022-05-13-at-13.10.27.png"} -->
<div class="wp-block-file"><a id="wp-block-file--media-4fff6e6c-0ba4-4897-9486-9c2bfc9e36f6" href="http://maggie.local/wp-content/uploads/2022/05/Screenshot-2022-05-13-at-13.10.27.png">Screenshot 2022-05-13 at 13.10.27</a><a href="http://maggie.local/wp-content/uploads/2022/05/Screenshot-2022-05-13-at-13.10.27.png" class="wp-block-file__button wp-element-button" download aria-describedby="wp-block-file--media-4fff6e6c-0ba4-4897-9486-9c2bfc9e36f6">Download</a></div>
<!-- /wp:file -->
```

And in the theme.json file I have this:

```
"styles": {
      "elements": {
	      "button": {
		      "border": {
			      "radius": "4px"
		      },
		      "color": {
			      "background": "blue",
			      "text": "yellow"
		      },
		      "typography": {
			      "fontSize": "22px",
			      "fontWeight": "strong",
			      "lineHeight": "2",
			      "textDecoration": "none"
		      },
		      "spacing": {
			      "padding": {
				      "top": "2em",
				      "bottom": "2em",
				      "left": "4em",
				      "right": "4em"
			      }
		      }
	      }
      }
 }
```

## Screenshots or screencast <!-- if applicable -->

With the theme.json changes:

Trunk | This PR
--- | ---
<img width="970" alt="Screenshot 2022-05-27 at 11 03 51" src="https://user-images.githubusercontent.com/3593343/170672907-101fd6e2-3589-41bb-b488-3b27ca189c8f.png"> | <img width="931" alt="Screenshot 2022-05-27 at 11 26 51" src="https://user-images.githubusercontent.com/3593343/170672913-45d2d312-577e-4638-bc17-90082a75e4b6.png">


Without the theme.json changes:


Trunk | This PR
--- | ---
<img width="937" alt="Screenshot 2022-05-27 at 11 32 51" src="https://user-images.githubusercontent.com/3593343/170673069-92722bd4-2ef0-4ea7-b857-7b5cfac8a15b.png"> | <img width="1002" alt="Screenshot 2022-05-27 at 11 32 37" src="https://user-images.githubusercontent.com/3593343/170673065-0e6c8f94-b706-4cdc-abc4-4779d9657615.png">


/cc @WordPress/block-themers 