### PR TITLE
Template Parts: Add search to replacement modal

### DIFF
--- a/packages/base-styles/_z-index.scss
+++ b/packages/base-styles/_z-index.scss
@@ -18,6 +18,7 @@ $z-layers: (
 	".block-editor-inserter__tabs .components-tab-panel__tab-content": 0, // lower scrolling content
 	".block-editor-inserter__tabs .components-tab-panel__tabs": 1, // higher sticky element
 	".block-editor-inserter__search": 1, // higher sticky element
+	".block-library-template-part__selection-search": 1, // higher sticky element
 
 	// These next two share a stacking context
 	".interface-complementary-area .components-panel" : 0, // lower scrolling content

--- a/packages/base-styles/_z-index.scss
+++ b/packages/base-styles/_z-index.scss
@@ -18,7 +18,6 @@ $z-layers: (
 	".block-editor-inserter__tabs .components-tab-panel__tab-content": 0, // lower scrolling content
 	".block-editor-inserter__tabs .components-tab-panel__tabs": 1, // higher sticky element
 	".block-editor-inserter__search": 1, // higher sticky element
-	".block-library-template-part__selection-search": 1, // higher sticky element
 
 	// These next two share a stacking context
 	".interface-complementary-area .components-panel" : 0, // lower scrolling content

--- a/packages/block-library/src/template-part/edit/selection-modal.js
+++ b/packages/block-library/src/template-part/edit/selection-modal.js
@@ -1,7 +1,7 @@
 /**
  * WordPress dependencies
  */
-import { useCallback, useMemo } from '@wordpress/element';
+import { useCallback, useMemo, useState } from '@wordpress/element';
 import { __, sprintf } from '@wordpress/i18n';
 import { store as noticesStore } from '@wordpress/notices';
 import { useDispatch } from '@wordpress/data';
@@ -11,6 +11,10 @@ import {
 	__experimentalBlockPatternsList as BlockPatternsList,
 	store as blockEditorStore,
 } from '@wordpress/block-editor';
+import {
+	SearchControl,
+	__experimentalHStack as HStack,
+} from '@wordpress/components';
 
 /**
  * Internal dependencies
@@ -21,6 +25,7 @@ import {
 	useCreateTemplatePartFromBlocks,
 } from './utils/hooks';
 import { createTemplatePartId } from './utils/create-template-part-id';
+import { searchItems } from './utils/search';
 
 export default function TemplatePartSelectionModal( {
 	setAttributes,
@@ -29,6 +34,8 @@ export default function TemplatePartSelectionModal( {
 	area,
 	clientId,
 } ) {
+	const [ searchValue, setSearchValue ] = useState( '' );
+
 	// When the templatePartId is undefined,
 	// it means the user is creating a new one from the placeholder.
 	const isReplacingTemplatePartContent = !! templatePartId;
@@ -37,18 +44,24 @@ export default function TemplatePartSelectionModal( {
 		templatePartId
 	);
 	// We can map template parts to block patters to reuse the BlockPatternsList UI
-	const templartPartsAsBlockPatterns = useMemo( () => {
-		return templateParts.map( ( templatePart ) => ( {
+	const filteredTemplateParts = useMemo( () => {
+		const partsAsPatterns = templateParts.map( ( templatePart ) => ( {
 			name: createTemplatePartId( templatePart.theme, templatePart.slug ),
 			title: templatePart.title.rendered,
 			blocks: parse( templatePart.content.raw ),
 			templatePart,
 		} ) );
-	}, [ templateParts ] );
-	const shownTemplateParts = useAsyncList( templartPartsAsBlockPatterns );
-	const { createSuccessNotice } = useDispatch( noticesStore );
+
+		return searchItems( partsAsPatterns, searchValue );
+	}, [ templateParts, searchValue ] );
+	const shownTemplateParts = useAsyncList( filteredTemplateParts );
 	const blockPatterns = useAlternativeBlockPatterns( area, clientId );
-	const shownBlockPatterns = useAsyncList( blockPatterns );
+	const filteredBlockPatterns = useMemo( () => {
+		return searchItems( blockPatterns, searchValue );
+	}, [ blockPatterns, searchValue ] );
+	const shownBlockPatterns = useAsyncList( filteredBlockPatterns );
+
+	const { createSuccessNotice } = useDispatch( noticesStore );
 	const { replaceInnerBlocks } = useDispatch( blockEditorStore );
 
 	const onTemplatePartSelect = useCallback( ( templatePart ) => {
@@ -76,40 +89,53 @@ export default function TemplatePartSelectionModal( {
 	);
 
 	return (
-		<>
-			<div className="block-library-template-part__selection-content">
-				{ !! templartPartsAsBlockPatterns.length && (
-					<div>
-						<h2>{ __( 'Existing template parts' ) }</h2>
-						<BlockPatternsList
-							blockPatterns={ templartPartsAsBlockPatterns }
-							shownPatterns={ shownTemplateParts }
-							onClickPattern={ ( pattern ) => {
-								onTemplatePartSelect( pattern.templatePart );
-							} }
-						/>
-					</div>
-				) }
-
-				{ !! blockPatterns.length && (
-					<div>
-						<h2>{ __( 'Patterns' ) }</h2>
-						<BlockPatternsList
-							blockPatterns={ blockPatterns }
-							shownPatterns={ shownBlockPatterns }
-							onClickPattern={ ( pattern, blocks ) => {
-								if ( isReplacingTemplatePartContent ) {
-									replaceInnerBlocks( clientId, blocks );
-								} else {
-									createFromBlocks( blocks, pattern.title );
-								}
-
-								onClose();
-							} }
-						/>
-					</div>
-				) }
+		<div className="block-library-template-part__selection-content">
+			<div className="block-library-template-part__selection-search">
+				<SearchControl
+					onChange={ setSearchValue }
+					value={ searchValue }
+					label={ __( 'Search for replacements' ) }
+					placeholder={ __( 'Search' ) }
+				/>
 			</div>
-		</>
+			{ !! filteredTemplateParts.length && (
+				<div>
+					<h2>{ __( 'Existing template parts' ) }</h2>
+					<BlockPatternsList
+						blockPatterns={ filteredTemplateParts }
+						shownPatterns={ shownTemplateParts }
+						onClickPattern={ ( pattern ) => {
+							onTemplatePartSelect( pattern.templatePart );
+						} }
+					/>
+				</div>
+			) }
+
+			{ !! filteredBlockPatterns.length && (
+				<div>
+					<h2>{ __( 'Patterns' ) }</h2>
+					<BlockPatternsList
+						blockPatterns={ filteredBlockPatterns }
+						shownPatterns={ shownBlockPatterns }
+						onClickPattern={ ( pattern, blocks ) => {
+							if ( isReplacingTemplatePartContent ) {
+								replaceInnerBlocks( clientId, blocks );
+							} else {
+								createFromBlocks( blocks, pattern.title );
+							}
+
+							onClose();
+						} }
+					/>
+				</div>
+			) }
+
+			{ ! filteredTemplateParts.length &&
+				! filteredBlockPatterns.length && (
+					<HStack alignment="center">
+						<p>{ __( 'No results found.' ) }</p>
+					</HStack>
+				) }
+		</div>
 	);
 }

--- a/packages/block-library/src/template-part/edit/selection-modal.js
+++ b/packages/block-library/src/template-part/edit/selection-modal.js
@@ -88,6 +88,9 @@ export default function TemplatePartSelectionModal( {
 		setAttributes
 	);
 
+	const hasTemplateParts = !! filteredTemplateParts.length;
+	const hasBlockPatterns = !! filteredBlockPatterns.length;
+
 	return (
 		<div className="block-library-template-part__selection-content">
 			<div className="block-library-template-part__selection-search">
@@ -98,7 +101,7 @@ export default function TemplatePartSelectionModal( {
 					placeholder={ __( 'Search' ) }
 				/>
 			</div>
-			{ !! filteredTemplateParts.length && (
+			{ hasTemplateParts && (
 				<div>
 					<h2>{ __( 'Existing template parts' ) }</h2>
 					<BlockPatternsList
@@ -111,7 +114,7 @@ export default function TemplatePartSelectionModal( {
 				</div>
 			) }
 
-			{ !! filteredBlockPatterns.length && (
+			{ hasBlockPatterns && (
 				<div>
 					<h2>{ __( 'Patterns' ) }</h2>
 					<BlockPatternsList
@@ -130,12 +133,11 @@ export default function TemplatePartSelectionModal( {
 				</div>
 			) }
 
-			{ ! filteredTemplateParts.length &&
-				! filteredBlockPatterns.length && (
-					<HStack alignment="center">
-						<p>{ __( 'No results found.' ) }</p>
-					</HStack>
-				) }
+			{ ! hasTemplateParts && ! hasBlockPatterns && (
+				<HStack alignment="center">
+					<p>{ __( 'No results found.' ) }</p>
+				</HStack>
+			) }
 		</div>
 	);
 }

--- a/packages/block-library/src/template-part/edit/selection-modal.js
+++ b/packages/block-library/src/template-part/edit/selection-modal.js
@@ -25,7 +25,7 @@ import {
 	useCreateTemplatePartFromBlocks,
 } from './utils/hooks';
 import { createTemplatePartId } from './utils/create-template-part-id';
-import { searchItems } from './utils/search';
+import { searchPatterns } from './utils/search';
 
 export default function TemplatePartSelectionModal( {
 	setAttributes,
@@ -52,12 +52,12 @@ export default function TemplatePartSelectionModal( {
 			templatePart,
 		} ) );
 
-		return searchItems( partsAsPatterns, searchValue );
+		return searchPatterns( partsAsPatterns, searchValue );
 	}, [ templateParts, searchValue ] );
 	const shownTemplateParts = useAsyncList( filteredTemplateParts );
 	const blockPatterns = useAlternativeBlockPatterns( area, clientId );
 	const filteredBlockPatterns = useMemo( () => {
-		return searchItems( blockPatterns, searchValue );
+		return searchPatterns( blockPatterns, searchValue );
 	}, [ blockPatterns, searchValue ] );
 	const shownBlockPatterns = useAsyncList( filteredBlockPatterns );
 

--- a/packages/block-library/src/template-part/edit/utils/search.js
+++ b/packages/block-library/src/template-part/edit/utils/search.js
@@ -1,0 +1,20 @@
+/**
+ * Filters an item list given a search term.
+ *
+ * @param {Array}  items       Item list
+ * @param {string} searchValue Search input.
+ *
+ * @return {Array} Filtered item list.
+ */
+export function searchItems( items, searchValue ) {
+	if ( ! searchValue ) {
+		return items;
+	}
+
+	const normalizedSearchValue = searchValue.toLowerCase();
+	return items.filter( ( item ) => {
+		const normalizedTitle = item.title.toLowerCase();
+
+		return normalizedTitle.includes( normalizedSearchValue );
+	} );
+}

--- a/packages/block-library/src/template-part/edit/utils/search.js
+++ b/packages/block-library/src/template-part/edit/utils/search.js
@@ -1,20 +1,76 @@
 /**
- * Filters an item list given a search term.
- *
- * @param {Array}  items       Item list
- * @param {string} searchValue Search input.
- *
- * @return {Array} Filtered item list.
+ * External dependencies
  */
-export function searchItems( items, searchValue ) {
-	if ( ! searchValue ) {
-		return items;
+import removeAccents from 'remove-accents';
+
+/**
+ * Sanitizes the search input string.
+ *
+ * @param {string} input The search input to normalize.
+ *
+ * @return {string} The normalized search input.
+ */
+function normalizeSearchInput( input = '' ) {
+	// Disregard diacritics.
+	input = removeAccents( input );
+
+	// Trim & Lowercase.
+	input = input.trim().toLowerCase();
+
+	return input;
+}
+
+/**
+ * Get the search rank for a given pattern and a specific search term.
+ *
+ * @param {Object} pattern     Pattern to rank
+ * @param {string} searchValue Search term
+ * @return {number} A pattern search rank
+ */
+function getSearchPatternRank( pattern, searchValue ) {
+	const normalizedSearchValue = normalizeSearchInput( searchValue );
+	const normalizedTitle = normalizeSearchInput( pattern.title );
+
+	let rank = 0;
+
+	if ( normalizedSearchValue === normalizedTitle ) {
+		rank += 30;
+	} else if ( normalizedTitle.startsWith( normalizedSearchValue ) ) {
+		rank += 20;
+	} else {
+		const searchTerms = normalizedSearchValue.split( ' ' );
+		const hasMatchedTerms = searchTerms.every( ( searchTerm ) =>
+			normalizedTitle.includes( searchTerm )
+		);
+
+		// Prefer pattern with every search word in the title.
+		if ( hasMatchedTerms ) {
+			rank += 10;
+		}
 	}
 
-	const normalizedSearchValue = searchValue.toLowerCase();
-	return items.filter( ( item ) => {
-		const normalizedTitle = item.title.toLowerCase();
+	return rank;
+}
 
-		return normalizedTitle.includes( normalizedSearchValue );
-	} );
+/**
+ * Filters an pattern list given a search term.
+ *
+ * @param {Array}  patterns    Item list
+ * @param {string} searchValue Search input.
+ *
+ * @return {Array} Filtered pattern list.
+ */
+export function searchPatterns( patterns = [], searchValue = '' ) {
+	if ( ! searchValue ) {
+		return patterns;
+	}
+
+	const rankedPatterns = patterns
+		.map( ( pattern ) => {
+			return [ pattern, getSearchPatternRank( pattern, searchValue ) ];
+		} )
+		.filter( ( [ , rank ] ) => rank > 0 );
+
+	rankedPatterns.sort( ( [ , rank1 ], [ , rank2 ] ) => rank2 - rank1 );
+	return rankedPatterns.map( ( [ pattern ] ) => pattern );
 }

--- a/packages/block-library/src/template-part/edit/utils/search.js
+++ b/packages/block-library/src/template-part/edit/utils/search.js
@@ -27,7 +27,7 @@ function normalizeSearchInput( input = '' ) {
  * @param {string} searchValue Search term
  * @return {number} A pattern search rank
  */
-function getSearchPatternRank( pattern, searchValue ) {
+function getPatternSearchRank( pattern, searchValue ) {
 	const normalizedSearchValue = normalizeSearchInput( searchValue );
 	const normalizedTitle = normalizeSearchInput( pattern.title );
 
@@ -67,7 +67,7 @@ export function searchPatterns( patterns = [], searchValue = '' ) {
 
 	const rankedPatterns = patterns
 		.map( ( pattern ) => {
-			return [ pattern, getSearchPatternRank( pattern, searchValue ) ];
+			return [ pattern, getPatternSearchRank( pattern, searchValue ) ];
 		} )
 		.filter( ( [ , rank ] ) => rank > 0 );
 

--- a/packages/block-library/src/template-part/editor.scss
+++ b/packages/block-library/src/template-part/editor.scss
@@ -19,8 +19,8 @@
 
 .block-library-template-part__selection-search {
 	background: $white;
-	z-index: z-index(".block-editor-template-part__selection-modal");
 	position: sticky;
 	top: 0;
 	padding: $grid-unit-20 0;
+	z-index: z-index(".block-library-template-part__selection-search");
 }

--- a/packages/block-library/src/template-part/editor.scss
+++ b/packages/block-library/src/template-part/editor.scss
@@ -16,3 +16,11 @@
 		}
 	}
 }
+
+.block-library-template-part__selection-search {
+	background: $white;
+	padding-top: $grid-unit-20;
+	position: sticky;
+	top: 0;
+	z-index: z-index(".block-library-template-part__selection-search");
+}

--- a/packages/block-library/src/template-part/editor.scss
+++ b/packages/block-library/src/template-part/editor.scss
@@ -19,19 +19,23 @@
 
 .block-library-template-part__selection-search {
 	background: $white;
-	position: absolute;
-	top: $grid-unit-20;
-	// Gap + close button size + header padding.
-	right: $grid-unit-10 + $button-size + $grid-unit-40;
 	z-index: z-index(".block-editor-template-part__selection-modal");
+	position: sticky;
+	top: 0;
+	padding: $grid-unit-20 0;
+
+	@include break-small() {
+		position: absolute;
+		top: $grid-unit-20;
+		// Gap + close button size + header padding.
+		right: $grid-unit-10 + $button-size + $grid-unit-40;
+		padding: 0;
+	}
 
 	.components-search-control {
 		input[type="search"].components-search-control__input {
-			height: $grid-unit * 5.5;
-			width: $grid-unit * 16;
-
 			@include break-small() {
-				width: auto;
+				height: $grid-unit * 5.5;
 			}
 		}
 	}

--- a/packages/block-library/src/template-part/editor.scss
+++ b/packages/block-library/src/template-part/editor.scss
@@ -26,7 +26,7 @@
 	z-index: z-index(".block-editor-template-part__selection-modal");
 
 	.components-search-control {
-		input[type=search].components-search-control__input {
+		input[type="search"].components-search-control__input {
 			height: $grid-unit * 5.5;
 		}
 	}

--- a/packages/block-library/src/template-part/editor.scss
+++ b/packages/block-library/src/template-part/editor.scss
@@ -24,4 +24,10 @@
 	// Gap + close button size + header padding.
 	right: $grid-unit-10 + $button-size + $grid-unit-40;
 	z-index: z-index(".block-editor-template-part__selection-modal");
+
+	.components-search-control {
+		input[type=search].components-search-control__input {
+			height: $grid-unit * 5.5;
+		}
+	}
 }

--- a/packages/block-library/src/template-part/editor.scss
+++ b/packages/block-library/src/template-part/editor.scss
@@ -23,20 +23,4 @@
 	position: sticky;
 	top: 0;
 	padding: $grid-unit-20 0;
-
-	@include break-small() {
-		position: absolute;
-		top: $grid-unit-20;
-		// Gap + close button size + header padding.
-		right: $grid-unit-10 + $button-size + $grid-unit-40;
-		padding: 0;
-	}
-
-	.components-search-control {
-		input[type="search"].components-search-control__input {
-			@include break-small() {
-				height: $grid-unit * 5.5;
-			}
-		}
-	}
 }

--- a/packages/block-library/src/template-part/editor.scss
+++ b/packages/block-library/src/template-part/editor.scss
@@ -19,8 +19,9 @@
 
 .block-library-template-part__selection-search {
 	background: $white;
-	padding-top: $grid-unit-20;
-	position: sticky;
-	top: 0;
-	z-index: z-index(".block-library-template-part__selection-search");
+	position: absolute;
+	top: $grid-unit-20;
+	// Gap + close button size + header padding.
+	right: $grid-unit-10 + $button-size + $grid-unit-40;
+	z-index: z-index(".block-editor-template-part__selection-modal");
 }

--- a/packages/block-library/src/template-part/editor.scss
+++ b/packages/block-library/src/template-part/editor.scss
@@ -28,6 +28,11 @@
 	.components-search-control {
 		input[type="search"].components-search-control__input {
 			height: $grid-unit * 5.5;
+			width: $grid-unit * 16;
+
+			@include break-small() {
+				width: auto;
+			}
 		}
 	}
 }


### PR DESCRIPTION
## What?
Resolves: #40791

Adds a new search functionality to the template parts replacement modal.

## Why?
It makes it easier to find specific template parts.

## How?
* Adds the `SearchControl` component to the modal.
* Introduces a new `searchItems` to perform a basic search based on a string match.

## Testing Instructions
1. Open the Site Editor.
2. Select a Template Part.
3. Select "Replace {templatePartName}" in the block options dropdown.
4. Try the new search feature.

## Screenshots or screencast <!-- if applicable -->

https://user-images.githubusercontent.com/240569/179185405-2ee28679-6ead-4e30-b4ab-60bd5e905028.mp4
