### PR TITLE
Update site editor region labels to match post editor

### DIFF
--- a/packages/e2e-test-utils-playwright/src/editor/site-editor.ts
+++ b/packages/e2e-test-utils-playwright/src/editor/site-editor.ts
@@ -9,20 +9,14 @@ import type { Editor } from './index';
  * @param {Editor} this
  */
 export async function saveSiteEditorEntities( this: Editor ) {
-	await this.page
-		.locator( 'role=region[name="Header"i] >> role=button[name="Save"i]' )
-		.click();
-
-	// The sidebar entities panel opens with another save button. Click this too.
-	await this.page
-		.locator( 'role=region[name="Publish"i] >> role=button[name="Save"i]' )
-		.click();
-
-	// The panel will close revealing the main editor save button again.
-	// It will have the classname `.is-busy` while saving. Wait for it to
-	// not have that classname.
-	// TODO - find a way to improve this selector to use role/name.
+	await this.page.click(
+		'role=region[name="Editor top bar"i] >> role=button[name="Save"i]'
+	);
+	// Second Save button in the entities panel.
+	await this.page.click(
+		'role=region[name="Publish"i] >> role=button[name="Save"i]'
+	);
 	await this.page.waitForSelector(
-		'css=.edit-site-save-button__button:not(.is-busy)'
+		'role=region[name="Editor top bar"i] >> role=button[name="Save"i][disabled]'
 	);
 }

--- a/packages/e2e-test-utils-playwright/src/editor/site-editor.ts
+++ b/packages/e2e-test-utils-playwright/src/editor/site-editor.ts
@@ -14,7 +14,7 @@ export async function saveSiteEditorEntities( this: Editor ) {
 	);
 	// Second Save button in the entities panel.
 	await this.page.click(
-		'role=region[name="Publish"i] >> role=button[name="Save"i]'
+		'role=region[name="Editor publish"i] >> role=button[name="Save"i]'
 	);
 	await this.page.waitForSelector(
 		'role=region[name="Editor top bar"i] >> role=button[name="Save"i][disabled]'

--- a/packages/e2e-test-utils/src/site-editor.js
+++ b/packages/e2e-test-utils/src/site-editor.js
@@ -274,7 +274,7 @@ export async function toggleGlobalStyles() {
  * @param {string} panelName Name of the panel that is going to be opened.
  */
 export async function openGlobalStylesPanel( panelName ) {
-	const selector = `//div[@aria-label="Settings"]//button[.//*[text()="${ panelName }"]]`;
+	const selector = `//div[@aria-label="Editor settings"]//button[.//*[text()="${ panelName }"]]`;
 	await ( await page.waitForXPath( selector ) ).click();
 }
 
@@ -283,6 +283,6 @@ export async function openGlobalStylesPanel( panelName ) {
  */
 export async function openPreviousGlobalStylesPanel() {
 	await page.click(
-		'div[aria-label="Settings"] button[aria-label="Navigate to the previous view"]'
+		'div[aria-label="Editor settings"] button[aria-label="Navigate to the previous view"]'
 	);
 }

--- a/packages/edit-site/src/components/editor/index.js
+++ b/packages/edit-site/src/components/editor/index.js
@@ -47,6 +47,15 @@ import { GlobalStylesProvider } from '../global-styles/global-styles-provider';
 import useTitle from '../routes/use-title';
 
 const interfaceLabels = {
+	/* translators: accessibility text for the editor top bar landmark region. */
+	header: __( 'Editor top bar' ),
+	/* translators: accessibility text for the editor content landmark region. */
+	body: __( 'Editor content' ),
+	/* translators: accessibility text for the editor settings landmark region. */
+	sidebar: __( 'Editor settings' ),
+	/* translators: accessibility text for the editor footer landmark region. */
+	footer: __( 'Editor footer' ),
+	/* translators: accessibility text for the navigation sidebar landmark region. */
 	drawer: __( 'Navigation Sidebar' ),
 };
 

--- a/packages/edit-site/src/components/editor/index.js
+++ b/packages/edit-site/src/components/editor/index.js
@@ -53,6 +53,8 @@ const interfaceLabels = {
 	body: __( 'Editor content' ),
 	/* translators: accessibility text for the editor settings landmark region. */
 	sidebar: __( 'Editor settings' ),
+	/* translators: accessibility text for the editor publish landmark region. */
+	actions: __( 'Editor publish' ),
 	/* translators: accessibility text for the editor footer landmark region. */
 	footer: __( 'Editor footer' ),
 	/* translators: accessibility text for the navigation sidebar landmark region. */

--- a/test/e2e/specs/site-editor/template-revert.spec.js
+++ b/test/e2e/specs/site-editor/template-revert.spec.js
@@ -34,9 +34,9 @@ test.describe( 'Template Revert', () => {
 			name: 'core/paragraph',
 			attributes: { content: 'Test' },
 		} );
-		await templateRevertUtils.save();
+		await editor.saveSiteEditorEntities();
 		await templateRevertUtils.revertTemplate();
-		await templateRevertUtils.save();
+		await editor.saveSiteEditorEntities();
 
 		await page.click( 'role=button[name="Show template details"i]' );
 
@@ -57,9 +57,9 @@ test.describe( 'Template Revert', () => {
 			name: 'core/paragraph',
 			attributes: { content: 'Test' },
 		} );
-		await templateRevertUtils.save();
+		await editor.saveSiteEditorEntities();
 		await templateRevertUtils.revertTemplate();
-		await templateRevertUtils.save();
+		await editor.saveSiteEditorEntities();
 
 		const contentAfter =
 			await templateRevertUtils.getCurrentSiteEditorContent();
@@ -78,9 +78,9 @@ test.describe( 'Template Revert', () => {
 			name: 'core/paragraph',
 			attributes: { content: 'Test' },
 		} );
-		await templateRevertUtils.save();
+		await editor.saveSiteEditorEntities();
 		await templateRevertUtils.revertTemplate();
-		await templateRevertUtils.save();
+		await editor.saveSiteEditorEntities();
 		await admin.visitSiteEditor();
 
 		const contentAfter =
@@ -97,20 +97,20 @@ test.describe( 'Template Revert', () => {
 			name: 'core/paragraph',
 			attributes: { content: 'Test' },
 		} );
-		await templateRevertUtils.save();
+		await editor.saveSiteEditorEntities();
 		const contentBefore =
 			await templateRevertUtils.getCurrentSiteEditorContent();
 
 		// Revert template and check state.
 		await templateRevertUtils.revertTemplate();
-		await templateRevertUtils.save();
+		await editor.saveSiteEditorEntities();
 		const contentAfterSave =
 			await templateRevertUtils.getCurrentSiteEditorContent();
 		expect( contentAfterSave ).not.toEqual( contentBefore );
 
 		// Undo revert by clicking header button and check state again.
 		await page.click(
-			'role=region[name="Header"i] >> role=button[name="Undo"i]'
+			'role=region[name="Editor top bar"i] >> role=button[name="Undo"i]'
 		);
 		const contentAfterUndo =
 			await templateRevertUtils.getCurrentSiteEditorContent();
@@ -126,12 +126,12 @@ test.describe( 'Template Revert', () => {
 			name: 'core/paragraph',
 			attributes: { content: 'Test' },
 		} );
-		await templateRevertUtils.save();
+		await editor.saveSiteEditorEntities();
 		const contentBefore =
 			await templateRevertUtils.getCurrentSiteEditorContent();
 
 		await templateRevertUtils.revertTemplate();
-		await templateRevertUtils.save();
+		await editor.saveSiteEditorEntities();
 
 		// Click the snackbar "Undo" button.
 		await page.click(
@@ -155,11 +155,11 @@ test.describe( 'Template Revert', () => {
 			name: 'core/paragraph',
 			attributes: { content: 'Test' },
 		} );
-		await templateRevertUtils.save();
+		await editor.saveSiteEditorEntities();
 		await templateRevertUtils.revertTemplate();
-		await templateRevertUtils.save();
+		await editor.saveSiteEditorEntities();
 		await page.click(
-			'role=region[name="Header"i] >> role=button[name="Undo"i]'
+			'role=region[name="Editor top bar"i] >> role=button[name="Undo"i]'
 		);
 
 		const contentAfterUndo =
@@ -167,7 +167,7 @@ test.describe( 'Template Revert', () => {
 		expect( contentAfterUndo ).not.toEqual( contentBefore );
 
 		await page.click(
-			'role=region[name="Header"i] >> role=button[name="Redo"i]'
+			'role=region[name="Editor top bar"i] >> role=button[name="Redo"i]'
 		);
 
 		const contentAfterRedo =
@@ -187,9 +187,9 @@ test.describe( 'Template Revert', () => {
 			name: 'core/paragraph',
 			attributes: { content: 'Test' },
 		} );
-		await templateRevertUtils.save();
+		await editor.saveSiteEditorEntities();
 		await templateRevertUtils.revertTemplate();
-		await templateRevertUtils.save();
+		await editor.saveSiteEditorEntities();
 
 		// Click undo in the snackbar. This reverts revert template action.
 		await page.click(
@@ -203,7 +203,7 @@ test.describe( 'Template Revert', () => {
 
 		// Click undo again, this time in the header. Reverts initial dummy content.
 		await page.click(
-			'role=region[name="Header"i] >> role=button[name="Undo"i]'
+			'role=region[name="Editor top bar"i] >> role=button[name="Undo"i]'
 		);
 
 		// Check dummy content is gone.
@@ -222,18 +222,18 @@ test.describe( 'Template Revert', () => {
 			name: 'core/paragraph',
 			attributes: { content: 'Test' },
 		} );
-		await templateRevertUtils.save();
+		await editor.saveSiteEditorEntities();
 		const contentBefore =
 			await templateRevertUtils.getCurrentSiteEditorContent();
 
 		await templateRevertUtils.revertTemplate();
-		await templateRevertUtils.save();
+		await editor.saveSiteEditorEntities();
 
 		await page.click(
-			'role=region[name="Header"i] >> role=button[name="Undo"i]'
+			'role=region[name="Editor top bar"i] >> role=button[name="Undo"i]'
 		);
 
-		await templateRevertUtils.save();
+		await editor.saveSiteEditorEntities();
 
 		await admin.visitSiteEditor();
 
@@ -252,18 +252,18 @@ test.describe( 'Template Revert', () => {
 			name: 'core/paragraph',
 			attributes: { content: 'Test' },
 		} );
-		await templateRevertUtils.save();
+		await editor.saveSiteEditorEntities();
 		const contentBefore =
 			await templateRevertUtils.getCurrentSiteEditorContent();
 
 		await templateRevertUtils.revertTemplate();
-		await templateRevertUtils.save();
+		await editor.saveSiteEditorEntities();
 
 		await page.click(
 			'role=button[name="Dismiss this notice"i] >> role=button[name="Undo"i]'
 		);
 
-		await templateRevertUtils.save();
+		await editor.saveSiteEditorEntities();
 		await admin.visitSiteEditor();
 
 		const contentAfter =
@@ -275,19 +275,6 @@ test.describe( 'Template Revert', () => {
 class TemplateRevertUtils {
 	constructor( { page } ) {
 		this.page = page;
-	}
-
-	async save() {
-		await this.page.click(
-			'role=region[name="Header"i] >> role=button[name="Save"i]'
-		);
-		// Second Save button in the entities panel.
-		await this.page.click(
-			'role=region[name="Publish"i] >> role=button[name="Save"i]'
-		);
-		await this.page.waitForSelector(
-			'role=region[name="Header"i] >> role=button[name="Save"i][disabled]'
-		);
 	}
 
 	async revertTemplate() {

--- a/test/e2e/specs/site-editor/title.spec.js
+++ b/test/e2e/specs/site-editor/title.spec.js
@@ -23,7 +23,7 @@ test.describe( 'Site editor title', () => {
 		} );
 
 		const title = await page.locator(
-			'role=region[name="Header"i] >> role=heading[level=1]'
+			'role=region[name="Editor top bar"i] >> role=heading[level=1]'
 		);
 
 		await expect( title ).toHaveText( 'Editing template: Index' );
@@ -40,7 +40,7 @@ test.describe( 'Site editor title', () => {
 		} );
 
 		const title = await page.locator(
-			'role=region[name="Header"i] >> role=heading[level=1]'
+			'role=region[name="Editor top bar"i] >> role=heading[level=1]'
 		);
 
 		await expect( title ).toHaveText( 'Editing template part: header' );


### PR DESCRIPTION
## What?
Updates the site editor's region labels to match the post editor

## Why?
The site editors labels were different for some reason.

Making them match the post editor is a good idea as it helps make the site editor experience familiar for screen reader users that already know the post editor.

It also makes it easier to write end to end test utilities that work across both editors.

## How?
Add the strings, innit.

## Testing Instructions
1. Using a screen reader, open the site editor and use the shortcut key for navigating regions (Ctrl + backtick or Ctrl + alt + N)
2. Do the same in the post editor

Expected: the labels for the editor topbar, editor settings, editor content and editor footer should match.