### PR TITLE
[Code Quality]: Remove leftovers of legacy query-loop block

### DIFF
--- a/packages/block-library/src/post-template/style.scss
+++ b/packages/block-library/src/post-template/style.scss
@@ -1,10 +1,4 @@
-.wp-block-post-template,
-// We have kept `wp-block-query-loop` class as well for backwards
-// compatibility with existing `QueryLoop` blocks that haven't been
-// updated, after the renaming of the block to `Post Template`.
-// See: https://github.com/WordPress/gutenberg/pull/32514.
-// TODO: Remove this class when WordPress 5.9 is released.
-.wp-block-query-loop {
+.wp-block-post-template {
 	margin-top: 0;
 	margin-bottom: 0;
 	max-width: 100%;

--- a/packages/blocks/src/api/parser/convert-legacy-block.js
+++ b/packages/blocks/src/api/parser/convert-legacy-block.js
@@ -49,12 +49,6 @@ export function convertLegacyBlockNameAndAttributes( name, attributes ) {
 		name = 'core/embed';
 	}
 
-	// Convert 'core/query-loop' blocks in existing content to 'core/post-template'.
-	// TODO: Remove this check when WordPress 5.9 is released.
-	if ( name === 'core/query-loop' ) {
-		name = 'core/post-template';
-	}
-
 	// Convert Post Comment blocks in existing content to Comment blocks.
 	// TODO: Remove these checks when WordPress 6.0 is released.
 	if ( name === 'core/post-comment-author' ) {


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
`Query Loop` landed in `core` in WP `5.8` and before landing we renamed it [here](https://github.com/WordPress/gutenberg/pull/32514).  Since that block was heavily tested/used by folks, I had added support for the legacy block for GB users, for just one release(`5.9`). I'm a bit late with `6.0` out, but let's remove it 😄 
<!-- In a few words, what is the PR actually doing? -->

## Testing Instructions
Everything should work as before. 