### PR TITLE
[RNMobile] RichText: Prevent early return in onSelectionChangeFromAztec when content has leading or trailing spaces

### DIFF
--- a/packages/rich-text/src/component/index.native.js
+++ b/packages/rich-text/src/component/index.native.js
@@ -659,9 +659,14 @@ export class RichText extends Component {
 
 		// Check for and discard events during quick typing. Updating the selection during quick typing isn't
 		// necessary and can cause UI lags. (see https://github.com/WordPress/gutenberg/pull/41682.)
+		const detectSpaceAtStartOrEnd =
+			contentWithoutRootTag.charAt( 0 ) === '' ||
+			contentWithoutRootTag.substr( contentWithoutRootTag.length - 1 ) ===
+				' ';
 		if (
 			contentWithoutRootTag !== this.value &&
-			this.lastAztecEventType === 'selection change'
+			this.lastAztecEventType === 'selection change' &&
+			! detectSpaceAtStartOrEnd
 		) {
 			return;
 		}

--- a/packages/rich-text/src/component/index.native.js
+++ b/packages/rich-text/src/component/index.native.js
@@ -660,6 +660,7 @@ export class RichText extends Component {
 		// Check for and discard events during quick typing. Updating the selection during quick typing isn't
 		// necessary and can cause UI lags. (see https://github.com/WordPress/gutenberg/pull/41682.)
 		// Note, it's necessary to detect leading or trailing spaces to prevent them from being stripped.
+		// (see https://github.com/WordPress/gutenberg/pull/42046.)
 		const leadingOrTrailingSpace =
 			contentWithoutRootTag.charAt( 0 ) === ' ' ||
 			contentWithoutRootTag.substr( contentWithoutRootTag.length - 1 ) ===

--- a/packages/rich-text/src/component/index.native.js
+++ b/packages/rich-text/src/component/index.native.js
@@ -660,7 +660,7 @@ export class RichText extends Component {
 		// Check for and discard events during quick typing. Updating the selection during quick typing isn't
 		// necessary and can cause UI lags. (see https://github.com/WordPress/gutenberg/pull/41682.)
 		const leadingOrTrailingSpace =
-			contentWithoutRootTag.charAt( 0 ) === '' ||
+			contentWithoutRootTag.charAt( 0 ) === ' ' ||
 			contentWithoutRootTag.substr( contentWithoutRootTag.length - 1 ) ===
 				' ';
 		if (

--- a/packages/rich-text/src/component/index.native.js
+++ b/packages/rich-text/src/component/index.native.js
@@ -659,6 +659,7 @@ export class RichText extends Component {
 
 		// Check for and discard events during quick typing. Updating the selection during quick typing isn't
 		// necessary and can cause UI lags. (see https://github.com/WordPress/gutenberg/pull/41682.)
+		// Note, it's necessary to detect leading or trailing spaces to prevent them from being stripped.
 		const leadingOrTrailingSpace =
 			contentWithoutRootTag.charAt( 0 ) === ' ' ||
 			contentWithoutRootTag.substr( contentWithoutRootTag.length - 1 ) ===

--- a/packages/rich-text/src/component/index.native.js
+++ b/packages/rich-text/src/component/index.native.js
@@ -659,14 +659,14 @@ export class RichText extends Component {
 
 		// Check for and discard events during quick typing. Updating the selection during quick typing isn't
 		// necessary and can cause UI lags. (see https://github.com/WordPress/gutenberg/pull/41682.)
-		const detectSpaceAtStartOrEnd =
+		const leadingOrTrailingSpace =
 			contentWithoutRootTag.charAt( 0 ) === '' ||
 			contentWithoutRootTag.substr( contentWithoutRootTag.length - 1 ) ===
 				' ';
 		if (
 			contentWithoutRootTag !== this.value &&
 			this.lastAztecEventType === 'selection change' &&
-			! detectSpaceAtStartOrEnd
+			! leadingOrTrailingSpace
 		) {
 			return;
 		}


### PR DESCRIPTION
## What?

In https://github.com/WordPress/gutenberg/pull/41682, the RichText component was update to return early in `RichText::onSelectionChangedFromAztec` when content changes are detected. This is to avoid unnecessary calls while a user is quickly typing.

Returning early, however, can cause leading or trailing spaces to be stripped out. This PR, therefore, iterates on the changes in https://github.com/WordPress/gutenberg/pull/41682 to prevent the early return when a leading or trailing empty space is detected in the user's content.

## Why?

We were alerted to some failures via [the `gutenberg-editor-block-insertion.test.js` tests](https://github.com/WordPress/gutenberg/blob/02699f597b391bc67da55b4f2a957ec764533a76/packages/react-native-editor/__device-tests__/gutenberg-editor-block-insertion.test.js). An example of a failure can be found [here](https://app.circleci.com/pipelines/github/wordpress-mobile/gutenberg-mobile/17887/workflows/27d98c84-4687-4e70-8a98-5005773e8792/jobs/98039):

```
Error: expect(received).toBe(expected) // Object.is equality

- Expected  - 2
+ Received  + 2

@@ -1,7 +1,7 @@
  <!-- wp:paragraph -->
- <p>beneath the busy continuum blinks the ineffective husband. why a metric now outside the official subway? how can the prompt crop exhaust his tree </p>
+ <p>beneath the busy continuum blinks the ineffective husband. why a metric now outside the official subway? how can the prompt crop exhaust his tree</p>
  <!-- /wp:paragraph -->

  <!-- wp:paragraph -->
  <p>does this chord crowd my emptied search? a theory bubbles under the cartoon. the discontinued speaker cracks every thick epic. extraordinary twin shifts behind</p>
  <!-- /wp:paragraph -->
@@ -9,7 +9,7 @@
  <!-- wp:paragraph -->
  <p>the finer continuum interprets the polynomial rabbit. when can the geology runs? an astronomer runs. should a communist consent?</p>
  <!-- /wp:paragraph -->

  <!-- wp:paragraph -->
- <p>the finer continuum interprets the polynomial rabbit. when can the geology runs? an astronomer runs. should a communist consent?</p>
+ <p>the finer continuum interprets the polynomial rabbit. when can the geology runs? an astronomer runs. should a communist consent? </p>
  <!-- /wp:paragraph -->
```

Through manual testing, it was possible to replicate a trailing space being removed when typing quickly into multiple paragraphs. As such, it's been determined that the issue is related to leading/trailing spaces, but more work needs to be done to identify exactly what's happening in the code.

## How?

A check has been added to detect whether content has leading or trailing spaces. If it does, then we no longer return early in `onSelectionChangeFromAztec`.  

Although this works to fix the bug described in this issue, more work needs to be done to figure out exactly why this the spaces are stripped out to begin with. Possibly helpful/relevant issues include:

* https://github.com/wordpress-mobile/gutenberg-mobile/pull/2127

## Testing Instructions

### Manual testing

* Open the editor in the iOS or Android app.
* Typing as quickly as possible, create a few new paragraph blocks, making sure to have some that have leading or trailing spaces.
* Switch to HTML mode to verify that any leading or trailing spaces have been retained. 

### Verify E2E failures are resolved

With this branch checked out, run `npm run native test:e2e:ios:local gutenberg-editor-block-insertion.test.js` from the Gutenberg directory in the terminal. Verify that all tests pass.
