### PR TITLE
fix: Image block preserves alt text from media library

### DIFF
--- a/packages/block-library/src/image/edit.native.js
+++ b/packages/block-library/src/image/edit.native.js
@@ -428,6 +428,7 @@ export class ImageEdit extends Component {
 			id: media.id,
 			url: media.url,
 			caption: media.caption,
+			alt: media.alt,
 		};
 
 		let additionalAttributes;

--- a/packages/react-native-bridge/android/react-native-bridge/src/main/java/org/wordpress/mobile/ReactNativeGutenbergBridge/RNMedia.kt
+++ b/packages/react-native-bridge/android/react-native-bridge/src/main/java/org/wordpress/mobile/ReactNativeGutenbergBridge/RNMedia.kt
@@ -8,5 +8,6 @@ interface RNMedia {
     val type: String
     val caption: String
     val title: String
+    val alt: String
     fun toMap(): WritableMap
 }

--- a/packages/react-native-bridge/android/react-native-bridge/src/main/java/org/wordpress/mobile/WPAndroidGlue/Media.kt
+++ b/packages/react-native-bridge/android/react-native-bridge/src/main/java/org/wordpress/mobile/WPAndroidGlue/Media.kt
@@ -14,7 +14,8 @@ data class Media(
     override val url: String,
     override val type: String,
     override val caption: String = "",
-    override val title: String = ""
+    override val title: String = "",
+    override val alt: String = ""
 ) : RNMedia {
     override fun toMap(): WritableMap = WritableNativeMap().apply {
         putInt("id", id)
@@ -22,6 +23,7 @@ data class Media(
         putString("type", type)
         putString("caption", caption)
         putString("title", title)
+        putString("alt", alt)
     }
 
     companion object {
@@ -31,7 +33,8 @@ data class Media(
             url: String,
             mimeType: String?,
             caption: String?,
-            title: String?
+            title: String?,
+            alt: String?,
         ): Media {
             val isMediaType = { mediaType: MediaType ->
                 mimeType?.startsWith(mediaType.name.toLowerCase(Locale.ROOT)) == true
@@ -41,7 +44,7 @@ data class Media(
                 isMediaType(VIDEO) -> VIDEO
                 else -> OTHER
             }.name.toLowerCase(Locale.ROOT)
-            return Media(id, url, type, caption ?: "", title ?: "")
+            return Media(id, url, type, caption ?: "", title ?: "", alt ?: "")
         }
     }
 }

--- a/packages/react-native-bridge/android/react-native-bridge/src/main/java/org/wordpress/mobile/WPAndroidGlue/Media.kt
+++ b/packages/react-native-bridge/android/react-native-bridge/src/main/java/org/wordpress/mobile/WPAndroidGlue/Media.kt
@@ -27,6 +27,18 @@ data class Media(
     }
 
     companion object {
+        private fun convertToType(mimeType: String?): String {
+            val isMediaType = { mediaType: MediaType ->
+                mimeType?.startsWith(mediaType.name.toLowerCase(Locale.ROOT)) == true
+            }
+            val type = when {
+                isMediaType(IMAGE) -> IMAGE
+                isMediaType(VIDEO) -> VIDEO
+                else -> OTHER
+            }.name.toLowerCase(Locale.ROOT)
+            return type;
+        }
+
         @JvmStatic
         fun createRNMediaUsingMimeType(
             id: Int,
@@ -36,15 +48,19 @@ data class Media(
             title: String?,
             alt: String?,
         ): Media {
-            val isMediaType = { mediaType: MediaType ->
-                mimeType?.startsWith(mediaType.name.toLowerCase(Locale.ROOT)) == true
-            }
-            val type = when {
-                isMediaType(IMAGE) -> IMAGE
-                isMediaType(VIDEO) -> VIDEO
-                else -> OTHER
-            }.name.toLowerCase(Locale.ROOT)
+            val type = convertToType(mimeType)
             return Media(id, url, type, caption ?: "", title ?: "", alt ?: "")
+        }
+        @JvmStatic
+        fun createRNMediaUsingMimeType(
+            id: Int,
+            url: String,
+            mimeType: String?,
+            caption: String?,
+            title: String?,
+        ): Media {
+            val type = convertToType(mimeType)
+            return Media(id, url, type, caption ?: "", title ?: "")
         }
     }
 }

--- a/packages/react-native-bridge/ios/GutenbergBridgeDelegate.swift
+++ b/packages/react-native-bridge/ios/GutenbergBridgeDelegate.swift
@@ -4,13 +4,15 @@ public struct MediaInfo: Encodable {
     public let type: String?
     public let title: String?
     public let caption: String?
+    public let alt: String?
 
-    public init(id: Int32?, url: String?, type: String?, caption: String? = nil, title: String? = nil) {
+    public init(id: Int32?, url: String?, type: String?, caption: String? = nil, title: String? = nil, alt: String? = nil) {
         self.id = id
         self.url = url
         self.type = type
         self.caption = caption
         self.title = title
+        self.alt = alt
     }
 }
 

--- a/packages/react-native-editor/CHANGELOG.md
+++ b/packages/react-native-editor/CHANGELOG.md
@@ -12,6 +12,7 @@ For each user feature we should also add a importance categorization label  to i
 ## Unreleased
 
 -   [*] Add 'Insert from URL' option to Video block [#41493]
+-   [*] Image block copies the alt text from the media library when selecting an item [#41839]
 
 ## 1.78.1
 

--- a/packages/react-native-editor/__device-tests__/helpers/test-data.js
+++ b/packages/react-native-editor/__device-tests__/helpers/test-data.js
@@ -96,7 +96,7 @@ exports.imageCompletehtml = `<!-- wp:image {"id":1,"sizeslug":"large"} -->
 <!-- /wp:paragraph -->`;
 
 exports.imageShorteHtml = `<!-- wp:image {"id":1,"sizeslug":"large"} -->
-<figure class="wp-block-image size-large"><img src="https://cldup.com/cXyG__fTLN.jpg" alt="" class="wp-image-1"/><figcaption>C'est la vie my friends</figcaption></figure>
+<figure class="wp-block-image size-large"><img src="https://cldup.com/cXyG__fTLN.jpg" alt="A snow-capped mountain top in a cloudy sky with red-leafed trees in the foreground" class="wp-image-1"/><figcaption>C'est la vie my friends</figcaption></figure>
 <!-- /wp:image -->
 
 <!-- wp:paragraph -->

--- a/packages/react-native-editor/android/app/src/main/java/com/gutenberg/MainApplication.java
+++ b/packages/react-native-editor/android/app/src/main/java/com/gutenberg/MainApplication.java
@@ -85,7 +85,7 @@ public class MainApplication extends Application implements ReactApplication, Gu
 
                 switch (mediaType) {
                     case IMAGE:
-                        rnMediaList.add(createRNMediaUsingMimeType(1, "https://cldup.com/cXyG__fTLN.jpg", "image", "Mountain", "", "A snowcapped mountain top in a cloudy sky with red leaved trees in the foreground"));
+                        rnMediaList.add(createRNMediaUsingMimeType(1, "https://cldup.com/cXyG__fTLN.jpg", "image", "Mountain", "", "A snow-capped mountain top in a cloudy sky with red-leafed trees in the foreground"));
                         break;
                     case VIDEO:
                         rnMediaList.add(createRNMediaUsingMimeType(2, "https://i.cloudup.com/YtZFJbuQCE.mov", "video", "Cloudup", ""));

--- a/packages/react-native-editor/android/app/src/main/java/com/gutenberg/MainApplication.java
+++ b/packages/react-native-editor/android/app/src/main/java/com/gutenberg/MainApplication.java
@@ -1,5 +1,7 @@
 package com.gutenberg;
 
+import static org.wordpress.mobile.WPAndroidGlue.Media.createRNMediaUsingMimeType;
+
 import android.app.Application;
 import android.content.Intent;
 import android.content.res.Configuration;
@@ -83,17 +85,17 @@ public class MainApplication extends Application implements ReactApplication, Gu
 
                 switch (mediaType) {
                     case IMAGE:
-                        rnMediaList.add(new Media(1, "https://cldup.com/cXyG__fTLN.jpg", "image", "Mountain", ""));
+                        rnMediaList.add(createRNMediaUsingMimeType(1, "https://cldup.com/cXyG__fTLN.jpg", "image", "Mountain", "", "A snowcapped mountain top in a cloudy sky with red leaved trees in the foreground"));
                         break;
                     case VIDEO:
-                        rnMediaList.add(new Media(2, "https://i.cloudup.com/YtZFJbuQCE.mov", "video", "Cloudup", ""));
+                        rnMediaList.add(createRNMediaUsingMimeType(2, "https://i.cloudup.com/YtZFJbuQCE.mov", "video", "Cloudup", ""));
                         break;
                     case ANY:
                     case OTHER:
-                        rnMediaList.add(new Media(3, "https://wordpress.org/latest.zip", "zip", "WordPress latest version", "WordPress.zip"));
+                        rnMediaList.add(createRNMediaUsingMimeType(3, "https://wordpress.org/latest.zip", "zip", "WordPress latest version", "WordPress.zip"));
                         break;
                     case AUDIO:
-                        rnMediaList.add(new Media(5, "https://cldup.com/59IrU0WJtq.mp3", "audio", "Summer presto", ""));
+                        rnMediaList.add(createRNMediaUsingMimeType(5, "https://cldup.com/59IrU0WJtq.mp3", "audio", "Summer presto", ""));
                         break;
                 }
                 mediaSelectedCallback.onMediaFileSelected(rnMediaList);
@@ -145,7 +147,7 @@ public class MainApplication extends Application implements ReactApplication, Gu
             public void requestMediaPickFrom(String mediaSource, MediaSelectedCallback mediaSelectedCallback, Boolean allowMultipleSelection) {
                 if (mediaSource.equals("1")) {
                     List<RNMedia> rnMediaList = new ArrayList<>();
-                    rnMediaList.add(new Media(1, "https://grad.illinois.edu/sites/default/files/pdfs/cvsamples.pdf", "other", "","cvsamples.pdf"));
+                    rnMediaList.add(createRNMediaUsingMimeType(1, "https://grad.illinois.edu/sites/default/files/pdfs/cvsamples.pdf", "other", "","cvsamples.pdf"));
                     mediaSelectedCallback.onMediaFileSelected(rnMediaList);
                 }
             }

--- a/packages/react-native-editor/ios/GutenbergDemo/GutenbergViewController.swift
+++ b/packages/react-native-editor/ios/GutenbergDemo/GutenbergViewController.swift
@@ -88,9 +88,9 @@ extension GutenbergViewController: GutenbergBridgeDelegate {
             case .image:
                 if(allowMultipleSelection) {
                     callback([MediaInfo(id: 1, url: "https://cldup.com/cXyG__fTLN.jpg", type: "image"),
-                              MediaInfo(id: 3, url: "https://cldup.com/cXyG__fTLN.jpg", type: "image", caption: "Mountain")])
+                              MediaInfo(id: 3, url: "https://cldup.com/cXyG__fTLN.jpg", type: "image", caption: "Mountain", alt: "A snow-capped mountain top in a cloudy sky with red-leafed trees in the foreground")])
                 } else {
-                    callback([MediaInfo(id: 1, url: "https://cldup.com/cXyG__fTLN.jpg", type: "image", caption: "Mountain")])
+                    callback([MediaInfo(id: 1, url: "https://cldup.com/cXyG__fTLN.jpg", type: "image", caption: "Mountain", alt: "A snow-capped mountain top in a cloudy sky with red-leafed trees in the foreground")])
                 }
             case .video:
                 if(allowMultipleSelection) {


### PR DESCRIPTION
## What?
When the alt text for a media item is present in the media library, copy the alt text into the Image block when the media item is selected. 

## Why?
Fixes https://github.com/wordpress-mobile/gutenberg-mobile/issues/4977. This updated behavior avoids the need to re-enter the alt text for each image inserted into the post content. 

## How?
The changes now send a media item's alt text value from the native host app to the block editor, which allows the block editor to set the alt text to the Image block's attributes. 

Additionally, the changes update all demo editor media creation to leverage the `createRNMediaUsingMimeType` helper, as the overloaded Kotlin function allows conditionally setting of alt text (e.g. videos do not have alt text). This also aligns with the approach taken in the host native apps. 

## Related PRs

* https://github.com/wordpress-mobile/gutenberg-mobile/pull/4976
* https://github.com/wordpress-mobile/WordPress-iOS/pull/18919
* https://github.com/wordpress-mobile/WordPress-Android/pull/16787

## Testing Instructions

<details><summary>Insert an image w/ alt text</summary>

1. Launch the WordPress native mobile app. 
1. Navigate to the _Media_ screen. 
1. Upload an image and set the _Alt Text_ for the image. 
1. Create a new post. 
1. Insert an Image block. 
1. Set the previously uploaded media item as the media for the newly inserted Image block. 
1. Open the block settings for the Image block. 
1. Verify the _Alt Text_ matches the value set within the _Media_ screen.

</details>

<details><summary>Insert a video</summary>

1. Launch the WordPress native mobile app. 
1. Create a new post. 
1. Insert an Video block. 
1. Set a previously uploaded video as the media for the newly inserted Video block. 
1. Verify the video displays as expected with no changes from the production app.

</details>

<details><summary>Insert a file</summary>

1. Launch the WordPress native mobile app. 
1. Create a new post. 
1. Insert an File block. 
1. Set a previously uploaded image/video/file as the media for the newly inserted File block. 
1. Verify the file displays as expected with no changes from the production app.

</details>

## Screenshots or screencast 

https://user-images.githubusercontent.com/438664/174880989-b497fb08-5cdb-47ab-82fe-5e2b5cf88b92.MP4
