### PR TITLE
Add an inline styles handler

### DIFF
--- a/lib/block-supports/elements.php
+++ b/lib/block-supports/elements.php
@@ -114,7 +114,7 @@ function gutenberg_render_elements_support_styles( $pre_render, $block ) {
 		);
 
 		if ( ! empty( $styles['css'] ) ) {
-			gutenberg_enqueue_block_support_styles( $styles['css'] );
+			WP_Inline_Styles_Handler::get_instance()->add_css( $styles['css'] );
 		}
 	}
 

--- a/lib/compat/wordpress-6.1/class-wp-inline-styles-handler.php
+++ b/lib/compat/wordpress-6.1/class-wp-inline-styles-handler.php
@@ -146,7 +146,6 @@ class WP_Inline_Styles_Handler {
 			}
 			$css .= '}';
 		}
-		error_log( strlen( $css ) );
 		return $css;
 	}
 

--- a/lib/compat/wordpress-6.1/class-wp-inline-styles-handler.php
+++ b/lib/compat/wordpress-6.1/class-wp-inline-styles-handler.php
@@ -1,0 +1,152 @@
+<?php
+/**
+ * Handler for inline styles.
+ *
+ * @package gutenberg
+ */
+
+/**
+ * Handler for inline styles.
+ */
+class WP_Inline_Styles_Handler {
+
+	/**
+	 * An array of selectors along with their styles.
+	 *
+	 * @var array
+	 */
+	private $styles_array = array();
+
+	/**
+	 * Get an instance of the object.
+	 *
+	 * @return WP_Inline_Styles_Handler
+	 */
+	public static function get_instance() {
+		static $instance;
+
+		if ( null === $instance ) {
+			$instance = new self();
+		}
+
+		return $instance;
+	}
+
+	/**
+	 * Constructor.
+	 * Private constructor, call get_instance() to get an instance of the object.
+	 *
+	 * Adds the action to print the inline styles.
+	 */
+	private function __construct() {
+		$action_hook_name = 'wp_footer';
+		if ( wp_is_block_theme() ) {
+			$action_hook_name = 'wp_head';
+		}
+
+		add_action( $action_hook_name, array( $this, 'print_styles' ) );
+	}
+
+	/**
+	 * Print styles.
+	 *
+	 * @return void
+	 */
+	public function print_styles() {
+		echo '<style>' . $this->get_styles() . '</style>';
+	}
+
+	/**
+	 * Add styles to the $styles_array in the object.
+	 *
+	 * @param array $styles An array of selectors along with their styles.
+	 *
+	 * @return void
+	 */
+	public function add_array_styles( $styles = array() ) {
+		foreach ( $styles as $selector => $selector_styles ) {
+			$this->add_selector_styles( $selector, $selector_styles );
+		}
+	}
+
+	/**
+	 * Add styles for a single selector.
+	 *
+	 * @param string $selector The CSS selector.
+	 * @param array  $styles   The styles for the defined selector.
+	 *
+	 * @return void
+	 */
+	public function add_selector_styles( $selector = '', $styles = array() ) {
+		if ( empty( $this->styles_array[ $selector ] ) ) {
+			$this->styles_array[ $selector ] = array();
+		}
+		$this->styles_array[ $selector ] = array_merge( $this->styles_array[ $selector ], $styles );
+	}
+
+	/**
+	 * Combines selectors from the $styles_array
+	 * when they have the same styles.
+	 *
+	 * @return void
+	 */
+	private function combine_selectors() {
+
+		$json_styles = array();
+
+		// Sort the styles to make comparing values easier.
+		foreach ( $this->styles_array as $selector => $styles ) {
+			ksort( $styles );
+			$this->styles_array[ $selector ] = $styles;
+
+			// Convert styles to JSON to make comparing them easier.
+			$json_styles[ $selector ] = json_encode( $styles );
+
+		}
+
+		// Combine selectors that have the same styles.
+		foreach ( $json_styles as $selector => $json ) {
+			// Get selectors that use the same styles.
+			$duplicates = array_keys( $json_styles, $json, true );
+
+			// Combine selectors for duplicates.
+			if ( 1 < count( $duplicates ) ) {
+				$css = $this->styles_array[ $selector ];
+				foreach ( $duplicates as $key ) {
+					unset( $json_styles[ $key ] );
+					unset( $this->styles_array[ $key ] );
+				}
+				$this->styles_array[ implode( ',', $duplicates ) ] = $css;
+			}
+		}
+	}
+
+	/**
+	 * Get the styles array with removed duplicates.
+	 *
+	 * @return array
+	 */
+	public function get_styles_array() {
+		$this->combine_selectors();
+		return $this->styles_array;
+	}
+
+	/**
+	 * Get CSS from the styles array.
+	 *
+	 * @return string
+	 */
+	public function get_styles() {
+		$css    = '';
+		$styles = $this->get_styles_array();
+		foreach ( $styles as $selector => $rules ) {
+			$css .= "$selector{";
+			foreach ( $rules as $key => $value ) {
+				$css .= "$key:$value;";
+			}
+			$css .= '}';
+		}
+		error_log( strlen( $css ) );
+		return $css;
+	}
+}

--- a/lib/compat/wordpress-6.1/class-wp-inline-styles-handler.php
+++ b/lib/compat/wordpress-6.1/class-wp-inline-styles-handler.php
@@ -127,7 +127,6 @@ class WP_Inline_Styles_Handler {
 	 * @return array
 	 */
 	public function get_styles_array() {
-		$this->combine_selectors();
 		return $this->styles_array;
 	}
 
@@ -137,7 +136,8 @@ class WP_Inline_Styles_Handler {
 	 * @return string
 	 */
 	public function get_styles() {
-		$css    = '';
+		$css = '';
+		$this->combine_selectors();
 		$styles = $this->get_styles_array();
 		foreach ( $styles as $selector => $rules ) {
 			$css .= "$selector{";

--- a/lib/compat/wordpress-6.1/class-wp-inline-styles-handler.php
+++ b/lib/compat/wordpress-6.1/class-wp-inline-styles-handler.php
@@ -44,7 +44,7 @@ class WP_Inline_Styles_Handler {
 			$action_hook_name = 'wp_head';
 		}
 
-		add_action( $action_hook_name, array( $this, 'print_styles' ) );
+		add_action( $action_hook_name, array( $this, 'print_styles' ), 20 );
 	}
 
 	/**

--- a/lib/compat/wordpress-6.1/class-wp-inline-styles-handler.php
+++ b/lib/compat/wordpress-6.1/class-wp-inline-styles-handler.php
@@ -149,4 +149,84 @@ class WP_Inline_Styles_Handler {
 		error_log( strlen( $css ) );
 		return $css;
 	}
+
+	/**
+	 * Add styles from CSS.
+	 *
+	 * @param string $css The CSS to parse and add.
+	 *
+	 * @return void
+	 */
+	public function add_css( $css = '' ) {
+		$this->add_array_styles( $this->parse_css( $css ) );
+	}
+
+	/**
+	 * Parse CSS and return an array of selectors and their styles.
+	 *
+	 * @param string $css The CSS to parse.
+	 *
+	 * @return array An array of selectors and their styles.
+	 */
+	private function parse_css( $css = '' ) {
+		$parts  = explode( '}', $css );
+		$styles = array();
+
+		foreach ( $parts as $part ) {
+			$part = trim( $part );
+			if ( ! $part ) {
+				continue;
+			}
+
+			$selector_styles = explode( '{', $part );
+			$selector        = trim( $selector_styles[0] );
+			if ( ! $selector ) {
+				continue;
+			}
+
+			$styles[ $selector ] = $this->parse_style_rules( $selector_styles[1] );
+
+			if ( ! $styles[ $selector ] ) {
+				unset( $styles[ $selector ] );
+				continue;
+			}
+		}
+		return $styles;
+	}
+
+	/**
+	 * Parse a CSS rule and return an array of properties and their values.
+	 *
+	 * @param string $rule The CSS rule to parse.
+	 *
+	 * @return array An array of properties and their values.
+	 */
+	private function parse_style_rules( $rule = '' ) {
+		$rule = trim( $rule );
+		if ( ! $rule ) {
+			return array();
+		}
+
+		$rules = explode( ';', $rule );
+		$style = array();
+
+		foreach ( $rules as $rule ) {
+			$rule = trim( $rule );
+			if ( ! $rule ) {
+				continue;
+			}
+
+			$rule_parts = explode( ':', $rule );
+			$property   = trim( $rule_parts[0] );
+			$value      = trim( $rule_parts[1] );
+
+			if ( ! $property || ! $value ) {
+				continue;
+			}
+
+			$style[ $property ] = $value;
+		}
+
+		return $style;
+	}
 }

--- a/lib/load.php
+++ b/lib/load.php
@@ -132,6 +132,7 @@ require __DIR__ . '/compat/wordpress-6.1/block-template-utils.php';
 require __DIR__ . '/compat/wordpress-6.1/wp-theme-get-post-templates.php';
 require __DIR__ . '/compat/wordpress-6.1/script-loader.php';
 require __DIR__ . '/compat/wordpress-6.1/date-settings.php';
+require __DIR__ . '/compat/wordpress-6.1/class-wp-inline-styles-handler.php';
 
 // Experimental features.
 remove_action( 'plugins_loaded', '_wp_theme_json_webfonts_handler' ); // Turns off WP 6.0's stopgap handler for Webfonts API.

--- a/packages/block-library/src/gallery/index.php
+++ b/packages/block-library/src/gallery/index.php
@@ -80,10 +80,14 @@ function block_core_gallery_render( $attributes, $content ) {
 		$gap_value  = $gap_row === $gap_column ? $gap_row : $gap_row . ' ' . $gap_column;
 	}
 
-	// Set the CSS variable to the column value, and the `gap` property to the combined gap value.
-	$style = '.' . $class . '{ --wp--style--unstable-gallery-gap: ' . $gap_column . '; gap: ' . $gap_value . '}';
+	WP_Inline_Styles_Handler::get_instance()->add_selector_styles(
+		".$class",
+		array(
+			'--wp--style--unstable-gallery-gap' => $gap_column,
+			'gap'                               => $gap_value,
+		)
+	);
 
-	gutenberg_enqueue_block_support_styles( $style, 11 );
 	return $content;
 }
 /**


### PR DESCRIPTION
## What?
Adds an inline-styles handler to improve & optimize the way we handle our styles.

## Why?
There has been an increase in the inline styles we add on the frontend; We add styles for global-styles, layouts, blocks styles, the list goes on.
This PR aims to improve the styles we add, by combining them and optimizing them. This can help improve the performance, as well as sustainability of our implementation on the frontend. 🌍 🌳 

## How?
Adds a `WP_Inline_Styles_Handler` class. Instead of printing a bunch of different `<style>` elements, we can use that object to add all styles to a "pool" of styles that can then be combined and printed all at once.
The class currently includes the following optimizations:
* Styles are added as an array. The result of that is that we don't have duplicate rules, since the array has the form `[selector => [ rule => value ] ]`.
* If multiple selectors have identical styles, then they are combined. So this: `.selector1 { color: red; } .selector2 { color: red; }` gets transformed to this: `.selector1,.selector2{color:red;}`. 

The PR in its current form adds the PHP class, and uses it in the functions for layout styles. The result is extremely positive: Before the PR, **the twentytwentyone theme adds ~12k of inline styles for layouts. After the PR, the size of those styles gets reduced to ~6k**. That means that we can shave multiple kilobytes of data loaded for 40% of the web... well worth it.

Though this PR only uses the class in the layouts functions, the more we use it the more it can optimize the styles. So we can in a future PR implement it for global styles as well as other block-supports that add inline styles, as part of our global-styles engine.

## Testing Instructions
Use any block theme and ensure that the frontend looks the same, while the amount of inlined styles is reduced.