### PR TITLE
Popover: pass missing anchor ref to the getAnchorRect callback prop

### DIFF
--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -6,6 +6,10 @@
 
 -   `TextHighlight`: Convert to TypeScript ([#41698](https://github.com/WordPress/gutenberg/pull/41698)).
 
+### Bug Fix
+
+-   `Popover`: pass missing anchor ref to the `getAnchorRef` callback prop. ([#42076](https://github.com/WordPress/gutenberg/pull/42076))
+
 ## 19.14.0 (2022-06-29)
 
 ### Bug Fix

--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -8,7 +8,7 @@
 
 ### Bug Fix
 
--   `Popover`: pass missing anchor ref to the `getAnchorRef` callback prop. ([#42076](https://github.com/WordPress/gutenberg/pull/42076))
+-   `Popover`: pass missing anchor ref to the `getAnchorRect` callback prop. ([#42076](https://github.com/WordPress/gutenberg/pull/42076))
 
 ## 19.14.0 (2022-06-29)
 

--- a/packages/components/src/popover/index.js
+++ b/packages/components/src/popover/index.js
@@ -128,6 +128,7 @@ const Popover = (
 	}
 
 	const arrowRef = useRef( null );
+	const anchorRefFallback = useRef( null );
 	const isMobileViewport = useViewportMatch( 'medium', '<' );
 	const isExpanded = expandOnMobile && isMobileViewport;
 	const hasArrow = ! isExpanded && ! noArrow;
@@ -203,7 +204,6 @@ const Popover = (
 			: undefined,
 		hasArrow ? arrow( { element: arrowRef } ) : undefined,
 	].filter( ( m ) => !! m );
-	const anchorRefFallback = useRef( null );
 	const slotName = useContext( slotNameContext ) || __unstableSlotName;
 	const slot = useSlot( slotName );
 

--- a/packages/components/src/popover/index.js
+++ b/packages/components/src/popover/index.js
@@ -272,10 +272,10 @@ const Popover = (
 					return anchorRect;
 				},
 			};
-		} else if ( getAnchorRect ) {
+		} else if ( getAnchorRect && anchorRefFallback.current ) {
 			usedRef = {
 				getBoundingClientRect() {
-					const rect = getAnchorRect();
+					const rect = getAnchorRect( anchorRefFallback.current );
 					return new window.DOMRect(
 						rect.x ?? rect.left,
 						rect.y ?? rect.top,

--- a/packages/components/src/popover/index.js
+++ b/packages/components/src/popover/index.js
@@ -148,8 +148,11 @@ const Popover = (
 			return anchorRef.ownerDocument;
 		} else if ( anchorRect && anchorRect?.ownerDocument ) {
 			return anchorRect.ownerDocument;
-		} else if ( getAnchorRect ) {
-			return getAnchorRect()?.ownerDocument ?? document;
+		} else if ( getAnchorRect && anchorRefFallback.current ) {
+			return (
+				getAnchorRect( anchorRefFallback.current )?.ownerDocument ??
+				document
+			);
 		}
 
 		return document;


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Fix a regression introduced in https://github.com/WordPress/gutenberg/pull/40740, by passing the anchor ref as an argument of the `getAnchorRect` callback prop.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

Prior to #40740, the `getAnchorRect` callback prop [used to receive the fallback anchor ref as an argument](https://github.com/WordPress/gutenberg/blob/b99e6688fba7037ccee46cb6b7d70917a5f2c418/packages/components/src/popover/index.js#L56-L67). This behavior was removed as part of the refactor in #40740.

This PR adds back that behavior.


## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

In an effort to replicate as closely as possible the logic that existed before #40740, the changes that this PR introduces are:

- `anchorRefFallback.current` ref is passed to the `getAnchorRef` callback prop
- the `getAnchorRect` prop is called only if `anchorRefFallback.current` holds a value (this is to mimic the logic from the [early return statement](https://github.com/WordPress/gutenberg/blob/b99e6688fba7037ccee46cb6b7d70917a5f2c418/packages/components/src/popover/index.js#L57-L59) that existed prior to the refactor from #40740)

I believe that the reason why this regression hasn't been encountered until now is because it looks like that the few usages of the `getAnchorRect` don't actually rely on its arguments (a quick search across the codebase should confirm this hypothesis).

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->

- Unit tests and e2e tests keep passing
- Storybook works as expected
- Add the `getAnchorRef` prop to the Storybook example, notice how:
  - Prior to this PR, the callback's argument is always `undefined`
  - After the changes from this PR, the callback's argument is defined and references the fallback anchor

 