### PR TITLE
Style-Engine: Make the Style Engine Store hookable

### DIFF
--- a/packages/style-engine/class-wp-style-engine-css-rules-store.php
+++ b/packages/style-engine/class-wp-style-engine-css-rules-store.php
@@ -45,8 +45,27 @@ class WP_Style_Engine_CSS_Rules_Store {
 		if ( ! isset( static::$stores[ $store_name ] ) ) {
 			static::$stores[ $store_name ] = new static();
 		}
-		return static::$stores[ $store_name ];
+
+		$store = static::$stores[ $store_name ];
+
+		/**
+		 * Filters the CSS Rules Store.
+		 *
+		 * @param WP_Style_Engine_CSS_Rules_Store $store      The CSS Rules Store.
+		 * @param string                          $store_name The name of the store.
+		 */
+		return apply_filters( 'wp_style_engine_css_rules_store', $store, $store_name );
 	}
+
+	/**
+	 * Get an array of all available stores.
+	 *
+	 * @return WP_Style_Engine_CSS_Rules_Store[]
+	 */
+	public static function get_stores() {
+		return static::$stores;
+	}
+
 	/**
 	 * Get an array of all rules.
 	 *


### PR DESCRIPTION
## What?

Adds a new `get_stores()` method to get an array of all available stores, and a `wp_style_engine_css_rules_store` filter to allow filtering/mutating the store.

## Why?

The style-engine should be hookable and allow customizations. The style engine is not just something that Core will use, it's something that can benefit plugins & themes as well.
By adding a hook in the store, we can allow caching plugins to do what they need to do in order to improve performance. Depending on the size of the inlined styles, one can choose to compile them to a file for example instead of have them rendered inline. Themes will be able to override CSS directly in the style engine instead of adding extra stylesheets.
One of the core philosophies of WP is that the system should be extensible and hookable, so this PR ensures that the style-engine is not a closed box.