### PR TITLE
Avoid intermitent failures in Comments block tests

### DIFF
--- a/packages/e2e-tests/specs/editor/blocks/comments.test.js
+++ b/packages/e2e-tests/specs/editor/blocks/comments.test.js
@@ -9,6 +9,7 @@ import {
 	publishPost,
 	setOption,
 	trashAllComments,
+	saveDraft,
 } from '@wordpress/e2e-test-utils';
 
 describe( 'Comments', () => {
@@ -29,6 +30,8 @@ describe( 'Comments', () => {
 		await createNewPost();
 		await insertBlock( 'Comments' );
 		await page.waitForXPath( '//p[contains(text(), "No results found.")]' );
+		// Prevent the "unsaved changes" warning dialog from opening.
+		await saveDraft();
 	} );
 	it( 'Pagination links are working as expected', async () => {
 		await createNewPost();

--- a/packages/e2e-tests/specs/editor/blocks/comments.test.js
+++ b/packages/e2e-tests/specs/editor/blocks/comments.test.js
@@ -59,12 +59,12 @@ describe( 'Comments', () => {
 		}
 
 		// We check that there is a previous comments page link.
-		expect(
-			await page.$( '.wp-block-comments-pagination-previous' )
-		).not.toBeNull();
-		expect(
-			await page.$( '.wp-block-comments-pagination-next' )
-		).toBeNull();
+		await expect( page ).toMatchElement(
+			'.wp-block-comments-pagination-previous'
+		);
+		await expect( page ).not.toMatchElement(
+			'.wp-block-comments-pagination-next'
+		);
 
 		await Promise.all( [
 			page.click( '.wp-block-comments-pagination-previous' ),
@@ -72,12 +72,12 @@ describe( 'Comments', () => {
 		] );
 
 		// We check that there are a previous and a next link.
-		expect(
-			await page.$( '.wp-block-comments-pagination-previous' )
-		).not.toBeNull();
-		expect(
-			await page.$( '.wp-block-comments-pagination-next' )
-		).not.toBeNull();
+		await expect( page ).toMatchElement(
+			'.wp-block-comments-pagination-previous'
+		);
+		await expect( page ).toMatchElement(
+			'.wp-block-comments-pagination-next'
+		);
 
 		await Promise.all( [
 			page.click( '.wp-block-comments-pagination-previous' ),
@@ -85,12 +85,12 @@ describe( 'Comments', () => {
 		] );
 
 		// We check that there is only have a next link
-		expect(
-			await page.$( '.wp-block-comments-pagination-previous' )
-		).toBeNull();
-		expect(
-			await page.$( '.wp-block-comments-pagination-next' )
-		).not.toBeNull();
+		await expect( page ).not.toMatchElement(
+			'.wp-block-comments-pagination-previous'
+		);
+		await expect( page ).toMatchElement(
+			'.wp-block-comments-pagination-next'
+		);
 	} );
 	it( 'Pagination links are not appearing if break comments is not enabled', async () => {
 		await setOption( 'page_comments', '0' );
@@ -117,12 +117,12 @@ describe( 'Comments', () => {
 			] );
 		}
 		// We check that there are no comments page link.
-		expect(
-			await page.$( '.wp-block-comments-pagination-previous' )
-		).toBeNull();
-		expect(
-			await page.$( '.wp-block-comments-pagination-next' )
-		).toBeNull();
+		await expect( page ).not.toMatchElement(
+			'.wp-block-comments-pagination-previous'
+		);
+		await expect( page ).not.toMatchElement(
+			'.wp-block-comments-pagination-next'
+		);
 	} );
 	afterAll( async () => {
 		await trashAllComments();

--- a/packages/e2e-tests/specs/editor/blocks/comments.test.js
+++ b/packages/e2e-tests/specs/editor/blocks/comments.test.js
@@ -84,7 +84,7 @@ describe( 'Comments', () => {
 			page.waitForNavigation( { waitUntil: 'networkidle0' } ),
 		] );
 
-		// We check that there is only have a next link
+		// We check that there is only a next comments page link.
 		await expect( page ).not.toMatchElement(
 			'.wp-block-comments-pagination-previous'
 		);


### PR DESCRIPTION
## What?

Some random failures are happening in the `comments.test.js` spec file ([example](https://github.com/WordPress/gutenberg/runs/7020903290?check_suite_focus=true)). This PR tries to address that issue.

## Why?

The failing tests could give the (false?) impression that related blocks are not properly working when they are. (They are, right?).

## How?

We're using `page.$()` in that test. Looking at the [documentation](https://github.com/smooth-code/jest-puppeteer/blob/master/packages/expect-puppeteer/README.md#toMatch), it seems that that function doesn't wait for an element to exist, so it could be failing before it happens?

To avoid that issue, I've replaced `page.$()` with `expect( page ).toMatchElement` (docs [here](https://github.com/smooth-code/jest-puppeteer/tree/master/packages/expect-puppeteer#expectinstancetomatchelementselector-options)), from `expect-puppeteer` (which is already installed).

```jsx
// We check that there is a previous comments page link.
await expect( page ).toMatchElement(
	'.wp-block-comments-pagination-previous'
);
await expect( page ).not.toMatchElement(
	'.wp-block-comments-pagination-next'
);
```

That is the approach I've followed. We can explore other alternatives, of course. 🙂 

## Testing Instructions

I'm not sure how to test this, TBH. I wasn't able to reproduce the original issue locally. Tests pass as expected with this PR's changes, but I'm not 100% sure this is going to work _always_ on the GH tests workflows. 
