### PR TITLE
Highlight today's date in DatePicker

### DIFF
--- a/packages/components/src/date-time/date/style.scss
+++ b/packages/components/src/date-time/date/style.scss
@@ -53,11 +53,20 @@
 		border: none;
 		font-size: $default-font-size;
 		border-radius: $radius-round;
+		background: $white;
+
+		&:hover {
+			color: var(--wp-admin-theme-color);
+		}
 
 		&:focus {
 			box-shadow: inset 0 0 0 var(--wp-admin-border-width-focus) var(--wp-admin-theme-color), inset 0 0 0 #{ $border-width-focus + $border-width } $white;
 			outline: 2px solid transparent; // Shown in Windows 10 high contrast mode.
 		}
+	}
+
+	.CalendarDay__today {
+		background: $gray-100;
 	}
 
 	.CalendarDay__selected {
@@ -66,6 +75,7 @@
 
 		&:hover {
 			background: var(--wp-admin-theme-color-darker-20);
+			color: $white;
 		}
 
 		&:focus {


### PR DESCRIPTION
## What?
Highlights which day is today in the date picker.

## Why?
I think this makes it easier to schedule posts. For example, it's difficult to schedule a post for "this Saturday" if you don't know what today is.

## How?
I made it so a light grey background appears on today's date.

I also made it so that, on hover, we alter the text colour instead of the background. I think this is consistent with other buttons that we have, but happy to do whatever here.

## Testing Instructions
1. Create or edit a post.
2. Open the post date picker.
3. Try to schedule a post for this Saturday.

## Screenshots or screencast 

<img width="279" alt="Screen Shot 2022-06-10 at 12 37 55" src="https://user-images.githubusercontent.com/612155/172979767-2a99f651-d2a7-45bb-b19e-4ba40d01c635.png">