### PR TITLE
Fix Nav block lower permission user tests by removing expectation of REST errors

### DIFF
--- a/packages/e2e-tests/specs/editor/blocks/navigation.test.js
+++ b/packages/e2e-tests/specs/editor/blocks/navigation.test.js
@@ -1331,11 +1331,6 @@ Expected mock function not to be called but it was called with: ["POST", "http:/
 			await page.waitForXPath(
 				`//*[contains(@class, 'components-snackbar__content')][ text()="${ noticeText }" ]`
 			);
-
-			// Expect a console 403 for requests to:
-			// * /wp/v2/settings?_locale=user
-			// * /wp/v2/templates?context=edit&post_type=post&per_page=100&_locale=user
-			expect( console ).toHaveErrored();
 		} );
 	} );
 


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Fixes Nav block user permissions tests by removing expectation that certain REST API endpoints will `403` for lower permission users. 

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

I noticed https://github.com/WordPress/gutenberg/issues/37604 was reopened (again) and I think this is because the REST errors were removed in https://github.com/WordPress/gutenberg/pull/42413. As the requests no longer fire we don't need to expect errors in the tests.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

Removes the `toHaveErrored()` assertion to cover:

* /wp/v2/settings?_locale=user
* /wp/v2/templates?context=edit&post_type=post&per_page=100&_locale=user

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->

Re-run the CI tests a few times and ensure that the following test does not fail:

https://github.com/WordPress/gutenberg/blob/80c536cefede0f1f8426120bc22c994e49f44b28/packages/e2e-tests/specs/editor/blocks/navigation.test.js#L1320



## Screenshots or screencast <!-- if applicable -->
