### PR TITLE
[RNMobile] Gallery block: Re-introduce `v1`

### DIFF
--- a/packages/block-library/src/gallery/shared.js
+++ b/packages/block-library/src/gallery/shared.js
@@ -45,8 +45,8 @@ function getGalleryBlockV2Enabled() {
  */
 export function isGalleryV2Enabled() {
 	// The logic for the native version is located in a different if statement
-	// due to the fact that the `process.env.IS_GUTENBERG_PLUGIN` constant
-	// should only be used as the condition in an if statement.
+	// due to a lint rule that prohibits a single conditional combining
+	// `process.env.IS_GUTENBERG_PLUGIN` with a native platform check.
 	if ( Platform.isNative ) {
 		return getGalleryBlockV2Enabled();
 	}

--- a/packages/block-library/src/gallery/shared.js
+++ b/packages/block-library/src/gallery/shared.js
@@ -3,6 +3,11 @@
  */
 import { get, pick } from 'lodash';
 
+/**
+ * WordPress dependencies
+ */
+import { Platform } from '@wordpress/element';
+
 export function defaultColumnsNumber( imageCount ) {
 	return imageCount ? Math.min( 3, imageCount ) : 3;
 }
@@ -23,6 +28,15 @@ export const pickRelevantMediaFiles = ( image, sizeSlug = 'large' ) => {
 	return imageProps;
 };
 
+function getGalleryBlockV2Enabled() {
+	// We want to fail early here, at least during beta testing phase, to ensure
+	// there aren't instances where undefined values cause false negatives.
+	if ( ! window.wp || typeof window.wp.galleryBlockV2Enabled !== 'boolean' ) {
+		throw 'window.wp.galleryBlockV2Enabled is not defined';
+	}
+	return window.wp.galleryBlockV2Enabled;
+}
+
 /**
  * The new gallery block format is not compatible with the use_BalanceTags option
  * in WP versions <= 5.8 https://core.trac.wordpress.org/ticket/54130. The
@@ -30,18 +44,17 @@ export const pickRelevantMediaFiles = ( image, sizeSlug = 'large' ) => {
  * can be removed when minimum supported WP version >=5.9.
  */
 export function isGalleryV2Enabled() {
+	// The logic for the native version is located in a different if statement
+	// due to the fact that the `process.env.IS_GUTENBERG_PLUGIN` constant
+	// should only be used as the condition in an if statement.
+	if ( Platform.isNative ) {
+		return getGalleryBlockV2Enabled();
+	}
+
 	// Only run the Gallery version compat check if the plugin is running, otherwise
 	// assume we are in 5.9 core and enable by default.
 	if ( process.env.IS_GUTENBERG_PLUGIN ) {
-		// We want to fail early here, at least during beta testing phase, to ensure
-		// there aren't instances where undefined values cause false negatives.
-		if (
-			! window.wp ||
-			typeof window.wp.galleryBlockV2Enabled !== 'boolean'
-		) {
-			throw 'window.wp.galleryBlockV2Enabled is not defined';
-		}
-		return window.wp.galleryBlockV2Enabled;
+		return getGalleryBlockV2Enabled();
 	}
 
 	return true;


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Re-introduce support for `v1` of the Gallery block to the native version of the editor.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

Addresses https://github.com/WordPress/gutenberg/issues/41465.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

The logic for getting the flag that determines whether to use `v1` and `v2` has been extracted to a new function `getGalleryBlockV2Enabled`. This way in the original function `isGalleryV2Enabled` we leave just two `if` statements, one per platform. This is required due to the limitation of the `process.env.IS_GUTENBERG_PLUGIN` constant, as you read in the comment within the code:

```
// The logic for the native version is located in a different if statement
// due to the fact that the `process.env.IS_GUTENBERG_PLUGIN` constant
// should only be used as the condition in an if statement.
```

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->
The `v2` version should only be used if at least one of the following conditions is met:
- The WordPress core version of the site is **5.9** or greater.
- The [`use_balanceTags` option](https://developer.wordpress.org/reference/functions/balancetags/#more-information) is enabled.

### Check `v1`
**Preparation:**
1. Install [WordPress version 5.8](https://wordpress.org/download/releases/) or lower locally ([installation instructions](https://wordpress.org/support/article/installing-wordpress-on-your-own-computer/#local-installation-instructions)).
2. Check that you can access the site locally (e.g. navigate to `http://localhost:8888/`).
3. Check that your local site is using WordPress version 5.8 by navigating to `<LOCAL_SITE_URL>/wp-admin/update-core.php`.
4. In the WordPress app, add a self-hosted site using the local site connection details.
**NOTE:** If you are testing with a device, instead of using the host `localhost`, use the local IP of your computer.

**Steps:**
1. Open the WordPress app and connect it with your local Metro server.
2. Navigate to the local site with WordPress core 5.8.
3. Open a post/page.
4. Add a Gallery block.
5. Add some images to the gallery.
6. Tap on the `...` button to open the editor settings.
7. Tap on "Switch to HTML Mode".
8. Observe that the HTML of the Gallery block is not composed of Image blocks (i.e. is `v1` format).
**Example:**
```
<!-- wp:gallery {"ids":[38],"linkTo":"none"} -->
<figure class="wp-block-gallery columns-1 is-cropped">
    <ul class="blocks-gallery-grid">
        <li class="blocks-gallery-item">
            <figure><img src="http://localhost:8888/wp-content/uploads/2022/06/265-5000x5000-1-scaled.jpeg" data-id="38"
                    class="wp-image-38" /></figure>
        </li>
    </ul>
</figure>
<!-- /wp:gallery -->
```

### Check `v2`
**Preparation:**
In WP.com, the WordPress version is greater than 5.8, so this can easily be tested by using a simple WP.com site.

**Steps:**
1. Open the WordPress app and connect it with your local Metro server.
2. Navigate to a WP.com site.
3. Open a post/page.
4. Add a Gallery block.
5. Add some images to the gallery.
6. Tap on the `...` button to open the editor settings.
7. Tap on "Switch to HTML Mode".
8. Observe that the HTML of the Gallery block contains Image blocks (i.e. is `v2` format):
**Example:**
```
<!-- wp:gallery {"linkTo":"none"} -->
<figure class="wp-block-gallery has-nested-images columns-default is-cropped">
    <!-- wp:image {"id":3326,"sizeSlug":"large","linkDestination":"none"} -->
    <figure class="wp-block-image size-large"><img
            src="https://****.files.wordpress.com/2022/05/image.jpg?w=1024" alt="" class="wp-image-3326" />
    </figure>
    <!-- /wp:image -->
</figure>
<!-- /wp:gallery -->
```

### Check that logic for the web version is unaffected by the change
**Preparation:**
Changes can be tested in the web version by adding the Gutenberg plugin to your local WordPress installation ([instructions](https://github.com/WordPress/gutenberg/blob/trunk/docs/contributors/code/getting-started-with-code-contribution.md#local-wordpress-environment)).

In my case, I managed to use my local Gutenberg repository by adding a symbolic link with name `gutenberg` into `<LOCAL_WP_INSTALLATION>/wp-content/plugins` folder. This allows using the command `npm run dev` to generate a development build on every change and reflect them on your local site. Alternatively, you can generate the production build by running `npm run build` and install the plugin in your local site.

**Steps:**
1. Navigate to your local site with WordPress core 5.8. via a browser.
2. Open a post/page.
3. Add a Gallery block.
5. Add some images to the gallery.
6. Click on the `...` button to open the editor settings.
7. Click on "Code editor".
8. Observe that the HTML of the Gallery block is not composed of Image blocks (i.e. is `v1` format).
**Example:**
```
<!-- wp:gallery {"ids":[38],"linkTo":"none"} -->
<figure class="wp-block-gallery columns-1 is-cropped">
    <ul class="blocks-gallery-grid">
        <li class="blocks-gallery-item">
            <figure><img src="http://localhost:8888/wp-content/uploads/2022/06/265-5000x5000-1-scaled.jpeg" data-id="38"
                    class="wp-image-38" /></figure>
        </li>
    </ul>
</figure>
<!-- /wp:gallery -->
```
9. Update WordPress to latest version in your local site (5.9 or greater).
10. Repeat steps 2 - 6.
11. Observe that the HTML of the Gallery block contains Image blocks (i.e. is `v2` format):
**Example:**
```
<!-- wp:gallery {"linkTo":"none"} -->
<figure class="wp-block-gallery has-nested-images columns-default is-cropped">
    <!-- wp:image {"id":3326,"sizeSlug":"large","linkDestination":"none"} -->
    <figure class="wp-block-image size-large"><img
            src="https://****.files.wordpress.com/2022/05/image.jpg?w=1024" alt="" class="wp-image-3326" />
    </figure>
    <!-- /wp:image -->
</figure>
<!-- /wp:gallery -->
```

## Screenshots or screencast <!-- if applicable -->
N/A
