### PR TITLE
[WIP] Style engine: split methods to generate css and classnames

### DIFF
--- a/lib/block-supports/border.php
+++ b/lib/block-supports/border.php
@@ -48,9 +48,9 @@ function gutenberg_apply_border_support( $block_type, $block_attributes ) {
 		return array();
 	}
 
-	$sides               = array( 'top', 'right', 'bottom', 'left' );
-	$border_block_styles = array();
-
+	$sides                    = array( 'top', 'right', 'bottom', 'left' );
+	$border_block_styles      = array();
+	$border_block_presets     = array();
 	$has_border_color_support = gutenberg_has_border_feature_support( $block_type, 'color' );
 	$has_border_width_support = gutenberg_has_border_feature_support( $block_type, 'width' );
 
@@ -99,9 +99,8 @@ function gutenberg_apply_border_support( $block_type, $block_attributes ) {
 		$has_border_color_support &&
 		! gutenberg_should_skip_block_supports_serialization( $block_type, '__experimentalBorder', 'color' )
 	) {
-		$preset_border_color          = array_key_exists( 'borderColor', $block_attributes ) ? "var:preset|color|{$block_attributes['borderColor']}" : null;
-		$custom_border_color          = _wp_array_get( $block_attributes, array( 'style', 'border', 'color' ), null );
-		$border_block_styles['color'] = $preset_border_color ? $preset_border_color : $custom_border_color;
+		$border_block_styles['color']  = _wp_array_get( $block_attributes, array( 'style', 'border', 'color' ), null );
+		$border_block_presets['color'] = array_key_exists( 'borderColor', $block_attributes ) ? "var:preset|color|{$block_attributes['borderColor']}" : null;
 	}
 
 	// Generate styles for individual border sides.
@@ -119,14 +118,15 @@ function gutenberg_apply_border_support( $block_type, $block_attributes ) {
 
 	// Collect classes and styles.
 	$attributes = array();
-	$styles     = gutenberg_style_engine_generate( array( 'border' => $border_block_styles ) );
+	$style      = gutenberg_style_engine_generate_css( array( 'border' => $border_block_styles ) );
+	$class      = gutenberg_style_engine_generate_classnames( array( 'border' => $border_block_presets ) );
 
-	if ( ! empty( $styles['classnames'] ) ) {
-		$attributes['class'] = $styles['classnames'];
+	if ( ! empty( $class ) ) {
+		$attributes['class'] = $class;
 	}
 
-	if ( ! empty( $styles['css'] ) ) {
-		$attributes['style'] = $styles['css'];
+	if ( ! empty( $style ) ) {
+		$attributes['style'] = $style;
 	}
 
 	return $attributes;

--- a/lib/block-supports/colors.php
+++ b/lib/block-supports/colors.php
@@ -100,7 +100,12 @@ function gutenberg_apply_colors_support( $block_type, $block_attributes ) {
 	}
 
 	$attributes = array();
-	$style      = gutenberg_style_engine_generate_css( array( 'border' => $color_block_styles ) );
+	$style      = gutenberg_style_engine_generate_css(
+		array( 'border' => $color_block_styles ),
+		array(
+			'skip_css_vars' => true,
+		)
+	);
 	$class      = gutenberg_style_engine_generate_classnames( array( 'border' => $color_block_presets ) );
 
 	if ( ! empty( $style ) ) {

--- a/lib/block-supports/colors.php
+++ b/lib/block-supports/colors.php
@@ -77,39 +77,38 @@ function gutenberg_apply_colors_support( $block_type, $block_attributes ) {
 	$has_background_colors_support = true === $color_support || ( is_array( $color_support ) && _wp_array_get( $color_support, array( 'background' ), true ) );
 	$has_gradients_support         = _wp_array_get( $color_support, array( 'gradients' ), false );
 	$color_block_styles            = array();
+	$color_block_presets           = array();
 
 	// Text colors.
 	// Check support for text colors.
 	if ( $has_text_colors_support && ! gutenberg_should_skip_block_supports_serialization( $block_type, 'color', 'text' ) ) {
-		$preset_text_color          = array_key_exists( 'textColor', $block_attributes ) ? "var:preset|color|{$block_attributes['textColor']}" : null;
-		$custom_text_color          = _wp_array_get( $block_attributes, array( 'style', 'color', 'text' ), null );
-		$color_block_styles['text'] = $preset_text_color ? $preset_text_color : $custom_text_color;
+		$color_block_styles['text']  = _wp_array_get( $block_attributes, array( 'style', 'color', 'text' ), null );
+		$color_block_presets['text'] = array_key_exists( 'textColor', $block_attributes ) ? "var:preset|color|{$block_attributes['textColor']}" : null;
 	}
 
 	// Background colors.
 	if ( $has_background_colors_support && ! gutenberg_should_skip_block_supports_serialization( $block_type, 'color', 'background' ) ) {
-		$preset_background_color          = array_key_exists( 'backgroundColor', $block_attributes ) ? "var:preset|color|{$block_attributes['backgroundColor']}" : null;
-		$custom_background_color          = _wp_array_get( $block_attributes, array( 'style', 'color', 'background' ), null );
-		$color_block_styles['background'] = $preset_background_color ? $preset_background_color : $custom_background_color;
+		$color_block_styles['background']  = _wp_array_get( $block_attributes, array( 'style', 'color', 'background' ), null );
+		$color_block_presets['background'] = array_key_exists( 'backgroundColor', $block_attributes ) ? "var:preset|color|{$block_attributes['backgroundColor']}" : null;
 	}
 
 	// Gradients.
 
 	if ( $has_gradients_support && ! gutenberg_should_skip_block_supports_serialization( $block_type, 'color', 'gradients' ) ) {
-		$preset_gradient_color          = array_key_exists( 'gradient', $block_attributes ) ? "var:preset|gradient|{$block_attributes['gradient']}" : null;
-		$custom_gradient_color          = _wp_array_get( $block_attributes, array( 'style', 'color', 'gradient' ), null );
-		$color_block_styles['gradient'] = $preset_gradient_color ? $preset_gradient_color : $custom_gradient_color;
+		$color_block_styles['gradient']  = _wp_array_get( $block_attributes, array( 'style', 'color', 'gradient' ), null );
+		$color_block_presets['gradient'] = array_key_exists( 'gradient', $block_attributes ) ? "var:preset|gradient|{$block_attributes['gradient']}" : null;
 	}
 
 	$attributes = array();
-	$styles     = gutenberg_style_engine_generate( array( 'color' => $color_block_styles ), array( 'convert_vars_to_classnames' => true ) );
+	$style      = gutenberg_style_engine_generate_css( array( 'border' => $color_block_styles ) );
+	$class      = gutenberg_style_engine_generate_classnames( array( 'border' => $color_block_presets ) );
 
-	if ( ! empty( $styles['classnames'] ) ) {
-		$attributes['class'] = $styles['classnames'];
+	if ( ! empty( $style ) ) {
+		$attributes['style'] = $style;
 	}
 
-	if ( ! empty( $styles['css'] ) ) {
-		$attributes['style'] = $styles['css'];
+	if ( ! empty( $class ) ) {
+		$attributes['class'] = $class;
 	}
 
 	return $attributes;

--- a/lib/block-supports/elements.php
+++ b/lib/block-supports/elements.php
@@ -105,7 +105,7 @@ function gutenberg_render_elements_support_styles( $pre_render, $block ) {
 	$link_block_styles = isset( $element_block_styles['link'] ) ? $element_block_styles['link'] : null;
 
 	if ( $link_block_styles ) {
-		$styles = gutenberg_style_engine_generate(
+		$styles = gutenberg_style_engine_generate_css(
 			$link_block_styles,
 			array(
 				'selector' => ".$class_name a",

--- a/lib/block-supports/spacing.php
+++ b/lib/block-supports/spacing.php
@@ -57,10 +57,12 @@ function gutenberg_apply_spacing_support( $block_type, $block_attributes ) {
 	$spacing_block_styles            = array();
 	$spacing_block_styles['padding'] = $has_padding_support && ! $skip_padding ? _wp_array_get( $block_styles, array( 'spacing', 'padding' ), null ) : null;
 	$spacing_block_styles['margin']  = $has_margin_support && ! $skip_margin ? _wp_array_get( $block_styles, array( 'spacing', 'margin' ), null ) : null;
-	$styles                          = gutenberg_style_engine_generate( array( 'spacing' => $spacing_block_styles ) );
+	$style                           = gutenberg_style_engine_generate_css(
+		array( 'spacing' => $spacing_block_styles ),
+	);
 
-	if ( ! empty( $styles['css'] ) ) {
-		$attributes['style'] = $styles['css'];
+	if ( ! empty( $style ) ) {
+		$attributes['style'] = $style;
 	}
 
 	return $attributes;

--- a/lib/block-supports/typography.php
+++ b/lib/block-supports/typography.php
@@ -98,17 +98,17 @@ function gutenberg_apply_typography_support( $block_type, $block_attributes ) {
 	$should_skip_text_transform  = gutenberg_should_skip_block_supports_serialization( $block_type, 'typography', 'textTransform' );
 	$should_skip_letter_spacing  = gutenberg_should_skip_block_supports_serialization( $block_type, 'typography', 'letterSpacing' );
 
-	$typography_block_styles = array();
+	$typography_block_styles  = array();
+	$typography_block_presets = array();
+
 	if ( $has_font_size_support && ! $should_skip_font_size ) {
-		$preset_font_size                    = array_key_exists( 'fontSize', $block_attributes ) ? "var:preset|font-size|{$block_attributes['fontSize']}" : null;
-		$custom_font_size                    = isset( $block_attributes['style']['typography']['fontSize'] ) ? $block_attributes['style']['typography']['fontSize'] : null;
-		$typography_block_styles['fontSize'] = $preset_font_size ? $preset_font_size : $custom_font_size;
+		$typography_block_styles['fontSize']  = isset( $block_attributes['style']['typography']['fontSize'] ) ? $block_attributes['style']['typography']['fontSize'] : null;
+		$typography_block_presets['fontSize'] = array_key_exists( 'fontSize', $block_attributes ) ? "var:preset|font-size|{$block_attributes['fontSize']}" : null;
 	}
 
 	if ( $has_font_family_support && ! $should_skip_font_family ) {
-		$preset_font_family                    = array_key_exists( 'fontFamily', $block_attributes ) ? "var:preset|font-family|{$block_attributes['fontFamily']}" : null;
-		$custom_font_family                    = isset( $block_attributes['style']['typography']['fontFamily'] ) ? gutenberg_typography_get_preset_inline_style_value( $block_attributes['style']['typography']['fontFamily'], 'font-family' ) : null;
-		$typography_block_styles['fontFamily'] = $preset_font_family ? $preset_font_family : $custom_font_family;
+		$typography_block_styles['fontFamily']  = isset( $block_attributes['style']['typography']['fontFamily'] ) ? $block_attributes['style']['typography']['fontFamily'] : null;
+		$typography_block_presets['fontFamily'] = array_key_exists( 'fontFamily', $block_attributes ) ? "var:preset|font-family|{$block_attributes['fontFamily']}" : null;
 	}
 
 	if ( $has_font_style_support && ! $should_skip_font_style && isset( $block_attributes['style']['typography']['fontStyle'] ) ) {
@@ -141,17 +141,15 @@ function gutenberg_apply_typography_support( $block_type, $block_attributes ) {
 	}
 
 	$attributes = array();
-	$styles     = gutenberg_style_engine_generate(
-		array( 'typography' => $typography_block_styles ),
-		array( 'convert_vars_to_classnames' => true )
-	);
+	$style      = gutenberg_style_engine_generate_css( array( 'border' => $typography_block_styles ) );
+	$class      = gutenberg_style_engine_generate_classnames( array( 'border' => $typography_block_presets ) );
 
-	if ( ! empty( $styles['classnames'] ) ) {
-		$attributes['class'] = $styles['classnames'];
+	if ( ! empty( $style ) ) {
+		$attributes['style'] = $style;
 	}
 
-	if ( ! empty( $styles['css'] ) ) {
-		$attributes['style'] = $styles['css'];
+	if ( ! empty( $class ) ) {
+		$attributes['class'] = $class;
 	}
 
 	return $attributes;

--- a/lib/block-supports/typography.php
+++ b/lib/block-supports/typography.php
@@ -141,7 +141,12 @@ function gutenberg_apply_typography_support( $block_type, $block_attributes ) {
 	}
 
 	$attributes = array();
-	$style      = gutenberg_style_engine_generate_css( array( 'border' => $typography_block_styles ) );
+	$style      = gutenberg_style_engine_generate_css(
+		array( 'border' => $typography_block_styles ),
+		array(
+			'skip_css_vars' => true,
+		)
+	);
 	$class      = gutenberg_style_engine_generate_classnames( array( 'border' => $typography_block_presets ) );
 
 	if ( ! empty( $style ) ) {


### PR DESCRIPTION
🚧 

Maybe we don't actually need this. 

The current generate functions are very block support-specific. Block supports require CSS and classnames. 

Moreover, if we are to generate semantic classnames for block supports in the future, the `array()` return value is already there to accommodate.

It'd save us a loop too 😄 

## What?
Create two methods `wp_style_engine_generate_classnames` and `wp_style_engine_generate_css`, both of which return strings.

This avoids returning `array( 'css' => '', 'classnames' => '' )`, which doesn't apply in all contexts

## Why?

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->

## Screenshots or screencast <!-- if applicable -->
