### PR TITLE
Fix link to "Good First Review" issues in README

### DIFF
--- a/docs/contributors/code/README.md
+++ b/docs/contributors/code/README.md
@@ -12,7 +12,7 @@ Real-time discussions for development take place in `#core-editor` and `#core-js
 
 The Gutenberg project uses GitHub for managing code and tracking issues. The main repository is at: [https://github.com/WordPress/gutenberg](https://github.com/WordPress/gutenberg).
 
-Browse [the issues list](https://github.com/wordpress/gutenberg/issues) to find issues to work on. The [good first issue](https://github.com/wordpress/gutenberg/issues?q=is%3Aopen+is%3Aissue+label%3A%22Good+First+Issue%22) and [good first review](https://github.com/wordpress/gutenberg/issues?q=is%3Aopen+is%3Aissue+label%3A%22Good+First+Issue%22) labels are good starting points.
+Browse [the issues list](https://github.com/wordpress/gutenberg/issues) to find issues to work on. The [good first issue](https://github.com/wordpress/gutenberg/issues?q=is%3Aopen+is%3Aissue+label%3A%22Good+First+Issue%22) and [good first review](https://github.com/WordPress/gutenberg/pulls?q=is%3Aopen+is%3Apr+label%3A%22Good+First+Review%22) labels are good starting points.
 
 ## Contributor Resources
 


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->
This PR fixes URL of the "Good First Review" link. Previously, it pointed to open issues with label "Good First Issue". After changes it's pointing to open **reviews** with label "Good First Review".

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

I was going through docs for contributors and when I clicked the "Good First Review" link I noticed it took me to the wrong page so I decided to fix it. It's not a biggie and I hope to contribute in a more meaningful way in the future :)

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

Nothing fancy, just updated URL of the link in README file.

## Testing Instructions

1. Check if the link to "Good First Review" filter works correctly from Github:
  - Go to https://github.com/mcliwanow/gutenberg/blob/fix/link-to-good-first-review/docs/contributors/code/README.md (updated README file)
  -  Click the "Good First Review" link
  - Verify that you are taken to open reviews for the Gutenberg repository and that label "Good First Review" is selected
2.  If your IDE support Previewing `.md` files then:
  - Checkout branch from this PR on your machine
  - Open file `docs/contributors/code/README.md` in Preview mode
  - Click the "Good First Review" link 
  - Verify that you are taken to open reviews for the Gutenberg repository and that label "Good First Review" is selected
