### PR TITLE
Lodash: Refactor away from `_.findIndex`

### DIFF
--- a/packages/components/src/mobile/bottom-sheet/cycle-picker-cell.native.js
+++ b/packages/components/src/mobile/bottom-sheet/cycle-picker-cell.native.js
@@ -1,8 +1,4 @@
 /**
- * External dependencies
- */
-import { findIndex } from 'lodash';
-/**
  * Internal dependencies
  */
 import Cell from './cell';
@@ -14,7 +10,9 @@ export default function BottomSheetCyclePickerCell( props ) {
 		return options[ ( selectedOptionIndex + 1 ) % options.length ].value;
 	};
 
-	const selectedOptionIndex = findIndex( options, [ 'value', value ] );
+	const selectedOptionIndex = options.findIndex(
+		( option ) => option.value === value
+	);
 	const optionsContainsValue =
 		options.length > 0 && selectedOptionIndex !== -1;
 


### PR DESCRIPTION
## What?
Lodash's `findIndex` is used only once in the entire codebase. This PR aims to remove that usage.

## Why?
Lodash is known to unnecessarily inflate the bundle size of packages, and in most cases, it can be replaced with native language functionality. See these for more information and rationale:

* https://github.com/WordPress/gutenberg/issues/16938#issuecomment-602837246
* https://github.com/WordPress/gutenberg/issues/17025
* https://github.com/WordPress/gutenberg/issues/39495 

## How?
Removing `_.findIndex()` is straightforward in favor of the native `Array.prototype.findIndex()` method.

## Testing Instructions
See #19232 for thorough testing instructions and ensure those still work.