### PR TITLE
Lodash: Refactor away from `_.isBoolean()`

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -96,6 +96,7 @@ module.exports = {
 							'identity',
 							'invoke',
 							'isArray',
+							'isBoolean',
 							'isFinite',
 							'isFunction',
 							'isNil',

--- a/packages/block-editor/src/store/selectors.js
+++ b/packages/block-editor/src/store/selectors.js
@@ -1444,7 +1444,7 @@ export function getTemplateLock( state, rootClientId ) {
 }
 
 const checkAllowList = ( list, item, defaultResult = null ) => {
-	if ( list === true || list === false ) {
+	if ( typeof list === 'boolean' ) {
 		return list;
 	}
 	if ( Array.isArray( list ) ) {

--- a/packages/block-editor/src/store/selectors.js
+++ b/packages/block-editor/src/store/selectors.js
@@ -4,7 +4,6 @@
 import {
 	castArray,
 	first,
-	isBoolean,
 	last,
 	map,
 	reduce,
@@ -1445,7 +1444,7 @@ export function getTemplateLock( state, rootClientId ) {
 }
 
 const checkAllowList = ( list, item, defaultResult = null ) => {
-	if ( isBoolean( list ) ) {
+	if ( list === true || list === false ) {
 		return list;
 	}
 	if ( Array.isArray( list ) ) {
@@ -2218,7 +2217,7 @@ export const __experimentalGetDirectInsertBlock = createSelector(
 );
 
 const checkAllowListRecursive = ( blocks, allowedBlockTypes ) => {
-	if ( isBoolean( allowedBlockTypes ) ) {
+	if ( allowedBlockTypes === true || allowedBlockTypes === false ) {
 		return allowedBlockTypes;
 	}
 

--- a/packages/block-editor/src/store/selectors.js
+++ b/packages/block-editor/src/store/selectors.js
@@ -2217,7 +2217,7 @@ export const __experimentalGetDirectInsertBlock = createSelector(
 );
 
 const checkAllowListRecursive = ( blocks, allowedBlockTypes ) => {
-	if ( allowedBlockTypes === true || allowedBlockTypes === false ) {
+	if ( typeof allowedBlockTypes === 'boolean' ) {
 		return allowedBlockTypes;
 	}
 


### PR DESCRIPTION
## What?
Lodash's `isBoolean()` is used only a couple of times in the entire codebase. This PR aims to remove that usage.

## Why?
Lodash is known to unnecessarily inflate the bundle size of packages, and in most cases, it can be replaced with native language functionality. See these for more information and rationale:

* https://github.com/WordPress/gutenberg/issues/16938#issuecomment-602837246
* https://github.com/WordPress/gutenberg/issues/17025
* https://github.com/WordPress/gutenberg/issues/39495 

## How?
Removing `isBoolean` is simple in favor of a simple `=== true || === false` check.

## Testing Instructions
* Verify all tests still pass: `npm run test-unit packages/block-editor/src/store/test/selectors.js`