### PR TITLE
Fix alignment styles for new wp-block-image output

### DIFF
--- a/packages/block-library/src/image/style.scss
+++ b/packages/block-library/src/image/style.scss
@@ -38,6 +38,7 @@
 		}
 	}
 
+	&.alignleft,
 	.alignleft {
 		/*rtl:ignore*/
 		float: left;
@@ -48,6 +49,7 @@
 		margin-bottom: 0.5em;
 	}
 
+	&.alignright,
 	.alignright {
 		/*rtl:ignore*/
 		float: right;

--- a/packages/block-library/src/image/style.scss
+++ b/packages/block-library/src/image/style.scss
@@ -60,7 +60,8 @@
 		margin-bottom: 0.5em;
 	}
 
-	// This is needed for classic themes where the align class is not on the container.
+	// This is needed for classic themes where the align class is not on the container before WordPress 6.0 and on the same container in 6.0.
+	&.aligncenter,
 	.aligncenter {
 		margin-left: auto;
 		margin-right: auto;


### PR DESCRIPTION
## What?
Adds additional alignleft, alignright and aligncenter selectors to target the wp-block-image container  when they're applied to the same element.

## Why?
Related WordPress/gutenberg#41365 
In Wordpress 6.0, Gutenberg no longer wraps image blocks with a `<div class="wp-block-image">`  div but applies the `.wp-block-image` class to the `<figure class="wp-block-image alignright">` element instead. This means the core block library needs to also target the `.alignleft` and `.alignright` classes on the same level as `.wp-block-image`.

## How?
Adds additional CSS selectors to target `.alignleft`, `.alignright` and `.aligncenter` classes when applied to the same element as the `.wp-block-image` class.

## Testing Instructions
1. Open a Post or Page.
2. Insert an Image Block
3. Align the image to the right.
4. Without this PR the image will not be aligned to the right when relying on the core block librarys stylesheet
