### PR TITLE
Change the BoxControl ARIA role from region to group.

### DIFF
--- a/docs/how-to-guides/accessibility.md
+++ b/docs/how-to-guides/accessibility.md
@@ -12,6 +12,6 @@ For setting up navigation between different regions, see the [navigateRegions pa
 
 Read more regarding landmark design from W3C:
 
--   [General Principles of Landmark Design](https://www.w3.org/TR/wai-aria-practices-1.1/#general-principles-of-landmark-design)
--   [ARIA Landmarks Example](https://www.w3.org/TR/wai-aria-practices/examples/landmarks/)
--   [HTML5 elements that by default define ARIA landmarks](https://www.w3.org/TR/wai-aria-practices/examples/landmarks/HTML5.html)
+-   [General Principles of Landmark Design](https://www.w3.org/WAI/ARIA/apg/practices/landmark-regions/#x4-2-general-principles-of-landmark-design)
+-   [ARIA Landmarks Examples](https://www.w3.org/WAI/ARIA/apg/example-index/landmarks/)
+-   [HTML5 elements that by default define ARIA landmarks](https://www.w3.org/WAI/ARIA/apg/practices/landmark-regions/#x4-1-html-sectioning-elements)

--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Bug Fix
+
+-   `BoxControl`: Change ARIA role from `region` to `group` to avoid unwanted ARIA landmark regions ([#42094](https://github.com/WordPress/gutenberg/pull/42094)).
+
 ### Internal
 
 -   `Grid`: Convert to TypeScript ([#41923](https://github.com/WordPress/gutenberg/pull/41923)).

--- a/packages/components/src/box-control/index.js
+++ b/packages/components/src/box-control/index.js
@@ -117,7 +117,7 @@ export default function BoxControl( {
 	};
 
 	return (
-		<Root id={ id } role="region" aria-labelledby={ headingId }>
+		<Root id={ id } role="group" aria-labelledby={ headingId }>
 			<Header className="component-box-control__header">
 				<FlexItem>
 					<Text

--- a/packages/components/src/higher-order/navigate-regions/README.md
+++ b/packages/components/src/higher-order/navigate-regions/README.md
@@ -1,6 +1,6 @@
 # navigateRegions
 
-`navigateRegions` is a React [higher-order component](https://facebook.github.io/react/docs/higher-order-components.html) adding keyboard navigation to switch between the different DOM elements marked as "regions" (role="region"). These regions should be focusable (By adding a tabIndex attribute for example). For better accessibility, these elements must be properly labelled to briefly describe the purpose of the content in the region. For more details, see "ARIA landmarks" in the [WAI-ARIA specification](https://www.w3.org/TR/wai-aria/).
+`navigateRegions` is a React [higher-order component](https://facebook.github.io/react/docs/higher-order-components.html) adding keyboard navigation to switch between the different DOM elements marked as "regions" (role="region"). These regions should be focusable (By adding a tabIndex attribute for example). For better accessibility, these elements must be properly labelled to briefly describe the purpose of the content in the region. For more details, see "Landmark Roles" in the [WAI-ARIA specification](https://www.w3.org/TR/wai-aria/) and "Landmark Regions" in the [ARIA Authoring Practices Guide](https://www.w3.org/WAI/ARIA/apg/practices/landmark-regions/).
 
 ## Example:
 
@@ -21,3 +21,6 @@ const MyComponentWithNavigateRegions = navigateRegions( () => (
 	</div>
 ) );
 ```
+
+## Notes:
+It's important to note that an ARIA `role="region"` is an ARIA landmark role. It should be reserved for sections of content sufficiently important to have it listed in a summary of the page. Only use this ARIA role for the main sections of a page. All perceivable content should reside in a semantically meaningful landmark in order that content is not missed by the user.


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

Fixes https://github.com/WordPress/gutenberg/issues/42093

## What?
<!-- In a few words, what is the PR actually doing? -->
Changes the `BoxControl` root element ARIA role from `region` to `group`:

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
- we don't want this component to be an ARIA landmark
- the `group` role is more appropriate, as it logically groups the form elements within `BoxControl`

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
It's important to know that when the ARIA `role="region"` is used on a labelled element, it determines an ARIA landmark. This pattern should only be used for 'real' ARIA landmarks i.e. the main section of a page that we want to be presented to assistive technology users as landmarks.
This PR just changes the hardcoded `role` value to `group`.



## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
- edit a post
- add a block that uses margin / padding / block spacing, e.g.: a Columns block
- select the Columns block
- in the block inspector toolbar, make sure to enable 'Padding' and 'Margin' in the Dimensions options menu (the vertical ellipsis on the right of 'Dimensions')
- inspect the source and observe the root element of the 'Padding' and 'Margin' control has a `role="group"` attribute.
- optionally inspect similar `BoxControl` components used in the Global Styles sidebar and in the Site Editor.

Optionally test with a screen reader e.g. VoiceOver (with Safari)
- Cmd + F5 to launch VoiceOver
- Go to the edited post you used for testing
- Select the Column block 
- Make sure the 'Padding' and 'Margin' controls are rendered in the block inspector sidebar
- Press Control + Option + U to launch the VoiceOver 'rotor'
- Use the Left or Right arrow keys to switch the 'rotor' to the Landmarks list
- Observe Margin and Padding are _not_ listed in the Landmarks list any longer.

## Screenshots or screencast <!-- if applicable -->
