### PR TITLE
Move defining style-engine definitions meta to block-supports

### DIFF
--- a/lib/block-supports/background.php
+++ b/lib/block-supports/background.php
@@ -92,6 +92,41 @@ function gutenberg_render_background_support( $block_content, $block ) {
 	return $block_content;
 }
 
+/**
+ * Style value parser that constructs a CSS definition array comprising a single CSS property and value.
+ * If the provided value is an array containing a `url` property, the function will return a CSS definition array
+ * with a single property and value, with `url` escaped and injected into a CSS `url()` function,
+ * e.g., array( 'background-image' => "url( '...' )" ).
+ *
+ * @param array $style_value      A single raw style value from $block_styles array.
+ * @param array $style_definition A single style definition from static::$block_style_definition_metadata.
+ *
+ * @return string[] An associative array of CSS definitions, e.g., array( "$property" => "$value", "$property" => "$value" ).
+ */
+function _gutenberg_block_supports_get_url_or_value_css_declaration( $style_value, $style_definition ) {
+	if ( empty( $style_value ) ) {
+		return array();
+	}
+
+	$css_declarations = array();
+
+	if ( isset( $style_definition['property_keys']['default'] ) ) {
+		$value = null;
+
+		if ( ! empty( $style_value['url'] ) ) {
+			$value = "url('" . $style_value['url'] . "')";
+		} elseif ( is_string( $style_value ) ) {
+			$value = $style_value;
+		}
+
+		if ( null !== $value ) {
+			$css_declarations[ $style_definition['property_keys']['default'] ] = $value;
+		}
+	}
+
+	return $css_declarations;
+}
+
 // Register the block support.
 WP_Block_Supports::get_instance()->register(
 	'background',
@@ -109,7 +144,7 @@ WP_Style_Engine_Gutenberg::register_block_style_definitions_metadata(
 			'property_keys' => array(
 				'default' => 'background-image',
 			),
-			'value_func'    => array( 'WP_Style_Engine_Gutenberg', 'get_url_or_value_css_declaration' ),
+			'value_func'    => '_gutenberg_block_supports_get_url_or_value_css_declaration',
 			'path'          => array( 'background', 'backgroundImage' ),
 		),
 		'backgroundSize'  => array(

--- a/lib/block-supports/background.php
+++ b/lib/block-supports/background.php
@@ -92,41 +92,6 @@ function gutenberg_render_background_support( $block_content, $block ) {
 	return $block_content;
 }
 
-/**
- * Style value parser that constructs a CSS definition array comprising a single CSS property and value.
- * If the provided value is an array containing a `url` property, the function will return a CSS definition array
- * with a single property and value, with `url` escaped and injected into a CSS `url()` function,
- * e.g., array( 'background-image' => "url( '...' )" ).
- *
- * @param array $style_value      A single raw style value from $block_styles array.
- * @param array $style_definition A single style definition from static::$block_style_definition_metadata.
- *
- * @return string[] An associative array of CSS definitions, e.g., array( "$property" => "$value", "$property" => "$value" ).
- */
-function _gutenberg_block_supports_get_url_or_value_css_declaration( $style_value, $style_definition ) {
-	if ( empty( $style_value ) ) {
-		return array();
-	}
-
-	$css_declarations = array();
-
-	if ( isset( $style_definition['property_keys']['default'] ) ) {
-		$value = null;
-
-		if ( ! empty( $style_value['url'] ) ) {
-			$value = "url('" . $style_value['url'] . "')";
-		} elseif ( is_string( $style_value ) ) {
-			$value = $style_value;
-		}
-
-		if ( null !== $value ) {
-			$css_declarations[ $style_definition['property_keys']['default'] ] = $value;
-		}
-	}
-
-	return $css_declarations;
-}
-
 // Register the block support.
 WP_Block_Supports::get_instance()->register(
 	'background',
@@ -144,7 +109,7 @@ WP_Style_Engine_Gutenberg::register_block_style_definitions_metadata(
 			'property_keys' => array(
 				'default' => 'background-image',
 			),
-			'value_func'    => '_gutenberg_block_supports_get_url_or_value_css_declaration',
+			'value_func'    => array( 'WP_Style_Engine_Gutenberg', 'get_url_or_value_css_declaration' ),
 			'path'          => array( 'background', 'backgroundImage' ),
 		),
 		'backgroundSize'  => array(

--- a/lib/block-supports/background.php
+++ b/lib/block-supports/background.php
@@ -109,7 +109,7 @@ WP_Style_Engine_Gutenberg::register_block_style_definitions_metadata(
 			'property_keys' => array(
 				'default' => 'background-image',
 			),
-			'value_func'    => array( self::class, 'get_url_or_value_css_declaration' ),
+			'value_func'    => array( 'WP_Style_Engine_Gutenberg', 'get_url_or_value_css_declaration' ),
 			'path'          => array( 'background', 'backgroundImage' ),
 		),
 		'backgroundSize'  => array(

--- a/lib/block-supports/background.php
+++ b/lib/block-supports/background.php
@@ -101,3 +101,22 @@ WP_Block_Supports::get_instance()->register(
 );
 
 add_filter( 'render_block', 'gutenberg_render_background_support', 10, 2 );
+
+WP_Style_Engine_Gutenberg::register_block_style_definitions_metadata(
+	'background',
+	array(
+		'backgroundImage' => array(
+			'property_keys' => array(
+				'default' => 'background-image',
+			),
+			'value_func'    => array( self::class, 'get_url_or_value_css_declaration' ),
+			'path'          => array( 'background', 'backgroundImage' ),
+		),
+		'backgroundSize'  => array(
+			'property_keys' => array(
+				'default' => 'background-size',
+			),
+			'path'          => array( 'background', 'backgroundSize' ),
+		),
+	)
+);

--- a/lib/block-supports/border.php
+++ b/lib/block-supports/border.php
@@ -199,28 +199,28 @@ WP_Style_Engine_Gutenberg::register_block_style_definitions_metadata(
 			'path'          => array( 'border', 'width' ),
 		),
 		'top'    => array(
-			'value_func' => array( self::class, 'get_individual_property_css_declarations' ),
+			'value_func' => array( 'WP_Style_Engine_Gutenberg', 'get_individual_property_css_declarations' ),
 			'path'       => array( 'border', 'top' ),
 			'css_vars'   => array(
 				'color' => '--wp--preset--color--$slug',
 			),
 		),
 		'right'  => array(
-			'value_func' => array( self::class, 'get_individual_property_css_declarations' ),
+			'value_func' => array( 'WP_Style_Engine_Gutenberg', 'get_individual_property_css_declarations' ),
 			'path'       => array( 'border', 'right' ),
 			'css_vars'   => array(
 				'color' => '--wp--preset--color--$slug',
 			),
 		),
 		'bottom' => array(
-			'value_func' => array( self::class, 'get_individual_property_css_declarations' ),
+			'value_func' => array( 'WP_Style_Engine_Gutenberg', 'get_individual_property_css_declarations' ),
 			'path'       => array( 'border', 'bottom' ),
 			'css_vars'   => array(
 				'color' => '--wp--preset--color--$slug',
 			),
 		),
 		'left'   => array(
-			'value_func' => array( self::class, 'get_individual_property_css_declarations' ),
+			'value_func' => array( 'WP_Style_Engine_Gutenberg', 'get_individual_property_css_declarations' ),
 			'path'       => array( 'border', 'left' ),
 			'css_vars'   => array(
 				'color' => '--wp--preset--color--$slug',

--- a/lib/block-supports/border.php
+++ b/lib/block-supports/border.php
@@ -162,3 +162,69 @@ WP_Block_Supports::get_instance()->register(
 		'apply'              => 'gutenberg_apply_border_support',
 	)
 );
+
+WP_Style_Engine_Gutenberg::register_block_style_definitions_metadata(
+	'border',
+	array(
+		'color'  => array(
+			'property_keys' => array(
+				'default'    => 'border-color',
+				'individual' => 'border-%s-color',
+			),
+			'path'          => array( 'border', 'color' ),
+			'classnames'    => array(
+				'has-border-color'       => true,
+				'has-$slug-border-color' => 'color',
+			),
+		),
+		'radius' => array(
+			'property_keys' => array(
+				'default'    => 'border-radius',
+				'individual' => 'border-%s-radius',
+			),
+			'path'          => array( 'border', 'radius' ),
+		),
+		'style'  => array(
+			'property_keys' => array(
+				'default'    => 'border-style',
+				'individual' => 'border-%s-style',
+			),
+			'path'          => array( 'border', 'style' ),
+		),
+		'width'  => array(
+			'property_keys' => array(
+				'default'    => 'border-width',
+				'individual' => 'border-%s-width',
+			),
+			'path'          => array( 'border', 'width' ),
+		),
+		'top'    => array(
+			'value_func' => array( self::class, 'get_individual_property_css_declarations' ),
+			'path'       => array( 'border', 'top' ),
+			'css_vars'   => array(
+				'color' => '--wp--preset--color--$slug',
+			),
+		),
+		'right'  => array(
+			'value_func' => array( self::class, 'get_individual_property_css_declarations' ),
+			'path'       => array( 'border', 'right' ),
+			'css_vars'   => array(
+				'color' => '--wp--preset--color--$slug',
+			),
+		),
+		'bottom' => array(
+			'value_func' => array( self::class, 'get_individual_property_css_declarations' ),
+			'path'       => array( 'border', 'bottom' ),
+			'css_vars'   => array(
+				'color' => '--wp--preset--color--$slug',
+			),
+		),
+		'left'   => array(
+			'value_func' => array( self::class, 'get_individual_property_css_declarations' ),
+			'path'       => array( 'border', 'left' ),
+			'css_vars'   => array(
+				'color' => '--wp--preset--color--$slug',
+			),
+		),
+	)
+);

--- a/lib/block-supports/border.php
+++ b/lib/block-supports/border.php
@@ -154,60 +154,6 @@ function gutenberg_has_border_feature_support( $block_type, $feature, $default_v
 	return block_has_support( $block_type, array( '__experimentalBorder', $feature ), $default_value );
 }
 
-/**
- * Style value parser that returns a CSS definition array comprising style properties
- * that have keys representing individual style properties, otherwise known as longhand CSS properties.
- * e.g., "$style_property-$individual_feature: $value;", which could represent the following:
- * "border-{top|right|bottom|left}-{color|width|style}: {value};" or,
- * "border-image-{outset|source|width|repeat|slice}: {value};"
- *
- * @param array $style_value                    A single raw style value from $block_styles array.
- * @param array $individual_property_definition A single style definition from static::$block_style_definition_metadata,
- *                                              representing an individual property of a CSS property, e.g., 'top' in 'border-top'.
- * @param array $options                        {
- *     Optional. An array of options. Default empty array.
- *
- *     @type bool $convert_vars_to_classnames Whether to skip converting incoming CSS var patterns, e.g., `var:preset|<PRESET_TYPE>|<PRESET_SLUG>`, to var( --wp--preset--* ) values. Default `false`.
- * }
- *
- * @return string[] An associative array of CSS definitions, e.g., array( "$property" => "$value", "$property" => "$value" ).
- */
-function _gutenberg_block_supports_get_individual_property_css_declarations( $style_value, $individual_property_definition, $options = array() ) {
-	if ( ! is_array( $style_value ) || empty( $style_value ) || empty( $individual_property_definition['path'] ) ) {
-		return array();
-	}
-
-	/*
-		* The first item in $individual_property_definition['path'] array tells us the style property, e.g., "border".
-		* We use this to get a corresponding CSS style definition such as "color" or "width" from the same group.
-		* The second item in $individual_property_definition['path'] array refers to the individual property marker, e.g., "top".
-		*/
-	$definition_group_key    = $individual_property_definition['path'][0];
-	$individual_property_key = $individual_property_definition['path'][1];
-	$should_skip_css_vars    = isset( $options['convert_vars_to_classnames'] ) && true === $options['convert_vars_to_classnames'];
-	$css_declarations        = array();
-
-	foreach ( $style_value as $css_property => $value ) {
-		if ( empty( $value ) ) {
-			continue;
-		}
-
-		// Build a path to the individual rules in definitions.
-		$style_definition_path = array( $definition_group_key, $css_property );
-		$style_definition      = _wp_array_get( WP_Style_Engine_Gutenberg::$block_style_definition_metadata, $style_definition_path, null );
-
-		if ( $style_definition && isset( $style_definition['property_keys']['individual'] ) ) {
-			// Set a CSS var if there is a valid preset value.
-			if ( is_string( $value ) && str_contains( $value, 'var:' ) && ! $should_skip_css_vars && ! empty( $individual_property_definition['css_vars'] ) ) {
-				$value = WP_Style_Engine_Gutenberg::get_css_var_value( $value, $individual_property_definition['css_vars'] );
-			}
-			$individual_css_property                      = sprintf( $style_definition['property_keys']['individual'], $individual_property_key );
-			$css_declarations[ $individual_css_property ] = $value;
-		}
-	}
-	return $css_declarations;
-}
-
 // Register the block support.
 WP_Block_Supports::get_instance()->register(
 	'border',
@@ -253,28 +199,28 @@ WP_Style_Engine_Gutenberg::register_block_style_definitions_metadata(
 			'path'          => array( 'border', 'width' ),
 		),
 		'top'    => array(
-			'value_func' => '_gutenberg_block_supports_get_individual_property_css_declarations',
+			'value_func' => array( 'WP_Style_Engine_Gutenberg', 'get_individual_property_css_declarations' ),
 			'path'       => array( 'border', 'top' ),
 			'css_vars'   => array(
 				'color' => '--wp--preset--color--$slug',
 			),
 		),
 		'right'  => array(
-			'value_func' => '_gutenberg_block_supports_get_individual_property_css_declarations',
+			'value_func' => array( 'WP_Style_Engine_Gutenberg', 'get_individual_property_css_declarations' ),
 			'path'       => array( 'border', 'right' ),
 			'css_vars'   => array(
 				'color' => '--wp--preset--color--$slug',
 			),
 		),
 		'bottom' => array(
-			'value_func' => '_gutenberg_block_supports_get_individual_property_css_declarations',
+			'value_func' => array( 'WP_Style_Engine_Gutenberg', 'get_individual_property_css_declarations' ),
 			'path'       => array( 'border', 'bottom' ),
 			'css_vars'   => array(
 				'color' => '--wp--preset--color--$slug',
 			),
 		),
 		'left'   => array(
-			'value_func' => '_gutenberg_block_supports_get_individual_property_css_declarations',
+			'value_func' => array( 'WP_Style_Engine_Gutenberg', 'get_individual_property_css_declarations' ),
 			'path'       => array( 'border', 'left' ),
 			'css_vars'   => array(
 				'color' => '--wp--preset--color--$slug',

--- a/lib/block-supports/border.php
+++ b/lib/block-supports/border.php
@@ -154,6 +154,60 @@ function gutenberg_has_border_feature_support( $block_type, $feature, $default_v
 	return block_has_support( $block_type, array( '__experimentalBorder', $feature ), $default_value );
 }
 
+/**
+ * Style value parser that returns a CSS definition array comprising style properties
+ * that have keys representing individual style properties, otherwise known as longhand CSS properties.
+ * e.g., "$style_property-$individual_feature: $value;", which could represent the following:
+ * "border-{top|right|bottom|left}-{color|width|style}: {value};" or,
+ * "border-image-{outset|source|width|repeat|slice}: {value};"
+ *
+ * @param array $style_value                    A single raw style value from $block_styles array.
+ * @param array $individual_property_definition A single style definition from static::$block_style_definition_metadata,
+ *                                              representing an individual property of a CSS property, e.g., 'top' in 'border-top'.
+ * @param array $options                        {
+ *     Optional. An array of options. Default empty array.
+ *
+ *     @type bool $convert_vars_to_classnames Whether to skip converting incoming CSS var patterns, e.g., `var:preset|<PRESET_TYPE>|<PRESET_SLUG>`, to var( --wp--preset--* ) values. Default `false`.
+ * }
+ *
+ * @return string[] An associative array of CSS definitions, e.g., array( "$property" => "$value", "$property" => "$value" ).
+ */
+function _gutenberg_block_supports_get_individual_property_css_declarations( $style_value, $individual_property_definition, $options = array() ) {
+	if ( ! is_array( $style_value ) || empty( $style_value ) || empty( $individual_property_definition['path'] ) ) {
+		return array();
+	}
+
+	/*
+		* The first item in $individual_property_definition['path'] array tells us the style property, e.g., "border".
+		* We use this to get a corresponding CSS style definition such as "color" or "width" from the same group.
+		* The second item in $individual_property_definition['path'] array refers to the individual property marker, e.g., "top".
+		*/
+	$definition_group_key    = $individual_property_definition['path'][0];
+	$individual_property_key = $individual_property_definition['path'][1];
+	$should_skip_css_vars    = isset( $options['convert_vars_to_classnames'] ) && true === $options['convert_vars_to_classnames'];
+	$css_declarations        = array();
+
+	foreach ( $style_value as $css_property => $value ) {
+		if ( empty( $value ) ) {
+			continue;
+		}
+
+		// Build a path to the individual rules in definitions.
+		$style_definition_path = array( $definition_group_key, $css_property );
+		$style_definition      = _wp_array_get( WP_Style_Engine_Gutenberg::$block_style_definition_metadata, $style_definition_path, null );
+
+		if ( $style_definition && isset( $style_definition['property_keys']['individual'] ) ) {
+			// Set a CSS var if there is a valid preset value.
+			if ( is_string( $value ) && str_contains( $value, 'var:' ) && ! $should_skip_css_vars && ! empty( $individual_property_definition['css_vars'] ) ) {
+				$value = WP_Style_Engine_Gutenberg::get_css_var_value( $value, $individual_property_definition['css_vars'] );
+			}
+			$individual_css_property                      = sprintf( $style_definition['property_keys']['individual'], $individual_property_key );
+			$css_declarations[ $individual_css_property ] = $value;
+		}
+	}
+	return $css_declarations;
+}
+
 // Register the block support.
 WP_Block_Supports::get_instance()->register(
 	'border',
@@ -199,28 +253,28 @@ WP_Style_Engine_Gutenberg::register_block_style_definitions_metadata(
 			'path'          => array( 'border', 'width' ),
 		),
 		'top'    => array(
-			'value_func' => array( 'WP_Style_Engine_Gutenberg', 'get_individual_property_css_declarations' ),
+			'value_func' => '_gutenberg_block_supports_get_individual_property_css_declarations',
 			'path'       => array( 'border', 'top' ),
 			'css_vars'   => array(
 				'color' => '--wp--preset--color--$slug',
 			),
 		),
 		'right'  => array(
-			'value_func' => array( 'WP_Style_Engine_Gutenberg', 'get_individual_property_css_declarations' ),
+			'value_func' => '_gutenberg_block_supports_get_individual_property_css_declarations',
 			'path'       => array( 'border', 'right' ),
 			'css_vars'   => array(
 				'color' => '--wp--preset--color--$slug',
 			),
 		),
 		'bottom' => array(
-			'value_func' => array( 'WP_Style_Engine_Gutenberg', 'get_individual_property_css_declarations' ),
+			'value_func' => '_gutenberg_block_supports_get_individual_property_css_declarations',
 			'path'       => array( 'border', 'bottom' ),
 			'css_vars'   => array(
 				'color' => '--wp--preset--color--$slug',
 			),
 		),
 		'left'   => array(
-			'value_func' => array( 'WP_Style_Engine_Gutenberg', 'get_individual_property_css_declarations' ),
+			'value_func' => '_gutenberg_block_supports_get_individual_property_css_declarations',
 			'path'       => array( 'border', 'left' ),
 			'css_vars'   => array(
 				'color' => '--wp--preset--color--$slug',

--- a/lib/block-supports/colors.php
+++ b/lib/block-supports/colors.php
@@ -135,3 +135,54 @@ WP_Block_Supports::get_instance()->register(
 		'apply'              => 'gutenberg_apply_colors_support',
 	)
 );
+
+WP_Style_Engine_Gutenberg::register_block_style_definitions_metadata(
+	'color.text',
+	array(
+		'property_keys' => array(
+			'default' => 'color',
+		),
+		'path'          => array( 'color', 'text' ),
+		'css_vars'      => array(
+			'color' => '--wp--preset--color--$slug',
+		),
+		'classnames'    => array(
+			'has-text-color'  => true,
+			'has-$slug-color' => 'color',
+		),
+	)
+);
+
+WP_Style_Engine_Gutenberg::register_block_style_definitions_metadata(
+	'color.background',
+	array(
+		'property_keys' => array(
+			'default' => 'background-color',
+		),
+		'path'          => array( 'color', 'background' ),
+		'css_vars'      => array(
+			'color' => '--wp--preset--color--$slug',
+		),
+		'classnames'    => array(
+			'has-background'             => true,
+			'has-$slug-background-color' => 'color',
+		),
+	)
+);
+
+WP_Style_Engine_Gutenberg::register_block_style_definitions_metadata(
+	'color.gradient',
+	array(
+		'property_keys' => array(
+			'default' => 'background',
+		),
+		'css_vars'      => array(
+			'gradient' => '--wp--preset--gradient--$slug',
+		),
+		'path'          => array( 'color', 'gradient' ),
+		'classnames'    => array(
+			'has-background'                => true,
+			'has-$slug-gradient-background' => 'gradient',
+		),
+	)
+);

--- a/lib/block-supports/dimensions.php
+++ b/lib/block-supports/dimensions.php
@@ -82,3 +82,19 @@ WP_Block_Supports::get_instance()->register(
 		'apply'              => 'gutenberg_apply_dimensions_support',
 	)
 );
+
+
+WP_Style_Engine_Gutenberg::register_block_style_definitions_metadata(
+	'dimensions',
+	array(
+		'minHeight' => array(
+			'property_keys' => array(
+				'default' => 'min-height',
+			),
+			'path'          => array( 'dimensions', 'minHeight' ),
+			'css_vars'      => array(
+				'spacing' => '--wp--preset--spacing--$slug',
+			),
+		),
+	)
+);

--- a/lib/block-supports/shadow.php
+++ b/lib/block-supports/shadow.php
@@ -75,3 +75,18 @@ WP_Block_Supports::get_instance()->register(
 		'apply'              => 'gutenberg_apply_shadow_support',
 	)
 );
+
+WP_Style_Engine_Gutenberg::register_block_style_definitions_metadata(
+	'shadow',
+	array(
+		'shadow' => array(
+			'property_keys' => array(
+				'default' => 'box-shadow',
+			),
+			'path'          => array( 'shadow' ),
+			'css_vars'      => array(
+				'shadow' => '--wp--preset--shadow--$slug',
+			),
+		),
+	)
+);

--- a/lib/block-supports/spacing.php
+++ b/lib/block-supports/spacing.php
@@ -81,3 +81,29 @@ WP_Block_Supports::get_instance()->register(
 		'apply'              => 'gutenberg_apply_spacing_support',
 	)
 );
+
+WP_Style_Engine_Gutenberg::register_block_style_definitions_metadata(
+	'spacing',
+	array(
+		'padding' => array(
+			'property_keys' => array(
+				'default'    => 'padding',
+				'individual' => 'padding-%s',
+			),
+			'path'          => array( 'spacing', 'padding' ),
+			'css_vars'      => array(
+				'spacing' => '--wp--preset--spacing--$slug',
+			),
+		),
+		'margin'  => array(
+			'property_keys' => array(
+				'default'    => 'margin',
+				'individual' => 'margin-%s',
+			),
+			'path'          => array( 'spacing', 'margin' ),
+			'css_vars'      => array(
+				'spacing' => '--wp--preset--spacing--$slug',
+			),
+		),
+	)
+);

--- a/lib/block-supports/typography.php
+++ b/lib/block-supports/typography.php
@@ -580,3 +580,76 @@ if ( function_exists( 'wp_render_typography_support' ) ) {
 	remove_filter( 'render_block', 'wp_render_typography_support' );
 }
 add_filter( 'render_block', 'gutenberg_render_typography_support', 10, 2 );
+
+
+WP_Style_Engine_Gutenberg::register_block_style_definitions_metadata(
+	'typography',
+	array(
+		'fontSize'       => array(
+			'property_keys' => array(
+				'default' => 'font-size',
+			),
+			'path'          => array( 'typography', 'fontSize' ),
+			'classnames'    => array(
+				'has-$slug-font-size' => 'font-size',
+			),
+		),
+		'fontFamily'     => array(
+			'property_keys' => array(
+				'default' => 'font-family',
+			),
+			'path'          => array( 'typography', 'fontFamily' ),
+			'classnames'    => array(
+				'has-$slug-font-family' => 'font-family',
+			),
+		),
+		'fontStyle'      => array(
+			'property_keys' => array(
+				'default' => 'font-style',
+			),
+			'path'          => array( 'typography', 'fontStyle' ),
+		),
+		'fontWeight'     => array(
+			'property_keys' => array(
+				'default' => 'font-weight',
+			),
+			'path'          => array( 'typography', 'fontWeight' ),
+		),
+		'lineHeight'     => array(
+			'property_keys' => array(
+				'default' => 'line-height',
+			),
+			'path'          => array( 'typography', 'lineHeight' ),
+		),
+		'textColumns'    => array(
+			'property_keys' => array(
+				'default' => 'column-count',
+			),
+			'path'          => array( 'typography', 'textColumns' ),
+		),
+		'textDecoration' => array(
+			'property_keys' => array(
+				'default' => 'text-decoration',
+			),
+			'path'          => array( 'typography', 'textDecoration' ),
+		),
+		'textTransform'  => array(
+			'property_keys' => array(
+				'default' => 'text-transform',
+			),
+			'path'          => array( 'typography', 'textTransform' ),
+		),
+		'letterSpacing'  => array(
+			'property_keys' => array(
+				'default' => 'letter-spacing',
+			),
+			'path'          => array( 'typography', 'letterSpacing' ),
+		),
+		'writingMode'    => array(
+			'property_keys' => array(
+				'default' => 'writing-mode',
+			),
+			'path'          => array( 'typography', 'writingMode' ),
+		),
+	)
+);

--- a/packages/style-engine/class-wp-style-engine.php
+++ b/packages/style-engine/class-wp-style-engine.php
@@ -42,238 +42,29 @@ final class WP_Style_Engine {
 	 *
 	 * @var array
 	 */
-	const BLOCK_STYLE_DEFINITIONS_METADATA = array(
-		'background' => array(
-			'backgroundImage' => array(
-				'property_keys' => array(
-					'default' => 'background-image',
-				),
-				'value_func'    => array( self::class, 'get_url_or_value_css_declaration' ),
-				'path'          => array( 'background', 'backgroundImage' ),
-			),
-			'backgroundSize'  => array(
-				'property_keys' => array(
-					'default' => 'background-size',
-				),
-				'path'          => array( 'background', 'backgroundSize' ),
-			),
-		),
-		'color'      => array(
-			'text'       => array(
-				'property_keys' => array(
-					'default' => 'color',
-				),
-				'path'          => array( 'color', 'text' ),
-				'css_vars'      => array(
-					'color' => '--wp--preset--color--$slug',
-				),
-				'classnames'    => array(
-					'has-text-color'  => true,
-					'has-$slug-color' => 'color',
-				),
-			),
-			'background' => array(
-				'property_keys' => array(
-					'default' => 'background-color',
-				),
-				'path'          => array( 'color', 'background' ),
-				'css_vars'      => array(
-					'color' => '--wp--preset--color--$slug',
-				),
-				'classnames'    => array(
-					'has-background'             => true,
-					'has-$slug-background-color' => 'color',
-				),
-			),
-			'gradient'   => array(
-				'property_keys' => array(
-					'default' => 'background',
-				),
-				'css_vars'      => array(
-					'gradient' => '--wp--preset--gradient--$slug',
-				),
-				'path'          => array( 'color', 'gradient' ),
-				'classnames'    => array(
-					'has-background'                => true,
-					'has-$slug-gradient-background' => 'gradient',
-				),
-			),
-		),
-		'border'     => array(
-			'color'  => array(
-				'property_keys' => array(
-					'default'    => 'border-color',
-					'individual' => 'border-%s-color',
-				),
-				'path'          => array( 'border', 'color' ),
-				'classnames'    => array(
-					'has-border-color'       => true,
-					'has-$slug-border-color' => 'color',
-				),
-			),
-			'radius' => array(
-				'property_keys' => array(
-					'default'    => 'border-radius',
-					'individual' => 'border-%s-radius',
-				),
-				'path'          => array( 'border', 'radius' ),
-			),
-			'style'  => array(
-				'property_keys' => array(
-					'default'    => 'border-style',
-					'individual' => 'border-%s-style',
-				),
-				'path'          => array( 'border', 'style' ),
-			),
-			'width'  => array(
-				'property_keys' => array(
-					'default'    => 'border-width',
-					'individual' => 'border-%s-width',
-				),
-				'path'          => array( 'border', 'width' ),
-			),
-			'top'    => array(
-				'value_func' => array( self::class, 'get_individual_property_css_declarations' ),
-				'path'       => array( 'border', 'top' ),
-				'css_vars'   => array(
-					'color' => '--wp--preset--color--$slug',
-				),
-			),
-			'right'  => array(
-				'value_func' => array( self::class, 'get_individual_property_css_declarations' ),
-				'path'       => array( 'border', 'right' ),
-				'css_vars'   => array(
-					'color' => '--wp--preset--color--$slug',
-				),
-			),
-			'bottom' => array(
-				'value_func' => array( self::class, 'get_individual_property_css_declarations' ),
-				'path'       => array( 'border', 'bottom' ),
-				'css_vars'   => array(
-					'color' => '--wp--preset--color--$slug',
-				),
-			),
-			'left'   => array(
-				'value_func' => array( self::class, 'get_individual_property_css_declarations' ),
-				'path'       => array( 'border', 'left' ),
-				'css_vars'   => array(
-					'color' => '--wp--preset--color--$slug',
-				),
-			),
-		),
-		'shadow'     => array(
-			'shadow' => array(
-				'property_keys' => array(
-					'default' => 'box-shadow',
-				),
-				'path'          => array( 'shadow' ),
-				'css_vars'      => array(
-					'shadow' => '--wp--preset--shadow--$slug',
-				),
-			),
-		),
-		'dimensions' => array(
-			'minHeight' => array(
-				'property_keys' => array(
-					'default' => 'min-height',
-				),
-				'path'          => array( 'dimensions', 'minHeight' ),
-				'css_vars'      => array(
-					'spacing' => '--wp--preset--spacing--$slug',
-				),
-			),
-		),
-		'spacing'    => array(
-			'padding' => array(
-				'property_keys' => array(
-					'default'    => 'padding',
-					'individual' => 'padding-%s',
-				),
-				'path'          => array( 'spacing', 'padding' ),
-				'css_vars'      => array(
-					'spacing' => '--wp--preset--spacing--$slug',
-				),
-			),
-			'margin'  => array(
-				'property_keys' => array(
-					'default'    => 'margin',
-					'individual' => 'margin-%s',
-				),
-				'path'          => array( 'spacing', 'margin' ),
-				'css_vars'      => array(
-					'spacing' => '--wp--preset--spacing--$slug',
-				),
-			),
-		),
-		'typography' => array(
-			'fontSize'       => array(
-				'property_keys' => array(
-					'default' => 'font-size',
-				),
-				'path'          => array( 'typography', 'fontSize' ),
-				'classnames'    => array(
-					'has-$slug-font-size' => 'font-size',
-				),
-			),
-			'fontFamily'     => array(
-				'property_keys' => array(
-					'default' => 'font-family',
-				),
-				'path'          => array( 'typography', 'fontFamily' ),
-				'classnames'    => array(
-					'has-$slug-font-family' => 'font-family',
-				),
-			),
-			'fontStyle'      => array(
-				'property_keys' => array(
-					'default' => 'font-style',
-				),
-				'path'          => array( 'typography', 'fontStyle' ),
-			),
-			'fontWeight'     => array(
-				'property_keys' => array(
-					'default' => 'font-weight',
-				),
-				'path'          => array( 'typography', 'fontWeight' ),
-			),
-			'lineHeight'     => array(
-				'property_keys' => array(
-					'default' => 'line-height',
-				),
-				'path'          => array( 'typography', 'lineHeight' ),
-			),
-			'textColumns'    => array(
-				'property_keys' => array(
-					'default' => 'column-count',
-				),
-				'path'          => array( 'typography', 'textColumns' ),
-			),
-			'textDecoration' => array(
-				'property_keys' => array(
-					'default' => 'text-decoration',
-				),
-				'path'          => array( 'typography', 'textDecoration' ),
-			),
-			'textTransform'  => array(
-				'property_keys' => array(
-					'default' => 'text-transform',
-				),
-				'path'          => array( 'typography', 'textTransform' ),
-			),
-			'letterSpacing'  => array(
-				'property_keys' => array(
-					'default' => 'letter-spacing',
-				),
-				'path'          => array( 'typography', 'letterSpacing' ),
-			),
-			'writingMode'    => array(
-				'property_keys' => array(
-					'default' => 'writing-mode',
-				),
-				'path'          => array( 'typography', 'writingMode' ),
-			),
-		),
-	);
+	private static $block_style_definition_metadata = array();
+
+	/**
+	 * Registers a style definition metadata for a defined path.
+	 * Adds the data to self::$block_style_definition_metadata.
+	 *
+	 * @param string $path The path to the style definition, in a dot-annotation format (e.g., "border.color").
+	 * @param array  $meta The style definition metadata.
+	 */
+	public static function register_block_style_definitions_metadata( $path = '', $meta = array() ) {
+		$result = array();
+		$keys   = explode( '.', $path );
+		$keys   = array_reverse( $keys );
+		$value  = $meta;
+		foreach ( $keys as $key ) {
+			// Wrap value with key over each iteration.
+			$value  = array(
+				$key => $value,
+			);
+			$result = array_merge_recursive( $result, $value );
+		}
+		static::$block_style_definition_metadata = array_merge_recursive( static::$block_style_definition_metadata, $result );
+	}
 
 	/**
 	 * Util: Extracts the slug in kebab case from a preset string, e.g., "heavenly-blue" from 'var:preset|color|heavenlyBlue'.
@@ -353,7 +144,7 @@ final class WP_Style_Engine {
 
 	/**
 	 * Returns classnames and CSS based on the values in a styles object.
-	 * Return values are parsed based on the instructions in BLOCK_STYLE_DEFINITIONS_METADATA.
+	 * Return values are parsed based on the instructions in static::$block_style_definition_metadata.
 	 *
 	 * @since 6.1.0
 	 *
@@ -381,7 +172,7 @@ final class WP_Style_Engine {
 		}
 
 		// Collect CSS and classnames.
-		foreach ( static::BLOCK_STYLE_DEFINITIONS_METADATA as $definition_group_key => $definition_group_style ) {
+		foreach ( static::$block_style_definition_metadata as $definition_group_key => $definition_group_style ) {
 			if ( empty( $block_styles[ $definition_group_key ] ) ) {
 				continue;
 			}
@@ -404,7 +195,7 @@ final class WP_Style_Engine {
 	 * Returns classnames, and generates classname(s) from a CSS preset property pattern, e.g., '`var:preset|<PRESET_TYPE>|<PRESET_SLUG>`'.
 	 *
 	 * @param array $style_value      A single raw style value or css preset property from the $block_styles array.
-	 * @param array $style_definition A single style definition from BLOCK_STYLE_DEFINITIONS_METADATA.
+	 * @param array $style_definition A single style definition from static::$block_style_definition_metadata.
 	 *
 	 * @return array|string[] An array of CSS classnames, or empty array.
 	 */
@@ -424,7 +215,7 @@ final class WP_Style_Engine {
 
 				if ( $slug ) {
 					/*
-					 * Right now we expect a classname pattern to be stored in BLOCK_STYLE_DEFINITIONS_METADATA.
+					 * Right now we expect a classname pattern to be stored in static::$block_style_definition_metadata.
 					 * One day, if there are no stored schemata, we could allow custom patterns or
 					 * generate classnames based on other properties
 					 * such as a path or a value or a prefix passed in options.
@@ -443,7 +234,7 @@ final class WP_Style_Engine {
 	 * @since 6.1.0
 	 *
 	 * @param array $style_value      A single raw style value from $block_styles array.
-	 * @param array $style_definition A single style definition from BLOCK_STYLE_DEFINITIONS_METADATA.
+	 * @param array $style_definition A single style definition from static::$block_style_definition_metadata.
 	 * @param array $options          {
 	 *     Optional. An array of options. Default empty array.
 	 *
@@ -513,7 +304,8 @@ final class WP_Style_Engine {
 	 * "border-image-{outset|source|width|repeat|slice}: {value};"
 	 *
 	 * @param array $style_value                    A single raw style value from $block_styles array.
-	 * @param array $individual_property_definition A single style definition from BLOCK_STYLE_DEFINITIONS_METADATA representing an individual property of a CSS property, e.g., 'top' in 'border-top'.
+	 * @param array $individual_property_definition A single style definition from static::$block_style_definition_metadata,
+	 *                                              representing an individual property of a CSS property, e.g., 'top' in 'border-top'.
 	 * @param array $options                        {
 	 *     Optional. An array of options. Default empty array.
 	 *
@@ -544,7 +336,7 @@ final class WP_Style_Engine {
 
 			// Build a path to the individual rules in definitions.
 			$style_definition_path = array( $definition_group_key, $css_property );
-			$style_definition      = _wp_array_get( static::BLOCK_STYLE_DEFINITIONS_METADATA, $style_definition_path, null );
+			$style_definition      = _wp_array_get( static::$block_style_definition_metadata, $style_definition_path, null );
 
 			if ( $style_definition && isset( $style_definition['property_keys']['individual'] ) ) {
 				// Set a CSS var if there is a valid preset value.
@@ -565,7 +357,7 @@ final class WP_Style_Engine {
 	 * e.g., array( 'background-image' => "url( '...' )" ).
 	 *
 	 * @param array $style_value      A single raw style value from $block_styles array.
-	 * @param array $style_definition A single style definition from BLOCK_STYLE_DEFINITIONS_METADATA.
+	 * @param array $style_definition A single style definition from static::$block_style_definition_metadata.
 	 *
 	 * @return string[] An associative array of CSS definitions, e.g., array( "$property" => "$value", "$property" => "$value" ).
 	 */

--- a/packages/style-engine/class-wp-style-engine.php
+++ b/packages/style-engine/class-wp-style-engine.php
@@ -314,7 +314,7 @@ final class WP_Style_Engine {
 	 *
 	 * @return string[] An associative array of CSS definitions, e.g., array( "$property" => "$value", "$property" => "$value" ).
 	 */
-	protected static function get_individual_property_css_declarations( $style_value, $individual_property_definition, $options = array() ) {
+	public static function get_individual_property_css_declarations( $style_value, $individual_property_definition, $options = array() ) {
 		if ( ! is_array( $style_value ) || empty( $style_value ) || empty( $individual_property_definition['path'] ) ) {
 			return array();
 		}
@@ -361,7 +361,7 @@ final class WP_Style_Engine {
 	 *
 	 * @return string[] An associative array of CSS definitions, e.g., array( "$property" => "$value", "$property" => "$value" ).
 	 */
-	protected static function get_url_or_value_css_declaration( $style_value, $style_definition ) {
+	public static function get_url_or_value_css_declaration( $style_value, $style_definition ) {
 		if ( empty( $style_value ) ) {
 			return array();
 		}

--- a/packages/style-engine/class-wp-style-engine.php
+++ b/packages/style-engine/class-wp-style-engine.php
@@ -42,7 +42,7 @@ final class WP_Style_Engine {
 	 *
 	 * @var array
 	 */
-	public static $block_style_definition_metadata = array();
+	private static $block_style_definition_metadata = array();
 
 	/**
 	 * Registers a style definition metadata for a defined path.
@@ -90,7 +90,7 @@ final class WP_Style_Engine {
 	 *
 	 * @return string The css var, or an empty string if no match for slug found.
 	 */
-	public static function get_css_var_value( $style_value, $css_vars ) {
+	protected static function get_css_var_value( $style_value, $css_vars ) {
 		foreach ( $css_vars as  $property_key => $css_var_pattern ) {
 			$slug = static::get_slug_from_preset_value( $style_value, $property_key );
 			if ( static::is_valid_style_value( $slug ) ) {
@@ -293,6 +293,95 @@ final class WP_Style_Engine {
 		}
 
 		$css_declarations[ $style_property_keys['default'] ] = $style_value;
+		return $css_declarations;
+	}
+
+	/**
+	 * Style value parser that returns a CSS definition array comprising style properties
+	 * that have keys representing individual style properties, otherwise known as longhand CSS properties.
+	 * e.g., "$style_property-$individual_feature: $value;", which could represent the following:
+	 * "border-{top|right|bottom|left}-{color|width|style}: {value};" or,
+	 * "border-image-{outset|source|width|repeat|slice}: {value};"
+	 *
+	 * @param array $style_value                    A single raw style value from $block_styles array.
+	 * @param array $individual_property_definition A single style definition from static::$block_style_definition_metadata,
+	 *                                              representing an individual property of a CSS property, e.g., 'top' in 'border-top'.
+	 * @param array $options                        {
+	 *     Optional. An array of options. Default empty array.
+	 *
+	 *     @type bool $convert_vars_to_classnames Whether to skip converting incoming CSS var patterns, e.g., `var:preset|<PRESET_TYPE>|<PRESET_SLUG>`, to var( --wp--preset--* ) values. Default `false`.
+	 * }
+	 *
+	 * @return string[] An associative array of CSS definitions, e.g., array( "$property" => "$value", "$property" => "$value" ).
+	 */
+	protected static function get_individual_property_css_declarations( $style_value, $individual_property_definition, $options = array() ) {
+		if ( ! is_array( $style_value ) || empty( $style_value ) || empty( $individual_property_definition['path'] ) ) {
+			return array();
+		}
+
+		/*
+		 * The first item in $individual_property_definition['path'] array tells us the style property, e.g., "border".
+		 * We use this to get a corresponding CSS style definition such as "color" or "width" from the same group.
+		 * The second item in $individual_property_definition['path'] array refers to the individual property marker, e.g., "top".
+		 */
+		$definition_group_key    = $individual_property_definition['path'][0];
+		$individual_property_key = $individual_property_definition['path'][1];
+		$should_skip_css_vars    = isset( $options['convert_vars_to_classnames'] ) && true === $options['convert_vars_to_classnames'];
+		$css_declarations        = array();
+
+		foreach ( $style_value as $css_property => $value ) {
+			if ( empty( $value ) ) {
+				continue;
+			}
+
+			// Build a path to the individual rules in definitions.
+			$style_definition_path = array( $definition_group_key, $css_property );
+			$style_definition      = _wp_array_get( static::$block_style_definition_metadata, $style_definition_path, null );
+
+			if ( $style_definition && isset( $style_definition['property_keys']['individual'] ) ) {
+				// Set a CSS var if there is a valid preset value.
+				if ( is_string( $value ) && str_contains( $value, 'var:' ) && ! $should_skip_css_vars && ! empty( $individual_property_definition['css_vars'] ) ) {
+					$value = static::get_css_var_value( $value, $individual_property_definition['css_vars'] );
+				}
+				$individual_css_property                      = sprintf( $style_definition['property_keys']['individual'], $individual_property_key );
+				$css_declarations[ $individual_css_property ] = $value;
+			}
+		}
+		return $css_declarations;
+	}
+
+	/**
+	 * Style value parser that constructs a CSS definition array comprising a single CSS property and value.
+	 * If the provided value is an array containing a `url` property, the function will return a CSS definition array
+	 * with a single property and value, with `url` escaped and injected into a CSS `url()` function,
+	 * e.g., array( 'background-image' => "url( '...' )" ).
+	 *
+	 * @param array $style_value      A single raw style value from $block_styles array.
+	 * @param array $style_definition A single style definition from static::$block_style_definition_metadata.
+	 *
+	 * @return string[] An associative array of CSS definitions, e.g., array( "$property" => "$value", "$property" => "$value" ).
+	 */
+	protected static function get_url_or_value_css_declaration( $style_value, $style_definition ) {
+		if ( empty( $style_value ) ) {
+			return array();
+		}
+
+		$css_declarations = array();
+
+		if ( isset( $style_definition['property_keys']['default'] ) ) {
+			$value = null;
+
+			if ( ! empty( $style_value['url'] ) ) {
+				$value = "url('" . $style_value['url'] . "')";
+			} elseif ( is_string( $style_value ) ) {
+				$value = $style_value;
+			}
+
+			if ( null !== $value ) {
+				$css_declarations[ $style_definition['property_keys']['default'] ] = $value;
+			}
+		}
+
 		return $css_declarations;
 	}
 


### PR DESCRIPTION
## What?
Moves defining the `BLOCK_STYLE_DEFINITIONS_METADATA` outside the styles engine, and in the respective block-supports.

## Why?
* Separation of concerns: Each block-support is responsible for adding its own definitions
* Avoid noise in the styles-engine object
* Extensibility

## How?
* Add a new `register_block_style_definitions_metadata` method in the `WP_Style_Engine` class.
* Move the arrays of data to their respective block-supports.

## Testing Instructions

## Screenshots or screencast <!-- if applicable -->
