### PR TITLE
Create Block: Fix regression from `_.size()` refactoring

### DIFF
--- a/packages/create-block/lib/init-package-json.js
+++ b/packages/create-block/lib/init-package-json.js
@@ -76,7 +76,7 @@ module.exports = async ( {
 	}
 
 	if ( wpScripts ) {
-		if ( npmDependencies.length ) {
+		if ( npmDependencies && npmDependencies.length ) {
 			info( '' );
 			info(
 				'Installing npm dependencies. It might take a couple of minutes...'
@@ -99,7 +99,7 @@ module.exports = async ( {
 			}
 		}
 
-		if ( npmDevDependencies.length ) {
+		if ( npmDevDependencies && npmDevDependencies.length ) {
 			info( '' );
 			info(
 				'Installing npm devDependencies. It might take a couple of minutes...'


### PR DESCRIPTION
## What?
This PR fixes #42047 - a regression, introduced by a recent Lodash migration.

## Why?
This fixes a regression that came from https://github.com/WordPress/gutenberg/pull/41810 as part of the Lodash migration work.

## How?
Double-checking the potentially undefined arguments before using them. 

## Testing Instructions
* With this branch checked out locally, in the Gutenberg repo, run `npx @wordpress/create-block example-block` and make sure that the process finishes correctly and you see the list of commands at the end.
* Verify `create-block` checks pass.