### PR TITLE
Lodash: Remove from plugins package

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17537,7 +17537,6 @@
 				"@wordpress/element": "file:packages/element",
 				"@wordpress/hooks": "file:packages/hooks",
 				"@wordpress/icons": "file:packages/icons",
-				"lodash": "^4.17.21",
 				"memize": "^1.1.0"
 			}
 		},

--- a/packages/plugins/package.json
+++ b/packages/plugins/package.json
@@ -30,7 +30,6 @@
 		"@wordpress/element": "file:../element",
 		"@wordpress/hooks": "file:../hooks",
 		"@wordpress/icons": "file:../icons",
-		"lodash": "^4.17.21",
 		"memize": "^1.1.0"
 	},
 	"peerDependencies": {

--- a/packages/plugins/src/components/plugin-area/index.js
+++ b/packages/plugins/src/components/plugin-area/index.js
@@ -1,7 +1,6 @@
 /**
  * External dependencies
  */
-import { map } from 'lodash';
 import memoize from 'memize';
 
 /**
@@ -67,8 +66,7 @@ class PluginArea extends Component {
 
 	getCurrentPluginsState() {
 		return {
-			plugins: map(
-				getPlugins( this.props.scope ),
+			plugins: getPlugins( this.props.scope ).map(
 				( { icon, name, render } ) => {
 					return {
 						Plugin: render,
@@ -110,7 +108,7 @@ class PluginArea extends Component {
 	render() {
 		return (
 			<div style={ { display: 'none' } }>
-				{ map( this.state.plugins, ( { context, Plugin } ) => (
+				{ this.state.plugins.map( ( { context, Plugin } ) => (
 					<PluginContextProvider
 						key={ context.name }
 						value={ context }


### PR DESCRIPTION
## What?
Lodash seems to have just a single use in the `@wordpress/plugins` package. This PR removes it and removes the `lodash` dependency from the package.

## Why?
Lodash is known to unnecessarily inflate the bundle size of packages, and in most cases, it can be replaced with native language functionality. See these for more information and rationale:

* https://github.com/WordPress/gutenberg/issues/16938#issuecomment-602837246
* https://github.com/WordPress/gutenberg/issues/17025
* https://github.com/WordPress/gutenberg/issues/39495 

## How?
Removing `map` is straightforward in favor of a simple `Array.prototype.map()` replacement.

## Testing Instructions
Verify that the plugin area in the post editor still loads correctly with and without any additional plugins.