### PR TITLE
Tooltip: Fix jitter at edge of screen by enabling __unstableShift

### DIFF
--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Bug Fix
 
+-   `Tooltip`: Opt in to `__stableShift` to ensure that the Tooltip is always within the viewport. ([#41524](https://github.com/WordPress/gutenberg/pull/41524))
 -   `FormTokenField`: Do not suggest the selected one even if `{ value: string }` is passed ([#41216](https://github.com/WordPress/gutenberg/pull/41216)).
 -   `CustomGradientBar`: Fix insertion and control point positioning to more closely follow cursor. ([#41492](https://github.com/WordPress/gutenberg/pull/41492))
 

--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Bug Fix
 
--   `Tooltip`: Opt in to `__stableShift` to ensure that the Tooltip is always within the viewport. ([#41524](https://github.com/WordPress/gutenberg/pull/41524))
+-   `Tooltip`: Opt in to `__unstableShift` to ensure that the Tooltip is always within the viewport. ([#41524](https://github.com/WordPress/gutenberg/pull/41524))
 -   `FormTokenField`: Do not suggest the selected one even if `{ value: string }` is passed ([#41216](https://github.com/WordPress/gutenberg/pull/41216)).
 -   `CustomGradientBar`: Fix insertion and control point positioning to more closely follow cursor. ([#41492](https://github.com/WordPress/gutenberg/pull/41492))
 

--- a/packages/components/src/tooltip/index.js
+++ b/packages/components/src/tooltip/index.js
@@ -65,6 +65,7 @@ const addPopoverToGrandchildren = ( {
 				aria-hidden="true"
 				animate={ false }
 				offset={ 12 }
+				__unstableShift
 			>
 				{ text }
 				<Shortcut


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Fix an issue with Tooltip where it would sometimes jitter when rendered at the edge of the screen.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

As of https://github.com/WordPress/gutenberg/pull/41402 the Popover sets `__unstableShift` as `false` by default. The Tooltip component requires this flag to render correctly, so let's opt it in.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

Opt the Tooltip component in to using the `__unstableShift` flag in the Popover.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->

1. Prior to this PR, open up the post editor and add a buttons block.
2. With the buttons block selected, hover over the Vertical orientation button to render its Tooltip.
3. Notice the jittering.
4. With this PR applied, there should be no jittering.

## Screenshots or screencast <!-- if applicable -->

| Before | After |
| --- | --- |
| ![2022-06-03 13 14 36](https://user-images.githubusercontent.com/14988353/171781392-75838759-eba3-431c-989d-d76bd8d731cb.gif) | <img width="291" alt="image" src="https://user-images.githubusercontent.com/14988353/171781363-57524ebd-ed32-4523-86de-c07a6f73f699.png"> |