### PR TITLE
Allow defining an aria-label in group blocks

### DIFF
--- a/docs/reference-guides/core-blocks.md
+++ b/docs/reference-guides/core-blocks.md
@@ -275,7 +275,7 @@ Gather blocks in a layout container. ([Source](https://github.com/WordPress/gute
 
 -	**Name:** core/group
 -	**Category:** design
--	**Supports:** align (full, wide), anchor, color (background, gradients, link, text), spacing (blockGap, margin, padding), typography (fontSize, lineHeight), ~~html~~
+-	**Supports:** align (full, wide), anchor, ariaLabel, color (background, gradients, link, text), spacing (blockGap, margin, padding), typography (fontSize, lineHeight), ~~html~~
 -	**Attributes:** tagName, templateLock
 
 ## Heading

--- a/packages/block-editor/src/hooks/aria-label.js
+++ b/packages/block-editor/src/hooks/aria-label.js
@@ -1,0 +1,67 @@
+/**
+ * WordPress dependencies
+ */
+import { addFilter } from '@wordpress/hooks';
+import { hasBlockSupport } from '@wordpress/blocks';
+
+const ARIA_LABEL_SCHEMA = {
+	type: 'string',
+	source: 'attribute',
+	attribute: 'aria-label',
+	selector: '*',
+};
+
+/**
+ * Filters registered block settings, extending attributes with ariaLabel using aria-label
+ * of the first node.
+ *
+ * @param {Object} settings Original block settings.
+ *
+ * @return {Object} Filtered block settings.
+ */
+export function addAttribute( settings ) {
+	// Allow blocks to specify their own attribute definition with default values if needed.
+	if ( settings?.attributes?.ariaLabel?.type ) {
+		return settings;
+	}
+	if ( hasBlockSupport( settings, 'ariaLabel' ) ) {
+		// Gracefully handle if settings.attributes is undefined.
+		settings.attributes = {
+			...settings.attributes,
+			ariaLabel: ARIA_LABEL_SCHEMA,
+		};
+	}
+
+	return settings;
+}
+
+/**
+ * Override props assigned to save component to inject aria-label, if block
+ * supports ariaLabel. This is only applied if the block's save result is an
+ * element and not a markup string.
+ *
+ * @param {Object} extraProps Additional props applied to save element.
+ * @param {Object} blockType  Block type.
+ * @param {Object} attributes Current block attributes.
+ *
+ * @return {Object} Filtered props applied to save element.
+ */
+export function addSaveProps( extraProps, blockType, attributes ) {
+	if ( hasBlockSupport( blockType, 'ariaLabel' ) ) {
+		extraProps[ 'aria-label' ] =
+			attributes.ariaLabel === '' ? null : attributes.ariaLabel;
+	}
+
+	return extraProps;
+}
+
+addFilter(
+	'blocks.registerBlockType',
+	'core/ariaLabel/attribute',
+	addAttribute
+);
+addFilter(
+	'blocks.getSaveContent.extraProps',
+	'core/ariaLabel/save-props',
+	addSaveProps
+);

--- a/packages/block-editor/src/hooks/index.js
+++ b/packages/block-editor/src/hooks/index.js
@@ -5,6 +5,7 @@ import './compat';
 import './align';
 import './lock';
 import './anchor';
+import './aria-label';
 import './custom-class-name';
 import './generated-class-name';
 import './style';

--- a/packages/block-library/src/group/block.json
+++ b/packages/block-library/src/group/block.json
@@ -21,6 +21,7 @@
 		"__experimentalSettings": true,
 		"align": [ "wide", "full" ],
 		"anchor": true,
+		"ariaLabel": true,
 		"html": false,
 		"color": {
 			"gradients": true,

--- a/schemas/json/block.json
+++ b/schemas/json/block.json
@@ -245,6 +245,11 @@
 					"description": "This property allows to enable wide alignment for your theme. To disable this behavior for a single block, set this flag to false.",
 					"default": true
 				},
+				"ariaLabel": {
+					"type": "boolean",
+					"description": "ARIA-labels let you define an accessible label for elements. This property allows defining an aria-label for the block, without exposing a UI field.",
+					"default": false
+				},
 				"className": {
 					"type": "boolean",
 					"description": "By default, the class .wp-block-your-block-name is added to the root element of your saved markup. This helps having a consistent mechanism for styling blocks that themes and plugins can rely on. If, for whatever reason, a class is not desired on the markup, this functionality can be disabled.",

--- a/schemas/json/block.json
+++ b/schemas/json/block.json
@@ -247,7 +247,7 @@
 				},
 				"ariaLabel": {
 					"type": "boolean",
-					"description": "ARIA-labels let you define an accessible label for elements. This property allows defining an aria-label for the block, without exposing a UI field.",
+					"description": "ARIA-labels let you define an accessible label for elements. This property allows enabling the definition of an aria-label for the block, without exposing a UI field.",
 					"default": false
 				},
 				"className": {


### PR DESCRIPTION
## What?
This PR allows defining an ARIA label for group blocks.

## Why?

When there are multiple landmarks of the same type (`<nav>`, `<aside>`, `<section>` etc), assistive technologies have no way to differentiate them. Group blocks allow users to select the HTML element they need, but in doing so, introduce an a11y issue. 

This PR attempts to resolve that, by allowing users & theme-developers to manually add an ARIA label in their templates.

## How?

Since this is something that may eventually be needed in other blocks, it was implemented as a hook.
To add support, we can simply define `supports.ariaLabel` as `true` in `block.json` files.
This implementation does NOT add a UI for the aria-label. A visible option would have the potential to confuse users, and could cause more harm than good if they enter the wrong thing or misunderstand the purpose.
However, allowing users & theme-authors to manually define an aria-label in their templates is something that can significantly enhance the a11y of themes, without exposing any option to users. Furthermore, implementing this as a hook will allow us to implement a UI if at some point in the future we choose to do so.
Right now, if we try to add an aria-label to a group block we get a validation error and this PR allows us to define the `aria-label` properly.

## Testing Instructions

You can use this content to test:

```html
<!-- wp:group {"tagName":"main","layout":{"inherit":true}} -->
<main class="wp-block-group"><!-- wp:paragraph -->
<p>Main</p>
<!-- /wp:paragraph --></main>
<!-- /wp:group -->

<!-- wp:group {"tagName":"aside","layout":{"inherit":true}} -->
<aside aria-label="first aside" class="wp-block-group"><!-- wp:paragraph -->
<p>Aside 1</p>
<!-- /wp:paragraph --></aside>
<!-- /wp:group -->

<!-- wp:group {"tagName":"aside","layout":{"inherit":true}} -->
<aside aria-label="second aside" class="wp-block-group"><!-- wp:paragraph -->
<p>Aside 2</p>
<!-- /wp:paragraph --></aside>
<!-- /wp:group -->
```

Before the PR: validation errors in the 2 `<aside>` groups.
After the PR: it works 🎉 