### PR TITLE
Pasting: Fix performance regression due to removeWindowsFragments

### DIFF
--- a/packages/block-editor/src/components/rich-text/use-paste-handler.js
+++ b/packages/block-editor/src/components/rich-text/use-paste-handler.js
@@ -254,17 +254,26 @@ export function usePasteHandler( props ) {
 }
 
 /**
- * Normalizes a given string of HTML to remove the Windows specific "Fragment" comments
- * and any preceeding and trailing whitespace.
+ * Normalizes a given string of HTML to remove the Windows-specific "Fragment"
+ * comments and any preceeding and trailing content.
  *
  * @param {string} html the html to be normalized
  * @return {string} the normalized html
  */
 function removeWindowsFragments( html ) {
-	const startReg = /.*<!--StartFragment-->/s;
-	const endReg = /<!--EndFragment-->.*/s;
+	const startStr = '<!--StartFragment-->';
+	const startIdx = html.indexOf( startStr );
+	if ( startIdx > -1 ) {
+		html = html.substring( startIdx + startStr.length );
+	}
 
-	return html.replace( startReg, '' ).replace( endReg, '' );
+	const endStr = '<!--EndFragment-->';
+	const endIdx = html.indexOf( endStr );
+	if ( endIdx > -1 ) {
+		html = html.substring( 0, endIdx );
+	}
+
+	return html;
 }
 
 /**

--- a/packages/block-editor/src/components/rich-text/use-paste-handler.js
+++ b/packages/block-editor/src/components/rich-text/use-paste-handler.js
@@ -265,6 +265,9 @@ function removeWindowsFragments( html ) {
 	const startIdx = html.indexOf( startStr );
 	if ( startIdx > -1 ) {
 		html = html.substring( startIdx + startStr.length );
+	} else {
+		// No point looking for EndFragment
+		return html;
 	}
 
 	const endStr = '<!--EndFragment-->';


### PR DESCRIPTION
Fixes #41826.
Alternative to #41881.

In RichText's `usePasteHandler`, `removeWindowsFragments` was running two `String#replace` with regular expressions made computationally expensive due to the use of `.*` and the `s / dotAll` flag, resulting in severe performance degradations when handling larger strings of HTML.

The solution is to manually trim the strings via a combination of `String#indexOf` and `String#substring`.

## Testing Instructions
See parent issue, #41826, confirm that pasting is now reasonably fast (~ 1s) for the attached sample.
