### PR TITLE
RangeControl: clamp initialPosition between min and max values

### DIFF
--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 -   `CustomSelectControl`: Fix font size and hover/focus style inconsistencies with `SelectControl` ([#42460](https://github.com/WordPress/gutenberg/pull/42460/)).
 -   `AnglePickerControl`: Fix gap between elements in RTL mode ([#42534](https://github.com/WordPress/gutenberg/pull/42534)).
+-   `RangeControl`: clamp initialPosition between min and max values ([#42571](https://github.com/WordPress/gutenberg/pull/42571)).
 
 ### Enhancements
 

--- a/packages/components/src/range-control/README.md
+++ b/packages/components/src/range-control/README.md
@@ -184,7 +184,7 @@ An icon to be shown above the slider next to its container title.
 
 ### `initialPosition`: `number`
 
-If no value exists this prop contains the slider starting position.
+The slider starting position, used when no `value` is passed. The `initialPosition` will be clamped between the provided `min` and `max` prop values.
 
 -   Required: No
 -   Platform: Web | Mobile

--- a/packages/components/src/range-control/test/index.tsx
+++ b/packages/components/src/range-control/test/index.tsx
@@ -200,6 +200,36 @@ describe( 'RangeControl', () => {
 
 			expect( rangeInput?.value ).toBe( '10' );
 		} );
+
+		it( 'should clamp initialPosition between min and max on first render, and on reset', () => {
+			render(
+				<RangeControl
+					initialPosition={ 200 }
+					min={ 0 }
+					max={ 100 }
+					allowReset
+				/>
+			);
+
+			const numberInput = getNumberInput();
+			const rangeInput = getRangeInput();
+			const resetButton = getResetButton();
+
+			// Value should be clamped on initial load
+			expect( numberInput?.value ).toBe( '100' );
+			expect( rangeInput?.value ).toBe( '100' );
+
+			fireChangeEvent( numberInput, '50' );
+
+			expect( numberInput?.value ).toBe( '50' );
+			expect( rangeInput?.value ).toBe( '50' );
+
+			// Value should be clamped after resetting
+			fireEvent.click( resetButton as Element );
+
+			expect( numberInput?.value ).toBe( '100' );
+			expect( rangeInput?.value ).toBe( '100' );
+		} );
 	} );
 
 	describe( 'input field', () => {

--- a/packages/components/src/range-control/types.ts
+++ b/packages/components/src/range-control/types.ts
@@ -119,7 +119,9 @@ export type RangeControlProps< IconProps = unknown > = Pick<
 		 */
 		icon?: string;
 		/**
-		 * If no value exists this prop contains the slider starting position.
+		 * The slider starting position, used when no `value` is passed.
+		 * The `initialPosition` will be clamped between the provided `min`
+		 * and `max` prop values.
 		 */
 		initialPosition?: number;
 		/**

--- a/packages/components/src/range-control/utils.ts
+++ b/packages/components/src/range-control/utils.ts
@@ -50,7 +50,10 @@ export function useControlledRangeValue(
 	const { min, max, value: valueProp, initial } = settings;
 	const [ state, setInternalState ] = useControlledState(
 		floatClamp( valueProp, min, max ),
-		{ initial, fallback: null }
+		{
+			initial: floatClamp( initial ?? null, min, max ),
+			fallback: null,
+		}
 	);
 
 	const setState = useCallback(


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Clamp the value of `initialPosition` between `min` and `max`, so that the `RangeControl`'s value (and in particular, the value displayed in the `NumberControl`) is within `min`/`max` bounds.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

This fixes a bug noticed in https://github.com/WordPress/gutenberg/pull/40535#pullrequestreview-1027230264

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

Wrapped `initialPosition` in a `floatClamp` call inside the `useControlledRangeValue` hook.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->

- Unit tests pass
- Undo changes from https://github.com/WordPress/gutenberg/commit/d193482cd4bbc7a7eef6a6251f48b7ab7537d8a9 and notice how the new unit test doesn't pass anymore
- Repeat the steps highlighted in https://github.com/WordPress/gutenberg/pull/40535#pullrequestreview-1027230264, the bug should be fixed
