### PR TITLE
Site Editor: Make Code Editor reflect block conversions

### DIFF
--- a/packages/edit-site/src/components/code-editor/index.js
+++ b/packages/edit-site/src/components/code-editor/index.js
@@ -1,7 +1,7 @@
 /**
  * WordPress dependencies
  */
-import { parse } from '@wordpress/blocks';
+import { parse, __unstableSerializeAndClean } from '@wordpress/blocks';
 import { useEntityBlockEditor, useEntityProp } from '@wordpress/core-data';
 import { useSelect, useDispatch } from '@wordpress/data';
 import { store as keyboardShortcutsStore } from '@wordpress/keyboard-shortcuts';
@@ -32,10 +32,17 @@ export default function CodeEditor() {
 		'postType',
 		templateType
 	);
-	const content =
-		contentStructure instanceof Function
-			? contentStructure( { blocks } )
-			: contentStructure;
+
+	// Replicates the logic found in getEditedPostContent().
+	let content;
+	if ( contentStructure instanceof Function ) {
+		content = contentStructure( { blocks } );
+	} else if ( blocks ) {
+		content = __unstableSerializeAndClean( blocks );
+	} else {
+		content = contentStructure;
+	}
+
 	const { switchEditorMode } = useDispatch( editSiteStore );
 	return (
 		<div className="edit-site-code-editor">

--- a/packages/edit-site/src/components/code-editor/index.js
+++ b/packages/edit-site/src/components/code-editor/index.js
@@ -38,6 +38,9 @@ export default function CodeEditor() {
 	if ( contentStructure instanceof Function ) {
 		content = contentStructure( { blocks } );
 	} else if ( blocks ) {
+		// If we have parsed blocks already, they should be our source of truth.
+		// Parsing applies block deprecations and legacy block conversions that
+		// unparsed content will not have.
 		content = __unstableSerializeAndClean( blocks );
 	} else {
 		content = contentStructure;


### PR DESCRIPTION
## What?
Fix #41944 (and potentially unblock #40506).

## Why?
If a block is undergoing a legacy block conversion upon loading in the Site Editor, and the user then switches to the Code Editor, that conversion is not reflected there. See #41944 for details.

_(This might also affect block deprecations.)_

## How?
By using the readily parsed (and thus, converted) blocks as the source of truth for the Code Editor, rather than the `content` state.

## Testing Instructions

This requires a bit of fiddling to test, since in order to run a legacy block conversion, we need a template that includes a legacy block. Try the following:

First of all, verify that the problem exists on `trunk` by using the instructions from #41944.

> - On `trunk`, edit the "Single" template in the Site Editor to add the "Comments" block.
> - Switch to the Code Editor and verify that the block's ID is `wp:comments-query-loop`.
> - Switch back to the Visual Editor.
> - Switch to the `update/rename-comments-query-loop` branch (note that that isnt't this PR but #40506), and reload the template in the Site Editor.
> - Open your browser console, and verify that it contains an "Updated blocks: core/comments` message.
> - Switch to the Code Editor. Verify that the block ID is still `wp:comments-query-loop` there ❌ 
> - Switch back to the Visual Editor.
> - Make a minor change to enable the 'Save' button, and save.
> - Switch to the Code Editor. The block ID should now be `wp:comments`.

Now, verify that this PR solves the problem:

- Remove the Comments block (whose ID is now `wp:comments`), save the template, and switch back to `trunk`.
- Add back the Comments block.
- Switch to the Code Editor and verify that the block's ID is `wp:comments-query-loop`.
- Switch back to the Visual Editor.
- Once again, switch to the `update/rename-comments-query-loop` branch.
- This time, cherry-pick the relevant commit from this branch (231c3f7).
- Reload the template in the Site Editor.
- Open your browser console, and verify that it contains an "Updated blocks: core/comments` message.
- Switch to the Code Editor. Verify that the block ID is now `wp:comments` there ✅ 

