### PR TITLE
Add setting to display rich text toolbar inline

### DIFF
--- a/packages/block-editor/src/components/observe-typing/index.js
+++ b/packages/block-editor/src/components/observe-typing/index.js
@@ -53,13 +53,10 @@ function isKeyDownEligibleForStartTyping( event ) {
  * element.
  */
 export function useMouseMoveTypingReset() {
-	const { isTyping, hasInlineToolbar } = useSelect( ( select ) => {
-		const { isTyping: _isTyping, getSettings } = select( blockEditorStore );
-		return {
-			isTyping: _isTyping(),
-			hasInlineToolbar: getSettings().hasInlineToolbar,
-		};
-	}, [] );
+	const isTyping = useSelect(
+		( select ) => select( blockEditorStore ).isTyping(),
+		[]
+	);
 	const { stopTyping } = useDispatch( blockEditorStore );
 
 	return useRefEffect(
@@ -69,8 +66,6 @@ export function useMouseMoveTypingReset() {
 			}
 
 			const { ownerDocument } = node;
-			const { defaultView } = ownerDocument;
-			const selection = defaultView.getSelection();
 			let lastClientX;
 			let lastClientY;
 
@@ -81,10 +76,6 @@ export function useMouseMoveTypingReset() {
 			 */
 			function stopTypingOnMouseMove( event ) {
 				const { clientX, clientY } = event;
-
-				if ( hasInlineToolbar && ! selection.isCollapsed ) {
-					return;
-				}
 
 				// We need to check that the mouse really moved because Safari
 				// triggers mousemove events when shift or ctrl are pressed.
@@ -250,29 +241,12 @@ export function useTypingObserver() {
 				startTyping();
 			}
 
-			function startTypingOnSelection() {
-				if ( ! selection.isCollapsed ) {
-					startTyping();
-				}
-			}
-
 			node.addEventListener( 'keypress', startTypingInTextField );
 			node.addEventListener( 'keydown', startTypingInTextField );
-
-			if ( hasInlineToolbar ) {
-				ownerDocument.addEventListener(
-					'selectionchange',
-					startTypingOnSelection
-				);
-			}
 
 			return () => {
 				node.removeEventListener( 'keypress', startTypingInTextField );
 				node.removeEventListener( 'keydown', startTypingInTextField );
-				ownerDocument.removeEventListener(
-					'selectionchange',
-					startTypingOnSelection
-				);
 			};
 		},
 		[ isTyping, hasInlineToolbar, startTyping, stopTyping ]

--- a/packages/block-editor/src/components/observe-typing/index.js
+++ b/packages/block-editor/src/components/observe-typing/index.js
@@ -124,11 +124,7 @@ export function useTypingObserver() {
 	}, [] );
 	const { startTyping, stopTyping } = useDispatch( blockEditorStore );
 
-	const ref1 = useMouseMoveTypingReset( {
-		isTyping,
-		hasInlineToolbar,
-		stopTyping,
-	} );
+	const ref1 = useMouseMoveTypingReset();
 	const ref2 = useRefEffect(
 		( node ) => {
 			const { ownerDocument } = node;

--- a/packages/block-editor/src/components/rich-text/format-toolbar-container.js
+++ b/packages/block-editor/src/components/rich-text/format-toolbar-container.js
@@ -36,7 +36,7 @@ function InlineSelectionToolbar( { value, anchorRef, activeFormats } ) {
 function InlineToolbar( { anchorRef } ) {
 	return (
 		<Popover
-			position="bottom center"
+			position="top center"
 			focusOnMount={ false }
 			anchorRef={ anchorRef }
 			className="block-editor-rich-text__inline-format-toolbar"

--- a/packages/block-editor/src/components/rich-text/format-toolbar-container.js
+++ b/packages/block-editor/src/components/rich-text/format-toolbar-container.js
@@ -2,21 +2,34 @@
  * WordPress dependencies
  */
 import { Popover, ToolbarGroup } from '@wordpress/components';
+import { useSelect } from '@wordpress/data';
+import { isCollapsed, useAnchorRef } from '@wordpress/rich-text';
 
 /**
  * Internal dependencies
  */
 import BlockControls from '../block-controls';
 import FormatToolbar from './format-toolbar';
+import { store as blockEditorStore } from '../../store';
 
-const FormatToolbarContainer = ( { inline, anchorRef } ) => {
-	if ( inline ) {
+const FormatToolbarContainer = ( { inline, anchorRef, value } ) => {
+	const hasInlineToolbar = useSelect(
+		( select ) => select( blockEditorStore ).getSettings().hasInlineToolbar,
+		[]
+	);
+	const selectionRef = useAnchorRef( { ref: anchorRef, value } );
+
+	if ( hasInlineToolbar || inline ) {
+		if ( hasInlineToolbar && isCollapsed( value ) ) {
+			return null;
+		}
+
 		// Render in popover.
 		return (
 			<Popover
 				position="top center"
 				focusOnMount={ false }
-				anchorRef={ anchorRef }
+				anchorRef={ hasInlineToolbar ? selectionRef : anchorRef }
 				className="block-editor-rich-text__inline-format-toolbar"
 				__unstableSlotName="block-toolbar"
 			>
@@ -28,6 +41,7 @@ const FormatToolbarContainer = ( { inline, anchorRef } ) => {
 			</Popover>
 		);
 	}
+
 	// Render regular toolbar.
 	return (
 		<BlockControls group="inline">

--- a/packages/block-editor/src/components/rich-text/format-toolbar-container.js
+++ b/packages/block-editor/src/components/rich-text/format-toolbar-container.js
@@ -3,7 +3,12 @@
  */
 import { Popover, ToolbarGroup } from '@wordpress/components';
 import { useSelect } from '@wordpress/data';
-import { isCollapsed, useAnchorRef } from '@wordpress/rich-text';
+import {
+	isCollapsed,
+	getActiveFormats,
+	useAnchorRef,
+	store as richTextStore,
+} from '@wordpress/rich-text';
 
 /**
  * Internal dependencies
@@ -17,17 +22,33 @@ const FormatToolbarContainer = ( { inline, anchorRef, value } ) => {
 		( select ) => select( blockEditorStore ).getSettings().hasInlineToolbar,
 		[]
 	);
-	const selectionRef = useAnchorRef( { ref: anchorRef, value } );
+	const activeFormats = getActiveFormats( value );
+	const lastFormat = activeFormats[ activeFormats.length - 1 ];
+	const lastFormatType = lastFormat?.type;
+	const settings = useSelect(
+		( select ) =>
+			select( richTextStore ).getFormatType( lastFormatType ) || {},
+		[ lastFormatType ]
+	);
+	const selectionRef = useAnchorRef( {
+		ref: anchorRef,
+		value,
+		settings,
+	} );
 
 	if ( hasInlineToolbar || inline ) {
-		if ( hasInlineToolbar && isCollapsed( value ) ) {
+		if (
+			hasInlineToolbar &&
+			isCollapsed( value ) &&
+			! activeFormats.length
+		) {
 			return null;
 		}
 
 		// Render in popover.
 		return (
 			<Popover
-				position="top center"
+				position="bottom center"
 				focusOnMount={ false }
 				anchorRef={ hasInlineToolbar ? selectionRef : anchorRef }
 				className="block-editor-rich-text__inline-format-toolbar"

--- a/packages/block-editor/src/components/rich-text/format-toolbar-container.js
+++ b/packages/block-editor/src/components/rich-text/format-toolbar-container.js
@@ -17,17 +17,11 @@ import BlockControls from '../block-controls';
 import FormatToolbar from './format-toolbar';
 import { store as blockEditorStore } from '../../store';
 
-const FormatToolbarContainer = ( { inline, anchorRef, value } ) => {
-	const hasInlineToolbar = useSelect(
-		( select ) => select( blockEditorStore ).getSettings().hasInlineToolbar,
-		[]
-	);
-	const activeFormats = getActiveFormats( value );
+function InlineSelectionToolbar( { value, anchorRef, activeFormats } ) {
 	const lastFormat = activeFormats[ activeFormats.length - 1 ];
 	const lastFormatType = lastFormat?.type;
 	const settings = useSelect(
-		( select ) =>
-			select( richTextStore ).getFormatType( lastFormatType ) || {},
+		( select ) => select( richTextStore ).getFormatType( lastFormatType ),
 		[ lastFormatType ]
 	);
 	const selectionRef = useAnchorRef( {
@@ -36,30 +30,50 @@ const FormatToolbarContainer = ( { inline, anchorRef, value } ) => {
 		settings,
 	} );
 
-	if ( hasInlineToolbar || inline ) {
-		if (
-			hasInlineToolbar &&
-			isCollapsed( value ) &&
-			! activeFormats.length
-		) {
+	return <InlineToolbar anchorRef={ selectionRef } />;
+}
+
+function InlineToolbar( { anchorRef } ) {
+	return (
+		<Popover
+			position="bottom center"
+			focusOnMount={ false }
+			anchorRef={ anchorRef }
+			className="block-editor-rich-text__inline-format-toolbar"
+			__unstableSlotName="block-toolbar"
+		>
+			<div className="block-editor-rich-text__inline-format-toolbar-group">
+				<ToolbarGroup>
+					<FormatToolbar />
+				</ToolbarGroup>
+			</div>
+		</Popover>
+	);
+}
+
+const FormatToolbarContainer = ( { inline, anchorRef, value } ) => {
+	const hasInlineToolbar = useSelect(
+		( select ) => select( blockEditorStore ).getSettings().hasInlineToolbar,
+		[]
+	);
+
+	if ( inline ) {
+		return <InlineToolbar anchorRef={ anchorRef } />;
+	}
+
+	if ( hasInlineToolbar ) {
+		const activeFormats = getActiveFormats( value );
+
+		if ( isCollapsed( value ) && ! activeFormats.length ) {
 			return null;
 		}
 
-		// Render in popover.
 		return (
-			<Popover
-				position="bottom center"
-				focusOnMount={ false }
-				anchorRef={ hasInlineToolbar ? selectionRef : anchorRef }
-				className="block-editor-rich-text__inline-format-toolbar"
-				__unstableSlotName="block-toolbar"
-			>
-				<div className="block-editor-rich-text__inline-format-toolbar-group">
-					<ToolbarGroup>
-						<FormatToolbar />
-					</ToolbarGroup>
-				</div>
-			</Popover>
+			<InlineSelectionToolbar
+				anchorRef={ anchorRef }
+				value={ value }
+				activeFormats={ activeFormats }
+			/>
 		);
 	}
 

--- a/packages/block-editor/src/components/rich-text/index.js
+++ b/packages/block-editor/src/components/rich-text/index.js
@@ -344,6 +344,7 @@ function RichTextWrapper(
 				<FormatToolbarContainer
 					inline={ inlineToolbar }
 					anchorRef={ anchorRef }
+					value={ value }
 				/>
 			) }
 			<TagName

--- a/packages/edit-post/src/components/preferences-modal/index.js
+++ b/packages/edit-post/src/components/preferences-modal/index.js
@@ -124,13 +124,6 @@ export default function EditPostPreferencesModal() {
 								label={ __( 'Reduce the interface' ) }
 							/>
 							<EnableFeature
-								featureName="inlineToolbar"
-								help={ __(
-									'Only show the rich text toolbar when selecting text.'
-								) }
-								label={ __( 'Inline toolbar' ) }
-							/>
-							<EnableFeature
 								featureName="themeStyles"
 								help={ __(
 									'Make the editor look like your theme.'

--- a/packages/edit-post/src/components/preferences-modal/index.js
+++ b/packages/edit-post/src/components/preferences-modal/index.js
@@ -124,6 +124,13 @@ export default function EditPostPreferencesModal() {
 								label={ __( 'Reduce the interface' ) }
 							/>
 							<EnableFeature
+								featureName="inlineToolbar"
+								help={ __(
+									'Only show the rich text toolbar when selecting text.'
+								) }
+								label={ __( 'Inline toolbar' ) }
+							/>
+							<EnableFeature
 								featureName="themeStyles"
 								help={ __(
 									'Make the editor look like your theme.'

--- a/packages/edit-post/src/editor.js
+++ b/packages/edit-post/src/editor.js
@@ -39,6 +39,7 @@ function Editor( {
 		hasFixedToolbar,
 		focusMode,
 		hasReducedUI,
+		hasInlineToolbar,
 		hasThemeStyles,
 		post,
 		preferredStyleVariations,
@@ -84,6 +85,7 @@ function Editor( {
 					__experimentalGetPreviewDeviceType() !== 'Desktop',
 				focusMode: isFeatureActive( 'focusMode' ),
 				hasReducedUI: isFeatureActive( 'reducedUI' ),
+				hasInlineToolbar: isFeatureActive( 'inlineToolbar' ),
 				hasThemeStyles: isFeatureActive( 'themeStyles' ),
 				preferredStyleVariations: select( preferencesStore ).get(
 					'core/edit-post',
@@ -116,6 +118,7 @@ function Editor( {
 			hasFixedToolbar,
 			focusMode,
 			hasReducedUI,
+			hasInlineToolbar,
 
 			// This is marked as experimental to give time for the quick inserter to mature.
 			__experimentalSetIsInserterOpened: setIsInserterOpened,

--- a/packages/editor/src/components/provider/use-block-editor-settings.js
+++ b/packages/editor/src/components/provider/use-block-editor-settings.js
@@ -136,6 +136,7 @@ function useBlockEditorSettings( settings, hasTemplate ) {
 				'generateAnchors',
 				'hasFixedToolbar',
 				'hasReducedUI',
+				'hasInlineToolbar',
 				'imageDefaultSize',
 				'imageDimensions',
 				'imageEditing',

--- a/packages/rich-text/README.md
+++ b/packages/rich-text/README.md
@@ -213,6 +213,19 @@ _Returns_
 
 -   `RichTextFormat|undefined`: Active format object of the specified type, or undefined.
 
+### getActiveFormats
+
+Gets the all format objects at the start of the selection.
+
+_Parameters_
+
+-   _value_ `RichTextValue`: Value to inspect.
+-   _EMPTY_ACTIVE_FORMATS_ `Array`: Array to return if there are no active formats.
+
+_Returns_
+
+-   `RichTextFormatList`: Active format objects.
+
 ### getActiveObject
 
 Gets the active object, if there is any.

--- a/packages/rich-text/src/index.js
+++ b/packages/rich-text/src/index.js
@@ -3,6 +3,7 @@ export { applyFormat } from './apply-format';
 export { concat } from './concat';
 export { create } from './create';
 export { getActiveFormat } from './get-active-format';
+export { getActiveFormats } from './get-active-formats';
 export { getActiveObject } from './get-active-object';
 export { getTextContent } from './get-text-content';
 export { isListRootSelected as __unstableIsListRootSelected } from './is-list-root-selected';


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?

Adds a setting to display the rich text toolbar inline, meaning next to selected text when there is selection.

![inline-toolbar-test](https://user-images.githubusercontent.com/4710635/178792495-d5858f2a-d82d-4d4c-b33f-5116d1d8a39a.gif)



## Why?

This can be automatically enabled when distraction free writing is enabled (#41740).
This option makes sense on its own too for people that prefer this interface style. It might even make sense to do this by default in the future. The rich text button is not really useful to be display all of the time.

## How?

With `useAnchorRef` it's easy to render the toolbar at the selection.

## Testing Instructions

Type some text. Try selecting with Shift+Alt+Arrow. The toolbar should appear. Try also selecting with the mouse.

## Screenshots or screencast <!-- if applicable -->
