### PR TITLE
[RNMobile] Bump AztecAndroid version to v1.5.9

### DIFF
--- a/packages/react-native-aztec/android/build.gradle
+++ b/packages/react-native-aztec/android/build.gradle
@@ -9,7 +9,7 @@ buildscript {
         jSoupVersion = '1.10.3'
         wordpressUtilsVersion = '2.3.0'
         espressoVersion = '3.0.1'
-        aztecVersion = 'v1.5.8'
+        aztecVersion = 'v1.5.9'
     }
 }
 


### PR DESCRIPTION
## What?
Bumps the version of the AztecAndroid dependency from v1.5.8 to v1.5.9.

## Why?
A new version of AztecAndroid is available with updates to the Placeholder API. More info at [AztecEditor-Android#990](https://github.com/wordpress-mobile/AztecEditor-Android/pull/990).

## Testing Instructions
1) Verify that the demo app runs without any issues
2) Review any further info from the [AztecAndroid Placeholder API](https://github.com/wordpress-mobile/AztecEditor-Android/pull/990/files#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5) as needed.
