### PR TITLE
Site Editor: Avoid content loss when switching between editors

### DIFF
--- a/packages/edit-site/src/components/code-editor/code-editor-text-area.js
+++ b/packages/edit-site/src/components/code-editor/code-editor-text-area.js
@@ -6,12 +6,6 @@ import Textarea from 'react-autosize-textarea';
 /**
  * WordPress dependencies
  */
-/**
- * WordPress dependencies
- */
-/**
- * WordPress dependencies
- */
 import { __ } from '@wordpress/i18n';
 import { useEffect, useState, useRef } from '@wordpress/element';
 import { useInstanceId } from '@wordpress/compose';

--- a/packages/edit-site/src/components/code-editor/code-editor-text-area.js
+++ b/packages/edit-site/src/components/code-editor/code-editor-text-area.js
@@ -13,7 +13,7 @@ import Textarea from 'react-autosize-textarea';
  * WordPress dependencies
  */
 import { __ } from '@wordpress/i18n';
-import { useState } from '@wordpress/element';
+import { useEffect, useState, useRef } from '@wordpress/element';
 import { useInstanceId } from '@wordpress/compose';
 import { VisuallyHidden } from '@wordpress/components';
 
@@ -21,6 +21,7 @@ export default function CodeEditorTextArea( { value, onChange, onInput } ) {
 	const [ stateValue, setStateValue ] = useState( value );
 	const [ isDirty, setIsDirty ] = useState( false );
 	const instanceId = useInstanceId( CodeEditorTextArea );
+	const valueRef = useRef();
 
 	if ( ! isDirty && stateValue !== value ) {
 		setStateValue( value );
@@ -42,6 +43,7 @@ export default function CodeEditorTextArea( { value, onChange, onInput } ) {
 		onInput( newValue );
 		setStateValue( newValue );
 		setIsDirty( true );
+		valueRef.current = newValue;
 	};
 
 	/**
@@ -55,6 +57,15 @@ export default function CodeEditorTextArea( { value, onChange, onInput } ) {
 			setIsDirty( false );
 		}
 	};
+
+	// Ensure changes aren't lost when component unmounts.
+	useEffect( () => {
+		return () => {
+			if ( valueRef.current ) {
+				onChange( valueRef.current );
+			}
+		};
+	}, [] );
 
 	return (
 		<>


### PR DESCRIPTION
## What?
Similar to #40730.

PR adds effect to commit changes when the Code Editor component unmounts.

## Testing Instructions
1. Open the Site Editor.
2. Switch to Code view (<kbd>Ctrl</kbd> + <kbd>Shift</kbd> + <kbd>Alt</kbd> + <kbd>M</kbd> or <kbd>⇧</kbd> + <kbd>⌥</kbd> + <kbd>⌘</kbd> + <kbd>M</kbd>)
3. Start typing in the content area.
4. Use the keyboard shortcut again to exit the Code view.
5. Confirm that new content is available in Visual Editor.
