### PR TITLE
Lodash: Refactor away from `_.overEvery()`

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -99,6 +99,7 @@ module.exports = {
 							'memoize',
 							'negate',
 							'noop',
+							'overEvery',
 							'random',
 							'reverse',
 							'stubFalse',

--- a/bin/packages/get-packages.js
+++ b/bin/packages/get-packages.js
@@ -3,7 +3,7 @@
  */
 const fs = require( 'fs' );
 const path = require( 'path' );
-const { isEmpty, overEvery } = require( 'lodash' );
+const { isEmpty } = require( 'lodash' );
 
 /**
  * Absolute path to packages directory.
@@ -54,7 +54,9 @@ function hasModuleField( file ) {
  *
  * @return {boolean} Whether to include file in build.
  */
-const filterPackages = overEvery( isDirectory, hasModuleField );
+function filterPackages( pkg ) {
+	return [ isDirectory, hasModuleField ].every( ( check ) => check( pkg ) );
+}
 
 /**
  * Returns the absolute path of all WordPress packages


### PR DESCRIPTION
## What?
Lodash's `overEvery()` is used only a few times in the entire codebase. This PR aims to remove that usage.

## Why?
Lodash is known to unnecessarily inflate the bundle size of packages, and in most cases, it can be replaced with native language functionality. See these for more information and rationale:

* https://github.com/WordPress/gutenberg/issues/16938#issuecomment-602837246
* https://github.com/WordPress/gutenberg/issues/17025
* https://github.com/WordPress/gutenberg/issues/39495 

## How?
Removing `_.overEvery()` is straightforward in favor of an `Array.prototype.every()` implementation.

## Testing Instructions

* Run a fresh build in watch mode.
* Verify all packages are being watched as you change code in them.
* Alternatively, add `console.log( modulePackages )` here:

https://github.com/WordPress/gutenberg/blob/1bf9f6e1ce3b977d7cd2c1fc236a0b2e9a043218/bin/packages/watch.js#L17

and verify that the list of all packages is properly displayed in your terminal.