### PR TITLE
Add visited to link element allowed pseudo selector list

### DIFF
--- a/lib/compat/wordpress-6.1/class-wp-theme-json-6-1.php
+++ b/lib/compat/wordpress-6.1/class-wp-theme-json-6-1.php
@@ -22,7 +22,7 @@ class WP_Theme_JSON_6_1 extends WP_Theme_JSON_6_0 {
 	 * Note: this will effect both top level and block level elements.
 	 */
 	const VALID_ELEMENT_PSEUDO_SELECTORS = array(
-		'link' => array( ':hover', ':focus', ':active' ),
+		'link' => array( ':hover', ':focus', ':active', ':visited' ),
 	);
 
 	/*


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Enables usage of [`:visited` pseudo class](https://developer.mozilla.org/en-US/docs/Web/CSS/:visited) within `theme.json` for `link` element only.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

Because it's a common selector.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

Add to the allow list.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->

1. Activate empty theme
2. Add the following block the appropriate place in your `theme.json`
```json
"styles": {
    "elements": {
        "link": {
            ":visited": {
                "color": {
                    "text": "green"
                }
            }
        }
    }
}
```
3. Check that once you've visited a link within the Editor & on the front end of the site it turns green.
4. Check the dev tools to confirm 100% that the `:visited` selector is used.

## Screenshots or screencast <!-- if applicable -->
<img width="1507" alt="Screen Shot 2022-07-01 at 15 33 58" src="https://user-images.githubusercontent.com/444434/176916394-2fe7dbd6-4118-49f6-a14c-f45a7a631408.png">
<img width="1494" alt="Screen Shot 2022-07-01 at 15 33 15" src="https://user-images.githubusercontent.com/444434/176916402-bab46c88-bf11-4691-ac13-99278050fa3a.png">

