### PR TITLE
Update to reflect change in Documentation label.

### DIFF
--- a/bin/plugin/commands/changelog.js
+++ b/bin/plugin/commands/changelog.js
@@ -89,7 +89,7 @@ const LABEL_TYPE_MAPPING = {
 	'[Type] Enhancement': 'Enhancements',
 	'[Type] New API': 'New APIs',
 	'[Type] Performance': 'Performance',
-	'[Type] Documentation': 'Documentation',
+	'[Type] Developer Documentation': 'Documentation',
 	'[Type] Code Quality': 'Code Quality',
 	'[Type] Security': 'Security',
 };
@@ -143,7 +143,7 @@ const LABEL_FEATURE_MAPPING = {
 	'Automated Testing': 'Testing',
 	'CSS Styling': 'CSS & Styling',
 	'developer-docs': 'Documentation',
-	'[Type] Documentation': 'Documentation',
+	'[Type] Developer Documentation': 'Documentation',
 	'Global Styles': 'Global Styles',
 	'[Type] Build Tooling': 'Build Tooling',
 	'npm Packages': 'npm Packages',

--- a/bin/plugin/commands/test/fixtures/pull-requests.json
+++ b/bin/plugin/commands/test/fixtures/pull-requests.json
@@ -1697,7 +1697,7 @@
 				"id": 567484057,
 				"node_id": "MDU6TGFiZWw1Njc0ODQwNTc=",
 				"url": "https://api.github.com/repos/WordPress/gutenberg/labels/[Type]%20Documentation",
-				"name": "[Type] Documentation",
+				"name": "[Type] Developer Documentation",
 				"color": "bfd4f2",
 				"default": false,
 				"description": ""
@@ -3822,7 +3822,7 @@
 				"id": 567484057,
 				"node_id": "MDU6TGFiZWw1Njc0ODQwNTc=",
 				"url": "https://api.github.com/repos/WordPress/gutenberg/labels/[Type]%20Documentation",
-				"name": "[Type] Documentation",
+				"name": "[Type] Developer Documentation",
 				"color": "bfd4f2",
 				"default": false,
 				"description": ""
@@ -4409,7 +4409,7 @@
 				"id": 567484057,
 				"node_id": "MDU6TGFiZWw1Njc0ODQwNTc=",
 				"url": "https://api.github.com/repos/WordPress/gutenberg/labels/[Type]%20Documentation",
-				"name": "[Type] Documentation",
+				"name": "[Type] Developer Documentation",
 				"color": "bfd4f2",
 				"default": false,
 				"description": ""
@@ -6218,7 +6218,7 @@
 				"id": 567484057,
 				"node_id": "MDU6TGFiZWw1Njc0ODQwNTc=",
 				"url": "https://api.github.com/repos/WordPress/gutenberg/labels/[Type]%20Documentation",
-				"name": "[Type] Documentation",
+				"name": "[Type] Developer Documentation",
 				"color": "bfd4f2",
 				"default": false,
 				"description": ""
@@ -6413,7 +6413,7 @@
 				"id": 567484057,
 				"node_id": "MDU6TGFiZWw1Njc0ODQwNTc=",
 				"url": "https://api.github.com/repos/WordPress/gutenberg/labels/[Type]%20Documentation",
-				"name": "[Type] Documentation",
+				"name": "[Type] Developer Documentation",
 				"color": "bfd4f2",
 				"default": false,
 				"description": ""
@@ -6988,7 +6988,7 @@
 				"id": 567484057,
 				"node_id": "MDU6TGFiZWw1Njc0ODQwNTc=",
 				"url": "https://api.github.com/repos/WordPress/gutenberg/labels/[Type]%20Documentation",
-				"name": "[Type] Documentation",
+				"name": "[Type] Developer Documentation",
 				"color": "bfd4f2",
 				"default": false,
 				"description": ""
@@ -7144,7 +7144,7 @@
 				"id": 567484057,
 				"node_id": "MDU6TGFiZWw1Njc0ODQwNTc=",
 				"url": "https://api.github.com/repos/WordPress/gutenberg/labels/[Type]%20Documentation",
-				"name": "[Type] Documentation",
+				"name": "[Type] Developer Documentation",
 				"color": "bfd4f2",
 				"default": false,
 				"description": ""
@@ -7692,7 +7692,7 @@
 				"id": 567484057,
 				"node_id": "MDU6TGFiZWw1Njc0ODQwNTc=",
 				"url": "https://api.github.com/repos/WordPress/gutenberg/labels/[Type]%20Documentation",
-				"name": "[Type] Documentation",
+				"name": "[Type] Developer Documentation",
 				"color": "bfd4f2",
 				"default": false,
 				"description": ""
@@ -9522,7 +9522,7 @@
 				"id": 567484057,
 				"node_id": "MDU6TGFiZWw1Njc0ODQwNTc=",
 				"url": "https://api.github.com/repos/WordPress/gutenberg/labels/[Type]%20Documentation",
-				"name": "[Type] Documentation",
+				"name": "[Type] Developer Documentation",
 				"color": "bfd4f2",
 				"default": false,
 				"description": ""
@@ -12900,7 +12900,7 @@
 				"id": 567484057,
 				"node_id": "MDU6TGFiZWw1Njc0ODQwNTc=",
 				"url": "https://api.github.com/repos/WordPress/gutenberg/labels/[Type]%20Documentation",
-				"name": "[Type] Documentation",
+				"name": "[Type] Developer Documentation",
 				"color": "bfd4f2",
 				"default": false,
 				"description": ""
@@ -13613,7 +13613,7 @@
 				"id": 567484057,
 				"node_id": "MDU6TGFiZWw1Njc0ODQwNTc=",
 				"url": "https://api.github.com/repos/WordPress/gutenberg/labels/[Type]%20Documentation",
-				"name": "[Type] Documentation",
+				"name": "[Type] Developer Documentation",
 				"color": "bfd4f2",
 				"default": false,
 				"description": ""


### PR DESCRIPTION
Earlier this week, the labels for [documentation were updated: ](https://wordpress.slack.com/archives/C02QB2JS7/p1657545760021909)

- New Label: `[Type] User Documentation] `- applied after the plugin release to flad user-facing changes that need updated in End User Documentation
- The old label [Type] Documentation] has been update to read `[Type] Developer Documentation`.

## What?
This PR changed _[Type] Documentation_ references to _[Type] Developer Documentation_
in the two files:
- Running the changelog.js creates the changelog
- Test script uses the example list in pull-requests.json file to create the snapshot., to test agains. 

## Why?
The release Changelog lost its Documentation section.

## How?
updated the strings

