### PR TITLE
`@wordpress/editor`: Add estimated time to read to table of contents in editor

### DIFF
--- a/packages/editor/src/components/table-of-contents/panel.js
+++ b/packages/editor/src/components/table-of-contents/panel.js
@@ -9,6 +9,7 @@ import { store as blockEditorStore } from '@wordpress/block-editor';
  * Internal dependencies
  */
 import WordCount from '../word-count';
+import TimeToRead from '../time-to-read';
 import DocumentOutline from '../document-outline';
 import CharacterCount from '../character-count';
 
@@ -65,6 +66,10 @@ function TableOfContentsPanel( { hasOutlineItemsDisabled, onRequestClose } ) {
 						<span className="table-of-contents__number">
 							{ numberOfBlocks }
 						</span>
+					</li>
+					<li className="table-of-contents__count">
+						{ __( 'Time to read' ) }
+						<TimeToRead />
 					</li>
 				</ul>
 			</div>

--- a/packages/editor/src/components/table-of-contents/panel.js
+++ b/packages/editor/src/components/table-of-contents/panel.js
@@ -40,14 +40,18 @@ function TableOfContentsPanel( { hasOutlineItemsDisabled, onRequestClose } ) {
 			>
 				<ul role="list" className="table-of-contents__counts">
 					<li className="table-of-contents__count">
+						{ __( 'Words' ) }
+						<WordCount />
+					</li>
+					<li className="table-of-contents__count">
 						{ __( 'Characters' ) }
 						<span className="table-of-contents__number">
 							<CharacterCount />
 						</span>
 					</li>
 					<li className="table-of-contents__count">
-						{ __( 'Words' ) }
-						<WordCount />
+						{ __( 'Time to read' ) }
+						<TimeToRead />
 					</li>
 					<li className="table-of-contents__count">
 						{ __( 'Headings' ) }
@@ -66,10 +70,6 @@ function TableOfContentsPanel( { hasOutlineItemsDisabled, onRequestClose } ) {
 						<span className="table-of-contents__number">
 							{ numberOfBlocks }
 						</span>
-					</li>
-					<li className="table-of-contents__count">
-						{ __( 'Time to read' ) }
-						<TimeToRead />
 					</li>
 				</ul>
 			</div>

--- a/packages/editor/src/components/time-to-read/index.js
+++ b/packages/editor/src/components/time-to-read/index.js
@@ -2,8 +2,9 @@
  * WordPress dependencies
  */
 import { useSelect } from '@wordpress/data';
-import { _x, _n } from '@wordpress/i18n';
+import { _x, _n, __, sprintf } from '@wordpress/i18n';
 import { count as wordCount } from '@wordpress/wordcount';
+import { createInterpolateElement } from '@wordpress/element';
 
 /**
  * Internal dependencies
@@ -34,13 +35,25 @@ export default function TimeToRead() {
 	const minutesToRead = Math.round(
 		wordCount( content, wordCountType ) / AVERAGE_READING_RATE
 	);
+	const minutesToReadString =
+		minutesToRead === 0
+			? createInterpolateElement( __( '<span>< 1</span> minute' ), {
+					span: <span className="table-of-contents__number" />,
+			  } )
+			: createInterpolateElement(
+					sprintf(
+						/* translators: %s is the number of minutes the post will take to read. */
+						_n(
+							'<span>%d</span> minute',
+							'<span>%d</span> minutes',
+							minutesToRead
+						),
+						minutesToRead
+					),
+					{
+						span: <span className="table-of-contents__number" />,
+					}
+			  );
 
-	return (
-		<span className="time-to-read">
-			<span className="table-of-contents__number">
-				{ minutesToRead }{ ' ' }
-			</span>
-			{ _n( 'minute', 'minutes', minutesToRead ) }
-		</span>
-	);
+	return <span className="time-to-read">{ minutesToReadString }</span>;
 }

--- a/packages/editor/src/components/time-to-read/index.js
+++ b/packages/editor/src/components/time-to-read/index.js
@@ -1,0 +1,39 @@
+/**
+ * WordPress dependencies
+ */
+import { useSelect } from '@wordpress/data';
+import { _x, _n } from '@wordpress/i18n';
+import { count as wordCount } from '@wordpress/wordcount';
+
+/**
+ * Internal dependencies
+ */
+import { store as editorStore } from '../../store';
+
+const AVERAGE_READING_RATE = 200;
+
+export default function TimeToRead() {
+	const content = useSelect(
+		( select ) => select( editorStore ).getEditedPostAttribute( 'content' ),
+		[]
+	);
+
+	/*
+	 * translators: If your word count is based on single characters (e.g. East Asian characters),
+	 * enter 'characters_excluding_spaces' or 'characters_including_spaces'. Otherwise, enter 'words'.
+	 * Do not translate into your own language.
+	 */
+	const wordCountType = _x( 'words', 'Word count type. Do not translate!' );
+	const minutesToRead = Math.round(
+		wordCount( content, wordCountType ) / AVERAGE_READING_RATE
+	);
+
+	return (
+		<span className="time-to-read">
+			<span className="table-of-contents__number">
+				{ minutesToRead }{ ' ' }
+			</span>
+			{ _n( 'minute', 'minutes', minutesToRead ) }
+		</span>
+	);
+}

--- a/packages/editor/src/components/time-to-read/index.js
+++ b/packages/editor/src/components/time-to-read/index.js
@@ -10,7 +10,14 @@ import { count as wordCount } from '@wordpress/wordcount';
  */
 import { store as editorStore } from '../../store';
 
-const AVERAGE_READING_RATE = 200;
+/**
+ * Average reading rate - based on average taken from
+ * https://irisreading.com/average-reading-speed-in-various-languages/
+ * (Characters/minute used for Chinese rather than words).
+ *
+ * @type {number} A rough estimate of the average reading rate across multiple languages.
+ */
+const AVERAGE_READING_RATE = 189;
 
 export default function TimeToRead() {
 	const content = useSelect(


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->
Adds an estimated time to read to the table of contents in the post editor.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
It would be a useful tool for editors to know how long their article will take (the average) reader to read.

Closes #38593.
## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
I took an average of the reading rate (words per minute, but characters per minute for Chinese) from this source: https://irisreading.com/average-reading-speed-in-various-languages/. A lot of other sources cite 200 wpm is the average reading rate but I think they didn't account for other languages. Using the average of 189 should get us a pretty good estimate.

Using this, I created a `TimeToRead` function, which uses `count` from `@wordpress/wordcount` to calculate how many minutes to display.

The number is styled larger than the text. **Please guide me on styling if we should do something different**.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->
1. Open a post or page and enter some text.
2. Open the table of contents panel (the `i` above the editor).
3. See the time to read presented at the end of the list.
4. Change the word count in your post, ensure the time to read increases appropriately. For every 189 words you add the time should increase by one minute.

## Screenshots or screencast <!-- if applicable -->
<img width="396" alt="image" src="https://user-images.githubusercontent.com/5656702/172733643-04217f19-6813-4e88-beaa-1ef5206408f4.png">

## Additional thoughts
If #41598 gets merged then we could possibly use `humanTimeDiff` to get the locale specific time between now and the estimated minutes to read. This displays time differences including from `a few seconds`, `x minutes`, `x hours`, `x days`, `x months` and `x years`.

The challenge here would be identifying how to split the resulting string into its locale-correct constituent parts (number of units of time, and string describing the unit of time) and styling the number and string differently. We also need to consider the case of the text only option, where the words are such that the post will take a single unit of time to read (i.e. `a minute`) and how we would style `a minute` where no number is present vs `2 minutes` where the number being larger than the text looks alright.
