### PR TITLE
Fix: CSS files don't build in dev mode on Windows

### DIFF
--- a/bin/packages/build.js
+++ b/bin/packages/build.js
@@ -116,7 +116,9 @@ function createStyleEntryTransform() {
 
 			packages.add( packageName );
 			const entries = await glob(
-				path.resolve( PACKAGES_DIR, packageName, 'src/*.scss' )
+				path
+					.resolve( PACKAGES_DIR, packageName, 'src/*.scss' )
+					.replace( /\\/g, '/' )
 			);
 
 			// Account for the specific case where block styles in


### PR DESCRIPTION
Related issue: 

- #37189
- #38326
- #38781

Follow-up on:

- #39388

## What?
This PR resolves a problem in Windows OS where CSS files are not properly monitored and built when `npm run dev` is run.

## Why? & How?

See [this comment](https://github.com/WordPress/gutenberg/pull/42041/files/c343aa35b611bf239a9a5577312a31e10d2e7aff#r909515306).

## Testing Instructions

- Execute `npm run dev`.
- Update SCSS files in `packages/` directory.
  (e.g. `packages\components\src\placeholder\style.scss`)
- Confirm that the corresponding CSS files in `build/` directory have been updated according to the SCSS update.
  (e.g. `build/components/style.css`)