### PR TITLE
Fix: two code issues on navigation link edit missing text

### DIFF
--- a/packages/block-library/src/navigation-link/edit.js
+++ b/packages/block-library/src/navigation-link/edit.js
@@ -312,7 +312,7 @@ const useIsInvalidLink = ( kind, type, id ) => {
 	return [ isInvalid, isDraft ];
 };
 
-const useMissingText = ( type ) => {
+function getMissingText( type ) {
 	let missingText = '';
 
 	switch ( type ) {
@@ -682,7 +682,7 @@ export default function NavigationLinkEdit( {
 		'wp-block-navigation-link__placeholder': ! url || isInvalid || isDraft,
 	} );
 
-	const missingText = useMissingText( type, isInvalid, isDraft );
+	const missingText = getMissingText( type );
 	/* translators: Whether the navigation link is Invalid or a Draft. */
 	const placeholderText = `(${
 		isInvalid ? __( 'Invalid' ) : __( 'Draft' )

--- a/packages/block-library/src/navigation-link/edit.js
+++ b/packages/block-library/src/navigation-link/edit.js
@@ -338,7 +338,7 @@ function getMissingText( type ) {
 	}
 
 	return missingText;
-};
+}
 
 /**
  * Removes HTML from a given string.


### PR DESCRIPTION
This PR fixes two issues:
- We were calling useMissingText to something that is not a react hook. It is just a pure getter based on the input it returns an output.
- We were passing three parameters to the function while it only receives one.