### PR TITLE
Fix: Inexistent parameter passed to getBlockIndex on getBlockInsertionPoint

### DIFF
--- a/packages/block-editor/src/store/selectors.js
+++ b/packages/block-editor/src/store/selectors.js
@@ -1382,7 +1382,7 @@ export function getBlockInsertionPoint( state ) {
 
 	if ( clientId ) {
 		rootClientId = getBlockRootClientId( state, clientId ) || undefined;
-		index = getBlockIndex( state, selectionEnd.clientId, rootClientId ) + 1;
+		index = getBlockIndex( state, selectionEnd.clientId ) + 1;
 	} else {
 		index = getBlockOrder( state ).length;
 	}


### PR DESCRIPTION
getBlockIndex only receives two parameters. We are passing three parameters in getBlockInsertionPoint, the last parameter is not required.