### PR TITLE
Components: refactor `ComboboxControl` to pass `exhaustive-deps`

### DIFF
--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -13,6 +13,7 @@
 -   `Guide`: use `code` instead of `keyCode` for keyboard events ([#43604](https://github.com/WordPress/gutenberg/pull/43604/)).
 -   `Navigation`: use `code` instead of `keyCode` for keyboard events ([#43644](https://github.com/WordPress/gutenberg/pull/43644/)).
 -   `ComboboxControl`: Add unit tests ([#42403](https://github.com/WordPress/gutenberg/pull/42403)).
+-   `ComboboxControl`: updated to satisfy `react/exhuastive-deps` eslint rule ([#41417](https://github.com/WordPress/gutenberg/pull/41417))
 
 ## 20.0.0 (2022-08-24)
 

--- a/packages/components/src/combobox-control/index.js
+++ b/packages/components/src/combobox-control/index.js
@@ -96,7 +96,7 @@ function ComboboxControl( {
 		} );
 
 		return startsWithMatch.concat( containsMatch );
-	}, [ inputValue, options, value ] );
+	}, [ inputValue, options ] );
 
 	const onSuggestionSelected = ( newSelectedSuggestion ) => {
 		setValue( newSelectedSuggestion.value );


### PR DESCRIPTION
## What?
Updates the `ComboboxControl` component to satisfy the `exhaustive-deps` eslint rule

## Why?
Part of the effort in https://github.com/WordPress/gutenberg/pull/41166 to apply `exhuastive-deps` to the Components package

## How?

I think we can safely remove `value` from the `matchingSuggestions` `useMemo` dependency array. `value` is a prop that, as far as I can tell, doesn't impact that matches based on current input.

The main risk here felt like the impact of the parent component updating `value` on us mid-search, so I've tested this in Storybook by adding an input that fires `setValue` on a five second delay. During that delay I began typing into the ComboBox and waiting for the `value` to change causing a rerender. When it did, the current matches didn't appear to be disrupted, and there was no impact in selecting an option based on the current input.

Just in case, @youknowriad, do you have any recollection of the details on adding `value` to this dependency array? It was a long time ago, but I wanted to double check in case I've overlooked something :) 

## Testing Instructions
1. From your local Gutenberg directory, run `npx eslint --rule 'react-hooks/exhaustive-deps: warn' packages/components/src/combobox-control`
2. Confirm that the linter returns no errors
3. Launch Storybook, test `ComboboxControl`'s stories/docs to ensure they still work as expected with no console errors
4. Confirm e2e tests still pass