### PR TITLE
Lodash: Refactor away from `_.flatten()`

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -84,6 +84,7 @@ module.exports = {
 							'differenceWith',
 							'dropRight',
 							'findIndex',
+							'flatten',
 							'isArray',
 							'isFinite',
 							'isFunction',

--- a/packages/edit-post/src/store/selectors.js
+++ b/packages/edit-post/src/store/selectors.js
@@ -2,7 +2,7 @@
  * External dependencies
  */
 import createSelector from 'rememo';
-import { includes, some, flatten, values } from 'lodash';
+import { includes, some, values } from 'lodash';
 
 /**
  * WordPress dependencies
@@ -410,7 +410,7 @@ export function getMetaBoxesPerLocation( state, location ) {
  */
 export const getAllMetaBoxes = createSelector(
 	( state ) => {
-		return flatten( values( state.metaBoxes.locations ) );
+		return values( state.metaBoxes.locations ).flat();
 	},
 	( state ) => [ state.metaBoxes.locations ]
 );

--- a/packages/editor/src/components/page-attributes/parent.js
+++ b/packages/editor/src/components/page-attributes/parent.js
@@ -7,7 +7,6 @@ import {
 	debounce,
 	repeat,
 	find,
-	flatten,
 	deburr,
 } from 'lodash';
 
@@ -111,7 +110,7 @@ export function PageAttributesParent() {
 				return priorityA >= priorityB ? 1 : -1;
 			} );
 
-			return flatten( sortedNodes );
+			return sortedNodes.flat();
 		};
 
 		let tree = pageItems.map( ( item ) => ( {


### PR DESCRIPTION
## What?
Lodash's `flatten` is used only a couple of times in the entire codebase. This PR aims to remove that usage.

## Why?
Lodash is known to unnecessarily inflate the bundle size of packages, and in most cases, it can be replaced with native language functionality. See these for more information and rationale:

* https://github.com/WordPress/gutenberg/issues/16938#issuecomment-602837246
* https://github.com/WordPress/gutenberg/issues/17025
* https://github.com/WordPress/gutenberg/issues/39495 

## How?
Removing `flatten` is straightforward in favor of a simple `Array.prototype.flatten()` replacement. However, we need to also ensure we're not calling it on arrays only. 

## Testing Instructions
* Edit a post and click on the Options > Preferences in the post editor settings and click on Panels.
* Verify you can still toggle on and off the "Custom Fields" section and it saves correctly.
* Having at least a few pages in your site, go to edit a page.
* Verify that the parent page in the Page Attributes panel still lists pages correctly.