### PR TITLE
Make 'Move to trash' button full width

### DIFF
--- a/packages/editor/src/components/post-trash/style.scss
+++ b/packages/editor/src/components/post-trash/style.scss
@@ -1,3 +1,6 @@
 .editor-post-trash.components-button {
+	display: flex;
+	justify-content: center;
 	margin-top: $grid-unit-05;
+	width: 100%;
 }


### PR DESCRIPTION
## What?
Makes the 'Move to trash' button in document settings 100% width.

## Why?
There's some uncertainty about where this button should go (see https://github.com/WordPress/gutenberg/pull/42175) but we can at least make it look nicer for now. See also https://github.com/WordPress/gutenberg/pull/42146 which did this for some other sidebar controls.

## How?


## Testing Instructions
1. Edit an existing post.
2. Look at the 'Move to trash' button in the sidebar.

## Screenshots or screencast 
| Before | After |
| - | - |
| <img width="291" alt="Screen Shot 2022-07-21 at 13 10 03" src="https://user-images.githubusercontent.com/612155/180122424-f4e65980-2944-42ce-b78e-57411009124c.png"> | <img width="293" alt="Screen Shot 2022-07-21 at 13 09 43" src="https://user-images.githubusercontent.com/612155/180122437-13482abf-170a-41e1-9f29-f81723f8e37a.png"> |