### PR TITLE
Lodash: Remove completely from `@wordpress/token-list` package

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -18143,8 +18143,7 @@
 		"@wordpress/token-list": {
 			"version": "file:packages/token-list",
 			"requires": {
-				"@babel/runtime": "^7.16.0",
-				"lodash": "^4.17.21"
+				"@babel/runtime": "^7.16.0"
 			}
 		},
 		"@wordpress/url": {

--- a/packages/token-list/package.json
+++ b/packages/token-list/package.json
@@ -26,8 +26,7 @@
 	"react-native": "src/index",
 	"types": "build-types",
 	"dependencies": {
-		"@babel/runtime": "^7.16.0",
-		"lodash": "^4.17.21"
+		"@babel/runtime": "^7.16.0"
 	},
 	"publishConfig": {
 		"access": "public"

--- a/packages/token-list/src/index.js
+++ b/packages/token-list/src/index.js
@@ -1,9 +1,4 @@
 /**
- * External dependencies
- */
-import { uniq, compact, without } from 'lodash';
-
-/**
  * A set of tokens.
  *
  * @see https://dom.spec.whatwg.org/#domtokenlist
@@ -75,7 +70,9 @@ export default class TokenList {
 	 */
 	set value( value ) {
 		value = String( value );
-		this._valueAsArray = uniq( compact( value.split( /\s+/g ) ) );
+		this._valueAsArray = [
+			...new Set( value.split( /\s+/g ).filter( Boolean ) ),
+		];
 		this._currentValue = this._valueAsArray.join( ' ' );
 	}
 
@@ -158,7 +155,9 @@ export default class TokenList {
 	 * @param {...string} items Items to remove.
 	 */
 	remove( ...items ) {
-		this.value = without( this._valueAsArray, ...items ).join( ' ' );
+		this.value = this._valueAsArray
+			.filter( ( val ) => ! items.includes( val ) )
+			.join( ' ' );
 	}
 
 	/**


### PR DESCRIPTION
## What?
This PR removes all of the Lodash from the `@wordpress/token-list` package, including the dependency. There are just a few usages and conversion is pretty straightforward. 

## Why?

Lodash is known to unnecessarily inflate the bundle size of packages, and in most cases, it can be replaced with native language functionality. See these for more information and rationale:

* https://github.com/WordPress/gutenberg/issues/16938#issuecomment-602837246
* https://github.com/WordPress/gutenberg/issues/17025
* https://github.com/WordPress/gutenberg/issues/39495 

## How?
We have to deal essentially with 3 simple methods (`compact`, `uniq`, and `without`), and migration away from them is pretty straightforward, especially because the functionality is covered by unit tests. 

## Testing Instructions

Verify all tests pass: `npm run test-unit packages/token-list`

