### PR TITLE
Try to fix the image rotating flaky test

### DIFF
--- a/test/e2e/specs/editor/blocks/image.spec.js
+++ b/test/e2e/specs/editor/blocks/image.spec.js
@@ -415,8 +415,11 @@ test.describe( 'Image', () => {
 		).toBeHidden();
 
 		// Assert that the image is edited.
+		await expect
+			.poll( async () => imageBlockUtils.getDataURL( image ) )
+			.not.toBe( initialImageDataURL );
+
 		const updatedImageDataURL = await imageBlockUtils.getDataURL( image );
-		expect( initialImageDataURL ).not.toEqual( updatedImageDataURL );
 
 		expect(
 			snapshotDiff( initialImageDataURL, updatedImageDataURL )


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->
Hopefully fix https://github.com/WordPress/gutenberg/issues/36904.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
Hopefully fix https://github.com/WordPress/gutenberg/issues/36904.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
By using `expect.poll` to wait for the assertion to succeed. It's a simple yet effective method to _redo_ an assertion until it passes. My best guess of why it's flaky is that the editor hasn't yet finished applying the rotating effects when we made the assertion.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->

```sh
npm run test-e2e:playwright -- test/e2e/specs/editor/blocks/image.spec.js --repeat-each 10
```