### PR TITLE
added the allowedFormat details in richtext readme

### DIFF
--- a/packages/block-editor/src/components/rich-text/README.md
+++ b/packages/block-editor/src/components/rich-text/README.md
@@ -49,7 +49,7 @@ _Optional._ By default, all registered formats are allowed. This setting can be 
 
 ```js
 <RichText
-	tagName="h2" // The tag here is the element output and editable in the admin
+	tagName="h2"
 	value={ attributes.content } // Any existing content, either from the database or an attribute default
 	allowedFormats={ [ 'core/bold', 'core/italic' ] } // Allow the content to be made bold or italic, but do not allow othe formatting options
 	onChange={ ( content ) => setAttributes( { content } ) } // Store updated content as a block attribute

--- a/packages/block-editor/src/components/rich-text/README.md
+++ b/packages/block-editor/src/components/rich-text/README.md
@@ -50,7 +50,7 @@ _Optional._ By default, all registered formats are allowed. This setting can be 
 ```js
 <RichText
 	tagName="h2"
-	value={ attributes.content } // Any existing content, either from the database or an attribute default
+	value={ attributes.content }
 	allowedFormats={ [ 'core/bold', 'core/italic' ] } // Allow the content to be made bold or italic, but do not allow othe formatting options
 	onChange={ ( content ) => setAttributes( { content } ) } // Store updated content as a block attribute
 	placeholder={ __( 'Heading...' ) } // Display this text before any content has been added by the user

--- a/packages/block-editor/src/components/rich-text/README.md
+++ b/packages/block-editor/src/components/rich-text/README.md
@@ -52,7 +52,7 @@ _Optional._ By default, all registered formats are allowed. This setting can be 
 	tagName="h2"
 	value={ attributes.content }
 	allowedFormats={ [ 'core/bold', 'core/italic' ] } // Allow the content to be made bold or italic, but do not allow othe formatting options
-	onChange={ ( content ) => setAttributes( { content } ) } // Store updated content as a block attribute
+	onChange={ ( content ) => setAttributes( { content } ) }
 	placeholder={ __( 'Heading...' ) } // Display this text before any content has been added by the user
 />
 ```

--- a/packages/block-editor/src/components/rich-text/README.md
+++ b/packages/block-editor/src/components/rich-text/README.md
@@ -53,7 +53,7 @@ _Optional._ By default, all registered formats are allowed. This setting can be 
 	value={ attributes.content }
 	allowedFormats={ [ 'core/bold', 'core/italic' ] } // Allow the content to be made bold or italic, but do not allow othe formatting options
 	onChange={ ( content ) => setAttributes( { content } ) }
-	placeholder={ __( 'Heading...' ) } // Display this text before any content has been added by the user
+	placeholder={ __( 'Heading...' ) }
 />
 ```
 

--- a/packages/block-editor/src/components/rich-text/README.md
+++ b/packages/block-editor/src/components/rich-text/README.md
@@ -43,7 +43,19 @@ _Optional._ Called when the block can be removed. `forward` is true when the sel
 
 ### `allowedFormats: Array`
 
-_Optional._ By default, all registered formats are allowed. This setting can be used to fine-tune the allowed formats. Example: `[ 'core/bold', 'core/link' ]`.
+_Optional._ By default, all registered formats are allowed. This setting can be used to fine-tune the allowed formats. If you want to limit the formats allowed, you can specify using allowedFormats property in your code. If you want to allow only bold and italic settings, then you need to pass it in array. Example: `[ 'core/bold', 'core/link' ]`.
+
+{% ESNext %}
+
+```js
+<RichText
+	tagName="h2" // The tag here is the element output and editable in the admin
+	value={ attributes.content } // Any existing content, either from the database or an attribute default
+	allowedFormats={ [ 'core/bold', 'core/italic' ] } // Allow the content to be made bold or italic, but do not allow othe formatting options
+	onChange={ ( content ) => setAttributes( { content } ) } // Store updated content as a block attribute
+	placeholder={ __( 'Heading...' ) } // Display this text before any content has been added by the user
+/>
+```
 
 ### `withoutInteractiveFormatting: Boolean`
 


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->
In this PR I have added the information about the allowedFormats property. In richtext package documentation, there is no detailed information and example about this property. So created the PR for this.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
In [rich-text package documentation](https://github.com/WordPress/gutenberg/tree/trunk/packages/block-editor/src/components/rich-text#allowedformats-array), there should be detailed information about the allowedFormats property.

The allowedFormats property provides the formatting options in tools. If you want to display only limited formatting options to richtext then allowedFormats is used.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
In my custom Gutenberg block, I want to stop displaying some formating options so I researched a lot and found about this allowedFormats property in one blog. So I think there should be detailed example documentation about allowedFormats property in [rich text package documentation](https://github.com/WordPress/gutenberg/tree/trunk/packages/block-editor/src/components/rich-text#allowedformats-array).

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->
Open the [rich text documentation](https://github.com/WordPress/gutenberg/tree/trunk/packages/block-editor/src/components/rich-text#allowedformats-array) and you will not find any detailed info about allowedFormats property.

## Screenshots or screencast <!-- if applicable -->
