### PR TITLE
package.json: bump engines.node version to >=14

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
 		"url": "https://github.com/WordPress/gutenberg/issues"
 	},
 	"engines": {
-		"node": ">=10.0.0",
+		"node": ">=14.0.0",
 		"npm": ">=6.9.0 <7"
 	},
 	"config": {


### PR DESCRIPTION
## What?

Bump the mininum required Node version for the project in package.json's `engines` property. The version requirement had been left at `>=10.0.0`, despite the de facto requirement of 14+, as suggested by `.nvmrc`.

## Why?

- There shouldn't be a discrepancy between `package.json > engines.node` and `.nvmrc`
- The `.nvmrc` declaration is only useful for users who actively use `nvm` to manage Node versions.
- Without an up-tp-date `engines.node` requirement, users attempting to build Gutenberg typically face confusing build-time errors that are difficult to trace back to the unsatisfied version requirement.
- Now, `npm install` with present an explicit error if the running Node version is outdated:

```
$ npm i
npm ERR! code ENOTSUP
npm ERR! notsup Unsupported engine for gutenberg@13.4.0-rc.1: wanted: {"node":">=14.0.0","npm":">=6.9.0 <7"} (current: {"node":"12.0.0","npm":"6.14.13"})
npm ERR! notsup Not compatible with your version of node/npm: gutenberg@13.4.0-rc.1
npm ERR! notsup Not compatible with your version of node/npm: gutenberg@13.4.0-rc.1
npm ERR! notsup Required: {"node":">=14.0.0","npm":">=6.9.0 <7"}
npm ERR! notsup Actual:   {"npm":"6.14.13","node":"12.0.0"}
```

## How

Version checking based on `engines.node` is enforced by [NPM's `engine-strict` config option](https://docs.npmjs.com/cli/v6/using-npm/config#engine-strict), originally enabled in #23600.

## Testing Instructions

1. Run `npm install` on Node 14 and observe that there are no changes in behaviour.
1. Try running `npm install` on Node 12 and observe that the command fails with an error about the version.
