### PR TITLE
Adds text decoration support to post title block

### DIFF
--- a/packages/block-library/src/post-title/block.json
+++ b/packages/block-library/src/post-title/block.json
@@ -51,6 +51,7 @@
 			"__experimentalFontWeight": true,
 			"__experimentalFontStyle": true,
 			"__experimentalTextTransform": true,
+			"__experimentalTextDecoration": true,
 			"__experimentalLetterSpacing": true,
 			"__experimentalDefaultControls": {
 				"fontSize": true,


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Closes #42310. Adds text decoration support to the core post title block.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

Because we want to style via global styles interface or the theme JSON configuration 
how the text is decorated in the post title block.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

Easy peasy, just added the support directive to the block's JSON configuration.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->

1. Switch to this branch
2. Use Empty theme (ideally)
3. in the theme.json of your theme add
```JSON
"textDecoration": "underline"
```
in `styles.blocks.core/post-title.typography`
4. The post title block should be underlined by default
5. The global styles interface should allow showing the "decoration" panel ans styling 
from it.

## Screenshots or screencast <!-- if applicable -->

[N/A]
