### PR TITLE
Style engine: allow for zero values for CSS properties in the style engine

### DIFF
--- a/packages/style-engine/class-wp-style-engine.php
+++ b/packages/style-engine/class-wp-style-engine.php
@@ -156,6 +156,25 @@ class WP_Style_Engine {
 	}
 
 	/**
+	 * Checks whether an incoming style value is valid.
+	 *
+	 * @param string? $style_value  A single css preset value.
+	 *
+	 * @return boolean
+	 */
+	protected static function is_valid_style_value( $style_value ) {
+		if ( '0' === $style_value ) {
+			return true;
+		}
+
+		if ( empty( $style_value ) ) {
+			return false;
+		}
+
+		return true;
+	}
+
+	/**
 	 * Returns classnames, and generates classname(s) from a CSS preset property pattern, e.g., 'var:preset|color|heavenly-blue'.
 	 *
 	 * @param array         $style_value      A single raw style value or css preset property from the generate() $block_styles array.
@@ -165,6 +184,11 @@ class WP_Style_Engine {
 	 */
 	protected static function get_classnames( $style_value, $style_definition ) {
 		$classnames = array();
+
+		if ( empty( $style_value ) ) {
+			return $classnames;
+		}
+
 		if ( ! empty( $style_definition['classnames'] ) ) {
 			foreach ( $style_definition['classnames'] as $classname => $property_key ) {
 				if ( true === $property_key ) {
@@ -196,12 +220,7 @@ class WP_Style_Engine {
 	 * @return array        An array of CSS rules.
 	 */
 	protected static function get_css( $style_value, $style_definition, $should_return_css_vars ) {
-		$rules = array();
-
-		if ( ! $style_value ) {
-			return $rules;
-		}
-
+		$rules          = array();
 		$style_property = $style_definition['property_key'];
 
 		// Build CSS var values from var:? values, e.g, `var(--wp--css--rule-slug )`
@@ -269,7 +288,7 @@ class WP_Style_Engine {
 			foreach ( $definition_group as $style_definition ) {
 				$style_value = _wp_array_get( $block_styles, $style_definition['path'], null );
 
-				if ( empty( $style_value ) ) {
+				if ( ! static::is_valid_style_value( $style_value ) ) {
 					continue;
 				}
 

--- a/packages/style-engine/class-wp-style-engine.php
+++ b/packages/style-engine/class-wp-style-engine.php
@@ -185,10 +185,6 @@ class WP_Style_Engine {
 	protected static function get_classnames( $style_value, $style_definition ) {
 		$classnames = array();
 
-		if ( empty( $style_value ) ) {
-			return $classnames;
-		}
-
 		if ( ! empty( $style_definition['classnames'] ) ) {
 			foreach ( $style_definition['classnames'] as $classname => $property_key ) {
 				if ( true === $property_key ) {

--- a/packages/style-engine/class-wp-style-engine.php
+++ b/packages/style-engine/class-wp-style-engine.php
@@ -185,6 +185,10 @@ class WP_Style_Engine {
 	protected static function get_classnames( $style_value, $style_definition ) {
 		$classnames = array();
 
+		if ( empty( $style_value ) ) {
+			return $classnames;
+		}
+
 		if ( ! empty( $style_definition['classnames'] ) ) {
 			foreach ( $style_definition['classnames'] as $classname => $property_key ) {
 				if ( true === $property_key ) {

--- a/packages/style-engine/phpunit/class-wp-style-engine-test.php
+++ b/packages/style-engine/phpunit/class-wp-style-engine-test.php
@@ -73,12 +73,13 @@ class WP_Style_Engine_Test extends WP_UnitTestCase {
 						'text' => 'var:preset|color|texas-flood',
 					),
 					'spacing' => array(
-						'margin' => '111px',
+						'margin'  => '111px',
+						'padding' => '0',
 					),
 				),
 				'options'         => array(),
 				'expected_output' => array(
-					'css'        => 'margin: 111px;',
+					'css'        => 'padding: 0; margin: 111px;',
 					'classnames' => 'has-text-color has-texas-flood-color',
 				),
 			),


### PR DESCRIPTION
## What?
Allow for zero values for CSS properties in the style engine.

## Why?
Just in case we come across a style value of `'0'` , e.g., `padding: '0'`.

This PR ensures the previous `empty()` check doesn't fail for '0'.

## How?
Create an opinionated, dedicated method so we can use it elsewhere if required.

## Testing Instructions

```bash
npm run test-unit-php /var/www/html/wp-content/plugins/gutenberg/packages/style-engine/phpunit/class-wp-style-engine-test.php
```
