### PR TITLE
Style engine: add border to frontend

### DIFF
--- a/packages/blocks/src/api/constants.js
+++ b/packages/blocks/src/api/constants.js
@@ -33,6 +33,7 @@ export const __EXPERIMENTAL_STYLE_PROPERTY = {
 	borderColor: {
 		value: [ 'border', 'color' ],
 		support: [ '__experimentalBorder', 'color' ],
+		useEngine: true,
 	},
 	borderRadius: {
 		value: [ 'border', 'radius' ],
@@ -43,62 +44,77 @@ export const __EXPERIMENTAL_STYLE_PROPERTY = {
 			borderBottomLeftRadius: 'bottomLeft',
 			borderBottomRightRadius: 'bottomRight',
 		},
+		useEngine: true,
 	},
 	borderStyle: {
 		value: [ 'border', 'style' ],
 		support: [ '__experimentalBorder', 'style' ],
+		useEngine: true,
 	},
 	borderWidth: {
 		value: [ 'border', 'width' ],
 		support: [ '__experimentalBorder', 'width' ],
+		useEngine: true,
 	},
 	borderTopColor: {
 		value: [ 'border', 'top', 'color' ],
 		support: [ '__experimentalBorder', 'color' ],
+		useEngine: true,
 	},
 	borderTopStyle: {
 		value: [ 'border', 'top', 'style' ],
 		support: [ '__experimentalBorder', 'style' ],
+		useEngine: true,
 	},
 	borderTopWidth: {
 		value: [ 'border', 'top', 'width' ],
 		support: [ '__experimentalBorder', 'width' ],
+		useEngine: true,
 	},
 	borderRightColor: {
 		value: [ 'border', 'right', 'color' ],
 		support: [ '__experimentalBorder', 'color' ],
+		useEngine: true,
 	},
 	borderRightStyle: {
 		value: [ 'border', 'right', 'style' ],
 		support: [ '__experimentalBorder', 'style' ],
+		useEngine: true,
 	},
 	borderRightWidth: {
 		value: [ 'border', 'right', 'width' ],
 		support: [ '__experimentalBorder', 'width' ],
+		useEngine: true,
 	},
 	borderBottomColor: {
 		value: [ 'border', 'bottom', 'color' ],
 		support: [ '__experimentalBorder', 'color' ],
+		useEngine: true,
 	},
 	borderBottomStyle: {
 		value: [ 'border', 'bottom', 'style' ],
 		support: [ '__experimentalBorder', 'style' ],
+		useEngine: true,
 	},
 	borderBottomWidth: {
 		value: [ 'border', 'bottom', 'width' ],
 		support: [ '__experimentalBorder', 'width' ],
+		useEngine: true,
 	},
 	borderLeftColor: {
 		value: [ 'border', 'left', 'color' ],
 		support: [ '__experimentalBorder', 'color' ],
+		useEngine: true,
 	},
 	borderLeftStyle: {
 		value: [ 'border', 'left', 'style' ],
 		support: [ '__experimentalBorder', 'style' ],
+		useEngine: true,
 	},
 	borderLeftWidth: {
 		value: [ 'border', 'left', 'width' ],
 		support: [ '__experimentalBorder', 'width' ],
+		useEngine: true,
 	},
 	color: {
 		value: [ 'color', 'text' ],

--- a/packages/style-engine/src/styles/border/index.ts
+++ b/packages/style-engine/src/styles/border/index.ts
@@ -1,0 +1,150 @@
+/**
+ * External dependencies
+ */
+import { camelCase, get } from 'lodash';
+
+/**
+ * Internal dependencies
+ */
+import type {
+	BorderIndividualStyles,
+	BorderIndividualProperty,
+	GeneratedCSSRule,
+	Style,
+	StyleDefinition,
+	StyleOptions,
+} from '../../types';
+import { generateRule, generateBoxRules } from '../utils';
+
+const color = {
+	name: 'color',
+	generate: (
+		style: Style,
+		options: StyleOptions,
+		path: string[] = [ 'border', 'color' ],
+		ruleKey: string = 'borderColor'
+	): GeneratedCSSRule[] => {
+		return generateRule( style, options, path, ruleKey );
+	},
+};
+
+const radius = {
+	name: 'radius',
+	generate: ( style: Style, options: StyleOptions ): GeneratedCSSRule[] => {
+		return generateBoxRules(
+			style,
+			options,
+			[ 'border', 'radius' ],
+			{
+				default: 'borderRadius',
+				individual: 'border%sRadius',
+			},
+			[ 'topLeft', 'topRight', 'bottomLeft', 'bottomRight' ]
+		);
+	},
+};
+
+const borderStyle = {
+	name: 'style',
+	generate: (
+		style: Style,
+		options: StyleOptions,
+		path: string[] = [ 'border', 'style' ],
+		ruleKey: string = 'borderStyle'
+	): GeneratedCSSRule[] => {
+		return generateRule( style, options, path, ruleKey );
+	},
+};
+
+const width = {
+	name: 'width',
+	generate: (
+		style: Style,
+		options: StyleOptions,
+		path: string[] = [ 'border', 'width' ],
+		ruleKey: string = 'borderWidth'
+	): GeneratedCSSRule[] => {
+		return generateRule( style, options, path, ruleKey );
+	},
+};
+
+const borderDefinitionsWithIndividualStyles: StyleDefinition[] = [
+	color,
+	borderStyle,
+	width,
+];
+
+/**
+ * Returns a curried generator function with the individual border property ('top' | 'right' | 'bottom' | 'left') baked in.
+ *
+ * @param  individualProperty Individual border property ('top' | 'right' | 'bottom' | 'left').
+ *
+ * @return StyleDefinition[ 'generate' ]
+ */
+const createBorderGenerateFunction =
+	( individualProperty: BorderIndividualProperty ) =>
+	( style: Style, options: StyleOptions ) => {
+		const styleValue:
+			| BorderIndividualStyles< typeof individualProperty >
+			| undefined = get( style, [ 'border', individualProperty ] );
+
+		if ( ! styleValue ) {
+			return [];
+		}
+
+		return borderDefinitionsWithIndividualStyles.reduce(
+			(
+				acc: GeneratedCSSRule[],
+				borderDefinition: StyleDefinition
+			): GeneratedCSSRule[] => {
+				const key = borderDefinition.name;
+				if (
+					styleValue.hasOwnProperty( key ) &&
+					typeof borderDefinition.generate === 'function'
+				) {
+					const ruleKey = camelCase(
+						`border-${ individualProperty }-${ key }`
+					);
+					acc.push(
+						...borderDefinition.generate(
+							style,
+							options,
+							[ 'border', individualProperty, key ],
+							ruleKey
+						)
+					);
+				}
+				return acc;
+			},
+			[]
+		);
+	};
+
+const borderTop = {
+	name: 'borderTop',
+	generate: createBorderGenerateFunction( 'top' ),
+};
+
+const borderRight = {
+	name: 'borderRight',
+	generate: createBorderGenerateFunction( 'right' ),
+};
+
+const borderBottom = {
+	name: 'borderBottom',
+	generate: createBorderGenerateFunction( 'bottom' ),
+};
+
+const borderLeft = {
+	name: 'borderLeft',
+	generate: createBorderGenerateFunction( 'left' ),
+};
+
+export default [
+	...borderDefinitionsWithIndividualStyles,
+	radius,
+	borderTop,
+	borderRight,
+	borderBottom,
+	borderLeft,
+];

--- a/packages/style-engine/src/styles/border/index.ts
+++ b/packages/style-engine/src/styles/border/index.ts
@@ -1,9 +1,4 @@
 /**
- * External dependencies
- */
-import { camelCase, get } from 'lodash';
-
-/**
  * Internal dependencies
  */
 import type {
@@ -14,7 +9,7 @@ import type {
 	StyleDefinition,
 	StyleOptions,
 } from '../../types';
-import { generateRule, generateBoxRules } from '../utils';
+import { generateRule, generateBoxRules, upperFirst } from '../utils';
 
 const color = {
 	name: 'color',
@@ -86,7 +81,7 @@ const createBorderGenerateFunction =
 	( style: Style, options: StyleOptions ) => {
 		const styleValue:
 			| BorderIndividualStyles< typeof individualProperty >
-			| undefined = get( style, [ 'border', individualProperty ] );
+			| undefined = style?.border?.[ individualProperty ];
 
 		if ( ! styleValue ) {
 			return [];
@@ -102,9 +97,9 @@ const createBorderGenerateFunction =
 					styleValue.hasOwnProperty( key ) &&
 					typeof borderDefinition.generate === 'function'
 				) {
-					const ruleKey = camelCase(
-						`border-${ individualProperty }-${ key }`
-					);
+					const ruleKey = `border${ upperFirst(
+						individualProperty
+					) }${ upperFirst( key ) }`;
 					acc.push(
 						...borderDefinition.generate(
 							style,

--- a/packages/style-engine/src/styles/index.ts
+++ b/packages/style-engine/src/styles/index.ts
@@ -1,8 +1,14 @@
 /**
  * Internal dependencies
  */
+import border from './border';
 import color from './color';
 import spacing from './spacing';
 import typography from './typography';
 
-export const styleDefinitions = [ ...color, ...spacing, ...typography ];
+export const styleDefinitions = [
+	...border,
+	...color,
+	...spacing,
+	...typography,
+];

--- a/packages/style-engine/src/styles/spacing/margin.ts
+++ b/packages/style-engine/src/styles/spacing/margin.ts
@@ -7,12 +7,10 @@ import { generateBoxRules } from '../utils';
 const margin = {
 	name: 'margin',
 	generate: ( style: Style, options: StyleOptions ) => {
-		return generateBoxRules(
-			style,
-			options,
-			[ 'spacing', 'margin' ],
-			'margin'
-		);
+		return generateBoxRules( style, options, [ 'spacing', 'margin' ], {
+			default: 'margin',
+			individual: 'margin%s',
+		} );
 	},
 };
 

--- a/packages/style-engine/src/styles/spacing/padding.ts
+++ b/packages/style-engine/src/styles/spacing/padding.ts
@@ -7,12 +7,10 @@ import { generateBoxRules } from '../utils';
 const padding = {
 	name: 'padding',
 	generate: ( style: Style, options: StyleOptions ) => {
-		return generateBoxRules(
-			style,
-			options,
-			[ 'spacing', 'padding' ],
-			'padding'
-		);
+		return generateBoxRules( style, options, [ 'spacing', 'padding' ], {
+			default: 'padding',
+			individual: 'padding%s',
+		} );
 	},
 };
 

--- a/packages/style-engine/src/styles/utils.ts
+++ b/packages/style-engine/src/styles/utils.ts
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { get, upperFirst } from 'lodash';
+import { get } from 'lodash';
 
 /**
  * Internal dependencies
@@ -57,7 +57,7 @@ export function generateRule(
  * @param ruleKeys             An array of CSS property keys and patterns.
  * @param individualProperties The "sides" or individual properties for which to generate rules.
  *
- * @return GeneratedCSSRule[] CSS rules.
+ * @return GeneratedCSSRule[]  CSS rules.
  */
 export function generateBoxRules(
 	style: Style,
@@ -110,7 +110,10 @@ export function generateBoxRules(
  * @return string A CSS var value.
  */
 export function getCSSVarFromStyleValue( styleValue: string ): string {
-	if ( styleValue.startsWith( VARIABLE_REFERENCE_PREFIX ) ) {
+	if (
+		typeof styleValue === 'string' &&
+		styleValue.startsWith( VARIABLE_REFERENCE_PREFIX )
+	) {
 		const variable = styleValue
 			.slice( VARIABLE_REFERENCE_PREFIX.length )
 			.split( VARIABLE_PATH_SEPARATOR_TOKEN_ATTRIBUTE )
@@ -118,4 +121,15 @@ export function getCSSVarFromStyleValue( styleValue: string ): string {
 		return `var(--wp--${ variable })`;
 	}
 	return styleValue;
+}
+
+/**
+ * Capitalizes the first letter in a string.
+ *
+ * @param {string} str The string whose first letter the function will capitalize.
+ *
+ * @return string A CSS var value.
+ */
+export function upperFirst( [ firstLetter, ...rest ]: string ) {
+	return firstLetter.toUpperCase() + rest.join( '' );
 }

--- a/packages/style-engine/src/test/index.js
+++ b/packages/style-engine/src/test/index.js
@@ -81,6 +81,57 @@ describe( 'generate', () => {
 			} )
 		).toEqual( 'color: var(--wp--preset--color--ham-sandwich);' );
 	} );
+
+	it( 'should parse border rules', () => {
+		expect(
+			generate( {
+				border: {
+					color: 'var:preset|color|perky-peppermint',
+					width: '0.5em',
+					style: 'dotted',
+					radius: '11px',
+				},
+			} )
+		).toEqual(
+			'border-color: var(--wp--preset--color--perky-peppermint); border-style: dotted; border-width: 0.5em; border-radius: 11px;'
+		);
+	} );
+
+	it( 'should parse individual border rules', () => {
+		expect(
+			generate( {
+				border: {
+					top: {
+						color: 'var:preset|color|sandy-beach',
+						width: '9px',
+						style: 'dashed',
+					},
+					right: {
+						color: 'var:preset|color|leafy-avenue',
+						width: '5rem',
+					},
+					bottom: {
+						color: '#eee',
+						width: '2%',
+						style: 'solid',
+					},
+					left: {
+						color: 'var:preset|color|avocado-blues',
+						width: '100px',
+						style: 'dotted',
+					},
+					radius: {
+						topLeft: '1px',
+						topRight: '2px',
+						bottomLeft: '3px',
+						bottomRight: '4px',
+					},
+				},
+			} )
+		).toEqual(
+			'border-top-left-radius: 1px; border-top-right-radius: 2px; border-bottom-left-radius: 3px; border-bottom-right-radius: 4px; border-top-color: var(--wp--preset--color--sandy-beach); border-top-style: dashed; border-top-width: 9px; border-right-color: var(--wp--preset--color--leafy-avenue); border-right-width: 5rem; border-bottom-color: #eee; border-bottom-style: solid; border-bottom-width: 2%; border-left-color: var(--wp--preset--color--avocado-blues); border-left-style: dotted; border-left-width: 100px;'
+		);
+	} );
 } );
 
 describe( 'getCSSRules', () => {

--- a/packages/style-engine/src/test/utils.js
+++ b/packages/style-engine/src/test/utils.js
@@ -1,0 +1,12 @@
+/**
+ * Internal dependencies
+ */
+import { upperFirst } from '../styles/utils';
+
+describe( 'utils', () => {
+	describe( 'upperFirst()', () => {
+		it( 'should return an string with a capitalized first letter', () => {
+			expect( upperFirst( 'toontown' ) ).toEqual( 'Toontown' );
+		} );
+	} );
+} );

--- a/packages/style-engine/src/types.ts
+++ b/packages/style-engine/src/types.ts
@@ -11,7 +11,31 @@ export type Box< T extends BoxVariants = undefined > = {
 	left?: CSSProperties[ T extends undefined ? 'left' : `${ T }Left` ];
 };
 
+export type BorderIndividualProperty = 'top' | 'right' | 'bottom' | 'left';
+export type BorderIndividualStyles< T extends BorderIndividualProperty > = {
+	color?: CSSProperties[ `border${ Capitalize< string & T > }Color` ];
+	style?: CSSProperties[ `border${ Capitalize< string & T > }Style` ];
+	width?: CSSProperties[ `border${ Capitalize< string & T > }Width` ];
+};
+
 export interface Style {
+	border?: {
+		color?: CSSProperties[ 'borderColor' ];
+		radius?:
+			| CSSProperties[ 'borderRadius' ]
+			| {
+					topLeft?: CSSProperties[ 'borderTopLeftRadius' ];
+					topRight?: CSSProperties[ 'borderTopRightRadius' ];
+					bottomLeft?: CSSProperties[ 'borderBottomLeftRadius' ];
+					bottomRight?: CSSProperties[ 'borderBottomLeftRadius' ];
+			  };
+		style?: CSSProperties[ 'borderStyle' ];
+		width?: CSSProperties[ 'borderWidth' ];
+		top?: BorderIndividualStyles< 'top' >;
+		right?: BorderIndividualStyles< 'right' >;
+		bottom?: BorderIndividualStyles< 'bottom' >;
+		left?: BorderIndividualStyles< 'left' >;
+	};
 	spacing?: {
 		margin?: CSSProperties[ 'margin' ] | Box< 'margin' >;
 		padding?: CSSProperties[ 'padding' ] | Box< 'padding' >;
@@ -40,6 +64,8 @@ export interface Style {
 	};
 }
 
+export type CssRulesKeys = { default: string; individual: string };
+
 export type StyleOptions = {
 	/**
 	 * CSS selector for the generated style.
@@ -59,6 +85,11 @@ export type GeneratedCSSRule = {
 
 export interface StyleDefinition {
 	name: string;
-	generate?: ( style: Style, options: StyleOptions ) => GeneratedCSSRule[];
+	generate?: (
+		style: Style,
+		options: StyleOptions,
+		path?: string[],
+		ruleKey?: string
+	) => GeneratedCSSRule[];
 	getClassNames?: ( style: Style ) => string[];
 }

--- a/packages/style-engine/src/types.ts
+++ b/packages/style-engine/src/types.ts
@@ -12,6 +12,7 @@ export type Box< T extends BoxVariants = undefined > = {
 };
 
 export type BorderIndividualProperty = 'top' | 'right' | 'bottom' | 'left';
+// `T` is one of the values in `BorderIndividualProperty`. The expected CSSProperties key is something like `borderTopColor`.
 export type BorderIndividualStyles< T extends BorderIndividualProperty > = {
 	color?: CSSProperties[ `border${ Capitalize< string & T > }Color` ];
 	style?: CSSProperties[ `border${ Capitalize< string & T > }Style` ];


### PR DESCRIPTION
## What?
Adding border style generation to the style engine JS package.

Related backed PR: https://github.com/WordPress/gutenberg/pull/40531

## Why?
Carrying on with consolidating styles outlined in the tracking issue:
- https://github.com/WordPress/gutenberg/issues/38167

## How?

- Adding border style types and generator functions.
- Refactoring generateBoxRules to accommodate various "individual" properties

## Testing Instructions

I'm using Empty Theme to test.

Create a new post and add some blocks, such as Group or Column.

Update the border styles, and play around with individual border styles.

Here is some example block code:

<details>

<summary>Example HTML</summary>

```html
<!-- wp:group {"style":{"border":{"radius":{"topLeft":"29px","topRight":"60px","bottomLeft":"77px","bottomRight":"72px"},"top":{"color":"#b62323","style":"dashed","width":"61px"},"right":{"color":"#3c3737","width":"38px","style":"solid"},"bottom":{"color":"var:preset|color|pale-cyan-blue","width":"15.59rem"},"left":{"color":"#a61f76","width":"52px","style":"dotted"}}}} -->
<div class="wp-block-group" style="border-top-left-radius:29px;border-top-right-radius:60px;border-bottom-left-radius:77px;border-bottom-right-radius:72px;border-top-color:#b62323;border-top-style:dashed;border-top-width:61px;border-right-color:#3c3737;border-right-style:solid;border-right-width:38px;border-bottom-color:var(--wp--preset--color--pale-cyan-blue);border-bottom-width:15.59rem;border-left-color:#a61f76;border-left-style:dotted;border-left-width:52px"></div>
<!-- /wp:group -->

<!-- wp:group {"style":{"border":{"radius":"11px","style":"dashed","width":"20px"}},"borderColor":"vivid-green-cyan"} -->
<div class="wp-block-group has-border-color has-vivid-green-cyan-border-color" style="border-style:dashed;border-width:20px;border-radius:11px"></div>
<!-- /wp:group -->

<!-- wp:site-title {"style":{"color":{"background":"#cf1c1c"},"typography":{"fontStyle":"italic","fontWeight":"800","letterSpacing":"32px","lineHeight":3.9,"textTransform":"uppercase"},"border":{"radius":{"topLeft":"20px","topRight":"0px","bottomLeft":"20px","bottomRight":"100px"},"top":{"color":"var:preset|color|vivid-cyan-blue","width":"9px"},"right":{"color":"var:preset|color|luminous-vivid-orange","width":"18px"},"bottom":{"color":"var:preset|color|vivid-cyan-blue","width":"12px"},"left":{"color":"#b82b2b","width":"83px"}},"spacing":{"padding":{"top":"82px","right":"82px","bottom":"82px","left":"82px"},"margin":{"top":"67px","right":"67px","bottom":"67px","left":"67px"}}},"textColor":"pale-pink","fontSize":"x-large"} /-->

<!-- wp:columns -->
<div class="wp-block-columns"><!-- wp:column {"style":{"border":{"top":{"color":"#863a3a","width":"41px"},"right":{"color":"var:preset|color|vivid-purple","width":"41px","style":"dashed"},"bottom":{"width":"57px"},"left":{"color":"var:preset|color|luminous-vivid-amber","width":"46px"}}}} -->
<div class="wp-block-column" style="border-top-color:#863a3a;border-top-width:41px;border-right-color:var(--wp--preset--color--vivid-purple);border-right-style:dashed;border-right-width:41px;border-bottom-width:57px;border-left-color:var(--wp--preset--color--luminous-vivid-amber);border-left-width:46px"></div>
<!-- /wp:column --></div>
<!-- /wp:columns -->
```

</details>

Save the post.

Check that the editor and frontend match.

Run the tests!

```bash
npm run test-unit packages/style-engine/src/test/index.js
```