### PR TITLE
[Raw Handling]: Stop gap solution for expensive handling when pasting html from Windows

### DIFF
--- a/packages/block-editor/src/components/rich-text/use-paste-handler.js
+++ b/packages/block-editor/src/components/rich-text/use-paste-handler.js
@@ -261,6 +261,9 @@ export function usePasteHandler( props ) {
  * @return {string} the normalized html
  */
 function removeWindowsFragments( html ) {
+	if ( ! html.includes( '<!--StartFragment-->' ) ) {
+		return html;
+	}
 	const startReg = /.*<!--StartFragment-->/s;
 	const endReg = /<!--EndFragment-->.*/s;
 


### PR DESCRIPTION

<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Related to: https://github.com/WordPress/gutenberg/issues/41826

The problem is in this [line/function](https://github.com/WordPress/gutenberg/blob/trunk/packages/block-editor/src/components/rich-text/use-paste-handler.js#L92)(removeWindowsFragments). This function was introduced https://github.com/WordPress/gutenberg/pull/33607 and passing the html string by two consecutive replace functions is quite expensive.

<!-- In a few words, what is the PR actually doing? -->

## Why?
The performance hit is big and if we don't find a proper solution quickly enough, this PR could server a stop gap solution.
Noting of course that  `replace` will still be called twice if in Windows.

## Testing Instructions
1. Copy html from anywhere ([ex here](https://en.wikipedia.org/wiki/Aristotle))
2. Paste in the editor **from any non Windows OS**
3. Observe that the content is pasted much quicker

#### Before



https://user-images.githubusercontent.com/16275880/175122414-2088490f-51a1-4da5-8939-42a048288794.mov




#### After

https://user-images.githubusercontent.com/16275880/175121857-047daf5e-c5e3-484c-91f1-1184332bdeb4.mov


