### PR TITLE
Add aria-checked to the selected heading level menu item.

### DIFF
--- a/packages/block-library/src/heading/heading-level-dropdown.js
+++ b/packages/block-library/src/heading/heading-level-dropdown.js
@@ -60,6 +60,7 @@ export default function HeadingLevelDropdown( { selectedLevel, onChange } ) {
 						onClick() {
 							onChange( targetLevel );
 						},
+						role: 'menuitemradio',
 					};
 				}
 			} ) }

--- a/packages/block-library/src/site-title/edit/level-toolbar.js
+++ b/packages/block-library/src/site-title/edit/level-toolbar.js
@@ -21,6 +21,7 @@ export default function LevelControl( { level, onChange } ) {
 					  sprintf( __( 'Heading %d' ), currentLevel ),
 			isActive,
 			onClick: () => onChange( currentLevel ),
+			role: 'menuitemradio',
 		};
 	} );
 	return (


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->
In the heading level dropdown menu, the selected heading level is highlighted only visually. There's no semantics to indicate its 'selected' state.

Additionally, this menu provides a single choice: only one level can be selected at a time. A role of `menuitemradio` is more appropriate than the generic `menuitem`.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
When screen reader users navigate through the heading level items, they don't have a clue what the selected one is.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
Passing a prop `role: 'menuitemradio'` fixes the semantics. When the menu item component has this role, it also automatically handles the `aria-checked` attribute, which provides the necessary information on the selected heading level.

## Testing Instructions
- Edit a Heading block.
- Click the 'Change heading level' button in the block toolbar.
- A dropdown menu with the heading levels opens.
- Inspect the source and check that:
  - Each menu item has a `role="menuitemradio"` attribute.
  - The selected heading level menu item has an `aria-checked="true"` attribute.
  - All the other ones have a `aria-checked="false"` attribute.
- Repeat the same check in the Site Editor, for the Site title heading level.


## Screenshots or screencast <!-- if applicable -->

<img width="743" alt="Screenshot 2022-07-08 at 16 10 45" src="https://user-images.githubusercontent.com/1682452/178011385-177de936-c563-415c-9836-93924e7fc401.png">


