### PR TITLE
Redirect old `theme_page` Site Editor routes to the new `site-editor.php` page

### DIFF
--- a/lib/README.md
+++ b/lib/README.md
@@ -18,12 +18,13 @@ structure for its PHP code:
   Core in the future X.Y release, or that were previously merged to Core in the
   X.Y release and remain in the plugin for backwards compatibility when running
   the plugin on older versions of WordPress.
+- `lib/compat/plugin` - Features for backwards compatibility for the plugin consumers. These files don't need to be merged to Core and should have a timeline for when they should be removed from the plugin.
 
 ## Best practices
 
 ### Prefer the `wp` prefix
 
-For features that may be merged to Core, it's best to use a `wp_` prefix for functions or a `WP_` prefix for classes. 
+For features that may be merged to Core, it's best to use a `wp_` prefix for functions or a `WP_` prefix for classes.
 
 This applies to both experimental and stable features.
 
@@ -86,7 +87,7 @@ When writing new functions and classes, it's good practice to use `! function_ex
 
 If Core has defined a symbol once and then Gutenberg defines it a second time, fatal errors will occur.
 
-Wrapping functions and classes avoids such errors if the feature is merged to Core. 
+Wrapping functions and classes avoids such errors if the feature is merged to Core.
 
 #### Good
 
@@ -122,7 +123,7 @@ Furthermore, a quick codebase search will also help you know if your new method 
 
 ### Note how your feature should look when merged to Core
 
-Developers should write a brief note about how their feature should be merged to Core, for example, which Core file or function should be patched. 
+Developers should write a brief note about how their feature should be merged to Core, for example, which Core file or function should be patched.
 
 Notes can be included in the doc comment.
 
@@ -133,7 +134,7 @@ This helps future developers know what to do when merging Gutenberg features int
 ```php
 /**
  * Returns a navigation object for the given slug.
- * 
+ *
  * Should live in `wp-includes/navigation.php` when merged to Core.
  *
  * @param string $slug

--- a/lib/compat/plugin/edit-site-routes-backwards-compat.php
+++ b/lib/compat/plugin/edit-site-routes-backwards-compat.php
@@ -28,7 +28,7 @@
  */
 function gutenberg_site_editor_menu() {
 	if ( wp_is_block_theme() ) {
-		add_submenu_page( 'themes.php', null, null, 'edit_theme_options', 'gutenberg-edit-site', 'gutenberg_edit_site_page' );
+		add_submenu_page( null, null, null, 'edit_theme_options', 'gutenberg-edit-site', 'gutenberg_edit_site_page' );
 	}
 }
 add_action( 'admin_menu', 'gutenberg_site_editor_menu', 9 );
@@ -41,3 +41,4 @@ function gutenberg_redirect_deprecated_to_new_site_editor_page() {
 		exit;
 }
 add_action( 'load-appearance_page_gutenberg-edit-site', 'gutenberg_redirect_deprecated_to_new_site_editor_page' );
+add_action( 'load-admin_page_gutenberg-edit-site', 'gutenberg_redirect_deprecated_to_new_site_editor_page' );

--- a/lib/compat/plugin/edit-site-routes-backwards-compat.php
+++ b/lib/compat/plugin/edit-site-routes-backwards-compat.php
@@ -1,5 +1,10 @@
 <?php
 /**
+ * Backwards compatibility handling for routes used by the plugin consumers.
+ * This doesn't need to be back ported to core and will be removed after WP 6.1,
+ * to ensure that the plugin consumers have enough time to migrate to the core's
+ * route (`site-editor.php`).
+ *
  * Whitelists the `theme.php` route and redirects the following routes:
  * - `themes.php?page=gutenberg-edit-site`
  * - `admin.php?page=gutenberg-edit-site`
@@ -8,15 +13,19 @@
  *
  * The old routes have been deprecated and removed in Gutenberg 13.7.0, but third-party
  * consumer code might still be referencing them. In order to not break the Site Editor
- * flows, we don't fully remove the old routes, but redirect them to the new one.
+ * flows, we don't fully remove the old routes, but redirect them to the core's one.
+ *
+ * @see https://github.com/WordPress/gutenberg/pull/41306
+ *
+ * @package gutenberg
  */
 
- /**
-	* "Whitelists" the old routes. Without this, trying to access the old Site Editor
-	* routes result in a HTTP 403 error.
-  *
-	* The whitelist is done by adding an wp-admin submenu page that won't be rendered.
-  */
+/**
+ * "Whitelists" the old routes. Without this, trying to access the old Site Editor
+ * routes result in a HTTP 403 error.
+ *
+ * The whitelist is done by adding an wp-admin submenu page that won't be rendered.
+ */
 function gutenberg_site_editor_menu() {
 	if ( wp_is_block_theme() ) {
 		add_submenu_page( 'themes.php', null, null, 'edit_theme_options', 'gutenberg-edit-site', 'gutenberg_edit_site_page' );

--- a/lib/compat/plugin/edit-site-routes-backwards-compat.php
+++ b/lib/compat/plugin/edit-site-routes-backwards-compat.php
@@ -38,5 +38,6 @@ add_action( 'admin_menu', 'gutenberg_site_editor_menu', 9 );
  */
 function gutenberg_redirect_deprecated_to_new_site_editor_page() {
 		wp_safe_redirect( 'site-editor.php' );
+		exit;
 }
 add_action( 'load-appearance_page_gutenberg-edit-site', 'gutenberg_redirect_deprecated_to_new_site_editor_page' );

--- a/lib/compat/plugin/edit-site-routes-backwards-compat.php
+++ b/lib/compat/plugin/edit-site-routes-backwards-compat.php
@@ -28,7 +28,7 @@
  */
 function gutenberg_site_editor_menu() {
 	if ( wp_is_block_theme() ) {
-		add_submenu_page( null, null, null, 'edit_theme_options', 'gutenberg-edit-site', 'gutenberg_edit_site_page' );
+		add_submenu_page( null, null, null, 'edit_theme_options', 'gutenberg-edit-site', '__return_empty_string' );
 	}
 }
 add_action( 'admin_menu', 'gutenberg_site_editor_menu', 9 );

--- a/lib/compat/plugin/edit-site-routes-backwards-compat.php
+++ b/lib/compat/plugin/edit-site-routes-backwards-compat.php
@@ -5,7 +5,7 @@
  * to ensure that the plugin consumers have enough time to migrate to the core's
  * route (`site-editor.php`).
  *
- * Whitelists the `theme.php` route and redirects the following routes:
+ * Allows the `theme.php` route and redirects the following routes:
  * - `themes.php?page=gutenberg-edit-site`
  * - `admin.php?page=gutenberg-edit-site`
  *
@@ -21,10 +21,10 @@
  */
 
 /**
- * "Whitelists" the old routes. Without this, trying to access the old Site Editor
- * routes result in a HTTP 403 error.
+ * Allows the old routes. Without this, trying to access the old Site Editor
+ * routes results in a HTTP 403 error.
  *
- * The whitelist is done by adding an wp-admin submenu page that won't be rendered.
+ * Allowing the route is done by adding an wp-admin submenu page that won't be rendered.
  */
 function gutenberg_site_editor_menu() {
 	if ( wp_is_block_theme() ) {

--- a/lib/compat/wordpress-6.0/edit-site-routes-backwards-compat.php
+++ b/lib/compat/wordpress-6.0/edit-site-routes-backwards-compat.php
@@ -1,0 +1,33 @@
+<?php
+/**
+ * Whitelists the `theme.php` route and redirects the following routes:
+ * - `themes.php?page=gutenberg-edit-site`
+ * - `admin.php?page=gutenberg-edit-site`
+ *
+ * To `site-editor.php`.
+ *
+ * The old routes have been deprecated and removed in Gutenberg 13.7.0, but third-party
+ * consumer code might still be referencing them. In order to not break the Site Editor
+ * flows, we don't fully remove the old routes, but redirect them to the new one.
+ */
+
+ /**
+	* "Whitelists" the old routes. Without this, trying to access the old Site Editor
+	* routes result in a HTTP 403 error.
+  *
+	* The whitelist is done by adding an wp-admin submenu page that won't be rendered.
+  */
+function gutenberg_site_editor_menu() {
+	if ( wp_is_block_theme() ) {
+		add_submenu_page( 'themes.php', null, null, 'edit_theme_options', 'gutenberg-edit-site', 'gutenberg_edit_site_page' );
+	}
+}
+add_action( 'admin_menu', 'gutenberg_site_editor_menu', 9 );
+
+/**
+ * Does the actual redirect to the new route upon triggering of the `load-appearance_page_gutenberg-edit-site` action.
+ */
+function gutenberg_redirect_deprecated_to_new_site_editor_page() {
+		wp_safe_redirect( 'site-editor.php' );
+}
+add_action( 'load-appearance_page_gutenberg-edit-site', 'gutenberg_redirect_deprecated_to_new_site_editor_page' );

--- a/lib/load.php
+++ b/lib/load.php
@@ -58,6 +58,9 @@ if ( class_exists( 'WP_REST_Controller' ) ) {
 
 require __DIR__ . '/experimental/editor-settings.php';
 
+// Gutenberg plugin compat.
+require __DIR__ . '/compat/plugin/edit-site-routes-backwards-compat.php';
+
 // WordPress 6.0 compat.
 require __DIR__ . '/compat/wordpress-6.0/block-gallery.php';
 require __DIR__ . '/compat/wordpress-6.0/block-editor-settings.php';
@@ -74,7 +77,6 @@ require __DIR__ . '/compat/wordpress-6.0/site-editor.php';
 require __DIR__ . '/compat/wordpress-6.0/edit-form-blocks.php';
 require __DIR__ . '/compat/wordpress-6.0/block-patterns-update.php';
 require __DIR__ . '/compat/wordpress-6.0/client-assets.php';
-require __DIR__ . '/compat/wordpress-6.0/edit-site-routes-backwards-compat.php';
 
 // WordPress 6.1 compat.
 require __DIR__ . '/compat/wordpress-6.1/blocks.php';

--- a/lib/load.php
+++ b/lib/load.php
@@ -74,6 +74,7 @@ require __DIR__ . '/compat/wordpress-6.0/site-editor.php';
 require __DIR__ . '/compat/wordpress-6.0/edit-form-blocks.php';
 require __DIR__ . '/compat/wordpress-6.0/block-patterns-update.php';
 require __DIR__ . '/compat/wordpress-6.0/client-assets.php';
+require __DIR__ . '/compat/wordpress-6.0/edit-site-routes-backwards-compat.php';
 
 // WordPress 6.1 compat.
 require __DIR__ . '/compat/wordpress-6.1/blocks.php';


### PR DESCRIPTION
## What?

Redirect the following routes:
* `admin.php?page=gutenberg-edit-site`
* `themes.php?page=gutenberg-edit-site`

To: `site-editor.php`

## Why?

Gutenberg 13.7 deprecated the `theme_page`-based routes (see above) for the Site Editor in this PR: https://github.com/WordPress/gutenberg/pull/41306. However, third-party code (i.e from plugins -- ex: Jetpack) might still reference the old routes. We don't want their flows to break with the 13.7 upgrade, and a good transient solution is to keep the old routes around while making them redirect to the new route.

#### What about the definitive solution?

I don't know what is the current backwards-compatibility policy for WordPress/Gutenberg, but it appears that we should be more careful about deprecating routes/paths. Ideally, routes are abstracted in helper methods and not hardcoded throughout the codebase. For example, let's say that the Site Editor route was wrapped in a `site_editor_url` helper method from the beginning. The helper would be defined in GB or WP version (if backported). Third-party consumers would (hopefully) be using that, and any underlying changes would be picked up automatically. This is more of food for thought for future route additions. Unfortunately, for the Site Editor, adding the helper now won't solve the immediate problem.

To entirely deprecate the old paths and get rid of the redirect, third-party consumers would need to add a conditional to check for the GB version and potentially the WP version, too (since the code might be backported to WP in the future, AFAIK). This is a possibility, and the effort would depend on how many third-party consumers are already referencing the old paths.

Or we could add this redirect and then add a route abstraction as suggested above so that any future changes won't need any conditionals or redirects anymore.

**What are your thoughts?**

## How?

Adds a new "theme_page"  if the theme is block_theme. This seems to whitelist the route and allows it to be accessible. Without it, we get a permission error from WordPress. It's added as a callback to the `admin_menu` action. 

Then, we add a callback to the `load-appearance_page_gutenberg-edit-site` action that finally redirects. From what I understand, this action is triggered when the aforementioned "theme_page" is loaded, and then the redirect takes place.

There's a problem for now, though, which I'm still trying to solve: the `add_theme_page` adds a new submenu for the Editor. We end up with two items under appearance :( ... is there a way to whitelist the routes without using `add_theme_page`?

I mainly found the code that worked by trial and error, so I would appreciate thoughts about whether there are any other better ways to accomplish it.

## Testing Instructions

* Build GB from this branch, fire up `wp-env`, login to the WP instance;
* `localhost:8889/wp-admin/admin.php?page=gutenberg-edit-site` should redirect to `localhost:8889/wp-admin/site-editor.php`
* `localhost:8889/wp-admin/themes.php?page=gutenberg-edit-site` should redirect to `localhost:8889/wp-admin/admin/site-editor.php`

## Screenshots or screencast <!-- if applicable -->
