### PR TITLE
Lodash: Refactor away from `_.truncate()`

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -115,6 +115,7 @@ module.exports = {
 							'take',
 							'toString',
 							'trim',
+							'truncate',
 							'uniqWith',
 							'values',
 						],

--- a/packages/block-editor/src/components/block-title/use-block-display-title.js
+++ b/packages/block-editor/src/components/block-title/use-block-display-title.js
@@ -1,9 +1,4 @@
 /**
- * External dependencies
- */
-import { truncate } from 'lodash';
-
-/**
  * WordPress dependencies
  */
 import { useSelect } from '@wordpress/data';
@@ -78,8 +73,15 @@ export default function useBlockDisplayTitle( clientId, maximumLength ) {
 	const blockTitle =
 		label && label !== blockType.title ? label : blockInformation.title;
 
-	if ( maximumLength && maximumLength > 0 ) {
-		return truncate( blockTitle, { length: maximumLength } );
+	if (
+		maximumLength &&
+		maximumLength > 0 &&
+		blockTitle.length > maximumLength
+	) {
+		const omission = '...';
+		return (
+			blockTitle.slice( 0, maximumLength - omission.length ) + omission
+		);
 	}
 
 	return blockTitle;


### PR DESCRIPTION
## What?
Lodash's `truncate()` is used only once in the entire codebase. This PR aims to remove that usage.

## Why?
Lodash is known to unnecessarily inflate the bundle size of packages, and in most cases, it can be replaced with native language functionality. See these for more information and rationale:

* https://github.com/WordPress/gutenberg/issues/16938#issuecomment-602837246
* https://github.com/WordPress/gutenberg/issues/17025
* https://github.com/WordPress/gutenberg/issues/39495 

## How?
Removing `_.truncate()` is straightforward in favor of a custom implementation that truncates the string to the specified limit if the string is longer, and if that's the case, appends an ellipsis.

## Testing Instructions

Verify tests still pass: `npm run test-unit packages/block-editor/src/components/block-title`