### PR TITLE
Fixed failing DateTimePicker Unit test.

### DIFF
--- a/packages/components/src/date-time/date/test/index.tsx
+++ b/packages/components/src/date-time/date/test/index.tsx
@@ -28,7 +28,7 @@ describe( 'DatePicker', () => {
 	it( "should highlight today's date when not provided a currentDate", () => {
 		render( <DatePicker /> );
 
-		const todayDescription = moment().format( 'dddd, MMM D, YYYY' );
+		const todayDescription = moment().format( 'dddd, MMMM D, YYYY' );
 		expect(
 			screen.getByRole( 'button', { name: todayDescription } )
 		).toHaveClass( 'CalendarDay__selected' );


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->
fix: #41480 

Fixed failing DateTimePicker Unit test.


## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
Tests dependent on the current date are failing, and tests fail on all branches.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
Within the unit test, the month name was being retrieved as an abbreviation.

"May" seems to have passed the test because it is three characters long.

## Testing Instructions
* Check unit test.

