### PR TITLE
Lodash: Remove completely from `@wordpress/nux` package

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17526,7 +17526,6 @@
 				"@wordpress/element": "file:packages/element",
 				"@wordpress/i18n": "file:packages/i18n",
 				"@wordpress/icons": "file:packages/icons",
-				"lodash": "^4.17.21",
 				"rememo": "^4.0.0"
 			}
 		},

--- a/packages/nux/package.json
+++ b/packages/nux/package.json
@@ -38,7 +38,6 @@
 		"@wordpress/element": "file:../element",
 		"@wordpress/i18n": "file:../i18n",
 		"@wordpress/icons": "file:../icons",
-		"lodash": "^4.17.21",
 		"rememo": "^4.0.0"
 	},
 	"peerDependencies": {

--- a/packages/nux/src/store/selectors.js
+++ b/packages/nux/src/store/selectors.js
@@ -2,7 +2,6 @@
  * External dependencies
  */
 import createSelector from 'rememo';
-import { includes, difference, has } from 'lodash';
 
 /**
  * An object containing information about a guide.
@@ -25,10 +24,12 @@ import { includes, difference, has } from 'lodash';
 export const getAssociatedGuide = createSelector(
 	( state, tipId ) => {
 		for ( const tipIds of state.guides ) {
-			if ( includes( tipIds, tipId ) ) {
-				const nonDismissedTips = difference(
-					tipIds,
-					Object.keys( state.preferences.dismissedTips )
+			if ( tipIds.includes( tipId ) ) {
+				const nonDismissedTips = tipIds.filter(
+					( tId ) =>
+						! Object.keys(
+							state.preferences.dismissedTips
+						).includes( tId )
 				);
 				const [ currentTipId = null, nextTipId = null ] =
 					nonDismissedTips;
@@ -56,7 +57,7 @@ export function isTipVisible( state, tipId ) {
 		return false;
 	}
 
-	if ( has( state.preferences.dismissedTips, [ tipId ] ) ) {
+	if ( state.preferences.dismissedTips?.hasOwnProperty( tipId ) ) {
 		return false;
 	}
 


### PR DESCRIPTION
## What?
This PR removes all of the Lodash from the `@wordpress/nux` package, including the dependency. There are just a few usages and conversion is pretty straightforward. Also, the package is deprecated, and it doesn't have any usage, so that makes it even easier.

## Why?

Lodash is known to unnecessarily inflate the bundle size of packages, and in most cases, it can be replaced with native language functionality. See these for more information and rationale:

* https://github.com/WordPress/gutenberg/issues/16938#issuecomment-602837246
* https://github.com/WordPress/gutenberg/issues/17025
* https://github.com/WordPress/gutenberg/issues/39495 

## How?
We have to deal essentially with 3 methods (`difference`, `includes` and `has` ), and migration away from them is pretty straightforward, especially because the functionality is covered by unit tests. 

## Testing Instructions

Verify all tests pass: `npm run test-unit packages/nux`

