### PR TITLE
Lodash: Refactor away from `_.chunk()`

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -79,6 +79,7 @@ module.exports = {
 					{
 						name: 'lodash',
 						importNames: [
+							'chunk',
 							'clamp',
 							'concat',
 							'defaultTo',

--- a/packages/core-data/src/batch/default-processor.js
+++ b/packages/core-data/src/batch/default-processor.js
@@ -1,9 +1,4 @@
 /**
- * External dependencies
- */
-import { chunk } from 'lodash';
-
-/**
  * WordPress dependencies
  */
 import apiFetch from '@wordpress/api-fetch';
@@ -15,6 +10,16 @@ import apiFetch from '@wordpress/api-fetch';
  * @type {number?}
  */
 let maxItems = null;
+
+function chunk( arr, chunkSize ) {
+	const tmp = [ ...arr ];
+	const cache = [];
+	while ( tmp.length ) {
+		cache.push( tmp.splice( 0, chunkSize ) );
+	}
+
+	return cache;
+}
 
 /**
  * Default batch processor. Sends its input requests to /batch/v1.


### PR DESCRIPTION
## What?
Lodash's `chunk()` is used only once a couple of times in the entire codebase. This PR aims to remove that usage.

## Why?
Lodash is known to unnecessarily inflate the bundle size of packages, and in most cases, it can be replaced with native language functionality. See these for more information and rationale:

* https://github.com/WordPress/gutenberg/issues/16938#issuecomment-602837246
* https://github.com/WordPress/gutenberg/issues/17025
* https://github.com/WordPress/gutenberg/issues/39495 

## How?
We're removing `_.chunk()` in favor of a custom imperative approach. Alternatively, we could try a declarative one that fits the code style here more, for example:

```
const chunk = ( array, chunkSize ) =>
	array.reduce(
		( arr, item, idx ) =>
			idx % chunkSize === 0
				? [ ...arr, [ item ] ]
				: [ ...arr.slice( 0, -1 ), [ ...arr.slice( -1 )[ 0 ], item ] ],
		[]
	);

```

But you'll notice it looks way more complex and less readable, which is why I went with the imperative one.

## Testing Instructions
Verify all tests still pass.