### PR TITLE
Remove the Template panel option from the Preferences modal

### DIFF
--- a/packages/edit-post/src/components/preferences-modal/index.js
+++ b/packages/edit-post/src/components/preferences-modal/index.js
@@ -206,12 +206,6 @@ export default function EditPostPreferencesModal() {
 									panelName="post-link"
 								/>
 							) }
-							{ isViewable && (
-								<EnablePanelOption
-									label={ __( 'Template' ) }
-									panelName="template"
-								/>
-							) }
 							<PostTaxonomies
 								taxonomyWrapper={ ( content, taxonomy ) => (
 									<EnablePanelOption


### PR DESCRIPTION
## What?
PR remove the Template panel option from the Preferences modal

## Why?
Now that Template settings are part of the Summary panel (#41925), this preference has no effect.

## Testing Instructions
1. Open a Post or Page.
2. Open Preferences modal and Panels tab.
3. Confirm that the Template toggle option isn't there.

## Screenshots or screencast <!-- if applicable -->
![CleanShot 2022-06-29 at 10 19 57](https://user-images.githubusercontent.com/240569/176365466-e19385b3-ed4e-4616-8695-143c7dba3f5c.png)
