### PR TITLE
List View: Use heading content for button label text if available

### DIFF
--- a/packages/block-editor/README.md
+++ b/packages/block-editor/README.md
@@ -246,6 +246,7 @@ _Parameters_
 -   _props_ `Object`:
 -   _props.clientId_ `string`: Client ID of block.
 -   _props.maximumLength_ `number|undefined`: The maximum length that the block title string may be before truncated.
+-   _props.context_ `string|undefined`: The context to pass to `getBlockLabel`.
 
 _Returns_
 

--- a/packages/block-editor/README.md
+++ b/packages/block-editor/README.md
@@ -246,7 +246,6 @@ _Parameters_
 -   _props_ `Object`:
 -   _props.clientId_ `string`: Client ID of block.
 -   _props.maximumLength_ `number|undefined`: The maximum length that the block title string may be before truncated.
--   _props.context_ `string|undefined`: The context to pass to `getBlockLabel`.
 
 _Returns_
 

--- a/packages/block-editor/src/components/block-settings-menu/block-settings-dropdown.js
+++ b/packages/block-editor/src/components/block-settings-menu/block-settings-dropdown.js
@@ -125,7 +125,10 @@ export function BlockSettingsDropdown( {
 		[ __experimentalSelectBlock ]
 	);
 
-	const blockTitle = useBlockDisplayTitle( firstBlockClientId, 25 );
+	const blockTitle = useBlockDisplayTitle( {
+		clientId: firstBlockClientId,
+		maximumLength: 25,
+	} );
 
 	const updateSelectionAfterRemove = useCallback(
 		__experimentalSelectBlock

--- a/packages/block-editor/src/components/block-title/index.js
+++ b/packages/block-editor/src/components/block-title/index.js
@@ -17,10 +17,9 @@ import useBlockDisplayTitle from './use-block-display-title';
  * @param {Object}           props
  * @param {string}           props.clientId      Client ID of block.
  * @param {number|undefined} props.maximumLength The maximum length that the block title string may be before truncated.
- * @param {string|undefined} props.context       The context to pass to `getBlockLabel`.
  *
  * @return {JSX.Element} Block title.
  */
-export default function BlockTitle( { clientId, maximumLength, context } ) {
-	return useBlockDisplayTitle( clientId, maximumLength, context );
+export default function BlockTitle( { clientId, maximumLength } ) {
+	return useBlockDisplayTitle( clientId, maximumLength );
 }

--- a/packages/block-editor/src/components/block-title/index.js
+++ b/packages/block-editor/src/components/block-title/index.js
@@ -22,5 +22,5 @@ import useBlockDisplayTitle from './use-block-display-title';
  * @return {JSX.Element} Block title.
  */
 export default function BlockTitle( { clientId, maximumLength, context } ) {
-	return useBlockDisplayTitle( clientId, maximumLength, context );
+	return useBlockDisplayTitle( { clientId, maximumLength, context } );
 }

--- a/packages/block-editor/src/components/block-title/index.js
+++ b/packages/block-editor/src/components/block-title/index.js
@@ -17,9 +17,10 @@ import useBlockDisplayTitle from './use-block-display-title';
  * @param {Object}           props
  * @param {string}           props.clientId      Client ID of block.
  * @param {number|undefined} props.maximumLength The maximum length that the block title string may be before truncated.
+ * @param {string|undefined} props.context       The context to pass to `getBlockLabel`.
  *
  * @return {JSX.Element} Block title.
  */
-export default function BlockTitle( { clientId, maximumLength } ) {
-	return useBlockDisplayTitle( clientId, maximumLength );
+export default function BlockTitle( { clientId, maximumLength, context } ) {
+	return useBlockDisplayTitle( clientId, maximumLength, context );
 }

--- a/packages/block-editor/src/components/block-title/use-block-display-title.js
+++ b/packages/block-editor/src/components/block-title/use-block-display-title.js
@@ -21,19 +21,20 @@ import { store as blockEditorStore } from '../../store';
  * @example
  *
  * ```js
- * useBlockDisplayTitle( 'afd1cb17-2c08-4e7a-91be-007ba7ddc3a1', 17 );
+ * useBlockDisplayTitle( { clientId: 'afd1cb17-2c08-4e7a-91be-007ba7ddc3a1', maximumLength: 17 } );
  * ```
  *
- * @param {string}           clientId      Client ID of block.
- * @param {number|undefined} maximumLength The maximum length that the block title string may be before truncated.
- * @param {string|undefined} context       The context to pass to `getBlockLabel`.
+ * @param {Object}           props
+ * @param {string}           props.clientId      Client ID of block.
+ * @param {number|undefined} props.maximumLength The maximum length that the block title string may be before truncated.
+ * @param {string|undefined} props.context       The context to pass to `getBlockLabel`.
  * @return {?string} Block title.
  */
-export default function useBlockDisplayTitle(
+export default function useBlockDisplayTitle( {
 	clientId,
 	maximumLength,
-	context
-) {
+	context,
+} ) {
 	const { attributes, name, reusableBlockTitle } = useSelect(
 		( select ) => {
 			if ( ! clientId ) {

--- a/packages/block-editor/src/components/block-title/use-block-display-title.js
+++ b/packages/block-editor/src/components/block-title/use-block-display-title.js
@@ -26,14 +26,9 @@ import { store as blockEditorStore } from '../../store';
  *
  * @param {string}           clientId      Client ID of block.
  * @param {number|undefined} maximumLength The maximum length that the block title string may be before truncated.
- * @param {string|undefined} context       The context to pass to `getBlockLabel`.
  * @return {?string} Block title.
  */
-export default function useBlockDisplayTitle(
-	clientId,
-	maximumLength,
-	context
-) {
+export default function useBlockDisplayTitle( clientId, maximumLength ) {
 	const { attributes, name, reusableBlockTitle } = useSelect(
 		( select ) => {
 			if ( ! clientId ) {
@@ -68,7 +63,7 @@ export default function useBlockDisplayTitle(
 	}
 	const blockType = getBlockType( name );
 	const blockLabel = blockType
-		? getBlockLabel( blockType, attributes, context )
+		? getBlockLabel( blockType, attributes )
 		: null;
 
 	const label = reusableBlockTitle || blockLabel;

--- a/packages/block-editor/src/components/block-title/use-block-display-title.js
+++ b/packages/block-editor/src/components/block-title/use-block-display-title.js
@@ -26,9 +26,14 @@ import { store as blockEditorStore } from '../../store';
  *
  * @param {string}           clientId      Client ID of block.
  * @param {number|undefined} maximumLength The maximum length that the block title string may be before truncated.
+ * @param {string|undefined} context       The context to pass to `getBlockLabel`.
  * @return {?string} Block title.
  */
-export default function useBlockDisplayTitle( clientId, maximumLength ) {
+export default function useBlockDisplayTitle(
+	clientId,
+	maximumLength,
+	context
+) {
 	const { attributes, name, reusableBlockTitle } = useSelect(
 		( select ) => {
 			if ( ! clientId ) {
@@ -63,7 +68,7 @@ export default function useBlockDisplayTitle( clientId, maximumLength ) {
 	}
 	const blockType = getBlockType( name );
 	const blockLabel = blockType
-		? getBlockLabel( blockType, attributes )
+		? getBlockLabel( blockType, attributes, context )
 		: null;
 
 	const label = reusableBlockTitle || blockLabel;

--- a/packages/block-editor/src/components/list-view/block-select-button.js
+++ b/packages/block-editor/src/components/list-view/block-select-button.js
@@ -82,8 +82,9 @@ function ListViewBlockSelectButton(
 				<BlockIcon icon={ blockInformation?.icon } showColors />
 				<HStack
 					alignment="center"
-					justify="flex-start"
 					className="block-editor-list-view-block-select-button__label-wrapper"
+					justify="flex-start"
+					spacing={ 1 }
 				>
 					<Truncate
 						className="block-editor-list-view-block-select-button__title"
@@ -96,12 +97,12 @@ function ListViewBlockSelectButton(
 							{ blockInformation.anchor }
 						</span>
 					) }
+					{ isLocked && (
+						<span className="block-editor-list-view-block-select-button__lock">
+							<Icon icon={ lock } />
+						</span>
+					) }
 				</HStack>
-				{ isLocked && (
-					<span className="block-editor-list-view-block-select-button__lock">
-						<Icon icon={ lock } />
-					</span>
-				) }
 			</Button>
 		</>
 	);

--- a/packages/block-editor/src/components/list-view/block-select-button.js
+++ b/packages/block-editor/src/components/list-view/block-select-button.js
@@ -39,7 +39,10 @@ function ListViewBlockSelectButton(
 	ref
 ) {
 	const blockInformation = useBlockDisplayInformation( clientId );
-	const blockTitle = useBlockDisplayTitle( clientId, undefined, 'list-view' );
+	const blockTitle = useBlockDisplayTitle( {
+		clientId,
+		context: 'list-view',
+	} );
 	const { isLocked } = useBlockLock( clientId );
 
 	// The `href` attribute triggers the browser's native HTML drag operations.

--- a/packages/block-editor/src/components/list-view/block-select-button.js
+++ b/packages/block-editor/src/components/list-view/block-select-button.js
@@ -6,7 +6,12 @@ import classnames from 'classnames';
 /**
  * WordPress dependencies
  */
-import { Button } from '@wordpress/components';
+import {
+	Button,
+	__experimentalTruncate as Truncate,
+} from '@wordpress/components';
+import { useSelect } from '@wordpress/data';
+import { __unstableStripHTML as stripHTML } from '@wordpress/dom';
 import { forwardRef } from '@wordpress/element';
 import { Icon, lock } from '@wordpress/icons';
 import { SPACE, ENTER } from '@wordpress/keycodes';
@@ -19,6 +24,11 @@ import useBlockDisplayInformation from '../use-block-display-information';
 import BlockTitle from '../block-title';
 import ListViewExpander from './expander';
 import { useBlockLock } from '../block-lock';
+import { store as blockEditorStore } from '../../store';
+
+// For this list of hard-coded blocks, the block content will be used as the button label.
+// If no content exists, then the block's title will be used as a fallback.
+const CONTENT_LABEL_BLOCKS = [ 'core/heading', 'core/paragraph' ];
 
 function ListViewBlockSelectButton(
 	{
@@ -35,6 +45,24 @@ function ListViewBlockSelectButton(
 	ref
 ) {
 	const blockInformation = useBlockDisplayInformation( clientId );
+
+	// Attempt to get block content as the label for the button.
+	const contentLabel = useSelect(
+		( select ) => {
+			let content;
+			const block = select( blockEditorStore ).getBlock( clientId );
+			if (
+				CONTENT_LABEL_BLOCKS.some(
+					( blockName ) => blockName === block?.name
+				)
+			) {
+				content = stripHTML( block?.attributes?.content );
+			}
+			return content;
+		},
+		[ clientId ]
+	);
+
 	const { isLocked } = useBlockLock( clientId );
 
 	// The `href` attribute triggers the browser's native HTML drag operations.
@@ -73,7 +101,16 @@ function ListViewBlockSelectButton(
 				<ListViewExpander onClick={ onToggleExpanded } />
 				<BlockIcon icon={ blockInformation?.icon } showColors />
 				<span className="block-editor-list-view-block-select-button__title">
-					<BlockTitle clientId={ clientId } maximumLength={ 35 } />
+					{ contentLabel ? (
+						<Truncate limit={ 35 } ellipsizeMode="tail">
+							{ contentLabel }
+						</Truncate>
+					) : (
+						<BlockTitle
+							clientId={ clientId }
+							maximumLength={ 35 }
+						/>
+					) }
 				</span>
 				{ blockInformation?.anchor && (
 					<span className="block-editor-list-view-block-select-button__anchor">

--- a/packages/block-editor/src/components/list-view/block-select-button.js
+++ b/packages/block-editor/src/components/list-view/block-select-button.js
@@ -11,8 +11,6 @@ import {
 	__experimentalHStack as HStack,
 	__experimentalTruncate as Truncate,
 } from '@wordpress/components';
-import { useSelect } from '@wordpress/data';
-import { __unstableStripHTML as stripHTML } from '@wordpress/dom';
 import { forwardRef } from '@wordpress/element';
 import { Icon, lock } from '@wordpress/icons';
 import { SPACE, ENTER } from '@wordpress/keycodes';
@@ -22,14 +20,9 @@ import { SPACE, ENTER } from '@wordpress/keycodes';
  */
 import BlockIcon from '../block-icon';
 import useBlockDisplayInformation from '../use-block-display-information';
-import BlockTitle from '../block-title';
+import useBlockDisplayTitle from '../block-title/use-block-display-title';
 import ListViewExpander from './expander';
 import { useBlockLock } from '../block-lock';
-import { store as blockEditorStore } from '../../store';
-
-// For this list of hard-coded blocks, the block content will be used as the button label.
-// If no content exists, then the block's title will be used as a fallback.
-const CONTENT_LABEL_BLOCKS = [ 'core/heading' ];
 
 function ListViewBlockSelectButton(
 	{
@@ -46,24 +39,7 @@ function ListViewBlockSelectButton(
 	ref
 ) {
 	const blockInformation = useBlockDisplayInformation( clientId );
-
-	// Attempt to get block content as the label for the button.
-	const contentLabel = useSelect(
-		( select ) => {
-			let content;
-			const block = select( blockEditorStore ).getBlock( clientId );
-			if (
-				CONTENT_LABEL_BLOCKS.some(
-					( blockName ) => blockName === block?.name
-				)
-			) {
-				content = stripHTML( block?.attributes?.content );
-			}
-			return content;
-		},
-		[ clientId ]
-	);
-
+	const blockTitle = useBlockDisplayTitle( clientId, undefined, 'list-view' );
 	const { isLocked } = useBlockLock( clientId );
 
 	// The `href` attribute triggers the browser's native HTML drag operations.
@@ -106,21 +82,12 @@ function ListViewBlockSelectButton(
 					justify="flex-start"
 					className="block-editor-list-view-block-select-button__label-wrapper"
 				>
-					{ contentLabel ? (
-						<Truncate
-							className="block-editor-list-view-block-select-button__title"
-							ellipsizeMode="auto"
-						>
-							{ contentLabel }
-						</Truncate>
-					) : (
-						<span className="block-editor-list-view-block-select-button__title">
-							<BlockTitle
-								clientId={ clientId }
-								maximumLength={ 35 }
-							/>
-						</span>
-					) }
+					<Truncate
+						className="block-editor-list-view-block-select-button__title"
+						ellipsizeMode="auto"
+					>
+						{ blockTitle }
+					</Truncate>
 					{ blockInformation?.anchor && (
 						<span className="block-editor-list-view-block-select-button__anchor">
 							{ blockInformation.anchor }

--- a/packages/block-editor/src/components/list-view/block-select-button.js
+++ b/packages/block-editor/src/components/list-view/block-select-button.js
@@ -6,12 +6,7 @@ import classnames from 'classnames';
 /**
  * WordPress dependencies
  */
-import {
-	Button,
-	__experimentalTruncate as Truncate,
-} from '@wordpress/components';
-import { useSelect } from '@wordpress/data';
-import { __unstableStripHTML as stripHTML } from '@wordpress/dom';
+import { Button } from '@wordpress/components';
 import { forwardRef } from '@wordpress/element';
 import { Icon, lock } from '@wordpress/icons';
 import { SPACE, ENTER } from '@wordpress/keycodes';
@@ -24,11 +19,6 @@ import useBlockDisplayInformation from '../use-block-display-information';
 import BlockTitle from '../block-title';
 import ListViewExpander from './expander';
 import { useBlockLock } from '../block-lock';
-import { store as blockEditorStore } from '../../store';
-
-// For this list of hard-coded blocks, the block content will be used as the button label.
-// If no content exists, then the block's title will be used as a fallback.
-const CONTENT_LABEL_BLOCKS = [ 'core/heading', 'core/paragraph' ];
 
 function ListViewBlockSelectButton(
 	{
@@ -45,23 +35,6 @@ function ListViewBlockSelectButton(
 	ref
 ) {
 	const blockInformation = useBlockDisplayInformation( clientId );
-
-	// Attempt to get block content as the label for the button.
-	const contentLabel = useSelect(
-		( select ) => {
-			let content;
-			const block = select( blockEditorStore ).getBlock( clientId );
-			if (
-				CONTENT_LABEL_BLOCKS.some(
-					( blockName ) => blockName === block?.name
-				)
-			) {
-				content = stripHTML( block?.attributes?.content );
-			}
-			return content;
-		},
-		[ clientId ]
-	);
 
 	const { isLocked } = useBlockLock( clientId );
 
@@ -101,16 +74,11 @@ function ListViewBlockSelectButton(
 				<ListViewExpander onClick={ onToggleExpanded } />
 				<BlockIcon icon={ blockInformation?.icon } showColors />
 				<span className="block-editor-list-view-block-select-button__title">
-					{ contentLabel ? (
-						<Truncate limit={ 35 } ellipsizeMode="tail">
-							{ contentLabel }
-						</Truncate>
-					) : (
-						<BlockTitle
-							clientId={ clientId }
-							maximumLength={ 35 }
-						/>
-					) }
+					<BlockTitle
+						clientId={ clientId }
+						maximumLength={ 35 }
+						context="list-view"
+					/>
 				</span>
 				{ blockInformation?.anchor && (
 					<span className="block-editor-list-view-block-select-button__anchor">

--- a/packages/block-editor/src/components/list-view/block-select-button.js
+++ b/packages/block-editor/src/components/list-view/block-select-button.js
@@ -35,7 +35,6 @@ function ListViewBlockSelectButton(
 	ref
 ) {
 	const blockInformation = useBlockDisplayInformation( clientId );
-
 	const { isLocked } = useBlockLock( clientId );
 
 	// The `href` attribute triggers the browser's native HTML drag operations.

--- a/packages/block-editor/src/components/list-view/block-select-button.js
+++ b/packages/block-editor/src/components/list-view/block-select-button.js
@@ -6,7 +6,13 @@ import classnames from 'classnames';
 /**
  * WordPress dependencies
  */
-import { Button } from '@wordpress/components';
+import {
+	Button,
+	__experimentalHStack as HStack,
+	__experimentalTruncate as Truncate,
+} from '@wordpress/components';
+import { useSelect } from '@wordpress/data';
+import { __unstableStripHTML as stripHTML } from '@wordpress/dom';
 import { forwardRef } from '@wordpress/element';
 import { Icon, lock } from '@wordpress/icons';
 import { SPACE, ENTER } from '@wordpress/keycodes';
@@ -19,6 +25,11 @@ import useBlockDisplayInformation from '../use-block-display-information';
 import BlockTitle from '../block-title';
 import ListViewExpander from './expander';
 import { useBlockLock } from '../block-lock';
+import { store as blockEditorStore } from '../../store';
+
+// For this list of hard-coded blocks, the block content will be used as the button label.
+// If no content exists, then the block's title will be used as a fallback.
+const CONTENT_LABEL_BLOCKS = [ 'core/heading' ];
 
 function ListViewBlockSelectButton(
 	{
@@ -35,6 +46,24 @@ function ListViewBlockSelectButton(
 	ref
 ) {
 	const blockInformation = useBlockDisplayInformation( clientId );
+
+	// Attempt to get block content as the label for the button.
+	const contentLabel = useSelect(
+		( select ) => {
+			let content;
+			const block = select( blockEditorStore ).getBlock( clientId );
+			if (
+				CONTENT_LABEL_BLOCKS.some(
+					( blockName ) => blockName === block?.name
+				)
+			) {
+				content = stripHTML( block?.attributes?.content );
+			}
+			return content;
+		},
+		[ clientId ]
+	);
+
 	const { isLocked } = useBlockLock( clientId );
 
 	// The `href` attribute triggers the browser's native HTML drag operations.
@@ -72,18 +101,32 @@ function ListViewBlockSelectButton(
 			>
 				<ListViewExpander onClick={ onToggleExpanded } />
 				<BlockIcon icon={ blockInformation?.icon } showColors />
-				<span className="block-editor-list-view-block-select-button__title">
-					<BlockTitle
-						clientId={ clientId }
-						maximumLength={ 35 }
-						context="list-view"
-					/>
-				</span>
-				{ blockInformation?.anchor && (
-					<span className="block-editor-list-view-block-select-button__anchor">
-						{ blockInformation.anchor }
-					</span>
-				) }
+				<HStack
+					alignment="center"
+					justify="flex-start"
+					className="block-editor-list-view-block-select-button__label-wrapper"
+				>
+					{ contentLabel ? (
+						<Truncate
+							className="block-editor-list-view-block-select-button__title"
+							ellipsizeMode="auto"
+						>
+							{ contentLabel }
+						</Truncate>
+					) : (
+						<span className="block-editor-list-view-block-select-button__title">
+							<BlockTitle
+								clientId={ clientId }
+								maximumLength={ 35 }
+							/>
+						</span>
+					) }
+					{ blockInformation?.anchor && (
+						<span className="block-editor-list-view-block-select-button__anchor">
+							{ blockInformation.anchor }
+						</span>
+					) }
+				</HStack>
 				{ isLocked && (
 					<span className="block-editor-list-view-block-select-button__lock">
 						<Icon icon={ lock } />

--- a/packages/block-editor/src/components/list-view/block-select-button.js
+++ b/packages/block-editor/src/components/list-view/block-select-button.js
@@ -86,12 +86,9 @@ function ListViewBlockSelectButton(
 					justify="flex-start"
 					spacing={ 1 }
 				>
-					<Truncate
-						className="block-editor-list-view-block-select-button__title"
-						ellipsizeMode="auto"
-					>
-						{ blockTitle }
-					</Truncate>
+					<span className="block-editor-list-view-block-select-button__title">
+						<Truncate ellipsizeMode="auto">{ blockTitle }</Truncate>
+					</span>
 					{ blockInformation?.anchor && (
 						<span className="block-editor-list-view-block-select-button__anchor">
 							{ blockInformation.anchor }

--- a/packages/block-editor/src/components/list-view/style.scss
+++ b/packages/block-editor/src/components/list-view/style.scss
@@ -299,6 +299,7 @@
 
 	.block-editor-list-view-block-select-button__label-wrapper {
 		max-width: 225px;
+		margin-right: $grid-unit-10;
 	}
 
 	.block-editor-list-view-block-select-button__anchor {
@@ -306,7 +307,7 @@
 		border-radius: $radius-block-ui;
 		display: inline-block;
 		padding: 2px 6px;
-		margin: 0 $grid-unit-10;
+		margin: 0 0 0 $grid-unit-10;
 		max-width: 120px;
 		overflow: hidden;
 		text-overflow: ellipsis;

--- a/packages/block-editor/src/components/list-view/style.scss
+++ b/packages/block-editor/src/components/list-view/style.scss
@@ -207,7 +207,7 @@
 	}
 
 	.block-editor-list-view-block__menu-cell {
-		padding-right: 5px;
+		padding-right: 4px;
 
 		.components-button.has-icon {
 			height: 24px;
@@ -298,8 +298,7 @@
 	}
 
 	.block-editor-list-view-block-select-button__label-wrapper {
-		max-width: 225px;
-		margin-right: $grid-unit-10;
+		max-width: 240px;
 	}
 
 	.block-editor-list-view-block-select-button__anchor {
@@ -307,7 +306,6 @@
 		border-radius: $radius-block-ui;
 		display: inline-block;
 		padding: 2px 6px;
-		margin: 0 0 0 $grid-unit-10;
 		max-width: 120px;
 		overflow: hidden;
 		text-overflow: ellipsis;

--- a/packages/block-editor/src/components/list-view/style.scss
+++ b/packages/block-editor/src/components/list-view/style.scss
@@ -297,6 +297,10 @@
 		}
 	}
 
+	.block-editor-list-view-block-select-button__label-wrapper {
+		max-width: 225px;
+	}
+
 	.block-editor-list-view-block-select-button__anchor {
 		background: rgba($black, 0.1);
 		border-radius: $radius-block-ui;

--- a/packages/block-editor/src/components/list-view/style.scss
+++ b/packages/block-editor/src/components/list-view/style.scss
@@ -97,7 +97,7 @@
 		align-items: center;
 		width: 100%;
 		height: auto;
-		padding: ($grid-unit-15 * 0.5) $grid-unit-15 ($grid-unit-15 * 0.5) 0;
+		padding: ($grid-unit-15 * 0.5) $grid-unit-05 ($grid-unit-15 * 0.5) 0;
 		text-align: left;
 		color: $gray-900;
 		border-radius: $radius-block-ui;
@@ -297,8 +297,11 @@
 		}
 	}
 
-	.block-editor-list-view-block-select-button__title {
+	.block-editor-list-view-block-select-button__label-wrapper {
 		min-width: 120px;
+	}
+
+	.block-editor-list-view-block-select-button__title {
 		width: 100%;
 		position: relative;
 

--- a/packages/block-editor/src/components/list-view/style.scss
+++ b/packages/block-editor/src/components/list-view/style.scss
@@ -207,7 +207,7 @@
 	}
 
 	.block-editor-list-view-block__menu-cell {
-		padding-right: 4px;
+		padding-right: $grid-unit-05;
 
 		.components-button.has-icon {
 			height: 24px;
@@ -297,8 +297,16 @@
 		}
 	}
 
-	.block-editor-list-view-block-select-button__label-wrapper {
-		max-width: 240px;
+	.block-editor-list-view-block-select-button__title {
+		min-width: 120px;
+		width: 100%;
+		position: relative;
+
+		.components-truncate {
+			position: absolute;
+			width: 100%;
+			transform: translateY(-50%);
+		}
 	}
 
 	.block-editor-list-view-block-select-button__anchor {
@@ -306,7 +314,7 @@
 		border-radius: $radius-block-ui;
 		display: inline-block;
 		padding: 2px 6px;
-		max-width: 120px;
+		max-width: 100px;
 		overflow: hidden;
 		text-overflow: ellipsis;
 	}

--- a/packages/block-editor/src/components/list-view/style.scss
+++ b/packages/block-editor/src/components/list-view/style.scss
@@ -302,7 +302,7 @@
 	}
 
 	.block-editor-list-view-block-select-button__title {
-		width: 100%;
+		flex: 1;
 		position: relative;
 
 		.components-truncate {
@@ -317,7 +317,7 @@
 		border-radius: $radius-block-ui;
 		display: inline-block;
 		padding: 2px 6px;
-		max-width: 100px;
+		max-width: min(100px, 40%);
 		overflow: hidden;
 		text-overflow: ellipsis;
 	}

--- a/packages/block-library/src/heading/index.js
+++ b/packages/block-library/src/heading/index.js
@@ -33,6 +33,7 @@ export const settings = {
 	__experimentalLabel( attributes, { context } ) {
 		if ( context === 'accessibility' ) {
 			const { content, level } = attributes;
+
 			return isEmpty( content )
 				? sprintf(
 						/* translators: accessibility text. %s: heading level. */

--- a/packages/block-library/src/heading/index.js
+++ b/packages/block-library/src/heading/index.js
@@ -31,9 +31,15 @@ export const settings = {
 		},
 	},
 	__experimentalLabel( attributes, { context } ) {
-		if ( context === 'accessibility' ) {
-			const { content, level } = attributes;
+		const { content, level } = attributes;
 
+		// In the list view, use the block's content as the label.
+		// If the content is empty, fall back to the default label.
+		if ( context === 'list-view' && content ) {
+			return content;
+		}
+
+		if ( context === 'accessibility' ) {
 			return isEmpty( content )
 				? sprintf(
 						/* translators: accessibility text. %s: heading level. */

--- a/packages/block-library/src/heading/index.js
+++ b/packages/block-library/src/heading/index.js
@@ -31,15 +31,8 @@ export const settings = {
 		},
 	},
 	__experimentalLabel( attributes, { context } ) {
-		const { content, level } = attributes;
-
-		// In the list view, use the block's content as the label.
-		// If the content is empty, fall back to the default label.
-		if ( context === 'list-view' && content ) {
-			return content;
-		}
-
 		if ( context === 'accessibility' ) {
+			const { content, level } = attributes;
 			return isEmpty( content )
 				? sprintf(
 						/* translators: accessibility text. %s: heading level. */

--- a/packages/e2e-test-utils/src/get-list-view-blocks.js
+++ b/packages/e2e-test-utils/src/get-list-view-blocks.js
@@ -6,6 +6,6 @@
  */
 export async function getListViewBlocks( blockLabel ) {
 	return page.$x(
-		`//table[contains(@aria-label,'Block navigation structure')]//a[span[text()='${ blockLabel }']]`
+		`//table[contains(@aria-label,'Block navigation structure')]//a//span[text()='${ blockLabel }']`
 	);
 }

--- a/packages/e2e-test-utils/src/get-list-view-blocks.js
+++ b/packages/e2e-test-utils/src/get-list-view-blocks.js
@@ -6,6 +6,6 @@
  */
 export async function getListViewBlocks( blockLabel ) {
 	return page.$x(
-		`//table[contains(@aria-label,'Block navigation structure')]//a//span[text()='${ blockLabel }']`
+		`//table[contains(@aria-label,'Block navigation structure')]//a[.//span[text()='${ blockLabel }']]`
 	);
 }

--- a/packages/e2e-tests/specs/editor/blocks/gallery.test.js
+++ b/packages/e2e-tests/specs/editor/blocks/gallery.test.js
@@ -103,7 +103,7 @@ describe( 'Gallery', () => {
 		// This xpath selects the anchor node for the block which has a child span which contains the text
 		// label of the block and then selects the expander span for that node.
 		const galleryExpander = await page.waitForXPath(
-			`//a[contains(., 'Gallery')]/span[contains(@class, 'block-editor-list-view__expander')]`
+			`//a[.//span[text()='Gallery']]/span[contains(@class, 'block-editor-list-view__expander')]`
 		);
 
 		await galleryExpander.click();

--- a/packages/e2e-tests/specs/editor/blocks/gallery.test.js
+++ b/packages/e2e-tests/specs/editor/blocks/gallery.test.js
@@ -103,7 +103,7 @@ describe( 'Gallery', () => {
 		// This xpath selects the anchor node for the block which has a child span which contains the text
 		// label of the block and then selects the expander span for that node.
 		const galleryExpander = await page.waitForXPath(
-			`//a[span[text()='Gallery']]/span[contains(@class, 'block-editor-list-view__expander')]`
+			`//a[contains(., 'Gallery')]/span[contains(@class, 'block-editor-list-view__expander')]`
 		);
 
 		await galleryExpander.click();

--- a/packages/e2e-tests/specs/editor/blocks/navigation.test.js
+++ b/packages/e2e-tests/specs/editor/blocks/navigation.test.js
@@ -1047,7 +1047,7 @@ Expected mock function not to be called but it was called with: ["POST", "http:/
 			await openListView();
 
 			const navExpander = await page.waitForXPath(
-				`//a[contains(., 'Navigation')]/span[contains(@class, 'block-editor-list-view__expander')]`
+				`//a[.//span[text()='Navigation']]/span[contains(@class, 'block-editor-list-view__expander')]`
 			);
 
 			await navExpander.click();

--- a/packages/e2e-tests/specs/editor/blocks/navigation.test.js
+++ b/packages/e2e-tests/specs/editor/blocks/navigation.test.js
@@ -1047,7 +1047,7 @@ Expected mock function not to be called but it was called with: ["POST", "http:/
 			await openListView();
 
 			const navExpander = await page.waitForXPath(
-				`//a[span[text()='Navigation']]/span[contains(@class, 'block-editor-list-view__expander')]`
+				`//a[contains(., 'Navigation')]/span[contains(@class, 'block-editor-list-view__expander')]`
 			);
 
 			await navExpander.click();


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Explore conditionally using the Heading block's content as the block button label in the List View, falling back to the block's title if no content is available.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

As discussed in https://github.com/WordPress/gutenberg/issues/33583, this could help improve navigating around the List View, and make it feel a little more like working with a document outline.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

* Update the `BlockTitle` component and `useBlockDisplayTitle` hook to support passing in a `context` string that will then be passed along to `getBlockLabel`.
* In the Heading block, check for a `list-view` context string and then conditionally return the block's content as the label.
* In the List View, pass in `list-view` as the context to `BlockTitle` for the block button.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->

1. Insert a heading block into a post/page
2. When the heading is empty it should say "Heading" in the list view
3. When the heading has any content in it, it should use that (truncated) in the list view
4. In the contextual menu for selecting a block within the editor canvas, it should still say "Remove Heading" and _not_ use the block's content as a label
5. Other blocks should display in the list view as before

## Screenshots or screencast <!-- if applicable -->

In the below screengrab, the empty Heading block defaults to using the block name as the label. As the content is updated, the label updates to use the block's content.

![2022-06-23 12 17 31](https://user-images.githubusercontent.com/14988353/175193564-2efe7fbc-0291-498d-8c0b-490538f042c2.gif)

| Before | After |
| --- | --- |
| <img width="347" alt="image" src="https://user-images.githubusercontent.com/14988353/177438487-4988fe96-5e3f-4ae5-bea0-bac98559438b.png"> | <img width="348" alt="image" src="https://user-images.githubusercontent.com/14988353/177438218-9c56e18e-c9a8-4476-9ef7-b301cd2b49b6.png"> |
