### PR TITLE
Lodash: Refactor away from `_.stubTrue` and `_.stubFalse`

### DIFF
--- a/packages/blocks/src/api/parser/apply-block-deprecated-versions.js
+++ b/packages/blocks/src/api/parser/apply-block-deprecated-versions.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { omit, stubFalse, castArray } from 'lodash';
+import { omit, castArray } from 'lodash';
 
 /**
  * Internal dependencies
@@ -10,6 +10,15 @@ import { DEPRECATED_ENTRY_KEYS } from '../constants';
 import { validateBlock } from '../validation';
 import { getBlockAttributes } from './get-block-attributes';
 import { applyBuiltInValidationFixes } from './apply-built-in-validation-fixes';
+
+/**
+ * Function that takes no arguments and always returns false.
+ *
+ * @return {boolean} Always returns false.
+ */
+function stubFalse() {
+	return false;
+}
 
 /**
  * Given a block object, returns a new copy of the block with any applicable

--- a/packages/blocks/src/api/validation/index.js
+++ b/packages/blocks/src/api/validation/index.js
@@ -2,7 +2,7 @@
  * External dependencies
  */
 import { Tokenizer } from 'simple-html-tokenizer';
-import { identity, xor, fromPairs, isEqual, includes, stubTrue } from 'lodash';
+import { identity, xor, fromPairs, isEqual, includes } from 'lodash';
 
 /**
  * WordPress dependencies
@@ -418,7 +418,7 @@ export const isEqualAttributesOfName = {
 	// For each boolean attribute, mere presence of attribute in both is enough
 	// to assume equivalence.
 	...fromPairs(
-		BOOLEAN_ATTRIBUTES.map( ( attribute ) => [ attribute, stubTrue ] )
+		BOOLEAN_ATTRIBUTES.map( ( attribute ) => [ attribute, () => true ] )
 	),
 };
 


### PR DESCRIPTION
## What?
Lodash's `stubTrue` and `stubFalse` are used only once each in the entire codebase. This PR aims to remove that usage.

## Why?
Lodash is known to unnecessarily inflate the bundle size of packages, and in most cases, it can be replaced with native language functionality. See these for more information and rationale:

* https://github.com/WordPress/gutenberg/issues/16938#issuecomment-602837246
* https://github.com/WordPress/gutenberg/issues/17025
* https://github.com/WordPress/gutenberg/issues/39495 

## How?
Removing both is straightforward as it's quickly replaced by a simple function that returns always either `true` or `false`.

## Testing Instructions
Verify related unit tests still pass `npm run test-unit packages/blocks/src/api`