### PR TITLE
fix: Update Image block native e2e test fixture

### DIFF
--- a/packages/react-native-editor/__device-tests__/helpers/test-data.js
+++ b/packages/react-native-editor/__device-tests__/helpers/test-data.js
@@ -96,7 +96,7 @@ exports.imageCompletehtml = `<!-- wp:image {"id":1,"sizeslug":"large"} -->
 <!-- /wp:paragraph -->`;
 
 exports.imageShorteHtml = `<!-- wp:image {"id":1,"sizeslug":"large"} -->
-<figure class="wp-block-image size-large"><img src="https://cldup.com/cXyG__fTLN.jpg" alt="A snow-capped mountain top in a cloudy sky with red-leafed trees in the foreground" class="wp-image-1"/><figcaption>C'est la vie my friends</figcaption></figure>
+<figure class="wp-block-image size-large"><img src="https://cldup.com/cXyG__fTLN.jpg" alt="A snow-capped mountain top in a cloudy sky with red-leafed trees in the foreground" class="wp-image-1"/><figcaption class="wp-element-caption">C'est la vie my friends</figcaption></figure>
 <!-- /wp:image -->
 
 <!-- wp:paragraph -->


### PR DESCRIPTION
## What?
Fix a failing Image block native e2e test: `Gutenberg Editor Image Block tests should be able to add an image block`.

## Why?
Relates to #41140. The lack of the newly defined caption element class caused the HTML test expectation to fail.

## How?
Add the newly defined caption element class to the e2e test fixture.

## Testing Instructions
Verify the relevant e2e test passes. This must be done locally, as the test only runs on CI in `wordpress-mobile/gutenberg-mobile` repository.

`npm run native test:e2e:ios:local gutenberg-editor-image-@canary`

## Screenshots or screencast <!-- if applicable -->
n/a
