### PR TITLE
Lodash: Refactor away from `_.countBy()`

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -82,6 +82,7 @@ module.exports = {
 							'chunk',
 							'clamp',
 							'concat',
+							'countBy',
 							'defaults',
 							'defaultTo',
 							'differenceWith',

--- a/bin/plugin/commands/changelog.js
+++ b/bin/plugin/commands/changelog.js
@@ -2,7 +2,6 @@
  * External dependencies
  */
 const {
-	countBy,
 	groupBy,
 	escapeRegExp,
 	uniq,
@@ -309,7 +308,17 @@ function getIssueFeature( issue ) {
 	// 1. Prefer explicit mapping of label to feature.
 	if ( featureCandidates.length ) {
 		// Get occurances of the feature labels.
-		const featureCounts = countBy( featureCandidates );
+		const featureCounts = featureCandidates.reduce(
+			/**
+			 * @param {Record<string,number>} acc     Accumulator
+			 * @param {string}                feature Feature label
+			 */
+			( acc, feature ) => ( {
+				...acc,
+				[ feature ]: ( acc[ feature ] || 0 ) + 1,
+			} ),
+			{}
+		);
 
 		// Check which matching label occurs most often.
 		const rankedFeatures = Object.keys( featureCounts ).sort(

--- a/packages/editor/src/components/document-outline/index.js
+++ b/packages/editor/src/components/document-outline/index.js
@@ -45,18 +45,16 @@ const multipleH1Headings = [
  * @return {Array} An array of heading blocks enhanced with the properties described above.
  */
 const computeOutlineHeadings = ( blocks = [] ) => {
-	return blocks
-		.map( ( block = {} ) => {
-			if ( block.name === 'core/heading' ) {
-				return {
-					...block,
-					level: block.attributes.level,
-					isEmpty: isEmptyHeading( block ),
-				};
-			}
-			return computeOutlineHeadings( block.innerBlocks );
-		} )
-		.flat();
+	return blocks.flatMap( ( block = {} ) => {
+		if ( block.name === 'core/heading' ) {
+			return {
+				...block,
+				level: block.attributes.level,
+				isEmpty: isEmptyHeading( block ),
+			};
+		}
+		return computeOutlineHeadings( block.innerBlocks );
+	} );
 };
 
 const isEmptyHeading = ( heading ) =>

--- a/packages/editor/src/components/document-outline/index.js
+++ b/packages/editor/src/components/document-outline/index.js
@@ -1,9 +1,4 @@
 /**
- * External dependencies
- */
-import { get } from 'lodash';
-
-/**
  * WordPress dependencies
  */
 import { __ } from '@wordpress/i18n';
@@ -163,7 +158,7 @@ export default compose(
 		return {
 			title: getEditedPostAttribute( 'title' ),
 			blocks: getBlocks(),
-			isTitleSupported: get( postType, [ 'supports', 'title' ], false ),
+			isTitleSupported: postType?.supports?.title ?? false,
 		};
 	} )
 )( DocumentOutline );

--- a/packages/editor/src/components/document-outline/index.js
+++ b/packages/editor/src/components/document-outline/index.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { countBy, get } from 'lodash';
+import { get } from 'lodash';
 
 /**
  * WordPress dependencies
@@ -85,7 +85,13 @@ export const DocumentOutline = ( {
 	// Not great but it's the simplest way to locate the title right now.
 	const titleNode = document.querySelector( '.editor-post-title__input' );
 	const hasTitle = isTitleSupported && title && titleNode;
-	const countByLevel = countBy( headings, 'level' );
+	const countByLevel = headings.reduce(
+		( acc, heading ) => ( {
+			...acc,
+			[ heading.level ]: ( acc[ heading.level ] || 0 ) + 1,
+		} ),
+		{}
+	);
 	const hasMultipleH1 = countByLevel[ 1 ] > 1;
 
 	return (

--- a/packages/editor/src/components/document-outline/index.js
+++ b/packages/editor/src/components/document-outline/index.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { countBy, flatMap, get } from 'lodash';
+import { countBy, get } from 'lodash';
 
 /**
  * WordPress dependencies
@@ -50,16 +50,18 @@ const multipleH1Headings = [
  * @return {Array} An array of heading blocks enhanced with the properties described above.
  */
 const computeOutlineHeadings = ( blocks = [] ) => {
-	return flatMap( blocks, ( block = {} ) => {
-		if ( block.name === 'core/heading' ) {
-			return {
-				...block,
-				level: block.attributes.level,
-				isEmpty: isEmptyHeading( block ),
-			};
-		}
-		return computeOutlineHeadings( block.innerBlocks );
-	} );
+	return blocks
+		.map( ( block = {} ) => {
+			if ( block.name === 'core/heading' ) {
+				return {
+					...block,
+					level: block.attributes.level,
+					isEmpty: isEmptyHeading( block ),
+				};
+			}
+			return computeOutlineHeadings( block.innerBlocks );
+		} )
+		.flat();
 };
 
 const isEmptyHeading = ( heading ) =>


### PR DESCRIPTION
## What?
Lodash's `countBy` is used only a couple of times in the entire codebase. This PR aims to remove that usage, together with a `flatMap()` and a `get()` around there.

## Why?
Lodash is known to unnecessarily inflate the bundle size of packages, and in most cases, it can be replaced with native language functionality. See these for more information and rationale:

* https://github.com/WordPress/gutenberg/issues/16938#issuecomment-602837246
* https://github.com/WordPress/gutenberg/issues/17025
* https://github.com/WordPress/gutenberg/issues/39495 

## How?
Removing `countBy` is straightforward in favor of a relatively short `reduce` implementation. We're addressing that in both locations. We're also removing a `flatMap()` usage in favor of `.map().flat()` (in the spirit of the recent #42218, #42219, and #42223), and a stray `get()` use in favor of direct access with optional chaining and nullish coalescing.

## Testing Instructions
* Verify the following tests pass:
  * `npm run test-unit packages/editor/src/components/document-outline`
  * `npm run test-unit bin/plugin/commands/test/changelog`
* Insert 2 or more H1 headings into your post, and click on the (i) icon in the edit post header toolbar.
* Verify you still get the "Multiple H1 headings are not recommended" message under each of the headings.