### PR TITLE
Fix tabbing from first or last block in site editor

### DIFF
--- a/packages/dom/src/dom/is-form-element.js
+++ b/packages/dom/src/dom/is-form-element.js
@@ -12,6 +12,10 @@ import isInputOrTextArea from './is-input-or-text-area';
  * @return {boolean} True if form element and false otherwise.
  */
 export default function isFormElement( element ) {
+	if ( ! element ) {
+		return false;
+	}
+
 	const { tagName } = element;
 	const checkForInputTextarea = isInputOrTextArea( element );
 	return (

--- a/test/e2e/specs/site-editor/writing-flow.spec.js
+++ b/test/e2e/specs/site-editor/writing-flow.spec.js
@@ -1,0 +1,83 @@
+/**
+ * WordPress dependencies
+ */
+const {
+	test,
+	expect,
+	Editor,
+} = require( '@wordpress/e2e-test-utils-playwright' );
+
+test.use( {
+	editor: async ( { page }, use ) => {
+		await use( new Editor( { page, hasIframe: true } ) );
+	},
+} );
+
+test.describe( 'Site editor writing flow', () => {
+	test.beforeAll( async ( { requestUtils } ) => {
+		await requestUtils.activateTheme( 'emptytheme' );
+	} );
+
+	test.afterAll( async ( { requestUtils } ) => {
+		await requestUtils.activateTheme( 'twentytwentyone' );
+	} );
+
+	// Check for regressions of https://github.com/WordPress/gutenberg/issues/41811.
+	test( 'allows shift tabbing to the block toolbar from the first block', async ( {
+		admin,
+		editor,
+		page,
+		pageUtils,
+	} ) => {
+		// Navigate to a template part with only a couple of blocks.
+		await admin.visitSiteEditor( {
+			postId: 'emptytheme//header',
+			postType: 'wp_template_part',
+		} );
+
+		// Select the first site title block.
+		const siteTitleBlock = editor.canvas.locator(
+			'role=document[name="Block: Site Title"i]'
+		);
+		await expect( siteTitleBlock ).toBeVisible();
+		await editor.selectBlocks( siteTitleBlock );
+
+		// Shift tab to the toolbar.
+		await pageUtils.pressKeyWithModifier( 'shift', 'Tab' );
+		const blockToolbarButton = page.locator(
+			'role=toolbar[name="Block tools"i] >> role=button[name="Site Title"i]'
+		);
+		await expect( blockToolbarButton ).toBeFocused();
+	} );
+
+	// Check for regressions of https://github.com/WordPress/gutenberg/issues/41811.
+	test.only( 'allows tabbing to the inspector from the last block', async ( {
+		admin,
+		editor,
+		page,
+		pageUtils,
+	} ) => {
+		// Navigate to a template part with only a couple of blocks.
+		await admin.visitSiteEditor( {
+			postId: 'emptytheme//header',
+			postType: 'wp_template_part',
+		} );
+
+		// Make sure the sidebar is open.
+		await editor.openDocumentSettingsSidebar();
+
+		// Select the last site tagline block.
+		const siteTaglineBlock = editor.canvas.locator(
+			'role=document[name="Block: Site Tagline"i]'
+		);
+		await expect( siteTaglineBlock ).toBeVisible();
+		await editor.selectBlocks( siteTaglineBlock );
+
+		// Tab to the inspector, tabbing three times to go past the two resize handles.
+		await pageUtils.pressKeyTimes( 'Tab', 3 );
+		const inspectorTemplateTab = page.locator(
+			'role=region[name="Editor settings"i] >> role=button[name="Template"i]'
+		);
+		await expect( inspectorTemplateTab ).toBeFocused();
+	} );
+} );

--- a/test/e2e/specs/site-editor/writing-flow.spec.js
+++ b/test/e2e/specs/site-editor/writing-flow.spec.js
@@ -51,7 +51,7 @@ test.describe( 'Site editor writing flow', () => {
 	} );
 
 	// Check for regressions of https://github.com/WordPress/gutenberg/issues/41811.
-	test.only( 'allows tabbing to the inspector from the last block', async ( {
+	test( 'allows tabbing to the inspector from the last block', async ( {
 		admin,
 		editor,
 		page,


### PR DESCRIPTION
## What?
Fixes #41811

Shift tabbing from the first block to the toolbar and tabbing from the last block to the inspector both seem to be broken in the site editor. This PR restores the expected behavior.

## Why?
From what I can tell this is a side effect of the iframed editor content. The WritingFlow component implements div elements before and after the editor content that are part of the tab order. In the post editor these are focused when tabbing beyond the first/last block boundaries and some logic transfers focus to the toolbar or inspector.

In the site editor, these are outside of the iframe and can't be found by the `tabbable` utility. That results in `undefined` being passed to `isFormElement`, which threw an error, and resulted in the code after that point that handles toolbar/inspector navigation not executing.

## How?
The fix seems as simple as making `isFormElement` return `false` when passed `undefined`. This seems ok as it matches what other similar utilities in the `@wordpress/dom` package do.

## Testing Instructions
E2E tests have been added

1. To make life easier create a new template part and add two blocks
2. Select the first block and try shift tabbing to the toolbar, the first toolbar button should be focused.
3. Open the inspector (Settings) using the cog icon if it isn't already open.
4. Select the last block and try tabbing (three times) to the inspector, the 'Template' tab button should be focused

## Screenshots or screencast <!-- if applicable -->
My screencast app was quarantined as malware. 😭 