### PR TITLE
Filter out images with no local id before loading media library

### DIFF
--- a/packages/block-library/src/gallery/edit.js
+++ b/packages/block-library/src/gallery/edit.js
@@ -547,7 +547,9 @@ function GalleryEdit( props ) {
 					onSelect={ updateImages }
 					name={ __( 'Add' ) }
 					multiple={ true }
-					mediaIds={ images.map( ( image ) => image.id ) }
+					mediaIds={ images
+						.filter( ( image ) => image.id )
+						.map( ( image ) => image.id ) }
 					addToGallery={ hasImageIds }
 				/>
 			</BlockControls>


### PR DESCRIPTION
## What?
Filters images with no id from the array of images that is passed to media library dialog

## Why?
Passing null ids causes all images in the media library to be selected.
Fixes: #42021

## How?
Filters out images that have no idea from the array passing to the media library.

## Testing Instructions
 - Add an Gallery block with external images, like the below:
 ```
 <!-- wp:gallery {"columns":2,"linkTo":"none"} -->
<figure class="wp-block-gallery has-nested-images columns-2 is-cropped"><!-- wp:image {"sizeSlug":"large","linkDestination":"none"} -->
<figure class="wp-block-image size-large"><img src="https://s.w.org/patterns/files/2021/06/image-from-rawpixel-id-3065130-jpeg-1024x1024.jpg" alt=""/></figure>
<!-- /wp:image -->

<!-- wp:image {"sizeSlug":"large","linkDestination":"none"} -->
<figure class="wp-block-image size-large"><img src="https://s.w.org/patterns/files/2021/06/image-from-rawpixel-id-3065130-jpeg-1024x1024.jpg" alt=""/></figure>
<!-- /wp:image -->

<!-- wp:image {"sizeSlug":"large","linkDestination":"none"} -->
<figure class="wp-block-image size-large"><img src="https://s.w.org/patterns/files/2021/06/image-from-rawpixel-id-3065130-jpeg-1024x1024.jpg" alt=""/></figure>
<!-- /wp:image --></figure>
<!-- /wp:gallery -->
 ```

- Select the `Add` button in the Gallery and check that the images in the media library are not selected.

## Screenshots or screencast 
Before:

https://user-images.githubusercontent.com/3629020/176801983-79585519-5991-400a-959e-b74f83d785de.mp4

After:

https://user-images.githubusercontent.com/3629020/176802007-ea6c3a70-ed9f-4666-8f50-a915c11e12e7.mp4




