### PR TITLE
Add 'wp-block-button__link' to the link selector's ':not' collection

### DIFF
--- a/lib/compat/wordpress-6.1/class-wp-theme-json-6-1.php
+++ b/lib/compat/wordpress-6.1/class-wp-theme-json-6-1.php
@@ -31,7 +31,7 @@ class WP_Theme_JSON_6_1 extends WP_Theme_JSON_6_0 {
 	 * @var string[]
 	 */
 	const ELEMENTS = array(
-		'link'    => 'a:not(.wp-element-button)',
+		'link'    => 'a:not(.wp-element-button, .wp-block-button__link)',
 		'heading' => 'h1, h2, h3, h4, h5, h6',
 		'h1'      => 'h1',
 		'h2'      => 'h2',


### PR DESCRIPTION

## What?

Add `wp-block-button__link` to the link selector's `:not` collection

## Why?
In #40260 the `.wp-element-button` class was introduced and link element styles were applied to all `a` anchor elements but excluded those with that class.  
However the class is only introduced on new content (or when old content is re-serialized).  So any Button Blocks created prior to that change have the link styles applied.

Expected:
<img width="328" alt="image" src="https://user-images.githubusercontent.com/146530/177824968-d5999c6c-6867-403c-9203-97d33682c73b.png">

Before:
<img width="317" alt="image" src="https://user-images.githubusercontent.com/146530/177824862-bddac270-aaad-49e5-acff-d3ef3ab86474.png">
<img width="1185" alt="image" src="https://user-images.githubusercontent.com/146530/177824935-420aa94c-4cf9-4835-94b2-3b1dea5e2510.png">

After:
<img width="329" alt="image" src="https://user-images.githubusercontent.com/146530/177825073-1cb82a47-cd1b-46d1-9cdb-69e395ebe052.png">
<img width="1200" alt="image" src="https://user-images.githubusercontent.com/146530/177825117-6c5afcc3-55ab-4810-badd-288e603ab7c2.png">


## How?
This adds the `.wp-block-button__link` to the anchor selector excluding any button that has that class from the anchor styles.

## Testing Instructions
Load a site that has content created prior to the #40260 change.  (I imported the content from [this site](https://theamdemo.wordpress.com/) and used [this page](https://theamdemo.wordpress.com/2019/06/25/gutenberg-button/)). 

Configure your theme with a link color via theme.json :
```
{
	"styles": {
		"elements": {
			"link": {
				"color": {
					"text": "green"
				}
			}
		}
	}
}	
```
Note that before this change the button block is rendered with the color assigned to the link element.
Apply the change and note that the button block is no longer rendered with the color assigned to the link element.
