### PR TITLE
Fix custom placeholder not displaying on subsequent Paragraph blocks

### DIFF
--- a/packages/block-library/src/paragraph/edit.js
+++ b/packages/block-library/src/paragraph/edit.js
@@ -146,6 +146,7 @@ function ParagraphBlock( {
 				}
 				data-empty={ content ? false : true }
 				placeholder={ placeholder || __( 'Type / to choose a block' ) }
+				data-has-custom-placeholder={ placeholder ? true : undefined }
 				__unstableEmbedURLOnPaste
 				__unstableAllowPrefixTransformations
 			/>

--- a/packages/block-library/src/paragraph/edit.js
+++ b/packages/block-library/src/paragraph/edit.js
@@ -146,7 +146,7 @@ function ParagraphBlock( {
 				}
 				data-empty={ content ? false : true }
 				placeholder={ placeholder || __( 'Type / to choose a block' ) }
-				data-has-custom-placeholder={ placeholder ? true : undefined }
+				data-custom-placeholder={ placeholder ? true : undefined }
 				__unstableEmbedURLOnPaste
 				__unstableAllowPrefixTransformations
 			/>

--- a/packages/block-library/src/paragraph/editor.scss
+++ b/packages/block-library/src/paragraph/editor.scss
@@ -3,7 +3,7 @@
 	min-height: auto !important;
 }
 
-// Hide multiple sequential paragraphs.
+// Hide multiple sequential paragraphs, but don't hide placeholders if a custom placeholder is set.
 .block-editor-block-list__block[data-empty="true"] {
 	[data-rich-text-placeholder] {
 		opacity: 1;
@@ -11,7 +11,9 @@
 }
 
 .block-editor-block-list__block[data-empty="true"] + .block-editor-block-list__block[data-empty="true"] {
-	[data-rich-text-placeholder] {
-		opacity: 0;
+	&:not([data-has-custom-placeholder="true"]) {
+		[data-rich-text-placeholder] {
+			opacity: 0;
+		}
 	}
 }

--- a/packages/block-library/src/paragraph/editor.scss
+++ b/packages/block-library/src/paragraph/editor.scss
@@ -11,7 +11,7 @@
 }
 
 .block-editor-block-list__block[data-empty="true"] + .block-editor-block-list__block[data-empty="true"] {
-	&:not([data-has-custom-placeholder="true"]) {
+	&:not([data-custom-placeholder="true"]) {
 		[data-rich-text-placeholder] {
 			opacity: 0;
 		}


### PR DESCRIPTION
## What?
Fixes #35928.

## Why?
If custom placeholders are set on Paragraph blocks, the custom placeholders for subsequent blocks are hidden. This is not ideal for certain implementations as the linked issue details. This is especially troublesome in pattern creation.

## How?
This PR solves this issue by conditionally adding the attribute `data-has-custom-placeholder` to Paragraph blocks with custom placeholders set. Then the Editor styles for Paragraph blocks have been updated to show the placeholders for subsequent blocks with this attribute. 

This approach follows the suggestion in #35928. There may be alternatives, but this seemed to be the most straightforward solution.

## Testing Instructions
1. Create a new page or post and add the following code example.
```
<!-- wp:paragraph {"placeholder":"Start writing your story..."} -->
<p></p>
<!-- /wp:paragraph -->

<!-- wp:paragraph {"placeholder":"This is another placeholder..."} -->
<p></p>
<!-- /wp:paragraph -->
```
2. You should see both placeholders. 
3. Now add the following code, the middle paragraph should have a hidden placeholder since there is no custom placeholder set. 
```
<!-- wp:paragraph {"placeholder":"Start writing your story..."} -->
<p></p>
<!-- /wp:paragraph -->

<!-- wp:paragraph -->
<p></p>
<!-- /wp:paragraph -->

<!-- wp:paragraph {"placeholder":"This is another placeholder..."} -->
<p></p>
<!-- /wp:paragraph -->
```

## Screenshots or screencast <!-- if applicable -->

Using the last code example above here is a before and after:

**Before this PR**
![image](https://user-images.githubusercontent.com/4832319/179654046-96d4f332-377e-43b7-99b5-26117482c079.png)

**After this PR**
![image](https://user-images.githubusercontent.com/4832319/179653907-7be1d1fb-cb04-4db0-bae0-ee88ff569164.png)
