### PR TITLE
Components: refactor `NavigationItem` to pass `exhaustive-deps`

### DIFF
--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -33,6 +33,7 @@
 -   `CustomGradientPicker`: Refactor away from Lodash ([#41901](https://github.com/WordPress/gutenberg/pull/41901/)).
 -   `SegmentedControl`: Refactor away from `_.values()` ([#41905](https://github.com/WordPress/gutenberg/pull/41905/)).
 -   `DimensionControl`: Refactor docs away from `_.partialRight()` ([#41909](https://github.com/WordPress/gutenberg/pull/41909/)).
+-   `NavigationItem` updated to ignore `react/exhuastive-deps` eslint rule ([#41639](https://github.com/WordPress/gutenberg/pull/41639)).
 
 ## 19.13.0 (2022-06-15)
 

--- a/packages/components/src/navigation/item/use-navigation-tree-item.js
+++ b/packages/components/src/navigation/item/use-navigation-tree-item.js
@@ -34,5 +34,14 @@ export const useNavigationTreeItem = ( itemId, props ) => {
 		return () => {
 			removeItem( itemId );
 		};
-	}, [ activeMenu, search ] );
+	}, [
+		activeMenu,
+		search,
+		addItem,
+		itemId,
+		props,
+		group,
+		menu,
+		removeItem,
+	] );
 };

--- a/packages/components/src/navigation/item/use-navigation-tree-item.js
+++ b/packages/components/src/navigation/item/use-navigation-tree-item.js
@@ -34,5 +34,14 @@ export const useNavigationTreeItem = ( itemId, props ) => {
 		return () => {
 			removeItem( itemId );
 		};
-	}, [ activeMenu, search, addItem, removeItem ] );
+	}, [
+		activeMenu,
+		search,
+		addItem,
+		removeItem,
+		props,
+		group,
+		itemId,
+		menu,
+	] );
 };

--- a/packages/components/src/navigation/item/use-navigation-tree-item.js
+++ b/packages/components/src/navigation/item/use-navigation-tree-item.js
@@ -34,5 +34,5 @@ export const useNavigationTreeItem = ( itemId, props ) => {
 		return () => {
 			removeItem( itemId );
 		};
-	}, [ activeMenu, search, addItem ] );
+	}, [ activeMenu, search, addItem, removeItem ] );
 };

--- a/packages/components/src/navigation/item/use-navigation-tree-item.js
+++ b/packages/components/src/navigation/item/use-navigation-tree-item.js
@@ -34,14 +34,5 @@ export const useNavigationTreeItem = ( itemId, props ) => {
 		return () => {
 			removeItem( itemId );
 		};
-	}, [
-		activeMenu,
-		search,
-		addItem,
-		itemId,
-		props,
-		group,
-		menu,
-		removeItem,
-	] );
+	}, [ activeMenu, search, addItem ] );
 };

--- a/packages/components/src/navigation/item/use-navigation-tree-item.js
+++ b/packages/components/src/navigation/item/use-navigation-tree-item.js
@@ -34,14 +34,7 @@ export const useNavigationTreeItem = ( itemId, props ) => {
 		return () => {
 			removeItem( itemId );
 		};
-	}, [
-		activeMenu,
-		search,
-		addItem,
-		removeItem,
-		props,
-		group,
-		itemId,
-		menu,
-	] );
+		// Ignore exhaustive-deps rule for now. See https://github.com/WordPress/gutenberg/pull/41639
+		// eslint-disable-next-line react-hooks/exhaustive-deps
+	}, [ activeMenu, search ] );
 };

--- a/packages/components/src/navigation/use-navigation-tree-nodes.js
+++ b/packages/components/src/navigation/use-navigation-tree-nodes.js
@@ -16,12 +16,12 @@ export const useNavigationTreeNodes = () => {
 		} ) );
 	}, [] );
 
-	const removeNode = ( key ) => {
+	const removeNode = useCallback( ( key ) => {
 		return setNodes( ( original ) => {
 			const { [ key ]: removedNode, ...remainingNodes } = original;
 			return remainingNodes;
 		} );
-	};
+	}, [] );
 
 	return { nodes, getNode, addNode, removeNode };
 };

--- a/packages/components/src/navigation/use-navigation-tree-nodes.js
+++ b/packages/components/src/navigation/use-navigation-tree-nodes.js
@@ -1,7 +1,7 @@
 /**
  * WordPress dependencies
  */
-import { useState } from '@wordpress/element';
+import { useState, useCallback } from '@wordpress/element';
 
 export const useNavigationTreeNodes = () => {
 	const [ nodes, setNodes ] = useState( {} );
@@ -14,7 +14,7 @@ export const useNavigationTreeNodes = () => {
 			...original,
 			[ key ]: newNode,
 		} ) );
-	};
+	}, [] );
 
 	const removeNode = ( key ) => {
 		return setNodes( ( original ) => {

--- a/packages/components/src/navigation/use-navigation-tree-nodes.js
+++ b/packages/components/src/navigation/use-navigation-tree-nodes.js
@@ -1,7 +1,7 @@
 /**
  * WordPress dependencies
  */
-import { useState, useCallback } from '@wordpress/element';
+import { useState } from '@wordpress/element';
 
 export const useNavigationTreeNodes = () => {
 	const [ nodes, setNodes ] = useState( {} );
@@ -14,14 +14,14 @@ export const useNavigationTreeNodes = () => {
 			...original,
 			[ key ]: newNode,
 		} ) );
-	}, [] );
+	};
 
-	const removeNode = useCallback( ( key ) => {
+	const removeNode = ( key ) => {
 		return setNodes( ( original ) => {
 			const { [ key ]: removedNode, ...remainingNodes } = original;
 			return remainingNodes;
 		} );
-	}, [] );
+	};
 
 	return { nodes, getNode, addNode, removeNode };
 };


### PR DESCRIPTION
> **Note** there will likely be interaction between this PR and [#41612](https://github.com/WordPress/gutenberg/pull/41612). I don't think it matters which merges first, but we should retest the second one before proceeding.

## What?
Updates the `NavigationItem` component **ignore** the `exhaustive-deps` eslint rule for now.

`Navigation` looks like it might need a deeper dive refactor to easily satisfy `exhuastive-deps`, and we may actually prefer using `Navigator` instead. For now, we'll disable warnings for this component, and can revisit the eslint rule if/when this component gets more attention in the future.

## Why?
Part of the effort in https://github.com/WordPress/gutenberg/pull/41166 to apply `exhuastive-deps` to the Components package

## How?
~~The `useEffect` in `useNavigationTreeItem.js` was missing most of its dependencies. Most (`props`, `group`, `itemId`, and `menu`) were addable without introducing unexpected behavior.~~

~~`addItem` and `removeItem` however were being redeclared on each render before being read from context. Wrapping each in `useCallback` allows for more stable references, preventing additional re-renders.~~

## Testing Instructions
1. From your local Gutenberg directory, run `npx eslint --rule 'react-hooks/exhaustive-deps: warn' packages/components/src/navigation/item`
2. Confirm that the linter returns no errors
3. Confirm `navigation` unit tests still pass
4. Run Storybook locally, confirm the `Navigation` component stories and/or docs still work as expected