### PR TITLE
Page List: Fetch items with 'view' context

### DIFF
--- a/packages/block-library/src/page-list/edit.js
+++ b/packages/block-library/src/page-list/edit.js
@@ -103,6 +103,14 @@ export default function PageListEdit( { context, clientId } ) {
 
 function useFrontPageId() {
 	return useSelect( ( select ) => {
+		const canReadSettings = select( coreStore ).canUser(
+			'read',
+			'settings'
+		);
+		if ( ! canReadSettings ) {
+			return undefined;
+		}
+
 		const site = select( coreStore ).getEntityRecord( 'root', 'site' );
 		return site?.show_on_front === 'page' && site?.page_on_front;
 	}, [] );

--- a/packages/block-library/src/page-list/edit.js
+++ b/packages/block-library/src/page-list/edit.js
@@ -117,6 +117,7 @@ function usePageData() {
 			order: 'asc',
 			_fields: [ 'id', 'link', 'parent', 'title', 'menu_order' ],
 			per_page: -1,
+			context: 'view',
 		}
 	);
 


### PR DESCRIPTION
## What?
PR updates the "Page List" block query to use the `view` context when fetching the page. In addition, it allows users with lower capabilities to preview block content in the editor.

I also added a capability check before fetching site settings to avoid a 403 error—related issue #42413.

## Testing Instructions
1. Create a user with an Author role.
2. Open a Post.
3. Insert a Page List block.
4. Confirm that block can fetch pages.
5. Confirm there're no 403 requests in the DevTools network tab.

## Screenshots or screencast <!-- if applicable -->
| Before | After |
| --- | --- |
|![CleanShot 2022-07-20 at 15 26 53](https://user-images.githubusercontent.com/240569/179972902-4aac49de-ed2a-4680-b6b8-61c187e2edd4.png)|![CleanShot 2022-07-20 at 15 26 29](https://user-images.githubusercontent.com/240569/179972917-525b6f6a-9644-4ed6-bcd4-a56205640f88.png)|

