### PR TITLE
Post title: fix single line paste

### DIFF
--- a/packages/editor/src/components/post-title/index.js
+++ b/packages/editor/src/components/post-title/index.js
@@ -149,7 +149,13 @@ function PostTitle( _, forwardedRef ) {
 			plainText,
 		} );
 
-		if ( typeof content !== 'string' && content.length ) {
+		event.preventDefault();
+
+		if ( ! content.length ) {
+			return;
+		}
+
+		if ( typeof content !== 'string' ) {
 			event.preventDefault();
 
 			const [ firstBlock ] = content;
@@ -164,6 +170,8 @@ function PostTitle( _, forwardedRef ) {
 			} else {
 				onInsertBlockAfter( content );
 			}
+		} else {
+			onUpdate( content );
 		}
 	}
 

--- a/packages/editor/src/components/post-title/index.js
+++ b/packages/editor/src/components/post-title/index.js
@@ -156,8 +156,6 @@ function PostTitle( _, forwardedRef ) {
 		}
 
 		if ( typeof content !== 'string' ) {
-			event.preventDefault();
-
 			const [ firstBlock ] = content;
 
 			if (

--- a/test/e2e/specs/editor/various/__snapshots__/Copy-cut-paste-should-paste-single-line-in-post-title-1-chromium.txt
+++ b/test/e2e/specs/editor/various/__snapshots__/Copy-cut-paste-should-paste-single-line-in-post-title-1-chromium.txt
@@ -1,0 +1,1 @@
+Hello World

--- a/test/e2e/specs/editor/various/copy-cut-paste.spec.js
+++ b/test/e2e/specs/editor/various/copy-cut-paste.spec.js
@@ -397,4 +397,23 @@ test.describe( 'Copy/cut/paste', () => {
 		await pageUtils.pressKeyWithModifier( 'primary', 'v' );
 		expect( await editor.getEditedPostContent() ).toMatchSnapshot();
 	} );
+
+	test( 'should paste single line in post title', async ( {
+		page,
+		pageUtils,
+	} ) => {
+		// This test checks whether we are correctly handling single line
+		// pasting in the post title. Previously we were accidentally falling
+		// back to default browser behaviour, allowing the browser to insert
+		// unfiltered HTML. When we swap out the post title in the post editor
+		// with the proper block, this test can be removed.
+		await pageUtils.setClipboardData( {
+			html: '<span style="border: 1px solid black">Hello World</span>',
+		} );
+		await pageUtils.pressKeyWithModifier( 'primary', 'v' );
+		// Expect the span to be filtered out.
+		expect(
+			await page.evaluate( () => document.activeElement.innerHTML )
+		).toMatchSnapshot();
+	} );
 } );


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?

Fixes #38637. The problem is that we forgot to handle the case when the pasteHandler outputs a string. Since we also didn't prevent default behaviour, the browser is handling it, which makes it seems like everything is working fine. But the browser will paste unfiltered HTML.

I guess we should add an e2e test?

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->

## Screenshots or screencast <!-- if applicable -->
