### PR TITLE
Adds recommendation to check for WP_Block_Patterns_Registry class

### DIFF
--- a/docs/reference-guides/block-api/block-patterns.md
+++ b/docs/reference-guides/block-api/block-patterns.md
@@ -16,6 +16,16 @@ In this Document:
 
 ## Block Patterns
 
+Before using the helper functions listed on this page it is advisable to check for the existence of the `WP_Block_Patterns_Registry` class.
+
+```
+if ( ! class_exists( 'WP_Block_Patterns_Registry' ) ) {
+     return;
+   }
+```
+
+This class only exists in versions of the block editor that support these helper functions.
+
 ### register_block_pattern
 
 The editor comes with several core block patterns. Theme and plugin authors can register additional custom block patterns using the `register_block_pattern` helper function.


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->
Adds a recommendation to check for  the existence of the `WP_Block_Patterns_Registry` class to the [Patterns page](https://developer.wordpress.org/block-editor/reference-guides/block-api/block-patterns/) in the docs.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
Older versions of WordPress won't have the `WP_Block_Patterns_Registry` class as block pattern functionality doesn't exist in older versions of WordPress or earlier versions of Gutenberg so recommend checking for the existence of the class before using any of:
- `register_block_pattern`
- `unregister_block_pattern`
- `register_block_pattern_category`
- `unregister_block_pattern_category`

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
Added a code sample and a description to the top of the documentation page.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->

## Screenshots or screencast <!-- if applicable -->
