### PR TITLE
Components: Remove Lodash from `DropdownMenu`

### DIFF
--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -24,6 +24,7 @@
 -   `ComboboxControl`: Refactor away from `_.deburr()` ([#42169](https://github.com/WordPress/gutenberg/pull/42169/)).
 -   `FormTokenField`: Refactor away from `_.identity()` ([#42215](https://github.com/WordPress/gutenberg/pull/42215/)).
 -   `SelectControl`: Use roles and `@testing-library/user-event` in unit tests ([#42308](https://github.com/WordPress/gutenberg/pull/42308)).
+-   `DropdownMenu`: Refactor away from Lodash ([#42218](https://github.com/WordPress/gutenberg/pull/42218/)).
 -   `ToolbarGroup`: Refactor away from `_.flatMap()` ([#42223](https://github.com/WordPress/gutenberg/pull/42223/)).
 -   `TreeSelect`: Refactor away from `_.flatMap()` ([#42223](https://github.com/WordPress/gutenberg/pull/42223/)).
 -   `Autocomplete`: Refactor away from `_.deburr()` ([#42266](https://github.com/WordPress/gutenberg/pull/42266/)).

--- a/packages/components/src/dropdown-menu/index.js
+++ b/packages/components/src/dropdown-menu/index.js
@@ -3,7 +3,6 @@
  * External dependencies
  */
 import classnames from 'classnames';
-import { flatMap, isEmpty } from 'lodash';
 
 /**
  * WordPress dependencies
@@ -59,13 +58,13 @@ function DropdownMenu( dropdownMenuProps ) {
 		noIcons,
 	} = dropdownMenuProps;
 
-	if ( isEmpty( controls ) && ! isFunction( children ) ) {
+	if ( ( ! controls || ! controls.length ) && ! isFunction( children ) ) {
 		return null;
 	}
 
 	// Normalize controls to nested array of objects (sets of controls)
 	let controlSets;
-	if ( ! isEmpty( controls ) ) {
+	if ( controls && controls.length ) {
 		controlSets = controls;
 		if ( ! Array.isArray( controlSets[ 0 ] ) ) {
 			controlSets = [ controlSets ];
@@ -146,50 +145,54 @@ function DropdownMenu( dropdownMenuProps ) {
 				return (
 					<NavigableMenu { ...mergedMenuProps } role="menu">
 						{ isFunction( children ) ? children( props ) : null }
-						{ flatMap( controlSets, ( controlSet, indexOfSet ) =>
-							controlSet.map( ( control, indexOfControl ) => (
-								<Button
-									key={ [
-										indexOfSet,
-										indexOfControl,
-									].join() }
-									onClick={ ( event ) => {
-										event.stopPropagation();
-										props.onClose();
-										if ( control.onClick ) {
-											control.onClick();
+						{ controlSets
+							?.map( ( controlSet, indexOfSet ) =>
+								controlSet.map( ( control, indexOfControl ) => (
+									<Button
+										key={ [
+											indexOfSet,
+											indexOfControl,
+										].join() }
+										onClick={ ( event ) => {
+											event.stopPropagation();
+											props.onClose();
+											if ( control.onClick ) {
+												control.onClick();
+											}
+										} }
+										className={ classnames(
+											'components-dropdown-menu__menu-item',
+											{
+												'has-separator':
+													indexOfSet > 0 &&
+													indexOfControl === 0,
+												'is-active': control.isActive,
+												'is-icon-only': ! control.title,
+											}
+										) }
+										icon={ control.icon }
+										label={ control.label }
+										aria-checked={
+											control.role ===
+												'menuitemcheckbox' ||
+											control.role === 'menuitemradio'
+												? control.isActive
+												: undefined
 										}
-									} }
-									className={ classnames(
-										'components-dropdown-menu__menu-item',
-										{
-											'has-separator':
-												indexOfSet > 0 &&
-												indexOfControl === 0,
-											'is-active': control.isActive,
-											'is-icon-only': ! control.title,
+										role={
+											control.role ===
+												'menuitemcheckbox' ||
+											control.role === 'menuitemradio'
+												? control.role
+												: 'menuitem'
 										}
-									) }
-									icon={ control.icon }
-									label={ control.label }
-									aria-checked={
-										control.role === 'menuitemcheckbox' ||
-										control.role === 'menuitemradio'
-											? control.isActive
-											: undefined
-									}
-									role={
-										control.role === 'menuitemcheckbox' ||
-										control.role === 'menuitemradio'
-											? control.role
-											: 'menuitem'
-									}
-									disabled={ control.isDisabled }
-								>
-									{ control.title }
-								</Button>
-							) )
-						) }
+										disabled={ control.isDisabled }
+									>
+										{ control.title }
+									</Button>
+								) )
+							)
+							.flat() }
 					</NavigableMenu>
 				);
 			} }

--- a/packages/components/src/dropdown-menu/index.js
+++ b/packages/components/src/dropdown-menu/index.js
@@ -58,13 +58,13 @@ function DropdownMenu( dropdownMenuProps ) {
 		noIcons,
 	} = dropdownMenuProps;
 
-	if ( ( ! controls || ! controls.length ) && ! isFunction( children ) ) {
+	if ( ! controls?.length && ! isFunction( children ) ) {
 		return null;
 	}
 
 	// Normalize controls to nested array of objects (sets of controls)
 	let controlSets;
-	if ( controls && controls.length ) {
+	if ( controls?.length ) {
 		controlSets = controls;
 		if ( ! Array.isArray( controlSets[ 0 ] ) ) {
 			controlSets = [ controlSets ];

--- a/packages/components/src/dropdown-menu/index.js
+++ b/packages/components/src/dropdown-menu/index.js
@@ -145,54 +145,50 @@ function DropdownMenu( dropdownMenuProps ) {
 				return (
 					<NavigableMenu { ...mergedMenuProps } role="menu">
 						{ isFunction( children ) ? children( props ) : null }
-						{ controlSets
-							?.map( ( controlSet, indexOfSet ) =>
-								controlSet.map( ( control, indexOfControl ) => (
-									<Button
-										key={ [
-											indexOfSet,
-											indexOfControl,
-										].join() }
-										onClick={ ( event ) => {
-											event.stopPropagation();
-											props.onClose();
-											if ( control.onClick ) {
-												control.onClick();
-											}
-										} }
-										className={ classnames(
-											'components-dropdown-menu__menu-item',
-											{
-												'has-separator':
-													indexOfSet > 0 &&
-													indexOfControl === 0,
-												'is-active': control.isActive,
-												'is-icon-only': ! control.title,
-											}
-										) }
-										icon={ control.icon }
-										label={ control.label }
-										aria-checked={
-											control.role ===
-												'menuitemcheckbox' ||
-											control.role === 'menuitemradio'
-												? control.isActive
-												: undefined
+						{ controlSets?.flatMap( ( controlSet, indexOfSet ) =>
+							controlSet.map( ( control, indexOfControl ) => (
+								<Button
+									key={ [
+										indexOfSet,
+										indexOfControl,
+									].join() }
+									onClick={ ( event ) => {
+										event.stopPropagation();
+										props.onClose();
+										if ( control.onClick ) {
+											control.onClick();
 										}
-										role={
-											control.role ===
-												'menuitemcheckbox' ||
-											control.role === 'menuitemradio'
-												? control.role
-												: 'menuitem'
+									} }
+									className={ classnames(
+										'components-dropdown-menu__menu-item',
+										{
+											'has-separator':
+												indexOfSet > 0 &&
+												indexOfControl === 0,
+											'is-active': control.isActive,
+											'is-icon-only': ! control.title,
 										}
-										disabled={ control.isDisabled }
-									>
-										{ control.title }
-									</Button>
-								) )
-							)
-							.flat() }
+									) }
+									icon={ control.icon }
+									label={ control.label }
+									aria-checked={
+										control.role === 'menuitemcheckbox' ||
+										control.role === 'menuitemradio'
+											? control.isActive
+											: undefined
+									}
+									role={
+										control.role === 'menuitemcheckbox' ||
+										control.role === 'menuitemradio'
+											? control.role
+											: 'menuitem'
+									}
+									disabled={ control.isDisabled }
+								>
+									{ control.title }
+								</Button>
+							) )
+						) }
 					</NavigableMenu>
 				);
 			} }

--- a/packages/components/src/dropdown-menu/index.native.js
+++ b/packages/components/src/dropdown-menu/index.native.js
@@ -2,7 +2,6 @@
  * External dependencies
  */
 import classnames from 'classnames';
-import { flatMap, isEmpty } from 'lodash';
 import { Platform } from 'react-native';
 /**
  * WordPress dependencies
@@ -53,13 +52,13 @@ function DropdownMenu( {
 	popoverProps,
 	toggleProps,
 } ) {
-	if ( isEmpty( controls ) && ! isFunction( children ) ) {
+	if ( ( ! controls || ! controls.length ) && ! isFunction( children ) ) {
 		return null;
 	}
 
 	// Normalize controls to nested array of objects (sets of controls)
 	let controlSets;
-	if ( ! isEmpty( controls ) ) {
+	if ( controls && controls.length ) {
 		controlSets = controls;
 		if ( ! Array.isArray( controlSets[ 0 ] ) ) {
 			controlSets = [ controlSets ];
@@ -131,9 +130,8 @@ function DropdownMenu( {
 							title={ label }
 							style={ { paddingLeft: 0, paddingRight: 0 } }
 						>
-							{ flatMap(
-								controlSets,
-								( controlSet, indexOfSet ) =>
+							{ controlSets
+								?.map( ( controlSet, indexOfSet ) =>
 									controlSet.map(
 										( control, indexOfControl ) => (
 											<BottomSheet.Cell
@@ -160,7 +158,8 @@ function DropdownMenu( {
 											/>
 										)
 									)
-							) }
+								)
+								.flat() }
 						</PanelBody>
 					</BottomSheet>
 				);

--- a/packages/components/src/dropdown-menu/index.native.js
+++ b/packages/components/src/dropdown-menu/index.native.js
@@ -52,13 +52,13 @@ function DropdownMenu( {
 	popoverProps,
 	toggleProps,
 } ) {
-	if ( ( ! controls || ! controls.length ) && ! isFunction( children ) ) {
+	if ( ! controls?.length && ! isFunction( children ) ) {
 		return null;
 	}
 
 	// Normalize controls to nested array of objects (sets of controls)
 	let controlSets;
-	if ( controls && controls.length ) {
+	if ( controls?.length ) {
 		controlSets = controls;
 		if ( ! Array.isArray( controlSets[ 0 ] ) ) {
 			controlSets = [ controlSets ];

--- a/packages/components/src/dropdown-menu/index.native.js
+++ b/packages/components/src/dropdown-menu/index.native.js
@@ -130,8 +130,8 @@ function DropdownMenu( {
 							title={ label }
 							style={ { paddingLeft: 0, paddingRight: 0 } }
 						>
-							{ controlSets
-								?.map( ( controlSet, indexOfSet ) =>
+							{ controlSets?.flatMap(
+								( controlSet, indexOfSet ) =>
 									controlSet.map(
 										( control, indexOfControl ) => (
 											<BottomSheet.Cell
@@ -158,8 +158,7 @@ function DropdownMenu( {
 											/>
 										)
 									)
-								)
-								.flat() }
+							) }
 						</PanelBody>
 					</BottomSheet>
 				);


### PR DESCRIPTION
## What?
This PR removes all of the Lodash from the `DropdownMenu` component. There are just a few usages and conversion is pretty straightforward. 

## Why?

Lodash is known to unnecessarily inflate the bundle size of packages, and in most cases, it can be replaced with native language functionality. See these for more information and rationale:

* https://github.com/WordPress/gutenberg/issues/16938#issuecomment-602837246
* https://github.com/WordPress/gutenberg/issues/17025
* https://github.com/WordPress/gutenberg/issues/39495 

## How?
We have to deal essentially a couple of methods, and migration away from them is pretty straightforward:

#### `flatMap()`

We're replacing it with a `map()` on the arrays, followed by a `.flat()` to flatten the result array.

#### `isEmpty()`

Since the usage is for arrays, ensuring they're not nullish and have `.length` is a substantial replacement.

## Testing Instructions
* On web, verify block transformation dropdown menu still appears and works well.
* On RN, verify heading level selection dropdown menu still appears and works well.
* Verify tests still pass: `npm run test-unit packages/components/src/dropdown-menu`.