### PR TITLE
Scripts: fix `--fix` doesn't work correctly

### DIFF
--- a/packages/scripts/utils/cli.js
+++ b/packages/scripts/utils/cli.js
@@ -21,7 +21,8 @@ const getArgFromCLI = ( arg ) => {
 
 const hasArgInCLI = ( arg ) => getArgFromCLI( arg ) !== undefined;
 
-const getFileArgsFromCLI = () => minimist( getArgsFromCLI() )._;
+const getFileArgsFromCLI = () =>
+	minimist( getArgsFromCLI(), { boolean: true } )._;
 
 const getNodeArgsFromCLI = () => {
 	const args = getArgsFromCLI();


### PR DESCRIPTION
Fixes #30466

## What?
This PR corrects the `--fix` option of wp-scripts so that the specified file is correctly reflected.

## Why?
If we don't specify the target file, all files are covered and itworks as expected:

```bash
wp-scripts lint-style -- --fix
```

However, as mentioned in [comment](https://github.com/WordPress/gutenberg/issues/30466#issuecomment-813910625), if some files are specified, it should be interpreted as follows by the external library [minimist](https://github.com/WordPress/gutenberg/blob/10f8542e26e83262f177cdcca30ca57ae516e644/packages/scripts/utils/cli.js#L24), and all files should be covered.

```bash
wp-scripts lint-style -- --fix test.js

to...

wp-scripts lint-style -- --fix=test.js
```


## How?
I found [an option in minimist](https://github.com/substack/minimist#var-argv--parseargsargs-opts) to properly handle double hyphenated arguments, so I applied it.

> opts.boolean - a boolean, string or array of strings to always treat as booleans. if true will treat all double hyphenated arguments without equal signs as boolean (e.g. affects --foo, not -f or --foo=bar)

## Testing Instructions

If you have the auto-formatting feature enabled in your code editor, turn it off once.

### lint-js

- Create three files, `test1.js`, `test2.js`, and `test3.js`, and write the following code:

```javascript
export const a="a";
```

- run `node ./packages/scripts/scripts/lint-js.js --fix test1.js test2.js`

- Only the two files you specify should be formatted as follows:

```javascript
export const a = 'a';
```

### lint-style

- Create three files, `test1.css`, `test2.css`, and `test3.css`, and write the following code:

```css
.test{font-size:10px}
```

- run `node ./packages/scripts/scripts/lint-style.js --fix test1.css test2.css`

- Only the two files you specify should be formatted as follows:

```css
.test {
	font-size: 10px;
}
```

