### PR TITLE
Element styles: adding stylesheet to load in the editor

### DIFF
--- a/packages/block-library/src/editor-elements.scss
+++ b/packages/block-library/src/editor-elements.scss
@@ -1,0 +1,10 @@
+/**
+ * Element styles for the editor
+ */
+.wp-element-button {
+	cursor: revert;
+
+	&[role="textbox"] {
+		cursor: text;
+	}
+}

--- a/packages/block-library/src/editor.scss
+++ b/packages/block-library/src/editor.scss
@@ -52,6 +52,8 @@
 @import "./post-comments/editor.scss";
 @import "./post-comments-form/editor.scss";
 
+@import "./editor-elements.scss";
+
 :root .editor-styles-wrapper {
 	@include background-colors-deprecated();
 	@include foreground-colors-deprecated();


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->
This is a follow-up of these PRs: https://github.com/WordPress/gutenberg/pull/42099 and https://github.com/WordPress/gutenberg/pull/42102.
I'm adding the editor styles for the editor from https://github.com/WordPress/gutenberg/pull/42099 missing in https://github.com/WordPress/gutenberg/pull/42102.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
Because we need a way to specify styles for a wp-element-* class in the editor.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
Adding a `elements-editor.scss` file as stylesheet to specify .wp-element-* styles for the editor.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->

1. Add a search block using the editor
2. Hover the button in the editor with both text and icon options
3. You should see that the cursor is as in the screenshots below.

## Screenshots or screencast <!-- if applicable -->

Editor text:
![image](https://user-images.githubusercontent.com/1310626/176934818-4bed161c-e018-440b-8e69-6d512456a8d4.png)


Editor icon:
![image](https://user-images.githubusercontent.com/1310626/176934892-37e6e257-2d7e-4ddf-b26a-453cbf84732f.png)

