### PR TITLE
ColorPicker: Downsize inputs to 36px

### DIFF
--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Enhancements
+
+-   `ColorPicker`: Change the inputs to the new 36px height ([#41795](https://github.com/WordPress/gutenberg/pull/41795)).
+
 ### Internal
 
 -   `Spinner`: Convert to TypeScript and update storybook ([#41540](https://github.com/WordPress/gutenberg/pull/41540/)).

--- a/packages/components/src/color-picker/hex-input.tsx
+++ b/packages/components/src/color-picker/hex-input.tsx
@@ -50,6 +50,7 @@ export const HexInput = ( { color, onChange, enableAlpha }: HexInputProps ) => {
 
 	return (
 		<ColorHexInputControl
+			__next36pxDefaultSize={ true }
 			prefix={
 				<Spacer
 					as={ Text }

--- a/packages/components/src/color-picker/input-with-slider.tsx
+++ b/packages/components/src/color-picker/input-with-slider.tsx
@@ -28,6 +28,7 @@ export const InputWithSlider = ( {
 	return (
 		<Spacer as={ HStack } spacing={ 4 }>
 			<NumberControlWrapper
+				__next36pxDefaultSize={ true }
 				min={ min }
 				max={ max }
 				label={ label }

--- a/packages/components/src/color-picker/styles.ts
+++ b/packages/components/src/color-picker/styles.ts
@@ -15,7 +15,6 @@ import Button from '../button';
 import {
 	BackdropUI,
 	Container as InputControlContainer,
-	Input,
 } from '../input-control/styles/input-control-styles';
 import InputControl from '../input-control';
 import CONFIG from '../utils/config-values';
@@ -41,14 +40,6 @@ export const RangeControl = styled( InnerRangeControl )`
 		margin-bottom: 0;
 	}
 `;
-
-// All inputs should be the same height so this should be changed at the component level.
-// That involves changing heights of multiple input types probably buttons too etc.
-// So until that is done we are already using the new height on the color picker so it matches the mockups.
-const inputHeightStyle = `
-&&& ${ Input } {
-	height: 40px;
-}`;
 
 // Make the Hue circle picker not go out of the bar.
 const interactiveHueStyles = `
@@ -107,8 +98,6 @@ export const ColorfulWrapper = styled.div`
 	${ StyledField } {
 		margin-bottom: 0;
 	}
-
-	${ inputHeightStyle }
 `;
 
 export const CopyButton = styled( Button )`


### PR DESCRIPTION
🚧 Currently on hold to reassess approach 🚧 

Part of #39397

## What?

Downsize the 40px inputs in `ColorPicker` to the new default 36px.

We can land these size changes immediately without coordination via `__next` prop, since they are already in an inconsistent state.

## Why?

As part of the effort to move toward consistent component sizes.

## Testing Instructions

1. `npm run storybook:dev`
2. See the story for `ColorPicker`. The RGB/HSL/HEX inputs should all be at 36px height.

