### PR TITLE
Writing flow: fix caret movement for multiple lines

### DIFF
--- a/packages/dom/CHANGELOG.md
+++ b/packages/dom/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- `getRectangleFromRange` may now return `null`.
+
 ## 3.13.0 (2022-07-13)
 
 ## 3.12.0 (2022-06-29)

--- a/packages/dom/README.md
+++ b/packages/dom/README.md
@@ -130,7 +130,7 @@ _Parameters_
 
 _Returns_
 
--   `DOMRect`: The rectangle.
+-   `DOMRect?`: The rectangle.
 
 ### getScrollContainer
 

--- a/packages/dom/README.md
+++ b/packages/dom/README.md
@@ -122,7 +122,8 @@ _Returns_
 
 ### getRectangleFromRange
 
-Get the rectangle of a given Range.
+Get the rectangle of a given Range. Returns `null` if no suitable rectangle
+can be found.
 
 _Parameters_
 

--- a/packages/dom/src/dom/get-rectangle-from-range.js
+++ b/packages/dom/src/dom/get-rectangle-from-range.js
@@ -8,7 +8,7 @@ import { assertIsDefined } from '../utils/assert-is-defined';
  *
  * @param {Range} range The range.
  *
- * @return {DOMRect} The rectangle.
+ * @return {DOMRect?} The rectangle.
  */
 export default function getRectangleFromRange( range ) {
 	// For uncollapsed ranges, get the rectangle that bounds the contents of the
@@ -73,7 +73,15 @@ export default function getRectangleFromRange( range ) {
 		range.setEnd( parentNode, index );
 	}
 
-	let rect = range.getClientRects()[ 0 ];
+	const rects = range.getClientRects();
+
+	// If we have multiple rectangles for a collapsed range, there's no way to
+	// know which it is, so don't return anything.
+	if ( rects.length > 1 ) {
+		return null;
+	}
+
+	let rect = rects[ 0 ];
 
 	// If the collapsed range starts (and therefore ends) at an element node,
 	// `getClientRects` can be empty in some browsers. This can be resolved

--- a/packages/dom/src/dom/get-rectangle-from-range.js
+++ b/packages/dom/src/dom/get-rectangle-from-range.js
@@ -4,7 +4,8 @@
 import { assertIsDefined } from '../utils/assert-is-defined';
 
 /**
- * Get the rectangle of a given Range.
+ * Get the rectangle of a given Range. Returns `null` if no suitable rectangle
+ * can be found.
  *
  * @param {Range} range The range.
  *

--- a/packages/e2e-tests/specs/editor/various/__snapshots__/writing-flow.test.js.snap
+++ b/packages/e2e-tests/specs/editor/various/__snapshots__/writing-flow.test.js.snap
@@ -122,6 +122,12 @@ exports[`Writing Flow should merge paragraphs 1`] = `
 <!-- /wp:paragraph -->"
 `;
 
+exports[`Writing Flow should move to the start of the first line on ArrowUp 1`] = `
+"<!-- wp:paragraph -->
+<p>.aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa</p>
+<!-- /wp:paragraph -->"
+`;
+
 exports[`Writing Flow should navigate around inline boundaries 1`] = `
 "<!-- wp:paragraph -->
 <p>FirstAfter</p>

--- a/packages/e2e-tests/specs/editor/various/__snapshots__/writing-flow.test.js.snap
+++ b/packages/e2e-tests/specs/editor/various/__snapshots__/writing-flow.test.js.snap
@@ -122,12 +122,6 @@ exports[`Writing Flow should merge paragraphs 1`] = `
 <!-- /wp:paragraph -->"
 `;
 
-exports[`Writing Flow should move to the start of the first line on ArrowUp 1`] = `
-"<!-- wp:paragraph -->
-<p>.aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa</p>
-<!-- /wp:paragraph -->"
-`;
-
 exports[`Writing Flow should navigate around inline boundaries 1`] = `
 "<!-- wp:paragraph -->
 <p>FirstAfter</p>

--- a/packages/e2e-tests/specs/editor/various/writing-flow.test.js
+++ b/packages/e2e-tests/specs/editor/various/writing-flow.test.js
@@ -778,7 +778,15 @@ describe( 'Writing Flow', () => {
 		await page.keyboard.press( 'ArrowUp' );
 		// Insert a "." for testing.
 		await page.keyboard.type( '.' );
-		// Expect the "." to be at the start of the paragraph.
-		expect( await getEditedPostContent() ).toMatchSnapshot();
+
+		// Expect the "." to be added at the start of the paragraph.
+		expect(
+			await page.evaluate( () =>
+				document.activeElement.getAttribute( 'data-type' )
+			)
+		).toBe( 'core/paragraph' );
+		expect(
+			await page.evaluate( () => document.activeElement.textContent )
+		).toMatch( /^\.a+$/ );
 	} );
 } );

--- a/packages/e2e-tests/specs/editor/various/writing-flow.test.js
+++ b/packages/e2e-tests/specs/editor/various/writing-flow.test.js
@@ -753,4 +753,32 @@ describe( 'Writing Flow', () => {
 		);
 		expect( paragraphs ).toEqual( [ 'first', 'second' ] );
 	} );
+
+	it( 'should move to the start of the first line on ArrowUp', async () => {
+		await page.keyboard.press( 'Enter' );
+		await page.keyboard.type( 'a' );
+
+		async function getHeight() {
+			return await page.evaluate(
+				() => document.activeElement.offsetHeight
+			);
+		}
+
+		const height = await getHeight();
+
+		// Keep typing until the height of the element increases. We need two
+		// lines.
+		while ( height === ( await getHeight() ) ) {
+			await page.keyboard.type( 'a' );
+		}
+
+		// Move to the start of the second line.
+		await page.keyboard.press( 'ArrowLeft' );
+		// Move to the start of the first line.
+		await page.keyboard.press( 'ArrowUp' );
+		// Insert a "." for testing.
+		await page.keyboard.type( '.' );
+		// Expect the "." to be at the start of the paragraph.
+		expect( await getEditedPostContent() ).toMatchSnapshot();
+	} );
 } );


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

## Why?

When there's multiple lines in a paragraph, it's not possible to move from the start of the second line to the start of the first line. This PR fixes that.

## How?

The browser returns two rectangles for this caret position: one visually positioned at the end of the first line and one at the start of the second line. So it's not possible to know where the caret actually is. We're previously just used the first rectangle, which made it seems like the caret is at the edge (first line). We can't simply switch to using the second rectangle because then we have the problem in the other vertical direction.

So to fix this issue, we have to not use any of the rectangles the browsers gives us when it gives two of them for a collapsed selection. Without a rectangle, the caret is automatically NOT at an edge, so we just fall back to the default browser behaviour.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->

## Screenshots or screencast <!-- if applicable -->
