### PR TITLE
Support pseudo selectors on `elements` in theme json

### DIFF
--- a/lib/compat/wordpress-6.1/class-wp-theme-json-6-1.php
+++ b/lib/compat/wordpress-6.1/class-wp-theme-json-6-1.php
@@ -22,7 +22,7 @@ class WP_Theme_JSON_6_1 extends WP_Theme_JSON_6_0 {
 	 * Note: this will effect both top level and block level elements.
 	 */
 	const VALID_ELEMENT_PSEUDO_SELECTORS = array(
-		'link' => array( ':hover', ':focus' ),
+		'link' => array( ':hover', ':focus', ':active' ),
 	);
 
 	const ELEMENTS = array(

--- a/lib/compat/wordpress-6.1/class-wp-theme-json-6-1.php
+++ b/lib/compat/wordpress-6.1/class-wp-theme-json-6-1.php
@@ -175,7 +175,7 @@ class WP_Theme_JSON_6_1 extends WP_Theme_JSON_6_0 {
 			$output = static::remove_insecure_styles( $input );
 
 			// Get a reference to element name from path.
-			// $metadata['path'] = array('styles','elements','link');
+			// $metadata['path'] = array('styles','elements','link');.
 			$current_element = $metadata['path'][ count( $metadata['path'] ) - 1 ];
 
 			// $output is stripped of pseudo selectors. Readd and process them
@@ -460,12 +460,12 @@ class WP_Theme_JSON_6_1 extends WP_Theme_JSON_6_0 {
 		// Attempt to parse a pseudo selector (e.g. ":hover") from the $selector ("a:hover").
 		$pseudo_matches = array();
 		preg_match( '/:[a-z]+/', $selector, $pseudo_matches );
-		$pseudo_selector = $pseudo_matches[0] ?? null;
+		$pseudo_selector = $pseudo_matches[0] ? $pseudo_matches[0] : null;
 
 		// Get a reference to element name from path.
 		// $block_metadata['path'] = array('styles','elements','link');
 		// Make sure that $block_metadata['path'] describes an element node, like ['styles', 'element', 'link'].
-		// Skip non-element paths like just ['styles']
+		// Skip non-element paths like just ['styles'].
 		$is_processing_element = in_array( 'elements', $block_metadata['path'], true );
 
 		$current_element = $is_processing_element ? $block_metadata['path'][ count( $block_metadata['path'] ) - 1 ] : null;
@@ -473,7 +473,6 @@ class WP_Theme_JSON_6_1 extends WP_Theme_JSON_6_0 {
 		// If the current selector is a pseudo selector that's defined in the allow list for the current
 		// element then compute the style properties for it.
 		// Otherwise just compute the styles for the default selector as normal.
-		$declarations_pseudo_selectors = array();
 		if ( $pseudo_selector && isset( $node[ $pseudo_selector ] ) && isset( static::VALID_ELEMENT_PSEUDO_SELECTORS[ $current_element ] ) && in_array( $pseudo_selector, static::VALID_ELEMENT_PSEUDO_SELECTORS[ $current_element ], true ) ) {
 			$declarations = static::compute_style_properties( $node[ $pseudo_selector ], $settings );
 		} else {

--- a/lib/compat/wordpress-6.1/class-wp-theme-json-6-1.php
+++ b/lib/compat/wordpress-6.1/class-wp-theme-json-6-1.php
@@ -460,7 +460,7 @@ class WP_Theme_JSON_6_1 extends WP_Theme_JSON_6_0 {
 		// Attempt to parse a pseudo selector (e.g. ":hover") from the $selector ("a:hover").
 		$pseudo_matches = array();
 		preg_match( '/:[a-z]+/', $selector, $pseudo_matches );
-		$pseudo_selector = $pseudo_matches[0] ? $pseudo_matches[0] : null;
+		$pseudo_selector = isset( $pseudo_matches[0] ) ? $pseudo_matches[0] : null;
 
 		// Get a reference to element name from path.
 		// $block_metadata['path'] = array('styles','elements','link');

--- a/lib/compat/wordpress-6.1/class-wp-theme-json-6-1.php
+++ b/lib/compat/wordpress-6.1/class-wp-theme-json-6-1.php
@@ -466,14 +466,15 @@ class WP_Theme_JSON_6_1 extends WP_Theme_JSON_6_0 {
 		// $block_metadata['path'] = array('styles','elements','link');
 		// Make sure that $block_metadata['path'] describes an element node, like ['styles', 'element', 'link'].
 		// Skip non-element paths like just ['styles']
-		$is_processing_element = count( $block_metadata['path'] ) === 3 && 'elements' === $block_metadata['path'][1];
-		$current_element       = $is_processing_element ? $block_metadata['path'][ count( $block_metadata['path'] ) - 1 ] : null;
+		$is_processing_element = in_array( 'elements', $block_metadata['path'], true );
+
+		$current_element = $is_processing_element ? $block_metadata['path'][ count( $block_metadata['path'] ) - 1 ] : null;
 
 		// If the current selector is a pseudo selector that's defined in the allow list for the current
 		// element then compute the style properties for it.
 		// Otherwise just compute the styles for the default selector as normal.
 		$declarations_pseudo_selectors = array();
-		if ( $pseudo_selector && isset( $node[ $pseudo_selector ] ) && isset( static::VALID_ELEMENT_PSEUDO_SELECTORS[ $current_element ] ) && in_array( $pseudo_selector, static::VALID_ELEMENT_PSEUDO_SELECTORS[ $current_element ] ) ) {
+		if ( $pseudo_selector && isset( $node[ $pseudo_selector ] ) && isset( static::VALID_ELEMENT_PSEUDO_SELECTORS[ $current_element ] ) && in_array( $pseudo_selector, static::VALID_ELEMENT_PSEUDO_SELECTORS[ $current_element ], true ) ) {
 			$declarations = static::compute_style_properties( $node[ $pseudo_selector ], $settings );
 		} else {
 			$declarations = static::compute_style_properties( $node, $settings );

--- a/lib/compat/wordpress-6.1/class-wp-theme-json-6-1.php
+++ b/lib/compat/wordpress-6.1/class-wp-theme-json-6-1.php
@@ -464,7 +464,10 @@ class WP_Theme_JSON_6_1 extends WP_Theme_JSON_6_0 {
 
 		// Get a reference to element name from path.
 		// $block_metadata['path'] = array('styles','elements','link');
-		$current_element = $block_metadata['path'][ count( $block_metadata['path'] ) - 1 ];
+		// Make sure that $block_metadata['path'] describes an element node, like ['styles', 'element', 'link'].
+		// Skip non-element paths like just ['styles']
+		$is_processing_element = count( $block_metadata['path'] ) === 3 && $block_metadata['path'][1] === 'elements';
+		$current_element = $is_processing_element ? $block_metadata['path'][ count( $block_metadata['path'] ) - 1 ] : nulll;
 
 		// If the current selector is a pseudo selector that's defined in the allow list for the current
 		// element then compute the style properties for it.

--- a/lib/compat/wordpress-6.1/class-wp-theme-json-6-1.php
+++ b/lib/compat/wordpress-6.1/class-wp-theme-json-6-1.php
@@ -15,6 +15,16 @@
  * @access private
  */
 class WP_Theme_JSON_6_1 extends WP_Theme_JSON_6_0 {
+
+	/**
+	 * Whitelist which defines which pseudo selectors are enabled for
+	 * which elements.
+	 * Note: this will effect both top level and block level elements.
+	 */
+	const VALID_ELEMENT_PSEUDO_SELECTORS = array(
+		'link' => array( ':hover', ':focus' ),
+	);
+
 	const ELEMENTS = array(
 		'link'   => 'a',
 		'h1'     => 'h1',
@@ -42,6 +52,176 @@ class WP_Theme_JSON_6_1 extends WP_Theme_JSON_6_0 {
 	public static function get_element_class_name( $element ) {
 		return array_key_exists( $element, static::__EXPERIMENTAL_ELEMENT_CLASS_NAMES ) ? static::__EXPERIMENTAL_ELEMENT_CLASS_NAMES[ $element ] : '';
 	}
+
+	/**
+	 * Sanitizes the input according to the schemas.
+	 *
+	 * @since 5.8.0
+	 * @since 5.9.0 Added the `$valid_block_names` and `$valid_element_name` parameters.
+	 *
+	 * @param array $input               Structure to sanitize.
+	 * @param array $valid_block_names   List of valid block names.
+	 * @param array $valid_element_names List of valid element names.
+	 * @return array The sanitized output.
+	 */
+	protected static function sanitize( $input, $valid_block_names, $valid_element_names ) {
+
+		$output = array();
+
+		if ( ! is_array( $input ) ) {
+			return $output;
+		}
+
+		// Preserve only the top most level keys.
+		$output = array_intersect_key( $input, array_flip( static::VALID_TOP_LEVEL_KEYS ) );
+
+		// Remove any rules that are annotated as "top" in VALID_STYLES constant.
+		// Some styles are only meant to be available at the top-level (e.g.: blockGap),
+		// hence, the schema for blocks & elements should not have them.
+		$styles_non_top_level = static::VALID_STYLES;
+		foreach ( array_keys( $styles_non_top_level ) as $section ) {
+			foreach ( array_keys( $styles_non_top_level[ $section ] ) as $prop ) {
+				if ( 'top' === $styles_non_top_level[ $section ][ $prop ] ) {
+					unset( $styles_non_top_level[ $section ][ $prop ] );
+				}
+			}
+		}
+
+		// Build the schema based on valid block & element names.
+		$schema                 = array();
+		$schema_styles_elements = array();
+
+		// Set allowed element pseudo selectors based on per element allow list.
+		// Target data structure in schema:
+		// e.g.
+		// - top level elements: `$schema['styles']['elements']['link'][':hover']`.
+		// - block level elements: `$schema['styles']['blocks']['core/button']['elements']['link'][':hover']`.
+		foreach ( $valid_element_names as $element ) {
+			$schema_styles_elements[ $element ] = $styles_non_top_level;
+
+			if ( array_key_exists( $element, static::VALID_ELEMENT_PSEUDO_SELECTORS ) ) {
+				foreach ( static::VALID_ELEMENT_PSEUDO_SELECTORS[ $element ] as $pseudo_selector ) {
+					$schema_styles_elements[ $element ][ $pseudo_selector ] = $styles_non_top_level;
+				}
+			}
+		}
+
+		$schema_styles_blocks   = array();
+		$schema_settings_blocks = array();
+		foreach ( $valid_block_names as $block ) {
+			$schema_settings_blocks[ $block ]           = static::VALID_SETTINGS;
+			$schema_styles_blocks[ $block ]             = $styles_non_top_level;
+			$schema_styles_blocks[ $block ]['elements'] = $schema_styles_elements;
+		}
+
+		$schema['styles']             = static::VALID_STYLES;
+		$schema['styles']['blocks']   = $schema_styles_blocks;
+		$schema['styles']['elements'] = $schema_styles_elements;
+		$schema['settings']           = static::VALID_SETTINGS;
+		$schema['settings']['blocks'] = $schema_settings_blocks;
+
+		// Remove anything that's not present in the schema.
+		foreach ( array( 'styles', 'settings' ) as $subtree ) {
+			if ( ! isset( $input[ $subtree ] ) ) {
+				continue;
+			}
+
+			if ( ! is_array( $input[ $subtree ] ) ) {
+				unset( $output[ $subtree ] );
+				continue;
+			}
+
+			$result = static::remove_keys_not_in_schema( $input[ $subtree ], $schema[ $subtree ] );
+
+			if ( empty( $result ) ) {
+				unset( $output[ $subtree ] );
+			} else {
+				$output[ $subtree ] = $result;
+			}
+		}
+
+		return $output;
+	}
+
+
+
+	/**
+	 * Removes insecure data from theme.json.
+	 *
+	 * @since 5.9.0
+	 *
+	 * @param array $theme_json Structure to sanitize.
+	 * @return array Sanitized structure.
+	 */
+	public static function remove_insecure_properties( $theme_json ) {
+		$sanitized = array();
+
+		$theme_json = WP_Theme_JSON_Schema::migrate( $theme_json );
+
+		$valid_block_names   = array_keys( static::get_blocks_metadata() );
+		$valid_element_names = array_keys( static::ELEMENTS );
+
+		$theme_json = static::sanitize( $theme_json, $valid_block_names, $valid_element_names );
+
+		$blocks_metadata = static::get_blocks_metadata();
+		$style_nodes     = static::get_style_nodes( $theme_json, $blocks_metadata );
+
+		foreach ( $style_nodes as $metadata ) {
+			$input = _wp_array_get( $theme_json, $metadata['path'], array() );
+			if ( empty( $input ) ) {
+				continue;
+			}
+
+			$output = static::remove_insecure_styles( $input );
+
+			// Get a reference to element name from path.
+			// $metadata['path'] = array('styles','elements','link');
+			$current_element = $metadata['path'][ count( $metadata['path'] ) - 1 ];
+
+			// $output is stripped of pseudo selectors. Readd and process them
+			// for insecure styles here.
+			if ( isset( static::VALID_ELEMENT_PSEUDO_SELECTORS[ $current_element ] ) ) {
+
+				foreach ( static::VALID_ELEMENT_PSEUDO_SELECTORS[ $current_element ] as $pseudo_selector ) {
+					if ( isset( $input[ $pseudo_selector ] ) ) {
+						$output[ $pseudo_selector ] = static::remove_insecure_styles( $input[ $pseudo_selector ] );
+					}
+				}
+			}
+
+			if ( ! empty( $output ) ) {
+				_wp_array_set( $sanitized, $metadata['path'], $output );
+			}
+		}
+
+		$setting_nodes = static::get_setting_nodes( $theme_json );
+		foreach ( $setting_nodes as $metadata ) {
+			$input = _wp_array_get( $theme_json, $metadata['path'], array() );
+			if ( empty( $input ) ) {
+				continue;
+			}
+
+			$output = static::remove_insecure_settings( $input );
+			if ( ! empty( $output ) ) {
+				_wp_array_set( $sanitized, $metadata['path'], $output );
+			}
+		}
+
+		if ( empty( $sanitized['styles'] ) ) {
+			unset( $theme_json['styles'] );
+		} else {
+			$theme_json['styles'] = $sanitized['styles'];
+		}
+
+		if ( empty( $sanitized['settings'] ) ) {
+			unset( $theme_json['settings'] );
+		} else {
+			$theme_json['settings'] = $sanitized['settings'];
+		}
+
+		return $theme_json;
+	}
+
 
 	/**
 	 * Returns the metadata for each block.
@@ -156,11 +336,27 @@ class WP_Theme_JSON_6_1 extends WP_Theme_JSON_6_0 {
 		);
 
 		if ( isset( $theme_json['styles']['elements'] ) ) {
+
 			foreach ( $theme_json['styles']['elements'] as $element => $node ) {
+
+				// Handle element defaults.
 				$nodes[] = array(
 					'path'     => array( 'styles', 'elements', $element ),
 					'selector' => static::ELEMENTS[ $element ],
 				);
+
+				// Handle any pseudo selectors for the element.
+				if ( isset( static::VALID_ELEMENT_PSEUDO_SELECTORS[ $element ] ) ) {
+					foreach ( static::VALID_ELEMENT_PSEUDO_SELECTORS[ $element ] as $pseudo_selector ) {
+
+						if ( isset( $theme_json['styles']['elements'][ $element ][ $pseudo_selector ] ) ) {
+							$nodes[] = array(
+								'path'     => array( 'styles', 'elements', $element ),
+								'selector' => static::ELEMENTS[ $element ] . $pseudo_selector,
+							);
+						}
+					}
+				}
 			}
 		}
 
@@ -228,6 +424,18 @@ class WP_Theme_JSON_6_1 extends WP_Theme_JSON_6_0 {
 						'path'     => array( 'styles', 'blocks', $name, 'elements', $element ),
 						'selector' => $selectors[ $name ]['elements'][ $element ],
 					);
+
+					// Handle any psuedo selectors for the element.
+					if ( isset( static::VALID_ELEMENT_PSEUDO_SELECTORS[ $element ] ) ) {
+						foreach ( static::VALID_ELEMENT_PSEUDO_SELECTORS[ $element ] as $pseudo_selector ) {
+							if ( isset( $theme_json['styles']['blocks'][ $name ]['elements'][ $element ][ $pseudo_selector ] ) ) {
+								$nodes[] = array(
+									'path'     => array( 'styles', 'blocks', $name, 'elements', $element ),
+									'selector' => $selectors[ $name ]['elements'][ $element ] . $pseudo_selector,
+								);
+							}
+						}
+					}
 				}
 			}
 		}
@@ -243,11 +451,32 @@ class WP_Theme_JSON_6_1 extends WP_Theme_JSON_6_0 {
 	 * @return string Styles for the block.
 	 */
 	public function get_styles_for_block( $block_metadata ) {
-		$node         = _wp_array_get( $this->theme_json, $block_metadata['path'], array() );
-		$selector     = $block_metadata['selector'];
-		$settings     = _wp_array_get( $this->theme_json, array( 'settings' ) );
-		$declarations = static::compute_style_properties( $node, $settings );
-		$block_rules  = '';
+
+		$node = _wp_array_get( $this->theme_json, $block_metadata['path'], array() );
+
+		$selector = $block_metadata['selector'];
+		$settings = _wp_array_get( $this->theme_json, array( 'settings' ) );
+
+		// Attempt to parse a pseudo selector (e.g. ":hover") from the $selector ("a:hover").
+		$pseudo_matches = array();
+		preg_match( '/:[a-z]+/', $selector, $pseudo_matches );
+		$pseudo_selector = $pseudo_matches[0] ?? null;
+
+		// Get a reference to element name from path.
+		// $block_metadata['path'] = array('styles','elements','link');
+		$current_element = $block_metadata['path'][ count( $block_metadata['path'] ) - 1 ];
+
+		// If the current selector is a pseudo selector that's defined in the allow list for the current
+		// element then compute the style properties for it.
+		// Otherwise just compute the styles for the default selector as normal.
+		$declarations_pseudo_selectors = array();
+		if ( $pseudo_selector && isset( $node[ $pseudo_selector ] ) && isset( static::VALID_ELEMENT_PSEUDO_SELECTORS[ $current_element ] ) && in_array( $pseudo_selector, static::VALID_ELEMENT_PSEUDO_SELECTORS[ $current_element ] ) ) {
+			$declarations = static::compute_style_properties( $node[ $pseudo_selector ], $settings );
+		} else {
+			$declarations = static::compute_style_properties( $node, $settings );
+		}
+
+		$block_rules = '';
 
 		// 1. Separate the ones who use the general selector
 		// and the ones who use the duotone selector.
@@ -271,10 +500,10 @@ class WP_Theme_JSON_6_1 extends WP_Theme_JSON_6_0 {
 			$block_rules .= 'body { margin: 0; }';
 		}
 
-		// 2. Generate the rules that use the general selector.
+		// 2. Generate and append the rules that use the general selector.
 		$block_rules .= static::to_ruleset( $selector, $declarations );
 
-		// 3. Generate the rules that use the duotone selector.
+		// 3. Generate and append the rules that use the duotone selector.
 		if ( isset( $block_metadata['duotone'] ) && ! empty( $declarations_duotone ) ) {
 			$selector_duotone = static::scope_selector( $block_metadata['selector'], $block_metadata['duotone'] );
 			$block_rules     .= static::to_ruleset( $selector_duotone, $declarations_duotone );

--- a/lib/compat/wordpress-6.1/class-wp-theme-json-6-1.php
+++ b/lib/compat/wordpress-6.1/class-wp-theme-json-6-1.php
@@ -466,8 +466,8 @@ class WP_Theme_JSON_6_1 extends WP_Theme_JSON_6_0 {
 		// $block_metadata['path'] = array('styles','elements','link');
 		// Make sure that $block_metadata['path'] describes an element node, like ['styles', 'element', 'link'].
 		// Skip non-element paths like just ['styles']
-		$is_processing_element = count( $block_metadata['path'] ) === 3 && $block_metadata['path'][1] === 'elements';
-		$current_element = $is_processing_element ? $block_metadata['path'][ count( $block_metadata['path'] ) - 1 ] : nulll;
+		$is_processing_element = count( $block_metadata['path'] ) === 3 && 'elements' === $block_metadata['path'][1];
+		$current_element       = $is_processing_element ? $block_metadata['path'][ count( $block_metadata['path'] ) - 1 ] : null;
 
 		// If the current selector is a pseudo selector that's defined in the allow list for the current
 		// element then compute the style properties for it.

--- a/lib/compat/wordpress-6.1/theme.json
+++ b/lib/compat/wordpress-6.1/theme.json
@@ -250,6 +250,11 @@
 					"fontSize": "1.125em",
 					"textDecoration": "none"
 				}
+			},
+			"link": {
+				"typography": {
+					"textDecoration": "underline"
+				}
 			}
 		},
 		"spacing": { "blockGap": "24px" }

--- a/packages/edit-site/src/components/global-styles/test/use-global-styles-output.js
+++ b/packages/edit-site/src/components/global-styles/test/use-global-styles-output.js
@@ -40,6 +40,20 @@ describe( 'global styles renderer', () => {
 										fontSize: '23px',
 									},
 								},
+								link: {
+									':hover': {
+										color: {
+											background: 'green',
+											text: 'yellow',
+										},
+									},
+									':focus': {
+										color: {
+											background: 'green',
+											text: 'yellow',
+										},
+									},
+								},
 							},
 						},
 					},
@@ -48,6 +62,18 @@ describe( 'global styles renderer', () => {
 							color: {
 								background: 'yellow',
 								text: 'yellow',
+							},
+							':hover': {
+								color: {
+									background: 'hotpink',
+									text: 'black',
+								},
+							},
+							':focus': {
+								color: {
+									background: 'hotpink',
+									text: 'black',
+								},
 							},
 						},
 					},
@@ -58,6 +84,7 @@ describe( 'global styles renderer', () => {
 					selector: '.my-heading1, .my-heading2',
 				},
 			};
+
 			expect( getNodesWithStyles( tree, blockSelectors ) ).toEqual( [
 				{
 					styles: {
@@ -73,6 +100,18 @@ describe( 'global styles renderer', () => {
 						color: {
 							background: 'yellow',
 							text: 'yellow',
+						},
+						':hover': {
+							color: {
+								background: 'hotpink',
+								text: 'black',
+							},
+						},
+						':focus': {
+							color: {
+								background: 'hotpink',
+								text: 'black',
+							},
 						},
 					},
 					selector: ELEMENTS.link,
@@ -101,6 +140,23 @@ describe( 'global styles renderer', () => {
 						},
 					},
 					selector: '.my-heading1 h2, .my-heading2 h2',
+				},
+				{
+					styles: {
+						':hover': {
+							color: {
+								background: 'green',
+								text: 'yellow',
+							},
+						},
+						':focus': {
+							color: {
+								background: 'green',
+								text: 'yellow',
+							},
+						},
+					},
+					selector: '.my-heading1 a, .my-heading2 a',
 				},
 			] );
 		} );
@@ -318,6 +374,21 @@ describe( 'global styles renderer', () => {
 								fontSize: '42px',
 							},
 						},
+						link: {
+							color: {
+								text: 'blue',
+							},
+							':hover': {
+								color: {
+									text: 'orange',
+								},
+							},
+							':focus': {
+								color: {
+									text: 'orange',
+								},
+							},
+						},
 					},
 					blocks: {
 						'core/group': {
@@ -345,6 +416,16 @@ describe( 'global styles renderer', () => {
 									color: {
 										text: 'hotpink',
 									},
+									':hover': {
+										color: {
+											text: 'red',
+										},
+									},
+									':focus': {
+										color: {
+											text: 'red',
+										},
+									},
 								},
 							},
 						},
@@ -358,27 +439,12 @@ describe( 'global styles renderer', () => {
 				},
 				'core/heading': {
 					selector: 'h1,h2,h3,h4,h5,h6',
-					elements: {
-						link:
-							'h1 ' +
-							ELEMENTS.link +
-							',h2 ' +
-							ELEMENTS.link +
-							',h3 ' +
-							ELEMENTS.link +
-							',h4 ' +
-							ELEMENTS.link +
-							',h5 ' +
-							ELEMENTS.link +
-							',h6 ' +
-							ELEMENTS.link,
-					},
 				},
 			};
 
 			expect( toStyles( tree, blockSelectors ) ).toEqual(
 				'body {margin: 0;}' +
-					'body{background-color: red;margin: 10px;padding: 10px;}h1{font-size: 42px;}.wp-block-group{margin-top: 10px;margin-right: 20px;margin-bottom: 30px;margin-left: 40px;padding-top: 11px;padding-right: 22px;padding-bottom: 33px;padding-left: 44px;}h1,h2,h3,h4,h5,h6{color: orange;}h1 a,h2 a,h3 a,h4 a,h5 a,h6 a{color: hotpink;}' +
+					'body{background-color: red;margin: 10px;padding: 10px;}h1{font-size: 42px;}a{color: blue;}a:hover{color: orange;}a:focus{color: orange;}.wp-block-group{margin-top: 10px;margin-right: 20px;margin-bottom: 30px;margin-left: 40px;padding-top: 11px;padding-right: 22px;padding-bottom: 33px;padding-left: 44px;}h1,h2,h3,h4,h5,h6{color: orange;}h1 a,h2 a,h3 a,h4 a,h5 a,h6 a{color: hotpink;}h1 a:hover,h2 a:hover,h3 a:hover,h4 a:hover,h5 a:hover,h6 a:hover{color: red;}h1 a:focus,h2 a:focus,h3 a:focus,h4 a:focus,h5 a:focus,h6 a:focus{color: red;}' +
 					'.wp-site-blocks > .alignleft { float: left; margin-right: 2em; }.wp-site-blocks > .alignright { float: right; margin-left: 2em; }.wp-site-blocks > .aligncenter { justify-content: center; margin-left: auto; margin-right: auto; }' +
 					'.has-white-color{color: var(--wp--preset--color--white) !important;}.has-white-background-color{background-color: var(--wp--preset--color--white) !important;}.has-white-border-color{border-color: var(--wp--preset--color--white) !important;}.has-black-color{color: var(--wp--preset--color--black) !important;}.has-black-background-color{background-color: var(--wp--preset--color--black) !important;}.has-black-border-color{border-color: var(--wp--preset--color--black) !important;}h1.has-blue-color,h2.has-blue-color,h3.has-blue-color,h4.has-blue-color,h5.has-blue-color,h6.has-blue-color{color: var(--wp--preset--color--blue) !important;}h1.has-blue-background-color,h2.has-blue-background-color,h3.has-blue-background-color,h4.has-blue-background-color,h5.has-blue-background-color,h6.has-blue-background-color{background-color: var(--wp--preset--color--blue) !important;}h1.has-blue-border-color,h2.has-blue-border-color,h3.has-blue-border-color,h4.has-blue-border-color,h5.has-blue-border-color,h6.has-blue-border-color{border-color: var(--wp--preset--color--blue) !important;}'
 			);

--- a/packages/edit-site/src/components/global-styles/use-global-styles-output.js
+++ b/packages/edit-site/src/components/global-styles/use-global-styles-output.js
@@ -397,10 +397,40 @@ export const toStyles = ( tree, blockSelectors, hasBlockGapSupport ) => {
 
 		// Process the remaning block styles (they use either normal block class or __experimentalSelector).
 		const declarations = getStylesDeclarations( styles );
-		if ( declarations.length === 0 ) {
-			return;
+		if ( declarations?.length ) {
+			ruleset = ruleset + `${ selector }{${ declarations.join( ';' ) };}`;
 		}
-		ruleset = ruleset + `${ selector }{${ declarations.join( ';' ) };}`;
+
+		// Check for pseudo selector in `styles` and handle separately.
+		const psuedoSelectorStyles = Object.entries( styles ).filter(
+			( [ key ] ) => key.startsWith( ':' )
+		);
+
+		if ( psuedoSelectorStyles?.length ) {
+			psuedoSelectorStyles.forEach( ( [ pseudoKey, pseudoRule ] ) => {
+				const pseudoDeclarations = getStylesDeclarations( pseudoRule );
+
+				if ( pseudoDeclarations?.length ) {
+					// `selector` maybe provided in a form
+					// where block level selectors have sub element
+					// selectors appended to them as a comma seperated
+					// string.
+					// e.g. `h1 a,h2 a,h3 a,h4 a,h5 a,h6 a`;
+					// Split and append pseudo selector to create
+					// the proper rules to target the elements.
+					const _selector = selector
+						.split( ',' )
+						.map( ( sel ) => sel + pseudoKey )
+						.join( ',' );
+
+					const psuedoRule = `${ _selector }{${ pseudoDeclarations.join(
+						';'
+					) };}`;
+
+					ruleset = ruleset + psuedoRule;
+				}
+			} );
+		}
 	} );
 
 	/* Add alignment / layout styles */

--- a/packages/edit-site/src/components/global-styles/use-global-styles-output.js
+++ b/packages/edit-site/src/components/global-styles/use-global-styles-output.js
@@ -410,25 +410,27 @@ export const toStyles = ( tree, blockSelectors, hasBlockGapSupport ) => {
 			psuedoSelectorStyles.forEach( ( [ pseudoKey, pseudoRule ] ) => {
 				const pseudoDeclarations = getStylesDeclarations( pseudoRule );
 
-				if ( pseudoDeclarations?.length ) {
-					// `selector` maybe provided in a form
-					// where block level selectors have sub element
-					// selectors appended to them as a comma seperated
-					// string.
-					// e.g. `h1 a,h2 a,h3 a,h4 a,h5 a,h6 a`;
-					// Split and append pseudo selector to create
-					// the proper rules to target the elements.
-					const _selector = selector
-						.split( ',' )
-						.map( ( sel ) => sel + pseudoKey )
-						.join( ',' );
-
-					const psuedoRule = `${ _selector }{${ pseudoDeclarations.join(
-						';'
-					) };}`;
-
-					ruleset = ruleset + psuedoRule;
+				if ( ! pseudoDeclarations?.length ) {
+					return;
 				}
+
+				// `selector` maybe provided in a form
+				// where block level selectors have sub element
+				// selectors appended to them as a comma seperated
+				// string.
+				// e.g. `h1 a,h2 a,h3 a,h4 a,h5 a,h6 a`;
+				// Split and append pseudo selector to create
+				// the proper rules to target the elements.
+				const _selector = selector
+					.split( ',' )
+					.map( ( sel ) => sel + pseudoKey )
+					.join( ',' );
+
+				const psuedoRule = `${ _selector }{${ pseudoDeclarations.join(
+					';'
+				) };}`;
+
+				ruleset = ruleset + psuedoRule;
 			} );
 		}
 	} );

--- a/phpunit/class-wp-theme-json-test.php
+++ b/phpunit/class-wp-theme-json-test.php
@@ -685,6 +685,261 @@ class WP_Theme_JSON_Gutenberg_Test extends WP_UnitTestCase {
 		);
 	}
 
+	function test_get_stylesheet_handles_whitelisted_element_pseudo_selectors() {
+		$theme_json = new WP_Theme_JSON_Gutenberg(
+			array(
+				'version' => WP_Theme_JSON_Gutenberg::LATEST_SCHEMA,
+				'styles'  => array(
+					'elements' => array(
+						'link' => array(
+							'color'  => array(
+								'text'       => 'green',
+								'background' => 'red',
+							),
+							':hover' => array(
+								'color'      => array(
+									'text'       => 'red',
+									'background' => 'green',
+								),
+								'typography' => array(
+									'textTransform' => 'uppercase',
+									'fontSize'      => '10em',
+								),
+							),
+							':focus' => array(
+								'color' => array(
+									'text'       => 'yellow',
+									'background' => 'black',
+								),
+							),
+						),
+					),
+				),
+			)
+		);
+
+		$base_styles = 'body { margin: 0; }.wp-site-blocks > .alignleft { float: left; margin-right: 2em; }.wp-site-blocks > .alignright { float: right; margin-left: 2em; }.wp-site-blocks > .aligncenter { justify-content: center; margin-left: auto; margin-right: auto; }';
+
+		$element_styles = 'a{background-color: red;color: green;}a:hover{background-color: green;color: red;font-size: 10em;text-transform: uppercase;}a:focus{background-color: black;color: yellow;}';
+
+		$expected = $base_styles . $element_styles;
+
+		$this->assertEquals( $expected, $theme_json->get_stylesheet() );
+		$this->assertEquals( $expected, $theme_json->get_stylesheet( array( 'styles' ) ) );
+	}
+
+	function test_get_stylesheet_handles_only_psuedo_selector_rules_for_given_property() {
+		$theme_json = new WP_Theme_JSON_Gutenberg(
+			array(
+				'version' => WP_Theme_JSON_Gutenberg::LATEST_SCHEMA,
+				'styles'  => array(
+					'elements' => array(
+						'link' => array(
+							':hover' => array(
+								'color'      => array(
+									'text'       => 'red',
+									'background' => 'green',
+								),
+								'typography' => array(
+									'textTransform' => 'uppercase',
+									'fontSize'      => '10em',
+								),
+							),
+							':focus' => array(
+								'color' => array(
+									'text'       => 'yellow',
+									'background' => 'black',
+								),
+							),
+						),
+					),
+				),
+			)
+		);
+
+		$base_styles = 'body { margin: 0; }.wp-site-blocks > .alignleft { float: left; margin-right: 2em; }.wp-site-blocks > .alignright { float: right; margin-left: 2em; }.wp-site-blocks > .aligncenter { justify-content: center; margin-left: auto; margin-right: auto; }';
+
+		$element_styles = 'a:hover{background-color: green;color: red;font-size: 10em;text-transform: uppercase;}a:focus{background-color: black;color: yellow;}';
+
+		$expected = $base_styles . $element_styles;
+
+		$this->assertEquals( $expected, $theme_json->get_stylesheet() );
+		$this->assertEquals( $expected, $theme_json->get_stylesheet( array( 'styles' ) ) );
+	}
+
+	function test_get_stylesheet_ignores_pseudo_selectors_on_non_whitelisted_elements() {
+		$theme_json = new WP_Theme_JSON_Gutenberg(
+			array(
+				'version' => WP_Theme_JSON_Gutenberg::LATEST_SCHEMA,
+				'styles'  => array(
+					'elements' => array(
+						'h4' => array(
+							'color'  => array(
+								'text'       => 'green',
+								'background' => 'red',
+							),
+							':hover' => array(
+								'color' => array(
+									'text'       => 'red',
+									'background' => 'green',
+								),
+							),
+							':focus' => array(
+								'color' => array(
+									'text'       => 'yellow',
+									'background' => 'black',
+								),
+							),
+						),
+					),
+				),
+			)
+		);
+
+		$base_styles = 'body { margin: 0; }.wp-site-blocks > .alignleft { float: left; margin-right: 2em; }.wp-site-blocks > .alignright { float: right; margin-left: 2em; }.wp-site-blocks > .aligncenter { justify-content: center; margin-left: auto; margin-right: auto; }';
+
+		$element_styles = 'h4{background-color: red;color: green;}';
+
+		$expected = $base_styles . $element_styles;
+
+		$this->assertEquals( $expected, $theme_json->get_stylesheet() );
+		$this->assertEquals( $expected, $theme_json->get_stylesheet( array( 'styles' ) ) );
+	}
+
+	function test_get_stylesheet_ignores_non_whitelisted_pseudo_selectors() {
+		$theme_json = new WP_Theme_JSON_Gutenberg(
+			array(
+				'version' => WP_Theme_JSON_Gutenberg::LATEST_SCHEMA,
+				'styles'  => array(
+					'elements' => array(
+						'link' => array(
+							'color'     => array(
+								'text'       => 'green',
+								'background' => 'red',
+							),
+							':hover'    => array(
+								'color' => array(
+									'text'       => 'red',
+									'background' => 'green',
+								),
+							),
+							':levitate' => array(
+								'color' => array(
+									'text'       => 'yellow',
+									'background' => 'black',
+								),
+							),
+						),
+					),
+				),
+			)
+		);
+
+		$base_styles = 'body { margin: 0; }.wp-site-blocks > .alignleft { float: left; margin-right: 2em; }.wp-site-blocks > .alignright { float: right; margin-left: 2em; }.wp-site-blocks > .aligncenter { justify-content: center; margin-left: auto; margin-right: auto; }';
+
+		$element_styles = 'a{background-color: red;color: green;}a:hover{background-color: green;color: red;}';
+
+		$expected = $base_styles . $element_styles;
+
+		$this->assertEquals( $expected, $theme_json->get_stylesheet() );
+		$this->assertEquals( $expected, $theme_json->get_stylesheet( array( 'styles' ) ) );
+		$this->assertStringNotContainsString( 'a:levitate{', $theme_json->get_stylesheet( array( 'styles' ) ) );
+	}
+
+	function test_get_stylesheet_handles_priority_of_elements_vs_block_elements_pseudo_selectors() {
+		$theme_json = new WP_Theme_JSON_Gutenberg(
+			array(
+				'version' => WP_Theme_JSON_Gutenberg::LATEST_SCHEMA,
+				'styles'  => array(
+					'blocks' => array(
+						'core/group' => array(
+							'elements' => array(
+								'link' => array(
+									'color'  => array(
+										'text'       => 'green',
+										'background' => 'red',
+									),
+									':hover' => array(
+										'color'      => array(
+											'text'       => 'red',
+											'background' => 'green',
+										),
+										'typography' => array(
+											'textTransform' => 'uppercase',
+											'fontSize' => '10em',
+										),
+									),
+									':focus' => array(
+										'color' => array(
+											'text'       => 'yellow',
+											'background' => 'black',
+										),
+									),
+								),
+							),
+						),
+					),
+				),
+			)
+		);
+
+		$base_styles = 'body { margin: 0; }.wp-site-blocks > .alignleft { float: left; margin-right: 2em; }.wp-site-blocks > .alignright { float: right; margin-left: 2em; }.wp-site-blocks > .aligncenter { justify-content: center; margin-left: auto; margin-right: auto; }';
+
+		$element_styles = '.wp-block-group a{background-color: red;color: green;}.wp-block-group a:hover{background-color: green;color: red;font-size: 10em;text-transform: uppercase;}.wp-block-group a:focus{background-color: black;color: yellow;}';
+
+		$expected = $base_styles . $element_styles;
+
+		$this->assertEquals( $expected, $theme_json->get_stylesheet() );
+		$this->assertEquals( $expected, $theme_json->get_stylesheet( array( 'styles' ) ) );
+	}
+
+		function test_get_stylesheet_handles_whitelisted_block_level_element_pseudo_selectors() {
+		$theme_json = new WP_Theme_JSON_Gutenberg(
+			array(
+				'version' => WP_Theme_JSON_Gutenberg::LATEST_SCHEMA,
+				'styles'  => array(
+					'elements' => array(
+						'link' => array(
+							'color'  => array(
+								'text'       => 'green',
+								'background' => 'red',
+							),
+							':hover' => array(
+								'color'      => array(
+									'text'       => 'red',
+									'background' => 'green',
+								),
+							)
+						),
+					),
+					'blocks' => array(
+						'core/group' => array(
+							'elements' => array(
+								'link' => array(
+									':hover' => array(
+										'color'      => array(
+											'text'       => 'yellow',
+											'background' => 'black',
+										),
+									)
+								),
+							),
+						),
+					),
+				),
+			)
+		);
+
+		$base_styles = 'body { margin: 0; }.wp-site-blocks > .alignleft { float: left; margin-right: 2em; }.wp-site-blocks > .alignright { float: right; margin-left: 2em; }.wp-site-blocks > .aligncenter { justify-content: center; margin-left: auto; margin-right: auto; }';
+
+		$element_styles = 'a{background-color: red;color: green;}a:hover{background-color: green;color: red;}.wp-block-group a:hover{background-color: black;color: yellow;}';
+
+		$expected = $base_styles . $element_styles;
+
+		$this->assertEquals( $expected, $theme_json->get_stylesheet() );
+		$this->assertEquals( $expected, $theme_json->get_stylesheet( array( 'styles' ) ) );
+	}
+
 	public function test_merge_incoming_data() {
 		$theme_json = new WP_Theme_JSON_Gutenberg(
 			array(
@@ -1518,6 +1773,8 @@ class WP_Theme_JSON_Gutenberg_Test extends WP_UnitTestCase {
 		$this->assertEqualSetsWithIndex( $expected, $actual );
 	}
 
+
+
 	function test_remove_insecure_properties_removes_unsafe_styles() {
 		$actual = WP_Theme_JSON_Gutenberg::remove_insecure_properties(
 			array(
@@ -2013,6 +2270,53 @@ class WP_Theme_JSON_Gutenberg_Test extends WP_UnitTestCase {
 				),
 			),
 		);
+		$this->assertEqualSetsWithIndex( $expected, $actual );
+	}
+
+	function test_remove_invalid_element_pseudo_selectors() {
+		$actual = WP_Theme_JSON_Gutenberg::remove_insecure_properties(
+			array(
+				'version' => WP_Theme_JSON_Gutenberg::LATEST_SCHEMA,
+				'styles'  => array(
+					'elements' => array(
+						'link' => array(
+							'color'  => array(
+								'text'       => 'hotpink',
+								'background' => 'yellow',
+							),
+							':hover' => array(
+								'color' => array(
+									'text'       => 'red',
+									'background' => 'blue',
+								),
+							),
+						),
+					),
+				),
+			),
+			true
+		);
+
+		$expected = array(
+			'version' => WP_Theme_JSON_Gutenberg::LATEST_SCHEMA,
+			'styles'  => array(
+				'elements' => array(
+					'link' => array(
+						'color'  => array(
+							'text'       => 'hotpink',
+							'background' => 'yellow',
+						),
+						':hover' => array(
+							'color' => array(
+								'text'       => 'red',
+								'background' => 'blue',
+							),
+						),
+					),
+				),
+			),
+		);
+
 		$this->assertEqualSetsWithIndex( $expected, $actual );
 	}
 

--- a/phpunit/class-wp-theme-json-test.php
+++ b/phpunit/class-wp-theme-json-test.php
@@ -893,7 +893,7 @@ class WP_Theme_JSON_Gutenberg_Test extends WP_UnitTestCase {
 		$this->assertEquals( $expected, $theme_json->get_stylesheet( array( 'styles' ) ) );
 	}
 
-		function test_get_stylesheet_handles_whitelisted_block_level_element_pseudo_selectors() {
+	function test_get_stylesheet_handles_whitelisted_block_level_element_pseudo_selectors() {
 		$theme_json = new WP_Theme_JSON_Gutenberg(
 			array(
 				'version' => WP_Theme_JSON_Gutenberg::LATEST_SCHEMA,
@@ -905,23 +905,23 @@ class WP_Theme_JSON_Gutenberg_Test extends WP_UnitTestCase {
 								'background' => 'red',
 							),
 							':hover' => array(
-								'color'      => array(
+								'color' => array(
 									'text'       => 'red',
 									'background' => 'green',
 								),
-							)
+							),
 						),
 					),
-					'blocks' => array(
+					'blocks'   => array(
 						'core/group' => array(
 							'elements' => array(
 								'link' => array(
 									':hover' => array(
-										'color'      => array(
+										'color' => array(
 											'text'       => 'yellow',
 											'background' => 'black',
 										),
-									)
+									),
 								),
 							),
 						),


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
As part of work towards https://github.com/WordPress/gutenberg/issues/38277, this PR enables `theme.json` support for `elements` (both top and _block_ level) to contain **pseudo selectors** in the form:

```json
{
    "elements": {
        "link": {
            "color": {
                "text": "green"
            },
            ":hover": {
                "color": {
                    "text": "hotpink"
                }
            }
        }
    },
    "blocks": {
        "core/group": {
             "elements": {
                "link": {
                    ":hover": {
                        "color": {
                            "text": "red"
                        }
                    }
                }
            }
        }
    }
}
```

Currently this PR imposes a whitelist which governs which psuedo selectors are available to be used on which elements. It looks like this but could be augmented as required:

```php
const VALID_ELEMENT_PSEUDO_SELECTORS = array(
    'link' => array( ':hover', ':focus' ),
);
```

Please note that once an element is "open" to a given pseudo selector all valid stlye properties are available to be changed. For example the following is valid whether you _should_ do it or not:

```json
{
    "elements": {
        "link": {
            "color": {
                "text": "green"
            },
            ":hover": {
                "color": {
                    "text": "hotpink"
                },
                "typography": {
                    "textTransform": "uppercase",
                    "fontSize": "10em"
                }
            }
        }
    }
}
```

My personal preference would be to lock things down to a bear minimum to avoid a11y issues but I guess perhaps we'll want things open to developers to make those choices just like they do every day in CSS. We can limit user choices but choosing not to expose UI controls for every possible style property.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

This is low level work to support styling of interactivity states in the editor and front end.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

Update the sanitization routines to allow various pseudo selectors on a per `element` basis. For now we only support `link`.

## Todo

- [x] Get `WP_Theme_JSON_Gutenberg::remove_insecure_properties` to allow for pseudo selectors.
- [x] Ensure pseudo selectors end up in final processed theme json
- [x] Ensure correct styles are generated for pseudo selectors from the theme json in editor.
- [x] Ensure correct styles are generated for pseudo selectors from the theme json on front end.
- [x] Consider enabling block-level `elements` pseudo selector support.
- [ ] Learn how to type/spell `pseudo` (note: this task will never be completed)
- [x] Add/augment automated tests.
- [ ] ~Create an allow/whitelist for per element pseudo selectors for use on client side (or pass the existing config value from PHP)~ - this can be handled in a followup.
- [x] Augment frontend JS global styles tests to assert on pseudo selector generation.
- [x] Refine PR desc and make RfR

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->

### Stress testing

Note this PR is being stress tested by [applying it various Themes](https://github.com/Automattic/themes/issues/6108).

### Testing with Archeo test PR

I have created an [example PR on the Archeo theme](https://github.com/Automattic/themes/pull/6101) to test this out. You can try that by running a copy of Archeo with that PR checked out.

### Manual testing
- Use a Theme where you can modify the `theme.json` file.
- Try adding some psudo selector styles for `link` element at top level:
```json
{
    "elements": {
        "link": {
            "color": {
                "text": "green"
            },
            ":hover": {
                "color": {
                    "text": "hotpink"
                }
            }
        }
    }
}
```
- validate standard `a` elements have a `hotpink` color when you hover over them on _both_ editor and frontend.
- now add an _invalid_ pseudo selector and check it isn't output in the stylesheet
```json
{
    "elements": {
        "link": {
            "color": {
                "text": "green"
            },
            ":thisisaninvalidselector": {
                "color": {
                    "text": "hotpink"
                }
            }
        }
    }
}
```
- following the same pattern as above now try adding an _unsupported_ selector such as `:target`.
- following the same pattern as above now try adding an _unsupported_ element like `button`. 
```json
{
    "elements": {
        "button": {
            "color": {
                "text": "green"
            },
            ":hover": {
                "color": {
                    "text": "hotpink"
                }
            }
        }
    }
}
```

Please be sure to check in both the Post and the Site Editor.

## Screenshots or screencast <!-- if applicable -->

### Editor
![Screen Capture on 2022-06-17 at 16-00-13](https://user-images.githubusercontent.com/444434/174335218-7a721265-f211-4426-846a-5c0a348668f3.gif)

### Frontend
![Screen Capture on 2022-06-17 at 15-57-50](https://user-images.githubusercontent.com/444434/174335230-5fc82522-b8a3-47fd-a414-eab50077a0f0.gif)


## Authors



Co-authored-by: Andrei Draganescu <[me@andreidraganescu.info](mailto:me@andreidraganescu.info)>, Adam Zielinski, Ben Dwyer <[ben@scruffian.com](mailto:ben@scruffian.com)>