### PR TITLE
Block Library: Remove unnecessary React Fragments

### DIFF
--- a/packages/block-library/src/buttons/edit.js
+++ b/packages/block-library/src/buttons/edit.js
@@ -53,11 +53,7 @@ function ButtonsEdit( { attributes: { layout = {} } } ) {
 		templateInsertUpdatesSelection: true,
 	} );
 
-	return (
-		<>
-			<div { ...innerBlocksProps } />
-		</>
-	);
+	return <div { ...innerBlocksProps } />;
 }
 
 export default ButtonsEdit;

--- a/packages/block-library/src/query-no-results/edit.js
+++ b/packages/block-library/src/query-no-results/edit.js
@@ -20,9 +20,6 @@ export default function QueryNoResultsEdit() {
 	const innerBlocksProps = useInnerBlocksProps( blockProps, {
 		template: TEMPLATE,
 	} );
-	return (
-		<>
-			<div { ...innerBlocksProps } />
-		</>
-	);
+
+	return <div { ...innerBlocksProps } />;
 }


### PR DESCRIPTION
## What?
A minor cleanup. PR removes unnecessary React Fragments from Block Library packages.

## Why?
I noticed those while browsing the code. No need to use fragments here.

## Testing Instructions
None. Doesn't change anything.
