### PR TITLE
Lodash: Refactor away from `_.size()`

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -101,6 +101,7 @@ module.exports = {
 							'noop',
 							'random',
 							'reverse',
+							'size',
 							'stubFalse',
 							'stubTrue',
 							'sum',

--- a/packages/block-editor/src/components/inserter/index.js
+++ b/packages/block-editor/src/components/inserter/index.js
@@ -1,7 +1,6 @@
 /**
  * External dependencies
  */
-import { size } from 'lodash';
 import classnames from 'classnames';
 
 /**
@@ -233,10 +232,9 @@ export default compose( [
 		const settings = getSettings();
 
 		const hasSingleBlockType =
-			size( allowedBlocks ) === 1 &&
-			size(
-				getBlockVariations( allowedBlocks[ 0 ].name, 'inserter' )
-			) === 0;
+			allowedBlocks?.length === 1 &&
+			getBlockVariations( allowedBlocks[ 0 ].name, 'inserter' )
+				?.length === 0;
 
 		let allowedBlockType = false;
 		if ( hasSingleBlockType ) {

--- a/packages/create-block/lib/init-package-json.js
+++ b/packages/create-block/lib/init-package-json.js
@@ -2,7 +2,7 @@
  * External dependencies
  */
 const { command } = require( 'execa' );
-const { isEmpty, omitBy, size } = require( 'lodash' );
+const { isEmpty, omitBy } = require( 'lodash' );
 const npmPackageArg = require( 'npm-package-arg' );
 const { join } = require( 'path' );
 const writePkg = require( 'write-pkg' );
@@ -76,7 +76,7 @@ module.exports = async ( {
 	}
 
 	if ( wpScripts ) {
-		if ( size( npmDependencies ) ) {
+		if ( npmDependencies.length ) {
 			info( '' );
 			info(
 				'Installing npm dependencies. It might take a couple of minutes...'
@@ -99,7 +99,7 @@ module.exports = async ( {
 			}
 		}
 
-		if ( size( npmDevDependencies ) ) {
+		if ( npmDevDependencies.length ) {
 			info( '' );
 			info(
 				'Installing npm devDependencies. It might take a couple of minutes...'

--- a/packages/edit-post/src/editor.js
+++ b/packages/edit-post/src/editor.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { forEach, size, map, without } from 'lodash';
+import { forEach, map, without } from 'lodash';
 
 /**
  * WordPress dependencies
@@ -126,7 +126,7 @@ function Editor( {
 		};
 
 		// Omit hidden block types if exists and non-empty.
-		if ( size( hiddenBlockTypes ) > 0 ) {
+		if ( hiddenBlockTypes.length > 0 ) {
 			// Defer to passed setting for `allowedBlockTypes` if provided as
 			// anything other than `true` (where `true` is equivalent to allow
 			// all block types).

--- a/packages/edit-post/src/editor.native.js
+++ b/packages/edit-post/src/editor.native.js
@@ -2,7 +2,7 @@
  * External dependencies
  */
 import memize from 'memize';
-import { size, map, without } from 'lodash';
+import { map, without } from 'lodash';
 import { I18nManager } from 'react-native';
 
 /**
@@ -62,7 +62,7 @@ class Editor extends Component {
 		};
 
 		// Omit hidden block types if exists and non-empty.
-		if ( size( hiddenBlockTypes ) > 0 ) {
+		if ( hiddenBlockTypes.length > 0 ) {
 			if ( settings.allowedBlockTypes === undefined ) {
 				// If no specific flags for allowedBlockTypes are set, assume `true`
 				// meaning allow all block types.


### PR DESCRIPTION
## What?
Lodash's `size()` is used only a few times in the entire codebase. This PR aims to remove that usage.

## Why?
Lodash is known to unnecessarily inflate the bundle size of packages, and in most cases, it can be replaced with native language functionality. See these for more information and rationale:

* https://github.com/WordPress/gutenberg/issues/16938#issuecomment-602837246
* https://github.com/WordPress/gutenberg/issues/17025
* https://github.com/WordPress/gutenberg/issues/39495 

## How?
Removing `_.size()` is straightforward in favor using `Array.prototype.length()`. In a few of the instances, we need optional chaining because the selectors could return `null`/`undefined`.

## Testing Instructions

* Verify inserting a column directly in a columns block still works well.
* Verify `create-block` still works (follow Quick Start instructions from: https://github.com/WordPress/gutenberg/blob/41325b983feabcc46615cd6b1a8a5efe64c5a9f0/packages/create-block/README.md#L18