### PR TITLE
Theme.json: Add block support feature level selectors for blocks

### DIFF
--- a/lib/compat/wordpress-6.1/class-wp-theme-json-6-1.php
+++ b/lib/compat/wordpress-6.1/class-wp-theme-json-6-1.php
@@ -101,7 +101,7 @@ class WP_Theme_JSON_6_1 extends WP_Theme_JSON_6_0 {
 
 	// List of block support features that can have their related styles
 	// generated under their own feature level selector rather than the block's.
-	const SUPPORT_FEATURES = array(
+	const BLOCK_SUPPORT_FEATURE_LEVEL_SELECTORS = array(
 		'__experimentalBorder' => 'border',
 		'color'                => 'color',
 		'spacing'              => 'spacing',
@@ -384,7 +384,7 @@ class WP_Theme_JSON_6_1 extends WP_Theme_JSON_6_0 {
 			// Generate block support feature level selectors if opted into
 			// for the current block.
 			$features = array();
-			foreach ( static::SUPPORT_FEATURES as $key => $feature ) {
+			foreach ( static::BLOCK_SUPPORT_FEATURE_LEVEL_SELECTORS as $key => $feature ) {
 				if (
 					isset( $block_type->supports[ $key ]['__experimentalSelector'] ) &&
 					$block_type->supports[ $key ]['__experimentalSelector']

--- a/lib/compat/wordpress-6.1/class-wp-theme-json-6-1.php
+++ b/lib/compat/wordpress-6.1/class-wp-theme-json-6-1.php
@@ -99,6 +99,15 @@ class WP_Theme_JSON_6_1 extends WP_Theme_JSON_6_0 {
 		'caption' => 'wp-element-caption',
 	);
 
+	// List of block support features that can have their related styles
+	// generated under their own feature level selector rather than the block's.
+	const SUPPORT_FEATURES = array(
+		'__experimentalBorder' => 'border',
+		'color'                => 'color',
+		'spacing'              => 'spacing',
+		'typography'           => 'typography',
+	);
+
 	/**
 	 * Given an element name, returns a class name.
 	 *
@@ -372,6 +381,25 @@ class WP_Theme_JSON_6_1 extends WP_Theme_JSON_6_0 {
 				static::$blocks_metadata[ $block_name ]['duotone'] = $block_type->supports['color']['__experimentalDuotone'];
 			}
 
+			// Generate block support feature level selectors if opted into
+			// for the current block.
+			$features = array();
+			foreach ( static::SUPPORT_FEATURES as $key => $feature ) {
+				if (
+					isset( $block_type->supports[ $key ]['__experimentalSelector'] ) &&
+					$block_type->supports[ $key ]['__experimentalSelector']
+				) {
+					$features[ $feature ] = static::scope_selector(
+						static::$blocks_metadata[ $block_name ]['selector'],
+						$block_type->supports[ $key ]['__experimentalSelector']
+					);
+				}
+			}
+
+			if ( ! empty( $features ) ) {
+				static::$blocks_metadata[ $block_name ]['features'] = $features;
+			}
+
 			// Assign defaults, then overwrite those that the block sets by itself.
 			// If the block selector is compounded, will append the element to each
 			// individual block selector.
@@ -510,11 +538,17 @@ class WP_Theme_JSON_6_1 extends WP_Theme_JSON_6_0 {
 				$duotone_selector = $selectors[ $name ]['duotone'];
 			}
 
+			$feature_selectors = null;
+			if ( isset( $selectors[ $name ]['features'] ) ) {
+				$feature_selectors = $selectors[ $name ]['features'];
+			}
+
 			$nodes[] = array(
 				'name'     => $name,
 				'path'     => array( 'styles', 'blocks', $name ),
 				'selector' => $selector,
 				'duotone'  => $duotone_selector,
+				'features' => $feature_selectors,
 			);
 
 			if ( isset( $theme_json['styles']['blocks'][ $name ]['elements'] ) ) {
@@ -622,6 +656,27 @@ class WP_Theme_JSON_6_1 extends WP_Theme_JSON_6_0 {
 		$selector = $block_metadata['selector'];
 		$settings = _wp_array_get( $this->theme_json, array( 'settings' ) );
 
+		// Process style declarations for block support features the current
+		// block contains selectors for. Values for a feature with a custom
+		// selector are filtered from the theme.json node before it is
+		// processed as normal.
+		$feature_declarations = array();
+
+		if ( ! empty( $block_metadata['features'] ) ) {
+			foreach ( $block_metadata['features'] as $feature_name => $feature_selector ) {
+				if ( ! empty( $node[ $feature_name ] ) ) {
+					// Create temporary node containing only the feature data
+					// to leverage existing `compute_style_properties` function.
+					$feature = array( $feature_name => $node[ $feature_name ] );
+					// Generate the feature's declarations only.
+					$feature_declarations[ $feature_selector ] = static::compute_style_properties( $feature, $settings, null, $this->theme_json );
+					// Remove the feature from the block's node now the
+					// styles will be included under the feature level selector.
+					unset( $node[ $feature_name ] );
+				}
+			}
+		}
+
 		// Get a reference to element name from path.
 		// $block_metadata['path'] = array('styles','elements','link');
 		// Make sure that $block_metadata['path'] describes an element node, like ['styles', 'element', 'link'].
@@ -693,6 +748,11 @@ class WP_Theme_JSON_6_1 extends WP_Theme_JSON_6_0 {
 			! empty( $block_metadata['name'] )
 		) {
 			$block_rules .= $this->get_layout_styles( $block_metadata );
+		}
+
+		// 5. Generate and append the feature level rulesets.
+		foreach ( $feature_declarations as $feature_selector => $individual_feature_declarations ) {
+			$block_rules .= static::to_ruleset( $feature_selector, $individual_feature_declarations );
 		}
 
 		if ( static::ROOT_BLOCK_SELECTOR === $selector ) {
@@ -880,8 +940,8 @@ class WP_Theme_JSON_6_1 extends WP_Theme_JSON_6_0 {
 	 * - prevent_override => Disables override of default presets by theme presets.
 	 *                       The relationship between whether to override the defaults
 	 *                       and whether the defaults are enabled is inverse:
-	 *                         - If defaults are enabled  => theme presets should not be overriden
-	 *                         - If defaults are disabled => theme presets should be overriden
+	 *                         - If defaults are enabled  => theme presets should not be overridden
+	 *                         - If defaults are disabled => theme presets should be overridden
 	 *                       For example, a theme sets defaultPalette to false,
 	 *                       making the default palette hidden from the user.
 	 *                       In that case, we want all the theme presets to be present,
@@ -1075,7 +1135,7 @@ class WP_Theme_JSON_6_1 extends WP_Theme_JSON_6_0 {
 			}
 
 			$below_sizes[] = array(
-				/* translators: %s: Muliple of t-shirt sizing, eg. 2X-Small */
+				/* translators: %s: Multiple of t-shirt sizing, eg. 2X-Small */
 				'name' => $x === $steps_mid_point - 1 ? __( 'Small', 'gutenberg' ) : sprintf( __( '%sX-Small', 'gutenberg' ), strval( $x_small_count ) ),
 				'slug' => $slug,
 				'size' => round( $current_step, 2 ) . $unit,
@@ -1112,7 +1172,7 @@ class WP_Theme_JSON_6_1 extends WP_Theme_JSON_6_0 {
 				: ( $spacing_scale['increment'] >= 1 ? $current_step * $spacing_scale['increment'] : $current_step / $spacing_scale['increment'] );
 
 			$above_sizes[] = array(
-				/* translators: %s: Muliple of t-shirt sizing, eg. 2X-Large */
+				/* translators: %s: Multiple of t-shirt sizing, eg. 2X-Large */
 				'name' => 0 === $x ? __( 'Large', 'gutenberg' ) : sprintf( __( '%sX-Large', 'gutenberg' ), strval( $x_large_count ) ),
 				'slug' => $slug,
 				'size' => round( $current_step, 2 ) . $unit,

--- a/lib/compat/wordpress-6.1/class-wp-theme-json-6-1.php
+++ b/lib/compat/wordpress-6.1/class-wp-theme-json-6-1.php
@@ -669,7 +669,17 @@ class WP_Theme_JSON_6_1 extends WP_Theme_JSON_6_0 {
 					// to leverage existing `compute_style_properties` function.
 					$feature = array( $feature_name => $node[ $feature_name ] );
 					// Generate the feature's declarations only.
-					$feature_declarations[ $feature_selector ] = static::compute_style_properties( $feature, $settings, null, $this->theme_json );
+					$new_feature_declarations = static::compute_style_properties( $feature, $settings, null, $this->theme_json );
+
+					// Merge new declarations with any that already exist for
+					// the feature selector. This may occur when multiple block
+					// support features use the same custom selector.
+					if ( isset( $feature_declarations[ $feature_selector ] ) ) {
+						$feature_declarations[ $feature_selector ] = array_merge( $feature_declarations[ $feature_selector ], $new_feature_declarations );
+					} else {
+						$feature_declarations[ $feature_selector ] = $new_feature_declarations;
+					}
+
 					// Remove the feature from the block's node now the
 					// styles will be included under the feature level selector.
 					unset( $node[ $feature_name ] );

--- a/packages/edit-site/src/components/global-styles/test/use-global-styles-output.js
+++ b/packages/edit-site/src/components/global-styles/test/use-global-styles-output.js
@@ -10,6 +10,7 @@ import {
 	getLayoutStyles,
 	getNodesWithSettings,
 	getNodesWithStyles,
+	getBlockSelectors,
 	toCustomProperties,
 	toStyles,
 } from '../use-global-styles-output';
@@ -57,6 +58,11 @@ describe( 'global styles renderer', () => {
 								},
 							},
 						},
+						'core/image': {
+							border: {
+								radius: '9999px',
+							},
+						},
 					},
 					elements: {
 						link: {
@@ -83,6 +89,10 @@ describe( 'global styles renderer', () => {
 			const blockSelectors = {
 				'core/heading': {
 					selector: '.my-heading1, .my-heading2',
+				},
+				'core/image': {
+					selector: '.my-image',
+					featureSelectors: '.my-image img, .my-image .crop-area',
 				},
 			};
 
@@ -158,6 +168,15 @@ describe( 'global styles renderer', () => {
 						},
 					},
 					selector: '.my-heading1 a, .my-heading2 a',
+				},
+				{
+					styles: {
+						border: {
+							radius: '9999px',
+						},
+					},
+					selector: '.my-image',
+					featureSelectors: '.my-image img, .my-image .crop-area',
 				},
 			] );
 		} );
@@ -430,6 +449,14 @@ describe( 'global styles renderer', () => {
 								},
 							},
 						},
+						'core/image': {
+							color: {
+								text: 'red',
+							},
+							border: {
+								radius: '9999px',
+							},
+						},
 					},
 				},
 			};
@@ -441,12 +468,18 @@ describe( 'global styles renderer', () => {
 				'core/heading': {
 					selector: 'h1,h2,h3,h4,h5,h6',
 				},
+				'core/image': {
+					selector: '.wp-block-image',
+					featureSelectors: {
+						border: '.wp-block-image img, .wp-block-image .wp-crop-area',
+					},
+				},
 			};
 
 			expect( toStyles( tree, blockSelectors ) ).toEqual(
 				'body {margin: 0;}' +
 					'body{background-color: red;margin: 10px;padding: 10px;}h1{font-size: 42px;}a{color: blue;}a:hover{color: orange;}a:focus{color: orange;}.wp-block-group{margin-top: 10px;margin-right: 20px;margin-bottom: 30px;margin-left: 40px;padding-top: 11px;padding-right: 22px;padding-bottom: 33px;padding-left: 44px;}h1,h2,h3,h4,h5,h6{color: orange;}h1 a,h2 a,h3 a,h4 a,h5 a,h6 a{color: hotpink;}h1 a:hover,h2 a:hover,h3 a:hover,h4 a:hover,h5 a:hover,h6 a:hover{color: red;}h1 a:focus,h2 a:focus,h3 a:focus,h4 a:focus,h5 a:focus,h6 a:focus{color: red;}' +
-					'.wp-site-blocks > .alignleft { float: left; margin-right: 2em; }.wp-site-blocks > .alignright { float: right; margin-left: 2em; }.wp-site-blocks > .aligncenter { justify-content: center; margin-left: auto; margin-right: auto; }' +
+					'.wp-block-image img, .wp-block-image .wp-crop-area{border-radius: 9999px }.wp-block-image{color: red;}.wp-site-blocks > .alignleft { float: left; margin-right: 2em; }.wp-site-blocks > .alignright { float: right; margin-left: 2em; }.wp-site-blocks > .aligncenter { justify-content: center; margin-left: auto; margin-right: auto; }' +
 					'.has-white-color{color: var(--wp--preset--color--white) !important;}.has-white-background-color{background-color: var(--wp--preset--color--white) !important;}.has-white-border-color{border-color: var(--wp--preset--color--white) !important;}.has-black-color{color: var(--wp--preset--color--black) !important;}.has-black-background-color{background-color: var(--wp--preset--color--black) !important;}.has-black-border-color{border-color: var(--wp--preset--color--black) !important;}h1.has-blue-color,h2.has-blue-color,h3.has-blue-color,h4.has-blue-color,h5.has-blue-color,h6.has-blue-color{color: var(--wp--preset--color--blue) !important;}h1.has-blue-background-color,h2.has-blue-background-color,h3.has-blue-background-color,h4.has-blue-background-color,h5.has-blue-background-color,h6.has-blue-background-color{background-color: var(--wp--preset--color--blue) !important;}h1.has-blue-border-color,h2.has-blue-border-color,h3.has-blue-border-color,h4.has-blue-border-color,h5.has-blue-border-color,h6.has-blue-border-color{border-color: var(--wp--preset--color--blue) !important;}'
 			);
 		} );
@@ -616,6 +649,34 @@ describe( 'global styles renderer', () => {
 			expect( layoutStyles ).toEqual(
 				'.wp-block-group.is-layout-flex { gap: 2em; }'
 			);
+		} );
+	} );
+
+	describe( 'getBlockSelectors', () => {
+		it( 'should return block selectors data', () => {
+			const imageSupports = {
+				__experimentalBorder: {
+					radius: true,
+					__experimentalSelector: 'img, .crop-area',
+				},
+				color: {
+					__experimentalDuotone: 'img',
+				},
+				__experimentalSelector: '.my-image',
+			};
+			const imageBlock = { name: 'core/image', supports: imageSupports };
+			const blockTypes = [ imageBlock ];
+
+			expect( getBlockSelectors( blockTypes ) ).toEqual( {
+				'core/image': {
+					name: imageBlock.name,
+					selector: imageSupports.__experimentalSelector,
+					duotoneSelector: imageSupports.color.__experimentalDuotone,
+					featureSelectors: {
+						border: '.my-image img, .my-image .crop-area',
+					},
+				},
+			} );
 		} );
 	} );
 } );

--- a/packages/edit-site/src/components/global-styles/test/use-global-styles-output.js
+++ b/packages/edit-site/src/components/global-styles/test/use-global-styles-output.js
@@ -672,9 +672,11 @@ describe( 'global styles renderer', () => {
 					name: imageBlock.name,
 					selector: imageSupports.__experimentalSelector,
 					duotoneSelector: imageSupports.color.__experimentalDuotone,
+					fallbackGapValue: undefined,
 					featureSelectors: {
 						border: '.my-image img, .my-image .crop-area',
 					},
+					hasLayoutSupport: false,
 				},
 			} );
 		} );

--- a/packages/edit-site/src/components/global-styles/use-global-styles-output.js
+++ b/packages/edit-site/src/components/global-styles/use-global-styles-output.js
@@ -35,7 +35,9 @@ import { PRESET_METADATA, ROOT_BLOCK_SELECTOR, scopeSelector } from './utils';
 import { GlobalStylesContext } from './context';
 import { useSetting } from './hooks';
 
-const SUPPORT_FEATURES = {
+// List of block support features that can have their related styles
+// generated under their own feature level selector rather than the block's.
+const BLOCK_SUPPORT_FEATURE_LEVEL_SELECTORS = {
 	__experimentalBorder: 'border',
 	color: 'color',
 	spacing: 'spacing',
@@ -694,7 +696,7 @@ export const getBlockSelectors = ( blockTypes ) => {
 
 		// For each block support feature add any custom selectors.
 		const featureSelectors = {};
-		Object.entries( SUPPORT_FEATURES ).forEach(
+		Object.entries( BLOCK_SUPPORT_FEATURE_LEVEL_SELECTORS ).forEach(
 			( [ featureKey, featureName ] ) => {
 				const featureSelector =
 					blockType?.supports?.[ featureKey ]?.__experimentalSelector;

--- a/packages/edit-site/src/components/global-styles/utils.js
+++ b/packages/edit-site/src/components/global-styles/utils.js
@@ -255,3 +255,34 @@ export function getValueFromVariable( features, blockName, variable ) {
 	}
 	return variable;
 }
+
+/**
+ * Function that scopes a selector with another one. This works a bit like
+ * SCSS nesting except the `&` operator isn't supported.
+ *
+ * @example
+ * ```js
+ * const scope = '.a, .b .c';
+ * const selector = '> .x, .y';
+ * const merged = scopeSelector( scope, selector );
+ * // merged is '.a > .x, .a .y, .b .c > .x, .b .c .y'
+ * ```
+ *
+ * @param {string} scope    Selector to scope to.
+ * @param {string} selector Original selector.
+ *
+ * @return {string} Scoped selector.
+ */
+export function scopeSelector( scope, selector ) {
+	const scopes = scope.split( ',' );
+	const selectors = selector.split( ',' );
+
+	const selectorsScoped = [];
+	scopes.forEach( ( outer ) => {
+		selectors.forEach( ( inner ) => {
+			selectorsScoped.push( `${ outer.trim() } ${ inner.trim() }` );
+		} );
+	} );
+
+	return selectorsScoped.join( ', ' );
+}

--- a/phpunit/bootstrap.php
+++ b/phpunit/bootstrap.php
@@ -105,10 +105,18 @@ function gutenberg_register_test_block_for_feature_selectors() {
 			'supports'    => array(
 				'__experimentalBorder'   => array(
 					'radius'                 => true,
-					'__experimentalSelector' => '.bordered',
+					'__experimentalSelector' => '.inner',
 				),
 				'color'                  => array(
 					'text' => true,
+				),
+				'spacing'                => array(
+					'padding' => true,
+					'__experimentalSelector' => '.inner',
+				),
+				'typography'                => array(
+					'fontSize' => true,
+					'__experimentalSelector' => '.sub-heading',
 				),
 				'__experimentalSelector' => '.wp-block-test, .wp-block-test__wrapper',
 			),

--- a/phpunit/bootstrap.php
+++ b/phpunit/bootstrap.php
@@ -111,11 +111,11 @@ function gutenberg_register_test_block_for_feature_selectors() {
 					'text' => true,
 				),
 				'spacing'                => array(
-					'padding' => true,
+					'padding'                => true,
 					'__experimentalSelector' => '.inner',
 				),
-				'typography'                => array(
-					'fontSize' => true,
+				'typography'             => array(
+					'fontSize'               => true,
 					'__experimentalSelector' => '.sub-heading',
 				),
 				'__experimentalSelector' => '.wp-block-test, .wp-block-test__wrapper',

--- a/phpunit/bootstrap.php
+++ b/phpunit/bootstrap.php
@@ -80,6 +80,43 @@ $GLOBALS['wp_tests_options'] = array(
 // Enable the widget block editor.
 tests_add_filter( 'gutenberg_use_widgets_block_editor', '__return_true' );
 
+/**
+ * Register test block prior to theme.json generating metadata.
+ *
+ * This new block is used to test experimental selectors. It is registered
+ * via `tests_add_filter()` here during bootstrapping so that it occurs prior
+ * to theme.json generating block metadata. Once a core block, such as Image,
+ * uses feature level selectors we could remove this in favour of testing via
+ * the core block.
+ */
+function gutenberg_register_test_block_for_feature_selectors() {
+	WP_Block_Type_Registry::get_instance()->register(
+		'test/test',
+		array(
+			'api_version' => 2,
+			'attributes'  => array(
+				'textColor' => array(
+					'type' => 'string',
+				),
+				'style'     => array(
+					'type' => 'object',
+				),
+			),
+			'supports'    => array(
+				'__experimentalBorder'   => array(
+					'radius'                 => true,
+					'__experimentalSelector' => '.bordered',
+				),
+				'color'                  => array(
+					'text' => true,
+				),
+				'__experimentalSelector' => '.wp-block-test, .wp-block-test__wrapper',
+			),
+		)
+	);
+}
+tests_add_filter( 'init', 'gutenberg_register_test_block_for_feature_selectors' );
+
 // Start up the WP testing environment.
 require $_tests_dir . '/includes/bootstrap.php';
 

--- a/phpunit/class-wp-theme-json-test.php
+++ b/phpunit/class-wp-theme-json-test.php
@@ -453,10 +453,10 @@ class WP_Theme_JSON_Gutenberg_Test extends WP_UnitTestCase {
 			array(
 				'version'  => WP_Theme_JSON_Gutenberg::LATEST_SCHEMA,
 				'settings' => array(
-					'border'  => array(
+					'border'     => array(
 						'radius' => true,
 					),
-					'color'   => array(
+					'color'      => array(
 						'custom'  => false,
 						'palette' => array(
 							array(
@@ -465,7 +465,7 @@ class WP_Theme_JSON_Gutenberg_Test extends WP_UnitTestCase {
 							),
 						),
 					),
-					'spacing' => array(
+					'spacing'    => array(
 						'padding' => true,
 					),
 					'typography' => array(
@@ -475,13 +475,13 @@ class WP_Theme_JSON_Gutenberg_Test extends WP_UnitTestCase {
 				'styles'   => array(
 					'blocks' => array(
 						'test/test' => array(
-							'border'  => array(
+							'border'     => array(
 								'radius' => '9999px',
 							),
-							'color'   => array(
+							'color'      => array(
 								'text' => 'green',
 							),
-							'spacing' => array(
+							'spacing'    => array(
 								'padding' => '20px',
 							),
 							'typography' => array(

--- a/phpunit/class-wp-theme-json-test.php
+++ b/phpunit/class-wp-theme-json-test.php
@@ -487,8 +487,6 @@ class WP_Theme_JSON_Gutenberg_Test extends WP_UnitTestCase {
 		$expected      = $base_styles . $block_styles . $preset_styles;
 
 		$this->assertEquals( $expected, $theme_json->get_stylesheet() );
-
-		unregister_block_type( 'test/test' );
 	}
 
 	function test_remove_invalid_element_pseudo_selectors() {

--- a/phpunit/class-wp-theme-json-test.php
+++ b/phpunit/class-wp-theme-json-test.php
@@ -453,10 +453,10 @@ class WP_Theme_JSON_Gutenberg_Test extends WP_UnitTestCase {
 			array(
 				'version'  => WP_Theme_JSON_Gutenberg::LATEST_SCHEMA,
 				'settings' => array(
-					'border' => array(
+					'border'  => array(
 						'radius' => true,
 					),
-					'color'  => array(
+					'color'   => array(
 						'custom'  => false,
 						'palette' => array(
 							array(
@@ -465,15 +465,27 @@ class WP_Theme_JSON_Gutenberg_Test extends WP_UnitTestCase {
 							),
 						),
 					),
+					'spacing' => array(
+						'padding' => true,
+					),
+					'typography' => array(
+						'fontSize' => true,
+					),
 				),
 				'styles'   => array(
 					'blocks' => array(
 						'test/test' => array(
-							'border' => array(
+							'border'  => array(
 								'radius' => '9999px',
 							),
-							'color'  => array(
+							'color'   => array(
 								'text' => 'green',
+							),
+							'spacing' => array(
+								'padding' => '20px',
+							),
+							'typography' => array(
+								'fontSize' => '3em',
 							),
 						),
 					),
@@ -482,7 +494,7 @@ class WP_Theme_JSON_Gutenberg_Test extends WP_UnitTestCase {
 		);
 
 		$base_styles   = 'body{--wp--preset--color--green: green;}body { margin: 0; }.wp-site-blocks > .alignleft { float: left; margin-right: 2em; }.wp-site-blocks > .alignright { float: right; margin-left: 2em; }.wp-site-blocks > .aligncenter { justify-content: center; margin-left: auto; margin-right: auto; }';
-		$block_styles  = '.wp-block-test, .wp-block-test__wrapper{color: green;}.wp-block-test .bordered, .wp-block-test__wrapper .bordered{border-radius: 9999px;}';
+		$block_styles  = '.wp-block-test, .wp-block-test__wrapper{color: green;}.wp-block-test .inner, .wp-block-test__wrapper .inner{border-radius: 9999px;padding: 20px;}.wp-block-test .sub-heading, .wp-block-test__wrapper .sub-heading{font-size: 3em;}';
 		$preset_styles = '.has-green-color{color: var(--wp--preset--color--green) !important;}.has-green-background-color{background-color: var(--wp--preset--color--green) !important;}.has-green-border-color{border-color: var(--wp--preset--color--green) !important;}';
 		$expected      = $base_styles . $block_styles . $preset_styles;
 

--- a/phpunit/class-wp-theme-json-test.php
+++ b/phpunit/class-wp-theme-json-test.php
@@ -228,7 +228,7 @@ class WP_Theme_JSON_Gutenberg_Test extends WP_UnitTestCase {
 		$this->assertEquals( $expected, $theme_json->get_stylesheet( array( 'styles' ) ) );
 	}
 
-	function test_get_stylesheet_handles_only_psuedo_selector_rules_for_given_property() {
+	function test_get_stylesheet_handles_only_pseudo_selector_rules_for_given_property() {
 		$theme_json = new WP_Theme_JSON_Gutenberg(
 			array(
 				'version' => WP_Theme_JSON_Gutenberg::LATEST_SCHEMA,

--- a/phpunit/class-wp-theme-json-test.php
+++ b/phpunit/class-wp-theme-json-test.php
@@ -563,7 +563,7 @@ class WP_Theme_JSON_Gutenberg_Test extends WP_UnitTestCase {
 	}
 
 	/**
-	 * Testing that dynamic properties in theme.json return the value they refrence, e.g.
+	 * Testing that dynamic properties in theme.json return the value they reference, e.g.
 	 * array( 'ref' => 'styles.color.background' ) => "#ffffff".
 	 */
 	function test_get_property_value_valid() {

--- a/phpunit/class-wp-theme-json-test.php
+++ b/phpunit/class-wp-theme-json-test.php
@@ -440,32 +440,15 @@ class WP_Theme_JSON_Gutenberg_Test extends WP_UnitTestCase {
 		$this->assertEquals( $expected, $theme_json->get_stylesheet( array( 'styles' ) ) );
 	}
 
+	/**
+	 * This test relies on a block having already been registered prior to
+	 * theme.json generating block metadata. Until a core block, such as Image,
+	 * opts into feature level selectors, we need to register a test block.
+	 * This is achieved via `tests_add_filter()` in Gutenberg's phpunit
+	 * bootstrap. After a core block adopts feature level selectors we could
+	 * remove that filter and instead use the core block for the following test.
+	 */
 	function test_get_stylesheet_with_block_support_feature_level_selectors() {
-		// Register a test block that will have feature level selectors.
-		WP_Block_Type_Registry::get_instance()->register(
-			'test/test',
-			array(
-				'api_version' => 2,
-				'attributes'  => array(
-					'textColor' => array(
-						'type' => 'string',
-					),
-					'style'     => array(
-						'type' => 'object',
-					),
-				),
-				'supports'    => array(
-					'border'                 => array(
-						'radius'                 => true,
-						'__experimentalSelector' => '.bordered',
-					),
-					'color'                  => array(
-						'text' => true,
-					),
-				),
-			)
-		);
-
 		$theme_json = new WP_Theme_JSON_Gutenberg(
 			array(
 				'version'  => WP_Theme_JSON_Gutenberg::LATEST_SCHEMA,


### PR DESCRIPTION
Related: https://github.com/WordPress/gutenberg/pull/31366

## What?

Allows custom CSS selectors for individual block support features e.g. for border support. This means styles generated for individual block support features can be applied to different elements within a block e.g the block wrapper or another element that can't be targeted via the elements API.

## Why?

While attempting to add border support to the image block we hit the issue where we need to skip border support serialization so we can apply the borders only to the inner `img` element.

If we add the `img` element to the Elements API, we end up creating a disjoint between the block editor and theme.json/global styles. The problem lies in the fact that we can't style the `img` elements via Global Styles. This leads us to a situation where a theme author could style all image block's `img` elements but if a user wished to tweak that styling they would have to edit every individual image.

Adding a "feature level selector" to theme.json and global styles means that we can keep the usual theme.json shape (no elements API use) and also keep using the Global Styles UI as per normal. The difference is that the generated styles target new custom CSS selectors.

## How?

- Adds support for defining `__experimentalSelector` prop within each individual block support
- Leverages the new feature level `__experimentalSelector` values to generate scoped CSS selectors specific to that block support
- Generates the styles for each block support opting into this, under the appropriate selector instead of under the block's root selector
- Some minor spelling and typo fixes

**Note: PHP unit tests were a little tricky to implement given that WordPress is loaded prior to the tests running meaning that WordPress' theme.json generates block metadata before our single, feature-level selector test could register a block. As a means of still having a programmatic test for the new selectors, I've added a `tests_add_filter()` call to the bootstrap to get a suitable block registered in time for testing. Once the Image block adopts these new selectors via https://github.com/WordPress/gutenberg/pull/31366 we could remove this filter and test via the image block.**

**We can also remove the `tests_add_filter` prior to merging this PR if we wish to keep things cleaner in the interim.**

## Testing Instructions
1. Run `npm run test-unit-php`
2. Run `npm run test-unit packages/edit-site/src/components/global-styles/test/use-global-styles-output.js`

#### Manual Testing

The generated styles can be manually tested via https://github.com/WordPress/gutenberg/pull/31366 which has been based on this PR.

1. Checkout https://github.com/WordPress/gutenberg/pull/31366
2. Edit your theme.json to style image blocks with a border (See snipped below for example image border config)
3. Create a new post, add an image, confirm the image border has been applied.
4. Save the post and view on the front end.
5. Inspect the image and ensure styles have been generated for `.wp-block-image img, .wp-block-image .wp-block-image__crop-area`

```json
{
	...
	"styles": {
		"blocks": {
			"core/image": {
				"border": {
					"radius": "9999px",
					"color": "fuchsia",
					"style": "dashed",
					"width": "3px"
				},
			}
		}
	}
}
```


Alternatively;

1. Update a block's support config to include an `__experimentalSelector` at the feature level (not root `supports` config)
2. Style that block and block support feature via theme.json
3. Load the editor and confirm styles have been generated for the block matching the selector you set.

