### PR TITLE
ColorPicker: Remove horizontal scrollbar when using HSL or RGB color input types

### DIFF
--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Bug Fix
+
+-   `ColorPicker`: Remove horizontal scrollbar when using HSL or RGB color input types. ([#41646](https://github.com/WordPress/gutenberg/pull/41646))
+
 ### Internal
 
 -   `InputControl`: Add tests and update to use `@testing-library/user-event` ([#41421](https://github.com/WordPress/gutenberg/pull/41421)).

--- a/packages/components/src/color-picker/component.tsx
+++ b/packages/components/src/color-picker/component.tsx
@@ -20,12 +20,13 @@ import {
 	contextConnect,
 	WordPressComponentProps,
 } from '../ui/context';
-import { HStack } from '../h-stack';
 import { Spacer } from '../spacer';
 import {
 	ColorfulWrapper,
 	SelectControl,
 	AuxiliaryColorArtefactWrapper,
+	AuxiliaryColorArtefactHStackHeader,
+	ColorInputWrapper,
 } from './styles';
 import { ColorCopyButton } from './color-copy-button';
 import { ColorInput } from './color-input';
@@ -95,7 +96,7 @@ const ColorPicker = (
 				enableAlpha={ enableAlpha }
 			/>
 			<AuxiliaryColorArtefactWrapper>
-				<HStack justify="space-between">
+				<AuxiliaryColorArtefactHStackHeader justify="space-between">
 					<SelectControl
 						options={ options }
 						value={ colorType }
@@ -109,14 +110,16 @@ const ColorPicker = (
 						color={ safeColordColor }
 						colorType={ copyFormat || colorType }
 					/>
-				</HStack>
+				</AuxiliaryColorArtefactHStackHeader>
 				<Spacer margin={ 4 } />
-				<ColorInput
-					colorType={ colorType }
-					color={ safeColordColor }
-					onChange={ handleChange }
-					enableAlpha={ enableAlpha }
-				/>
+				<ColorInputWrapper>
+					<ColorInput
+						colorType={ colorType }
+						color={ safeColordColor }
+						onChange={ handleChange }
+						enableAlpha={ enableAlpha }
+					/>
+				</ColorInputWrapper>
 			</AuxiliaryColorArtefactWrapper>
 		</ColorfulWrapper>
 	);

--- a/packages/components/src/color-picker/component.tsx
+++ b/packages/components/src/color-picker/component.tsx
@@ -20,7 +20,6 @@ import {
 	contextConnect,
 	WordPressComponentProps,
 } from '../ui/context';
-import { Spacer } from '../spacer';
 import {
 	ColorfulWrapper,
 	SelectControl,
@@ -111,8 +110,7 @@ const ColorPicker = (
 						colorType={ copyFormat || colorType }
 					/>
 				</AuxiliaryColorArtefactHStackHeader>
-				<Spacer margin={ 4 } />
-				<ColorInputWrapper>
+				<ColorInputWrapper direction="column" gap={ 2 }>
 					<ColorInput
 						colorType={ colorType }
 						color={ safeColordColor }

--- a/packages/components/src/color-picker/hex-input.tsx
+++ b/packages/components/src/color-picker/hex-input.tsx
@@ -11,6 +11,7 @@ import { __ } from '@wordpress/i18n';
 /**
  * Internal dependencies
  */
+import { HStack } from '../h-stack';
 import { Text } from '../text';
 import { Spacer } from '../spacer';
 import { space } from '../ui/utils/space';
@@ -49,23 +50,25 @@ export const HexInput = ( { color, onChange, enableAlpha }: HexInputProps ) => {
 	};
 
 	return (
-		<ColorHexInputControl
-			prefix={
-				<Spacer
-					as={ Text }
-					marginLeft={ space( 3.5 ) }
-					color={ COLORS.ui.theme }
-					lineHeight={ 1 }
-				>
-					#
-				</Spacer>
-			}
-			value={ color.toHex().slice( 1 ).toUpperCase() }
-			onChange={ handleChange }
-			maxLength={ enableAlpha ? 9 : 7 }
-			label={ __( 'Hex color' ) }
-			hideLabelFromVision
-			__unstableStateReducer={ stateReducer }
-		/>
+		<Spacer as={ HStack } spacing={ 4 }>
+			<ColorHexInputControl
+				prefix={
+					<Spacer
+						as={ Text }
+						marginLeft={ space( 3.5 ) }
+						color={ COLORS.ui.theme }
+						lineHeight={ 1 }
+					>
+						#
+					</Spacer>
+				}
+				value={ color.toHex().slice( 1 ).toUpperCase() }
+				onChange={ handleChange }
+				maxLength={ enableAlpha ? 9 : 7 }
+				label={ __( 'Hex color' ) }
+				hideLabelFromVision
+				__unstableStateReducer={ stateReducer }
+			/>
+		</Spacer>
 	);
 };

--- a/packages/components/src/color-picker/hex-input.tsx
+++ b/packages/components/src/color-picker/hex-input.tsx
@@ -11,7 +11,6 @@ import { __ } from '@wordpress/i18n';
 /**
  * Internal dependencies
  */
-import { HStack } from '../h-stack';
 import { Text } from '../text';
 import { Spacer } from '../spacer';
 import { space } from '../ui/utils/space';
@@ -50,25 +49,23 @@ export const HexInput = ( { color, onChange, enableAlpha }: HexInputProps ) => {
 	};
 
 	return (
-		<Spacer as={ HStack } spacing={ 4 }>
-			<ColorHexInputControl
-				prefix={
-					<Spacer
-						as={ Text }
-						marginLeft={ space( 3.5 ) }
-						color={ COLORS.ui.theme }
-						lineHeight={ 1 }
-					>
-						#
-					</Spacer>
-				}
-				value={ color.toHex().slice( 1 ).toUpperCase() }
-				onChange={ handleChange }
-				maxLength={ enableAlpha ? 9 : 7 }
-				label={ __( 'Hex color' ) }
-				hideLabelFromVision
-				__unstableStateReducer={ stateReducer }
-			/>
-		</Spacer>
+		<ColorHexInputControl
+			prefix={
+				<Spacer
+					as={ Text }
+					marginLeft={ space( 3.5 ) }
+					color={ COLORS.ui.theme }
+					lineHeight={ 1 }
+				>
+					#
+				</Spacer>
+			}
+			value={ color.toHex().slice( 1 ).toUpperCase() }
+			onChange={ handleChange }
+			maxLength={ enableAlpha ? 9 : 7 }
+			label={ __( 'Hex color' ) }
+			hideLabelFromVision
+			__unstableStateReducer={ stateReducer }
+		/>
 	);
 };

--- a/packages/components/src/color-picker/input-with-slider.tsx
+++ b/packages/components/src/color-picker/input-with-slider.tsx
@@ -26,7 +26,7 @@ export const InputWithSlider = ( {
 	value,
 }: InputWithSliderProps ) => {
 	return (
-		<Spacer as={ HStack } spacing={ 4 }>
+		<HStack spacing={ 4 }>
 			<NumberControlWrapper
 				min={ min }
 				max={ max }
@@ -55,6 +55,6 @@ export const InputWithSlider = ( {
 				onChange={ onChange }
 				withInputField={ false }
 			/>
-		</Spacer>
+		</HStack>
 	);
 };

--- a/packages/components/src/color-picker/styles.ts
+++ b/packages/components/src/color-picker/styles.ts
@@ -60,7 +60,10 @@ const interactiveHueStyles = `
 }`;
 
 export const AuxiliaryColorArtefactWrapper = styled.div`
-	padding: ${ space( 2 ) } 0 };
+	padding-top: ${ space( 2 ) };
+	padding-right: 0;
+	padding-left: 0;
+	padding-bottom: ${ space( 3 ) };
 `;
 
 export const AuxiliaryColorArtefactHStackHeader = styled( HStack )`

--- a/packages/components/src/color-picker/styles.ts
+++ b/packages/components/src/color-picker/styles.ts
@@ -12,6 +12,7 @@ import InnerRangeControl from '../range-control';
 import { StyledField } from '../base-control/styles/base-control-styles';
 import { space } from '../ui/utils/space';
 import Button from '../button';
+import { HStack } from '../h-stack';
 import {
 	BackdropUI,
 	Container as InputControlContainer,
@@ -36,6 +37,7 @@ export const SelectControl = styled( InnerSelectControl )`
 
 export const RangeControl = styled( InnerRangeControl )`
 	flex: 1;
+	margin-right: ${ space( 2 ) };
 
 	${ StyledField } {
 		margin-bottom: 0;
@@ -58,7 +60,17 @@ const interactiveHueStyles = `
 }`;
 
 export const AuxiliaryColorArtefactWrapper = styled.div`
-	padding: ${ space( 2 ) } ${ space( 4 ) };
+	padding: ${ space( 2 ) } 0 };
+`;
+
+export const AuxiliaryColorArtefactHStackHeader = styled( HStack )`
+	padding-left: ${ space( 4 ) };
+	padding-right: ${ space( 4 ) };
+`;
+
+export const ColorInputWrapper = styled.div`
+	padding-left: ${ space( 4 ) };
+	padding-right: ${ space( 3 ) };
 `;
 
 export const ColorfulWrapper = styled.div`

--- a/packages/components/src/color-picker/styles.ts
+++ b/packages/components/src/color-picker/styles.ts
@@ -12,6 +12,7 @@ import InnerRangeControl from '../range-control';
 import { StyledField } from '../base-control/styles/base-control-styles';
 import { space } from '../ui/utils/space';
 import Button from '../button';
+import { Flex } from '../flex';
 import { HStack } from '../h-stack';
 import {
 	BackdropUI,
@@ -63,7 +64,7 @@ export const AuxiliaryColorArtefactWrapper = styled.div`
 	padding-top: ${ space( 2 ) };
 	padding-right: 0;
 	padding-left: 0;
-	padding-bottom: ${ space( 3 ) };
+	padding-bottom: 0;
 `;
 
 export const AuxiliaryColorArtefactHStackHeader = styled( HStack )`
@@ -71,9 +72,11 @@ export const AuxiliaryColorArtefactHStackHeader = styled( HStack )`
 	padding-right: ${ space( 4 ) };
 `;
 
-export const ColorInputWrapper = styled.div`
+export const ColorInputWrapper = styled( Flex )`
+	padding-top: ${ space( 4 ) };
 	padding-left: ${ space( 4 ) };
 	padding-right: ${ space( 3 ) };
+	padding-bottom: ${ space( 5 ) };
 `;
 
 export const ColorfulWrapper = styled.div`
@@ -85,6 +88,7 @@ export const ColorfulWrapper = styled.div`
 		align-items: center;
 		width: 216px;
 		height: auto;
+		overflow: hidden;
 	}
 
 	.react-colorful__saturation {


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Raised in the review for https://github.com/WordPress/gutenberg/pull/41222#pullrequestreview-985829772:

In the ColorPicker component, ensure that the range controls in their 100% position don't cause the component to overflow and create a horizontal scrollbar when used in a popover.

Also, ensure that the bottom margin / padding of the input fields is consistent between each color input type.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

It appears that the `RangeControl` component's slider handle (intentionally) overflows the width of the control so that the handle is more visible — the drawback is that this can cause this particular Popover to overflow. To fix this, we can give the component a little more breathing room. It seemed safer to fix it here, than to update the `RangeControl` directly, where it could adversely affect other instances of that component.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

* Add a little more wrapping to the color input control components so that we can set different padding for the header area versus the input fields.
* Set a larger amount of padding and adjust the margin for the RangeControl sliders for the HSL and RGB inputs so that the 100% position doesn't overflow the container.
* Update the bottom padding to ensure that in its full height size, there's no vertical scrollbar, and that the bottom padding is consistent between Hex, RGB, and HSL inputs.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->

To more clearly see when there's a horizontal scrollbar, if you're running macOS, go to System Preferences > General > Show scroll bars, and set it to Always.

1. Before this PR, open up the post editor and add a paragraph.
2. Go to set a background color and set a custom color.
3. Switch between the different kinds of color inputs, and notice that the bottom spacing is inconsistent between Hex and the two other controls (RGB and HSL)
4. Notice that RGB and HSL have a horizontal scrollbar if at least one range control slider is set to 100% (an easy way to test this is to set to white in RGB)
5. After this PR, there should be consistent bottom padding between color input types, and there should be no horizontal scrollbar

(Note: in Storybook, the `ColorPicker` component is not rendered in a Popover, so it's best to test this component change in the editor)

## Screenshots or screencast <!-- if applicable -->

| RGB Before | RGB After |
| --- | --- |
| ![image](https://user-images.githubusercontent.com/14988353/172970707-b6244632-82f6-41c7-ab89-1a1903734be9.png) | ![image](https://user-images.githubusercontent.com/14988353/172974043-0ef6e470-9359-4562-9be2-274c0c400f9c.png) |
| Hex Before | Hex After |
| ![image](https://user-images.githubusercontent.com/14988353/172974188-d54182df-ad42-4730-8a1d-c8da90c52040.png) | ![image](https://user-images.githubusercontent.com/14988353/172974071-435fc221-1d71-44a2-b26f-8e5ba553abf9.png) |