### PR TITLE
Navigation submenus: Allow Escape key to close the submenu and focus trigger

### DIFF
--- a/packages/block-library/src/navigation-submenu/view.js
+++ b/packages/block-library/src/navigation-submenu/view.js
@@ -49,13 +49,16 @@ document.addEventListener( 'click', function ( event ) {
 		}
 	} );
 } );
-// Close on focus outside.
+// Close on focus outside or escape key.
 document.addEventListener( 'keyup', function ( event ) {
 	const submenuBlocks = document.querySelectorAll(
-		'.wp-block-navigation-submenu'
+		'.wp-block-navigation-item.has-child'
 	);
-	submenuBlocks.forEach( ( block ) => {
-		if ( ! block.contains( event.target ) ) {
+	submenuBlocks.forEach( function ( block ) {
+		if (
+			! block.contains( event.target ) ||
+			( block.contains( event.target ) && event.key === 'Escape' )
+		) {
 			closeSubmenus( block );
 		}
 	} );

--- a/packages/block-library/src/navigation-submenu/view.js
+++ b/packages/block-library/src/navigation-submenu/view.js
@@ -3,6 +3,7 @@ const closeSubmenus = ( element ) => {
 		.querySelectorAll( '[aria-expanded="true"]' )
 		.forEach( ( toggle ) => {
 			toggle.setAttribute( 'aria-expanded', 'false' );
+			// Always focus the trigger, this becomes especially useful in closing submenus with escape key to ensure focus doesn't get trapped.
 			toggle.focus();
 		} );
 };

--- a/packages/block-library/src/navigation-submenu/view.js
+++ b/packages/block-library/src/navigation-submenu/view.js
@@ -52,9 +52,9 @@ document.addEventListener( 'click', function ( event ) {
 // Close on focus outside or escape key.
 document.addEventListener( 'keyup', function ( event ) {
 	const submenuBlocks = document.querySelectorAll(
-		'.wp-block-navigation-item.has-child'
+		'.wp-block-navigation-submenu'
 	);
-	submenuBlocks.forEach( function ( block ) {
+	submenuBlocks.forEach( ( block ) => {
 		if (
 			! block.contains( event.target ) ||
 			( block.contains( event.target ) && event.key === 'Escape' )

--- a/packages/block-library/src/navigation-submenu/view.js
+++ b/packages/block-library/src/navigation-submenu/view.js
@@ -3,6 +3,7 @@ const closeSubmenus = ( element ) => {
 		.querySelectorAll( '[aria-expanded="true"]' )
 		.forEach( ( toggle ) => {
 			toggle.setAttribute( 'aria-expanded', 'false' );
+			toggle.focus();
 		} );
 };
 

--- a/packages/block-library/src/navigation/view.js
+++ b/packages/block-library/src/navigation/view.js
@@ -4,6 +4,7 @@ function closeSubmenus( element ) {
 		.querySelectorAll( '[aria-expanded="true"]' )
 		.forEach( function ( toggle ) {
 			toggle.setAttribute( 'aria-expanded', 'false' );
+			toggle.focus();
 		} );
 }
 
@@ -55,13 +56,16 @@ window.addEventListener( 'load', () => {
 			}
 		} );
 	} );
-	// Close on focus outside.
+	// Close on focus outside or escape key.
 	document.addEventListener( 'keyup', function ( event ) {
 		const submenuBlocks = document.querySelectorAll(
 			'.wp-block-navigation-item.has-child'
 		);
 		submenuBlocks.forEach( function ( block ) {
-			if ( ! block.contains( event.target ) ) {
+			if (
+				! block.contains( event.target ) ||
+				( block.contains( event.target ) && event.key === 'Escape' )
+			) {
 				closeSubmenus( block );
 			}
 		} );

--- a/packages/block-library/src/navigation/view.js
+++ b/packages/block-library/src/navigation/view.js
@@ -4,6 +4,7 @@ function closeSubmenus( element ) {
 		.querySelectorAll( '[aria-expanded="true"]' )
 		.forEach( function ( toggle ) {
 			toggle.setAttribute( 'aria-expanded', 'false' );
+			// Always focus the trigger, this becomes especially useful in closing submenus with escape key to ensure focus doesn't get trapped.
 			toggle.focus();
 		} );
 }


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Adding the ability to close open submenus via Escape key and focus the submenu trigger.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

For better accessibility.

- https://github.com/WordPress/wporg-mu-plugins/issues/207
- https://github.com/WordPress/wporg-mu-plugins/pull/210

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

Modify the JS on the front-end.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->

1. Create a submenu using the navigation block.
2. Open the front-end.
3. Tab to the submenu trigger.
4. Press Escape.
5. Check to ensure `aria-expanded` was removed and the submenu trigger should not have lost focus.

## Screenshots or screencast <!-- if applicable -->
