### PR TITLE
Element: Introduce `isPlainObject()` utility

### DIFF
--- a/packages/element/README.md
+++ b/packages/element/README.md
@@ -246,6 +246,23 @@ _Returns_
 
 -   `boolean`: True when an element is considered empty.
 
+### isPlainObject
+
+Checks if the provided value is a plain object.
+
+Plain objects are objects that are either:
+
+-   created by the `Object` constructor, or
+-   with a `[[Prototype]]` of `null`.
+
+_Parameters_
+
+-   _value_ `*`: Value to check.
+
+_Returns_
+
+-   `boolean`: True when value is considered a plain object.
+
 ### isValidElement
 
 Checks if an object is a valid WPElement.

--- a/packages/element/src/serialize.js
+++ b/packages/element/src/serialize.js
@@ -28,7 +28,7 @@
 /**
  * External dependencies
  */
-import { kebabCase, isPlainObject } from 'lodash';
+import { kebabCase } from 'lodash';
 
 /**
  * WordPress dependencies
@@ -44,6 +44,7 @@ import {
  */
 import { createContext, Fragment, StrictMode, forwardRef } from './react';
 import RawHTML from './raw-html';
+import { isPlainObject } from './utils';
 
 /** @typedef {import('./react').WPElement} WPElement */
 

--- a/packages/element/src/test/utils.js
+++ b/packages/element/src/test/utils.js
@@ -2,7 +2,7 @@
  * Internal dependencies
  */
 import { createElement } from '../react';
-import { isEmptyElement } from '../utils';
+import { isEmptyElement, isPlainObject } from '../utils';
 
 describe( 'isEmptyElement', () => {
 	test( 'should be empty', () => {
@@ -19,5 +19,42 @@ describe( 'isEmptyElement', () => {
 		expect( isEmptyElement( 'test' ) ).toBe( false );
 		expect( isEmptyElement( createElement( 'div' ) ) ).toBe( false );
 		expect( isEmptyElement( [ 'x' ] ) ).toBe( false );
+	} );
+} );
+
+describe( 'isPlainObject', () => {
+	test( 'should return true for plain objects', () => {
+		expect( isPlainObject( { foo: 'bar' } ) ).toBe( true );
+		expect( isPlainObject( new Object() ) ).toBe( true );
+		expect( isPlainObject( Object.prototype ) ).toBe( true );
+		expect( isPlainObject( Object.create( Object.prototype ) ) ).toBe(
+			true
+		);
+		expect( isPlainObject( Object.create( null ) ) ).toBe( true );
+	} );
+
+	test( 'should return false for anything else', () => {
+		expect( isPlainObject( undefined ) ).toBe( false );
+		expect( isPlainObject( null ) ).toBe( false );
+		expect( isPlainObject( true ) ).toBe( false );
+		expect( isPlainObject( [ 1, 2, 3 ] ) ).toBe( false );
+		expect( isPlainObject( '' ) ).toBe( false );
+		expect( isPlainObject( 5 ) ).toBe( false );
+		expect( isPlainObject( NaN ) ).toBe( false );
+		expect( isPlainObject( Infinity ) ).toBe( false );
+		expect( isPlainObject( new Array() ) ).toBe( false );
+		expect( isPlainObject( new String( '' ) ) ).toBe( false );
+		expect( isPlainObject( new Number( 5 ) ) ).toBe( false );
+		expect( isPlainObject( /someRegex/ ) ).toBe( false );
+		expect( isPlainObject( new Set( [ 1, 2, 3 ] ) ) ).toBe( false );
+		expect( isPlainObject( function () {} ) ).toBe( false );
+		expect( isPlainObject( () => {} ) ).toBe( false );
+		expect(
+			isPlainObject(
+				new ( function () {
+					return this;
+				} )()
+			)
+		).toBe( false );
 	} );
 } );

--- a/packages/element/src/utils.js
+++ b/packages/element/src/utils.js
@@ -15,3 +15,28 @@ export const isEmptyElement = ( element ) => {
 
 	return ! element;
 };
+
+/**
+ * Checks if the provided value is a plain object.
+ *
+ * Plain objects are objects that are either:
+ * - created by the `Object` constructor, or
+ * - with a `[[Prototype]]` of `null`.
+ *
+ * @param {*} value Value to check.
+ * @return {boolean} True when value is considered a plain object.
+ */
+export const isPlainObject = ( value ) => {
+	if ( typeof value !== 'object' || value === null ) {
+		return false;
+	}
+
+	if ( Object.getPrototypeOf( value ) === null ) {
+		return true;
+	}
+
+	return (
+		value.constructor === Object &&
+		Object.prototype.toString.call( value ) === '[object Object]'
+	);
+};


### PR DESCRIPTION
## What?
This PR introduces a new local `isPlainObject()` utility to replace Lodash's version. Part of the effort to completely remove Lodash from Gutenberg.

I'd like to seek some feedback on two points here:

* What do you think about placing (and exposing) this utility function in the `@wordpress/element` package, given that it's necessary for rendering style attribute values? Any better place to place it?
* Any thoughts or concerns on the implementation? 

This is part of #16938.

## Why?

Lodash is known to unnecessarily inflate the bundle size of packages, and in most cases, it can be replaced with native language functionality. See these for more information and rationale:

* https://github.com/WordPress/gutenberg/issues/16938#issuecomment-602837246
* https://github.com/WordPress/gutenberg/issues/17025
* https://github.com/WordPress/gutenberg/issues/39495 

## How?
We're essentially duplicating how Lodash's `isPlainObject()` works, in order to support objects with `null` prototype. Take a look at the tests to see what values we're expecting to be `true` and `false`.

If we all agree on this approach, I'm planning to work on a few more PRs to remove the rest of `isPlainObject()` including the custom inline versions I introduced in #41751.

## Testing Instructions
* Verify all tests still pass.