### PR TITLE
Navigation: Move block CSS to JSON

### DIFF
--- a/packages/block-library/src/navigation/block.json
+++ b/packages/block-library/src/navigation/block.json
@@ -114,6 +114,15 @@
 			"default": {
 				"type": "flex"
 			}
+		},
+		"__experimentalStyle": {
+			"elements": {
+				"link": {
+					"color": {
+						"text": "inherit"
+					}
+				}
+			}
 		}
 	},
 	"viewScript": [ "file:./view.min.js", "file:./view-modal.min.js" ],

--- a/packages/block-library/src/navigation/style.scss
+++ b/packages/block-library/src/navigation/style.scss
@@ -44,7 +44,6 @@ $navigation-icon-size: 24px;
 	// By adding low specificity, we enable compatibility with link colors set in theme.json,
 	// but still allow them to be overridden by user-set colors.
 	.wp-block-navigation-item__content {
-		color: inherit;
 		display: block;
 
 		// Set the default menu item padding to zero, to allow text-only buttons.


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
When themes want to override the hover color of the navigation block, this is not possible using theme.json, because this CSS selector is too strong.

The same is true for `textDecoration`.

## Why?
We need to allow themes to set the hover color and text-decoration of links inside the navigation block using theme.json, so it can be edited by users.

## How?
This moves the style rules from the block CSS to JSON.

## Testing Instructions
This needs to be tested alongside this PR: https://github.com/WordPress/gutenberg/pull/41786
You can test using the Stewart theme, and this PR: https://github.com/Automattic/themes/pull/6121
Without this PR, the link hover colors and text-decoration inside the navigation block are inheriting from the link color and text-decoration
With this PR the link hover colors and text-decoration inside the navigation block use the settings from theme.json


## Screenshots or screencast <!-- if applicable -->
Before:
<img width="499" alt="Screenshot 2022-06-23 at 10 01 40" src="https://user-images.githubusercontent.com/275961/175262661-41eaee68-58bf-4ad2-9b25-9bcc4e99b510.png">

After:
<img width="501" alt="Screenshot 2022-06-23 at 10 09 05" src="https://user-images.githubusercontent.com/275961/175262628-77a4f073-4472-4a71-8dfe-907179745169.png">

@WordPress/block-themers 

