### PR TITLE
Popover: Fix width on `expandOnMobile`

### DIFF
--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Bug Fix
 
+-   `Popover`, `Dropdown`: Fix width when `expandOnMobile` is enabled ([#42635](https://github.com/WordPress/gutenberg/pull/42635/)).
 -   `CustomSelectControl`: Fix font size and hover/focus style inconsistencies with `SelectControl` ([#42460](https://github.com/WordPress/gutenberg/pull/42460/)).
 -   `AnglePickerControl`: Fix gap between elements in RTL mode ([#42534](https://github.com/WordPress/gutenberg/pull/42534)).
 -   `RangeControl`: clamp initialPosition between min and max values ([#42571](https://github.com/WordPress/gutenberg/pull/42571)).

--- a/packages/components/src/popover/stories/index.js
+++ b/packages/components/src/popover/stories/index.js
@@ -27,6 +27,7 @@ export const _default = () => {
 	const show = boolean( 'Example: Show', true );
 	const children = text( 'children', 'Popover Content' );
 	const animate = boolean( 'animate', false );
+	const expandOnMobile = boolean( 'expandOnMobile', false );
 	const focusOnMount = select(
 		'focusOnMount',
 		{
@@ -41,6 +42,7 @@ export const _default = () => {
 	const props = {
 		animate,
 		children,
+		expandOnMobile,
 		focusOnMount,
 		noArrow,
 		isAlternate,

--- a/packages/components/src/popover/style.scss
+++ b/packages/components/src/popover/style.scss
@@ -31,7 +31,7 @@
 		position: static;
 		height: calc(100% - #{ $panel-header-height });
 		overflow-y: visible;
-		min-width: auto;
+		width: auto;
 		border: none;
 		outline: none;
 		border-top: $border-width solid $gray-900;


### PR DESCRIPTION
Fixes #42631

## What?

Fixes a CSS regression introduced in #40740 where the popover content is not full-width in mobile viewports when `expandOnMobile` is enabled.

## Testing Instructions

### Components

1. `npm run storybook:dev`
2. In stories for `Popover` or `Dropdown`, enable the `expandOnMobile` prop, and make the viewport narrow.

### Block editor

1. `npm run dev`
2. In the block editor, make the viewport narrow and open the **quick inserter**. (This is the inline "Add block" button in the writing flow, not the main block inserter in the top left.)

## Screenshots or screencast <!-- if applicable -->

| Before | After |
|--------|-------|
|<img width="320" alt="Popover content width is shrunken" src="https://user-images.githubusercontent.com/555336/180451545-b8d351b9-2623-4242-8143-74335aa4a2e8.png">|<img width="321" alt="Popover content width is 100%" src="https://user-images.githubusercontent.com/555336/180451565-d140eadb-fafb-4363-bef0-36d21b0500bb.png">|
|<img width="391" alt="Quick inserter popover is not full width in mobile" src="https://user-images.githubusercontent.com/555336/180451670-ed0b7f89-11ab-4559-b6ea-9150af23c547.png">|<img width="614" alt="Quick inserter popover is full width" src="https://user-images.githubusercontent.com/555336/180473076-48a29a50-302e-48c0-884f-9c363bdb9985.png">|


