### PR TITLE
Avoid including null values in blocks list

### DIFF
--- a/packages/block-library/src/index.js
+++ b/packages/block-library/src/index.js
@@ -153,7 +153,7 @@ const getAllBlocks = () => [
 	buttons,
 	calendar,
 	categories,
-	window.wp && window.wp.oldEditor ? classic : null, // Only add the classic block in WP Context.
+	...( window.wp && window.wp.oldEditor ? [ classic ] : [] ), // Only add the classic block in WP Context.
 	code,
 	column,
 	columns,


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

The problem reported in https://github.com/WordPress/gutenberg/issues/41263 seems to be caused because of the inclusion of a `null` value in the list of blocks returned by [`getBlocks`](https://github.com/WordPress/gutenberg/blob/4b3aed1455b3224109f9b3ca5d1f0de97f673892/packages/block-library/src/index.js#L138). 

This small change will prevent having a `null` when the code is not running on a WP Context.


## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

fixes https://github.com/WordPress/gutenberg/issues/41263


## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

It avoids having `null` values in the list of blocks

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->

1. Run `npm run storybook:dev`
2. Visit the `Playground/Block editor/Default` story
3. Ensure you see the editor instead of an exception traceback.

## Screenshots or screencast <!-- if applicable -->

Before:
<img width="1281" alt="image" src="https://user-images.githubusercontent.com/1574407/171597863-d5e96271-c9e8-404d-a03f-7e6f64f96fb0.png">


After:
<img width="1283" alt="image" src="https://user-images.githubusercontent.com/1574407/171597822-3354929a-20b8-412d-88bb-796582b8b3af.png">


