### PR TITLE
Allow navigation modal to support duplicates

### DIFF
--- a/packages/block-library/src/navigation/view-modal.js
+++ b/packages/block-library/src/navigation/view-modal.js
@@ -28,6 +28,25 @@ function navigationToggleModal( modal ) {
 }
 
 window.addEventListener( 'load', () => {
+	//If the navigation block with modal is duplicated on the page by another
+	//underlying block eg. Gutenslider, we need to ensure the duplicates all have
+	//and are referenced by unique ids.
+
+	let navBlockIndex = 0;
+
+	Array.prototype.forEach.call(
+		document.querySelectorAll(
+			'.wp-block-navigation__responsive-container'
+		),
+		function ( navBlock ) {
+			navBlock.id += '-' + navBlockIndex;
+			navBlock.previousElementSibling.setAttribute(
+				'data-micromodal-trigger',
+				navBlock.id
+			);
+			navBlockIndex++;
+		}
+	);
 	MicroModal.init( {
 		onShow: navigationToggleModal,
 		onClose: navigationToggleModal,


### PR DESCRIPTION
If the navigation block with modal is duplicated on the page by another underlying block eg. Gutenslider, we need to ensure the duplicates all have and are referenced by unique ids.

<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Updating the navigation/view-modal.js navigation function to support duplicate navigation modal blocks.

## Why?
This fixes situations that occur when the navigation modal is used with another block. e.g. Gutenslider that can create duplicates of the same navigation modal

## How?
We find any blocks with the class of wp-block-navigation__responsive-container then apply a unique identifier on the elements which then allows the navigationToggleModal() function to work as normal

## Testing Instructions
1. Install Gutenslider
2. Open a page
3. Insert a Gutenslider block
4. Ensure the Slide Mode under General -> Slide Mode is 'Fixed'
5. Insert slides into the block
6. Insert a navigation block to the bottom of the stack (As Shown in the screenshot)
7. Add enough items
 to the navigation menu to allow for an overlay menu to appear
8. Save and Navigate to the page when you added the blocks
9. Resize the screen to show the Overlay Menu icon
10. Clicking the icon will open up the menu as desired

<img width="343" alt="Screen Shot 2022-06-20 at 6 00 39 PM" src="https://user-images.githubusercontent.com/15954287/174535502-1d03343c-1f1a-45cb-90d8-23fd9fc0b616.png">
