### PR TITLE
List v2: switch to default block type on Backspace from start

### DIFF
--- a/packages/block-library/src/list-item/hooks/use-merge.js
+++ b/packages/block-library/src/list-item/hooks/use-merge.js
@@ -79,15 +79,20 @@ export default function useMerge( clientId ) {
 		return getBlockOrder( order[ 0 ] )[ 0 ];
 	}
 
-	function switchToDefaultBlockType() {
+	function switchToDefaultBlockType( forward ) {
 		const rootClientId = getBlockRootClientId( clientId );
 		const replacement = switchToBlockType(
 			getBlock( rootClientId ),
 			getDefaultBlockName()
 		);
+		const indexToSelect = forward ? replacement.length - 1 : 0;
+		const initialPosition = forward ? -1 : 0;
 		registry.batch( () => {
 			replaceBlock( rootClientId, replacement );
-			selectBlock( replacement[ 0 ].clientId );
+			selectBlock(
+				replacement[ indexToSelect ].clientId,
+				initialPosition
+			);
 		} );
 	}
 
@@ -96,7 +101,7 @@ export default function useMerge( clientId ) {
 			const nextBlockClientId = getNextId( clientId );
 
 			if ( ! nextBlockClientId ) {
-				switchToDefaultBlockType();
+				switchToDefaultBlockType( forward );
 				return;
 			}
 
@@ -129,7 +134,7 @@ export default function useMerge( clientId ) {
 					mergeBlocks( trailingId, clientId );
 				} );
 			} else {
-				switchToDefaultBlockType();
+				switchToDefaultBlockType( forward );
 			}
 		}
 	};

--- a/packages/block-library/src/list-item/hooks/use-merge.js
+++ b/packages/block-library/src/list-item/hooks/use-merge.js
@@ -79,7 +79,7 @@ export default function useMerge( clientId ) {
 		return getBlockOrder( order[ 0 ] )[ 0 ];
 	}
 
-	function deleteList() {
+	function switchToDefaultBlockType() {
 		const rootClientId = getBlockRootClientId( clientId );
 		const replacement = switchToBlockType(
 			getBlock( rootClientId ),
@@ -96,7 +96,7 @@ export default function useMerge( clientId ) {
 			const nextBlockClientId = getNextId( clientId );
 
 			if ( ! nextBlockClientId ) {
-				deleteList();
+				switchToDefaultBlockType();
 				return;
 			}
 
@@ -129,7 +129,7 @@ export default function useMerge( clientId ) {
 					mergeBlocks( trailingId, clientId );
 				} );
 			} else {
-				deleteList();
+				switchToDefaultBlockType();
 			}
 		}
 	};


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?

Fixes #42500.

Allows "merge" from the start/end of a list. Notice that there's an improvement compared to v1: there's an intermediate step now.

|v1|v2|
|-|-|
|![list-v1-merge](https://user-images.githubusercontent.com/4710635/180466346-249034f8-2416-4f9a-8e89-4a3cccd8d349.gif)|![list-v2-merge](https://user-images.githubusercontent.com/4710635/180466458-98f978a3-ccc9-4d18-9516-c5d31e70cb5c.gif)|


Related: #42503.

## Why?

Allows a list to be removed when pressing Backspace from the start of a list.

## How?

This completes `onMerge`. Takes advantage of `switchToBlockType`.

## Testing Instructions

Create a paragraph an a list. Press Backspace from an empty list. It should delete the list and replace it with a paragraph. Focus should land in that paragraph.

## Screenshots or screencast <!-- if applicable -->
