### PR TITLE
[Block Editor]: Fix block variation registration when `icon` is an `object` and contains `transform` scope

### DIFF
--- a/packages/block-editor/src/components/block-variation-transforms/index.js
+++ b/packages/block-editor/src/components/block-variation-transforms/index.js
@@ -34,7 +34,7 @@ function VariationsButtons( {
 			{ variations.map( ( variation ) => (
 				<Button
 					key={ variation.name }
-					icon={ <BlockIcon icon={ variation.icon } /> }
+					icon={ <BlockIcon icon={ variation.icon } showColors /> }
 					isPressed={ selectedValue === variation.name }
 					label={
 						selectedValue === variation.name

--- a/packages/block-editor/src/components/block-variation-transforms/index.js
+++ b/packages/block-editor/src/components/block-variation-transforms/index.js
@@ -17,6 +17,7 @@ import { chevronDown } from '@wordpress/icons';
 /**
  * Internal dependencies
  */
+import BlockIcon from '../block-icon';
 import { store as blockEditorStore } from '../../store';
 
 function VariationsButtons( {
@@ -33,7 +34,7 @@ function VariationsButtons( {
 			{ variations.map( ( variation ) => (
 				<Button
 					key={ variation.name }
-					icon={ variation.icon }
+					icon={ <BlockIcon icon={ variation.icon } /> }
 					isPressed={ selectedValue === variation.name }
 					label={
 						selectedValue === variation.name
@@ -126,7 +127,7 @@ function __experimentalBlockVariationTransforms( { blockClientId } ) {
 		}
 		variations.forEach( ( variation ) => {
 			if ( variation.icon ) {
-				variationIcons.add( variation.icon );
+				variationIcons.add( variation.icon?.src || variation.icon );
 			}
 		} );
 		return variationIcons.size === variations.length;


### PR DESCRIPTION


<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Fixes: https://github.com/WordPress/gutenberg/issues/41453
Introduced in: https://github.com/WordPress/gutenberg/pull/40036
<!-- In a few words, what is the PR actually doing? -->

## Why?
Currently if we register a block variation with an `object` `icon` and include `transform` in `scope`, there is a check to show only `icons` in the block variations transform control in inspector controls, which breaks the editor. We don't take into account that the `icon` can be an `object` so I updated the code to use `BlockIcon` which does and seems a better choice either way for this use case.

## Testing Instructions
1. In the editor open the `console` and add the below snippet
2. Then add a `Group` block and observe that in inspector controls show the variation's icon. 

### Snippet to add in console
```
wp.blocks.registerBlockVariation(
	'core/group',
	{
		name: 'custom-group',
		title: 'Custom Group',
		icon: { src: 'email', foreground: '#ff0000' },
		scope: [ 'block', 'inserter', 'transform' ]
	},
);
```

#### Before

https://user-images.githubusercontent.com/16275880/171186148-a1f1c643-8c8d-48aa-8872-8d444768041d.mov



#### After

https://user-images.githubusercontent.com/16275880/171186174-2fdcdca3-bc9a-43be-ba4c-23532cd131f8.mov


