### PR TITLE
Block Locking: Add the 'Apply to inner blocks' option

### DIFF
--- a/packages/block-editor/src/components/block-lock/modal.js
+++ b/packages/block-editor/src/components/block-lock/modal.js
@@ -10,6 +10,7 @@ import {
 	FlexItem,
 	Icon,
 	Modal,
+	ToggleControl,
 } from '@wordpress/components';
 import { lock as lockIcon, unlock as unlockIcon } from '@wordpress/icons';
 import { useInstanceId } from '@wordpress/compose';
@@ -23,16 +24,33 @@ import useBlockLock from './use-block-lock';
 import useBlockDisplayInformation from '../use-block-display-information';
 import { store as blockEditorStore } from '../../store';
 
+function getTemplateLockValue( lock ) {
+	// Prevents all operations.
+	if ( lock.remove && lock.move ) {
+		return 'all';
+	}
+
+	// Prevents inserting or removing blocks, but allows moving existing blocks.
+	if ( lock.remove && ! lock.move ) {
+		return 'insert';
+	}
+
+	return false;
+}
+
 export default function BlockLockModal( { clientId, onClose } ) {
+	const [ applyTemplateLock, setApplyTemplateLock ] = useState( false );
 	const [ lock, setLock ] = useState( { move: false, remove: false } );
 	const { canEdit, canMove, canRemove } = useBlockLock( clientId );
-	const { isReusable } = useSelect(
+	const { isReusable, hasTemplateLock } = useSelect(
 		( select ) => {
 			const { getBlockName } = select( blockEditorStore );
 			const blockName = getBlockName( clientId );
+			const blockType = getBlockType( blockName );
 
 			return {
-				isReusable: isReusableBlock( getBlockType( blockName ) ),
+				isReusable: isReusableBlock( blockType ),
+				hasTemplateLock: !! blockType?.attributes?.templateLock,
 			};
 		},
 		[ clientId ]
@@ -69,7 +87,12 @@ export default function BlockLockModal( { clientId, onClose } ) {
 			<form
 				onSubmit={ ( event ) => {
 					event.preventDefault();
-					updateBlockAttributes( [ clientId ], { lock } );
+					updateBlockAttributes( [ clientId ], {
+						lock,
+						templateLock: applyTemplateLock
+							? getTemplateLockValue( lock )
+							: undefined,
+					} );
 					onClose();
 				} }
 			>
@@ -171,6 +194,16 @@ export default function BlockLockModal( { clientId, onClose } ) {
 							/>
 						</li>
 					</ul>
+					{ hasTemplateLock && (
+						<ToggleControl
+							className="block-editor-block-lock-modal__template-lock"
+							label={ __( 'Apply to inner blocks' ) }
+							checked={ applyTemplateLock }
+							onChange={ () =>
+								setApplyTemplateLock( ! applyTemplateLock )
+							}
+						/>
+					) }
 				</div>
 				<Flex
 					className="block-editor-block-lock-modal__actions"

--- a/packages/block-editor/src/components/block-lock/modal.js
+++ b/packages/block-editor/src/components/block-lock/modal.js
@@ -197,7 +197,7 @@ export default function BlockLockModal( { clientId, onClose } ) {
 					{ hasTemplateLock && (
 						<ToggleControl
 							className="block-editor-block-lock-modal__template-lock"
-							label={ __( 'Apply to inner blocks' ) }
+							label={ __( 'Apply to all children' ) }
 							checked={ applyTemplateLock }
 							onChange={ () =>
 								setApplyTemplateLock( ! applyTemplateLock )

--- a/packages/block-editor/src/components/block-lock/modal.js
+++ b/packages/block-editor/src/components/block-lock/modal.js
@@ -197,7 +197,7 @@ export default function BlockLockModal( { clientId, onClose } ) {
 					{ hasTemplateLock && (
 						<ToggleControl
 							className="block-editor-block-lock-modal__template-lock"
-							label={ __( 'Apply to all children' ) }
+							label={ __( 'Apply to all blocks inside' ) }
 							checked={ applyTemplateLock }
 							disabled={ lock.move && ! lock.remove }
 							onChange={ () =>

--- a/packages/block-editor/src/components/block-lock/modal.js
+++ b/packages/block-editor/src/components/block-lock/modal.js
@@ -39,21 +39,25 @@ function getTemplateLockValue( lock ) {
 }
 
 export default function BlockLockModal( { clientId, onClose } ) {
-	const [ applyTemplateLock, setApplyTemplateLock ] = useState( false );
 	const [ lock, setLock ] = useState( { move: false, remove: false } );
 	const { canEdit, canMove, canRemove } = useBlockLock( clientId );
-	const { isReusable, hasTemplateLock } = useSelect(
+	const { isReusable, templateLock, hasTemplateLock } = useSelect(
 		( select ) => {
-			const { getBlockName } = select( blockEditorStore );
+			const { getBlockName, getBlockAttributes } =
+				select( blockEditorStore );
 			const blockName = getBlockName( clientId );
 			const blockType = getBlockType( blockName );
 
 			return {
 				isReusable: isReusableBlock( blockType ),
+				templateLock: getBlockAttributes( clientId )?.templateLock,
 				hasTemplateLock: !! blockType?.attributes?.templateLock,
 			};
 		},
 		[ clientId ]
+	);
+	const [ applyTemplateLock, setApplyTemplateLock ] = useState(
+		templateLock ?? false
 	);
 	const { updateBlockAttributes } = useDispatch( blockEditorStore );
 	const blockInformation = useBlockDisplayInformation( clientId );

--- a/packages/block-editor/src/components/block-lock/modal.js
+++ b/packages/block-editor/src/components/block-lock/modal.js
@@ -57,7 +57,7 @@ export default function BlockLockModal( { clientId, onClose } ) {
 		[ clientId ]
 	);
 	const [ applyTemplateLock, setApplyTemplateLock ] = useState(
-		templateLock ?? false
+		!! templateLock
 	);
 	const { updateBlockAttributes } = useDispatch( blockEditorStore );
 	const blockInformation = useBlockDisplayInformation( clientId );

--- a/packages/block-editor/src/components/block-lock/modal.js
+++ b/packages/block-editor/src/components/block-lock/modal.js
@@ -199,6 +199,7 @@ export default function BlockLockModal( { clientId, onClose } ) {
 							className="block-editor-block-lock-modal__template-lock"
 							label={ __( 'Apply to all children' ) }
 							checked={ applyTemplateLock }
+							disabled={ lock.move && ! lock.remove }
 							onChange={ () =>
 								setApplyTemplateLock( ! applyTemplateLock )
 							}

--- a/packages/block-editor/src/components/block-lock/style.scss
+++ b/packages/block-editor/src/components/block-lock/style.scss
@@ -53,6 +53,15 @@
 	}
 }
 
+.block-editor-block-lock-modal__template-lock {
+	border-top: $border-width solid $gray-300;
+	padding: $grid-unit-15 0;
+
+	.components-base-control__field {
+		margin: 0;
+	}
+}
+
 .block-editor-block-lock-modal__actions {
 	margin-top: $grid-unit-30;
 }

--- a/packages/block-editor/src/components/block-lock/style.scss
+++ b/packages/block-editor/src/components/block-lock/style.scss
@@ -55,6 +55,7 @@
 
 .block-editor-block-lock-modal__template-lock {
 	border-top: $border-width solid $gray-300;
+	margin-top: $grid-unit-20;
 	padding: $grid-unit-15 0;
 
 	.components-base-control__field {


### PR DESCRIPTION
## What?
Resolves #40069.

PR adds the new "Apply to inner blocks" option to the Block Locking modal.

## How?
After chatting with @mtias at WCEU, we decided to try and implement this feature using the `templateLock` attribute for container blocks. The `templateLock` is already supported by API and provides a native way to inherit lock status.

You can find more details on how the `templateLock` and block lock work together can be found in [the original Dev Note](https://make.wordpress.org/core/2022/01/08/locking-blocks-in-wordpress-5-9/#working-alongside-templatelock).

## Limitations

* Not all lock options can have a matching `templateLock` value. E.g., If you decided to restrict only movement and apply this to inner blocks, nothing would happen.
* Currently, only Group, Cover, and Colum block support template lock. We probably have to expand this support.

## Testing Instructions
1. Open a Post or Page.
2. Insert a Group Block and add inner blocks.
3. Open the lock modal via Block options.
4. Select options and "Apply to all children" to apply them to inner bocks.

## Screenshots or screencast <!-- if applicable -->

https://user-images.githubusercontent.com/240569/175211036-5ed170be-d089-49e3-b3e2-2f61055be93e.mp4
