### PR TITLE
Post Template: Update fallback label

### DIFF
--- a/packages/edit-post/src/components/sidebar/post-template/index.js
+++ b/packages/edit-post/src/components/sidebar/post-template/index.js
@@ -95,7 +95,7 @@ function PostTemplateToggle( { isOpen, onClick } ) {
 			}
 			onClick={ onClick }
 		>
-			{ templateTitle ?? __( '(none)' ) }
+			{ templateTitle ?? __( 'Default template' ) }
 		</Button>
 	);
 }


### PR DESCRIPTION
## What?
PR updates post template's fallback text from `(none)` to `Default template`.

## Why?
While there might not be an associate template in some cases, WP will still resolve to the `Default template` available in the hierarchy.

## Testing Instructions
1. Install and activate [`emptytheme`](https://github.com/WordPress/theme-experiments/tree/master/emptytheme).
2. Open a Post or Page.
3. Confirm Post Template component displays "Default template".

## Screenshots or screencast <!-- if applicable -->
| Before | After |
| --- | --- |
|![CleanShot 2022-06-30 at 11 02 07](https://user-images.githubusercontent.com/240569/176613577-ff264462-83d1-4e6e-9069-fe0ebc7b422c.png)|![CleanShot 2022-06-30 at 11 01 25](https://user-images.githubusercontent.com/240569/176613595-048dda2f-fda0-4961-a418-19c3dad8d945.png)|

