### PR TITLE
FSE: Pre-populate template with fallback upon creation

### DIFF
--- a/lib/compat/wordpress-6.1/block-template-utils.php
+++ b/lib/compat/wordpress-6.1/block-template-utils.php
@@ -165,6 +165,22 @@ function gutenberg_get_block_templates( $query = array(), $template_type = 'wp_t
 	return apply_filters( 'get_block_templates', $query_result, $query, $template_type );
 }
 
+function gutenberg_get_template_slugs( $template ) {
+	$limit = 2;
+	if ( strpos( $template, 'single-' ) === 0 || strpos( $template, 'taxonomy-' ) === 0 ) {
+		// E.g. single-post-mypost or taxonomy-recipes-vegetarian.
+		$limit = 3;
+	}
+	$parts = explode( '-', $template, $limit );
+	$type  = array_shift( $parts );
+	$slugs = array( $type );
+
+	foreach ( $parts as $part ) {
+		array_unshift( $slugs, $slugs[0] . '-' . $part );
+	}
+	return $slugs;
+}
+
 /**
  * Retrieves a single unified template object using its id.
  *

--- a/lib/compat/wordpress-6.1/class-gutenberg-rest-templates-controller.php
+++ b/lib/compat/wordpress-6.1/class-gutenberg-rest-templates-controller.php
@@ -194,13 +194,13 @@ class Gutenberg_REST_Templates_Controller extends WP_REST_Templates_Controller {
 			$changes->ID          = $template->wp_id;
 			$changes->post_status = 'publish';
 		}
-		if ( isset( $request['content'] ) ) {
+		if ( isset( $request['content'] ) && ! empty( $request['content'] ) ) {
 			$changes->post_content = $request['content'];
 		} elseif ( null !== $template && 'custom' !== $template->source ) {
 			$changes->post_content = $template->content;
-		} elseif( null === $template && empty( $template->content ) ) {
-			$templates = gutenberg_get_template_slugs( $template->slug );
-			$fallback_template = resolve_block_template( $template->slug, $templates, '' );
+		} elseif ( null === $template && empty( $request['content'] ) ) {
+			$fallback_templates = gutenberg_get_template_slugs( $request['slug'] );
+			$fallback_template  = resolve_block_template( $request['slug'], $fallback_templates, '' );
 			if ( ! $fallback_template ) {
 				$fallback_template = resolve_block_template( 'index', array(), '' );
 			}

--- a/lib/compat/wordpress-6.1/class-gutenberg-rest-templates-controller.php
+++ b/lib/compat/wordpress-6.1/class-gutenberg-rest-templates-controller.php
@@ -198,6 +198,13 @@ class Gutenberg_REST_Templates_Controller extends WP_REST_Templates_Controller {
 			$changes->post_content = $request['content'];
 		} elseif ( null !== $template && 'custom' !== $template->source ) {
 			$changes->post_content = $template->content;
+		} elseif( null === $template && empty( $template->content ) ) {
+			$templates = gutenberg_get_template_slugs( $template->slug );
+			$fallback_template = resolve_block_template( $template->slug, $templates, '' );
+			if ( ! $fallback_template ) {
+				$fallback_template = resolve_block_template( 'index', array(), '' );
+			}
+			$changes->post_content = $fallback_template->content;
 		}
 		if ( isset( $request['title'] ) ) {
 			$changes->post_title = $request['title'];

--- a/phpunit/compat/wordpress-6.1/block-template-utils-test.php
+++ b/phpunit/compat/wordpress-6.1/block-template-utils-test.php
@@ -1,0 +1,26 @@
+<?php
+/**
+ * Tests_Block_Template_Utils class
+ *
+ * @package gutenberg
+ */
+
+/**
+ * Tests for the Block Templates abstraction layer.
+ *
+ * @group block-templates
+ */
+class Tests_Block_Template_Utils_6_1 extends WP_UnitTestCase {
+	public function test_get_template_slugs() {
+		$templates = gutenberg_get_template_slugs( 'single-post-hello-world' );
+		$this->assertSame(
+			array(
+				'single-post-hello-world',
+				// Should *not* fall back to `single-post-hello`!
+				'single-post',
+				'single',
+			),
+			$templates
+		);
+	}
+}


### PR DESCRIPTION
## What?
Alternative to #41848, based on some ideas shared by @ntsekouras in DM.

Purports to fix #36648, as an alternative approach to #37054 and #41848. For more background, see https://github.com/WordPress/gutenberg/pull/37054#issuecomment-988271255

_(More description to come)_

## Why?
See e.g. https://github.com/WordPress/gutenberg/pull/37258#issuecomment-1136144085 and https://github.com/WordPress/gutenberg/pull/37258#issuecomment-1161697393.

## How?

By using the "next best" template per template hierarchy resolution to pre-populate a newly created template's content. 

## Testing Instructions

This testing routine will verify a number of things:
- That if a new template is created, it will pre-populate the editor with the "next best", less specific, fallback template.
  - This can be either a manually created template, or a theme-supplied one.
- That the template titles and descriptions are correct.

First, we create a "Single Post" template and verify that it comes pre-populated with the contents of the theme-supplied "Single" template:

1. Enable the Twenty Twenty-Two theme.
2. Go to the Site Editor.
3. Click the "W" logo menu in the top left corner.
4. In the sidebar that opens, select "Templates".
6. Click the "Add New" button in the top right corner.
7. In the dropdown that opens, click on the "Single item: Post" template.
8. In the modal that opens, click on "All Posts -- For all items".
11. Verify that the site editor opens, pre-populated with the generic "single" template. (This is to ensure parity with the frontend, which would also use the "single" template as a fallback when there's no dedicated single-_post_ template.)
12. Verify that the title and description are still as prior to this PR ("Single item: Post" --  "Displays a single item: Post.")
13. Make a change to the template. Make sure it's not to the header or footer template parts, nor to the post content. Ideally, insert a Paragraph block with some text right above the footer (and below the content). (Verify that it's a direct child of the template by checking in the bottom breadcrumbs bar that it shows up as "Template > Paragraph".)
9. Save the template.
10. Once saved, navigate back to the "Templates" screen (via the top left "W" button that opens the sidebar).
14. Verify that there's now a "Single item: Post" template at the top of the list of the theme's templates.
15. Verify that it's distinct from the "Single" template at the bottom of the list.

Second, we create a "Single Post" template for a specific post and verify that it comes pre-populated with the generic "Single Post" template that we just created: **This is still buggy, reload every time you go back to the template list**

1. In the template list, click the "Add New" button in the top right corner.
2. Since you've already created the generic "Single item: Post" template, the editor will directly open a modal to ask you for _which_ post you'd like to create a template. 
10. Select a post from that list, e.g. the standard WordPress "Hello World" post.
11. Verify that the site editor opens, with the "Single item: Post" template contents loaded that you just created. (This is again to reflect parity with the frontend).
12. Verify that the template content has the change that you just made earlier to the "Single item: Post" template.
13. Verify that the title and description are still as prior to this PR ("Post: Hello world!" -- "Template for Post: Hello world!").
14. Make another change to the template, ideally to the part that you changed to distinguish the "Single item: Post" template.
9. Save the template.
10. Once saved, navigate back to the "Templates" screen (via the top left 'W' button that opens the sidebar).
15. Verify that there's now a "Post: Hello World!" template at the top of the list of the theme's templates.
16. Verify that it's distinct from the "Single item: Post" template right below.

Ideally, give it some more smoke testing -- whatever you can think of makes sense: delete the template again; find a way to test it on the frontend; etc.
