### PR TITLE
Lodash: Refactor away from `_.defaultTo()`

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -80,6 +80,7 @@ module.exports = {
 						name: 'lodash',
 						importNames: [
 							'concat',
+							'defaultTo',
 							'differenceWith',
 							'dropRight',
 							'findIndex',

--- a/packages/customize-widgets/src/components/sidebar-block-editor/index.js
+++ b/packages/customize-widgets/src/components/sidebar-block-editor/index.js
@@ -1,9 +1,4 @@
 /**
- * External dependencies
- */
-import { defaultTo } from 'lodash';
-
-/**
  * WordPress dependencies
  */
 import { store as coreStore } from '@wordpress/core-data';
@@ -50,10 +45,8 @@ export default function SidebarBlockEditor( {
 	} = useSelect( ( select ) => {
 		const { get } = select( preferencesStore );
 		return {
-			hasUploadPermissions: defaultTo(
-				select( coreStore ).canUser( 'create', 'media' ),
-				true
-			),
+			hasUploadPermissions:
+				select( coreStore ).canUser( 'create', 'media' ) ?? true,
 			isFixedToolbarActive: !! get(
 				'core/customize-widgets',
 				'fixedToolbar'

--- a/packages/edit-widgets/src/components/widget-areas-block-editor-provider/index.js
+++ b/packages/edit-widgets/src/components/widget-areas-block-editor-provider/index.js
@@ -1,9 +1,4 @@
 /**
- * External dependencies
- */
-import { defaultTo } from 'lodash';
-
-/**
  * WordPress dependencies
  */
 import { SlotFillProvider } from '@wordpress/components';
@@ -41,10 +36,8 @@ export default function WidgetAreasBlockEditorProvider( {
 		keepCaretInsideBlock,
 	} = useSelect(
 		( select ) => ( {
-			hasUploadPermissions: defaultTo(
-				select( coreStore ).canUser( 'create', 'media' ),
-				true
-			),
+			hasUploadPermissions:
+				select( coreStore ).canUser( 'create', 'media' ) ?? true,
 			widgetAreas: select( editWidgetsStore ).getWidgetAreas(),
 			widgets: select( editWidgetsStore ).getWidgets(),
 			reusableBlocks: ALLOW_REUSABLE_BLOCKS

--- a/packages/editor/src/components/provider/use-block-editor-settings.js
+++ b/packages/editor/src/components/provider/use-block-editor-settings.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { pick, defaultTo, unionBy } from 'lodash';
+import { pick, unionBy } from 'lodash';
 
 /**
  * WordPress dependencies
@@ -52,10 +52,7 @@ function useBlockEditorSettings( settings, hasTemplate ) {
 						{ per_page: -1 }
 				  )
 				: [], // Reusable blocks are fetched in the native version of this hook.
-			hasUploadPermissions: defaultTo(
-				canUser( 'create', 'media' ),
-				true
-			),
+			hasUploadPermissions: canUser( 'create', 'media' ) ?? true,
 			userCanCreatePages: canUser( 'create', 'pages' ),
 			pageOnFront: siteSettings?.page_on_front,
 		};


### PR DESCRIPTION
## What?
Lodash's `defaultTo()` is used only a few times in the entire codebase. This PR aims to remove that usage.

## Why?
Lodash is known to unnecessarily inflate the bundle size of packages, and in most cases, it can be replaced with native language functionality. See these for more information and rationale:

* https://github.com/WordPress/gutenberg/issues/16938#issuecomment-602837246
* https://github.com/WordPress/gutenberg/issues/17025
* https://github.com/WordPress/gutenberg/issues/39495 

## How?
Removing `defaultTo()` usages with just 2 arguments (which matches all of our usages) is straightforward in favor of simple optional chaining replacement.

## Testing Instructions
* Smoke test the post editor and verify it still loads correctly.
* Smoke test the widgets editor and verify it still loads correctly.