### PR TITLE
Global styles: filter block level styles before compiling global stylesheet

### DIFF
--- a/lib/compat/wordpress-6.1/script-loader.php
+++ b/lib/compat/wordpress-6.1/script-loader.php
@@ -84,6 +84,13 @@ function gutenberg_enqueue_global_styles() {
 		return;
 	}
 
+	/**
+	 * If we are loading CSS for each block separately, then we can load the theme.json CSS conditionally.
+	 * This removes the CSS from the global-styles stylesheet and adds it to the inline CSS for each block.
+	 * This filter has to be registered before we call gutenberg_get_global_stylesheet();
+	 */
+	add_filter( 'gutenberg_get_style_nodes', 'filter_out_block_nodes', 10, 1 );
+
 	$stylesheet = gutenberg_get_global_stylesheet();
 	if ( empty( $stylesheet ) ) {
 		return;
@@ -93,11 +100,6 @@ function gutenberg_enqueue_global_styles() {
 	wp_add_inline_style( 'global-styles', $stylesheet );
 	wp_enqueue_style( 'global-styles' );
 
-	/**
-	 * If we are loading CSS for each block separately, then we can load the theme.json CSS conditionally.
-	 * This removes the CSS from the global-styles stylesheet and adds it to the inline CSS for each block.
-	 */
-	add_filter( 'gutenberg_get_style_nodes', 'filter_out_block_nodes' );
 	// add each block as an inline css.
 	wp_add_global_styles_for_blocks();
 }


### PR DESCRIPTION
Fixes https://github.com/WordPress/gutenberg/issues/42206

## What? Why? How?
Since https://github.com/WordPress/gutenberg/pull/42005, global block styles are enqueued twice:

1. In `global-styles-inline-css`
2. In wp-block-social-links-inline-css

This causes duplicate styles in `styles.blocks[ $block_name ]` rendered to the HTML.

The `gutenberg_get_style_nodes` filter has to be registered before we call `gutenberg_get_global_stylesheet()` otherwise global styles won't filter out the block styles that are later enqueued.

## Testing Instructions
Add some block styles to your theme.json. Any block will do. 

I'm using emptytheme and the Social links block as an example.

<details>

<summary>Example theme.json</summary>

```json
{
	"version": 2,
	"settings": {
		"appearanceTools": true,
		"layout": {
			"contentSize": "840px",
			"wideSize": "1100px"
		}
	},
	"styles": {
		"spacing": {
		},
		"blocks": {
			"core/social-links": {
				"spacing": {
					"blockGap": "55px",
					"margin": "100px",
					"padding": "150px"
				},
				"color": {
					"text": "red",
					"background": "yellow"
				}
			}
		}
	},
	"patterns": [
		"short-text-surrounded-by-round-images",
		"partner-logos"
	]
}

```

</details>

Create a post with that block and publish it.

<details>

<summary>Example block code</summary>

```html
<!-- wp:social-links -->
<ul class="wp-block-social-links"><!-- wp:social-link {"url":"https://wordpress.org","service":"wordpress"} /-->

<!-- wp:social-link {"url":"https://wordpress.org","service":"wordpress"} /-->

<!-- wp:social-link {"url":"https://wordpress.org","service":"wordpress"} /-->

<!-- wp:social-link {"url":"https://wordpress.org","service":"wordpress"} /-->

<!-- wp:social-link {"url":"https://wordpress.org","service":"wordpress"} /-->

<!-- wp:social-link {"url":"https://wordpress.org","service":"wordpress"} /-->

<!-- wp:social-link {"url":"https://wordpress.org","service":"wordpress"} /-->

<!-- wp:social-link {"url":"https://wordpress.org","service":"wordpress"} /-->

<!-- wp:social-link {"url":"https://wordpress.org","service":"wordpress"} /-->

<!-- wp:social-link {"url":"https://wordpress.org","service":"wordpress"} /-->

<!-- wp:social-link {"url":"https://wordpress.org","service":"wordpress"} /-->

<!-- wp:social-link {"url":"https://wordpress.org","service":"wordpress"} /-->

<!-- wp:social-link {"url":"https://wordpress.org","service":"wordpress"} /-->

<!-- wp:social-link {"url":"https://wordpress.org","service":"wordpress"} /-->

<!-- wp:social-link {"url":"https://wordpress.org","service":"wordpress"} /-->

<!-- wp:social-link {"url":"https://wordpress.org","service":"wordpress"} /-->

<!-- wp:social-link {"url":"https://wordpress.org","service":"wordpress"} /-->

<!-- wp:social-link {"url":"https://wordpress.org","service":"wordpress"} /-->

<!-- wp:social-link {"url":"https://wordpress.org","service":"wordpress"} /-->

<!-- wp:social-link {"url":"https://wordpress.org","service":"wordpress"} /-->

<!-- wp:social-link {"url":"https://wordpress.org","service":"wordpress"} /-->

<!-- wp:social-link {"url":"https://wordpress.org","service":"wordpress"} /-->

<!-- wp:social-link {"url":"https://wordpress.org","service":"wordpress"} /-->

<!-- wp:social-link {"url":"https://wordpress.org","service":"wordpress"} /--></ul>
<!-- /wp:social-links -->


```

</details>


Inspect the block HTML and see that the styles are NOT applied twice.


