### PR TITLE
Lodash: Refactor away from `_.lowerCase()`

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -99,6 +99,7 @@ module.exports = {
 							'isObjectLike',
 							'isUndefined',
 							'keys',
+							'lowerCase',
 							'memoize',
 							'negate',
 							'noop',

--- a/packages/components/src/mobile/link-picker/index.native.js
+++ b/packages/components/src/mobile/link-picker/index.native.js
@@ -3,7 +3,6 @@
  */
 import { SafeAreaView, TouchableOpacity, View } from 'react-native';
 import Clipboard from '@react-native-clipboard/clipboard';
-import { lowerCase, startsWith } from 'lodash';
 
 /**
  * WordPress dependencies
@@ -26,7 +25,7 @@ import styles from './styles.scss';
 export const createDirectEntry = ( value ) => {
 	let type = 'URL';
 
-	const protocol = lowerCase( getProtocol( value ) ) || '';
+	const protocol = getProtocol( value )?.toLowerCase() || '';
 
 	if ( protocol.includes( 'mailto' ) ) {
 		type = 'mailto';
@@ -36,7 +35,7 @@ export const createDirectEntry = ( value ) => {
 		type = 'tel';
 	}
 
-	if ( startsWith( value, '#' ) ) {
+	if ( value?.startsWith( '#' ) ) {
 		type = 'internal';
 	}
 


### PR DESCRIPTION
## What?
Lodash's `lowerCase()` is used only once in the entire codebase. This PR aims to remove that usage.

## Why?
Lodash is known to unnecessarily inflate the bundle size of packages, and in most cases, it can be replaced with native language functionality. See these for more information and rationale:

* https://github.com/WordPress/gutenberg/issues/16938#issuecomment-602837246
* https://github.com/WordPress/gutenberg/issues/17025
* https://github.com/WordPress/gutenberg/issues/39495 

## How?
Removing `_.lowerCase()` is straightforward in favor of using `String.prototype.toLowerCase()` with optional chaining. Optional chaining is necessary to ensure we're not running it on an `undefined` - which is a valid scenario for `getProtocol()`.

We're also removing a stray `startsWith()`, which is straightforwardly being replaced with an optionally chained `String.prototype.startsWith()`. Optional chaining is required there, because the `value` is provided externally, and could theoretically be a non-string value.

## Testing Instructions

Follow testing steps here: https://github.com/wordpress-mobile/gutenberg-mobile/pull/2484#issue-448736366