### PR TITLE
Introduce parser for dynamic token system

### DIFF
--- a/lib/load.php
+++ b/lib/load.php
@@ -151,6 +151,7 @@ require __DIR__ . '/blocks.php';
 require __DIR__ . '/client-assets.php';
 require __DIR__ . '/demo.php';
 require __DIR__ . '/experiments-page.php';
+require __DIR__ . '/tokens.php';
 
 // Copied package PHP files.
 if ( file_exists( __DIR__ . '/../build/style-engine/class-wp-style-engine-gutenberg.php' ) ) {

--- a/lib/tokens.php
+++ b/lib/tokens.php
@@ -22,6 +22,31 @@ function register_token( $namespace, $name, $replacer, $priority = 10 ) {
 }
 
 
+function tokens_core_replacer( $rendered, $token ) {
+	global $post_id;
+
+	if ( 'core' !== $token->namespace ) {
+		return $rendered;
+	}
+
+	switch ( $token->name ) {
+		case 'featured-image':
+			return get_the_post_thumbnail_url();
+
+		case 'permalink':
+			$permalink = get_permalink( is_int( $token->value ) ? $token->value : $post_id );
+
+			return false !== $permalink ? $permalink : '';
+
+		case 'plugins_url':
+			return plugins_url();
+
+		default:
+			return $token->fallback;
+	}
+}
+
+
 function tokens_token_replacer( $token ) {
 	return apply_filters( 'render_token', $token->fallback, $token );
 }
@@ -35,11 +60,8 @@ function tokens_swap_tokens( $text ) {
 function tokens_init() {
 	require_once __DIR__ . '/../packages/tokens/token-parser.php';
 
+	add_filter( 'render_token', 'tokens_core_replacer', 2, 10 );
 	add_filter( 'the_content', 'tokens_swap_tokens', 1, 1000 );
-
-	register_token( 'core', 'echo', function ( $rendered, $token ) { return $token->value; } );
-	register_token( 'core', 'featured-image', function ( $rendered, $token ) { return get_the_post_thumbnail_url(); } );
-	register_token( 'core', 'plugins-url', function ( $rendered, $token ) { return plugins_url(); } );
 }
 
 add_action( 'init', 'tokens_init' );

--- a/lib/tokens.php
+++ b/lib/tokens.php
@@ -1,0 +1,45 @@
+<?php
+/**
+ * Token functions specific for the Gutenberg editor plugin.
+ *
+ * @package gutenberg
+ */
+
+
+function register_token( $namespace, $name, $replacer, $priority = 10 ) {
+	add_filter(
+		'render_token',
+		function ( $rendered, $token ) use ( $namespace, $name, $replacer ) {
+			if ( ! ( $namespace === $token->namespace && $name === $token->name ) ) {
+				return $rendered;
+			}
+
+			return call_user_func( $replacer, $rendered, $token );
+		},
+		$priority,
+		2
+	);
+}
+
+
+function tokens_token_replacer( $token ) {
+	return apply_filters( 'render_token', $token->fallback, $token );
+}
+
+
+function tokens_swap_tokens( $text ) {
+	return WP_Token_parser::swap_tokens( 'tokens_token_replacer', $text );
+}
+
+
+function tokens_init() {
+	require_once __DIR__ . '/../packages/tokens/token-parser.php';
+
+	add_filter( 'the_content', 'tokens_swap_tokens', 1, 1000 );
+
+	register_token( 'core', 'echo', function ( $rendered, $token ) { return $token->value; } );
+	register_token( 'core', 'featured-image', function ( $rendered, $token ) { return get_the_post_thumbnail_url(); } );
+	register_token( 'core', 'plugins-url', function ( $rendered, $token ) { return plugins_url(); } );
+}
+
+add_action( 'init', 'tokens_init' );

--- a/packages/tokens/README.md
+++ b/packages/tokens/README.md
@@ -1,0 +1,67 @@
+# Tokens
+
+This module provides the functionality necessary to implement a dynamic-token replacement system.
+Dynamic tokens are simple and non-nested markers within a document that refer to externally-sourced data.
+On page render they are to be replaced with some server-side function.
+During edit sessions they should appear visually as tokens and not as their replaced values.
+Tokens should be replaced with basic textual content.
+
+## Usage
+
+Because tokens are designed to support human entry their syntax is more flexible than block comment delimiters.
+There are multiple ways to enter tokens that have different levels of convenience for the varying amounts of their required information.
+
+### Token properties
+
+| Name | Data Type | Description |
+|---|---|---|
+| `token` | Identifier | Indicates the `name` of a token as its `namespace`, or `core` if the namespace is omitted. e.g. `featured-image` or `my-plugin/weather`. |
+| `value` | `any` | Data passed to token rendering function as an argument. Some tokens might need more than just a name to properly render. e.g. `{"stat": "temperature", "unit": "C"}` |
+| `fallback` | `string` | Plaintext string to render in place of the token if no suitable renderer is avialable. This may occur after uninstalling a plugin or when importing content from another site. Without a fallback tokens will be removed from the document to prevent leaking internal or private information. |
+
+### Token sytnax
+
+Choosing an appropriate token syntax is mostly an exercise in determining how much information is necessary to render the token.
+The more data we need, the more sytnax we also need.
+Likewise the less data we need to convey, the terser we can write the token.
+
+#### Namespacing and the `core` namespace
+
+Tokens are identified by their `namespace` and `name` pair.
+For example, `my-plugin/weather` identifies the `weather` token in the `my-plugin` namespace.
+Typically the `namespace` corresponds to the WordPress plugin which registered the token.
+The `core` namespace is special and represents the functionality built in to WordPress.
+It's possible to omit the `core/` namespace prefix when identifying a token.
+Likewise, if a token lacks a namespace it's implied to be provided in the `core` namespace.
+
+#### Simple tokens
+
+Tokens that don't require any arguments can be entered with their unescaped names.
+
+| Syntax | Meaning                                   |
+|---|-------------------------------------------|
+| `#{featured-image}#` | Display the `core/featured-image` token |
+| `#{core/featured-image}#` | Display the `core/featured-iamge}` token |
+| `#{retro/page-counter}#` | Display the `retro/page-counter` token |
+
+
+#### Simple tokens with arguments
+
+If your token needs additional information in order to properly render you can pass them in as augmented JSON.
+
+| Syntax | Meaning                                   |
+|---|-------------------------------------------|
+| `#{permalink=14}#` | Display the permalink for the post whose id is 14 |
+| `#{my-plugin/weather={"stat": "temperature", "units": "C"}}#` | Display the temperature in ºC |
+| `#{echo="\u{3c}span\u{3e}\u{23}1\u{3c}/span\u{3e}"}#` | Render `<span>#1</span>` |
+
+#### Tokens with fallback
+
+If a token provides a fallback value it must use the fully-verbose syntax.
+It's always possible to use the full syntax.
+
+| Syntax | Meaning                                   |
+|---|-------------------------------------------|
+| `#{"token":"sportier/stat", "value":{"sport": "basketball", "game": "latest"}, "fallback": "TBD"}}#` | Show the score for the latest basketball game, but the plugin isn't available render `TBD` instead. |
+
+## Background

--- a/packages/tokens/README.md
+++ b/packages/tokens/README.md
@@ -64,4 +64,21 @@ It's always possible to use the full syntax.
 |---|-------------------------------------------|
 | `#{"token":"sportier/stat", "value":{"sport": "basketball", "game": "latest"}, "fallback": "TBD"}}#` | Show the score for the latest basketball game, but the plugin isn't available render `TBD` instead. |
 
+#### Indicating context for token
+
+While not currently supported, it may arise that we need to indicate in which context the token is found.
+This is due to the fact that there are different escaping and security concerns for content bound for HTML attributes than there are for those bound for HTML markup, similarly for other potential contexts.
+
+Tokens support indicating this with a _sigil_ at the front of the token syntax according to the following table.
+Not all potential sigils are meaningful, and in the absence of a recognized sigil the context for a token remains blank  (`null`).
+
+| Sigil | Associated context                                     |
+|---|--------------------------------------------------------|
+| `a` | token is inside an HTML attribute                      |
+| `h` | token is inside normal HTML markup                     |
+| `j` | token is inside a `<script>` tag or in JavaScript code |
+
+The context is a hint to the backend on how to render and escape the token content.
+It's not yet decided if these will be enforced by the token system or left up to the token authors to enforce.
+
 ## Background

--- a/packages/tokens/test/index.js
+++ b/packages/tokens/test/index.js
@@ -1,0 +1,28 @@
+/**
+ * External dependencies
+ */
+import path from 'path';
+
+/**
+ * Internal dependencies
+ */
+import { swapTokens } from '../token-parser';
+import { jsTester, phpTester } from './shared.test';
+
+const parse = ( input ) => {
+	let count = 0;
+	const tokens = [];
+
+	const tokenReplacer = ( token ) => {
+		tokens.push( token );
+		return `{{TOKEN_${ ++count }}}`;
+	};
+
+	const output = swapTokens( tokenReplacer, input );
+
+	return { tokens, output };
+};
+
+describe( 'tokens', jsTester( parse ) ); // eslint-disable-line jest/valid-describe-callback
+
+phpTester( 'token-parser-php', path.join( __dirname, 'test-parser.php' ) );

--- a/packages/tokens/test/shared.test.js
+++ b/packages/tokens/test/shared.test.js
@@ -56,7 +56,7 @@ export const jsTester = ( parse ) => () => {
 	it( 'avoids escaping quoted tokens', () => {
 		expect( parse( '##{not-a-token}#' ) ).toEqual( {
 			tokens: [],
-			output: '##{not-a-token}#',
+			output: '#{not-a-token}#',
 		} );
 	} );
 

--- a/packages/tokens/test/shared.test.js
+++ b/packages/tokens/test/shared.test.js
@@ -1,5 +1,16 @@
+// eslint-disable-next-line jest/no-export
 export const jsTester = ( parse ) => () => {
 	const tokenForms = [
+		[
+			'#{echo}#',
+			{
+				namespace: 'core',
+				name: 'echo',
+				value: null,
+				fallback: '',
+				context: null,
+			},
+		],
 		[
 			'#{core/identity}#',
 			{
@@ -7,6 +18,7 @@ export const jsTester = ( parse ) => () => {
 				name: 'identity',
 				value: null,
 				fallback: '',
+				context: null,
 			},
 		],
 		[
@@ -16,6 +28,7 @@ export const jsTester = ( parse ) => () => {
 				name: 'identity',
 				value: null,
 				fallback: '',
+				context: null,
 			},
 		],
 		[
@@ -25,6 +38,7 @@ export const jsTester = ( parse ) => () => {
 				name: 'echo',
 				value: '<',
 				fallback: '',
+				context: null,
 			},
 		],
 		[
@@ -34,6 +48,7 @@ export const jsTester = ( parse ) => () => {
 				name: 'widget',
 				value: { name: 'sprocket' },
 				fallback: 'just a sprocket',
+				context: null,
 			},
 		],
 		[
@@ -43,6 +58,7 @@ export const jsTester = ( parse ) => () => {
 				name: 'widget',
 				value: { name: 'sprocket' },
 				fallback: '',
+				context: null,
 			},
 		],
 	];
@@ -73,10 +89,25 @@ export const jsTester = ( parse ) => () => {
 					name: 'echo',
 					value: 'look out for #1',
 					fallback: '',
+					context: null,
 				},
 			],
 			output: '{{TOKEN_1}}',
 		} );
+	} );
+
+	it.each( [
+		[ '#a{echo}#', 'attribute' ],
+		[ '#h{echo}#', 'html' ],
+		[ '#j{echo}#', 'javascript' ],
+		[ '#z{echo}#', null ],
+		[ '#3{echo}#', null ],
+		[ '#{echo}#', null ],
+	] )( 'recognizes context-specifying sigils: %s', ( input, context ) => {
+		expect( parse( input ).tokens[ 0 ] ).toHaveProperty(
+			'context',
+			context
+		);
 	} );
 };
 
@@ -104,6 +135,7 @@ const makeTest = hasPHP
 	: // eslint-disable-next-line jest/no-disabled-tests, jest/valid-describe-callback, jest/valid-title
 	  ( ...args ) => describe.skip( ...args );
 
+// eslint-disable-next-line jest/no-export
 export const phpTester = ( name, filename ) =>
 	makeTest(
 		name,
@@ -137,6 +169,7 @@ export const phpTester = ( name, filename ) =>
 							)
 						);
 					} catch ( e ) {
+						// eslint-disable-next-line no-console
 						console.error( process.stdout );
 						throw new Error(
 							'failed to parse JSON:\n' + process.stdout

--- a/packages/tokens/test/shared.test.js
+++ b/packages/tokens/test/shared.test.js
@@ -1,0 +1,147 @@
+export const jsTester = ( parse ) => () => {
+	const tokenForms = [
+		[
+			'#{core/identity}#',
+			{
+				namespace: 'core',
+				name: 'identity',
+				value: null,
+				fallback: '',
+			},
+		],
+		[
+			'#{"token":"core/identity"}#',
+			{
+				namespace: 'core',
+				name: 'identity',
+				value: null,
+				fallback: '',
+			},
+		],
+		[
+			'#{echo="\u{3c}"}#',
+			{
+				namespace: 'core',
+				name: 'echo',
+				value: '<',
+				fallback: '',
+			},
+		],
+		[
+			'#{"token":"my_plugin/widget", "value": {"name": "sprocket"}, "fallback": "just a sprocket"}#',
+			{
+				namespace: 'my_plugin',
+				name: 'widget',
+				value: { name: 'sprocket' },
+				fallback: 'just a sprocket',
+			},
+		],
+		[
+			'#{my_plugin/widget={"name":"sprocket"}}#',
+			{
+				namespace: 'my_plugin',
+				name: 'widget',
+				value: { name: 'sprocket' },
+				fallback: '',
+			},
+		],
+	];
+
+	it.each( tokenForms )( 'basic token syntax: %s', ( input, token ) => {
+		const output = parse( input );
+		expect( output ).toHaveProperty( 'tokens', [ token ] );
+		expect( output ).toHaveProperty( 'output', '{{TOKEN_1}}' );
+	} );
+
+	it( 'avoids escaping quoted tokens', () => {
+		expect( parse( '##{not-a-token}#' ) ).toEqual( {
+			tokens: [],
+			output: '##{not-a-token}#',
+		} );
+	} );
+
+	it( 'fails to parse when # is unescaped inside of token', () => {
+		expect( parse( '#{echo="look out for #1"}#' ) ).toEqual( {
+			tokens: [],
+			output: '#{echo="look out for #1"}#',
+		} );
+
+		expect( parse( '#{echo="look out for \\u00231"}#' ) ).toEqual( {
+			tokens: [
+				{
+					namespace: 'core',
+					name: 'echo',
+					value: 'look out for #1',
+					fallback: '',
+				},
+			],
+			output: '{{TOKEN_1}}',
+		} );
+	} );
+};
+
+const hasPHP =
+	'test' === process.env.NODE_ENV
+		? ( () => {
+				const process = require( 'child_process' ).spawnSync(
+					'php',
+					[ '-r', 'echo 1;' ],
+					{
+						encoding: 'utf8',
+					}
+				);
+
+				return process.status === 0 && process.stdout === '1';
+		  } )()
+		: false;
+
+// Skipping if `php` isn't available to us, such as in local dev without it
+// skipping preserves snapshots while commenting out or simply
+// not injecting the tests prompts `jest` to remove "obsolete snapshots"
+const makeTest = hasPHP
+	? // eslint-disable-next-line jest/valid-describe-callback, jest/valid-title
+	  ( ...args ) => describe( ...args )
+	: // eslint-disable-next-line jest/no-disabled-tests, jest/valid-describe-callback, jest/valid-title
+	  ( ...args ) => describe.skip( ...args );
+
+export const phpTester = ( name, filename ) =>
+	makeTest(
+		name,
+		'test' === process.env.NODE_ENV
+			? jsTester( ( doc ) => {
+					const process = require( 'child_process' ).spawnSync(
+						'php',
+						[ '-f', filename ],
+						{
+							input: doc,
+							encoding: 'utf8',
+							timeout: 30 * 1000, // Abort after 30 seconds, that's too long anyway.
+						}
+					);
+
+					if ( process.status !== 0 ) {
+						throw new Error( process.stderr || process.stdout );
+					}
+
+					try {
+						/*
+						 * Due to an issue with PHP's json_encode() serializing an empty associative array
+						 * as an empty list `[]` we're manually replacing the already-encoded bit here.
+						 *
+						 * This is an issue with the test runner, not with the parser.
+						 */
+						return JSON.parse(
+							process.stdout.replace(
+								/"attributes":\s*\[\]/g,
+								'"attributes":{}'
+							)
+						);
+					} catch ( e ) {
+						console.error( process.stdout );
+						throw new Error(
+							'failed to parse JSON:\n' + process.stdout
+						);
+					}
+			  } )
+			: () => {}
+	);

--- a/packages/tokens/test/test-parser.php
+++ b/packages/tokens/test/test-parser.php
@@ -1,0 +1,24 @@
+<?php
+/**
+ * PHP Test Helper
+ *
+ * Facilitates running PHP parser against same tests as the JS parser implementation.
+ *
+ * @package gutenberg
+ */
+
+// Include the generated parser.
+require_once __DIR__ . '/../token-parser.php';
+
+$count = 0;
+$tokens = [];
+
+$output = WP_Token_Parser::swap_tokens(
+	function ( $token ) use ( &$count, &$tokens ) {
+		$tokens[] = $token;
+		return '{{TOKEN_' . ++$count . '}}';
+	},
+	file_get_contents( 'php://stdin' )
+);
+
+echo json_encode( [ 'tokens' => $tokens, 'output' => $output ] );

--- a/packages/tokens/token-parser.js
+++ b/packages/tokens/token-parser.js
@@ -25,7 +25,7 @@ export const swapTokens = ( tokenReplacer, input ) => {
 		new RegExp( '(#)?#{([^#]*)}#' ),
 		( fullMatch, quoted, tokenContents ) => {
 			if ( quoted ) {
-				return fullMatch;
+				return fullMatch.slice(1);
 			}
 
 			const token = parseTokenContents( tokenContents );

--- a/packages/tokens/token-parser.js
+++ b/packages/tokens/token-parser.js
@@ -1,0 +1,80 @@
+/**
+ * @typedef {Object} WPToken
+ * @property {string}              namespace  e.g. "core", "query", or "my-plugin"
+ * @property {string}              name       e.g. "home_url", "featured-iamge", "my-token"
+ * @property {Record<string, any>} value      defined by each token separately.
+ * @property {string}              fallback   what to render if no matching token plugin available.
+ */
+
+/**
+ * @callback TokenReplacer
+ * @param {WPToken} token The parsed token to replace.
+ * @return {string} the replacement string.
+ */
+
+/**
+ * Replaces dynamic tokens in a document with the return value
+ * from their callback or with a fallback value if one exists.
+ *
+ * @param {TokenReplacer} tokenReplacer
+ * @param {string}        input
+ * @return {string}       output
+ */
+export const swapTokens = ( tokenReplacer, input ) => {
+	return input.replace(
+		new RegExp( '(#)?#{([^#]*)}#' ),
+		( fullMatch, quoted, tokenContents ) => {
+			if ( quoted ) {
+				return fullMatch;
+			}
+
+			const token = parseTokenContents( tokenContents );
+			if ( ! token ) {
+				return '';
+			}
+
+			return tokenReplacer( token ) ?? token.fallback;
+		}
+	);
+};
+
+/**
+ * Parses the inner contents of a token.
+ *
+ * @param {string} contents the inner contents of a token to parse.
+ * @return {WPToken|null} the parsed token or null if invalid.
+ */
+const parseTokenContents = ( contents ) => {
+	const matches = contents.match(
+		/^(?:([a-z][a-z\d_-]*)\/)?([a-z\d_-]*)(?:=(.+))?$/i
+	);
+
+	if ( matches ) {
+		const [ , rawNamespace, name, rawValue ] = matches;
+		const namespace = rawNamespace || 'core';
+		const value = rawValue ? jsonDecode( rawValue ) : null;
+
+		return { namespace, name, value, fallback: '' }
+	}
+
+	const tokenData = jsonDecode( `{${ contents }}` );
+	if ( null === tokenData ) {
+		return null;
+	}
+
+	const nameMatch = tokenData.token?.match(
+		/^(?:([a-z][a-z\d_-]*)\/)?([a-z\d_-]*)$/i
+	);
+	if ( ! nameMatch ) {
+		return null;
+	}
+
+	const [ , rawNamespace, name ] = nameMatch;
+	const namespace = rawNamespace || 'core';
+	const value = tokenData?.value ?? null;
+	const fallback = tokenData?.fallback ?? '';
+
+	return { namespace, name, value, fallback };
+};
+
+const jsonDecode = ( s ) => JSON.parse( s );

--- a/packages/tokens/token-parser.php
+++ b/packages/tokens/token-parser.php
@@ -52,7 +52,7 @@ class WP_Token_Parser
 				list( '0' => $full_match, 'QUOTED' => $quoted, 'TOKEN_CONTENTS' => $contents ) = $matches;
 
 				if ( ! empty( $quoted ) ) {
-					return $full_match;
+					return substr( $full_match, 1 );
 				}
 
 				$token = self::parse_token_contents( $contents );

--- a/packages/tokens/token-parser.php
+++ b/packages/tokens/token-parser.php
@@ -1,0 +1,148 @@
+<?php
+
+class WP_Token
+{
+	/**
+	 * @var string
+	 */
+	public $namespace;
+
+	/**
+	 * @var string
+	 */
+	public $name;
+
+	/**
+	 * @var mixed
+	 */
+	public $value;
+
+	/**
+	 * @var string
+	 */
+	public $fallback;
+
+	function __construct( $namespace, $name, $value = null, $fallback = '' ) {
+		$this->namespace  = $namespace;
+		$this->name       = $name;
+		$this->value      = $value;
+		$this->fallback   = $fallback;
+	}
+}
+
+class WP_Token_Parser
+{
+	/**
+	 * Replaces dynamic tokens in a document with the return value
+	 * from their callback or with a fallback value if one exists.
+	 */
+	public static function swap_tokens( $token_replacer, $input )
+	{
+		if ( ! is_callable( $token_replacer ) ) {
+			return null;
+		}
+
+		if ( ! is_string( $input ) ) {
+			return null;
+		}
+
+		return preg_replace_callback(
+			"~(?P<QUOTED>#)?#{(?P<TOKEN_CONTENTS>[^#]*)}#~",
+			function ( $matches ) use ( $token_replacer ) {
+				list( '0' => $full_match, 'QUOTED' => $quoted, 'TOKEN_CONTENTS' => $contents ) = $matches;
+
+				if ( ! empty( $quoted ) ) {
+					return $full_match;
+				}
+
+				$token = self::parse_token_contents( $contents );
+				if ( ! $token ) {
+					/*
+					 * Something is malformed. Hide the token to
+					 * avoid exposing internal or private data.
+					 */
+					return '';
+				}
+
+				$output = call_user_func( $token_replacer, $token );
+				return null !== $output ? $output : $token->fallback;
+			},
+			$input
+		);
+	}
+
+
+	/**
+	 * Parses the inner contents of a token.
+	 *
+	 * @param string $contents
+	 * @return WP_Token|null The parsed token.
+	 */
+	public static function parse_token_contents( $contents ) {
+		$matches = null;
+
+		/*
+		 * Token shorthand syntax allows for quicker entry of simple tokens.
+		 *
+		 * Examples:
+		 *     #{identity}#
+		 *     #{core/identity}#
+		 *     #{echo="\u003ctest\u003e"}#  <-- "<test>"
+		 *     #{plugin-url="my_plugin"}#
+		 *     #{my_plugin/weather={"stat": "temperature", "units": "C"}}#
+		 */
+		if ( 1 === preg_match(
+			'~^(?:(?P<NAMESPACE>[a-z][a-z\d_-]*)/)?(?P<NAME>[a-z][a-z\d_-]*)(?:=(?P<VALUE>.+))?$~i',
+			$contents,
+			$matches
+		)) {
+			$rawNamespace = isset( $matches['NAMESPACE'] ) ? $matches['NAMESPACE'] : '';
+			$namespace    = empty( $rawNamespace ) ? 'core' : $rawNamespace;
+			$name         = $matches['NAME'];
+			$rawValue     = isset( $matches['VALUE'] ) ? $matches['VALUE'] : '';
+			$value        = ! empty( $rawValue ) ? self::json_decode( $rawValue ) : null;
+
+			return null === $value
+				? new WP_Token( $namespace, $name )
+				: new WP_Token( $namespace, $name, $value );
+		}
+
+		/*
+		 * If not using the shorthand syntax we have to attempt to parse this as augmented JSON.
+		 *
+		 * Examples:
+		 *     #{"name":"query/published-date", "value":{"format":"%A"}}#
+		 *     #{"name":"my-plugin/weather", "value":{"stat":"temperature", "units": "C"}, "fallback": "hot"}#
+		 */
+		$token_data = self::json_decode( "{{$contents}}" );
+		if ( null === $token_data ) {
+			/*
+			 * Because we wrap this in curly brackets `null` is
+			 * not a possible valid parse, meaning if we get
+			 * this value it indicates that our parse failed.
+			 */
+			return null;
+		}
+
+		$name_matches = null;
+		$token_name = isset( $token_data['token'] ) ? $token_data['token'] : '';
+		if ( ! preg_match( '~^(?:(?P<NAMESPACE>[a-z][a-z\d_-]*)/)?(?P<NAME>[a-z][a-z\d_-]*)$~i', $token_name, $name_matches ) ) {
+			return null;
+		}
+
+		$rawNamespace = isset( $name_matches['NAMESPACE'] ) ? $name_matches['NAMESPACE'] : '';
+		$namespace    = empty( $rawNamespace ) ? 'core' : $rawNamespace;
+
+		return new WP_Token(
+			$namespace,
+			$name_matches['NAME'],
+			isset( $token_data['value'] ) ? $token_data['value'] : null,
+			isset( $token_data['fallback'] ) ? $token_data['fallback'] : ''
+		);
+	}
+
+
+	public static function json_decode( $input ) {
+		return json_decode( $input, JSON_OBJECT_AS_ARRAY );
+	}
+}


### PR DESCRIPTION
## Status

 - Unlock storing Bit syntax in Core: WordPress/wordpress-develop#6390
 - Add bits to RichText in editor: WordPress/gutenberg#60735

## What?

Introduces a system to replace dynamic tokens with rendered values, a.k.a. "Shortcodes 2.0"

Discussion in #39831

"Tokens" are like shortcodes; they exist independent from blocks. They may be found inside of blocks, but they exist at the lexical level. Tokens have an identity unto themselves, such as "the URL of the featured image of the current post." On page renders they are replaced by the server. During edit sessions they appear in inputs _as visual tokens_. While previewing blocks in the editor they are replaced by JavaScript inside the editor.

Tokens provide a more restricted way of replacing basic text content with values provided from external sources. They cannot nest and they should limit themselves to plaintext replacements (though it's possible to provide _anything_ from the server when rendering them).

Check out the [README](https://github.com/WordPress/gutenberg/blob/b92e299968c3c746face648b635b607fed873645/packages/tokens/README.md) for more information on syntax forms and use. Development of those things is happening there too.

## Why?

Blocks are heavy abstractions representing rich content types. While blocks fulfill many things that shortcodes were never able to fulfill well, they leave a gap in providing simple inline content from external sources - for example, the title of the current post.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

## Testing Instructions

Example post:
```html
<!-- wp:paragraph -->
<p>This is a <a href="#{just-a-token}#" data-type="internal">link to a fragment.</a></p>
<!-- /wp:paragraph -->

<!-- wp:image {"sizeSlug":"large"} -->
<figure class="wp-block-image size-large"><img src="#{featured-image}#" alt=""/><figcaption class="wp-element-caption">This image references a fragment only.</figcaption></figure>
<!-- /wp:image -->

<!-- wp:paragraph -->
<p>It's possible to mix text and tokens.</p>
<!-- /wp:paragraph -->

<!-- wp:image {"sizeSlug":"large"} -->
<figure class="wp-block-image size-large"><img src="#{plugins-url}#/gutenberg/docs/how-to-guides/data-basics/media/list-of-pages/filter.jpg" alt=""/></figure>
<!-- /wp:image -->
```

## Screenshots or screencast <!-- if applicable -->
