### PR TITLE
Fix typo in default category template's description

### DIFF
--- a/lib/compat/wordpress-6.1/block-template-utils.php
+++ b/lib/compat/wordpress-6.1/block-template-utils.php
@@ -24,6 +24,12 @@ function gutenberg_get_default_block_template_types( $default_template_types ) {
 			'description' => __( 'The default template for displaying any single post or attachment.', 'gutenberg' ),
 		);
 	}
+	if ( isset( $default_template_types['category'] ) ) {
+		$default_template_types['category'] = array(
+			'title'       => _x( 'Category', 'Template name', 'gutenberg' ),
+			'description' => __( 'Displays latest posts from a single post category.', 'gutenberg' ),
+		);
+	}
 	return $default_template_types;
 }
 add_filter( 'default_template_types', 'gutenberg_get_default_block_template_types', 10 );


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Resolves: https://github.com/WordPress/gutenberg/issues/42579

This PR updates the default category template's description from: `Displays latest posts in single post category.` to `Displays latest posts from a single post category.`.

From the issue:
>This came up as part of the [fifteenth call for testing for the FSE Outreach Program](https://make.wordpress.org/test/2022/07/11/fse-program-testing-call-15-category-customization/#comment-2612) which explores using the category templates:

> > The description for the category template would be clearer to me with an ‘a’ added: “Displays latest posts in a single post category.”


I also changed `in` to `from` to match the taxonomy description: `Displays latest posts from a single post taxonomy.`