### PR TITLE
Format Library: Add keyboard shortcut for Strikethrough

### DIFF
--- a/packages/customize-widgets/src/components/keyboard-shortcut-help-modal/config.js
+++ b/packages/customize-widgets/src/components/keyboard-shortcut-help-modal/config.js
@@ -28,4 +28,8 @@ export const textFormattingShortcuts = [
 		keyCombination: { modifier: 'primary', character: 'u' },
 		description: __( 'Underline the selected text.' ),
 	},
+	{
+		keyCombination: { modifier: 'access', character: 'd' },
+		description: __( 'Strikethrough the selected text.' ),
+	},
 ];

--- a/packages/edit-post/src/components/keyboard-shortcut-help-modal/config.js
+++ b/packages/edit-post/src/components/keyboard-shortcut-help-modal/config.js
@@ -29,6 +29,10 @@ export const textFormattingShortcuts = [
 		description: __( 'Underline the selected text.' ),
 	},
 	{
+		keyCombination: { modifier: 'access', character: 'd' },
+		description: __( 'Strikethrough the selected text.' ),
+	},
+	{
 		keyCombination: { modifier: 'access', character: 'x' },
 		description: __( 'Make the selected text inline code.' ),
 	},

--- a/packages/edit-post/src/components/keyboard-shortcut-help-modal/test/__snapshots__/index.js.snap
+++ b/packages/edit-post/src/components/keyboard-shortcut-help-modal/test/__snapshots__/index.js.snap
@@ -83,6 +83,13 @@ exports[`KeyboardShortcutHelpModal should match snapshot when the modal is activ
           },
         },
         Object {
+          "description": "Strikethrough the selected text.",
+          "keyCombination": Object {
+            "character": "d",
+            "modifier": "access",
+          },
+        },
+        Object {
           "description": "Make the selected text inline code.",
           "keyCombination": Object {
             "character": "x",

--- a/packages/edit-site/src/components/keyboard-shortcut-help-modal/config.js
+++ b/packages/edit-site/src/components/keyboard-shortcut-help-modal/config.js
@@ -29,6 +29,10 @@ export const textFormattingShortcuts = [
 		description: __( 'Underline the selected text.' ),
 	},
 	{
+		keyCombination: { modifier: 'access', character: 'd' },
+		description: __( 'Strikethrough the selected text.' ),
+	},
+	{
 		keyCombination: { modifier: 'access', character: 'x' },
 		description: __( 'Make the selected text inline code.' ),
 	},

--- a/packages/edit-widgets/src/components/keyboard-shortcut-help-modal/config.js
+++ b/packages/edit-widgets/src/components/keyboard-shortcut-help-modal/config.js
@@ -29,6 +29,10 @@ export const textFormattingShortcuts = [
 		description: __( 'Underline the selected text.' ),
 	},
 	{
+		keyCombination: { modifier: 'access', character: 'd' },
+		description: __( 'Strikethrough the selected text.' ),
+	},
+	{
 		keyCombination: { modifier: 'access', character: 'x' },
 		description: __( 'Make the selected text inline code.' ),
 	},

--- a/packages/format-library/src/strikethrough/index.js
+++ b/packages/format-library/src/strikethrough/index.js
@@ -3,7 +3,10 @@
  */
 import { __ } from '@wordpress/i18n';
 import { toggleFormat } from '@wordpress/rich-text';
-import { RichTextToolbarButton } from '@wordpress/block-editor';
+import {
+	RichTextToolbarButton,
+	RichTextShortcut,
+} from '@wordpress/block-editor';
 import { formatStrikethrough } from '@wordpress/icons';
 
 const name = 'core/strikethrough';
@@ -21,13 +24,20 @@ export const strikethrough = {
 		}
 
 		return (
-			<RichTextToolbarButton
-				icon={ formatStrikethrough }
-				title={ title }
-				onClick={ onClick }
-				isActive={ isActive }
-				role="menuitemcheckbox"
-			/>
+			<>
+				<RichTextShortcut
+					type="access"
+					character="d"
+					onUse={ onClick }
+				/>
+				<RichTextToolbarButton
+					icon={ formatStrikethrough }
+					title={ title }
+					onClick={ onClick }
+					isActive={ isActive }
+					role="menuitemcheckbox"
+				/>
+			</>
 		);
 	},
 };


### PR DESCRIPTION
## What?
Similar to #41816.

PR adds the missing keyboard shortcut of the "Strikethrough" format. It matches the shortcut documented in [Keyboards Shortcuts](https://wordpress.org/support/article/keyboard-shortcuts/) support page - `ctrl-alt-d` on MacOS and `alt-shift-d` on Windows/Linux.

## Testing Instructions
1. Open a Post or Page.
2. Insert a Paragraph block and add text.
3. Select text and use the new shortcut to apply the "Strikethrough" format.
