### PR TITLE
Duplicate query in `render_block_core_post_template`

### DIFF
--- a/packages/block-library/src/post-template/index.php
+++ b/packages/block-library/src/post-template/index.php
@@ -44,23 +44,15 @@ function render_block_core_post_template( $attributes, $content, $block ) {
 	$page_key = isset( $block->context['queryId'] ) ? 'query-' . $block->context['queryId'] . '-page' : 'query-page';
 	$page     = empty( $_GET[ $page_key ] ) ? 1 : (int) $_GET[ $page_key ];
 
-	$query_args = build_query_vars_from_query_block( $block, $page );
 	// Override the custom query with the global query if needed.
 	$use_global_query = ( isset( $block->context['query']['inherit'] ) && $block->context['query']['inherit'] );
 	if ( $use_global_query ) {
 		global $wp_query;
-		if ( $wp_query && isset( $wp_query->query_vars ) && is_array( $wp_query->query_vars ) ) {
-			// Unset `offset` because if is set, $wp_query overrides/ignores the paged parameter and breaks pagination.
-			unset( $query_args['offset'] );
-			$query_args = wp_parse_args( $wp_query->query_vars, $query_args );
-
-			if ( empty( $query_args['post_type'] ) && is_singular() ) {
-				$query_args['post_type'] = get_post_type( get_the_ID() );
-			}
-		}
+		$query = $wp_query;
+	} else {
+		$query_args = build_query_vars_from_query_block( $block, $page );
+		$query      = new WP_Query( $query_args );
 	}
-
-	$query = new WP_Query( $query_args );
 
 	if ( ! $query->have_posts() ) {
 		return '';
@@ -95,7 +87,9 @@ function render_block_core_post_template( $attributes, $content, $block ) {
 		$content      .= '<li class="' . esc_attr( $post_classes ) . '">' . $block_content . '</li>';
 	}
 
-	wp_reset_postdata();
+	if ( ! $use_global_query ) {
+		wp_reset_postdata();
+	}
 
 	return sprintf(
 		'<ul %1$s>%2$s</ul>',


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Stop duplicate query in Duplicate query in `render_block_core_post_template`. 

See #41200

#### Before
<img width="179" alt="Screenshot 2022-06-23 at 19 09 54" src="https://user-images.githubusercontent.com/237508/175527304-39042b58-b19f-42db-bd5f-a30cd570dcf6.png">

#### After
<img width="210" alt="Screenshot 2022-06-23 at 19 08 29" src="https://user-images.githubusercontent.com/237508/175527386-c693306e-ce70-40d0-b8bd-30a45624607e.png">

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->

## Screenshots or screencast <!-- if applicable -->
