### PR TITLE
Style engine: update return PHP doc comment and other nitpicks

### DIFF
--- a/packages/style-engine/class-wp-style-engine.php
+++ b/packages/style-engine/class-wp-style-engine.php
@@ -229,11 +229,11 @@ class WP_Style_Engine {
 	 * @return WP_Style_Engine The main instance.
 	 */
 	public static function get_instance() {
-		if ( null === self::$instance ) {
-			self::$instance = new self();
+		if ( null === static::$instance ) {
+			static::$instance = new static();
 		}
 
-		return self::$instance;
+		return static::$instance;
 	}
 
 	/**
@@ -423,17 +423,17 @@ class WP_Style_Engine {
 		}
 
 		// Build CSS rules output.
-		$css_selector = isset( $options['selector'] ) ? $options['selector'] : null;
-		$style_rules  = new WP_Style_Engine_CSS_Declarations( $css_declarations );
+		$css_selector     = isset( $options['selector'] ) ? $options['selector'] : null;
+		$css_declarations = new WP_Style_Engine_CSS_Declarations( $css_declarations );
 
 		// The return object.
 		$styles_output = array();
-		$css           = $style_rules->get_declarations_string();
+		$css           = $css_declarations->get_declarations_string();
 
 		// Return css, if any.
 		if ( ! empty( $css ) ) {
 			$styles_output['css']          = $css;
-			$styles_output['declarations'] = $style_rules->get_declarations();
+			$styles_output['declarations'] = $css_declarations->get_declarations();
 			// Return an entire rule if there is a selector.
 			if ( $css_selector ) {
 				$styles_output['css'] = $css_selector . ' { ' . $css . ' }';
@@ -503,7 +503,7 @@ class WP_Style_Engine {
  * Example usage:
  *
  * $styles = wp_style_engine_get_block_supports_styles( array( 'color' => array( 'text' => '#cccccc' ) ) );
- * // Returns `array( 'css' => 'color: #cccccc', 'classnames' => 'has-color' )`.
+ * // Returns `array( 'css' => 'color: #cccccc', 'declarations' => array( 'color' => '#cccccc' ), 'classnames' => 'has-color' )`.
  *
  * @access public
  *
@@ -511,8 +511,9 @@ class WP_Style_Engine {
  * @param array<string> $options      An array of options to determine the output.
  *
  * @return array<string>|null array(
- *     'styles'     => (string) A CSS ruleset formatted to be placed in an HTML `style` attribute or tag.
- *     'classnames' => (string) Classnames separated by a space.
+ *     'styles'        => (string) A CSS ruleset or declarations block formatted to be placed in an HTML `style` attribute or tag.
+ *     'declarations'  => (array) An array of property/value pairs representing parsed CSS declarations.
+ *     'classnames'    => (string) Classnames separated by a space.
  * );
  */
 function wp_style_engine_get_block_supports_styles( $block_styles, $options = array() ) {


### PR DESCRIPTION

## What?

Some small changes that have been bugging me this afternoon.


So this PR:

- Adds `declarations` to return value docs
- Renames $style_rules to $css_declarations
- Changes `self::` to `static::` for future classes that may extend this one

## Why?
Did I really need to create this PR? Not really.

Would I have slept tonight if I hadn't? HELL NO! 🔥 

## How?

Bashing at my keyboard.

## Testing Instructions
If the tests pass, things are great.
