### PR TITLE
Block-Editor: Add tooltip on replace image's URL

### DIFF
--- a/packages/block-editor/src/components/media-replace-flow/index.js
+++ b/packages/block-editor/src/components/media-replace-flow/index.js
@@ -16,6 +16,7 @@ import {
 	ToolbarButton,
 	Dropdown,
 	withFilters,
+	Tooltip,
 } from '@wordpress/components';
 import { useSelect, withDispatch } from '@wordpress/data';
 import { DOWN } from '@wordpress/keycodes';
@@ -192,16 +193,21 @@ const MediaReplaceFlow = ( {
 							<span className="block-editor-media-replace-flow__image-url-label">
 								{ __( 'Current media URL:' ) }
 							</span>
-							<LinkControl
-								value={ { url: mediaURLValue } }
-								settings={ [] }
-								showSuggestions={ false }
-								onChange={ ( { url } ) => {
-									setMediaURLValue( url );
-									onSelectURL( url );
-									editMediaButtonRef.current.focus();
-								} }
-							/>
+
+							<Tooltip text={ mediaURLValue } position="bottom">
+								<div>
+									<LinkControl
+										value={ { url: mediaURLValue } }
+										settings={ [] }
+										showSuggestions={ false }
+										onChange={ ( { url } ) => {
+											setMediaURLValue( url );
+											onSelectURL( url );
+											editMediaButtonRef.current.focus();
+										} }
+									/>
+								</div>
+							</Tooltip>
 						</form>
 					) }
 				</>


### PR DESCRIPTION
Fixes [#32249](https://github.com/WordPress/gutenberg/issues/32249)

## What?
Added a hover tooltip when editing an image's URL using the `Replace` toolbar option.

## Why?
When editing an image's URL, being able to see the full URL is very important. However, the `Current media URL` field is far too narrow.

## How?
Added a tooltip when hovering on the image's URL field displaying the full URL.

## Testing Instructions
1. Create a new post or edit an existing post
2. Add "Image" block and select "Insert from URL" option
3. Enter an image URL
4. Select the "Replace" button
5. Hover over the URL. A tooltip should appear underneath displaying the full URL of the image

## Screenshot
<img width="758" alt="Screenshot 2022-06-02 at 15 57 06" src="https://user-images.githubusercontent.com/37012961/171658780-1503a308-4cb2-4c3a-830f-c15633b203a0.png">

