### PR TITLE
[Site Editor]: Fix Reakit warning on creation template component

### DIFF
--- a/packages/edit-site/src/components/add-new-template/add-custom-template-modal.js
+++ b/packages/edit-site/src/components/add-new-template/add-custom-template-modal.js
@@ -158,6 +158,7 @@ function SuggestionList( { entityForSuggestions, onSelect } ) {
 					{ ...composite }
 					role="listbox"
 					className="edit-site-custom-template-modal__suggestions_list"
+					aria-label={ __( 'Suggestions list' ) }
 				>
 					{ suggestions.map( ( suggestion ) => (
 						<SuggestionListItem


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?

This PR fixes the warning coming from a missing `aria-label` in adding new templates in site editor
<!-- In a few words, what is the PR actually doing? -->
