### PR TITLE
Documentation: Include section on how to test code for a given WP major

### DIFF
--- a/docs/reference-guides/packages.md
+++ b/docs/reference-guides/packages.md
@@ -37,3 +37,19 @@ Once installed, you can access the component in your code using:
 ```js
 import { PlainText } from '@wordpress/block-editor';
 ```
+
+## Testing JavaScript code from a specific major WordPress version
+
+There is a way to quickly install a version of the individual WordPress package used with a given WordPress major version using [npm distribution tags](https://docs.npmjs.com/cli/v8/commands/npm-dist-tag) (example for WordPress `5.8.x`):
+
+```bash
+npm install @wordpress/block-editor@wp-5.8
+```
+
+It’s also possible to update all existing WordPress packages in the project with a single command:
+
+```bash
+npx @wordpress/scripts packages-update --dist-tag=wp-5.8
+```
+
+All major WordPress versions starting from `5.7.x` are supported (e.g., `wp-5.7` or `wp-6.0`). Each individual dist-tag always points to the latest bug fix release for that major version line.


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Closes #24376.

Adds the same information included in the post [WordPress packages publish to npm every two weeks](https://make.wordpress.org/core/2022/07/12/wordpress-packages-publish-to-npm-every-two-weeks/).

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

To make people aware how they can test JavaScript code from a specific major WordPress version.

## How?

The new section is going to live at https://developer.wordpress.org/block-editor/reference-guides/packages/.

It can be previewed at https://github.com/WordPress/gutenberg/blob/2a91836f61709c8e4d477be9e3ab40a349989f53/docs/reference-guides/packages.md#testing-javascript-code-from-a-specific-major-wordpress-version

