### PR TITLE
Lodash: Remove completely from `@wordpress/annotations` package

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16398,7 +16398,6 @@
 				"@wordpress/hooks": "file:packages/hooks",
 				"@wordpress/i18n": "file:packages/i18n",
 				"@wordpress/rich-text": "file:packages/rich-text",
-				"lodash": "^4.17.21",
 				"rememo": "^4.0.0",
 				"uuid": "^8.3.0"
 			}

--- a/packages/annotations/package.json
+++ b/packages/annotations/package.json
@@ -30,7 +30,6 @@
 		"@wordpress/hooks": "file:../hooks",
 		"@wordpress/i18n": "file:../i18n",
 		"@wordpress/rich-text": "file:../rich-text",
-		"lodash": "^4.17.21",
 		"rememo": "^4.0.0",
 		"uuid": "^8.3.0"
 	},

--- a/packages/annotations/src/store/reducer.js
+++ b/packages/annotations/src/store/reducer.js
@@ -1,9 +1,4 @@
 /**
- * External dependencies
- */
-import { mapValues } from 'lodash';
-
-/**
  * Filters an array based on the predicate, but keeps the reference the same if
  * the array hasn't changed.
  *
@@ -19,6 +14,23 @@ function filterWithReference( collection, predicate ) {
 		? collection
 		: filteredCollection;
 }
+
+/**
+ * Creates a new object with the same keys, but with `callback()` called as
+ * a transformer function on each of the values.
+ *
+ * @param {Object}   obj      The object to transform.
+ * @param {Function} callback The function to transform each object value.
+ * @return {Array} Transformed object.
+ */
+const mapValues = ( obj, callback ) =>
+	Object.entries( obj ).reduce(
+		( acc, [ key, value ] ) => ( {
+			...acc,
+			[ key ]: callback( value ),
+		} ),
+		{}
+	);
 
 /**
  * Verifies whether the given annotations is a valid annotation.

--- a/packages/annotations/src/store/selectors.js
+++ b/packages/annotations/src/store/selectors.js
@@ -2,7 +2,6 @@
  * External dependencies
  */
 import createSelector from 'rememo';
-import { flatMap } from 'lodash';
 
 /**
  * Shared reference to an empty array for cases where it is important to avoid
@@ -79,7 +78,5 @@ export const __experimentalGetAnnotationsForRichText = createSelector(
  * @return {Array} All annotations currently applied.
  */
 export function __experimentalGetAnnotations( state ) {
-	return flatMap( state, ( annotations ) => {
-		return annotations;
-	} );
+	return Object.values( state ).flat();
 }


### PR DESCRIPTION
## What?
This PR removes all of the Lodash from the `@wordpress/annotations` package, including the dependency. There are just a few usages and conversion is pretty straightforward. 

## Why?

Lodash is known to unnecessarily inflate the bundle size of packages, and in most cases, it can be replaced with native language functionality. See these for more information and rationale:

* https://github.com/WordPress/gutenberg/issues/16938#issuecomment-602837246
* https://github.com/WordPress/gutenberg/issues/17025
* https://github.com/WordPress/gutenberg/issues/39495 

## How?
We have to deal essentially with 2 methods (`mapValues`, and `flatMap` ), and migration away from them is pretty straightforward, especially because the functionality is covered by unit tests. 

## Testing Instructions

Verify all tests pass: `npm run test-unit packages/annotations`

