### PR TITLE
Post Comments Form: Fix warning i18n

### DIFF
--- a/packages/block-library/src/post-comments-form/edit.js
+++ b/packages/block-library/src/post-comments-form/edit.js
@@ -62,13 +62,10 @@ export default function PostCommentsFormEdit( {
 
 	if ( ! isSiteEditor && 'open' !== commentStatus ) {
 		if ( 'closed' === commentStatus ) {
-			warning = sprintf(
-				/* translators: 1: Post type (i.e. "post", "page") */
-				__(
-					'Post Comments Form block: Comments on this %s are not allowed.'
-				),
-				postType
+			warning = __(
+				'Post Comments Form block: Comments are not enabled for this item.'
 			);
+
 			actions = [
 				<Button
 					key="enableComments"
@@ -86,7 +83,7 @@ export default function PostCommentsFormEdit( {
 			warning = sprintf(
 				/* translators: 1: Post type (i.e. "post", "page") */
 				__(
-					'Post Comments Form block: Comments for this post type (%s) are not enabled.'
+					'Post Comments Form block: Comments are not enabled for this post type (%s).'
 				),
 				postType
 			);


### PR DESCRIPTION
## What?
Fix an i18n issue with a warning message in the Post Comments Form block.

## Why?
It was [flagged in Slack](https://wordpress.slack.com/archives/C02QB2JS7/p1656941435092899) the the previous message is problematic to translate into languages with grammatical gender. 

> One of the strings has a problem:
> `Post Comments Form block: Comments on this %s are not allowed.`
> The translators comment reads `1: Post type (i.e. "post", "page")`
> And for Swedish, for instance, the word "this" will have different form, depending on whether this is a post or a page.

## How?
By changing the message to `Post Comments Form block: Comments are not enabled for this item.`

(Note that the message should really only refer to the current post or page (or CPT), _not_ the entire post type, so it shouldn't read `Comments are not enabled for this post type: %s`. We have [separate logic](https://github.com/WordPress/gutenberg/blob/265ed3914e87e420b19c3883837a682f46f9e1a7/packages/block-library/src/post-comments-form/edit.js#L85-L93) for that.)

## Testing Instructions
- Create a new post.
- Open the inspector sidebar for the Post.
- Disable comments for the post. 
![image](https://user-images.githubusercontent.com/96308/172672995-29733e62-d42f-4429-b511-163d8508f007.png)
- Add the Comments block to the post.
- Verify that the warning reads as specified above.

## Screenshots or screencast

![image](https://user-images.githubusercontent.com/96308/177196416-f3cbc0a9-06a2-4d95-b072-3c585339f892.png)
