### PR TITLE
#30930 -  Make it easier to select "Edit visually" when in "Edit as HTML

### DIFF
--- a/packages/block-editor/src/components/block-settings-menu/block-edit-visually-button.js
+++ b/packages/block-editor/src/components/block-settings-menu/block-edit-visually-button.js
@@ -45,10 +45,7 @@ export default function BlockEditVisuallyButton( { clientIds, ...props } ) {
 	}
 
 	return (
-		<ToolbarButton
-			onClick={ onClick }
-			{ ...props }
-		>
+		<ToolbarButton onClick={ onClick } { ...props }>
 			{ __( 'Edit visually' ) }
 		</ToolbarButton>
 	);

--- a/packages/block-editor/src/components/block-settings-menu/block-edit-visually-button.js
+++ b/packages/block-editor/src/components/block-settings-menu/block-edit-visually-button.js
@@ -16,12 +16,10 @@ export default function BlockEditVisuallyButton( { clientIds, ...props } ) {
 	const { block, shouldRender } = useSelect(
 		( select ) => {
 			const firstBlockClientId = clientIds[ 0 ];
-			const { isBlockMultiSelected, getBlockMode, getBlock } = select(
-				blockEditorStore
-			);
-			const isSingleSelected = ! isBlockMultiSelected(
-				firstBlockClientId
-			);
+			const { isBlockMultiSelected, getBlockMode, getBlock } =
+				select( blockEditorStore );
+			const isSingleSelected =
+				! isBlockMultiSelected( firstBlockClientId );
 			const isHtmlMode = getBlockMode( firstBlockClientId ) === 'html';
 
 			return {

--- a/packages/block-editor/src/components/block-settings-menu/block-edit-visually-button.js
+++ b/packages/block-editor/src/components/block-settings-menu/block-edit-visually-button.js
@@ -46,7 +46,6 @@ export default function BlockEditVisuallyButton( { clientIds, ...props } ) {
 
 	return (
 		<ToolbarButton
-			title={ __( 'Edit visually' ) }
 			onClick={ onClick }
 			{ ...props }
 		>

--- a/packages/block-editor/src/components/block-settings-menu/block-edit-visually-button.js
+++ b/packages/block-editor/src/components/block-settings-menu/block-edit-visually-button.js
@@ -12,7 +12,7 @@ import { useCallback } from '@wordpress/element';
  */
 import { store as blockEditorStore } from '../../store';
 
-export default function BlockVisuallyConvertButton( { clientIds, ...props } ) {
+export default function BlockEditVisuallyButton( { clientIds, ...props } ) {
 	const { block, shouldRender } = useSelect(
 		( select ) => {
 			const firstBlockClientId = clientIds[ 0 ];

--- a/packages/block-editor/src/components/block-settings-menu/block-edit-visually-button.js
+++ b/packages/block-editor/src/components/block-settings-menu/block-edit-visually-button.js
@@ -2,7 +2,7 @@
  * WordPress dependencies
  */
 import { rawHandler, getBlockContent } from '@wordpress/blocks';
-import { ToolbarButton } from '@wordpress/components';
+import { ToolbarButton, ToolbarGroup } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 import { useSelect, useDispatch } from '@wordpress/data';
 import { useCallback } from '@wordpress/element';
@@ -45,8 +45,10 @@ export default function BlockEditVisuallyButton( { clientIds, ...props } ) {
 	}
 
 	return (
-		<ToolbarButton onClick={ onClick } { ...props }>
-			{ __( 'Edit visually' ) }
-		</ToolbarButton>
+		<ToolbarGroup>
+			<ToolbarButton onClick={ onClick } { ...props }>
+				{ __( 'Edit visually' ) }
+			</ToolbarButton>
+		</ToolbarGroup>
 	);
 }

--- a/packages/block-editor/src/components/block-settings-menu/block-visually-convert-button.js
+++ b/packages/block-editor/src/components/block-settings-menu/block-visually-convert-button.js
@@ -1,0 +1,56 @@
+/**
+ * WordPress dependencies
+ */
+import { rawHandler, getBlockContent } from '@wordpress/blocks';
+import { ToolbarButton } from '@wordpress/components';
+import { __ } from '@wordpress/i18n';
+import { useSelect, useDispatch } from '@wordpress/data';
+import { useCallback } from '@wordpress/element';
+
+/**
+ * Internal dependencies
+ */
+import { store as blockEditorStore } from '../../store';
+
+export default function BlockVisuallyConvertButton( { clientIds, ...props } ) {
+	const { block, shouldRender } = useSelect(
+		( select ) => {
+			const firstBlockClientId = clientIds[ 0 ];
+			const { isBlockMultiSelected, getBlockMode, getBlock } = select(
+				blockEditorStore
+			);
+			const isSingleSelected = ! isBlockMultiSelected(
+				firstBlockClientId
+			);
+			const isHtmlMode = getBlockMode( firstBlockClientId ) === 'html';
+
+			return {
+				block: getBlock( firstBlockClientId ),
+				shouldRender: isSingleSelected && isHtmlMode,
+			};
+		},
+		[ clientIds[ 0 ] ]
+	);
+
+	const { replaceBlocks } = useDispatch( blockEditorStore );
+	const onClick = useCallback( () => {
+		replaceBlocks(
+			block.clientId,
+			rawHandler( { HTML: getBlockContent( block ) } )
+		);
+	}, [ block ] );
+
+	if ( ! shouldRender ) {
+		return null;
+	}
+
+	return (
+		<ToolbarButton
+			title={ __( 'Edit visually' ) }
+			onClick={ onClick }
+			{ ...props }
+		>
+			{ __( 'Edit visually' ) }
+		</ToolbarButton>
+	);
+}

--- a/packages/block-editor/src/components/block-settings-menu/index.js
+++ b/packages/block-editor/src/components/block-settings-menu/index.js
@@ -7,7 +7,7 @@ import { ToolbarGroup, ToolbarItem } from '@wordpress/components';
  * Internal dependencies
  */
 import BlockSettingsDropdown from './block-settings-dropdown';
-import BlockVisuallyConvertButton from './block-visually-convert-button';
+import BlockEditVisuallyButton from './block-edit-visually-button';
 
 export function BlockSettingsMenu( { clientIds, ...props } ) {
 	return (
@@ -21,7 +21,7 @@ export function BlockSettingsMenu( { clientIds, ...props } ) {
 					/>
 				) }
 			</ToolbarItem>
-			<BlockVisuallyConvertButton clientIds={ clientIds } { ...props } />
+			<BlockEditVisuallyButton clientIds={ clientIds } { ...props } />
 		</ToolbarGroup>
 	);
 }

--- a/packages/block-editor/src/components/block-settings-menu/index.js
+++ b/packages/block-editor/src/components/block-settings-menu/index.js
@@ -12,6 +12,7 @@ import BlockEditVisuallyButton from './block-edit-visually-button';
 export function BlockSettingsMenu( { clientIds, ...props } ) {
 	return (
 		<ToolbarGroup>
+			<BlockEditVisuallyButton clientIds={ clientIds } { ...props } />
 			<ToolbarItem>
 				{ ( toggleProps ) => (
 					<BlockSettingsDropdown
@@ -21,7 +22,6 @@ export function BlockSettingsMenu( { clientIds, ...props } ) {
 					/>
 				) }
 			</ToolbarItem>
-			<BlockEditVisuallyButton clientIds={ clientIds } { ...props } />
 		</ToolbarGroup>
 	);
 }

--- a/packages/block-editor/src/components/block-settings-menu/index.js
+++ b/packages/block-editor/src/components/block-settings-menu/index.js
@@ -7,6 +7,7 @@ import { ToolbarGroup, ToolbarItem } from '@wordpress/components';
  * Internal dependencies
  */
 import BlockSettingsDropdown from './block-settings-dropdown';
+import BlockVisuallyConvertButton from './block-visually-convert-button';
 
 export function BlockSettingsMenu( { clientIds, ...props } ) {
 	return (
@@ -20,6 +21,7 @@ export function BlockSettingsMenu( { clientIds, ...props } ) {
 					/>
 				) }
 			</ToolbarItem>
+			<BlockVisuallyConvertButton clientIds={ clientIds } { ...props } />
 		</ToolbarGroup>
 	);
 }

--- a/packages/block-editor/src/components/block-settings-menu/index.js
+++ b/packages/block-editor/src/components/block-settings-menu/index.js
@@ -11,18 +11,20 @@ import BlockEditVisuallyButton from './block-edit-visually-button';
 
 export function BlockSettingsMenu( { clientIds, ...props } ) {
 	return (
-		<ToolbarGroup>
+		<>
 			<BlockEditVisuallyButton clientIds={ clientIds } { ...props } />
-			<ToolbarItem>
-				{ ( toggleProps ) => (
-					<BlockSettingsDropdown
-						clientIds={ clientIds }
-						toggleProps={ toggleProps }
-						{ ...props }
-					/>
-				) }
-			</ToolbarItem>
-		</ToolbarGroup>
+			<ToolbarGroup>
+				<ToolbarItem>
+					{ ( toggleProps ) => (
+						<BlockSettingsDropdown
+							clientIds={ clientIds }
+							toggleProps={ toggleProps }
+							{ ...props }
+						/>
+					) }
+				</ToolbarItem>
+			</ToolbarGroup>
+		</>
 	);
 }
 


### PR DESCRIPTION
## What?
Make it easier to select "Edit visually" when in "Edit as HTML" mode #30930

## Why?
https://github.com/WordPress/gutenberg/issues/30930

@adamziel @carolinan 

