### PR TITLE
Use the Style Engine in layout block-supports

### DIFF
--- a/lib/block-supports/layout.php
+++ b/lib/block-supports/layout.php
@@ -44,7 +44,7 @@ function gutenberg_get_layout_style( $selector, $layout, $has_block_gap_support 
 	// Use a unique store to avoid conflicts with other stores and implementations.
 	$store     = WP_Style_Engine_CSS_Rules_Store_Gutenberg::get_store( 'block-supports/layout/' . md5( $selector ) );
 	$processor = new WP_Style_Engine_Processor_Gutenberg( $store );
-	return $processor->get_css();
+	return $processor->get_css( true );
 }
 
 /**

--- a/lib/block-supports/layout.php
+++ b/lib/block-supports/layout.php
@@ -132,7 +132,6 @@ function gutenberg_get_layout_style( $selector, $layout, $has_block_gap_support 
 				$gap_value  = $gap_row === $gap_column ? $gap_row : $gap_row . ' ' . $gap_column;
 			}
 			if ( $gap_value && ! $should_skip_gap_serialization ) {
-				$declarations[ $selector ]        = isset( $declarations[ $selector ] ) ? $declarations[ $selector ] : array();
 				$declarations[ $selector ]['gap'] = $gap_value;
 			}
 		}

--- a/lib/block-supports/layout.php
+++ b/lib/block-supports/layout.php
@@ -122,7 +122,7 @@ function gutenberg_get_layout_style( $selector, $layout, $has_block_gap_support 
 		}
 
 		if ( ! empty( $layout['flexWrap'] ) && 'nowrap' === $layout['flexWrap'] ) {
-			$declarations[ $selector ] = array( 'flex-wrap' => 'nowrap' );
+			$declarations[ $selector ]['flex-wrap'] = 'nowrap';
 		}
 
 		if ( $has_block_gap_support ) {

--- a/lib/block-supports/layout.php
+++ b/lib/block-supports/layout.php
@@ -41,7 +41,9 @@ function gutenberg_register_layout_support( $block_type ) {
 function gutenberg_get_layout_style( $selector, $layout, $has_block_gap_support = false, $gap_value = null, $should_skip_gap_serialization = false, $fallback_gap_value = '0.5em', $block_spacing = null ) {
 	$layout_type = isset( $layout['type'] ) ? $layout['type'] : 'default';
 
+	// An array of CSS declarations (selector => [ property => value ] pairs).
 	$declarations = array( $selector => array() );
+
 	if ( 'default' === $layout_type ) {
 		$content_size = isset( $layout['contentSize'] ) ? $layout['contentSize'] : '';
 		$wide_size    = isset( $layout['wideSize'] ) ? $layout['wideSize'] : '';

--- a/lib/block-supports/layout.php
+++ b/lib/block-supports/layout.php
@@ -57,7 +57,7 @@ function gutenberg_get_layout_style( $selector, $layout, $has_block_gap_support 
 		$wide_max_width_value = wp_strip_all_tags( explode( ';', $wide_max_width_value )[0] );
 
 		if ( $content_size || $wide_size ) {
-			$store->add_rule( "$selector > :where(:not(.alignleft):not(.alignright):not(.alignfull))" )->set_declarations(
+			$store->add_rule( "$selector > :where(:not(.alignleft):not(.alignright):not(.alignfull))" )->add_declarations(
 				array(
 					'max-width'    => $all_max_width_value,
 					'margin-left'  => 'auto !important',
@@ -65,8 +65,8 @@ function gutenberg_get_layout_style( $selector, $layout, $has_block_gap_support 
 				)
 			);
 
-			$store->add_rule( "$selector > .alignwide" )->set_declarations( array( 'max-width' => $wide_max_width_value ) );
-			$store->add_rule( "$selector .alignfull" )->set_declarations( array( 'max-width' => 'none' ) );
+			$store->add_rule( "$selector > .alignwide" )->add_declarations( array( 'max-width' => $wide_max_width_value ) );
+			$store->add_rule( "$selector .alignfull" )->add_declarations( array( 'max-width' => 'none' ) );
 
 			if ( isset( $block_spacing ) ) {
 				$block_spacing_values = gutenberg_style_engine_get_block_supports_styles(
@@ -79,11 +79,11 @@ function gutenberg_get_layout_style( $selector, $layout, $has_block_gap_support 
 				// They're added separately because padding might only be set on one side.
 				if ( isset( $block_spacing_values['declarations']['padding-right'] ) ) {
 					$padding_right = $block_spacing_values['declarations']['padding-right'];
-					$store->add_rule( "$selector > .alignfull" )->set_declarations( array( 'margin-right' => "calc($padding_right * -1)" ) );
+					$store->add_rule( "$selector > .alignfull" )->add_declarations( array( 'margin-right' => "calc($padding_right * -1)" ) );
 				}
 				if ( isset( $block_spacing_values['declarations']['padding-left'] ) ) {
 					$padding_left = $block_spacing_values['declarations']['padding-left'];
-					$store->add_rule( "$selector > .alignfull" )->set_declarations( array( 'margin-left' => "calc($padding_left * -1)" ) );
+					$store->add_rule( "$selector > .alignfull" )->add_declarations( array( 'margin-left' => "calc($padding_left * -1)" ) );
 				}
 			}
 		}
@@ -93,13 +93,13 @@ function gutenberg_get_layout_style( $selector, $layout, $has_block_gap_support 
 				$gap_value = isset( $gap_value['top'] ) ? $gap_value['top'] : null;
 			}
 			if ( $gap_value && ! $should_skip_gap_serialization ) {
-				$store->add_rule( "$selector > *" )->set_declarations(
+				$store->add_rule( "$selector > *" )->add_declarations(
 					array(
 						'margin-block-start' => '0',
 						'margin-block-end'   => '0',
 					)
 				);
-				$store->add_rule( "$selector > * + *" )->set_declarations(
+				$store->add_rule( "$selector > * + *" )->add_declarations(
 					array(
 						'margin-block-start' => $gap_value,
 						'margin-block-end'   => '0',
@@ -127,7 +127,7 @@ function gutenberg_get_layout_style( $selector, $layout, $has_block_gap_support 
 		}
 
 		if ( ! empty( $layout['flexWrap'] ) && 'nowrap' === $layout['flexWrap'] ) {
-			$store->add_rule( $selector )->set_declarations( array( 'flex-wrap' => 'nowrap' ) );
+			$store->add_rule( $selector )->add_declarations( array( 'flex-wrap' => 'nowrap' ) );
 		}
 
 		if ( $has_block_gap_support ) {
@@ -137,7 +137,7 @@ function gutenberg_get_layout_style( $selector, $layout, $has_block_gap_support 
 				$gap_value  = $gap_row === $gap_column ? $gap_row : $gap_row . ' ' . $gap_column;
 			}
 			if ( $gap_value && ! $should_skip_gap_serialization ) {
-				$store->add_rule( $selector )->set_declarations( array( 'gap' => $gap_value ) );
+				$store->add_rule( $selector )->add_declarations( array( 'gap' => $gap_value ) );
 			}
 		}
 
@@ -148,21 +148,21 @@ function gutenberg_get_layout_style( $selector, $layout, $has_block_gap_support 
 			 * by custom css.
 			 */
 			if ( ! empty( $layout['justifyContent'] ) && array_key_exists( $layout['justifyContent'], $justify_content_options ) ) {
-				$store->add_rule( $selector )->set_declarations( array( 'justify-content' => $justify_content_options[ $layout['justifyContent'] ] ) );
+				$store->add_rule( $selector )->add_declarations( array( 'justify-content' => $justify_content_options[ $layout['justifyContent'] ] ) );
 			}
 
 			if ( ! empty( $layout['verticalAlignment'] ) && array_key_exists( $layout['verticalAlignment'], $vertical_alignment_options ) ) {
-				$store->add_rule( $selector )->set_declarations( array( 'align-items' => $vertical_alignment_options[ $layout['verticalAlignment'] ] ) );
+				$store->add_rule( $selector )->add_declarations( array( 'align-items' => $vertical_alignment_options[ $layout['verticalAlignment'] ] ) );
 			}
 		} else {
-			$store->add_rule( $selector )->set_declarations(
+			$store->add_rule( $selector )->add_declarations(
 				array(
 					'flex-direction' => 'column',
 					'align-items'    => 'flex-start',
 				)
 			);
 			if ( ! empty( $layout['justifyContent'] ) && array_key_exists( $layout['justifyContent'], $justify_content_options ) ) {
-				$store->add_rule( $selector )->set_declarations( array( 'align-items' => $justify_content_options[ $layout['justifyContent'] ] ) );
+				$store->add_rule( $selector )->add_declarations( array( 'align-items' => $justify_content_options[ $layout['justifyContent'] ] ) );
 			}
 		}
 	}

--- a/lib/block-supports/layout.php
+++ b/lib/block-supports/layout.php
@@ -41,7 +41,7 @@ function gutenberg_register_layout_support( $block_type ) {
 function gutenberg_get_layout_style( $selector, $layout, $has_block_gap_support = false, $gap_value = null, $should_skip_gap_serialization = false, $fallback_gap_value = '0.5em', $block_spacing = null ) {
 	$layout_type = isset( $layout['type'] ) ? $layout['type'] : 'default';
 
-	$style = '';
+	$declarations = array( $selector => array() );
 	if ( 'default' === $layout_type ) {
 		$content_size = isset( $layout['contentSize'] ) ? $layout['contentSize'] : '';
 		$wide_size    = isset( $layout['wideSize'] ) ? $layout['wideSize'] : '';
@@ -55,14 +55,14 @@ function gutenberg_get_layout_style( $selector, $layout, $has_block_gap_support 
 		$wide_max_width_value = wp_strip_all_tags( explode( ';', $wide_max_width_value )[0] );
 
 		if ( $content_size || $wide_size ) {
-			$style  = "$selector > :where(:not(.alignleft):not(.alignright):not(.alignfull)) {";
-			$style .= 'max-width: ' . esc_html( $all_max_width_value ) . ';';
-			$style .= 'margin-left: auto !important;';
-			$style .= 'margin-right: auto !important;';
-			$style .= '}';
+			$declarations[ "$selector > :where(:not(.alignleft):not(.alignright):not(.alignfull))" ] = array(
+				'max-width'    => $all_max_width_value,
+				'margin-left'  => 'auto !important',
+				'margin-right' => 'auto !important',
+			);
 
-			$style .= "$selector > .alignwide { max-width: " . esc_html( $wide_max_width_value ) . ';}';
-			$style .= "$selector .alignfull { max-width: none; }";
+			$declarations[ "$selector > .alignwide" ] = array( 'max-width' => $wide_max_width_value );
+			$declarations[ "$selector .alignfull" ]   = array( 'max-width' => 'none' );
 
 			if ( isset( $block_spacing ) ) {
 				$block_spacing_values = gutenberg_style_engine_get_block_supports_styles(
@@ -73,13 +73,14 @@ function gutenberg_get_layout_style( $selector, $layout, $has_block_gap_support 
 
 				// Handle negative margins for alignfull children of blocks with custom padding set.
 				// They're added separately because padding might only be set on one side.
+				$declarations[ "$selector > .alignfull" ] = array();
 				if ( isset( $block_spacing_values['declarations']['padding-right'] ) ) {
 					$padding_right = $block_spacing_values['declarations']['padding-right'];
-					$style        .= "$selector > .alignfull { margin-right:calc($padding_right * -1); }";
+					$declarations[ "$selector > .alignfull" ]['margin-right'] = "calc($padding_right * -1)";
 				}
 				if ( isset( $block_spacing_values['declarations']['padding-left'] ) ) {
 					$padding_left = $block_spacing_values['declarations']['padding-left'];
-					$style       .= "$selector > .alignfull { margin-left: calc($padding_left * -1); }";
+					$declarations[ "$selector > .alignfull" ]['margin-left'] = "calc($padding_left * -1)";
 				}
 			}
 		}
@@ -89,8 +90,14 @@ function gutenberg_get_layout_style( $selector, $layout, $has_block_gap_support 
 				$gap_value = isset( $gap_value['top'] ) ? $gap_value['top'] : null;
 			}
 			if ( $gap_value && ! $should_skip_gap_serialization ) {
-				$style .= "$selector > * { margin-block-start: 0; margin-block-end: 0; }";
-				$style .= "$selector > * + * { margin-block-start: $gap_value; margin-block-end: 0; }";
+				$declarations[ "$selector > *" ]     = array(
+					'margin-block-start' => '0',
+					'margin-block-end'   => '0',
+				);
+				$declarations[ "$selector > * + *" ] = array(
+					'margin-block-start' => $gap_value,
+					'margin-block-end'   => '0',
+				);
 			}
 		}
 	} elseif ( 'flex' === $layout_type ) {
@@ -113,7 +120,7 @@ function gutenberg_get_layout_style( $selector, $layout, $has_block_gap_support 
 		}
 
 		if ( ! empty( $layout['flexWrap'] ) && 'nowrap' === $layout['flexWrap'] ) {
-			$style .= "$selector { flex-wrap: nowrap; }";
+			$declarations[ $selector ] = array( 'flex-wrap' => 'nowrap' );
 		}
 
 		if ( $has_block_gap_support ) {
@@ -123,9 +130,8 @@ function gutenberg_get_layout_style( $selector, $layout, $has_block_gap_support 
 				$gap_value  = $gap_row === $gap_column ? $gap_row : $gap_row . ' ' . $gap_column;
 			}
 			if ( $gap_value && ! $should_skip_gap_serialization ) {
-				$style .= "$selector {";
-				$style .= "gap: $gap_value;";
-				$style .= '}';
+				$declarations[ $selector ]        = isset( $declarations[ $selector ] ) ? $declarations[ $selector ] : array();
+				$declarations[ $selector ]['gap'] = $gap_value;
 			}
 		}
 
@@ -136,28 +142,30 @@ function gutenberg_get_layout_style( $selector, $layout, $has_block_gap_support 
 			 * by custom css.
 			 */
 			if ( ! empty( $layout['justifyContent'] ) && array_key_exists( $layout['justifyContent'], $justify_content_options ) ) {
-				$style .= "$selector {";
-				$style .= "justify-content: {$justify_content_options[ $layout['justifyContent'] ]};";
-				$style .= '}';
+				$declarations[ $selector ]['justify-content'] = $justify_content_options[ $layout['justifyContent'] ];
 			}
 
 			if ( ! empty( $layout['verticalAlignment'] ) && array_key_exists( $layout['verticalAlignment'], $vertical_alignment_options ) ) {
-				$style .= "$selector {";
-				$style .= "align-items: {$vertical_alignment_options[ $layout['verticalAlignment'] ]};";
-				$style .= '}';
+				$declarations[ $selector ]['align-items'] = $vertical_alignment_options[ $layout['verticalAlignment'] ];
 			}
 		} else {
-			$style .= "$selector {";
-			$style .= 'flex-direction: column;';
+			$declarations[ $selector ]['flex-direction'] = 'column';
+			$declarations[ $selector ]['align-items']    = 'flex-start';
 			if ( ! empty( $layout['justifyContent'] ) && array_key_exists( $layout['justifyContent'], $justify_content_options ) ) {
-				$style .= "align-items: {$justify_content_options[ $layout['justifyContent'] ]};";
-			} else {
-				$style .= 'align-items: flex-start;';
+				$declarations[ $selector ]['align-items'] = $justify_content_options[ $layout['justifyContent'] ];
 			}
-			$style .= '}';
 		}
 	}
 
+	$style = '';
+	foreach ( $declarations as $css_selector => $item_declarations ) {
+		if ( empty( $item_declarations ) ) {
+			continue;
+		}
+		$declarations_obj = new WP_Style_Engine_CSS_Declarations_Gutenberg( $item_declarations );
+		$css              = $declarations_obj->get_declarations_string();
+		$style           .= $css_selector . '{' . $css . '}';
+	}
 	return $style;
 }
 

--- a/lib/block-supports/layout.php
+++ b/lib/block-supports/layout.php
@@ -41,8 +41,8 @@ function gutenberg_register_layout_support( $block_type ) {
 function gutenberg_get_layout_style( $selector, $layout, $has_block_gap_support = false, $gap_value = null, $should_skip_gap_serialization = false, $fallback_gap_value = '0.5em', $block_spacing = null ) {
 	$layout_type = isset( $layout['type'] ) ? $layout['type'] : 'default';
 
-	// An array of CSS declarations (selector => [ property => value ] pairs).
-	$declarations = array( $selector => array() );
+	// Get the block-supports Style-Engine Store.
+	$store = WP_Style_Engine_CSS_Rules_Store_Gutenberg::get_store( 'block-supports' );
 
 	if ( 'default' === $layout_type ) {
 		$content_size = isset( $layout['contentSize'] ) ? $layout['contentSize'] : '';
@@ -57,14 +57,16 @@ function gutenberg_get_layout_style( $selector, $layout, $has_block_gap_support 
 		$wide_max_width_value = wp_strip_all_tags( explode( ';', $wide_max_width_value )[0] );
 
 		if ( $content_size || $wide_size ) {
-			$declarations[ "$selector > :where(:not(.alignleft):not(.alignright):not(.alignfull))" ] = array(
-				'max-width'    => $all_max_width_value,
-				'margin-left'  => 'auto !important',
-				'margin-right' => 'auto !important',
+			$store->add_rule( "$selector > :where(:not(.alignleft):not(.alignright):not(.alignfull))" )->set_declarations(
+				array(
+					'max-width'    => $all_max_width_value,
+					'margin-left'  => 'auto !important',
+					'margin-right' => 'auto !important',
+				)
 			);
 
-			$declarations[ "$selector > .alignwide" ] = array( 'max-width' => $wide_max_width_value );
-			$declarations[ "$selector .alignfull" ]   = array( 'max-width' => 'none' );
+			$store->add_rule( "$selector > .alignwide" )->set_declarations( array( 'max-width' => $wide_max_width_value ) );
+			$store->add_rule( "$selector .alignfull" )->set_declarations( array( 'max-width' => 'none' ) );
 
 			if ( isset( $block_spacing ) ) {
 				$block_spacing_values = gutenberg_style_engine_get_block_supports_styles(
@@ -75,14 +77,13 @@ function gutenberg_get_layout_style( $selector, $layout, $has_block_gap_support 
 
 				// Handle negative margins for alignfull children of blocks with custom padding set.
 				// They're added separately because padding might only be set on one side.
-				$declarations[ "$selector > .alignfull" ] = array();
 				if ( isset( $block_spacing_values['declarations']['padding-right'] ) ) {
 					$padding_right = $block_spacing_values['declarations']['padding-right'];
-					$declarations[ "$selector > .alignfull" ]['margin-right'] = "calc($padding_right * -1)";
+					$store->add_rule( "$selector > .alignfull" )->set_declarations( array( 'margin-right' => "calc($padding_right * -1)" ) );
 				}
 				if ( isset( $block_spacing_values['declarations']['padding-left'] ) ) {
 					$padding_left = $block_spacing_values['declarations']['padding-left'];
-					$declarations[ "$selector > .alignfull" ]['margin-left'] = "calc($padding_left * -1)";
+					$store->add_rule( "$selector > .alignfull" )->set_declarations( array( 'margin-left' => "calc($padding_left * -1)" ) );
 				}
 			}
 		}
@@ -92,13 +93,17 @@ function gutenberg_get_layout_style( $selector, $layout, $has_block_gap_support 
 				$gap_value = isset( $gap_value['top'] ) ? $gap_value['top'] : null;
 			}
 			if ( $gap_value && ! $should_skip_gap_serialization ) {
-				$declarations[ "$selector > *" ]     = array(
-					'margin-block-start' => '0',
-					'margin-block-end'   => '0',
+				$store->add_rule( "$selector > *" )->set_declarations(
+					array(
+						'margin-block-start' => '0',
+						'margin-block-end'   => '0',
+					)
 				);
-				$declarations[ "$selector > * + *" ] = array(
-					'margin-block-start' => $gap_value,
-					'margin-block-end'   => '0',
+				$store->add_rule( "$selector > * + *" )->set_declarations(
+					array(
+						'margin-block-start' => $gap_value,
+						'margin-block-end'   => '0',
+					)
 				);
 			}
 		}
@@ -122,7 +127,7 @@ function gutenberg_get_layout_style( $selector, $layout, $has_block_gap_support 
 		}
 
 		if ( ! empty( $layout['flexWrap'] ) && 'nowrap' === $layout['flexWrap'] ) {
-			$declarations[ $selector ]['flex-wrap'] = 'nowrap';
+			$store->add_rule( $selector )->set_declarations( array( 'flex-wrap' => 'nowrap' ) );
 		}
 
 		if ( $has_block_gap_support ) {
@@ -132,7 +137,7 @@ function gutenberg_get_layout_style( $selector, $layout, $has_block_gap_support 
 				$gap_value  = $gap_row === $gap_column ? $gap_row : $gap_row . ' ' . $gap_column;
 			}
 			if ( $gap_value && ! $should_skip_gap_serialization ) {
-				$declarations[ $selector ]['gap'] = $gap_value;
+				$store->add_rule( $selector )->set_declarations( array( 'gap' => $gap_value ) );
 			}
 		}
 
@@ -143,30 +148,31 @@ function gutenberg_get_layout_style( $selector, $layout, $has_block_gap_support 
 			 * by custom css.
 			 */
 			if ( ! empty( $layout['justifyContent'] ) && array_key_exists( $layout['justifyContent'], $justify_content_options ) ) {
-				$declarations[ $selector ]['justify-content'] = $justify_content_options[ $layout['justifyContent'] ];
+				$store->add_rule( $selector )->set_declarations( array( 'justify-content' => $justify_content_options[ $layout['justifyContent'] ] ) );
 			}
 
 			if ( ! empty( $layout['verticalAlignment'] ) && array_key_exists( $layout['verticalAlignment'], $vertical_alignment_options ) ) {
-				$declarations[ $selector ]['align-items'] = $vertical_alignment_options[ $layout['verticalAlignment'] ];
+				$store->add_rule( $selector )->set_declarations( array( 'align-items' => $vertical_alignment_options[ $layout['verticalAlignment'] ] ) );
 			}
 		} else {
-			$declarations[ $selector ]['flex-direction'] = 'column';
-			$declarations[ $selector ]['align-items']    = 'flex-start';
+			$store->add_rule( $selector )->set_declarations(
+				array(
+					'flex-direction' => 'column',
+					'align-items'    => 'flex-start',
+				)
+			);
 			if ( ! empty( $layout['justifyContent'] ) && array_key_exists( $layout['justifyContent'], $justify_content_options ) ) {
-				$declarations[ $selector ]['align-items'] = $justify_content_options[ $layout['justifyContent'] ];
+				$store->add_rule( $selector )->set_declarations( array( 'align-items' => $justify_content_options[ $layout['justifyContent'] ] ) );
 			}
 		}
 	}
 
 	$style = '';
-	foreach ( $declarations as $css_selector => $item_declarations ) {
-		if ( empty( $item_declarations ) ) {
-			continue;
-		}
-		$declarations_obj = new WP_Style_Engine_CSS_Declarations_Gutenberg( $item_declarations );
-		$css              = $declarations_obj->get_declarations_string();
-		$style           .= $css_selector . '{' . $css . '}';
+	$rules = $store->get_all_rules();
+	foreach ( $rules as $rule ) {
+		$style .= $rule->get_css();
 	}
+
 	return $style;
 }
 

--- a/lib/compat/wordpress-6.1/script-loader.php
+++ b/lib/compat/wordpress-6.1/script-loader.php
@@ -52,7 +52,7 @@ function gutenberg_enqueue_style_engine_store( $store_name ) {
 		static function () use ( $store_name ) {
 			$store     = WP_Style_Engine_CSS_Rules_Store_Gutenberg::get_store( $store_name );
 			$processor = new WP_Style_Engine_Processor_Gutenberg( $store );
-			$css       = $processor->get_css();
+			$css       = $processor->get_css( true );
 			if ( $css ) {
 				echo '<style id="wp-style-engine-' . esc_attr( str_replace( '/', '-', $store_name ) ) . '">' . $css . '</style>';
 			}

--- a/lib/compat/wordpress-6.1/script-loader.php
+++ b/lib/compat/wordpress-6.1/script-loader.php
@@ -23,10 +23,7 @@
  * @param int    $priority To set the priority for the add_action.
  */
 function gutenberg_enqueue_block_support_styles( $style, $priority = 10 ) {
-	$action_hook_name = 'wp_footer';
-	if ( wp_is_block_theme() ) {
-		$action_hook_name = 'wp_head';
-	}
+	$action_hook_name = wp_is_block_theme() ? 'wp_head' : 'wp_footer';
 	add_action(
 		$action_hook_name,
 		static function () use ( $style ) {
@@ -43,16 +40,13 @@ function gutenberg_enqueue_block_support_styles( $style, $priority = 10 ) {
  * @param string $store_name The name of the store.
  */
 function gutenberg_enqueue_style_engine_store( $store_name ) {
-	$action_hook_name = 'wp_footer';
-	if ( wp_is_block_theme() ) {
-		$action_hook_name = 'wp_head';
-	}
+	$action_hook_name = wp_is_block_theme() ? 'wp_head' : 'wp_footer';
 	add_action(
 		$action_hook_name,
 		static function () use ( $store_name ) {
-			$store     = WP_Style_Engine_CSS_Rules_Store_Gutenberg::get_store( $store_name );
-			$processor = new WP_Style_Engine_Processor_Gutenberg( $store );
-			$css       = $processor->get_css( true );
+			$css = ( new WP_Style_Engine_Processor_Gutenberg(
+				WP_Style_Engine_CSS_Rules_Store_Gutenberg::get_store( $store_name )
+			) )->get_css( true );
 			if ( $css ) {
 				echo '<style id="wp-style-engine-' . esc_attr( str_replace( '/', '-', $store_name ) ) . '">' . $css . '</style>';
 			}

--- a/lib/compat/wordpress-6.1/script-loader.php
+++ b/lib/compat/wordpress-6.1/script-loader.php
@@ -37,6 +37,30 @@ function gutenberg_enqueue_block_support_styles( $style, $priority = 10 ) {
 }
 
 /**
+ * This function takes care of adding inline styles
+ * from a Style-Engine store.
+ *
+ * @param string $store_name The name of the store.
+ */
+function gutenberg_enqueue_style_engine_store( $store_name ) {
+	$action_hook_name = 'wp_footer';
+	if ( wp_is_block_theme() ) {
+		$action_hook_name = 'wp_head';
+	}
+	add_action(
+		$action_hook_name,
+		static function () use ( $store_name ) {
+			$store     = WP_Style_Engine_CSS_Rules_Store_Gutenberg::get_store( $store_name );
+			$processor = new WP_Style_Engine_Processor_Gutenberg( $store );
+			$css       = $processor->get_css();
+			if ( $css ) {
+				echo '<style id="wp-style-engine-' . esc_attr( str_replace( '/', '-', $store_name ) ) . '">' . $css . '</style>';
+			}
+		}
+	);
+}
+
+/**
  * This applies a filter to the list of style nodes that comes from `get_style_nodes` in WP_Theme_JSON.
  * This particular filter removes all of the blocks from the array.
  *

--- a/packages/style-engine/class-wp-style-engine-processor.php
+++ b/packages/style-engine/class-wp-style-engine-processor.php
@@ -37,9 +37,11 @@ class WP_Style_Engine_Processor {
 	/**
 	 * Get the CSS rules as a string.
 	 *
+	 * @param bool $remove_printed_rules Whether to remove printed rules.
+	 *
 	 * @return string The computed CSS.
 	 */
-	public function get_css() {
+	public function get_css( $remove_printed_rules = false ) {
 		// Combine CSS selectors that have identical declarations.
 		$this->combine_rules_selectors();
 
@@ -49,8 +51,10 @@ class WP_Style_Engine_Processor {
 		foreach ( $rules as $rule ) {
 			// Add the CSS.
 			$css .= $rule->get_css();
-			// Remove the rule from the store to avoid double-rendering.
-			$this->store->remove_rule( $rule->get_selector() );
+			if ( $remove_printed_rules ) {
+				// Remove the rule from the store to avoid double-rendering.
+				$this->store->remove_rule( $rule->get_selector() );
+			}
 		}
 		return $css;
 	}

--- a/packages/style-engine/class-wp-style-engine-processor.php
+++ b/packages/style-engine/class-wp-style-engine-processor.php
@@ -47,7 +47,10 @@ class WP_Style_Engine_Processor {
 		$css   = '';
 		$rules = $this->store->get_all_rules();
 		foreach ( $rules as $rule ) {
+			// Add the CSS.
 			$css .= $rule->get_css();
+			// Remove the rule from the store to avoid double-rendering.
+			$this->store->remove_rule( $rule->get_selector() );
 		}
 		return $css;
 	}


### PR DESCRIPTION
## What?
https://github.com/WordPress/gutenberg/pull/40875 refactored the `layout.php` block-supports to be more efficient. In https://github.com/WordPress/gutenberg/pull/42043 we introduced a `WP_Style_Engine_CSS_Declarations` object, so this PR makes use of the declarations object in the refactored layout file.

## Why?
Use the Style Engine where appropriate.

## How?
Use an array of selectors along with their declarations, then compile that to get the final string.

## Testing Instructions
Load a page in the twentytwentytwo theme (or any other block theme) and check that the layout styles are there. Should be pretty easy to check, if the styles are missing the layout is broken 😆 
