### PR TITLE
Page Break Block: Remove duplicate block class

### DIFF
--- a/packages/block-library/src/nextpage/edit.js
+++ b/packages/block-library/src/nextpage/edit.js
@@ -7,9 +7,7 @@ import { useBlockProps } from '@wordpress/block-editor';
 export default function NextPageEdit() {
 	return (
 		<div { ...useBlockProps() }>
-			<div className="wp-block-nextpage">
-				<span>{ __( 'Page break' ) }</span>
-			</div>
+			<span>{ __( 'Page break' ) }</span>
 		</div>
 	);
 }


### PR DESCRIPTION
Follow-up on #26054
Related: #42120

## What?
This PR removes the duplicate block class (`wp-block-nextpage`) in the `core/nextpage` block.

## Why?
In #26054, the block API has been updated to v2.
At that time, I suspect that the original block class may have remained.

## How?
I removed a `div` tag with a hardcoded block class inside `useBlockProps`.

## Screenshots or screencast

I've compared them with the major themes, and the appearance does not change at all.

| theme | before | after |
| ---- | ---- | ---- |
| Twenty Twenty Two | ![nextpage_tt2_before](https://user-images.githubusercontent.com/54422211/177158433-c5386f22-00a6-4036-a6bc-5e0c85d923d9.png) | ![nextpage_tt2_after](https://user-images.githubusercontent.com/54422211/177158458-71ac4973-5a6f-440a-9a67-b04eb58c5eca.png) |
| Twenty Twenty One | ![nextpage_tt1_before](https://user-images.githubusercontent.com/54422211/177158478-30ea99c3-df02-48e9-91a4-f314b2bec06d.png) | ![nextpage_tt1_after](https://user-images.githubusercontent.com/54422211/177158500-b7d6b2fc-76a2-43f4-a68a-b333ad0a6024.png) |
| Twenty Twenty | ![nextpage_tt0_before](https://user-images.githubusercontent.com/54422211/177158524-07b27f5c-4a06-4526-acd8-949b8b6d5ee8.png) | ![nextpage_tt0_after](https://user-images.githubusercontent.com/54422211/177158544-0de04eb6-6e6d-418e-9b7b-0162b7dbc01c.png) |