### PR TITLE
Navigation component: Prevent title and href props from being rendered as HTML attributes.

### DIFF
--- a/packages/components/src/navigation/item/base.js
+++ b/packages/components/src/navigation/item/base.js
@@ -2,6 +2,7 @@
  * External dependencies
  */
 import classnames from 'classnames';
+import { omit } from 'lodash';
 
 /**
  * WordPress dependencies
@@ -32,7 +33,10 @@ export default function NavigationItemBase( props ) {
 	const classes = classnames( 'components-navigation__item', className );
 
 	return (
-		<ItemBaseUI className={ classes } { ...restProps }>
+		<ItemBaseUI
+			className={ classes }
+			{ ...omit( restProps, [ 'title', 'href' ] ) }
+		>
 			{ children }
 		</ItemBaseUI>
 	);

--- a/packages/components/src/navigation/item/base.js
+++ b/packages/components/src/navigation/item/base.js
@@ -2,7 +2,6 @@
  * External dependencies
  */
 import classnames from 'classnames';
-import { omit } from 'lodash';
 
 /**
  * WordPress dependencies
@@ -19,7 +18,8 @@ import { ItemBaseUI } from '../styles/navigation-styles';
 let uniqueId = 0;
 
 export default function NavigationItemBase( props ) {
-	const { children, className, ...restProps } = props;
+	// Also avoid to pass the `title` and `href` props to the ItemBaseUI styled component.
+	const { children, className, title, href, ...restProps } = props;
 
 	const [ itemId ] = useState( `item-${ ++uniqueId }` );
 
@@ -33,10 +33,7 @@ export default function NavigationItemBase( props ) {
 	const classes = classnames( 'components-navigation__item', className );
 
 	return (
-		<ItemBaseUI
-			className={ classes }
-			{ ...omit( restProps, [ 'title', 'href' ] ) }
-		>
+		<ItemBaseUI className={ classes } { ...restProps }>
 			{ children }
 		</ItemBaseUI>
 	);


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->
In the Navigation component, the `<li>` elements render a title attribute and a href attribute:
- The title attribute just repeats the visible text.
- The href attribute on the `<li>` element is invalid HTML.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
- Title attributes are arguably useful. See this Trac ticket: https://core.trac.wordpress.org/ticket/24766. In this specific case, they just repeat the visible text. Visually, that's redundant. Also, screen readers may announce the title attribute, depending on user settings, leading to unnecessary noise for users.
- The href attribute rendered on `<li>` element is just invalid HTML.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
This PR uses lodash `omit` to remove `title` and `href` from the passed props.
Worth noting the `<li>` element is a styled component. I'm not sure it actually needs the passed `restProps`. 

## Testing Instructions
- Go to the site editor.
- Open the navigation sidebar on the left.
- Inspect the navigation links: Site, Templates, Template Parts.
- Check the `<li>` elements that contain the links don't have a title and href attribute.

## Screenshots or screencast <!-- if applicable -->

Screenshot with the unnecessary HTML attributes rendered and title attribute 'tooltip' visible on hover:

<img width="1587" alt="Screenshot 2022-06-20 at 14 30 59" src="https://user-images.githubusercontent.com/1682452/174768815-ccfbf6cf-d7b7-4389-a413-c2911a9abf92.png">

It happens also when the item is 'text only'. Screenshot from the storybook:

<img width="599" alt="Screenshot 2022-06-20 at 14 22 20" src="https://user-images.githubusercontent.com/1682452/174768988-db6925b8-6119-46fb-806a-d3417ce548a4.png">



