### PR TITLE
Style engine: generate root global styles from global styles object

### DIFF
--- a/lib/compat/wordpress-6.1/class-wp-theme-json-6-1.php
+++ b/lib/compat/wordpress-6.1/class-wp-theme-json-6-1.php
@@ -679,10 +679,12 @@ class WP_Theme_JSON_6_1 extends WP_Theme_JSON_6_0 {
 				Style engine is generating the root styles only.
 				This way we can iteratively introduce it to start generating styles.elements, and styles.blocks.
 			*/
+
 			$block_rules .= gutenberg_style_engine_generate_global_styles(
 				$node,
 				array(
 					'selector' => $selector,
+					'prettify' => defined( 'SCRIPT_DEBUG' ) && SCRIPT_DEBUG,
 				)
 			);
 

--- a/lib/compat/wordpress-6.1/class-wp-theme-json-6-1.php
+++ b/lib/compat/wordpress-6.1/class-wp-theme-json-6-1.php
@@ -673,19 +673,15 @@ class WP_Theme_JSON_6_1 extends WP_Theme_JSON_6_0 {
 			 * user-generated values take precedence in the CSS cascade.
 			 * @link https://github.com/WordPress/gutenberg/issues/36147.
 			 */
-			$block_rules .= 'body { margin: 0; /* reset */ }';
+			$block_rules .= 'body { margin: 0; }';
 
 			/*
 				Style engine is generating the root styles only.
 				This way we can iteratively introduce it to start generating styles.elements, and styles.blocks.
 			*/
-
 			$block_rules .= gutenberg_style_engine_generate_global_styles(
 				$node,
-				array(
-					'selector' => $selector,
-					'prettify' => defined( 'SCRIPT_DEBUG' ) && SCRIPT_DEBUG,
-				)
+				array( 'selector' => $selector )
 			);
 
 		} else {

--- a/packages/style-engine/class-wp-style-engine-css-declarations.php
+++ b/packages/style-engine/class-wp-style-engine-css-declarations.php
@@ -98,7 +98,9 @@ class WP_Style_Engine_CSS_Declarations {
 		$declarations_array  = $this->get_declarations();
 		$declarations_output = '';
 		foreach ( $declarations_array as $property => $value ) {
-			$filtered_declaration = esc_html( safecss_filter_attr( "{$property}: {$value}" ) );
+			//$filtered_declaration = esc_html( safecss_filter_attr( "{$property}: {$value}" ) );
+			// @TODO temporary to allow --wp--style--block-gap through.
+			$filtered_declaration = esc_html( "{$property}: {$value}" );
 			if ( $filtered_declaration ) {
 				$declarations_output .= $filtered_declaration . '; ';
 			}

--- a/packages/style-engine/class-wp-style-engine-css-declarations.php
+++ b/packages/style-engine/class-wp-style-engine-css-declarations.php
@@ -41,22 +41,6 @@ class WP_Style_Engine_CSS_Declarations {
 	}
 
 	/**
-	 * Checks a CSS property string to see whether it is a valid CSS custom property.
-	 * In conjuction with static:sanitize_property it only allows `--wp--${slug}--{$kebab_case_css_property}`.
-	 *
-	 * This explicit checks is required because
-	 * safecss_filter_attr_allow_css filter in safecss_filter_attr (kses.php)
-	 * does not let through CSS custom variables.
-	 *
-	 * @param string $css_property The CSS property.
-	 *
-	 * @return boolean
-	 */
-	protected function is_valid_custom_property( $css_property ) {
-		return 1 === preg_match( '/^--wp--[a-z]+--[a-z0-9-]+$/', $css_property );
-	}
-
-	/**
 	 * Add a single declaration.
 	 *
 	 * @param string $property The CSS property.
@@ -115,11 +99,7 @@ class WP_Style_Engine_CSS_Declarations {
 		$declarations_output = '';
 
 		foreach ( $declarations_array as $property => $value ) {
-			$declaration = "{$property}: {$value}";
-			if ( ! static::is_valid_custom_property( $property ) ) {
-				$declaration = safecss_filter_attr( $declaration );
-			}
-			$filtered_declaration = esc_html( $declaration );
+			$filtered_declaration = esc_html( safecss_filter_attr( "{$property}: {$value}" ) );
 			if ( $filtered_declaration ) {
 				$declarations_output .= $filtered_declaration . '; ';
 			}

--- a/packages/style-engine/class-wp-style-engine-css-declarations.php
+++ b/packages/style-engine/class-wp-style-engine-css-declarations.php
@@ -108,14 +108,9 @@ class WP_Style_Engine_CSS_Declarations {
 	/**
 	 * Filters and compiles the CSS declarations.
 	 *
-	 * @param array $options array(
-	 *     'prettify' => (boolean) Whether to format the output with indents and new lines.
-	 * );.
-	 *
 	 * @return string The CSS declarations.
 	 */
-	public function get_declarations_string( $options ) {
-		$should_prettify     = isset( $options['prettify'] ) ? $options['prettify'] : null;
+	public function get_declarations_string() {
 		$declarations_array  = $this->get_declarations();
 		$declarations_output = '';
 
@@ -126,14 +121,10 @@ class WP_Style_Engine_CSS_Declarations {
 			}
 			$filtered_declaration = esc_html( $declaration );
 			if ( $filtered_declaration ) {
-				if ( $should_prettify ) {
-					$declarations_output .= "\t$filtered_declaration;\n";
-				} else {
-					$declarations_output .= $filtered_declaration . '; ';
-				}
+				$declarations_output .= $filtered_declaration . '; ';
 			}
 		}
-		return rtrim( $declarations_output, ' ' );
+		return rtrim( $declarations_output );
 	}
 
 	/**

--- a/packages/style-engine/class-wp-style-engine.php
+++ b/packages/style-engine/class-wp-style-engine.php
@@ -142,7 +142,7 @@ class WP_Style_Engine {
 			),
 		),
 		'spacing'    => array(
-			'padding'  => array(
+			'padding' => array(
 				'property_keys' => array(
 					'default'    => 'padding',
 					'individual' => 'padding-%s',
@@ -152,17 +152,7 @@ class WP_Style_Engine {
 					'spacing' => '--wp--preset--spacing--$slug',
 				),
 			),
-			'blockGap' => array(
-				'property_keys' => array(
-					// @TODO 'grid-gap' has been deprecated in favor of 'gap'.
-					// See: https://developer.mozilla.org/en-US/docs/Web/CSS/gap.
-					// Update the white list in safecss_filter_attr (kses.php).
-					// See: https://core.trac.wordpress.org/ticket/56122
-					'default' => 'grid-gap',
-				),
-				'path'          => array( 'spacing', 'blockGap' ),
-			),
-			'margin'   => array(
+			'margin'  => array(
 				'property_keys' => array(
 					'default'    => 'margin',
 					'individual' => 'margin-%s',
@@ -374,7 +364,6 @@ class WP_Style_Engine {
 		$css_declarations     = array();
 		$style_property_keys  = $style_definition['property_keys'];
 		$should_skip_css_vars = isset( $options['convert_vars_to_classnames'] ) && true === $options['convert_vars_to_classnames'];
-		$custom_css_property  = isset( $options['custom_properties'] ) && is_array( $options['custom_properties'] ) ? _wp_array_get( $options['custom_properties'], $style_definition['path'], null ) : null;
 
 		// Build CSS var values from var:? values, e.g, `var(--wp--css--rule-slug )`
 		// Check if the value is a CSS preset and there's a corresponding css_var pattern in the style definition.
@@ -382,8 +371,7 @@ class WP_Style_Engine {
 			if ( ! $should_skip_css_vars && ! empty( $style_definition['css_vars'] ) ) {
 				$css_var = static::get_css_var_value( $style_value, $style_definition['css_vars'] );
 				if ( $css_var ) {
-					$css_property                      = $custom_css_property ? $custom_css_property : $style_property_keys['default'];
-					$css_declarations[ $css_property ] = $css_var;
+					$css_declarations[ $style_property_keys['default'] ] = $css_var;
 				}
 			}
 			return $css_declarations;
@@ -397,8 +385,7 @@ class WP_Style_Engine {
 				if ( is_string( $value ) && strpos( $value, 'var:' ) !== false && ! $should_skip_css_vars && ! empty( $style_definition['css_vars'] ) ) {
 					$value = static::get_css_var_value( $value, $style_definition['css_vars'] );
 				}
-				$css_property        = $custom_css_property ? $custom_css_property : $style_property_keys['individual'];
-				$individual_property = sprintf( $css_property, _wp_to_kebab_case( $key ) );
+				$individual_property = sprintf( $style_property_keys['individual'], _wp_to_kebab_case( $key ) );
 
 				// If the style value contains a reference to another value in the tree.
 				if ( isset( $value['ref'] ) ) {
@@ -410,8 +397,7 @@ class WP_Style_Engine {
 				}
 			}
 		} else {
-			$css_property                      = $custom_css_property ? $custom_css_property : $style_property_keys['default'];
-			$css_declarations[ $css_property ] = $style_value;
+			$css_declarations[ $style_property_keys['default'] ] = $style_value;
 		}
 
 		return $css_declarations;
@@ -508,10 +494,7 @@ class WP_Style_Engine {
 
 		// Layer 0: Root.
 		$root_level_options_defaults = array(
-			'selector'          => 'body',
-			'custom_properties' => array(
-				'spacing' => array( 'blockGap' => '--wp--style--block-gap' ),
-			),
+			'selector' => 'body',
 		);
 		$root_level_options          = wp_parse_args( $options, $root_level_options_defaults );
 		$root_level_styles           = $this->get_block_supports_styles(

--- a/packages/style-engine/class-wp-style-engine.php
+++ b/packages/style-engine/class-wp-style-engine.php
@@ -232,16 +232,6 @@ class WP_Style_Engine {
 	);
 
 	/**
-	 * The valid elements that can be found under styles.
-	 *
-	 * @var string[]
-	 */
-	const ELEMENTS = array(
-		'link' => 'a',
-		'h1'   => 'h1',
-	);
-
-	/**
 	 * Utility method to retrieve the main instance of the class.
 	 *
 	 * The instance will be created if it does not exist yet.
@@ -433,7 +423,7 @@ class WP_Style_Engine {
 	 *
 	 * @param array $block_styles Styles from a block's attributes object.
 	 * @param array $options      array(
-	 *     'selector'                   => (string) When a selector is passed, `generate()` will return a full CSS rule `$selector { ...rules }`, otherwise a concatenated string of properties and values.
+	 *     'selector'                   => (string) When a selector is passed, the style engine will return a full CSS rule `$selector { ...rules }`, otherwise a concatenated string of properties and values.
 	 *     'convert_vars_to_classnames' => (boolean) Whether to skip converting CSS var:? values to var( --wp--preset--* ) values. Default is `false`.
 	 * );.
 	 *
@@ -498,13 +488,20 @@ class WP_Style_Engine {
 		return $styles_output;
 	}
 
+	/**
+	 * Returns a stylesheet of CSS rules from a theme.json/global styles object.
+	 *
+	 * @param array $global_styles Styles object from theme.json.
+	 * @param array $options       array(
+	 *     'selector' => (string) When a selector is passed, the style engine will return a full CSS rule `$selector { ...rules }`, otherwise a concatenated string of properties and values.
+	 * );.
+	 *
+	 * @return string A stylesheet.
+	 */
 	public function generate_global_styles( $global_styles, $options ) {
 		if ( empty( $global_styles ) || ! is_array( $global_styles ) ) {
 			return null;
 		}
-
-		// Treat the selector value as the root selector.
-		$css_selector = isset( $options['selector'] ) ? $options['selector'] : 'body';
 
 		// The return stylesheet.
 		$global_stylesheet = '';
@@ -513,15 +510,13 @@ class WP_Style_Engine {
 		$root_level_options_defaults = array(
 			'selector'          => 'body',
 			'custom_properties' => array(
-				'spacing' => array(
-					'blockGap' => '--wp--style--block-gap',
-				),
+				'spacing' => array( 'blockGap' => '--wp--style--block-gap' ),
 			),
 		);
 		$root_level_options          = wp_parse_args( $options, $root_level_options_defaults );
 		$root_level_styles           = $this->get_block_supports_styles(
 			$global_styles,
-			$root_level_options,
+			$root_level_options
 		);
 
 		if ( ! empty( $root_level_styles['css'] ) ) {
@@ -622,7 +617,22 @@ function wp_style_engine_get_block_supports_styles( $block_styles, $options = ar
 	return null;
 }
 
-
+/**
+ * Global public interface method to WP_Style_Engine->generate_global_styles to generate a stylesheet styles from a single theme.json style object.
+ * See: https://developer.wordpress.org/block-editor/reference-guides/theme-json-reference/theme-json-living/#styles
+ *
+ * Example usage:
+ *
+ * $styles = wp_style_engine_generate_global_styles( array( 'color' => array( 'text' => '#cccccc' ) ) );
+ * // Returns `body { color: #cccccc }`.
+ *
+ * @access public
+ *
+ * @param array         $global_styles The value of a block's attributes.style.
+ * @param array<string> $options      An array of options to determine the output.
+ *
+ * @return string A stylesheet.
+ */
 function wp_style_engine_generate_global_styles( $global_styles, $options = array() ) {
 	if ( class_exists( 'WP_Style_Engine' ) ) {
 		$style_engine = WP_Style_Engine::get_instance();

--- a/packages/style-engine/class-wp-style-engine.php
+++ b/packages/style-engine/class-wp-style-engine.php
@@ -414,6 +414,7 @@ class WP_Style_Engine {
 	 * @param array $options      array(
 	 *     'selector'                   => (string) When a selector is passed, `generate()` will return a full CSS rule `$selector { ...rules }`, otherwise a concatenated string of properties and values.
 	 *     'convert_vars_to_classnames' => (boolean) Whether to skip converting CSS var:? values to var( --wp--preset--* ) values. Default is `false`.
+	 *     'prettify'                   => (boolean) Whether to format the output with indents and new lines.
 	 * );.
 	 *
 	 * @return array|null array(
@@ -447,12 +448,13 @@ class WP_Style_Engine {
 		}
 
 		// Build CSS rules output.
-		$css_selector = isset( $options['selector'] ) ? $options['selector'] : null;
-		$style_rules  = new WP_Style_Engine_CSS_Declarations( $css_declarations );
+		$css_selector    = isset( $options['selector'] ) ? $options['selector'] : null;
+		$should_prettify = isset( $options['prettify'] ) ? $options['prettify'] : null;
+		$style_rules     = new WP_Style_Engine_CSS_Declarations( $css_declarations );
 
 		// The return object.
 		$styles_output = array();
-		$css           = $style_rules->get_declarations_string();
+		$css           = $style_rules->get_declarations_string( array( 'prettify' => $should_prettify ) );
 
 		// Return css, if any.
 		if ( ! empty( $css ) ) {
@@ -460,7 +462,11 @@ class WP_Style_Engine {
 			$styles_output['declarations'] = $style_rules->get_declarations();
 			// Return an entire rule if there is a selector.
 			if ( $css_selector ) {
-				$styles_output['css'] = $css_selector . ' { ' . $css . ' }';
+				if ( $should_prettify ) {
+					$styles_output['css'] = $css_selector . ' {' . "\n" . $css . '}' . "\n";
+				} else {
+					$styles_output['css'] = $css_selector . ' { ' . $css . ' }';
+				}
 			}
 		}
 
@@ -484,48 +490,28 @@ class WP_Style_Engine {
 		$global_stylesheet = '';
 
 		// Layer 0: Root.
-		$root_level_styles = $this->get_block_supports_styles(
-			$global_styles,
-			array(
-				'selector'          => $css_selector,
-				'custom_properties' => array(
-					'spacing' => array(
-						'blockGap' => '--wp--style--block-gap',
-					),
+		$root_level_options_defaults = array(
+			'selector'          => 'body',
+			'custom_properties' => array(
+				'spacing' => array(
+					'blockGap' => '--wp--style--block-gap',
 				),
 			),
+		);
+		$root_level_options          = wp_parse_args( $options, $root_level_options_defaults );
+		$root_level_styles           = $this->get_block_supports_styles(
+			$global_styles,
+			$root_level_options,
 		);
 
 		if ( ! empty( $root_level_styles['css'] ) ) {
 			$global_stylesheet .= $root_level_styles['css'] . ' ';
 		}
 
-		/*
-		// Layer 1: Elements.
-		if ( isset( $global_styles['elements'] ) && is_array( $global_styles['elements'] ) ) {
-			foreach ( $global_styles['elements'] as $element_name => $element_styles ) {
-				$selector = isset( static::ELEMENTS[ $element_name ] ) ? static::ELEMENTS[ $element_name ] : null;
-				if ( ! $selector ) {
-					continue;
-				}
-				$element_level_styles = $this->get_block_supports_styles( $element_styles, array( 'selector' => $selector ) );
-				if ( ! empty( $element_level_styles['css'] ) ) {
-					$global_stylesheet .= $element_level_styles['css'] . ' ';
-				}
-			}
-		}
+		// @TODO Layer 1: Elements.
 
-		// Layer 2: Blocks.
-		if ( isset( $global_styles['blocks'] ) && is_array( $global_styles['blocks'] ) ) {
-			foreach ( $global_styles['blocks'] as $block_name => $block_styles ) {
-				$selector           = '.wp-block-' . str_replace( '/', '-', str_replace( 'core/', '', $block_name ) );
-				$block_level_styles = $this->get_block_supports_styles( $block_styles, array( 'selector' => $selector ) );
-				if ( ! empty( $block_level_styles['css'] ) ) {
-					$global_stylesheet .= $block_level_styles['css'] . ' ';
-				}
-			}
-		}
-		*/
+		// @TODO Layer 2: Blocks.
+
 		if ( ! empty( $global_stylesheet ) ) {
 			return rtrim( $global_stylesheet );
 		}

--- a/packages/style-engine/phpunit/class-wp-style-engine-test.php
+++ b/packages/style-engine/phpunit/class-wp-style-engine-test.php
@@ -488,8 +488,7 @@ class WP_Style_Engine_Test extends WP_UnitTestCase {
 						'background' => 'var(--wp--preset--color--background)',
 					),
 					'spacing'    => array(
-						'blockGap' => '2rem',
-						'padding'  => array(
+						'padding' => array(
 							'top'    => '10%',
 							'right'  => '20%',
 							'bottom' => '10%',
@@ -503,7 +502,7 @@ class WP_Style_Engine_Test extends WP_UnitTestCase {
 					),
 				),
 				'options'         => null,
-				'expected_output' => 'body { color: var(--wp--preset--color--foreground); background-color: var(--wp--preset--color--background); padding-top: 10%; padding-right: 20%; padding-bottom: 10%; padding-left: 20%; --wp--style--block-gap: 2rem; font-size: 1rem; font-family: var(--wp--preset--font-family--system-font); line-height: 2; }',
+				'expected_output' => 'body { color: var(--wp--preset--color--foreground); background-color: var(--wp--preset--color--background); padding-top: 10%; padding-right: 20%; padding-bottom: 10%; padding-left: 20%; font-size: 1rem; font-family: var(--wp--preset--font-family--system-font); line-height: 2; }',
 			),
 			'compiles_with_ref_pointers'               => array(
 				'global_styles'   => array(
@@ -512,11 +511,11 @@ class WP_Style_Engine_Test extends WP_UnitTestCase {
 						'text'       => array( 'ref' => 'styles.color.background' ),
 					),
 					'spacing' => array(
-						'blockGap' => '2rem',
-						'padding'  => array(
-							'top'    => array( 'ref' => 'styles.spacing.blockGap' ),
+						'margin'  => '2rem',
+						'padding' => array(
+							'top'    => array( 'ref' => 'styles.spacing.margin' ),
 							'right'  => '20%',
-							'bottom' => array( 'ref' => 'styles.spacing.blockGap' ),
+							'bottom' => array( 'ref' => 'styles.spacing.margin' ),
 							'left'   => '20%',
 						),
 					),
@@ -528,7 +527,7 @@ class WP_Style_Engine_Test extends WP_UnitTestCase {
 					),
 				),
 				'options'         => null,
-				'expected_output' => 'body { color: #ffffff; background-color: #ffffff; border-top-width: 20%; border-top-style: dashed; padding-top: 2rem; padding-right: 20%; padding-bottom: 2rem; padding-left: 20%; --wp--style--block-gap: 2rem; }',
+				'expected_output' => 'body { color: #ffffff; background-color: #ffffff; border-top-width: 20%; border-top-style: dashed; padding-top: 2rem; padding-right: 20%; padding-bottom: 2rem; padding-left: 20%; margin: 2rem; }',
 			),
 			'ignores_other_top_level_keys'             => array(
 				'global_styles'   => array(

--- a/packages/style-engine/phpunit/class-wp-style-engine-test.php
+++ b/packages/style-engine/phpunit/class-wp-style-engine-test.php
@@ -476,12 +476,12 @@ class WP_Style_Engine_Test extends WP_UnitTestCase {
 	 */
 	public function data_generate_global_styles_fixtures() {
 		return array(
-			'default_return_value'                         => array(
+			'default_return_value'                     => array(
 				'global_styles'   => array(),
 				'options'         => null,
 				'expected_output' => null,
 			),
-			'default_return_valid_top_level_css_rules'     => array(
+			'default_return_valid_top_level_css_rules' => array(
 				'global_styles'   => array(
 					'color'      => array(
 						'text'       => 'var(--wp--preset--color--foreground)',
@@ -503,12 +503,58 @@ class WP_Style_Engine_Test extends WP_UnitTestCase {
 					),
 				),
 				'options'         => null,
-				'expected_output' => 'body { color: var(--wp--preset--color--foreground); background-color: var(--wp--preset--color--background); padding-top: 10%; padding-right: 20%; padding-bottom: 10%; padding-left: 20%; font-size: 1rem; font-family: var(--wp--preset--font-family--system-font); line-height: 2; }',
+				'expected_output' => 'body { color: var(--wp--preset--color--foreground); background-color: var(--wp--preset--color--background); padding-top: 10%; padding-right: 20%; padding-bottom: 10%; padding-left: 20%; --wp--style--block-gap: 2rem; font-size: 1rem; font-family: var(--wp--preset--font-family--system-font); line-height: 2; }',
 			),
-			'default_return_valid_element_level_css_rules' => array(
+			'compiles_with_ref_pointers'               => array(
+				'global_styles'   => array(
+					'color'   => array(
+						'background' => '#ffffff',
+						'text'       => array( 'ref' => 'styles.color.background' ),
+					),
+					'spacing' => array(
+						'blockGap' => '2rem',
+						'padding'  => array(
+							'top'    => array( 'ref' => 'styles.spacing.blockGap' ),
+							'right'  => '20%',
+							'bottom' => array( 'ref' => 'styles.spacing.blockGap' ),
+							'left'   => '20%',
+						),
+					),
+					'border'  => array(
+						'top' => array(
+							'width' => array( 'ref' => 'styles.spacing.padding.left' ),
+							'style' => 'dashed',
+						),
+					),
+				),
+				'options'         => null,
+				'expected_output' => 'body { color: #ffffff; background-color: #ffffff; border-top-width: 20%; border-top-style: dashed; padding-top: 2rem; padding-right: 20%; padding-bottom: 2rem; padding-left: 20%; --wp--style--block-gap: 2rem; }',
+			),
+			'ignores_other_top_level_keys'             => array(
 				'global_styles'   => array(
 					'spacing'  => array(
 						'margin' => '20%',
+					),
+					'blocks'   => array(
+						'core/button'     => array(
+							'border' => array(
+								'radius' => '0',
+							),
+							'color'  => array(
+								'text'       => 'piano-red',
+								'background' => 'muddy-waters',
+							),
+						),
+						'core/site-title' => array(
+							'typography' => array(
+								'fontSize'   => 'clamp(2em, 2vw, 4em)',
+								'fontFamily' => 'Roboto,Oxygen-Sans,Ubuntu,sans-serif',
+								'fontStyle'  => 'italic',
+							),
+							'margin'     => array(
+								'bottom' => '20px',
+							),
+						),
 					),
 					'elements' => array(
 						'h1'   => array(
@@ -534,37 +580,7 @@ class WP_Style_Engine_Test extends WP_UnitTestCase {
 					),
 				),
 				'options'         => null,
-				'expected_output' => 'body { margin: 20%; } h1 { color: #ffffff; background-color: #000000; border-radius: 0; } a { color: var(--wp--preset--color--foreground); font-style: underline; }',
-			),
-			'default_return_valid_block_level_css_rules'   => array(
-				'global_styles'   => array(
-					'spacing' => array(
-						'margin' => '20%',
-					),
-					'blocks'  => array(
-						'core/button'     => array(
-							'border' => array(
-								'radius' => '0',
-							),
-							'color'  => array(
-								'text'       => 'piano-red',
-								'background' => 'muddy-waters',
-							),
-						),
-						'core/site-title' => array(
-							'typography' => array(
-								'fontSize'   => 'clamp(2em, 2vw, 4em)',
-								'fontFamily' => 'Roboto,Oxygen-Sans,Ubuntu,sans-serif',
-								'fontStyle'  => 'italic',
-							),
-							'margin'     => array(
-								'bottom' => '20px',
-							),
-						),
-					),
-				),
-				'options'         => null,
-				'expected_output' => 'body { margin: 20%; } .wp-block-button { color: piano-red; background-color: muddy-waters; border-radius: 0; } .wp-block-site-title { font-family: Roboto,Oxygen-Sans,Ubuntu,sans-serif; font-style: italic; }',
+				'expected_output' => 'body { margin: 20%; }',
 			),
 		);
 	}

--- a/packages/style-engine/phpunit/class-wp-style-engine-test.php
+++ b/packages/style-engine/phpunit/class-wp-style-engine-test.php
@@ -458,4 +458,114 @@ class WP_Style_Engine_Test extends WP_UnitTestCase {
 			),
 		);
 	}
+
+	/**
+	 * Tests generating styles and classnames based on various manifestations of the $global_styles argument.
+	 *
+	 * @dataProvider data_generate_global_styles_fixtures
+	 */
+	public function test_generate_global_styles( $global_styles, $options, $expected_output ) {
+		$generated_styles = wp_style_engine_generate_global_styles( $global_styles, $options );
+		$this->assertSame( $expected_output, $generated_styles );
+	}
+
+	/**
+	 * Data provider.
+	 *
+	 * @return array
+	 */
+	public function data_generate_global_styles_fixtures() {
+		return array(
+			'default_return_value'                         => array(
+				'global_styles'   => array(),
+				'options'         => null,
+				'expected_output' => null,
+			),
+			'default_return_valid_top_level_css_rules'     => array(
+				'global_styles'   => array(
+					'color'      => array(
+						'text'       => 'var(--wp--preset--color--foreground)',
+						'background' => 'var(--wp--preset--color--background)',
+					),
+					'spacing'    => array(
+						'blockGap' => '2rem',
+						'padding'  => array(
+							'top'    => '10%',
+							'right'  => '20%',
+							'bottom' => '10%',
+							'left'   => '20%',
+						),
+					),
+					'typography' => array(
+						'fontFamily' => 'var(--wp--preset--font-family--system-font)',
+						'lineHeight' => 2,
+						'fontSize'   => '1rem',
+					),
+				),
+				'options'         => null,
+				'expected_output' => 'body { color: var(--wp--preset--color--foreground); background-color: var(--wp--preset--color--background); padding-top: 10%; padding-right: 20%; padding-bottom: 10%; padding-left: 20%; font-size: 1rem; font-family: var(--wp--preset--font-family--system-font); line-height: 2; }',
+			),
+			'default_return_valid_element_level_css_rules' => array(
+				'global_styles'   => array(
+					'spacing'  => array(
+						'margin' => '20%',
+					),
+					'elements' => array(
+						'h1'   => array(
+							'border' => array(
+								'radius' => '0',
+							),
+							'color'  => array(
+								'text'       => '#ffffff',
+								'background' => '#000000',
+							),
+						),
+						'link' => array(
+							'typography' => array(
+								'fontStyle' => 'underline',
+							),
+							'margin'     => array(
+								'bottom' => '20px',
+							),
+							'color'      => array(
+								'text' => 'var(--wp--preset--color--foreground)',
+							),
+						),
+					),
+				),
+				'options'         => null,
+				'expected_output' => 'body { margin: 20%; } h1 { color: #ffffff; background-color: #000000; border-radius: 0; } a { color: var(--wp--preset--color--foreground); font-style: underline; }',
+			),
+			'default_return_valid_block_level_css_rules'   => array(
+				'global_styles'   => array(
+					'spacing' => array(
+						'margin' => '20%',
+					),
+					'blocks'  => array(
+						'core/button'     => array(
+							'border' => array(
+								'radius' => '0',
+							),
+							'color'  => array(
+								'text'       => 'piano-red',
+								'background' => 'muddy-waters',
+							),
+						),
+						'core/site-title' => array(
+							'typography' => array(
+								'fontSize'   => 'clamp(2em, 2vw, 4em)',
+								'fontFamily' => 'Roboto,Oxygen-Sans,Ubuntu,sans-serif',
+								'fontStyle'  => 'italic',
+							),
+							'margin'     => array(
+								'bottom' => '20px',
+							),
+						),
+					),
+				),
+				'options'         => null,
+				'expected_output' => 'body { margin: 20%; } .wp-block-button { color: piano-red; background-color: muddy-waters; border-radius: 0; } .wp-block-site-title { font-family: Roboto,Oxygen-Sans,Ubuntu,sans-serif; font-style: italic; }',
+			),
+		);
+	}
 }

--- a/phpunit/class-wp-theme-json-test.php
+++ b/phpunit/class-wp-theme-json-test.php
@@ -526,7 +526,7 @@ class WP_Theme_JSON_Gutenberg_Test extends WP_UnitTestCase {
 			)
 		);
 
-		$expected = 'body { margin: 0; }body{background-color: #ffffff;color: #000000;}.wp-site-blocks > .alignleft { float: left; margin-right: 2em; }.wp-site-blocks > .alignright { float: right; margin-left: 2em; }.wp-site-blocks > .aligncenter { justify-content: center; margin-left: auto; margin-right: auto; }.wp-element-button, .wp-block-button__link{background-color: #000000;color: #ffffff;}';
+		$expected = 'body { margin: 0; }body { color: #000000; background-color: #ffffff; }.wp-site-blocks > .alignleft { float: left; margin-right: 2em; }.wp-site-blocks > .alignright { float: right; margin-left: 2em; }.wp-site-blocks > .aligncenter { justify-content: center; margin-left: auto; margin-right: auto; }.wp-element-button, .wp-block-button__link{background-color: #000000;color: #ffffff;}';
 		$this->assertEquals( $expected, $theme_json->get_stylesheet() );
 	}
 
@@ -558,7 +558,7 @@ class WP_Theme_JSON_Gutenberg_Test extends WP_UnitTestCase {
 			)
 		);
 
-		$expected = 'body { margin: 0; }body{background-color: #ffffff;}.wp-site-blocks > .alignleft { float: left; margin-right: 2em; }.wp-site-blocks > .alignright { float: right; margin-left: 2em; }.wp-site-blocks > .aligncenter { justify-content: center; margin-left: auto; margin-right: auto; }.wp-element-button, .wp-block-button__link{color: #ffffff;}';
+		$expected = 'body { margin: 0; }body { background-color: #ffffff; }.wp-site-blocks > .alignleft { float: left; margin-right: 2em; }.wp-site-blocks > .alignright { float: right; margin-left: 2em; }.wp-site-blocks > .aligncenter { justify-content: center; margin-left: auto; margin-right: auto; }.wp-element-button, .wp-block-button__link{color: #ffffff;}';
 		$this->assertSame( $expected, $theme_json->get_stylesheet() );
 	}
 
@@ -589,7 +589,7 @@ class WP_Theme_JSON_Gutenberg_Test extends WP_UnitTestCase {
 			)
 		);
 
-		$expected = 'body { margin: 0; }body{background-color: #ffffff;color: #ffffff;}.wp-site-blocks > .alignleft { float: left; margin-right: 2em; }.wp-site-blocks > .alignright { float: right; margin-left: 2em; }.wp-site-blocks > .aligncenter { justify-content: center; margin-left: auto; margin-right: auto; }.wp-element-button, .wp-block-button__link{color: #ffffff;}';
+		$expected = 'body { margin: 0; }body { color: #ffffff; background-color: #ffffff; }.wp-site-blocks > .alignleft { float: left; margin-right: 2em; }.wp-site-blocks > .alignright { float: right; margin-left: 2em; }.wp-site-blocks > .aligncenter { justify-content: center; margin-left: auto; margin-right: auto; }.wp-element-button, .wp-block-button__link{color: #ffffff;}';
 		$this->assertEquals( $expected, $theme_json->get_stylesheet() );
 	}
 
@@ -612,7 +612,7 @@ class WP_Theme_JSON_Gutenberg_Test extends WP_UnitTestCase {
 			)
 		);
 
-		$expected = 'body { margin: 0; }body{background-color: #ffffff;}.wp-site-blocks > .alignleft { float: left; margin-right: 2em; }.wp-site-blocks > .alignright { float: right; margin-left: 2em; }.wp-site-blocks > .aligncenter { justify-content: center; margin-left: auto; margin-right: auto; }';
+		$expected = 'body { margin: 0; }body { background-color: #ffffff; }.wp-site-blocks > .alignleft { float: left; margin-right: 2em; }.wp-site-blocks > .alignright { float: right; margin-left: 2em; }.wp-site-blocks > .aligncenter { justify-content: center; margin-left: auto; margin-right: auto; }';
 		$this->assertEquals( $expected, $theme_json->get_stylesheet() );
 	}
 

--- a/test/emptytheme/theme.json
+++ b/test/emptytheme/theme.json
@@ -7,26 +7,5 @@
 			"wideSize": "1100px"
 		}
 	},
-	"styles": {
-		"spacing": {
-			"margin": {
-				"top": "12px"
-			}
-		},
-		"blocks": {
-			"core/columns": {
-				"spacing": {
-					"blockGap": "22px"
-				},
-				"blocks": {
-					"core/social-links": {
-						"spacing": {
-							"blockGap": "55px"
-						}
-					}
-				}
-			}
-		}
-	},
 	"patterns": [ "short-text-surrounded-by-round-images", "partner-logos" ]
 }

--- a/test/emptytheme/theme.json
+++ b/test/emptytheme/theme.json
@@ -7,5 +7,26 @@
 			"wideSize": "1100px"
 		}
 	},
+	"styles": {
+		"spacing": {
+			"margin": {
+				"top": "12px"
+			}
+		},
+		"blocks": {
+			"core/columns": {
+				"spacing": {
+					"blockGap": "22px"
+				},
+				"blocks": {
+					"core/social-links": {
+						"spacing": {
+							"blockGap": "55px"
+						}
+					}
+				}
+			}
+		}
+	},
 	"patterns": [ "short-text-surrounded-by-round-images", "partner-logos" ]
 }


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?

Adding a new method to generate global styles: wp_style_engine_generate_global_styles

Because there are loads of idiosyncrasies in global styles, we're starting with the root layer and will then turn to `style.elements` and `style.blocks`

This PR takes care of:

- the styles directly under `styles` in theme.json
- caters for the property conversion from `blockGap` to `--wp--style--block-gap`
- does a style value lookup where a `ref` value is found (See https://github.com/WordPress/gutenberg/pull/41696)

## Why?

Instead of plugging in the block style generator into WP_Theme_JSON like in https://github.com/WordPress/gutenberg/pull/40955, let's see if we can pass the entire merged global styles object to the style engine to generate a stylesheet.

## How?

The global styles object will generate a stylesheet:

```php
$merged_global_styles = array(
    'spacing'  => array(
        'margin' => '20%',
    ),
    'elements' => array(
        'h1'   => array(
            'border' => array(
                'radius' => '0',
            ),
            'color'  => array(
                'text'       => '#ffffff',
                'background' => '#000000',
            ),
        ),
        'link' => array(
            'typography' => array(
                'fontStyle' => 'underline',
            ),
            'margin'     => array(
                'bottom' => '20px',
            ),
            'color'      => array(
                'text' => 'var(--wp--preset--color--foreground)',
            ),
        ),
    ),
);

echo wp_style_engine_generate_global_styles( $merged_global_styles );
// returns: 
// 'body { margin: 20%; } h1 { color: #ffffff; background-color: #000000; border-radius: 0; } a { color: var(--wp--preset--color--foreground); font-style: underline; }'

```

## Up next

To keep things smaller and more testable, we're focussing on root-level global styles. Elements and blocks styles will be worked on in stages.

For example:

```php
// @TODO Layer 1: Elements.
if ( isset( $global_styles['elements'] ) && is_array( $global_styles['elements'] ) ) {
    foreach ( $global_styles['elements'] as $element_name => $element_styles ) {
        $selector = isset( static::ELEMENTS[ $element_name ] ) ? static::ELEMENTS[ $element_name ] : null;
        if ( ! $selector ) {
            continue;
        }
        $element_level_styles = $this->get_block_supports_styles( $element_styles, array( 'selector' => $selector ) );
        if ( ! empty( $element_level_styles['css'] ) ) {
            $global_stylesheet .= $element_level_styles['css'] . ' ';
        }
    }
}

// @TODO Layer 2: Blocks.
if ( isset( $global_styles['blocks'] ) && is_array( $global_styles['blocks'] ) ) {
    foreach ( $global_styles['blocks'] as $block_name => $block_styles ) {
        $selector           = '.wp-block-' . str_replace( '/', '-', str_replace( 'core/', '', $block_name ) );
        $block_level_styles = $this->get_block_supports_styles( $block_styles, array( 'selector' => $selector ) );
        if ( ! empty( $block_level_styles['css'] ) ) {
            $global_stylesheet .= $block_level_styles['css'] . ' ';
        }
    }
}
```

## Testing Instructions


Create a new post with some layout blocks, or any blocks for that matter.

Style your site using theme.json and/or the site editor global styles tools.


<details>

<summary>Some theme.json inspiration</summary>

```json
{
	"version": 2,
	"settings": {
		"appearanceTools": true,
		"layout": {
			"contentSize": "840px",
			"wideSize": "1100px"
		}
	},
	"styles": {
		"spacing": {
			"blockGap": "44px",
			"margin": {
				"top": "12px"
			},
			"padding": {
				"bottom": { "ref" : "styles.spacing.margin.top" }
			}
		}
	},
	"patterns": [ "short-text-surrounded-by-round-images", "partner-logos" ]
}
```

</details>




The styles should appear in the `body` tag of `global-styles-inline-css` in the HTML. E.g.,

```css
body { padding-bottom: 12px; --wp--style--block-gap: 44px; margin-top: 12px; }
```

### Unit tests
All tests
```bash
npm run test-unit-php
```

Style engine tests
```bash
npm run test-unit-php /var/www/html/wp-content/plugins/gutenberg/packages/style-engine/phpunit/class-wp-style-engine-test.php
```
