### PR TITLE
Lodash: Refactor away from `_.identity()`

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -93,6 +93,7 @@ module.exports = {
 							'findLast',
 							'flatten',
 							'flattenDeep',
+							'identity',
 							'invoke',
 							'isArray',
 							'isFinite',

--- a/packages/block-editor/src/components/block-list/index.native.js
+++ b/packages/block-editor/src/components/block-list/index.native.js
@@ -1,7 +1,6 @@
 /**
  * External dependencies
  */
-import { identity } from 'lodash';
 import { View, Platform, TouchableWithoutFeedback } from 'react-native';
 
 /**
@@ -35,6 +34,7 @@ import { BlockDraggableWrapper } from '../block-draggable';
 import { store as blockEditorStore } from '../../store';
 
 export const OnCaretVerticalPositionChange = createContext();
+const identity = ( x ) => x;
 
 const stylesMemo = {};
 const getStyles = (

--- a/packages/block-editor/src/hooks/utils.js
+++ b/packages/block-editor/src/hooks/utils.js
@@ -5,7 +5,6 @@ import {
 	pickBy,
 	isEmpty,
 	isObject,
-	identity,
 	mapValues,
 	forEach,
 	get,
@@ -18,6 +17,8 @@ import {
  * WordPress dependencies
  */
 import { getBlockSupport } from '@wordpress/blocks';
+
+const identity = ( x ) => x;
 
 /**
  * Removed falsy values from nested object.

--- a/packages/block-editor/src/store/reducer.js
+++ b/packages/block-editor/src/store/reducer.js
@@ -11,7 +11,6 @@ import {
 	mapValues,
 	isEqual,
 	isEmpty,
-	identity,
 	omitBy,
 } from 'lodash';
 
@@ -25,6 +24,8 @@ import { store as blocksStore } from '@wordpress/blocks';
  */
 import { PREFERENCES_DEFAULTS, SETTINGS_DEFAULTS } from './defaults';
 import { insertAt, moveTo } from './array';
+
+const identity = ( x ) => x;
 
 /**
  * Given an array of blocks, returns an object where each key is a nesting

--- a/packages/block-library/src/utils/clean-empty-object.js
+++ b/packages/block-library/src/utils/clean-empty-object.js
@@ -1,7 +1,9 @@
 /**
  * External dependencies
  */
-import { isEmpty, isObject, identity, mapValues, pickBy } from 'lodash';
+import { isEmpty, isObject, mapValues, pickBy } from 'lodash';
+
+const identity = ( x ) => x;
 
 /**
  * Removed empty nodes from nested objects.

--- a/packages/blocks/src/api/validation/index.js
+++ b/packages/blocks/src/api/validation/index.js
@@ -2,7 +2,7 @@
  * External dependencies
  */
 import { Tokenizer } from 'simple-html-tokenizer';
-import { identity, xor, fromPairs, isEqual, includes } from 'lodash';
+import { xor, fromPairs, isEqual, includes } from 'lodash';
 
 /**
  * WordPress dependencies
@@ -24,6 +24,8 @@ import { normalizeBlockType } from '../utils';
 /** @typedef {import('../parser').WPBlock} WPBlock */
 /** @typedef {import('../registration').WPBlockType} WPBlockType */
 /** @typedef {import('./logger').LoggerItem} LoggerItem */
+
+const identity = ( x ) => x;
 
 /**
  * Globally matches any consecutive whitespace

--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -17,6 +17,7 @@
 -   `ColorPicker` updated to satisfy `react/exhuastive-deps` eslint rule ([#41294](https://github.com/WordPress/gutenberg/pull/41294)).
 -   `Slot`/`Fill`: Refactor away from Lodash ([#42153](https://github.com/WordPress/gutenberg/pull/42153/)).
 -   `ComboboxControl`: Refactor away from `_.deburr()` ([#42169](https://github.com/WordPress/gutenberg/pull/42169/)).
+-   `FormTokenField`: Refactor away from `_.identity()` ([#42215](https://github.com/WordPress/gutenberg/pull/42215/)).
 
 ### Bug Fix
 

--- a/packages/components/src/form-token-field/index.tsx
+++ b/packages/components/src/form-token-field/index.tsx
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { last, clone, uniq, map, difference, identity, some } from 'lodash';
+import { last, clone, uniq, map, difference, some } from 'lodash';
 import classnames from 'classnames';
 import type { KeyboardEvent, MouseEvent, TouchEvent } from 'react';
 
@@ -34,6 +34,8 @@ import { TokensAndInputWrapperFlex } from './styles';
 import SuggestionsList from './suggestions-list';
 import type { FormTokenFieldProps, TokenItem } from './types';
 import { FlexItem } from '../flex';
+
+const identity = ( value: string ) => value;
 
 /**
  * A `FormTokenField` is a field similar to the tags and categories fields in the interim editor chrome,

--- a/packages/edit-site/src/components/global-styles/global-styles-provider.js
+++ b/packages/edit-site/src/components/global-styles/global-styles-provider.js
@@ -1,14 +1,7 @@
 /**
  * External dependencies
  */
-import {
-	mergeWith,
-	pickBy,
-	isEmpty,
-	isObject,
-	identity,
-	mapValues,
-} from 'lodash';
+import { mergeWith, pickBy, isEmpty, isObject, mapValues } from 'lodash';
 
 /**
  * WordPress dependencies
@@ -21,6 +14,8 @@ import { store as coreStore } from '@wordpress/core-data';
  * Internal dependencies
  */
 import { GlobalStylesContext } from './context';
+
+const identity = ( x ) => x;
 
 function mergeTreesCustomizer( _, srcValue ) {
 	// We only pass as arrays the presets,

--- a/packages/editor/src/components/post-taxonomies/index.js
+++ b/packages/editor/src/components/post-taxonomies/index.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { filter, identity, includes } from 'lodash';
+import { filter, includes } from 'lodash';
 
 /**
  * WordPress dependencies
@@ -17,6 +17,8 @@ import { store as coreStore } from '@wordpress/core-data';
 import HierarchicalTermSelector from './hierarchical-term-selector';
 import FlatTermSelector from './flat-term-selector';
 import { store as editorStore } from '../../store';
+
+const identity = ( x ) => x;
 
 export function PostTaxonomies( {
 	postType,


### PR DESCRIPTION
## What?
Lodash's `identity` is used only a few times in the entire codebase. This PR aims to remove that usage.

## Why?
Lodash is known to unnecessarily inflate the bundle size of packages, and in most cases, it can be replaced with native language functionality. See these for more information and rationale:

* https://github.com/WordPress/gutenberg/issues/16938#issuecomment-602837246
* https://github.com/WordPress/gutenberg/issues/17025
* https://github.com/WordPress/gutenberg/issues/39495 

## How?
Removing `identity` is straightforward in favor of a simple function that returns the same argument. While we could inlne it and redeclare it every time, this can cause some unexpected bugs and especially unexpected re-renders, because it will be a different function every time.

## Testing Instructions
* Verify all tests still pass.
* Smoke test the `FormTokenField` in storybook.
* Smoke test global styles in the site editor.
* Smoke test adding/removing/changing categories and tags in a post.
* RN: Verify the block list still looks and works well in different contexts.