### PR TITLE
Block Social Links: Make links use CSS variables instead of just hex code.

### DIFF
--- a/packages/block-library/src/social-link/block.json
+++ b/packages/block-library/src/social-link/block.json
@@ -22,7 +22,9 @@
 		"openInNewTab",
 		"showLabels",
 		"iconColorValue",
-		"iconBackgroundColorValue"
+		"iconBackgroundColorValue",
+		"iconColor",
+		"iconBackgroundColor"
 	],
 	"supports": {
 		"reusable": false,

--- a/packages/block-library/src/social-link/edit.js
+++ b/packages/block-library/src/social-link/edit.js
@@ -70,10 +70,19 @@ const SocialLinkEdit = ( {
 	setAttributes,
 } ) => {
 	const { url, service, label } = attributes;
-	const { showLabels, iconColorValue, iconBackgroundColorValue } = context;
+	const {
+		showLabels,
+		iconColorValue,
+		iconBackgroundColorValue,
+		iconBackgroundColor,
+		iconColor,
+	} = context;
 	const [ showURLPopover, setPopover ] = useState( false );
 	const classes = classNames( 'wp-social-link', 'wp-social-link-' + service, {
 		'wp-social-link__is-incomplete': ! url,
+		[ `has-${ iconColor }-icon-color` ]: iconColor,
+		[ `has-${ iconBackgroundColor }-background-color` ]:
+			iconBackgroundColor,
 	} );
 
 	const ref = useRef();

--- a/packages/block-library/src/social-link/index.php
+++ b/packages/block-library/src/social-link/index.php
@@ -303,12 +303,28 @@ function block_core_social_link_services( $service = '', $field = '' ) {
 function block_core_social_link_get_color_styles( $context ) {
 	$styles = array();
 
-	if ( array_key_exists( 'iconColorValue', $context ) ) {
-		$styles[] = 'color: ' . $context['iconColorValue'] . '; ';
+	if ( array_key_exists( 'iconColor', $context ) ) {
+		if ( array_key_exists( 'iconColorValue', $context ) ) {
+			$styles[] = 'color: var(--wp--preset--color--' . $context['iconColor'] . ', ' . $context['iconColorValue'] . '); ';
+		} else {
+			$styles[] = 'color: var(--wp--preset--color--' . $context['iconColor'] . '); ';
+		}
+	} else {
+		if ( array_key_exists( 'iconColorValue', $context ) ) {
+			$styles[] = 'color: ' . $context['iconColorValue'] . '; ';
+		}
 	}
 
-	if ( array_key_exists( 'iconBackgroundColorValue', $context ) ) {
-		$styles[] = 'background-color: ' . $context['iconBackgroundColorValue'] . '; ';
+	if ( array_key_exists( 'iconBackgroundColor', $context ) ) {
+		if ( array_key_exists( 'iconBackgroundColorValue', $context ) ) {
+			$styles[] = 'background-color: var(--wp--preset--color--' . $context['iconBackgroundColor'] . ', ' . $context['iconBackgroundColorValue'] . '); ';
+		} else {
+			$styles[] = 'background-color: var(--wp--preset--color--' . $context['iconBackgroundColor'] . '); ';
+		}
+	} else {
+		if ( array_key_exists( 'iconBackgroundColorValue', $context ) ) {
+			$styles[] = 'background-color: ' . $context['iconBackgroundColorValue'] . '; ';
+		}
 	}
 
 	return implode( '', $styles );

--- a/packages/block-library/src/social-links/block.json
+++ b/packages/block-library/src/social-links/block.json
@@ -42,7 +42,9 @@
 		"openInNewTab": "openInNewTab",
 		"showLabels": "showLabels",
 		"iconColorValue": "iconColorValue",
-		"iconBackgroundColorValue": "iconBackgroundColorValue"
+		"iconBackgroundColorValue": "iconBackgroundColorValue",
+		"iconColor": "iconColor",
+		"iconBackgroundColor": "iconBackgroundColor"
 	},
 	"supports": {
 		"align": [ "left", "center", "right" ],


### PR DESCRIPTION
Fixes #36462.

<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Make social links use CSS variable for color with hex fallback. Allows site colors to be changed and update the social link icons as well instead of staying set at what they were originally set at.

## Why?
Allows full site editing to change colors without needing to individually change every instance of the social links block to update to the new color.

## How?
Adds two variables, iconColor and iconBackgroundColor, to the context passed down to social link items. The color slug is then used to populate the CSS variable with the hex code as a fall back in case a theme switch were to happen.

## Testing Instructions
1. Open the Site Editor.
2. Add a social links block some where and add some social links.
3. Set the link color and background color to a preset from the palette.
4. Open the Site Editor Styles sidebar and change the color of the matching presets. The link color and background should update to match what is set as the new value.

## Screenshots or screencast
