### PR TITLE
fix: Correct alt text footnote spacing

### DIFF
--- a/packages/block-library/src/image/edit.native.js
+++ b/packages/block-library/src/image/edit.native.js
@@ -574,7 +574,7 @@ export class ImageEdit extends Component {
 					<>
 						{ __(
 							'Describe the purpose of the image. Leave empty if the image is purely decorative.'
-						) }
+						) }{ ' ' }
 						<FooterMessageLink
 							href={
 								'https://www.w3.org/WAI/tutorials/images/decision-tree/'


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## Related PRs

* https://github.com/wordpress-mobile/gutenberg-mobile/pull/5031

## What?
<!-- In a few words, what is the PR actually doing? -->
Add a space between the two sentences of the alt text footnote.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
A space was lacking between the two sentences within the alt text footnote. This occurred due to the way React parses the separate link element found within this particular footnote. Originally an appropriate space was included in the first sentence, but it was accidentally removed entirely within #38115 to avoid i18n script errors.


## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
Place the required space character in a separate expression. This achieves the appropriate sentence spacing, but avoids i18n script errors caused by trailing spaces within translation strings.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->
1. Open the native block editor.
1. Inserter an _Image_ block.
1. Tap the settings cog icon to open the block settings.
1. Tap _Alt Text_.
1. Verify an appropriate space between the two sentences of the footnote.

## Screenshots or screencast <!-- if applicable -->

| Before | After |
| - | - |
| <img width="452" alt="Alt text footnote before lacks space between sentences" src="https://user-images.githubusercontent.com/438664/179516406-f9c93c8e-ffc1-4e51-b725-9392c29bb0ed.png"> | <img width="452" alt="Alt text footnote before has space between sentences" src="https://user-images.githubusercontent.com/438664/179516404-809ef137-8b9a-495f-af67-b78517a77a80.png"> |


