### PR TITLE
Show user's avatar in post author dropdown

### DIFF
--- a/packages/components/src/custom-select-control/index.js
+++ b/packages/components/src/custom-select-control/index.js
@@ -151,6 +151,15 @@ export default function CustomSelectControl( {
 					describedBy: getDescribedBy(),
 				} ) }
 			>
+				{ selectedItem.__experimentalImage && (
+					<img
+						className="components-custom-select-control__button-image"
+						alt=""
+						width={ 32 }
+						height={ 32 }
+						{ ...selectedItem.__experimentalImage }
+					/>
+				) }
 				{ itemToString( selectedItem ) }
 				<Icon
 					icon={ chevronDown }
@@ -179,6 +188,7 @@ export default function CustomSelectControl( {
 									{
 										'is-highlighted':
 											index === highlightedIndex,
+										'has-image': !! item.__experimentalImage,
 										'has-hint': !! item.__experimentalHint,
 										'is-next-36px-default-size': __next36pxDefaultSize,
 									}
@@ -186,6 +196,15 @@ export default function CustomSelectControl( {
 								style: item.style,
 							} ) }
 						>
+							{ item.__experimentalImage && (
+								<img
+									className="components-custom-select-control__item-image"
+									alt=""
+									width={ 32 }
+									height={ 32 }
+									{ ...item.__experimentalImage }
+								/>
+							) }
 							{ item.name }
 							{ item.__experimentalHint && (
 								<span className="components-custom-select-control__item-hint">

--- a/packages/components/src/custom-select-control/stories/index.js
+++ b/packages/components/src/custom-select-control/stories/index.js
@@ -87,3 +87,60 @@ WithHints.args = {
 		},
 	],
 };
+
+export const WithImages = CustomSelectControl.bind( {} );
+WithImages.args = {
+	...Default.args,
+	options: [
+		{
+			key: 'adam',
+			name: 'Adam Zielinski',
+			__experimentalImage: {
+				src:
+					'https://www.gravatar.com/avatar/3b7ea537531208d83deed8f3e78bc771?s=100&r=g',
+				width: 48,
+				height: 48,
+			},
+		},
+		{
+			key: 'greg',
+			name: 'Greg Ziółkowski',
+			__experimentalImage: {
+				src:
+					'https://www.gravatar.com/avatar/475d323ceec2e73597729eef1c5bf263?s=100&r=g',
+				width: 48,
+				height: 48,
+			},
+		},
+		{
+			key: 'robert',
+			name: 'Robert Anderson',
+			__experimentalImage: {
+				src:
+					'https://www.gravatar.com/avatar/c9ae983c4a94490f209c06dd46b801e4?s=100&r=g',
+				width: 48,
+				height: 48,
+			},
+		},
+		{
+			key: 'george',
+			name: 'George Mamadashvili',
+			__experimentalImage: {
+				src:
+					'https://www.gravatar.com/avatar/ddda3dc3a8502b3e1889905a9d500f3f?s=100&r=g',
+				width: 48,
+				height: 48,
+			},
+		},
+		{
+			key: 'isabel',
+			name: 'Isabel Brison',
+			__experimentalImage: {
+				src:
+					'https://www.gravatar.com/avatar/0236f3f6facfcca37aa798f9c6766116?s=100&r=g',
+				width: 48,
+				height: 48,
+			},
+		},
+	],
+};

--- a/packages/components/src/custom-select-control/style.scss
+++ b/packages/components/src/custom-select-control/style.scss
@@ -21,6 +21,8 @@
 	// For all button sizes allow sufficient space for the
 	// dropdown "arrow" icon to display.
 	&.components-custom-select-control__button {
+		padding-top: $grid-unit-05;
+		padding-bottom: $grid-unit-05;
 		// TODO: Some of these can be removed after some internal inconsistencies are addressed, such as the chevron
 		// (https://github.com/WordPress/gutenberg/issues/39400) and Button padding (https://github.com/WordPress/gutenberg/issues/39431)
 		padding-left: $grid-unit-20;
@@ -35,6 +37,12 @@
 	&:focus:not(:disabled) {
 		border-color: var(--wp-admin-theme-color);
 		box-shadow: 0 0 0 ($border-width-focus - $border-width) var(--wp-admin-theme-color);
+	}
+
+	.components-custom-select-control__button-image {
+		max-height: 100%;
+		width: auto;
+		margin-right: $grid-unit-05;
 	}
 
 	.components-custom-select-control__button-icon {
@@ -74,7 +82,7 @@
 .components-custom-select-control__item {
 	align-items: center;
 	display: grid;
-	grid-template-columns: auto auto;
+	grid-template-columns: auto 30px;
 	list-style-type: none;
 	padding: $grid-unit-10 $grid-unit-20;
 	cursor: default;
@@ -84,11 +92,24 @@
 		padding: $grid-unit-10;
 	}
 
+	&.has-image {
+		grid-template-columns: max-content auto 30px;
+	}
 	&.has-hint {
 		grid-template-columns: auto auto 30px;
 	}
+	&.has-image.has-hint {
+		grid-template-columns: max-content auto auto 30px;
+	}
+
 	&.is-highlighted {
 		background: $gray-300;
+	}
+
+	.components-custom-select-control__item-image {
+		max-height: $button-size - $grid-unit-05 * 2 - $border-width * 2;
+		width: auto;
+		margin-right: $grid-unit-05;
 	}
 	.components-custom-select-control__item-hint {
 		color: $gray-700;

--- a/packages/editor/src/components/post-author/constants.js
+++ b/packages/editor/src/components/post-author/constants.js
@@ -1,6 +1,6 @@
 export const AUTHORS_QUERY = {
 	who: 'authors',
 	per_page: 50,
-	_fields: 'id,name',
+	_fields: 'id,name,avatar_urls',
 	context: 'view', // Allows non-admins to perform requests.
 };

--- a/packages/editor/src/components/post-author/select.js
+++ b/packages/editor/src/components/post-author/select.js
@@ -5,7 +5,7 @@ import { __ } from '@wordpress/i18n';
 import { useMemo } from '@wordpress/element';
 import { useSelect, useDispatch } from '@wordpress/data';
 import { decodeEntities } from '@wordpress/html-entities';
-import { SelectControl } from '@wordpress/components';
+import { CustomSelectControl } from '@wordpress/components';
 import { store as coreStore } from '@wordpress/core-data';
 
 /**
@@ -27,25 +27,34 @@ function PostAuthorSelect() {
 
 	const authorOptions = useMemo( () => {
 		return ( authors ?? [] ).map( ( author ) => {
+			const [ avatarSize, avatarURL ] = Object.entries(
+				author.avatar_urls
+			).find( ( [ size ] ) => size >= 26 * 2 );
 			return {
-				value: author.id,
-				label: decodeEntities( author.name ),
+				key: author.id,
+				name: decodeEntities( author.name ),
+				__experimentalImage: {
+					src: avatarURL,
+					width: avatarSize / 2,
+					height: avatarSize / 2,
+				},
 			};
 		} );
 	}, [ authors ] );
 
-	const setAuthorId = ( value ) => {
-		const author = Number( value );
+	const setAuthorId = ( option ) => {
+		const author = Number( option.key );
 		editPost( { author } );
 	};
 
 	return (
-		<SelectControl
-			className="post-author-selector"
+		<CustomSelectControl
+			className="editor-post-author-select"
 			label={ __( 'Author' ) }
 			options={ authorOptions }
 			onChange={ setAuthorId }
-			value={ postAuthor }
+			value={ authorOptions.find( ( { key } ) => key === postAuthor ) }
+			__next36pxDefaultSize
 		/>
 	);
 }

--- a/packages/editor/src/components/post-author/style.scss
+++ b/packages/editor/src/components/post-author/style.scss
@@ -1,0 +1,4 @@
+.editor-post-author-select,
+.editor-post-author-select .components-custom-select-control__button {
+	width: 100%;
+}

--- a/packages/editor/src/style.scss
+++ b/packages/editor/src/style.scss
@@ -4,6 +4,7 @@
 @import "./components/entities-saved-states/style.scss";
 @import "./components/error-boundary/style.scss";
 @import "./components/page-attributes/style.scss";
+@import "./components/post-author/style.scss";
 @import "./components/post-excerpt/style.scss";
 @import "./components/post-featured-image/style.scss";
 @import "./components/post-format/style.scss";


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Quick go at updating `CustomSelectControl` to allow an image to be shown alongside each option and updating the _Author_ dropdown in the post inspector to show user avatars.

## Why?
Part of https://github.com/WordPress/gutenberg/issues/39082.

Based on the mockup in https://github.com/WordPress/gutenberg/issues/40281#issuecomment-1106243892.

Originally we were going to create an _Author_ popover but I think it's worth exploring a dropdown with avatar images as a simpler alternative.

## How?
- Updates `CustomSelectControl` to accept an `image` attribute in each of the options given to `options`. This `image` attribute can be set to an object containing `src`, `width`, `height`, etc.
- Updates `PostAuthor` to use `CustomSelectControl` and display user avatars.
- If the site has more than 25 users, a combobox will be shown instead of a dropdown. We could look at making similar changes to `ComboboxControl` if we want to show avatars there too? Or maybe _this_ is when we use a popover?

## Testing Instructions
1. Create a post.
2. Open the post settings sidebar.
3. Look at the _Author_ control.

Also have a look at the new storybook added for `CustomSelectControl`.

## Screenshots or screencast 
https://user-images.githubusercontent.com/612155/170939326-6bcfd85e-8cd2-4ce0-8e26-40da327aa985.mp4