### PR TITLE
Lodash: Refactor away from `_.take()`

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -95,6 +95,7 @@ module.exports = {
 							'stubTrue',
 							'sum',
 							'sumBy',
+							'take',
 						],
 						message:
 							'This Lodash method is not recommended. Please use native functionality instead. If using `memoize`, please use `memize` instead.',

--- a/packages/block-editor/src/components/link-control/test/fixtures/index.js
+++ b/packages/block-editor/src/components/link-control/test/fixtures/index.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { uniqueId, take } from 'lodash';
+import { uniqueId } from 'lodash';
 
 export const fauxEntitySuggestions = [
 	{
@@ -41,7 +41,7 @@ export const fetchFauxEntitySuggestions = (
 	{ isInitialSuggestions } = {}
 ) => {
 	const suggestions = isInitialSuggestions
-		? take( fauxEntitySuggestions, 3 )
+		? fauxEntitySuggestions.slice( 0, 3 )
 		: fauxEntitySuggestions;
 	return Promise.resolve( suggestions );
 };

--- a/packages/components/src/form-token-field/index.tsx
+++ b/packages/components/src/form-token-field/index.tsx
@@ -3,7 +3,6 @@
  */
 import {
 	last,
-	take,
 	clone,
 	uniq,
 	map,
@@ -498,7 +497,7 @@ export function FormTokenField( props: FormTokenFieldProps ) {
 			_suggestions = startsWithMatch.concat( containsMatch );
 		}
 
-		return take( _suggestions, _maxSuggestions );
+		return _suggestions.slice( 0, _maxSuggestions );
 	}
 
 	function getSelectedSuggestion() {

--- a/packages/components/src/mobile/segmented-control/index.native.js
+++ b/packages/components/src/mobile/segmented-control/index.native.js
@@ -9,7 +9,7 @@ import {
 	Animated,
 	Easing,
 } from 'react-native';
-import { take, values, map, reduce } from 'lodash';
+import { values, map, reduce } from 'lodash';
 /**
  * WordPress dependencies
  */
@@ -103,7 +103,7 @@ const SegmentedControls = ( {
 			? styles.containerIOS
 			: styles.container;
 		const widths = map( values( segmentsDimensions ), 'width' );
-		const widthsDistance = take( widths, index );
+		const widthsDistance = widths.slice( 0, index );
 		const widthsDistanceSum = reduce(
 			widthsDistance,
 			( sum, n ) => sum + n


### PR DESCRIPTION
## What?
Lodash's `take` is used only a few times in the entire codebase. This PR aims to remove that usage.

## Why?
Lodash is known to unnecessarily inflate the bundle size of packages, and in most cases, it can be replaced with native language functionality. See these for more information and rationale:

* https://github.com/WordPress/gutenberg/issues/16938#issuecomment-602837246
* https://github.com/WordPress/gutenberg/issues/17025
* https://github.com/WordPress/gutenberg/issues/39495 

## How?
Removing `take` is straightforward in favor of a simple `Array.prototype.slice()` replacement.

## Testing Instructions
* Add a post on a site with more than 20 terms that share a similar keyword and when adding terms, use that keyword and verify suggestions still appear and are limited to the first 20 terms.
* Verify these tests still pass: `npm run test-unit packages/block-editor/src/components/link-control`
* Follow https://github.com/WordPress/gutenberg/pull/21326#issuecomment-617145882 and make sure segmented controls inside color settings still work well.