### PR TITLE
Lodash: Refactor away from `_.once()`

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -103,6 +103,7 @@ module.exports = {
 							'negate',
 							'noop',
 							'nth',
+							'once',
 							'overEvery',
 							'partialRight',
 							'random',

--- a/packages/editor/src/components/local-autosave-monitor/index.js
+++ b/packages/editor/src/components/local-autosave-monitor/index.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { once, uniqueId, omit } from 'lodash';
+import { uniqueId, omit } from 'lodash';
 
 /**
  * WordPress dependencies
@@ -27,23 +27,28 @@ const requestIdleCallback = window.requestIdleCallback
 	? window.requestIdleCallback
 	: window.requestAnimationFrame;
 
+let hasStorageSupport;
 /**
  * Function which returns true if the current environment supports browser
  * sessionStorage, or false otherwise. The result of this function is cached and
  * reused in subsequent invocations.
  */
-const hasSessionStorageSupport = once( () => {
-	try {
-		// Private Browsing in Safari 10 and earlier will throw an error when
-		// attempting to set into sessionStorage. The test here is intentional in
-		// causing a thrown error as condition bailing from local autosave.
-		window.sessionStorage.setItem( '__wpEditorTestSessionStorage', '' );
-		window.sessionStorage.removeItem( '__wpEditorTestSessionStorage' );
-		return true;
-	} catch ( error ) {
-		return false;
+const hasSessionStorageSupport = () => {
+	if ( typeof hasStorageSupport === 'undefined' ) {
+		try {
+			// Private Browsing in Safari 10 and earlier will throw an error when
+			// attempting to set into sessionStorage. The test here is intentional in
+			// causing a thrown error as condition bailing from local autosave.
+			window.sessionStorage.setItem( '__wpEditorTestSessionStorage', '' );
+			window.sessionStorage.removeItem( '__wpEditorTestSessionStorage' );
+			hasStorageSupport = true;
+		} catch ( error ) {
+			hasStorageSupport = false;
+		}
 	}
-} );
+
+	return hasStorageSupport;
+};
 
 /**
  * Custom hook which manages the creation of a notice prompting the user to


### PR DESCRIPTION
## What?
Lodash's `once()` is used only once in the entire codebase. This PR aims to remove that usage.

## Why?
Lodash is known to unnecessarily inflate the bundle size of packages, and in most cases, it can be replaced with native language functionality. See these for more information and rationale:

* https://github.com/WordPress/gutenberg/issues/16938#issuecomment-602837246
* https://github.com/WordPress/gutenberg/issues/17025
* https://github.com/WordPress/gutenberg/issues/39495 

## How?
Removing `_.once()` is straightforward in favor of a custom implementation that executes the code, and stores a result in an extra variable, in order to use that variable instead of executing the code on subsequent invocation.

## Testing Instructions

As you edit a post but don't save, verify autosaving still works. You can check on the session storage in your browser's dev tools - an item with this key should be created: `wp-autosave-block-editor-post-ID` where `ID` is the ID of the post.