### PR TITLE
[WIP] List View: Try adding partial content for the paragraph block

### DIFF
--- a/packages/block-editor/src/components/list-view/block-select-button.js
+++ b/packages/block-editor/src/components/list-view/block-select-button.js
@@ -105,15 +105,19 @@ function ListViewBlockSelectButton(
 					spacing={ 1 }
 				>
 					<span className="block-editor-list-view-block-select-button__title">
-						<Truncate ellipsizeMode="auto">{ blockTitle }</Truncate>
-					</span>
-					{ !! partialContent && (
-						<span className="block-editor-list-view-block-select-button__partial-content">
+						<span className="block-editor-list-view-block-select-button__title__inner-wrapper">
 							<Truncate ellipsizeMode="auto">
-								{ partialContent }
+								{ blockTitle }
 							</Truncate>
+							{ !! partialContent && (
+								<span className="block-editor-list-view-block-select-button__partial-content">
+									<Truncate ellipsizeMode="auto">
+										{ partialContent }
+									</Truncate>
+								</span>
+							) }
 						</span>
-					) }
+					</span>
 					{ blockInformation?.anchor && (
 						<span className="block-editor-list-view-block-select-button__anchor">
 							{ blockInformation.anchor }

--- a/packages/block-editor/src/components/list-view/block-select-button.js
+++ b/packages/block-editor/src/components/list-view/block-select-button.js
@@ -11,6 +11,9 @@ import {
 	__experimentalHStack as HStack,
 	__experimentalTruncate as Truncate,
 } from '@wordpress/components';
+import { getDefaultBlockName } from '@wordpress/blocks';
+import { useSelect } from '@wordpress/data';
+import { __unstableStripHTML as stripHTML } from '@wordpress/dom';
 import { forwardRef } from '@wordpress/element';
 import { Icon, lock } from '@wordpress/icons';
 import { SPACE, ENTER } from '@wordpress/keycodes';
@@ -23,6 +26,7 @@ import useBlockDisplayInformation from '../use-block-display-information';
 import useBlockDisplayTitle from '../block-title/use-block-display-title';
 import ListViewExpander from './expander';
 import { useBlockLock } from '../block-lock';
+import { store as blockEditorStore } from '../../store';
 
 function ListViewBlockSelectButton(
 	{
@@ -38,6 +42,20 @@ function ListViewBlockSelectButton(
 	},
 	ref
 ) {
+	const { partialContent } = useSelect(
+		( select ) => {
+			const block = select( blockEditorStore ).getBlock( clientId );
+			const isDefaultBlock = block?.name === getDefaultBlockName();
+
+			return {
+				partialContent: isDefaultBlock
+					? stripHTML( block?.attributes?.content )
+					: undefined,
+			};
+		},
+		[ clientId ]
+	);
+
 	const blockInformation = useBlockDisplayInformation( clientId );
 	const blockTitle = useBlockDisplayTitle( {
 		clientId,
@@ -89,6 +107,13 @@ function ListViewBlockSelectButton(
 					<span className="block-editor-list-view-block-select-button__title">
 						<Truncate ellipsizeMode="auto">{ blockTitle }</Truncate>
 					</span>
+					{ !! partialContent && (
+						<span className="block-editor-list-view-block-select-button__partial-content">
+							<Truncate ellipsizeMode="auto">
+								{ partialContent }
+							</Truncate>
+						</span>
+					) }
 					{ blockInformation?.anchor && (
 						<span className="block-editor-list-view-block-select-button__anchor">
 							{ blockInformation.anchor }

--- a/packages/block-editor/src/components/list-view/block-select-button.js
+++ b/packages/block-editor/src/components/list-view/block-select-button.js
@@ -106,7 +106,13 @@ function ListViewBlockSelectButton(
 				>
 					<span className="block-editor-list-view-block-select-button__title">
 						<span className="block-editor-list-view-block-select-button__title__inner-wrapper">
-							<Truncate ellipsizeMode="auto">
+							<Truncate
+								ellipsizeMode="auto"
+								className={ classnames( {
+									'block-editor-list-view-block-select-button__title--no-shrink':
+										!! partialContent,
+								} ) }
+							>
 								{ blockTitle }
 							</Truncate>
 							{ !! partialContent && (

--- a/packages/block-editor/src/components/list-view/style.scss
+++ b/packages/block-editor/src/components/list-view/style.scss
@@ -301,7 +301,8 @@
 		min-width: 120px;
 	}
 
-	.block-editor-list-view-block-select-button__title {
+	.block-editor-list-view-block-select-button__title,
+	.block-editor-list-view-block-select-button__partial-content {
 		flex: 1;
 		position: relative;
 
@@ -310,6 +311,10 @@
 			width: 100%;
 			transform: translateY(-50%);
 		}
+	}
+
+	.block-editor-list-view-block-select-button__partial-content {
+		opacity: 0.5;
 	}
 
 	.block-editor-list-view-block-select-button__anchor {

--- a/packages/block-editor/src/components/list-view/style.scss
+++ b/packages/block-editor/src/components/list-view/style.scss
@@ -301,12 +301,11 @@
 		min-width: 120px;
 	}
 
-	.block-editor-list-view-block-select-button__title,
-	.block-editor-list-view-block-select-button__partial-content {
+	.block-editor-list-view-block-select-button__title {
 		flex: 1;
 		position: relative;
 
-		.components-truncate {
+		.block-editor-list-view-block-select-button__title__inner-wrapper {
 			position: absolute;
 			width: 100%;
 			transform: translateY(-50%);

--- a/packages/block-editor/src/components/list-view/style.scss
+++ b/packages/block-editor/src/components/list-view/style.scss
@@ -306,14 +306,22 @@
 		position: relative;
 
 		.block-editor-list-view-block-select-button__title__inner-wrapper {
+			display: flex;
+			gap: 0.5em;
 			position: absolute;
 			width: 100%;
 			transform: translateY(-50%);
 		}
 	}
 
+	.block-editor-list-view-block-select-button__title--no-shrink {
+		flex-shrink: 0;
+	}
+
 	.block-editor-list-view-block-select-button__partial-content {
 		opacity: 0.5;
+		flex-basis: 100%;
+		overflow: hidden;
 	}
 
 	.block-editor-list-view-block-select-button__anchor {


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

🚧 🚧 🚧 🚧 WIP: This is just a draft for the moment 🚧 🚧 🚧 🚧 

Following up on #41855, this PR explores adding partial content of the paragraph block to the list view to see if it helps with navigating the list, particularly for posts with lots of content.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

To improve navigating the List View when there are large numbers of similar blocks (e.g. a big post with lots of paragraphs)

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

TBC

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->

## Screenshots or screencast <!-- if applicable -->

This is a WIP screenshot, note that the positioning is incorrect (the text should follow directly after the Paragraph label)

<img width="347" alt="image" src="https://user-images.githubusercontent.com/14988353/178676069-d317ca53-6877-41c3-b13f-0e2485372a16.png">
