### PR TITLE
Cover block: Remove setting of default position when toggling parallax

### DIFF
--- a/packages/block-library/src/cover/edit/index.js
+++ b/packages/block-library/src/cover/edit/index.js
@@ -161,7 +161,9 @@ function CoverEdit( {
 
 	const backgroundImage = url ? `url(${ url })` : undefined;
 
-	const backgroundPosition = mediaPosition( focalPoint );
+	const backgroundPosition = focalPoint
+		? mediaPosition( focalPoint )
+		: undefined;
 
 	const bgStyle = { backgroundColor: overlayColor.color };
 	const mediaStyle = {

--- a/packages/block-library/src/cover/save.js
+++ b/packages/block-library/src/cover/save.js
@@ -77,7 +77,9 @@ export default function save( { attributes } ) {
 
 	const backgroundImage = url ? `url(${ url })` : undefined;
 
-	const backgroundPosition = mediaPosition( focalPoint );
+	const backgroundPosition = focalPoint
+		? mediaPosition( focalPoint )
+		: undefined;
 
 	const classes = classnames(
 		{

--- a/packages/block-library/src/cover/shared.js
+++ b/packages/block-library/src/cover/shared.js
@@ -21,10 +21,9 @@ export const VIDEO_BACKGROUND_TYPE = 'video';
 export const COVER_MIN_HEIGHT = 50;
 export const COVER_MAX_HEIGHT = 1000;
 export const COVER_DEFAULT_HEIGHT = 300;
-export const DEFAULT_FOCAL_POINT = { x: 0.5, y: 0.5 };
 export const ALLOWED_MEDIA_TYPES = [ 'image', 'video' ];
 
-export function mediaPosition( { x, y } = DEFAULT_FOCAL_POINT ) {
+export function mediaPosition( { x, y } ) {
 	return `${ Math.round( x * 100 ) }% ${ Math.round( y * 100 ) }%`;
 }
 

--- a/packages/block-library/src/cover/style.scss
+++ b/packages/block-library/src/cover/style.scss
@@ -201,6 +201,8 @@
 video.wp-block-cover__video-background {
 	&.has-parallax {
 		background-attachment: fixed;
+		background-position: 50%;
+		background-size: cover;
 
 		// Mobile Safari does not support fixed background attachment properly.
 		// See also https://stackoverflow.com/questions/24154666/background-size-cover-not-working-on-ios


### PR DESCRIPTION
## What?
Removes the setting of a default focal point that was added in #40554

## Why?
To fix a change in the zooming of fixed images that this introduced. Fixes: #42407

## How?
Removes default position setting and adds additional CSS to return positioning of parallax images to pre 13.4 release

## Testing Instructions

- Add a cover block with a large background image - [like this one](https://cloudup.com/c5Uwi07_2q1)
- Toggle the fixed background option and check that the image doesn't zoom a long way way (see before and after screencasts below
- Also check that application of duotone to the image still works in editor and frontend

## Screenshots or screencast 

Before:

https://user-images.githubusercontent.com/3629020/179130317-65b1b1bf-b867-49d9-b996-2bfc0622a24d.mp4

After:

https://user-images.githubusercontent.com/3629020/179130330-818c8aa6-b90c-466c-9bde-67cdad189acb.mp4



