### PR TITLE
WIP: Introduce HTML processor for server-side block modification on render

### DIFF
--- a/lib/experimental/class-wp-html-processor.php
+++ b/lib/experimental/class-wp-html-processor.php
@@ -1,0 +1,269 @@
+<?php
+
+/**
+ * Processes an input HTML document by applying a specified set
+ * of patches to that input. Tokenizes HTML but does not fully
+ * parse the input document.
+ */
+class WP_HTML_Processor {
+	/**
+	 * Input HTML document to process set by constructor.
+	 *
+	 * Example:
+	 * <code>
+	 *     $processor = new WP_HTML_Processor( '<div class="wp-block-group">Content</div>' );
+	 * </code>
+	 *
+	 * @var string
+	 */
+	public $input;
+
+
+	/**
+	 * Describes the constraints imposed on the HTML tag we're trying to match.
+	 *
+	 * @see WP_Tag_Find_Descriptor::parse()
+	 *
+	 * @var WP_Tag_Find_Descriptor
+	 */
+	public $descriptor;
+
+
+	/**
+	 * Set of modifications to perform on input HTML document, built
+	 * via calls to the fluid API exposed by WP_HTML_Processor.
+	 *
+	 * @var WP_Tag_Modifications
+	 */
+	public $modifications;
+
+
+	public function __construct( $input ) {
+		$this->input = $input;
+	}
+}
+
+
+/**
+ * Describes the search conditions for finding a given tag in an HTML document.
+ */
+class WP_Tag_Find_Descriptor {
+	/**
+	 * We're looking for an HTML tag of this name, up to the comparable
+	 * equivalence of those names (lower-cased, Unicode-normalized, etc...).
+	 * If we're looking for "any tag" then this property will be `null`.
+	 *
+	 * h1...h6 are special since they are variations of the same base tag.
+	 * To find "any heading tag" pass the special value `h`.
+	 *
+	 * @var string|null
+	 */
+	public $tag_name;
+
+
+	/**
+	 * We're looking for a tag also containing this CSS class name, up to
+	 * the comparable equivalence of those names. If we're not looking for
+	 * a class name this property will be `null`.
+	 *
+	 * @var string|null
+	 */
+	public $class_name;
+
+
+	/**
+	 * We're looking for a tag that also has some data-attribute values.
+	 * If all we care about is the presence of one of those values this
+	 * will contain the name of that attribute, up to the comparable
+	 * equivalence of that name. If we also want to constrain the value
+	 * of that attribute we will have a pair containing the name of the
+	 * attribute (to equivalence) with a predicate function. If we're
+	 * not looking for a data-attribute this property will be `null`.
+	 *
+	 * Example:
+	 * <code>
+	 *     // has a `data-wp-container` attribute
+	 *     'data-wp-container'
+	 *
+	 *     // has a `data-wp-container` attribute with the value `core/group`
+	 *     ['data-wp-block', 'core/group']
+	 *
+	 *     // has a `data-test-group` attribute with an even-valued id
+	 *     ['data-test-group', function ( $group ) { return 0 === (int) $group % 2; }]
+	 * </code>
+	 *
+	 * @var array<string|callable>
+	 */
+	public $data_attribute;
+
+
+	/**
+	 * Used to skip matches in case we expect more than one to exist.
+	 * This constraint applies after all other constraints have held.
+	 * For example, to find the third `<div>` tag containing the
+	 * `wp-block` class name set `match_offset = 3`. If not provided
+	 * the default indication is to find the first match.
+	 *
+	 * @default 1
+	 * @var int
+	 */
+	public $match_offset;
+
+
+	/**
+	 * Creates a tag find descriptor given the input parameters specifying
+	 * the intended match, encodes inputs for searching.
+	 *
+	 * @param array $query {
+	 *     Which tag name to find, having which class, etc…
+	 *
+	 *     @type string|null $tag_name   Which tag to find, or `null` for "any tag," or `h` for "any h1 through h6."
+	 *     @type int|null $match_offset  Find the Nth tag matching all search criteria.
+	 *                                   1 for "first" tag, 3 for "third," etc.
+	 *                                   Defaults to first tag.
+	 *     @type string|null $class_name Tag must contain this whole class name to match.
+	 *     @type array<string|callable>  Tag must contain data-attribute of given name and optionally a given
+	 *                                   value, or a given predicate function which returns whether the
+	 *                                   attribute's value constitutes a match.
+	 * }
+	 * @return WP_Tag_Find_Descriptor Used by WP_HTML_Processor when scanning HTML.
+	 */
+	public static function parse( $query ) {
+		$descriptor = new WP_Tag_Find_Descriptor();
+
+		$tag_name = $query['tag_name'];
+		$descriptor->tag_name = null !== $tag_name
+			? self::comparable( $tag_name )
+			: null;
+
+		$match_offset = isset( $query['match_offset'] ) ? $query['match_offset'] : 0;
+		$descriptor->match_offset = is_integer( $match_offset )
+			? $match_offset
+			: 0;
+
+		$containing_class = isset( $query['class_name'] ) ? $query['class_name'] : null;
+		$descriptor->class_name = is_string( $containing_class )
+			? self::comparable( $containing_class )
+			: null;
+
+		$data_attribute = isset( $query['data_attribute'] ) ? $query['data_attribute'] : null;
+		if ( is_string( $data_attribute ) ) {
+			$descriptor->data_attribute = $data_attribute;
+		} elseif ( is_array( $data_attribute ) && is_string( $data_attribute[0] ) && ( is_callable( $data_attribute[1] ) || function_exists( $data_attribute[1] ) ) ) {
+			$descriptor->data_attribute = $data_attribute;
+		} else {
+			$descriptor->data_attribute = null;
+		}
+
+		return $descriptor;
+	}
+
+
+	public static function comparable( $input ) {
+		return strtolower( trim( $input ) );
+	}
+
+
+	public function needs_only_tag() {
+		return $this->class_name === null && $this->data_attribute === null;
+	}
+
+	public function needs_class() {
+		return $this->class_name !== null;
+	}
+
+	public function needs_data_attribute() {
+		return $this->data_attribute !== null;
+	}
+}
+
+
+class WP_Tag_Finder_Tag {
+	/**
+	 * The matched tag name within an HTML tag match.
+	 *
+	 * @var string
+	 */
+	public $tag_name;
+
+	/**
+	 * Lazily-built index of found attributes within an HTML tag match.
+	 *
+	 * Example:
+	 * <code>
+	 *     // supposing the parser is working through this content
+	 *     // and stops after recognizing the `id` attribute
+	 *     // <div id="test-4" class=outline title="data:text/plain;base64=asdk3nk1j3fo8">
+	 *     //                 ^ parsing will continue from this point
+	 *     $this->attributes = array(
+	 *         'id' => array( 6, 17, 'test-4' )
+	 *     );
+	 *
+	 *     // when picking up parsing again, or when asking to find the
+	 *     // `class` attribute we will continue and add to this array
+	 *     $this->attributes = array(
+	 *         'id' => array( 6, 17, 'test-4' ),
+	 *         'class' => array( 18, 32, 'outline' )
+	 *     );
+	 * </code>
+	 *
+	 * @var array<int|string>
+	 */
+	public $attributes;
+}
+
+
+class WP_Tag_Modifications {
+	/**
+	 * Which class names to add or remove from a tag.
+	 * If `true` then add and if `false` then remove.
+	 *
+	 * These are tracked separately from attribute updates
+	 * because they are semantically distinct, whereas this
+	 * interface exists for the common case of adding and
+	 * removing class names while other attributes are
+	 * generally modified as with DOM `setAttribute` calls.
+	 *
+	 * When modifying an HTML document these will eventually
+	 * be collapsed into a single lexical update to replace
+	 * the `class` attribute.
+	 *
+	 * Example:
+	 * <code>
+	 *     // Add the `wp-block-group` class, remove the `wp-group` class.
+	 *     $class_changes = array( 'wp-block-group' => true, 'wp-group' => false );
+	 * </code>
+	 *
+	 * @var array<boolean>
+	 */
+	public $class_changes;
+
+
+	/**
+	 * Lexical replacements to apply to input HTML document.
+	 *
+	 * HTML modifications collapse into lexical replacements in order to
+	 * provide an efficient mechanism to update documents lazily and in
+	 * order to support a variety of semantic modifications without
+	 * building a complicated parsing machinery. That is, it's up to
+	 * the calling class to generate the lexical modification from the
+	 * semantic change requested.
+	 *
+	 * Example:
+	 * <code>
+	 *     // Replace an attribute stored with a new value, indices
+	 *     // sourced from the lazily-parsed HTML recognizer.
+	 *     list( $start, $end, $old_value ) = $attributes['src'];
+	 *     $modifications[] = array( $start, $end, get_the_post_thumbnail_url() );
+	 *
+	 *     // Correspondingly, something like this
+	 *     // will appear in the replacements array.
+	 *     $replacements = array(
+	 *         array( 14, 28, 'https://my-site.my-domain/wp-content/uploads/2014/08/kittens.jpg' )
+	 *     );
+	 * </code>
+	 *
+	 * @var array<int|string>
+	 */
+	public $replacements;
+}

--- a/lib/experimental/class-wp-html-processor.php
+++ b/lib/experimental/class-wp-html-processor.php
@@ -7,19 +7,6 @@
  */
 class WP_HTML_Processor {
 	/**
-	 * Input HTML document to process set by constructor.
-	 *
-	 * Example:
-	 * <code>
-	 *     $processor = new WP_HTML_Processor( '<div class="wp-block-group">Content</div>' );
-	 * </code>
-	 *
-	 * @var string
-	 */
-	public $input;
-
-
-	/**
 	 * Describes the constraints imposed on the HTML tag we're trying to match.
 	 *
 	 * @see WP_Tag_Find_Descriptor::parse()
@@ -27,6 +14,14 @@ class WP_HTML_Processor {
 	 * @var WP_Tag_Find_Descriptor
 	 */
 	public $descriptor;
+
+
+	/**
+	 * Tracks parsing while scanning input document.
+	 *
+	 * @var WP_HTML_Processor_Parse_State
+	 */
+	public $state;
 
 
 	/**
@@ -39,7 +34,29 @@ class WP_HTML_Processor {
 
 
 	public function __construct( $input ) {
-		$this->input = $input;
+		$this->state = new WP_HTML_Processor_Parse_State( $input );
+	}
+
+
+	public function find( WP_Tag_Find_Descriptor $descriptor ) {
+		$this->state->reset();
+		$this->descriptor = $descriptor;
+		$this->modifications = new WP_Tag_Modifications();
+	}
+
+
+	public function apply() {
+		// find tag
+		// apply modifications
+		// construct output
+
+		// @TODO: This is a stub; implement the real apply() behavior.
+		return $this->state->document;
+	}
+
+
+	public function __toString() {
+		return $this->apply();
 	}
 }
 
@@ -178,13 +195,44 @@ class WP_Tag_Find_Descriptor {
 }
 
 
-class WP_Tag_Finder_Tag {
+class WP_HTML_Processor_Parse_State {
 	/**
-	 * The matched tag name within an HTML tag match.
+	 * Input HTML document we're processing.
 	 *
 	 * @var string
 	 */
-	public $tag_name;
+	public $document;
+
+	/**
+	 * Byte offset in the input document we will start or continue parsing.
+	 *
+	 * @var int
+	 */
+	public $start_at = 0;
+
+
+	/**
+	 * Whether we've already found the tag meeting our search constraints.
+	 *
+	 * @var boolean
+	 */
+	public $did_match = false;
+
+
+	/**
+	 * Byte offset in the current tag being inspected starts, includes leading `<`.
+	 *
+	 * @var int|null
+	 */
+	public $tag_start = null;
+
+
+	/**
+	 * Start and end of matched tag name, or `null` if not yet found.
+	 *
+	 * @var array<int|string>|null
+	 */
+	public $tag_name = null;
 
 	/**
 	 * Lazily-built index of found attributes within an HTML tag match.
@@ -209,7 +257,20 @@ class WP_Tag_Finder_Tag {
 	 *
 	 * @var array<int|string>
 	 */
-	public $attributes;
+	public $attributes = array();
+
+
+	public function __construct( $input ) {
+		$this->document = $input;
+	}
+
+
+	public function reset() {
+		$this->tag_name = null;
+		$this->attributes = array();
+		$this->did_match = false;
+		$this->tag_start = null;
+	}
 }
 
 

--- a/lib/experimental/class-wp-html-processor.php
+++ b/lib/experimental/class-wp-html-processor.php
@@ -82,7 +82,6 @@ class WP_HTML_Processor {
 
 	public function find( $query ) {
 		$this->commit_class_changes();
-//		$this->scanner->reset();
 		$this->descriptor = WP_Tag_Find_Descriptor::parse( $query );
 		if ( false === $this->scanner->scan( $this->descriptor ) ) {
 			return false;
@@ -481,13 +480,6 @@ class WP_HTML_Scanner {
 
 
 	/**
-	 * Whether we found the tag we searched for.
-	 *
-	 * @var bool
-	 */
-	public $did_match = false;
-
-	/**
 	 * Byte offset in the input document we will start or continue parsing.
 	 *
 	 * @var int
@@ -543,13 +535,11 @@ class WP_HTML_Scanner {
 
 	public function scan( WP_Tag_Find_Descriptor $descriptor, $found_already = 0, $tag = null ) {
 		if ( $found_already === $descriptor->match_offset ) {
-			$this->did_match = true;
 			return $tag;
 		}
 
 		$tag = $this->find_next_tag();
 		if ( ! $tag ) {
-			$this->did_match = false;
 			return false;
 		}
 
@@ -571,6 +561,7 @@ class WP_HTML_Scanner {
 	 * @return WP_HTML_Scanner_Token|false
 	 */
 	public function find_next_tag() {
+		// @TODO: Handle <DOCTYPE>
 		if ( 1 !== preg_match(
 			/*
 			 * Unfortunately we can't try to search for only the tag name we want because that might
@@ -594,7 +585,6 @@ class WP_HTML_Scanner {
 			return $this->find_next_tag();
 		}
 
-		$this->did_match = false;
 		$this->start_at = $start_at + strlen( $full_match );
 		$this->tag_name = WP_HTML_Scanner_Token::from_preg_match( $tag_match['TAG'] );
 		$this->tag_start = $this->tag_name->start - 1; // rewind past the leading `<`
@@ -667,7 +657,6 @@ class WP_HTML_Scanner {
 	}
 
 	public function reset() {
-		$this->did_match = false;
 		$this->tag_name = null;
 		$this->attributes = array();
 		$this->tag_start = null;

--- a/lib/experimental/class-wp-html-processor.php
+++ b/lib/experimental/class-wp-html-processor.php
@@ -577,7 +577,7 @@ class WP_HTML_Scanner {
 			 * lead us to skip over other tags and lose track of our place. So we need to search for
 			 * _every_ tag and then check after we find one if it's the one we are looking for.
 			 */
-	"~<!--(?>.*?-->)|<!\[CDATA\[(?>.*?>)|<\?(?>.*?)>|<(?P<TAG>[a-z][^\t\x{0A}\x{0C} /?>]*)~Smui",
+	"~<!--(?>.*?-->)|<!\[CDATA\[(?>.*?\]\]>)|<\?(?>.*?)>|<(?P<TAG>[a-z][^\t\x{0A}\x{0C} /?>]*)~Smui",
 			$this->document,
 			$tag_match,
 			PREG_OFFSET_CAPTURE,
@@ -606,7 +606,7 @@ class WP_HTML_Scanner {
 	public function find_next_attribute() {
 		// Find the attribute name
 		if ( 1 !== preg_match(
-			'~[\t\x{0a}\x{0c}\x{0d} ]*(?P<NAME>=?[^=/>\t\x{0C} ]*)~Smiu',
+			'~[\t\x{0a}\x{0c} ]*(?P<NAME>=?[^=/>\t\x{0A}\x{0C} ]*)~Smiu',
 			$this->document,
 			$attribute_match,
 			PREG_OFFSET_CAPTURE,
@@ -643,7 +643,7 @@ class WP_HTML_Scanner {
 				break;
 
 			default:
-				$pattern = '~(?P<VALUE>[^\t\x{0a}\x{0c}\x{0d} >]*)~Smiu';
+				$pattern = '~(?P<VALUE>[^\t\x{0a}\x{0c} >]*)~Smiu';
 				break;
 		}
 

--- a/lib/experimental/class-wp-html-processor.php
+++ b/lib/experimental/class-wp-html-processor.php
@@ -143,7 +143,7 @@ class WP_HTML_Processor {
 	}
 
 
-	public function add_attribute( $name, $value ) {
+	private function add_attribute( $name, $value ) {
 		$tag_name = $this->scanner->tag_name;
 		$insert_at = $tag_name->start + $tag_name->length;
 
@@ -199,14 +199,14 @@ class WP_HTML_Processor {
 	}
 
 
-	public static function serialize_attribute( $name, $value ) {
+	private static function serialize_attribute( $name, $value ) {
 		$value = str_replace( '"', "&quot;", $value );
 
 		return "{$name}=\"{$value}\"";
 	}
 
 
-	public function commit_class_changes() {
+	private function commit_class_changes() {
 		if ( empty( $this->class_changes ) ) {
 			return;
 		}
@@ -250,7 +250,7 @@ class WP_HTML_Processor {
 	}
 
 
-	public function apply() {
+	private function apply() {
 		$document = $this->scanner->document;
 
 		$this->commit_class_changes();
@@ -612,7 +612,7 @@ class WP_HTML_Scanner {
 	/**
 	 * @return WP_HTML_Scanner_Token|false
 	 */
-	public function find_next_tag() {
+	private function find_next_tag() {
 		// @TODO: Handle <DOCTYPE>
 		if ( 1 !== preg_match(
 			/*
@@ -646,7 +646,7 @@ class WP_HTML_Scanner {
 	}
 
 
-	public function find_next_attribute() {
+	private function find_next_attribute() {
 		// Find the attribute name
 		if ( 1 !== preg_match(
 			'~[\t\x{0a}\x{0c} ]*(?P<NAME>=?[^=/>\t\x{0A}\x{0C} ]*)~Smiu',
@@ -706,11 +706,5 @@ class WP_HTML_Scanner {
 		$this->start_at = $value_start_at + strlen( $full_match );
 
 		return new WP_HTML_Attribute_Token( $name_token, $value_token, $name_token->start, $value_start_at + strlen( $full_match ) );
-	}
-
-	public function reset() {
-		$this->tag_name = null;
-		$this->attributes = array();
-		$this->tag_start = null;
 	}
 }

--- a/lib/experimental/class-wp-html-processor.php
+++ b/lib/experimental/class-wp-html-processor.php
@@ -14,6 +14,11 @@
  *    some fairly robust support because it's not difficult to
  *    create misleading HTML through the block editor. For
  *    example, as can happen with a number of plaintext inputs.
+ *  - Cleanup comparable copies so strings people add, such as
+ *    with add_class(), get pasted verbatim into the output
+ *    even though we use the comparable to d-duplicate entries.
+ *    Same goes for the attribute names - we don't want to
+ *    modify what we don't need to.
  *
  * Performance ideas:
  *
@@ -202,6 +207,10 @@ class WP_HTML_Processor {
 		$document = $this->scanner->document;
 
 		$this->commit_class_changes();
+
+		if ( empty( $this->modifications->replacements ) ) {
+			return $document;
+		}
 
 		/*
 		 * Since we could be asking to modify attributes in a different
@@ -687,7 +696,7 @@ class WP_Tag_Modifications {
 	 *
 	 * @var array<boolean>
 	 */
-	public $class_changes;
+	public $class_changes = array();
 
 
 	/**
@@ -716,5 +725,5 @@ class WP_Tag_Modifications {
 	 *
 	 * @var array<int|string>
 	 */
-	public $replacements;
+	public $replacements = array();
 }

--- a/lib/experimental/class-wp-html-processor.php
+++ b/lib/experimental/class-wp-html-processor.php
@@ -226,7 +226,7 @@ class WP_Tag_Find_Descriptor {
 			}
 
 			$pattern_class = preg_quote( $this->class_name, '~' );
-			return 1 === preg_match( "~(?:^|[\t ]){$pattern_class}(?:[\t ]|$)~", $attributes['class']->value->comparable );
+			return 1 === preg_match( "~(?:^|[\t ]){$pattern_class}(?:[\t ]|$)~Smui", $attributes['class']->value->comparable );
 		}
 
 		if ( null === $this->class_name ) {
@@ -424,7 +424,7 @@ class WP_HTML_Scanner {
 			 * lead us to skip over other tags and lose track of our place. So we need to search for
 			 * _every_ tag and then check after we find one if it's the one we are looking for.
 			 */
-	"~<!--(?>.*?-->)|<!\[CDATA\[(?>.*?>)|<\?(?>.*?)>|<(?P<TAG>[a-z][^\t\x{0A}\x{0C} /?>]*)~mui",
+	"~<!--(?>.*?-->)|<!\[CDATA\[(?>.*?>)|<\?(?>.*?)>|<(?P<TAG>[a-z][^\t\x{0A}\x{0C} /?>]*)~Smui",
 			$this->document,
 			$tag_match,
 			PREG_OFFSET_CAPTURE,
@@ -453,7 +453,7 @@ class WP_HTML_Scanner {
 	public function find_next_attribute() {
 		// Find the attribute name
 		if ( 1 !== preg_match(
-			'~[\t\x{0a}\x{0c}\x{0d} ]*(?P<NAME>=?[^=/>\t\x{0C} ]*)~miu',
+			'~[\t\x{0a}\x{0c}\x{0d} ]*(?P<NAME>=?[^=/>\t\x{0C} ]*)~Smiu',
 			$this->document,
 			$attribute_match,
 			PREG_OFFSET_CAPTURE,
@@ -481,20 +481,20 @@ class WP_HTML_Scanner {
 		switch ( $this->document[ $this->start_at ] ) {
 			case '"':
 				$this->start_at += 1;
-				$pattern = '~(?P<VALUE>[^"]*)"~miu';
+				$pattern = '~(?P<VALUE>[^"]*)"~Smiu';
 				break;
 
 			case "'":
 				$this->start_at += 1;
-				$pattern = "~(?P<VALUE>[^']*)'~miu";
+				$pattern = "~(?P<VALUE>[^']*)'~Smiu";
 				break;
 
 			default:
-				$pattern = '~(?P<VALUE>[^\t\x{0a}\x{0c}\x{0d} >]*)~miu';
+				$pattern = '~(?P<VALUE>[^\t\x{0a}\x{0c}\x{0d} >]*)~Smiu';
 				break;
 		}
 
-		if ( 1 != preg_match(
+		if ( 1 !== preg_match(
 			$pattern,
 			$this->document,
 			$value_match,


### PR DESCRIPTION
## What

Currently provides some data structures necessary for tracking and modifying
an HTML document. No implementation code exists yet and this is mainly here
to establish system design and documentation.

Alternative implementation to associated #42485

## Why?

There exists too many fragile and duplicate backend RegExp matchers to replace
individual HTML elements within block code.

## How?

Provides a standard and highly-restricted HTML modification API to separate the
act of _finding_ HTML tokens from _replacing_ or _updating_ HTML values.

## Testing Instructions

There is nothing yet to test.