### PR TITLE
Extract common API from Global Styles color UI controls

### DIFF
--- a/packages/edit-site/src/components/global-styles/hooks.js
+++ b/packages/edit-site/src/components/global-styles/hooks.js
@@ -311,11 +311,11 @@ export function useCanCustomizeColor( name, requiredSetting, requiredSupport ) {
 	const [ solids ] = useSetting( 'color.palette', name );
 	const [ areCustomSolidsEnabled ] = useSetting( 'color.custom', name );
 
-	const [ isTextEnabled ] = useSetting( requiredSetting, name );
+	const [ isSettingEnabled ] = useSetting( requiredSetting, name );
 
 	return (
 		supports.includes( requiredSupport ) &&
-		isTextEnabled &&
+		isSettingEnabled &&
 		( solids.length > 0 || areCustomSolidsEnabled )
 	);
 }

--- a/packages/edit-site/src/components/global-styles/hooks.js
+++ b/packages/edit-site/src/components/global-styles/hooks.js
@@ -305,3 +305,17 @@ export function useGradientsPerOrigin( name ) {
 		return result;
 	}, [ customGradients, themeGradients, defaultGradients ] );
 }
+
+export function useCanCustomizeColor( name, requiredSetting, requiredSupport ) {
+	const supports = getSupportedGlobalStylesPanels( name );
+	const [ solids ] = useSetting( 'color.palette', name );
+	const [ areCustomSolidsEnabled ] = useSetting( 'color.custom', name );
+
+	const [ isTextEnabled ] = useSetting( requiredSetting, name );
+
+	return (
+		supports.includes( requiredSupport ) &&
+		isTextEnabled &&
+		( solids.length > 0 || areCustomSolidsEnabled )
+	);
+}

--- a/packages/edit-site/src/components/global-styles/screen-button-color.js
+++ b/packages/edit-site/src/components/global-styles/screen-button-color.js
@@ -35,7 +35,7 @@ function ScreenButtonColor( { name } ) {
 			<ScreenElementColorpicker
 				name={ name }
 				element="button"
-				path="elements.button.background.text"
+				path="elements.button.color.text"
 			/>
 			<h4 className="edit-site-global-styles-section-title">
 				{ __( 'Background color' ) }
@@ -43,7 +43,7 @@ function ScreenButtonColor( { name } ) {
 			<ScreenElementColorpicker
 				name={ name }
 				element="button"
-				path="elements.button.background.text"
+				path="elements.button.color.background"
 			/>
 		</>
 	);

--- a/packages/edit-site/src/components/global-styles/screen-button-color.js
+++ b/packages/edit-site/src/components/global-styles/screen-button-color.js
@@ -1,0 +1,52 @@
+/**
+ * WordPress dependencies
+ */
+import { __ } from '@wordpress/i18n';
+
+/**
+ * Internal dependencies
+ */
+import ScreenHeader from './header';
+import { useCanCustomizeColor } from './hooks';
+import ScreenElementColorpicker from './screen-element-colorpicker';
+
+function ScreenButtonColor( { name } ) {
+	const canCustomize = useCanCustomizeColor(
+		name,
+		'color.background',
+		'buttonColor'
+	);
+
+	if ( ! canCustomize ) {
+		return null;
+	}
+
+	return (
+		<>
+			<ScreenHeader
+				title={ __( 'Buttons' ) }
+				description={ __(
+					'Manage the fonts and typography used on buttons.'
+				) }
+			/>
+			<h4 className="edit-site-global-styles-section-title">
+				{ __( 'Text color' ) }
+			</h4>
+			<ScreenElementColorpicker
+				name={ name }
+				element="button"
+				path="elements.button.background.text"
+			/>
+			<h4 className="edit-site-global-styles-section-title">
+				{ __( 'Background color' ) }
+			</h4>
+			<ScreenElementColorpicker
+				name={ name }
+				element="button"
+				path="elements.button.background.text"
+			/>
+		</>
+	);
+}
+
+export default ScreenButtonColor;

--- a/packages/edit-site/src/components/global-styles/screen-element-colorpicker.js
+++ b/packages/edit-site/src/components/global-styles/screen-element-colorpicker.js
@@ -1,0 +1,35 @@
+/**
+ * WordPress dependencies
+ */
+import { __experimentalColorGradientControl as ColorGradientControl } from '@wordpress/block-editor';
+
+/**
+ * Internal dependencies
+ */
+import { useSetting, useStyle, useColorsPerOrigin } from './hooks';
+
+function ScreenElementColorpicker( { name, element, path } ) {
+	const colorsPerOrigin = useColorsPerOrigin( name );
+	const [ areCustomSolidsEnabled ] = useSetting( 'color.custom', name );
+	const [ color, setColor ] = useStyle( path, name );
+	const [ userColor ] = useStyle( path, name, 'user' );
+
+	return (
+		<>
+			<ColorGradientControl
+				className={ `edit-site-screen-${ element }-color__control` }
+				colors={ colorsPerOrigin }
+				disableCustomColors={ ! areCustomSolidsEnabled }
+				__experimentalHasMultipleOrigins
+				showTitle={ false }
+				enableAlpha
+				__experimentalIsRenderedInSidebar
+				colorValue={ color }
+				onColorChange={ setColor }
+				clearable={ color === userColor }
+			/>
+		</>
+	);
+}
+
+export default ScreenElementColorpicker;

--- a/packages/edit-site/src/components/global-styles/screen-link-color.js
+++ b/packages/edit-site/src/components/global-styles/screen-link-color.js
@@ -31,7 +31,7 @@ function ScreenLinkColor( { name } ) {
 			/>
 			<ScreenElementColorpicker
 				name={ name }
-				element="button"
+				element="link"
 				path="elements.link.color.text"
 			/>
 		</>

--- a/packages/edit-site/src/components/global-styles/screen-link-color.js
+++ b/packages/edit-site/src/components/global-styles/screen-link-color.js
@@ -2,44 +2,22 @@
  * WordPress dependencies
  */
 import { __ } from '@wordpress/i18n';
-import { __experimentalColorGradientControl as ColorGradientControl } from '@wordpress/block-editor';
 
 /**
  * Internal dependencies
  */
 import ScreenHeader from './header';
-import {
-	getSupportedGlobalStylesPanels,
-	useSetting,
-	useStyle,
-	useColorsPerOrigin,
-} from './hooks';
+import { useCanCustomizeColor } from './hooks';
+import ScreenElementColorpicker from './screen-element-colorpicker';
 
 function ScreenLinkColor( { name } ) {
-	const supports = getSupportedGlobalStylesPanels( name );
-	const [ solids ] = useSetting( 'color.palette', name );
-	const [ areCustomSolidsEnabled ] = useSetting( 'color.custom', name );
-
-	const colorsPerOrigin = useColorsPerOrigin( name );
-
-	const [ isLinkEnabled ] = useSetting( 'color.link', name );
-
-	const hasLinkColor =
-		supports.includes( 'linkColor' ) &&
-		isLinkEnabled &&
-		( solids.length > 0 || areCustomSolidsEnabled );
-
-	const [ linkColor, setLinkColor ] = useStyle(
-		'elements.link.color.text',
-		name
-	);
-	const [ userLinkColor ] = useStyle(
-		'elements.link.color.text',
+	const canCustomize = useCanCustomizeColor(
 		name,
-		'user'
+		'color.text',
+		'linkColor'
 	);
 
-	if ( ! hasLinkColor ) {
+	if ( ! canCustomize ) {
 		return null;
 	}
 
@@ -51,17 +29,10 @@ function ScreenLinkColor( { name } ) {
 					'Set the default color used for links across the site.'
 				) }
 			/>
-			<ColorGradientControl
-				className="edit-site-screen-link-color__control"
-				colors={ colorsPerOrigin }
-				disableCustomColors={ ! areCustomSolidsEnabled }
-				__experimentalHasMultipleOrigins
-				showTitle={ false }
-				enableAlpha
-				__experimentalIsRenderedInSidebar
-				colorValue={ linkColor }
-				onColorChange={ setLinkColor }
-				clearable={ linkColor === userLinkColor }
+			<ScreenElementColorpicker
+				name={ name }
+				element="button"
+				path="elements.link.color.text"
 			/>
 		</>
 	);

--- a/packages/edit-site/src/components/global-styles/screen-text-color.js
+++ b/packages/edit-site/src/components/global-styles/screen-text-color.js
@@ -28,7 +28,7 @@ function ScreenTextColor( { name } ) {
 			<ScreenElementColorpicker
 				name={ name }
 				element="button"
-				path="elements.link.color.text"
+				path="color.text"
 			/>
 		</>
 	);

--- a/packages/edit-site/src/components/global-styles/screen-text-color.js
+++ b/packages/edit-site/src/components/global-styles/screen-text-color.js
@@ -2,36 +2,18 @@
  * WordPress dependencies
  */
 import { __ } from '@wordpress/i18n';
-import { __experimentalColorGradientControl as ColorGradientControl } from '@wordpress/block-editor';
 
 /**
  * Internal dependencies
  */
 import ScreenHeader from './header';
-import {
-	getSupportedGlobalStylesPanels,
-	useSetting,
-	useStyle,
-	useColorsPerOrigin,
-} from './hooks';
+import { useCanCustomizeColor } from './hooks';
+import ScreenElementColorpicker from './screen-element-colorpicker';
 
 function ScreenTextColor( { name } ) {
-	const supports = getSupportedGlobalStylesPanels( name );
-	const [ solids ] = useSetting( 'color.palette', name );
-	const [ areCustomSolidsEnabled ] = useSetting( 'color.custom', name );
-	const [ isTextEnabled ] = useSetting( 'color.text', name );
+	const canCustomize = useCanCustomizeColor( name, 'color.text', 'color' );
 
-	const colorsPerOrigin = useColorsPerOrigin( name );
-
-	const hasTextColor =
-		supports.includes( 'color' ) &&
-		isTextEnabled &&
-		( solids.length > 0 || areCustomSolidsEnabled );
-
-	const [ color, setColor ] = useStyle( 'color.text', name );
-	const [ userColor ] = useStyle( 'color.text', name, 'user' );
-
-	if ( ! hasTextColor ) {
+	if ( ! canCustomize ) {
 		return null;
 	}
 
@@ -43,17 +25,10 @@ function ScreenTextColor( { name } ) {
 					'Set the default color used for text across the site.'
 				) }
 			/>
-			<ColorGradientControl
-				className="edit-site-screen-text-color__control"
-				colors={ colorsPerOrigin }
-				disableCustomColors={ ! areCustomSolidsEnabled }
-				__experimentalHasMultipleOrigins
-				showTitle={ false }
-				enableAlpha
-				__experimentalIsRenderedInSidebar
-				colorValue={ color }
-				onColorChange={ setColor }
-				clearable={ color === userColor }
+			<ScreenElementColorpicker
+				name={ name }
+				element="button"
+				path="elements.link.color.text"
 			/>
 		</>
 	);


### PR DESCRIPTION
## What?
https://github.com/WordPress/gutenberg/pull/41659 makes it clear that adding new elements to Global Styles UI require a lot of code duplication.

This PR is the first step to lowering thid footprint.

It extracts two common APIs:

* ScreenElementColorpicker
* useCanCustomizeColor

A reasonable next step would be to build a generic `ScreenColorElement` component the same way as we have `ScreenTypographyElement`.

Oh, and this PR will have to be rebased once #41659 lands.

## Testing Instructions

1. Check if the ideas in this PR make sense
2. Confirm all the tests are green – this PR is just a refactoring without any functional changes.

cc @getdave @scruffian @draganescu 