### PR TITLE
MediaReplaceFlow: Fix UI showing stale URL by avoiding state duplication

### DIFF
--- a/packages/block-editor/src/components/media-replace-flow/index.js
+++ b/packages/block-editor/src/components/media-replace-flow/index.js
@@ -1,7 +1,7 @@
 /**
  * WordPress dependencies
  */
-import { useEffect, useState, useRef } from '@wordpress/element';
+import { useRef } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import { speak } from '@wordpress/a11y';
 import {
@@ -55,18 +55,6 @@ const MediaReplaceFlow = ( {
 	addToGallery,
 	handleUpload = true,
 } ) => {
-	const [ mediaURLValue, setMediaURLValue ] = useState( mediaURL );
-
-	// In the event of an external change to prop `mediaURL`, synchronize
-	// internal state `mediaURLValue`. Synchronization is especially important
-	// when dealing with images that are being uploaded and whose URL changes
-	// from a blob to a proper URL.
-	useEffect( () => {
-		if ( mediaURL && mediaURL !== mediaURLValue ) {
-			setMediaURLValue( mediaURL );
-		}
-	}, [ mediaURL ] );
-
 	const mediaUpload = useSelect( ( select ) => {
 		return select( blockEditorStore ).getSettings().mediaUpload;
 	}, [] );
@@ -99,7 +87,6 @@ const MediaReplaceFlow = ( {
 			onToggleFeaturedImage();
 		}
 		closeMenu();
-		setMediaURLValue( media?.url );
 		// Calling `onSelect` after the state update since it might unmount the component.
 		onSelect( media );
 		speak( __( 'The media file has been replaced' ) );
@@ -224,14 +211,13 @@ const MediaReplaceFlow = ( {
 								{ __( 'Current media URL:' ) }
 							</span>
 
-							<Tooltip text={ mediaURLValue } position="bottom">
+							<Tooltip text={ mediaURL } position="bottom">
 								<div>
 									<LinkControl
-										value={ { url: mediaURLValue } }
+										value={ { url: mediaURL } }
 										settings={ [] }
 										showSuggestions={ false }
 										onChange={ ( { url } ) => {
-											setMediaURLValue( url );
 											onSelectURL( url );
 											editMediaButtonRef.current.focus();
 										} }

--- a/packages/block-editor/src/components/media-replace-flow/index.js
+++ b/packages/block-editor/src/components/media-replace-flow/index.js
@@ -1,7 +1,7 @@
 /**
  * WordPress dependencies
  */
-import { useState, useRef } from '@wordpress/element';
+import { useEffect, useState, useRef } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import { speak } from '@wordpress/a11y';
 import {
@@ -56,6 +56,17 @@ const MediaReplaceFlow = ( {
 	handleUpload = true,
 } ) => {
 	const [ mediaURLValue, setMediaURLValue ] = useState( mediaURL );
+
+	// In the event of an external change to prop `mediaURL`, synchronize
+	// internal state `mediaURLValue`. Synchronization is especially important
+	// when dealing with images that are being uploaded and whose URL changes
+	// from a blob to a proper URL.
+	useEffect( () => {
+		if ( mediaURL && mediaURL !== mediaURLValue ) {
+			setMediaURLValue( mediaURL );
+		}
+	}, [ mediaURL ] );
+
 	const mediaUpload = useSelect( ( select ) => {
 		return select( blockEditorStore ).getSettings().mediaUpload;
 	}, [] );

--- a/packages/block-editor/src/components/media-replace-flow/test/index.js
+++ b/packages/block-editor/src/components/media-replace-flow/test/index.js
@@ -4,25 +4,35 @@
 import { render, fireEvent } from '@testing-library/react';
 
 /**
+ * WordPress dependencies
+ */
+import { useState } from '@wordpress/element';
+
+/**
  * Internal dependencies
  */
 import MediaReplaceFlow from '../';
 
 const noop = () => {};
 
-function setUpMediaReplaceFlow() {
-	const { container } = render(
+function TestWrapper() {
+	const [ mediaURL, setMediaURL ] = useState( 'https://example.media' );
+	return (
 		<MediaReplaceFlow
 			mediaId={ 1 }
-			mediaURL={ 'https://example.media' }
+			mediaURL={ mediaURL }
 			allowedTypes={ [ 'png' ] }
 			accept="image/*"
 			onSelect={ noop }
-			onSelectURL={ noop }
+			onSelectURL={ setMediaURL }
 			onError={ noop }
 			onCloseModal={ noop }
 		/>
 	);
+}
+
+function setUpMediaReplaceFlow() {
+	const { container } = render( <TestWrapper /> );
 	return container;
 }
 


### PR DESCRIPTION
## What?

Fixes a UI bug discovered in #41994.

## Why?

After a new Image block has uploaded an image to the media library, the "Replace" popover will incorrectly report the image's URL as `blob:...`, even though the block has correctly updated its `url` attribute to the new resource in the media library.

<img width="504" alt="media-replace-flow-sync-url" src="https://user-images.githubusercontent.com/150562/177138626-4eb3469e-1a30-4228-95eb-a3a0c8dff12f.png">

## How?

The `MediaReplaceFlow` component is passed `mediaURL` as a prop, but it also keeps its own internal URL state (`mediaURLValue`) using `mediaURL` as a seed. The reason for keeping internal state is to let users edit the URL in an "edit and confirm" kind of interaction, as initially implemented in #16200 ([see line](https://github.com/WordPress/gutenberg/pull/16200/files?diff=unified&w=1#diff-fc35a9c6160f3d54e5685594e41dc7a2b4ee7c4d96e7ad8c6ce7fdb8206deff7R114)), but that lends itself to synchronisation bugs. This PR removes the component's internal state altogether and uses the `mediaURL` prop directly. The actual link-editing functionality is provided by `LinkControl` (a descendant of `MediaReplaceFlow`), which already does it own state synchronisation anyway.

## Testing Instructions
See original report in https://github.com/WordPress/gutenberg/issues/41994#issuecomment-1173627889.

* Copy an external image by navigating to a public webpage, right-clicking on an image and selecting "Copy Image"
* In the block editor, paste to insert a new Image block
* Once the image has finished uploading (it should change from transparent to opaque), click "Replace" in the block toolbar
* Confirm that the image's URL inside the popover element is correct (it should be a URL pointing to the site's media library). It should not be a `blob:` URL.