### PR TITLE
Lodash: Remove completely from `@wordpress/interface` package

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17413,8 +17413,7 @@
 				"@wordpress/plugins": "file:packages/plugins",
 				"@wordpress/preferences": "file:packages/preferences",
 				"@wordpress/viewport": "file:packages/viewport",
-				"classnames": "^2.3.1",
-				"lodash": "^4.17.21"
+				"classnames": "^2.3.1"
 			}
 		},
 		"@wordpress/is-shallow-equal": {

--- a/packages/interface/package.json
+++ b/packages/interface/package.json
@@ -43,8 +43,7 @@
 		"@wordpress/plugins": "file:../plugins",
 		"@wordpress/preferences": "file:../preferences",
 		"@wordpress/viewport": "file:../viewport",
-		"classnames": "^2.3.1",
-		"lodash": "^4.17.21"
+		"classnames": "^2.3.1"
 	},
 	"peerDependencies": {
 		"react": "^17.0.0",

--- a/packages/interface/src/components/action-item/index.js
+++ b/packages/interface/src/components/action-item/index.js
@@ -1,9 +1,4 @@
 /**
- * External dependencies
- */
-import { isEmpty } from 'lodash';
-
-/**
  * WordPress dependencies
  */
 import { ButtonGroup, Button, Slot, Fill } from '@wordpress/components';
@@ -25,7 +20,7 @@ function ActionItemSlot( {
 			fillProps={ fillProps }
 		>
 			{ ( fills ) => {
-				if ( isEmpty( Children.toArray( fills ) ) ) {
+				if ( ! Children.toArray( fills ).length ) {
 					return null;
 				}
 

--- a/packages/interface/src/components/complementary-area-more-menu-item/index.js
+++ b/packages/interface/src/components/complementary-area-more-menu-item/index.js
@@ -1,9 +1,4 @@
 /**
- * External dependencies
- */
-import { omit } from 'lodash';
-
-/**
  * WordPress dependencies
  */
 import { check } from '@wordpress/icons';
@@ -15,16 +10,15 @@ import { MenuItem } from '@wordpress/components';
 import ComplementaryAreaToggle from '../complementary-area-toggle';
 import ActionItem from '../action-item';
 
-const PluginsMenuItem = ( props ) => (
+const PluginsMenuItem = ( {
+	__unstableExplicitMenuItem,
+	__unstableTarget,
+	...restProps
+} ) => (
 	// Menu item is marked with unstable prop for backward compatibility.
 	// They are removed so they don't leak to DOM elements.
 	// @see https://github.com/WordPress/gutenberg/issues/14457
-	<MenuItem
-		{ ...omit( props, [
-			'__unstableExplicitMenuItem',
-			'__unstableTarget',
-		] ) }
-	/>
+	<MenuItem { ...restProps } />
 );
 
 export default function ComplementaryAreaMoreMenuItem( {

--- a/packages/interface/src/components/complementary-area-more-menu-item/index.js
+++ b/packages/interface/src/components/complementary-area-more-menu-item/index.js
@@ -11,15 +11,13 @@ import ComplementaryAreaToggle from '../complementary-area-toggle';
 import ActionItem from '../action-item';
 
 const PluginsMenuItem = ( {
-	__unstableExplicitMenuItem,
-	__unstableTarget,
-	...restProps
-} ) => (
 	// Menu item is marked with unstable prop for backward compatibility.
 	// They are removed so they don't leak to DOM elements.
 	// @see https://github.com/WordPress/gutenberg/issues/14457
-	<MenuItem { ...restProps } />
-);
+	__unstableExplicitMenuItem,
+	__unstableTarget,
+	...restProps
+} ) => <MenuItem { ...restProps } />;
 
 export default function ComplementaryAreaMoreMenuItem( {
 	scope,

--- a/packages/interface/src/components/complementary-area-toggle/index.js
+++ b/packages/interface/src/components/complementary-area-toggle/index.js
@@ -1,9 +1,4 @@
 /**
- * External dependencies
- */
-import { omit } from 'lodash';
-
-/**
  * WordPress dependencies
  */
 import { Button } from '@wordpress/components';
@@ -21,6 +16,7 @@ function ComplementaryAreaToggle( {
 	identifier,
 	icon,
 	selectedIcon,
+	name,
 	...props
 } ) {
 	const ComponentToUse = as;
@@ -42,7 +38,7 @@ function ComplementaryAreaToggle( {
 					enableComplementaryArea( scope, identifier );
 				}
 			} }
-			{ ...omit( props, [ 'name' ] ) }
+			{ ...props }
 		/>
 	);
 }

--- a/packages/interface/src/components/pinned-items/index.js
+++ b/packages/interface/src/components/pinned-items/index.js
@@ -16,8 +16,7 @@ function PinnedItemsSlot( { scope, className, ...props } ) {
 	return (
 		<Slot name={ `PinnedItems/${ scope }` } { ...props }>
 			{ ( fills ) =>
-				fills &&
-				fills.length && (
+				fills?.length > 0 && (
 					<div
 						className={ classnames(
 							className,

--- a/packages/interface/src/components/pinned-items/index.js
+++ b/packages/interface/src/components/pinned-items/index.js
@@ -1,7 +1,6 @@
 /**
  * External dependencies
  */
-import { isEmpty } from 'lodash';
 import classnames from 'classnames';
 
 /**
@@ -17,7 +16,8 @@ function PinnedItemsSlot( { scope, className, ...props } ) {
 	return (
 		<Slot name={ `PinnedItems/${ scope }` } { ...props }>
 			{ ( fills ) =>
-				! isEmpty( fills ) && (
+				fills &&
+				fills.length && (
 					<div
 						className={ classnames(
 							className,


### PR DESCRIPTION
## What?
This PR removes all of the Lodash from the `@wordpress/interface` package, including the `lodash` dependency altogether. There are just a few usages and conversion is pretty straightforward. 

## Why?

Lodash is known to unnecessarily inflate the bundle size of packages, and in most cases, it can be replaced with native language functionality. See these for more information and rationale:

* https://github.com/WordPress/gutenberg/issues/16938#issuecomment-602837246
* https://github.com/WordPress/gutenberg/issues/17025
* https://github.com/WordPress/gutenberg/issues/39495 

## How?
We're dealing with straightforwardly replacing a few methods, namely:

#### `omit`

We're using destructuring with rest props, which nicely handles the omission.

#### `isEmpty`

Simple enough to replace with `Array.prototype.length`.

## Testing Instructions

Smoke test Nav Sidebar and verify it still works well. 