### PR TITLE
Tests: Ignore test files in `build-types` folder

### DIFF
--- a/test/unit/jest.config.js
+++ b/test/unit/jest.config.js
@@ -28,6 +28,7 @@ module.exports = {
 		'/packages/e2e-test-utils-playwright/src/test.ts',
 		'<rootDir>/.*/build/',
 		'<rootDir>/.*/build-module/',
+		'<rootDir>/.*/build-types/',
 		'<rootDir>/.+.native.js$',
 		'/packages/react-native-*',
 	],


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

After running `npm run build` TypeScript types are created in `build-types` folders. They also include types for test files causing the following error when running `npm runt test-unit`:

<img width="1256" alt="Screenshot 2022-07-08 at 09 42 52" src="https://user-images.githubusercontent.com/699132/177950046-f2e1b982-ec3b-4d44-9388-a0f033aa1cc3.png">


## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

It looks like TypeScript got enabled in unit tests recently, and Jest matches generate files with types in the `test` subfolders.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

Jest ignores now all files created in `build-types` subfolders.

## Testing Instructions

Run

```bash
npm run build
npm run test-unit
```

Check whether all tests pass.