### PR TITLE
Add local dev notes to aid when doing work on schemas

### DIFF
--- a/schemas/README.md
+++ b/schemas/README.md
@@ -34,4 +34,30 @@ For a specific version of the schema, replace `trunk` with `wp/X.X`:
 
 Visual Studio Code and PhpStorm are two popular editors that work out of the box. However, some editors require a plugin installed, and not all editors recognize the `$schema` property. Check your editor's documentation for details. Additionally, [SchemaStore.org](https://www.schemastore.org/) and [JSON Schema](https://json-schema.org/implementations.html#editors) have lists of editors known to have support if your current editor is unsupported.
 
+## Local Development
+
+You may wish to update one of the schemas to conform to a new change in the structure. In order to do this you'll want to be able to see how your changes impact how your IDE displays schema information.
+
+To allow this you will need to:
+
+-   update your theme's `theme.json` to reference the _local_ version of the schema file:
+
+```json
+{
+	"$schema": "file://{{FULL_FILE_PATH}}/schemas/json/theme.json"
+}
+```
+
+-   update your block's `block.json` to include:
+
+```json
+{
+	"$schema": "file://{{FULL_FILE_PATH}}/schemas/json/block.json"
+}
+```
+
+Be sure to replace `{{FULL_FILE_PATH}}` with the full local path to your Gutenberg repo.
+
+With this in place you should now be able to edit either `schemas/json/theme .json` or `schemas/json/block.json` in order to see changes reflected in `theme.json` or `block.json` in your IDE.
+
 <br/><br/><p align="center"><img src="https://s.w.org/style/images/codeispoetry.png?1" alt="Code is Poetry." /></p>


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Update the docs to explain how to do local dev on the schemas.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

This information was missing from the docs and I had to work it out myself.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

Provides information on setting your `theme.json` to point at a local schema rather than the "hosted" version.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->

- Read docs
- Try following the instructions to see if you can get the changes to your local schema to be reflected in a `theme.json` file. 

## Screenshots or screencast <!-- if applicable -->
