### PR TITLE
Implement support for merging plugin theme.json into active block theme.json

### DIFF
--- a/.wp-env.json
+++ b/.wp-env.json
@@ -8,7 +8,8 @@
 				"wp-content/plugins/gutenberg": ".",
 				"wp-content/mu-plugins": "./packages/e2e-tests/mu-plugins",
 				"wp-content/plugins/gutenberg-test-plugins": "./packages/e2e-tests/plugins",
-				"wp-content/themes/gutenberg-test-themes": "./test/gutenberg-test-themes"
+				"wp-content/themes/gutenberg-test-themes": "./test/gutenberg-test-themes",
+				"wp-content/plugins/test-plugin-theme-json": "./test/test-plugin-theme-json"
 			}
 		}
 	}

--- a/lib/experimental/class-wp-theme-json-gutenberg.php
+++ b/lib/experimental/class-wp-theme-json-gutenberg.php
@@ -16,4 +16,13 @@
  */
 class WP_Theme_JSON_Gutenberg extends WP_Theme_JSON_6_1 {
 
+	/**
+	 * Cleans cached data across class instances.
+	 *
+	 * @since 6.1.0
+	 */
+	public static function clean_cached_data() {
+		static::$blocks_metadata = null;
+	}
+
 }

--- a/lib/experimental/class-wp-theme-json-resolver-gutenberg.php
+++ b/lib/experimental/class-wp-theme-json-resolver-gutenberg.php
@@ -150,24 +150,21 @@ class WP_Theme_JSON_Resolver_Gutenberg extends WP_Theme_JSON_Resolver_6_1 {
 		if ( null === static::$plugins ) {
 			$plugins_data        = array();
 			$active_plugin_paths = wp_get_active_and_valid_plugins();
+			$plugin_json         = new WP_Theme_JSON_Gutenberg();
 			foreach ( $active_plugin_paths as $path ) {
 				$config = static::read_json_file( dirname( $path ) . '/theme.json' );
 				if ( ! empty( $config ) ) {
+					$plugin_meta_data = get_plugin_data( $path, false, false );
+					if ( isset( $plugin_meta_data['TextDomain'] ) ) {
+						$config = static::translate( $config, $plugin_meta_data['TextDomain'] );
+					}
+					// TODO, this is where we could potentially introduce different merge
+					// strategies for plugin provided data.
+					$plugin_json->merge(
+						new WP_Theme_JSON_Gutenberg( $config )
+					);
 					$plugins_data[ $path ] = $config;
 				}
-			}
-			// have configs from plugins, now let's register and merge.
-			$plugin_json = new WP_Theme_JSON_Gutenberg();
-			foreach ( $plugins_data as $plugin_path => $plugin_config ) {
-				$plugin_meta_data = get_plugin_data( $plugin_path, false, false );
-				if ( isset( $plugin_meta_data['TextDomain'] ) ) {
-					$plugin_config = static::translate( $plugin_config, $plugin_meta_data['TextDomain'] );
-				}
-				// TODO, this is where we could potentially introduce different merge
-				// strategies for plugin provided data.
-				$plugin_json->merge(
-					new WP_Theme_JSON_Gutenberg( $plugin_config )
-				);
 			}
 			static::$plugins = $plugin_json;
 		}

--- a/test/test-plugin-theme-json/test-plugin-theme-json.php
+++ b/test/test-plugin-theme-json/test-plugin-theme-json.php
@@ -1,0 +1,10 @@
+<?php
+/**
+ * Plugin Name: Test Plugin Theme JSON
+ * Plugin URI: https://dev.test
+ * Description: For testing plugin adding theme.json.
+ * Version: 1.0
+ * Author: WordPress
+ * Author URI: https://dev.test
+ * Text Domain:  dev-test
+ */

--- a/test/test-plugin-theme-json/theme.json
+++ b/test/test-plugin-theme-json/theme.json
@@ -1,0 +1,42 @@
+{
+	"$schema": "https://schemas.wp.org/trunk/theme.json",
+	"settings": {
+		"appearanceTools": true,
+		"border": {
+			"color": true,
+			"radius": true,
+			"style": true,
+			"width": true
+		},
+		"color": {
+			"custom": true,
+			"customGradient": true,
+			"link": true,
+			"palette": [
+				{
+					"color": "#e44064",
+					"name": "Pink Red",
+					"slug": "pink-red"
+				}
+			]
+		}
+	},
+	"styles": {
+		"blocks": {
+			"core/button": {
+				"border": {
+					"radius": "10px"
+				},
+				"color": {
+					"background": "var(--wp--preset--color--pink-red)"
+				}
+			},
+			"mycustom/block": {
+				"color": {
+					"background": "var(--wp--preset--color--pink-red)"
+				}
+			}
+		}
+	},
+	"version": 2
+}


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->
This is an initial working proof of concept solving #41707 with a goal of serving as a basis for further discussion on what we want to land as the initial iteration in Gutenberg.

**Note:** I'm not 100% clear on the strategy for what classes (compat classes) the code should be in for easier potential merge to WP core so reviewers please let me know if changes are needed related to that.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

See #41707 for details. However, in summary, with the advent of `theme.json` becoming the primary entry point for much of the defaults around a site's customization and personalization, there is a need for a mechanism for plugins to:

- provide default styles or settings for their blocks that can be overridden by themes.
- expose custom properties that can be overridden by themes.
- provide and expose a set of custom templates for post types.
- indicate what patterns to register from the Patterns directory.

Preliminary discussion in #41707 suggests that accepting a `theme.json` provided by a plugin might be a suitable mechanism for this. This PR provides a working POC that can serves as a reference for further evaluation and discussion.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

In this PR:

- Any active plugin with a `theme.json` in its root directory will have that file merged with the properties of the active `theme.json` on the site.
- In the priority chain, the plugins theme.json will sit between blocks and themes (so the theme's `theme.json` will override that provided by plugins).
- Currently, the merge strategy for multiple plugins is kept simple and simply follows the order returned from calling the `wp_get_active_and_valid_plugins` function (I think currently alphabetically?).

### Some remaining open questions that are not addressed in this PR

**Caching/Performance**

There is caching per request (in keeping with the current behaviour for other sources) that exists for retrieving plugin-provided `theme.json` files. It should be fairly performant already, but there may be potential that sites with a _lot_ of plugins might be impacted given the discovery part of the process. There is an open question around whether more persistent caching _across_ requests might be needed. I have some ideas there (including resetting the cache on plugin activation and deactivation) but I think that's something that could be done in a subsequent iteration if it's deemed needed. Any persistent caching would likely have to consider network vs site activated plugins.

**Pattern retrieval**

[Via `_register_remote_theme_patterns`](https://github.com/WordPress/gutenberg/blob/c81fb68193ef25fb42a05f3f004a0c0921fd1643/lib/compat/wordpress-6.0/block-patterns.php#L26), the `patterns` property is returned _only from the `theme.json` provided by the active theme_ (not the merged `theme.json`). If we want pattern slugs provided by plugins `theme.json` to be included here then this would need to be modified.

**i18n**

Currently, I *think* the same method of translation for available properties is handled in the code submitted. However, I only looked at this shallowly so it'd need a good review by someone familiar with how that works. I know this definitely won't handle any custom properties that plugins might extend on `theme.json`.

**Allowing custom properties**

Speaking of which, plugins will not be able to enhance `theme.json` with custom properties with this current PR. It'd require work in the `WP_Theme_JSON` (or equivalent compat class)  I'm on the fence whether, this _should_ be allowed or not given:

- `theme.json` has a specific schema.
- the use case for custom properties still isn't very clear to me yet. 

I think if this is a demonstrable need, we should address this separately. However, I mention it here because it _could_ impact the evaluation of this PR as a viable approach overall.

**Merging strategy for multiple plugins with a `theme.json` file**

While there are some comments indicating places we could potentially implement a different merge strategy for plugins `theme.json` files, it's not clear what that strategy should be (or even if it's necessary). I'm leaning more towards this mechanism being provided as a method for plugins to _add_ defaults specific to their exposed blocks/patterns/templates to the active theme and _not_ a mechanism for overriding other plugins defaults (which should be the purview of a theme). However, I know practically this doesn't leave room for the nuances of other use-cases where that may be desired.

Hence, this is very much an open question. I do wonder though if it'd be sufficient to roll out this POC as is and deal with the merging strategy in subsequent iterations once those use-cases are clearer?

**Restrict which properties plugins can define?**

Somewhat related to the merging strategy question, while this PR is liberal in what plugins can define in their `theme.json` file, I do wonder if it's too liberal. With the current merge strategy, if plugins define every property then there will always be one plugin that "wins" in the final rendered "plugin provided `theme.json` file" which could lead to unexpected behaviour. So this opens the question of whether we should either restrict which properties plugins can define or potentially have plugins only provide a custom `.json` file that only merges with a subset of `theme.json` properties. The latter aligns mostly with what Luis [suggested here](https://github.com/WordPress/gutenberg/issues/41707#issuecomment-1156535854).

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->

There are some PHPUnit tests that cover the expected behaviour viewable in this PR, but it's also testable using the following instructions.

1. All you need for testing is a plugin with a defined `theme.json` file. You can use what is implemented for PHPUnit tests in this PR. 
2. Activate the plugin.
3.  Take note of what properties are new and not overridden by the active theme's `theme.json` and verify that those are utilized by Gutenberg in the editor (for instance a custom block styles property defined in the plugin provided `theme.json`).
4. Take note of what properties are also present in the active theme's `theme.json` and ensure that when viewed in the editor that the _active theme's_ implementation is what is preserved.
