### PR TITLE
Theme variations UI: ensure that equality check takes into account all default theme properties

### DIFF
--- a/packages/edit-site/src/components/global-styles/screen-style-variations.js
+++ b/packages/edit-site/src/components/global-styles/screen-style-variations.js
@@ -66,7 +66,7 @@ function Variation( { variation } ) {
 	}, [ user, variation ] );
 
 	const styleVariationTitle =
-		variation?.title || __( 'Untitled theme style.' );
+		variation?.title || __( 'Untitled theme style' );
 
 	return (
 		<GlobalStylesContext.Provider value={ context }>

--- a/packages/edit-site/src/components/global-styles/screen-style-variations.js
+++ b/packages/edit-site/src/components/global-styles/screen-style-variations.js
@@ -65,6 +65,9 @@ function Variation( { variation } ) {
 		return compareVariations( user, variation );
 	}, [ user, variation ] );
 
+	const styleVariationTitle =
+		variation?.title || __( 'Untitled theme style.' );
+
 	return (
 		<GlobalStylesContext.Provider value={ context }>
 			<div
@@ -78,7 +81,8 @@ function Variation( { variation } ) {
 				onClick={ selectVariation }
 				onKeyDown={ selectOnEnter }
 				tabIndex="0"
-				aria-label={ variation?.title }
+				aria-label={ styleVariationTitle }
+				aria-current={ isActive }
 				onFocus={ () => setIsFocused( true ) }
 				onBlur={ () => setIsFocused( false ) }
 			>

--- a/packages/edit-site/src/components/global-styles/screen-style-variations.js
+++ b/packages/edit-site/src/components/global-styles/screen-style-variations.js
@@ -109,7 +109,10 @@ function ScreenStyleVariations() {
 				settings: {},
 				styles: {},
 			},
-			...variations,
+			...variations.map( ( variation ) => ( {
+				settings: variation.settings ?? {},
+				styles: variation.styles ?? {},
+			} ) ),
 		];
 	}, [ variations ] );
 

--- a/packages/edit-site/src/components/global-styles/screen-style-variations.js
+++ b/packages/edit-site/src/components/global-styles/screen-style-variations.js
@@ -65,9 +65,6 @@ function Variation( { variation } ) {
 		return compareVariations( user, variation );
 	}, [ user, variation ] );
 
-	const styleVariationTitle =
-		variation?.title || __( 'Untitled theme style' );
-
 	return (
 		<GlobalStylesContext.Provider value={ context }>
 			<div
@@ -81,7 +78,7 @@ function Variation( { variation } ) {
 				onClick={ selectVariation }
 				onKeyDown={ selectOnEnter }
 				tabIndex="0"
-				aria-label={ styleVariationTitle }
+				aria-label={ variation?.title }
 				aria-current={ isActive }
 				onFocus={ () => setIsFocused( true ) }
 				onBlur={ () => setIsFocused( false ) }
@@ -114,6 +111,7 @@ function ScreenStyleVariations() {
 				styles: {},
 			},
 			...variations.map( ( variation ) => ( {
+				...variation,
 				settings: variation.settings ?? {},
 				styles: variation.styles ?? {},
 			} ) ),


### PR DESCRIPTION
## What?

Adding a default `settings: {}` or `styles: {}` values to theme style variations before checking equality.

Also adding an `aria-current` attribute to the variation buttons to indicate the currently-selected item.

Discovered while refactoring the [style variation E2E tests.](https://github.com/WordPress/gutenberg/pull/41427)

## Why?

At the moment, if a theme style does not contain one of 'settings' or 'styles', it won't be shown as active in the UI.

Properties such as 'settings' or 'styles' may not not present in the theme.json.

GlobalStylesContext [adds empty object value for style and settings  by default](https://github.com/WordPress/gutenberg/blob/29aa181fdc157d0f3bc23c1e21dc894ca1c71be6/packages/edit-site/src/components/global-styles/hooks.js#L23) via `setUserConfig()`. 

This is merged with incoming theme.json data, so the properties exist regardless of whether they exist in theme.json.

This leads to issues when comparing user and theme variation theme data, and, therefore, the `active` state of the style variations in the site editor.

We're really talking about a UI problem here, but this is a quick fix to get around the bug.

An alternative might look at modifying the default.

```js
const EMPTY_CONFIG = { settings: {}, styles: {} };
```

Or somehow returning empty objects from the [API callback](https://github.com/WordPress/gutenberg/blob/5c4cc20e4d2274896efa42d16788ab9bbd485c28/lib/compat/wordpress-6.0/class-wp-theme-json-resolver-6-0.php#L156)

## How?
Adding a default `settings: {}` or `styles: {}` for style variation so that they match the theme.json model used everywhere.

## Testing Instructions

For this one we're going to have to go to the testing site: http://localhost:8889/wp-admin

Activate the **gutenberg-test-themes/style-variations** themes. [Here is the working directory](https://github.com/WordPress/gutenberg/tree/6f0265a46b751a97d2991080abe91273b34a45dd/packages/e2e-tests/themes/style-variations) in the project.

<img width="336" alt="Screen Shot 2022-06-08 at 2 48 59 pm" src="https://user-images.githubusercontent.com/6458278/172534026-cc8a73cc-b029-437b-ab7e-f32a799064d1.png">

Fortunately, the "yellow.json" style variation provides an example of our use case. It doesn't have a "settings" property.

You can also add your own to test themes without a "styles" property, by adding a new file under `/packages/e2e-tests/themes/style-variations/styles/`

```json
{
	"version": 2,
	"title": "Little Birdy",
	"settings": {
		"appearanceTools": true,
		"layout": {
			"contentSize": "840px",
			"wideSize": "1100px"
		}
	}
}

```

Head over to the [site editor](http://localhost:8889/wp-admin/themes.php?page=gutenberg-edit-site&postType=wp_template&postId=gutenberg-test-themes%2Fstyle-variations%2F%2Findex) and browse the theme styles:


Now ensure that, if you select a new theme style, the `is-active` class and `aria-current` are present.

### This PR 😄 

![2022-06-08 15 23 22](https://user-images.githubusercontent.com/6458278/172538210-b9ff49c4-1ef9-4ea1-92be-1c4ed0557e73.gif)


## Trunk 😦 
![2022-06-08 15 29 22](https://user-images.githubusercontent.com/6458278/172538956-6ccaf45f-d6eb-4157-931e-79a2d1f75b7d.gif)


