### PR TITLE
Fix: isEditedPostAutosaveable test case.

### DIFF
--- a/packages/editor/src/store/test/selectors.js
+++ b/packages/editor/src/store/test/selectors.js
@@ -1599,7 +1599,7 @@ describe( 'selectors', () => {
 
 			for ( const variantField of fields ) {
 				for ( const constantField of fields.filter(
-					( f ) => ! f === variantField
+					( f ) => f !== variantField
 				) ) {
 					const state = {
 						editor: {


### PR DESCRIPTION
The condition ! f === variantField always returned false so the test did not executed at all. Watching the code it seems we want to use `( f ) => f !== variantField`.