### PR TITLE
[RNMobile] Fix missing translations for locales that include region (only on Android)

### DIFF
--- a/packages/react-native-editor/src/setup-locale.js
+++ b/packages/react-native-editor/src/setup-locale.js
@@ -22,6 +22,8 @@ export default (
 	pluginTranslations = []
 ) => {
 	const setDomainLocaleData = ( { getTranslation, domain = 'default' } ) => {
+		// Lowercase the locale value as translation filenames are also lowercased.
+		locale = locale?.toLowerCase();
 		let translations = getTranslation( locale );
 		if ( locale && ! translations ) {
 			// Try stripping out the regional


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

This PR fixes an issue related to missing translations for languages which locale include the region, specifically the following ones:
- `en-au` - English (Australia)
- `en-ca` - English (Canada)
- `en-gb` - English (UK)
- `en-nz` - English (New Zealand)
- `en-za` - English (South Africa)
- `es-ar` - Spanish (Argentina)
- `es-cl` - Spanish (Chile)
- `es-cr` - Spanish (Costa Rica)
- `nl-be` - Dutch (Belgium)
- `pt-br` - Portuguese (Brazil)
- `zh-cn` - Chinese (China)
- `zh-tw` - Chinese (Taiwan)

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

Addresses https://github.com/WordPress/gutenberg/issues/41667.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

<img align="right" width="200" src="https://user-images.githubusercontent.com/14905380/173319954-a4dbf4aa-eefe-4d69-a9c9-88fc2b5b1564.png">

The issue is caused due to fact that the region part of the locale on Android is uppercased, which leads to not finding the associated translation file, as their filenames are lowercased. As an example, when using Chinese (Taiwan) (locale `zh-tw`), the locale value passed to [`setDomainLocaleData`](https://github.com/WordPress/gutenberg/blob/9508b0a514a7725da36ab2b9a9b98ba9072bd9b4/packages/react-native-editor/src/setup-locale.js#L24) function is `zh-TW` but the filename of the translation file is `gutenberg/packages/react-native-editor/i18n-cache/data/zh-tw.json`.

In order to solve it, the locale value is lowercased so it can fetch the proper translation file.

<br clear="both"/>

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->
1. Change the device language to Chinese/Taiwan (i.e. `zh-tw`).
2. Open the app.
3. Open a post/page.
4. Tap on the ➕ button located in the toolbar.
5. Observe that the block titles within the block picker are translated.

## Screenshots or screencast <!-- if applicable -->

Before|After
--|--
<img src=https://user-images.githubusercontent.com/14905380/173316793-56126b7c-b41c-4978-be2a-d267b8ed4c91.png>|<img src=https://user-images.githubusercontent.com/14905380/173316819-2fafeb33-0793-430e-93bb-7e06db0c7ca9.png>

