### PR TITLE
Lodash: Refactor away from `_.nth()`

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -101,6 +101,7 @@ module.exports = {
 							'memoize',
 							'negate',
 							'noop',
+							'nth',
 							'overEvery',
 							'random',
 							'reverse',

--- a/docs/tool/manifest.js
+++ b/docs/tool/manifest.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-const { camelCase, nth, upperFirst } = require( 'lodash' );
+const { camelCase, upperFirst } = require( 'lodash' );
 const fs = require( 'fs' );
 const glob = require( 'glob' ).sync;
 const { join } = require( 'path' );
@@ -51,7 +51,8 @@ function getPackageManifest( packageFolderNames ) {
  */
 function getComponentManifest( paths ) {
 	return paths.map( ( filePath ) => {
-		const slug = nth( filePath.split( '/' ), -2 );
+		const pathFragments = filePath.split( '/' );
+		const slug = pathFragments[ pathFragments.length - 2 ];
 		return {
 			title: upperFirst( camelCase( slug ) ),
 			slug,
@@ -70,10 +71,14 @@ function generateRootManifestFromTOCItems( items, parent = null ) {
 	items.forEach( ( obj ) => {
 		const fileName = Object.keys( obj )[ 0 ];
 		const children = obj[ fileName ];
+		const fileNameFragments = fileName.split( '/' );
 
-		let slug = nth( fileName.split( '/' ), -1 ).replace( '.md', '' );
+		let slug = fileNameFragments[ fileNameFragments.length - 1 ].replace(
+			'.md',
+			''
+		);
 		if ( 'readme' === slug.toLowerCase() ) {
-			slug = nth( fileName.split( '/' ), -2 );
+			slug = fileNameFragments[ fileNameFragments.length - 2 ];
 
 			// Special case - the root 'docs' readme needs the 'handbook' slug.
 			if ( parent === null && 'docs' === slug ) {


### PR DESCRIPTION
## What?
Lodash's `nth` is used only once in the entire codebase. This PR aims to remove that usage.

## Why?
Lodash is known to unnecessarily inflate the bundle size of packages, and in most cases, it can be replaced with native language functionality. See these for more information and rationale:

* https://github.com/WordPress/gutenberg/issues/16938#issuecomment-602837246
* https://github.com/WordPress/gutenberg/issues/17025
* https://github.com/WordPress/gutenberg/issues/39495 

## How?
Removing `nth` is straightforward in favor of a simple replacement, based on the index of the element, optionally relative to the length of the array if negative.

## Testing Instructions
* Verify `npm run docs:gen` runs and completes without problems.