### PR TITLE
Comment Author and Date blocks: aligned editor markup with the frontend

### DIFF
--- a/packages/block-library/src/comment-author-name/edit.js
+++ b/packages/block-library/src/comment-author-name/edit.js
@@ -97,7 +97,7 @@ export default function Edit( {
 				{ inspectorControls }
 				{ blockControls }
 				<div { ...blockProps }>
-					<p>{ _x( 'Comment Author', 'block title' ) }</p>
+					{ _x( 'Comment Author', 'block title' ) }
 				</div>
 			</>
 		);
@@ -111,7 +111,7 @@ export default function Edit( {
 			{ displayName }
 		</a>
 	) : (
-		<p>{ displayName }</p>
+		{ displayName }
 	);
 
 	return (

--- a/packages/block-library/src/comment-date/edit.js
+++ b/packages/block-library/src/comment-date/edit.js
@@ -64,7 +64,7 @@ export default function Edit( {
 			<>
 				{ inspectorControls }
 				<div { ...blockProps }>
-					<p>{ _x( 'Comment Date', 'block title' ) }</p>
+					<time>{ _x( 'Comment Date', 'block title' ) }</time>
 				</div>
 			</>
 		);


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->
Fixes https://github.com/WordPress/gutenberg/issues/41621 for the Comment Author block and the Comment date block

Co-created with @c4rl0sbr4v0

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
The markup on the frontend and the editor are not the same and that causes discrepancies of styling (in this case because of the margin the editor adds to p tags).

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
I changed the markup in the editor to be like what's on the frontend. Maybe we should make them also look like links in the editor when no comment ID is present? so that the link styles are also visible on the editor, but I'd prefer that we discuss that since it seemed a bit more involved than this change.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->

I tested with Blockbase theme.

1. Add the comments block
2. Check the frontend and the editor, the comment date and author name have extra spacing coming from the paragraph that is only showing in the editor.

## Screenshots or screencast <!-- if applicable -->

Before:

Frontend | Editor
--- | ---
<img width="880" alt="Screenshot 2022-06-09 at 15 43 55" src="https://user-images.githubusercontent.com/3593343/172863693-ea66d878-a62d-4d81-9a2f-a3d1b18038ee.png"> | <img width="821" alt="Screenshot 2022-06-09 at 15 53 22" src="https://user-images.githubusercontent.com/3593343/172864073-8e0fc87f-d1ee-4a2a-adc0-51e3feaf8075.png">


After:

Frontend | Editor
--- | ---
<img width="880" alt="Screenshot 2022-06-09 at 15 43 55" src="https://user-images.githubusercontent.com/3593343/172863693-ea66d878-a62d-4d81-9a2f-a3d1b18038ee.png"> | <img width="823" alt="Screenshot 2022-06-09 at 15 51 17" src="https://user-images.githubusercontent.com/3593343/172863700-460307b5-df23-44e1-9cc3-90f1566b1e87.png">

