### PR TITLE
Adding axial top bottom margin to the cover block.

### DIFF
--- a/docs/reference-guides/core-blocks.md
+++ b/docs/reference-guides/core-blocks.md
@@ -230,7 +230,7 @@ Add an image or video with a text overlay — great for headers. ([Source](https
 
 -	**Name:** core/cover
 -	**Category:** media
--	**Supports:** align, anchor, color (~~background~~, ~~text~~), spacing (padding), ~~html~~
+-	**Supports:** align, anchor, color (~~background~~, ~~text~~), spacing (margin, padding), ~~html~~
 -	**Attributes:** allowedBlocks, alt, backgroundType, contentPosition, customGradient, customOverlayColor, dimRatio, focalPoint, gradient, hasParallax, id, isDark, isRepeated, minHeight, minHeightUnit, overlayColor, templateLock, url, useFeaturedImage
 
 ## Embed

--- a/packages/block-library/src/cover/block.json
+++ b/packages/block-library/src/cover/block.json
@@ -83,6 +83,7 @@
 		"html": false,
 		"spacing": {
 			"padding": true,
+			"margin": [ "top", "bottom" ],
 			"__experimentalDefaultControls": {
 				"padding": true
 			}


### PR DESCRIPTION
## What?
Revives https://github.com/WordPress/gutenberg/pull/33835 and fixes https://github.com/WordPress/gutenberg/issues/41879 by bringing top and bottom margin controls to the cover block:

![2022-06-27 12 09 35](https://user-images.githubusercontent.com/6458278/175848515-dd98fbc5-1e06-4619-be9e-42219982a169.gif)


## Why?

Previous attempts to add this control were put in doubt due to the unavailability of the visualizer. It looks like the visualizer is looking better since https://github.com/WordPress/gutenberg/pull/40505

## How?
Via block.json

## Testing Instructions

1. In a new post, create a Cover block. Check that the dimensions panel is there and margin controls are disabled by default.
2. Select margin under the ToolsPanel and adjust the value.
3. Check that your changes are reflected on the published post.
4. Edit the top and bottom margin separately. 
5. Behold your ground-breaking results and rejoice!

