### PR TITLE
Lodash: Refactor away from `_.snakeCase()`

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -121,6 +121,7 @@ module.exports = {
 							'repeat',
 							'reverse',
 							'size',
+							'snakeCase',
 							'stubFalse',
 							'stubTrue',
 							'sum',

--- a/package-lock.json
+++ b/package-lock.json
@@ -16839,6 +16839,7 @@
 			"requires": {
 				"@wordpress/lazy-import": "file:packages/lazy-import",
 				"chalk": "^4.0.0",
+				"change-case": "^4.1.2",
 				"check-node-version": "^4.1.0",
 				"commander": "^9.2.0",
 				"execa": "^4.0.2",
@@ -16969,6 +16970,7 @@
 				"@wordpress/api-fetch": "file:packages/api-fetch",
 				"@wordpress/keycodes": "file:packages/keycodes",
 				"@wordpress/url": "file:packages/url",
+				"change-case": "^4.1.2",
 				"form-data": "^4.0.0",
 				"lodash": "^4.17.21",
 				"node-fetch": "^2.6.0"
@@ -28478,6 +28480,17 @@
 			"resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001352.tgz",
 			"integrity": "sha512-GUgH8w6YergqPQDGWhJGt8GDRnY0L/iJVQcU3eJ46GYf52R8tk0Wxp0PymuFVZboJYXGiCqwozAYZNRjVj6IcA=="
 		},
+		"capital-case": {
+			"version": "1.0.4",
+			"resolved": "https://registry.npmjs.org/capital-case/-/capital-case-1.0.4.tgz",
+			"integrity": "sha512-ds37W8CytHgwnhGGTi88pcPyR15qoNkOpYwmMMfnWqqWgESapLqvDx6huFjQ5vqWSn2Z06173XNA7LtMOeUh1A==",
+			"dev": true,
+			"requires": {
+				"no-case": "^3.0.4",
+				"tslib": "^2.0.3",
+				"upper-case-first": "^2.0.2"
+			}
+		},
 		"capture-exit": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/capture-exit/-/capture-exit-2.0.0.tgz",
@@ -28564,6 +28577,26 @@
 						"has-flag": "^4.0.0"
 					}
 				}
+			}
+		},
+		"change-case": {
+			"version": "4.1.2",
+			"resolved": "https://registry.npmjs.org/change-case/-/change-case-4.1.2.tgz",
+			"integrity": "sha512-bSxY2ws9OtviILG1EiY5K7NNxkqg/JnRnFxLtKQ96JaviiIxi7djMrSd0ECT9AC+lttClmYwKw53BWpOMblo7A==",
+			"dev": true,
+			"requires": {
+				"camel-case": "^4.1.2",
+				"capital-case": "^1.0.4",
+				"constant-case": "^3.0.4",
+				"dot-case": "^3.0.4",
+				"header-case": "^2.0.4",
+				"no-case": "^3.0.4",
+				"param-case": "^3.0.4",
+				"pascal-case": "^3.1.2",
+				"path-case": "^3.0.4",
+				"sentence-case": "^3.0.4",
+				"snake-case": "^3.0.4",
+				"tslib": "^2.0.3"
 			}
 		},
 		"char-regex": {
@@ -29621,6 +29654,17 @@
 			"version": "2.0.2",
 			"resolved": "https://registry.npmjs.org/consolidated-events/-/consolidated-events-2.0.2.tgz",
 			"integrity": "sha512-2/uRVMdRypf5z/TW/ncD/66l75P5hH2vM/GR8Jf8HLc2xnfJtmina6F6du8+v4Z2vTrMo7jC+W1tmEEuuELgkQ=="
+		},
+		"constant-case": {
+			"version": "3.0.4",
+			"resolved": "https://registry.npmjs.org/constant-case/-/constant-case-3.0.4.tgz",
+			"integrity": "sha512-I2hSBi7Vvs7BEuJDr5dDHfzb/Ruj3FyvFyh7KLilAjNQw3Be+xgqUBA2W6scVEcL0hL1dwPRtIqEPVUCKkSsyQ==",
+			"dev": true,
+			"requires": {
+				"no-case": "^3.0.4",
+				"tslib": "^2.0.3",
+				"upper-case": "^2.0.2"
+			}
 		},
 		"constants-browserify": {
 			"version": "1.0.0",
@@ -37302,6 +37346,16 @@
 			"resolved": "https://registry.npmjs.org/he/-/he-1.2.0.tgz",
 			"integrity": "sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw==",
 			"dev": true
+		},
+		"header-case": {
+			"version": "2.0.4",
+			"resolved": "https://registry.npmjs.org/header-case/-/header-case-2.0.4.tgz",
+			"integrity": "sha512-H/vuk5TEEVZwrR0lp2zed9OCo1uAILMlx0JEMgC26rzyJJ3N1v6XkwHHXJQdR2doSjcGPM6OKPYoJgf0plJ11Q==",
+			"dev": true,
+			"requires": {
+				"capital-case": "^1.0.4",
+				"tslib": "^2.0.3"
+			}
 		},
 		"hermes-engine": {
 			"version": "0.9.0",
@@ -48436,6 +48490,16 @@
 			"integrity": "sha512-BapA40NHICOS+USX9SN4tyhq+A2RrN/Ws5F0Z5aMHDp98Fl86lX8Oti8B7uN93L4Ifv4fHOEA+pQw87gmMO/lQ==",
 			"dev": true
 		},
+		"path-case": {
+			"version": "3.0.4",
+			"resolved": "https://registry.npmjs.org/path-case/-/path-case-3.0.4.tgz",
+			"integrity": "sha512-qO4qCFjXqVTrcbPt/hQfhTQ+VhFsqNKOPtytgNKkKxSoEp3XPUQ8ObFuePylOIok5gjn69ry8XiULxCwot3Wfg==",
+			"dev": true,
+			"requires": {
+				"dot-case": "^3.0.4",
+				"tslib": "^2.0.3"
+			}
+		},
 		"path-dirname": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/path-dirname/-/path-dirname-1.0.2.tgz",
@@ -53042,6 +53106,17 @@
 				}
 			}
 		},
+		"sentence-case": {
+			"version": "3.0.4",
+			"resolved": "https://registry.npmjs.org/sentence-case/-/sentence-case-3.0.4.tgz",
+			"integrity": "sha512-8LS0JInaQMCRoQ7YUytAo/xUu5W2XnQxV2HI/6uM6U7CITS1RqPElr30V6uIqyMKM9lJGRVFy5/4CuzcixNYSg==",
+			"dev": true,
+			"requires": {
+				"no-case": "^3.0.4",
+				"tslib": "^2.0.3",
+				"upper-case-first": "^2.0.2"
+			}
+		},
 		"serialize-error": {
 			"version": "2.1.0",
 			"resolved": "https://registry.npmjs.org/serialize-error/-/serialize-error-2.1.0.tgz",
@@ -53476,6 +53551,16 @@
 			"resolved": "https://registry.npmjs.org/smart-buffer/-/smart-buffer-4.1.0.tgz",
 			"integrity": "sha512-iVICrxOzCynf/SNaBQCw34eM9jROU/s5rzIhpOvzhzuYHfJR/DhZfDkXiZSgKXfgv26HT3Yni3AV/DGw0cGnnw==",
 			"dev": true
+		},
+		"snake-case": {
+			"version": "3.0.4",
+			"resolved": "https://registry.npmjs.org/snake-case/-/snake-case-3.0.4.tgz",
+			"integrity": "sha512-LAOh4z89bGQvl9pFfNF8V146i7o7/CqFPbqzYgP+yYzDIDeS9HaNFtXABamRW+AQzEVODcvE79ljJ+8a9YSdMg==",
+			"dev": true,
+			"requires": {
+				"dot-case": "^3.0.4",
+				"tslib": "^2.0.3"
+			}
 		},
 		"snapdragon": {
 			"version": "0.8.2",
@@ -57777,6 +57862,24 @@
 			"resolved": "https://registry.npmjs.org/upath/-/upath-1.2.0.tgz",
 			"integrity": "sha512-aZwGpamFO61g3OlfT7OQCHqhGnW43ieH9WZeP7QxN/G/jS4jfqUkZxoryvJgVPEcrl5NL/ggHsSmLMHuH64Lhg==",
 			"dev": true
+		},
+		"upper-case": {
+			"version": "2.0.2",
+			"resolved": "https://registry.npmjs.org/upper-case/-/upper-case-2.0.2.tgz",
+			"integrity": "sha512-KgdgDGJt2TpuwBUIjgG6lzw2GWFRCW9Qkfkiv0DxqHHLYJHmtmdUIKcZd8rHgFSjopVTlw6ggzCm1b8MFQwikg==",
+			"dev": true,
+			"requires": {
+				"tslib": "^2.0.3"
+			}
+		},
+		"upper-case-first": {
+			"version": "2.0.2",
+			"resolved": "https://registry.npmjs.org/upper-case-first/-/upper-case-first-2.0.2.tgz",
+			"integrity": "sha512-514ppYHBaKwfJRK/pNC6c/OxfGa0obSnAl106u97Ed0I625Nin96KAjttZF6ZL3e1XLtphxnqrOi9iWgm+u+bg==",
+			"dev": true,
+			"requires": {
+				"tslib": "^2.0.3"
+			}
 		},
 		"uri-js": {
 			"version": "4.2.2",

--- a/packages/create-block/lib/scaffold.js
+++ b/packages/create-block/lib/scaffold.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-const { snakeCase, camelCase, upperFirst } = require( 'lodash' );
+const { camelCase, snakeCase } = require( 'change-case' );
 
 /**
  * Internal dependencies
@@ -12,6 +12,10 @@ const initWPScripts = require( './init-wp-scripts' );
 const initWPEnv = require( './init-wp-env' );
 const { code, info, success } = require( './log' );
 const { writeOutputAsset, writeOutputTemplate } = require( './output' );
+
+function upperFirst( str ) {
+	return str.charAt( 0 ).toUpperCase() + str.substr( 1 );
+}
 
 module.exports = async (
 	{ blockOutputTemplates, pluginOutputTemplates, outputAssets },

--- a/packages/create-block/package.json
+++ b/packages/create-block/package.json
@@ -33,6 +33,7 @@
 	"dependencies": {
 		"@wordpress/lazy-import": "file:../lazy-import",
 		"chalk": "^4.0.0",
+		"change-case": "^4.1.2",
 		"check-node-version": "^4.1.0",
 		"commander": "^9.2.0",
 		"execa": "^4.0.2",

--- a/packages/e2e-test-utils/package.json
+++ b/packages/e2e-test-utils/package.json
@@ -33,6 +33,7 @@
 		"@wordpress/api-fetch": "file:../api-fetch",
 		"@wordpress/keycodes": "file:../keycodes",
 		"@wordpress/url": "file:../url",
+		"change-case": "^4.1.2",
 		"form-data": "^4.0.0",
 		"lodash": "^4.17.21",
 		"node-fetch": "^2.6.0"

--- a/packages/e2e-test-utils/src/create-user.js
+++ b/packages/e2e-test-utils/src/create-user.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { snakeCase } from 'lodash';
+import { snakeCase } from 'change-case';
 
 /**
  * Internal dependencies


### PR DESCRIPTION
## What?
This PR removes the `_.snakeCase()` usage completely and deprecates the function. It also uses the opportunity to remove a couple other Lodash usages in the same files.

## Why?

Lodash is known to unnecessarily inflate the bundle size of packages, and in most cases, it can be replaced with native language functionality. See these for more information and rationale:

* https://github.com/WordPress/gutenberg/issues/16938#issuecomment-602837246
* https://github.com/WordPress/gutenberg/issues/17025
* https://github.com/WordPress/gutenberg/issues/39495 

## How?

We're suggesting to use the `change-case` library, which offers modular functions for all the casing functions we use from Lodash (like `snakeCase`, `capitalize`, `startCase`, `camelCase`, `kebabCase` ), at a small price (the methods are small themselves), and has TS support. The benefit of using that external library for all those case conversion functions is that we won't have to maintain our own versions of them, and those are already broadly used and tested.

In particular, we replace the couple of `snakeCase()` Lodash usages in favor of the `change-case` ones, and we replace a sibling `camelCase` use with the `change-case` method. Furthermore, we replace the `upperFirst` with a custom implementation, because it's simple enough (a short one-liner).

## Testing Instructions
* Verify `npx @wordpress/create-block test-block` still works well.
* Verify all tests still pass.