### PR TITLE
Export BlockPatternsList component to be available as indicated in its documentation.

### DIFF
--- a/packages/block-editor/src/components/index.js
+++ b/packages/block-editor/src/components/index.js
@@ -28,7 +28,7 @@ export { default as BlockNavigationDropdown } from './block-navigation/dropdown'
 export { default as BlockStyles } from './block-styles';
 export { default as __experimentalBlockVariationPicker } from './block-variation-picker';
 export { default as __experimentalBlockPatternSetup } from './block-pattern-setup';
-export { default as BlockPatternsList } from './block-patterns-list';
+export { default as BlockPatternList } from './block-patterns-list';
 export { default as __experimentalBlockVariationTransforms } from './block-variation-transforms';
 export {
 	BlockVerticalAlignmentToolbar,

--- a/packages/block-editor/src/components/index.js
+++ b/packages/block-editor/src/components/index.js
@@ -28,6 +28,7 @@ export { default as BlockNavigationDropdown } from './block-navigation/dropdown'
 export { default as BlockStyles } from './block-styles';
 export { default as __experimentalBlockVariationPicker } from './block-variation-picker';
 export { default as __experimentalBlockPatternSetup } from './block-pattern-setup';
+export { default as BlockPatternsList } from './block-patterns-list';
 export { default as __experimentalBlockVariationTransforms } from './block-variation-transforms';
 export {
 	BlockVerticalAlignmentToolbar,


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Exporting a component in order to be consistent with its documentation.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

The component `BlockPatternList` is not exported, but according to the documentation [here](https://github.com/WordPress/gutenberg/tree/8029f73ff0d4066a5d3fd72fb5a7cff9b6a05b7e/packages/block-editor/src/components/block-patterns-list), it could be used like this:

```
import { BlockPatternList } from '@wordpress/block-editor';

const MyBlockPatternList = () => (
	<BlockPatternList
		blockPatterns={ shownBlockPatterns }
		shownPatterns={ shownBlockPatterns }
		onClickPattern={ onSelectBlockPattern }
	/>
);
```

## How?

My PR exports the `BlockPatternList` component.

## Testing Instructions

Just try to use the component as indicated in the previous code fragment.
