### PR TITLE
Preferences Panel: Filters hidden blocks to only count those which are still registered

### DIFF
--- a/packages/edit-post/src/components/block-manager/index.js
+++ b/packages/edit-post/src/components/block-manager/index.js
@@ -117,12 +117,18 @@ export default withSelect( ( select ) => {
 		isMatchingSearchTerm,
 	} = select( blocksStore );
 	const { getHiddenBlockTypes } = select( editPostStore );
-	const hiddenBlockTypes = getHiddenBlockTypes();
+
+	const blockTypes = getBlockTypes();
+	const hiddenBlockTypes = getHiddenBlockTypes().filter( ( hiddenBlock ) => {
+		return blockTypes.some(
+			( registeredBlock ) => registeredBlock.name === hiddenBlock
+		);
+	} );
 	const numberOfHiddenBlocks =
 		isArray( hiddenBlockTypes ) && hiddenBlockTypes.length;
 
 	return {
-		blockTypes: getBlockTypes(),
+		blockTypes,
 		categories: getCategories(),
 		hasBlockSupport,
 		isMatchingSearchTerm,

--- a/packages/edit-post/src/components/block-manager/index.js
+++ b/packages/edit-post/src/components/block-manager/index.js
@@ -118,6 +118,11 @@ export default withSelect( ( select ) => {
 	} = select( blocksStore );
 	const { getHiddenBlockTypes } = select( editPostStore );
 
+	// Some hidden blocks become unregistered
+	// by removing for instance the plugin that registered them, yet
+	// they're still remain as hidden by the user's action.
+	// We consider "hidden", blocks which were hidden and
+	// are still registered.
 	const blockTypes = getBlockTypes();
 	const hiddenBlockTypes = getHiddenBlockTypes().filter( ( hiddenBlock ) => {
 		return blockTypes.some(


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Fixes #33670.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

When uninstalling plugins that provide blocks their setting as hidden should be ignored.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

Filter the hidden blocks through the list of registered blocks.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->

1. Add a plugin that has a block collection
2. Uncheck the visibility for the blocks from the plugin
3. Disable/uninstall the plugin
4. The block manager should not show hidden blocks message

## Screenshots or screencast <!-- if applicable -->

https://user-images.githubusercontent.com/107534/171164774-a42f2761-721e-465a-ab39-2f081c5b38d4.mp4


