### PR TITLE
BorderBoxControl: Add Tooltips around split border controls

### DIFF
--- a/packages/components/src/border-box-control/border-box-control-split-controls/component.tsx
+++ b/packages/components/src/border-box-control/border-box-control-split-controls/component.tsx
@@ -9,6 +9,7 @@ import { useMergeRefs } from '@wordpress/compose';
  * Internal dependencies
  */
 import BorderBoxControlVisualizer from '../border-box-control-visualizer';
+import Tooltip from '../../tooltip';
 import { BorderControl } from '../../border-control';
 import { Grid } from '../../grid';
 import { contextConnect, WordPressComponentProps } from '../../ui/context';
@@ -64,41 +65,62 @@ const BorderBoxControlSplitControls = (
 				value={ value }
 				__next36pxDefaultSize={ __next36pxDefaultSize }
 			/>
-			<BorderControl
-				className={ centeredClassName }
-				hideLabelFromVision={ true }
-				label={ __( 'Top border' ) }
-				onChange={ ( newBorder ) => onChange( newBorder, 'top' ) }
-				__unstablePopoverProps={ popoverProps }
-				value={ value?.top }
-				{ ...sharedBorderControlProps }
-			/>
-			<BorderControl
-				hideLabelFromVision={ true }
-				label={ __( 'Left border' ) }
-				onChange={ ( newBorder ) => onChange( newBorder, 'left' ) }
-				__unstablePopoverProps={ popoverProps }
-				value={ value?.left }
-				{ ...sharedBorderControlProps }
-			/>
-			<BorderControl
-				className={ rightAlignedClassName }
-				hideLabelFromVision={ true }
-				label={ __( 'Right border' ) }
-				onChange={ ( newBorder ) => onChange( newBorder, 'right' ) }
-				__unstablePopoverProps={ popoverProps }
-				value={ value?.right }
-				{ ...sharedBorderControlProps }
-			/>
-			<BorderControl
-				className={ centeredClassName }
-				hideLabelFromVision={ true }
-				label={ __( 'Bottom border' ) }
-				onChange={ ( newBorder ) => onChange( newBorder, 'bottom' ) }
-				__unstablePopoverProps={ popoverProps }
-				value={ value?.bottom }
-				{ ...sharedBorderControlProps }
-			/>
+			<Tooltip text={ __( 'Top border' ) } position="top">
+				<div className={ centeredClassName }>
+					<BorderControl
+						hideLabelFromVision={ true }
+						label={ __( 'Top border' ) }
+						onChange={ ( newBorder ) =>
+							onChange( newBorder, 'top' )
+						}
+						__unstablePopoverProps={ popoverProps }
+						value={ value?.top }
+						{ ...sharedBorderControlProps }
+					/>
+				</div>
+			</Tooltip>
+			<Tooltip text={ __( 'Left border' ) } position="top">
+				<div>
+					<BorderControl
+						hideLabelFromVision={ true }
+						label={ __( 'Left border' ) }
+						onChange={ ( newBorder ) =>
+							onChange( newBorder, 'left' )
+						}
+						__unstablePopoverProps={ popoverProps }
+						value={ value?.left }
+						{ ...sharedBorderControlProps }
+					/>
+				</div>
+			</Tooltip>
+			<Tooltip text={ __( 'Right border' ) } position="top">
+				<div className={ rightAlignedClassName }>
+					<BorderControl
+						hideLabelFromVision={ true }
+						label={ __( 'Right border' ) }
+						onChange={ ( newBorder ) =>
+							onChange( newBorder, 'right' )
+						}
+						__unstablePopoverProps={ popoverProps }
+						value={ value?.right }
+						{ ...sharedBorderControlProps }
+					/>
+				</div>
+			</Tooltip>
+			<Tooltip text={ __( 'Bottom border' ) } position="top">
+				<div className={ centeredClassName }>
+					<BorderControl
+						hideLabelFromVision={ true }
+						label={ __( 'Bottom border' ) }
+						onChange={ ( newBorder ) =>
+							onChange( newBorder, 'bottom' )
+						}
+						__unstablePopoverProps={ popoverProps }
+						value={ value?.bottom }
+						{ ...sharedBorderControlProps }
+					/>
+				</div>
+			</Tooltip>
 		</Grid>
 	);
 };


### PR DESCRIPTION
Related: 
- https://github.com/WordPress/gutenberg/issues/42095
- https://github.com/WordPress/gutenberg/pull/42348
- https://github.com/WordPress/gutenberg/pull/42212

## What?

Add basic tooltips around each individual side's border control within the `BorderBoxControl`

## Why?

Assists speech recognition software users in identifying the names of individual border fields. See: https://github.com/WordPress/gutenberg/issues/42095#issuecomment-1183968034

## How?

- Follows the same approach to adding Tooltips as used by `BoxControl` and `BorderRadiusControl` components
- Individual border controls are wrapped in a `Tooltip` with an inner `div` wrapper.

## Known Issues

The recent addition of a [Tooltip to the border color and style picker button](https://github.com/WordPress/gutenberg/pull/42348) means when it is hovered two Tooltips are displayed at once.

<img width="415" alt="Screen Shot 2022-07-25 at 2 24 58 pm" src="https://user-images.githubusercontent.com/60436221/180704329-801add26-04c1-499d-b873-17e4060304d9.png">

##### Possible options

1. Remove the tooltip from the color/style picker button
2. Revert the recent change rendering the color style picker dropdown as a `UnitControl` prefix. This means we could wrap the `UnitControl` with a tooltip independently to the dropdown.
3. Extend `InputControl` to support optionally wrapping its `InputField` with a tooltip.

## Testing Instructions
1. Start up Storybook and visit the [`BorderBoxControl` page](http://localhost:50240/?path=/story/components-experimental-borderboxcontrol--default).
2. Click the "Unlink sides" button to see the individual side border controls.
3. Hover over the various fields and confirm appropriate tooltips display
4. Notice the concurrent tooltips when hovering a side's border color/style picker button
5. Confirm the `BorderBoxControl` functions the same as on trunk despite the tooltips.

## Screenshots or screencast <!-- if applicable -->

https://user-images.githubusercontent.com/60436221/180704875-d0d72bad-f27e-4c5d-a2a1-daa76ad14529.mp4


