### PR TITLE
Mobile - Skip some of the Drag & Drop E2E on iOS

### DIFF
--- a/packages/react-native-editor/__device-tests__/gutenberg-editor-drag-and-drop.test.js
+++ b/packages/react-native-editor/__device-tests__/gutenberg-editor-drag-and-drop.test.js
@@ -53,61 +53,73 @@ describe( 'Gutenberg Editor Drag & Drop blocks tests', () => {
 		await editorPage.removeBlockAtPosition( blockNames.paragraph, 1 );
 	} );
 
-	it( 'should be able to long-press on a text-based block to paste a text in a focused textinput', async () => {
-		// Add a Paragraph block
-		await editorPage.addNewBlock( blockNames.paragraph );
-		const paragraphBlockElement = await editorPage.getTextBlockAtPosition(
-			blockNames.paragraph
-		);
+	// skip iOS for now
+	if ( isAndroid() ) {
+		it( 'should be able to long-press on a text-based block to paste a text in a focused textinput', async () => {
+			// Add a Paragraph block
+			await editorPage.addNewBlock( blockNames.paragraph );
+			const paragraphBlockElement = await editorPage.getTextBlockAtPosition(
+				blockNames.paragraph
+			);
 
-		// Set clipboard text
-		await setClipboard( editorPage.driver, testData.shortText );
+			// Set clipboard text
+			await setClipboard( editorPage.driver, testData.shortText );
 
-		// Dismiss auto-suggestion popup
-		if ( isAndroid() ) {
-			// On Andrdoid 10 a new auto-suggestion popup is appearing to let the user paste text recently put in the clipboard. Let's dismiss it.
-			await editorPage.dismissAndroidClipboardSmartSuggestion();
-		}
+			// Dismiss auto-suggestion popup
+			if ( isAndroid() ) {
+				// On Andrdoid 10 a new auto-suggestion popup is appearing to let the user paste text recently put in the clipboard. Let's dismiss it.
+				await editorPage.dismissAndroidClipboardSmartSuggestion();
+			}
 
-		// Paste into the Paragraph block
-		await tapPasteAboveElement( editorPage.driver, paragraphBlockElement );
-		const paragraphText = await editorPage.getTextForParagraphBlockAtPosition(
-			1
-		);
+			// Paste into the Paragraph block
+			await tapPasteAboveElement(
+				editorPage.driver,
+				paragraphBlockElement
+			);
+			const paragraphText = await editorPage.getTextForParagraphBlockAtPosition(
+				1
+			);
 
-		// Expect to have the pasted text in the Paragraph block
-		expect( paragraphText ).toMatch( testData.shortText );
+			// Expect to have the pasted text in the Paragraph block
+			expect( paragraphText ).toMatch( testData.shortText );
 
-		// Remove the block
-		await editorPage.removeBlockAtPosition( blockNames.paragraph );
-	} );
+			// Remove the block
+			await editorPage.removeBlockAtPosition( blockNames.paragraph );
+		} );
+	}
 
-	it( 'should be able to long-press on a text-based block using the PlainText component to paste a text in a focused textinput', async () => {
-		// Add a Shortcode block
-		await editorPage.addNewBlock( blockNames.shortcode );
-		const shortcodeBlockElement = await editorPage.getShortBlockTextInputAtPosition(
-			blockNames.shortcode
-		);
+	// skip iOS for now
+	if ( isAndroid() ) {
+		it( 'should be able to long-press on a text-based block using the PlainText component to paste a text in a focused textinput', async () => {
+			// Add a Shortcode block
+			await editorPage.addNewBlock( blockNames.shortcode );
+			const shortcodeBlockElement = await editorPage.getShortBlockTextInputAtPosition(
+				blockNames.shortcode
+			);
 
-		// Set clipboard text
-		await setClipboard( editorPage.driver, testData.shortText );
+			// Set clipboard text
+			await setClipboard( editorPage.driver, testData.shortText );
 
-		// Dismiss auto-suggestion popup
-		if ( isAndroid() ) {
-			// On Andrdoid 10 a new auto-suggestion popup is appearing to let the user paste text recently put in the clipboard. Let's dismiss it.
-			await editorPage.dismissAndroidClipboardSmartSuggestion();
-		}
+			// Dismiss auto-suggestion popup
+			if ( isAndroid() ) {
+				// On Andrdoid 10 a new auto-suggestion popup is appearing to let the user paste text recently put in the clipboard. Let's dismiss it.
+				await editorPage.dismissAndroidClipboardSmartSuggestion();
+			}
 
-		// Paste into the Shortcode block
-		await tapPasteAboveElement( editorPage.driver, shortcodeBlockElement );
-		const shortcodeText = await shortcodeBlockElement.text();
+			// Paste into the Shortcode block
+			await tapPasteAboveElement(
+				editorPage.driver,
+				shortcodeBlockElement
+			);
+			const shortcodeText = await shortcodeBlockElement.text();
 
-		// Expect to have the pasted text in the Shortcode block
-		expect( shortcodeText ).toMatch( testData.shortText );
+			// Expect to have the pasted text in the Shortcode block
+			expect( shortcodeText ).toMatch( testData.shortText );
 
-		// Remove the block
-		await editorPage.removeBlockAtPosition( blockNames.shortcode );
-	} );
+			// Remove the block
+			await editorPage.removeBlockAtPosition( blockNames.shortcode );
+		} );
+	}
 
 	it( 'should be able to drag & drop a text-based block when the textinput is not focused', async () => {
 		// Initialize the editor with two Paragraph blocks

--- a/packages/react-native-editor/__device-tests__/gutenberg-editor-drag-and-drop.test.js
+++ b/packages/react-native-editor/__device-tests__/gutenberg-editor-drag-and-drop.test.js
@@ -12,6 +12,9 @@ import {
 } from './helpers/utils';
 import testData from './helpers/test-data';
 
+// Used to skip some tests on iOS
+const onlyOnAndroid = isAndroid() ? it : it.skip;
+
 describe( 'Gutenberg Editor Drag & Drop blocks tests', () => {
 	beforeEach( async () => {
 		await clearClipboard( editorPage.driver );
@@ -53,9 +56,9 @@ describe( 'Gutenberg Editor Drag & Drop blocks tests', () => {
 		await editorPage.removeBlockAtPosition( blockNames.paragraph, 1 );
 	} );
 
-	// skip iOS for now
-	if ( isAndroid() ) {
-		it( 'should be able to long-press on a text-based block to paste a text in a focused textinput', async () => {
+	onlyOnAndroid(
+		'should be able to long-press on a text-based block to paste a text in a focused textinput',
+		async () => {
 			// Add a Paragraph block
 			await editorPage.addNewBlock( blockNames.paragraph );
 			const paragraphBlockElement = await editorPage.getTextBlockAtPosition(
@@ -85,12 +88,12 @@ describe( 'Gutenberg Editor Drag & Drop blocks tests', () => {
 
 			// Remove the block
 			await editorPage.removeBlockAtPosition( blockNames.paragraph );
-		} );
-	}
+		}
+	);
 
-	// skip iOS for now
-	if ( isAndroid() ) {
-		it( 'should be able to long-press on a text-based block using the PlainText component to paste a text in a focused textinput', async () => {
+	onlyOnAndroid(
+		'should be able to long-press on a text-based block using the PlainText component to paste a text in a focused textinput',
+		async () => {
 			// Add a Shortcode block
 			await editorPage.addNewBlock( blockNames.shortcode );
 			const shortcodeBlockElement = await editorPage.getShortBlockTextInputAtPosition(
@@ -118,8 +121,8 @@ describe( 'Gutenberg Editor Drag & Drop blocks tests', () => {
 
 			// Remove the block
 			await editorPage.removeBlockAtPosition( blockNames.shortcode );
-		} );
-	}
+		}
+	);
 
 	it( 'should be able to drag & drop a text-based block when the textinput is not focused', async () => {
 		// Initialize the editor with two Paragraph blocks


### PR DESCRIPTION
- `Gutenberg Mobile PR` -> https://github.com/wordpress-mobile/gutenberg-mobile/pull/4926

## What?
This PR disables some of the newly introduced Drag & Drop blocks E2E due to flakiness.

## Why?
We are currently investigating how we can perform the long-pressing interaction needed for these tests to be reliable on CI.

## How?
It disables the following tests for iOS:

- should be able to long-press on a text-based block to paste a text in a focused textinput
- should be able to long-press on a text-based block using the PlainText component to paste a text in a focused textinput

It keeps only two tests for iOS, pending to see if those are more reliable.

## Testing Instructions
- Full E2E tests should pass in the [Gutenberg Mobile PR](https://github.com/wordpress-mobile/gutenberg-mobile/pull/4926).

## Screenshots or screencast <!-- if applicable -->
N / A