### PR TITLE
Lodash: Remove completely from `@wordpress/keyboard-shortcuts` package

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17458,7 +17458,6 @@
 				"@wordpress/data": "file:packages/data",
 				"@wordpress/element": "file:packages/element",
 				"@wordpress/keycodes": "file:packages/keycodes",
-				"lodash": "^4.17.21",
 				"rememo": "^4.0.0"
 			}
 		},

--- a/packages/keyboard-shortcuts/package.json
+++ b/packages/keyboard-shortcuts/package.json
@@ -29,7 +29,6 @@
 		"@wordpress/data": "file:../data",
 		"@wordpress/element": "file:../element",
 		"@wordpress/keycodes": "file:../keycodes",
-		"lodash": "^4.17.21",
 		"rememo": "^4.0.0"
 	},
 	"peerDependencies": {

--- a/packages/keyboard-shortcuts/src/store/reducer.js
+++ b/packages/keyboard-shortcuts/src/store/reducer.js
@@ -1,9 +1,4 @@
 /**
- * External dependencies
- */
-import { omit } from 'lodash';
-
-/**
  * Reducer returning the registered shortcuts
  *
  * @param {Object} state  Current state.
@@ -24,7 +19,8 @@ function reducer( state = {}, action ) {
 				},
 			};
 		case 'UNREGISTER_SHORTCUT':
-			return omit( state, action.name );
+			const { [ action.name ]: actionName, ...remainingState } = state;
+			return remainingState;
 	}
 
 	return state;

--- a/packages/keyboard-shortcuts/src/store/selectors.js
+++ b/packages/keyboard-shortcuts/src/store/selectors.js
@@ -2,7 +2,6 @@
  * External dependencies
  */
 import createSelector from 'rememo';
-import { compact } from 'lodash';
 
 /**
  * WordPress dependencies
@@ -118,10 +117,10 @@ export function getShortcutAliases( state, name ) {
 
 export const getAllShortcutKeyCombinations = createSelector(
 	( state, name ) => {
-		return compact( [
+		return [
 			getShortcutKeyCombination( state, name ),
 			...getShortcutAliases( state, name ),
-		] );
+		].filter( Boolean );
 	},
 	( state, name ) => [ state[ name ] ]
 );


### PR DESCRIPTION
## What?
This PR removes all of the Lodash from the `@wordpress/keyboard-shortcuts` package, including the `lodash` dependency altogether. There are just a few usages and conversion is pretty straightforward. 

## Why?

Lodash is known to unnecessarily inflate the bundle size of packages, and in most cases, it can be replaced with native language functionality. See these for more information and rationale:

* https://github.com/WordPress/gutenberg/issues/16938#issuecomment-602837246
* https://github.com/WordPress/gutenberg/issues/17025
* https://github.com/WordPress/gutenberg/issues/39495 

## How?
We're dealing with straightforwardly replacing a few methods, namely:

#### `compact`

One of the most straightforward conversions when it's called with arrays - we can just replace it with `Array.prototype.filter( Boolean )`.

#### `omit`

We're using destructuring with rest props, which nicely handles the omission.

## Testing Instructions

This is not very straightforward to test, as unregistering the keyboard shortcuts requires manual modifications to trigger. However, you can verify that keyboard shortcuts within the customizer block widgets still work well.