### PR TITLE
Start with featured image in media placeholder

### DIFF
--- a/packages/block-editor/src/components/media-placeholder/index.js
+++ b/packages/block-editor/src/components/media-placeholder/index.js
@@ -71,6 +71,7 @@ export function MediaPlaceholder( {
 	onSelect,
 	onCancel,
 	onSelectURL,
+	onToggleFeaturedImage,
 	onDoubleClick,
 	onFilesPreUpload = noop,
 	onHTMLDrop = noop,
@@ -307,6 +308,22 @@ export function MediaPlaceholder( {
 		);
 	};
 
+	const renderFeaturedImageToggle = () => {
+		return (
+			onToggleFeaturedImage && (
+				<div className="block-editor-media-placeholder__url-input-container">
+					<Button
+						className="block-editor-media-placeholder__button"
+						onClick={ onToggleFeaturedImage }
+						variant="tertiary"
+					>
+						{ __( 'Use featured image' ) }
+					</Button>
+				</div>
+			)
+		);
+	};
+
 	const renderMediaUploadChecked = () => {
 		const defaultButton = ( { open } ) => {
 			return (
@@ -361,6 +378,7 @@ export function MediaPlaceholder( {
 									</Button>
 									{ uploadMediaLibraryButton }
 									{ renderUrlSelectionUI() }
+									{ renderFeaturedImageToggle() }
 									{ renderCancelLink() }
 								</>
 							);
@@ -389,6 +407,7 @@ export function MediaPlaceholder( {
 					</FormFileUpload>
 					{ uploadMediaLibraryButton }
 					{ renderUrlSelectionUI() }
+					{ renderFeaturedImageToggle() }
 					{ renderCancelLink() }
 				</>
 			);

--- a/packages/block-editor/src/components/media-placeholder/index.js
+++ b/packages/block-editor/src/components/media-placeholder/index.js
@@ -72,6 +72,7 @@ export function MediaPlaceholder( {
 	onCancel,
 	onSelectURL,
 	onToggleFeaturedImage,
+	hasFeaturedImage,
 	onDoubleClick,
 	onFilesPreUpload = noop,
 	onHTMLDrop = noop,
@@ -316,6 +317,7 @@ export function MediaPlaceholder( {
 						className="block-editor-media-placeholder__button"
 						onClick={ onToggleFeaturedImage }
 						variant="tertiary"
+						disabled={ ! hasFeaturedImage }
 					>
 						{ __( 'Use featured image' ) }
 					</Button>

--- a/packages/block-editor/src/components/media-placeholder/index.js
+++ b/packages/block-editor/src/components/media-placeholder/index.js
@@ -72,7 +72,6 @@ export function MediaPlaceholder( {
 	onCancel,
 	onSelectURL,
 	onToggleFeaturedImage,
-	hasFeaturedImage,
 	onDoubleClick,
 	onFilesPreUpload = noop,
 	onHTMLDrop = noop,
@@ -317,7 +316,6 @@ export function MediaPlaceholder( {
 						className="block-editor-media-placeholder__button"
 						onClick={ onToggleFeaturedImage }
 						variant="tertiary"
-						disabled={ ! hasFeaturedImage }
 					>
 						{ __( 'Use featured image' ) }
 					</Button>

--- a/packages/block-library/src/cover/edit/block-controls.js
+++ b/packages/block-library/src/cover/edit/block-controls.js
@@ -14,19 +14,19 @@ import { __ } from '@wordpress/i18n';
 /**
  * Internal dependencies
  */
-import { ALLOWED_MEDIA_TYPES, IMAGE_BACKGROUND_TYPE } from '../shared';
+import { ALLOWED_MEDIA_TYPES } from '../shared';
 
 export default function CoverBlockControls( {
 	attributes,
 	setAttributes,
 	onSelectMedia,
 	currentSettings,
+	toggleUseFeaturedImage,
 } ) {
 	const {
 		contentPosition,
 		id,
 		useFeaturedImage,
-		dimRatio,
 		minHeight,
 		minHeightUnit,
 	} = attributes;
@@ -63,17 +63,6 @@ export default function CoverBlockControls( {
 		} );
 	};
 
-	const toggleUseFeaturedImage = () => {
-		setAttributes( {
-			id: undefined,
-			url: undefined,
-			useFeaturedImage: ! useFeaturedImage,
-			dimRatio: dimRatio === 100 ? 50 : dimRatio,
-			backgroundType: useFeaturedImage
-				? IMAGE_BACKGROUND_TYPE
-				: undefined,
-		} );
-	};
 	return (
 		<>
 			<BlockControls group="block">

--- a/packages/block-library/src/cover/edit/block-controls.js
+++ b/packages/block-library/src/cover/edit/block-controls.js
@@ -23,13 +23,8 @@ export default function CoverBlockControls( {
 	currentSettings,
 	toggleUseFeaturedImage,
 } ) {
-	const {
-		contentPosition,
-		id,
-		useFeaturedImage,
-		minHeight,
-		minHeightUnit,
-	} = attributes;
+	const { contentPosition, id, useFeaturedImage, minHeight, minHeightUnit } =
+		attributes;
 	const { hasInnerBlocks, url } = currentSettings;
 
 	const [ prevMinHeightValue, setPrevMinHeightValue ] = useState( minHeight );

--- a/packages/block-library/src/cover/edit/cover-placeholder.js
+++ b/packages/block-library/src/cover/edit/cover-placeholder.js
@@ -16,6 +16,7 @@ export default function CoverPlaceholder( {
 	onSelectMedia,
 	onError,
 	style,
+	toggleUseFeaturedImage,
 } ) {
 	return (
 		<MediaPlaceholder
@@ -30,6 +31,7 @@ export default function CoverPlaceholder( {
 			accept="image/*,video/*"
 			allowedTypes={ ALLOWED_MEDIA_TYPES }
 			disableMediaButtons={ disableMediaButtons }
+			onToggleFeaturedImage={ toggleUseFeaturedImage }
 			onError={ onError }
 			style={ style }
 		>

--- a/packages/block-library/src/cover/edit/cover-placeholder.js
+++ b/packages/block-library/src/cover/edit/cover-placeholder.js
@@ -17,6 +17,7 @@ export default function CoverPlaceholder( {
 	onError,
 	style,
 	toggleUseFeaturedImage,
+	hasFeaturedImage,
 } ) {
 	return (
 		<MediaPlaceholder
@@ -32,6 +33,7 @@ export default function CoverPlaceholder( {
 			allowedTypes={ ALLOWED_MEDIA_TYPES }
 			disableMediaButtons={ disableMediaButtons }
 			onToggleFeaturedImage={ toggleUseFeaturedImage }
+			hasFeaturedImage={ hasFeaturedImage }
 			onError={ onError }
 			style={ style }
 		>

--- a/packages/block-library/src/cover/edit/cover-placeholder.js
+++ b/packages/block-library/src/cover/edit/cover-placeholder.js
@@ -17,7 +17,6 @@ export default function CoverPlaceholder( {
 	onError,
 	style,
 	toggleUseFeaturedImage,
-	hasFeaturedImage,
 } ) {
 	return (
 		<MediaPlaceholder
@@ -33,7 +32,6 @@ export default function CoverPlaceholder( {
 			allowedTypes={ ALLOWED_MEDIA_TYPES }
 			disableMediaButtons={ disableMediaButtons }
 			onToggleFeaturedImage={ toggleUseFeaturedImage }
-			hasFeaturedImage={ hasFeaturedImage }
 			onError={ onError }
 			style={ style }
 		>

--- a/packages/block-library/src/cover/edit/index.js
+++ b/packages/block-library/src/cover/edit/index.js
@@ -211,6 +211,18 @@ function CoverEdit( {
 		overlayColor,
 	};
 
+	const toggleUseFeaturedImage = () => {
+		setAttributes( {
+			id: undefined,
+			url: undefined,
+			useFeaturedImage: ! useFeaturedImage,
+			dimRatio: dimRatio === 100 ? 50 : dimRatio,
+			backgroundType: useFeaturedImage
+				? IMAGE_BACKGROUND_TYPE
+				: undefined,
+		} );
+	};
+
 	const blockControls = (
 		<CoverBlockControls
 			attributes={ attributes }
@@ -232,17 +244,6 @@ function CoverEdit( {
 			toggleUseFeaturedImage={ toggleUseFeaturedImage }
 		/>
 	);
-	const toggleUseFeaturedImage = () => {
-		setAttributes( {
-			id: undefined,
-			url: undefined,
-			useFeaturedImage: ! useFeaturedImage,
-			dimRatio: dimRatio === 100 ? 50 : dimRatio,
-			backgroundType: useFeaturedImage
-				? IMAGE_BACKGROUND_TYPE
-				: undefined,
-		} );
-	};
 
 	if ( ! useFeaturedImage && ! hasInnerBlocks && ! hasBackground ) {
 		return (

--- a/packages/block-library/src/cover/edit/index.js
+++ b/packages/block-library/src/cover/edit/index.js
@@ -217,6 +217,7 @@ function CoverEdit( {
 			setAttributes={ setAttributes }
 			onSelectMedia={ onSelectMedia }
 			currentSettings={ currentSettings }
+			toggleUseFeaturedImage={ toggleUseFeaturedImage }
 		/>
 	);
 
@@ -228,8 +229,20 @@ function CoverEdit( {
 			setOverlayColor={ setOverlayColor }
 			coverRef={ ref }
 			currentSettings={ currentSettings }
+			toggleUseFeaturedImage={ toggleUseFeaturedImage }
 		/>
 	);
+	const toggleUseFeaturedImage = () => {
+		setAttributes( {
+			id: undefined,
+			url: undefined,
+			useFeaturedImage: ! useFeaturedImage,
+			dimRatio: dimRatio === 100 ? 50 : dimRatio,
+			backgroundType: useFeaturedImage
+				? IMAGE_BACKGROUND_TYPE
+				: undefined,
+		} );
+	};
 
 	if ( ! useFeaturedImage && ! hasInnerBlocks && ! hasBackground ) {
 		return (
@@ -249,6 +262,7 @@ function CoverEdit( {
 						style={ {
 							minHeight: minHeightWithUnit || undefined,
 						} }
+						toggleUseFeaturedImage={ toggleUseFeaturedImage }
 					>
 						<div className="wp-block-cover__placeholder-background-options">
 							<ColorPalette
@@ -384,6 +398,7 @@ function CoverEdit( {
 					disableMediaButtons
 					onSelectMedia={ onSelectMedia }
 					onError={ onUploadError }
+					toggleUseFeaturedImage={ toggleUseFeaturedImage }
 				/>
 				<div { ...innerBlocksProps } />
 			</div>

--- a/packages/block-library/src/cover/edit/index.js
+++ b/packages/block-library/src/cover/edit/index.js
@@ -263,6 +263,7 @@ function CoverEdit( {
 							minHeight: minHeightWithUnit || undefined,
 						} }
 						toggleUseFeaturedImage={ toggleUseFeaturedImage }
+						hasFeaturedImage={ !! mediaUrl }
 					>
 						<div className="wp-block-cover__placeholder-background-options">
 							<ColorPalette
@@ -399,6 +400,7 @@ function CoverEdit( {
 					onSelectMedia={ onSelectMedia }
 					onError={ onUploadError }
 					toggleUseFeaturedImage={ toggleUseFeaturedImage }
+					hasFeaturedImage={ !! mediaUrl }
 				/>
 				<div { ...innerBlocksProps } />
 			</div>

--- a/packages/block-library/src/cover/edit/index.js
+++ b/packages/block-library/src/cover/edit/index.js
@@ -264,7 +264,6 @@ function CoverEdit( {
 							minHeight: minHeightWithUnit || undefined,
 						} }
 						toggleUseFeaturedImage={ toggleUseFeaturedImage }
-						hasFeaturedImage={ !! mediaUrl }
 					>
 						<div className="wp-block-cover__placeholder-background-options">
 							<ColorPalette
@@ -401,7 +400,6 @@ function CoverEdit( {
 					onSelectMedia={ onSelectMedia }
 					onError={ onUploadError }
 					toggleUseFeaturedImage={ toggleUseFeaturedImage }
-					hasFeaturedImage={ !! mediaUrl }
 				/>
 				<div { ...innerBlocksProps } />
 			</div>


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

This PR allows supporting media blocks to offer users the option to start 
with featured image from the placeholder state.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

To avoid having to pick another media to only then get the option and 
because the featured image is now hidden behind the "Add media" block 
control in the media replace flow.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

The PR adds a button to the media placeholder which only shows up if a 
handler is provided for clicking it. It is also implemented in the cover 
block because this block has a handler.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->

1. Make a post
2. Add a cover block
3. You should see the new "Use featured image" button
4. Click this button
5. Set a featured image for the post
6. Observe the block displays it 

## Screenshots or screencast <!-- if applicable -->

https://user-images.githubusercontent.com/107534/173602832-f88d482e-ac8f-4070-9fd7-4be63aff7769.mp4


