### PR TITLE
ScrollLock: Improve Storybook story for Docs view

### DIFF
--- a/packages/components/src/scroll-lock/stories/index.tsx
+++ b/packages/components/src/scroll-lock/stories/index.tsx
@@ -73,7 +73,12 @@ export const Default: ComponentStory< typeof ScrollLock > = () => {
 				} }
 			>
 				<StripedBackground>
-					<div>Start scrolling down...</div>
+					<div>
+						Start scrolling down. Once you scroll to the end of this
+						container with the stripes, the rest of the page will
+						continue scrolling. <code>ScrollLock</code> prevents
+						this &quot;scroll bleed&quot; from happening.
+					</div>
 					<ToggleContainer>
 						<Button variant="primary" onClick={ toggleLock }>
 							Toggle Scroll Lock

--- a/packages/components/src/scroll-lock/stories/index.tsx
+++ b/packages/components/src/scroll-lock/stories/index.tsx
@@ -64,18 +64,28 @@ export const Default: ComponentStory< typeof ScrollLock > = () => {
 	const toggleLock = () => setScrollLocked( ! isScrollLocked );
 
 	return (
-		<StripedBackground>
-			<div>Start scrolling down...</div>
-			<ToggleContainer>
-				<Button variant="primary" onClick={ toggleLock }>
-					Toggle Scroll Lock
-				</Button>
-				{ isScrollLocked && <ScrollLock /> }
-				<p>
-					Scroll locked:{ ' ' }
-					<strong>{ isScrollLocked ? 'Yes' : 'No' }</strong>
-				</p>
-			</ToggleContainer>
-		</StripedBackground>
+		<div style={ { height: 1000 } }>
+			<div
+				style={ {
+					overflow: 'auto',
+					height: 240,
+					border: '1px solid lightgray',
+				} }
+			>
+				<StripedBackground>
+					<div>Start scrolling down...</div>
+					<ToggleContainer>
+						<Button variant="primary" onClick={ toggleLock }>
+							Toggle Scroll Lock
+						</Button>
+						{ isScrollLocked && <ScrollLock /> }
+						<p>
+							Scroll locked:{ ' ' }
+							<strong>{ isScrollLocked ? 'Yes' : 'No' }</strong>
+						</p>
+					</ToggleContainer>
+				</StripedBackground>
+			</div>
+		</div>
 	);
 };


### PR DESCRIPTION
Merge after #42303

## What?

Tweaks the Storybook story for ScrollLock so the point of the component is better demonstrated, especially in Docs view.

## Why?

The point of the ScrollLock component is that it prevents scroll bleed from a modal to the page body. (_Scroll bleed_ in this context is when you're scrolling the inner container, and once you reach the end the scrolling continues on to the parent container.)

To demonstrate this, there needs to be at least two overflowing scrolling containers: the "modal" and the "page body".

## How?

Add some div wrappers to ensure that we have two scrolling containers, nested.

## Testing Instructions

1. `npm run storybook:dev`
2. See the story for ScrollLock. You should be able to experience the scroll bleed, both in Canvas view and Docs view.
