### PR TITLE
Remove top margin on the first paragraph in a modal

### DIFF
--- a/packages/block-editor/src/components/block-lock/modal.js
+++ b/packages/block-editor/src/components/block-lock/modal.js
@@ -66,6 +66,11 @@ export default function BlockLockModal( { clientId, onClose } ) {
 			closeLabel={ __( 'Close' ) }
 			onRequestClose={ onClose }
 		>
+			<p>
+				{ __(
+					'Choose specific attributes to restrict or lock all available options.'
+				) }
+			</p>
 			<form
 				onSubmit={ ( event ) => {
 					event.preventDefault();
@@ -73,11 +78,6 @@ export default function BlockLockModal( { clientId, onClose } ) {
 					onClose();
 				} }
 			>
-				<p>
-					{ __(
-						'Choose specific attributes to restrict or lock all available options.'
-					) }
-				</p>
 				<div
 					role="group"
 					aria-labelledby={ instanceId }

--- a/packages/components/src/modal/style.scss
+++ b/packages/components/src/modal/style.scss
@@ -95,6 +95,10 @@
 	.components-modal__content.has-scrolled-content:not(.hide-header) & {
 		border-bottom-color: $gray-300;
 	}
+
+	& + p {
+		margin-top: 0;
+	}
 }
 
 .components-modal__header-heading-container {


### PR DESCRIPTION
## What?
This PR removes the top margin when a paragraph immediately follows `.components-modal__header`.

## Why?
Because the top margin is creating a too-large space between the modal header and the modal content:

<img width="533" alt="Screenshot 2022-07-12 at 13 58 06" src="https://user-images.githubusercontent.com/846565/178496241-ff3832bb-459b-4a87-a206-1ccff3a45c0d.png">

## How?
Just a small CSS tweak:

```
.components-modal__header + p { 
margin-top: 0; 
}

```
## Testing Instructions
1. Open a modal where a paragraph immediately follows the modal header, one example is the selection step when creating a template for a specific post.
2. Ensure the first paragraph has no top margin.

## Screenshots or screencast <!-- if applicable -->
<img width="530" alt="Screenshot 2022-07-12 at 14 05 04" src="https://user-images.githubusercontent.com/846565/178496740-6484efea-0ff2-4545-b375-04bb8862dc23.png">
