### PR TITLE
Add: Author nicename template creation ability

### DIFF
--- a/packages/edit-site/src/components/add-new-template/new-template.js
+++ b/packages/edit-site/src/components/add-new-template/new-template.js
@@ -38,6 +38,7 @@ import {
 	useDefaultTemplateTypes,
 	useTaxonomiesMenuItems,
 	usePostTypeMenuItems,
+	useAuthorMenuItem,
 } from './utils';
 import AddCustomGenericTemplateModal from './add-custom-generic-template-modal';
 import { useHistory } from '../routes';
@@ -243,26 +244,30 @@ function useMissingTemplates(
 		useTaxonomiesMenuItems( onClickMenuItem );
 	const { defaultPostTypesMenuItems, postTypesMenuItems } =
 		usePostTypeMenuItems( onClickMenuItem );
-	[ ...defaultTaxonomiesMenuItems, ...defaultPostTypesMenuItems ].forEach(
-		( menuItem ) => {
-			if ( ! menuItem ) {
-				return;
-			}
-			const matchIndex = enhancedMissingDefaultTemplateTypes.findIndex(
-				( template ) => template.slug === menuItem.slug
-			);
-			// Some default template types might have been filtered above from
-			// `missingDefaultTemplates` because they only check for the general
-			// template. So here we either replace or append the item, augmented
-			// with the check if it has available specific item to create a
-			// template for.
-			if ( matchIndex > -1 ) {
-				enhancedMissingDefaultTemplateTypes[ matchIndex ] = menuItem;
-			} else {
-				enhancedMissingDefaultTemplateTypes.push( menuItem );
-			}
+
+	const authorMenuItem = useAuthorMenuItem( onClickMenuItem );
+	[
+		...defaultTaxonomiesMenuItems,
+		...defaultPostTypesMenuItems,
+		authorMenuItem,
+	].forEach( ( menuItem ) => {
+		if ( ! menuItem ) {
+			return;
 		}
-	);
+		const matchIndex = enhancedMissingDefaultTemplateTypes.findIndex(
+			( template ) => template.slug === menuItem.slug
+		);
+		// Some default template types might have been filtered above from
+		// `missingDefaultTemplates` because they only check for the general
+		// template. So here we either replace or append the item, augmented
+		// with the check if it has available specific item to create a
+		// template for.
+		if ( matchIndex > -1 ) {
+			enhancedMissingDefaultTemplateTypes[ matchIndex ] = menuItem;
+		} else {
+			enhancedMissingDefaultTemplateTypes.push( menuItem );
+		}
+	} );
 	// Update the sort order to match the DEFAULT_TEMPLATE_SLUGS order.
 	enhancedMissingDefaultTemplateTypes?.sort( ( template1, template2 ) => {
 		return (

--- a/packages/edit-site/src/components/add-new-template/utils.js
+++ b/packages/edit-site/src/components/add-new-template/utils.js
@@ -408,6 +408,62 @@ export const useTaxonomiesMenuItems = ( onClickMenuItem ) => {
 	return taxonomiesMenuItems;
 };
 
+const AUTHOR_TEMPLATE_PREFIX = { user: 'author' };
+export function useAuthorMenuItem( onClickMenuItem ) {
+	const existingTemplates = useExistingTemplates();
+	const defaultTemplateTypes = useDefaultTemplateTypes();
+	const authorInfo = useEntitiesInfo( 'root', AUTHOR_TEMPLATE_PREFIX );
+	const authorMenuItem = defaultTemplateTypes?.find(
+		( { slug } ) => slug === 'author'
+	);
+	if ( authorMenuItem && authorInfo.user?.hasEntities ) {
+		authorMenuItem.onClick = ( template ) => {
+			onClickMenuItem( {
+				type: 'root',
+				slug: 'user',
+				config: {
+					queryArgs: ( { search } ) => {
+						return {
+							_fields: 'id,name,slug,link',
+							orderBy: search ? 'name' : 'count',
+							exclude: authorInfo.user.existingEntitiesIds,
+							who: 'authors',
+						};
+					},
+					getSpecificTemplate: ( suggestion ) => {
+						const title = sprintf(
+							// translators: %s: Represents the name of an author e.g: "Jorge".
+							__( 'Author: %s' ),
+							suggestion.name
+						);
+						const description = sprintf(
+							// translators: %s: Represents the name of an author e.g: "Jorge".
+							__( 'Template for Author: %s' ),
+							suggestion.name
+						);
+						return {
+							title,
+							description,
+							slug: `author-${ suggestion.slug }`,
+						};
+					},
+				},
+				labels: {
+					singular_name: __( 'Author' ),
+					search_items: __( 'Search Authors' ),
+					not_found: __( 'No authors found.' ),
+					all_items: __( 'All Authors' ),
+				},
+				hasGeneralTemplate: !! existingTemplates.find(
+					( { slug } ) => slug === 'author'
+				),
+				template,
+			} );
+		};
+	}
+	return authorMenuItem;
+}
+
 /**
  * Helper hook that filters all the existing templates by the given
  * object with the entity's slug as key and the template prefix as value.

--- a/packages/edit-site/src/components/add-new-template/utils.js
+++ b/packages/edit-site/src/components/add-new-template/utils.js
@@ -437,7 +437,7 @@ export function useAuthorMenuItem( onClickMenuItem ) {
 					queryArgs: ( { search } ) => {
 						return {
 							_fields: 'id,name,slug,link',
-							orderBy: search ? 'name' : 'count',
+							orderBy: search ? 'name' : 'registered_date',
 							exclude: authorInfo.user.existingEntitiesIds,
 							who: 'authors',
 						};
@@ -579,12 +579,12 @@ const useTemplatesToExclude = (
 const useEntitiesInfo = (
 	entityName,
 	templatePrefixes,
-	additionalQueryParameters
+	additionalQueryParameters = {}
 ) => {
 	const recordsToExcludePerEntity = useTemplatesToExclude(
 		entityName,
 		templatePrefixes,
-		( additionalQueryParameters = {} )
+		additionalQueryParameters
 	);
 	const entitiesInfo = useSelect(
 		( select ) => {

--- a/packages/edit-site/src/components/add-new-template/utils.js
+++ b/packages/edit-site/src/components/add-new-template/utils.js
@@ -483,7 +483,7 @@ useAuthorMenuItem.AUTHOR_TEMPLATE_ENTITY_OBJECT = [
 	{
 		entitySlug: 'user',
 		templatePrefix: 'author',
-		additionalQueryParameters: { who: 'author' },
+		additionalQueryParameters: { who: 'authors' },
 	},
 ];
 

--- a/packages/edit-site/src/components/add-new-template/utils.js
+++ b/packages/edit-site/src/components/add-new-template/utils.js
@@ -425,13 +425,14 @@ export function useAuthorMenuItem( onClickMenuItem ) {
 		'root',
 		useAuthorMenuItem.AUTHOR_TEMPLATE_ENTITY_OBJECT
 	);
-	const authorMenuItem = defaultTemplateTypes?.find(
+	let authorMenuItem = defaultTemplateTypes?.find(
 		( { slug } ) => slug === 'author'
 	);
 	const hasGeneralTemplate = existingTemplates?.find(
 		( { slug } ) => slug === 'author'
 	);
 	if ( authorMenuItem && authorInfo.user?.hasEntities ) {
+		authorMenuItem = { ...authorMenuItem };
 		authorMenuItem.onClick = ( template ) => {
 			onClickMenuItem( {
 				type: 'root',

--- a/packages/edit-site/src/components/add-new-template/utils.js
+++ b/packages/edit-site/src/components/add-new-template/utils.js
@@ -422,7 +422,13 @@ export function useAuthorMenuItem( onClickMenuItem ) {
 		( { slug } ) => slug === 'author'
 	);
 	if ( ! authorMenuItem ) {
-		return;
+		authorMenuItem = {
+			description: __(
+				'Displays latest posts written by a single author.'
+			),
+			slug: 'author',
+			title: 'Author',
+		};
 	}
 	const hasGeneralTemplate = !! existingTemplates?.find(
 		( { slug } ) => slug === 'author'

--- a/packages/edit-site/src/components/add-new-template/utils.js
+++ b/packages/edit-site/src/components/add-new-template/utils.js
@@ -409,11 +409,13 @@ export const useTaxonomiesMenuItems = ( onClickMenuItem ) => {
 };
 
 function useAuthorNeedsUniqueIndentifier() {
-	const authors = useSelect( ( select ) =>
-		select( coreStore ).getUsers( { who: 'authors', per_page: -1 } )
+	const authors = useSelect(
+		( select ) =>
+			select( coreStore ).getUsers( { who: 'authors', per_page: -1 } ),
+		[]
 	);
 	const authorsCountByName = useMemo( () => {
-		return ( authors || [] ).reduce( ( { name }, authorsCount ) => {
+		return ( authors || [] ).reduce( ( authorsCount, { name } ) => {
 			authorsCount[ name ] = ( authorsCount[ name ] || 0 ) + 1;
 			return authorsCount;
 		}, {} );
@@ -483,18 +485,11 @@ export function useAuthorMenuItem( onClickMenuItem ) {
 									__( 'Author: %s' ),
 									suggestion.name
 							  );
-						const description = needsUniqueId
-							? sprintf(
-									// translators: %1$s: Represents the name of an author e.g: "Jorge", %2$s: Represents the slug of an author e.g: "author-jorge-slug".
-									__( 'Template for Author: %1$s (%2$s)' ),
-									suggestion.name,
-									suggestion.slug
-							  )
-							: sprintf(
-									// translators: %s: Represents the name of an author e.g: "Jorge".
-									__( 'Template for Author: %s' ),
-									suggestion.name
-							  );
+						const description = sprintf(
+							// translators: %s: Represents the name of an author e.g: "Jorge".
+							__( 'Template for Author: %s' ),
+							suggestion.name
+						);
 						return {
 							title,
 							description,


### PR DESCRIPTION
This PR adds an option to create an author-nicename template on the site editor UI.
It uses the same UI as Posts and Taxonomies.

Part of: https://github.com/WordPress/gutenberg/issues/37407


![image](https://user-images.githubusercontent.com/11271197/177386676-7478d9fd-a503-4c57-b8fc-de42d2edd9fd.png)
![image](https://user-images.githubusercontent.com/11271197/177386785-20331348-a50f-4eb7-8891-0c5601ae40dd.png)

The unrequited horizontal scroll is an issue already on posts and taxonomies and should be addressed separately.
