### PR TITLE
Add link element `:hover` interactivity control to global styles UI

### DIFF
--- a/packages/edit-site/src/components/global-styles/screen-colors.js
+++ b/packages/edit-site/src/components/global-styles/screen-colors.js
@@ -82,6 +82,12 @@ function LinkColorItem( { name, parentMenu } ) {
 	const supports = getSupportedGlobalStylesPanels( name );
 	const hasSupport = supports.includes( 'linkColor' );
 	const [ color ] = useStyle( 'elements.link.color.text', name );
+	const [ colorHover ] = useStyle( 'elements.link.:hover.color.text', name );
+	const [ colorFocus ] = useStyle( 'elements.link.:focus.color.text', name );
+	const [ colorActive ] = useStyle(
+		'elements.link.:active.color.text',
+		name
+	);
 
 	if ( ! hasSupport ) {
 		return null;
@@ -93,9 +99,20 @@ function LinkColorItem( { name, parentMenu } ) {
 			aria-label={ __( 'Colors link styles' ) }
 		>
 			<HStack justify="flex-start">
-				<ColorIndicatorWrapper expanded={ false }>
-					<ColorIndicator colorValue={ color } />
-				</ColorIndicatorWrapper>
+				<ZStack isLayered={ false } offset={ -8 }>
+					<ColorIndicatorWrapper expanded={ false }>
+						<ColorIndicator colorValue={ color } />
+					</ColorIndicatorWrapper>
+					<ColorIndicatorWrapper expanded={ false }>
+						<ColorIndicator colorValue={ colorHover } />
+					</ColorIndicatorWrapper>
+					<ColorIndicatorWrapper expanded={ false }>
+						<ColorIndicator colorValue={ colorFocus } />
+					</ColorIndicatorWrapper>
+					<ColorIndicatorWrapper expanded={ false }>
+						<ColorIndicator colorValue={ colorActive } />
+					</ColorIndicatorWrapper>
+				</ZStack>
 				<FlexItem>{ __( 'Links' ) }</FlexItem>
 			</HStack>
 		</NavigationButtonAsItem>

--- a/packages/edit-site/src/components/global-styles/screen-colors.js
+++ b/packages/edit-site/src/components/global-styles/screen-colors.js
@@ -83,11 +83,6 @@ function LinkColorItem( { name, parentMenu } ) {
 	const hasSupport = supports.includes( 'linkColor' );
 	const [ color ] = useStyle( 'elements.link.color.text', name );
 	const [ colorHover ] = useStyle( 'elements.link.:hover.color.text', name );
-	const [ colorFocus ] = useStyle( 'elements.link.:focus.color.text', name );
-	const [ colorActive ] = useStyle(
-		'elements.link.:active.color.text',
-		name
-	);
 
 	if ( ! hasSupport ) {
 		return null;
@@ -105,12 +100,6 @@ function LinkColorItem( { name, parentMenu } ) {
 					</ColorIndicatorWrapper>
 					<ColorIndicatorWrapper expanded={ false }>
 						<ColorIndicator colorValue={ colorHover } />
-					</ColorIndicatorWrapper>
-					<ColorIndicatorWrapper expanded={ false }>
-						<ColorIndicator colorValue={ colorFocus } />
-					</ColorIndicatorWrapper>
-					<ColorIndicatorWrapper expanded={ false }>
-						<ColorIndicator colorValue={ colorActive } />
 					</ColorIndicatorWrapper>
 				</ZStack>
 				<FlexItem>{ __( 'Links' ) }</FlexItem>

--- a/packages/edit-site/src/components/global-styles/screen-link-color.js
+++ b/packages/edit-site/src/components/global-styles/screen-link-color.js
@@ -3,7 +3,7 @@
  */
 import { __ } from '@wordpress/i18n';
 import { __experimentalColorGradientControl as ColorGradientControl } from '@wordpress/block-editor';
-
+import { TabPanel } from '@wordpress/components';
 /**
  * Internal dependencies
  */
@@ -48,21 +48,48 @@ function ScreenLinkColor( { name } ) {
 			<ScreenHeader
 				title={ __( 'Links' ) }
 				description={ __(
-					'Set the default color used for links across the site.'
+					'Set the colors used for links across the site.'
 				) }
 			/>
-			<ColorGradientControl
-				className="edit-site-screen-link-color__control"
-				colors={ colorsPerOrigin }
-				disableCustomColors={ ! areCustomSolidsEnabled }
-				__experimentalHasMultipleOrigins
-				showTitle={ false }
-				enableAlpha
-				__experimentalIsRenderedInSidebar
-				colorValue={ linkColor }
-				onColorChange={ setLinkColor }
-				clearable={ linkColor === userLinkColor }
-			/>
+
+			<TabPanel
+				className="my-tab-panel"
+				tabs={ [
+					{
+						name: 'default',
+						title: 'Default',
+						className: 'color-text-default',
+					},
+					{
+						name: 'hover',
+						title: 'Hover',
+						className: 'color-text-hover',
+					},
+					{
+						name: 'focus',
+						title: 'Focus',
+						className: 'color-text-focus',
+					},
+				] }
+			>
+				{ ( tab ) => (
+					<>
+						<p>Selected tab: { tab.title }</p>
+						<ColorGradientControl
+							className="edit-site-screen-link-color__control"
+							colors={ colorsPerOrigin }
+							disableCustomColors={ ! areCustomSolidsEnabled }
+							__experimentalHasMultipleOrigins
+							showTitle={ false }
+							enableAlpha
+							__experimentalIsRenderedInSidebar
+							colorValue={ linkColor }
+							onColorChange={ setLinkColor }
+							clearable={ linkColor === userLinkColor }
+						/>
+					</>
+				) }
+			</TabPanel>
 		</>
 	);
 }

--- a/packages/edit-site/src/components/global-styles/screen-link-color.js
+++ b/packages/edit-site/src/components/global-styles/screen-link-color.js
@@ -33,11 +33,36 @@ function ScreenLinkColor( { name } ) {
 		'elements.link.color.text',
 		name
 	);
+
+	const [ linkHoverColor, setLinkHoverColor ] = useStyle(
+		'elements.link.:hover.color.text',
+		name
+	);
+
 	const [ userLinkColor ] = useStyle(
 		'elements.link.color.text',
 		name,
 		'user'
 	);
+
+	const [ userLinkHoverColor ] = useStyle(
+		'elements.link.:hover.color.text',
+		name,
+		'user'
+	);
+
+	const PSEUDOSTATES = {
+		default: {
+			value: linkColor,
+			handler: setLinkColor,
+			userValue: userLinkColor,
+		},
+		hover: {
+			value: linkHoverColor,
+			handler: setLinkHoverColor,
+			userValue: userLinkHoverColor,
+		},
+	};
 
 	if ( ! hasLinkColor ) {
 		return null;
@@ -65,30 +90,35 @@ function ScreenLinkColor( { name } ) {
 						title: 'Hover',
 						className: 'color-text-hover',
 					},
-					{
-						name: 'focus',
-						title: 'Focus',
-						className: 'color-text-focus',
-					},
 				] }
 			>
-				{ ( tab ) => (
-					<>
-						<p>Selected tab: { tab.title }</p>
-						<ColorGradientControl
-							className="edit-site-screen-link-color__control"
-							colors={ colorsPerOrigin }
-							disableCustomColors={ ! areCustomSolidsEnabled }
-							__experimentalHasMultipleOrigins
-							showTitle={ false }
-							enableAlpha
-							__experimentalIsRenderedInSidebar
-							colorValue={ linkColor }
-							onColorChange={ setLinkColor }
-							clearable={ linkColor === userLinkColor }
-						/>
-					</>
-				) }
+				{ ( tab ) => {
+					const psuedoSelector = tab.name;
+
+					return (
+						<>
+							<ColorGradientControl
+								className="edit-site-screen-link-color__control"
+								colors={ colorsPerOrigin }
+								disableCustomColors={ ! areCustomSolidsEnabled }
+								__experimentalHasMultipleOrigins
+								showTitle={ false }
+								enableAlpha
+								__experimentalIsRenderedInSidebar
+								colorValue={
+									PSEUDOSTATES[ psuedoSelector ].value
+								}
+								onColorChange={
+									PSEUDOSTATES[ psuedoSelector ].handler
+								}
+								clearable={
+									PSEUDOSTATES[ psuedoSelector ].value ===
+									PSEUDOSTATES[ psuedoSelector ].userValue
+								}
+							/>
+						</>
+					);
+				} }
 			</TabPanel>
 		</>
 	);

--- a/packages/edit-site/src/components/global-styles/screen-link-color.js
+++ b/packages/edit-site/src/components/global-styles/screen-link-color.js
@@ -15,11 +15,6 @@ import {
 	useColorsPerOrigin,
 } from './hooks';
 
-function ucFirst( str ) {
-	if ( ! str ) return str;
-	return str[ 0 ].toUpperCase() + str.slice( 1 );
-}
-
 function ScreenLinkColor( { name } ) {
 	const supports = getSupportedGlobalStylesPanels( name );
 	const [ solids ] = useSetting( 'color.palette', name );
@@ -36,6 +31,7 @@ function ScreenLinkColor( { name } ) {
 
 	const pseudoStates = {
 		default: {
+			label: __( 'Default' ),
 			...useStyle( 'elements.link.color.text', name ).reduce(
 				( acc, psuedoSelector, index ) => {
 					acc[ index === 0 ? 'value' : 'handler' ] = psuedoSelector;
@@ -50,6 +46,7 @@ function ScreenLinkColor( { name } ) {
 			)[ 0 ],
 		},
 		hover: {
+			label: __( 'Hover' ),
 			...useStyle( 'elements.link.:hover.color.text', name ).reduce(
 				( acc, psuedoSelector, index ) => {
 					acc[ index === 0 ? 'value' : 'handler' ] = psuedoSelector;
@@ -69,13 +66,15 @@ function ScreenLinkColor( { name } ) {
 		return null;
 	}
 
-	const tabs = Object.keys( pseudoStates ).map( ( pseudoSelector ) => {
-		return {
-			name: pseudoSelector,
-			title: ucFirst( pseudoSelector ),
-			className: `color-text-${ pseudoSelector }`,
-		};
-	} );
+	const tabs = Object.entries( pseudoStates ).map(
+		( [ selector, config ] ) => {
+			return {
+				name: selector,
+				title: config.label,
+				className: `color-text-${ selector }`,
+			};
+		}
+	);
 
 	return (
 		<>

--- a/packages/edit-site/src/components/global-styles/screen-link-color.js
+++ b/packages/edit-site/src/components/global-styles/screen-link-color.js
@@ -15,6 +15,11 @@ import {
 	useColorsPerOrigin,
 } from './hooks';
 
+function ucFirst( str ) {
+	if ( ! str ) return str;
+	return str[ 0 ].toUpperCase() + str.slice( 1 );
+}
+
 function ScreenLinkColor( { name } ) {
 	const supports = getSupportedGlobalStylesPanels( name );
 	const [ solids ] = useSetting( 'color.palette', name );
@@ -68,6 +73,14 @@ function ScreenLinkColor( { name } ) {
 		return null;
 	}
 
+	const tabs = Object.keys( PSEUDOSTATES ).map( ( pseudoSelector ) => {
+		return {
+			name: pseudoSelector,
+			title: ucFirst( pseudoSelector ),
+			className: `color-text-${ pseudoSelector }`,
+		};
+	} );
+
 	return (
 		<>
 			<ScreenHeader
@@ -77,21 +90,7 @@ function ScreenLinkColor( { name } ) {
 				) }
 			/>
 
-			<TabPanel
-				className="my-tab-panel"
-				tabs={ [
-					{
-						name: 'default',
-						title: 'Default',
-						className: 'color-text-default',
-					},
-					{
-						name: 'hover',
-						title: 'Hover',
-						className: 'color-text-hover',
-					},
-				] }
-			>
+			<TabPanel className="my-tab-panel" tabs={ tabs }>
 				{ ( tab ) => {
 					const psuedoSelector = tab.name;
 

--- a/packages/edit-site/src/components/global-styles/screen-link-color.js
+++ b/packages/edit-site/src/components/global-styles/screen-link-color.js
@@ -32,13 +32,8 @@ function ScreenLinkColor( { name } ) {
 	const pseudoStates = {
 		default: {
 			label: __( 'Default' ),
-			...useStyle( 'elements.link.color.text', name ).reduce(
-				( acc, pseudoSelector, index ) => {
-					acc[ index === 0 ? 'value' : 'handler' ] = pseudoSelector;
-					return acc;
-				},
-				{}
-			),
+			value: useStyle( 'elements.link.color.text', name )[ 0 ],
+			handler: useStyle( 'elements.link.color.text', name )[ 1 ],
 			userValue: useStyle(
 				'elements.link.color.text',
 				name,
@@ -47,13 +42,8 @@ function ScreenLinkColor( { name } ) {
 		},
 		hover: {
 			label: __( 'Hover' ),
-			...useStyle( 'elements.link.:hover.color.text', name ).reduce(
-				( acc, pseudoSelector, index ) => {
-					acc[ index === 0 ? 'value' : 'handler' ] = pseudoSelector;
-					return acc;
-				},
-				{}
-			),
+			value: useStyle( 'elements.link.:hover.color.text', name )[ 0 ],
+			handler: useStyle( 'elements.link.:hover.color.text', name )[ 1 ],
 			userValue: useStyle(
 				'elements.link.:hover.color.text',
 				name,

--- a/packages/edit-site/src/components/global-styles/screen-link-color.js
+++ b/packages/edit-site/src/components/global-styles/screen-link-color.js
@@ -39,6 +39,16 @@ function ScreenLinkColor( { name } ) {
 		name
 	);
 
+	const [ linkFocusColor, setLinkFocusColor ] = useStyle(
+		'elements.link.:focus.color.text',
+		name
+	);
+
+	const [ linkActiveColor, setLinkActiveColor ] = useStyle(
+		'elements.link.:active.color.text',
+		name
+	);
+
 	const [ userLinkColor ] = useStyle(
 		'elements.link.color.text',
 		name,
@@ -47,6 +57,18 @@ function ScreenLinkColor( { name } ) {
 
 	const [ userLinkHoverColor ] = useStyle(
 		'elements.link.:hover.color.text',
+		name,
+		'user'
+	);
+
+	const [ userLinkFocusColor ] = useStyle(
+		'elements.link.:focus.color.text',
+		name,
+		'user'
+	);
+
+	const [ userLinkActiveColor ] = useStyle(
+		'elements.link.:active.color.text',
 		name,
 		'user'
 	);
@@ -61,6 +83,16 @@ function ScreenLinkColor( { name } ) {
 			value: linkHoverColor,
 			handler: setLinkHoverColor,
 			userValue: userLinkHoverColor,
+		},
+		focus: {
+			value: linkFocusColor,
+			handler: setLinkFocusColor,
+			userValue: userLinkFocusColor,
+		},
+		active: {
+			value: linkActiveColor,
+			handler: setLinkActiveColor,
+			userValue: userLinkActiveColor,
 		},
 	};
 
@@ -89,6 +121,16 @@ function ScreenLinkColor( { name } ) {
 						name: 'hover',
 						title: 'Hover',
 						className: 'color-text-hover',
+					},
+					{
+						name: 'focus',
+						title: 'Focus',
+						className: 'color-text-focus',
+					},
+					{
+						name: 'active',
+						title: 'Active',
+						className: 'color-text-active',
 					},
 				] }
 			>

--- a/packages/edit-site/src/components/global-styles/screen-link-color.js
+++ b/packages/edit-site/src/components/global-styles/screen-link-color.js
@@ -39,16 +39,6 @@ function ScreenLinkColor( { name } ) {
 		name
 	);
 
-	const [ linkFocusColor, setLinkFocusColor ] = useStyle(
-		'elements.link.:focus.color.text',
-		name
-	);
-
-	const [ linkActiveColor, setLinkActiveColor ] = useStyle(
-		'elements.link.:active.color.text',
-		name
-	);
-
 	const [ userLinkColor ] = useStyle(
 		'elements.link.color.text',
 		name,
@@ -57,18 +47,6 @@ function ScreenLinkColor( { name } ) {
 
 	const [ userLinkHoverColor ] = useStyle(
 		'elements.link.:hover.color.text',
-		name,
-		'user'
-	);
-
-	const [ userLinkFocusColor ] = useStyle(
-		'elements.link.:focus.color.text',
-		name,
-		'user'
-	);
-
-	const [ userLinkActiveColor ] = useStyle(
-		'elements.link.:active.color.text',
 		name,
 		'user'
 	);
@@ -83,16 +61,6 @@ function ScreenLinkColor( { name } ) {
 			value: linkHoverColor,
 			handler: setLinkHoverColor,
 			userValue: userLinkHoverColor,
-		},
-		focus: {
-			value: linkFocusColor,
-			handler: setLinkFocusColor,
-			userValue: userLinkFocusColor,
-		},
-		active: {
-			value: linkActiveColor,
-			handler: setLinkActiveColor,
-			userValue: userLinkActiveColor,
 		},
 	};
 
@@ -121,16 +89,6 @@ function ScreenLinkColor( { name } ) {
 						name: 'hover',
 						title: 'Hover',
 						className: 'color-text-hover',
-					},
-					{
-						name: 'focus',
-						title: 'Focus',
-						className: 'color-text-focus',
-					},
-					{
-						name: 'active',
-						title: 'Active',
-						className: 'color-text-active',
 					},
 				] }
 			>

--- a/packages/edit-site/src/components/global-styles/screen-link-color.js
+++ b/packages/edit-site/src/components/global-styles/screen-link-color.js
@@ -88,7 +88,12 @@ function ScreenLinkColor( { name } ) {
 
 			<TabPanel className="my-tab-panel" tabs={ tabs }>
 				{ ( tab ) => {
-					const psuedoSelector = tab.name;
+					const pseudoSelectorConfig =
+						pseudoStates[ tab.name ] ?? null;
+
+					if ( ! pseudoSelectorConfig ) {
+						return null;
+					}
 
 					return (
 						<>
@@ -100,15 +105,11 @@ function ScreenLinkColor( { name } ) {
 								showTitle={ false }
 								enableAlpha
 								__experimentalIsRenderedInSidebar
-								colorValue={
-									pseudoStates[ psuedoSelector ].value
-								}
-								onColorChange={
-									pseudoStates[ psuedoSelector ].handler
-								}
+								colorValue={ pseudoSelectorConfig.value }
+								onColorChange={ pseudoSelectorConfig.handler }
 								clearable={
-									pseudoStates[ psuedoSelector ].value ===
-									pseudoStates[ psuedoSelector ].userValue
+									pseudoSelectorConfig.value ===
+									pseudoSelectorConfig.userValue
 								}
 							/>
 						</>

--- a/packages/edit-site/src/components/global-styles/screen-link-color.js
+++ b/packages/edit-site/src/components/global-styles/screen-link-color.js
@@ -33,8 +33,8 @@ function ScreenLinkColor( { name } ) {
 		default: {
 			label: __( 'Default' ),
 			...useStyle( 'elements.link.color.text', name ).reduce(
-				( acc, psuedoSelector, index ) => {
-					acc[ index === 0 ? 'value' : 'handler' ] = psuedoSelector;
+				( acc, pseudoSelector, index ) => {
+					acc[ index === 0 ? 'value' : 'handler' ] = pseudoSelector;
 					return acc;
 				},
 				{}
@@ -48,8 +48,8 @@ function ScreenLinkColor( { name } ) {
 		hover: {
 			label: __( 'Hover' ),
 			...useStyle( 'elements.link.:hover.color.text', name ).reduce(
-				( acc, psuedoSelector, index ) => {
-					acc[ index === 0 ? 'value' : 'handler' ] = psuedoSelector;
+				( acc, pseudoSelector, index ) => {
+					acc[ index === 0 ? 'value' : 'handler' ] = pseudoSelector;
 					return acc;
 				},
 				{}

--- a/packages/edit-site/src/components/global-styles/screen-link-color.js
+++ b/packages/edit-site/src/components/global-styles/screen-link-color.js
@@ -34,38 +34,34 @@ function ScreenLinkColor( { name } ) {
 		isLinkEnabled &&
 		( solids.length > 0 || areCustomSolidsEnabled );
 
-	const [ linkColor, setLinkColor ] = useStyle(
-		'elements.link.color.text',
-		name
-	);
-
-	const [ linkHoverColor, setLinkHoverColor ] = useStyle(
-		'elements.link.:hover.color.text',
-		name
-	);
-
-	const [ userLinkColor ] = useStyle(
-		'elements.link.color.text',
-		name,
-		'user'
-	);
-
-	const [ userLinkHoverColor ] = useStyle(
-		'elements.link.:hover.color.text',
-		name,
-		'user'
-	);
-
-	const PSEUDOSTATES = {
+	const pseudoStates = {
 		default: {
-			value: linkColor,
-			handler: setLinkColor,
-			userValue: userLinkColor,
+			...useStyle( 'elements.link.color.text', name ).reduce(
+				( acc, psuedoSelector, index ) => {
+					acc[ index === 0 ? 'value' : 'handler' ] = psuedoSelector;
+					return acc;
+				},
+				{}
+			),
+			userValue: useStyle(
+				'elements.link.color.text',
+				name,
+				'user'
+			)[ 0 ],
 		},
 		hover: {
-			value: linkHoverColor,
-			handler: setLinkHoverColor,
-			userValue: userLinkHoverColor,
+			...useStyle( 'elements.link.:hover.color.text', name ).reduce(
+				( acc, psuedoSelector, index ) => {
+					acc[ index === 0 ? 'value' : 'handler' ] = psuedoSelector;
+					return acc;
+				},
+				{}
+			),
+			userValue: useStyle(
+				'elements.link.:hover.color.text',
+				name,
+				'user'
+			)[ 0 ],
 		},
 	};
 
@@ -73,7 +69,7 @@ function ScreenLinkColor( { name } ) {
 		return null;
 	}
 
-	const tabs = Object.keys( PSEUDOSTATES ).map( ( pseudoSelector ) => {
+	const tabs = Object.keys( pseudoStates ).map( ( pseudoSelector ) => {
 		return {
 			name: pseudoSelector,
 			title: ucFirst( pseudoSelector ),
@@ -105,14 +101,14 @@ function ScreenLinkColor( { name } ) {
 								enableAlpha
 								__experimentalIsRenderedInSidebar
 								colorValue={
-									PSEUDOSTATES[ psuedoSelector ].value
+									pseudoStates[ psuedoSelector ].value
 								}
 								onColorChange={
-									PSEUDOSTATES[ psuedoSelector ].handler
+									pseudoStates[ psuedoSelector ].handler
 								}
 								clearable={
-									PSEUDOSTATES[ psuedoSelector ].value ===
-									PSEUDOSTATES[ psuedoSelector ].userValue
+									pseudoStates[ psuedoSelector ].value ===
+									pseudoStates[ psuedoSelector ].userValue
 								}
 							/>
 						</>


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->



## What?
<!-- In a few words, what is the PR actually doing? -->

Building on foundation put in place in https://github.com/WordPress/gutenberg/pull/41786, this PR adds UI to allow users to set interactivity states for the _top level_ link element for:

- [x] hover
- [ ] ~focus~ we decided to simply and handle `:hover` only for now.
- [ ] ~active~ we decided to simply and handle `:hover` only for now.

As ~these are~ this is currently the only value supported in the Theme JSON handler this is all we expose for now.

Note: we deliberately simplified this initial implementation. See https://github.com/WordPress/gutenberg/pull/41976#issuecomment-1170068631 for context.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

We should allow users to set global values for link interactivity.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

Following designs in https://github.com/WordPress/gutenberg/issues/38277#issuecomment-1127757011 this PR adds a tab panel and duplicates the existing color components inside of each tab but this time dynamically generating the values and handlers.

Note: this is currently all very hardcoded and not particularly DRY. However I think that is acceptable and we can refactor as and when we add more elements/states.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->

1. Use a Theme which doesn't have CSS for top level `a` elements or their respective pseudo selectors.
2. Open Global Styles UI.
3. Go into Colors -> Links.
4. Set some colors for default and all of the states. Make sure it's obvious.
5. Click around in the UI and / or use dev tools to trigger the respective interactivity states. 
6. Check they match up with the UI settings.
7. Save. And cross check with front end of the site.

## Screenshots or screencast <!-- if applicable -->


https://user-images.githubusercontent.com/444434/176478942-fcc3814b-7b1e-493e-a2c0-7450624991a2.mp4

<img width="394" alt="Screenshot 2022-06-29 at 16 42 08" src="https://user-images.githubusercontent.com/444434/176478990-cb7f59e7-04f5-4be7-9672-ec56b4e369d0.png">
<img width="415" alt="Screenshot 2022-06-29 at 16 42 04" src="https://user-images.githubusercontent.com/444434/176478995-285518e3-d13d-4351-84d1-14a7f8fe167c.png">



