### PR TITLE
Add `humanTimeDiff` to `@wordpress/date`

### DIFF
--- a/packages/date/CHANGELOG.md
+++ b/packages/date/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+### New Feature
+-	Add `humanTimeDiff` function to get the difference between two timestamps in a human-readable format.
+
 ## 4.10.0 (2022-06-01)
 
 ## 4.9.0 (2022-05-18)

--- a/packages/date/README.md
+++ b/packages/date/README.md
@@ -117,7 +117,7 @@ _Parameters_
 
 -   _from_ `Moment | Date | string | undefined`: The timestamp to measure from. Defaults to the current time if undefined or invalid.
 -   _to_ `Moment | Date | string | undefined`: The timestamp to measure to. Defaults to the current time if undefined or invalid.
--   _includeAffix_ `boolean`: Whether to include the "ago" suffix in the comparison.
+-   _includeAffix_ `boolean`: Whether to include the "ago" or "to" affix in the comparison.
 
 _Returns_
 

--- a/packages/date/README.md
+++ b/packages/date/README.md
@@ -109,6 +109,20 @@ _Returns_
 
 -   `string`: Formatted date.
 
+### humanTimeDiff
+
+Returns the difference between two timestamps in a human-readable format.
+
+_Parameters_
+
+-   _from_ `Moment | Date | string | undefined`: The timestamp to measure from. Defaults to the current time if undefined or invalid.
+-   _to_ `Moment | Date | string | undefined`: The timestamp to measure to. Defaults to the current time if undefined or invalid.
+-   _includeAffix_ `boolean`: Whether to include the "ago" suffix in the comparison.
+
+_Returns_
+
+-   `string`: The difference between the timestamps.
+
 ### isInTheFuture
 
 Check whether a date is considered in the future according to the WordPress settings.

--- a/packages/date/src/index.js
+++ b/packages/date/src/index.js
@@ -561,6 +561,20 @@ export function getDate( dateString ) {
 }
 
 /**
+ * Returns the difference between two timestamps in a human-readable format.
+ *
+ * @param {Moment | Date | string | undefined} from         The timestamp to measure from. Defaults to the current time if undefined or invalid.
+ * @param {Moment | Date | string | undefined} to           The timestamp to measure to. Defaults to the current time if undefined or invalid.
+ * @param {boolean}                            includeAffix Whether to include the "ago" suffix in the comparison.
+ * @return {string} The difference between the timestamps.
+ */
+export function humanTimeDiff( from, to, includeAffix ) {
+	from = momentLib( from );
+	to = momentLib( to );
+	return from.from( to, ! includeAffix );
+}
+
+/**
  * Creates a moment instance using the given timezone or, if none is provided, using global settings.
  *
  * @param {Moment | Date | string | undefined} dateValue Date object or string, parsable

--- a/packages/date/src/index.js
+++ b/packages/date/src/index.js
@@ -570,9 +570,9 @@ export function getDate( dateString ) {
  */
 export function humanTimeDiff( from, to, includeAffix ) {
 	// Normalize inputs to a moment object, defaults to current time.
-	from = momentLib( from );
-	to = momentLib( to );
-	return from.from( to, ! includeAffix );
+	const momentFrom = momentLib( from );
+	const momentTo = momentLib( to );
+	return momentFrom.from( momentTo, ! includeAffix );
 }
 
 /**

--- a/packages/date/src/index.js
+++ b/packages/date/src/index.js
@@ -565,10 +565,11 @@ export function getDate( dateString ) {
  *
  * @param {Moment | Date | string | undefined} from         The timestamp to measure from. Defaults to the current time if undefined or invalid.
  * @param {Moment | Date | string | undefined} to           The timestamp to measure to. Defaults to the current time if undefined or invalid.
- * @param {boolean}                            includeAffix Whether to include the "ago" suffix in the comparison.
+ * @param {boolean}                            includeAffix Whether to include the "ago" or "to" affix in the comparison.
  * @return {string} The difference between the timestamps.
  */
 export function humanTimeDiff( from, to, includeAffix ) {
+	// Normalize inputs to a moment object, defaults to current time.
 	from = momentLib( from );
 	to = momentLib( to );
 	return from.from( to, ! includeAffix );

--- a/packages/date/src/test/index.js
+++ b/packages/date/src/test/index.js
@@ -1,4 +1,9 @@
 /**
+ * External dependencies
+ */
+import momentLib from 'moment';
+
+/**
  * Internal dependencies
  */
 import {
@@ -8,6 +13,7 @@ import {
 	getDate,
 	gmdate,
 	gmdateI18n,
+	humanTimeDiff,
 	isInTheFuture,
 	setSettings,
 } from '../';
@@ -587,6 +593,228 @@ describe( 'Function gmdateI18n', () => {
 
 		// Restore default settings.
 		setSettings( settings );
+	} );
+} );
+
+describe( 'Function humanTimeDiff', () => {
+	it( 'should show a human readable string showing the difference between two timestamps', () => {
+		// Set a date one second in the past and check it works between then and now.
+		expect(
+			humanTimeDiff( new Date( Number( getDate() ) - 1000 ) )
+		).toEqual( 'a few seconds' );
+
+		// Set a date two seconds in the past and check it works between then and now.
+		expect(
+			humanTimeDiff( new Date( Number( getDate() ) - 1000 * 2 ) )
+		).toEqual( 'a few seconds' );
+
+		// Check it works when two timestamps are supplied.
+		expect(
+			humanTimeDiff(
+				new Date( Number( getDate() ) - 1000 * 2 ),
+				new Date( Number( getDate() ) - 1000 * 3 )
+			)
+		).toEqual( 'a few seconds' );
+		expect(
+			humanTimeDiff(
+				new Date( Number( getDate() ) - 1000 * 2 ),
+				new Date( Number( getDate() ) - 1000 * 61 )
+			)
+		).toEqual( 'a minute' );
+
+		// Set a date one minute in the past and check it works between then and now.
+		expect(
+			humanTimeDiff( new Date( Number( getDate() ) - 1000 * 60 ) )
+		).toEqual( 'a minute' );
+
+		// Set a date two minutes in the past and check it works between then and now.
+		expect(
+			humanTimeDiff( new Date( Number( getDate() ) - 1000 * 120 ) )
+		).toEqual( '2 minutes' );
+
+		// Check it works when two timestamps are supplied.
+		expect(
+			humanTimeDiff(
+				new Date( Number( getDate() ) - 1000 * 60 ),
+				new Date( Number( getDate() ) - 1000 * 120 )
+			)
+		).toEqual( 'a minute' );
+		expect(
+			humanTimeDiff(
+				new Date( Number( getDate() ) - 1000 * 60 * 2 ),
+				new Date( Number( getDate() ) - 1000 * 60 * 44 )
+			)
+		).toEqual( '42 minutes' );
+
+		// Set a date one hour in the past and check it works between then and now.
+		expect(
+			humanTimeDiff( new Date( Number( getDate() ) - 1000 * 60 * 60 ) )
+		).toEqual( 'an hour' );
+
+		// Set a date two hours in the past and check it works between then and now.
+		expect(
+			humanTimeDiff(
+				new Date( Number( getDate() ) - 1000 * 60 * 60 * 2 )
+			)
+		).toEqual( '2 hours' );
+
+		// Check it works when two timestamps are supplied.
+		expect(
+			humanTimeDiff(
+				new Date( Number( getDate() ) - 1000 * 60 * 60 ),
+				new Date( Number( getDate() ) - 1000 * 60 * 60 * 2 )
+			)
+		).toEqual( 'an hour' );
+		expect(
+			humanTimeDiff(
+				new Date( Number( getDate() ) - 1000 * 60 * 60 * 2 ),
+				new Date( Number( getDate() ) - 1000 * 60 * 60 * 7 )
+			)
+		).toEqual( '5 hours' );
+
+		// Set a date one day in the past and check it works between then and now.
+		expect(
+			humanTimeDiff(
+				new Date( Number( getDate() ) - 1000 * 60 * 60 * 24 )
+			)
+		).toEqual( 'a day' );
+
+		// Set a date two hours in the past and check it works between then and now.
+		expect(
+			humanTimeDiff(
+				new Date( Number( getDate() ) - 1000 * 60 * 60 * 24 * 2 )
+			)
+		).toEqual( '2 days' );
+
+		// Check it works when two timestamps are supplied.
+		expect(
+			humanTimeDiff(
+				new Date( Number( getDate() ) - 1000 * 60 * 60 * 24 * 2 ),
+				new Date( Number( getDate() ) - 1000 * 60 * 60 * 24 * 3 )
+			)
+		).toEqual( 'a day' );
+		expect(
+			humanTimeDiff(
+				new Date( Number( getDate() ) - 1000 * 60 * 60 * 24 * 2 ),
+				new Date( Number( getDate() ) - 1000 * 60 * 60 * 24 * 8 )
+			)
+		).toEqual( '6 days' );
+
+		// Set a date one month in the past and check it works between then and now.
+		expect(
+			humanTimeDiff(
+				new Date( Number( getDate() ) - 1000 * 60 * 60 * 24 * 30 )
+			)
+		).toEqual( 'a month' );
+
+		// Set a date two months in the past and check it works between then and now.
+		expect(
+			humanTimeDiff(
+				new Date( Number( getDate() ) - 1000 * 60 * 60 * 24 * 60 )
+			)
+		).toEqual( '2 months' );
+
+		// Check it works when two timestamps are supplied.
+		expect(
+			humanTimeDiff(
+				new Date( Number( getDate() ) - 1000 * 60 * 60 * 24 * 60 ),
+				new Date( Number( getDate() ) - 1000 * 60 * 60 * 24 * 90 )
+			)
+		).toEqual( 'a month' );
+		expect(
+			humanTimeDiff(
+				new Date( Number( getDate() ) - 1000 * 60 * 60 * 24 * 30 * 2 ),
+				new Date( Number( getDate() ) - 1000 * 60 * 60 * 24 * 30 * 9 )
+			)
+		).toEqual( '7 months' );
+
+		// Set a date one year in the past and check it works between then and now.
+		expect(
+			humanTimeDiff(
+				new Date( Number( getDate() ) - 1000 * 60 * 60 * 24 * 365 )
+			)
+		).toEqual( 'a year' );
+
+		// Set a date one year in the future and check it works between then and now.
+		expect(
+			humanTimeDiff(
+				new Date( Number( getDate() ) + 1000 * 60 * 60 * 24 * 365 )
+			)
+		).toEqual( 'a year' );
+
+		// Set a date two months in the past and check it works between then and now.
+		expect(
+			humanTimeDiff(
+				new Date( Number( getDate() ) - 1000 * 60 * 60 * 24 * 365 * 2 )
+			)
+		).toEqual( '2 years' );
+
+		// Check it works when two timestamps are supplied.
+		expect(
+			humanTimeDiff(
+				new Date( Number( getDate() ) - 1000 * 60 * 60 * 24 * 365 ),
+				new Date( Number( getDate() ) - 1000 * 60 * 60 * 24 * 365 * 2 )
+			)
+		).toEqual( 'a year' );
+		expect(
+			humanTimeDiff(
+				new Date( Number( getDate() ) - 1000 * 60 * 60 * 24 * 365 ),
+				new Date( Number( getDate() ) - 1000 * 60 * 60 * 24 * 365 * 12 )
+			)
+		).toEqual( '11 years' );
+	} );
+
+	it( 'should include the suffix if includeAffix is true', () => {
+		// Set a date one second in the past and check it works between then and now.
+		expect(
+			humanTimeDiff(
+				new Date( Number( getDate() ) - 1000 ),
+				new Date( Number( getDate() ) - 1000 ),
+				true
+			)
+		).toEqual( 'a few seconds ago' );
+
+		expect(
+			humanTimeDiff(
+				new Date( Number( getDate() ) - 1000 * 60 * 44 ),
+				new Date( Number( getDate() ) - 1000 * 60 * 2 ),
+				true
+			)
+		).toEqual( '42 minutes ago' );
+
+		expect(
+			humanTimeDiff(
+				new Date( Number( getDate() ) - 1000 * 60 * 2 ),
+				new Date( Number( getDate() ) - 1000 * 60 * 44 ),
+				true
+			)
+		).toEqual( 'in 42 minutes' );
+	} );
+	it( 'should ignore the timezone if both dates are in the same timezone', () => {
+		const settings = __experimentalGetSettings();
+
+		// Set a timezone in the past.
+		setSettings( {
+			...settings,
+			timezone: { offset: '-4', string: 'America/New_York' },
+		} );
+		// Set a date one second in the past and check it works between then and now.
+		expect(
+			humanTimeDiff(
+				new Date( Number( getDate() ) - 1000 ),
+				new Date( Number( getDate() ) - 2000 )
+			)
+		).toEqual( 'a few seconds' );
+	} );
+
+	it( 'should compare across two different timezones', () => {
+		// Set a date in UTC and another in America/New_York (4 hours in the past) and check it works between the different timestamps.
+		expect(
+			humanTimeDiff(
+				momentLib.tz( '2022-06-07T22:31:18', 'America/New_York' ),
+				momentLib.tz( '2022-06-07T22:31:18', 'Etc/UTC' )
+			)
+		).toEqual( '4 hours' );
 	} );
 } );
 


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->
Adds a `humanTimeDiff` function to `@wordpress/date` along with some tests.
## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
To allow the generation of a human-readable difference between timestamps that is available in Gutenberg. Also to fix #14486

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
Using `moment`'s [`from`](https://momentjs.com/docs/#/displaying/from/) utility we can generate the differences in their human readable format. This uses the [locale supplied to `moment`](https://github.com/WordPress/gutenberg/blob/trunk/packages/date/src/index.js#L105-L120) to generate the strings.

## Testing Instructions

1. Please run the unit tests (`npm run test`) and ensure they pass.