### PR TITLE
Clarify updateNavigationLinkBlockAttributes

### DIFF
--- a/packages/block-library/src/navigation-link/edit.js
+++ b/packages/block-library/src/navigation-link/edit.js
@@ -239,7 +239,7 @@ export const updateNavigationLinkBlockAttributes = (
 
 	const useNewLabel =
 		newLabel &&
-		originalLabel !== newLabel &&
+		newLabel !== originalLabel &&
 		// LinkControl without the title field relies
 		// on the check below. Specifically, it assumes that
 		// the URL is the same as a title.

--- a/packages/block-library/src/navigation-link/edit.js
+++ b/packages/block-library/src/navigation-link/edit.js
@@ -261,12 +261,6 @@ export const updateNavigationLinkBlockAttributes = (
 		? escape( newLabel )
 		: originalLabel || escape( newUrlWithoutHttp );
 
-	// const isTitleAlreadyEscaped = ! newLabel || isNewLabelTheSameAsUrl || originalLabel === newLabel;
-	//
-	// const escapedNewLabel = isTitleAlreadyEscaped
-	// 	? originalLabel || escape( newUrl )
-	// 	: escape( newLabel );
-	//
 	// In https://github.com/WordPress/gutenberg/pull/24670 we decided to use "tag" in favor of "post_tag"
 	const type = newType === 'post_tag' ? 'tag' : newType.replace( '-', '_' );
 

--- a/packages/block-library/src/navigation-link/edit.js
+++ b/packages/block-library/src/navigation-link/edit.js
@@ -225,20 +225,28 @@ export const updateNavigationLinkBlockAttributes = (
 	} = blockAttributes;
 
 	const {
-		title = '', // the title of any provided Post.
-		url = '',
+		title: newLabel = '', // the title of any provided Post.
+		url: newUrl = '',
 
 		opensInNewTab,
 		id,
 		kind: newKind = originalKind,
 		type: newType = originalType,
 	} = updatedValue;
-	const normalizedTitle = title.replace( /http(s?):\/\//gi, '' );
-	const normalizedURL = url.replace( /http(s?):\/\//gi, '' );
-	const escapeTitle =
-		title !== '' &&
-		normalizedTitle !== normalizedURL &&
-		originalLabel !== title;
+
+	const newLabelWithoutHttp = newLabel.replace( /http(s?):\/\//gi, '' );
+	const newUrlWithoutHttp = newUrl.replace( /http(s?):\/\//gi, '' );
+
+	const useNewLabel =
+		newLabel &&
+		originalLabel !== newLabel &&
+		// LinkControl without the title field relies
+		// on the check below. Specifically, it assumes that
+		// the URL is the same as a title.
+		// This logic a) looks suspicious and b) should really
+		// live in the LinkControl and not here. It's a great
+		// candidate for future refactoring.
+		newLabelWithoutHttp !== newUrlWithoutHttp;
 
 	// Unfortunately this causes the escaping model to be inverted.
 	// The escaped content is stored in the block attributes (and ultimately in the database),
@@ -249,10 +257,16 @@ export const updateNavigationLinkBlockAttributes = (
 	// See also:
 	// - https://github.com/WordPress/gutenberg/pull/41063
 	// - https://github.com/WordPress/gutenberg/pull/18617.
-	const label = escapeTitle
-		? escape( title )
-		: originalLabel || escape( normalizedURL );
+	const label = useNewLabel
+		? escape( newLabel )
+		: originalLabel || escape( newUrlWithoutHttp );
 
+	// const isTitleAlreadyEscaped = ! newLabel || isNewLabelTheSameAsUrl || originalLabel === newLabel;
+	//
+	// const escapedNewLabel = isTitleAlreadyEscaped
+	// 	? originalLabel || escape( newUrl )
+	// 	: escape( newLabel );
+	//
 	// In https://github.com/WordPress/gutenberg/pull/24670 we decided to use "tag" in favor of "post_tag"
 	const type = newType === 'post_tag' ? 'tag' : newType.replace( '-', '_' );
 
@@ -265,7 +279,7 @@ export const updateNavigationLinkBlockAttributes = (
 
 	setAttributes( {
 		// Passed `url` may already be encoded. To prevent double encoding, decodeURI is executed to revert to the original string.
-		...( url && { url: encodeURI( safeDecodeURI( url ) ) } ),
+		...( newUrl && { url: encodeURI( safeDecodeURI( newUrl ) ) } ),
 		...( label && { label } ),
 		...( undefined !== opensInNewTab && { opensInNewTab } ),
 		...( id && Number.isInteger( id ) && { id } ),


### PR DESCRIPTION
## What?

Let's use more intuitive variable names and document an odd behavior as a docstring.

Understanding that function as it stands took me and @getdave two hours. Hopefully this PR will make it easier for the next person.

Co-authored by Dave Smith <@getdave>

## Testing Instructions

This is a developer experience change that shouldn't affect the logic. To test, confirm the tests are green and the logic is equivalent to how it was before this PR. 