### PR TITLE
Lodash: Refactor away from `_.findLast()`

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -88,6 +88,7 @@ module.exports = {
 							'each',
 							'findIndex',
 							'findKey',
+							'findLast',
 							'flatten',
 							'flattenDeep',
 							'isArray',

--- a/packages/blocks/src/store/selectors.js
+++ b/packages/blocks/src/store/selectors.js
@@ -2,17 +2,7 @@
  * External dependencies
  */
 import createSelector from 'rememo';
-import {
-	deburr,
-	filter,
-	findLast,
-	first,
-	flow,
-	get,
-	includes,
-	map,
-	some,
-} from 'lodash';
+import { deburr, filter, flow, get, includes, map, some } from 'lodash';
 
 /** @typedef {import('../api/registration').WPBlockVariation} WPBlockVariation */
 /** @typedef {import('../api/registration').WPBlockVariationScope} WPBlockVariationScope */
@@ -165,7 +155,11 @@ export function getActiveBlockVariation( state, blockName, attributes, scope ) {
 export function getDefaultBlockVariation( state, blockName, scope ) {
 	const variations = getBlockVariations( state, blockName, scope );
 
-	return findLast( variations, 'isDefault' ) || first( variations );
+	const defaultVariation = [ ...variations ]
+		.reverse()
+		.find( ( { isDefault } ) => !! isDefault );
+
+	return defaultVariation || variations[ 0 ];
 }
 
 /**

--- a/packages/docgen/lib/markdown/embed.js
+++ b/packages/docgen/lib/markdown/embed.js
@@ -1,14 +1,8 @@
-/**
- * External dependencies
- */
-const { findLast } = require( 'lodash' );
-
 const getHeadingIndex = ( ast, index ) => {
 	const astBeforeIndex = ast.children.slice( 0, index );
-	const lastHeading = findLast(
-		astBeforeIndex,
-		( node ) => node.type === 'heading'
-	);
+	const lastHeading = astBeforeIndex
+		.reverse()
+		.find( ( node ) => node.type === 'heading' );
 	return lastHeading ? lastHeading.depth : 1;
 };
 


### PR DESCRIPTION
## What?
Lodash's `findLast()` is used only a couple of times in the entire codebase. This PR aims to remove that usage.

## Why?
Lodash is known to unnecessarily inflate the bundle size of packages, and in most cases, it can be replaced with native language functionality. See these for more information and rationale:

* https://github.com/WordPress/gutenberg/issues/16938#issuecomment-602837246
* https://github.com/WordPress/gutenberg/issues/17025
* https://github.com/WordPress/gutenberg/issues/39495 

## How?
Removing `_.findLast()` is straightforward in favor of an `Array.prototype.reverse()` on a copy of an array, then using the same predicate in a `Array.prototype.find()`. We're also using the opportunity to remove a nearby `_.first()`.

## Testing Instructions

* Verify tests pass: `npm run test-unit packages/blocks/src/store/test/selectors.js`
* Verify `npx docgen` with any package's `index.js` file still works well and generates documentation files correctly.