### PR TITLE
serializeBlock fix ESLint warning

### DIFF
--- a/packages/blocks/src/api/serializer.js
+++ b/packages/blocks/src/api/serializer.js
@@ -340,8 +340,8 @@ export function getCommentDelimitedContent(
  * Returns the content of a block, including comment delimiters, determining
  * serialized attributes and content form from the current state of the block.
  *
- * @param {WPBlock}                      block   Block instance.
- * @param {WPBlockSerializationOptions}  options Serialization options.
+ * @param {WPBlock}                     block   Block instance.
+ * @param {WPBlockSerializationOptions} options Serialization options.
  *
  * @return {string} Serialized block.
  */


### PR DESCRIPTION
Fixes ESLint warning for `serializeBlock`. Noticed while browsing the code.

```
Expected JSDoc block lines to be aligned.
```
