### PR TITLE
Base Styles: Apply `long-content-fade` gradient from transparent to color

### DIFF
--- a/packages/base-styles/_mixins.scss
+++ b/packages/base-styles/_mixins.scss
@@ -77,7 +77,7 @@
 	}
 
 	@if $direction == "bottom" {
-		background: linear-gradient(to top, rgba($color, 0), $color 90%);
+		background: linear-gradient(to top, transparent, $color 90%);
 		left: $edge;
 		right: $edge;
 		top: $edge;
@@ -86,7 +86,7 @@
 	}
 
 	@if $direction == "top" {
-		background: linear-gradient(to bottom, rgba($color, 0), $color 90%);
+		background: linear-gradient(to bottom, transparent, $color 90%);
 		top: calc(100% - $size);
 		left: $edge;
 		right: $edge;
@@ -95,7 +95,7 @@
 	}
 
 	@if $direction == "left" {
-		background: linear-gradient(to left, rgba($color, 0), $color 90%);
+		background: linear-gradient(to left, transparent, $color 90%);
 		top: $edge;
 		left: $edge;
 		bottom: $edge;
@@ -105,7 +105,7 @@
 	}
 
 	@if $direction == "right" {
-		background: linear-gradient(to right, rgba($color, 0), $color 90%);
+		background: linear-gradient(to right, transparent, $color 90%);
 		top: $edge;
 		bottom: $edge;
 		right: $edge;


### PR DESCRIPTION
## What?

The `long-content-fade` mixin expects the `$color` argument to be in RGB format, that is because it needs a way to get the zero-opacity version of that color.

This was done by interpolating the chosen `$color` (say `#fff`) with a `rgba` call, like `rgba( $color, 0 )`.

## Why?

Though this works fine with raw RGB colors, it won't work with other color formats, nor with CSS variables.

## How?

I'm moving from `rgba( $color, 0 )` to `transparent`, which is essentially the same thing.

It shouldn't make any difference in the front-end, but it will improve the way we write CSS since now we're going to be able to pass other formats of colors, even variables, to that mixin.

`transparent` is [well supported](https://caniuse.com/mdn-css_types_color_transparent), so there's no need to use 5-year-old technology anymore.

## Testing Instructions

Apply [this branch](https://github.com/Automattic/wp-calypso/pull/65560) to Calypso;

Still in Calypso: run `yarn workspace @automattic/search run storybook`. It should open Storybook. Go to the `With Different Color` story, type something in the search input and you should see something like that:

![image](https://user-images.githubusercontent.com/26530524/178795765-d4d1cde2-a50f-4356-bd0f-9fa4f30d1703.png)

Notice how the fading effect at the edge of the search input is gone. This is because I'm using a CSS variable to style the `<Search />` component.

Now, check out this branch in local Gutenberg, run:

```sh
cd <calypso>/node_modules/@wordpress
mv base-styles base-styles-bkp
ln -s <gutenberg>/packages/base-styles base-styles
```

So you have this PR's version of `base-styles` loaded in Calypso. I'm not sure why, but `yarn link` didn't work for me. When you refresh Storybook, you should see:

![image](https://user-images.githubusercontent.com/26530524/178796267-7baf60fd-b65d-4ab0-a631-96a4dc3c9182.png)

Notice how the edges are fading out and it indicates that there are more characters hidden.