### PR TITLE
Ignore library CSS and built CSS in stylelint

### DIFF
--- a/.stylelintignore
+++ b/.stylelintignore
@@ -1,1 +1,4 @@
+build
+build-style
+node_modules
 packages/stylelint-config/test


### PR DESCRIPTION
## What?
This PR adds library CSS and built-in CSS to stylelint exclusion rules.

## Why?
The following directories contain CSS files owned by the library or generated by the build.

- `build/`
- `build-style/`
- `node_modules/`

`lint-css` script doesn't make errors because [it targets scss files](https://github.com/WordPress/gutenberg/blob/0a5bbb4a07bab5b0f2ee0a1276339eda5d1a5a95/package.json#L273), but some code editors will output an error according to the stylelint settings, as shown below:

![stylelint](https://user-images.githubusercontent.com/54422211/176342706-4b6eab46-b3f6-45ab-b60d-28b0a1238bbc.png)

## How?
I took `.eslintignore` as a reference and added `build`, `build-style`, `node_modules` to `.stylelintignore`.
If you know other files or directories that should be added, please let me know.
