### PR TITLE
Fix tooltip appearing when opening popovers in Summary panel

### DIFF
--- a/packages/edit-post/src/components/sidebar/post-schedule/index.js
+++ b/packages/edit-post/src/components/sidebar/post-schedule/index.js
@@ -20,6 +20,7 @@ export default function PostSchedule() {
 					popoverProps={ { anchorRef } }
 					position="bottom left"
 					contentClassName="edit-post-post-schedule__dialog"
+					focusOnMount
 					renderToggle={ ( { isOpen, onToggle } ) => (
 						<PostScheduleToggle
 							isOpen={ isOpen }

--- a/packages/edit-post/src/components/sidebar/post-template/index.js
+++ b/packages/edit-post/src/components/sidebar/post-template/index.js
@@ -48,6 +48,7 @@ export default function PostTemplate() {
 				position="bottom left"
 				className="edit-post-post-template__dropdown"
 				contentClassName="edit-post-post-template__dialog"
+				focusOnMount
 				renderToggle={ ( { isOpen, onToggle } ) => (
 					<PostTemplateToggle
 						isOpen={ isOpen }

--- a/packages/edit-post/src/components/sidebar/post-url/index.js
+++ b/packages/edit-post/src/components/sidebar/post-url/index.js
@@ -21,6 +21,7 @@ export default function PostURL() {
 					position="bottom left"
 					className="edit-post-post-url__dropdown"
 					contentClassName="edit-post-post-url__dialog"
+					focusOnMount
 					renderToggle={ ( { isOpen, onToggle } ) => (
 						<PostURLToggle isOpen={ isOpen } onClick={ onToggle } />
 					) }

--- a/packages/edit-post/src/components/sidebar/post-visibility/index.js
+++ b/packages/edit-post/src/components/sidebar/post-visibility/index.js
@@ -33,6 +33,7 @@ export function PostVisibility() {
 								// when the label changes.
 								anchorRef: rowRef.current,
 							} }
+							focusOnMount
 							renderToggle={ ( { isOpen, onToggle } ) => (
 								<PostVisibilityToggle
 									isOpen={ isOpen }


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Adds `focusOnMount` to all of the popovers in the Summary panel.

## Why?
The default behaviour is that the first focusable element receives focus. This isn't desirable for a popover that isn't a menu. Also, this was causing a tooltip to appear immediately after opening these popovers, which is distracting:

<img width="329" alt="Screen Shot 2022-07-13 at 14 30 38" src="https://user-images.githubusercontent.com/612155/178651180-ebbcf1ee-ffcb-4857-90cc-0c8ad121c537.png">

By setting `focusOnMount`, the container receives focus, not the first focusable element:

<img width="321" alt="Screen Shot 2022-07-13 at 14 30 42" src="https://user-images.githubusercontent.com/612155/178651246-8a5381d8-8f7b-4c0d-a715-df1b496ed6c0.png">

You can then press <kbd>Tab</kbd> to move focus to the first focusable element.

## How?


## Testing Instructions
1. Create or edit a post.
1. Open the _Visibility_, _Publish_, _URL_, or _Template_ popovers.
1. No tooltip should appear. Everything should be usable if using the keyboard.

## Screenshots or screencast 