### PR TITLE
UnitControl: Update unit dropdown design

### DIFF
--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -11,6 +11,7 @@
 
 -   Add `box-sizing` reset style mixin to utils ([#42754](https://github.com/WordPress/gutenberg/pull/42754)).
 -   `ResizableBox`: Make tooltip background match `Tooltip` component's ([#42800](https://github.com/WordPress/gutenberg/pull/42800)).
+-   `UnitControl`: Update unit dropdown design for the large size variant ([#42000](https://github.com/WordPress/gutenberg/pull/42000)).
 
 ### Internal
 

--- a/packages/components/src/unit-control/stories/index.tsx
+++ b/packages/components/src/unit-control/stories/index.tsx
@@ -24,9 +24,6 @@ const meta: ComponentMeta< typeof UnitControl > = {
 		__unstableStateReducer: {
 			control: { type: null },
 		},
-		size: {
-			control: { type: 'select' },
-		},
 		onChange: {
 			action: 'onChange',
 			control: { type: null },

--- a/packages/components/src/unit-control/stories/index.tsx
+++ b/packages/components/src/unit-control/stories/index.tsx
@@ -51,16 +51,14 @@ const DefaultTemplate: ComponentStory< typeof UnitControl > = ( {
 	const [ value, setValue ] = useState< string | undefined >( '10px' );
 
 	return (
-		<div style={ { maxWidth: '100px' } }>
-			<UnitControl
-				{ ...args }
-				value={ value }
-				onChange={ ( v, extra ) => {
-					setValue( v );
-					onChange?.( v, extra );
-				} }
-			/>
-		</div>
+		<UnitControl
+			{ ...args }
+			value={ value }
+			onChange={ ( v, extra ) => {
+				setValue( v );
+				onChange?.( v, extra );
+			} }
+		/>
 	);
 };
 
@@ -122,16 +120,14 @@ export const WithCustomUnits: ComponentStory< typeof UnitControl > = ( {
 	const [ value, setValue ] = useState< string | undefined >( '80km' );
 
 	return (
-		<div style={ { maxWidth: '100px' } }>
-			<UnitControl
-				{ ...args }
-				value={ value }
-				onChange={ ( v, extra ) => {
-					setValue( v );
-					onChange?.( v, extra );
-				} }
-			/>
-		</div>
+		<UnitControl
+			{ ...args }
+			value={ value }
+			onChange={ ( v, extra ) => {
+				setValue( v );
+				onChange?.( v, extra );
+			} }
+		/>
 	);
 };
 WithCustomUnits.args = {

--- a/packages/components/src/unit-control/styles/unit-control-styles.ts
+++ b/packages/components/src/unit-control/styles/unit-control-styles.ts
@@ -10,6 +10,7 @@ import { COLORS, CONFIG, rtl } from '../../utils';
 import NumberControl from '../../number-control';
 import { BackdropUI } from '../../input-control/styles/input-control-styles';
 import type { SelectSize } from '../types';
+import { space } from '../../ui/utils/space';
 
 // Using `selectSize` instead of `size` to avoid a type conflict with the
 // `size` HTML attribute of the `select` element.
@@ -59,24 +60,44 @@ export const ValueInput = styled( NumberControl )`
 	}
 `;
 
-const baseUnitLabelStyles = css`
-	appearance: none;
-	background: transparent;
-	border-radius: 2px;
-	border: none;
-	box-sizing: border-box;
-	color: ${ COLORS.darkGray[ 500 ] };
-	display: block;
-	font-size: 8px;
-	letter-spacing: -0.5px;
-	outline: none;
-	padding: 2px 1px;
-	text-align-last: center;
-	text-transform: uppercase;
-	width: 20px;
+const baseUnitLabelStyles = ( { selectSize }: SelectProps ) => {
+	const base = css`
+		appearance: none;
+		background: transparent;
+		border-radius: 2px;
+		border: none;
+		box-sizing: border-box;
+		display: block;
+		outline: none;
+		text-align-last: center;
 
-	${ rtl( { borderTopLeftRadius: 0, borderBottomLeftRadius: 0 } )() }
-`;
+		${ rtl( { borderTopLeftRadius: 0, borderBottomLeftRadius: 0 } )() }
+	`;
+	const defaultLabelSize = css`
+		padding: 2px 1px;
+		width: 20px;
+		color: ${ COLORS.darkGray[ 500 ] };
+		font-size: 8px;
+		letter-spacing: -0.5px;
+		text-transform: uppercase;
+	`;
+	const largeLabelSize = css`
+		padding-left: ${ space( 1 ) };
+		padding-right: ${ space( 4 ) };
+		color: ${ COLORS.ui.theme };
+		font-size: 13px;
+	`;
+	const labelSize = {
+		default: defaultLabelSize,
+		small: defaultLabelSize,
+		'__unstable-large': largeLabelSize,
+	};
+
+	return css`
+		${ base };
+		${ labelSize[ selectSize ] };
+	`;
+};
 
 export const UnitLabel = styled.div< SelectProps >`
 	&&& {
@@ -95,6 +116,7 @@ export const UnitSelect = styled.select< SelectProps >`
 		/* Removing margin ensures focus styles neatly overlay the wrapper. */
 		margin: 0;
 		transition: box-shadow 0.1s linear, border 0.1s linear;
+		font-family: inherit;
 
 		&:hover {
 			background-color: ${ COLORS.lightGray[ 300 ] };

--- a/packages/components/src/unit-control/styles/unit-control-styles.ts
+++ b/packages/components/src/unit-control/styles/unit-control-styles.ts
@@ -126,8 +126,8 @@ export const UnitSelect = styled.select< SelectProps >`
 
 		&:focus {
 			border: 1px solid ${ COLORS.ui.borderFocus };
-			box-shadow: inset 0 0 0 ${ CONFIG.borderWidth }
-				${ COLORS.ui.borderFocus };
+			box-shadow: inset 0 0 0
+				${ CONFIG.borderWidth + ' ' + COLORS.ui.borderFocus };
 			outline-offset: 0;
 			outline: 2px solid transparent;
 			z-index: 1;

--- a/packages/components/src/unit-control/styles/unit-control-styles.ts
+++ b/packages/components/src/unit-control/styles/unit-control-styles.ts
@@ -74,9 +74,9 @@ const baseUnitLabelStyles = ( { selectSize }: SelectProps ) => {
 		`,
 		large: css`
 			box-sizing: border-box;
-			width: 36px;
-			height: 36px;
-			margin-inline-end: 2px;
+			width: 24px;
+			height: 24px;
+			margin-inline-end: ${ space( 2 ) };
 			padding: ${ space( 1 ) };
 			display: flex;
 			justify-content: center;

--- a/packages/components/src/unit-control/styles/unit-control-styles.ts
+++ b/packages/components/src/unit-control/styles/unit-control-styles.ts
@@ -74,16 +74,17 @@ const baseUnitLabelStyles = ( { selectSize }: SelectProps ) => {
 		`,
 		large: css`
 			box-sizing: border-box;
-			width: 24px;
+			min-width: 24px;
+			max-width: 48px;
 			height: 24px;
 			margin-inline-end: ${ space( 2 ) };
 			padding: ${ space( 1 ) };
-			display: flex;
-			justify-content: center;
-			align-items: center;
 			color: ${ COLORS.ui.theme };
 			font-size: 13px;
 			text-align-last: center;
+			white-space: nowrap;
+			overflow: hidden;
+			text-overflow: ellipsis;
 		`,
 	};
 
@@ -125,6 +126,10 @@ const unitSelectSizes = ( { selectSize = 'default' }: SelectProps ) => {
 			}
 		`,
 		large: css`
+			display: flex;
+			justify-content: center;
+			align-items: center;
+
 			&:hover {
 				color: ${ COLORS.ui.borderFocus };
 				box-shadow: inset 0 0 0

--- a/packages/components/src/unit-control/styles/unit-control-styles.ts
+++ b/packages/components/src/unit-control/styles/unit-control-styles.ts
@@ -104,6 +104,8 @@ export const UnitLabel = styled.div< SelectProps >`
 		pointer-events: none;
 
 		${ baseUnitLabelStyles };
+
+		color: ${ COLORS.gray[ 900 ] };
 	}
 `;
 

--- a/packages/components/src/unit-control/styles/unit-control-styles.ts
+++ b/packages/components/src/unit-control/styles/unit-control-styles.ts
@@ -68,6 +68,7 @@ const baseUnitLabelStyles = ( { selectSize }: SelectProps ) => {
 			width: 20px;
 			color: ${ COLORS.darkGray[ 500 ] };
 			font-size: 8px;
+			line-height: 1;
 			letter-spacing: -0.5px;
 			text-transform: uppercase;
 			text-align-last: center;
@@ -81,6 +82,7 @@ const baseUnitLabelStyles = ( { selectSize }: SelectProps ) => {
 			padding: ${ space( 1 ) };
 			color: ${ COLORS.ui.theme };
 			font-size: 13px;
+			line-height: 1;
 			text-align-last: center;
 			white-space: nowrap;
 			overflow: hidden;
@@ -105,8 +107,6 @@ const unitSelectSizes = ( { selectSize = 'default' }: SelectProps ) => {
 	const sizes = {
 		default: css`
 			height: 100%;
-			/* Removing margin ensures focus styles neatly overlay the wrapper. */
-			margin: 0;
 			border: 1px solid transparent;
 			transition: box-shadow 0.1s linear, border 0.1s linear;
 
@@ -149,18 +149,24 @@ const unitSelectSizes = ( { selectSize = 'default' }: SelectProps ) => {
 };
 
 export const UnitSelect = styled.select< SelectProps >`
-	appearance: none;
-	background: transparent;
-	border-radius: 2px;
-	border: none;
-	display: block;
-	outline: none;
-	font-family: inherit;
+	// The && counteracts <select> styles in WP forms.css
+	&& {
+		appearance: none;
+		background: transparent;
+		border-radius: 2px;
+		border: none;
+		display: block;
+		outline: none;
+		/* Removing margin ensures focus styles neatly overlay the wrapper. */
+		margin: 0;
+		min-height: auto;
+		font-family: inherit;
 
-	&:not( :disabled ) {
-		cursor: pointer;
+		&:not( :disabled ) {
+			cursor: pointer;
+		}
+
+		${ baseUnitLabelStyles };
+		${ unitSelectSizes };
 	}
-
-	${ baseUnitLabelStyles };
-	${ unitSelectSizes };
 `;

--- a/packages/components/src/unit-control/styles/unit-control-styles.ts
+++ b/packages/components/src/unit-control/styles/unit-control-styles.ts
@@ -61,42 +61,33 @@ export const ValueInput = styled( NumberControl )`
 `;
 
 const baseUnitLabelStyles = ( { selectSize }: SelectProps ) => {
-	const base = css`
-		appearance: none;
-		background: transparent;
-		border-radius: 2px;
-		border: none;
-		box-sizing: border-box;
-		display: block;
-		outline: none;
-		text-align-last: center;
-
-		${ rtl( { borderTopLeftRadius: 0, borderBottomLeftRadius: 0 } )() }
-	`;
-	const defaultLabelSize = css`
-		padding: 2px 1px;
-		width: 20px;
-		color: ${ COLORS.darkGray[ 500 ] };
-		font-size: 8px;
-		letter-spacing: -0.5px;
-		text-transform: uppercase;
-	`;
-	const largeLabelSize = css`
-		padding-left: ${ space( 1 ) };
-		padding-right: ${ space( 4 ) };
-		color: ${ COLORS.ui.theme };
-		font-size: 13px;
-	`;
-	const labelSize = {
-		default: defaultLabelSize,
-		small: defaultLabelSize,
-		'__unstable-large': largeLabelSize,
+	const sizes = {
+		default: css`
+			box-sizing: border-box;
+			padding: 2px 1px;
+			width: 20px;
+			color: ${ COLORS.darkGray[ 500 ] };
+			font-size: 8px;
+			letter-spacing: -0.5px;
+			text-transform: uppercase;
+			text-align-last: center;
+		`,
+		large: css`
+			box-sizing: border-box;
+			width: 36px;
+			height: 36px;
+			margin-inline-end: 2px;
+			padding: ${ space( 1 ) };
+			display: flex;
+			justify-content: center;
+			align-items: center;
+			color: ${ COLORS.ui.theme };
+			font-size: 13px;
+			text-align-last: center;
+		`,
 	};
 
-	return css`
-		${ base };
-		${ labelSize[ selectSize ] };
-	`;
+	return selectSize === '__unstable-large' ? sizes.large : sizes.default;
 };
 
 export const UnitLabel = styled.div< SelectProps >`
@@ -109,36 +100,62 @@ export const UnitLabel = styled.div< SelectProps >`
 	}
 `;
 
-export const UnitSelect = styled.select< SelectProps >`
-	&&& {
-		${ baseUnitLabelStyles };
-		cursor: pointer;
-		border: 1px solid transparent;
-		height: 100%;
-		/* Removing margin ensures focus styles neatly overlay the wrapper. */
-		margin: 0;
-		transition: box-shadow 0.1s linear, border 0.1s linear;
-		font-family: inherit;
+const unitSelectSizes = ( { selectSize = 'default' }: SelectProps ) => {
+	const sizes = {
+		default: css`
+			height: 100%;
+			/* Removing margin ensures focus styles neatly overlay the wrapper. */
+			margin: 0;
+			border: 1px solid transparent;
+			transition: box-shadow 0.1s linear, border 0.1s linear;
 
-		&:hover {
-			background-color: ${ COLORS.lightGray[ 300 ] };
-		}
+			${ rtl( { borderTopLeftRadius: 0, borderBottomLeftRadius: 0 } )() }
 
-		&:focus {
-			border: 1px solid ${ COLORS.ui.borderFocus };
-			box-shadow: inset 0 0 0
-				${ CONFIG.borderWidth + ' ' + COLORS.ui.borderFocus };
-			outline-offset: 0;
-			outline: 2px solid transparent;
-			z-index: 1;
-		}
-
-		&:disabled {
-			cursor: initial;
-
-			&:hover {
-				background-color: transparent;
+			&:not(:disabled):hover {
+				background-color: ${ COLORS.lightGray[ 300 ] };
 			}
-		}
+
+			&:focus {
+				border: 1px solid ${ COLORS.ui.borderFocus };
+				box-shadow: inset 0 0 0
+					${ CONFIG.borderWidth + ' ' + COLORS.ui.borderFocus };
+				outline-offset: 0;
+				outline: 2px solid transparent;
+				z-index: 1;
+			}
+		`,
+		large: css`
+			&:hover {
+				color: ${ COLORS.ui.borderFocus };
+				box-shadow: inset 0 0 0
+					${ CONFIG.borderWidth + ' ' + COLORS.ui.borderFocus };
+				outline: ${ CONFIG.borderWidth } solid transparent; // For High Contrast Mode
+			}
+
+			&:focus {
+				box-shadow: 0 0 0
+					${ CONFIG.borderWidthFocus + ' ' + COLORS.ui.borderFocus };
+				outline: ${ CONFIG.borderWidthFocus } solid transparent; // For High Contrast Mode
+			}
+		`,
+	};
+
+	return selectSize === '__unstable-large' ? sizes.large : sizes.default;
+};
+
+export const UnitSelect = styled.select< SelectProps >`
+	appearance: none;
+	background: transparent;
+	border-radius: 2px;
+	border: none;
+	display: block;
+	outline: none;
+	font-family: inherit;
+
+	&:not( :disabled ) {
+		cursor: pointer;
 	}
+
+	${ baseUnitLabelStyles };
+	${ unitSelectSizes };
 `;

--- a/packages/components/src/unit-control/types.ts
+++ b/packages/components/src/unit-control/types.ts
@@ -43,7 +43,7 @@ export type UnitControlOnChangeCallback = InputChangeCallback<
 	{ data?: WPUnitControlUnit }
 >;
 
-export type UnitSelectControlProps = {
+export type UnitSelectControlProps = Pick< InputControlProps, 'size' > & {
 	/**
 	 * Whether the control can be focused via keyboard navigation.
 	 *
@@ -54,12 +54,6 @@ export type UnitSelectControlProps = {
 	 * A callback function invoked when the value is changed.
 	 */
 	onChange?: UnitControlOnChangeCallback;
-	/**
-	 * Size of the control option. Supports "default" and "small".
-	 *
-	 * @default 'default'
-	 */
-	size?: SelectSize;
 	/**
 	 * Current unit.
 	 */


### PR DESCRIPTION
Part of #41973

## What?

Updates the unit dropdown to the new designs for the 40px size variant.

## Why?

To get our components closer to the mockups.

## How?

Add conditional styles for the dropdown depending on the size variant.

## Testing Instructions

1. `npm run storybook:dev`
2. See the stories for UnitControl.

### Known issues

- #42650

## Screenshots or screencast <!-- if applicable -->

https://user-images.githubusercontent.com/555336/181043192-35466198-5e32-47b7-970a-ab559d47a1f6.mp4

### When the unit isn't a dropdown (i.e. single unit case)

<img src="https://user-images.githubusercontent.com/555336/176149227-6305ea21-78d2-4e98-8580-14ac16afc992.png" alt="Dropdown text has no accent color when the dropdown is inactive" width="120">


