### PR TITLE
Webfonts API: Document `fontFace` and it’s values in `theme.json` schema

### DIFF
--- a/docs/reference-guides/theme-json-reference/theme-json-living.md
+++ b/docs/reference-guides/theme-json-reference/theme-json-living.md
@@ -101,7 +101,7 @@ Settings related to typography.
 | textTransform | boolean | true |  |
 | dropCap | boolean | true |  |
 | fontSizes | array |  | name, size, slug |
-| fontFamilies | array |  | fontFamily, name, slug |
+| fontFamilies | array |  | fontFace, fontFamily, name, slug |
 
 ---
 

--- a/schemas/json/theme.json
+++ b/schemas/json/theme.json
@@ -317,6 +317,33 @@
 									"fontFamily": {
 										"description": "CSS font-family value.",
 										"type": "string"
+									},
+									"fontFace": {
+										"description": "",
+										"type": "array",
+										"items": {
+											"type": "object",
+											"fontFamily": {
+												"description": "CSS font-family value.",
+												"type": "string"
+											},
+											"fontWeight": {
+												"description": "CSS font-weight values, list delimited by spaces.",
+												"type": "string"
+											},
+											"fontStyle": {
+												"description": "CSS font-style value.",
+												"type": "string"
+											},
+											"fontStretch": {
+												"description": "CSS font-stretch value.",
+												"type": "string"
+											},
+											"src": {
+												"description": "Paths or URLs to the font files.",
+												"type": "array"
+											}
+										}
 									}
 								},
 								"additionalProperties": false

--- a/schemas/json/theme.json
+++ b/schemas/json/theme.json
@@ -328,7 +328,7 @@
 												"type": "string"
 											},
 											"fontWeight": {
-												"description": "CSS font-weight values, list delimited by spaces.",
+												"description": "List of available font weights, separated by a space.",
 												"type": "string"
 											},
 											"fontStyle": {

--- a/schemas/json/theme.json
+++ b/schemas/json/theme.json
@@ -316,92 +316,93 @@
 									},
 									"fontFamily": {
 										"description": "CSS font-family value.",
-										"type": "string",
-										"default": ""
+										"type": "string"
 									},
 									"fontFace": {
-										"description": "",
+										"description": "Array of font-face declarations.",
 										"type": "array",
 										"items": {
 											"type": "object",
-											"fontFamily": {
-												"description": "CSS font-family value.",
-												"type": "string",
-												"default": ""
-											},
-											"fontStyle": {
-												"description": "CSS font-style value.",
-												"type": "string",
-												"default": "normal"
-											},
-											"fontWeight": {
-												"description": "List of available font weights, separated by a space.",
-												"type": "string",
-												"default": "400"
-											},
-											"fontDisplay": {
-												"description": "CSS font-display value.",
-												"type": "string",
-												"default": "fallback",
-												"enum": [
-													"auto",
-													"block",
-													"fallback",
-													"swap"
-												]
-											},
-											"src": {
-												"description": "Paths or URLs to the font files.",
-												"oneOf": [
-													{
-														"type": "string"
-													},
-													{
-														"type": "array",
-														"items": {
+											"properties": {
+												"fontFamily": {
+													"description": "CSS font-family value.",
+													"type": "string",
+													"default": ""
+												},
+												"fontStyle": {
+													"description": "CSS font-style value.",
+													"type": "string",
+													"default": "normal"
+												},
+												"fontWeight": {
+													"description": "List of available font weights, separated by a space.",
+													"type": "string",
+													"default": "400"
+												},
+												"fontDisplay": {
+													"description": "CSS font-display value.",
+													"type": "string",
+													"default": "fallback",
+													"enum": [
+														"auto",
+														"block",
+														"fallback",
+														"swap"
+													]
+												},
+												"src": {
+													"description": "Paths or URLs to the font files.",
+													"oneOf": [
+														{
 															"type": "string"
+														},
+														{
+															"type": "array",
+															"items": {
+																"type": "string"
+															}
 														}
-													}
-												],
-												"default": []
+													],
+													"default": []
+												},
+												"fontStretch": {
+													"description": "CSS font-stretch value.",
+													"type": "string"
+												},
+												"ascendOverride": {
+													"description": "CSS ascend-override value.",
+													"type": "string"
+												},
+												"descendOverride": {
+													"description": "CSS descend-override value.",
+													"type": "string"
+												},
+												"fontVariant": {
+													"description": "CSS font-variant value.",
+													"type": "string"
+												},
+												"fontFeatureSettings": {
+													"description": "CSS font-feature-settings value.",
+													"type": "string"
+												},
+												"fontVariationSettings": {
+													"description": "CSS font-variation-settings value.",
+													"type": "string"
+												},
+												"lineGapOverride": {
+													"description": "CSS line-gap-override value.",
+													"type": "string"
+												},
+												"sizeAdjust": {
+													"description": "CSS size-adjust value.",
+													"type": "string"
+												},
+												"unicodeRange": {
+													"description": "CSS unicode-range value.",
+													"type": "string"
+												}
 											},
-											"fontStretch": {
-												"description": "CSS font-stretch value.",
-												"type": "string"
-											},
-											"ascendOverride": {
-												"description": "CSS ascend-override value.",
-												"type": "string"
-											},
-											"descendOverride": {
-												"description": "CSS descend-override value.",
-												"type": "string"
-											},
-											"fontVariant": {
-												"description": "CSS font-variant value.",
-												"type": "string"
-											},
-											"fontFeatureSettings": {
-												"description": "CSS font-feature-settings value.",
-												"type": "string"
-											},
-											"fontVariationSettings": {
-												"description": "CSS font-variation-settings value.",
-												"type": "string"
-											},
-											"lineGapOverride": {
-												"description": "CSS line-gap-override value.",
-												"type": "string"
-											},
-											"sizeAdjust": {
-												"description": "CSS size-adjust value.",
-												"type": "string"
-											},
-											"unicodeRange": {
-												"description": "CSS unicode-range value.",
-												"type": "string"
-											},
-											"required": [ "fontFamily", "fontWeight",  "src"  ],
+											"required": [ "fontFamily", "fontWeight",  "src" ],
 											"additionalProperties": false
 										}
 									}

--- a/schemas/json/theme.json
+++ b/schemas/json/theme.json
@@ -402,7 +402,7 @@
 													"type": "string"
 												}
 											},
-											"required": [ "fontFamily", "fontWeight",  "src" ],
+											"required": [ "fontFamily", "fontWeight", "src" ],
 											"additionalProperties": false
 										}
 									}

--- a/schemas/json/theme.json
+++ b/schemas/json/theme.json
@@ -400,10 +400,10 @@
 											"unicodeRange": {
 												"description": "CSS unicode-range value.",
 												"type": "string"
-											}
-										},
-										"required": [ "fontFamily", "fontWeight",  "src"  ],
-										"additionalProperties": false
+											},
+											"required": [ "fontFamily", "fontWeight",  "src"  ],
+											"additionalProperties": false
+										}
 									}
 								},
 								"additionalProperties": false

--- a/schemas/json/theme.json
+++ b/schemas/json/theme.json
@@ -337,7 +337,15 @@
 												"fontWeight": {
 													"description": "List of available font weights, separated by a space.",
 													"type": "string",
-													"default": "400"
+													"default": "400",
+													"oneOf": [
+														{
+															"type": "string"
+														},
+														{
+															"type": "integer"
+														}
+													]
 												},
 												"fontDisplay": {
 													"description": "CSS font-display value.",

--- a/schemas/json/theme.json
+++ b/schemas/json/theme.json
@@ -316,7 +316,8 @@
 									},
 									"fontFamily": {
 										"description": "CSS font-family value.",
-										"type": "string"
+										"type": "string",
+										"default": ""
 									},
 									"fontFace": {
 										"description": "",
@@ -325,25 +326,84 @@
 											"type": "object",
 											"fontFamily": {
 												"description": "CSS font-family value.",
-												"type": "string"
-											},
-											"fontWeight": {
-												"description": "List of available font weights, separated by a space.",
-												"type": "string"
+												"type": "string",
+												"default": ""
 											},
 											"fontStyle": {
 												"description": "CSS font-style value.",
-												"type": "string"
+												"type": "string",
+												"default": "normal"
+											},
+											"fontWeight": {
+												"description": "List of available font weights, separated by a space.",
+												"type": "string",
+												"default": "400"
+											},
+											"fontDisplay": {
+												"description": "CSS font-display value.",
+												"type": "string",
+												"default": "fallback",
+												"enum": [
+													"auto",
+													"block",
+													"fallback",
+													"swap"
+												]
+											},
+											"src": {
+												"description": "Paths or URLs to the font files.",
+												"oneOf": [
+													{
+														"type": "string"
+													},
+													{
+														"type": "array",
+														"items": {
+															"type": "string"
+														}
+													}
+												],
+												"default": []
 											},
 											"fontStretch": {
 												"description": "CSS font-stretch value.",
 												"type": "string"
 											},
-											"src": {
-												"description": "Paths or URLs to the font files.",
-												"type": "array"
+											"ascendOverride": {
+												"description": "CSS ascend-override value.",
+												"type": "string"
+											},
+											"descendOverride": {
+												"description": "CSS descend-override value.",
+												"type": "string"
+											},
+											"fontVariant": {
+												"description": "CSS font-variant value.",
+												"type": "string"
+											},
+											"fontFeatureSettings": {
+												"description": "CSS font-feature-settings value.",
+												"type": "string"
+											},
+											"fontVariationSettings": {
+												"description": "CSS font-variation-settings value.",
+												"type": "string"
+											},
+											"lineGapOverride": {
+												"description": "CSS line-gap-override value.",
+												"type": "string"
+											},
+											"sizeAdjust": {
+												"description": "CSS size-adjust value.",
+												"type": "string"
+											},
+											"unicodeRange": {
+												"description": "CSS unicode-range value.",
+												"type": "string"
 											}
-										}
+										},
+										"required": [ "fontFamily", "fontWeight",  "src"  ],
+										"additionalProperties": false
 									}
 								},
 								"additionalProperties": false

--- a/schemas/json/theme.json
+++ b/schemas/json/theme.json
@@ -402,7 +402,7 @@
 													"type": "string"
 												}
 											},
-											"required": [ "fontFamily", "fontWeight", "src" ],
+											"required": [ "fontFamily", "src" ],
 											"additionalProperties": false
 										}
 									}


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Document the `fontFace` properties that we [introduced in WordPress 6.0 as part of the WebFonts API](https://make.wordpress.org/core/2022/05/03/global-styles-variations-in-wordpress-6-0/).

## Why?
Because there is no documentation.

## How?
By including the basic technical documentation to the `theme.json` schema.

## Testing Instructions
Create a `theme.json` and paste the following in the code. Currently, it says that the `fontFace` is not allowed. Replace `https://schemas.wp.org/trunk/theme.json` with `https://raw.githubusercontent.com/grappler/gutenberg/schema-fontFace/schemas/json/theme.json` to test changes.
<details>
<summary>`theme.json` code</summary>

```json
{
	"$schema": "https://schemas.wp.org/trunk/theme.json",
	"version": 2,
	"settings": {
		"typography": {
			"fontFamilies": [
				{
					"fontFamily": "\"Source Serif Pro\", serif",
					"name": "Source Serif Pro",
					"slug": "source-serif-pro"
				},
				{
					"fontFamily": "\"Inter\", sans-serif",
					"name": "Inter",
					"slug": "inter",
					"fontFace": [
						{
							"fontFamily": "Inter",
							"fontWeight": "200 900",
							"fontStyle": "normal",
							"fontStretch": "normal",
							"src": [ "file:./assets/fonts/inter/Inter.ttf" ]
						}
					]
				}
			]
		}
	}
}
```
</details>

### Screenshots
<img width="478" alt="image" src="https://user-images.githubusercontent.com/1785641/174842194-7de799e3-644e-4f73-b14b-0c4fc978a60c.png">
