### PR TITLE
List v2: improve paste handling

### DIFF
--- a/packages/block-library/src/list-item/edit.js
+++ b/packages/block-library/src/list-item/edit.js
@@ -28,6 +28,7 @@ import {
 	useOutdentListItem,
 	useSplit,
 } from './hooks';
+import { convertToListItems } from './utils';
 
 function IndentUI( { clientId } ) {
 	const [ canIndent, indentListItem ] = useIndentListItem( clientId );
@@ -88,7 +89,9 @@ export default function ListItemEdit( {
 					placeholder={ placeholder || __( 'List' ) }
 					onSplit={ onSplit }
 					onMerge={ mergeBlocks }
-					onReplace={ onReplace }
+					onReplace={ ( blocks, ...args ) => {
+						onReplace( convertToListItems( blocks ), ...args );
+					} }
 				/>
 				{ innerBlocksProps.children }
 			</li>

--- a/packages/block-library/src/list-item/utils.js
+++ b/packages/block-library/src/list-item/utils.js
@@ -1,14 +1,38 @@
 /**
  * WordPress dependencies
  */
-import { createBlock } from '@wordpress/blocks';
+import { createBlock, switchToBlockType } from '@wordpress/blocks';
+
+/**
+ * Internal dependencies
+ */
+import { name as listItemName } from './block.json';
+import { name as listName } from '../list/block.json';
 
 export function createListItem( listItemAttributes, listAttributes, children ) {
 	return createBlock(
-		'core/list-item',
+		listItemName,
 		listItemAttributes,
 		! children?.length
 			? []
-			: [ createBlock( 'core/list', listAttributes, children ) ]
+			: [ createBlock( listName, listAttributes, children ) ]
 	);
+}
+
+export function convertToListItems( blocks ) {
+	const listItems = [];
+
+	for ( let block of blocks ) {
+		if ( block.name === listItemName ) {
+			listItems.push( block );
+		} else if ( block.name === listName ) {
+			listItems.push( ...block.innerBlocks );
+		} else if ( ( block = switchToBlockType( block, listName ) ) ) {
+			for ( const { innerBlocks } of block ) {
+				listItems.push( ...innerBlocks );
+			}
+		}
+	}
+
+	return listItems;
 }


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?

Fixes #39887.
Fixes #40980.

When pasting anything in a list item, convert the posted blocks to a list, extract the transformed list items, and insert that.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

## Testing Instructions

1. Create a list.2. 
2. Copy a paragraph and paste it into the list. It should convert the paragraph to a list item.
3. Copy a whole list block and paste it into the list. It should insert the list items.
4. Copy a list item and paste it into the list. It should still work.
5. Try copying multiple blocks. It will only paste content that can be converted to list items.

## Screenshots or screencast <!-- if applicable -->
