### PR TITLE
Lodash: Remove completely from `jest-console` package

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17426,8 +17426,7 @@
 			"dev": true,
 			"requires": {
 				"@babel/runtime": "^7.16.0",
-				"jest-matcher-utils": "^27.4.2",
-				"lodash": "^4.17.21"
+				"jest-matcher-utils": "^27.4.2"
 			}
 		},
 		"@wordpress/jest-preset-default": {

--- a/packages/jest-console/package.json
+++ b/packages/jest-console/package.json
@@ -33,8 +33,7 @@
 	"types": "types",
 	"dependencies": {
 		"@babel/runtime": "^7.16.0",
-		"jest-matcher-utils": "^27.4.2",
-		"lodash": "^4.17.21"
+		"jest-matcher-utils": "^27.4.2"
 	},
 	"peerDependencies": {
 		"jest": ">=27"

--- a/packages/jest-console/src/index.js
+++ b/packages/jest-console/src/index.js
@@ -1,9 +1,4 @@
 /**
- * External dependencies
- */
-import { forEach } from 'lodash';
-
-/**
  * Internal dependencies
  */
 import './matchers';
@@ -12,10 +7,11 @@ import supportedMatchers from './supported-matchers';
 /**
  * Sets spy on the console object's method to make it possible to fail test when method called without assertion.
  *
- * @param {string} matcherName Name of Jest matcher.
- * @param {string} methodName  Name of console method.
+ * @param {Array}  args
+ * @param {string} args."0" Name of console method.
+ * @param {string} args."1" Name of Jest matcher.
  */
-const setConsoleMethodSpy = ( matcherName, methodName ) => {
+const setConsoleMethodSpy = ( [ methodName, matcherName ] ) => {
 	const spy = jest
 		.spyOn( console, methodName )
 		.mockName( `console.${ methodName }` );
@@ -47,4 +43,4 @@ const setConsoleMethodSpy = ( matcherName, methodName ) => {
 	afterEach( assertExpectedCalls );
 };
 
-forEach( supportedMatchers, setConsoleMethodSpy );
+Object.entries( supportedMatchers ).forEach( setConsoleMethodSpy );

--- a/packages/jest-console/src/matchers.js
+++ b/packages/jest-console/src/matchers.js
@@ -2,7 +2,6 @@
  * External dependencies
  */
 import { matcherHint, printExpected, printReceived } from 'jest-matcher-utils';
-import { isEqual, reduce, some } from 'lodash';
 
 /**
  * Internal dependencies
@@ -33,12 +32,13 @@ const createToHaveBeenCalledMatcher =
 		};
 	};
 
-const createToHaveBeenCalledWith =
-	( matcherName, methodName ) =>
-	( received, ...expected ) => {
+const createToHaveBeenCalledWith = ( matcherName, methodName ) =>
+	function ( received, ...expected ) {
 		const spy = received[ methodName ];
 		const calls = spy.mock.calls;
-		const pass = some( calls, ( objects ) => isEqual( objects, expected ) );
+		const pass = calls.some( ( objects ) =>
+			this.equals( objects, expected )
+		);
 		const message = pass
 			? () =>
 					matcherHint( `.not${ matcherName }`, spy.getMockName() ) +
@@ -63,9 +63,8 @@ const createToHaveBeenCalledWith =
 	};
 
 expect.extend(
-	reduce(
-		supportedMatchers,
-		( result, matcherName, methodName ) => {
+	Object.entries( supportedMatchers ).reduce(
+		( result, [ methodName, matcherName ] ) => {
 			const matcherNameWith = `${ matcherName }With`;
 
 			return {


### PR DESCRIPTION
## What?
This PR removes all Lodash from the `@wordpress/jest-console` package, including the dependency. There are just a few usages and conversion is pretty straightforward. 

## Why?

Lodash is known to unnecessarily inflate the bundle size of packages, and in most cases, it can be replaced with native language functionality. See these for more information and rationale:

* https://github.com/WordPress/gutenberg/issues/16938#issuecomment-602837246
* https://github.com/WordPress/gutenberg/issues/17025
* https://github.com/WordPress/gutenberg/issues/39495 

## How?
We have to deal essentially with 3 simple methods (`forEach`, `reduce`, and `some` ), and migration away from them is pretty straightforward in favor of native functionality. `isEqual` is more interesting to implement, however, we can conveniently use jest's `equals` that is [available in custom matchers](https://jestjs.io/docs/expect#thisequalsa-b).

## Testing Instructions

Verify all tests still pass: `npm run test-unit`

