### PR TITLE
Classic Block: Remove CSS properties with vendor prefixes

### DIFF
--- a/packages/block-library/src/freeform/editor.scss
+++ b/packages/block-library/src/freeform/editor.scss
@@ -211,8 +211,6 @@
 		margin: 0;
 		text-align: center;
 		padding: 6px;
-		-webkit-box-sizing: border-box;
-		-moz-box-sizing: border-box;
 		box-sizing: border-box;
 	}
 


### PR DESCRIPTION
This small PR removes CSS properties with vendor prefixes from the classic block.
I think it isn't necessary to explicitly specify properties with vendor prefixes for `box-sizing`.