### PR TITLE
Lower the priority of the gallery gap css so it loads after the block  layout css

### DIFF
--- a/packages/block-library/src/gallery/index.php
+++ b/packages/block-library/src/gallery/index.php
@@ -86,7 +86,8 @@ function block_core_gallery_render( $attributes, $content ) {
 		'wp_footer',
 		function () use ( $style ) {
 			echo '<style> ' . $style . '</style>';
-		}
+		},
+		11
 	);
 	return $content;
 }


### PR DESCRIPTION
## What?
Fixes the order that the Gallery gap CSS is enqueued so it is not overwritten by layout CSS in non block themes

## Why?
Currently for non-block themes the Gallery block gap CSS is being loading prior to the layout CSS, so the gap value is overwritten by the default 0.5em value

## How?
Set the action priority lower in the Gallery render method.  This issue is also fixed by #41015, but this smaller change may be easier to backport to 6.0.1?

## Testing Instructions

- In a non-block theme, add a custom CSS var or `--wp--style--gallery-gap-default: 37px;`
- Add a Gallery and check in the frontend that the gap is set to `37px`
- Also try and block theme and make sure gap still works as expected

## Screenshots

Before:
<img width="486" alt="Screen Shot 2022-05-30 at 1 24 11 PM" src="https://user-images.githubusercontent.com/3629020/170901611-0c05d3b6-22ac-49c4-8136-4abe54455cba.png">

After:
<img width="481" alt="Screen Shot 2022-05-30 at 1 23 28 PM" src="https://user-images.githubusercontent.com/3629020/170901627-82be6678-ef63-487c-942e-70ee6c0a0574.png">