### PR TITLE
Respect uncontrolled inner blocks on Navigation block in editor and front of site

### DIFF
--- a/packages/block-library/src/navigation/edit/index.js
+++ b/packages/block-library/src/navigation/edit/index.js
@@ -207,11 +207,16 @@ function Navigation( {
 		hasResolvedCanUserCreateNavigationMenu,
 	} = useNavigationMenu( ref );
 
-	// Attempt to retrieve and prioritize any existing navigation menu unless
-	// a specific ref is allocated or the user is explicitly creating a new menu. The aim is
-	// for the block to "just work" from a user perspective using existing data.
+	// Attempt to retrieve and prioritize any existing navigation menu unless:
+	// - the are uncontrolled inner blocks already present in the block.
+	// - the user is creating a new menu.
+	// - there is more than 1 Navigation Post (wp_navigation).
+	// This attempts to pick the first menu if there is a single Navigation Post. If more
+	// than 1 exists then no attempt to automatically pick a menu is made.
+	// The aim is for the block to "just work" from a user perspective using existing data.
 	useEffect( () => {
 		if (
+			hasUncontrolledInnerBlocks ||
 			isCreatingNavigationMenu ||
 			ref ||
 			! navigationMenus?.length ||


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

**This change means that Themes **should not be including inner blocks in their Navigation blocks** in their templates/parts. The only exception to this would be if they wanted to opt out of some of the current / future menu picking optimisations and automations provided by the block (e.g. carrying across menus on Theme switch).**

----
This PR updates the Navigation block to prefer and _preserve_ uncontrolled inner blocks over all other types of Navigation "content" that a Navigation block can display.

This means that if there are any uncontrolled inner blocks present the block will:

- **_not_** attempt to find automatically assign the most appropriate Navigation Menu (`wp_navigation`).
- **_not_** replace the inner blocks with a Navigation Menu, even if a `ref` is present. 

**Important:** The major change with this approach is that if [any themes use the Page List block as a pseudo "placeholder" in their Navigation block](https://github.com/WordPress/twentytwentytwo/blob/27054dbcb95f5d72cd943a0f3318c3ad97599f85/parts/header.html#L9-L11) (as follows):

```
<!-- wp:navigation --><!-- wp:page-list /--><!-- /wp:navigation -->
```

...then that Theme is effectively **opting out of any current/future automatic picking of menus** (e.g. on Theme switch).



For example, currently if there is a single `wp_navigation` post present on the site then the Nav block will automatically pick and use that menu when the Nav block is inserted. This is useful for scenarios such as Theme switching as the menu will effectively be automatically "carried over" to the new Theme without requiring user intervention. In the future we anticipate this functionality being extended and improved.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->


In https://github.com/WordPress/gutenberg/issues/38291#issuecomment-1171582948 we identified that the block is currently exhibiting different behaviour between the Editor and the front of the site.

This PR normalizes the behaviour so that the block will always respect any uncontrolled inner blocks if they are present.

This allows use cases such as creating Navigation patterns in the editor.



## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

In the effect which attempts to _automatically_ assign a Navigation Post to the block, we now test for uncontrolled inner blocks. If these are present then we abort the automated behaviour thereby allowing the uncontrolled blocks to be rendered.

Note that if the user makes any changes to the uncontrolled blocks to make them "dirty" then they will still be automatically converted into a `wp_navigation` post (existing behaviour).

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->

### Basic Testing
1. Create a single Navigation (`wp_navigation`) post. You can do this by creating an empty Navigation block and adding some items and saving in the multi-entity saving flow.
2. Validate you have only a single `wp_navigation` post (tip: goto `wp-admin/edit.php?post_type=wp_navigation`).
3. New Post.
4. Toggle code editor mode in the Editor.
5. Paste `<!-- wp:navigation --><!-- wp:page-list /--><!-- /wp:navigation -->`.
6. Exit code editor mode.
7. See the Page List block preserved within the Navigation block.
8. You can check by using List View and/or toggling Code Editor mode again and making sure there is no `ref` attribute and that you can still see in the block markup for the inner blocks.
9. Publish the post and validate the exact same content is output on the front of the site (i.e. a Navigation with a page list).

### Theme Switch testing

- again check you only have a single Navigation Post (see above).
- Install Archeo (note that currently [Archeo uses a Page List as inner blocks](https://github.com/Automattic/themes/blob/8ac496ee802c4cb6973b68772b96a274d56bcf56/archeo/parts/header.html#L5-L7)).
- switch Themes to Archeo
- go to Site Editor
- See that Archeo is showing the Page List block and has not carried across your Navigation items.
- Modify this file in Archeo and remove the inner `<!-- wp:page-list /-->`.
- Reload the Site Editor (simulates a Theme switch).
- See that now the items from your Navigation are correctly carried across and the page list is ignored.
- DO NOT SAVE
- Switch to front of site.
- See that it's rendering the exact same thing.

## Screenshots or screencast <!-- if applicable -->

https://user-images.githubusercontent.com/444434/177537722-d63cb2cd-298d-4c97-9fc9-4a235cf3998d.mov


