### PR TITLE
Convert `SearchControl` component to TypeScript

### DIFF
--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -36,6 +36,7 @@
 -   `RadioControl`: Refactor away from `_.isEmpty()` ([#42468](https://github.com/WordPress/gutenberg/pull/42468)).
 -   `SelectControl`: Refactor away from `_.isEmpty()` ([#42468](https://github.com/WordPress/gutenberg/pull/42468)).
 -   `ComboboxControl`: Replace `keyboardEvent.keyCode` with `keyboardEvent.code`([#42569](https://github.com/WordPress/gutenberg/pull/42569)).
+-   `SearchControl`: Convert to TypeScript ([#42647](https://github.com/WordPress/gutenberg/pull/42647)).
 
 ## 19.15.0 (2022-07-13)
 

--- a/packages/components/src/search-control/index.tsx
+++ b/packages/components/src/search-control/index.tsx
@@ -1,6 +1,7 @@
 /**
  * External dependencies
  */
+import type { ForwardedRef } from 'react';
 import classnames from 'classnames';
 
 /**
@@ -14,8 +15,9 @@ import { forwardRef, useRef } from '@wordpress/element';
 /**
  * Internal dependencies
  */
-import { Button } from '../';
+import { Button } from '../button';
 import BaseControl from '../base-control';
+import type { SearchControlProps } from './types';
 
 function SearchControl(
 	{
@@ -28,8 +30,8 @@ function SearchControl(
 		hideLabelFromVision = true,
 		help,
 		onClose,
-	},
-	forwardedRef
+	}: SearchControlProps,
+	forwardedRef: ForwardedRef< any >
 ) {
 	const searchRef = useRef();
 	const instanceId = useInstanceId( SearchControl );
@@ -53,7 +55,9 @@ function SearchControl(
 					label={ __( 'Reset search' ) }
 					onClick={ () => {
 						onChange( '' );
-						searchRef.current.focus();
+						if ( searchRef.current ) {
+							( searchRef.current as HTMLInputElement )?.focus();
+						}
 					} }
 				/>
 			);

--- a/packages/components/src/search-control/index.tsx
+++ b/packages/components/src/search-control/index.tsx
@@ -33,7 +33,7 @@ function SearchControl(
 	}: SearchControlProps,
 	forwardedRef: ForwardedRef< any >
 ) {
-	const searchRef = useRef();
+	const searchRef = useRef< HTMLInputElement >();
 	const instanceId = useInstanceId( SearchControl );
 	const id = `components-search-control-${ instanceId }`;
 

--- a/packages/components/src/search-control/index.tsx
+++ b/packages/components/src/search-control/index.tsx
@@ -55,9 +55,7 @@ function SearchControl(
 					label={ __( 'Reset search' ) }
 					onClick={ () => {
 						onChange( '' );
-						if ( searchRef.current ) {
-							( searchRef.current as HTMLInputElement )?.focus();
-						}
+						searchRef.current?.focus();
 					} }
 				/>
 			);

--- a/packages/components/src/search-control/types.ts
+++ b/packages/components/src/search-control/types.ts
@@ -9,13 +9,13 @@ import type { KeyboardEventHandler } from 'react';
 import type { WPElement } from '@wordpress/element';
 
 export type SearchControlProps = {
-	className: string | undefined;
+	className?: string;
 	onChange: ( arg0: string ) => {};
 	onKeyDown: KeyboardEventHandler< HTMLInputElement >;
 	value: string | number;
 	label: string;
-	placeholder: string | undefined;
-	hideLabelFromVision: boolean | undefined;
-	help: string | WPElement | undefined;
+	placeholder?: string;
+	hideLabelFromVision?: boolean;
+	help?: string | WPElement;
 	onClose: VoidFunction;
 };

--- a/packages/components/src/search-control/types.ts
+++ b/packages/components/src/search-control/types.ts
@@ -17,5 +17,5 @@ export type SearchControlProps = {
 	placeholder: string | undefined;
 	hideLabelFromVision: boolean | undefined;
 	help: string | WPElement | undefined;
-	onClose: Function;
+	onClose: VoidFunction;
 };

--- a/packages/components/src/search-control/types.ts
+++ b/packages/components/src/search-control/types.ts
@@ -1,0 +1,21 @@
+/**
+ * External dependencies
+ */
+import type { KeyboardEventHandler } from 'react';
+
+/**
+ * WordPress dependencies
+ */
+import type { WPElement } from '@wordpress/element';
+
+export type SearchControlProps = {
+	className: string | undefined;
+	onChange: ( arg0: string ) => {};
+	onKeyDown: KeyboardEventHandler< HTMLInputElement >;
+	value: string | number;
+	label: string;
+	placeholder: string | undefined;
+	hideLabelFromVision: boolean | undefined;
+	help: String | WPElement | undefined;
+	onClose: Function;
+};

--- a/packages/components/src/search-control/types.ts
+++ b/packages/components/src/search-control/types.ts
@@ -16,6 +16,6 @@ export type SearchControlProps = {
 	label: string;
 	placeholder: string | undefined;
 	hideLabelFromVision: boolean | undefined;
-	help: String | WPElement | undefined;
+	help: string | WPElement | undefined;
 	onClose: Function;
 };

--- a/packages/components/tsconfig.json
+++ b/packages/components/tsconfig.json
@@ -78,6 +78,7 @@
 		"src/resizable-box/**/*",
 		"src/scroll-lock/**/*",
 		"src/scrollable/**/*",
+		"src/search-control/**/*",
 		"src/select-control/**/*",
 		"src/shortcut/**/*",
 		"src/slot-fill/**/*",


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Converts the `SearchControl` component to TypeScript
<!-- In a few words, what is the PR actually doing? -->

## Why?
As part of an [effort](https://github.com/WordPress/gutenberg/issues/35744) to convert `@wordpress/components` to TypeScript
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
Mainly by adding types to the `SearchControl` component

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
1. Create a new post
2. Click the block inserter
3. Type 'Columns' in the `SearchControl` component
4. Expected: The 'Columns' block appeasr

## Screenshots or screencast <!-- if applicable -->
![conver](https://user-images.githubusercontent.com/4063887/180517473-88bd3b8c-8df8-4ca4-8c7e-4e227be31916.gif)


