### PR TITLE
Layout: Add not .alignfull rule from root CSS PR

### DIFF
--- a/lib/block-supports/layout.php
+++ b/lib/block-supports/layout.php
@@ -54,7 +54,7 @@ function gutenberg_get_layout_style( $selector, $layout, $has_block_gap_support 
 		$wide_max_width_value = wp_strip_all_tags( explode( ';', $wide_max_width_value )[0] );
 
 		if ( $content_size || $wide_size ) {
-			$style  = "$selector > :where(:not(.alignleft):not(.alignright)) {";
+			$style  = "$selector > :where(:not(.alignleft):not(.alignright):not(.alignfull)) {";
 			$style .= 'max-width: ' . esc_html( $all_max_width_value ) . ';';
 			$style .= 'margin-left: auto !important;';
 			$style .= 'margin-right: auto !important;';

--- a/packages/block-editor/src/layouts/flow.js
+++ b/packages/block-editor/src/layouts/flow.js
@@ -132,7 +132,7 @@ export default {
 				? `
 					${ appendSelectors(
 						selector,
-						'> :where(:not(.alignleft):not(.alignright))'
+						'> :where(:not(.alignleft):not(.alignright):not(.alignfull))'
 					) } {
 						max-width: ${ contentSize ?? wideSize };
 						margin-left: auto !important;


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

As reported in #42604, Gutenberg 13.7 was released but didn't include the fix for full width alignment introduced in https://github.com/WordPress/gutenberg/pull/42085 (that PR is slated for 13.8).

This PR attempts to grab a couple of the fixes for the full width alignment, and targets the `release/13.7` branch. This PR exists in case it's desired to push a patch / point release without having to include or cherry pick all of https://github.com/WordPress/gutenberg/pull/42085.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

Due to the issue in #42604 causing issues for TwentyTwentyTwo (or themes with their own custom negative margin rules for full width alignment blocks) it could be worth a higher priority fix than waiting for 13.8.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

Add the `:not(.alignfull)` pseudo class rule to the content size and flow layouts so that the `!important` margin-left and margin-right rules aren't applied to full width alignment blocks.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->

Follow the testing steps in #42604 and see if this PR resolves the issue. Is it enough as a shorter-term fix, or do we need to revisit the specificity of the selectors?

## Screenshots or screencast <!-- if applicable -->

| Before | After |
| --- | --- |
| <img width="1263" alt="image" src="https://user-images.githubusercontent.com/14988353/180342927-ca92593d-795c-4b23-a271-501e5ff6b6ab.png"> | <img width="1264" alt="image" src="https://user-images.githubusercontent.com/14988353/180342855-6b741c01-9a32-447c-8087-f01b36eb376b.png"> |