### PR TITLE
Add configuration option to skip autop on freeform blocks when parsing blocks

### DIFF
--- a/packages/blocks/src/api/parser/index.js
+++ b/packages/blocks/src/api/parser/index.js
@@ -53,7 +53,7 @@ import { applyBuiltInValidationFixes } from './apply-built-in-validation-fixes';
 /**
  * @typedef  {Object}  ParseOptions
  * @property {boolean} __unstableSkipMigrationLogs If a block is migrated from a deprecated version, skip logging the migration details.
- * @property {boolean} __unstableAutoP             Whether to run autoP in freeform content.
+ * @property {boolean} __unstableSkipAutop         Whether to skip autop in freeform content.
  */
 
 /**
@@ -101,7 +101,7 @@ export function normalizeRawBlock( rawBlock, options ) {
 	// meaning there are no negative consequences to repeated autop calls.
 	if (
 		rawBlockName === fallbackBlockName &&
-		options?.__unstableAutoP !== false
+		! options?.__unstableSkipAutop
 	) {
 		rawInnerHTML = autop( rawInnerHTML ).trim();
 	}

--- a/packages/blocks/src/api/parser/index.js
+++ b/packages/blocks/src/api/parser/index.js
@@ -53,7 +53,7 @@ import { applyBuiltInValidationFixes } from './apply-built-in-validation-fixes';
 /**
  * @typedef  {Object}  ParseOptions
  * @property {boolean} __unstableSkipMigrationLogs If a block is migrated from a deprecated version, skip logging the migration details.
- * @property {boolean} __unstableFreeformAutoP     Whether to run autoP in freeform content.
+ * @property {boolean} __unstableAutoP             Whether to run autoP in freeform content.
  */
 
 /**
@@ -101,7 +101,7 @@ export function normalizeRawBlock( rawBlock, options ) {
 	// meaning there are no negative consequences to repeated autop calls.
 	if (
 		rawBlockName === fallbackBlockName &&
-		options.__unstableFreeformAutoP !== false
+		options.__unstableAutoP !== false
 	) {
 		rawInnerHTML = autop( rawInnerHTML ).trim();
 	}

--- a/packages/blocks/src/api/parser/index.js
+++ b/packages/blocks/src/api/parser/index.js
@@ -53,7 +53,7 @@ import { applyBuiltInValidationFixes } from './apply-built-in-validation-fixes';
 /**
  * @typedef  {Object}  ParseOptions
  * @property {boolean?} __unstableSkipMigrationLogs If a block is migrated from a deprecated version, skip logging the migration details.
- * @property {boolean?} __unstableSkipAutop         Whether to skip autop in freeform content.
+ * @property {boolean?} __unstableSkipAutop         Whether to skip autop when processing freeform content.
  */
 
 /**

--- a/packages/blocks/src/api/parser/index.js
+++ b/packages/blocks/src/api/parser/index.js
@@ -52,8 +52,8 @@ import { applyBuiltInValidationFixes } from './apply-built-in-validation-fixes';
 
 /**
  * @typedef  {Object}  ParseOptions
- * @property {boolean} __unstableSkipMigrationLogs If a block is migrated from a deprecated version, skip logging the migration details.
- * @property {boolean} __unstableSkipAutop         Whether to skip autop in freeform content.
+ * @property {boolean?} __unstableSkipMigrationLogs If a block is migrated from a deprecated version, skip logging the migration details.
+ * @property {boolean?} __unstableSkipAutop         Whether to skip autop in freeform content.
  */
 
 /**
@@ -82,8 +82,8 @@ function convertLegacyBlocks( rawBlock ) {
  * Normalize the raw block by applying the fallback block name if none given,
  * sanitize the parsed HTML...
  *
- * @param {WPRawBlock}   rawBlock The raw block object.
- * @param {ParseOptions} options  Extra options for handling block parsing.
+ * @param {WPRawBlock}    rawBlock The raw block object.
+ * @param {ParseOptions?} options  Extra options for handling block parsing.
  *
  * @return {WPRawBlock} The normalized block object.
  */

--- a/packages/blocks/src/api/parser/index.js
+++ b/packages/blocks/src/api/parser/index.js
@@ -53,6 +53,7 @@ import { applyBuiltInValidationFixes } from './apply-built-in-validation-fixes';
 /**
  * @typedef  {Object}  ParseOptions
  * @property {boolean} __unstableSkipMigrationLogs If a block is migrated from a deprecated version, skip logging the migration details.
+ * @property {boolean} __unstableFreeformAutoP     Whether to run autoP in freeform content.
  */
 
 /**
@@ -81,11 +82,12 @@ function convertLegacyBlocks( rawBlock ) {
  * Normalize the raw block by applying the fallback block name if none given,
  * sanitize the parsed HTML...
  *
- * @param {WPRawBlock} rawBlock The raw block object.
+ * @param {WPRawBlock}   rawBlock The raw block object.
+ * @param {ParseOptions} options  Extra options for handling block parsing.
  *
  * @return {WPRawBlock} The normalized block object.
  */
-export function normalizeRawBlock( rawBlock ) {
+export function normalizeRawBlock( rawBlock, options ) {
 	const fallbackBlockName = getFreeformContentHandlerName();
 
 	// If the grammar parsing don't produce any block name, use the freeform block.
@@ -97,7 +99,10 @@ export function normalizeRawBlock( rawBlock ) {
 	// Fallback content may be upgraded from classic content expecting implicit
 	// automatic paragraphs, so preserve them. Assumes wpautop is idempotent,
 	// meaning there are no negative consequences to repeated autop calls.
-	if ( rawBlockName === fallbackBlockName ) {
+	if (
+		rawBlockName === fallbackBlockName &&
+		options.__unstableFreeformAutoP !== false
+	) {
 		rawInnerHTML = autop( rawInnerHTML ).trim();
 	}
 
@@ -188,7 +193,7 @@ function applyBlockValidation( unvalidatedBlock, blockType ) {
  * @return {WPBlock} Fully parsed block.
  */
 export function parseRawBlock( rawBlock, options ) {
-	let normalizedBlock = normalizeRawBlock( rawBlock );
+	let normalizedBlock = normalizeRawBlock( rawBlock, options );
 
 	// During the lifecycle of the project, we renamed some old blocks
 	// and transformed others to new blocks. To avoid breaking existing content,

--- a/packages/blocks/src/api/parser/index.js
+++ b/packages/blocks/src/api/parser/index.js
@@ -101,7 +101,7 @@ export function normalizeRawBlock( rawBlock, options ) {
 	// meaning there are no negative consequences to repeated autop calls.
 	if (
 		rawBlockName === fallbackBlockName &&
-		options.__unstableAutoP !== false
+		options?.__unstableAutoP !== false
 	) {
 		rawInnerHTML = autop( rawInnerHTML ).trim();
 	}

--- a/packages/blocks/src/api/parser/test/index.js
+++ b/packages/blocks/src/api/parser/test/index.js
@@ -100,6 +100,22 @@ describe( 'block parser', () => {
 			expect( block.attributes ).toEqual( { content: '<p>content</p>' } );
 		} );
 
+		it( 'skips adding paragraph tags if __unstableSkipAutop is passed as an option', () => {
+			registerBlockType( 'core/freeform-block', unknownBlockSettings );
+			setFreeformContentHandlerName( 'core/freeform-block' );
+
+			const block = parseRawBlock(
+				{
+					innerHTML: 'content',
+				},
+				{
+					__unstableSkipAutop: true,
+				}
+			);
+			expect( block.name ).toEqual( 'core/freeform-block' );
+			expect( block.attributes ).toEqual( { content: 'content' } );
+		} );
+
 		it( 'should not create a block if no unknown type handler', () => {
 			const block = parseRawBlock( {
 				blockName: 'core/test-block',

--- a/packages/customize-widgets/src/utils.js
+++ b/packages/customize-widgets/src/utils.js
@@ -107,7 +107,7 @@ export function widgetToBlock( { id, idBase, number, instance } ) {
 
 	if ( idBase === 'block' ) {
 		const parsedBlocks = parse( raw.content, {
-			__unstableAutoP: false,
+			__unstableSkipAutop: true,
 		} );
 		block = parsedBlocks.length
 			? parsedBlocks[ 0 ]

--- a/packages/customize-widgets/src/utils.js
+++ b/packages/customize-widgets/src/utils.js
@@ -107,7 +107,7 @@ export function widgetToBlock( { id, idBase, number, instance } ) {
 
 	if ( idBase === 'block' ) {
 		const parsedBlocks = parse( raw.content, {
-			__unstableFreeformAutoP: false,
+			__unstableAutoP: false,
 		} );
 		block = parsedBlocks.length
 			? parsedBlocks[ 0 ]

--- a/packages/customize-widgets/src/utils.js
+++ b/packages/customize-widgets/src/utils.js
@@ -106,7 +106,9 @@ export function widgetToBlock( { id, idBase, number, instance } ) {
 	} = instance;
 
 	if ( idBase === 'block' ) {
-		const parsedBlocks = parse( raw.content );
+		const parsedBlocks = parse( raw.content, {
+			__unstableFreeformAutoP: false,
+		} );
 		block = parsedBlocks.length
 			? parsedBlocks[ 0 ]
 			: createBlock( 'core/paragraph', {} );

--- a/packages/edit-widgets/src/store/transformers.js
+++ b/packages/edit-widgets/src/store/transformers.js
@@ -12,7 +12,9 @@ import { addWidgetIdToBlock } from '@wordpress/widgets';
  */
 export function transformWidgetToBlock( widget ) {
 	if ( widget.id_base === 'block' ) {
-		const parsedBlocks = parse( widget.instance.raw.content );
+		const parsedBlocks = parse( widget.instance.raw.content, {
+			__unstableFreeformAutoP: false,
+		} );
 		if ( ! parsedBlocks.length ) {
 			return addWidgetIdToBlock(
 				createBlock( 'core/paragraph', {}, [] ),

--- a/packages/edit-widgets/src/store/transformers.js
+++ b/packages/edit-widgets/src/store/transformers.js
@@ -13,7 +13,7 @@ import { addWidgetIdToBlock } from '@wordpress/widgets';
 export function transformWidgetToBlock( widget ) {
 	if ( widget.id_base === 'block' ) {
 		const parsedBlocks = parse( widget.instance.raw.content, {
-			__unstableAutoP: false,
+			__unstableSkipAutop: true,
 		} );
 		if ( ! parsedBlocks.length ) {
 			return addWidgetIdToBlock(

--- a/packages/edit-widgets/src/store/transformers.js
+++ b/packages/edit-widgets/src/store/transformers.js
@@ -13,7 +13,7 @@ import { addWidgetIdToBlock } from '@wordpress/widgets';
 export function transformWidgetToBlock( widget ) {
 	if ( widget.id_base === 'block' ) {
 		const parsedBlocks = parse( widget.instance.raw.content, {
-			__unstableFreeformAutoP: false,
+			__unstableAutoP: false,
 		} );
 		if ( ! parsedBlocks.length ) {
 			return addWidgetIdToBlock(

--- a/test/e2e/specs/widgets/customizing-widgets.spec.js
+++ b/test/e2e/specs/widgets/customizing-widgets.spec.js
@@ -574,6 +574,33 @@ test.describe( 'Widgets Customizer', () => {
 			)
 		).toBeVisible();
 	} );
+
+	// Check for regressions of https://github.com/WordPress/gutenberg/issues/33832.
+	test( 'preserves content in the Custom HTML block', async ( {
+		page,
+		widgetsCustomizerPage,
+	} ) => {
+		await widgetsCustomizerPage.visitCustomizerPage();
+		await widgetsCustomizerPage.expandWidgetArea( 'Footer #1' );
+
+		await widgetsCustomizerPage.addBlock( 'Custom HTML' );
+		const HTMLBlockTextarea = page.locator(
+			'role=document[name="Block: Custom HTML"i] >> role=textbox[name="HTML"i]'
+		);
+		await HTMLBlockTextarea.type( 'hello' );
+
+		// Click Publish
+		await Promise.all( [
+			page.waitForResponse( '/wp-admin/admin-ajax.php' ),
+			page.click( 'role=button[name="Publish"i]' ),
+		] );
+
+		// reload
+		await widgetsCustomizerPage.visitCustomizerPage();
+		await widgetsCustomizerPage.expandWidgetArea( 'Footer #1' );
+
+		await expect( HTMLBlockTextarea ).toHaveText( 'hello' );
+	} );
 } );
 
 class WidgetsCustomizerPage {


### PR DESCRIPTION
## What?
Fixes #33832

The widget editor has had a long standing issue in that the block parser runs `autoP` on its freeform content. The widget editor doesn't have a classic block, so it uses the HTML block as its freeform content handler.

Unfortunately this results in paragraphs being automatically inserted into HTML block content.

## Why?
The autop functionality was originally implemented to support the back compat of classic block content. The widget editor doesn't have a classic block and typically isn't used to manage post content / article style text, so the default behavior of the parser is meaningless.

## How?
Adds an option to the parser. I think this is the lowest friction option.

This is a tricky issue to tackle because of the need for backwards compatibility. IMO the parser ideally wouldn't run `autoP` on content at all, this could have been part of the classic block from the start. But I don't think that can be changed now. 

## Alternatives

This could also be part of the `setFreeformContentHandler` function:
```js
setFreeformContentHandler( 'core/html', { autop: false, commentDelimiters: true } );
```

@noisysocks Also mentioned an alternative - https://github.com/WordPress/gutenberg/issues/33832#issuecomment-1039880471

But this seems more complex, because the parser doesn't know the difference between a paste and a normal parse. 🤔 

## Testing Instructions
1. Go to Dashboard > Appearance > Widgets.
2. Insert a Custom HTML Block into the footer and insert this code:
```html
<div><p>some text</p>
<a href="http://www.test.com">link text</a>
</div>
<svg height="90" width="200">
  <text x="10" y="20" style="fill:red;">Several lines:
    <tspan x="10" y="45">First line.</tspan>
    <tspan x="10" y="70">Second line.</tspan>
  </text>
</svg> 
```
3. Update and check it appears on the webpage and is correct.
4. Go back to Dashboard and then back to Appearance > Widgets.
5. Observe the Custom HTML code is preserved and unchanged.

In trunk: Observe the Custom HTML code has additional paragraph and line break tags.

## Screenshots or screencast <!-- if applicable -->
Meaningless screenshot:
![Screen Shot 2022-07-22 at 4 15 08 pm](https://user-images.githubusercontent.com/677833/180395358-34ac145e-5ab2-4d9b-bea6-389cfe55cdf4.png)

