### PR TITLE
Post Editor: Preload templates post type permissions

### DIFF
--- a/lib/compat/wordpress-6.1/edit-form-blocks.php
+++ b/lib/compat/wordpress-6.1/edit-form-blocks.php
@@ -6,7 +6,7 @@
  */
 
 /**
- * Optimizes the preload paths registered in Core (`edit-form-blocks.php`).
+ * Adds the preload paths registered in Core (`edit-form-blocks.php`).
  *
  * @param array $preload_paths Preload paths to be filtered.
  * @return array

--- a/lib/compat/wordpress-6.1/edit-form-blocks.php
+++ b/lib/compat/wordpress-6.1/edit-form-blocks.php
@@ -8,7 +8,8 @@
 /**
  * Adds the preload paths registered in Core (`edit-form-blocks.php`).
  *
- * @param array $preload_paths Preload paths to be filtered.
+ * @param array                   $preload_paths    Preload paths to be filtered.
+ * @param WP_Block_Editor_Context $context The current block editor context.
  * @return array
  */
 function gutenberg_preload_template_permissions( $preload_paths, $context ) {

--- a/lib/compat/wordpress-6.1/edit-form-blocks.php
+++ b/lib/compat/wordpress-6.1/edit-form-blocks.php
@@ -1,0 +1,21 @@
+<?php
+/**
+ * Patches resources loaded by the block editor page.
+ *
+ * @package gutenberg
+ */
+
+/**
+ * Optimizes the preload paths registered in Core (`edit-form-blocks.php`).
+ *
+ * @param array $preload_paths Preload paths to be filtered.
+ * @return array
+ */
+function gutenberg_preload_template_permissions( $preload_paths, $context ) {
+	if ( ! empty( $context->post ) ) {
+		$preload_paths[] = array( rest_get_route_for_post_type_items( 'wp_template' ), 'OPTIONS' );
+	}
+
+	return $preload_paths;
+}
+add_filter( 'block_editor_rest_api_preload_paths', 'gutenberg_preload_template_permissions', 10, 2 );

--- a/lib/load.php
+++ b/lib/load.php
@@ -87,6 +87,7 @@ require __DIR__ . '/compat/wordpress-6.1/wp-theme-get-post-templates.php';
 require __DIR__ . '/compat/wordpress-6.1/script-loader.php';
 require __DIR__ . '/compat/wordpress-6.1/date-settings.php';
 require __DIR__ . '/compat/wordpress-6.1/block-patterns.php';
+require __DIR__ . '/compat/wordpress-6.1/edit-form-blocks.php';
 
 // Experimental features.
 remove_action( 'plugins_loaded', '_wp_theme_json_webfonts_handler' ); // Turns off WP 6.0's stopgap handler for Webfonts API.


### PR DESCRIPTION
## What?
Resolves #33994.

PR adds preloading for templates post-type permissions.

## Why?
We usually preload permissions for the post types used in the editor. It also improves the time to render a bit for the PostTemplate component.

## Testing Instructions
1. Open a Post or Page
2. Open the DevTools Network tab and filter for `templates`
3. Confirm that the OPTIONS request isn't made

## Screenshots or screencast <!-- if applicable -->
![CleanShot 2022-07-07 at 09 02 59](https://user-images.githubusercontent.com/240569/177695385-4c438bbd-0388-4757-9253-425d02d18004.png)

