### PR TITLE
Adds featured image toggle to media replace flow

### DIFF
--- a/packages/block-editor/src/components/media-replace-flow/index.js
+++ b/packages/block-editor/src/components/media-replace-flow/index.js
@@ -46,7 +46,7 @@ const MediaReplaceFlow = ( {
 	onError,
 	onSelect,
 	onSelectURL,
-	onSelectFeaturedImage,
+	onToggleFeaturedImage,
 	useFeaturedImage,
 	onFilesUpload = noop,
 	name = __( 'Replace' ),
@@ -88,6 +88,9 @@ const MediaReplaceFlow = ( {
 	};
 
 	const selectMedia = ( media, closeMenu ) => {
+		if ( useFeaturedImage && onToggleFeaturedImage ) {
+			onToggleFeaturedImage();
+		}
 		closeMenu();
 		setMediaURLValue( media?.url );
 		// Calling `onSelect` after the state update since it might unmount the component.
@@ -155,53 +158,51 @@ const MediaReplaceFlow = ( {
 			renderContent={ ( { onClose } ) => (
 				<>
 					<NavigableMenu className="block-editor-media-replace-flow__media-upload-menu">
-						{ ! useFeaturedImage && (
-							<>
-								<MediaUpload
-									gallery={ gallery }
-									addToGallery={ addToGallery }
+						<>
+							<MediaUpload
+								gallery={ gallery }
+								addToGallery={ addToGallery }
+								multiple={ multiple }
+								value={ multiple ? mediaIds : mediaId }
+								onSelect={ ( media ) =>
+									selectMedia( media, onClose )
+								}
+								allowedTypes={ allowedTypes }
+								render={ ( { open } ) => (
+									<MenuItem
+										icon={ mediaIcon }
+										onClick={ open }
+									>
+										{ __( 'Open Media Library' ) }
+									</MenuItem>
+								) }
+							/>
+							<MediaUploadCheck>
+								<FormFileUpload
+									onChange={ ( event ) => {
+										uploadFiles( event, onClose );
+									} }
+									accept={ accept }
 									multiple={ multiple }
-									value={ multiple ? mediaIds : mediaId }
-									onSelect={ ( media ) =>
-										selectMedia( media, onClose )
-									}
-									allowedTypes={ allowedTypes }
-									render={ ( { open } ) => (
-										<MenuItem
-											icon={ mediaIcon }
-											onClick={ open }
-										>
-											{ __( 'Open Media Library' ) }
-										</MenuItem>
-									) }
+									render={ ( { openFileDialog } ) => {
+										return (
+											<MenuItem
+												icon={ upload }
+												onClick={ () => {
+													openFileDialog();
+												} }
+											>
+												{ __( 'Upload' ) }
+											</MenuItem>
+										);
+									} }
 								/>
-								<MediaUploadCheck>
-									<FormFileUpload
-										onChange={ ( event ) => {
-											uploadFiles( event, onClose );
-										} }
-										accept={ accept }
-										multiple={ multiple }
-										render={ ( { openFileDialog } ) => {
-											return (
-												<MenuItem
-													icon={ upload }
-													onClick={ () => {
-														openFileDialog();
-													} }
-												>
-													{ __( 'Upload' ) }
-												</MenuItem>
-											);
-										} }
-									/>
-								</MediaUploadCheck>
-							</>
-						) }
-						{ onSelectFeaturedImage && (
+							</MediaUploadCheck>
+						</>
+						{ onToggleFeaturedImage && (
 							<MenuItem
 								icon={ postFeaturedImage }
-								onClick={ onSelectFeaturedImage }
+								onClick={ onToggleFeaturedImage }
 								isPressed={ useFeaturedImage }
 							>
 								{ __( 'Use featured image' ) }

--- a/packages/block-editor/src/components/media-replace-flow/index.js
+++ b/packages/block-editor/src/components/media-replace-flow/index.js
@@ -20,7 +20,11 @@ import {
 } from '@wordpress/components';
 import { useSelect, withDispatch } from '@wordpress/data';
 import { DOWN } from '@wordpress/keycodes';
-import { upload, media as mediaIcon } from '@wordpress/icons';
+import {
+	postFeaturedImage,
+	upload,
+	media as mediaIcon,
+} from '@wordpress/icons';
 import { compose } from '@wordpress/compose';
 import { __unstableStripHTML as stripHTML } from '@wordpress/dom';
 import { store as noticesStore } from '@wordpress/notices';
@@ -42,6 +46,8 @@ const MediaReplaceFlow = ( {
 	onError,
 	onSelect,
 	onSelectURL,
+	onSelectFeaturedImage,
+	useFeaturedImage,
 	onFilesUpload = noop,
 	name = __( 'Replace' ),
 	createNotice,
@@ -149,42 +155,58 @@ const MediaReplaceFlow = ( {
 			renderContent={ ( { onClose } ) => (
 				<>
 					<NavigableMenu className="block-editor-media-replace-flow__media-upload-menu">
-						<MediaUpload
-							gallery={ gallery }
-							addToGallery={ addToGallery }
-							multiple={ multiple }
-							value={ multiple ? mediaIds : mediaId }
-							onSelect={ ( media ) =>
-								selectMedia( media, onClose )
-							}
-							allowedTypes={ allowedTypes }
-							render={ ( { open } ) => (
-								<MenuItem icon={ mediaIcon } onClick={ open }>
-									{ __( 'Open Media Library' ) }
-								</MenuItem>
-							) }
-						/>
-						<MediaUploadCheck>
-							<FormFileUpload
-								onChange={ ( event ) => {
-									uploadFiles( event, onClose );
-								} }
-								accept={ accept }
-								multiple={ multiple }
-								render={ ( { openFileDialog } ) => {
-									return (
+						{ ! useFeaturedImage && (
+							<>
+								<MediaUpload
+									gallery={ gallery }
+									addToGallery={ addToGallery }
+									multiple={ multiple }
+									value={ multiple ? mediaIds : mediaId }
+									onSelect={ ( media ) =>
+										selectMedia( media, onClose )
+									}
+									allowedTypes={ allowedTypes }
+									render={ ( { open } ) => (
 										<MenuItem
-											icon={ upload }
-											onClick={ () => {
-												openFileDialog();
-											} }
+											icon={ mediaIcon }
+											onClick={ open }
 										>
-											{ __( 'Upload' ) }
+											{ __( 'Open Media Library' ) }
 										</MenuItem>
-									);
-								} }
-							/>
-						</MediaUploadCheck>
+									) }
+								/>
+								<MediaUploadCheck>
+									<FormFileUpload
+										onChange={ ( event ) => {
+											uploadFiles( event, onClose );
+										} }
+										accept={ accept }
+										multiple={ multiple }
+										render={ ( { openFileDialog } ) => {
+											return (
+												<MenuItem
+													icon={ upload }
+													onClick={ () => {
+														openFileDialog();
+													} }
+												>
+													{ __( 'Upload' ) }
+												</MenuItem>
+											);
+										} }
+									/>
+								</MediaUploadCheck>
+							</>
+						) }
+						{ onSelectFeaturedImage && (
+							<MenuItem
+								icon={ postFeaturedImage }
+								onClick={ onSelectFeaturedImage }
+								isPressed={ useFeaturedImage }
+							>
+								{ __( 'Use featured image' ) }
+							</MenuItem>
+						) }
 						{ children }
 					</NavigableMenu>
 					{ onSelectURL && (

--- a/packages/block-library/src/cover/edit/block-controls.js
+++ b/packages/block-library/src/cover/edit/block-controls.js
@@ -2,7 +2,6 @@
  * WordPress dependencies
  */
 import { useState } from '@wordpress/element';
-import { ToolbarButton } from '@wordpress/components';
 
 import {
 	BlockControls,
@@ -11,7 +10,6 @@ import {
 	__experimentalBlockFullHeightAligmentControl as FullHeightAlignmentControl,
 } from '@wordpress/block-editor';
 import { __ } from '@wordpress/i18n';
-import { postFeaturedImage } from '@wordpress/icons';
 
 /**
  * Internal dependencies
@@ -97,22 +95,16 @@ export default function CoverBlockControls( {
 				/>
 			</BlockControls>
 			<BlockControls group="other">
-				<ToolbarButton
-					icon={ postFeaturedImage }
-					label={ __( 'Use featured image' ) }
-					isPressed={ useFeaturedImage }
-					onClick={ toggleUseFeaturedImage }
+				<MediaReplaceFlow
+					mediaId={ id }
+					mediaURL={ url }
+					allowedTypes={ ALLOWED_MEDIA_TYPES }
+					accept="image/*,video/*"
+					onSelect={ onSelectMedia }
+					onSelectFeaturedImage={ toggleUseFeaturedImage }
+					useFeaturedImage={ useFeaturedImage }
+					name={ ! url ? __( 'Add Media' ) : __( 'Replace' ) }
 				/>
-				{ ! useFeaturedImage && (
-					<MediaReplaceFlow
-						mediaId={ id }
-						mediaURL={ url }
-						allowedTypes={ ALLOWED_MEDIA_TYPES }
-						accept="image/*,video/*"
-						onSelect={ onSelectMedia }
-						name={ ! url ? __( 'Add Media' ) : __( 'Replace' ) }
-					/>
-				) }
 			</BlockControls>
 		</>
 	);

--- a/packages/block-library/src/cover/edit/block-controls.js
+++ b/packages/block-library/src/cover/edit/block-controls.js
@@ -101,7 +101,7 @@ export default function CoverBlockControls( {
 					allowedTypes={ ALLOWED_MEDIA_TYPES }
 					accept="image/*,video/*"
 					onSelect={ onSelectMedia }
-					onSelectFeaturedImage={ toggleUseFeaturedImage }
+					onToggleFeaturedImage={ toggleUseFeaturedImage }
 					useFeaturedImage={ useFeaturedImage }
 					name={ ! url ? __( 'Add Media' ) : __( 'Replace' ) }
 				/>


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Advances #40156. Adds featured image toggle to media replace flow, uses 
cover block to showcase.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

Having the media option in the same place seems more intuitive. The 
toolbar block control seemed to bother many users and a lot of UX 
feedback consistently asked for this toggle to be in the media replace 
how.

Also, as other media blocks would like to have access to featured image 
it's good to expose it through one common interface element.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

Adds a toggle to the dropdown. If the block that uses `MediaReplaceFlow` 
provides a featured image handler the toggle shows up. When featured 
image is toggled on the other options are not visible.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->

1. Create a post
2. Add a cover block
3. From add media, click use featured image
4. If the block has a featured image it will show, the toggle is pressed, 
the other media options are not visible

## Screenshots or screencast <!-- if applicable -->

https://user-images.githubusercontent.com/107534/171385052-a4af9d5d-fa2b-4911-b8ae-ec35ea713e66.mp4


