### PR TITLE
Add inline docs on building API docs to commit block API verify error message 

### DIFF
--- a/bin/api-docs/are-api-docs-unstaged.js
+++ b/bin/api-docs/are-api-docs-unstaged.js
@@ -35,7 +35,7 @@ const getUnstagedReadmes = () =>
 				'\n',
 				'Some API docs may be out of date:',
 				unstagedReadmes.toString(),
-				'Either stage them or continue with --no-verify.',
+				'Either build and stage them with npm run api-docs:blocks or continue with --no-verify.',
 				'\n'
 			)
 		);


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?

If you make a change to a block's attributes and then commit the pre-commit check will fail with the following message:

> Some API docs may be out of date: docs/reference-guides/core-blocks.md Either stage them or continue with --no-verify.

<img width="1098" alt="Screen Shot 2022-07-14 at 14 36 03" src="https://user-images.githubusercontent.com/444434/178983795-3036c746-5aff-47b2-8486-1d794373e160.png">

This PR adds instructions inline within the error message to include details on how to rebuild the API docs.


Closes https://github.com/WordPress/gutenberg/issues/42420

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

Because it's easier if the error tells you how to fix it.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

Adds instructions to error.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->

- Make temp branch.
- Make a modification to a block by adding an attribute to it's `block.json`
- Commit
- See error message containing instructions to run `npm run api-docs:blocks`.

## Screenshots or screencast <!-- if applicable -->
