### PR TITLE
Update Theme JSON `$schema` to account for pseudo selector support

### DIFF
--- a/schemas/json/theme.json
+++ b/schemas/json/theme.json
@@ -915,21 +915,24 @@
 			"properties": {
 				"link": {
 					"type": "object",
-					"anyOf": [
+					"allOf": [
 						{
-							"$ref": "#/definitions/stylesPropertiesComplete"
+							"$ref": "#/definitions/stylesProperties"
 						},
 						{
-							"type": "object",
 							"properties": {
+								"border": {},
+								"color": {},
+								"spacing": {},
+								"typography": {},
 								":hover": {
-									"$ref": "#/definitions/stylesProperties"
+									"$ref": "#/definitions/stylesPropertiesComplete"
 								},
 								":focus": {
-									"$ref": "#/definitions/stylesProperties"
+									"$ref": "#/definitions/stylesPropertiesComplete"
 								},
 								":active": {
-									"$ref": "#/definitions/stylesProperties"
+									"$ref": "#/definitions/stylesPropertiesComplete"
 								}
 							},
 							"additionalProperties": false

--- a/schemas/json/theme.json
+++ b/schemas/json/theme.json
@@ -909,11 +909,32 @@
 				}
 			]
 		},
+
 		"stylesElementsPropertiesComplete": {
 			"type": "object",
 			"properties": {
 				"link": {
-					"$ref": "#/definitions/stylesPropertiesComplete"
+					"type": "object",
+					"anyOf": [
+						{
+							"$ref": "#/definitions/stylesPropertiesComplete"
+						},
+						{
+							"type": "object",
+							"properties": {
+								":hover": {
+									"$ref": "#/definitions/stylesProperties"
+								},
+								":focus": {
+									"$ref": "#/definitions/stylesProperties"
+								},
+								":active": {
+									"$ref": "#/definitions/stylesProperties"
+								}
+							},
+							"additionalProperties": false
+						}
+					]
 				},
 				"h1": {
 					"$ref": "#/definitions/stylesPropertiesComplete"


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
In https://github.com/WordPress/gutenberg/pull/41786 we added pseudo selector support to Theme JSON. We now need to update the `schema` for Theme JSON so we get accurate feedback in code editors such as Visual Studio Code.

When working on this PR you might like to reference: https://json-schema.org/understanding-json-schema/

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

We need good develop experience

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

Update the schema for `elements` both at the top level and inside blocks to know about the valid `pseudo` selectors - `:hover`, `:focus`, and `:active` on the `link` element only.

Note that this introduces some duplication in under the `stylesElementsPropertiesComplete.properties.link.allOf[1].properties` object where

```
"border": {},
"color": {},
"spacing": {},
"typography": {},
```

is effectively duplicating `stylesPropertiesComplete`.

@adamziel and I spent some time trying to work out a way to DRY this up, but the way `additionalProperties` locks things down for extension seems to preclude the possibility of achieving this.

In the future as more elements start to allow pseudo elements we may need to DRY the schema up more but for now this is good enough.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->

1. Activate a Theme which you can modify locally.
2. Open the Theme's `theme.json` file and update the `$schema` to point to your local Gutenberg version do the schema file (e.g. `"$schema": "file:///Users/{{YOUR_USER}}/Sites/gutenberg/schemas/json/theme.json"`).
3. Add some pseudo selector rules under `elements.link` and `{{BLOCK_NAME}}.elements.link` and check your IDE doesn't complain to you.
4. Add some invalid pseudo selectors and check it does complain.
5. Add some pseudo rules under an element which is _not_ `link` and check it complains.

## Screenshots or screencast <!-- if applicable -->
