### PR TITLE
Lodash: Refactor away from `_.keyBy()`

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -99,6 +99,7 @@ module.exports = {
 							'isNumber',
 							'isObjectLike',
 							'isUndefined',
+							'keyBy',
 							'keys',
 							'lowerCase',
 							'memoize',

--- a/packages/blocks/src/store/reducer.js
+++ b/packages/blocks/src/store/reducer.js
@@ -40,6 +40,7 @@ export const DEFAULT_CATEGORIES = [
 	{ slug: 'reusable', title: __( 'Reusable blocks' ) },
 ];
 
+// Key block types by their name.
 function keyBlockTypesByName( types ) {
 	return types.reduce(
 		( newBlockTypes, block ) => ( {

--- a/packages/blocks/src/store/reducer.js
+++ b/packages/blocks/src/store/reducer.js
@@ -6,7 +6,6 @@ import {
 	find,
 	get,
 	isEmpty,
-	keyBy,
 	map,
 	mapValues,
 	omit,
@@ -40,6 +39,16 @@ export const DEFAULT_CATEGORIES = [
 	{ slug: 'embed', title: __( 'Embeds' ) },
 	{ slug: 'reusable', title: __( 'Reusable blocks' ) },
 ];
+
+function keyBlockTypesByName( types ) {
+	return types.reduce(
+		( newBlockTypes, block ) => ( {
+			...newBlockTypes,
+			[ block.name ]: block,
+		} ),
+		{}
+	);
+}
 
 /**
  * Reducer managing the unprocessed block types in a form passed when registering the by block.
@@ -79,7 +88,7 @@ export function blockTypes( state = {}, action ) {
 		case 'ADD_BLOCK_TYPES':
 			return {
 				...state,
-				...keyBy( action.blockTypes, 'name' ),
+				...keyBlockTypesByName( action.blockTypes ),
 			};
 		case 'REMOVE_BLOCK_TYPES':
 			return omit( state, action.names );
@@ -102,7 +111,7 @@ export function blockStyles( state = {}, action ) {
 			return {
 				...state,
 				...mapValues(
-					keyBy( action.blockTypes, 'name' ),
+					keyBlockTypesByName( action.blockTypes ),
 					( blockType ) => {
 						return uniqBy(
 							[
@@ -159,7 +168,7 @@ export function blockVariations( state = {}, action ) {
 			return {
 				...state,
 				...mapValues(
-					keyBy( action.blockTypes, 'name' ),
+					keyBlockTypesByName( action.blockTypes ),
 					( blockType ) => {
 						return uniqBy(
 							[

--- a/packages/core-data/src/reducer.js
+++ b/packages/core-data/src/reducer.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { keyBy, map, groupBy, flowRight, isEqual, get } from 'lodash';
+import { map, groupBy, flowRight, isEqual, get } from 'lodash';
 
 /**
  * WordPress dependencies
@@ -55,7 +55,13 @@ export function users( state = { byId: {}, queries: {} }, action ) {
 			return {
 				byId: {
 					...state.byId,
-					...keyBy( action.users, 'id' ),
+					...action.users.reduce(
+						( newUsers, user ) => ( {
+							...newUsers,
+							[ user.id ]: user,
+						} ),
+						{}
+					),
 				},
 				queries: {
 					...state.queries,

--- a/packages/core-data/src/reducer.js
+++ b/packages/core-data/src/reducer.js
@@ -55,6 +55,7 @@ export function users( state = { byId: {}, queries: {} }, action ) {
 			return {
 				byId: {
 					...state.byId,
+					// Key users by their ID.
 					...action.users.reduce(
 						( newUsers, user ) => ( {
 							...newUsers,

--- a/packages/edit-site/src/store/selectors.js
+++ b/packages/edit-site/src/store/selectors.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { map, keyBy } from 'lodash';
+import { map } from 'lodash';
 import createSelector from 'rememo';
 
 /**
@@ -341,10 +341,15 @@ export const getCurrentTemplateTemplateParts = createRegistrySelector(
 			'wp_template_part',
 			{ per_page: -1 }
 		);
-		const templatePartsById = keyBy(
-			templateParts,
-			( templatePart ) => templatePart.id
-		);
+		const templatePartsById = templateParts
+			? templateParts.reduce(
+					( newTemplateParts, part ) => ( {
+						...newTemplateParts,
+						[ part.id ]: part,
+					} ),
+					{}
+			  )
+			: {};
 
 		return ( template.blocks ?? [] )
 			.filter( ( block ) => isTemplatePart( block ) )

--- a/packages/edit-site/src/store/selectors.js
+++ b/packages/edit-site/src/store/selectors.js
@@ -342,7 +342,8 @@ export const getCurrentTemplateTemplateParts = createRegistrySelector(
 			{ per_page: -1 }
 		);
 		const templatePartsById = templateParts
-			? templateParts.reduce(
+			? // Key template parts by their ID.
+			  templateParts.reduce(
 					( newTemplateParts, part ) => ( {
 						...newTemplateParts,
 						[ part.id ]: part,

--- a/packages/edit-widgets/src/store/selectors.js
+++ b/packages/edit-widgets/src/store/selectors.js
@@ -1,9 +1,4 @@
 /**
- * External dependencies
- */
-import { keyBy } from 'lodash';
-
-/**
  * WordPress dependencies
  */
 import { createRegistrySelector } from '@wordpress/data';
@@ -36,7 +31,15 @@ export const getWidgets = createRegistrySelector( ( select ) => () => {
 		buildWidgetsQuery()
 	);
 
-	return keyBy( widgets, 'id' );
+	return (
+		widgets?.reduce(
+			( allWidgets, widget ) => ( {
+				...allWidgets,
+				[ widget.id ]: widget,
+			} ),
+			{}
+		) || {}
+	);
 } );
 
 /**

--- a/packages/edit-widgets/src/store/selectors.js
+++ b/packages/edit-widgets/src/store/selectors.js
@@ -32,6 +32,7 @@ export const getWidgets = createRegistrySelector( ( select ) => () => {
 	);
 
 	return (
+		// Key widgets by their ID.
 		widgets?.reduce(
 			( allWidgets, widget ) => ( {
 				...allWidgets,

--- a/packages/rich-text/src/store/reducer.js
+++ b/packages/rich-text/src/store/reducer.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { keyBy, omit } from 'lodash';
+import { omit } from 'lodash';
 
 /**
  * WordPress dependencies
@@ -21,7 +21,13 @@ export function formatTypes( state = {}, action ) {
 		case 'ADD_FORMAT_TYPES':
 			return {
 				...state,
-				...keyBy( action.formatTypes, 'name' ),
+				...action.formatTypes.reduce(
+					( newFormatTypes, type ) => ( {
+						...newFormatTypes,
+						[ type.name ]: type,
+					} ),
+					{}
+				),
 			};
 		case 'REMOVE_FORMAT_TYPES':
 			return omit( state, action.names );

--- a/packages/rich-text/src/store/reducer.js
+++ b/packages/rich-text/src/store/reducer.js
@@ -21,6 +21,7 @@ export function formatTypes( state = {}, action ) {
 		case 'ADD_FORMAT_TYPES':
 			return {
 				...state,
+				// Key format types by their name.
 				...action.formatTypes.reduce(
 					( newFormatTypes, type ) => ( {
 						...newFormatTypes,


### PR DESCRIPTION
## What?
Lodash's `keyBy()` is used only a few times in the entire codebase. This PR aims to remove that usage.

## Why?
Lodash is known to unnecessarily inflate the bundle size of packages, and in most cases, it can be replaced with native language functionality. See these for more information and rationale:

* https://github.com/WordPress/gutenberg/issues/16938#issuecomment-602837246
* https://github.com/WordPress/gutenberg/issues/17025
* https://github.com/WordPress/gutenberg/issues/39495 

## How?
Removing `_.keyBy()` is straightforward in favor of an `Array.prototype.reduce()` that goes through the array elements and builds an object, with the specified key as a key, and the entire object as a value. We're intentionally not touching the co-existing Lodash usage to keep the PR shorter and self-contained. All usages are within stores, and that area is generally well covered by tests.

## Testing Instructions

* Verify all tests still pass.