### PR TITLE
Lodash: Refactor away from `_.differenceWith()` in the inserter

### DIFF
--- a/packages/block-editor/src/components/inserter/search-items.js
+++ b/packages/block-editor/src/components/inserter/search-items.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { deburr, differenceWith, find, words } from 'lodash';
+import { deburr, find, words } from 'lodash';
 
 // Default search helpers.
 const defaultGetName = ( item ) => item.name || '';
@@ -47,11 +47,11 @@ export const getNormalizedSearchTerms = ( input = '' ) => {
 };
 
 const removeMatchingTerms = ( unmatchedTerms, unprocessedTerms ) => {
-	return differenceWith(
-		unmatchedTerms,
-		getNormalizedSearchTerms( unprocessedTerms ),
-		( unmatchedTerm, unprocessedTerm ) =>
-			unprocessedTerm.includes( unmatchedTerm )
+	return unmatchedTerms.filter(
+		( term ) =>
+			! getNormalizedSearchTerms(
+				unprocessedTerms
+			).some( ( unprocessedTerm ) => unprocessedTerm.includes( term ) )
 	);
 };
 


### PR DESCRIPTION
## What?
Lodash's `differenceWith` is used only once in the entire codebase. This PR aims to remove that usage.

## Why?
Lodash is known to unnecessarily inflate the bundle size of packages, and in most cases, it can be replaced with native language functionality. See these for more information and rationale:

* https://github.com/WordPress/gutenberg/issues/16938#issuecomment-602837246
* https://github.com/WordPress/gutenberg/issues/17025
* https://github.com/WordPress/gutenberg/issues/39495 

## How?
I suggest replacing `differenceWith` with a straightforward combination of `Array.prototype.filter()`, `Array.prototype.some()` and `Array.prototype.includes()`.

## Testing Instructions
* Verify inserter works well with multiple keywords (see the testing instructions of #19122).
* Verify unit tests still pass: `yarn run test-unit packages/block-editor/src/components/inserter`