### PR TITLE
Widgets Editor: Improve action button spacing

### DIFF
--- a/packages/edit-widgets/src/components/header/style.scss
+++ b/packages/edit-widgets/src/components/header/style.scss
@@ -25,18 +25,12 @@
 
 .edit-widgets-header__actions {
 	display: flex;
+	align-items: center;
 
-	.components-button {
-		margin-right: $grid-unit-05;
+	gap: $grid-unit-05;
 
-		@include break-small() {
-			margin-right: $grid-unit-15;
-		}
-	}
-
-	.edit-widgets-more-menu .components-button,
-	.interface-pinned-items .components-button {
-		margin-right: 0;
+	@include break-small() {
+		gap: $grid-unit-10;
 	}
 }
 


### PR DESCRIPTION
## What?
A follow-up to #40411.

PR updates the button spacing in the right corner of Widgets Editor to match recent improvements to other editors.

## Testing Instructions
1. Activate a Classic theme.
2. Open Widgets editor.
3. Confirm that button spacing in the right corner matches Post Editor or Site Editor.

## Screenshots or screencast <!-- if applicable -->
| Before | After |
| --- | --- |
|![CleanShot 2022-06-23 at 20 04 31](https://user-images.githubusercontent.com/240569/175344909-d2ee7905-881f-4b69-851b-1048578ded4d.png)|![CleanShot 2022-06-23 at 20 03 28](https://user-images.githubusercontent.com/240569/175344925-34278cca-91f9-47b1-82a6-29c8b7999ac8.png)|


