### PR TITLE
Add some missing package dependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -18274,6 +18274,7 @@
 				"@wordpress/a11y": "file:packages/a11y",
 				"@wordpress/components": "file:packages/components",
 				"@wordpress/data": "file:packages/data",
+				"@wordpress/element": "file:packages/element",
 				"@wordpress/i18n": "file:packages/i18n",
 				"@wordpress/icons": "file:packages/icons",
 				"classnames": "^2.3.1"
@@ -18546,6 +18547,7 @@
 		"@wordpress/reusable-blocks": {
 			"version": "file:packages/reusable-blocks",
 			"requires": {
+				"@babel/runtime": "^7.16.0",
 				"@wordpress/block-editor": "file:packages/block-editor",
 				"@wordpress/blocks": "file:packages/blocks",
 				"@wordpress/components": "file:packages/components",
@@ -18702,7 +18704,8 @@
 			"requires": {
 				"@babel/runtime": "^7.16.0",
 				"@wordpress/compose": "file:packages/compose",
-				"@wordpress/data": "file:packages/data"
+				"@wordpress/data": "file:packages/data",
+				"@wordpress/element": "file:packages/element"
 			}
 		},
 		"@wordpress/warning": {

--- a/packages/preferences/package.json
+++ b/packages/preferences/package.json
@@ -32,6 +32,7 @@
 		"@wordpress/a11y": "file:../a11y",
 		"@wordpress/components": "file:../components",
 		"@wordpress/data": "file:../data",
+		"@wordpress/element": "file:../element",
 		"@wordpress/i18n": "file:../i18n",
 		"@wordpress/icons": "file:../icons",
 		"classnames": "^2.3.1"

--- a/packages/reusable-blocks/package.json
+++ b/packages/reusable-blocks/package.json
@@ -28,6 +28,7 @@
 		"{src,build,build-module}/{index.js,store/index.js}"
 	],
 	"dependencies": {
+		"@babel/runtime": "^7.16.0",
 		"@wordpress/block-editor": "file:../block-editor",
 		"@wordpress/blocks": "file:../blocks",
 		"@wordpress/components": "file:../components",

--- a/packages/viewport/package.json
+++ b/packages/viewport/package.json
@@ -27,7 +27,8 @@
 	"dependencies": {
 		"@babel/runtime": "^7.16.0",
 		"@wordpress/compose": "file:../compose",
-		"@wordpress/data": "file:../data"
+		"@wordpress/data": "file:../data",
+		"@wordpress/element": "file:../element"
 	},
 	"peerDependencies": {
 		"react": "^18.0.0"


### PR DESCRIPTION
!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->
Add some missing package dependencies

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
Build code transformations can introduce dependencies on packages such
as @wordpress/element and @babel/runtime. These need to be declared if
the package is to function correctly with yarn's p'n'p or pnpm with
hoisting disabled.

- @wordpress/preferences depends on @wordpress/element (fixes #41341)
- @wordpress/reusable-blocks depends on @babel/runtime (fixes #41343)
- @wordpress/viewport depends on @wordpress/element (fixes #41346)

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
Adding the missing dependencies. Normally I'd probably have done the @babel/runtime dep as a peer dep, but I see you use a normal dependency everywhere else so I followed along.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->
1. Follow the reproduction instructions in the linked bug to set up the test and reproduce the bug.
2. Do `yarn add <package>@file:/path/to/gutenberg/packages/<package>` or (with pnpm 7) `pnpm add <package>@file:/path/to/gutenberg/packages/<package>` to point yarn or pnpm at the locally built version of the package.
3. Repeat the final instruction in the reproduction to check that the bug is fixed.