### PR TITLE
Fix: the description text of block movers for horizontal movement

### DIFF
--- a/packages/block-editor/src/components/block-mover/mover-description.js
+++ b/packages/block-editor/src/components/block-mover/mover-description.js
@@ -349,7 +349,7 @@ export function getMultiBlockMoverDescription(
 
 		if ( movementDirection === 'right' ) {
 			return __(
-				'Blocks cannot be moved right as they are already are at the leftmost position'
+				'Blocks cannot be moved right as they are already are at the rightmost position'
 			);
 		}
 	}

--- a/packages/block-editor/src/components/block-mover/mover-description.js
+++ b/packages/block-editor/src/components/block-mover/mover-description.js
@@ -3,6 +3,21 @@
  */
 import { __, _n, sprintf, isRTL } from '@wordpress/i18n';
 
+const getMovementDirection = ( moveDirection, orientation ) => {
+	if ( moveDirection === 'up' ) {
+		if ( orientation === 'horizontal' ) {
+			return isRTL() ? 'right' : 'left';
+		}
+		return 'up';
+	} else if ( moveDirection === 'down' ) {
+		if ( orientation === 'horizontal' ) {
+			return isRTL() ? 'left' : 'right';
+		}
+		return 'down';
+	}
+	return null;
+};
+
 /**
  * Return a label for the block movement controls depending on block position.
  *
@@ -30,21 +45,6 @@ export function getBlockMoverDescription(
 ) {
 	const position = firstIndex + 1;
 
-	const getMovementDirection = ( moveDirection ) => {
-		if ( moveDirection === 'up' ) {
-			if ( orientation === 'horizontal' ) {
-				return isRTL() ? 'right' : 'left';
-			}
-			return 'up';
-		} else if ( moveDirection === 'down' ) {
-			if ( orientation === 'horizontal' ) {
-				return isRTL() ? 'left' : 'right';
-			}
-			return 'down';
-		}
-		return null;
-	};
-
 	if ( selectedCount > 1 ) {
 		return getMultiBlockMoverDescription(
 			selectedCount,
@@ -52,7 +52,7 @@ export function getBlockMoverDescription(
 			isFirst,
 			isLast,
 			dir,
-			getMovementDirection
+			orientation
 		);
 	}
 
@@ -66,13 +66,13 @@ export function getBlockMoverDescription(
 
 	if ( dir > 0 && ! isLast ) {
 		// Moving down.
-		const movementDirection = getMovementDirection( 'down' );
+		const movementDirection = getMovementDirection( 'down', orientation );
 
 		if ( movementDirection === 'down' ) {
 			return sprintf(
 				// translators: 1: Type of block (i.e. Text, Image etc), 2: Position of selected block, 3: New position
 				__(
-					'Move %1$s block from position %2$d down to position %3$d'
+					`Move %1$s block from position %2$d down to position %3$d`
 				),
 				type,
 				position,
@@ -107,7 +107,7 @@ export function getBlockMoverDescription(
 
 	if ( dir > 0 && isLast ) {
 		// Moving down, and is the last item.
-		const movementDirection = getMovementDirection( 'down' );
+		const movementDirection = getMovementDirection( 'down', orientation );
 
 		if ( movementDirection === 'down' ) {
 			return sprintf(
@@ -142,7 +142,7 @@ export function getBlockMoverDescription(
 
 	if ( dir < 0 && ! isFirst ) {
 		// Moving up.
-		const movementDirection = getMovementDirection( 'up' );
+		const movementDirection = getMovementDirection( 'up', orientation );
 
 		if ( movementDirection === 'up' ) {
 			return sprintf(
@@ -181,7 +181,7 @@ export function getBlockMoverDescription(
 
 	if ( dir < 0 && isFirst ) {
 		// Moving up, and is the first item.
-		const movementDirection = getMovementDirection( 'up' );
+		const movementDirection = getMovementDirection( 'up', orientation );
 
 		if ( movementDirection === 'up' ) {
 			return sprintf(
@@ -218,14 +218,14 @@ export function getBlockMoverDescription(
 /**
  * Return a label for the block movement controls depending on block position.
  *
- * @param {number}   selectedCount        Number of blocks selected.
- * @param {number}   firstIndex           The index (position - 1) of the first block selected.
- * @param {boolean}  isFirst              This is the first block.
- * @param {boolean}  isLast               This is the last block.
- * @param {number}   dir                  Direction of movement (> 0 is considered to be going
- *                                        down, < 0 is up).
- * @param {Function} getMovementDirection Returns movement direction (string) based on the orientation
- *                                        of the selected blocks
+ * @param {number}  selectedCount Number of blocks selected.
+ * @param {number}  firstIndex    The index (position - 1) of the first block selected.
+ * @param {boolean} isFirst       This is the first block.
+ * @param {boolean} isLast        This is the last block.
+ * @param {number}  dir           Direction of movement (> 0 is considered to be going
+ *                                down, < 0 is up).
+ * @param {string}  orientation   The orientation of the block movers, vertical or
+ *                                horizontal.
  *
  * @return {string} Label for the block movement controls.
  */
@@ -235,13 +235,13 @@ export function getMultiBlockMoverDescription(
 	isFirst,
 	isLast,
 	dir,
-	getMovementDirection
+	orientation
 ) {
 	const position = firstIndex + 1;
 
 	if ( dir < 0 && ! isFirst ) {
 		// moving up
-		const movementDirection = getMovementDirection( 'up' );
+		const movementDirection = getMovementDirection( 'up', orientation );
 
 		if ( movementDirection === 'up' ) {
 			return sprintf(
@@ -272,7 +272,7 @@ export function getMultiBlockMoverDescription(
 
 	if ( dir < 0 && isFirst ) {
 		// moving up, and the selected blocks are the first item
-		const movementDirection = getMovementDirection( 'up' );
+		const movementDirection = getMovementDirection( 'up', orientation );
 
 		if ( movementDirection === 'up' ) {
 			return __(
@@ -289,7 +289,7 @@ export function getMultiBlockMoverDescription(
 
 	if ( dir > 0 && ! isLast ) {
 		// moving down
-		const movementDirection = getMovementDirection( 'down' );
+		const movementDirection = getMovementDirection( 'down', orientation );
 
 		if ( movementDirection === 'down' ) {
 			return sprintf(
@@ -320,7 +320,7 @@ export function getMultiBlockMoverDescription(
 
 	if ( dir > 0 && isLast ) {
 		// moving down, and the selected blocks are the last item
-		const movementDirection = getMovementDirection( 'down' );
+		const movementDirection = getMovementDirection( 'down', orientation );
 
 		if ( movementDirection === 'down' ) {
 			return __(

--- a/packages/block-editor/src/components/block-mover/mover-description.js
+++ b/packages/block-editor/src/components/block-mover/mover-description.js
@@ -1,7 +1,7 @@
 /**
  * WordPress dependencies
  */
-import { __, _n, sprintf, isRTL } from '@wordpress/i18n';
+import { __, sprintf, isRTL } from '@wordpress/i18n';
 
 const getMovementDirection = ( moveDirection, orientation ) => {
 	if ( moveDirection === 'up' ) {
@@ -246,11 +246,7 @@ export function getMultiBlockMoverDescription(
 		if ( movementDirection === 'up' ) {
 			return sprintf(
 				// translators: 1: Number of selected blocks, 2: Position of selected blocks
-				_n(
-					'Move %1$d block from position %2$d up by one place',
-					'Move %1$d blocks from position %2$d up by one place',
-					selectedCount
-				),
+				__( 'Move %1$d blocks from position %2$d up by one place' ),
 				selectedCount,
 				position
 			);
@@ -259,11 +255,7 @@ export function getMultiBlockMoverDescription(
 		if ( movementDirection === 'left' ) {
 			return sprintf(
 				// translators: 1: Number of selected blocks, 2: Position of selected blocks
-				_n(
-					'Move %1$d block from position %2$d left by one place',
-					'Move %1$d blocks from position %2$d left by one place',
-					selectedCount
-				),
+				__( 'Move %1$d blocks from position %2$d left by one place' ),
 				selectedCount,
 				position
 			);
@@ -294,11 +286,7 @@ export function getMultiBlockMoverDescription(
 		if ( movementDirection === 'down' ) {
 			return sprintf(
 				// translators: 1: Number of selected blocks, 2: Position of selected blocks
-				_n(
-					'Move %1$d block from position %2$d down by one place',
-					'Move %1$d blocks from position %2$d down by one place',
-					selectedCount
-				),
+				__( 'Move %1$d blocks from position %2$d down by one place' ),
 				selectedCount,
 				position
 			);
@@ -307,11 +295,7 @@ export function getMultiBlockMoverDescription(
 		if ( movementDirection === 'right' ) {
 			return sprintf(
 				// translators: 1: Number of selected blocks, 2: Position of selected blocks
-				_n(
-					'Move %1$d block from position %2$d right by one place',
-					'Move %1$d blocks from position %2$d right by one place',
-					selectedCount
-				),
+				__( 'Move %1$d blocks from position %2$d right by one place' ),
 				selectedCount,
 				position
 			);

--- a/packages/block-editor/src/components/block-mover/mover-description.js
+++ b/packages/block-editor/src/components/block-mover/mover-description.js
@@ -239,6 +239,11 @@ export function getMultiBlockMoverDescription(
 ) {
 	const position = firstIndex + 1;
 
+	if ( isFirst && isLast ) {
+		// All blocks are selected
+		return __( 'All blocks are selected, and cannot be moved' );
+	}
+
 	if ( dir > 0 && ! isLast ) {
 		// moving down
 		const movementDirection = getMovementDirection( 'down', orientation );

--- a/packages/block-editor/src/components/block-mover/mover-description.js
+++ b/packages/block-editor/src/components/block-mover/mover-description.js
@@ -72,7 +72,7 @@ export function getBlockMoverDescription(
 			return sprintf(
 				// translators: 1: Type of block (i.e. Text, Image etc), 2: Position of selected block, 3: New position
 				__(
-					`Move %1$s block from position %2$d down to position %3$d`
+					'Move %1$s block from position %2$d down to position %3$d'
 				),
 				type,
 				position,

--- a/packages/block-editor/src/components/block-mover/mover-description.js
+++ b/packages/block-editor/src/components/block-mover/mover-description.js
@@ -51,7 +51,8 @@ export function getBlockMoverDescription(
 			firstIndex,
 			isFirst,
 			isLast,
-			dir
+			dir,
+			getMovementDirection
 		);
 	}
 
@@ -217,12 +218,14 @@ export function getBlockMoverDescription(
 /**
  * Return a label for the block movement controls depending on block position.
  *
- * @param {number}  selectedCount Number of blocks selected.
- * @param {number}  firstIndex    The index (position - 1) of the first block selected.
- * @param {boolean} isFirst       This is the first block.
- * @param {boolean} isLast        This is the last block.
- * @param {number}  dir           Direction of movement (> 0 is considered to be going
- *                                down, < 0 is up).
+ * @param {number}   selectedCount        Number of blocks selected.
+ * @param {number}   firstIndex           The index (position - 1) of the first block selected.
+ * @param {boolean}  isFirst              This is the first block.
+ * @param {boolean}  isLast               This is the last block.
+ * @param {number}   dir                  Direction of movement (> 0 is considered to be going
+ *                                        down, < 0 is up).
+ * @param {Function} getMovementDirection Returns movement direction (string) based on the orientation
+ *                                        of the selected blocks
  *
  * @return {string} Label for the block movement controls.
  */
@@ -231,43 +234,104 @@ export function getMultiBlockMoverDescription(
 	firstIndex,
 	isFirst,
 	isLast,
-	dir
+	dir,
+	getMovementDirection
 ) {
 	const position = firstIndex + 1;
 
-	if ( dir < 0 && isFirst ) {
-		return __( 'Blocks cannot be moved up as they are already at the top' );
-	}
-
-	if ( dir > 0 && isLast ) {
-		return __(
-			'Blocks cannot be moved down as they are already at the bottom'
-		);
-	}
-
 	if ( dir < 0 && ! isFirst ) {
-		return sprintf(
-			// translators: 1: Number of selected blocks, 2: Position of selected blocks
-			_n(
-				'Move %1$d block from position %2$d up by one place',
-				'Move %1$d blocks from position %2$d up by one place',
-				selectedCount
-			),
-			selectedCount,
-			position
-		);
+		// moving up
+		const movementDirection = getMovementDirection( 'up' );
+
+		if ( movementDirection === 'up' ) {
+			return sprintf(
+				// translators: 1: Number of selected blocks, 2: Position of selected blocks
+				_n(
+					'Move %1$d block from position %2$d up by one place',
+					'Move %1$d blocks from position %2$d up by one place',
+					selectedCount
+				),
+				selectedCount,
+				position
+			);
+		}
+
+		if ( movementDirection === 'left' ) {
+			return sprintf(
+				// translators: 1: Number of selected blocks, 2: Position of selected blocks
+				_n(
+					'Move %1$d block from position %2$d left by one place',
+					'Move %1$d blocks from position %2$d left by one place',
+					selectedCount
+				),
+				selectedCount,
+				position
+			);
+		}
+	}
+
+	if ( dir < 0 && isFirst ) {
+		// moving up, and the selected blocks are the first item
+		const movementDirection = getMovementDirection( 'up' );
+
+		if ( movementDirection === 'up' ) {
+			return __(
+				'Blocks cannot be moved up as they are already at the top'
+			);
+		}
+
+		if ( movementDirection === 'left' ) {
+			return __(
+				'Blocks cannot be moved left as they are already are at the leftmost position'
+			);
+		}
 	}
 
 	if ( dir > 0 && ! isLast ) {
-		return sprintf(
-			// translators: 1: Number of selected blocks, 2: Position of selected blocks
-			_n(
-				'Move %1$d block from position %2$d down by one place',
-				'Move %1$d blocks from position %2$d down by one place',
-				selectedCount
-			),
-			selectedCount,
-			position
-		);
+		// moving down
+		const movementDirection = getMovementDirection( 'down' );
+
+		if ( movementDirection === 'down' ) {
+			return sprintf(
+				// translators: 1: Number of selected blocks, 2: Position of selected blocks
+				_n(
+					'Move %1$d block from position %2$d down by one place',
+					'Move %1$d blocks from position %2$d down by one place',
+					selectedCount
+				),
+				selectedCount,
+				position
+			);
+		}
+
+		if ( movementDirection === 'right' ) {
+			return sprintf(
+				// translators: 1: Number of selected blocks, 2: Position of selected blocks
+				_n(
+					'Move %1$d block from position %2$d right by one place',
+					'Move %1$d blocks from position %2$d right by one place',
+					selectedCount
+				),
+				selectedCount,
+				position
+			);
+		}
+	}
+
+	if ( dir > 0 && isLast ) {
+		// moving down, and the selected blocks are the last item
+		const movementDirection = getMovementDirection( 'down' );
+
+		if ( movementDirection === 'down' ) {
+			return __(
+				'Blocks cannot be moved down as they are already at the bottom'
+			);
+		}
+
+		if ( movementDirection === 'right' ) {
+			return __(
+				'Blocks cannot be moved right as they are already are at the rightmost position'
+			);
+		}
 	}
 }

--- a/packages/block-editor/src/components/block-mover/mover-description.js
+++ b/packages/block-editor/src/components/block-mover/mover-description.js
@@ -239,14 +239,14 @@ export function getMultiBlockMoverDescription(
 ) {
 	const position = firstIndex + 1;
 
-	if ( dir < 0 && ! isFirst ) {
-		// moving up
-		const movementDirection = getMovementDirection( 'up', orientation );
+	if ( dir > 0 && ! isLast ) {
+		// moving down
+		const movementDirection = getMovementDirection( 'down', orientation );
 
-		if ( movementDirection === 'up' ) {
+		if ( movementDirection === 'down' ) {
 			return sprintf(
 				// translators: 1: Number of selected blocks, 2: Position of selected blocks
-				__( 'Move %1$d blocks from position %2$d up by one place' ),
+				__( 'Move %1$d blocks from position %2$d down by one place' ),
 				selectedCount,
 				position
 			);
@@ -256,37 +256,6 @@ export function getMultiBlockMoverDescription(
 			return sprintf(
 				// translators: 1: Number of selected blocks, 2: Position of selected blocks
 				__( 'Move %1$d blocks from position %2$d left by one place' ),
-				selectedCount,
-				position
-			);
-		}
-	}
-
-	if ( dir < 0 && isFirst ) {
-		// moving up, and the selected blocks are the first item
-		const movementDirection = getMovementDirection( 'up', orientation );
-
-		if ( movementDirection === 'up' ) {
-			return __(
-				'Blocks cannot be moved up as they are already at the top'
-			);
-		}
-
-		if ( movementDirection === 'left' ) {
-			return __(
-				'Blocks cannot be moved left as they are already are at the leftmost position'
-			);
-		}
-	}
-
-	if ( dir > 0 && ! isLast ) {
-		// moving down
-		const movementDirection = getMovementDirection( 'down', orientation );
-
-		if ( movementDirection === 'down' ) {
-			return sprintf(
-				// translators: 1: Number of selected blocks, 2: Position of selected blocks
-				__( 'Move %1$d blocks from position %2$d down by one place' ),
 				selectedCount,
 				position
 			);
@@ -312,9 +281,70 @@ export function getMultiBlockMoverDescription(
 			);
 		}
 
+		if ( movementDirection === 'left' ) {
+			return __(
+				'Blocks cannot be moved left as they are already are at the leftmost position'
+			);
+		}
+
 		if ( movementDirection === 'right' ) {
 			return __(
 				'Blocks cannot be moved right as they are already are at the rightmost position'
+			);
+		}
+	}
+
+	if ( dir < 0 && ! isFirst ) {
+		// moving up
+		const movementDirection = getMovementDirection( 'up', orientation );
+
+		if ( movementDirection === 'up' ) {
+			return sprintf(
+				// translators: 1: Number of selected blocks, 2: Position of selected blocks
+				__( 'Move %1$d blocks from position %2$d up by one place' ),
+				selectedCount,
+				position
+			);
+		}
+
+		if ( movementDirection === 'left' ) {
+			return sprintf(
+				// translators: 1: Number of selected blocks, 2: Position of selected blocks
+				__( 'Move %1$d blocks from position %2$d left by one place' ),
+				selectedCount,
+				position
+			);
+		}
+
+		if ( movementDirection === 'right' ) {
+			return sprintf(
+				// translators: 1: Number of selected blocks, 2: Position of selected blocks
+				__( 'Move %1$d blocks from position %2$d right by one place' ),
+				selectedCount,
+				position
+			);
+		}
+	}
+
+	if ( dir < 0 && isFirst ) {
+		// moving up, and the selected blocks are the first item
+		const movementDirection = getMovementDirection( 'up', orientation );
+
+		if ( movementDirection === 'up' ) {
+			return __(
+				'Blocks cannot be moved up as they are already at the top'
+			);
+		}
+
+		if ( movementDirection === 'left' ) {
+			return __(
+				'Blocks cannot be moved left as they are already are at the leftmost position'
+			);
+		}
+
+		if ( movementDirection === 'right' ) {
+			return __(
+				'Blocks cannot be moved right as they are already are at the leftmost position'
 			);
 		}
 	}

--- a/packages/block-editor/src/components/block-mover/test/mover-description.js
+++ b/packages/block-editor/src/components/block-mover/test/mover-description.js
@@ -183,9 +183,7 @@ describe( 'block mover', () => {
 					true,
 					negativeDirection
 				)
-			).toBe(
-				'Blocks cannot be moved up as they are already at the top'
-			);
+			).toBe( 'All blocks are selected, and cannot be moved' );
 		} );
 
 		it( 'generates a title for a selection of blocks at the bottom', () => {
@@ -238,9 +236,7 @@ describe( 'block mover', () => {
 					negativeDirection,
 					'horizontal'
 				)
-			).toBe(
-				'Blocks cannot be moved left as they are already are at the leftmost position'
-			);
+			).toBe( 'All blocks are selected, and cannot be moved' );
 		} );
 
 		it( 'indicates that blocks cannot be moved right when the orientation is horizontal and the block is the last block', () => {

--- a/packages/block-editor/src/components/block-mover/test/mover-description.js
+++ b/packages/block-editor/src/components/block-mover/test/mover-description.js
@@ -201,5 +201,61 @@ describe( 'block mover', () => {
 				'Blocks cannot be moved down as they are already at the bottom'
 			);
 		} );
+
+		it( 'indicates that blocks can be moved left when the orientation is horizontal and the direction is negative', () => {
+			expect(
+				getMultiBlockMoverDescription(
+					4,
+					1,
+					false,
+					true,
+					negativeDirection,
+					'horizontal'
+				)
+			).toBe( 'Move 4 blocks from position 2 left by one place' );
+		} );
+
+		it( 'indicates that blocks can be moved right when the orientation is horizontal and the direction is positive', () => {
+			expect(
+				getMultiBlockMoverDescription(
+					4,
+					0,
+					true,
+					false,
+					positiveDirection,
+					'horizontal'
+				)
+			).toBe( 'Move 4 blocks from position 1 right by one place' );
+		} );
+
+		it( 'indicates that blocks cannot be moved left when the orientation is horizontal and a selection of blocks at the left', () => {
+			expect(
+				getMultiBlockMoverDescription(
+					4,
+					1,
+					true,
+					true,
+					negativeDirection,
+					'horizontal'
+				)
+			).toBe(
+				'Blocks cannot be moved left as they are already are at the leftmost position'
+			);
+		} );
+
+		it( 'indicates that blocks cannot be moved right when the orientation is horizontal and the block is the last block', () => {
+			expect(
+				getMultiBlockMoverDescription(
+					4,
+					2,
+					false,
+					true,
+					positiveDirection,
+					'horizontal'
+				)
+			).toBe(
+				'Blocks cannot be moved right as they are already are at the rightmost position'
+			);
+		} );
 	} );
 } );


### PR DESCRIPTION
Clone of #32337
Fix: #25158

This PR is newly created to reflect the latest trunk in #32337 sent from `thisissandip:fix/block-mover-description-text`.

## Description
The button to move the block has the following two accessibility attributes:

- `aria-label`: indicates the direction to move
- `aria-describedby`: Indicates where to move to or whether to move

This PR fixes a problem where the text indicated by `aria-describedby` does not consider the orientation if the layout orientation is horizontal.

## How has this been tested?
1. Select a block that can be moved horizontally (eg. Buttons Block)
2. Add 2 to 3 blocks to move them around
3. Select multiple blocks
4. Inspect the block mover buttons
5. The correct descriptive text should be displayed according to the orientation of the blocks

## Screenshots 

### Horizontal layout

#### Select the first two blocks

![horizontal_1](https://user-images.githubusercontent.com/54422211/178873727-eefc751f-7717-4631-adbd-22c337b66ede.png)

#### Select the two blocks in between

![horizontal_2](https://user-images.githubusercontent.com/54422211/178873825-3e99bc49-5e1f-4833-84af-c22362e25540.png)

#### Select the last two blocks

![horizontal_3](https://user-images.githubusercontent.com/54422211/178873906-7c2bf092-db9e-4f91-8802-016136390f3d.png)

### Vertical layout

#### Select the first two blocks

![vertical_1](https://user-images.githubusercontent.com/54422211/178873993-8d517996-9984-47b7-9b9f-7065f4c87f7f.png)

#### Select the two blocks in between

![vertical_2](https://user-images.githubusercontent.com/54422211/178874097-c701170e-d1f4-490d-95d1-c5f0412425c8.png)

#### Select the last two blocks

![vertical_3](https://user-images.githubusercontent.com/54422211/178874177-ceefe3a2-796a-419d-8d48-5680406a223f.png)

## Types of changes
Bug fix

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
