### PR TITLE
Lodash: Refactor away from `_.isString()` in `@wordpress/element`

### DIFF
--- a/packages/element/src/react.js
+++ b/packages/element/src/react.js
@@ -27,7 +27,6 @@ import {
 	lazy,
 	Suspense,
 } from 'react';
-import { isString } from 'lodash';
 
 /**
  * Object containing a React element.
@@ -231,7 +230,7 @@ export function switchChildrenNodeName( children, nodeName ) {
 	return (
 		children &&
 		Children.map( children, ( elt, index ) => {
-			if ( isString( elt ) ) {
+			if ( typeof elt?.valueOf() === 'string' ) {
 				return createElement( nodeName, { key: index }, elt );
 			}
 			const { children: childrenProp, ...props } = elt.props;

--- a/packages/element/src/utils.js
+++ b/packages/element/src/utils.js
@@ -1,9 +1,4 @@
 /**
- * External dependencies
- */
-import { isString } from 'lodash';
-
-/**
  * Checks if the provided WP element is empty.
  *
  * @param {*} element WP element to check.
@@ -14,7 +9,7 @@ export const isEmptyElement = ( element ) => {
 		return false;
 	}
 
-	if ( isString( element ) || Array.isArray( element ) ) {
+	if ( typeof element?.valueOf() === 'string' || Array.isArray( element ) ) {
 		return ! element.length;
 	}
 


### PR DESCRIPTION
## What?
This PR removes Lodash's `isString()` from the `@wordpress/element` package. I'm removing Lodash from the `@element` package in small steps, as it's very high-impact and has lots of usages, so any changes there have to be very carefully tested.

Part of #16938.

## Why?
Furthermore, Lodash is known to unnecessarily inflate the bundle size of packages, and in most cases, it can be replaced with native language functionality. This package is also commonly used on the front end of the sites - directly or consequently, so by removing Lodash from it, we reduce the chance for Lodash to be necessary on the front end of sites.

For more information, see the discussion in https://github.com/WordPress/gutenberg/issues/16938.

## How?
`_.isString()` is generally as simple as replacing with `typeof val === 'string'`. However, we need to account for `null` / `undefined` values, and we also need to ensure that the `new String()` constructor syntax works as well. The shortest way to support both constructor syntax and literal syntax this is to use `val.valueOf()`. Furthermore, to ensure we're not running `.valueOf()` against nullish values, we're using optional chaining: `val?.valueOf()`.

## Testing Instructions

Verify all tests pass: `npm run test-unit packages/element`

