### PR TITLE
Ignore *.d.ts files when running unit tests

### DIFF
--- a/test/unit/jest.config.js
+++ b/test/unit/jest.config.js
@@ -29,6 +29,7 @@ module.exports = {
 		'<rootDir>/.*/build/',
 		'<rootDir>/.*/build-module/',
 		'<rootDir>/.*/build-types/',
+		'<rootDir>/.+.d.ts$',
 		'<rootDir>/.+.native.js$',
 		'/packages/react-native-*',
 	],


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Configures jest to ignore `*.d.ts` files.

## Why?
When running `npm run test-unit` locally (I don't know why it doesn't happen in CI?) I get a lot of "No tests found" errors caused by jest trying to run tests in `.d.ts` files.

## Testing Instructions
Run `npm run test-unit` locally.