### PR TITLE
Blocks: Refactor blocks API away from `_.flatMap()`

### DIFF
--- a/packages/blocks/src/api/factory.js
+++ b/packages/blocks/src/api/factory.js
@@ -8,7 +8,6 @@ import {
 	some,
 	filter,
 	first,
-	flatMap,
 	has,
 	uniq,
 	isEmpty,
@@ -293,10 +292,9 @@ const getBlockTypesForPossibleToTransforms = ( blocks ) => {
 	} );
 
 	// Build a list of block names using the possible 'to' transforms.
-	const blockNames = flatMap(
-		possibleTransforms,
-		( transformation ) => transformation.blocks
-	);
+	const blockNames = possibleTransforms
+		.map( ( transformation ) => transformation.blocks )
+		.flat();
 
 	// Map block names to block types.
 	return blockNames.map( ( name ) =>
@@ -402,9 +400,9 @@ export function findTransform( transforms, predicate ) {
 export function getBlockTransforms( direction, blockTypeOrName ) {
 	// When retrieving transforms for all block types, recurse into self.
 	if ( blockTypeOrName === undefined ) {
-		return flatMap( getBlockTypes(), ( { name } ) =>
-			getBlockTransforms( direction, name )
-		);
+		return getBlockTypes()
+			.map( ( { name } ) => getBlockTransforms( direction, name ) )
+			.flat();
 	}
 
 	// Validate that block type exists and has array of direction.

--- a/packages/blocks/src/api/raw-handling/index.js
+++ b/packages/blocks/src/api/raw-handling/index.js
@@ -1,9 +1,4 @@
 /**
- * External dependencies
- */
-import { flatMap, compact } from 'lodash';
-
-/**
  * WordPress dependencies
  */
 import deprecated from '@wordpress/deprecated';
@@ -51,8 +46,8 @@ export function rawHandler( { HTML = '' } ) {
 	const pieces = shortcodeConverter( HTML );
 	const blockContentSchema = getBlockContentSchema();
 
-	return compact(
-		flatMap( pieces, ( piece ) => {
+	return pieces
+		.map( ( piece ) => {
 			// Already a block from shortcode.
 			if ( typeof piece !== 'string' ) {
 				return piece;
@@ -78,5 +73,6 @@ export function rawHandler( { HTML = '' } ) {
 
 			return htmlToBlocks( piece );
 		} )
-	);
+		.flat()
+		.filter( Boolean );
 }

--- a/packages/blocks/src/api/raw-handling/paste-handler.js
+++ b/packages/blocks/src/api/raw-handling/paste-handler.js
@@ -1,9 +1,4 @@
 /**
- * External dependencies
- */
-import { flatMap, compact } from 'lodash';
-
-/**
  * WordPress dependencies
  */
 import { getPhrasingContentSchema, removeInvalidHTML } from '@wordpress/dom';
@@ -174,8 +169,8 @@ export function pasteHandler( {
 	const phrasingContentSchema = getPhrasingContentSchema( 'paste' );
 	const blockContentSchema = getBlockContentSchema( 'paste' );
 
-	const blocks = compact(
-		flatMap( pieces, ( piece ) => {
+	const blocks = pieces
+		.map( ( piece ) => {
 			// Already a block from shortcode.
 			if ( typeof piece !== 'string' ) {
 				return piece;
@@ -216,7 +211,8 @@ export function pasteHandler( {
 
 			return htmlToBlocks( piece );
 		} )
-	);
+		.flat()
+		.filter( Boolean );
 
 	// If we're allowed to return inline content, and there is only one
 	// inlineable block, and the original plain text content does not have any


### PR DESCRIPTION
## What?
This PR removes all of the `_.flatMap()` usage from the blocks API. There are just a few usages and conversion is pretty straightforward. With #42218 in place, we have only a few other `flatMap()` usages to remove to completely deprecate that Lodash function.

## Why?

Lodash is known to unnecessarily inflate the bundle size of packages, and in most cases, it can be replaced with native language functionality. See these for more information and rationale:

* https://github.com/WordPress/gutenberg/issues/16938#issuecomment-602837246
* https://github.com/WordPress/gutenberg/issues/17025
* https://github.com/WordPress/gutenberg/issues/39495 

## How?

We're replacing `flatMap()` array usages with `.map()`, followed by `.flat()`. We also remove a couple of stray `compact()` usages, that are easy enough to replace with `.filter( Boolean )`.

## Testing Instructions

The affected areas are well covered by tests, verify the following still pass:

* `npm run test-unit test/integration/blocks-raw-handling`
* `npm run test-unit packages/blocks/src/api/test/factory.js`

