### PR TITLE
Rich text: remove placeholder on composition start

### DIFF
--- a/packages/rich-text/src/component/use-input-and-selection.js
+++ b/packages/rich-text/src/component/use-input-and-selection.js
@@ -48,7 +48,7 @@ function fixPlaceholderSelection( defaultView ) {
 	if (
 		! targetNode ||
 		targetNode.nodeType !== targetNode.ELEMENT_NODE ||
-		! targetNode.getAttribute( PLACEHOLDER_ATTR_NAME )
+		! targetNode.hasAttribute( PLACEHOLDER_ATTR_NAME )
 	) {
 		return;
 	}

--- a/packages/rich-text/src/component/use-input-and-selection.js
+++ b/packages/rich-text/src/component/use-input-and-selection.js
@@ -27,6 +27,8 @@ const INSERTION_INPUT_TYPES_TO_IGNORE = new Set( [
 
 const EMPTY_ACTIVE_FORMATS = [];
 
+const PLACEHOLDER_ATTR_NAME = 'data-rich-text-placeholder';
+
 /**
  * If the selection is set on the placeholder element, collapse the selection to
  * the start (before the placeholder).
@@ -46,7 +48,7 @@ function fixPlaceholderSelection( defaultView ) {
 	if (
 		! targetNode ||
 		targetNode.nodeType !== targetNode.ELEMENT_NODE ||
-		! targetNode.getAttribute( 'data-rich-text-placeholder' )
+		! targetNode.getAttribute( PLACEHOLDER_ATTR_NAME )
 	) {
 		return;
 	}
@@ -238,6 +240,11 @@ export function useInputAndSelection( props ) {
 				'selectionchange',
 				handleSelectionChange
 			);
+			// Remove the placeholder. Since the rich text value doesn't update
+			// during composition, the placeholder doesn't get removed. There's
+			// no need to re-add it, when the value is updated on compositionend
+			// it will be re-added when the value is empty.
+			element.querySelector( `[${ PLACEHOLDER_ATTR_NAME }]` ).remove();
 		}
 
 		function onCompositionEnd() {


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?

When composing characters in rich text, the placeholder remains in place because the rich text value doesn't update internally. We can't update the value internally because that would destroy the state of composition set by the browser (because we modify the dom). So the only option we have is to remove it from the dom on composition start. An ugly solution, but can't think of another way right now.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->

## Screenshots or screencast <!-- if applicable -->
