### PR TITLE
edit-post/sidebar/template: Fix lack of context on action buttons and improve A11Y

### DIFF
--- a/packages/edit-post/src/components/sidebar/template/actions.js
+++ b/packages/edit-post/src/components/sidebar/template/actions.js
@@ -126,8 +126,8 @@ function PostTemplateActions( { isPostsPage } ) {
 						onClick={ () => __unstableSwitchToTemplateMode() }
 						label={ sprintf(
 							// Translators: 1: The title or the slug of the currently selected template.
-							__( 'Edit Template: %s' ),
-							template?.title ?? template.slug
+							__( 'Edit template: %s' ),
+							template?.title.toLowerCase() ?? template.slug
 						) }
 					>
 						{ __( 'Edit' ) }
@@ -137,7 +137,7 @@ function PostTemplateActions( { isPostsPage } ) {
 					<Button
 						variant="link"
 						onClick={ () => setIsModalOpen( true ) }
-						label={ _x( 'New Template', 'action' ) }
+						label={ _x( 'New template', 'action' ) }
 					>
 						{
 							/* translators: button to create a new template */

--- a/packages/edit-post/src/components/sidebar/template/actions.js
+++ b/packages/edit-post/src/components/sidebar/template/actions.js
@@ -6,7 +6,7 @@ import { kebabCase } from 'lodash';
 /**
  * WordPress dependencies
  */
-import { __, _x } from '@wordpress/i18n';
+import { __, _x, sprintf } from '@wordpress/i18n';
 import {
 	Button,
 	Modal,
@@ -124,6 +124,11 @@ function PostTemplateActions( { isPostsPage } ) {
 					<Button
 						variant="link"
 						onClick={ () => __unstableSwitchToTemplateMode() }
+						label={ sprintf(
+							// Translators: 1: The title or the slug of the currently selected template.
+							__( 'Edit Template: %s' ),
+							template?.title ?? template.slug
+						) }
 					>
 						{ __( 'Edit' ) }
 					</Button>
@@ -132,6 +137,7 @@ function PostTemplateActions( { isPostsPage } ) {
 					<Button
 						variant="link"
 						onClick={ () => setIsModalOpen( true ) }
+						label={ _x( 'New Template', 'action' ) }
 					>
 						{
 							/* translators: button to create a new template */

--- a/test/e2e/specs/editor/various/post-editor-template-mode.spec.js
+++ b/test/e2e/specs/editor/various/post-editor-template-mode.spec.js
@@ -296,9 +296,9 @@ class PostEditorTemplateMode {
 
 		await this.expandTemplatePanel();
 
-		// Only match the beginning of Edit Template: because it contains the template name or slug afterwards.
+		// Only match the beginning of Edit template: because it contains the template name or slug afterwards.
 		await this.editorSettingsSidebar
-			.locator( 'role=button[name^="Edit Template: "i]' )
+			.locator( 'role=button[name^="Edit template: "i]' )
 			.click();
 
 		// Check that we switched properly to edit mode.
@@ -336,7 +336,7 @@ class PostEditorTemplateMode {
 		await this.expandTemplatePanel();
 
 		const newTemplateButton = this.editorSettingsSidebar.locator(
-			'role=button[name="New Template"i]'
+			'role=button[name="New template"i]'
 		);
 		await newTemplateButton.click();
 

--- a/test/e2e/specs/editor/various/post-editor-template-mode.spec.js
+++ b/test/e2e/specs/editor/various/post-editor-template-mode.spec.js
@@ -297,7 +297,7 @@ class PostEditorTemplateMode {
 		await this.expandTemplatePanel();
 
 		await this.editorSettingsSidebar
-			.locator( 'role=button[name="Edit"i]' )
+			.locator( 'role=button[name^="Edit Template: "i]' )
 			.click();
 
 		// Check that we switched properly to edit mode.
@@ -335,7 +335,7 @@ class PostEditorTemplateMode {
 		await this.expandTemplatePanel();
 
 		const newTemplateButton = this.editorSettingsSidebar.locator(
-			'role=button[name="New"i]'
+			'role=button[name="New Template"i]'
 		);
 		await newTemplateButton.click();
 

--- a/test/e2e/specs/editor/various/post-editor-template-mode.spec.js
+++ b/test/e2e/specs/editor/various/post-editor-template-mode.spec.js
@@ -296,6 +296,7 @@ class PostEditorTemplateMode {
 
 		await this.expandTemplatePanel();
 
+		// Only match the beginning of Edit Template: because it contains the template name or slug afterwards.
 		await this.editorSettingsSidebar
 			.locator( 'role=button[name^="Edit Template: "i]' )
 			.click();


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Adds `aria-label` to the template action buttons Edit/New to provide more context.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

Screen reader users rely on context to know that is the action they wish to take. Edit what? New what?

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

Adds the `aria-label`.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->

1. Open a post or page.
2. Open the settings for the page or post.
3. If collapsed, expand Template: name_of_current_template_here.
4. Notice how Edit/New buttons now read the following. Edit Template: currently_selected_template/New Template.

## Screenshots or screencast <!-- if applicable -->
