### PR TITLE
Block Library: Fix Prettier error

### DIFF
--- a/packages/block-library/src/list-item/hooks/use-outdent-list-item.js
+++ b/packages/block-library/src/list-item/hooks/use-outdent-list-item.js
@@ -29,9 +29,8 @@ export default function useOutdentListItem( clientId ) {
 		},
 		[ clientId ]
 	);
-	const { replaceBlocks, selectionChange, multiSelect } = useDispatch(
-		blockEditorStore
-	);
+	const { replaceBlocks, selectionChange, multiSelect } =
+		useDispatch( blockEditorStore );
 	const {
 		getBlockRootClientId,
 		getBlockAttributes,


### PR DESCRIPTION
## What?
PR fixes Prettier error introduced via #41713.

```
error  Replace `·useDispatch(⏎↹↹blockEditorStore⏎↹` with `⏎↹↹useDispatch(·blockEditorStore·`  prettier/prettier
```

I think the original branch required rebasing after #40542 was merged.

## Testing Instructions
Static Analysis should be passing
