### PR TITLE
feat: Inserter displays block collections

### DIFF
--- a/packages/block-editor/src/components/block-types-list/index.native.js
+++ b/packages/block-editor/src/components/block-types-list/index.native.js
@@ -107,12 +107,10 @@ export default function BlockTypesList( {
 	const renderListItem = ( { item } ) => {
 		return (
 			<InserterButton
-				{ ...{
-					item,
-					itemWidth,
-					maxWidth,
-					onSelect,
-				} }
+				item={ item }
+				itemWidth={ itemWidth }
+				maxWidth={ maxWidth }
+				onSelect={ onSelect }
 			/>
 		);
 	};

--- a/packages/block-editor/src/components/block-types-list/index.native.js
+++ b/packages/block-editor/src/components/block-types-list/index.native.js
@@ -14,7 +14,8 @@ import {
  * WordPress dependencies
  */
 import { useState, useEffect } from '@wordpress/element';
-import { BottomSheet, InserterButton } from '@wordpress/components';
+import { BottomSheet, Gradient, InserterButton } from '@wordpress/components';
+import { usePreferredColorScheme } from '@wordpress/compose';
 
 /**
  * Internal dependencies
@@ -115,6 +116,12 @@ export default function BlockTypesList( {
 		);
 	};
 
+	const colorScheme = usePreferredColorScheme();
+	const sectionHeaderGradientValue =
+		colorScheme === 'light'
+			? 'linear-gradient(#fff 70%, rgba(255, 255, 255, 0))'
+			: 'linear-gradient(#2e2e2e 70%, rgba(46, 46, 46, 0))';
+
 	const renderSectionHeader = ( { section: { metadata } } ) => {
 		if ( ! metadata?.icon ) {
 			return null;
@@ -122,9 +129,12 @@ export default function BlockTypesList( {
 
 		return (
 			<TouchableWithoutFeedback accessible={ false }>
-				<View style={ styles[ 'block-types-list__section-header' ] }>
+				<Gradient
+					gradientValue={ sectionHeaderGradientValue }
+					style={ styles[ 'block-types-list__section-header' ] }
+				>
 					{ metadata?.icon }
-				</View>
+				</Gradient>
 			</TouchableWithoutFeedback>
 		);
 	};

--- a/packages/block-editor/src/components/block-types-list/index.native.js
+++ b/packages/block-editor/src/components/block-types-list/index.native.js
@@ -4,6 +4,7 @@
 import {
 	Dimensions,
 	FlatList,
+	SectionList,
 	StyleSheet,
 	TouchableWithoutFeedback,
 	View,
@@ -24,7 +25,7 @@ const MIN_COL_NUM = 3;
 
 export default function BlockTypesList( {
 	name,
-	items,
+	sections,
 	onSelect,
 	listProps,
 	initialNumToRender = 3,
@@ -80,33 +81,66 @@ export default function BlockTypesList( {
 		listProps.contentContainerStyle
 	);
 
+	const renderSection = ( { item } ) => {
+		return (
+			<TouchableWithoutFeedback accessible={ false }>
+				<FlatList
+					data={ item.list }
+					key={ `InserterUI-${ name }-${ numberOfColumns }` } // Re-render when numberOfColumns changes.
+					numColumns={ numberOfColumns }
+					ItemSeparatorComponent={ () => (
+						<TouchableWithoutFeedback accessible={ false }>
+							<View
+								style={
+									styles[ 'block-types-list__row-separator' ]
+								}
+							/>
+						</TouchableWithoutFeedback>
+					) }
+					scrollEnabled={ false }
+					renderItem={ renderListItem }
+				/>
+			</TouchableWithoutFeedback>
+		);
+	};
+
+	const renderListItem = ( { item } ) => {
+		return (
+			<InserterButton
+				{ ...{
+					item,
+					itemWidth,
+					maxWidth,
+					onSelect,
+				} }
+			/>
+		);
+	};
+
+	const renderSectionHeader = ( { section: { metadata } } ) => {
+		if ( ! metadata?.icon ) {
+			return null;
+		}
+
+		return (
+			<TouchableWithoutFeedback accessible={ false }>
+				<View style={ styles[ 'block-types-list__section-header' ] }>
+					{ metadata?.icon }
+				</View>
+			</TouchableWithoutFeedback>
+		);
+	};
+
 	return (
-		<FlatList
+		<SectionList
 			onLayout={ onLayout }
-			key={ `InserterUI-${ name }-${ numberOfColumns }` } // Re-render when numberOfColumns changes.
 			testID={ `InserterUI-${ name }` }
 			keyboardShouldPersistTaps="always"
-			numColumns={ numberOfColumns }
-			data={ items }
+			sections={ sections }
 			initialNumToRender={ initialNumToRender }
-			ItemSeparatorComponent={ () => (
-				<TouchableWithoutFeedback accessible={ false }>
-					<View
-						style={ styles[ 'block-types-list__row-separator' ] }
-					/>
-				</TouchableWithoutFeedback>
-			) }
 			keyExtractor={ ( item ) => item.id }
-			renderItem={ ( { item } ) => (
-				<InserterButton
-					{ ...{
-						item,
-						itemWidth,
-						maxWidth,
-						onSelect,
-					} }
-				/>
-			) }
+			renderItem={ renderSection }
+			renderSectionHeader={ renderSectionHeader }
 			{ ...listProps }
 			contentContainerStyle={ {
 				...contentContainerStyle,

--- a/packages/block-editor/src/components/block-types-list/index.native.js
+++ b/packages/block-editor/src/components/block-types-list/index.native.js
@@ -6,6 +6,7 @@ import {
 	FlatList,
 	SectionList,
 	StyleSheet,
+	Text,
 	TouchableWithoutFeedback,
 	View,
 } from 'react-native';
@@ -15,7 +16,10 @@ import {
  */
 import { useState, useEffect } from '@wordpress/element';
 import { BottomSheet, Gradient, InserterButton } from '@wordpress/components';
-import { usePreferredColorScheme } from '@wordpress/compose';
+import {
+	usePreferredColorScheme,
+	usePreferredColorSchemeStyle,
+} from '@wordpress/compose';
 
 /**
  * Internal dependencies
@@ -121,9 +125,13 @@ export default function BlockTypesList( {
 		colorScheme === 'light'
 			? 'linear-gradient(#fff 70%, rgba(255, 255, 255, 0))'
 			: 'linear-gradient(#2e2e2e 70%, rgba(46, 46, 46, 0))';
+	const sectionHeaderTitleStyles = usePreferredColorSchemeStyle(
+		styles[ 'block-types-list__section-header-title' ],
+		styles[ 'block-types-list__section-header-title--dark' ]
+	);
 
 	const renderSectionHeader = ( { section: { metadata } } ) => {
-		if ( ! metadata?.icon ) {
+		if ( ! metadata?.icon || ! metadata?.title ) {
 			return null;
 		}
 
@@ -134,6 +142,9 @@ export default function BlockTypesList( {
 					style={ styles[ 'block-types-list__section-header' ] }
 				>
 					{ metadata?.icon }
+					<Text style={ sectionHeaderTitleStyles }>
+						{ metadata?.title }
+					</Text>
 				</Gradient>
 			</TouchableWithoutFeedback>
 		);

--- a/packages/block-editor/src/components/block-types-list/index.native.js
+++ b/packages/block-editor/src/components/block-types-list/index.native.js
@@ -136,7 +136,6 @@ export default function BlockTypesList( {
 			keyboardShouldPersistTaps="always"
 			sections={ sections }
 			initialNumToRender={ initialNumToRender }
-			keyExtractor={ ( item ) => item.id }
 			renderItem={ renderSection }
 			renderSectionHeader={ renderSectionHeader }
 			{ ...listProps }

--- a/packages/block-editor/src/components/block-types-list/style.native.scss
+++ b/packages/block-editor/src/components/block-types-list/style.native.scss
@@ -17,7 +17,7 @@
 .block-types-list__section-header-title {
 	color: $black;
 	font-size: 16px;
-	margin-left: 0.5rem;
+	margin-left: 10px;
 }
 
 .block-types-list__section-header-title--dark {

--- a/packages/block-editor/src/components/block-types-list/style.native.scss
+++ b/packages/block-editor/src/components/block-types-list/style.native.scss
@@ -15,6 +15,7 @@
 }
 
 .block-types-list__section-header-title {
+	color: $black;
 	font-size: 16px;
 	margin-left: 0.5rem;
 }

--- a/packages/block-editor/src/components/block-types-list/style.native.scss
+++ b/packages/block-editor/src/components/block-types-list/style.native.scss
@@ -5,3 +5,10 @@
 .block-types-list__column {
 	padding: $grid-unit-20;
 }
+
+.block-types-list__section-header {
+	flex-direction: row;
+	justify-content: center;
+	padding-bottom: 16;
+	padding-top: 32;
+}

--- a/packages/block-editor/src/components/block-types-list/style.native.scss
+++ b/packages/block-editor/src/components/block-types-list/style.native.scss
@@ -7,8 +7,18 @@
 }
 
 .block-types-list__section-header {
+	align-items: center;
 	flex-direction: row;
 	justify-content: center;
 	padding-bottom: 16;
 	padding-top: 32;
+}
+
+.block-types-list__section-header-title {
+	font-size: 16px;
+	margin-left: 0.5rem;
+}
+
+.block-types-list__section-header-title--dark {
+	color: $white;
 }

--- a/packages/block-editor/src/components/inserter/block-types-tab.native.js
+++ b/packages/block-editor/src/components/inserter/block-types-tab.native.js
@@ -1,7 +1,6 @@
 /**
  * WordPress dependencies
  */
-import { useSelect } from '@wordpress/data';
 import { useMemo } from '@wordpress/element';
 
 /**
@@ -9,7 +8,6 @@ import { useMemo } from '@wordpress/element';
  */
 import BlockTypesList from '../block-types-list';
 import useClipboardBlock from './hooks/use-clipboard-block';
-import { store as blockEditorStore } from '../../store';
 import useBlockTypeImpressions from './hooks/use-block-type-impressions';
 import { createInserterSection, filterInserterItems } from './utils';
 import useBlockTypesState from './hooks/use-block-types-state';
@@ -17,31 +15,21 @@ import useBlockTypesState from './hooks/use-block-types-state';
 const getBlockNamespace = ( item ) => item.name.split( '/' )[ 0 ];
 
 function BlockTypesTab( { onSelect, rootClientId, listProps } ) {
-	const [ , , collections ] = useBlockTypesState( rootClientId, onSelect );
-	const clipboardBlock = useClipboardBlock( rootClientId );
-
-	const { blockTypes } = useSelect(
-		( select ) => {
-			const { getInserterItems } = select( blockEditorStore );
-			const blockItems = filterInserterItems(
-				getInserterItems( rootClientId )
-			);
-
-			return {
-				blockTypes: clipboardBlock
-					? [ clipboardBlock, ...blockItems ]
-					: blockItems,
-			};
-		},
-		[ rootClientId ]
+	const [ rawBlockTypes, , collections, onSelectItem ] = useBlockTypesState(
+		rootClientId,
+		onSelect
 	);
-
+	const clipboardBlock = useClipboardBlock( rootClientId );
+	const filteredBlockTypes = filterInserterItems( rawBlockTypes );
+	const blockTypes = clipboardBlock
+		? [ clipboardBlock, ...filteredBlockTypes ]
+		: filteredBlockTypes;
 	const { items, trackBlockTypeSelected } =
 		useBlockTypeImpressions( blockTypes );
 
 	const handleSelect = ( ...args ) => {
 		trackBlockTypeSelected( ...args );
-		onSelect( ...args );
+		onSelectItem( ...args );
 	};
 
 	const collectionSections = useMemo( () => {

--- a/packages/block-editor/src/components/inserter/block-types-tab.native.js
+++ b/packages/block-editor/src/components/inserter/block-types-tab.native.js
@@ -15,7 +15,7 @@ import useBlockTypesState from './hooks/use-block-types-state';
 const getBlockNamespace = ( item ) => item.name.split( '/' )[ 0 ];
 
 function BlockTypesTab( { onSelect, rootClientId, listProps } ) {
-	const [ rawBlockTypes, , collections, onSelectItem ] = useBlockTypesState(
+	const [ rawBlockTypes, , collections ] = useBlockTypesState(
 		rootClientId,
 		onSelect
 	);
@@ -29,7 +29,7 @@ function BlockTypesTab( { onSelect, rootClientId, listProps } ) {
 
 	const handleSelect = ( ...args ) => {
 		trackBlockTypeSelected( ...args );
-		onSelectItem( ...args );
+		onSelect( ...args );
 	};
 
 	const collectionSections = useMemo( () => {

--- a/packages/block-editor/src/components/inserter/reusable-blocks-tab.native.js
+++ b/packages/block-editor/src/components/inserter/reusable-blocks-tab.native.js
@@ -8,7 +8,7 @@ import { useSelect } from '@wordpress/data';
  */
 import BlockTypesList from '../block-types-list';
 import { store as blockEditorStore } from '../../store';
-import { filterInserterItems } from './utils';
+import { createInserterSection, filterInserterItems } from './utils';
 
 function ReusableBlocksTab( { onSelect, rootClientId, listProps } ) {
 	const { items } = useSelect(
@@ -23,10 +23,12 @@ function ReusableBlocksTab( { onSelect, rootClientId, listProps } ) {
 		[ rootClientId ]
 	);
 
+	const sections = [ createInserterSection( { key: 'reuseable', items } ) ];
+
 	return (
 		<BlockTypesList
 			name="ReusableBlocks"
-			items={ items }
+			sections={ sections }
 			onSelect={ onSelect }
 			listProps={ listProps }
 		/>

--- a/packages/block-editor/src/components/inserter/search-results.native.js
+++ b/packages/block-editor/src/components/inserter/search-results.native.js
@@ -11,7 +11,7 @@ import BlockTypesList from '../block-types-list';
 import InserterNoResults from './no-results';
 import { store as blockEditorStore } from '../../store';
 import useBlockTypeImpressions from './hooks/use-block-type-impressions';
-import { filterInserterItems } from './utils';
+import { createInserterSection, filterInserterItems } from './utils';
 
 function InserterSearchResults( {
 	filterValue,
@@ -51,7 +51,9 @@ function InserterSearchResults( {
 		<BlockTypesList
 			name="Blocks"
 			initialNumToRender={ isFullScreen ? 10 : 3 }
-			{ ...{ items, onSelect: handleSelect, listProps } }
+			sections={ [ createInserterSection( { key: 'search', items } ) ] }
+			onSelect={ handleSelect }
+			listProps={ listProps }
 		/>
 	);
 }

--- a/packages/block-editor/src/components/inserter/test/block-types-tab.native.js
+++ b/packages/block-editor/src/components/inserter/test/block-types-tab.native.js
@@ -18,6 +18,8 @@ jest.mock( '../hooks/use-clipboard-block' );
 jest.mock( '@wordpress/data/src/components/use-select' );
 
 const selectMock = {
+	getCategories: jest.fn().mockReturnValue( [] ),
+	getCollections: jest.fn().mockReturnValue( [] ),
 	getInserterItems: jest.fn().mockReturnValue( [] ),
 	canInsertBlockType: jest.fn(),
 	getBlockType: jest.fn(),

--- a/packages/block-editor/src/components/inserter/test/utils.native.js
+++ b/packages/block-editor/src/components/inserter/test/utils.native.js
@@ -1,0 +1,37 @@
+/**
+ * Internal dependencies
+ */
+import { createInserterSection } from '../utils';
+
+describe( 'createInserterSection', () => {
+	it( 'returns the expected object shape', () => {
+		const key = 'mock-1';
+		const items = [ 1, 2, 3 ];
+		const metadata = { icon: 'icon-mock', title: 'Title Mock' };
+
+		expect( createInserterSection( { key, metadata, items } ) ).toEqual(
+			expect.objectContaining( {
+				metadata,
+				data: [ { key, list: items } ],
+			} )
+		);
+	} );
+
+	it( 'return always includes metadata', () => {
+		const key = 'mock-1';
+		const items = [ 1, 2, 3 ];
+
+		expect( createInserterSection( { key, items } ) ).toEqual(
+			expect.objectContaining( {
+				metadata: {},
+				data: [ { key, list: items } ],
+			} )
+		);
+	} );
+
+	it( 'requires a unique key', () => {
+		expect( () => {
+			createInserterSection( { items: [ 1, 2, 3 ] } );
+		} ).toThrow( 'A unique key for the section must be provided.' );
+	} );
+} );

--- a/packages/block-editor/src/components/inserter/utils.native.js
+++ b/packages/block-editor/src/components/inserter/utils.native.js
@@ -33,3 +33,10 @@ export function filterInserterItems(
 		blockAllowed( block, { onlyReusable, allowReusable } )
 	);
 }
+
+export function createInserterSection( { key, metadata, items } ) {
+	return {
+		metadata,
+		data: [ { key, list: items } ],
+	};
+}

--- a/packages/block-editor/src/components/inserter/utils.native.js
+++ b/packages/block-editor/src/components/inserter/utils.native.js
@@ -34,7 +34,11 @@ export function filterInserterItems(
 	);
 }
 
-export function createInserterSection( { key, metadata, items } ) {
+export function createInserterSection( { key, metadata = {}, items } ) {
+	if ( ! key ) {
+		throw new Error( 'A unique key for the section must be provided.' );
+	}
+
 	return {
 		metadata,
 		data: [ { key, list: items } ],

--- a/packages/react-native-editor/CHANGELOG.md
+++ b/packages/react-native-editor/CHANGELOG.md
@@ -12,6 +12,7 @@ For each user feature we should also add a importance categorization label  to i
 ## Unreleased
 
 -   [*] Add React Native FastImage [#42009]
+-   [*] Block inserter displays block collections [#42405]
 
 ## 1.79.0
 -   [*] Add 'Insert from URL' option to Video block [#41493]


### PR DESCRIPTION
## Related PRs
* https://github.com/wordpress-mobile/gutenberg-mobile/pull/5024

## What?
Display block type collections created with [`registerBlockCollection`](https://github.com/WordPress/gutenberg/blob/v13.6.0/docs/reference-guides/block-api/block-registration.md#registerblockcollection) within the native block inserter. 

## Why?
Allow additional organization of block types, similar to the web block inserter. 

## How?
Leverage`SectionList` in the `BlockTypesList` component to allow displaying section headers before each block type collection in the inserter. Given that `SectionList` does not support `numColumns`, that property is placed upon the nested `FlatList` rendered for each row of blocks. 

The `BlockTypesTab` and `SearchResults` components now structure their block types data in the form of sections. The former now retrieves the collection sections from the store, before populating each section with the relevant block type. 

## Testing Instructions

<details><summary>Self-hosted site displays zero collections</summary>

1. Open the native editor for a self-hosted site. 
2. Open the block inserter. 
3. Scroll to the bottom of the inserter. 
4. Verify there is no collection of blocks found at the bottom of the list. 
5. Tap a block. 
6. Verify the block is inserted to the content as expected. 

</details>

<details><summary>Jetpack-connected site displays a Jetpack collection</summary>

1. Open the native editor for a Jetpack-connected site. 
2. Open the block inserter. 
3. Scroll to the bottom of the inserter. 
4. Verify there is a "Jetpack powered" collection of blocks found at the bottom of the list. 
5. Tap a block. 
6. Verify the block is inserted to the content as expected. 

</details>

<details><summary>Block inserter search functions without error</summary>

1. Open the native editor for a site. 
2. Open the block inserter. 
3. Type a query into the search field. 
4. Verify relevant block types are displayed after the list is filtered.  
5. Tap a block. 
6. Verify the block is inserted to the content as expected. 

</details>

<details><summary>Reusable blocks tab functions without error</summary>

1. Open the native editor for a site that has reusable blocks. 
2. Open the block inserter. 
3. Tap the _Reusable_ tab towards the top of the inserter. 
4. Verify the expected reusable blocks are displayed atop the list. 
6. Tap a reusable block. 
8. Verify the block is inserted to the content as expected. 

</details>

## Screenshots or screencast

> **Note** The video and screenshots below include an outdated badge with a green background. It has since been updated to a badge with a transparent background. 

<details><summary>UX Interactions</summary>

https://user-images.githubusercontent.com/438664/179032491-6a4fa917-bd81-4b46-8af3-6f7c027f47d0.MP4

</details>

<details><summary>UI Screenshots</summary>

| Light | Dark |
| - | - |
| ![iOS light mode: block inserter collections](https://user-images.githubusercontent.com/438664/179032723-a4274a6b-744d-4120-b69d-e4863ae0fb12.PNG) |  ![iOS dark mode: block inserter collections](https://user-images.githubusercontent.com/438664/179032803-04a62817-3678-44f5-83f7-1b2ef6423eef.PNG) | 
| ![Android light mode: block inserter collections](https://user-images.githubusercontent.com/438664/179033887-6972c3e4-f6bb-4377-8d19-36ccbb3d5bb1.jpg) | ![Android dark mode: block inserter collections](https://user-images.githubusercontent.com/438664/179033903-9fdeaa46-cea6-43bc-ad4a-d62d641240d4.jpg) |

</details>