### PR TITLE
Fix: Double condition on or on block editor reducer

### DIFF
--- a/packages/block-editor/src/store/reducer.js
+++ b/packages/block-editor/src/store/reducer.js
@@ -398,12 +398,11 @@ const withBlockTree =
 				const updatedBlockUids = [];
 				if ( action.fromRootClientId ) {
 					updatedBlockUids.push( action.fromRootClientId );
+				} else {
+					updatedBlockUids.push( '' );
 				}
 				if ( action.toRootClientId ) {
 					updatedBlockUids.push( action.toRootClientId );
-				}
-				if ( ! action.fromRootClientId || ! action.fromRootClientId ) {
-					updatedBlockUids.push( '' );
 				}
 				newState.tree = updateParentInnerBlocksInTree(
 					newState,


### PR DESCRIPTION
This PR fixes a duplicate condition on the or "! action.fromRootClientId || ! action.fromRootClientId". It also moves the condition to an else clause to make things more explicit.