### PR TITLE
Try using shadows instead of borders on interface skeleton

### DIFF
--- a/packages/interface/src/components/interface-skeleton/style.scss
+++ b/packages/interface/src/components/interface-skeleton/style.scss
@@ -66,7 +66,7 @@ html.interface-interface-skeleton__html-container {
 	// Footer overlap prevention
 	.has-footer & {
 		@include break-medium() {
-			padding-bottom: $button-size-small + $border-width;
+			padding-bottom: $button-size-small;
 		}
 	}
 }
@@ -97,7 +97,7 @@ html.interface-interface-skeleton__html-container {
 	flex-shrink: 0;
 	position: absolute;
 	z-index: z-index(".interface-interface-skeleton__sidebar");
-	top: 0;
+	top: 1px;
 	right: 0;
 	bottom: 0;
 	left: 0;
@@ -116,20 +116,20 @@ html.interface-interface-skeleton__html-container {
 	overflow: auto;
 
 	@include break-medium() {
-		border-left: $border-width solid $gray-200;
+		box-shadow: ( $border-width * -1 ) 0 0 0 rgba(0, 0, 0, 0.12);
 	}
 }
 
 .interface-interface-skeleton__secondary-sidebar {
 	@include break-medium() {
-		border-right: $border-width solid $gray-200;
+		box-shadow: $border-width 0 0 0 rgba(0, 0, 0, 0.12);
 	}
 }
 
 .interface-interface-skeleton__header {
 	flex-shrink: 0;
 	height: auto;  // Keep the height flexible.
-	border-bottom: $border-width solid $gray-200;
+	box-shadow: 0 0 0 $border-width rgba(0, 0, 0, 0.12);
 	z-index: z-index(".interface-interface-skeleton__header");
 	color: $gray-900;
 }
@@ -137,7 +137,7 @@ html.interface-interface-skeleton__html-container {
 .interface-interface-skeleton__footer {
 	height: auto; // Keep the height flexible.
 	flex-shrink: 0;
-	border-top: $border-width solid $gray-200;
+	box-shadow: 0 0 0 $border-width rgba(0, 0, 0, 0.12);
 	color: $gray-900;
 	position: absolute;
 	bottom: 0;


### PR DESCRIPTION
## What?
Replaces gray interface skeleton borders with opaque shadows, which tightens up the UI when darker background colors are used. 

## Why?
This PR explores using box-shadows instead of borders on the interface skeleton, to tighten up the interface on sites that have darker background colors. Currently if the background color of the site is darker than the border, you end up with a slight distortion around the edges of the interface. 

By using shadows, we can maintain an edge with lighter backgrounds, but on darker backgrounds (where the edge is already defined by the background color) it's sharp - instead of distorted. 

## How?
Replacing borders with box shadows. 

## Testing Instructions
1. Open a Post or Page.
2. View the interface skeleton

---

## Before
Notice the distortion around the gray borders against the colored background:

![before](https://user-images.githubusercontent.com/1813435/178069744-2ef51390-1624-4e9a-aa81-7dad39995e5d.png)

But there is distortion on lighter backgrounds:

![CleanShot 2022-07-08 at 17 03 08@2x](https://user-images.githubusercontent.com/1813435/178069986-80a98ad8-06f4-4ad5-9d61-07f7f3c554d6.png)

Zoomed in: 

<img width="572" alt="CleanShot 2022-07-08 at 17 06 56@2x" src="https://user-images.githubusercontent.com/1813435/178070468-1a749d45-51cb-4ef5-916f-bb1c5e72d75a.png">

---

## After
No distortion around the edges of the interface:

![after](https://user-images.githubusercontent.com/1813435/178069734-65713c27-6732-4f4a-b4cf-745f781b194f.png)

Zoomed in: 

<img width="573" alt="CleanShot 2022-07-08 at 17 07 23@2x" src="https://user-images.githubusercontent.com/1813435/178070608-73f71960-3a05-4b57-9448-a0d0df5cd7ba.png">

Borders with lighter backgrounds still look as they do today:

![CleanShot 2022-07-08 at 17 01 00@2x](https://user-images.githubusercontent.com/1813435/178069905-c17e3154-1f1c-405f-83ab-b19b93326e9e.png)

