### PR TITLE
[Full Site Editing]: Update descriptions for creating taxonomy templates

### DIFF
--- a/packages/edit-site/src/components/add-new-template/add-custom-template-modal.js
+++ b/packages/edit-site/src/components/add-new-template/add-custom-template-modal.js
@@ -22,7 +22,7 @@ import { useEntityRecords } from '@wordpress/core-data';
 /**
  * Internal dependencies
  */
-import { mapToIHasNameAndId } from './utils';
+import { mapToIHasNameAndId, needsUniqueIdentifier } from './utils';
 
 const EMPTY_ARRAY = [];
 
@@ -38,17 +38,27 @@ function selectSuggestion( suggestion, onSelect, entityForSuggestions ) {
 		labels.singular_name,
 		suggestion.name
 	);
+	const description = sprintf(
+		// translators: Represents the description of a user's custom template in the Site Editor, e.g. "Template for Post: Hello, WordPress"
+		__( 'Template for %1$s' ),
+		title
+	);
+	const _needsUniqueIdentifier = needsUniqueIdentifier( labels, slug );
+	const augmentedTitle = _needsUniqueIdentifier
+		? sprintf(
+				// translators: Represents the title of a user's custom template in the Site Editor, where %1$s is the template title and %2$s is the slug of the taxonomy, e.g. "Category: shoes (product_tag)"
+				__( '%1$s %2$s' ),
+				title,
+				_needsUniqueIdentifier ? `(${ slug })` : ''
+		  )
+		: title;
 	let newTemplateSlug = `${ templateSlug || slug }-${ suggestion.slug }`;
 	if ( templatePrefix ) {
 		newTemplateSlug = templatePrefix + newTemplateSlug;
 	}
 	const newTemplate = {
-		title,
-		description: sprintf(
-			// translators: Represents the description of a user's custom template in the Site Editor, e.g. "Template for Post: Hello, WordPress"
-			__( 'Template for %1$s' ),
-			title
-		),
+		title: augmentedTitle,
+		description,
 		slug: newTemplateSlug,
 	};
 	onSelect( newTemplate );

--- a/packages/edit-site/src/components/add-new-template/utils.js
+++ b/packages/edit-site/src/components/add-new-template/utils.js
@@ -110,6 +110,13 @@ export const entitiesConfig = {
 	taxonomy: {
 		...taxonomyBaseConfig,
 		templatePrefix: 'taxonomy-',
+		getDescription: ( labels, slug ) =>
+			sprintf(
+				// translators: %1s: Name of the taxonomy e.g: "Product Categories"; %2s: Slug of the taxonomy e.g: "product-categories".
+				__( 'Displays a single taxonomy: %1$s (%2$s).' ),
+				labels.singular_name,
+				slug
+			),
 	},
 	category: { ...taxonomyBaseConfig },
 	tag: { ...taxonomyBaseConfig, templateSlug: 'tag' },
@@ -337,7 +344,10 @@ export const useExtraTemplates = (
 				: {
 						slug: generalTemplateSlug,
 						title: entityConfig.getTitle( labels ),
-						description: entityConfig.getDescription( labels ),
+						description: entityConfig.getDescription(
+							labels,
+							slug
+						),
 						icon: entityConfig.getIcon?.( icon ),
 				  };
 			const hasEntities = entitiesInfo?.[ slug ]?.hasEntities;


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Follow up of: https://github.com/WordPress/gutenberg/pull/41875
Addresses: https://github.com/WordPress/gutenberg/pull/41875#issuecomment-1163172183

In site editor a user can create various templates and as of https://github.com/WordPress/gutenberg/pull/41875, can create any taxonomy template. The design to create a template uses a taxonomy's `labels`.

The problem here is that some taxonomies(ex: Product categories from WooCommerce) have some identical labels with Category. This results to: 

<img width="826" alt="Screenshot 2022-07-06 at 6 15 44 PM" src="https://user-images.githubusercontent.com/16275880/177585695-781080a7-4239-46cf-9923-a48ffeda7710.png">

`Category` is the WP category and `Single taxonomy: Category` is the Products category that happens to have the same label. We face the same situation in the create template's description.

<img width="1032" alt="Screenshot 2022-06-22 at 14 59 47" src="https://user-images.githubusercontent.com/846565/175048195-d9e02f18-c01e-4262-8b73-e28e98fa1caa.png">

## How?

The only unique identifier for taxonomies seems to be the `slug`. This initial commit just adds it the menu item description in the end and nothing more intentionally. Obviously we need to decide where and how to add this information to make the most sense.

An alternative could be to update the main titles from `Single taxonomy: Category`-> `Taxonomy: Category ($slug)` and not the descriptions.

