### PR TITLE
Enable `shift` in URLPopover component

### DIFF
--- a/packages/block-editor/src/components/url-popover/index.js
+++ b/packages/block-editor/src/components/url-popover/index.js
@@ -33,6 +33,7 @@ function URLPopover( {
 			className="block-editor-url-popover"
 			focusOnMount={ focusOnMount }
 			position={ position }
+			__unstableShift
 			{ ...popoverProps }
 		>
 			<div className="block-editor-url-popover__input-container">

--- a/packages/block-editor/src/components/url-popover/test/__snapshots__/index.js.snap
+++ b/packages/block-editor/src/components/url-popover/test/__snapshots__/index.js.snap
@@ -2,6 +2,7 @@
 
 exports[`URLPopover matches the snapshot in its default state 1`] = `
 <ForwardRef(Popover)
+  __unstableShift={true}
   className="block-editor-url-popover"
   focusOnMount="firstElement"
   position="bottom center"
@@ -38,6 +39,7 @@ exports[`URLPopover matches the snapshot in its default state 1`] = `
 
 exports[`URLPopover matches the snapshot when the settings are toggled open 1`] = `
 <ForwardRef(Popover)
+  __unstableShift={true}
   className="block-editor-url-popover"
   focusOnMount="firstElement"
   position="bottom center"
@@ -81,6 +83,7 @@ exports[`URLPopover matches the snapshot when the settings are toggled open 1`] 
 
 exports[`URLPopover matches the snapshot when there are no settings 1`] = `
 <ForwardRef(Popover)
+  __unstableShift={true}
   className="block-editor-url-popover"
   focusOnMount="firstElement"
   position="bottom center"


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
This PR adds makes URLPopover component to use the `shift` functionality which checks if the popover is within the viewport. I'm currently exploring some issues with the Popover and I'm still wondering where we should not want to `shift` and made that [change here](https://github.com/WordPress/gutenberg/pull/41402). 

We might remove this flag in the future or change the default, or pass some more specific options to fine tune the shifting of some components..
<!-- In a few words, what is the PR actually doing? -->


## Testing Instructions
1. Test components that use `URLPopover` near the edges of a viewport. 
2. Examples are the `Social Icons` block, or the `Image` block to insert link.

#### Before


https://user-images.githubusercontent.com/16275880/177723635-374dcdc6-a9df-46dd-add2-ac9eef9331e9.mov


#### After


https://user-images.githubusercontent.com/16275880/177723625-4d4da29e-c498-469c-b91e-46eba89bd722.mov



