### PR TITLE
Improve the headings hierarchy in the site editor page

### DIFF
--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -10,6 +10,10 @@
 
 -   `Autocomplete`: Add heading and fix type for `onReplace` in README. ([#49798](https://github.com/WordPress/gutenberg/pull/49798)).
 
+### Internal
+
+-   `Navigation`: Make sure `NavigationMenu` and `NavigationGroup` don't render an empty `aria-labelledby` attribute ([#42495](https://github.com/WordPress/gutenberg/pull/42495)).
+
 ## 23.8.0 (2023-04-12)
 
 ### Internal

--- a/packages/components/src/navigation/group/index.tsx
+++ b/packages/components/src/navigation/group/index.tsx
@@ -59,7 +59,10 @@ export function NavigationGroup( {
 						{ title }
 					</GroupTitleUI>
 				) }
-				<ul aria-labelledby={ groupTitleId } role="group">
+				<ul
+					aria-labelledby={ title ? groupTitleId : undefined }
+					role="group"
+				>
 					{ children }
 				</ul>
 			</li>

--- a/packages/components/src/navigation/menu/index.tsx
+++ b/packages/components/src/navigation/menu/index.tsx
@@ -87,7 +87,7 @@ export function NavigationMenu( props: NavigationMenuProps ) {
 				) }
 
 				<NavigableMenu>
-					<ul aria-labelledby={ menuTitleId }>
+					<ul aria-labelledby={ title ? menuTitleId : undefined }>
 						{ children }
 						{ search && ! isSearchDebouncing && (
 							<NavigationSearchNoResultsFound search={ search } />

--- a/packages/edit-site/src/components/header-edit-mode/document-actions/index.js
+++ b/packages/edit-site/src/components/header-edit-mode/document-actions/index.js
@@ -129,7 +129,7 @@ export default function DocumentActions() {
 				<Text
 					size="body"
 					className="edit-site-document-actions__title"
-					as="h1"
+					as="h2"
 				>
 					<VisuallyHidden as="span">
 						{ sprintf(

--- a/packages/edit-site/src/components/header-edit-mode/document-actions/style.scss
+++ b/packages/edit-site/src/components/header-edit-mode/document-actions/style.scss
@@ -30,18 +30,14 @@
 		}
 	}
 
-	.edit-site-document-actions__title-wrapper > h1 {
-		margin: 0;
-
-		// See comment above about min-width
-		min-width: 0;
-	}
-
 	.edit-site-document-actions__title {
 		white-space: nowrap;
 		overflow: hidden;
 		text-overflow: ellipsis;
 		color: currentColor;
+
+		// See comment above about min-width
+		min-width: 0;
 	}
 
 	.edit-site-document-actions__secondary-item {

--- a/packages/edit-site/src/components/list/header.js
+++ b/packages/edit-site/src/components/list/header.js
@@ -30,7 +30,7 @@ export default function Header( { templateType } ) {
 
 	return (
 		<header className="edit-site-list-header">
-			<Heading level={ 1 } className="edit-site-list-header__title">
+			<Heading level={ 2 } className="edit-site-list-header__title">
 				{ postType.labels?.name }
 			</Heading>
 

--- a/packages/edit-site/src/components/list/table.js
+++ b/packages/edit-site/src/components/list/table.js
@@ -98,7 +98,7 @@ export default function Table( { templateType } ) {
 						role="row"
 					>
 						<td className="edit-site-list-table-column" role="cell">
-							<Heading level={ 4 }>
+							<Heading level={ 3 } size={ 16 }>
 								<Link
 									params={ {
 										postId: template.id,

--- a/packages/edit-site/src/components/sidebar-navigation-screen/index.js
+++ b/packages/edit-site/src/components/sidebar-navigation-screen/index.js
@@ -63,7 +63,10 @@ export default function SidebarNavigationScreen( {
 				{ actions }
 			</HStack>
 
-			<nav className="edit-site-sidebar-navigation-screen__content">
+			<nav
+				aria-label={ __( 'Editor' ) }
+				className="edit-site-sidebar-navigation-screen__content"
+			>
 				{ description && (
 					<p className="edit-site-sidebar-navigation-screen__description">
 						{ description }

--- a/packages/edit-site/src/style.scss
+++ b/packages/edit-site/src/style.scss
@@ -33,11 +33,11 @@
 @import "./components/style-book/style.scss";
 @import "./hooks/push-changes-to-global-styles/style.scss";
 
-html #wpadminbar {
+body.js #wpadminbar {
 	display: none;
 }
 
-html #wpbody {
+body.js #wpbody {
 	padding-top: 0;
 }
 
@@ -45,11 +45,10 @@ html #wpbody {
 // We scope it to .wp-toolbar to be wp-admin only, to prevent bleed into other implementations.
 html.wp-toolbar {
 	background: $white;
-	padding-top: 0;
 }
 
-body.appearance_page_gutenberg-template-parts,
-body.site-editor-php {
+body.js.appearance_page_gutenberg-template-parts,
+body.js.site-editor-php {
 	@include wp-admin-reset(".edit-site");
 }
 
@@ -71,6 +70,10 @@ body.site-editor-php {
 		position: fixed;
 		right: 0;
 		top: 0;
+	}
+
+	.no-js & {
+		min-height: 0;
 	}
 
 	.interface-interface-skeleton {

--- a/test/e2e/specs/site-editor/browser-history.spec.js
+++ b/test/e2e/specs/site-editor/browser-history.spec.js
@@ -54,7 +54,10 @@ test.describe( 'Site editor browser history', () => {
 			'/wp-admin/site-editor.php?path=%2Fwp_template%2Fall'
 		);
 
-		const title = page.getByRole( 'heading', { level: 1 } );
+		const header = page.getByRole( 'region', {
+			name: 'Templates list - Header',
+		} );
+		const title = header.getByRole( 'heading', { level: 2 } );
 		await expect( title ).toHaveText( 'Templates' );
 	} );
 } );

--- a/test/e2e/specs/site-editor/title.spec.js
+++ b/test/e2e/specs/site-editor/title.spec.js
@@ -23,7 +23,7 @@ test.describe( 'Site editor title', () => {
 			canvas: 'edit',
 		} );
 		const title = page.locator(
-			'role=region[name="Editor top bar"i] >> role=heading[level=1]'
+			'role=region[name="Editor top bar"i] >> role=heading[level=2]'
 		);
 
 		await expect( title ).toHaveText( 'Editing template: Index' );
@@ -40,7 +40,7 @@ test.describe( 'Site editor title', () => {
 			canvas: 'edit',
 		} );
 		const title = page.locator(
-			'role=region[name="Editor top bar"i] >> role=heading[level=1]'
+			'role=region[name="Editor top bar"i] >> role=heading[level=2]'
 		);
 
 		await expect( title ).toHaveText( 'Editing template part: header' );


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->
Fixes https://github.com/WordPress/gutenberg/issues/42373

## What?
<!-- In a few words, what is the PR actually doing? -->
- Changes some heading levels and removes some headings to make the headings hierarchy a bit more meaningful and not skip levels.
- Makes sure the `Navigation` sub-components `NavigationMenu` and `NavigationGroup` don't render an empty `aria-labelledby` attribute. Note: this component is no longer used. It was in use when this PR was first crafted. Keeping this change as it's a simple improvement.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
A good headings structure is not just about good semantics. Headings are also a navigational tool for screen reader users, as they can use dedicated commands to jump through headings, get a sense of the overall content, and navigate a page. This principle applies also to administration user interfaces, where headings can be used to identify the main parts of the interface.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
- This PR should be coordinated with the core Trac ticket https://core.trac.wordpress.org/ticket/56228  where the main H1 heading of the _site_ editor page is moved to the core PHP side. This change makes the H1 the first thing in the main content and it's consistent with the _post_ editor.
- The current H1 heading on the Site Editor page is changed to H2.
- Other headings levels are changed, to not skip levels.
- Some headings are removed, as they don't make much sense in the overall hierarchy. This mostly applies to some headings in some popovers.

## Updated testing Instructions
- Hint: use the HeadingsMap browser extension. It's available for Chrome and Firefox.
- Go to the Site Editor.
- Check the 'Document Actions' visually hidden heading is now a H2. E.g. 'Editing template; Home'.
- Click the 'Document Actions' chevron icon button to open the template details popover.
- Check the template title in the popover is not a H4 any longer. It's now a styled paragraph. Note: this was fixed in the meantime in https://github.com/WordPress/gutenberg/pull/43151/files#diff-7e0fc5b7f25a211775738bacb60e23d4d6ce09907a12eb0aebd493199e75e3e4L56
- Open the Navigation left sidebar and check the heading at the top is now a H2. Note: this was fixed in the meantime with the introduction of the `Navigator` component that replaced `Navigation`.
- Go to 'Templates' or 'Template Parts' in the navigation and open the 'Manage all' page.
- Inspect the headings in the templates list and check they're now H3.
- Disable JavaScript in your browser and refresh the page.
- Observe the WordPress admin bar `#wpadminbar` is not hidden with `display: none;` and the admin menu is not partially hidden behing the admin bar. This is in preparation for https://core.trac.wordpress.org/ticket/56228.

## Old Instructions
- Hint: use the HeadingsMap browser extension. It's available for Chrome and Firefox.
- Apply the patch for the core part that is attached to https://core.trac.wordpress.org/ticket/56228
- Go to the Site Editor.
- Use HeadingsMap and check the main H1 is a visually hidden heading with text 'Edit site'.
- Check the Document Actions visually hidden heading is now a H2. E.g. 'Editing template; Home'.
- Click the Document Actions chevron icon button to open the template details popover.
- Check the template title in the popover is not a H4 any longer. It's now a styled paragraph.
- Open the Navigation left sidebar and check the heading 'Editor' is now a H2.
- Click 'Templates' or 'Template Parts' in the navigation to open the templates list.
- Inspect the headings in the templates list and check they're now H3.
- Disable JAvaScript in your browser and refresh the page.
- Observe there's now a visible H1 heading 'Edit site' and a no-js WordPress notice.

## Screenshots or screencast <!-- if applicable -->
