### PR TITLE
Color Controls: Allow popovers to remain within smaller viewports

### DIFF
--- a/packages/block-editor/src/components/colors-gradients/dropdown.js
+++ b/packages/block-editor/src/components/colors-gradients/dropdown.js
@@ -114,6 +114,7 @@ export default function ColorGradientSettingsDropdown( {
 		popoverProps = {
 			placement: 'left-start',
 			offset: 36,
+			__unstableShift: true,
 		};
 	}
 


### PR DESCRIPTION
Fixes: https://github.com/WordPress/gutenberg/issues/41894

## What?

Allows color control popovers from the Inspector Controls sidebar to remain within smaller viewports.

_Note: This PR only restores the visibility and usability of the color control popovers. There is some ongoing work around better positioning after the floatingUI changes. Once that settles we can improve the color popover positioning as a follow-up._


## Why?

After the recent switch of popovers to use the floatingUI library (https://github.com/WordPress/gutenberg/pull/40740) the color controls were offset to outside the sidebar. This placement and offset meant the popover was outside the viewport when the sidebar becomes a full-width overlay on smaller viewports.

## How?

Toggles on the `__unstableShift` Popover prop so that if the popover falls outside the viewport it is automatically repositioned.

## Testing Instructions

1. Prior to checking out this PR, edit a post and narrow your viewport to a mobile size where the sidebar becomes full-width
2. Open the block inspector controls and confirm that you cannot see the color controls popover when clicking them
3. Checkout this PR and repeat the process confirming that the color popover is now usable

## Screenshots or screencast <!-- if applicable -->

| Before | After |
|---|---|
| <video src="https://user-images.githubusercontent.com/60436221/175482451-5f7c9fa1-1ae9-4cdf-81db-0c4086ed01af.mp4" /> | <video src="https://user-images.githubusercontent.com/60436221/175482467-9b7e27d7-2eba-44be-8c7d-6481e77481d1.mp4" /> |



