### PR TITLE
Abbreviate post schedule date when possible

### DIFF
--- a/packages/e2e-tests/specs/editor/various/datepicker.test.js
+++ b/packages/e2e-tests/specs/editor/various/datepicker.test.js
@@ -51,7 +51,7 @@ function formatDatePickerValues(
 ) {
 	const dayTrimmed = trimLeadingZero( day );
 	const hoursTrimmed = trimLeadingZero( hours );
-	return `${ monthLabel } ${ dayTrimmed }, ${ year } ${ hoursTrimmed }:${ minutes } ${ amOrPm } ${ timezone }`;
+	return `${ monthLabel } ${ dayTrimmed }, ${ year } ${ hoursTrimmed }:${ minutes }\xa0${ amOrPm } ${ timezone }`;
 }
 
 async function getPublishingDate() {

--- a/packages/e2e-tests/specs/editor/various/datepicker.test.js
+++ b/packages/e2e-tests/specs/editor/various/datepicker.test.js
@@ -45,17 +45,13 @@ function trimLeadingZero( str ) {
 	return str[ 0 ] === '0' ? str.slice( 1 ) : str;
 }
 
-function formatDatePickerValues( {
-	year,
-	monthLabel,
-	day,
-	hours,
-	minutes,
-	amOrPm,
-} ) {
+function formatDatePickerValues(
+	{ year, monthLabel, day, hours, minutes, amOrPm },
+	timezone
+) {
 	const dayTrimmed = trimLeadingZero( day );
 	const hoursTrimmed = trimLeadingZero( hours );
-	return `${ monthLabel } ${ dayTrimmed }, ${ year } ${ hoursTrimmed }:${ minutes } ${ amOrPm }`;
+	return `${ monthLabel } ${ dayTrimmed }, ${ year } ${ hoursTrimmed }:${ minutes } ${ amOrPm } ${ timezone }`;
 }
 
 async function getPublishingDate() {
@@ -70,11 +66,13 @@ describe.each( [ [ 'UTC-10' ], [ 'UTC' ], [ 'UTC+10' ] ] )(
 	( timezone ) => {
 		let oldTimezone;
 		beforeEach( async () => {
+			await page.emulateTimezone( 'America/New_York' ); // Set browser to a timezone that's different to `timezone`.
 			oldTimezone = await changeSiteTimezone( timezone );
 			await createNewPost();
 		} );
 		afterEach( async () => {
 			await changeSiteTimezone( oldTimezone );
+			await page.emulateTimezone( null );
 		} );
 
 		it( 'should show the publishing date as "Immediately" if the date is not altered', async () => {
@@ -98,7 +96,7 @@ describe.each( [ [ 'UTC-10' ], [ 'UTC' ], [ 'UTC+10' ] ] )(
 			const publishingDate = await getPublishingDate();
 
 			expect( publishingDate ).toBe(
-				formatDatePickerValues( datePickerValues )
+				formatDatePickerValues( datePickerValues, timezone )
 			);
 		} );
 
@@ -119,7 +117,7 @@ describe.each( [ [ 'UTC-10' ], [ 'UTC' ], [ 'UTC+10' ] ] )(
 			expect( publishingDate ).not.toEqual( 'Immediately' );
 			// The expected date format will be "Sep 26, 2018 11:52 pm".
 			expect( publishingDate ).toBe(
-				formatDatePickerValues( datePickerValues )
+				formatDatePickerValues( datePickerValues, timezone )
 			);
 		} );
 

--- a/packages/edit-post/src/components/sidebar/post-schedule/index.js
+++ b/packages/edit-post/src/components/sidebar/post-schedule/index.js
@@ -8,10 +8,13 @@ import {
 	PostSchedule as PostScheduleForm,
 	PostScheduleLabel,
 	PostScheduleCheck,
+	usePostScheduleLabel,
 } from '@wordpress/editor';
 
-export function PostSchedule() {
+export default function PostSchedule() {
 	const anchorRef = useRef();
+
+	const fullLabel = usePostScheduleLabel( { full: true } );
 
 	return (
 		<PostScheduleCheck>
@@ -28,6 +31,7 @@ export function PostSchedule() {
 								onClick={ onToggle }
 								aria-expanded={ isOpen }
 								variant="tertiary"
+								label={ fullLabel }
 							>
 								<PostScheduleLabel />
 							</Button>
@@ -41,5 +45,3 @@ export function PostSchedule() {
 		</PostScheduleCheck>
 	);
 }
-
-export default PostSchedule;

--- a/packages/edit-post/src/components/sidebar/post-schedule/style.scss
+++ b/packages/edit-post/src/components/sidebar/post-schedule/style.scss
@@ -16,6 +16,16 @@
 	text-align: left;
 	white-space: normal;
 	height: auto;
+
+	// This span is added by the Popover in Tooltip when no anchorRef is
+	// provided. We set its width to 0 so that it does not cause the button text
+	// to wrap to a new line when displaying the tooltip. A better fix would be
+	// to pass anchorRef and avoid the need for a span alltogether, which is
+	// what this PR allows us to do:
+	// https://github.com/WordPress/gutenberg/pull/41268.
+	span {
+		width: 0;
+	}
 }
 
 .edit-post-post-schedule__dialog .components-popover__content {

--- a/packages/edit-post/src/components/sidebar/post-schedule/style.scss
+++ b/packages/edit-post/src/components/sidebar/post-schedule/style.scss
@@ -2,15 +2,20 @@
 	width: 100%;
 	position: relative;
 	justify-content: flex-start;
+	align-items: flex-start;
 
 	span {
 		display: block;
 		width: 45%;
+		flex-shrink: 0;
+		padding: 6px 0;
 	}
 }
 
 .components-button.edit-post-post-schedule__toggle {
-	text-align: right;
+	text-align: left;
+	white-space: normal;
+	height: auto;
 }
 
 .edit-post-post-schedule__dialog .components-popover__content {

--- a/packages/editor/src/components/index.js
+++ b/packages/editor/src/components/index.js
@@ -41,7 +41,10 @@ export { default as PostPublishPanel } from './post-publish-panel';
 export { default as PostSavedState } from './post-saved-state';
 export { default as PostSchedule } from './post-schedule';
 export { default as PostScheduleCheck } from './post-schedule/check';
-export { default as PostScheduleLabel } from './post-schedule/label';
+export {
+	default as PostScheduleLabel,
+	usePostScheduleLabel,
+} from './post-schedule/label';
 export { default as PostSlug } from './post-slug';
 export { default as PostSlugCheck } from './post-slug/check';
 export { default as PostSticky } from './post-sticky';

--- a/packages/editor/src/components/post-schedule/label.js
+++ b/packages/editor/src/components/post-schedule/label.js
@@ -34,7 +34,7 @@ export function getFullPostScheduleLabel( dateAttribute ) {
 	const timezoneAbbreviation = getTimezoneAbbreviation();
 	const formattedDate = dateI18n(
 		// translators: If using a space between 'g:i' and 'a', use a non-breaking sapce.
-		_x( 'F j, Y g:i a', 'post schedule full date format' ),
+		_x( 'F j, Y g:i\xa0a', 'post schedule full date format' ),
 		date
 	);
 	return isRTL()
@@ -63,7 +63,7 @@ export function getPostScheduleLabel(
 			// translators: %s: Time of day the post is scheduled for.
 			__( 'Today at %s' ),
 			// translators: If using a space between 'g:i' and 'a', use a non-breaking sapce.
-			dateI18n( _x( 'g:i a', 'post schedule time format' ), date )
+			dateI18n( _x( 'g:i\xa0a', 'post schedule time format' ), date )
 		);
 	}
 
@@ -75,21 +75,21 @@ export function getPostScheduleLabel(
 			// translators: %s: Time of day the post is scheduled for.
 			__( 'Tomorrow at %s' ),
 			// translators: If using a space between 'g:i' and 'a', use a non-breaking sapce.
-			dateI18n( _x( 'g:i a', 'post schedule time format' ), date )
+			dateI18n( _x( 'g:i\xa0a', 'post schedule time format' ), date )
 		);
 	}
 
 	if ( date.getFullYear() === now.getFullYear() ) {
 		return dateI18n(
 			// translators: If using a space between 'g:i' and 'a', use a non-breaking sapce.
-			_x( 'F j g:i a', 'post schedule date format without year' ),
+			_x( 'F j g:i\xa0a', 'post schedule date format without year' ),
 			date
 		);
 	}
 
 	return dateI18n(
 		// translators: Use a non-breaking space between 'g:i' and 'a' if appropriate.
-		_x( 'F j, Y g:i a', 'post schedule full date format' ),
+		_x( 'F j, Y g:i\xa0a', 'post schedule full date format' ),
 		date
 	);
 }

--- a/packages/editor/src/components/post-schedule/label.js
+++ b/packages/editor/src/components/post-schedule/label.js
@@ -1,28 +1,122 @@
 /**
  * WordPress dependencies
  */
-import { __ } from '@wordpress/i18n';
-import { format, __experimentalGetSettings } from '@wordpress/date';
-import { withSelect } from '@wordpress/data';
+import { __, _x, sprintf, isRTL } from '@wordpress/i18n';
+import { __experimentalGetSettings, getDate, dateI18n } from '@wordpress/date';
+import { useSelect } from '@wordpress/data';
 
 /**
  * Internal dependencies
  */
 import { store as editorStore } from '../../store';
 
-export function PostScheduleLabel( { date, isFloating } ) {
-	const settings = __experimentalGetSettings();
-	return date && ! isFloating
-		? format(
-				`${ settings.formats.date } ${ settings.formats.time }`,
-				date
-		  )
-		: __( 'Immediately' );
+export default function PostScheduleLabel( props ) {
+	return usePostScheduleLabel( props );
 }
 
-export default withSelect( ( select ) => {
-	return {
-		date: select( editorStore ).getEditedPostAttribute( 'date' ),
-		isFloating: select( editorStore ).isEditedPostDateFloating(),
-	};
-} )( PostScheduleLabel );
+export function usePostScheduleLabel( { full } ) {
+	const { date, isFloating } = useSelect(
+		( select ) => ( {
+			date: select( editorStore ).getEditedPostAttribute( 'date' ),
+			isFloating: select( editorStore ).isEditedPostDateFloating(),
+		} ),
+		[]
+	);
+
+	return full
+		? getFullPostScheduleLabel( date )
+		: getPostScheduleLabel( date, { isFloating } );
+}
+
+export function getFullPostScheduleLabel( dateAttribute ) {
+	const date = getDate( dateAttribute );
+
+	const timezoneAbbreviation = getTimezoneAbbreviation();
+	const formattedDate = dateI18n(
+		// translators: If using a space between 'g:i' and 'a', use a non-breaking sapce.
+		_x( 'F j, Y g:i a', 'post schedule full date format' ),
+		date
+	);
+	return isRTL()
+		? `${ timezoneAbbreviation } ${ formattedDate }`
+		: `${ formattedDate } ${ timezoneAbbreviation }`;
+}
+
+export function getPostScheduleLabel(
+	dateAttribute,
+	{ isFloating = false, now = new Date() } = {}
+) {
+	if ( ! dateAttribute || isFloating ) {
+		return __( 'Immediately' );
+	}
+
+	// If the user timezone does not equal the site timezone then using words
+	// like 'tomorrow' is confusing, so show the full date.
+	if ( ! isTimezoneSameAsSiteTimezone( now ) ) {
+		return getFullPostScheduleLabel( dateAttribute );
+	}
+
+	const date = getDate( dateAttribute );
+
+	if ( isSameDay( date, now ) ) {
+		return sprintf(
+			// translators: %s: Time of day the post is scheduled for.
+			__( 'Today at %s' ),
+			// translators: If using a space between 'g:i' and 'a', use a non-breaking sapce.
+			dateI18n( _x( 'g:i a', 'post schedule time format' ), date )
+		);
+	}
+
+	const tomorrow = new Date( now );
+	tomorrow.setDate( tomorrow.getDate() + 1 );
+
+	if ( isSameDay( date, tomorrow ) ) {
+		return sprintf(
+			// translators: %s: Time of day the post is scheduled for.
+			__( 'Tomorrow at %s' ),
+			// translators: If using a space between 'g:i' and 'a', use a non-breaking sapce.
+			dateI18n( _x( 'g:i a', 'post schedule time format' ), date )
+		);
+	}
+
+	if ( date.getFullYear() === now.getFullYear() ) {
+		return dateI18n(
+			// translators: If using a space between 'g:i' and 'a', use a non-breaking sapce.
+			_x( 'F j g:i a', 'post schedule date format without year' ),
+			date
+		);
+	}
+
+	return dateI18n(
+		// translators: Use a non-breaking space between 'g:i' and 'a' if appropriate.
+		_x( 'F j, Y g:i a', 'post schedule full date format' ),
+		date
+	);
+}
+
+function getTimezoneAbbreviation() {
+	const { timezone } = __experimentalGetSettings();
+
+	if ( timezone.abbr && isNaN( Number( timezone.abbr ) ) ) {
+		return timezone.abbr;
+	}
+
+	const symbol = timezone.offset < 0 ? '' : '+';
+	return `UTC${ symbol }${ timezone.offset }`;
+}
+
+function isTimezoneSameAsSiteTimezone( date ) {
+	const { timezone } = __experimentalGetSettings();
+
+	const siteOffset = Number( timezone.offset );
+	const dateOffset = -1 * ( date.getTimezoneOffset() / 60 );
+	return siteOffset === dateOffset;
+}
+
+function isSameDay( left, right ) {
+	return (
+		left.getDate() === right.getDate() &&
+		left.getMonth() === right.getMonth() &&
+		left.getFullYear() === right.getFullYear()
+	);
+}

--- a/packages/editor/src/components/post-schedule/test/label.js
+++ b/packages/editor/src/components/post-schedule/test/label.js
@@ -1,32 +1,144 @@
 /**
- * External dependencies
+ * WordPress dependencies
  */
-import { shallow } from 'enzyme';
+import { __experimentalGetSettings, setSettings } from '@wordpress/date';
 
 /**
  * Internal dependencies
  */
-import { PostScheduleLabel } from '../label';
+import { getFullPostScheduleLabel, getPostScheduleLabel } from '../label';
 
-describe( 'PostScheduleLabel', () => {
+describe( 'getFullPostScheduleLabel', () => {
+	it( 'should show a date', () => {
+		const label = getFullPostScheduleLabel( '2022-04-28T15:30:00' );
+		expect( label ).toBe( 'April 28, 2022 3:30 pm UTC+0' );
+	} );
+
+	it( "should show site's timezone abbr", () => {
+		const settings = __experimentalGetSettings();
+
+		setSettings( {
+			...settings,
+			timezone: { offset: 10, string: 'Australia/Sydney', abbr: 'AEST' },
+		} );
+
+		const label = getFullPostScheduleLabel( '2022-04-28T15:30:00' );
+		expect( label ).toBe( 'April 28, 2022 3:30 pm AEST' );
+
+		setSettings( settings );
+	} );
+
+	it( "should show site's timezone offset", () => {
+		const settings = __experimentalGetSettings();
+
+		setSettings( {
+			...settings,
+			timezone: { offset: 10 },
+		} );
+
+		const label = getFullPostScheduleLabel( '2022-04-28T15:30:00' );
+		expect( label ).toBe( 'April 28, 2022 3:30 pm UTC+10' );
+
+		setSettings( settings );
+	} );
+} );
+
+describe( 'getPostScheduleLabel', () => {
 	it( 'should show the post will be published immediately if no publish date is set', () => {
-		const wrapper = shallow( <PostScheduleLabel date={ undefined } /> );
-		expect( wrapper.text() ).toBe( 'Immediately' );
+		const label = getPostScheduleLabel( undefined );
+		expect( label ).toBe( 'Immediately' );
 	} );
 
 	it( 'should show the post will be published immediately if it has a floating date', () => {
-		const date = '2018-09-17T01:23:45.678Z';
-		const wrapper = shallow(
-			<PostScheduleLabel date={ date } isFloating={ true } />
-		);
-		expect( wrapper.text() ).toBe( 'Immediately' );
+		const label = getPostScheduleLabel( '2022-04-28T15:30:00', {
+			isFloating: true,
+		} );
+		expect( label ).toBe( 'Immediately' );
 	} );
 
-	it( 'should show the scheduled publish date if a date has been set', () => {
-		const date = '2018-09-17T01:23:45.678Z';
-		const wrapper = shallow(
-			<PostScheduleLabel date={ date } isFloating={ false } />
+	it( "should show full date if user timezone does not equal site's timezone", () => {
+		const now = new Date( '2022-04-28T13:00:00.000Z' );
+		jest.spyOn( now, 'getTimezoneOffset' ).mockImplementationOnce(
+			() => 10 * -60 // UTC+10
 		);
-		expect( wrapper.text() ).not.toBe( 'Immediately' );
+
+		const label = getPostScheduleLabel( '2022-04-28T15:30:00', { now } );
+		expect( label ).toBe( 'April 28, 2022 3:30 pm UTC+0' );
+	} );
+
+	it( "should show today if date is same day as now and user timezone equals site's timezone", () => {
+		const settings = __experimentalGetSettings();
+
+		setSettings( {
+			...settings,
+			timezone: { offset: 10 },
+		} );
+
+		const now = new Date( '2022-04-28T03:00:00.000Z' );
+		jest.spyOn( now, 'getTimezoneOffset' ).mockImplementationOnce(
+			() => 10 * -60 // UTC+10
+		);
+
+		const label = getPostScheduleLabel( '2022-04-28T15:30:00', { now } );
+		expect( label ).toBe( 'Today at 3:30 pm' );
+
+		setSettings( settings );
+	} );
+
+	it( "should show tomorrow if date is same day as now + 1 day and user timezone equals site's timezone", () => {
+		const settings = __experimentalGetSettings();
+
+		setSettings( {
+			...settings,
+			timezone: { offset: 10 },
+		} );
+
+		const now = new Date( '2022-04-28T03:00:00.000Z' );
+		jest.spyOn( now, 'getTimezoneOffset' ).mockImplementationOnce(
+			() => 10 * -60 // UTC+10
+		);
+
+		const label = getPostScheduleLabel( '2022-04-29T15:30:00', { now } );
+		expect( label ).toBe( 'Tomorrow at 3:30 pm' );
+
+		setSettings( settings );
+	} );
+
+	it( "should hide year if date is same year as now and user timezone equals site's timezone", () => {
+		const settings = __experimentalGetSettings();
+
+		setSettings( {
+			...settings,
+			timezone: { offset: 10 },
+		} );
+
+		const now = new Date( '2022-04-28T03:00:00.000Z' );
+		jest.spyOn( now, 'getTimezoneOffset' ).mockImplementationOnce(
+			() => 10 * -60 // UTC+10
+		);
+
+		const label = getPostScheduleLabel( '2022-12-25T15:30:00', { now } );
+		expect( label ).toBe( 'December 25 3:30 pm' );
+
+		setSettings( settings );
+	} );
+
+	it( "should show year if date is not same year as now and user timezone equals site's timezone", () => {
+		const settings = __experimentalGetSettings();
+
+		setSettings( {
+			...settings,
+			timezone: { offset: 10 },
+		} );
+
+		const now = new Date( '2022-04-28T03:00:00.000Z' );
+		jest.spyOn( now, 'getTimezoneOffset' ).mockImplementationOnce(
+			() => 10 * -60 // UTC+10
+		);
+
+		const label = getPostScheduleLabel( '2023-04-28T15:30:00', { now } );
+		expect( label ).toBe( 'April 28, 2023 3:30 pm' );
+
+		setSettings( settings );
 	} );
 } );

--- a/packages/editor/src/components/post-schedule/test/label.js
+++ b/packages/editor/src/components/post-schedule/test/label.js
@@ -11,7 +11,7 @@ import { getFullPostScheduleLabel, getPostScheduleLabel } from '../label';
 describe( 'getFullPostScheduleLabel', () => {
 	it( 'should show a date', () => {
 		const label = getFullPostScheduleLabel( '2022-04-28T15:30:00' );
-		expect( label ).toBe( 'April 28, 2022 3:30 pm UTC+0' );
+		expect( label ).toBe( 'April 28, 2022 3:30\xa0pm UTC+0' ); // Unused, for backwards compatibility.
 	} );
 
 	it( "should show site's timezone abbr", () => {
@@ -23,7 +23,7 @@ describe( 'getFullPostScheduleLabel', () => {
 		} );
 
 		const label = getFullPostScheduleLabel( '2022-04-28T15:30:00' );
-		expect( label ).toBe( 'April 28, 2022 3:30 pm AEST' );
+		expect( label ).toBe( 'April 28, 2022 3:30\xa0pm AEST' );
 
 		setSettings( settings );
 	} );
@@ -37,7 +37,7 @@ describe( 'getFullPostScheduleLabel', () => {
 		} );
 
 		const label = getFullPostScheduleLabel( '2022-04-28T15:30:00' );
-		expect( label ).toBe( 'April 28, 2022 3:30 pm UTC+10' );
+		expect( label ).toBe( 'April 28, 2022 3:30\xa0pm UTC+10' );
 
 		setSettings( settings );
 	} );
@@ -63,7 +63,7 @@ describe( 'getPostScheduleLabel', () => {
 		);
 
 		const label = getPostScheduleLabel( '2022-04-28T15:30:00', { now } );
-		expect( label ).toBe( 'April 28, 2022 3:30 pm UTC+0' );
+		expect( label ).toBe( 'April 28, 2022 3:30\xa0pm UTC+0' );
 	} );
 
 	it( "should show today if date is same day as now and user timezone equals site's timezone", () => {
@@ -80,7 +80,7 @@ describe( 'getPostScheduleLabel', () => {
 		);
 
 		const label = getPostScheduleLabel( '2022-04-28T15:30:00', { now } );
-		expect( label ).toBe( 'Today at 3:30 pm' );
+		expect( label ).toBe( 'Today at 3:30\xa0pm' );
 
 		setSettings( settings );
 	} );
@@ -99,7 +99,7 @@ describe( 'getPostScheduleLabel', () => {
 		);
 
 		const label = getPostScheduleLabel( '2022-04-29T15:30:00', { now } );
-		expect( label ).toBe( 'Tomorrow at 3:30 pm' );
+		expect( label ).toBe( 'Tomorrow at 3:30\xa0pm' );
 
 		setSettings( settings );
 	} );
@@ -118,7 +118,7 @@ describe( 'getPostScheduleLabel', () => {
 		);
 
 		const label = getPostScheduleLabel( '2022-12-25T15:30:00', { now } );
-		expect( label ).toBe( 'December 25 3:30 pm' );
+		expect( label ).toBe( 'December 25 3:30\xa0pm' );
 
 		setSettings( settings );
 	} );
@@ -137,7 +137,7 @@ describe( 'getPostScheduleLabel', () => {
 		);
 
 		const label = getPostScheduleLabel( '2023-04-28T15:30:00', { now } );
-		expect( label ).toBe( 'April 28, 2023 3:30 pm' );
+		expect( label ).toBe( 'April 28, 2023 3:30\xa0pm' );
 
 		setSettings( settings );
 	} );


### PR DESCRIPTION
## What?
Use abbreviations such as 'Today' and 'Tomorrow' in the post schedule label when it makes sense to do so.

## Why?
Part of https://github.com/WordPress/gutenberg/issues/39082. Specifically, [this page in the Figma](https://www.figma.com/file/8vEDwRwmzWhxvcvhc6yaQk/Status-%26-visibility?node-id=405%3A24187):

![Date](https://user-images.githubusercontent.com/612155/173762409-84b157be-96f8-44db-a34b-fdf0a2465d9f.png)

## How?
I added a bunch of if statements to `PostScheduleLabel`! 😀

I followed what's outlined in the design above pretty closely, except for:

- If the user's timezone does not match the site's timezone, then we always show the full date. This avoids ambiguity around what e.g. 'tomorrow' means when the timezones are different.

- If the site's timezone has a name (e.g. 'AEST') then we show that instead of the UTC offset (e.g. 'UTC+10'). This is what we do in the date picker.

All of the date formats are passed through `_x` so that they can be localised.

I switched to using `wp.date.dateI18n` (instead of `wp.date.format`) so that any words in the dates (e.g. 'Monday') can be localised.

## Testing Instructions
1. Create or edit a post.
2. Click on the publish date to schedule the post.
3. Play with different dates e.g. today, tomorrow, this year, next year.
4. Play with different timezones by setting the site's timezone in Settings → General.

## Screenshots or screencast 
https://user-images.githubusercontent.com/612155/173764671-1f6b5027-7552-463a-a617-b3981b00318c.mp4