### PR TITLE
URL: Remove all of Lodash from the package

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -18276,7 +18276,7 @@
 			"version": "file:packages/url",
 			"requires": {
 				"@babel/runtime": "^7.16.0",
-				"lodash": "^4.17.21"
+				"remove-accents": "^0.4.2"
 			}
 		},
 		"@wordpress/viewport": {
@@ -52224,6 +52224,11 @@
 			"version": "4.0.0",
 			"resolved": "https://registry.npmjs.org/rememo/-/rememo-4.0.0.tgz",
 			"integrity": "sha512-6BAfg1Dqg6UteZBEH9k6EHHersM86/EcBOMtJV+h+xEn1GC3H+gAgJWpexWYAamAxD0qXNmIt50iS/zuZKnQag=="
+		},
+		"remove-accents": {
+			"version": "0.4.2",
+			"resolved": "https://registry.npmjs.org/remove-accents/-/remove-accents-0.4.2.tgz",
+			"integrity": "sha512-7pXIJqJOq5tFgG1A2Zxti3Ht8jJF337m4sowbuHsW30ZnkQFnDzy9qBNhgzX8ZLW4+UBcXiiR7SwR6pokHsxiA=="
 		},
 		"remove-trailing-separator": {
 			"version": "1.1.0",

--- a/packages/url/package.json
+++ b/packages/url/package.json
@@ -28,7 +28,7 @@
 	"sideEffects": false,
 	"dependencies": {
 		"@babel/runtime": "^7.16.0",
-		"lodash": "^4.17.21"
+		"remove-accents": "^0.4.2"
 	},
 	"publishConfig": {
 		"access": "public"

--- a/packages/url/src/clean-for-slug.js
+++ b/packages/url/src/clean-for-slug.js
@@ -27,5 +27,5 @@ export function cleanForSlug( string ) {
 		.replace( /[\s\./]+/g, '-' )
 		.replace( /[^\p{L}\p{N}_-]+/gu, '' )
 		.toLowerCase()
-		.replace( /(^-)|(-$)/g, '' );
+		.replace( /(^-+)|(-+$)/g, '' );
 }

--- a/packages/url/src/clean-for-slug.js
+++ b/packages/url/src/clean-for-slug.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { deburr, trim } from 'lodash';
+import removeAccents from 'remove-accents';
 
 /**
  * Performs some basic cleanup of a string for use as a post slug.
@@ -23,11 +23,10 @@ export function cleanForSlug( string ) {
 	if ( ! string ) {
 		return '';
 	}
-	return trim(
-		deburr( string )
-			.replace( /[\s\./]+/g, '-' )
-			.replace( /[^\p{L}\p{N}_-]+/gu, '' )
-			.toLowerCase(),
-		'-'
-	);
+	return removeAccents( string )
+		.replace( /[\s\./]+/g, '-' )
+		.replace( /[^\p{L}\p{N}_-]+/gu, '' )
+		.toLowerCase()
+		.trim()
+		.replace( /(^-)|(-$)/g, '' );
 }

--- a/packages/url/src/clean-for-slug.js
+++ b/packages/url/src/clean-for-slug.js
@@ -23,9 +23,15 @@ export function cleanForSlug( string ) {
 	if ( ! string ) {
 		return '';
 	}
-	return removeAccents( string )
-		.replace( /[\s\./]+/g, '-' )
-		.replace( /[^\p{L}\p{N}_-]+/gu, '' )
-		.toLowerCase()
-		.replace( /(^-+)|(-+$)/g, '' );
+	return (
+		removeAccents( string )
+			// Convert each group of whitespace, periods, and forward slashes to a hyphen.
+			.replace( /[\s\./]+/g, '-' )
+			// Remove anything that's not a letter, number, underscore or hyphen.
+			.replace( /[^\p{L}\p{N}_-]+/gu, '' )
+			// Convert to lowercase
+			.toLowerCase()
+			// Remove any remaining leading or trailing hyphens.
+			.replace( /(^-+)|(-+$)/g, '' )
+	);
 }

--- a/packages/url/src/clean-for-slug.js
+++ b/packages/url/src/clean-for-slug.js
@@ -27,6 +27,5 @@ export function cleanForSlug( string ) {
 		.replace( /[\s\./]+/g, '-' )
 		.replace( /[^\p{L}\p{N}_-]+/gu, '' )
 		.toLowerCase()
-		.trim()
 		.replace( /(^-)|(-$)/g, '' );
 }

--- a/packages/url/src/test/index.js
+++ b/packages/url/src/test/index.js
@@ -1,9 +1,4 @@
 /**
- * External dependencies
- */
-import { every } from 'lodash';
-
-/**
  * Internal dependencies
  */
 import {
@@ -44,35 +39,37 @@ describe( 'isURL', () => {
 } );
 
 describe( 'isEmail', () => {
-	it( 'returns true when given things that look like an email', () => {
-		const emails = [
-			'simple@wordpress.org',
-			'very.common@wordpress.org',
-			'disposable.style.email.with+symbol@wordpress.org',
-			'other.email-with-hyphen@wordpress.org',
-			'fully-qualified-domain@wordpress.org',
-			'user.name+tag+sorting@wordpress.org',
-			'x@wordpress.org',
-			'wordpress-indeed@strange-wordpress.org',
-			'wordpress@s.wordpress',
-		];
+	it.each( [
+		'simple@wordpress.org',
+		'very.common@wordpress.org',
+		'disposable.style.email.with+symbol@wordpress.org',
+		'other.email-with-hyphen@wordpress.org',
+		'fully-qualified-domain@wordpress.org',
+		'user.name+tag+sorting@wordpress.org',
+		'x@wordpress.org',
+		'wordpress-indeed@strange-wordpress.org',
+		'wordpress@s.wordpress',
+		'1234567890123456789012345678901234567890123456789012345678901234+x@wordpress.org',
+	] )(
+		'returns true when given things that look like an email: %s',
+		( email ) => {
+			expect( isEmail( email ) ).toBe( true );
+		}
+	);
 
-		expect( every( emails, isEmail ) ).toBe( true );
-	} );
-
-	it( "returns false when given things that don't look like an email", () => {
-		const emails = [
-			'Abc.wordpress.org',
-			'A@b@c@wordpress.org',
-			'a"b(c)d,e:f;g<h>i[jk]l@wordpress.org',
-			'just"not"right@wordpress.org',
-			'this is"notallowed@wordpress.org',
-			'this still"not\\allowed@wordpress.org',
-			'1234567890123456789012345678901234567890123456789012345678901234+x@wordpress.org',
-		];
-
-		expect( every( emails, isEmail ) ).toBe( false );
-	} );
+	it.each( [
+		'Abc.wordpress.org',
+		'A@b@c@wordpress.org',
+		'a"b(c)d,e:f;g<h>i[jk]l@wordpress.org',
+		'just"not"right@wordpress.org',
+		'this is"notallowed@wordpress.org',
+		'this still"not\\allowed@wordpress.org',
+	] )(
+		"returns false when given things that don't look like an email: %s",
+		( email ) => {
+			expect( isEmail( email ) ).toBe( false );
+		}
+	);
 } );
 
 describe( 'getProtocol', () => {

--- a/packages/url/src/test/index.js
+++ b/packages/url/src/test/index.js
@@ -998,6 +998,12 @@ describe( 'cleanForSlug', () => {
 		expect( cleanForSlug( '안녕하세요 ' ) ).toBe( '안녕하세요' );
 		expect( cleanForSlug( '繁体字 ' ) ).toBe( '繁体字' );
 	} );
+
+	it( 'Should trim multiple leading and trailing dashes', () => {
+		expect( cleanForSlug( '  -Is th@t Déjà_vu- 	' ) ).toBe(
+			'is-tht-deja_vu'
+		);
+	} );
 } );
 
 describe( 'normalizePath', () => {


### PR DESCRIPTION
## What?
This PR removes all of the Lodash from the `@wordpress/url` package. There are just a few usages and conversion is pretty straightforward.

Fixes #39495.

## Why?
Lodash is a major part of the `@wordpress/url` package - [over 94%](https://bundlephobia.com/package/@wordpress/url@3.5.1). By removing it, we're drastically reducing the bundle size of that package and eventually all of the packages that depend on it (`@wordpress/api-fetch` being the obvious one to call out here - see #39495). It's one of the packages that have a utility on the frontend, and by keeping it small, we reduce the bytes that have to be downloaded for the end users of sites that use that package on the front end. Last, but not least, all the projects that use this package will also benefit from the smaller bundle size.

Furthermore, Lodash is known to unnecessarily inflate the bundle size of packages, and in most cases, it can be replaced with native language functionality. See these for more information and rationale:

* https://github.com/WordPress/gutenberg/issues/16938#issuecomment-602837246
* https://github.com/WordPress/gutenberg/issues/17025
* https://github.com/WordPress/gutenberg/issues/39495 

## How?
We have to deal essentially with 3 methods, and each of them is handled specifically:

### `deburr()`
The most complex one. Used to essentially convert accented characters to their non-accented versions. Luckily, I wrote a clone of WordPress core's PHP [`remove_accents()`](https://developer.wordpress.org/reference/functions/remove_accents/) a while ago, and [wrapped it as a package](https://www.npmjs.com/package/remove-accents). Simple as it is, it does all the conversion for us at little cost. It also comes with TS definitions.

### `trim()`

Used to remove all leading and trailing dashes. That's straightforward enough to replace with another simple `replace` call.

### `every()`

Used only in tests to verify all correct emails are considered correct emails, and all incorrect emails are considered incorrect emails by the `isEmail()` function.

However, these tests currently have a bug. `every()` will return `false` if even one of these is `false`, so the assertion that all of them are falsy is incorrect. This PR uses the opportunity to rewrite the incorrect assertions to separate tests (using `it.each`) and that way each of the emails is a separate test case. That allows us to catch the failing one that was being hidden under the ambiguous `every()` call. You'll notice that I'm moving the `1234567890123456789012345678901234567890123456789012345678901234+x@wordpress.org` email address that is actually valid according to the regex to the group of emails that are considered valid. The idea is to make tests pass since the tests were previously wrong, and not introduce any functional changes to the `isEmail()` function, since those are unrelated to the purpose of this PR.

If y'all would prefer that, I'm happy to follow up and introduce this backwards compatibility breaking change to `isEmail()` and provide a limit to the "local-part" of the email address so that email is considered invalid. However, I personally didn't see anything about a limit of the "local-part" of the email address in the [IME RFC (RFC5322)](https://datatracker.ietf.org/doc/html/rfc5322#section-3.4.1), so my personal preference would be to not touch the function and just adapt the tests, which I did in this PR.

## Testing Instructions

Verify all tests pass: `npm run test-unit packages/url`

