### PR TITLE
AnglePickerControl: Fix gap between elements in RTL mode

### DIFF
--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+## Bug Fix
+
+-   `AnglePickerControl`: Fix gap between elements in RTL mode ([#42534](https://github.com/WordPress/gutenberg/pull/42534)).
+
 ### Enhancements
 
 -   `BorderControl`: Improve labelling, tooltips and DOM structure ([#42348](https://github.com/WordPress/gutenberg/pull/42348/)).

--- a/packages/components/src/angle-picker-control/index.js
+++ b/packages/components/src/angle-picker-control/index.js
@@ -34,7 +34,7 @@ export default function AnglePickerControl( {
 	const classes = classnames( 'components-angle-picker-control', className );
 
 	return (
-		<Root className={ classes }>
+		<Root className={ classes } gap={ 4 }>
 			<FlexBlock>
 				<NumberControl
 					label={ label }
@@ -62,7 +62,6 @@ export default function AnglePickerControl( {
 			</FlexBlock>
 			<FlexItem
 				style={ {
-					marginLeft: space( 4 ),
 					marginBottom: space( 1 ),
 					marginTop: 'auto',
 				} }


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
The `AnglePickerControl` uses inline css to define the space between the elements instead of using the build in gap prop of the `Flex` component. The result of this is that in RTL mode there is a space to the left of the component and the gap is not the same.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
Makes the gap the same in LTR and RTL.

## How?
Use build-in gap feature in `Flex` to define the gap.

## Testing Instructions
1. Fire up storybook and go the the `AnglePickerControl`.
2. Check that the gap in the same in RTL and LTR mode.
3. Check that there is no extra margin to the left of the component in RTL mode.
