### PR TITLE
Avatar: Add test to ensure that user image updates when user switched.

### DIFF
--- a/packages/e2e-test-utils-playwright/src/request-utils/index.ts
+++ b/packages/e2e-test-utils-playwright/src/request-utils/index.ts
@@ -13,7 +13,7 @@ import { WP_ADMIN_USER, WP_BASE_URL } from '../config';
 import type { User } from './login';
 import { login } from './login';
 import { listMedia, uploadMedia, deleteMedia, deleteAllMedia } from './media';
-import { listUsers, deleteUser, createUser, deleteAllUsers } from './users';
+import { createUser, deleteAllUsers } from './users';
 import { setupRest, rest, getMaxBatchSize, batchRest } from './rest';
 import { getPluginsMap, activatePlugin, deactivatePlugin } from './plugins';
 import { deleteAllTemplates } from './templates';
@@ -134,9 +134,7 @@ class RequestUtils {
 	uploadMedia = uploadMedia.bind( this );
 	deleteMedia = deleteMedia.bind( this );
 	deleteAllMedia = deleteAllMedia.bind( this );
-	listUsers = listUsers.bind( this );
 	createUser = createUser.bind( this );
-	deleteUser = deleteUser.bind( this );
 	deleteAllUsers = deleteAllUsers.bind( this );
 }
 

--- a/packages/e2e-test-utils-playwright/src/request-utils/index.ts
+++ b/packages/e2e-test-utils-playwright/src/request-utils/index.ts
@@ -13,6 +13,7 @@ import { WP_ADMIN_USER, WP_BASE_URL } from '../config';
 import type { User } from './login';
 import { login } from './login';
 import { listMedia, uploadMedia, deleteMedia, deleteAllMedia } from './media';
+import { listUsers, deleteUser, createUser, deleteAllUsers } from './users';
 import { setupRest, rest, getMaxBatchSize, batchRest } from './rest';
 import { getPluginsMap, activatePlugin, deactivatePlugin } from './plugins';
 import { deleteAllTemplates } from './templates';
@@ -133,6 +134,10 @@ class RequestUtils {
 	uploadMedia = uploadMedia.bind( this );
 	deleteMedia = deleteMedia.bind( this );
 	deleteAllMedia = deleteAllMedia.bind( this );
+	listUsers = listUsers.bind( this );
+	createUser = createUser.bind( this );
+	deleteUser = deleteUser.bind( this );
+	deleteAllUsers = deleteAllUsers.bind( this );
 }
 
 export type { StorageState };

--- a/packages/e2e-test-utils-playwright/src/request-utils/users.ts
+++ b/packages/e2e-test-utils-playwright/src/request-utils/users.ts
@@ -89,14 +89,14 @@ async function deleteUser( this: RequestUtils, userId: number ) {
  * @param  this
  */
 async function deleteAllUsers( this: RequestUtils ) {
-	const users = await this.listUsers();
+	const users = await listUsers.bind( this )();
 
 	// The users endpoint doesn't support batch request yet.
 	const responses = await Promise.all(
-		users.map( ( user ) => this.deleteUser( user.id ) )
+		users.map( ( user: User ) => deleteUser.bind( this )( user.id ) )
 	);
 
 	return responses;
 }
 
-export { listUsers, createUser, deleteAllUsers, deleteUser };
+export { createUser, deleteAllUsers };

--- a/packages/e2e-test-utils-playwright/src/request-utils/users.ts
+++ b/packages/e2e-test-utils-playwright/src/request-utils/users.ts
@@ -11,10 +11,10 @@ export interface User {
 export interface UserData {
 	username: string;
 	email: string;
-	firstName: string;
-	lastName: string;
-	password: string;
-	roles: string[];
+	firstName?: string;
+	lastName?: string;
+	password?: string;
+	roles?: string[];
 }
 
 /**

--- a/packages/e2e-test-utils-playwright/src/request-utils/users.ts
+++ b/packages/e2e-test-utils-playwright/src/request-utils/users.ts
@@ -17,6 +17,15 @@ export interface UserData {
 	roles?: string[];
 }
 
+export interface UserRequestData {
+	username: string;
+	email: string;
+	first_name?: string;
+	last_name?: string;
+	password?: string;
+	roles?: string[];
+}
+
 /**
  * List all users.
  *
@@ -43,17 +52,31 @@ async function listUsers( this: RequestUtils ) {
  * @param  user User data to create.
  */
 async function createUser( this: RequestUtils, user: UserData ) {
+	const userData: UserRequestData = {
+		username: user.username,
+		email: user.email,
+	};
+
+	if ( user.firstName ) {
+		userData.first_name = user.firstName;
+	}
+
+	if ( user.lastName ) {
+		userData.last_name = user.lastName;
+	}
+
+	if ( user.password ) {
+		userData.password = user.password;
+	}
+
+	if ( user.roles ) {
+		userData.roles = user.roles;
+	}
+
 	const response = await this.rest< User >( {
 		method: 'POST',
 		path: '/wp/v2/users',
-		data: {
-			username: user.username,
-			email: user.email,
-			first_name: user.firstName,
-			last_name: user.lastName,
-			password: user.password,
-			roles: user.roles,
-		},
+		data: userData,
 	} );
 
 	return response;

--- a/packages/e2e-test-utils-playwright/src/request-utils/users.ts
+++ b/packages/e2e-test-utils-playwright/src/request-utils/users.ts
@@ -67,13 +67,6 @@ async function createUser( this: RequestUtils, user: UserData ) {
  * @param  userId The ID of the user.
  */
 async function deleteUser( this: RequestUtils, userId: number ) {
-	// Do not delete main user account.
-	if ( userId === 1 ) {
-		return new Promise( ( resolve ) => {
-			resolve( true );
-		} );
-	}
-
 	const response = await this.rest( {
 		method: 'DELETE',
 		path: `/wp/v2/users/${ userId }`,
@@ -93,7 +86,10 @@ async function deleteAllUsers( this: RequestUtils ) {
 
 	// The users endpoint doesn't support batch request yet.
 	const responses = await Promise.all(
-		users.map( ( user: User ) => deleteUser.bind( this )( user.id ) )
+		users
+			// Do not delete root user.
+			.filter( ( user: User ) => user.id !== 1 )
+			.map( ( user: User ) => deleteUser.bind( this )( user.id ) )
 	);
 
 	return responses;

--- a/packages/e2e-test-utils-playwright/src/request-utils/users.ts
+++ b/packages/e2e-test-utils-playwright/src/request-utils/users.ts
@@ -1,0 +1,102 @@
+/**
+ * Internal dependencies
+ */
+import type { RequestUtils } from './index';
+
+export interface User {
+	id: number;
+	email: string;
+}
+
+export interface UserData {
+	username: string;
+	email: string;
+	firstName: string;
+	lastName: string;
+	password: string;
+	roles: string[];
+}
+
+/**
+ * List all users.
+ *
+ * @see https://developer.wordpress.org/rest-api/reference/users/#list-users
+ * @param  this
+ */
+async function listUsers( this: RequestUtils ) {
+	const response = await this.rest< User[] >( {
+		method: 'GET',
+		path: '/wp/v2/users',
+		params: {
+			per_page: 100,
+		},
+	} );
+
+	return response;
+}
+
+/**
+ * Add a test user.
+ *
+ * @see https://developer.wordpress.org/rest-api/reference/users/#create-a-user
+ * @param  this
+ * @param  user User data to create.
+ */
+async function createUser( this: RequestUtils, user: UserData ) {
+	const response = await this.rest< User >( {
+		method: 'POST',
+		path: '/wp/v2/users',
+		data: {
+			username: user.username,
+			email: user.email,
+			first_name: user.firstName,
+			last_name: user.lastName,
+			password: user.password,
+			roles: user.roles,
+		},
+	} );
+
+	return response;
+}
+
+/**
+ * Delete a user.
+ *
+ * @see https://developer.wordpress.org/rest-api/reference/users/#delete-a-user
+ * @param  this
+ * @param  userId The ID of the user.
+ */
+async function deleteUser( this: RequestUtils, userId: number ) {
+	// Do not delete main user account.
+	if ( userId === 1 ) {
+		return new Promise( ( resolve ) => {
+			resolve( true );
+		} );
+	}
+
+	const response = await this.rest( {
+		method: 'DELETE',
+		path: `/wp/v2/users/${ userId }`,
+		params: { force: true, reassign: 1 },
+	} );
+
+	return response;
+}
+
+/**
+ * Delete all users except main root user.
+ *
+ * @param  this
+ */
+async function deleteAllUsers( this: RequestUtils ) {
+	const users = await this.listUsers();
+
+	// The users endpoint doesn't support batch request yet.
+	const responses = await Promise.all(
+		users.map( ( user ) => this.deleteUser( user.id ) )
+	);
+
+	return responses;
+}
+
+export { listUsers, createUser, deleteAllUsers, deleteUser };

--- a/test/e2e/specs/editor/blocks/avatar.spec.js
+++ b/test/e2e/specs/editor/blocks/avatar.spec.js
@@ -75,7 +75,5 @@ test.describe( 'Avatar', () => {
 		const newSrc = await avatarImage.getAttribute( 'src' );
 
 		expect( newSrc ).not.toBe( originalSrc );
-
-		await expect( userInput ).toBeVisible();
 	} );
 } );

--- a/test/e2e/specs/editor/blocks/avatar.spec.js
+++ b/test/e2e/specs/editor/blocks/avatar.spec.js
@@ -38,7 +38,7 @@ test.describe( 'Avatar', () => {
 		const username = 'Gravatar Gravatar';
 
 		const avatarBlock = page.locator(
-			'role=document[name="Block: Avatar"]'
+			'role=document[name="Block: Avatar"i]'
 		);
 
 		await expect( avatarBlock ).toBeVisible();

--- a/test/e2e/specs/editor/blocks/avatar.spec.js
+++ b/test/e2e/specs/editor/blocks/avatar.spec.js
@@ -41,8 +41,6 @@ test.describe( 'Avatar', () => {
 			'role=document[name="Block: Avatar"i]'
 		);
 
-		await expect( avatarBlock ).toBeVisible();
-
 		const avatarImage = avatarBlock.locator( 'img' );
 
 		await expect( avatarImage ).toBeVisible();

--- a/test/e2e/specs/editor/blocks/avatar.spec.js
+++ b/test/e2e/specs/editor/blocks/avatar.spec.js
@@ -63,16 +63,12 @@ test.describe( 'Avatar', () => {
 			'.components-combobox-control__input'
 		);
 
-		await expect( userInput ).toBeVisible();
-
 		// Set new user.
 		await userInput.click();
 
 		const newUser = userComboBox.locator(
 			'role=option[name="' + username + '"]'
 		);
-
-		await expect( newUser ).toBeVisible();
 
 		await newUser.click();
 

--- a/test/e2e/specs/editor/blocks/avatar.spec.js
+++ b/test/e2e/specs/editor/blocks/avatar.spec.js
@@ -53,22 +53,14 @@ test.describe( 'Avatar', () => {
 
 		await expect( blockInspectorControls ).toBeVisible();
 
-		const userComboBox = blockInspectorControls.locator(
-			'.components-combobox-control'
-		);
-
-		await expect( userComboBox ).toBeVisible();
-
-		const userInput = userComboBox.locator(
-			'.components-combobox-control__input'
+		const userInput = page.locator(
+			'role=region[name="Editor settings"i] >> role=combobox[name="User"i]'
 		);
 
 		// Set new user.
 		await userInput.click();
 
-		const newUser = userComboBox.locator(
-			'role=option[name="' + username + '"]'
-		);
+		const newUser = page.locator( 'role=option[name="' + username + '"]' );
 
 		await newUser.click();
 

--- a/test/e2e/specs/editor/blocks/avatar.spec.js
+++ b/test/e2e/specs/editor/blocks/avatar.spec.js
@@ -1,0 +1,87 @@
+/**
+ * WordPress dependencies
+ */
+
+const { test, expect } = require( '@wordpress/e2e-test-utils-playwright' );
+
+test.describe( 'Avatar', () => {
+	test.beforeAll( async ( { requestUtils } ) => {
+		await requestUtils.deleteAllUsers();
+	} );
+
+	test.beforeEach( async ( { admin, requestUtils } ) => {
+		await requestUtils.createUser( {
+			username: 'user',
+			email: 'gravatartest@gmail.com',
+			firstName: 'Gravatar',
+			lastName: 'Gravatar',
+			roles: [ 'author' ],
+			password: 'gravatargravatar123magic',
+		} );
+
+		await admin.createNewPost();
+	} );
+
+	test.afterEach( async ( { requestUtils } ) => {
+		await requestUtils.deleteAllUsers();
+	} );
+
+	test( 'should change image when user is changed', async ( {
+		editor,
+		page,
+	} ) => {
+		// Inserting a quote block
+		await editor.insertBlock( {
+			name: 'core/avatar',
+		} );
+
+		const username = 'Gravatar Gravatar';
+
+		const avatarBlock = page.locator(
+			'role=document[name="Block: Avatar"]'
+		);
+
+		await expect( avatarBlock ).toBeVisible();
+
+		const avatarImage = avatarBlock.locator( 'img' );
+
+		await expect( avatarImage ).toBeVisible();
+
+		const originalSrc = await avatarImage.getAttribute( 'src' );
+
+		const blockInspectorControls = page.locator(
+			'.block-editor-block-inspector'
+		);
+
+		await expect( blockInspectorControls ).toBeVisible();
+
+		const userComboBox = blockInspectorControls.locator(
+			'.components-combobox-control'
+		);
+
+		await expect( userComboBox ).toBeVisible();
+
+		const userInput = userComboBox.locator(
+			'.components-combobox-control__input'
+		);
+
+		await expect( userInput ).toBeVisible();
+
+		// Set new user.
+		await userInput.click();
+
+		const newUser = userComboBox.locator(
+			'role=option[name="' + username + '"]'
+		);
+
+		await expect( newUser ).toBeVisible();
+
+		await newUser.click();
+
+		const newSrc = await avatarImage.getAttribute( 'src' );
+
+		expect( newSrc ).not.toBe( originalSrc );
+
+		await expect( userInput ).toBeVisible();
+	} );
+} );


### PR DESCRIPTION
Fixes #39645.

<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Add e2e tests in Playwright for the avatar block. When a user is switched check if the image src updates as well.

## Why?
Adds e2e tests for the avatar block to ensure that we are always properly updating the image src.

## How?
Adds user helper utilities to the `@wordpress/e2e-test-utils-playwright` for adding users and cleaning up added users. This is used to add a sample user, Gravatar Gravatar, The new user is selected from the user combo box and the original source is checked against the new source after the user has been updated.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
1. `npm i`
2. `npm run build`
3. `npm run test-e2e:playwright -- editor/blocks/avatar.spec.js`
4. Ensure tests pass

## Screenshots or screencast <!-- if applicable -->
Not applicable.