### PR TITLE
Lodash: Remove completely from `@wordpress/media-utils` package

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -82,6 +82,7 @@ module.exports = {
 							'chunk',
 							'clamp',
 							'concat',
+							'defaults',
 							'defaultTo',
 							'differenceWith',
 							'dropRight',

--- a/package-lock.json
+++ b/package-lock.json
@@ -17496,8 +17496,7 @@
 				"@wordpress/api-fetch": "file:packages/api-fetch",
 				"@wordpress/blob": "file:packages/blob",
 				"@wordpress/element": "file:packages/element",
-				"@wordpress/i18n": "file:packages/i18n",
-				"lodash": "^4.17.21"
+				"@wordpress/i18n": "file:packages/i18n"
 			}
 		},
 		"@wordpress/notices": {

--- a/packages/media-utils/package.json
+++ b/packages/media-utils/package.json
@@ -29,8 +29,7 @@
 		"@wordpress/api-fetch": "file:../api-fetch",
 		"@wordpress/blob": "file:../blob",
 		"@wordpress/element": "file:../element",
-		"@wordpress/i18n": "file:../i18n",
-		"lodash": "^4.17.21"
+		"@wordpress/i18n": "file:../i18n"
 	},
 	"publishConfig": {
 		"access": "public"


### PR DESCRIPTION
## What?
This PR removes all of the Lodash from the `@wordpress/media-utils` package, including the `lodash` dependency altogether. There are just a few usages and conversion is pretty straightforward. 

## Why?

Lodash is known to unnecessarily inflate the bundle size of packages, and in most cases, it can be replaced with native language functionality. See these for more information and rationale:

* https://github.com/WordPress/gutenberg/issues/16938#issuecomment-602837246
* https://github.com/WordPress/gutenberg/issues/17025
* https://github.com/WordPress/gutenberg/issues/39495 

## How?
This PR could serve as a demonstration of why Lodash can be just completely unnecessary and can most often be replaced with elegant JavaScript code. We're dealing with replacing a few methods, namely:

#### `defaults`

For the simple use case, it can be replaced just by creating a new object and using object spread syntax. This is the one and only usage of this method, so we're also deprecating it in ESLint as well.

#### `castArray`

Replacing `castArray` is as simple as checking if X is an array, and creating an array with the X element if it's not.

#### `pick`

Replacing `pick` is generally pretty easy when we destructure a few object properties we can name, and create an object with them. However, the usage here has a bit more properties, so we're using a `reduce()` call to iterate through them all. 

#### `compact`

One of the most straightforward conversions when it's called with arrays - we can just replace it with `Array.prototype.filter( Boolean )`.

#### `flatMap`

We're replacing it with a `map()` on the result of `Object.entries()`, followed by a `.flat()` to flatten the result array.

#### `forEach`

Simple enough to replace with `Array.prototype.forEach()`

#### `get`

Straightforward replace with direct access, when necessary we add optional chaining and use nullish coalescing for handling default values.

#### `has`

Usually replaced with `Object.hasOwn()` or `Object.hasOwnProperty()`, but in this case it's not necessary, because an `Error` object always has a `message`, and even if it doesn't, we're still allowed to access an undefined property.

#### `includes`

Simple enough to replace with `Array.prototype.includes()` and `String.prototype.includes()`.

#### `map`

Simple enough to replace with `Array.prototype.map()`.

#### `omit`

We're using destructuring with rest props, which nicely handles the omission.

#### `some`

Simple enough to replace with `Array.prototype.some()`

#### `startsWith`

Simple enough to replace with `String.prototype.startsWith()`.

## Testing Instructions

* Insert a Gallery block.
* Upload a few images in it and create a gallery from them.
* While an image is selected, click "Replace" and click on "Open Media Library".
* Verify tests pass: `npm run test-unit packages/media-utils/src/utils`