### PR TITLE
Skip flaky nav e2e test

### DIFF
--- a/packages/e2e-tests/specs/editor/blocks/navigation.test.js
+++ b/packages/e2e-tests/specs/editor/blocks/navigation.test.js
@@ -388,7 +388,10 @@ describe( 'Navigation', () => {
 			expect( loadingSpinner ).toBeNull();
 		} );
 
-		it( 'shows a loading indicator whilst ref resolves to Navigation post items', async () => {
+		// Skip reason: This test is quite flaky recently.
+		// See https://github.com/WordPress/gutenberg/issues/39231.
+		// eslint-disable-next-line jest/no-disabled-tests
+		it.skip( 'shows a loading indicator whilst ref resolves to Navigation post items', async () => {
 			const testNavId = 1;
 
 			let resolveNavigationRequest;


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->
Skip flaky nav e2e test until it's fixed.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
It's blocking contributors to merge their PR and causing confusing results. The issue is being tracked in https://github.com/WordPress/gutenberg/issues/39231.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
Skip the test `shows a loading indicator whilst ref resolves to Navigation post items`.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->
CI should pass.
