### PR TITLE
Lodash: Refactor away from `_.isUndefined()`

### DIFF
--- a/packages/block-library/src/latest-posts/edit.js
+++ b/packages/block-library/src/latest-posts/edit.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { get, includes, invoke, isUndefined, pickBy } from 'lodash';
+import { get, includes, invoke, pickBy } from 'lodash';
 import classnames from 'classnames';
 
 /**
@@ -113,7 +113,7 @@ export default function LatestPostsEdit( { attributes, setAttributes } ) {
 					per_page: postsToShow,
 					_embed: 'wp:featuredmedia',
 				},
-				( value ) => ! isUndefined( value )
+				( value ) => typeof value !== 'undefined'
 			);
 
 			return {


### PR DESCRIPTION
## What?
Lodash's `isUndefined` is used only once in the entire codebase. This PR aims to remove that usage.

## Why?
Lodash is known to unnecessarily inflate the bundle size of packages, and in most cases, it can be replaced with native language functionality. See these for more information and rationale:

* https://github.com/WordPress/gutenberg/issues/16938#issuecomment-602837246
* https://github.com/WordPress/gutenberg/issues/17025
* https://github.com/WordPress/gutenberg/issues/39495 

## How?
Removing `isUndefined` is straightforward as it's quickly replaced by a simple vanilla JS check.

## Testing Instructions
* Open a post to edit, and insert the Latest Posts block in it.
* Play with the settings of the block (namely, Categories and Author)
* Verify the posts in the dynamic block preview still match the selected query.