### PR TITLE
Lodash: Refactor away from `_.isMatch()`

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -103,6 +103,7 @@ module.exports = {
 							'isBoolean',
 							'isFinite',
 							'isFunction',
+							'isMatch',
 							'isNil',
 							'isNumber',
 							'isObject',

--- a/packages/block-editor/src/utils/block-variation-transforms.js
+++ b/packages/block-editor/src/utils/block-variation-transforms.js
@@ -1,8 +1,3 @@
-/**
- * External dependencies
- */
-import { isMatch } from 'lodash';
-
 /** @typedef {import('@wordpress/blocks').WPBlockVariation} WPBlockVariation */
 
 /**
@@ -24,7 +19,9 @@ export const __experimentalGetMatchingVariation = (
 	if ( ! variations || ! blockAttributes ) return;
 	const matches = variations.filter( ( { attributes } ) => {
 		if ( ! attributes || ! Object.keys( attributes ).length ) return false;
-		return isMatch( blockAttributes, attributes );
+		return Object.entries( attributes ).every(
+			( [ key, value ] ) => blockAttributes[ key ] === value
+		);
 	} );
 	if ( matches.length !== 1 ) return;
 	return matches[ 0 ];

--- a/packages/block-editor/src/utils/block-variation-transforms.js
+++ b/packages/block-editor/src/utils/block-variation-transforms.js
@@ -1,5 +1,17 @@
 /** @typedef {import('@wordpress/blocks').WPBlockVariation} WPBlockVariation */
 
+function matchesAttributes( blockAttributes, variation ) {
+	return Object.entries( variation ).every( ( [ key, value ] ) => {
+		if (
+			typeof value === 'object' &&
+			typeof blockAttributes[ key ] === 'object'
+		) {
+			return matchesAttributes( blockAttributes[ key ], value );
+		}
+		return blockAttributes[ key ] === value;
+	} );
+}
+
 /**
  * Matches the provided block variations with a block's attributes. If no match
  * or more than one matches are found it returns `undefined`. If a single match is
@@ -19,9 +31,7 @@ export const __experimentalGetMatchingVariation = (
 	if ( ! variations || ! blockAttributes ) return;
 	const matches = variations.filter( ( { attributes } ) => {
 		if ( ! attributes || ! Object.keys( attributes ).length ) return false;
-		return Object.entries( attributes ).every(
-			( [ key, value ] ) => blockAttributes[ key ] === value
-		);
+		return matchesAttributes( blockAttributes, attributes );
 	} );
 	if ( matches.length !== 1 ) return;
 	return matches[ 0 ];

--- a/packages/block-editor/src/utils/test/block-variation-transforms.js
+++ b/packages/block-editor/src/utils/test/block-variation-transforms.js
@@ -40,6 +40,18 @@ describe( 'getMatchingVariation', () => {
 				getMatchingVariation( { level: 1, other: 'prop' }, variations )
 			).toBeUndefined();
 		} );
+		it( 'when variation has a nested attribute', () => {
+			const variations = [
+				{ name: 'one', attributes: { query: { author: 'somebody' } } },
+				{ name: 'two', attributes: { query: { author: 'nobody' } } },
+			];
+			expect(
+				getMatchingVariation(
+					{ query: { author: 'foobar' }, other: 'prop' },
+					variations
+				)
+			).toBeUndefined();
+		} );
 	} );
 	describe( 'should find a match', () => {
 		it( 'when variation has one attribute', () => {
@@ -62,6 +74,18 @@ describe( 'getMatchingVariation', () => {
 			expect(
 				getMatchingVariation(
 					{ level: 1, content: 'hi', other: 'prop' },
+					variations
+				).name
+			).toEqual( 'one' );
+		} );
+		it( 'when variation has a nested attribute', () => {
+			const variations = [
+				{ name: 'one', attributes: { query: { author: 'somebody' } } },
+				{ name: 'two', attributes: { query: { author: 'nobody' } } },
+			];
+			expect(
+				getMatchingVariation(
+					{ query: { author: 'somebody' }, other: 'prop' },
 					variations
 				).name
 			).toEqual( 'one' );


### PR DESCRIPTION
## What?
This PR removes the `_.isMatch()` usage completely and deprecates the function. It has a single usage and it's pretty straightforward to replace.

## Why?

Lodash is known to unnecessarily inflate the bundle size of packages, and in most cases, it can be replaced with native language functionality. See these for more information and rationale:

* https://github.com/WordPress/gutenberg/issues/16938#issuecomment-602837246
* https://github.com/WordPress/gutenberg/issues/17025
* https://github.com/WordPress/gutenberg/issues/39495 

## How?

We're replacing `_.isMatch()` with a simple custom function that iterates through all elements of the second object and verifies that all keys are present in the first object with the same values. There are prior existence checks for both object, which ensures that this is a safe change.

## Testing Instructions
* Verify all tests still pass: `npm run test-unit packages/block-editor/src/utils/test/block-variation-transforms.js`