### PR TITLE
Experiment: ToolsPanel: Try moving the menu off the sidebar to improve UX

### DIFF
--- a/packages/block-editor/src/components/colors-gradients/panel-color-gradient-settings.js
+++ b/packages/block-editor/src/components/colors-gradients/panel-color-gradient-settings.js
@@ -89,7 +89,10 @@ export const PanelColorGradientSettingsInner = ( {
 					);
 				} );
 			} }
+			menuPosition="left"
 			panelId={ panelId }
+			popoverOffset={ 48 }
+			popoverPlacement="left-start"
 			__experimentalFirstVisibleItemClass="first"
 			__experimentalLastVisibleItemClass="last"
 		>

--- a/packages/block-editor/src/components/inspector-controls/block-support-tools-panel.js
+++ b/packages/block-editor/src/components/inspector-controls/block-support-tools-panel.js
@@ -67,7 +67,10 @@ export default function BlockSupportToolsPanel( { children, group, label } ) {
 			label={ label }
 			resetAll={ resetAll }
 			key={ panelId }
+			menuPosition="left"
 			panelId={ panelId }
+			popoverOffset={ 48 }
+			popoverPlacement="left-start"
 			hasInnerWrapper={ true }
 			shouldRenderPlaceholderItems={ true } // Required to maintain fills ordering.
 			__experimentalFirstVisibleItemClass="first"

--- a/packages/components/src/tools-panel/tools-panel-header/README.md
+++ b/packages/components/src/tools-panel/tools-panel-header/README.md
@@ -25,6 +25,20 @@ Text to be displayed within the panel header. It is also passed along as the
 
 -   Required: Yes
 
+### `menuPosition`: `left` | `right`
+
+Whether the menu toggle is positioned to the left or right of the panel's
+title.
+
+- Required: No
+- Default: `right`
+
+### `popoverProps`: `Record< string, unknown >`
+
+An internal prop used to control the visibility of the dropdown.
+
+- Required: No
+
 ### `resetAll`: `() => void`
 
 The `resetAll` prop provides the callback to execute when the "Reset all" menu

--- a/packages/components/src/tools-panel/tools-panel-header/component.tsx
+++ b/packages/components/src/tools-panel/tools-panel-header/component.tsx
@@ -152,6 +152,8 @@ const ToolsPanelHeader = (
 		headingClassName,
 		label: labelText,
 		menuItems,
+		menuPosition = 'right',
+		popoverProps,
 		resetAll,
 		toggleItem,
 		...headerProps
@@ -177,52 +179,63 @@ const ToolsPanelHeader = (
 		( [ , isSelected ] ) => isSelected
 	);
 
+	const menuJustification =
+		menuPosition === 'right' ? 'space-between' : 'flex-start';
+
+	const dropdown = hasMenuItems && (
+		<DropdownMenu
+			icon={ dropDownMenuIcon }
+			label={ dropDownMenuLabelText }
+			menuProps={ { className: dropdownMenuClassName } }
+			toggleProps={ {
+				isSmall: true,
+				describedBy: dropdownMenuDescriptionText,
+			} }
+			popoverProps={ popoverProps }
+		>
+			{ () => (
+				<>
+					<DefaultControlsGroup
+						items={ defaultItems }
+						toggleItem={ toggleItem }
+					/>
+					<OptionalControlsGroup
+						items={ optionalItems }
+						toggleItem={ toggleItem }
+					/>
+					<MenuGroup>
+						<MenuItem
+							aria-disabled={ ! canResetAll }
+							variant={ 'tertiary' }
+							onClick={ () => {
+								if ( canResetAll ) {
+									resetAll();
+									speak(
+										__( 'All options reset' ),
+										'assertive'
+									);
+								}
+							} }
+						>
+							{ __( 'Reset all' ) }
+						</MenuItem>
+					</MenuGroup>
+				</>
+			) }
+		</DropdownMenu>
+	);
+
 	return (
-		<HStack { ...headerProps } ref={ forwardedRef }>
+		<HStack
+			{ ...headerProps }
+			justify={ menuJustification }
+			ref={ forwardedRef }
+		>
+			{ menuPosition === 'left' && dropdown }
 			<Heading level={ 2 } className={ headingClassName }>
 				{ labelText }
 			</Heading>
-			{ hasMenuItems && (
-				<DropdownMenu
-					icon={ dropDownMenuIcon }
-					label={ dropDownMenuLabelText }
-					menuProps={ { className: dropdownMenuClassName } }
-					toggleProps={ {
-						isSmall: true,
-						describedBy: dropdownMenuDescriptionText,
-					} }
-				>
-					{ () => (
-						<>
-							<DefaultControlsGroup
-								items={ defaultItems }
-								toggleItem={ toggleItem }
-							/>
-							<OptionalControlsGroup
-								items={ optionalItems }
-								toggleItem={ toggleItem }
-							/>
-							<MenuGroup>
-								<MenuItem
-									aria-disabled={ ! canResetAll }
-									variant={ 'tertiary' }
-									onClick={ () => {
-										if ( canResetAll ) {
-											resetAll();
-											speak(
-												__( 'All options reset' ),
-												'assertive'
-											);
-										}
-									} }
-								>
-									{ __( 'Reset all' ) }
-								</MenuItem>
-							</MenuGroup>
-						</>
-					) }
-				</DropdownMenu>
-			) }
+			{ menuPosition === 'right' && dropdown }
 		</HStack>
 	);
 };

--- a/packages/components/src/tools-panel/tools-panel/README.md
+++ b/packages/components/src/tools-panel/tools-panel/README.md
@@ -88,7 +88,25 @@ wrapper element allowing the panel to lay them out accordingly.
 Text to be displayed within the panel's header and as the `aria-label` for the
 panel's dropdown menu.
 
-- Required: Yes
+### `menuPosition`: `left` | `right`
+
+Whether the menu toggle is positioned to the left or right of the panel's
+header.
+
+- Required: No
+- Default: `right`
+
+### `popoverOffset`: `number`
+
+The space between the popover and the menu toggle.
+
+- Required: No
+
+### `popoverPlacement`: `string`
+
+The position of the menu popover compared to the menu toggle.
+
+- Required: No
 
 ### `panelId`: `string`
 

--- a/packages/components/src/tools-panel/tools-panel/component.tsx
+++ b/packages/components/src/tools-panel/tools-panel/component.tsx
@@ -20,7 +20,9 @@ const ToolsPanel = (
 	const {
 		children,
 		label,
+		menuPosition,
 		panelContext,
+		popoverProps,
 		resetAllItems,
 		toggleItem,
 		...toolsPanelProps
@@ -33,6 +35,8 @@ const ToolsPanel = (
 					label={ label }
 					resetAll={ resetAllItems }
 					toggleItem={ toggleItem }
+					menuPosition={ menuPosition }
+					popoverProps={ popoverProps }
 				/>
 				{ children }
 			</ToolsPanelContext.Provider>

--- a/packages/components/src/tools-panel/tools-panel/hook.ts
+++ b/packages/components/src/tools-panel/tools-panel/hook.ts
@@ -59,6 +59,8 @@ export function useToolsPanel(
 		className,
 		resetAll,
 		panelId,
+		popoverOffset,
+		popoverPlacement,
 		hasInnerWrapper,
 		shouldRenderPlaceholderItems,
 		__experimentalFirstVisibleItemClass,
@@ -276,6 +278,11 @@ export function useToolsPanel(
 		[ ...panelItems ].reverse()
 	);
 
+	const popoverProps =
+		popoverPlacement || popoverOffset
+			? { placement: popoverPlacement, offset: popoverOffset }
+			: undefined;
+
 	const panelContext = useMemo(
 		() => ( {
 			areAllOptionalControlsHidden,
@@ -312,6 +319,7 @@ export function useToolsPanel(
 	return {
 		...otherProps,
 		panelContext,
+		popoverProps,
 		resetAllItems,
 		toggleItem,
 		className: classes,

--- a/packages/components/src/tools-panel/types.ts
+++ b/packages/components/src/tools-panel/types.ts
@@ -22,11 +22,26 @@ export type ToolsPanelProps = {
 	 */
 	label: string;
 	/**
+	 * Whether the menu toggle is positioned to the left or right of the panel's
+	 * header.
+	 *
+	 * @default 'right'
+	 */
+	menuPosition?: 'left' | 'right';
+	/**
 	 * If a `panelId` is set, it is passed through the `ToolsPanelContext` and
 	 * used to restrict panel items. Only items with a matching `panelId` will
 	 * be able to register themselves with this panel.
 	 */
 	panelId: string;
+	/**
+	 * The space between the popover and the menu toggle.
+	 */
+	popoverOffset?: number;
+	/**
+	 * The position of the menu popover compared to the menu toggle.
+	 */
+	popoverPlacement?: string;
 	/**
 	 * A function to call when the `Reset all` menu option is selected. This is
 	 * passed through to the panel's header component.
@@ -55,6 +70,17 @@ export type ToolsPanelHeaderProps = {
 	 * the `label` for the panel header's `DropdownMenu`.
 	 */
 	label: string;
+	/**
+	 * Whether the menu toggle is positioned to the left or right of the panel's
+	 * header.
+	 *
+	 * @default true
+	 */
+	menuPosition?: 'left' | 'right';
+	/**
+	 * An internal prop used to control the visibility of the dropdown.
+	 */
+	popoverProps?: Record< string, unknown >;
 	/**
 	 * The `resetAll` prop provides the callback to execute when the "Reset all"
 	 * menu item is selected. Its purpose is to facilitate resetting any control


### PR DESCRIPTION
### ⚠️ Important! ⚠️ 

**This is an experimental PR only and isn't intended for final review until design considerations and alternatives are taken into acccount.** 

Related: 
- https://github.com/WordPress/gutenberg/issues/41376

## What?

Allows the `ToolsPanel` menu to be positioned and moves the menu's popover off the sidebar within the editor.

## Why?

Moving the menu off the sidebar within the editor aims to minimise some current UX problems. 

See #41376 for more details on problems.

## How?

- Adds new `menuPosition`, `popoverPlacement`, and `popoverOffset` props to the `ToolsPanel`.
- Uses the new props to assemble popover props to pass to the dropdown component used in the `ToolsPanelHeader`
- Updates the editor's use of the `ToolsPanel` to move the menu toggle to the left of the panel header and position the menu's popover to the left of the sidebar

## Testing Instructions

1. Select a block such as the paragraph or group blocks in the editor and play with its menu, toggling on/off or resetting controls.

## Screenshots or screencast <!-- if applicable -->

https://user-images.githubusercontent.com/60436221/171778611-e8dd4aed-0e31-42df-8770-f5bb8dcf6b9e.mp4


