### PR TITLE
Components: refactor `DateDayPicker` to pass `exhaustive-deps`

### DIFF
--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -30,8 +30,7 @@
 -   `BoxControl`: Update unit tests to use `@testing-library/user-event` ([#41422](https://github.com/WordPress/gutenberg/pull/41422)).
 -   `Surface`: Convert to TypeScript ([#41212](https://github.com/WordPress/gutenberg/pull/41212)).
 -   `Autocomplete` updated to satisfy `react/exhuastive-deps` eslint rule ([#41382](https://github.com/WordPress/gutenberg/pull/41382))
--   `DateDayPicker`: Update unit tests to use `@testing-library/user-event` ([#41470](https://github.com/WordPress/gutenberg/pull/41470)).
-
+-   `DateDayPicker` updated to satisfy `react/exhuastive-deps` eslint rule ([#41470](https://github.com/WordPress/gutenberg/pull/41470)).
 ### Experimental
 
 -   `Spacer`: Add RTL support. ([#41172](https://github.com/WordPress/gutenberg/pull/41172))

--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -30,6 +30,7 @@
 -   `BoxControl`: Update unit tests to use `@testing-library/user-event` ([#41422](https://github.com/WordPress/gutenberg/pull/41422)).
 -   `Surface`: Convert to TypeScript ([#41212](https://github.com/WordPress/gutenberg/pull/41212)).
 -   `Autocomplete` updated to satisfy `react/exhuastive-deps` eslint rule ([#41382](https://github.com/WordPress/gutenberg/pull/41382))
+-   `DateDayPicker`: Update unit tests to use `@testing-library/user-event` ([#41470](https://github.com/WordPress/gutenberg/pull/41470)).
 
 ### Experimental
 

--- a/packages/components/src/date-time/date/index.tsx
+++ b/packages/components/src/date-time/date/index.tsx
@@ -64,7 +64,7 @@ function DatePickerDay( { day, events = [] }: DatePickerDayProps ) {
 		);
 
 		parentNode.setAttribute( 'aria-label', dayWithEventsDescription );
-	}, [ events.length ] );
+	}, [ day, events.length ] );
 
 	return (
 		<Day


### PR DESCRIPTION
## What?
Updates the `DateDayPicker` component to satisfy the `exhaustive-deps` eslint rule (specifically by updating the `ControlPoints` subcomponent)

## Why?
Part of the effort in https://github.com/WordPress/gutenberg/pull/41166 to apply `exhuastive-deps` to the Components package

## How?

add the `day` prop to the `useEffect` dependency array

## Testing Instructions
1. From your local Gutenberg directory, run `npx eslint --rule 'react-hooks/exhaustive-deps: warn' packages/components/src/date-time`
2. Confirm that the linter returns no errors
3. Confirm unit tests still pass
4. Test the component in Storybook, confirm stories and/or docs still work as expected


