### PR TITLE
Lodash: Remove completely from `@wordpress/shortcode` package

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -86,6 +86,7 @@ module.exports = {
 							'differenceWith',
 							'dropRight',
 							'each',
+							'extend',
 							'findIndex',
 							'findKey',
 							'findLast',

--- a/package-lock.json
+++ b/package-lock.json
@@ -18121,7 +18121,6 @@
 			"version": "file:packages/shortcode",
 			"requires": {
 				"@babel/runtime": "^7.16.0",
-				"lodash": "^4.17.21",
 				"memize": "^1.1.0"
 			}
 		},

--- a/packages/shortcode/package.json
+++ b/packages/shortcode/package.json
@@ -26,7 +26,6 @@
 	"react-native": "src/index",
 	"dependencies": {
 		"@babel/runtime": "^7.16.0",
-		"lodash": "^4.17.21",
 		"memize": "^1.1.0"
 	},
 	"publishConfig": {

--- a/packages/shortcode/src/index.js
+++ b/packages/shortcode/src/index.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { isString, isEqual, forEach } from 'lodash';
+import { isEqual, forEach } from 'lodash';
 import memize from 'memize';
 
 /**
@@ -276,7 +276,7 @@ const shortcode = Object.assign(
 		}
 
 		// Parse a string of attributes.
-		if ( isString( attributes ) ) {
+		if ( typeof attributes === 'string' ) {
 			this.attrs = attrs( attributes );
 			// Identify a correctly formatted `attrs` object.
 		} else if (

--- a/packages/shortcode/src/index.js
+++ b/packages/shortcode/src/index.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { pick, isString, isEqual, forEach } from 'lodash';
+import { isString, isEqual, forEach } from 'lodash';
 import memize from 'memize';
 
 /**
@@ -262,12 +262,8 @@ export function fromMatch( match ) {
  */
 const shortcode = Object.assign(
 	function ( options ) {
-		Object.assign(
-			this,
-			pick( options || {}, 'tag', 'attrs', 'type', 'content' )
-		);
-
-		const attributes = this.attrs;
+		const { tag, attrs: attributes, type, content } = options || {};
+		Object.assign( this, { tag, type, content } );
 
 		// Ensure we have a correctly formatted `attrs` object.
 		this.attrs = {

--- a/packages/shortcode/src/index.js
+++ b/packages/shortcode/src/index.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { extend, pick, isString, isEqual, forEach } from 'lodash';
+import { pick, isString, isEqual, forEach } from 'lodash';
 import memize from 'memize';
 
 /**
@@ -260,9 +260,9 @@ export function fromMatch( match ) {
  *
  * @return {WPShortcode} Shortcode instance.
  */
-const shortcode = extend(
+const shortcode = Object.assign(
 	function ( options ) {
-		extend(
+		Object.assign(
 			this,
 			pick( options || {}, 'tag', 'attrs', 'type', 'content' )
 		);
@@ -304,7 +304,7 @@ const shortcode = extend(
 	}
 );
 
-extend( shortcode.prototype, {
+Object.assign( shortcode.prototype, {
 	/**
 	 * Get a shortcode attribute.
 	 *

--- a/packages/shortcode/src/index.js
+++ b/packages/shortcode/src/index.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { isEqual, forEach } from 'lodash';
+import { forEach } from 'lodash';
 import memize from 'memize';
 
 /**
@@ -275,12 +275,15 @@ const shortcode = Object.assign(
 			return;
 		}
 
+		const attributeTypes = [ 'named', 'numeric' ];
+
 		// Parse a string of attributes.
 		if ( typeof attributes === 'string' ) {
 			this.attrs = attrs( attributes );
 			// Identify a correctly formatted `attrs` object.
 		} else if (
-			isEqual( Object.keys( attributes ), [ 'named', 'numeric' ] )
+			attributes.length === attributeTypes.length &&
+			attributeTypes.every( ( t, key ) => t === attributes[ key ] )
 		) {
 			this.attrs = attributes;
 			// Handle a flat object of attributes.

--- a/packages/shortcode/src/index.js
+++ b/packages/shortcode/src/index.js
@@ -1,7 +1,6 @@
 /**
  * External dependencies
  */
-import { forEach } from 'lodash';
 import memize from 'memize';
 
 /**
@@ -288,7 +287,7 @@ const shortcode = Object.assign(
 			this.attrs = attributes;
 			// Handle a flat object of attributes.
 		} else {
-			forEach( attributes, ( value, key ) => {
+			Object.entries( attributes ).forEach( ( [ key, value ] ) => {
 				this.set( key, value );
 			} );
 		}
@@ -345,7 +344,7 @@ Object.assign( shortcode.prototype, {
 	string() {
 		let text = '[' + this.tag;
 
-		forEach( this.attrs.numeric, ( value ) => {
+		this.attrs.numeric.forEach( ( value ) => {
 			if ( /\s/.test( value ) ) {
 				text += ' "' + value + '"';
 			} else {
@@ -353,7 +352,7 @@ Object.assign( shortcode.prototype, {
 			}
 		} );
 
-		forEach( this.attrs.named, ( value, name ) => {
+		Object.entries( this.attrs.named ).forEach( ( [ name, value ] ) => {
 			text += ' ' + name + '="' + value + '"';
 		} );
 


### PR DESCRIPTION
## What?
This PR removes all of the Lodash from the `@wordpress/shortcode` package, including the `lodash` dependency altogether. There are just a few usages and conversion is pretty straightforward.  Feel free to review commit-by-commit if it makes it easier - I've tried to keep commits atomic.

## Why?

Lodash is known to unnecessarily inflate the bundle size of packages, and in most cases, it can be replaced with native language functionality. See these for more information and rationale:

* https://github.com/WordPress/gutenberg/issues/16938#issuecomment-602837246
* https://github.com/WordPress/gutenberg/issues/17025
* https://github.com/WordPress/gutenberg/issues/39495 

## How?
We're dealing with straightforwardly replacing a few methods, namely:

#### `extend`

We're replacing this with the native `Object.assign()`, which does the same job in all the affected instances. We're also deprecating this function, because this is its last usage.

#### `pick`

We're using simple destructuring and creating a new object from the destructured properties.

#### `isString`

Replacing this is a simple as using `typeof x === 'string'`.

#### `isEqual`

`isEqual()` is commonly a complex function, especially when deep comparing, however here that's not the case. Here we compare two one-dimensional arrays, with 2 elements each, so it's pretty easy to replace this with a `.length` comparison, followed by a `.every()` call that verifies that each element is the same.

#### `forEach`

Replacing `forEach()` with the native `Array.prototype.forEach()`, and we use `Object.entries()` where necessary to convert from object to array in order to be able to iterate it.

## Testing Instructions

* Insert a classic block.
* Click the button to insert a media.
* In the media modal, click "Create Gallery".
* Select multiple images, and click "Create Gallery".
* Click "Insert gallery".
* Tinker with the gallery settings, and verify that the shortcode is still handled properly (including after save and refresh), including:
  * Add and remove images.
  * Change the settings (for example, columns)
  * Go to manually edit, and pass a numeric value for the columns. 
* Verify tests still pass: `npm run test-unit packages/shortcode`