### PR TITLE
Singular string is written as a plural

### DIFF
--- a/packages/block-library/src/comments-title/index.php
+++ b/packages/block-library/src/comments-title/index.php
@@ -56,7 +56,7 @@ function render_block_core_comments_title( $attributes ) {
 		} else {
 			$comments_title = sprintf(
 				/* translators: %s: Number of comments. */
-				_n( '%s responses', '%s responses', $comments_count ),
+				_n( '%s response', '%s responses', $comments_count ),
 				number_format_i18n( $comments_count )
 			);
 		}


### PR DESCRIPTION
The singular string is ritten as a plural

<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->

## Screenshots or screencast <!-- if applicable -->
