### PR TITLE
BorderControl: Make fieldset and legend use optional

### DIFF
--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -11,6 +11,7 @@
 ### Enhancements
 
 -   `BorderControl`: Improve labelling, tooltips and DOM structure ([#42348](https://github.com/WordPress/gutenberg/pull/42348/)).
+-   `BorderControl`: Allow optional rendering as fieldset with legend ([#42611](https://github.com/WordPress/gutenberg/pull/42611)).
 -   `BaseControl`: Set zero padding on `StyledLabel` to ensure cross-browser styling ([#42348](https://github.com/WordPress/gutenberg/pull/42348/)).
 -   `InputControl`: Implement wrapper subcomponents for adding responsive padding to `prefix`/`suffix` ([#42378](https://github.com/WordPress/gutenberg/pull/42378)).
 -   `SelectControl`: Add flag for larger default size ([#42456](https://github.com/WordPress/gutenberg/pull/42456/)).

--- a/packages/components/src/border-control/border-control/README.md
+++ b/packages/components/src/border-control/border-control/README.md
@@ -113,6 +113,14 @@ _Note: the value may be `undefined` if a user clears all border properties._
 
 - Required: Yes
 
+### `renderAsFieldset`: `boolean`
+
+Whether or not the `BorderControl` should render as a fieldset and use a legend
+for its label.
+
+- Required: No
+- Default: false
+
 ### `shouldSanitizeBorder`: `boolean`
 
 If opted into, sanitizing the border means that if no width or color have been

--- a/packages/components/src/border-control/border-control/component.tsx
+++ b/packages/components/src/border-control/border-control/component.tsx
@@ -16,19 +16,19 @@ import { VisuallyHidden } from '../../visually-hidden';
 import { contextConnect, WordPressComponentProps } from '../../ui/context';
 import { useBorderControl } from './hook';
 
-import type { BorderControlProps, LabelProps } from '../types';
+import type { BorderControlProps, BorderLabelProps } from '../types';
 
-const BorderLabel = ( props: LabelProps ) => {
-	const { label, hideLabelFromVision } = props;
+const BorderLabel = ( props: BorderLabelProps ) => {
+	const { label, hideLabelFromVision, ...labelProps } = props;
 
 	if ( ! label ) {
 		return null;
 	}
 
 	return hideLabelFromVision ? (
-		<VisuallyHidden as="legend">{ label }</VisuallyHidden>
+		<VisuallyHidden { ...labelProps }>{ label }</VisuallyHidden>
 	) : (
-		<StyledLabel as="legend">{ label }</StyledLabel>
+		<StyledLabel { ...labelProps }>{ label }</StyledLabel>
 	);
 };
 
@@ -50,6 +50,7 @@ const UnconnectedBorderControl = (
 		placeholder,
 		__unstablePopoverProps,
 		previousStyleSelection,
+		renderAsFieldset = false,
 		showDropdownHeader,
 		sliderClassName,
 		value: border,
@@ -64,10 +65,15 @@ const UnconnectedBorderControl = (
 	} = useBorderControl( props );
 
 	return (
-		<View as="fieldset" { ...otherProps } ref={ forwardedRef }>
+		<View
+			as={ renderAsFieldset ? 'fieldset' : undefined }
+			{ ...otherProps }
+			ref={ forwardedRef }
+		>
 			<BorderLabel
 				label={ label }
 				hideLabelFromVision={ hideLabelFromVision }
+				as={ renderAsFieldset ? 'legend' : undefined }
 			/>
 			<HStack spacing={ 3 }>
 				<HStack className={ innerWrapperClassName } alignment="stretch">

--- a/packages/components/src/border-control/types.ts
+++ b/packages/components/src/border-control/types.ts
@@ -60,6 +60,13 @@ export type LabelProps = {
 	label?: string;
 };
 
+export type BorderLabelProps = LabelProps & {
+	/**
+	 * Allows rendering the label as a legend for use inside a fieldset.
+	 */
+	as?: 'legend';
+};
+
 export type BorderControlProps = ColorProps &
 	LabelProps & {
 		/**
@@ -84,6 +91,13 @@ export type BorderControlProps = ColorProps &
 		 * An internal prop used to control the visibility of the dropdown.
 		 */
 		__unstablePopoverProps?: Record< string, unknown >;
+		/**
+		 * Whether or not the `BorderControl` should render as a fieldset and
+		 * use a legend for its label.
+		 *
+		 * @default false
+		 */
+		renderAsFieldset?: boolean;
 		/**
 		 * If opted into, sanitizing the border means that if no width or color
 		 * have been selected, the border style is also cleared and `undefined`


### PR DESCRIPTION
Related:
- https://github.com/WordPress/gutenberg/issues/42095
- https://github.com/WordPress/gutenberg/pull/42348
- https://github.com/WordPress/gutenberg/pull/42351

## What?

Makes rendering the `BorderControl` as a `fieldset` with a `legend` for its label, optional.

## Why?

The `BorderControl` is primarily used within the `BorderBoxControl` which itself should be a `fieldset`. This PR facilitates avoiding nested fieldsets.

Further context can be found here: https://github.com/WordPress/gutenberg/pull/42351#issuecomment-1188767776

## How?

- Adds a new `renderAsFieldset` prop to the `BorderControl`
- Updates the `BorderControl` to render using a fieldset/legend combo based on the new prop

## Testing Instructions
1. Checkout this PR and start up the Storybook: `npm run storybook:dev`
2. Vist the [`BorderControl` page](http://localhost:50240/?path=/story/components-experimental-bordercontrol--default)
3. Inspect the control and note by default its wrapper should be a `div` with `label`
4. Toggle the `renderAsFieldset` prop to true i the controls
5. Re-inspect the control, it should now be using a `fieldset`/`legend` combo. There should also be no visual change.
