### PR TITLE
Lodash: Refactor away from `_.random()`

### DIFF
--- a/packages/e2e-tests/specs/editor/various/taxonomies.test.js
+++ b/packages/e2e-tests/specs/editor/various/taxonomies.test.js
@@ -1,9 +1,4 @@
 /**
- * External dependencies
- */
-import { random } from 'lodash';
-
-/**
  * WordPress dependencies
  */
 import {
@@ -18,6 +13,12 @@ import {
  */
 const TAG_TOKEN_SELECTOR =
 	'.components-form-token-field__token-text span:not(.components-visually-hidden)';
+
+function generateRandomNumber() {
+	// Using `Math.random()` directly is fine in this testing context.
+	// eslint-disable-next-line no-restricted-syntax
+	return Math.round( 1 + Math.random() * ( Number.MAX_SAFE_INTEGER - 1 ) );
+}
 
 describe( 'Taxonomies', () => {
 	const canCreatTermInTaxonomy = ( taxonomy ) => {
@@ -152,7 +153,7 @@ describe( 'Taxonomies', () => {
 		// Click the tag input field.
 		await tagInput.click();
 
-		const tagName = "tag'-" + random( 1, Number.MAX_SAFE_INTEGER );
+		const tagName = "tag'-" + generateRandomNumber();
 
 		// Type the category name in the field.
 		await tagInput.type( tagName );
@@ -211,7 +212,7 @@ describe( 'Taxonomies', () => {
 		// Click the tag input field.
 		await tagInput.click();
 
-		const tagName = 'tag-' + random( 1, Number.MAX_SAFE_INTEGER );
+		const tagName = 'tag-' + generateRandomNumber();
 
 		// Type the category name in the field.
 		await tagInput.type( tagName );


### PR DESCRIPTION
## What?
Lodash's `random` is used only once in the entire codebase. This PR aims to remove that usage.

## Why?
Lodash is known to unnecessarily inflate the bundle size of packages, and in most cases, it can be replaced with native language functionality. See these for more information and rationale:

* https://github.com/WordPress/gutenberg/issues/16938#issuecomment-602837246
* https://github.com/WordPress/gutenberg/issues/17025
* https://github.com/WordPress/gutenberg/issues/39495 

## How?
Removing `random` is straightforward in favor of a simple `Math`-based implementation.

## Testing Instructions
This only touches the taxonomies e2e test suite, so verify those still pass.