### PR TITLE
Add a CSS class to all static blocks with className supports

### DIFF
--- a/lib/blocks.php
+++ b/lib/blocks.php
@@ -357,8 +357,13 @@ add_action( 'init', 'gutenberg_register_legacy_social_link_blocks' );
  * Ensures there's a `wp-block-<block name>` CSS class in the
  * rendered markup of every block with supports.className
  * set to true.
- * 
+ *
  * @since 6.2.0
+ *
+ * @param  string $block_content Rendered block content.
+ * @param  array  $parsed_block  The block being rendered.
+ * @param  object $block         Block object.
+ * @return string                Updated block content.
  */
 function gutenberg_add_default_class_name_to_rendered_block_markup( $block_content, $parsed_block, $block ) {
 	if ( ! $block_content ) {

--- a/lib/blocks.php
+++ b/lib/blocks.php
@@ -352,3 +352,33 @@ function gutenberg_register_legacy_social_link_blocks() {
 }
 
 add_action( 'init', 'gutenberg_register_legacy_social_link_blocks' );
+
+/**
+ * Ensures there's a `wp-block-<block name>` CSS class in the
+ * rendered markup of every block with supports.className
+ * set to true.
+ * 
+ * @since 6.2.0
+ */
+function gutenberg_add_default_class_name_to_rendered_block_markup( $block_content, $parsed_block, $block ) {
+	if ( ! $block_content ) {
+		return $block_content;
+	}
+
+	if ( ! $block->block_type || $block->block_type->is_dynamic() ) {
+		return $block_content;
+	}
+
+	$class_name_supports = _wp_array_get( $block->block_type->supports, array( 'className' ), false );
+	if ( ! $class_name_supports ) {
+		return $block_content;
+	}
+
+	$tags = new WP_HTML_Tag_Processor( $block_content );
+	if ( $tags->next_tag() ) {
+		$tags->add_class( wp_get_block_default_classname( $block->name ) );
+	}
+	return $tags->get_updated_html();
+}
+
+add_action( 'render_block', 'gutenberg_add_default_class_name_to_rendered_block_markup', 10, 3 );


### PR DESCRIPTION
## What?

Ensures all static blocks with `supports.className === true` are rendered with an appropriate `wp-block-$name` class name.

It's what https://github.com/WordPress/gutenberg/pull/42122 does for the heading block, only generalized to all blocks.

This is possible thanks to [WP_HTML_Tag_Processor](https://github.com/WordPress/gutenberg/issues/44410).

## Why?

Precisely targeting blocks with CSS requires having class names that currently aren't there.

## How?

By adding a `render_block` hook with the logic previously created just for the heading block.

## Alternatives considered

I explored leaning on `get_block_wrapper_attributes`, but it falls short:

* It only processes the `style` and `class` properties, meaning a heading block with an anchor set would lose its `id`.
* It ignores any additional attributes stored in `$block_content` but not block attributes.
* We'd still need to some parsing to replace the old wrapping HTML tag stored in `$block_content`.
* It infers attributes from global variables.

## Testing Instructions

_(ignore these for now)_

1. Update `block-library/src/paragraph/block.json` and set `supports.className` to `true`
2. Confirm that all the paragraph blocks are now rendered with the `wp-block-paragraph` CSS class.

cc @mtias @draganescu @spacedmonkey @dmsnell @ZebulanStanphill @getdave @scruffian @Mamaduka @carolinan  @luminuu 