### PR TITLE
Dimensions Global Styles: Split props into separate hooks to tidy up the panel component

### DIFF
--- a/packages/edit-site/src/components/global-styles/dimensions-panel.js
+++ b/packages/edit-site/src/components/global-styles/dimensions-panel.js
@@ -104,6 +104,115 @@ function splitStyleValue( value ) {
 	return value;
 }
 
+// Props for managing `layout.contentSize`.
+function useContentSizeProps( name ) {
+	const [ contentSizeValue, setContentSizeValue ] = useSetting(
+		'layout.contentSize',
+		name
+	);
+	const [ userSetContentSizeValue ] = useSetting(
+		'layout.contentSize',
+		name,
+		'user'
+	);
+	const hasUserSetContentSizeValue = () => !! userSetContentSizeValue;
+	const resetContentSizeValue = () => setContentSizeValue( '' );
+	return {
+		contentSizeValue,
+		setContentSizeValue,
+		hasUserSetContentSizeValue,
+		resetContentSizeValue,
+	};
+}
+
+// Props for managing `layout.wideSize`.
+function useWideSizeProps( name ) {
+	const [ wideSizeValue, setWideSizeValue ] = useSetting(
+		'layout.wideSize',
+		name
+	);
+	const [ userSetWideSizeValue ] = useSetting(
+		'layout.wideSize',
+		name,
+		'user'
+	);
+	const hasUserSetWideSizeValue = () => !! userSetWideSizeValue;
+	const resetWideSizeValue = () => setWideSizeValue( '' );
+	return {
+		wideSizeValue,
+		setWideSizeValue,
+		hasUserSetWideSizeValue,
+		resetWideSizeValue,
+	};
+}
+
+// Props for managing `spacing.padding`.
+function usePaddingProps( name ) {
+	const [ rawPadding, setRawPadding ] = useStyle( 'spacing.padding', name );
+	const paddingValues = splitStyleValue( rawPadding );
+	const paddingSides = useCustomSides( name, 'padding' );
+	const isAxialPadding =
+		paddingSides &&
+		paddingSides.some( ( side ) => AXIAL_SIDES.includes( side ) );
+
+	const setPaddingValues = ( newPaddingValues ) => {
+		const padding = filterValuesBySides( newPaddingValues, paddingSides );
+		setRawPadding( padding );
+	};
+	const resetPaddingValue = () => setPaddingValues( {} );
+	const hasPaddingValue = () =>
+		!! paddingValues && Object.keys( paddingValues ).length;
+
+	return {
+		paddingValues,
+		paddingSides,
+		isAxialPadding,
+		setPaddingValues,
+		resetPaddingValue,
+		hasPaddingValue,
+	};
+}
+
+// Props for managing `spacing.margin`.
+function useMarginProps( name ) {
+	const [ rawMargin, setRawMargin ] = useStyle( 'spacing.margin', name );
+	const marginValues = splitStyleValue( rawMargin );
+	const marginSides = useCustomSides( name, 'margin' );
+	const isAxialMargin =
+		marginSides &&
+		marginSides.some( ( side ) => AXIAL_SIDES.includes( side ) );
+
+	const setMarginValues = ( newMarginValues ) => {
+		const margin = filterValuesBySides( newMarginValues, marginSides );
+		setRawMargin( margin );
+	};
+	const resetMarginValue = () => setMarginValues( {} );
+	const hasMarginValue = () =>
+		!! marginValues && Object.keys( marginValues ).length;
+
+	return {
+		marginValues,
+		marginSides,
+		isAxialMargin,
+		setMarginValues,
+		resetMarginValue,
+		hasMarginValue,
+	};
+}
+
+// Props for managing `spacing.blockGap`.
+function useBlockGapProps( name ) {
+	const [ gapValue, setGapValue ] = useStyle( 'spacing.blockGap', name );
+	const resetGapValue = () => setGapValue( undefined );
+	const hasGapValue = () => !! gapValue;
+	return {
+		gapValue,
+		setGapValue,
+		resetGapValue,
+		hasGapValue,
+	};
+}
+
 export default function DimensionsPanel( { name } ) {
 	const showContentSizeControl = useHasContentSize( name );
 	const showWideSizeControl = useHasWideSize( name );
@@ -120,67 +229,45 @@ export default function DimensionsPanel( { name } ) {
 		],
 	} );
 
-	const [ contentSizeValue, setContentSizeValue ] = useSetting(
-		'layout.contentSize',
-		name
-	);
+	// Props for managing `layout.contentSize`.
+	const {
+		contentSizeValue,
+		setContentSizeValue,
+		hasUserSetContentSizeValue,
+		resetContentSizeValue,
+	} = useContentSizeProps( name );
 
-	const [ userSetContentSizeValue ] = useSetting(
-		'layout.contentSize',
-		name,
-		'user'
-	);
+	// Props for managing `layout.wideSize`.
+	const {
+		wideSizeValue,
+		setWideSizeValue,
+		hasUserSetWideSizeValue,
+		resetWideSizeValue,
+	} = useWideSizeProps( name );
 
-	const hasUserSetContentSizeValue = () => !! userSetContentSizeValue;
-	const resetContentSizeValue = () => setContentSizeValue( '' );
+	// Props for managing `spacing.padding`.
+	const {
+		paddingValues,
+		paddingSides,
+		isAxialPadding,
+		setPaddingValues,
+		resetPaddingValue,
+		hasPaddingValue,
+	} = usePaddingProps( name );
 
-	const [ wideSizeValue, setWideSizeValue ] = useSetting(
-		'layout.wideSize',
-		name
-	);
+	// Props for managing `spacing.margin`.
+	const {
+		marginValues,
+		marginSides,
+		isAxialMargin,
+		setMarginValues,
+		resetMarginValue,
+		hasMarginValue,
+	} = useMarginProps( name );
 
-	const [ userSetWideSizeValue ] = useSetting(
-		'layout.wideSize',
-		name,
-		'user'
-	);
-
-	const hasUserSetWideSizeValue = () => !! userSetWideSizeValue;
-	const resetWideSizeValue = () => setWideSizeValue( '' );
-
-	const [ rawPadding, setRawPadding ] = useStyle( 'spacing.padding', name );
-	const paddingValues = splitStyleValue( rawPadding );
-	const paddingSides = useCustomSides( name, 'padding' );
-	const isAxialPadding =
-		paddingSides &&
-		paddingSides.some( ( side ) => AXIAL_SIDES.includes( side ) );
-
-	const setPaddingValues = ( newPaddingValues ) => {
-		const padding = filterValuesBySides( newPaddingValues, paddingSides );
-		setRawPadding( padding );
-	};
-	const resetPaddingValue = () => setPaddingValues( {} );
-	const hasPaddingValue = () =>
-		!! paddingValues && Object.keys( paddingValues ).length;
-
-	const [ rawMargin, setRawMargin ] = useStyle( 'spacing.margin', name );
-	const marginValues = splitStyleValue( rawMargin );
-	const marginSides = useCustomSides( name, 'margin' );
-	const isAxialMargin =
-		marginSides &&
-		marginSides.some( ( side ) => AXIAL_SIDES.includes( side ) );
-
-	const setMarginValues = ( newMarginValues ) => {
-		const margin = filterValuesBySides( newMarginValues, marginSides );
-		setRawMargin( margin );
-	};
-	const resetMarginValue = () => setMarginValues( {} );
-	const hasMarginValue = () =>
-		!! marginValues && Object.keys( marginValues ).length;
-
-	const [ gapValue, setGapValue ] = useStyle( 'spacing.blockGap', name );
-	const resetGapValue = () => setGapValue( undefined );
-	const hasGapValue = () => !! gapValue;
+	// Props for managing `spacing.blockGap`.
+	const { gapValue, setGapValue, resetGapValue, hasGapValue } =
+		useBlockGapProps( name );
 
 	const resetAll = () => {
 		resetPaddingValue();


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Split the methods used for adjusting each of the different layout and spacing properties in the Dimensions global styles panel into separate hooks.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

Now that the `DimensionsPanel` component has more controls within it, I find it a little hard to read and comprehend. This could be personal preference, but I was wondering if it'll be easier to read and make changes to if we tuck the function / callback definitions for each layout or spacing property into its own hook.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

Take the existing logic of the callbacks in the `DimensionsPanel` in global styles, and place them inside hooks, based on the particular property being manipulated.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->

Test the the controls in the DimensionsPanel in global styles behaves as on trunk:

* Adjust root level controls such as `contentSize` and `wideSize`.
* Adjust the block-level styles of Columns block for the remaining features `padding`, `margin`, `blockGap`.
* Ensure that reset behaviour behaves as on trunk

I'm very happy for feedback if folks think this isn't an improvement as I'm aware that "code quality" changes can sometimes be quite subjective 🙂