### PR TITLE
Upgrade Rememo to v4

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17046,7 +17046,7 @@
 				"@wordpress/i18n": "file:packages/i18n",
 				"@wordpress/rich-text": "file:packages/rich-text",
 				"lodash": "^4.17.21",
-				"rememo": "^3.0.0",
+				"rememo": "^4.0.0",
 				"uuid": "^8.3.0"
 			}
 		},
@@ -17168,7 +17168,7 @@
 				"lodash": "^4.17.21",
 				"react-autosize-textarea": "^7.1.0",
 				"react-easy-crop": "^3.0.0",
-				"rememo": "^3.0.0",
+				"rememo": "^4.0.0",
 				"traverse": "^0.6.6"
 			},
 			"dependencies": {
@@ -17309,7 +17309,7 @@
 				"hpq": "^1.3.0",
 				"lodash": "^4.17.21",
 				"memize": "^1.1.0",
-				"rememo": "^3.0.0",
+				"rememo": "^4.0.0",
 				"showdown": "^1.9.1",
 				"simple-html-tokenizer": "^0.5.7",
 				"uuid": "^8.3.0"
@@ -17476,7 +17476,7 @@
 				"equivalent-key-map": "^0.2.2",
 				"lodash": "^4.17.21",
 				"memize": "^1.1.0",
-				"rememo": "^3.0.0",
+				"rememo": "^4.0.0",
 				"uuid": "^8.3.0"
 			}
 		},
@@ -17713,7 +17713,7 @@
 				"classnames": "^2.3.1",
 				"lodash": "^4.17.21",
 				"memize": "^1.1.0",
-				"rememo": "^3.0.0"
+				"rememo": "^4.0.0"
 			}
 		},
 		"@wordpress/edit-site": {
@@ -17752,7 +17752,7 @@
 				"history": "^5.1.0",
 				"lodash": "^4.17.21",
 				"react-autosize-textarea": "^7.1.0",
-				"rememo": "^3.0.0"
+				"rememo": "^4.0.0"
 			}
 		},
 		"@wordpress/edit-widgets": {
@@ -17821,7 +17821,7 @@
 				"lodash": "^4.17.21",
 				"memize": "^1.1.0",
 				"react-autosize-textarea": "^7.1.0",
-				"rememo": "^3.0.0"
+				"rememo": "^4.0.0"
 			}
 		},
 		"@wordpress/element": {
@@ -18106,7 +18106,7 @@
 				"@wordpress/element": "file:packages/element",
 				"@wordpress/keycodes": "file:packages/keycodes",
 				"lodash": "^4.17.21",
-				"rememo": "^3.0.0"
+				"rememo": "^4.0.0"
 			}
 		},
 		"@wordpress/keycodes": {
@@ -18174,7 +18174,7 @@
 				"@wordpress/i18n": "file:packages/i18n",
 				"@wordpress/icons": "file:packages/icons",
 				"lodash": "^4.17.21",
-				"rememo": "^3.0.0"
+				"rememo": "^4.0.0"
 			}
 		},
 		"@wordpress/plugins": {
@@ -18681,7 +18681,7 @@
 				"@wordpress/keycodes": "file:packages/keycodes",
 				"lodash": "^4.17.21",
 				"memize": "^1.1.0",
-				"rememo": "^3.0.0"
+				"rememo": "^4.0.0"
 			}
 		},
 		"@wordpress/scripts": {
@@ -52552,9 +52552,9 @@
 			}
 		},
 		"rememo": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/rememo/-/rememo-3.0.0.tgz",
-			"integrity": "sha512-eWtut/7pqMRnSccbexb647iPjN7ir6Tmf4RG92ZVlykFEkHqGYy9tWnpHH3I+FS+WQ6lQ1i1iDgarYzGKgTcRQ=="
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/rememo/-/rememo-4.0.0.tgz",
+			"integrity": "sha512-6BAfg1Dqg6UteZBEH9k6EHHersM86/EcBOMtJV+h+xEn1GC3H+gAgJWpexWYAamAxD0qXNmIt50iS/zuZKnQag=="
 		},
 		"remove-trailing-separator": {
 			"version": "1.1.0",

--- a/packages/annotations/package.json
+++ b/packages/annotations/package.json
@@ -31,7 +31,7 @@
 		"@wordpress/i18n": "file:../i18n",
 		"@wordpress/rich-text": "file:../rich-text",
 		"lodash": "^4.17.21",
-		"rememo": "^3.0.0",
+		"rememo": "^4.0.0",
 		"uuid": "^8.3.0"
 	},
 	"peerDependencies": {

--- a/packages/block-editor/package.json
+++ b/packages/block-editor/package.json
@@ -67,7 +67,7 @@
 		"lodash": "^4.17.21",
 		"react-autosize-textarea": "^7.1.0",
 		"react-easy-crop": "^3.0.0",
-		"rememo": "^3.0.0",
+		"rememo": "^4.0.0",
 		"traverse": "^0.6.6"
 	},
 	"peerDependencies": {

--- a/packages/blocks/package.json
+++ b/packages/blocks/package.json
@@ -46,7 +46,7 @@
 		"hpq": "^1.3.0",
 		"lodash": "^4.17.21",
 		"memize": "^1.1.0",
-		"rememo": "^3.0.0",
+		"rememo": "^4.0.0",
 		"showdown": "^1.9.1",
 		"simple-html-tokenizer": "^0.5.7",
 		"uuid": "^8.3.0"

--- a/packages/core-data/package.json
+++ b/packages/core-data/package.json
@@ -42,7 +42,7 @@
 		"equivalent-key-map": "^0.2.2",
 		"lodash": "^4.17.21",
 		"memize": "^1.1.0",
-		"rememo": "^3.0.0",
+		"rememo": "^4.0.0",
 		"uuid": "^8.3.0"
 	},
 	"peerDependencies": {

--- a/packages/edit-post/package.json
+++ b/packages/edit-post/package.json
@@ -55,7 +55,7 @@
 		"classnames": "^2.3.1",
 		"lodash": "^4.17.21",
 		"memize": "^1.1.0",
-		"rememo": "^3.0.0"
+		"rememo": "^4.0.0"
 	},
 	"peerDependencies": {
 		"react": "^17.0.0",

--- a/packages/edit-site/package.json
+++ b/packages/edit-site/package.json
@@ -59,7 +59,7 @@
 		"history": "^5.1.0",
 		"lodash": "^4.17.21",
 		"react-autosize-textarea": "^7.1.0",
-		"rememo": "^3.0.0"
+		"rememo": "^4.0.0"
 	},
 	"peerDependencies": {
 		"react": "^17.0.0",

--- a/packages/editor/package.json
+++ b/packages/editor/package.json
@@ -61,7 +61,7 @@
 		"lodash": "^4.17.21",
 		"memize": "^1.1.0",
 		"react-autosize-textarea": "^7.1.0",
-		"rememo": "^3.0.0"
+		"rememo": "^4.0.0"
 	},
 	"peerDependencies": {
 		"react": "^17.0.0",

--- a/packages/keyboard-shortcuts/package.json
+++ b/packages/keyboard-shortcuts/package.json
@@ -30,7 +30,7 @@
 		"@wordpress/element": "file:../element",
 		"@wordpress/keycodes": "file:../keycodes",
 		"lodash": "^4.17.21",
-		"rememo": "^3.0.0"
+		"rememo": "^4.0.0"
 	},
 	"peerDependencies": {
 		"react": "^17.0.0"

--- a/packages/nux/package.json
+++ b/packages/nux/package.json
@@ -39,7 +39,7 @@
 		"@wordpress/i18n": "file:../i18n",
 		"@wordpress/icons": "file:../icons",
 		"lodash": "^4.17.21",
-		"rememo": "^3.0.0"
+		"rememo": "^4.0.0"
 	},
 	"peerDependencies": {
 		"react": "^17.0.0",

--- a/packages/rich-text/package.json
+++ b/packages/rich-text/package.json
@@ -39,7 +39,7 @@
 		"@wordpress/keycodes": "file:../keycodes",
 		"lodash": "^4.17.21",
 		"memize": "^1.1.0",
-		"rememo": "^3.0.0"
+		"rememo": "^4.0.0"
 	},
 	"peerDependencies": {
 		"react": "^17.0.0"


### PR DESCRIPTION
## What?

Upgrades the `rememo` dependency to the latest version, across all packages.

## Why?

The latest version includes type definitions, which ensures that functions created through `createSelector` retain the original function type of the function being memoized.

Related discussion: https://github.com/WordPress/gutenberg/pull/41235#discussion_r879368708

It's also ever-so-slightly smaller, as it removes IE10 compatibility code (https://github.com/aduth/rememo/commit/68ad3b57cf548e750a052461c201f49a15f37dd2).

## How?

Updates packages.

## Testing Instructions

1. `npm install`
2. Check there's no type errors: `npx tsc`
3. Enjoy type definitions for selector functions ([example](https://user-images.githubusercontent.com/1779930/170796418-2561682c-e298-4110-a034-a1120a28081e.png), [reference source](https://github.com/WordPress/gutenberg/blob/f6a75904cbf4979be6213034e1459ff1c397a948/packages/core-data/src/selectors.ts#L150))