### PR TITLE
Plugin: Fix PHP fatal error when using WP 5.9

### DIFF
--- a/lib/compat/wordpress-6.0/block-patterns.php
+++ b/lib/compat/wordpress-6.0/block-patterns.php
@@ -5,42 +5,44 @@
  * @package gutenberg
  */
 
-/**
- * Registers patterns from Pattern Directory provided by a theme's
- * `theme.json` file.
- */
-function gutenberg_register_remote_theme_patterns() {
-	if ( ! get_theme_support( 'core-block-patterns' ) ) {
-		return;
-	}
+if ( ! function_exists( '_register_remote_theme_patterns' ) ) {
+	/**
+	 * Registers patterns from Pattern Directory provided by a theme's
+	 * `theme.json` file.
+	 */
+	function _register_remote_theme_patterns() {
+		if ( ! get_theme_support( 'core-block-patterns' ) ) {
+			return;
+		}
 
-	if ( ! apply_filters( 'should_load_remote_block_patterns', true ) ) {
-		return;
-	}
+		if ( ! apply_filters( 'should_load_remote_block_patterns', true ) ) {
+			return;
+		}
 
-	if ( ! WP_Theme_JSON_Resolver_Gutenberg::theme_has_support() ) {
-		return;
-	}
+		if ( ! WP_Theme_JSON_Resolver_Gutenberg::theme_has_support() ) {
+			return;
+		}
 
-	$pattern_settings = WP_Theme_JSON_Resolver_Gutenberg::get_theme_data()->get_patterns();
-	if ( empty( $pattern_settings ) ) {
-		return;
-	}
+		$pattern_settings = WP_Theme_JSON_Resolver_Gutenberg::get_theme_data()->get_patterns();
+		if ( empty( $pattern_settings ) ) {
+			return;
+		}
 
-	$request         = new WP_REST_Request( 'GET', '/wp/v2/pattern-directory/patterns' );
-	$request['slug'] = implode( ',', $pattern_settings );
-	$response        = rest_do_request( $request );
-	if ( $response->is_error() ) {
-		return;
-	}
-	$patterns          = $response->get_data();
-	$patterns_registry = WP_Block_Patterns_Registry::get_instance();
-	foreach ( $patterns as $pattern ) {
-		$pattern_name = sanitize_title( $pattern['title'] );
-		// Some patterns might be already registered as core patterns with the `core` prefix.
-		$is_registered = $patterns_registry->is_registered( $pattern_name ) || $patterns_registry->is_registered( "core/$pattern_name" );
-		if ( ! $is_registered ) {
-			register_block_pattern( $pattern_name, (array) $pattern );
+		$request         = new WP_REST_Request( 'GET', '/wp/v2/pattern-directory/patterns' );
+		$request['slug'] = implode( ',', $pattern_settings );
+		$response        = rest_do_request( $request );
+		if ( $response->is_error() ) {
+			return;
+		}
+		$patterns          = $response->get_data();
+		$patterns_registry = WP_Block_Patterns_Registry::get_instance();
+		foreach ( $patterns as $pattern ) {
+			$pattern_name = sanitize_title( $pattern['title'] );
+			// Some patterns might be already registered as core patterns with the `core` prefix.
+			$is_registered = $patterns_registry->is_registered( $pattern_name ) || $patterns_registry->is_registered( "core/$pattern_name" );
+			if ( ! $is_registered ) {
+				register_block_pattern( $pattern_name, (array) $pattern );
+			}
 		}
 	}
 }

--- a/lib/compat/wordpress-6.0/block-patterns.php
+++ b/lib/compat/wordpress-6.0/block-patterns.php
@@ -29,7 +29,7 @@ if ( ! function_exists( '_register_remote_theme_patterns' ) ) {
 		}
 
 		$request         = new WP_REST_Request( 'GET', '/wp/v2/pattern-directory/patterns' );
-		$request['slug'] = implode( ',', $pattern_settings );
+		$request['slug'] = $pattern_settings;
 		$response        = rest_do_request( $request );
 		if ( $response->is_error() ) {
 			return;


### PR DESCRIPTION
## What?
PR fixes PHP fatal error when using Gutenberg plugin with WP 5.9.

Error:

```
PHP Fatal error:  Uncaught Error: Call to undefined function _register_remote_theme_patterns() in ~/wp-content/plugins/gutenberg/lib/compat/wordpress-6.1/class-gutenberg-rest-block-patterns-controller.php:96
```

## Why?
The patterns controller was using a function only available in WP 6.0.

## How?
Renamed gutenberg_register_remote_theme_patterns and wrapped it into a guard clause.

## Testing Instructions
1. Downgrade to WP 5.9.x - `wp core update --version=5.9.3 --force`
2. Open a Post or Page
3. Confirm there's no fatal error in `debug.log`
