### PR TITLE
Lodash: Refactor away from `_.isNil()`

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -90,6 +90,7 @@ module.exports = {
 							'isArray',
 							'isFinite',
 							'isFunction',
+							'isNil',
 							'isNumber',
 							'isObjectLike',
 							'isUndefined',

--- a/packages/blocks/src/api/registration.js
+++ b/packages/blocks/src/api/registration.js
@@ -6,7 +6,6 @@
 import {
 	camelCase,
 	isEmpty,
-	isNil,
 	isObject,
 	isString,
 	mapKeys,
@@ -177,7 +176,10 @@ export function unstable__bootstrapServerSideBlockDefinitions( definitions ) {
 			continue;
 		}
 		serverSideBlockDefinitions[ blockName ] = mapKeys(
-			pickBy( definitions[ blockName ], ( value ) => ! isNil( value ) ),
+			pickBy(
+				definitions[ blockName ],
+				( value ) => value !== null && typeof value !== 'undefined'
+			),
 			( value, key ) => camelCase( key )
 		);
 	}

--- a/packages/blocks/src/api/registration.js
+++ b/packages/blocks/src/api/registration.js
@@ -178,7 +178,7 @@ export function unstable__bootstrapServerSideBlockDefinitions( definitions ) {
 		serverSideBlockDefinitions[ blockName ] = mapKeys(
 			pickBy(
 				definitions[ blockName ],
-				( value ) => value !== null && typeof value !== 'undefined'
+				( value ) => value !== null && value !== undefined
 			),
 			( value, key ) => camelCase( key )
 		);

--- a/packages/components/src/elevation/hook.js
+++ b/packages/components/src/elevation/hook.js
@@ -2,7 +2,6 @@
  * External dependencies
  */
 import { css } from '@emotion/react';
-import { isNil } from 'lodash';
 
 /**
  * WordPress dependencies
@@ -16,6 +15,7 @@ import { useContextSystem } from '../ui/context';
 import * as styles from './styles';
 import { CONFIG, reduceMotion } from '../utils';
 import { useCx } from '../utils/hooks/use-cx';
+import { isValueDefined } from '../utils/values';
 
 /**
  * @param {number} value
@@ -49,13 +49,13 @@ export function useElevation( props ) {
 
 	const classes = useMemo( () => {
 		/** @type {number | undefined} */
-		let hoverValue = ! isNil( hover ) ? hover : value * 2;
+		let hoverValue = isValueDefined( hover ) ? hover : value * 2;
 		/** @type {number | undefined} */
-		let activeValue = ! isNil( active ) ? active : value / 2;
+		let activeValue = isValueDefined( active ) ? active : value / 2;
 
 		if ( ! isInteractive ) {
-			hoverValue = ! isNil( hover ) ? hover : undefined;
-			activeValue = ! isNil( active ) ? active : undefined;
+			hoverValue = isValueDefined( hover ) ? hover : undefined;
+			activeValue = isValueDefined( active ) ? active : undefined;
 		}
 
 		const transition = `box-shadow ${ CONFIG.transitionDuration } ${ CONFIG.transitionTimingFunction }`;
@@ -76,7 +76,7 @@ export function useElevation( props ) {
 			reduceMotion( 'transition' )
 		);
 
-		if ( ! isNil( hoverValue ) ) {
+		if ( isValueDefined( hoverValue ) ) {
 			sx.hover = css`
 				*:hover > & {
 					box-shadow: ${ getBoxShadow( hoverValue ) };
@@ -84,7 +84,7 @@ export function useElevation( props ) {
 			`;
 		}
 
-		if ( ! isNil( activeValue ) ) {
+		if ( isValueDefined( activeValue ) ) {
 			sx.active = css`
 				*:active > & {
 					box-shadow: ${ getBoxShadow( activeValue ) };
@@ -92,7 +92,7 @@ export function useElevation( props ) {
 			`;
 		}
 
-		if ( ! isNil( focus ) ) {
+		if ( isValueDefined( focus ) ) {
 			sx.focus = css`
 				*:focus > & {
 					box-shadow: ${ getBoxShadow( focus ) };

--- a/packages/components/src/h-stack/utils.js
+++ b/packages/components/src/h-stack/utils.js
@@ -1,7 +1,7 @@
 /**
- * External dependencies
+ * Internal dependencies
  */
-import { isNil } from 'lodash';
+import { isValueDefined } from '../utils/values';
 
 /** @type {import('./types').Alignments} */
 const ALIGNMENTS = {
@@ -41,7 +41,7 @@ const V_ALIGNMENTS = {
  */
 /* eslint-enable jsdoc/valid-types */
 export function getAlignmentProps( alignment, direction = 'row' ) {
-	if ( isNil( alignment ) ) {
+	if ( ! isValueDefined( alignment ) ) {
 		return {};
 	}
 	const isVertical = direction === 'column';

--- a/packages/components/src/truncate/utils.js
+++ b/packages/components/src/truncate/utils.js
@@ -1,7 +1,7 @@
 /**
- * External dependencies
+ * Internal dependencies
  */
-import { isNil } from 'lodash';
+import { isValueDefined } from '../utils/values';
 
 export const TRUNCATE_ELLIPSIS = '…';
 export const TRUNCATE_TYPE = {
@@ -38,7 +38,9 @@ export function truncateMiddle( word, headLength, tailLength, ellipsis ) {
 	// eslint-disable-next-line no-bitwise
 	const backLength = ~~tailLength;
 	/* istanbul ignore next */
-	const truncateStr = ! isNil( ellipsis ) ? ellipsis : TRUNCATE_ELLIPSIS;
+	const truncateStr = isValueDefined( ellipsis )
+		? ellipsis
+		: TRUNCATE_ELLIPSIS;
 
 	if (
 		( frontLength === 0 && backLength === 0 ) ||


### PR DESCRIPTION
## What?
Lodash's `isNil()` is used only once in the entire codebase. This PR aims to remove that usage.

## Why?
Lodash is known to unnecessarily inflate the bundle size of packages, and in most cases, it can be replaced with native language functionality. See these for more information and rationale:

* https://github.com/WordPress/gutenberg/issues/16938#issuecomment-602837246
* https://github.com/WordPress/gutenberg/issues/17025
* https://github.com/WordPress/gutenberg/issues/39495 

## How?
Removing `_.isNil()` is straightforward in favor of checking if the value is a `null` or `undefined`.

## Testing Instructions
* Spin up storybook: `npm run storybook:dev`
* Verify the Elevation component still works well.
* Verify the HStack component still works well.
* Verify the ColorPalette component (particularly the selected color name) still works well.
* Verify block registration still works well and all server-side registered blocks still work.