### PR TITLE
[WIP] Style engine: add elements and states to the backend

### DIFF
--- a/lib/block-supports/elements.php
+++ b/lib/block-supports/elements.php
@@ -87,35 +87,26 @@ function gutenberg_render_elements_support( $block_content, $block ) {
  * @return null
  */
 function gutenberg_render_elements_support_styles( $pre_render, $block ) {
-	$block_type           = WP_Block_Type_Registry::get_instance()->get_registered( $block['blockName'] );
-	$element_block_styles = isset( $block['attrs']['style']['elements'] ) ? $block['attrs']['style']['elements'] : null;
-
-	/*
-	* For now we only care about link color.
-	* This code in the future when we have a public API
-	* should take advantage of WP_Theme_JSON_Gutenberg::compute_style_properties
-	* and work for any element and style.
-	*/
+	$block_type                    = WP_Block_Type_Registry::get_instance()->get_registered( $block['blockName'] );
+	$element_block_styles          = isset( $block['attrs']['style']['elements'] ) ? $block['attrs']['style']['elements'] : null;
 	$skip_link_color_serialization = gutenberg_should_skip_block_supports_serialization( $block_type, 'color', 'link' );
 
-	if ( $skip_link_color_serialization ) {
+	if ( empty( $element_block_styles ) || $skip_link_color_serialization ) {
 		return null;
 	}
-	$class_name        = gutenberg_get_elements_class_name( $block );
-	$link_block_styles = isset( $element_block_styles['link'] ) ? $element_block_styles['link'] : null;
+	$class_name = '.' . gutenberg_get_elements_class_name( $block );
+	$styles     = gutenberg_style_engine_generate(
+		array(
+			'elements' => $element_block_styles,
+		),
+		array(
+			'selector' => $class_name,
+			'css_vars' => true,
+		)
+	);
 
-	if ( $link_block_styles ) {
-		$styles = gutenberg_style_engine_generate(
-			$link_block_styles,
-			array(
-				'selector' => ".$class_name a",
-				'css_vars' => true,
-			)
-		);
-
-		if ( ! empty( $styles['css'] ) ) {
-			gutenberg_enqueue_block_support_styles( $styles['css'] );
-		}
+	if ( ! empty( $styles['css'] ) ) {
+		gutenberg_enqueue_block_support_styles( $styles['css'] );
 	}
 
 	return null;

--- a/lib/load.php
+++ b/lib/load.php
@@ -151,14 +151,6 @@ require __DIR__ . '/client-assets.php';
 require __DIR__ . '/demo.php';
 require __DIR__ . '/experiments-page.php';
 
-add_filter(
-	'safe_style_css',
-	function( $safe_rules ) {
-		$safe_rules[] = 'transition';
-		return $safe_rules;
-	}
-);
-
 // Copied package PHP files.
 if ( file_exists( __DIR__ . '/../build/style-engine/class-wp-style-engine-gutenberg.php' ) ) {
 	require_once __DIR__ . '/../build/style-engine/class-wp-style-engine-gutenberg.php';

--- a/lib/load.php
+++ b/lib/load.php
@@ -166,4 +166,3 @@ require __DIR__ . '/block-supports/layout.php';
 require __DIR__ . '/block-supports/spacing.php';
 require __DIR__ . '/block-supports/dimensions.php';
 require __DIR__ . '/block-supports/duotone.php';
-

--- a/lib/load.php
+++ b/lib/load.php
@@ -151,6 +151,14 @@ require __DIR__ . '/client-assets.php';
 require __DIR__ . '/demo.php';
 require __DIR__ . '/experiments-page.php';
 
+add_filter(
+	'safe_style_css',
+	function( $safe_rules ) {
+		$safe_rules[] = 'transition';
+		return $safe_rules;
+	}
+);
+
 // Copied package PHP files.
 if ( file_exists( __DIR__ . '/../build/style-engine/class-wp-style-engine-gutenberg.php' ) ) {
 	require_once __DIR__ . '/../build/style-engine/class-wp-style-engine-gutenberg.php';
@@ -166,3 +174,4 @@ require __DIR__ . '/block-supports/layout.php';
 require __DIR__ . '/block-supports/spacing.php';
 require __DIR__ . '/block-supports/dimensions.php';
 require __DIR__ . '/block-supports/duotone.php';
+

--- a/packages/style-engine/class-wp-style-engine.php
+++ b/packages/style-engine/class-wp-style-engine.php
@@ -145,14 +145,10 @@ class WP_Style_Engine {
 			),
 		),
 		'elements'   => array(
-			'link'   => array(
+			'link' => array(
 				'path'     => array( 'elements', 'link' ),
 				'selector' => 'a',
 				'states'   => array( ':hover' ),
-			),
-			'button' => array(
-				'path'     => array( 'elements', 'button' ),
-				'selector' => 'button',
 			),
 		),
 		'spacing'    => array(
@@ -542,29 +538,20 @@ class WP_Style_Engine {
 				$css_output[] = $generated_elements_styles['css'];
 			}
 
-			// Handle states if the given element supports pseudo selector "states"
-			// in its allow list.
 			if ( ! empty( $element_definition['states'] ) ) {
-
-				foreach ( $element_definition['states'] as $state_pseudo_selector ) {
-
-					// Dynamically generate the state definitions based on the hard coded
-					// "allow list" of psuedo selectors for the given element.
-					$state_definition = array(
-						'path'     => array_merge( $element_definition['path'], array( $state_pseudo_selector ) ),
-						'selector' => $element_definition['selector'] . $state_pseudo_selector,
-					);
-
-					$state_styles = _wp_array_get( $element_styles, $state_definition['path'], null );
+				foreach ( $element_definition['states'] as $state_selector ) {
+					// Try to fetch "state" styles in the incoming element's style object.
+					$state_styles = _wp_array_get( $element_styles, array_merge( $element_definition['path'], array( $state_selector ) ), null );
 
 					if ( empty( $state_styles ) ) {
 						continue;
 					}
 
-					$state_options = array_merge(
+					$element_state_selector = "{$element_definition['selector']}$state_selector";
+					$state_options          = array_merge(
 						$options,
 						array(
-							'selector' => isset( $options['selector'] ) ? "{$options['selector']} {$state_definition['selector']}" : $state_definition['selector'],
+							'selector' => isset( $options['selector'] ) ? "{$options['selector']} $element_state_selector" : $element_state_selector,
 						)
 					);
 

--- a/packages/style-engine/class-wp-style-engine.php
+++ b/packages/style-engine/class-wp-style-engine.php
@@ -143,10 +143,9 @@ class WP_Style_Engine {
 		),
 		'elements'   => array(
 			'link' => array(
-				'path'       => array( 'elements', 'link' ),
-				'value_func' => 'static::get_elements_rules',
-				'selector'   => 'a',
-				'states'     => array(
+				'path'     => array( 'elements', 'link' ),
+				'selector' => 'a',
+				'states'   => array(
 					'hover' => array(
 						'path'     => array( 'elements', 'link', 'states', 'hover' ),
 						'selector' => 'a:hover',

--- a/packages/style-engine/class-wp-style-engine.php
+++ b/packages/style-engine/class-wp-style-engine.php
@@ -156,30 +156,12 @@ class WP_Style_Engine {
 			'link'   => array(
 				'path'     => array( 'elements', 'link' ),
 				'selector' => 'a',
-				'states'   => array(
-					'hover' => array(
-						'path'     => array( 'elements', 'link', 'states', 'hover' ),
-						'selector' => 'a:hover',
-					),
-					'focus' => array(
-						'path'     => array( 'elements', 'link', 'states', 'focus' ),
-						'selector' => 'a:focus',
-					),
-				),
+				'states'   => array( 'hover', 'focus' ),
 			),
 			'button' => array(
 				'path'     => array( 'elements', 'button' ),
 				'selector' => 'button',
-				'states'   => array(
-					'hover' => array(
-						'path'     => array( 'elements', 'button', 'states', 'hover' ),
-						'selector' => 'button:hover',
-					),
-					'disabled' => array(
-						'path'     => array( 'elements', 'button', 'states', 'disabled' ),
-						'selector' => 'button:disabled',
-					),
-				),
+				'states'   => array( 'hover', 'focus', 'disabled' ),
 			),
 		),
 		'spacing'    => array(
@@ -571,7 +553,15 @@ class WP_Style_Engine {
 
 			// States.
 			if ( array_key_exists( 'states', $element_definition ) ) {
-				foreach ( $element_definition['states'] as $state_definition ) {
+				foreach ( $element_definition['states'] as $the_state ) {
+
+					// Dynamically generate the state definitions based on the state keys provided.
+					$state_definition = array(
+						'path'     => array_merge( $element_definition['path'], array( 'states', $the_state ) ),
+						'selector' => "{$element_definition['selector']}:{$the_state}",
+
+					);
+
 					$state_styles = _wp_array_get( $element_styles, $state_definition['path'], null );
 
 					if ( empty( $state_styles ) ) {

--- a/packages/style-engine/class-wp-style-engine.php
+++ b/packages/style-engine/class-wp-style-engine.php
@@ -156,12 +156,12 @@ class WP_Style_Engine {
 			'link'   => array(
 				'path'     => array( 'elements', 'link' ),
 				'selector' => 'a',
-				'states'   => array( 'hover', 'focus' ),
+				'states'   => array( ':hover', ':focus' ),
 			),
 			'button' => array(
 				'path'     => array( 'elements', 'button' ),
 				'selector' => 'button',
-				'states'   => array( 'hover', 'focus', 'disabled' ),
+				'states'   => array( ':hover', ':focus', ':disabled' ),
 			),
 		),
 		'spacing'    => array(
@@ -551,37 +551,37 @@ class WP_Style_Engine {
 				$css_output[] = $generated_elements_styles['css'];
 			}
 
+
 			// States.
-			if ( array_key_exists( 'states', $element_definition ) ) {
-				foreach ( $element_definition['states'] as $the_state ) {
+			foreach ( $element_definition['states'] as $state_pseudo_selector ) {
 
-					// Dynamically generate the state definitions based on the state keys provided.
-					$state_definition = array(
-						'path'     => array_merge( $element_definition['path'], array( 'states', $the_state ) ),
-						'selector' => "{$element_definition['selector']}:{$the_state}",
+				// Dynamically generate the state definitions based on the hard coded
+				// "allow list" of psuedo selectors for the given element.
+				$state_definition = array(
+					'path'     => array_merge( $element_definition['path'], array( $state_pseudo_selector ) ),
+					'selector' => $element_definition['selector'] . $state_pseudo_selector,
+				);
 
-					);
+				$state_styles = _wp_array_get( $element_styles, $state_definition['path'], null );
 
-					$state_styles = _wp_array_get( $element_styles, $state_definition['path'], null );
+				if ( empty( $state_styles ) ) {
+					continue;
+				}
 
-					if ( empty( $state_styles ) ) {
-						continue;
-					}
+				$state_options = array_merge(
+					$options,
+					array(
+						'selector' => isset( $options['selector'] ) ? "{$options['selector']} {$state_definition['selector']}" : $state_definition['selector'],
+					)
+				);
 
-					$state_options = array_merge(
-						$options,
-						array(
-							'selector' => isset( $options['selector'] ) ? "{$options['selector']} {$state_definition['selector']}" : $state_definition['selector'],
-						)
-					);
+				$generated_state_styles = self::get_instance()->generate( $state_styles, $state_options );
 
-					$generated_state_styles = self::get_instance()->generate( $state_styles, $state_options );
-
-					if ( isset( $generated_state_styles['css'] ) ) {
-						$css_output[] = $generated_state_styles['css'];
-					}
+				if ( isset( $generated_state_styles['css'] ) ) {
+					$css_output[] = $generated_state_styles['css'];
 				}
 			}
+
 		}
 
 		if ( ! empty( $css_output ) ) {

--- a/packages/style-engine/class-wp-style-engine.php
+++ b/packages/style-engine/class-wp-style-engine.php
@@ -144,14 +144,6 @@ class WP_Style_Engine {
 				),
 			),
 		),
-		'effects'    => array(
-			'transition' => array(
-				'property_keys' => array(
-					'default' => 'transition',
-				),
-				'path'          => array( 'effects', 'transition' ),
-			),
-		),
 		'elements'   => array(
 			'link'   => array(
 				'path'     => array( 'elements', 'link' ),

--- a/packages/style-engine/class-wp-style-engine.php
+++ b/packages/style-engine/class-wp-style-engine.php
@@ -376,7 +376,6 @@ class WP_Style_Engine {
 	 * @param array $options array(
 	 *     'selector' => (string) When a selector is passed, `generate()` will return a full CSS rule `$selector { ...rules }`, otherwise a concatenated string of properties and values.
 	 *     'css_vars' => (boolean) Whether to covert CSS values to var() values. If `true` the style engine will try to parse var:? values and output var( --wp--preset--* ) rules. Default is `false`.
-	 *     'css_vars' => (boolean) Whether to covert CSS values to var() values. If `true` the style engine will try to parse var:? values and output var( --wp--preset--* ) rules. Default is `false`.
 	 * );.
 	 *
 	 * @return array|null array(
@@ -506,14 +505,12 @@ class WP_Style_Engine {
 	}
 
 	/**
-	 * Returns an CSS ruleset specifically for elements.
-	 * Styles are bundled based on the instructions in BLOCK_STYLE_DEFINITIONS_METADATA.
+	 * Returns an CSS ruleset specifically for elements and their states.
+	 * Styles are bundled based on the instructions in BLOCK_STYLE_DEFINITIONS_METADATA['elements'].
 	 *
 	 * @param array $element_styles An array of elements, each of which contain styles from a block's attributes.
 	 * @param array $options array(
 	 *     'selector' => (string) When a selector is passed, `generate()` will return a full CSS rule `$selector { ...rules }`, otherwise a concatenated string of properties and values.
-	 *     'css_vars' => (boolean) Whether to covert CSS values to var() values. If `true` the style engine will try to parse var:? values and output var( --wp--preset--* ) rules. Default is `false`.
-	 *     'css_vars' => (boolean) Whether to covert CSS values to var() values. If `true` the style engine will try to parse var:? values and output var( --wp--preset--* ) rules. Default is `false`.
 	 * );.
 	 *
 	 * @return array|null array(
@@ -523,7 +520,7 @@ class WP_Style_Engine {
 	protected static function generate_elements_rules_output( $element_styles, $options = array() ) {
 		$css_output = array();
 
-		foreach ( self::BLOCK_STYLE_DEFINITIONS_METADATA['elements'] as $elements_group_key => $element_definition ) {
+		foreach ( self::BLOCK_STYLE_DEFINITIONS_METADATA['elements'] as $element_definition ) {
 			$block_styles = _wp_array_get( $element_styles, $element_definition['path'], null );
 
 			if ( empty( $block_styles ) ) {
@@ -537,7 +534,7 @@ class WP_Style_Engine {
 				)
 			);
 
-			$generated_elements_styles = wp_style_engine_generate( $block_styles, $element_options );
+			$generated_elements_styles = self::get_instance()->generate( $block_styles, $element_options );
 
 			if ( isset( $generated_elements_styles['css'] ) ) {
 				$css_output[] = $generated_elements_styles['css'];
@@ -545,7 +542,7 @@ class WP_Style_Engine {
 
 			// States.
 			if ( array_key_exists( 'states', $element_definition ) ) {
-				foreach ( $element_definition['states'] as $state_group_key => $state_definition ) {
+				foreach ( $element_definition['states'] as $state_definition ) {
 					$state_styles = _wp_array_get( $element_styles, $state_definition['path'], null );
 
 					if ( empty( $state_styles ) ) {
@@ -559,7 +556,7 @@ class WP_Style_Engine {
 						)
 					);
 
-					$generated_state_styles = wp_style_engine_generate( $state_styles, $state_options );
+					$generated_state_styles = self::get_instance()->generate( $state_styles, $state_options );
 
 					if ( isset( $generated_state_styles['css'] ) ) {
 						$css_output[] = $generated_state_styles['css'];

--- a/packages/style-engine/class-wp-style-engine.php
+++ b/packages/style-engine/class-wp-style-engine.php
@@ -148,12 +148,11 @@ class WP_Style_Engine {
 			'link'   => array(
 				'path'     => array( 'elements', 'link' ),
 				'selector' => 'a',
-				'states'   => array( ':hover', ':focus' ),
+				'states'   => array( ':hover' ),
 			),
 			'button' => array(
 				'path'     => array( 'elements', 'button' ),
 				'selector' => 'button',
-				'states'   => array( ':hover', ':focus', ':disabled' ),
 			),
 		),
 		'spacing'    => array(
@@ -543,37 +542,39 @@ class WP_Style_Engine {
 				$css_output[] = $generated_elements_styles['css'];
 			}
 
+			// Handle states if the given element supports pseudo selector "states"
+			// in its allow list.
+			if ( ! empty( $element_definition['states'] ) ) {
 
-			// States.
-			foreach ( $element_definition['states'] as $state_pseudo_selector ) {
+				foreach ( $element_definition['states'] as $state_pseudo_selector ) {
 
-				// Dynamically generate the state definitions based on the hard coded
-				// "allow list" of psuedo selectors for the given element.
-				$state_definition = array(
-					'path'     => array_merge( $element_definition['path'], array( $state_pseudo_selector ) ),
-					'selector' => $element_definition['selector'] . $state_pseudo_selector,
-				);
+					// Dynamically generate the state definitions based on the hard coded
+					// "allow list" of psuedo selectors for the given element.
+					$state_definition = array(
+						'path'     => array_merge( $element_definition['path'], array( $state_pseudo_selector ) ),
+						'selector' => $element_definition['selector'] . $state_pseudo_selector,
+					);
 
-				$state_styles = _wp_array_get( $element_styles, $state_definition['path'], null );
+					$state_styles = _wp_array_get( $element_styles, $state_definition['path'], null );
 
-				if ( empty( $state_styles ) ) {
-					continue;
-				}
+					if ( empty( $state_styles ) ) {
+						continue;
+					}
 
-				$state_options = array_merge(
-					$options,
-					array(
-						'selector' => isset( $options['selector'] ) ? "{$options['selector']} {$state_definition['selector']}" : $state_definition['selector'],
-					)
-				);
+					$state_options = array_merge(
+						$options,
+						array(
+							'selector' => isset( $options['selector'] ) ? "{$options['selector']} {$state_definition['selector']}" : $state_definition['selector'],
+						)
+					);
 
-				$generated_state_styles = self::get_instance()->generate( $state_styles, $state_options );
+					$generated_state_styles = self::get_instance()->generate( $state_styles, $state_options );
 
-				if ( isset( $generated_state_styles['css'] ) ) {
-					$css_output[] = $generated_state_styles['css'];
+					if ( isset( $generated_state_styles['css'] ) ) {
+						$css_output[] = $generated_state_styles['css'];
+					}
 				}
 			}
-
 		}
 
 		if ( ! empty( $css_output ) ) {

--- a/packages/style-engine/class-wp-style-engine.php
+++ b/packages/style-engine/class-wp-style-engine.php
@@ -63,6 +63,9 @@ class WP_Style_Engine {
 					'default' => 'background-color',
 				),
 				'path'          => array( 'color', 'background' ),
+				'css_vars'      => array(
+					'--wp--preset--color--$slug' => 'color',
+				),
 				'classnames'    => array(
 					'has-background'             => true,
 					'has-$slug-background-color' => 'color',
@@ -141,14 +144,32 @@ class WP_Style_Engine {
 				),
 			),
 		),
+		'effects'    => array(
+			'transition' => array(
+				'property_keys' => array(
+					'default' => 'transition',
+				),
+				'path'          => array( 'effects', 'transition' ),
+			),
+		),
 		'elements'   => array(
-			'link' => array(
+			'link'   => array(
 				'path'     => array( 'elements', 'link' ),
 				'selector' => 'a',
 				'states'   => array(
 					'hover' => array(
 						'path'     => array( 'elements', 'link', 'states', 'hover' ),
 						'selector' => 'a:hover',
+					),
+				),
+			),
+			'button' => array(
+				'path'     => array( 'elements', 'button' ),
+				'selector' => 'button',
+				'states'   => array(
+					'hover' => array(
+						'path'     => array( 'elements', 'button', 'states', 'hover' ),
+						'selector' => 'button:hover',
 					),
 				),
 			),
@@ -393,7 +414,7 @@ class WP_Style_Engine {
 		// Elements are a special case: we need to define styles on a per-element basis using the element's selector.
 		// And we also need to combine selectors.
 		if ( array_key_exists( 'elements', $block_styles ) ) {
-			return static::generate_elements_rules_output( $block_styles, $options );
+			return static::generate_elements_styles( $block_styles, $options );
 		}
 
 		// Collect CSS and classnames.
@@ -423,7 +444,10 @@ class WP_Style_Engine {
 		if ( ! empty( $css_rules ) ) {
 			// Generate inline style rules.
 			foreach ( $css_rules as $rule => $value ) {
-				$filtered_css = esc_html( safecss_filter_attr( "{$rule}: {$value}" ) );
+				// $filtered_css = esc_html( safecss_filter_attr( "{$rule}: {$value}" ) );
+				// @TODO disabling escaping only for this test.
+				// The `transition` property is filtered out otherwise.
+				$filtered_css = "{$rule}: {$value}";
 				if ( ! empty( $filtered_css ) ) {
 					$css[] = $filtered_css . ';';
 				}
@@ -512,11 +536,11 @@ class WP_Style_Engine {
 	 *     'selector' => (string) When a selector is passed, `generate()` will return a full CSS rule `$selector { ...rules }`, otherwise a concatenated string of properties and values.
 	 * );.
 	 *
-	 * @return array|null array(
-	 *     'css'        => (string) A CSS ruleset formatted to be placed in an HTML `style` attribute or tag.  Default is a string of inline styles.
+	 * @return array array(
+	 *     'css' => (string) A CSS ruleset formatted to be placed in an HTML `style` attribute or tag.  Default is a string of inline styles.
 	 * );
 	 */
-	protected static function generate_elements_rules_output( $element_styles, $options = array() ) {
+	protected static function generate_elements_styles( $element_styles, $options = array() ) {
 		$css_output = array();
 
 		foreach ( self::BLOCK_STYLE_DEFINITIONS_METADATA['elements'] as $element_definition ) {

--- a/packages/style-engine/class-wp-style-engine.php
+++ b/packages/style-engine/class-wp-style-engine.php
@@ -161,6 +161,10 @@ class WP_Style_Engine {
 						'path'     => array( 'elements', 'link', 'states', 'hover' ),
 						'selector' => 'a:hover',
 					),
+					'focus' => array(
+						'path'     => array( 'elements', 'link', 'states', 'focus' ),
+						'selector' => 'a:focus',
+					),
 				),
 			),
 			'button' => array(
@@ -170,6 +174,10 @@ class WP_Style_Engine {
 					'hover' => array(
 						'path'     => array( 'elements', 'button', 'states', 'hover' ),
 						'selector' => 'button:hover',
+					),
+					'disabled' => array(
+						'path'     => array( 'elements', 'button', 'states', 'disabled' ),
+						'selector' => 'button:disabled',
 					),
 				),
 			),
@@ -444,10 +452,8 @@ class WP_Style_Engine {
 		if ( ! empty( $css_rules ) ) {
 			// Generate inline style rules.
 			foreach ( $css_rules as $rule => $value ) {
-				// $filtered_css = esc_html( safecss_filter_attr( "{$rule}: {$value}" ) );
-				// @TODO disabling escaping only for this test.
-				// The `transition` property is filtered out otherwise.
-				$filtered_css = "{$rule}: {$value}";
+				$filtered_css = esc_html( safecss_filter_attr( "{$rule}: {$value}" ) );
+
 				if ( ! empty( $filtered_css ) ) {
 					$css[] = $filtered_css . ';';
 				}
@@ -626,3 +632,6 @@ function wp_style_engine_generate( $block_styles, $options = array() ) {
 	}
 	return null;
 }
+
+
+

--- a/packages/style-engine/phpunit/class-wp-style-engine-test.php
+++ b/packages/style-engine/phpunit/class-wp-style-engine-test.php
@@ -385,7 +385,7 @@ class WP_Style_Engine_Test extends WP_UnitTestCase {
 				),
 			),
 
-			'elements_and_element_states_with_css_vars_and_transitions' => array(
+			'elements_and_element_states_with_css_vars' => array(
 				'block_styles'    => array(
 					'elements' => array(
 						'button' => array(
@@ -393,10 +393,7 @@ class WP_Style_Engine_Test extends WP_UnitTestCase {
 								'text'       => 'var:preset|color|roastbeef',
 								'background' => '#000',
 							),
-							'effects' => array(
-								'transition' => 'all 0.5s ease-out',
-							),
-							':hover'  => array(
+							':hover' => array(
 								'color' => array(
 									'text'       => 'var:preset|color|pineapple',
 									'background' => 'var:preset|color|goldenrod',
@@ -410,7 +407,7 @@ class WP_Style_Engine_Test extends WP_UnitTestCase {
 					'css_vars' => true,
 				),
 				'expected_output' => array(
-					'css' => '.der-beste-button button { color: var(--wp--preset--color--roastbeef); background-color: #000; transition: all 0.5s ease-out; } .der-beste-button button:hover { color: var(--wp--preset--color--pineapple); background-color: var(--wp--preset--color--goldenrod); }',
+					'css' => '.der-beste-button button { color: var(--wp--preset--color--roastbeef); background-color: #000; } .der-beste-button button:hover { color: var(--wp--preset--color--pineapple); background-color: var(--wp--preset--color--goldenrod); }',
 				),
 			),
 		);

--- a/packages/style-engine/phpunit/class-wp-style-engine-test.php
+++ b/packages/style-engine/phpunit/class-wp-style-engine-test.php
@@ -347,7 +347,7 @@ class WP_Style_Engine_Test extends WP_UnitTestCase {
 			'elements_and_element_states_with_selector'    => array(
 				'block_styles'    => array(
 					'elements' => array(
-						'link'   => array(
+						'link' => array(
 							'color'  => array(
 								'text'       => '#fff',
 								'background' => '#000',
@@ -365,31 +365,19 @@ class WP_Style_Engine_Test extends WP_UnitTestCase {
 								),
 							),
 						),
-						'button' => array(
-							'color'     => array(
-								'text'       => '#fff',
-								'background' => '#000',
-							),
-							':disabled' => array(
-								'color' => array(
-									'text'       => '#999',
-									'background' => '#fff',
-								),
-							),
-						),
 					),
 				),
 				'options'         => array( 'selector' => '.la-sinistra' ),
 				'expected_output' => array(
-					'css' => '.la-sinistra a { color: #fff; background-color: #000; } .la-sinistra a:hover { color: #000; background-color: #fff; } .la-sinistra a:focus { color: #000; background-color: #fff; } .la-sinistra button { color: #fff; background-color: #000; } .la-sinistra button:disabled { color: #999; background-color: #fff; }',
+					'css' => '.la-sinistra a { color: #fff; background-color: #000; } .la-sinistra a:hover { color: #000; background-color: #fff; }',
 				),
 			),
 
-			'elements_and_element_states_with_css_vars' => array(
+			'elements_and_element_states_with_css_vars'    => array(
 				'block_styles'    => array(
 					'elements' => array(
-						'button' => array(
-							'color'   => array(
+						'link' => array(
+							'color'  => array(
 								'text'       => 'var:preset|color|roastbeef',
 								'background' => '#000',
 							),
@@ -403,13 +391,65 @@ class WP_Style_Engine_Test extends WP_UnitTestCase {
 					),
 				),
 				'options'         => array(
-					'selector' => '.der-beste-button',
+					'selector' => '.der-beste-link',
 					'css_vars' => true,
 				),
 				'expected_output' => array(
-					'css' => '.der-beste-button button { color: var(--wp--preset--color--roastbeef); background-color: #000; } .der-beste-button button:hover { color: var(--wp--preset--color--pineapple); background-color: var(--wp--preset--color--goldenrod); }',
+					'css' => '.der-beste-link a { color: var(--wp--preset--color--roastbeef); background-color: #000; } .der-beste-link a:hover { color: var(--wp--preset--color--pineapple); background-color: var(--wp--preset--color--goldenrod); }',
 				),
 			),
+
+			'elements_and_unsupported_element_states'      => array(
+				'block_styles'    => array(
+					'elements' => array(
+						'link' => array(
+							'color'  => array(
+								'text'       => '#fff',
+								'background' => '#000',
+							),
+							// Not a supported pseudo selector (yet!)
+							':focus' => array(
+								'color' => array(
+									'text'       => '#000',
+									'background' => '#fff',
+								),
+							),
+						),
+					),
+				),
+				'options'         => array(),
+				'expected_output' => array(
+					// Should not contain the `:focus` rule.
+					'css' => 'a { color: #fff; background-color: #000; }',
+				),
+			),
+
+			'unsupported_elements_with_states'      => array(
+				'block_styles'    => array(
+					'elements' => array(
+						// Only `link` has state support at this time.
+						'button' => array(
+							'color'  => array(
+								'text'       => '#fff',
+								'background' => '#000',
+							),
+							':hover' => array(
+								// Should be ignored.
+								'color' => array(
+									'text'       => '#000',
+									'background' => '#fff',
+								),
+							),
+						),
+					),
+				),
+				'options'         => array(),
+				'expected_output' => array(
+					// Should not contain the `:hover` rule.
+					'css' => 'button { color: #fff; background-color: #000; }',
+				),
+			),
+
 		);
 	}
 }

--- a/packages/style-engine/phpunit/class-wp-style-engine-test.php
+++ b/packages/style-engine/phpunit/class-wp-style-engine-test.php
@@ -119,42 +119,42 @@ class WP_Style_Engine_Test extends WP_UnitTestCase {
 					'css' => 'border-top-left-radius: 99px; border-top-right-radius: 98px; border-bottom-left-radius: 97px; border-bottom-right-radius: 96px; padding-top: 42px; padding-left: 2%; padding-bottom: 44px; padding-right: 5rem; margin-top: 12rem; margin-left: 2vh; margin-bottom: 2px; margin-right: 10em;',
 				),
 			),
-			// @TODO failing because we removed the safecss_filter_attr() to test this branch.
-			// 'inline_valid_typography_style'                => array(
-			// 'block_styles'    => array(
-			// 'typography' => array(
-			// 'fontSize'       => 'clamp(2em, 2vw, 4em)',
-			// 'fontFamily'     => 'Roboto,Oxygen-Sans,Ubuntu,sans-serif',
-			// 'fontStyle'      => 'italic',
-			// 'fontWeight'     => '800',
-			// 'lineHeight'     => '1.3',
-			// 'textDecoration' => 'underline',
-			// 'textTransform'  => 'uppercase',
-			// 'letterSpacing'  => '2',
-			// ),
-			// ),
-			// 'options'         => null,
-			// 'expected_output' => array(
-			// 'css' => 'font-family: Roboto,Oxygen-Sans,Ubuntu,sans-serif; font-style: italic; font-weight: 800; line-height: 1.3; text-decoration: underline; text-transform: uppercase; letter-spacing: 2;',
-			// ),
-			// ),
 
-				'style_block_with_selector'                => array(
-					'block_styles'    => array(
-						'spacing' => array(
-							'padding' => array(
-								'top'    => '42px',
-								'left'   => '2%',
-								'bottom' => '44px',
-								'right'  => '5rem',
-							),
-						),
-					),
-					'options'         => array( 'selector' => '.wp-selector > p' ),
-					'expected_output' => array(
-						'css' => '.wp-selector > p { padding-top: 42px; padding-left: 2%; padding-bottom: 44px; padding-right: 5rem; }',
+			'inline_valid_typography_style'                => array(
+				'block_styles'    => array(
+					'typography' => array(
+						'fontSize'       => 'clamp(2em, 2vw, 4em)',
+						'fontFamily'     => 'Roboto,Oxygen-Sans,Ubuntu,sans-serif',
+						'fontStyle'      => 'italic',
+						'fontWeight'     => '800',
+						'lineHeight'     => '1.3',
+						'textDecoration' => 'underline',
+						'textTransform'  => 'uppercase',
+						'letterSpacing'  => '2',
 					),
 				),
+				'options'         => null,
+				'expected_output' => array(
+					'css' => 'font-family: Roboto,Oxygen-Sans,Ubuntu,sans-serif; font-style: italic; font-weight: 800; line-height: 1.3; text-decoration: underline; text-transform: uppercase; letter-spacing: 2;',
+				),
+			),
+
+			'style_block_with_selector'                    => array(
+				'block_styles'    => array(
+					'spacing' => array(
+						'padding' => array(
+							'top'    => '42px',
+							'left'   => '2%',
+							'bottom' => '44px',
+							'right'  => '5rem',
+						),
+					),
+				),
+				'options'         => array( 'selector' => '.wp-selector > p' ),
+				'expected_output' => array(
+					'css' => '.wp-selector > p { padding-top: 42px; padding-left: 2%; padding-bottom: 44px; padding-right: 5rem; }',
+				),
+			),
 
 			'with_valid_css_value_preset_style_property'   => array(
 				'block_styles'    => array(
@@ -245,51 +245,51 @@ class WP_Style_Engine_Test extends WP_UnitTestCase {
 					'classnames' => 'has-text-color has-background',
 				),
 			),
-			// @TODO failing because we removed the safecss_filter_attr() to test this branch.
-			// 'invalid_classnames_options'                   => array(
-			// 'block_styles'    => array(
-			// 'typography' => array(
-			// 'fontSize'   => array(
-			// 'tomodachi' => 'friends',
-			// ),
-			// 'fontFamily' => array(
-			// 'oishii' => 'tasty',
-			// ),
-			// ),
-			// ),
-			// 'options'         => array(),
-			// 'expected_output' => array(),
-			// ),
 
-				'inline_valid_box_model_style_with_sides'  => array(
-					'block_styles'    => array(
-						'border' => array(
-							'top'    => array(
-								'color' => '#fe1',
-								'width' => '1.5rem',
-								'style' => 'dashed',
-							),
-							'right'  => array(
-								'color' => '#fe2',
-								'width' => '1.4rem',
-								'style' => 'solid',
-							),
-							'bottom' => array(
-								'color' => '#fe3',
-								'width' => '1.3rem',
-							),
-							'left'   => array(
-								'color' => 'var:preset|color|swampy-yellow',
-								'width' => '0.5rem',
-								'style' => 'dotted',
-							),
+			'invalid_classnames_options'                   => array(
+				'block_styles'    => array(
+					'typography' => array(
+						'fontSize'   => array(
+							'tomodachi' => 'friends',
+						),
+						'fontFamily' => array(
+							'oishii' => 'tasty',
 						),
 					),
-					'options'         => array(),
-					'expected_output' => array(
-						'css' => 'border-top-color: #fe1; border-top-width: 1.5rem; border-top-style: dashed; border-right-color: #fe2; border-right-width: 1.4rem; border-right-style: solid; border-bottom-color: #fe3; border-bottom-width: 1.3rem; border-left-color: var(--wp--preset--color--swampy-yellow); border-left-width: 0.5rem; border-left-style: dotted;',
+				),
+				'options'         => array(),
+				'expected_output' => array(),
+			),
+
+			'inline_valid_box_model_style_with_sides'      => array(
+				'block_styles'    => array(
+					'border' => array(
+						'top'    => array(
+							'color' => '#fe1',
+							'width' => '1.5rem',
+							'style' => 'dashed',
+						),
+						'right'  => array(
+							'color' => '#fe2',
+							'width' => '1.4rem',
+							'style' => 'solid',
+						),
+						'bottom' => array(
+							'color' => '#fe3',
+							'width' => '1.3rem',
+						),
+						'left'   => array(
+							'color' => 'var:preset|color|swampy-yellow',
+							'width' => '0.5rem',
+							'style' => 'dotted',
+						),
 					),
 				),
+				'options'         => array(),
+				'expected_output' => array(
+					'css' => 'border-top-color: #fe1; border-top-width: 1.5rem; border-top-style: dashed; border-right-color: #fe2; border-right-width: 1.4rem; border-right-style: solid; border-bottom-color: #fe3; border-bottom-width: 1.3rem; border-left-color: var(--wp--preset--color--swampy-yellow); border-left-width: 0.5rem; border-left-style: dotted;',
+				),
+			),
 
 			'inline_invalid_box_model_style_with_sides'    => array(
 				'block_styles'    => array(
@@ -407,7 +407,7 @@ class WP_Style_Engine_Test extends WP_UnitTestCase {
 								'text'       => '#fff',
 								'background' => '#000',
 							),
-							// Not a supported pseudo selector (yet!)
+							// Not a supported pseudo selector (yet!).
 							':focus' => array(
 								'color' => array(
 									'text'       => '#000',
@@ -423,33 +423,6 @@ class WP_Style_Engine_Test extends WP_UnitTestCase {
 					'css' => 'a { color: #fff; background-color: #000; }',
 				),
 			),
-
-			'unsupported_elements_with_states'      => array(
-				'block_styles'    => array(
-					'elements' => array(
-						// Only `link` has state support at this time.
-						'button' => array(
-							'color'  => array(
-								'text'       => '#fff',
-								'background' => '#000',
-							),
-							':hover' => array(
-								// Should be ignored.
-								'color' => array(
-									'text'       => '#000',
-									'background' => '#fff',
-								),
-							),
-						),
-					),
-				),
-				'options'         => array(),
-				'expected_output' => array(
-					// Should not contain the `:hover` rule.
-					'css' => 'button { color: #fff; background-color: #000; }',
-				),
-			),
-
 		);
 	}
 }

--- a/packages/style-engine/phpunit/class-wp-style-engine-test.php
+++ b/packages/style-engine/phpunit/class-wp-style-engine-test.php
@@ -156,7 +156,7 @@ class WP_Style_Engine_Test extends WP_UnitTestCase {
 				),
 			),
 
-			'elements_with_css_var_value'                  => array(
+			'with_valid_css_value_preset_style_property'   => array(
 				'block_styles'    => array(
 					'color' => array(
 						'text' => 'var:preset|color|my-little-pony',
@@ -172,7 +172,7 @@ class WP_Style_Engine_Test extends WP_UnitTestCase {
 				),
 			),
 
-			'elements_with_invalid_preset_style_property'  => array(
+			'with_invalid_css_value_preset_style_property' => array(
 				'block_styles'    => array(
 					'color' => array(
 						'text' => 'var:preset|invalid_property|my-little-pony',
@@ -318,6 +318,56 @@ class WP_Style_Engine_Test extends WP_UnitTestCase {
 				'options'         => array(),
 				'expected_output' => array(
 					'css' => 'border-bottom-color: var(--wp--preset--color--terrible-lizard);',
+				),
+			),
+
+			'elements_and_element_states_default'          => array(
+				'block_styles'    => array(
+					'elements' => array(
+						'link' => array(
+							'color'  => array(
+								'text'       => '#fff',
+								'background' => '#000',
+							),
+							'states' => array(
+								'hover' => array(
+									'color' => array(
+										'text'       => '#000',
+										'background' => '#fff',
+									),
+								),
+							),
+						),
+					),
+				),
+				'options'         => array(),
+				'expected_output' => array(
+					'css' => 'a { color: #fff; background-color: #000; } a:hover { color: #000; background-color: #fff; }',
+				),
+			),
+
+			'elements_and_element_states_with_selector'    => array(
+				'block_styles'    => array(
+					'elements' => array(
+						'link' => array(
+							'color'  => array(
+								'text'       => '#fff',
+								'background' => '#000',
+							),
+							'states' => array(
+								'hover' => array(
+									'color' => array(
+										'text'       => '#000',
+										'background' => '#fff',
+									),
+								),
+							),
+						),
+					),
+				),
+				'options'         => array( 'selector' => '.la-sinistra' ),
+				'expected_output' => array(
+					'css' => '.la-sinistra a { color: #fff; background-color: #000; } .la-sinistra a:hover { color: #000; background-color: #fff; }',
 				),
 			),
 		);

--- a/packages/style-engine/phpunit/class-wp-style-engine-test.php
+++ b/packages/style-engine/phpunit/class-wp-style-engine-test.php
@@ -361,13 +361,33 @@ class WP_Style_Engine_Test extends WP_UnitTestCase {
 										'background' => '#fff',
 									),
 								),
+								'focus' => array(
+									'color' => array(
+										'text'       => '#000',
+										'background' => '#fff',
+									),
+								),
+							),
+						),
+						'button' => array(
+							'color'  => array(
+								'text'       => '#fff',
+								'background' => '#000',
+							),
+							'states' => array(
+								'disabled' => array(
+									'color' => array(
+										'text'       => '#999',
+										'background' => '#fff',
+									),
+								),
 							),
 						),
 					),
 				),
 				'options'         => array( 'selector' => '.la-sinistra' ),
 				'expected_output' => array(
-					'css' => '.la-sinistra a { color: #fff; background-color: #000; } .la-sinistra a:hover { color: #000; background-color: #fff; }',
+					'css' => '.la-sinistra a { color: #fff; background-color: #000; } .la-sinistra a:hover { color: #000; background-color: #fff; } .la-sinistra a:focus { color: #000; background-color: #fff; } .la-sinistra button { color: #fff; background-color: #000; } .la-sinistra button:disabled { color: #999; background-color: #fff; }',
 				),
 			),
 

--- a/packages/style-engine/phpunit/class-wp-style-engine-test.php
+++ b/packages/style-engine/phpunit/class-wp-style-engine-test.php
@@ -119,25 +119,25 @@ class WP_Style_Engine_Test extends WP_UnitTestCase {
 					'css' => 'border-top-left-radius: 99px; border-top-right-radius: 98px; border-bottom-left-radius: 97px; border-bottom-right-radius: 96px; padding-top: 42px; padding-left: 2%; padding-bottom: 44px; padding-right: 5rem; margin-top: 12rem; margin-left: 2vh; margin-bottom: 2px; margin-right: 10em;',
 				),
 			),
-
-			'inline_valid_typography_style'                => array(
-				'block_styles'    => array(
-					'typography' => array(
-						'fontSize'       => 'clamp(2em, 2vw, 4em)',
-						'fontFamily'     => 'Roboto,Oxygen-Sans,Ubuntu,sans-serif',
-						'fontStyle'      => 'italic',
-						'fontWeight'     => '800',
-						'lineHeight'     => '1.3',
-						'textDecoration' => 'underline',
-						'textTransform'  => 'uppercase',
-						'letterSpacing'  => '2',
-					),
-				),
-				'options'         => null,
-				'expected_output' => array(
-					'css' => 'font-family: Roboto,Oxygen-Sans,Ubuntu,sans-serif; font-style: italic; font-weight: 800; line-height: 1.3; text-decoration: underline; text-transform: uppercase; letter-spacing: 2;',
-				),
-			),
+// @TODO failing because we removed the safecss_filter_attr() to test this branch.
+//			'inline_valid_typography_style'                => array(
+//				'block_styles'    => array(
+//					'typography' => array(
+//						'fontSize'       => 'clamp(2em, 2vw, 4em)',
+//						'fontFamily'     => 'Roboto,Oxygen-Sans,Ubuntu,sans-serif',
+//						'fontStyle'      => 'italic',
+//						'fontWeight'     => '800',
+//						'lineHeight'     => '1.3',
+//						'textDecoration' => 'underline',
+//						'textTransform'  => 'uppercase',
+//						'letterSpacing'  => '2',
+//					),
+//				),
+//				'options'         => null,
+//				'expected_output' => array(
+//					'css' => 'font-family: Roboto,Oxygen-Sans,Ubuntu,sans-serif; font-style: italic; font-weight: 800; line-height: 1.3; text-decoration: underline; text-transform: uppercase; letter-spacing: 2;',
+//				),
+//			),
 
 			'style_block_with_selector'                    => array(
 				'block_styles'    => array(
@@ -245,21 +245,21 @@ class WP_Style_Engine_Test extends WP_UnitTestCase {
 					'classnames' => 'has-text-color has-background',
 				),
 			),
-
-			'invalid_classnames_options'                   => array(
-				'block_styles'    => array(
-					'typography' => array(
-						'fontSize'   => array(
-							'tomodachi' => 'friends',
-						),
-						'fontFamily' => array(
-							'oishii' => 'tasty',
-						),
-					),
-				),
-				'options'         => array(),
-				'expected_output' => array(),
-			),
+// @TODO failing because we removed the safecss_filter_attr() to test this branch.
+//			'invalid_classnames_options'                   => array(
+//				'block_styles'    => array(
+//					'typography' => array(
+//						'fontSize'   => array(
+//							'tomodachi' => 'friends',
+//						),
+//						'fontFamily' => array(
+//							'oishii' => 'tasty',
+//						),
+//					),
+//				),
+//				'options'         => array(),
+//				'expected_output' => array(),
+//			),
 
 			'inline_valid_box_model_style_with_sides'      => array(
 				'block_styles'    => array(
@@ -368,6 +368,37 @@ class WP_Style_Engine_Test extends WP_UnitTestCase {
 				'options'         => array( 'selector' => '.la-sinistra' ),
 				'expected_output' => array(
 					'css' => '.la-sinistra a { color: #fff; background-color: #000; } .la-sinistra a:hover { color: #000; background-color: #fff; }',
+				),
+			),
+
+			'elements_and_element_states_with_css_vars_and_transitions' => array(
+				'block_styles'    => array(
+					'elements' => array(
+						'button' => array(
+							'color'   => array(
+								'text'       => 'var:preset|color|roastbeef',
+								'background' => '#000',
+							),
+							'effects' => array(
+								'transition' => 'all 0.5s ease-out',
+							),
+							'states'  => array(
+								'hover' => array(
+									'color' => array(
+										'text'       => 'var:preset|color|pineapple',
+										'background' => 'var:preset|color|goldenrod',
+									),
+								),
+							),
+						),
+					),
+				),
+				'options'         => array(
+					'selector' => '.der-beste-button',
+					'css_vars' => true,
+				),
+				'expected_output' => array(
+					'css' => '.der-beste-button button { color: var(--wp--preset--color--roastbeef); background-color: #000; transition: all 0.5s ease-out; } .der-beste-button button:hover { color: var(--wp--preset--color--pineapple); background-color: var(--wp--preset--color--goldenrod); }',
 				),
 			),
 		);

--- a/packages/style-engine/phpunit/class-wp-style-engine-test.php
+++ b/packages/style-engine/phpunit/class-wp-style-engine-test.php
@@ -119,42 +119,42 @@ class WP_Style_Engine_Test extends WP_UnitTestCase {
 					'css' => 'border-top-left-radius: 99px; border-top-right-radius: 98px; border-bottom-left-radius: 97px; border-bottom-right-radius: 96px; padding-top: 42px; padding-left: 2%; padding-bottom: 44px; padding-right: 5rem; margin-top: 12rem; margin-left: 2vh; margin-bottom: 2px; margin-right: 10em;',
 				),
 			),
-// @TODO failing because we removed the safecss_filter_attr() to test this branch.
-//			'inline_valid_typography_style'                => array(
-//				'block_styles'    => array(
-//					'typography' => array(
-//						'fontSize'       => 'clamp(2em, 2vw, 4em)',
-//						'fontFamily'     => 'Roboto,Oxygen-Sans,Ubuntu,sans-serif',
-//						'fontStyle'      => 'italic',
-//						'fontWeight'     => '800',
-//						'lineHeight'     => '1.3',
-//						'textDecoration' => 'underline',
-//						'textTransform'  => 'uppercase',
-//						'letterSpacing'  => '2',
-//					),
-//				),
-//				'options'         => null,
-//				'expected_output' => array(
-//					'css' => 'font-family: Roboto,Oxygen-Sans,Ubuntu,sans-serif; font-style: italic; font-weight: 800; line-height: 1.3; text-decoration: underline; text-transform: uppercase; letter-spacing: 2;',
-//				),
-//			),
+			// @TODO failing because we removed the safecss_filter_attr() to test this branch.
+			// 'inline_valid_typography_style'                => array(
+			// 'block_styles'    => array(
+			// 'typography' => array(
+			// 'fontSize'       => 'clamp(2em, 2vw, 4em)',
+			// 'fontFamily'     => 'Roboto,Oxygen-Sans,Ubuntu,sans-serif',
+			// 'fontStyle'      => 'italic',
+			// 'fontWeight'     => '800',
+			// 'lineHeight'     => '1.3',
+			// 'textDecoration' => 'underline',
+			// 'textTransform'  => 'uppercase',
+			// 'letterSpacing'  => '2',
+			// ),
+			// ),
+			// 'options'         => null,
+			// 'expected_output' => array(
+			// 'css' => 'font-family: Roboto,Oxygen-Sans,Ubuntu,sans-serif; font-style: italic; font-weight: 800; line-height: 1.3; text-decoration: underline; text-transform: uppercase; letter-spacing: 2;',
+			// ),
+			// ),
 
-			'style_block_with_selector'                    => array(
-				'block_styles'    => array(
-					'spacing' => array(
-						'padding' => array(
-							'top'    => '42px',
-							'left'   => '2%',
-							'bottom' => '44px',
-							'right'  => '5rem',
+				'style_block_with_selector'                => array(
+					'block_styles'    => array(
+						'spacing' => array(
+							'padding' => array(
+								'top'    => '42px',
+								'left'   => '2%',
+								'bottom' => '44px',
+								'right'  => '5rem',
+							),
 						),
 					),
+					'options'         => array( 'selector' => '.wp-selector > p' ),
+					'expected_output' => array(
+						'css' => '.wp-selector > p { padding-top: 42px; padding-left: 2%; padding-bottom: 44px; padding-right: 5rem; }',
+					),
 				),
-				'options'         => array( 'selector' => '.wp-selector > p' ),
-				'expected_output' => array(
-					'css' => '.wp-selector > p { padding-top: 42px; padding-left: 2%; padding-bottom: 44px; padding-right: 5rem; }',
-				),
-			),
 
 			'with_valid_css_value_preset_style_property'   => array(
 				'block_styles'    => array(
@@ -245,51 +245,51 @@ class WP_Style_Engine_Test extends WP_UnitTestCase {
 					'classnames' => 'has-text-color has-background',
 				),
 			),
-// @TODO failing because we removed the safecss_filter_attr() to test this branch.
-//			'invalid_classnames_options'                   => array(
-//				'block_styles'    => array(
-//					'typography' => array(
-//						'fontSize'   => array(
-//							'tomodachi' => 'friends',
-//						),
-//						'fontFamily' => array(
-//							'oishii' => 'tasty',
-//						),
-//					),
-//				),
-//				'options'         => array(),
-//				'expected_output' => array(),
-//			),
+			// @TODO failing because we removed the safecss_filter_attr() to test this branch.
+			// 'invalid_classnames_options'                   => array(
+			// 'block_styles'    => array(
+			// 'typography' => array(
+			// 'fontSize'   => array(
+			// 'tomodachi' => 'friends',
+			// ),
+			// 'fontFamily' => array(
+			// 'oishii' => 'tasty',
+			// ),
+			// ),
+			// ),
+			// 'options'         => array(),
+			// 'expected_output' => array(),
+			// ),
 
-			'inline_valid_box_model_style_with_sides'      => array(
-				'block_styles'    => array(
-					'border' => array(
-						'top'    => array(
-							'color' => '#fe1',
-							'width' => '1.5rem',
-							'style' => 'dashed',
-						),
-						'right'  => array(
-							'color' => '#fe2',
-							'width' => '1.4rem',
-							'style' => 'solid',
-						),
-						'bottom' => array(
-							'color' => '#fe3',
-							'width' => '1.3rem',
-						),
-						'left'   => array(
-							'color' => 'var:preset|color|swampy-yellow',
-							'width' => '0.5rem',
-							'style' => 'dotted',
+				'inline_valid_box_model_style_with_sides'  => array(
+					'block_styles'    => array(
+						'border' => array(
+							'top'    => array(
+								'color' => '#fe1',
+								'width' => '1.5rem',
+								'style' => 'dashed',
+							),
+							'right'  => array(
+								'color' => '#fe2',
+								'width' => '1.4rem',
+								'style' => 'solid',
+							),
+							'bottom' => array(
+								'color' => '#fe3',
+								'width' => '1.3rem',
+							),
+							'left'   => array(
+								'color' => 'var:preset|color|swampy-yellow',
+								'width' => '0.5rem',
+								'style' => 'dotted',
+							),
 						),
 					),
+					'options'         => array(),
+					'expected_output' => array(
+						'css' => 'border-top-color: #fe1; border-top-width: 1.5rem; border-top-style: dashed; border-right-color: #fe2; border-right-width: 1.4rem; border-right-style: solid; border-bottom-color: #fe3; border-bottom-width: 1.3rem; border-left-color: var(--wp--preset--color--swampy-yellow); border-left-width: 0.5rem; border-left-style: dotted;',
+					),
 				),
-				'options'         => array(),
-				'expected_output' => array(
-					'css' => 'border-top-color: #fe1; border-top-width: 1.5rem; border-top-style: dashed; border-right-color: #fe2; border-right-width: 1.4rem; border-right-style: solid; border-bottom-color: #fe3; border-bottom-width: 1.3rem; border-left-color: var(--wp--preset--color--swampy-yellow); border-left-width: 0.5rem; border-left-style: dotted;',
-				),
-			),
 
 			'inline_invalid_box_model_style_with_sides'    => array(
 				'block_styles'    => array(
@@ -329,12 +329,10 @@ class WP_Style_Engine_Test extends WP_UnitTestCase {
 								'text'       => '#fff',
 								'background' => '#000',
 							),
-							'states' => array(
-								'hover' => array(
-									'color' => array(
-										'text'       => '#000',
-										'background' => '#fff',
-									),
+							':hover' => array(
+								'color' => array(
+									'text'       => '#000',
+									'background' => '#fff',
 								),
 							),
 						),
@@ -349,37 +347,33 @@ class WP_Style_Engine_Test extends WP_UnitTestCase {
 			'elements_and_element_states_with_selector'    => array(
 				'block_styles'    => array(
 					'elements' => array(
-						'link' => array(
+						'link'   => array(
 							'color'  => array(
 								'text'       => '#fff',
 								'background' => '#000',
 							),
-							'states' => array(
-								'hover' => array(
-									'color' => array(
-										'text'       => '#000',
-										'background' => '#fff',
-									),
+							':hover' => array(
+								'color' => array(
+									'text'       => '#000',
+									'background' => '#fff',
 								),
-								'focus' => array(
-									'color' => array(
-										'text'       => '#000',
-										'background' => '#fff',
-									),
+							),
+							':focus' => array(
+								'color' => array(
+									'text'       => '#000',
+									'background' => '#fff',
 								),
 							),
 						),
 						'button' => array(
-							'color'  => array(
+							'color'     => array(
 								'text'       => '#fff',
 								'background' => '#000',
 							),
-							'states' => array(
-								'disabled' => array(
-									'color' => array(
-										'text'       => '#999',
-										'background' => '#fff',
-									),
+							':disabled' => array(
+								'color' => array(
+									'text'       => '#999',
+									'background' => '#fff',
 								),
 							),
 						),
@@ -402,12 +396,10 @@ class WP_Style_Engine_Test extends WP_UnitTestCase {
 							'effects' => array(
 								'transition' => 'all 0.5s ease-out',
 							),
-							'states'  => array(
-								'hover' => array(
-									'color' => array(
-										'text'       => 'var:preset|color|pineapple',
-										'background' => 'var:preset|color|goldenrod',
-									),
+							':hover'  => array(
+								'color' => array(
+									'text'       => 'var:preset|color|pineapple',
+									'background' => 'var:preset|color|goldenrod',
 								),
 							),
 						),


### PR DESCRIPTION
## What?

Updates the Style Engine to add support for:
- `elements` styles - limited to `link` and `button`.
- individual element "states" - e.g., `a:hover`, `focus` and so on (limited to `link` only).

Initially only `link` elements are supported with the `:hover` pseudo selector. However the system is open to extension so in the future it will be easy to add support for more selectors.

Background context: https://github.com/WordPress/gutenberg/pull/41383#issuecomment-1149931908

Related to:
- https://github.com/WordPress/gutenberg/pull/40987


```php

wp_style_engine_generate(
    array(
        'elements' => array(
            'link' => array(
                'color'  => array(
                    'text'       => '#fff',
                    'background' => '#000',
                ),				
                ':hover' => array(
                    'color' => array(
                        'text'       => '#000',
                        'background' => '#fff',
                    ),
                ),				
            ),
        ),
    )
, array( 'selector' => '.la-sinistra' ) );


/*

Returns: 

array(
    'css' => '.la-sinistra a { color: #fff; background-color: #000; } .la-sinistra a:hover { color: #000; background-color: #fff; }',
)

*/
```


## Why?

Theme developers and user are requesting the ability to control interactivity states. By adding support to the Style Engine we prepare the ground for the code that handles both editor and front end styles to output the correct CSS based on the `theme.json`.

In the future this will also open the door to a UI for configuring interactivity states. 

## How?

The style engine will now iterate over `elements` key of the block styles and generate the appropriate CSS based on the rules found within those definitions.

In addition, any pseudo selectors found within `elements` will be generated for the given element, having first been checked against an "allowed list" (to avoid things like `h1:hover` which is not a best practice and should be avoided).

## Testing Instructions

Follow the test instructions over at https://github.com/WordPress/gutenberg/pull/40987. 

There should be no change in the way we output link styles in `elements.php`

In relation to the new "states", e.g., `:hover`, currently this is only backend support and adding rules to `theme.json` will have no effect. This PR updates the style engine so check the unit tests make sense and cover the key scenarios.

```bash
npm run test-unit-php /var/www/html/wp-content/plugins/gutenberg/packages/style-engine/phpunit/class-wp-style-engine-test.php
```