### PR TITLE
Move setting registration into WP 6.0 compat

### DIFF
--- a/lib/compat/wordpress-5.9/edit-site-page.php
+++ b/lib/compat/wordpress-5.9/edit-site-page.php
@@ -203,42 +203,6 @@ function gutenberg_edit_site_init( $hook ) {
 add_action( 'admin_enqueue_scripts', 'gutenberg_edit_site_init' );
 
 /**
- * Register a core site setting for front page information.
- */
-function register_site_editor_homepage_settings() {
-	register_setting(
-		'reading',
-		'show_on_front',
-		array(
-			'show_in_rest' => true,
-			'type'         => 'string',
-			'description'  => __( 'What to show on the front page', 'gutenberg' ),
-		)
-	);
-
-	register_setting(
-		'reading',
-		'page_on_front',
-		array(
-			'show_in_rest' => true,
-			'type'         => 'number',
-			'description'  => __( 'The ID of the page that should be displayed on the front page', 'gutenberg' ),
-		)
-	);
-
-	register_setting(
-		'reading',
-		'page_for_posts',
-		array(
-			'show_in_rest' => true,
-			'type'         => 'number',
-			'description'  => __( 'The ID of the page that should display the latest posts', 'gutenberg' ),
-		)
-	);
-}
-add_action( 'init', 'register_site_editor_homepage_settings', 10 );
-
-/**
  * Tells the script loader to load the scripts and styles of custom block on site editor screen.
  *
  * @param bool $is_block_editor_screen Current decision about loading block assets.

--- a/lib/compat/wordpress-6.0/rest-api.php
+++ b/lib/compat/wordpress-6.0/rest-api.php
@@ -43,3 +43,41 @@ function gutenberg_register_rest_block_pattern_categories() {
 	$block_patterns->register_routes();
 }
 add_action( 'rest_api_init', 'gutenberg_register_rest_block_pattern_categories' );
+
+/**
+ * Register a core site settings.
+ *
+ * Note: Needs to be backported into the `register_initial_settings` function.
+ */
+function gutenberg_register_site_settings() {
+	register_setting(
+		'reading',
+		'show_on_front',
+		array(
+			'show_in_rest' => true,
+			'type'         => 'string',
+			'description'  => __( 'What to show on the front page', 'gutenberg' ),
+		)
+	);
+
+	register_setting(
+		'reading',
+		'page_on_front',
+		array(
+			'show_in_rest' => true,
+			'type'         => 'number',
+			'description'  => __( 'The ID of the page that should be displayed on the front page', 'gutenberg' ),
+		)
+	);
+
+	register_setting(
+		'reading',
+		'page_for_posts',
+		array(
+			'show_in_rest' => true,
+			'type'         => 'number',
+			'description'  => __( 'The ID of the page that should display the latest posts', 'gutenberg' ),
+		)
+	);
+}
+add_action( 'rest_api_init', 'gutenberg_register_site_settings', 10 );


### PR DESCRIPTION
## What?
PR moves site setting registration from WP 5.9 to 6.0 compat directory.

P.S. I'll have core backport PR ready for tomorrow as well - https://github.com/WordPress/gutenberg/pull/38607#issuecomment-1138526934.

## Why?
WP 6.0 compat is the correct directory.

## Testing Instructions
1. Open a Post or Page.
2. Run this snippet in the DevTools console - `wp.data.select('core').getEntityRecord( 'root', 'site' );`
3. Confirm that settings are still returned.

## Screenshots or screencast <!-- if applicable -->
![CleanShot 2022-06-27 at 21 40 03](https://user-images.githubusercontent.com/240569/176003259-4617bd17-715f-4cfe-b5c4-97381f5c49f2.png)

