### PR TITLE
Compare against default category in the settings instead of hardcoded slug

### DIFF
--- a/packages/editor/src/components/post-publish-panel/maybe-category-panel.js
+++ b/packages/editor/src/components/post-publish-panel/maybe-category-panel.js
@@ -23,7 +23,7 @@ function MaybeCategoryPanel() {
 		const postType = select( editorStore ).getCurrentPostType();
 		const categoriesTaxonomy =
 			select( coreStore ).getTaxonomy( 'category' );
-		const defaultCategoryId = select( coreStore ).getEntityRecords(
+		const defaultCategoryId = select( coreStore ).getEntityRecord(
 			'root',
 			'site'
 		)?.default_category;

--- a/packages/editor/src/components/post-publish-panel/maybe-category-panel.js
+++ b/packages/editor/src/components/post-publish-panel/maybe-category-panel.js
@@ -21,14 +21,18 @@ import { store as editorStore } from '../../store';
 function MaybeCategoryPanel() {
 	const hasNoCategory = useSelect( ( select ) => {
 		const postType = select( editorStore ).getCurrentPostType();
-		const categoriesTaxonomy =
-			select( coreStore ).getTaxonomy( 'category' );
-		const defaultCategorySlug = 'uncategorized';
+		const categoriesTaxonomy = select( coreStore ).getTaxonomy(
+			'category'
+		);
+		const defaultCategoryId = select( coreStore ).getEntityRecords(
+			'root',
+			'site'
+		)?.default_category;
 		const defaultCategory = select( coreStore ).getEntityRecords(
 			'taxonomy',
 			'category',
 			{
-				slug: defaultCategorySlug,
+				id: defaultCategoryId,
 			}
 		)?.[ 0 ];
 		const postTypeSupportsCategories =

--- a/packages/editor/src/components/post-publish-panel/maybe-category-panel.js
+++ b/packages/editor/src/components/post-publish-panel/maybe-category-panel.js
@@ -21,9 +21,8 @@ import { store as editorStore } from '../../store';
 function MaybeCategoryPanel() {
 	const hasNoCategory = useSelect( ( select ) => {
 		const postType = select( editorStore ).getCurrentPostType();
-		const categoriesTaxonomy = select( coreStore ).getTaxonomy(
-			'category'
-		);
+		const categoriesTaxonomy =
+			select( coreStore ).getTaxonomy( 'category' );
 		const defaultCategoryId = select( coreStore ).getEntityRecords(
 			'root',
 			'site'


### PR DESCRIPTION
## What?
Get default category based of setting instead of hardcoded slug.

## Why?
Fixes https://github.com/WordPress/gutenberg/issues/41955

## How?
Instead of using the hardcoded slug, the ID for the default category is fetched from the settings.

## Testing Instructions
**Test 1**
1. Create a new post and publish
2. The suggestion for categories should show in the pre-publish panel

**Test 2**
1. Create a new category
2. Change the default category to the newly created category in the writing setting `wp-admin/options-writing.php`
3. Create a new post with the new category
4. Publish post and see the suggestion for categories in the pre-publish panel
