### PR TITLE
Fix FormTokenField outputting duplicate ids from ComboboxControl

### DIFF
--- a/packages/components/src/form-token-field/index.tsx
+++ b/packages/components/src/form-token-field/index.tsx
@@ -71,9 +71,13 @@ export function FormTokenField( props: FormTokenFieldProps ) {
 		__experimentalExpandOnFocus = false,
 		__experimentalValidateInput = () => true,
 		__experimentalShowHowTo = true,
+		__experimentalCustomIdPrefix = '',
 	} = props;
 
-	const instanceId = useInstanceId( FormTokenField );
+	const instanceId = useInstanceId(
+		FormTokenField,
+		__experimentalCustomIdPrefix
+	);
 
 	// We reset to these initial values again in the onBlur
 	const [ incompleteTokenValue, setIncompleteTokenValue ] = useState( '' );

--- a/packages/components/src/form-token-field/types.ts
+++ b/packages/components/src/form-token-field/types.ts
@@ -147,6 +147,12 @@ export interface FormTokenFieldProps
 	 * @default true
 	 */
 	__experimentalShowHowTo?: boolean;
+	/**
+	 * Custom prefix for input id and label htmlFor values. This ensures a more unique id.
+	 *
+	 * @default empty string
+	 */
+	__experimentalCustomIdPrefix?: string;
 }
 
 export interface SuggestionsListProps< T = string | { value: string } > {

--- a/packages/editor/src/components/post-taxonomies/flat-term-selector.js
+++ b/packages/editor/src/components/post-taxonomies/flat-term-selector.js
@@ -292,6 +292,7 @@ function FlatTermSelector( { slug } ) {
 				onInputChange={ debouncedSearch }
 				maxSuggestions={ MAX_TERMS_SUGGESTIONS }
 				label={ newTermLabel }
+				__experimentalCustomIdPrefix={ slug }
 				messages={ {
 					added: termAddedLabel,
 					removed: termRemovedLabel,


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Adds the `__experimentalCustomIdPrefix` property to `FormTokenField` and modifies `useInstanceId` hook to make use of it when available.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

I noticed on make.wordpress.org, the author field and the tags field had duplicate ids. This means the labels on each of these fields will not be read because labels require unique ids with their associated inputs for screen reader support. This is also the rule of the web, unique ids.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

I modified `FormTokenField` and adjusted the post tags usage to include the custom prefix property.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->

I am not sure how to test this since I can only seem to replicate on make.wordpress.org. My guess is the fields adjust because there are too many tags or something.

## Screenshots or screencast <!-- if applicable -->
