### PR TITLE
Button Block: Change text-decoration style to low specificity

### DIFF
--- a/packages/block-library/src/button/style.scss
+++ b/packages/block-library/src/button/style.scss
@@ -8,7 +8,6 @@ $blocks-block__margin: 0.5em;
 	cursor: pointer;
 	display: inline-block;
 	text-align: center;
-	text-decoration: none;
 	word-break: break-word; // overflow-wrap doesn't work well if a link is wrapped in the div, so use word-break here.
 	box-sizing: border-box;
 
@@ -32,6 +31,9 @@ $blocks-block__margin: 0.5em;
 // These rules are set to zero specificity to keep the default styles for buttons.
 // They are needed for backwards compatibility.
 :where(.wp-block-button__link) {
+	// This needs a low specificity so it won't override the rules from the button element if defined in theme.json.
+	text-decoration: none;
+
 	// 100% causes an oval, but any explicit but really high value retains the pill shape.
 	border-radius: 9999px;
 


### PR DESCRIPTION
Fix #42292

## What?
This PR reduces the specificity of `text-decoration` style given to `.wp-block-button__link` in the front end style of `core/button`.

## Why?
Text decoration styles may be defined in `theme.json`.
In addition, if `textDecoration` is specified in `styles.elements.button`, `.wp-block-button__link` is also subjected to it.

However, the settings in `theme.json` are not reflected because `text-decoration:none` is defined as the default button style.

## How?
I have reduced the specificity of the default style of the buttons, referring to #41393.

## Testing Instructions

- Activate Twenty Twenty Two theme.
- Insert "Button" and "Post Comments Form" block on the post editor (Post Comments Form block includes button block).
- On the front end, confirm that **`text-decoration` is none as before**.
- In theme.json, set `textDecoration` to "underline" for the button element:

```json
{
  "styles": {
    "elements": {
      "button": {
        "typography": {
          "textDecoration": "underline"
        }
      }
    }
  }
}
```

- On the front end, confirm that the underline is applied.

## Screenshots or screencast

| Before | After |
| --- | --- |
| ![before](https://user-images.githubusercontent.com/54422211/179904251-d530ddb6-c31e-4473-a9c4-78101e844cda.png) | ![after](https://user-images.githubusercontent.com/54422211/179904288-b73035c5-0c0f-49c6-a5a6-735878347f07.png) |

## Point of Concern

In Twenty Twenty Two, if `textDecoration: "underline"` is applied to a button element, it changes to dashed style on hover or focus.
However, I think this is an issue that should be addressed on the theme side.

![tt2-dashed](https://user-images.githubusercontent.com/54422211/179904993-a5004fce-620c-4b80-b345-2e3f7fffd619.png)
