### PR TITLE
Fix mismatching label and visible text on the Toggle block inserter button

### DIFF
--- a/packages/edit-post/src/components/header/header-toolbar/index.js
+++ b/packages/edit-post/src/components/header/header-toolbar/index.js
@@ -106,6 +106,14 @@ function HeaderToolbar() {
 			setIsInserterOpened( true );
 		}
 	}, [ isInserterOpened, setIsInserterOpened ] );
+
+	/* translators: button label text should, if possible, be under 16 characters. */
+	const longLabel = _x(
+		'Toggle block inserter',
+		'Generic label for block inserter button'
+	);
+	const shortLabel = ! isInserterOpened ? __( 'Add' ) : __( 'Close' );
+
 	return (
 		<NavigableToolbar
 			className="edit-post-header-toolbar"
@@ -122,17 +130,9 @@ function HeaderToolbar() {
 					onClick={ openInserter }
 					disabled={ ! isInserterEnabled }
 					icon={ plus }
-					/* translators: button label text should, if possible, be under 16
-			characters. */
-					label={ _x(
-						'Toggle block inserter',
-						'Generic label for block inserter button'
-					) }
+					label={ showIconLabels ? shortLabel : longLabel }
 					showTooltip={ ! showIconLabels }
-				>
-					{ showIconLabels &&
-						( ! isInserterOpened ? __( 'Add' ) : __( 'Close' ) ) }
-				</ToolbarItem>
+				/>
 				{ ( isWideViewport || ! showIconLabels ) && (
 					<>
 						{ isLargeViewport && (

--- a/packages/edit-post/src/components/header/header-toolbar/style.scss
+++ b/packages/edit-post/src/components/header/header-toolbar/style.scss
@@ -101,13 +101,10 @@
 	padding: 0;
 
 	.show-icon-labels & {
+		width: auto;
 		height: 36px;
+		padding: 0 $grid-unit-10;
 	}
-}
-
-.edit-post-header-toolbar .edit-post-header-toolbar__left > .edit-post-header-toolbar__inserter-toggle.has-text.has-icon {
-	width: auto;
-	padding: 0 $grid-unit-10;
 }
 
 .show-icon-labels .edit-post-header-toolbar__left > * + * {

--- a/packages/edit-post/src/components/header/style.scss
+++ b/packages/edit-post/src/components/header/style.scss
@@ -146,12 +146,6 @@
 		}
 	}
 
-	// The inserter has a custom label, different from its aria-label, so we don't want to display both.
-	.edit-post-header-toolbar__inserter-toggle.edit-post-header-toolbar__inserter-toggle {
-		&::after {
-			content: none;
-		}
-	}
 	// The post saved state button has a custom label only on small breakpoint
 	.editor-post-save-draft.editor-post-save-draft {
 		&::after {

--- a/packages/edit-site/src/components/header/index.js
+++ b/packages/edit-site/src/components/header/index.js
@@ -106,6 +106,13 @@ export default function Header( {
 
 	const isFocusMode = templateType === 'wp_template_part';
 
+	/* translators: button label text should, if possible, be under 16 characters. */
+	const longLabel = _x(
+		'Toggle block inserter',
+		'Generic label for block inserter button'
+	);
+	const shortLabel = ! isInserterOpen ? __( 'Add' ) : __( 'Close' );
+
 	return (
 		<div className="edit-site-header">
 			<NavigableToolbar
@@ -123,17 +130,9 @@ export default function Header( {
 						onClick={ openInserter }
 						disabled={ ! isVisualMode }
 						icon={ plus }
-						/* translators: button label text should, if possible, be under 16
-				characters. */
-						label={ _x(
-							'Toggle block inserter',
-							'Generic label for block inserter button'
-						) }
+						label={ showIconLabels ? shortLabel : longLabel }
 						showTooltip={ ! showIconLabels }
-					>
-						{ showIconLabels &&
-							( ! isInserterOpen ? __( 'Add' ) : __( 'Close' ) ) }
-					</ToolbarItem>
+					/>
 					{ isLargeViewport && (
 						<>
 							<ToolbarItem

--- a/packages/edit-site/src/components/header/style.scss
+++ b/packages/edit-site/src/components/header/style.scss
@@ -226,15 +226,17 @@ body.is-navigation-sidebar-open {
 		padding-right: 6px;
 	}
 
-	// The inserter and the template details toggle have custom labels, different from their aria-label, so we don't want to display both.
-	.edit-site-header-toolbar__inserter-toggle.edit-site-header-toolbar__inserter-toggle,
+	// The template details toggle has a custom label, different from its aria-label, so we don't want to display both.
 	.edit-site-document-actions__get-info.edit-site-document-actions__get-info.edit-site-document-actions__get-info {
 		&::after {
 			content: none;
 		}
+	}
 
+	.edit-site-header-toolbar__inserter-toggle.edit-site-header-toolbar__inserter-toggle,
+	.edit-site-document-actions__get-info.edit-site-document-actions__get-info.edit-site-document-actions__get-info {
 		height: 36px;
-		padding: 0 6px;
+		padding: 0 $grid-unit-10;
 	}
 
 	.edit-site-header_start .edit-site-header__toolbar > * + * {


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->
Fixes https://github.com/WordPress/gutenberg/issues/42236

## What?
<!-- In a few words, what is the PR actually doing? -->
When the 'Show button text labels' preference is enabled, the visible text and the aria-label of the Toggle block inserter button mismatch. 

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
It's very important that the actual accessible name (in this case the aria-label) matches or at least starts with the visible text. Otherwise, the mismatch will be a barrier for some users e.g.:
- speech recognition software users 
- low vision screen reader users

More details:
WCAG Success Criterion 2.5.3 Label in Name
https://www.w3.org/TR/WCAG21/#label-in-name

Worth reminding one of the main goals of the 'Show button text labels' preference is to visually expose the accessible name of a control for users who need to _see_ the name to use it, for example, with a voice command.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
- Avoids to use visible text that mismatches the aria-label.
- Removes CSS exceptions for the button: the visible text is now CSS generated content based on the aria-label attribute, as for all the other buttons.

## Testing Instructions
- Edit a post.
- Check the 'Toggle block inserter' button (the one with the '+' icon) functionality and styling are unchanged.
- Check the button aria-label is 'Toggle block inserter'.
- Go to Options > Preferences and enable the 'Show button text labels' preference.
- Check the button visible text and aria-label are now 'Add'.
- Activate the button and check the visible text and aria-label are 'Close'.
- Check the button functionality and styling are unchanged.
- Repeat in the Site Editor.

## Screenshots or screencast <!-- if applicable -->
