### PR TITLE
Components: refactor `InputControl` to pass `exhaustive-deps`

### DIFF
--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -26,6 +26,7 @@
 -   `Dropdown`: Make sure cleanup (closing the dropdown) only runs when the menu has actually been opened.
 -   Enhance the TypeScript migration guidelines ([#41669](https://github.com/WordPress/gutenberg/pull/41669)).
 -   `ExternalLink`: Convert to TypeScript ([#41681](https://github.com/WordPress/gutenberg/pull/41681)).
+-   `InputControl` updated to satisfy `react/exhuastive-deps` eslint rule ([#41601](https://github.com/WordPress/gutenberg/pull/41601))
 
 ## 19.12.0 (2022-06-01)
 

--- a/packages/components/src/input-control/utils.ts
+++ b/packages/components/src/input-control/utils.ts
@@ -63,7 +63,7 @@ export function useDragCursor(
 			// @ts-expect-error
 			document.documentElement.style.cursor = null;
 		}
-	}, [ isDragging ] );
+	}, [ isDragging, dragCursor ] );
 
 	return dragCursor;
 }


### PR DESCRIPTION
## What?
Updates the `InputControl` component to satisfy the `exhaustive-deps` eslint rule

## Why?
Part of the effort in https://github.com/WordPress/gutenberg/pull/41166 to apply `exhuastive-deps` to the Components package

## How?
Add the `dragCursor` prop to the dep array.

## Testing Instructions
1. From your local Gutenberg directory, run `npx eslint --rule 'react-hooks/exhaustive-deps: warn' packages/components/src/input-control`
2. Confirm that the linter returns no errors
3. Confirm unit tests still pass
4. Run Storybook locally, confirm the components stories and/or docs still work as expected.
5. Also in Storybook, test the `NumberControl` component to confirm dragging still works (`NumberControl` is build on `InputControl` and is a good place to test the dragging functionality)


