### PR TITLE
ColorPicker: Widen hex input field for mobile

### DIFF
--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Bug Fix
 
 -   `ColorPicker`: Remove horizontal scrollbar when using HSL or RGB color input types. ([#41646](https://github.com/WordPress/gutenberg/pull/41646))
+-   `ColorPicker`: Widen hex input field for mobile. ([#42004](https://github.com/WordPress/gutenberg/pull/42004))
 
 ### Enhancements
 

--- a/packages/components/src/color-picker/hex-input.tsx
+++ b/packages/components/src/color-picker/hex-input.tsx
@@ -11,10 +11,10 @@ import { __ } from '@wordpress/i18n';
 /**
  * Internal dependencies
  */
+import { InputControl } from '../input-control';
 import { Text } from '../text';
 import { Spacer } from '../spacer';
 import { space } from '../ui/utils/space';
-import { ColorHexInputControl } from './styles';
 import { COLORS } from '../utils/colors-values';
 import type { StateReducer } from '../input-control/reducer/state';
 
@@ -49,7 +49,7 @@ export const HexInput = ( { color, onChange, enableAlpha }: HexInputProps ) => {
 	};
 
 	return (
-		<ColorHexInputControl
+		<InputControl
 			prefix={
 				<Spacer
 					as={ Text }
@@ -66,6 +66,7 @@ export const HexInput = ( { color, onChange, enableAlpha }: HexInputProps ) => {
 			label={ __( 'Hex color' ) }
 			hideLabelFromVision
 			__unstableStateReducer={ stateReducer }
+			__unstableInputWidth="9em"
 		/>
 	);
 };

--- a/packages/components/src/color-picker/styles.ts
+++ b/packages/components/src/color-picker/styles.ts
@@ -19,7 +19,6 @@ import {
 	Container as InputControlContainer,
 	Input,
 } from '../input-control/styles/input-control-styles';
-import InputControl from '../input-control';
 import CONFIG from '../utils/config-values';
 
 export const NumberControlWrapper = styled( NumberControl )`
@@ -139,8 +138,4 @@ export const CopyButton = styled( Button )`
 			margin-right: 0;
 		}
 	}
-`;
-
-export const ColorHexInputControl = styled( InputControl )`
-	width: 8em;
 `;


### PR DESCRIPTION
## What?

Increases the width of the Hex input field in ColorPicker.

## Why?

So the value doesn't get cut off on narrow screens (where font-size is increased to 16px).

## How?

Via the `__unstableInputWidth` prop, instead of ad hoc CSS.

## Testing Instructions

1. `npm run storybook:dev`
2. See the ColorPicker story in Canvas mode.
3. Make the preview narrow enough to where the input field text size increases to 16px. (It's easier to test if you temporarily remove the code for the duplicate ColorPicker in the story.)
4. Try some hex values and make sure they don't overflow.

## Screenshots or screencast <!-- if applicable -->

| Before | After |
|--------|-------|
|<img src="https://user-images.githubusercontent.com/555336/176164245-c220d195-90c1-4f0f-9ce3-37d7c1f1ff73.png" alt="Hex value is slightly cut off at the end" width="120">|<img src="https://user-images.githubusercontent.com/555336/176164254-7b22d978-0b84-4d3c-8e7c-82d9aa84246c.png" alt="Hex value fits" width="120">|





