### PR TITLE
Border Radius: Prevent invalid css unit only styles or empty radii style attribute

### DIFF
--- a/packages/block-editor/src/components/border-radius-control/all-input-control.js
+++ b/packages/block-editor/src/components/border-radius-control/all-input-control.js
@@ -7,13 +7,49 @@ import { __ } from '@wordpress/i18n';
 /**
  * Internal dependencies
  */
-import { getAllValue, hasMixedValues, hasDefinedValues } from './utils';
+import {
+	getAllValue,
+	getAllUnit,
+	hasMixedValues,
+	hasDefinedValues,
+} from './utils';
 
-export default function AllInputControl( { onChange, values, ...props } ) {
-	const allValue = getAllValue( values );
+export default function AllInputControl( {
+	onChange,
+	selectedUnits,
+	setSelectedUnits,
+	values,
+	...props
+} ) {
+	let allValue = getAllValue( values );
+
+	if ( allValue === undefined ) {
+		// If we don't have any value set the unit to any current selection
+		// or the most common unit from the individual radii values.
+		allValue = getAllUnit( selectedUnits );
+	}
+
 	const hasValues = hasDefinedValues( values );
 	const isMixed = hasValues && hasMixedValues( values );
 	const allPlaceholder = isMixed ? __( 'Mixed' ) : null;
+
+	// Filter out CSS-unit-only values to prevent invalid styles.
+	const handleOnChange = ( next ) => {
+		const isNumeric = ! isNaN( parseFloat( next ) );
+		const nextValue = isNumeric ? next : undefined;
+		onChange( nextValue );
+	};
+
+	// Store current unit selection for use as fallback for individual
+	// radii controls.
+	const handleOnUnitChange = ( unit ) => {
+		setSelectedUnits( {
+			topLeft: unit,
+			topRight: unit,
+			bottomLeft: unit,
+			bottomRight: unit,
+		} );
+	};
 
 	return (
 		<UnitControl
@@ -22,7 +58,8 @@ export default function AllInputControl( { onChange, values, ...props } ) {
 			disableUnits={ isMixed }
 			isOnly
 			value={ allValue }
-			onChange={ onChange }
+			onChange={ handleOnChange }
+			onUnitChange={ handleOnUnitChange }
 			placeholder={ allPlaceholder }
 		/>
 	);

--- a/packages/block-editor/src/components/border-radius-control/index.js
+++ b/packages/block-editor/src/components/border-radius-control/index.js
@@ -25,10 +25,10 @@ import {
 } from './utils';
 
 const DEFAULT_VALUES = {
-	topLeft: null,
-	topRight: null,
-	bottomLeft: null,
-	bottomRight: null,
+	topLeft: undefined,
+	topRight: undefined,
+	bottomLeft: undefined,
+	bottomRight: undefined,
 };
 const MIN_BORDER_RADIUS_VALUE = 0;
 const MAX_BORDER_RADIUS_VALUES = {
@@ -51,11 +51,27 @@ export default function BorderRadiusControl( { onChange, values } ) {
 		! hasDefinedValues( values ) || ! hasMixedValues( values )
 	);
 
+	// Tracking selected units via internal state allows filtering of CSS unit
+	// only values from being saved while maintaining preexisting unit selection
+	// behaviour. Filtering CSS only values prevents invalid style values.
+	const [ selectedUnits, setSelectedUnits ] = useState( {
+		flat:
+			typeof values === 'string'
+				? parseQuantityAndUnitFromRawValue( values )[ 1 ]
+				: undefined,
+		topLeft: parseQuantityAndUnitFromRawValue( values?.topLeft )[ 1 ],
+		topRight: parseQuantityAndUnitFromRawValue( values?.topRight )[ 1 ],
+		bottomLeft: parseQuantityAndUnitFromRawValue( values?.bottomLeft )[ 1 ],
+		bottomRight: parseQuantityAndUnitFromRawValue(
+			values?.bottomRight
+		)[ 1 ],
+	} );
+
 	const units = useCustomUnits( {
 		availableUnits: useSetting( 'spacing.units' ) || [ 'px', 'em', 'rem' ],
 	} );
 
-	const unit = getAllUnit( values );
+	const unit = getAllUnit( selectedUnits );
 	const unitConfig = units && units.find( ( item ) => item.value === unit );
 	const step = unitConfig?.step || 1;
 
@@ -82,6 +98,8 @@ export default function BorderRadiusControl( { onChange, values } ) {
 							values={ values }
 							min={ MIN_BORDER_RADIUS_VALUE }
 							onChange={ onChange }
+							selectedUnits={ selectedUnits }
+							setSelectedUnits={ setSelectedUnits }
 							units={ units }
 						/>
 						<RangeControl
@@ -101,6 +119,8 @@ export default function BorderRadiusControl( { onChange, values } ) {
 					<InputControls
 						min={ MIN_BORDER_RADIUS_VALUE }
 						onChange={ onChange }
+						selectedUnits={ selectedUnits }
+						setSelectedUnits={ setSelectedUnits }
 						values={ values || DEFAULT_VALUES }
 						units={ units }
 					/>

--- a/packages/block-editor/src/components/border-radius-control/index.js
+++ b/packages/block-editor/src/components/border-radius-control/index.js
@@ -53,7 +53,7 @@ export default function BorderRadiusControl( { onChange, values } ) {
 
 	// Tracking selected units via internal state allows filtering of CSS unit
 	// only values from being saved while maintaining preexisting unit selection
-	// behaviour. Filtering CSS only values prevents invalid style values.
+	// behaviour. Filtering CSS unit only values prevents invalid style values.
 	const [ selectedUnits, setSelectedUnits ] = useState( {
 		flat:
 			typeof values === 'string'

--- a/packages/block-editor/src/components/border-radius-control/input-controls.js
+++ b/packages/block-editor/src/components/border-radius-control/input-controls.js
@@ -2,6 +2,7 @@
  * WordPress dependencies
  */
 import {
+	__experimentalParseQuantityAndUnitFromRawValue as parseQuantityAndUnitFromRawValue,
 	__experimentalUnitControl as UnitControl,
 	Tooltip,
 } from '@wordpress/components';
@@ -16,6 +17,8 @@ const CORNERS = {
 
 export default function BoxInputControls( {
 	onChange,
+	selectedUnits,
+	setSelectedUnits,
 	values: valuesProp,
 	...props
 } ) {
@@ -24,10 +27,20 @@ export default function BoxInputControls( {
 			return;
 		}
 
+		// Filter out CSS-unit-only values to prevent invalid styles.
+		const isNumeric = ! isNaN( parseFloat( next ) );
+		const nextValue = isNumeric ? next : undefined;
+
 		onChange( {
 			...values,
-			[ corner ]: next ? next : undefined,
+			[ corner ]: nextValue,
 		} );
+	};
+
+	const createHandleOnUnitChange = ( side ) => ( next ) => {
+		const newUnits = { ...selectedUnits };
+		newUnits[ side ] = next;
+		setSelectedUnits( newUnits );
 	};
 
 	// For shorthand style & backwards compatibility, handle flat string value.
@@ -46,18 +59,32 @@ export default function BoxInputControls( {
 	// https://github.com/WordPress/gutenberg/pull/24966#issuecomment-685875026
 	return (
 		<div className="components-border-radius-control__input-controls-wrapper">
-			{ Object.entries( CORNERS ).map( ( [ key, label ] ) => (
-				<Tooltip text={ label } position="top" key={ key }>
-					<div className="components-border-radius-control__tooltip-wrapper">
-						<UnitControl
-							{ ...props }
-							aria-label={ label }
-							value={ values[ key ] }
-							onChange={ createHandleOnChange( key ) }
-						/>
-					</div>
-				</Tooltip>
-			) ) }
+			{ Object.entries( CORNERS ).map( ( [ corner, label ] ) => {
+				const [ parsedQuantity, parsedUnit ] =
+					parseQuantityAndUnitFromRawValue( values[ corner ] );
+
+				const computedUnit = values[ corner ]
+					? parsedUnit
+					: selectedUnits[ corner ] || selectedUnits.flat;
+
+				return (
+					<Tooltip text={ label } position="top" key={ corner }>
+						<div className="components-border-radius-control__tooltip-wrapper">
+							<UnitControl
+								{ ...props }
+								aria-label={ label }
+								value={ [ parsedQuantity, computedUnit ].join(
+									''
+								) }
+								onChange={ createHandleOnChange( corner ) }
+								onUnitChange={ createHandleOnUnitChange(
+									corner
+								) }
+							/>
+						</div>
+					</Tooltip>
+				);
+			} ) }
 		</div>
 	);
 }

--- a/packages/block-editor/src/components/border-radius-control/test/utils.js
+++ b/packages/block-editor/src/components/border-radius-control/test/utils.js
@@ -9,73 +9,35 @@ import {
 	mode,
 } from '../utils';
 
+const defaultUnitSelections = {
+	flat: undefined,
+	topLeft: '%',
+	topRight: 'rem',
+	bottomLeft: 'rem',
+	bottomRight: 'vw',
+};
+
 describe( 'getAllUnit', () => {
-	describe( 'when provided string based values', () => {
-		it( 'should return valid unit when passed a valid unit', () => {
-			expect( getAllUnit( '32em' ) ).toBe( 'em' );
-		} );
-
-		it( 'should fall back to px when passed an invalid unit', () => {
-			expect( getAllUnit( '32apples' ) ).toBe( 'px' );
-		} );
-
-		it( 'should fall back to px when passed a value without a unit', () => {
-			expect( getAllUnit( '32' ) ).toBe( 'px' );
-		} );
+	it( 'should return flat radius unit when selected', () => {
+		const selectedUnits = { ...defaultUnitSelections, flat: 'em' };
+		expect( getAllUnit( selectedUnits ) ).toBe( 'em' );
 	} );
 
-	describe( 'when provided object based values', () => {
-		it( 'should return the most common value', () => {
-			const values = {
-				bottomLeft: '2em',
-				bottomRight: '2em',
-				topLeft: '0',
-				topRight: '2px',
-			};
-			expect( getAllUnit( values ) ).toBe( 'em' );
-		} );
-
-		it( 'should return the real value when the most common value is undefined', () => {
-			const values = {
-				bottomLeft: '0',
-				bottomRight: '0',
-				topLeft: '0',
-				topRight: '2em',
-			};
-			expect( getAllUnit( values ) ).toBe( 'em' );
-		} );
-
-		it( 'should return the most common value there are no undefined values', () => {
-			const values = {
-				bottomLeft: '1em',
-				bottomRight: '1em',
-				topLeft: '2px',
-				topRight: '2em',
-			};
-			expect( getAllUnit( values ) ).toBe( 'em' );
-		} );
-
-		it( 'should fall back to px when all values are undefined or equivalent', () => {
-			const values = {
-				bottomLeft: '0',
-				bottomRight: undefined,
-				topLeft: undefined,
-				topRight: '0',
-			};
-			expect( getAllUnit( values ) ).toBe( 'px' );
-		} );
+	it( 'should return most common corner unit', () => {
+		expect( getAllUnit( defaultUnitSelections ) ).toBe( 'rem' );
 	} );
 
-	describe( 'when provided invalid values', () => {
-		it( 'should return px when passed an array', () => {
-			expect( getAllUnit( [] ) ).toBe( 'px' );
-		} );
-		it( 'should return px when passed a boolean', () => {
-			expect( getAllUnit( false ) ).toBe( 'px' );
-		} );
-		it( 'should return px when passed undefined', () => {
-			expect( getAllUnit( false ) ).toBe( 'px' );
-		} );
+	it( 'should return a real unit when the most common is undefined', () => {
+		expect( getAllUnit( { bottomRight: '%' } ) ).toBe( '%' );
+	} );
+
+	it( 'should return most common corner unit when some are unselected', () => {
+		const selectedUnits = { ...defaultUnitSelections, topLeft: undefined };
+		expect( getAllUnit( selectedUnits ) ).toBe( 'rem' );
+	} );
+
+	it( 'should fallback to px when all values are undefined', () => {
+		expect( getAllUnit( {} ) ).toBe( 'px' );
 	} );
 } );
 

--- a/packages/block-editor/src/components/border-radius-control/utils.js
+++ b/packages/block-editor/src/components/border-radius-control/utils.js
@@ -28,24 +28,20 @@ export function mode( inputArray ) {
 }
 
 /**
- * Returns the most common CSS unit in the radius values.
- * Falls back to `px` as a default unit.
+ * Returns the most common CSS unit from the current CSS unit selections.
  *
- * @param {Object|string} values Radius values.
- * @return {string}              Most common CSS unit in values. Default: `px`.
+ * - If a single flat border radius is set, its unit will be used
+ * - If individual corner selections, the most common of those will be used
+ * - Failing any unit selections a default of 'px' is returned.
+ *
+ * @param {Object} selectedUnits Unit selections for flat radius & each corner.
+ * @return {string} Most common CSS unit from current selections. Default: `px`.
  */
-export function getAllUnit( values = {} ) {
-	if ( typeof values === 'string' ) {
-		const [ , unit ] = parseQuantityAndUnitFromRawValue( values );
-		return unit || 'px';
-	}
-
-	const allUnits = Object.values( values ).map( ( value ) => {
-		const [ , unit ] = parseQuantityAndUnitFromRawValue( value );
-		return unit;
-	} );
-
-	return mode( allUnits ) || 'px';
+export function getAllUnit( selectedUnits = {} ) {
+	const { flat, ...cornerUnits } = selectedUnits;
+	return (
+		flat || mode( Object.values( cornerUnits ).filter( Boolean ) ) || 'px'
+	);
 }
 
 /**

--- a/packages/block-editor/src/hooks/border-radius.js
+++ b/packages/block-editor/src/hooks/border-radius.js
@@ -19,17 +19,13 @@ export function BorderRadiusEdit( props ) {
 	} = props;
 
 	const onChange = ( newRadius ) => {
-		let newStyle = {
+		const newStyle = cleanEmptyObject( {
 			...style,
 			border: {
 				...style?.border,
 				radius: newRadius,
 			},
-		};
-
-		if ( newRadius === undefined || newRadius === '' ) {
-			newStyle = cleanEmptyObject( newStyle );
-		}
+		} );
 
 		setAttributes( { style: newStyle } );
 	};


### PR DESCRIPTION
Fixes: https://github.com/WordPress/gutenberg/issues/42354
Related: https://github.com/WordPress/gutenberg/pull/33444

## What?

- Prevents css-unit-only values being saved to border-radius style attributes, in turn preventing the generation of invalid CSS styles
- Prevents saving entirely empty border-radius style attribute

## Why?

Cleans up invalid CSS styles and unwarranted block attributes.

## How?

- Updates `BorderRadiusControl` to manage unit selections via internal state so they can be separated from the saved block style attributes.
- Filters out CSS unit only values from saved border-radius attributes
- Utilises the internal unit selections state to simplify determining the current unit for the linked control view


## Testing Instructions
1.  Edit a post in the block editor
2.  Add a group block and select it
3.  Within the sidebar, change the border-radius unit without supplying any value
4.  Switch to the code editor view and you'll find that the block's style object contains a css-unit-only value for `radius`
5.  Switch back to the visual editor and add some further content inside the group block
6.  Save the post and view it on the front end
7.  Inspect the group block element and notice the invalid styles
8. Back in the editor, select the block but this time add a border-radius value
9. Expand the control to edit individual corner radii and manually delete each field's value
10. Switch to the code editor view and notice the empty border-radius object
11. Checkout this PR, rebuild and then reload the editor
12. Repeat steps 1-10 however you should see no CSS-unit-only values, invalid styles, or empty border style attribute when inspecting the block via code view
13. Confirm border-radius support still functions correctly in Global Styles
14. Run utils tests: `npm run test-unit packages/block-editor/src/components/border-radius-control/test/`

## Screenshots or screencast <!-- if applicable -->

| Before | After |
|---|---|
| <video src="https://user-images.githubusercontent.com/60436221/178901034-da3d82e1-2f9a-46f5-964f-13f88e92ea3a.mp4" /> |  <video src="https://user-images.githubusercontent.com/60436221/178901040-4bbb3e54-0bd9-450b-9930-a1ba29711d1c.mp4" /> |




