### PR TITLE
Style engine: check item value validity

### DIFF
--- a/packages/style-engine/class-wp-style-engine.php
+++ b/packages/style-engine/class-wp-style-engine.php
@@ -370,7 +370,7 @@ class WP_Style_Engine {
 					$value = static::get_css_var_value( $value, $style_definition['css_vars'] );
 				}
 				$individual_property = sprintf( $style_property_keys['individual'], _wp_to_kebab_case( $key ) );
-				if ( static::is_valid_style_value( $style_value ) ) {
+				if ( $individual_property && static::is_valid_style_value( $value ) ) {
 					$css_declarations[ $individual_property ] = $value;
 				}
 			}
@@ -511,9 +511,9 @@ class WP_Style_Engine {
  * @param array<string> $options      An array of options to determine the output.
  *
  * @return array<string>|null array(
- *     'styles'        => (string) A CSS ruleset or declarations block formatted to be placed in an HTML `style` attribute or tag.
- *     'declarations'  => (array) An array of property/value pairs representing parsed CSS declarations.
- *     'classnames'    => (string) Classnames separated by a space.
+ *     'css'          => (string) A CSS ruleset or declarations block formatted to be placed in an HTML `style` attribute or tag.
+ *     'declarations' => (array) An array of property/value pairs representing parsed CSS declarations.
+ *     'classnames'   => (string) Classnames separated by a space.
  * );
  */
 function wp_style_engine_get_block_supports_styles( $block_styles, $options = array() ) {


### PR DESCRIPTION
## What?
Doing what I should have done in https://github.com/WordPress/gutenberg/pull/42306 and check the individual property value instead of the array.

Update return comment to reflect accurate property name.

## Why?
Currently, if a style value is an array, the style engine calls `is_valid_style_value` on the array itself rather than the items in that array.


## Testing Instructions
Tests are 🍏 