### PR TITLE
Add item limit and ordering to Categories  List block

### DIFF
--- a/docs/reference-guides/core-blocks.md
+++ b/docs/reference-guides/core-blocks.md
@@ -78,7 +78,7 @@ Display a list of all categories. ([Source](https://github.com/WordPress/gutenbe
 -	**Name:** core/categories
 -	**Category:** widgets
 -	**Supports:** align, ~~html~~
--	**Attributes:** displayAsDropdown, showEmpty, showHierarchy, showOnlyTopLevel, showPostCounts, termsToShow
+-	**Attributes:** displayAsDropdown, order, orderBy, showEmpty, showHierarchy, showOnlyTopLevel, showPostCounts, termsToShow
 
 ## Code
 

--- a/docs/reference-guides/core-blocks.md
+++ b/docs/reference-guides/core-blocks.md
@@ -78,7 +78,7 @@ Display a list of all categories. ([Source](https://github.com/WordPress/gutenbe
 -	**Name:** core/categories
 -	**Category:** widgets
 -	**Supports:** align, ~~html~~
--	**Attributes:** displayAsDropdown, showEmpty, showHierarchy, showOnlyTopLevel, showPostCounts
+-	**Attributes:** displayAsDropdown, showEmpty, showHierarchy, showOnlyTopLevel, showPostCounts, termsToShow
 
 ## Code
 

--- a/packages/block-library/src/categories/block.json
+++ b/packages/block-library/src/categories/block.json
@@ -30,6 +30,14 @@
 		"termsToShow": {
 			"type": "number",
 			"default": -1
+		},
+		"order": {
+			"type": "string",
+			"default": "asc"
+		},
+		"orderBy": {
+			"type": "string",
+			"default": "name"
 		}
 	},
 	"supports": {

--- a/packages/block-library/src/categories/block.json
+++ b/packages/block-library/src/categories/block.json
@@ -26,6 +26,10 @@
 		"showEmpty": {
 			"type": "boolean",
 			"default": false
+		},
+		"termsToShow": {
+			"type": "number",
+			"default": -1
 		}
 	},
 	"supports": {

--- a/packages/block-library/src/categories/edit.js
+++ b/packages/block-library/src/categories/edit.js
@@ -13,6 +13,7 @@ import {
 	ToggleControl,
 	VisuallyHidden,
 	RangeControl,
+	SelectControl,
 } from '@wordpress/components';
 import { useInstanceId } from '@wordpress/compose';
 import { InspectorControls, useBlockProps } from '@wordpress/block-editor';
@@ -35,6 +36,8 @@ export default function CategoriesEdit( {
 		showOnlyTopLevel,
 		showEmpty,
 		termsToShow,
+		order,
+		orderBy,
 	},
 	setAttributes,
 } ) {
@@ -43,6 +46,8 @@ export default function CategoriesEdit( {
 		per_page: termsToShow,
 		hide_empty: ! showEmpty,
 		context: 'view',
+		order,
+		orderby: orderBy,
 	};
 	if ( showOnlyTopLevel ) {
 		query.parent = 0;
@@ -210,6 +215,43 @@ export default function CategoriesEdit( {
 							required
 						/>
 					) }
+					<SelectControl
+						label={ __( 'Order by' ) }
+						value={ `${ orderBy }/${ order }` }
+						options={ [
+							{
+								label: __( 'Name (ascending)' ),
+								value: 'name/asc',
+							},
+							{
+								label: __( 'Name (descending)' ),
+								value: 'name/desc',
+							},
+							{
+								/* translators: label for ordering posts by title in ascending order */
+								label: __( 'Count (ascending)' ),
+								value: 'count/asc',
+							},
+							{
+								/* translators: label for ordering posts by count in descending order */
+								label: __( 'Count (descending)' ),
+								value: 'count/desc',
+							},
+						] }
+						onChange={ ( value ) => {
+							const [ newOrderBy, newOrder ] = value.split( '/' );
+							if ( newOrder !== order ) {
+								setAttributes( {
+									order: newOrder,
+								} );
+							}
+							if ( newOrderBy !== orderBy ) {
+								setAttributes( {
+									orderBy: newOrderBy,
+								} );
+							}
+						} }
+					/>
 				</PanelBody>
 			</InspectorControls>
 			{ isResolving && (

--- a/packages/block-library/src/categories/edit.js
+++ b/packages/block-library/src/categories/edit.js
@@ -142,6 +142,9 @@ export default function CategoriesEdit( {
 	// for the range control.
 	const currentNumberCategories = categories?.length || 1;
 
+	const numberOfItemsToShow =
+		termsToShow === SHOW_ALL ? currentNumberCategories : termsToShow;
+
 	return (
 		<div { ...useBlockProps() }>
 			<InspectorControls>
@@ -175,22 +178,32 @@ export default function CategoriesEdit( {
 					) }
 				</PanelBody>
 				<PanelBody title={ __( 'Sorting and filtering' ) }>
-					<RangeControl
-						label={ __( 'Number of items' ) }
-						value={
-							termsToShow === SHOW_ALL
-								? currentNumberCategories
-								: termsToShow
-						}
-						onChange={ ( newValue ) =>
+					<ToggleControl
+						label={ __( 'Limit items' ) }
+						checked={ termsToShow !== SHOW_ALL }
+						onChange={ () => {
 							setAttributes( {
-								termsToShow: newValue,
-							} )
-						}
-						min={ 1 }
-						max={ MAX_TERMS_LIMIT }
-						required
+								termsToShow:
+									termsToShow === SHOW_ALL
+										? numberOfItemsToShow
+										: SHOW_ALL,
+							} );
+						} }
 					/>
+					{ termsToShow !== SHOW_ALL && (
+						<RangeControl
+							label={ __( 'Number of items' ) }
+							value={ numberOfItemsToShow }
+							onChange={ ( newValue ) =>
+								setAttributes( {
+									termsToShow: newValue,
+								} )
+							}
+							min={ 1 }
+							max={ MAX_TERMS_LIMIT }
+							required
+						/>
+					) }
 				</PanelBody>
 			</InspectorControls>
 			{ isResolving && (

--- a/packages/block-library/src/categories/edit.js
+++ b/packages/block-library/src/categories/edit.js
@@ -19,8 +19,10 @@ import { InspectorControls, useBlockProps } from '@wordpress/block-editor';
 import { __ } from '@wordpress/i18n';
 import { pin } from '@wordpress/icons';
 import { useEntityRecords } from '@wordpress/core-data';
+import { useState } from '@wordpress/element';
 
 const SHOW_ALL = -1;
+const DEFAULT_ITEMS_LIMIT = 5;
 
 // 100 is the max RangeControl supports
 const MAX_TERMS_LIMIT = 100;
@@ -50,6 +52,9 @@ export default function CategoriesEdit( {
 		'category',
 		query
 	);
+
+	const [ localTermsToShow, setLocalTermsToShow ] =
+		useState( DEFAULT_ITEMS_LIMIT );
 
 	const getCategoriesList = ( parentId ) => {
 		if ( ! categories?.length ) {
@@ -138,13 +143,6 @@ export default function CategoriesEdit( {
 		];
 	};
 
-	// Fallback to 1 is required to ensure a valid value
-	// for the range control.
-	const currentNumberCategories = categories?.length || 1;
-
-	const numberOfItemsToShow =
-		termsToShow === SHOW_ALL ? currentNumberCategories : termsToShow;
-
 	return (
 		<div { ...useBlockProps() }>
 			<InspectorControls>
@@ -179,13 +177,13 @@ export default function CategoriesEdit( {
 				</PanelBody>
 				<PanelBody title={ __( 'Sorting and filtering' ) }>
 					<ToggleControl
-						label={ __( 'Limit items' ) }
+						label={ __( 'Limit number of items' ) }
 						checked={ termsToShow !== SHOW_ALL }
 						onChange={ () => {
 							setAttributes( {
 								termsToShow:
 									termsToShow === SHOW_ALL
-										? numberOfItemsToShow
+										? localTermsToShow
 										: SHOW_ALL,
 							} );
 						} }
@@ -193,12 +191,20 @@ export default function CategoriesEdit( {
 					{ termsToShow !== SHOW_ALL && (
 						<RangeControl
 							label={ __( 'Number of items' ) }
-							value={ numberOfItemsToShow }
-							onChange={ ( newValue ) =>
+							value={
+								termsToShow === SHOW_ALL
+									? DEFAULT_ITEMS_LIMIT
+									: termsToShow
+							}
+							onChange={ ( newValue ) => {
 								setAttributes( {
 									termsToShow: newValue,
-								} )
-							}
+								} );
+
+								// Local backup to avoid Limit Items toggle
+								// wiping out the user's selection.
+								setLocalTermsToShow( newValue );
+							} }
 							min={ 1 }
 							max={ MAX_TERMS_LIMIT }
 							required

--- a/packages/block-library/src/categories/edit.js
+++ b/packages/block-library/src/categories/edit.js
@@ -12,12 +12,18 @@ import {
 	Spinner,
 	ToggleControl,
 	VisuallyHidden,
+	RangeControl,
 } from '@wordpress/components';
 import { useInstanceId } from '@wordpress/compose';
 import { InspectorControls, useBlockProps } from '@wordpress/block-editor';
 import { __ } from '@wordpress/i18n';
 import { pin } from '@wordpress/icons';
 import { useEntityRecords } from '@wordpress/core-data';
+
+const SHOW_ALL = -1;
+
+// 100 is the max RangeControl supports
+const MAX_TERMS_LIMIT = 100;
 
 export default function CategoriesEdit( {
 	attributes: {
@@ -26,11 +32,16 @@ export default function CategoriesEdit( {
 		showPostCounts,
 		showOnlyTopLevel,
 		showEmpty,
+		termsToShow,
 	},
 	setAttributes,
 } ) {
 	const selectId = useInstanceId( CategoriesEdit, 'blocks-category-select' );
-	const query = { per_page: -1, hide_empty: ! showEmpty, context: 'view' };
+	const query = {
+		per_page: termsToShow,
+		hide_empty: ! showEmpty,
+		context: 'view',
+	};
 	if ( showOnlyTopLevel ) {
 		query.parent = 0;
 	}
@@ -39,6 +50,7 @@ export default function CategoriesEdit( {
 		'category',
 		query
 	);
+
 	const getCategoriesList = ( parentId ) => {
 		if ( ! categories?.length ) {
 			return [];
@@ -126,6 +138,10 @@ export default function CategoriesEdit( {
 		];
 	};
 
+	// Fallback to 1 is required to ensure a valid value
+	// for the range control.
+	const currentNumberCategories = categories?.length || 1;
+
 	return (
 		<div { ...useBlockProps() }>
 			<InspectorControls>
@@ -157,6 +173,24 @@ export default function CategoriesEdit( {
 							onChange={ toggleAttribute( 'showHierarchy' ) }
 						/>
 					) }
+				</PanelBody>
+				<PanelBody title={ __( 'Sorting and filtering' ) }>
+					<RangeControl
+						label={ __( 'Number of items' ) }
+						value={
+							termsToShow === SHOW_ALL
+								? currentNumberCategories
+								: termsToShow
+						}
+						onChange={ ( newValue ) =>
+							setAttributes( {
+								termsToShow: newValue,
+							} )
+						}
+						min={ 1 }
+						max={ MAX_TERMS_LIMIT }
+						required
+					/>
 				</PanelBody>
 			</InspectorControls>
 			{ isResolving && (

--- a/packages/block-library/src/categories/index.php
+++ b/packages/block-library/src/categories/index.php
@@ -23,11 +23,12 @@ function render_block_core_categories( $attributes ) {
 	$args = array(
 		'echo'         => false,
 		'hierarchical' => ! empty( $attributes['showHierarchy'] ),
-		'orderby'      => 'name',
+		'orderby'      => $attributes['orderBy'],
+		'order'        => $attributes['order'],
 		'show_count'   => ! empty( $attributes['showPostCounts'] ),
 		'title_li'     => '',
 		'hide_empty'   => empty( $attributes['showEmpty'] ),
-		'number'       => $attributes['termsToShow'] === -1 ? $term_query_show_all : $attributes['termsToShow']
+		'number'       => $attributes['termsToShow'] === -1 ? $term_query_show_all : $attributes['termsToShow'],
 	);
 	if ( ! empty( $attributes['showOnlyTopLevel'] ) && $attributes['showOnlyTopLevel'] ) {
 		$args['parent'] = 0;

--- a/packages/block-library/src/categories/index.php
+++ b/packages/block-library/src/categories/index.php
@@ -16,6 +16,10 @@ function render_block_core_categories( $attributes ) {
 	static $block_id = 0;
 	$block_id++;
 
+	// WP_Term_Query `number` parameter uses 0 to represent "all".
+	// https://developer.wordpress.org/reference/classes/wp_term_query/__construct/#parameters
+	$term_query_show_all = 0;
+
 	$args = array(
 		'echo'         => false,
 		'hierarchical' => ! empty( $attributes['showHierarchy'] ),
@@ -23,6 +27,7 @@ function render_block_core_categories( $attributes ) {
 		'show_count'   => ! empty( $attributes['showPostCounts'] ),
 		'title_li'     => '',
 		'hide_empty'   => empty( $attributes['showEmpty'] ),
+		'number'       => $attributes['termsToShow'] === -1 ? $term_query_show_all : $attributes['termsToShow']
 	);
 	if ( ! empty( $attributes['showOnlyTopLevel'] ) && $attributes['showOnlyTopLevel'] ) {
 		$args['parent'] = 0;

--- a/packages/block-library/src/categories/index.php
+++ b/packages/block-library/src/categories/index.php
@@ -17,7 +17,7 @@ function render_block_core_categories( $attributes ) {
 	$block_id++;
 
 	// WP_Term_Query `number` parameter uses 0 to represent "all".
-	// https://developer.wordpress.org/reference/classes/wp_term_query/__construct/#parameters
+	// https://developer.wordpress.org/reference/classes/wp_term_query/__construct/#parameters.
 	$term_query_show_all = 0;
 
 	$args = array(
@@ -28,7 +28,7 @@ function render_block_core_categories( $attributes ) {
 		'show_count'   => ! empty( $attributes['showPostCounts'] ),
 		'title_li'     => '',
 		'hide_empty'   => empty( $attributes['showEmpty'] ),
-		'number'       => $attributes['termsToShow'] === -1 ? $term_query_show_all : $attributes['termsToShow'],
+		'number'       => -1 === $attributes['termsToShow'] ? $term_query_show_all : $attributes['termsToShow'],
 	);
 	if ( ! empty( $attributes['showOnlyTopLevel'] ) && $attributes['showOnlyTopLevel'] ) {
 		$args['parent'] = 0;

--- a/test/integration/fixtures/blocks/core__categories.json
+++ b/test/integration/fixtures/blocks/core__categories.json
@@ -7,7 +7,10 @@
 			"showHierarchy": false,
 			"showPostCounts": false,
 			"showOnlyTopLevel": false,
-			"showEmpty": false
+			"showEmpty": false,
+			"termsToShow": -1,
+			"order": "asc",
+			"orderBy": "name"
 		},
 		"innerBlocks": []
 	}


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Currently there is no way to limit the number of terms shown in the Categories block. Neither is there a way to order the items. This PR allows you to do both! 

Closes https://github.com/WordPress/gutenberg/issues/42358

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

Many designs require a limit on the number of Categories displayed. For example imagine you wanted a "Top 5 Categories". Without the ability to limit to `5` and then order by the number of associated posts (i.e. `count`) then this design is not possible.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

Adds a new attribute and associated toggle and range controls to limit the number of items displayed. Users' selection is preferred at all times to avoid losing values when toggling rapidly.

Also adds `order` and `orderBy` attributes with hard coded options of:

* name (ASC)
* name (DESC)
* count (ASC)
* count (DESC)

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->

I would recommend using FakerPress to generate the data required for testing.

1. Add some Categories.
2. Add some Posts and associate with Categories.
3. Add a Categories block.
4. See by default all Categories are shown. Check both editor and front end respect.
5. Toggle `Limit items` (should default to `5` - this is hardcoded).
6. Change the limit. Check both editor and front end respect.
7. Now change the ordering. Check both editor and front end respect.

## Screenshots or screencast <!-- if applicable -->


https://user-images.githubusercontent.com/444434/178974994-aa30ae2b-bf1e-45f2-b873-1c07594dc337.mov






Co-authored-by: Alex Lende <[alex@lende.xyz](mailto:alex@lende.xyz)>