### PR TITLE
Chore: Remove two empty unrequired object destructuring

### DIFF
--- a/packages/block-library/src/video/tracks-editor.js
+++ b/packages/block-library/src/video/tracks-editor.js
@@ -209,7 +209,7 @@ export default function TracksEditor( { tracks = [], onChange } ) {
 					icon={ captionIcon }
 				/>
 			) }
-			renderContent={ ( {} ) => {
+			renderContent={ () => {
 				if ( trackBeingEdited !== null ) {
 					return (
 						<SingleTrackEditor

--- a/packages/editor/src/components/post-template/index.js
+++ b/packages/editor/src/components/post-template/index.js
@@ -16,7 +16,7 @@ import { store as coreStore } from '@wordpress/core-data';
  */
 import { store as editorStore } from '../../store';
 
-export function PostTemplate( {} ) {
+export function PostTemplate() {
 	const { availableTemplates, selectedTemplate, isViewable } = useSelect(
 		( select ) => {
 			const {


### PR DESCRIPTION
Doing an empty object destructuring is useless and makes people wonder if there was some bug and we should be reading some property so I guess we can just remove them. I verified in both cases we don't pass anything to the function/component.