### PR TITLE
Make sure useFocusOnMount runs when all the children tabbable elements have mounted

### DIFF
--- a/packages/components/src/popover/test/index.tsx
+++ b/packages/components/src/popover/test/index.tsx
@@ -138,9 +138,12 @@ describe( 'Popover', () => {
 		} );
 
 		describe( 'focus behavior', () => {
-			it( 'should focus the popover by default when opened', async () => {
+			it( 'should focus the popover container when opened', async () => {
 				render(
-					<Popover data-testid="popover-element">
+					<Popover
+						focusOnMount={ true }
+						data-testid="popover-element"
+					>
 						Popover content
 					</Popover>
 				);

--- a/packages/compose/src/hooks/use-focus-on-mount/index.js
+++ b/packages/compose/src/hooks/use-focus-on-mount/index.js
@@ -40,23 +40,23 @@ export default function useFocusOnMount( focusOnMount = 'firstElement' ) {
 			return;
 		}
 
-		const focusTimeout = setTimeout( () => {
-			let target = node;
-
-			if ( focusOnMountRef.current === 'firstElement' ) {
-				const firstTabbable = focus.tabbable.find( node )[ 0 ];
-
-				if ( firstTabbable ) {
-					target = /** @type {HTMLElement} */ ( firstTabbable );
-				}
-			}
-
-			target.focus( {
+		if ( focusOnMountRef.current !== 'firstElement' ) {
+			node.focus( {
 				// When focusing newly mounted dialogs,
 				// the position of the popover is often not right on the first render
 				// This prevents the layout shifts when focusing the dialogs.
 				preventScroll: true,
 			} );
+
+			return;
+		}
+
+		const focusTimeout = setTimeout( () => {
+			const firstTabbable = focus.tabbable.find( node )[ 0 ];
+
+			if ( firstTabbable ) {
+				/** @type {HTMLElement} */ ( firstTabbable ).focus();
+			}
 		}, 0 );
 
 		return () => clearTimeout( focusTimeout );

--- a/packages/compose/src/hooks/use-focus-on-mount/index.js
+++ b/packages/compose/src/hooks/use-focus-on-mount/index.js
@@ -40,21 +40,25 @@ export default function useFocusOnMount( focusOnMount = 'firstElement' ) {
 			return;
 		}
 
-		let target = node;
+		const focusTimeout = setTimeout( () => {
+			let target = node;
 
-		if ( focusOnMountRef.current === 'firstElement' ) {
-			const firstTabbable = focus.tabbable.find( node )[ 0 ];
+			if ( focusOnMountRef.current === 'firstElement' ) {
+				const firstTabbable = focus.tabbable.find( node )[ 0 ];
 
-			if ( firstTabbable ) {
-				target = /** @type {HTMLElement} */ ( firstTabbable );
+				if ( firstTabbable ) {
+					target = /** @type {HTMLElement} */ ( firstTabbable );
+				}
 			}
-		}
 
-		target.focus( {
-			// When focusing newly mounted dialogs,
-			// the position of the popover is often not right on the first render
-			// This prevents the layout shifts when focusing the dialogs.
-			preventScroll: true,
-		} );
+			target.focus( {
+				// When focusing newly mounted dialogs,
+				// the position of the popover is often not right on the first render
+				// This prevents the layout shifts when focusing the dialogs.
+				preventScroll: true,
+			} );
+		}, 0 );
+
+		return () => clearTimeout( focusTimeout );
 	}, [] );
 }

--- a/packages/e2e-tests/specs/editor/various/__snapshots__/rich-text.test.js.snap
+++ b/packages/e2e-tests/specs/editor/various/__snapshots__/rich-text.test.js.snap
@@ -136,17 +136,17 @@ exports[`RichText should paste paragraph contents into list 1`] = `
 
 exports[`RichText should preserve internal formatting 1`] = `
 "<!-- wp:paragraph -->
-<p><mark style=\\"background-color:rgba(0, 0, 0, 0)\\" class=\\"has-inline-color has-gray-color\\">1</mark></p>
+<p><mark style=\\"background-color:rgba(0, 0, 0, 0)\\" class=\\"has-inline-color has-cyan-bluish-gray-color\\">1</mark></p>
 <!-- /wp:paragraph -->"
 `;
 
 exports[`RichText should preserve internal formatting 2`] = `
 "<!-- wp:paragraph -->
-<p><mark style=\\"background-color:rgba(0, 0, 0, 0)\\" class=\\"has-inline-color has-gray-color\\">1</mark></p>
+<p><mark style=\\"background-color:rgba(0, 0, 0, 0)\\" class=\\"has-inline-color has-cyan-bluish-gray-color\\">1</mark></p>
 <!-- /wp:paragraph -->
 
 <!-- wp:paragraph -->
-<p><mark style=\\"background-color:rgba(0, 0, 0, 0)\\" class=\\"has-inline-color has-gray-color\\">1</mark></p>
+<p><mark style=\\"background-color:rgba(0, 0, 0, 0)\\" class=\\"has-inline-color has-cyan-bluish-gray-color\\">1</mark></p>
 <!-- /wp:paragraph -->"
 `;
 

--- a/packages/e2e-tests/specs/editor/various/__snapshots__/rich-text.test.js.snap
+++ b/packages/e2e-tests/specs/editor/various/__snapshots__/rich-text.test.js.snap
@@ -136,17 +136,17 @@ exports[`RichText should paste paragraph contents into list 1`] = `
 
 exports[`RichText should preserve internal formatting 1`] = `
 "<!-- wp:paragraph -->
-<p><mark style=\\"background-color:rgba(0, 0, 0, 0)\\" class=\\"has-inline-color has-cyan-bluish-gray-color\\">1</mark></p>
+<p><mark style=\\"background-color:rgba(0, 0, 0, 0)\\" class=\\"has-inline-color has-gray-color\\">1</mark></p>
 <!-- /wp:paragraph -->"
 `;
 
 exports[`RichText should preserve internal formatting 2`] = `
 "<!-- wp:paragraph -->
-<p><mark style=\\"background-color:rgba(0, 0, 0, 0)\\" class=\\"has-inline-color has-cyan-bluish-gray-color\\">1</mark></p>
+<p><mark style=\\"background-color:rgba(0, 0, 0, 0)\\" class=\\"has-inline-color has-gray-color\\">1</mark></p>
 <!-- /wp:paragraph -->
 
 <!-- wp:paragraph -->
-<p><mark style=\\"background-color:rgba(0, 0, 0, 0)\\" class=\\"has-inline-color has-cyan-bluish-gray-color\\">1</mark></p>
+<p><mark style=\\"background-color:rgba(0, 0, 0, 0)\\" class=\\"has-inline-color has-gray-color\\">1</mark></p>
 <!-- /wp:paragraph -->"
 `;
 

--- a/packages/e2e-tests/specs/editor/various/rich-text.test.js
+++ b/packages/e2e-tests/specs/editor/various/rich-text.test.js
@@ -412,7 +412,8 @@ describe( 'RichText', () => {
 		await page.waitForXPath(
 			'//button[@role="tab"][@aria-selected="true"][text()="Text"]'
 		);
-		// Tab to the "Text" tab.
+		// Initial focus is on the "Text" tab.
+		// Tab to the "Custom color picker".
 		await page.keyboard.press( 'Tab' );
 		// Tab to black.
 		await page.keyboard.press( 'Tab' );

--- a/packages/e2e-tests/specs/editor/various/rich-text.test.js
+++ b/packages/e2e-tests/specs/editor/various/rich-text.test.js
@@ -419,7 +419,6 @@ describe( 'RichText', () => {
 		await page.keyboard.press( 'Tab' );
 		// Select color other than black.
 		await page.keyboard.press( 'Tab' );
-		await page.keyboard.press( 'Tab' );
 		await page.keyboard.press( 'Enter' );
 
 		expect( await getEditedPostContent() ).toMatchSnapshot();


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

Fixes https://github.com/WordPress/gutenberg/issues/42064

## What?
<!-- In a few words, what is the PR actually doing? -->
Makes sure `useFocusOnMount` runs when all the tabbable elements within the node `useFocusOnMount` is applied to are actually mounted.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
When opening the block toolbar settings menus, initial focus goes to the second menu item. It should go to the first item.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
Restores the `SetTimeout` that was removed in https://github.com/WordPress/gutenberg/pull/27699

I'm not that familiar with this implementation and maybe there are better ways to fix the issue. The point is `useFocusOnMount` runs on a parent component that contains tabbable elements. The components that render the tabbable elements may be mounted slightly after the parent node is mounted so they're 'skipped'. To avoid this, `useFocusOnMount` needs to run when all children tabbables are actually mounted.

## Updated Testing instructions.
The 'Show/Hide more settings' button was removed from the block toolbar Options menu in https://github.com/WordPress/gutenberg/pull/46709. That cured the symptom and not the root cause of this issue. `useFocusOnMount` still fails when the children tabbable elements are mounted at a later time than the `node` where `useFocusOnMount` is used. To test:

- Either temporarily revert the changes from https://github.com/WordPress/gutenberg/pull/46709 (it's a simple revert) and follow the Old Testing Instructions.
- Or:
- First, reproduce the bug on trunk:
- Activate Twenty Twenty-One.
- Go to Appearance > Customize > Widgets
- Select a block in the left sidebar.
- Click the 'Options' button in the block toolbar.
- The Options dropdown menu opens.
- Observe initial focus goes to the second menu item.
- Expected: Initial focus to be on the first item 'Show more settings'.
- Screenshot:

<img width="845" alt="Screenshot 2023-02-24 at 15 14 11" src="https://user-images.githubusercontent.com/1682452/221203904-e6d5342d-e3cb-4f11-acaf-61f089236d19.png">

- Switch to this branch and build.
- Repeat the steps above.
- Observe initial focus goes to the first menu item: 'Show more settings'.

**Additionally:**
As a side effect, this PR fixes the initial focus on the Popover component. In the Popover, the default value of `focusOnMount` is `firstElement`. However, that doesn't work. Actually, initial focus goes to the Popover node. That's because the current `focusOnMount` implementation sort-of [fallbacks to the main node](https://github.com/WordPress/gutenberg/blob/8164936ce75281f0714463d5022e4cd0a13b1c31/packages/compose/src/hooks/use-focus-on-mount/index.js#L43-L58) if no first tabbable is found. To test:
- On trunk
- Go to the Post editor.
- Select a paragraph and click More > Highlight in the block toolbar.
- A Popover with a color picker opens.
- Observe initial focus is set on the Popover wrapper:
  - There's no visible focus style at first.
  - Press the Tab key.
  - Observe focus moves to the 'Text" tab.
- Expected: initial focus to be set on the 'Text" tab.
- Switch to this PR and build.
- Repeat the steps above.
- Observe initial focus is set on the 'Text" tab. **Note**: you need to open the Popover by using the keyboard otherwise you won't see the focus style. Screenshot:

<img width="544" alt="Screenshot 2023-02-24 at 15 54 54" src="https://user-images.githubusercontent.com/1682452/221209823-9b98bf08-4e2a-4fc0-bd8d-3590445f372b.png">


## Old Testing Instructions
- Reproduce the original bug on trunk:
- Select a block to make the block toolbar appear.
- Click the 'Options' button in the toolbar: the Options menu opens.
- Observe that the initial focus goes to the second menu item 'Copy block'.
- Switch to this branch,
- Repeat the steps above.
- Observe that the initial focus goes to the first menu item 'Hide more settings' (if the Settings sidebar is closed, this would be 'Show more settings').
- Test other places where `useFocusOnMount` is used, to make sure everything still works as expected. For example:
  - Open the general 'Options' in the editor top bar.
  - Observe that initial focus goes to the 'Top toolbar' setting.

## Screenshots or screencast <!-- if applicable -->
