### PR TITLE
Lodash: Remove most of it from `@wordpress/element` package

### DIFF
--- a/packages/element/src/serialize.js
+++ b/packages/element/src/serialize.js
@@ -28,14 +28,7 @@
 /**
  * External dependencies
  */
-import {
-	isEmpty,
-	castArray,
-	omit,
-	startsWith,
-	kebabCase,
-	isPlainObject,
-} from 'lodash';
+import { kebabCase, isPlainObject } from 'lodash';
 
 /**
  * WordPress dependencies
@@ -508,7 +501,7 @@ function getNormalAttributeName( attribute ) {
  * @return {string} Normalized property name.
  */
 function getNormalStylePropertyName( property ) {
-	if ( startsWith( property, '--' ) ) {
+	if ( property.startsWith( '--' ) ) {
 		return property;
 	}
 
@@ -579,7 +572,7 @@ export function renderElement( element, context, legacyContext = {} ) {
 			const { children, ...wrapperProps } = props;
 
 			return renderNativeComponent(
-				isEmpty( wrapperProps ) ? null : 'div',
+				! Object.keys( wrapperProps ).length ? null : 'div',
 				{
 					...wrapperProps,
 					dangerouslySetInnerHTML: { __html: children },
@@ -653,7 +646,9 @@ export function renderNativeComponent(
 		// place of children. Ensure to omit so it is not assigned as attribute
 		// as well.
 		content = renderChildren( props.value, context, legacyContext );
-		props = omit( props, 'value' );
+		// eslint-disable-next-line no-unused-vars
+		const { value, ...restProps } = props;
+		props = restProps;
 	} else if (
 		props.dangerouslySetInnerHTML &&
 		typeof props.dangerouslySetInnerHTML.__html === 'string'
@@ -731,7 +726,7 @@ export function renderComponent(
 function renderChildren( children, context, legacyContext = {} ) {
 	let result = '';
 
-	children = castArray( children );
+	children = Array.isArray( children ) ? children : [ children ];
 
 	for ( let i = 0; i < children.length; i++ ) {
 		const child = children[ i ];


### PR DESCRIPTION
## What?
This PR removes most of the Lodash from the `@wordpress/element` package. We're targeting the more common and easy to convert usages, leaving the rest for another time. 

This PR addresses a big part of #16938.

## Why?

Lodash is known to unnecessarily inflate the bundle size of packages, and in most cases, it can be replaced with native language functionality. See these for more information and rationale:

* https://github.com/WordPress/gutenberg/issues/16938#issuecomment-602837246
* https://github.com/WordPress/gutenberg/issues/17025
* https://github.com/WordPress/gutenberg/issues/39495 

## How?

We're using the built-in `String.prototype.startsWith()` instead of `startsWith()`, `Object.keys().length` to work around the `isEmpty()` usage, destructuring with rest props instead of `omit()`, and `Array.isArray( x ) ? x : [ x ]` instead of `castArray()`.

## Testing Instructions

Verify all tests pass: `npm run test-unit packages/element`

