### PR TITLE
Make the site editor header toolbar use the ARIA toolbar pattern

### DIFF
--- a/packages/edit-site/src/components/header/index.js
+++ b/packages/edit-site/src/components/header/index.js
@@ -109,7 +109,7 @@ export default function Header( {
 	return (
 		<div className="edit-site-header">
 			<NavigableToolbar
-				className="edit-post-header-toolbar"
+				className="edit-site-header_start"
 				aria-label={ __( 'Document tools' ) }
 			>
 				<div className="edit-site-header__toolbar">

--- a/packages/edit-site/src/components/header/index.js
+++ b/packages/edit-site/src/components/header/index.js
@@ -6,6 +6,7 @@ import { useViewportMatch } from '@wordpress/compose';
 import {
 	ToolSelector,
 	__experimentalPreviewOptions as PreviewOptions,
+	NavigableToolbar,
 } from '@wordpress/block-editor';
 import { useSelect, useDispatch } from '@wordpress/data';
 import { PinnedItems } from '@wordpress/interface';
@@ -107,47 +108,72 @@ export default function Header( {
 
 	return (
 		<div className="edit-site-header">
-			<div className="edit-site-header_start">
+			<NavigableToolbar
+				className="edit-post-header-toolbar"
+				aria-label={ __( 'Document tools' ) }
+			>
 				<div className="edit-site-header__toolbar">
-					<Button
+					<ToolbarItem
 						ref={ inserterButton }
+						as={ Button }
+						className="edit-site-header-toolbar__inserter-toggle"
 						variant="primary"
 						isPressed={ isInserterOpen }
-						className="edit-site-header-toolbar__inserter-toggle"
-						disabled={ ! isVisualMode }
 						onMouseDown={ preventDefault }
 						onClick={ openInserter }
+						disabled={ ! isVisualMode }
 						icon={ plus }
+						/* translators: button label text should, if possible, be under 16
+				characters. */
 						label={ _x(
 							'Toggle block inserter',
 							'Generic label for block inserter button'
 						) }
+						showTooltip={ ! showIconLabels }
 					>
 						{ showIconLabels &&
 							( ! isInserterOpen ? __( 'Add' ) : __( 'Close' ) ) }
-					</Button>
+					</ToolbarItem>
 					{ isLargeViewport && (
 						<>
 							<ToolbarItem
 								as={ ToolSelector }
+								showTooltip={ ! showIconLabels }
+								variant={
+									showIconLabels ? 'tertiary' : undefined
+								}
 								disabled={ ! isVisualMode }
 							/>
-							<UndoButton />
-							<RedoButton />
-							<Button
+							<ToolbarItem
+								as={ UndoButton }
+								showTooltip={ ! showIconLabels }
+								variant={
+									showIconLabels ? 'tertiary' : undefined
+								}
+							/>
+							<ToolbarItem
+								as={ RedoButton }
+								showTooltip={ ! showIconLabels }
+								variant={
+									showIconLabels ? 'tertiary' : undefined
+								}
+							/>
+							<ToolbarItem
+								as={ Button }
 								className="edit-site-header-toolbar__list-view-toggle"
-								disabled={ ! isVisualMode }
 								icon={ listView }
+								disabled={ ! isVisualMode }
 								isPressed={ isListViewOpen }
 								/* translators: button label text should, if possible, be under 16 characters. */
 								label={ __( 'List View' ) }
 								onClick={ toggleListView }
 								shortcut={ listViewShortcut }
+								showTooltip={ ! showIconLabels }
 							/>
 						</>
 					) }
 				</div>
-			</div>
+			</NavigableToolbar>
 
 			<div className="edit-site-header_center">
 				<DocumentActions

--- a/packages/edit-site/src/components/header/style.scss
+++ b/packages/edit-site/src/components/header/style.scss
@@ -16,9 +16,14 @@ $header-toolbar-min-width: 335px;
 		@include reduce-motion("transition");
 	}
 
-	.edit-site-header_start,
+	.edit-site-header_start {
+		display: flex;
+		border: none;
+	}
+
 	.edit-site-header_end {
 		display: flex;
+		justify-content: flex-end;
 	}
 
 	.edit-site-header_center {
@@ -32,10 +37,6 @@ $header-toolbar-min-width: 335px;
 		// subsequently truncate child text, we set an explicit min-width.
 		// See https://dev.w3.org/csswg/css-flexbox/#min-size-auto
 		min-width: 0;
-	}
-
-	.edit-site-header_end {
-		justify-content: flex-end;
 	}
 }
 
@@ -152,6 +153,49 @@ body.is-navigation-sidebar-open {
 	}
 }
 
+.edit-site-header_start {
+	display: flex;
+	border: none;
+
+	// The Toolbar component adds different styles to buttons, so we reset them
+	// here to the original button styles
+	.edit-site-header__toolbar > .components-button.has-icon,
+	.edit-site-header__toolbar > .components-dropdown > .components-button.has-icon {
+		height: $button-size;
+		min-width: $button-size;
+		padding: 6px;
+
+		&.is-pressed {
+			background: $gray-900;
+		}
+
+		&:focus:not(:disabled) {
+			box-shadow: 0 0 0 var(--wp-admin-border-width-focus) var(--wp-admin-theme-color), inset 0 0 0 $border-width $white;
+			outline: 1px solid transparent;
+		}
+
+		&::before {
+			display: none;
+		}
+	}
+
+	.edit-site-header__toolbar > .edit-site-header-toolbar__inserter-toggle.has-icon {
+		margin-right: $grid-unit-10;
+		// Special dimensions for this button.
+		min-width: 32px;
+		width: 32px;
+		height: 32px;
+		padding: 0;
+	}
+
+	.edit-site-header__toolbar > .edit-site-header-toolbar__inserter-toggle.has-text.has-icon {
+		width: auto;
+		padding: 0 $grid-unit-10;
+	}
+
+
+}
+
 // Button text label styles
 
 .show-icon-labels .edit-site-header {
@@ -191,5 +235,9 @@ body.is-navigation-sidebar-open {
 
 		height: 36px;
 		padding: 0 6px;
+	}
+
+	.edit-site-header_start .edit-site-header__toolbar > * + * {
+		margin-left: $grid-unit-10;
 	}
 }

--- a/packages/edit-site/src/components/header/undo-redo/redo.js
+++ b/packages/edit-site/src/components/header/undo-redo/redo.js
@@ -7,8 +7,9 @@ import { useSelect, useDispatch } from '@wordpress/data';
 import { redo as redoIcon, undo as undoIcon } from '@wordpress/icons';
 import { displayShortcut } from '@wordpress/keycodes';
 import { store as coreStore } from '@wordpress/core-data';
+import { forwardRef } from '@wordpress/element';
 
-export default function RedoButton() {
+function RedoButton( props, ref ) {
 	const hasRedo = useSelect(
 		( select ) => select( coreStore ).hasRedo(),
 		[]
@@ -16,6 +17,8 @@ export default function RedoButton() {
 	const { redo } = useDispatch( coreStore );
 	return (
 		<Button
+			{ ...props }
+			ref={ ref }
 			icon={ ! isRTL() ? redoIcon : undoIcon }
 			label={ __( 'Redo' ) }
 			shortcut={ displayShortcut.primaryShift( 'z' ) }
@@ -27,3 +30,5 @@ export default function RedoButton() {
 		/>
 	);
 }
+
+export default forwardRef( RedoButton );

--- a/packages/edit-site/src/components/header/undo-redo/undo.js
+++ b/packages/edit-site/src/components/header/undo-redo/undo.js
@@ -7,8 +7,9 @@ import { useSelect, useDispatch } from '@wordpress/data';
 import { undo as undoIcon, redo as redoIcon } from '@wordpress/icons';
 import { displayShortcut } from '@wordpress/keycodes';
 import { store as coreStore } from '@wordpress/core-data';
+import { forwardRef } from '@wordpress/element';
 
-export default function UndoButton() {
+function UndoButton( props, ref ) {
 	const hasUndo = useSelect(
 		( select ) => select( coreStore ).hasUndo(),
 		[]
@@ -16,6 +17,8 @@ export default function UndoButton() {
 	const { undo } = useDispatch( coreStore );
 	return (
 		<Button
+			{ ...props }
+			ref={ ref }
 			icon={ ! isRTL() ? undoIcon : redoIcon }
 			label={ __( 'Undo' ) }
 			shortcut={ displayShortcut.primary( 'z' ) }
@@ -27,3 +30,5 @@ export default function UndoButton() {
 		/>
 	);
 }
+
+export default forwardRef( UndoButton );


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

Fixes https://github.com/WordPress/gutenberg/issues/41869

## What?
Improves accessibility by making the header toolbar in the Site Editor use the ARIA toolbar pattern. This is consistent with other similar toolbars, e.g. the header toolbar in the Block Editor, in the Edit widgets, Edit navigation, etc.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
The header toolbar in the Site Editor has a different keyboard interaction model compared to other similar toolbars. Also, has different semantics.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
- Wrapped the left part of the header toolbar within a `<NavigableToolbar>` component, similarly to the header in the post editor and other toolbars.
- Changed the toolbar items to `<ToolbarItem>` components. This is necessary to determine whether the toolbar is an 'accessible toolbar' that uses the `<Toolbar>` component.
- Slightly refactored the Undo and Redo buttons to make them compatible with ToolbarItem.
- The `<Toolbar>` component. add some different styles to the buttons, so it was necessary to adjust the CSS. These changes are basically copied from the styles used for the edit post toolbar, see `packages/edit-post/src/components/header/header-toolbar/style.scss`. These changes also improve consistency.

## Testing Instructions
- Go to the Site Editor.
- Use the Tab key to navigate the interface.
- Check the 'Document Tools' toolbar (the one in the screenshot below) has only one tab stop.

<img width="621" alt="Screenshot 2022-06-23 at 12 23 23" src="https://user-images.githubusercontent.com/1682452/175278217-0fe87436-c299-4445-aefc-62f9a0ad7942.png">

- Once focus is on one of the buttons of the toolbar, check you can navigate to the other buttons by using these keys:
  - `Right arrow` to move to the next button.
  - `Left arrow` to move to the previous button.
  - `End` to move to the last button.
  - `Home` to move to the first button.
  - Note: Some keyboards don't have dedicated Home and End keys. They do provide key combinations for them. For example, on a mackbook: Home is `Fn + Left arrow`, End is `Fn + Right arrow`.
- Check the toolbar is wrapped within an element with these HTML attributes:
  - role="toolbar"
  - aria-label="Document Tools"

**Check the style:**
- Compare the header in the Site Editor with the one in the Block editor and check they match as close as possible.
- Check the focus styles when tabbing/arrowing through the buttons/
- Go to Options > Preferences and check the setting 'Show button text labels'.
- The buttons now show text instead of icons: check the style is okay.
- Emulate a mobile device and check the responsive styles are okay, with and without the setting 'Show button text labels'.
- Check for any potential styling glitches.

Note: at some viewport widths, the overall header in the Site Editor would need some work but this is out of the scope of this issue.

## Screenshots or screencast <!-- if applicable -->
