### PR TITLE
Lodash: Refactor away from `_.flatMap()`

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -93,6 +93,7 @@ module.exports = {
 							'findIndex',
 							'findKey',
 							'findLast',
+							'flatMap',
 							'flatten',
 							'flattenDeep',
 							'fromPairs',

--- a/packages/block-library/src/list/v2/transforms.js
+++ b/packages/block-library/src/list/v2/transforms.js
@@ -1,14 +1,6 @@
 /**
  * WordPress dependencies
  */
-/**
- * External dependencies
- */
-import { flatMap } from 'lodash';
-
-/**
- * WordPress dependencies
- */
 import { createBlock } from '@wordpress/blocks';
 import { create, split, toHTMLString } from '@wordpress/rich-text';
 
@@ -39,7 +31,7 @@ function getListContentSchema( { phrasingContentSchema } ) {
 }
 
 function getListContentFlat( blocks ) {
-	return flatMap( blocks, ( { name, attributes, innerBlocks = [] } ) => {
+	return blocks.flatMap( ( { name, attributes, innerBlocks = [] } ) => {
 		if ( name === 'core/list-item' ) {
 			return [ attributes.content, ...getListContentFlat( innerBlocks ) ];
 		}

--- a/tools/webpack/packages.js
+++ b/tools/webpack/packages.js
@@ -3,7 +3,6 @@
  */
 const CopyWebpackPlugin = require( 'copy-webpack-plugin' );
 const { join } = require( 'path' );
-const { flatMap } = require( 'lodash' );
 
 /**
  * WordPress dependencies
@@ -105,9 +104,8 @@ const vendors = {
 		'react-dom/umd/react-dom.production.min.js',
 	],
 };
-const vendorsCopyConfig = flatMap(
-	vendors,
-	( [ devFilename, prodFilename ], key ) => {
+const vendorsCopyConfig = Object.entries( vendors ).flatMap(
+	( [ key, [ devFilename, prodFilename ] ] ) => {
 		return [
 			{
 				from: `node_modules/${ devFilename }`,


### PR DESCRIPTION
## What?
This PR removes the `_.flatMap()` usage completely and deprecates the function. 

## Why?

Lodash is known to unnecessarily inflate the bundle size of packages, and in most cases, it can be replaced with native language functionality. See these for more information and rationale:

* https://github.com/WordPress/gutenberg/issues/16938#issuecomment-602837246
* https://github.com/WordPress/gutenberg/issues/17025
* https://github.com/WordPress/gutenberg/issues/39495 

## How?

We're replacing it with the native `Array.prototype.flatMap()`.

## Testing Instructions
* Verify Gutenberg still builds and emits the `react` and `react-dom` bundles in `build/vendors/*`
* Go through test instructions of #41741 and verify they still work correctly.