### PR TITLE
Fix retrieving autosaves when using a custom rest_namespace

### DIFF
--- a/packages/core-data/src/resolvers.js
+++ b/packages/core-data/src/resolvers.js
@@ -327,9 +327,9 @@ export const getAutosaves = ( postType, postId ) => async ( {
 	dispatch,
 	resolveSelect,
 } ) => {
-	const { rest_base: restBase } = await resolveSelect.getPostType( postType );
+	const { rest_base: restBase, rest_namespace: restNamespace } = await resolveSelect.getPostType( postType );
 	const autosaves = await apiFetch( {
-		path: `/wp/v2/${ restBase }/${ postId }/autosaves?context=edit`,
+		path: `/${ restNamespace }/${ restBase }/${ postId }/autosaves?context=edit`,
 	} );
 
 	if ( autosaves && autosaves.length ) {

--- a/packages/core-data/src/resolvers.js
+++ b/packages/core-data/src/resolvers.js
@@ -328,8 +328,10 @@ export const getAutosaves = ( postType, postId ) => async ( {
 	resolveSelect,
 } ) => {
 	const { rest_base: restBase, rest_namespace: restNamespace } = await resolveSelect.getPostType( postType );
+	const namespace = rest_namespace ?? 'wp/v2';
+
 	const autosaves = await apiFetch( {
-		path: `/${ restNamespace }/${ restBase }/${ postId }/autosaves?context=edit`,
+		path: `/${ namespace }/${ restBase }/${ postId }/autosaves?context=edit`,
 	} );
 
 	if ( autosaves && autosaves.length ) {


### PR DESCRIPTION
When specifying `rest_namespace` in a custom post type, a hardcoded `wp/v2` in `getAutosaves` results in a 404<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->

## Screenshots or screencast <!-- if applicable -->
