### PR TITLE
Lodash: Refactor away from `_.isNumber()`

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -90,6 +90,7 @@ module.exports = {
 							'isArray',
 							'isFinite',
 							'isFunction',
+							'isNumber',
 							'isObjectLike',
 							'isUndefined',
 							'keys',

--- a/packages/annotations/src/store/reducer.js
+++ b/packages/annotations/src/store/reducer.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { isNumber, mapValues } from 'lodash';
+import { mapValues } from 'lodash';
 
 /**
  * Filters an array based on the predicate, but keeps the reference the same if
@@ -28,8 +28,8 @@ function filterWithReference( collection, predicate ) {
  */
 function isValidAnnotationRange( annotation ) {
 	return (
-		isNumber( annotation.start ) &&
-		isNumber( annotation.end ) &&
+		typeof annotation.start === 'number' &&
+		typeof annotation.end === 'number' &&
 		annotation.start <= annotation.end
 	);
 }

--- a/packages/components/src/box-control/utils.js
+++ b/packages/components/src/box-control/utils.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { isEmpty, isNumber } from 'lodash';
+import { isEmpty } from 'lodash';
 
 /**
  * WordPress dependencies
@@ -82,16 +82,16 @@ export function getAllValue(
 		: '';
 
 	/**
-	 * The isNumber check is important. On reset actions, the incoming value
+	 * The typeof === 'number' check is important. On reset actions, the incoming value
 	 * may be null or an empty string.
 	 *
 	 * Also, the value may also be zero (0), which is considered a valid unit value.
 	 *
-	 * isNumber() is more specific for these cases, rather than relying on a
+	 * typeof === 'number' is more specific for these cases, rather than relying on a
 	 * simple truthy check.
 	 */
 	let commonUnit;
-	if ( isNumber( commonQuantity ) ) {
+	if ( typeof commonQuantity === 'number' ) {
 		commonUnit = mode( allParsedUnits );
 	} else {
 		// Set meaningful unit selection if no commonQuantity and user has previously

--- a/packages/element/src/utils.js
+++ b/packages/element/src/utils.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { isNumber, isString } from 'lodash';
+import { isString } from 'lodash';
 
 /**
  * Checks if the provided WP element is empty.
@@ -10,7 +10,7 @@ import { isNumber, isString } from 'lodash';
  * @return {boolean} True when an element is considered empty.
  */
 export const isEmptyElement = ( element ) => {
-	if ( isNumber( element ) ) {
+	if ( typeof element === 'number' ) {
 		return false;
 	}
 

--- a/packages/shortcode/src/index.js
+++ b/packages/shortcode/src/index.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { extend, pick, isString, isEqual, forEach, isNumber } from 'lodash';
+import { extend, pick, isString, isEqual, forEach } from 'lodash';
 import memize from 'memize';
 
 /**
@@ -316,7 +316,9 @@ extend( shortcode.prototype, {
 	 * @return {string} Attribute value.
 	 */
 	get( attr ) {
-		return this.attrs[ isNumber( attr ) ? 'numeric' : 'named' ][ attr ];
+		return this.attrs[ typeof attr === 'number' ? 'numeric' : 'named' ][
+			attr
+		];
 	},
 
 	/**
@@ -331,7 +333,8 @@ extend( shortcode.prototype, {
 	 * @return {WPShortcode} Shortcode instance.
 	 */
 	set( attr, value ) {
-		this.attrs[ isNumber( attr ) ? 'numeric' : 'named' ][ attr ] = value;
+		this.attrs[ typeof attr === 'number' ? 'numeric' : 'named' ][ attr ] =
+			value;
 		return this;
 	},
 


### PR DESCRIPTION
## What?
Lodash's `isNumber()` is used only a few times in the entire codebase. This PR aims to remove that usage.

## Why?
Lodash is known to unnecessarily inflate the bundle size of packages, and in most cases, it can be replaced with native language functionality. See these for more information and rationale:

* https://github.com/WordPress/gutenberg/issues/16938#issuecomment-602837246
* https://github.com/WordPress/gutenberg/issues/17025
* https://github.com/WordPress/gutenberg/issues/39495 

## How?
Removing `_.isNumber()` is straightforward in favor of a simple `typeof x === 'number'`. 

There's one special case that Lodash used to handle, when we use the constructor syntax `new Number( 5 )`, and we're not handling that here. I believe that this makes sense - the `new Number(5)` actually produces a wrapper object, and as an object, it's not really a number. So we intentionally don't support this. We have no usages of this in the codebase and I'd suggest not encouraging it anyway.

## Testing Instructions
* Verify `BoxControl` in a `Gallery` block still works well.
* Verify shortcodes with numeric and string attributes are still parsed well.
* Verify all tests still pass.