### PR TITLE
ESLint: Restrict removed Lodash functions

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -82,6 +82,22 @@ module.exports = {
 						message: 'Please use `memize` instead.',
 					},
 					{
+						name: 'lodash',
+						importNames: [
+							'differenceWith',
+							'findIndex',
+							'isUndefined',
+							'negate',
+							'random',
+							'reverse',
+							'stubFalse',
+							'stubTrue',
+							'sum',
+						],
+						message:
+							'This Lodash method is not recommended. Please use native functionality instead.',
+					},
+					{
 						name: 'reakit',
 						message:
 							'Please use Reakit API through `@wordpress/components` instead.',

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -78,15 +78,11 @@ module.exports = {
 					},
 					{
 						name: 'lodash',
-						importNames: [ 'memoize' ],
-						message: 'Please use `memize` instead.',
-					},
-					{
-						name: 'lodash',
 						importNames: [
 							'differenceWith',
 							'findIndex',
 							'isUndefined',
+							'memoize',
 							'negate',
 							'random',
 							'reverse',
@@ -95,7 +91,7 @@ module.exports = {
 							'sum',
 						],
 						message:
-							'This Lodash method is not recommended. Please use native functionality instead.',
+							'This Lodash method is not recommended. Please use native functionality instead. If using `memoize`, please use `memize` instead.',
 					},
 					{
 						name: 'reakit',


### PR DESCRIPTION
## What?
This PR restricts importing of Lodash functions that we've already migrated from. See https://github.com/WordPress/gutenberg/pulls?q=is%3Apr+is%3Aclosed+author%3Atyxla+Lodash+updated%3A%3E2022-06-01+ for a list of the recent migration PRs.

## Why?
The short-term goal is to avoid reintroducing Lodash functions that we've moved away from. The long-term goal is to eventually get rid of the entirety of Lodash and restrict its imports completely.

## How?
We introduce an extension to the `no-restricted-imports` rule that prevents importing Lodash functions that have already been migrated.

## Testing Instructions
Try importing a restricted function like `reverse` from Lodash and verify you get an ESLint error.