### PR TITLE
Create Block: Added prompt to continue when minimum system requirements not met

### DIFF
--- a/packages/create-block/CHANGELOG.md
+++ b/packages/create-block/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+### Enhancement
+
 -   Added prompt to continue when minimum system requirements not met ([#42151](https://github.com/WordPress/gutenberg/pull/42151)).
 
 ## 3.3.0 (2022-06-01)

--- a/packages/create-block/CHANGELOG.md
+++ b/packages/create-block/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+-   Added prompt to continue when minimum system requirements not met ([#42151](https://github.com/WordPress/gutenberg/pull/42151)).
+
 ## 3.3.0 (2022-06-01)
 
 ### Enhancement

--- a/packages/create-block/lib/check-system-requirements.js
+++ b/packages/create-block/lib/check-system-requirements.js
@@ -1,6 +1,7 @@
 /**
  * External dependencies
  */
+const inquirer = require( 'inquirer' );
 const checkSync = require( 'check-node-version' );
 const { forEach } = require( 'lodash' );
 const { promisify } = require( 'util' );
@@ -14,20 +15,45 @@ const check = promisify( checkSync );
 
 async function checkSystemRequirements( engines ) {
 	const result = await check( engines );
+
 	if ( ! result.isSatisfied ) {
 		log.error( 'Minimum system requirements not met!' );
 		log.info( '' );
+
 		forEach( result.versions, ( { isSatisfied, wanted }, name ) => {
 			if ( ! isSatisfied ) {
 				log.error(
 					`Error: Wanted ${ name } version ${ wanted.raw } (${ wanted.range })`
 				);
-				log.info(
-					check.PROGRAMS[ name ].getInstallInstructions( wanted.raw )
-				);
 			}
 		} );
-		process.exit( 1 );
+
+		log.info( '' );
+
+		const { yesContinue } = await inquirer.prompt( [
+			{
+				type: 'confirm',
+				name: 'yesContinue',
+				message: 'Are you sure you want to continue anyway?',
+				default: false,
+			},
+		] );
+
+		if ( ! yesContinue ) {
+			log.error( 'Cancelled.' );
+			log.info( '' );
+
+			forEach( result.versions, ( { isSatisfied, wanted }, name ) => {
+				if ( ! isSatisfied ) {
+					log.info(
+						check.PROGRAMS[ name ].getInstallInstructions(
+							wanted.raw
+						)
+					);
+				}
+			} );
+			process.exit( 1 );
+		}
 	}
 }
 

--- a/packages/create-block/lib/check-system-requirements.js
+++ b/packages/create-block/lib/check-system-requirements.js
@@ -3,6 +3,7 @@
  */
 const inquirer = require( 'inquirer' );
 const checkSync = require( 'check-node-version' );
+const tools = require( 'check-node-version/tools' );
 const { forEach } = require( 'lodash' );
 const { promisify } = require( 'util' );
 
@@ -46,9 +47,7 @@ async function checkSystemRequirements( engines ) {
 			forEach( result.versions, ( { isSatisfied, wanted }, name ) => {
 				if ( ! isSatisfied ) {
 					log.info(
-						check.PROGRAMS[ name ].getInstallInstructions(
-							wanted.raw
-						)
+						tools[ name ].getInstallInstructions( wanted.raw )
 					);
 				}
 			} );


### PR DESCRIPTION
Fix: #40403

## What?
This PR adds a prompt in `create-block` to ask whether to continue even if the system requirements are not met.

## Why?
However, as noted in [this comment](https://github.com/WordPress/gutenberg/issues/40403#issuecomment-1110565638), there are some cases where system requirements are not determined correctly in certain environments.

## How?
Added prompt to confirm whether to run the program as is even if system requirements are not met.

## Testing Instructions

- Use the node version control tool to lower the `node` version below `12` or `npm` version below `6.9`.
- `cd ./packages/create-block`
- `node index.js`
- Confirm that an error message is displayed indicating that either npm or node does not meet the system requirements.
-  If you select `no`, confirm that the program exits as before.
- If you select `yes`, make sure that the program will continue to run

## Screenshots or screencast <!-- if applicable -->

https://user-images.githubusercontent.com/54422211/177324687-4b3310b6-1fee-4f47-bd11-f6e5d5373248.mp4
