### PR TITLE
core/search block button: adding consistent cursor settings

### DIFF
--- a/packages/block-library/src/search/editor.scss
+++ b/packages/block-library/src/search/editor.scss
@@ -12,6 +12,11 @@
 		border-radius: initial;
 		display: flex;
 		align-items: center;
+		cursor: revert;
+
+		&[role="textbox"] {
+			cursor: text;
+		}
 	}
 
 	&__components-button-group {

--- a/packages/block-library/src/search/style.scss
+++ b/packages/block-library/src/search/style.scss
@@ -1,6 +1,7 @@
 .wp-block-search__button {
 	margin-left: 0.625em;
 	word-break: normal;
+	cursor: pointer;
 
 	&.has-icon {
 		line-height: 0;


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->
adding consistent cursor settings for core/search block button.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
Because currently, we are not applying cursor CSS for this block as we do for other blocks.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
Adding CSS for the block frontend and editor.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->
1. Add a search block using the editor
2. Hover the button in the editor with both text and icon options
3. Hover the button in the public version

## Screenshots or screencast <!-- if applicable -->

## Before:
Editor text:
![image](https://user-images.githubusercontent.com/1310626/176934634-cbf23715-221e-4106-97a0-c3b3dbb85102.png)


Editor icon:
![image](https://user-images.githubusercontent.com/1310626/176934706-05c19340-d641-4321-9c04-2c85331b5bd4.png)


Public:
![image](https://user-images.githubusercontent.com/1310626/176934755-c93205d1-c49e-4da8-8b46-a3ac6d6da044.png)


## After
Editor text:
![image](https://user-images.githubusercontent.com/1310626/176934818-4bed161c-e018-440b-8e69-6d512456a8d4.png)


Editor icon:
![image](https://user-images.githubusercontent.com/1310626/176934892-37e6e257-2d7e-4ddf-b26a-453cbf84732f.png)

Public:
![image](https://user-images.githubusercontent.com/1310626/176934923-7b0f8bf0-aa9f-412a-86e9-e7df2656bd09.png)

