### PR TITLE
Add: Frontend section presets output

### DIFF
--- a/lib/block-supports/settings.php
+++ b/lib/block-supports/settings.php
@@ -96,7 +96,7 @@ function _gutenberg_add_block_level_preset_styles( $pre_render, $block ) {
 	// the root selector for preset variables needs to target every possible block selector
 	// in order for the general setting to override any bock specific setting of a parent block or
 	// the site root.
-	$variables_root_selector = ',[class*="wp-block"]';
+	$variables_root_selector = '*,[class*="wp-block"]';
 	$registry                = WP_Block_Type_Registry::get_instance();
 	$blocks                  = $registry->get_all_registered();
 	foreach ( $blocks as $block_type ) {
@@ -107,7 +107,7 @@ function _gutenberg_add_block_level_preset_styles( $pre_render, $block ) {
 			$variables_root_selector .= ',' . $block_type->supports['__experimentalSelector'];
 		}
 	}
-	$variables_root_selector = WP_Theme_JSON_6_1::scope_selector( $variables_root_selector, $class_name );
+	$variables_root_selector = WP_Theme_JSON_6_1::scope_selector( $class_name, $variables_root_selector );
 
 	// Remove any potentially unsafe styles.
 	$theme_json_shape  = WP_Theme_JSON_Gutenberg::remove_insecure_properties(
@@ -125,7 +125,7 @@ function _gutenberg_add_block_level_preset_styles( $pre_render, $block ) {
 		array( 'variables' ),
 		null,
 		array(
-			'root_selector' => $variables_root_selector . ',' . $class_name . ' *',
+			'root_selector' => $variables_root_selector,
 			'scope'         => $class_name,
 		)
 	);

--- a/lib/block-supports/settings.php
+++ b/lib/block-supports/settings.php
@@ -1,0 +1,151 @@
+<?php
+/**
+ * Block level presets support.
+ *
+ * @package gutenberg
+ */
+
+/**
+ * Get the class name used on block level presets.
+ *
+ * @access private
+ *
+ * @param array $block Block object.
+ * @return string      The unique class name.
+ */
+function _gutenberg_get_presets_class_name( $block ) {
+	return 'wp-settings-' . md5( serialize( $block ) );
+}
+
+/**
+ * Update the block content with block level presets class name.
+ *
+ * @access private
+ *
+ * @param  string $block_content Rendered block content.
+ * @param  array  $block         Block object.
+ * @return string                Filtered block content.
+ */
+function _gutenberg_add_block_level_presets_class( $block_content, $block ) {
+	if ( ! $block_content ) {
+		return $block_content;
+	}
+
+	// return early if the block doesn't have support for settings.
+	$block_type = WP_Block_Type_Registry::get_instance()->get_registered( $block['blockName'] );
+	if ( ! block_has_support( $block_type, array( '__experimentalSettings' ), false ) ) {
+		return $block_content;
+	}
+
+	// return early if no settings are found on the block attributes.
+	$block_settings = _wp_array_get( $block, array( 'attrs', 'settings' ), null );
+	if ( empty( $block_settings ) ) {
+		return $block_content;
+	}
+
+	$class_name = _gutenberg_get_presets_class_name( $block );
+
+	// Like the layout hook this assumes the hook only applies to blocks with a single wrapper.
+	// Retrieve the opening tag of the first HTML element.
+	$html_element_matches = array();
+	preg_match( '/<[^>]+>/', $block_content, $html_element_matches, PREG_OFFSET_CAPTURE );
+	$first_element = $html_element_matches[0][0];
+	// If the first HTML element has a class attribute just add the new class
+	// as we do on layout and duotone.
+	if ( strpos( $first_element, 'class="' ) !== false ) {
+		$content = preg_replace(
+			'/' . preg_quote( 'class="', '/' ) . '/',
+			'class="' . $class_name . ' ',
+			$block_content,
+			1
+		);
+	} else {
+		// If the first HTML element has no class attribute we should inject the attribute before the attribute at the end.
+		$first_element_offset = $html_element_matches[0][1];
+		$content              = substr_replace( $block_content, ' class="' . $class_name . '"', $first_element_offset + strlen( $first_element ) - 1, 0 );
+	}
+
+	return $content;
+}
+
+/**
+ * Render the block level presets stylesheet.
+ *
+ * @access private
+ *
+ * @param string|null $pre_render   The pre-rendered content. Default null.
+ * @param array       $block The block being rendered.
+ *
+ * @return null
+ */
+function _gutenberg_add_block_level_preset_styles( $pre_render, $block ) {
+	// Return early if the block has not support for descendent block styles.
+	$block_type = WP_Block_Type_Registry::get_instance()->get_registered( $block['blockName'] );
+	if ( ! block_has_support( $block_type, array( '__experimentalSettings' ), false ) ) {
+		return null;
+	}
+
+	// return early if no settings are found on the block attributes.
+	$block_settings = _wp_array_get( $block, array( 'attrs', 'settings' ), null );
+	if ( empty( $block_settings ) ) {
+		return null;
+	}
+
+	$class_name = '.' . _gutenberg_get_presets_class_name( $block );
+
+	// the root selector for preset variables needs to target every possible block selector
+	// in order for the general setting to override any bock specific setting of a parent block or
+	// the site root.
+	$variables_root_selector = ',[class*="wp-block"]';
+	$registry                = WP_Block_Type_Registry::get_instance();
+	$blocks                  = $registry->get_all_registered();
+	foreach ( $blocks as $block_type ) {
+		if (
+			isset( $block_type->supports['__experimentalSelector'] ) &&
+			is_string( $block_type->supports['__experimentalSelector'] )
+		) {
+			$variables_root_selector .= ',' . $block_type->supports['__experimentalSelector'];
+		}
+	}
+	$variables_root_selector = WP_Theme_JSON_6_1::scope_selector( $variables_root_selector, $class_name );
+
+	// Remove any potentially unsafe styles.
+	$theme_json_shape  = WP_Theme_JSON_Gutenberg::remove_insecure_properties(
+		array(
+			'version'  => WP_Theme_JSON_Gutenberg::LATEST_SCHEMA,
+			'settings' => $block_settings,
+		)
+	);
+	$theme_json_object = new WP_Theme_JSON_Gutenberg( $theme_json_shape );
+
+	$styles = '';
+
+	// include preset css variables declaration on the stylesheet.
+	$styles .= $theme_json_object->get_stylesheet(
+		array( 'variables' ),
+		null,
+		array(
+			'root_selector' => $variables_root_selector . ',' . $class_name . ' *',
+			'scope'         => $class_name,
+		)
+	);
+
+	// include preset css classes on the the stylesheet.
+	$styles .= $theme_json_object->get_stylesheet(
+		array( 'presets' ),
+		null,
+		array(
+			'root_selector' => $class_name . ',' . $class_name . ' *',
+			'scope'         => $class_name,
+		)
+	);
+
+	if ( ! empty( $styles ) ) {
+		gutenberg_enqueue_block_support_styles( $styles );
+	}
+
+	return null;
+}
+
+add_filter( 'render_block', '_gutenberg_add_block_level_presets_class', 10, 2 );
+add_filter( 'pre_render_block', '_gutenberg_add_block_level_preset_styles', 10, 2 );

--- a/lib/compat/wordpress-6.1/class-wp-theme-json-6-1.php
+++ b/lib/compat/wordpress-6.1/class-wp-theme-json-6-1.php
@@ -445,7 +445,7 @@ class WP_Theme_JSON_6_1 extends WP_Theme_JSON_6_0 {
 				static::$blocks_metadata[ $block_name ]['features'] = $features;
 			}
 
-			// Assign defaults, then overwrite those that the block sets by itself.
+			// Assign defaults, then override those that the block sets by itself.
 			// If the block selector is compounded, will append the element to each
 			// individual block selector.
 			$block_selectors = explode( ',', static::$blocks_metadata[ $block_name ]['selector'] );
@@ -625,9 +625,12 @@ class WP_Theme_JSON_6_1 extends WP_Theme_JSON_6_0 {
 	 *                         'styles': only the styles section in theme.json.
 	 *                         'presets': only the classes for the presets.
 	 * @param array $origins A list of origins to include. By default it includes VALID_ORIGINS.
+	 * @param array $options An array of options for now used for internal purposes only (may change without notice).
+	 *                       The options currently supported are 'scope' that makes sure all style are scoped to a given selector,
+	 *                       and root_selector which overwrites and forces a given selector to be used on the root node.
 	 * @return string Stylesheet.
 	 */
-	public function get_stylesheet( $types = array( 'variables', 'styles', 'presets' ), $origins = null ) {
+	public function get_stylesheet( $types = array( 'variables', 'styles', 'presets' ), $origins = null, $options = array() ) {
 		if ( null === $origins ) {
 			$origins = static::VALID_ORIGINS;
 		}
@@ -648,6 +651,27 @@ class WP_Theme_JSON_6_1 extends WP_Theme_JSON_6_0 {
 		$style_nodes     = static::get_style_nodes( $this->theme_json, $blocks_metadata );
 		$setting_nodes   = static::get_setting_nodes( $this->theme_json, $blocks_metadata );
 
+		$root_style_key    = array_search( static::ROOT_BLOCK_SELECTOR, array_column( $style_nodes, 'selector' ), true );
+		$root_settings_key = array_search( static::ROOT_BLOCK_SELECTOR, array_column( $setting_nodes, 'selector' ), true );
+
+		if ( ! empty( $options['scope'] ) ) {
+			foreach ( $setting_nodes as &$node ) {
+				$node['selector'] = static::scope_selector( $options['scope'], $node['selector'] );
+			}
+			foreach ( $style_nodes as &$node ) {
+				$node['selector'] = static::scope_selector( $options['scope'], $node['selector'] );
+			}
+		}
+
+		if ( ! empty( $options['root_selector'] ) ) {
+			if ( false !== $root_settings_key ) {
+				$setting_nodes[ $root_settings_key ]['selector'] = $options['root_selector'];
+			}
+			if ( false !== $root_style_key ) {
+				$setting_nodes[ $root_style_key ]['selector'] = $options['root_selector'];
+			}
+		}
+
 		$stylesheet = '';
 
 		if ( in_array( 'variables', $types, true ) ) {
@@ -655,23 +679,30 @@ class WP_Theme_JSON_6_1 extends WP_Theme_JSON_6_0 {
 		}
 
 		if ( in_array( 'styles', $types, true ) ) {
-			$root_block_key = array_search( static::ROOT_BLOCK_SELECTOR, array_column( $style_nodes, 'selector' ), true );
-
-			if ( false !== $root_block_key ) {
-				$stylesheet .= $this->get_root_layout_rules( static::ROOT_BLOCK_SELECTOR, $style_nodes[ $root_block_key ] );
+			if ( false !== $root_style_key ) {
+				$stylesheet .= $this->get_root_layout_rules( $style_nodes[ $root_style_key ]['selector'], $style_nodes[ $root_style_key ] );
 			}
 			$stylesheet .= $this->get_block_classes( $style_nodes );
 		} elseif ( in_array( 'base-layout-styles', $types, true ) ) {
+			$root_selector    = static::ROOT_BLOCK_SELECTOR;
+			$columns_selector = '.wp-block-columns';
+			if ( ! empty( $options['scope'] ) ) {
+				$root_selector = $options['root_selector'];
+			}
+			if ( ! empty( $options['scope'] ) ) {
+				$root_selector    = static::scope_selector( $options['scope'], $root_selector );
+				$columns_selector = static::scope_selector( $options['scope'], $columns_selector );
+			}
 			// Base layout styles are provided as part of `styles`, so only output separately if explicitly requested.
 			// For backwards compatibility, the Columns block is explicitly included, to support a different default gap value.
 			$base_styles_nodes = array(
 				array(
 					'path'     => array( 'styles' ),
-					'selector' => static::ROOT_BLOCK_SELECTOR,
+					'selector' => $root_selector,
 				),
 				array(
 					'path'     => array( 'styles', 'blocks', 'core/columns' ),
-					'selector' => '.wp-block-columns',
+					'selector' => $columns_selector,
 					'name'     => 'core/columns',
 				),
 			);
@@ -1516,4 +1547,50 @@ class WP_Theme_JSON_6_1 extends WP_Theme_JSON_6_0 {
 		}
 		return $block_rules;
 	}
+
+	/**
+	 * Function that scopes a selector with another one. This works a bit like
+	 * SCSS nesting except the `&` operator isn't supported.
+	 *
+	 * <code>
+	 * $scope = '.a, .b .c';
+	 * $selector = '> .x, .y';
+	 * $merged = scope_selector( $scope, $selector );
+	 * // $merged is '.a > .x, .a .y, .b .c > .x, .b .c .y'
+	 * </code>
+	 *
+	 * @since 5.9.0
+	 *
+	 * @param string $scope    Selector to scope to.
+	 * @param string $selector Original selector.
+	 * @return string Scoped selector.
+	 */
+	public static function scope_selector( $scope, $selector ) {
+		$scopes    = explode( ',', $scope );
+		$selectors = explode( ',', $selector );
+
+		$selectors_scoped = array();
+		foreach ( $scopes as $outer ) {
+			foreach ( $selectors as $inner ) {
+				$outer = trim( $outer );
+				$inner = trim( $inner );
+				if ( empty( $outer ) ) {
+					if ( empty( $inner ) ) {
+						continue;
+					}
+					$selectors_scoped[] = $inner;
+				} else {
+					if ( empty( $inner ) ) {
+						$selectors_scoped[] = $outer;
+					} else {
+						$selectors_scoped[] = $outer . ' ' . $inner;
+					}
+				}
+			}
+		}
+
+		$result = implode( ', ', $selectors_scoped );
+		return $result;
+	}
+
 }

--- a/lib/compat/wordpress-6.1/class-wp-theme-json-6-1.php
+++ b/lib/compat/wordpress-6.1/class-wp-theme-json-6-1.php
@@ -687,11 +687,11 @@ class WP_Theme_JSON_6_1 extends WP_Theme_JSON_6_0 {
 			$root_selector    = static::ROOT_BLOCK_SELECTOR;
 			$columns_selector = '.wp-block-columns';
 			if ( ! empty( $options['scope'] ) ) {
-				$root_selector = $options['root_selector'];
-			}
-			if ( ! empty( $options['scope'] ) ) {
 				$root_selector    = static::scope_selector( $options['scope'], $root_selector );
 				$columns_selector = static::scope_selector( $options['scope'], $columns_selector );
+			}
+			if ( ! empty( $options['root_selector'] ) ) {
+				$root_selector = $options['root_selector'];
 			}
 			// Base layout styles are provided as part of `styles`, so only output separately if explicitly requested.
 			// For backwards compatibility, the Columns block is explicitly included, to support a different default gap value.
@@ -1574,17 +1574,12 @@ class WP_Theme_JSON_6_1 extends WP_Theme_JSON_6_0 {
 			foreach ( $selectors as $inner ) {
 				$outer = trim( $outer );
 				$inner = trim( $inner );
-				if ( empty( $outer ) ) {
-					if ( empty( $inner ) ) {
-						continue;
-					}
+				if ( ! empty( $outer ) && ! empty( $inner ) ) {
+					$selectors_scoped[] = $outer . ' ' . $inner;
+				} elseif ( empty( $outer ) ) {
 					$selectors_scoped[] = $inner;
-				} else {
-					if ( empty( $inner ) ) {
-						$selectors_scoped[] = $outer;
-					} else {
-						$selectors_scoped[] = $outer . ' ' . $inner;
-					}
+				} elseif ( empty( $inner ) ) {
+					$selectors_scoped[] = $outer;
 				}
 			}
 		}

--- a/lib/load.php
+++ b/lib/load.php
@@ -126,6 +126,7 @@ if ( is_dir( __DIR__ . '/../build/style-engine' ) ) {
 
 // Block supports overrides.
 require __DIR__ . '/block-supports/utils.php';
+require __DIR__ . '/block-supports/settings.php';
 require __DIR__ . '/block-supports/elements.php';
 require __DIR__ . '/block-supports/colors.php';
 require __DIR__ . '/block-supports/typography.php';


### PR DESCRIPTION
Part of https://github.com/WordPress/gutenberg/issues/40318.

This PR allows a block to define the preset settings of its nested blocks using the same shape as theme.json.


Continuation of https://github.com/WordPress/gutenberg/pull/40547.

## Shape

```
<!-- wp:group {"settings":{"blocks":{"core/button":{"color":{"palette":{"custom":[{"slug":"button-red","color":"red","name":"button red"},{"slug":"button-blue","color":"blue","name":"button blue"}]}}}},"color":{"palette":{"custom":[{"slug":"global-aquamarine","color":"aquamarine","name":"Global aquamarine"},{"slug":"global-pink","color":"pink","name":"Global Pink"}]}}}} -->
<div class="wp-block-group"><!-- wp:paragraph -->
<p>Leaf paragraph of inner group block.</p>
<!-- /wp:paragraph -->

<!-- wp:buttons -->
<div class="wp-block-buttons"><!-- wp:button {"backgroundColor":"button-blue"} -->
<div class="wp-block-button"><a class="wp-block-button__link has-button-blue-background-color has-background wp-element-button">blue</a></div>
<!-- /wp:button -->

<!-- wp:button {"backgroundColor":"button-red"} -->
<div class="wp-block-button"><a class="wp-block-button__link has-button-red-background-color has-background wp-element-button">red</a></div>
<!-- /wp:button --></div>
<!-- /wp:buttons -->

<!-- wp:paragraph {"backgroundColor":"global-aquamarine"} -->
<p class="has-global-aquamarine-background-color has-background">global-aquamarine</p>
<!-- /wp:paragraph -->

<!-- wp:paragraph {"backgroundColor":"global-pink"} -->
<p class="has-global-pink-background-color has-background">global-pink</p>
<!-- /wp:paragraph --></div>
<!-- /wp:group -->
```

### Formatted json:
```
{
   "settings":{
      "blocks":{
         "core/button":{
            "color":{
               "palette":{
                  "custom":[
                     {
                        "slug":"button-red",
                        "color":"red",
                        "name":"button red"
                     },
                     {
                        "slug":"button-blue",
                        "color":"blue",
                        "name":"button blue"
                     }
                  ]
               }
            }
         }
      },
      "color":{
         "palette":{
            "custom":[
               {
                  "slug":"global-aquamarine",
                  "color":"aquamarine",
                  "name":"Global aquamarine"
               },
               {
                  "slug":"global-pink",
                  "color":"pink",
                  "name":"Global Pink"
               }
            ]
         }
      }
   }
}
```

### Engine output

```
.wp-block-level-presets-4884af9a06466a917323943b61ae5826, .wp-block-level-presets-4884af9a06466a917323943b61ae5826 [class*="wp-block"], .wp-block-level-presets-4884af9a06466a917323943b61ae5826 .wp-block-button .wp-block-button__link, .wp-block-level-presets-4884af9a06466a917323943b61ae5826 h1, .wp-block-level-presets-4884af9a06466a917323943b61ae5826 h2, .wp-block-level-presets-4884af9a06466a917323943b61ae5826 h3, .wp-block-level-presets-4884af9a06466a917323943b61ae5826 h4, .wp-block-level-presets-4884af9a06466a917323943b61ae5826 h5, .wp-block-level-presets-4884af9a06466a917323943b61ae5826 h6, .wp-block-level-presets-4884af9a06466a917323943b61ae5826 ol, .wp-block-level-presets-4884af9a06466a917323943b61ae5826 ul, .wp-block-level-presets-4884af9a06466a917323943b61ae5826 p, .wp-block-level-presets-4884af9a06466a917323943b61ae5826 .wp-block-table > table{
    --wp--preset--color--global-aquamarine: aquamarine;
    --wp--preset--color--global-pink: pink;
}
.wp-block-level-presets-4884af9a06466a917323943b61ae5826 .wp-block-button .wp-block-button__link{
    --wp--preset--color--button-red: red;
    --wp--preset--color--button-blue: blue;
}
.wp-block-level-presets-4884af9a06466a917323943b61ae5826.has-global-aquamarine-color,.wp-block-level-presets-4884af9a06466a917323943b61ae5826 *.has-global-aquamarine-color{
    color: var(--wp--preset--color--global-aquamarine) !important;
}
.wp-block-level-presets-4884af9a06466a917323943b61ae5826.has-global-pink-color,.wp-block-level-presets-4884af9a06466a917323943b61ae5826 *.has-global-pink-color{
    color: var(--wp--preset--color--global-pink) !important;
}
.wp-block-level-presets-4884af9a06466a917323943b61ae5826.has-global-aquamarine-background-color,.wp-block-level-presets-4884af9a06466a917323943b61ae5826 *.has-global-aquamarine-background-color{
    background-color: var(--wp--preset--color--global-aquamarine) !important;
}
.wp-block-level-presets-4884af9a06466a917323943b61ae5826.has-global-pink-background-color,.wp-block-level-presets-4884af9a06466a917323943b61ae5826 *.has-global-pink-background-color{
    background-color: var(--wp--preset--color--global-pink) !important;
}
.wp-block-level-presets-4884af9a06466a917323943b61ae5826.has-global-aquamarine-border-color,.wp-block-level-presets-4884af9a06466a917323943b61ae5826 *.has-global-aquamarine-border-color{
    border-color: var(--wp--preset--color--global-aquamarine) !important;
}
.wp-block-level-presets-4884af9a06466a917323943b61ae5826.has-global-pink-border-color,.wp-block-level-presets-4884af9a06466a917323943b61ae5826 *.has-global-pink-border-color{
    border-color: var(--wp--preset--color--global-pink) !important;
}
.wp-block-level-presets-4884af9a06466a917323943b61ae5826 .wp-block-button .wp-block-button__link.has-button-red-color{
    color: var(--wp--preset--color--button-red) !important;
}
.wp-block-level-presets-4884af9a06466a917323943b61ae5826 .wp-block-button .wp-block-button__link.has-button-blue-color{
    color: var(--wp--preset--color--button-blue) !important;
}
.wp-block-level-presets-4884af9a06466a917323943b61ae5826 .wp-block-button .wp-block-button__link.has-button-red-background-color{
    background-color: var(--wp--preset--color--button-red) !important;
}
.wp-block-level-presets-4884af9a06466a917323943b61ae5826 .wp-block-button .wp-block-button__link.has-button-blue-background-color{
    background-color: var(--wp--preset--color--button-blue) !important;
}
.wp-block-level-presets-4884af9a06466a917323943b61ae5826 .wp-block-button .wp-block-button__link.has-button-red-border-color{
    border-color: var(--wp--preset--color--button-red) !important;
}
.wp-block-level-presets-4884af9a06466a917323943b61ae5826 .wp-block-button .wp-block-button__link.has-button-blue-border-color{
    border-color: var(--wp--preset--color--button-blue) !important;
}
  
 
```
## What?
It follows what was defined in https://github.com/WordPress/gutenberg/pull/40547. The presets of a section overwrite everything set on the theme.json, even block-specific presets, so for the global presets of a section, we need to overwrite any block-specific settings as discussed in the other PR, which makes a complex  CSS rule.
It follows the algorithms that were discussed with @oandregal and @youknowriad.


## Testing
I pasted the group block above in the editor and verified the output on the front was the one also shared above and identical to the following screenshot:
![image](https://user-images.githubusercontent.com/11271197/191095929-9dfec7c0-1f92-4026-a808-06e6e1559616.png)

