### PR TITLE
chore: Set permissions for GitHub actions

### DIFF
--- a/.github/workflows/build-plugin-zip.yml
+++ b/.github/workflows/build-plugin-zip.yml
@@ -17,8 +17,13 @@ concurrency:
     group: ${{ github.workflow }}-${{ github.event_name == 'pull_request' && github.head_ref || github.sha }}
     cancel-in-progress: true
 
+permissions:
+  contents: read
+
 jobs:
     compute-stable-branches:
+        permissions:
+          contents: none
         name: Compute current and next stable release branches
         runs-on: ubuntu-latest
         if: ${{ github.event_name == 'workflow_dispatch' }}
@@ -44,6 +49,8 @@ jobs:
                   fi
 
     bump-version:
+        permissions:
+          contents: write  # for Git to git push
         name: Bump version
         runs-on: ubuntu-latest
         needs: compute-stable-branches
@@ -209,6 +216,8 @@ jobs:
                   path: ./release-notes.txt
 
     revert-version-bump:
+        permissions:
+          contents: write  # for Git to git push
         name: Revert version bump if build failed
         needs: [bump-version, build]
         runs-on: ubuntu-latest
@@ -254,6 +263,8 @@ jobs:
                   git push --set-upstream origin trunk
 
     create-release:
+        permissions:
+          contents: write  # for actions/create-release to create a release
         name: Create Release Draft and Attach Asset
         needs: [bump-version, build]
         runs-on: ubuntu-latest

--- a/.github/workflows/bundle-size.yml
+++ b/.github/workflows/bundle-size.yml
@@ -31,8 +31,16 @@ concurrency:
     group: ${{ github.workflow }}-${{ github.event_name == 'pull_request' && github.head_ref || github.sha }}
     cancel-in-progress: true
 
+permissions:
+  contents: read
+
 jobs:
     build:
+        permissions:
+          checks: write  # for preactjs/compressed-size-action to create and update the checks
+          contents: read  # for actions/checkout to fetch code
+          issues: write  # for preactjs/compressed-size-action to create comments
+          pull-requests: write  # for preactjs/compressed-size-action to write a PR review
         name: Check
         runs-on: ubuntu-latest
 

--- a/.github/workflows/create-block.yml
+++ b/.github/workflows/create-block.yml
@@ -12,6 +12,9 @@ concurrency:
     group: ${{ github.workflow }}-${{ github.event_name == 'pull_request' && github.head_ref || github.sha }}
     cancel-in-progress: true
 
+permissions:
+  contents: read
+
 jobs:
     checks:
         name: Checks

--- a/.github/workflows/end2end-test-playwright.yml
+++ b/.github/workflows/end2end-test-playwright.yml
@@ -15,6 +15,9 @@ concurrency:
     group: ${{ github.workflow }}-${{ github.event_name == 'pull_request' && github.head_ref || github.sha }}
     cancel-in-progress: true
 
+permissions:
+  contents: read
+
 jobs:
     e2e:
         name: E2E Tests

--- a/.github/workflows/end2end-test.yml
+++ b/.github/workflows/end2end-test.yml
@@ -15,6 +15,9 @@ concurrency:
     group: ${{ github.workflow }}-${{ github.event_name == 'pull_request' && github.head_ref || github.sha }}
     cancel-in-progress: true
 
+permissions:
+  contents: read
+
 jobs:
     admin:
         name: Admin - ${{ matrix.part }}

--- a/.github/workflows/publish-npm-packages.yml
+++ b/.github/workflows/publish-npm-packages.yml
@@ -23,6 +23,9 @@ concurrency:
     group: ${{ github.workflow }}-${{ github.event_name == 'pull_request' && github.head_ref || github.sha }}
     cancel-in-progress: true
 
+permissions:
+  contents: read
+
 jobs:
     release:
         name: Release - ${{ github.event.inputs.release_type }}

--- a/.github/workflows/rnmobile-ios-runner.yml
+++ b/.github/workflows/rnmobile-ios-runner.yml
@@ -12,6 +12,9 @@ concurrency:
     group: ${{ github.workflow }}-${{ github.event_name == 'pull_request' && github.head_ref || github.sha }}
     cancel-in-progress: true
 
+permissions:
+  contents: read
+
 jobs:
     test:
         runs-on: macos-11

--- a/.github/workflows/stale-issue-add-needs-testing.yml
+++ b/.github/workflows/stale-issue-add-needs-testing.yml
@@ -3,8 +3,14 @@ on:
     schedule:
         - cron: '45 1 * * *'
 
+permissions:
+  contents: read
+
 jobs:
     stale:
+        permissions:
+          issues: write  # for actions/stale to close stale issues
+          pull-requests: write  # for actions/stale to close stale PRs
         runs-on: ubuntu-latest
         if: ${{ github.repository == 'WordPress/gutenberg' }}
 

--- a/.github/workflows/stale-issue-mark-stale.yml
+++ b/.github/workflows/stale-issue-mark-stale.yml
@@ -3,8 +3,14 @@ on:
     schedule:
         - cron: '55 1 * * *'
 
+permissions:
+  contents: read
+
 jobs:
     stale:
+        permissions:
+          issues: write  # for actions/stale to close stale issues
+          pull-requests: write  # for actions/stale to close stale PRs
         runs-on: ubuntu-latest
         if: ${{ github.repository == 'WordPress/gutenberg' }}
 

--- a/.github/workflows/stale-issue-needs-info.yml
+++ b/.github/workflows/stale-issue-needs-info.yml
@@ -3,8 +3,14 @@ on:
     schedule:
         - cron: '30 1 * * *'
 
+permissions:
+  contents: read
+
 jobs:
     stale:
+        permissions:
+          issues: write  # for actions/stale to close stale issues
+          pull-requests: write  # for actions/stale to close stale PRs
         runs-on: ubuntu-latest
         if: ${{ github.repository == 'WordPress/gutenberg' }}
 

--- a/.github/workflows/static-checks.yml
+++ b/.github/workflows/static-checks.yml
@@ -15,6 +15,9 @@ concurrency:
     group: ${{ github.workflow }}-${{ github.event_name == 'pull_request' && github.head_ref || github.sha }}
     cancel-in-progress: true
 
+permissions:
+  contents: read
+
 jobs:
     check:
         name: All

--- a/.github/workflows/unit-test.yml
+++ b/.github/workflows/unit-test.yml
@@ -17,6 +17,9 @@ concurrency:
     group: ${{ github.workflow }}-${{ github.event_name == 'pull_request' && github.head_ref || github.sha }}
     cancel-in-progress: true
 
+permissions:
+  contents: read
+
 jobs:
     unit-js:
         name: JavaScript

--- a/.github/workflows/upload-release-to-plugin-repo.yml
+++ b/.github/workflows/upload-release-to-plugin-repo.yml
@@ -4,8 +4,13 @@ on:
     release:
         types: [published]
 
+permissions:
+  contents: read
+
 jobs:
     get-release-branch:
+        permissions:
+          contents: none
         name: Get release branch name
         runs-on: ubuntu-latest
         if: github.event.release.assets[0]
@@ -23,6 +28,8 @@ jobs:
                   echo "::set-output name=release_branch::$(echo $RELEASE_BRANCH)"
 
     update-changelog:
+        permissions:
+          contents: write  # for Git to git push
         name: Update Changelog on ${{ matrix.branch }} branch
         runs-on: ubuntu-latest
         if: github.event.release.assets[0]
@@ -95,6 +102,8 @@ jobs:
                   path: ./changelog.txt
 
     upload:
+        permissions:
+          contents: none
         name: Upload Gutenberg Plugin
         runs-on: ubuntu-latest
         environment: wp.org plugin


### PR DESCRIPTION
 Restrict the GitHub token permissions only to the required ones; this way, even if the attackers will succeed in compromising your workflow, they won’t be able to do much.

- Included permissions for the action. https://github.com/ossf/scorecard/blob/main/docs/checks.md#token-permissions

https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#permissions

https://docs.github.com/en/actions/using-jobs/assigning-permissions-to-jobs

[Keeping your GitHub Actions and workflows secure Part 1: Preventing pwn requests](https://securitylab.github.com/research/github-actions-preventing-pwn-requests/)

Signed-off-by: nathannaveen <42319948+nathannaveen@users.noreply.github.com>
