### PR TITLE
Allow highlighting multiple strings with TextHighlight component

### DIFF
--- a/packages/components/src/text-highlight/README.md
+++ b/packages/components/src/text-highlight/README.md
@@ -23,9 +23,9 @@ const MyTextHighlight = () => (
 
 The component accepts the following props.
 
-### `highlight`: `string`
+### `highlight`: `string | string[]`
 
-The string to search for and highlight within the `text`. Case insensitive. Multiple matches.
+The string or array of strings to search for and highlight within the `text`. Case insensitive. Multiple matches.
 
 -   Required: Yes
 -   Default: `''`

--- a/packages/components/src/text-highlight/index.tsx
+++ b/packages/components/src/text-highlight/index.tsx
@@ -30,16 +30,23 @@ import type { TextHighlightProps } from './types';
  */
 export const TextHighlight = ( props: TextHighlightProps ) => {
 	const { text = '', highlight = '' } = props;
-	const trimmedHighlightText = highlight.trim();
+	// Convert single string to array, trim thim & filters empty|null values.
+	const trimmedHighlightText = ( ! Array.isArray( highlight )
+		? [ highlight ]
+		: highlight
+	)
+		// Trim each highlight.
+		.map( ( h ) => h.trim() )
+		// Filter out empty | null items.
+		.filter( ( h ) => !! h )
+		// Escape regex for each string.
+		.map( ( h ) => escapeRegExp( h ) );
 
-	if ( ! trimmedHighlightText ) {
+	if ( ! trimmedHighlightText.length ) {
 		return <>{ text }</>;
 	}
 
-	const regex = new RegExp(
-		`(${ escapeRegExp( trimmedHighlightText ) })`,
-		'gi'
-	);
+	const regex = new RegExp( `(${ trimmedHighlightText.join( '|' ) })`, 'gi' );
 
 	return createInterpolateElement( text.replace( regex, '<mark>$&</mark>' ), {
 		mark: <mark />,

--- a/packages/components/src/text-highlight/stories/index.tsx
+++ b/packages/components/src/text-highlight/stories/index.tsx
@@ -28,6 +28,18 @@ export const Default: ComponentStory< typeof TextHighlight > = Template.bind(
 	{}
 );
 Default.args = {
-	text: 'We call the new editor Gutenberg. The entire editing experience has been rebuilt for media rich pages and posts.',
+	text:
+		'We call the new editor Gutenberg. The entire editing experience has been rebuilt for media rich pages and posts.',
 	highlight: 'Gutenberg',
+};
+
+export const WithMultipleHighlightTerms: ComponentStory<
+	typeof TextHighlight
+> = Template.bind( {} );
+
+WithMultipleHighlightTerms.args = {
+	...Default.args,
+	text:
+		'We call the new editor Gutenberg. The entire editing experience has been rebuilt for media rich pages and posts.',
+	highlight: [ 'edit', 'post' ],
 };

--- a/packages/components/src/text-highlight/test/index.tsx
+++ b/packages/components/src/text-highlight/test/index.tsx
@@ -38,7 +38,7 @@ describe( 'TextHighlight', () => {
 			}
 		);
 
-		it( 'should highlight multiple occurances of the string every time it exists in the text', () => {
+		it( 'should highlight multiple occurances of a single string every time it exists in the text', () => {
 			const highlight = 'edit';
 
 			const { container } = render(
@@ -56,7 +56,29 @@ describe( 'TextHighlight', () => {
 			} );
 		} );
 
-		it( 'should highlight occurances of a string regardless of capitalisation', () => {
+		it( 'should highlight multiple occurances of multiple strings every time they exist in the text', () => {
+			const highlight = [ 'edit', 'post' ];
+
+			const { container } = render(
+				<TextHighlight text={ defaultText } highlight={ highlight } />
+			);
+
+			const highlightedEls = getMarks( container );
+
+			expect( highlightedEls ).toHaveLength( 3 );
+
+			// Join strings & make sure the matcher is case insensitive, since the test should
+			// match regardless of the case of the string.
+			const regex = new RegExp( `(${ highlight.join( '|' ) })`, 'i' );
+
+			highlightedEls.forEach( ( el ) => {
+				expect( el.textContent ).toEqual(
+					expect.stringMatching( regex )
+				);
+			} );
+		} );
+
+		it( 'should highlight occurances of a single string regardless of capitalisation', () => {
 			// Note that `The` occurs twice in the default text, once in
 			// lowercase and once capitalized.
 			const highlight = 'The';

--- a/packages/components/src/text-highlight/types.ts
+++ b/packages/components/src/text-highlight/types.ts
@@ -5,7 +5,7 @@ export type TextHighlightProps = {
 	 *
 	 * @default ''
 	 */
-	highlight: string;
+	highlight: string | string[];
 	/**
 	 * The string of text to be tested for occurrences of then given
 	 * `highlight`.


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Modifies `TextHighlight` to accept `string | string[]` for `highlight` prop.

## Why?
Was attempting to highlight multiple strings and found this impossible with the current version.
- Nesting didn't work as it expects the `text` to be a string, and thus can't handle nesting one highlight inside another.
- Passing a joined string using `|` for regex match is stripped out during escaping.

## How?
1. Convert single highlight string to `[ highlight ]` so its always an array for mapping.
2. Mapped highlight strings through trim, filtered empty results, then filtered again through `escapeRegex`
3. Modified the regex match and empty highlight text checks to work with an array of values joined using `|`.

## Screenshots or screencast <!-- if applicable -->
![image](https://user-images.githubusercontent.com/847818/178127563-77810d3a-6edb-461b-97a9-eaf9fb8e400d.png)

```js
<TextHighlight
    text={ 'User Has Role(s)' }
    highlight={ [ 'user', 'role' ] }
/>
```