### PR TITLE
[RNMobile] Update Aztec-Android version to v1.6.0

### DIFF
--- a/packages/react-native-aztec/android/build.gradle
+++ b/packages/react-native-aztec/android/build.gradle
@@ -9,7 +9,7 @@ buildscript {
         jSoupVersion = '1.10.3'
         wordpressUtilsVersion = '2.3.0'
         espressoVersion = '3.0.1'
-        aztecVersion = 'v1.5.9'
+        aztecVersion = 'v1.6.0'
     }
 }
 


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

This PR updates Aztec-Android version to [`v1.6.0`](https://github.com/wordpress-mobile/AztecEditor-Android/releases/tag/v1.6.0) which updates Android Gradle Plugin version to `7.2.1`. In #42136 we updated the `react-native-bridge`, `react-native-aztec` & `react-native-editor` to Android Gradle Plugin `7.2.1`, so this PR closes the loop on that work.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

We want to use the same Android Gradle Plugin version across our projects to avoid any conflicts.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->

* Smoke test the demo app
