### PR TITLE
Post Template: Update template title selector

### DIFF
--- a/packages/edit-post/src/components/sidebar/post-template/index.js
+++ b/packages/edit-post/src/components/sidebar/post-template/index.js
@@ -66,7 +66,16 @@ export default function PostTemplate() {
 
 function PostTemplateToggle( { isOpen, onClick } ) {
 	const templateTitle = useSelect( ( select ) => {
-		return select( editPostStore ).getEditedPostTemplate()?.title;
+		const templateSlug =
+			select( editorStore ).getEditedPostAttribute( 'template' );
+
+		const settings = select( editorStore ).getEditorSettings();
+		if ( templateSlug && settings.availableTemplates[ templateSlug ] ) {
+			return settings.availableTemplates[ templateSlug ];
+		}
+
+		const template = select( editPostStore ).getEditedPostTemplate();
+		return template?.title ?? template?.slug;
 	}, [] );
 
 	return (

--- a/packages/edit-post/src/components/sidebar/post-template/index.js
+++ b/packages/edit-post/src/components/sidebar/post-template/index.js
@@ -12,6 +12,7 @@ import { store as coreStore } from '@wordpress/core-data';
  * Internal dependencies
  */
 import PostTemplateForm from './form';
+import { store as editPostStore } from '../../../store';
 
 export default function PostTemplate() {
 	const anchorRef = useRef();
@@ -65,19 +66,7 @@ export default function PostTemplate() {
 
 function PostTemplateToggle( { isOpen, onClick } ) {
 	const templateTitle = useSelect( ( select ) => {
-		const templateSlug =
-			select( editorStore ).getEditedPostAttribute( 'template' );
-
-		const settings = select( editorStore ).getEditorSettings();
-		if ( settings.availableTemplates[ templateSlug ] ) {
-			return settings.availableTemplates[ templateSlug ];
-		}
-
-		const template = select( coreStore )
-			.getEntityRecords( 'postType', 'wp_template', { per_page: -1 } )
-			?.find( ( { slug } ) => slug === templateSlug );
-
-		return template?.title.rendered;
+		return select( editPostStore ).getEditedPostTemplate()?.title;
 	}, [] );
 
 	return (

--- a/packages/edit-post/src/components/sidebar/post-template/index.js
+++ b/packages/edit-post/src/components/sidebar/post-template/index.js
@@ -69,9 +69,10 @@ function PostTemplateToggle( { isOpen, onClick } ) {
 		const templateSlug =
 			select( editorStore ).getEditedPostAttribute( 'template' );
 
-		const settings = select( editorStore ).getEditorSettings();
-		if ( templateSlug && settings.availableTemplates[ templateSlug ] ) {
-			return settings.availableTemplates[ templateSlug ];
+		const { supportsTemplateMode, availableTemplates } =
+			select( editorStore ).getEditorSettings();
+		if ( ! supportsTemplateMode && availableTemplates[ templateSlug ] ) {
+			return availableTemplates[ templateSlug ];
 		}
 
 		const template = select( editPostStore ).getEditedPostTemplate();


### PR DESCRIPTION
## What?
PR updates template title selector to use `getEditedPostTemplate`.

## Why?
The `getEditedPostTemplate` also tried to resolve titles for default WP templates, like "Single" and "Page." The Template panel used this selector as well.

## Testing Instructions
1. Open a Post or Page.
2. Confirm the "Post Template" document is setting displays a correct title instead of the "Default Template" fallback.

## Screenshots or screencast <!-- if applicable -->
| Post | Page |
| --- | --- |
|![CleanShot 2022-07-01 at 15 51 35](https://user-images.githubusercontent.com/240569/176889398-0a2ef9fd-1129-4ff3-ae86-8999698fb8bf.png)|![CleanShot 2022-07-01 at 15 51 18](https://user-images.githubusercontent.com/240569/176889414-79bea20f-de90-4017-86dc-ae00b298242e.png)|

