### PR TITLE
'keyCode' event property replaced with 'code'

### DIFF
--- a/packages/block-editor/src/components/link-control/index.js
+++ b/packages/block-editor/src/components/link-control/index.js
@@ -12,7 +12,6 @@ import { keyboardReturn } from '@wordpress/icons';
 import { __ } from '@wordpress/i18n';
 import { useRef, useState, useEffect } from '@wordpress/element';
 import { focus } from '@wordpress/dom';
-import { ENTER } from '@wordpress/keycodes';
 
 /**
  * Internal dependencies
@@ -245,7 +244,7 @@ function LinkControl( {
 	const handleSubmitWithEnter = ( event ) => {
 		const { code } = event;
 		if (
-			code === ENTER &&
+			code === "Enter" &&
 			! currentInputIsEmpty // Disallow submitting empty values.
 		) {
 			event.preventDefault();

--- a/packages/block-editor/src/components/link-control/index.js
+++ b/packages/block-editor/src/components/link-control/index.js
@@ -243,9 +243,9 @@ function LinkControl( {
 	};
 
 	const handleSubmitWithEnter = ( event ) => {
-		const { keyCode } = event;
+		const { code } = event;
 		if (
-			keyCode === ENTER &&
+			code === ENTER &&
 			! currentInputIsEmpty // Disallow submitting empty values.
 		) {
 			event.preventDefault();


### PR DESCRIPTION
keyCode is deprecated for some time. See https://developer.mozilla.org/en-US/docs/Web/API/KeyboardEvent/keyCode. Since WordPress no longer supports IE, there is no reason not to update the code.

