### PR TITLE
[Full Site Editing]: Update `clear customizations` copy for templates

### DIFF
--- a/packages/edit-post/src/components/header/template-title/delete-template.js
+++ b/packages/edit-post/src/components/header/template-title/delete-template.js
@@ -84,12 +84,12 @@ export default function DeleteTemplate() {
 					} }
 					info={
 						isRevertable
-							? __( 'Restore template to default state' )
+							? __( 'Use the template as supplied by the theme' )
 							: undefined
 					}
 				>
 					{ isRevertable
-						? __( 'Clear customizations' )
+						? __( 'Delete custom template' )
 						: __( 'Delete template' ) }
 				</MenuItem>
 				<ConfirmDialog

--- a/packages/edit-post/src/components/header/template-title/delete-template.js
+++ b/packages/edit-post/src/components/header/template-title/delete-template.js
@@ -84,12 +84,12 @@ export default function DeleteTemplate() {
 					} }
 					info={
 						isRevertable
-							? __( 'Use the template as supplied by the theme' )
+							? __( 'Use the template as supplied by the theme.' )
 							: undefined
 					}
 				>
 					{ isRevertable
-						? __( 'Delete custom template' )
+						? __( 'Clear customizations' )
 						: __( 'Delete template' ) }
 				</MenuItem>
 				<ConfirmDialog

--- a/packages/edit-site/src/components/list/actions/index.js
+++ b/packages/edit-site/src/components/list/actions/index.js
@@ -79,13 +79,15 @@ export default function Actions( { template } ) {
 					) }
 					{ isRevertable && (
 						<MenuItem
-							info={ __( 'Restore to default state' ) }
+							info={ __(
+								'Use the template as supplied by the theme'
+							) }
 							onClick={ () => {
 								revertAndSaveTemplate();
 								onClose();
 							} }
 						>
-							{ __( 'Clear customizations' ) }
+							{ __( 'Delete custom template' ) }
 						</MenuItem>
 					) }
 				</MenuGroup>

--- a/packages/edit-site/src/components/list/actions/index.js
+++ b/packages/edit-site/src/components/list/actions/index.js
@@ -80,14 +80,14 @@ export default function Actions( { template } ) {
 					{ isRevertable && (
 						<MenuItem
 							info={ __(
-								'Use the template as supplied by the theme'
+								'Use the template as supplied by the theme.'
 							) }
 							onClick={ () => {
 								revertAndSaveTemplate();
 								onClose();
 							} }
 						>
-							{ __( 'Delete custom template' ) }
+							{ __( 'Clear customizations' ) }
 						</MenuItem>
 					) }
 				</MenuGroup>

--- a/packages/edit-site/src/components/sidebar/template-card/template-actions.js
+++ b/packages/edit-site/src/components/sidebar/template-card/template-actions.js
@@ -28,13 +28,15 @@ export default function Actions( { template } ) {
 			{ ( { onClose } ) => (
 				<MenuGroup>
 					<MenuItem
-						info={ __( 'Restore to default state' ) }
+						info={ __(
+							'Use the template as supplied by the theme'
+						) }
 						onClick={ () => {
 							revertTemplate( template );
 							onClose();
 						} }
 					>
-						{ __( 'Clear customizations' ) }
+						{ __( 'Delete custom template' ) }
 					</MenuItem>
 				</MenuGroup>
 			) }

--- a/packages/edit-site/src/components/sidebar/template-card/template-actions.js
+++ b/packages/edit-site/src/components/sidebar/template-card/template-actions.js
@@ -29,14 +29,14 @@ export default function Actions( { template } ) {
 				<MenuGroup>
 					<MenuItem
 						info={ __(
-							'Use the template as supplied by the theme'
+							'Use the template as supplied by the theme.'
 						) }
 						onClick={ () => {
 							revertTemplate( template );
 							onClose();
 						} }
 					>
-						{ __( 'Delete custom template' ) }
+						{ __( 'Clear customizations' ) }
 					</MenuItem>
 				</MenuGroup>
 			) }

--- a/packages/edit-site/src/components/template-details/index.js
+++ b/packages/edit-site/src/components/template-details/index.js
@@ -79,10 +79,12 @@ export default function TemplateDetails( { template, onClose } ) {
 				<MenuGroup className="edit-site-template-details__group edit-site-template-details__revert">
 					<MenuItem
 						className="edit-site-template-details__revert-button"
-						info={ __( 'Restore template to default state' ) }
+						info={ __(
+							'Use the template as supplied by the theme'
+						) }
 						onClick={ revert }
 					>
-						{ __( 'Clear customizations' ) }
+						{ __( 'Delete custom template' ) }
 					</MenuItem>
 				</MenuGroup>
 			) }

--- a/packages/edit-site/src/components/template-details/index.js
+++ b/packages/edit-site/src/components/template-details/index.js
@@ -80,11 +80,11 @@ export default function TemplateDetails( { template, onClose } ) {
 					<MenuItem
 						className="edit-site-template-details__revert-button"
 						info={ __(
-							'Use the template as supplied by the theme'
+							'Use the template as supplied by the theme.'
 						) }
 						onClick={ revert }
 					>
-						{ __( 'Delete custom template' ) }
+						{ __( 'Clear customizations' ) }
 					</MenuItem>
 				</MenuGroup>
 			) }

--- a/packages/edit-site/src/components/template-details/template-areas.js
+++ b/packages/edit-site/src/components/template-details/template-areas.js
@@ -59,7 +59,9 @@ function TemplatePartItemMore( {
 			{ isTemplateRevertable( templatePart ) && (
 				<MenuGroup>
 					<MenuItem
-						info={ __( 'Restore template to default state' ) }
+						info={ __(
+							'Use the template part as supplied by the theme'
+						) }
 						onClick={ clearCustomizations }
 					>
 						{ __( 'Clear customizations' ) }

--- a/packages/edit-site/src/components/template-details/template-areas.js
+++ b/packages/edit-site/src/components/template-details/template-areas.js
@@ -64,7 +64,7 @@ function TemplatePartItemMore( {
 						) }
 						onClick={ clearCustomizations }
 					>
-						{ __( 'Clear customizations' ) }
+						{ __( 'Delete custom template part' ) }
 					</MenuItem>
 				</MenuGroup>
 			) }

--- a/packages/edit-site/src/components/template-details/template-areas.js
+++ b/packages/edit-site/src/components/template-details/template-areas.js
@@ -60,11 +60,11 @@ function TemplatePartItemMore( {
 				<MenuGroup>
 					<MenuItem
 						info={ __(
-							'Use the template part as supplied by the theme'
+							'Use the template part as supplied by the theme.'
 						) }
 						onClick={ clearCustomizations }
 					>
-						{ __( 'Delete custom template part' ) }
+						{ __( 'Clear customizations' ) }
 					</MenuItem>
 				</MenuGroup>
 			) }

--- a/test/e2e/specs/site-editor/template-revert.spec.js
+++ b/test/e2e/specs/site-editor/template-revert.spec.js
@@ -42,7 +42,7 @@ test.describe( 'Template Revert', () => {
 
 		// The revert button isn't visible anymore.
 		await expect(
-			page.locator( 'role=menuitem[name=/Clear customizations/i]' )
+			page.locator( 'role=menuitem[name=/Delete custom template/i]' )
 		).not.toBeVisible();
 	} );
 
@@ -279,7 +279,9 @@ class TemplateRevertUtils {
 
 	async revertTemplate() {
 		await this.page.click( 'role=button[name="Show template details"i]' );
-		await this.page.click( 'role=menuitem[name=/Clear customizations/i]' );
+		await this.page.click(
+			'role=menuitem[name=/Delete custom template/i]'
+		);
 		await this.page.waitForSelector(
 			'role=button[name="Dismiss this notice"i] >> text="Template reverted."'
 		);

--- a/test/e2e/specs/site-editor/template-revert.spec.js
+++ b/test/e2e/specs/site-editor/template-revert.spec.js
@@ -42,7 +42,7 @@ test.describe( 'Template Revert', () => {
 
 		// The revert button isn't visible anymore.
 		await expect(
-			page.locator( 'role=menuitem[name=/Delete custom template/i]' )
+			page.locator( 'role=menuitem[name=/Clear customizations/i]' )
 		).not.toBeVisible();
 	} );
 
@@ -279,9 +279,7 @@ class TemplateRevertUtils {
 
 	async revertTemplate() {
 		await this.page.click( 'role=button[name="Show template details"i]' );
-		await this.page.click(
-			'role=menuitem[name=/Delete custom template/i]'
-		);
+		await this.page.click( 'role=menuitem[name=/Clear customizations/i]' );
 		await this.page.waitForSelector(
 			'role=button[name="Dismiss this notice"i] >> text="Template reverted."'
 		);


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Resolves: https://github.com/WordPress/gutenberg/issues/30773

This PR updates the `clear customizations` copy for templates to revert user changes. Based on these two comments [1](https://github.com/WordPress/gutenberg/issues/36303#issuecomment-1156431276), [2](https://github.com/WordPress/gutenberg/issues/36303#issuecomment-1156544327):

>The wording of "revert to theme" doesn't imply an update or awareness that there is an update.

>Delete custom template
> Use the template as supplied by the theme
<!-- In a few words, what is the PR actually doing? -->



