### PR TITLE
Lodash: Refactor away from `_.clamp()`

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -79,6 +79,7 @@ module.exports = {
 					{
 						name: 'lodash',
 						importNames: [
+							'clamp',
 							'concat',
 							'defaultTo',
 							'differenceWith',

--- a/packages/components/src/focal-point-picker/index.native.js
+++ b/packages/components/src/focal-point-picker/index.native.js
@@ -3,7 +3,6 @@
  */
 import { Animated, PanResponder, View } from 'react-native';
 import Video from 'react-native-video';
-import { clamp } from 'lodash';
 
 /**
  * WordPress dependencies
@@ -24,6 +23,7 @@ import FocalPoint from './focal-point';
 import Tooltip from './tooltip';
 import styles from './style.scss';
 import { isVideoType } from './utils';
+import { clamp } from '../utils/math';
 
 const MIN_POSITION_VALUE = 0;
 const MAX_POSITION_VALUE = 100;

--- a/packages/components/src/range-control/index.js
+++ b/packages/components/src/range-control/index.js
@@ -3,7 +3,6 @@
  * External dependencies
  */
 import classnames from 'classnames';
-import { clamp } from 'lodash';
 
 /**
  * WordPress dependencies
@@ -20,6 +19,7 @@ import Button from '../button';
 import Icon from '../icon';
 import { COLORS } from '../utils';
 import { floatClamp, useControlledRangeValue } from './utils';
+import { clamp } from '../utils/math';
 import InputRange from './input-range';
 import RangeRail from './rail';
 import SimpleTooltip from './tooltip';

--- a/packages/components/src/range-control/utils.js
+++ b/packages/components/src/range-control/utils.js
@@ -1,8 +1,4 @@
 // @ts-nocheck
-/**
- * External dependencies
- */
-import { clamp } from 'lodash';
 
 /**
  * WordPress dependencies
@@ -13,6 +9,7 @@ import { useCallback, useRef, useEffect, useState } from '@wordpress/element';
  * Internal dependencies
  */
 import { useControlledState } from '../utils/hooks';
+import { clamp } from '../utils/math';
 
 const noop = () => {};
 

--- a/packages/components/src/utils/math.js
+++ b/packages/components/src/utils/math.js
@@ -65,7 +65,7 @@ function getPrecision( value ) {
  *
  * @return {number} The clamped value.
  */
-export function clamp( value = 0, min = -Infinity, max = Infinity ) {
+export function clamp( value, min, max ) {
 	const baseValue = getNumber( value );
 	return Math.max( min, Math.min( baseValue, max ) );
 }

--- a/packages/components/src/utils/math.js
+++ b/packages/components/src/utils/math.js
@@ -1,9 +1,4 @@
 /**
- * External dependencies
- */
-import { clamp } from 'lodash';
-
-/**
  * Parses and retrieves a number value.
  *
  * @param {unknown} value The incoming value.
@@ -59,6 +54,20 @@ export function subtract( ...args ) {
 function getPrecision( value ) {
 	const split = ( value + '' ).split( '.' );
 	return split[ 1 ] !== undefined ? split[ 1 ].length : 0;
+}
+
+/**
+ * Clamps a value based on a min/max range.
+ *
+ * @param {number} value The value.
+ * @param {number} min   The minimum range.
+ * @param {number} max   The maximum range.
+ *
+ * @return {number} The clamped value.
+ */
+export function clamp( value = 0, min = -Infinity, max = Infinity ) {
+	const baseValue = getNumber( value );
+	return Math.max( min, Math.min( baseValue, max ) );
 }
 
 /**

--- a/packages/components/src/utils/test/math.js
+++ b/packages/components/src/utils/test/math.js
@@ -1,7 +1,7 @@
 /**
  * Internal dependencies
  */
-import { add, subtract, roundClamp } from '../math';
+import { add, clamp, subtract, roundClamp } from '../math';
 
 describe( 'add', () => {
 	it( 'should add string and number values', () => {
@@ -34,6 +34,27 @@ describe( 'subtract', () => {
 
 	it( 'should subtract multiple arguments', () => {
 		expect( subtract( '105', '30', 10, 5 ) ).toBe( 60 );
+	} );
+} );
+
+describe( 'clamp', () => {
+	it( 'should clamp a value between min and max', () => {
+		expect( clamp( 10, 1, 10 ) ).toBe( 10 );
+		expect( clamp( 1, 1, 10 ) ).toBe( 1 );
+		expect( clamp( 0, 1, 10 ) ).toBe( 1 );
+
+		expect( clamp( 50, 1, 10 ) ).toBe( 10 );
+		expect( clamp( 50, -10, 10 ) ).toBe( 10 );
+		expect( clamp( -50, -10, 10 ) ).toBe( -10 );
+
+		expect( clamp( Infinity, -10, 10 ) ).toBe( 10 );
+		expect( clamp( -Infinity, -10, 10 ) ).toBe( -10 );
+	} );
+
+	it( 'should clamp number or string values', () => {
+		expect( clamp( '50', 1, 10 ) ).toBe( 10 );
+		expect( clamp( '50', -10, 10 ) ).toBe( 10 );
+		expect( clamp( -50, -10, '10' ) ).toBe( -10 );
 	} );
 } );
 


### PR DESCRIPTION
## What?
Lodash's `clamp` is used only a few times in the entire codebase, and it's only in the components package. This PR aims to remove that usage.

## Why?
Lodash is known to unnecessarily inflate the bundle size of packages, and in most cases, it can be replaced with native language functionality. See these for more information and rationale:

* https://github.com/WordPress/gutenberg/issues/16938#issuecomment-602837246
* https://github.com/WordPress/gutenberg/issues/17025
* https://github.com/WordPress/gutenberg/issues/39495 

## How?
Removing `clamp` is straightforward in favor of a simple custom implementation that does a `Math.max()` and `Max.min()`. Since we already have a `roundClamp()` utility function in the package, it made sense to abstract the `clamp()` part into its own. We're adding some tests as well. We're not exporting the utility function outside of the package intentionally, but that can easily be done if necessary. 

## Testing Instructions
* Verify all components package tests pass: `npm run test-unit packages/components`
* Insert an Avatar block.
* Play with the Image Size setting:
  * Try inputting a negative value, verify it gets back to 24.
  * Try inputting a smaller than 24 value, verify it gets back to 24.
  * Try inputting a larger than 240 value, verify it gets back to 240.