### PR TITLE
Block Editor: Propose new `useBlockAttribute` hook for blocks

### DIFF
--- a/packages/block-editor/CHANGELOG.md
+++ b/packages/block-editor/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### New Features
+
+-   Added `useBlockAttribute` hook to simplify handling block attributes when editing blocks ([#42391](https://github.com/WordPress/gutenberg/pull/42391)).
+
 ## 9.5.0 (2022-07-13)
 
 ## 9.4.0 (2022-06-29)

--- a/packages/block-editor/README.md
+++ b/packages/block-editor/README.md
@@ -671,6 +671,34 @@ _Related_
 
 -   <https://github.com/WordPress/gutenberg/blob/HEAD/packages/block-editor/src/components/url-popover/README.md>
 
+### useBlockAttribute
+
+Returns the current value for a block attribute and a function to update it.
+It automatically detects the block instance that should get updated based on the block edit context.
+
+_Usage_
+
+```jsx
+import { useBlockAttribute } from '@wordpress/block-editor';
+import { TextControl } from '@wordpress/components';
+
+function ContentInput() {
+    const [ content, setContent ] = useBlockAttribute( 'content' );
+    return (
+        <TextControl value={ content } onChange={ setContent ) } />
+    );
+}
+```
+
+_Parameters_
+
+-   _name_ `string`: Attribute name.
+-   _transform_ `[Function]`: Optional transform function applied when setting attribute value.
+
+_Returns_
+
+-   `[*, Function]`: A tuple of the current attribute value and a function to update it.
+
 ### useBlockDisplayInformation
 
 Hook used to try to find a matching block variation and return

--- a/packages/block-editor/src/components/index.js
+++ b/packages/block-editor/src/components/index.js
@@ -146,6 +146,7 @@ export {
 export { default as Warning } from './warning';
 export { default as WritingFlow } from './writing-flow';
 export { default as useBlockDisplayInformation } from './use-block-display-information';
+export { default as useBlockAttribute } from './use-block-attribute';
 export { default as __unstableIframe } from './iframe';
 export { default as __experimentalUseNoRecursiveRenders } from './use-no-recursive-renders';
 export { default as __experimentalBlockPatternsList } from './block-patterns-list';

--- a/packages/block-editor/src/components/use-block-attribute/index.js
+++ b/packages/block-editor/src/components/use-block-attribute/index.js
@@ -47,10 +47,12 @@ export default function useBlockAttribute( name, transform ) {
 	const setCurrentValue = useCallback(
 		( newValue ) => {
 			updateBlockAttributes( clientId, {
-				[ name ]: transform ? transform( newValue ) : newValue,
+				[ name ]: transform
+					? transform( newValue, currentValue )
+					: newValue,
 			} );
 		},
-		[ updateBlockAttributes, transform ]
+		[ transform, currentValue ]
 	);
 
 	return [ currentValue, setCurrentValue ];

--- a/packages/block-editor/src/components/use-block-attribute/index.js
+++ b/packages/block-editor/src/components/use-block-attribute/index.js
@@ -1,0 +1,57 @@
+/**
+ * WordPress dependencies
+ */
+import { useDispatch, useSelect } from '@wordpress/data';
+import { useCallback } from '@wordpress/element';
+
+/**
+ * Internal dependencies
+ */
+import { store as blockEditorStore } from '../../store';
+import { useBlockEditContext } from '../block-edit';
+
+/**
+ * Returns the current value for a block attribute and a function to update it.
+ * It automatically detects the block instance that should get updated based on the block edit context.
+ *
+ * @example
+ *
+ * ```jsx
+ * import { useBlockAttribute } from '@wordpress/block-editor';
+ * import { TextControl } from '@wordpress/components';
+ *
+ * function ContentInput() {
+ *     const [ content, setContent ] = useBlockAttribute( 'content' );
+ *     return (
+ *         <TextControl value={ content } onChange={ setContent ) } />
+ *     );
+ * }
+ * ```
+ *
+ * @param {string}   name        Attribute name.
+ * @param {Function} [transform] Optional transform function applied when setting attribute value.
+ *
+ * @return {[*, Function]} A tuple of the current attribute value and a function to update it.
+ */
+export default function useBlockAttribute( name, transform ) {
+	const { clientId } = useBlockEditContext();
+	const currentValue = useSelect(
+		( select ) => {
+			const { getBlockAttributes } = select( blockEditorStore );
+
+			return getBlockAttributes( clientId )?.[ name ];
+		},
+		[ clientId, name ]
+	);
+	const { updateBlockAttributes } = useDispatch( blockEditorStore );
+	const setCurrentValue = useCallback(
+		( newValue ) => {
+			updateBlockAttributes( clientId, {
+				[ name ]: transform ? transform( newValue ) : newValue,
+			} );
+		},
+		[ updateBlockAttributes, transform ]
+	);
+
+	return [ currentValue, setCurrentValue ];
+}

--- a/packages/block-library/src/archives/edit.js
+++ b/packages/block-library/src/archives/edit.js
@@ -8,11 +8,25 @@ import {
 	Disabled,
 } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
-import { InspectorControls, useBlockProps } from '@wordpress/block-editor';
+import {
+	InspectorControls,
+	useBlockAttribute,
+	useBlockProps,
+} from '@wordpress/block-editor';
 import ServerSideRender from '@wordpress/server-side-render';
 
-export default function ArchivesEdit( { attributes, setAttributes } ) {
-	const { showPostCounts, displayAsDropdown, type } = attributes;
+const flipOldValue = ( _, oldValue ) => ! oldValue;
+
+export default function ArchivesEdit( { attributes } ) {
+	const [ displayAsDropdown, setDisplayAsDropdown ] = useBlockAttribute(
+		'displayAsDropdown',
+		flipOldValue
+	);
+	const [ showPostCounts, setShowPostCounts ] = useBlockAttribute(
+		'showPostCounts',
+		flipOldValue
+	);
+	const [ type, setType ] = useBlockAttribute( 'type' );
 
 	return (
 		<>
@@ -21,20 +35,12 @@ export default function ArchivesEdit( { attributes, setAttributes } ) {
 					<ToggleControl
 						label={ __( 'Display as dropdown' ) }
 						checked={ displayAsDropdown }
-						onChange={ () =>
-							setAttributes( {
-								displayAsDropdown: ! displayAsDropdown,
-							} )
-						}
+						onChange={ setDisplayAsDropdown }
 					/>
 					<ToggleControl
 						label={ __( 'Show post counts' ) }
 						checked={ showPostCounts }
-						onChange={ () =>
-							setAttributes( {
-								showPostCounts: ! showPostCounts,
-							} )
-						}
+						onChange={ setShowPostCounts }
 					/>
 					<SelectControl
 						label={ __( 'Group by:' ) }
@@ -45,9 +51,7 @@ export default function ArchivesEdit( { attributes, setAttributes } ) {
 							{ label: __( 'Day' ), value: 'daily' },
 						] }
 						value={ type }
-						onChange={ ( value ) =>
-							setAttributes( { type: value } )
-						}
+						onChange={ setType }
 					/>
 				</PanelBody>
 			</InspectorControls>

--- a/packages/block-library/src/latest-posts/edit.js
+++ b/packages/block-library/src/latest-posts/edit.js
@@ -3,6 +3,7 @@
  */
 import { get, includes, pickBy } from 'lodash';
 import classnames from 'classnames';
+import memoize from 'memize';
 
 /**
  * WordPress dependencies
@@ -68,6 +69,9 @@ function getFeaturedImageDetails( post, size ) {
 }
 
 export default function LatestPostsEdit( { attributes, setAttributes } ) {
+	const createUpdater = memoize( ( name ) => ( nextValue ) => {
+		setAttributes( { [ name ]: nextValue } );
+	} );
 	const instanceId = useInstanceId( LatestPostsEdit );
 	const {
 		postsToShow,
@@ -209,9 +213,7 @@ export default function LatestPostsEdit( { attributes, setAttributes } ) {
 				<ToggleControl
 					label={ __( 'Post content' ) }
 					checked={ displayPostContent }
-					onChange={ ( value ) =>
-						setAttributes( { displayPostContent: value } )
-					}
+					onChange={ createUpdater( 'displayPostContent' ) }
 				/>
 				{ displayPostContent && (
 					<RadioControl
@@ -224,11 +226,7 @@ export default function LatestPostsEdit( { attributes, setAttributes } ) {
 								value: 'full_post',
 							},
 						] }
-						onChange={ ( value ) =>
-							setAttributes( {
-								displayPostContentRadio: value,
-							} )
-						}
+						onChange={ createUpdater( 'displayPostContentRadio' ) }
 					/>
 				) }
 				{ displayPostContent &&
@@ -236,9 +234,7 @@ export default function LatestPostsEdit( { attributes, setAttributes } ) {
 						<RangeControl
 							label={ __( 'Max number of words in excerpt' ) }
 							value={ excerptLength }
-							onChange={ ( value ) =>
-								setAttributes( { excerptLength: value } )
-							}
+							onChange={ createUpdater( 'excerptLength' ) }
 							min={ MIN_EXCERPT_LENGTH }
 							max={ MAX_EXCERPT_LENGTH }
 						/>
@@ -249,16 +245,12 @@ export default function LatestPostsEdit( { attributes, setAttributes } ) {
 				<ToggleControl
 					label={ __( 'Display author name' ) }
 					checked={ displayAuthor }
-					onChange={ ( value ) =>
-						setAttributes( { displayAuthor: value } )
-					}
+					onChange={ createUpdater( 'displayAuthor' ) }
 				/>
 				<ToggleControl
 					label={ __( 'Display post date' ) }
 					checked={ displayPostDate }
-					onChange={ ( value ) =>
-						setAttributes( { displayPostDate: value } )
-					}
+					onChange={ createUpdater( 'displayPostDate' ) }
 				/>
 			</PanelBody>
 
@@ -266,9 +258,7 @@ export default function LatestPostsEdit( { attributes, setAttributes } ) {
 				<ToggleControl
 					label={ __( 'Display featured image' ) }
 					checked={ displayFeaturedImage }
-					onChange={ ( value ) =>
-						setAttributes( { displayFeaturedImage: value } )
-					}
+					onChange={ createUpdater( 'displayFeaturedImage' ) }
 				/>
 				{ displayFeaturedImage && (
 					<>
@@ -305,11 +295,9 @@ export default function LatestPostsEdit( { attributes, setAttributes } ) {
 							</BaseControl.VisualLabel>
 							<BlockAlignmentToolbar
 								value={ featuredImageAlign }
-								onChange={ ( value ) =>
-									setAttributes( {
-										featuredImageAlign: value,
-									} )
-								}
+								onChange={ createUpdater(
+									'featuredImageAlign'
+								) }
 								controls={ [ 'left', 'center', 'right' ] }
 								isCollapsed={ false }
 							/>
@@ -317,11 +305,9 @@ export default function LatestPostsEdit( { attributes, setAttributes } ) {
 						<ToggleControl
 							label={ __( 'Add link to featured image' ) }
 							checked={ addLinkToFeaturedImage }
-							onChange={ ( value ) =>
-								setAttributes( {
-									addLinkToFeaturedImage: value,
-								} )
-							}
+							onChange={ createUpdater(
+								'addLinkToFeaturedImage'
+							) }
 						/>
 					</>
 				) }
@@ -331,15 +317,9 @@ export default function LatestPostsEdit( { attributes, setAttributes } ) {
 				<QueryControls
 					{ ...{ order, orderBy } }
 					numberOfItems={ postsToShow }
-					onOrderChange={ ( value ) =>
-						setAttributes( { order: value } )
-					}
-					onOrderByChange={ ( value ) =>
-						setAttributes( { orderBy: value } )
-					}
-					onNumberOfItemsChange={ ( value ) =>
-						setAttributes( { postsToShow: value } )
-					}
+					onOrderChange={ createUpdater( 'order' ) }
+					onOrderByChange={ createUpdater( 'orderBy' ) }
+					onNumberOfItemsChange={ createUpdater( 'postsToShow' ) }
 					categorySuggestions={ categorySuggestions }
 					onCategoryChange={ selectCategories }
 					selectedCategories={ categories }
@@ -357,9 +337,7 @@ export default function LatestPostsEdit( { attributes, setAttributes } ) {
 					<RangeControl
 						label={ __( 'Columns' ) }
 						value={ columns }
-						onChange={ ( value ) =>
-							setAttributes( { columns: value } )
-						}
+						onChange={ createUpdater( 'columns' ) }
 						min={ 2 }
 						max={
 							! hasPosts


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

I’m playing with a React hook that could simplify handling block attributes in the block’s edit components. We discussed the idea with @adamziel at CloudFest Hackathon 2022 when we worked on Bento components integration with custom blocks. We noticed a lot of places where very similar callback were defined, example:

https://github.com/Bento-WordPress/gutenberg-bento/blob/fbf3152d889219d0bef3f87e182852b50e37acb8/src/accordion-section/edit.js#L29-L39

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

The assumption is that it would improve the developer experience for more complex blocks that use subcomponents. There are two issues:
-  You need to pass down `attributes` and `setAttributes`. Sometimes, it goes more than one level down. This also makes code reuse harder as you need to ensure that both the attribute and `setAttributes` need to be propagated through all components in the tree.
- `onChange` (and other) callbacks usually have similar code. They tend to be defined inline, which causes re-renders. The same applies to the `attributes` object - whenever it changes then child components re-render, too. 

The hope here is that we can address those pain points and help to write more performant code out of the box.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

New React hook.

### useBlockAttribute

Returns the current value for a block attribute and a function to update it. It automatically detects the block instance that should get updated based on the block edit context.

_Usage_

```jsx
import { useBlockAttribute } from '@wordpress/block-editor';
import { TextControl } from '@wordpress/components';

function ContentInput() {
    const [ content, setContent ] = useBlockAttribute( 'content' );
    return (
        <TextControl value={ content } onChange={ setContent ) } />
    );
}
```

_Parameters_

-   _name_ `string`: Attribute name.
-   _transform_ `[Function]`: Optional transform function applied when setting attribute value.

_Returns_

-   `[*, Function]`: A tuple of the current attribute value and a function to update it.