### PR TITLE
Popover: tidy up and improve shifting behavior

### DIFF
--- a/packages/components/src/popover/index.js
+++ b/packages/components/src/popover/index.js
@@ -255,7 +255,21 @@ const Popover = (
 		__unstableShift
 			? shift( {
 					crossAxis: true,
-					limiter: limitShift(),
+					limiter: limitShift( {
+						offset: ( { floating } ) => {
+							// iFrame-specific correction aimed at allowing the floating element
+							// to shift fully below the reference element.
+							if ( ownerDocument === document ) {
+								return 0;
+							}
+							// TODO: adapt code based on the placement
+							// (see https://floating-ui.com/docs/shift#limitshift-offset)
+							return {
+								mainAxis: 0,
+								crossAxis: -floating.height,
+							};
+						},
+					} ),
 					padding: 1, // Necessary to avoid flickering at the edge of the viewport.
 			  } )
 			: undefined,

--- a/packages/components/src/popover/index.js
+++ b/packages/components/src/popover/index.js
@@ -143,7 +143,7 @@ const Popover = (
 		onFocusOutside,
 		__unstableSlotName = SLOT_NAME,
 		__unstableObserveElement,
-		__unstableForcePosition,
+		__unstableForcePosition = false,
 		__unstableShift = false,
 		...contentProps
 	},

--- a/packages/components/src/popover/index.js
+++ b/packages/components/src/popover/index.js
@@ -82,7 +82,7 @@ const ArrowTriangle = ( props ) => (
 const slotNameContext = createContext();
 
 // Converts the `Popover`'s legacy "position" prop to the
-// new "placement" prop (used by `gloating-ui`).
+// new "placement" prop (used by `floating-ui`).
 const positionToPlacement = ( position ) => {
 	const [ x, y, z ] = position.split( ' ' );
 
@@ -137,6 +137,22 @@ const placementToAnimationOrigin = ( placement, rtl ) => {
 
 	return animationOrigin;
 };
+
+/**
+ * @param {FloatingUIPlacement} placement
+ * @return {'top' | 'right' | 'bottom' | 'left'} The side
+ */
+export function getSide( placement ) {
+	return placement.split( '-' )[ 0 ];
+}
+
+/**
+ * @param {FloatingUIPlacement} placement
+ * @return {'x' | 'y'} The axis
+ */
+export function getMainAxisFromPlacement( placement ) {
+	return [ 'top', 'bottom' ].includes( getSide( placement ) ) ? 'x' : 'y';
+}
 
 const Popover = (
 	{
@@ -272,17 +288,25 @@ const Popover = (
 			? shift( {
 					crossAxis: true,
 					limiter: limitShift( {
-						offset: ( { floating } ) => {
+						offset: ( { floating, placement } ) => {
 							// iFrame-specific correction aimed at allowing the floating element
 							// to shift fully below the reference element.
 							if ( ownerDocument === document ) {
 								return 0;
 							}
-							// TODO: adapt code based on the placement
-							// (see https://floating-ui.com/docs/shift#limitshift-offset)
+
+							const computedMainAxis =
+								getMainAxisFromPlacement( placement );
+
 							return {
-								mainAxis: 0,
-								crossAxis: -floating.height,
+								mainAxis:
+									computedMainAxis === 'x'
+										? 0
+										: -floating.height,
+								crossAxis:
+									computedMainAxis === 'x'
+										? -floating.height
+										: 0,
 							};
 						},
 					} ),

--- a/packages/components/src/popover/index.js
+++ b/packages/components/src/popover/index.js
@@ -129,7 +129,7 @@ const Popover = (
 		noArrow = true,
 		isAlternate,
 		position,
-		placement = 'bottom-start',
+		placement: placementProp = 'bottom-start',
 		offset,
 		focusOnMount = 'firstElement',
 		anchorRef,
@@ -157,9 +157,10 @@ const Popover = (
 	const isMobileViewport = useViewportMatch( 'medium', '<' );
 	const isExpanded = expandOnMobile && isMobileViewport;
 	const hasArrow = ! isExpanded && ! noArrow;
-	const usedPlacement = position
+
+	const normalizedPlacementProp = position
 		? positionToPlacement( position )
-		: placement;
+		: placementProp;
 
 	const ownerDocument = useMemo( () => {
 		let documentToReturn;
@@ -199,7 +200,7 @@ const Popover = (
 		return { x: iframeRect.left, y: iframeRect.top };
 	}, [ ownerDocument ] );
 
-	const middlewares = [
+	const middleware = [
 		frameOffset || offset
 			? offsetMiddleware( ( { placement: currentPlacement } ) => {
 					if ( ! frameOffset ) {
@@ -286,12 +287,9 @@ const Popover = (
 		strategy,
 		refs,
 		update,
-		placement: placementData,
+		placement: computedPlacement,
 		middlewareData: { arrow: arrowData = {} },
-	} = useFloating( {
-		placement: usedPlacement,
-		middleware: middlewares,
-	} );
+	} = useFloating( { placement: normalizedPlacementProp, middleware } );
 
 	const mergedRefs = useMergeRefs( [ floating, dialogRef, ref ] );
 
@@ -379,7 +377,7 @@ const Popover = (
 		!! animate &&
 		getAnimateClassName( {
 			type: 'appear',
-			origin: placementToAnimationOrigin( placementData ),
+			origin: placementToAnimationOrigin( computedPlacement ),
 		} );
 
 	// Disable reason: We care to capture the _bubbled_ events from inputs

--- a/packages/components/src/popover/index.js
+++ b/packages/components/src/popover/index.js
@@ -105,17 +105,17 @@ const positionToPlacement = ( position ) => {
 /** @type {Object.<FloatingUIPlacement, AppearOrigin>} */
 const PLACEMENT_TO_ANIMATION_ORIGIN_MAP = {
 	top: 'bottom',
-	'top-start': 'bottom right',
-	'top-end': 'bottom left',
+	'top-start': 'bottom left',
+	'top-end': 'bottom right',
 	right: 'middle left',
-	'right-start': 'bottom left',
-	'right-end': 'top left',
+	'right-start': 'top left',
+	'right-end': 'bottom left',
 	bottom: 'top',
-	'bottom-start': 'top right',
-	'bottom-end': 'top left',
+	'bottom-start': 'top left',
+	'bottom-end': 'top right',
 	left: 'middle right',
-	'left-start': 'bottom right',
-	'left-end': 'top right',
+	'left-start': 'top right',
+	'left-end': 'bottom right',
 };
 
 /**

--- a/packages/components/src/popover/index.js
+++ b/packages/components/src/popover/index.js
@@ -99,9 +99,6 @@ const positionToPlacement = ( position ) => {
 	return y;
 };
 
-// Given the floating-ui `placement`, compute the origin used for the entrance
-// animation. The origin should be on the "opposite" side from the placement.
-
 /** @type {Object.<FloatingUIPlacement, AppearOrigin>} */
 const PLACEMENT_TO_ANIMATION_ORIGIN_MAP = {
 	top: 'bottom',
@@ -119,6 +116,8 @@ const PLACEMENT_TO_ANIMATION_ORIGIN_MAP = {
 };
 
 /**
+ * Given the floating-ui `placement`, compute the origin used for the entrance
+ * animation. The origin should be on the "opposite" side from the placement.
  *
  * @param {FloatingUIPlacement} placement A placement string from floating ui
  * @param {boolean}             rtl

--- a/packages/components/src/popover/index.js
+++ b/packages/components/src/popover/index.js
@@ -42,11 +42,11 @@ import Button from '../button';
 import ScrollLock from '../scroll-lock';
 import { Slot, Fill, useSlot } from '../slot-fill';
 import { getAnimateClassName } from '../animate';
-
-/**
- * @typedef {import('../animate').AppearOrigin} AppearOrigin
- * @typedef {import('@floating-ui/react-dom').Placement} FloatingUIPlacement
- */
+import {
+	positionToPlacement,
+	placementToAnimationOrigin,
+	getMainAxisFromPlacement,
+} from './utils';
 
 /**
  * Name of slot in which popover should fill.
@@ -80,78 +80,6 @@ const ArrowTriangle = ( props ) => (
 );
 
 const slotNameContext = createContext();
-
-// Converts the `Popover`'s legacy "position" prop to the
-// new "placement" prop (used by `floating-ui`).
-const positionToPlacement = ( position ) => {
-	const [ x, y, z ] = position.split( ' ' );
-
-	if ( [ 'top', 'bottom' ].includes( x ) ) {
-		let suffix = '';
-		if ( ( !! z && z === 'left' ) || y === 'right' ) {
-			suffix = '-start';
-		} else if ( ( !! z && z === 'right' ) || y === 'left' ) {
-			suffix = '-end';
-		}
-		return x + suffix;
-	}
-
-	return y;
-};
-
-/** @type {Object.<FloatingUIPlacement, AppearOrigin>} */
-const PLACEMENT_TO_ANIMATION_ORIGIN_MAP = {
-	top: 'bottom',
-	'top-start': 'bottom left',
-	'top-end': 'bottom right',
-	right: 'middle left',
-	'right-start': 'top left',
-	'right-end': 'bottom left',
-	bottom: 'top',
-	'bottom-start': 'top left',
-	'bottom-end': 'top right',
-	left: 'middle right',
-	'left-start': 'top right',
-	'left-end': 'bottom right',
-};
-
-/**
- * Given the floating-ui `placement`, compute the origin used for the entrance
- * animation. The origin should be on the "opposite" side from the placement.
- *
- * @param {FloatingUIPlacement} placement A placement string from floating ui
- * @param {boolean}             rtl
- * @return {AppearOrigin} The Animation origin string
- */
-const placementToAnimationOrigin = ( placement, rtl ) => {
-	/** @type {AppearOrigin} */
-	let animationOrigin =
-		PLACEMENT_TO_ANIMATION_ORIGIN_MAP[ placement ] ?? 'middle';
-
-	if ( rtl && /left/gi.test( animationOrigin ) ) {
-		animationOrigin = animationOrigin.replace( /left/gi, 'right' );
-	} else if ( rtl && /right/gi.test( animationOrigin ) ) {
-		animationOrigin = animationOrigin.replace( /right/gi, 'left' );
-	}
-
-	return animationOrigin;
-};
-
-/**
- * @param {FloatingUIPlacement} placement
- * @return {'top' | 'right' | 'bottom' | 'left'} The side
- */
-export function getSide( placement ) {
-	return placement.split( '-' )[ 0 ];
-}
-
-/**
- * @param {FloatingUIPlacement} placement
- * @return {'x' | 'y'} The axis
- */
-export function getMainAxisFromPlacement( placement ) {
-	return [ 'top', 'bottom' ].includes( getSide( placement ) ) ? 'x' : 'y';
-}
 
 const Popover = (
 	{

--- a/packages/components/src/popover/index.js
+++ b/packages/components/src/popover/index.js
@@ -43,6 +43,11 @@ import { Slot, Fill, useSlot } from '../slot-fill';
 import { getAnimateClassName } from '../animate';
 
 /**
+ * @typedef {import('../animate').AppearOrigin} AppearOrigin
+ * @typedef {import('@floating-ui/react-dom').Placement} FloatingUIPlacement
+ */
+
+/**
  * Name of slot in which popover should fill.
  *
  * @type {string}
@@ -93,33 +98,32 @@ const positionToPlacement = ( position ) => {
 	return y;
 };
 
-// Given the placement, compute the animation origin used for the entrance
-// animation. The origin should the the "opposite" of the placement.
+// Given the floating-ui `placement`, compute the origin used for the entrance
+// animation. The origin should be on the "opposite" side from the placement.
+
+/** @type {Object.<FloatingUIPlacement, AppearOrigin>} */
+const PLACEMENT_TO_ANIMATION_ORIGIN_MAP = {
+	top: 'bottom',
+	'top-start': 'bottom right',
+	'top-end': 'bottom left',
+	right: 'middle left',
+	'right-start': 'bottom left',
+	'right-end': 'top left',
+	bottom: 'top',
+	'bottom-start': 'top right',
+	'bottom-end': 'top left',
+	left: 'middle right',
+	'left-start': 'bottom right',
+	'left-end': 'top right',
+};
+
+/**
+ *
+ * @param {FloatingUIPlacement} placement A placement string from floating ui
+ * @return {AppearOrigin} The Animation origin string
+ */
 const placementToAnimationOrigin = ( placement ) => {
-	const [ placementX, placementY ] = placement.split( '-' );
-
-	let animOriginX, animOriginY;
-	if ( placementX === 'top' || placementX === 'bottom' ) {
-		animOriginX = placementX === 'top' ? 'bottom' : 'top';
-		animOriginY = 'middle';
-		if ( placementY === 'start' ) {
-			animOriginY = 'left';
-		} else if ( placementY === 'end' ) {
-			animOriginY = 'right';
-		}
-	}
-
-	if ( placementX === 'left' || placementX === 'right' ) {
-		animOriginX = 'center';
-		animOriginY = placementX === 'left' ? 'right' : 'left';
-		if ( placementY === 'start' ) {
-			animOriginX = 'top';
-		} else if ( placementY === 'end' ) {
-			animOriginX = 'bottom';
-		}
-	}
-
-	return animOriginX + ' ' + animOriginY;
+	return PLACEMENT_TO_ANIMATION_ORIGIN_MAP[ placement ] ?? 'middle';
 };
 
 const Popover = (

--- a/packages/components/src/popover/index.js
+++ b/packages/components/src/popover/index.js
@@ -75,6 +75,8 @@ const ArrowTriangle = ( props ) => (
 
 const slotNameContext = createContext();
 
+// Converts the `Popover`'s legacy "position" prop to the
+// new "placement" prop (used by `gloating-ui`).
 const positionToPlacement = ( position ) => {
 	const [ x, y, z ] = position.split( ' ' );
 
@@ -91,6 +93,8 @@ const positionToPlacement = ( position ) => {
 	return y;
 };
 
+// Given the placement, compute the animation origin used for the entrance
+// animation. The origin should the the "opposite" of the placement.
 const placementToAnimationOrigin = ( placement ) => {
 	const [ placementX, placementY ] = placement.split( '-' );
 
@@ -281,12 +285,17 @@ const Popover = (
 	} );
 
 	const {
+		// Positioning coordinates
 		x,
 		y,
+		// Callback refs *not regular refs) This allows the position to be updated
+		// when either elements change.
 		reference,
 		floating,
-		strategy,
+		// Object with "regular" refs to both "reference" and "floating"
 		refs,
+		// Type of CSS position property to use (absolute or fixed)
+		strategy,
 		update,
 		placement: computedPlacement,
 		middlewareData: { arrow: arrowData = {} },
@@ -415,6 +424,7 @@ const Popover = (
 					  }
 			}
 		>
+			{ /* Prevents scroll on the document */ }
 			{ isExpanded && <ScrollLock /> }
 			{ isExpanded && (
 				<div className="components-popover__header">

--- a/packages/components/src/popover/index.js
+++ b/packages/components/src/popover/index.js
@@ -33,6 +33,7 @@ import {
 import { close } from '@wordpress/icons';
 import deprecated from '@wordpress/deprecated';
 import { Path, SVG } from '@wordpress/primitives';
+import { isRTL } from '@wordpress/i18n';
 
 /**
  * Internal dependencies
@@ -120,10 +121,21 @@ const PLACEMENT_TO_ANIMATION_ORIGIN_MAP = {
 /**
  *
  * @param {FloatingUIPlacement} placement A placement string from floating ui
+ * @param {boolean}             rtl
  * @return {AppearOrigin} The Animation origin string
  */
-const placementToAnimationOrigin = ( placement ) => {
-	return PLACEMENT_TO_ANIMATION_ORIGIN_MAP[ placement ] ?? 'middle';
+const placementToAnimationOrigin = ( placement, rtl ) => {
+	/** @type {AppearOrigin} */
+	let animationOrigin =
+		PLACEMENT_TO_ANIMATION_ORIGIN_MAP[ placement ] ?? 'middle';
+
+	if ( rtl && /left/gi.test( animationOrigin ) ) {
+		animationOrigin = animationOrigin.replace( /left/gi, 'right' );
+	} else if ( rtl && /right/gi.test( animationOrigin ) ) {
+		animationOrigin = animationOrigin.replace( /right/gi, 'left' );
+	}
+
+	return animationOrigin;
 };
 
 const Popover = (
@@ -420,7 +432,7 @@ const Popover = (
 		!! animate &&
 		getAnimateClassName( {
 			type: 'appear',
-			origin: placementToAnimationOrigin( computedPlacement ),
+			origin: placementToAnimationOrigin( computedPlacement, isRTL() ),
 		} );
 
 	const mergedFloatingRef = useMergeRefs( [

--- a/packages/components/src/popover/index.js
+++ b/packages/components/src/popover/index.js
@@ -373,7 +373,7 @@ const Popover = (
 		);
 	}, [ anchorRef, anchorRect, getAnchorRect ] );
 
-	// This is only needed for a smoth transition when moving blocks.
+	// This is only needed for a smooth transition when moving blocks.
 	useLayoutEffect( () => {
 		if ( ! __unstableObserveElement ) {
 			return;

--- a/packages/components/src/popover/index.js
+++ b/packages/components/src/popover/index.js
@@ -143,7 +143,7 @@ const Popover = (
 		__unstableShift = false,
 		...contentProps
 	},
-	ref
+	forwardedRef
 ) => {
 	if ( range ) {
 		deprecated( 'range prop in Popover component', {
@@ -154,6 +154,7 @@ const Popover = (
 
 	const arrowRef = useRef( null );
 	const anchorRefFallback = useRef( null );
+
 	const isMobileViewport = useViewportMatch( 'medium', '<' );
 	const isExpanded = expandOnMobile && isMobileViewport;
 	const hasArrow = ! isExpanded && ! noArrow;
@@ -291,8 +292,6 @@ const Popover = (
 		middlewareData: { arrow: arrowData = {} },
 	} = useFloating( { placement: normalizedPlacementProp, middleware } );
 
-	const mergedRefs = useMergeRefs( [ floating, dialogRef, ref ] );
-
 	// Updates references
 	useLayoutEffect( () => {
 		// No ref or position have been passed
@@ -380,6 +379,12 @@ const Popover = (
 			origin: placementToAnimationOrigin( computedPlacement ),
 		} );
 
+	const mergedFloatingRef = useMergeRefs( [
+		floating,
+		dialogRef,
+		forwardedRef,
+	] );
+
 	// Disable reason: We care to capture the _bubbled_ events from inputs
 	// within popover as inferring close intent.
 
@@ -397,7 +402,7 @@ const Popover = (
 				}
 			) }
 			{ ...contentProps }
-			ref={ mergedRefs }
+			ref={ mergedFloatingRef }
 			{ ...dialogProps }
 			tabIndex="-1"
 			style={

--- a/packages/components/src/popover/index.js
+++ b/packages/components/src/popover/index.js
@@ -474,7 +474,7 @@ const Popover = (
 					ref={ arrowRef }
 					className={ [
 						'components-popover__arrow',
-						`is-${ placementData.split( '-' )[ 0 ] }`,
+						`is-${ computedPlacement.split( '-' )[ 0 ] }`,
 					].join( ' ' ) }
 					style={ {
 						left: Number.isFinite( arrowData?.x )

--- a/packages/components/src/popover/index.js
+++ b/packages/components/src/popover/index.js
@@ -92,30 +92,30 @@ const positionToPlacement = ( position ) => {
 };
 
 const placementToAnimationOrigin = ( placement ) => {
-	const [ a, b ] = placement.split( '-' );
+	const [ placementX, placementY ] = placement.split( '-' );
 
-	let x, y;
-	if ( a === 'top' || a === 'bottom' ) {
-		x = a === 'top' ? 'bottom' : 'top';
-		y = 'middle';
-		if ( b === 'start' ) {
-			y = 'left';
-		} else if ( b === 'end' ) {
-			y = 'right';
+	let animOriginX, animOriginY;
+	if ( placementX === 'top' || placementX === 'bottom' ) {
+		animOriginX = placementX === 'top' ? 'bottom' : 'top';
+		animOriginY = 'middle';
+		if ( placementY === 'start' ) {
+			animOriginY = 'left';
+		} else if ( placementY === 'end' ) {
+			animOriginY = 'right';
 		}
 	}
 
-	if ( a === 'left' || a === 'right' ) {
-		x = 'center';
-		y = a === 'left' ? 'right' : 'left';
-		if ( b === 'start' ) {
-			x = 'top';
-		} else if ( b === 'end' ) {
-			x = 'bottom';
+	if ( placementX === 'left' || placementX === 'right' ) {
+		animOriginX = 'center';
+		animOriginY = placementX === 'left' ? 'right' : 'left';
+		if ( placementY === 'start' ) {
+			animOriginX = 'top';
+		} else if ( placementY === 'end' ) {
+			animOriginX = 'bottom';
 		}
 	}
 
-	return x + ' ' + y;
+	return animOriginX + ' ' + animOriginY;
 };
 
 const Popover = (

--- a/packages/components/src/popover/index.js
+++ b/packages/components/src/popover/index.js
@@ -371,7 +371,7 @@ const Popover = (
 			refs.floating.current,
 			update
 		);
-	}, [ anchorRef, anchorRect, getAnchorRect ] );
+	}, [ anchorRef, anchorRect, getAnchorRect, reference, update ] );
 
 	// This is only needed for a smooth transition when moving blocks.
 	useLayoutEffect( () => {

--- a/packages/components/src/popover/index.js
+++ b/packages/components/src/popover/index.js
@@ -400,7 +400,8 @@ const Popover = (
 		};
 	}, [ __unstableObserveElement ] );
 
-	// If we're using getAnchorRect, we need to update the position as we scroll the iframe.
+	// If the reference element is in a different ownerDocument (e.g. iFrame),
+	// we need to manually update the floating's position on scroll.
 	useLayoutEffect( () => {
 		if ( ownerDocument === document ) {
 			return;

--- a/packages/components/src/popover/test/__snapshots__/index.js.snap
+++ b/packages/components/src/popover/test/__snapshots__/index.js.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`Popover should pass additional props to portaled element 1`] = `
+exports[`Popover Component should pass additional props to portaled element 1`] = `
 <span>
   <div
     class="components-popover components-animate__appear is-from-left is-from-top"
@@ -17,7 +17,7 @@ exports[`Popover should pass additional props to portaled element 1`] = `
 </span>
 `;
 
-exports[`Popover should render content 1`] = `
+exports[`Popover Component should render content 1`] = `
 <span>
   <div
     class="components-popover components-animate__appear is-from-left is-from-top"

--- a/packages/components/src/popover/test/index.js
+++ b/packages/components/src/popover/test/index.js
@@ -12,58 +12,83 @@ import { useRef } from '@wordpress/element';
  * Internal dependencies
  */
 import Popover from '../';
+import { positionToPlacement } from '../utils';
 
 describe( 'Popover', () => {
-	afterEach( () => {
-		if ( document.activeElement ) {
-			document.activeElement.blur();
-		}
-	} );
-
-	it( 'should allow focus-on-open behavior to be disabled', () => {
-		expect( document.activeElement ).toBe( document.body );
-
-		act( () => {
-			render( <Popover focusOnMount={ false } /> );
-
-			jest.advanceTimersByTime( 1 );
+	describe( 'Component', () => {
+		afterEach( () => {
+			if ( document.activeElement ) {
+				document.activeElement.blur();
+			}
 		} );
 
-		expect( document.activeElement ).toBe( document.body );
-	} );
+		it( 'should allow focus-on-open behavior to be disabled', () => {
+			expect( document.activeElement ).toBe( document.body );
 
-	it( 'should render content', () => {
-		let result;
-		act( () => {
-			result = render( <Popover>Hello</Popover> );
+			act( () => {
+				render( <Popover focusOnMount={ false } /> );
+
+				jest.advanceTimersByTime( 1 );
+			} );
+
+			expect( document.activeElement ).toBe( document.body );
 		} );
 
-		expect( result.container.querySelector( 'span' ) ).toMatchSnapshot();
-	} );
+		it( 'should render content', () => {
+			let result;
+			act( () => {
+				result = render( <Popover>Hello</Popover> );
+			} );
 
-	it( 'should pass additional props to portaled element', () => {
-		let result;
-		act( () => {
-			result = render( <Popover role="tooltip">Hello</Popover> );
+			expect(
+				result.container.querySelector( 'span' )
+			).toMatchSnapshot();
 		} );
 
-		expect( result.container.querySelector( 'span' ) ).toMatchSnapshot();
+		it( 'should pass additional props to portaled element', () => {
+			let result;
+			act( () => {
+				result = render( <Popover role="tooltip">Hello</Popover> );
+			} );
+
+			expect(
+				result.container.querySelector( 'span' )
+			).toMatchSnapshot();
+		} );
+
+		it( 'should render correctly when anchorRef is provided', () => {
+			const PopoverWithAnchor = ( args ) => {
+				const anchorRef = useRef( null );
+
+				return (
+					<div>
+						<p ref={ anchorRef }>Anchor</p>
+						<Popover { ...args } anchorRef={ anchorRef } />
+					</div>
+				);
+			};
+
+			render( <PopoverWithAnchor>Popover content</PopoverWithAnchor> );
+
+			expect( screen.getByText( 'Popover content' ) ).toBeInTheDocument();
+		} );
 	} );
 
-	it( 'should render correctly when anchorRef is provided', () => {
-		const PopoverWithAnchor = ( args ) => {
-			const anchorRef = useRef( null );
-
-			return (
-				<div>
-					<p ref={ anchorRef }>Anchor</p>
-					<Popover { ...args } anchorRef={ anchorRef } />
-				</div>
+	describe( 'positionToPlacement', () => {
+		it.each( [
+			[ 'top left', 'top-end' ],
+			[ 'top center', 'top' ],
+			[ 'top right', 'top-start' ],
+			[ 'middle left', 'left' ],
+			[ 'middle center', 'center' ],
+			[ 'middle right', 'right' ],
+			[ 'bottom left', 'bottom-end' ],
+			[ 'bottom center', 'bottom' ],
+			[ 'bottom right', 'bottom-start' ],
+		] )( 'converts `%s` to `%s`', ( inputPosition, expectedPlacement ) => {
+			expect( positionToPlacement( inputPosition ) ).toEqual(
+				expectedPlacement
 			);
-		};
-
-		render( <PopoverWithAnchor>Popover content</PopoverWithAnchor> );
-
-		expect( screen.getByText( 'Popover content' ) ).toBeInTheDocument();
+		} );
 	} );
 } );

--- a/packages/components/src/popover/utils.js
+++ b/packages/components/src/popover/utils.js
@@ -1,0 +1,91 @@
+/**
+ * @typedef {import('../animate').AppearOrigin} AppearOrigin
+ * @typedef {import('@floating-ui/react-dom').Placement} FloatingUIPlacement
+ * @typedef {	'top left' | 'top center' | 'top right' | 'middle left' | 'middle center' | 'middle right' | 'bottom left' | 'bottom center' | 'bottom right' | 'bottom left' | 'bottom center' | 'bottom right' } LegacyPosition
+ */
+
+/**
+ * Converts the `Popover`'s legacy "position" prop to the new "placement" prop
+ * (used by `floating-ui`).
+ *
+ * @param {LegacyPosition} position The legacy position
+ * @return {FloatingUIPlacement} The corresponding placement
+ */
+export const positionToPlacement = ( position ) => {
+	const [ x, y, z ] = position.split( ' ' );
+
+	if ( [ 'top', 'bottom' ].includes( x ) ) {
+		let suffix = '';
+		if ( ( !! z && z === 'left' ) || y === 'right' ) {
+			suffix = '-start';
+		} else if ( ( !! z && z === 'right' ) || y === 'left' ) {
+			suffix = '-end';
+		}
+
+		// @ts-ignore
+		return x + suffix;
+	}
+
+	// @ts-ignore
+	return y;
+};
+
+/** @type {Object.<FloatingUIPlacement, AppearOrigin>} */
+const PLACEMENT_TO_ANIMATION_ORIGIN_MAP = {
+	top: 'bottom',
+	'top-start': 'bottom left',
+	'top-end': 'bottom right',
+	right: 'middle left',
+	'right-start': 'top left',
+	'right-end': 'bottom left',
+	bottom: 'top',
+	'bottom-start': 'top left',
+	'bottom-end': 'top right',
+	left: 'middle right',
+	'left-start': 'top right',
+	'left-end': 'bottom right',
+};
+
+/**
+ * Given the floating-ui `placement`, compute the origin used for the entrance
+ * animation. The origin should be on the "opposite" side from the placement.
+ *
+ * @param {FloatingUIPlacement} placement A placement string from floating ui
+ * @param {boolean}             rtl
+ * @return {AppearOrigin} The Animation origin string
+ */
+export const placementToAnimationOrigin = ( placement, rtl ) => {
+	/** @type {AppearOrigin} */
+	let animationOrigin =
+		PLACEMENT_TO_ANIMATION_ORIGIN_MAP[ placement ] ?? 'middle';
+
+	if ( rtl && /left/gi.test( animationOrigin ) ) {
+		/** @type {AppearOrigin} */
+		animationOrigin = /** @type {AppearOrigin} */ (
+			animationOrigin.replace( /left/gi, 'right' )
+		);
+	} else if ( rtl && /right/gi.test( animationOrigin ) ) {
+		animationOrigin = /** @type {AppearOrigin} */ (
+			animationOrigin.replace( /right/gi, 'left' )
+		);
+	}
+
+	return animationOrigin;
+};
+
+/**
+ * @param {FloatingUIPlacement} placement
+ * @return {'top' | 'right' | 'bottom' | 'left'} The side
+ */
+function getSide( placement ) {
+	// @ts-ignore
+	return placement.split( '-' )[ 0 ];
+}
+
+/**
+ * @param {FloatingUIPlacement} placement
+ * @return {'x' | 'y'} The axis
+ */
+export function getMainAxisFromPlacement( placement ) {
+	return [ 'top', 'bottom' ].includes( getSide( placement ) ) ? 'x' : 'y';
+}


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

The main changes in this PR are:
- refactored the custom `frameOffset` middleware to use the `offset` middleware instead of manually adding up `x` and `y` coordinates
- refined the logic in the `limitShift()` floating UI's option, in order to allow the floating element to fully shift past its reference when scrolling down in the site editor 
- added a default value to the `__unstableForcePosition` prop 
- added an exhaustive set of dependencies to the `useLayoutEffect` hook in the `Popover` component 
- the remaining changes are variable renames and inline comments that I found myself changing while understanding more about how `Popover` works

You can refer to the individual commits for an easier review of the changes.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

(partially) fixes the regression flagged in #41575

alternative approach to #42417 and #42521

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->

So far, I've only tested these changes with the block toolbar in the site editor and post editor.
We should definitely test more throughly and across all different popover usages, but first I'd first like to establish if this is a potentially good approach, before investing more time in it

## Screenshots or screencast <!-- if applicable -->

https://user-images.githubusercontent.com/1083581/179748774-82043f59-5567-4440-b26b-e28b06fb4c8c.mp4


