### PR TITLE
[Browser Issues] Block editor inserter: Fix blocks and patterns selector panel width flicker

### DIFF
--- a/packages/block-editor/src/components/inserter/style.scss
+++ b/packages/block-editor/src/components/inserter/style.scss
@@ -1,5 +1,6 @@
 $block-inserter-preview-height: 350px;
 $block-inserter-width: 350px;
+$block-inserter-scrollbar-width: 17px;
 $block-inserter-tabs-height: 44px;
 
 .block-editor-inserter {
@@ -13,11 +14,15 @@ $block-inserter-tabs-height: 44px;
 
 	@include break-medium {
 		position: relative;
+		scrollbar-width: $block-inserter-scrollbar-width;
 	}
 }
 
 .block-editor-inserter__content {
 	position: relative;
+	@include break-medium {
+		width: calc(#{ $block-inserter-width } - #{$block-inserter-scrollbar-width});
+	}
 }
 
 .block-editor-inserter__popover.is-quick {


### PR DESCRIPTION
## What?
<!-- In a few words, what is the PR actually doing? -->
This PR fixe blocks and patterns selector panel width flicker bug.

## Why?
#41794
Switching Blocks and Patterns tabs back and forth selector panel, panel inner elements (search bar, patterns list ) width flicker. The width flickering issue is due to the scrollbar. 

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
This is done by adding `max-width` ($block-inserter-width - $block-inserter-scrollbar-width ) in `.block-editor-inserter__content`.
- Different browsers have different scroll bar widths, added a `$block-inserter-scrollbar-width: 17px;`  SCSS variable. `17px`  is the width is most common in different browsers.

## Testing Instructions
1. Open a Post or Page.
2. Click on the `Toggle block inserter` button. 
![image](https://user-images.githubusercontent.com/32260742/179281701-f4cd43a3-7da3-461a-85ce-300ad979eb65.png)
3. Star switching Blocks and Patterns tabs back and forth selector panel.

## Screenshots or screencast 
![switching Blocks and Patterns tabs back and forth selector panel](https://user-images.githubusercontent.com/32260742/179282113-2c93fadd-fd57-4068-b106-8dd68bbb30ad.gif)

