### PR TITLE
Add label to Preview options dropdown menu

### DIFF
--- a/packages/block-editor/src/components/preview-options/index.js
+++ b/packages/block-editor/src/components/preview-options/index.js
@@ -35,13 +35,16 @@ export default function PreviewOptions( {
 		/* translators: button label text should, if possible, be under 16 characters. */
 		children: __( 'Preview' ),
 	};
+	const menuProps = {
+		'aria-label': __( 'Preview options' ),
+	};
 	return (
 		<DropdownMenu
 			className="block-editor-post-preview__dropdown"
 			popoverProps={ popoverProps }
 			toggleProps={ toggleProps }
+			menuProps={ menuProps }
 			icon={ null }
-			label={ __( 'Preview options' ) }
 		>
 			{ () => (
 				<>

--- a/packages/block-editor/src/components/preview-options/index.js
+++ b/packages/block-editor/src/components/preview-options/index.js
@@ -41,6 +41,7 @@ export default function PreviewOptions( {
 			popoverProps={ popoverProps }
 			toggleProps={ toggleProps }
 			icon={ null }
+			label={ __( 'Preview options' ) }
 		>
 			{ () => (
 				<>


### PR DESCRIPTION
## What?

Resolves #41514.

PR adds label the Preview options dropdown menu.

## Testing Instructions
1. Open a Post or Page. and click the "Preview" button in the top toolbar.
2. Open up browser code inspector.
3. Check that preview dropdown markup has an accessible label.

## Screenshots or screencast <!-- if applicable -->

<img width="858" alt="Screenshot 2022-06-06 at 13 50 17" src="https://user-images.githubusercontent.com/240569/172164355-11bfd128-f9a8-4ce8-87be-3fd53c45983a.png">

