### PR TITLE
remove deprecated eslint rules

### DIFF
--- a/packages/eslint-plugin/CHANGELOG.md
+++ b/packages/eslint-plugin/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Code Quality
+
+-   Remove deprecated rules `no-negated-in-lhs` replaced with `no-unsafe-negation`, and `jsx-a11y/label-has-for` replaced with `jsx-a11/label-has-associated-control` ([#42654](https://github.com/WordPress/gutenberg/pull/42654)). 
+
 ## 12.6.0 (2022-06-29)
 
 -   Enable `no-unused-vars`'s setting `ignoreRestSiblings` to allow unused variables when destructuring with rest properties ([#41897](https://github.com/WordPress/gutenberg/pull/41897)).

--- a/packages/eslint-plugin/configs/es5.js
+++ b/packages/eslint-plugin/configs/es5.js
@@ -42,7 +42,6 @@ module.exports = {
 		'no-mixed-spaces-and-tabs': 'error',
 		'no-multiple-empty-lines': [ 'error', { max: 1 } ],
 		'no-multi-spaces': 'error',
-		'no-negated-in-lhs': 'error',
 		'no-nested-ternary': 'error',
 		'no-redeclare': 'error',
 		'no-shadow': 'error',

--- a/packages/eslint-plugin/configs/jsx-a11y.js
+++ b/packages/eslint-plugin/configs/jsx-a11y.js
@@ -2,12 +2,6 @@ module.exports = {
 	extends: [ 'plugin:jsx-a11y/recommended' ],
 	plugins: [ 'jsx-a11y' ],
 	rules: {
-		'jsx-a11y/label-has-for': [
-			'error',
-			{
-				required: 'id',
-			},
-		],
 		'jsx-a11y/media-has-caption': 'off',
 		'jsx-a11y/no-noninteractive-tabindex': 'off',
 		'jsx-a11y/role-has-required-aria-props': 'off',


### PR DESCRIPTION
their replacements are already added (es5.js no-unsafe-negation) or are enabled by default already (jsx-11y label-has-associated-control)

## What?
Remove deprecated eslint rules

## Why?
Bc they're deprecated

## How?
Remove code from config

## Testing Instructions
Run eslint with the given config. There is no change in output, since eslint silently ignored the rules already.
