### PR TITLE
Theme.json: Add support for heading / caption elements in theme.json schema

### DIFF
--- a/schemas/json/theme.json
+++ b/schemas/json/theme.json
@@ -1112,6 +1112,9 @@
 						}
 					]
 				},
+				"heading": {
+					"$ref": "#/definitions/stylesPropertiesComplete"
+				},
 				"h1": {
 					"$ref": "#/definitions/stylesPropertiesComplete"
 				},
@@ -1128,6 +1131,9 @@
 					"$ref": "#/definitions/stylesPropertiesComplete"
 				},
 				"h6": {
+					"$ref": "#/definitions/stylesPropertiesComplete"
+				},
+				"caption": {
 					"$ref": "#/definitions/stylesPropertiesComplete"
 				}
 			},


### PR DESCRIPTION
Fix: #42313

The following PRs have added global style support for the heading and caption elements:

- #41140
- #41981

We now need to update the schema for theme.json to reflect this accurately.