### PR TITLE
[RNMobile] Fix crash on iOS related to JSI and Reanimated by bumping `react-native-reanimated` version to `2.4.1-wp-3`

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17397,7 +17397,7 @@
 				"react-native-linear-gradient": "https://raw.githubusercontent.com/wordpress-mobile/react-native-linear-gradient/v2.5.6-wp-2/react-native-linear-gradient-2.5.6-wp-2.tgz",
 				"react-native-modal": "^11.10.0",
 				"react-native-prompt-android": "https://raw.githubusercontent.com/wordpress-mobile/react-native-prompt-android/v1.0.0-wp-2/react-native-prompt-android-1.0.0-wp-2.tgz",
-				"react-native-reanimated": "https://raw.githubusercontent.com/wordpress-mobile/react-native-reanimated/fix/invalidation-display-link/react-native-reanimated-2.4.1-wp-3.tgz",
+				"react-native-reanimated": "https://raw.githubusercontent.com/wordpress-mobile/react-native-reanimated/2.4.1-wp-3/react-native-reanimated-2.4.1-wp-3.tgz",
 				"react-native-safe-area": "^0.5.0",
 				"react-native-safe-area-context": "3.2.0",
 				"react-native-sass-transformer": "^1.1.1",
@@ -50255,7 +50255,7 @@
 			"integrity": "sha512-9whL4Kc5OU5Q89Dneq8oT8vpQTA/cEz24EIPXEQ2KGo1Dkf4qzer5+98YXJM2F8yitCP8UKHOL8WIiE7zukXBA=="
 		},
 		"react-native-reanimated": {
-			"version": "https://raw.githubusercontent.com/wordpress-mobile/react-native-reanimated/fix/invalidation-display-link/react-native-reanimated-2.4.1-wp-3.tgz",
+			"version": "https://raw.githubusercontent.com/wordpress-mobile/react-native-reanimated/2.4.1-wp-3/react-native-reanimated-2.4.1-wp-3.tgz",
 			"integrity": "sha512-LnfbSRe9WZIj/LT9ZrtiDKCjEqCPp+wcugBIUCgfb6przB3dwrCOiFdxZBD+Py58h6wN7fVpIOhPaP5rGQ1TQQ==",
 			"requires": {
 				"@babel/plugin-transform-object-assign": "^7.10.4",

--- a/package-lock.json
+++ b/package-lock.json
@@ -17397,7 +17397,7 @@
 				"react-native-linear-gradient": "https://raw.githubusercontent.com/wordpress-mobile/react-native-linear-gradient/v2.5.6-wp-2/react-native-linear-gradient-2.5.6-wp-2.tgz",
 				"react-native-modal": "^11.10.0",
 				"react-native-prompt-android": "https://raw.githubusercontent.com/wordpress-mobile/react-native-prompt-android/v1.0.0-wp-2/react-native-prompt-android-1.0.0-wp-2.tgz",
-				"react-native-reanimated": "https://raw.githubusercontent.com/wordpress-mobile/react-native-reanimated/2.4.1-wp-2/react-native-reanimated-2.4.1-wp-2.tgz",
+				"react-native-reanimated": "https://raw.githubusercontent.com/wordpress-mobile/react-native-reanimated/fix/invalidation-display-link/react-native-reanimated-2.4.1-wp-3.tgz",
 				"react-native-safe-area": "^0.5.0",
 				"react-native-safe-area-context": "3.2.0",
 				"react-native-sass-transformer": "^1.1.1",
@@ -50255,8 +50255,8 @@
 			"integrity": "sha512-9whL4Kc5OU5Q89Dneq8oT8vpQTA/cEz24EIPXEQ2KGo1Dkf4qzer5+98YXJM2F8yitCP8UKHOL8WIiE7zukXBA=="
 		},
 		"react-native-reanimated": {
-			"version": "https://raw.githubusercontent.com/wordpress-mobile/react-native-reanimated/2.4.1-wp-2/react-native-reanimated-2.4.1-wp-2.tgz",
-			"integrity": "sha512-8Mu7150ezI5PGBYAatqhQlau0nkeXMVNZIODAU7l1e7qjfEALZiuxKMkvWhFw1xBCqx+qRv24yYns7I5GGiZGQ==",
+			"version": "https://raw.githubusercontent.com/wordpress-mobile/react-native-reanimated/fix/invalidation-display-link/react-native-reanimated-2.4.1-wp-3.tgz",
+			"integrity": "sha512-LnfbSRe9WZIj/LT9ZrtiDKCjEqCPp+wcugBIUCgfb6przB3dwrCOiFdxZBD+Py58h6wN7fVpIOhPaP5rGQ1TQQ==",
 			"requires": {
 				"@babel/plugin-transform-object-assign": "^7.10.4",
 				"@types/invariant": "^2.2.35",

--- a/packages/react-native-editor/ios/Podfile.lock
+++ b/packages/react-native-editor/ios/Podfile.lock
@@ -306,7 +306,7 @@ PODS:
     - React-Core
   - RNGestureHandler (2.3.2-wp-1):
     - React-Core
-  - RNReanimated (2.4.1-wp-2):
+  - RNReanimated (2.4.1-wp-3):
     - DoubleConversion
     - FBLazyVector
     - FBReactNativeSpec
@@ -539,7 +539,7 @@ SPEC CHECKSUMS:
   RNCClipboard: 99fc8ad669a376b756fbc8098ae2fd05c0ed0668
   RNCMaskedView: c298b644a10c0c142055b3ae24d83879ecb13ccd
   RNGestureHandler: 3b13cc25407d1cdbee33b6ae65790a55c032d2a9
-  RNReanimated: d87c75f1076bab3402d6cd0b7322be51d333d10e
+  RNReanimated: b413cc7aa3e2a740d9804cda3a9396a68f9eea7f
   RNScreens: 953633729a42e23ad0c93574d676b361e3335e8b
   RNSVG: 36a7359c428dcb7c6bce1cc546fbfebe069809b0
   RNTAztecView: 2524811d1168d1f5148220ec8ea3c012ec8f059c

--- a/packages/react-native-editor/package.json
+++ b/packages/react-native-editor/package.json
@@ -65,7 +65,7 @@
 		"react-native-linear-gradient": "https://raw.githubusercontent.com/wordpress-mobile/react-native-linear-gradient/v2.5.6-wp-2/react-native-linear-gradient-2.5.6-wp-2.tgz",
 		"react-native-modal": "^11.10.0",
 		"react-native-prompt-android": "https://raw.githubusercontent.com/wordpress-mobile/react-native-prompt-android/v1.0.0-wp-2/react-native-prompt-android-1.0.0-wp-2.tgz",
-		"react-native-reanimated": "https://raw.githubusercontent.com/wordpress-mobile/react-native-reanimated/2.4.1-wp-2/react-native-reanimated-2.4.1-wp-2.tgz",
+		"react-native-reanimated": "https://raw.githubusercontent.com/wordpress-mobile/react-native-reanimated/fix/invalidation-display-link/react-native-reanimated-2.4.1-wp-3.tgz",
 		"react-native-safe-area": "^0.5.0",
 		"react-native-safe-area-context": "3.2.0",
 		"react-native-sass-transformer": "^1.1.1",

--- a/packages/react-native-editor/package.json
+++ b/packages/react-native-editor/package.json
@@ -65,7 +65,7 @@
 		"react-native-linear-gradient": "https://raw.githubusercontent.com/wordpress-mobile/react-native-linear-gradient/v2.5.6-wp-2/react-native-linear-gradient-2.5.6-wp-2.tgz",
 		"react-native-modal": "^11.10.0",
 		"react-native-prompt-android": "https://raw.githubusercontent.com/wordpress-mobile/react-native-prompt-android/v1.0.0-wp-2/react-native-prompt-android-1.0.0-wp-2.tgz",
-		"react-native-reanimated": "https://raw.githubusercontent.com/wordpress-mobile/react-native-reanimated/fix/invalidation-display-link/react-native-reanimated-2.4.1-wp-3.tgz",
+		"react-native-reanimated": "https://raw.githubusercontent.com/wordpress-mobile/react-native-reanimated/2.4.1-wp-3/react-native-reanimated-2.4.1-wp-3.tgz",
 		"react-native-safe-area": "^0.5.0",
 		"react-native-safe-area-context": "3.2.0",
 		"react-native-sass-transformer": "^1.1.1",


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Bump `react-native-reanimated` dependency version for including [a fix](https://github.com/wordpress-mobile/react-native-reanimated/pull/16) that addresses a crash on iOS related to JSI and the Reanimated library.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

This PR fixes a crash that affects a high number of users in version `19.9` of the WordPress-iOS app.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

Bump `react-native-reanimated` dependency to version `2.4.1-wp-3`.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->
1. Open a post and close it right after it opens.
2. Open another post quickly and close it again right after it opens.
3. Repeat the above steps multiple times.
4. Observe that the app doesn't crash.

**NOTE:** The crash might be not reproducible in some devices. So, in order to verify that it doesn't happen, try with the WordPress-iOS version `19.9` first and confirm that it crashes using the testing instructions.

## Screenshots or screencast <!-- if applicable -->
N/A