### PR TITLE
ComboboxControl: use custom prefix when generating the instanceId

### DIFF
--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -20,6 +20,10 @@
 
 -   `Popover`: pass missing anchor ref to the `getAnchorRect` callback prop. ([#42076](https://github.com/WordPress/gutenberg/pull/42076))
 
+### Bug Fix
+
+-   `ComboboxControl`: use custom prefix when generating the instanceId ([#42134](https://github.com/WordPress/gutenberg/pull/42134).
+
 ## 19.14.0 (2022-06-29)
 
 ### Bug Fix

--- a/packages/components/src/combobox-control/index.js
+++ b/packages/components/src/combobox-control/index.js
@@ -61,7 +61,10 @@ function ComboboxControl( {
 } ) {
 	const currentOption = options.find( ( option ) => option.value === value );
 	const currentLabel = currentOption?.label ?? '';
-	const instanceId = useInstanceId( ComboboxControl );
+	// Use a custom prefix when generating the `instanceId` to avoid having
+	// duplicate input IDs when rendering this component and `FormTokenField`
+	// in the same page (see https://github.com/WordPress/gutenberg/issues/42112).
+	const instanceId = useInstanceId( ComboboxControl, 'combobox-control' );
 	const [ selectedSuggestion, setSelectedSuggestion ] = useState(
 		currentOption || null
 	);

--- a/packages/components/src/combobox-control/stories/index.js
+++ b/packages/components/src/combobox-control/stories/index.js
@@ -7,7 +7,6 @@ import { useState } from '@wordpress/element';
  * Internal dependencies
  */
 import ComboboxControl from '../';
-import FormTokenField from '../../form-token-field';
 
 const countries = [
 	{ name: 'Afghanistan', code: 'AF' },
@@ -288,39 +287,3 @@ _default.args = {
 	__next36pxDefaultSize: false,
 	allowReset: false,
 };
-
-export function TestDuplicateInstanceIds( args ) {
-	const [ comboboxValue, setComboboxValue ] = useState( null );
-
-	const [ selectedContinents, setSelectedContinents ] = useState( [] );
-
-	return (
-		<>
-			<ComboboxControl
-				{ ...args }
-				value={ comboboxValue }
-				onChange={ setComboboxValue }
-				label="Select a country"
-				options={ countryOptions }
-			/>
-
-			<FormTokenField
-				{ ...args }
-				label="Type a continent"
-				value={ selectedContinents }
-				onChange={ ( tokens ) => setSelectedContinents( tokens ) }
-				suggestions={ [
-					'Africa',
-					'America',
-					'Antarctica',
-					'Asia',
-					'Europe',
-					'Oceania',
-				] }
-			/>
-
-			<p>Value CBB: { comboboxValue }</p>
-			<p>Value FTF: { selectedContinents }</p>
-		</>
-	);
-}

--- a/packages/components/src/combobox-control/stories/index.js
+++ b/packages/components/src/combobox-control/stories/index.js
@@ -7,6 +7,7 @@ import { useState } from '@wordpress/element';
  * Internal dependencies
  */
 import ComboboxControl from '../';
+import FormTokenField from '../../form-token-field';
 
 const countries = [
 	{ name: 'Afghanistan', code: 'AF' },
@@ -287,3 +288,39 @@ _default.args = {
 	__next36pxDefaultSize: false,
 	allowReset: false,
 };
+
+export function TestDuplicateInstanceIds( args ) {
+	const [ comboboxValue, setComboboxValue ] = useState( null );
+
+	const [ selectedContinents, setSelectedContinents ] = useState( [] );
+
+	return (
+		<>
+			<ComboboxControl
+				{ ...args }
+				value={ comboboxValue }
+				onChange={ setComboboxValue }
+				label="Select a country"
+				options={ countryOptions }
+			/>
+
+			<FormTokenField
+				{ ...args }
+				label="Type a continent"
+				value={ selectedContinents }
+				onChange={ ( tokens ) => setSelectedContinents( tokens ) }
+				suggestions={ [
+					'Africa',
+					'America',
+					'Antarctica',
+					'Asia',
+					'Europe',
+					'Oceania',
+				] }
+			/>
+
+			<p>Value CBB: { comboboxValue }</p>
+			<p>Value FTF: { selectedContinents }</p>
+		</>
+	);
+}


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Fixes #42112

Fixes a bug which caused different `input` elements to be assigned the same `id` in case a `ComboboxControl` and a `FormTokenField` components are rendered in the same page and are assigned the same `instanceId`.

I initially wanted to add a unit test for this, but:

- `ComboboxControl` has no unit tests (😱)
- `FormTokenField`'s tests are written with `React.TestUtils` (which I never used before)

...and so, for the sake of landing this fix quickly, I decided to skip unit tests.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

Every ID assigned to an element in a page should be unique — non-unique IDs technically make the page's markup non-valid and can cause severe difficulties to users relying on assistive technology.

See https://github.com/WordPress/gutenberg/issues/42112#issuecomment-1174036360 for a more detailed explanation.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

In order to avoid the `TokenInput` component to receive the same `instanceId` from both `ComboboxControl` and `FormTokenField`, the `ComboboxControl` component now passes a custom `prefix` when calling `useInstanceId`. This means that, while the `id`s received by `FormTokenField` are simple numbers (1, 2, 3..), the `id`s generated for `ComboboxControl` will all be prefixed (i.e. `combobox-control-1`, `combobox-control-2`, `combobox-control-3`...)

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->

Follow the instructions in #42112 's description, the bug should be not reproducible anymore.

Alternatively, I've added a temporary Storybook example:

1. Run `npm run storybook:dev` and visit http://localhost:50240/?path=/story/components-comboboxcontrol--test-duplicate-instance-ids
2. Once on the "Test Duplicate Instance Ids" example, hard-reload the page (this is important to ensure that `ComboboxControl` and `FormTokenField` receive the same `instanceId` internally)
3. Inspect the two `input` elements rendered in the page, assess that they have different `id`s

For completeness, undo the changes to `packages/components/src/combobox-control/index.js` introduced from this PR, repeat the points above, and verify that the bug can be reproduced.

## Screenshots or screencast <!-- if applicable -->

| Before (trunk) | After (this PR) |
|---|---|
| ![image](https://user-images.githubusercontent.com/1083581/177202560-3e892e45-15d1-42e4-bfb1-352293c2a4ed.png) | ![image](https://user-images.githubusercontent.com/1083581/177202580-bc6c544e-4662-4441-8c5d-8854f8aa29e3.png) |