### PR TITLE
Theme.json Documentation - Added new FAQ on disabling caching of theme.json

### DIFF
--- a/docs/how-to-guides/themes/theme-json.md
+++ b/docs/how-to-guides/themes/theme-json.md
@@ -25,6 +25,7 @@ WordPress 5.8 comes with [a new mechanism](https://make.wordpress.org/core/2021/
     - The naming schema of CSS Custom Properties
     - Why using -- as a separator?
     - How settings under "custom" create new CSS Custom Properties
+    - Why does it take so long to update the styles in the browser?
 
 ## Rationale
 
@@ -1200,3 +1201,7 @@ The default value is 2em.
 	}
 }
 ```
+
+### Why does it take so long to update the styles in the browser?
+
+When you are actively developing with theme.json you may notice it takes 30+ seconds for your changes to show up in the browser, this is because `theme.json` is cached. To remove this caching issue, set either [`WP_DEBUG`](https://wordpress.org/support/article/debugging-in-wordpress/#wp_debug) or [`SCRIPT_DEBUG`](https://wordpress.org/support/article/debugging-in-wordpress/#script_debug) to 'true' in your [`wp-config.php`](https://wordpress.org/support/article/editing-wp-config-php/). This tells WordPress to skip the cache and always use fresh data.


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
One of the issues that many devs face when working with theme.json for the first time is waiting for the browser to show their changes. Unfortunately it takes 30+ seconds if you do not have WP_DEBUG or SCRIPT_DEBUG set to true to bypass caching theme.json. 

## Why?
This documentation is to help other developers learning for the first time. Will provide a better developer experience.

## How?
Explains what they need to do to bypass caching of theme.json

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->

## Screenshots or screencast <!-- if applicable -->
I posed this question to twitter and the community has provided a terrific answer that deserves to be included here for future developers to also utilize and hopefully avoid any initial frustrations in the developer experience.

Original Tweet: https://twitter.com/schutzsmith/status/1544365317731880963?s=21&t=nCyZ2sva06NMv_8khBOgdw

Answer 1: https://twitter.com/cometmarie/status/1544411492010835970

Answer 2: https://twitter.com/fklux/status/1545297824794959872
