### PR TITLE
BlockSettingsMenuControls: Fix 'showLockButton' check

### DIFF
--- a/packages/block-editor/src/components/block-settings-menu-controls/index.js
+++ b/packages/block-editor/src/components/block-settings-menu-controls/index.js
@@ -20,7 +20,7 @@ import {
 	useConvertToGroupButtonProps,
 	ConvertToGroupButton,
 } from '../convert-to-group-buttons';
-import { BlockLockMenuItem } from '../block-lock';
+import { BlockLockMenuItem, useBlockLock } from '../block-lock';
 import { store as blockEditorStore } from '../../store';
 
 const { Fill, Slot } = createSlotFill( 'BlockSettingsMenuControls' );
@@ -47,7 +47,8 @@ const BlockSettingsMenuControlsSlot = ( { fillProps, clientIds = null } ) => {
 		[ clientIds ]
 	);
 
-	const showLockButton = selectedClientIds.length === 1;
+	const { canLock } = useBlockLock( selectedClientIds[ 0 ] );
+	const showLockButton = selectedClientIds.length === 1 && canLock;
 
 	// Check if current selection of blocks is Groupable or Ungroupable
 	// and pass this props down to ConvertToGroupButton.


### PR DESCRIPTION
## What?
Fixes #41224.

PR updates `showLockButton` to avoid rendering empty MenuGroup.

## Why?
The condition wasn't checking if Block Lock Controls where disabled via block supports.

## Testing Instructions
1. Open a Post or Page.
2. Disable Group block from Preferences.
3. Run test block snipped in the DevTools console.
4. Insert the Lock Check block.
5. Confirm that there's no empty MenuGroup in block options.

```js
wp.blocks.registerBlockType( 'mamaduka/lock-check', {
	title: "Lock Check",
	icon: "lock",
	category: "text",
	attributes: {},
	supports: {
		lock: false,
		reusable: false,
	},

	edit: () => wp.element.createElement('div', {}, 'Lock Check Block.' ),
	save: () => null,
});
```

## Screenshots or screencast

![CleanShot 2022-06-17 at 16 39 51](https://user-images.githubusercontent.com/240569/174300031-e37f91a2-98e8-48df-8901-aacd479254ae.png)

