### PR TITLE
Cover: Add text color block support

### DIFF
--- a/docs/reference-guides/core-blocks.md
+++ b/docs/reference-guides/core-blocks.md
@@ -230,7 +230,7 @@ Add an image or video with a text overlay — great for headers. ([Source](https
 
 -	**Name:** core/cover
 -	**Category:** media
--	**Supports:** align, anchor, color (~~background~~, ~~text~~), spacing (blockGap, margin, padding), typography (fontSize, lineHeight), ~~html~~
+-	**Supports:** align, anchor, color (text, ~~background~~), spacing (blockGap, margin, padding), typography (fontSize, lineHeight), ~~html~~
 -	**Attributes:** allowedBlocks, alt, backgroundType, contentPosition, customGradient, customOverlayColor, dimRatio, focalPoint, gradient, hasParallax, id, isDark, isRepeated, minHeight, minHeightUnit, overlayColor, tagName, templateLock, url, useFeaturedImage
 
 ## Embed

--- a/packages/block-library/src/cover/block.json
+++ b/packages/block-library/src/cover/block.json
@@ -96,7 +96,7 @@
 		},
 		"color": {
 			"__experimentalDuotone": "> .wp-block-cover__image-background, > .wp-block-cover__video-background",
-			"text": false,
+			"text": true,
 			"background": false
 		},
 		"typography": {

--- a/packages/block-library/src/cover/block.json
+++ b/packages/block-library/src/cover/block.json
@@ -97,7 +97,8 @@
 		"color": {
 			"__experimentalDuotone": "> .wp-block-cover__image-background, > .wp-block-cover__video-background",
 			"text": true,
-			"background": false
+			"background": false,
+			"__experimentalSkipSerialization": [ "gradients" ]
 		},
 		"typography": {
 			"fontSize": true,

--- a/packages/block-library/src/cover/style.scss
+++ b/packages/block-library/src/cover/style.scss
@@ -106,15 +106,9 @@
 	.wp-block-cover__inner-container {
 		width: 100%;
 		z-index: z-index(".wp-block-cover__inner-container");
-		color: $white;
+		color: inherit;
 		// Reset the fixed LTR direction at the root of the block in RTL languages.
 		/*rtl:raw: direction: rtl; */
-	}
-
-	&.is-light {
-		.wp-block-cover__inner-container {
-			color: $black;
-		}
 	}
 
 	p,
@@ -284,4 +278,19 @@ section.wp-block-cover-image > h2,
 	max-width: $content-width;
 	padding: 0.44em;
 	text-align: center;
+}
+
+// If Cover block's text color has not been set adjust default color
+// based on if overlay is light or not. The following styles leverage
+// `:where` to allow for generic global styles that have a low specificity to
+// still take precedence.
+
+:where(.wp-block-cover:not(.has-text-color)),
+:where(.wp-block-cover-image:not(.has-text-color)) {
+	color: $white;
+}
+
+:where(.wp-block-cover.is-light:not(.has-text-color)),
+:where(.wp-block-cover-image.is-light:not(.has-text-color)) {
+	color: $black;
 }


### PR DESCRIPTION
Depends on:
- https://github.com/WordPress/gutenberg/pull/41102

Related:
- https://github.com/WordPress/gutenberg/pull/38458
- https://github.com/WordPress/gutenberg/pull/40666

## What?

Adds text color support to the Cover block.

## Why?

This makes it easier to style the text color for a Cover's inner blocks as it can be set once only on the Cover block itself. It also allows us to clean up the Media & Text transforms so that text colors are cleanly passed between the resulting blocks.


## How?

- Opts into text color support
- Updates the Media & Text from/to transforms to handle text colors via block support attributes rather than updating inner blocks as well.
- Moves the light/dark adjustments of text color to the main block wrapper and applies them leveraging `:where` to allow for global styles or theme.json supplied colors to take precedence. (Whether this is desirable could be up for discussion)

## Testing Instructions

1. Create a couple of Media & Text blocks and assign them text and background colors, test both preset and custom colors.
2. Transform the Media & Text blocks to a Cover block
3. Check that the colors are assigned appropriately on the new Cover blocks i.e. the overlay is correct, the text color is only applied to the Cover block, and it all looks correct
4. Convert back to a Media & Text blocks and double check they appear as they did prior to the original transformation
5. Create a Cover block, add a gradient overlay and assign a text color.
6. Transform this Cover block to a Media & Text block and back again. It's color should be correct after each transform.
7. Try adjusting the overlay opacity for the Cover block between very low and very high values. The selected text color should be honored and not change.
8. Save the post and check the text color appears correctly on the front end
9. Back in the editor, remove the text color selection and again adjust the overlay opacity between the extremes.  The visual color of the text should be modified due to the light/dark handling of the Cover block.
10. Save again and make sure the light/dark adjusted color is reflected on the frontend.
11. Trial styling Cover block colors via theme.json and Global Styles. The global styles value should be applied over the light/dark defaults.

## Screenshots or screencast <!-- if applicable -->

| Adjusting Colors | Transforming Cover Blocks |
|---|---|
| <video src="https://user-images.githubusercontent.com/60436221/172309831-5a5cdb8b-baef-4bb8-8d8c-cd9b47bd2c77.mp4" /> | <video src="https://user-images.githubusercontent.com/60436221/172309841-5abd0959-6886-4c51-9e98-5c6d314d6dac.mp4" /> |





