### PR TITLE
Popover: improve iframe offset computation

### DIFF
--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -9,6 +9,7 @@
 -   `AnglePickerControl`: Fix gap between elements in RTL mode ([#42534](https://github.com/WordPress/gutenberg/pull/42534)).
 -   `RangeControl`: clamp initialPosition between min and max values ([#42571](https://github.com/WordPress/gutenberg/pull/42571)).
 -   `Tooltip`: avoid unnecessary re-renders of select child elements ([#42483](https://github.com/WordPress/gutenberg/pull/42483)).
+-   `Popover`: Fix offset when the reference element is within an iframe. ([#42417](https://github.com/WordPress/gutenberg/pull/42417)).
 
 ### Enhancements
 
@@ -50,13 +51,12 @@
 -   `Popover`: call `getAnchorRect` callback prop even if `anchorRefFallback` has no value. ([#42329](https://github.com/WordPress/gutenberg/pull/42329)).
 -   Fix `ToolTip` position to ensure it is always positioned relative to the first child of the ToolTip. ([#41268](https://github.com/WordPress/gutenberg/pull/41268))
 
-### Enhancement
-
--   `ToggleGroupControl`: Add large size variant ([#42008](https://github.com/WordPress/gutenberg/pull/42008/)).
 
 ### Enhancements
 
+-   `ToggleGroupControl`: Add large size variant ([#42008](https://github.com/WordPress/gutenberg/pull/42008/)).
 -   `InputControl`: Ensure that the padding between a `prefix`/`suffix` and the text input stays at a reasonable 8px, even in larger size variants ([#42166](https://github.com/WordPress/gutenberg/pull/42166)).
+
 
 ### Internal
 

--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -57,7 +57,6 @@
 -   `ToggleGroupControl`: Add large size variant ([#42008](https://github.com/WordPress/gutenberg/pull/42008/)).
 -   `InputControl`: Ensure that the padding between a `prefix`/`suffix` and the text input stays at a reasonable 8px, even in larger size variants ([#42166](https://github.com/WordPress/gutenberg/pull/42166)).
 
-
 ### Internal
 
 -   `Grid`: Convert to TypeScript ([#41923](https://github.com/WordPress/gutenberg/pull/41923)).

--- a/packages/components/src/popover/README.md
+++ b/packages/components/src/popover/README.md
@@ -71,6 +71,13 @@ Each of these base placements has an alignment in the form -start and -end. For 
 -   Required: No
 -   Default: `"bottom-start"`
 
+### offset
+
+The distance (in pixels) between the anchor and popover.
+
+-   Type: `Number`
+-   Required: No
+
 ### children
 
 The content to be displayed within the popover.

--- a/packages/components/src/popover/index.js
+++ b/packages/components/src/popover/index.js
@@ -180,6 +180,9 @@ const Popover = (
 					const isTopBottomPlacement =
 						currentPlacement.includes( 'top' ) ||
 						currentPlacement.includes( 'bottom' );
+
+					// The axes here seem to be opposite to what the floating-ui docs
+					// state, but this seems to work. :confused-emoji:
 					const mainAxis = isTopBottomPlacement ? 'y' : 'x';
 					const crossAxis = mainAxis === 'x' ? 'y' : 'x';
 

--- a/packages/components/src/popover/index.js
+++ b/packages/components/src/popover/index.js
@@ -93,12 +93,6 @@ const placementToAnimationOrigin = ( placement ) => {
 	return x + ' ' + y;
 };
 
-const getMainAxis = ( placement ) =>
-	placement.includes( 'top' ) || placement.includes( 'bottom' ) ? 'y' : 'x';
-
-const getCrossAxis = ( placement ) =>
-	getMainAxis( placement ) === 'x' ? 'y' : 'x';
-
 const Popover = (
 	{
 		range,
@@ -183,23 +177,22 @@ const Popover = (
 		offset ? offsetMiddleware( offset ) : undefined,
 		frameOffset
 			? offsetMiddleware( ( { placement: currentPlacement } ) => {
-					const mainAxis = getMainAxis( currentPlacement );
-					const crossAxis = getCrossAxis( currentPlacement );
+					const isTopBottomPlacement =
+						currentPlacement.includes( 'top' ) ||
+						currentPlacement.includes( 'bottom' );
+					const mainAxis = isTopBottomPlacement ? 'y' : 'x';
+					const crossAxis = mainAxis === 'x' ? 'y' : 'x';
 
 					// When the popover is before the reference, subtract the offset,
-					// else add it.
-					const mainAxisModifier = currentPlacement.includes( 'top' )
-						? -1
-						: 1;
-					const crossAxisModifier = currentPlacement.includes(
-						'left'
-					)
-						? -1
-						: 1;
+					// of the main axis else add it.
+					const hasBeforePlacement =
+						currentPlacement.includes( 'top' ) ||
+						currentPlacement.includes( 'left' );
+					const mainAxisModifier = hasBeforePlacement ? -1 : 1;
 
 					return {
 						mainAxis: frameOffset[ mainAxis ] * mainAxisModifier,
-						crossAxis: frameOffset[ crossAxis ] * crossAxisModifier,
+						crossAxis: frameOffset[ crossAxis ],
 					};
 			  } )
 			: undefined,
@@ -224,6 +217,7 @@ const Popover = (
 					padding: 1, // Necessary to avoid flickering at the edge of the viewport.
 			  } )
 			: undefined,
+
 		hasArrow ? arrow( { element: arrowRef } ) : undefined,
 	].filter( ( m ) => !! m );
 	const slotName = useContext( slotNameContext ) || __unstableSlotName;

--- a/packages/components/src/popover/index.js
+++ b/packages/components/src/popover/index.js
@@ -181,8 +181,9 @@ const Popover = (
 						currentPlacement.includes( 'top' ) ||
 						currentPlacement.includes( 'bottom' );
 
-					// The axes here seem to be opposite to what the floating-ui docs
-					// state, but this seems to work. :confused-emoji:
+					// The main axis should represent the gap between the
+					// floating element and the reference element. The cross
+					// axis is always perpendicular to the main axis.
 					const mainAxis = isTopBottomPlacement ? 'y' : 'x';
 					const crossAxis = mainAxis === 'x' ? 'y' : 'x';
 

--- a/packages/components/src/popover/index.js
+++ b/packages/components/src/popover/index.js
@@ -174,9 +174,12 @@ const Popover = (
 	}, [ ownerDocument ] );
 
 	const middlewares = [
-		offset ? offsetMiddleware( offset ) : undefined,
-		frameOffset
+		frameOffset || offset
 			? offsetMiddleware( ( { placement: currentPlacement } ) => {
+					if ( ! frameOffset ) {
+						return offset;
+					}
+
 					const isTopBottomPlacement =
 						currentPlacement.includes( 'top' ) ||
 						currentPlacement.includes( 'bottom' );
@@ -193,9 +196,12 @@ const Popover = (
 						currentPlacement.includes( 'top' ) ||
 						currentPlacement.includes( 'left' );
 					const mainAxisModifier = hasBeforePlacement ? -1 : 1;
+					const normalizedOffset = offset ? offset : 0;
 
 					return {
-						mainAxis: frameOffset[ mainAxis ] * mainAxisModifier,
+						mainAxis:
+							normalizedOffset +
+							frameOffset[ mainAxis ] * mainAxisModifier,
 						crossAxis: frameOffset[ crossAxis ],
 					};
 			  } )

--- a/packages/components/src/popover/index.js
+++ b/packages/components/src/popover/index.js
@@ -221,7 +221,6 @@ const Popover = (
 					padding: 1, // Necessary to avoid flickering at the edge of the viewport.
 			  } )
 			: undefined,
-
 		hasArrow ? arrow( { element: arrowRef } ) : undefined,
 	].filter( ( m ) => !! m );
 	const slotName = useContext( slotNameContext ) || __unstableSlotName;

--- a/packages/format-library/src/link/inline.js
+++ b/packages/format-library/src/link/inline.js
@@ -227,7 +227,7 @@ function InlineLinkUI( {
 			focusOnMount={ focusOnMount.current }
 			onClose={ stopAddingLink }
 			position="bottom center"
-			__unstableShift
+			__unstableShift={ { crossAxis: false } }
 		>
 			<LinkControl
 				key={ forceRemountKey }

--- a/packages/format-library/src/link/inline.js
+++ b/packages/format-library/src/link/inline.js
@@ -227,7 +227,7 @@ function InlineLinkUI( {
 			focusOnMount={ focusOnMount.current }
 			onClose={ stopAddingLink }
 			position="bottom center"
-			__unstableShift={ { crossAxis: false } }
+			__unstableShift
 		>
 			<LinkControl
 				key={ forceRemountKey }


### PR DESCRIPTION
## What?
#42389 fixed an issue with Link Control popovers going offscreen, but as @ntsekouras pointed out, in the site editor the popover isn't taking the iframe offset into account and while now onscreen is incorrectly positioned.

## Why?
The issue seems to be that the custom `iframeOffset` middleware in the Popover component doesn't work well with floating-ui's `shift` middleware.

`shift` expects to receive any offsets via middleware data, but `iframeOffset` doesn't do this:
https://github.com/floating-ui/floating-ui/blob/77c4b27a8096cafe06e58b2c7592317d6d3a3aea/packages/core/src/middleware/shift.ts#L203-L212

The easiest fix seems to be use floating-ui's own `offset` middelware instead of our custom middleware.

## How?
In practice it was a bit harder than I thought to fix this. The main difficulty is that when using floating ui's `offset` middleware, the `mainAxis` and `crossAxis` values need to be specified instead of `x` and `y`, and floating-ui doesn't seem to offer any way to determine what those are.

It also seems that when position is `top` or `left` the offset needs to be subtracted, and when `bottom` or `right` added. As soon as I fixed the link popover issue, the toolbar was offset incorrectly until I multiplied the offset by the correct sign.

## Testing Instructions
1. Open the site editor
2. Select a paragraph
3. Try adding a link

Expected: The toolbar and the link popover should be positioned correctly.

## Screenshots or screencast <!-- if applicable -->
### Before
![Screen Shot 2022-07-15 at 10 03 27 am](https://user-images.githubusercontent.com/677833/179132054-d6a7bf24-bce6-4f94-a8fb-a2d859cda670.png)

### After
![Screen Shot 2022-07-14 at 5 18 20 pm](https://user-images.githubusercontent.com/677833/178948668-90dde5f5-6b58-4103-8863-fa3ca3b8288f.png)

### Other screenshots

To make sure this was right, I tried setting the button block's popover positioning to 'top', 'bottom', 'left' and 'right' and checked the results. I also added some left margin to the site editor's iframe to ensure that x axis offsetting works correctly, and the results were all correct:

#### Top placement
![Screen Shot 2022-07-19 at 12 15 17 pm](https://user-images.githubusercontent.com/677833/179663745-2a6ea7cd-614f-467f-afb2-807629210eba.png)

#### Right placement
![Screen Shot 2022-07-19 at 12 11 34 pm](https://user-images.githubusercontent.com/677833/179663774-d3370196-0a5a-416f-b3e4-2047dbd3eb39.png)

#### Bottom placement
![Screen Shot 2022-07-19 at 12 15 40 pm](https://user-images.githubusercontent.com/677833/179663812-57665a36-c9d0-4ffc-ba21-4cfdbe7fa666.png)

#### Left placement
![Screen Shot 2022-07-19 at 12 14 46 pm](https://user-images.githubusercontent.com/677833/179663834-a9b85980-89ed-44ed-b9df-d90ac6f26d5b.png)