### PR TITLE
Remove hardcoded reference to rest namespace in trash post.

### DIFF
--- a/packages/editor/src/store/actions.js
+++ b/packages/editor/src/store/actions.js
@@ -250,10 +250,12 @@ export const trashPost =
 			.resolveSelect( coreStore )
 			.getPostType( postTypeSlug );
 		registry.dispatch( noticesStore ).removeNotice( TRASH_POST_NOTICE_ID );
+		const { rest_base: restBase, rest_namespace: restNamespace = 'wp/v2' } =
+			postType;
 		try {
 			const post = select.getCurrentPost();
 			await apiFetch( {
-				path: `/wp/v2/${ postType.rest_base }/${ post.id }`,
+				path: `/${ restNamespace }/${ restBase }/${ post.id }`,
 				method: 'DELETE',
 			} );
 


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Related https://github.com/WordPress/gutenberg/pull/41542

Remove hardcoded reference to namespace for post type. 

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->

## Screenshots or screencast <!-- if applicable -->
