### PR TITLE
More Block: Remove duplicate block class

### DIFF
--- a/packages/block-library/src/more/edit.js
+++ b/packages/block-library/src/more/edit.js
@@ -53,17 +53,15 @@ export default function MoreEdit( {
 				</PanelBody>
 			</InspectorControls>
 			<div { ...useBlockProps() }>
-				<div className="wp-block-more">
-					<input
-						aria-label={ __( 'Read more link text' ) }
-						type="text"
-						value={ customText }
-						placeholder={ DEFAULT_TEXT }
-						onChange={ onChangeInput }
-						onKeyDown={ onKeyDown }
-						style={ style }
-					/>
-				</div>
+				<input
+					aria-label={ __( 'Read more link text' ) }
+					type="text"
+					value={ customText }
+					placeholder={ DEFAULT_TEXT }
+					onChange={ onChangeInput }
+					onKeyDown={ onKeyDown }
+					style={ style }
+				/>
 			</div>
 		</>
 	);


### PR DESCRIPTION
Follow-up on #26054
Related: #42121

## What?
This PR removes the duplicate block class (`wp-block-more`) in the `core/more` block.

## Why?
In #26054, the block API has been updated to v2.
At that time, I suspect that the original block class may have remained.

## How?
I removed a `div` tag with a hardcoded block class inside `useBlockProps`.

## Screenshots or screencast

I've compared them with the major themes, and the appearance does not change at all.

| theme | before | after |
| ---- | ---- | ---- |
| Twenty Twenty Two | ![more_tt2_before](https://user-images.githubusercontent.com/54422211/177155792-cce9e66c-c518-4868-8670-06aec1947b52.png) | ![more_tt2_after](https://user-images.githubusercontent.com/54422211/177155910-5facd898-99de-4f6d-9f8f-669e56c4804a.png) |
| Twenty Twenty One | ![more_tt1_before](https://user-images.githubusercontent.com/54422211/177155942-a66fdb11-7ea0-4e6b-8735-54884c60b41c.png) | ![more_tt1_after](https://user-images.githubusercontent.com/54422211/177155968-17bb4c9c-068b-4420-8931-ce0761217153.png) |
| Twenty Twenty | ![more_tt0_before](https://user-images.githubusercontent.com/54422211/177155999-f5175ef1-f58f-48b3-8edc-c9bfa642d6a4.png) | ![more_tt0_after](https://user-images.githubusercontent.com/54422211/177156014-57ff9cc5-c46b-4ebe-a979-3d825dc61abd.png) |
