### PR TITLE
Site Editor: Update template details browse label

### DIFF
--- a/packages/edit-site/src/components/template-details/index.js
+++ b/packages/edit-site/src/components/template-details/index.js
@@ -1,8 +1,7 @@
 /**
  * WordPress dependencies
  */
-import { useMemo } from '@wordpress/element';
-import { sprintf, __ } from '@wordpress/i18n';
+import { __ } from '@wordpress/i18n';
 import {
 	Button,
 	MenuGroup,
@@ -17,10 +16,6 @@ import { store as editorStore } from '@wordpress/editor';
  * Internal dependencies
  */
 import isTemplateRevertable from '../../utils/is-template-revertable';
-import {
-	MENU_TEMPLATES,
-	TEMPLATE_PARTS_SUB_MENUS,
-} from '../navigation-sidebar/navigation-panel/constants';
 import { store as editSiteStore } from '../../store';
 import TemplateAreas from './template-areas';
 import EditTemplateTitle from './edit-template-title';
@@ -33,16 +28,6 @@ export default function TemplateDetails( { template, onClose } ) {
 		[]
 	);
 	const { revertTemplate } = useDispatch( editSiteStore );
-
-	const templateSubMenu = useMemo( () => {
-		if ( template?.type === 'wp_template' ) {
-			return { title: __( 'templates' ), menu: MENU_TEMPLATES };
-		}
-
-		return TEMPLATE_PARTS_SUB_MENUS.find(
-			( { area } ) => area === template?.area
-		);
-	}, [ template ] );
 
 	const browseAllLinkProps = useLink( {
 		// TODO: We should update this to filter by template part's areas as well.
@@ -106,11 +91,9 @@ export default function TemplateDetails( { template, onClose } ) {
 				className="edit-site-template-details__show-all-button"
 				{ ...browseAllLinkProps }
 			>
-				{ sprintf(
-					/* translators: the template part's area name ("Headers", "Sidebars") or "templates". */
-					__( 'Browse all %s' ),
-					templateSubMenu.title
-				) }
+				{ template?.type === 'wp_template'
+					? __( 'Browse all templates' )
+					: __( 'Browse all template parts' ) }
 			</Button>
 		</div>
 	);


### PR DESCRIPTION
## What?
Resolves #41170.

PR update "Browse all" label for template parts in the details dropdown.

## Why?
The area-based filtering was never implemented, so the label was misleading.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

## Testing Instructions
1. Open a template part in the Site Editor.
2. Confirm the new label.

## Screenshots or screencast <!-- if applicable -->
![CleanShot 2022-07-12 at 11 46 13](https://user-images.githubusercontent.com/240569/178438431-a859894b-1031-4061-af61-2aa2a7bcfb26.png)

