### PR TITLE
Lodash: Remove from `Navigation` components

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16720,6 +16720,7 @@
 				"react-colorful": "^5.3.1",
 				"react-dates": "^21.8.0",
 				"reakit": "^1.3.8",
+				"remove-accents": "^0.4.2",
 				"uuid": "^8.3.0"
 			},
 			"dependencies": {

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -67,6 +67,7 @@
 		"react-colorful": "^5.3.1",
 		"react-dates": "^21.8.0",
 		"reakit": "^1.3.8",
+		"remove-accents": "^0.4.2",
 		"uuid": "^8.3.0"
 	},
 	"peerDependencies": {

--- a/packages/components/src/navigation/group/index.js
+++ b/packages/components/src/navigation/group/index.js
@@ -2,7 +2,6 @@
  * External dependencies
  */
 import classnames from 'classnames';
-import { find, uniqueId } from 'lodash';
 
 /**
  * WordPress dependencies
@@ -16,8 +15,10 @@ import { NavigationGroupContext } from './context';
 import { GroupTitleUI } from '../styles/navigation-styles';
 import { useNavigationContext } from '../context';
 
+let uniqueId = 0;
+
 export default function NavigationGroup( { children, className, title } ) {
-	const [ groupId ] = useState( uniqueId( 'group-' ) );
+	const [ groupId ] = useState( `group-${ ++uniqueId }` );
 	const {
 		navigationTree: { items },
 	} = useNavigationContext();
@@ -25,7 +26,11 @@ export default function NavigationGroup( { children, className, title } ) {
 	const context = { group: groupId };
 
 	// Keep the children rendered to make sure invisible items are included in the navigation tree.
-	if ( ! find( items, { group: groupId, _isVisible: true } ) ) {
+	if (
+		! Object.values( items ).some(
+			( item ) => item.group === groupId && item._isVisible
+		)
+	) {
 		return (
 			<NavigationGroupContext.Provider value={ context }>
 				{ children }

--- a/packages/components/src/navigation/item/base.js
+++ b/packages/components/src/navigation/item/base.js
@@ -2,7 +2,6 @@
  * External dependencies
  */
 import classnames from 'classnames';
-import { uniqueId } from 'lodash';
 
 /**
  * WordPress dependencies
@@ -16,10 +15,12 @@ import { useNavigationContext } from '../context';
 import { useNavigationTreeItem } from './use-navigation-tree-item';
 import { ItemBaseUI } from '../styles/navigation-styles';
 
+let uniqueId = 0;
+
 export default function NavigationItemBase( props ) {
 	const { children, className, ...restProps } = props;
 
-	const [ itemId ] = useState( uniqueId( 'item-' ) );
+	const [ itemId ] = useState( `item-${ ++uniqueId }` );
 
 	useNavigationTreeItem( itemId, props );
 	const { navigationTree } = useNavigationContext();

--- a/packages/components/src/navigation/menu/menu-title-search.js
+++ b/packages/components/src/navigation/menu/menu-title-search.js
@@ -1,9 +1,4 @@
 /**
- * External dependencies
- */
-import { filter } from 'lodash';
-
-/**
  * WordPress dependencies
  */
 import { useEffect, useRef } from '@wordpress/element';
@@ -49,7 +44,9 @@ function MenuTitleSearch( {
 			return;
 		}
 
-		const count = filter( items, '_isVisible' ).length;
+		const count = Object.values( items ).filter(
+			( item ) => item._isVisible
+		).length;
 		const resultsFoundMessage = sprintf(
 			/* translators: %d: number of results. */
 			_n( '%d result found.', '%d results found.', count ),

--- a/packages/components/src/navigation/menu/search-no-results-found.js
+++ b/packages/components/src/navigation/menu/search-no-results-found.js
@@ -1,9 +1,4 @@
 /**
- * External dependencies
- */
-import { filter } from 'lodash';
-
-/**
  * WordPress dependencies
  */
 import { __ } from '@wordpress/i18n';
@@ -19,7 +14,9 @@ export default function NavigationSearchNoResultsFound( { search } ) {
 		navigationTree: { items },
 	} = useNavigationContext();
 
-	const resultsCount = filter( items, '_isVisible' ).length;
+	const resultsCount = Object.values( items ).filter(
+		( item ) => item._isVisible
+	).length;
 
 	if ( ! search || !! resultsCount ) {
 		return null;

--- a/packages/components/src/navigation/use-navigation-tree-nodes.js
+++ b/packages/components/src/navigation/use-navigation-tree-nodes.js
@@ -1,9 +1,4 @@
 /**
- * External dependencies
- */
-import { omit } from 'lodash';
-
-/**
  * WordPress dependencies
  */
 import { useState } from '@wordpress/element';
@@ -13,14 +8,22 @@ export const useNavigationTreeNodes = () => {
 
 	const getNode = ( key ) => nodes[ key ];
 
-	const addNode = ( key, value ) =>
-		setNodes( ( original ) => ( {
+	const addNode = ( key, value ) => {
+		// eslint-disable-next-line no-unused-vars
+		const { children, ...newNode } = value;
+		return setNodes( ( original ) => ( {
 			...original,
-			[ key ]: omit( value, 'children' ),
+			[ key ]: newNode,
 		} ) );
+	};
 
-	const removeNode = ( key ) =>
-		setNodes( ( original ) => omit( original, key ) );
+	const removeNode = ( key ) => {
+		return setNodes( ( original ) => {
+			// eslint-disable-next-line no-unused-vars
+			const { [ key ]: removedNode, ...remainingNodes } = original;
+			return remainingNodes;
+		} );
+	};
 
 	return { nodes, getNode, addNode, removeNode };
 };

--- a/packages/components/src/navigation/utils.js
+++ b/packages/components/src/navigation/utils.js
@@ -1,11 +1,11 @@
 /**
  * External dependencies
  */
-import { deburr } from 'lodash';
+import removeAccents from 'remove-accents';
 
 // @see packages/block-editor/src/components/inserter/search-items.js
 export const normalizeInput = ( input ) =>
-	deburr( input ).replace( /^\//, '' ).toLowerCase();
+	removeAccents( input ).replace( /^\//, '' ).toLowerCase();
 
 export const normalizedSearch = ( title, search ) =>
 	-1 !== normalizeInput( title ).indexOf( normalizeInput( search ) );


### PR DESCRIPTION
## What?
This PR removes all of the Lodash from the `Navigation` component group. There are just a few usages and conversion is pretty straightforward. 

## Why?

Lodash is known to unnecessarily inflate the bundle size of packages, and in most cases, it can be replaced with native language functionality. See these for more information and rationale:

* https://github.com/WordPress/gutenberg/issues/16938#issuecomment-602837246
* https://github.com/WordPress/gutenberg/issues/17025
* https://github.com/WordPress/gutenberg/issues/39495 

## How?
We have to deal essentially a few methods, and migration away from them is pretty straightforward:

#### `uniqueId`

We're just using a straightforward non-exposed counter instead.

#### `filter`

We're using `Array.prototype.filter()` in combination with `Object.values()` to convert to an array where necessary.

#### `deburr`

We're using the `remove-accents` package instead, as we already did in a few other instances (see #41687 and #41702).

#### `find`

We're using `Array.prototype.some()` as we're not really interested in using the results, but rather just checking if a value is found with the specified criteria.

#### `omit`

We're using simple object destructuring to omit properties with certain keys from objects.

## Testing Instructions

* Spin up storybook: `npm run storybook:dev`
* Play with all the Navigation component examples and verify everything's still working well.
* Verify tests still pass: `npm run test-unit packages/components/src/navigation`

