### PR TITLE
Site Editor: Allow clearing template name field while typing

### DIFF
--- a/packages/edit-site/src/components/template-details/edit-template-title.js
+++ b/packages/edit-site/src/components/template-details/edit-template-title.js
@@ -4,8 +4,10 @@
 import { __ } from '@wordpress/i18n';
 import { TextControl } from '@wordpress/components';
 import { useEntityProp } from '@wordpress/core-data';
+import { useState } from '@wordpress/element';
 
 export default function EditTemplateTitle( { template } ) {
+	const [ forceEmpty, setForceEmpty ] = useState( false );
 	const [ title, setTitle ] = useEntityProp(
 		'postType',
 		template.type,
@@ -16,13 +18,19 @@ export default function EditTemplateTitle( { template } ) {
 	return (
 		<TextControl
 			label={ __( 'Title' ) }
-			value={ title }
+			value={ forceEmpty ? '' : title }
 			help={ __(
 				'Give the template a title that indicates its purpose, e.g. "Full Width".'
 			) }
 			onChange={ ( newTitle ) => {
-				setTitle( newTitle || template.slug );
+				if ( ! newTitle && ! forceEmpty ) {
+					setForceEmpty( true );
+					return;
+				}
+				setForceEmpty( false );
+				setTitle( newTitle );
 			} }
+			onBlur={ () => setForceEmpty( false ) }
 		/>
 	);
 }


### PR DESCRIPTION
## What?
Similar to #42065.

PR updates logic in `EditTemplateTitle` to temporarily allow clearing the name field while a user is typing. Previously it would fall back to the template slug.

## Why?
I noticed that Site Editor had the same issue as Template Mode.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

## Testing Instructions
1. Open a custom template in Site Editor.
2. Open the templates details dropdown in the top toolbar.
3. Clear the template name.

## Screenshots or screencast <!-- if applicable -->

https://user-images.githubusercontent.com/240569/177306733-d8ccdfd9-94ff-4845-8cab-f7c246173e7d.mp4
