### PR TITLE
Lodash: Refactor away from `_.repeat()`

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -110,6 +110,7 @@ module.exports = {
 							'partialRight',
 							'random',
 							'reject',
+							'repeat',
 							'reverse',
 							'size',
 							'stubFalse',

--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Internal
 
 -   `TextHighlight`: Convert to TypeScript ([#41698](https://github.com/WordPress/gutenberg/pull/41698)).
+-   `TreeSelect`: Refactor away from `_.repeat()` ([#42070](https://github.com/WordPress/gutenberg/pull/42070/)).
 
 ## 19.14.0 (2022-06-29)
 

--- a/packages/components/src/tree-select/index.tsx
+++ b/packages/components/src/tree-select/index.tsx
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { unescape as unescapeString, repeat, flatMap, compact } from 'lodash';
+import { unescape as unescapeString, flatMap, compact } from 'lodash';
 
 /**
  * WordPress dependencies
@@ -18,7 +18,7 @@ function getSelectOptions( tree: Tree[], level = 0 ): SelectOptions {
 		{
 			value: treeNode.id,
 			label:
-				repeat( '\u00A0', level * 3 ) + unescapeString( treeNode.name ),
+				'\u00A0'.repeat( level * 3 ) + unescapeString( treeNode.name ),
 		},
 		...getSelectOptions( treeNode.children || [], level + 1 ),
 	] );

--- a/packages/editor/src/components/page-attributes/parent.js
+++ b/packages/editor/src/components/page-attributes/parent.js
@@ -5,7 +5,6 @@ import {
 	get,
 	unescape as unescapeString,
 	debounce,
-	repeat,
 	find,
 	deburr,
 } from 'lodash';
@@ -98,7 +97,7 @@ export function PageAttributesParent() {
 				{
 					value: treeNode.id,
 					label:
-						repeat( '— ', level ) + unescapeString( treeNode.name ),
+						'— '.repeat( level ) + unescapeString( treeNode.name ),
 					rawName: treeNode.name,
 				},
 				...getOptionsFromTree( treeNode.children || [], level + 1 ),


### PR DESCRIPTION
## What?
Lodash's `repeat()` is used only a couple of times in the entire codebase. This PR aims to remove that usage.

## Why?
Lodash is known to unnecessarily inflate the bundle size of packages, and in most cases, it can be replaced with native language functionality. See these for more information and rationale:

* https://github.com/WordPress/gutenberg/issues/16938#issuecomment-602837246
* https://github.com/WordPress/gutenberg/issues/17025
* https://github.com/WordPress/gutenberg/issues/39495 

## How?
Removing `repeat()` is straightforward in favor of a simple `String.prototype.repeat()` replacement, as long as we run it on a variable that's a certain string (which applies to both uses).

## Testing Instructions
* Create a 3-level page structure in your WP admin.
* Go to create a new page.
* Verify that as you pick "Parent Page" in "Page Attributes", the hierarchy is still properly reflected by one dash per level.