### PR TITLE
Scripts:  plugin-zip to include root path files

### DIFF
--- a/packages/scripts/CHANGELOG.md
+++ b/packages/scripts/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Bug Fix
+
+-   Fix incorrect handling in `plugin-zip` for root-level files and some specific platform conditions ([#41439](https://github.com/WordPress/gutenberg/pull/41439)).
+
 ## 23.1.0 (2022-05-18)
 
 ### New Feature

--- a/packages/scripts/scripts/plugin-zip.js
+++ b/packages/scripts/scripts/plugin-zip.js
@@ -49,7 +49,8 @@ if ( hasPackageProp( 'files' ) ) {
 
 files.forEach( ( file ) => {
 	stdout.write( `  Adding \`${ file }\`.\n` );
-	zip.addLocalFile( file, dirname( file ) );
+	const zipDirectory = dirname( file );
+	zip.addLocalFile( file, zipDirectory !== '.' ? zipDirectory : '' );
 } );
 
 zip.writeZip( `./${ name }.zip` );


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->
In some special conditions, plugin-zip was not adding root path files as part of zip.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
Fixes: #40528 

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
Add condition to avoid prefix `.` in the path of root files.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->
1. Generate the [Gutenride plugin](https://developer.wordpress.org/block-editor/getting-started/create-block/wp-plugin/#generate-plugin-files)
```console
$ npx @wordpress/create-block gutenpride
```

2. Move into the plugin folder
``` console
$ cd gutenpride
```

3. Create the zip file
```console
$ npm run plugin-zip

> gutenpride@0.1.0 plugin-zip
> wp-scripts plugin-zip

Creating archive for `gutenpride` plugin... 🎁

Using Plugin Handbook best practices to discover files:

  Adding `gutenpride.php`.
  Adding `readme.txt`.
  Adding `build/block.json`.
  Adding `build/index.asset.php`.
  Adding `build/index.css`.
  Adding `build/index.js`.
  Adding `build/style-index.css`.

Done. `gutenpride.zip` is ready! 🎉
```

4. List files in archive
```
$ unzip -l gutenpride.zip 
Archive:  gutenpride.zip
  Length      Date    Time    Name
---------  ---------- -----   ----
      885  2022-04-25 11:12   gutenpride.php
     1826  2022-04-25 11:12   readme.txt
      446  2022-04-25 11:13   build/block.json
      150  2022-04-25 11:13   build/index.asset.php
       57  2022-04-25 11:13   build/index.css
     1513  2022-04-25 11:13   build/index.js
       83  2022-04-25 11:13   build/style-index.css
---------                     -------
     4960                     7 files
```
## Screenshots or screencast <!-- if applicable -->
