### PR TITLE
Style Engine: Rename WP_Style_Engine_CSS_Rule->set_declarations to add_declarations

### DIFF
--- a/packages/style-engine/class-wp-style-engine-css-rule.php
+++ b/packages/style-engine/class-wp-style-engine-css-rule.php
@@ -43,7 +43,7 @@ class WP_Style_Engine_CSS_Rule {
 	 */
 	public function __construct( $selector = '', $declarations = array() ) {
 		$this->set_selector( $selector );
-		$this->set_declarations( $declarations );
+		$this->add_declarations( $declarations );
 	}
 
 	/**
@@ -70,7 +70,7 @@ class WP_Style_Engine_CSS_Rule {
 	 *
 	 * @return WP_Style_Engine_CSS_Rule Returns the object to allow chaining of methods.
 	 */
-	public function set_declarations( $declarations ) {
+	public function add_declarations( $declarations ) {
 		$is_declarations_object = ! is_array( $declarations );
 		$declarations_array     = $is_declarations_object ? $declarations->get_declarations() : $declarations;
 

--- a/packages/style-engine/phpunit/class-wp-style-engine-css-rule-test.php
+++ b/packages/style-engine/phpunit/class-wp-style-engine-css-rule-test.php
@@ -43,7 +43,7 @@ class WP_Style_Engine_CSS_Rule_Test extends WP_UnitTestCase {
 			'font-size' => '4px',
 		);
 		$css_rule                    = new WP_Style_Engine_CSS_Rule( $selector, $first_declaration );
-		$css_rule->set_declarations( new WP_Style_Engine_CSS_Declarations( $overwrite_first_declaration ) );
+		$css_rule->add_declarations( new WP_Style_Engine_CSS_Declarations( $overwrite_first_declaration ) );
 
 		$expected = '.taggart {font-size: 4px;}';
 		$this->assertSame( $expected, $css_rule->get_css() );
@@ -52,13 +52,13 @@ class WP_Style_Engine_CSS_Rule_Test extends WP_UnitTestCase {
 	/**
 	 * Should set selector and rules on instantiation.
 	 */
-	public function test_set_declarations() {
+	public function test_add_declarations() {
 		// Declarations using a WP_Style_Engine_CSS_Declarations object.
 		$some_css_declarations = new WP_Style_Engine_CSS_Declarations( array( 'margin-top' => '10px' ) );
 		// Declarations using a property => value array.
 		$some_more_css_declarations = array( 'font-size' => '1rem' );
 		$css_rule                   = new WP_Style_Engine_CSS_Rule( '.hill-street-blues', $some_css_declarations );
-		$css_rule->set_declarations( $some_more_css_declarations );
+		$css_rule->add_declarations( $some_more_css_declarations );
 
 		$expected = '.hill-street-blues {margin-top: 10px; font-size: 1rem;}';
 		$this->assertSame( $expected, $css_rule->get_css() );

--- a/packages/style-engine/phpunit/class-wp-style-engine-css-rules-store-test.php
+++ b/packages/style-engine/phpunit/class-wp-style-engine-css-rules-store-test.php
@@ -52,7 +52,7 @@ class WP_Style_Engine_CSS_Rules_Store_Test extends WP_UnitTestCase {
 			'border-radius' => '10rem',
 		);
 		$css_declarations = new WP_Style_Engine_CSS_Declarations( $pie_declarations );
-		$store_rule->set_declarations( $css_declarations );
+		$store_rule->add_declarations( $css_declarations );
 
 		$store_rule = $new_pie_store->add_rule( $selector );
 		$expected   = "$selector {{$css_declarations->get_declarations_string()}}";
@@ -78,7 +78,7 @@ class WP_Style_Engine_CSS_Rules_Store_Test extends WP_UnitTestCase {
 			'border-radius' => '10rem',
 		);
 		$css_declarations   = new WP_Style_Engine_CSS_Declarations( $pizza_declarations );
-		$store_rule->set_declarations( array( $css_declarations ) );
+		$store_rule->add_declarations( array( $css_declarations ) );
 
 		$expected = array(
 			$selector => $store_rule,
@@ -91,7 +91,7 @@ class WP_Style_Engine_CSS_Rules_Store_Test extends WP_UnitTestCase {
 			'font-size'    => '10rem',
 		);
 		$css_declarations       = new WP_Style_Engine_CSS_Declarations( $new_pizza_declarations );
-		$store_rule->set_declarations( array( $css_declarations ) );
+		$store_rule->add_declarations( array( $css_declarations ) );
 
 		$expected = array(
 			$selector => $store_rule,
@@ -104,7 +104,7 @@ class WP_Style_Engine_CSS_Rules_Store_Test extends WP_UnitTestCase {
 		);
 		$new_store_rule           = $new_pizza_store->add_rule( $new_selector );
 		$css_declarations         = new WP_Style_Engine_CSS_Declarations( $newer_pizza_declarations );
-		$new_store_rule->set_declarations( array( $css_declarations ) );
+		$new_store_rule->add_declarations( array( $css_declarations ) );
 
 		$expected = array(
 			$selector     => $store_rule,


### PR DESCRIPTION
## What?
Renames the `set_declarations` method to `add_declarations`

## Why?
`set` gives the impression that the declarations we're adding will _replace_ the ones that existed. Instead, what the method does is to `add` declarations to the ones that already exist (and if none exist, then and only then can it be considered `set`).
