### PR TITLE
Search block: remove double spaces

### DIFF
--- a/packages/block-library/src/search/index.php
+++ b/packages/block-library/src/search/index.php
@@ -80,12 +80,15 @@ function render_block_core_search( $attributes ) {
 	}
 
 	if ( $show_button ) {
+		$button_classes = array();
 		$button_internal_markup = '';
-		$button_classes         = $color_classes;
+		if ( ! empty( $color_classes ) ) {
+			$button_classes[] = $color_classes;
+		}
 		$aria_label             = '';
 
-		if ( ! $is_button_inside ) {
-			$button_classes .= ' ' . $border_color_classes;
+		if ( ! $is_button_inside && ! empty( $border_color_classes ) ) {
+			$button_classes[] = $border_color_classes;
 		}
 		if ( ! $use_icon_button ) {
 			if ( ! empty( $attributes['buttonText'] ) ) {
@@ -93,7 +96,7 @@ function render_block_core_search( $attributes ) {
 			}
 		} else {
 			$aria_label      = sprintf( 'aria-label="%s"', esc_attr( wp_strip_all_tags( $attributes['buttonText'] ) ) );
-			$button_classes .= ' has-icon';
+			$button_classes[] = 'has-icon';
 
 			$button_internal_markup =
 				'<svg class="search-icon" viewBox="0 0 24 24" width="24" height="24">
@@ -102,11 +105,11 @@ function render_block_core_search( $attributes ) {
 		}
 
 		// Include the button element class.
-		$button_classes .= ' ' . WP_Theme_JSON_GUTENBERG::__EXPERIMENTAL_ELEMENT_BUTTON_CLASS_NAME;
-
+		$button_classes[] = WP_Theme_JSON_GUTENBERG::__EXPERIMENTAL_ELEMENT_BUTTON_CLASS_NAME;
+var_dump( $button_classes );
 		$button_markup = sprintf(
 			'<button type="submit" class="wp-block-search__button %s" %s %s>%s</button>',
-			esc_attr( $button_classes ),
+			esc_attr( implode( ' ', $button_classes ) ),
 			$inline_styles['button'],
 			$aria_label,
 			$button_internal_markup

--- a/packages/block-library/src/search/index.php
+++ b/packages/block-library/src/search/index.php
@@ -80,12 +80,12 @@ function render_block_core_search( $attributes ) {
 	}
 
 	if ( $show_button ) {
-		$button_classes = array();
+		$button_classes         = array();
 		$button_internal_markup = '';
 		if ( ! empty( $color_classes ) ) {
 			$button_classes[] = $color_classes;
 		}
-		$aria_label             = '';
+		$aria_label = '';
 
 		if ( ! $is_button_inside && ! empty( $border_color_classes ) ) {
 			$button_classes[] = $border_color_classes;
@@ -95,7 +95,7 @@ function render_block_core_search( $attributes ) {
 				$button_internal_markup = wp_kses_post( $attributes['buttonText'] );
 			}
 		} else {
-			$aria_label      = sprintf( 'aria-label="%s"', esc_attr( wp_strip_all_tags( $attributes['buttonText'] ) ) );
+			$aria_label       = sprintf( 'aria-label="%s"', esc_attr( wp_strip_all_tags( $attributes['buttonText'] ) ) );
 			$button_classes[] = 'has-icon';
 
 			$button_internal_markup =

--- a/packages/block-library/src/search/index.php
+++ b/packages/block-library/src/search/index.php
@@ -106,7 +106,7 @@ function render_block_core_search( $attributes ) {
 
 		// Include the button element class.
 		$button_classes[] = WP_Theme_JSON_GUTENBERG::__EXPERIMENTAL_ELEMENT_BUTTON_CLASS_NAME;
-var_dump( $button_classes );
+
 		$button_markup = sprintf(
 			'<button type="submit" class="wp-block-search__button %s" %s %s>%s</button>',
 			esc_attr( implode( ' ', $button_classes ) ),


### PR DESCRIPTION
## What?
Removes double spaces from the class names in the Search block. Fixes https://github.com/WordPress/gutenberg/issues/41608

## Why?
Not sure!

## How?
Makes $block_classes an array, not a string so they can be output using `implode`.

## Testing Instructions
- Add the search block to a post
- Check the markup of the block and ensure there's only one space between each class name.