### PR TITLE
fix: Workaround Android 12 webview crash

### DIFF
--- a/packages/components/src/sandbox/index.native.js
+++ b/packages/components/src/sandbox/index.native.js
@@ -1,13 +1,14 @@
 /**
  * External dependencies
  */
-import { Dimensions, Platform } from 'react-native';
+import { Dimensions, StyleSheet } from 'react-native';
 import { WebView } from 'react-native-webview';
 
 /**
  * WordPress dependencies
  */
 import {
+	Platform,
 	renderToString,
 	memo,
 	useRef,
@@ -307,6 +308,7 @@ function Sandbox( {
 			style={ [
 				sandboxStyles[ 'sandbox-webview__content' ],
 				getSizeStyle(),
+				Platform.isAndroid && workaroundStyles.webView,
 			] }
 			onMessage={ checkMessageForResize }
 			scrollEnabled={ false }
@@ -316,5 +318,16 @@ function Sandbox( {
 		/>
 	);
 }
+
+const workaroundStyles = StyleSheet.create( {
+	webView: {
+		/**
+		 * The slight opacity below is a workaround for an Android crash caused from combining Android
+		 * 12's new scroll overflow behavior and webviews.
+		 * https://github.com/react-native-webview/react-native-webview/issues/1915#issuecomment-808869253
+		 */
+		opacity: 0.99,
+	},
+} );
 
 export default memo( Sandbox );

--- a/packages/react-native-editor/CHANGELOG.md
+++ b/packages/react-native-editor/CHANGELOG.md
@@ -13,6 +13,7 @@ For each user feature we should also add a importance categorization label  to i
 
 -   [*] Add React Native FastImage [#42009]
 -   [*] Block inserter displays block collections [#42405]
+-   [**] Fix a crash when scrolling posts containing Embed blocks (Android 12 only) [#42514]
 
 ## 1.79.0
 -   [*] Add 'Insert from URL' option to Video block [#41493]


### PR DESCRIPTION
## Related PRs

* https://github.com/wordpress-mobile/gutenberg-mobile/pull/5033

## What?
Fixes #42514. Apply a workaround to prevent a crash on Android when webviews are displayed within a scroll view. The crash appears to originate with incompatibility with Android 12's new overflow scroll behavior.

## Why?
The editor crash creates a bad user experience with the possibility of content loss.

## How?
Applying `opacity: 0.99` [prevents the crash](https://github.com/react-native-webview/react-native-webview/issues/1915#issuecomment-808869253) from occurring. I perceive this change to be less than ideal, and should be considered a temporary fix while we seek a more appropriate solution for the `react-native-webview` library.

I explored other workarounds like [`androidLayerType="software"`](https://github.com/react-native-webview/react-native-webview/issues/1915#issuecomment-880989194) as well, but feared possible performance issues from the change based upon https://github.com/react-native-webview/react-native-webview/issues/1915#issuecomment-1047605643 and my own research. However, I do not fully understand the `opacity: 0.99` workaround. It is possible that it similarly creates a "software layer."


## Testing Instructions
Perform the testing steps outlined in #42514 with various Embed variants (e.g. YouTube, Twitter) and posts of different content lengths.

## Screenshots or screencast <!-- if applicable -->
n/a
