### PR TITLE
Correct string for commenter

### DIFF
--- a/packages/block-library/src/post-comments/edit.js
+++ b/packages/block-library/src/post-comments/edit.js
@@ -200,7 +200,7 @@ export default function PostCommentsEdit( {
 											<br />
 											{ createInterpolateElement(
 												__(
-													'Commenter avatars come from <a>Gravatar</a>'
+													'Commentator avatars come from <a>Gravatar</a>'
 												),
 												{
 													a: (


### PR DESCRIPTION
Hello,

I wonder if "commentator" is not more accurate than "commenter" which seems to not exist:
https://dictionary.cambridge.org/us/spellcheck/english/?q=commenter

https://dictionary.cambridge.org/us/dictionary/english/commentator

#wceu2022
