### PR TITLE
Annotation API: fix __experimentalGetPropsForEditableTreePreparation

### DIFF
--- a/packages/block-editor/src/components/rich-text/use-format-types.js
+++ b/packages/block-editor/src/components/rich-text/use-format-types.js
@@ -145,10 +145,11 @@ export function useFormatTypes( {
 					);
 			}
 
+			const selected = getPrefixedKeys( keyedSelected, type.name );
 			changeHandlers.push(
 				type.__experimentalCreateOnChangeEditableValue(
 					{
-						...( keyedSelected[ type.name ] || {} ),
+						...( typeof selected === 'object' ? selected : {} ),
 						...dispatchers,
 					},
 					{

--- a/packages/block-editor/src/components/rich-text/use-format-types.js
+++ b/packages/block-editor/src/components/rich-text/use-format-types.js
@@ -38,7 +38,7 @@ function prefixSelectKeys( selected, prefix ) {
 	return mapKeys( selected, ( value, key ) => `${ prefix }.${ key }` );
 }
 
-function getPrefixedKeys( selected, prefix ) {
+function getPrefixedSelectKeys( selected, prefix ) {
 	if ( selected[ prefix ] ) return selected[ prefix ];
 	return Object.keys( selected )
 		.filter( ( key ) => key.startsWith( prefix + '.' ) )
@@ -117,7 +117,7 @@ export function useFormatTypes( {
 	formatTypes.forEach( ( type ) => {
 		if ( type.__experimentalCreatePrepareEditableTree ) {
 			const handler = type.__experimentalCreatePrepareEditableTree(
-				getPrefixedKeys( keyedSelected, type.name ),
+				getPrefixedSelectKeys( keyedSelected, type.name ),
 				{
 					richTextIdentifier: identifier,
 					blockClientId: clientId,
@@ -145,7 +145,7 @@ export function useFormatTypes( {
 					);
 			}
 
-			const selected = getPrefixedKeys( keyedSelected, type.name );
+			const selected = getPrefixedSelectKeys( keyedSelected, type.name );
 			changeHandlers.push(
 				type.__experimentalCreateOnChangeEditableValue(
 					{

--- a/packages/block-editor/src/components/rich-text/use-format-types.js
+++ b/packages/block-editor/src/components/rich-text/use-format-types.js
@@ -1,12 +1,13 @@
 /**
+ * External dependencies
+ */
+import { mapKeys } from 'lodash';
+
+/**
  * WordPress dependencies
  */
 import { useMemo } from '@wordpress/element';
 import { useSelect, useDispatch } from '@wordpress/data';
-
-/**
- * Internal dependencies
- */
 import { store as richTextStore } from '@wordpress/rich-text';
 
 function formatTypesSelector( select ) {
@@ -31,6 +32,23 @@ const interactiveContentTags = new Set( [
 	'textarea',
 	'video',
 ] );
+
+function prefixSelectKeys( selected, prefix ) {
+	if ( typeof selected !== 'object' ) {
+		return { [ prefix ]: selected };
+	}
+
+	return mapKeys( selected, ( value, key ) => `${ prefix }.${ key }` );
+}
+
+function getPrefixedKeys( selected, prefix ) {
+	return Object.keys( selected )
+		.filter( ( key ) => key.startsWith( prefix + '.' ) )
+		.reduce( ( accumulator, key ) => {
+			accumulator[ key.slice( prefix.length + 1 ) ] = selected[ key ];
+			return accumulator;
+		}, {} );
+}
 
 /**
  * This hook provides RichText with the `formatTypes` and its derived props from
@@ -68,18 +86,23 @@ export function useFormatTypes( {
 	const keyedSelected = useSelect(
 		( select ) =>
 			formatTypes.reduce( ( accumulator, type ) => {
-				if ( type.__experimentalGetPropsForEditableTreePreparation ) {
-					accumulator[ type.name ] =
+				if ( ! type.__experimentalGetPropsForEditableTreePreparation ) {
+					return accumulator;
+				}
+
+				return {
+					...accumulator,
+					...prefixSelectKeys(
 						type.__experimentalGetPropsForEditableTreePreparation(
 							select,
 							{
 								richTextIdentifier: identifier,
 								blockClientId: clientId,
 							}
-						);
-				}
-
-				return accumulator;
+						),
+						type.name
+					),
+				};
 			}, {} ),
 		[ formatTypes, clientId, identifier ]
 	);
@@ -89,11 +112,14 @@ export function useFormatTypes( {
 	const changeHandlers = [];
 	const dependencies = [];
 
+	for ( const key in keyedSelected ) {
+		dependencies.push( keyedSelected[ key ] );
+	}
+
 	formatTypes.forEach( ( type ) => {
 		if ( type.__experimentalCreatePrepareEditableTree ) {
-			const selected = keyedSelected[ type.name ];
 			const handler = type.__experimentalCreatePrepareEditableTree(
-				selected,
+				getPrefixedKeys( keyedSelected, type.name ),
 				{
 					richTextIdentifier: identifier,
 					blockClientId: clientId,
@@ -104,10 +130,6 @@ export function useFormatTypes( {
 				valueHandlers.push( handler );
 			} else {
 				prepareHandlers.push( handler );
-			}
-
-			for ( const key in selected ) {
-				dependencies.push( selected[ key ] );
 			}
 		}
 

--- a/packages/block-editor/src/components/rich-text/use-format-types.js
+++ b/packages/block-editor/src/components/rich-text/use-format-types.js
@@ -34,14 +34,12 @@ const interactiveContentTags = new Set( [
 ] );
 
 function prefixSelectKeys( selected, prefix ) {
-	if ( typeof selected !== 'object' ) {
-		return { [ prefix ]: selected };
-	}
-
+	if ( typeof selected !== 'object' ) return { [ prefix ]: selected };
 	return mapKeys( selected, ( value, key ) => `${ prefix }.${ key }` );
 }
 
 function getPrefixedKeys( selected, prefix ) {
+	if ( selected[ prefix ] ) return selected[ prefix ];
 	return Object.keys( selected )
 		.filter( ( key ) => key.startsWith( prefix + '.' ) )
 		.reduce( ( accumulator, key ) => {

--- a/packages/format-library/src/default-formats.js
+++ b/packages/format-library/src/default-formats.js
@@ -13,7 +13,39 @@ import { subscript } from './subscript';
 import { superscript } from './superscript';
 import { keyboard } from './keyboard';
 
+const caret = {
+	name: 'asblocks/caret',
+	title: 'Example',
+	tagName: 'mark',
+	className: 'caret',
+	attributes: {
+		id: 'id',
+		className: 'class',
+	},
+	edit() {
+		return null;
+	},
+	__experimentalGetPropsForEditableTreePreparation(
+		select,
+		{ blockClientId }
+	) {
+		// Just calling this, will make the text selection to be unreliable
+		// If you comment out this line, then everything works fine.
+		select( 'core/block-editor' ).getBlockName( blockClientId );
+
+		return {
+			carets: [],
+		};
+	},
+	__experimentalCreatePrepareEditableTree() {
+		return ( formats ) => {
+			return formats;
+		};
+	},
+};
+
 export default [
+	caret,
 	bold,
 	code,
 	image,

--- a/packages/format-library/src/default-formats.js
+++ b/packages/format-library/src/default-formats.js
@@ -29,12 +29,8 @@ const caret = {
 		select,
 		{ blockClientId }
 	) {
-		// Just calling this, will make the text selection to be unreliable
-		// If you comment out this line, then everything works fine.
-		select( 'core/block-editor' ).getBlockName( blockClientId );
-
 		return {
-			carets: [],
+			carets: select( 'core/block-editor' ).getBlockName( blockClientId ),
 		};
 	},
 	__experimentalCreatePrepareEditableTree() {

--- a/packages/format-library/src/default-formats.js
+++ b/packages/format-library/src/default-formats.js
@@ -13,35 +13,7 @@ import { subscript } from './subscript';
 import { superscript } from './superscript';
 import { keyboard } from './keyboard';
 
-const caret = {
-	name: 'asblocks/caret',
-	title: 'Example',
-	tagName: 'mark',
-	className: 'caret',
-	attributes: {
-		id: 'id',
-		className: 'class',
-	},
-	edit() {
-		return null;
-	},
-	__experimentalGetPropsForEditableTreePreparation(
-		select,
-		{ blockClientId }
-	) {
-		return {
-			carets: select( 'core/block-editor' ).getBlockName( blockClientId ),
-		};
-	},
-	__experimentalCreatePrepareEditableTree() {
-		return ( formats ) => {
-			return formats;
-		};
-	},
-};
-
 export default [
-	caret,
 	bold,
 	code,
 	image,


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?

Fixes #23428.

When `__experimentalGetPropsForEditableTreePreparation` returns an object with multiple keys, the object itself is not a stable key that can be in turn returned as a key with `useSelect`.

In other words, this ends up being passed to `useSelect`, which will cause excessive rerenders:

```
{
  'core/format-bold': {
    somethingSelected,
    anotherThing,
  }
}
```

Solution: flatten the tree to:

```
{
  'core/format-bold.somethingSelected': somethingSelected,
  'core/format-bold.anotherThing': anotherThing,
}
```

So that `useSelect` can do its shallow equal magic.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

## Testing Instructions

See #23428. Create a format that subscribes to the block editor store:

```js
{
 	name: 'asblocks/caret',
 	title: 'Example',
 	tagName: 'mark',
 	className: 'caret',
 	attributes: {},
 	edit() {
 		return null;
 	},
 	__experimentalGetPropsForEditableTreePreparation( select ) {
 		select( 'core/block-editor' );
 		return {};
 	},
 	__experimentalCreatePrepareEditableTree() {
 		return ( formats ) => {
 			return formats;
 		};
 	},
 }
```

> I wanted to add an e2e test, but it seems incredibly hard to write a test case that consistently fails in trunk. I tried to subscribe the test annotation format to the block editor store, which should cause a lot of re-renders on select, but the tests still pass.

https://github.com/WordPress/gutenberg/issues/23428#issuecomment-1192403771

## Screenshots or screencast <!-- if applicable -->
