### PR TITLE
Migrate Block Mover Test For Playwright

### DIFF
--- a/test/e2e/specs/editor/various/block-mover.spec.js
+++ b/test/e2e/specs/editor/various/block-mover.spec.js
@@ -22,7 +22,7 @@ test.describe( 'block mover', () => {
 		await page.focus( 'text=First Paragraph' );
 		await editor.showBlockToolbar();
 
-		const blockMover = await page.$$( '.block-editor-block-mover' );
+		const blockMover = await page.locator( '.block-editor-block-mover' );
 		// There should be a block mover.
 		expect( blockMover ).toHaveLength( 1 );
 	} );
@@ -41,7 +41,7 @@ test.describe( 'block mover', () => {
 		await editor.showBlockToolbar();
 
 		// Ensure no block mover exists when only one block exists on the page.
-		const blockMover = await page.$$( '.block-editor-block-mover' );
+		const blockMover = await page.locator( '.block-editor-block-mover' );
 		expect( blockMover ).toHaveLength( 0 );
 	} );
 } );

--- a/test/e2e/specs/editor/various/block-mover.spec.js
+++ b/test/e2e/specs/editor/various/block-mover.spec.js
@@ -21,10 +21,11 @@ test.describe( 'block mover', () => {
 		// Select a block so the block mover is rendered.
 		await page.focus( 'text=First Paragraph' );
 		await editor.showBlockToolbar();
-
-		const blockMover = await page.locator( '.block-editor-block-mover' );
-		// There should be a block mover.
-		expect( blockMover ).toHaveLength( 1 );
+		const count = await page.$$eval(
+			'.block-editor-block-mover',
+			( el ) => el.length
+		);
+		expect( count ).toBe( 1 );
 	} );
 
 	test( 'should hide block mover when only one block exists', async ( {
@@ -37,11 +38,13 @@ test.describe( 'block mover', () => {
 
 		// Select a block so the block mover has the possibility of being rendered.
 		await page.focus( 'text=First Paragraph' );
-
 		await editor.showBlockToolbar();
 
 		// Ensure no block mover exists when only one block exists on the page.
-		const blockMover = await page.locator( '.block-editor-block-mover' );
-		expect( blockMover ).toHaveLength( 0 );
+		const count = await page.$$eval(
+			'.block-editor-block-mover',
+			( el ) => el.length
+		);
+		expect( count ).toBe( 0 );
 	} );
 } );

--- a/test/e2e/specs/editor/various/block-mover.spec.js
+++ b/test/e2e/specs/editor/various/block-mover.spec.js
@@ -1,14 +1,17 @@
 /**
  * WordPress dependencies
  */
-import { createNewPost, showBlockToolbar } from '@wordpress/e2e-test-utils';
+const { test, expect } = require( '@wordpress/e2e-test-utils-playwright' );
 
-describe( 'block mover', () => {
-	beforeEach( async () => {
-		await createNewPost();
+test.describe( 'block mover', () => {
+	test.beforeEach( async ( { admin } ) => {
+		await admin.createNewPost();
 	} );
 
-	it( 'should show block mover when more than one block exists', async () => {
+	test( 'should show block mover when more than one block exists', async ( {
+		editor,
+		page,
+	} ) => {
 		// Create a two blocks on the page.
 		await page.click( '.block-editor-default-block-appender' );
 		await page.keyboard.type( 'First Paragraph' );
@@ -16,24 +19,26 @@ describe( 'block mover', () => {
 		await page.keyboard.type( 'Second Paragraph' );
 
 		// Select a block so the block mover is rendered.
-		await page.focus( '[data-type="core/paragraph"]' );
-
-		await showBlockToolbar();
+		await page.focus( 'text=First Paragraph' );
+		await editor.showBlockToolbar();
 
 		const blockMover = await page.$$( '.block-editor-block-mover' );
 		// There should be a block mover.
 		expect( blockMover ).toHaveLength( 1 );
 	} );
 
-	it( 'should hide block mover when only one block exists', async () => {
+	test( 'should hide block mover when only one block exists', async ( {
+		editor,
+		page,
+	} ) => {
 		// Create a single block on the page.
 		await page.click( '.block-editor-default-block-appender' );
 		await page.keyboard.type( 'First Paragraph' );
 
 		// Select a block so the block mover has the possibility of being rendered.
-		await page.focus( '.block-editor-block-list__block' );
+		await page.focus( 'text=First Paragraph' );
 
-		await showBlockToolbar();
+		await editor.showBlockToolbar();
 
 		// Ensure no block mover exists when only one block exists on the page.
 		const blockMover = await page.$$( '.block-editor-block-mover' );

--- a/test/e2e/specs/editor/various/block-mover.spec.js
+++ b/test/e2e/specs/editor/various/block-mover.spec.js
@@ -13,19 +13,27 @@ test.describe( 'block mover', () => {
 		page,
 	} ) => {
 		// Create a two blocks on the page.
-		await page.click( '.block-editor-default-block-appender' );
-		await page.keyboard.type( 'First Paragraph' );
-		await page.keyboard.press( 'Enter' );
-		await page.keyboard.type( 'Second Paragraph' );
+		await editor.insertBlock( {
+			name: 'core/paragraph',
+			attributes: { content: 'First Paragraph' },
+		} );
+		await editor.insertBlock( {
+			name: 'core/paragraph',
+			attributes: { content: 'Second Paragraph' },
+		} );
 
 		// Select a block so the block mover is rendered.
 		await page.focus( 'text=First Paragraph' );
 		await editor.showBlockToolbar();
-		const count = await page.$$eval(
-			'.block-editor-block-mover',
-			( el ) => el.length
+
+		const moveDownButton = page.locator(
+			'role=toolbar[name="Block tools"i] >> role=button[name="Move down"i]'
 		);
-		expect( count ).toBe( 1 );
+		const moveUpButton = page.locator(
+			'role=toolbar[name="Block tools"i] >> role=button[name="Move up"i]'
+		);
+		await expect( moveDownButton ).toBeVisible();
+		await expect( moveUpButton ).toBeVisible();
 	} );
 
 	test( 'should hide block mover when only one block exists', async ( {
@@ -33,18 +41,23 @@ test.describe( 'block mover', () => {
 		page,
 	} ) => {
 		// Create a single block on the page.
-		await page.click( '.block-editor-default-block-appender' );
-		await page.keyboard.type( 'First Paragraph' );
 
+		await editor.insertBlock( {
+			name: 'core/paragraph',
+			attributes: { content: 'First Paragraph' },
+		} );
 		// Select a block so the block mover has the possibility of being rendered.
 		await page.focus( 'text=First Paragraph' );
 		await editor.showBlockToolbar();
 
 		// Ensure no block mover exists when only one block exists on the page.
-		const count = await page.$$eval(
-			'.block-editor-block-mover',
-			( el ) => el.length
+		const moveDownButton = page.locator(
+			'role=toolbar[name="Block tools"i] >> role=button[name="Move down"i]'
 		);
-		expect( count ).toBe( 0 );
+		const moveUpButton = page.locator(
+			'role=toolbar[name="Block tools"i] >> role=button[name="Move up"i]'
+		);
+		await expect( moveDownButton ).toBeHidden();
+		await expect( moveUpButton ).toBeHidden();
 	} );
 } );


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->
## What?
<!-- In a few words, what is the PR actually doing? -->
Part of https://github.com/WordPress/gutenberg/issues/38851.
Migrate[ block-mover.test.js](https://github.com/WordPress/gutenberg/blob/trunk/packages/e2e-tests/specs/editor/various/block-mover.test.js) to its Playwright version.
## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
Part of https://github.com/WordPress/gutenberg/issues/38851.
## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
See[ MIGRATION.md](https://github.com/WordPress/gutenberg/blob/trunk/test/e2e/MIGRATION.md) for migration steps.
## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->
Run` npm run test-e2e:playwright test/e2e/specs/editor/various/block-mover.spec.js`