### PR TITLE
Improvements to "inherit default layout" toggle

### DIFF
--- a/packages/block-editor/src/hooks/layout.js
+++ b/packages/block-editor/src/hooks/layout.js
@@ -146,7 +146,7 @@ function LayoutPanel( { setAttributes, attributes, name: blockName } ) {
 											'Nested blocks use theme content width with options for full and wide widths.'
 									  )
 									: __(
-											'Nested blocks will fill the width of this container'
+											'Nested blocks will fill the width of this container.'
 									  ) }
 							</p>
 						</>

--- a/packages/block-editor/src/hooks/layout.js
+++ b/packages/block-editor/src/hooks/layout.js
@@ -130,15 +130,26 @@ function LayoutPanel( { setAttributes, attributes, name: blockName } ) {
 			<InspectorControls>
 				<PanelBody title={ __( 'Layout' ) }>
 					{ showInheritToggle && (
-						<ToggleControl
-							label={ __( 'Inherit default layout' ) }
-							checked={ !! inherit }
-							onChange={ () =>
-								setAttributes( {
-									layout: { inherit: ! inherit },
-								} )
-							}
-						/>
+						<>
+							<ToggleControl
+								label={ __( 'Blocks use full width' ) }
+								checked={ ! inherit }
+								onChange={ () =>
+									setAttributes( {
+										layout: { inherit: ! inherit },
+									} )
+								}
+							/>
+							<p className="block-editor-hooks__layout-controls-helptext">
+								{ !! inherit
+									? __(
+											'Nested blocks use default content width with options for full and wide widths.'
+									  )
+									: __(
+											'Nested blocks will fill the width of this container'
+									  ) }
+							</p>
+						</>
 					) }
 
 					{ ! inherit && allowSwitching && (

--- a/packages/block-editor/src/hooks/layout.js
+++ b/packages/block-editor/src/hooks/layout.js
@@ -132,7 +132,7 @@ function LayoutPanel( { setAttributes, attributes, name: blockName } ) {
 					{ showInheritToggle && (
 						<>
 							<ToggleControl
-								label={ __( 'Blocks use full width' ) }
+								label={ __( 'Inner blocks use full width' ) }
 								checked={ ! inherit }
 								onChange={ () =>
 									setAttributes( {
@@ -143,7 +143,7 @@ function LayoutPanel( { setAttributes, attributes, name: blockName } ) {
 							<p className="block-editor-hooks__layout-controls-helptext">
 								{ !! inherit
 									? __(
-											'Nested blocks use default content width with options for full and wide widths.'
+											'Nested blocks use theme content width with options for full and wide widths.'
 									  )
 									: __(
 											'Nested blocks will fill the width of this container'


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Fixes #31950, taking into account suggestions in #36082.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

The "Inherit default layout" toggle is confusing in how it's worded: what is the default layout? where are we inheriting it from?

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

This PR tries changing the toggle text and adding descriptions to explain its actual effect on the block content.

## Note

I'm not sure how we can best make the description text accessible. While it could be attached to the toggle field with an `aria-describedby`, the fact that the text changes according to the toggle position may make it confusing as a description. But on the other hand it is valuable to have the description be dynamic, so it explains what can be expected from the current state. Thoughts and suggestions welcome!

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->

1. Add a Group block in a post.
2. Add some content inside the Group block.
3. In Group block Layout settings (in the sidebar), check that "Inherit default layout" toggle now reads "Blocks use full width" and still works as expected.

## Screenshots or screencast <!-- if applicable -->

Before:
<img width="279" alt="Screen Shot 2022-06-23 at 6 04 11 pm" src="https://user-images.githubusercontent.com/8096000/175248667-da93006a-a20c-445c-81c1-d9b2078c094d.png">
<img width="281" alt="Screen Shot 2022-06-23 at 6 04 18 pm" src="https://user-images.githubusercontent.com/8096000/175248684-89d1b1dc-59b9-481c-bf25-78f71ec9782c.png">

After:

<img width="283" alt="Screen Shot 2022-06-23 at 6 03 55 pm" src="https://user-images.githubusercontent.com/8096000/175248734-00d7ae14-a26b-4d9b-b162-0b7b8046212d.png">
<img width="282" alt="Screen Shot 2022-06-23 at 6 03 48 pm" src="https://user-images.githubusercontent.com/8096000/175248768-098eb3d3-1159-4921-8a27-0c7c64280d3f.png">

