### PR TITLE
Button Elements: Allow element styles in classic themes

### DIFF
--- a/lib/compat/wordpress-6.0/get-global-styles-and-settings.php
+++ b/lib/compat/wordpress-6.0/get-global-styles-and-settings.php
@@ -92,9 +92,7 @@ function gutenberg_get_global_stylesheet( $types = array() ) {
 	}
 	$tree                = WP_Theme_JSON_Resolver_Gutenberg::get_merged_data();
 	$supports_theme_json = WP_Theme_JSON_Resolver_Gutenberg::theme_has_support();
-	if ( empty( $types ) && ! $supports_theme_json ) {
-		$types = array( 'variables', 'presets' );
-	} elseif ( empty( $types ) ) {
+	if ( empty( $types ) ) {
 		$types = array( 'variables', 'styles', 'presets' );
 	}
 

--- a/lib/compat/wordpress-6.1/theme.json
+++ b/lib/compat/wordpress-6.1/theme.json
@@ -246,6 +246,9 @@
 					"text": "#fff",
 					"background": "#32373c"
 				},
+				"spacing": {
+					"padding": "calc(0.667em + 2px) calc(1.333em + 2px)"
+				},
 				"typography": {
 					"fontSize": "inherit",
 					"fontFamily": "inherit",

--- a/packages/block-library/src/search/theme.scss
+++ b/packages/block-library/src/search/theme.scss
@@ -3,3 +3,8 @@
 		font-weight: bold;
 	}
 }
+
+.wp-block-search__button {
+	border: 1px solid #ccc;
+	padding: 0.375em 0.625em;
+}


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
In https://github.com/WordPress/gutenberg/pull/34180, we moved block and element styles into JSON as well as migrating the styles of the `core/buttons` block away from CSS and into these new formats. 

Classic themes don't load styles provided in JSON. This changes that, so that we now also include _core only_ block and element styles from theme.json.

## Why?
We need to ensure that the correct element styles are provided to all themes, not just block themes.

## How?
Previously we only output variables and presets from theme.json, not the styles section. IMO it's safe to use this section as we restrict it to only the rules coming from the core styles, not from other origins:

```
		if ( ! $supports_theme_json ) {
			$origins = array( 'default' );
		}
```
 

## Testing Instructions
- Use a classic theme
- Add a buttons block
- Confirm that the buttons look styled with the default styles.


## Screenshots or screencast <!-- if applicable -->
<img width="739" alt="Screenshot 2022-06-28 at 15 35 57" src="https://user-images.githubusercontent.com/275961/176206475-dc319d54-8db2-4411-8539-20940da86f9b.png">

The search block looks like this:
<img width="738" alt="Screenshot 2022-06-28 at 15 45 16" src="https://user-images.githubusercontent.com/275961/176208766-6c2cf213-4bcb-4b0b-8870-82ac15fdcf63.png">



@WordPress/block-themers 
