### PR TITLE
[Block Cover]: Fix focal point for repeated background

### DIFF
--- a/packages/block-library/src/cover/index.php
+++ b/packages/block-library/src/cover/index.php
@@ -18,7 +18,7 @@ function render_block_core_cover( $attributes, $content ) {
 		return $content;
 	}
 
-	if ( ! ( $attributes['hasParallax'] || $attributes['isRepeated'] ) ) {
+	if ( ! ( $attributes['hasParallax'] ) ) {
 		$attr = array(
 			'class'           => 'wp-block-cover__image-background',
 			'data-object-fit' => 'cover',


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->
In my PR, I have removed the condition `isRepeated` is checked and because of the condition it was not able to add css property `background-postion` or `object-position`.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
Fixes: #40809

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
I removed the OR (||) condition
## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->

1. Create a new page and add a Cover block with an image.
2. 1.Toggle on the Repeated background option.
3. 1. Change the focal point settings and publish the page.
4. 1. Go to the frontend and see that the focal point settings are not applied to the image.
5. 1. Go back to edit the page, refresh, and see that the focal point settings are saved and applied to the image.

## Screenshots or screencast <!-- if applicable -->

https://user-images.githubusercontent.com/21127788/170842053-11d79ca4-1a6c-45dc-9985-106c3e631f8d.mov

