### PR TITLE
Fix list view drop indicator positioning

### DIFF
--- a/packages/block-editor/src/components/list-view/drop-indicator.js
+++ b/packages/block-editor/src/components/list-view/drop-indicator.js
@@ -81,7 +81,7 @@ export default function ListViewDropIndicator( {
 			left: rect.left + indent,
 			right: rect.right,
 			width: 0,
-			height: rect.height,
+			height: 0,
 			ownerDocument,
 		};
 


### PR DESCRIPTION
## What?
Fixes #42058

After the recent popover component refactor, drop indicators in List View were misaligned, always seemingly being out by the height of one block.

## Why?
The bug seems to be in the computation of the rectangle used to position the drop indicator. This is called the popover 'anchor' rectangle.

The rectangle should have a zero height because it has `top` and `bottom` values that are always the same. But in `trunk` the rectangle was always given the height of a block in List View (an impossible rectangle).

Before the popover refactor, this incorrect `height` value must have been ignored, but after it seems the height is taken into account.

That explains why the position is alway out by the height of one block.

## How?
Change the height to `0`.

## Testing Instructions
1. Try dragging and dropping blocks in List View.
2. The bug should be fixed.

## Screenshots or screencast <!-- if applicable -->
### Before

https://user-images.githubusercontent.com/677833/178450884-e14c61c4-a9d3-49a5-b66d-0332ec25131f.mp4


### After

https://user-images.githubusercontent.com/677833/178450523-86849097-5772-4ae2-b70a-4bb2806c2352.mp4


