### PR TITLE
Add supports to basic sample code.

### DIFF
--- a/docs/reference-guides/block-api/block-deprecation.md
+++ b/docs/reference-guides/block-api/block-deprecation.md
@@ -55,11 +55,16 @@ const attributes = {
 		default: 'some random value',
 	},
 };
+const supports = {
+	className: false,
+};
 
 registerBlockType( 'gutenberg/block-with-deprecated-version', {
 	// ... other block properties go here
 
 	attributes,
+	
+	supports,
 
 	save( props ) {
 		return <div>{ props.attributes.text }</div>;
@@ -68,6 +73,8 @@ registerBlockType( 'gutenberg/block-with-deprecated-version', {
 	deprecated: [
 		{
 			attributes,
+			
+			supports,
 
 			save( props ) {
 				return <p>{ props.attributes.text }</p>;
@@ -87,12 +94,17 @@ var el = wp.element.createElement,
 			type: 'string',
 			default: 'some random value',
 		},
+	},
+	supports = {
+		className: false,
 	};
 
 registerBlockType( 'gutenberg/block-with-deprecated-version', {
 	// ... other block properties go here
 
 	attributes: attributes,
+
+	supports: supports,
 
 	save: function ( props ) {
 		return el( 'div', {}, props.attributes.text );


### PR DESCRIPTION
## What?
Add supports to basic sample code.

## Why?
Like `attributes` and `save`, `supports` are not automatically inherited from the current version, so they need to be defined in some cases, but the basic sample code does not describe them, so it is difficult for beginners to understand.
I think this should add a description for clarity.

By the way, this page uses const to refer to the global wp object, but other pages use import statements. I feel that mixing the two could cause confusion, but should this page also be an import statement?