### PR TITLE
Placeholder: Add an illustration option to the Placeholder component

### DIFF
--- a/packages/block-library/src/cover/edit/index.js
+++ b/packages/block-library/src/cover/edit/index.js
@@ -10,7 +10,7 @@ import namesPlugin from 'colord/plugins/names';
  */
 import { useEntityProp, store as coreStore } from '@wordpress/core-data';
 import { useEffect, useRef } from '@wordpress/element';
-import { Spinner } from '@wordpress/components';
+import { Placeholder, Spinner } from '@wordpress/components';
 import { compose } from '@wordpress/compose';
 import {
 	withColors,
@@ -24,7 +24,6 @@ import {
 import { __ } from '@wordpress/i18n';
 import { useSelect, useDispatch } from '@wordpress/data';
 import { isBlobURL } from '@wordpress/blob';
-import { SVG, Path } from '@wordpress/primitives';
 import { store as noticesStore } from '@wordpress/notices';
 
 /**
@@ -46,18 +45,6 @@ import CoverPlaceholder from './cover-placeholder';
 import ResizableCover from './resizable-cover';
 
 extend( [ namesPlugin ] );
-
-const placeholderIllustration = (
-	<SVG
-		className="components-placeholder__illustration"
-		fill="none"
-		xmlns="http://www.w3.org/2000/svg"
-		viewBox="0 0 60 60"
-		preserveAspectRatio="none"
-	>
-		<Path vectorEffect="non-scaling-stroke" d="M60 60 0 0" />
-	</SVG>
-);
 
 function getInnerBlocksTemplate( attributes ) {
 	return [
@@ -360,9 +347,10 @@ function CoverEdit( {
 				) }
 
 				{ ! url && useFeaturedImage && (
-					<div className="wp-block-cover__image--placeholder-image">
-						{ placeholderIllustration }
-					</div>
+					<Placeholder
+						className="wp-block-cover__image--placeholder-image"
+						withIllustration={ true }
+					/>
 				) }
 
 				{ url &&

--- a/packages/block-library/src/cover/editor.scss
+++ b/packages/block-library/src/cover/editor.scss
@@ -69,19 +69,6 @@
 		right: 0;
 		bottom: 0;
 		left: 0;
-
-		// Style the placeholder illustration.
-		.components-placeholder__illustration {
-			position: absolute;
-			left: 0;
-			width: 100%;
-			height: 100%;
-			stroke: currentColor;
-			stroke-dasharray: 3;
-			opacity: 0.4;
-		}
-
-		border: $border-width dashed currentColor;
 	}
 
 }

--- a/packages/block-library/src/post-featured-image/edit.js
+++ b/packages/block-library/src/post-featured-image/edit.js
@@ -20,7 +20,6 @@ import {
 } from '@wordpress/block-editor';
 import { __, sprintf } from '@wordpress/i18n';
 import { upload } from '@wordpress/icons';
-import { SVG, Path } from '@wordpress/primitives';
 import { store as noticesStore } from '@wordpress/notices';
 
 /**
@@ -28,24 +27,18 @@ import { store as noticesStore } from '@wordpress/notices';
  */
 import DimensionControls from './dimension-controls';
 
-const placeholderIllustration = (
-	<SVG
-		className="components-placeholder__illustration"
-		fill="none"
-		xmlns="http://www.w3.org/2000/svg"
-		viewBox="0 0 60 60"
-		preserveAspectRatio="none"
-	>
-		<Path vectorEffect="non-scaling-stroke" d="M60 60 0 0" />
-	</SVG>
-);
-
 const ALLOWED_MEDIA_TYPES = [ 'image' ];
-const placeholderChip = (
-	<div className="wp-block-post-featured-image__placeholder">
-		{ placeholderIllustration }
-	</div>
-);
+
+const placeholder = ( content ) => {
+	return (
+		<Placeholder
+			className="block-editor-media-placeholder"
+			withIllustration={ true }
+		>
+			{ content }
+		</Placeholder>
+	);
+};
 
 function getMediaSourceUrlBySizeSlug( media, slug ) {
 	return (
@@ -101,15 +94,6 @@ function PostFeaturedImageDisplay( {
 		style: { width, height },
 	} );
 
-	const placeholder = ( content ) => {
-		return (
-			<Placeholder className="block-editor-media-placeholder">
-				{ placeholderIllustration }
-				{ content }
-			</Placeholder>
-		);
-	};
-
 	const onSelectImage = ( value ) => {
 		if ( value?.id ) {
 			setFeaturedImage( value.id );
@@ -153,7 +137,7 @@ function PostFeaturedImageDisplay( {
 		return (
 			<>
 				{ controls }
-				<div { ...blockProps }>{ placeholderChip }</div>
+				<div { ...blockProps }>{ placeholder() }</div>
 			</>
 		);
 	}
@@ -187,7 +171,7 @@ function PostFeaturedImageDisplay( {
 	} else {
 		// We have a Featured image so show a Placeholder if is loading.
 		image = ! media ? (
-			placeholderChip
+			placeholder()
 		) : (
 			<img
 				src={ mediaUrl }
@@ -232,7 +216,7 @@ function PostFeaturedImageDisplay( {
 export default function PostFeaturedImageEdit( props ) {
 	const blockProps = useBlockProps();
 	if ( ! props.context?.postId ) {
-		return <div { ...blockProps }>{ placeholderChip }</div>;
+		return <div { ...blockProps }>{ placeholder() }</div>;
 	}
 	return <PostFeaturedImageDisplay { ...props } />;
 }

--- a/packages/block-library/src/post-featured-image/editor.scss
+++ b/packages/block-library/src/post-featured-image/editor.scss
@@ -39,21 +39,6 @@
 		// against any background color.
 		color: currentColor;
 		background: transparent;
-		&::before {
-			content: "";
-			display: block;
-			position: absolute;
-			top: 0;
-			right: 0;
-			bottom: 0;
-			left: 0;
-			border: $border-width dashed currentColor;
-			opacity: 0.4;
-			pointer-events: none;
-
-			// Inherit border radius from style variations.
-			border-radius: inherit;
-		}
 
 		// Style the upload button.
 		.components-placeholder__fieldset {
@@ -80,20 +65,6 @@
 
 		.components-button.components-button > svg {
 			color: $white;
-		}
-
-		// Style the placeholder illustration.
-		.components-placeholder__illustration {
-			position: absolute;
-			top: 0;
-			right: 0;
-			bottom: 0;
-			left: 0;
-			width: 100%;
-			height: 100%;
-			stroke: currentColor;
-			stroke-dasharray: 3;
-			opacity: 0.4;
 		}
 
 		// Show default placeholder height when not resized.

--- a/packages/block-library/src/site-logo/edit.js
+++ b/packages/block-library/src/site-logo/edit.js
@@ -40,7 +40,6 @@ import {
 import { useSelect, useDispatch } from '@wordpress/data';
 import { store as coreStore } from '@wordpress/core-data';
 import { crop, upload } from '@wordpress/icons';
-import { SVG, Path } from '@wordpress/primitives';
 import { store as noticesStore } from '@wordpress/notices';
 
 /**
@@ -520,20 +519,8 @@ export default function LogoEdit( {
 			<Placeholder
 				className={ placeholderClassName }
 				preview={ logoImage }
+				withIllustration={ true }
 			>
-				{
-					<SVG
-						className="components-placeholder__illustration"
-						fill="none"
-						xmlns="http://www.w3.org/2000/svg"
-						viewBox="0 0 60 60"
-					>
-						<Path
-							vectorEffect="non-scaling-stroke"
-							d="m61 32.622-13.555-9.137-15.888 9.859a5 5 0 0 1-5.386-.073l-9.095-5.989L1 37.5"
-						/>
-					</SVG>
-				}
 				{ content }
 			</Placeholder>
 		);

--- a/packages/block-library/src/site-logo/editor.scss
+++ b/packages/block-library/src/site-logo/editor.scss
@@ -131,20 +131,6 @@
 		.components-button.components-button > svg {
 			color: $white;
 		}
-
-		// Style the placeholder illustration.
-		.components-placeholder__illustration {
-			position: absolute;
-			top: 0;
-			right: 0;
-			bottom: 0;
-			left: 0;
-			width: 100%;
-			height: 100%;
-			stroke: currentColor;
-			stroke-dasharray: 3;
-			opacity: 0.4;
-		}
 	}
 
 	// Show upload button on block selection.

--- a/packages/components/src/placeholder/README.md
+++ b/packages/components/src/placeholder/README.md
@@ -11,9 +11,10 @@ const MyPlaceholder = () => <Placeholder icon={ more } label="Placeholder" />;
 
 ### Props
 
-| Name             | Type                | Default     | Description                                                       |
-| ---------------- | ------------------- | ----------- | ----------------------------------------------------------------- |
-| `icon`           | `string, WPElement` | `undefined` | If provided, renders an icon next to the label.                   |
-| `label`          | `string`            | `undefined` | Renders a label for the placeholder.                              |
-| `instructions`   | `string`            | `undefined` | Renders instruction text below label.                             |
-| `isColumnLayout` | `bool`              | `false`     | Changes placeholder children layout from flex-row to flex-column. |
+| Name              | Type                | Default     | Description                                                       |
+| ----------------  | ------------------- | ----------- | ----------------------------------------------------------------- |
+| `icon`            | `string, WPElement` | `undefined` | If provided, renders an icon next to the label.                   |
+| `label`           | `string`            | `undefined` | Renders a label for the placeholder.                              |
+| `instructions`    | `string`            | `undefined` | Renders instruction text below label.                             |
+| `isColumnLayout`  | `bool`              | `false`     | Changes placeholder children layout from flex-row to flex-column. |
+| `withIllustration`| `bool`              | `false`     | Outputs a placeholder illustration.                             |

--- a/packages/components/src/placeholder/index.js
+++ b/packages/components/src/placeholder/index.js
@@ -7,24 +7,38 @@ import classnames from 'classnames';
  * WordPress dependencies
  */
 import { useResizeObserver } from '@wordpress/compose';
+import { SVG, Path } from '@wordpress/primitives';
 
 /**
  * Internal dependencies
  */
 import Icon from '../icon';
 
+const PlaceholderIllustration = (
+	<SVG
+		className="components-placeholder__illustration"
+		fill="none"
+		xmlns="http://www.w3.org/2000/svg"
+		viewBox="0 0 60 60"
+		preserveAspectRatio="none"
+	>
+		<Path vectorEffect="non-scaling-stroke" d="M60 60 0 0" />
+	</SVG>
+);
+
 /**
  * Renders a placeholder. Normally used by blocks to render their empty state.
  *
- * @param {Object}    props                The component props.
- * @param {WPIcon}    props.icon           An icon rendered before the label.
- * @param {WPElement} props.children       Children to be rendered.
- * @param {string}    props.label          Title of the placeholder.
- * @param {string}    props.instructions   Instructions of the placeholder.
- * @param {string}    props.className      Class to set on the container div.
- * @param {Object}    props.notices        A rendered notices list.
- * @param {Object}    props.preview        Preview to be rendered in the placeholder.
- * @param {boolean}   props.isColumnLayout Whether a column layout should be used.
+ * @param {Object}    props                  The component props.
+ * @param {WPIcon}    props.icon             An icon rendered before the label.
+ * @param {WPElement} props.children         Children to be rendered.
+ * @param {string}    props.label            Title of the placeholder.
+ * @param {string}    props.instructions     Instructions of the placeholder.
+ * @param {string}    props.className        Class to set on the container div.
+ * @param {Object}    props.notices          A rendered notices list.
+ * @param {Object}    props.preview          Preview to be rendered in the placeholder.
+ * @param {boolean}   props.isColumnLayout   Whether a column layout should be used.
+ * @param {boolean}   props.withIllustration Whether to add an illustration to the placeholder.
  *
  * @return {Object} The rendered placeholder.
  */
@@ -37,6 +51,7 @@ function Placeholder( {
 	notices,
 	preview,
 	isColumnLayout,
+	withIllustration,
 	...additionalProps
 } ) {
 	const [ resizeListener, { width } ] = useResizeObserver();
@@ -55,13 +70,15 @@ function Placeholder( {
 	const classes = classnames(
 		'components-placeholder',
 		className,
-		modifierClassNames
+		modifierClassNames,
+		withIllustration ? 'has-illustration' : null
 	);
 	const fieldsetClasses = classnames( 'components-placeholder__fieldset', {
 		'is-column-layout': isColumnLayout,
 	} );
 	return (
 		<div { ...additionalProps } className={ classes }>
+			{ withIllustration ? PlaceholderIllustration : null }
 			{ resizeListener }
 			{ notices }
 			{ preview && (

--- a/packages/components/src/placeholder/style.scss
+++ b/packages/components/src/placeholder/style.scss
@@ -30,6 +30,13 @@
 	.components-base-control__label {
 		font-size: $default-font-size;
 	}
+
+	&.has-illustration {
+		background: none;
+		border: none;
+		box-shadow: none;
+		min-width: 100px;
+	}
 }
 
 .components-placeholder__error,
@@ -170,4 +177,20 @@
 			padding: 0 $grid-unit-10 2px;
 		}
 	}
+}
+
+// Style the placeholder illustration.
+.components-placeholder__illustration {
+	border: $border-width dashed currentColor;
+	box-sizing: border-box;
+	position: absolute;
+	top: 0;
+	right: 0;
+	bottom: 0;
+	left: 0;
+	width: 100%;
+	height: 100%;
+	stroke: currentColor;
+	stroke-dasharray: 3;
+	opacity: 0.4;
 }


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
I noticed that we have the same SVG in three places to add an illustration to the Placeholder component. This moves that SVG into a the Placeholder component itself so that we can share the code and simplify the implementation.

## Why?
Make it simpler!

## How?
This adds a new prop `withIllustration` to the placeholder component, which is used to determine whether to output the illustration. It then removes the illustration from the individual components as well as the associated CSS.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
1. Open a Post or Page that doesn't have a featured image.
2. Add a Site Logo block, and check that the placeholder state has a dashed placeholder illustration.
3. Add a Post Featured Image block, and check that the placeholder state has a dashed placeholder illustration.
4. Add a Clover block and set it to use a Featured Image, and check that the placeholder state has a dashed placeholder illustration.
5. Add a query block and then add a  a Post Featured Image block to it, and check that the placeholder state has a dashed placeholder illustration. (this uses a different branch of the code).


## Screenshots or screencast <!-- if applicable -->
<img width="1412" alt="Screenshot 2022-06-08 at 18 02 59" src="https://user-images.githubusercontent.com/275961/172675079-f634f2a7-3f41-4a21-bfee-7a6d915e4a79.png">
<img width="1156" alt="Screenshot 2022-06-08 at 18 04 00" src="https://user-images.githubusercontent.com/275961/172675233-58061db0-db30-48d5-9c8c-44f83648ccf3.png">


## Note
The illustration used in the Site Logo block is slightly different to the others, but IMO its better to have consistency.