### PR TITLE
Block Editor: Use optional chaining in 'block-list' component

### DIFF
--- a/packages/block-editor/src/components/block-list/block.js
+++ b/packages/block-editor/src/components/block-list/block.js
@@ -56,10 +56,10 @@ function mergeWrapperProps( propsA, propsB ) {
 		...propsB,
 	};
 
-	if ( propsA && propsB && propsA.className && propsB.className ) {
+	if ( propsA?.className && propsB?.className ) {
 		newProps.className = classnames( propsA.className, propsB.className );
 	}
-	if ( propsA && propsB && propsA.style && propsB.style ) {
+	if ( propsA?.style && propsB?.style ) {
 		newProps.style = { ...propsA.style, ...propsB.style };
 	}
 


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Hey Everyone. 🙂
Looks like in line number 59 & 62 there's 4 `&& check` can be replaced with 2 `optional chaining (?.)`.

## Why?
(`?.`) already used in line number 190 of this file (packages/block-editor/src/components/block-list/block.js) and many other files in this repository. So, I think (`?.`) can be used where applicable.