### PR TITLE
Post sidebar: use flex-start to align items

### DIFF
--- a/packages/edit-post/src/components/sidebar/post-schedule/style.scss
+++ b/packages/edit-post/src/components/sidebar/post-schedule/style.scss
@@ -1,7 +1,7 @@
 .edit-post-post-schedule {
 	width: 100%;
 	position: relative;
-	justify-content: left;
+	justify-content: flex-start;
 
 	span {
 		display: block;

--- a/packages/edit-post/src/components/sidebar/post-visibility/style.scss
+++ b/packages/edit-post/src/components/sidebar/post-visibility/style.scss
@@ -1,6 +1,6 @@
 .edit-post-post-visibility {
 	width: 100%;
-	justify-content: left;
+	justify-content: flex-start;
 
 	span {
 		display: block;


### PR DESCRIPTION
## What?
Fixes https://github.com/WordPress/gutenberg/issues/41370

Props to @alifaraji for catching.

## Why? And How?!!
So that the sidebar post items are correctly justified in LTR and RTL languages, let's use flex-start instead of an explicit 'left'.

## Testing Instructions

1. Open the post editor and check out the Post sidebar in both LTR (e.g., Spanish, English) and RTL (e.g., Arabic, Hebrew) languages
2. The post schedule and visibility items should be left aligned for LTR languages, and right aligned for RTL languages.

### Before (RTL)
<img width="894" alt="Screen Shot 2022-06-02 at 11 45 57 am" src="https://user-images.githubusercontent.com/6458278/171529868-912c289f-fd68-4732-b33f-aebba1d48a65.png">


### After (RTL)
<img width="852" alt="Screen Shot 2022-06-02 at 11 44 09 am" src="https://user-images.githubusercontent.com/6458278/171529839-0116e255-5ba6-4016-bf69-e1e291aad579.png">

### LTR languages should display no change

<img width="836" alt="Screen Shot 2022-06-02 at 11 44 52 am" src="https://user-images.githubusercontent.com/6458278/171529830-4ac72396-af72-4917-ac7d-9f3222f7e6a7.png">

