### PR TITLE
Lodash: Refactor away from `_.isObjectLike()`

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -86,6 +86,7 @@ module.exports = {
 							'isArray',
 							'isFinite',
 							'isFunction',
+							'isObjectLike',
 							'isUndefined',
 							'memoize',
 							'negate',

--- a/packages/blocks/src/api/factory.js
+++ b/packages/blocks/src/api/factory.js
@@ -6,7 +6,6 @@ import {
 	every,
 	castArray,
 	some,
-	isObjectLike,
 	filter,
 	first,
 	flatMap,
@@ -541,7 +540,10 @@ export function switchToBlockType( blocks, name ) {
 
 	// Ensure that the transformation function returned an object or an array
 	// of objects.
-	if ( ! isObjectLike( transformationResults ) ) {
+	if (
+		transformationResults === null ||
+		typeof transformationResults !== 'object'
+	) {
 		return null;
 	}
 

--- a/packages/core-data/src/utils/with-weak-map-cache.js
+++ b/packages/core-data/src/utils/with-weak-map-cache.js
@@ -1,9 +1,4 @@
 /**
- * External dependencies
- */
-import { isObjectLike } from 'lodash';
-
-/**
  * Given a function, returns an enhanced function which caches the result and
  * tracks in WeakMap. The result is only cached if the original function is
  * passed a valid object-like argument (requirement for WeakMap key).
@@ -25,7 +20,7 @@ function withWeakMapCache( fn ) {
 			// Can reach here if key is not valid for WeakMap, since `has`
 			// will return false for invalid key. Since `set` will throw,
 			// ensure that key is valid before setting into cache.
-			if ( isObjectLike( key ) ) {
+			if ( key !== null && typeof key === 'object' ) {
 				cache.set( key, value );
 			}
 		}


### PR DESCRIPTION
## What?
Lodash's `isObjectLike()` is used only a couple of times in the entire codebase. This PR aims to remove that usage.

## Why?
Lodash is known to unnecessarily inflate the bundle size of packages, and in most cases, it can be replaced with native language functionality. See these for more information and rationale:

* https://github.com/WordPress/gutenberg/issues/16938#issuecomment-602837246
* https://github.com/WordPress/gutenberg/issues/17025
* https://github.com/WordPress/gutenberg/issues/39495 

## How?
`isObjectLike` is straightforward to replace it with a `typeof value === 'object' && value !== null`. The `null` check is needed because `typeof null` yields `object` too. This PR replaces both usages. 

## Testing Instructions
* Verify blocks API tests pass `npm run test-unit packages/blocks/src/api/`
* Verify `core-data` utils tests pass: `npm run test-unit packages/core-data/src/utils/`