### PR TITLE
Create Block: More careful prompts to continue when minimum system requirements are not met

### DIFF
--- a/packages/create-block/lib/check-system-requirements.js
+++ b/packages/create-block/lib/check-system-requirements.js
@@ -30,6 +30,8 @@ async function checkSystemRequirements( engines ) {
 		} );
 
 		log.info( '' );
+		log.error( 'The program may not complete correctly if you continue.' );
+		log.info( '' );
 
 		const { yesContinue } = await inquirer.prompt( [
 			{


### PR DESCRIPTION
Follow up on: #42151

## What?

As noted in [this comment](https://github.com/WordPress/gutenberg/pull/42151#issuecomment-1176012796), we decided to display a more carefully message when system requirements are not met in Create Block.
But I forgot to commit that change after presenting the screen capture.

Sorry about that, but please check this PR to see that I have added it.


## Screenshots or screencast <!-- if applicable -->

![create-block](https://user-images.githubusercontent.com/54422211/177899063-3ef4346e-9f62-4be2-bb1b-8efe258d9034.png)

