### PR TITLE
Update the block popover position as we scroll the container

### DIFF
--- a/packages/block-editor/src/components/block-popover/index.js
+++ b/packages/block-editor/src/components/block-popover/index.js
@@ -62,6 +62,7 @@ export default function BlockPopover( {
 			// Observe movement for block animations (especially horizontal).
 			__unstableObserveElement={ selectedElement }
 			__unstableForcePosition
+			__unstableShift
 			{ ...props }
 			className={ classnames(
 				'block-editor-block-popover',


### PR DESCRIPTION
Extracted from #41156 

## What?

In the site editor, if you select a block and scroll the page, you'll notice that the block toolbar doesn't stick by the block element. This PR fixes that.

## How?

The behavior here (update on scroll) was present in the original Popover implementation, this just brings it back.

**Notes**

 - There are still some small issues that I haven't been able to fix yet. (Position of the toolbar after opening the inserter for instance). It's unclear to me, how this worked in the previous popover implementation.

## Testing Instructions

1- Navigate to the site editor
2- Select a block
3- scroll the canvas
4- the block popover should stay by the block.
