### PR TITLE
Layout: Add a disable-layout-styles theme supports flag to opt out of all layout styles

### DIFF
--- a/docs/how-to-guides/themes/theme-support.md
+++ b/docs/how-to-guides/themes/theme-support.md
@@ -305,6 +305,18 @@ add_theme_support( 'disable-custom-gradients' );
 
 When set, users will be restricted to the default gradients provided in the block editor or the gradients provided via the `editor-gradient-presets` theme support setting.
 
+### Disabling base layout styles
+
+_**Note:** Since WordPress 6.1._
+
+Themes can opt out of generated block layout styles that provide default structural styles for core blocks including Group, Columns, Buttons, and Social Icons. By using the following code, these themes commit to providing their own structural styling, as using this feature will result in core blocks displaying incorrectly in both the editor and site frontend:
+
+```php
+add_theme_support( 'disable-layout-styles' );
+```
+
+For themes looking to customize `blockGap` styles or block spacing, see [the developer docs on Global Settings & Styles](/docs/how-to-guides/themes/theme-json/#what-is-blockgap-and-how-can-i-use-it).
+
 ### Supporting custom line heights
 
 Some blocks like paragraph and headings support customizing the line height. Themes can enable support for this feature with the following code:

--- a/lib/block-supports/layout.php
+++ b/lib/block-supports/layout.php
@@ -241,15 +241,18 @@ function gutenberg_render_layout_support_flag( $block_content, $block ) {
 	$fallback_gap_value = _wp_array_get( $block_type->supports, array( 'spacing', 'blockGap', '__experimentalDefault' ), '0.5em' );
 	$block_spacing      = _wp_array_get( $block, array( 'attrs', 'style', 'spacing' ), null );
 
-	// If a block's block.json skips serialization for spacing or spacing.blockGap,
-	// don't apply the user-defined value to the styles.
-	$should_skip_gap_serialization = gutenberg_should_skip_block_supports_serialization( $block_type, 'spacing', 'blockGap' );
-	$style                         = gutenberg_get_layout_style( ".$block_classname.$container_class", $used_layout, $has_block_gap_support, $gap_value, $should_skip_gap_serialization, $fallback_gap_value, $block_spacing );
+	// Only generate Layout styles if the theme has not opted-out.
+	if ( ! current_theme_supports( 'disable-layout-styles' ) ) {
+		// If a block's block.json skips serialization for spacing or spacing.blockGap,
+		// don't apply the user-defined value to the styles.
+		$should_skip_gap_serialization = gutenberg_should_skip_block_supports_serialization( $block_type, 'spacing', 'blockGap' );
+		$style                         = gutenberg_get_layout_style( ".$block_classname.$container_class", $used_layout, $has_block_gap_support, $gap_value, $should_skip_gap_serialization, $fallback_gap_value, $block_spacing );
 
-	// Only add container class and enqueue block support styles if unique styles were generated.
-	if ( ! empty( $style ) ) {
-		$class_names[] = $container_class;
-		wp_enqueue_block_support_styles( $style );
+		// Only add container class and enqueue block support styles if unique styles were generated.
+		if ( ! empty( $style ) ) {
+			$class_names[] = $container_class;
+			wp_enqueue_block_support_styles( $style );
+		}
 	}
 
 	// This assumes the hook only applies to blocks with a single wrapper.

--- a/lib/block-supports/layout.php
+++ b/lib/block-supports/layout.php
@@ -226,23 +226,25 @@ function gutenberg_render_layout_support_flag( $block_content, $block ) {
 		$class_names[] = sanitize_title( $layout_classname );
 	}
 
-	$gap_value = _wp_array_get( $block, array( 'attrs', 'style', 'spacing', 'blockGap' ) );
-	// Skip if gap value contains unsupported characters.
-	// Regex for CSS value borrowed from `safecss_filter_attr`, and used here
-	// because we only want to match against the value, not the CSS attribute.
-	if ( is_array( $gap_value ) ) {
-		foreach ( $gap_value as $key => $value ) {
-			$gap_value[ $key ] = $value && preg_match( '%[\\\(&=}]|/\*%', $value ) ? null : $value;
-		}
-	} else {
-		$gap_value = $gap_value && preg_match( '%[\\\(&=}]|/\*%', $gap_value ) ? null : $gap_value;
-	}
-
-	$fallback_gap_value = _wp_array_get( $block_type->supports, array( 'spacing', 'blockGap', '__experimentalDefault' ), '0.5em' );
-	$block_spacing      = _wp_array_get( $block, array( 'attrs', 'style', 'spacing' ), null );
-
 	// Only generate Layout styles if the theme has not opted-out.
+	// Attribute-based Layout classnames are output in all cases.
 	if ( ! current_theme_supports( 'disable-layout-styles' ) ) {
+
+		$gap_value = _wp_array_get( $block, array( 'attrs', 'style', 'spacing', 'blockGap' ) );
+		// Skip if gap value contains unsupported characters.
+		// Regex for CSS value borrowed from `safecss_filter_attr`, and used here
+		// because we only want to match against the value, not the CSS attribute.
+		if ( is_array( $gap_value ) ) {
+			foreach ( $gap_value as $key => $value ) {
+				$gap_value[ $key ] = $value && preg_match( '%[\\\(&=}]|/\*%', $value ) ? null : $value;
+			}
+		} else {
+			$gap_value = $gap_value && preg_match( '%[\\\(&=}]|/\*%', $gap_value ) ? null : $gap_value;
+		}
+
+		$fallback_gap_value = _wp_array_get( $block_type->supports, array( 'spacing', 'blockGap', '__experimentalDefault' ), '0.5em' );
+		$block_spacing      = _wp_array_get( $block, array( 'attrs', 'style', 'spacing' ), null );
+
 		// If a block's block.json skips serialization for spacing or spacing.blockGap,
 		// don't apply the user-defined value to the styles.
 		$should_skip_gap_serialization = gutenberg_should_skip_block_supports_serialization( $block_type, 'spacing', 'blockGap' );

--- a/lib/compat/wordpress-6.1/block-editor-settings.php
+++ b/lib/compat/wordpress-6.1/block-editor-settings.php
@@ -171,6 +171,7 @@ function gutenberg_get_block_editor_settings( $settings ) {
 	}
 
 	$settings['localAutosaveInterval'] = 15;
+	$settings['disableLayoutStyles']   = current_theme_supports( 'disable-layout-styles' );
 
 	return $settings;
 }

--- a/lib/compat/wordpress-6.1/class-wp-theme-json-6-1.php
+++ b/lib/compat/wordpress-6.1/class-wp-theme-json-6-1.php
@@ -1252,6 +1252,11 @@ class WP_Theme_JSON_6_1 extends WP_Theme_JSON_6_0 {
 		$block_rules = '';
 		$block_type  = null;
 
+		// Skip outputting layout styles if explicitly disabled.
+		if ( current_theme_supports( 'disable-layout-styles' ) ) {
+			return $block_rules;
+		}
+
 		if ( isset( $block_metadata['name'] ) ) {
 			$block_type = WP_Block_Type_Registry::get_instance()->get_registered( $block_metadata['name'] );
 			if ( ! block_has_support( $block_type, array( '__experimentalLayout' ), false ) ) {

--- a/lib/compat/wordpress-6.1/theme.php
+++ b/lib/compat/wordpress-6.1/theme.php
@@ -1,0 +1,31 @@
+<?php
+/**
+ * Temporary compatibility shims for features present in Gutenberg.
+ * This file should be removed when WordPress 6.1.0 becomes the lowest
+ * supported version by this plugin.
+ *
+ * @package gutenberg
+ */
+
+/**
+ * This function runs in addition to the core `create_initial_theme_features`.
+ * The 6.1 release needs to update the core function to include the body of this function.
+ *
+ * Creates the initial theme features when the 'setup_theme' action is fired.
+ *
+ * See {@see 'setup_theme'}.
+ *
+ * @since 5.5.0
+ * @since 6.0.1 The `block-templates` feature was added.
+ * @since 6.1.0 The `disable-layout-styles` feature was added.
+ */
+function gutenberg_create_initial_theme_features() {
+	register_theme_feature(
+		'disable-layout-styles',
+		array(
+			'description'  => __( 'Whether the theme disables generated layout styles.', 'gutenberg' ),
+			'show_in_rest' => true,
+		)
+	);
+}
+add_action( 'setup_theme', 'gutenberg_create_initial_theme_features', 0 );

--- a/lib/experimental/class-wp-rest-block-editor-settings-controller.php
+++ b/lib/experimental/class-wp-rest-block-editor-settings-controller.php
@@ -204,6 +204,12 @@ class WP_REST_Block_Editor_Settings_Controller extends WP_REST_Controller {
 					'context'     => array( 'post-editor', 'site-editor', 'widgets-editor' ),
 				),
 
+				'disableLayoutStyles'                    => array(
+					'description' => __( 'Disables output of layout styles.', 'gutenberg' ),
+					'type'        => 'boolean',
+					'context'     => array( 'post-editor', 'site-editor', 'widgets-editor' ),
+				),
+
 				'enableCustomLineHeight'                 => array(
 					'description' => __( 'Enables custom line height.', 'gutenberg' ),
 					'type'        => 'boolean',

--- a/lib/load.php
+++ b/lib/load.php
@@ -88,6 +88,7 @@ require __DIR__ . '/compat/wordpress-6.1/script-loader.php';
 require __DIR__ . '/compat/wordpress-6.1/date-settings.php';
 require __DIR__ . '/compat/wordpress-6.1/block-patterns.php';
 require __DIR__ . '/compat/wordpress-6.1/edit-form-blocks.php';
+require __DIR__ . '/compat/wordpress-6.1/theme.php';
 
 // Experimental features.
 remove_action( 'plugins_loaded', '_wp_theme_json_webfonts_handler' ); // Turns off WP 6.0's stopgap handler for Webfonts API.

--- a/packages/block-editor/src/hooks/layout.js
+++ b/packages/block-editor/src/hooks/layout.js
@@ -84,22 +84,6 @@ function useLayoutClasses( layout, layoutDefinitions ) {
 	return layoutClassnames;
 }
 
-/**
- * Determines whether or not the theme has disabled all layout styles output.
- *
- * This feature only disables the output of layout styles,
- * the controls for adjusting layout will still be available in the editor.
- * Themes that use this feature commit to providing their own styling for layout features.
- *
- * @return {boolean} Whether or not the theme opts-in to disable all layout styles.
- */
-function useThemeHasDisabledLayoutStyles() {
-	return useSelect( ( select ) => {
-		const { getSettings } = select( blockEditorStore );
-		return !! getSettings().disableLayoutStyles;
-	} );
-}
-
 function LayoutPanel( { setAttributes, attributes, name: blockName } ) {
 	const { layout } = attributes;
 	const defaultThemeLayout = useSetting( 'layout' );
@@ -284,8 +268,12 @@ export const withLayoutStyles = createHigherOrderComponent(
 			name,
 			layoutBlockSupportKey
 		);
+		const disableLayoutStyles = useSelect( ( select ) => {
+			const { getSettings } = select( blockEditorStore );
+			return !! getSettings().disableLayoutStyles;
+		} );
 		const shouldRenderLayoutStyles =
-			hasLayoutBlockSupport && ! useThemeHasDisabledLayoutStyles();
+			hasLayoutBlockSupport && ! disableLayoutStyles;
 		const id = useInstanceId( BlockListBlock );
 		const defaultThemeLayout = useSetting( 'layout' ) || {};
 		const element = useContext( BlockList.__unstableElementContext );

--- a/packages/block-editor/src/hooks/layout.js
+++ b/packages/block-editor/src/hooks/layout.js
@@ -84,6 +84,22 @@ function useLayoutClasses( layout, layoutDefinitions ) {
 	return layoutClassnames;
 }
 
+/**
+ * Determines whether or not the theme has disabled all layout styles output.
+ *
+ * This feature only disables the output of layout styles,
+ * the controls for adjusting layout will still be available in the editor.
+ * Themes that use this feature commit to providing their own styling for layout features.
+ *
+ * @return {boolean} Whether or not the theme opts-in to disable all layout styles.
+ */
+function useThemeHasDisabledLayoutStyles() {
+	return useSelect( ( select ) => {
+		const { getSettings } = select( blockEditorStore );
+		return !! getSettings().disableLayoutStyles;
+	} );
+}
+
 function LayoutPanel( { setAttributes, attributes, name: blockName } ) {
 	const { layout } = attributes;
 	const defaultThemeLayout = useSetting( 'layout' );
@@ -264,10 +280,12 @@ export const withInspectorControls = createHigherOrderComponent(
 export const withLayoutStyles = createHigherOrderComponent(
 	( BlockListBlock ) => ( props ) => {
 		const { name, attributes } = props;
-		const shouldRenderLayoutStyles = hasBlockSupport(
+		const hasLayoutBlockSupport = hasBlockSupport(
 			name,
 			layoutBlockSupportKey
 		);
+		const shouldRenderLayoutStyles =
+			hasLayoutBlockSupport && ! useThemeHasDisabledLayoutStyles();
 		const id = useInstanceId( BlockListBlock );
 		const defaultThemeLayout = useSetting( 'layout' ) || {};
 		const element = useContext( BlockList.__unstableElementContext );
@@ -277,7 +295,7 @@ export const withLayoutStyles = createHigherOrderComponent(
 		const usedLayout = layout?.inherit
 			? defaultThemeLayout
 			: layout || defaultBlockLayout || {};
-		const layoutClasses = shouldRenderLayoutStyles
+		const layoutClasses = hasLayoutBlockSupport
 			? useLayoutClasses( usedLayout, defaultThemeLayout?.definitions )
 			: null;
 		const selector = `.${ getBlockDefaultClassName(

--- a/packages/edit-post/src/components/visual-editor/index.js
+++ b/packages/edit-post/src/components/visual-editor/index.js
@@ -118,13 +118,15 @@ export default function VisualEditor( { styles } ) {
 		( select ) => select( editPostStore ).hasMetaBoxes(),
 		[]
 	);
-	const { themeSupportsLayout, assets } = useSelect( ( select ) => {
-		const _settings = select( blockEditorStore ).getSettings();
-		return {
-			themeSupportsLayout: _settings.supportsLayout,
-			assets: _settings.__unstableResolvedAssets,
-		};
-	}, [] );
+	const { themeHasDisabledLayoutStyles, themeSupportsLayout, assets } =
+		useSelect( ( select ) => {
+			const _settings = select( blockEditorStore ).getSettings();
+			return {
+				themeHasDisabledLayoutStyles: _settings.disableLayoutStyles,
+				themeSupportsLayout: _settings.supportsLayout,
+				assets: _settings.__unstableResolvedAssets,
+			};
+		}, [] );
 	const { clearSelectedBlock } = useDispatch( blockEditorStore );
 	const { setIsEditingTemplate } = useDispatch( editPostStore );
 	const desktopCanvasStyles = {
@@ -241,13 +243,17 @@ export default function VisualEditor( { styles } ) {
 						assets={ assets }
 						style={ { paddingBottom } }
 					>
-						{ themeSupportsLayout && ! isTemplateMode && (
-							<LayoutStyle
-								selector=".edit-post-visual-editor__post-title-wrapper, .block-editor-block-list__layout.is-root-container"
-								layout={ defaultLayout }
-								layoutDefinitions={ defaultLayout?.definitions }
-							/>
-						) }
+						{ themeSupportsLayout &&
+							! themeHasDisabledLayoutStyles &&
+							! isTemplateMode && (
+								<LayoutStyle
+									selector=".edit-post-visual-editor__post-title-wrapper, .block-editor-block-list__layout.is-root-container"
+									layout={ defaultLayout }
+									layoutDefinitions={
+										defaultLayout?.definitions
+									}
+								/>
+							) }
 						{ ! isTemplateMode && (
 							<div
 								className="edit-post-visual-editor__post-title-wrapper"

--- a/packages/edit-site/src/components/global-styles/use-global-styles-output.js
+++ b/packages/edit-site/src/components/global-styles/use-global-styles-output.js
@@ -539,7 +539,7 @@ export const toStyles = (
 	blockSelectors,
 	hasBlockGapSupport,
 	hasFallbackGapSupport,
-	skipLayoutStyles = false
+	disableLayoutStyles = false
 ) => {
 	const nodesWithStyles = getNodesWithStyles( tree, blockSelectors );
 	const nodesWithSettings = getNodesWithSettings( tree, blockSelectors );
@@ -616,7 +616,7 @@ export const toStyles = (
 
 			// Process blockGap and layout styles.
 			if (
-				! skipLayoutStyles &&
+				! disableLayoutStyles &&
 				( ROOT_BLOCK_SELECTOR === selector || hasLayoutSupport )
 			) {
 				ruleset += getLayoutStyles( {
@@ -767,22 +767,6 @@ export const getBlockSelectors = ( blockTypes ) => {
 	return result;
 };
 
-/**
- * Determines whether or not the theme has disabled all layout styles output.
- *
- * This feature only disables the output of layout styles,
- * the controls for adjusting layout will still be available in the editor.
- * Themes that use this feature commit to providing their own styling for layout features.
- *
- * @return {boolean} Whether or not the theme opts-in to disable all layout styles.
- */
-function useThemeHasDisabledLayoutStyles() {
-	return useSelect( ( select ) => {
-		const { getSettings } = select( blockEditorStore );
-		return !! getSettings().disableLayoutStyles;
-	} );
-}
-
 export function useGlobalStylesOutput() {
 	const [ stylesheets, setStylesheets ] = useState( [] );
 	const [ settings, setSettings ] = useState( {} );
@@ -791,7 +775,10 @@ export function useGlobalStylesOutput() {
 	const [ blockGap ] = useSetting( 'spacing.blockGap' );
 	const hasBlockGapSupport = blockGap !== null;
 	const hasFallbackGapSupport = ! hasBlockGapSupport; // This setting isn't useful yet: it exists as a placeholder for a future explicit fallback styles support.
-	const skipLayoutStyles = useThemeHasDisabledLayoutStyles();
+	const disableLayoutStyles = useSelect( ( select ) => {
+		const { getSettings } = select( blockEditorStore );
+		return !! getSettings().disableLayoutStyles;
+	} );
 
 	useEffect( () => {
 		if ( ! mergedConfig?.styles || ! mergedConfig?.settings ) {
@@ -808,7 +795,7 @@ export function useGlobalStylesOutput() {
 			blockSelectors,
 			hasBlockGapSupport,
 			hasFallbackGapSupport,
-			skipLayoutStyles
+			disableLayoutStyles
 		);
 		const filters = toSvgFilters( mergedConfig, blockSelectors );
 		setStylesheets( [
@@ -827,7 +814,7 @@ export function useGlobalStylesOutput() {
 		hasBlockGapSupport,
 		hasFallbackGapSupport,
 		mergedConfig,
-		skipLayoutStyles,
+		disableLayoutStyles,
 	] );
 
 	return [ stylesheets, settings, svgFilters, hasBlockGapSupport ];

--- a/packages/edit-site/src/components/global-styles/use-global-styles-output.js
+++ b/packages/edit-site/src/components/global-styles/use-global-styles-output.js
@@ -823,7 +823,12 @@ export function useGlobalStylesOutput() {
 		] );
 		setSettings( mergedConfig.settings );
 		setSvgFilters( filters );
-	}, [ hasBlockGapSupport, hasFallbackGapSupport, mergedConfig ] );
+	}, [
+		hasBlockGapSupport,
+		hasFallbackGapSupport,
+		mergedConfig,
+		skipLayoutStyles,
+	] );
 
 	return [ stylesheets, settings, svgFilters, hasBlockGapSupport ];
 }

--- a/packages/editor/src/components/provider/use-block-editor-settings.js
+++ b/packages/editor/src/components/provider/use-block-editor-settings.js
@@ -129,6 +129,7 @@ function useBlockEditorSettings( settings, hasTemplate ) {
 				'disableCustomColors',
 				'disableCustomFontSizes',
 				'disableCustomGradients',
+				'disableLayoutStyles',
 				'enableCustomLineHeight',
 				'enableCustomSpacing',
 				'enableCustomUnits',

--- a/phpunit/class-wp-theme-json-test.php
+++ b/phpunit/class-wp-theme-json-test.php
@@ -104,6 +104,37 @@ class WP_Theme_JSON_Gutenberg_Test extends WP_UnitTestCase {
 	}
 
 	/**
+	 * @dataProvider data_get_layout_definitions
+	 *
+	 * @param array $layout_definitions Layout definitions as stored in core theme.json.
+	 */
+	public function test_get_stylesheet_skips_layout_styles( $layout_definitions ) {
+		add_theme_support( 'disable-layout-styles' );
+		$theme_json = new WP_Theme_JSON_Gutenberg(
+			array(
+				'version'  => WP_Theme_JSON_Gutenberg::LATEST_SCHEMA,
+				'settings' => array(
+					'layout'  => array(
+						'definitions' => $layout_definitions,
+					),
+					'spacing' => array(
+						'blockGap' => null,
+					),
+				),
+			),
+			'default'
+		);
+		$stylesheet = $theme_json->get_stylesheet( array( 'base-layout-styles' ) );
+		remove_theme_support( 'disable-layout-styles' );
+
+		// All Layout styles should be skipped.
+		$this->assertEquals(
+			'',
+			$stylesheet
+		);
+	}
+
+	/**
 	 * Data provider.
 	 *
 	 * @return array


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Add a theme support flag to allow themes to opt out of all Layout block support styles via `add_theme_support( 'disable-layout-styles' );`.

A draft dev note for this feature can be found in this comment: https://github.com/WordPress/gutenberg/pull/42544#issuecomment-1198863716

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

As discussed in https://github.com/WordPress/gutenberg/pull/41487#issuecomment-1188326739, https://github.com/WordPress/gutenberg/issues/42333, https://github.com/WordPress/gutenberg/issues/41431 and elsewhere, many themes decided to opt-out of Layout styles altogether via overriding or removing the `'gutenberg_render_layout_support_flag'` filter. This results in two issues:

* It removes classname generation in addition to Layout style output.
* As of https://github.com/WordPress/gutenberg/pull/40875 base layout style generation is moved to the global styles output, so removing the above callback does not remove all Layout styles.

So, this PR proposes providing an explicit approach for themes that wish to opt-out of Layout styles altogether to do so, via `add_theme_support( 'disable-layout-styles' );`. Note that themes that opt-out of Layout styles will then be responsible for providing _all_ CSS styling for block layouts. However, as discussed in related issues, many (particularly Classic themes) expect to do so.

The goal here is to reduce friction caused by the Layout block support, and more explicitly define the expectations of the Layout support.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

* Add a `disable-layout-styles` theme support flag, and expose it in block editor settings, so that it's available in JS.
* Skip outputting all Layout block support styles if this flag is set to `true`, however continue to render semantic classnames. (For themes that _also_ wish to opt-out of semantic classnames, they can do this via also overriding the `'gutenberg_render_layout_support_flag'` — this PR does not propose adding a flag to switch off semantic classnames)

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->

1. With this PR applied, double-check that blocks like Columns, Social Icons, Buttons, etc render correctly
2. Add the following line to a theme's `functions.php` file (e.g. in TwentyTwentyTwo add it to the `twentytwentytwo_support` function):

```php
		// Opt in to remove layout styles.
		add_theme_support( 'disable-layout-styles' );
```
3. In the editor, and on the site frontend, default _and_ flex layouts provided by the layout block support should no longer render.
4. If you inspect the markup of blocks that use the Layout support, the semantic classnames should still be output (e.g. a Buttons block that sets space-between content justification will have a classname string of `"is-content-justification-space-between is-layout-flex wp-block-buttons"`)
5. Test with both a blocks-based theme (e.g. TwentyTwentyTwo) and a classic theme (e.g. TwentyTwentyOne)

<details>
<summary>Here's some markup for testing</summary>

```html
<!-- wp:columns -->
<div class="wp-block-columns"><!-- wp:column {"style":{"color":{"background":"#f0e8f7"},"spacing":{"padding":{"top":"15px","right":"15px","bottom":"15px","left":"15px"}}}} -->
<div class="wp-block-column has-background" style="background-color:#f0e8f7;padding-top:15px;padding-right:15px;padding-bottom:15px;padding-left:15px"><!-- wp:paragraph -->
<p>Column A</p>
<!-- /wp:paragraph --></div>
<!-- /wp:column -->

<!-- wp:column {"style":{"color":{"background":"#f0e8f7"},"spacing":{"padding":{"top":"15px","right":"15px","bottom":"15px","left":"15px"}}}} -->
<div class="wp-block-column has-background" style="background-color:#f0e8f7;padding-top:15px;padding-right:15px;padding-bottom:15px;padding-left:15px"><!-- wp:paragraph -->
<p>Column B</p>
<!-- /wp:paragraph --></div>
<!-- /wp:column -->

<!-- wp:column {"style":{"color":{"background":"#f0e8f7"},"spacing":{"padding":{"top":"15px","right":"15px","bottom":"15px","left":"15px"}}}} -->
<div class="wp-block-column has-background" style="background-color:#f0e8f7;padding-top:15px;padding-right:15px;padding-bottom:15px;padding-left:15px"><!-- wp:paragraph -->
<p>Column C</p>
<!-- /wp:paragraph --></div>
<!-- /wp:column --></div>
<!-- /wp:columns -->

<!-- wp:buttons {"layout":{"type":"flex","justifyContent":"space-between"}} -->
<div class="wp-block-buttons"><!-- wp:button -->
<div class="wp-block-button"><a class="wp-block-button__link wp-element-button">Button A</a></div>
<!-- /wp:button -->

<!-- wp:button -->
<div class="wp-block-button"><a class="wp-block-button__link wp-element-button">Button B</a></div>
<!-- /wp:button -->

<!-- wp:button -->
<div class="wp-block-button"><a class="wp-block-button__link wp-element-button">Button C</a></div>
<!-- /wp:button -->

<!-- wp:button -->
<div class="wp-block-button"><a class="wp-block-button__link wp-element-button">Button D</a></div>
<!-- /wp:button --></div>
<!-- /wp:buttons -->

<!-- wp:social-links -->
<ul class="wp-block-social-links"><!-- wp:social-link {"url":"https://wordpress.org","service":"wordpress"} /-->

<!-- wp:social-link {"url":"https://wordpress.org","service":"wordpress"} /-->

<!-- wp:social-link {"url":"https://wordpress.org","service":"wordpress"} /-->

<!-- wp:social-link {"url":"https://wordpress.org","service":"wordpress"} /-->

<!-- wp:social-link {"url":"https://wordpress.org","service":"wordpress"} /-->

<!-- wp:social-link {"url":"https://wordpress.org","service":"wordpress"} /-->

<!-- wp:social-link {"url":"https://wordpress.org","service":"wordpress"} /-->

<!-- wp:social-link {"url":"https://wordpress.org","service":"wordpress"} /-->

<!-- wp:social-link {"url":"https://wordpress.org","service":"wordpress"} /-->

<!-- wp:social-link {"url":"https://wordpress.org","service":"wordpress"} /-->

<!-- wp:social-link {"url":"https://wordpress.org","service":"wordpress"} /--></ul>
<!-- /wp:social-links -->

<!-- wp:buttons {"layout":{"type":"flex","justifyContent":"space-between","orientation":"vertical"}} -->
<div class="wp-block-buttons"><!-- wp:button -->
<div class="wp-block-button"><a class="wp-block-button__link wp-element-button">Button A</a></div>
<!-- /wp:button -->

<!-- wp:button -->
<div class="wp-block-button"><a class="wp-block-button__link wp-element-button">Button B</a></div>
<!-- /wp:button -->

<!-- wp:button -->
<div class="wp-block-button"><a class="wp-block-button__link wp-element-button">Button C</a></div>
<!-- /wp:button -->

<!-- wp:button -->
<div class="wp-block-button"><a class="wp-block-button__link wp-element-button">Button D</a></div>
<!-- /wp:button --></div>
<!-- /wp:buttons -->
```
</details>


## Screenshots or screencast <!-- if applicable -->

Note, this feature intentionally removes generated Layout styles, however styles provided by individual blocks in their own CSS files are not affected by this feature.

| TwentyTwentyTwo without the setting | TwentyTwentyTwo with the setting |
| --- | --- |
| <img width="1109" alt="image" src="https://user-images.githubusercontent.com/14988353/180145738-8f46dc74-59ed-46fc-b531-db85edc5babb.png"> | <img width="1253" alt="image" src="https://user-images.githubusercontent.com/14988353/180146889-41aa4b3e-f08a-4897-b4d7-e438ddf54022.png"> |

| TwentyTwentyOne without the setting | TwentyTwentyOne with the setting |
| --- | --- |
| <img width="1153" alt="image" src="https://user-images.githubusercontent.com/14988353/180147597-3ad2e462-78d3-4612-a04d-9860243dec76.png"> | <img width="1143" alt="image" src="https://user-images.githubusercontent.com/14988353/180147381-256c12aa-5eda-4282-ae34-fb388e871f84.png"> |

The new feature should also appear in API requests to the `themes` endpoint. One way to test this is to inspect network requests from the post editor, and filter by `themes`. The response for the current theme should include the default value in the `theme_supports` object:

<img width="347" alt="image" src="https://user-images.githubusercontent.com/14988353/181182075-81dbcb38-fb02-4000-8e89-5470f0a40a68.png">
