### PR TITLE
[data] Enable manually specifying curried selector signatures

### DIFF
--- a/packages/data/src/types.ts
+++ b/packages/data/src/types.ts
@@ -96,13 +96,11 @@ type Store<
  * interdependent generic parameters.
  * For more context, see https://github.com/WordPress/gutenberg/pull/41578
  */
-type CurriedState< F > =
-	F extends SelectorWithCustomCurrySignature
-		? F['CurriedSignature']
-		: F extends ( state: any, ...args: infer P ) => infer R
-			? ( ...args: P ) => R
-			: F;
-
+type CurriedState< F > = F extends SelectorWithCustomCurrySignature
+	? F[ 'CurriedSignature' ]
+	: F extends ( state: any, ...args: infer P ) => infer R
+	? ( ...args: P ) => R
+	: F;
 /**
  * Utility to manually specify curried selector signatures.
  *

--- a/packages/data/src/types.ts
+++ b/packages/data/src/types.ts
@@ -76,18 +76,73 @@ type Store<
 	: never;
 
 /**
- * Removes the first argument from a function
+ * Removes the first argument from a function.
  *
- * This is designed to remove the `state` parameter from
+ * By default, it removes the `state` parameter from
  * registered selectors since that argument is supplied
  * by the editor when calling `select(…)`.
  *
  * For functions with no arguments, which some selectors
  * are free to define, returns the original function.
+ *
+ * It is possible to manually provide a custom curried signature
+ * and avoid the automatic inference. When the
+ * F generic argument passed to this helper extends the
+ * SelectorWithCustomCurrySignature type, the F['CurriedSignature']
+ * property is used verbatim.
+ *
+ * This is useful because TypeScript does not correctly remove
+ * arguments from complex function signatures constrained by
+ * interdependent generic parameters.
  */
-type CurriedState< F > = F extends ( state: any, ...args: infer P ) => infer R
-	? ( ...args: P ) => R
-	: F;
+type CurriedState< F > =
+	F extends SelectorWithCustomCurrySignature
+		? F['CurriedSignature']
+		: F extends ( state: any, ...args: infer P ) => infer R
+			? ( ...args: P ) => R
+			: F;
+
+/**
+ * Utility to manually specify curried selector signatures.
+ *
+ * It comes handy when TypeScript can't automatically produce the
+ * correct curried function signature. For example:
+ *
+ * ```ts
+ * type BadlyInferredSignature = CurriedState<
+ *     <K extends string | number>(
+ *         state: any,
+ *         kind: K,
+ *         key: K extends string ? 'one value' : false
+ *     ) => K
+ * >
+ * // BadlyInferredSignature evaluates to:
+ * // (kind: string number, key: false "one value") => string number
+ * ```
+ *
+ * With SelectorWithCustomCurrySignature, we can provide a custom
+ * signature and avoid relying on TypeScript inference:
+ * ```ts
+ * interface MySelectorSignature extends SelectorWithCustomCurrySignature {
+ *     <K extends string | number>(
+ *         state: any,
+ *         kind: K,
+ *         key: K extends string ? 'one value' : false
+ *     ): K;
+ *
+ *     CurriedSignature: <K extends string | number>(
+ *         kind: K,
+ *         key: K extends string ? 'one value' : false
+ *     ): K;
+ * }
+ * type CorrectlyInferredSignature = CurriedState<MySelectorSignature>
+ * // <K extends string | number>(kind: K, key: K extends string ? 'one value' : false): K;
+ * ```
+ */
+export interface SelectorWithCustomCurrySignature {
+	__isCurryContainer: true;
+	CurriedSignature: Function;
+}
 
 /**
  * Returns a function whose return type is a Promise of the given return type.

--- a/packages/data/src/types.ts
+++ b/packages/data/src/types.ts
@@ -94,6 +94,7 @@ type Store<
  * This is useful because TypeScript does not correctly remove
  * arguments from complex function signatures constrained by
  * interdependent generic parameters.
+ * For more context, see https://github.com/WordPress/gutenberg/pull/41578
  */
 type CurriedState< F > =
 	F extends SelectorWithCustomCurrySignature
@@ -137,6 +138,8 @@ type CurriedState< F > =
  * }
  * type CorrectlyInferredSignature = CurriedState<MySelectorSignature>
  * // <K extends string | number>(kind: K, key: K extends string ? 'one value' : false): K;
+ *
+ * For even more context, see https://github.com/WordPress/gutenberg/pull/41578
  * ```
  */
 export interface SelectorWithCustomCurrySignature {


### PR DESCRIPTION
## What problem is this PR solving?

The `CurriedState` provided in https://github.com/WordPress/gutenberg/pull/39081 does not correctly curry complex type signatures.

### What's `CurriedState`?

The `CurriedState` type is provided to remove the `state` argument from selectors function signatures:

```ts
type SimpleSelector = (state: {}, myNumberArg: number) => string;
const selector = {} as SimpleSelector;
selector({}, 15);

const curried = {} as CurriedState<SimpleSelector>;
curried(15);
```

It's needed to transform the definitions in `selectors.ts` that accept the `state` argument, to signatures exposed by `useSelect(select => select( store )./*...*/)` that do not accept the `state` argument`

### Where does it fall short?

Here's a minimalistic example:

```ts
type BadlyInferredSignature = CurriedState<
    <K extends string | number>(
        state: any,
        kind: K,
        key: K extends string ? 'one value' : false
    ) => K
>
// BadlyInferredSignature evaluates to:
// (kind: string number, key: false | "one value") => string number
```

## What solution does this PR propose?

I don't believe TypeScript supports the kind of automatic transformation the `CurriedState` wants to do.

This PR provides an escape hatch to manually specify the curried signatures when TypeScript falls short:

```ts
interface MySelectorSignature extends SelectorWithCustomCurrySignature {
    <K extends string | number>(
        state: any,
        kind: K,
        key: K extends string ? 'one value' : false
    ): K;

    CurriedSignature: <K extends string | number>(
        kind: K,
        key: K extends string ? 'one value' : false
    ): K;
}
type CorrectlyInferredSignature = CurriedState<MySelectorSignature>
// <K extends string | number>(kind: K, key: K extends string ? 'one value' : false): K;
```

## What else has been tried?

I've tried a ton of different ways to infer things automatically.

Here's the basic setup used in all the attempts:

```ts
interface CommentEntityRecord { id: number; content: string; }
interface PostEntityRecord { id: string; title: string; }

type EntityConfig =
    | { kind: 'root', record: CommentEntityRecord, keyType: number }
    | { kind: 'postType', record: PostEntityRecord, keyType: string }

const getEntityRecords = <K extends EntityConfig['kind']>(
    kind: K,
    key: Extract<EntityConfig, { kind: K }>['keyType']
): Extract<EntityConfig, { kind: K }>['record'] => { return {} as any; };

const getEntityRecordsWithState = <K extends EntityConfig['kind']>(
    state: any,
    kind: K,
    key: Extract<EntityConfig, { kind: K }>['keyType']
): Extract<EntityConfig, { kind: K }>['record'] => { return {} as any; };
```

Instead of trying to do the `Curry`, which clones the signature with one argument less, I tried to just clone the signature which seems easier and requires less complexity.

My ideal `Clone` type helper would do the following:

```ts
type ClonedF = Clone<F>;
// ClonedF is the same as F.
```

The only constraint is I am not allowed to simply do this:
```ts
type Clone<F> = F;
```

After many hours, I don't think such type can be created in a way that works with generic functions.

### Universal clone like `CloneAnyFunction<F>`

In this scenario, we need to derive F somehow

One way to infer the function type is to use the infer TypeScript feature:
```ts
type InferredSignature = typeof getEntityRecords extends (...args:infer A) => infer R ? (...args:A) => R : never;
//   ^? (kind: "root" | "postType", key: string | number) => CommentEntityRecord | PostEntityRecord
```
InferredSignature type is not constrained in the same way as the actual arguments are, so this is dead end.

Another way would be to use the typeof operator:
```ts
type TypeOfSignature = typeof getEntityRecords;
//   ^? <K extends "root" | "postType">(kind: K, key: (Extract<{kind:  //...
```
It seems like a step in the right direction – the TypeOfSignature type reflects all the constraints we care about.

Unfortunately, there isn't much we can do with them. For example, we can't extract them with the Parameters<> helper:
```ts
type SelectorArguments = Parameters<TypeOfSignature>
//   ^? [kind: "root" | "postType", key: string | number]
```

SelectorArguments is the same as args of the InferredSignature – which tells me that raw `typeof` is a dead end.

There's a twist on `typeof` called ["instantiation expressions"](https://github.com/microsoft/TypeScript/pull/47607):
```ts
type InstantiatedTypeOfSignature = typeof getEntityRecords<'root'>;
//   ^? (kind: "root", key: number) => CommentEntityRecord
```

It is better in that the signature reflects the actual constraints imposed on the getEntityRecords definition. The problem now is that it's only for the specific kind value of 'root'. We want to make it work for any possible kind value.

Let's try passing a type union:

```ts
type InstantiatedTypeOfSignatureUnion = typeof getEntityRecords<'root' | 'postType'>;
//   ^? (kind: "root" | "postType", key: string | number) => CommentEntityRecord | PostEntityRecord
```
Nope, this signature lacks the constraints as well.

Finally, we could try parametrizing the signature type as follows:
```ts
type ParametrizedSignature<Param0> = typeof getEntityRecords<Param0>;
```

The problem here is that we'd need to specify the exact same constraints as getEntityRecords, otherwise we get this error:
```
Type 'Generic1' does not satisfy the constraint '"root" | "postType"'
```
 
The only solution seems to be really:
```ts
type SpecializedSignature<Param0 extends EntityConfig['kind']> = typeof getEntityRecords<Param0>;
//   ^? <Param0 extends "root" | "postType">(kind: Param0, key: (Extract<{kind:  //...
```

The only thing we did here, though, is we moved the Kind from a function to a proxy type. We still have all the same problems as before, e.g.: 

```ts
type SadlyUnspecializedArguments = Parameters<SpecializedSignature<EntityConfig['kind']>>
//   ^? [kind: "root" | "postType", key: string I number]
type SadlyUnspecializedClone = SpecializedSignature<EntityConfig['kind']> extends (...args:infer A) => infer R ? (...args:A) => R : never;
//   ^? (kind: "root" | "postType", key: string | number) => CommentEntityRecord | PostEntityRecord
```

This tells me that TypeScript doesn't support a universal Clone type such as the one below:

```ts
type CloneAnyFunction<F> = /* ... */;
```

F must be either instantiated type or parametrized with generics, but there aren't any TS features that enable extracting the nuanced, constrained argument types from it.

### Parametrized clone like  `CloneAnyFunction<Arg0, Arg1, Return>`

I've also tried my luck with Parametrization

There aren't many ways of formulating such a parametrized clone type I can think of. I only found the following Curry implementation on StackOverflow:

```ts
type FN1<A, R>             = (a: A) => R
type FN2<A, B, R>          = ((a: A, b: B) => R)             | ((a: A) => FN1<B, R>)
type FN3<A, B, C, R>       = ((a: A, b: B, c: C) => R)       | ((a: A, b: B) => FN1<C, R>)       | ((a: A) => FN2<B, C, R>)

interface Curry {
    <A, R>(fn: (arg0:A) => R): FN1<A, R>
    <A, B, R>(fn: (arg0:A, arg1:B) => R): FN2<A, B, R>
    <A, B, C, R>(fn: (arg0:A, arg1:B, arg2:C) => R): FN3<A, B, C, R>
}

const curry = {} as Curry;
curry(getEntityRecords);
```

Unfortunately, we're running into the same kind of "insufficient constraints" errors as before:

```
 Types of parameters 'kind' and 'arg0' are incompatible.
  Type 'unknown' is not assignable to type '"root" | "postType"'.(2769)
```
 
We could, of course, specify the constraints explicitly:

```ts
type FN1Explicit<A, R>             = (a: A) => R
type FN2Explicit<A extends EntityConfig['kind'], B, R>          = ((a: A, b: B) => R)             | ((a: A) => FN1Explicit<B, R>)
type FN3Explicit<A extends any, B extends EntityConfig['kind'], C, R>       = ((a: A, b: B, c: C) => R)       | ((a: A, b: B) => FN1Explicit<C, R>)       | ((a: A) => FN2Explicit<B, C, R>)

interface CurryExplicit {
    <A, R>(fn: (arg0:A) => R): FN1Explicit<A, R>
    <A extends EntityConfig['kind'], B extends Extract<EntityConfig, { kind: A }>['keyType'], R>(fn: (arg0:A, arg1:B) => R): FN2Explicit<A, B, R>
    <A, B extends EntityConfig['kind'], C, R>(fn: (arg0:A, arg1:B, arg2:C) => R): FN3Explicit<A, B, C, R>
}

const curryExplicit = {} as CurryExplicit;
const curriedWithExplicitConstraints = curryExplicit(getEntityRecords);
type CurriedWithExplicitConstraints = typeof curriedWithExplicitConstraints;
//   ^?          ^? (kind: "root" | "postType", key: string | number) => CommentEntityRecord | PostEntityRecord
```
But even after all this effort, we're back to the non-specific type signature.

### Parametrized arguments tuple

Once the type constraints are baked into a function type signature, they are stuck there. There seems to be no TypeScript feature that can split the function apart into a constrained arguments type and a constrained return type.

But what if we define the arguments tuple manually?

```ts
type Kind = EntityConfig['kind'];

type SelectorArgs<K extends Kind> = [
    state: any,
    kind: K,
    key: Extract<EntityConfig, { kind: K }>['keyType']
]
```

Oki, now let's slice it:
```ts
type SlicedArgs<K extends Kind> = SelectorArgs<K> extends [any, infer A1, infer A2] ? [A1, A2] : never;
const selectorWithSlicedArgs = <K extends Kind>(...args:SlicedArgs<K>) => null;
```

Uh-oh! selectorWithSlicedArgs accepts the unconstrained arguments. We can't even slice the parametrized tuple in a way that preserves the constraints! This leaves us with only one option: provide the curried and uncurried type signatures manually :(

And it's exactly what this PR proposes.

### Manually specifying both signatures

We want to do two things with selectors like `getEntityRecords`:

* Call them
* Transform their signature into a curried form

Let's define a type that is both callable and also contains information about the manually-defined curried signature:

```ts
interface SelectorWithCustomCurrySignature {
    __isCurryContainer: true;
    CurriedSignature: Function;
}

interface GetEntityRecords_AsContainer extends SelectorWithCustomCurrySignature {
    <K extends EntityConfig['kind']>(
        state: any,
        kind: K,
        key: Extract<EntityConfig, { kind: K }>['keyType']
    ): Extract<EntityConfig, { kind: K }>['record'];

    CurriedSignature: <K extends EntityConfig['kind']>(
        kind: K,
        key: Extract<EntityConfig, { kind: K }>['keyType']
    ) => Extract<EntityConfig, { kind: K }>['record'];
}
```

Here's a proof it can be called just like a regular function:

```ts
const getEntityRecords_container = {} as GetEntityRecords_AsContainer;
const result1 = getEntityRecords_container({}, 'root', '15'); // Type error on the third argument as expected
const result2 = getEntityRecords_container({}, 'root', 15);   // result2 is CommentEntityRecord as expected
const result3 = getEntityRecords_container({}, 'postType', '15'); // result2 is PostEntityRecord as expected
const result4 = getEntityRecords_container({}, 'postType', 15);   // Type error on the third argument as expected
```

It even respects our type constraints, great!

Now, let's try currying:

```ts
// Here's the CurriedState implementation provided by
// [data] Fill out type definition for data registry (https://github.com/WordPress/gutenberg/pull/39081)
// type CurriedState< F > = F extends ( state: any, ...args: infer P ) => infer R
// 	? ( ...args: P ) => R
// 	: F;

// And here's a slightly augmented one that recognizes "curry containers":
type CurriedState< F > =
    F extends SelectorWithCustomCurrySignature
        ? F['CurriedSignature']
        :
    F extends ( state: any, ...args: infer P ) => infer R
	    ? ( ...args: P ) => R
	    : F;

type CurriedGetEntityRecords = CurriedState<GetEntityRecords_AsContainer>;
//   ^?
// Yes! Finally success

const getEntityRecords_curried = {} as CurriedGetEntityRecords;
const result1_curried = getEntityRecords_curried('root', '15'); // Type error on the third argument as ezpected
const result2_curried = getEntityRecords_curried('root', 15);   // result2 is CommentEntityRecord as expected
const result3_curried = getEntityRecords_curried('postType', '15'); // result2 is PostEntityRecord as expected
const result4_curried = getEntityRecords_curried('postType', 15);   // Type error on the third argument as ezpected
```

Brilliant! And, in case you wondered, `CurriedState` can still automatically curry any other function:

```ts
type SimpleSelector = (state: {}, myNumberArg: number) => string;
const simpleSelector = {} as SimpleSelector;
const result1_simple = simpleSelector({}, '15'); // Type error on the second argument as expected
const result2_simple = simpleSelector({}, 15);   // result2 is of type string as expected 

const simpleSelector_curried = {} as CurriedState<SimpleSelector>;
const result1_simple_curried = simpleSelector_curried('15'); // Type error on the only argument as expected
const result2_simple_curried = simpleSelector_curried(15);   // result2 is of type string as expected 
```

## Testing Instructions

The checks are all red, that's fine – it's a PR to another branch based on a pretty old trunk

1. Confirm the idea makes sense
2. Confirm the implementation is sound
3. Confirm it actually works as described above


cc @dmsnell @sarayourfriend @sirreal @jsnajdr 
