### PR TITLE
Make the Templates list customized info accessible

### DIFF
--- a/packages/edit-site/src/components/list/added-by.js
+++ b/packages/edit-site/src/components/list/added-by.js
@@ -16,7 +16,6 @@ import {
 	plugins as pluginIcon,
 	globe as globeIcon,
 } from '@wordpress/icons';
-import { __ } from '@wordpress/i18n';
 
 const TEMPLATE_POST_TYPE_NAMES = [ 'wp_template', 'wp_template_part' ];
 
@@ -101,29 +100,6 @@ function AddedBySite() {
 	return (
 		<BaseAddedBy icon={ globeIcon } imageUrl={ logoURL } text={ name } />
 	);
-}
-
-export function CustomizedTemplateInfo( { template } ) {
-	// Template originally provided by a theme, but customized by a user.
-	// Templates originally didn't have the 'origin' field so identify
-	// older customized templates by checking for no origin and a 'theme'
-	// or 'custom' source.
-	if (
-		template.author &&
-		template.has_theme_file &&
-		( template.origin === 'theme' ||
-			( ! template.origin &&
-				[ 'theme', 'custom' ].includes( template.source ) ) ||
-			template.origin === 'plugin' )
-	) {
-		return (
-			<p className="edit-site-list-template-customized-info">
-				{ __( 'This template has been customized.' ) }
-			</p>
-		);
-	}
-
-	return null;
 }
 
 export default function AddedBy( { templateType, template } ) {

--- a/packages/edit-site/src/components/list/customized-template-info.js
+++ b/packages/edit-site/src/components/list/customized-template-info.js
@@ -1,0 +1,27 @@
+/**
+ * WordPress dependencies
+ */
+import { __ } from '@wordpress/i18n';
+
+export default function CustomizedTemplateInfo( { template } ) {
+	// Template originally provided by a theme, but customized by a user.
+	// Templates originally didn't have the 'origin' field so identify
+	// older customized templates by checking for no origin and a 'theme'
+	// or 'custom' source.
+	if (
+		template.author &&
+		template.has_theme_file &&
+		( template.origin === 'theme' ||
+			( ! template.origin &&
+				[ 'theme', 'custom' ].includes( template.source ) ) ||
+			template.origin === 'plugin' )
+	) {
+		return (
+			<p className="edit-site-list-template-customized-info">
+				{ __( 'This template has been customized.' ) }
+			</p>
+		);
+	}
+
+	return null;
+}

--- a/packages/edit-site/src/components/list/style.scss
+++ b/packages/edit-site/src/components/list/style.scss
@@ -157,18 +157,6 @@
 	svg {
 		fill: $white;
 	}
-
-	&.is-customized::after {
-		position: absolute;
-		content: "";
-		background: var(--wp-admin-theme-color);
-		height: $grid-unit-10;
-		width: $grid-unit-10;
-		outline: 2px solid $white;
-		border-radius: 100%;
-		top: -1px;
-		right: -1px;
-	}
 }
 
 .edit-site-list-added-by__avatar {
@@ -192,5 +180,21 @@
 		img {
 			opacity: 1;
 		}
+	}
+}
+
+.edit-site-list-template-customized-info {
+	display: flex;
+	align-items: center;
+	margin: $grid-unit-05 0 0;
+
+	&::before {
+		content: "";
+		background: var(--wp-admin-theme-color);
+		height: $grid-unit-10;
+		width: $grid-unit-10;
+		outline: 2px solid $white;
+		border-radius: 100%;
+		margin-right: $grid-unit-05;
 	}
 }

--- a/packages/edit-site/src/components/list/table.js
+++ b/packages/edit-site/src/components/list/table.js
@@ -15,7 +15,8 @@ import { decodeEntities } from '@wordpress/html-entities';
  */
 import Link from '../routes/link';
 import Actions from './actions';
-import AddedBy, { CustomizedTemplateInfo } from './added-by';
+import AddedBy from './added-by';
+import CustomizedTemplateInfo from './customized-template-info';
 
 export default function Table( { templateType } ) {
 	const { records: templates, isResolving: isLoading } = useEntityRecords(

--- a/packages/edit-site/src/components/list/table.js
+++ b/packages/edit-site/src/components/list/table.js
@@ -15,7 +15,7 @@ import { decodeEntities } from '@wordpress/html-entities';
  */
 import Link from '../routes/link';
 import Actions from './actions';
-import AddedBy from './added-by';
+import AddedBy, { CustomizedTemplateInfo } from './added-by';
 
 export default function Table( { templateType } ) {
 	const { records: templates, isResolving: isLoading } = useEntityRecords(
@@ -95,6 +95,7 @@ export default function Table( { templateType } ) {
 								</Link>
 							</Heading>
 							{ template.description }
+							<CustomizedTemplateInfo template={ template } />
 						</td>
 
 						<td className="edit-site-list-table-column" role="cell">


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->
Fixes https://github.com/WordPress/gutenberg/issues/42557

## What?
<!-- In a few words, what is the PR actually doing? -->
In the Templates list, makes the indication of whether a template has been customized accessible to all users.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
The 'blue dot' and tooltip to indicate a template that has been customized by a user are not accessible. The tooltip is only shown on hover, thus isn't accessible to keyboard users and screen reader users. There's no other textual information available. Also, this is a _data_ table. The 'Added by' column should only contain the data type indicated by the column header: who/what added the template. Instead, the 'customized info' is more related to the template _state_. The first column seems a more appropriate place for this information, as it's more a generic data type about the 'template details' (name, description, and state).

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
Split the 'customized info' to a separate component that renders visible text in the first column.
There are several conditions in the logic to determine whether a template has been customized by a user. Previously, _one_ of the conditions was based on (no) `imageUrl`. I changed it to 'if there is a template author'. The other conditions are unchanged. I'd appreciate some help to check if this is correct. Cc @talldan 🙏 

## Testing Instructions
- Create a custom template (Templates list > Add new > Custom template).
- Customize one of the templates supplied by the theme.
- Go to the Templates list.
- Check the customized info is only displayed for the theme template you customized.
- Observe the customized info is now visible text in the first table column.

## Screenshots or screencast <!-- if applicable -->

Before:

<img width="1040" alt="before" src="https://user-images.githubusercontent.com/1682452/180172387-59196b66-af21-459b-a760-cf8fe8299327.png">

After:

<img width="1041" alt="after" src="https://user-images.githubusercontent.com/1682452/180172447-34953244-7379-4376-b7d2-e0fe2f0d5fac.png">
