### PR TITLE
Improve accessibility of the templates list Actions column

### DIFF
--- a/packages/edit-site/src/components/list/actions/index.js
+++ b/packages/edit-site/src/components/list/actions/index.js
@@ -5,6 +5,7 @@ import { useDispatch } from '@wordpress/data';
 import { store as coreStore } from '@wordpress/core-data';
 import { __ } from '@wordpress/i18n';
 import { DropdownMenu, MenuGroup, MenuItem } from '@wordpress/components';
+import { chevronDown } from '@wordpress/icons';
 import { store as noticesStore } from '@wordpress/notices';
 
 /**
@@ -52,11 +53,12 @@ export default function Actions( { template } ) {
 
 	return (
 		<DropdownMenu
-			icon={ null }
+			icon={ chevronDown }
 			className="edit-site-list-table__actions"
+			text={ __( 'Actions' ) }
 			toggleProps={ {
-				children: __( 'Actions' ),
-				isSecondary: true,
+				variant: 'tertiary',
+				iconPosition: 'right',
 			} }
 		>
 			{ ( { onClose } ) => (

--- a/packages/edit-site/src/components/list/actions/index.js
+++ b/packages/edit-site/src/components/list/actions/index.js
@@ -5,7 +5,6 @@ import { useDispatch } from '@wordpress/data';
 import { store as coreStore } from '@wordpress/core-data';
 import { __ } from '@wordpress/i18n';
 import { DropdownMenu, MenuGroup, MenuItem } from '@wordpress/components';
-import { moreVertical } from '@wordpress/icons';
 import { store as noticesStore } from '@wordpress/notices';
 
 /**
@@ -26,7 +25,7 @@ export default function Actions( { template } ) {
 	const isRevertable = isTemplateRevertable( template );
 
 	if ( ! isRemovable && ! isRevertable ) {
-		return null;
+		return __( 'No actions' );
 	}
 
 	async function revertAndSaveTemplate() {
@@ -53,9 +52,12 @@ export default function Actions( { template } ) {
 
 	return (
 		<DropdownMenu
-			icon={ moreVertical }
-			label={ __( 'Actions' ) }
+			icon={ null }
 			className="edit-site-list-table__actions"
+			toggleProps={ {
+				children: __( 'Actions' ),
+				isSecondary: true,
+			} }
 		>
 			{ ( { onClose } ) => (
 				<MenuGroup>

--- a/packages/edit-site/src/components/list/actions/index.js
+++ b/packages/edit-site/src/components/list/actions/index.js
@@ -4,8 +4,13 @@
 import { useDispatch } from '@wordpress/data';
 import { store as coreStore } from '@wordpress/core-data';
 import { __ } from '@wordpress/i18n';
-import { DropdownMenu, MenuGroup, MenuItem } from '@wordpress/components';
-import { chevronDown } from '@wordpress/icons';
+import {
+	DropdownMenu,
+	MenuGroup,
+	MenuItem,
+	VisuallyHidden,
+} from '@wordpress/components';
+import { Icon, chevronDown, reset } from '@wordpress/icons';
 import { store as noticesStore } from '@wordpress/notices';
 
 /**
@@ -26,7 +31,14 @@ export default function Actions( { template } ) {
 	const isRevertable = isTemplateRevertable( template );
 
 	if ( ! isRemovable && ! isRevertable ) {
-		return __( 'No actions' );
+		return (
+			<>
+				<Icon icon={ reset } />
+				<VisuallyHidden>
+					{ __( 'No actions available' ) }
+				</VisuallyHidden>
+			</>
+		);
 	}
 
 	async function revertAndSaveTemplate() {

--- a/packages/edit-site/src/components/list/actions/index.js
+++ b/packages/edit-site/src/components/list/actions/index.js
@@ -10,7 +10,7 @@ import {
 	MenuItem,
 	VisuallyHidden,
 } from '@wordpress/components';
-import { Icon, chevronDown, reset } from '@wordpress/icons';
+import { Icon, moreVertical, reset } from '@wordpress/icons';
 import { store as noticesStore } from '@wordpress/notices';
 
 /**
@@ -65,12 +65,11 @@ export default function Actions( { template } ) {
 
 	return (
 		<DropdownMenu
-			icon={ chevronDown }
+			icon={ moreVertical }
 			className="edit-site-list-table__actions"
 			text={ __( 'Actions' ) }
 			toggleProps={ {
 				variant: 'tertiary',
-				iconPosition: 'right',
 			} }
 		>
 			{ ( { onClose } ) => (

--- a/packages/edit-site/src/components/list/style.scss
+++ b/packages/edit-site/src/components/list/style.scss
@@ -63,18 +63,19 @@
 	max-width: 960px;
 
 	tr {
-		border-top: $border-width solid $gray-100;
-		margin: 0;
-
-		&:first-child {
-			border-top: 0;
-		}
-
 		th,
 		td {
+			border-top: $border-width solid $gray-100;
 			padding: $grid-unit-20;
 			@include break-medium() {
 				padding: $grid-unit-30 $grid-unit-40;
+			}
+		}
+
+		&:first-child {
+			th,
+			td {
+				border-top: 0;
 			}
 		}
 
@@ -107,10 +108,10 @@
 		font-weight: 600;
 		text-align: left;
 		color: $gray-900;
-		border-top: none;
-		border-bottom: $border-width solid $gray-300;
 
 		th {
+			border-top: 0;
+			border-bottom: $border-width solid $gray-300;
 			font-weight: inherit;
 		}
 	}

--- a/packages/edit-site/src/components/list/style.scss
+++ b/packages/edit-site/src/components/list/style.scss
@@ -63,10 +63,6 @@
 	max-width: 960px;
 
 	tr {
-		display: flex;
-		align-items: center;
-		padding: $grid-unit-20;
-		box-sizing: border-box;
 		border-top: $border-width solid $gray-100;
 		margin: 0;
 
@@ -74,14 +70,17 @@
 			border-top: 0;
 		}
 
-		@include break-medium() {
-			padding: $grid-unit-30 $grid-unit-40;
+		th,
+		td {
+			padding: $grid-unit-20;
+			@include break-medium() {
+				padding: $grid-unit-30 $grid-unit-40;
+			}
 		}
 
 		// Template.
 		.edit-site-list-table-column:nth-child(1) {
-			width: calc(60% - 18px);
-			padding-right: $grid-unit-30;
+			width: 58%;
 
 			a {
 				display: inline-block;
@@ -93,14 +92,13 @@
 
 		// Added by.
 		.edit-site-list-table-column:nth-child(2) {
-			width: calc(40% - 18px);
+			width: 30%;
 			word-break: break-word;
 		}
 
 		// Actions.
 		.edit-site-list-table-column:nth-child(3) {
-			min-width: $button-size;
-			flex-shrink: 0;
+			width: 12%;
 		}
 	}
 

--- a/packages/edit-site/src/components/list/table.js
+++ b/packages/edit-site/src/components/list/table.js
@@ -4,10 +4,7 @@
 import { useSelect } from '@wordpress/data';
 import { store as coreStore, useEntityRecords } from '@wordpress/core-data';
 import { __, sprintf } from '@wordpress/i18n';
-import {
-	VisuallyHidden,
-	__experimentalHeading as Heading,
-} from '@wordpress/components';
+import { __experimentalHeading as Heading } from '@wordpress/components';
 import { decodeEntities } from '@wordpress/html-entities';
 
 /**
@@ -85,7 +82,7 @@ export default function Table( { templateType } ) {
 						className="edit-site-list-table-column"
 						role="columnheader"
 					>
-						<VisuallyHidden>{ __( 'Actions' ) }</VisuallyHidden>
+						{ __( 'Manage' ) }
 					</th>
 				</tr>
 			</thead>


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->
Fixes https://github.com/WordPress/gutenberg/issues/42505

## What?
<!-- In a few words, what is the PR actually doing? -->
Changes the Actions button in the templates list to use text instead of only an icon. Also makes the column header visible to as there's no reason to hide it.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
The ellipsis icon of the Actions button is barely visible for low vision users. In other places, for example in the block toolbar, the ellipsis icon is more visible because of the context and the borders. Instead, in the templates list is very light.

From an accessibility perspective, the golden rule for 'icon-only' buttons should be: use them only when there's really no space to use visible text. In this case, there's enough space to use tedxt and there's no reason to use only an icon.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
- Changes the dropdown menu toggle button to use visible text + a chevron icon instead of only the ellipsis icon.
- Makes the column header text visible and changes it from 'Actions' to 'Manage' to avoid repetition.
- **Removes the flex styles used for the column**.  This is necessary to make the column header text and the buttons within the cells align correctly. I'm not sure why flexbox was used in the first place.
- Since this is a _data_ table, make sure to not have empty cells and use visually hidden text for the 'no actions' case.

## Testing Instructions
- Go to the Site Editor.
- Make sure to have a default template with some customization and a custom template.
- Click Toggle navigation, and then click Templates.
- Observe the third column header text is now visible.
- Observe the customized templates have a button in the third column. The button text is 'Actions' plus a chevron icon.
- Observe the templates with no actions available have an icon representing a line in the third column and that there's a visually hidden text 'No actions available'. This pattern is consistent with the one already used in the WordPress list tables.
- Check there are no breaking style changes.
- Worth noting this table was not fully responsive already. The CSS changes don't improve responsiveness but seems to me they don't make it worse either.

## Screenshots or screencast <!-- if applicable -->

Before:

<img width="1051" alt="before" src="https://user-images.githubusercontent.com/1682452/179959407-b2f055c0-4764-4968-9f98-cd9feeb365f9.png">

After: 

<img width="1091" alt="after" src="https://user-images.githubusercontent.com/1682452/179959453-f351041e-07d7-46f2-8882-406dc0448917.png">

