### PR TITLE
Try moving block css from supports > __experimentalStyle to a top level style key in block.json

### DIFF
--- a/docs/reference-guides/core-blocks.md
+++ b/docs/reference-guides/core-blocks.md
@@ -50,7 +50,7 @@ Prompt visitors to take action with a button-style link. ([Source](https://githu
 
 -	**Name:** core/button
 -	**Category:** design
--	**Supports:** align, anchor, color (background, gradients, text), spacing (padding), typography (fontSize), ~~alignWide~~, ~~reusable~~
+-	**Supports:** align, anchor, blockStyles (border, color, spacing, typography), color (background, gradients, text), spacing (padding), typography (fontSize), ~~alignWide~~, ~~reusable~~
 -	**Attributes:** backgroundColor, gradient, linkTarget, placeholder, rel, text, textColor, title, url, width
 
 ## Buttons

--- a/lib/compat/wordpress-6.1/blocks.php
+++ b/lib/compat/wordpress-6.1/blocks.php
@@ -164,6 +164,7 @@ add_filter( 'block_type_metadata', 'gutenberg_block_type_metadata_multiple_view_
  * Allows multiple block styles.
  *
  * This is a duplicate of _wp_multiple_block_styles, except that it removes the line that sets the key to the first item in the array.
+ * We also check that $handle is a string.
  *
  * @since 5.9.0
  *

--- a/lib/compat/wordpress-6.1/blocks.php
+++ b/lib/compat/wordpress-6.1/blocks.php
@@ -158,3 +158,48 @@ function gutenberg_block_type_metadata_multiple_view_scripts( $metadata ) {
 	return $metadata;
 }
 add_filter( 'block_type_metadata', 'gutenberg_block_type_metadata_multiple_view_scripts' );
+
+
+/**
+ * Allows multiple block styles.
+ *
+ * This is a duplicate of _wp_multiple_block_styles, except that it removes the line that sets the key to the first item in the array.
+ *
+ * @since 5.9.0
+ *
+ * @param array $metadata Metadata for registering a block type.
+ * @return array Metadata for registering a block type.
+ */
+function _gutenberg_multiple_block_styles( $metadata ) {
+	foreach ( array( 'style', 'editorStyle' ) as $key ) {
+		if ( ! empty( $metadata[ $key ] ) && is_array( $metadata[ $key ] ) ) {
+			$default_style = array_shift( $metadata[ $key ] );
+			foreach ( $metadata[ $key ] as $handle ) {
+				$args = array( 'handle' => $handle );
+				if ( 0 === strpos( $handle, 'file:' ) && isset( $metadata['file'] ) ) {
+					$style_path      = remove_block_asset_path_prefix( $handle );
+					$theme_path_norm = wp_normalize_path( get_theme_file_path() );
+					$style_path_norm = wp_normalize_path( realpath( dirname( $metadata['file'] ) . '/' . $style_path ) );
+					$is_theme_block  = isset( $metadata['file'] ) && 0 === strpos( $metadata['file'], $theme_path_norm );
+
+					$style_uri = plugins_url( $style_path, $metadata['file'] );
+
+					if ( $is_theme_block ) {
+						$style_uri = get_theme_file_uri( str_replace( $theme_path_norm, '', $style_path_norm ) );
+					}
+
+					$args = array(
+						'handle' => sanitize_key( "{$metadata['name']}-{$style_path}" ),
+						'src'    => $style_uri,
+					);
+				}
+
+				wp_enqueue_block_style( $metadata['name'], $args );
+			}
+		}
+	}
+
+	return $metadata;
+}
+remove_filter( 'block_type_metadata', '_wp_multiple_block_styles' );
+add_filter( 'block_type_metadata', '_gutenberg_multiple_block_styles', 9 );

--- a/lib/compat/wordpress-6.1/blocks.php
+++ b/lib/compat/wordpress-6.1/blocks.php
@@ -176,7 +176,7 @@ function _gutenberg_multiple_block_styles( $metadata ) {
 			$default_style = array_shift( $metadata[ $key ] );
 			foreach ( $metadata[ $key ] as $handle ) {
 				$args = array( 'handle' => $handle );
-				if ( 0 === strpos( $handle, 'file:' ) && isset( $metadata['file'] ) ) {
+				if ( is_string( $handle ) && 0 === strpos( $handle, 'file:' ) && isset( $metadata['file'] ) ) {
 					$style_path      = remove_block_asset_path_prefix( $handle );
 					$theme_path_norm = wp_normalize_path( get_theme_file_path() );
 					$style_path_norm = wp_normalize_path( realpath( dirname( $metadata['file'] ) . '/' . $style_path ) );

--- a/lib/compat/wordpress-6.1/blocks.php
+++ b/lib/compat/wordpress-6.1/blocks.php
@@ -174,7 +174,7 @@ add_filter( 'block_type_metadata', 'gutenberg_block_type_metadata_multiple_view_
 function _gutenberg_multiple_block_styles( $metadata ) {
 	foreach ( array( 'style', 'editorStyle' ) as $key ) {
 		if ( ! empty( $metadata[ $key ] ) && is_array( $metadata[ $key ] ) ) {
-			$default_style = array_shift( $metadata[ $key ] );
+			//$default_style = array_shift( $metadata[ $key ] );
 			foreach ( $metadata[ $key ] as $handle ) {
 				$args = array( 'handle' => $handle );
 				if ( is_string( $handle ) && 0 === strpos( $handle, 'file:' ) && isset( $metadata['file'] ) ) {
@@ -203,4 +203,5 @@ function _gutenberg_multiple_block_styles( $metadata ) {
 	return $metadata;
 }
 remove_filter( 'block_type_metadata', '_wp_multiple_block_styles' );
+remove_filter( 'block_type_metadata', 'gutenberg_multiple_block_styles' );
 add_filter( 'block_type_metadata', '_gutenberg_multiple_block_styles', 9 );

--- a/lib/experimental/class-wp-theme-json-resolver-gutenberg.php
+++ b/lib/experimental/class-wp-theme-json-resolver-gutenberg.php
@@ -98,4 +98,37 @@ class WP_Theme_JSON_Resolver_Gutenberg extends WP_Theme_JSON_Resolver_6_0 {
 		return $with_theme_supports;
 	}
 
+	public static function get_block_data() {
+		$registry = WP_Block_Type_Registry::get_instance();
+		$blocks   = $registry->get_all_registered();
+		$config   = array( 'version' => 1 );
+		foreach( $blocks as $block_name => $block_type ) {
+			if ( isset( $block_type->supports['blockStyles'] ) ) {
+				$config['styles']['blocks'][ $block_name ] = $block_type->supports['blockStyles'];
+			}
+		}
+
+		// Core here means it's the lower level part of the styles chain.
+		// It can be a core or a third-party block.
+		return new WP_Theme_JSON( $config, 'core' );
+	}
+
+	public static function get_merged_data( $origin = 'custom' ) {
+		if ( is_array( $origin ) ) {
+			_deprecated_argument( __FUNCTION__, '5.9' );
+		}
+
+		$result = new WP_Theme_JSON_Gutenberg();
+		$result->merge( static::get_core_data() );
+		$result->merge( static::get_block_data() );
+		$result->merge( static::get_theme_data() );
+
+		if ( 'custom' === $origin ) {
+			$result->merge( static::get_user_data() );
+		}
+
+		return $result;
+	}
+
+
 }

--- a/lib/experimental/class-wp-theme-json-resolver-gutenberg.php
+++ b/lib/experimental/class-wp-theme-json-resolver-gutenberg.php
@@ -103,8 +103,8 @@ class WP_Theme_JSON_Resolver_Gutenberg extends WP_Theme_JSON_Resolver_6_0 {
 		$blocks   = $registry->get_all_registered();
 		$config   = array( 'version' => 1 );
 		foreach ( $blocks as $block_name => $block_type ) {
-			if ( isset( $block_type->supports['blockStyles'] ) ) {
-				$config['styles']['blocks'][ $block_name ] = static::removeJsonComments( $block_type->supports['blockStyles'] );
+			if ( is_array( $block_type->style ) ) {
+				$config['styles']['blocks'][ $block_name ] = static::removeJsonComments( $block_type->style );
 			}
 		}
 

--- a/lib/experimental/class-wp-theme-json-resolver-gutenberg.php
+++ b/lib/experimental/class-wp-theme-json-resolver-gutenberg.php
@@ -102,15 +102,26 @@ class WP_Theme_JSON_Resolver_Gutenberg extends WP_Theme_JSON_Resolver_6_0 {
 		$registry = WP_Block_Type_Registry::get_instance();
 		$blocks   = $registry->get_all_registered();
 		$config   = array( 'version' => 1 );
-		foreach( $blocks as $block_name => $block_type ) {
+		foreach ( $blocks as $block_name => $block_type ) {
 			if ( isset( $block_type->supports['blockStyles'] ) ) {
-				$config['styles']['blocks'][ $block_name ] = $block_type->supports['blockStyles'];
+				$config['styles']['blocks'][ $block_name ] = static::removeJsonComments( $block_type->supports['blockStyles'] );
 			}
 		}
 
 		// Core here means it's the lower level part of the styles chain.
 		// It can be a core or a third-party block.
 		return new WP_Theme_JSON( $config, 'core' );
+	}
+
+	private static function removeJsonComments( $array ) {
+		unset( $array['//'] );
+		foreach ( $array as $k => $v ) {
+			if ( is_array( $v ) ) {
+				$array[ $k ] = static::removeJsonComments( $v );
+			}
+		}
+
+		return $array;
 	}
 
 	public static function get_merged_data( $origin = 'custom' ) {
@@ -122,7 +133,6 @@ class WP_Theme_JSON_Resolver_Gutenberg extends WP_Theme_JSON_Resolver_6_0 {
 		$result->merge( static::get_core_data() );
 		$result->merge( static::get_block_data() );
 		$result->merge( static::get_theme_data() );
-
 		if ( 'custom' === $origin ) {
 			$result->merge( static::get_user_data() );
 		}

--- a/packages/block-library/src/button/block.json
+++ b/packages/block-library/src/button/block.json
@@ -89,35 +89,34 @@
 				"radius": true
 			}
 		},
-		"__experimentalSelector": ".wp-block-button__link",
-		"blockStyles": {
-			"border": {
-				"//": "100% causes an oval, but any explicit but really high value retains the pill shape.",
-				"radius": "9999px"
-			},
-			"color": {
-				"text": "#fff",
-				"background": "#32373c"
-			},
-			"typography": {
-				"fontSize": "1.125em",
-				"textDecoration": "none"
-			},
-			"spacing": {
-				"padding": {
-					"//": "The extra 2px are added to size solids the same as the outline versions.",
-					"top": "calc(0.667em + 2px)",
-					"right": "calc(1.333em + 2px)",
-					"bottom": "calc(0.667em + 2px)",
-					"left": "calc(1.333em + 2px)"
-				}
-			}
-		}
+		"__experimentalSelector": ".wp-block-button__link"
 	},
 	"styles": [
 		{ "name": "fill", "label": "Fill", "isDefault": true },
 		{ "name": "outline", "label": "Outline" }
 	],
 	"editorStyle": "wp-block-button-editor",
-	"style": "wp-block-button"
+	"style": [ "wp-block-button", {
+		"border": {
+			"//": "100% causes an oval, but any explicit but really high value retains the pill shape.",
+			"radius": "9999px"
+		},
+		"color": {
+			"text": "#fff",
+			"background": "#32373c"
+		},
+		"typography": {
+			"fontSize": "1.125em",
+			"textDecoration": "none"
+		},
+		"spacing": {
+			"padding": {
+				"//": "The extra 2px are added to size solids the same as the outline versions.",
+				"top": "calc(0.667em + 2px)",
+				"right": "calc(1.333em + 2px)",
+				"bottom": "calc(0.667em + 2px)",
+				"left": "calc(1.333em + 2px)"
+			}
+		}
+	} ]
 }

--- a/packages/block-library/src/button/block.json
+++ b/packages/block-library/src/button/block.json
@@ -92,6 +92,7 @@
 		"__experimentalSelector": ".wp-block-button__link",
 		"blockStyles": {
 			"border": {
+				"//": "100% causes an oval, but any explicit but really high value retains the pill shape.",
 				"radius": "9999px"
 			},
 			"color": {
@@ -104,6 +105,7 @@
 			},
 			"spacing": {
 				"padding": {
+					"//": "The extra 2px are added to size solids the same as the outline versions.",
 					"top": "calc(0.667em + 2px)",
 					"right": "calc(1.333em + 2px)",
 					"bottom": "calc(0.667em + 2px)",

--- a/packages/block-library/src/button/block.json
+++ b/packages/block-library/src/button/block.json
@@ -89,22 +89,27 @@
 				"radius": true
 			}
 		},
-		"__experimentalSelector": ".wp-block-button__link"
-	},
-	"blockStyles": {
-		"border": {
-			"radius": "9999px"
-		},
-		"color": {
-			"text": "#fff",
-			"background": "#32373c"
-		},
-		"typography": {
-			"fontSize": "1.125em",
-			"textDecoration": "none"
-		},
-		"spacing": {
-			"padding": "calc(0.667em + 2px) calc(1.333em + 2px)"
+		"__experimentalSelector": ".wp-block-button__link",
+		"blockStyles": {
+			"border": {
+				"radius": "9999px"
+			},
+			"color": {
+				"text": "#fff",
+				"background": "#32373c"
+			},
+			"typography": {
+				"fontSize": "1.125em",
+				"textDecoration": "none"
+			},
+			"spacing": {
+				"padding": {
+					"top": "calc(0.667em + 2px)",
+					"right": "calc(1.333em + 2px)",
+					"bottom": "calc(0.667em + 2px)",
+					"left": "calc(1.333em + 2px)"
+				}
+			}
 		}
 	},
 	"styles": [

--- a/packages/block-library/src/button/block.json
+++ b/packages/block-library/src/button/block.json
@@ -91,6 +91,22 @@
 		},
 		"__experimentalSelector": ".wp-block-button__link"
 	},
+	"blockStyles": {
+		"border": {
+			"radius": "9999px"
+		},
+		"color": {
+			"text": "#fff",
+			"background": "#32373c"
+		},
+		"typography": {
+			"fontSize": "1.125em",
+			"textDecoration": "none"
+		},
+		"spacing": {
+			"padding": "calc(0.667em + 2px) calc(1.333em + 2px)"
+		}
+	},
 	"styles": [
 		{ "name": "fill", "label": "Fill", "isDefault": true },
 		{ "name": "outline", "label": "Outline" }

--- a/packages/block-library/src/button/style.scss
+++ b/packages/block-library/src/button/style.scss
@@ -4,14 +4,9 @@ $blocks-block__margin: 0.5em;
 // Prefer the link selector instead of the regular button classname
 // to support the previous markup in addition to the new one.
 .wp-block-button__link {
-	color: $white;
-	background-color: #32373c;
-	border-radius: 9999px; // 100% causes an oval, but any explicit but really high value retains the pill shape.
 	box-shadow: none;
 	cursor: pointer;
 	display: inline-block;
-	font-size: 1.125em;
-	padding: calc(0.667em + 2px) calc(1.333em + 2px); // The extra 2px are added to size solids the same as the outline versions.
 	text-align: center;
 	text-decoration: none;
 	word-break: break-word; // overflow-wrap doesn't work well if a link is wrapped in the div, so use word-break here.


### PR DESCRIPTION
In https://github.com/WordPress/gutenberg/pull/34180 we moved block CSS to supports > __experimentalStyle but ideally it should live in the `style` key at the root level. This PR is an exploration to see if that's possible.

Can be tested with https://github.com/WordPress/wordpress-develop/pull/2798