### PR TITLE
FSE: Fall back to next best template in hierarchy when querying through REST API (Take Two)

### DIFF
--- a/lib/compat/wordpress-6.1/block-template-utils.php
+++ b/lib/compat/wordpress-6.1/block-template-utils.php
@@ -223,7 +223,42 @@ function gutenberg_get_block_template( $id, $template_type = 'wp_template' ) {
 	$block_template->id     = $id;
 	$block_template->slug   = $slug;
 	$default_template_types = get_default_block_template_types();
-	if ( array_key_exists( $slug, $default_template_types ) ) {
+
+	$slug_parts = explode( '-', $slug, 3 );
+	if ( count( $slug_parts ) > 1 ) {
+		if ( 'single' === $slug_parts [0] ) {
+			// Get CPT labels
+			$post_type = get_post_type_object( $slug_parts[1] );
+			$labels    = $post_type->labels;
+
+			if ( count( $slug_parts ) > 2 ) {
+				// Now we look for the CPT with slug as defined in $slug_parts[2]
+				$post                  = get_page_by_path( $slug_parts[2], OBJECT, $slug_parts[1] );
+				$block_template->title = sprintf(
+					// translators: Represents the title of a user's custom template in the Site Editor, where %1$s is the singular name of a post type and %2$s is the name of the post, e.g. "Post: Hello, WordPress"
+					__( '%1$s: %2$s' ),
+					$labels->singular_name,
+					$post->post_title
+				);
+				$block_template->description = sprintf(
+						// translators: Represents the description of a user's custom template in the Site Editor, e.g. "Template for Post: Hello, WordPress"
+					__( 'Template for %1$s' ),
+					$block_template->title
+				);
+			} else {
+				$block_template->title = sprintf(
+					// translators: %s: Name of the post type e.g: "Post".
+					__( 'Single item: %s' ),
+					$labels->singular_name
+				);
+				$block_template->description = sprintf(
+					// translators: %s: Name of the post type e.g: "Post".
+					__( 'Displays a single item: %s.' ),
+					$labels->singular_name
+				);
+			}
+		}
+	} elseif ( array_key_exists( $slug, $default_template_types ) ) {
 		$block_template->title       = $default_template_types[ $slug ]['title'];
 		$block_template->description = $default_template_types[ $slug ]['description'];
 	}

--- a/lib/compat/wordpress-6.1/block-template-utils.php
+++ b/lib/compat/wordpress-6.1/block-template-utils.php
@@ -165,6 +165,22 @@ function gutenberg_get_block_templates( $query = array(), $template_type = 'wp_t
 	return apply_filters( 'get_block_templates', $query_result, $query, $template_type );
 }
 
+function gutenberg_get_template_slugs( $template ) {
+	$limit = 2;
+	if ( strpos( $template, 'single-' ) === 0 || strpos( $template, 'taxonomy-' ) === 0 ) {
+		// E.g. single-post-mypost or taxonomy-recipes-vegetarian.
+		$limit = 3;
+	}
+	$parts = explode( '-', $template, $limit );
+	$type = array_shift( $parts );
+	$slugs = array( $type );
+
+	foreach( $parts as $part ) {
+		array_unshift( $slugs, $slugs[0] . '-' . $part );
+	}
+	return $slugs;
+}
+
 /**
  * Retrieves a single unified template object using its id.
  *
@@ -196,7 +212,9 @@ function gutenberg_get_block_template( $id, $template_type = 'wp_template' ) {
 		return null;
 	}
 	list( , $slug ) = $parts;
-	$block_template = resolve_block_template( $slug, array(), '' );
+
+	$templates = gutenberg_get_template_slugs( $slug );
+	$block_template = resolve_block_template( $slug, $templates, '' );
 	if ( ! $block_template ) {
 		$block_template = resolve_block_template( 'index', array(), '' );
 	}

--- a/lib/compat/wordpress-6.1/block-template-utils.php
+++ b/lib/compat/wordpress-6.1/block-template-utils.php
@@ -195,33 +195,20 @@ function gutenberg_get_block_template( $id, $template_type = 'wp_template' ) {
 	if ( count( $parts ) < 2 ) {
 		return null;
 	}
-	list( $theme, $slug ) = $parts;
-	$wp_query_args        = array(
-		'post_name__in'  => array( $slug ),
-		'post_type'      => $template_type,
-		'post_status'    => array( 'auto-draft', 'draft', 'publish', 'trash' ),
-		'posts_per_page' => 1,
-		'no_found_rows'  => true,
-		'tax_query'      => array(
-			array(
-				'taxonomy' => 'wp_theme',
-				'field'    => 'name',
-				'terms'    => $theme,
-			),
-		),
-	);
-	$template_query       = new WP_Query( $wp_query_args );
-	$posts                = $template_query->posts;
-
-	if ( count( $posts ) > 0 ) {
-		$template = gutenberg_build_block_template_result_from_post( $posts[0] );
-
-		if ( ! is_wp_error( $template ) ) {
-			return $template;
-		}
+	list( , $slug ) = $parts;
+	$block_template = resolve_block_template( $slug, array(), '' );
+	if ( ! $block_template ) {
+		$block_template = resolve_block_template( 'index', array(), '' );
 	}
-
-	$block_template = get_block_file_template( $id, $template_type );
+	// This might give us a fallback template with a different ID,
+	// so we have to override it to make sure it's correct.
+	$block_template->id     = $id;
+	$block_template->slug   = $slug;
+	$default_template_types = get_default_block_template_types();
+	if ( array_key_exists( $slug, $default_template_types ) ) {
+		$block_template->title       = $default_template_types[ $slug ]['title'];
+		$block_template->description = $default_template_types[ $slug ]['description'];
+	}
 
 	/**
 	 * Filters the queried block template object after it's been fetched.

--- a/lib/compat/wordpress-6.1/block-template-utils.php
+++ b/lib/compat/wordpress-6.1/block-template-utils.php
@@ -172,10 +172,10 @@ function gutenberg_get_template_slugs( $template ) {
 		$limit = 3;
 	}
 	$parts = explode( '-', $template, $limit );
-	$type = array_shift( $parts );
+	$type  = array_shift( $parts );
 	$slugs = array( $type );
 
-	foreach( $parts as $part ) {
+	foreach ( $parts as $part ) {
 		array_unshift( $slugs, $slugs[0] . '-' . $part );
 	}
 	return $slugs;
@@ -213,7 +213,7 @@ function gutenberg_get_block_template( $id, $template_type = 'wp_template' ) {
 	}
 	list( , $slug ) = $parts;
 
-	$templates = gutenberg_get_template_slugs( $slug );
+	$templates      = gutenberg_get_template_slugs( $slug );
 	$block_template = resolve_block_template( $slug, $templates, '' );
 	if ( ! $block_template ) {
 		$block_template = resolve_block_template( 'index', array(), '' );

--- a/lib/compat/wordpress-6.1/block-template-utils.php
+++ b/lib/compat/wordpress-6.1/block-template-utils.php
@@ -274,7 +274,7 @@ function gutenberg_get_block_template( $id, $template_type = 'wp_template' ) {
 	$block_template->id   = $id;
 	$block_template->slug = $slug;
 
-	$template_type_info          = gutenberg_get_block_template_type_for_slug();
+	$template_type_info          = gutenberg_get_block_template_type_for_slug( $slug );
 	$block_template->title       = $template_type_info['title'];
 	$block_template->description = $template_type_info['description'];
 

--- a/lib/compat/wordpress-6.1/class-gutenberg-rest-templates-controller.php
+++ b/lib/compat/wordpress-6.1/class-gutenberg-rest-templates-controller.php
@@ -96,6 +96,23 @@ class Gutenberg_REST_Templates_Controller extends WP_REST_Templates_Controller {
 	}
 
 	/**
+	 * Deletes a single template.
+	 *
+	 * @since 5.8.0
+	 *
+	 * @param WP_REST_Request $request Full details about the request.
+	 * @return WP_REST_Response|WP_Error Response object on success, or WP_Error object on failure.
+	 */
+	public function delete_item( $request ) {
+		$template = get_block_template( $request['id'], $this->post_type );
+		if ( ! $template || $template->id !== $request['id'] ) { // Make sure there is a template for this ID (and not just a fallback one).
+			return new WP_Error( 'rest_template_not_found', __( 'No templates exist with that id.' ), array( 'status' => 404 ) );
+		}
+
+		return parent::delete_item( $request );
+	}
+
+	/**
 	 * Updates a single template.
 	 *
 	 * @since 5.8.0

--- a/packages/edit-site/src/components/add-new-template/new-template.js
+++ b/packages/edit-site/src/components/add-new-template/new-template.js
@@ -13,7 +13,7 @@ import {
 	NavigableMenu,
 } from '@wordpress/components';
 import { useState } from '@wordpress/element';
-import { useSelect } from '@wordpress/data';
+import { useSelect, useDispatch } from '@wordpress/data';
 import { store as coreStore } from '@wordpress/core-data';
 import { store as editorStore } from '@wordpress/editor';
 import {
@@ -39,6 +39,7 @@ import { __, sprintf } from '@wordpress/i18n';
 import AddCustomTemplateModal from './add-custom-template-modal';
 import { usePostTypes, usePostTypesEntitiesInfo } from './utils';
 import { useHistory } from '../routes';
+import { store as editSiteStore } from '../../store';
 
 const DEFAULT_TEMPLATE_SLUGS = [
 	'front-page',
@@ -92,10 +93,17 @@ export default function NewTemplate( { postType } ) {
 	);
 	const postTypesEntitiesInfo = usePostTypesEntitiesInfo( existingTemplates );
 
+	const { setTemplate } = useDispatch( editSiteStore );
+
 	async function createTemplate( template ) {
 		const { slug } = template;
+		const templateId = theme.stylesheet + '//' + slug.toString();
+
+		// Set template before navigating away to avoid initial stale value.
+		setTemplate( templateId, slug );
+
 		history.push( {
-			postId: theme.stylesheet + '//' + slug.toString(),
+			postId: templateId,
 			postType: 'wp_template',
 		} );
 	}

--- a/packages/edit-site/src/components/add-new-template/new-template.js
+++ b/packages/edit-site/src/components/add-new-template/new-template.js
@@ -74,9 +74,8 @@ const TEMPLATE_ICONS = {
 export default function NewTemplate( { postType } ) {
 	const history = useHistory();
 	const postTypes = usePostTypes();
-	const [ showCustomTemplateModal, setShowCustomTemplateModal ] = useState(
-		false
-	);
+	const [ showCustomTemplateModal, setShowCustomTemplateModal ] =
+		useState( false );
 	const [ entityForSuggestions, setEntityForSuggestions ] = useState( {} );
 	const { existingTemplates, defaultTemplateTypes, theme } = useSelect(
 		( select ) => ( {
@@ -85,9 +84,8 @@ export default function NewTemplate( { postType } ) {
 				'wp_template',
 				{ per_page: -1 }
 			),
-			defaultTemplateTypes: select(
-				editorStore
-			).__experimentalGetDefaultTemplateTypes(),
+			defaultTemplateTypes:
+				select( editorStore ).__experimentalGetDefaultTemplateTypes(),
 			theme: select( coreStore ).getCurrentTheme(),
 		} ),
 		[]

--- a/phpunit/compat/wordpress-6.1/block-template-utils-test.php
+++ b/phpunit/compat/wordpress-6.1/block-template-utils-test.php
@@ -1,0 +1,26 @@
+<?php
+/**
+ * Tests_Block_Template_Utils class
+ *
+ * @package gutenberg
+ */
+
+/**
+ * Tests for the Block Templates abstraction layer.
+ *
+ * @group block-templates
+ */
+class Tests_Block_Template_Utils_6_1 extends WP_UnitTestCase {
+	public function test_get_template_slugs() {
+		$templates = gutenberg_get_template_slugs( 'single-post-hello-world' );
+		$this->assertSame(
+			array(
+				'single-post-hello-world',
+				// Should *not* fall back to `single-post-hello`!
+				'single-post',
+				'single',
+			),
+			$templates
+		);
+	}
+}

--- a/phpunit/compat/wordpress-6.1/block-template-utils-test.php
+++ b/phpunit/compat/wordpress-6.1/block-template-utils-test.php
@@ -41,7 +41,19 @@ class Tests_Block_Template_Utils_6_1 extends WP_UnitTestCase {
 		);
 	}
 
-	public function test_gutenberg_get_block_template_type_for_slug() {
+	public function test_gutenberg_get_block_template_type_for_slug_generic() {
+		$template_slug = 'single-' . self::$post->post_type;
+		$template_info = gutenberg_get_block_template_type_for_slug( $template_slug );
+		$this->assertSame(
+			array(
+				'title'       => 'Single item: Post',
+				'description' => 'Displays a single item: Post.',
+			),
+			$template_info
+		);
+	}
+
+	public function test_gutenberg_get_block_template_type_for_slug_individual() {
 		$template_slug = 'single-' . self::$post->post_type . '-' . self::$post->post_name;
 		$template_info = gutenberg_get_block_template_type_for_slug( $template_slug );
 		$this->assertSame(

--- a/phpunit/compat/wordpress-6.1/block-template-utils-test.php
+++ b/phpunit/compat/wordpress-6.1/block-template-utils-test.php
@@ -11,6 +11,23 @@
  * @group block-templates
  */
 class Tests_Block_Template_Utils_6_1 extends WP_UnitTestCase {
+	private static $post;
+
+	public static function wpSetUpBeforeClass() {
+		$args       = array(
+			'post_type'    => 'post',
+			'post_name'    => 'hello-world',
+			'post_title'   => 'Hello World!',
+			'post_content' => 'Welcome to WordPress. This is your first post. Edit or delete it, then start writing!',
+			'post_excerpt' => 'Welcome to WordPress.',
+		);
+		self::$post = self::factory()->post->create_and_get( $args );
+	}
+
+	public static function wpTearDownAfterClass() {
+		wp_delete_post( self::$post->ID );
+	}
+
 	public function test_get_template_slugs() {
 		$templates = gutenberg_get_template_slugs( 'single-post-hello-world' );
 		$this->assertSame(
@@ -21,6 +38,18 @@ class Tests_Block_Template_Utils_6_1 extends WP_UnitTestCase {
 				'single',
 			),
 			$templates
+		);
+	}
+
+	public function test_gutenberg_get_block_template_type_for_slug() {
+		$template_slug = 'single-' . self::$post->post_type . '-' . self::$post->post_name;
+		$template_info = gutenberg_get_block_template_type_for_slug( $template_slug );
+		$this->assertSame(
+			array(
+				'title'       => 'Post: Hello World!',
+				'description' => 'Template for Post: Hello World!',
+			),
+			$template_info
 		);
 	}
 }


### PR DESCRIPTION
## What?

Take Two of #37258.

Purports to fix #36648, as an alternative approach to #37054. For more background, see https://github.com/WordPress/gutenberg/pull/37054#issuecomment-988271255

_(More description to come)_

## Why?
See e.g. https://github.com/WordPress/gutenberg/pull/37258#issuecomment-1136144085 and https://github.com/WordPress/gutenberg/pull/37258#issuecomment-1161697393.

## How?

By always using the full template hierarchy to look for potential fallback templates, even when queried for a template ID.

## Testing Instructions

This testing routine will verify a number of things:
- That if a new template is created, it will pre-populate the editor with the "next best", less specific, fallback template.
  - This can be either a manually created template, or a theme-supplied one.
- That the template titles and descriptions are correct.

First, we create a "Single Post" template and verify that it comes pre-populated with the contents of the theme-supplied "Single" template:

1. Enable the Twenty Twenty-Two theme.
2. Go to the Site Editor.
3. Click the "W" logo menu in the top left corner.
4. In the sidebar that opens, select "Templates".
6. Click the "Add New" button in the top right corner.
7. In the dropdown that opens, click on the "Single item: Post" template.
8. In the modal that opens, click on "All Posts -- For all items".
11. Verify that the site editor opens, pre-populated with the generic "single" template. (This is to ensure parity with the frontend, which would also use the "single" template as a fallback when there's no dedicated single-_post_ template.)
12. Verify that the title and description are still as prior to this PR ("Single item: Post" --  "Displays a single item: Post.")
13. Make a change to the template. Make sure it's not to the header or footer template parts, nor to the post content. Ideally, insert a Paragraph block with some text right above the footer (and below the content). (Verify that it's a direct child of the template by checking in the bottom breadcrumbs bar that it shows up as "Template > Paragraph".)
9. Save the template.
10. Once saved, navigate back to the "Templates" screen (via the top left "W" button that opens the sidebar).
14. Verify that there's now a "Single item: Post" template at the top of the list of the theme's templates.
15. Verify that it's distinct from the "Single" template at the bottom of the list.

Second, we create a "Single Post" template for a specific post and verify that it comes pre-populated with the generic "Single Post" template that we just created: **This is still buggy, reload every time you go back to the template list**

1. In the template list, click the "Add New" button in the top right corner.
2. Since you've already created the generic "Single item: Post" template, the editor will directly open a modal to ask you for _which_ post you'd like to create a template. 
10. Select a post from that list, e.g. the standard WordPress "Hello World" post.
11. Verify that the site editor opens, with the "Single item: Post" template contents loaded that you just created. (This is again to reflect parity with the frontend).
12. Verify that the template content has the change that you just made earlier to the "Single item: Post" template.
13. Verify that the title and description are still as prior to this PR ("Post: Hello world!" -- "Template for Post: Hello world!").
14. Make another change to the template, ideally to the part that you changed to distinguish the "Single item: Post" template.
9. Save the template.
10. Once saved, navigate back to the "Templates" screen (via the top left 'W' button that opens the sidebar).
15. Verify that there's now a "Post: Hello World!" template at the top of the list of the theme's templates.
16. Verify that it's distinct from the "Single item: Post" template right below.

Ideally, give it some more smoke testing -- whatever you can think of makes sense: delete the template again; find a way to test it on the frontend; etc.

## TODO

- [x] Use the proper template title (i.e. "Single Post: Hello World" instead of "Single") and description.
- [x] Fix issue with blank template when creating second template in a row ([see](https://github.com/WordPress/gutenberg/pull/41848#issuecomment-1167477225)).
- [ ] Fix issue with changes to post-specific templates (e.g. `single-post-hello-world`) being applied to existing CPT-specific templates (e.g. `single-post`).
- [ ] Integrate the Home/Frontpage fallback logic (`gutenberg_resolve_home_template`/`_resolve_home_block_template`).
- [ ] We might be able to remove some client-side logic, or infer it via REST API (if we also expose some template titles).

## Screenshots
TBD
