### PR TITLE
Template Parts: Disable block transformations

### DIFF
--- a/packages/block-editor/src/components/block-switcher/index.js
+++ b/packages/block-editor/src/components/block-switcher/index.js
@@ -98,8 +98,14 @@ export const BlockSwitcherDropdownMenu = ( { clientIds, blocks } ) => {
 	// Pattern transformation through the `Patterns` API.
 	const onPatternTransform = ( transformedBlocks ) =>
 		replaceBlocks( clientIds, transformedBlocks );
+
+	/**
+	 * The `isTemplate` check is a stopgap solution here.
+	 * Ideally, the Transforms API should handle this
+	 * by allowing to exclude blocks from wildcard transformations.
+	 */
 	const hasPossibleBlockTransformations =
-		!! possibleBlockTransformations.length && canRemove;
+		!! possibleBlockTransformations.length && canRemove && ! isTemplate;
 	const hasPatternTransformation = !! patterns?.length && canRemove;
 	if ( ! hasBlockStyles && ! hasPossibleBlockTransformations ) {
 		return (


### PR DESCRIPTION
## What?
Resolves #29296.

PR disables transformations for Template Parts block.

## Why?
See the issue.

## How?
Updated `hasPossibleBlockTransformations` check to include `isTemplate` condition. I also added a comment that this is a stopgap solution.

## Testing Instructions
1. Open Site Editor
2. Select any Template Part.
3. Confirm that transformation action is disabled.
4. Confirm that other blocks can still be transformed.
