### PR TITLE
Custom labelling/naming of blocks in List View

### DIFF
--- a/packages/block-editor/src/components/list-view/block-contents.js
+++ b/packages/block-editor/src/components/list-view/block-contents.js
@@ -171,6 +171,7 @@ const ListViewBlockContents = forwardRef(
 							toggleLabelEditingMode={ toggleLabelEditingMode }
 							supportsBlockNaming={ supportsBlockNaming }
 							blockTitle={ blockTitle }
+							clientId={ clientId }
 							{ ...props }
 						/>
 					) }

--- a/packages/block-editor/src/components/list-view/block-input.js
+++ b/packages/block-editor/src/components/list-view/block-input.js
@@ -1,0 +1,144 @@
+/**
+ * WordPress dependencies
+ */
+import {
+	__experimentalHStack as HStack,
+	__experimentalTruncate as Truncate,
+	__experimentalInputControl as InputControl,
+	VisuallyHidden,
+} from '@wordpress/components';
+import { speak } from '@wordpress/a11y';
+import { useInstanceId, useFocusOnMount } from '@wordpress/compose';
+import { forwardRef, useState } from '@wordpress/element';
+import { ENTER, ESCAPE } from '@wordpress/keycodes';
+import { __, sprintf } from '@wordpress/i18n';
+import { Icon, lock } from '@wordpress/icons';
+
+/**
+ * External dependencies
+ */
+import classnames from 'classnames';
+
+/**
+ * Internal dependencies
+ */
+import BlockIcon from '../block-icon';
+import ListViewExpander from './expander';
+
+const ListViewBlockInput = forwardRef(
+	(
+		{
+			className,
+			onToggleExpanded,
+			toggleLabelEditingMode,
+			blockInformation,
+			isLocked,
+			blockTitle,
+			onSubmit,
+		},
+		ref
+	) => {
+		const inputRef = useFocusOnMount();
+		const inputDescriptionId = useInstanceId(
+			ListViewBlockInput,
+			`block-editor-list-view-block-node__input-description`
+		);
+
+		// Local state for value of input **pre-submission**.
+		const [ inputValue, setInputValue ] = useState( blockTitle );
+
+		const onKeyDownHandler = ( event ) => {
+			// Trap events to input when editing to avoid
+			// default list view key handing (e.g. arrow
+			// keys for navigation).
+			event.stopPropagation();
+
+			// Handle ENTER and ESC exits editing mode.
+			if ( event.keyCode === ENTER || event.keyCode === ESCAPE ) {
+				if ( event.keyCode === ESCAPE ) {
+					// Must be assertive to immediately announce change.
+					speak( 'Leaving edit mode', 'assertive' );
+				}
+
+				if ( event.keyCode === ENTER ) {
+					// Submit changes only for ENTER.
+					onSubmit( inputValue );
+					const successAnnouncement = sprintf(
+						/* translators: %s: new name/label for the block */
+						__( 'Block name updated to: "%s".' ),
+						inputValue
+					);
+					// Must be assertive to immediately announce change.
+					speak( successAnnouncement, 'assertive' );
+				}
+
+				toggleLabelEditingMode( false );
+			}
+		};
+
+		return (
+			<div
+				ref={ ref }
+				className={ classnames(
+					'block-editor-list-view-block-node',
+					'block-editor-list-view-block-input',
+					className
+				) }
+			>
+				<ListViewExpander onClick={ onToggleExpanded } />
+				<BlockIcon icon={ blockInformation?.icon } showColors />
+				<HStack
+					alignment="center"
+					className="block-editor-list-view-block-node__label-wrapper"
+					justify="flex-start"
+					spacing={ 1 }
+				>
+					<span className="block-editor-list-view-block-node__title">
+						<InputControl
+							ref={ inputRef }
+							value={ inputValue }
+							label={ __( 'Edit block name' ) }
+							hideLabelFromVision
+							onChange={ ( nextValue ) => {
+								setInputValue( nextValue ?? '' );
+							} }
+							onBlur={ () => {
+								toggleLabelEditingMode( false );
+
+								// Reset the input's local state to avoid
+								// stale values.
+								setInputValue( blockTitle );
+							} }
+							onKeyDown={ onKeyDownHandler }
+							aria-describedby={ inputDescriptionId }
+						/>
+						<VisuallyHidden>
+							<p id={ inputDescriptionId }>
+								{ __(
+									'Press the ENTER key to submit or the ESCAPE key to cancel.'
+								) }
+							</p>
+						</VisuallyHidden>
+					</span>
+					{ blockInformation?.anchor && (
+						<span className="block-editor-list-view-block-node__anchor-wrapper">
+							<Truncate
+								className="block-editor-list-view-block-node__anchor"
+								ellipsizeMode="auto"
+							>
+								{ blockInformation.anchor }
+							</Truncate>
+						</span>
+					) }
+					{ isLocked && (
+						<span className="block-editor-list-view-block-node__lock">
+							<Icon icon={ lock } />
+						</span>
+					) }
+				</HStack>
+			</div>
+		);
+	}
+);
+
+export default ListViewBlockInput;

--- a/packages/block-editor/src/components/list-view/block-options-rename-item.js
+++ b/packages/block-editor/src/components/list-view/block-options-rename-item.js
@@ -1,0 +1,44 @@
+/**
+ * WordPress dependencies
+ */
+import { MenuItem } from '@wordpress/components';
+
+import { __ } from '@wordpress/i18n';
+
+/**
+ * Internal dependencies
+ */
+
+import BlockSettingsMenuControls from '../block-settings-menu-controls';
+
+function BlockOptionsRenameItem( { clientId, onClick } ) {
+	return (
+		<BlockSettingsMenuControls>
+			{ ( { selectedClientIds, __unstableDisplayLocation } ) => {
+				// Only enabled for single selections.
+				const canRename =
+					selectedClientIds.length === 1 &&
+					clientId === selectedClientIds[ 0 ];
+
+				// This check ensures
+				// - the `BlockSettingsMenuControls` fill
+				// doesn't render multiple times and also that it renders for
+				// the block from which the menu was triggered.
+				// - `Rename` only appears in the ListView options.
+				// - `Rename` only appears for blocks that support renaming.
+				if (
+					__unstableDisplayLocation !== 'list-view' ||
+					! canRename
+				) {
+					return null;
+				}
+
+				return (
+					<MenuItem onClick={ onClick }>{ __( 'Rename' ) }</MenuItem>
+				);
+			} }
+		</BlockSettingsMenuControls>
+	);
+}
+
+export default BlockOptionsRenameItem;

--- a/packages/block-editor/src/components/list-view/block-select-button.js
+++ b/packages/block-editor/src/components/list-view/block-select-button.js
@@ -189,15 +189,15 @@ function ListViewBlockSelectButton(
 				/>
 				<HStack
 					alignment="center"
-					className="block-editor-list-view-block-node__label-wrapper"
+					className="block-editor-list-view-block-select-button__label-wrapper"
 					justify="flex-start"
 					spacing={ 1 }
 				>
-					<span className="block-editor-list-view-block-node__title">
+					<span className="block-editor-list-view-block-select-button__title">
 						<Truncate ellipsizeMode="auto">{ blockTitle }</Truncate>
 					</span>
 					{ blockInformation?.anchor && (
-						<span className="block-editor-list-view-block-node__anchor-wrapper">
+						<span className="block-editor-list-view-block-select-button__anchor-wrapper">
 							<Truncate
 								className="block-editor-list-view-block-node__anchor"
 								ellipsizeMode="auto"
@@ -231,7 +231,7 @@ function ListViewBlockSelectButton(
 						</span>
 					) : null }
 					{ isLocked && (
-						<span className="block-editor-list-view-block-node__lock">
+						<span className="block-editor-list-view-block-select-button__lock">
 							<Icon icon={ lock } />
 						</span>
 					) }

--- a/packages/block-editor/src/components/list-view/block.js
+++ b/packages/block-editor/src/components/list-view/block.js
@@ -102,19 +102,28 @@ function ListViewBlock( {
 		level
 	);
 
-	const blockAriaLabel = isLocked
+	let blockAriaLabel = __( 'Link' );
+	if ( blockInformation ) {
+		blockAriaLabel = isLocked
+			? sprintf(
+					// translators: %s: The title of the block. This string indicates a link to select the locked block.
+					__( '%s link (locked)' ),
+					blockInformation.name || blockInformation.title
+			  )
+			: sprintf(
+					// translators: %s: The title of the block. This string indicates a link to select the block.
+					__( '%s link' ),
+					blockInformation.name || blockInformation.title
+			  );
+	}
+
+	const settingsAriaLabel = blockInformation
 		? sprintf(
 				// translators: %s: The title of the block. This string indicates a link to select the locked block.
 				__( '%s (locked)' ),
 				blockTitle
 		  )
 		: blockTitle;
-
-	const settingsAriaLabel = sprintf(
-		// translators: %s: The title of the block.
-		__( 'Options for %s' ),
-		blockTitle
-	);
 
 	const {
 		isTreeGridMounted,

--- a/packages/block-editor/src/components/list-view/style.scss
+++ b/packages/block-editor/src/components/list-view/style.scss
@@ -299,11 +299,11 @@
 		}
 	}
 
-	.block-editor-list-view-block-select-button__label-wrapper {
+	.block-editor-list-view-block-node__label-wrapper {
 		min-width: 120px;
 	}
 
-	.block-editor-list-view-block-select-button__title {
+	.block-editor-list-view-block-node__title {
 		flex: 1;
 		position: relative;
 
@@ -312,15 +312,23 @@
 			width: 100%;
 			transform: translateY(-50%);
 		}
+
+		/* Match input's text position with non-editable visual state */
+		.components-input-control {
+			height: 24px;
+			position: relative;
+			left: -8px;
+			border-radius: $radius-block-ui * 2;
+		}
 	}
 
-	.block-editor-list-view-block-select-button__anchor-wrapper {
+	.block-editor-list-view-block-node__anchor-wrapper {
 		position: relative;
 		max-width: min(110px, 40%);
 		width: 100%;
 	}
 
-	.block-editor-list-view-block-select-button__anchor {
+	.block-editor-list-view-block-node__anchor {
 		position: absolute;
 		right: 0;
 		transform: translateY(-50%);
@@ -328,10 +336,11 @@
 		border-radius: $radius-block-ui;
 		padding: 2px 6px;
 		max-width: 100%;
+		overflow: hidden;
 		box-sizing: border-box;
 	}
 
-	&.is-selected .block-editor-list-view-block-select-button__anchor {
+	&.is-selected .block-editor-list-view-block-node__anchor {
 		background: rgba($black, 0.3);
 	}
 
@@ -364,6 +373,11 @@
 			box-shadow: 0 0 0 $radius-block-ui var(--wp-admin-theme-color);
 		}
 	}
+}
+
+.block-editor-list-view-block-node__description,
+.block-editor-list-view-appender__description {
+	display: none;
 }
 
 .block-editor-list-view-block__contents-cell,

--- a/packages/block-editor/src/components/use-block-display-information/index.js
+++ b/packages/block-editor/src/components/use-block-display-information/index.js
@@ -26,6 +26,7 @@ import { store as blockEditorStore } from '../../store';
  * @property {WPIcon}  icon        Block type icon.
  * @property {string}  description A detailed block type description.
  * @property {string}  anchor      HTML anchor.
+ * @property {?string} name        Human-readable, user-provided custom name for the block.
  */
 
 /**
@@ -94,6 +95,7 @@ export default function useBlockDisplayInformation( clientId ) {
 				anchor: attributes?.anchor,
 				positionLabel,
 				positionType: attributes?.style?.position?.type,
+				name: attributes?.metadata?.name,
 			};
 			if ( ! match ) return blockTypeInfo;
 
@@ -105,6 +107,7 @@ export default function useBlockDisplayInformation( clientId ) {
 				anchor: attributes?.anchor,
 				positionLabel,
 				positionType: attributes?.style?.position?.type,
+				name: attributes?.metadata?.name,
 			};
 		},
 		[ clientId ]

--- a/packages/block-library/src/group/block.json
+++ b/packages/block-library/src/group/block.json
@@ -21,6 +21,7 @@
 		}
 	},
 	"supports": {
+		"__experimentalMetadata": true,
 		"__experimentalOnEnter": true,
 		"__experimentalOnMerge": true,
 		"__experimentalSettings": true,


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->
![Screen Capture on 2022-07-21 at 16-23-01](https://user-images.githubusercontent.com/444434/180251831-9415b5ee-8e2f-4d2b-b187-791637d51ce3.gif)

## What?
<!-- In a few words, what is the PR actually doing? -->

In https://github.com/WordPress/gutenberg/issues/33583 we learnt that many people want to be able to give blocks in the List View a custom name/label.

This PR ~is an experiment to~ explores how this might work. Currently it works for **Group blocks only** and allows you to **double click on the block name** and provide an alternative label for the block.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

It's an important feature to allow users to distinguish between blocks in the List View. Given that they are currently all labelled by the block name it can be difficult to distinguish between them.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

This builds upon the great work in https://github.com/WordPress/gutenberg/pull/41855 and now also from https://github.com/WordPress/gutenberg/pull/40393.

In short it:

- ~adds Block Supports definitions for `__experimentalMetadata`.~ done separately in https://github.com/WordPress/gutenberg/pull/43986
- enables support for this on the Group Block.
- adds automatic generation of the `__experimentalLabel`  method on block settings to utilise the `name` attribute if it is set.
- uses the custom label stored in the block's metadata attribute if set.
- updates List View block nodes to have an "editable" mode which is accessible on double click (a11y has been considered an an alternative method will be implemented prior to merging this PR).
- when the user "commits" their custom label, the block's metadata attribute is updated.

~The approach of using a block attribute to store this alias is up for debate. I favour it because , by virtue of it being a block attribute, it is portable between editors/posts...etc. This may not be desirable however and we may prefer to store this information in the editor settings on a per editor basis.~ Solution shipped in https://github.com/WordPress/gutenberg/pull/43986.



## Todo

- [x] Arrow keys don't work correctly in the input. I think it should behave as a modal does where the events don't bubble out.
- [x] Escape could cancel editing - currently it closes List View. 
- [x] Drag and drop should also probably be disabled while editing.
- [x] Disable for blocks except Group!
- [x] A11y - add "edit" interaction to the 3 dots option menu to ensure interaction is accessible via keyboard
- [x] Automatically generate `__experimentalLabel` function on block settings if metadata support for `name` is enabled on block.
- [x] Update to `__experimentalMetadata` to bring into line with https://github.com/WordPress/gutenberg/pull/40393
- [x] Lock down feature to Group block only (again).
- [ ] Consider updating `packages/block-editor/src/components/block-title/use-block-display-title.js` to utilise metadata to retrieve the custom name. This will greatly expand the scope of the PR.
- [x] Fix bug where Cmd + A (i.e. "Select all") in the input element, triggers selection of all blocks in the List View.
- [x] Add tests for `hasBlockMetadataSupport` 
- [x] Make `hasBlockMetadataSupport` `__experimental`.
- [ ] Fix ListView item focus handling when hitting `ENTER` - currently returns to canvas.


## Potential followup features

The following features probably won't make the cut for _this_ PR but could/should be considered for future:

- [Backport `metadata` attribute to WP Core](https://github.com/WordPress/wordpress-develop/blob/60284ca7516e31ebbefa4875772e687e42a90a8f/src/wp-includes/class-wp-block-type.php#L207-L215).
- [Can we take the name and make it the element's ID and/or class as well? And (to be perfect) attach it to the surrounding (parent) block-DIV as a class, e.g. div id="block-16" class="widget widget_block customname"?](https://github.com/WordPress/gutenberg/pull/42605#issuecomment-1192308185)


## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->

- Add a few Group blocks to a Post.
- Toggle List View.
- Double click the name of the Group blocks to enter "editing mode".
- Enter a custom label and hit `ENTER`.
- See the label persisted as an `alias` attribute.
- Reload page. See custom label is preserved.



## Screenshots or screencast <!-- if applicable -->


https://user-images.githubusercontent.com/444434/182180577-ef5d1b7b-0bd0-4bdf-81b4-bc7dff4e18f6.mov



Closes https://github.com/WordPress/gutenberg/issues/33583

Co-authored-by: Alex Stine <alex.stine@yourtechadvisors.com>
Co-authored-by: Jorge Costa <jorge.costa@developer.pt>
Co-authored-by: Andrei Draganescu <107534+draganescu@users.noreply.github.com>
