### PR TITLE
Allow removing CSS declarations from the WP_Style_Engine_CSS_Declarations object

### DIFF
--- a/packages/style-engine/class-wp-style-engine-css-declarations.php
+++ b/packages/style-engine/class-wp-style-engine-css-declarations.php
@@ -98,7 +98,7 @@ class WP_Style_Engine_CSS_Declarations {
 	 *
 	 * @return void
 	 */
-	public function remove_declarations( $declarations ) {
+	public function remove_declarations( $declarations = array() ) {
 		foreach ( $declarations as $property ) {
 			$this->remove_declaration( $property );
 		}

--- a/packages/style-engine/class-wp-style-engine-css-declarations.php
+++ b/packages/style-engine/class-wp-style-engine-css-declarations.php
@@ -68,6 +68,17 @@ class WP_Style_Engine_CSS_Declarations {
 	}
 
 	/**
+	 * Remove a single declaration.
+	 *
+	 * @param string $property The CSS property.
+	 *
+	 * @return void
+	 */
+	public function remove_declaration( $property ) {
+		unset( $this->declarations[ $property ] );
+	}
+
+	/**
 	 * Add multiple declarations.
 	 *
 	 * @param array $declarations An array of declarations.
@@ -77,6 +88,19 @@ class WP_Style_Engine_CSS_Declarations {
 	public function add_declarations( $declarations ) {
 		foreach ( $declarations as $property => $value ) {
 			$this->add_declaration( $property, $value );
+		}
+	}
+
+	/**
+	 * Remove multiple declarations.
+	 *
+	 * @param array $declarations An array of properties.
+	 *
+	 * @return void
+	 */
+	public function remove_declarations( $declarations ) {
+		foreach ( $declarations as $property ) {
+			$this->remove_declaration( $property );
 		}
 	}
 

--- a/packages/style-engine/phpunit/class-wp-style-engine-css-declarations-test.php
+++ b/packages/style-engine/phpunit/class-wp-style-engine-css-declarations-test.php
@@ -105,4 +105,50 @@ class WP_Style_Engine_CSS_Declarations_Test extends WP_UnitTestCase {
 			$css_declarations->get_declarations_string()
 		);
 	}
+
+	/**
+	 * Should remove a declaration
+	 */
+	public function test_remove_declaration() {
+		$input_declarations = array(
+			'color'       => 'tomato',
+			'margin'      => '10em 10em 20em 1px',
+			'font-family' => 'Happy Font serif',
+		);
+		$css_declarations   = new WP_Style_Engine_CSS_Declarations( $input_declarations );
+
+		$this->assertSame(
+			'color: tomato; margin: 10em 10em 20em 1px; font-family: Happy Font serif;',
+			$css_declarations->get_declarations_string()
+		);
+
+		$css_declarations->remove_declaration( 'color' );
+		$this->assertSame(
+			'margin: 10em 10em 20em 1px; font-family: Happy Font serif;',
+			$css_declarations->get_declarations_string()
+		);
+	}
+
+	/**
+	 * Should remove declarations
+	 */
+	public function test_remove_declarations() {
+		$input_declarations = array(
+			'color'       => 'cucumber',
+			'margin'      => '10em 10em 20em 1px',
+			'font-family' => 'Happy Font serif',
+		);
+		$css_declarations   = new WP_Style_Engine_CSS_Declarations( $input_declarations );
+
+		$this->assertSame(
+			'color: cucumber; margin: 10em 10em 20em 1px; font-family: Happy Font serif;',
+			$css_declarations->get_declarations_string()
+		);
+
+		$css_declarations->remove_declarations( array( 'color', 'margin' ) );
+		$this->assertSame(
+			'font-family: Happy Font serif;',
+			$css_declarations->get_declarations_string()
+		);
+	}
 }


### PR DESCRIPTION
## What?
Allow removing CSS declarations from the `WP_Style_Engine_CSS_Declarations` object.

## Why?
We should be able to not only add `color: red` to an element... We should also be able to remove it when needed.

## How?
Added a `remove_declaration` and a `remove_declarations` method in the `WP_Style_Engine_CSS_Declarations` object.
