### PR TITLE
UnitControl: Update unit select's focus styles

### DIFF
--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 -   `BorderControl`: Improve labelling, tooltips and DOM structure ([#42348](https://github.com/WordPress/gutenberg/pull/42348/)).
 -   `BaseControl`: Set zero padding on `StyledLabel` to ensure cross-browser styling ([#42348](https://github.com/WordPress/gutenberg/pull/42348/)).
+-   `UnitControl`: Update unit select's focus styles to match input's ([#42383](https://github.com/WordPress/gutenberg/pull/42383)).
 
 ### Internal
 

--- a/packages/components/src/unit-control/styles/unit-control-styles.ts
+++ b/packages/components/src/unit-control/styles/unit-control-styles.ts
@@ -6,8 +6,9 @@ import styled from '@emotion/styled';
 /**
  * Internal dependencies
  */
-import { COLORS, rtl } from '../../utils';
+import { COLORS, CONFIG, rtl } from '../../utils';
 import NumberControl from '../../number-control';
+import { BackdropUI } from '../../input-control/styles/input-control-styles';
 import type { SelectSize } from '../types';
 
 // Using `selectSize` instead of `size` to avoid a type conflict with the
@@ -23,6 +24,11 @@ type InputProps = {
 export const Root = styled.div`
 	box-sizing: border-box;
 	position: relative;
+
+	/* Target the InputControl's backdrop and make focus styles smoother. */
+	&&& ${ BackdropUI } {
+		transition: box-shadow 0.1s linear;
+	}
 `;
 
 const arrowStyles = ( { disableUnits }: InputProps ) => {
@@ -86,15 +92,21 @@ export const UnitSelect = styled.select< SelectProps >`
 		cursor: pointer;
 		border: 1px solid transparent;
 		height: 100%;
+		/* Removing margin ensures focus styles neatly overlay the wrapper. */
+		margin: 0;
+		transition: box-shadow 0.1s linear, border 0.1s linear;
 
 		&:hover {
 			background-color: ${ COLORS.lightGray[ 300 ] };
 		}
 
 		&:focus {
-			border-color: ${ COLORS.ui.borderFocus };
-			outline: 2px solid transparent;
+			border: 1px solid ${ COLORS.ui.borderFocus };
+			box-shadow: inset 0 0 0 ${ CONFIG.borderWidth }
+				${ COLORS.ui.borderFocus };
 			outline-offset: 0;
+			outline: 2px solid transparent;
+			z-index: 1;
 		}
 
 		&:disabled {

--- a/packages/components/src/unit-control/test/__snapshots__/index.tsx.snap
+++ b/packages/components/src/unit-control/test/__snapshots__/index.tsx.snap
@@ -7,7 +7,7 @@ Snapshot Diff:
 
 @@ -1,10 +1,10 @@
   <div
-    class="components-unit-control-wrapper css-aa2xc3-Root e1bagdl33"
+    class="components-unit-control-wrapper css-zi0c81-Root e1bagdl33"
   >
     <div
 -     class="components-flex components-input-control components-number-control components-unit-control e1bagdl32 ep48uk90 em5sgkm7 css-1njfmeu-View-Flex-sx-Base-sx-Items-ItemsColumn-Root-rootLabelPositionStyles-Input-ValueInput-arrowStyles em57xhy0"


### PR DESCRIPTION
Related:
- https://github.com/WordPress/gutenberg/pull/42212

## What?

Fixes the unit select's focus styling within the `UnitControl` component.

## Why?

As it currently stands the `UnitControl` wrapper's border obscures focus styles. The focus border/box-shadow is a little inconsistent as well.

## How?

- Brings in the style overrides previously applied to the unit select within the `BorderControl` component.
- The focus styles were initially outlined in https://github.com/WordPress/gutenberg/issues/40897
- Removes 1px left/right margin from UnitSelect which caused inset box-shadow to expose the wrapper's border.

## Testing Instructions

1. Take a look at the focus styling for the `UnitControl` in Storybook on trunk
2. Checkout this branch and ensure the unit select's focus styles are visible and consistent with the inputs
3. Repeat the process this time checking instances of the `UnitControl` within the editors

## Screenshots or screencast <!-- if applicable -->

#### Before

https://user-images.githubusercontent.com/60436221/178658709-e62ab275-dcb6-47ee-93a0-d9264e64160d.mp4



#### After

https://user-images.githubusercontent.com/60436221/178658720-1ee396fd-31d9-4064-91c9-30947042325f.mp4



