### PR TITLE
Lodash: Refactor away from `_.values()`

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -115,6 +115,7 @@ module.exports = {
 							'toString',
 							'trim',
 							'uniqWith',
+							'values',
 						],
 						message:
 							'This Lodash method is not recommended. Please use native functionality instead. If using `memoize`, please use `memize` instead.',

--- a/packages/components/src/mobile/segmented-control/index.native.js
+++ b/packages/components/src/mobile/segmented-control/index.native.js
@@ -9,7 +9,6 @@ import {
 	Animated,
 	Easing,
 } from 'react-native';
-import { values, map, reduce } from 'lodash';
 /**
  * WordPress dependencies
  */
@@ -101,10 +100,11 @@ const SegmentedControls = ( {
 		const { paddingLeft: offset } = isIOS
 			? styles.containerIOS
 			: styles.container;
-		const widths = map( values( segmentsDimensions ), 'width' );
+		const widths = Object.values( segmentsDimensions ).map(
+			( dimension ) => dimension.width
+		);
 		const widthsDistance = widths.slice( 0, index );
-		const widthsDistanceSum = reduce(
-			widthsDistance,
+		const widthsDistanceSum = widthsDistance.reduce(
 			( sum, n ) => sum + n
 		);
 

--- a/packages/components/src/mobile/segmented-control/index.native.js
+++ b/packages/components/src/mobile/segmented-control/index.native.js
@@ -105,7 +105,8 @@ const SegmentedControls = ( {
 		);
 		const widthsDistance = widths.slice( 0, index );
 		const widthsDistanceSum = widthsDistance.reduce(
-			( sum, n ) => sum + n
+			( sum, n ) => sum + n,
+			0
 		);
 
 		const endValue = index === 0 ? 0 : widthsDistanceSum;

--- a/packages/edit-post/src/store/selectors.js
+++ b/packages/edit-post/src/store/selectors.js
@@ -2,7 +2,6 @@
  * External dependencies
  */
 import createSelector from 'rememo';
-import { includes, some, values } from 'lodash';
 
 /**
  * WordPress dependencies
@@ -43,8 +42,7 @@ export const isEditorSidebarOpened = createRegistrySelector(
 			select( interfaceStore ).getActiveComplementaryArea(
 				'core/edit-post'
 			);
-		return includes(
-			[ 'edit-post/document', 'edit-post/block' ],
+		return [ 'edit-post/document', 'edit-post/block' ].includes(
 			activeGeneralSidebar
 		);
 	}
@@ -65,8 +63,7 @@ export const isPluginSidebarOpened = createRegistrySelector(
 			);
 		return (
 			!! activeGeneralSidebar &&
-			! includes(
-				[ 'edit-post/document', 'edit-post/block' ],
+			! [ 'edit-post/document', 'edit-post/block' ].includes(
 				activeGeneralSidebar
 			)
 		);
@@ -254,7 +251,7 @@ export function isPublishSidebarOpened( state ) {
  * @return {boolean} Whether or not the panel is removed.
  */
 export function isEditorPanelRemoved( state, panelName ) {
-	return includes( state.removedPanels, panelName );
+	return state.removedPanels.includes( panelName );
 }
 
 /**
@@ -369,7 +366,7 @@ export const getActiveMetaBoxLocations = createSelector(
 export function isMetaBoxLocationVisible( state, location ) {
 	return (
 		isMetaBoxLocationActive( state, location ) &&
-		some( getMetaBoxesPerLocation( state, location ), ( { id } ) => {
+		getMetaBoxesPerLocation( state, location )?.some( ( { id } ) => {
 			return isEditorPanelEnabled( state, `meta-box-${ id }` );
 		} )
 	);
@@ -410,7 +407,7 @@ export function getMetaBoxesPerLocation( state, location ) {
  */
 export const getAllMetaBoxes = createSelector(
 	( state ) => {
-		return values( state.metaBoxes.locations ).flat();
+		return Object.values( state.metaBoxes.locations ).flat();
 	},
 	( state ) => [ state.metaBoxes.locations ]
 );


### PR DESCRIPTION
## What?
Lodash's `values()` is used only a few times in the entire codebase. This PR aims to remove that usage. We also remove a couple of simple usages that are used in the affected files

## Why?
Lodash is known to unnecessarily inflate the bundle size of packages, and in most cases, it can be replaced with native language functionality. See these for more information and rationale:

* https://github.com/WordPress/gutenberg/issues/16938#issuecomment-602837246
* https://github.com/WordPress/gutenberg/issues/17025
* https://github.com/WordPress/gutenberg/issues/39495 

## How?
Removing `_.values()` is straightforward in favor of using `Object.values()`. We're also removing a few Lodash usages that are replaced easily with their native counterparts - `reduce()`, `map()`, `includes()`, and `some()`.

## Testing Instructions

* Verify tests pass: `npm run test-unit packages/edit-post/src/store`
* Follow https://github.com/WordPress/gutenberg/pull/21326#issuecomment-617145882 and make sure segmented controls inside color settings still work well.

## Questions

Since this touches a react native version of a component, should it have a changelog entry @mirka @ciampo?