### PR TITLE
Components: refactor `NavigatorButton` to pass `exhaustive-deps`

### DIFF
--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -23,6 +23,7 @@
 -   `NavigableContainer`: use `code` instead of `keyCode` for keyboard events, rewrite tests using RTL and `user-event` ([#43606](https://github.com/WordPress/gutenberg/pull/43606/)).
 -   `ComboboxControl`: updated to satisfy `react/exhuastive-deps` eslint rule ([#41417](https://github.com/WordPress/gutenberg/pull/41417))
 -   `FormTokenField`: Refactor away from Lodash ([#43744](https://github.com/WordPress/gutenberg/pull/43744/)).
+-   `NavigatorButton`: updated to satisfy `react/exhaustive-deps` eslint rule ([#42051](https://github.com/WordPress/gutenberg/pull/42051))
 
 ## 20.0.0 (2022-08-24)
 

--- a/packages/components/src/navigator/navigator-button/hook.ts
+++ b/packages/components/src/navigator/navigator-button/hook.ts
@@ -41,7 +41,7 @@ export function useNavigatorButton(
 				} );
 				onClick?.( e );
 			},
-			[ goTo, onClick ]
+			[ goTo, onClick, attributeName, escapedPath ]
 		);
 
 	return {


### PR DESCRIPTION
## What?

Updates the `NavigatorButton` component to satisfy the `exhaustive-deps` eslint rule

## Why?

Part of the effort in https://github.com/WordPress/gutenberg/pull/41166 to apply `exhaustive-deps` to the Components package

## How?

Add the `attributeName` prop & `escapedName` to the `useCallback` dependency array.

## Testing Instructions

1. From your local Gutenberg directory, run `npx eslint --rule 'react-hooks/exhaustive-deps: warn' packages/components/src/navigation/index.js`
2. Confirm that the linter returns no errors
3. Confirm unit tests still pass
4. Run Storybook locally, confirm the components stories and/or docs still work as expected
