### PR TITLE
Playwright: fix relative URLs

### DIFF
--- a/docs/contributors/code/getting-started-with-code-contribution.md
+++ b/docs/contributors/code/getting-started-with-code-contribution.md
@@ -144,7 +144,7 @@ ln -s gutenberg/packages/e2e-tests/plugins/* .
 You'll need to run this again if new plugins are added. To run e2e tests:
 
 ```bash
-WP_BASE_URL=http://localhost:8888/gutenberg npm run test-e2e
+WP_BASE_URL=http://localhost:8888/gutenberg/ npm run test-e2e
 ```
 
 #### Caching of PHP files

--- a/packages/e2e-test-utils-playwright/src/request-utils/login.ts
+++ b/packages/e2e-test-utils-playwright/src/request-utils/login.ts
@@ -10,7 +10,7 @@ export interface User {
 
 async function login( this: RequestUtils, user: User = this.user ) {
 	// Login to admin using request context.
-	let response = await this.request.post( '/wp-login.php', {
+	let response = await this.request.post( 'wp-login.php', {
 		failOnStatusCode: true,
 		form: {
 			log: user.username,
@@ -21,7 +21,7 @@ async function login( this: RequestUtils, user: User = this.user ) {
 
 	// Get the nonce.
 	response = await this.request.get(
-		'/wp-admin/admin-ajax.php?action=rest-nonce',
+		'wp-admin/admin-ajax.php?action=rest-nonce',
 		{
 			failOnStatusCode: true,
 		}


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?

The relative URLs for login should be without a starting slash so base URLs with a subfolder work correctly.
See https://playwright.dev/docs/api/class-testoptions#test-options-base-url.
See #38570.

## Why?

My tests won't run locally otherwise with MAMP.

## How?

## Testing Instructions

If you're using MAMP, `WP_BASE_URL=http://localhost:8888/gutenberg/ npm run test-e2e` should now work correctly.

## Screenshots or screencast <!-- if applicable -->
