### PR TITLE
Block Library: Use more clear and inclusive language in comments

### DIFF
--- a/packages/block-library/src/navigation-link/index.js
+++ b/packages/block-library/src/navigation-link/index.js
@@ -88,7 +88,7 @@ export const settings = {
 	transforms,
 };
 
-// importing this file includes side effects. This is allowed in block-library/package.json under sideEffects
+// importing this file includes side effects. This is added in block-library/package.json under sideEffects
 addFilter(
 	'blocks.registerBlockType',
 	'core/navigation-link',

--- a/packages/block-library/src/navigation-link/index.js
+++ b/packages/block-library/src/navigation-link/index.js
@@ -88,7 +88,7 @@ export const settings = {
 	transforms,
 };
 
-// importing this file includes side effects. This is whitelisted in block-library/package.json under sideEffects
+// importing this file includes side effects. This is allowed in block-library/package.json under sideEffects
 addFilter(
 	'blocks.registerBlockType',
 	'core/navigation-link',

--- a/packages/block-library/src/post-terms/index.js
+++ b/packages/block-library/src/post-terms/index.js
@@ -19,7 +19,7 @@ export const settings = {
 	edit,
 };
 
-// Importing this file includes side effects. This is allowed in block-library/package.json under sideEffects
+// Importing this file includes side effects. This is added in block-library/package.json under sideEffects
 addFilter(
 	'blocks.registerBlockType',
 	'core/template-part',

--- a/packages/block-library/src/post-terms/index.js
+++ b/packages/block-library/src/post-terms/index.js
@@ -19,7 +19,7 @@ export const settings = {
 	edit,
 };
 
-// Importing this file includes side effects. This is whitelisted in block-library/package.json under sideEffects
+// Importing this file includes side effects. This is allowed in block-library/package.json under sideEffects
 addFilter(
 	'blocks.registerBlockType',
 	'core/template-part',

--- a/packages/block-library/src/query/index.js
+++ b/packages/block-library/src/query/index.js
@@ -25,6 +25,6 @@ export const settings = {
 	deprecated,
 };
 
-// Importing this file includes side effects and is whitelisted
+// Importing this file includes side effects and is allowed
 // in block-library/package.json under `sideEffects`.
 addFilter( 'editor.BlockEdit', 'core/query', queryInspectorControls );

--- a/packages/block-library/src/query/index.js
+++ b/packages/block-library/src/query/index.js
@@ -25,6 +25,6 @@ export const settings = {
 	deprecated,
 };
 
-// Importing this file includes side effects and is allowed
+// Importing this file includes side effects and is added
 // in block-library/package.json under `sideEffects`.
 addFilter( 'editor.BlockEdit', 'core/query', queryInspectorControls );

--- a/packages/block-library/src/template-part/index.js
+++ b/packages/block-library/src/template-part/index.js
@@ -47,7 +47,7 @@ export const settings = {
 	edit,
 };
 
-// Importing this file includes side effects. This is allowed in block-library/package.json under sideEffects
+// Importing this file includes side effects. This is added in block-library/package.json under sideEffects
 addFilter(
 	'blocks.registerBlockType',
 	'core/template-part',

--- a/packages/block-library/src/template-part/index.js
+++ b/packages/block-library/src/template-part/index.js
@@ -47,7 +47,7 @@ export const settings = {
 	edit,
 };
 
-// Importing this file includes side effects. This is whitelisted in block-library/package.json under sideEffects
+// Importing this file includes side effects. This is allowed in block-library/package.json under sideEffects
 addFilter(
 	'blocks.registerBlockType',
 	'core/template-part',


### PR DESCRIPTION
## What?
Related WP core ticket: https://core.trac.wordpress.org/ticket/50413

PR removes the "whitelist" in favor of more clear and inclusive language.

## Testing Instructions
None. PR only updates code comments.
