### PR TITLE
Lodash: Refactor away from `_.noop()`

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -85,6 +85,7 @@ module.exports = {
 							'isUndefined',
 							'memoize',
 							'negate',
+							'noop',
 							'random',
 							'reverse',
 							'stubFalse',

--- a/packages/block-directory/src/components/downloadable-blocks-list/index.js
+++ b/packages/block-directory/src/components/downloadable-blocks-list/index.js
@@ -1,9 +1,4 @@
 /**
- * External dependencies
- */
-import { noop } from 'lodash';
-
-/**
  * WordPress dependencies
  */
 import { __ } from '@wordpress/i18n';
@@ -19,6 +14,8 @@ import { useDispatch } from '@wordpress/data';
  */
 import DownloadableBlockListItem from '../downloadable-block-list-item';
 import { store as blockDirectoryStore } from '../../store';
+
+const noop = () => {};
 
 function DownloadableBlocksList( { items, onHover = noop, onSelect } ) {
 	const composite = useCompositeState();

--- a/packages/block-editor/src/autocompleters/block.js
+++ b/packages/block-editor/src/autocompleters/block.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { noop, orderBy } from 'lodash';
+import { orderBy } from 'lodash';
 
 /**
  * WordPress dependencies
@@ -21,6 +21,7 @@ import useBlockTypesState from '../components/inserter/hooks/use-block-types-sta
 import BlockIcon from '../components/block-icon';
 import { store as blockEditorStore } from '../store';
 
+const noop = () => {};
 const SHOWN_BLOCK_TYPES = 9;
 
 /** @typedef {import('@wordpress/components').WPCompleter} WPCompleter */

--- a/packages/block-editor/src/components/block-alignment-matrix-control/index.js
+++ b/packages/block-editor/src/components/block-alignment-matrix-control/index.js
@@ -1,8 +1,4 @@
 /**
- * External dependencies
- */
-import { noop } from 'lodash';
-/**
  * WordPress dependencies
  */
 import { __ } from '@wordpress/i18n';
@@ -12,6 +8,8 @@ import {
 	Dropdown,
 	__experimentalAlignmentMatrixControl as AlignmentMatrixControl,
 } from '@wordpress/components';
+
+const noop = () => {};
 
 function BlockAlignmentMatrixControl( props ) {
 	const {

--- a/packages/block-editor/src/components/block-compare/test/block-view.js
+++ b/packages/block-editor/src/components/block-compare/test/block-view.js
@@ -2,12 +2,13 @@
  * External dependencies
  */
 import { shallow } from 'enzyme';
-import { noop } from 'lodash';
 
 /**
  * Internal dependencies
  */
 import BlockView from '../block-view';
+
+const noop = () => {};
 
 describe( 'BlockView', () => {
 	test( 'should match snapshot', () => {

--- a/packages/block-editor/src/components/block-edit/test/edit.js
+++ b/packages/block-editor/src/components/block-edit/test/edit.js
@@ -2,7 +2,6 @@
  * External dependencies
  */
 import { shallow, mount } from 'enzyme';
-import { noop } from 'lodash';
 
 /**
  * WordPress dependencies
@@ -18,6 +17,8 @@ import {
  */
 import { Edit } from '../edit';
 import { BlockContextProvider } from '../../block-context';
+
+const noop = () => {};
 
 describe( 'Edit', () => {
 	afterEach( () => {

--- a/packages/block-editor/src/components/block-settings-menu/block-mode-toggle.js
+++ b/packages/block-editor/src/components/block-settings-menu/block-mode-toggle.js
@@ -1,9 +1,4 @@
 /**
- * External dependencies
- */
-import { noop } from 'lodash';
-
-/**
  * WordPress dependencies
  */
 import { __ } from '@wordpress/i18n';
@@ -16,6 +11,8 @@ import { compose } from '@wordpress/compose';
  * Internal dependencies
  */
 import { store as blockEditorStore } from '../../store';
+
+const noop = () => {};
 
 export function BlockModeToggle( {
 	blockType,

--- a/packages/block-editor/src/components/block-settings-menu/block-settings-dropdown.js
+++ b/packages/block-editor/src/components/block-settings-menu/block-settings-dropdown.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { castArray, flow, noop } from 'lodash';
+import { castArray, flow } from 'lodash';
 
 /**
  * WordPress dependencies
@@ -33,6 +33,7 @@ import { store as blockEditorStore } from '../../store';
 import useBlockDisplayTitle from '../block-title/use-block-display-title';
 import { useShowMoversGestures } from '../block-toolbar/utils';
 
+const noop = () => {};
 const POPOVER_PROPS = {
 	className: 'block-editor-block-settings-menu__popover',
 	position: 'bottom right',

--- a/packages/block-editor/src/components/block-styles/index.js
+++ b/packages/block-editor/src/components/block-styles/index.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { noop, debounce } from 'lodash';
+import { debounce } from 'lodash';
 import classnames from 'classnames';
 
 /**
@@ -38,6 +38,8 @@ function BlockStylesPreviewPanelFill( { children, scope, ...props } ) {
 // relative to the editor pane.
 // The value is the equivalent of the container's right position.
 const DEFAULT_POSITION_TOP = 16;
+
+const noop = () => {};
 
 // Block Styles component for the Settings Sidebar.
 function BlockStyles( {

--- a/packages/block-editor/src/components/block-styles/menu-items.js
+++ b/packages/block-editor/src/components/block-styles/menu-items.js
@@ -1,9 +1,4 @@
 /**
- * External dependencies
- */
-import { noop } from 'lodash';
-
-/**
  * WordPress dependencies
  */
 import { MenuItem, __experimentalText as Text } from '@wordpress/components';
@@ -13,6 +8,8 @@ import { check } from '@wordpress/icons';
  * Internal dependencies
  */
 import useStylesForBlocks from './use-styles-for-block';
+
+const noop = () => {};
 
 export default function BlockStylesMenuItems( { clientId, onSwitch = noop } ) {
 	const { onSelect, stylesToRender, activeStyle } = useStylesForBlocks( {

--- a/packages/block-editor/src/components/block-toolbar/utils.js
+++ b/packages/block-editor/src/components/block-toolbar/utils.js
@@ -1,15 +1,10 @@
 /**
- * External dependencies
- */
-import { noop } from 'lodash';
-
-/**
  * WordPress dependencies
  */
 import { useState, useRef, useEffect } from '@wordpress/element';
 
 const { clearTimeout, setTimeout } = window;
-
+const noop = () => {};
 const DEBOUNCE_TIMEOUT = 200;
 
 /**

--- a/packages/block-editor/src/components/color-palette/test/control.js
+++ b/packages/block-editor/src/components/color-palette/test/control.js
@@ -2,12 +2,13 @@
  * External dependencies
  */
 import { create, act } from 'react-test-renderer';
-import { noop } from 'lodash';
 
 /**
  * Internal dependencies
  */
 import ColorPaletteControl from '../control';
+
+const noop = () => {};
 
 describe( 'ColorPaletteControl', () => {
 	it( 'matches the snapshot', async () => {

--- a/packages/block-editor/src/components/colors-gradients/test/control.js
+++ b/packages/block-editor/src/components/colors-gradients/test/control.js
@@ -3,12 +3,13 @@
  */
 import { render, screen } from '@testing-library/react';
 import { create, act } from 'react-test-renderer';
-import { noop } from 'lodash';
 
 /**
  * Internal dependencies
  */
 import ColorGradientControl from '../control';
+
+const noop = () => {};
 
 const getButtonWithAriaLabelStartPredicate = ( ariaLabelStart ) => (
 	element

--- a/packages/block-editor/src/components/image-size-control/index.js
+++ b/packages/block-editor/src/components/image-size-control/index.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { isEmpty, noop } from 'lodash';
+import { isEmpty } from 'lodash';
 
 /**
  * WordPress dependencies
@@ -20,6 +20,7 @@ import { __ } from '@wordpress/i18n';
 import useDimensionHandler from './use-dimension-handler';
 
 const IMAGE_SIZE_PRESETS = [ 25, 50, 75, 100 ];
+const noop = () => {};
 
 export default function ImageSizeControl( {
 	imageWidth,

--- a/packages/block-editor/src/components/inserter/library.js
+++ b/packages/block-editor/src/components/inserter/library.js
@@ -1,9 +1,4 @@
 /**
- * External dependencies
- */
-import { noop } from 'lodash';
-
-/**
  * WordPress dependencies
  */
 import { useSelect } from '@wordpress/data';
@@ -14,6 +9,8 @@ import { forwardRef } from '@wordpress/element';
  */
 import InserterMenu from './menu';
 import { store as blockEditorStore } from '../../store';
+
+const noop = () => {};
 
 function InserterLibrary(
 	{

--- a/packages/block-editor/src/components/link-control/index.js
+++ b/packages/block-editor/src/components/link-control/index.js
@@ -1,7 +1,6 @@
 /**
  * External dependencies
  */
-import { noop } from 'lodash';
 import classnames from 'classnames';
 
 /**
@@ -96,6 +95,8 @@ import { DEFAULT_LINK_SETTINGS } from './constants';
  * @property {string|Function|undefined}  createSuggestionButtonText The text to use in the button that calls createSuggestion.
  * @property {Function}                   renderControlBottom        Optional controls to be rendered at the bottom of the component.
  */
+
+const noop = () => {};
 
 /**
  * Renders a link control. A link control is a controlled input which maintains

--- a/packages/block-editor/src/components/link-control/search-input.js
+++ b/packages/block-editor/src/components/link-control/search-input.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { noop, omit } from 'lodash';
+import { omit } from 'lodash';
 import classnames from 'classnames';
 /**
  * WordPress dependencies
@@ -22,6 +22,8 @@ import useSearchHandler from './use-search-handler';
 // to the fetchLinkSuggestions passed in block editor settings
 // which will cause an unintended http request.
 const noopSearchHandler = () => Promise.resolve( [] );
+
+const noop = () => {};
 
 const LinkControlSearchInput = forwardRef(
 	(

--- a/packages/block-editor/src/components/link-control/settings-drawer.js
+++ b/packages/block-editor/src/components/link-control/settings-drawer.js
@@ -1,13 +1,10 @@
 /**
- * External dependencies
- */
-import { noop } from 'lodash';
-
-/**
  * WordPress dependencies
  */
 import { __ } from '@wordpress/i18n';
 import { ToggleControl, VisuallyHidden } from '@wordpress/components';
+
+const noop = () => {};
 
 const LinkControlSettingsDrawer = ( { value, onChange = noop, settings } ) => {
 	if ( ! settings || ! settings.length ) {

--- a/packages/block-editor/src/components/media-placeholder/index.js
+++ b/packages/block-editor/src/components/media-placeholder/index.js
@@ -1,7 +1,6 @@
 /**
  * External dependencies
  */
-import { noop } from 'lodash';
 import classnames from 'classnames';
 
 /**
@@ -26,6 +25,8 @@ import MediaUpload from '../media-upload';
 import MediaUploadCheck from '../media-upload/check';
 import URLPopover from '../url-popover';
 import { store as blockEditorStore } from '../../store';
+
+const noop = () => {};
 
 const InsertFromURLPopover = ( { src, onChange, onSubmit, onClose } ) => (
 	<URLPopover onClose={ onClose }>

--- a/packages/block-editor/src/components/media-replace-flow/index.js
+++ b/packages/block-editor/src/components/media-replace-flow/index.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { noop, uniqueId } from 'lodash';
+import { uniqueId } from 'lodash';
 
 /**
  * WordPress dependencies
@@ -36,6 +36,8 @@ import MediaUpload from '../media-upload';
 import MediaUploadCheck from '../media-upload/check';
 import LinkControl from '../link-control';
 import { store as blockEditorStore } from '../../store';
+
+const noop = () => {};
 
 const MediaReplaceFlow = ( {
 	mediaURL,

--- a/packages/block-editor/src/components/panel-color-settings/test/index.js
+++ b/packages/block-editor/src/components/panel-color-settings/test/index.js
@@ -2,12 +2,13 @@
  * External dependencies
  */
 import { render } from '@testing-library/react';
-import { noop } from 'lodash';
 
 /**
  * Internal dependencies
  */
 import PanelColorSettings from '../';
+
+const noop = () => {};
 
 describe( 'PanelColorSettings', () => {
 	it( 'should not render anything if there are no colors to choose', async () => {

--- a/packages/block-editor/src/components/provider/use-block-sync.js
+++ b/packages/block-editor/src/components/provider/use-block-sync.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { last, noop } from 'lodash';
+import { last } from 'lodash';
 
 /**
  * WordPress dependencies
@@ -14,6 +14,8 @@ import { cloneBlock } from '@wordpress/blocks';
  * Internal dependencies
  */
 import { store as blockEditorStore } from '../../store';
+
+const noop = () => {};
 
 /**
  * A function to call when the block value has been updated in the block-editor

--- a/packages/block-editor/src/components/rich-text/embed-handler-picker.native.js
+++ b/packages/block-editor/src/components/rich-text/embed-handler-picker.native.js
@@ -1,9 +1,4 @@
 /**
- * External dependencies
- */
-import { noop } from 'lodash';
-
-/**
  * WordPress dependencies
  */
 import {
@@ -15,6 +10,8 @@ import {
 } from '@wordpress/element';
 import { Picker } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
+
+const noop = () => {};
 
 const DEFAULT_PICKER_OPTIONS = [
 	{

--- a/packages/block-editor/src/components/ungroup-button/index.native.js
+++ b/packages/block-editor/src/components/ungroup-button/index.native.js
@@ -1,9 +1,4 @@
 /**
- * External dependencies
- */
-import { noop } from 'lodash';
-
-/**
  * WordPress dependencies
  */
 import { store as blocksStore } from '@wordpress/blocks';
@@ -17,6 +12,8 @@ import { compose } from '@wordpress/compose';
  */
 import UngroupIcon from './icon';
 import { store as blockEditorStore } from '../../store';
+
+const noop = () => {};
 
 export function UngroupButton( { onConvertFromGroup, isUngroupable = false } ) {
 	if ( ! isUngroupable ) {

--- a/packages/block-editor/src/hooks/test/align.js
+++ b/packages/block-editor/src/hooks/test/align.js
@@ -1,7 +1,6 @@
 /**
  * External dependencies
  */
-import { noop } from 'lodash';
 import renderer, { act } from 'react-test-renderer';
 
 /**
@@ -24,6 +23,8 @@ import {
 	withDataAlign,
 	addAssignedAlign,
 } from '../align';
+
+const noop = () => {};
 
 describe( 'align', () => {
 	const blockSettings = {

--- a/packages/block-editor/src/hooks/test/generated-class-name.js
+++ b/packages/block-editor/src/hooks/test/generated-class-name.js
@@ -1,9 +1,4 @@
 /**
- * External dependencies
- */
-import { noop } from 'lodash';
-
-/**
  * WordPress dependencies
  */
 import { applyFilters } from '@wordpress/hooks';
@@ -12,6 +7,8 @@ import { applyFilters } from '@wordpress/hooks';
  * Internal dependencies
  */
 import '../generated-class-name';
+
+const noop = () => {};
 
 describe( 'generated className', () => {
 	const blockSettings = {

--- a/packages/block-editor/src/hooks/test/utils.js
+++ b/packages/block-editor/src/hooks/test/utils.js
@@ -1,9 +1,4 @@
 /**
- * External dependencies
- */
-import { noop } from 'lodash';
-
-/**
  * WordPress dependencies
  */
 import { applyFilters } from '@wordpress/hooks';
@@ -12,6 +7,8 @@ import { applyFilters } from '@wordpress/hooks';
  * Internal dependencies
  */
 import '../anchor';
+
+const noop = () => {};
 
 describe( 'anchor', () => {
 	const blockSettings = {

--- a/packages/block-editor/src/store/test/actions.js
+++ b/packages/block-editor/src/store/test/actions.js
@@ -1,7 +1,6 @@
 /**
  * External dependencies
  */
-import { noop } from 'lodash';
 import deepFreeze from 'deep-freeze';
 
 /**
@@ -23,6 +22,8 @@ import * as selectors from '../selectors';
 import reducer from '../reducer';
 import * as actions from '../actions';
 import { STORE_NAME as blockEditorStoreName } from '../../store/constants';
+
+const noop = () => {};
 
 const {
 	clearSelectedBlock,

--- a/packages/block-editor/src/store/test/reducer.js
+++ b/packages/block-editor/src/store/test/reducer.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { values, noop, omit } from 'lodash';
+import { values, omit } from 'lodash';
 import deepFreeze from 'deep-freeze';
 
 /**
@@ -33,6 +33,8 @@ import {
 	lastBlockAttributesChange,
 	lastBlockInserted,
 } from '../reducer';
+
+const noop = () => {};
 
 describe( 'state', () => {
 	describe( 'hasSameKeys()', () => {

--- a/packages/block-library/src/media-text/deprecated.js
+++ b/packages/block-library/src/media-text/deprecated.js
@@ -2,7 +2,7 @@
  * External dependencies
  */
 import classnames from 'classnames';
-import { noop, isEmpty, omit } from 'lodash';
+import { isEmpty, omit } from 'lodash';
 
 /**
  * WordPress dependencies
@@ -15,6 +15,7 @@ import { InnerBlocks, getColorClassName } from '@wordpress/block-editor';
 import { imageFillStyles } from './media-container';
 
 const DEFAULT_MEDIA_WIDTH = 50;
+const noop = () => {};
 
 const migrateCustomColors = ( attributes ) => {
 	if ( ! attributes.customBackgroundColor ) {

--- a/packages/block-library/src/media-text/media-container.js
+++ b/packages/block-library/src/media-text/media-container.js
@@ -2,7 +2,6 @@
  * External dependencies
  */
 import classnames from 'classnames';
-import { noop } from 'lodash';
 
 /**
  * WordPress dependencies
@@ -30,6 +29,7 @@ import icon from './media-container-icon';
  * Constants
  */
 const ALLOWED_MEDIA_TYPES = [ 'image', 'video' ];
+const noop = () => {};
 
 export function imageFillStyles( url, focalPoint ) {
 	return url

--- a/packages/block-library/src/media-text/save.js
+++ b/packages/block-library/src/media-text/save.js
@@ -2,7 +2,7 @@
  * External dependencies
  */
 import classnames from 'classnames';
-import { noop, isEmpty } from 'lodash';
+import { isEmpty } from 'lodash';
 
 /**
  * WordPress dependencies
@@ -16,6 +16,7 @@ import { imageFillStyles } from './media-container';
 import { DEFAULT_MEDIA_SIZE_SLUG } from './constants';
 
 const DEFAULT_MEDIA_WIDTH = 50;
+const noop = () => {};
 
 export default function save( { attributes } ) {
 	const {

--- a/packages/blocks/src/api/test/factory.js
+++ b/packages/blocks/src/api/test/factory.js
@@ -2,7 +2,7 @@
  * External dependencies
  */
 import deepFreeze from 'deep-freeze';
-import { noop, times } from 'lodash';
+import { times } from 'lodash';
 
 /**
  * Internal dependencies
@@ -26,6 +26,8 @@ import {
 	unregisterBlockType,
 	setGroupingBlockName,
 } from '../registration';
+
+const noop = () => {};
 
 describe( 'block factory', () => {
 	const defaultBlockSettings = {

--- a/packages/blocks/src/api/test/registration.js
+++ b/packages/blocks/src/api/test/registration.js
@@ -3,7 +3,7 @@
 /**
  * External dependencies
  */
-import { noop, get, omit, pick } from 'lodash';
+import { get, omit, pick } from 'lodash';
 
 /**
  * WordPress dependencies
@@ -37,6 +37,8 @@ import {
 } from '../registration';
 import { BLOCK_ICON_DEFAULT, DEPRECATED_ENTRY_KEYS } from '../constants';
 import { store as blocksStore } from '../../store';
+
+const noop = () => {};
 
 describe( 'blocks', () => {
 	const defaultBlockSettings = {

--- a/packages/blocks/src/api/test/templates.js
+++ b/packages/blocks/src/api/test/templates.js
@@ -1,9 +1,4 @@
 /**
- * External dependencies
- */
-import { noop } from 'lodash';
-
-/**
  * Internal dependencies
  */
 import { createBlock } from '../factory';
@@ -16,6 +11,8 @@ import {
 	doBlocksMatchTemplate,
 	synchronizeBlocksWithTemplate,
 } from '../templates';
+
+const noop = () => {};
 
 describe( 'templates', () => {
 	beforeAll( () => {

--- a/packages/blocks/src/api/test/utils.js
+++ b/packages/blocks/src/api/test/utils.js
@@ -1,9 +1,4 @@
 /**
- * External dependencies
- */
-import { noop } from 'lodash';
-
-/**
  * Internal dependencies
  */
 import { createBlock } from '../factory';
@@ -20,6 +15,8 @@ import {
 	__experimentalSanitizeBlockAttributes,
 	__experimentalGetBlockAttributesNamesByRole,
 } from '../utils';
+
+const noop = () => {};
 
 describe( 'block helpers', () => {
 	beforeAll( () => {

--- a/packages/components/src/alignment-matrix-control/index.js
+++ b/packages/components/src/alignment-matrix-control/index.js
@@ -1,7 +1,6 @@
 /**
  * External dependencies
  */
-import { noop } from 'lodash';
 import classnames from 'classnames';
 
 /**
@@ -19,6 +18,8 @@ import { Composite, CompositeGroup, useCompositeState } from '../composite';
 import { Root, Row } from './styles/alignment-matrix-control-styles';
 import AlignmentMatrixControlIcon from './icon';
 import { GRID, getItemId } from './utils';
+
+const noop = () => {};
 
 function useBaseId( id ) {
 	const instanceId = useInstanceId(

--- a/packages/components/src/box-control/all-input-control.js
+++ b/packages/components/src/box-control/all-input-control.js
@@ -1,8 +1,4 @@
 /**
- * External dependencies
- */
-import { noop } from 'lodash';
-/**
  * Internal dependencies
  */
 import UnitControl from './unit-control';
@@ -13,6 +9,8 @@ import {
 	isValuesMixed,
 	isValuesDefined,
 } from './utils';
+
+const noop = () => {};
 
 export default function AllInputControl( {
 	onChange = noop,

--- a/packages/components/src/box-control/index.js
+++ b/packages/components/src/box-control/index.js
@@ -1,9 +1,4 @@
 /**
- * External dependencies
- */
-import { noop } from 'lodash';
-
-/**
  * WordPress dependencies
  */
 import { useInstanceId } from '@wordpress/compose';
@@ -38,6 +33,8 @@ import { useControlledState } from '../utils/hooks';
 const defaultInputProps = {
 	min: 0,
 };
+
+const noop = () => {};
 
 function useUniqueId( idProp ) {
 	const instanceId = useInstanceId( BoxControl, 'inspector-box-control' );

--- a/packages/components/src/box-control/input-controls.js
+++ b/packages/components/src/box-control/input-controls.js
@@ -1,15 +1,12 @@
 /**
- * External dependencies
- */
-import { noop } from 'lodash';
-
-/**
  * Internal dependencies
  */
 import UnitControl from './unit-control';
 import { parseQuantityAndUnitFromRawValue } from '../unit-control/utils';
 import { ALL_SIDES, LABELS } from './utils';
 import { LayoutContainer, Layout } from './styles/box-control-styles';
+
+const noop = () => {};
 
 export default function BoxInputControls( {
 	onChange = noop,

--- a/packages/components/src/box-control/unit-control.js
+++ b/packages/components/src/box-control/unit-control.js
@@ -1,7 +1,6 @@
 /**
  * External dependencies
  */
-import { noop } from 'lodash';
 import { useHover } from '@use-gesture/react';
 
 /**
@@ -9,6 +8,8 @@ import { useHover } from '@use-gesture/react';
  */
 import BaseTooltip from '../tooltip';
 import { UnitControlWrapper, UnitControl } from './styles/box-control-styles';
+
+const noop = () => {};
 
 export default function BoxUnitControl( {
 	isFirst,

--- a/packages/components/src/checkbox-control/test/index.tsx
+++ b/packages/components/src/checkbox-control/test/index.tsx
@@ -3,7 +3,6 @@
  */
 import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
-import { noop } from 'lodash';
 
 /**
  * WordPress dependencies
@@ -15,6 +14,8 @@ import { useState } from '@wordpress/element';
  */
 import BaseCheckboxControl from '..';
 import type { CheckboxControlProps } from '../types';
+
+const noop = () => {};
 
 const getInput = () => screen.getByRole( 'checkbox' ) as HTMLInputElement;
 

--- a/packages/components/src/combobox-control/index.js
+++ b/packages/components/src/combobox-control/index.js
@@ -2,7 +2,7 @@
  * External dependencies
  */
 import classnames from 'classnames';
-import { noop, deburr } from 'lodash';
+import { deburr } from 'lodash';
 /**
  * WordPress dependencies
  */
@@ -28,6 +28,8 @@ import BaseControl from '../base-control';
 import Button from '../button';
 import { Flex, FlexBlock, FlexItem } from '../flex';
 import withFocusOutside from '../higher-order/with-focus-outside';
+
+const noop = () => {};
 
 const DetectOutside = withFocusOutside(
 	class extends Component {

--- a/packages/components/src/date-time/date-time/index.tsx
+++ b/packages/components/src/date-time/date-time/index.tsx
@@ -1,7 +1,6 @@
 /**
  * External dependencies
  */
-import { noop } from 'lodash';
 import type { ForwardedRef } from 'react';
 
 /**
@@ -24,6 +23,8 @@ import { Heading } from '../../heading';
 import { Spacer } from '../../spacer';
 
 export { DatePicker, TimePicker };
+
+const noop = () => {};
 
 function UnforwardedDateTimePicker(
 	{

--- a/packages/components/src/date-time/date/index.tsx
+++ b/packages/components/src/date-time/date/index.tsx
@@ -3,7 +3,6 @@
  */
 import moment from 'moment';
 import type { Moment } from 'moment';
-import { noop } from 'lodash';
 // Needed to initialise the default datepicker styles.
 // See: https://github.com/airbnb/react-dates#initialize
 import 'react-dates/initialize';
@@ -27,6 +26,7 @@ import { Day, NavPrevButton, NavNextButton } from './styles';
 
 const TIMEZONELESS_FORMAT = 'YYYY-MM-DDTHH:mm:ss';
 const ARIAL_LABEL_TIME_FORMAT = 'dddd, LL';
+const noop = () => {};
 
 function DatePickerDay( { day, events = [] }: DatePickerDayProps ) {
 	const ref = useRef< HTMLDivElement >( null );

--- a/packages/components/src/focal-point-picker/controls.js
+++ b/packages/components/src/focal-point-picker/controls.js
@@ -1,9 +1,4 @@
 /**
- * External dependencies
- */
-import { noop } from 'lodash';
-
-/**
  * WordPress dependencies
  */
 import { __ } from '@wordpress/i18n';
@@ -19,6 +14,7 @@ import { fractionToPercentage } from './utils';
 
 const TEXTCONTROL_MIN = 0;
 const TEXTCONTROL_MAX = 100;
+const noop = () => {};
 
 export default function FocalPointPickerControls( {
 	onChange = noop,

--- a/packages/components/src/focal-point-picker/media.js
+++ b/packages/components/src/focal-point-picker/media.js
@@ -1,9 +1,4 @@
 /**
- * External dependencies
- */
-import { noop } from 'lodash';
-
-/**
  * WordPress dependencies
  */
 import { useRef, useLayoutEffect } from '@wordpress/element';
@@ -13,6 +8,8 @@ import { useRef, useLayoutEffect } from '@wordpress/element';
  */
 import { MediaPlaceholder } from './styles/focal-point-picker-style';
 import { isVideoType } from './utils';
+
+const noop = () => {};
 
 export default function Media( {
 	alt,

--- a/packages/components/src/form-toggle/index.js
+++ b/packages/components/src/form-toggle/index.js
@@ -2,7 +2,8 @@
  * External dependencies
  */
 import classnames from 'classnames';
-import { noop } from 'lodash';
+
+export const noop = () => {};
 
 function FormToggle( {
 	className,

--- a/packages/components/src/form-toggle/test/index.js
+++ b/packages/components/src/form-toggle/test/index.js
@@ -2,12 +2,11 @@
  * External dependencies
  */
 import { shallow } from 'enzyme';
-import { noop } from 'lodash';
 
 /**
  * Internal dependencies
  */
-import FormToggle from '../';
+import FormToggle, { noop } from '../';
 
 describe( 'FormToggle', () => {
 	describe( 'basic rendering', () => {

--- a/packages/components/src/form-token-field/token.tsx
+++ b/packages/components/src/form-token-field/token.tsx
@@ -2,7 +2,6 @@
  * External dependencies
  */
 import classnames from 'classnames';
-import { noop } from 'lodash';
 
 /**
  * WordPress dependencies
@@ -17,6 +16,8 @@ import { closeSmall } from '@wordpress/icons';
 import Button from '../button';
 import { VisuallyHidden } from '../visually-hidden';
 import type { TokenProps } from './types';
+
+const noop = () => {};
 
 export default function Token( {
 	value,

--- a/packages/components/src/input-control/index.tsx
+++ b/packages/components/src/input-control/index.tsx
@@ -1,7 +1,6 @@
 /**
  * External dependencies
  */
-import { noop } from 'lodash';
 import classNames from 'classnames';
 import type { ForwardedRef } from 'react';
 
@@ -18,6 +17,8 @@ import InputBase from './input-base';
 import InputField from './input-field';
 import type { InputControlProps } from './types';
 import { useDraft } from './utils';
+
+const noop = () => {};
 
 function useUniqueId( idProp?: string ) {
 	const instanceId = useInstanceId( InputControl );

--- a/packages/components/src/input-control/input-field.tsx
+++ b/packages/components/src/input-control/input-field.tsx
@@ -1,7 +1,6 @@
 /**
  * External dependencies
  */
-import { noop } from 'lodash';
 import { useDrag } from '@use-gesture/react';
 import type {
 	SyntheticEvent,
@@ -25,6 +24,8 @@ import { useDragCursor } from './utils';
 import { Input } from './styles/input-control-styles';
 import { useInputControlStateReducer } from './reducer/reducer';
 import type { InputFieldProps } from './types';
+
+const noop = () => {};
 
 function InputField(
 	{

--- a/packages/components/src/menu-item/test/index.js
+++ b/packages/components/src/menu-item/test/index.js
@@ -2,7 +2,6 @@
  * External dependencies
  */
 import { shallow } from 'enzyme';
-import { noop } from 'lodash';
 
 /**
  * WordPress dependencies
@@ -13,6 +12,8 @@ import { more } from '@wordpress/icons';
  * Internal dependencies
  */
 import { MenuItem } from '../';
+
+const noop = () => {};
 
 describe( 'MenuItem', () => {
 	it( 'should match snapshot when only label provided', () => {

--- a/packages/components/src/menu-items-choice/index.js
+++ b/packages/components/src/menu-items-choice/index.js
@@ -1,9 +1,4 @@
 /**
- * External dependencies
- */
-import { noop } from 'lodash';
-
-/**
  * WordPress dependencies
  */
 import { check } from '@wordpress/icons';
@@ -12,6 +7,8 @@ import { check } from '@wordpress/icons';
  * Internal dependencies
  */
 import MenuItem from '../menu-item';
+
+const noop = () => {};
 
 export default function MenuItemsChoice( {
 	choices = [],

--- a/packages/components/src/navigable-container/container.js
+++ b/packages/components/src/navigable-container/container.js
@@ -2,7 +2,7 @@
 /**
  * External dependencies
  */
-import { omit, noop, isFunction } from 'lodash';
+import { omit, isFunction } from 'lodash';
 
 /**
  * WordPress dependencies
@@ -10,6 +10,7 @@ import { omit, noop, isFunction } from 'lodash';
 import { Component, forwardRef } from '@wordpress/element';
 import { focus } from '@wordpress/dom';
 
+const noop = () => {};
 const MENU_ITEM_ROLES = [ 'menuitem', 'menuitemradio', 'menuitemcheckbox' ];
 
 function cycleValue( value, total, offset ) {

--- a/packages/components/src/navigation/context.js
+++ b/packages/components/src/navigation/context.js
@@ -1,9 +1,4 @@
 /**
- * External dependencies
- */
-import { noop } from 'lodash';
-
-/**
  * WordPress dependencies
  */
 import { createContext, useContext } from '@wordpress/element';
@@ -12,6 +7,8 @@ import { createContext, useContext } from '@wordpress/element';
  * Internal dependencies
  */
 import { ROOT_MENU } from './constants';
+
+const noop = () => {};
 
 export const NavigationContext = createContext( {
 	activeItem: undefined,

--- a/packages/components/src/navigation/index.js
+++ b/packages/components/src/navigation/index.js
@@ -2,7 +2,6 @@
  * External dependencies
  */
 import classnames from 'classnames';
-import { noop } from 'lodash';
 
 /**
  * WordPress dependencies
@@ -18,6 +17,8 @@ import { ROOT_MENU } from './constants';
 import { NavigationContext } from './context';
 import { NavigationUI } from './styles/navigation-styles';
 import { useCreateNavigationTree } from './use-create-navigation-tree';
+
+const noop = () => {};
 
 export default function Navigation( {
 	activeItem,

--- a/packages/components/src/navigation/item/index.js
+++ b/packages/components/src/navigation/item/index.js
@@ -2,7 +2,6 @@
  * External dependencies
  */
 import classnames from 'classnames';
-import { noop } from 'lodash';
 
 /**
  * WordPress dependencies
@@ -18,6 +17,8 @@ import { useNavigationContext } from '../context';
 import { ItemUI, ItemIconUI } from '../styles/navigation-styles';
 import NavigationItemBaseContent from './base-content';
 import NavigationItemBase from './base';
+
+const noop = () => {};
 
 export default function NavigationItem( props ) {
 	const {

--- a/packages/components/src/notice/index.js
+++ b/packages/components/src/notice/index.js
@@ -1,7 +1,6 @@
 /**
  * External dependencies
  */
-import { noop } from 'lodash';
 import classnames from 'classnames';
 
 /**
@@ -18,6 +17,8 @@ import { close } from '@wordpress/icons';
 import { Button } from '../';
 
 /** @typedef {import('@wordpress/element').WPElement} WPElement */
+
+const noop = () => {};
 
 /**
  * Custom hook which announces the message with the given politeness, if a

--- a/packages/components/src/notice/list.js
+++ b/packages/components/src/notice/list.js
@@ -2,12 +2,14 @@
  * External dependencies
  */
 import classnames from 'classnames';
-import { noop, omit } from 'lodash';
+import { omit } from 'lodash';
 
 /**
  * Internal dependencies
  */
 import Notice from './';
+
+const noop = () => {};
 
 /**
  * Renders a list of notices.

--- a/packages/components/src/panel/body.js
+++ b/packages/components/src/panel/body.js
@@ -2,7 +2,6 @@
  * External dependencies
  */
 import classnames from 'classnames';
-import { noop } from 'lodash';
 
 /**
  * WordPress dependencies
@@ -17,6 +16,8 @@ import { chevronUp, chevronDown } from '@wordpress/icons';
 import Button from '../button';
 import Icon from '../icon';
 import { useControlledState, useUpdateEffect } from '../utils';
+
+const noop = () => {};
 
 export function PanelBody(
 	{

--- a/packages/components/src/range-control/index.js
+++ b/packages/components/src/range-control/index.js
@@ -3,7 +3,7 @@
  * External dependencies
  */
 import classnames from 'classnames';
-import { clamp, isFinite, noop } from 'lodash';
+import { clamp, isFinite } from 'lodash';
 
 /**
  * WordPress dependencies
@@ -34,6 +34,8 @@ import {
 	Thumb,
 	Wrapper,
 } from './styles/range-control-styles';
+
+const noop = () => {};
 
 function RangeControl(
 	{

--- a/packages/components/src/range-control/input-range.js
+++ b/packages/components/src/range-control/input-range.js
@@ -1,10 +1,5 @@
 // @ts-nocheck
 /**
- * External dependencies
- */
-import { noop } from 'lodash';
-
-/**
  * WordPress dependencies
  */
 import { forwardRef } from '@wordpress/element';
@@ -14,6 +9,8 @@ import { forwardRef } from '@wordpress/element';
  */
 import { InputRange as BaseInputRange } from './styles/range-control-styles';
 import { useDebouncedHoverInteraction } from './utils';
+
+const noop = () => {};
 
 function InputRange(
 	{

--- a/packages/components/src/range-control/utils.js
+++ b/packages/components/src/range-control/utils.js
@@ -2,7 +2,7 @@
 /**
  * External dependencies
  */
-import { clamp, noop } from 'lodash';
+import { clamp } from 'lodash';
 
 /**
  * WordPress dependencies
@@ -13,6 +13,8 @@ import { useCallback, useRef, useEffect, useState } from '@wordpress/element';
  * Internal dependencies
  */
 import { useControlledState } from '../utils/hooks';
+
+const noop = () => {};
 
 /**
  * A float supported clamp function for a specific value.

--- a/packages/components/src/resizable-box/resize-tooltip/index.tsx
+++ b/packages/components/src/resizable-box/resize-tooltip/index.tsx
@@ -1,7 +1,6 @@
 /**
  * External dependencies
  */
-import { noop } from 'lodash';
 import classnames from 'classnames';
 import type { Ref, ForwardedRef } from 'react';
 
@@ -29,6 +28,8 @@ type ResizeTooltipProps = React.ComponentProps< typeof Root > & {
 	showPx?: boolean;
 	zIndex?: number;
 };
+
+const noop = () => {};
 
 function ResizeTooltip(
 	{

--- a/packages/components/src/resizable-box/resize-tooltip/utils.ts
+++ b/packages/components/src/resizable-box/resize-tooltip/utils.ts
@@ -1,15 +1,11 @@
 /**
- * External dependencies
- */
-import { noop } from 'lodash';
-
-/**
  * WordPress dependencies
  */
 import { useEffect, useRef, useState } from '@wordpress/element';
 import { useResizeObserver } from '@wordpress/compose';
 
 const { clearTimeout, setTimeout } = window;
+const noop = () => {};
 
 export type Axis = 'x' | 'y';
 

--- a/packages/components/src/select-control/index.tsx
+++ b/packages/components/src/select-control/index.tsx
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { isEmpty, noop } from 'lodash';
+import { isEmpty } from 'lodash';
 import classNames from 'classnames';
 import type { ChangeEvent, FocusEvent, ForwardedRef } from 'react';
 
@@ -20,6 +20,8 @@ import InputBase from '../input-control/input-base';
 import { Select, DownArrowWrapper } from './styles/select-control-styles';
 import type { WordPressComponentProps } from '../ui/context';
 import type { SelectControlProps } from './types';
+
+const noop = () => {};
 
 function useUniqueId( idProp?: string ) {
 	const instanceId = useInstanceId( SelectControl );

--- a/packages/components/src/snackbar/index.js
+++ b/packages/components/src/snackbar/index.js
@@ -1,7 +1,6 @@
 /**
  * External dependencies
  */
-import { noop } from 'lodash';
 import classnames from 'classnames';
 
 /**
@@ -17,6 +16,7 @@ import warning from '@wordpress/warning';
  */
 import { Button } from '../';
 
+const noop = () => {};
 const NOTICE_TIMEOUT = 10000;
 
 /** @typedef {import('@wordpress/element').WPElement} WPElement */

--- a/packages/components/src/snackbar/list.js
+++ b/packages/components/src/snackbar/list.js
@@ -2,7 +2,7 @@
  * External dependencies
  */
 import classnames from 'classnames';
-import { omit, noop } from 'lodash';
+import { omit } from 'lodash';
 
 /**
  * WordPress dependencies
@@ -19,6 +19,7 @@ import {
 	__unstableAnimatePresence as AnimatePresence,
 } from '../animation';
 
+const noop = () => {};
 const SNACKBAR_VARIANTS = {
 	init: {
 		height: 0,

--- a/packages/components/src/tab-panel/index.js
+++ b/packages/components/src/tab-panel/index.js
@@ -2,7 +2,7 @@
  * External dependencies
  */
 import classnames from 'classnames';
-import { partial, noop, find } from 'lodash';
+import { partial, find } from 'lodash';
 
 /**
  * WordPress dependencies
@@ -15,6 +15,8 @@ import { useInstanceId } from '@wordpress/compose';
  */
 import { NavigableMenu } from '../navigable-container';
 import Button from '../button';
+
+const noop = () => {};
 
 const TabButton = ( { tabId, onClick, children, selected, ...rest } ) => (
 	<Button

--- a/packages/components/src/utils/hooks/test/use-controlled-state.js
+++ b/packages/components/src/utils/hooks/test/use-controlled-state.js
@@ -2,12 +2,13 @@
  * External dependencies
  */
 import { render, fireEvent, screen } from '@testing-library/react';
-import { noop } from 'lodash';
 
 /**
  * Internal dependencies
  */
 import useControlledState from '../use-controlled-state';
+
+const noop = () => {};
 
 describe( 'hooks', () => {
 	const getInput = () => screen.getByTestId( 'input' );

--- a/packages/dependency-extraction-webpack-plugin/test/__snapshots__/build.js.snap
+++ b/packages/dependency-extraction-webpack-plugin/test/__snapshots__/build.js.snap
@@ -32,17 +32,12 @@ Array [
 `;
 
 exports[`DependencyExtractionWebpackPlugin Webpack \`dynamic-import\` should produce expected output: Asset file 'main.asset.php' should match snapshot 1`] = `
-"<?php return array('dependencies' => array('lodash', 'wp-blob'), 'version' => '3b0a96e3e47e0db92969');
+"<?php return array('dependencies' => array('wp-blob'), 'version' => 'c8be4fceac30d1d00ca7');
 "
 `;
 
 exports[`DependencyExtractionWebpackPlugin Webpack \`dynamic-import\` should produce expected output: External modules should match snapshot 1`] = `
 Array [
-  Object {
-    "externalType": "window",
-    "request": "lodash",
-    "userRequest": "lodash",
-  },
   Object {
     "externalType": "window",
     "request": Array [

--- a/packages/dependency-extraction-webpack-plugin/test/fixtures/dynamic-import/index.js
+++ b/packages/dependency-extraction-webpack-plugin/test/fixtures/dynamic-import/index.js
@@ -1,6 +1,1 @@
-/**
- * External dependencies
- */
-import _ from 'lodash';
-
-import( './util' ).then( _.noop );
+import( './util' ).then( () => {} );

--- a/packages/dom/src/dom/clean-node-list.js
+++ b/packages/dom/src/dom/clean-node-list.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { includes, noop } from 'lodash';
+import { includes } from 'lodash';
 
 /**
  * Internal dependencies
@@ -12,6 +12,8 @@ import unwrap from './unwrap';
 import { isPhrasingContent } from '../phrasing-content';
 import insertAfter from './insert-after';
 import isElement from './is-element';
+
+const noop = () => {};
 
 /* eslint-disable jsdoc/valid-types */
 /**

--- a/packages/edit-navigation/src/components/menu-switcher/index.js
+++ b/packages/edit-navigation/src/components/menu-switcher/index.js
@@ -1,9 +1,4 @@
 /**
- * External dependencies
- */
-import { noop } from 'lodash';
-
-/**
  * WordPress dependencies
  */
 import {
@@ -20,6 +15,8 @@ import { decodeEntities } from '@wordpress/html-entities';
  * Internal dependencies
  */
 import AddMenu from '../add-menu';
+
+const noop = () => {};
 
 export default function MenuSwitcher( {
 	menus,

--- a/packages/edit-post/src/components/keyboard-shortcut-help-modal/test/index.js
+++ b/packages/edit-post/src/components/keyboard-shortcut-help-modal/test/index.js
@@ -1,13 +1,14 @@
 /**
  * External dependencies
  */
-import { noop } from 'lodash';
 import { shallow } from 'enzyme';
 
 /**
  * Internal dependencies
  */
 import { KeyboardShortcutHelpModal } from '../index';
+
+const noop = () => {};
 
 describe( 'KeyboardShortcutHelpModal', () => {
 	it( 'should match snapshot when the modal is active', () => {

--- a/packages/edit-post/src/components/visual-editor/block-inspector-button.js
+++ b/packages/edit-post/src/components/visual-editor/block-inspector-button.js
@@ -1,9 +1,4 @@
 /**
- * External dependencies
- */
-import { noop } from 'lodash';
-
-/**
  * WordPress dependencies
  */
 import { __ } from '@wordpress/i18n';
@@ -16,6 +11,8 @@ import { store as keyboardShortcutsStore } from '@wordpress/keyboard-shortcuts';
  * Internal dependencies
  */
 import { store as editPostStore } from '../../store';
+
+const noop = () => {};
 
 export function BlockInspectorButton( { onClick = noop, small = false } ) {
 	const { shortcut, areAdvancedSettingsOpened } = useSelect(

--- a/packages/edit-site/src/components/global-styles/gradients-palette-panel.js
+++ b/packages/edit-site/src/components/global-styles/gradients-palette-panel.js
@@ -1,9 +1,4 @@
 /**
- * External dependencies
- */
-import { noop } from 'lodash';
-
-/**
  * WordPress dependencies
  */
 import {
@@ -19,6 +14,8 @@ import { __ } from '@wordpress/i18n';
  */
 import { useSetting } from './hooks';
 import Subtitle from './subtitle';
+
+const noop = () => {};
 
 export default function GradientPalettePanel( { name } ) {
 	const [ themeGradients, setThemeGradients ] = useSetting(

--- a/packages/editor/src/components/post-publish-button/index.js
+++ b/packages/editor/src/components/post-publish-button/index.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { noop, get, some } from 'lodash';
+import { get, some } from 'lodash';
 import classnames from 'classnames';
 
 /**
@@ -18,6 +18,8 @@ import { __ } from '@wordpress/i18n';
  */
 import PublishButtonLabel from './label';
 import { store as editorStore } from '../../store';
+
+const noop = () => {};
 
 export class PostPublishButton extends Component {
 	constructor( props ) {

--- a/packages/editor/src/utils/media-upload/index.js
+++ b/packages/editor/src/utils/media-upload/index.js
@@ -1,9 +1,4 @@
 /**
- * External dependencies
- */
-import { noop } from 'lodash';
-
-/**
  * WordPress dependencies
  */
 import { select } from '@wordpress/data';
@@ -13,6 +8,8 @@ import { uploadMedia } from '@wordpress/media-utils';
  * Internal dependencies
  */
 import { store as editorStore } from '../../store';
+
+const noop = () => {};
 
 /**
  * Upload a media file when the file upload button is activated.

--- a/packages/element/src/test/serialize.js
+++ b/packages/element/src/test/serialize.js
@@ -1,9 +1,4 @@
 /**
- * External dependencies
- */
-import { noop } from 'lodash';
-
-/**
  * Internal dependencies
  */
 import {
@@ -23,6 +18,8 @@ import serialize, {
 	renderAttributes,
 	renderStyle,
 } from '../serialize';
+
+const noop = () => {};
 
 describe( 'serialize()', () => {
 	it( 'should allow only valid attribute names', () => {

--- a/packages/interface/src/components/action-item/index.js
+++ b/packages/interface/src/components/action-item/index.js
@@ -1,13 +1,15 @@
 /**
  * External dependencies
  */
-import { isEmpty, noop } from 'lodash';
+import { isEmpty } from 'lodash';
 
 /**
  * WordPress dependencies
  */
 import { ButtonGroup, Button, Slot, Fill } from '@wordpress/components';
 import { Children } from '@wordpress/element';
+
+const noop = () => {};
 
 function ActionItemSlot( {
 	name,

--- a/packages/media-utils/src/utils/upload-media.js
+++ b/packages/media-utils/src/utils/upload-media.js
@@ -9,7 +9,6 @@ import {
 	has,
 	includes,
 	map,
-	noop,
 	omit,
 	some,
 	startsWith,
@@ -21,6 +20,8 @@ import {
 import apiFetch from '@wordpress/api-fetch';
 import { createBlobURL, revokeBlobURL } from '@wordpress/blob';
 import { __, sprintf } from '@wordpress/i18n';
+
+const noop = () => {};
 
 /**
  * Browsers may use unexpected mime types, and they differ from browser to browser.

--- a/packages/nux/src/components/dot-tip/test/index.js
+++ b/packages/nux/src/components/dot-tip/test/index.js
@@ -2,12 +2,13 @@
  * External dependencies
  */
 import { shallow } from 'enzyme';
-import { noop } from 'lodash';
 
 /**
  * Internal dependencies
  */
 import { DotTip } from '..';
+
+const noop = () => {};
 
 describe( 'DotTip', () => {
 	it( 'should not render anything if invisible', () => {

--- a/packages/rich-text/src/test/get-format-type.js
+++ b/packages/rich-text/src/test/get-format-type.js
@@ -1,15 +1,12 @@
 /**
- * External dependencies
- */
-import { noop } from 'lodash';
-
-/**
  * Internal dependencies
  */
 import { getFormatType } from '../get-format-type';
 import { unregisterFormatType } from '../unregister-format-type';
 import { registerFormatType } from '../register-format-type';
 import { getFormatTypes } from '../get-format-types';
+
+const noop = () => {};
 
 describe( 'getFormatType', () => {
 	beforeAll( () => {

--- a/packages/rich-text/src/test/get-format-types.js
+++ b/packages/rich-text/src/test/get-format-types.js
@@ -1,14 +1,11 @@
 /**
- * External dependencies
- */
-import { noop } from 'lodash';
-
-/**
  * Internal dependencies
  */
 import { getFormatTypes } from '../get-format-types';
 import { unregisterFormatType } from '../unregister-format-type';
 import { registerFormatType } from '../register-format-type';
+
+const noop = () => {};
 
 describe( 'getFormatTypes', () => {
 	beforeAll( () => {

--- a/packages/rich-text/src/test/unregister-format-type.js
+++ b/packages/rich-text/src/test/unregister-format-type.js
@@ -1,15 +1,12 @@
 /**
- * External dependencies
- */
-import { noop } from 'lodash';
-
-/**
  * Internal dependencies
  */
 import { unregisterFormatType } from '../unregister-format-type';
 import { registerFormatType } from '../register-format-type';
 import { getFormatTypes } from '../get-format-types';
 import { getFormatType } from '../get-format-type';
+
+const noop = () => {};
 
 describe( 'unregisterFormatType', () => {
 	const defaultFormatSettings = {


### PR DESCRIPTION
## What?
Lodash's `noop` is the most used Lodash method in this repository. It's also one of the simplest: it's just an empty function that takes no arguments and returns nothing. This PR aims to remove that usage. While it might look like a large one, it really does the same thing for all `noop` occurrences.


## Why?
Lodash is known to unnecessarily inflate the bundle size of packages, and in most cases, it can be replaced with native language functionality. See these for more information and rationale:

* https://github.com/WordPress/gutenberg/issues/16938#issuecomment-602837246
* https://github.com/WordPress/gutenberg/issues/17025
* https://github.com/WordPress/gutenberg/issues/39495 

## How?
Removing `noop` is straightforward in favor of a simple function with no arguments and an empty body that returns nothing. I've made a conscious decision here not to abstract our own function and reuse it everywhere because that would needlessly complicate the dependency graph. Instead, I've declared a `noop` function inline per component where necessary, and that way we get the best of both worlds: we have no additional dependencies, but still, we prevent extra re-renders because `noop` will always be the same within each component.

## Testing Instructions
Verify all tests still pass. 

## Notes

~Seems like there is a JS unit test failure, but it's unrelated, and seems to be caused by an obsolete version of `caniuse-lite`, I'm proposing a fix for it in #41675.~ #41675 has been merged, so unit tests will now pass.