### PR TITLE
add missing wpautop for reusable blocks content

### DIFF
--- a/packages/block-library/src/block/index.php
+++ b/packages/block-library/src/block/index.php
@@ -46,6 +46,7 @@ function render_block_core_block( $attributes ) {
 	global $wp_embed;
 	$content = $wp_embed->run_shortcode( $reusable_block->post_content );
 	$content = $wp_embed->autoembed( $content );
+	$content = wpautop( $content );
 
 	$content = do_blocks( $content );
 	unset( $seen_refs[ $attributes['ref'] ] );


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
add missing wpautop for reusable blocks content

## Why?
see #38053


