### PR TITLE
BlockPreview: Fix 'Infinity' is invalid 'minHeight' value warning

### DIFF
--- a/packages/block-editor/src/components/block-preview/auto.js
+++ b/packages/block-editor/src/components/block-preview/auto.js
@@ -100,7 +100,7 @@ function AutoBlockPreview( {
 						// See: https://github.com/WordPress/gutenberg/pull/38175.
 						maxHeight: MAX_HEIGHT,
 						minHeight:
-							scale < 1 && __experimentalMinHeight
+							scale !== 0 && scale < 1 && __experimentalMinHeight
 								? __experimentalMinHeight / scale
 								: __experimentalMinHeight,
 					} }


### PR DESCRIPTION
## What?
PR fixes `Infinity is an invalid value for the minHeight CSS style property` warning triggered when opening Query Loop setup modal.

## Why?
tl;dr - Can't divide by zero.

The initial value of `containerWidth` is `null` before the resizer observer updates it. Because of this `scale` can be `0` and in JS `Number / 0 = Infinity`. 

### Test
```js
const scale = null / 600;
const minHeight = 450 / 0;

console.log( scale, minHeight );
```

## Testing Instructions
1. Open a Post or Page.
2. Insert a Query Loop Block.
3. Click on the "Choose" button to open the modal.
4. Confirm there's no warning in the console.

## Screenshots or screencast <!-- if applicable -->
![CleanShot 2022-06-16 at 12 47 17](https://user-images.githubusercontent.com/240569/174053835-f8d274c0-4430-469f-983e-f7737c88e12d.png)

