### PR TITLE
Components: refactor `FontSizePicker` to pass `exhaustive-deps`

### DIFF
--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -15,6 +15,7 @@
 -   `Flex` updated to satisfy `react/exhuastive-deps` eslint rule ([#41507](https://github.com/WordPress/gutenberg/pull/41507)).
 -   `CustomGradientBar` updated to satisfy `react/exhuastive-deps` eslint rule ([#41463](https://github.com/WordPress/gutenberg/pull/41463))
 -   `TreeSelect`: Convert to TypeScript ([#41536](https://github.com/WordPress/gutenberg/pull/41536)).
+-   `FontSizePicker`: updated to satisfy `react/exhuastive-deps` eslint rule ([#41600](https://github.com/WordPress/gutenberg/pull/41600)).
 
 ## 19.12.0 (2022-06-01)
 

--- a/packages/components/src/font-size-picker/index.js
+++ b/packages/components/src/font-size-picker/index.js
@@ -103,9 +103,11 @@ function FontSizePicker(
 		return hint;
 	}, [
 		showCustomValueControl,
-		selectedOption?.slug,
+		selectedOption?.name,
+		selectedOption?.size,
 		value,
 		isCustomValue,
+		shouldUseSelectControl,
 		fontSizesContainComplexValues,
 	] );
 


### PR DESCRIPTION
## What?
Updates the `FontSizePicker` component to satisfy the `exhaustive-deps` eslint rule 

## Why?
Part of the effort in https://github.com/WordPress/gutenberg/pull/41166 to apply `exhuastive-deps` to the Components package

## How?
add `selectedOption?.name`, `selectedOption?.size`, and `shouldUseSelectControl` to the `headerHint` `useMemo` dep array. Remove `selectedOption?.slug` which isn't a necessary dep of this callback.

I'm guessing the goal with `selectedOption?.slug` was to cover both `.name` and `.size` with a single dependency, but cc'ing @ntsekouras in case you had something different in mind when [this was first introduced](https://github.com/WordPress/gutenberg/pull/35395)

## Testing Instructions
1. From your local Gutenberg directory, run `npx eslint --rule 'react-hooks/exhaustive-deps: warn' packages/components/src/font-size-picker`
2. Confirm that the linter returns no errors
3. Confirm unit tests still pass
4. Run Storybook locally, confirm the components stories and/or docs still work as expected
