### PR TITLE
ComboboxControl: refactor `onKeyDown` to use `keyboardEvent.code`

### DIFF
--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -30,6 +30,7 @@
 -   `BoxControl`: Refactor away from `_.isEmpty()` ([#42468](https://github.com/WordPress/gutenberg/pull/42468)).
 -   `RadioControl`: Refactor away from `_.isEmpty()` ([#42468](https://github.com/WordPress/gutenberg/pull/42468)).
 -   `SelectControl`: Refactor away from `_.isEmpty()` ([#42468](https://github.com/WordPress/gutenberg/pull/42468)).
+-   `ComboboxControl`: Replace `keyboardEvent.keyCode` with `keyboardEvent.code`([#42569](https://github.com/WordPress/gutenberg/pull/42569)).
 
 ## 19.15.0 (2022-07-13)
 

--- a/packages/components/src/combobox-control/index.js
+++ b/packages/components/src/combobox-control/index.js
@@ -16,7 +16,6 @@ import {
 	useEffect,
 } from '@wordpress/element';
 import { useInstanceId } from '@wordpress/compose';
-import { ENTER, UP, DOWN, ESCAPE } from '@wordpress/keycodes';
 import { speak } from '@wordpress/a11y';
 import { closeSmall } from '@wordpress/icons';
 
@@ -119,22 +118,22 @@ function ComboboxControl( {
 			return;
 		}
 
-		switch ( event.keyCode ) {
-			case ENTER:
+		switch ( event.code ) {
+			case 'Enter':
 				if ( selectedSuggestion ) {
 					onSuggestionSelected( selectedSuggestion );
 					preventDefault = true;
 				}
 				break;
-			case UP:
+			case 'ArrowUp':
 				handleArrowNavigation( -1 );
 				preventDefault = true;
 				break;
-			case DOWN:
+			case 'ArrowDown':
 				handleArrowNavigation( 1 );
 				preventDefault = true;
 				break;
-			case ESCAPE:
+			case 'Escape':
 				setIsExpanded( false );
 				setSelectedSuggestion( null );
 				preventDefault = true;


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->
Related: https://github.com/WordPress/gutenberg/pull/42403

## What?
Replace `ComboboxControl`'s use of imported `@wordpress/keycodes` with `keyboardEvent.code` values for relevant key presses.

## Why?
The `ComboboxControl` component's `onKeyDown` method currently imports several keycodes from `@wordpress/keycodes`. This turned out to be problematic while writing unit tests, because newer tools like `testing-librabry` rely on `keyboardEvent.code` or `keyboardEvent.key` [for keypress events](https://testing-library.com/docs/user-event/keyboard).

## How?
Removing the current imports and replacing the key values with [the corresponding `keyboardEvent.code` values](https://developer.mozilla.org/en-US/docs/Web/API/KeyboardEvent/code).

kudos to @ciampo for guiding me to the solution on this one 🎉 

## Testing Instructions
Launch Storybook and test the `ComboboxControl` component using keypresses.

- `Tab` to focus the component
- `ArrowUp` and `ArrowDown` to navigate
- `Enter` to select
- Navigate some more
- `Escape` to collapse without selecting
