### PR TITLE
Lodash: Refactor away from `_.sum()`

### DIFF
--- a/packages/e2e-tests/specs/performance/post-editor.test.js
+++ b/packages/e2e-tests/specs/performance/post-editor.test.js
@@ -3,7 +3,6 @@
  */
 import { basename, join } from 'path';
 import { writeFileSync } from 'fs';
-import { sum } from 'lodash';
 
 /**
  * WordPress dependencies
@@ -226,6 +225,10 @@ describe( 'Post Editor Performance', () => {
 	} );
 
 	it( 'Searching the inserter', async () => {
+		function sum( arr ) {
+			return arr.reduce( ( a, b ) => a + b, 0 );
+		}
+
 		// Measure time to search the inserter and get results.
 		await openGlobalBlockInserter();
 		for ( let j = 0; j < 10; j++ ) {


### PR DESCRIPTION
## What?
Lodash's `sum` is used only once in the entire codebase. This PR aims to remove that usage.

## Why?
Lodash is known to unnecessarily inflate the bundle size of packages, and in most cases, it can be replaced with native language functionality. See these for more information and rationale:

* https://github.com/WordPress/gutenberg/issues/16938#issuecomment-602837246
* https://github.com/WordPress/gutenberg/issues/17025
* https://github.com/WordPress/gutenberg/issues/39495 

## How?
Removing `sum` is straightforward in favor of a simple `Array.prototype.reduce()` implementation.

## Testing Instructions
This only touches the post editor performance test suite, so verify performance tests still pass.