### PR TITLE
Lodash: Refactor away from `_.flattenDeep()`

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -88,6 +88,7 @@ module.exports = {
 							'each',
 							'findIndex',
 							'flatten',
+							'flattenDeep',
 							'isArray',
 							'isFinite',
 							'isFunction',

--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -10,6 +10,7 @@
 
 -   `Spinner`: Convert to TypeScript and update storybook ([#41540](https://github.com/WordPress/gutenberg/pull/41540/)).
 -   `InputControl`: Add tests and update to use `@testing-library/user-event` ([#41421](https://github.com/WordPress/gutenberg/pull/41421)).
+-   `AlignmentMatrixControl`: Refactor away from `_.flattenDeep()` in utils ([#41814](https://github.com/WordPress/gutenberg/pull/41814/)).
 
 ## 19.13.0 (2022-06-15)
 

--- a/packages/components/src/alignment-matrix-control/utils.js
+++ b/packages/components/src/alignment-matrix-control/utils.js
@@ -1,9 +1,4 @@
 /**
- * External dependencies
- */
-import { flattenDeep } from 'lodash';
-
-/**
  * WordPress dependencies
  */
 import { __ } from '@wordpress/i18n';
@@ -28,7 +23,7 @@ export const ALIGNMENT_LABEL = {
 };
 
 // Transforms GRID into a flat Array of values.
-export const ALIGNMENTS = flattenDeep( GRID );
+export const ALIGNMENTS = GRID.flat();
 
 /**
  * Parses and transforms an incoming value to better match the alignment values


### PR DESCRIPTION
## What?
Lodash's `flattenDeep()` is used only a few times in the entire codebase. This PR aims to remove that usage.

## Why?
Lodash is known to unnecessarily inflate the bundle size of packages, and in most cases, it can be replaced with native language functionality. See these for more information and rationale:

* https://github.com/WordPress/gutenberg/issues/16938#issuecomment-602837246
* https://github.com/WordPress/gutenberg/issues/17025
* https://github.com/WordPress/gutenberg/issues/39495 

## How?
Removing `flattenDeep()` when used with 1 level of depth is as straightforward as replacing it with `Array.prototype.flat()`.

## Testing Instructions

* Insert a Cover block.
* Upload an image.
* In the block toolbar, click on the alignment matrix icon.
* Verify setting different alignments of content still works as before.