### PR TITLE
Group block: Add context to the word "Row"

### DIFF
--- a/packages/block-library/src/group/variations.js
+++ b/packages/block-library/src/group/variations.js
@@ -1,7 +1,7 @@
 /**
  * WordPress dependencies
  */
-import { __ } from '@wordpress/i18n';
+import { __, _x } from '@wordpress/i18n';
 import { group, row, stack } from '@wordpress/icons';
 
 const variations = [
@@ -19,7 +19,7 @@ const variations = [
 	},
 	{
 		name: 'group-row',
-		title: __( 'Row' ),
+		title: _x( 'Row', 'single horizontal line' ),
 		description: __( 'Arrange blocks horizontally.' ),
 		attributes: { layout: { type: 'flex', flexWrap: 'nowrap' } },
 		scope: [ 'inserter', 'transform' ],


### PR DESCRIPTION
## What?
This PR adds context to the label of the variation (**Row**) in the group block.

## Why?
In the WordPress core and Gutenberg, the word "Row" appears in a total of three places.
The locations and meanings of the occurrences and the context are as follows: 

| No. | Description | Where? | Context | Screenshot |
| -- | -- | -- | -- | -- |
| 1 | "Row" in TinyMCE's table | WordPress Core ([source](https://github.com/WordPress/wordpress-develop/blob/e94cd298c6e0208a5feb888099601feadf460eda/src/wp-includes/class-wp-editor.php#L1301)) | None | ![block-tinymce](https://user-images.githubusercontent.com/54422211/177901677-0d1b2cd7-cb4c-4141-a586-4487be11ff3d.png) | 
| 2 | "Row" in group block variation | Gutenberg ([source](https://github.com/WordPress/gutenberg/blob/bbd198d8380e302c38e471cb68a69bb307fa4ba9/packages/block-library/src/group/variations.js#L22)) | None | ![block-variation](https://user-images.githubusercontent.com/54422211/177901754-d8d42fe2-df29-400f-8b9f-1a50b791af09.png) | 
| 3 | Transform multiple blocks to "Row" variation | Gutenberg ([source](https://github.com/WordPress/gutenberg/blob/bbd198d8380e302c38e471cb68a69bb307fa4ba9/packages/block-editor/src/components/convert-to-group-buttons/toolbar.js#L85)) | single horizontal line | ![block-grouping](https://user-images.githubusercontent.com/54422211/177901725-90d9ec54-96a9-42de-a21e-1978b5056033.png)  |

The word "Row" has different contexts in group and table blocks, and  each must be assigned a different text in Japanese. (It might happen in other languages).
Therefore, the No. 2 and No. 3 texts need a common context.

## How?
I added the same context to No.2 text as to No.3 text.




