### PR TITLE
Post Editor: Avoid 403 errors for users with low permissions

### DIFF
--- a/lib/compat/wordpress-6.1/edit-form-blocks.php
+++ b/lib/compat/wordpress-6.1/edit-form-blocks.php
@@ -15,6 +15,7 @@
 function gutenberg_preload_template_permissions( $preload_paths, $context ) {
 	if ( ! empty( $context->post ) ) {
 		$preload_paths[] = array( rest_get_route_for_post_type_items( 'wp_template' ), 'OPTIONS' );
+		$preload_paths[] = array( '/wp/v2/settings', 'OPTIONS' );
 	}
 
 	return $preload_paths;

--- a/packages/edit-post/src/editor.js
+++ b/packages/edit-post/src/editor.js
@@ -56,7 +56,7 @@ function Editor( {
 				getEditedPostTemplate,
 				getHiddenBlockTypes,
 			} = select( editPostStore );
-			const { getEntityRecord, getPostType, getEntityRecords } =
+			const { getEntityRecord, getPostType, getEntityRecords, canUser } =
 				select( coreStore );
 			const { getEditorSettings } = select( editorStore );
 			const { getBlockTypes } = select( blocksStore );
@@ -77,6 +77,7 @@ function Editor( {
 			const supportsTemplateMode =
 				getEditorSettings().supportsTemplateMode;
 			const isViewable = getPostType( postType )?.viewable ?? false;
+			const canEditTemplate = canUser( 'create', 'templates' );
 
 			return {
 				hasFixedToolbar:
@@ -94,7 +95,7 @@ function Editor( {
 				keepCaretInsideBlock: isFeatureActive( 'keepCaretInsideBlock' ),
 				isTemplateMode: isEditingTemplate(),
 				template:
-					supportsTemplateMode && isViewable
+					supportsTemplateMode && isViewable && canEditTemplate
 						? getEditedPostTemplate()
 						: null,
 				post: postObject,

--- a/packages/editor/src/components/provider/use-block-editor-settings.js
+++ b/packages/editor/src/components/provider/use-block-editor-settings.js
@@ -41,7 +41,9 @@ function useBlockEditorSettings( settings, hasTemplate ) {
 		const isWeb = Platform.OS === 'web';
 		const { canUser, getEntityRecord } = select( coreStore );
 
-		const siteSettings = getEntityRecord( 'root', 'site' );
+		const siteSettings = canUser( 'read', 'settings' )
+			? getEntityRecord( 'root', 'site' )
+			: {};
 
 		return {
 			canUseUnfilteredHTML: canUserUseUnfilteredHTML(),

--- a/packages/editor/src/components/provider/use-block-editor-settings.js
+++ b/packages/editor/src/components/provider/use-block-editor-settings.js
@@ -43,7 +43,7 @@ function useBlockEditorSettings( settings, hasTemplate ) {
 
 		const siteSettings = canUser( 'read', 'settings' )
 			? getEntityRecord( 'root', 'site' )
-			: {};
+			: undefined;
 
 		return {
 			canUseUnfilteredHTML: canUserUseUnfilteredHTML(),


### PR DESCRIPTION
## What?
PR fixes 403 errors in the post editor for low capability users, like authors.

Similar issue #29845.

## Why?
The editor should check permission before making requests when data isn't available for everyone.

## How?
* Added `canEditTemplate` check before requesting `getEditedPostTemplate`. Authors can't edit templates, so there's no need for this data.
* Added `canUser( 'read', 'settings' )` check in `useBlockEditorSettings` before request site settings.
* I had to preload `OPTIONS /wp/v2/settings` since the request is made in the critical path. The settings endpoint has been preloaded since #39256.

## Testing Instructions
1. Login to the test site with an Author role.
2. Open a Post or Page.
3. Open the DevTools network tab and confirm there're no 403 requests.

## Screenshots or screencast <!-- if applicable -->

![CleanShot 2022-07-14 at 12 12 15](https://user-images.githubusercontent.com/240569/178935007-84e4058f-37e0-4895-85e8-f1efe2b85780.png)

