### PR TITLE
Elements: lower specificity of elements block css

### DIFF
--- a/lib/compat/wordpress-6.1/class-wp-theme-json-6-1.php
+++ b/lib/compat/wordpress-6.1/class-wp-theme-json-6-1.php
@@ -291,7 +291,7 @@ class WP_Theme_JSON_6_1 extends WP_Theme_JSON_6_0 {
 					// to an array, so that the block selector is added to both parts of the selector.
 					$el_selectors = explode( ',', $el_selector );
 					foreach ( $el_selectors as $el_selector_item ) {
-						$element_selector[] = $selector . ' ' . $el_selector_item;
+						$element_selector[] = $selector . ' :where(' . $el_selector_item . ')';
 					}
 				}
 				static::$blocks_metadata[ $block_name ]['elements'][ $el_name ] = implode( ',', $element_selector );

--- a/lib/compat/wordpress-6.1/class-wp-theme-json-6-1.php
+++ b/lib/compat/wordpress-6.1/class-wp-theme-json-6-1.php
@@ -291,7 +291,7 @@ class WP_Theme_JSON_6_1 extends WP_Theme_JSON_6_0 {
 					// to an array, so that the block selector is added to both parts of the selector.
 					$el_selectors = explode( ',', $el_selector );
 					foreach ( $el_selectors as $el_selector_item ) {
-						$element_selector[] = $selector . ' :where(' . $el_selector_item . ')';
+						$element_selector[] = $selector . ' ' . $el_selector_item;
 					}
 				}
 				static::$blocks_metadata[ $block_name ]['elements'][ $el_name ] = implode( ',', $element_selector );

--- a/packages/block-library/src/file/block.json
+++ b/packages/block-library/src/file/block.json
@@ -56,16 +56,7 @@
 	},
 	"supports": {
 		"anchor": true,
-		"align": true,
-		"__experimentalStyle": {
-			"elements": {
-				"button": {
-					"typography": {
-						"fontSize": "0.8em"
-					}
-				}
-			}
-		}
+		"align": true
 	},
 	"viewScript": "file:./view.min.js",
 	"editorStyle": "wp-block-file-editor",

--- a/packages/block-library/src/file/style.scss
+++ b/packages/block-library/src/file/style.scss
@@ -1,6 +1,10 @@
 .wp-block-file {
 	margin-bottom: 1.5em;
 
+	&:not(.wp-element-button) {
+		font-size: 0.8em;
+	}
+
 	&.aligncenter {
 		text-align: center;
 	}


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->
This PR fixes an issue with the default font size defined for the file block not being overridden by theme.json button element rules.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
After https://github.com/WordPress/gutenberg/pull/41822 got merged, the block.json defaults where generating a CSS that was more specific than the one generated by a themes theme.json file for the same element, so it was always being applied.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
I removed the default font size definition and moved it to the CSS, and made it only apply to non element file buttons.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->

On a block theme add this to theme.json:

```
"elements": {
            "button": {
				"typography": {
                                           "fontSize": "2em"
				}
            }
}
```

Insert a file block and check the font size of the button. Without this PR it's always 0.8em, with this PR it should apply what's on theme.json.

If the block doesn't have the `.wp-element-button` class, the 0.8em should be applying, keeping backward compat.


## Screenshots or screencast <!-- if applicable -->

Before:
<img width="679" alt="Screenshot 2022-06-24 at 09 44 23" src="https://user-images.githubusercontent.com/3593343/175492367-df616e01-f909-4884-b6c1-c4ff66b6ccac.png">


After:


<img width="664" alt="Screenshot 2022-06-24 at 09 55 52" src="https://user-images.githubusercontent.com/3593343/175492358-ab4e4775-6c2b-4a92-b6aa-dbe47bc2ee8e.png">
