### PR TITLE
CustomSelectControl: refactor using ariakit

### DIFF
--- a/docs/manifest.json
+++ b/docs/manifest.json
@@ -738,9 +738,33 @@
 		"parent": "components"
 	},
 	{
+		"title": "CustomSelectControlArrow",
+		"slug": "custom-select-control-arrow",
+		"markdown_source": "../packages/components/src/custom-select-control-new/custom-select-control-arrow/README.md",
+		"parent": "components"
+	},
+	{
+		"title": "CustomSelectControlGroupLabel",
+		"slug": "custom-select-control-group-label",
+		"markdown_source": "../packages/components/src/custom-select-control-new/custom-select-control-group-label/README.md",
+		"parent": "components"
+	},
+	{
+		"title": "CustomSelectControlGroup",
+		"slug": "custom-select-control-group",
+		"markdown_source": "../packages/components/src/custom-select-control-new/custom-select-control-group/README.md",
+		"parent": "components"
+	},
+	{
 		"title": "CustomSelectControlItem",
 		"slug": "custom-select-control-item",
 		"markdown_source": "../packages/components/src/custom-select-control-new/custom-select-control-item/README.md",
+		"parent": "components"
+	},
+	{
+		"title": "CustomSelectControlSeparator",
+		"slug": "custom-select-control-separator",
+		"markdown_source": "../packages/components/src/custom-select-control-new/custom-select-control-separator/README.md",
 		"parent": "components"
 	},
 	{

--- a/docs/manifest.json
+++ b/docs/manifest.json
@@ -738,6 +738,18 @@
 		"parent": "components"
 	},
 	{
+		"title": "CustomSelectControlItem",
+		"slug": "custom-select-control-item",
+		"markdown_source": "../packages/components/src/custom-select-control-new/custom-select-control-item/README.md",
+		"parent": "components"
+	},
+	{
+		"title": "CustomSelectControl",
+		"slug": "custom-select-control",
+		"markdown_source": "../packages/components/src/custom-select-control-new/custom-select-control/README.md",
+		"parent": "components"
+	},
+	{
 		"title": "CustomSelectControl",
 		"slug": "custom-select-control",
 		"markdown_source": "../packages/components/src/custom-select-control/README.md",

--- a/package-lock.json
+++ b/package-lock.json
@@ -16699,6 +16699,7 @@
 				"@wordpress/primitives": "file:packages/primitives",
 				"@wordpress/rich-text": "file:packages/rich-text",
 				"@wordpress/warning": "file:packages/warning",
+				"ariakit": "2.0.0-next.36",
 				"classnames": "^2.3.1",
 				"colord": "^2.7.0",
 				"dom-scroll-into-view": "^1.2.1",
@@ -16728,6 +16729,33 @@
 						"@emotion/utils": "^1.0.0",
 						"csstype": "^3.0.2"
 					}
+				},
+				"@floating-ui/core": {
+					"version": "1.0.0",
+					"resolved": "https://registry.npmjs.org/@floating-ui/core/-/core-1.0.0.tgz",
+					"integrity": "sha512-sm3nW0hHAxTv3gRDdCH8rNVQxijF+qPFo5gAeXCErRjKC7Qc28lIQ3R9Vd7Gw+KgwfA7RhRydDFuGeI0peGq7A=="
+				},
+				"@floating-ui/dom": {
+					"version": "1.0.0",
+					"resolved": "https://registry.npmjs.org/@floating-ui/dom/-/dom-1.0.0.tgz",
+					"integrity": "sha512-PMqJvY5Fae8HVQgUqM+lidprS6p9LSvB0AUhCdYKqr3YCaV+WaWCeVNBtXPRY2YIdrgcsL2+vd5F07FxgihHUw==",
+					"requires": {
+						"@floating-ui/core": "^1.0.0"
+					}
+				},
+				"ariakit": {
+					"version": "2.0.0-next.36",
+					"resolved": "https://registry.npmjs.org/ariakit/-/ariakit-2.0.0-next.36.tgz",
+					"integrity": "sha512-H/ZqRgy5tGGKOcOsZ24lc5cBoQ83vgCFd+mC87UWdIEdYqhKNPPjFZona/V/l0SRtn9Mar+t93QbggyThOw6Qg==",
+					"requires": {
+						"@floating-ui/dom": "^1.0.0",
+						"ariakit-utils": "0.17.0-next.23"
+					}
+				},
+				"ariakit-utils": {
+					"version": "0.17.0-next.23",
+					"resolved": "https://registry.npmjs.org/ariakit-utils/-/ariakit-utils-0.17.0-next.23.tgz",
+					"integrity": "sha512-r6a8rvjTBNbdNVWhGm4XL8hTlpIlP0G+yJf3No48kK6QpR1JN9QinLI/wMwWwJnxDYfwnBhkbcROCqF7iT/4ig=="
 				},
 				"colord": {
 					"version": "2.8.0",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -53,6 +53,7 @@
 		"@wordpress/primitives": "file:../primitives",
 		"@wordpress/rich-text": "file:../rich-text",
 		"@wordpress/warning": "file:../warning",
+		"ariakit": "2.0.0-next.36",
 		"classnames": "^2.3.1",
 		"colord": "^2.7.0",
 		"dom-scroll-into-view": "^1.2.1",

--- a/packages/components/src/custom-select-control-new/custom-select-control-arrow/README.md
+++ b/packages/components/src/custom-select-control-new/custom-select-control-arrow/README.md
@@ -1,0 +1,3 @@
+# CustomSelectControlArrow
+
+TODO

--- a/packages/components/src/custom-select-control-new/custom-select-control-arrow/component.tsx
+++ b/packages/components/src/custom-select-control-new/custom-select-control-arrow/component.tsx
@@ -13,7 +13,7 @@ import { forwardRef } from '@wordpress/element';
  * Internal dependencies
  */
 import { useSelectControlArrow } from './hook';
-import { WordPressComponentProps } from '../../ui/context';
+import type { WordPressComponentProps } from '../../ui/context';
 import type { SelectControlArrowProps } from '../types';
 
 const UnforwardedSelectControlArrow = (

--- a/packages/components/src/custom-select-control-new/custom-select-control-arrow/component.tsx
+++ b/packages/components/src/custom-select-control-new/custom-select-control-arrow/component.tsx
@@ -1,0 +1,32 @@
+/**
+ * External dependencies
+ */
+import type { ForwardedRef } from 'react';
+import { SelectArrow } from 'ariakit/select';
+
+/**
+ * WordPress dependencies
+ */
+import { forwardRef } from '@wordpress/element';
+
+/**
+ * Internal dependencies
+ */
+import { useSelectControlArrow } from './hook';
+import { WordPressComponentProps } from '../../ui/context';
+import type { SelectControlArrowProps } from '../types';
+
+const UnforwardedSelectControlArrow = (
+	props: WordPressComponentProps< SelectControlArrowProps, 'span', false >,
+	forwardedRef: ForwardedRef< any >
+) => {
+	const allProps = useSelectControlArrow( props );
+
+	// TODO: investigate incompatibility with the "as" prop.
+	return <SelectArrow { ...allProps } ref={ forwardedRef } />;
+};
+
+// TODO: JSDocs
+export const SelectControlArrow = forwardRef( UnforwardedSelectControlArrow );
+
+export default SelectControlArrow;

--- a/packages/components/src/custom-select-control-new/custom-select-control-arrow/hook.ts
+++ b/packages/components/src/custom-select-control-new/custom-select-control-arrow/hook.ts
@@ -1,0 +1,30 @@
+/**
+ * WordPress dependencies
+ */
+import { useMemo } from '@wordpress/element';
+
+/**
+ * Internal dependencies
+ */
+import * as styles from '../styles';
+import type { WordPressComponentProps } from '../../ui/context';
+import { useCx } from '../../utils/hooks/use-cx';
+import { SelectControlArrowProps } from '../types';
+
+// TODO:
+// - should we allow polymorphism ?
+export const useSelectControlArrow = ( {
+	className,
+	...props
+}: WordPressComponentProps< SelectControlArrowProps, 'span', false > ) => {
+	const cx = useCx();
+	const arrowClassName = useMemo(
+		() => cx( styles.arrow, className ),
+		[ className, cx ]
+	);
+
+	return {
+		...props,
+		className: arrowClassName,
+	};
+};

--- a/packages/components/src/custom-select-control-new/custom-select-control-arrow/hook.ts
+++ b/packages/components/src/custom-select-control-new/custom-select-control-arrow/hook.ts
@@ -9,7 +9,7 @@ import { useMemo } from '@wordpress/element';
 import * as styles from '../styles';
 import type { WordPressComponentProps } from '../../ui/context';
 import { useCx } from '../../utils/hooks/use-cx';
-import { SelectControlArrowProps } from '../types';
+import type { SelectControlArrowProps } from '../types';
 
 // TODO:
 // - should we allow polymorphism ?

--- a/packages/components/src/custom-select-control-new/custom-select-control-arrow/index.ts
+++ b/packages/components/src/custom-select-control-new/custom-select-control-arrow/index.ts
@@ -1,0 +1,2 @@
+export { default } from './component';
+export { useSelectControlArrow } from './hook';

--- a/packages/components/src/custom-select-control-new/custom-select-control-group-label/README.md
+++ b/packages/components/src/custom-select-control-new/custom-select-control-group-label/README.md
@@ -1,0 +1,3 @@
+# CustomSelectControlGroupLabel
+
+TODO

--- a/packages/components/src/custom-select-control-new/custom-select-control-group-label/component.tsx
+++ b/packages/components/src/custom-select-control-new/custom-select-control-group-label/component.tsx
@@ -13,7 +13,7 @@ import { forwardRef } from '@wordpress/element';
  * Internal dependencies
  */
 import { useSelectControlGroupLabel } from './hook';
-import { WordPressComponentProps } from '../../ui/context';
+import type { WordPressComponentProps } from '../../ui/context';
 import type { SelectControlGroupLabelProps } from '../types';
 
 const UnforwardedSelectControlGroupLabel = (

--- a/packages/components/src/custom-select-control-new/custom-select-control-group-label/component.tsx
+++ b/packages/components/src/custom-select-control-new/custom-select-control-group-label/component.tsx
@@ -1,0 +1,38 @@
+/**
+ * External dependencies
+ */
+import type { ForwardedRef } from 'react';
+import { SelectGroupLabel } from 'ariakit/select';
+
+/**
+ * WordPress dependencies
+ */
+import { forwardRef } from '@wordpress/element';
+
+/**
+ * Internal dependencies
+ */
+import { useSelectControlGroupLabel } from './hook';
+import { WordPressComponentProps } from '../../ui/context';
+import type { SelectControlGroupLabelProps } from '../types';
+
+const UnforwardedSelectControlGroupLabel = (
+	props: WordPressComponentProps<
+		SelectControlGroupLabelProps,
+		'div',
+		false
+	>,
+	forwardedRef: ForwardedRef< any >
+) => {
+	const allProps = useSelectControlGroupLabel( props );
+
+	// TODO: investigate incompatibility with the "as" prop.
+	return <SelectGroupLabel { ...allProps } ref={ forwardedRef } />;
+};
+
+// TODO: JSDocs
+export const SelectControlGroupLabel = forwardRef(
+	UnforwardedSelectControlGroupLabel
+);
+
+export default SelectControlGroupLabel;

--- a/packages/components/src/custom-select-control-new/custom-select-control-group-label/hook.ts
+++ b/packages/components/src/custom-select-control-new/custom-select-control-group-label/hook.ts
@@ -1,0 +1,31 @@
+/**
+ * WordPress dependencies
+ */
+import { useMemo } from '@wordpress/element';
+
+/**
+ * Internal dependencies
+ */
+import * as styles from '../styles';
+import type { WordPressComponentProps } from '../../ui/context';
+import { useCx } from '../../utils/hooks/use-cx';
+import { SelectControlGroupLabelProps } from '../types';
+
+// TODO:
+// - should we use 'option' instead of `div` for props inheritance?
+// - should we allow polymorphism ?
+export const useSelectControlGroupLabel = ( {
+	className,
+	...props
+}: WordPressComponentProps< SelectControlGroupLabelProps, 'div', false > ) => {
+	const cx = useCx();
+	const groupLabelClassName = useMemo(
+		() => cx( styles.groupLabel, className ),
+		[ className, cx ]
+	);
+
+	return {
+		...props,
+		className: groupLabelClassName,
+	};
+};

--- a/packages/components/src/custom-select-control-new/custom-select-control-group-label/hook.ts
+++ b/packages/components/src/custom-select-control-new/custom-select-control-group-label/hook.ts
@@ -9,7 +9,7 @@ import { useMemo } from '@wordpress/element';
 import * as styles from '../styles';
 import type { WordPressComponentProps } from '../../ui/context';
 import { useCx } from '../../utils/hooks/use-cx';
-import { SelectControlGroupLabelProps } from '../types';
+import type { SelectControlGroupLabelProps } from '../types';
 
 // TODO:
 // - should we use 'option' instead of `div` for props inheritance?

--- a/packages/components/src/custom-select-control-new/custom-select-control-group-label/index.ts
+++ b/packages/components/src/custom-select-control-new/custom-select-control-group-label/index.ts
@@ -1,0 +1,2 @@
+export { default } from './component';
+export { useSelectControlGroupLabel } from './hook';

--- a/packages/components/src/custom-select-control-new/custom-select-control-group/README.md
+++ b/packages/components/src/custom-select-control-new/custom-select-control-group/README.md
@@ -1,0 +1,3 @@
+# CustomSelectControlGroup
+
+TODO

--- a/packages/components/src/custom-select-control-new/custom-select-control-group/component.tsx
+++ b/packages/components/src/custom-select-control-new/custom-select-control-group/component.tsx
@@ -1,0 +1,32 @@
+/**
+ * External dependencies
+ */
+import type { ForwardedRef } from 'react';
+import { SelectGroup } from 'ariakit/select';
+
+/**
+ * WordPress dependencies
+ */
+import { forwardRef } from '@wordpress/element';
+
+/**
+ * Internal dependencies
+ */
+import { useSelectControlGroup } from './hook';
+import { WordPressComponentProps } from '../../ui/context';
+import type { SelectControlGroupProps } from '../types';
+
+const UnforwardedSelectControlGroup = (
+	props: WordPressComponentProps< SelectControlGroupProps, 'div', false >,
+	forwardedRef: ForwardedRef< any >
+) => {
+	const allProps = useSelectControlGroup( props );
+
+	// TODO: investigate incompatibility with the "as" prop.
+	return <SelectGroup { ...allProps } ref={ forwardedRef } />;
+};
+
+// TODO: JSDocs
+export const SelectControlGroup = forwardRef( UnforwardedSelectControlGroup );
+
+export default SelectControlGroup;

--- a/packages/components/src/custom-select-control-new/custom-select-control-group/component.tsx
+++ b/packages/components/src/custom-select-control-new/custom-select-control-group/component.tsx
@@ -13,7 +13,7 @@ import { forwardRef } from '@wordpress/element';
  * Internal dependencies
  */
 import { useSelectControlGroup } from './hook';
-import { WordPressComponentProps } from '../../ui/context';
+import type { WordPressComponentProps } from '../../ui/context';
 import type { SelectControlGroupProps } from '../types';
 
 const UnforwardedSelectControlGroup = (

--- a/packages/components/src/custom-select-control-new/custom-select-control-group/hook.ts
+++ b/packages/components/src/custom-select-control-new/custom-select-control-group/hook.ts
@@ -1,0 +1,30 @@
+/**
+ * WordPress dependencies
+ */
+import { useMemo } from '@wordpress/element';
+
+/**
+ * Internal dependencies
+ */
+import * as styles from '../styles';
+import type { WordPressComponentProps } from '../../ui/context';
+import { useCx } from '../../utils/hooks/use-cx';
+import { SelectControlGroupProps } from '../types';
+
+// TODO:
+// - should we allow polymorphism ?
+export const useSelectControlGroup = ( {
+	className,
+	...props
+}: WordPressComponentProps< SelectControlGroupProps, 'div', false > ) => {
+	const cx = useCx();
+	const groupClassName = useMemo(
+		() => cx( styles.group, className ),
+		[ className, cx ]
+	);
+
+	return {
+		...props,
+		className: groupClassName,
+	};
+};

--- a/packages/components/src/custom-select-control-new/custom-select-control-group/hook.ts
+++ b/packages/components/src/custom-select-control-new/custom-select-control-group/hook.ts
@@ -9,7 +9,7 @@ import { useMemo } from '@wordpress/element';
 import * as styles from '../styles';
 import type { WordPressComponentProps } from '../../ui/context';
 import { useCx } from '../../utils/hooks/use-cx';
-import { SelectControlGroupProps } from '../types';
+import type { SelectControlGroupProps } from '../types';
 
 // TODO:
 // - should we allow polymorphism ?

--- a/packages/components/src/custom-select-control-new/custom-select-control-group/index.ts
+++ b/packages/components/src/custom-select-control-new/custom-select-control-group/index.ts
@@ -1,0 +1,2 @@
+export { default } from './component';
+export { useSelectControlGroup } from './hook';

--- a/packages/components/src/custom-select-control-new/custom-select-control-item-check/README.md
+++ b/packages/components/src/custom-select-control-new/custom-select-control-item-check/README.md
@@ -1,0 +1,3 @@
+# CustomSelectControlItemCheck
+
+TODO

--- a/packages/components/src/custom-select-control-new/custom-select-control-item-check/component.tsx
+++ b/packages/components/src/custom-select-control-new/custom-select-control-item-check/component.tsx
@@ -1,0 +1,37 @@
+/**
+ * External dependencies
+ */
+import type { ForwardedRef } from 'react';
+import { SelectItemCheck } from 'ariakit/select';
+
+/**
+ * WordPress dependencies
+ */
+import { forwardRef } from '@wordpress/element';
+
+/**
+ * Internal dependencies
+ */
+import { useSelectControlItemCheck } from './hook';
+import type { WordPressComponentProps } from '../../ui/context';
+import type { SelectControlItemCheckProps } from '../types';
+
+const UnforwardedSelectControlItemCheck = (
+	props: WordPressComponentProps<
+		SelectControlItemCheckProps,
+		'span',
+		false
+	>,
+	forwardedRef: ForwardedRef< any >
+) => {
+	const allProps = useSelectControlItemCheck( props );
+
+	return <SelectItemCheck { ...allProps } ref={ forwardedRef } />;
+};
+
+// TODO: JSDocs
+export const SelectControlItemCheck = forwardRef(
+	UnforwardedSelectControlItemCheck
+);
+
+export default SelectControlItemCheck;

--- a/packages/components/src/custom-select-control-new/custom-select-control-item-check/hook.ts
+++ b/packages/components/src/custom-select-control-new/custom-select-control-item-check/hook.ts
@@ -1,0 +1,28 @@
+/**
+ * WordPress dependencies
+ */
+import { useMemo } from '@wordpress/element';
+
+/**
+ * Internal dependencies
+ */
+import * as styles from '../styles';
+import type { WordPressComponentProps } from '../../ui/context';
+import { useCx } from '../../utils/hooks/use-cx';
+import type { SelectControlItemCheckProps } from '../types';
+
+export const useSelectControlItemCheck = ( {
+	className,
+	...props
+}: WordPressComponentProps< SelectControlItemCheckProps, 'span', false > ) => {
+	const cx = useCx();
+	const itemCheckClassName = useMemo(
+		() => cx( styles.itemCheck, className ),
+		[ className, cx ]
+	);
+
+	return {
+		...props,
+		className: itemCheckClassName,
+	};
+};

--- a/packages/components/src/custom-select-control-new/custom-select-control-item-check/index.ts
+++ b/packages/components/src/custom-select-control-new/custom-select-control-item-check/index.ts
@@ -1,0 +1,2 @@
+export { default } from './component';
+export { useSelectControlItemCheck } from './hook';

--- a/packages/components/src/custom-select-control-new/custom-select-control-item/README.md
+++ b/packages/components/src/custom-select-control-new/custom-select-control-item/README.md
@@ -1,0 +1,3 @@
+# CustomSelectControlItem
+
+TODO

--- a/packages/components/src/custom-select-control-new/custom-select-control-item/component.tsx
+++ b/packages/components/src/custom-select-control-new/custom-select-control-item/component.tsx
@@ -1,0 +1,32 @@
+/**
+ * External dependencies
+ */
+import type { ForwardedRef } from 'react';
+import { SelectItem } from 'ariakit/select';
+
+/**
+ * WordPress dependencies
+ */
+import { forwardRef } from '@wordpress/element';
+
+/**
+ * Internal dependencies
+ */
+import { useSelectControlItem } from './hook';
+import { WordPressComponentProps } from '../../ui/context';
+import type { SelectControlItemProps } from '../types';
+
+const UnforwardedSelectControlItem = (
+	props: WordPressComponentProps< SelectControlItemProps, 'div', false >,
+	forwardedRef: ForwardedRef< any >
+) => {
+	const allProps = useSelectControlItem( props );
+
+	// TODO: investigate incompatibility with the "as" prop.
+	return <SelectItem { ...allProps } ref={ forwardedRef } />;
+};
+
+// TODO: JSDocs
+export const SelectControlItem = forwardRef( UnforwardedSelectControlItem );
+
+export default SelectControlItem;

--- a/packages/components/src/custom-select-control-new/custom-select-control-item/component.tsx
+++ b/packages/components/src/custom-select-control-new/custom-select-control-item/component.tsx
@@ -13,7 +13,7 @@ import { forwardRef } from '@wordpress/element';
  * Internal dependencies
  */
 import { useSelectControlItem } from './hook';
-import { WordPressComponentProps } from '../../ui/context';
+import type { WordPressComponentProps } from '../../ui/context';
 import type { SelectControlItemProps } from '../types';
 
 const UnforwardedSelectControlItem = (

--- a/packages/components/src/custom-select-control-new/custom-select-control-item/hook.ts
+++ b/packages/components/src/custom-select-control-new/custom-select-control-item/hook.ts
@@ -1,0 +1,31 @@
+/**
+ * WordPress dependencies
+ */
+import { useMemo } from '@wordpress/element';
+
+/**
+ * Internal dependencies
+ */
+import * as styles from '../styles';
+import type { WordPressComponentProps } from '../../ui/context';
+import { useCx } from '../../utils/hooks/use-cx';
+import { SelectControlItemProps } from '../types';
+
+// TODO:
+// - should we use 'option' instead of `div` for props inheritance?
+// - should we allow polymorphism ?
+export const useSelectControlItem = ( {
+	className,
+	...props
+}: WordPressComponentProps< SelectControlItemProps, 'div', false > ) => {
+	const cx = useCx();
+	const itemClassName = useMemo(
+		() => cx( styles.item, className ),
+		[ className, cx ]
+	);
+
+	return {
+		...props,
+		className: itemClassName,
+	};
+};

--- a/packages/components/src/custom-select-control-new/custom-select-control-item/hook.ts
+++ b/packages/components/src/custom-select-control-new/custom-select-control-item/hook.ts
@@ -9,7 +9,7 @@ import { useMemo } from '@wordpress/element';
 import * as styles from '../styles';
 import type { WordPressComponentProps } from '../../ui/context';
 import { useCx } from '../../utils/hooks/use-cx';
-import { SelectControlItemProps } from '../types';
+import type { SelectControlItemProps } from '../types';
 
 // TODO:
 // - should we use 'option' instead of `div` for props inheritance?

--- a/packages/components/src/custom-select-control-new/custom-select-control-item/index.ts
+++ b/packages/components/src/custom-select-control-new/custom-select-control-item/index.ts
@@ -1,0 +1,2 @@
+export { default } from './component';
+export { useSelectControlItem } from './hook';

--- a/packages/components/src/custom-select-control-new/custom-select-control-row/README.md
+++ b/packages/components/src/custom-select-control-new/custom-select-control-row/README.md
@@ -1,0 +1,3 @@
+# CustomSelectControlRow
+
+TODO

--- a/packages/components/src/custom-select-control-new/custom-select-control-row/component.tsx
+++ b/packages/components/src/custom-select-control-new/custom-select-control-row/component.tsx
@@ -1,0 +1,31 @@
+/**
+ * External dependencies
+ */
+import type { ForwardedRef } from 'react';
+import { SelectRow } from 'ariakit/select';
+
+/**
+ * WordPress dependencies
+ */
+import { forwardRef } from '@wordpress/element';
+
+/**
+ * Internal dependencies
+ */
+import { useSelectControlRow } from './hook';
+import type { WordPressComponentProps } from '../../ui/context';
+import type { SelectControlRowProps } from '../types';
+
+const UnforwardedSelectControlRow = (
+	props: WordPressComponentProps< SelectControlRowProps, 'div', false >,
+	forwardedRef: ForwardedRef< any >
+) => {
+	const allProps = useSelectControlRow( props );
+
+	return <SelectRow { ...allProps } ref={ forwardedRef } />;
+};
+
+// TODO: JSDocs
+export const SelectControlRow = forwardRef( UnforwardedSelectControlRow );
+
+export default SelectControlRow;

--- a/packages/components/src/custom-select-control-new/custom-select-control-row/hook.ts
+++ b/packages/components/src/custom-select-control-new/custom-select-control-row/hook.ts
@@ -1,0 +1,28 @@
+/**
+ * WordPress dependencies
+ */
+import { useMemo } from '@wordpress/element';
+
+/**
+ * Internal dependencies
+ */
+import * as styles from '../styles';
+import type { WordPressComponentProps } from '../../ui/context';
+import { useCx } from '../../utils/hooks/use-cx';
+import type { SelectControlRowProps } from '../types';
+
+export const useSelectControlRow = ( {
+	className,
+	...props
+}: WordPressComponentProps< SelectControlRowProps, 'div', false > ) => {
+	const cx = useCx();
+	const rowClassName = useMemo(
+		() => cx( styles.row, className ),
+		[ className, cx ]
+	);
+
+	return {
+		...props,
+		className: rowClassName,
+	};
+};

--- a/packages/components/src/custom-select-control-new/custom-select-control-row/index.ts
+++ b/packages/components/src/custom-select-control-new/custom-select-control-row/index.ts
@@ -1,0 +1,2 @@
+export { default } from './component';
+export { useSelectControlRow } from './hook';

--- a/packages/components/src/custom-select-control-new/custom-select-control-separator/README.md
+++ b/packages/components/src/custom-select-control-new/custom-select-control-separator/README.md
@@ -1,0 +1,3 @@
+# CustomSelectControlSeparator
+
+TODO

--- a/packages/components/src/custom-select-control-new/custom-select-control-separator/component.tsx
+++ b/packages/components/src/custom-select-control-new/custom-select-control-separator/component.tsx
@@ -13,7 +13,7 @@ import { forwardRef } from '@wordpress/element';
  * Internal dependencies
  */
 import { useSelectControlSeparator } from './hook';
-import { WordPressComponentProps } from '../../ui/context';
+import type { WordPressComponentProps } from '../../ui/context';
 import type { SelectControlSeparatorProps } from '../types';
 
 const UnforwardedSelectControlSeparator = (

--- a/packages/components/src/custom-select-control-new/custom-select-control-separator/component.tsx
+++ b/packages/components/src/custom-select-control-new/custom-select-control-separator/component.tsx
@@ -1,0 +1,33 @@
+/**
+ * External dependencies
+ */
+import type { ForwardedRef } from 'react';
+import { SelectSeparator } from 'ariakit/select';
+
+/**
+ * WordPress dependencies
+ */
+import { forwardRef } from '@wordpress/element';
+
+/**
+ * Internal dependencies
+ */
+import { useSelectControlSeparator } from './hook';
+import { WordPressComponentProps } from '../../ui/context';
+import type { SelectControlSeparatorProps } from '../types';
+
+const UnforwardedSelectControlSeparator = (
+	props: WordPressComponentProps< SelectControlSeparatorProps, 'hr', false >,
+	forwardedRef: ForwardedRef< any >
+) => {
+	const allProps = useSelectControlSeparator( props );
+
+	return <SelectSeparator { ...allProps } ref={ forwardedRef } />;
+};
+
+// TODO: JSDocs
+export const SelectControlSeparator = forwardRef(
+	UnforwardedSelectControlSeparator
+);
+
+export default SelectControlSeparator;

--- a/packages/components/src/custom-select-control-new/custom-select-control-separator/hook.ts
+++ b/packages/components/src/custom-select-control-new/custom-select-control-separator/hook.ts
@@ -9,7 +9,7 @@ import { useMemo } from '@wordpress/element';
 import * as styles from '../styles';
 import type { WordPressComponentProps } from '../../ui/context';
 import { useCx } from '../../utils/hooks/use-cx';
-import { SelectControlSeparatorProps } from '../types';
+import type { SelectControlSeparatorProps } from '../types';
 
 export const useSelectControlSeparator = ( {
 	className,

--- a/packages/components/src/custom-select-control-new/custom-select-control-separator/hook.ts
+++ b/packages/components/src/custom-select-control-new/custom-select-control-separator/hook.ts
@@ -1,0 +1,28 @@
+/**
+ * WordPress dependencies
+ */
+import { useMemo } from '@wordpress/element';
+
+/**
+ * Internal dependencies
+ */
+import * as styles from '../styles';
+import type { WordPressComponentProps } from '../../ui/context';
+import { useCx } from '../../utils/hooks/use-cx';
+import { SelectControlSeparatorProps } from '../types';
+
+export const useSelectControlSeparator = ( {
+	className,
+	...props
+}: WordPressComponentProps< SelectControlSeparatorProps, 'hr', false > ) => {
+	const cx = useCx();
+	const separatorClassName = useMemo(
+		() => cx( styles.separator, className ),
+		[ className, cx ]
+	);
+
+	return {
+		...props,
+		className: separatorClassName,
+	};
+};

--- a/packages/components/src/custom-select-control-new/custom-select-control-separator/index.ts
+++ b/packages/components/src/custom-select-control-new/custom-select-control-separator/index.ts
@@ -1,0 +1,2 @@
+export { default } from './component';
+export { useSelectControlSeparator } from './hook';

--- a/packages/components/src/custom-select-control-new/custom-select-control/README.md
+++ b/packages/components/src/custom-select-control-new/custom-select-control/README.md
@@ -1,0 +1,3 @@
+# CustomSelectControl
+
+TODO

--- a/packages/components/src/custom-select-control-new/custom-select-control/component.tsx
+++ b/packages/components/src/custom-select-control-new/custom-select-control/component.tsx
@@ -1,0 +1,94 @@
+/**
+ * External dependencies
+ */
+import type { ForwardedRef } from 'react';
+import {
+	Select,
+	SelectLabel,
+	SelectPopover,
+	SelectArrow,
+} from 'ariakit/select';
+
+/**
+ * WordPress dependencies
+ */
+import { forwardRef } from '@wordpress/element';
+
+/**
+ * Internal dependencies
+ */
+
+import { useSelectControl } from './hook';
+import { WordPressComponentProps } from '../../ui/context';
+import { CustomSelectControlItem } from '../';
+import type { SelectControlOption, SelectControlProps } from '../types';
+
+const SelectControlCustomSelectLabel = ( {
+	options,
+	value,
+}: {
+	options: SelectControlOption[];
+	value?: string;
+} ) => (
+	<>
+		{ /* Use the label associated to the option's value, fallback to the value itself */ }
+		{ options.find( ( option ) => option.value === value )?.label ?? value }
+		<SelectArrow />
+	</>
+);
+
+const UnforwardedSelectControl = (
+	props: WordPressComponentProps< SelectControlProps, 'select', false >,
+	forwardedRef: ForwardedRef< any >
+) => {
+	const {
+		label,
+		options,
+		children,
+		selectState,
+		wrapperClassName,
+		labelClassName,
+		selectClassName,
+		popoverClassName,
+	} = useSelectControl( props );
+
+	return (
+		<div className={ wrapperClassName }>
+			<SelectLabel state={ selectState } className={ labelClassName }>
+				{ label }
+			</SelectLabel>
+			<Select state={ selectState } className={ selectClassName }>
+				{ options?.length ? (
+					<SelectControlCustomSelectLabel
+						options={ options }
+						value={ selectState.value }
+					/>
+				) : (
+					selectState.value
+				) }
+			</Select>
+			<SelectPopover state={ selectState } className={ popoverClassName }>
+				{ children ??
+					options?.map( ( option, index ) => {
+						const key =
+							option.id ||
+							`${ option.label }-${ option.value }-${ index }`;
+						return (
+							<CustomSelectControlItem
+								key={ key }
+								value={ option.value }
+								disabled={ option.disabled }
+							>
+								{ option.label }
+							</CustomSelectControlItem>
+						);
+					} ) }
+			</SelectPopover>
+		</div>
+	);
+};
+
+// TODO: JSDocs
+export const SelectControl = forwardRef( UnforwardedSelectControl );
+
+export default SelectControl;

--- a/packages/components/src/custom-select-control-new/custom-select-control/component.tsx
+++ b/packages/components/src/custom-select-control-new/custom-select-control/component.tsx
@@ -12,9 +12,8 @@ import { forwardRef } from '@wordpress/element';
 /**
  * Internal dependencies
  */
-
 import { useSelectControl } from './hook';
-import { WordPressComponentProps } from '../../ui/context';
+import type { WordPressComponentProps } from '../../ui/context';
 import { CustomSelectControlItem, CustomSelectControlArrow } from '../';
 import type { SelectControlOption, SelectControlProps } from '../types';
 

--- a/packages/components/src/custom-select-control-new/custom-select-control/component.tsx
+++ b/packages/components/src/custom-select-control-new/custom-select-control/component.tsx
@@ -71,6 +71,7 @@ const UnforwardedSelectControl = (
 				) }
 			</Select>
 			<SelectPopover state={ selectState } className={ popoverClassName }>
+				{ /* Popover arrow? */ }
 				{ children ??
 					options?.map( ( option, index ) => {
 						const key =

--- a/packages/components/src/custom-select-control-new/custom-select-control/component.tsx
+++ b/packages/components/src/custom-select-control-new/custom-select-control/component.tsx
@@ -2,12 +2,7 @@
  * External dependencies
  */
 import type { ForwardedRef } from 'react';
-import {
-	Select,
-	SelectLabel,
-	SelectPopover,
-	SelectArrow,
-} from 'ariakit/select';
+import { Select, SelectLabel, SelectPopover } from 'ariakit/select';
 
 /**
  * WordPress dependencies
@@ -20,7 +15,7 @@ import { forwardRef } from '@wordpress/element';
 
 import { useSelectControl } from './hook';
 import { WordPressComponentProps } from '../../ui/context';
-import { CustomSelectControlItem } from '../';
+import { CustomSelectControlItem, CustomSelectControlArrow } from '../';
 import type { SelectControlOption, SelectControlProps } from '../types';
 
 const SelectControlCustomSelectLabel = ( {
@@ -33,7 +28,7 @@ const SelectControlCustomSelectLabel = ( {
 	<>
 		{ /* Use the label associated to the option's value, fallback to the value itself */ }
 		{ options.find( ( option ) => option.value === value )?.label ?? value }
-		<SelectArrow />
+		<CustomSelectControlArrow />
 	</>
 );
 
@@ -64,7 +59,11 @@ const UnforwardedSelectControl = (
 						value={ selectState.value }
 					/>
 				) : (
-					selectState.value
+					// TODO: add support for custom render function
+					<>
+						{ selectState.value }
+						<CustomSelectControlArrow />
+					</>
 				) }
 			</Select>
 			<SelectPopover state={ selectState } className={ popoverClassName }>

--- a/packages/components/src/custom-select-control-new/custom-select-control/component.tsx
+++ b/packages/components/src/custom-select-control-new/custom-select-control/component.tsx
@@ -81,6 +81,9 @@ const UnforwardedSelectControl = (
 								key={ key }
 								value={ option.value }
 								disabled={ option.disabled }
+								preventScrollOnKeyDown={
+									index === 0 ? true : false
+								}
 							>
 								{ option.label }
 							</CustomSelectControlItem>

--- a/packages/components/src/custom-select-control-new/custom-select-control/component.tsx
+++ b/packages/components/src/custom-select-control-new/custom-select-control/component.tsx
@@ -17,7 +17,7 @@ import type { WordPressComponentProps } from '../../ui/context';
 import { CustomSelectControlItem, CustomSelectControlArrow } from '../';
 import type { SelectControlOption, SelectControlProps } from '../types';
 
-const SelectControlCustomSelectLabel = ( {
+const CustomDisplayedValue = ( {
 	options,
 	value,
 }: {
@@ -58,7 +58,7 @@ const UnforwardedSelectControl = (
 				ref={ forwardedRef }
 			>
 				{ options?.length ? (
-					<SelectControlCustomSelectLabel
+					<CustomDisplayedValue
 						options={ options }
 						value={ selectState.value }
 					/>

--- a/packages/components/src/custom-select-control-new/custom-select-control/component.tsx
+++ b/packages/components/src/custom-select-control-new/custom-select-control/component.tsx
@@ -52,7 +52,12 @@ const UnforwardedSelectControl = (
 			<SelectLabel state={ selectState } className={ labelClassName }>
 				{ label }
 			</SelectLabel>
-			<Select state={ selectState } className={ selectClassName }>
+			<Select
+				state={ selectState }
+				className={ selectClassName }
+				// TODO: where should the ref be forwarded?
+				ref={ forwardedRef }
+			>
 				{ options?.length ? (
 					<SelectControlCustomSelectLabel
 						options={ options }

--- a/packages/components/src/custom-select-control-new/custom-select-control/hook.ts
+++ b/packages/components/src/custom-select-control-new/custom-select-control/hook.ts
@@ -1,0 +1,64 @@
+/**
+ * External dependencies
+ */
+import { useSelectState } from 'ariakit/select';
+
+/**
+ * WordPress dependencies
+ */
+import { useMemo } from '@wordpress/element';
+
+/**
+ * Internal dependencies
+ */
+import * as styles from '../styles';
+import type { WordPressComponentProps } from '../../ui/context';
+import { useCx } from '../../utils/hooks/use-cx';
+import { SelectControlProps } from '../types';
+
+// TODO:
+// - should we use 'select' instead of `div` for props inheritance?
+// - should we allow polymorphism ?
+export const useSelectControl = ( {
+	value,
+	className,
+	...props
+}: WordPressComponentProps< SelectControlProps, 'select', false > ) => {
+	// TODO: take some of these settings as props?
+	const selectState = useSelectState( {
+		// TODO: check if it works, understand if we should expose
+		// a different prop for the initial value?
+		defaultValue: value,
+		sameWidth: true,
+		gutter: 4,
+	} );
+
+	// TODO: deprecate options prop
+
+	const cx = useCx();
+	const wrapperClassName = useMemo(
+		() => cx( styles.wrapper, className ),
+		[ className, cx ]
+	);
+	const labelClassName = useMemo(
+		() => cx( styles.label, className ),
+		[ className, cx ]
+	);
+	const selectClassName = useMemo(
+		() => cx( styles.select, className ),
+		[ className, cx ]
+	);
+	const popoverClassName = useMemo(
+		() => cx( styles.popover, className ),
+		[ className, cx ]
+	);
+
+	return {
+		...props,
+		selectState,
+		wrapperClassName,
+		labelClassName,
+		selectClassName,
+		popoverClassName,
+	};
+};

--- a/packages/components/src/custom-select-control-new/custom-select-control/hook.ts
+++ b/packages/components/src/custom-select-control-new/custom-select-control/hook.ts
@@ -14,7 +14,7 @@ import { useMemo } from '@wordpress/element';
 import * as styles from '../styles';
 import type { WordPressComponentProps } from '../../ui/context';
 import { useCx } from '../../utils/hooks/use-cx';
-import { SelectControlProps } from '../types';
+import type { SelectControlProps } from '../types';
 
 // TODO:
 // - should we use 'select' instead of `div` for props inheritance?

--- a/packages/components/src/custom-select-control-new/custom-select-control/index.ts
+++ b/packages/components/src/custom-select-control-new/custom-select-control/index.ts
@@ -1,0 +1,2 @@
+export { default } from './component';
+export { useSelectControl } from './hook';

--- a/packages/components/src/custom-select-control-new/index.ts
+++ b/packages/components/src/custom-select-control-new/index.ts
@@ -1,0 +1,2 @@
+export { default as CustomSelectControl } from './custom-select-control';
+export { default as CustomSelectControlItem } from './custom-select-control-item';

--- a/packages/components/src/custom-select-control-new/index.ts
+++ b/packages/components/src/custom-select-control-new/index.ts
@@ -1,4 +1,5 @@
 export { default as CustomSelectControl } from './custom-select-control';
 export { default as CustomSelectControlItem } from './custom-select-control-item';
 export { default as CustomSelectControlGroup } from './custom-select-control-group';
+export { default as CustomSelectControlGroupLabel } from './custom-select-control-group-label';
 export { default as CustomSelectControlArrow } from './custom-select-control-arrow';

--- a/packages/components/src/custom-select-control-new/index.ts
+++ b/packages/components/src/custom-select-control-new/index.ts
@@ -1,2 +1,3 @@
 export { default as CustomSelectControl } from './custom-select-control';
 export { default as CustomSelectControlItem } from './custom-select-control-item';
+export { default as CustomSelectControlArrow } from './custom-select-control-arrow';

--- a/packages/components/src/custom-select-control-new/index.ts
+++ b/packages/components/src/custom-select-control-new/index.ts
@@ -4,3 +4,4 @@ export { default as CustomSelectControlGroup } from './custom-select-control-gro
 export { default as CustomSelectControlGroupLabel } from './custom-select-control-group-label';
 export { default as CustomSelectControlArrow } from './custom-select-control-arrow';
 export { default as CustomSelectControlSeparator } from './custom-select-control-separator';
+export { default as CustomSelectControlRow } from './custom-select-control-row';

--- a/packages/components/src/custom-select-control-new/index.ts
+++ b/packages/components/src/custom-select-control-new/index.ts
@@ -5,3 +5,4 @@ export { default as CustomSelectControlGroupLabel } from './custom-select-contro
 export { default as CustomSelectControlArrow } from './custom-select-control-arrow';
 export { default as CustomSelectControlSeparator } from './custom-select-control-separator';
 export { default as CustomSelectControlRow } from './custom-select-control-row';
+export { default as CustomSelectControlItemCheck } from './custom-select-control-item-check';

--- a/packages/components/src/custom-select-control-new/index.ts
+++ b/packages/components/src/custom-select-control-new/index.ts
@@ -3,3 +3,4 @@ export { default as CustomSelectControlItem } from './custom-select-control-item
 export { default as CustomSelectControlGroup } from './custom-select-control-group';
 export { default as CustomSelectControlGroupLabel } from './custom-select-control-group-label';
 export { default as CustomSelectControlArrow } from './custom-select-control-arrow';
+export { default as CustomSelectControlSeparator } from './custom-select-control-separator';

--- a/packages/components/src/custom-select-control-new/index.ts
+++ b/packages/components/src/custom-select-control-new/index.ts
@@ -1,3 +1,4 @@
 export { default as CustomSelectControl } from './custom-select-control';
 export { default as CustomSelectControlItem } from './custom-select-control-item';
+export { default as CustomSelectControlGroup } from './custom-select-control-group';
 export { default as CustomSelectControlArrow } from './custom-select-control-arrow';

--- a/packages/components/src/custom-select-control-new/stories/index.tsx
+++ b/packages/components/src/custom-select-control-new/stories/index.tsx
@@ -1,0 +1,58 @@
+/**
+ * External dependencies
+ */
+import type { ComponentMeta, ComponentStory } from '@storybook/react';
+
+/**
+ * WordPress dependencies
+ */
+// import { useState } from '@wordpress/element';
+
+/**
+ * Internal dependencies
+ */
+import { CustomSelectControl, CustomSelectControlItem } from '../';
+
+const meta: ComponentMeta< typeof CustomSelectControl > = {
+	component: CustomSelectControl,
+	title: 'Components (Experimental)/CustomSelectControlNew',
+	argTypes: {},
+	parameters: {
+		controls: {
+			expanded: true,
+		},
+		docs: { source: { state: 'open' } },
+	},
+};
+export default meta;
+
+// TODO:
+// - with options prop
+// - controlled vs uncontrolled
+// - with HTML "options"?
+// - example with custom author dropdown
+
+const DefaultTemplate: ComponentStory< typeof CustomSelectControl > = ( {
+	onChange,
+	...args
+} ) => {
+	// const [ value, setValue ] = useState< string | undefined >( '10px' );
+
+	return (
+		<CustomSelectControl { ...args }>
+			<CustomSelectControlItem value="Venus" />
+			<CustomSelectControlItem value="Earth">
+				Planet Earth
+			</CustomSelectControlItem>
+			<CustomSelectControlItem value="Mars" />
+			<CustomSelectControlItem value="Jupiter" disabled />
+			<CustomSelectControlItem value="Neptune" />
+		</CustomSelectControl>
+	);
+};
+
+export const Default: ComponentStory< typeof CustomSelectControl > =
+	DefaultTemplate.bind( {} );
+Default.args = {
+	label: 'With `CustomSelectControlItem` children',
+};

--- a/packages/components/src/custom-select-control-new/stories/index.tsx
+++ b/packages/components/src/custom-select-control-new/stories/index.tsx
@@ -11,7 +11,13 @@ import type { ComponentMeta, ComponentStory } from '@storybook/react';
 /**
  * Internal dependencies
  */
-import { CustomSelectControl, CustomSelectControlItem } from '../';
+import {
+	CustomSelectControl,
+	CustomSelectControlItem,
+	CustomSelectControlGroup,
+	CustomSelectControlGroupLabel,
+	CustomSelectControlSeparator,
+} from '../';
 
 const meta: ComponentMeta< typeof CustomSelectControl > = {
 	component: CustomSelectControl,
@@ -27,32 +33,65 @@ const meta: ComponentMeta< typeof CustomSelectControl > = {
 export default meta;
 
 // TODO:
-// - with options prop
+// - with `options` prop
 // - controlled vs uncontrolled
-// - with HTML "options"?
+// - with HTML `<options />` (and related vanilla elements)?
 // - example with custom author dropdown
 
-const DefaultTemplate: ComponentStory< typeof CustomSelectControl > = ( {
+export const Default: ComponentStory< typeof CustomSelectControl > = ( {
 	onChange,
 	...args
-} ) => {
-	// const [ value, setValue ] = useState< string | undefined >( '10px' );
-
-	return (
-		<CustomSelectControl { ...args }>
-			<CustomSelectControlItem value="Venus" />
-			<CustomSelectControlItem value="Earth">
-				Planet Earth
-			</CustomSelectControlItem>
-			<CustomSelectControlItem value="Mars" />
-			<CustomSelectControlItem value="Jupiter" disabled />
-			<CustomSelectControlItem value="Neptune" />
-		</CustomSelectControl>
-	);
+} ) => (
+	<CustomSelectControl { ...args }>
+		<CustomSelectControlItem value="Venus" />
+		<CustomSelectControlItem value="Earth">
+			{ /* Custom item label */ }
+			Planet Earth
+		</CustomSelectControlItem>
+		<CustomSelectControlItem value="Mars" />
+		<CustomSelectControlItem value="Jupiter" disabled />
+		<CustomSelectControlItem value="Neptune" />
+	</CustomSelectControl>
+);
+Default.args = {
+	label: 'Choose a planet',
 };
 
-export const Default: ComponentStory< typeof CustomSelectControl > =
-	DefaultTemplate.bind( {} );
-Default.args = {
-	label: 'With `CustomSelectControlItem` children',
+export const WithGroupsAndSeparators: ComponentStory<
+	typeof CustomSelectControl
+> = ( { onChange, ...args } ) => (
+	<CustomSelectControl { ...args }>
+		<CustomSelectControlGroup>
+			<CustomSelectControlGroupLabel>
+				Primary
+			</CustomSelectControlGroupLabel>
+			<CustomSelectControlItem value="Red" />
+			<CustomSelectControlItem value="Yellow" />
+			<CustomSelectControlItem value="Blue" />
+		</CustomSelectControlGroup>
+		<CustomSelectControlSeparator />
+		<CustomSelectControlGroup>
+			<CustomSelectControlGroupLabel>
+				Secondary
+			</CustomSelectControlGroupLabel>
+			<CustomSelectControlItem value="Orange" />
+			<CustomSelectControlItem value="Green" />
+			<CustomSelectControlItem value="Purple" />
+		</CustomSelectControlGroup>
+		<CustomSelectControlSeparator />
+		<CustomSelectControlGroup>
+			<CustomSelectControlGroupLabel>
+				Tertiary
+			</CustomSelectControlGroupLabel>
+			<CustomSelectControlItem value="Amber" />
+			<CustomSelectControlItem value="Vermilion" />
+			<CustomSelectControlItem value="Magenta" />
+			<CustomSelectControlItem value="Violet" />
+			<CustomSelectControlItem value="Teal" />
+			<CustomSelectControlItem value="Chartreuse" />
+		</CustomSelectControlGroup>
+	</CustomSelectControl>
+);
+WithGroupsAndSeparators.args = {
+	label: 'Pick a color',
 };

--- a/packages/components/src/custom-select-control-new/stories/index.tsx
+++ b/packages/components/src/custom-select-control-new/stories/index.tsx
@@ -59,39 +59,49 @@ Default.args = {
 
 export const WithGroupsAndSeparators: ComponentStory<
 	typeof CustomSelectControl
-> = ( { onChange, ...args } ) => (
-	<CustomSelectControl { ...args }>
-		<CustomSelectControlGroup>
-			<CustomSelectControlGroupLabel>
-				Primary
-			</CustomSelectControlGroupLabel>
-			<CustomSelectControlItem value="Red" />
-			<CustomSelectControlItem value="Yellow" />
-			<CustomSelectControlItem value="Blue" />
-		</CustomSelectControlGroup>
-		<CustomSelectControlSeparator />
-		<CustomSelectControlGroup>
-			<CustomSelectControlGroupLabel>
-				Secondary
-			</CustomSelectControlGroupLabel>
-			<CustomSelectControlItem value="Orange" />
-			<CustomSelectControlItem value="Green" />
-			<CustomSelectControlItem value="Purple" />
-		</CustomSelectControlGroup>
-		<CustomSelectControlSeparator />
-		<CustomSelectControlGroup>
-			<CustomSelectControlGroupLabel>
-				Tertiary
-			</CustomSelectControlGroupLabel>
-			<CustomSelectControlItem value="Amber" />
-			<CustomSelectControlItem value="Vermilion" />
-			<CustomSelectControlItem value="Magenta" />
-			<CustomSelectControlItem value="Violet" />
-			<CustomSelectControlItem value="Teal" />
-			<CustomSelectControlItem value="Chartreuse" />
-		</CustomSelectControlGroup>
-	</CustomSelectControl>
-);
+> = ( { onChange, ...args } ) => {
+	return (
+		<CustomSelectControl { ...args }>
+			{ [
+				{ label: 'Primary', values: [ 'Red', 'Yellow', 'Blue' ] },
+				{ label: 'Secondary', values: [ 'Orange', 'Green', 'Purple' ] },
+				{
+					label: 'Tertiary',
+					values: [
+						'Amber',
+						'Vermilion',
+						'Magenta',
+						'Violet',
+						'Teal',
+						'Chartreuse',
+					],
+				},
+			].map( ( { label, values }, groupIndex, groupArray ) => (
+				<>
+					<CustomSelectControlGroup>
+						<CustomSelectControlGroupLabel>
+							{ label }
+						</CustomSelectControlGroupLabel>
+						{ values.map( ( value, valueIndex ) => (
+							<CustomSelectControlItem
+								key={ value }
+								value={ value }
+								// Enables scroll on key down so pressing ArrowUp will scroll up and
+								// reveals the group label.
+								preventScrollOnKeyDown={
+									groupIndex === 0 && valueIndex === 0
+								}
+							/>
+						) ) }
+					</CustomSelectControlGroup>
+					{ groupIndex < groupArray.length - 1 ? (
+						<CustomSelectControlSeparator />
+					) : null }
+				</>
+			) ) }
+		</CustomSelectControl>
+	);
+};
 WithGroupsAndSeparators.args = {
 	label: 'Pick a color',
 };

--- a/packages/components/src/custom-select-control-new/stories/index.tsx
+++ b/packages/components/src/custom-select-control-new/stories/index.tsx
@@ -38,10 +38,9 @@ export default meta;
 // - with HTML `<options />` (and related vanilla elements)?
 // - example with custom author dropdown
 
-export const Default: ComponentStory< typeof CustomSelectControl > = ( {
-	onChange,
-	...args
-} ) => (
+export const Default: ComponentStory< typeof CustomSelectControl > = (
+	args
+) => (
 	<CustomSelectControl { ...args }>
 		<CustomSelectControlItem value="Venus" />
 		<CustomSelectControlItem value="Earth">
@@ -59,7 +58,7 @@ Default.args = {
 
 export const WithGroupsAndSeparators: ComponentStory<
 	typeof CustomSelectControl
-> = ( { onChange, ...args } ) => {
+> = ( args ) => {
 	return (
 		<CustomSelectControl { ...args }>
 			{ [

--- a/packages/components/src/custom-select-control-new/styles.ts
+++ b/packages/components/src/custom-select-control-new/styles.ts
@@ -1,0 +1,100 @@
+/**
+ * External dependencies
+ */
+import { css } from '@emotion/react';
+
+/**
+ * Internal dependencies
+ */
+/**
+ * Internal dependencies
+ */
+import { COLORS, CONFIG } from '../utils';
+import { space } from '../ui/utils/space';
+
+const focused = css`
+	outline: 2px solid hsl( 204, 100%, 40% );
+`;
+
+//  TODO: convert to Flex or HStack
+export const wrapper = css`
+	display: flex;
+	flex-direction: column;
+	gap: 0.5rem;
+`;
+
+// TODO: use base control label? Text? Heading?
+export const label = css``;
+
+// TODO: convert to Flex?
+export const select = css`
+	/* Should be set by parent */
+	width: 200px;
+	display: flex;
+	height: 2.5rem;
+	cursor: default;
+	align-items: center;
+	justify-content: space-between;
+	gap: 0.25rem;
+	white-space: nowrap;
+	border-radius: 0.5rem;
+	background-color: hsl( 204, 20%, 94% );
+	padding-left: 1rem;
+	padding-right: 1rem;
+	font-size: 1rem;
+	line-height: 1.5rem;
+
+	&:hover {
+		background-color: hsl( 204, 20%, 91% );
+	}
+
+	&[aria-disabled='true'] {
+		opacity: 0.5;
+	}
+
+	&:focus-visible,
+	&[data-focus-visible] {
+		${ focused };
+	}
+`;
+
+// TODO: convert to Flex?
+export const popover = css`
+	z-index: 50;
+	display: flex;
+	max-height: 20rem;
+	flex-direction: column;
+	border-radius: 0.5rem;
+	border-width: 1px;
+	border-style: solid;
+	border-color: hsl( 204, 20%, 88% );
+	background-color: hsl( 204, 20%, 100% );
+	padding: 0.5rem;
+	color: hsl( 204, 10%, 10% );
+	filter: drop-shadow( 0 4px 6px rgba( 0, 0, 0, 15% ) );
+
+	&:focus-visible,
+	&[data-focus-visible] {
+		${ focused };
+	}
+`;
+
+export const item = css`
+	outline: none;
+	display: flex;
+	cursor: default;
+	scroll-margin: 0.5rem;
+	align-items: center;
+	gap: 0.5rem;
+	border-radius: 0.25rem;
+	padding: 0.5rem;
+
+	&[data-active-item] {
+		background-color: hsl( 204, 100%, 40% );
+		color: hsl( 0, 0%, 100% );
+	}
+
+	&[aria-disabled='true'] {
+		opacity: 0.5;
+	}
+`;

--- a/packages/components/src/custom-select-control-new/styles.ts
+++ b/packages/components/src/custom-select-control-new/styles.ts
@@ -99,6 +99,10 @@ export const item = css`
 	}
 `;
 
+export const itemCheck = css`
+	/* TODO: styles (decide after prepping a storybook example) */
+`;
+
 export const arrow = css``;
 
 export const group = css``;

--- a/packages/components/src/custom-select-control-new/styles.ts
+++ b/packages/components/src/custom-select-control-new/styles.ts
@@ -100,3 +100,5 @@ export const item = css`
 `;
 
 export const arrow = css``;
+
+export const group = css``;

--- a/packages/components/src/custom-select-control-new/styles.ts
+++ b/packages/components/src/custom-select-control-new/styles.ts
@@ -6,8 +6,6 @@ import { css } from '@emotion/react';
 /**
  * Internal dependencies
  */
-import { COLORS, CONFIG } from '../utils';
-import { space } from '../ui/utils/space';
 
 const focused = css`
 	outline: 2px solid hsl( 204, 100%, 40% );

--- a/packages/components/src/custom-select-control-new/styles.ts
+++ b/packages/components/src/custom-select-control-new/styles.ts
@@ -111,3 +111,13 @@ export const groupLabel = css`
 	font-weight: 500;
 	opacity: 0.6;
 `;
+
+export const separator = css`
+	border-color: currentcolor;
+	margin-top: 0.5rem;
+	margin-bottom: 0.5rem;
+	height: 0px;
+	border-top-width: 1px;
+	opacity: 0.25;
+	width: 100%;
+`;

--- a/packages/components/src/custom-select-control-new/styles.ts
+++ b/packages/components/src/custom-select-control-new/styles.ts
@@ -102,3 +102,12 @@ export const item = css`
 export const arrow = css``;
 
 export const group = css``;
+
+export const groupLabel = css`
+	cursor: default;
+	padding: 0.5rem;
+	font-size: 0.875rem;
+	line-height: 1.25rem;
+	font-weight: 500;
+	opacity: 0.6;
+`;

--- a/packages/components/src/custom-select-control-new/styles.ts
+++ b/packages/components/src/custom-select-control-new/styles.ts
@@ -98,3 +98,5 @@ export const item = css`
 		opacity: 0.5;
 	}
 `;
+
+export const arrow = css``;

--- a/packages/components/src/custom-select-control-new/styles.ts
+++ b/packages/components/src/custom-select-control-new/styles.ts
@@ -60,10 +60,13 @@ export const select = css`
 
 // TODO: convert to Flex?
 export const popover = css`
+	/* TODO: add flexibility, e.g.: min(var(--popover-available-height, 300px), 300px); */
+	max-height: 20rem;
 	z-index: 50;
 	display: flex;
-	max-height: 20rem;
 	flex-direction: column;
+	overflow: auto;
+	overscroll-behavior: contain;
 	border-radius: 0.5rem;
 	border-width: 1px;
 	border-style: solid;
@@ -80,7 +83,7 @@ export const popover = css`
 `;
 
 export const item = css`
-	outline: none;
+	outline: none !important;
 	display: flex;
 	cursor: default;
 	scroll-margin: 0.5rem;

--- a/packages/components/src/custom-select-control-new/styles.ts
+++ b/packages/components/src/custom-select-control-new/styles.ts
@@ -6,9 +6,6 @@ import { css } from '@emotion/react';
 /**
  * Internal dependencies
  */
-/**
- * Internal dependencies
- */
 import { COLORS, CONFIG } from '../utils';
 import { space } from '../ui/utils/space';
 
@@ -113,6 +110,11 @@ export const groupLabel = css`
 	line-height: 1.25rem;
 	font-weight: 500;
 	opacity: 0.6;
+`;
+
+//  TODO: convert to Flex or HStack
+export const row = css`
+	display: 'flex';
 `;
 
 export const separator = css`

--- a/packages/components/src/custom-select-control-new/types.ts
+++ b/packages/components/src/custom-select-control-new/types.ts
@@ -1,0 +1,31 @@
+/**
+ * External dependencies
+ */
+import type { ReactNode } from 'react';
+
+type SelectControlOptionBase = {
+	value: string;
+	label?: string;
+	disabled?: boolean;
+};
+
+// options[] data object
+export type SelectControlOption = SelectControlOptionBase & {
+	id?: string;
+};
+
+// React component props
+export type SelectControlItemProps = SelectControlOptionBase & {
+	className?: string;
+	children?: ReactNode;
+};
+
+// react component props
+export type SelectControlProps = {
+	value?: string;
+	label?: string;
+	// TODO: explain that they are ignored if `children` is specified
+	options?: SelectControlOption[];
+	children?: ReactNode;
+	className?: string;
+};

--- a/packages/components/src/custom-select-control-new/types.ts
+++ b/packages/components/src/custom-select-control-new/types.ts
@@ -40,3 +40,7 @@ export type SelectControlGroupLabelProps = {
 };
 
 export type SelectControlSeparatorProps = {};
+
+export type SelectControlRowProps = {
+	children: ReactNode;
+};

--- a/packages/components/src/custom-select-control-new/types.ts
+++ b/packages/components/src/custom-select-control-new/types.ts
@@ -34,3 +34,7 @@ export type SelectControlArrowProps = {};
 export type SelectControlGroupProps = {
 	children: ReactNode;
 };
+
+export type SelectControlGroupLabelProps = {
+	children: ReactNode;
+};

--- a/packages/components/src/custom-select-control-new/types.ts
+++ b/packages/components/src/custom-select-control-new/types.ts
@@ -20,7 +20,6 @@ export type SelectControlItemProps = SelectControlOptionBase & {
 	children?: ReactNode;
 };
 
-// react component props
 export type SelectControlProps = {
 	value?: string;
 	label?: string;
@@ -29,3 +28,5 @@ export type SelectControlProps = {
 	children?: ReactNode;
 	className?: string;
 };
+
+export type SelectControlArrowProps = {};

--- a/packages/components/src/custom-select-control-new/types.ts
+++ b/packages/components/src/custom-select-control-new/types.ts
@@ -16,8 +16,11 @@ export type SelectControlOption = SelectControlOptionBase & {
 
 // React component props
 export type SelectControlItemProps = SelectControlOptionBase & {
+	// Is classname necessary, with WordPressComponentProps?
 	className?: string;
 	children?: ReactNode;
+	// Do we want to expose this prop?
+	checked?: boolean;
 };
 
 export type SelectControlProps = {
@@ -26,21 +29,34 @@ export type SelectControlProps = {
 	// TODO: explain that they are ignored if `children` is specified
 	options?: SelectControlOption[];
 	children?: ReactNode;
+	// Is classname necessary, with WordPressComponentProps?
 	className?: string;
 };
 
-export type SelectControlArrowProps = {};
+export type SelectControlArrowProps = {
+	// Is classname necessary, with WordPressComponentProps?
+	className?: string;
+};
 
 export type SelectControlGroupProps = {
 	children: ReactNode;
+	// Is classname necessary, with WordPressComponentProps?
+	className?: string;
 };
 
 export type SelectControlGroupLabelProps = {
 	children: ReactNode;
+	// Is classname necessary, with WordPressComponentProps?
+	className?: string;
 };
 
-export type SelectControlSeparatorProps = {};
+export type SelectControlSeparatorProps = {
+	// Is classname necessary, with WordPressComponentProps?
+	className?: string;
+};
 
 export type SelectControlRowProps = {
 	children: ReactNode;
+	// Is classname necessary, with WordPressComponentProps?
+	className?: string;
 };

--- a/packages/components/src/custom-select-control-new/types.ts
+++ b/packages/components/src/custom-select-control-new/types.ts
@@ -21,6 +21,8 @@ export type SelectControlItemProps = SelectControlOptionBase & {
 	children?: ReactNode;
 	// Do we want to expose this prop?
 	checked?: boolean;
+	// Should we expose this?
+	preventScrollOnKeyDown?: boolean;
 };
 
 export type SelectControlItemCheckProps = SelectControlOptionBase & {

--- a/packages/components/src/custom-select-control-new/types.ts
+++ b/packages/components/src/custom-select-control-new/types.ts
@@ -23,6 +23,12 @@ export type SelectControlItemProps = SelectControlOptionBase & {
 	checked?: boolean;
 };
 
+export type SelectControlItemCheckProps = SelectControlOptionBase & {
+	// Is classname necessary, with WordPressComponentProps?
+	className?: string;
+	children?: ReactNode;
+};
+
 export type SelectControlProps = {
 	value?: string;
 	label?: string;

--- a/packages/components/src/custom-select-control-new/types.ts
+++ b/packages/components/src/custom-select-control-new/types.ts
@@ -38,3 +38,5 @@ export type SelectControlGroupProps = {
 export type SelectControlGroupLabelProps = {
 	children: ReactNode;
 };
+
+export type SelectControlSeparatorProps = {};

--- a/packages/components/src/custom-select-control-new/types.ts
+++ b/packages/components/src/custom-select-control-new/types.ts
@@ -30,3 +30,7 @@ export type SelectControlProps = {
 };
 
 export type SelectControlArrowProps = {};
+
+export type SelectControlGroupProps = {
+	children: ReactNode;
+};

--- a/packages/components/tsconfig.json
+++ b/packages/components/tsconfig.json
@@ -46,6 +46,7 @@
 		"src/color-palette/**/*",
 		"src/color-picker/**/*",
 		"src/confirm-dialog/**/*",
+		"src/custom-select-control-new/**/*",
 		"src/dashicon/**/*",
 		"src/date-time/**/*",
 		"src/disabled/**/*",


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Related to #41466
Related to https://github.com/WordPress/gutenberg/pull/41430#issuecomment-1157690629
Related to https://github.com/WordPress/gutenberg/issues/43475
Likely superseeds https://github.com/WordPress/gutenberg/pull/37272

This PR attempts to refactor the `CustomSelectControl` component using the `Select` components from `ariakit`

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

Using `ariakit` under the hood will allow us to:
- delegate the accessibility / usability work to the `ariakit` library
- work towards a more unified set of components based on the `select` element
- explore enhancements to components and APIs that can unlock more polished UIs

See #41466 for more details.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

- [x] Create a new temporary component to start exploring using `ariakit`
- [x] Add more components:
  - [x] Group
  - [x] Group label
  - [x] Arrow
  - [x] Separator
  - [x] Check item
  - [x] Row
- [ ] Add storybook examples to cover all new components
- [ ] Update styles to match the required design
- [ ] Refine types, docs, examples
- [ ] Understand which APIs to adopt (`options` vs passing `children`) (also see this [comment](https://github.com/WordPress/gutenberg/pull/41952#issuecomment-1171140086))
- [ ] Add the same unit tests from current `CustomSelectControl` component
  - [ ] work towards having all tests pass again
  - [ ] if needed, write a "compat layer" to translate from new version to legacy version
- [ ] Look into new requirements:
  - [ ] add `onHighlightedIndexChange` or similar prop
  - [ ] potentially add any new APIs (`renderItem` prop?)
  - [ ] potentially deprecate any old APIs (`options` prop?)
  - [ ] how to make the label visually hidden?
- [ ] Update StoryBook with new low-level and high-level examples:
  - [ ] Example: post author dropdown
- [ ] Try to swap current usages of `CustomSelectControl` from old to new component


## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->

TBD

## Screenshots or screencast <!-- if applicable -->

TBD