### PR TITLE
Second attempt at fixing #29484

### DIFF
--- a/packages/block-library/src/post-content/index.php
+++ b/packages/block-library/src/post-content/index.php
@@ -46,8 +46,9 @@ function render_block_core_post_content( $attributes, $content, $block ) {
 	// so that `the_preview` for the current post can apply.
 	// We force this behavior by omitting the third argument (post ID) from the `get_the_content`.
 	$content = get_the_content();
+
 	// Check for nextpage to display page links for paginated posts.
-	if ( has_block( 'core/nextpage' ) ) {
+	if ( $GLOBALS['multipage'] ) {
 		$content .= wp_link_pages( array( 'echo' => 0 ) );
 	}
 


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Fixes #29484

## Why?
The previous patch, #37672, does not work 100% of the time. [See details.](https://github.com/WordPress/gutenberg/issues/29484#issuecomment-1127562671)

## How?
The [`wp_link_pages`](https://developer.wordpress.org/reference/functions/wp_link_pages/) uses the `$multipage` global variable to determine whether to output pagination, so checking the same variable in this context should ensure that the pagination is output whenever there is anything to output and omitted when it would be empty.

I was tempted to check `isset( $GLOBALS['multipage'] )`, but seeing that `wp_link_pages` does not include such a check, I left it out.

## Testing Instructions
1. Create a post using the classic editor and add the `<!--nextpage-->` tag
2. Verify that the pagination is output for this post
3. Through a plugin, use the [`content_pagination`](https://developer.wordpress.org/reference/hooks/content_pagination/) filter to add pagination to a post that does not contain the `<!--nextpage-->` tag
4. Verify that the pagination is output for this post
5. Create a post using the block editor and add the `core/nextpage` block
6. Verify that the pagination is output for this post
7. Create a post that does not have pagination
8. Verify that the pagination is omitted for this post

## Screenshots or screencast <!-- if applicable -->
