### PR TITLE
Fix pattern carousel / grid styling regression

### DIFF
--- a/packages/block-editor/src/components/block-pattern-setup/index.js
+++ b/packages/block-editor/src/components/block-pattern-setup/index.js
@@ -28,7 +28,6 @@ const SetupContent = ( {
 	activeSlide,
 	patterns,
 	onBlockPatternSelect,
-	height,
 } ) => {
 	const composite = useCompositeState();
 	const containerClass = 'block-editor-block-pattern-setup__container';
@@ -41,7 +40,6 @@ const SetupContent = ( {
 		return (
 			<div
 				className="block-editor-block-pattern-setup__carousel"
-				style={ { height } }
 			>
 				<div className={ containerClass }>
 					<ul className="carousel-container">
@@ -50,7 +48,6 @@ const SetupContent = ( {
 								className={ slideClass.get( index ) || '' }
 								key={ pattern.name }
 								pattern={ pattern }
-								minHeight={ height }
 							/>
 						) ) }
 					</ul>
@@ -60,7 +57,6 @@ const SetupContent = ( {
 	}
 	return (
 		<div
-			style={ { height } }
 			className="block-editor-block-pattern-setup__grid"
 		>
 			<Composite

--- a/packages/block-editor/src/components/block-pattern-setup/index.js
+++ b/packages/block-editor/src/components/block-pattern-setup/index.js
@@ -167,7 +167,6 @@ const BlockPatternSetup = ( {
 					activeSlide={ activeSlide }
 					patterns={ patterns }
 					onBlockPatternSelect={ onPatternSelectCallback }
-					height={ contentHeight - ( 74 + 60 ) } // Content - ( modal header + modal actions )
 				/>
 				<SetupToolbar
 					viewMode={ viewMode }

--- a/packages/block-editor/src/components/block-pattern-setup/index.js
+++ b/packages/block-editor/src/components/block-pattern-setup/index.js
@@ -38,9 +38,7 @@ const SetupContent = ( {
 			[ activeSlide + 1, 'next-slide' ],
 		] );
 		return (
-			<div
-				className="block-editor-block-pattern-setup__carousel"
-			>
+			<div className="block-editor-block-pattern-setup__carousel">
 				<div className={ containerClass }>
 					<ul className="carousel-container">
 						{ patterns.map( ( pattern, index ) => (
@@ -56,9 +54,7 @@ const SetupContent = ( {
 		);
 	}
 	return (
-		<div
-			className="block-editor-block-pattern-setup__grid"
-		>
+		<div className="block-editor-block-pattern-setup__grid">
 			<Composite
 				{ ...composite }
 				role="listbox"

--- a/packages/block-editor/src/components/block-pattern-setup/index.js
+++ b/packages/block-editor/src/components/block-pattern-setup/index.js
@@ -11,7 +11,7 @@ import {
 } from '@wordpress/components';
 
 import { useState } from '@wordpress/element';
-import { useInstanceId, useResizeObserver } from '@wordpress/compose';
+import { useInstanceId } from '@wordpress/compose';
 import { __ } from '@wordpress/i18n';
 
 /**
@@ -143,8 +143,6 @@ const BlockPatternSetup = ( {
 	const [ activeSlide, setActiveSlide ] = useState( 0 );
 	const { replaceBlock } = useDispatch( blockEditorStore );
 	const patterns = usePatternsSetup( clientId, blockName, filterPatternsFn );
-	const [ contentResizeListener, { height: contentHeight } ] =
-		useResizeObserver();
 
 	if ( ! patterns?.length ) {
 		return null;
@@ -158,7 +156,6 @@ const BlockPatternSetup = ( {
 		onBlockPatternSelect || onBlockPatternSelectDefault;
 	return (
 		<>
-			{ contentResizeListener }
 			<div
 				className={ `block-editor-block-pattern-setup view-mode-${ viewMode }` }
 			>

--- a/packages/block-editor/src/components/block-pattern-setup/style.scss
+++ b/packages/block-editor/src/components/block-pattern-setup/style.scss
@@ -17,6 +17,7 @@
 			display: block;
 			width: 100%;
 			padding: $grid-unit-40;
+			padding-bottom: 0;
 			padding-top: 0;
 			column-count: 2;
 
@@ -54,6 +55,8 @@
 		text-align: left;
 		margin: 0;
 		color: $gray-900;
+		position: absolute;
+		bottom: 0;
 		// Block UI appearance.
 		background-color: $white;
 		display: flex;
@@ -129,5 +132,4 @@
 .block-editor-block-pattern-setup__carousel,
 .block-editor-block-pattern-setup__grid {
 	width: 100%;
-	overflow-y: auto;
 }

--- a/packages/block-library/src/query/editor.scss
+++ b/packages/block-library/src/query/editor.scss
@@ -20,7 +20,6 @@
 }
 
 .block-editor-query-pattern__selection-modal .components-modal__content {
-	//overflow: hidden;
 	padding: 0;
 	margin-bottom: $header-height; // $header-height to accommodate bottom toolbar
 	&::before {

--- a/packages/block-library/src/query/editor.scss
+++ b/packages/block-library/src/query/editor.scss
@@ -20,8 +20,9 @@
 }
 
 .block-editor-query-pattern__selection-modal .components-modal__content {
-	overflow: hidden;
+	//overflow: hidden;
 	padding: 0;
+	margin-bottom: $header-height; // $header-height to accommodate bottom toolbar
 	&::before {
 		margin-bottom: 0;
 	}


### PR DESCRIPTION
A small styling regression occurred in the pattern carousel/grid when we merged https://github.com/WordPress/gutenberg/pull/40781 which this PR fixes.

### Trunk

https://user-images.githubusercontent.com/846565/177605532-aec8a7b9-1f28-4dab-98bd-b55ce39de7b8.mp4

Note that on scroll _no border appears_ beneath the modal header.

### This PR

https://user-images.githubusercontent.com/846565/177605016-e9e6a404-3b3e-4150-9b55-d48082c0e464.mp4

A border now appears beneath the modal header on scroll.

### To test

1. Select a Query block
2. Click 'Replace' in the toolbar to open the pattern modal
3. Observe that as you scroll a border is applied to the modal header.
