### PR TITLE
Doc: Update getEntityRecord/s param description

### DIFF
--- a/docs/reference-guides/data/data-core.md
+++ b/docs/reference-guides/data/data-core.md
@@ -240,7 +240,7 @@ _Parameters_
 -   _kind_ `K`: Entity kind.
 -   _name_ `N`: Entity name.
 -   _key_ `KeyOf< R >`: Record's key
--   _query_ Optional query.
+-   _query_ Optional query. If requesting specific fields, fields must always include the ID.
 
 _Returns_
 
@@ -289,7 +289,7 @@ _Parameters_
 -   _state_ `State`: State tree
 -   _kind_ `K`: Entity kind.
 -   _name_ `N`: Entity name.
--   _query_ Optional terms query.
+-   _query_ Optional terms query. If requesting specific fields, fields must always include the ID.
 
 _Returns_
 

--- a/packages/core-data/README.md
+++ b/packages/core-data/README.md
@@ -487,7 +487,7 @@ _Parameters_
 -   _kind_ `K`: Entity kind.
 -   _name_ `N`: Entity name.
 -   _key_ `KeyOf< R >`: Record's key
--   _query_ Optional query.
+-   _query_ Optional query. If requesting specific fields, fields must always include the ID.
 
 _Returns_
 
@@ -536,7 +536,7 @@ _Parameters_
 -   _state_ `State`: State tree
 -   _kind_ `K`: Entity kind.
 -   _name_ `N`: Entity name.
--   _query_ Optional terms query.
+-   _query_ Optional terms query. If requesting specific fields, fields must always include the ID.
 
 _Returns_
 

--- a/packages/core-data/src/resolvers.js
+++ b/packages/core-data/src/resolvers.js
@@ -50,7 +50,8 @@ export const getCurrentUser =
  * @param {string}           name  Entity name.
  * @param {number|string}    key   Record's key
  * @param {Object|undefined} query Optional object of query parameters to
- *                                 include with request.
+ *                                 include with request. If requesting specific
+ *                                 fields, fields must always include the ID.
  */
 export const getEntityRecord =
 	( kind, name, key = '', query ) =>
@@ -131,7 +132,8 @@ export const getEditedEntityRecord = forwardResolver( 'getEntityRecord' );
  *
  * @param {string}  kind  Entity kind.
  * @param {string}  name  Entity name.
- * @param {Object?} query Query Object.
+ * @param {Object?} query Query Object. If requesting specific fields, fields
+ *                        must always include the ID.
  */
 export const getEntityRecords =
 	( kind, name, query = {} ) =>

--- a/packages/core-data/src/selectors.ts
+++ b/packages/core-data/src/selectors.ts
@@ -296,7 +296,8 @@ interface GetEntityRecord {
  * @param  kind  Entity kind.
  * @param  name  Entity name.
  * @param  key   Record's key
- * @param  query Optional query.
+ * @param  query Optional query. If requesting specific
+ *               fields, fields must always include the ID.
  *
  * @return Record.
  */
@@ -526,7 +527,8 @@ interface GetEntityRecords {
  * @param  state State tree
  * @param  kind  Entity kind.
  * @param  name  Entity name.
- * @param  query Optional terms query.
+ * @param  query Optional terms query. If requesting specific
+ *               fields, fields must always include the ID.
  *
  * @return Records.
  */


### PR DESCRIPTION
Fixes #31692

## What?
This PR enhances the parameter descriptions for the `getEntityRecord/s` documentation.

## Why?

We must always include the ID when using a fields query for `getEntityRecord/s`.
But as [this comment](https://github.com/WordPress/gutenberg/issues/31692#issuecomment-842438805) states, it is not explicitly stated in the documentation and can only be read from [the comments in the source code](https://github.com/WordPress/gutenberg/blob/d2418afff41428b9f92be7ce168b32a23a8c1137/packages/core-data/src/resolvers.js#L72-L74).

## Testing Instructions
There are no testable code changes.