### PR TITLE
useSelect: Use useDebugValue to better display data in DevTools

### DIFF
--- a/packages/data/CHANGELOG.md
+++ b/packages/data/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Enhancements
+
+-   Use `useDebugValue` in `useSelect` to better display data in React DevTools ([#42225](https://github.com/WordPress/gutenberg/pull/42225)).
+
 ## 6.12.0 (2022-06-29)
 
 ## 6.11.0 (2022-06-15)

--- a/packages/data/src/components/use-select/index.js
+++ b/packages/data/src/components/use-select/index.js
@@ -7,7 +7,13 @@ import { useMemoOne } from 'use-memo-one';
  * WordPress dependencies
  */
 import { createQueue } from '@wordpress/priority-queue';
-import { useRef, useCallback, useMemo, useReducer } from '@wordpress/element';
+import {
+	useRef,
+	useCallback,
+	useMemo,
+	useReducer,
+	useDebugValue,
+} from '@wordpress/element';
 import isShallowEqual from '@wordpress/is-shallow-equal';
 import { useIsomorphicLayoutEffect } from '@wordpress/compose';
 
@@ -247,6 +253,8 @@ export default function useSelect( mapSelect, deps ) {
 		// We're passing these in from the calling function and want to make sure we're
 		// examining every individual value inside the `deps` array.
 	}, [ registry, wrapSelect, hasMappingFunction, depsChangedFlag ] );
+
+	useDebugValue( mapOutput );
 
 	return hasMappingFunction ? mapOutput : registry.select( mapSelect );
 }


### PR DESCRIPTION
## What?
A proposal to add `useDebugValue` to the `useSelect` hook for better-displaying data in DevTools.

## Why?
A user might be more familiar with how `useDebugValue` outputs data in React DevTools and find information quickly instead of familiarizing `useSelect` internals

## Testing Instructions
1. Open a Post or Page.
2. Profile small action via React DevTools.
3. Confirm that the `useSelect` hook displays debug value

## Screenshots or screencast <!-- if applicable -->
| Before | After |
| --- | --- |
|![CleanShot 2022-07-07 at 14 44 51](https://user-images.githubusercontent.com/240569/177757538-6da0a7f2-3e68-4117-bf93-8e9df6f8ed43.png)|![CleanShot 2022-07-07 at 14 47 19](https://user-images.githubusercontent.com/240569/177757523-c428cd53-916b-4fca-9bae-718adaf25185.png)|


