### PR TITLE
Lodash: Refactor `PageAttributesParent` away from `_.deburr()`

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17173,7 +17173,8 @@
 				"lodash": "^4.17.21",
 				"memize": "^1.1.0",
 				"react-autosize-textarea": "^7.1.0",
-				"rememo": "^4.0.0"
+				"rememo": "^4.0.0",
+				"remove-accents": "^0.4.2"
 			}
 		},
 		"@wordpress/element": {

--- a/packages/editor/package.json
+++ b/packages/editor/package.json
@@ -61,7 +61,8 @@
 		"lodash": "^4.17.21",
 		"memize": "^1.1.0",
 		"react-autosize-textarea": "^7.1.0",
-		"rememo": "^4.0.0"
+		"rememo": "^4.0.0",
+		"remove-accents": "^0.4.2"
 	},
 	"peerDependencies": {
 		"react": "^17.0.0",

--- a/packages/editor/src/components/page-attributes/parent.js
+++ b/packages/editor/src/components/page-attributes/parent.js
@@ -1,13 +1,8 @@
 /**
  * External dependencies
  */
-import {
-	get,
-	unescape as unescapeString,
-	debounce,
-	find,
-	deburr,
-} from 'lodash';
+import { get, unescape as unescapeString, debounce, find } from 'lodash';
+import removeAccents from 'remove-accents';
 
 /**
  * WordPress dependencies
@@ -32,8 +27,8 @@ function getTitle( post ) {
 }
 
 export const getItemPriority = ( name, searchValue ) => {
-	const normalizedName = deburr( name ).toLowerCase();
-	const normalizedSearch = deburr( searchValue ).toLowerCase();
+	const normalizedName = removeAccents( name || '' ).toLowerCase();
+	const normalizedSearch = removeAccents( searchValue || '' ).toLowerCase();
 	if ( normalizedName === normalizedSearch ) {
 		return 0;
 	}


### PR DESCRIPTION
## What?
This PR removes the `_.deburr()` usage from `PageAttributesParent` in the editor package. We have a couple more `deburr()` usages, but we're gracefully refactoring them in order to ensure we're not introducing bugs, since `deburr()` is a bit too liberal and works with any types of values.

## Why?

Lodash is known to unnecessarily inflate the bundle size of packages, and in most cases, it can be replaced with native language functionality. See these for more information and rationale:

* https://github.com/WordPress/gutenberg/issues/16938#issuecomment-602837246
* https://github.com/WordPress/gutenberg/issues/17025
* https://github.com/WordPress/gutenberg/issues/39495 

## How?

We're replacing it with the `remove-accents` package that we've been using as a replacement of `_.deburr()` in other packages already. We're adding a safeguard `|| ''` to ensure that the functionality behaves the same way - `deburr()` plays it safe and works with any values, and sometimes we might have a `false` value.

## Testing Instructions
* Make sure you have multiple levels of pages.
* Go to add a new page. 
* Verify that setting a parent still works the same way - selecting and searching for one.