### PR TITLE
Elements: fix heading and caption element selectors

### DIFF
--- a/packages/blocks/src/api/constants.js
+++ b/packages/blocks/src/api/constants.js
@@ -214,6 +214,7 @@ export const __EXPERIMENTAL_STYLE_PROPERTY = {
 
 export const __EXPERIMENTAL_ELEMENTS = {
 	link: 'a',
+	heading: 'h1, h2, h3, h4, h5, h6',
 	h1: 'h1',
 	h2: 'h2',
 	h3: 'h3',
@@ -221,6 +222,8 @@ export const __EXPERIMENTAL_ELEMENTS = {
 	h5: 'h5',
 	h6: 'h6',
 	button: '.wp-element-button, .wp-block-button__link',
+	caption:
+		'.wp-element-caption, .wp-block-audio figcaption, .wp-block-embed figcaption, .wp-block-gallery figcaption, .wp-block-image figcaption, .wp-block-table figcaption, .wp-block-video figcaption',
 };
 
 export const __EXPERIMENTAL_PATHS_WITH_MERGE = {


### PR DESCRIPTION
- Fix #42177
- Related to: #41246

## What?
This PR adds support for button / heading elements to the Site Editor.

## Why?
The following PRs have added global style support for the heading and caption elements:

- #41140
- #41981

But it doesn't work in the Site Editor.

## How?
There is also a list of supported elements in the Site Editor, so we need to add them to this list.

## Testing Instructions
- Activate the Empty theme with the following `theme.json` defined.

<details>
<summary>theme.json</summary>

```json
{
	"version": 2,
	"settings": {
		"layout": {
			"contentSize": "650px"
		}
	},
	"styles": {
		"elements": {
			"button": {
				"color": {
					"background": "blue"
				}
			},
			"heading": {
				"color": {
					"background": "blue"
				}
			},
			"caption": {
				"color": {
					"background": "blue"
				}
			}
		}
	}
}
```
</details>

- Insert `core/heading` block and blocks with the `caption` element into the site editor template.

<details>
<summary>Sample HTML</summary>

```html
<!-- wp:heading {"level":1} -->
<h1>h1</h1>
<!-- /wp:heading -->

<!-- wp:heading -->
<h2>h2</h2>
<!-- /wp:heading -->

<!-- wp:heading {"level":3} -->
<h3>h3</h3>
<!-- /wp:heading -->

<!-- wp:heading {"level":4} -->
<h4>h4</h4>
<!-- /wp:heading -->

<!-- wp:heading {"level":4} -->
<h4>h5</h4>
<!-- /wp:heading -->

<!-- wp:heading {"level":6} -->
<h6>h6</h6>
<!-- /wp:heading -->

<!-- wp:buttons -->
<div class="wp-block-buttons"><!-- wp:button -->
<div class="wp-block-button"><a class="wp-block-button__link wp-element-button">Button</a></div>
<!-- /wp:button --></div>
<!-- /wp:buttons -->

<!-- wp:spacer {"height":"38px"} -->
<div style="height:38px" aria-hidden="true" class="wp-block-spacer"></div>
<!-- /wp:spacer -->

<!-- wp:image {"width":311,"height":207,"sizeSlug":"large"} -->
<figure class="wp-block-image size-large is-resized"><img src="https://live.staticflickr.com/4572/38004374914_6b686d708e_b.jpg" alt="" width="311" height="207"/><figcaption class="wp-element-caption">Caption</figcaption></figure>
<!-- /wp:image -->
```
</details>

- Confirm that the blue background color defined in theme.json is applied to each element.

## Screenshots or screencast <!-- if applicable -->

![site-editor](https://user-images.githubusercontent.com/54422211/179347351-d37d40ae-3181-42d8-9683-57bd7be466e9.png)
