### PR TITLE
Style engine: enqueue block support styles

### DIFF
--- a/lib/block-supports/elements.php
+++ b/lib/block-supports/elements.php
@@ -104,18 +104,7 @@ function gutenberg_render_elements_support_styles( $pre_render, $block ) {
 	$class_name        = gutenberg_get_elements_class_name( $block );
 	$link_block_styles = isset( $element_block_styles['link'] ) ? $element_block_styles['link'] : null;
 
-	if ( $link_block_styles ) {
-		$styles = gutenberg_style_engine_get_styles(
-			$link_block_styles,
-			array(
-				'selector' => ".$class_name a",
-			)
-		);
-
-		if ( ! empty( $styles['css'] ) ) {
-			gutenberg_enqueue_block_support_styles( $styles['css'] );
-		}
-	}
+	gutenberg_style_engine_enqueue_block_supports_styles( ".$class_name a", $link_block_styles );
 
 	return null;
 }

--- a/lib/block-supports/elements.php
+++ b/lib/block-supports/elements.php
@@ -104,7 +104,7 @@ function gutenberg_render_elements_support_styles( $pre_render, $block ) {
 	$class_name        = gutenberg_get_elements_class_name( $block );
 	$link_block_styles = isset( $element_block_styles['link'] ) ? $element_block_styles['link'] : null;
 
-	gutenberg_style_engine_get_block_supports_styles(
+	gutenberg_style_engine_get_styles(
 		$link_block_styles,
 		array(
 			'selector' => ".$class_name a",

--- a/lib/block-supports/elements.php
+++ b/lib/block-supports/elements.php
@@ -104,7 +104,13 @@ function gutenberg_render_elements_support_styles( $pre_render, $block ) {
 	$class_name        = gutenberg_get_elements_class_name( $block );
 	$link_block_styles = isset( $element_block_styles['link'] ) ? $element_block_styles['link'] : null;
 
-	gutenberg_style_engine_enqueue_block_supports_styles( ".$class_name a", $link_block_styles );
+	gutenberg_style_engine_get_block_supports_styles(
+		$link_block_styles,
+		array(
+			'selector' => ".$class_name a",
+			'enqueue'  => true,
+		)
+	);
 
 	return null;
 }

--- a/lib/block-supports/elements.php
+++ b/lib/block-supports/elements.php
@@ -108,6 +108,7 @@ function gutenberg_render_elements_support_styles( $pre_render, $block ) {
 		$link_block_styles,
 		array(
 			'selector' => ".$class_name a",
+			'context'  => 'block-supports',
 			'enqueue'  => true,
 		)
 	);

--- a/lib/block-supports/layout.php
+++ b/lib/block-supports/layout.php
@@ -208,7 +208,6 @@ function gutenberg_get_layout_style( $selector, $layout, $has_block_gap_support 
 
 		// Return compiled layout styles to retain backwards compatibility.
 		// Since https://github.com/WordPress/gutenberg/pull/42452 we no longer call wp_enqueue_block_support_styles in this block supports file.
-		var_dump(gutenberg_style_engine_get_stylesheet_from_css_rules( $layout_styles ));
 		return gutenberg_style_engine_get_stylesheet_from_css_rules( $layout_styles );
 	}
 

--- a/lib/block-supports/layout.php
+++ b/lib/block-supports/layout.php
@@ -161,9 +161,15 @@ function gutenberg_get_layout_style( $selector, $layout, $has_block_gap_support 
 	}
 
 	if ( ! empty( $layout_styles ) ) {
+		// Add to the style engine store to enqueue and render layout styles.
 		gutenberg_style_engine_add_to_store( 'layout-block-supports', $layout_styles );
+
+		// Return compiled layout styles to retain backwards compatibility.
+		// Since https://github.com/WordPress/gutenberg/pull/42452 we no longer call wp_enqueue_block_support_styles in this block supports file.
 		return gutenberg_style_engine_get_stylesheet( 'layout-block-supports' );
 	}
+
+	return '';
 }
 
 /**

--- a/lib/block-supports/layout.php
+++ b/lib/block-supports/layout.php
@@ -57,20 +57,20 @@ function gutenberg_get_layout_style( $selector, $layout, $has_block_gap_support 
 			array_push(
 				$layout_styles,
 				array(
-					'selector'         => "$selector > :where(:not(.alignleft):not(.alignright):not(.alignfull))",
-					'css_declarations' => array(
+					'selector'     => "$selector > :where(:not(.alignleft):not(.alignright):not(.alignfull))",
+					'declarations' => array(
 						'max-width'    => $all_max_width_value,
 						'margin-left'  => 'auto !important',
 						'margin-right' => 'auto !important',
 					),
 				),
 				array(
-					'selector'         => "$selector > .alignwide",
-					'css_declarations' => array( 'max-width' => $wide_max_width_value ),
+					'selector'     => "$selector > .alignwide",
+					'declarations' => array( 'max-width' => $wide_max_width_value ),
 				),
 				array(
-					'selector'         => "$selector .alignfull",
-					'css_declarations' => array( 'max-width' => 'none' ),
+					'selector'     => "$selector .alignfull",
+					'declarations' => array( 'max-width' => 'none' ),
 				)
 			);
 
@@ -86,15 +86,15 @@ function gutenberg_get_layout_style( $selector, $layout, $has_block_gap_support 
 				if ( isset( $block_spacing_values['declarations']['padding-right'] ) ) {
 					$padding_right   = $block_spacing_values['declarations']['padding-right'];
 					$layout_styles[] = array(
-						'selector'         => "$selector > .alignfull",
-						'css_declarations' => array( 'margin-right' => "calc($padding_right * -1)" ),
+						'selector'     => "$selector > .alignfull",
+						'declarations' => array( 'margin-right' => "calc($padding_right * -1)" ),
 					);
 				}
 				if ( isset( $block_spacing_values['declarations']['padding-left'] ) ) {
 					$padding_left    = $block_spacing_values['declarations']['padding-left'];
 					$layout_styles[] = array(
-						'selector'         => "$selector > .alignfull",
-						'css_declarations' => array( 'margin-left' => "calc($padding_left * -1)" ),
+						'selector'     => "$selector > .alignfull",
+						'declarations' => array( 'margin-left' => "calc($padding_left * -1)" ),
 					);
 				}
 			}
@@ -108,15 +108,15 @@ function gutenberg_get_layout_style( $selector, $layout, $has_block_gap_support 
 				array_push(
 					$layout_styles,
 					array(
-						'selector'         => "$selector > *",
-						'css_declarations' => array(
+						'selector'     => "$selector > *",
+						'declarations' => array(
 							'margin-block-start' => '0',
 							'margin-block-end'   => '0',
 						),
 					),
 					array(
-						'selector'         => "$selector > * + *",
-						'css_declarations' => array(
+						'selector'     => "$selector > * + *",
+						'declarations' => array(
 							'margin-block-start' => $gap_value,
 							'margin-block-end'   => '0',
 						),
@@ -145,8 +145,8 @@ function gutenberg_get_layout_style( $selector, $layout, $has_block_gap_support 
 
 		if ( ! empty( $layout['flexWrap'] ) && 'nowrap' === $layout['flexWrap'] ) {
 			$layout_styles[] = array(
-				'selector'         => $selector,
-				'css_declarations' => array( 'flex-wrap' => 'nowrap' ),
+				'selector'     => $selector,
+				'declarations' => array( 'flex-wrap' => 'nowrap' ),
 			);
 		}
 
@@ -158,8 +158,8 @@ function gutenberg_get_layout_style( $selector, $layout, $has_block_gap_support 
 			}
 			if ( $gap_value && ! $should_skip_gap_serialization ) {
 				$layout_styles[] = array(
-					'selector'         => $selector,
-					'css_declarations' => array( 'gapp' => $gap_value ),
+					'selector'     => $selector,
+					'declarations' => array( 'gapp' => $gap_value ),
 				);
 			}
 		}
@@ -172,15 +172,15 @@ function gutenberg_get_layout_style( $selector, $layout, $has_block_gap_support 
 			 */
 			if ( ! empty( $layout['justifyContent'] ) && array_key_exists( $layout['justifyContent'], $justify_content_options ) ) {
 				$layout_styles[] = array(
-					'selector'         => $selector,
-					'css_declarations' => array( 'justify-content' => $justify_content_options[ $layout['justifyContent'] ] ),
+					'selector'     => $selector,
+					'declarations' => array( 'justify-content' => $justify_content_options[ $layout['justifyContent'] ] ),
 				);
 			}
 
 			if ( ! empty( $layout['verticalAlignment'] ) && array_key_exists( $layout['verticalAlignment'], $vertical_alignment_options ) ) {
 				$layout_styles[] = array(
-					'selector'         => $selector,
-					'css_declarations' => array( 'align-items' => $vertical_alignment_options[ $layout['verticalAlignment'] ] ),
+					'selector'     => $selector,
+					'declarations' => array( 'align-items' => $vertical_alignment_options[ $layout['verticalAlignment'] ] ),
 				);
 			}
 		} else {
@@ -190,13 +190,13 @@ function gutenberg_get_layout_style( $selector, $layout, $has_block_gap_support 
 			);
 			if ( ! empty( $layout['justifyContent'] ) && array_key_exists( $layout['justifyContent'], $justify_content_options ) ) {
 				$layout_styles[] = array(
-					'selector'         => $selector,
-					'css_declarations' => array( 'align-items' => $justify_content_options[ $layout['justifyContent'] ] ),
+					'selector'     => $selector,
+					'declarations' => array( 'align-items' => $justify_content_options[ $layout['justifyContent'] ] ),
 				);
 			} else {
 				$layout_styles[] = array(
-					'selector'         => $selector,
-					'css_declarations' => array( 'align-items' => 'flex-start' ),
+					'selector'     => $selector,
+					'declarations' => array( 'align-items' => 'flex-start' ),
 				);
 			}
 		}

--- a/lib/block-supports/layout.php
+++ b/lib/block-supports/layout.php
@@ -159,7 +159,7 @@ function gutenberg_get_layout_style( $selector, $layout, $has_block_gap_support 
 			if ( $gap_value && ! $should_skip_gap_serialization ) {
 				$layout_styles[] = array(
 					'selector'     => $selector,
-					'declarations' => array( 'gapp' => $gap_value ),
+					'declarations' => array( 'gap' => $gap_value ),
 				);
 			}
 		}

--- a/lib/block-supports/layout.php
+++ b/lib/block-supports/layout.php
@@ -71,7 +71,7 @@ function gutenberg_get_layout_style( $selector, $layout, $has_block_gap_support 
 				array(
 					'selector'         => "$selector .alignfull",
 					'css_declarations' => array( 'max-width' => 'none' ),
-				),
+				)
 			);
 
 			if ( isset( $block_spacing ) ) {
@@ -120,7 +120,7 @@ function gutenberg_get_layout_style( $selector, $layout, $has_block_gap_support 
 							'margin-block-start' => $gap_value,
 							'margin-block-end'   => '0',
 						),
-					),
+					)
 				);
 			}
 		}

--- a/packages/style-engine/class-wp-style-engine-css-rule.php
+++ b/packages/style-engine/class-wp-style-engine-css-rule.php
@@ -110,6 +110,6 @@ class WP_Style_Engine_CSS_Rule {
 	 * @return string
 	 */
 	public function get_css() {
-		return $this->get_selector() . ' { ' . $this->declarations->get_declarations_string() . ' }';
+		return $this->get_selector() . ' {' . $this->declarations->get_declarations_string() . '}';
 	}
 }

--- a/packages/style-engine/class-wp-style-engine-css-rule.php
+++ b/packages/style-engine/class-wp-style-engine-css-rule.php
@@ -51,7 +51,7 @@ class WP_Style_Engine_CSS_Rule {
 	 *
 	 * @param string $selector The CSS selector.
 	 *
-	 * @return WP_Style_Engine_CSS_Rule Returns the object to allow chaining of methods.
+	 * @return WP_Style_Engine_CSS_Rule|void Returns the object to allow chaining of methods.
 	 */
 	public function set_selector( $selector ) {
 		if ( empty( $selector ) ) {
@@ -110,6 +110,6 @@ class WP_Style_Engine_CSS_Rule {
 	 * @return string
 	 */
 	public function get_css() {
-		return $this->get_selector() . ' {' . $this->declarations->get_declarations_string() . '}';
+		return $this->get_selector() . ' { ' . $this->declarations->get_declarations_string() . ' }';
 	}
 }

--- a/packages/style-engine/class-wp-style-engine-css-rules-store.php
+++ b/packages/style-engine/class-wp-style-engine-css-rules-store.php
@@ -27,6 +27,14 @@ class WP_Style_Engine_CSS_Rules_Store {
 	 */
 	protected static $stores = array();
 
+
+	/**
+	 * The store name.
+	 *
+	 * @var string
+	 */
+	protected $name = '';
+
 	/**
 	 * An array of CSS Rules objects assigned to the store.
 	 *
@@ -44,6 +52,8 @@ class WP_Style_Engine_CSS_Rules_Store {
 	public static function get_store( $store_name = 'default' ) {
 		if ( ! isset( static::$stores[ $store_name ] ) ) {
 			static::$stores[ $store_name ] = new static();
+			// Set the store name.
+			static::$stores[ $store_name ]->name = $store_name;
 		}
 		return static::$stores[ $store_name ];
 	}
@@ -64,6 +74,15 @@ class WP_Style_Engine_CSS_Rules_Store {
 	 */
 	public static function remove_all_stores() {
 		static::$stores = array();
+	}
+
+	/**
+	 * Get the store name.
+	 *
+	 * @return string
+	 */
+	public function get_name() {
+		return $this->name;
 	}
 
 	/**

--- a/packages/style-engine/class-wp-style-engine-css-rules-store.php
+++ b/packages/style-engine/class-wp-style-engine-css-rules-store.php
@@ -47,6 +47,25 @@ class WP_Style_Engine_CSS_Rules_Store {
 		}
 		return static::$stores[ $store_name ];
 	}
+
+	/**
+	 * Get an array of all available stores.
+	 *
+	 * @return WP_Style_Engine_CSS_Rules_Store[]
+	 */
+	public static function get_stores() {
+		return static::$stores;
+	}
+
+	/**
+	 * Clears all stores from static::$stores.
+	 *
+	 * @return void
+	 */
+	public static function remove_all_stores() {
+		static::$stores = array();
+	}
+
 	/**
 	 * Get an array of all rules.
 	 *

--- a/packages/style-engine/class-wp-style-engine-css-rules-store.php
+++ b/packages/style-engine/class-wp-style-engine-css-rules-store.php
@@ -53,7 +53,7 @@ class WP_Style_Engine_CSS_Rules_Store {
 		if ( ! isset( static::$stores[ $store_name ] ) ) {
 			static::$stores[ $store_name ] = new static();
 			// Set the store name.
-			static::$stores[ $store_name ]->name = $store_name;
+			static::$stores[ $store_name ]->set_name( $store_name );
 		}
 		return static::$stores[ $store_name ];
 	}
@@ -74,6 +74,17 @@ class WP_Style_Engine_CSS_Rules_Store {
 	 */
 	public static function remove_all_stores() {
 		static::$stores = array();
+	}
+
+	/**
+	 * Set the store name.
+	 *
+	 * @param string $name The store name.
+	 *
+	 * @return void
+	 */
+	public function set_name( $name ) {
+		$this->name = $name;
 	}
 
 	/**

--- a/packages/style-engine/class-wp-style-engine-processor.php
+++ b/packages/style-engine/class-wp-style-engine-processor.php
@@ -38,7 +38,7 @@ class WP_Style_Engine_Processor {
 	 * @param WP_Style_Engine_CSS_Rules_Store $store The store to add.
 	 */
 	public function add_store( WP_Style_Engine_CSS_Rules_Store $store ) {
-		$this->stores[] = $store;
+		$this->stores[ $store->get_name() ] = $store;
 	}
 
 	/**

--- a/packages/style-engine/class-wp-style-engine-processor.php
+++ b/packages/style-engine/class-wp-style-engine-processor.php
@@ -2,7 +2,7 @@
 /**
  * WP_Style_Engine_Processor
  *
- * Compiles styles from a store of CSS rules.
+ * Compiles styles from stores or collection of CSS rules.
  *
  * @package Gutenberg
  */
@@ -12,11 +12,18 @@ if ( class_exists( 'WP_Style_Engine_Processor' ) ) {
 }
 
 /**
- * Compiles styles from a collection of CSS rules.
+ * Compiles styles from stores or collection of CSS rules.
  *
  * @access private
  */
 class WP_Style_Engine_Processor {
+
+	/**
+	 * The Style-Engine Store objects
+	 *
+	 * @var WP_Style_Engine_CSS_Rules_Store[]
+	 */
+	protected $stores = array();
 
 	/**
 	 * The set of CSS rules that this processor will work on.
@@ -26,12 +33,12 @@ class WP_Style_Engine_Processor {
 	protected $css_rules = array();
 
 	/**
-	 * Constructor.
+	 * Add a store to the processor.
 	 *
-	 * @param WP_Style_Engine_CSS_Rule[] $css_rules An array of WP_Style_Engine_CSS_Rule objects from a store or otherwise.
+	 * @param WP_Style_Engine_CSS_Rules_Store $store The store to add.
 	 */
-	public function __construct( $css_rules = array() ) {
-		$this->add_rules( $css_rules );
+	public function add_store( WP_Style_Engine_CSS_Rules_Store $store ) {
+		$this->stores[] = $store;
 	}
 
 	/**
@@ -59,6 +66,11 @@ class WP_Style_Engine_Processor {
 	 * @return string The computed CSS.
 	 */
 	public function get_css() {
+		// If we have stores, get the rules from them.
+		foreach ( $this->stores as $store ) {
+			$this->add_rules( $store->get_all_rules() );
+		}
+
 		// Combine CSS selectors that have identical declarations.
 		$this->combine_rules_selectors();
 

--- a/packages/style-engine/class-wp-style-engine-processor.php
+++ b/packages/style-engine/class-wp-style-engine-processor.php
@@ -91,11 +91,9 @@ class WP_Style_Engine_Processor {
 		// Build an array of selectors along with the JSON-ified styles to make comparisons easier.
 		$selectors_json = array();
 		foreach ( $this->css_rules as $rule ) {
-
-			$rule_selector = $rule->get_selector();
-			$declarations  = $rule->get_declarations()->get_declarations();
+			$declarations = $rule->get_declarations()->get_declarations();
 			ksort( $declarations );
-			$selectors_json[ $rule_selector ] = wp_json_encode( $declarations );
+			$selectors_json[ $rule->get_selector() ] = wp_json_encode( $declarations );
 		}
 
 		// Combine selectors that have the same styles.
@@ -107,7 +105,7 @@ class WP_Style_Engine_Processor {
 				continue;
 			}
 
-			$new_declarations = $this->css_rules[ $selector ]->get_declarations();
+			$declarations = $this->css_rules[ $selector ]->get_declarations();
 
 			foreach ( $duplicates as $key ) {
 				// Unset the duplicates from the $selectors_json array to avoid looping through them as well.
@@ -116,7 +114,7 @@ class WP_Style_Engine_Processor {
 				unset( $this->css_rules[ $key ] );
 			}
 			// Create a new rule with the combined selectors.
-			$this->css_rules[ implode( ',', $duplicates ) ] = new WP_Style_Engine_CSS_Rule( implode( ',', $duplicates ), $new_declarations );
+			$this->css_rules[ implode( ',', $duplicates ) ] = new WP_Style_Engine_CSS_Rule( implode( ',', $duplicates ), $declarations );
 		}
 	}
 }

--- a/packages/style-engine/class-wp-style-engine-processor.php
+++ b/packages/style-engine/class-wp-style-engine-processor.php
@@ -54,9 +54,9 @@ class WP_Style_Engine_Processor {
 			$selector = $rule->get_selector();
 			if ( isset( $this->css_rules[ $selector ] ) ) {
 				$this->css_rules[ $selector ]->add_declarations( $rule->get_declarations() );
-			} else {
-				$this->css_rules[ $rule->get_selector() ] = $rule;
+				continue;
 			}
+			$this->css_rules[ $rule->get_selector() ] = $rule;
 		}
 	}
 

--- a/packages/style-engine/class-wp-style-engine-processor.php
+++ b/packages/style-engine/class-wp-style-engine-processor.php
@@ -90,7 +90,7 @@ class WP_Style_Engine_Processor {
 	private function combine_rules_selectors() {
 		// Build an array of selectors along with the JSON-ified styles to make comparisons easier.
 		$selectors_json = array();
-		foreach ( $this->css_rules as $index => $rule ) {
+		foreach ( $this->css_rules as $rule ) {
 
 			$rule_selector = $rule->get_selector();
 			$declarations  = $rule->get_declarations()->get_declarations();

--- a/packages/style-engine/class-wp-style-engine.php
+++ b/packages/style-engine/class-wp-style-engine.php
@@ -390,8 +390,8 @@ class WP_Style_Engine {
 	 * );.
 	 *
 	 * @return array array(
-	 *     'css_declarations' => (array) An array of parsed CSS property => CSS value pairs.
-	 *     'classnames'       => (array) A flat array of classnames.
+	 *     'declarations' => (array) An array of parsed CSS property => CSS value pairs.
+	 *     'classnames'   => (array) A flat array of classnames.
 	 * );
 	 */
 	public function parse_block_styles( $block_styles, $options ) {
@@ -421,8 +421,8 @@ class WP_Style_Engine {
 		}
 
 		return array(
-			'classnames'       => $classnames,
-			'css_declarations' => $css_declarations,
+			'classnames'   => $classnames,
+			'declarations' => $css_declarations,
 		);
 	}
 
@@ -653,11 +653,11 @@ function wp_style_engine_get_styles( $block_styles, $options = array() ) {
 		return $styles_output;
 	}
 
-	if ( ! empty( $parsed_styles['css_declarations'] ) ) {
-		$styles_output['css']          = $style_engine::compile_css( $parsed_styles['css_declarations'], $options['selector'] );
-		$styles_output['declarations'] = $parsed_styles['css_declarations'];
+	if ( ! empty( $parsed_styles['declarations'] ) ) {
+		$styles_output['css']          = $style_engine::compile_css( $parsed_styles['declarations'], $options['selector'] );
+		$styles_output['declarations'] = $parsed_styles['declarations'];
 		if ( true === $options['enqueue'] ) {
-			$style_engine::store_css_rule( $options['context'], $options['selector'], $parsed_styles['css_declarations'] );
+			$style_engine::store_css_rule( $options['context'], $options['selector'], $parsed_styles['declarations'] );
 		}
 	}
 
@@ -676,7 +676,7 @@ function wp_style_engine_get_styles( $block_styles, $options = array() ) {
  * @param string $store_key A valid store key.
  * @param array  $css_rules array(
  *     'selector'         => (string) A CSS selector.
- *     'css_declarations' => (boolean) An array of CSS definitions, e.g., array( "$property" => "$value" ).
+ *     'declarations' => (boolean) An array of CSS definitions, e.g., array( "$property" => "$value" ).
  * );.
  *
  * @return WP_Style_Engine_CSS_Rules_Store|null.
@@ -692,23 +692,23 @@ function wp_style_engine_add_to_store( $store_key, $css_rules = array() ) {
 	}
 
 	foreach ( $css_rules as $css_rule ) {
-		if ( ! isset( $css_rule['selector'], $css_rule['css_declarations'] ) ) {
+		if ( ! isset( $css_rule['selector'], $css_rule['declarations'] ) ) {
 			continue;
 		}
-		$style_engine::store_css_rule( $store_key, $css_rule['selector'], $css_rule['css_declarations'] );
+		$style_engine::store_css_rule( $store_key, $css_rule['selector'], $css_rule['declarations'] );
 	}
 	return $style_engine::get_store( $store_key );
 }
 
 /**
- * Returns compiled CSS from a collection of selectors and css_declarations.
+ * Returns compiled CSS from a collection of selectors and declarations.
  * This won't add to any store, but is useful for returnin a compiled style sheet from any CSS selector + declarations combos.
  *
  * @access public
  *
  * @param array $css_rules array(
- *     'selector'         => (string) A CSS selector.
- *     'css_declarations' => (boolean) An array of CSS definitions, e.g., array( "$property" => "$value" ).
+ *     'selector'     => (string) A CSS selector.
+ *     'declarations' => (boolean) An array of CSS definitions, e.g., array( "$property" => "$value" ).
  * );.
  *
  * @return string A compiled CSS string.
@@ -722,14 +722,14 @@ function wp_style_engine_get_stylesheet_from_css_rules( $css_rules = array() ) {
 	$css_rule_objects = array();
 
 	foreach ( $css_rules as $css_rule ) {
-		if ( ! isset( $css_rule['selector'], $css_rule['css_declarations'] ) ) {
+		if ( ! isset( $css_rule['selector'], $css_rule['declarations'] ) ) {
 			continue;
 		}
 
-		if ( empty( $css_rule['css_declarations'] ) || ! is_array( $css_rule['css_declarations'] ) ) {
+		if ( empty( $css_rule['declarations'] ) || ! is_array( $css_rule['declarations'] ) ) {
 			continue;
 		}
-		$css_rule_objects[] = new WP_Style_Engine_CSS_Rule( $css_rule['selector'], $css_rule['css_declarations'] );
+		$css_rule_objects[] = new WP_Style_Engine_CSS_Rule( $css_rule['selector'], $css_rule['declarations'] );
 	}
 
 	if ( empty( $css_rule_objects ) ) {

--- a/packages/style-engine/class-wp-style-engine.php
+++ b/packages/style-engine/class-wp-style-engine.php
@@ -638,12 +638,11 @@ function wp_style_engine_get_styles( $block_styles, $options = array() ) {
 	);
 
 	$options       = wp_parse_args( $options, $defaults );
-	$style_engine  = WP_Style_Engine::get_instance();
 	$parsed_styles = null;
 
 	// Block supports styles.
 	if ( 'block-supports' === $options['context'] ) {
-		$parsed_styles = $style_engine::parse_block_styles( $block_styles, $options );
+		$parsed_styles = WP_Style_Engine::parse_block_styles( $block_styles, $options );
 	}
 
 	// Output.
@@ -654,10 +653,10 @@ function wp_style_engine_get_styles( $block_styles, $options = array() ) {
 	}
 
 	if ( ! empty( $parsed_styles['declarations'] ) ) {
-		$styles_output['css']          = $style_engine::compile_css( $parsed_styles['declarations'], $options['selector'] );
+		$styles_output['css']          = WP_Style_Engine::compile_css( $parsed_styles['declarations'], $options['selector'] );
 		$styles_output['declarations'] = $parsed_styles['declarations'];
 		if ( true === $options['enqueue'] ) {
-			$style_engine::store_css_rule( $options['context'], $options['selector'], $parsed_styles['declarations'] );
+			WP_Style_Engine::store_css_rule( $options['context'], $options['selector'], $parsed_styles['declarations'] );
 		}
 	}
 
@@ -686,18 +685,17 @@ function wp_style_engine_add_to_store( $store_key, $css_rules = array() ) {
 		return null;
 	}
 
-	$style_engine = WP_Style_Engine::get_instance();
 	if ( empty( $css_rules ) ) {
-		return $style_engine::get_store( $store_key );
+		return WP_Style_Engine::get_store( $store_key );
 	}
 
 	foreach ( $css_rules as $css_rule ) {
 		if ( ! isset( $css_rule['selector'], $css_rule['declarations'] ) ) {
 			continue;
 		}
-		$style_engine::store_css_rule( $store_key, $css_rule['selector'], $css_rule['declarations'] );
+		WP_Style_Engine::store_css_rule( $store_key, $css_rule['selector'], $css_rule['declarations'] );
 	}
-	return $style_engine::get_store( $store_key );
+	return WP_Style_Engine::get_store( $store_key );
 }
 
 /**
@@ -718,7 +716,6 @@ function wp_style_engine_get_stylesheet_from_css_rules( $css_rules = array() ) {
 		return '';
 	}
 
-	$style_engine     = WP_Style_Engine::get_instance();
 	$css_rule_objects = array();
 
 	foreach ( $css_rules as $css_rule ) {
@@ -736,5 +733,5 @@ function wp_style_engine_get_stylesheet_from_css_rules( $css_rules = array() ) {
 		return '';
 	}
 
-	return $style_engine::compile_stylesheet_from_css_rules( $css_rule_objects );
+	return WP_Style_Engine::compile_stylesheet_from_css_rules( $css_rule_objects );
 }

--- a/packages/style-engine/class-wp-style-engine.php
+++ b/packages/style-engine/class-wp-style-engine.php
@@ -373,17 +373,8 @@ class WP_Style_Engine {
 				continue;
 			}
 
-			$css_rules = $store_instance->get_all_rules();
-
-			if ( empty( $css_rules ) ) {
-				continue;
-			}
-
-			$styles_output = '';
-
-			foreach ( $css_rules as $css_rule ) {
-				$styles_output .= $css_rule->get_css();
-			}
+			$processor     = new WP_Style_Engine_Processor( $store_instance );
+			$styles_output = $processor->get_css();
 
 			if ( ! empty( $styles_output ) ) {
 				wp_register_style( $store_key, false, array(), true, true );

--- a/packages/style-engine/class-wp-style-engine.php
+++ b/packages/style-engine/class-wp-style-engine.php
@@ -31,16 +31,6 @@ class WP_Style_Engine {
 	private static $instance = null;
 
 	/**
-	 * Instance of WP_Style_Engine_CSS_Rules_Store to hold block supports CSS rules.
-	 *
-	 * @var array<string, WP_Style_Engine_CSS_Rules_Store|null>
-	 */
-	private static $stores = array(
-		'layout-block-supports' => null,
-		'block-supports'        => null,
-	);
-
-	/**
 	 * Style definitions that contain the instructions to
 	 * parse/output valid Gutenberg styles from a block's attributes.
 	 * For every style definition, the follow properties are valid:
@@ -292,9 +282,6 @@ class WP_Style_Engine {
 	 * Private constructor to prevent instantiation.
 	 */
 	private function __construct() {
-		foreach ( static::$stores as $store_key => $store_instance ) {
-			static::$stores[ $store_key ] = WP_Style_Engine_CSS_Rules_Store::get_store( $store_key );
-		}
 		// Register the hook callback to render stored styles to the page.
 		static::render_styles( array( __CLASS__, 'process_and_enqueue_stored_styles' ) );
 	}
@@ -319,31 +306,26 @@ class WP_Style_Engine {
 	 *
 	 * @param string $css_selector     When a selector is passed, the function will return a full CSS rule `$selector { ...rules }`, otherwise a concatenated string of properties and values.
 	 * @param array  $css_declarations An array of parsed CSS property => CSS value pairs.
-	 * @param string $store_key        A valid key corresponding to an existing store in static::$stores.
+	 * @param string $store_key        A valid store key.
 	 *
 	 * @return void.
 	 */
 	public static function store_css_rule( $css_selector, $css_declarations, $store_key ) {
-		if ( ! $css_selector || ! isset( static::$stores[ $store_key ] ) ) {
+		if ( empty( $css_selector ) || empty( $css_declarations ) ) {
 			return;
 		}
-		$css_declarations = new WP_Style_Engine_CSS_Declarations( $css_declarations );
-		$stored_css_rule  = static::$stores[ $store_key ]->add_rule( $css_selector );
-		$stored_css_rule->add_declarations( $css_declarations );
+		static::get_store( $store_key )->add_rule( $css_selector )->add_declarations( $css_declarations );
 	}
 
 	/**
 	 * Returns a store by store key.
 	 *
-	 * @param string $store_key A valid key corresponding to an existing store in static::$stores.
+	 * @param string $store_key A store key.
 	 *
-	 * @return WP_Style_Engine_CSS_Rules_Store|null The store, if found, otherwise `null`.
+	 * @return WP_Style_Engine_CSS_Rules_Store
 	 */
 	public static function get_store( $store_key ) {
-		if ( ! isset( static::$stores[ $store_key ] ) ) {
-			return null;
-		}
-		return static::$stores[ $store_key ];
+		return WP_Style_Engine_CSS_Rules_Store::get_store( $store_key );
 	}
 
 	/**
@@ -382,14 +364,16 @@ class WP_Style_Engine {
 	 * Fetches, processes and compiles stored styles, then renders them to the page.
 	 */
 	public static function process_and_enqueue_stored_styles() {
-		// 1. Block supports
-		// @TODO we could loop through static::$stores to enqueue and get the key.
-		$styles_output = static::compile_stylesheet_from_store( 'block-supports' ) . static::compile_stylesheet_from_store( 'layout-block-supports' );
+		$stores = WP_Style_Engine_CSS_Rules_Store::get_stores();
 
-		if ( ! empty( $styles_output ) ) {
-			wp_register_style( 'block-supports', false, array(), true, true );
-			wp_add_inline_style( 'block-supports', $styles_output );
-			wp_enqueue_style( 'block-supports' );
+		foreach ( $stores as $key => $store ) {
+			$styles = static::compile_stylesheet_from_store( $key );
+
+			if ( ! empty( $styles ) ) {
+				wp_register_style( $key, false, array(), true, true );
+				wp_add_inline_style( $key, $styles );
+				wp_enqueue_style( $key );
+			}
 		}
 	}
 
@@ -595,40 +579,21 @@ class WP_Style_Engine {
 		if ( $css_selector ) {
 			$css_rule = new WP_Style_Engine_CSS_Rule( $css_selector, $css_declarations );
 			return $css_rule->get_css();
-		} else {
-			$css_declarations = new WP_Style_Engine_CSS_Declarations( $css_declarations );
-			return $css_declarations->get_declarations_string();
 		}
-	}
-
-	/**
-	 * Returns a string of classnames,
-	 *
-	 * @param string $classnames A flat array of classnames.
-	 *
-	 * @return string A string of classnames separate by a space.
-	 */
-	public function compile_classnames( $classnames ) {
-		if ( empty( $classnames ) || ! is_array( $classnames ) ) {
-			return null;
-		}
-		return implode( ' ', array_unique( $classnames ) );
+		$css_declarations = new WP_Style_Engine_CSS_Declarations( $css_declarations );
+		return $css_declarations->get_declarations_string();
 	}
 
 	/**
 	 * Returns a compiled stylesheet from stored CSS rules.
 	 *
-	 * @param string $store_key A valid key corresponding to an existing store in static::$stores.
+	 * @param string $store_key A valid key.
 	 *
 	 * @return string A compiled stylesheet from stored CSS rules.
 	 */
 	public static function compile_stylesheet_from_store( $store_key ) {
-		$store = static::get_store( $store_key );
-		if ( $store ) {
-			$processor = new WP_Style_Engine_Processor( $store );
-			return $processor->get_css();
-		}
-		return '';
+		$processor = new WP_Style_Engine_Processor( static::get_store( $store_key ) );
+		return $processor->get_css();
 	}
 }
 
@@ -683,7 +648,7 @@ function wp_style_engine_get_styles( $block_styles, $options = array() ) {
 	}
 
 	if ( ! empty( $parsed_styles['classnames'] ) ) {
-		$styles_output['classnames'] = $style_engine->compile_classnames( $parsed_styles['classnames'] );
+		$styles_output['classnames'] = implode( ' ', array_unique( $parsed_styles['classnames'] ) );
 	}
 
 	return array_filter( $styles_output );
@@ -700,19 +665,21 @@ function wp_style_engine_get_styles( $block_styles, $options = array() ) {
  *     'css_declarations' => (boolean) An array of CSS definitions, e.g., array( "$property" => "$value" ).
  * );.
  *
- * @return WP_Style_Engine_CSS_Rules_Store|null The store, if found, otherwise `null`.
+ * @return WP_Style_Engine_CSS_Rules_Store.
  */
 function wp_style_engine_add_to_store( $store_key, $css_rules = array() ) {
-	if ( empty( $store_key ) || empty( $css_rules ) ) {
-		return null;
-	}
-	if ( class_exists( 'WP_Style_Engine' ) ) {
-		$style_engine = WP_Style_Engine::get_instance();
-		foreach ( $css_rules as $selector => $css_declarations ) {
-			$style_engine::store_css_rule( $selector, $css_declarations, $store_key );
-		}
+	$style_engine = WP_Style_Engine::get_instance();
+	if ( empty( $css_rules ) ) {
 		return $style_engine::get_store( $store_key );
 	}
+
+	foreach ( $css_rules as $selector => $css_declarations ) {
+		if ( empty( $selector ) || empty( $css_declarations ) ) {
+			continue;
+		}
+		$style_engine::store_css_rule( $selector, $css_declarations, $store_key );
+	}
+	return $style_engine::get_store( $store_key );
 }
 
 /**
@@ -726,11 +693,8 @@ function wp_style_engine_add_to_store( $store_key, $css_rules = array() ) {
  */
 function wp_style_engine_get_stylesheet( $store_key ) {
 	if ( empty( $store_key ) ) {
-		return null;
+		return '';
 	}
-	if ( class_exists( 'WP_Style_Engine' ) ) {
-		return WP_Style_Engine::get_instance()::compile_stylesheet_from_store( $store_key );
-	}
-	return null;
+	return WP_Style_Engine::get_instance()::compile_stylesheet_from_store( $store_key );
 }
 

--- a/packages/style-engine/class-wp-style-engine.php
+++ b/packages/style-engine/class-wp-style-engine.php
@@ -600,7 +600,7 @@ class WP_Style_Engine {
 }
 
 /**
- * Global public interface method to WP_Style_Engine::get_styles to generate styles from a single style object, e.g.,
+ * Global public interface method to generate styles from a single style object, e.g.,
  * the value of a block's attributes.style object or the top level styles in theme.json.
  * See: https://developer.wordpress.org/block-editor/reference-guides/theme-json-reference/theme-json-living/#styles and
  * https://developer.wordpress.org/block-editor/reference-guides/block-api/block-supports/
@@ -685,17 +685,20 @@ function wp_style_engine_add_to_store( $store_key, $css_rules = array() ) {
 		return null;
 	}
 
+	// Get instance here to ensure that we register hooks to enqueue stored styles.
+	$style_engine = WP_Style_Engine::get_instance();
+
 	if ( empty( $css_rules ) ) {
-		return WP_Style_Engine::get_store( $store_key );
+		return $style_engine::get_store( $store_key );
 	}
 
 	foreach ( $css_rules as $css_rule ) {
 		if ( ! isset( $css_rule['selector'], $css_rule['declarations'] ) ) {
 			continue;
 		}
-		WP_Style_Engine::store_css_rule( $store_key, $css_rule['selector'], $css_rule['declarations'] );
+		$style_engine::store_css_rule( $store_key, $css_rule['selector'], $css_rule['declarations'] );
 	}
-	return WP_Style_Engine::get_store( $store_key );
+	return $style_engine::get_store( $store_key );
 }
 
 /**

--- a/packages/style-engine/class-wp-style-engine.php
+++ b/packages/style-engine/class-wp-style-engine.php
@@ -518,9 +518,10 @@ class WP_Style_Engine {
 			$styles_output['declarations'] = $css_declarations->get_declarations();
 			// Return an entire rule if there is a selector.
 			if ( $css_selector ) {
-				$styles_output['css'] = $css_selector . ' { ' . $css . ' }';
+				$css_rule             = new WP_Style_Engine_CSS_Rule( $css_selector, $css_declarations );
+				$styles_output['css'] = $css_rule->get_css();
 				if ( $should_store_and_enqueue ) {
-					$stored_css_rule = static::$stores['block-supports']->get_rule( $css_selector );
+					$stored_css_rule = static::$stores['block-supports']->add_rule( $css_selector );
 					$stored_css_rule->set_declarations( $css_declarations );
 				}
 			}

--- a/packages/style-engine/class-wp-style-engine.php
+++ b/packages/style-engine/class-wp-style-engine.php
@@ -694,7 +694,7 @@ function wp_style_engine_add_to_store( $store_key, $css_rules = array() ) {
 	}
 
 	foreach ( $css_rules as $css_rule ) {
-		if ( ! isset( $css_rule['selector'], $css_rule['declarations'] ) ) {
+		if ( empty( $css_rule['selector'] ) || empty( $css_rule['declarations'] ) ) {
 			continue;
 		}
 		$style_engine::store_css_rule( $store_key, $css_rule['selector'], $css_rule['declarations'] );

--- a/packages/style-engine/class-wp-style-engine.php
+++ b/packages/style-engine/class-wp-style-engine.php
@@ -723,11 +723,7 @@ function wp_style_engine_get_stylesheet_from_css_rules( $css_rules = array() ) {
 	$css_rule_objects = array();
 
 	foreach ( $css_rules as $css_rule ) {
-		if ( ! isset( $css_rule['selector'], $css_rule['declarations'] ) ) {
-			continue;
-		}
-
-		if ( empty( $css_rule['declarations'] ) || ! is_array( $css_rule['declarations'] ) ) {
+		if ( empty( $css_rule['selector'] ) || empty( $css_rule['declarations'] ) || ! is_array( $css_rule['declarations'] ) ) {
 			continue;
 		}
 		$css_rule_objects[] = new WP_Style_Engine_CSS_Rule( $css_rule['selector'], $css_rule['declarations'] );

--- a/packages/style-engine/class-wp-style-engine.php
+++ b/packages/style-engine/class-wp-style-engine.php
@@ -738,22 +738,3 @@ function wp_style_engine_get_stylesheet_from_css_rules( $css_rules = array() ) {
 
 	return $style_engine::compile_stylesheet_from_css_rules( $css_rule_objects );
 }
-
-/**
- * Returns a compiled stylesheet from stored CSS rules.
- *
- * @access public
- *
- * @param string $store_key        A valid store key.
- *
- * @return string A compiled stylesheet from stored CSS rules.
- */
-function wp_style_engine_get_stylesheet_from_store( $store_key ) {
-	if ( empty( $store_key ) || ! class_exists( 'WP_Style_Engine' ) ) {
-		return '';
-	}
-
-	$style_engine = WP_Style_Engine::get_instance();
-	$store        = $style_engine::get_store( $store_key );
-	return WP_Style_Engine::compile_stylesheet_from_css_rules( $store->get_all_rules() );
-}

--- a/packages/style-engine/class-wp-style-engine.php
+++ b/packages/style-engine/class-wp-style-engine.php
@@ -304,7 +304,7 @@ class WP_Style_Engine {
 
 			$styles_output = '';
 
-			foreach ( $css_rules as $selector => $css_rule ) {
+			foreach ( $css_rules as $selector => $css_rule ) { // phpcs:ignore VariableAnalysis.CodeAnalysis.VariableAnalysis.UnusedVariable
 				$styles_output .= $css_rule->get_css();
 			}
 

--- a/packages/style-engine/class-wp-style-engine.php
+++ b/packages/style-engine/class-wp-style-engine.php
@@ -367,7 +367,9 @@ class WP_Style_Engine {
 		$stores = WP_Style_Engine_CSS_Rules_Store::get_stores();
 
 		foreach ( $stores as $key => $store ) {
-			$styles = static::compile_stylesheet_from_css_rules( $store->get_all_rules() );
+			$processor = new WP_Style_Engine_Processor();
+			$processor->add_store( $store );
+			$styles = $processor->get_css();
 
 			if ( ! empty( $styles ) ) {
 				wp_register_style( $key, false, array(), true, true );
@@ -591,7 +593,8 @@ class WP_Style_Engine {
 	 * @return string A compiled stylesheet from stored CSS rules.
 	 */
 	public static function compile_stylesheet_from_css_rules( $css_rules ) {
-		$processor = new WP_Style_Engine_Processor( $css_rules );
+		$processor = new WP_Style_Engine_Processor();
+		$processor->add_rules( $css_rules );
 		return $processor->get_css();
 	}
 }
@@ -752,5 +755,5 @@ function wp_style_engine_get_stylesheet_from_store( $store_key ) {
 
 	$style_engine = WP_Style_Engine::get_instance();
 	$store        = $style_engine::get_store( $store_key );
-	return WP_Style_Engine::get_instance()::compile_stylesheet_from_css_rules( $store->get_all_rules() );
+	return WP_Style_Engine::compile_stylesheet_from_css_rules( $store->get_all_rules() );
 }

--- a/packages/style-engine/class-wp-style-engine.php
+++ b/packages/style-engine/class-wp-style-engine.php
@@ -659,34 +659,34 @@ class WP_Style_Engine {
  * );
  */
 function wp_style_engine_get_styles( $block_styles, $options = array() ) {
-	if ( class_exists( 'WP_Style_Engine' ) ) {
-		$defaults = array(
-			'selector'                   => null,
-			'convert_vars_to_classnames' => false,
-			'enqueue'                    => false,
-		);
-
-		$options       = wp_parse_args( $options, $defaults );
-		$style_engine  = WP_Style_Engine::get_instance();
-		$parsed_styles = $style_engine->parse_block_supports_styles( $block_styles, $options );
-
-		// Output.
-		$styles_output = array();
-		if ( ! empty( $parsed_styles['css_declarations'] ) ) {
-			$styles_output['css']          = $style_engine->compile_css( $parsed_styles['css_declarations'], $options['selector'] );
-			$styles_output['declarations'] = $parsed_styles['css_declarations'];
-			if ( true === $options['enqueue'] ) {
-				$style_engine::store_css_rule( $options['selector'], $parsed_styles['css_declarations'], 'block-supports' );
-			}
-		}
-
-		if ( ! empty( $parsed_styles['classnames'] ) ) {
-			$styles_output['classnames'] = $style_engine->compile_classnames( $parsed_styles['classnames'] );
-		}
-
-		return array_filter( $styles_output );
+	if ( ! class_exists( 'WP_Style_Engine' ) ) {
+		return array();
 	}
-	return array();
+	$defaults = array(
+		'selector'                   => null,
+		'convert_vars_to_classnames' => false,
+		'enqueue'                    => false,
+	);
+
+	$options       = wp_parse_args( $options, $defaults );
+	$style_engine  = WP_Style_Engine::get_instance();
+	$parsed_styles = $style_engine->parse_block_supports_styles( $block_styles, $options );
+
+	// Output.
+	$styles_output = array();
+	if ( ! empty( $parsed_styles['css_declarations'] ) ) {
+		$styles_output['css']          = $style_engine->compile_css( $parsed_styles['css_declarations'], $options['selector'] );
+		$styles_output['declarations'] = $parsed_styles['css_declarations'];
+		if ( true === $options['enqueue'] ) {
+			$style_engine::store_css_rule( $options['selector'], $parsed_styles['css_declarations'], 'block-supports' );
+		}
+	}
+
+	if ( ! empty( $parsed_styles['classnames'] ) ) {
+		$styles_output['classnames'] = $style_engine->compile_classnames( $parsed_styles['classnames'] );
+	}
+
+	return array_filter( $styles_output );
 }
 
 /**

--- a/packages/style-engine/class-wp-style-engine.php
+++ b/packages/style-engine/class-wp-style-engine.php
@@ -283,7 +283,7 @@ class WP_Style_Engine {
 	 */
 	private function __construct() {
 		// Register the hook callback to render stored styles to the page.
-		static::render_styles( array( __CLASS__, 'process_and_enqueue_stored_styles' ) );
+		static::register_actions( array( __CLASS__, 'process_and_enqueue_stored_styles' ) );
 	}
 
 	/**
@@ -331,7 +331,7 @@ class WP_Style_Engine {
 	/**
 	 * Taken from gutenberg_enqueue_block_support_styles()
 	 *
-	 * This function takes care of adding inline styles
+	 * This function takes care of registering hooks to add inline styles
 	 * in the proper place, depending on the theme in use.
 	 *
 	 * For block themes, it's loaded in the head.
@@ -344,7 +344,7 @@ class WP_Style_Engine {
 	 *
 	 * @see gutenberg_enqueue_block_support_styles()
 	 */
-	protected static function render_styles( $callable, $priority = 10 ) {
+	protected static function register_actions( $callable, $priority = 10 ) {
 		if ( ! $callable ) {
 			return;
 		}
@@ -637,12 +637,13 @@ function wp_style_engine_get_styles( $block_styles, $options = array() ) {
 		'enqueue'                    => false,
 	);
 
+	$style_engine  = WP_Style_Engine::get_instance();
 	$options       = wp_parse_args( $options, $defaults );
 	$parsed_styles = null;
 
 	// Block supports styles.
 	if ( 'block-supports' === $options['context'] ) {
-		$parsed_styles = WP_Style_Engine::parse_block_styles( $block_styles, $options );
+		$parsed_styles = $style_engine::parse_block_styles( $block_styles, $options );
 	}
 
 	// Output.
@@ -653,10 +654,10 @@ function wp_style_engine_get_styles( $block_styles, $options = array() ) {
 	}
 
 	if ( ! empty( $parsed_styles['declarations'] ) ) {
-		$styles_output['css']          = WP_Style_Engine::compile_css( $parsed_styles['declarations'], $options['selector'] );
+		$styles_output['css']          = $style_engine::compile_css( $parsed_styles['declarations'], $options['selector'] );
 		$styles_output['declarations'] = $parsed_styles['declarations'];
 		if ( true === $options['enqueue'] ) {
-			WP_Style_Engine::store_css_rule( $options['context'], $options['selector'], $parsed_styles['declarations'] );
+			$style_engine::store_css_rule( $options['context'], $options['selector'], $parsed_styles['declarations'] );
 		}
 	}
 

--- a/packages/style-engine/class-wp-style-engine.php
+++ b/packages/style-engine/class-wp-style-engine.php
@@ -394,7 +394,7 @@ class WP_Style_Engine {
 	 *     'classnames'   => (array) A flat array of classnames.
 	 * );
 	 */
-	public function parse_block_styles( $block_styles, $options ) {
+	public static function parse_block_styles( $block_styles, $options ) {
 		if ( empty( $block_styles ) || ! is_array( $block_styles ) ) {
 			return array();
 		}
@@ -600,7 +600,7 @@ class WP_Style_Engine {
 }
 
 /**
- * Global public interface method to WP_Style_Engine->get_styles to generate styles from a single style object, e.g.,
+ * Global public interface method to WP_Style_Engine::get_styles to generate styles from a single style object, e.g.,
  * the value of a block's attributes.style object or the top level styles in theme.json.
  * See: https://developer.wordpress.org/block-editor/reference-guides/theme-json-reference/theme-json-living/#styles and
  * https://developer.wordpress.org/block-editor/reference-guides/block-api/block-supports/
@@ -643,7 +643,7 @@ function wp_style_engine_get_styles( $block_styles, $options = array() ) {
 
 	// Block supports styles.
 	if ( 'block-supports' === $options['context'] ) {
-		$parsed_styles = $style_engine->parse_block_styles( $block_styles, $options );
+		$parsed_styles = $style_engine::parse_block_styles( $block_styles, $options );
 	}
 
 	// Output.
@@ -702,7 +702,7 @@ function wp_style_engine_add_to_store( $store_key, $css_rules = array() ) {
 
 /**
  * Returns compiled CSS from a collection of selectors and declarations.
- * This won't add to any store, but is useful for returnin a compiled style sheet from any CSS selector + declarations combos.
+ * This won't add to any store, but is useful for returning a compiled style sheet from any CSS selector + declarations combos.
  *
  * @access public
  *

--- a/packages/style-engine/class-wp-style-engine.php
+++ b/packages/style-engine/class-wp-style-engine.php
@@ -348,13 +348,9 @@ class WP_Style_Engine {
 		if ( ! $callable ) {
 			return;
 		}
-		$action_hook_name = 'wp_footer';
-		if ( wp_is_block_theme() ) {
-			$action_hook_name = 'wp_head';
-		}
 		add_action( 'wp_enqueue_scripts', $callable );
 		add_action(
-			$action_hook_name,
+			wp_is_block_theme() ? 'wp_head' : 'wp_footer',
 			$callable,
 			$priority
 		);
@@ -472,10 +468,7 @@ class WP_Style_Engine {
 	 * @return array        An array of CSS definitions, e.g., array( "$property" => "$value" ).
 	 */
 	protected static function get_css_declarations( $style_value, $style_definition, $should_skip_css_vars = false ) {
-		if (
-			isset( $style_definition['value_func'] ) &&
-			is_callable( $style_definition['value_func'] )
-		) {
+		if ( isset( $style_definition['value_func'] ) && is_callable( $style_definition['value_func'] ) ) {
 			return call_user_func( $style_definition['value_func'], $style_value, $style_definition, $should_skip_css_vars );
 		}
 

--- a/packages/style-engine/phpunit/class-wp-style-engine-css-rule-test.php
+++ b/packages/style-engine/phpunit/class-wp-style-engine-css-rule-test.php
@@ -27,7 +27,7 @@ class WP_Style_Engine_CSS_Rule_Test extends WP_UnitTestCase {
 
 		$this->assertSame( $selector, $css_rule->get_selector() );
 
-		$expected = "$selector {{$css_declarations->get_declarations_string()}}";
+		$expected = "$selector { {$css_declarations->get_declarations_string()} }";
 		$this->assertSame( $expected, $css_rule->get_css() );
 	}
 
@@ -45,7 +45,7 @@ class WP_Style_Engine_CSS_Rule_Test extends WP_UnitTestCase {
 		$css_rule                    = new WP_Style_Engine_CSS_Rule( $selector, $first_declaration );
 		$css_rule->add_declarations( new WP_Style_Engine_CSS_Declarations( $overwrite_first_declaration ) );
 
-		$expected = '.taggart {font-size: 4px;}';
+		$expected = '.taggart { font-size: 4px; }';
 		$this->assertSame( $expected, $css_rule->get_css() );
 	}
 
@@ -60,7 +60,7 @@ class WP_Style_Engine_CSS_Rule_Test extends WP_UnitTestCase {
 		$css_rule                   = new WP_Style_Engine_CSS_Rule( '.hill-street-blues', $some_css_declarations );
 		$css_rule->add_declarations( $some_more_css_declarations );
 
-		$expected = '.hill-street-blues {margin-top: 10px; font-size: 1rem;}';
+		$expected = '.hill-street-blues { margin-top: 10px; font-size: 1rem; }';
 		$this->assertSame( $expected, $css_rule->get_css() );
 	}
 
@@ -89,7 +89,7 @@ class WP_Style_Engine_CSS_Rule_Test extends WP_UnitTestCase {
 		);
 		$css_declarations   = new WP_Style_Engine_CSS_Declarations( $input_declarations );
 		$css_rule           = new WP_Style_Engine_CSS_Rule( $selector, $css_declarations );
-		$expected           = "$selector {{$css_declarations->get_declarations_string()}}";
+		$expected           = "$selector { {$css_declarations->get_declarations_string()} }";
 
 		$this->assertSame( $expected, $css_rule->get_css() );
 	}

--- a/packages/style-engine/phpunit/class-wp-style-engine-css-rule-test.php
+++ b/packages/style-engine/phpunit/class-wp-style-engine-css-rule-test.php
@@ -27,7 +27,7 @@ class WP_Style_Engine_CSS_Rule_Test extends WP_UnitTestCase {
 
 		$this->assertSame( $selector, $css_rule->get_selector() );
 
-		$expected = "$selector { {$css_declarations->get_declarations_string()} }";
+		$expected = "$selector {{$css_declarations->get_declarations_string()}}";
 		$this->assertSame( $expected, $css_rule->get_css() );
 	}
 
@@ -45,7 +45,7 @@ class WP_Style_Engine_CSS_Rule_Test extends WP_UnitTestCase {
 		$css_rule                    = new WP_Style_Engine_CSS_Rule( $selector, $first_declaration );
 		$css_rule->add_declarations( new WP_Style_Engine_CSS_Declarations( $overwrite_first_declaration ) );
 
-		$expected = '.taggart { font-size: 4px; }';
+		$expected = '.taggart {font-size: 4px;}';
 		$this->assertSame( $expected, $css_rule->get_css() );
 	}
 
@@ -60,7 +60,7 @@ class WP_Style_Engine_CSS_Rule_Test extends WP_UnitTestCase {
 		$css_rule                   = new WP_Style_Engine_CSS_Rule( '.hill-street-blues', $some_css_declarations );
 		$css_rule->add_declarations( $some_more_css_declarations );
 
-		$expected = '.hill-street-blues { margin-top: 10px; font-size: 1rem; }';
+		$expected = '.hill-street-blues {margin-top: 10px; font-size: 1rem;}';
 		$this->assertSame( $expected, $css_rule->get_css() );
 	}
 
@@ -89,7 +89,7 @@ class WP_Style_Engine_CSS_Rule_Test extends WP_UnitTestCase {
 		);
 		$css_declarations   = new WP_Style_Engine_CSS_Declarations( $input_declarations );
 		$css_rule           = new WP_Style_Engine_CSS_Rule( $selector, $css_declarations );
-		$expected           = "$selector { {$css_declarations->get_declarations_string()} }";
+		$expected           = "$selector {{$css_declarations->get_declarations_string()}}";
 
 		$this->assertSame( $expected, $css_rule->get_css() );
 	}

--- a/packages/style-engine/phpunit/class-wp-style-engine-css-rules-store-test.php
+++ b/packages/style-engine/phpunit/class-wp-style-engine-css-rules-store-test.php
@@ -14,6 +14,9 @@ require __DIR__ . '/../class-wp-style-engine-css-declarations.php';
  * Tests for registering, storing and retrieving CSS Rules.
  */
 class WP_Style_Engine_CSS_Rules_Store_Test extends WP_UnitTestCase {
+	/**
+	 * Tear down after each test.
+	 */
 	public function tear_down() {
 		parent::tear_down();
 		WP_Style_Engine_CSS_Rules_Store::remove_all_stores();

--- a/packages/style-engine/phpunit/class-wp-style-engine-css-rules-store-test.php
+++ b/packages/style-engine/phpunit/class-wp-style-engine-css-rules-store-test.php
@@ -14,6 +14,10 @@ require __DIR__ . '/../class-wp-style-engine-css-declarations.php';
  * Tests for registering, storing and retrieving CSS Rules.
  */
 class WP_Style_Engine_CSS_Rules_Store_Test extends WP_UnitTestCase {
+	public function tear_down() {
+		parent::tear_down();
+		WP_Style_Engine_CSS_Rules_Store::remove_all_stores();
+	}
 	/**
 	 * Should create a new store.
 	 */
@@ -34,6 +38,41 @@ class WP_Style_Engine_CSS_Rules_Store_Test extends WP_UnitTestCase {
 
 		$the_same_fish_store = WP_Style_Engine_CSS_Rules_Store::get_store( 'fish-n-chips' );
 		$this->assertEquals( $selector, $the_same_fish_store->add_rule( $selector )->get_selector() );
+	}
+
+	/**
+	 * Should return all previously created stores.
+	 */
+	public function test_get_stores() {
+		$burrito_store    = WP_Style_Engine_CSS_Rules_Store::get_store( 'burrito' );
+		$quesadilla_store = WP_Style_Engine_CSS_Rules_Store::get_store( 'quesadilla' );
+		$this->assertEquals(
+			array(
+				'burrito'    => $burrito_store,
+				'quesadilla' => $quesadilla_store,
+			),
+			WP_Style_Engine_CSS_Rules_Store::get_stores()
+		);
+	}
+
+	/**
+	 * Should delete all previously created stores.
+	 */
+	public function test_remove_all_stores() {
+		$dolmades_store = WP_Style_Engine_CSS_Rules_Store::get_store( 'dolmades' );
+		$tzatziki_store = WP_Style_Engine_CSS_Rules_Store::get_store( 'tzatziki' );
+		$this->assertEquals(
+			array(
+				'dolmades' => $dolmades_store,
+				'tzatziki' => $tzatziki_store,
+			),
+			WP_Style_Engine_CSS_Rules_Store::get_stores()
+		);
+		WP_Style_Engine_CSS_Rules_Store::remove_all_stores();
+		$this->assertEquals(
+			array(),
+			WP_Style_Engine_CSS_Rules_Store::get_stores()
+		);
 	}
 
 	/**

--- a/packages/style-engine/phpunit/class-wp-style-engine-processor-test.php
+++ b/packages/style-engine/phpunit/class-wp-style-engine-processor-test.php
@@ -15,11 +15,33 @@ require __DIR__ . '/../class-wp-style-engine-processor.php';
  */
 class WP_Style_Engine_Processor_Test extends WP_UnitTestCase {
 	/**
+	 * Should compile CSS rules.
+	 */
+	public function test_return_rules_as_css() {
+		$a_nice_css_rule = new WP_Style_Engine_CSS_Rule( '.a-nice-rule' );
+		$a_nice_css_rule->add_declarations(
+			array(
+				'color'            => 'var(--nice-color)',
+				'background-color' => 'purple',
+			)
+		);
+		$a_nicer_css_rule = new WP_Style_Engine_CSS_Rule( '.a-nicer-rule' );
+		$a_nicer_css_rule->add_declarations(
+			array(
+				'font-family'      => 'Nice sans',
+				'font-size'        => '1em',
+				'background-color' => 'purple',
+			)
+		);
+		$a_nice_processor = new WP_Style_Engine_Processor( array( $a_nice_css_rule, $a_nicer_css_rule ) );
+		$this->assertEquals( '.a-nice-rule {color: var(--nice-color); background-color: purple;}.a-nicer-rule {font-family: Nice sans; font-size: 1em; background-color: purple;}', $a_nice_processor->get_css() );
+	}
+
+	/**
 	 * Should compile CSS rules from the store.
 	 */
 	public function test_return_store_rules_as_css() {
-		$a_nice_store    = WP_Style_Engine_CSS_Rules_Store_Gutenberg::get_store( 'nice' );
-		$a_nice_renderer = new WP_Style_Engine_Processor_Gutenberg( $a_nice_store );
+		$a_nice_store = WP_Style_Engine_CSS_Rules_Store_Gutenberg::get_store( 'nice' );
 		$a_nice_store->add_rule( '.a-nice-rule' )->add_declarations(
 			array(
 				'color'            => 'var(--nice-color)',
@@ -33,7 +55,7 @@ class WP_Style_Engine_Processor_Test extends WP_UnitTestCase {
 				'background-color' => 'purple',
 			)
 		);
-
+		$a_nice_renderer = new WP_Style_Engine_Processor_Gutenberg( $a_nice_store->get_all_rules() );
 		$this->assertEquals( '.a-nice-rule {color: var(--nice-color); background-color: purple;}.a-nicer-rule {font-family: Nice sans; font-size: 1em; background-color: purple;}', $a_nice_renderer->get_css() );
 	}
 
@@ -41,87 +63,100 @@ class WP_Style_Engine_Processor_Test extends WP_UnitTestCase {
 	 * Should merge CSS declarations.
 	 */
 	public function test_dedupe_and_merge_css_declarations() {
-		$an_excellent_store    = WP_Style_Engine_CSS_Rules_Store_Gutenberg::get_store( 'excellent' );
-		$an_excellent_renderer = new WP_Style_Engine_Processor_Gutenberg( $an_excellent_store );
-		$an_excellent_store->add_rule( '.an-excellent-rule' )->add_declarations(
+		$an_excellent_rule      = new WP_Style_Engine_CSS_Rule( '.an-excellent-rule' );
+		$an_excellent_processor = new WP_Style_Engine_Processor();
+		$an_excellent_rule->add_declarations(
 			array(
 				'color'        => 'var(--excellent-color)',
 				'border-style' => 'dotted',
 			)
 		);
-		$an_excellent_store->add_rule( '.an-excellent-rule' )->add_declarations(
+		$an_excellent_processor->add_rules( $an_excellent_rule );
+
+		$another_excellent_rule = new WP_Style_Engine_CSS_Rule( '.an-excellent-rule' );
+		$another_excellent_rule->add_declarations(
 			array(
 				'color'        => 'var(--excellent-color)',
 				'border-style' => 'dotted',
 				'border-color' => 'brown',
 			)
 		);
+		$an_excellent_processor->add_rules( $another_excellent_rule );
+		$this->assertEquals( '.an-excellent-rule {color: var(--excellent-color); border-style: dotted; border-color: brown;}', $an_excellent_processor->get_css() );
 
-		$this->assertEquals( '.an-excellent-rule {color: var(--excellent-color); border-style: dotted; border-color: brown;}', $an_excellent_renderer->get_css() );
-
-		$an_excellent_store->add_rule( '.an-excellent-rule' )->add_declarations(
+		$yet_another_excellent_rule = new WP_Style_Engine_CSS_Rule( '.an-excellent-rule' );
+		$yet_another_excellent_rule->add_declarations(
 			array(
 				'color'        => 'var(--excellent-color)',
 				'border-style' => 'dashed',
 				'border-width' => '2px',
 			)
 		);
-
-		$this->assertEquals( '.an-excellent-rule {color: var(--excellent-color); border-style: dashed; border-color: brown; border-width: 2px;}', $an_excellent_renderer->get_css() );
+		$an_excellent_processor->add_rules( $yet_another_excellent_rule );
+		$this->assertEquals( '.an-excellent-rule {color: var(--excellent-color); border-style: dashed; border-color: brown; border-width: 2px;}', $an_excellent_processor->get_css() );
 	}
 
 	/**
 	 * Should combine duplicate CSS rules.
 	 */
 	public function test_combine_css_rules() {
-		$a_sweet_store    = WP_Style_Engine_CSS_Rules_Store_Gutenberg::get_store( 'sweet' );
-		$a_sweet_renderer = new WP_Style_Engine_Processor_Gutenberg( $a_sweet_store );
-		$a_sweet_store->add_rule( '.a-sweet-rule' )->add_declarations(
-			array(
-				'color'            => 'var(--sweet-color)',
-				'background-color' => 'purple',
-			)
-		);
-		$a_sweet_store->add_rule( '#an-even-sweeter-rule > marquee' )->add_declarations(
+		$a_sweet_rule = new WP_Style_Engine_CSS_Rule(
+			'.a-sweet-rule',
 			array(
 				'color'            => 'var(--sweet-color)',
 				'background-color' => 'purple',
 			)
 		);
 
-		$this->assertEquals( '.a-sweet-rule,#an-even-sweeter-rule > marquee {color: var(--sweet-color); background-color: purple;}', $a_sweet_renderer->get_css() );
+		$a_sweeter_rule = new WP_Style_Engine_CSS_Rule(
+			'#an-even-sweeter-rule > marquee',
+			array(
+				'color'            => 'var(--sweet-color)',
+				'background-color' => 'purple',
+			)
+		);
+
+		$a_sweet_processor = new WP_Style_Engine_Processor( array( $a_sweet_rule, $a_sweeter_rule ) );
+
+		$this->assertEquals( '.a-sweet-rule,#an-even-sweeter-rule > marquee {color: var(--sweet-color); background-color: purple;}', $a_sweet_processor->get_css() );
 	}
-
-	/**
-	 * Should combine and store CSS rules.
-	 */
-	public function test_store_combined_css_rules() {
-		$a_lovely_store    = WP_Style_Engine_CSS_Rules_Store_Gutenberg::get_store( 'lovely' );
-		$a_lovely_renderer = new WP_Style_Engine_Processor_Gutenberg( $a_lovely_store );
-		$a_lovely_store->add_rule( '.a-lovely-rule' )->add_declarations(
+		/**
+		 * Should combine and store CSS rules.
+		 */
+	public function test_combine_previously_added_css_rules() {
+		$a_lovely_processor = new WP_Style_Engine_Processor();
+		$a_lovely_rule      = new WP_Style_Engine_CSS_Rule(
+			'.a-lovely-rule',
 			array(
 				'border-color' => 'purple',
 			)
 		);
-		$a_lovely_store->add_rule( '.a-lovelier-rule' )->add_declarations(
+		$a_lovely_processor->add_rules( $a_lovely_rule );
+		$a_lovelier_rule = new WP_Style_Engine_CSS_Rule(
+			'.a-lovelier-rule',
 			array(
 				'border-color' => 'purple',
 			)
 		);
+		$a_lovely_processor->add_rules( $a_lovelier_rule );
+		$this->assertEquals( '.a-lovely-rule,.a-lovelier-rule {border-color: purple;}', $a_lovely_processor->get_css() );
 
-		$this->assertEquals( '.a-lovely-rule,.a-lovelier-rule {border-color: purple;}', $a_lovely_renderer->get_css() );
-
-		$a_lovely_store->add_rule( '.a-most-lovely-rule' )->add_declarations(
+		$a_most_lovely_rule = new WP_Style_Engine_CSS_Rule(
+			'.a-most-lovely-rule',
 			array(
 				'border-color' => 'purple',
 			)
 		);
-		$a_lovely_store->add_rule( '.a-perfectly-lovely-rule' )->add_declarations(
+		$a_lovely_processor->add_rules( $a_most_lovely_rule );
+
+		$a_perfectly_lovely_rule = new WP_Style_Engine_CSS_Rule(
+			'.a-perfectly-lovely-rule',
 			array(
 				'border-color' => 'purple',
 			)
 		);
+		$a_lovely_processor->add_rules( $a_perfectly_lovely_rule );
 
-		$this->assertEquals( '.a-lovely-rule,.a-lovelier-rule,.a-most-lovely-rule,.a-perfectly-lovely-rule {border-color: purple;}', $a_lovely_renderer->get_css() );
+		$this->assertEquals( '.a-lovely-rule,.a-lovelier-rule,.a-most-lovely-rule,.a-perfectly-lovely-rule {border-color: purple;}', $a_lovely_processor->get_css() );
 	}
 }

--- a/packages/style-engine/phpunit/class-wp-style-engine-processor-test.php
+++ b/packages/style-engine/phpunit/class-wp-style-engine-processor-test.php
@@ -33,7 +33,8 @@ class WP_Style_Engine_Processor_Test extends WP_UnitTestCase {
 				'background-color' => 'purple',
 			)
 		);
-		$a_nice_processor = new WP_Style_Engine_Processor( array( $a_nice_css_rule, $a_nicer_css_rule ) );
+		$a_nice_processor = new WP_Style_Engine_Processor();
+		$a_nice_processor->add_rules( array( $a_nice_css_rule, $a_nicer_css_rule ) );
 		$this->assertEquals( '.a-nice-rule {color: var(--nice-color); background-color: purple;}.a-nicer-rule {font-family: Nice sans; font-size: 1em; background-color: purple;}', $a_nice_processor->get_css() );
 	}
 
@@ -55,7 +56,8 @@ class WP_Style_Engine_Processor_Test extends WP_UnitTestCase {
 				'background-color' => 'purple',
 			)
 		);
-		$a_nice_renderer = new WP_Style_Engine_Processor_Gutenberg( $a_nice_store->get_all_rules() );
+		$a_nice_renderer = new WP_Style_Engine_Processor_Gutenberg();
+		$a_nice_renderer->add_store( $a_nice_store );
 		$this->assertEquals( '.a-nice-rule {color: var(--nice-color); background-color: purple;}.a-nicer-rule {font-family: Nice sans; font-size: 1em; background-color: purple;}', $a_nice_renderer->get_css() );
 	}
 
@@ -116,7 +118,8 @@ class WP_Style_Engine_Processor_Test extends WP_UnitTestCase {
 			)
 		);
 
-		$a_sweet_processor = new WP_Style_Engine_Processor( array( $a_sweet_rule, $a_sweeter_rule ) );
+		$a_sweet_processor = new WP_Style_Engine_Processor();
+		$a_sweet_processor->add_rules( array( $a_sweet_rule, $a_sweeter_rule ) );
 
 		$this->assertEquals( '.a-sweet-rule,#an-even-sweeter-rule > marquee {color: var(--sweet-color); background-color: purple;}', $a_sweet_processor->get_css() );
 	}

--- a/packages/style-engine/phpunit/class-wp-style-engine-test.php
+++ b/packages/style-engine/phpunit/class-wp-style-engine-test.php
@@ -512,40 +512,14 @@ class WP_Style_Engine_Test extends WP_UnitTestCase {
 	 * Tests adding rules to a store and retrieving a generated stylesheet.
 	 */
 	public function test_add_to_store() {
-		$css_rules = array(
-			array(
-				'selector'     => '.saruman',
-				'declarations' => array(
-					'color'        => 'white',
-					'height'       => '100px',
-					'border-style' => 'solid',
-					'align-self'   => 'unset',
-				),
-			),
-			array(
-				'selector'     => '.gandalf',
-				'declarations' => array(
-					'color'        => 'grey',
-					'height'       => '90px',
-					'border-style' => 'dotted',
-					'align-self'   => 'safe center',
-				),
-			),
-			array(
-				'selector'     => '.radagast',
-				'declarations' => array(
-					'color'        => 'brown',
-					'height'       => '60px',
-					'border-style' => 'dashed',
-					'align-self'   => 'stretch',
-				),
-			),
-		);
-		$store     = wp_style_engine_add_to_store( 'test-store', $css_rules );
+		$store = wp_style_engine_add_to_store( 'test-store', array() );
+
+		// wp_style_engine_add_to_store returns a store object.
 		$this->assertInstanceOf( 'WP_Style_Engine_CSS_Rules_Store', $store );
 
-		$compiled_stylesheet = wp_style_engine_get_stylesheet_from_store( 'test-store' );
-		$this->assertSame( '.saruman {color: white; height: 100px; border-style: solid; align-self: unset;}.gandalf {color: grey; height: 90px; border-style: dotted; align-self: safe center;}.radagast {color: brown; height: 60px; border-style: dashed; align-self: stretch;}', $compiled_stylesheet );
+		// Check that the style engine knows about the store.
+		$stored_store = WP_Style_Engine::get_instance()::get_store( 'test-store' );
+		$this->assertInstanceOf( 'WP_Style_Engine_CSS_Rules_Store', $stored_store );
 	}
 
 	/**
@@ -584,5 +558,49 @@ class WP_Style_Engine_Test extends WP_UnitTestCase {
 
 		$compiled_stylesheet = wp_style_engine_get_stylesheet_from_css_rules( $css_rules );
 		$this->assertSame( '.saruman {color: white; height: 100px; border-style: solid; align-self: unset;}.gandalf {color: grey; height: 90px; border-style: dotted; align-self: safe center;}.radagast {color: brown; height: 60px; border-style: dashed; align-self: stretch;}', $compiled_stylesheet );
+	}
+
+	/**
+	 * Tests that incoming styles are deduped and merged.
+	 */
+	public function test_get_deduped_and_merged_stylesheet() {
+		$css_rules = array(
+			array(
+				'selector'     => '.gandalf',
+				'declarations' => array(
+					'color'        => 'grey',
+					'height'       => '90px',
+					'border-style' => 'dotted',
+				),
+			),
+			array(
+				'selector'     => '.gandalf',
+				'declarations' => array(
+					'color'         => 'white',
+					'height'        => '190px',
+					'padding'       => '10px',
+					'margin-bottom' => '100px',
+				),
+			),
+			array(
+				'selector'     => '.dumbledore',
+				'declarations' => array(
+					'color'        => 'grey',
+					'height'       => '90px',
+					'border-style' => 'dotted',
+				),
+			),
+			array(
+				'selector'     => '.rincewind',
+				'declarations' => array(
+					'color'        => 'grey',
+					'height'       => '90px',
+					'border-style' => 'dotted',
+				),
+			),
+		);
+
+		$compiled_stylesheet = wp_style_engine_get_stylesheet_from_css_rules( $css_rules );
+		$this->assertSame( '.gandalf {color: white; height: 190px; border-style: dotted; padding: 10px; margin-bottom: 100px;}.dumbledore,.rincewind {color: grey; height: 90px; border-style: dotted;}', $compiled_stylesheet );
 	}
 }

--- a/packages/style-engine/phpunit/class-wp-style-engine-test.php
+++ b/packages/style-engine/phpunit/class-wp-style-engine-test.php
@@ -29,8 +29,8 @@ class WP_Style_Engine_Test extends WP_UnitTestCase {
 	 *
 	 * @dataProvider data_generate_block_supports_styles_fixtures
 	 *
-	 * @param array  $block_styles    The incoming block styles object.
-	 * @param array  $options         Style engine options.
+	 * @param array  $block_styles The incoming block styles object.
+	 * @param array  $options Style engine options.
 	 * @param string $expected_output The expected output.
 	 */
 	public function test_generate_block_supports_styles( $block_styles, $options, $expected_output ) {
@@ -512,30 +512,77 @@ class WP_Style_Engine_Test extends WP_UnitTestCase {
 	 * Tests adding rules to a store and retrieving a generated stylesheet.
 	 */
 	public function test_add_to_store() {
-		$styles = array(
-			'.saruman'  => array(
-				'color'        => 'white',
-				'height'       => '100px',
-				'border-style' => 'solid',
-				'align-self'   => 'unset',
+		$css_rules = array(
+			array(
+				'selector'         => '.saruman',
+				'css_declarations' => array(
+					'color'        => 'white',
+					'height'       => '100px',
+					'border-style' => 'solid',
+					'align-self'   => 'unset',
+				),
 			),
-			'.gandalf'  => array(
-				'color'        => 'grey',
-				'height'       => '90px',
-				'border-style' => 'dotted',
-				'align-self'   => 'safe center',
+			array(
+				'selector'         => '.gandalf',
+				'css_declarations' => array(
+					'color'        => 'grey',
+					'height'       => '90px',
+					'border-style' => 'dotted',
+					'align-self'   => 'safe center',
+				),
 			),
-			'.radagast' => array(
-				'color'        => 'brown',
-				'height'       => '60px',
-				'border-style' => 'dashed',
-				'align-self'   => 'stretch',
+			array(
+				'selector'         => '.radagast',
+				'css_declarations' => array(
+					'color'        => 'brown',
+					'height'       => '60px',
+					'border-style' => 'dashed',
+					'align-self'   => 'stretch',
+				),
 			),
 		);
-		$store  = wp_style_engine_add_to_store( 'test-store', $styles );
+		$store     = wp_style_engine_add_to_store( 'test-store', $css_rules );
 		$this->assertInstanceOf( 'WP_Style_Engine_CSS_Rules_Store', $store );
 
-		$compiled_stylesheet = wp_style_engine_get_stylesheet( 'test-store' );
+		$compiled_stylesheet = wp_style_engine_get_stylesheet_from_store( 'test-store' );
+		$this->assertSame( '.saruman {color: white; height: 100px; border-style: solid; align-self: unset;}.gandalf {color: grey; height: 90px; border-style: dotted; align-self: safe center;}.radagast {color: brown; height: 60px; border-style: dashed; align-self: stretch;}', $compiled_stylesheet );
+	}
+
+	/**
+	 * Tests retrieving a generated stylesheet from any rules.
+	 */
+	public function test_get_stylesheet_from_css_rules() {
+		$css_rules = array(
+			array(
+				'selector'         => '.saruman',
+				'css_declarations' => array(
+					'color'        => 'white',
+					'height'       => '100px',
+					'border-style' => 'solid',
+					'align-self'   => 'unset',
+				),
+			),
+			array(
+				'selector'         => '.gandalf',
+				'css_declarations' => array(
+					'color'        => 'grey',
+					'height'       => '90px',
+					'border-style' => 'dotted',
+					'align-self'   => 'safe center',
+				),
+			),
+			array(
+				'selector'         => '.radagast',
+				'css_declarations' => array(
+					'color'        => 'brown',
+					'height'       => '60px',
+					'border-style' => 'dashed',
+					'align-self'   => 'stretch',
+				),
+			),
+		);
+
+		$compiled_stylesheet = wp_style_engine_get_stylesheet_from_css_rules( $css_rules );
 		$this->assertSame( '.saruman {color: white; height: 100px; border-style: solid; align-self: unset;}.gandalf {color: grey; height: 90px; border-style: dotted; align-self: safe center;}.radagast {color: brown; height: 60px; border-style: dashed; align-self: stretch;}', $compiled_stylesheet );
 	}
 }

--- a/packages/style-engine/phpunit/class-wp-style-engine-test.php
+++ b/packages/style-engine/phpunit/class-wp-style-engine-test.php
@@ -514,8 +514,8 @@ class WP_Style_Engine_Test extends WP_UnitTestCase {
 	public function test_add_to_store() {
 		$css_rules = array(
 			array(
-				'selector'         => '.saruman',
-				'css_declarations' => array(
+				'selector'     => '.saruman',
+				'declarations' => array(
 					'color'        => 'white',
 					'height'       => '100px',
 					'border-style' => 'solid',
@@ -523,8 +523,8 @@ class WP_Style_Engine_Test extends WP_UnitTestCase {
 				),
 			),
 			array(
-				'selector'         => '.gandalf',
-				'css_declarations' => array(
+				'selector'     => '.gandalf',
+				'declarations' => array(
 					'color'        => 'grey',
 					'height'       => '90px',
 					'border-style' => 'dotted',
@@ -532,8 +532,8 @@ class WP_Style_Engine_Test extends WP_UnitTestCase {
 				),
 			),
 			array(
-				'selector'         => '.radagast',
-				'css_declarations' => array(
+				'selector'     => '.radagast',
+				'declarations' => array(
 					'color'        => 'brown',
 					'height'       => '60px',
 					'border-style' => 'dashed',
@@ -554,8 +554,8 @@ class WP_Style_Engine_Test extends WP_UnitTestCase {
 	public function test_get_stylesheet_from_css_rules() {
 		$css_rules = array(
 			array(
-				'selector'         => '.saruman',
-				'css_declarations' => array(
+				'selector'     => '.saruman',
+				'declarations' => array(
 					'color'        => 'white',
 					'height'       => '100px',
 					'border-style' => 'solid',
@@ -563,8 +563,8 @@ class WP_Style_Engine_Test extends WP_UnitTestCase {
 				),
 			),
 			array(
-				'selector'         => '.gandalf',
-				'css_declarations' => array(
+				'selector'     => '.gandalf',
+				'declarations' => array(
 					'color'        => 'grey',
 					'height'       => '90px',
 					'border-style' => 'dotted',
@@ -572,8 +572,8 @@ class WP_Style_Engine_Test extends WP_UnitTestCase {
 				),
 			),
 			array(
-				'selector'         => '.radagast',
-				'css_declarations' => array(
+				'selector'     => '.radagast',
+				'declarations' => array(
 					'color'        => 'brown',
 					'height'       => '60px',
 					'border-style' => 'dashed',

--- a/packages/style-engine/phpunit/class-wp-style-engine-test.php
+++ b/packages/style-engine/phpunit/class-wp-style-engine-test.php
@@ -27,23 +27,23 @@ class WP_Style_Engine_Test extends WP_UnitTestCase {
 	/**
 	 * Tests generating block styles and classnames based on various manifestations of the $block_styles argument.
 	 *
-	 * @dataProvider data_generate_block_supports_styles_fixtures
+	 * @dataProvider data_get_styles_fixtures
 	 *
 	 * @param array  $block_styles The incoming block styles object.
 	 * @param array  $options Style engine options.
 	 * @param string $expected_output The expected output.
 	 */
-	public function test_generate_block_supports_styles( $block_styles, $options, $expected_output ) {
+	public function test_generate_get_styles( $block_styles, $options, $expected_output ) {
 		$generated_styles = wp_style_engine_get_styles( $block_styles, $options );
 		$this->assertSame( $expected_output, $generated_styles );
 	}
 
 	/**
-	 * Data provider.
+	 * Data provider for test_generate_get_styles().
 	 *
 	 * @return array
 	 */
-	public function data_generate_block_supports_styles_fixtures() {
+	public function data_get_styles_fixtures() {
 		return array(
 			'default_return_value'                         => array(
 				'block_styles'    => array(),
@@ -506,6 +506,34 @@ class WP_Style_Engine_Test extends WP_UnitTestCase {
 				),
 			),
 		);
+	}
+
+	/**
+	 * Tests adding rules to a store and retrieving a generated stylesheet.
+	 */
+	public function test_enqueue_block_styles_store() {
+		$block_styles = array(
+			'spacing' => array(
+				'padding' => array(
+					'top'    => '42px',
+					'left'   => '2%',
+					'bottom' => '44px',
+					'right'  => '5rem',
+				),
+			),
+		);
+
+		$generated_styles = wp_style_engine_get_styles(
+			$block_styles,
+			array(
+				'enqueue'  => true,
+				'context'  => 'block-supports',
+				'selector' => 'article',
+			)
+		);
+		$store            = WP_Style_Engine::get_instance()::get_store( 'block-supports' );
+		$rule             = $store->get_all_rules()['article'];
+		$this->assertSame( $generated_styles['css'], $rule->get_css() );
 	}
 
 	/**

--- a/packages/style-engine/phpunit/class-wp-style-engine-test.php
+++ b/packages/style-engine/phpunit/class-wp-style-engine-test.php
@@ -39,13 +39,13 @@ class WP_Style_Engine_Test extends WP_UnitTestCase {
 			'default_return_value'                         => array(
 				'block_styles'    => array(),
 				'options'         => null,
-				'expected_output' => null,
+				'expected_output' => array(),
 			),
 
 			'inline_invalid_block_styles_empty'            => array(
 				'block_styles'    => 'hello world!',
 				'options'         => null,
-				'expected_output' => null,
+				'expected_output' => array(),
 			),
 
 			'inline_invalid_block_styles_unknown_style'    => array(
@@ -189,7 +189,7 @@ class WP_Style_Engine_Test extends WP_UnitTestCase {
 				),
 				'options'         => array( 'selector' => '.wp-selector > p' ),
 				'expected_output' => array(
-					'css'          => '.wp-selector > p { padding-top: 42px; padding-left: 2%; padding-bottom: 44px; padding-right: 5rem; }',
+					'css'          => '.wp-selector > p {padding-top: 42px; padding-left: 2%; padding-bottom: 44px; padding-right: 5rem;}',
 					'declarations' => array(
 						'padding-top'    => '42px',
 						'padding-left'   => '2%',
@@ -209,7 +209,7 @@ class WP_Style_Engine_Test extends WP_UnitTestCase {
 					'selector' => '.wp-selector',
 				),
 				'expected_output' => array(
-					'css'          => '.wp-selector { color: var(--wp--preset--color--my-little-pony); }',
+					'css'          => '.wp-selector {color: var(--wp--preset--color--my-little-pony);}',
 					'declarations' => array(
 						'color' => 'var(--wp--preset--color--my-little-pony)',
 					),

--- a/packages/style-engine/phpunit/class-wp-style-engine-test.php
+++ b/packages/style-engine/phpunit/class-wp-style-engine-test.php
@@ -7,6 +7,8 @@
  */
 
 require __DIR__ . '/../class-wp-style-engine-css-declarations.php';
+require __DIR__ . '/../class-wp-style-engine-css-rule.php';
+require __DIR__ . '/../class-wp-style-engine-css-rules-store.php';
 require __DIR__ . '/../class-wp-style-engine.php';
 
 /**

--- a/packages/style-engine/phpunit/class-wp-style-engine-test.php
+++ b/packages/style-engine/phpunit/class-wp-style-engine-test.php
@@ -6,6 +6,7 @@
  * @subpackage style-engine
  */
 
+require __DIR__ . '/../class-wp-style-engine-processor.php';
 require __DIR__ . '/../class-wp-style-engine-css-declarations.php';
 require __DIR__ . '/../class-wp-style-engine-css-rule.php';
 require __DIR__ . '/../class-wp-style-engine-css-rules-store.php';
@@ -15,6 +16,14 @@ require __DIR__ . '/../class-wp-style-engine.php';
  * Tests for registering, storing and generating styles.
  */
 class WP_Style_Engine_Test extends WP_UnitTestCase {
+	/**
+	 * Tear down after each test.
+	 */
+	public function tear_down() {
+		parent::tear_down();
+		WP_Style_Engine_CSS_Rules_Store::remove_all_stores();
+	}
+
 	/**
 	 * Tests generating block styles and classnames based on various manifestations of the $block_styles argument.
 	 *
@@ -74,7 +83,7 @@ class WP_Style_Engine_Test extends WP_UnitTestCase {
 				'expected_output' => array(),
 			),
 
-			'valid_inline_css_and_classnames'              => array(
+			'valid_inline_css_and_classnames_as_default_context' => array(
 				'block_styles'    => array(
 					'color'   => array(
 						'text' => 'var:preset|color|texas-flood',
@@ -100,6 +109,44 @@ class WP_Style_Engine_Test extends WP_UnitTestCase {
 					),
 					'classnames'   => 'has-text-color has-texas-flood-color has-border-color has-cool-caramel-border-color',
 				),
+			),
+
+			'valid_inline_css_and_classnames_with_context' => array(
+				'block_styles'    => array(
+					'color'   => array(
+						'text' => 'var:preset|color|little-lamb',
+					),
+					'spacing' => array(
+						'margin' => '20px',
+					),
+				),
+				'options'         => array(
+					'convert_vars_to_classnames' => true,
+					'context'                    => 'block-supports',
+				),
+				'expected_output' => array(
+					'css'          => 'margin: 20px;',
+					'declarations' => array(
+						'margin' => '20px',
+					),
+					'classnames'   => 'has-text-color has-little-lamb-color',
+				),
+			),
+
+			'invalid_context'                              => array(
+				'block_styles'    => array(
+					'color'   => array(
+						'text' => 'var:preset|color|sugar',
+					),
+					'spacing' => array(
+						'padding' => '20000px',
+					),
+				),
+				'options'         => array(
+					'convert_vars_to_classnames' => true,
+					'context'                    => 'i-love-doughnuts',
+				),
+				'expected_output' => array(),
 			),
 
 			'inline_valid_box_model_style'                 => array(
@@ -459,5 +506,36 @@ class WP_Style_Engine_Test extends WP_UnitTestCase {
 				),
 			),
 		);
+	}
+
+	/**
+	 * Tests adding rules to a store and retrieving a generated stylesheet.
+	 */
+	public function test_add_to_store() {
+		$styles = array(
+			'.saruman'  => array(
+				'color'        => 'white',
+				'height'       => '100px',
+				'border-style' => 'solid',
+				'align-self'   => 'unset',
+			),
+			'.gandalf'  => array(
+				'color'        => 'grey',
+				'height'       => '90px',
+				'border-style' => 'dotted',
+				'align-self'   => 'safe center',
+			),
+			'.radagast' => array(
+				'color'        => 'brown',
+				'height'       => '60px',
+				'border-style' => 'dashed',
+				'align-self'   => 'stretch',
+			),
+		);
+		$store  = wp_style_engine_add_to_store( 'test-store', $styles );
+		$this->assertInstanceOf( 'WP_Style_Engine_CSS_Rules_Store', $store );
+
+		$compiled_stylesheet = wp_style_engine_get_stylesheet( 'test-store' );
+		$this->assertSame( '.saruman {color: white; height: 100px; border-style: solid; align-self: unset;}.gandalf {color: grey; height: 90px; border-style: dotted; align-self: safe center;}.radagast {color: brown; height: 60px; border-style: dashed; align-self: stretch;}', $compiled_stylesheet );
 	}
 }


### PR DESCRIPTION
## What?

This PR extends the backend style engine, and:

- enables the storing and enqueuing of layout and elements block support styles.
- batches layout and elements styles on the backend into a single HTML style tag 

## Why?
This is part of the effort to reduce the number of style tags in the rendered HTML. 

## How?
Using the classes laid down by @aristath in https://github.com/WordPress/gutenberg/pull/42222, it's now possible to build stylesheets and enqueue CSS for rendering on the frontend.

There are three global functions that help to achieve this:

### wp_style_engine_get_styles()

Use this function for style objects that require parsing, for instance, the value of a block's attributes.style object or the top level styles in theme.json.

To enqueue a style for rendering in the frontend, the `$options` array requires the following:

1. **selector (string)** - this is the CSS selector for your block style CSS declarations.
2. **context (string)** - this tells the style engine where to store the styles. Styles in the same context will be batched together and printed in the same HTML style tag. The default is `'block-supports'`.
3. **enqueue (boolean)** - tells the style engine to enqueue the styles and print them in the frontend.

`wp_style_engine_get_styles` will return the compiled CSS and CSS declarations array.

```php
$block_styles =  array(
     'spacing' => array( 'padding' => '100px' )
);
$styles = wp_style_engine_get_styles(
    $block_styles,
    array(
        'selector' => '.a-selector',
        'context'  => 'block-supports',
        'enqueue'  => true,
    )
);
print_r( $styles );

/*
array(
    'css'                 => '.a-selector{padding:10px}'
    'declarations'  => array( 'padding' => '100px' )
)
*/
```

### wp_style_engine_add_to_store()

Use this function to enqueue any CSS rules. It will automatically merge declarations and combine selectors.

```php
$styles = array(
    array(
        'selector'.       => '.wp-pumpkin',
        'declarations' => array( 'color' => 'orange' )
    ),
    array(
        'selector'.       => '.wp-tomato',
        'declarations' => array( 'color' => 'red' )
    ),
    array(
        'selector'.       => '.wp-tomato',
        'declarations' => array( 'padding' => '100px' )
    ),
    array(
        'selector'.       => '.wp-kumquat',
        'declarations' => array( 'color' => 'orange' )
    ),
);

wp_style_engine_add_to_store( 'layout-block-supports', $styles );


```

The resulting stylesheet will be:
```html
<style id='layout-block-supports-inline-css'>
.wp-pumpkin, .wp-kumquat {color:orange}.wp-tomato{color:red;padding:100px}
</style>
```

### wp_style_engine_get_stylesheet_from_css_rules()

Use this function to compile and return a stylesheet for any CSS rules. This function does not enqueue styles, but rather acts as a CSS compiler.

It has a similar function signature to `wp_style_engine_add_to_store`,

```php
$styles = array(
    array(
        'selector'.       => '.wp-pumpkin',
        'declarations' => array( 'color' => 'orange' )
    ),
    array(
        'selector'.       => '.wp-tomato',
        'declarations' => array( 'color' => 'red' )
    ),
    array(
        'selector'.       => '.wp-tomato',
        'declarations' => array( 'padding' => '100px' )
    ),
    array(
        'selector'.       => '.wp-kumquat',
        'declarations' => array( 'color' => 'orange' )
    ),
);

$stylesheet = wp_style_engine_get_stylesheet_from_css_rules( 'layout-block-supports', $styles );
print_r( $stylesheet ); // .wp-pumpkin, .wp-kumquat {color:orange}.wp-tomato{color:red;padding:100px}
```

## Future iterations

- Move enqueue logic into Gutenberg
- Add an optimize (and possibly a prettify) flag to toggle selector combination optimization and whitespace
  
## Testing Instructions

This PR enqueues both link elements styles and Layout block support styles.

In a new post add some text links and assign them a color. 

Insert a few group blocks and adjust the layout settings (alignment, widths, justifications). Ideally, manually test each of the features of both default/flow and flex-based Layouts using blocks such as Group, Columns, Buttons. 

Ensure that the colors and layout appear on the frontend as expected.

Here's some test block HTML. I'm testing using emptytheme, but we should also test in other themes including classic themes.

<details>

<summary>Example markup for custom link colors</summary>

```html
<!-- wp:paragraph -->
<p><a href="https://test.com">Test</a> paragraph with a link.</p>
<!-- /wp:paragraph -->

<!-- wp:paragraph {"style":{"elements":{"link":{"color":{"text":"#842ecf"}}}}} -->
<p class="has-link-color"><a href="https://test.com">Test</a> paragraph with a link.</p>
<!-- /wp:paragraph -->

<!-- wp:paragraph {"style":{"elements":{"link":{"color":{"text":"#842ecf"}}}}} -->
<p class="has-link-color"><a href="https://test.com">Test</a> paragraph with a link.</p>
<!-- /wp:paragraph -->

<!-- wp:paragraph {"style":{"elements":{"link":{"color":{"text":"var:preset|color|pale-pink"}}}}} -->
<p class="has-link-color"><a href="https://test.com">Test</a> paragraph with a link.</p>
<!-- /wp:paragraph -->

<!-- wp:paragraph {"style":{"elements":{"link":{"color":{"text":"var:preset|color|pale-pink"}}}}} -->
<p class="has-link-color"><a href="https://test.com">Test</a> paragraph with a link.</p>
<!-- /wp:paragraph -->

<!-- wp:heading {"style":{"elements":{"link":{"color":{"text":"var:preset|color|pale-pink"}}}}} -->
<h2 class="has-link-color">H2 with a <a href="https://wordpress.org">link</a></h2>
<!-- /wp:heading -->

<!-- wp:group {"style":{"elements":{"link":{"color":{"text":"#fbc941"}}}}} -->
<div class="wp-block-group has-link-color"><!-- wp:paragraph -->
<p><a href="https://wordpress.org">Test</a> paragraph with a link inside a group;</p>
<!-- /wp:paragraph --></div>
<!-- /wp:group -->

<!-- wp:group {"style":{"elements":{"link":{"color":{"text":"#fbc941"}}}}} -->
<div class="wp-block-group has-link-color"><!-- wp:paragraph -->
<p><a href="https://wordpress.org">Test</a> paragraph with a link inside a group;</p>
<!-- /wp:paragraph --></div>
<!-- /wp:group -->

<!-- wp:group {"backgroundColor":"luminous-vivid-amber","layout":{"inherit":true}} -->
<div class="wp-block-group has-luminous-vivid-amber-background-color has-background"><!-- wp:columns -->
<div class="wp-block-columns"><!-- wp:column {"width":"47px","layout":{"contentSize":"26px"}} -->
<div class="wp-block-column" style="flex-basis:47px"><!-- wp:paragraph -->
<p>testest</p>
<!-- /wp:paragraph --></div>
<!-- /wp:column -->

<!-- wp:column -->
<div class="wp-block-column"><!-- wp:paragraph -->
<p>test</p>
<!-- /wp:paragraph --></div>
<!-- /wp:column --></div>
<!-- /wp:columns --></div>
<!-- /wp:group -->

<!-- wp:group {"backgroundColor":"luminous-vivid-orange","layout":{"inherit":false,"contentSize":"402px"}} -->
<div class="wp-block-group has-luminous-vivid-orange-background-color has-background"><!-- wp:columns -->
<div class="wp-block-columns"><!-- wp:column {"width":"47px","layout":{"contentSize":"26px"}} -->
<div class="wp-block-column" style="flex-basis:47px"><!-- wp:paragraph -->
<p>test</p>
<!-- /wp:paragraph --></div>
<!-- /wp:column -->

<!-- wp:column -->
<div class="wp-block-column"><!-- wp:paragraph -->
<p>test</p>
<!-- /wp:paragraph --></div>
<!-- /wp:column --></div>
<!-- /wp:columns --></div>
<!-- /wp:group -->

<!-- wp:group {"backgroundColor":"luminous-vivid-orange","layout":{"type":"flex","flexWrap":"nowrap"}} -->
<div class="wp-block-group has-luminous-vivid-orange-background-color has-background"><!-- wp:columns -->
<div class="wp-block-columns"><!-- wp:column {"width":"47px","layout":{"contentSize":"26px"}} -->
<div class="wp-block-column" style="flex-basis:47px"><!-- wp:paragraph -->
<p>test</p>
<!-- /wp:paragraph --></div>
<!-- /wp:column -->

<!-- wp:column -->
<div class="wp-block-column"><!-- wp:paragraph -->
<p>test</p>
<!-- /wp:paragraph --></div>
<!-- /wp:column --></div>
<!-- /wp:columns --></div>
<!-- /wp:group -->

<!-- wp:group {"backgroundColor":"vivid-purple"} -->
<div class="wp-block-group has-vivid-purple-background-color has-background"><!-- wp:paragraph -->
<p>test</p>
<!-- /wp:paragraph --></div>
<!-- /wp:group -->
```

</details>

<details>

<summary>Example markup for Layout support</summary>

```html
<!-- wp:group {"align":"full","style":{"spacing":{"padding":{"top":"30px","right":"30px","bottom":"30px","left":"30px"}}},"backgroundColor":"vivid-red","layout":{"contentSize":"600px"}} -->
<div class="wp-block-group alignfull has-vivid-red-background-color has-background" style="padding-top:30px;padding-right:30px;padding-bottom:30px;padding-left:30px"><!-- wp:cover {"overlayColor":"primary","align":"full"} -->
<div class="wp-block-cover alignfull"><span aria-hidden="true" class="wp-block-cover__background has-primary-background-color has-background-dim-100 has-background-dim"></span><div class="wp-block-cover__inner-container"><!-- wp:paragraph {"align":"center","placeholder":"Write title…","fontSize":"large"} -->
<p class="has-text-align-center has-large-font-size">A cover block that's full width to the edge</p>
<!-- /wp:paragraph --></div></div>
<!-- /wp:cover --></div>
<!-- /wp:group -->

<!-- wp:buttons {"layout":{"type":"flex","flexWrap":"nowrap"},"style":{"spacing":{"blockGap":"50px"}}} -->
<div class="wp-block-buttons"><!-- wp:button -->
<div class="wp-block-button"><a class="wp-block-button__link wp-element-button">Button</a></div>
<!-- /wp:button -->

<!-- wp:button -->
<div class="wp-block-button"><a class="wp-block-button__link wp-element-button">Button</a></div>
<!-- /wp:button -->

<!-- wp:button -->
<div class="wp-block-button"><a class="wp-block-button__link wp-element-button">Button</a></div>
<!-- /wp:button -->

<!-- wp:button -->
<div class="wp-block-button"><a class="wp-block-button__link wp-element-button">Button</a></div>
<!-- /wp:button -->

<!-- wp:button -->
<div class="wp-block-button"><a class="wp-block-button__link wp-element-button">Button</a></div>
<!-- /wp:button -->

<!-- wp:button -->
<div class="wp-block-button"><a class="wp-block-button__link wp-element-button">Button</a></div>
<!-- /wp:button -->

<!-- wp:button -->
<div class="wp-block-button"><a class="wp-block-button__link wp-element-button">Button</a></div>
<!-- /wp:button -->

<!-- wp:button -->
<div class="wp-block-button"><a class="wp-block-button__link wp-element-button">Button</a></div>
<!-- /wp:button -->

<!-- wp:button -->
<div class="wp-block-button"><a class="wp-block-button__link wp-element-button">Button</a></div>
<!-- /wp:button -->

<!-- wp:button -->
<div class="wp-block-button"><a class="wp-block-button__link wp-element-button">Button</a></div>
<!-- /wp:button -->

<!-- wp:button -->
<div class="wp-block-button"><a class="wp-block-button__link wp-element-button">Button</a></div>
<!-- /wp:button -->

<!-- wp:button -->
<div class="wp-block-button"><a class="wp-block-button__link wp-element-button">Button</a></div>
<!-- /wp:button --></div>
<!-- /wp:buttons -->

<!-- wp:buttons {"layout":{"type":"flex","justifyContent":"left"},"style":{"spacing":{"blockGap":"5px"}}} -->
<div class="wp-block-buttons"><!-- wp:button -->
<div class="wp-block-button"><a class="wp-block-button__link wp-element-button">Button A</a></div>
<!-- /wp:button -->

<!-- wp:button -->
<div class="wp-block-button"><a class="wp-block-button__link wp-element-button">Button B</a></div>
<!-- /wp:button -->

<!-- wp:button -->
<div class="wp-block-button"><a class="wp-block-button__link wp-element-button">Button C</a></div>
<!-- /wp:button --></div>
<!-- /wp:buttons -->

<!-- wp:buttons {"layout":{"type":"flex","justifyContent":"center"},"style":{"spacing":{"blockGap":"2px"}}} -->
<div class="wp-block-buttons"><!-- wp:button -->
<div class="wp-block-button"><a class="wp-block-button__link wp-element-button">Button A</a></div>
<!-- /wp:button -->

<!-- wp:button -->
<div class="wp-block-button"><a class="wp-block-button__link wp-element-button">Button B</a></div>
<!-- /wp:button -->

<!-- wp:button -->
<div class="wp-block-button"><a class="wp-block-button__link wp-element-button">Button C</a></div>
<!-- /wp:button --></div>
<!-- /wp:buttons -->

<!-- wp:buttons {"layout":{"type":"flex","justifyContent":"right"},"style":{"spacing":{"blockGap":"2px"}}} -->
<div class="wp-block-buttons"><!-- wp:button -->
<div class="wp-block-button"><a class="wp-block-button__link wp-element-button">Button A</a></div>
<!-- /wp:button -->

<!-- wp:button -->
<div class="wp-block-button"><a class="wp-block-button__link wp-element-button">Button B</a></div>
<!-- /wp:button -->

<!-- wp:button -->
<div class="wp-block-button"><a class="wp-block-button__link wp-element-button">Button C</a></div>
<!-- /wp:button --></div>
<!-- /wp:buttons -->

<!-- wp:buttons {"layout":{"type":"flex","justifyContent":"center"},"style":{"spacing":{"blockGap":"2px"}}} -->
<div class="wp-block-buttons"><!-- wp:button -->
<div class="wp-block-button"><a class="wp-block-button__link wp-element-button">Button A</a></div>
<!-- /wp:button -->

<!-- wp:button -->
<div class="wp-block-button"><a class="wp-block-button__link wp-element-button">Button B<br>on multiple rows</a></div>
<!-- /wp:button -->

<!-- wp:button -->
<div class="wp-block-button"><a class="wp-block-button__link wp-element-button">Button C</a></div>
<!-- /wp:button --></div>
<!-- /wp:buttons -->

<!-- wp:buttons {"layout":{"type":"flex","justifyContent":"center","verticalAlignment":"top"},"style":{"spacing":{"blockGap":"2px"}}} -->
<div class="wp-block-buttons"><!-- wp:button -->
<div class="wp-block-button"><a class="wp-block-button__link wp-element-button">Button A</a></div>
<!-- /wp:button -->

<!-- wp:button -->
<div class="wp-block-button"><a class="wp-block-button__link wp-element-button">Button B<br>on multiple rows</a></div>
<!-- /wp:button -->

<!-- wp:button -->
<div class="wp-block-button"><a class="wp-block-button__link wp-element-button">Button C</a></div>
<!-- /wp:button --></div>
<!-- /wp:buttons -->

<!-- wp:buttons {"layout":{"type":"flex","justifyContent":"center","verticalAlignment":"bottom"},"style":{"spacing":{"blockGap":"2px"}}} -->
<div class="wp-block-buttons"><!-- wp:button -->
<div class="wp-block-button"><a class="wp-block-button__link wp-element-button">Button A</a></div>
<!-- /wp:button -->

<!-- wp:button -->
<div class="wp-block-button"><a class="wp-block-button__link wp-element-button">Button B<br>on multiple rows</a></div>
<!-- /wp:button -->

<!-- wp:button -->
<div class="wp-block-button"><a class="wp-block-button__link wp-element-button">Button C</a></div>
<!-- /wp:button --></div>
<!-- /wp:buttons -->

<!-- wp:buttons {"layout":{"type":"flex","justifyContent":"center","orientation":"vertical","flexWrap":"wrap"},"style":{"spacing":{"blockGap":"2px"}}} -->
<div class="wp-block-buttons"><!-- wp:button -->
<div class="wp-block-button"><a class="wp-block-button__link wp-element-button">Button A</a></div>
<!-- /wp:button -->

<!-- wp:button -->
<div class="wp-block-button"><a class="wp-block-button__link wp-element-button">Button B</a></div>
<!-- /wp:button -->

<!-- wp:button -->
<div class="wp-block-button"><a class="wp-block-button__link wp-element-button">Button C</a></div>
<!-- /wp:button --></div>
<!-- /wp:buttons -->
```

</details>

<img width="814" alt="Screen Shot 2022-07-25 at 11 27 27 am" src="https://user-images.githubusercontent.com/6458278/180676720-8fd9ac9a-a2f7-4cd5-b189-5a4f3539e7f0.png">

Enable `"useRootPaddingAwareAlignments": true` in your theme.json and give a group block full alignment and some left and right padding. 

The layout styles should be printed as expected, e.g., `.wp-block-group.wp-container-6 > .alignfull {margin-right: calc(26px * -1); margin-left: calc(69px * -1);}`

Also make sure the CSS rules are being batched into a single, inline style sheet. For example, this:

```html
<style id='block-supports-inline-css'>
.wp-elements-bb563b31fce88a8bb12898100773d8e7 a {color: #842ecf;}.wp-elements-4cebe23f336adf33d0fd72ee6511e88e a {color: #fbc941;}.wp-elements-58f56fce71e24389540d1fff37a68db8 a,.wp-elements-cad477801df51349bcb7ad151a4593cb a {color: var(--wp--preset--color--pale-pink);}
</style>
<style id='layout-block-supports-inline-css'>
.wp-block-group.wp-container-6 > .alignfull {margin-right: calc(26px * -1); margin-left: calc(69px * -1);}.wp-block-group.wp-container-10 > :where(:not(.alignleft):not(.alignright):not(.alignfull)) {max-width: 402px; margin-left: auto !important; margin-right: auto !important;}.wp-block-group.wp-container-10 > .alignwide {max-width: 402px;}.wp-block-column.wp-container-3 > :where(:not(.alignleft):not(.alignright):not(.alignfull)),.wp-block-column.wp-container-7 > :where(:not(.alignleft):not(.alignright):not(.alignfull)),.wp-block-column.wp-container-11 > :where(:not(.alignleft):not(.alignright):not(.alignfull)) {max-width: 26px; margin-left: auto !important; margin-right: auto !important;}.wp-block-column.wp-container-3 > .alignwide,.wp-block-column.wp-container-7 > .alignwide,.wp-block-column.wp-container-11 > .alignwide {max-width: 26px;}.wp-block-column.wp-container-3 .alignfull,.wp-block-group.wp-container-6 .alignfull,.wp-block-column.wp-container-7 .alignfull,.wp-block-group.wp-container-10 .alignfull,.wp-block-column.wp-container-11 .alignfull,.wp-block-post-content.wp-container-16 .alignfull {max-width: none;}.wp-block-columns.wp-container-5,.wp-block-columns.wp-container-9,.wp-block-columns.wp-container-13,.wp-block-group.wp-container-14 {flex-wrap: nowrap;}.wp-block-group.wp-container-6 > :where(:not(.alignleft):not(.alignright):not(.alignfull)),.wp-block-post-content.wp-container-16 > :where(:not(.alignleft):not(.alignright):not(.alignfull)) {max-width: 840px; margin-left: auto !important; margin-right: auto !important;}.wp-block-group.wp-container-6 > .alignwide,.wp-block-post-content.wp-container-16 > .alignwide {max-width: 1100px;}
</style>
```

Instead of this:

```html
	<style>.wp-block-navigation.wp-container-3 {justify-content: flex-end;}</style>
<style>.wp-block-group.wp-container-4 {justify-content: space-between;}</style>
<style>.wp-block-group.wp-container-5 > :where(:not(.alignleft):not(.alignright):not(.alignfull)) {max-width: 650px;margin-left: auto !important;margin-right: auto !important;}.wp-block-group.wp-container-5 > .alignwide { max-width: 1000px;}.wp-block-group.wp-container-5 .alignfull { max-width: none; }</style>
<style>.wp-block-group.wp-container-6 > :where(:not(.alignleft):not(.alignright):not(.alignfull)) {max-width: 650px;margin-left: auto !important;margin-right: auto !important;}.wp-block-group.wp-container-6 > .alignwide { max-width: 1000px;}.wp-block-group.wp-container-6 .alignfull { max-width: none; }</style>
<style>.wp-elements-bb563b31fce88a8bb12898100773d8e7 a { color: #842ecf; }</style>
<style>.wp-elements-bb563b31fce88a8bb12898100773d8e7 a { color: #842ecf; }</style>
<style>.wp-elements-58f56fce71e24389540d1fff37a68db8 a { color: var(--wp--preset--color--pale-pink); }</style>
<style>.wp-elements-58f56fce71e24389540d1fff37a68db8 a { color: var(--wp--preset--color--pale-pink); }</style>
<style>.wp-elements-cad477801df51349bcb7ad151a4593cb a { color: var(--wp--preset--color--pale-pink); }</style>
<style>.wp-elements-4cebe23f336adf33d0fd72ee6511e88e a { color: #fbc941; }</style>
<style>.wp-elements-4cebe23f336adf33d0fd72ee6511e88e a { color: #fbc941; }</style>
<style>.wp-block-column.wp-container-9 > :where(:not(.alignleft):not(.alignright):not(.alignfull)) {max-width: 26px;margin-left: auto !important;margin-right: auto !important;}.wp-block-column.wp-container-9 > .alignwide { max-width: 26px;}.wp-block-column.wp-container-9 .alignfull { max-width: none; }</style>
<style>.wp-block-columns.wp-container-11 { flex-wrap: nowrap; }</style>
<style>.wp-block-group.wp-container-12 > :where(:not(.alignleft):not(.alignright):not(.alignfull)) {max-width: 650px;margin-left: auto !important;margin-right: auto !important;}.wp-block-group.wp-container-12 > .alignwide { max-width: 1000px;}.wp-block-group.wp-container-12 .alignfull { max-width: none; }</style>
<style>.wp-block-column.wp-container-13 > :where(:not(.alignleft):not(.alignright):not(.alignfull)) {max-width: 26px;margin-left: auto !important;margin-right: auto !important;}.wp-block-column.wp-container-13 > .alignwide { max-width: 26px;}.wp-block-column.wp-container-13 .alignfull { max-width: none; }</style>
<style>.wp-block-columns.wp-container-15 { flex-wrap: nowrap; }</style>
<style>.wp-block-group.wp-container-16 > :where(:not(.alignleft):not(.alignright):not(.alignfull)) {max-width: 402px;margin-left: auto !important;margin-right: auto !important;}.wp-block-group.wp-container-16 > .alignwide { max-width: 402px;}.wp-block-group.wp-container-16 .alignfull { max-width: none; }</style>
<style>.wp-block-column.wp-container-17 > :where(:not(.alignleft):not(.alignright):not(.alignfull)) {max-width: 26px;margin-left: auto !important;margin-right: auto !important;}.wp-block-column.wp-container-17 > .alignwide { max-width: 26px;}.wp-block-column.wp-container-17 .alignfull { max-width: none; }</style>
<style>.wp-block-columns.wp-container-19 { flex-wrap: nowrap; }</style>
<style>.wp-block-group.wp-container-20 { flex-wrap: nowrap; }</style>
<style>.wp-block-post-content.wp-container-22 > :where(:not(.alignleft):not(.alignright):not(.alignfull)) {max-width: 650px;margin-left: auto !important;margin-right: auto !important;}.wp-block-post-content.wp-container-22 > .alignwide { max-width: 1000px;}.wp-block-post-content.wp-container-22 .alignfull { max-width: none; }</style>
<style>.wp-block-group.wp-container-24 > :where(:not(.alignleft):not(.alignright):not(.alignfull)) {max-width: 650px;margin-left: auto !important;margin-right: auto !important;}.wp-block-group.wp-container-24 > .alignwide { max-width: 1000px;}.wp-block-group.wp-container-24 .alignfull { max-width: none; }</style>
<style>.wp-block-group.wp-container-26 {justify-content: space-between;}</style>
<style>.wp-block-group.wp-container-27 > :where(:not(.alignleft):not(.alignright):not(.alignfull)) {max-width: 650px;margin-left: auto !important;margin-right: auto !important;}.wp-block-group.wp-container-27 > .alignwide { max-width: 1000px;}.wp-block-group.wp-container-27 .alignfull { max-width: none; }</style>
<style>.wp-block-group.wp-container-28 > :where(:not(.alignleft):not(.alignright):not(.alignfull)) {max-width: 650px;margin-left: auto !important;margin-right: auto !important;}.wp-block-group.wp-container-28 > .alignwide { max-width: 1000px;}.wp-block-group.wp-container-28 .alignfull { max-width: none; }</style>

```