### PR TITLE
Update the text of the block alignment control to include "width"

### DIFF
--- a/packages/block-editor/src/components/block-alignment-control/test/__snapshots__/index.js.snap
+++ b/packages/block-editor/src/components/block-alignment-control/test/__snapshots__/index.js.snap
@@ -73,7 +73,7 @@ exports[`BlockAlignmentUI should match snapshot 1`] = `
     </SVG>
   }
   isCollapsed={true}
-  label="Align"
+  label="Change alignment or width"
   popoverProps={
     Object {
       "isAlternate": true,
@@ -81,7 +81,7 @@ exports[`BlockAlignmentUI should match snapshot 1`] = `
   }
   toggleProps={
     Object {
-      "describedBy": "Change alignment",
+      "describedBy": "Change alignment or width",
     }
   }
 />

--- a/packages/block-editor/src/components/block-alignment-control/test/index.native.js
+++ b/packages/block-editor/src/components/block-alignment-control/test/index.native.js
@@ -13,7 +13,7 @@ it( 'should call onChange with undefined when the control is already active', ()
 	const screen = render(
 		<BlockAlignmentUI value="right" onChange={ onChangeMock } />
 	);
-	const alignButton = screen.getByA11yLabel( 'Align' );
+	const alignButton = screen.getByA11yLabel( 'Change alignment or width' );
 	fireEvent.press( alignButton );
 	const rightAlignmentButton = screen.getByA11yLabel( 'Align right' );
 	fireEvent.press( rightAlignmentButton );
@@ -27,7 +27,7 @@ it( 'should call onChange with alignment value when the control is inactive', ()
 	const screen = render(
 		<BlockAlignmentUI value="left" onChange={ onChangeMock } />
 	);
-	const alignButton = screen.getByA11yLabel( 'Align' );
+	const alignButton = screen.getByA11yLabel( 'Change alignment or width' );
 	fireEvent.press( alignButton );
 	const centerAlignmentButton = screen.getByA11yLabel( 'Align center' );
 	fireEvent.press( centerAlignmentButton );

--- a/packages/block-editor/src/components/block-alignment-control/ui.js
+++ b/packages/block-editor/src/components/block-alignment-control/ui.js
@@ -52,8 +52,8 @@ function BlockAlignmentUI( {
 		icon: activeAlignmentControl
 			? activeAlignmentControl.icon
 			: defaultAlignmentControl.icon,
-		label: __( 'Align' ),
-		toggleProps: { describedBy: __( 'Change alignment' ) },
+		label: __( 'Change alignment or width' ),
+		toggleProps: { describedBy: __( 'Change alignment or width' ) },
 	};
 	const extraProps = isToolbar
 		? {

--- a/packages/block-editor/src/components/block-alignment-control/ui.native.js
+++ b/packages/block-editor/src/components/block-alignment-control/ui.native.js
@@ -47,7 +47,7 @@ function BlockAlignmentUI( {
 		: toolbarUIComponent;
 
 	const commonProps = {
-		label: __( 'Align' ),
+		label: __( 'Change alignment or width' ),
 	};
 	const extraProps = isBottomSheetControl
 		? {

--- a/packages/block-editor/src/components/block-alignment-control/ui.native.js
+++ b/packages/block-editor/src/components/block-alignment-control/ui.native.js
@@ -77,7 +77,7 @@ function BlockAlignmentUI( {
 					};
 				} ),
 				popoverProps: POPOVER_PROPS,
-				toggleProps: { describedBy: __( 'Change alignment' ) },
+				toggleProps: { describedBy: __( 'Change alignment or width' ) },
 		  };
 
 	return <UIComponent { ...commonProps } { ...extraProps } />;

--- a/packages/block-library/src/embed/test/index.native.js
+++ b/packages/block-library/src/embed/test/index.native.js
@@ -668,7 +668,9 @@ describe( 'Embed block', () => {
 
 				// Open alignment options.
 				fireEvent.press(
-					await waitFor( () => getByA11yLabel( 'Align' ) )
+					await waitFor( () =>
+						getByA11yLabel( 'Change alignment or width' )
+					)
 				);
 
 				// Select alignment option.

--- a/packages/e2e-tests/specs/editor/plugins/align-hook.test.js
+++ b/packages/e2e-tests/specs/editor/plugins/align-hook.test.js
@@ -151,7 +151,7 @@ describe( 'Align Hook Works As Expected', () => {
 		it( 'Shows no alignment buttons on the alignment toolbar', async () => {
 			await insertBlock( BLOCK_NAME );
 			const CHANGE_ALIGNMENT_BUTTON_SELECTOR =
-				'.block-editor-block-toolbar .components-dropdown-menu__toggle[aria-label="Align"]';
+				'.block-editor-block-toolbar .components-dropdown-menu__toggle[aria-label="Change alignment or width"]';
 			const changeAlignmentButton = await page.$(
 				CHANGE_ALIGNMENT_BUTTON_SELECTOR
 			);


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->
Updates the text for the alignment control from "Align" to "Change alignment or width".
Partial for #30724.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
Users have left feedback saying that it is confusing that the tooltip for the width options is "Align", making the width options more difficult to find.

Note: The vertical alignment button text is "Change vertical alignment" and the item justification text is "Change item justification".

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
This is a text only change.

## Testing Instructions

1. Apply the PR
2. In the block editor, add a block with width and alignment controls.
3. Hover over the alignment and width option in the toolbar and see that the toolbar text is "Change alignment or width"
4. With a screen reader, navigate to the block toolbar option and confirm that the correct button name is announced.
5. In the options > Preference panel, Appearance: Enable "Show button text labels". Confirm that the toolbar button text is correct.

## Screenshots or screencast <!-- if applicable -->
![Block toolbar with visible tooltip with the updated text](https://user-images.githubusercontent.com/7422055/177006048-41227514-4884-42be-8dd9-c09d20ca9431.png)


