### PR TITLE
Social Icons Block: Fix button opacity in template parts.

### DIFF
--- a/packages/block-library/src/social-link/editor.scss
+++ b/packages/block-library/src/social-link/editor.scss
@@ -9,6 +9,9 @@
 		height: auto;
 		line-height: 0;
 
+		// This rule ensures social link buttons display correctly in template parts.
+		opacity: 1;
+
 		// This rule is duplicated from the style.scss and needs to be the same as there.
 		padding: 0.25em;
 	}


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Fixes: #42640

## Why?
Social Icons do not display correctly when placed inside of template parts in the Editor. This is due to some global styles, see the linked issue for more details.

## How?
We apply additional block-specific opacity styling to ensure the icons display correctly in the Editor. 

## Testing Instructions

1. Use Twenty Twenty-Two or another block theme
2. Open the Site Editor and add the Social Icons block to a template part.
3. Configure a few social icons.
4. Click off of the template part and see that the icons remain correctly displayed.

## Screenshots or screencast <!-- if applicable -->

**Social Icons before this PR:** 
![image](https://user-images.githubusercontent.com/4832319/180492637-6ace69de-12bf-425b-b228-5a97b71c433a.png)

**Social Icons after this PR:**
![image](https://user-images.githubusercontent.com/4832319/180492671-17540312-52ba-4124-a114-df0a19e510df.png)

