### PR TITLE
Make date picker respect site's 'Week Starts On' setting

### DIFF
--- a/lib/compat/wordpress-6.1/date-settings.php
+++ b/lib/compat/wordpress-6.1/date-settings.php
@@ -1,0 +1,75 @@
+<?php
+
+/**
+ * Removes the call to wp.date.setSettings() added by Core and adds our own call
+ * to wp.date.setSettings().
+ *
+ * This lets us add a new l10n.dayOfWeek setting.
+ *
+ * To merge this into Core, simply update the wp.date.setSettings() call in
+ * wp_default_packages_inline_scripts.
+ */
+function gutenberg_update_date_settings( $scripts ) {
+	global $wp_locale;
+
+	$inline_scripts = $scripts->get_data( 'wp-date', 'after' );
+	if ( $inline_scripts ) {
+		foreach( $inline_scripts as $index => $inline_script ) {
+			if ( str_starts_with( $inline_script, 'wp.date.setSettings' ) ) {
+				unset( $scripts->registered['wp-date']->extra['after'][ $index ] );
+			}
+		}
+	}
+
+	// Calculate the timezone abbr (EDT, PST) if possible.
+	$timezone_string = get_option( 'timezone_string', 'UTC' );
+	$timezone_abbr   = '';
+
+	if ( ! empty( $timezone_string ) ) {
+		$timezone_date = new DateTime( 'now', new DateTimeZone( $timezone_string ) );
+		$timezone_abbr = $timezone_date->format( 'T' );
+	}
+
+	$scripts->add_inline_script(
+		'wp-date',
+		sprintf(
+			'wp.date.setSettings( %s );',
+			wp_json_encode(
+				array(
+					'l10n'     => array(
+						'locale'        => get_user_locale(),
+						'months'        => array_values( $wp_locale->month ),
+						'monthsShort'   => array_values( $wp_locale->month_abbrev ),
+						'weekdays'      => array_values( $wp_locale->weekday ),
+						'weekdaysShort' => array_values( $wp_locale->weekday_abbrev ),
+						'meridiem'      => (object) $wp_locale->meridiem,
+						'relative'      => array(
+							/* translators: %s: Duration. */
+							'future' => __( '%s from now', 'gutenberg' ),
+							/* translators: %s: Duration. */
+							'past'   => __( '%s ago', 'gutenberg' ),
+						),
+						'startOfWeek' => (int) get_option( 'start_of_week', 0 ),
+					),
+					'formats'  => array(
+						/* translators: Time format, see https://www.php.net/manual/datetime.format.php */
+						'time'                => get_option( 'time_format', __( 'g:i a', 'gutenberg' ) ),
+						/* translators: Date format, see https://www.php.net/manual/datetime.format.php */
+						'date'                => get_option( 'date_format', __( 'F j, Y', 'gutenberg' ) ),
+						/* translators: Date/Time format, see https://www.php.net/manual/datetime.format.php */
+						'datetime'            => __( 'F j, Y g:i a', 'gutenberg' ),
+						/* translators: Abbreviated date/time format, see https://www.php.net/manual/datetime.format.php */
+						'datetimeAbbreviated' => __( 'M j, Y g:i a', 'gutenberg' ),
+					),
+					'timezone' => array(
+						'offset' => get_option( 'gmt_offset', 0 ),
+						'string' => $timezone_string,
+						'abbr'   => $timezone_abbr,
+					),
+				)
+			)
+		),
+		'after'
+	);
+}
+add_action( 'wp_default_scripts', 'gutenberg_update_date_settings' );

--- a/lib/compat/wordpress-6.1/date-settings.php
+++ b/lib/compat/wordpress-6.1/date-settings.php
@@ -1,4 +1,9 @@
 <?php
+/**
+ * Updates to the settings given to @wordpress/date.
+ *
+ * @package gutenberg
+ */
 
 /**
  * Removes the call to wp.date.setSettings() added by Core and adds our own call
@@ -8,13 +13,15 @@
  *
  * To merge this into Core, simply update the wp.date.setSettings() call in
  * wp_default_packages_inline_scripts.
+ *
+ * @param WP_Scripts $scripts WP_Scripts object.
  */
 function gutenberg_update_date_settings( $scripts ) {
 	global $wp_locale;
 
 	$inline_scripts = $scripts->get_data( 'wp-date', 'after' );
 	if ( $inline_scripts ) {
-		foreach( $inline_scripts as $index => $inline_script ) {
+		foreach ( $inline_scripts as $index => $inline_script ) {
 			if ( str_starts_with( $inline_script, 'wp.date.setSettings' ) ) {
 				unset( $scripts->registered['wp-date']->extra['after'][ $index ] );
 			}
@@ -49,7 +56,7 @@ function gutenberg_update_date_settings( $scripts ) {
 							/* translators: %s: Duration. */
 							'past'   => __( '%s ago', 'gutenberg' ),
 						),
-						'startOfWeek' => (int) get_option( 'start_of_week', 0 ),
+						'startOfWeek'   => (int) get_option( 'start_of_week', 0 ),
 					),
 					'formats'  => array(
 						/* translators: Time format, see https://www.php.net/manual/datetime.format.php */

--- a/lib/load.php
+++ b/lib/load.php
@@ -130,6 +130,7 @@ require __DIR__ . '/compat/wordpress-6.1/class-wp-theme-json-6-1.php';
 require __DIR__ . '/compat/wordpress-6.1/block-template-utils.php';
 require __DIR__ . '/compat/wordpress-6.1/wp-theme-get-post-templates.php';
 require __DIR__ . '/compat/wordpress-6.1/script-loader.php';
+require __DIR__ . '/compat/wordpress-6.1/date-settings.php';
 
 // Experimental features.
 remove_action( 'plugins_loaded', '_wp_theme_json_webfonts_handler' ); // Turns off WP 6.0's stopgap handler for Webfonts API.

--- a/packages/block-editor/src/components/publish-date-time-picker/index.js
+++ b/packages/block-editor/src/components/publish-date-time-picker/index.js
@@ -4,6 +4,7 @@
 import { DateTimePicker } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 import { forwardRef } from '@wordpress/element';
+import { __experimentalGetSettings as getSettings } from '@wordpress/date';
 
 /**
  * Internal dependencies
@@ -27,6 +28,7 @@ function PublishDateTimePicker(
 				onClose={ onClose }
 			/>
 			<DateTimePicker
+				startOfWeek={ getSettings().l10n.startOfWeek }
 				__nextRemoveHelpButton
 				__nextRemoveResetButton
 				onChange={ onChange }

--- a/packages/components/src/date-time/README.md
+++ b/packages/components/src/date-time/README.md
@@ -77,6 +77,13 @@ List of events to show in the date picker. Each event will appear as a dot on th
 -   Type: `Array`
 -   Required: No
 
+### `startOfWeek`: `number`
+
+The day that the week should start on. 0 for Sunday, 1 for Monday, etc.
+
+- Required: No
+- Default: 0
+
 ### `__nextRemoveHelpButton`: `boolean`
 
 Start opting in to not displaying a Help button which will become the default in a future version.

--- a/packages/components/src/date-time/date-time/index.tsx
+++ b/packages/components/src/date-time/date-time/index.tsx
@@ -33,6 +33,7 @@ function UnforwardedDateTimePicker(
 		onMonthPreviewed = noop,
 		onChange,
 		events,
+		startOfWeek,
 		__nextRemoveHelpButton = false,
 		__nextRemoveResetButton = false,
 	}: DateTimePickerProps,
@@ -78,6 +79,7 @@ function UnforwardedDateTimePicker(
 						isInvalidDate={ isInvalidDate }
 						events={ events }
 						onMonthPreviewed={ onMonthPreviewed }
+						startOfWeek={ startOfWeek }
 					/>
 				</>
 			) }

--- a/packages/components/src/date-time/date/index.tsx
+++ b/packages/components/src/date-time/date/index.tsx
@@ -103,6 +103,7 @@ export function DatePicker( {
 	events,
 	isInvalidDate,
 	onMonthPreviewed,
+	startOfWeek = 0,
 }: DatePickerProps ) {
 	const nodeRef = useRef< HTMLDivElement >( null );
 
@@ -197,6 +198,7 @@ export function DatePicker( {
 				isOutsideRange={ ( date ) => {
 					return !! isInvalidDate && isInvalidDate( date.toDate() );
 				} }
+				firstDayOfWeek={ startOfWeek }
 				onPrevMonthClick={ onMonthPreviewedHandler }
 				onNextMonthClick={ onMonthPreviewedHandler }
 				renderDayContents={ ( day ) => (

--- a/packages/components/src/date-time/types.ts
+++ b/packages/components/src/date-time/types.ts
@@ -76,6 +76,13 @@ export type DatePickerProps = {
 	 * dot on the day of the event.
 	 */
 	events?: DatePickerEvent[];
+
+	/**
+	 * The day that the week should start on. 0 for Sunday, 1 for Monday, etc.
+	 *
+	 * @default 0
+	 */
+	startOfWeek?: 0 | 1 | 2 | 3 | 4 | 5 | 6;
 };
 
 export type DateTimePickerProps = Omit< DatePickerProps, 'onChange' > &

--- a/packages/date/src/index.js
+++ b/packages/date/src/index.js
@@ -41,6 +41,7 @@ import 'moment-timezone/moment-timezone-utils';
  * @property {MomentLocaleSpecification['weekdaysShort']} weekdaysShort Locale weekdays short.
  * @property {MeridiemConfig}                             meridiem      Meridiem config.
  * @property {MomentLocaleSpecification['relativeTime']}  relative      Relative time config.
+ * @property {0|1|2|3|4|5|6}                              startOfWeek   Day that the week starts on.
  */
 /* eslint-enable jsdoc/valid-types */
 
@@ -118,6 +119,7 @@ let settings = {
 			y: 'a year',
 			yy: '%d years',
 		},
+		startOfWeek: 0,
 	},
 	formats: {
 		time: 'g: i a',


### PR DESCRIPTION
## What?
Fixes https://github.com/WordPress/gutenberg/issues/41078.

Makes the calendar used in the post publish date picker respect the _Week Starts On_ setting that WordPress has.

## Why?
Different locales have different conventions around when the first day of the week is. Also some weirdos like me have a strong preference on the matter.

## How?
The library we use for the calendar, `react-dates`, already supports this setting, so I'm just passing the setting along from PHP to the component via `@wordpress/date` settings which is where we put all the other locale specific date settings.

## Testing Instructions
1. Create or edit a post.
2. Open the post date. Observe whether the week starts on e.g. Sunday.
3. Go to Settings → General and change the _Week Starts On_ setting.
2. Create or edit a post.
3. Open the post date. Observe that the calendar has changed.

## Screenshots or screencast 
https://user-images.githubusercontent.com/612155/172999235-93c19019-c05a-4d53-b2c4-effd6b72e41f.mp4
