### PR TITLE
Lodash: Refactor away from `_.reject()`

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -109,6 +109,7 @@ module.exports = {
 							'overEvery',
 							'partialRight',
 							'random',
+							'reject',
 							'reverse',
 							'size',
 							'stubFalse',

--- a/packages/format-library/src/text-color/inline.native.js
+++ b/packages/format-library/src/text-color/inline.native.js
@@ -1,10 +1,4 @@
 /**
- * External dependencies
- */
-
-import { reject } from 'lodash';
-
-/**
  * WordPress dependencies
  */
 import { useCallback, useMemo } from '@wordpress/element';
@@ -110,7 +104,9 @@ function setColors( value, name, colorSettings, colors ) {
 		const newFormat = applyFormat( value, format );
 		const { activeFormats } = newFormat;
 		newFormat.formats[ value.start ] = [
-			...reject( activeFormats, { type: format.type } ),
+			...( activeFormats?.filter(
+				( { type } ) => type !== format.type
+			) || [] ),
 			format,
 		];
 		return newFormat;

--- a/packages/rich-text/src/apply-format.js
+++ b/packages/rich-text/src/apply-format.js
@@ -1,10 +1,4 @@
 /**
- * External dependencies
- */
-
-import { find, reject } from 'lodash';
-
-/**
  * Internal dependencies
  */
 
@@ -42,9 +36,9 @@ export function applyFormat(
 
 	// The selection is collapsed.
 	if ( startIndex === endIndex ) {
-		const startFormat = find( newFormats[ startIndex ], {
-			type: format.type,
-		} );
+		const startFormat = newFormats[ startIndex ]?.find(
+			( { type } ) => type === format.type
+		);
 
 		// If the caret is at a format of the same type, expand start and end to
 		// the edges of the format. This is useful to apply new attributes.
@@ -110,7 +104,9 @@ export function applyFormat(
 		// inputs with the format so new input appears with the format applied,
 		// and ensures a format of the same type uses the latest values.
 		activeFormats: [
-			...reject( activeFormats, { type: format.type } ),
+			...( activeFormats?.filter(
+				( { type } ) => type !== format.type
+			) || [] ),
 			format,
 		],
 	} );

--- a/packages/rich-text/src/remove-format.js
+++ b/packages/rich-text/src/remove-format.js
@@ -1,10 +1,4 @@
 /**
- * External dependencies
- */
-
-import { find, reject } from 'lodash';
-
-/**
  * Internal dependencies
  */
 
@@ -36,17 +30,27 @@ export function removeFormat(
 	// If the selection is collapsed, expand start and end to the edges of the
 	// format.
 	if ( startIndex === endIndex ) {
-		const format = find( newFormats[ startIndex ], { type: formatType } );
+		const format = newFormats[ startIndex ]?.find(
+			( { type } ) => type === formatType
+		);
 
 		if ( format ) {
-			while ( find( newFormats[ startIndex ], format ) ) {
+			while (
+				newFormats[ startIndex ]?.find(
+					( newFormat ) => newFormat === format
+				)
+			) {
 				filterFormats( newFormats, startIndex, formatType );
 				startIndex--;
 			}
 
 			endIndex++;
 
-			while ( find( newFormats[ endIndex ], format ) ) {
+			while (
+				newFormats[ endIndex ]?.find(
+					( newFormat ) => newFormat === format
+				)
+			) {
 				filterFormats( newFormats, endIndex, formatType );
 				endIndex++;
 			}
@@ -62,7 +66,8 @@ export function removeFormat(
 	return normaliseFormats( {
 		...value,
 		formats: newFormats,
-		activeFormats: reject( activeFormats, { type: formatType } ),
+		activeFormats:
+			activeFormats?.filter( ( { type } ) => type !== formatType ) || [],
 	} );
 }
 


### PR DESCRIPTION
## What?
Lodash's `reject()` is used only a few times in the entire codebase. This PR aims to remove that usage.

## Why?
Lodash is known to unnecessarily inflate the bundle size of packages, and in most cases, it can be replaced with native language functionality. See these for more information and rationale:

* https://github.com/WordPress/gutenberg/issues/16938#issuecomment-602837246
* https://github.com/WordPress/gutenberg/issues/17025
* https://github.com/WordPress/gutenberg/issues/39495 

## How?
Removing `_.reject()` is straightforward in favor of `Array.prototype.filter()`. 

We also use the opportunity to remove a couple of stray `find()` usages that are easily replacible with `Array.prototype.find()`.

## Testing Instructions

* Verify rich text package tests still pass: `npm run test-unit packages/rich-text`
* Follow the instructions from #37915 for the RN-related changes.