### PR TITLE
Theme JSON Docs: Clarify null, true, and false values for blockGap setting

### DIFF
--- a/docs/how-to-guides/themes/theme-json.md
+++ b/docs/how-to-guides/themes/theme-json.md
@@ -1201,7 +1201,7 @@ The setting for `blockGap` is either a boolean or `null` value and is `null` by 
 
 - `true`: Opt into displaying _Block spacing_ controls in the editor UI and output `blockGap` styles.
 - `false`: Opt out of displaying _Block spacing_ controls in the editor UI, with `blockGap` styles stored in `theme.json` still being rendered. This allows themes to use `blockGap` values without allowing users to make changes within the editor.
-- `null` (default): Opt out of displaying _Block spacing_ controls, _and_ prevent output of `blockGap` styles.
+- `null` (default): Opt out of displaying _Block spacing_ controls, _and_ prevent the output of `blockGap` styles.
 
 The value defined for the root `styles.spacing.blockGap` style is also output as a CSS property, named `--wp--style--block-gap`.
 

--- a/docs/how-to-guides/themes/theme-json.md
+++ b/docs/how-to-guides/themes/theme-json.md
@@ -1203,7 +1203,7 @@ The setting for `blockGap` is a boolean, and its default value is `null`. This a
 - `false`: Opt out of displaying _Block spacing_ controls in the editor UI, with `blockGap` styles stored in `theme.json` still being rendered. This allows themes to make use of `blockGap` values, without allowing users to make changes within the editor.
 - `null` (default): Opt out of displaying _Block spacing_ controls, _and_ prevent output of `blockGap` styles.
 
-The value defined for the root `blockGap` style is also output as a CSS property, named `--wp--style--block-gap`.
+The value defined for the root `styles.spacing.blockGap` style is also output as a CSS property, named `--wp--style--block-gap`.
 
 ### Why does it take so long to update the styles in the browser?
 

--- a/docs/how-to-guides/themes/theme-json.md
+++ b/docs/how-to-guides/themes/theme-json.md
@@ -1200,7 +1200,7 @@ For blocks that contain inner blocks, such as Group, Columns, Buttons, and Socia
 The setting for `blockGap` is either a boolean or `null` value and is `null` by default. This allows an extra level of control over style output. The `settings.spacing.blockGap` setting in a `theme.json` file accepts the following values:
 
 - `true`: Opt into displaying _Block spacing_ controls in the editor UI and output `blockGap` styles.
-- `false`: Opt out of displaying _Block spacing_ controls in the editor UI, with `blockGap` styles stored in `theme.json` still being rendered. This allows themes to make use of `blockGap` values, without allowing users to make changes within the editor.
+- `false`: Opt out of displaying _Block spacing_ controls in the editor UI, with `blockGap` styles stored in `theme.json` still being rendered. This allows themes to use `blockGap` values without allowing users to make changes within the editor.
 - `null` (default): Opt out of displaying _Block spacing_ controls, _and_ prevent output of `blockGap` styles.
 
 The value defined for the root `styles.spacing.blockGap` style is also output as a CSS property, named `--wp--style--block-gap`.

--- a/docs/how-to-guides/themes/theme-json.md
+++ b/docs/how-to-guides/themes/theme-json.md
@@ -1147,7 +1147,7 @@ body {
 
 /* CSS classes for the preset values */
 .has-<PRESET_SLUG>-<PRESET_TYPE> { ... }
-.has-pale-pink-color { color: var(--wp--preset--color--pale-pink) !important; } 
+.has-pale-pink-color { color: var(--wp--preset--color--pale-pink) !important; }
 .has-large-font-size { font-size: var(--wp--preset--font-size--large) !important; }
 ```
 
@@ -1179,12 +1179,7 @@ As a result of this change, it’s now the block author and theme author’s res
 
 ### What is blockGap and how can I use it?
 
-blockGap adjusts the vertical margin, or gap, between blocks.
-It is also used for margins between inner blocks in columns, buttons, and social icons.
-In the editor, the control for the blockGap is called Block spacing, located in the Dimensions panel.
-
-The value you define for the blockGap style uses a CSS property, a preset, named `--wp--style--block-gap`.
-The default value is 2em.
+For blocks that contain inner blocks, such as Group, Columns, Buttons, and Social Icons, `blockGap` controls the spacing between inner blocks. Depending on the layout of the block, the `blockGap` value will be output as either a vertical margin or a `gap` value. In the editor, the control for the `blockGap` value is called _Block spacing_, located in the Dimensions panel.
 
 ```json
 {
@@ -1201,6 +1196,14 @@ The default value is 2em.
 	}
 }
 ```
+
+The setting for `blockGap` is a boolean, and its default value is `null`. This allows an extra level of control over style output. The `settings.spacing.blockGap` setting in a `theme.json` file accepts the following values:
+
+- `true`: Opt in to displaying _Block spacing_ controls in the editor UI, and output `blockGap` styles.
+- `false`: Opt out of displaying _Block spacing_ controls in the editor UI, with `blockGap` styles stored in `theme.json` still being rendered. This allows themes to make use of `blockGap` values, without allowing users to make changes within the editor.
+- `null` (default): Opt out of displaying _Block spacing_ controls, _and_ prevent output of `blockGap` styles.
+
+The value defined for the root `blockGap` style is also output as a CSS property, named `--wp--style--block-gap`.
 
 ### Why does it take so long to update the styles in the browser?
 

--- a/docs/how-to-guides/themes/theme-json.md
+++ b/docs/how-to-guides/themes/theme-json.md
@@ -1197,7 +1197,7 @@ For blocks that contain inner blocks, such as Group, Columns, Buttons, and Socia
 }
 ```
 
-The setting for `blockGap` is a boolean, and its default value is `null`. This allows an extra level of control over style output. The `settings.spacing.blockGap` setting in a `theme.json` file accepts the following values:
+The setting for `blockGap` is either a boolean or `null` value and is `null` by default. This allows an extra level of control over style output. The `settings.spacing.blockGap` setting in a `theme.json` file accepts the following values:
 
 - `true`: Opt in to displaying _Block spacing_ controls in the editor UI, and output `blockGap` styles.
 - `false`: Opt out of displaying _Block spacing_ controls in the editor UI, with `blockGap` styles stored in `theme.json` still being rendered. This allows themes to make use of `blockGap` values, without allowing users to make changes within the editor.

--- a/docs/how-to-guides/themes/theme-json.md
+++ b/docs/how-to-guides/themes/theme-json.md
@@ -1199,7 +1199,7 @@ For blocks that contain inner blocks, such as Group, Columns, Buttons, and Socia
 
 The setting for `blockGap` is either a boolean or `null` value and is `null` by default. This allows an extra level of control over style output. The `settings.spacing.blockGap` setting in a `theme.json` file accepts the following values:
 
-- `true`: Opt in to displaying _Block spacing_ controls in the editor UI, and output `blockGap` styles.
+- `true`: Opt into displaying _Block spacing_ controls in the editor UI and output `blockGap` styles.
 - `false`: Opt out of displaying _Block spacing_ controls in the editor UI, with `blockGap` styles stored in `theme.json` still being rendered. This allows themes to make use of `blockGap` values, without allowing users to make changes within the editor.
 - `null` (default): Opt out of displaying _Block spacing_ controls, _and_ prevent output of `blockGap` styles.
 


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Update `blockGap` documentation in the handbook to reflect the three values that the setting accepts. This (hopefully) makes it clearer how themes can utilise blockGap style output, while preventing the _Block spacing_ control from being displayed in the editor UI.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

Based on discussion in https://github.com/WordPress/gutenberg/issues/40381, it appears that the unique feature of `blockGap` where it defaults to `null` but can be usefully set to `false` was undocumented. This PR attempts to document it!

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

Update the Theme JSON documentation to clarify the behaviour of `true`, `false`, and `null` for `settings.spacing.blockGap`.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->

Please check for typos / verify the information added appears to be correct.

## Screenshots or screencast <!-- if applicable -->
