### PR TITLE
[WIP] Style engine: register styles for enqueuing and rendering

### DIFF
--- a/lib/block-supports/elements.php
+++ b/lib/block-supports/elements.php
@@ -105,11 +105,11 @@ function gutenberg_render_elements_support_styles( $pre_render, $block ) {
 	$link_block_styles = isset( $element_block_styles['link'] ) ? $element_block_styles['link'] : null;
 
 	if ( $link_block_styles ) {
-		gutenberg_style_engine_enqueue_block_support_styles(
+		gutenberg_style_engine_enqueue_styles(
 			$link_block_styles,
 			array(
 				'selector' => ".$class_name a",
-				'css_vars' => true,
+				'layer'    => 'block-supports',
 			)
 		);
 

--- a/lib/block-supports/elements.php
+++ b/lib/block-supports/elements.php
@@ -112,10 +112,6 @@ function gutenberg_render_elements_support_styles( $pre_render, $block ) {
 				'layer'    => 'block-supports',
 			)
 		);
-
-//		if ( ! empty( $styles['css'] ) ) {
-//			gutenberg_enqueue_block_support_styles( $styles['css'] );
-//		}
 	}
 
 	return null;

--- a/lib/block-supports/elements.php
+++ b/lib/block-supports/elements.php
@@ -105,7 +105,7 @@ function gutenberg_render_elements_support_styles( $pre_render, $block ) {
 	$link_block_styles = isset( $element_block_styles['link'] ) ? $element_block_styles['link'] : null;
 
 	if ( $link_block_styles ) {
-		$styles = gutenberg_style_engine_generate(
+		gutenberg_style_engine_enqueue_block_support_styles(
 			$link_block_styles,
 			array(
 				'selector' => ".$class_name a",
@@ -113,9 +113,9 @@ function gutenberg_render_elements_support_styles( $pre_render, $block ) {
 			)
 		);
 
-		if ( ! empty( $styles['css'] ) ) {
-			gutenberg_enqueue_block_support_styles( $styles['css'] );
-		}
+//		if ( ! empty( $styles['css'] ) ) {
+//			gutenberg_enqueue_block_support_styles( $styles['css'] );
+//		}
 	}
 
 	return null;

--- a/lib/load.php
+++ b/lib/load.php
@@ -157,6 +157,14 @@ if ( file_exists( __DIR__ . '/../build/style-engine/class-wp-style-engine-gutenb
 	require_once __DIR__ . '/../build/style-engine/class-wp-style-engine-gutenberg.php';
 }
 
+if ( file_exists( __DIR__ . '/../build/style-engine/class-wp-style-engine-store-gutenberg.php' ) ) {
+	require_once __DIR__ . '/../build/style-engine/class-wp-style-engine-store-gutenberg.php';
+}
+
+if ( file_exists( __DIR__ . '/../build/style-engine/class-wp-style-engine-renderer-gutenberg.php' ) ) {
+	require_once __DIR__ . '/../build/style-engine/class-wp-style-engine-renderer-gutenberg.php';
+}
+
 // Block supports overrides.
 require __DIR__ . '/block-supports/utils.php';
 require __DIR__ . '/block-supports/elements.php';

--- a/packages/style-engine/class-wp-style-engine-renderer.php
+++ b/packages/style-engine/class-wp-style-engine-renderer.php
@@ -20,32 +20,24 @@ if ( class_exists( 'WP_Style_Engine_Renderer' ) ) {
  */
 class WP_Style_Engine_Renderer {
 	/**
-	 * Constructor.
-	 *
-	 * @return void
-	 */
-	public function __construct() {
-		// @TODO some argument to determine how/where the styles are rendered.
-		// For example, we could enqueue specific inline styles like global styles, see: gutenberg_enqueue_global_styles().
-		//
-	}
-
-	/**
 	 * Prints registered styles in the page head or footer.
+	 *
+	 * @TODO this shares code with the styles engine class in generate(). Centralize.
 	 *
 	 * @see $this->enqueue_block_support_styles
 	 */
-	public function render_registered_styles( $styles ) {
-		if ( empty( $styles ) ) {
+	public static function render_registered_block_supports_styles() {
+		$style_engine         = WP_Style_Engine::get_instance();
+		$block_support_styles = $style_engine->get_block_support_styles();
+
+		if ( empty( $block_support_styles ) ) {
 			return;
 		}
 
 		$output = '';
 
-		foreach ( $styles as $selector => $rules ) {
-				$output .= "\t$selector { ";
-				$output .= implode( ' ', $rules );
-				$output .= " }\n";
+		foreach ( $block_support_styles as $style ) {
+				$output .= "{$style['sanitized_output']}\n";
 		}
 
 		echo "<style>\n$output</style>\n";
@@ -64,14 +56,14 @@ class WP_Style_Engine_Renderer {
 	 *
 	 * @see gutenberg_enqueue_block_support_styles()
 	 */
-	private function enqueue_block_support_styles() {
+	public static function enqueue_block_support_styles() {
 		$action_hook_name = 'wp_footer';
 		if ( wp_is_block_theme() ) {
 			$action_hook_name = 'wp_head';
 		}
 		add_action(
 			$action_hook_name,
-			array( $this, 'render_registered_styles' )
+			array( __CLASS__, 'render_registered_block_supports_styles' )
 		);
 	}
 }

--- a/packages/style-engine/class-wp-style-engine-renderer.php
+++ b/packages/style-engine/class-wp-style-engine-renderer.php
@@ -1,10 +1,12 @@
 <?php
-// @TODO we probably don't need this right now.
-// Just toying around.
 /**
  * WP_Style_Engine_Renderer
  *
- * Renders CSS on the frontend.
+ * A library of CSS rule generators and render functions.
+ *
+ * @TODO Consider splitting out the rule generators (?).
+ * Or creating a base interface and then a bunch of separate render classes for each "layer", e.g.,
+ * one for block supports, one for global styles.
  *
  * @package Gutenberg
  */
@@ -14,7 +16,7 @@ if ( class_exists( 'WP_Style_Engine_Renderer' ) ) {
 }
 
 /**
- * Renders CSS on the frontend..
+ * Renders CSS on the frontend.
  *
  * @access private
  */
@@ -36,12 +38,87 @@ class WP_Style_Engine_Renderer {
 
 		$output = '';
 
-		foreach ( $block_support_styles as $style ) {
-				$output .= "{$style['sanitized_output']}\n";
+		foreach ( $block_support_styles as $selector => $css_definitions ) {
+			$output .= self::generate_css_rule( $selector, $css_definitions, true );
 		}
 
 		echo "<style>\n$output</style>\n";
 	}
+
+	/**
+	 * Filters incoming CSS properties against WordPress Core's allowed CSS attributes in wp-includes/kses.php.
+	 *
+	 * @param string $property_declaration A CSS property declaration, e.g., `color: 'pink'`.
+	 *
+	 * @return string A filtered CSS property. Empty if not allowed.
+	 */
+	public static function sanitize_property_declaration( $property_declaration ) {
+		return esc_html( safecss_filter_attr( $property_declaration ) );
+	}
+
+	/**
+	 * Creates a string consisting of CSS property declarations suitable for the value of an HTML element's style attribute.
+	 *
+	 * @param array $css_definitions An collection of CSS definitions `[ [ 'color' => 'red' ] ]`.
+	 *
+	 * @return string A concatenated string of CSS properties, e.g. `'color: red; font-size:12px'`
+	 */
+	public static function generate_inline_property_declarations( $css_definitions ) {
+		$css_rule_inline = '';
+
+		if ( empty( $css_definitions ) ) {
+			return $css_rule_inline;
+		}
+		foreach ( $css_definitions as $definition => $value ) {
+			$filtered_css = self::sanitize_property_declaration( "{$definition}: {$value}" );
+			if ( ! empty( $filtered_css ) ) {
+				$css_rule_inline .= $filtered_css . ';';
+			}
+		}
+		return $css_rule_inline;
+	}
+
+	/**
+	 * Creates a string consisting of a CSS rule
+	 *
+	 * @param string  $selector A CSS selector, e.g., `.some-class-name`.
+	 * @param array   $css_definitions An collection of CSS definitions `[ [ 'color' => 'red' ] ]`.
+	 * @param boolean $should_prettify Whether to print spaces and carriage returns.
+	 *
+	 * @return string A CSS rule, e.g. `'.some-selector { color: red; font-size:12px }'`
+	 */
+	public static function generate_css_rule( $selector, $css_definitions, $should_prettify = false ) {
+		$css_rule_block = '';
+
+		if ( ! $selector || empty( $css_definitions ) ) {
+			return $css_rule_block;
+		}
+
+		$css_rule_block = $should_prettify ? "$selector {\n" : "$selector { ";
+
+		foreach ( $css_definitions as $definition => $value ) {
+			$filtered_css = self::sanitize_property_declaration( "{$definition}: {$value}" );
+			if ( ! empty( $filtered_css ) ) {
+				if ( $should_prettify ) {
+					$css_rule_block .= "\t$filtered_css;\n";
+				} else {
+					$css_rule_block .= $filtered_css . ';';
+				}
+			}
+		}
+		$css_rule_block .= $should_prettify ? "}\n" : ' }';
+		return $css_rule_block;
+	}
+
+	// @TODO The following method takes over the work of enqueuing block support styles for now.
+	// Later we'd want to identify which styles we're rendering, e.g., is this a global styles ruleset,
+	// so we can create appropriate "layers" / control specificity.
+	// We could create separate blocks for each layer, e.g.,
+	// wp_register_style( 'global-styles-layer', false, array(), true, true );
+	// wp_add_inline_style( 'global-styles-layer', $styles );
+	// wp_enqueue_style( 'global-styles-layer' );
+	// Or build them and print them all out in one.
+	// Just how, I don't know right now :D.
 
 	/**
 	 * Taken from gutenberg_enqueue_block_support_styles()
@@ -55,15 +132,18 @@ class WP_Style_Engine_Renderer {
 	 * the render_block.
 	 *
 	 * @see gutenberg_enqueue_block_support_styles()
+	 *
+	 * @param int $priority To set the priority for the add_action.
 	 */
-	public static function enqueue_block_support_styles() {
+	public static function enqueue_block_support_styles( $priority = 10 ) {
 		$action_hook_name = 'wp_footer';
 		if ( wp_is_block_theme() ) {
 			$action_hook_name = 'wp_head';
 		}
 		add_action(
 			$action_hook_name,
-			array( __CLASS__, 'render_registered_block_supports_styles' )
+			array( __CLASS__, 'render_registered_block_supports_styles' ),
+			$priority
 		);
 	}
 }

--- a/packages/style-engine/class-wp-style-engine-renderer.php
+++ b/packages/style-engine/class-wp-style-engine-renderer.php
@@ -30,7 +30,7 @@ class WP_Style_Engine_Renderer {
 	 */
 	public static function render_registered_block_supports_styles() {
 		$style_engine         = WP_Style_Engine::get_instance();
-		$block_support_styles = $style_engine->get_block_support_styles();
+		$block_support_styles = $style_engine->get_registered_styles( 'block-supports' );
 
 		if ( empty( $block_support_styles ) ) {
 			return;

--- a/packages/style-engine/class-wp-style-engine-renderer.php
+++ b/packages/style-engine/class-wp-style-engine-renderer.php
@@ -1,0 +1,78 @@
+<?php
+// @TODO we probably don't need this right now.
+// Just toying around.
+/**
+ * WP_Style_Engine_Renderer
+ *
+ * Renders CSS on the frontend.
+ *
+ * @package Gutenberg
+ */
+
+if ( class_exists( 'WP_Style_Engine_Renderer' ) ) {
+	return;
+}
+
+/**
+ * Renders CSS on the frontend..
+ *
+ * @access private
+ */
+class WP_Style_Engine_Renderer {
+	/**
+	 * Constructor.
+	 *
+	 * @return void
+	 */
+	public function __construct() {
+		// @TODO some argument to determine how/where the styles are rendered.
+		// For example, we could enqueue specific inline styles like global styles, see: gutenberg_enqueue_global_styles().
+		//
+	}
+
+	/**
+	 * Prints registered styles in the page head or footer.
+	 *
+	 * @see $this->enqueue_block_support_styles
+	 */
+	public function render_registered_styles( $styles ) {
+		if ( empty( $styles ) ) {
+			return;
+		}
+
+		$output = '';
+
+		foreach ( $styles as $selector => $rules ) {
+				$output .= "\t$selector { ";
+				$output .= implode( ' ', $rules );
+				$output .= " }\n";
+		}
+
+		echo "<style>\n$output</style>\n";
+	}
+
+	/**
+	 * Taken from gutenberg_enqueue_block_support_styles()
+	 *
+	 * This function takes care of adding inline styles
+	 * in the proper place, depending on the theme in use.
+	 *
+	 * For block themes, it's loaded in the head.
+	 * For classic ones, it's loaded in the body
+	 * because the wp_head action  happens before
+	 * the render_block.
+	 *
+	 * @see gutenberg_enqueue_block_support_styles()
+	 */
+	private function enqueue_block_support_styles() {
+		$action_hook_name = 'wp_footer';
+		if ( wp_is_block_theme() ) {
+			$action_hook_name = 'wp_head';
+		}
+		add_action(
+			$action_hook_name,
+			array( $this, 'render_registered_styles' )
+		);
+	}
+}
+

--- a/packages/style-engine/class-wp-style-engine-store.php
+++ b/packages/style-engine/class-wp-style-engine-store.php
@@ -1,0 +1,140 @@
+<?php
+/**
+ * WP_Style_Engine_Store
+ *
+ * Registers and stores styles to be processed or rendered on the frontend.
+ *
+ * @package Gutenberg
+ */
+
+// Probably don't need this, but it was just helped to design things.
+if ( ! interface_exists( 'WP_Style_Engine_Store_Interface' ) ) {
+	/**
+	 * Registers and retrieves stored styles.
+	 *
+	 * @access private
+	 */
+	interface WP_Style_Engine_Store_Interface {
+		/**
+		 * Register a style
+		 *
+		 * @param string $key Unique key for a $style_data object.
+		 * @param array  $style_data Associative array of style information.
+		 * @return void
+		 */
+		public function register( $key, $style_data );
+
+		/**
+		 * Retrieves style data from the store.
+		 *
+		 * @param string $key Unique key for a $style_data object.
+		 * @return void
+		 */
+		public function get( $key );
+	}
+}
+
+/**
+ * Registers and stores styles to be processed or rendered on the frontend.
+ *
+ * @access private
+ */
+class WP_Style_Engine_Store implements WP_Style_Engine_Store_Interface {
+	/**
+	 * Registered styles.
+	 *
+	 * @var WP_Style_Engine_Store|null
+	 */
+	private $registered_styles = array();
+
+	/**
+	 * Register a style
+	 *
+	 * @param string $key Unique key for a $style_data object.
+	 * @param array  $style_data Associative array of style information.
+	 * @return void
+	 */
+	public function register( $key, $style_data ) {
+		if ( empty( $key ) || empty( $style_data ) ) {
+			return;
+		}
+
+		if ( isset( $this->registered_styles[ $key ] ) ) {
+			$style_data = array_unique( array_merge( $this->registered_styles[ $key ], $style_data ) );
+		}
+		$this->registered_styles[ $key ] = $style_data;
+	}
+
+	/**
+	 * Retrieves style data from the store.
+	 *
+	 * @param string $key Optional unique key for a $style_data object to return a single style object.
+	 * @param array? $style_data Associative array of style information.
+	 */
+	public function get( $key = null ) {
+		if ( isset( $this->registered_styles[ $key ] ) ) {
+			return $this->registered_styles[ $key ];
+		}
+		return $this->registered_styles;
+	}
+}
+
+/*
+
+For each style category we could have a separate object:
+e.g.,
+
+$global_style_store = new WP_Style_Engine_Store();
+$block_supports_style_store = new WP_Style_Engine_Store();
+
+
+@TODO
+
+Work out enqueuing and rendering
+*/
+	/**
+	 * Prints registered styles in the page head or footer.
+	 *
+	 * @see $this->enqueue_block_support_styles
+
+	public function output_registered_block_support_styles() {
+		if ( empty( $this->registered_block_support_styles ) ) {
+			return;
+		}
+
+		$output = '';
+
+		foreach ( $this->registered_block_support_styles as $selector => $rules ) {
+				$output .= "\t$selector { ";
+				$output .= implode( ' ', $rules );
+				$output .= " }\n";
+		}
+
+		echo "<style>\n$output</style>\n";
+	} */
+
+	/**
+	 * Taken from gutenberg_enqueue_block_support_styles()
+	 *
+	 * This function takes care of adding inline styles
+	 * in the proper place, depending on the theme in use.
+	 *
+	 * For block themes, it's loaded in the head.
+	 * For classic ones, it's loaded in the body
+	 * because the wp_head action  happens before
+	 * the render_block.
+	 *
+	 * @see gutenberg_enqueue_block_support_styles()
+
+	private function enqueue_block_support_styles() {
+		$action_hook_name = 'wp_footer';
+		if ( wp_is_block_theme() ) {
+			$action_hook_name = 'wp_head';
+		}
+		add_action(
+			$action_hook_name,
+			array( $this, 'output_registered_block_support_styles' )
+		);
+	} */
+
+

--- a/packages/style-engine/class-wp-style-engine-store.php
+++ b/packages/style-engine/class-wp-style-engine-store.php
@@ -7,45 +7,45 @@
  * @package Gutenberg
  */
 
-// Probably don't need this, but it was just helped to design things.
-if ( ! interface_exists( 'WP_Style_Engine_Store_Interface' ) ) {
-	/**
-	 * Registers and retrieves stored styles.
-	 *
-	 * @access private
-	 */
-	interface WP_Style_Engine_Store_Interface {
-		/**
-		 * Register a style
-		 *
-		 * @param string $key Unique key for a $style_data object.
-		 * @param array  $style_data Associative array of style information.
-		 * @return void
-		 */
-		public function register( $key, $style_data );
-
-		/**
-		 * Retrieves style data from the store.
-		 *
-		 * @param string $key Unique key for a $style_data object.
-		 * @return void
-		 */
-		public function get( $key );
-	}
+if ( class_exists( 'WP_Style_Engine_Store' ) ) {
+	return;
 }
 
 /**
  * Registers and stores styles to be processed or rendered on the frontend.
  *
+ * For each style category we could have a separate object, e.g.,
+ * $global_style_store = new WP_Style_Engine_Store();
+ * $block_supports_style_store = new WP_Style_Engine_Store();
+ *
  * @access private
  */
-class WP_Style_Engine_Store implements WP_Style_Engine_Store_Interface {
+class WP_Style_Engine_Store {
 	/**
 	 * Registered styles.
 	 *
 	 * @var WP_Style_Engine_Store|null
 	 */
 	private $registered_styles = array();
+
+	/**
+	 * A key to identify the store. Default value is 'global'.
+	 *
+	 * @var WP_Style_Engine_Store|null
+	 */
+	private $store_key = 'global-styles';
+
+	/**
+	 * Constructor.
+	 *
+	 * @param string $store_key A key/name/id to identify the store.
+	 * @return void
+	 */
+	public function __construct( $store_key = null ) {
+		if ( ! empty( $store_key ) ) {
+			$this->store_key = $store_key;
+		}
+	}
 
 	/**
 	 * Register a style
@@ -70,6 +70,8 @@ class WP_Style_Engine_Store implements WP_Style_Engine_Store_Interface {
 	 *
 	 * @param string $key Optional unique key for a $style_data object to return a single style object.
 	 * @param array? $style_data Associative array of style information.
+	 *
+	 * @return array Registered styles
 	 */
 	public function get( $key = null ) {
 		if ( isset( $this->registered_styles[ $key ] ) ) {
@@ -78,63 +80,3 @@ class WP_Style_Engine_Store implements WP_Style_Engine_Store_Interface {
 		return $this->registered_styles;
 	}
 }
-
-/*
-
-For each style category we could have a separate object:
-e.g.,
-
-$global_style_store = new WP_Style_Engine_Store();
-$block_supports_style_store = new WP_Style_Engine_Store();
-
-
-@TODO
-
-Work out enqueuing and rendering
-*/
-	/**
-	 * Prints registered styles in the page head or footer.
-	 *
-	 * @see $this->enqueue_block_support_styles
-
-	public function output_registered_block_support_styles() {
-		if ( empty( $this->registered_block_support_styles ) ) {
-			return;
-		}
-
-		$output = '';
-
-		foreach ( $this->registered_block_support_styles as $selector => $rules ) {
-				$output .= "\t$selector { ";
-				$output .= implode( ' ', $rules );
-				$output .= " }\n";
-		}
-
-		echo "<style>\n$output</style>\n";
-	} */
-
-	/**
-	 * Taken from gutenberg_enqueue_block_support_styles()
-	 *
-	 * This function takes care of adding inline styles
-	 * in the proper place, depending on the theme in use.
-	 *
-	 * For block themes, it's loaded in the head.
-	 * For classic ones, it's loaded in the body
-	 * because the wp_head action  happens before
-	 * the render_block.
-	 *
-	 * @see gutenberg_enqueue_block_support_styles()
-
-	private function enqueue_block_support_styles() {
-		$action_hook_name = 'wp_footer';
-		if ( wp_is_block_theme() ) {
-			$action_hook_name = 'wp_head';
-		}
-		add_action(
-			$action_hook_name,
-			array( $this, 'output_registered_block_support_styles' )
-		);
-	} */
-
-

--- a/packages/style-engine/class-wp-style-engine-store.php
+++ b/packages/style-engine/class-wp-style-engine-store.php
@@ -45,6 +45,9 @@ class WP_Style_Engine_Store {
 		if ( ! empty( $store_key ) ) {
 			$this->store_key = $store_key;
 		}
+
+		// Render engine for styles.
+		WP_Style_Engine_Renderer::enqueue_block_support_styles();
 	}
 
 	/**

--- a/packages/style-engine/class-wp-style-engine-store.php
+++ b/packages/style-engine/class-wp-style-engine-store.php
@@ -29,34 +29,50 @@ class WP_Style_Engine_Store {
 	private $registered_styles = array();
 
 	/**
+	 * Gather internals.
+	 */
+	public function __construct( $layers = array() ) {
+		foreach ( $layers as $layer ) {
+			$this->registered_styles[ $layer ] = array();
+		}
+	}
+
+	/**
 	 * Register a style
 	 *
+	 * @param string $layer Unique key for a layer.
 	 * @param string $key Unique key for a $style_data object.
 	 * @param array  $style_data Associative array of style information.
 	 * @return void
 	 */
-	public function register( $key, $style_data ) {
-		if ( empty( $key ) || empty( $style_data ) ) {
+	public function register( $layer, $key, $style_data ) {
+		if ( empty( $layer ) || empty( $key ) || empty( $style_data ) ) {
 			return;
 		}
 
-		if ( isset( $this->registered_styles[ $key ] ) ) {
-			$style_data = array_unique( array_merge( $this->registered_styles[ $key ], $style_data ) );
+		if ( isset( $this->registered_styles[ $layer ][ $key ] ) ) {
+			$style_data = array_unique( array_merge( $this->registered_styles[ $layer ][ $key ], $style_data ) );
 		}
-		$this->registered_styles[ $key ] = $style_data;
+		$this->registered_styles[ $layer ][ $key ] = $style_data;
 	}
 
 	/**
 	 * Retrieves style data from the store.
 	 *
+	 * @param string $layer Unique key for a layer.
 	 * @param string $key Optional unique key for a $style_data object to return a single style object.
 	 *
 	 * @return array Registered styles
 	 */
-	public function get( $key = null ) {
-		if ( isset( $this->registered_styles[ $key ] ) ) {
-			return $this->registered_styles[ $key ];
+	public function get( $layer = null, $key = null ) {
+		if ( isset( $this->registered_styles[ $layer ][ $key ] ) ) {
+			return $this->registered_styles[ $layer ][ $key ];
 		}
+
+		if ( isset( $this->registered_styles[ $layer ] ) ) {
+			return $this->registered_styles[ $layer ];
+		}
+
 		return $this->registered_styles;
 	}
 }

--- a/packages/style-engine/class-wp-style-engine-store.php
+++ b/packages/style-engine/class-wp-style-engine-store.php
@@ -29,28 +29,6 @@ class WP_Style_Engine_Store {
 	private $registered_styles = array();
 
 	/**
-	 * A key to identify the store. Default value is 'global'.
-	 *
-	 * @var WP_Style_Engine_Store|null
-	 */
-	private $store_key = 'global-styles';
-
-	/**
-	 * Constructor.
-	 *
-	 * @param string $store_key A key/name/id to identify the store.
-	 * @return void
-	 */
-	public function __construct( $store_key = null ) {
-		if ( ! empty( $store_key ) ) {
-			$this->store_key = $store_key;
-		}
-
-		// Render engine for styles.
-		WP_Style_Engine_Renderer::enqueue_block_support_styles();
-	}
-
-	/**
 	 * Register a style
 	 *
 	 * @param string $key Unique key for a $style_data object.
@@ -72,7 +50,6 @@ class WP_Style_Engine_Store {
 	 * Retrieves style data from the store.
 	 *
 	 * @param string $key Optional unique key for a $style_data object to return a single style object.
-	 * @param array? $style_data Associative array of style information.
 	 *
 	 * @return array Registered styles
 	 */

--- a/packages/style-engine/class-wp-style-engine-store.php
+++ b/packages/style-engine/class-wp-style-engine-store.php
@@ -43,23 +43,25 @@ class WP_Style_Engine_Store {
 	 * @param string $layer Unique key for a layer.
 	 * @param string $key Unique key for a $style_data object.
 	 * @param array  $style_data Associative array of style information.
-	 * @return void
+	 * @return boolean Whether registration was successful.
 	 */
 	public function register( $layer, $key, $style_data ) {
 		if ( empty( $layer ) || empty( $key ) || empty( $style_data ) ) {
-			return;
+			return false;
 		}
 
 		if ( isset( $this->registered_styles[ $layer ][ $key ] ) ) {
 			$style_data = array_unique( array_merge( $this->registered_styles[ $layer ][ $key ], $style_data ) );
 		}
 		$this->registered_styles[ $layer ][ $key ] = $style_data;
+		return true;
 	}
 
 	/**
-	 * Retrieves style data from the store.
+	 * Retrieves style data from the store. If neither $layer nor $key are provided,
+	 * this method will return everything in the store.
 	 *
-	 * @param string $layer Unique key for a layer.
+	 * @param string $layer Optional unique key for a layer to return all styles for a layer.
 	 * @param string $key Optional unique key for a $style_data object to return a single style object.
 	 *
 	 * @return array Registered styles

--- a/packages/style-engine/class-wp-style-engine.php
+++ b/packages/style-engine/class-wp-style-engine.php
@@ -31,6 +31,13 @@ class WP_Style_Engine {
 	private static $instance = null;
 
 	/**
+	 * Registered styles.
+	 *
+	 * @var WP_Style_Engine_Store|null
+	 */
+	private $block_supports_store = null;
+
+	/**
 	 * Style definitions that contain the instructions to
 	 * parse/output valid Gutenberg styles from a block's attributes.
 	 * For every style definition, the follow properties are valid:
@@ -216,6 +223,13 @@ class WP_Style_Engine {
 	);
 
 	/**
+	 * Gather internals.
+	 */
+	public function __construct() {
+		$this->block_supports_store = new WP_Style_Engine_Store( 'block_supports' );
+	}
+
+	/**
 	 * Utility method to retrieve the main instance of the class.
 	 *
 	 * The instance will be created if it does not exist yet.
@@ -228,6 +242,19 @@ class WP_Style_Engine {
 		}
 
 		return self::$instance;
+	}
+
+	/**
+	 * Global public interface to register block support styles support.
+	 *
+	 * @access private
+	 *
+	 * @param string $key Unique key for a $style_data object.
+	 * @param array  $style_data Associative array of style information.
+	 * @return void
+	 */
+	public function register_block_support_styles( $key, $style_data ) {
+		$this->block_supports_store->register( $key, $style_data );
 	}
 
 	/**
@@ -513,3 +540,21 @@ function wp_style_engine_generate( $block_styles, $options = array() ) {
 	}
 	return null;
 }
+
+// @TODO Just testing!
+/**
+ * Global public interface to register block support styles support.
+ *
+ * @access public
+ *
+ * @param string $key Unique key for a $style_data object.
+ * @param array  $style_data Associative array of style information.
+ * @return void
+ */
+function wp_style_engine_register_block_support_styles( $key, $style_data ) {
+	if ( class_exists( 'WP_Style_Engine' ) ) {
+		$style_engine = WP_Style_Engine::get_instance();
+		$style_engine->register_block_support_styles( $key, $style_data );
+	}
+}
+

--- a/packages/style-engine/class-wp-style-engine.php
+++ b/packages/style-engine/class-wp-style-engine.php
@@ -2,6 +2,7 @@
 /**
  * WP_Style_Engine
  *
+ * Singleton.
  * Generates classnames and block styles.
  *
  * @package Gutenberg
@@ -39,8 +40,11 @@ class WP_Style_Engine {
 
 	/**
 	 * An ordered list of style layers from least specific to most specific.
-	 * The layers loosely represent a cascade layer system.
+	 * The layers loosely represent a cascade layer system. See: https://developer.mozilla.org/en-US/docs/Web/CSS/@layer
 	 * The layer name will also be the key to retrieve the corresponding styles from the store.
+	 * Using a "store" for each layer of the style hierarchy, one can control the order in which they're rendered.
+	 *
+	 * @TODO are static, named layers dynamic enough? Or should we define numerically according specificity? E.g., @wp-layer-1?
 	 */
 	const STYLE_LAYERS = array(
 		'block-supports', // User-defined block-level overrides.
@@ -235,12 +239,9 @@ class WP_Style_Engine {
 	 * Gather internals.
 	 */
 	public function __construct() {
-		// @TODO not sure where to instantiate stuff or whether to dependency inject yet.
-		// The hope is to have several "stores" for each layer of the style hierarchy.
-		// This is so we can control the order in which we render.
-		// Each store might have a unique way to render on the frontend, maybe not.
+		// @TODO not sure where keep as singleton or whether to dependency inject yet.
 		$this->styles_store = new WP_Style_Engine_Store( self::STYLE_LAYERS );
-		WP_Style_Engine_Renderer::enqueue_block_support_styles();
+		WP_Style_Engine_Renderer::enqueue_registered_styles();
 	}
 
 	/**
@@ -280,7 +281,7 @@ class WP_Style_Engine {
 	 * @param string $layer Unique key for a layer.
 	 * @return array All registered block support styles.
 	 */
-	public function get_registered_styles( $layer ) {
+	public function get_registered_styles( $layer = null ) {
 		return $this->styles_store->get( $layer );
 	}
 

--- a/packages/style-engine/phpunit/class-wp-style-engine-test.php
+++ b/packages/style-engine/phpunit/class-wp-style-engine-test.php
@@ -7,6 +7,8 @@
  */
 
 require __DIR__ . '/../class-wp-style-engine.php';
+require __DIR__ . '/../class-wp-style-engine-store.php';
+require __DIR__ . '/../class-wp-style-engine-renderer.php';
 
 /**
  * Tests for registering, storing and generating styles.


### PR DESCRIPTION
WIP

## What?

Background context: https://github.com/WordPress/gutenberg/pull/40987#issuecomment-1139281230

## Why?

One of the aims is to be able to bundle output styles, and also open up the possibility of pre-processing, e.g., deduping

## How?

Creating separate methods to handle style registration, taking into account the various "levels" of styles e.g., global and block supports.

## Testing Instructions

Using Empty Theme:

<details>

<summary>Example</summary>

```html
<!-- wp:site-title {"style":{"elements":{"link":{"color":{"text":"var:preset|color|pale-pink"}}}}} /-->

<!-- wp:site-title {"style":{"elements":{"link":{"color":{"text":"var:preset|color|luminous-vivid-orange"}}}}} /-->

<!-- wp:site-title {"style":{"elements":{"link":{"color":{"text":"#adc63b"}}}}} /-->

<!-- wp:site-title {"style":{"elements":{"link":{"color":{"text":"#7a4857"}}}}} /-->

<!-- wp:site-title {"style":{"elements":{"link":{"color":{"text":"var:preset|color|light-green-cyan"}}}}} /-->

<!-- wp:site-title {"style":{"elements":{"link":{"color":{"text":"#8262b8"}}}}} /-->

<!-- wp:site-title {"style":{"elements":{"link":{"color":{"text":"var:preset|color|luminous-vivid-amber"}}}}} /-->

<!-- wp:site-title {"style":{"elements":{"link":{"color":{"text":"#40b876"}}}}} /-->

```

</details>


Instead of a `<style />` tag for each rule, we're collating them into one:


```html
	<style>
.wp-elements-6d26dce62e274fbec11380003187995e a { color: var(--wp--preset--color--pale-pink); }
.wp-elements-a6211bd0f50d510936cd495c9e6faf09 a { color: var(--wp--preset--color--luminous-vivid-orange); }
.wp-elements-22d4684938a5ddc0b4a8acf9de8f342c a { color: #adc63b; }
.wp-elements-ba2415e4f4b296c98a0588d746879f5e a { color: #7a4857; }
.wp-elements-ec2ade59a6ecee7bacbe0d1db8c47e65 a { color: var(--wp--preset--color--light-green-cyan); }
.wp-elements-f5f55867de2f30d0db781fb9ec6877b6 a { color: #8262b8; }
.wp-elements-413f8142f63e0ef2e72d3770f1ef248a a { color: var(--wp--preset--color--luminous-vivid-amber); }
.wp-elements-75e03a47eff33fd77f6c021bd12f9034 a { color: #40b876; }
</style>
```

The plan is to allow opt-in support for cascade layers as well:

```html
<style id='wp-styles-layers-inline-css'>
@layer block-supports;
@layer block-supports {
	.wp-elements-bcb267d41f505e6ed08295db66596d26 a {
		color: #b5a6c2;
	}
	.wp-elements-51918bcc051f54979165325dde6fb588 a {
		color: var(--wp--preset--color--vivid-red);
	}
	.wp-elements-18f8c54e1a82f75d4d71f249a8dd88f4 a {
		color: var(--wp--preset--color--luminous-vivid-amber);
	}
}
</style>
```