### PR TITLE
Post Template: Fix layout issue by ensuring layout classname is attached to wrapper `li` elements

### DIFF
--- a/packages/block-library/src/post-template/index.php
+++ b/packages/block-library/src/post-template/index.php
@@ -96,7 +96,7 @@ function render_block_core_post_template( $attributes, $content, $block ) {
 		$li_opening_tag = '<li class="' . esc_attr( $post_classes ) . '">';
 		$li_closing_tag = '</li>';
 
-		// 4. Assign this markup to the block instance's innerHTML
+		// 4. Assign this markup to the block instance's innerHTML attribute.
 		$block_instance['innerHTML'] = $li_opening_tag . $li_closing_tag;
 
 		// 5. Assign the opening tag to the first element of the instance's innerContent array.

--- a/packages/block-library/src/post-template/index.php
+++ b/packages/block-library/src/post-template/index.php
@@ -86,26 +86,31 @@ function render_block_core_post_template( $attributes, $content, $block ) {
 		// The Post Template block has no markup stored in post content, so here,
 		// we generate a wrapper `li` tag to contain the rendered inner blocks.
 
-		// 1. Get the parsed block object.
+		// Get the parsed block object.
 		$block_instance = $block->parsed_block;
 
-		// 2. Get the classes for the post instance.
+		// Get the classes for the post instance.
 		$post_classes = implode( ' ', get_post_class( 'wp-block-post' ) );
 
-		// 3. Create the HTML markup for the opening and closing tags of the list item.
+		// Create the HTML markup for the opening and closing tags of the list item.
 		$li_opening_tag = '<li class="' . esc_attr( $post_classes ) . '">';
 		$li_closing_tag = '</li>';
 
-		// 4. Assign this markup to the block instance's innerHTML attribute.
+		// Assign this markup to the block instance's innerHTML attribute.
 		$block_instance['innerHTML'] = $li_opening_tag . $li_closing_tag;
 
-		// 5. Assign the opening tag to the first element of the instance's innerContent array.
-		$block_instance['innerContent'][0] = $li_opening_tag;
+		if ( count( $block_instance['innerContent'] ) > 1 ) {
+			// Assign the opening tag to the first element of the instance's innerContent array.
+			$block_instance['innerContent'][0] = $li_opening_tag;
 
-		// 6. Assign the closing tag to the last element of the instance's innerContent array.
-		$block_instance['innerContent'][ count( $block_instance['innerContent'] ) - 1 ] = $li_closing_tag;
+			// Assign the closing tag to the last element of the instance's innerContent array.
+			$block_instance['innerContent'][ count( $block_instance['innerContent'] ) - 1 ] = $li_closing_tag;
+		} else {
+			// If there are no children in the template, concatenate to a single string.
+			$block_instance['innerContent'] = array( $li_opening_tag . $li_closing_tag );
+		}
 
-		// 7. Render the block using the augmented block object that contains the desired markup.
+		// Render the block using the augmented block object that contains the desired markup.
 		// This ensures that the resulting `$block_content` has the appropriate layout container
 		// class attached to the wrapping `li` element, which avoids the conflict of two competing
 		// layout classes. For background, see: https://github.com/WordPress/gutenberg/issues/41026.
@@ -119,7 +124,7 @@ function render_block_core_post_template( $attributes, $content, $block ) {
 			)
 		)->render( array( 'dynamic' => false ) );
 
-		// 8. Concatenate to the wrapper block's content.
+		// Concatenate to the wrapper block's content.
 		$content .= $block_content;
 	}
 

--- a/packages/block-library/src/post-template/index.php
+++ b/packages/block-library/src/post-template/index.php
@@ -90,7 +90,7 @@ function render_block_core_post_template( $attributes, $content, $block ) {
 		$block_instance = $block->parsed_block;
 
 		// 2. Get the classes for the post instance.
-		$post_classes   = implode( ' ', get_post_class( 'wp-block-post' ) );
+		$post_classes = implode( ' ', get_post_class( 'wp-block-post' ) );
 
 		// 3. Create the HTML markup for the opening and closing tags of the list item.
 		$li_opening_tag = '<li class="' . esc_attr( $post_classes ) . '">';

--- a/packages/block-library/src/post-template/index.php
+++ b/packages/block-library/src/post-template/index.php
@@ -96,17 +96,16 @@ function render_block_core_post_template( $attributes, $content, $block ) {
 		$li_opening_tag = '<li class="' . esc_attr( $post_classes ) . '">';
 		$li_closing_tag = '</li>';
 
-		// 4. Assign this markup to the block instance's innerHTML and innerContent attributes.
-		// The Post Template block will always have a single slot for innerBlocks, so the innerContent
-		// array should safely be a hard-coded array of 3 items: opening tag, null, and closing tag.
-		$block_instance['innerHTML']    = $li_opening_tag . $li_closing_tag;
-		$block_instance['innerContent'] = array(
-			$li_opening_tag,
-			null,
-			$li_closing_tag,
-		);
+		// 4. Assign this markup to the block instance's innerHTML
+		$block_instance['innerHTML'] = $li_opening_tag . $li_closing_tag;
 
-		// 5. Render the block using the augmented block object that contains the desired markup.
+		// 5. Assign the opening tag to the first element of the instance's innerContent array.
+		$block_instance['innerContent'][0] = $li_opening_tag;
+
+		// 6. Assign the closing tag to the last element of the instance's innerContent array.
+		$block_instance['innerContent'][ count( $block_instance['innerContent'] ) - 1 ] = $li_closing_tag;
+
+		// 7. Render the block using the augmented block object that contains the desired markup.
 		// This ensures that the resulting `$block_content` has the appropriate layout container
 		// class attached to the wrapping `li` element, which avoids the conflict of two competing
 		// layout classes. For background, see: https://github.com/WordPress/gutenberg/issues/41026.
@@ -120,7 +119,7 @@ function render_block_core_post_template( $attributes, $content, $block ) {
 			)
 		)->render( array( 'dynamic' => false ) );
 
-		// 6. Concatenate to the wrapper block's content.
+		// 8. Concatenate to the wrapper block's content.
 		$content .= $block_content;
 	}
 


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Fixes: https://github.com/WordPress/gutenberg/issues/41026

Update Post Template server-side rendering to pass wrapper `li` tag markup in with the block object when rendering inner instances of the block. This fixes an issue where the layout classname for the instance of the Post Template block was being passed to the _child_ of the block, instead of the `li` wrapper.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

In #41026 it was reported that the individual instances of the Post Template block rendered within the Query Loop block erroneously apply a duplicate layout classname. This is because the Post Template block has no markup of its own, so when it was being manually rendered within each instance of the loop, the markup of the innerBlocks was being targeted for the Post Template block's layout classname. One way to fix this is to ensure that prior to being rendered, the block instance has the correct wrapper `li` markup so that the existing logic of the Layout block support can work as intended.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

* Update the logic of the internal query loop to inject the `li` tag _prior_ to rendering the block, so that the Layout block support can apply the classname to the correct wrapper element.
* Add inline code comments to explain how and why the block works the way it does, to hopefully help future debugging if we ever run into any further issues.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->

1. Add a Query Loop block to a post
2. In the Post Template, create some blocks to demonstrate what goes wrong if the Layout classname is erroneously added to a child block. For example, in the below screenshots, I've used a Columns block as the direct child of Post Template. In this case, it should be fairly obvious that the styling is incorrect, as the second Column will receive the `margin-block-start` gap of the default Layout type, adding an unexpected top margin on the second column.

<img width="345" alt="image" src="https://user-images.githubusercontent.com/14988353/174512592-7d15279f-95c0-4ce6-b2c4-6c9cb321d7d7.png">

Prior to this PR, you should see that there will be odd styling issues as in the below screenshots.
After this PR, you should see that the styling issues are resolved, and if you inspect the markup, the wrapper `li` element should have the container class, and its first child Columns block should not have duplicate classnames.

## Screenshots or screencast <!-- if applicable -->

| Before | After |
| --- | --- |
| <img width="926" alt="image" src="https://user-images.githubusercontent.com/14988353/174511907-8507f99e-44b3-48d6-afbe-f11778244164.png"> | <img width="964" alt="image" src="https://user-images.githubusercontent.com/14988353/174511807-25d630ea-1e8f-423b-8c7d-3ccf1a3235f2.png"> |