### PR TITLE
[Mobile] - Runner config - Update Xcode to 13.2.1

### DIFF
--- a/.github/workflows/rnmobile-ios-runner.yml
+++ b/.github/workflows/rnmobile-ios-runner.yml
@@ -18,7 +18,7 @@ jobs:
         if: ${{ github.repository == 'WordPress/gutenberg' || github.event_name == 'pull_request' }}
         strategy:
             matrix:
-                xcode: ['13.0']
+                xcode: ['13.2.1']
                 device: ['iPhone 11']
                 native-test-name: [gutenberg-editor-initial-html]
 


### PR DESCRIPTION
Related PRs:
- `Gutenberg Mobile` -> https://github.com/wordpress-mobile/gutenberg-mobile/pull/5035

## What?
This PR updates the Xcode version to `13.2.1`, the [latest available](https://github.com/actions/virtual-environments/blob/main/images/macos/macos-11-Readme.md#xcode) for our current `macos-11` environment in CI.

## Why?
To prevent future Xcode deprecations and to use the same version as we are using in development.

## How?
By updating the version in the runner's config.

## Testing Instructions

CI checks should pass correctly.

## Screenshots or screencast <!-- if applicable -->
N/A