### PR TITLE
Writing flow: fix caret placement in corners

### DIFF
--- a/packages/dom/src/dom/place-caret-at-edge.js
+++ b/packages/dom/src/dom/place-caret-at-edge.js
@@ -22,8 +22,14 @@ function getRange( container, isReverse, x ) {
 	const containerRect = container.getBoundingClientRect();
 	// When placing at the end (isReverse), find the closest range to the bottom
 	// right corner. When placing at the start, to the top left corner.
+	// Ensure x is defined and within the container's boundaries. When it's
+	// exactly at the boundary, it's not considered within the boundaries.
 	if ( x === undefined ) {
 		x = isReverse ? containerRect.right - 1 : containerRect.left + 1;
+	} else if ( x <= containerRect.left ) {
+		x = containerRect.left + 1;
+	} else if ( x >= containerRect.right ) {
+		x = containerRect.right - 1;
 	}
 	const y = isReverseDir ? containerRect.bottom - 1 : containerRect.top + 1;
 	return hiddenCaretRangeFromPoint( ownerDocument, x, y, container );

--- a/packages/e2e-tests/specs/editor/various/writing-flow.test.js
+++ b/packages/e2e-tests/specs/editor/various/writing-flow.test.js
@@ -789,4 +789,41 @@ describe( 'Writing Flow', () => {
 			await page.evaluate( () => document.activeElement.textContent )
 		).toMatch( /^\.a+$/ );
 	} );
+
+	it( 'should vertically move the caret from corner to corner', async () => {
+		await page.keyboard.press( 'Enter' );
+		await page.keyboard.type( 'a' );
+
+		async function getHeight() {
+			return await page.evaluate(
+				() => document.activeElement.offsetHeight
+			);
+		}
+
+		const height = await getHeight();
+
+		// Keep typing until the height of the element increases. We need two
+		// lines.
+		while ( height === ( await getHeight() ) ) {
+			await page.keyboard.type( 'a' );
+		}
+
+		// Create a new paragraph.
+		await page.keyboard.press( 'Enter' );
+		// Move to the start of the first line.
+		await page.keyboard.press( 'ArrowUp' );
+		// Insert a "." for testing.
+		await page.keyboard.type( '.' );
+
+		// Expect the "." to be added at the start of the second line.
+		// It should not be added to the first line!
+		expect(
+			await page.evaluate( () =>
+				document.activeElement.getAttribute( 'data-type' )
+			)
+		).toBe( 'core/paragraph' );
+		expect(
+			await page.evaluate( () => document.activeElement.textContent )
+		).toMatch( /^a+\.a$/ );
+	} );
 } );


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?

Currently, when you move the caret up from the start of a paragraph to a paragraph with multiple lines, it moves the caret to the start of that paragraph. Instead, it should be placed at the bottom left corner.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

## How?

The problem is that we're trying to place the caret right at the edge. This doesn't work. We need to adjust the `x` value slightly inwards.

## Testing Instructions
See above and e2e test.

## Screenshots or screencast <!-- if applicable -->
