### PR TITLE
Cover Block: Prevent transform to Group block when featured image is set.

### DIFF
--- a/packages/block-library/src/cover/transforms.js
+++ b/packages/block-library/src/cover/transforms.js
@@ -206,10 +206,10 @@ const transforms = {
 		{
 			type: 'block',
 			blocks: [ 'core/group' ],
-			isMatch: ( { url } ) => {
+			isMatch: ( { url, useFeaturedImage } ) => {
 				// If the Cover block uses background media, skip this transform,
 				// and instead use the Group block's default transform.
-				if ( url ) {
+				if ( url || useFeaturedImage ) {
 					return false;
 				}
 				return true;


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Partially fixes https://github.com/WordPress/gutenberg/issues/42613

## Why?
Logic was added to the Cover block (https://github.com/WordPress/gutenberg/pull/40293, https://github.com/WordPress/gutenberg/pull/40212) that allows it to transform into a Group block in certain circumstances. While this functionality might be debatable, it's disabled when the Cover block has media applied. The original PRs did not include a check for the new Featured Image option. This PR corrects for that. 

## How?
We simply check if the `useFeaturedImage` attribute is set. If so, we ignore the custom Cover --> Group transform and use the default Group transform. 

## Testing Instructions
1. Add a Cover block to a post of page that have a Featured Image
2. Choose Featured Image as the media option on the Cover block. 
3. Group the Cover block and see that the Cover block is now placed inside of a Group block. Previously the Cover block would have been transformed into a Group block and the Featured Image lost. 

## Screenshots or screencast 

**Functionality prior to this PR:**
![cover-block-before](https://user-images.githubusercontent.com/4832319/180482851-65ba1c53-fed5-44bd-b4c9-2622d5809756.gif)

**Functionality after this PR:**
![cover-block-after](https://user-images.githubusercontent.com/4832319/180482865-0e4326c2-bef7-4a47-b3da-b1afcfc1e154.gif)


