### PR TITLE
Lodash: Refactor pascal case usages away from Lodash

### DIFF
--- a/docs/tool/manifest.js
+++ b/docs/tool/manifest.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-const { camelCase, upperFirst } = require( 'lodash' );
+const { pascalCase } = require( 'change-case' );
 const fs = require( 'fs' );
 const glob = require( 'glob' ).sync;
 const { join } = require( 'path' );
@@ -54,7 +54,7 @@ function getComponentManifest( paths ) {
 		const pathFragments = filePath.split( '/' );
 		const slug = pathFragments[ pathFragments.length - 2 ];
 		return {
-			title: upperFirst( camelCase( slug ) ),
+			title: pascalCase( slug ),
 			slug,
 			markdown_source: `${ baseRepoUrl }/${ filePath }`,
 			parent: 'components',
@@ -85,7 +85,7 @@ function generateRootManifestFromTOCItems( items, parent = null ) {
 				slug = 'handbook';
 			}
 		}
-		let title = upperFirst( camelCase( slug ) );
+		let title = pascalCase( slug );
 		const markdownSource = fs.readFileSync( fileName, 'utf8' );
 		const titleMarkdown = markdownSource.match( /^#\s(.+)$/m );
 		if ( titleMarkdown ) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -16801,6 +16801,7 @@
 				"@wordpress/is-shallow-equal": "file:packages/is-shallow-equal",
 				"@wordpress/keycodes": "file:packages/keycodes",
 				"@wordpress/priority-queue": "file:packages/priority-queue",
+				"change-case": "^4.1.2",
 				"clipboard": "^2.0.8",
 				"lodash": "^4.17.21",
 				"mousetrap": "^1.6.5",
@@ -16820,6 +16821,7 @@
 				"@wordpress/i18n": "file:packages/i18n",
 				"@wordpress/is-shallow-equal": "file:packages/is-shallow-equal",
 				"@wordpress/url": "file:packages/url",
+				"change-case": "^4.1.2",
 				"equivalent-key-map": "^0.2.2",
 				"lodash": "^4.17.21",
 				"memize": "^1.1.0",
@@ -28432,7 +28434,6 @@
 			"version": "4.1.2",
 			"resolved": "https://registry.npmjs.org/camel-case/-/camel-case-4.1.2.tgz",
 			"integrity": "sha512-gxGWBrTT1JuMx6R+o5PTXMmUnhnVzLQ9SNutD4YqKtI6ap897t3tKECYla6gCWEkplXnlNybEkZg9GEGxKFCgw==",
-			"dev": true,
 			"requires": {
 				"pascal-case": "^3.1.2",
 				"tslib": "^2.0.3"
@@ -28494,7 +28495,6 @@
 			"version": "1.0.4",
 			"resolved": "https://registry.npmjs.org/capital-case/-/capital-case-1.0.4.tgz",
 			"integrity": "sha512-ds37W8CytHgwnhGGTi88pcPyR15qoNkOpYwmMMfnWqqWgESapLqvDx6huFjQ5vqWSn2Z06173XNA7LtMOeUh1A==",
-			"dev": true,
 			"requires": {
 				"no-case": "^3.0.4",
 				"tslib": "^2.0.3",
@@ -28593,7 +28593,6 @@
 			"version": "4.1.2",
 			"resolved": "https://registry.npmjs.org/change-case/-/change-case-4.1.2.tgz",
 			"integrity": "sha512-bSxY2ws9OtviILG1EiY5K7NNxkqg/JnRnFxLtKQ96JaviiIxi7djMrSd0ECT9AC+lttClmYwKw53BWpOMblo7A==",
-			"dev": true,
 			"requires": {
 				"camel-case": "^4.1.2",
 				"capital-case": "^1.0.4",
@@ -29669,7 +29668,6 @@
 			"version": "3.0.4",
 			"resolved": "https://registry.npmjs.org/constant-case/-/constant-case-3.0.4.tgz",
 			"integrity": "sha512-I2hSBi7Vvs7BEuJDr5dDHfzb/Ruj3FyvFyh7KLilAjNQw3Be+xgqUBA2W6scVEcL0hL1dwPRtIqEPVUCKkSsyQ==",
-			"dev": true,
 			"requires": {
 				"no-case": "^3.0.4",
 				"tslib": "^2.0.3",
@@ -31884,7 +31882,6 @@
 			"version": "3.0.4",
 			"resolved": "https://registry.npmjs.org/dot-case/-/dot-case-3.0.4.tgz",
 			"integrity": "sha512-Kv5nKlh6yRrdrGvxeJ2e5y2eRUpkUosIW4A2AS38zwSz27zu7ufDwQPi5Jhs3XAlGNetl3bmnGhQsMtkKJnj3w==",
-			"dev": true,
 			"requires": {
 				"no-case": "^3.0.4",
 				"tslib": "^2.0.3"
@@ -37296,7 +37293,6 @@
 			"version": "2.0.4",
 			"resolved": "https://registry.npmjs.org/header-case/-/header-case-2.0.4.tgz",
 			"integrity": "sha512-H/vuk5TEEVZwrR0lp2zed9OCo1uAILMlx0JEMgC26rzyJJ3N1v6XkwHHXJQdR2doSjcGPM6OKPYoJgf0plJ11Q==",
-			"dev": true,
 			"requires": {
 				"capital-case": "^1.0.4",
 				"tslib": "^2.0.3"
@@ -43671,7 +43667,6 @@
 			"version": "2.0.2",
 			"resolved": "https://registry.npmjs.org/lower-case/-/lower-case-2.0.2.tgz",
 			"integrity": "sha512-7fm3l3NAF9WfN6W3JOmf5drwpVqX78JtoGJ3A6W0a6ZnldM41w2fV5D490psKFTpMds8TJse/eHLFFsNHHjHgg==",
-			"dev": true,
 			"requires": {
 				"tslib": "^2.0.3"
 			}
@@ -46137,7 +46132,6 @@
 			"version": "3.0.4",
 			"resolved": "https://registry.npmjs.org/no-case/-/no-case-3.0.4.tgz",
 			"integrity": "sha512-fgAN3jGAh+RoxUGZHTSOLJIqUc2wmoBwGR4tbpNAKmmovFoWq0OdRkb0VkldReO2a2iBT/OEulG9XSUc10r3zg==",
-			"dev": true,
 			"requires": {
 				"lower-case": "^2.0.2",
 				"tslib": "^2.0.3"
@@ -48233,7 +48227,6 @@
 			"version": "3.0.4",
 			"resolved": "https://registry.npmjs.org/param-case/-/param-case-3.0.4.tgz",
 			"integrity": "sha512-RXlj7zCYokReqWpOPH9oYivUzLYZ5vAPIfEmCTNViosC78F8F0H9y7T7gG2M39ymgutxF5gcFEsyZQSph9Bp3A==",
-			"dev": true,
 			"requires": {
 				"dot-case": "^3.0.4",
 				"tslib": "^2.0.3"
@@ -48338,7 +48331,6 @@
 			"version": "3.1.2",
 			"resolved": "https://registry.npmjs.org/pascal-case/-/pascal-case-3.1.2.tgz",
 			"integrity": "sha512-uWlGT3YSnK9x3BQJaOdcZwrnV6hPpd8jFH1/ucpiLRPh/2zCVJKS19E4GvYHvaCcACn3foXZ0cLB9Wrx1KGe5g==",
-			"dev": true,
 			"requires": {
 				"no-case": "^3.0.4",
 				"tslib": "^2.0.3"
@@ -48451,7 +48443,6 @@
 			"version": "3.0.4",
 			"resolved": "https://registry.npmjs.org/path-case/-/path-case-3.0.4.tgz",
 			"integrity": "sha512-qO4qCFjXqVTrcbPt/hQfhTQ+VhFsqNKOPtytgNKkKxSoEp3XPUQ8ObFuePylOIok5gjn69ry8XiULxCwot3Wfg==",
-			"dev": true,
 			"requires": {
 				"dot-case": "^3.0.4",
 				"tslib": "^2.0.3"
@@ -53073,7 +53064,6 @@
 			"version": "3.0.4",
 			"resolved": "https://registry.npmjs.org/sentence-case/-/sentence-case-3.0.4.tgz",
 			"integrity": "sha512-8LS0JInaQMCRoQ7YUytAo/xUu5W2XnQxV2HI/6uM6U7CITS1RqPElr30V6uIqyMKM9lJGRVFy5/4CuzcixNYSg==",
-			"dev": true,
 			"requires": {
 				"no-case": "^3.0.4",
 				"tslib": "^2.0.3",
@@ -53519,7 +53509,6 @@
 			"version": "3.0.4",
 			"resolved": "https://registry.npmjs.org/snake-case/-/snake-case-3.0.4.tgz",
 			"integrity": "sha512-LAOh4z89bGQvl9pFfNF8V146i7o7/CqFPbqzYgP+yYzDIDeS9HaNFtXABamRW+AQzEVODcvE79ljJ+8a9YSdMg==",
-			"dev": true,
 			"requires": {
 				"dot-case": "^3.0.4",
 				"tslib": "^2.0.3"
@@ -57824,7 +57813,6 @@
 			"version": "2.0.2",
 			"resolved": "https://registry.npmjs.org/upper-case/-/upper-case-2.0.2.tgz",
 			"integrity": "sha512-KgdgDGJt2TpuwBUIjgG6lzw2GWFRCW9Qkfkiv0DxqHHLYJHmtmdUIKcZd8rHgFSjopVTlw6ggzCm1b8MFQwikg==",
-			"dev": true,
 			"requires": {
 				"tslib": "^2.0.3"
 			}
@@ -57833,7 +57821,6 @@
 			"version": "2.0.2",
 			"resolved": "https://registry.npmjs.org/upper-case-first/-/upper-case-first-2.0.2.tgz",
 			"integrity": "sha512-514ppYHBaKwfJRK/pNC6c/OxfGa0obSnAl106u97Ed0I625Nin96KAjttZF6ZL3e1XLtphxnqrOi9iWgm+u+bg==",
-			"dev": true,
 			"requires": {
 				"tslib": "^2.0.3"
 			}

--- a/package.json
+++ b/package.json
@@ -169,6 +169,7 @@
 		"benchmark": "2.1.4",
 		"browserslist": "4.17.6",
 		"chalk": "4.1.1",
+		"change-case": "4.1.2",
 		"commander": "9.2.0",
 		"concurrently": "3.5.0",
 		"copy-webpack-plugin": "10.2.0",

--- a/packages/compose/package.json
+++ b/packages/compose/package.json
@@ -38,6 +38,7 @@
 		"@wordpress/is-shallow-equal": "file:../is-shallow-equal",
 		"@wordpress/keycodes": "file:../keycodes",
 		"@wordpress/priority-queue": "file:../priority-queue",
+		"change-case": "^4.1.2",
 		"clipboard": "^2.0.8",
 		"lodash": "^4.17.21",
 		"mousetrap": "^1.6.5",

--- a/packages/compose/src/utils/create-higher-order-component/index.ts
+++ b/packages/compose/src/utils/create-higher-order-component/index.ts
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { camelCase, upperFirst } from 'lodash';
+import { pascalCase } from 'change-case';
 import type { ComponentType } from 'react';
 
 type GetProps< C > = C extends ComponentType< infer P > ? P : never;
@@ -45,7 +45,7 @@ export function createHigherOrderComponent<
  */
 const hocName = ( name: string, Inner: ComponentType< any > ) => {
 	const inner = Inner.displayName || Inner.name || 'Component';
-	const outer = upperFirst( camelCase( name ) );
+	const outer = pascalCase( name ?? '' );
 
 	return `${ outer }(${ inner })`;
 };

--- a/packages/core-data/package.json
+++ b/packages/core-data/package.json
@@ -39,6 +39,7 @@
 		"@wordpress/i18n": "file:../i18n",
 		"@wordpress/is-shallow-equal": "file:../is-shallow-equal",
 		"@wordpress/url": "file:../url",
+		"change-case": "^4.1.2",
 		"equivalent-key-map": "^0.2.2",
 		"lodash": "^4.17.21",
 		"memize": "^1.1.0",

--- a/packages/core-data/src/entities.ts
+++ b/packages/core-data/src/entities.ts
@@ -1,7 +1,8 @@
 /**
  * External dependencies
  */
-import { upperFirst, camelCase, map, find, get, startCase } from 'lodash';
+import { capitalCase, pascalCase } from 'change-case';
+import { map, find, get } from 'lodash';
 
 /**
  * WordPress dependencies
@@ -457,7 +458,9 @@ async function loadPostTypeEntities() {
 			getTitle: ( record ) =>
 				record?.title?.rendered ||
 				record?.title ||
-				( isTemplate ? startCase( record.slug ) : String( record.id ) ),
+				( isTemplate
+					? capitalCase( record.slug ?? '' )
+					: String( record.id ) ),
 			__unstablePrePersist: isTemplate ? undefined : prePersistPostType,
 			__unstable_rest_base: postType.rest_base,
 		};
@@ -511,12 +514,11 @@ export const getMethodName = (
 	usePlural = false
 ) => {
 	const entityConfig = find( rootEntitiesConfig, { kind, name } );
-	const kindPrefix = kind === 'root' ? '' : upperFirst( camelCase( kind ) );
-	const nameSuffix =
-		upperFirst( camelCase( name ) ) + ( usePlural ? 's' : '' );
+	const kindPrefix = kind === 'root' ? '' : pascalCase( kind );
+	const nameSuffix = pascalCase( name ) + ( usePlural ? 's' : '' );
 	const suffix =
 		usePlural && 'plural' in entityConfig! && entityConfig?.plural
-			? upperFirst( camelCase( entityConfig.plural ) )
+			? pascalCase( entityConfig.plural )
 			: nameSuffix;
 	return `${ prefix }${ kindPrefix }${ suffix }`;
 };

--- a/packages/create-block/lib/scaffold.js
+++ b/packages/create-block/lib/scaffold.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-const { camelCase, snakeCase } = require( 'change-case' );
+const { pascalCase, snakeCase } = require( 'change-case' );
 
 /**
  * Internal dependencies
@@ -12,10 +12,6 @@ const initWPScripts = require( './init-wp-scripts' );
 const initWPEnv = require( './init-wp-env' );
 const { code, info, success } = require( './log' );
 const { writeOutputAsset, writeOutputTemplate } = require( './output' );
-
-function upperFirst( str ) {
-	return str.charAt( 0 ).toUpperCase() + str.substr( 1 );
-}
 
 module.exports = async (
 	{ blockOutputTemplates, pluginOutputTemplates, outputAssets },
@@ -61,7 +57,7 @@ module.exports = async (
 		namespaceSnakeCase: snakeCase( namespace ),
 		slug,
 		slugSnakeCase: snakeCase( slug ),
-		slugPascalCase: upperFirst( camelCase( slug ) ),
+		slugPascalCase: pascalCase( slug ),
 		title,
 		description,
 		dashicon,


### PR DESCRIPTION
## What?
This PR removes a few `_.upperFirst( _.camelCase() )` usages in favor of `change-case`'s `pascalCase()`. This leaves a few more usages of both functions that we'll be addressing in a separate PR.

## Why?

Lodash is known to unnecessarily inflate the bundle size of packages, and in most cases, it can be replaced with native language functionality. See these for more information and rationale:

* https://github.com/WordPress/gutenberg/issues/16938#issuecomment-602837246
* https://github.com/WordPress/gutenberg/issues/17025
* https://github.com/WordPress/gutenberg/issues/39495 

## How?

Similar to #42427, we're suggesting to use the `change-case` library, which offers modular functions for all the casing functions we use from Lodash (like `snakeCase`, `capitalize`, `startCase`, `camelCase`, `kebabCase` ), at a small price (the methods are small themselves), and has TS support. The benefit of using that external library for all those case conversion functions is that we won't have to maintain our own versions of them, and those are already broadly used and tested.

In particular, we replace a few of `_.upperFirst( _.camelCase() )` Lodash usages in favor of the `change-case` one (`pascalCase`). We also replace a stray `_.startCase()` with its corresponding `capitalCase()`.

## Testing Instructions
* Verify `npm run docs:gen` runs and completes without problems.
* Verify all tests still pass.
* Verify `npx @wordpress/create-block test-block` still works well.