### PR TITLE
Layout: Move generation of util classes to existing method to avoid adding global public method WP

### DIFF
--- a/lib/block-supports/layout.php
+++ b/lib/block-supports/layout.php
@@ -146,40 +146,6 @@ function gutenberg_get_layout_style( $selector, $layout, $has_block_gap_support 
 }
 
 /**
- * Generates the utility classnames for the given blocks layout attributes.
- * This method was primarily added to reintroduce classnames that were removed
- * in the 5.9 release (https://github.com/WordPress/gutenberg/issues/38719), rather
- * than providing an extensive list of all possible layout classes. The plan is to
- * have the style engine generate a more extensive list of utility classnames which
- * will then replace this method.
- *
- * @param array $block_attributes Array of block attributes.
- *
- * @return array Array of CSS classname strings.
- */
-function gutenberg_get_layout_classes( $block_attributes ) {
-	$class_names = array();
-
-	if ( empty( $block_attributes['layout'] ) ) {
-		return $class_names;
-	}
-
-	if ( ! empty( $block_attributes['layout']['orientation'] ) ) {
-		$class_names[] = 'is-' . sanitize_title( $block_attributes['layout']['orientation'] );
-	}
-
-	if ( ! empty( $block_attributes['layout']['justifyContent'] ) ) {
-		$class_names[] = 'is-content-justification-' . sanitize_title( $block_attributes['layout']['justifyContent'] );
-	}
-
-	if ( ! empty( $block_attributes['layout']['flexWrap'] ) && 'nowrap' === $block_attributes['layout']['flexWrap'] ) {
-		$class_names[] = 'is-nowrap';
-	}
-
-	return $class_names;
-}
-
-/**
  * Renders the layout config to the block wrapper.
  *
  * @param  string $block_content Rendered block content.
@@ -206,9 +172,25 @@ function gutenberg_render_layout_support_flag( $block_content, $block ) {
 		$used_layout = $default_layout;
 	}
 
+	$class_names     = array();
 	$container_class = wp_unique_id( 'wp-container-' );
-	$class_names     = gutenberg_get_layout_classes( $block['attrs'] );
 	$class_names[]   = $container_class;
+
+	// The following section was added to reintroduce a small set of layout classnames that were
+	// removed in the 5.9 release (https://github.com/WordPress/gutenberg/issues/38719). It is
+	// not intended to provide an extended set of classes to match all block layout attributes
+	// here.
+	if ( ! empty( $block['attrs']['layout']['orientation'] ) ) {
+		$class_names[] = 'is-' . sanitize_title( $block['attrs']['layout']['orientation'] );
+	}
+
+	if ( ! empty( $block['attrs']['layout']['justifyContent'] ) ) {
+		$class_names[] = 'is-content-justification-' . sanitize_title( $block['attrs']['layout']['justifyContent'] );
+	}
+
+	if ( ! empty( $block['attrs']['layout']['flexWrap'] ) && 'nowrap' === $block['attrs']['layout']['flexWrap'] ) {
+		$class_names[] = 'is-nowrap';
+	}
 
 	$gap_value = _wp_array_get( $block, array( 'attrs', 'style', 'spacing', 'blockGap' ) );
 	// Skip if gap value contains unsupported characters.


### PR DESCRIPTION
## What?
Moves adding  several layout utility classnames to blocks that have layout attributes specified into `gutenberg_render_layout_support_flag` instead of own method.

## Why?
To avoid adding a potentially temporary method to global `wp_` scope in 6.0.1 release.


## How?
Copy pasta from one place to another

## Testing Instructions

- Add a Buttons block with one child Button block
- On parent Buttons block set alignment to centre and turn off the wrapping option
- Check that `is-content-justification-center` and `is-nowrap` classes are added in editor and frontend

## Screenshots or screencast 
<img width="571" alt="Screen Shot 2022-06-02 at 11 17 33 AM" src="https://user-images.githubusercontent.com/3629020/171517150-cb77fac2-0b2d-4a57-98ef-984e2f1bd558.png">
