### PR TITLE
Block Editor: Fix incorrect '_n' usage

### DIFF
--- a/packages/block-editor/src/components/block-settings-menu/block-settings-dropdown.js
+++ b/packages/block-editor/src/components/block-settings-menu/block-settings-dropdown.js
@@ -16,7 +16,7 @@ import {
 	useCallback,
 	useRef,
 } from '@wordpress/element';
-import { __, _n, sprintf } from '@wordpress/i18n';
+import { __, sprintf } from '@wordpress/i18n';
 import { store as keyboardShortcutsStore } from '@wordpress/keyboard-shortcuts';
 import { useCopyToClipboard } from '@wordpress/compose';
 
@@ -42,7 +42,8 @@ const POPOVER_PROPS = {
 
 function CopyMenuItem( { blocks, onCopy } ) {
 	const ref = useCopyToClipboard( () => serialize( blocks ), onCopy );
-	const copyMenuItemLabel = _n( 'Copy block', 'Copy blocks', blocks.length );
+	const copyMenuItemLabel =
+		blocks.length > 1 ? __( 'Copy blocks' ) : __( 'Copy block' );
 	return <MenuItem ref={ ref }>{ copyMenuItemLabel }</MenuItem>;
 }
 


### PR DESCRIPTION
## What?
PR fixes the incorrect `_n` translation method usage in the Block Editor package.

The issue was initially reported in the [core-editor Slack channel](https://wordpress.slack.com/archives/C02QB2JS7/p1655926186924949). Props to @tobifjellner.

## Why?
The `_n` translation function shouldn't be used for "one item" or "more than one items" cases. Details - https://developer.wordpress.org/reference/functions/_n/#comment-2397

## Testing Instructions
1. Open a Post or Page.
2. Insert multiple blocks.
3. Select a single block and confirm Copy label is rendered in the singular form.
4. Select multiple blocks and confirm the plural form of the same string.
