### PR TITLE
Site Editor: Fix description in GetTemplateInfo

### DIFF
--- a/packages/editor/src/store/selectors.js
+++ b/packages/editor/src/store/selectors.js
@@ -1606,14 +1606,16 @@ export function __experimentalGetTemplateInfo( state, template ) {
 		return {};
 	}
 
-	const { excerpt, slug, title, area } = template;
+	const { description, slug, title, area } = template;
 	const {
 		title: defaultTitle,
 		description: defaultDescription,
 	} = __experimentalGetDefaultTemplateType( state, slug );
 
 	const templateTitle = isString( title ) ? title : title?.rendered;
-	const templateDescription = isString( excerpt ) ? excerpt : excerpt?.raw;
+	const templateDescription = isString( description )
+		? description
+		: description?.raw;
 	const templateIcon =
 		__experimentalGetDefaultTemplatePartAreas( state ).find(
 			( item ) => area === item.area

--- a/packages/editor/src/store/test/selectors.js
+++ b/packages/editor/src/store/test/selectors.js
@@ -2968,7 +2968,7 @@ describe( 'selectors', () => {
 			expect(
 				__experimentalGetTemplateInfo( state, {
 					slug: 'index',
-					excerpt: { raw: 'test description' },
+					description: { raw: 'test description' },
 				} ).description
 			).toEqual( 'test description' );
 		} );
@@ -2996,7 +2996,7 @@ describe( 'selectors', () => {
 			expect(
 				__experimentalGetTemplateInfo( state, {
 					slug: 'index',
-					excerpt: { raw: 'test description' },
+					description: { raw: 'test description' },
 				} )
 			).toEqual( {
 				title: 'Default (Index)',
@@ -3008,7 +3008,7 @@ describe( 'selectors', () => {
 				__experimentalGetTemplateInfo( state, {
 					slug: 'index',
 					title: { rendered: 'test title' },
-					excerpt: { raw: 'test description' },
+					description: { raw: 'test description' },
 				} )
 			).toEqual( {
 				title: 'test title',


### PR DESCRIPTION
## What?
PR updates `__experimentalGetTemplateInfo` selector to use correct property for description.

## Why?
While template descriptions are stored as post type except they should be accessed via the `description` property.

I noticed while testing #41387

## Testing Instructions
1. Use the method from #41387 to create a custom template in the Site Editor.
2. Confirm that description is displayed when viewing template details in the dropdown.

## Screenshots or screencast <!-- if applicable -->

![CleanShot 2022-05-27 at 13 39 09](https://user-images.githubusercontent.com/240569/170674187-69e2cdeb-cb74-4e61-b35f-022a3bde48db.png)


