### PR TITLE
Migrate Navigation block color controls to Block Supports

### DIFF
--- a/docs/reference-guides/core-blocks.md
+++ b/docs/reference-guides/core-blocks.md
@@ -393,7 +393,7 @@ A collection of blocks that allow visitors to get around your site. ([Source](ht
 -	**Name:** core/navigation
 -	**Category:** theme
 -	**Supports:** align (full, wide), anchor, color (background, link, text), inserter, spacing (blockGap, units), typography (fontSize, lineHeight), ~~html~~
--	**Attributes:** __unstableLocation, backgroundColor, customBackgroundColor, customOverlayBackgroundColor, customOverlayTextColor, hasIcon, icon, maxNestingLevel, openSubmenusOnClick, overlayBackgroundColor, overlayMenu, overlayTextColor, ref, rgbBackgroundColor, rgbTextColor, showSubmenuIcon
+-	**Attributes:** __unstableLocation, backgroundColor, customBackgroundColor, customOverlayBackgroundColor, customOverlayLinkColor, customOverlayTextColor, hasIcon, icon, maxNestingLevel, openSubmenusOnClick, overlayBackgroundColor, overlayLinkColor, overlayMenu, overlayTextColor, ref, rgbBackgroundColor, rgbTextColor, showSubmenuIcon
 
 ## Custom Link
 

--- a/docs/reference-guides/core-blocks.md
+++ b/docs/reference-guides/core-blocks.md
@@ -392,8 +392,8 @@ A collection of blocks that allow visitors to get around your site. ([Source](ht
 
 -	**Name:** core/navigation
 -	**Category:** theme
--	**Supports:** align (full, wide), anchor, inserter, spacing (blockGap, units), typography (fontSize, lineHeight), ~~html~~
--	**Attributes:** __unstableLocation, backgroundColor, customBackgroundColor, customOverlayBackgroundColor, customOverlayTextColor, customTextColor, hasIcon, icon, maxNestingLevel, openSubmenusOnClick, overlayBackgroundColor, overlayMenu, overlayTextColor, ref, rgbBackgroundColor, rgbTextColor, showSubmenuIcon, textColor
+-	**Supports:** align (full, wide), anchor, color (background, link, text), inserter, spacing (blockGap, units), typography (fontSize, lineHeight), ~~html~~
+-	**Attributes:** __unstableLocation, backgroundColor, customBackgroundColor, customOverlayBackgroundColor, customOverlayTextColor, hasIcon, icon, maxNestingLevel, openSubmenusOnClick, overlayBackgroundColor, overlayMenu, overlayTextColor, ref, rgbBackgroundColor, rgbTextColor, showSubmenuIcon
 
 ## Custom Link
 

--- a/packages/block-library/src/navigation-link/block.json
+++ b/packages/block-library/src/navigation-link/block.json
@@ -47,6 +47,8 @@
 		"customBackgroundColor",
 		"overlayTextColor",
 		"customOverlayTextColor",
+		"overlayLinkColor",
+		"customOverlayLinkColor",
 		"overlayBackgroundColor",
 		"customOverlayBackgroundColor",
 		"fontSize",

--- a/packages/block-library/src/navigation-link/edit.js
+++ b/packages/block-library/src/navigation-link/edit.js
@@ -156,6 +156,8 @@ function getColors( context, isSubMenu ) {
 		customBackgroundColor,
 		overlayTextColor,
 		customOverlayTextColor,
+		overlayLinkColor,
+		customOverlayLinkColor,
 		overlayBackgroundColor,
 		customOverlayBackgroundColor,
 		style,
@@ -173,6 +175,12 @@ function getColors( context, isSubMenu ) {
 		colors.textColor = textColor;
 	} else if ( !! style?.color?.text ) {
 		colors.customTextColor = style.color.text;
+	}
+
+	if ( isSubMenu && !! customOverlayLinkColor ) {
+		colors.customLinkColor = customOverlayLinkColor;
+	} else if ( isSubMenu && !! overlayLinkColor ) {
+		colors.linkColor = overlayLinkColor;
 	}
 
 	if ( isSubMenu && !! customOverlayBackgroundColor ) {
@@ -643,6 +651,8 @@ export default function NavigationLinkEdit( {
 		customTextColor,
 		backgroundColor,
 		customBackgroundColor,
+		customLinkColor,
+		linkColor,
 	} = getColors( context, ! isTopLevelLink );
 
 	function onKeyDown( event ) {
@@ -678,9 +688,20 @@ export default function NavigationLinkEdit( {
 		blockProps.onClick = () => setIsLinkOpen( true );
 	}
 
-	const classes = classnames( 'wp-block-navigation-item__content', {
-		'wp-block-navigation-link__placeholder': ! url || isInvalid || isDraft,
-	} );
+	const linkProps = {
+		className: classnames( 'wp-block-navigation-item__content', {
+			'wp-block-navigation-link__placeholder':
+				! url || isInvalid || isDraft,
+		} ),
+		style: {
+			...( customLinkColor && {
+				color: customLinkColor,
+			} ),
+			...( linkColor && {
+				color: `var(--wp--preset--color--${ linkColor })`,
+			} ),
+		},
+	};
 
 	const missingText = getMissingText( type );
 	/* translators: Whether the navigation link is Invalid or a Draft. */
@@ -745,7 +766,7 @@ export default function NavigationLinkEdit( {
 			</InspectorControls>
 			<div { ...blockProps }>
 				{ /* eslint-disable jsx-a11y/anchor-is-valid */ }
-				<a className={ classes }>
+				<a { ...linkProps }>
 					{ /* eslint-enable */ }
 					{ ! url ? (
 						<div className="wp-block-navigation-link__placeholder-text">

--- a/packages/block-library/src/navigation/block.json
+++ b/packages/block-library/src/navigation/block.json
@@ -11,12 +11,6 @@
 		"ref": {
 			"type": "number"
 		},
-		"textColor": {
-			"type": "string"
-		},
-		"customTextColor": {
-			"type": "string"
-		},
 		"rgbTextColor": {
 			"type": "string"
 		},

--- a/packages/block-library/src/navigation/block.json
+++ b/packages/block-library/src/navigation/block.json
@@ -91,6 +91,13 @@
 		"anchor": true,
 		"html": false,
 		"inserter": true,
+		"color": {
+			"link": true,
+			"__experimentalDefaultControls": {
+				"background": true,
+				"text": false
+			}
+		},
 		"typography": {
 			"fontSize": true,
 			"lineHeight": true,

--- a/packages/block-library/src/navigation/block.json
+++ b/packages/block-library/src/navigation/block.json
@@ -58,6 +58,12 @@
 		"customOverlayTextColor": {
 			"type": "string"
 		},
+		"overlayLinkColor": {
+			"type": "string"
+		},
+		"customOverlayLinkColor": {
+			"type": "string"
+		},
 		"maxNestingLevel": {
 			"type": "number",
 			"default": 5
@@ -70,6 +76,8 @@
 		"customBackgroundColor": "customBackgroundColor",
 		"overlayTextColor": "overlayTextColor",
 		"customOverlayTextColor": "customOverlayTextColor",
+		"overlayLinkColor": "overlayLinkColor",
+		"customOverlayLinkColor": "customOverlayLinkColor",
 		"overlayBackgroundColor": "overlayBackgroundColor",
 		"customOverlayBackgroundColor": "customOverlayBackgroundColor",
 		"fontSize": "fontSize",

--- a/packages/block-library/src/navigation/deprecated.js
+++ b/packages/block-library/src/navigation/deprecated.js
@@ -28,6 +28,33 @@ const migrateIdToRef = ( { navigationMenuId, ...attributes } ) => {
 	};
 };
 
+const migrateTextColorToLinkColor = ( {
+	textColor,
+	customTextColor,
+	...attributes
+} ) => {
+	return {
+		...attributes,
+		textColor: null,
+		customTextColor: null,
+		style: {
+			...attributes?.style,
+			elements: {
+				...attributes?.style?.elements,
+				link: {
+					...attributes?.style?.elements?.link,
+					color: {
+						...attributes?.style?.elements?.link?.color,
+						text:
+							customTextColor ||
+							`var:preset|color|${ textColor }`,
+					},
+				},
+			},
+		},
+	};
+};
+
 const migrateWithLayout = ( attributes ) => {
 	if ( !! attributes.layout ) {
 		return attributes;
@@ -49,6 +76,127 @@ const migrateWithLayout = ( attributes ) => {
 	}
 
 	return updatedAttributes;
+};
+
+const v7 = {
+	attributes: {
+		ref: {
+			type: 'number',
+		},
+		textColor: {
+			type: 'string',
+		},
+		customTextColor: {
+			type: 'string',
+		},
+		rgbTextColor: {
+			type: 'string',
+		},
+		backgroundColor: {
+			type: 'string',
+		},
+		customBackgroundColor: {
+			type: 'string',
+		},
+		rgbBackgroundColor: {
+			type: 'string',
+		},
+		showSubmenuIcon: {
+			type: 'boolean',
+			default: true,
+		},
+		openSubmenusOnClick: {
+			type: 'boolean',
+			default: false,
+		},
+		overlayMenu: {
+			type: 'string',
+			default: 'mobile',
+		},
+		hasIcon: {
+			type: 'boolean',
+			default: true,
+		},
+		__unstableLocation: {
+			type: 'string',
+		},
+		overlayBackgroundColor: {
+			type: 'string',
+		},
+		customOverlayBackgroundColor: {
+			type: 'string',
+		},
+		overlayTextColor: {
+			type: 'string',
+		},
+		customOverlayTextColor: {
+			type: 'string',
+		},
+		maxNestingLevel: {
+			type: 'number',
+			default: 5,
+		},
+	},
+	supports: {
+		align: [ 'wide', 'full' ],
+		anchor: true,
+		html: false,
+		inserter: true,
+		color: {
+			link: true,
+			__experimentalDefaultControls: {
+				background: true,
+				text: false,
+			},
+		},
+		typography: {
+			fontSize: true,
+			lineHeight: true,
+			__experimentalFontStyle: true,
+			__experimentalFontWeight: true,
+			__experimentalTextTransform: true,
+			__experimentalFontFamily: true,
+			__experimentalTextDecoration: true,
+			__experimentalSkipSerialization: [ 'textDecoration' ],
+			__experimentalDefaultControls: {
+				fontSize: true,
+			},
+		},
+		spacing: {
+			blockGap: true,
+			units: [ 'px', 'em', 'rem', 'vh', 'vw' ],
+			__experimentalDefaultControls: {
+				blockGap: true,
+			},
+		},
+		__experimentalLayout: {
+			allowSwitching: false,
+			allowInheriting: false,
+			allowVerticalAlignment: false,
+			default: {
+				type: 'flex',
+			},
+		},
+		__experimentalStyle: {
+			elements: {
+				link: {
+					color: {
+						text: 'inherit',
+					},
+				},
+			},
+		},
+	},
+	save( { attributes } ) {
+		if ( attributes.ref ) {
+			return;
+		}
+		return <InnerBlocks.Content />;
+	},
+	isEligible: ( { textColor, customTextColor } ) => {
+		return !! customTextColor || !! textColor;
+	},
+	migrate: migrateTextColorToLinkColor,
 };
 
 const v6 = {
@@ -353,6 +501,7 @@ const migrateTypographyPresets = function ( attributes ) {
 };
 
 const deprecated = [
+	v7,
 	v6,
 	v5,
 	v4,

--- a/packages/block-library/src/navigation/deprecated.js
+++ b/packages/block-library/src/navigation/deprecated.js
@@ -35,8 +35,6 @@ const migrateTextColorToLinkColor = ( {
 } ) => {
 	return {
 		...attributes,
-		textColor: null,
-		customTextColor: null,
 		style: {
 			...attributes?.style,
 			elements: {
@@ -193,7 +191,11 @@ const v7 = {
 		}
 		return <InnerBlocks.Content />;
 	},
-	isEligible: ( { textColor, customTextColor } ) => {
+	isEligible: ( { textColor, customTextColor, ...attributes } ) => {
+		if ( attributes?.style?.elements?.link?.color?.text ) {
+			return false;
+		}
+
 		return !! customTextColor || !! textColor;
 	},
 	migrate: migrateTextColorToLinkColor,

--- a/packages/block-library/src/navigation/deprecated.js
+++ b/packages/block-library/src/navigation/deprecated.js
@@ -28,13 +28,16 @@ const migrateIdToRef = ( { navigationMenuId, ...attributes } ) => {
 	};
 };
 
-const migrateTextColorToLinkColor = ( {
+const migrateTextColorToGlobalStylesLinkColor = ( {
 	textColor,
 	customTextColor,
 	...attributes
 } ) => {
+	const newColor = customTextColor || `var:preset|color|${ textColor }`;
+
 	return {
 		...attributes,
+		textColor: customTextColor || textColor,
 		style: {
 			...attributes?.style,
 			elements: {
@@ -43,9 +46,7 @@ const migrateTextColorToLinkColor = ( {
 					...attributes?.style?.elements?.link,
 					color: {
 						...attributes?.style?.elements?.link?.color,
-						text:
-							customTextColor ||
-							`var:preset|color|${ textColor }`,
+						text: newColor,
 					},
 				},
 			},
@@ -198,7 +199,7 @@ const v7 = {
 
 		return !! customTextColor || !! textColor;
 	},
-	migrate: migrateTextColorToLinkColor,
+	migrate: migrateTextColorToGlobalStylesLinkColor,
 };
 
 const v6 = {

--- a/packages/block-library/src/navigation/edit/index.js
+++ b/packages/block-library/src/navigation/edit/index.js
@@ -75,6 +75,8 @@ function Navigation( {
 	setOverlayBackgroundColor,
 	overlayTextColor,
 	setOverlayTextColor,
+	overlayLinkColor,
+	setOverlayLinkColor,
 
 	// These props are used by the navigation editor to override specific
 	// navigation block settings.
@@ -596,6 +598,11 @@ function Navigation( {
 							label: __( 'Submenu & overlay text' ),
 						},
 						{
+							value: overlayLinkColor.color,
+							onChange: setOverlayLinkColor,
+							label: __( 'Submenu & overlay links' ),
+						},
+						{
 							value: overlayBackgroundColor.color,
 							onChange: setOverlayBackgroundColor,
 							label: __( 'Submenu & overlay background' ),
@@ -682,6 +689,7 @@ function Navigation( {
 					isHiddenByDefault={ 'always' === overlayMenu }
 					overlayBackgroundColor={ overlayBackgroundColor }
 					overlayTextColor={ overlayTextColor }
+					overlayLinkColor={ overlayLinkColor }
 				>
 					<UnsavedInnerBlocks
 						blocks={ uncontrolledInnerBlocks }
@@ -914,6 +922,7 @@ function Navigation( {
 							isHiddenByDefault={ 'always' === overlayMenu }
 							overlayBackgroundColor={ overlayBackgroundColor }
 							overlayTextColor={ overlayTextColor }
+							overlayLinkColor={ overlayLinkColor }
 						>
 							{ isEntityAvailable && (
 								<NavigationInnerBlocks
@@ -936,5 +945,6 @@ export default withColors(
 	{ textColor: 'color' },
 	{ backgroundColor: 'color' },
 	{ overlayBackgroundColor: 'color' },
-	{ overlayTextColor: 'color' }
+	{ overlayTextColor: 'color' },
+	{ overlayLinkColor: 'color' }
 )( Navigation );


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Migrates Nav block text / link color to Global Styles implementation. 

Also allows Nav block link styles to overide those defined on ancestor blocks.

~Fixes https://github.com/WordPress/gutenberg/issues/41146~

Part of https://github.com/WordPress/gutenberg/issues/44712

TBC.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

The Nav block uses a non-standard, custom implementation of the `Color` controls. 

It is also using an _implicit_ CSS rule (`color: inherit`) to propagate the value of `Text Color` down onto its Link `a` elements. Unfortunately this means that any `Link` rules from Global Styles and/or ancestor blocks which target `a` will overwrite the _implicit_ rules defined by the block because the global styles rules are output _after_ the block rules.


## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

This PR deprecates the existing bespoke Text Color attributes and migrates any colors defined on those attributes over to the `styles.elements.link.colors.text` attribute of the block and the `textColor` attribute _provided by block supports_.

This PR aims to fix that by utilising the standards based Block Supports `color` implementation. This provides:

- Text
- Background
- Link

...colors.

It also moves the custom Submenu/Overlay color controls into their own panel. This is suboptimal UX wise but is the simplest option to get the majority of the block over to standards.

**Please see https://github.com/WordPress/gutenberg/issues/41146#issuecomment-1172231277 for full context and explaination on what we're trying to achieve here.**


## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->

## Screenshots or screencast <!-- if applicable -->
