### PR TITLE
Flex: Remove experimental from docs and storybook

### DIFF
--- a/packages/components/src/flex/flex-block/README.md
+++ b/packages/components/src/flex/flex-block/README.md
@@ -1,9 +1,5 @@
 # FlexBlock
 
-<div class="callout callout-alert">
-This feature is still experimental. “Experimental” means this is an early implementation subject to drastic and breaking changes.
-</div>
-
 A layout component to contain items of a fixed width within `Flex`.
 
 ## Usage

--- a/packages/components/src/flex/flex-block/component.js
+++ b/packages/components/src/flex/flex-block/component.js
@@ -22,9 +22,13 @@ function FlexBlock( props, forwardedRef ) {
  * ```jsx
  * import { Flex, FlexBlock } from '@wordpress/components';
  *
- * <Flex>
- *   <FlexBlock>...</FlexBlock>
- * </Flex>
+ * function Example() {
+ *   return (
+ *     <Flex>
+ *       <FlexBlock>...</FlexBlock>
+ *     </Flex>
+ *   );
+ * }
  * ```
  */
 const ConnectedFlexBlock = contextConnect( FlexBlock, 'FlexBlock' );

--- a/packages/components/src/flex/flex-block/component.js
+++ b/packages/components/src/flex/flex-block/component.js
@@ -20,8 +20,10 @@ function FlexBlock( props, forwardedRef ) {
  *
  * @example
  * ```jsx
+ * import { Flex, FlexBlock } from '@wordpress/components';
+ *
  * <Flex>
- * 	<FlexBlock>...</FlexBlock>
+ *   <FlexBlock>...</FlexBlock>
  * </Flex>
  * ```
  */

--- a/packages/components/src/flex/flex-item/README.md
+++ b/packages/components/src/flex/flex-item/README.md
@@ -1,9 +1,5 @@
 # FlexItem
 
-<div class="callout callout-alert">
-This feature is still experimental. “Experimental” means this is an early implementation subject to drastic and breaking changes.
-</div>
-
 A layout component to contain items of a fixed width within `Flex`.
 
 ## Usage

--- a/packages/components/src/flex/flex-item/component.js
+++ b/packages/components/src/flex/flex-item/component.js
@@ -22,9 +22,13 @@ function FlexItem( props, forwardedRef ) {
  * ```jsx
  * import { Flex, FlexItem } from '@wordpress/components';
  *
- * <Flex>
- *   <FlexItem>...</FlexItem>
- * </Flex>
+ * function Example() {
+ *   return (
+ *     <Flex>
+ *       <FlexItem>...</FlexItem>
+ *     </Flex>
+ *   );
+ * }
  * ```
  */
 const ConnectedFlexItem = contextConnect( FlexItem, 'FlexItem' );

--- a/packages/components/src/flex/flex-item/component.js
+++ b/packages/components/src/flex/flex-item/component.js
@@ -20,8 +20,10 @@ function FlexItem( props, forwardedRef ) {
  *
  * @example
  * ```jsx
+ * import { Flex, FlexItem } from '@wordpress/components';
+ *
  * <Flex>
- * 	<FlexItem>...</FlexItem>
+ *   <FlexItem>...</FlexItem>
  * </Flex>
  * ```
  */

--- a/packages/components/src/flex/flex/README.md
+++ b/packages/components/src/flex/flex/README.md
@@ -7,11 +7,7 @@
 `Flex` is used with any of it's two sub-components, `FlexItem` and `FlexBlock`.
 
 ```jsx
-import {
-	Flex,
-	FlexBlock,
-	FlexItem,
-} from '@wordpress/components';
+import { Flex, FlexBlock, FlexItem } from '@wordpress/components';
 
 function Example() {
 	return (

--- a/packages/components/src/flex/flex/component.js
+++ b/packages/components/src/flex/flex/component.js
@@ -33,27 +33,21 @@ function Flex( props, forwardedRef ) {
  *
  * @example
  * ```jsx
- * import {
- * 	__experimentalFlex as Flex,
- * 	__experimentalFlexBlock as FlexBlock,
- * 	__experimentalFlexItem as FlexItem,
- * 	__experimentalText as Text
- * } from `@wordpress/components`;
+ * import { Flex, FlexBlock, FlexItem } from '@wordpress/components';
  *
  * function Example() {
- * 	return (
- * 		<Flex>
- * 			<FlexItem>
- * 				<Text>Code</Text>
- * 			</FlexItem>
- * 			<FlexBlock>
- * 				<Text>Poetry</Text>
- * 			</FlexBlock>
- * 		</Flex>
- * 	);
+ *   return (
+ *     <Flex>
+ *       <FlexItem>
+ *         <p>Code</p>
+ *       </FlexItem>
+ *       <FlexBlock>
+ *         <p>Poetry</p>
+ *       </FlexBlock>
+ *     </Flex>
+ *   );
  * }
  * ```
- *
  */
 const ConnectedFlex = contextConnect( Flex, 'Flex' );
 

--- a/packages/components/src/flex/stories/index.js
+++ b/packages/components/src/flex/stories/index.js
@@ -6,7 +6,7 @@ import { View } from '../../view';
 
 export default {
 	component: Flex,
-	title: 'Components (Experimental)/Flex',
+	title: 'Components/Flex',
 };
 
 export const _default = () => {


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Remove experimental callout and update inline docs in `Flex`, `FlexItem` and `FlexBlock` components.

## Why?
The components are not exported as experimental and the docs/storybook should reflect this.

## How?
Updated inline storybook, inline docs and readme docs.
