### PR TITLE
Elements: Add UI for button elements

### DIFF
--- a/packages/edit-site/src/components/global-styles/screen-button-color.js
+++ b/packages/edit-site/src/components/global-styles/screen-button-color.js
@@ -7,6 +7,9 @@ import { __experimentalColorGradientControl as ColorGradientControl } from '@wor
 /**
  * Internal dependencies
  */
+/**
+ * Internal dependencies
+ */
 import ScreenHeader from './header';
 import {
 	getSupportedGlobalStylesPanels,
@@ -22,9 +25,12 @@ function ScreenButtonColor( { name } ) {
 
 	const colorsPerOrigin = useColorsPerOrigin( name );
 
+	const [ isBackgroundEnabled ] = useSetting( 'color.background', name );
+
 	const hasButtonColor =
 		supports.includes( 'buttonColor' ) &&
-		( solids.length > 0 || areCustomSolidsEnabled ); // TODO - use the right check
+		isBackgroundEnabled &&
+		( solids.length > 0 || areCustomSolidsEnabled );
 
 	const [ buttonTextColor, setButtonTextColor ] = useStyle(
 		'elements.button.color.text',

--- a/packages/edit-site/src/components/global-styles/screen-button-color.js
+++ b/packages/edit-site/src/components/global-styles/screen-button-color.js
@@ -7,9 +7,6 @@ import { __experimentalColorGradientControl as ColorGradientControl } from '@wor
 /**
  * Internal dependencies
  */
-/**
- * Internal dependencies
- */
 import ScreenHeader from './header';
 import {
 	getSupportedGlobalStylesPanels,

--- a/packages/edit-site/src/components/global-styles/screen-colors.js
+++ b/packages/edit-site/src/components/global-styles/screen-colors.js
@@ -104,7 +104,7 @@ function LinkColorItem( { name, parentMenu } ) {
 
 function ButtonColorItem( { name, parentMenu } ) {
 	const supports = getSupportedGlobalStylesPanels( name );
-	const hasSupport = supports.includes( 'linkColor' ); // TODO - use a real support
+	const hasSupport = supports.includes( 'buttonColor' );
 	const [ color ] = useStyle( 'elements.button.color.text', name );
 	const [ bgColor ] = useStyle( 'elements.button.color.background', name );
 

--- a/packages/edit-site/src/components/global-styles/style.scss
+++ b/packages/edit-site/src/components/global-styles/style.scss
@@ -113,3 +113,16 @@
 	// Match the height of the rest of the icons (24px).
 	height: $grid-unit * 3;
 }
+
+.edit-site-global-styles__color-indicator-wrapper > .component-color-indicator:first-child {
+	// the point is to be on top of other colors
+	z-index: 3;
+	position: relative;
+	right: 0;
+}
+
+.edit-site-global-styles__color-indicator-wrapper > .component-color-indicator,
+.edit-site-global-styles__color-indicator-wrapper.has-multiple-colors + .components-flex-item {
+	position: relative;
+	right: 20px;
+}

--- a/packages/edit-site/src/components/global-styles/style.scss
+++ b/packages/edit-site/src/components/global-styles/style.scss
@@ -113,16 +113,3 @@
 	// Match the height of the rest of the icons (24px).
 	height: $grid-unit * 3;
 }
-
-.edit-site-global-styles__color-indicator-wrapper > .component-color-indicator:first-child {
-	// the point is to be on top of other colors
-	z-index: 3;
-	position: relative;
-	right: 0;
-}
-
-.edit-site-global-styles__color-indicator-wrapper > .component-color-indicator,
-.edit-site-global-styles__color-indicator-wrapper.has-multiple-colors + .components-flex-item {
-	position: relative;
-	right: 20px;
-}

--- a/packages/edit-site/src/components/global-styles/style.scss
+++ b/packages/edit-site/src/components/global-styles/style.scss
@@ -58,8 +58,7 @@
 }
 
 .edit-site-global-styles-section-title {
-	font-size: calc(1.95 * 8px);
-	color: rgb(30, 30, 30);
+	color: $gray-800;
 	font-weight: 600;
 	line-height: 1.2;
 	padding: $grid-unit-20;


### PR DESCRIPTION
## What?
#41246 introduced support for the `button` element in `theme.json`. This adds a UI to make it possible to edit button elements in Global Styles. 

## Why?
To allow users to edit their button styles.

## How?
Duplicating existing global styles controls.

## Testing Instructions
1. In the Site Editor, open Global Styles
2. Open the Typography panel
3. You should see an option to modify the typography options for buttons
4. Open the Colors panel
5. You should see an option to modify the color options for buttons
6. Modifications in both panels should update the preview and when saved the frontend.

## Screenshots or screencast <!-- if applicable -->
Typography


https://user-images.githubusercontent.com/107534/174039260-65f705c3-29fd-41b1-961e-924731808054.mp4


