### PR TITLE
Fluid typography: add configurable settings for minimum font size to theme.json

### DIFF
--- a/docs/reference-guides/theme-json-reference/theme-json-living.md
+++ b/docs/reference-guides/theme-json-reference/theme-json-living.md
@@ -119,7 +119,7 @@ Settings related to typography.
 | customFontSize | boolean | true |  |
 | fontStyle | boolean | true |  |
 | fontWeight | boolean | true |  |
-| fluid | object |  |  |
+| fluid | undefined | false |  |
 | letterSpacing | boolean | true |  |
 | lineHeight | boolean | false |  |
 | textDecoration | boolean | true |  |

--- a/docs/reference-guides/theme-json-reference/theme-json-living.md
+++ b/docs/reference-guides/theme-json-reference/theme-json-living.md
@@ -119,7 +119,7 @@ Settings related to typography.
 | customFontSize | boolean | true |  |
 | fontStyle | boolean | true |  |
 | fontWeight | boolean | true |  |
-| fluid | boolean |  |  |
+| fluid | object |  |  |
 | letterSpacing | boolean | true |  |
 | lineHeight | boolean | false |  |
 | textDecoration | boolean | true |  |

--- a/lib/block-supports/typography.php
+++ b/lib/block-supports/typography.php
@@ -477,6 +477,8 @@ function gutenberg_get_typography_font_size_value( $preset, $should_use_fluid_ty
 		return $preset['size'];
 	}
 
+	$fluid_settings = is_array( $typography_settings['fluid'] ) ? $typography_settings['fluid'] : array();
+
 	// Defaults.
 	$default_maximum_viewport_width   = isset( $fluid_settings['maxViewPortWidth'] ) ? $fluid_settings['maxViewPortWidth'] : '1600px';
 	$default_minimum_viewport_width   = isset( $fluid_settings['minViewPortWidth'] ) ? $fluid_settings['minViewPortWidth'] : '768px';

--- a/lib/block-supports/typography.php
+++ b/lib/block-supports/typography.php
@@ -360,26 +360,6 @@ function gutenberg_get_typography_value_and_unit( $raw_value, $options = array()
  * @return string|null A font-size value using clamp().
  */
 function gutenberg_get_computed_fluid_font_size_value( $args = array() ) {
-	/**
-	 * Filters the fluid font size arguments array before the internal calculations take place.
-	 *
-	 * Return a non-null value to bypass the WordPress internal calculations.
-	 *
-	 * @param string|null $fluid_typography_value Return a font-size value using the passed arguments to short-circuit the default calculations,
-	 *                                            or null to allow WordPress to calculate the font size value.
-	 * @param array $args array(
-	 *     'maximum_viewport_width' => (string) Maximum size up to which type will have fluidity.
-	 *     'minimum_viewport_width' => (string) Minimum viewport size from which type will have fluidity.
-	 *     'maximum_font_size'      => (string) Maximum font size.
-	 *     'minimum_font_size'      => (string) Minimum font size.
-	 *     'scale_factor'           => (number) A scale factor to determine how fast a font scales within boundaries.
-	 * );.
-	 */
-	$fluid_typography_value = apply_filters( 'pre_get_computed_fluid_font_size_value', null, $args );
-	if ( ! is_null( $fluid_typography_value ) ) {
-		return $fluid_typography_value;
-	}
-
 	$maximum_viewport_width_raw = isset( $args['maximum_viewport_width'] ) ? $args['maximum_viewport_width'] : null;
 	$minimum_viewport_width_raw = isset( $args['minimum_viewport_width'] ) ? $args['minimum_viewport_width'] : null;
 	$maximum_font_size_raw      = isset( $args['maximum_font_size'] ) ? $args['maximum_font_size'] : null;

--- a/lib/block-supports/typography.php
+++ b/lib/block-supports/typography.php
@@ -451,17 +451,17 @@ function gutenberg_get_typography_font_size_value( $preset, $should_use_fluid_ty
 
 	// Checks if fluid font sizes are activated.
 	$typography_settings         = gutenberg_get_global_settings( array( 'typography' ) );
-	$should_use_fluid_typography = isset( $typography_settings['fluid'] ) && true === $typography_settings['fluid'] ? true : $should_use_fluid_typography;
+	$should_use_fluid_typography = isset( $typography_settings['fluid'] ) && ! empty( $typography_settings['fluid'] ) ? true : $should_use_fluid_typography;
 
 	if ( ! $should_use_fluid_typography ) {
 		return $preset['size'];
 	}
 
 	// Defaults.
-	$default_maximum_viewport_width   = '1600px';
-	$default_minimum_viewport_width   = '768px';
-	$default_minimum_font_size_factor = 0.75;
-	$default_scale_factor             = 1;
+	$default_maximum_viewport_width   = isset( $fluid_settings['maxViewPortWidth'] ) ? $fluid_settings['maxViewPortWidth'] : '1600px';
+	$default_minimum_viewport_width   = isset( $fluid_settings['minViewPortWidth'] ) ? $fluid_settings['minViewPortWidth'] : '768px';
+	$default_minimum_font_size_factor = isset( $fluid_settings['minFontSizeFactor'] ) && is_numeric( $fluid_settings['minFontSizeFactor'] ) ? $fluid_settings['minFontSizeFactor'] : 0.75;
+	$default_scale_factor             = isset( $fluid_settings['scaleFactor'] ) && is_numeric( $fluid_settings['scaleFactor'] ) ? $fluid_settings['scaleFactor'] : 1;
 	$default_minimum_font_size_limit  = '14px';
 
 	// Font sizes.

--- a/lib/block-supports/typography.php
+++ b/lib/block-supports/typography.php
@@ -451,20 +451,24 @@ function gutenberg_get_typography_font_size_value( $preset, $should_use_fluid_ty
 
 	// Checks if fluid font sizes are activated.
 	$typography_settings         = gutenberg_get_global_settings( array( 'typography' ) );
-	$should_use_fluid_typography = isset( $typography_settings['fluid'] ) && ! empty( $typography_settings['fluid'] ) ? true : $should_use_fluid_typography;
+	$should_use_fluid_typography
+		= isset( $typography_settings['fluid'] ) &&
+		( true === $typography_settings['fluid'] || is_array( $typography_settings['fluid'] ) ) ?
+		true :
+		$should_use_fluid_typography;
 
 	if ( ! $should_use_fluid_typography ) {
 		return $preset['size'];
 	}
 
-	$fluid_settings = is_array( $typography_settings['fluid'] ) ? $typography_settings['fluid'] : array();
+	$fluid_settings = isset( $typography_settings['fluid'] ) && is_array( $typography_settings['fluid'] ) ? $typography_settings['fluid'] : array();
 
 	// Defaults.
 	$default_maximum_viewport_width   = isset( $fluid_settings['maxViewPortWidth'] ) ? $fluid_settings['maxViewPortWidth'] : '1600px';
 	$default_minimum_viewport_width   = isset( $fluid_settings['minViewPortWidth'] ) ? $fluid_settings['minViewPortWidth'] : '768px';
 	$default_minimum_font_size_factor = isset( $fluid_settings['minFontSizeFactor'] ) && is_numeric( $fluid_settings['minFontSizeFactor'] ) ? $fluid_settings['minFontSizeFactor'] : 0.75;
 	$default_scale_factor             = isset( $fluid_settings['scaleFactor'] ) && is_numeric( $fluid_settings['scaleFactor'] ) ? $fluid_settings['scaleFactor'] : 1;
-	$global_minimum_font_size         = isset( $fluid_settings['minFontSize'] ) && is_numeric( $fluid_settings['minFontSize'] ) ? $fluid_settings['minFontSize'] : '14px';
+	$global_minimum_font_size         = isset( $fluid_settings['minFontSize'] ) ? $fluid_settings['minFontSize'] : '14px';
 
 	// Font sizes.
 	$fluid_font_size_settings = isset( $preset['fluid'] ) ? $preset['fluid'] : null;
@@ -517,7 +521,6 @@ function gutenberg_get_typography_font_size_value( $preset, $should_use_fluid_ty
 	 */
 	if ( ! $minimum_font_size_raw ) {
 		$calculated_minimum_font_size = round( $preferred_size['value'] * $default_minimum_font_size_factor, 3 );
-
 		// Only use calculated min font size if it's > $minimum_font_size_limit value.
 		if ( ! empty( $minimum_font_size_limit ) && $calculated_minimum_font_size <= $minimum_font_size_limit['value'] ) {
 			$minimum_font_size_raw = $minimum_font_size_limit['value'] . $minimum_font_size_limit['unit'];

--- a/lib/block-supports/typography.php
+++ b/lib/block-supports/typography.php
@@ -464,7 +464,7 @@ function gutenberg_get_typography_font_size_value( $preset, $should_use_fluid_ty
 	$default_minimum_viewport_width   = isset( $fluid_settings['minViewPortWidth'] ) ? $fluid_settings['minViewPortWidth'] : '768px';
 	$default_minimum_font_size_factor = isset( $fluid_settings['minFontSizeFactor'] ) && is_numeric( $fluid_settings['minFontSizeFactor'] ) ? $fluid_settings['minFontSizeFactor'] : 0.75;
 	$default_scale_factor             = isset( $fluid_settings['scaleFactor'] ) && is_numeric( $fluid_settings['scaleFactor'] ) ? $fluid_settings['scaleFactor'] : 1;
-	$default_minimum_font_size_limit  = '14px';
+	$global_minimum_font_size         = isset( $fluid_settings['minFontSize'] ) && is_numeric( $fluid_settings['minFontSize'] ) ? $fluid_settings['minFontSize'] : '14px';
 
 	// Font sizes.
 	$fluid_font_size_settings = isset( $preset['fluid'] ) ? $preset['fluid'] : null;
@@ -488,7 +488,7 @@ function gutenberg_get_typography_font_size_value( $preset, $should_use_fluid_ty
 
 	// Parses the minimum font size limit, so we can perform checks using it.
 	$minimum_font_size_limit = gutenberg_get_typography_value_and_unit(
-		$default_minimum_font_size_limit,
+		$global_minimum_font_size,
 		array(
 			'coerce_to' => $preferred_size['unit'],
 		)

--- a/lib/block-supports/typography.php
+++ b/lib/block-supports/typography.php
@@ -359,7 +359,27 @@ function gutenberg_get_typography_value_and_unit( $raw_value, $options = array()
  * }
  * @return string|null A font-size value using clamp().
  */
-function gutenberg_get_computed_fluid_typography_value( $args = array() ) {
+function gutenberg_get_computed_fluid_font_size_value( $args = array() ) {
+	/**
+	 * Filters the fluid font size arguments array before the internal calculations take place.
+	 *
+	 * Return a non-null value to bypass the WordPress internal calculations.
+	 *
+	 * @param string|null $fluid_typography_value Return a font-size value using the passed arguments to short-circuit the default calculations,
+	 *                                            or null to allow WordPress to calculate the font size value.
+	 * @param array $args array(
+	 *     'maximum_viewport_width' => (string) Maximum size up to which type will have fluidity.
+	 *     'minimum_viewport_width' => (string) Minimum viewport size from which type will have fluidity.
+	 *     'maximum_font_size'      => (string) Maximum font size.
+	 *     'minimum_font_size'      => (string) Minimum font size.
+	 *     'scale_factor'           => (number) A scale factor to determine how fast a font scales within boundaries.
+	 * );.
+	 */
+	$fluid_typography_value = apply_filters( 'pre_get_computed_fluid_font_size_value', null, $args );
+	if ( ! is_null( $fluid_typography_value ) ) {
+		return $fluid_typography_value;
+	}
+
 	$maximum_viewport_width_raw = isset( $args['maximum_viewport_width'] ) ? $args['maximum_viewport_width'] : null;
 	$minimum_viewport_width_raw = isset( $args['minimum_viewport_width'] ) ? $args['minimum_viewport_width'] : null;
 	$maximum_font_size_raw      = isset( $args['maximum_font_size'] ) ? $args['maximum_font_size'] : null;
@@ -524,7 +544,7 @@ function gutenberg_get_typography_font_size_value( $preset, $should_use_fluid_ty
 		}
 	}
 
-	$fluid_font_size_value = gutenberg_get_computed_fluid_typography_value(
+	$fluid_font_size_value = gutenberg_get_computed_fluid_font_size_value(
 		array(
 			'minimum_viewport_width' => $default_minimum_viewport_width,
 			'maximum_viewport_width' => $default_maximum_viewport_width,

--- a/lib/block-supports/typography.php
+++ b/lib/block-supports/typography.php
@@ -359,7 +359,7 @@ function gutenberg_get_typography_value_and_unit( $raw_value, $options = array()
  * }
  * @return string|null A font-size value using clamp().
  */
-function gutenberg_get_computed_fluid_font_size_value( $args = array() ) {
+function gutenberg_get_computed_fluid_typography_value( $args = array() ) {
 	$maximum_viewport_width_raw = isset( $args['maximum_viewport_width'] ) ? $args['maximum_viewport_width'] : null;
 	$minimum_viewport_width_raw = isset( $args['minimum_viewport_width'] ) ? $args['minimum_viewport_width'] : null;
 	$maximum_font_size_raw      = isset( $args['maximum_font_size'] ) ? $args['maximum_font_size'] : null;
@@ -464,13 +464,11 @@ function gutenberg_get_typography_font_size_value( $preset, $should_use_fluid_ty
 	$fluid_settings = isset( $typography_settings['fluid'] ) && is_array( $typography_settings['fluid'] ) ? $typography_settings['fluid'] : array();
 
 	// Defaults.
-	$default_maximum_viewport_width   = isset( $fluid_settings['maxViewPortWidth'] ) &&
-										! empty( gutenberg_get_typography_value_and_unit( $fluid_settings['maxViewPortWidth'] ) ) ? $fluid_settings['maxViewPortWidth'] : '1600px';
-	$default_minimum_viewport_width   = isset( $fluid_settings['minViewPortWidth'] ) &&
-										! empty( gutenberg_get_typography_value_and_unit( $fluid_settings['minViewPortWidth'] ) ) ? $fluid_settings['minViewPortWidth'] : '768px';
-	$default_minimum_font_size_factor = isset( $fluid_settings['minFontSizeFactor'] ) && is_numeric( $fluid_settings['minFontSizeFactor'] ) ? $fluid_settings['minFontSizeFactor'] : 0.75;
-	$default_scale_factor             = isset( $fluid_settings['scaleFactor'] ) && is_numeric( $fluid_settings['scaleFactor'] ) ? $fluid_settings['scaleFactor'] : 1;
-	$global_minimum_font_size         = isset( $fluid_settings['minFontSize'] ) &&
+	$default_maximum_viewport_width   = '1600px';
+	$default_minimum_viewport_width   = '768px';
+	$default_minimum_font_size_factor = 0.75;
+	$default_scale_factor             = 1;
+	$default_minimum_font_size_limit  = isset( $fluid_settings['minFontSize'] ) &&
 										! empty( gutenberg_get_typography_value_and_unit( $fluid_settings['minFontSize'] ) ) ? $fluid_settings['minFontSize'] : '14px';
 
 	// Font sizes.
@@ -495,7 +493,7 @@ function gutenberg_get_typography_font_size_value( $preset, $should_use_fluid_ty
 
 	// Parses the minimum font size limit, so we can perform checks using it.
 	$minimum_font_size_limit = gutenberg_get_typography_value_and_unit(
-		$global_minimum_font_size,
+		$default_minimum_font_size_limit,
 		array(
 			'coerce_to' => $preferred_size['unit'],
 		)
@@ -524,6 +522,7 @@ function gutenberg_get_typography_font_size_value( $preset, $should_use_fluid_ty
 	 */
 	if ( ! $minimum_font_size_raw ) {
 		$calculated_minimum_font_size = round( $preferred_size['value'] * $default_minimum_font_size_factor, 3 );
+
 		// Only use calculated min font size if it's > $minimum_font_size_limit value.
 		if ( ! empty( $minimum_font_size_limit ) && $calculated_minimum_font_size <= $minimum_font_size_limit['value'] ) {
 			$minimum_font_size_raw = $minimum_font_size_limit['value'] . $minimum_font_size_limit['unit'];
@@ -532,7 +531,7 @@ function gutenberg_get_typography_font_size_value( $preset, $should_use_fluid_ty
 		}
 	}
 
-	$fluid_font_size_value = gutenberg_get_computed_fluid_font_size_value(
+	$fluid_font_size_value = gutenberg_get_computed_fluid_typography_value(
 		array(
 			'minimum_viewport_width' => $default_minimum_viewport_width,
 			'maximum_viewport_width' => $default_maximum_viewport_width,

--- a/lib/block-supports/typography.php
+++ b/lib/block-supports/typography.php
@@ -468,8 +468,8 @@ function gutenberg_get_typography_font_size_value( $preset, $should_use_fluid_ty
 	$default_minimum_viewport_width   = '768px';
 	$default_minimum_font_size_factor = 0.75;
 	$default_scale_factor             = 1;
-	$default_minimum_font_size_limit  = isset( $fluid_settings['minFontSize'] ) &&
-										! empty( gutenberg_get_typography_value_and_unit( $fluid_settings['minFontSize'] ) ) ? $fluid_settings['minFontSize'] : '14px';
+	$has_min_font_size                = isset( $fluid_settings['minFontSize'] ) && ! empty( gutenberg_get_typography_value_and_unit( $fluid_settings['minFontSize'] ) );
+	$default_minimum_font_size_limit  = $has_min_font_size ? $fluid_settings['minFontSize'] : '14px';
 
 	// Font sizes.
 	$fluid_font_size_settings = isset( $preset['fluid'] ) ? $preset['fluid'] : null;

--- a/lib/block-supports/typography.php
+++ b/lib/block-supports/typography.php
@@ -464,11 +464,14 @@ function gutenberg_get_typography_font_size_value( $preset, $should_use_fluid_ty
 	$fluid_settings = isset( $typography_settings['fluid'] ) && is_array( $typography_settings['fluid'] ) ? $typography_settings['fluid'] : array();
 
 	// Defaults.
-	$default_maximum_viewport_width   = isset( $fluid_settings['maxViewPortWidth'] ) ? $fluid_settings['maxViewPortWidth'] : '1600px';
-	$default_minimum_viewport_width   = isset( $fluid_settings['minViewPortWidth'] ) ? $fluid_settings['minViewPortWidth'] : '768px';
+	$default_maximum_viewport_width   = isset( $fluid_settings['maxViewPortWidth'] ) &&
+										! empty( gutenberg_get_typography_value_and_unit( $fluid_settings['maxViewPortWidth'] ) ) ? $fluid_settings['maxViewPortWidth'] : '1600px';
+	$default_minimum_viewport_width   = isset( $fluid_settings['minViewPortWidth'] ) &&
+										! empty( gutenberg_get_typography_value_and_unit( $fluid_settings['minViewPortWidth'] ) ) ? $fluid_settings['minViewPortWidth'] : '768px';
 	$default_minimum_font_size_factor = isset( $fluid_settings['minFontSizeFactor'] ) && is_numeric( $fluid_settings['minFontSizeFactor'] ) ? $fluid_settings['minFontSizeFactor'] : 0.75;
 	$default_scale_factor             = isset( $fluid_settings['scaleFactor'] ) && is_numeric( $fluid_settings['scaleFactor'] ) ? $fluid_settings['scaleFactor'] : 1;
-	$global_minimum_font_size         = isset( $fluid_settings['minFontSize'] ) ? $fluid_settings['minFontSize'] : '14px';
+	$global_minimum_font_size         = isset( $fluid_settings['minFontSize'] ) &&
+										! empty( gutenberg_get_typography_value_and_unit( $fluid_settings['minFontSize'] ) ) ? $fluid_settings['minFontSize'] : '14px';
 
 	// Font sizes.
 	$fluid_font_size_settings = isset( $preset['fluid'] ) ? $preset['fluid'] : null;

--- a/packages/block-editor/CHANGELOG.md
+++ b/packages/block-editor/CHANGELOG.md
@@ -9,6 +9,7 @@
 ### Enhancements
 
 -   `URLInput`: the `renderSuggestions` callback prop now receives `currentInputValue` as a new parameter ([45806](https://github.com/WordPress/gutenberg/pull/45806)).
+-   Fluid typography: add configurable fluid typography settings to theme.json ([#42489](https://github.com/WordPress/gutenberg/pull/42489)).
 
 ### Bug Fix
 

--- a/packages/block-editor/CHANGELOG.md
+++ b/packages/block-editor/CHANGELOG.md
@@ -9,7 +9,7 @@
 ### Enhancements
 
 -   `URLInput`: the `renderSuggestions` callback prop now receives `currentInputValue` as a new parameter ([45806](https://github.com/WordPress/gutenberg/pull/45806)).
--   Fluid typography: add configurable fluid typography settings to theme.json ([#42489](https://github.com/WordPress/gutenberg/pull/42489)).
+-   Fluid typography: add configurable fluid typography settings for minimum font size to theme.json ([#42489](https://github.com/WordPress/gutenberg/pull/42489)).
 
 ### Bug Fix
 

--- a/packages/block-editor/README.md
+++ b/packages/block-editor/README.md
@@ -428,6 +428,7 @@ _Parameters_
 -   _args.minimumFontSize_ `?string`: Minimum font size for any clamp() calculation. Optional.
 -   _args.scaleFactor_ `?number`: A scale factor to determine how fast a font scales within boundaries. Optional.
 -   _args.minimumFontSizeFactor_ `?number`: How much to scale defaultFontSize by to derive minimumFontSize. Optional.
+-   _args.minimumFontSizeLimit_ `?string`: The smallest a calculated font size may be. Optional.
 
 _Returns_
 

--- a/packages/block-editor/README.md
+++ b/packages/block-editor/README.md
@@ -521,7 +521,7 @@ attributes.
 _Parameters_
 
 -   _attributes_ `Object`: Block attributes.
--   _isFluidFontSizeActive_ `boolean`: Whether the function should try to convert font sizes to fluid values.
+-   _fluidTypographySettings_ `Object|boolean`: If boolean, whether the function should try to convert font sizes to fluid values, otherwise an object containing theme fluid typography settings.
 
 _Returns_
 

--- a/packages/block-editor/src/components/font-sizes/fluid-utils.js
+++ b/packages/block-editor/src/components/font-sizes/fluid-utils.js
@@ -40,6 +40,7 @@ const DEFAULT_MINIMUM_FONT_SIZE_LIMIT = '14px';
  * @param {?string}       args.minimumFontSize       Minimum font size for any clamp() calculation. Optional.
  * @param {?number}       args.scaleFactor           A scale factor to determine how fast a font scales within boundaries. Optional.
  * @param {?number}       args.minimumFontSizeFactor How much to scale defaultFontSize by to derive minimumFontSize. Optional.
+ * @param {?string}       args.minimumFontSizeLimit  The smallest a calculated font size may be. Optional.
  *
  * @return {string|null} A font-size value using clamp().
  */

--- a/packages/block-editor/src/components/font-sizes/fluid-utils.js
+++ b/packages/block-editor/src/components/font-sizes/fluid-utils.js
@@ -48,12 +48,23 @@ export function getComputedFluidTypographyValue( {
 	minimumFontSize,
 	maximumFontSize,
 	fontSize,
-	minimumViewPortWidth = DEFAULT_MINIMUM_VIEWPORT_WIDTH,
-	maximumViewPortWidth = DEFAULT_MAXIMUM_VIEWPORT_WIDTH,
+	minimumViewPortWidth,
+	maximumViewPortWidth,
 	scaleFactor = DEFAULT_SCALE_FACTOR,
 	minimumFontSizeFactor = DEFAULT_MINIMUM_FONT_SIZE_FACTOR,
-	minimumFontSizeLimit = DEFAULT_MINIMUM_FONT_SIZE_LIMIT,
+	minimumFontSizeLimit,
 } ) {
+	// Defaults.
+	minimumViewPortWidth = !! getTypographyValueAndUnit( minimumViewPortWidth )
+		? minimumViewPortWidth
+		: DEFAULT_MINIMUM_VIEWPORT_WIDTH;
+	maximumViewPortWidth = !! getTypographyValueAndUnit( maximumViewPortWidth )
+		? maximumViewPortWidth
+		: DEFAULT_MAXIMUM_VIEWPORT_WIDTH;
+	minimumFontSizeLimit = !! getTypographyValueAndUnit( minimumFontSizeLimit )
+		? minimumFontSizeLimit
+		: DEFAULT_MINIMUM_FONT_SIZE_LIMIT;
+
 	/*
 	 * Calculates missing minimumFontSize and maximumFontSize from
 	 * defaultFontSize if provided.

--- a/packages/block-editor/src/components/font-sizes/fluid-utils.js
+++ b/packages/block-editor/src/components/font-sizes/fluid-utils.js
@@ -48,19 +48,13 @@ export function getComputedFluidTypographyValue( {
 	minimumFontSize,
 	maximumFontSize,
 	fontSize,
-	minimumViewPortWidth,
-	maximumViewPortWidth,
+	minimumViewPortWidth = DEFAULT_MINIMUM_VIEWPORT_WIDTH,
+	maximumViewPortWidth = DEFAULT_MAXIMUM_VIEWPORT_WIDTH,
 	scaleFactor = DEFAULT_SCALE_FACTOR,
 	minimumFontSizeFactor = DEFAULT_MINIMUM_FONT_SIZE_FACTOR,
 	minimumFontSizeLimit,
 } ) {
-	// Defaults.
-	minimumViewPortWidth = !! getTypographyValueAndUnit( minimumViewPortWidth )
-		? minimumViewPortWidth
-		: DEFAULT_MINIMUM_VIEWPORT_WIDTH;
-	maximumViewPortWidth = !! getTypographyValueAndUnit( maximumViewPortWidth )
-		? maximumViewPortWidth
-		: DEFAULT_MAXIMUM_VIEWPORT_WIDTH;
+	// Validate incoming settings and set defaults.
 	minimumFontSizeLimit = !! getTypographyValueAndUnit( minimumFontSizeLimit )
 		? minimumFontSizeLimit
 		: DEFAULT_MINIMUM_FONT_SIZE_LIMIT;

--- a/packages/block-editor/src/hooks/font-size.js
+++ b/packages/block-editor/src/hooks/font-size.js
@@ -324,13 +324,29 @@ function addEditPropsForFluidCustomFontSizes( blockType ) {
 		// BlockListContext.Provider. If we set fontSize using editor.
 		// BlockListBlock instead of using getEditWrapperProps then the value is
 		// clobbered when the core/style/addEditProps filter runs.
-		const isFluidTypographyEnabled =
-			!! select( blockEditorStore ).getSettings().__experimentalFeatures
+		const fluidTypographyConfig =
+			select( blockEditorStore ).getSettings().__experimentalFeatures
 				?.typography?.fluid;
 
+		const fluidTypographySettings =
+			typeof fluidTypographyConfig?.fluid === 'object'
+				? fluidTypographyConfig?.fluid
+				: {};
+
 		const newFontSize =
-			fontSize && isFluidTypographyEnabled
-				? getComputedFluidTypographyValue( { fontSize } )
+			fontSize && !! fluidTypographyConfig
+				? getComputedFluidTypographyValue( {
+						fontSize,
+						minimumViewPortWidth:
+							fluidTypographySettings?.minViewPortWidth,
+						maximumViewPortWidth:
+							fluidTypographySettings?.maxViewPortWidth,
+						scaleFactor: fluidTypographySettings?.scaleFactor,
+						minimumFontSizeFactor:
+							fluidTypographySettings?.minViewPortWidth,
+						maximumFontSizeFactor:
+							fluidTypographySettings?.maxFontSizeFactor,
+				  } )
 				: null;
 
 		if ( newFontSize === null ) {

--- a/packages/block-editor/src/hooks/font-size.js
+++ b/packages/block-editor/src/hooks/font-size.js
@@ -329,8 +329,8 @@ function addEditPropsForFluidCustomFontSizes( blockType ) {
 				?.typography?.fluid;
 
 		const fluidTypographySettings =
-			typeof fluidTypographyConfig?.fluid === 'object'
-				? fluidTypographyConfig?.fluid
+			typeof fluidTypographyConfig === 'object'
+				? fluidTypographyConfig
 				: {};
 
 		const newFontSize =
@@ -343,9 +343,9 @@ function addEditPropsForFluidCustomFontSizes( blockType ) {
 							fluidTypographySettings?.maxViewPortWidth,
 						scaleFactor: fluidTypographySettings?.scaleFactor,
 						minimumFontSizeFactor:
-							fluidTypographySettings?.minViewPortWidth,
-						maximumFontSizeFactor:
-							fluidTypographySettings?.maxFontSizeFactor,
+							fluidTypographySettings?.minFontSizeFactor,
+						minimumFontSizeLimit:
+							fluidTypographySettings?.minFontSize,
 				  } )
 				: null;
 

--- a/packages/block-editor/src/hooks/font-size.js
+++ b/packages/block-editor/src/hooks/font-size.js
@@ -337,13 +337,6 @@ function addEditPropsForFluidCustomFontSizes( blockType ) {
 			fontSize && !! fluidTypographyConfig
 				? getComputedFluidTypographyValue( {
 						fontSize,
-						minimumViewPortWidth:
-							fluidTypographySettings?.minViewPortWidth,
-						maximumViewPortWidth:
-							fluidTypographySettings?.maxViewPortWidth,
-						scaleFactor: fluidTypographySettings?.scaleFactor,
-						minimumFontSizeFactor:
-							fluidTypographySettings?.minFontSizeFactor,
 						minimumFontSizeLimit:
 							fluidTypographySettings?.minFontSize,
 				  } )

--- a/packages/block-editor/src/hooks/test/use-typography-props.js
+++ b/packages/block-editor/src/hooks/test/use-typography-props.js
@@ -47,4 +47,34 @@ describe( 'getTypographyClassesAndStyles', () => {
 			},
 		} );
 	} );
+
+	it( 'should return configured fluid font size styles', () => {
+		const attributes = {
+			fontFamily: 'tofu',
+			style: {
+				typography: {
+					textDecoration: 'underline',
+					fontSize: '2rem',
+					textTransform: 'uppercase',
+				},
+			},
+		};
+		expect(
+			getTypographyClassesAndStyles( attributes, {
+				minViewPortWidth: '900px',
+				maxViewPortWidth: '1900px',
+				scaleFactor: 2,
+				minFontSizeFactor: 0.9,
+				minFontSize: '1rem',
+			} )
+		).toEqual( {
+			className: 'has-tofu-font-family',
+			style: {
+				textDecoration: 'underline',
+				fontSize:
+					'clamp(1.8rem, 1.8rem + ((1vw - 0.563rem) * 0.64), 2rem)',
+				textTransform: 'uppercase',
+			},
+		} );
+	} );
 } );

--- a/packages/block-editor/src/hooks/test/use-typography-props.js
+++ b/packages/block-editor/src/hooks/test/use-typography-props.js
@@ -61,10 +61,6 @@ describe( 'getTypographyClassesAndStyles', () => {
 		};
 		expect(
 			getTypographyClassesAndStyles( attributes, {
-				minViewPortWidth: '900px',
-				maxViewPortWidth: '1900px',
-				scaleFactor: 2,
-				minFontSizeFactor: 0.9,
 				minFontSize: '1rem',
 			} )
 		).toEqual( {
@@ -72,7 +68,7 @@ describe( 'getTypographyClassesAndStyles', () => {
 			style: {
 				textDecoration: 'underline',
 				fontSize:
-					'clamp(1.8rem, 1.8rem + ((1vw - 0.563rem) * 0.64), 2rem)',
+					'clamp(1.5rem, 1.5rem + ((1vw - 0.48rem) * 0.962), 2rem)',
 				textTransform: 'uppercase',
 			},
 		} );

--- a/packages/block-editor/src/hooks/use-typography-props.js
+++ b/packages/block-editor/src/hooks/use-typography-props.js
@@ -19,19 +19,23 @@ import { getComputedFluidTypographyValue } from '../components/font-sizes/fluid-
  * Provides the CSS class names and inline styles for a block's typography support
  * attributes.
  *
- * @param {Object}          attributes              Block attributes.
- * @param {Object|boolean}  fluidTypographySettings If boolean, whether the function should try to convert font sizes to fluid values,
- *                                                  otherwise an object containing theme fluid typography settings.
+ * @param {Object}         attributes              Block attributes.
+ * @param {Object|boolean} fluidTypographySettings If boolean, whether the function should try to convert font sizes to fluid values,
+ *                                                 otherwise an object containing theme fluid typography settings.
  *
  * @return {Object} Typography block support derived CSS classes & styles.
  */
 export function getTypographyClassesAndStyles(
 	attributes,
-	fluidTypographySettings = {}
+	fluidTypographySettings
 ) {
 	let typographyStyles = attributes?.style?.typography || {};
 
-	if ( !! fluidTypographySettings ) {
+	if (
+		!! fluidTypographySettings &&
+		( true === fluidTypographySettings ||
+			Object.keys( fluidTypographySettings ).length !== 0 )
+	) {
 		typographyStyles = {
 			...typographyStyles,
 			fontSize: getComputedFluidTypographyValue( {

--- a/packages/block-editor/src/hooks/use-typography-props.js
+++ b/packages/block-editor/src/hooks/use-typography-props.js
@@ -19,22 +19,29 @@ import { getComputedFluidTypographyValue } from '../components/font-sizes/fluid-
  * Provides the CSS class names and inline styles for a block's typography support
  * attributes.
  *
- * @param {Object}  attributes            Block attributes.
- * @param {boolean} isFluidFontSizeActive Whether the function should try to convert font sizes to fluid values.
+ * @param {Object}          attributes              Block attributes.
+ * @param {Object|boolean}  fluidTypographySettings If boolean, whether the function should try to convert font sizes to fluid values,
+ *                                                  otherwise an object containing theme fluid typography settings.
  *
  * @return {Object} Typography block support derived CSS classes & styles.
  */
 export function getTypographyClassesAndStyles(
 	attributes,
-	isFluidFontSizeActive
+	fluidTypographySettings = {}
 ) {
 	let typographyStyles = attributes?.style?.typography || {};
 
-	if ( isFluidFontSizeActive ) {
+	if ( !! fluidTypographySettings ) {
 		typographyStyles = {
 			...typographyStyles,
 			fontSize: getComputedFluidTypographyValue( {
 				fontSize: attributes?.style?.typography?.fontSize,
+				minimumViewPortWidth: fluidTypographySettings?.minViewPortWidth,
+				maximumViewPortWidth: fluidTypographySettings?.maxViewPortWidth,
+				scaleFactor: fluidTypographySettings?.scaleFactor,
+				minimumFontSizeFactor:
+					fluidTypographySettings?.minFontSizeFactor,
+				minimumFontSizeLimit: fluidTypographySettings?.minFontSize,
 			} ),
 		};
 	}

--- a/packages/block-editor/src/hooks/use-typography-props.js
+++ b/packages/block-editor/src/hooks/use-typography-props.js
@@ -36,17 +36,14 @@ export function getTypographyClassesAndStyles(
 		( true === fluidTypographySettings ||
 			Object.keys( fluidTypographySettings ).length !== 0 )
 	) {
+		const newFontSize =
+			getComputedFluidTypographyValue( {
+				fontSize: attributes?.style?.typography?.fontSize,
+				minimumFontSizeLimit: fluidTypographySettings?.minFontSize,
+			} ) || attributes?.style?.typography?.fontSize;
 		typographyStyles = {
 			...typographyStyles,
-			fontSize: getComputedFluidTypographyValue( {
-				fontSize: attributes?.style?.typography?.fontSize,
-				minimumViewPortWidth: fluidTypographySettings?.minViewPortWidth,
-				maximumViewPortWidth: fluidTypographySettings?.maxViewPortWidth,
-				scaleFactor: fluidTypographySettings?.scaleFactor,
-				minimumFontSizeFactor:
-					fluidTypographySettings?.minFontSizeFactor,
-				minimumFontSizeLimit: fluidTypographySettings?.minFontSize,
-			} ),
+			fontSize: newFontSize,
 		};
 	}
 

--- a/packages/block-library/src/search/edit.js
+++ b/packages/block-library/src/search/edit.js
@@ -114,10 +114,10 @@ export default function SearchEdit( {
 	}
 
 	const colorProps = useColorProps( attributes );
-	const fluidTypographyEnabled = useSetting( 'typography.fluid' );
+	const fluidTypographySettings = useSetting( 'typography.fluid' );
 	const typographyProps = useTypographyProps(
 		attributes,
-		fluidTypographyEnabled
+		fluidTypographySettings
 	);
 	const unitControlInstanceId = useInstanceId( UnitControl );
 	const unitControlInputId = `wp-block-search__width-${ unitControlInstanceId }`;

--- a/packages/edit-site/CHANGELOG.md
+++ b/packages/edit-site/CHANGELOG.md
@@ -4,7 +4,11 @@
 
 ### Breaking Changes
 
--   Updated dependencies to require React 18 ([45235](https://github.com/WordPress/gutenberg/pull/45235))
+-   Updated dependencies to require React 18 ([45235](https://github.com/WordPress/gutenberg/pull/45235)).
+
+### Enhancements
+
+-   Fluid typography: add configurable fluid typography settings to theme.json ([#42489](https://github.com/WordPress/gutenberg/pull/42489)).
 
 ## 4.19.0 (2022-11-16)
 

--- a/packages/edit-site/CHANGELOG.md
+++ b/packages/edit-site/CHANGELOG.md
@@ -8,7 +8,7 @@
 
 ### Enhancements
 
--   Fluid typography: add configurable fluid typography settings to theme.json ([#42489](https://github.com/WordPress/gutenberg/pull/42489)).
+-   Fluid typography: add configurable fluid typography settings for minimum font size to theme.json ([#42489](https://github.com/WordPress/gutenberg/pull/42489)).
 
 ## 4.19.0 (2022-11-16)
 

--- a/packages/edit-site/src/components/global-styles/test/typography-utils.js
+++ b/packages/edit-site/src/components/global-styles/test/typography-utils.js
@@ -7,7 +7,8 @@ describe( 'typography utils', () => {
 	describe( 'getTypographyFontSizeValue', () => {
 		[
 			{
-				message: 'returns value when fluid typography is deactivated',
+				message:
+					'should return value when fluid typography is not active',
 				preset: {
 					size: '28px',
 				},
@@ -16,7 +17,7 @@ describe( 'typography utils', () => {
 			},
 
 			{
-				message: 'returns value where font size is 0',
+				message: 'should return value where font size is 0',
 				preset: {
 					size: 0,
 				},
@@ -25,7 +26,7 @@ describe( 'typography utils', () => {
 			},
 
 			{
-				message: "returns value where font size is '0'",
+				message: "should return value where font size is '0'",
 				preset: {
 					size: '0',
 				},
@@ -34,7 +35,7 @@ describe( 'typography utils', () => {
 			},
 
 			{
-				message: 'returns value where `size` is `null`.',
+				message: 'should return value where `size` is `null`.',
 				preset: {
 					size: null,
 				},
@@ -43,7 +44,7 @@ describe( 'typography utils', () => {
 			},
 
 			{
-				message: 'returns value when fluid is `false`',
+				message: 'should return value when fluid is `false`',
 				preset: {
 					size: '28px',
 					fluid: false,
@@ -55,7 +56,7 @@ describe( 'typography utils', () => {
 			},
 
 			{
-				message: 'returns already clamped value',
+				message: 'should return already clamped value',
 				preset: {
 					size: 'clamp(21px, 1.313rem + ((1vw - 7.68px) * 2.524), 42px)',
 					fluid: false,
@@ -68,7 +69,7 @@ describe( 'typography utils', () => {
 			},
 
 			{
-				message: 'returns value with unsupported unit',
+				message: 'should return value with unsupported unit',
 				preset: {
 					size: '1000%',
 					fluid: false,
@@ -80,7 +81,7 @@ describe( 'typography utils', () => {
 			},
 
 			{
-				message: 'returns clamp value with rem min and max units',
+				message: 'should return clamp value with rem min and max units',
 				preset: {
 					size: '1.75rem',
 				},
@@ -92,7 +93,7 @@ describe( 'typography utils', () => {
 			},
 
 			{
-				message: 'returns clamp value with eem min and max units',
+				message: 'should return clamp value with eem min and max units',
 				preset: {
 					size: '1.75em',
 				},
@@ -104,7 +105,7 @@ describe( 'typography utils', () => {
 			},
 
 			{
-				message: 'returns clamp value for floats',
+				message: 'should return clamp value for floats',
 				preset: {
 					size: '100.175px',
 				},
@@ -116,7 +117,8 @@ describe( 'typography utils', () => {
 			},
 
 			{
-				message: 'coerces integer to `px` and returns clamp value',
+				message:
+					'should coerce integer to `px` and returns clamp value',
 				preset: {
 					size: 33,
 					fluid: true,
@@ -129,7 +131,7 @@ describe( 'typography utils', () => {
 			},
 
 			{
-				message: 'coerces float to `px` and returns clamp value',
+				message: 'should coerce float to `px` and returns clamp value',
 				preset: {
 					size: 100.23,
 					fluid: true,
@@ -142,7 +144,8 @@ describe( 'typography utils', () => {
 			},
 
 			{
-				message: 'returns clamp value when `fluid` is empty array',
+				message:
+					'should return clamp value when `fluid` is empty array',
 				preset: {
 					size: '28px',
 					fluid: [],
@@ -155,7 +158,7 @@ describe( 'typography utils', () => {
 			},
 
 			{
-				message: 'returns clamp value when `fluid` is `null`',
+				message: 'should return clamp value when `fluid` is `null`',
 				preset: {
 					size: '28px',
 					fluid: null,
@@ -169,7 +172,7 @@ describe( 'typography utils', () => {
 
 			{
 				message:
-					'returns clamp value if min font size is greater than max',
+					'should return clamp value if min font size is greater than max',
 				preset: {
 					size: '3rem',
 					fluid: {
@@ -185,7 +188,7 @@ describe( 'typography utils', () => {
 			},
 
 			{
-				message: 'returns value with invalid min/max fluid units',
+				message: 'should return value with invalid min/max fluid units',
 				preset: {
 					size: '10em',
 					fluid: {
@@ -201,7 +204,7 @@ describe( 'typography utils', () => {
 
 			{
 				message:
-					'returns value when size is < lower bounds and no fluid min/max set',
+					'should return value when size is < lower bounds and no fluid min/max set',
 				preset: {
 					size: '3px',
 				},
@@ -213,7 +216,7 @@ describe( 'typography utils', () => {
 
 			{
 				message:
-					'returns value when size is equal to lower bounds and no fluid min/max set',
+					'should return value when size is equal to lower bounds and no fluid min/max set',
 				preset: {
 					size: '14px',
 				},
@@ -224,7 +227,8 @@ describe( 'typography utils', () => {
 			},
 
 			{
-				message: 'returns clamp value with different min max units',
+				message:
+					'should return clamp value with different min max units',
 				preset: {
 					size: '28px',
 					fluid: {
@@ -240,7 +244,8 @@ describe( 'typography utils', () => {
 			},
 
 			{
-				message: 'returns clamp value where no fluid max size is set',
+				message:
+					'should return clamp value where no fluid max size is set',
 				preset: {
 					size: '28px',
 					fluid: {
@@ -255,7 +260,8 @@ describe( 'typography utils', () => {
 			},
 
 			{
-				message: 'returns clamp value where no fluid min size is set',
+				message:
+					'should return clamp value where no fluid min size is set',
 				preset: {
 					size: '28px',
 					fluid: {
@@ -320,7 +326,7 @@ describe( 'typography utils', () => {
 
 			{
 				message:
-					'returns clamp value when min and max font sizes are equal',
+					'should return clamp value when min and max font sizes are equal',
 				preset: {
 					size: '4rem',
 					fluid: {
@@ -333,8 +339,44 @@ describe( 'typography utils', () => {
 				},
 				expected: 'clamp(30px, 1.875rem + ((1vw - 7.68px) * 1), 30px)',
 			},
+
+			// Equivalent custom config PHP unit tests in `test_should_covert_font_sizes_to_fluid_values()`.
+			{
+				message: 'should return clamp value using custom fluid config',
+				preset: {
+					size: '50px',
+				},
+				typographySettings: {
+					fluid: {
+						minViewPortWidth: '1000px',
+						maxViewPortWidth: '2000px',
+						scaleFactor: 2,
+						minFontSizeFactor: 0.8,
+						minFontSize: '16px',
+					},
+				},
+				expected: 'clamp(40px, 2.5rem + ((1vw - 10px) * 2), 50px)',
+			},
+
+			{
+				message:
+					'should return value when font size <= custom min font size bound',
+				preset: {
+					size: '15px',
+				},
+				typographySettings: {
+					fluid: {
+						minViewPortWidth: '1000px',
+						maxViewPortWidth: '2000px',
+						scaleFactor: 2,
+						minFontSizeFactor: 0.8,
+						minFontSize: '16px',
+					},
+				},
+				expected: '15px',
+			},
 		].forEach( ( { message, preset, typographySettings, expected } ) => {
-			it( `should ${ message }`, () => {
+			it( `${ message }`, () => {
 				expect(
 					getTypographyFontSizeValue( preset, typographySettings )
 				).toBe( expected );

--- a/packages/edit-site/src/components/global-styles/test/typography-utils.js
+++ b/packages/edit-site/src/components/global-styles/test/typography-utils.js
@@ -344,18 +344,14 @@ describe( 'typography utils', () => {
 			{
 				message: 'should return clamp value using custom fluid config',
 				preset: {
-					size: '50px',
+					size: '17px',
 				},
 				typographySettings: {
 					fluid: {
-						minViewPortWidth: '1000px',
-						maxViewPortWidth: '2000px',
-						scaleFactor: 2,
-						minFontSizeFactor: 0.8,
 						minFontSize: '16px',
 					},
 				},
-				expected: 'clamp(40px, 2.5rem + ((1vw - 10px) * 2), 50px)',
+				expected: 'clamp(16px, 1rem + ((1vw - 7.68px) * 0.12), 17px)',
 			},
 
 			{
@@ -366,10 +362,6 @@ describe( 'typography utils', () => {
 				},
 				typographySettings: {
 					fluid: {
-						minViewPortWidth: '1000px',
-						maxViewPortWidth: '2000px',
-						scaleFactor: 2,
-						minFontSizeFactor: 0.8,
 						minFontSize: '16px',
 					},
 				},

--- a/packages/edit-site/src/components/global-styles/test/typography-utils.js
+++ b/packages/edit-site/src/components/global-styles/test/typography-utils.js
@@ -340,6 +340,21 @@ describe( 'typography utils', () => {
 				expected: 'clamp(30px, 1.875rem + ((1vw - 7.68px) * 1), 30px)',
 			},
 
+			{
+				message:
+					'should use default min font size value where min font size unit in fluid config is not supported',
+				preset: {
+					size: '15px',
+				},
+				typographySettings: {
+					fluid: {
+						minFontSize: '16%',
+					},
+				},
+				expected:
+					'clamp(14px, 0.875rem + ((1vw - 7.68px) * 0.12), 15px)',
+			},
+
 			// Equivalent custom config PHP unit tests in `test_should_covert_font_sizes_to_fluid_values()`.
 			{
 				message: 'should return clamp value using custom fluid config',

--- a/packages/edit-site/src/components/global-styles/typography-utils.js
+++ b/packages/edit-site/src/components/global-styles/typography-utils.js
@@ -24,12 +24,22 @@ import { getComputedFluidTypographyValue } from '@wordpress/block-editor';
  */
 
 /**
+ * @typedef {Object} TypographySettings
+ * @property {?string|?number} size              A default font size.
+ * @property {?string}         minViewPortWidth  Minimum viewport size from which type will have fluidity. Optional if size is specified.
+ * @property {?string}         maxViewPortWidth  Maximum size up to which type will have fluidity. Optional if size is specified.
+ * @property {?number}         scaleFactor       A scale factor to determine how fast a font scales within boundaries. Optional.
+ * @property {?number}         minFontSizeFactor How much to scale defaultFontSize by to derive minimumFontSize. Optional.
+ * @property {?number}         maxFontSizeFactor How much to scale defaultFontSize by to derive maximumFontSize. Optional.
+ */
+
+/**
  * Returns a font-size value based on a given font-size preset.
  * Takes into account fluid typography parameters and attempts to return a css formula depending on available, valid values.
  *
- * @param {Preset}  preset
- * @param {Object}  typographySettings
- * @param {boolean} typographySettings.fluid Whether fluid typography is enabled.
+ * @param {Preset}                     preset
+ * @param {Object}                     typographySettings
+ * @param {boolean|TypographySettings} typographySettings.fluid Whether fluid typography is enabled, and, optionally, fluid font size options.
  *
  * @return {string|*} A font-size value or the value of preset.size.
  */
@@ -44,7 +54,11 @@ export function getTypographyFontSizeValue( preset, typographySettings ) {
 		return defaultSize;
 	}
 
-	if ( true !== typographySettings?.fluid ) {
+	if (
+		false === typographySettings?.fluid ||
+		( !! typographySettings?.fluid &&
+			Object.keys( typographySettings.fluid ).length === 0 )
+	) {
 		return defaultSize;
 	}
 
@@ -53,10 +67,20 @@ export function getTypographyFontSizeValue( preset, typographySettings ) {
 		return defaultSize;
 	}
 
+	const fluidTypographySettings =
+		typeof typographySettings?.fluid === 'object'
+			? typographySettings?.fluid
+			: {};
+
 	const fluidFontSizeValue = getComputedFluidTypographyValue( {
 		minimumFontSize: preset?.fluid?.min,
 		maximumFontSize: preset?.fluid?.max,
 		fontSize: defaultSize,
+		minimumViewPortWidth: fluidTypographySettings?.minViewPortWidth,
+		maximumViewPortWidth: fluidTypographySettings?.maxViewPortWidth,
+		scaleFactor: fluidTypographySettings?.scaleFactor,
+		minimumFontSizeFactor: fluidTypographySettings?.minViewPortWidth,
+		maximumFontSizeFactor: fluidTypographySettings?.maxFontSizeFactor,
 	} );
 
 	if ( !! fluidFontSizeValue ) {

--- a/packages/edit-site/src/components/global-styles/typography-utils.js
+++ b/packages/edit-site/src/components/global-styles/typography-utils.js
@@ -55,7 +55,7 @@ export function getTypographyFontSizeValue( preset, typographySettings ) {
 	}
 
 	if (
-		true !== typographySettings?.fluid ||
+		! typographySettings?.fluid ||
 		( typeof typographySettings?.fluid === 'object' &&
 			Object.keys( typographySettings.fluid ).length === 0 )
 	) {
@@ -79,7 +79,7 @@ export function getTypographyFontSizeValue( preset, typographySettings ) {
 		minimumViewPortWidth: fluidTypographySettings?.minViewPortWidth,
 		maximumViewPortWidth: fluidTypographySettings?.maxViewPortWidth,
 		scaleFactor: fluidTypographySettings?.scaleFactor,
-		minimumFontSizeFactor: fluidTypographySettings?.minViewPortWidth,
+		minimumFontSizeFactor: fluidTypographySettings?.minFontSizeFactor,
 		minimumFontSizeLimit: fluidTypographySettings?.minFontSize,
 	} );
 

--- a/packages/edit-site/src/components/global-styles/typography-utils.js
+++ b/packages/edit-site/src/components/global-styles/typography-utils.js
@@ -30,7 +30,7 @@ import { getComputedFluidTypographyValue } from '@wordpress/block-editor';
  * @property {?string}         maxViewPortWidth  Maximum size up to which type will have fluidity. Optional if size is specified.
  * @property {?number}         scaleFactor       A scale factor to determine how fast a font scales within boundaries. Optional.
  * @property {?number}         minFontSizeFactor How much to scale defaultFontSize by to derive minimumFontSize. Optional.
- * @property {?number}         maxFontSizeFactor How much to scale defaultFontSize by to derive maximumFontSize. Optional.
+ * @property {?string}         minFontSize       The smallest a calculated font size may be. Optional.
  */
 
 /**
@@ -55,8 +55,8 @@ export function getTypographyFontSizeValue( preset, typographySettings ) {
 	}
 
 	if (
-		false === typographySettings?.fluid ||
-		( !! typographySettings?.fluid &&
+		true !== typographySettings?.fluid ||
+		( typeof typographySettings?.fluid === 'object' &&
 			Object.keys( typographySettings.fluid ).length === 0 )
 	) {
 		return defaultSize;
@@ -80,7 +80,7 @@ export function getTypographyFontSizeValue( preset, typographySettings ) {
 		maximumViewPortWidth: fluidTypographySettings?.maxViewPortWidth,
 		scaleFactor: fluidTypographySettings?.scaleFactor,
 		minimumFontSizeFactor: fluidTypographySettings?.minViewPortWidth,
-		maximumFontSizeFactor: fluidTypographySettings?.maxFontSizeFactor,
+		minimumFontSizeLimit: fluidTypographySettings?.minFontSize,
 	} );
 
 	if ( !! fluidFontSizeValue ) {

--- a/packages/edit-site/src/components/global-styles/typography-utils.js
+++ b/packages/edit-site/src/components/global-styles/typography-utils.js
@@ -76,10 +76,6 @@ export function getTypographyFontSizeValue( preset, typographySettings ) {
 		minimumFontSize: preset?.fluid?.min,
 		maximumFontSize: preset?.fluid?.max,
 		fontSize: defaultSize,
-		minimumViewPortWidth: fluidTypographySettings?.minViewPortWidth,
-		maximumViewPortWidth: fluidTypographySettings?.maxViewPortWidth,
-		scaleFactor: fluidTypographySettings?.scaleFactor,
-		minimumFontSizeFactor: fluidTypographySettings?.minFontSizeFactor,
 		minimumFontSizeLimit: fluidTypographySettings?.minFontSize,
 	} );
 

--- a/phpunit/block-supports/typography-test.php
+++ b/phpunit/block-supports/typography-test.php
@@ -825,4 +825,40 @@ class WP_Block_Supports_Typography_Test extends WP_UnitTestCase {
 			'size: array' => array( array( '10' ) ),
 		);
 	}
+
+	/**
+	 * Tests bypassing WordPress font size calculations using the `pre_get_computed_fluid_typography_value` filter.
+	 */
+	public function test_gutenberg_get_computed_fluid_typography_value_filter() {
+		add_filter( 'pre_get_computed_fluid_font_size_value', array( $this, 'filter_fluid_font_size' ), 10, 2 );
+		$filtered_fluid_font_size_value = gutenberg_get_computed_fluid_font_size_value(
+			array(
+				'minimum_viewport_width' => '100px',
+				'maximum_viewport_width' => '200px',
+				'minimum_font_size'      => '1em',
+				'maximum_font_size'      => '2em',
+				'scale_factor'           => '.9',
+			)
+		);
+		remove_filter( 'pre_get_computed_fluid_font_size_value', array( $this, 'filter_fluid_font_size' ) );
+		$this->assertSame( 'clamp(1em, 0.818rem + .9vw, 2em)', $filtered_fluid_font_size_value );
+	}
+
+	/**
+	 * Filters the fluid font size arguments array before the internal calculations take place.
+	 *
+	 * @param string|null $fluid_typography_value Return a font-size value using the passed arguments to short-circuit the default calculations,
+	 *                                            or null to allow WordPress to calculate the font size value.
+	 * @param array       $args array(
+	 *           'maximum_viewport_width' => (string) Maximum size up to which type will have fluidity.
+	 *           'minimum_viewport_width' => (string) Minimum viewport size from which type will have fluidity.
+	 *           'maximum_font_size'      => (string) Maximum font size.
+	 *           'minimum_font_size'      => (string) Minimum font size.
+	 *           'scale_factor'           => (number) A scale factor to determine how fast a font scales within boundaries.
+	 *       );.
+	 * @return string A font-size value
+	 */
+	public function filter_fluid_font_size( $fluid_typography_value, $args ) {
+		return "clamp({$args['minimum_font_size']}, 0.818rem + {$args['scale_factor']}vw, {$args['maximum_font_size']})";
+	}
 }

--- a/phpunit/block-supports/typography-test.php
+++ b/phpunit/block-supports/typography-test.php
@@ -825,40 +825,4 @@ class WP_Block_Supports_Typography_Test extends WP_UnitTestCase {
 			'size: array' => array( array( '10' ) ),
 		);
 	}
-
-	/**
-	 * Tests bypassing WordPress font size calculations using the `pre_get_computed_fluid_typography_value` filter.
-	 */
-	public function test_gutenberg_get_computed_fluid_typography_value_filter() {
-		add_filter( 'pre_get_computed_fluid_font_size_value', array( $this, 'filter_fluid_font_size' ), 10, 2 );
-		$filtered_fluid_font_size_value = gutenberg_get_computed_fluid_font_size_value(
-			array(
-				'minimum_viewport_width' => '100px',
-				'maximum_viewport_width' => '200px',
-				'minimum_font_size'      => '1em',
-				'maximum_font_size'      => '2em',
-				'scale_factor'           => '.9',
-			)
-		);
-		remove_filter( 'pre_get_computed_fluid_font_size_value', array( $this, 'filter_fluid_font_size' ) );
-		$this->assertSame( 'clamp(1em, 0.818rem + .9vw, 2em)', $filtered_fluid_font_size_value );
-	}
-
-	/**
-	 * Filters the fluid font size arguments array before the internal calculations take place.
-	 *
-	 * @param string|null $fluid_typography_value Return a font-size value using the passed arguments to short-circuit the default calculations,
-	 *                                            or null to allow WordPress to calculate the font size value.
-	 * @param array       $args array(
-	 *           'maximum_viewport_width' => (string) Maximum size up to which type will have fluidity.
-	 *           'minimum_viewport_width' => (string) Minimum viewport size from which type will have fluidity.
-	 *           'maximum_font_size'      => (string) Maximum font size.
-	 *           'minimum_font_size'      => (string) Minimum font size.
-	 *           'scale_factor'           => (number) A scale factor to determine how fast a font scales within boundaries.
-	 *       );.
-	 * @return string A font-size value
-	 */
-	public function filter_fluid_font_size( $fluid_typography_value, $args ) {
-		return "clamp({$args['minimum_font_size']}, 0.818rem + {$args['scale_factor']}vw, {$args['maximum_font_size']})";
-	}
 }

--- a/phpunit/block-supports/typography-test.php
+++ b/phpunit/block-supports/typography-test.php
@@ -614,15 +614,20 @@ class WP_Block_Supports_Typography_Test extends WP_UnitTestCase {
 	 */
 	public function data_generate_block_supports_font_size_fixtures() {
 		return array(
-			'default_return_value'               => array(
+			'returns value when fluid typography is not active'          => array(
 				'font_size_value'             => '50px',
 				'should_use_fluid_typography' => false,
 				'expected_output'             => 'font-size:50px;',
 			),
-			'return_value_with_fluid_typography' => array(
+			'returns clamp value using custom fluid config'              => array(
 				'font_size_value'             => '50px',
 				'should_use_fluid_typography' => true,
-				'expected_output'             => 'font-size:clamp(37.5px, 2.344rem + ((1vw - 7.68px) * 1.502), 50px);',
+				'expected_output'             => 'font-size:clamp(40px, 2.5rem + ((1vw - 10px) * 2), 50px);',
+			),
+			'returns value when font size <= custom min font size bound' => array(
+				'font_size_value'             => '15px',
+				'should_use_fluid_typography' => true,
+				'expected_output'             => 'font-size:15px;',
 			),
 		);
 	}
@@ -680,7 +685,7 @@ class WP_Block_Supports_Typography_Test extends WP_UnitTestCase {
 				'block_content'               => '<h2 class="has-vivid-red-background-color has-background has-link-color" style="margin-top:var(--wp--preset--spacing--60);font-size:4rem;font-style:normal;font-weight:600;letter-spacing:29px;text-decoration:underline;text-transform:capitalize">This is a heading</h2>',
 				'font_size_value'             => '4rem',
 				'should_use_fluid_typography' => true,
-				'expected_output'             => '<h2 class="has-vivid-red-background-color has-background has-link-color" style="margin-top:var(--wp--preset--spacing--60);font-size:clamp(3rem, 3rem + ((1vw - 0.48rem) * 1.923), 4rem);font-style:normal;font-weight:600;letter-spacing:29px;text-decoration:underline;text-transform:capitalize">This is a heading</h2>',
+				'expected_output'             => '<h2 class="has-vivid-red-background-color has-background has-link-color" style="margin-top:var(--wp--preset--spacing--60);font-size:clamp(3.2rem, 3.2rem + ((1vw - 0.625rem) * 2.56), 4rem);font-style:normal;font-weight:600;letter-spacing:29px;text-decoration:underline;text-transform:capitalize">This is a heading</h2>',
 			),
 			'return_content_if_no_inline_font_size_found'  => array(
 				'block_content'               => '<p class="has-medium-font-size" style="font-style:normal;font-weight:600;letter-spacing:29px;">A paragraph inside a group</p>',
@@ -698,13 +703,13 @@ class WP_Block_Supports_Typography_Test extends WP_UnitTestCase {
 				'block_content'               => '<p class="has-medium-font-size" style="    font-size:   20px   ;    ">A paragraph inside a group</p>',
 				'font_size_value'             => '20px',
 				'should_use_fluid_typography' => true,
-				'expected_output'             => '<p class="has-medium-font-size" style="    font-size:clamp(15px, 0.938rem + ((1vw - 7.68px) * 0.601), 20px);    ">A paragraph inside a group</p>',
+				'expected_output'             => '<p class="has-medium-font-size" style="    font-size:clamp(16px, 1rem + ((1vw - 10px) * 0.8), 20px);    ">A paragraph inside a group</p>',
 			),
 			'return_content_with_first_match_replace_only' => array(
 				'block_content'               => "<div class=\"wp-block-group\" style=\"font-size:1.5em\"> \n \n<p style=\"font-size:1.5em\">A paragraph inside a group</p></div>",
 				'font_size_value'             => '1.5em',
 				'should_use_fluid_typography' => true,
-				'expected_output'             => "<div class=\"wp-block-group\" style=\"font-size:clamp(1.125em, 1.125rem + ((1vw - 0.48em) * 0.721), 1.5em);\"> \n \n<p style=\"font-size:1.5em\">A paragraph inside a group</p></div>",
+				'expected_output'             => "<div class=\"wp-block-group\" style=\"font-size:clamp(1.2em, 1.2rem + ((1vw - 0.625em) * 0.96), 1.5em);\"> \n \n<p style=\"font-size:1.5em\">A paragraph inside a group</p></div>",
 			),
 		);
 	}

--- a/phpunit/data/themedir1/block-theme-child-with-fluid-typography-config/style.css
+++ b/phpunit/data/themedir1/block-theme-child-with-fluid-typography-config/style.css
@@ -1,0 +1,8 @@
+/*
+Theme Name: Block Theme Child Theme With Fluid Typography
+Theme URI: https://wordpress.org/
+Description: For testing purposes only.
+Template: block-theme
+Version: 1.0.0
+Text Domain: block-theme-child-with-fluid-typography
+*/

--- a/phpunit/data/themedir1/block-theme-child-with-fluid-typography-config/theme.json
+++ b/phpunit/data/themedir1/block-theme-child-with-fluid-typography-config/theme.json
@@ -3,7 +3,9 @@
 	"settings": {
 		"appearanceTools": true,
 		"typography": {
-			"fluid": true
+			"fluid": {
+				"minFontSize": "16px"
+			}
 		}
 	}
 }

--- a/phpunit/data/themedir1/block-theme-child-with-fluid-typography/theme.json
+++ b/phpunit/data/themedir1/block-theme-child-with-fluid-typography/theme.json
@@ -3,7 +3,14 @@
 	"settings": {
 		"appearanceTools": true,
 		"typography": {
-			"fluid": true
+			"fluid": {
+				"maxViewPortWidth": "2000px",
+				"minViewPortWidth": "1000px",
+				"minFontSizeFactor": 1.5,
+				"maxFontSizeFactor": 2,
+				"scaleFactor": 2,
+				"minFontSize": "16px"
+			}
 		}
 	}
 }

--- a/phpunit/data/themedir1/block-theme-child-with-fluid-typography/theme.json
+++ b/phpunit/data/themedir1/block-theme-child-with-fluid-typography/theme.json
@@ -6,8 +6,7 @@
 			"fluid": {
 				"maxViewPortWidth": "2000px",
 				"minViewPortWidth": "1000px",
-				"minFontSizeFactor": 1.5,
-				"maxFontSizeFactor": 2,
+				"minFontSizeFactor": 0.8,
 				"scaleFactor": 2,
 				"minFontSize": "16px"
 			}

--- a/schemas/json/theme.json
+++ b/schemas/json/theme.json
@@ -234,8 +234,12 @@
 						"blockGap": {
 							"description": "Enables `--wp--style--block-gap` to be generated from styles.spacing.blockGap.\nA value of `null` instead of `false` further disables layout styles from being generated.",
 							"oneOf": [
-								{ "type": "boolean" },
-								{ "type": "null" }
+								{
+									"type": "boolean"
+								},
+								{
+									"type": "null"
+								}
 							],
 							"default": null
 						},
@@ -354,29 +358,38 @@
 						},
 						"fluid": {
 							"description": "Enables fluid typography and allows users to set global fluid typography parameters.",
-							"type": "object",
-							"properties": {
-								"maxViewPortWidth": {
-									"description": "Allow users to set custom a max viewport width in px, rem or em, used to set the maximum size boundary of a fluid font.",
-									"type": "string"
+							"oneOf": [
+								{
+									"type": "object",
+									"properties": {
+										"maxViewPortWidth": {
+											"description": "Allow users to set custom a max viewport width in px, rem or em, used to set the maximum size boundary of a fluid font.",
+											"type": "string"
+										},
+										"minViewPortWidth": {
+											"description": "Allow users to set custom a min viewport width in px, rem or em, used to set the minimum size boundary of a fluid font",
+											"type": "string"
+										},
+										"minFontSizeFactor": {
+											"description": "Used to calculate a minimum font size from a single size value, where `fluidSize.min` is not set.",
+											"type": "number"
+										},
+										"maxFontSizeFactor": {
+											"description": "Used to calculate a maximum font size from a single size value, where `fluidSize.max` is not set.",
+											"type": "number"
+										},
+										"scaleFactor": {
+											"description": "Determines the rate of font size change between the minimum and maximum font sizes. The higher the value the faster the change.",
+											"type": "number"
+										}
+									},
+									"additionalProperties": false
 								},
-								"minViewPortWidth": {
-									"description": "Allow users to set custom a min viewport width in px, rem or em, used to set the minimum size boundary of a fluid font",
-									"type": "string"
-								},
-								"minFontSizeFactor": {
-									"description": "Used to calculate a minimum font size from a single size value, where `fluidSize.min` is not set.",
-									"type": "number"
-								},
-								"maxFontSizeFactor": {
-									"description": "Used to calculate a maximum font size from a single size value, where `fluidSize.max` is not set.",
-									"type": "number"
-								},
-								"scaleFactor": {
-									"description": "Determines the rate of font size change between the minimum and maximum font sizes. The higher the value the faster the change.",
-									"type": "number"
+								{
+									"type": "boolean"
 								}
-							}
+							],
+							"default": false
 						},
 						"letterSpacing": {
 							"description": "Allow users to set custom letter spacing.",
@@ -581,13 +594,27 @@
 		},
 		"settingsProperties": {
 			"allOf": [
-				{ "$ref": "#/definitions/settingsPropertiesAppearanceTools" },
-				{ "$ref": "#/definitions/settingsPropertiesBorder" },
-				{ "$ref": "#/definitions/settingsPropertiesColor" },
-				{ "$ref": "#/definitions/settingsPropertiesLayout" },
-				{ "$ref": "#/definitions/settingsPropertiesSpacing" },
-				{ "$ref": "#/definitions/settingsPropertiesTypography" },
-				{ "$ref": "#/definitions/settingsPropertiesCustom" }
+				{
+					"$ref": "#/definitions/settingsPropertiesAppearanceTools"
+				},
+				{
+					"$ref": "#/definitions/settingsPropertiesBorder"
+				},
+				{
+					"$ref": "#/definitions/settingsPropertiesColor"
+				},
+				{
+					"$ref": "#/definitions/settingsPropertiesLayout"
+				},
+				{
+					"$ref": "#/definitions/settingsPropertiesSpacing"
+				},
+				{
+					"$ref": "#/definitions/settingsPropertiesTypography"
+				},
+				{
+					"$ref": "#/definitions/settingsPropertiesCustom"
+				}
 			]
 		},
 		"settingsPropertiesComplete": {
@@ -649,13 +676,21 @@
 								}
 							}
 						},
-						{ "$ref": "#/definitions/settingsPropertiesColor" },
-						{ "$ref": "#/definitions/settingsPropertiesLayout" },
-						{ "$ref": "#/definitions/settingsPropertiesSpacing" },
+						{
+							"$ref": "#/definitions/settingsPropertiesColor"
+						},
+						{
+							"$ref": "#/definitions/settingsPropertiesLayout"
+						},
+						{
+							"$ref": "#/definitions/settingsPropertiesSpacing"
+						},
 						{
 							"$ref": "#/definitions/settingsPropertiesTypography"
 						},
-						{ "$ref": "#/definitions/settingsPropertiesCustom" }
+						{
+							"$ref": "#/definitions/settingsPropertiesCustom"
+						}
 					]
 				},
 				"core/buttons": {

--- a/schemas/json/theme.json
+++ b/schemas/json/theme.json
@@ -353,8 +353,30 @@
 							"default": true
 						},
 						"fluid": {
-							"description": "Opts into fluid typography.",
-							"type": "boolean"
+							"description": "Enables fluid typography and allows users to set global fluid typography parameters.",
+							"type": "object",
+							"properties": {
+								"maxViewPortWidth": {
+									"description": "Allow users to set custom a max viewport width in px, rem or em, used to set the maximum size boundary of a fluid font.",
+									"type": "string"
+								},
+								"minViewPortWidth": {
+									"description": "Allow users to set custom a min viewport width in px, rem or em, used to set the minimum size boundary of a fluid font",
+									"type": "string"
+								},
+								"minFontSizeFactor": {
+									"description": "Used to calculate a minimum font size from a single size value, where `fluidSize.min` is not set.",
+									"type": "number"
+								},
+								"maxFontSizeFactor": {
+									"description": "Used to calculate a maximum font size from a single size value, where `fluidSize.max` is not set.",
+									"type": "number"
+								},
+								"scaleFactor": {
+									"description": "Determines the rate of font size change between the minimum and maximum font sizes. The higher the value the faster the change.",
+									"type": "number"
+								}
+							}
 						},
 						"letterSpacing": {
 							"description": "Allow users to set custom letter spacing.",

--- a/schemas/json/theme.json
+++ b/schemas/json/theme.json
@@ -234,12 +234,8 @@
 						"blockGap": {
 							"description": "Enables `--wp--style--block-gap` to be generated from styles.spacing.blockGap.\nA value of `null` instead of `false` further disables layout styles from being generated.",
 							"oneOf": [
-								{
-									"type": "boolean"
-								},
-								{
-									"type": "null"
-								}
+								{ "type": "boolean" },
+								{ "type": "null" }
 							],
 							"default": null
 						},
@@ -362,22 +358,6 @@
 								{
 									"type": "object",
 									"properties": {
-										"maxViewPortWidth": {
-											"description": "Allow users to set custom a max viewport width in px, rem or em, used to set the maximum size boundary of a fluid font.",
-											"type": "string"
-										},
-										"minViewPortWidth": {
-											"description": "Allow users to set a custom min viewport width in px, rem or em, used to set the minimum size boundary of a fluid font",
-											"type": "string"
-										},
-										"minFontSizeFactor": {
-											"description": "Used to calculate a minimum font size from a single size value, where `fluidSize.min` is not set.",
-											"type": "number"
-										},
-										"scaleFactor": {
-											"description": "Determines the rate of font size change between the minimum and maximum font sizes. The higher the value the faster the change.",
-											"type": "number"
-										},
 										"minFontSize": {
 											"description": "Allow users to set a global minimum font size boundary in px, rem or em. Custom font sizes below this value will not be clamped, and all calculated minimum font sizes will be, a at minimum, this value.",
 											"type": "string"
@@ -594,27 +574,13 @@
 		},
 		"settingsProperties": {
 			"allOf": [
-				{
-					"$ref": "#/definitions/settingsPropertiesAppearanceTools"
-				},
-				{
-					"$ref": "#/definitions/settingsPropertiesBorder"
-				},
-				{
-					"$ref": "#/definitions/settingsPropertiesColor"
-				},
-				{
-					"$ref": "#/definitions/settingsPropertiesLayout"
-				},
-				{
-					"$ref": "#/definitions/settingsPropertiesSpacing"
-				},
-				{
-					"$ref": "#/definitions/settingsPropertiesTypography"
-				},
-				{
-					"$ref": "#/definitions/settingsPropertiesCustom"
-				}
+				{ "$ref": "#/definitions/settingsPropertiesAppearanceTools" },
+				{ "$ref": "#/definitions/settingsPropertiesBorder" },
+				{ "$ref": "#/definitions/settingsPropertiesColor" },
+				{ "$ref": "#/definitions/settingsPropertiesLayout" },
+				{ "$ref": "#/definitions/settingsPropertiesSpacing" },
+				{ "$ref": "#/definitions/settingsPropertiesTypography" },
+				{ "$ref": "#/definitions/settingsPropertiesCustom" }
 			]
 		},
 		"settingsPropertiesComplete": {
@@ -676,21 +642,13 @@
 								}
 							}
 						},
-						{
-							"$ref": "#/definitions/settingsPropertiesColor"
-						},
-						{
-							"$ref": "#/definitions/settingsPropertiesLayout"
-						},
-						{
-							"$ref": "#/definitions/settingsPropertiesSpacing"
-						},
+						{ "$ref": "#/definitions/settingsPropertiesColor" },
+						{ "$ref": "#/definitions/settingsPropertiesLayout" },
+						{ "$ref": "#/definitions/settingsPropertiesSpacing" },
 						{
 							"$ref": "#/definitions/settingsPropertiesTypography"
 						},
-						{
-							"$ref": "#/definitions/settingsPropertiesCustom"
-						}
+						{ "$ref": "#/definitions/settingsPropertiesCustom" }
 					]
 				},
 				"core/buttons": {

--- a/schemas/json/theme.json
+++ b/schemas/json/theme.json
@@ -367,20 +367,20 @@
 											"type": "string"
 										},
 										"minViewPortWidth": {
-											"description": "Allow users to set custom a min viewport width in px, rem or em, used to set the minimum size boundary of a fluid font",
+											"description": "Allow users to set a custom min viewport width in px, rem or em, used to set the minimum size boundary of a fluid font",
 											"type": "string"
 										},
 										"minFontSizeFactor": {
 											"description": "Used to calculate a minimum font size from a single size value, where `fluidSize.min` is not set.",
 											"type": "number"
 										},
-										"maxFontSizeFactor": {
-											"description": "Used to calculate a maximum font size from a single size value, where `fluidSize.max` is not set.",
-											"type": "number"
-										},
 										"scaleFactor": {
 											"description": "Determines the rate of font size change between the minimum and maximum font sizes. The higher the value the faster the change.",
 											"type": "number"
+										},
+										"minFontSize": {
+											"description": "Allow users to set a global minimum font size boundary in px, rem or em. Custom font sizes below this value will not be clamped, and all calculated minimum font sizes will be, a at minimum, this value.",
+											"type": "string"
 										}
 									},
 									"additionalProperties": false


### PR DESCRIPTION
## What?
Part of 
- https://github.com/WordPress/gutenberg/issues/44888

Follows on from https://github.com/WordPress/gutenberg/pull/39529 by adding configurable fluid font-size settings.

The first setting to be added is `settings.typography.fluid.minFontSize`, which sets the lower bound at which custom font sizes are converted to clamp values.

The current, hard-coded value is `14px`.

## Why?

The hard-coded value of `14px` may not be appropriate for some theme designs.

## How?
By checking global fluid typography for values.

## Testing Instructions

Play with `minFontSize` in the fluid config settings (px/rem/em units only) and ensure that custom font sizes are only clamp above the value you set. 

```json
{
	"version": 2,
	"settings": {
		"appearanceTools": true,
		"layout": {
			"contentSize": "840px",
			"wideSize": "1100px"
		},
		"typography": {
			"fluid": {
				"minFontSize": "16px"
			}
		}
	}
}

```

<details>
<summary>sample editor code</summary>

```html
<!-- wp:heading {"level":1,"style":{"typography":{"fontSize":"145px"}}} -->
<h1 class="wp-block-heading" style="font-size:145px">Heading 1</h1>
<!-- /wp:heading -->

<!-- wp:paragraph {"style":{"typography":{"fontSize":"15px"}}} -->
<p style="font-size:35px">Start with the basic building block of all narrative. Start with the basic building block of all narrative.Start with the basic building block of all narrative.Start with the basic building block of all narrative.Start with the basic building block of all narrative.Start with the basic building block of all narrative.Start with the basic building block of all narrative.Start with the basic building block of all narrative.Start with the basic building block of all narrative.Start with the basic building block of all narrative.Start with the basic building block of all narrative.Start with the basic building block of all narrative.Start with the basic building block of all narrative.Start with the basic building block of all narrative.Start with the basic building block of all narrative.Start with the basic building block of all narrative.Start with the basic building block of all narrative.</p>
<!-- /wp:paragraph -->

<!-- wp:search {"label":"Search","buttonText":"Search","style":{"typography":{"fontSize":"82px"}}} /-->
```
</details>

Run the tests!

```
npm run test:unit:php -- --filter WP_Block_Supports_Typography_Test
```

```
npm run test:unit packages/block-editor/src/components/font-sizes/test/fluid-utils.js
```

```
npm run test:unit packages/edit-site/src/components/global-styles/test/typography-utils.js
```

```
npm run test:unit packages/block-editor/src/hooks/test/use-typography-props.js
```

## See also

- https://github.com/WordPress/gutenberg/issues/34345
- https://github.com/WordPress/gutenberg/issues/24480
- https://github.com/WordPress/gutenberg/pull/39529