### PR TITLE
Experiment: Style Engine Rules & Store objects

### DIFF
--- a/lib/load.php
+++ b/lib/load.php
@@ -116,7 +116,10 @@ if ( file_exists( __DIR__ . '/../build/style-engine/class-wp-style-engine-gutenb
 if ( file_exists( __DIR__ . '/../build/style-engine/class-wp-style-engine-css-declarations-gutenberg.php' ) ) {
 	require_once __DIR__ . '/../build/style-engine/class-wp-style-engine-css-declarations-gutenberg.php';
 }
+if ( file_exists( __DIR__ . '/../build/style-engine/class-wp-style-engine-css-rule-gutenberg.php' ) ) {
+	require_once __DIR__ . '/../build/style-engine/class-wp-style-engine-css-rule-gutenberg.php';
 
+}
 // Block supports overrides.
 require __DIR__ . '/block-supports/utils.php';
 require __DIR__ . '/block-supports/elements.php';

--- a/lib/load.php
+++ b/lib/load.php
@@ -118,8 +118,11 @@ if ( file_exists( __DIR__ . '/../build/style-engine/class-wp-style-engine-css-de
 }
 if ( file_exists( __DIR__ . '/../build/style-engine/class-wp-style-engine-css-rule-gutenberg.php' ) ) {
 	require_once __DIR__ . '/../build/style-engine/class-wp-style-engine-css-rule-gutenberg.php';
-
 }
+if ( file_exists( __DIR__ . '/../build/style-engine/class-wp-style-engine-css-rules-store-gutenberg.php' ) ) {
+	require_once __DIR__ . '/../build/style-engine/class-wp-style-engine-css-rules-store-gutenberg.php';
+}
+
 // Block supports overrides.
 require __DIR__ . '/block-supports/utils.php';
 require __DIR__ . '/block-supports/elements.php';

--- a/packages/style-engine/class-wp-style-engine-css-rule.php
+++ b/packages/style-engine/class-wp-style-engine-css-rule.php
@@ -50,12 +50,16 @@ class WP_Style_Engine_CSS_Rule {
 	 * Set the selector.
 	 *
 	 * @param string $selector The CSS selector.
+	 *
+	 * @return WP_Style_Engine_CSS_Rule Returns the object to allow chaining of methods.
 	 */
 	public function set_selector( $selector ) {
 		if ( empty( $selector ) ) {
 			return;
 		}
 		$this->selector = esc_html( $selector );
+
+		return $this;
 	}
 
 	/**
@@ -63,6 +67,8 @@ class WP_Style_Engine_CSS_Rule {
 	 *
 	 * @param array|WP_Style_Engine_CSS_Declarations $declarations An array of declarations (property => value pairs),
 	 *                                                             or a WP_Style_Engine_CSS_Declarations object.
+	 *
+	 * @return WP_Style_Engine_CSS_Rule Returns the object to allow chaining of methods.
 	 */
 	public function set_declarations( $declarations ) {
 		$is_declarations_object = ! is_array( $declarations );
@@ -74,6 +80,8 @@ class WP_Style_Engine_CSS_Rule {
 			$this->declarations = new WP_Style_Engine_CSS_Declarations( $declarations_array );
 		}
 		$this->declarations->add_declarations( $declarations_array );
+
+		return $this;
 	}
 
 	/**

--- a/packages/style-engine/class-wp-style-engine-css-rule.php
+++ b/packages/style-engine/class-wp-style-engine-css-rule.php
@@ -26,13 +26,6 @@ class WP_Style_Engine_CSS_Rule {
 	protected $selector;
 
 	/**
-	 * The parent rule.
-	 *
-	 * @var WP_Style_Engine_CSS_Rule
-	 */
-	protected $parent;
-
-	/**
 	 * The selector declarations.
 	 *
 	 * Contains an array of WP_Style_Engine_CSS_Declarations objects.
@@ -45,12 +38,10 @@ class WP_Style_Engine_CSS_Rule {
 	 * Constructor
 	 *
 	 * @param string                             $selector     The CSS selector.
-	 * @param WP_Style_Engine_CSS_Rule|null      $parent       The parent rule.
 	 * @param WP_Style_Engine_CSS_Declarations[] $declarations An array of WP_Style_Engine_CSS_Declarations objects.
 	 */
-	public function __construct( $selector = '', $parent = null, $declarations = array() ) {
+	public function __construct( $selector = '', $declarations = array() ) {
 		$this->set_selector( $selector );
-		$this->set_parent( $parent );
 		$this->set_declarations( $declarations );
 	}
 
@@ -67,18 +58,6 @@ class WP_Style_Engine_CSS_Rule {
 	}
 
 	/**
-	 * Set the parent selector.
-	 *
-	 * @param WP_Style_Engine_CSS_Rule $parent The parent rule.
-	 */
-	public function set_parent( $parent ) {
-		if ( ! $parent instanceof WP_Style_Engine_CSS_Rule ) {
-			return;
-		}
-		$this->parent = $parent;
-	}
-
-	/**
 	 * Set the declarations.
 	 *
 	 * @param WP_Style_Engine_CSS_Declarations[] $declarations An array of WP_Style_Engine_CSS_Declarations objects.
@@ -91,24 +70,12 @@ class WP_Style_Engine_CSS_Rule {
 	}
 
 	/**
-	 * Get the parent selector.
-	 *
-	 * @return string
-	 */
-	public function get_parent_selector() {
-		return $this->parent ? $this->parent->get_selector() : '';
-	}
-
-	/**
 	 * Get the full selector.
 	 *
 	 * @return string
 	 */
 	public function get_selector() {
-		if ( 0 === strpos( $this->selector, '&' ) ) {
-			return $this->get_parent_selector() . substr( $this->selector, 1 );
-		}
-		return $this->get_parent_selector() . ' ' . $this->selector;
+		return $this->selector;
 	}
 
 	/**

--- a/packages/style-engine/class-wp-style-engine-css-rule.php
+++ b/packages/style-engine/class-wp-style-engine-css-rule.php
@@ -1,0 +1,107 @@
+<?php
+/**
+ * WP_Style_Engine_CSS_Rule
+ *
+ * An object for CSS rules.
+ *
+ * @package Gutenberg
+ */
+
+if ( class_exists( 'WP_Style_Engine_CSS_Rule' ) ) {
+	return;
+}
+
+/**
+ * Holds, sanitizes, processes and prints CSS declarations for the style engine.
+ *
+ * @access private
+ */
+class WP_Style_Engine_CSS_Rule {
+
+	/**
+	 * The selector.
+	 *
+	 * @var string
+	 */
+	protected $selector;
+
+	/**
+	 * The parent rule.
+	 *
+	 * @var WP_Style_Engine_CSS_Rule
+	 */
+	protected $parent;
+
+	/**
+	 * The selector declarations.
+	 *
+	 * Contains an array of WP_Style_Engine_CSS_Declarations objects.
+	 *
+	 * @var WP_Style_Engine_CSS_Declarations[]
+	 */
+	protected $declarations = array();
+
+	/**
+	 * Constructor
+	 *
+	 * @param string                             $selector     The CSS selector.
+	 * @param WP_Style_Engine_CSS_Rule|null      $parent       The parent rule.
+	 * @param WP_Style_Engine_CSS_Declarations[] $declarations An array of WP_Style_Engine_CSS_Declarations objects.
+	 */
+	public function __construct( $selector = '', $parent = null, $declarations = array() ) {
+		$this->set_selector( $selector );
+		$this->set_parent( $parent );
+		$this->set_declarations( $declarations );
+	}
+
+	/**
+	 * Set the selector.
+	 *
+	 * @param string $selector The CSS selector.
+	 */
+	public function set_selector( $selector ) {
+		$this->selector = $selector;
+	}
+
+	/**
+	 * Set the parent selector.
+	 *
+	 * @param WP_Style_Engine_CSS_Rule $parent The parent rule.
+	 */
+	public function set_parent( $parent ) {
+		$this->parent = $parent;
+	}
+
+	/**
+	 * Set the declarations.
+	 *
+	 * @param WP_Style_Engine_CSS_Declarations[] $declarations An array of WP_Style_Engine_CSS_Declarations objects.
+	 */
+	public function set_declarations( $declarations ) {
+		if ( $declarations instanceof WP_Style_Engine_CSS_Declarations ) {
+			$declarations = array( $declarations );
+		}
+		$this->declarations = array_merge( $this->$declarations, $declarations );
+	}
+
+	/**
+	 * Get the parent selector.
+	 *
+	 * @return string
+	 */
+	public function get_parent_selector() {
+		return $this->parent ? $this->parent->get_selector() : '';
+	}
+
+	/**
+	 * Get the full selector.
+	 *
+	 * @return string
+	 */
+	public function get_selector() {
+		if ( 0 === strpos( $this->selector, '&' ) ) {
+			return $this->get_parent_selector() . substr( $this->selector, 1 );
+		}
+		return $this->get_parent_selector() . ' ' . $this->selector;
+	}
+}

--- a/packages/style-engine/class-wp-style-engine-css-rule.php
+++ b/packages/style-engine/class-wp-style-engine-css-rule.php
@@ -57,7 +57,7 @@ class WP_Style_Engine_CSS_Rule {
 		if ( empty( $selector ) ) {
 			return;
 		}
-		$this->selector = esc_html( $selector );
+		$this->selector = $selector;
 
 		return $this;
 	}

--- a/packages/style-engine/class-wp-style-engine-css-rule.php
+++ b/packages/style-engine/class-wp-style-engine-css-rule.php
@@ -60,6 +60,9 @@ class WP_Style_Engine_CSS_Rule {
 	 * @param string $selector The CSS selector.
 	 */
 	public function set_selector( $selector ) {
+		if ( empty( $selector ) ) {
+			return;
+		}
 		$this->selector = $selector;
 	}
 
@@ -69,6 +72,9 @@ class WP_Style_Engine_CSS_Rule {
 	 * @param WP_Style_Engine_CSS_Rule $parent The parent rule.
 	 */
 	public function set_parent( $parent ) {
+		if ( ! $parent instanceof WP_Style_Engine_CSS_Rule ) {
+			return;
+		}
 		$this->parent = $parent;
 	}
 
@@ -81,7 +87,7 @@ class WP_Style_Engine_CSS_Rule {
 		if ( $declarations instanceof WP_Style_Engine_CSS_Declarations ) {
 			$declarations = array( $declarations );
 		}
-		$this->declarations = array_merge( $this->$declarations, $declarations );
+		$this->declarations = array_merge( $this->declarations, $declarations );
 	}
 
 	/**
@@ -103,5 +109,19 @@ class WP_Style_Engine_CSS_Rule {
 			return $this->get_parent_selector() . substr( $this->selector, 1 );
 		}
 		return $this->get_parent_selector() . ' ' . $this->selector;
+	}
+
+	/**
+	 * Get the CSS.
+	 *
+	 * @return string
+	 */
+	public function get_css() {
+		$css = $this->get_selector() . ' {';
+		foreach ( $this->declarations as $declaration ) {
+			$css .= $declaration->get_declarations_string();
+		}
+		$css .= '}';
+		return $css;
 	}
 }

--- a/packages/style-engine/class-wp-style-engine-css-rule.php
+++ b/packages/style-engine/class-wp-style-engine-css-rule.php
@@ -54,7 +54,7 @@ class WP_Style_Engine_CSS_Rule {
 		if ( empty( $selector ) ) {
 			return;
 		}
-		$this->selector = $selector;
+		$this->selector = esc_html( $selector );
 	}
 
 	/**

--- a/packages/style-engine/class-wp-style-engine-css-rule.php
+++ b/packages/style-engine/class-wp-style-engine-css-rule.php
@@ -76,7 +76,9 @@ class WP_Style_Engine_CSS_Rule {
 
 		if ( null === $this->declarations && $is_declarations_object ) {
 			$this->declarations = $declarations;
-		} elseif ( null === $this->declarations ) {
+			return $this;
+		}
+		if ( null === $this->declarations ) {
 			$this->declarations = new WP_Style_Engine_CSS_Declarations( $declarations_array );
 		}
 		$this->declarations->add_declarations( $declarations_array );

--- a/packages/style-engine/class-wp-style-engine-css-rules-store.php
+++ b/packages/style-engine/class-wp-style-engine-css-rules-store.php
@@ -19,33 +19,49 @@ if ( class_exists( 'WP_Style_Engine_CSS_Rules_Store' ) ) {
 class WP_Style_Engine_CSS_Rules_Store {
 
 	/**
-	 * An array of CSS Rules objects.
+	 * An array of named WP_Style_Engine_CSS_Rules_Store objects.
 	 *
 	 * @static
+	 *
+	 * @var WP_Style_Engine_CSS_Rules_Store[]
+	 */
+	protected static $stores = array();
+
+	/**
+	 * An array of CSS Rules objects assigned to the store.
 	 *
 	 * @var WP_Style_Engine_CSS_Rule[]
 	 */
-	protected static $rules = array();
+	protected $rules = array();
 
+	/**
+	 * Get an instance of the store.
+	 *
+	 * @param string $store_name The name of the store.
+	 *
+	 * @return WP_Style_Engine_CSS_Rules_Store
+	 */
+	public static function get_store( $store_name ) {
+		if ( ! isset( static::$stores[ $store_name ] ) ) {
+			static::$stores[ $store_name ] = new WP_Style_Engine_CSS_Rules_Store( $store_name );
+		}
+		return static::$stores[ $store_name ];
+	}
 	/**
 	 * Get an array of all rules.
 	 *
-	 * @static
-	 *
 	 * @return WP_Style_Engine_CSS_Rule[]
 	 */
-	public static function get_all_rules() {
-		return static::$rules;
+	public function get_all_rules() {
+		return $this->rules;
 	}
 
 	/**
 	 * Get a WP_Style_Engine_CSS_Rule object by its selector.
 	 *
-	 * @static
-	 *
 	 * @param string $selector The CSS selector.
 	 */
-	public static function get_rule( $selector ) {
+	public function get_rule( $selector ) {
 
 		$selector = trim( $selector );
 
@@ -55,10 +71,10 @@ class WP_Style_Engine_CSS_Rules_Store {
 		}
 
 		// Create the rule if it doesn't exist.
-		if ( empty( static::$rules[ $selector ] ) ) {
-			static::$rules[ $selector ] = new WP_Style_Engine_CSS_Rule( $selector );
+		if ( empty( $this->rules[ $selector ] ) ) {
+			$this->rules[ $selector ] = new WP_Style_Engine_CSS_Rule( $selector );
 		}
 
-		return static::$rules[ $selector ];
+		return $this->rules[ $selector ];
 	}
 }

--- a/packages/style-engine/class-wp-style-engine-css-rules-store.php
+++ b/packages/style-engine/class-wp-style-engine-css-rules-store.php
@@ -41,7 +41,7 @@ class WP_Style_Engine_CSS_Rules_Store {
 	 *
 	 * @return WP_Style_Engine_CSS_Rules_Store
 	 */
-	public static function get_store( $store_name ) {
+	public static function get_store( $store_name = 'default' ) {
 		if ( ! isset( static::$stores[ $store_name ] ) ) {
 			static::$stores[ $store_name ] = new WP_Style_Engine_CSS_Rules_Store( $store_name );
 		}

--- a/packages/style-engine/class-wp-style-engine-css-rules-store.php
+++ b/packages/style-engine/class-wp-style-engine-css-rules-store.php
@@ -54,87 +54,11 @@ class WP_Style_Engine_CSS_Rules_Store {
 			return;
 		}
 
-		// If the selector is already stored, return it.
-		if ( isset( static::$rules[ $selector ] ) ) {
-			return static::$rules[ $selector ];
-		}
-
-		// Create the selector if it doesn't exist.
-		// To do that, first deconstruct the selector to its parts
-		// and build the hierarchy of selector objects prior to storing it.
-		$selector_parts = static::deconstruct_selector( $selector );
-		$full_selector  = '';
-		foreach ( $selector_parts as $key => $selector_part ) {
-			// Get the parent object if needed.
-			$parent = 0 === $key ? null : static::get_rule( $full_selector );
-			// Compile the full selector for the store.
-			$full_selector .= ( 0 === strpos( $selector_part, '&' ) ) ? substr( $selector_part, 1 ) : ' ' . $selector_part;
-			if ( 0 === $key ) {
-				$full_selector = ltrim( $full_selector );
-			}
-			// Create the rule if it doesn't exist.
-			if ( empty( static::$rules[ $full_selector ] ) ) {
-				static::$rules[ $full_selector ] = new WP_Style_Engine_CSS_Rule( $selector_part, $parent );
-			}
+		// Create the rule if it doesn't exist.
+		if ( empty( static::$rules[ $selector ] ) ) {
+			static::$rules[ $selector ] = new WP_Style_Engine_CSS_Rule( $selector );
 		}
 
 		return static::$rules[ $selector ];
-	}
-
-	/**
-	 * Deconstruct a selector to its parts.
-	 *
-	 * @static
-	 *
-	 * @param string $selector The CSS selector.
-	 *
-	 * @return array An array of selector parts.
-	 */
-	public static function deconstruct_selector( $selector ) {
-		$selector = trim( $selector );
-
-		// Split selector parts on space characters.
-		$parts = explode( ' ', $selector );
-		$parts = array_map( 'trim', $parts );
-
-		// Remove empty parts.
-		$parts = array_filter( $parts );
-
-		// Split parts on ':' characters.
-		$parts = static::deconstruct_selector_array_on_character( $parts, ':' );
-
-		return $parts;
-	}
-
-	/**
-	 * Expands and re-structures an array based on a character.
-	 *
-	 * @static
-	 *
-	 * @param array  $array The array to expand.
-	 * @param string $character The character to expand on.
-	 *
-	 * @return array The expanded array.
-	 */
-	public static function deconstruct_selector_array_on_character( $array, $character ) {
-		$new_array = array();
-		foreach ( $array as $value ) {
-			if ( strpos( $value, $character ) === false ) {
-				$new_array[] = $value;
-				continue;
-			}
-
-			// Use "SPLIT_CHARACTER" as a delimiter.
-			$value = str_replace( $character, "SPLIT_CHARACTER$character", $value );
-
-			// Pseudo-selectors are a special case.
-			if ( ':' === $character ) {
-				$value = str_replace( ':', '&:', $value );
-			}
-
-			$value     = explode( 'SPLIT_CHARACTER', $value );
-			$new_array = array_merge( $new_array, $value );
-		}
-		return $new_array;
 	}
 }

--- a/packages/style-engine/class-wp-style-engine-css-rules-store.php
+++ b/packages/style-engine/class-wp-style-engine-css-rules-store.php
@@ -47,6 +47,8 @@ class WP_Style_Engine_CSS_Rules_Store {
 	 */
 	public static function get_rule( $selector ) {
 
+		$selector = trim( $selector );
+
 		// Bail early if there is no selector.
 		if ( empty( $selector ) ) {
 			return;
@@ -64,7 +66,7 @@ class WP_Style_Engine_CSS_Rules_Store {
 		$full_selector  = '';
 		foreach ( $selector_parts as $key => $selector_part ) {
 			// Get the parent object if needed.
-			$parent = 0 === $key ? null : static::get_rule( $selector_parts[ $full_selector ] );
+			$parent = 0 === $key ? null : static::get_rule( $full_selector );
 			// Compile the full selector for the store.
 			$full_selector .= ( 0 === strpos( $selector_part, '&' ) ) ? substr( $selector_part, 1 ) : ' ' . $selector_part;
 			if ( 0 === $key ) {

--- a/packages/style-engine/class-wp-style-engine-css-rules-store.php
+++ b/packages/style-engine/class-wp-style-engine-css-rules-store.php
@@ -43,7 +43,7 @@ class WP_Style_Engine_CSS_Rules_Store {
 	 */
 	public static function get_store( $store_name = 'default' ) {
 		if ( ! isset( static::$stores[ $store_name ] ) ) {
-			static::$stores[ $store_name ] = new WP_Style_Engine_CSS_Rules_Store( $store_name );
+			static::$stores[ $store_name ] = new static( $store_name );
 		}
 		return static::$stores[ $store_name ];
 	}

--- a/packages/style-engine/class-wp-style-engine-css-rules-store.php
+++ b/packages/style-engine/class-wp-style-engine-css-rules-store.php
@@ -1,0 +1,138 @@
+<?php
+/**
+ * WP_Style_Engine_CSS_Rules_Store
+ *
+ * A store for WP_Style_Engine_CSS_Rule objects.
+ *
+ * @package Gutenberg
+ */
+
+if ( class_exists( 'WP_Style_Engine_CSS_Rules_Store' ) ) {
+	return;
+}
+
+/**
+ * Holds, sanitizes, processes and prints CSS declarations for the style engine.
+ *
+ * @access private
+ */
+class WP_Style_Engine_CSS_Rules_Store {
+
+	/**
+	 * An array of CSS Rules objects.
+	 *
+	 * @static
+	 *
+	 * @var WP_Style_Engine_CSS_Rule[]
+	 */
+	protected static $rules = array();
+
+	/**
+	 * Get an array of all rules.
+	 *
+	 * @static
+	 *
+	 * @return WP_Style_Engine_CSS_Rule[]
+	 */
+	public static function get_all_rules() {
+		return static::$rules;
+	}
+
+	/**
+	 * Get a WP_Style_Engine_CSS_Rule object by its selector.
+	 *
+	 * @static
+	 *
+	 * @param string $selector The CSS selector.
+	 */
+	public static function get_rule( $selector ) {
+		if ( empty( $selector ) ) {
+			return;
+		}
+
+		$selector_parts = static::deconstruct_selector( $selector );
+		$full_selector  = '';
+		foreach ( $selector_parts as $key => $selector_part ) {
+			// Get the parent object if needed.
+			$parent = 0 === $key ? null : static::get_rule( $selector_parts[ $full_selector ] );
+			// Compile the full selector for the store.
+			$full_selector .= ( 0 === strpos( $selector_part, '&' ) ) ? substr( $selector_part, 1 ) : ' ' . $selector_part;
+			if ( 0 === $key ) {
+				$full_selector = ltrim( $full_selector );
+			}
+			// Create the rule if it doesn't exist.
+			if ( empty( static::$rules[ $full_selector ] ) ) {
+				static::$rules[ $full_selector ] = new WP_Style_Engine_CSS_Rule( $selector_part, $parent );
+			}
+		}
+
+		return static::$rules[ $selector ];
+	}
+
+	/**
+	 * Deconstruct a selector to its parts.
+	 *
+	 * @static
+	 *
+	 * @param string $selector The CSS selector.
+	 *
+	 * @return array An array of selector parts.
+	 */
+	public static function deconstruct_selector( $selector ) {
+		$selector = trim( $selector );
+
+		// Split selector parts on space characters.
+		$parts = explode( ' ', $selector );
+		$parts = array_map( 'trim', $parts );
+
+		// Remove empty parts.
+		$parts = array_filter( $parts );
+
+		// Split parts on ':' characters.
+		$parts = static::deconstruct_selector_array_on_character( $parts, ':' );
+
+		return $parts;
+	}
+
+	/**
+	 * Expands and re-structures an array based on a character.
+	 *
+	 * @static
+	 *
+	 * @param array  $array The array to expand.
+	 * @param string $character The character to expand on.
+	 *
+	 * @return array The expanded array.
+	 */
+	public static function deconstruct_selector_array_on_character( $array, $character ) {
+		$new_array = array();
+		foreach ( $array as $value ) {
+			if ( strpos( $value, $character ) === false ) {
+				$new_array[] = $value;
+				continue;
+			}
+
+			$value = str_replace( $character, "SPLIT_CHARACTER$character", $value );
+			if ( ':' === $character ) {
+				$value = str_replace( ':', '&:', $value );
+			}
+			$value     = explode( 'SPLIT_CHARACTER', $value );
+			$new_array = array_merge( $new_array, $value );
+		}
+		return $new_array;
+	}
+
+	/**
+	 * Inject an array inside an array at a specific index.
+	 *
+	 * @static
+	 *
+	 * @param array $array The array to inject into.
+	 * @param array $inject The array to inject.
+	 * @param int   $index The index to inject at.
+	 */
+	public static function inject_array_at_index( $array, $inject, $index ) {
+		$array = array_slice( $array, 0, $index, true ) + $inject + array_slice( $array, $index, count( $array ) - $index, true );
+		return $array;
+	}
+}

--- a/packages/style-engine/class-wp-style-engine-css-rules-store.php
+++ b/packages/style-engine/class-wp-style-engine-css-rules-store.php
@@ -46,10 +46,20 @@ class WP_Style_Engine_CSS_Rules_Store {
 	 * @param string $selector The CSS selector.
 	 */
 	public static function get_rule( $selector ) {
+
+		// Bail early if there is no selector.
 		if ( empty( $selector ) ) {
 			return;
 		}
 
+		// If the selector is already stored, return it.
+		if ( isset( static::$rules[ $selector ] ) ) {
+			return static::$rules[ $selector ];
+		}
+
+		// Create the selector if it doesn't exist.
+		// To do that, first deconstruct the selector to its parts
+		// and build the hierarchy of selector objects prior to storing it.
 		$selector_parts = static::deconstruct_selector( $selector );
 		$full_selector  = '';
 		foreach ( $selector_parts as $key => $selector_part ) {
@@ -112,27 +122,17 @@ class WP_Style_Engine_CSS_Rules_Store {
 				continue;
 			}
 
+			// Use "SPLIT_CHARACTER" as a delimiter.
 			$value = str_replace( $character, "SPLIT_CHARACTER$character", $value );
+
+			// Pseudo-selectors are a special case.
 			if ( ':' === $character ) {
 				$value = str_replace( ':', '&:', $value );
 			}
+
 			$value     = explode( 'SPLIT_CHARACTER', $value );
 			$new_array = array_merge( $new_array, $value );
 		}
 		return $new_array;
-	}
-
-	/**
-	 * Inject an array inside an array at a specific index.
-	 *
-	 * @static
-	 *
-	 * @param array $array The array to inject into.
-	 * @param array $inject The array to inject.
-	 * @param int   $index The index to inject at.
-	 */
-	public static function inject_array_at_index( $array, $inject, $index ) {
-		$array = array_slice( $array, 0, $index, true ) + $inject + array_slice( $array, $index, count( $array ) - $index, true );
-		return $array;
 	}
 }

--- a/packages/style-engine/class-wp-style-engine-css-rules-store.php
+++ b/packages/style-engine/class-wp-style-engine-css-rules-store.php
@@ -78,4 +78,15 @@ class WP_Style_Engine_CSS_Rules_Store {
 
 		return $this->rules[ $selector ];
 	}
+
+	/**
+	 * Remove a selector from the store.
+	 *
+	 * @param string $selector The CSS selector.
+	 *
+	 * @return void
+	 */
+	public function remove_rule( $selector ) {
+		unset( $this->rules[ $selector ] );
+	}
 }

--- a/packages/style-engine/class-wp-style-engine-css-rules-store.php
+++ b/packages/style-engine/class-wp-style-engine-css-rules-store.php
@@ -58,10 +58,11 @@ class WP_Style_Engine_CSS_Rules_Store {
 
 	/**
 	 * Get a WP_Style_Engine_CSS_Rule object by its selector.
+	 * If the rule does not exist, it will be created.
 	 *
 	 * @param string $selector The CSS selector.
 	 */
-	public function get_rule( $selector ) {
+	public function add_rule( $selector ) {
 
 		$selector = trim( $selector );
 

--- a/packages/style-engine/class-wp-style-engine-css-rules-store.php
+++ b/packages/style-engine/class-wp-style-engine-css-rules-store.php
@@ -43,7 +43,7 @@ class WP_Style_Engine_CSS_Rules_Store {
 	 */
 	public static function get_store( $store_name = 'default' ) {
 		if ( ! isset( static::$stores[ $store_name ] ) ) {
-			static::$stores[ $store_name ] = new static( $store_name );
+			static::$stores[ $store_name ] = new static();
 		}
 		return static::$stores[ $store_name ];
 	}
@@ -61,6 +61,8 @@ class WP_Style_Engine_CSS_Rules_Store {
 	 * If the rule does not exist, it will be created.
 	 *
 	 * @param string $selector The CSS selector.
+	 *
+	 * @return WP_Style_Engine_CSS_Rule|null Returns a WP_Style_Engine_CSS_Rule object, or null if the selector is empty.
 	 */
 	public function add_rule( $selector ) {
 

--- a/packages/style-engine/phpunit/class-wp-style-engine-css-rule-test.php
+++ b/packages/style-engine/phpunit/class-wp-style-engine-css-rule-test.php
@@ -1,0 +1,96 @@
+<?php
+/**
+ * Tests the Style Engine CSS Rule class.
+ *
+ * @package    Gutenberg
+ * @subpackage style-engine
+ */
+
+require __DIR__ . '/../class-wp-style-engine-css-rule.php';
+require __DIR__ . '/../class-wp-style-engine-css-declarations.php';
+
+/**
+ * Tests for registering, storing and generating CSS declarations.
+ */
+class WP_Style_Engine_CSS_Rule_Test extends WP_UnitTestCase {
+	/**
+	 * Should set declarations on instantiation.
+	 */
+	public function test_instantiate_with_selector_and_rules() {
+		$selector           = '.law-and-order';
+		$input_declarations = array(
+			'margin-top' => '10px',
+			'font-size'  => '2rem',
+		);
+		$css_declarations   = new WP_Style_Engine_CSS_Declarations( $input_declarations );
+		$css_rule           = new WP_Style_Engine_CSS_Rule( $selector, $css_declarations );
+
+		$this->assertSame( $selector, $css_rule->get_selector() );
+
+		$expected = "$selector {{$css_declarations->get_declarations_string()}}";
+		$this->assertSame( $expected, $css_rule->get_css() );
+	}
+
+	/**
+	 * Test dedupe declaration properties.
+	 */
+	public function test_dedupe_properties_in_rules() {
+		$selector                    = '.taggart';
+		$first_declaration           = array(
+			'font-size' => '2rem',
+		);
+		$overwrite_first_declaration = array(
+			'font-size' => '4px',
+		);
+		$css_rule                    = new WP_Style_Engine_CSS_Rule( $selector, $first_declaration );
+		$css_rule->set_declarations( new WP_Style_Engine_CSS_Declarations( $overwrite_first_declaration ) );
+
+		$expected = '.taggart {font-size: 4px;}';
+		$this->assertSame( $expected, $css_rule->get_css() );
+	}
+
+	/**
+	 * Should set selector and rules on instantiation.
+	 */
+	public function test_set_declarations() {
+		// Declarations using a WP_Style_Engine_CSS_Declarations object.
+		$some_css_declarations = new WP_Style_Engine_CSS_Declarations( array( 'margin-top' => '10px' ) );
+		// Declarations using a property => value array.
+		$some_more_css_declarations = array( 'font-size' => '1rem' );
+		$css_rule                   = new WP_Style_Engine_CSS_Rule( '.hill-street-blues', $some_css_declarations );
+		$css_rule->set_declarations( $some_more_css_declarations );
+
+		$expected = '.hill-street-blues {margin-top: 10px; font-size: 1rem;}';
+		$this->assertSame( $expected, $css_rule->get_css() );
+	}
+
+	/**
+	 * Should set selector and rules on instantiation.
+	 */
+	public function test_set_selector() {
+		$selector = '.taggart';
+		$css_rule = new WP_Style_Engine_CSS_Rule( $selector );
+
+		$this->assertSame( $selector, $css_rule->get_selector() );
+
+		$css_rule->set_selector( '.law-and-order' );
+
+		$this->assertSame( '.law-and-order', $css_rule->get_selector() );
+	}
+
+	/**
+	 * Should set selector and rules on instantiation.
+	 */
+	public function test_get_css() {
+		$selector           = '.chips';
+		$input_declarations = array(
+			'margin-top' => '10px',
+			'font-size'  => '2rem',
+		);
+		$css_declarations   = new WP_Style_Engine_CSS_Declarations( $input_declarations );
+		$css_rule           = new WP_Style_Engine_CSS_Rule( $selector, $css_declarations );
+		$expected           = "$selector {{$css_declarations->get_declarations_string()}}";
+
+		$this->assertSame( $expected, $css_rule->get_css() );
+	}
+}

--- a/packages/style-engine/phpunit/class-wp-style-engine-css-rules-store-test.php
+++ b/packages/style-engine/phpunit/class-wp-style-engine-css-rules-store-test.php
@@ -1,0 +1,115 @@
+<?php
+/**
+ * Tests the Style Engine CSS Rules Store class.
+ *
+ * @package    Gutenberg
+ * @subpackage style-engine
+ */
+
+require __DIR__ . '/../class-wp-style-engine-css-rules-store.php';
+require __DIR__ . '/../class-wp-style-engine-css-rule.php';
+require __DIR__ . '/../class-wp-style-engine-css-declarations.php';
+
+/**
+ * Tests for registering, storing and retrieving CSS Rules.
+ */
+class WP_Style_Engine_CSS_Rules_Store_Test extends WP_UnitTestCase {
+	/**
+	 * Should create a new store.
+	 */
+	public function test_create_new_store() {
+		$new_pancakes_store = WP_Style_Engine_CSS_Rules_Store::get_store( 'pancakes-with-strawberries' );
+		$this->assertInstanceOf( 'WP_Style_Engine_CSS_Rules_Store', $new_pancakes_store );
+	}
+
+	/**
+	 * Should return previously created store when the same selector key is passed.
+	 */
+	public function test_get_store() {
+		$new_fish_store = WP_Style_Engine_CSS_Rules_Store::get_store( 'fish-n-chips' );
+		$selector       = '.haddock';
+
+		$new_fish_store->get_rule( $selector )->get_selector();
+		$this->assertEquals( $selector, $new_fish_store->get_rule( $selector )->get_selector() );
+
+		$the_same_fish_store = WP_Style_Engine_CSS_Rules_Store::get_store( 'fish-n-chips' );
+		$this->assertEquals( $selector, $the_same_fish_store->get_rule( $selector )->get_selector() );
+	}
+
+	/**
+	 * Should return a stored rule.
+	 */
+	public function test_get_rule() {
+		$new_pie_store = WP_Style_Engine_CSS_Rules_Store::get_store( 'meat-pie' );
+		$selector      = '.wp-block-sauce a:hover';
+		$store_rule    = $new_pie_store->get_rule( $selector );
+		$expected      = "$selector {}";
+		$this->assertEquals( $expected, $store_rule->get_css() );
+
+		$pie_declarations = array(
+			'color'         => 'brown',
+			'border-color'  => 'yellow',
+			'border-radius' => '10rem',
+		);
+		$css_declarations = new WP_Style_Engine_CSS_Declarations( $pie_declarations );
+		$store_rule->set_declarations( $css_declarations );
+
+		$store_rule = $new_pie_store->get_rule( $selector );
+		$expected   = "$selector {{$css_declarations->get_declarations_string()}}";
+		$this->assertEquals( $expected, $store_rule->get_css() );
+	}
+
+	/**
+	 * Should return all stored rules.
+	 */
+	public function test_get_all_rules() {
+		$new_pizza_store = WP_Style_Engine_CSS_Rules_Store::get_store( 'pizza-with-mozzarella' );
+		$selector        = '.wp-block-anchovies a:hover';
+		$store_rule      = $new_pizza_store->get_rule( $selector );
+		$expected        = array(
+			$selector => $store_rule,
+		);
+
+		$this->assertEquals( $expected, $new_pizza_store->get_all_rules() );
+
+		$pizza_declarations = array(
+			'color'         => 'red',
+			'border-color'  => 'yellow',
+			'border-radius' => '10rem',
+		);
+		$css_declarations   = new WP_Style_Engine_CSS_Declarations( $pizza_declarations );
+		$store_rule->set_declarations( array( $css_declarations ) );
+
+		$expected = array(
+			$selector => $store_rule,
+		);
+		$this->assertEquals( $expected, $new_pizza_store->get_all_rules() );
+
+		$new_pizza_declarations = array(
+			'color'        => 'red',
+			'border-color' => 'red',
+			'font-size'    => '10rem',
+		);
+		$css_declarations       = new WP_Style_Engine_CSS_Declarations( $new_pizza_declarations );
+		$store_rule->set_declarations( array( $css_declarations ) );
+
+		$expected = array(
+			$selector => $store_rule,
+		);
+		$this->assertEquals( $expected, $new_pizza_store->get_all_rules() );
+
+		$new_selector             = '.wp-block-mushroom a:hover';
+		$newer_pizza_declarations = array(
+			'padding' => '100px',
+		);
+		$new_store_rule           = $new_pizza_store->get_rule( $new_selector );
+		$css_declarations         = new WP_Style_Engine_CSS_Declarations( $newer_pizza_declarations );
+		$new_store_rule->set_declarations( array( $css_declarations ) );
+
+		$expected = array(
+			$selector     => $store_rule,
+			$new_selector => $new_store_rule,
+		);
+		$this->assertEquals( $expected, $new_pizza_store->get_all_rules() );
+	}
+}

--- a/packages/style-engine/phpunit/class-wp-style-engine-css-rules-store-test.php
+++ b/packages/style-engine/phpunit/class-wp-style-engine-css-rules-store-test.php
@@ -29,20 +29,20 @@ class WP_Style_Engine_CSS_Rules_Store_Test extends WP_UnitTestCase {
 		$new_fish_store = WP_Style_Engine_CSS_Rules_Store::get_store( 'fish-n-chips' );
 		$selector       = '.haddock';
 
-		$new_fish_store->get_rule( $selector )->get_selector();
-		$this->assertEquals( $selector, $new_fish_store->get_rule( $selector )->get_selector() );
+		$new_fish_store->add_rule( $selector )->get_selector();
+		$this->assertEquals( $selector, $new_fish_store->add_rule( $selector )->get_selector() );
 
 		$the_same_fish_store = WP_Style_Engine_CSS_Rules_Store::get_store( 'fish-n-chips' );
-		$this->assertEquals( $selector, $the_same_fish_store->get_rule( $selector )->get_selector() );
+		$this->assertEquals( $selector, $the_same_fish_store->add_rule( $selector )->get_selector() );
 	}
 
 	/**
 	 * Should return a stored rule.
 	 */
-	public function test_get_rule() {
+	public function test_add_rule() {
 		$new_pie_store = WP_Style_Engine_CSS_Rules_Store::get_store( 'meat-pie' );
 		$selector      = '.wp-block-sauce a:hover';
-		$store_rule    = $new_pie_store->get_rule( $selector );
+		$store_rule    = $new_pie_store->add_rule( $selector );
 		$expected      = "$selector {}";
 		$this->assertEquals( $expected, $store_rule->get_css() );
 
@@ -54,7 +54,7 @@ class WP_Style_Engine_CSS_Rules_Store_Test extends WP_UnitTestCase {
 		$css_declarations = new WP_Style_Engine_CSS_Declarations( $pie_declarations );
 		$store_rule->set_declarations( $css_declarations );
 
-		$store_rule = $new_pie_store->get_rule( $selector );
+		$store_rule = $new_pie_store->add_rule( $selector );
 		$expected   = "$selector {{$css_declarations->get_declarations_string()}}";
 		$this->assertEquals( $expected, $store_rule->get_css() );
 	}
@@ -65,7 +65,7 @@ class WP_Style_Engine_CSS_Rules_Store_Test extends WP_UnitTestCase {
 	public function test_get_all_rules() {
 		$new_pizza_store = WP_Style_Engine_CSS_Rules_Store::get_store( 'pizza-with-mozzarella' );
 		$selector        = '.wp-block-anchovies a:hover';
-		$store_rule      = $new_pizza_store->get_rule( $selector );
+		$store_rule      = $new_pizza_store->add_rule( $selector );
 		$expected        = array(
 			$selector => $store_rule,
 		);
@@ -102,7 +102,7 @@ class WP_Style_Engine_CSS_Rules_Store_Test extends WP_UnitTestCase {
 		$newer_pizza_declarations = array(
 			'padding' => '100px',
 		);
-		$new_store_rule           = $new_pizza_store->get_rule( $new_selector );
+		$new_store_rule           = $new_pizza_store->add_rule( $new_selector );
 		$css_declarations         = new WP_Style_Engine_CSS_Declarations( $newer_pizza_declarations );
 		$new_store_rule->set_declarations( array( $css_declarations ) );
 

--- a/tools/webpack/packages.js
+++ b/tools/webpack/packages.js
@@ -37,6 +37,7 @@ const bundledPackagesPhpConfig = [
 		to: 'build/style-engine/',
 		replaceClasses: [
 			'WP_Style_Engine_CSS_Declarations',
+			'WP_Style_Engine_CSS_Rule',
 			'WP_Style_Engine',
 		],
 	},

--- a/tools/webpack/packages.js
+++ b/tools/webpack/packages.js
@@ -37,6 +37,7 @@ const bundledPackagesPhpConfig = [
 		to: 'build/style-engine/',
 		replaceClasses: [
 			'WP_Style_Engine_CSS_Declarations',
+			'WP_Style_Engine_CSS_Rules_Store',
 			'WP_Style_Engine_CSS_Rule',
 			'WP_Style_Engine',
 		],


### PR DESCRIPTION
## What?

This is a proof of concept, experimenting with possible implementations for the future of the Style Engine and how we may structure things.

This PR adds 2 objects:
* `WP_Style_Engine_CSS_Rule`
* `WP_Style_Engine_CSS_Rules_Store`

Reading the comments in other tickets, I think we'll need to create an object for rules, and allow them to be nested to accommodate child elements, pseudo-selectors etc.

## The `WP_Style_Engine_CSS_Rule` object

This object holds a selector, the parent (if one exists), and the declarations, along with selector-specific methods.

## The `WP_Style_Engine_CSS_Rules_Store` object

This object holds a collection of `WP_Style_Engine_CSS_Rule` objects by selector.

## Usage

```php
$rule = WP_Style_Engine_CSS_Rules_Store_Gutenberg::get_rule( '.wp-block-button a:hover' );
$rule->set_declarations(
	new WP_Style_Engine_CSS_Declarations_Gutenberg(
		array(
			'color'            => 'var(--block-button-link-hover-color)',
			'outline'          => '1px solid var(--block-button-link-hover-color)',
			'background-color' => 'black',
		)
	)
);
$css = $rule->get_css();
// string(97) " .wp-block-button a:hover {color: var(--block-button-link-hover-color); background-color: black;}"
```

The above will create 3 `WP_Style_Engine_CSS_Rule` objects, one for each of these selectors:
* `.wp-block-button`
* `.wp-block-button a`
* `.wp-block-button a:hover`

The benefit of this structure is that this way, we can know which children - if any - a selector has, we can assign style-declarations on each of them, we can add & remove children and so on.
CSS becomes hierarchical and reflected in the objects structure. We can then process them as we see fit

## Unit tests

```bash
npm run test-unit-php /var/www/html/wp-content/plugins/gutenberg/packages/style-engine/phpunit/class-wp-style-engine-css-rule-test.php
```

```bash
npm run test-unit-php /var/www/html/wp-content/plugins/gutenberg/packages/style-engine/phpunit/class-wp-style-engine-css-rules-store-test.php
```