### PR TITLE
feat: Add BottomSheetV2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -56265,7 +56265,7 @@
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
 				"@babel/runtime": "^7.20.0",
-				"@gorhom/bottom-sheet": "^4.3.2",
+				"@gorhom/bottom-sheet": "4.4.7",
 				"@react-native-clipboard/clipboard": "1.11.2",
 				"@react-native-community/blur": "4.2.0",
 				"@react-native-community/slider": "https://raw.githubusercontent.com/wordpress-mobile/react-native-slider/v3.0.2-wp-4/react-native-community-slider-3.0.2-wp-4.tgz",
@@ -68726,7 +68726,7 @@
 			"version": "file:packages/react-native-editor",
 			"requires": {
 				"@babel/runtime": "^7.20.0",
-				"@gorhom/bottom-sheet": "^4.3.2",
+				"@gorhom/bottom-sheet": "4.4.7",
 				"@react-native-clipboard/clipboard": "1.11.2",
 				"@react-native-community/blur": "4.2.0",
 				"@react-native-community/slider": "https://raw.githubusercontent.com/wordpress-mobile/react-native-slider/v3.0.2-wp-4/react-native-community-slider-3.0.2-wp-4.tgz",

--- a/package-lock.json
+++ b/package-lock.json
@@ -3817,6 +3817,43 @@
 			"resolved": "https://registry.npmjs.org/@floating-ui/utils/-/utils-0.1.1.tgz",
 			"integrity": "sha512-m0G6wlnhm/AX0H12IOWtK8gASEMffnX08RtKkCgTdHb9JpHKGloI7icFfLg9ZmQeavcvR0PKmzxClyuFPSjKWw=="
 		},
+		"node_modules/@gorhom/bottom-sheet": {
+			"version": "4.4.7",
+			"resolved": "https://registry.npmjs.org/@gorhom/bottom-sheet/-/bottom-sheet-4.4.7.tgz",
+			"integrity": "sha512-ukTuTqDQi2heo68hAJsBpUQeEkdqP9REBcn47OpuvPKhdPuO1RBOOADjqXJNCnZZRcY+HqbnGPMSLFVc31zylQ==",
+			"dependencies": {
+				"@gorhom/portal": "1.0.14",
+				"invariant": "^2.2.4"
+			},
+			"peerDependencies": {
+				"@types/react": "*",
+				"@types/react-native": "*",
+				"react": "*",
+				"react-native": "*",
+				"react-native-gesture-handler": ">=1.10.1",
+				"react-native-reanimated": ">=2.2.0"
+			},
+			"peerDependenciesMeta": {
+				"@types/react": {
+					"optional": true
+				},
+				"@types/react-native": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/@gorhom/portal": {
+			"version": "1.0.14",
+			"resolved": "https://registry.npmjs.org/@gorhom/portal/-/portal-1.0.14.tgz",
+			"integrity": "sha512-MXyL4xvCjmgaORr/rtryDNFy3kU4qUbKlwtQqqsygd0xX3mhKjOLn6mQK8wfu0RkoE0pBE0nAasRoHua+/QZ7A==",
+			"dependencies": {
+				"nanoid": "^3.3.1"
+			},
+			"peerDependencies": {
+				"react": "*",
+				"react-native": "*"
+			}
+		},
 		"node_modules/@hapi/hoek": {
 			"version": "9.2.1",
 			"resolved": "https://registry.npmjs.org/@hapi/hoek/-/hoek-9.2.1.tgz",
@@ -56228,6 +56265,7 @@
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
 				"@babel/runtime": "^7.20.0",
+				"@gorhom/bottom-sheet": "^4.3.2",
 				"@react-native-clipboard/clipboard": "1.11.2",
 				"@react-native-community/blur": "4.2.0",
 				"@react-native-community/slider": "https://raw.githubusercontent.com/wordpress-mobile/react-native-slider/v3.0.2-wp-4/react-native-community-slider-3.0.2-wp-4.tgz",
@@ -59094,6 +59132,23 @@
 			"version": "0.1.1",
 			"resolved": "https://registry.npmjs.org/@floating-ui/utils/-/utils-0.1.1.tgz",
 			"integrity": "sha512-m0G6wlnhm/AX0H12IOWtK8gASEMffnX08RtKkCgTdHb9JpHKGloI7icFfLg9ZmQeavcvR0PKmzxClyuFPSjKWw=="
+		},
+		"@gorhom/bottom-sheet": {
+			"version": "4.4.7",
+			"resolved": "https://registry.npmjs.org/@gorhom/bottom-sheet/-/bottom-sheet-4.4.7.tgz",
+			"integrity": "sha512-ukTuTqDQi2heo68hAJsBpUQeEkdqP9REBcn47OpuvPKhdPuO1RBOOADjqXJNCnZZRcY+HqbnGPMSLFVc31zylQ==",
+			"requires": {
+				"@gorhom/portal": "1.0.14",
+				"invariant": "^2.2.4"
+			}
+		},
+		"@gorhom/portal": {
+			"version": "1.0.14",
+			"resolved": "https://registry.npmjs.org/@gorhom/portal/-/portal-1.0.14.tgz",
+			"integrity": "sha512-MXyL4xvCjmgaORr/rtryDNFy3kU4qUbKlwtQqqsygd0xX3mhKjOLn6mQK8wfu0RkoE0pBE0nAasRoHua+/QZ7A==",
+			"requires": {
+				"nanoid": "^3.3.1"
+			}
 		},
 		"@hapi/hoek": {
 			"version": "9.2.1",
@@ -68671,6 +68726,7 @@
 			"version": "file:packages/react-native-editor",
 			"requires": {
 				"@babel/runtime": "^7.20.0",
+				"@gorhom/bottom-sheet": "^4.3.2",
 				"@react-native-clipboard/clipboard": "1.11.2",
 				"@react-native-community/blur": "4.2.0",
 				"@react-native-community/slider": "https://raw.githubusercontent.com/wordpress-mobile/react-native-slider/v3.0.2-wp-4/react-native-community-slider-3.0.2-wp-4.tgz",

--- a/packages/components/src/dropdown-menu/index.native.js
+++ b/packages/components/src/dropdown-menu/index.native.js
@@ -15,6 +15,7 @@ import { menu } from '@wordpress/icons';
  */
 import Button from '../button';
 import Dropdown from '../dropdown';
+import styles from './style';
 
 function mergeProps( defaultProps = {}, props = {} ) {
 	const mergedProps = {
@@ -111,10 +112,7 @@ function DropdownMenu( {
 						index={ isOpen ? 0 : -1 }
 						onClose={ onClose }
 						snapPoints={ [ BottomSheetV2.CONTENT_HEIGHT ] }
-						style={ {
-							paddingLeft: 16,
-							paddingRight: 16,
-						} }
+						style={ styles[ 'dropdown-menu__bottom-sheet' ] }
 					>
 						{ isFunction( children ) ? children( props ) : null }
 						<PanelBody

--- a/packages/components/src/dropdown-menu/index.native.js
+++ b/packages/components/src/dropdown-menu/index.native.js
@@ -6,7 +6,7 @@ import { Platform } from 'react-native';
 /**
  * WordPress dependencies
  */
-import { BottomSheet, PanelBody } from '@wordpress/components';
+import { BottomSheet, BottomSheetV2, PanelBody } from '@wordpress/components';
 import { withPreferredColorScheme } from '@wordpress/compose';
 import { menu } from '@wordpress/icons';
 
@@ -107,10 +107,14 @@ function DropdownMenu( {
 			} }
 			renderContent={ ( { isOpen, onClose, ...props } ) => {
 				return (
-					<BottomSheet
-						hideHeader={ true }
-						isVisible={ isOpen }
+					<BottomSheetV2
+						index={ isOpen ? 0 : -1 }
 						onClose={ onClose }
+						snapPoints={ [ BottomSheetV2.CONTENT_HEIGHT ] }
+						style={ {
+							paddingLeft: 16,
+							paddingRight: 16,
+						} }
 					>
 						{ isFunction( children ) ? children( props ) : null }
 						<PanelBody
@@ -147,7 +151,7 @@ function DropdownMenu( {
 									)
 							) }
 						</PanelBody>
-					</BottomSheet>
+					</BottomSheetV2>
 				);
 			} }
 		/>

--- a/packages/components/src/dropdown-menu/index.native.js
+++ b/packages/components/src/dropdown-menu/index.native.js
@@ -9,13 +9,13 @@ import { Platform } from 'react-native';
 import { BottomSheet, BottomSheetV2, PanelBody } from '@wordpress/components';
 import { withPreferredColorScheme } from '@wordpress/compose';
 import { menu } from '@wordpress/icons';
+import { useSafeAreaInsets } from 'react-native-safe-area-context';
 
 /**
  * Internal dependencies
  */
 import Button from '../button';
 import Dropdown from '../dropdown';
-import styles from './style';
 
 function mergeProps( defaultProps = {}, props = {} ) {
 	const mergedProps = {
@@ -52,6 +52,8 @@ function DropdownMenu( {
 	popoverProps,
 	toggleProps,
 } ) {
+	const { bottom: bottomInset } = useSafeAreaInsets();
+
 	if ( ! controls?.length && ! isFunction( children ) ) {
 		return null;
 	}
@@ -112,12 +114,11 @@ function DropdownMenu( {
 						index={ isOpen ? 0 : -1 }
 						onClose={ onClose }
 						snapPoints={ [ BottomSheetV2.CONTENT_HEIGHT ] }
-						style={ styles[ 'dropdown-menu__bottom-sheet' ] }
 					>
 						{ isFunction( children ) ? children( props ) : null }
 						<PanelBody
 							title={ label }
-							style={ { paddingLeft: 0, paddingRight: 0 } }
+							style={ { marginBottom: bottomInset + 20 } }
 						>
 							{ controlSets?.flatMap(
 								( controlSet, indexOfSet ) =>

--- a/packages/components/src/dropdown-menu/style.native.scss
+++ b/packages/components/src/dropdown-menu/style.native.scss
@@ -1,4 +1,0 @@
-.dropdown-menu__bottom-sheet {
-	padding-left: 16px;
-	padding-right: 16px;
-}

--- a/packages/components/src/dropdown-menu/style.native.scss
+++ b/packages/components/src/dropdown-menu/style.native.scss
@@ -1,0 +1,4 @@
+.dropdown-menu__bottom-sheet {
+	padding-left: 16px;
+	padding-right: 16px;
+}

--- a/packages/components/src/index.native.js
+++ b/packages/components/src/index.native.js
@@ -84,6 +84,7 @@ export {
 } from './mobile/autocompletion-items';
 export { default as Autocomplete } from './autocomplete';
 export { default as BottomSheet } from './mobile/bottom-sheet';
+export { default as BottomSheetV2 } from './mobile/bottom-sheet-v2';
 export {
 	BottomSheetConsumer,
 	BottomSheetProvider,

--- a/packages/components/src/mobile/bottom-sheet-v2/index.native.js
+++ b/packages/components/src/mobile/bottom-sheet-v2/index.native.js
@@ -42,6 +42,7 @@ function BottomSheetWithRef(
 		( props ) => (
 			<BottomSheetBackdrop
 				{ ...props }
+				opacity={ 0.2 }
 				disappearsOnIndex={ -1 }
 				appearsOnIndex={ 0 }
 			/>

--- a/packages/components/src/mobile/bottom-sheet-v2/index.native.js
+++ b/packages/components/src/mobile/bottom-sheet-v2/index.native.js
@@ -20,7 +20,7 @@ import {
 } from '@wordpress/element';
 
 function BottomSheetV2WithRef(
-	{ onClose, children, index = 0, snapPoints = [ '50%' ], style } = {},
+	{ children, index = 0, onClose, snapPoints = [ '50%' ] } = {},
 	ref
 ) {
 	const bottomSheetRef = useRef( null );
@@ -85,7 +85,6 @@ function BottomSheetV2WithRef(
 				} }
 				ref={ bottomSheetRef }
 				snapPoints={ animatedSnapPoints }
-				style={ style }
 			>
 				<BottomSheetScrollView onLayout={ handleContentLayout }>
 					{ children }

--- a/packages/components/src/mobile/bottom-sheet-v2/index.native.js
+++ b/packages/components/src/mobile/bottom-sheet-v2/index.native.js
@@ -109,10 +109,14 @@ const BottomSheetModalWithRef = (
 	 * would simplify migrating to `BottomSheetModal` in the future if the editor
 	 * header navigation is rendered by React Native, not the native host app.
 	 */
-	useImperativeHandle( ref, () => ( {
-		present: handlePresent,
-		dismiss: handleDismiss,
-	} ) );
+	useImperativeHandle(
+		ref,
+		() => ( {
+			present: handlePresent,
+			dismiss: handleDismiss,
+		} ),
+		[ handleDismiss, handlePresent ]
+	);
 
 	const handleClose = useCallback( () => {
 		setVisible( false );

--- a/packages/components/src/mobile/bottom-sheet-v2/index.native.js
+++ b/packages/components/src/mobile/bottom-sheet-v2/index.native.js
@@ -19,6 +19,11 @@ import {
 	useRef,
 } from '@wordpress/element';
 
+/**
+ * Internal dependencies
+ */
+import styles from './style';
+
 function BottomSheetV2WithRef(
 	{ children, index = 0, onClose, snapPoints = [ '50%' ] } = {},
 	ref
@@ -69,13 +74,18 @@ function BottomSheetV2WithRef(
 		animatedContentHeight,
 		handleContentLayout,
 	} = useBottomSheetDynamicSnapPoints( snapPoints );
+
 	return (
 		<Modal transparent={ true } visible={ visible }>
 			<BottomSheet
 				backdropComponent={ renderBackdrop }
+				backgroundStyle={ styles[ 'bottom-sheet-v2__background' ] }
 				enablePanDownToClose={ true }
 				contentHeight={ animatedContentHeight }
 				handleHeight={ animatedHandleHeight }
+				handleIndicatorStyle={
+					styles[ 'bottom-sheet-v2__handle-indicator' ]
+				}
 				index={ internalIndex }
 				onClose={ () => {
 					setVisible( false );

--- a/packages/components/src/mobile/bottom-sheet-v2/index.native.js
+++ b/packages/components/src/mobile/bottom-sheet-v2/index.native.js
@@ -19,6 +19,7 @@ import {
 	useImperativeHandle,
 	useRef,
 } from '@wordpress/element';
+import { usePreferredColorSchemeStyle } from '@wordpress/compose';
 
 /**
  * Internal dependencies
@@ -29,6 +30,14 @@ function BottomSheetWithRef(
 	{ children, index, onClose, snapPoints = [ '50%' ] } = {},
 	ref
 ) {
+	const backgroundStyle = [
+		styles[ 'bottom-sheet-v2__background' ],
+		usePreferredColorSchemeStyle(
+			null,
+			styles[ 'bottom-sheet-v2__background--dark' ]
+		),
+	];
+
 	const renderBackdrop = useCallback(
 		( props ) => (
 			<BottomSheetBackdrop
@@ -50,7 +59,7 @@ function BottomSheetWithRef(
 	return (
 		<BottomSheetExternal
 			backdropComponent={ renderBackdrop }
-			backgroundStyle={ styles[ 'bottom-sheet-v2__background' ] }
+			backgroundStyle={ backgroundStyle }
 			enablePanDownToClose={ true }
 			contentHeight={ animatedContentHeight }
 			handleHeight={ animatedHandleHeight }

--- a/packages/components/src/mobile/bottom-sheet-v2/index.native.js
+++ b/packages/components/src/mobile/bottom-sheet-v2/index.native.js
@@ -7,6 +7,7 @@ import BottomSheet, {
 	useBottomSheetDynamicSnapPoints,
 } from '@gorhom/bottom-sheet';
 import { Modal } from 'react-native';
+import { gestureHandlerRootHOC } from 'react-native-gesture-handler';
 
 /**
  * WordPress dependencies
@@ -18,6 +19,7 @@ import {
 	useImperativeHandle,
 	useRef,
 } from '@wordpress/element';
+import { compose } from '@wordpress/compose';
 
 /**
  * Internal dependencies
@@ -25,11 +27,10 @@ import {
 import styles from './style';
 
 function BottomSheetV2WithRef(
-	{ children, index = 0, onClose, snapPoints = [ '50%' ] } = {},
+	{ children, index = 0, onClose, setVisible, snapPoints = [ '50%' ] } = {},
 	ref
 ) {
 	const bottomSheetRef = useRef( null );
-	const [ visible, setVisible ] = useState( index >= 0 );
 	/**
 	 * `internalIndex` is used to allow displaying the modal on initial render,
 	 * which is required in some areas of the code base that do not easily support
@@ -76,36 +77,51 @@ function BottomSheetV2WithRef(
 	} = useBottomSheetDynamicSnapPoints( snapPoints );
 
 	return (
-		<Modal transparent={ true } visible={ visible }>
-			<BottomSheet
-				backdropComponent={ renderBackdrop }
-				backgroundStyle={ styles[ 'bottom-sheet-v2__background' ] }
-				enablePanDownToClose={ true }
-				contentHeight={ animatedContentHeight }
-				handleHeight={ animatedHandleHeight }
-				handleIndicatorStyle={
-					styles[ 'bottom-sheet-v2__handle-indicator' ]
+		<BottomSheet
+			backdropComponent={ renderBackdrop }
+			backgroundStyle={ styles[ 'bottom-sheet-v2__background' ] }
+			enablePanDownToClose={ true }
+			contentHeight={ animatedContentHeight }
+			handleHeight={ animatedHandleHeight }
+			handleIndicatorStyle={
+				styles[ 'bottom-sheet-v2__handle-indicator' ]
+			}
+			index={ internalIndex }
+			onClose={ () => {
+				setVisible( false );
+				if ( onClose ) {
+					onClose();
 				}
-				index={ internalIndex }
-				onClose={ () => {
-					setVisible( false );
-					if ( onClose ) {
-						onClose();
-					}
-				} }
-				ref={ bottomSheetRef }
-				snapPoints={ animatedSnapPoints }
-			>
-				<BottomSheetScrollView onLayout={ handleContentLayout }>
-					{ children }
-				</BottomSheetScrollView>
-			</BottomSheet>
-		</Modal>
+			} }
+			ref={ bottomSheetRef }
+			snapPoints={ animatedSnapPoints }
+		>
+			<BottomSheetScrollView onLayout={ handleContentLayout }>
+				{ children }
+			</BottomSheetScrollView>
+		</BottomSheet>
 	);
 }
 
-const BottomSheetV2 = forwardRef( BottomSheetV2WithRef );
+const BottomSheetV2 = compose( [ gestureHandlerRootHOC, forwardRef ] )(
+	BottomSheetV2WithRef
+);
 
-BottomSheetV2.CONTENT_HEIGHT = 'CONTENT_HEIGHT';
+const BottomSheetModal = forwardRef( ( { index = 0, ...rest }, ref ) => {
+	const [ visible, setVisible ] = useState( index >= 0 );
 
-export default BottomSheetV2;
+	return (
+		<Modal transparent={ true } visible={ visible }>
+			<BottomSheetV2
+				{ ...rest }
+				index={ index }
+				ref={ ref }
+				setVisible={ setVisible }
+			/>
+		</Modal>
+	);
+} );
+
+BottomSheetModal.CONTENT_HEIGHT = 'CONTENT_HEIGHT';
+
+export default BottomSheetModal;

--- a/packages/components/src/mobile/bottom-sheet-v2/index.native.js
+++ b/packages/components/src/mobile/bottom-sheet-v2/index.native.js
@@ -90,7 +90,7 @@ const BottomSheetModalWithRef = (
 	/**
 	 * `internalIndex` is used to allow displaying the modal on initial render,
 	 * which is required in some areas of the code base that do not easily support
-	 * an call to an imperative `present` method.
+	 * a call to an imperative `present` method.
 	 */
 	const [ internalIndex, setInternalIndex ] = useState( index );
 	const [ visible, setVisible ] = useState( index >= 0 );

--- a/packages/components/src/mobile/bottom-sheet-v2/index.native.js
+++ b/packages/components/src/mobile/bottom-sheet-v2/index.native.js
@@ -1,0 +1,102 @@
+/**
+ * External dependencies
+ */
+import BottomSheet, {
+	BottomSheetBackdrop,
+	BottomSheetScrollView,
+	useBottomSheetDynamicSnapPoints,
+} from '@gorhom/bottom-sheet';
+import { Modal } from 'react-native';
+
+/**
+ * WordPress dependencies
+ */
+import {
+	forwardRef,
+	useCallback,
+	useState,
+	useImperativeHandle,
+	useRef,
+} from '@wordpress/element';
+
+function BottomSheetV2WithRef(
+	{ onClose, children, index = 0, snapPoints = [ '50%' ], style } = {},
+	ref
+) {
+	const bottomSheetRef = useRef( null );
+	const [ visible, setVisible ] = useState( index >= 0 );
+	/**
+	 * `internalIndex` is used to allow displaying the modal on initial render,
+	 * which is required in some areas of the code base that do not easily support
+	 * an call to an imperative `present` method.
+	 */
+	const [ internalIndex, setInternalIndex ] = useState( index );
+
+	const handlePresent = useCallback( () => {
+		setVisible( true );
+		setInternalIndex( index >= 0 ? index : 0 );
+	}, [] );
+
+	const handleDismiss = useCallback( () => {
+		bottomSheetRef.current?.close();
+	}, [] );
+
+	/**
+	 * Utilize imperative handle to mimic the `@gorhom/bottom-sheet` API, which
+	 * would simplify migrating to `BottomSheetModal` in the future once the
+	 * editor header navigation is rendered by React Native, not the native host
+	 * app.
+	 */
+	useImperativeHandle( ref, () => ( {
+		present: handlePresent,
+		dismiss: handleDismiss,
+	} ) );
+
+	const renderBackdrop = useCallback(
+		( props ) => (
+			<BottomSheetBackdrop
+				{ ...props }
+				disappearsOnIndex={ -1 }
+				appearsOnIndex={ 0 }
+			/>
+		),
+		[]
+	);
+
+	const {
+		animatedHandleHeight,
+		animatedSnapPoints,
+		animatedContentHeight,
+		handleContentLayout,
+	} = useBottomSheetDynamicSnapPoints( snapPoints );
+	return (
+		<Modal transparent={ true } visible={ visible }>
+			<BottomSheet
+				backdropComponent={ renderBackdrop }
+				enablePanDownToClose={ true }
+				contentHeight={ animatedContentHeight }
+				handleHeight={ animatedHandleHeight }
+				index={ internalIndex }
+				onClose={ () => {
+					setVisible( false );
+					if ( onClose ) {
+						onClose();
+					}
+				} }
+				ref={ bottomSheetRef }
+				snapPoints={ animatedSnapPoints }
+				style={ style }
+			>
+				<BottomSheetScrollView onLayout={ handleContentLayout }>
+					{ children }
+				</BottomSheetScrollView>
+			</BottomSheet>
+		</Modal>
+	);
+}
+
+const BottomSheetV2 = forwardRef( BottomSheetV2WithRef );
+
+BottomSheetV2.CONTENT_HEIGHT = 'CONTENT_HEIGHT';
+
+export default BottomSheetV2;

--- a/packages/components/src/mobile/bottom-sheet-v2/index.native.js
+++ b/packages/components/src/mobile/bottom-sheet-v2/index.native.js
@@ -24,7 +24,7 @@ import { usePreferredColorSchemeStyle } from '@wordpress/compose';
 /**
  * Internal dependencies
  */
-import styles from './style';
+import styles from './style.scss';
 
 function BottomSheetWithRef(
 	{ children, index, onClose, snapPoints = [ '50%' ] } = {},

--- a/packages/components/src/mobile/bottom-sheet-v2/index.native.js
+++ b/packages/components/src/mobile/bottom-sheet-v2/index.native.js
@@ -7,7 +7,7 @@ import BottomSheetExternal, {
 	useBottomSheetDynamicSnapPoints,
 } from '@gorhom/bottom-sheet';
 import { Modal } from 'react-native';
-import { gestureHandlerRootHOC } from 'react-native-gesture-handler';
+import { GestureHandlerRootView } from 'react-native-gesture-handler';
 
 /**
  * WordPress dependencies
@@ -19,7 +19,6 @@ import {
 	useImperativeHandle,
 	useRef,
 } from '@wordpress/element';
-import { compose } from '@wordpress/compose';
 
 /**
  * Internal dependencies
@@ -70,9 +69,7 @@ function BottomSheetWithRef(
 	);
 }
 
-const BottomSheet = compose( [ gestureHandlerRootHOC, forwardRef ] )(
-	BottomSheetWithRef
-);
+const BottomSheet = forwardRef( BottomSheetWithRef );
 
 const BottomSheetModalWithRef = (
 	{ index = 0, onClose, ...bottomSheetProps },
@@ -115,13 +112,21 @@ const BottomSheetModalWithRef = (
 	}, [ onClose ] );
 
 	return (
-		<Modal transparent={ true } visible={ visible }>
-			<BottomSheet
-				{ ...bottomSheetProps }
-				index={ internalIndex }
-				ref={ ref }
-				onClose={ handleClose }
-			/>
+		<Modal
+			onRequestClose={ handleDismiss }
+			transparent={ true }
+			visible={ visible }
+		>
+			<GestureHandlerRootView
+				style={ styles[ 'bottom-sheet-v2__gesture-handler' ] }
+			>
+				<BottomSheet
+					{ ...bottomSheetProps }
+					index={ internalIndex }
+					ref={ bottomSheetRef }
+					onClose={ handleClose }
+				/>
+			</GestureHandlerRootView>
 		</Modal>
 	);
 };

--- a/packages/components/src/mobile/bottom-sheet-v2/index.native.js
+++ b/packages/components/src/mobile/bottom-sheet-v2/index.native.js
@@ -98,7 +98,7 @@ const BottomSheetModalWithRef = (
 	const handlePresent = useCallback( () => {
 		setVisible( true );
 		setInternalIndex( index >= 0 ? index : 0 );
-	}, [] );
+	}, [ index ] );
 
 	const handleDismiss = useCallback( () => {
 		bottomSheetRef.current?.close();

--- a/packages/components/src/mobile/bottom-sheet-v2/style.native.scss
+++ b/packages/components/src/mobile/bottom-sheet-v2/style.native.scss
@@ -6,6 +6,10 @@
 	border-radius: 8px;
 }
 
+.bottom-sheet-v2__background--dark {
+	background-color: $modal-background-dark;
+}
+
 .bottom-sheet-v2__handle-indicator {
 	background-color: $light-gray-400;
 	border-radius: 2px;

--- a/packages/components/src/mobile/bottom-sheet-v2/style.native.scss
+++ b/packages/components/src/mobile/bottom-sheet-v2/style.native.scss
@@ -1,0 +1,9 @@
+.bottom-sheet-v2__background {
+	border-radius: 8px;
+}
+
+.bottom-sheet-v2__handle-indicator {
+	background-color: $light-gray-400;
+	border-radius: 2px;
+	width: 36px;
+}

--- a/packages/components/src/mobile/bottom-sheet-v2/style.native.scss
+++ b/packages/components/src/mobile/bottom-sheet-v2/style.native.scss
@@ -1,3 +1,7 @@
+.bottom-sheet-v2__gesture-handler {
+	flex: 1;
+}
+
 .bottom-sheet-v2__background {
 	border-radius: 8px;
 }

--- a/packages/edit-post/src/editor.native.js
+++ b/packages/edit-post/src/editor.native.js
@@ -2,7 +2,7 @@
  * External dependencies
  */
 import memize from 'memize';
-import { I18nManager } from 'react-native';
+import { I18nManager, StyleSheet } from 'react-native';
 import { GestureHandlerRootView } from 'react-native-gesture-handler';
 
 /**
@@ -173,7 +173,7 @@ class Editor extends Component {
 		};
 
 		return (
-			<GestureHandlerRootView style={ { flex: 1 } }>
+			<GestureHandlerRootView style={ styles.container }>
 				<SlotFillProvider>
 					<EditorProvider
 						settings={ editorSettings }
@@ -189,6 +189,12 @@ class Editor extends Component {
 		);
 	}
 }
+
+const styles = StyleSheet.create( {
+	container: {
+		flex: 1,
+	},
+} );
 
 export default compose( [
 	withSelect( ( select ) => {

--- a/packages/react-native-editor/package.json
+++ b/packages/react-native-editor/package.json
@@ -30,7 +30,7 @@
 	"react-native": "src/index",
 	"dependencies": {
 		"@babel/runtime": "^7.20.0",
-		"@gorhom/bottom-sheet": "^4.3.2",
+		"@gorhom/bottom-sheet": "4.4.7",
 		"@react-native-clipboard/clipboard": "1.11.2",
 		"@react-native-community/blur": "4.2.0",
 		"@react-native-community/slider": "https://raw.githubusercontent.com/wordpress-mobile/react-native-slider/v3.0.2-wp-4/react-native-community-slider-3.0.2-wp-4.tgz",

--- a/packages/react-native-editor/package.json
+++ b/packages/react-native-editor/package.json
@@ -30,6 +30,7 @@
 	"react-native": "src/index",
 	"dependencies": {
 		"@babel/runtime": "^7.20.0",
+		"@gorhom/bottom-sheet": "^4.3.2",
 		"@react-native-clipboard/clipboard": "1.11.2",
 		"@react-native-community/blur": "4.2.0",
 		"@react-native-community/slider": "https://raw.githubusercontent.com/wordpress-mobile/react-native-slider/v3.0.2-wp-4/react-native-community-slider-3.0.2-wp-4.tgz",


### PR DESCRIPTION
## Related PRs

* https://github.com/wordpress-mobile/gutenberg-mobile/pull/5057

## What?
Adds `BottomSheetV2` as a potential replacement for the existing `BottomSheet` to address #37559. Updates `DropdownMenu` to utilize `BottomSheetV2`. 

## Why?
Relates to https://github.com/WordPress/gutenberg/issues/42192. As detailed in #37559, the current `BottomSheet` suffers from a number performance and quality issues. 

## How?
The proposed `BottomSheetV2` utilizes [`@gorhom/bottom-sheet`](https://gorhom.github.io/react-native-bottom-sheet/) to benefit from the attention to detail placed on features like performance, dynamic height, gestures, etc. 

## Remaining Work

- [ ] Address unintended style divergences, e.g. drag handle vertical alignment. 
- [ ] Address jump in bottom sheet height on Android while keyboard is open. 
- [ ] Test tablet device. 
- [ ] Test integration with WP host apps. 
- [ ] Fix failing CI tests. 

## Testing Instructions

Perform the following for the heading level/alignment selection bottom sheets on various devices and orientations. 

* Open and close. 
* Swipe to close. 
* Tap backdrop to close. 
* Select option with sheet. 
* Use with device text size set to a11y minimum/maximum. 
* Use with device voice control. 

## Screenshots or screencast 

<details><summary>Android Screenshots</summary>

| Before | After |
| - | - |
| ![before-heading](https://user-images.githubusercontent.com/438664/177639468-687857a3-419a-4dd5-a1fa-71d53122ff79.jpg) | ![after-heading](https://user-images.githubusercontent.com/438664/177639465-6470b73e-e1b3-4de3-b072-45b74f0acc5b.jpg) |
| ![before-alignment](https://user-images.githubusercontent.com/438664/177639467-149767d3-8005-47c0-86ea-4d65046a36af.jpg) | ![after-alignment](https://user-images.githubusercontent.com/438664/177639461-b92a2f85-2b52-4664-8c2d-0591d4c6f3f3.jpg) |

</details>

<details><summary>iOS Screenshots</summary>

| Before | After |
| - | - |
| ![before-heading](https://user-images.githubusercontent.com/438664/177637330-37a59b4d-42d1-4c36-b388-58b22dda73dd.PNG) |  ![after-heading](https://user-images.githubusercontent.com/438664/177637325-49f78e1c-d188-4447-bdb4-32df9a6d1a21.PNG) |
| ![before-alignment](https://user-images.githubusercontent.com/438664/177637327-f7141399-f217-439d-b089-77afff390141.PNG) | ![after-alignment](https://user-images.githubusercontent.com/438664/177637322-0522efae-50e9-4738-ae2d-d6313084404e.PNG) |

</details>

<details><summary>iOS Interactions</summary>

https://user-images.githubusercontent.com/438664/177637099-7d9483e8-735b-4d8f-a794-b1b6078dc30e.MP4

</details> 

