### PR TITLE
Lodash: Refactor away from `_.each()`

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -83,6 +83,7 @@ module.exports = {
 							'defaultTo',
 							'differenceWith',
 							'dropRight',
+							'each',
 							'findIndex',
 							'isArray',
 							'isFinite',

--- a/packages/block-library/src/image/utils.js
+++ b/packages/block-library/src/image/utils.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { isEmpty, each, get } from 'lodash';
+import { isEmpty, get } from 'lodash';
 
 /**
  * Internal dependencies
@@ -13,7 +13,7 @@ export function removeNewTabRel( currentRel ) {
 
 	if ( currentRel !== undefined && ! isEmpty( newRel ) ) {
 		if ( ! isEmpty( newRel ) ) {
-			each( NEW_TAB_REL, ( relVal ) => {
+			NEW_TAB_REL.forEach( ( relVal ) => {
 				const regExp = new RegExp( '\\b' + relVal + '\\b', 'gi' );
 				newRel = newRel.replace( regExp, '' );
 			} );

--- a/packages/components/src/form-token-field/index.tsx
+++ b/packages/components/src/form-token-field/index.tsx
@@ -1,16 +1,7 @@
 /**
  * External dependencies
  */
-import {
-	last,
-	clone,
-	uniq,
-	map,
-	difference,
-	each,
-	identity,
-	some,
-} from 'lodash';
+import { last, clone, uniq, map, difference, identity, some } from 'lodash';
 import classnames from 'classnames';
 import type { KeyboardEvent, MouseEvent, TouchEvent } from 'react';
 
@@ -481,7 +472,7 @@ export function FormTokenField( props: FormTokenFieldProps ) {
 		} else {
 			match = match.toLocaleLowerCase();
 
-			each( _suggestions, ( suggestion ) => {
+			_suggestions.forEach( ( suggestion ) => {
 				const index = suggestion.toLocaleLowerCase().indexOf( match );
 				if ( normalizedValue.indexOf( suggestion ) === -1 ) {
 					if ( index === 0 ) {

--- a/packages/components/src/navigable-container/test/menu.js
+++ b/packages/components/src/navigable-container/test/menu.js
@@ -2,7 +2,6 @@
  * External dependencies
  */
 import { fireEvent, render } from '@testing-library/react';
-import { each } from 'lodash';
 
 /**
  * WordPress dependencies
@@ -16,7 +15,7 @@ import { NavigableMenu } from '../menu';
 
 function simulateVisible( container, selector ) {
 	const elements = container.querySelectorAll( selector );
-	each( elements, ( elem ) => {
+	elements.forEach( ( elem ) => {
 		elem.getClientRects = () => [
 			'trick-jsdom-into-having-size-for-element-rect',
 		];

--- a/packages/components/src/navigable-container/test/tabbable.js
+++ b/packages/components/src/navigable-container/test/tabbable.js
@@ -2,7 +2,6 @@
  * External dependencies
  */
 import { fireEvent, render } from '@testing-library/react';
-import { each } from 'lodash';
 
 /**
  * WordPress dependencies
@@ -16,7 +15,7 @@ import { TabbableContainer } from '../tabbable';
 
 function simulateVisible( container, selector ) {
 	const elements = container.querySelectorAll( selector );
-	each( elements, ( elem ) => {
+	elements.forEach( ( elem ) => {
 		elem.getClientRects = () => [
 			'trick-jsdom-into-having-size-for-element-rect',
 		];


### PR DESCRIPTION
## What?
Lodash's `each()` is used only a few times in the entire codebase. This PR aims to remove that usage.

## Why?
Lodash is known to unnecessarily inflate the bundle size of packages, and in most cases, it can be replaced with native language functionality. See these for more information and rationale:

* https://github.com/WordPress/gutenberg/issues/16938#issuecomment-602837246
* https://github.com/WordPress/gutenberg/issues/17025
* https://github.com/WordPress/gutenberg/issues/39495 

## How?
Removing `each` is straightforward in favor of a simple `Array.prototype.forEach()` replacement. However, we need to also ensure we're not calling it on non-arrays - it's easily achievable by manually tracing where the array comes from and whether it's always an array.

## Testing Instructions
* Insert a gallery block with a few images.
* In the gallery block settings, change the images to lead to the attachment page.
* Toggle on the "Open in new tab" toggle and save the post.
* Click "Preview" and verify that the images open in new tab and have a `rel="noopener"` attribute as well.
* Toggle off the "Open in new tab" toggle and save the post.
* Click "Preview" and verify that the images no longer open in new tab and don't have a `rel="noopener"` attribute anymore.
* Type in the tag field and ensure matches are still suggested properly.
* Verify affected tests still pass: `npm run test-unit packages/components/src/navigable-container`