### PR TITLE
CustomSelectControl: Use styles from SelectControl

### DIFF
--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -2,12 +2,18 @@
 
 ## Unreleased
 
+### Bug Fix
+
+-   `CustomSelectControl`: Fix font size and hover/focus style inconsistencies with `SelectControl` ([#42460](https://github.com/WordPress/gutenberg/pull/42460/)).
+
 ### Enhancements
 
 -   `BorderControl`: Improve labelling, tooltips and DOM structure ([#42348](https://github.com/WordPress/gutenberg/pull/42348/)).
 -   `BaseControl`: Set zero padding on `StyledLabel` to ensure cross-browser styling ([#42348](https://github.com/WordPress/gutenberg/pull/42348/)).
 -   `SelectControl`: Add flag for larger default size ([#42456](https://github.com/WordPress/gutenberg/pull/42456/)).
 -   `UnitControl`: Update unit select's focus styles to match input's ([#42383](https://github.com/WordPress/gutenberg/pull/42383)).
+-   `CustomSelectControl`: Add size variants ([#42460](https://github.com/WordPress/gutenberg/pull/42460/)).
+-   `CustomSelectControl`: Add flag to opt in to unconstrained width ([#42460](https://github.com/WordPress/gutenberg/pull/42460/)).
 
 ### Internal
 

--- a/packages/components/src/custom-select-control/index.js
+++ b/packages/components/src/custom-select-control/index.js
@@ -9,12 +9,14 @@ import classnames from 'classnames';
  */
 import { Icon, check, chevronDown } from '@wordpress/icons';
 import { __, sprintf } from '@wordpress/i18n';
-import { useCallback } from '@wordpress/element';
+import { useCallback, useState } from '@wordpress/element';
 
 /**
  * Internal dependencies
  */
-import { Button, VisuallyHidden } from '../';
+import { VisuallyHidden } from '../';
+import { Select as SelectControlSelect } from '../select-control/styles/select-control-styles';
+import InputBase from '../input-control/input-base';
 
 const itemToString = ( item ) => item?.name;
 // This is needed so that in Windows, where
@@ -64,6 +66,8 @@ export default function CustomSelectControl( {
 	describedBy,
 	options: items,
 	onChange: onSelectedItemChange,
+	/** @type {import('../select-control/types').SelectControlProps.size} */
+	size = 'default',
 	value: _selectedItem,
 } ) {
 	const {
@@ -84,6 +88,8 @@ export default function CustomSelectControl( {
 			: undefined ),
 		stateReducer,
 	} );
+
+	const [ isFocused, setIsFocused ] = useState( false );
 
 	function getDescribedBy() {
 		if ( describedBy ) {
@@ -138,31 +144,29 @@ export default function CustomSelectControl( {
 					{ label }
 				</label>
 			) }
-			<Button
-				{ ...getToggleButtonProps( {
-					// This is needed because some speech recognition software don't support `aria-labelledby`.
-					'aria-label': label,
-					'aria-labelledby': undefined,
-					className: classnames(
-						'components-custom-select-control__button',
-						{ 'is-next-36px-default-size': __next36pxDefaultSize }
-					),
-					isSmall: ! __next36pxDefaultSize,
-					describedBy: getDescribedBy(),
-				} ) }
-			>
-				{ itemToString( selectedItem ) }
-				<Icon
-					icon={ chevronDown }
-					className={ classnames(
-						'components-custom-select-control__button-icon',
-						{
-							'is-next-36px-default-size': __next36pxDefaultSize,
-						}
-					) }
-					size={ 18 }
-				/>
-			</Button>
+			<InputBase isFocused={ isOpen || isFocused }>
+				<SelectControlSelect
+					as="button"
+					onFocus={ () => setIsFocused( true ) }
+					onBlur={ () => setIsFocused( false ) }
+					selectSize={ size }
+					__next36pxDefaultSize={ __next36pxDefaultSize }
+					{ ...getToggleButtonProps( {
+						// This is needed because some speech recognition software don't support `aria-labelledby`.
+						'aria-label': label,
+						'aria-labelledby': undefined,
+						className: 'components-custom-select-control__button',
+						describedBy: getDescribedBy(),
+					} ) }
+				>
+					{ itemToString( selectedItem ) }
+					<Icon
+						icon={ chevronDown }
+						className="components-custom-select-control__button-icon"
+						size={ 18 }
+					/>
+				</SelectControlSelect>
+			</InputBase>
 			{ /* eslint-disable-next-line jsx-a11y/no-noninteractive-element-interactions */ }
 			<ul { ...menuProps } onKeyDown={ onKeyDownHandler }>
 				{ isOpen &&

--- a/packages/components/src/custom-select-control/index.js
+++ b/packages/components/src/custom-select-control/index.js
@@ -60,6 +60,8 @@ const stateReducer = (
 export default function CustomSelectControl( {
 	/** Start opting into the larger default height that will become the default size in a future version. */
 	__next36pxDefaultSize = false,
+	/** Start opting into the unconstrained width that will become the default in a future version. */
+	__nextUnconstrainedWidth = false,
 	className,
 	hideLabelFromVision,
 	label,
@@ -144,7 +146,13 @@ export default function CustomSelectControl( {
 					{ label }
 				</label>
 			) }
-			<InputBase isFocused={ isOpen || isFocused }>
+			<InputBase
+				isFocused={ isOpen || isFocused }
+				__unstableInputWidth={
+					__nextUnconstrainedWidth ? undefined : 'auto'
+				}
+				labelPosition={ __nextUnconstrainedWidth ? undefined : 'top' }
+			>
 				<SelectControlSelect
 					as="button"
 					onFocus={ () => setIsFocused( true ) }
@@ -155,7 +163,13 @@ export default function CustomSelectControl( {
 						// This is needed because some speech recognition software don't support `aria-labelledby`.
 						'aria-label': label,
 						'aria-labelledby': undefined,
-						className: 'components-custom-select-control__button',
+						className: classnames(
+							'components-custom-select-control__button',
+							{
+								'is-next-unconstrained-width':
+									__nextUnconstrainedWidth,
+							}
+						),
 						describedBy: getDescribedBy(),
 					} ) }
 				>

--- a/packages/components/src/custom-select-control/stories/index.js
+++ b/packages/components/src/custom-select-control/stories/index.js
@@ -10,6 +10,12 @@ export default {
 		__next36pxDefaultSize: {
 			control: { type: 'boolean' },
 		},
+		size: {
+			control: {
+				type: 'radio',
+				options: [ 'small', 'default', '__unstable-large' ],
+			},
+		},
 	},
 };
 

--- a/packages/components/src/custom-select-control/stories/index.js
+++ b/packages/components/src/custom-select-control/stories/index.js
@@ -7,9 +7,8 @@ export default {
 	title: 'Components/CustomSelectControl',
 	component: CustomSelectControl,
 	argTypes: {
-		__next36pxDefaultSize: {
-			control: { type: 'boolean' },
-		},
+		__next36pxDefaultSize: { control: { type: 'boolean' } },
+		__nextUnconstrainedWidth: { control: { type: 'boolean' } },
 		size: {
 			control: {
 				type: 'radio',

--- a/packages/components/src/custom-select-control/style.scss
+++ b/packages/components/src/custom-select-control/style.scss
@@ -8,45 +8,16 @@
 }
 
 .components-custom-select-control__button {
-	border: 1px solid $gray-700;
-	border-radius: $radius-block-ui;
-	min-width: 130px;
 	position: relative;
 	text-align: left;
-
-	&:not(.is-next-36px-default-size) {
-		min-height: 30px;
-	}
-
-	// For all button sizes allow sufficient space for the
-	// dropdown "arrow" icon to display.
-	&.components-custom-select-control__button {
-		// TODO: Some of these can be removed after some internal inconsistencies are addressed, such as the chevron
-		// (https://github.com/WordPress/gutenberg/issues/39400) and Button padding (https://github.com/WordPress/gutenberg/issues/39431)
-		padding-left: $grid-unit-20;
-		padding-right: $icon-size + $grid-unit-10;
-
-		&:not(.is-next-36px-default-size) {
-			padding-left: $grid-unit-10;
-			padding-right: $icon-size;
-		}
-	}
-
-	&:focus:not(:disabled) {
-		border-color: var(--wp-admin-theme-color);
-		box-shadow: 0 0 0 ($border-width-focus - $border-width) var(--wp-admin-theme-color);
-	}
+	outline: 0; // focus ring is handled elsewhere
 
 	.components-custom-select-control__button-icon {
 		height: 100%;
 		padding: 0;
 		position: absolute;
-		right: $grid-unit-10;
+		right: $grid-unit-05;
 		top: 0;
-
-		&:not(.is-next-36px-default-size) {
-			right: $grid-unit-05;
-		}
 	}
 }
 

--- a/packages/components/src/custom-select-control/style.scss
+++ b/packages/components/src/custom-select-control/style.scss
@@ -12,6 +12,10 @@
 	text-align: left;
 	outline: 0; // focus ring is handled elsewhere
 
+	&:not(.is-next-unconstrained-width) {
+		min-width: 130px;
+	}
+
 	.components-custom-select-control__button-icon {
 		height: 100%;
 		padding: 0;


### PR DESCRIPTION
- Part of #41973 
- Based on #42456
- Fixes #39433

## What?

Reuse the same styling components used in SelectControl for a more consistent design. This replaces the hacky `Button`-based styling that was being used.

## Why?

This eliminates a bunch of styling inconsistencies between SelectControl and CustomSelectControl, including:

- font size
- hover and focus styles
- default width

Plus, we get all the size variants for free.

## How?

To limit the scope of this PR, the following will be done as follow-up tasks:

- Move the `chevronDown` icon to the standard `suffix` prop (after #42378 lands).
- Clean up all the [`width: 100%` overrides](https://cs.github.com/?q=components-custom-select-control__button%20language%3ASCSS&scopeName=Gutenberg&scope=repo%3Awordpress%2Fgutenberg) in the codebase.
- Once all the CustomSelectControl instances in the repo have the `__nextConstrainedWidth` flag, add an official deprecation warning.

## Testing Instructions

1. `npm run storybook:dev` and see the CustomSelectControl story.
2. When `__nextUnconstrainedWidth=false`, the width behavior should be the same as in [trunk](https://wordpress.github.io/gutenberg/?path=/story/components-customselectcontrol--default). Basically, the width is 130px by default but can grow if the selected option label is longer than that.
3. When `__nextUnconstrainedWidth=true`, each size variant should look the same as the ones for SelectControl.

## Screenshots or screencast <!-- if applicable -->

https://user-images.githubusercontent.com/555336/179189613-1e4b0668-5c92-4b5d-91b1-532320daaa4a.mp4


