### PR TITLE
Update link to sample code in gutenberg-examples

### DIFF
--- a/docs/how-to-guides/data-basics/README.md
+++ b/docs/how-to-guides/data-basics/README.md
@@ -4,7 +4,7 @@ This tutorial aims to get you comfortable with the Gutenberg data layer. It guid
 
 ![](https://raw.githubusercontent.com/WordPress/gutenberg/HEAD/docs/how-to-guides/data-basics/media/list-of-pages/part1-finished.jpg)
 
-You may review the [finished app](https://github.com/WordPress/gutenberg-examples/tree/trunk/09-code-data-basics-esnext) in the gutenberg-examples repository.
+You may review the [finished app](https://github.com/WordPress/gutenberg-examples/tree/trunk/non-block-examples/09-code-data-basics-esnext) in the gutenberg-examples repository.
 
 ### Table of Contents
 


### PR DESCRIPTION
## What?
This PR fixes the "finished app" link on [this page](https://developer.wordpress.org/block-editor/how-to-guides/data-basics/) to point to the updated location of the [gutenberg-examples repository](https://github.com/WordPress/gutenberg-examples/) sample code. This link changed due to this refactor https://github.com/WordPress/gutenberg-examples/commit/33348e98209b4ba8aae3e30c636c040b74e63092 and PR: https://github.com/WordPress/gutenberg-examples/pull/195

## Why?
The link was changed when the files were reorganized in the example code repository.

## How?
I found the example code repository on github and noticed that the directory had changed. I copied the link to this directory and compared it with the link on the site and noticed the difference/created this PR

## Testing Instructions
Try to click the new link and verify that it functions correctly and links to the correct location on github.