### PR TITLE
[Block Editor]: Fix content loss from `replaceInnerBlocks` with controlled blocks

### DIFF
--- a/packages/block-editor/src/store/reducer.js
+++ b/packages/block-editor/src/store/reducer.js
@@ -689,7 +689,8 @@ const withReplaceInnerBlocks = ( reducer ) => ( state, action ) => {
 			index: 0,
 		} );
 
-		// We need to re-attach the block order of the controlled inner blocks.
+		// We need to re-attach the controlled inner blocks to the blocks tree and
+		// preserve their block order.
 		// Otherwise, an inner block controller's blocks will be deleted entirely
 		// from its entity..
 		stateAfterInsert.order = {
@@ -699,6 +700,20 @@ const withReplaceInnerBlocks = ( reducer ) => ( state, action ) => {
 				( result, value, key ) => {
 					if ( state.order[ key ] ) {
 						result[ key ] = state.order[ key ];
+					}
+					return result;
+				},
+				{}
+			),
+		};
+		stateAfterInsert.tree = {
+			...stateAfterInsert.tree,
+			...reduce(
+				nestedControllers,
+				( result, value, _key ) => {
+					const key = `controlled||${ _key }`;
+					if ( state.tree[ key ] ) {
+						result[ key ] = state.tree[ key ];
 					}
 					return result;
 				},

--- a/packages/block-editor/src/store/reducer.js
+++ b/packages/block-editor/src/store/reducer.js
@@ -690,9 +690,8 @@ const withReplaceInnerBlocks = ( reducer ) => ( state, action ) => {
 		} );
 
 		// We need to re-attach the controlled inner blocks to the blocks tree and
-		// preserve their block order.
-		// Otherwise, an inner block controller's blocks will be deleted entirely
-		// from its entity..
+		// preserve their block order. Otherwise, an inner block controller's blocks
+		// will be deleted entirely from its entity.
 		stateAfterInsert.order = {
 			...stateAfterInsert.order,
 			...reduce(

--- a/packages/block-editor/src/store/test/reducer.js
+++ b/packages/block-editor/src/store/test/reducer.js
@@ -2094,6 +2094,130 @@ describe( 'state', () => {
 					expect( state.tree.child ).toBeUndefined();
 					expect( state.tree.chicken.innerBlocks ).toEqual( [] );
 				} );
+				it( 'should preserve the controlled blocks in state and re-attach them in other pieces of state(order, tree, etc..), when we replace inner blocks', () => {
+					const initialState = {
+						byClientId: {
+							'group-id': {
+								clientId: 'group-id',
+								name: 'core/group',
+								isValid: true,
+							},
+							'reusable-id': {
+								clientId: 'reusable-id',
+								name: 'core/block',
+								isValid: true,
+							},
+							'paragraph-id': {
+								clientId: 'paragraph-id',
+								name: 'core/paragraph',
+								isValid: true,
+							},
+						},
+						order: {
+							'': [ 'group-id' ],
+							'group-id': [ 'reusable-id' ],
+							'reusable-id': [ 'paragraph-id' ],
+							'paragraph-id': [],
+						},
+						controlledInnerBlocks: {
+							'reusable-id': true,
+						},
+						parents: {
+							'group-id': '',
+							'reusable-id': 'group-id',
+							'paragraph-id': 'reusable-id',
+						},
+						tree: {
+							'group-id': {
+								clientId: 'group-id',
+								name: 'core/group',
+								isValid: true,
+								innerBlocks: [
+									{
+										clientId: 'reusable-id',
+										name: 'core/block',
+										isValid: true,
+										attributes: {
+											ref: 687,
+										},
+										innerBlocks: [],
+									},
+								],
+							},
+							'reusable-id': {
+								clientId: 'reusable-id',
+								name: 'core/block',
+								isValid: true,
+								attributes: {
+									ref: 687,
+								},
+								innerBlocks: [],
+							},
+							'': {
+								innerBlocks: [
+									{
+										clientId: 'group-id',
+										name: 'core/group',
+										isValid: true,
+										innerBlocks: [
+											{
+												clientId: 'reusable-id',
+												name: 'core/block',
+												isValid: true,
+												attributes: {
+													ref: 687,
+												},
+												innerBlocks: [],
+											},
+										],
+									},
+								],
+							},
+							'paragraph-id': {
+								clientId: 'paragraph-id',
+								name: 'core/paragraph',
+								isValid: true,
+								innerBlocks: [],
+							},
+							'controlled||reusable-id': {
+								innerBlocks: [
+									{
+										clientId: 'paragraph-id',
+										name: 'core/paragraph',
+										isValid: true,
+										innerBlocks: [],
+									},
+								],
+							},
+						},
+					};
+					// We will dispatch an action that replaces the inner
+					// blocks with the same inner blocks, which contain
+					// a controlled block (`reusable-id`).
+					const action = {
+						type: 'REPLACE_INNER_BLOCKS',
+						rootClientId: 'group-id',
+						blocks: [
+							{
+								clientId: 'reusable-id',
+								name: 'core/block',
+								isValid: true,
+								attributes: {
+									ref: 687,
+								},
+								innerBlocks: [],
+							},
+						],
+						updateSelection: false,
+					};
+					const state = blocks( initialState, action );
+					expect( state.order ).toEqual(
+						expect.objectContaining( initialState.order )
+					);
+					expect( state.tree ).toEqual(
+						expect.objectContaining( initialState.tree )
+					);
+				} );
 			} );
 		} );
 	} );


### PR DESCRIPTION


<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Fixes: https://github.com/WordPress/gutenberg/issues/41887

When we dispatch `REPLACE_INNER_BLOCKS` action we have a special handling which consists of two steps:
1. Remove blocks
2. Insert blocks

In this flow(`withReplaceInnerBlocks`) we have some special handling for controlled blocks(reusable, postContent, etc..) where we keep them in state during the removal(`keepControlledInnerBlocks`) and we are updating the `order` again after insertion.

What we are missing is the update of `block tree`. I think the only reason we missed that until now is because in our code base we have just a few calls to `replaceInnerBlocks`, where most of them(if not all) aren't affected by this bug - example use cases would be replacing blocks with entirely new blocks or replacing blocks that only specific blocks are allowed(non controlled blocks).


## Testing Instructions(also can be seen in the video)
1. In a page add some content
2. Go to `edit` the template
3. Transform the `PostContent` to `Columns` and add a new columns(this is where the call to `replaceInnerBlocks` happens).
4. If you save, you'll observe that now you've updated only the template and the content is preserved.

#### Before


https://user-images.githubusercontent.com/16275880/175545154-67da1d8c-bb9f-4dc8-9721-97e0d17a7104.mov


#### After


https://user-images.githubusercontent.com/16275880/175545168-4e1517de-df3e-4b01-b949-5ea4832f2dd2.mov


## Notes
1. **Good testing is needed here to avoid any regression**, as content loss is really really bad 😄 . Please test extensively.
2. I think this is the best place to put this code, but the whole logic is very complex, so I'd need more eyes on this one!
3. For `remove blocks and replace blocks` with have similar handling in a [different flow](https://github.com/WordPress/gutenberg/blob/trunk/packages/block-editor/src/store/reducer.js#L322)(`REPLACE_BLOCKS_AUGMENTED_WITH_CHILDREN`, `REMOVE_BLOCKS_AUGMENTED_WITH_CHILDREN `)
4. `controlled` blocks are the blocks that are a separate entity like `reusable blocks, template parts, etc..`.