### PR TITLE
Social Link: Automatically prepend emails with mailto protocol

### DIFF
--- a/packages/block-library/src/social-link/index.php
+++ b/packages/block-library/src/social-link/index.php
@@ -27,6 +27,10 @@ function render_block_core_social_link( $attributes, $content, $block ) {
 		return '';
 	}
 
+	if ( is_email( $url ) ) {
+		$url = 'mailto:' . $url;
+	}
+
 	/**
 	 * Prepend URL with https:// if it doesn't appear to contain a scheme
 	 * and it's not a relative link starting with //.

--- a/packages/block-library/src/social-link/index.php
+++ b/packages/block-library/src/social-link/index.php
@@ -27,6 +27,10 @@ function render_block_core_social_link( $attributes, $content, $block ) {
 		return '';
 	}
 
+	/**
+	 * Prepend emails with `mailto:` if not set.
+	 * The `is_email` returns false for emails with schema.
+	 */
 	if ( is_email( $url ) ) {
 		$url = 'mailto:' . $url;
 	}


### PR DESCRIPTION
## What?
Resolves #21876.

PR updates Social Links renderer to prepend emails with `mailto:` protocol if it's not set.

## Why?
The current renderer results in an invalid link prefix - `http://info@example.com/`. This was happening before #42167, because of `esc_url`.

## Testing Instructions
1. Open a Post or Page.
2. Insert an example block snippet.
3. Confirm that email without a prefix has one.
4. There's no double prefix for the second email.

```html
<!-- wp:social-links -->
<ul class="wp-block-social-links"><!-- wp:social-link {"url":"gutenberg@example.com","service":"mail"} /-->

<!-- wp:social-link {"url":"mailto:gutenberg@example.com","service":"mail"} /--></ul>
<!-- /wp:social-links -->
```
