### PR TITLE
Layout content size controls: add left alignment to line up with description and other elements

### DIFF
--- a/packages/edit-site/src/components/global-styles/dimensions-panel.js
+++ b/packages/edit-site/src/components/global-styles/dimensions-panel.js
@@ -205,7 +205,7 @@ export default function DimensionsPanel( { name } ) {
 					onDeselect={ resetContentSizeValue }
 					isShownByDefault={ true }
 				>
-					<HStack alignment="flex-end">
+					<HStack alignment="flex-end" justify="flex-start">
 						<UnitControl
 							label={ __( 'Content' ) }
 							labelPosition="top"
@@ -230,7 +230,7 @@ export default function DimensionsPanel( { name } ) {
 					onDeselect={ resetWideSizeValue }
 					isShownByDefault={ true }
 				>
-					<HStack alignment="flex-end">
+					<HStack alignment="flex-end" justify="flex-start">
 						<UnitControl
 							label={ __( 'Wide' ) }
 							labelPosition="top"


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

A very tiny follow-up to #42309 to make sure the `HStack` elements are left aligned in the global styles UI for layout content and wide size controls.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

Without setting `justify`, too, it looks like the `HStack` was defaulting to being centre-aligned. It's very subtle, only a couple of pixels different.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

* Add `justify` prop to the two `HStack` components (we could use `bottomLeft` in `alignment` instead, but personally I have a slight preference to using the CSS properties as it's a little more explicit as to what's happening if you're familiar with flex properties). Happy to change it if need be.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->

Open up global styles and go to the Layout panel in the right-hand sidebar. Check that the text for Content now lines up with the description `Set the width of the main content area.` and the `Padding` label.

## Screenshots or screencast <!-- if applicable -->

| Before | After |
| --- | --- |
| ![image](https://user-images.githubusercontent.com/14988353/180110039-2b13a90c-523a-4142-9c0d-3054a180c139.png) | ![image](https://user-images.githubusercontent.com/14988353/180110052-663acbd3-8b63-4a79-9a0d-06e302693b82.png) |