### PR TITLE
Scripts: exit error code 1 when status value is null

### DIFF
--- a/packages/scripts/CHANGELOG.md
+++ b/packages/scripts/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Bug Fix
+
+-   Fix the incorrect exit error code when status missing in `webpack` call for `build` and `start` commands ([#42396](https://github.com/WordPress/gutenberg/pull/42396)).
+
 ## 23.3.0 (2022-06-15)
 
 ### Enhancements

--- a/packages/scripts/scripts/build.js
+++ b/packages/scripts/scripts/build.js
@@ -31,4 +31,4 @@ process.env.WP_SRC_DIRECTORY = hasArgInCLI( '--webpack-src-dir' )
 const { status } = spawn( resolveBin( 'webpack' ), getWebpackArgs(), {
 	stdio: 'inherit',
 } );
-process.exit( status || EXIT_ERROR_CODE );
+process.exit( status === null ? EXIT_ERROR_CODE : status );

--- a/packages/scripts/scripts/build.js
+++ b/packages/scripts/scripts/build.js
@@ -8,6 +8,7 @@ const { sync: resolveBin } = require( 'resolve-bin' );
  * Internal dependencies
  */
 const { getWebpackArgs, hasArgInCLI, getArgFromCLI } = require( '../utils' );
+const EXIT_ERROR_CODE = 1;
 
 process.env.NODE_ENV = process.env.NODE_ENV || 'production';
 
@@ -30,4 +31,4 @@ process.env.WP_SRC_DIRECTORY = hasArgInCLI( '--webpack-src-dir' )
 const { status } = spawn( resolveBin( 'webpack' ), getWebpackArgs(), {
 	stdio: 'inherit',
 } );
-process.exit( status );
+process.exit( status || EXIT_ERROR_CODE );

--- a/packages/scripts/scripts/start.js
+++ b/packages/scripts/scripts/start.js
@@ -8,6 +8,7 @@ const { sync: resolveBin } = require( 'resolve-bin' );
  * Internal dependencies
  */
 const { getArgFromCLI, getWebpackArgs, hasArgInCLI } = require( '../utils' );
+const EXIT_ERROR_CODE = 1;
 
 if ( hasArgInCLI( '--webpack-no-externals' ) ) {
 	process.env.WP_NO_EXTERNALS = true;
@@ -36,4 +37,4 @@ const { status } = spawn(
 		stdio: 'inherit',
 	}
 );
-process.exit( status );
+process.exit( status === null ? EXIT_ERROR_CODE : status );


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->
Fixes: #41712

## What?
<!-- In a few words, what is the PR actually doing? -->
Introduced a new variable `EXIT_ERROR_CODE` to be used in case the status is `null`

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
We use `wp-scripts build` to create the webpack build in a CI pipeline.
The CI pipeline relies on the return code to determine the job status.
If the build fails with the "JavaScript heap out of memory" error, the wp-scripts build returns status 0.
This causes the next pipeline stage to run, which leads to the deployment of a corrupted build artifact.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
This is an environment-specific issue in Linux. In my local mac, it works fine. I have added an OR condition if `status` is null then return `EXIT_ERROR_CODE`. In the case of success `status` value must be `0`.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->

1. Checkout to the PR branch
2. Try `NODE_OPTIONS="--max_old_space_size=64" yarn wp-scripts build` in Linux environment
3. Verify the exit status code is `1`
`
## Screenshots or screencast <!-- if applicable --> NA
