### PR TITLE
Block styles: Account for style block nodes that have no name

### DIFF
--- a/lib/compat/wordpress-6.1/get-global-styles-and-settings.php
+++ b/lib/compat/wordpress-6.1/get-global-styles-and-settings.php
@@ -9,7 +9,7 @@
  * Adds global style rules to the inline style for each block.
  */
 function wp_add_global_styles_for_blocks() {
-	$tree = WP_Theme_JSON_Resolver_Gutenberg::get_merged_data();
+	$tree        = WP_Theme_JSON_Resolver_Gutenberg::get_merged_data();
 	$block_nodes = $tree->get_styles_block_nodes();
 	foreach ( $block_nodes as $metadata ) {
 		$block_css = $tree->get_styles_for_block( $metadata );

--- a/lib/compat/wordpress-6.1/get-global-styles-and-settings.php
+++ b/lib/compat/wordpress-6.1/get-global-styles-and-settings.php
@@ -10,14 +10,35 @@
  */
 function wp_add_global_styles_for_blocks() {
 	$tree = WP_Theme_JSON_Resolver_Gutenberg::get_merged_data();
-	// TODO some nodes dont have a name...
 	$block_nodes = $tree->get_styles_block_nodes();
 	foreach ( $block_nodes as $metadata ) {
-		$block_css  = $tree->get_styles_for_block( $metadata );
-		$block_name = str_replace( 'core/', '', $metadata['name'] );
-		// These block styles are added on block_render.
-		// This hooks inline CSS to them so that they are loaded conditionally
-		// based on whether or not the block is used on the page.
-		wp_add_inline_style( 'wp-block-' . $block_name, $block_css );
+		$block_css = $tree->get_styles_for_block( $metadata );
+
+		if ( isset( $metadata['name'] ) ) {
+			$block_name = str_replace( 'core/', '', $metadata['name'] );
+			// These block styles are added on block_render.
+			// This hooks inline CSS to them so that they are loaded conditionally
+			// based on whether or not the block is used on the page.
+			wp_add_inline_style( 'wp-block-' . $block_name, $block_css );
+		}
+
+		// The likes of block element styles from theme.json do not have  $metadata['name'] set.
+		if ( ! isset( $metadata['name'] ) && ! empty( $metadata['path'] ) ) {
+			$result = array_values(
+				array_filter(
+					$metadata['path'],
+					function ( $item ) {
+						if ( strpos( $item, 'core/' ) !== false ) {
+							return true;
+						}
+						return false;
+					}
+				)
+			);
+			if ( isset( $result[0] ) ) {
+				$block_name = str_replace( 'core/', '', $result[0] );
+				wp_add_inline_style( 'wp-block-' . $block_name, $block_css );
+			}
+		}
 	}
 }


### PR DESCRIPTION
## What?
Adds processing of block style nodes with no name to `wp_add_global_styles_for_blocks`.

## Why?
Since https://github.com/WordPress/gutenberg/pull/41160 was merged style block nodes with no name, eg. block element styles from theme.json, are not getting inline styles added in the frontend.
Fixes:  #41443

## How?
Processes nodes that have no name, but have a path.

## To test

- In a block based theme add the following to `theme.json` styles.blocks section

```
			"core/columns": {
				"elements": {
					"h2": {
						"color": {
							"text": "red",
							"background": "black"
						},
						"typography": {
							"fontSize": "var(--wp--preset--font-size--small)"
						}
					}
				}
			}
```

- Add a columns block and within it nest an `h2` header, and see if it displays with black background and red text in editor and frontend.

### Screenshots, screen recording, code snippet

Before #41160 :
<img width="422" alt="Screen Shot 2022-05-31 at 12 30 02 PM" src="https://user-images.githubusercontent.com/3629020/171072808-5a5e1846-3002-43fa-b1c2-d74442383169.png">

After:
<img width="314" alt="Screen Shot 2022-05-31 at 12 32 24 PM" src="https://user-images.githubusercontent.com/3629020/171072821-d429bc48-b34d-46f3-aa90-d008488c24c1.png">

