### PR TITLE
Fix XML formatting

### DIFF
--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -62,8 +62,8 @@
 		<exclude-pattern>phpunit/*</exclude-pattern>
 	</rule>
 	<rule ref="Generic.Commenting.DocComment.Empty">
-    	<exclude-pattern>phpunit/*</exclude-pattern>
-    </rule>
+		<exclude-pattern>phpunit/*</exclude-pattern>
+	</rule>
 	<rule ref="Generic.Commenting.DocComment.MissingShort">
 		<exclude-pattern>phpunit/*</exclude-pattern>
 	</rule>


### PR DESCRIPTION
## What?
On line 65 & 66 i.e. rule for `Generic.Commenting.DocComment.Empty` DOM element aligned properly.

## Why?
To stick with formatting standard and for uniformity.
