### PR TITLE
[Components - Popover]: Fix regression of inbetween inserter in site editor

### DIFF
--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -6,8 +6,9 @@
 
 -   `BoxControl`: Change ARIA role from `region` to `group` to avoid unwanted ARIA landmark regions ([#42094](https://github.com/WordPress/gutenberg/pull/42094)).
 -   `FocalPointPicker`, `FormTokenField`, `ResizableBox`: Fixed SSR breakage ([#42248](https://github.com/WordPress/gutenberg/pull/42248)).
--   `Popover`: pass missing anchor ref to the `getAnchorRect` callback prop. ([#42076](https://github.com/WordPress/gutenberg/pull/42076))
 -   `ComboboxControl`: use custom prefix when generating the instanceId ([#42134](https://github.com/WordPress/gutenberg/pull/42134).
+-   `Popover`: pass missing anchor ref to the `getAnchorRect` callback prop. ([#42076](https://github.com/WordPress/gutenberg/pull/42076)).
+-   `Popover`: call `getAnchorRect` callback prop even if `anchorRefFallback` has not a value. ([#42329](https://github.com/WordPress/gutenberg/pull/42329)).
 
 ### Internal
 

--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -8,7 +8,7 @@
 -   `FocalPointPicker`, `FormTokenField`, `ResizableBox`: Fixed SSR breakage ([#42248](https://github.com/WordPress/gutenberg/pull/42248)).
 -   `ComboboxControl`: use custom prefix when generating the instanceId ([#42134](https://github.com/WordPress/gutenberg/pull/42134).
 -   `Popover`: pass missing anchor ref to the `getAnchorRect` callback prop. ([#42076](https://github.com/WordPress/gutenberg/pull/42076)).
--   `Popover`: call `getAnchorRect` callback prop even if `anchorRefFallback` has not a value. ([#42329](https://github.com/WordPress/gutenberg/pull/42329)).
+-   `Popover`: call `getAnchorRect` callback prop even if `anchorRefFallback` has no value. ([#42329](https://github.com/WordPress/gutenberg/pull/42329)).
 
 ### Internal
 

--- a/packages/components/src/popover/README.md
+++ b/packages/components/src/popover/README.md
@@ -61,7 +61,7 @@ Set this prop to `false` to disable focus changing entirely. This should only be
 
 ### placement
 
-The direction in which the popover should open relative to its parent node or anchor node. 
+The direction in which the popover should open relative to its parent node or anchor node.
 
 The available base placements are 'top', 'right', 'bottom', 'left'.
 
@@ -137,7 +137,7 @@ A callback function which is used to override the anchor value computation algor
 
 If you need the `DOMRect` object i.e., the position of popover to be calculated on every time, the popover re-renders, then use `getAnchorRect`.
 
-`getAnchorRect` callback function receives a reference to the popover anchor element as a function parameter and it should return a `DOMRect` object.
+`getAnchorRect` callback function receives a reference to the popover anchor element as a function parameter and it should return a `DOMRect` object. Noting that `getAnchorRect` can be called with `null`.
 
 -   Type: `Function`
 -   Required: No

--- a/packages/components/src/popover/index.js
+++ b/packages/components/src/popover/index.js
@@ -148,7 +148,7 @@ const Popover = (
 			return anchorRef.ownerDocument;
 		} else if ( anchorRect && anchorRect?.ownerDocument ) {
 			return anchorRect.ownerDocument;
-		} else if ( getAnchorRect && anchorRefFallback.current ) {
+		} else if ( getAnchorRect ) {
 			return (
 				getAnchorRect( anchorRefFallback.current )?.ownerDocument ??
 				document
@@ -275,7 +275,7 @@ const Popover = (
 					return anchorRect;
 				},
 			};
-		} else if ( getAnchorRect && anchorRefFallback.current ) {
+		} else if ( getAnchorRect ) {
 			usedRef = {
 				getBoundingClientRect() {
 					const rect = getAnchorRect( anchorRefFallback.current );


### PR DESCRIPTION


<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
https://github.com/WordPress/gutenberg/pull/42076 seems to have caused a regression. This PR removes the extra check for `anchorRefFallback.current`.  I think the early return in the old implementation was because the computation was happening inside a [useLayoutEffect](https://github.com/WordPress/gutenberg/blob/b99e6688fba7037ccee46cb6b7d70917a5f2c418/packages/components/src/popover/index.js#L240) with different dependencies and order.

I think `getAnchorRect` should be called even without a fallback ref as many implementations don't take this into account and return something different.. The below is @ciampo 's comment from the original PR:

> I believe that the reason why this regression hasn't been encountered until now is because it looks like that the few usages of the getAnchorRect don't actually rely on its arguments (a quick search across the codebase should confirm this hypothesis).


#### Regression


https://user-images.githubusercontent.com/16275880/178273628-c2668e74-b6cf-4a74-b99e-dc01d8438def.mov


#### After

https://user-images.githubusercontent.com/16275880/178273645-dc575f6d-6d9e-435c-801c-f00c1a04cf37.mov


