### PR TITLE
Documentation Rename Templates page to Block Templates

### DIFF
--- a/docs/manifest.json
+++ b/docs/manifest.json
@@ -438,7 +438,7 @@
 		"parent": "block-api"
 	},
 	{
-		"title": "Templates",
+		"title": "Block Templates",
 		"slug": "block-templates",
 		"markdown_source": "../docs/reference-guides/block-api/block-templates.md",
 		"parent": "block-api"

--- a/docs/reference-guides/block-api/block-templates.md
+++ b/docs/reference-guides/block-api/block-templates.md
@@ -1,6 +1,6 @@
-# Templates
+# Block Templates
 
-A block template is defined as a list of block items. Such blocks can have predefined attributes, placeholder content, and be static or dynamic. Block templates allow specifying a default initial state for an editor session.
+A block template is defined as a list of block items. Such blocks can have predefined attributes, placeholder content, and be static or dynamic. Block templates allow specifying a default initial state for an editor session. 
 
 The scope of templates include:
 


### PR DESCRIPTION
This updates the title of the [documentation page](https://developer.wordpress.org/block-editor/reference-guides/block-api/block-templates/) from "Templates" to "Block Templates" to distinguish is from Theme Templates. 
On first read, the content itself seems to be still relevant and correct. 