### PR TITLE
Social Links: Set the default protocol to 'https' if not specified

### DIFF
--- a/packages/block-library/src/social-link/index.php
+++ b/packages/block-library/src/social-link/index.php
@@ -27,6 +27,14 @@ function render_block_core_social_link( $attributes, $content, $block ) {
 		return '';
 	}
 
+	/**
+	 * Prepend URL with https:// if it doesn't appear to contain a scheme
+	 * and it's not a relative link starting with //.
+	 */
+	if ( ! parse_url( $url, PHP_URL_SCHEME ) && ! str_starts_with( $url, '//' ) ) {
+		$url = 'https://' . $url;
+	}
+
 	$rel_target_attributes = '';
 	if ( $open_in_new_tab ) {
 		$rel_target_attributes = 'rel="noopener nofollow" target="_blank"';


### PR DESCRIPTION
## What?
Resolves #21699.
Alternative to #30100.

PR tries to use `https` as the default protocol if the URL doesn't appear to contain schema and it's not a relative link starting with //.

## Why?
If URL has no schema `esc_url`, prepend it with `http://`. All social media platforms use `https://`, so it makes sense to be the default fallback.

## How?
I've used slightly modified logic from `esc_url`. Schema is checked using `parse_url` and code only checks for relative links with `//` prefix.

## Testing Instructions
1. Open a Post or Page
2. Insert the example block (snippet below).
3. Save and view the post.
4. On the front-end inspect block elements and confirm that only WordPress social link has a default protocol.

## Snippet

```html
<!-- wp:social-links -->
<ul class="wp-block-social-links"><!-- wp:social-link {"url":"//twitter.com/WordPress","service":"twitter"} /-->

<!-- wp:social-link {"url":"profiles.wordpress.org/wordpress/","service":"wordpress"} /-->

<!-- wp:social-link {"url":"http://github.com/WordPress","service":"github"} /--></ul>
<!-- /wp:social-links -->
```

## Screenshots or screencast <!-- if applicable -->
