### PR TITLE
Lodash: Refactor away from `_.words()`

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -142,6 +142,7 @@ module.exports = {
 							'uniqueId',
 							'uniqWith',
 							'values',
+							'words',
 							'zip',
 						],
 						message:

--- a/package-lock.json
+++ b/package-lock.json
@@ -16506,6 +16506,7 @@
 				"@wordpress/url": "file:packages/url",
 				"@wordpress/warning": "file:packages/warning",
 				"@wordpress/wordcount": "file:packages/wordcount",
+				"change-case": "^4.1.2",
 				"classnames": "^2.3.1",
 				"colord": "^2.7.0",
 				"diff": "^4.0.2",
@@ -16515,6 +16516,7 @@
 				"react-autosize-textarea": "^7.1.0",
 				"react-easy-crop": "^3.0.0",
 				"rememo": "^4.0.0",
+				"remove-accents": "^0.4.2",
 				"traverse": "^0.6.6"
 			},
 			"dependencies": {

--- a/packages/block-editor/package.json
+++ b/packages/block-editor/package.json
@@ -59,6 +59,7 @@
 		"@wordpress/url": "file:../url",
 		"@wordpress/warning": "file:../warning",
 		"@wordpress/wordcount": "file:../wordcount",
+		"change-case": "^4.1.2",
 		"classnames": "^2.3.1",
 		"colord": "^2.7.0",
 		"diff": "^4.0.2",
@@ -68,6 +69,7 @@
 		"react-autosize-textarea": "^7.1.0",
 		"react-easy-crop": "^3.0.0",
 		"rememo": "^4.0.0",
+		"remove-accents": "^0.4.2",
 		"traverse": "^0.6.6"
 	},
 	"peerDependencies": {

--- a/packages/block-editor/src/components/inserter/search-items.js
+++ b/packages/block-editor/src/components/inserter/search-items.js
@@ -1,7 +1,9 @@
 /**
  * External dependencies
  */
-import { deburr, find, words } from 'lodash';
+import { noCase } from 'change-case';
+import removeAccents from 'remove-accents';
+import { find } from 'lodash';
 
 // Default search helpers.
 const defaultGetName = ( item ) => item.name || '';
@@ -21,7 +23,7 @@ const defaultGetCollection = () => null;
 function normalizeSearchInput( input = '' ) {
 	// Disregard diacritics.
 	//  Input: "média"
-	input = deburr( input );
+	input = removeAccents( input );
 
 	// Accommodate leading slash, matching autocomplete expectations.
 	//  Input: "/media"
@@ -35,6 +37,17 @@ function normalizeSearchInput( input = '' ) {
 }
 
 /**
+ * Extracts words from an input string.
+ *
+ * @param {string} input The input string.
+ *
+ * @return {Array} Words, extracted from the input string.
+ */
+function extractWords( input = '' ) {
+	return noCase( input ).split( ' ' ).filter( Boolean );
+}
+
+/**
  * Converts the search term into a list of normalized terms.
  *
  * @param {string} input The search term to normalize.
@@ -42,8 +55,7 @@ function normalizeSearchInput( input = '' ) {
  * @return {string[]} The normalized list of search terms.
  */
 export const getNormalizedSearchTerms = ( input = '' ) => {
-	// Extract words.
-	return words( normalizeSearchInput( input ) );
+	return extractWords( normalizeSearchInput( input ) );
 };
 
 const removeMatchingTerms = ( unmatchedTerms, unprocessedTerms ) => {
@@ -150,7 +162,7 @@ export function getItemSearchRank( item, searchTerm, config = {} ) {
 			category,
 			collection,
 		].join( ' ' );
-		const normalizedSearchTerms = words( normalizedSearchInput );
+		const normalizedSearchTerms = extractWords( normalizedSearchInput );
 		const unmatchedTerms = removeMatchingTerms(
 			normalizedSearchTerms,
 			terms


### PR DESCRIPTION
## What?
This PR removes the `_.words()` usage completely and deprecates the function. It also removes one of the last remaining `_.deburr()` usages in the same file in favor of `remove-accents` that we've been using in other packages already.

## Why?

Lodash is known to unnecessarily inflate the bundle size of packages, and in most cases, it can be replaced with native language functionality. See these for more information and rationale:

* https://github.com/WordPress/gutenberg/issues/16938#issuecomment-602837246
* https://github.com/WordPress/gutenberg/issues/17025
* https://github.com/WordPress/gutenberg/issues/39495 

## How?

Similar to #42427, we're suggesting to use the `change-case` library, which offers modular functions for all the casing functions we use from Lodash (like `snakeCase`, `capitalize`, `startCase`, `camelCase`, `kebabCase` ), at a small price (the methods are small themselves), and has TS support. The benefit of using that external library for all those case conversion functions is that we won't have to maintain our own versions of them, and those are already broadly used and tested.

In particular, we replace the single instance of `words()` with a custom implementation that uses `noCase()` to generate a normalized string of words, then splits it into an array and filters out the empty values.

We also use the opportunity to remove one of the last remaining `_.deburr()` usages in that same file, since it touches the same functionality we're testing here. 

## Testing Instructions
* Verify all tests still pass, particularly:
  * `npm run test-unit packages/block-editor/src/components/inserter/test/search-items.js`
* Verify searching in all inserters (inline slash inserter, header toolbar, inline block editor inserter) still works well:
  * Searching for blocks using their name, description or keywords still works the same way as before.
  * Searching for a string with diacritics still works the same way: `média`