### PR TITLE
Try/add missing typography support to button block

### DIFF
--- a/docs/reference-guides/core-blocks.md
+++ b/docs/reference-guides/core-blocks.md
@@ -50,7 +50,7 @@ Prompt visitors to take action with a button-style link. ([Source](https://githu
 
 -	**Name:** core/button
 -	**Category:** design
--	**Supports:** align, anchor, color (background, gradients, text), spacing (padding), typography (fontSize), ~~alignWide~~, ~~reusable~~
+-	**Supports:** align, anchor, color (background, gradients, text), spacing (padding), typography (fontSize, lineHeight), ~~alignWide~~, ~~reusable~~
 -	**Attributes:** backgroundColor, gradient, linkTarget, placeholder, rel, text, textColor, title, url, width
 
 ## Buttons

--- a/docs/reference-guides/core-blocks.md
+++ b/docs/reference-guides/core-blocks.md
@@ -50,7 +50,7 @@ Prompt visitors to take action with a button-style link. ([Source](https://githu
 
 -	**Name:** core/button
 -	**Category:** design
--	**Supports:** align, anchor, color (background, gradients, text), spacing (padding), typography (fontSize, lineHeight), ~~alignWide~~, ~~reusable~~
+-	**Supports:** align, anchor, color (background, gradients, text), spacing (padding), typography (fontSize), ~~alignWide~~, ~~reusable~~
 -	**Attributes:** backgroundColor, gradient, linkTarget, placeholder, rel, text, textColor, title, url, width
 
 ## Buttons

--- a/packages/block-library/src/button/block.json
+++ b/packages/block-library/src/button/block.json
@@ -69,6 +69,10 @@
 		"typography": {
 			"fontSize": true,
 			"__experimentalFontFamily": true,
+			"lineHeight": true,
+			"__experimentalFontStyle": true,
+			"__experimentalFontWeight": true,
+			"__experimentalLetterSpacing": true,
 			"__experimentalTextTransform": true,
 			"__experimentalDefaultControls": {
 				"fontSize": true

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -1,6 +1,5 @@
 {
 	"compilerOptions": {
-		"baseUrl": ".",
 		"allowJs": true,
 		"checkJs": true,
 		"allowSyntheticDefaultImports": true,
@@ -13,9 +12,7 @@
 		"composite": true,
 		"emitDeclarationOnly": true,
 		"isolatedModules": true,
-		"paths": {
-			"csstype": ["./node_modules/csstype/"]
-		  },
+
 		/* Strict Type-Checking Options */
 		"strict": true,
 

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -1,5 +1,6 @@
 {
 	"compilerOptions": {
+		"baseUrl": ".",
 		"allowJs": true,
 		"checkJs": true,
 		"allowSyntheticDefaultImports": true,
@@ -12,7 +13,9 @@
 		"composite": true,
 		"emitDeclarationOnly": true,
 		"isolatedModules": true,
-
+		"paths": {
+			"csstype": ["./node_modules/csstype/"]
+		  },
 		/* Strict Type-Checking Options */
 		"strict": true,
 


### PR DESCRIPTION
This PR adds some missing typography supports to button block, which are already available in Gutenberg. 
It enables following Editor UI under typography settings

- Line height
- Letter spacing
- Font style
- Font weight

![button](https://user-images.githubusercontent.com/98376250/159480455-a7b416e7-4996-4bc9-a889-52d6ac4deba1.png)

With the help of this PR block theme developers and website admin will have more customization options to create more beautiful website and design patterns. 
In some places, designers require to have different typography as compare to global typography like font-family, font-weight, line-height etc. to create unique designs. 
In the absence of these typography settings on block level, block theme developers are rely on custom css for these typography options which are not editable by website admin using frontend editor tools. So this PR will provide more flexibility and help admin to get more controls over design and UI elements.

Testing Steps
1. Activate Twenty Twenty-Two theme
2. Add a new page
3. Add a button
4. Add Line height, Letter spacing, Text transform, Font style and Font weight to the button
5. Publish the page 
6. View and check the page for assigned typography options 

Please check this [screen-cast](https://app.usebubbles.com/tY4CcWhrrUzWa6KafMmP7A/typography-supports-to-button-heading-and-paragraph-blocks)
