### PR TITLE
Style engine: abstract parsing methods

### DIFF
--- a/lib/load.php
+++ b/lib/load.php
@@ -115,6 +115,9 @@ if ( file_exists( __DIR__ . '/../build/style-engine/class-wp-style-engine-gutenb
 if ( file_exists( __DIR__ . '/../build/style-engine/class-wp-style-engine-css-declarations-gutenberg.php' ) ) {
 	require_once __DIR__ . '/../build/style-engine/class-wp-style-engine-css-declarations-gutenberg.php';
 }
+if ( file_exists( __DIR__ . '/../build/style-engine/class-wp-style-engine-parser-gutenberg.php' ) ) {
+	require_once __DIR__ . '/../build/style-engine/class-wp-style-engine-parser-gutenberg.php';
+}
 
 // Block supports overrides.
 require __DIR__ . '/block-supports/utils.php';

--- a/packages/style-engine/class-wp-style-engine-css-declarations.php
+++ b/packages/style-engine/class-wp-style-engine-css-declarations.php
@@ -17,7 +17,6 @@ if ( class_exists( 'WP_Style_Engine_CSS_Declarations' ) ) {
  * @access private
  */
 class WP_Style_Engine_CSS_Declarations {
-
 	/**
 	 * An array of CSS declarations (property => value pairs).
 	 *

--- a/packages/style-engine/class-wp-style-engine-parser.php
+++ b/packages/style-engine/class-wp-style-engine-parser.php
@@ -16,56 +16,447 @@ if ( class_exists( 'WP_Style_Engine_Parser' ) ) {
  */
 class WP_Style_Engine_Parser {
 	/**
-	 * An array of valid style definitions.
+	 * Style definitions that contain the instructions to
+	 * parse/output valid Gutenberg styles from a block's attributes.
+	 * For every style definition, the follow properties are valid:
+	 *  - classnames    => (array) an array of classnames to be returned for block styles. The key is a classname or pattern.
+	 *                    A value of `true` means the classname should be applied always. Otherwise, a valid CSS property (string)
+	 *                    to match the incoming value, e.g., "color" to match var:preset|color|somePresetSlug.
+	 *  - css_vars      => (array) an array of key value pairs used to generate CSS var values. The key is a CSS var pattern, whose `$slug` fragment will be replaced with a preset slug.
+	 *                    The value should be a valid CSS property (string) to match the incoming value, e.g., "color" to match var:preset|color|somePresetSlug.
+	 *  - property_keys => (array) array of keys whose values represent a valid CSS property, e.g., "margin" or "border".
+	 *  - path          => (array) a path that accesses the corresponding style value in the block style object.
+	 *  - value_func    => (string) the name of a function to generate a CSS definition array for a particular style object. The output of this function should be `array( "$property" => "$value", ... )`.
+	 */
+	const BLOCK_STYLE_DEFINITIONS_METADATA = array(
+		'color'      => array(
+			'text'       => array(
+				'property_keys' => array(
+					'default' => 'color',
+				),
+				'path'          => array( 'color', 'text' ),
+				'css_vars'      => array(
+					'color' => '--wp--preset--color--$slug',
+				),
+				'classnames'    => array(
+					'has-text-color'  => true,
+					'has-$slug-color' => 'color',
+				),
+			),
+			'background' => array(
+				'property_keys' => array(
+					'default' => 'background-color',
+				),
+				'path'          => array( 'color', 'background' ),
+				'classnames'    => array(
+					'has-background'             => true,
+					'has-$slug-background-color' => 'color',
+				),
+			),
+			'gradient'   => array(
+				'property_keys' => array(
+					'default' => 'background',
+				),
+				'path'          => array( 'color', 'gradient' ),
+				'classnames'    => array(
+					'has-background'                => true,
+					'has-$slug-gradient-background' => 'gradient',
+				),
+			),
+		),
+		'border'     => array(
+			'color'  => array(
+				'property_keys' => array(
+					'default'    => 'border-color',
+					'individual' => 'border-%s-color',
+				),
+				'path'          => array( 'border', 'color' ),
+				'classnames'    => array(
+					'has-border-color'       => true,
+					'has-$slug-border-color' => 'color',
+				),
+			),
+			'radius' => array(
+				'property_keys' => array(
+					'default'    => 'border-radius',
+					'individual' => 'border-%s-radius',
+				),
+				'path'          => array( 'border', 'radius' ),
+			),
+			'style'  => array(
+				'property_keys' => array(
+					'default'    => 'border-style',
+					'individual' => 'border-%s-style',
+				),
+				'path'          => array( 'border', 'style' ),
+			),
+			'width'  => array(
+				'property_keys' => array(
+					'default'    => 'border-width',
+					'individual' => 'border-%s-width',
+				),
+				'path'          => array( 'border', 'width' ),
+			),
+			'top'    => array(
+				'value_func' => 'static::get_individual_property_css_declarations',
+				'path'       => array( 'border', 'top' ),
+				'css_vars'   => array(
+					'color' => '--wp--preset--color--$slug',
+				),
+			),
+			'right'  => array(
+				'value_func' => 'static::get_individual_property_css_declarations',
+				'path'       => array( 'border', 'right' ),
+				'css_vars'   => array(
+					'color' => '--wp--preset--color--$slug',
+				),
+			),
+			'bottom' => array(
+				'value_func' => 'static::get_individual_property_css_declarations',
+				'path'       => array( 'border', 'bottom' ),
+				'css_vars'   => array(
+					'color' => '--wp--preset--color--$slug',
+				),
+			),
+			'left'   => array(
+				'value_func' => 'static::get_individual_property_css_declarations',
+				'path'       => array( 'border', 'left' ),
+				'css_vars'   => array(
+					'color' => '--wp--preset--color--$slug',
+				),
+			),
+		),
+		'spacing'    => array(
+			'padding' => array(
+				'property_keys' => array(
+					'default'    => 'padding',
+					'individual' => 'padding-%s',
+				),
+				'path'          => array( 'spacing', 'padding' ),
+				'css_vars'      => array(
+					'spacing' => '--wp--preset--spacing--$slug',
+				),
+			),
+			'margin'  => array(
+				'property_keys' => array(
+					'default'    => 'margin',
+					'individual' => 'margin-%s',
+				),
+				'path'          => array( 'spacing', 'margin' ),
+				'css_vars'      => array(
+					'spacing' => '--wp--preset--spacing--$slug',
+				),
+			),
+		),
+		'typography' => array(
+			'fontSize'       => array(
+				'property_keys' => array(
+					'default' => 'font-size',
+				),
+				'path'          => array( 'typography', 'fontSize' ),
+				'classnames'    => array(
+					'has-$slug-font-size' => 'font-size',
+				),
+			),
+			'fontFamily'     => array(
+				'property_keys' => array(
+					'default' => 'font-family',
+				),
+				'path'          => array( 'typography', 'fontFamily' ),
+				'classnames'    => array(
+					'has-$slug-font-family' => 'font-family',
+				),
+			),
+			'fontStyle'      => array(
+				'property_keys' => array(
+					'default' => 'font-style',
+				),
+				'path'          => array( 'typography', 'fontStyle' ),
+			),
+			'fontWeight'     => array(
+				'property_keys' => array(
+					'default' => 'font-weight',
+				),
+				'path'          => array( 'typography', 'fontWeight' ),
+			),
+			'lineHeight'     => array(
+				'property_keys' => array(
+					'default' => 'line-height',
+				),
+				'path'          => array( 'typography', 'lineHeight' ),
+			),
+			'textDecoration' => array(
+				'property_keys' => array(
+					'default' => 'text-decoration',
+				),
+				'path'          => array( 'typography', 'textDecoration' ),
+			),
+			'textTransform'  => array(
+				'property_keys' => array(
+					'default' => 'text-transform',
+				),
+				'path'          => array( 'typography', 'textTransform' ),
+			),
+			'letterSpacing'  => array(
+				'property_keys' => array(
+					'default' => 'letter-spacing',
+				),
+				'path'          => array( 'typography', 'letterSpacing' ),
+			),
+		),
+	);
+
+	/**
+	 * CSS declarations.
 	 *
 	 * @var array
 	 */
-	protected $style_definitions = array();
+	private $css_declarations = array();
+
+	/**
+	 * Classnames.
+	 *
+	 * @var array
+	 */
+	private $classnames = array();
 
 	/**
 	 * Constructor for this object.
 	 *
-	 * If a `$declarations` array is passed, it will be used to populate
-	 * the initial $declarations prop of the object by calling add_declarations().
-	 *
-	 * @param array $style_definitions An array of declarations (property => value pairs).
+	 * @param array $block_styles A block styles object.
+	 * @param array $options      array(
+	 *     'convert_vars_to_classnames' => (boolean) Whether to skip converting CSS var:? values to var( --wp--preset--* ) values. Default is `false`.
+	 * );.
 	 */
-	public function __construct( $style_definitions = array() ) {
-		if ( empty( $style_definitions ) ) {
+	public function __construct( $block_styles, $options = array() ) {
+		if ( empty( $block_styles ) ) {
 			return;
 		}
-		$this->style_definitions = $style_definitions;
+		$this->css_declarations = static::parse_css( $block_styles, $options );
+		$this->classnames       = static::parse_classnames( $block_styles );
 	}
 
-	public function parse( $styles, $should_skip_css_vars ) {
-		if ( empty( $this->style_definitions ) ) {
-			return null;
+	/**
+	 * Returns generated CSS declarations.
+	 *
+	 * @access public
+	 *
+	 * @return array
+	 */
+	public function get_css_declarations() {
+		return $this->css_declarations;
+	}
+
+	/**
+	 * Returns generated classnames concatenated in a string.
+	 *
+	 * @access public
+	 *
+	 * @return string
+	 */
+	public function get_classnames_string() {
+		if ( empty( $this->classnames ) ) {
+			return '';
+		}
+		return implode( ' ', array_unique( $this->classnames ) );
+	}
+
+	/**
+	 * Parses $block_styles for CSS.
+	 *
+	 * @param array $block_styles A block styles object.
+	 * @param array $options      Options.
+	 *
+	 * @return array              An array of property => value pairs, i.e., CSS declarations.
+	 */
+	protected static function parse_css( $block_styles, $options = array() ) {
+		$css_declarations = array();
+
+		if ( empty( $block_styles ) ) {
+			return $css_declarations;
 		}
 
-		$css_declarations     = array();
-		$classnames           = array();
-
-		// Collect CSS and classnames.
-		foreach ( $this->style_definitions as $definition_group_key => $definition_group_style ) {
-			if ( empty( $styles[ $definition_group_key ] ) ) {
+		foreach ( static::BLOCK_STYLE_DEFINITIONS_METADATA as $definition_group_key => $definition_group_style ) {
+			if ( empty( $block_styles[ $definition_group_key ] ) ) {
 				continue;
 			}
 			foreach ( $definition_group_style as $style_definition ) {
-				$style_value = _wp_array_get( $styles, $style_definition['path'], null );
+				$style_value = _wp_array_get( $block_styles, $style_definition['path'], null );
 
 				if ( ! static::is_valid_style_value( $style_value ) ) {
 					continue;
 				}
 
-				$classnames       = array_merge( $classnames, static::get_classnames( $style_value, $style_definition ) );
-				$css_declarations = array_merge( $css_declarations, static::get_css_declarations( $style_value, $style_definition, $should_skip_css_vars ) );
+				$css_declarations = array_merge( $css_declarations, static::generate_css_declarations( $style_value, $style_definition, $options ) );
 			}
 		}
 
-		return array(
-			'css_declarations' => $css_declarations,
-			'classnames'       => $classnames,
-		);
+		return $css_declarations;
+	}
+
+	/**
+	 * Parses $block_styles for classnames.
+	 *
+	 * @param array $block_styles A block styles object.
+	 *
+	 * @return array
+	 */
+	protected static function parse_classnames( $block_styles ) {
+		$classnames = array();
+
+		foreach ( static::BLOCK_STYLE_DEFINITIONS_METADATA as $definition_group_key => $definition_group_style ) {
+			if ( empty( $block_styles[ $definition_group_key ] ) ) {
+				continue;
+			}
+			foreach ( $definition_group_style as $style_definition ) {
+				$style_value = _wp_array_get( $block_styles, $style_definition['path'], null );
+
+				if ( ! static::is_valid_style_value( $style_value ) ) {
+					continue;
+				}
+
+				$classnames = array_merge( $classnames, static::generate_classnames( $style_value, $style_definition ) );
+			}
+		}
+
+		return $classnames;
+	}
+
+	/**
+	 * Returns classnames, and generates classname(s) from a CSS preset property pattern, e.g., 'var:preset|color|heavenly-blue'.
+	 *
+	 * @param array         $style_value      A single raw style value or css preset property from the generate() $block_styles array.
+	 * @param array<string> $style_definition A single style definition from BLOCK_STYLE_DEFINITIONS_METADATA.
+	 *
+	 * @return array        An array of CSS classnames.
+	 */
+	protected static function generate_classnames( $style_value, $style_definition ) {
+		$classnames = array();
+
+		if ( empty( $style_value ) ) {
+			return $classnames;
+		}
+
+		if ( ! empty( $style_definition['classnames'] ) ) {
+			foreach ( $style_definition['classnames'] as $classname => $property_key ) {
+				if ( true === $property_key ) {
+					$classnames[] = $classname;
+				}
+
+				$slug = static::get_slug_from_preset_value( $style_value, $property_key );
+
+				if ( $slug ) {
+					// Right now we expect a classname pattern to be stored in BLOCK_STYLE_DEFINITIONS_METADATA.
+					// One day, if there are no stored schemata, we could allow custom patterns or
+					// generate classnames based on other properties
+					// such as a path or a value or a prefix passed in options.
+					$classnames[] = strtr( $classname, array( '$slug' => $slug ) );
+				}
+			}
+		}
+
+		return $classnames;
+	}
+
+	/**
+	 * Returns an array of CSS declarations based on valid block style values.
+	 *
+	 * @param array         $style_value          A single raw style value from the generate() $block_styles array.
+	 * @param array<string> $style_definition     A single style definition from BLOCK_STYLE_DEFINITIONS_METADATA.
+	 * @param array<string> $options              Options passed to the constructor.
+	 *
+	 * @return array        An array of CSS definitions, e.g., array( "$property" => "$value" ).
+	 */
+	protected static function generate_css_declarations( $style_value, $style_definition, $options ) {
+		if (
+			isset( $style_definition['value_func'] ) &&
+			is_callable( $style_definition['value_func'] )
+		) {
+			return call_user_func( $style_definition['value_func'], $style_value, $style_definition, $options );
+		}
+
+		$css_declarations     = array();
+		$style_property_keys  = $style_definition['property_keys'];
+		$should_skip_css_vars = isset( $options['convert_vars_to_classnames'] ) && true === $options['convert_vars_to_classnames'];
+
+		// Build CSS var values from var:? values, e.g, `var(--wp--css--rule-slug )`
+		// Check if the value is a CSS preset and there's a corresponding css_var pattern in the style definition.
+		if ( is_string( $style_value ) && strpos( $style_value, 'var:' ) !== false ) {
+			if ( ! $should_skip_css_vars && ! empty( $style_definition['css_vars'] ) ) {
+				$css_var = static::get_css_var_value( $style_value, $style_definition['css_vars'] );
+				if ( $css_var ) {
+					$css_declarations[ $style_property_keys['default'] ] = $css_var;
+				}
+			}
+			return $css_declarations;
+		}
+
+		// Default rule builder.
+		// If the input contains an array, assume box model-like properties
+		// for styles such as margins and padding.
+		if ( is_array( $style_value ) ) {
+			foreach ( $style_value as $key => $value ) {
+				if ( is_string( $value ) && strpos( $value, 'var:' ) !== false && ! $should_skip_css_vars && ! empty( $style_definition['css_vars'] ) ) {
+					$value = static::get_css_var_value( $value, $style_definition['css_vars'] );
+				}
+				$individual_property = sprintf( $style_property_keys['individual'], _wp_to_kebab_case( $key ) );
+				if ( static::is_valid_style_value( $style_value ) ) {
+					$css_declarations[ $individual_property ] = $value;
+				}
+			}
+		} else {
+			$css_declarations[ $style_property_keys['default'] ] = $style_value;
+		}
+
+		return $css_declarations;
+	}
+
+	/**
+	 * Style value parser that returns a CSS definition array comprising style properties
+	 * that have keys representing individual style properties, otherwise known as longhand CSS properties.
+	 * e.g., "$style_property-$individual_feature: $value;", which could represent the following:
+	 * "border-{top|right|bottom|left}-{color|width|style}: {value};" or,
+	 * "border-image-{outset|source|width|repeat|slice}: {value};"
+	 *
+	 * @param array         $style_value                    A single raw Gutenberg style attributes value for a CSS property.
+	 * @param array         $individual_property_definition A single style definition from BLOCK_STYLE_DEFINITIONS_METADATA.
+	 * @param array<string> $options                        Options passed to the constructor.
+	 *
+	 * @return array An array of CSS definitions, e.g., array( "$property" => "$value" ).
+	 */
+	protected static function get_individual_property_css_declarations( $style_value, $individual_property_definition, $options ) {
+		$css_declarations = array();
+
+		if ( ! is_array( $style_value ) || empty( $style_value ) || empty( $individual_property_definition['path'] ) ) {
+			return $css_declarations;
+		}
+
+		// The first item in $individual_property_definition['path'] array tells us the style property, e.g., "border".
+		// We use this to get a corresponding CSS style definition such as "color" or "width" from the same group.
+		// The second item in $individual_property_definition['path'] array refers to the individual property marker, e.g., "top".
+		$definition_group_key    = $individual_property_definition['path'][0];
+		$individual_property_key = $individual_property_definition['path'][1];
+		$should_skip_css_vars    = isset( $options['convert_vars_to_classnames'] ) && true === $options['convert_vars_to_classnames'];
+
+		foreach ( $style_value as $css_property => $value ) {
+			if ( empty( $value ) ) {
+				continue;
+			}
+
+			// Build a path to the individual rules in definitions.
+			$style_definition_path = array( $definition_group_key, $css_property );
+			$style_definition      = _wp_array_get( static::BLOCK_STYLE_DEFINITIONS_METADATA, $style_definition_path, null );
+
+			if ( $style_definition && isset( $style_definition['property_keys']['individual'] ) ) {
+				// Set a CSS var if there is a valid preset value.
+				if ( is_string( $value ) && strpos( $value, 'var:' ) !== false && ! $should_skip_css_vars && ! empty( $individual_property_definition['css_vars'] ) ) {
+					$value = static::get_css_var_value( $value, $individual_property_definition['css_vars'] );
+				}
+				$individual_css_property                      = sprintf( $style_definition['property_keys']['individual'], $individual_property_key );
+				$css_declarations[ $individual_css_property ] = $value;
+			}
+		}
+		return $css_declarations;
 	}
 
 	/**
@@ -125,138 +516,4 @@ class WP_Style_Engine_Parser {
 		return null;
 	}
 
-	/**
-	 * Returns classnames, and generates classname(s) from a CSS preset property pattern, e.g., 'var:preset|color|heavenly-blue'.
-	 *
-	 * @param array         $style_value      A single raw style value or css preset property from the generate() $block_styles array.
-	 * @param array<string> $style_definition A single style definition from BLOCK_STYLE_DEFINITIONS_METADATA.
-	 *
-	 * @return array        An array of CSS classnames.
-	 */
-	protected static function get_classnames( $style_value, $style_definition ) {
-		$classnames = array();
-
-		if ( empty( $style_value ) ) {
-			return $classnames;
-		}
-
-		if ( ! empty( $style_definition['classnames'] ) ) {
-			foreach ( $style_definition['classnames'] as $classname => $property_key ) {
-				if ( true === $property_key ) {
-					$classnames[] = $classname;
-				}
-
-				$slug = static::get_slug_from_preset_value( $style_value, $property_key );
-
-				if ( $slug ) {
-					// Right now we expect a classname pattern to be stored in BLOCK_STYLE_DEFINITIONS_METADATA.
-					// One day, if there are no stored schemata, we could allow custom patterns or
-					// generate classnames based on other properties
-					// such as a path or a value or a prefix passed in options.
-					$classnames[] = strtr( $classname, array( '$slug' => $slug ) );
-				}
-			}
-		}
-
-		return $classnames;
-	}
-
-	/**
-	 * Returns an array of CSS declarations based on valid block style values.
-	 *
-	 * @param array         $style_value          A single raw style value from the generate() $block_styles array.
-	 * @param array<string> $style_definition     A single style definition from BLOCK_STYLE_DEFINITIONS_METADATA.
-	 * @param boolean       $should_skip_css_vars Whether to skip compiling CSS var values.
-	 *
-	 * @return array        An array of CSS definitions, e.g., array( "$property" => "$value" ).
-	 */
-	protected static function get_css_declarations( $style_value, $style_definition, $should_skip_css_vars = false ) {
-		if (
-			isset( $style_definition['value_func'] ) &&
-			is_callable( $style_definition['value_func'] )
-		) {
-			return call_user_func( $style_definition['value_func'], $style_value, $style_definition, $should_skip_css_vars );
-		}
-
-		$css_declarations    = array();
-		$style_property_keys = $style_definition['property_keys'];
-
-		// Build CSS var values from var:? values, e.g, `var(--wp--css--rule-slug )`
-		// Check if the value is a CSS preset and there's a corresponding css_var pattern in the style definition.
-		if ( is_string( $style_value ) && strpos( $style_value, 'var:' ) !== false ) {
-			if ( ! $should_skip_css_vars && ! empty( $style_definition['css_vars'] ) ) {
-				$css_var = static::get_css_var_value( $style_value, $style_definition['css_vars'] );
-				if ( $css_var ) {
-					$css_declarations[ $style_property_keys['default'] ] = $css_var;
-				}
-			}
-			return $css_declarations;
-		}
-
-		// Default rule builder.
-		// If the input contains an array, assume box model-like properties
-		// for styles such as margins and padding.
-		if ( is_array( $style_value ) ) {
-			foreach ( $style_value as $key => $value ) {
-				if ( is_string( $value ) && strpos( $value, 'var:' ) !== false && ! $should_skip_css_vars && ! empty( $style_definition['css_vars'] ) ) {
-					$value = static::get_css_var_value( $value, $style_definition['css_vars'] );
-				}
-				$individual_property = sprintf( $style_property_keys['individual'], _wp_to_kebab_case( $key ) );
-				if ( static::is_valid_style_value( $style_value ) ) {
-					$css_declarations[ $individual_property ] = $value;
-				}
-			}
-		} else {
-			$css_declarations[ $style_property_keys['default'] ] = $style_value;
-		}
-
-		return $css_declarations;
-	}
-
-	/**
-	 * Style value parser that returns a CSS definition array comprising style properties
-	 * that have keys representing individual style properties, otherwise known as longhand CSS properties.
-	 * e.g., "$style_property-$individual_feature: $value;", which could represent the following:
-	 * "border-{top|right|bottom|left}-{color|width|style}: {value};" or,
-	 * "border-image-{outset|source|width|repeat|slice}: {value};"
-	 *
-	 * @param array   $style_value                    A single raw Gutenberg style attributes value for a CSS property.
-	 * @param array   $individual_property_definition A single style definition from BLOCK_STYLE_DEFINITIONS_METADATA.
-	 * @param boolean $should_skip_css_vars           Whether to skip compiling CSS var values.
-	 *
-	 * @return array An array of CSS definitions, e.g., array( "$property" => "$value" ).
-	 */
-	protected static function get_individual_property_css_declarations( $style_value, $individual_property_definition, $should_skip_css_vars ) {
-		$css_declarations = array();
-
-		if ( ! is_array( $style_value ) || empty( $style_value ) || empty( $individual_property_definition['path'] ) ) {
-			return $css_declarations;
-		}
-
-		// The first item in $individual_property_definition['path'] array tells us the style property, e.g., "border".
-		// We use this to get a corresponding CSS style definition such as "color" or "width" from the same group.
-		// The second item in $individual_property_definition['path'] array refers to the individual property marker, e.g., "top".
-		$definition_group_key    = $individual_property_definition['path'][0];
-		$individual_property_key = $individual_property_definition['path'][1];
-
-		foreach ( $style_value as $css_property => $value ) {
-			if ( empty( $value ) ) {
-				continue;
-			}
-
-			// Build a path to the individual rules in definitions.
-			$style_definition_path = array( $definition_group_key, $css_property );
-			$style_definition      = _wp_array_get( $this->style_definitions, $style_definition_path, null );
-
-			if ( $style_definition && isset( $style_definition['property_keys']['individual'] ) ) {
-				// Set a CSS var if there is a valid preset value.
-				if ( is_string( $value ) && strpos( $value, 'var:' ) !== false && ! $should_skip_css_vars && ! empty( $individual_property_definition['css_vars'] ) ) {
-					$value = static::get_css_var_value( $value, $individual_property_definition['css_vars'] );
-				}
-				$individual_css_property                      = sprintf( $style_definition['property_keys']['individual'], $individual_property_key );
-				$css_declarations[ $individual_css_property ] = $value;
-			}
-		}
-		return $css_declarations;
-	}
 }

--- a/packages/style-engine/class-wp-style-engine-parser.php
+++ b/packages/style-engine/class-wp-style-engine-parser.php
@@ -1,0 +1,262 @@
+<?php
+/**
+ * WP_Style_Engine_Parser
+ *
+ * @package Gutenberg
+ */
+
+if ( class_exists( 'WP_Style_Engine_Parser' ) ) {
+	return;
+}
+
+/**
+ * Holds, sanitizes, processes and prints CSS declarations for the style engine.
+ *
+ * @access private
+ */
+class WP_Style_Engine_Parser {
+	/**
+	 * An array of valid style definitions.
+	 *
+	 * @var array
+	 */
+	protected $style_definitions = array();
+
+	/**
+	 * Constructor for this object.
+	 *
+	 * If a `$declarations` array is passed, it will be used to populate
+	 * the initial $declarations prop of the object by calling add_declarations().
+	 *
+	 * @param array $style_definitions An array of declarations (property => value pairs).
+	 */
+	public function __construct( $style_definitions = array() ) {
+		if ( empty( $style_definitions ) ) {
+			return;
+		}
+		$this->style_definitions = $style_definitions;
+	}
+
+	public function parse( $styles, $should_skip_css_vars ) {
+		if ( empty( $this->style_definitions ) ) {
+			return null;
+		}
+
+		$css_declarations     = array();
+		$classnames           = array();
+
+		// Collect CSS and classnames.
+		foreach ( $this->style_definitions as $definition_group_key => $definition_group_style ) {
+			if ( empty( $styles[ $definition_group_key ] ) ) {
+				continue;
+			}
+			foreach ( $definition_group_style as $style_definition ) {
+				$style_value = _wp_array_get( $styles, $style_definition['path'], null );
+
+				if ( ! static::is_valid_style_value( $style_value ) ) {
+					continue;
+				}
+
+				$classnames       = array_merge( $classnames, static::get_classnames( $style_value, $style_definition ) );
+				$css_declarations = array_merge( $css_declarations, static::get_css_declarations( $style_value, $style_definition, $should_skip_css_vars ) );
+			}
+		}
+
+		return array(
+			'css_declarations' => $css_declarations,
+			'classnames'       => $classnames,
+		);
+	}
+
+	/**
+	 * Checks whether an incoming block style value is valid.
+	 *
+	 * @param string? $style_value  A single css preset value.
+	 *
+	 * @return boolean
+	 */
+	protected static function is_valid_style_value( $style_value ) {
+		if ( '0' === $style_value ) {
+			return true;
+		}
+
+		if ( empty( $style_value ) ) {
+			return false;
+		}
+
+		return true;
+	}
+
+	/**
+	 * Extracts the slug in kebab case from a preset string, e.g., "heavenly-blue" from 'var:preset|color|heavenlyBlue'.
+	 *
+	 * @param string? $style_value  A single css preset value.
+	 * @param string  $property_key The CSS property that is the second element of the preset string. Used for matching.
+	 *
+	 * @return string|null The slug, or null if not found.
+	 */
+	protected static function get_slug_from_preset_value( $style_value, $property_key ) {
+		if ( is_string( $style_value ) && strpos( $style_value, "var:preset|{$property_key}|" ) !== false ) {
+			$index_to_splice = strrpos( $style_value, '|' ) + 1;
+			return _wp_to_kebab_case( substr( $style_value, $index_to_splice ) );
+		}
+		return null;
+	}
+
+	/**
+	 * Generates a css var string, eg var(--wp--preset--color--background) from a preset string, eg. `var:preset|space|50`.
+	 *
+	 * @param string $style_value  A single css preset value.
+	 * @param array  $css_vars The css var patterns used to generate the var string.
+	 *
+	 * @return string|null The css var, or null if no match for slug found.
+	 */
+	protected static function get_css_var_value( $style_value, $css_vars ) {
+		foreach ( $css_vars as  $property_key => $css_var_pattern ) {
+			$slug = static::get_slug_from_preset_value( $style_value, $property_key );
+			if ( $slug ) {
+				$var = strtr(
+					$css_var_pattern,
+					array( '$slug' => $slug )
+				);
+				return "var($var)";
+			}
+		}
+		return null;
+	}
+
+	/**
+	 * Returns classnames, and generates classname(s) from a CSS preset property pattern, e.g., 'var:preset|color|heavenly-blue'.
+	 *
+	 * @param array         $style_value      A single raw style value or css preset property from the generate() $block_styles array.
+	 * @param array<string> $style_definition A single style definition from BLOCK_STYLE_DEFINITIONS_METADATA.
+	 *
+	 * @return array        An array of CSS classnames.
+	 */
+	protected static function get_classnames( $style_value, $style_definition ) {
+		$classnames = array();
+
+		if ( empty( $style_value ) ) {
+			return $classnames;
+		}
+
+		if ( ! empty( $style_definition['classnames'] ) ) {
+			foreach ( $style_definition['classnames'] as $classname => $property_key ) {
+				if ( true === $property_key ) {
+					$classnames[] = $classname;
+				}
+
+				$slug = static::get_slug_from_preset_value( $style_value, $property_key );
+
+				if ( $slug ) {
+					// Right now we expect a classname pattern to be stored in BLOCK_STYLE_DEFINITIONS_METADATA.
+					// One day, if there are no stored schemata, we could allow custom patterns or
+					// generate classnames based on other properties
+					// such as a path or a value or a prefix passed in options.
+					$classnames[] = strtr( $classname, array( '$slug' => $slug ) );
+				}
+			}
+		}
+
+		return $classnames;
+	}
+
+	/**
+	 * Returns an array of CSS declarations based on valid block style values.
+	 *
+	 * @param array         $style_value          A single raw style value from the generate() $block_styles array.
+	 * @param array<string> $style_definition     A single style definition from BLOCK_STYLE_DEFINITIONS_METADATA.
+	 * @param boolean       $should_skip_css_vars Whether to skip compiling CSS var values.
+	 *
+	 * @return array        An array of CSS definitions, e.g., array( "$property" => "$value" ).
+	 */
+	protected static function get_css_declarations( $style_value, $style_definition, $should_skip_css_vars = false ) {
+		if (
+			isset( $style_definition['value_func'] ) &&
+			is_callable( $style_definition['value_func'] )
+		) {
+			return call_user_func( $style_definition['value_func'], $style_value, $style_definition, $should_skip_css_vars );
+		}
+
+		$css_declarations    = array();
+		$style_property_keys = $style_definition['property_keys'];
+
+		// Build CSS var values from var:? values, e.g, `var(--wp--css--rule-slug )`
+		// Check if the value is a CSS preset and there's a corresponding css_var pattern in the style definition.
+		if ( is_string( $style_value ) && strpos( $style_value, 'var:' ) !== false ) {
+			if ( ! $should_skip_css_vars && ! empty( $style_definition['css_vars'] ) ) {
+				$css_var = static::get_css_var_value( $style_value, $style_definition['css_vars'] );
+				if ( $css_var ) {
+					$css_declarations[ $style_property_keys['default'] ] = $css_var;
+				}
+			}
+			return $css_declarations;
+		}
+
+		// Default rule builder.
+		// If the input contains an array, assume box model-like properties
+		// for styles such as margins and padding.
+		if ( is_array( $style_value ) ) {
+			foreach ( $style_value as $key => $value ) {
+				if ( is_string( $value ) && strpos( $value, 'var:' ) !== false && ! $should_skip_css_vars && ! empty( $style_definition['css_vars'] ) ) {
+					$value = static::get_css_var_value( $value, $style_definition['css_vars'] );
+				}
+				$individual_property = sprintf( $style_property_keys['individual'], _wp_to_kebab_case( $key ) );
+				if ( static::is_valid_style_value( $style_value ) ) {
+					$css_declarations[ $individual_property ] = $value;
+				}
+			}
+		} else {
+			$css_declarations[ $style_property_keys['default'] ] = $style_value;
+		}
+
+		return $css_declarations;
+	}
+
+	/**
+	 * Style value parser that returns a CSS definition array comprising style properties
+	 * that have keys representing individual style properties, otherwise known as longhand CSS properties.
+	 * e.g., "$style_property-$individual_feature: $value;", which could represent the following:
+	 * "border-{top|right|bottom|left}-{color|width|style}: {value};" or,
+	 * "border-image-{outset|source|width|repeat|slice}: {value};"
+	 *
+	 * @param array   $style_value                    A single raw Gutenberg style attributes value for a CSS property.
+	 * @param array   $individual_property_definition A single style definition from BLOCK_STYLE_DEFINITIONS_METADATA.
+	 * @param boolean $should_skip_css_vars           Whether to skip compiling CSS var values.
+	 *
+	 * @return array An array of CSS definitions, e.g., array( "$property" => "$value" ).
+	 */
+	protected static function get_individual_property_css_declarations( $style_value, $individual_property_definition, $should_skip_css_vars ) {
+		$css_declarations = array();
+
+		if ( ! is_array( $style_value ) || empty( $style_value ) || empty( $individual_property_definition['path'] ) ) {
+			return $css_declarations;
+		}
+
+		// The first item in $individual_property_definition['path'] array tells us the style property, e.g., "border".
+		// We use this to get a corresponding CSS style definition such as "color" or "width" from the same group.
+		// The second item in $individual_property_definition['path'] array refers to the individual property marker, e.g., "top".
+		$definition_group_key    = $individual_property_definition['path'][0];
+		$individual_property_key = $individual_property_definition['path'][1];
+
+		foreach ( $style_value as $css_property => $value ) {
+			if ( empty( $value ) ) {
+				continue;
+			}
+
+			// Build a path to the individual rules in definitions.
+			$style_definition_path = array( $definition_group_key, $css_property );
+			$style_definition      = _wp_array_get( $this->style_definitions, $style_definition_path, null );
+
+			if ( $style_definition && isset( $style_definition['property_keys']['individual'] ) ) {
+				// Set a CSS var if there is a valid preset value.
+				if ( is_string( $value ) && strpos( $value, 'var:' ) !== false && ! $should_skip_css_vars && ! empty( $individual_property_definition['css_vars'] ) ) {
+					$value = static::get_css_var_value( $value, $individual_property_definition['css_vars'] );
+				}
+				$individual_css_property                      = sprintf( $style_definition['property_keys']['individual'], $individual_property_key );
+				$css_declarations[ $individual_css_property ] = $value;
+			}
+		}
+		return $css_declarations;
+	}
+}

--- a/packages/style-engine/class-wp-style-engine.php
+++ b/packages/style-engine/class-wp-style-engine.php
@@ -237,151 +237,6 @@ class WP_Style_Engine {
 	}
 
 	/**
-	 * Extracts the slug in kebab case from a preset string, e.g., "heavenly-blue" from 'var:preset|color|heavenlyBlue'.
-	 *
-	 * @param string? $style_value  A single css preset value.
-	 * @param string  $property_key The CSS property that is the second element of the preset string. Used for matching.
-	 *
-	 * @return string|null The slug, or null if not found.
-	 */
-	protected static function get_slug_from_preset_value( $style_value, $property_key ) {
-		if ( is_string( $style_value ) && strpos( $style_value, "var:preset|{$property_key}|" ) !== false ) {
-			$index_to_splice = strrpos( $style_value, '|' ) + 1;
-			return _wp_to_kebab_case( substr( $style_value, $index_to_splice ) );
-		}
-		return null;
-	}
-
-	/**
-	 * Generates a css var string, eg var(--wp--preset--color--background) from a preset string, eg. `var:preset|space|50`.
-	 *
-	 * @param string $style_value  A single css preset value.
-	 * @param array  $css_vars The css var patterns used to generate the var string.
-	 *
-	 * @return string|null The css var, or null if no match for slug found.
-	 */
-	protected static function get_css_var_value( $style_value, $css_vars ) {
-		foreach ( $css_vars as  $property_key => $css_var_pattern ) {
-			$slug = static::get_slug_from_preset_value( $style_value, $property_key );
-			if ( $slug ) {
-				$var = strtr(
-					$css_var_pattern,
-					array( '$slug' => $slug )
-				);
-				return "var($var)";
-			}
-		}
-		return null;
-	}
-
-	/**
-	 * Checks whether an incoming block style value is valid.
-	 *
-	 * @param string? $style_value  A single css preset value.
-	 *
-	 * @return boolean
-	 */
-	protected static function is_valid_style_value( $style_value ) {
-		if ( '0' === $style_value ) {
-			return true;
-		}
-
-		if ( empty( $style_value ) ) {
-			return false;
-		}
-
-		return true;
-	}
-
-	/**
-	 * Returns classnames, and generates classname(s) from a CSS preset property pattern, e.g., 'var:preset|color|heavenly-blue'.
-	 *
-	 * @param array         $style_value      A single raw style value or css preset property from the generate() $block_styles array.
-	 * @param array<string> $style_definition A single style definition from BLOCK_STYLE_DEFINITIONS_METADATA.
-	 *
-	 * @return array        An array of CSS classnames.
-	 */
-	protected static function get_classnames( $style_value, $style_definition ) {
-		$classnames = array();
-
-		if ( empty( $style_value ) ) {
-			return $classnames;
-		}
-
-		if ( ! empty( $style_definition['classnames'] ) ) {
-			foreach ( $style_definition['classnames'] as $classname => $property_key ) {
-				if ( true === $property_key ) {
-					$classnames[] = $classname;
-				}
-
-				$slug = static::get_slug_from_preset_value( $style_value, $property_key );
-
-				if ( $slug ) {
-					// Right now we expect a classname pattern to be stored in BLOCK_STYLE_DEFINITIONS_METADATA.
-					// One day, if there are no stored schemata, we could allow custom patterns or
-					// generate classnames based on other properties
-					// such as a path or a value or a prefix passed in options.
-					$classnames[] = strtr( $classname, array( '$slug' => $slug ) );
-				}
-			}
-		}
-
-		return $classnames;
-	}
-
-	/**
-	 * Returns an array of CSS declarations based on valid block style values.
-	 *
-	 * @param array         $style_value          A single raw style value from the generate() $block_styles array.
-	 * @param array<string> $style_definition     A single style definition from BLOCK_STYLE_DEFINITIONS_METADATA.
-	 * @param boolean       $should_skip_css_vars Whether to skip compiling CSS var values.
-	 *
-	 * @return array        An array of CSS definitions, e.g., array( "$property" => "$value" ).
-	 */
-	protected static function get_css_declarations( $style_value, $style_definition, $should_skip_css_vars = false ) {
-		if (
-			isset( $style_definition['value_func'] ) &&
-			is_callable( $style_definition['value_func'] )
-		) {
-			return call_user_func( $style_definition['value_func'], $style_value, $style_definition, $should_skip_css_vars );
-		}
-
-		$css_declarations    = array();
-		$style_property_keys = $style_definition['property_keys'];
-
-		// Build CSS var values from var:? values, e.g, `var(--wp--css--rule-slug )`
-		// Check if the value is a CSS preset and there's a corresponding css_var pattern in the style definition.
-		if ( is_string( $style_value ) && strpos( $style_value, 'var:' ) !== false ) {
-			if ( ! $should_skip_css_vars && ! empty( $style_definition['css_vars'] ) ) {
-				$css_var = static::get_css_var_value( $style_value, $style_definition['css_vars'] );
-				if ( $css_var ) {
-					$css_declarations[ $style_property_keys['default'] ] = $css_var;
-				}
-			}
-			return $css_declarations;
-		}
-
-		// Default rule builder.
-		// If the input contains an array, assume box model-like properties
-		// for styles such as margins and padding.
-		if ( is_array( $style_value ) ) {
-			foreach ( $style_value as $key => $value ) {
-				if ( is_string( $value ) && strpos( $value, 'var:' ) !== false && ! $should_skip_css_vars && ! empty( $style_definition['css_vars'] ) ) {
-					$value = static::get_css_var_value( $value, $style_definition['css_vars'] );
-				}
-				$individual_property = sprintf( $style_property_keys['individual'], _wp_to_kebab_case( $key ) );
-				if ( static::is_valid_style_value( $style_value ) ) {
-					$css_declarations[ $individual_property ] = $value;
-				}
-			}
-		} else {
-			$css_declarations[ $style_property_keys['default'] ] = $style_value;
-		}
-
-		return $css_declarations;
-	}
-
-	/**
 	 * Returns classnames and CSS based on the values in a block attributes.styles object.
 	 * Return values are parsed based on the instructions in BLOCK_STYLE_DEFINITIONS_METADATA.
 	 *
@@ -401,30 +256,13 @@ class WP_Style_Engine {
 			return null;
 		}
 
-		$css_declarations     = array();
-		$classnames           = array();
 		$should_skip_css_vars = isset( $options['convert_vars_to_classnames'] ) && true === $options['convert_vars_to_classnames'];
-
-		// Collect CSS and classnames.
-		foreach ( static::BLOCK_STYLE_DEFINITIONS_METADATA as $definition_group_key => $definition_group_style ) {
-			if ( empty( $block_styles[ $definition_group_key ] ) ) {
-				continue;
-			}
-			foreach ( $definition_group_style as $style_definition ) {
-				$style_value = _wp_array_get( $block_styles, $style_definition['path'], null );
-
-				if ( ! static::is_valid_style_value( $style_value ) ) {
-					continue;
-				}
-
-				$classnames       = array_merge( $classnames, static::get_classnames( $style_value, $style_definition ) );
-				$css_declarations = array_merge( $css_declarations, static::get_css_declarations( $style_value, $style_definition, $should_skip_css_vars ) );
-			}
-		}
+		$style_parser         = new WP_Style_Engine_Parser( static::BLOCK_STYLE_DEFINITIONS_METADATA );
+		$parsed_styles        = $style_parser->parse( $block_styles, $should_skip_css_vars );
 
 		// Build CSS rules output.
 		$css_selector = isset( $options['selector'] ) ? $options['selector'] : null;
-		$style_rules  = new WP_Style_Engine_CSS_Declarations( $css_declarations );
+		$style_rules  = new WP_Style_Engine_CSS_Declarations( $parsed_styles['css_declarations'] );
 
 		// The return object.
 		$styles_output = array();
@@ -441,58 +279,11 @@ class WP_Style_Engine {
 		}
 
 		// Return classnames, if any.
-		if ( ! empty( $classnames ) ) {
-			$styles_output['classnames'] = implode( ' ', array_unique( $classnames ) );
+		if ( ! empty( $parsed_styles['classnames'] ) ) {
+			$styles_output['classnames'] = implode( ' ', array_unique( $parsed_styles['classnames'] ) );
 		}
 
 		return $styles_output;
-	}
-
-	/**
-	 * Style value parser that returns a CSS definition array comprising style properties
-	 * that have keys representing individual style properties, otherwise known as longhand CSS properties.
-	 * e.g., "$style_property-$individual_feature: $value;", which could represent the following:
-	 * "border-{top|right|bottom|left}-{color|width|style}: {value};" or,
-	 * "border-image-{outset|source|width|repeat|slice}: {value};"
-	 *
-	 * @param array   $style_value                    A single raw Gutenberg style attributes value for a CSS property.
-	 * @param array   $individual_property_definition A single style definition from BLOCK_STYLE_DEFINITIONS_METADATA.
-	 * @param boolean $should_skip_css_vars           Whether to skip compiling CSS var values.
-	 *
-	 * @return array An array of CSS definitions, e.g., array( "$property" => "$value" ).
-	 */
-	protected static function get_individual_property_css_declarations( $style_value, $individual_property_definition, $should_skip_css_vars ) {
-		$css_declarations = array();
-
-		if ( ! is_array( $style_value ) || empty( $style_value ) || empty( $individual_property_definition['path'] ) ) {
-			return $css_declarations;
-		}
-
-		// The first item in $individual_property_definition['path'] array tells us the style property, e.g., "border".
-		// We use this to get a corresponding CSS style definition such as "color" or "width" from the same group.
-		// The second item in $individual_property_definition['path'] array refers to the individual property marker, e.g., "top".
-		$definition_group_key    = $individual_property_definition['path'][0];
-		$individual_property_key = $individual_property_definition['path'][1];
-
-		foreach ( $style_value as $css_property => $value ) {
-			if ( empty( $value ) ) {
-				continue;
-			}
-
-			// Build a path to the individual rules in definitions.
-			$style_definition_path = array( $definition_group_key, $css_property );
-			$style_definition      = _wp_array_get( static::BLOCK_STYLE_DEFINITIONS_METADATA, $style_definition_path, null );
-
-			if ( $style_definition && isset( $style_definition['property_keys']['individual'] ) ) {
-				// Set a CSS var if there is a valid preset value.
-				if ( is_string( $value ) && strpos( $value, 'var:' ) !== false && ! $should_skip_css_vars && ! empty( $individual_property_definition['css_vars'] ) ) {
-					$value = static::get_css_var_value( $value, $individual_property_definition['css_vars'] );
-				}
-				$individual_css_property                      = sprintf( $style_definition['property_keys']['individual'], $individual_property_key );
-				$css_declarations[ $individual_css_property ] = $value;
-			}
-		}
-		return $css_declarations;
 	}
 }
 

--- a/packages/style-engine/class-wp-style-engine.php
+++ b/packages/style-engine/class-wp-style-engine.php
@@ -31,197 +31,6 @@ class WP_Style_Engine {
 	private static $instance = null;
 
 	/**
-	 * Style definitions that contain the instructions to
-	 * parse/output valid Gutenberg styles from a block's attributes.
-	 * For every style definition, the follow properties are valid:
-	 *  - classnames    => (array) an array of classnames to be returned for block styles. The key is a classname or pattern.
-	 *                    A value of `true` means the classname should be applied always. Otherwise, a valid CSS property (string)
-	 *                    to match the incoming value, e.g., "color" to match var:preset|color|somePresetSlug.
-	 *  - css_vars      => (array) an array of key value pairs used to generate CSS var values. The key is a CSS var pattern, whose `$slug` fragment will be replaced with a preset slug.
-	 *                    The value should be a valid CSS property (string) to match the incoming value, e.g., "color" to match var:preset|color|somePresetSlug.
-	 *  - property_keys => (array) array of keys whose values represent a valid CSS property, e.g., "margin" or "border".
-	 *  - path          => (array) a path that accesses the corresponding style value in the block style object.
-	 *  - value_func    => (string) the name of a function to generate a CSS definition array for a particular style object. The output of this function should be `array( "$property" => "$value", ... )`.
-	 */
-	const BLOCK_STYLE_DEFINITIONS_METADATA = array(
-		'color'      => array(
-			'text'       => array(
-				'property_keys' => array(
-					'default' => 'color',
-				),
-				'path'          => array( 'color', 'text' ),
-				'css_vars'      => array(
-					'color' => '--wp--preset--color--$slug',
-				),
-				'classnames'    => array(
-					'has-text-color'  => true,
-					'has-$slug-color' => 'color',
-				),
-			),
-			'background' => array(
-				'property_keys' => array(
-					'default' => 'background-color',
-				),
-				'path'          => array( 'color', 'background' ),
-				'classnames'    => array(
-					'has-background'             => true,
-					'has-$slug-background-color' => 'color',
-				),
-			),
-			'gradient'   => array(
-				'property_keys' => array(
-					'default' => 'background',
-				),
-				'path'          => array( 'color', 'gradient' ),
-				'classnames'    => array(
-					'has-background'                => true,
-					'has-$slug-gradient-background' => 'gradient',
-				),
-			),
-		),
-		'border'     => array(
-			'color'  => array(
-				'property_keys' => array(
-					'default'    => 'border-color',
-					'individual' => 'border-%s-color',
-				),
-				'path'          => array( 'border', 'color' ),
-				'classnames'    => array(
-					'has-border-color'       => true,
-					'has-$slug-border-color' => 'color',
-				),
-			),
-			'radius' => array(
-				'property_keys' => array(
-					'default'    => 'border-radius',
-					'individual' => 'border-%s-radius',
-				),
-				'path'          => array( 'border', 'radius' ),
-			),
-			'style'  => array(
-				'property_keys' => array(
-					'default'    => 'border-style',
-					'individual' => 'border-%s-style',
-				),
-				'path'          => array( 'border', 'style' ),
-			),
-			'width'  => array(
-				'property_keys' => array(
-					'default'    => 'border-width',
-					'individual' => 'border-%s-width',
-				),
-				'path'          => array( 'border', 'width' ),
-			),
-			'top'    => array(
-				'value_func' => 'static::get_individual_property_css_declarations',
-				'path'       => array( 'border', 'top' ),
-				'css_vars'   => array(
-					'color' => '--wp--preset--color--$slug',
-				),
-			),
-			'right'  => array(
-				'value_func' => 'static::get_individual_property_css_declarations',
-				'path'       => array( 'border', 'right' ),
-				'css_vars'   => array(
-					'color' => '--wp--preset--color--$slug',
-				),
-			),
-			'bottom' => array(
-				'value_func' => 'static::get_individual_property_css_declarations',
-				'path'       => array( 'border', 'bottom' ),
-				'css_vars'   => array(
-					'color' => '--wp--preset--color--$slug',
-				),
-			),
-			'left'   => array(
-				'value_func' => 'static::get_individual_property_css_declarations',
-				'path'       => array( 'border', 'left' ),
-				'css_vars'   => array(
-					'color' => '--wp--preset--color--$slug',
-				),
-			),
-		),
-		'spacing'    => array(
-			'padding' => array(
-				'property_keys' => array(
-					'default'    => 'padding',
-					'individual' => 'padding-%s',
-				),
-				'path'          => array( 'spacing', 'padding' ),
-				'css_vars'      => array(
-					'spacing' => '--wp--preset--spacing--$slug',
-				),
-			),
-			'margin'  => array(
-				'property_keys' => array(
-					'default'    => 'margin',
-					'individual' => 'margin-%s',
-				),
-				'path'          => array( 'spacing', 'margin' ),
-				'css_vars'      => array(
-					'spacing' => '--wp--preset--spacing--$slug',
-				),
-			),
-		),
-		'typography' => array(
-			'fontSize'       => array(
-				'property_keys' => array(
-					'default' => 'font-size',
-				),
-				'path'          => array( 'typography', 'fontSize' ),
-				'classnames'    => array(
-					'has-$slug-font-size' => 'font-size',
-				),
-			),
-			'fontFamily'     => array(
-				'property_keys' => array(
-					'default' => 'font-family',
-				),
-				'path'          => array( 'typography', 'fontFamily' ),
-				'classnames'    => array(
-					'has-$slug-font-family' => 'font-family',
-				),
-			),
-			'fontStyle'      => array(
-				'property_keys' => array(
-					'default' => 'font-style',
-				),
-				'path'          => array( 'typography', 'fontStyle' ),
-			),
-			'fontWeight'     => array(
-				'property_keys' => array(
-					'default' => 'font-weight',
-				),
-				'path'          => array( 'typography', 'fontWeight' ),
-			),
-			'lineHeight'     => array(
-				'property_keys' => array(
-					'default' => 'line-height',
-				),
-				'path'          => array( 'typography', 'lineHeight' ),
-			),
-			'textDecoration' => array(
-				'property_keys' => array(
-					'default' => 'text-decoration',
-				),
-				'path'          => array( 'typography', 'textDecoration' ),
-			),
-			'textTransform'  => array(
-				'property_keys' => array(
-					'default' => 'text-transform',
-				),
-				'path'          => array( 'typography', 'textTransform' ),
-			),
-			'letterSpacing'  => array(
-				'property_keys' => array(
-					'default' => 'letter-spacing',
-				),
-				'path'          => array( 'typography', 'letterSpacing' ),
-			),
-		),
-	);
-
-	/**
 	 * Utility method to retrieve the main instance of the class.
 	 *
 	 * The instance will be created if it does not exist yet.
@@ -238,7 +47,7 @@ class WP_Style_Engine {
 
 	/**
 	 * Returns classnames and CSS based on the values in a block attributes.styles object.
-	 * Return values are parsed based on the instructions in BLOCK_STYLE_DEFINITIONS_METADATA.
+	 * Return values are parsed based on the instructions in WP_Style_Engine_Parser.
 	 *
 	 * @param array $block_styles Styles from a block's attributes object.
 	 * @param array $options      array(
@@ -256,22 +65,18 @@ class WP_Style_Engine {
 			return null;
 		}
 
-		$should_skip_css_vars = isset( $options['convert_vars_to_classnames'] ) && true === $options['convert_vars_to_classnames'];
-		$style_parser         = new WP_Style_Engine_Parser( static::BLOCK_STYLE_DEFINITIONS_METADATA );
-		$parsed_styles        = $style_parser->parse( $block_styles, $should_skip_css_vars );
-
-		// Build CSS rules output.
-		$css_selector = isset( $options['selector'] ) ? $options['selector'] : null;
-		$style_rules  = new WP_Style_Engine_CSS_Declarations( $parsed_styles['css_declarations'] );
+		$parser           = new WP_Style_Engine_Parser( $block_styles, $options );
+		$css_declarations = new WP_Style_Engine_CSS_Declarations( $parser->get_css_declarations() );
 
 		// The return object.
 		$styles_output = array();
-		$css           = $style_rules->get_declarations_string();
 
 		// Return css, if any.
+		$css = $css_declarations->get_declarations_string();
 		if ( ! empty( $css ) ) {
 			$styles_output['css']          = $css;
-			$styles_output['declarations'] = $style_rules->get_declarations();
+			$styles_output['declarations'] = $css_declarations->get_declarations();
+			$css_selector                  = isset( $options['selector'] ) ? $options['selector'] : null;
 			// Return an entire rule if there is a selector.
 			if ( $css_selector ) {
 				$styles_output['css'] = $css_selector . ' { ' . $css . ' }';
@@ -279,8 +84,9 @@ class WP_Style_Engine {
 		}
 
 		// Return classnames, if any.
-		if ( ! empty( $parsed_styles['classnames'] ) ) {
-			$styles_output['classnames'] = implode( ' ', array_unique( $parsed_styles['classnames'] ) );
+		$classnames = $parser->get_classnames_string();
+		if ( ! empty( $classnames ) ) {
+			$styles_output['classnames'] = $classnames;
 		}
 
 		return $styles_output;

--- a/packages/style-engine/phpunit/class-wp-style-engine-test.php
+++ b/packages/style-engine/phpunit/class-wp-style-engine-test.php
@@ -6,6 +6,7 @@
  * @subpackage style-engine
  */
 
+require __DIR__ . '/../class-wp-style-engine-parser.php';
 require __DIR__ . '/../class-wp-style-engine-css-declarations.php';
 require __DIR__ . '/../class-wp-style-engine.php';
 

--- a/tools/webpack/packages.js
+++ b/tools/webpack/packages.js
@@ -36,6 +36,7 @@ const bundledPackagesPhpConfig = [
 		from: './packages/style-engine/',
 		to: 'build/style-engine/',
 		replaceClasses: [
+			'WP_Style_Engine_Parser',
 			'WP_Style_Engine_CSS_Declarations',
 			'WP_Style_Engine',
 		],


### PR DESCRIPTION
## What?
Trying to work out whether it's worth abstracting parsing methods or if it's a premature optimization.

## Why?
The `WP_Style_Engine` class could be primarily a facade, with other classes taking care of the heavy work.

## How?
Create a new class `WP_Style_Engine_Parser` to house all the methods that are used to parse a Gutenberg style object.

## Testing Instructions
```bash
npm run test-unit-php /var/www/html/wp-content/plugins/gutenberg/packages/style-engine/phpunit/class-wp-style-engine-test.php
```