### PR TITLE
Show template part selection modal when inserting header or footer variations

### DIFF
--- a/packages/block-library/src/template-part/edit/index.js
+++ b/packages/block-library/src/template-part/edit/index.js
@@ -45,9 +45,6 @@ export default function TemplatePartEdit( {
 	const templatePartId = createTemplatePartId( theme, slug );
 	const [ hasAlreadyRendered, RecursionProvider ] =
 		useNoRecursiveRenders( templatePartId );
-	const [ isTemplatePartSelectionOpen, setIsTemplatePartSelectionOpen ] =
-		useState( false );
-
 	// Set the postId block attribute if it did not exist,
 	// but wait until the inner blocks have loaded to allow
 	// new edits to trigger this.
@@ -82,6 +79,10 @@ export default function TemplatePartEdit( {
 		},
 		[ templatePartId, clientId ]
 	);
+
+	const [ isTemplatePartSelectionOpen, setIsTemplatePartSelectionOpen ] =
+		useState( ! slug && [ 'header', 'footer' ].includes( area ) );
+
 	const { templateParts } = useAlternativeTemplateParts(
 		area,
 		templatePartId


### PR DESCRIPTION
## What?
This is an alternative version of #42142

## Why?
This should help explore alternative solutions that don't require such big API changes.

## How?
This PR differs from #42142 in that:
- In #42142, the inserter is responsible for showing the template part selection modal and the block is only inserted after an existing template part or pattern is selected from the modal
- In this PR, the template part block is inserted first, and the block shows the template part selection modal.

Pros:
- It's a very small code change
- Doesn't require a new block API

Cons:
- It can be a little bit glitchy compared to the other PR—you see a flash of the block being inserted first before the modal appears
- When using the quick inserter, the template part selection modal doesn't seem to display (reliably). I think the block placeholder is receiving focus in the background which causes the modal to close.
- Feels a bit hacky.
