### PR TITLE
Post Template: Fix condition checks

### DIFF
--- a/packages/edit-post/src/components/sidebar/post-template/form.js
+++ b/packages/edit-post/src/components/sidebar/post-template/form.js
@@ -50,7 +50,10 @@ export default function PostTemplateForm( { onClose } ) {
 			),
 			selectedTemplateSlug:
 				select( editorStore ).getEditedPostAttribute( 'template' ),
-			canCreate: canCreateTemplates && ! _isPostsPage,
+			canCreate:
+				canCreateTemplates &&
+				! _isPostsPage &&
+				editorSettings.supportsTemplateMode,
 			canEdit:
 				canCreateTemplates &&
 				editorSettings.supportsTemplateMode &&

--- a/packages/edit-post/src/components/sidebar/post-template/index.js
+++ b/packages/edit-post/src/components/sidebar/post-template/index.js
@@ -27,7 +27,7 @@ export default function PostTemplate() {
 		const hasTemplates =
 			!! settings.availableTemplates &&
 			Object.keys( settings.availableTemplates ).length > 0;
-		if ( ! hasTemplates ) {
+		if ( ! hasTemplates && ! settings.supportsTemplateMode ) {
 			return false;
 		}
 

--- a/packages/edit-post/src/components/sidebar/post-template/index.js
+++ b/packages/edit-post/src/components/sidebar/post-template/index.js
@@ -27,8 +27,8 @@ export default function PostTemplate() {
 		const hasTemplates =
 			!! settings.availableTemplates &&
 			Object.keys( settings.availableTemplates ).length > 0;
-		if ( hasTemplates ) {
-			return true;
+		if ( ! hasTemplates ) {
+			return false;
 		}
 
 		const canCreateTemplates =


### PR DESCRIPTION
## What?
A follow-up to #41925.

PR fixes the following conditions for the "Post Template" component:
1. Don't display template settings, when a theme has no templates and doesn't support template mode.
2. Don't display the "Add template" action when a theme doesn't support template mode.

## Why?
1. If a theme has no templates and block template support is disabled, there's no need to display this option since the user can't select templates.
2. If the block template support is disabled, the user shouldn't be able to create templates.

These match behavior of the previous Post Template panel component.

P.S. @noisysocks, sorry I missed this during initial testing.

## Testing Instructions

### Theme with no templates
1. Enable the TwentyNineteen theme.
2. Open a Post or Page.
3. Confirm the Post Template option isn't visible in document settings.

### Theme with templates, no block template support
1. Enable the TwentyTwenty theme.
2. Open a Post or Page.
3. Confirm the Post Template option is available, but no "Add template" action.

### Block Theme
1. Enable TT2 theme.
2. Open a Post or Page.
3. 3. Confirm the Post Template option is available with the "Add template" action.

## Screenshots or screencast <!-- if applicable -->
| TwentyNineteen | TwentyTwenty | TT2 |
| --- | --- | --- |
|![CleanShot 2022-06-29 at 14 16 26](https://user-images.githubusercontent.com/240569/176413134-04f0580c-6e1c-431b-b447-daf3fb5ac140.png)|![CleanShot 2022-06-29 at 14 16 42](https://user-images.githubusercontent.com/240569/176413124-947edc8a-f9e2-4bbf-b124-8e0ed2407f8e.png)|![CleanShot 2022-06-29 at 14 16 12](https://user-images.githubusercontent.com/240569/176413142-e5013c2e-a8a2-470e-88b0-8b00045c370d.png)|
