### PR TITLE
Fix link element hover bleeding into button element default styles

### DIFF
--- a/lib/compat/wordpress-6.1/class-wp-theme-json-6-1.php
+++ b/lib/compat/wordpress-6.1/class-wp-theme-json-6-1.php
@@ -17,7 +17,7 @@
 class WP_Theme_JSON_6_1 extends WP_Theme_JSON_6_0 {
 
 	/**
-	 * Whitelist which defines which pseudo selectors are enabled for
+	 * Define which defines which pseudo selectors are enabled for
 	 * which elements.
 	 * Note: this will effect both top level and block level elements.
 	 */
@@ -31,7 +31,7 @@ class WP_Theme_JSON_6_1 extends WP_Theme_JSON_6_0 {
 	 * @var string[]
 	 */
 	const ELEMENTS = array(
-		'link'    => 'a',
+		'link'    => 'a:not(.wp-element-button)',
 		'h1'      => 'h1',
 		'h2'      => 'h2',
 		'h3'      => 'h3',
@@ -431,7 +431,7 @@ class WP_Theme_JSON_6_1 extends WP_Theme_JSON_6_0 {
 						'selector' => $selectors[ $name ]['elements'][ $element ],
 					);
 
-					// Handle any psuedo selectors for the element.
+					// Handle any pseudo selectors for the element.
 					if ( isset( static::VALID_ELEMENT_PSEUDO_SELECTORS[ $element ] ) ) {
 						foreach ( static::VALID_ELEMENT_PSEUDO_SELECTORS[ $element ] as $pseudo_selector ) {
 							if ( isset( $theme_json['styles']['blocks'][ $name ]['elements'][ $element ][ $pseudo_selector ] ) ) {
@@ -462,11 +462,6 @@ class WP_Theme_JSON_6_1 extends WP_Theme_JSON_6_0 {
 		$selector = $block_metadata['selector'];
 		$settings = _wp_array_get( $this->theme_json, array( 'settings' ) );
 
-		// Attempt to parse a pseudo selector (e.g. ":hover") from the $selector ("a:hover").
-		$pseudo_matches = array();
-		preg_match( '/:[a-z]+/', $selector, $pseudo_matches );
-		$pseudo_selector = isset( $pseudo_matches[0] ) ? $pseudo_matches[0] : null;
-
 		// Get a reference to element name from path.
 		// $block_metadata['path'] = array('styles','elements','link');
 		// Make sure that $block_metadata['path'] describes an element node, like ['styles', 'element', 'link'].
@@ -474,6 +469,21 @@ class WP_Theme_JSON_6_1 extends WP_Theme_JSON_6_0 {
 		$is_processing_element = in_array( 'elements', $block_metadata['path'], true );
 
 		$current_element = $is_processing_element ? $block_metadata['path'][ count( $block_metadata['path'] ) - 1 ] : null;
+
+		$element_pseudo_allowed = isset( static::VALID_ELEMENT_PSEUDO_SELECTORS[ $current_element ] ) ? static::VALID_ELEMENT_PSEUDO_SELECTORS[ $current_element ] : array();
+
+		// Check for allowed pseudo classes (e.g. ":hover") from the $selector ("a:hover").
+		// This also resets the array keys.
+		$pseudo_matches = array_values(
+			array_filter(
+				$element_pseudo_allowed,
+				function( $pseudo_selector ) use ( $selector ) {
+					return str_contains( $selector, $pseudo_selector );
+				}
+			)
+		);
+
+		$pseudo_selector = isset( $pseudo_matches[0] ) ? $pseudo_matches[0] : null;
 
 		// If the current selector is a pseudo selector that's defined in the allow list for the current
 		// element then compute the style properties for it.

--- a/phpunit/class-wp-theme-json-test.php
+++ b/phpunit/class-wp-theme-json-test.php
@@ -43,7 +43,7 @@ class WP_Theme_JSON_Gutenberg_Test extends WP_UnitTestCase {
 
 		$base_styles = 'body { margin: 0; }.wp-site-blocks > .alignleft { float: left; margin-right: 2em; }.wp-site-blocks > .alignright { float: right; margin-left: 2em; }.wp-site-blocks > .aligncenter { justify-content: center; margin-left: auto; margin-right: auto; }';
 
-		$element_styles = 'a{background-color: red;color: green;}a:hover{background-color: green;color: red;font-size: 10em;text-transform: uppercase;}a:focus{background-color: black;color: yellow;}';
+		$element_styles = 'a:not(.wp-element-button){background-color: red;color: green;}a:not(.wp-element-button):hover{background-color: green;color: red;font-size: 10em;text-transform: uppercase;}a:not(.wp-element-button):focus{background-color: black;color: yellow;}';
 
 		$expected = $base_styles . $element_styles;
 
@@ -82,7 +82,7 @@ class WP_Theme_JSON_Gutenberg_Test extends WP_UnitTestCase {
 
 		$base_styles = 'body { margin: 0; }.wp-site-blocks > .alignleft { float: left; margin-right: 2em; }.wp-site-blocks > .alignright { float: right; margin-left: 2em; }.wp-site-blocks > .aligncenter { justify-content: center; margin-left: auto; margin-right: auto; }';
 
-		$element_styles = 'a:hover{background-color: green;color: red;font-size: 10em;text-transform: uppercase;}a:focus{background-color: black;color: yellow;}';
+		$element_styles = 'a:not(.wp-element-button):hover{background-color: green;color: red;font-size: 10em;text-transform: uppercase;}a:not(.wp-element-button):focus{background-color: black;color: yellow;}';
 
 		$expected = $base_styles . $element_styles;
 
@@ -160,7 +160,7 @@ class WP_Theme_JSON_Gutenberg_Test extends WP_UnitTestCase {
 
 		$base_styles = 'body { margin: 0; }.wp-site-blocks > .alignleft { float: left; margin-right: 2em; }.wp-site-blocks > .alignright { float: right; margin-left: 2em; }.wp-site-blocks > .aligncenter { justify-content: center; margin-left: auto; margin-right: auto; }';
 
-		$element_styles = 'a{background-color: red;color: green;}a:hover{background-color: green;color: red;}';
+		$element_styles = 'a:not(.wp-element-button){background-color: red;color: green;}a:not(.wp-element-button):hover{background-color: green;color: red;}';
 
 		$expected = $base_styles . $element_styles;
 
@@ -208,7 +208,7 @@ class WP_Theme_JSON_Gutenberg_Test extends WP_UnitTestCase {
 
 		$base_styles = 'body { margin: 0; }.wp-site-blocks > .alignleft { float: left; margin-right: 2em; }.wp-site-blocks > .alignright { float: right; margin-left: 2em; }.wp-site-blocks > .aligncenter { justify-content: center; margin-left: auto; margin-right: auto; }';
 
-		$element_styles = '.wp-block-group a{background-color: red;color: green;}.wp-block-group a:hover{background-color: green;color: red;font-size: 10em;text-transform: uppercase;}.wp-block-group a:focus{background-color: black;color: yellow;}';
+		$element_styles = '.wp-block-group a:not(.wp-element-button){background-color: red;color: green;}.wp-block-group a:not(.wp-element-button):hover{background-color: green;color: red;font-size: 10em;text-transform: uppercase;}.wp-block-group a:not(.wp-element-button):focus{background-color: black;color: yellow;}';
 
 		$expected = $base_styles . $element_styles;
 
@@ -255,7 +255,7 @@ class WP_Theme_JSON_Gutenberg_Test extends WP_UnitTestCase {
 
 		$base_styles = 'body { margin: 0; }.wp-site-blocks > .alignleft { float: left; margin-right: 2em; }.wp-site-blocks > .alignright { float: right; margin-left: 2em; }.wp-site-blocks > .aligncenter { justify-content: center; margin-left: auto; margin-right: auto; }';
 
-		$element_styles = 'a{background-color: red;color: green;}a:hover{background-color: green;color: red;}.wp-block-group a:hover{background-color: black;color: yellow;}';
+		$element_styles = 'a:not(.wp-element-button){background-color: red;color: green;}a:not(.wp-element-button):hover{background-color: green;color: red;}.wp-block-group a:not(.wp-element-button):hover{background-color: black;color: yellow;}';
 
 		$expected = $base_styles . $element_styles;
 


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?

In https://github.com/WordPress/gutenberg/issues/42055 we discovered that `link` element styles were bleeding into `button` element styles. This PR fixes that by targeting only non-button element `a` nodes with the CSS. It also fixes a bug with the detection of pseudo selectors in the Theme JSON.

Fixes https://github.com/WordPress/gutenberg/issues/42055.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

The `link` element is mapped to a raw `a` CSS selector:

https://github.com/WordPress/gutenberg/blob/895ca1f6a7d7e492974ea55f693aecbeb1d5bbe3/lib/compat/wordpress-6.1/class-wp-theme-json-6-1.php#L33-L43

When this config is translated into CSS rules for `elements` then we get following - admittedly rather broad - selector:

```css
a {
    // rules here
}
```

Unfortunately however, [the button block uses an `a` in its markup](https://github.com/WordPress/gutenberg/blob/895ca1f6a7d7e492974ea55f693aecbeb1d5bbe3/packages/block-library/src/button/save.js#L58). 

```html
<div class="wp-block-button">
    <a class="wp-block-button__link wp-element-button">I am a button</a>
</div>
```

This means that the styles intended for `link` elements only, end up unintentionally "polluting" the button block styling.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

The suggested solution is to more carefully target anchor nodes which are not `button` elements. This is done by checking that the `a` node in question is `:not(.wp-element-button)`.

This PR therefore updates the elements constant with a new selector mapping:

```diff
const ELEMENTS = array(
-    'link'    => 'a',
+    'link'    => 'a:not(.wp-element-button)',
    // other element mappings
);
```

This results in a more specific rule being generated to target global `a` (aka `link`) elements:

```css
a:not(.wp-element-button) {
    // rules here
}
```

Unfortunately however, this has a side effect of exposing a bug in t[he way we generated pseudo class styles for elements in Theme JSON](https://github.com/WordPress/gutenberg/pull/41786). Specifically we use naive regex (I wrote it so it's ok to say that! 😆 ) that is based on the presence of a colon `:` to parse out the potential pseudo class (e.g. `:hover` from the selector `a:hover`).

https://github.com/WordPress/gutenberg/blob/895ca1f6a7d7e492974ea55f693aecbeb1d5bbe3/lib/compat/wordpress-6.1/class-wp-theme-json-6-1.php#L465-L468

The problem is that `:not()` is incorrectly determined to be a "interactivity state" psuedo class (e.g. `:hover`, `:focus`...etc) which causes the rules to be misapplied.

This PR updates the logic to check for the presence of an element-_specific_ set of _whitelisted_ pseudo classes.

```php
// Illustrative code only - see `Files changed` for actual code implementation.
$selector = 'a:not('.wp-element-button'):hover';
$element_pseudo_whitelist = array(':hover',':focus',':active');
$pseudo_matches = array_values(
    array_filter(
        $element_pseudo_whitelist,
        function( $pseudo_selector ) use ( $selector ) {
            return str_contains( $selector, $pseudo_selector ); 
        }
    )
);
```

The whitelist is as per that which already exists in `trunk`:

https://github.com/WordPress/gutenberg/blob/895ca1f6a7d7e492974ea55f693aecbeb1d5bbe3/lib/compat/wordpress-6.1/class-wp-theme-json-6-1.php#L19-L26

By doing this the pseudo selectors are output correctly.



## Testing Instructions
1. Switch to emtpytheme
2. Add this to your theme.json file under `elements`
```
			"link": {
				"border": {
					"color": "grey",
					"radius": "1px",
					"width": "5px",
					"style": "solid"
				},
				"color": {
					"background": "lightblue",
					"text": "red"
				},
				"spacing": {
					"padding": "10px"
				},
				"typography": {
					"fontFamily": "sans-serif",
					"fontSize": "20px",
					"textDecoration": "none"
				},
				":hover": {
					"border": {
						"color": "black",
						"radius": "10px",
						"width": "5px",
						"style": "solid"
					},
					"color": {
						"background": "red",
						"text": "black"
					}
				},
				":focus": {
					"border": {
						"color": "black",
						"radius": "10px",
						"width": "5px",
						"style": "solid"
					},
					"color": {
						"background": "red",
						"text": "black"
					}
				}
			}
```
3. Add some buttons blocks
4. Switch to the _**front**_ of your site.
5. Check that none of the rules for the `link` element are applied to buttons as well as to links.
6. Check against the testing instructions in https://github.com/WordPress/gutenberg/issues/42055


## Screenshots or screencast <!-- if applicable -->

### Before

Both the `link` _and_ `button` elements take on the styles shown in the `theme.json` excerpt from the `Testing Instructions`. This shouldn't happen. Buttons should not be targetted.

<img width="606" alt="Screen Shot 2022-06-30 at 11 48 48" src="https://user-images.githubusercontent.com/444434/176675390-66db1e57-3c0b-4981-be5f-ccf790816c05.png">

### After

The `link` elements take on the styles shown in the `theme.json` excerpt from the `Testing Instructions` whereas the `button` elements ignore these styles.
<img width="604" alt="Screen Shot 2022-06-30 at 11 49 16" src="https://user-images.githubusercontent.com/444434/176675398-08e3a68b-cbd3-4d4f-a630-79ce889bf87f.png">

