### PR TITLE
On template creation, don't show search if not needed

### DIFF
--- a/packages/edit-site/src/components/add-new-template/add-custom-template-modal.js
+++ b/packages/edit-site/src/components/add-new-template/add-custom-template-modal.js
@@ -1,7 +1,7 @@
 /**
  * WordPress dependencies
  */
-import { useState, useMemo, useEffect } from '@wordpress/element';
+import { useState, useMemo, useEffect, useRef } from '@wordpress/element';
 import { __, sprintf } from '@wordpress/i18n';
 import {
 	Button,
@@ -145,14 +145,25 @@ function SuggestionList( { entityForSuggestions, onSelect } ) {
 		debouncedSearch
 	);
 	const { labels } = entityForSuggestions;
+	// If there are less suggestions than our initial ones with no `search`(10),
+	// there is no need to show the `SearchControl`. We use a `ref` to track
+	// this because the initial search request is enough to let us decide.
+	const showSearchControl = useRef( false );
+	useEffect( () => {
+		if ( ! showSearchControl.current && suggestions?.length > 9 ) {
+			showSearchControl.current = true;
+		}
+	}, [ suggestions ] );
 	return (
 		<>
-			<SearchControl
-				onChange={ setSearch }
-				value={ search }
-				label={ labels.search_items }
-				placeholder={ labels.search_items }
-			/>
+			{ showSearchControl.current && (
+				<SearchControl
+					onChange={ setSearch }
+					value={ search }
+					label={ labels.search_items }
+					placeholder={ labels.search_items }
+				/>
+			) }
 			{ !! suggestions?.length && (
 				<Composite
 					{ ...composite }

--- a/packages/edit-site/src/components/add-new-template/add-custom-template-modal.js
+++ b/packages/edit-site/src/components/add-new-template/add-custom-template-modal.js
@@ -1,7 +1,7 @@
 /**
  * WordPress dependencies
  */
-import { useState, useMemo, useEffect, useRef } from '@wordpress/element';
+import { useState, useMemo, useEffect } from '@wordpress/element';
 import { __, sprintf } from '@wordpress/i18n';
 import {
 	Button,
@@ -145,18 +145,13 @@ function SuggestionList( { entityForSuggestions, onSelect } ) {
 		debouncedSearch
 	);
 	const { labels } = entityForSuggestions;
-	// If there are less suggestions than our initial ones with no `search`(10),
-	// there is no need to show the `SearchControl`. We use a `ref` to track
-	// this because the initial search request is enough to let us decide.
-	const showSearchControl = useRef( false );
-	useEffect( () => {
-		if ( ! showSearchControl.current && suggestions?.length > 9 ) {
-			showSearchControl.current = true;
-		}
-	}, [ suggestions ] );
+	const [ showSearchControl, setShowSearchControl ] = useState( false );
+	if ( ! showSearchControl && suggestions?.length > 9 ) {
+		setShowSearchControl( true );
+	}
 	return (
 		<>
-			{ showSearchControl.current && (
+			{ showSearchControl && (
 				<SearchControl
 					onChange={ setSearch }
 					value={ search }


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Resolves: https://github.com/WordPress/gutenberg/issues/42337



When creating a template for something like a Category, we should not render a search box if we have less than the initial results we suggest, as they are shown directly. The current number of the initial suggestions are `10`.


#### Before
<img width="634" alt="image" src="https://user-images.githubusercontent.com/548849/178313624-0a31fc46-25c1-4234-a68a-1cb5befb7504.png">
<!-- In a few words, what is the PR actually doing? -->


#### After
<img width="660" alt="Screenshot 2022-07-12 at 12 31 37 PM" src="https://user-images.githubusercontent.com/16275880/178459168-f801a6f3-01f2-453f-a67c-5a81dc69d52c.png">

