### PR TITLE
Correct the documented return type for `WP_Block_Parser::render()`

### DIFF
--- a/packages/block-serialization-default-parser/parser.php
+++ b/packages/block-serialization-default-parser/parser.php
@@ -222,7 +222,7 @@ class WP_Block_Parser {
 	 * @since 5.0.0
 	 *
 	 * @param string $document Input document being parsed.
-	 * @return WP_Block_Parser_Block[]
+	 * @return array[]
 	 */
 	function parse( $document ) {
 		$this->document    = $document;


### PR DESCRIPTION
## What?

This fixes an inline documentation error for the `WP_Block_Parser::render()` method.

## Why?

This method returns an array of arrays, not an array of `WP_Block_Parser_Block` instances. The `proceed()` method always casts the `WP_Block_Parser_Block` instance to an array.

* https://github.com/WordPress/gutenberg/blob/5de7f238df8d07337e11809667e531ce3baf1a88/packages/block-serialization-default-parser/parser.php#L303
* https://github.com/WordPress/gutenberg/blob/5de7f238df8d07337e11809667e531ce3baf1a88/packages/block-serialization-default-parser/parser.php#L312

## Testing Instructions

1. Call the `parse_blocks()` function with some post content that contains blocks
2. Observe that an array of arrays is returned
