### PR TITLE
Fix newlines in block editor after a user mention

### DIFF
--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -8,6 +8,7 @@
 -   `FormTokenField`: Do not suggest the selected one even if `{ value: string }` is passed ([#41216](https://github.com/WordPress/gutenberg/pull/41216)).
 -   `CustomGradientBar`: Fix insertion and control point positioning to more closely follow cursor. ([#41492](https://github.com/WordPress/gutenberg/pull/41492))
 -   `FormTokenField`: Added Padding to resolve close button overlap issue ([#41556](https://github.com/WordPress/gutenberg/pull/41556)).
+-   `Autocomplete`: Prevent autocompletion entries (such as user mentions) from breaking subsequent newlines in the same block ([#41749](https://github.com/WordPress/gutenberg/pull/41749)).
 
 ### Enhancements
 

--- a/packages/components/src/autocomplete/index.js
+++ b/packages/components/src/autocomplete/index.js
@@ -12,6 +12,7 @@ import {
 	useState,
 	useRef,
 	useMemo,
+	useCallback,
 } from '@wordpress/element';
 import {
 	ENTER,
@@ -210,13 +211,16 @@ function useAutocomplete( {
 	 *
 	 * @param {Array} options
 	 */
-	function onChangeOptions( options ) {
-		setSelectedIndex(
-			options.length === filteredOptions.length ? selectedIndex : 0
-		);
-		setFilteredOptions( options );
-		announce( options );
-	}
+	const onChangeOptions = useCallback(
+		( options ) => {
+			setSelectedIndex(
+				options.length === filteredOptions.length ? selectedIndex : 0
+			);
+			setFilteredOptions( options );
+			announce( options );
+		},
+		[ announce, filteredOptions.length, selectedIndex ]
+	);
 
 	function handleKeyDown( event ) {
 		backspacing.current = event.keyCode === BACKSPACE;

--- a/packages/components/src/autocomplete/index.js
+++ b/packages/components/src/autocomplete/index.js
@@ -184,27 +184,30 @@ function useAutocomplete( {
 		setAutocompleterUI( null );
 	}
 
-	function announce( options ) {
-		if ( ! debouncedSpeak ) {
-			return;
-		}
-		if ( !! options.length ) {
-			debouncedSpeak(
-				sprintf(
-					/* translators: %d: number of results. */
-					_n(
-						'%d result found, use up and down arrow keys to navigate.',
-						'%d results found, use up and down arrow keys to navigate.',
+	const announce = useCallback(
+		( options ) => {
+			if ( ! debouncedSpeak ) {
+				return;
+			}
+			if ( !! options.length ) {
+				debouncedSpeak(
+					sprintf(
+						/* translators: %d: number of results. */
+						_n(
+							'%d result found, use up and down arrow keys to navigate.',
+							'%d results found, use up and down arrow keys to navigate.',
+							options.length
+						),
 						options.length
 					),
-					options.length
-				),
-				'assertive'
-			);
-		} else {
-			debouncedSpeak( __( 'No results.' ), 'assertive' );
-		}
-	}
+					'assertive'
+				);
+			} else {
+				debouncedSpeak( __( 'No results.' ), 'assertive' );
+			}
+		},
+		[ debouncedSpeak ]
+	);
 
 	/**
 	 * Load options for an autocompleter.


### PR DESCRIPTION
## What?
Fix #41724

Memoize `onChangeOptions` and subsequent dependencies.

## Why?
When `onChangeOptions` was added as a `useLayoutEffect` dependency in #41382, new lines after user mentions became very unreliable.

I think (not 100% sure, but it bears out in my testing) that a race condition was introduced. When the new dep was placed, the effect began firing on every render because `onChangeOptions` was actually being redeclared each time. This effect firing would in turn call two state setters (`setSelectedIndex` and `setFilteredOptions`). If either of these was updated with a new value, a new render would trigger, repeating the cycle. It wasn't quite an infinite loop, so no errors appeared, but it did create frequent cases where the `useEffect` responsible for calling `reset()` would be prevented from firing.

My working theory is that because `useLayoutEffect` fires before the render completes, the state was changing before that `reset` function could do its job and clear the stored autocomplete input... so when `Enter/Return` was pressed, the component inserted the value it had previously been asked to insert from the completion popover.

## How?
Since the problem appeared to stem from firing that `useLayoutEffect` too often, we can wrap `onChangeOptions` in a `useCallback`. The function itself shouldn't change, so effectively I expect this effect to only fire on changes to `items`.

This, in turn, required `announce` to get a similar `useCallback` wrapper. `onChangeOptions` should now only actually fire when there's a change to either the length of the `filterOptions` array, or the `selectedIndex` (which should be exactly what we want).

## Testing Instructions
1. Confirm your testing site has at least one additional user
2. Before applying this PR, create a new post in the block editor
3. In a paragraph block add a user mention wit h`@` followed by part of another user's name. Select them with `Return/Enter`
4. Press `space` and enter a few characters of text
5. Press `Return/Enter`
6. Repeat a few times if the bug doesn't present itself

At least some (probably most if not all) of the time, your followup text should be erased by the autocompleter.

After applying this PR, repeat the same steps. You should get a new paragraph block when hitting `Return/Enter` each time.
