### PR TITLE
Components: Remove `_.flatMap()` from `ToolbarGroup` and `TreeSelect`

### DIFF
--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -24,6 +24,8 @@
 -   `ComboboxControl`: Refactor away from `_.deburr()` ([#42169](https://github.com/WordPress/gutenberg/pull/42169/)).
 -   `FormTokenField`: Refactor away from `_.identity()` ([#42215](https://github.com/WordPress/gutenberg/pull/42215/)).
 -   `SelectControl`: Use roles and `@testing-library/user-event` in unit tests ([#42308](https://github.com/WordPress/gutenberg/pull/42308)).
+-   `ToolbarGroup`: Refactor away from `_.flatMap()` ([#42223](https://github.com/WordPress/gutenberg/pull/42223/)).
+-   `TreeSelect`: Refactor away from `_.flatMap()` ([#42223](https://github.com/WordPress/gutenberg/pull/42223/)).
 -   `Autocomplete`: Refactor away from `_.deburr()` ([#42266](https://github.com/WordPress/gutenberg/pull/42266/)).
 -   `MenuItem`: Refactor away from `_.isString()` ([#42268](https://github.com/WordPress/gutenberg/pull/42268/)).
 -   `Shortcut`: Refactor away from `_.isString()` ([#42268](https://github.com/WordPress/gutenberg/pull/42268/)).

--- a/packages/components/src/toolbar-group/index.js
+++ b/packages/components/src/toolbar-group/index.js
@@ -2,7 +2,6 @@
  * External dependencies
  */
 import classnames from 'classnames';
-import { flatMap } from 'lodash';
 
 /**
  * WordPress dependencies
@@ -92,19 +91,21 @@ function ToolbarGroup( {
 
 	return (
 		<ToolbarGroupContainer className={ finalClassName } { ...props }>
-			{ flatMap( controlSets, ( controlSet, indexOfSet ) =>
-				controlSet.map( ( control, indexOfControl ) => (
-					<ToolbarButton
-						key={ [ indexOfSet, indexOfControl ].join() }
-						containerClassName={
-							indexOfSet > 0 && indexOfControl === 0
-								? 'has-left-divider'
-								: null
-						}
-						{ ...control }
-					/>
-				) )
-			) }
+			{ controlSets
+				?.map( ( controlSet, indexOfSet ) =>
+					controlSet.map( ( control, indexOfControl ) => (
+						<ToolbarButton
+							key={ [ indexOfSet, indexOfControl ].join() }
+							containerClassName={
+								indexOfSet > 0 && indexOfControl === 0
+									? 'has-left-divider'
+									: null
+							}
+							{ ...control }
+						/>
+					) )
+				)
+				.flat() }
 			{ children }
 		</ToolbarGroupContainer>
 	);

--- a/packages/components/src/toolbar-group/index.js
+++ b/packages/components/src/toolbar-group/index.js
@@ -91,21 +91,19 @@ function ToolbarGroup( {
 
 	return (
 		<ToolbarGroupContainer className={ finalClassName } { ...props }>
-			{ controlSets
-				?.map( ( controlSet, indexOfSet ) =>
-					controlSet.map( ( control, indexOfControl ) => (
-						<ToolbarButton
-							key={ [ indexOfSet, indexOfControl ].join() }
-							containerClassName={
-								indexOfSet > 0 && indexOfControl === 0
-									? 'has-left-divider'
-									: null
-							}
-							{ ...control }
-						/>
-					) )
-				)
-				.flat() }
+			{ controlSets?.flatMap( ( controlSet, indexOfSet ) =>
+				controlSet.map( ( control, indexOfControl ) => (
+					<ToolbarButton
+						key={ [ indexOfSet, indexOfControl ].join() }
+						containerClassName={
+							indexOfSet > 0 && indexOfControl === 0
+								? 'has-left-divider'
+								: null
+						}
+						{ ...control }
+					/>
+				) )
+			) }
 			{ children }
 		</ToolbarGroupContainer>
 	);

--- a/packages/components/src/tree-select/index.tsx
+++ b/packages/components/src/tree-select/index.tsx
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { unescape as unescapeString, flatMap, compact } from 'lodash';
+import { unescape as unescapeString, compact } from 'lodash';
 
 /**
  * WordPress dependencies
@@ -14,14 +14,17 @@ import { SelectControl } from '../select-control';
 import type { TreeSelectProps, Tree, SelectOptions } from './types';
 
 function getSelectOptions( tree: Tree[], level = 0 ): SelectOptions {
-	return flatMap( tree, ( treeNode ) => [
-		{
-			value: treeNode.id,
-			label:
-				'\u00A0'.repeat( level * 3 ) + unescapeString( treeNode.name ),
-		},
-		...getSelectOptions( treeNode.children || [], level + 1 ),
-	] );
+	return tree
+		.map( ( treeNode ) => [
+			{
+				value: treeNode.id,
+				label:
+					'\u00A0'.repeat( level * 3 ) +
+					unescapeString( treeNode.name ),
+			},
+			...getSelectOptions( treeNode.children || [], level + 1 ),
+		] )
+		.flat();
 }
 
 /**

--- a/packages/components/src/tree-select/index.tsx
+++ b/packages/components/src/tree-select/index.tsx
@@ -14,17 +14,14 @@ import { SelectControl } from '../select-control';
 import type { TreeSelectProps, Tree, SelectOptions } from './types';
 
 function getSelectOptions( tree: Tree[], level = 0 ): SelectOptions {
-	return tree
-		.map( ( treeNode ) => [
-			{
-				value: treeNode.id,
-				label:
-					'\u00A0'.repeat( level * 3 ) +
-					unescapeString( treeNode.name ),
-			},
-			...getSelectOptions( treeNode.children || [], level + 1 ),
-		] )
-		.flat();
+	return tree.flatMap( ( treeNode ) => [
+		{
+			value: treeNode.id,
+			label:
+				'\u00A0'.repeat( level * 3 ) + unescapeString( treeNode.name ),
+		},
+		...getSelectOptions( treeNode.children || [], level + 1 ),
+	] );
 }
 
 /**


### PR DESCRIPTION
## What?
This PR removes the `_.flatMap()` usage from the `ToolbarGroup` and `TreeSelect` components. The PR looks larger than expected, but most is just whitespace change, caused by `prettier`.

Together with #42219 and #42218, this removes most of the `_.flatMap()` usage. The rest can be removed in a single PR after those are merged.

## Why?

Lodash is known to unnecessarily inflate the bundle size of packages, and in most cases, it can be replaced with native language functionality. See these for more information and rationale:

* https://github.com/WordPress/gutenberg/issues/16938#issuecomment-602837246
* https://github.com/WordPress/gutenberg/issues/17025
* https://github.com/WordPress/gutenberg/issues/39495 

## How?

We're replacing it with a `map()` on the arrays, followed by a `.flat()` to flatten the result array.

## Testing Instructions
* Verify all tests pass: `npm run test-unit packages/components/src/toolbar-group`
* Smoke test `ToolbarGroup` and `TreeSelect` in storybook.