### PR TITLE
Lodash: Refactor away from `_.trim()`

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -96,6 +96,7 @@ module.exports = {
 							'sum',
 							'sumBy',
 							'take',
+							'trim',
 						],
 						message:
 							'This Lodash method is not recommended. Please use native functionality instead. If using `memoize`, please use `memize` instead.',

--- a/package-lock.json
+++ b/package-lock.json
@@ -16740,7 +16740,8 @@
 				"lodash": "^4.17.21",
 				"memize": "^1.1.0",
 				"micromodal": "^0.4.10",
-				"moment": "^2.22.1"
+				"moment": "^2.22.1",
+				"remove-accents": "^0.4.2"
 			},
 			"dependencies": {
 				"colord": {

--- a/packages/block-library/package.json
+++ b/packages/block-library/package.json
@@ -66,7 +66,8 @@
 		"lodash": "^4.17.21",
 		"memize": "^1.1.0",
 		"micromodal": "^0.4.10",
-		"moment": "^2.22.1"
+		"moment": "^2.22.1",
+		"remove-accents": "^0.4.2"
 	},
 	"peerDependencies": {
 		"react": "^17.0.0",

--- a/packages/block-library/src/heading/autogenerate-anchors.js
+++ b/packages/block-library/src/heading/autogenerate-anchors.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { deburr, trim } from 'lodash';
+import removeAccents from 'remove-accents';
 
 /**
  * Object map tracking anchors.
@@ -32,11 +32,14 @@ const getTextWithoutMarkup = ( text ) => {
  */
 const getSlug = ( content ) => {
 	// Get the slug.
-	return trim(
-		deburr( getTextWithoutMarkup( content ) )
+	return (
+		removeAccents( getTextWithoutMarkup( content ) )
+			// Convert anything that's not a letter or number to a hyphen.
 			.replace( /[^\p{L}\p{N}]+/gu, '-' )
-			.toLowerCase(),
-		'-'
+			// Convert to lowercase
+			.toLowerCase()
+			// Remove any remaining leading or trailing hyphens.
+			.replace( /(^-+)|(-+$)/g, '' )
 	);
 };
 


### PR DESCRIPTION
## What?
Lodash's `trim` is used only once in the entire codebase. This PR aims to remove that usage.

## Why?
Lodash is known to unnecessarily inflate the bundle size of packages, and in most cases, it can be replaced with native language functionality. See these for more information and rationale:

* https://github.com/WordPress/gutenberg/issues/16938#issuecomment-602837246
* https://github.com/WordPress/gutenberg/issues/17025
* https://github.com/WordPress/gutenberg/issues/39495 

## How?
Removing `trim` is straightforward in favor of a simple `String.prototype.trim()` replacement. In the cases we need to trim and replace with another character (which our use case is), we use a simple regex replacement. We also use the opportunity to remove a `deburr()` call as we did in #41687. Finally, we're adding some comments to the regex part for comprehensibility, just like we did in #41687.

## Testing Instructions
* Add a Table of Contents block to a post.
* Add a couple of heading blocks with various characters in them
* Verify that the headings appear properly under the Table of Contents block
* Verify that each of the Table of Contents items anchors properly to the corresponding headings.