### PR TITLE
Components: Fix block editor crash when multiple Autocompleters are placed in the same block

### DIFF
--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -11,6 +11,7 @@
 -   `CustomGradientBar`: Fix insertion and control point positioning to more closely follow cursor. ([#41492](https://github.com/WordPress/gutenberg/pull/41492))
 -   `FormTokenField`: Added Padding to resolve close button overlap issue ([#41556](https://github.com/WordPress/gutenberg/pull/41556)).
 -   `ComboboxControl`: fix the autofocus behavior after resetting the value. ([#41737](https://github.com/WordPress/gutenberg/pull/41737)).
+-   `Autocomplete`: Prevent using multiple autocompleters in a single block from triggering an endless loop ([#41770](https://github.com/WordPress/gutenberg/pull/41770)).
 
 ### Enhancements
 

--- a/packages/components/src/autocomplete/index.js
+++ b/packages/components/src/autocomplete/index.js
@@ -278,6 +278,14 @@ function useAutocomplete( {
 		}
 	}, [ record ] );
 
+	// Used to track the number of filtered options for the subsequent useEffect
+	// This way, filteredOptions.length (which is part of state) isn't a dependency
+	// and cannot contribute to an infinite loop.
+	const filteredOptionsLengthRef = useRef();
+	useEffect( () => {
+		filteredOptionsLengthRef.current = filteredOptions.length;
+	}, [ filteredOptions.length ] );
+
 	useEffect( () => {
 		if ( ! textContent ) {
 			reset();
@@ -309,7 +317,7 @@ function useAutocomplete( {
 				// it will be caught by this guard.
 				if ( tooDistantFromTrigger ) return false;
 
-				const mismatch = filteredOptions.length === 0;
+				const mismatch = filteredOptionsLengthRef.current === 0;
 				const wordsFromTrigger = textWithoutTrigger.split( /\s/ );
 				// We need to allow the effect to run when not backspacing and if there
 				// was a mismatch. i.e when typing a trigger + the match string or when
@@ -375,14 +383,7 @@ function useAutocomplete( {
 				: AutocompleterUI
 		);
 		setFilterValue( query );
-	}, [
-		textContent,
-		AutocompleterUI,
-		autocompleter,
-		completers,
-		record,
-		filteredOptions.length,
-	] );
+	}, [ textContent, AutocompleterUI, autocompleter, completers, record ] );
 
 	const { key: selectedKey = '' } = filteredOptions[ selectedIndex ] || {};
 	const { className } = autocompleter || {};


### PR DESCRIPTION
## What?
Proposed fix for #41709
Dependent on #41749

## Why?
The `Autocomplete` component was [recently refactored](https://github.com/WordPress/gutenberg/pull/41382) to pass `exhaustive-deps`, and some of the new dependencies have had unexpected side effects. Specifically for this PR, if you have multiple Autocompleters you want to use in a single block, the second one can trigger a loop that crashes the editor.

## How?
This crash appears to have been triggered by the combination of two new `useEffect` dependencies:

1. `onChangeOptions` in `autocomplete/autocompleter-ui.js`: This function is re-declared on each render, resulting in a race condition that had other side effects. A fix for this is already proposed in #41749.
2. `filteredOptions.length` in `autocomplete/index.js`: This dependency triggered some extra renders, but on a single completer it didn't result in a loop.

When an autocompleter loads, the `filteredOptions.length` value starts off at zero, and then updates on a re-render when the available options load in. With `filteredOptions.length` as a dependency, this caused the effect to run again on that render.

During that extra render, the callback to `setAutoCompleterUI` would get stuck re-rendering endlessly, switching between the two different completers each time.

Storing `filteredOptions.length` in a new Ref lets us remove it from the dep array. This way when the updated options load in, an additional render won't be triggered when the new number is populated, avoiding the loop.

## Testing Instructions
First, I'd recommend reproducing the bug using @johngodley's excellent repro steps in the [original issue](https://github.com/WordPress/gutenberg/issues/41709) so you can see the loop/crash in action.

Once you've un-stuck your browser, you'll need to apply the fix in #41749 on top of this PR. That will prevent `onChangeOptions` from contributing to the loop. Cherry pick the commits from that PR onto this one (feel free to skip the CHANGELOG update, of course).

Repeat the test by creating a new post and typing a combination of `@user +user @user` autocompleters.
