### PR TITLE
Add utility classnames back to blocks that have layout attributes specified

### DIFF
--- a/lib/block-supports/layout.php
+++ b/lib/block-supports/layout.php
@@ -169,7 +169,7 @@ function gutenberg_get_layout_classes( $block_attributes ) {
 	}
 
 	if ( ! empty( $block_attributes['layout']['justifyContent'] ) ) {
-		$class_names[] = 'is-content-justification-' . sanitize_title(  $block_attributes['layout']['justifyContent'] );
+		$class_names[] = 'is-content-justification-' . sanitize_title( $block_attributes['layout']['justifyContent'] );
 	}
 
 	if ( ! empty( $block_attributes['layout']['flexWrap'] ) && 'nowrap' === $block_attributes['layout']['flexWrap'] ) {

--- a/lib/block-supports/layout.php
+++ b/lib/block-supports/layout.php
@@ -210,7 +210,7 @@ function gutenberg_render_layout_support_flag( $block_content, $block ) {
 	$class_names     = gutenberg_get_layout_classes( $block['attrs'] );
 	$class_names[]   = $container_class;
 
-	$gap_value  = _wp_array_get( $block, array( 'attrs', 'style', 'spacing', 'blockGap' ) );
+	$gap_value = _wp_array_get( $block, array( 'attrs', 'style', 'spacing', 'blockGap' ) );
 	// Skip if gap value contains unsupported characters.
 	// Regex for CSS value borrowed from `safecss_filter_attr`, and used here
 	// because we only want to match against the value, not the CSS attribute.

--- a/lib/block-supports/layout.php
+++ b/lib/block-supports/layout.php
@@ -146,6 +146,35 @@ function gutenberg_get_layout_style( $selector, $layout, $has_block_gap_support 
 }
 
 /**
+ * Generates the utility classnames for the given blocks layout attributes.
+ *
+ * @param array $block_attributes Array of block attributes.
+ *
+ * @return array Array of CSS classname strings.
+ */
+function gutenberg_get_layout_classes( $block_attributes ) {
+	$class_names = array();
+
+	if ( empty( $block_attributes['layout'] ) ) {
+		return $class_names;
+	}
+
+	if ( ! empty( $block_attributes['layout']['orientation'] ) ) {
+		$class_names[] = 'is-' . $block_attributes['layout']['orientation'];
+	}
+
+	if ( ! empty( $block_attributes['layout']['justifyContent'] ) ) {
+		$class_names[] = 'is-content-justification-' . $block_attributes['layout']['justifyContent'];
+	}
+
+	if ( ! empty( $block_attributes['layout']['flexWrap'] ) && 'nowrap' === $block_attributes['layout']['flexWrap'] ) {
+		$class_names[] = 'is-nowrap';
+	}
+
+	return $class_names;
+}
+
+/**
  * Renders the layout config to the block wrapper.
  *
  * @param  string $block_content Rendered block content.
@@ -172,7 +201,11 @@ function gutenberg_render_layout_support_flag( $block_content, $block ) {
 		$used_layout = $default_layout;
 	}
 
-	$class_name = wp_unique_id( 'wp-container-' );
+	// TODO: Should we handle the case where a block has opted out of using a classname? (e.g. how paragraph disables classnames)
+	$block_classname = wp_get_block_default_classname( $block['blockName'] );
+	$container_class = wp_unique_id( 'wp-container-' );
+	$class_names     = array_merge( array( $block_classname, $container_class ), gutenberg_get_layout_classes( $block['attrs'] ) );
+
 	$gap_value  = _wp_array_get( $block, array( 'attrs', 'style', 'spacing', 'blockGap' ) );
 	// Skip if gap value contains unsupported characters.
 	// Regex for CSS value borrowed from `safecss_filter_attr`, and used here
@@ -190,12 +223,12 @@ function gutenberg_render_layout_support_flag( $block_content, $block ) {
 	// If a block's block.json skips serialization for spacing or spacing.blockGap,
 	// don't apply the user-defined value to the styles.
 	$should_skip_gap_serialization = gutenberg_should_skip_block_supports_serialization( $block_type, 'spacing', 'blockGap' );
-	$style                         = gutenberg_get_layout_style( ".$class_name", $used_layout, $has_block_gap_support, $gap_value, $should_skip_gap_serialization, $fallback_gap_value );
+	$style                         = gutenberg_get_layout_style( ".$block_classname.$container_class", $used_layout, $has_block_gap_support, $gap_value, $should_skip_gap_serialization, $fallback_gap_value );
 	// This assumes the hook only applies to blocks with a single wrapper.
 	// I think this is a reasonable limitation for that particular hook.
 	$content = preg_replace(
 		'/' . preg_quote( 'class="', '/' ) . '/',
-		'class="' . esc_attr( $class_name ) . ' ',
+		'class="' . esc_attr( implode( ' ', $class_names ) ) . ' ',
 		$block_content,
 		1
 	);

--- a/lib/block-supports/layout.php
+++ b/lib/block-supports/layout.php
@@ -160,11 +160,11 @@ function gutenberg_get_layout_classes( $block_attributes ) {
 	}
 
 	if ( ! empty( $block_attributes['layout']['orientation'] ) ) {
-		$class_names[] = 'is-' . $block_attributes['layout']['orientation'];
+		$class_names[] = 'is-' . sanitize_title( $block_attributes['layout']['orientation'] );
 	}
 
 	if ( ! empty( $block_attributes['layout']['justifyContent'] ) ) {
-		$class_names[] = 'is-content-justification-' . $block_attributes['layout']['justifyContent'];
+		$class_names[] = 'is-content-justification-' . sanitize_title(  $block_attributes['layout']['justifyContent'] );
 	}
 
 	if ( ! empty( $block_attributes['layout']['flexWrap'] ) && 'nowrap' === $block_attributes['layout']['flexWrap'] ) {
@@ -201,10 +201,9 @@ function gutenberg_render_layout_support_flag( $block_content, $block ) {
 		$used_layout = $default_layout;
 	}
 
-	// TODO: Should we handle the case where a block has opted out of using a classname? (e.g. how paragraph disables classnames)
-	$block_classname = wp_get_block_default_classname( $block['blockName'] );
 	$container_class = wp_unique_id( 'wp-container-' );
-	$class_names     = array_merge( array( $block_classname, $container_class ), gutenberg_get_layout_classes( $block['attrs'] ) );
+	$class_names     = gutenberg_get_layout_classes( $block['attrs'] );
+	$class_names[]   = $container_class;
 
 	$gap_value  = _wp_array_get( $block, array( 'attrs', 'style', 'spacing', 'blockGap' ) );
 	// Skip if gap value contains unsupported characters.
@@ -223,7 +222,7 @@ function gutenberg_render_layout_support_flag( $block_content, $block ) {
 	// If a block's block.json skips serialization for spacing or spacing.blockGap,
 	// don't apply the user-defined value to the styles.
 	$should_skip_gap_serialization = gutenberg_should_skip_block_supports_serialization( $block_type, 'spacing', 'blockGap' );
-	$style                         = gutenberg_get_layout_style( ".$block_classname.$container_class", $used_layout, $has_block_gap_support, $gap_value, $should_skip_gap_serialization, $fallback_gap_value );
+	$style                         = gutenberg_get_layout_style( ".$container_class", $used_layout, $has_block_gap_support, $gap_value, $should_skip_gap_serialization, $fallback_gap_value );
 	// This assumes the hook only applies to blocks with a single wrapper.
 	// I think this is a reasonable limitation for that particular hook.
 	$content = preg_replace(

--- a/lib/block-supports/layout.php
+++ b/lib/block-supports/layout.php
@@ -147,6 +147,11 @@ function gutenberg_get_layout_style( $selector, $layout, $has_block_gap_support 
 
 /**
  * Generates the utility classnames for the given blocks layout attributes.
+ * This method was primarily added to reintroduce classnames that were removed
+ * in the 5.9 release (https://github.com/WordPress/gutenberg/issues/38719), rather
+ * than providing an extensive list of all possible layout classes. The plan is to
+ * have the style engine generate a more extensive list of utility classnames which
+ * will then replace this method.
  *
  * @param array $block_attributes Array of block attributes.
  *

--- a/packages/block-editor/src/hooks/layout.js
+++ b/packages/block-editor/src/hooks/layout.js
@@ -2,7 +2,7 @@
  * External dependencies
  */
 import classnames from 'classnames';
-import { has } from 'lodash';
+import { has, kebabCase } from 'lodash';
 
 /**
  * WordPress dependencies
@@ -52,12 +52,16 @@ function getLayoutClasses( attributes ) {
 	}
 
 	if ( attributes?.layout?.orientation ) {
-		layoutClassnames.push( `is-${ attributes.layout.orientation }` );
+		layoutClassnames.push(
+			`is-${ kebabCase( attributes.layout.orientation ) }`
+		);
 	}
 
 	if ( attributes?.layout?.justifyContent ) {
 		layoutClassnames.push(
-			`is-content-justification-${ attributes.layout.justifyContent }`
+			`is-content-justification-${ kebabCase(
+				attributes.layout.justifyContent
+			) }`
 		);
 	}
 

--- a/packages/block-editor/src/hooks/layout.js
+++ b/packages/block-editor/src/hooks/layout.js
@@ -32,6 +32,40 @@ import { getLayoutType, getLayoutTypes } from '../layouts';
 
 const layoutBlockSupportKey = '__experimentalLayout';
 
+/**
+ * Generates the utility classnames for the given blocks layout attributes.
+ *
+ * @param { Array } attributes Array of block attributes.
+ *
+ * @return { Array } Array of CSS classname strings.
+ */
+function getLayoutClasses( attributes ) {
+	const layoutClassnames = [];
+
+	if ( ! attributes.layout ) {
+		return layoutClassnames;
+	}
+
+	if ( attributes?.layout?.orientation ) {
+		layoutClassnames.push( `is-${ attributes.layout.orientation }` );
+	}
+
+	if ( attributes?.layout?.justifyContent ) {
+		layoutClassnames.push(
+			`is-content-justification-${ attributes.layout.justifyContent }`
+		);
+	}
+
+	if (
+		attributes?.layout?.flexWrap &&
+		attributes.layout.flexWrap === 'nowrap'
+	) {
+		layoutClassnames.push( 'is-nowrap' );
+	}
+
+	return layoutClassnames;
+}
+
 function LayoutPanel( { setAttributes, attributes, name: blockName } ) {
 	const { layout } = attributes;
 	const defaultThemeLayout = useSetting( 'layout' );
@@ -212,9 +246,13 @@ export const withLayoutStyles = createHigherOrderComponent(
 		const usedLayout = layout?.inherit
 			? defaultThemeLayout
 			: layout || defaultBlockLayout || {};
-		const className = classnames( props?.className, {
-			[ `wp-container-${ id }` ]: shouldRenderLayoutStyles,
-		} );
+		const className = classnames(
+			props?.className,
+			{
+				[ `wp-container-${ id }` ]: shouldRenderLayoutStyles,
+			},
+			getLayoutClasses( attributes )
+		);
 
 		return (
 			<>

--- a/packages/block-editor/src/hooks/layout.js
+++ b/packages/block-editor/src/hooks/layout.js
@@ -34,6 +34,11 @@ const layoutBlockSupportKey = '__experimentalLayout';
 
 /**
  * Generates the utility classnames for the given blocks layout attributes.
+ * This method was primarily added to reintroduce classnames that were removed
+ * in the 5.9 release (https://github.com/WordPress/gutenberg/issues/38719), rather
+ * than providing an extensive list of all possible layout classes. The plan is to
+ * have the style engine generate a more extensive list of utility classnames which
+ * will then replace this method.
  *
  * @param { Array } attributes Array of block attributes.
  *

--- a/packages/block-editor/src/hooks/layout.js
+++ b/packages/block-editor/src/hooks/layout.js
@@ -255,12 +255,15 @@ export const withLayoutStyles = createHigherOrderComponent(
 		const usedLayout = layout?.inherit
 			? defaultThemeLayout
 			: layout || defaultBlockLayout || {};
+		const layoutClasses = shouldRenderLayoutStyles
+			? getLayoutClasses( attributes )
+			: null;
 		const className = classnames(
 			props?.className,
 			{
 				[ `wp-container-${ id }` ]: shouldRenderLayoutStyles,
 			},
-			getLayoutClasses( attributes )
+			layoutClasses
 		);
 
 		return (


### PR DESCRIPTION
## What?
Add several layout utility classnames to blocks that have layout attributes specified

## Why?
[In 5.9 these utility classnames were removed](https://github.com/WordPress/gutenberg/issues/38719) which removed the ability for theme/plugin authors to assign their own custom CSS related to specific layout selections. This was mostly related to the Button block

## How?
Adds these classes dynamically based on attributes, rather than saving them to the serialized content

## Testing Instructions

- Add a Buttons block with one child Button block
- On parent Buttons block set alignment to centre and turn off the wrapping option
- Check that `is-content-justification-center` and `is-nowrap` classes are added in editor and frontend

## Screenshots or screencast 
<img width="571" alt="Screen Shot 2022-06-02 at 11 17 33 AM" src="https://user-images.githubusercontent.com/3629020/171517150-cb77fac2-0b2d-4a57-98ef-984e2f1bd558.png">


