### PR TITLE
Lodash: Refactor away from `_.fromPairs()`

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -94,6 +94,7 @@ module.exports = {
 							'findLast',
 							'flatten',
 							'flattenDeep',
+							'fromPairs',
 							'identity',
 							'invoke',
 							'isArray',

--- a/packages/blocks/src/api/validation/index.js
+++ b/packages/blocks/src/api/validation/index.js
@@ -2,7 +2,7 @@
  * External dependencies
  */
 import { Tokenizer } from 'simple-html-tokenizer';
-import { xor, fromPairs, isEqual, includes } from 'lodash';
+import { xor, isEqual, includes } from 'lodash';
 
 /**
  * WordPress dependencies
@@ -398,7 +398,7 @@ export function getStyleProperties( text ) {
 			return [ key.trim(), getNormalizedStyleValue( value.trim() ) ];
 		} );
 
-	return fromPairs( pairs );
+	return Object.fromEntries( pairs );
 }
 
 /**
@@ -419,7 +419,7 @@ export const isEqualAttributesOfName = {
 	},
 	// For each boolean attribute, mere presence of attribute in both is enough
 	// to assume equivalence.
-	...fromPairs(
+	...Object.fromEntries(
 		BOOLEAN_ATTRIBUTES.map( ( attribute ) => [ attribute, () => true ] )
 	),
 };

--- a/packages/create-block/lib/templates.js
+++ b/packages/create-block/lib/templates.js
@@ -6,7 +6,6 @@ const glob = require( 'fast-glob' );
 const { resolve } = require( 'path' );
 const { existsSync } = require( 'fs' );
 const { mkdtemp, readFile } = require( 'fs' ).promises;
-const { fromPairs } = require( 'lodash' );
 const npmPackageArg = require( 'npm-package-arg' );
 const { tmpdir } = require( 'os' );
 const { join } = require( 'path' );
@@ -53,7 +52,7 @@ const getOutputTemplates = async ( outputTemplatesPath ) => {
 		cwd: outputTemplatesPath,
 		dot: true,
 	} );
-	return fromPairs(
+	return Object.fromEntries(
 		await Promise.all(
 			outputTemplatesFiles.map( async ( outputTemplateFile ) => {
 				const outputFile = outputTemplateFile.replace(
@@ -75,7 +74,7 @@ const getOutputAssets = async ( outputAssetsPath ) => {
 		cwd: outputAssetsPath,
 		dot: true,
 	} );
-	return fromPairs(
+	return Object.fromEntries(
 		await Promise.all(
 			outputAssetFiles.map( async ( outputAssetFile ) => {
 				const outputAsset = await readFile(

--- a/test/integration/full-content/full-content.test.js
+++ b/test/integration/full-content/full-content.test.js
@@ -2,7 +2,7 @@
  * External dependencies
  */
 import glob from 'fast-glob';
-import { fromPairs, startsWith, get } from 'lodash';
+import { startsWith, get } from 'lodash';
 import { format } from 'util';
 
 /**
@@ -57,7 +57,7 @@ describe( 'full post content fixture', () => {
 		const blockMetadataFiles = glob.sync(
 			'packages/block-library/src/*/block.json'
 		);
-		const blockDefinitions = fromPairs(
+		const blockDefinitions = Object.fromEntries(
 			blockMetadataFiles.map( ( file ) => {
 				const { name, ...metadata } = require( file );
 				return [ name, metadata ];


### PR DESCRIPTION
## What?
Lodash's `fromPairs` is used only a few times in the entire codebase. This PR aims to remove that usage.

## Why?
Lodash is known to unnecessarily inflate the bundle size of packages, and in most cases, it can be replaced with native language functionality. See these for more information and rationale:

* https://github.com/WordPress/gutenberg/issues/16938#issuecomment-602837246
* https://github.com/WordPress/gutenberg/issues/17025
* https://github.com/WordPress/gutenberg/issues/39495 

## How?
Removing `fromPairs` is straightforward in favor of a simple `Object.fromEntries()` replacement. 

## Testing Instructions
* Verify `create-block` still works well: `npx @wordpress/create-block testblock`
* Verify full content integration tests still pass: `npm run test-unit test/integration/full-content/`
* Verify block validation tests still pass: `npm run test-unit packages/blocks/src/api/test/validation.js`