### PR TITLE
Webfonts: increase priority of init hook to account for block reregistration

### DIFF
--- a/lib/experimental/register-webfonts-from-theme-json.php
+++ b/lib/experimental/register-webfonts-from-theme-json.php
@@ -9,7 +9,6 @@
  * Register webfonts defined in theme.json.
  */
 function gutenberg_register_webfonts_from_theme_json() {
-
 	// Get settings.
 	$settings = WP_Theme_JSON_Resolver_Gutenberg::get_merged_data()->get_settings();
 

--- a/lib/experimental/register-webfonts-from-theme-json.php
+++ b/lib/experimental/register-webfonts-from-theme-json.php
@@ -9,6 +9,7 @@
  * Register webfonts defined in theme.json.
  */
 function gutenberg_register_webfonts_from_theme_json() {
+
 	// Get settings.
 	$settings = WP_Theme_JSON_Resolver_Gutenberg::get_merged_data()->get_settings();
 
@@ -174,4 +175,9 @@ function gutenberg_add_registered_webfonts_to_theme_json( $data ) {
 	return $data;
 }
 
-add_action( 'init', 'gutenberg_register_webfonts_from_theme_json' );
+// `gutenberg_register_webfonts_from_theme_json()` calls `WP_Theme_JSON_Resolver_Gutenberg::get_merged_data()`, which instantiates `WP_Theme_JSON_Gutenberg()`;
+// Gutenberg server-side blocks are registered via the init hook with a priority value of `20`. E.g., `add_action( 'init', 'register_block_core_image', 20 )`;
+// This priority value is added dynamically during the build. See: tools/webpack/blocks.js.
+// We want to make sure Gutenberg blocks are re-registered before any Theme_JSON operations take place
+// so that we have access to updated merged data.
+add_action( 'init', 'gutenberg_register_webfonts_from_theme_json', 21 );


### PR DESCRIPTION
Fixes https://github.com/WordPress/gutenberg/issues/41296 (I think)


## What?

Webfonts are registered via the `init` hook at the highest priority. 

Gutenberg server-side blocks are registered via the `init `hook with a priority value of `20`. E.g., `add_action( 'init', 'register_block_core_image', 20 )`;

This priority value is added dynamically during the build. See: [tools/webpack/blocks.js](https://github.com/WordPress/gutenberg/blob/trunk/tools/webpack/blocks.js#L164).

`gutenberg_register_webfonts_from_theme_json()` calls `WP_Theme_JSON_Resolver_Gutenberg::get_merged_data()`, 
which instantiates `WP_Theme_JSON_Gutenberg()`;

Unfortunately this happens before Gutenberg server-side blocks are re-registered, therefore any plugin-only updates to block.json for example do not appear in the theme.json merged data.


## Why?

We want to make sure Gutenberg blocks are re-registered **before** any Theme_JSON operations take place so that we have access to updated merged data.

## How?

Bumping priority from `20` to `21`: `add_action( 'init', 'gutenberg_register_webfonts_from_theme_json', 21 );`

## Testing Instructions

Add an `__experimentalSelector` property to a block in its block.json file:

```json
	"supports": {
		...
		"__experimentalSelector": ".wp-block-image img"
	},
```


Check that the selector is registered in [get_blocks_metadata](https://github.com/WordPress/gutenberg/blob/9614359ff62bd4df6f9bc9eb023318c643c55a8b/lib/compat/wordpress-6.1/class-wp-theme-json-6-1.php#L70)

And that blocks load as per normal 😄 

Go through the test steps on the original webfonts PR:

- https://github.com/WordPress/gutenberg/pull/37140


