### PR TITLE
Lodash: Refactor `useArrowNav()` away from `_.reverse()` and `_.find()`

### DIFF
--- a/packages/block-editor/src/components/writing-flow/use-arrow-nav.js
+++ b/packages/block-editor/src/components/writing-flow/use-arrow-nav.js
@@ -1,9 +1,4 @@
 /**
- * External dependencies
- */
-import { find } from 'lodash';
-
-/**
  * WordPress dependencies
  */
 import {
@@ -130,7 +125,7 @@ export function getClosestTabbable(
 		return true;
 	}
 
-	return find( focusableNodes, isTabCandidate );
+	return focusableNodes.find( isTabCandidate );
 }
 
 export default function useArrowNav() {

--- a/packages/block-editor/src/components/writing-flow/use-arrow-nav.js
+++ b/packages/block-editor/src/components/writing-flow/use-arrow-nav.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { find, reverse } from 'lodash';
+import { find } from 'lodash';
 
 /**
  * WordPress dependencies
@@ -89,7 +89,7 @@ export function getClosestTabbable(
 	let focusableNodes = focus.focusable.find( containerElement );
 
 	if ( isReverse ) {
-		focusableNodes = reverse( focusableNodes );
+		focusableNodes.reverse();
 	}
 
 	// Consider as candidates those focusables after the current target. It's


### PR DESCRIPTION
## What?
Lodash's `_.reverse()` is used only once in the entire codebase. This PR aims to remove that usage. We also use the opportunity to refactor a straightforward `_.find()` to `Array.prototype.find()`.

## Why?
Lodash is known to unnecessarily inflate the bundle size of packages, and in most cases, it can be replaced with native language functionality. See these for more information and rationale:

* https://github.com/WordPress/gutenberg/issues/16938#issuecomment-602837246
* https://github.com/WordPress/gutenberg/issues/17025
* https://github.com/WordPress/gutenberg/issues/39495 

## How?
Since there's no special nullish handling, removing `reverse()` and `find()` is straightforwardly achieved by replacing them with the corresponding `Array` prototype native methods.

## Testing Instructions
* Smoke test the writing flow and verify that arrow navigation still works well. 
* Verify that multi-selection and partial block selection still work well.