### PR TITLE
Comments block: Remove stray legacy class from edit

### DIFF
--- a/packages/block-library/src/comments/edit.js
+++ b/packages/block-library/src/comments/edit.js
@@ -91,10 +91,7 @@ const TEMPLATE = [
 export default function CommentsEdit( { attributes, setAttributes } ) {
 	const { tagName: TagName } = attributes;
 
-	const blockProps = useBlockProps( {
-		// We add the previous block name for backward compatibility.
-		className: 'wp-block-comments-query-loop',
-	} );
+	const blockProps = useBlockProps();
 	const innerBlocksProps = useInnerBlocksProps( blockProps, {
 		template: TEMPLATE,
 	} );


### PR DESCRIPTION
## What?
Remove an unnecessary `wp-comments-query-loop` class from the Comments block's edit mode. This fixes an oversight from #40506. Discovered here: https://github.com/WordPress/gutenberg/pull/41807#discussion_r917959662

## Why?
The extra class is unnecessary (and potentially confusing):

- Blocks that are _really_ converted from the old `core/comments-query-loop` slug retain the extra class [via the logic in `convert-legacy-blocks.js`](https://github.com/WordPress/gutenberg/blob/b4d23a7e5bc4aa28917415bed70d05462e63d7dc/packages/blocks/src/api/parser/convert-legacy-block.js#L63-L74) as a serialized attribute.
- Blocks that are newly inserted don't have the `wp-comments-query-loop` when serialized -- and shouldn't have it in the editor, either.

## How?
By removing that class 😎 

## Testing Instructions

We want to ascertain that the `wp-comments-query-loop` class is:
1. absent from the editor "block list block wrapper" if the Comments block was newly inserted
2. present if the block was indeed converted from a `core/comments-query-loop` block.

The block list block wrapper looks something like this:

![image](https://user-images.githubusercontent.com/96308/178297262-a95207d0-fdb0-4d67-83f3-092825ee1586.png)

Testing scenario 1. is pretty much trivial: Insert the block (e.g. into the Site Editor's Single post template), locate its "block list block wrapper" in the browser's element inspector, and verify that it doesn't have the `wp-comments-query-loop` class.

To test scenario 2., you can:
- Switch to `trunk`.
- Revert bbd198d (that's the merge commit for #40506) and rebuild Gutenberg.
- Open the Site Editor, edit the Single post template, insert the Comments block there, and save the template.
- Verify in the Code Editor that its ID is `core/comments-query-loop`
- Switch back to the Visual Editor.
- Switch to this PR's branch (`remove/comments-block-edit-stray-legacy-class`).
- Reload the Site Editor.
- Locate the Comments block's "block list block wrapper" in the element inspector, and verify that it now _has_ the `wp-comments-query-loop` class.

(Don't forget to remove the revert commit of bbd198d afterwards! On `trunk` (use with caution!): `git reset --hard HEAD^`)

