### PR TITLE
[Mobile] - Add shouldUseFastImage capability for the Image component

### DIFF
--- a/packages/block-editor/src/components/block-styles/preview.native.js
+++ b/packages/block-editor/src/components/block-styles/preview.native.js
@@ -8,8 +8,8 @@ import {
 	Dimensions,
 	Animated,
 	Easing,
+	Image,
 } from 'react-native';
-import FastImage from 'react-native-fast-image';
 
 /**
  * WordPress dependencies
@@ -91,7 +91,7 @@ function StylePreview( { onPress, isActive, style, url } ) {
 				<View style={ styles.imageWrapper }>
 					{ isActive &&
 						getOutline( [ styles.outline, innerOutlineStyle ] ) }
-					<FastImage
+					<Image
 						style={ [ styles.image, styles[ name ] ] }
 						source={ { uri: url } }
 					/>

--- a/packages/block-library/src/image/edit.native.js
+++ b/packages/block-library/src/image/edit.native.js
@@ -665,6 +665,7 @@ export class ImageEdit extends Component {
 			context,
 			featuredImageId,
 			wasBlockJustInserted,
+			shouldUseFastImage,
 		} = this.props;
 		const { align, url, alt, id, sizeSlug, className } = attributes;
 		const hasImageContext = context
@@ -845,6 +846,9 @@ export class ImageEdit extends Component {
 											isUploadInProgress={
 												isUploadInProgress
 											}
+											shouldUseFastImage={
+												shouldUseFastImage
+											}
 											onSelectMediaUploadOption={
 												this.onSelectMediaUploadOption
 											}
@@ -904,7 +908,8 @@ export default compose( [
 			isSelected,
 			clientId,
 		} = props;
-		const { imageSizes, imageDefaultSize } = getSettings();
+		const { imageSizes, imageDefaultSize, shouldUseFastImage } =
+			getSettings();
 		const isNotFileUrl = id && getProtocol( url ) !== 'file:';
 		const featuredImageId = getEditedPostAttribute( 'featured_media' );
 
@@ -921,6 +926,7 @@ export default compose( [
 			image: shouldGetMedia ? getMedia( id ) : null,
 			imageSizes,
 			imageDefaultSize,
+			shouldUseFastImage,
 			featuredImageId,
 			wasBlockJustInserted: wasBlockJustInserted(
 				clientId,

--- a/packages/components/src/mobile/image/index.native.js
+++ b/packages/components/src/mobile/image/index.native.js
@@ -157,6 +157,9 @@ const ImageComponent = ( {
 			opacity: isUploadInProgress ? 0.3 : 1,
 			height: containerSize?.height,
 		},
+		! resizeMode && {
+			aspectRatio: imageData?.aspectRatio,
+		},
 		focalPoint && styles.focalPoint,
 		focalPoint &&
 			getImageWithFocalPointStyles(
@@ -217,9 +220,6 @@ const ImageComponent = ( {
 				) : (
 					<View style={ focalPoint && styles.focalPointContent }>
 						<Image
-							{ ...( ! resizeMode && {
-								aspectRatio: imageData?.aspectRatio,
-							} ) }
 							style={ imageStyles }
 							source={ { uri: url } }
 							{ ...( ! focalPoint && {

--- a/packages/components/src/mobile/image/index.native.js
+++ b/packages/components/src/mobile/image/index.native.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { Image, Text, View } from 'react-native';
+import { Image as RNImage, Text, View } from 'react-native';
 import FastImage from 'react-native-fast-image';
 
 /**
@@ -37,6 +37,7 @@ const ImageComponent = ( {
 	height: imageHeight,
 	highlightSelected = true,
 	isSelected,
+	shouldUseFastImage,
 	isUploadFailed,
 	isUploadInProgress,
 	mediaPickerOptions,
@@ -53,11 +54,15 @@ const ImageComponent = ( {
 } ) => {
 	const [ imageData, setImageData ] = useState( null );
 	const [ containerSize, setContainerSize ] = useState( null );
+	const Image = ! shouldUseFastImage ? RNImage : FastImage;
+	const imageResizeMode = ! shouldUseFastImage
+		? resizeMode
+		: FastImage.resizeMode[ resizeMode ];
 
 	useEffect( () => {
 		let isCurrent = true;
 		if ( url ) {
-			Image.getSize( url, ( imgWidth, imgHeight ) => {
+			RNImage.getSize( url, ( imgWidth, imgHeight ) => {
 				if ( ! isCurrent ) {
 					return;
 				}
@@ -211,7 +216,7 @@ const ImageComponent = ( {
 					</View>
 				) : (
 					<View style={ focalPoint && styles.focalPointContent }>
-						<FastImage
+						<Image
 							{ ...( ! resizeMode && {
 								aspectRatio: imageData?.aspectRatio,
 							} ) }
@@ -220,7 +225,7 @@ const ImageComponent = ( {
 							{ ...( ! focalPoint && {
 								resizeMethod: 'scale',
 							} ) }
-							resizeMode={ FastImage.resizeMode[ resizeMode ] }
+							resizeMode={ imageResizeMode }
 						/>
 					</View>
 				) }

--- a/packages/react-native-bridge/android/react-native-bridge/src/main/java/org/wordpress/mobile/WPAndroidGlue/GutenbergProps.kt
+++ b/packages/react-native-bridge/android/react-native-bridge/src/main/java/org/wordpress/mobile/WPAndroidGlue/GutenbergProps.kt
@@ -18,6 +18,7 @@ data class GutenbergProps @JvmOverloads constructor(
     val enableUnsupportedBlockEditor: Boolean,
     val canEnableUnsupportedBlockEditor: Boolean,
     val isAudioBlockMediaUploadEnabled: Boolean,
+    val shouldUseFastImage: Boolean,
     val enableReusableBlock: Boolean,
     val localeSlug: String,
     val postType: String,
@@ -65,6 +66,7 @@ data class GutenbergProps @JvmOverloads constructor(
         putBoolean(PROP_CAPABILITIES_UNSUPPORTED_BLOCK_EDITOR, enableUnsupportedBlockEditor)
         putBoolean(PROP_CAPABILITIES_CAN_ENABLE_UNSUPPORTED_BLOCK_EDITOR, canEnableUnsupportedBlockEditor)
         putBoolean(PROP_CAPABILITIES_IS_AUDIO_BLOCK_MEDIA_UPLOAD_ENABLED, isAudioBlockMediaUploadEnabled)
+        putBoolean(PROP_CAPABILITIES_SHOULD_USE_FASTIMAGE, shouldUseFastImage)
         putBoolean(PROP_CAPABILITIES_REUSABLE_BLOCK, enableReusableBlock)
         putBoolean(PROP_CAPABILITIES_FACEBOOK_EMBED_BLOCK, enableFacebookEmbed)
         putBoolean(PROP_CAPABILITIES_INSTAGRAM_EMBED_BLOCK, enableInstagramEmbed)
@@ -109,6 +111,7 @@ data class GutenbergProps @JvmOverloads constructor(
         const val PROP_CAPABILITIES_UNSUPPORTED_BLOCK_EDITOR = "unsupportedBlockEditor"
         const val PROP_CAPABILITIES_CAN_ENABLE_UNSUPPORTED_BLOCK_EDITOR = "canEnableUnsupportedBlockEditor"
         const val PROP_CAPABILITIES_IS_AUDIO_BLOCK_MEDIA_UPLOAD_ENABLED = "isAudioBlockMediaUploadEnabled"
+        const val PROP_CAPABILITIES_SHOULD_USE_FASTIMAGE = "shouldUseFastImage"
         const val PROP_CAPABILITIES_REUSABLE_BLOCK = "reusableBlock"
 
         /**

--- a/packages/react-native-bridge/ios/GutenbergBridgeDelegate.swift
+++ b/packages/react-native-bridge/ios/GutenbergBridgeDelegate.swift
@@ -32,6 +32,7 @@ public enum Capabilities: String {
     case instagramEmbed
     case loomEmbed
     case smartframeEmbed
+    case shouldUseFastImage
 }
 
 /// Wrapper for single block data


### PR DESCRIPTION
**Related PRs:**

- `Gutenberg Mobile` -> https://github.com/wordpress-mobile/gutenberg-mobile/pull/5028
- `WordPress iOS` -> https://github.com/wordpress-mobile/WordPress-iOS/pull/19057
- `WordPress Android` -> https://github.com/wordpress-mobile/WordPress-Android/pull/16913

## What?
After [adding](https://github.com/WordPress/gutenberg/pull/42009) React Native FastImage while testing another PR some issues were found where some images wouldn't load.

## Why?
It turns out we have a custom implementation of [RCTImageURLLoader](https://github.com/wordpress-mobile/WordPress-iOS/blob/trunk/WordPress/Classes/ViewRelated/Gutenberg/GutenbergImageLoader.swift) which handles image downloads when using React Native's `Image` component taking into account different scenarios like private sites, so now that we were only using React Native FastImage, for private sites, images won't load.

## How?
FastImage supports passing headers for authenticated URLs but since we handle different types of sites this approach currently would be difficult to use.

After some internal discussion, we decided to use `FastImage` for public sites and `Image` for private ones for now.

So now the main apps will pass a new capability `shouldUseFastImage` that will be set to `true` for public sites and `false` for private ones.

## Testing Instructions

Test the following cases with the following environments for both iOS and Android:

- [ ] Simple site (public)
- [ ] Simple site (private)
- [ ] Atomic site (public)
- [ ] Atomic site (private) (optional: there's another issue that's already [reported](https://github.com/wordpress-mobile/WordPress-iOS/issues/19055) where media, in general, is not working for Atomic private sites)
- [ ] Self-hosted site (public)
- [ ] Self-hosted site (private) (optional: there's no setting to set a site as private, I tried using the `WP Maintenance Mode` plugin)

### Test case 1 - Image block upload

- Open the app
- Create a new post
- Add an Image block
- Upload an image from the device
- Once the image finish uploading **expect** to see the image visible in the block

### Test case 2 - Gallery block upload

- Open the app
- Create a new post
- Add a Gallery block
- Upload some images from the device
- Once the images finish uploading **expect** to see the images visible in the block

## Screenshots or screencast <!-- if applicable -->

N/A