### PR TITLE
Add block variations for individual template parts

### DIFF
--- a/packages/block-editor/src/components/inserter-list-item/index.js
+++ b/packages/block-editor/src/components/inserter-list-item/index.js
@@ -11,6 +11,7 @@ import {
 	createBlock,
 	createBlocksFromInnerBlocksTemplate,
 } from '@wordpress/blocks';
+import { __experimentalTruncate as Truncate } from '@wordpress/components';
 import { ENTER } from '@wordpress/keycodes';
 
 /**
@@ -135,7 +136,9 @@ function InserterListItem( {
 							<BlockIcon icon={ item.icon } showColors />
 						</span>
 						<span className="block-editor-block-types-list__item-title">
-							{ item.title }
+							<Truncate numberOfLines={ 3 }>
+								{ item.title }
+							</Truncate>
 						</span>
 					</InserterListboxItem>
 				</div>

--- a/packages/block-editor/src/components/inserter/preview-panel.js
+++ b/packages/block-editor/src/components/inserter/preview-panel.js
@@ -5,7 +5,6 @@ import {
 	isReusableBlock,
 	createBlock,
 	getBlockFromExample,
-	getBlockType,
 } from '@wordpress/blocks';
 import { __ } from '@wordpress/i18n';
 
@@ -16,31 +15,24 @@ import BlockCard from '../block-card';
 import BlockPreview from '../block-preview';
 
 function InserterPreviewPanel( { item } ) {
-	const { name, title, icon, description, initialAttributes } = item;
-	const hoveredItemBlockType = getBlockType( name );
+	const { name, title, icon, description, initialAttributes, example } = item;
 	const isReusable = isReusableBlock( item );
 	return (
 		<div className="block-editor-inserter__preview-container">
 			<div className="block-editor-inserter__preview">
-				{ isReusable || hoveredItemBlockType?.example ? (
+				{ isReusable || example ? (
 					<div className="block-editor-inserter__preview-content">
 						<BlockPreview
 							__experimentalPadding={ 16 }
-							viewportWidth={
-								hoveredItemBlockType.example?.viewportWidth ??
-								500
-							}
+							viewportWidth={ example?.viewportWidth ?? 500 }
 							blocks={
-								hoveredItemBlockType.example
+								example
 									? getBlockFromExample( item.name, {
 											attributes: {
-												...hoveredItemBlockType.example
-													.attributes,
+												...example.attributes,
 												...initialAttributes,
 											},
-											innerBlocks:
-												hoveredItemBlockType.example
-													.innerBlocks,
+											innerBlocks: example.innerBlocks,
 									  } )
 									: createBlock( name, initialAttributes )
 							}

--- a/packages/block-library/src/template-part/index.php
+++ b/packages/block-library/src/template-part/index.php
@@ -204,7 +204,11 @@ function build_template_part_block_instance_variations() {
 		$variations[] = array(
 			'name'        => sanitize_title( $template_part->slug ),
 			'title'       => $template_part->title,
-			'description' => $template_part->description,
+			// If there's no description for the template part don't show the
+			// block description. This is a bit hacky, but prevent the fallback
+			// by using a non-breaking space so that the value of description
+			// isn't falsey.
+			'description' => $template_part->description || '&nbsp;',
 			'attributes'  => array(
 				'slug'  => $template_part->slug,
 				'theme' => $template_part->theme,

--- a/packages/block-library/src/template-part/index.php
+++ b/packages/block-library/src/template-part/index.php
@@ -189,6 +189,9 @@ function build_template_part_block_instance_variations() {
 		'post_type'      => 'wp_template_part',
     ), 'wp_template_part' );
 
+	$defined_areas = get_allowed_block_template_part_areas();
+	$icon_by_area = array_combine( array_column( $defined_areas, 'area' ), array_column( $defined_areas, 'icon' ) );
+
 	foreach ( $template_parts as $template_part ) {
 		$variations[] = array(
 			'name'        => sanitize_title( $template_part->slug ),
@@ -197,7 +200,7 @@ function build_template_part_block_instance_variations() {
 			'attributes'  => array(
 				'slug' => $template_part->slug,
 				'theme' => $template_part->theme,
-				'area' => $template_part->area,
+				'area' => $icon_by_area[$template_part->area],
 			),
 			'scope'       => array( 'inserter' ),
 			'icon'        => $template_part->area,

--- a/packages/block-library/src/template-part/index.php
+++ b/packages/block-library/src/template-part/index.php
@@ -200,15 +200,15 @@ function build_template_part_block_instance_variations() {
 			'attributes'  => array(
 				'slug' => $template_part->slug,
 				'theme' => $template_part->theme,
-				'area' => $icon_by_area[$template_part->area],
+				'area' => $template_part->area,
 			),
 			'scope'       => array( 'inserter' ),
-			'icon'        => $template_part->area,
+			'icon'        => $icon_by_area[$template_part->area],
 			'example'     => array(
 				'attributes'  => array(
 					'slug' => $template_part->slug,
 					'theme' => $template_part->theme,
-					'area' => $icon_by_area[$template_part->area],
+					'area' => $template_part->area,
 				),
 			)
 		);

--- a/packages/block-library/src/template-part/index.php
+++ b/packages/block-library/src/template-part/index.php
@@ -204,6 +204,13 @@ function build_template_part_block_instance_variations() {
 			),
 			'scope'       => array( 'inserter' ),
 			'icon'        => $template_part->area,
+			'example'     => array(
+				'attributes'  => array(
+					'slug' => $template_part->slug,
+					'theme' => $template_part->theme,
+					'area' => $icon_by_area[$template_part->area],
+				),
+			)
 		);
 	}
 	return $variations;

--- a/packages/block-library/src/template-part/index.php
+++ b/packages/block-library/src/template-part/index.php
@@ -234,7 +234,7 @@ function build_template_part_block_instance_variations() {
  * @return array Array containing the block variation objects.
  */
 function build_template_part_block_variations() {
-	return array_merge( build_template_part_block_variations(), build_template_part_block_instance_variations() );
+	return array_merge( build_template_part_block_area_variations(), build_template_part_block_instance_variations() );
 }
 
 /**

--- a/packages/block-library/src/template-part/index.php
+++ b/packages/block-library/src/template-part/index.php
@@ -163,7 +163,7 @@ function render_block_core_template_part( $attributes ) {
  *
  * @return array Array containing the block variation objects.
  */
-function build_template_part_block_variations() {
+function build_template_part_block_area_variations() {
 	$variations    = array();
 	$defined_areas = get_allowed_block_template_part_areas();
 	foreach ( $defined_areas as $area ) {
@@ -183,6 +183,29 @@ function build_template_part_block_variations() {
 	return $variations;
 }
 
+function build_template_part_block_instance_variations() {
+	$variations     = array();
+	$template_parts = get_block_templates( array(
+		'post_type'      => 'wp_template_part',
+    ), 'wp_template_part' );
+
+	foreach ( $template_parts as $template_part ) {
+		$variations[] = array(
+			'name'        => sanitize_title( $template_part->slug ),
+			'title'       => $template_part->title,
+			'description' => $template_part->description,
+			'attributes'  => array(
+				'slug' => $template_part->slug,
+				'theme' => $template_part->theme,
+				'area' => $template_part->area,
+			),
+			'scope'       => array( 'inserter' ),
+			'icon'        => $template_part->area,
+		);
+	}
+	return $variations;
+}
+
 /**
  * Registers the `core/template-part` block on the server.
  */
@@ -191,7 +214,7 @@ function register_block_core_template_part() {
 		__DIR__ . '/template-part',
 		array(
 			'render_callback' => 'render_block_core_template_part',
-			'variations'      => build_template_part_block_variations(),
+			'variations'      => array_merge( build_template_part_block_variations(), build_template_part_block_instance_variations() )
 		)
 	);
 }

--- a/packages/block-library/src/template-part/index.php
+++ b/packages/block-library/src/template-part/index.php
@@ -159,7 +159,7 @@ function render_block_core_template_part( $attributes ) {
 }
 
 /**
- * Returns an array of variation objects for the template part block.
+ * Returns an array of area variation objects for the template part block.
  *
  * @return array Array containing the block variation objects.
  */
@@ -183,14 +183,22 @@ function build_template_part_block_area_variations() {
 	return $variations;
 }
 
+/**
+ * Returns an array of instance variation objects for the template part block
+ *
+ * @return array Array containing the block variation objects.
+ */
 function build_template_part_block_instance_variations() {
 	$variations     = array();
-	$template_parts = get_block_templates( array(
-		'post_type'      => 'wp_template_part',
-    ), 'wp_template_part' );
+	$template_parts = get_block_templates(
+		array(
+			'post_type' => 'wp_template_part',
+		),
+		'wp_template_part'
+	);
 
 	$defined_areas = get_allowed_block_template_part_areas();
-	$icon_by_area = array_combine( array_column( $defined_areas, 'area' ), array_column( $defined_areas, 'icon' ) );
+	$icon_by_area  = array_combine( array_column( $defined_areas, 'area' ), array_column( $defined_areas, 'icon' ) );
 
 	foreach ( $template_parts as $template_part ) {
 		$variations[] = array(
@@ -198,19 +206,19 @@ function build_template_part_block_instance_variations() {
 			'title'       => $template_part->title,
 			'description' => $template_part->description,
 			'attributes'  => array(
-				'slug' => $template_part->slug,
+				'slug'  => $template_part->slug,
 				'theme' => $template_part->theme,
-				'area' => $template_part->area,
+				'area'  => $template_part->area,
 			),
 			'scope'       => array( 'inserter' ),
-			'icon'        => $icon_by_area[$template_part->area],
+			'icon'        => $icon_by_area[ $template_part->area ],
 			'example'     => array(
-				'attributes'  => array(
-					'slug' => $template_part->slug,
+				'attributes' => array(
+					'slug'  => $template_part->slug,
 					'theme' => $template_part->theme,
-					'area' => $template_part->area,
+					'area'  => $template_part->area,
 				),
-			)
+			),
 		);
 	}
 	return $variations;
@@ -224,7 +232,7 @@ function register_block_core_template_part() {
 		__DIR__ . '/template-part',
 		array(
 			'render_callback' => 'render_block_core_template_part',
-			'variations'      => array_merge( build_template_part_block_variations(), build_template_part_block_instance_variations() )
+			'variations'      => array_merge( build_template_part_block_variations(), build_template_part_block_instance_variations() ),
 		)
 	);
 }

--- a/packages/block-library/src/template-part/index.php
+++ b/packages/block-library/src/template-part/index.php
@@ -229,6 +229,15 @@ function build_template_part_block_instance_variations() {
 }
 
 /**
+ * Returns an array of all template part block variations.
+ *
+ * @return array Array containing the block variation objects.
+ */
+function build_template_part_block_variations() {
+	return array_merge( build_template_part_block_variations(), build_template_part_block_instance_variations() );
+}
+
+/**
  * Registers the `core/template-part` block on the server.
  */
 function register_block_core_template_part() {
@@ -236,7 +245,7 @@ function register_block_core_template_part() {
 		__DIR__ . '/template-part',
 		array(
 			'render_callback' => 'render_block_core_template_part',
-			'variations'      => array_merge( build_template_part_block_variations(), build_template_part_block_instance_variations() ),
+			'variations'      => build_template_part_block_variations(),
 		)
 	);
 }


### PR DESCRIPTION
## What?
Closes #31748

Adds a variation for each individual template part. Makes it so that users can see individual template parts like 'Header (dark, large)' (from TT2) in the inserter. The goal is to make it easier to insert existing template parts directly from the inserter.

## Why?
This is part of the discussion here - https://github.com/WordPress/gutenberg/pull/42142#issuecomment-1180391165

The plan at the moment is to explore quicker and easier ways for users to insert existing template part content (both existing template parts and patterns).

## How?
Adds additional block variations by expanding on the PHP code that adds area variations.

## Testing Instructions
1. Open the site editor
2. Open the block inserter
3. Find the template part blocks, see additional variations for existing template parts

## Screenshots or screencast <!-- if applicable -->
![Screen Shot 2022-07-18 at 2 40 34 pm](https://user-images.githubusercontent.com/677833/179456972-4fbe791d-71e8-447d-b1bb-fb81dfcca558.png)
