### PR TITLE
Lodash: Refactor away from `_.invoke()`

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -92,6 +92,7 @@ module.exports = {
 							'findLast',
 							'flatten',
 							'flattenDeep',
+							'invoke',
 							'isArray',
 							'isFinite',
 							'isFunction',

--- a/packages/block-library/src/latest-posts/edit.js
+++ b/packages/block-library/src/latest-posts/edit.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { get, includes, invoke, pickBy } from 'lodash';
+import { get, includes, pickBy } from 'lodash';
 import classnames from 'classnames';
 
 /**
@@ -432,11 +432,7 @@ export default function LatestPostsEdit( { attributes, setAttributes } ) {
 			</BlockControls>
 			<ul { ...blockProps }>
 				{ displayPosts.map( ( post, i ) => {
-					const titleTrimmed = invoke( post, [
-						'title',
-						'rendered',
-						'trim',
-					] );
+					const titleTrimmed = post.title.rendered.trim();
 					let excerpt = post.excerpt.rendered;
 					const currentAuthor = authorList?.find(
 						( author ) => author.id === post.author

--- a/packages/editor/src/components/page-attributes/order.js
+++ b/packages/editor/src/components/page-attributes/order.js
@@ -1,9 +1,4 @@
 /**
- * External dependencies
- */
-import { invoke } from 'lodash';
-
-/**
  * WordPress dependencies
  */
 import { __ } from '@wordpress/i18n';
@@ -24,10 +19,7 @@ export const PageAttributesOrder = ( { onUpdateOrder, order = 0 } ) => {
 	const setUpdatedOrder = ( value ) => {
 		setOrderInput( value );
 		const newOrder = Number( value );
-		if (
-			Number.isInteger( newOrder ) &&
-			invoke( value, [ 'trim' ] ) !== ''
-		) {
+		if ( Number.isInteger( newOrder ) && value.trim?.() !== '' ) {
 			onUpdateOrder( Number( value ) );
 		}
 	};


### PR DESCRIPTION
## What?
Lodash's `invoke` is used only a couple of times in the entire codebase. This PR aims to remove that usage.

## Why?
Lodash is known to unnecessarily inflate the bundle size of packages, and in most cases, it can be replaced with native language functionality. See these for more information and rationale:

* https://github.com/WordPress/gutenberg/issues/16938#issuecomment-602837246
* https://github.com/WordPress/gutenberg/issues/17025
* https://github.com/WordPress/gutenberg/issues/39495 

## How?
Removing `invoke` is straightforward in favor of just invoking the method on the desired path.

## Testing Instructions
* Verify that after you insert a latest posts block, you can see post titles properly, and for posts without title you still see `(no title)`.
* Verify that you can still set and retrieve the order of a page correctly.
* Verify unit tests still pass.