### PR TITLE
`InputControl`: Add tests and update to use @testing-library/user-event

### DIFF
--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Internal
+
+-   `InputControl`: Add tests and update to use `@testing-library/user-event` ([#41421](https://github.com/WordPress/gutenberg/pull/41421)).
+
 ## 19.13.0 (2022-06-15)
 
 ### Bug Fix

--- a/packages/components/src/input-control/test/index.js
+++ b/packages/components/src/input-control/test/index.js
@@ -68,13 +68,16 @@ describe( 'InputControl', () => {
 		it( 'should update value onChange', async () => {
 			const user = setupUser();
 			const spy = jest.fn();
-			render( <InputControl value="Hello" onChange={ spy } /> );
+			render(
+				<InputControl value="Hello" onChange={ ( v ) => spy( v ) } />
+			);
 			const input = getInput();
 
 			await user.type( input, ' there' );
 
 			expect( input ).toHaveValue( 'Hello there' );
 			expect( spy ).toHaveBeenCalledTimes( 6 );
+			expect( spy ).toHaveBeenLastCalledWith( 'Hello there' );
 		} );
 
 		it( 'should work as a controlled component', async () => {
@@ -86,15 +89,13 @@ describe( 'InputControl', () => {
 			const input = getInput();
 
 			await user.type( input, '2' );
-
-			// Ensuring <InputControl /> is controlled.
+			// Blurs the input.
 			await user.click( document.body );
 
 			// Updating the value via props.
 			rerender( <InputControl value="three" onChange={ spy } /> );
 
 			expect( input ).toHaveValue( 'three' );
-
 			/*
 			 * onChange called only once. onChange is not called when a
 			 * parent component explicitly passed a (new value) change down to
@@ -109,8 +110,6 @@ describe( 'InputControl', () => {
 				<InputControl value="Original" onChange={ spy } />
 			);
 			const input = getInput();
-
-			// Assuming <InputControl /> is controlled (not focused)
 
 			// Updating the value.
 			rerender( <InputControl value="New" onChange={ spy } /> );

--- a/packages/components/src/input-control/test/index.js
+++ b/packages/components/src/input-control/test/index.js
@@ -184,6 +184,7 @@ describe( 'InputControl', () => {
 			const input = getInput();
 
 			await user.type( input, ' now' );
+			// Clicking document.body to trigger a blur event on the input.
 			await user.click( document.body );
 
 			expect( spyChange ).toHaveBeenLastCalledWith( 'this is meow' );

--- a/packages/components/src/input-control/test/index.js
+++ b/packages/components/src/input-control/test/index.js
@@ -89,7 +89,7 @@ describe( 'InputControl', () => {
 			const input = getInput();
 
 			await user.type( input, '2' );
-			// Blurs the input.
+			// Clicking document.body to trigger a blur event on the input.
 			await user.click( document.body );
 
 			// Updating the value via props.
@@ -136,6 +136,7 @@ describe( 'InputControl', () => {
 			const input = getInput();
 
 			await user.type( input, 'that was then' );
+			// Clicking document.body to trigger a blur event on the input.
 			await user.click( document.body );
 
 			expect( spy ).toHaveBeenCalledTimes( 1 );

--- a/packages/components/src/input-control/test/index.js
+++ b/packages/components/src/input-control/test/index.js
@@ -5,6 +5,11 @@ import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 
 /**
+ * WordPress dependencies
+ */
+import { useState } from '@wordpress/element';
+
+/**
  * Internal dependencies
  */
 import BaseInputControl from '../';
@@ -83,17 +88,29 @@ describe( 'InputControl', () => {
 		it( 'should work as a controlled component', async () => {
 			const user = setupUser();
 			const spy = jest.fn();
-			const { rerender } = render(
-				<InputControl value="one" onChange={ spy } />
-			);
+			const Example = () => {
+				const [ state, setState ] = useState( 'one' );
+				const onChange = ( value ) => {
+					setState( value );
+					spy( value );
+				};
+				const onKeyDown = ( { key } ) => {
+					if ( key === 'Escape' ) setState( 'three' );
+				};
+				return (
+					<InputControl
+						value={ state }
+						onChange={ onChange }
+						onKeyDown={ onKeyDown }
+					/>
+				);
+			};
+			render( <Example /> );
 			const input = getInput();
 
 			await user.type( input, '2' );
-			// Clicking document.body to trigger a blur event on the input.
-			await user.click( document.body );
-
-			// Updating the value via props.
-			rerender( <InputControl value="three" onChange={ spy } /> );
+			// Make a controlled update.
+			await user.keyboard( '{Escape}' );
 
 			expect( input ).toHaveValue( 'three' );
 			/*

--- a/packages/components/src/input-control/test/index.js
+++ b/packages/components/src/input-control/test/index.js
@@ -76,7 +76,7 @@ describe( 'InputControl', () => {
 			await user.type( input, ' there' );
 
 			expect( input ).toHaveValue( 'Hello there' );
-			expect( spy ).toHaveBeenCalledTimes( 6 );
+			expect( spy ).toHaveBeenCalledTimes( ' there'.length );
 			expect( spy ).toHaveBeenLastCalledWith( 'Hello there' );
 		} );
 


### PR DESCRIPTION
## What?
Updates the `InputControl` unit tests to use `@testing-library/user-event` for interacting with the component and adds a couple new tests.

## Why?
- Makes the tests of user interaction closer to actual use and thereby increase the likelihood of catching bugs.
- Increases test coverage.

## How?
https://testing-library.com/docs/ecosystem-user-event/

## Testing Instructions
`npm run test-unit input-control`
