### PR TITLE
Components: refactor`FocalPointPicker` to pass exhaustive-deps

### DIFF
--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -9,6 +9,7 @@
 -   `Scrollable`: Convert to TypeScript ([#42016](https://github.com/WordPress/gutenberg/pull/42016)).
 -   `Spacer`: Complete TypeScript migration ([#42013](https://github.com/WordPress/gutenberg/pull/42013)).
 -   `TreeSelect`: Refactor away from `_.repeat()` ([#42070](https://github.com/WordPress/gutenberg/pull/42070/)).
+-   `FocalPointPicker` updated to satisfy `react/exhuastive-deps` eslint rule ([#41520](https://github.com/WordPress/gutenberg/pull/41520)).
 
 ## 19.14.0 (2022-06-29)
 

--- a/packages/components/src/focal-point-picker/index.native.js
+++ b/packages/components/src/focal-point-picker/index.native.js
@@ -120,7 +120,7 @@ function FocalPointPicker( props ) {
 					setSliderKey( ( prevState ) => prevState + 1 );
 				},
 			} ),
-		[ containerSize ]
+		[ containerSize, pan, onChange, shouldEnableBottomSheetScroll ]
 	);
 
 	const mediaBackground = usePreferredColorSchemeStyle(

--- a/packages/components/src/focal-point-picker/index.native.js
+++ b/packages/components/src/focal-point-picker/index.native.js
@@ -40,8 +40,8 @@ function FocalPointPicker( props ) {
 	const [ videoNaturalSize, setVideoNaturalSize ] = useState( null );
 	const [ tooltipVisible, setTooltipVisible ] = useState( false );
 
-	let locationPageOffsetX = useRef().current;
-	let locationPageOffsetY = useRef().current;
+	const locationPageOffsetX = useRef();
+	const locationPageOffsetY = useRef();
 	const videoRef = useRef( null );
 
 	useEffect( () => {
@@ -86,8 +86,8 @@ function FocalPointPicker( props ) {
 						pageX,
 						pageY,
 					} = event.nativeEvent;
-					locationPageOffsetX = pageX - x;
-					locationPageOffsetY = pageY - y;
+					locationPageOffsetX.current = pageX - x;
+					locationPageOffsetY.current = pageY - y;
 					pan.setValue( { x, y } ); // Set cursor to tap location.
 					pan.extractOffset(); // Set offset to current value.
 				},
@@ -106,8 +106,8 @@ function FocalPointPicker( props ) {
 					// Specifically, dragging the handle outside the bounds of the image
 					// results in inaccurate locationX and locationY coordinates to be
 					// reported. https://github.com/facebook/react-native/issues/15290#issuecomment-435494944
-					const x = pageX - locationPageOffsetX;
-					const y = pageY - locationPageOffsetY;
+					const x = pageX - locationPageOffsetX.current;
+					const y = pageY - locationPageOffsetY.current;
 					onChange( {
 						x: clamp( x / containerSize?.width, 0, 1 ).toFixed( 2 ),
 						y: clamp( y / containerSize?.height, 0, 1 ).toFixed(

--- a/packages/components/src/focal-point-picker/index.native.js
+++ b/packages/components/src/focal-point-picker/index.native.js
@@ -67,7 +67,7 @@ function FocalPointPicker( props ) {
 				y: focalPoint.y * containerSize.height,
 			} );
 		}
-	}, [ focalPoint, containerSize ] );
+	}, [ focalPoint, containerSize, pan ] );
 
 	// Pan responder to manage drag handle interactivity.
 	const panResponder = useMemo(

--- a/packages/components/src/focal-point-picker/tooltip/index.native.js
+++ b/packages/components/src/focal-point-picker/tooltip/index.native.js
@@ -12,7 +12,6 @@ import {
 	useRef,
 	useState,
 	useContext,
-	useCallback,
 } from '@wordpress/element';
 
 /**
@@ -67,18 +66,17 @@ function Label( { align, text, xOffset, yOffset } ) {
 	}
 
 	useEffect( () => {
+		const startAnimation = () => {
+			Animated.timing( animationValue, {
+				toValue: visible ? 1 : 0,
+				duration: visible ? 300 : 150,
+				useNativeDriver: true,
+				delay: visible ? 500 : 0,
+				easing: Easing.out( Easing.quad ),
+			} ).start();
+		};
 		startAnimation();
-	}, [ visible, startAnimation ] );
-
-	const startAnimation = useCallback( () => {
-		Animated.timing( animationValue, {
-			toValue: visible ? 1 : 0,
-			duration: visible ? 300 : 150,
-			useNativeDriver: true,
-			delay: visible ? 500 : 0,
-			easing: Easing.out( Easing.quad ),
-		} ).start();
-	}, [ visible, animationValue ] );
+	}, [ animationValue, visible ] );
 
 	// Transforms rely upon onLayout to enable custom offsets additions.
 	let tooltipTransforms;

--- a/packages/components/src/focal-point-picker/tooltip/index.native.js
+++ b/packages/components/src/focal-point-picker/tooltip/index.native.js
@@ -12,6 +12,7 @@ import {
 	useRef,
 	useState,
 	useContext,
+	useCallback,
 } from '@wordpress/element';
 
 /**
@@ -67,9 +68,9 @@ function Label( { align, text, xOffset, yOffset } ) {
 
 	useEffect( () => {
 		startAnimation();
-	}, [ visible ] );
+	}, [ visible, startAnimation ] );
 
-	const startAnimation = () => {
+	const startAnimation = useCallback( () => {
 		Animated.timing( animationValue, {
 			toValue: visible ? 1 : 0,
 			duration: visible ? 300 : 150,
@@ -77,7 +78,7 @@ function Label( { align, text, xOffset, yOffset } ) {
 			delay: visible ? 500 : 0,
 			easing: Easing.out( Easing.quad ),
 		} ).start();
-	};
+	}, [ visible, animationValue ] );
 
 	// Transforms rely upon onLayout to enable custom offsets additions.
 	let tooltipTransforms;

--- a/packages/components/src/mobile/focal-point-settings-panel/index.native.js
+++ b/packages/components/src/mobile/focal-point-settings-panel/index.native.js
@@ -8,7 +8,7 @@ import { useRoute, useNavigation } from '@react-navigation/native';
  * WordPress dependencies
  */
 import { __ } from '@wordpress/i18n';
-import { memo, useContext, useState } from '@wordpress/element';
+import { memo, useContext, useState, useCallback } from '@wordpress/element';
 import { BottomSheetContext, FocalPointPicker } from '@wordpress/components';
 
 /**
@@ -56,7 +56,7 @@ const FocalPointSettingsPanelMemo = memo(
 				</NavBar>
 				<FocalPointPicker
 					focalPoint={ draftFocalPoint }
-					onChange={ setPosition }
+					onChange={ useCallback( () => setPosition, [] ) }
 					shouldEnableBottomSheetScroll={
 						shouldEnableBottomSheetScroll
 					}

--- a/packages/components/src/mobile/focal-point-settings-panel/index.native.js
+++ b/packages/components/src/mobile/focal-point-settings-panel/index.native.js
@@ -56,7 +56,7 @@ const FocalPointSettingsPanelMemo = memo(
 				</NavBar>
 				<FocalPointPicker
 					focalPoint={ draftFocalPoint }
-					onChange={ useCallback( () => setPosition, [] ) }
+					onChange={ useCallback( () => setPosition(), [] ) }
 					shouldEnableBottomSheetScroll={
 						shouldEnableBottomSheetScroll
 					}

--- a/packages/components/src/mobile/focal-point-settings-panel/index.native.js
+++ b/packages/components/src/mobile/focal-point-settings-panel/index.native.js
@@ -56,7 +56,7 @@ const FocalPointSettingsPanelMemo = memo(
 				</NavBar>
 				<FocalPointPicker
 					focalPoint={ draftFocalPoint }
-					onChange={ useCallback( () => setPosition(), [] ) }
+					onChange={ useCallback( setPosition, [] ) }
 					shouldEnableBottomSheetScroll={
 						shouldEnableBottomSheetScroll
 					}


### PR DESCRIPTION
## What?
Updates the `FocalPointPicker` component to satisfy the `exhaustive-deps` eslint rule

## Why?
Part of the effort in https://github.com/WordPress/gutenberg/pull/41166 to apply `exhuastive-deps` to the Components package

## How?
**Drag handle `useEffect`**
Add `pan` to the `useEffect` dep array

**panResponder**
`locationPageOffsetX` and `locationPageOffsetY` were both declared as `useRef().current`, which is effectively `undefined` and not an actual ref object.

This meant that later on, when mutating these variables, we weren't actually updating a ref, but assigning values that could simply be lost on future renders.

Instead, we now declare both values as actual refs (`useRef()`) and then update the `.current` value later on, preserving the assigned value between renders.

We then added `pan`, `onChange`, and `shouldEnableBottomSheetScroll` to the `useEffect` dep array.

**Tooltip**
`startAnimation` was expected as a dependency for the `useEffect` call.  Doing so also requires wrapping `startAnimation` in its own `useCallback`, dependent on `animationValue`. 

Another option on the Tooltip would be to simply move the code executed by `startAnimation` directly into `useEffect`. That function isn't being called anywhere else, so it doesn't really need a separate declaration. This would require adding `animationValue` to `useEffect`'s dep array.

I went with the first option, because while more verbose, I felt the named function improved readability, but I'm happy with either path.

**Note:**
I've done the best I can with the code changes themselves, but these are all unfortunately React native changes, so I'm a bit out of my depth on actually testing them, so I'm crossing my fingers and calling in the cavalry: cc @geriux.

I'm hopeful these changes and any subsequent adjustments work well  🤞 but if they're too messy I may defer further work on this to a React native expert with better tools/dev environment in place.

## Testing Instructions
1. From your local Gutenberg directory, run `npx eslint --rule 'react-hooks/exhaustive-deps: warn' packages/components/src/focal-point-picker`
2. Confirm that the linter returns no errors
3. Confirm unit tests still pass

