### PR TITLE
Lodash: Refactor away from `_.partialRight()`

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -104,6 +104,7 @@ module.exports = {
 							'noop',
 							'nth',
 							'overEvery',
+							'partialRight',
 							'random',
 							'reverse',
 							'size',

--- a/packages/components/src/dimension-control/README.md
+++ b/packages/components/src/dimension-control/README.md
@@ -11,11 +11,14 @@ This feature is still experimental. “Experimental” means this is an early im
 In a block's `edit` implementation, render a `<DimensionControl />` component.
 
 ```jsx
-import { partialRight } from 'lodash';
-
 import { registerBlockType } from '@wordpress/blocks';
 import { __ } from '@wordpress/i18n';
 import { DimensionControl } from '@wordpress/components';
+
+const partialRight =
+	( fn, ...partialArgs ) =>
+	( ...args ) =>
+		fn( ...args, ...partialArgs );
 
 registerBlockType( 'my-plugin/my-block', {
 	// ...

--- a/packages/format-library/src/link/utils.js
+++ b/packages/format-library/src/link/utils.js
@@ -1,9 +1,4 @@
 /**
- * External dependencies
- */
-import { startsWith, find } from 'lodash';
-
-/**
  * WordPress dependencies
  */
 import {
@@ -47,7 +42,7 @@ export function isValidHref( href ) {
 		// Add some extra checks for http(s) URIs, since these are the most common use-case.
 		// This ensures URIs with an http protocol have exactly two forward slashes following the protocol.
 		if (
-			startsWith( protocol, 'http' ) &&
+			protocol.startsWith( 'http' ) &&
 			! /^https?:\/\/[^\/\s]/i.test( trimmedHref )
 		) {
 			return false;
@@ -75,7 +70,7 @@ export function isValidHref( href ) {
 	}
 
 	// Validate anchor links.
-	if ( startsWith( trimmedHref, '#' ) && ! isValidFragment( trimmedHref ) ) {
+	if ( trimmedHref.startsWith( '#' ) && ! isValidFragment( trimmedHref ) ) {
 		return false;
 	}
 
@@ -146,17 +141,17 @@ export function getFormatBoundary(
 	// Clone formats to avoid modifying source formats.
 	const newFormats = formats.slice();
 
-	const formatAtStart = find( newFormats[ startIndex ], {
-		type: format.type,
-	} );
+	const formatAtStart = newFormats[ startIndex ]?.find(
+		( { type } ) => type === format.type
+	);
 
-	const formatAtEnd = find( newFormats[ endIndex ], {
-		type: format.type,
-	} );
+	const formatAtEnd = newFormats[ endIndex ]?.find(
+		( { type } ) => type === format.type
+	);
 
-	const formatAtEndMinusOne = find( newFormats[ endIndex - 1 ], {
-		type: format.type,
-	} );
+	const formatAtEndMinusOne = newFormats[ endIndex - 1 ]?.find(
+		( { type } ) => type === format.type
+	);
 
 	if ( !! formatAtStart ) {
 		// Set values to conform to "start"

--- a/packages/format-library/src/link/utils.js
+++ b/packages/format-library/src/link/utils.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { startsWith, find, partialRight } from 'lodash';
+import { startsWith, find } from 'lodash';
 
 /**
  * WordPress dependencies
@@ -238,6 +238,11 @@ function walkToBoundary(
 
 	return index;
 }
+
+const partialRight =
+	( fn, ...partialArgs ) =>
+	( ...args ) =>
+		fn( ...args, ...partialArgs );
 
 const walkToStart = partialRight( walkToBoundary, 'backwards' );
 


### PR DESCRIPTION
## What?
Lodash's `partialRight()` is used only a couple of times in the entire codebase, and one of them is in the documentation. This PR aims to remove that usage.

## Why?
Lodash is known to unnecessarily inflate the bundle size of packages, and in most cases, it can be replaced with native language functionality. See these for more information and rationale:

* https://github.com/WordPress/gutenberg/issues/16938#issuecomment-602837246
* https://github.com/WordPress/gutenberg/issues/17025
* https://github.com/WordPress/gutenberg/issues/39495 

## How?
Removing `_.partialRight()` is straightforward in favor of a custom implementation that creates a function that appends custom arguments after the ones with which the function was originally called.

We're also removing a `startsWith()` and a `find()` that are easily replaceable with native corresponding functionality and well-covered by tests.

## Testing Instructions

Verify tests pass: `npm run test-unit packages/format-library`

## Questions
This touches the docs of a component, so should it include a changelog entry @mirka @ciampo?