### PR TITLE
Hide prefix and suffix placeholders in post terms

### DIFF
--- a/packages/block-library/src/post-terms/edit.js
+++ b/packages/block-library/src/post-terms/edit.js
@@ -40,6 +40,7 @@ export default function PostTermsEdit( {
 	attributes,
 	clientId,
 	context,
+	isSelected,
 	setAttributes,
 	insertBlocksAfter,
 } ) {
@@ -96,7 +97,7 @@ export default function PostTermsEdit( {
 			</InspectorControls>
 			<div { ...blockProps }>
 				{ isLoading && <Spinner /> }
-				{ ! isLoading && hasPostTerms && (
+				{ ! isLoading && hasPostTerms && ( isSelected || prefix ) && (
 					<RichText
 						allowedFormats={ ALLOWED_FORMATS }
 						className="wp-block-post-terms__prefix"
@@ -135,7 +136,7 @@ export default function PostTermsEdit( {
 					! hasPostTerms &&
 					( selectedTerm?.labels?.no_terms ||
 						__( 'Term items not found.' ) ) }
-				{ ! isLoading && hasPostTerms && (
+				{ ! isLoading && hasPostTerms && ( isSelected || suffix ) && (
 					<RichText
 						allowedFormats={ ALLOWED_FORMATS }
 						className="wp-block-post-terms__suffix"


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Hides the prefix and suffix when the block is not selected so it matches what is shown in save.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

Fixes #42318

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

Hides the prefix and suffix placeholders when the block is not selected.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->

1. Add Query Loop.
2. Add Categories block to template.
3. Ensure Categories block is NOT selected.
4. Prefix and suffix should not be shown.
5. Add text to prefix or suffix.
6. Deselect Categories block.
7. Entered text should still be shown.

## Screenshots or screencast <!-- if applicable -->

![selecting and deselecting the post types shows and hides the prefix and suffix](https://user-images.githubusercontent.com/5129775/178945218-c88221c9-f56d-4c92-baf1-071314a80a13.gif)

Co-authored-by: Dave Smith <getdavemail@gmail.com>