### PR TITLE
Writing flow: Fix focus trap on certain input types

### DIFF
--- a/packages/block-editor/CHANGELOG.md
+++ b/packages/block-editor/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Bug fix
+
+-   Fix focus trap on certain `input` elements when navigating within a block with the left/right arrow keys ([#41538](https://github.com/WordPress/gutenberg/pull/41538)).
+
 ## 9.2.0 (2022-06-01)
 
 ## 9.1.0 (2022-05-18)

--- a/packages/block-editor/src/components/writing-flow/test/index.js
+++ b/packages/block-editor/src/components/writing-flow/test/index.js
@@ -12,7 +12,13 @@ describe( 'isNavigationCandidate', () => {
 	let elements;
 	beforeAll( () => {
 		elements = {};
-		elements.input = document.createElement( 'input' );
+
+		elements.inputText = document.createElement( 'input' );
+		elements.inputText.setAttribute( 'type', 'text' );
+
+		elements.inputCheckbox = document.createElement( 'input' );
+		elements.inputCheckbox.setAttribute( 'type', 'checkbox' );
+
 		elements.contentEditable = document.createElement( 'p' );
 		elements.contentEditable.contentEditable = true;
 	} );
@@ -20,7 +26,7 @@ describe( 'isNavigationCandidate', () => {
 	it( 'should return true if vertically navigating input without modifier', () => {
 		[ UP, DOWN ].forEach( ( keyCode ) => {
 			const result = isNavigationCandidate(
-				elements.input,
+				elements.inputText,
 				keyCode,
 				false
 			);
@@ -32,7 +38,7 @@ describe( 'isNavigationCandidate', () => {
 	it( 'should return false if vertically navigating input with modifier', () => {
 		[ UP, DOWN ].forEach( ( keyCode ) => {
 			const result = isNavigationCandidate(
-				elements.input,
+				elements.inputText,
 				keyCode,
 				true
 			);
@@ -44,12 +50,24 @@ describe( 'isNavigationCandidate', () => {
 	it( 'should return false if horizontally navigating input', () => {
 		[ LEFT, RIGHT ].forEach( ( keyCode ) => {
 			const result = isNavigationCandidate(
-				elements.input,
+				elements.inputText,
 				keyCode,
 				false
 			);
 
 			expect( result ).toBe( false );
+		} );
+	} );
+
+	it( 'should return true if horizontally navigating simple inputs like checkboxes', () => {
+		[ LEFT, RIGHT ].forEach( ( keyCode ) => {
+			const result = isNavigationCandidate(
+				elements.inputCheckbox,
+				keyCode,
+				false
+			);
+
+			expect( result ).toBe( true );
 		} );
 	} );
 

--- a/packages/block-editor/src/components/writing-flow/use-arrow-nav.js
+++ b/packages/block-editor/src/components/writing-flow/use-arrow-nav.js
@@ -43,9 +43,25 @@ export function isNavigationCandidate( element, keyCode, hasModifier ) {
 		return true;
 	}
 
-	// Native inputs should not navigate horizontally.
 	const { tagName } = element;
-	return tagName !== 'INPUT' && tagName !== 'TEXTAREA';
+
+	// Native inputs should not navigate horizontally, unless they are simple types that don't need left/right arrow keys.
+	if ( tagName === 'INPUT' ) {
+		const simpleInputTypes = [
+			'button',
+			'checkbox',
+			'color',
+			'file',
+			'image',
+			'radio',
+			'reset',
+			'submit',
+		];
+		return simpleInputTypes.includes( element.getAttribute( 'type' ) );
+	}
+
+	// Native textareas should not navigate horizontally.
+	return tagName !== 'TEXTAREA';
 }
 
 /**


### PR DESCRIPTION
Fixes #32715

## What?

Fixes an issue where keyboard focus could get stuck on certain types of `<input>` elements when using the left/right arrow keys to navigate interactive elements within a block.

## Why?

There is no need to prevent horizontal arrow nav on `input` element types that do not require horizontal arrow nav internally, such as `checkbox` and `radio`.

## How?

I picked out an allowlist of input types (from [MDN](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input#input_types)) that are safe to be navigation candidates.

## Testing Instructions

1. Add a `<input type="checkbox" />` to the edit component of a core block, such as `Code`. If necessary, flexbox the container so the buttons are horizontally aligned.

    Example modification of the Code block:

    ```js
		<div { ...blockProps } style={ { display: 'flex' } }>
			<input type="checkbox" />
			<input type="radio" />
			<pre>
				<RichText
					tagName="code"
					value={ attributes.content }
					onChange={ ( content ) => setAttributes( { content } ) }
					onRemove={ onRemove }
					placeholder={ __( 'Write code…' ) }
					aria-label={ __( 'Code' ) }
					preserveWhiteSpace
					__unstablePastePlainText
				/>
			</pre>
		</div>

    ```

2. Move keyboard focus to the first `<input>`, and hit the right arrow key.

## Screenshots or screencast <!-- if applicable -->

https://user-images.githubusercontent.com/555336/171871821-a4584c55-3d1a-4966-a98d-55bbce849a04.mp4


