### PR TITLE
Avatar block: error on loading if Avatars are disabled on Settings

### DIFF
--- a/packages/block-library/src/avatar/hooks.js
+++ b/packages/block-library/src/avatar/hooks.js
@@ -76,12 +76,14 @@ export function useUserAvatar( { userId, postId, postType } ) {
 		},
 		[ postType, postId, userId ]
 	);
-	const avatarUrls = authorDetails && authorDetails.avatar_urls !== undefined
-		? Object.values( authorDetails.avatar_urls )
-		: null;
-	const sizes = authorDetails && authorDetails.avatar_urls !== undefined
-		? Object.keys( authorDetails.avatar_urls )
-		: null;
+	const avatarUrls =
+		authorDetails && authorDetails.avatar_urls !== undefined
+			? Object.values( authorDetails.avatar_urls )
+			: null;
+	const sizes =
+		authorDetails && authorDetails.avatar_urls !== undefined
+			? Object.keys( authorDetails.avatar_urls )
+			: null;
 	const { minSize, maxSize } = getAvatarSizes( sizes );
 	const defaultAvatar = useDefaultAvatar();
 	return {

--- a/packages/block-library/src/avatar/hooks.js
+++ b/packages/block-library/src/avatar/hooks.js
@@ -76,10 +76,10 @@ export function useUserAvatar( { userId, postId, postType } ) {
 		},
 		[ postType, postId, userId ]
 	);
-	const avatarUrls = authorDetails
+	const avatarUrls = authorDetails && authorDetails.avatar_urls !== undefined
 		? Object.values( authorDetails.avatar_urls )
 		: null;
-	const sizes = authorDetails
+	const sizes = authorDetails && authorDetails.avatar_urls !== undefined
 		? Object.keys( authorDetails.avatar_urls )
 		: null;
 	const { minSize, maxSize } = getAvatarSizes( sizes );


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->
Fixes #41308
Closes #41313
Closes #41354

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
Right now, if Avatars are disabled on settings and we try to add it as a block, we got an error:
![Screenshot 2022-06-07 at 16 25 31](https://user-images.githubusercontent.com/37012961/172405317-55d3b263-63d8-4b49-8478-7b83e7c8963c.png)

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

Maybe it would be a good idea to make this block conditional if Avatar is disabled, or add a warning. But in this PR, we are just avoiding the JS error (the avatar will load the default one on the editor, and not in the frontend if they are disabled, causing some inconsistency between them).

We can maybe address it in another PR after some design feedback:
cc @javierarce , @richtabor, @estelaris 

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->
In trunk:
1.) Disable avatars on settings.
2.) Add Avatar block.
3.) Check the crash

After the fix:
1.) Disable avatars on settings.
2.) Add Avatar block.
3.) Avatar is displayed on the editor, not in the frontend.

## Screenshots or screencast <!-- if applicable -->
