### PR TITLE
JS Error Tracking: Allow custom error reporting logic to be called in Error Boundaries via a WP action hook

### DIFF
--- a/docs/reference-guides/actions/editor-actions.md
+++ b/docs/reference-guides/actions/editor-actions.md
@@ -1,0 +1,24 @@
+# Editor Actions
+
+To help you hook into the editor lifecycle and extend it, the following Actions are exposed:
+
+### Error Boundaries
+
+#### `editor.ErrorBoundary.errorLogged`
+
+Allows you to hook into the editor Error Boundaries' `componentDidCatch` and gives you access to the error object.
+
+You can use If you want to get hold of the error object that's handled by the boundaries, i.e to send them to an external error tracking tool.
+
+_Example_:
+
+```js
+addAction(
+	'editor.ErrorBoundary.errorLogged',
+	'mu-plugin/error-capture-setup',
+	( error ) => {
+		// error is the exception's error object
+		ErrorCaptureTool.captureError( error );
+	}
+);
+```

--- a/docs/reference-guides/actions/editor-actions.md
+++ b/docs/reference-guides/actions/editor-actions.md
@@ -8,7 +8,7 @@ To help you hook into the editor lifecycle and extend it, the following Actions 
 
 Allows you to hook into the editor Error Boundaries' `componentDidCatch` and gives you access to the error object.
 
-You can use If you want to get hold of the error object that's handled by the boundaries, i.e to send them to an external error tracking tool.
+You can use if you want to get hold of the error object that's handled by the boundaries, i.e to send them to an external error tracking tool.
 
 _Example_:
 

--- a/packages/customize-widgets/src/components/error-boundary/index.js
+++ b/packages/customize-widgets/src/components/error-boundary/index.js
@@ -28,7 +28,7 @@ export default class ErrorBoundary extends Component {
 	componentDidCatch( error ) {
 		this.setState( { error } );
 
-		doAction( 'gb.reportErrorBoundaryException', error );
+		doAction( 'editor.ErrorBoundary.errorLogged', error );
 	}
 
 	render() {

--- a/packages/customize-widgets/src/components/error-boundary/index.js
+++ b/packages/customize-widgets/src/components/error-boundary/index.js
@@ -6,6 +6,7 @@ import { __ } from '@wordpress/i18n';
 import { Button } from '@wordpress/components';
 import { Warning } from '@wordpress/block-editor';
 import { useCopyToClipboard } from '@wordpress/compose';
+import { doAction } from '@wordpress/hooks';
 
 function CopyButton( { text, children } ) {
 	const ref = useCopyToClipboard( text );
@@ -26,6 +27,8 @@ export default class ErrorBoundary extends Component {
 
 	componentDidCatch( error ) {
 		this.setState( { error } );
+
+		doAction( 'gb.reportErrorBoundaryException', error );
 	}
 
 	render() {

--- a/packages/customize-widgets/src/components/test/error-boundary.js
+++ b/packages/customize-widgets/src/components/test/error-boundary.js
@@ -1,0 +1,38 @@
+/**
+ * WordPress dependencies
+ */
+import * as wpHooks from '@wordpress/hooks';
+/**
+ * Internal dependencies
+ */
+import ErrorBoundary from '../error-boundary';
+/**
+ * External dependencies
+ */
+import { render } from '@testing-library/react';
+
+const theError = new Error( 'Kaboom' );
+
+const ChildComponent = () => {
+	throw theError;
+};
+
+describe( 'Error Boundary', () => {
+	describe( 'when error is thrown from a Child component', () => {
+		it( 'calls the `editor.ErrorBoundary.errorLogged` hook action with the error object', () => {
+			const doAction = jest.spyOn( wpHooks, 'doAction' );
+
+			render(
+				<ErrorBoundary>
+					<ChildComponent />
+				</ErrorBoundary>
+			);
+
+			expect( doAction ).toHaveBeenCalledWith(
+				'editor.ErrorBoundary.errorLogged',
+				theError
+			);
+			expect( console ).toHaveErrored();
+		} );
+	} );
+} );

--- a/packages/edit-navigation/src/components/error-boundary/index.js
+++ b/packages/edit-navigation/src/components/error-boundary/index.js
@@ -5,7 +5,6 @@ import { Component } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import { Button } from '@wordpress/components';
 import { Warning } from '@wordpress/block-editor';
-import { doAction } from '@wordpress/hooks';
 
 class ErrorBoundary extends Component {
 	constructor() {
@@ -20,8 +19,6 @@ class ErrorBoundary extends Component {
 
 	componentDidCatch( error ) {
 		this.setState( { error } );
-
-		doAction( 'gb.reportErrorBoundaryException', error );
 	}
 
 	reboot() {

--- a/packages/edit-navigation/src/components/error-boundary/index.js
+++ b/packages/edit-navigation/src/components/error-boundary/index.js
@@ -5,6 +5,7 @@ import { Component } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import { Button } from '@wordpress/components';
 import { Warning } from '@wordpress/block-editor';
+import { doAction } from '@wordpress/hooks';
 
 class ErrorBoundary extends Component {
 	constructor() {
@@ -19,6 +20,8 @@ class ErrorBoundary extends Component {
 
 	componentDidCatch( error ) {
 		this.setState( { error } );
+
+		doAction( 'gb.reportErrorBoundaryException', error );
 	}
 
 	reboot() {

--- a/packages/edit-site/src/components/error-boundary/index.js
+++ b/packages/edit-site/src/components/error-boundary/index.js
@@ -3,6 +3,7 @@
  */
 import { Component } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
+import { doAction } from '@wordpress/hooks';
 
 /**
  * Internal dependencies
@@ -18,6 +19,10 @@ export default class ErrorBoundary extends Component {
 		this.state = {
 			error: null,
 		};
+	}
+
+	componentDidCatch( error ) {
+		doAction( 'gb.reportErrorBoundaryException', error );
 	}
 
 	static getDerivedStateFromError( error ) {

--- a/packages/edit-site/src/components/error-boundary/index.js
+++ b/packages/edit-site/src/components/error-boundary/index.js
@@ -22,7 +22,7 @@ export default class ErrorBoundary extends Component {
 	}
 
 	componentDidCatch( error ) {
-		doAction( 'gb.reportErrorBoundaryException', error );
+		doAction( 'editor.ErrorBoundary.errorLogged', error );
 	}
 
 	static getDerivedStateFromError( error ) {

--- a/packages/edit-site/src/components/test/error-boundary.js
+++ b/packages/edit-site/src/components/test/error-boundary.js
@@ -1,0 +1,38 @@
+/**
+ * WordPress dependencies
+ */
+import * as wpHooks from '@wordpress/hooks';
+/**
+ * Internal dependencies
+ */
+import ErrorBoundary from '../error-boundary';
+/**
+ * External dependencies
+ */
+import { render } from '@testing-library/react';
+
+const theError = new Error( 'Kaboom' );
+
+const ChildComponent = () => {
+	throw theError;
+};
+
+describe( 'Error Boundary', () => {
+	describe( 'when error is thrown from a Child component', () => {
+		it( 'calls the `editor.ErrorBoundary.errorLogged` hook action with the error object', () => {
+			const doAction = jest.spyOn( wpHooks, 'doAction' );
+
+			render(
+				<ErrorBoundary>
+					<ChildComponent />
+				</ErrorBoundary>
+			);
+
+			expect( doAction ).toHaveBeenCalledWith(
+				'editor.ErrorBoundary.errorLogged',
+				theError
+			);
+			expect( console ).toHaveErrored();
+		} );
+	} );
+} );

--- a/packages/edit-widgets/src/components/error-boundary/index.js
+++ b/packages/edit-widgets/src/components/error-boundary/index.js
@@ -6,6 +6,7 @@ import { __ } from '@wordpress/i18n';
 import { Button } from '@wordpress/components';
 import { Warning } from '@wordpress/block-editor';
 import { useCopyToClipboard } from '@wordpress/compose';
+import { doAction } from '@wordpress/hooks';
 
 function CopyButton( { text, children } ) {
 	const ref = useCopyToClipboard( text );
@@ -29,6 +30,8 @@ export default class ErrorBoundary extends Component {
 
 	componentDidCatch( error ) {
 		this.setState( { error } );
+
+		doAction( 'gb.reportErrorBoundaryException', error );
 	}
 
 	reboot() {

--- a/packages/edit-widgets/src/components/error-boundary/index.js
+++ b/packages/edit-widgets/src/components/error-boundary/index.js
@@ -31,7 +31,7 @@ export default class ErrorBoundary extends Component {
 	componentDidCatch( error ) {
 		this.setState( { error } );
 
-		doAction( 'gb.reportErrorBoundaryException', error );
+		doAction( 'editor.ErrorBoundary.errorLogged', error );
 	}
 
 	reboot() {

--- a/packages/edit-widgets/src/components/test/error-boundary.js
+++ b/packages/edit-widgets/src/components/test/error-boundary.js
@@ -1,0 +1,38 @@
+/**
+ * WordPress dependencies
+ */
+import * as wpHooks from '@wordpress/hooks';
+/**
+ * Internal dependencies
+ */
+import ErrorBoundary from '../error-boundary';
+/**
+ * External dependencies
+ */
+import { render } from '@testing-library/react';
+
+const theError = new Error( 'Kaboom' );
+
+const ChildComponent = () => {
+	throw theError;
+};
+
+describe( 'Error Boundary', () => {
+	describe( 'when error is thrown from a Child component', () => {
+		it( 'calls the `editor.ErrorBoundary.errorLogged` hook action with the error object', () => {
+			const doAction = jest.spyOn( wpHooks, 'doAction' );
+
+			render(
+				<ErrorBoundary>
+					<ChildComponent />
+				</ErrorBoundary>
+			);
+
+			expect( doAction ).toHaveBeenCalledWith(
+				'editor.ErrorBoundary.errorLogged',
+				theError
+			);
+			expect( console ).toHaveErrored();
+		} );
+	} );
+} );

--- a/packages/editor/src/components/error-boundary/index.js
+++ b/packages/editor/src/components/error-boundary/index.js
@@ -7,6 +7,7 @@ import { Button } from '@wordpress/components';
 import { select } from '@wordpress/data';
 import { Warning } from '@wordpress/block-editor';
 import { useCopyToClipboard } from '@wordpress/compose';
+import { doAction } from '@wordpress/hooks';
 
 /**
  * Internal dependencies
@@ -36,6 +37,8 @@ class ErrorBoundary extends Component {
 
 	componentDidCatch( error ) {
 		this.setState( { error } );
+
+		doAction( 'gb.reportErrorBoundaryException', error );
 	}
 
 	reboot() {

--- a/packages/editor/src/components/error-boundary/index.js
+++ b/packages/editor/src/components/error-boundary/index.js
@@ -38,7 +38,7 @@ class ErrorBoundary extends Component {
 	componentDidCatch( error ) {
 		this.setState( { error } );
 
-		doAction( 'gb.reportErrorBoundaryException', error );
+		doAction( 'editor.ErrorBoundary.errorLogged', error );
 	}
 
 	reboot() {


### PR DESCRIPTION
## What?
<!-- In a few words, what is the PR actually doing? -->

Create an extension point in Gutenberg Error Boundaries that allows any client code (**browser** JS code running in the same context as the GB editor) to call custom logic as part of the boundaries' `componentDidCatch` methods, via a WP action hook. This logic can be set by any JS code running in the same context as the Gutenberg plugin that has access to import and use `addAction` from the `@wordpress/hooks` package.


## Why?

Error Boundaries provide a great way to customize the way rendering errors are caught and presented to the user, however, they end up swallowing the errors. This means that if you want to report it somewhere else, you're out of luck (as in, you need to modify the actual GB source code).

A typical real-world scenario is the use of tools like Sentry or Rollbar. By default, these tools setup a global error handler that will track and capture any uncaught error that ends up bubbling up to it. This is not the case for errors handled by React Error Boundaries, so they end up not being captured at all.

These tools usually provide their own Error Boundaries that will take care of capturing the errors, but Gutenberg already has many Error Boundaries with their custom logic, and we're not looking to replace them. We also don't want to couple the custom error reporting logic to the Error Boundary classes, either. We want them to be optional and set by any other JS code running in the same context (any other plugin/mu-plugin or enqueued js file).

## How?

For each React Error Boundary in Gutenberg, as part of the `componentDidCall` callback, we introduce a new `gb.reportErrorBoundaryException` action hook call (the name is provisory and up for discussion) and pass the `error` as its payload:

```js
class ErrorBoundary extends Component {
	componentDidCatch( error ) {
		this.setState( { error } );

		doAction( 'gb.reportErrorBoundaryException', error );
	}
}
```

Then, in any client JS code - which could be, say, the logic that sets up a tool like Sentry or Rollbar - we can then do something like:

```js
Sentry.init( {
	dsn: 'https://<dsn>',
} );

addAction( 'gb.reportErrorBoundaryException', 'mu-plugin/sentry-setup', ( error ) => {
	Sentry.reportError( error );
} );
```

## TODO
* [x] Discuss the approach :)
* [x] Add unit-tests
* [x] Add manual testing instructions
* [x] Should we worry about multiple `addAction` calls setting multiple callbacks? (I think not)
* [ ] Any security concerns?

## Testing Instructions

#### 1) In your WP test instance, add a `wp-content/mu-plugins/test.php` file with the following contents:

```php
<?php
function testit() {
    wp_register_script('test', '');
    wp_enqueue_script('test' );
    wp_add_inline_script('test', "wp.hooks.addAction('gb.reportErrorBoundaryException', 'testing', (error) => {
       console.error('Opsie!', error);
    });");
}

add_action( 'admin_enqueue_scripts', 'testit', 99 );
```

#### 2) Force an error in a component that's wrapped by one of the available React Error Boundaries. Here's a diff for the `PostTitle` component, which will test the Error Boundary in `packages/editor/src/components/error-boundary`:

```diff
diff --git i/packages/editor/src/components/post-title/index.js w/packages/editor/src/components/post-title/index.js
index 6930819700..19bb9b9a72 100644
--- i/packages/editor/src/components/post-title/index.js
+++ w/packages/editor/src/components/post-title/index.js
@@ -208,6 +208,7 @@ function PostTitle( _, forwardedRef ) {
                                ref={ useMergeRefs( [ richTextRef, ref ] ) }
                                contentEditable
                                className={ className }
+                               foo={ bar }
                                aria-label={ decodedPlaceholder }
                                role="textbox"
                                aria-multiline="true"
```

**Apply this diff to your custom build of GB based on this branch. Make sure it's installed and active in your WP test instance.**


#### 3) Start a new post. You'll see the `The editor has encountered an unexpected error.` warning message, and if you open the console, you should see the `error` log prefixed with `Opsie`, meaning the custom action callback you setup in step 1) ran successfully.

Resolves: https://github.com/WordPress/gutenberg/issues/41094