### PR TITLE
Add aria-hidden to query pagination arrows

### DIFF
--- a/packages/block-library/src/query-pagination-next/edit.js
+++ b/packages/block-library/src/query-pagination-next/edit.js
@@ -35,6 +35,7 @@ export default function QueryPaginationNextEdit( {
 			{ displayArrow && (
 				<span
 					className={ `wp-block-query-pagination-next-arrow is-arrow-${ paginationArrow }` }
+					aria-hidden={ true }
 				>
 					{ displayArrow }
 				</span>

--- a/packages/block-library/src/query-pagination-previous/edit.js
+++ b/packages/block-library/src/query-pagination-previous/edit.js
@@ -25,6 +25,7 @@ export default function QueryPaginationPreviousEdit( {
 			{ displayArrow && (
 				<span
 					className={ `wp-block-query-pagination-previous-arrow is-arrow-${ paginationArrow }` }
+					aria-hidden={ true }
 				>
 					{ displayArrow }
 				</span>


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->
Fixes #41940

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
Screen readers announces the arrow icons. They shouldn't announce the icons because the icons are decorative.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
Adds aria-hidden= true to the span that is the container for the icon.

## Testing Instructions
Use Safari and VoiceOver (or other combo)
Make sure there are more than 10 published posts.
Go to the site Editor with the Twenty Twenty-Two theme activated
Navigate the Home template by using VoiceOver and go to the 'Next Page' block in the pagination
Use CTR+Option+ arrow to navigate to the link text and arrow
Observe that VoiceOver lo longer reads out the arrow as 'right arrow'

## Screenshots or screencast <!-- if applicable -->
