### PR TITLE
Allow post title block to use a <p> element

### DIFF
--- a/packages/block-library/src/post-title/edit.js
+++ b/packages/block-library/src/post-title/edit.js
@@ -20,7 +20,8 @@ import { useEntityProp } from '@wordpress/core-data';
 /**
  * Internal dependencies
  */
-import HeadingLevelDropdown from '../heading/heading-level-dropdown';
+import LevelControl from '../site-title/edit/level-toolbar';
+import LevelIcon from '../site-title/edit/level-icon';
 import { useCanEditEntity } from '../utils/hooks';
 
 export default function PostTitleEdit( {
@@ -102,8 +103,9 @@ export default function PostTitleEdit( {
 	return (
 		<>
 			<BlockControls group="block">
-				<HeadingLevelDropdown
-					selectedLevel={ level }
+				<LevelControl
+					icon={ <LevelIcon level={ level } /> }
+					level={ level }
 					onChange={ ( newLevel ) =>
 						setAttributes( { level: newLevel } )
 					}


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->
Allows the post title to use `<p>` in addition to heading level 1-6.
This is a  proppsal for solving #30549.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
Headings are not always the ideal element for the title, depending on the design.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
Instead of importing the heading level from the heading block, the post title now imports the level drop down and icon from the site title block, which already allows using the `<p>` tag.

## Testing Instructions

1. Apply the PR
2. In the block editor, add a post title block.
3. In the block toolbar, change the level to P.
4. Confirm that the tag changes in the editor and front.
5. Confirm that any styles applied to the block in global styles or theme.json are still applied with the P tag in use.
6. Make changes to the block's typography and color settings and confirm that they save and display correctly.

## Screenshots or screencast <!-- if applicable -->

![post title block displaying the paragraph and heading level options in the block toolbar.](https://user-images.githubusercontent.com/7422055/180185259-5ed5b7a8-085c-440d-98b7-740c2385a4d6.png)

