### PR TITLE
Fix: Condition bug on BoxControl.

### DIFF
--- a/packages/components/src/box-control/axial-input-controls.js
+++ b/packages/components/src/box-control/axial-input-controls.js
@@ -106,7 +106,7 @@ export default function AxialInputControls( {
 
 	const first = filteredSides[ 0 ];
 	const last = filteredSides[ filteredSides.length - 1 ];
-	const only = first === last;
+	const only = first === last && first;
 
 	return (
 		<Layout


### PR DESCRIPTION
"only"  variable is only used in "isOnly={ only === side }" and given that side is a string the condition is always false. On file packages/components/src/box-control/input-controls.js we have identical code and we see only defined as "first === last && first" so I think in packages/components/src/box-control/axial-input-controls.js it should be the same.
