### PR TITLE
Components: Fix `ComboboxControl` post-reset focus

### DIFF
--- a/packages/components/src/combobox-control/index.js
+++ b/packages/components/src/combobox-control/index.js
@@ -168,7 +168,7 @@ function ComboboxControl( {
 
 	const handleOnReset = () => {
 		onChange( null );
-		inputContainer.current.input.focus();
+		inputContainer.current.focus();
 	};
 
 	// Update current selections when the filter input changes.


### PR DESCRIPTION
## What?
This PR fixes the autofocus in the `ComboboxControl` component that happens after resetting the value.

I found this while working on #41733.

## Why?
It fixes a bug:

![](https://cldup.com/TAKjvHAXKQ.png)

## How?
We're now properly referencing the input.

## Testing Instructions
* Spin up storybook: `npm run storybook:dev`
* Go to `ComboboxControl` and click on Docs.
* Toggle the "allowReset" setting on.
* Select an item.
* Click on the "X" button to reset.
* Verify it no longer explodes with the error above and autofocuses the field correctly.