### PR TITLE
Navigation block: Only focus submenu trigger on escape key press

### DIFF
--- a/packages/block-library/src/navigation-submenu/view.js
+++ b/packages/block-library/src/navigation-submenu/view.js
@@ -61,7 +61,7 @@ document.addEventListener( 'keyup', function ( event ) {
 			const toggle = block.querySelector( '[aria-expanded="true"]' );
 			closeSubmenus( block );
 			// Focus the submenu trigger so focus does not get trapped in the closed submenu.
-			toggle.focus();
+			toggle?.focus();
 		}
 	} );
 } );

--- a/packages/block-library/src/navigation-submenu/view.js
+++ b/packages/block-library/src/navigation-submenu/view.js
@@ -3,8 +3,6 @@ const closeSubmenus = ( element ) => {
 		.querySelectorAll( '[aria-expanded="true"]' )
 		.forEach( ( toggle ) => {
 			toggle.setAttribute( 'aria-expanded', 'false' );
-			// Always focus the trigger, this becomes especially useful in closing submenus with escape key to ensure focus doesn't get trapped.
-			toggle.focus();
 		} );
 };
 
@@ -57,11 +55,13 @@ document.addEventListener( 'keyup', function ( event ) {
 		'.wp-block-navigation-submenu'
 	);
 	submenuBlocks.forEach( ( block ) => {
-		if (
-			! block.contains( event.target ) ||
-			( block.contains( event.target ) && event.key === 'Escape' )
-		) {
+		if ( ! block.contains( event.target ) ) {
 			closeSubmenus( block );
+		} else if ( event.key === 'Escape' ) {
+			const toggle = block.querySelector( '[aria-expanded="true"]' );
+			closeSubmenus( block );
+			// Focus the submenu trigger so focus does not get trapped in the closed submenu.
+			toggle.focus();
 		}
 	} );
 } );

--- a/packages/block-library/src/navigation/view.js
+++ b/packages/block-library/src/navigation/view.js
@@ -4,8 +4,6 @@ function closeSubmenus( element ) {
 		.querySelectorAll( '[aria-expanded="true"]' )
 		.forEach( function ( toggle ) {
 			toggle.setAttribute( 'aria-expanded', 'false' );
-			// Always focus the trigger, this becomes especially useful in closing submenus with escape key to ensure focus doesn't get trapped.
-			toggle.focus();
 		} );
 }
 
@@ -63,11 +61,13 @@ window.addEventListener( 'load', () => {
 			'.wp-block-navigation-item.has-child'
 		);
 		submenuBlocks.forEach( function ( block ) {
-			if (
-				! block.contains( event.target ) ||
-				( block.contains( event.target ) && event.key === 'Escape' )
-			) {
+			if ( ! block.contains( event.target ) ) {
 				closeSubmenus( block );
+			} else if ( event.key === 'Escape' ) {
+				const toggle = block.querySelector( '[aria-expanded="true"]' );
+				closeSubmenus( block );
+				// Focus the submenu trigger so focus does not get trapped in the closed submenu.
+				toggle.focus();
 			}
 		} );
 	} );

--- a/packages/block-library/src/navigation/view.js
+++ b/packages/block-library/src/navigation/view.js
@@ -67,7 +67,7 @@ window.addEventListener( 'load', () => {
 				const toggle = block.querySelector( '[aria-expanded="true"]' );
 				closeSubmenus( block );
 				// Focus the submenu trigger so focus does not get trapped in the closed submenu.
-				toggle.focus();
+				toggle?.focus();
 			}
 		} );
 	} );


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Fixes #41975

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

My last change introduced too much bad UX behavior.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

Only target escape key press to place focus on the submenu trigger.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->

1. Insert a navigation block and create a menu.
2. Create a submenu.
3. View the front-end.
4. Open the submenu.
5. Press escape key.
6. Notice how focus is placed on the submenu trigger.
7. Open the submenu again.
8. Use the tab key to tab out of the submenu.
9. Notice how the submenu closes but focus does not reset to the submenu trigger.

## Screenshots or screencast <!-- if applicable -->
