### PR TITLE
Components: refactor `Navigation` to pass `exhaustive-deps`

### DIFF
--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -34,6 +34,7 @@
 -   `Shortcut`: Refactor away from `_.isObject()` ([#42336](https://github.com/WordPress/gutenberg/pull/42336/)).
 -   `RangeControl`: Convert to TypeScript ([#40535](https://github.com/WordPress/gutenberg/pull/40535)).
 -   `ExternalLink`: Refactor away from Lodash ([#42341](https://github.com/WordPress/gutenberg/pull/42341/)).
+-   `Navigation`: updated to satisfy `react/exhuastive-deps` eslint rule ([#41612](https://github.com/WordPress/gutenberg/pull/41612))
 
 ## 19.14.0 (2022-06-29)
 

--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -34,7 +34,7 @@
 -   `Shortcut`: Refactor away from `_.isObject()` ([#42336](https://github.com/WordPress/gutenberg/pull/42336/)).
 -   `RangeControl`: Convert to TypeScript ([#40535](https://github.com/WordPress/gutenberg/pull/40535)).
 -   `ExternalLink`: Refactor away from Lodash ([#42341](https://github.com/WordPress/gutenberg/pull/42341/)).
--   `Navigation`: updated to satisfy `react/exhuastive-deps` eslint rule ([#41612](https://github.com/WordPress/gutenberg/pull/41612))
+-   `Navigation`: updated to satisfy `react/exhaustive-deps` eslint rule ([#41612](https://github.com/WordPress/gutenberg/pull/41612))
 
 ## 19.14.0 (2022-06-29)
 

--- a/packages/components/src/navigation/index.js
+++ b/packages/components/src/navigation/index.js
@@ -54,6 +54,9 @@ export default function Navigation( {
 		if ( activeMenu !== menu ) {
 			setActiveMenu( activeMenu );
 		}
+		// Ignore exhaustive-deps here, as it would require either a larger refactor or some questionable workarounds.
+		// See https://github.com/WordPress/gutenberg/pull/41612 for context.
+		// eslint-disable-next-line react-hooks/exhaustive-deps
 	}, [ activeMenu ] );
 
 	const context = {

--- a/packages/components/src/navigation/index.js
+++ b/packages/components/src/navigation/index.js
@@ -28,6 +28,7 @@ export default function Navigation( {
 	onActivateMenu = noop,
 } ) {
 	const [ menu, setMenu ] = useState( activeMenu );
+	const menuRef = useRef( activeMenu );
 	const [ slideOrigin, setSlideOrigin ] = useState();
 	const navigationTree = useCreateNavigationTree();
 	const defaultSlideOrigin = isRTL() ? 'right' : 'left';
@@ -51,7 +52,11 @@ export default function Navigation( {
 	}, [] );
 
 	useEffect( () => {
-		if ( activeMenu !== menu ) {
+		menuRef.current = menu;
+	}, [ menu ] );
+
+	useEffect( () => {
+		if ( activeMenu !== menuRef.current ) {
 			setActiveMenu( activeMenu );
 		}
 	}, [ activeMenu ] );

--- a/packages/components/src/navigation/index.js
+++ b/packages/components/src/navigation/index.js
@@ -55,9 +55,11 @@ export default function Navigation( {
 		menuRef.current = menu;
 	}, [ menu ] );
 
+	// Used to prevent resetting the `menu` state when navigating between menus
+	const setActiveMenuRef = useRef( setActiveMenu );
 	useEffect( () => {
 		if ( activeMenu !== menuRef.current ) {
-			setActiveMenu( activeMenu );
+			setActiveMenuRef.current( activeMenu );
 		}
 	}, [ activeMenu ] );
 

--- a/packages/components/src/navigation/index.js
+++ b/packages/components/src/navigation/index.js
@@ -6,12 +6,7 @@ import classnames from 'classnames';
 /**
  * WordPress dependencies
  */
-import {
-	useEffect,
-	useLayoutEffect,
-	useRef,
-	useState,
-} from '@wordpress/element';
+import { useEffect, useRef, useState } from '@wordpress/element';
 import { isRTL } from '@wordpress/i18n';
 
 /**
@@ -55,15 +50,9 @@ export default function Navigation( {
 		}
 	}, [] );
 
-	// Used to prevent excessive useEffect fires when navigation is being controlled by parent component
-	const controlledMenuUpdate = useRef( { setActiveMenu, menu } );
-	useLayoutEffect( () => {
-		controlledMenuUpdate.current = { setActiveMenu, menu };
-	} );
-
 	useEffect( () => {
-		if ( activeMenu !== controlledMenuUpdate.current.menu ) {
-			controlledMenuUpdate.current.setActiveMenu( activeMenu );
+		if ( activeMenu !== menu ) {
+			setActiveMenu( activeMenu );
 		}
 	}, [ activeMenu ] );
 

--- a/packages/components/src/navigation/index.js
+++ b/packages/components/src/navigation/index.js
@@ -6,7 +6,12 @@ import classnames from 'classnames';
 /**
  * WordPress dependencies
  */
-import { useEffect, useRef, useState } from '@wordpress/element';
+import {
+	useEffect,
+	useLayoutEffect,
+	useRef,
+	useState,
+} from '@wordpress/element';
 import { isRTL } from '@wordpress/i18n';
 
 /**
@@ -28,7 +33,6 @@ export default function Navigation( {
 	onActivateMenu = noop,
 } ) {
 	const [ menu, setMenu ] = useState( activeMenu );
-	const menuRef = useRef( activeMenu );
 	const [ slideOrigin, setSlideOrigin ] = useState();
 	const navigationTree = useCreateNavigationTree();
 	const defaultSlideOrigin = isRTL() ? 'right' : 'left';
@@ -51,15 +55,15 @@ export default function Navigation( {
 		}
 	}, [] );
 
-	useEffect( () => {
-		menuRef.current = menu;
-	}, [ menu ] );
+	// Used to prevent excessive useEffect fires when navigation is being controlled by parent component
+	const controlledMenuUpdate = useRef( { setActiveMenu, menu } );
+	useLayoutEffect( () => {
+		controlledMenuUpdate.current = { setActiveMenu, menu };
+	} );
 
-	// Used to prevent resetting the `menu` state when navigating between menus
-	const setActiveMenuRef = useRef( setActiveMenu );
 	useEffect( () => {
-		if ( activeMenu !== menuRef.current ) {
-			setActiveMenuRef.current( activeMenu );
+		if ( activeMenu !== controlledMenuUpdate.current.menu ) {
+			controlledMenuUpdate.current.setActiveMenu( activeMenu );
 		}
 	}, [ activeMenu ] );
 


### PR DESCRIPTION
> **Note** there will likely be interaction between this PR and [#41639](https://github.com/WordPress/gutenberg/pull/41639). I don't think it matters which merges first, but we should retest the second one before proceeding.

## What?
Updates the `Navigation` component to ~satisfy~ **ignore** the `exhaustive-deps` eslint rule

## Why?
Part of the effort in https://github.com/WordPress/gutenberg/pull/41166 to apply `exhuastive-deps` to the Components package

## How?

Update: Because we ultimately prefer `Navigator` to `Navigation`, and fixing this component looks like it'd take either a heavier refactor or excessive reliance on `useRef`, we're option to disable the rule in this case rather than refactor the component.

~**Missing dependency: `menu`**~

~The component has an effect that checks to see if the `activeMenu` prop has been changed, which would currently only happen if it came from the parent component. The effect does this by checking the `activeMenu` prop against the current `menu` state. If they don't match, `menu` is updated to `activeMenu`. This effectively allows the parent component to control what menu or submenu is being displayed.~

~We can't add `menu` as an effect dependency because if `menu` was just changed (triggering a re-render and our effect) we know it no longer matches `activeMenu`. This means the effect will update `menu` _back_ to once again match `activeMenu`.~

~To fix this, we can update a ref of the current `menu` state value, and have the effect check against that instead. We no longer need `menu` in the dep array for `exhaustive-deps`, so we won't be firing the effect on every submenu navigation that updates the `menu` state.~

~To keep `menu` and `menuRef` in state, we can use another `useEffect` call. The dependency on `menu` in this case will limit the ref updates for us.~

~**Missing dependency: `setActiveMenu`**~

~Adding `setActivemenu` menu as a dep here is no good. We'd need to wrap it in a `useCallback` and then its own dependencies would update too often, redeclaring the function and triggering the effect on all menu navigations. Instead, if we use a Ref of the function we eliminate the need for a dep, while still giving the effect access to the functionality.~

## Testing Instructions
1. From your local Gutenberg directory, run `npx eslint --rule 'react-hooks/exhaustive-deps: warn' packages/components/src/navigation/index.js`
2. Confirm that the linter returns no errors
3. Confirm unit tests still pass
4. Run Storybook locally, confirm the components stories and/or docs still work as expected
