### PR TITLE
[TypeScript] Add default context types to Entity Records in core-data

### DIFF
--- a/packages/core-data/src/entity-types/attachment.ts
+++ b/packages/core-data/src/entity-types/attachment.ts
@@ -13,6 +13,7 @@ import type {
 } from './helpers';
 
 import type { BaseEntityRecords as _BaseEntityRecords } from './base-entity-records';
+import type { DefaultContextOf } from './index';
 
 declare module './base-entity-records' {
 	export namespace BaseEntityRecords {
@@ -141,6 +142,6 @@ declare module './base-entity-records' {
 	}
 }
 
-export type Attachment< C extends Context > = OmitNevers<
-	_BaseEntityRecords.Attachment< C >
->;
+export type Attachment<
+	C extends Context = DefaultContextOf< 'root', 'media' >
+> = OmitNevers< _BaseEntityRecords.Attachment< C > >;

--- a/packages/core-data/src/entity-types/comment.ts
+++ b/packages/core-data/src/entity-types/comment.ts
@@ -9,6 +9,7 @@ import type {
 	RenderedText,
 } from './helpers';
 import type { BaseEntityRecords as _BaseEntityRecords } from './base-entity-records';
+import type { DefaultContextOf } from './index';
 
 export type CommentStatus = 'hold' | 'approve' | 'spam' | 'trash' | '1' | '0';
 
@@ -91,6 +92,6 @@ declare module './base-entity-records' {
 	}
 }
 
-export type Comment< C extends Context > = OmitNevers<
-	_BaseEntityRecords.Comment< C >
->;
+export type Comment<
+	C extends Context = DefaultContextOf< 'root', 'comment' >
+> = OmitNevers< _BaseEntityRecords.Comment< C > >;

--- a/packages/core-data/src/entity-types/menu-location.ts
+++ b/packages/core-data/src/entity-types/menu-location.ts
@@ -4,6 +4,7 @@
 import type { Context, OmitNevers } from './helpers';
 
 import type { BaseEntityRecords as _BaseEntityRecords } from './base-entity-records';
+import type { DefaultContextOf } from './index';
 
 declare module './base-entity-records' {
 	export namespace BaseEntityRecords {
@@ -24,6 +25,6 @@ declare module './base-entity-records' {
 	}
 }
 
-export type MenuLocation< C extends Context > = OmitNevers<
-	_BaseEntityRecords.MenuLocation< C >
->;
+export type MenuLocation<
+	C extends Context = DefaultContextOf< 'root', 'menuLocation' >
+> = OmitNevers< _BaseEntityRecords.MenuLocation< C > >;

--- a/packages/core-data/src/entity-types/nav-menu-item.ts
+++ b/packages/core-data/src/entity-types/nav-menu-item.ts
@@ -9,6 +9,7 @@ import type {
 } from './helpers';
 
 import type { BaseEntityRecords as _BaseEntityRecords } from './base-entity-records';
+import type { DefaultContextOf } from './index';
 
 export type NavMenuItemType =
 	| 'taxonomy'
@@ -106,6 +107,6 @@ declare module './base-entity-records' {
 	}
 }
 
-export type NavMenuItem< C extends Context > = OmitNevers<
-	_BaseEntityRecords.NavMenuItem< C >
->;
+export type NavMenuItem<
+	C extends Context = DefaultContextOf< 'root', 'menuItem' >
+> = OmitNevers< _BaseEntityRecords.NavMenuItem< C > >;

--- a/packages/core-data/src/entity-types/nav-menu.ts
+++ b/packages/core-data/src/entity-types/nav-menu.ts
@@ -4,6 +4,7 @@
 import type { Context, ContextualField, OmitNevers } from './helpers';
 
 import type { BaseEntityRecords as _BaseEntityRecords } from './base-entity-records';
+import { DefaultContextOf } from './index';
 
 declare module './base-entity-records' {
 	export namespace BaseEntityRecords {
@@ -48,6 +49,6 @@ declare module './base-entity-records' {
 	}
 }
 
-export type NavMenu< C extends Context > = OmitNevers<
-	_BaseEntityRecords.NavMenu< C >
->;
+export type NavMenu<
+	C extends Context = DefaultContextOf< 'root', 'menu' >
+> = OmitNevers< _BaseEntityRecords.NavMenu< C > >;

--- a/packages/core-data/src/entity-types/page.ts
+++ b/packages/core-data/src/entity-types/page.ts
@@ -12,6 +12,7 @@ import type {
 } from './helpers';
 
 import type { BaseEntityRecords as _BaseEntityRecords } from './base-entity-records';
+import type { DefaultContextOf } from './index';
 
 declare module './base-entity-records' {
 	export namespace BaseEntityRecords {
@@ -139,6 +140,6 @@ declare module './base-entity-records' {
 	}
 }
 
-export type Page< C extends Context > = OmitNevers<
-	_BaseEntityRecords.Page< C >
->;
+export type Page<
+	C extends Context = DefaultContextOf< 'postType', 'page' >
+> = OmitNevers< _BaseEntityRecords.Page< C > >;

--- a/packages/core-data/src/entity-types/plugin.ts
+++ b/packages/core-data/src/entity-types/plugin.ts
@@ -9,6 +9,7 @@ import type {
 } from './helpers';
 
 import type { BaseEntityRecords as _BaseEntityRecords } from './base-entity-records';
+import type { DefaultContextOf } from './index';
 
 declare module './base-entity-records' {
 	export namespace BaseEntityRecords {
@@ -74,6 +75,6 @@ declare module './base-entity-records' {
 }
 
 export type PluginStatus = 'active' | 'inactive';
-export type Plugin< C extends Context > = OmitNevers<
-	_BaseEntityRecords.Plugin< C >
->;
+export type Plugin<
+	C extends Context = DefaultContextOf< 'root', 'plugin' >
+> = OmitNevers< _BaseEntityRecords.Plugin< C > >;

--- a/packages/core-data/src/entity-types/post.ts
+++ b/packages/core-data/src/entity-types/post.ts
@@ -13,6 +13,7 @@ import type {
 } from './helpers';
 
 import type { BaseEntityRecords as _BaseEntityRecords } from './base-entity-records';
+import type { DefaultContextOf } from './index';
 
 declare module './base-entity-records' {
 	export namespace BaseEntityRecords {
@@ -148,6 +149,6 @@ declare module './base-entity-records' {
 	}
 }
 
-export type Post< C extends Context > = OmitNevers<
-	_BaseEntityRecords.Post< C >
->;
+export type Post<
+	C extends Context = DefaultContextOf< 'postType', 'post' >
+> = OmitNevers< _BaseEntityRecords.Post< C > >;

--- a/packages/core-data/src/entity-types/settings.ts
+++ b/packages/core-data/src/entity-types/settings.ts
@@ -9,6 +9,7 @@ import type {
 } from './helpers';
 
 import type { BaseEntityRecords as _BaseEntityRecords } from './base-entity-records';
+import type { DefaultContextOf } from './index';
 
 declare module './base-entity-records' {
 	export namespace BaseEntityRecords {
@@ -93,6 +94,6 @@ declare module './base-entity-records' {
 	}
 }
 
-export type Settings< C extends Context > = OmitNevers<
-	_BaseEntityRecords.Settings< C >
->;
+export type Settings<
+	C extends Context = DefaultContextOf< 'root', 'site' >
+> = OmitNevers< _BaseEntityRecords.Settings< C > >;

--- a/packages/core-data/src/entity-types/sidebar.ts
+++ b/packages/core-data/src/entity-types/sidebar.ts
@@ -4,6 +4,7 @@
 import type { Context, OmitNevers } from './helpers';
 
 import type { BaseEntityRecords as _BaseEntityRecords } from './base-entity-records';
+import type { DefaultContextOf } from './index';
 
 declare module './base-entity-records' {
 	export namespace BaseEntityRecords {
@@ -54,6 +55,6 @@ declare module './base-entity-records' {
 
 type SidebarStatus = 'active' | 'inactive';
 
-export type Sidebar< C extends Context > = OmitNevers<
-	_BaseEntityRecords.Sidebar< C >
->;
+export type Sidebar<
+	C extends Context = DefaultContextOf< 'root', 'sidebar' >
+> = OmitNevers< _BaseEntityRecords.Sidebar< C > >;

--- a/packages/core-data/src/entity-types/taxonomy.ts
+++ b/packages/core-data/src/entity-types/taxonomy.ts
@@ -4,6 +4,7 @@
 import type { Context, ContextualField, OmitNevers } from './helpers';
 
 import type { BaseEntityRecords as _BaseEntityRecords } from './base-entity-records';
+import type { DefaultContextOf } from './index';
 
 declare module './base-entity-records' {
 	export namespace BaseEntityRecords {
@@ -87,6 +88,6 @@ declare module './base-entity-records' {
 	}
 }
 
-export type Taxonomy< C extends Context > = OmitNevers<
-	_BaseEntityRecords.Taxonomy< C >
->;
+export type Taxonomy<
+	C extends Context = DefaultContextOf< 'postType', 'taxonomy' >
+> = OmitNevers< _BaseEntityRecords.Taxonomy< C > >;

--- a/packages/core-data/src/entity-types/theme.ts
+++ b/packages/core-data/src/entity-types/theme.ts
@@ -4,6 +4,7 @@
 import type { Context, PostFormat, RenderedText, OmitNevers } from './helpers';
 
 import type { BaseEntityRecords as _BaseEntityRecords } from './base-entity-records';
+import type { DefaultContextOf } from './index';
 
 declare module './base-entity-records' {
 	export namespace BaseEntityRecords {
@@ -217,6 +218,6 @@ declare module './base-entity-records' {
 	}
 }
 
-export type Theme< C extends Context > = OmitNevers<
-	_BaseEntityRecords.Theme< C >
->;
+export type Theme<
+	C extends Context = DefaultContextOf< 'root', 'theme' >
+> = OmitNevers< _BaseEntityRecords.Theme< C > >;

--- a/packages/core-data/src/entity-types/type.ts
+++ b/packages/core-data/src/entity-types/type.ts
@@ -4,6 +4,7 @@
 import type { Context, ContextualField, OmitNevers } from './helpers';
 
 import type { BaseEntityRecords as _BaseEntityRecords } from './base-entity-records';
+import type { DefaultContextOf } from './index';
 
 declare module './base-entity-records' {
 	export namespace BaseEntityRecords {
@@ -75,6 +76,6 @@ declare module './base-entity-records' {
 	}
 }
 
-export type Type< C extends Context > = OmitNevers<
-	_BaseEntityRecords.Type< C >
->;
+export type Type<
+	C extends Context = DefaultContextOf< 'root', 'postType' >
+> = OmitNevers< _BaseEntityRecords.Type< C > >;

--- a/packages/core-data/src/entity-types/user.ts
+++ b/packages/core-data/src/entity-types/user.ts
@@ -9,6 +9,7 @@ import type {
 } from './helpers';
 
 import type { BaseEntityRecords as _BaseEntityRecords } from './base-entity-records';
+import type { DefaultContextOf } from './index';
 
 declare module './base-entity-records' {
 	export namespace BaseEntityRecords {
@@ -109,6 +110,6 @@ declare module './base-entity-records' {
 	}
 }
 
-export type User< C extends Context > = OmitNevers<
-	_BaseEntityRecords.User< C >
->;
+export type User<
+	C extends Context = DefaultContextOf< 'root', 'user' >
+> = OmitNevers< _BaseEntityRecords.User< C > >;

--- a/packages/core-data/src/entity-types/widget-type.ts
+++ b/packages/core-data/src/entity-types/widget-type.ts
@@ -4,6 +4,7 @@
 import type { Context, OmitNevers } from './helpers';
 
 import type { BaseEntityRecords as _BaseEntityRecords } from './base-entity-records';
+import type { DefaultContextOf } from './index';
 
 declare module './base-entity-records' {
 	export namespace BaseEntityRecords {
@@ -32,6 +33,6 @@ declare module './base-entity-records' {
 	}
 }
 
-export type WidgetType< C extends Context > = OmitNevers<
-	_BaseEntityRecords.WidgetType< C >
->;
+export type WidgetType<
+	C extends Context = DefaultContextOf< 'root', 'widgetType' >
+> = OmitNevers< _BaseEntityRecords.WidgetType< C > >;

--- a/packages/core-data/src/entity-types/widget.ts
+++ b/packages/core-data/src/entity-types/widget.ts
@@ -4,6 +4,7 @@
 import type { Context, ContextualField, OmitNevers } from './helpers';
 
 import type { BaseEntityRecords as _BaseEntityRecords } from './base-entity-records';
+import type { DefaultContextOf } from './index';
 
 declare module './base-entity-records' {
 	export namespace BaseEntityRecords {
@@ -59,6 +60,6 @@ declare module './base-entity-records' {
 	}
 }
 
-export type Widget< C extends Context > = OmitNevers<
-	_BaseEntityRecords.Widget< C >
->;
+export type Widget<
+	C extends Context = DefaultContextOf< 'root', 'widget' >
+> = OmitNevers< _BaseEntityRecords.Widget< C > >;

--- a/packages/core-data/src/entity-types/wp-template-part.ts
+++ b/packages/core-data/src/entity-types/wp-template-part.ts
@@ -10,6 +10,7 @@ import type {
 } from './helpers';
 
 import type { BaseEntityRecords as _BaseEntityRecords } from './base-entity-records';
+import type { DefaultContextOf } from './index';
 
 declare module './base-entity-records' {
 	export namespace BaseEntityRecords {
@@ -89,6 +90,6 @@ declare module './base-entity-records' {
 	}
 }
 
-export type WpTemplatePart< C extends Context > = OmitNevers<
-	_BaseEntityRecords.WpTemplatePart< C >
->;
+export type WpTemplatePart<
+	C extends Context = DefaultContextOf< 'postType', 'wp_template_part' >
+> = OmitNevers< _BaseEntityRecords.WpTemplatePart< C > >;

--- a/packages/core-data/src/entity-types/wp-template.ts
+++ b/packages/core-data/src/entity-types/wp-template.ts
@@ -10,6 +10,7 @@ import type {
 } from './helpers';
 
 import type { BaseEntityRecords as _BaseEntityRecords } from './base-entity-records';
+import type { DefaultContextOf } from './index';
 
 declare module './base-entity-records' {
 	export namespace BaseEntityRecords {
@@ -89,6 +90,6 @@ declare module './base-entity-records' {
 	}
 }
 
-export type WpTemplate< C extends Context > = OmitNevers<
-	_BaseEntityRecords.WpTemplate< C >
->;
+export type WpTemplate<
+	C extends Context = DefaultContextOf< 'postType', 'wp_template' >
+> = OmitNevers< _BaseEntityRecords.WpTemplate< C > >;


### PR DESCRIPTION
## What?

All entity record types are parametrized by a generic Context parameter, e.g.:

```ts
type MyType = Page<'edit'>
```

Oftentimes, we need to refer to an entity using its default context type, which gets pretty entangled:

```ts
type MyType = Page<DefaultContextOf<Page<any>>>
```

This PR adds default value to all the Context generic type parameters so that the above can be simplified to:

```ts
type MyType = Page
```

## Why?

We want to have autocompletion and TypeScript support for core-data primitives, see https://github.com/WordPress/gutenberg/pull/39025 for more context.

## Testing Instructions

Confirm the CI checks are green – this PR doesn't contain any runtime changes to test.

@noisysocks @sirreal @dmsnell @sarayourfriend