### PR TITLE
Add: Post type restriction API for patterns.

### DIFF
--- a/packages/edit-site/src/components/block-editor/index.js
+++ b/packages/edit-site/src/components/block-editor/index.js
@@ -83,11 +83,19 @@ export default function BlockEditor( { setIsInserterOpen } ) {
 			[
 				...( settingsBlockPatterns || [] ),
 				...( restBlockPatterns || [] ),
-			].filter(
-				( x, index, arr ) =>
-					index === arr.findIndex( ( y ) => x.name === y.name )
-			),
-		[ settingsBlockPatterns, restBlockPatterns ]
+			]
+				.filter(
+					( x, index, arr ) =>
+						index === arr.findIndex( ( y ) => x.name === y.name )
+				)
+				.filter( ( { postTypes } ) => {
+					return (
+						! postTypes ||
+						( Array.isArray( postTypes ) &&
+							postTypes.includes( templateType ) )
+					);
+				} ),
+		[ settingsBlockPatterns, restBlockPatterns, templateType ]
 	);
 
 	const blockPatternCategories = useMemo(

--- a/packages/editor/src/components/provider/use-block-editor-settings.js
+++ b/packages/editor/src/components/provider/use-block-editor-settings.js
@@ -36,8 +36,10 @@ function useBlockEditorSettings( settings, hasTemplate ) {
 		canUseUnfilteredHTML,
 		userCanCreatePages,
 		pageOnFront,
+		postType,
 	} = useSelect( ( select ) => {
-		const { canUserUseUnfilteredHTML } = select( editorStore );
+		const { canUserUseUnfilteredHTML, getCurrentPostType } =
+			select( editorStore );
 		const isWeb = Platform.OS === 'web';
 		const { canUser, getEntityRecord } = select( coreStore );
 
@@ -57,6 +59,7 @@ function useBlockEditorSettings( settings, hasTemplate ) {
 			hasUploadPermissions: canUser( 'create', 'media' ) ?? true,
 			userCanCreatePages: canUser( 'create', 'pages' ),
 			pageOnFront: siteSettings?.page_on_front,
+			postType: getCurrentPostType(),
 		};
 	}, [] );
 
@@ -81,11 +84,19 @@ function useBlockEditorSettings( settings, hasTemplate ) {
 			[
 				...( settingsBlockPatterns || [] ),
 				...( restBlockPatterns || [] ),
-			].filter(
-				( x, index, arr ) =>
-					index === arr.findIndex( ( y ) => x.name === y.name )
-			),
-		[ settingsBlockPatterns, restBlockPatterns ]
+			]
+				.filter(
+					( x, index, arr ) =>
+						index === arr.findIndex( ( y ) => x.name === y.name )
+				)
+				.filter( ( { postTypes } ) => {
+					return (
+						! postTypes ||
+						( Array.isArray( postTypes ) &&
+							postTypes.includes( postType ) )
+					);
+				} ),
+		[ settingsBlockPatterns, restBlockPatterns, postType ]
 	);
 
 	const blockPatternCategories = useMemo(


### PR DESCRIPTION
This PR implements the postTypes restriction for patterns. If a pattern specifies some postTypes the pattern will only be show if one of the post types is being edited.

## API
```
register_block_pattern( 'custom-pattern', array(
			'title'      => _x( 'A product pattern', 'Block pattern title', 'gutenberg' ),
			'postTypes' = array( 'product' ),
			'content'    => '...',
		) );
```

Depends on https://github.com/WordPress/gutenberg/pull/41791 which changes the rest endpoint to include the post-type property.