### PR TITLE
Add Playwright tests for WordPress navigation

### DIFF
--- a/packages/e2e-test-utils-playwright/src/request-utils/index.ts
+++ b/packages/e2e-test-utils-playwright/src/request-utils/index.ts
@@ -18,7 +18,7 @@ import { getPluginsMap, activatePlugin, deactivatePlugin } from './plugins';
 import { deleteAllTemplates } from './templates';
 import { activateTheme } from './themes';
 import { deleteAllBlocks } from './blocks';
-import { deleteAllPosts } from './posts';
+import { createNewPage, deleteAllPosts } from './posts';
 import { resetPreferences } from './preferences';
 import { deleteAllWidgets, addWidgetBlock } from './widgets';
 
@@ -127,6 +127,7 @@ class RequestUtils {
 	uploadMedia = uploadMedia;
 	deleteMedia = deleteMedia;
 	deleteAllMedia = deleteAllMedia;
+	createNewPage = createNewPage;
 }
 
 export type { StorageState };

--- a/packages/e2e-test-utils-playwright/src/request-utils/index.ts
+++ b/packages/e2e-test-utils-playwright/src/request-utils/index.ts
@@ -18,7 +18,7 @@ import { getPluginsMap, activatePlugin, deactivatePlugin } from './plugins';
 import { deleteAllTemplates } from './templates';
 import { activateTheme } from './themes';
 import { deleteAllBlocks } from './blocks';
-import { createNewPage, deleteAllPosts } from './posts';
+import { createNewPage, deleteAllPosts, deletePage } from './posts';
 import { resetPreferences } from './preferences';
 import { deleteAllWidgets, addWidgetBlock } from './widgets';
 
@@ -128,6 +128,7 @@ class RequestUtils {
 	deleteMedia = deleteMedia;
 	deleteAllMedia = deleteAllMedia;
 	createNewPage = createNewPage;
+	deletePage = deletePage;
 }
 
 export type { StorageState };

--- a/packages/e2e-test-utils-playwright/src/request-utils/posts.js
+++ b/packages/e2e-test-utils-playwright/src/request-utils/posts.js
@@ -3,6 +3,27 @@
  *
  * @this {import('./index').RequestUtils}
  */
+
+export async function createNewPage( title, status = 'draft' ) {
+	const post = await this.rest( {
+		method: 'POST',
+		path: '/wp/v2/pages',
+		params: {
+			title,
+			status,
+		},
+	} );
+
+	return post;
+}
+
+export async function deletePage( id ) {
+	await this.rest( {
+		method: 'DELETE',
+		path: `/wp/v2/pages/${ id }`,
+	} );
+}
+
 export async function deleteAllPosts() {
 	// List all posts.
 	// https://developer.wordpress.org/rest-api/reference/posts/#list-posts

--- a/test/e2e/specs/various/menu.spec.js
+++ b/test/e2e/specs/various/menu.spec.js
@@ -33,7 +33,7 @@ test.describe( 'Classic menus', () => {
 
 		await page.click( `[aria-label="Most Recent"] >> text=${ pageTitle }` );
 
-		await page.locator( 'input[name="add-post-type-menu-item"]' ).click();
+		await page.locator( '#submit-posttype-page' ).click();
 
 		await expect(
 			page.locator( '#menu-to-edit .menu-item-title' )

--- a/test/e2e/specs/various/menu.spec.js
+++ b/test/e2e/specs/various/menu.spec.js
@@ -1,0 +1,63 @@
+/**
+ * WordPress dependencies
+ */
+const { test, expect } = require( '@wordpress/e2e-test-utils-playwright' );
+
+test.describe( 'Classic menus', () => {
+	test( 'When a menu item is active, it should have the .current-menu-item class name', async ( {
+		admin,
+		page,
+		requestUtils,
+	} ) => {
+		const random = getRandomInt( 9999 );
+		const pageTitle = `Page ${ random }`;
+
+		const newPage = await requestUtils.createNewPage(
+			pageTitle,
+			'publish'
+		);
+
+		// Create a new menu
+		await admin.visitAdminPage( 'nav-menus.php?menu=0' );
+		await page.type(
+			'role=textbox[name="Menu Name"i]',
+			`Menu ${ random }`
+		);
+		await page.check( '#locations-primary' );
+
+		await page.locator( '#save_menu_footer' ).focus();
+		await Promise.all( [
+			page.waitForNavigation(),
+			page.locator( '#save_menu_footer' ).click(),
+		] );
+
+		await page.click( `[aria-label="Most Recent"] >> text=${ pageTitle }` );
+
+		await page.locator( 'input[name="add-post-type-menu-item"]' ).click();
+
+		await expect(
+			page.locator( '#menu-to-edit .menu-item-title' )
+		).toContainText( `${ pageTitle }` );
+
+		await page.locator( '#save_menu_footer' ).focus();
+		await Promise.all( [
+			page.waitForNavigation(),
+			page.locator( '#save_menu_footer' ).click(),
+		] );
+
+		// Go to the created page
+		await page.goto( newPage.guid.rendered );
+
+		// Check that the menu item has the class name .current-menu-item
+		await expect(
+			page.locator( `.page-item-${ newPage.id }` )
+		).toHaveClass( /current-menu-item/ );
+
+		// Delete the page
+		await requestUtils.deletePage( newPage.id );
+	} );
+} );
+
+function getRandomInt( max ) {
+	return Math.floor( Math.random() * max );
+}


### PR DESCRIPTION
## What?
Part of https://github.com/WordPress/gutenberg/issues/38851. Initial tests for the WordPress menu.

This should ultimately be part of WordPress Core.

## Why?

See this [post](https://make.wordpress.org/core/2022/03/23/migrating-wordpress-e2e-tests-to-playwright/) for an overview of the migration.

## How?
By following the [migration guide](https://github.com/WordPress/gutenberg/blob/HEAD/test/e2e/MIGRATION.md).

## Testing Instructions
```sh
npm run test-e2e:playwright -- /test/e2e/specs/various/menu.spec.js
```

---

This PR will help to move https://github.com/WordPress/gutenberg/pull/40778#pullrequestreview-996469968 forward. It includes only the test for the `.current-menu-item` class.
