### PR TITLE
Border Controls/Color Palette: Ensure popovers remain within small viewports

### DIFF
--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -10,8 +10,8 @@
 
 -   Wrapped `ColorIndicator` in a `forwardRef` call ([#41587](https://github.com/WordPress/gutenberg/pull/41587)).
 -   `BorderControl`: Improve TypeScript support. ([#41843](https://github.com/WordPress/gutenberg/pull/41843)).
--   `DatePicer`: highlight today's date. ([#41647](https://github.com/WordPress/gutenberg/pull/41647/)).
--   `BorderBoxControl`: Allow border popover to remain within smaller viewports ([#41930](https://github.com/WordPress/gutenberg/pull/41930)).
+-   `DatePicker`: highlight today's date. ([#41647](https://github.com/WordPress/gutenberg/pull/41647/)).
+-   Allow automatic repositioning of `BorderBoxControl` and `ColorPalette` popovers within smaller viewports ([#41930](https://github.com/WordPress/gutenberg/pull/41930)).
 
 ### Internal
 

--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -11,6 +11,7 @@
 -   Wrapped `ColorIndicator` in a `forwardRef` call ([#41587](https://github.com/WordPress/gutenberg/pull/41587)).
 -   `BorderControl`: Improve TypeScript support. ([#41843](https://github.com/WordPress/gutenberg/pull/41843)).
 -   `DatePicer`: highlight today's date. ([#41647](https://github.com/WordPress/gutenberg/pull/41647/)).
+-   `BorderBoxControl`: Allow border popover to remain within smaller viewports ([#41930](https://github.com/WordPress/gutenberg/pull/41930)).
 
 ### Internal
 

--- a/packages/components/src/border-box-control/border-box-control-split-controls/component.tsx
+++ b/packages/components/src/border-box-control/border-box-control-split-controls/component.tsx
@@ -43,6 +43,7 @@ const BorderBoxControlSplitControls = (
 				placement: popoverPlacement,
 				offset: popoverOffset,
 				anchorRef: containerRef,
+				__unstableShift: true,
 		  }
 		: undefined;
 

--- a/packages/components/src/border-box-control/border-box-control/component.tsx
+++ b/packages/components/src/border-box-control/border-box-control/component.tsx
@@ -69,6 +69,7 @@ const BorderBoxControl = (
 				placement: popoverPlacement,
 				offset: popoverOffset,
 				anchorRef: containerRef,
+				__unstableShift: true,
 		  }
 		: undefined;
 

--- a/packages/components/src/color-palette/index.js
+++ b/packages/components/src/color-palette/index.js
@@ -118,7 +118,11 @@ export function CustomColorPickerDropdown( { isRenderedInSidebar, ...props } ) {
 			contentClassName="components-color-palette__custom-color-dropdown-content"
 			popoverProps={
 				isRenderedInSidebar
-					? { placement: 'left-start', offset: 20 }
+					? {
+							placement: 'left-start',
+							offset: 20,
+							__unstableShift: true,
+					  }
 					: undefined
 			}
 			{ ...props }


### PR DESCRIPTION
Related:
- https://github.com/WordPress/gutenberg/issues/41894
- https://github.com/WordPress/gutenberg/pull/41929

## What?

Ensures that BorderControl and BorderBoxControl popovers are positioned within smaller viewports.

**Note: The automatic repositioning of popovers since the floatingUI changes is a little clunky. This PR only aims to restore the popovers to the viewport so they are usable until we refine the popover behaviour more generally.**

## Why?

After the switch to using floatingUI library for Popovers, they aren't repositioned by default when they fall outside the viewport. Without this the popovers are unusable.

## How?

Turns on `__unstableShift` for the border control popovers as well as the custom color picker popover.

## Testing Instructions
1. Edit a post and reduce the viewport down to a mobile-like size
2. Select a block that supports borders e.g. Group
3. Open the inspector controls sidebar and click on the border controls and toggle on their popovers, they should now be within the viewport.

## Screenshots or screencast <!-- if applicable -->

| Before | After |
|---|---|
| <video src="https://user-images.githubusercontent.com/60436221/176333822-f8103c0b-2ade-4aaa-95f7-cd03821a3dd5.mp4" /> | <video src="https://user-images.githubusercontent.com/60436221/176333828-e630cbf6-a626-4f99-b72a-6603affcaa8f.mp4" /> |


