### PR TITLE
Comment template: left, center and right alignments

### DIFF
--- a/packages/block-library/src/comment-template/style.scss
+++ b/packages/block-library/src/comment-template/style.scss
@@ -14,7 +14,7 @@
 		list-style: none;
 		padding-left: 2rem;
 	}
-	
+
 	&.alignleft {
 		float: left;
 	}
@@ -24,7 +24,7 @@
 		margin-right: auto;
 		width: fit-content;
 	}
-	
+
 	&.alignright {
 		float: right;
 	}

--- a/packages/block-library/src/comment-template/style.scss
+++ b/packages/block-library/src/comment-template/style.scss
@@ -14,4 +14,18 @@
 		list-style: none;
 		padding-left: 2rem;
 	}
+	
+	&.alignleft {
+		float: left;
+	}
+
+	&.aligncenter {
+		margin-left: auto;
+		margin-right: auto;
+		width: fit-content;
+	}
+	
+	&.alignright {
+		float: right;
+	}
 }


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->
Adds CSS for left, center and right alignments to the comment template block.

Closes #40269

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
The comment template did not align to the left, center or right on the front when the toolbar alignment options were enabled.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->

1. Apply the PR.
2. Create a new post or page in the block editor.
3. Add a 3 comment blocks.
4. Select the inner comment template blocks and align one to left, one to center, and one to right.
5. Confirm that the alignments work in the editor.
6. Save and view the result on the front, confirm that the alignments work on the front.

7. Optionally, move the comment template block to different positions inside the comment query block, and test with different inner blocks inside the comment template. Confirm that the alignments still work.

## Screenshots or screencast <!-- if applicable -->
Using empty theme:

Left.  **Not pretty,** but it works:

![comment template is aligned to the left on the front](https://user-images.githubusercontent.com/7422055/175247022-15e548be-c914-45bb-8eb2-fd8b77767b77.png)

Center:
![comment template is aligned to the center on the front](https://user-images.githubusercontent.com/7422055/175246704-cca7f84e-5775-41b6-b8e6-9db3828ea071.png)

Right:
![comment template is aligned to the right on the front](https://user-images.githubusercontent.com/7422055/175247303-bb7e1cd8-58ee-4cdc-80bb-be8d75985746.png)




