### PR TITLE
Update versions in WordPress for upcoming 6.0.1 release

### DIFF
--- a/docs/contributors/versions-in-wordpress.md
+++ b/docs/contributors/versions-in-wordpress.md
@@ -6,6 +6,7 @@ If anything looks incorrect here, please bring it up in #core-editor in [WordPre
 
 | Gutenberg Versions | WordPress Version |
 | ------------------ | ----------------- |
+| 12.0-13.0          | 6.0.1             |
 | 12.0-13.0          | 6.0               |
 | 10.8-11.9          | 5.9.3             |
 | 10.8-11.9          | 5.9.2             |


### PR DESCRIPTION
## What?

This updates the versions in WP doc for the upcoming minor release https://make.wordpress.org/core/2022/06/25/wordpress-6-0-x-release-team-and-6-0-1-schedule/

## Why?

To keep the page up to date. 

