### PR TITLE
Post Author: rendering html for the author description at the editor

### DIFF
--- a/packages/block-library/src/post-author-biography/edit.js
+++ b/packages/block-library/src/post-author-biography/edit.js
@@ -55,7 +55,10 @@ function PostAuthorBiographyEdit( {
 					} }
 				/>
 			</BlockControls>
-			<div { ...blockProps }> { displayAuthorBiography } </div>
+			<div
+				{ ...blockProps }
+				dangerouslySetInnerHTML={ { __html: displayAuthorBiography } }
+			/>
 		</>
 	);
 }

--- a/packages/block-library/src/post-author/edit.js
+++ b/packages/block-library/src/post-author/edit.js
@@ -162,9 +162,12 @@ function PostAuthorEdit( {
 						{ authorDetails?.name || __( 'Post Author' ) }
 					</p>
 					{ showBio && (
-						<p className="wp-block-post-author__bio">
-							{ authorDetails?.description }
-						</p>
+						<p
+							className="wp-block-post-author__bio"
+							dangerouslySetInnerHTML={ {
+								__html: authorDetails?.description,
+							} }
+						/>
 					) }
 				</div>
 			</div>


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->
This pr has added the functionality for the author's description block render HTML in the editor. When the author includes a link in his description, the HTML is not rendered at the editor displaying the HTML code.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

Some users can get confused with the author's description  can render HTML or not at the front-end 

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

This PR has included `dangerouslySetInnerHTML` to render the HTML code at the editor.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->

1. Open the author's settings
2. add a description with HTML code
3. insert the author description block
4. check if the HTML will be rendered at the editor


## Screenshots or screencast <!-- if applicable -->

before the change in the Editor
![Screen Shot 2022-07-03 at 23 10 52](https://user-images.githubusercontent.com/330792/177058858-4ddba685-9eee-4211-8399-d8e8921de0ee.png)

after the change in the editor
![Screen Shot 2022-07-03 at 23 22 15](https://user-images.githubusercontent.com/330792/177059140-0a319605-1233-4e3b-b8f5-10fc5cdd00de.png)

