### PR TITLE
Add layout content size controls to global styles

### DIFF
--- a/packages/edit-site/src/components/global-styles/dimensions-panel.js
+++ b/packages/edit-site/src/components/global-styles/dimensions-panel.js
@@ -195,65 +195,61 @@ export default function DimensionsPanel( { name } ) {
 			{ ( showContentSizeControl || showWideSizeControl ) && (
 				<Flex>
 					{ showContentSizeControl && (
-						<FlexItem>
-							<ToolsPanelItem
-								label={ __( 'Content size' ) }
-								hasValue={ hasUserSetContentSizeValue }
-								onDeselect={ resetContentSizeValue }
-								isShownByDefault={ true }
-							>
-								<Flex align="flex-end">
-									<FlexItem>
-										<UnitControl
-											label={ __( 'Content' ) }
-											labelPosition="top"
-											__unstableInputWidth="80px"
-											value={ contentSizeValue || '' }
-											onChange={ ( nextContentSize ) => {
-												setContentSizeValue(
-													nextContentSize
-												);
-											} }
-											units={ units }
-										/>
-									</FlexItem>
-									<FlexItem>
-										<Icon icon={ positionCenter } />
-									</FlexItem>
-								</Flex>
-							</ToolsPanelItem>
-						</FlexItem>
+						<ToolsPanelItem
+							as={ FlexItem }
+							label={ __( 'Content size' ) }
+							hasValue={ hasUserSetContentSizeValue }
+							onDeselect={ resetContentSizeValue }
+							isShownByDefault={ true }
+						>
+							<Flex align="flex-end">
+								<FlexItem>
+									<UnitControl
+										label={ __( 'Content' ) }
+										labelPosition="top"
+										__unstableInputWidth="80px"
+										value={ contentSizeValue || '' }
+										onChange={ ( nextContentSize ) => {
+											setContentSizeValue(
+												nextContentSize
+											);
+										} }
+										units={ units }
+									/>
+								</FlexItem>
+								<FlexItem>
+									<Icon icon={ positionCenter } />
+								</FlexItem>
+							</Flex>
+						</ToolsPanelItem>
 					) }
 
 					{ showWideSizeControl && (
-						<FlexItem>
-							<ToolsPanelItem
-								label={ __( 'Wide size' ) }
-								hasValue={ hasUserSetWideSizeValue }
-								onDeselect={ resetWideSizeValue }
-								isShownByDefault={ true }
-							>
-								<Flex align="flex-end">
-									<FlexItem>
-										<UnitControl
-											label={ __( 'Wide' ) }
-											labelPosition="top"
-											__unstableInputWidth="80px"
-											value={ wideSizeValue || '' }
-											onChange={ ( nextWideSize ) => {
-												setWideSizeValue(
-													nextWideSize
-												);
-											} }
-											units={ units }
-										/>
-									</FlexItem>
-									<FlexItem>
-										<Icon icon={ stretchWide } />
-									</FlexItem>
-								</Flex>
-							</ToolsPanelItem>
-						</FlexItem>
+						<ToolsPanelItem
+							as={ FlexItem }
+							label={ __( 'Wide size' ) }
+							hasValue={ hasUserSetWideSizeValue }
+							onDeselect={ resetWideSizeValue }
+							isShownByDefault={ true }
+						>
+							<Flex align="flex-end">
+								<FlexItem>
+									<UnitControl
+										label={ __( 'Wide' ) }
+										labelPosition="top"
+										__unstableInputWidth="80px"
+										value={ wideSizeValue || '' }
+										onChange={ ( nextWideSize ) => {
+											setWideSizeValue( nextWideSize );
+										} }
+										units={ units }
+									/>
+								</FlexItem>
+								<FlexItem>
+									<Icon icon={ stretchWide } />
+								</FlexItem>
+							</Flex>
+						</ToolsPanelItem>
 					) }
 				</Flex>
 			) }

--- a/packages/edit-site/src/components/global-styles/dimensions-panel.js
+++ b/packages/edit-site/src/components/global-styles/dimensions-panel.js
@@ -194,7 +194,7 @@ export default function DimensionsPanel( { name } ) {
 		<ToolsPanel label={ __( 'Dimensions' ) } resetAll={ resetAll }>
 			{ ( showContentSizeControl || showWideSizeControl ) && (
 				<span className="span-columns">
-					Set the width of the main content area.
+					{ __( 'Set the width of the main content area.' ) }
 				</span>
 			) }
 			{ showContentSizeControl && (

--- a/packages/edit-site/src/components/global-styles/dimensions-panel.js
+++ b/packages/edit-site/src/components/global-styles/dimensions-panel.js
@@ -125,7 +125,13 @@ export default function DimensionsPanel( { name } ) {
 		name
 	);
 
-	const hasContentSizeValue = () => !! contentSizeValue;
+	const [ userSetContentSizeValue ] = useSetting(
+		'layout.contentSize',
+		name,
+		'user'
+	);
+
+	const hasUserSetContentSizeValue = () => !! userSetContentSizeValue;
 	const resetContentSizeValue = () => setContentSizeValue( '' );
 
 	const [ wideSizeValue, setWideSizeValue ] = useSetting(
@@ -133,7 +139,13 @@ export default function DimensionsPanel( { name } ) {
 		name
 	);
 
-	const hasWideSizeValue = () => !! wideSizeValue;
+	const [ userSetWideSizeValue ] = useSetting(
+		'layout.wideSize',
+		name,
+		'user'
+	);
+
+	const hasUserSetWideSizeValue = () => !! userSetWideSizeValue;
 	const resetWideSizeValue = () => setWideSizeValue( '' );
 
 	const [ rawPadding, setRawPadding ] = useStyle( 'spacing.padding', name );
@@ -174,6 +186,8 @@ export default function DimensionsPanel( { name } ) {
 		resetPaddingValue();
 		resetMarginValue();
 		resetGapValue();
+		resetContentSizeValue();
+		resetWideSizeValue();
 	};
 
 	return (
@@ -184,7 +198,7 @@ export default function DimensionsPanel( { name } ) {
 						<FlexItem>
 							<ToolsPanelItem
 								label={ __( 'Content size' ) }
-								hasValue={ hasContentSizeValue }
+								hasValue={ hasUserSetContentSizeValue }
 								onDeselect={ resetContentSizeValue }
 								isShownByDefault={ true }
 							>
@@ -215,7 +229,7 @@ export default function DimensionsPanel( { name } ) {
 						<FlexItem>
 							<ToolsPanelItem
 								label={ __( 'Wide size' ) }
-								hasValue={ hasWideSizeValue }
+								hasValue={ hasUserSetWideSizeValue }
 								onDeselect={ resetWideSizeValue }
 								isShownByDefault={ true }
 							>

--- a/packages/edit-site/src/components/global-styles/dimensions-panel.js
+++ b/packages/edit-site/src/components/global-styles/dimensions-panel.js
@@ -8,8 +8,11 @@ import {
 	__experimentalBoxControl as BoxControl,
 	__experimentalUnitControl as UnitControl,
 	__experimentalUseCustomUnits as useCustomUnits,
+	Flex,
+	FlexItem,
 } from '@wordpress/components';
 import { __experimentalUseCustomSides as useCustomSides } from '@wordpress/block-editor';
+import { Icon, positionCenter, stretchWide } from '@wordpress/icons';
 
 /**
  * Internal dependencies
@@ -19,11 +22,27 @@ import { getSupportedGlobalStylesPanels, useSetting, useStyle } from './hooks';
 const AXIAL_SIDES = [ 'horizontal', 'vertical' ];
 
 export function useHasDimensionsPanel( name ) {
+	const hasContentSize = useHasContentSize( name );
+	const hasWideSize = useHasWideSize( name );
 	const hasPadding = useHasPadding( name );
 	const hasMargin = useHasMargin( name );
 	const hasGap = useHasGap( name );
 
-	return hasPadding || hasMargin || hasGap;
+	return hasContentSize || hasWideSize || hasPadding || hasMargin || hasGap;
+}
+
+function useHasContentSize( name ) {
+	const supports = getSupportedGlobalStylesPanels( name );
+	const [ settings ] = useSetting( 'layout.contentSize', name );
+
+	return settings && supports.includes( 'contentSize' );
+}
+
+function useHasWideSize( name ) {
+	const supports = getSupportedGlobalStylesPanels( name );
+	const [ settings ] = useSetting( 'layout.wideSize', name );
+
+	return settings && supports.includes( 'wideSize' );
 }
 
 function useHasPadding( name ) {
@@ -86,6 +105,8 @@ function splitStyleValue( value ) {
 }
 
 export default function DimensionsPanel( { name } ) {
+	const showContentSizeControl = useHasContentSize( name );
+	const showWideSizeControl = useHasWideSize( name );
 	const showPaddingControl = useHasPadding( name );
 	const showMarginControl = useHasMargin( name );
 	const showGapControl = useHasGap( name );
@@ -98,6 +119,22 @@ export default function DimensionsPanel( { name } ) {
 			'vw',
 		],
 	} );
+
+	const [ contentSizeValue, setContentSizeValue ] = useSetting(
+		'layout.contentSize',
+		name
+	);
+
+	const hasContentSizeValue = () => !! contentSizeValue;
+	const resetContentSizeValue = () => setContentSizeValue( '' );
+
+	const [ wideSizeValue, setWideSizeValue ] = useSetting(
+		'layout.wideSize',
+		name
+	);
+
+	const hasWideSizeValue = () => !! wideSizeValue;
+	const resetWideSizeValue = () => setWideSizeValue( '' );
 
 	const [ rawPadding, setRawPadding ] = useStyle( 'spacing.padding', name );
 	const paddingValues = splitStyleValue( rawPadding );
@@ -141,6 +178,66 @@ export default function DimensionsPanel( { name } ) {
 
 	return (
 		<ToolsPanel label={ __( 'Dimensions' ) } resetAll={ resetAll }>
+			<Flex>
+				<FlexItem>
+					{ showContentSizeControl && (
+						<ToolsPanelItem
+							label={ __( 'Content size' ) }
+							hasValue={ hasContentSizeValue }
+							onDeselect={ resetContentSizeValue }
+							isShownByDefault={ true }
+						>
+							<Flex>
+								<FlexItem>
+									<UnitControl
+										label={ __( 'Content' ) }
+										labelPosition="top"
+										__unstableInputWidth="80px"
+										value={ contentSizeValue || '' }
+										onChange={ ( nextContentSize ) => {
+											setContentSizeValue(
+												nextContentSize
+											);
+										} }
+										units={ units }
+									/>
+								</FlexItem>
+								<FlexItem>
+									<Icon icon={ positionCenter } />
+								</FlexItem>
+							</Flex>
+						</ToolsPanelItem>
+					) }
+				</FlexItem>
+				<FlexItem>
+					{ showWideSizeControl && (
+						<ToolsPanelItem
+							label={ __( 'Wide size' ) }
+							hasValue={ hasWideSizeValue }
+							onDeselect={ resetWideSizeValue }
+							isShownByDefault={ true }
+						>
+							<Flex>
+								<FlexItem>
+									<UnitControl
+										label={ __( 'Wide' ) }
+										labelPosition="top"
+										__unstableInputWidth="80px"
+										value={ wideSizeValue || '' }
+										onChange={ ( nextWideSize ) => {
+											setWideSizeValue( nextWideSize );
+										} }
+										units={ units }
+									/>
+								</FlexItem>
+								<FlexItem>
+									<Icon icon={ stretchWide } />
+								</FlexItem>
+							</Flex>
+						</ToolsPanelItem>
+					) }
+				</FlexItem>
+			</Flex>
 			{ showPaddingControl && (
 				<ToolsPanelItem
 					hasValue={ hasPaddingValue }

--- a/packages/edit-site/src/components/global-styles/dimensions-panel.js
+++ b/packages/edit-site/src/components/global-styles/dimensions-panel.js
@@ -187,7 +187,7 @@ export default function DimensionsPanel( { name } ) {
 							onDeselect={ resetContentSizeValue }
 							isShownByDefault={ true }
 						>
-							<Flex>
+							<Flex align="flex-end">
 								<FlexItem>
 									<UnitControl
 										label={ __( 'Content' ) }
@@ -217,7 +217,7 @@ export default function DimensionsPanel( { name } ) {
 							onDeselect={ resetWideSizeValue }
 							isShownByDefault={ true }
 						>
-							<Flex>
+							<Flex align="flex-end">
 								<FlexItem>
 									<UnitControl
 										label={ __( 'Wide' ) }

--- a/packages/edit-site/src/components/global-styles/dimensions-panel.js
+++ b/packages/edit-site/src/components/global-styles/dimensions-panel.js
@@ -178,66 +178,71 @@ export default function DimensionsPanel( { name } ) {
 
 	return (
 		<ToolsPanel label={ __( 'Dimensions' ) } resetAll={ resetAll }>
-			<Flex>
-				<FlexItem>
+			{ ( showContentSizeControl || showWideSizeControl ) && (
+				<Flex>
 					{ showContentSizeControl && (
-						<ToolsPanelItem
-							label={ __( 'Content size' ) }
-							hasValue={ hasContentSizeValue }
-							onDeselect={ resetContentSizeValue }
-							isShownByDefault={ true }
-						>
-							<Flex align="flex-end">
-								<FlexItem>
-									<UnitControl
-										label={ __( 'Content' ) }
-										labelPosition="top"
-										__unstableInputWidth="80px"
-										value={ contentSizeValue || '' }
-										onChange={ ( nextContentSize ) => {
-											setContentSizeValue(
-												nextContentSize
-											);
-										} }
-										units={ units }
-									/>
-								</FlexItem>
-								<FlexItem>
-									<Icon icon={ positionCenter } />
-								</FlexItem>
-							</Flex>
-						</ToolsPanelItem>
+						<FlexItem>
+							<ToolsPanelItem
+								label={ __( 'Content size' ) }
+								hasValue={ hasContentSizeValue }
+								onDeselect={ resetContentSizeValue }
+								isShownByDefault={ true }
+							>
+								<Flex align="flex-end">
+									<FlexItem>
+										<UnitControl
+											label={ __( 'Content' ) }
+											labelPosition="top"
+											__unstableInputWidth="80px"
+											value={ contentSizeValue || '' }
+											onChange={ ( nextContentSize ) => {
+												setContentSizeValue(
+													nextContentSize
+												);
+											} }
+											units={ units }
+										/>
+									</FlexItem>
+									<FlexItem>
+										<Icon icon={ positionCenter } />
+									</FlexItem>
+								</Flex>
+							</ToolsPanelItem>
+						</FlexItem>
 					) }
-				</FlexItem>
-				<FlexItem>
+
 					{ showWideSizeControl && (
-						<ToolsPanelItem
-							label={ __( 'Wide size' ) }
-							hasValue={ hasWideSizeValue }
-							onDeselect={ resetWideSizeValue }
-							isShownByDefault={ true }
-						>
-							<Flex align="flex-end">
-								<FlexItem>
-									<UnitControl
-										label={ __( 'Wide' ) }
-										labelPosition="top"
-										__unstableInputWidth="80px"
-										value={ wideSizeValue || '' }
-										onChange={ ( nextWideSize ) => {
-											setWideSizeValue( nextWideSize );
-										} }
-										units={ units }
-									/>
-								</FlexItem>
-								<FlexItem>
-									<Icon icon={ stretchWide } />
-								</FlexItem>
-							</Flex>
-						</ToolsPanelItem>
+						<FlexItem>
+							<ToolsPanelItem
+								label={ __( 'Wide size' ) }
+								hasValue={ hasWideSizeValue }
+								onDeselect={ resetWideSizeValue }
+								isShownByDefault={ true }
+							>
+								<Flex align="flex-end">
+									<FlexItem>
+										<UnitControl
+											label={ __( 'Wide' ) }
+											labelPosition="top"
+											__unstableInputWidth="80px"
+											value={ wideSizeValue || '' }
+											onChange={ ( nextWideSize ) => {
+												setWideSizeValue(
+													nextWideSize
+												);
+											} }
+											units={ units }
+										/>
+									</FlexItem>
+									<FlexItem>
+										<Icon icon={ stretchWide } />
+									</FlexItem>
+								</Flex>
+							</ToolsPanelItem>
+						</FlexItem>
 					) }
-				</FlexItem>
-			</Flex>
+				</Flex>
+			) }
 			{ showPaddingControl && (
 				<ToolsPanelItem
 					hasValue={ hasPaddingValue }

--- a/packages/edit-site/src/components/global-styles/dimensions-panel.js
+++ b/packages/edit-site/src/components/global-styles/dimensions-panel.js
@@ -6,10 +6,10 @@ import {
 	__experimentalToolsPanel as ToolsPanel,
 	__experimentalToolsPanelItem as ToolsPanelItem,
 	__experimentalBoxControl as BoxControl,
+	__experimentalHStack as HStack,
 	__experimentalUnitControl as UnitControl,
 	__experimentalUseCustomUnits as useCustomUnits,
-	Flex,
-	FlexItem,
+	__experimentalView as View,
 } from '@wordpress/components';
 import { __experimentalUseCustomSides as useCustomSides } from '@wordpress/block-editor';
 import { Icon, positionCenter, stretchWide } from '@wordpress/icons';
@@ -193,65 +193,59 @@ export default function DimensionsPanel( { name } ) {
 	return (
 		<ToolsPanel label={ __( 'Dimensions' ) } resetAll={ resetAll }>
 			{ ( showContentSizeControl || showWideSizeControl ) && (
-				<Flex>
-					{ showContentSizeControl && (
-						<ToolsPanelItem
-							as={ FlexItem }
-							label={ __( 'Content size' ) }
-							hasValue={ hasUserSetContentSizeValue }
-							onDeselect={ resetContentSizeValue }
-							isShownByDefault={ true }
-						>
-							<Flex align="flex-end">
-								<FlexItem>
-									<UnitControl
-										label={ __( 'Content' ) }
-										labelPosition="top"
-										__unstableInputWidth="80px"
-										value={ contentSizeValue || '' }
-										onChange={ ( nextContentSize ) => {
-											setContentSizeValue(
-												nextContentSize
-											);
-										} }
-										units={ units }
-									/>
-								</FlexItem>
-								<FlexItem>
-									<Icon icon={ positionCenter } />
-								</FlexItem>
-							</Flex>
-						</ToolsPanelItem>
-					) }
-
-					{ showWideSizeControl && (
-						<ToolsPanelItem
-							as={ FlexItem }
-							label={ __( 'Wide size' ) }
-							hasValue={ hasUserSetWideSizeValue }
-							onDeselect={ resetWideSizeValue }
-							isShownByDefault={ true }
-						>
-							<Flex align="flex-end">
-								<FlexItem>
-									<UnitControl
-										label={ __( 'Wide' ) }
-										labelPosition="top"
-										__unstableInputWidth="80px"
-										value={ wideSizeValue || '' }
-										onChange={ ( nextWideSize ) => {
-											setWideSizeValue( nextWideSize );
-										} }
-										units={ units }
-									/>
-								</FlexItem>
-								<FlexItem>
-									<Icon icon={ stretchWide } />
-								</FlexItem>
-							</Flex>
-						</ToolsPanelItem>
-					) }
-				</Flex>
+				<span className="span-columns">
+					Set the width of the main content area.
+				</span>
+			) }
+			{ showContentSizeControl && (
+				<ToolsPanelItem
+					className="single-column"
+					label={ __( 'Content size' ) }
+					hasValue={ hasUserSetContentSizeValue }
+					onDeselect={ resetContentSizeValue }
+					isShownByDefault={ true }
+				>
+					<HStack alignment="flex-end">
+						<UnitControl
+							label={ __( 'Content' ) }
+							labelPosition="top"
+							__unstableInputWidth="80px"
+							value={ contentSizeValue || '' }
+							onChange={ ( nextContentSize ) => {
+								setContentSizeValue( nextContentSize );
+							} }
+							units={ units }
+						/>
+						<View>
+							<Icon icon={ positionCenter } />
+						</View>
+					</HStack>
+				</ToolsPanelItem>
+			) }
+			{ showWideSizeControl && (
+				<ToolsPanelItem
+					className="single-column"
+					label={ __( 'Wide size' ) }
+					hasValue={ hasUserSetWideSizeValue }
+					onDeselect={ resetWideSizeValue }
+					isShownByDefault={ true }
+				>
+					<HStack alignment="flex-end">
+						<UnitControl
+							label={ __( 'Wide' ) }
+							labelPosition="top"
+							__unstableInputWidth="80px"
+							value={ wideSizeValue || '' }
+							onChange={ ( nextWideSize ) => {
+								setWideSizeValue( nextWideSize );
+							} }
+							units={ units }
+						/>
+						<View>
+							<Icon icon={ stretchWide } />
+						</View>
+					</HStack>
+				</ToolsPanelItem>
 			) }
 			{ showPaddingControl && (
 				<ToolsPanelItem

--- a/packages/edit-site/src/components/global-styles/hooks.js
+++ b/packages/edit-site/src/components/global-styles/hooks.js
@@ -168,6 +168,8 @@ const ROOT_BLOCK_SUPPORTS = [
 	'textDecoration',
 	'textTransform',
 	'padding',
+	'contentSize',
+	'wideSize',
 ];
 
 export function getSupportedGlobalStylesPanels( name ) {

--- a/packages/edit-site/src/components/sidebar/style.scss
+++ b/packages/edit-site/src/components/sidebar/style.scss
@@ -60,6 +60,10 @@
 	grid-column: span 1;
 }
 
+.edit-site-global-styles-sidebar .components-tools-panel .span-columns {
+	grid-column: 1 / -1;
+}
+
 .edit-site-global-styles-sidebar__blocks-group {
 	padding-top: $grid-unit-30;
 	border-top: $border-width solid $gray-200;


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Adds content size and wide size controls to global styles, under "Layout"

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

Fixes #35955.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

* Enables `contentSize` and `wideSize` in `ROOT_BLOCK_SUPPORTS`;
* Adds controls to Dimensions panel in the root Layout section of Global Styles sidebar.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. --><!-- 3. etc. -->

1. In the global styles panel, go to Layout and check that Content and Wide size inputs are visible under "Dimensions".
2. Add values to those fields and check that content sizes update sitewide.
3. Check that values can be reset from the kebab menu in the Dimensions panel.

## Screenshots or screencast <!-- if applicable -->


<img width="280" alt="Screen Shot 2022-07-15 at 5 45 23 pm" src="https://user-images.githubusercontent.com/8096000/179177138-4c0d70fa-7f55-4d5e-bb5d-77fc4950fd60.png">

<img width="281" alt="Screen Shot 2022-07-15 at 5 45 16 pm" src="https://user-images.githubusercontent.com/8096000/179177156-caaffa3c-4f00-43af-921c-732e43bfab76.png">


