### PR TITLE
Placeholder: Add a box-sizing border-box to input fields

### DIFF
--- a/packages/components/src/placeholder/style.scss
+++ b/packages/components/src/placeholder/style.scss
@@ -31,6 +31,11 @@
 		font-size: $default-font-size;
 	}
 
+	.components-text-control__input,
+	.components-textarea-control__input {
+		box-sizing: border-box;
+	}
+
 	&.has-illustration {
 		background: none;
 		border: none;


### PR DESCRIPTION
Part of #41961.

## What?
This PR applies `box-sizing: border-box` to input elements (`TextControl`, `TextareaControl`) placed on `Placeholder` component.

## Why?
In the post editor, `box-sizing: border-box` is applied to the input elements because `form.css` is loaded (Perhaps this is not the expected style.).

![post-editor](https://user-images.githubusercontent.com/54422211/178145415-7301c3ee-7ba0-4c56-a613-c5fae5642e8c.png)

In the site editor, the input elements overflows because `form.css` is not loaded.

![site-editor](https://user-images.githubusercontent.com/54422211/178145438-91f77628-279d-48a5-9b1a-92a4e0bd6ecd.png)

## How?
I think `box-sizing: border-box` should be applied to the input element just as [Button component has](https://github.com/WordPress/gutenberg/blob/de11d1d7e0a4f72dc24362e559aaba635b74dff4/packages/components/src/button/style.scss#L16).
However, I limited it to elements within `Placeholder` component only to minimize the scope of influence.

For now, this response will only improve the table block placeholder layout.

![after](https://user-images.githubusercontent.com/54422211/178145914-d5a21436-5e7c-43f8-89b6-259c190524e8.png)

