### PR TITLE
Theme.json: Fix schema for button elements

### DIFF
--- a/schemas/json/theme.json
+++ b/schemas/json/theme.json
@@ -1084,7 +1084,7 @@
 			"type": "object",
 			"properties": {
 				"button": {
-					"$ref": "#/definitions/stylesPropertiesAndElementsComplete"
+					"$ref": "#/definitions/stylesPropertiesComplete"
 				},
 				"link": {
 					"type": "object",


### PR DESCRIPTION
Follow up on: #42133

## What?
This PR fixes the schema of `styles.elements.button` in `theme.json`.

## Why?
`elements` properties can be nested forever because `stylesElementsPropertiesComplete` is defined as the schema of `styles.elements.button`


https://user-images.githubusercontent.com/54422211/178990454-9b9ab284-5c5d-4b1c-a73f-877362fa59d4.mp4

## How?
Changed `stylesElementsPropertiesComplete` to `stylesPropertiesComplete`.

## Testing Instructions

- Create a empty theme with `theme.json`.
- Set https://raw.githubusercontent.com/WordPress/gutenberg/fix/schema-theme-elements-button/schemas/json/theme.json in the schema URL.
- Confirm that the `element` property cannot be added to a `button` properties.

![theme json](https://user-images.githubusercontent.com/54422211/178991086-955546cc-8fbd-4036-b52d-d593fa309fd1.png)

