### PR TITLE
Lodash: Remove completely from `@wordpress/wordcount` package

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -18189,8 +18189,7 @@
 		"@wordpress/wordcount": {
 			"version": "file:packages/wordcount",
 			"requires": {
-				"@babel/runtime": "^7.16.0",
-				"lodash": "^4.17.21"
+				"@babel/runtime": "^7.16.0"
 			}
 		},
 		"@xtuc/ieee754": {

--- a/packages/wordcount/package.json
+++ b/packages/wordcount/package.json
@@ -26,8 +26,7 @@
 	"react-native": "src/index",
 	"sideEffects": false,
 	"dependencies": {
-		"@babel/runtime": "^7.16.0",
-		"lodash": "^4.17.21"
+		"@babel/runtime": "^7.16.0"
 	},
 	"publishConfig": {
 		"access": "public"

--- a/packages/wordcount/src/index.js
+++ b/packages/wordcount/src/index.js
@@ -1,9 +1,4 @@
 /**
- * External dependencies
- */
-import { extend, flow } from 'lodash';
-
-/**
  * Internal dependencies
  */
 import { defaultSettings } from './defaultSettings';
@@ -37,7 +32,7 @@ import transposeHTMLEntitiesToCountableChars from './transposeHTMLEntitiesToCoun
  * @return {WPWordCountSettings} The combined settings object to be used.
  */
 function loadSettings( type, userSettings ) {
-	const settings = extend( {}, defaultSettings, userSettings );
+	const settings = Object.assign( {}, defaultSettings, userSettings );
 
 	settings.shortcodes = settings.l10n?.shortcodes ?? [];
 
@@ -70,15 +65,15 @@ function loadSettings( type, userSettings ) {
  * @return {number} Count of words.
  */
 function countWords( text, regex, settings ) {
-	text = flow(
+	text = [
 		stripTags.bind( null, settings ),
 		stripHTMLComments.bind( null, settings ),
 		stripShortcodes.bind( null, settings ),
 		stripSpaces.bind( null, settings ),
 		stripHTMLEntities.bind( null, settings ),
 		stripConnectors.bind( null, settings ),
-		stripRemovables.bind( null, settings )
-	)( text );
+		stripRemovables.bind( null, settings ),
+	].reduce( ( result, fn ) => fn( result ), text );
 	text = text + '\n';
 	return text.match( regex )?.length ?? 0;
 }
@@ -93,14 +88,14 @@ function countWords( text, regex, settings ) {
  * @return {number} Count of characters.
  */
 function countCharacters( text, regex, settings ) {
-	text = flow(
+	text = [
 		stripTags.bind( null, settings ),
 		stripHTMLComments.bind( null, settings ),
 		stripShortcodes.bind( null, settings ),
 		transposeAstralsToCountableChar.bind( null, settings ),
 		stripSpaces.bind( null, settings ),
-		transposeHTMLEntitiesToCountableChars.bind( null, settings )
-	)( text );
+		transposeHTMLEntitiesToCountableChars.bind( null, settings ),
+	].reduce( ( result, fn ) => fn( result ), text );
 	text = text + '\n';
 	return text.match( regex )?.length ?? 0;
 }


### PR DESCRIPTION
## What?
This PR removes all of the Lodash from the `@wordpress/wordcount` package, including the dependency. There are just a few usages and conversion is pretty straightforward. 

## Why?

Lodash is known to unnecessarily inflate the bundle size of packages, and in most cases, it can be replaced with native language functionality. See these for more information and rationale:

* https://github.com/WordPress/gutenberg/issues/16938#issuecomment-602837246
* https://github.com/WordPress/gutenberg/issues/17025
* https://github.com/WordPress/gutenberg/issues/39495 

## How?
We have to deal essentially with 2 methods (`extend`, and `flow` ), and migration away from them is pretty straightforward, especially because the functionality is well covered by unit tests. 

## Testing Instructions

* Verify that the table of contents character count triggered by the (i) in the edit post toolbar still works well.
* Verify all tests pass: `npm run test-unit packages/wordcount`

