### PR TITLE
Block Library (Avatar Block): Remove Unnecessary '&& check' as 'optional chaining (authorDetails?.avatar_urls) check' is already used

### DIFF
--- a/packages/block-library/src/avatar/hooks.js
+++ b/packages/block-library/src/avatar/hooks.js
@@ -76,15 +76,12 @@ export function useUserAvatar( { userId, postId, postType } ) {
 		},
 		[ postType, postId, userId ]
 	);
-
-	const avatarUrls =
-		authorDetails && authorDetails?.avatar_urls
-			? Object.values( authorDetails.avatar_urls )
-			: null;
-	const sizes =
-		authorDetails && authorDetails?.avatar_urls
-			? Object.keys( authorDetails.avatar_urls )
-			: null;
+	const avatarUrls = authorDetails?.avatar_urls
+		? Object.values( authorDetails.avatar_urls )
+		: null;
+	const sizes = authorDetails?.avatar_urls
+		? Object.keys( authorDetails.avatar_urls )
+		: null;
 	const { minSize, maxSize } = getAvatarSizes( sizes );
 	const defaultAvatar = useDefaultAvatar();
 	return {


### PR DESCRIPTION
#### Hey Everyone, This is my first PR. Please review it. 🙂

## What?
In line number 81 & 85, There's `&&` check for `authorDetails` and then optional chaining (`?.`) is used. Looks like using both of them together is unnecessary. 
Just only using `authorDetails && authorDetails.avatar_urls` without the 'optional chaining (`?`)' is enough.
Or Just only using the latter check like `authorDetails?.avatar_urls` is also enough. (I did this one in my PR)

## Why?
In the scenario where `authorDetails` is `null` or `undefined`, just using the optional chaining check like this: `authorDetails?.avatar_urls`  will prevent any error and will return 'undefined'. So, in that scenario there won't be any error and also as `Conditional (ternary) operator` is used for `avatarUrls` & `sizes`, both of this will be `null` (won't cause any error). 