### PR TITLE
Post Template: Ensure layout classnames are not attached to inner li elements

### DIFF
--- a/packages/block-library/src/post-template/index.php
+++ b/packages/block-library/src/post-template/index.php
@@ -102,8 +102,8 @@ function render_block_core_post_template( $attributes, $content, $block ) {
 		)->render( array( 'dynamic' => false ) );
 
 		// Wrap the render inner blocks in a `li` element with the appropriate post classes.
-		$post_classes  = implode( ' ', get_post_class( 'wp-block-post' ) );
-		$content      .= '<li class="' . esc_attr( $post_classes ) . '">' . $block_content . '</li>';
+		$post_classes = implode( ' ', get_post_class( 'wp-block-post' ) );
+		$content     .= '<li class="' . esc_attr( $post_classes ) . '">' . $block_content . '</li>';
 	}
 
 	wp_reset_postdata();

--- a/packages/block-library/src/post-template/index.php
+++ b/packages/block-library/src/post-template/index.php
@@ -90,7 +90,8 @@ function render_block_core_post_template( $attributes, $content, $block ) {
 		// This ensures that for the inner instances of the Post Template block, we do not render any block supports.
 		$block_instance['blockName'] = 'core/null';
 
-		// Render the inner blocks of the Post Template block, with `dynamic` set to `false` to ensure that no wrapper markup is included.
+		// Render the inner blocks of the Post Template block with `dynamic` set to `false` to prevent calling
+		// `render_callback` and ensure that no wrapper markup is included.
 		$block_content = (
 			new WP_Block(
 				$block_instance,

--- a/packages/block-library/src/post-template/index.php
+++ b/packages/block-library/src/post-template/index.php
@@ -82,15 +82,26 @@ function render_block_core_post_template( $attributes, $content, $block ) {
 	$content = '';
 	while ( $query->have_posts() ) {
 		$query->the_post();
+
+		// Get an instance of the current Post Template block.
+		$block_instance = $block->parsed_block;
+
+		// Set the block name to one that does not correspond to an existing registered block.
+		// This ensures that for the inner instances of the Post Template block, we do not render any block supports.
+		$block_instance['blockName'] = 'core/null';
+
+		// Render the inner blocks of the Post Template block, with `dynamic` set to `false` to ensure that no wrapper markup is included.
 		$block_content = (
 			new WP_Block(
-				$block->parsed_block,
+				$block_instance,
 				array(
 					'postType' => get_post_type(),
 					'postId'   => get_the_ID(),
 				)
 			)
 		)->render( array( 'dynamic' => false ) );
+
+		// Wrap the render inner blocks in a `li` element with the appropriate post classes.
 		$post_classes  = implode( ' ', get_post_class( 'wp-block-post' ) );
 		$content      .= '<li class="' . esc_attr( $post_classes ) . '">' . $block_content . '</li>';
 	}


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Fixes #41026 by ensuring that the Layout block support for the Post Template block is only applied on the outer-most wrapper, and not on the first child of each instance of the inner query loop. This PR is an alternative to #41802.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

Based on discussion in #41802, the Post Template block's inner `li` elements should not receive a Layout container classname. Within the Post Template block, there is a loop that iterates over the current query. For each instance of that loop, we need to output an `li` element with the block's inner blocks as the template.

Prior to this PR, the container Post Template block is rendered again for each of these inner instances, however this has an undesirable side-effect that the Post Template block's block supports are invoked an additional time for each of these instances of the loop, on the inner wrapper.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

When rendering the inner wrapper to contain the post template for each instance of the loop, set the blockname to a `null` name that does not correspond to any registered blocks. This ensures that no block supports are invoked on this inner wrapper element, effectively skipping all block supports for that inner wrapper, ensuring that Post Template block supports are only applied to the outer wrapper.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->

1. Add a Query Loop block to a post
2. In the Post Template, create some blocks to demonstrate what goes wrong if the Layout classname is erroneously added to a child block. For example, in the below screenshots, I've used a Columns block as the direct child of Post Template. In this case, it should be fairly obvious that the styling is incorrect, as the second Column will receive the margin-block-start gap of the default Layout type, adding an unexpected top margin on the second column.

## Screenshots or screencast <!-- if applicable -->

In the Before screenshot below, note that the first child of the highlighted `li` element receives two container classnames (`wp-container-12` and `wp-container-11`). In the After screenshot, it only receives the single `wp-container-11` classname.

| Before | After |
| --- | --- |
| <img width="970" alt="image" src="https://user-images.githubusercontent.com/14988353/174716336-ac054185-e425-4e85-9a6d-c1e1e71eae0c.png"> | <img width="953" alt="image" src="https://user-images.githubusercontent.com/14988353/174716282-132e5bcf-1608-4139-987e-35b85f0d4730.png"> |
