### PR TITLE
Global Styles: Always load block CSS from __experimentalStyle

### DIFF
--- a/lib/compat/wordpress-6.1/get-global-styles-and-settings.php
+++ b/lib/compat/wordpress-6.1/get-global-styles-and-settings.php
@@ -14,6 +14,11 @@ function wp_add_global_styles_for_blocks() {
 	foreach ( $block_nodes as $metadata ) {
 		$block_css = $tree->get_styles_for_block( $metadata );
 
+		if ( ! wp_should_load_separate_core_block_assets() ) {
+			wp_add_inline_style( 'global-styles', $block_css );
+			continue;
+		}
+
 		if ( isset( $metadata['name'] ) ) {
 			$block_name = str_replace( 'core/', '', $metadata['name'] );
 			// These block styles are added on block_render.

--- a/lib/compat/wordpress-6.1/script-loader.php
+++ b/lib/compat/wordpress-6.1/script-loader.php
@@ -84,18 +84,7 @@ function gutenberg_enqueue_global_styles() {
 		return;
 	}
 
-	/**
-	 * If we are loading CSS for each block separately, then we can load the theme.json CSS conditionally.
-	 * This removes the CSS from the global-styles stylesheet and adds it to the inline CSS for each block.
-	 */
-	if ( $separate_assets ) {
-		add_filter( 'gutenberg_get_style_nodes', 'filter_out_block_nodes' );
-		// add each block as an inline css.
-		wp_add_global_styles_for_blocks();
-	}
-
 	$stylesheet = gutenberg_get_global_stylesheet();
-
 	if ( empty( $stylesheet ) ) {
 		return;
 	}
@@ -103,6 +92,14 @@ function gutenberg_enqueue_global_styles() {
 	wp_register_style( 'global-styles', false, array(), true, true );
 	wp_add_inline_style( 'global-styles', $stylesheet );
 	wp_enqueue_style( 'global-styles' );
+
+	/**
+	 * If we are loading CSS for each block separately, then we can load the theme.json CSS conditionally.
+	 * This removes the CSS from the global-styles stylesheet and adds it to the inline CSS for each block.
+	 */
+	add_filter( 'gutenberg_get_style_nodes', 'filter_out_block_nodes' );
+	// add each block as an inline css.
+	wp_add_global_styles_for_blocks();
 }
 
 remove_action( 'wp_enqueue_scripts', 'wp_enqueue_global_styles' );


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
We need to _always_ load the styles from __experimentalStyle, not just when assets are being split.

## Why?
This needs to happen so that the __experimentalStyle rules are always applied.

## How?
We attach the block styles to the end of the global styles CSS.

## Testing Instructions
1. Switch to the theme Toujours
2. Add two images to a post
3. Ensure that there is a 1em margin between the two images.

Fixes https://github.com/Automattic/wp-calypso/issues/64994

## Screenshots or screencast <!-- if applicable -->
<img width="1354" alt="Screenshot 2022-06-28 at 12 58 39" src="https://user-images.githubusercontent.com/275961/176173106-404ba5a3-600d-47ff-8e7f-d7df686ff18d.png">

@WordPress/block-themers 