### PR TITLE
Lodash: Refactor away from `_.capitalize()`

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -79,6 +79,7 @@ module.exports = {
 					{
 						name: 'lodash',
 						importNames: [
+							'capitalize',
 							'chunk',
 							'clamp',
 							'compact',

--- a/package-lock.json
+++ b/package-lock.json
@@ -16979,6 +16979,7 @@
 				"@wordpress/api-fetch": "file:packages/api-fetch",
 				"@wordpress/keycodes": "file:packages/keycodes",
 				"@wordpress/url": "file:packages/url",
+				"change-case": "^4.1.2",
 				"form-data": "^4.0.0",
 				"lodash": "^4.17.21"
 			}
@@ -17536,6 +17537,7 @@
 			"requires": {
 				"@babel/runtime": "^7.16.0",
 				"@wordpress/i18n": "file:packages/i18n",
+				"change-case": "^4.1.2",
 				"lodash": "^4.17.21"
 			}
 		},

--- a/packages/e2e-test-utils-playwright/package.json
+++ b/packages/e2e-test-utils-playwright/package.json
@@ -34,6 +34,7 @@
 		"@wordpress/api-fetch": "file:../api-fetch",
 		"@wordpress/keycodes": "file:../keycodes",
 		"@wordpress/url": "file:../url",
+		"change-case": "^4.1.2",
 		"form-data": "^4.0.0",
 		"lodash": "^4.17.21"
 	},

--- a/packages/e2e-test-utils-playwright/src/page-utils/press-key-with-modifier.ts
+++ b/packages/e2e-test-utils-playwright/src/page-utils/press-key-with-modifier.ts
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { capitalize } from 'lodash';
+import { capitalCase } from 'change-case';
 import type { Page } from '@playwright/test';
 
 /**
@@ -123,7 +123,7 @@ export async function pressKeyWithModifier(
 			_isApple() ? [ SHIFT, ALT ] : [ SHIFT, CTRL ],
 	};
 	const mappedModifiers = overWrittenModifiers[ modifier ]( isAppleOS ).map(
-		( keycode ) => ( keycode === CTRL ? 'Control' : capitalize( keycode ) )
+		( keycode ) => ( keycode === CTRL ? 'Control' : capitalCase( keycode ) )
 	);
 
 	await this.page.keyboard.press(

--- a/packages/e2e-test-utils/src/press-key-with-modifier.js
+++ b/packages/e2e-test-utils/src/press-key-with-modifier.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { capitalize } from 'lodash';
+import { capitalCase } from 'change-case';
 
 /**
  * WordPress dependencies
@@ -168,7 +168,7 @@ export async function pressKeyWithModifier( modifier, key ) {
 
 	await Promise.all(
 		mappedModifiers.map( async ( mod ) => {
-			const capitalizedMod = capitalize( ctrlSwap( mod ) );
+			const capitalizedMod = capitalCase( ctrlSwap( mod ) );
 			return page.keyboard.down( capitalizedMod );
 		} )
 	);
@@ -177,7 +177,7 @@ export async function pressKeyWithModifier( modifier, key ) {
 
 	await Promise.all(
 		mappedModifiers.map( async ( mod ) => {
-			const capitalizedMod = capitalize( ctrlSwap( mod ) );
+			const capitalizedMod = capitalCase( ctrlSwap( mod ) );
 			return page.keyboard.up( capitalizedMod );
 		} )
 	);

--- a/packages/keycodes/package.json
+++ b/packages/keycodes/package.json
@@ -29,6 +29,7 @@
 	"dependencies": {
 		"@babel/runtime": "^7.16.0",
 		"@wordpress/i18n": "file:../i18n",
+		"change-case": "^4.1.2",
 		"lodash": "^4.17.21"
 	},
 	"publishConfig": {

--- a/packages/keycodes/src/index.js
+++ b/packages/keycodes/src/index.js
@@ -12,7 +12,8 @@
 /**
  * External dependencies
  */
-import { get, mapValues, includes, capitalize, xor } from 'lodash';
+import { capitalCase } from 'change-case';
+import { get, mapValues, includes, xor } from 'lodash';
 
 /**
  * WordPress dependencies
@@ -232,7 +233,7 @@ export const displayShortcutList = mapValues( modifiers, ( modifier ) => {
 			/** @type {string[]} */ ( [] )
 		);
 
-		const capitalizedCharacter = capitalize( character );
+		const capitalizedCharacter = capitalCase( character );
 		return [ ...modifierKeys, capitalizedCharacter ];
 	};
 } );
@@ -294,7 +295,7 @@ export const shortcutAriaLabel = mapValues( modifiers, ( modifier ) => {
 		};
 
 		return [ ...modifier( _isApple ), character ]
-			.map( ( key ) => capitalize( get( replacementKeyMap, key, key ) ) )
+			.map( ( key ) => capitalCase( get( replacementKeyMap, key, key ) ) )
 			.join( isApple ? ' ' : ' + ' );
 	};
 } );


### PR DESCRIPTION
## What?
This PR removes the `_.capitalize()` usage completely and deprecates the function. 

## Why?

Lodash is known to unnecessarily inflate the bundle size of packages, and in most cases, it can be replaced with native language functionality. See these for more information and rationale:

* https://github.com/WordPress/gutenberg/issues/16938#issuecomment-602837246
* https://github.com/WordPress/gutenberg/issues/17025
* https://github.com/WordPress/gutenberg/issues/39495 

## How?

Similar to #42427, we're suggesting to use the `change-case` library, which offers modular functions for all the casing functions we use from Lodash (like `snakeCase`, `capitalize`, `startCase`, `camelCase`, `kebabCase` ), at a small price (the methods are small themselves), and has TS support. The benefit of using that external library for all those case conversion functions is that we won't have to maintain our own versions of them, and those are already broadly used and tested.

In particular, we replace a few of `capitalize()` Lodash usages in favor of the `change-case` one (`capitalCase`).

## Testing Instructions
* Verify all tests still pass.