### PR TITLE
Columns block: Change title of one third/two thirds column variation to 66/33

### DIFF
--- a/packages/block-library/src/columns/variations.js
+++ b/packages/block-library/src/columns/variations.js
@@ -57,7 +57,7 @@ const variations = [
 	},
 	{
 		name: 'two-columns-one-third-two-thirds',
-		title: __( '30 / 70' ),
+		title: __( '33 / 66' ),
 		description: __( 'Two columns; one-third, two-thirds split' ),
 		icon: (
 			<SVG
@@ -81,7 +81,7 @@ const variations = [
 	},
 	{
 		name: 'two-columns-two-thirds-one-third',
-		title: __( '70 / 30' ),
+		title: __( '66 / 33' ),
 		description: __( 'Two columns; two-thirds, one-third split' ),
 		icon: (
 			<SVG


### PR DESCRIPTION
## What?
Change title of one third/two thirds column variation to 66/33 from 70/30 

## Why?
Fixes: #41699

## How?
Changes variation title

## Testing Instructions

- Add a column block and make sure both one third/two thirds variations show 66/33 and 33/66

## Screenshots or screencast 
Before:
<img width="483" alt="Screen Shot 2022-06-15 at 5 27 44 PM" src="https://user-images.githubusercontent.com/3629020/173745330-a4f815c3-c746-425c-b3ea-889f96001487.png">

After:
<img width="470" alt="Screen Shot 2022-06-15 at 5 24 49 PM" src="https://user-images.githubusercontent.com/3629020/173744835-5abb9185-a774-4f87-9a47-a6c557cb069e.png">


