### PR TITLE
Handle cases when getBlockType returns undefined

### DIFF
--- a/packages/block-editor/src/components/block-settings-menu/block-mode-toggle.js
+++ b/packages/block-editor/src/components/block-settings-menu/block-mode-toggle.js
@@ -22,6 +22,7 @@ export function BlockModeToggle( {
 	isCodeEditingEnabled = true,
 } ) {
 	if (
+		! blockType ||
 		! hasBlockSupport( blockType, 'html', true ) ||
 		! isCodeEditingEnabled
 	) {

--- a/packages/block-editor/src/components/block-tools/block-contextual-toolbar.js
+++ b/packages/block-editor/src/components/block-tools/block-contextual-toolbar.js
@@ -36,11 +36,13 @@ function BlockContextualToolbar( { focusOnMount, isFixed, ...props } ) {
 					getBlockType( getBlockName( selectedBlockClientId ) ),
 				hasParents: parents.length,
 				showParentSelector:
+					parentBlockType &&
 					hasBlockSupport(
 						parentBlockType,
 						'__experimentalParentSelector',
 						true
-					) && selectedBlockClientIds.length <= 1,
+					) &&
+					selectedBlockClientIds.length <= 1,
 			};
 		},
 		[]

--- a/packages/blocks/src/api/raw-handling/shortcode-converter.js
+++ b/packages/blocks/src/api/raw-handling/shortcode-converter.js
@@ -92,8 +92,13 @@ function segmentHTMLToShortcodeBlock(
 			( schema ) => schema.shortcode( match.shortcode.attrs, match )
 		);
 
+		const blockType = getBlockType( transformation.blockName );
+		if ( ! blockType ) {
+			return [ HTML ];
+		}
+
 		const transformationBlockType = {
-			...getBlockType( transformation.blockName ),
+			...blockType,
 			attributes: transformation.attributes,
 		};
 

--- a/packages/blocks/src/api/serializer.js
+++ b/packages/blocks/src/api/serializer.js
@@ -361,6 +361,10 @@ export function serializeBlock( block, { isInnerBlocks = false } = {} ) {
 	}
 
 	const blockType = getBlockType( blockName );
+	if ( ! blockType ) {
+		return saveContent;
+	}
+
 	const saveAttributes = getCommentAttributes( blockType, block.attributes );
 	return getCommentDelimitedContent( blockName, saveAttributes, saveContent );
 }

--- a/packages/blocks/src/api/utils.js
+++ b/packages/blocks/src/api/utils.js
@@ -161,7 +161,7 @@ export function getBlockLabel( blockType, attributes, context = 'visual' ) {
  * than the visual label and includes the block title and the value of the
  * `getLabel` function if it's specified.
  *
- * @param {Object}  blockType              The block type.
+ * @param {?Object} blockType              The block type.
  * @param {Object}  attributes             The values of the block's attributes.
  * @param {?number} position               The position of the block in the block list.
  * @param {string}  [direction='vertical'] The direction of the block layout.


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Added a few checks to determine if result of `getBlockType` is defined.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
As reported in https://github.com/WordPress/gutenberg/issues/34462 ,  `getBlockType` selector might return `undefined` and in few places it was assumed that it would return an object.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
In places that were assuming that result of `getBlockType` is an object I have added some checks to make sure that case when it's `undefined` is handled too.

I get no errors on the console but I see a "null" block after running `wp.data.dispatch('core/blocks').removeBlockTypes('core/missing')`  and clicking on the block. Not sure if it's correct or not. 

<img width="1211" alt="image" src="https://user-images.githubusercontent.com/4765119/175136530-82e9b9ef-99e0-4193-8807-61f1f88333c4.png">

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->
Test instructions can be found [here](https://github.com/WordPress/gutenberg/pull/35097#issuecomment-938058089). 

> **Note**
If someone could confirm that default values returned in those 2 places are correct it would be perfect 🙏 
- https://github.com/WordPress/gutenberg/commit/69faa9328244c80ac4028fc1f214f21cc5a8dbf6#diff-6b8a8712230f209945133ddda4688f21090127c9fd9f885e988579020b3426a6R97
- https://github.com/WordPress/gutenberg/commit/69faa9328244c80ac4028fc1f214f21cc5a8dbf6#diff-9740c1068259d4fb58036de0b2fa8a58ba9bb83f0c4b7c85aee6c0835698accaR365