### PR TITLE
Equalize modal content padding

### DIFF
--- a/packages/components/src/modal/style.scss
+++ b/packages/components/src/modal/style.scss
@@ -119,7 +119,7 @@
 .components-modal__content {
 	flex: 1;
 	margin-top: $header-height + $grid-unit-20;
-	padding: 0 $grid-unit-40 $grid-unit-30;
+	padding: 0 $grid-unit-40 $grid-unit-40;
 	overflow: auto;
 
 	&.hide-header {


### PR DESCRIPTION
## What?
Updates the padding on modal content so that the bottom matches left and right.

## Why?
It is more visually appealing.

## Testing Instructions
Open a modal an check that the bottom padding matches the left and right.

## Screenshots or screencast <!-- if applicable -->
| Before | After |
| --- | --- |
| <img width="505" alt="Screenshot 2022-07-12 at 14 09 13" src="https://user-images.githubusercontent.com/846565/178497845-05dd435d-e46e-477d-85f6-0da6f5b8995b.png"> | <img width="482" alt="Screenshot 2022-07-12 at 14 09 29" src="https://user-images.githubusercontent.com/846565/178497883-6dd85773-2303-49a0-abc4-eb2b28b0a773.png"> |

