### PR TITLE
Data: Experiment with loading logger middleware

### DIFF
--- a/packages/data/src/loading-middleware.js
+++ b/packages/data/src/loading-middleware.js
@@ -1,0 +1,55 @@
+/**
+ * Simple loading logging redux middleware.
+ *
+ * @type {import('redux').Middleware}
+ */
+
+const formatLoadedEntry = ( action ) => {
+	let formatted = action.selectorName;
+
+	if ( action.args?.length ) {
+		formatted += ': ' + JSON.stringify( action.args );
+	}
+
+	return formatted;
+};
+
+const getCurrentTime = () => {
+	const date = new Date();
+	return (
+		date.getHours() +
+		':' +
+		date.getMinutes() +
+		':' +
+		date.getSeconds() +
+		'.' +
+		date.getMilliseconds()
+	);
+};
+
+const actionTypeMap = {
+	START_RESOLUTION: 'Started loading',
+	START_RESOLUTIONS: 'Started bulk loading',
+	FINISH_RESOLUTION: 'Finished loading',
+	FINISH_RESOLUTIONS: 'Finished bulk loading',
+	FAIL_RESOLUTION: 'Failed loading',
+	FAIL_RESOLUTIONS: 'Failed bulk loading',
+	INVALIDATE_RESOLUTION: 'Canceled loading',
+};
+
+const loadingMiddleware = () => ( next ) => ( action ) => {
+	if ( actionTypeMap.hasOwnProperty( action.type ) ) {
+		// eslint-disable-next-line no-console
+		console.log(
+			getCurrentTime() +
+				': ' +
+				actionTypeMap[ action.type ] +
+				' ' +
+				formatLoadedEntry( action )
+		);
+	}
+
+	return next( action );
+};
+
+export default loadingMiddleware;

--- a/packages/data/src/redux-store/index.js
+++ b/packages/data/src/redux-store/index.js
@@ -16,6 +16,7 @@ import createReduxRoutineMiddleware from '@wordpress/redux-routine';
  */
 import { builtinControls } from '../controls';
 import promise from '../promise-middleware';
+import loadingMiddleware from '../loading-middleware';
 import createResolversCacheMiddleware from '../resolvers-cache-middleware';
 import createThunkMiddleware from './thunk-middleware';
 import metadataReducer from './metadata/reducer';
@@ -242,6 +243,7 @@ function instantiateReduxStore( key, options, registry, thunkArgs ) {
 	const middlewares = [
 		createResolversCacheMiddleware( registry, key ),
 		promise,
+		loadingMiddleware,
 		createReduxRoutineMiddleware( normalizedControls ),
 		createThunkMiddleware( thunkArgs ),
 	];


### PR DESCRIPTION
## What?
This PR is an experiment - DO NOT MERGE.

It intends to add a simple logger middleware to the resolutions of the data package.

## Why?
This can be helpful in observing what data we're loading, how long it takes, and more specifically the order in which it happens.

This can be useful in order to investigate the next steps in improving the editor loading experience.

See https://github.com/WordPress/gutenberg/issues/35503

## How?
A simple middleware that logs to the browser console.

## Testing Instructions
Open the editor with your browser console open, and observe the messages.

## Screenshots or screencast <!-- if applicable -->
![](https://cldup.com/E3RTG6K6_h.png)