### PR TITLE
Site Editor: Remove leftover class

### DIFF
--- a/packages/edit-site/src/style.scss
+++ b/packages/edit-site/src/style.scss
@@ -26,7 +26,6 @@ html.wp-toolbar {
 	background: $white;
 }
 
-body.appearance_page_gutenberg-edit-site,
 body.site-editor-php {
 	@include wp-admin-reset(".edit-site");
 }


### PR DESCRIPTION
## What?
PR removes leftover class for plugin's custom Site Editor page.

## Why?
This page and class aren't used anymore.

## Testing Instructions
None. The change doesn't affect anything—just a cleanup.