### PR TITLE
post comment form block changes

### DIFF
--- a/packages/block-library/src/post-comments-form/style.scss
+++ b/packages/block-library/src/post-comments-form/style.scss
@@ -27,6 +27,7 @@
 		display: inline-block;
 		text-align: center;
 		overflow-wrap: break-word;
+		width: 100%;
 	}
 
 	textarea,


### PR DESCRIPTION
Solved Issue  [#56121](https://core.trac.wordpress.org/ticket/56121)
Twenty Twenty Two theme Post comments form block having button width issue occur on front end side.
Steps to replicate:
1: Twenty Twenty Two
2: Add Post comments form block
3: Publish post and check the form on front side.

Url:[https://share.cleanshot.com/tyTa7KXtWEzZnHyD7P1S](https://share.cleanshot.com/tyTa7KXtWEzZnHyD7P1S)