### PR TITLE
Blocks: Add new `render` field to `block.json`

### DIFF
--- a/docs/reference-guides/block-api/block-metadata.md
+++ b/docs/reference-guides/block-api/block-metadata.md
@@ -46,14 +46,15 @@ Starting in WordPress 5.8 release, we encourage using the `block.json` metadata 
 			"title": "Example",
 			"attributes": {
 				"message": "This is an example!"
-			},
+			}
 		}
 	],
-	"editorScript": "file:./build/index.js",
-	"script": "file:./build/script.js",
-	"viewScript": "file:./build/view.js",
-	"editorStyle": "file:./build/index.css",
-	"style": "file:./build/style.css"
+	"editorScript": "file:./index.js",
+	"script": "file:./script.js",
+	"viewScript": "file:./view.js",
+	"editorStyle": "file:./index.css",
+	"style": "file:./style.css",
+	"render": "file:./render.php"
 }
 ```
 
@@ -83,7 +84,7 @@ This function takes two params relevant in this context (`$block_type` accepts m
 
 -   `$block_type` (`string`) – path to the folder where the `block.json` file is located or full path to the metadata file if named differently.
 -   `$args` (`array`) – an optional array of block type arguments. Default value: `[]`. Any arguments may be defined. However, the one described below is supported by default:
-    -   `$render_callback` (`callable`) – callback used to render blocks of this block type.
+    -   `$render_callback` (`callable`) – callback used to render blocks of this block type, it's an alternative to the `render` field in `block.json`.
 
 It returns the registered block type (`WP_Block_Type`) on success or `false` on failure.
 
@@ -432,11 +433,11 @@ See the [the example documentation](/docs/reference-guides/block-api/block-regis
 
 ### Variations
 
-- Type: `object[]`
-- Optional
-- Localized: Yes (`title`, `description`, and `keywords` of each variation only)
-- Property: `variations`
-- Since: `WordPress 5.9.0`
+-   Type: `object[]`
+-   Optional
+-   Localized: Yes (`title`, `description`, and `keywords` of each variation only)
+-   Property: `variations`
+-   Since: `WordPress 5.9.0`
 
 ```json
 {
@@ -469,7 +470,7 @@ See the [the variations documentation](/docs/reference-guides/block-api/block-va
 -   Property: `editorScript`
 
 ```json
-{ "editorScript": "file:./build/index.js" }
+{ "editorScript": "file:./index.js" }
 ```
 
 Block type editor script definition. It will only be enqueued in the context of the editor.
@@ -482,7 +483,7 @@ Block type editor script definition. It will only be enqueued in the context of 
 -   Property: `script`
 
 ```json
-{ "script": "file:./build/script.js" }
+{ "script": "file:./script.js" }
 ```
 
 Block type frontend and editor script definition. It will be enqueued both in the editor and when viewing the content on the front of the site.
@@ -496,7 +497,7 @@ Block type frontend and editor script definition. It will be enqueued both in th
 -   Since: `WordPress 5.9.0`
 
 ```json
-{ "viewScript": "file:./build/view.js" }
+{ "viewScript": "file:./view.js" }
 ```
 
 Block type frontend script definition. It will be enqueued only when viewing the content on the front of the site.
@@ -511,7 +512,7 @@ _Note: An option to pass also an array of view scripts exists since WordPress `6
 -   Property: `editorStyle`
 
 ```json
-{ "editorStyle": "file:./build/index.css" }
+{ "editorStyle": "file:./index.css" }
 ```
 
 Block type editor style definition. It will only be enqueued in the context of the editor.
@@ -526,20 +527,50 @@ _Note: An option to pass also an array of editor styles exists since WordPress `
 -   Property: `style`
 
 ```json
-{ "style": "file:./build/style.css" }
+{ "style": "file:./style.css" }
 ```
 
 Block type frontend and editor style definition. It will be enqueued both in the editor and when viewing the content on the front of the site.
 
 _Note: An option to pass also an array of styles exists since WordPress `5.9.0`._
 
+### Render
+
+-   Type: `WPDefinedPath` ([learn more](#wpdefinedpath))
+-   Optional
+-   Localized: No
+-   Property: `render`
+-   Since: `WordPress 6.1.0`
+
+```json
+{ "render": "file:./render.php" }
+```
+
+PHP file to use when rendering the block type on the server to show on the front end. The following variables are exposed to the file:
+
+-   `$attributes` (`array`): The block attributes.
+-   `$content` (`string`): The block default content.
+-   `$block` (`WP_Block`): The block instance.
+
 ## Assets
+
+### `WPDefinedPath`
+
+The `WPDefinedPath` type is a subtype of string, where the value represents a path to a JavaScript, CSS or PHP file relative to where `block.json` file is located. The path provided must be prefixed with `file:`. This approach is based on how npm handles [local paths](https://docs.npmjs.com/files/package.json#local-paths) for packages.
+
+**Example:**
+
+In `block.json`:
+
+```json
+{
+	"render": "file:./render.php"
+}
+```
 
 ### `WPDefinedAsset`
 
-The `WPDefinedAsset` type is a subtype of string, where the value represents a path to a JavaScript or CSS file relative to where `block.json` file is located. The path provided must be prefixed with `file:`. This approach is based on how npm handles [local paths](https://docs.npmjs.com/files/package.json#local-paths) for packages.
-
-An alternative would be a script or style handle name referencing an already registered asset using WordPress helpers.
+It extends `WPDefinedPath` for JavaScript and CSS files. An alternative to the file path would be a script or style handle name referencing an already registered asset using WordPress helpers.
 
 **Example:**
 
@@ -570,8 +601,8 @@ The definition is stored inside separate PHP file which ends with `.asset.php` a
 **Example:**
 
 ```
-block.json
 build/
+├─ block.json
 ├─ index.js
 └─ index.asset.php
 ```
@@ -579,7 +610,7 @@ build/
 In `block.json`:
 
 ```json
-{ "editorScript": "file:./build/index.js" }
+{ "editorScript": "file:./index.js" }
 ```
 
 In `build/index.asset.php`:

--- a/lib/compat/wordpress-6.1/blocks.php
+++ b/lib/compat/wordpress-6.1/blocks.php
@@ -228,6 +228,10 @@ function gutenberg_block_type_metadata_render_template( $settings, $metadata ) {
 		)
 	);
 
+	// Bail if the file does not exist.
+	if ( ! file_exists( $template_path ) ) {
+		return $settings;
+	}
 	/**
 	 * Renders the block on the server.
 	 *

--- a/schemas/json/block.json
+++ b/schemas/json/block.json
@@ -574,6 +574,10 @@
 					}
 				}
 			}
+		},
+		"render": {
+			"type": "string",
+			"description": "Template file loaded on the server when rendering a block."
 		}
 	},
 	"required": [ "name", "title" ],


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

A technical prototype for [Editor: Consider adding `render` property for block types](https://core.trac.wordpress.org/ticket/53148) in WordPress Trac. I will add tests and documentation only when people find this proposal useful.

Related to the proposal https://github.com/WordPress/gutenberg/pull/41289 from @ryanwelcher to add `--is-dynamic` flag to `@wordpress/create-block`.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

See comment from @spacedmonkey https://github.com/WordPress/gutenberg/pull/13693#discussion_r287337504.

> Current the render callback is a function call. How would it work as a file? Why not make it `renderTemplate` but still allow for `renderCallback`. Function calls, should be a method in a class or be namespaced, which wouldn't really work in another file.
>
> ACF blocks, has a rendercallback / render template in it's block definitions.

There is also another thread started by @spacedmonkey in https://github.com/WordPress/gutenberg/pull/13693#discussion_r288121797 which expands on this topic.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

New `render` field in `block.json` file that accepts a string value.

The path to the file should be prefixed with `file:` and be relative to the `block.json` file in the build (target) folder. It's exactly the same pattern as used with scripts and styles in `block.json`.

PHP file that renders the template for the block can use 3 variables that are the same as `render_callback` takes as params:

- `$attributes` (`array`) - block attributes.
- `$content` (`string`) - block default content.
- `$block` (`WP_Block`) - block instance.

~Important note: I refactored the Archive block to use the new `render` field in `block.json` only for testing purposes. We rather won't do it as using function declarations is problematic with this approach because template files sometimes need to load several times for a given block type. When that happens, then we encounter a function redeclaration error.~ Removed from PR.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->

Ensure that the temporarily refactored Archive blocks still work as before.

To test with custom blocks you need to add `render` field in the `block.json` file.

_Example:_

`src/block.json`

```json
{
    "name": "test/my-block",
    "render": "file:./render.php"
}
```

`src/render.php`

```php
<div <?php echo get_block_wrapper_attributes(); ?>>
    <?php echo $attributes['text']; ?>
</div>
```
