### PR TITLE
Docs: Add `variations` key to `block.json` JSON schema definition

### DIFF
--- a/docs/reference-guides/block-api/block-metadata.md
+++ b/docs/reference-guides/block-api/block-metadata.md
@@ -40,6 +40,15 @@ Starting in WordPress 5.8 release, we encourage using the `block.json` metadata 
 			"message": "This is a notice!"
 		}
 	},
+	"variations": [
+		{
+			"name": "example",
+			"title": "Example",
+			"attributes": {
+				"message": "This is an example!"
+			},
+		}
+	]
 	"editorScript": "file:./build/index.js",
 	"script": "file:./build/script.js",
 	"viewScript": "file:./build/view.js",

--- a/docs/reference-guides/block-api/block-metadata.md
+++ b/docs/reference-guides/block-api/block-metadata.md
@@ -436,6 +436,7 @@ See the [the example documentation](/docs/reference-guides/block-api/block-regis
 - Optional
 - Localized: Yes (`title`, `description`, and `keywords` of each variation only)
 - Property: `variations`
+- Since: `WordPress 5.9.0`
 
 ```json
 {

--- a/docs/reference-guides/block-api/block-metadata.md
+++ b/docs/reference-guides/block-api/block-metadata.md
@@ -421,6 +421,34 @@ It provides structured example data for the block. This data is used to construc
 
 See the [the example documentation](/docs/reference-guides/block-api/block-registration.md#example-optional) for more details.
 
+### Variations
+
+- Type: `array`
+- Optional
+- Localized: Yes (`title`, `description`, and `keywords` of each variation only)
+- Property: `variations`
+
+```json
+{
+	"variations": [
+		{
+			"name": "example",
+			"title": "Example",
+			"attributes": {
+				"level": 2,
+				"message": "This is an example!"
+			},
+			"scope": [ "block" ],
+			"isActive": [ "level" ]
+		}
+	]
+}
+```
+
+_Note: JavaScript functions (isActive) and React elements (icon) can't be used in block.json_
+
+See the [the variations documentation](/docs/reference-guides/block-api/block-variations.md) for more details.
+
 ### Editor Script
 
 -   Type: `WPDefinedAsset` ([learn more](#wpdefinedasset))

--- a/docs/reference-guides/block-api/block-metadata.md
+++ b/docs/reference-guides/block-api/block-metadata.md
@@ -423,7 +423,7 @@ See the [the example documentation](/docs/reference-guides/block-api/block-regis
 
 ### Variations
 
-- Type: `array`
+- Type: `object[]`
 - Optional
 - Localized: Yes (`title`, `description`, and `keywords` of each variation only)
 - Property: `variations`
@@ -445,7 +445,9 @@ See the [the example documentation](/docs/reference-guides/block-api/block-regis
 }
 ```
 
-_Note: JavaScript functions (isActive) and React elements (icon) can't be used in block.json_
+Block Variations is the API that allows a block to have similar versions of it, but all these versions share some common functionality. Each block variation is differentiated from the others by setting some initial attributes or inner blocks. Then at the time when a block is inserted these attributes and/or inner blocks are applied.
+
+_Note: In JavaScript you can provide a function for the `isActive` property, and a React element for the `icon`. In the `block.json` file both only support strings_
 
 See the [the variations documentation](/docs/reference-guides/block-api/block-variations.md) for more details.
 

--- a/schemas/json/block.json
+++ b/schemas/json/block.json
@@ -504,8 +504,22 @@
 						"description": "A detailed variation description."
 					},
 					"category": {
-						"type": "string",
-						"description": "A category classification, used in search interfaces to arrange block types by category."
+						"description": "A category classification, used in search interfaces to arrange block types by category.",
+						"anyOf": [
+							{
+								"type": "string"
+							},
+							{
+								"enum": [
+									"text",
+									"media",
+									"design",
+									"widgets",
+									"theme",
+									"embed"
+								]
+							}
+						]
 					},
 					"icon": {
 						"description": "An icon helping to visualize the variation. It can have the same shape as the block type.",

--- a/schemas/json/block.json
+++ b/schemas/json/block.json
@@ -523,14 +523,7 @@
 					},
 					"icon": {
 						"description": "An icon helping to visualize the variation. It can have the same shape as the block type.",
-						"oneOf": [
-							{
-								"type": "string"
-							},
-							{
-								"type": "object"
-							}
-						]
+						"type": "string"
 					},
 					"isDefault": {
 						"type": "boolean",

--- a/schemas/json/block.json
+++ b/schemas/json/block.json
@@ -482,6 +482,86 @@
 					}
 				}
 			]
+		},
+		"variations": {
+			"type": "array",
+			"description": "Block Variations is the API that allows a block to have similar versions of it, but all these versions share some common functionality.",
+			"items": {
+				"type": "object",
+				"required": [ "name", "title" ],
+				"additionalProperties": false,
+				"properties": {
+					"name": {
+						"type": "string",
+						"description": "The unique and machine-readable name."
+					},
+					"title": {
+						"type": "string",
+						"description": "A human-readable variation title."
+					},
+					"description": {
+						"type": "string",
+						"description": "A detailed variation description."
+					},
+					"category": {
+						"type": "string",
+						"description": "A category classification, used in search interfaces to arrange block types by category."
+					},
+					"icon": {
+						"description": "An icon helping to visualize the variation. It can have the same shape as the block type.",
+						"oneOf": [
+							{
+								"type": "string"
+							},
+							{
+								"type": "object"
+							}
+						]
+					},
+					"isDefault": {
+						"type": "boolean",
+						"default": false,
+						"description": "Indicates whether the current variation is the default one."
+					},
+					"attributes": {
+						"type": "object",
+						"description": "Values that override block attributes."
+					},
+					"innerBlocks": {
+						"type": "array",
+						"items": {
+							"type": "array"
+						},
+						"description": "Initial configuration of nested blocks."
+					},
+					"example": {
+						"type": "object",
+						"description": "Example provides structured data for the block preview. You can set to undefined to disable the preview shown for the block type."
+					},
+					"scope": {
+						"type": "array",
+						"description": "The list of scopes where the variation is applicable.",
+						"items": {
+							"enum": [ "inserter", "block", "transform" ]
+						},
+						"default": [ "inseter", "block" ]
+					},
+					"keywords": {
+						"type": "array",
+						"description": "An array of terms (which can be translated) that help users discover the variation while searching.",
+						"items": {
+							"type": "string"
+						}
+					},
+					"isActive": {
+						"type": "array",
+						"items": {
+							"type": "string"
+						},
+						"description": "The list of attributes that should be compared. Each attributes will be matched and the variation will be active if all of them are matching."
+					}
+				}
+			}
 		}
 	},
 	"required": [ "name", "title" ],


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->
Add the `variations` key with all of its available sub properties to the `block.json` JSON schema.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

The JSON Schemas are great because they greatly improve the Developer Experience of working with custom blocks. However, they aren't of much use if they are not including all the options that are actually available. 

Closes #40490.
Part of #41236.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->

_will update this once the initial testing passes_
