### PR TITLE
Experiment with Comments Hydration

### DIFF
--- a/packages/block-library/src/comment-template/index.php
+++ b/packages/block-library/src/comment-template/index.php
@@ -119,7 +119,7 @@ function render_block_core_comment_template( $attributes, $content, $block ) {
 	);
 
 	$empty_template = sprintf( $template_wrapper, '' );
-	$template = sprintf( $template_wrapper, sprintf( $block_wrapper, $actual_block . $empty_template ) );
+	$template       = sprintf( $template_wrapper, sprintf( $block_wrapper, $actual_block . $empty_template ) );
 	return sprintf( $block_wrapper, $actual_block . $template );
 }
 

--- a/packages/block-library/src/comment-template/index.php
+++ b/packages/block-library/src/comment-template/index.php
@@ -101,11 +101,16 @@ function render_block_core_comment_template( $attributes, $content, $block ) {
 
 	$wrapper_attributes = get_block_wrapper_attributes();
 
-	return sprintf(
+	$block_wrapper = sprintf( '<gutenberg-interactive-block data-gutenberg-block-type="%1$s" data-gutenberg-hydrate="idle" data-gutenberg-context-used="%2$s">', $block->name, json_encode( $block->context ) );
+
+	$actual_block = sprintf(
 		'<ol %1$s>%2$s</ol>',
 		$wrapper_attributes,
 		block_core_comment_template_render_comments( $comments, $block )
 	);
+
+	$template = '<template class="gutenberg-inner-blocks">' . $block_wrapper . $actual_block . '<template class="gutenberg-inner-blocks"></template>' . '</gutenberg-interactive-block>' . '</template>';
+	return $block_wrapper . $actual_block . $template . '</gutenberg-interactive-block>';
 }
 
 /**

--- a/packages/block-library/src/comment-template/index.php
+++ b/packages/block-library/src/comment-template/index.php
@@ -101,7 +101,14 @@ function render_block_core_comment_template( $attributes, $content, $block ) {
 
 	$wrapper_attributes = get_block_wrapper_attributes();
 
-	$block_wrapper = sprintf( '<gutenberg-interactive-block data-gutenberg-block-type="%1$s" data-gutenberg-hydrate="idle" data-gutenberg-context-used="%2$s">', $block->name, json_encode( $block->context ) );
+	$block_wrapper = sprintf(
+		'<gutenberg-interactive-block ' .
+		'data-gutenberg-block-type="%1$s" ' .
+		'data-gutenberg-hydrate="idle" ' .
+		'data-gutenberg-context-used="%2$s">',
+		$block->name,
+		json_encode( $block->context )
+	);
 
 	$actual_block = sprintf(
 		'<ol %1$s>%2$s</ol>',

--- a/packages/block-library/src/comment-template/index.php
+++ b/packages/block-library/src/comment-template/index.php
@@ -119,7 +119,8 @@ function render_block_core_comment_template( $attributes, $content, $block ) {
 	);
 
 	$empty_template = sprintf( $template_wrapper, '' );
-	return sprintf( $template_wrapper, sprintf( $block_wrapper, $actual_block . $empty_template ) );
+	$template = sprintf( $template_wrapper, sprintf( $block_wrapper, $actual_block . $empty_template ) );
+	return sprintf( $block_wrapper, $actual_block . $template );
 }
 
 /**

--- a/packages/block-library/src/comment-template/index.php
+++ b/packages/block-library/src/comment-template/index.php
@@ -108,7 +108,9 @@ function render_block_core_comment_template( $attributes, $content, $block ) {
 		'data-gutenberg-context-used="%2$s">',
 		$block->name,
 		json_encode( $block->context )
-	);
+	) . '%1$s</gutenberg-interactive-block>';
+
+	$template_wrapper = '<template class="gutenberg-inner-blocks">%1$s</template>';
 
 	$actual_block = sprintf(
 		'<ol %1$s>%2$s</ol>',
@@ -116,8 +118,8 @@ function render_block_core_comment_template( $attributes, $content, $block ) {
 		block_core_comment_template_render_comments( $comments, $block )
 	);
 
-	$template = '<template class="gutenberg-inner-blocks">' . $block_wrapper . $actual_block . '<template class="gutenberg-inner-blocks"></template>' . '</gutenberg-interactive-block>' . '</template>';
-	return $block_wrapper . $actual_block . $template . '</gutenberg-interactive-block>';
+	$empty_template = sprintf( $template_wrapper, '' );
+	return sprintf( $template_wrapper, sprintf( $block_wrapper, $actual_block . $empty_template ) );
 }
 
 /**


### PR DESCRIPTION
## What?
Experiment to enable frontend block hydration for some Comments blocks (early WIP). Resulting from a pair-programming session with @c4rl0sbr4v0.


Needs https://github.com/WordPress/block-hydration-experiments.

## Why?
See https://github.com/WordPress/block-hydration-experiments for some background 🙂 

## How?
By trying to add the relevant Custom Element wrappers to the Comment Template block's PHP.

## Testing Instructions
- Have a local copy of the https://github.com/WordPress/[block-hydration-experiments](https://github.com/WordPress/block-hydration-experiments) repo in a directory next to Gutenberg's.
- Add a `.wp-env.override.json` file to that repo, with the following contents:

```json
{
        "plugins": [".", "../gutenberg"]
}
```

- From the `block-hydration-experiments` directory, run
 
```
npm i
npm run build
npm run wp-env start
```

- Navigate to `localhost:8888/wp-admin` as usual to access your local test site. Verify in the plugins section that both the Gutenberg and "Block Hydration Experiments" plugin are active.
- Create a new post and insert the Comments block.
- Publish and view the post.
- (To be continued, not quite working yet.)

## TODO

- [ ] Make this work (hydration doesn't seem to be run currently).
- [ ] Make it so that submitting a new comment uses the Comment Template block to render that comment instantly.
  - [ ] We'll need to figure out some sort of interface to directly pass information to the block that doesn't rely on a comment ID passed via context.

cc/ @WordPress/frontend-dx 🙂 
