### PR TITLE
Fix labelling and semantics of the paragraph block Left to right control

### DIFF
--- a/packages/block-library/src/paragraph/edit.js
+++ b/packages/block-library/src/paragraph/edit.js
@@ -8,7 +8,7 @@ import classnames from 'classnames';
  */
 import { __, _x, isRTL } from '@wordpress/i18n';
 import {
-	ToolbarDropdownMenu,
+	ToolbarButton,
 	ToggleControl,
 	__experimentalToolsPanelItem as ToolsPanelItem,
 } from '@wordpress/components';
@@ -33,19 +33,13 @@ const name = 'core/paragraph';
 function ParagraphRTLControl( { direction, setDirection } ) {
 	return (
 		isRTL() && (
-			<ToolbarDropdownMenu
-				controls={ [
-					{
-						icon: formatLtr,
-						title: _x( 'Left to right', 'editor button' ),
-						isActive: direction === 'ltr',
-						onClick() {
-							setDirection(
-								direction === 'ltr' ? undefined : 'ltr'
-							);
-						},
-					},
-				] }
+			<ToolbarButton
+				icon={ formatLtr }
+				title={ _x( 'Left to right', 'editor button' ) }
+				isActive={ direction === 'ltr' }
+				onClick={ () => {
+					setDirection( direction === 'ltr' ? undefined : 'ltr' );
+				} }
 			/>
 		)
 	);


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->
Fixes https://github.com/WordPress/gutenberg/issues/42314

## What?
<!-- In a few words, what is the PR actually doing? -->
This PR seeks to fix the `ParagraphRTLControl` shown when the admin is set to a RTL language. This control renders a dropdown menu that has only one menu item. The dropdown toggle button is unlabelled and the menu item doesn't have any semantics for the selected state.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
This control used to be a simple Toggle button. It was changed to a dropdown menu in https://github.com/WordPress/gutenberg/pull/29863 in the context of a large refactoring. I guess changing this control was not intentional: a dropdown menu doesn't make much sense in this case. Also, using a simple toggle button restores the missing labelling and selected state semantics.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
Converted the Paragraph block `ParagraphRTLControl` from a `ToolbarDropdownMenu`  to a `ToolbarButton`.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
- Set the WordPress admin to an RTL language.
- Edit a post and add a Paragraph block.
- Select the Paragraph block to make its toolbar appear.
- Inspect the 'Left to Right' button in the toolbar:
  - observe it has an `aria-label` attribute with value 'Left to Right'
  - observe it has an `aria-pressed` attribute with value false / true depending on whether the setting is active
- Check the button functionality is unchanged.

## Screenshots or screencast <!-- if applicable -->

Before (dropdown):

<img width="884" alt="Screenshot 2022-07-11 at 10 04 44" src="https://user-images.githubusercontent.com/1682452/178249947-1a2ffa2d-4563-45b4-86cf-9266b4a007e9.png">

After (toolbar toggle button):

<img width="752" alt="Screenshot 2022-07-11 at 11 46 07" src="https://user-images.githubusercontent.com/1682452/178250125-eca0aac3-718f-40de-93aa-b9be1468c7b6.png">

