### PR TITLE
Editors: Add a link completer shortcut to the help modals

### DIFF
--- a/packages/customize-widgets/src/components/keyboard-shortcut-help-modal/config.js
+++ b/packages/customize-widgets/src/components/keyboard-shortcut-help-modal/config.js
@@ -21,6 +21,10 @@ export const textFormattingShortcuts = [
 		description: __( 'Remove a link.' ),
 	},
 	{
+		keyCombination: { character: '[[' },
+		description: __( 'Insert a link to a post or page' ),
+	},
+	{
 		keyCombination: { modifier: 'primary', character: 'u' },
 		description: __( 'Underline the selected text.' ),
 	},

--- a/packages/edit-site/src/components/keyboard-shortcut-help-modal/config.js
+++ b/packages/edit-site/src/components/keyboard-shortcut-help-modal/config.js
@@ -21,6 +21,10 @@ export const textFormattingShortcuts = [
 		description: __( 'Remove a link.' ),
 	},
 	{
+		keyCombination: { character: '[[' },
+		description: __( 'Insert a link to a post or page' ),
+	},
+	{
 		keyCombination: { modifier: 'primary', character: 'u' },
 		description: __( 'Underline the selected text.' ),
 	},

--- a/packages/edit-widgets/src/components/keyboard-shortcut-help-modal/config.js
+++ b/packages/edit-widgets/src/components/keyboard-shortcut-help-modal/config.js
@@ -21,6 +21,10 @@ export const textFormattingShortcuts = [
 		description: __( 'Remove a link.' ),
 	},
 	{
+		keyCombination: { character: '[[' },
+		description: __( 'Insert a link to a post or page' ),
+	},
+	{
 		keyCombination: { modifier: 'primary', character: 'u' },
 		description: __( 'Underline the selected text.' ),
 	},


### PR DESCRIPTION
## What?
A follow-up to #29172.

PRs add a link completer shortcut to the Keyboard Shortcuts helo modal. Currently, the shortcut is only listed in the post editor.

## Testing Instructions
 1. Open a Site or Widget editor.
 2. Open Keyboard Shortcuts helo modal.
 3. Confirm that a new shortcut is listed.

## Screenshots or screencast <!-- if applicable -->

![CleanShot 2022-06-22 at 16 07 05](https://user-images.githubusercontent.com/240569/175025620-b88f1c62-e729-4d48-855b-5313f4193b04.png)
