### PR TITLE
List v2: remove default block margin

### DIFF
--- a/packages/block-library/src/editor.scss
+++ b/packages/block-library/src/editor.scss
@@ -51,6 +51,7 @@
 @import "./post-featured-image/editor.scss";
 @import "./post-comments/editor.scss";
 @import "./post-comments-form/editor.scss";
+@import "./list/editor.scss";
 
 :root .editor-styles-wrapper {
 	@include background-colors-deprecated();

--- a/packages/block-library/src/list/editor.scss
+++ b/packages/block-library/src/list/editor.scss
@@ -1,0 +1,9 @@
+.editor-styles-wrapper {
+	// Ideally we shouldn't set default margin as this will also revert theme
+	// styles.
+	.wp-block-list[data-block],
+	.wp-block-list-item[data-block] {
+		margin-top: revert;
+		margin-bottom: revert;
+	}
+}


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?

Fixes #42526. There's a default margin that is applied to all blocks, but should be removed for lists and list items. Unfortunately, this will also revert any margin set by themes. The only way to avoid that would be to get rid of this default margin we're setting for all blocks. I'm not sure why that's needed. We could revisit this later.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->

## Screenshots or screencast <!-- if applicable -->
