### PR TITLE
Rich text: remove empty text nodes from editable tree

### DIFF
--- a/packages/rich-text/src/test/__snapshots__/to-dom.js.snap
+++ b/packages/rich-text/src/test/__snapshots__/to-dom.js.snap
@@ -11,6 +11,20 @@ exports[`recordToDom should create a value with formatting 1`] = `
 </body>
 `;
 
+exports[`recordToDom should create a value with formatting 2`] = `
+Object {
+  "endPath": Array [
+    0,
+    0,
+    4,
+  ],
+  "startPath": Array [
+    0,
+    1,
+  ],
+}
+`;
+
 exports[`recordToDom should create a value with formatting for split tags 1`] = `
 <body>
   <em
@@ -20,6 +34,20 @@ exports[`recordToDom should create a value with formatting for split tags 1`] = 
   </em>
   
 </body>
+`;
+
+exports[`recordToDom should create a value with formatting for split tags 2`] = `
+Object {
+  "endPath": Array [
+    0,
+    0,
+    2,
+  ],
+  "startPath": Array [
+    0,
+    1,
+  ],
+}
 `;
 
 exports[`recordToDom should create a value with formatting with attributes 1`] = `
@@ -34,6 +62,20 @@ exports[`recordToDom should create a value with formatting with attributes 1`] =
 </body>
 `;
 
+exports[`recordToDom should create a value with formatting with attributes 2`] = `
+Object {
+  "endPath": Array [
+    0,
+    0,
+    4,
+  ],
+  "startPath": Array [
+    0,
+    1,
+  ],
+}
+`;
+
 exports[`recordToDom should create a value with image object 1`] = `
 <body>
   
@@ -42,6 +84,17 @@ exports[`recordToDom should create a value with image object 1`] = `
   />
   
 </body>
+`;
+
+exports[`recordToDom should create a value with image object 2`] = `
+Object {
+  "endPath": Array [
+    1,
+  ],
+  "startPath": Array [
+    1,
+  ],
+}
 `;
 
 exports[`recordToDom should create a value with image object and formatting 1`] = `
@@ -53,10 +106,22 @@ exports[`recordToDom should create a value with image object and formatting 1`] 
     <img
       src=""
     />
-    
   </em>
   
 </body>
+`;
+
+exports[`recordToDom should create a value with image object and formatting 2`] = `
+Object {
+  "endPath": Array [
+    0,
+    2,
+  ],
+  "startPath": Array [
+    0,
+    1,
+  ],
+}
 `;
 
 exports[`recordToDom should create a value with image object and text after 1`] = `
@@ -74,6 +139,19 @@ exports[`recordToDom should create a value with image object and text after 1`] 
 </body>
 `;
 
+exports[`recordToDom should create a value with image object and text after 2`] = `
+Object {
+  "endPath": Array [
+    1,
+    2,
+  ],
+  "startPath": Array [
+    0,
+    1,
+  ],
+}
+`;
+
 exports[`recordToDom should create a value with image object and text before 1`] = `
 <body>
   te
@@ -82,10 +160,21 @@ exports[`recordToDom should create a value with image object and text before 1`]
     <img
       src=""
     />
-    
   </em>
   
 </body>
+`;
+
+exports[`recordToDom should create a value with image object and text before 2`] = `
+Object {
+  "endPath": Array [
+    1,
+    2,
+  ],
+  "startPath": Array [
+    1,
+  ],
+}
 `;
 
 exports[`recordToDom should create a value with nested formatting 1`] = `
@@ -101,10 +190,38 @@ exports[`recordToDom should create a value with nested formatting 1`] = `
 </body>
 `;
 
+exports[`recordToDom should create a value with nested formatting 2`] = `
+Object {
+  "endPath": Array [
+    0,
+    0,
+    0,
+    4,
+  ],
+  "startPath": Array [
+    0,
+    0,
+    1,
+  ],
+}
+`;
+
 exports[`recordToDom should create a value without formatting 1`] = `
 <body>
   test
 </body>
+`;
+
+exports[`recordToDom should create a value without formatting 2`] = `
+Object {
+  "endPath": Array [
+    0,
+    4,
+  ],
+  "startPath": Array [
+    1,
+  ],
+}
 `;
 
 exports[`recordToDom should create an empty value 1`] = `
@@ -114,11 +231,33 @@ exports[`recordToDom should create an empty value 1`] = `
 </body>
 `;
 
+exports[`recordToDom should create an empty value 2`] = `
+Object {
+  "endPath": Array [
+    1,
+  ],
+  "startPath": Array [
+    1,
+  ],
+}
+`;
+
 exports[`recordToDom should create an empty value from empty tags 1`] = `
 <body>
   
   ﻿
 </body>
+`;
+
+exports[`recordToDom should create an empty value from empty tags 2`] = `
+Object {
+  "endPath": Array [
+    1,
+  ],
+  "startPath": Array [
+    1,
+  ],
+}
 `;
 
 exports[`recordToDom should disarm on* attribute 1`] = `
@@ -131,6 +270,17 @@ exports[`recordToDom should disarm on* attribute 1`] = `
 </body>
 `;
 
+exports[`recordToDom should disarm on* attribute 2`] = `
+Object {
+  "endPath": Array [
+    1,
+  ],
+  "startPath": Array [
+    1,
+  ],
+}
+`;
+
 exports[`recordToDom should disarm script 1`] = `
 <body>
   
@@ -139,6 +289,17 @@ exports[`recordToDom should disarm script 1`] = `
   />
   
 </body>
+`;
+
+exports[`recordToDom should disarm script 2`] = `
+Object {
+  "endPath": Array [
+    1,
+  ],
+  "startPath": Array [
+    1,
+  ],
+}
 `;
 
 exports[`recordToDom should filter format boundary attributes 1`] = `
@@ -152,6 +313,20 @@ exports[`recordToDom should filter format boundary attributes 1`] = `
 </body>
 `;
 
+exports[`recordToDom should filter format boundary attributes 2`] = `
+Object {
+  "endPath": Array [
+    0,
+    0,
+    4,
+  ],
+  "startPath": Array [
+    0,
+    1,
+  ],
+}
+`;
+
 exports[`recordToDom should handle br 1`] = `
 <body>
   
@@ -163,6 +338,17 @@ exports[`recordToDom should handle br 1`] = `
 </body>
 `;
 
+exports[`recordToDom should handle br 2`] = `
+Object {
+  "endPath": Array [
+    1,
+  ],
+  "startPath": Array [
+    1,
+  ],
+}
+`;
+
 exports[`recordToDom should handle br with formatting 1`] = `
 <body>
   <em
@@ -172,11 +358,23 @@ exports[`recordToDom should handle br with formatting 1`] = `
     <br
       data-rich-text-line-break="true"
     />
-    
   </em>
   
   ﻿
 </body>
+`;
+
+exports[`recordToDom should handle br with formatting 2`] = `
+Object {
+  "endPath": Array [
+    0,
+    2,
+  ],
+  "startPath": Array [
+    0,
+    1,
+  ],
+}
 `;
 
 exports[`recordToDom should handle br with text 1`] = `
@@ -189,18 +387,40 @@ exports[`recordToDom should handle br with text 1`] = `
 </body>
 `;
 
+exports[`recordToDom should handle br with text 2`] = `
+Object {
+  "endPath": Array [
+    2,
+  ],
+  "startPath": Array [
+    0,
+    2,
+  ],
+}
+`;
+
 exports[`recordToDom should handle double br 1`] = `
 <body>
   a
   <br
     data-rich-text-line-break="true"
   />
-  
   <br
     data-rich-text-line-break="true"
   />
   b
 </body>
+`;
+
+exports[`recordToDom should handle double br 2`] = `
+Object {
+  "endPath": Array [
+    3,
+  ],
+  "startPath": Array [
+    2,
+  ],
+}
 `;
 
 exports[`recordToDom should handle empty list value 1`] = `
@@ -212,6 +432,19 @@ exports[`recordToDom should handle empty list value 1`] = `
 </body>
 `;
 
+exports[`recordToDom should handle empty list value 2`] = `
+Object {
+  "endPath": Array [
+    0,
+    1,
+  ],
+  "startPath": Array [
+    0,
+    1,
+  ],
+}
+`;
+
 exports[`recordToDom should handle empty multiline value 1`] = `
 <body>
   <p>
@@ -219,6 +452,19 @@ exports[`recordToDom should handle empty multiline value 1`] = `
     ﻿
   </p>
 </body>
+`;
+
+exports[`recordToDom should handle empty multiline value 2`] = `
+Object {
+  "endPath": Array [
+    0,
+    1,
+  ],
+  "startPath": Array [
+    0,
+    1,
+  ],
+}
 `;
 
 exports[`recordToDom should handle middle empty list value 1`] = `
@@ -234,6 +480,19 @@ exports[`recordToDom should handle middle empty list value 1`] = `
     ﻿
   </li>
 </body>
+`;
+
+exports[`recordToDom should handle middle empty list value 2`] = `
+Object {
+  "endPath": Array [
+    1,
+    1,
+  ],
+  "startPath": Array [
+    1,
+    1,
+  ],
+}
 `;
 
 exports[`recordToDom should handle multiline list value 1`] = `
@@ -263,6 +522,24 @@ exports[`recordToDom should handle multiline list value 1`] = `
 </body>
 `;
 
+exports[`recordToDom should handle multiline list value 2`] = `
+Object {
+  "endPath": Array [
+    0,
+    1,
+    1,
+    1,
+    0,
+    0,
+    1,
+  ],
+  "startPath": Array [
+    0,
+    1,
+  ],
+}
+`;
+
 exports[`recordToDom should handle multiline value 1`] = `
 <body>
   <p>
@@ -274,12 +551,41 @@ exports[`recordToDom should handle multiline value 1`] = `
 </body>
 `;
 
+exports[`recordToDom should handle multiline value 2`] = `
+Object {
+  "endPath": Array [
+    1,
+    1,
+  ],
+  "startPath": Array [
+    0,
+    0,
+    1,
+  ],
+}
+`;
+
 exports[`recordToDom should handle multiline value with element selection 1`] = `
 <body>
   <li>
     one
   </li>
 </body>
+`;
+
+exports[`recordToDom should handle multiline value with element selection 2`] = `
+Object {
+  "endPath": Array [
+    0,
+    0,
+    3,
+  ],
+  "startPath": Array [
+    0,
+    0,
+    3,
+  ],
+}
 `;
 
 exports[`recordToDom should handle multiline value with empty 1`] = `
@@ -292,6 +598,19 @@ exports[`recordToDom should handle multiline value with empty 1`] = `
     ﻿
   </p>
 </body>
+`;
+
+exports[`recordToDom should handle multiline value with empty 2`] = `
+Object {
+  "endPath": Array [
+    1,
+    1,
+  ],
+  "startPath": Array [
+    1,
+    1,
+  ],
+}
 `;
 
 exports[`recordToDom should handle nested empty list value 1`] = `
@@ -308,18 +627,45 @@ exports[`recordToDom should handle nested empty list value 1`] = `
 </body>
 `;
 
+exports[`recordToDom should handle nested empty list value 2`] = `
+Object {
+  "endPath": Array [
+    0,
+    1,
+    0,
+    1,
+  ],
+  "startPath": Array [
+    0,
+    1,
+    0,
+    1,
+  ],
+}
+`;
+
 exports[`recordToDom should handle selection before br 1`] = `
 <body>
   a
   <br
     data-rich-text-line-break="true"
   />
-  
   <br
     data-rich-text-line-break="true"
   />
   b
 </body>
+`;
+
+exports[`recordToDom should handle selection before br 2`] = `
+Object {
+  "endPath": Array [
+    2,
+  ],
+  "startPath": Array [
+    2,
+  ],
+}
 `;
 
 exports[`recordToDom should ignore formats at line separator 1`] = `
@@ -338,10 +684,29 @@ exports[`recordToDom should ignore formats at line separator 1`] = `
 </body>
 `;
 
+exports[`recordToDom should ignore formats at line separator 2`] = `
+Object {
+  "endPath": Array [],
+  "startPath": Array [],
+}
+`;
+
 exports[`recordToDom should ignore manually added object replacement character 1`] = `
 <body>
   test
 </body>
+`;
+
+exports[`recordToDom should ignore manually added object replacement character 2`] = `
+Object {
+  "endPath": Array [
+    0,
+    4,
+  ],
+  "startPath": Array [
+    1,
+  ],
+}
 `;
 
 exports[`recordToDom should ignore manually added object replacement character with formatting 1`] = `
@@ -353,6 +718,20 @@ exports[`recordToDom should ignore manually added object replacement character w
   </em>
   
 </body>
+`;
+
+exports[`recordToDom should ignore manually added object replacement character with formatting 2`] = `
+Object {
+  "endPath": Array [
+    0,
+    0,
+    2,
+  ],
+  "startPath": Array [
+    0,
+    1,
+  ],
+}
 `;
 
 exports[`recordToDom should not error with overlapping formats (1) 1`] = `
@@ -371,6 +750,23 @@ exports[`recordToDom should not error with overlapping formats (1) 1`] = `
   </a>
   
 </body>
+`;
+
+exports[`recordToDom should not error with overlapping formats (1) 2`] = `
+Object {
+  "endPath": Array [
+    0,
+    0,
+    0,
+    1,
+  ],
+  "startPath": Array [
+    0,
+    0,
+    0,
+    1,
+  ],
+}
 `;
 
 exports[`recordToDom should not error with overlapping formats (2) 1`] = `
@@ -395,10 +791,39 @@ exports[`recordToDom should not error with overlapping formats (2) 1`] = `
 </body>
 `;
 
+exports[`recordToDom should not error with overlapping formats (2) 2`] = `
+Object {
+  "endPath": Array [
+    0,
+    0,
+    0,
+    1,
+  ],
+  "startPath": Array [
+    0,
+    0,
+    0,
+    1,
+  ],
+}
+`;
+
 exports[`recordToDom should preserve emoji 1`] = `
 <body>
   🍒
 </body>
+`;
+
+exports[`recordToDom should preserve emoji 2`] = `
+Object {
+  "endPath": Array [
+    0,
+    2,
+  ],
+  "startPath": Array [
+    1,
+  ],
+}
 `;
 
 exports[`recordToDom should preserve emoji in formatting 1`] = `
@@ -412,10 +837,37 @@ exports[`recordToDom should preserve emoji in formatting 1`] = `
 </body>
 `;
 
+exports[`recordToDom should preserve emoji in formatting 2`] = `
+Object {
+  "endPath": Array [
+    0,
+    0,
+    2,
+  ],
+  "startPath": Array [
+    0,
+    1,
+  ],
+}
+`;
+
 exports[`recordToDom should preserve non breaking space 1`] = `
 <body>
   test  test
 </body>
+`;
+
+exports[`recordToDom should preserve non breaking space 2`] = `
+Object {
+  "endPath": Array [
+    0,
+    5,
+  ],
+  "startPath": Array [
+    0,
+    5,
+  ],
+}
 `;
 
 exports[`recordToDom should remove padding 1`] = `
@@ -425,8 +877,31 @@ exports[`recordToDom should remove padding 1`] = `
 </body>
 `;
 
+exports[`recordToDom should remove padding 2`] = `
+Object {
+  "endPath": Array [
+    1,
+  ],
+  "startPath": Array [
+    1,
+  ],
+}
+`;
+
 exports[`recordToDom should replace characters to format HTML with space 1`] = `
 <body>
    
 </body>
+`;
+
+exports[`recordToDom should replace characters to format HTML with space 2`] = `
+Object {
+  "endPath": Array [
+    0,
+    1,
+  ],
+  "startPath": Array [
+    1,
+  ],
+}
 `;

--- a/packages/rich-text/src/test/__snapshots__/to-dom.js.snap
+++ b/packages/rich-text/src/test/__snapshots__/to-dom.js.snap
@@ -224,11 +224,9 @@ exports[`recordToDom should handle empty multiline value 1`] = `
 exports[`recordToDom should handle middle empty list value 1`] = `
 <body>
   <li>
-    
     ﻿
   </li>
   <li>
-    
     ﻿
   </li>
   <li>
@@ -299,7 +297,6 @@ exports[`recordToDom should handle multiline value with empty 1`] = `
 exports[`recordToDom should handle nested empty list value 1`] = `
 <body>
   <li>
-    
     ﻿
     <ul>
       <li>

--- a/packages/rich-text/src/test/helpers/index.js
+++ b/packages/rich-text/src/test/helpers/index.js
@@ -552,8 +552,8 @@ export const spec = [
 			endOffset: 0,
 			endContainer: element.querySelector( 'ul > li' ),
 		} ),
-		startPath: [ 0, 2, 0, 0, 0 ],
-		endPath: [ 0, 2, 0, 0, 0 ],
+		startPath: [ 0, 1, 0, 0, 0 ],
+		endPath: [ 0, 1, 0, 0, 0 ],
 		record: {
 			start: 1,
 			end: 1,

--- a/packages/rich-text/src/test/to-dom.js
+++ b/packages/rich-text/src/test/to-dom.js
@@ -21,19 +21,17 @@ describe( 'recordToDom', () => {
 		require( '../store' );
 	} );
 
-	spec.forEach(
-		( { description, multilineTag, record, startPath, endPath } ) => {
-			// eslint-disable-next-line jest/valid-title
-			it( description, () => {
-				const { body, selection } = toDom( {
-					value: record,
-					multilineTag,
-				} );
-				expect( body ).toMatchSnapshot();
-				expect( selection ).toEqual( { startPath, endPath } );
+	spec.forEach( ( { description, multilineTag, record } ) => {
+		// eslint-disable-next-line jest/valid-title
+		it( description, () => {
+			const { body, selection } = toDom( {
+				value: record,
+				multilineTag,
 			} );
-		}
-	);
+			expect( body ).toMatchSnapshot();
+			expect( selection ).toMatchSnapshot();
+		} );
+	} );
 } );
 
 describe( 'applyValue', () => {

--- a/packages/rich-text/src/to-dom.js
+++ b/packages/rich-text/src/to-dom.js
@@ -143,15 +143,17 @@ export function toDom( {
 		remove,
 		appendText,
 		onStartIndex( body, pointer ) {
-			const offset = pointer.nodeValue
-				? [ pointer.nodeValue.length ]
-				: null;
+			const offset =
+				typeof pointer.nodeValue !== 'undefined'
+					? [ pointer.nodeValue.length ]
+					: null;
 			startPath = createPathToNode( pointer, body, offset );
 		},
 		onEndIndex( body, pointer ) {
-			const offset = pointer.nodeValue
-				? [ pointer.nodeValue.length ]
-				: null;
+			const offset =
+				typeof pointer.nodeValue !== 'undefined'
+					? [ pointer.nodeValue.length ]
+					: null;
 			endPath = createPathToNode( pointer, body, offset );
 		},
 		isEditableTree,

--- a/packages/rich-text/src/to-dom.js
+++ b/packages/rich-text/src/to-dom.js
@@ -25,7 +25,11 @@ function createPathToNode( node, rootNode, path ) {
 		i++;
 	}
 
-	path = [ i, ...path ];
+	if ( ! path ) {
+		path = [ i + 1 ];
+	} else {
+		path = [ i, ...path ];
+	}
 
 	if ( parentNode !== rootNode ) {
 		path = createPathToNode( parentNode, rootNode, path );
@@ -139,14 +143,16 @@ export function toDom( {
 		remove,
 		appendText,
 		onStartIndex( body, pointer ) {
-			startPath = createPathToNode( pointer, body, [
-				pointer.nodeValue.length,
-			] );
+			const offset = pointer.nodeValue
+				? [ pointer.nodeValue.length ]
+				: null;
+			startPath = createPathToNode( pointer, body, offset );
 		},
 		onEndIndex( body, pointer ) {
-			endPath = createPathToNode( pointer, body, [
-				pointer.nodeValue.length,
-			] );
+			const offset = pointer.nodeValue
+				? [ pointer.nodeValue.length ]
+				: null;
+			endPath = createPathToNode( pointer, body, offset );
 		},
 		isEditableTree,
 		placeholder,

--- a/packages/rich-text/src/to-tree.js
+++ b/packages/rich-text/src/to-tree.js
@@ -146,17 +146,24 @@ export function toTree( {
 	const multilineFormat = { type: multilineTag };
 	const activeFormats = getActiveFormats( value );
 	const deepestActiveFormat = activeFormats[ activeFormats.length - 1 ];
+	const emptyNodes = [];
 
 	let lastSeparatorFormats;
 	let lastCharacterFormats;
 	let lastCharacter;
 
+	function appendEmpty( parent ) {
+		const node = append( parent, '' );
+		emptyNodes.push( node );
+		return node;
+	}
+
 	// If we're building a multiline tree, start off with a multiline element.
 	if ( multilineTag ) {
-		append( append( tree, { type: multilineTag } ), '' );
+		appendEmpty( append( tree, { type: multilineTag } ) );
 		lastCharacterFormats = lastSeparatorFormats = [ multilineFormat ];
 	} else {
-		append( tree, '' );
+		appendEmpty( tree );
 	}
 
 	for ( let i = 0; i < formatsLength; i++ ) {
@@ -260,11 +267,14 @@ export function toTree( {
 					} )
 				);
 
-				if ( isText( pointer ) && getText( pointer ).length === 0 ) {
-					remove( pointer );
-				}
+				emptyNodes.forEach( ( node ) => {
+					if ( getText( node ).length === 0 ) {
+						remove( node );
+					}
+				} );
+				emptyNodes.length = 0;
 
-				pointer = append( newNode, '' );
+				pointer = appendEmpty( newNode );
 			} );
 		}
 
@@ -311,7 +321,7 @@ export function toTree( {
 				);
 			}
 			// Ensure pointer is text node.
-			pointer = append( getParent( pointer ), '' );
+			pointer = appendEmpty( getParent( pointer ) );
 		} else if ( ! preserveWhiteSpace && character === '\n' ) {
 			pointer = append( getParent( pointer ), {
 				type: 'br',
@@ -323,7 +333,7 @@ export function toTree( {
 				object: true,
 			} );
 			// Ensure pointer is text node.
-			pointer = append( getParent( pointer ), '' );
+			pointer = appendEmpty( getParent( pointer ) );
 		} else if ( ! isText( pointer ) ) {
 			pointer = append( getParent( pointer ), character );
 		} else {

--- a/packages/rich-text/src/to-tree.js
+++ b/packages/rich-text/src/to-tree.js
@@ -201,16 +201,6 @@ export function toTree( {
 
 		let pointer = getLastChild( tree );
 
-		if ( shouldInsertPadding && character === LINE_SEPARATOR ) {
-			let node = pointer;
-
-			while ( ! isText( node ) ) {
-				node = getLastChild( node );
-			}
-
-			append( getParent( node ), ZWNBSP );
-		}
-
 		// Set selection for the start of line.
 		if ( lastCharacter === LINE_SEPARATOR ) {
 			let node = pointer;
@@ -226,6 +216,16 @@ export function toTree( {
 			if ( onEndIndex && end === i ) {
 				onEndIndex( tree, node );
 			}
+		}
+
+		if ( shouldInsertPadding && character === LINE_SEPARATOR ) {
+			let node = pointer;
+
+			while ( ! isText( node ) ) {
+				node = getLastChild( node );
+			}
+
+			append( getParent( node ), ZWNBSP );
 		}
 
 		if ( characterFormats ) {
@@ -285,7 +285,8 @@ export function toTree( {
 			continue;
 		}
 
-		// If there is selection at 0, handle it before characters are inserted.
+		// If there is selection at 0, handle it before characters are inserted,
+		// but after formatting is added.
 		if ( i === 0 ) {
 			if ( onStartIndex && start === 0 ) {
 				onStartIndex( tree, pointer );
@@ -320,8 +321,6 @@ export function toTree( {
 					} )
 				);
 			}
-			// Ensure pointer is text node.
-			pointer = appendEmpty( getParent( pointer ) );
 		} else if ( ! preserveWhiteSpace && character === '\n' ) {
 			pointer = append( getParent( pointer ), {
 				type: 'br',
@@ -332,8 +331,6 @@ export function toTree( {
 					: undefined,
 				object: true,
 			} );
-			// Ensure pointer is text node.
-			pointer = appendEmpty( getParent( pointer ) );
 		} else if ( ! isText( pointer ) ) {
 			pointer = append( getParent( pointer ), character );
 		} else {


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Attempt to remove empty nodes from rich text's editable tree. This is preparatory work for #41655, because React has problems reconciling with empty text nodes.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->

## Screenshots or screencast <!-- if applicable -->
