### PR TITLE
Button: Add theme.json support for toggling Width settings panel

### DIFF
--- a/docs/reference-guides/core-blocks.md
+++ b/docs/reference-guides/core-blocks.md
@@ -50,7 +50,7 @@ Prompt visitors to take action with a button-style link. ([Source](https://githu
 
 -	**Name:** core/button
 -	**Category:** design
--	**Supports:** align, anchor, color (background, gradients, text), spacing (padding), typography (fontSize), ~~alignWide~~, ~~reusable~~
+-	**Supports:** align, anchor, color (background, gradients, text), spacing (padding, width), typography (fontSize), ~~alignWide~~, ~~reusable~~
 -	**Attributes:** backgroundColor, gradient, linkTarget, placeholder, rel, text, textColor, title, url, width
 
 ## Buttons

--- a/docs/reference-guides/theme-json-reference/theme-json-living.md
+++ b/docs/reference-guides/theme-json-reference/theme-json-living.md
@@ -4,7 +4,7 @@
 >
 > There're related documents you may be interested in: the [theme.json v1](/docs/reference-guides/theme-json-reference/theme-json-v1.md) specification and the [reference to migrate from theme.json v1 to v2](/docs/reference-guides/theme-json-reference/theme-json-migrations.md).
 
-This reference guide lists the settings and style properties defined in the theme.json schema. See the [theme.json how to guide](/docs/how-to-guides/themes/theme-json.md) for examples and guide on how to use the theme.json file in your theme. 
+This reference guide lists the settings and style properties defined in the theme.json schema. See the [theme.json how to guide](/docs/how-to-guides/themes/theme-json.md) for examples and guide on how to use the theme.json file in your theme.
 
 ## Schema
 
@@ -82,6 +82,7 @@ Settings related to spacing.
 | blockGap | undefined | null |  |
 | margin | boolean | false |  |
 | padding | boolean | false |  |
+| width | boolean | true |  |
 | units | array | px,em,rem,vh,vw,% |  |
 | customSpacingSize | boolean | true |  |
 | spacingSizes | array |  | name, size, slug |

--- a/lib/compat/wordpress-6.0/class-wp-theme-json-6-0.php
+++ b/lib/compat/wordpress-6.0/class-wp-theme-json-6-0.php
@@ -233,6 +233,7 @@ class WP_Theme_JSON_6_0 extends WP_Theme_JSON {
 			'margin'   => null,
 			'padding'  => null,
 			'units'    => null,
+			'width'    => null,
 		),
 		'typography'      => array(
 			'customFontSize' => null,

--- a/lib/compat/wordpress-6.1/class-wp-theme-json-6-1.php
+++ b/lib/compat/wordpress-6.1/class-wp-theme-json-6-1.php
@@ -847,6 +847,7 @@ class WP_Theme_JSON_6_1 extends WP_Theme_JSON_6_0 {
 			'margin'            => null,
 			'padding'           => null,
 			'units'             => null,
+			'width'             => null,
 		),
 		'typography'      => array(
 			'customFontSize' => null,

--- a/packages/block-library/src/button/block.json
+++ b/packages/block-library/src/button/block.json
@@ -80,7 +80,8 @@
 			"padding": [ "horizontal", "vertical" ],
 			"__experimentalDefaultControls": {
 				"padding": true
-			}
+			},
+			"width": true
 		},
 		"__experimentalBorder": {
 			"radius": true,

--- a/packages/block-library/src/button/edit.js
+++ b/packages/block-library/src/button/edit.js
@@ -21,6 +21,7 @@ import {
 	InspectorControls,
 	RichText,
 	useBlockProps,
+	useSetting,
 	__experimentalUseBorderProps as useBorderProps,
 	__experimentalUseColorProps as useColorProps,
 	__experimentalGetSpacingClassesAndStyles as useSpacingProps,
@@ -125,6 +126,7 @@ function ButtonEdit( props ) {
 	const isURLSet = !! url;
 	const opensInNewTab = linkTarget === '_blank';
 
+	const isWidthPanelEnabled = false !== useSetting( 'spacing.width' );
 	function startEditing( event ) {
 		event.preventDefault();
 		setIsEditingURL( true );
@@ -243,12 +245,14 @@ function ButtonEdit( props ) {
 					/>
 				</Popover>
 			) }
-			<InspectorControls>
-				<WidthPanel
-					selectedWidth={ width }
-					setAttributes={ setAttributes }
-				/>
-			</InspectorControls>
+			{ isWidthPanelEnabled && (
+				<InspectorControls>
+					<WidthPanel
+						selectedWidth={ width }
+						setAttributes={ setAttributes }
+					/>
+				</InspectorControls>
+			) }
 			<InspectorControls __experimentalGroup="advanced">
 				<TextControl
 					label={ __( 'Link rel' ) }

--- a/schemas/json/theme.json
+++ b/schemas/json/theme.json
@@ -219,6 +219,11 @@
 							"type": "boolean",
 							"default": false
 						},
+						"width": {
+							"description": "Allow users to set a custom width.",
+							"type": "boolean",
+							"default": true
+						},
 						"units": {
 							"description": "List of units the user can use for spacing values.",
 							"type": "array",


### PR DESCRIPTION

## What?
This allows theme developers to manage support for the **Width settings** panel on the Button block using `theme.json`.

## Why?
Unlike most spacing-related settings, this panel and associated block option requires that theme developers explicitly add support for the classes it applies to Button blocks. With no way to define support at the theme level for this setting, developers are required to either leave in a panel with options that don't do anything, or add support for it. The latter option is often not feasible given corporate branding requirements and/or rigidly defined design libraries.

All other spacing and sizing related options are toggle-able via `theme.json`. As such, Button width settings should be consistent with its related options.

Fixes #38767. See #19796

## How?
We toggle visibility for the panel in Button's edit component using `useSetting()` to grab the new setting added to `theme.json`. Appropriate entries have been added for the new setting to both the `theme.json` schema as well as the `core-blocks` and `theme-json-living` documentation.

Support for this feature can now be toggled via the `spacing.width` property in `theme.json`

## Testing Instructions

1. Open a Post or Page
2. Add a Button block
3. Confirm that the Width settings panel is visible
4. In `theme.json` for the currently active theme, add `spacing.width: false` to the `settings.spacing` property
5. Reload the Post/Page editor, and confirm that the Width settings panel on the Button block is no longer visible.
6. Confirm that the same is true if `spacing.width: false` is set at the block setting level in `theme.json`

