### PR TITLE
Shortcuts: add Ctrl+Y for redo on Windows

### DIFF
--- a/packages/block-editor/src/components/inserter-list-item/index.js
+++ b/packages/block-editor/src/components/inserter-list-item/index.js
@@ -12,7 +12,7 @@ import {
 	createBlocksFromInnerBlocksTemplate,
 } from '@wordpress/blocks';
 import { __experimentalTruncate as Truncate } from '@wordpress/components';
-import { ENTER } from '@wordpress/keycodes';
+import { ENTER, isAppleOS } from '@wordpress/keycodes';
 
 /**
  * Internal dependencies
@@ -20,22 +20,6 @@ import { ENTER } from '@wordpress/keycodes';
 import BlockIcon from '../block-icon';
 import { InserterListboxItem } from '../inserter-listbox';
 import InserterDraggableBlocks from '../inserter-draggable-blocks';
-
-/**
- * Return true if platform is MacOS.
- *
- * @param {Object} _window window object by default; used for DI testing.
- *
- * @return {boolean} True if MacOS; false otherwise.
- */
-function isAppleOS( _window = window ) {
-	const { platform } = _window.navigator;
-
-	return (
-		platform.indexOf( 'Mac' ) !== -1 ||
-		[ 'iPad', 'iPhone' ].includes( platform )
-	);
-}
 
 function InserterListItem( {
 	className,

--- a/packages/compose/src/hooks/use-keyboard-shortcut/index.js
+++ b/packages/compose/src/hooks/use-keyboard-shortcut/index.js
@@ -3,12 +3,13 @@
  */
 import Mousetrap from 'mousetrap';
 import 'mousetrap/plugins/global-bind/mousetrap-global-bind';
-import { includes, castArray } from 'lodash';
+import { castArray } from 'lodash';
 
 /**
  * WordPress dependencies
  */
 import { useEffect, useRef } from '@wordpress/element';
+import { isAppleOS } from '@wordpress/keycodes';
 
 /**
  * A block selection object.
@@ -20,22 +21,6 @@ import { useEffect, useRef } from '@wordpress/element';
  * @property {boolean}                                [isDisabled] Disables the keyboard handler if the value is true.
  * @property {import('react').RefObject<HTMLElement>} [target]     React reference to the DOM element used to catch the keyboard event.
  */
-
-/**
- * Return true if platform is MacOS.
- *
- * @param {Window} [_window] window object by default; used for DI testing.
- *
- * @return {boolean} True if MacOS; false otherwise.
- */
-function isAppleOS( _window = window ) {
-	const { platform } = _window.navigator;
-
-	return (
-		platform.indexOf( 'Mac' ) !== -1 ||
-		includes( [ 'iPad', 'iPhone' ], platform )
-	);
-}
 
 /* eslint-disable jsdoc/valid-types */
 /**

--- a/packages/editor/src/components/global-keyboard-shortcuts/register-shortcuts.js
+++ b/packages/editor/src/components/global-keyboard-shortcuts/register-shortcuts.js
@@ -6,6 +6,7 @@ import { useDispatch } from '@wordpress/data';
 import { __ } from '@wordpress/i18n';
 import { BlockEditorKeyboardShortcuts } from '@wordpress/block-editor';
 import { store as keyboardShortcutsStore } from '@wordpress/keyboard-shortcuts';
+import { isAppleOS } from '@wordpress/keycodes';
 
 function EditorKeyboardShortcutsRegister() {
 	// Registering the shortcuts.
@@ -39,6 +40,16 @@ function EditorKeyboardShortcutsRegister() {
 				modifier: 'primaryShift',
 				character: 'z',
 			},
+			// Disable on Apple OS because it conflict's with the browser
+			// history shortcut.
+			aliases: isAppleOS()
+				? []
+				: [
+						{
+							modifier: 'primary',
+							character: 'y',
+						},
+				  ],
 		} );
 	}, [ registerShortcut ] );
 

--- a/packages/editor/src/components/global-keyboard-shortcuts/register-shortcuts.js
+++ b/packages/editor/src/components/global-keyboard-shortcuts/register-shortcuts.js
@@ -40,8 +40,10 @@ function EditorKeyboardShortcutsRegister() {
 				modifier: 'primaryShift',
 				character: 'z',
 			},
-			// Disable on Apple OS because it conflict's with the browser
-			// history shortcut.
+			// Disable on Apple OS because it conflicts with the browser's
+			// history shortcut. It's a fine alias for both Windows and Linux.
+			// Since there's no conflict for Ctrl+Shift+Z on both Windows and
+			// Linux, we keep it as the default for consistency.
 			aliases: isAppleOS()
 				? []
 				: [

--- a/packages/keycodes/README.md
+++ b/packages/keycodes/README.md
@@ -114,6 +114,18 @@ Keycode for F10 key.
 
 Keycode for HOME key.
 
+### isAppleOS
+
+Return true if platform is MacOS.
+
+_Parameters_
+
+-   _\_window_ `Window?`: window object by default; used for DI testing.
+
+_Returns_
+
+-   `boolean`: True if MacOS; false otherwise.
+
 ### isKeyboardEvent
 
 An object that contains functions to check if a keyboard event matches a

--- a/packages/keycodes/src/index.js
+++ b/packages/keycodes/src/index.js
@@ -144,6 +144,8 @@ export const SHIFT = 'shift';
  */
 export const ZERO = 48;
 
+export { isAppleOS };
+
 /**
  * Object that contains functions that return the available modifier
  * depending on platform.


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?

Fixes #8921.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

`Ctrl+Y` is the de-facto default shortcut for undo on Windows.

## How?

Exports `isAppleOs` in the key codes package because it seems generally handy in the context of shortcuts.

## Testing Instructions

Check if `Ctrl+Y` works on Windows. Make sure it doesn't work on Mac.

## Screenshots or screencast <!-- if applicable -->
