### PR TITLE
ComboboxControl: add unit tests

### DIFF
--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -12,6 +12,7 @@
 -   Refactor `FocalPointPicker` to function component ([#39168](https://github.com/WordPress/gutenberg/pull/39168)).
 -   `Guide`: use `code` instead of `keyCode` for keyboard events ([#43604](https://github.com/WordPress/gutenberg/pull/43604/)).
 -   `Navigation`: use `code` instead of `keyCode` for keyboard events ([#43644](https://github.com/WordPress/gutenberg/pull/43644/)).
+-   `ComboboxControl`: Add unit tests ([#42403](https://github.com/WordPress/gutenberg/pull/42403)).
 
 ## 20.0.0 (2022-08-24)
 

--- a/packages/components/src/combobox-control/test/index.js
+++ b/packages/components/src/combobox-control/test/index.js
@@ -179,4 +179,31 @@ describe( 'ComboboxControl', () => {
 		expect( onChangeSpy ).toHaveBeenCalledWith( targetOption.value );
 		expect( input ).toHaveValue( targetOption.name );
 	} );
+
+	it( 'should select the correct option from a search', async () => {
+		const user = setupUser();
+		const targetOption = timezones[ 13 ];
+		const searchString = targetOption.label.substring( 0, 11 );
+		const onChangeSpy = jest.fn();
+		render(
+			<TestComboboxControl
+				label={ defaultLabelText }
+				onChange={ onChangeSpy }
+			/>
+		);
+		const input = getInput( defaultLabelText );
+
+		// Pressing tab selects the input and shows the options
+		await user.tab();
+
+		// Type enough characters to ensure a predictable search result
+		await user.keyboard( searchString );
+
+		// Pressing Enter/Return selects the currently focused option
+		await user.keyboard( '{Enter}' );
+
+		expect( onChangeSpy ).toHaveBeenCalledTimes( 1 );
+		expect( onChangeSpy ).toHaveBeenCalledWith( targetOption.value );
+		expect( input ).toHaveValue( targetOption.name );
+	} );
 } );

--- a/packages/components/src/combobox-control/test/index.js
+++ b/packages/components/src/combobox-control/test/index.js
@@ -53,6 +53,10 @@ const getLabel = ( labelText ) => screen.getByText( labelText );
 const getInput = ( name ) => screen.getByRole( 'combobox', { name } );
 const getOption = ( name ) => screen.getByRole( 'option', { name } );
 const getAllOptions = () => screen.getAllByRole( 'option' );
+const setTargetOption = ( index ) => {
+	const searchString = timezones[ index ].label.substring( 0, 11 );
+	return { searchString, ...timezones[ index ] };
+};
 const setupUser = () =>
 	userEvent.setup( {
 		advanceTimers: jest.advanceTimersByTime,
@@ -121,7 +125,7 @@ describe( 'ComboboxControl', () => {
 
 	it( 'should select the correct option via click events', async () => {
 		const user = setupUser();
-		const targetOption = timezones[ 2 ];
+		const targetOption = setTargetOption( 2 );
 		const onChangeSpy = jest.fn();
 		render(
 			<TestComboboxControl
@@ -145,7 +149,7 @@ describe( 'ComboboxControl', () => {
 	it( 'should select the correct option via keypress events', async () => {
 		const user = setupUser();
 		const targetIndex = 4;
-		const targetOption = timezones[ targetIndex ];
+		const targetOption = setTargetOption( targetIndex );
 		const onChangeSpy = jest.fn();
 		render(
 			<TestComboboxControl
@@ -173,8 +177,7 @@ describe( 'ComboboxControl', () => {
 
 	it( 'should select the correct option from a search', async () => {
 		const user = setupUser();
-		const targetOption = timezones[ 13 ];
-		const searchString = targetOption.label.substring( 0, 11 );
+		const targetOption = setTargetOption( 13 );
 		const onChangeSpy = jest.fn();
 		render(
 			<TestComboboxControl
@@ -188,7 +191,7 @@ describe( 'ComboboxControl', () => {
 		await user.tab();
 
 		// Type enough characters to ensure a predictable search result
-		await user.keyboard( searchString );
+		await user.keyboard( targetOption.searchString );
 
 		// Pressing Enter/Return selects the currently focused option
 		await user.keyboard( '{Enter}' );
@@ -201,8 +204,7 @@ describe( 'ComboboxControl', () => {
 	it( 'should process multiple entries in a single session', async () => {
 		const user = setupUser();
 		const unmatchedString = 'Mordor';
-		const targetOption = timezones[ 6 ];
-		const searchString = targetOption.label.substring( 0, 11 );
+		const targetOption = setTargetOption( 6 );
 		const onChangeSpy = jest.fn();
 		render(
 			<TestComboboxControl
@@ -242,12 +244,12 @@ describe( 'ComboboxControl', () => {
 		} );
 
 		// Run a second search with a valid string.
-		await user.keyboard( searchString );
+		await user.keyboard( targetOption.searchString );
 		const validSearchRenderedOptions = getAllOptions();
 
 		// Find option that match the search string.
 		const matches = timezones.filter( ( option ) =>
-			option.label.includes( searchString )
+			option.label.includes( targetOption.searchString )
 		);
 
 		// Confirm the rendered options match the provided dataset based on the current string.

--- a/packages/components/src/combobox-control/test/index.js
+++ b/packages/components/src/combobox-control/test/index.js
@@ -15,44 +15,39 @@ import { useState } from '@wordpress/element';
 import ComboboxControl from '../';
 
 const timezones = [
-	{ name: 'Greenwich Mean Time', abbreviation: 'GMT' },
-	{ name: 'Universal Coordinated Time', abbreviation: 'UTC' },
-	{ name: 'European Central Time', abbreviation: 'ECT' },
-	{ name: '(Arabic) Egypt Standard Time', abbreviation: 'ART' },
-	{ name: 'Eastern African Time', abbreviation: 'EAT' },
-	{ name: 'Middle East Time', abbreviation: 'MET' },
-	{ name: 'Near East Time', abbreviation: 'NET' },
-	{ name: 'Pakistan Lahore Time', abbreviation: 'PLT' },
-	{ name: 'India Standard Time', abbreviation: 'IST' },
-	{ name: 'Bangladesh Standard Time', abbreviation: 'BST' },
-	{ name: 'Vietnam Standard Time', abbreviation: 'VST' },
-	{ name: 'China Taiwan Time', abbreviation: 'CTT' },
-	{ name: 'Japan Standard Time', abbreviation: 'JST' },
-	{ name: 'Australia Central Time', abbreviation: 'ACT' },
-	{ name: 'Australia Eastern Time', abbreviation: 'AET' },
-	{ name: 'Solomon Standard Time', abbreviation: 'SST' },
-	{ name: 'New Zealand Standard Time', abbreviation: 'NST' },
-	{ name: 'Midway Islands Time', abbreviation: 'MIT' },
-	{ name: 'Hawaii Standard Time', abbreviation: 'HST' },
-	{ name: 'Alaska Standard Time', abbreviation: 'AST' },
-	{ name: 'Pacific Standard Time', abbreviation: 'PST' },
-	{ name: 'Phoenix Standard Time', abbreviation: 'PNT' },
-	{ name: 'Mountain Standard Time', abbreviation: 'MST' },
-	{ name: 'Central Standard Time', abbreviation: 'CST' },
-	{ name: 'Eastern Standard Time', abbreviation: 'EST' },
-	{ name: 'Indiana Eastern Standard Time', abbreviation: 'IET' },
-	{ name: 'Puerto Rico and US Virgin Islands Time', abbreviation: 'PRT' },
-	{ name: 'Canada Newfoundland Time', abbreviation: 'CNT' },
-	{ name: 'Argentina Standard Time', abbreviation: 'AGT' },
-	{ name: 'Brazil Eastern Time', abbreviation: 'BET' },
-	{ name: 'Central African Time', abbreviation: 'CAT' },
+	{ label: 'Greenwich Mean Time', value: 'GMT' },
+	{ label: 'Universal Coordinated Time', value: 'UTC' },
+	{ label: 'European Central Time', value: 'ECT' },
+	{ label: '(Arabic) Egypt Standard Time', value: 'ART' },
+	{ label: 'Eastern African Time', value: 'EAT' },
+	{ label: 'Middle East Time', value: 'MET' },
+	{ label: 'Near East Time', value: 'NET' },
+	{ label: 'Pakistan Lahore Time', value: 'PLT' },
+	{ label: 'India Standard Time', value: 'IST' },
+	{ label: 'Bangladesh Standard Time', value: 'BST' },
+	{ label: 'Vietnam Standard Time', value: 'VST' },
+	{ label: 'China Taiwan Time', value: 'CTT' },
+	{ label: 'Japan Standard Time', value: 'JST' },
+	{ label: 'Australia Central Time', value: 'ACT' },
+	{ label: 'Australia Eastern Time', value: 'AET' },
+	{ label: 'Solomon Standard Time', value: 'SST' },
+	{ label: 'New Zealand Standard Time', value: 'NST' },
+	{ label: 'Midway Islands Time', value: 'MIT' },
+	{ label: 'Hawaii Standard Time', value: 'HST' },
+	{ label: 'Alaska Standard Time', value: 'AST' },
+	{ label: 'Pacific Standard Time', value: 'PST' },
+	{ label: 'Phoenix Standard Time', value: 'PNT' },
+	{ label: 'Mountain Standard Time', value: 'MST' },
+	{ label: 'Central Standard Time', value: 'CST' },
+	{ label: 'Eastern Standard Time', value: 'EST' },
+	{ label: 'Indiana Eastern Standard Time', value: 'IET' },
+	{ label: 'Puerto Rico and US Virgin Islands Time', value: 'PRT' },
+	{ label: 'Canada Newfoundland Time', value: 'CNT' },
+	{ label: 'Argentina Standard Time', value: 'AGT' },
+	{ label: 'Brazil Eastern Time', value: 'BET' },
+	{ label: 'Central African Time', value: 'CAT' },
 ];
-const mapTimezoneOption = ( tz ) => ( {
-	value: tz.abbreviation,
-	label: tz.name,
-} );
 
-const timezoneOptions = timezones.map( mapTimezoneOption );
 const defaultLabelText = 'Select a timezone';
 const getLabel = () => screen.getByText( defaultLabelText );
 const getInput = () => screen.getByRole( 'combobox' );
@@ -71,7 +66,7 @@ describe( 'ComboboxControl', () => {
 					{ ...props }
 					value={ value }
 					label={ defaultLabelText }
-					options={ timezoneOptions }
+					options={ timezones }
 					onChange={ setValue }
 				/>
 				<p data-testid="value-output">{ value }</p>
@@ -117,7 +112,7 @@ describe( 'ComboboxControl', () => {
 		for ( const option of renderedOptions.values() ) {
 			renderedOptionNames.push( option.textContent );
 		}
-		const timezoneNames = timezones.map( ( tz ) => tz.name );
+		const timezoneNames = timezones.map( ( tz ) => tz.label );
 
 		expect( renderedOptionNames ).toEqual( timezoneNames );
 	} );
@@ -130,12 +125,12 @@ describe( 'ComboboxControl', () => {
 		input.focus();
 		await user.click(
 			screen.getByRole( 'option', {
-				name: timezones[ targetIndex ].name,
+				name: timezones[ targetIndex ].label,
 			} )
 		);
 		const currentValue = screen.getByTestId( 'value-output' ).textContent;
 
-		expect( input.value ).toEqual( timezones[ targetIndex ].name );
-		expect( currentValue ).toEqual( timezones[ targetIndex ].abbreviation );
+		expect( input.value ).toEqual( timezones[ targetIndex ].label );
+		expect( currentValue ).toEqual( timezones[ targetIndex ].value );
 	} );
 } );

--- a/packages/components/src/combobox-control/test/index.js
+++ b/packages/components/src/combobox-control/test/index.js
@@ -49,7 +49,7 @@ const timezones = [
 ];
 
 const defaultLabelText = 'Select a timezone';
-const getLabel = () => screen.getByText( defaultLabelText );
+const getLabel = ( labelText ) => screen.getByText( labelText );
 const getInput = ( name ) => screen.getByRole( 'combobox', { name } );
 const getOption = ( name ) => screen.getByRole( 'option', { name } );
 const getAllOptions = () => screen.getAllByRole( 'option' );
@@ -59,7 +59,7 @@ const setupUser = () =>
 	} );
 
 describe( 'ComboboxControl', () => {
-	const TestComboboxControl = ( { onChange, ...props } ) => {
+	const TestComboboxControl = ( { label, onChange, ...props } ) => {
 		const [ value, setValue ] = useState( null );
 		const handleOnChange = ( newValue ) => {
 			setValue( newValue );
@@ -70,7 +70,7 @@ describe( 'ComboboxControl', () => {
 				<ComboboxControl
 					{ ...props }
 					value={ value }
-					label={ defaultLabelText }
+					label={ label }
 					options={ timezones }
 					onChange={ handleOnChange }
 				/>
@@ -79,21 +79,26 @@ describe( 'ComboboxControl', () => {
 	};
 
 	it( 'should render', () => {
-		render( <TestComboboxControl /> );
+		render( <TestComboboxControl label={ defaultLabelText } /> );
 
 		const input = getInput( defaultLabelText );
 		expect( input ).toBeVisible();
 	} );
 
 	it( 'should render with visible label', () => {
-		render( <TestComboboxControl /> );
-		const label = getLabel();
+		render( <TestComboboxControl label={ defaultLabelText } /> );
+		const label = getLabel( defaultLabelText );
 		expect( label ).toBeVisible();
 	} );
 
 	it( 'should render with hidden label', () => {
-		render( <TestComboboxControl hideLabelFromVision={ true } /> );
-		const label = getLabel();
+		render(
+			<TestComboboxControl
+				label={ defaultLabelText }
+				hideLabelFromVision={ true }
+			/>
+		);
+		const label = getLabel( defaultLabelText );
 
 		expect( label ).toBeInTheDocument();
 		expect( label ).toHaveAttribute(
@@ -103,7 +108,7 @@ describe( 'ComboboxControl', () => {
 	} );
 
 	it( 'should render with the correct options', () => {
-		render( <TestComboboxControl /> );
+		render( <TestComboboxControl label={ defaultLabelText } /> );
 
 		getInput( defaultLabelText ).focus();
 
@@ -125,7 +130,12 @@ describe( 'ComboboxControl', () => {
 		const user = setupUser();
 		const targetOption = timezones[ 2 ];
 		const onChangeSpy = jest.fn();
-		render( <TestComboboxControl onChange={ onChangeSpy } /> );
+		render(
+			<TestComboboxControl
+				label={ defaultLabelText }
+				onChange={ onChangeSpy }
+			/>
+		);
 		const input = getInput( defaultLabelText );
 
 		// Clicking on the input shows the options

--- a/packages/components/src/combobox-control/test/index.js
+++ b/packages/components/src/combobox-control/test/index.js
@@ -143,7 +143,7 @@ describe( 'ComboboxControl', () => {
 
 		expect( onChangeSpy ).toHaveBeenCalledTimes( 1 );
 		expect( onChangeSpy ).toHaveBeenCalledWith( targetOption.value );
-		expect( input ).toHaveValue( targetOption.name );
+		expect( input ).toHaveValue( targetOption.label );
 	} );
 
 	it( 'should select the correct option via keypress events', async () => {
@@ -172,7 +172,7 @@ describe( 'ComboboxControl', () => {
 
 		expect( onChangeSpy ).toHaveBeenCalledTimes( 1 );
 		expect( onChangeSpy ).toHaveBeenCalledWith( targetOption.value );
-		expect( input ).toHaveValue( targetOption.name );
+		expect( input ).toHaveValue( targetOption.label );
 	} );
 
 	it( 'should select the correct option from a search', async () => {
@@ -198,7 +198,7 @@ describe( 'ComboboxControl', () => {
 
 		expect( onChangeSpy ).toHaveBeenCalledTimes( 1 );
 		expect( onChangeSpy ).toHaveBeenCalledWith( targetOption.value );
-		expect( input ).toHaveValue( targetOption.name );
+		expect( input ).toHaveValue( targetOption.label );
 	} );
 
 	it( 'should process multiple entries in a single session', async () => {
@@ -263,6 +263,6 @@ describe( 'ComboboxControl', () => {
 
 		expect( onChangeSpy ).toHaveBeenCalledTimes( 1 );
 		expect( onChangeSpy ).toHaveBeenCalledWith( targetOption.value );
-		expect( input ).toHaveValue( targetOption.name );
+		expect( input ).toHaveValue( targetOption.label );
 	} );
 } );

--- a/packages/components/src/combobox-control/test/index.js
+++ b/packages/components/src/combobox-control/test/index.js
@@ -42,15 +42,14 @@ const timezones = [
 	{ name: 'Central African Time', abbreviation: 'CAT' },
 ];
 const mapTimezoneOption = ( tz ) => ( {
-	value: tz.name,
-	label: tz.abbreviation,
+	value: tz.abbreviation,
+	label: tz.name,
 } );
 
 const timezoneOptions = timezones.map( mapTimezoneOption );
 const defaultLabelText = 'Select a timezone';
-const getLabel = ( text = defaultLabelText ) => {
-	return screen.getByText( text );
-};
+const getLabel = () => screen.getByText( defaultLabelText );
+const getInput = () => screen.getByRole( 'combobox' );
 
 describe( 'ComboboxControl', () => {
 	const TestComboboxControl = ( props ) => (
@@ -64,29 +63,48 @@ describe( 'ComboboxControl', () => {
 		</>
 	);
 
-	describe( 'Basic rendering', () => {
-		it( 'should render', () => {
-			render( <TestComboboxControl /> );
+	it( 'should render', () => {
+		render( <TestComboboxControl /> );
 
-			const input = screen.getByRole( 'combobox' );
-			expect( input ).toBeVisible();
-		} );
+		const input = getInput();
+		expect( input ).toBeVisible();
+	} );
 
-		it( 'should render with visible label', () => {
-			render( <TestComboboxControl /> );
-			const label = getLabel();
-			expect( label ).toBeVisible();
-		} );
+	it( 'should render with visible label', () => {
+		render( <TestComboboxControl /> );
+		const label = getLabel();
+		expect( label ).toBeVisible();
+	} );
 
-		it( 'should render with hidden label', () => {
-			render( <TestComboboxControl hideLabelFromVision={ true } /> );
-			const label = getLabel();
+	it( 'should render with hidden label', () => {
+		render( <TestComboboxControl hideLabelFromVision={ true } /> );
+		const label = getLabel();
 
-			expect( label ).toBeInTheDocument();
-			expect( label ).toHaveAttribute(
-				'data-wp-component',
-				'VisuallyHidden'
-			);
-		} );
+		expect( label ).toBeInTheDocument();
+		expect( label ).toHaveAttribute(
+			'data-wp-component',
+			'VisuallyHidden'
+		);
+	} );
+
+	it( 'should render with the correct options', () => {
+		render( <TestComboboxControl /> );
+
+		getInput().focus();
+
+		const renderedOptions = document.querySelectorAll(
+			'.components-combobox-control__suggestions-container ul[role="listbox"] li[role="option"]'
+		);
+
+		expect( renderedOptions.length ).toEqual( timezones.length );
+
+		// Confirm the rendered options match the provided dataset.
+		const renderedOptionNames = [];
+		for ( const option of renderedOptions.values() ) {
+			renderedOptionNames.push( option.textContent );
+		}
+		const timezoneNames = timezones.map( ( tz ) => tz.name );
+
+		expect( renderedOptionNames ).toEqual( timezoneNames );
 	} );
 } );

--- a/packages/components/src/combobox-control/test/index.js
+++ b/packages/components/src/combobox-control/test/index.js
@@ -122,7 +122,9 @@ describe( 'ComboboxControl', () => {
 		// Confirm the rendered options match the provided dataset.
 		expect( renderedOptions ).toHaveLength( timezones.length );
 		renderedOptions.forEach( ( option, optionIndex ) => {
-			expect( option ).toHaveTextContent( timezones[ optionIndex ].name );
+			expect( option ).toHaveTextContent(
+				timezones[ optionIndex ].label
+			);
 		} );
 	} );
 

--- a/packages/components/src/combobox-control/test/index.js
+++ b/packages/components/src/combobox-control/test/index.js
@@ -78,13 +78,6 @@ describe( 'ComboboxControl', () => {
 		);
 	};
 
-	it( 'should render', () => {
-		render( <TestComboboxControl label={ defaultLabelText } /> );
-
-		const input = getInput( defaultLabelText );
-		expect( input ).toBeVisible();
-	} );
-
 	it( 'should render with visible label', () => {
 		render( <TestComboboxControl label={ defaultLabelText } /> );
 		const label = getLabel( defaultLabelText );

--- a/packages/components/src/combobox-control/test/index.js
+++ b/packages/components/src/combobox-control/test/index.js
@@ -216,6 +216,32 @@ describe.each( [
 		expect( input ).toHaveValue( targetOption.label );
 	} );
 
+	it( 'should render aria-live announcement upon selection', async () => {
+		const user = setupUser();
+		const targetOption = setTargetOption( 9 );
+		const onChangeSpy = jest.fn();
+		render(
+			<Component
+				options={ timezones }
+				label={ defaultLabelText }
+				onChange={ onChangeSpy }
+			/>
+		);
+
+		// Pressing tab selects the input and shows the options
+		await user.tab();
+
+		// Type enough characters to ensure a predictable search result
+		await user.keyboard( targetOption.searchString );
+
+		// Pressing Enter/Return selects the currently focused option
+		await user.keyboard( '{Enter}' );
+
+		const itemSelectedAnnouncement = screen.getByText( 'Item selected.' );
+
+		expect( itemSelectedAnnouncement ).toBeInTheDocument();
+	} );
+
 	it( 'should process multiple entries in a single session', async () => {
 		const user = setupUser();
 		const unmatchedString = 'Mordor';

--- a/packages/components/src/combobox-control/test/index.js
+++ b/packages/components/src/combobox-control/test/index.js
@@ -56,10 +56,7 @@ const timezoneOptions = timezones.map( mapTimezoneOption );
 const defaultLabelText = 'Select a timezone';
 const getLabel = () => screen.getByText( defaultLabelText );
 const getInput = () => screen.getByRole( 'combobox' );
-const getRenderedOptions = () =>
-	document.querySelectorAll(
-		'.components-combobox-control__suggestions-container ul[role="listbox"] li[role="option"]'
-	);
+const getRenderedOptions = () => screen.getAllByRole( 'option' );
 
 describe( 'ComboboxControl', () => {
 	// Use real timers to avoid timeout errors from userEvent

--- a/packages/components/src/combobox-control/test/index.js
+++ b/packages/components/src/combobox-control/test/index.js
@@ -148,4 +148,33 @@ describe( 'ComboboxControl', () => {
 		expect( onChangeSpy ).toHaveBeenCalledWith( targetOption.value );
 		expect( input ).toHaveValue( targetOption.name );
 	} );
+
+	it( 'should select the correct option via keypress events', async () => {
+		const user = setupUser();
+		const targetIndex = 4;
+		const targetOption = timezones[ targetIndex ];
+		const onChangeSpy = jest.fn();
+		render(
+			<TestComboboxControl
+				label={ defaultLabelText }
+				onChange={ onChangeSpy }
+			/>
+		);
+		const input = getInput( defaultLabelText );
+
+		// Pressing tab selects the input and shows the options
+		await user.tab();
+
+		// Navigate the options using the down arrow
+		for ( let i = 0; i < targetIndex; i++ ) {
+			await user.keyboard( '{ArrowDown}' );
+		}
+
+		// Pressing Enter/Return selects the currently focused option
+		await user.keyboard( '{Enter}' );
+
+		expect( onChangeSpy ).toHaveBeenCalledTimes( 1 );
+		expect( onChangeSpy ).toHaveBeenCalledWith( targetOption.value );
+		expect( input ).toHaveValue( targetOption.name );
+	} );
 } );

--- a/packages/components/src/combobox-control/test/index.js
+++ b/packages/components/src/combobox-control/test/index.js
@@ -107,10 +107,13 @@ describe( 'ComboboxControl', () => {
 		);
 	} );
 
-	it( 'should render with the correct options', () => {
+	it( 'should render with the correct options', async () => {
+		const user = setupUser();
 		render( <TestComboboxControl label={ defaultLabelText } /> );
+		const input = getInput( defaultLabelText );
 
-		getInput( defaultLabelText ).focus();
+		// Clicking on the input shows the options
+		await user.click( input );
 
 		const renderedOptions = getAllOptions();
 

--- a/packages/components/src/combobox-control/test/index.js
+++ b/packages/components/src/combobox-control/test/index.js
@@ -110,8 +110,6 @@ describe( 'ComboboxControl', () => {
 
 		const renderedOptions = getAllOptions();
 
-		expect( renderedOptions.length ).toEqual( timezones.length );
-
 		// Confirm the rendered options match the provided dataset.
 		expect( renderedOptions ).toHaveLength( timezones.length );
 		renderedOptions.forEach( ( option, optionIndex ) => {

--- a/packages/components/src/combobox-control/test/index.js
+++ b/packages/components/src/combobox-control/test/index.js
@@ -94,6 +94,7 @@ describe.each( [
 			<Component options={ timezones } label={ defaultLabelText } />
 		);
 		const label = getLabel( defaultLabelText );
+		expect( label ).toBeInTheDocument();
 		expect( label ).toBeVisible();
 	} );
 

--- a/packages/components/src/combobox-control/test/index.js
+++ b/packages/components/src/combobox-control/test/index.js
@@ -62,35 +62,45 @@ const setupUser = () =>
 		advanceTimers: jest.advanceTimersByTime,
 	} );
 
-describe( 'ComboboxControl', () => {
-	const TestComboboxControl = ( { label, onChange, ...props } ) => {
-		const [ value, setValue ] = useState( null );
-		const handleOnChange = ( newValue ) => {
-			setValue( newValue );
-			onChange?.( newValue );
-		};
-		return (
-			<>
-				<ComboboxControl
-					{ ...props }
-					value={ value }
-					label={ label }
-					options={ timezones }
-					onChange={ handleOnChange }
-				/>
-			</>
-		);
+const ControlledComboboxControl = ( {
+	value: valueProp,
+	onChange,
+	...props
+} ) => {
+	const [ value, setValue ] = useState( valueProp );
+	const handleOnChange = ( newValue ) => {
+		setValue( newValue );
+		onChange?.( newValue );
 	};
+	return (
+		<>
+			<ComboboxControl
+				{ ...props }
+				value={ value }
+				onChange={ handleOnChange }
+			/>
+		</>
+	);
+};
+
+describe.each( [
+	[ 'uncontrolled', ComboboxControl ],
+	[ 'controlled', ControlledComboboxControl ],
+] )( 'ComboboxControl %s', ( ...modeAndComponent ) => {
+	const [ , Component ] = modeAndComponent;
 
 	it( 'should render with visible label', () => {
-		render( <TestComboboxControl label={ defaultLabelText } /> );
+		render(
+			<Component options={ timezones } label={ defaultLabelText } />
+		);
 		const label = getLabel( defaultLabelText );
 		expect( label ).toBeVisible();
 	} );
 
 	it( 'should render with hidden label', () => {
 		render(
-			<TestComboboxControl
+			<Component
+				options={ timezones }
 				label={ defaultLabelText }
 				hideLabelFromVision={ true }
 			/>
@@ -106,7 +116,9 @@ describe( 'ComboboxControl', () => {
 
 	it( 'should render with the correct options', async () => {
 		const user = setupUser();
-		render( <TestComboboxControl label={ defaultLabelText } /> );
+		render(
+			<Component options={ timezones } label={ defaultLabelText } />
+		);
 		const input = getInput( defaultLabelText );
 
 		// Clicking on the input shows the options
@@ -128,7 +140,8 @@ describe( 'ComboboxControl', () => {
 		const targetOption = setTargetOption( 2 );
 		const onChangeSpy = jest.fn();
 		render(
-			<TestComboboxControl
+			<Component
+				options={ timezones }
 				label={ defaultLabelText }
 				onChange={ onChangeSpy }
 			/>
@@ -152,7 +165,8 @@ describe( 'ComboboxControl', () => {
 		const targetOption = setTargetOption( targetIndex );
 		const onChangeSpy = jest.fn();
 		render(
-			<TestComboboxControl
+			<Component
+				options={ timezones }
 				label={ defaultLabelText }
 				onChange={ onChangeSpy }
 			/>
@@ -180,7 +194,8 @@ describe( 'ComboboxControl', () => {
 		const targetOption = setTargetOption( 13 );
 		const onChangeSpy = jest.fn();
 		render(
-			<TestComboboxControl
+			<Component
+				options={ timezones }
 				label={ defaultLabelText }
 				onChange={ onChangeSpy }
 			/>
@@ -207,7 +222,8 @@ describe( 'ComboboxControl', () => {
 		const targetOption = setTargetOption( 6 );
 		const onChangeSpy = jest.fn();
 		render(
-			<TestComboboxControl
+			<Component
+				options={ timezones }
 				label={ defaultLabelText }
 				onChange={ onChangeSpy }
 			/>

--- a/packages/components/src/combobox-control/test/index.js
+++ b/packages/components/src/combobox-control/test/index.js
@@ -51,7 +51,7 @@ const timezones = [
 const defaultLabelText = 'Select a timezone';
 const getLabel = () => screen.getByText( defaultLabelText );
 const getInput = ( name ) => screen.getByRole( 'combobox', { name } );
-const getRenderedOptions = () => screen.getAllByRole( 'option' );
+const getAllOptions = () => screen.getAllByRole( 'option' );
 const setupUser = () =>
 	userEvent.setup( {
 		advanceTimers: jest.advanceTimersByTime,
@@ -103,7 +103,7 @@ describe( 'ComboboxControl', () => {
 
 		getInput( defaultLabelText ).focus();
 
-		const renderedOptions = getRenderedOptions();
+		const renderedOptions = getAllOptions();
 
 		expect( renderedOptions.length ).toEqual( timezones.length );
 

--- a/packages/components/src/combobox-control/test/index.js
+++ b/packages/components/src/combobox-control/test/index.js
@@ -57,13 +57,12 @@ const defaultLabelText = 'Select a timezone';
 const getLabel = () => screen.getByText( defaultLabelText );
 const getInput = () => screen.getByRole( 'combobox' );
 const getRenderedOptions = () => screen.getAllByRole( 'option' );
-
-describe( 'ComboboxControl', () => {
-	// Use real timers to avoid timeout errors from userEvent
-	beforeEach( () => {
-		jest.useRealTimers();
+const setupUser = () =>
+	userEvent.setup( {
+		advanceTimers: jest.advanceTimersByTime,
 	} );
 
+describe( 'ComboboxControl', () => {
 	const TestComboboxControl = ( props ) => {
 		const [ value, setValue ] = useState( null );
 		return (
@@ -124,11 +123,12 @@ describe( 'ComboboxControl', () => {
 	} );
 
 	it( 'should select the correct option with click', async () => {
+		const user = setupUser();
 		render( <TestComboboxControl /> );
 		const targetIndex = 2;
 		const input = getInput();
 		input.focus();
-		await userEvent.click(
+		await user.click(
 			screen.getByRole( 'option', {
 				name: timezones[ targetIndex ].name,
 			} )

--- a/packages/components/src/combobox-control/test/index.js
+++ b/packages/components/src/combobox-control/test/index.js
@@ -50,7 +50,7 @@ const timezones = [
 
 const defaultLabelText = 'Select a timezone';
 const getLabel = () => screen.getByText( defaultLabelText );
-const getInput = () => screen.getByRole( 'combobox' );
+const getInput = ( name ) => screen.getByRole( 'combobox', { name } );
 const getRenderedOptions = () => screen.getAllByRole( 'option' );
 const setupUser = () =>
 	userEvent.setup( {
@@ -77,7 +77,7 @@ describe( 'ComboboxControl', () => {
 	it( 'should render', () => {
 		render( <TestComboboxControl /> );
 
-		const input = getInput();
+		const input = getInput( defaultLabelText );
 		expect( input ).toBeVisible();
 	} );
 
@@ -101,7 +101,7 @@ describe( 'ComboboxControl', () => {
 	it( 'should render with the correct options', () => {
 		render( <TestComboboxControl /> );
 
-		getInput().focus();
+		getInput( defaultLabelText ).focus();
 
 		const renderedOptions = getRenderedOptions();
 
@@ -121,7 +121,7 @@ describe( 'ComboboxControl', () => {
 		const user = setupUser();
 		render( <TestComboboxControl /> );
 		const targetIndex = 2;
-		const input = getInput();
+		const input = getInput( defaultLabelText );
 		input.focus();
 		await user.click(
 			screen.getByRole( 'option', {

--- a/packages/components/src/combobox-control/test/index.js
+++ b/packages/components/src/combobox-control/test/index.js
@@ -120,13 +120,10 @@ describe( 'ComboboxControl', () => {
 		expect( renderedOptions.length ).toEqual( timezones.length );
 
 		// Confirm the rendered options match the provided dataset.
-		const renderedOptionNames = [];
-		for ( const option of renderedOptions.values() ) {
-			renderedOptionNames.push( option.textContent );
-		}
-		const timezoneNames = timezones.map( ( tz ) => tz.label );
-
-		expect( renderedOptionNames ).toEqual( timezoneNames );
+		expect( renderedOptions ).toHaveLength( timezones.length );
+		renderedOptions.forEach( ( option, optionIndex ) => {
+			expect( option ).toHaveTextContent( timezones[ optionIndex ].name );
+		} );
 	} );
 
 	it( 'should select the correct option via click events', async () => {

--- a/packages/components/src/combobox-control/test/index.js
+++ b/packages/components/src/combobox-control/test/index.js
@@ -1,0 +1,92 @@
+/**
+ * External dependencies
+ */
+import { render, screen } from '@testing-library/react';
+
+/**
+ * Internal dependencies
+ */
+import ComboboxControl from '../';
+
+const timezones = [
+	{ name: 'Greenwich Mean Time', abbreviation: 'GMT' },
+	{ name: 'Universal Coordinated Time', abbreviation: 'UTC' },
+	{ name: 'European Central Time', abbreviation: 'ECT' },
+	{ name: '(Arabic) Egypt Standard Time', abbreviation: 'ART' },
+	{ name: 'Eastern African Time', abbreviation: 'EAT' },
+	{ name: 'Middle East Time', abbreviation: 'MET' },
+	{ name: 'Near East Time', abbreviation: 'NET' },
+	{ name: 'Pakistan Lahore Time', abbreviation: 'PLT' },
+	{ name: 'India Standard Time', abbreviation: 'IST' },
+	{ name: 'Bangladesh Standard Time', abbreviation: 'BST' },
+	{ name: 'Vietnam Standard Time', abbreviation: 'VST' },
+	{ name: 'China Taiwan Time', abbreviation: 'CTT' },
+	{ name: 'Japan Standard Time', abbreviation: 'JST' },
+	{ name: 'Australia Central Time', abbreviation: 'ACT' },
+	{ name: 'Australia Eastern Time', abbreviation: 'AET' },
+	{ name: 'Solomon Standard Time', abbreviation: 'SST' },
+	{ name: 'New Zealand Standard Time', abbreviation: 'NST' },
+	{ name: 'Midway Islands Time', abbreviation: 'MIT' },
+	{ name: 'Hawaii Standard Time', abbreviation: 'HST' },
+	{ name: 'Alaska Standard Time', abbreviation: 'AST' },
+	{ name: 'Pacific Standard Time', abbreviation: 'PST' },
+	{ name: 'Phoenix Standard Time', abbreviation: 'PNT' },
+	{ name: 'Mountain Standard Time', abbreviation: 'MST' },
+	{ name: 'Central Standard Time', abbreviation: 'CST' },
+	{ name: 'Eastern Standard Time', abbreviation: 'EST' },
+	{ name: 'Indiana Eastern Standard Time', abbreviation: 'IET' },
+	{ name: 'Puerto Rico and US Virgin Islands Time', abbreviation: 'PRT' },
+	{ name: 'Canada Newfoundland Time', abbreviation: 'CNT' },
+	{ name: 'Argentina Standard Time', abbreviation: 'AGT' },
+	{ name: 'Brazil Eastern Time', abbreviation: 'BET' },
+	{ name: 'Central African Time', abbreviation: 'CAT' },
+];
+const mapTimezoneOption = ( tz ) => ( {
+	value: tz.name,
+	label: tz.abbreviation,
+} );
+
+const timezoneOptions = timezones.map( mapTimezoneOption );
+const defaultLabelText = 'Select a timezone';
+const getLabel = ( text = defaultLabelText ) => {
+	return screen.getByText( text );
+};
+
+describe( 'ComboboxControl', () => {
+	const TestComboboxControl = ( props ) => (
+		<>
+			<ComboboxControl
+				{ ...props }
+				value={ null }
+				label={ defaultLabelText }
+				options={ timezoneOptions }
+			/>
+		</>
+	);
+
+	describe( 'Basic rendering', () => {
+		it( 'should render', () => {
+			render( <TestComboboxControl /> );
+
+			const input = screen.getByRole( 'combobox' );
+			expect( input ).toBeVisible();
+		} );
+
+		it( 'should render with visible label', () => {
+			render( <TestComboboxControl /> );
+			const label = getLabel();
+			expect( label ).toBeVisible();
+		} );
+
+		it( 'should render with hidden label', () => {
+			render( <TestComboboxControl hideLabelFromVision={ true } /> );
+			const label = getLabel();
+
+			expect( label ).toBeInTheDocument();
+			expect( label ).toHaveAttribute(
+				'data-wp-component',
+				'VisuallyHidden'
+			);
+		} );
+	} );
+} );

--- a/packages/components/src/combobox-control/test/index.js
+++ b/packages/components/src/combobox-control/test/index.js
@@ -53,10 +53,7 @@ const getLabel = ( labelText ) => screen.getByText( labelText );
 const getInput = ( name ) => screen.getByRole( 'combobox', { name } );
 const getOption = ( name ) => screen.getByRole( 'option', { name } );
 const getAllOptions = () => screen.getAllByRole( 'option' );
-const getTargetOption = ( options, index ) => {
-	const searchString = options[ index ].label.substring( 0, 11 );
-	return { searchString, ...options[ index ] };
-};
+const getOptionSearchString = ( option ) => option.label.substring( 0, 11 );
 const setupUser = () =>
 	userEvent.setup( {
 		advanceTimers: jest.advanceTimersByTime,
@@ -138,7 +135,7 @@ describe.each( [
 
 	it( 'should select the correct option via click events', async () => {
 		const user = setupUser();
-		const targetOption = getTargetOption( timezones, 2 );
+		const targetOption = timezones[ 2 ];
 		const onChangeSpy = jest.fn();
 		render(
 			<Component
@@ -163,7 +160,7 @@ describe.each( [
 	it( 'should select the correct option via keypress events', async () => {
 		const user = setupUser();
 		const targetIndex = 4;
-		const targetOption = getTargetOption( timezones, targetIndex );
+		const targetOption = timezones[ targetIndex ];
 		const onChangeSpy = jest.fn();
 		render(
 			<Component
@@ -192,7 +189,7 @@ describe.each( [
 
 	it( 'should select the correct option from a search', async () => {
 		const user = setupUser();
-		const targetOption = getTargetOption( timezones, 13 );
+		const targetOption = timezones[ 13 ];
 		const onChangeSpy = jest.fn();
 		render(
 			<Component
@@ -207,7 +204,7 @@ describe.each( [
 		await user.tab();
 
 		// Type enough characters to ensure a predictable search result
-		await user.keyboard( targetOption.searchString );
+		await user.keyboard( getOptionSearchString( targetOption ) );
 
 		// Pressing Enter/Return selects the currently focused option
 		await user.keyboard( '{Enter}' );
@@ -219,7 +216,7 @@ describe.each( [
 
 	it( 'should render aria-live announcement upon selection', async () => {
 		const user = setupUser();
-		const targetOption = getTargetOption( timezones, 9 );
+		const targetOption = timezones[ 9 ];
 		const onChangeSpy = jest.fn();
 		render(
 			<Component
@@ -233,7 +230,7 @@ describe.each( [
 		await user.tab();
 
 		// Type enough characters to ensure a predictable search result
-		await user.keyboard( targetOption.searchString );
+		await user.keyboard( getOptionSearchString( targetOption ) );
 
 		// Pressing Enter/Return selects the currently focused option
 		await user.keyboard( '{Enter}' );
@@ -248,7 +245,7 @@ describe.each( [
 	it( 'should process multiple entries in a single session', async () => {
 		const user = setupUser();
 		const unmatchedString = 'Mordor';
-		const targetOption = getTargetOption( timezones, 6 );
+		const targetOption = timezones[ 6 ];
 		const onChangeSpy = jest.fn();
 		render(
 			<Component
@@ -289,12 +286,13 @@ describe.each( [
 		} );
 
 		// Run a second search with a valid string.
-		await user.keyboard( targetOption.searchString );
+		const searchString = getOptionSearchString( targetOption );
+		await user.keyboard( searchString );
 		const validSearchRenderedOptions = getAllOptions();
 
 		// Find option that match the search string.
 		const matches = timezones.filter( ( option ) =>
-			option.label.includes( targetOption.searchString )
+			option.label.includes( searchString )
 		);
 
 		// Confirm the rendered options match the provided dataset based on the current string.

--- a/packages/components/src/combobox-control/test/index.js
+++ b/packages/components/src/combobox-control/test/index.js
@@ -53,9 +53,9 @@ const getLabel = ( labelText ) => screen.getByText( labelText );
 const getInput = ( name ) => screen.getByRole( 'combobox', { name } );
 const getOption = ( name ) => screen.getByRole( 'option', { name } );
 const getAllOptions = () => screen.getAllByRole( 'option' );
-const setTargetOption = ( index ) => {
-	const searchString = timezones[ index ].label.substring( 0, 11 );
-	return { searchString, ...timezones[ index ] };
+const getTargetOption = ( options, index ) => {
+	const searchString = options[ index ].label.substring( 0, 11 );
+	return { searchString, ...options[ index ] };
 };
 const setupUser = () =>
 	userEvent.setup( {
@@ -138,7 +138,7 @@ describe.each( [
 
 	it( 'should select the correct option via click events', async () => {
 		const user = setupUser();
-		const targetOption = setTargetOption( 2 );
+		const targetOption = getTargetOption( timezones, 2 );
 		const onChangeSpy = jest.fn();
 		render(
 			<Component
@@ -163,7 +163,7 @@ describe.each( [
 	it( 'should select the correct option via keypress events', async () => {
 		const user = setupUser();
 		const targetIndex = 4;
-		const targetOption = setTargetOption( targetIndex );
+		const targetOption = getTargetOption( timezones, targetIndex );
 		const onChangeSpy = jest.fn();
 		render(
 			<Component
@@ -192,7 +192,7 @@ describe.each( [
 
 	it( 'should select the correct option from a search', async () => {
 		const user = setupUser();
-		const targetOption = setTargetOption( 13 );
+		const targetOption = getTargetOption( timezones, 13 );
 		const onChangeSpy = jest.fn();
 		render(
 			<Component
@@ -219,7 +219,7 @@ describe.each( [
 
 	it( 'should render aria-live announcement upon selection', async () => {
 		const user = setupUser();
-		const targetOption = setTargetOption( 9 );
+		const targetOption = getTargetOption( timezones, 9 );
 		const onChangeSpy = jest.fn();
 		render(
 			<Component
@@ -246,7 +246,7 @@ describe.each( [
 	it( 'should process multiple entries in a single session', async () => {
 		const user = setupUser();
 		const unmatchedString = 'Mordor';
-		const targetOption = setTargetOption( 6 );
+		const targetOption = getTargetOption( timezones, 6 );
 		const onChangeSpy = jest.fn();
 		render(
 			<Component

--- a/packages/components/src/combobox-control/test/index.js
+++ b/packages/components/src/combobox-control/test/index.js
@@ -238,9 +238,11 @@ describe.each( [
 		// Pressing Enter/Return selects the currently focused option
 		await user.keyboard( '{Enter}' );
 
-		const itemSelectedAnnouncement = screen.getByText( 'Item selected.' );
-
-		expect( itemSelectedAnnouncement ).toBeInTheDocument();
+		expect(
+			screen.getByText( 'Item selected.', {
+				selector: '[aria-live]',
+			} )
+		).toBeInTheDocument();
 	} );
 
 	it( 'should process multiple entries in a single session', async () => {


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Add unit tests to the ComboboxControl component

## Why?
Following up on the conversation in #41417 where it was noted this component currently lacks any tests, making it harder to update it with confidence.

## How?
Five tests are currently implemented:
- test basic rendering of the component
- test that the label is visible when expected (the default)
- test that the label is hidden when expected (if `hideLabelFromVision` prop  is `true`)
- test that the correct list of options are rendered
- test that the correct option is selected when clicked

I did plan to add an additional test to validate the correct option is selected via keypresses, but ran into trouble implementing it. I wasn't able to get `userEffect.keyboard()` to register `downarrow` key presses, nor could I get it to simulate hitting `enter`. I was able to simulate typing in part of the option's name, but without `enter` to confirm the selection, the test wasn't viable.

I'm not 100% sure why that is, but I did find that [for some elements, certain keypresses (like arrowdown) aren't fully implemented](https://github.com/testing-library/user-event/issues/843#issuecomment-1068812316). This may be related?

## Testing Instructions
Run `npm run test-unit packages/components/src/combobox-control`

## Screenshots or screencast <!-- if applicable -->
