### PR TITLE
ESLint: Enable `ignoreRestSiblings` option for `no-unused-vars` rule

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -30770,7 +30770,7 @@
 		"css.escape": {
 			"version": "1.5.1",
 			"resolved": "https://registry.npmjs.org/css.escape/-/css.escape-1.5.1.tgz",
-			"integrity": "sha512-YUifsXXuknHlUsmlgyY0PKzgPOr7/FjCePfHNt0jxm83wHZi44VDMQ7/fGNkjY3/jV1MC+1CmZbaHzugyeRtpg==",
+			"integrity": "sha1-QuJ9T6BK4y+TGktNQZH6nN3ul8s=",
 			"dev": true
 		},
 		"cssesc": {
@@ -43685,7 +43685,7 @@
 		"lz-string": {
 			"version": "1.4.4",
 			"resolved": "https://registry.npmjs.org/lz-string/-/lz-string-1.4.4.tgz",
-			"integrity": "sha512-0ckx7ZHRPqb0oUm8zNr+90mtf9DQB60H1wMCjBtfi62Kl3a7JbHob6gA2bC+xRvZoOL+1hzUK8jeuEIQE8svEQ==",
+			"integrity": "sha1-wNjq82BZ9wV5bh40SBHPTEmNOiY=",
 			"dev": true
 		},
 		"macos-release": {

--- a/packages/block-library/src/comments-title/deprecated.js
+++ b/packages/block-library/src/comments-title/deprecated.js
@@ -18,13 +18,11 @@ export default [
 		},
 		supports,
 		migrate: ( oldAttributes ) => {
-			/* eslint-disable no-unused-vars */
 			const {
 				singleCommentLabel,
 				multipleCommentsLabel,
 				...newAttributes
 			} = oldAttributes;
-			/* eslint-enable no-unused-vars */
 			return newAttributes;
 		},
 		isEligible: ( { multipleCommentsLabel, singleCommentLabel } ) =>

--- a/packages/components/src/custom-gradient-picker/index.js
+++ b/packages/components/src/custom-gradient-picker/index.js
@@ -66,7 +66,6 @@ const GradientTypePicker = ( { gradientAST, hasGradient, onChange } ) => {
 	};
 
 	const onSetRadialGradient = () => {
-		// eslint-disable-next-line no-unused-vars
 		const { orientation, ...restGradientAST } = gradientAST;
 		onChange(
 			serializeGradient( {

--- a/packages/components/src/mobile/bottom-sheet/keyboard-avoiding-view.native.js
+++ b/packages/components/src/mobile/bottom-sheet/keyboard-avoiding-view.native.js
@@ -98,13 +98,8 @@ class KeyboardAvoidingView extends Component {
 	}
 
 	render() {
-		const {
-			children,
-			enabled,
-			keyboardVerticalOffset, // eslint-disable-line no-unused-vars
-			style,
-			...props
-		} = this.props;
+		const { children, enabled, keyboardVerticalOffset, style, ...props } =
+			this.props;
 
 		let finalStyle = style;
 		if ( Platform.OS === 'ios' ) {

--- a/packages/components/src/navigation/use-navigation-tree-nodes.js
+++ b/packages/components/src/navigation/use-navigation-tree-nodes.js
@@ -9,7 +9,6 @@ export const useNavigationTreeNodes = () => {
 	const getNode = ( key ) => nodes[ key ];
 
 	const addNode = ( key, value ) => {
-		// eslint-disable-next-line no-unused-vars
 		const { children, ...newNode } = value;
 		return setNodes( ( original ) => ( {
 			...original,
@@ -19,7 +18,6 @@ export const useNavigationTreeNodes = () => {
 
 	const removeNode = ( key ) => {
 		return setNodes( ( original ) => {
-			// eslint-disable-next-line no-unused-vars
 			const { [ key ]: removedNode, ...remainingNodes } = original;
 			return remainingNodes;
 		} );

--- a/packages/editor/src/components/provider/index.native.js
+++ b/packages/editor/src/components/provider/index.native.js
@@ -319,13 +319,7 @@ class NativeEditorProvider extends Component {
 	}
 
 	render() {
-		const {
-			children,
-			post, // eslint-disable-line no-unused-vars
-			capabilities,
-			settings,
-			...props
-		} = this.props;
+		const { children, post, capabilities, settings, ...props } = this.props;
 		const editorSettings = this.getEditorSettings( settings, capabilities );
 
 		return (

--- a/packages/element/src/serialize.js
+++ b/packages/element/src/serialize.js
@@ -646,7 +646,6 @@ export function renderNativeComponent(
 		// place of children. Ensure to omit so it is not assigned as attribute
 		// as well.
 		content = renderChildren( props.value, context, legacyContext );
-		// eslint-disable-next-line no-unused-vars
 		const { value, ...restProps } = props;
 		props = restProps;
 	} else if (

--- a/packages/eslint-plugin/CHANGELOG.md
+++ b/packages/eslint-plugin/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+-   Enable `no-unused-vars`'s setting `ignoreRestSiblings` to allow unused variables when destructuring with rest properties ([#41897](https://github.com/WordPress/gutenberg/pull/41897)).
+
 ## 12.2.0 (2022-05-04)
 
 ### Bug Fix

--- a/packages/eslint-plugin/configs/es5.js
+++ b/packages/eslint-plugin/configs/es5.js
@@ -52,7 +52,7 @@ module.exports = {
 		'no-unreachable': 'error',
 		'no-unsafe-negation': 'error',
 		'no-unused-expressions': 'error',
-		'no-unused-vars': 'error',
+		'no-unused-vars': [ 'error', { ignoreRestSiblings: true } ],
 		'no-useless-return': 'error',
 		'no-whitespace-before-property': 'error',
 		'no-with': 'error',

--- a/packages/eslint-plugin/configs/jshint.js
+++ b/packages/eslint-plugin/configs/jshint.js
@@ -9,7 +9,7 @@ module.exports = {
 		'no-trailing-spaces': 'error',
 		'no-undef': 'error',
 		'no-unused-expressions': 'error',
-		'no-unused-vars': 'error',
+		'no-unused-vars': [ 'error', { ignoreRestSiblings: true } ],
 		'one-var': [ 'error', 'always' ],
 		quotes: [ 'error', 'single' ],
 		'wrap-iife': [ 'error', 'any' ],

--- a/packages/react-native-aztec/src/AztecView.js
+++ b/packages/react-native-aztec/src/AztecView.js
@@ -214,7 +214,6 @@ class AztecView extends Component {
 	}
 
 	render() {
-		// eslint-disable-next-line no-unused-vars
 		const { onActiveFormatsChange, ...otherProps } = this.props;
 		// `style` has to be destructured separately, without `otherProps`, because of:
 		// https://github.com/WordPress/gutenberg/issues/23611

--- a/packages/react-native-editor/src/index.js
+++ b/packages/react-native-editor/src/index.js
@@ -36,7 +36,6 @@ const registerGutenberg = ( {
 		constructor( props ) {
 			super( props );
 
-			// eslint-disable-next-line no-unused-vars
 			const { rootTag, ...parentProps } = this.props;
 
 			// Setup locale.


### PR DESCRIPTION
## What?
This PR enables the `ignoreRestSiblings` option of the `no-unused-vars` ESLint rule in order to allow for declaring unused variables when using spread during destructuring. Previously, we had to ignore that rule to allow this, so this PR cleans those ignores up as well.

## Why?
Declaring a variable in order to spread the rest of the object during destructuring is a common way to omit properties out of objects in modern JavaScript and it should be allowed by our linter.

This came up in a review by @mirka here: https://github.com/WordPress/gutenberg/pull/41865#discussion_r903930787

## How?
We're specifically enabling the `ignoreRestSiblings` option for the `no-unused-vars` rule, and removing all prior rule ignore comments that are no longer necessary.

## Testing Instructions
* Verify there are no new ESLint errors introduced.
* Verify all checks are green.

## Question

@ciampo @mirka we're removing a couple of ESLint rule ignore comments from the components package - does this need a CHANGELOG entry? Let me know, and I'm happy to add one.
