### PR TITLE
Lodash: Remove completely from `@wordpress/notices` package

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17507,8 +17507,7 @@
 			"requires": {
 				"@babel/runtime": "^7.16.0",
 				"@wordpress/a11y": "file:packages/a11y",
-				"@wordpress/data": "file:packages/data",
-				"lodash": "^4.17.21"
+				"@wordpress/data": "file:packages/data"
 			}
 		},
 		"@wordpress/npm-package-json-lint-config": {

--- a/packages/notices/package.json
+++ b/packages/notices/package.json
@@ -27,8 +27,7 @@
 	"dependencies": {
 		"@babel/runtime": "^7.16.0",
 		"@wordpress/a11y": "file:../a11y",
-		"@wordpress/data": "file:../data",
-		"lodash": "^4.17.21"
+		"@wordpress/data": "file:../data"
 	},
 	"peerDependencies": {
 		"react": "^17.0.0"

--- a/packages/notices/src/store/actions.js
+++ b/packages/notices/src/store/actions.js
@@ -1,9 +1,4 @@
 /**
- * External dependencies
- */
-import { uniqueId } from 'lodash';
-
-/**
  * Internal dependencies
  */
 import { DEFAULT_CONTEXT, DEFAULT_STATUS } from './constants';
@@ -18,6 +13,8 @@ import { DEFAULT_CONTEXT, DEFAULT_STATUS } from './constants';
  *                               triggered by user.
  *
  */
+
+let uniqueId = 0;
 
 /**
  * Returns an action object used in signalling that a notice is to be created.
@@ -54,7 +51,7 @@ export function createNotice( status = DEFAULT_STATUS, content, options = {} ) {
 		speak = true,
 		isDismissible = true,
 		context = DEFAULT_CONTEXT,
-		id = uniqueId( context ),
+		id = `${ context }${ ++uniqueId }`,
 		actions = [],
 		type = 'default',
 		__unstableHTML,

--- a/packages/notices/src/store/reducer.js
+++ b/packages/notices/src/store/reducer.js
@@ -1,9 +1,4 @@
 /**
- * External dependencies
- */
-import { reject } from 'lodash';
-
-/**
  * Internal dependencies
  */
 import onSubKey from './utils/on-sub-key';
@@ -22,12 +17,12 @@ const notices = onSubKey( 'context' )( ( state = [], action ) => {
 		case 'CREATE_NOTICE':
 			// Avoid duplicates on ID.
 			return [
-				...reject( state, { id: action.notice.id } ),
+				...state.filter( ( { id } ) => id !== action.notice.id ),
 				action.notice,
 			];
 
 		case 'REMOVE_NOTICE':
-			return reject( state, { id: action.id } );
+			return state.filter( ( { id } ) => id !== action.id );
 	}
 
 	return state;


### PR DESCRIPTION
## What?
This PR removes all of the Lodash from the `@wordpress/notices` package, including the dependency. There are just a few usages and conversion is pretty straightforward. 

## Why?

Lodash is known to unnecessarily inflate the bundle size of packages, and in most cases, it can be replaced with native language functionality. See these for more information and rationale:

* https://github.com/WordPress/gutenberg/issues/16938#issuecomment-602837246
* https://github.com/WordPress/gutenberg/issues/17025
* https://github.com/WordPress/gutenberg/issues/39495 

## How?
We have to deal essentially with 2 methods (`reject`, and `uniqueId` ), and migration away from them is pretty straightforward, especially because the functionality is covered by unit tests. 

## Testing Instructions

Verify all tests pass: `npm run test-unit packages/notices`

