### PR TITLE
Query Title: Add a search title variation

### DIFF
--- a/docs/reference-guides/core-blocks.md
+++ b/docs/reference-guides/core-blocks.md
@@ -663,7 +663,7 @@ Display the query title. ([Source](https://github.com/WordPress/gutenberg/tree/t
 -	**Name:** core/query-title
 -	**Category:** theme
 -	**Supports:** align (full, wide), color (background, gradients, text), spacing (margin), typography (fontSize, lineHeight), ~~html~~
--	**Attributes:** level, textAlign, type
+-	**Attributes:** level, showSearchTerm, textAlign, type
 
 ## Quote
 

--- a/packages/block-library/src/query-title/block.json
+++ b/packages/block-library/src/query-title/block.json
@@ -16,6 +16,10 @@
 		"level": {
 			"type": "number",
 			"default": 1
+		},
+		"showSearchTerm": {
+			"type": "boolean",
+			"default": true
 		}
 	},
 	"supports": {

--- a/packages/block-library/src/query-title/edit.js
+++ b/packages/block-library/src/query-title/edit.js
@@ -19,7 +19,7 @@ import { __ } from '@wordpress/i18n';
  */
 import HeadingLevelDropdown from '../heading/heading-level-dropdown';
 
-const SUPPORTED_TYPES = [ 'archive' ];
+const SUPPORTED_TYPES = [ 'archive', 'search' ];
 
 export default function QueryTitleEdit( {
 	attributes: { type, level, textAlign },
@@ -29,11 +29,10 @@ export default function QueryTitleEdit( {
 	const blockProps = useBlockProps( {
 		className: classnames( {
 			[ `has-text-align-${ textAlign }` ]: textAlign,
-			'wp-block-query-title__placeholder': type === 'archive',
+			'wp-block-query-title__placeholder': true,
 		} ),
 	} );
-	// The plan is to augment this block with more
-	// block variations like `Search Title`.
+
 	if ( ! SUPPORTED_TYPES.includes( type ) ) {
 		return (
 			<div { ...blockProps }>
@@ -46,6 +45,10 @@ export default function QueryTitleEdit( {
 	if ( type === 'archive' ) {
 		titleElement = (
 			<TagName { ...blockProps }>{ __( 'Archive title' ) }</TagName>
+		);
+	} else if ( type === 'search' ) {
+		titleElement = (
+			<TagName { ...blockProps }>{ __( 'Search results:' ) }</TagName>
 		);
 	}
 	return (

--- a/packages/block-library/src/query-title/edit.js
+++ b/packages/block-library/src/query-title/edit.js
@@ -9,9 +9,11 @@ import classnames from 'classnames';
 import {
 	AlignmentControl,
 	BlockControls,
+	InspectorControls,
 	useBlockProps,
 	Warning,
 } from '@wordpress/block-editor';
+import { ToggleControl, PanelBody } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 
 /**
@@ -22,7 +24,7 @@ import HeadingLevelDropdown from '../heading/heading-level-dropdown';
 const SUPPORTED_TYPES = [ 'archive', 'search' ];
 
 export default function QueryTitleEdit( {
-	attributes: { type, level, textAlign },
+	attributes: { type, level, textAlign, showSearchTerm },
 	setAttributes,
 } ) {
 	const TagName = `h${ level }`;
@@ -48,7 +50,30 @@ export default function QueryTitleEdit( {
 		);
 	} else if ( type === 'search' ) {
 		titleElement = (
-			<TagName { ...blockProps }>{ __( 'Search results:' ) }</TagName>
+			<>
+				<InspectorControls>
+					<PanelBody title={ __( 'Settings' ) }>
+						<ToggleControl
+							label={ __( 'Show search term in title' ) }
+							onChange={ () =>
+								setAttributes( {
+									showSearchTerm: ! showSearchTerm,
+								} )
+							}
+							checked={ showSearchTerm }
+						/>
+					</PanelBody>
+				</InspectorControls>
+				{ showSearchTerm ? (
+					<TagName { ...blockProps }>
+						{ __( 'Search results for: "search term"' ) }
+					</TagName>
+				) : (
+					<TagName { ...blockProps }>
+						{ __( 'Search results:' ) }
+					</TagName>
+				) }
+			</>
 		);
 	}
 	return (

--- a/packages/block-library/src/query-title/edit.js
+++ b/packages/block-library/src/query-title/edit.js
@@ -29,9 +29,8 @@ export default function QueryTitleEdit( {
 } ) {
 	const TagName = `h${ level }`;
 	const blockProps = useBlockProps( {
-		className: classnames( {
+		className: classnames( 'wp-block-query-title__placeholder', {
 			[ `has-text-align-${ textAlign }` ]: textAlign,
-			'wp-block-query-title__placeholder': true,
 		} ),
 	} );
 
@@ -48,7 +47,9 @@ export default function QueryTitleEdit( {
 		titleElement = (
 			<TagName { ...blockProps }>{ __( 'Archive title' ) }</TagName>
 		);
-	} else if ( type === 'search' ) {
+	}
+
+	if ( type === 'search' ) {
 		titleElement = (
 			<>
 				<InspectorControls>
@@ -64,18 +65,16 @@ export default function QueryTitleEdit( {
 						/>
 					</PanelBody>
 				</InspectorControls>
-				{ showSearchTerm ? (
-					<TagName { ...blockProps }>
-						{ __( 'Search results for: "search term"' ) }
-					</TagName>
-				) : (
-					<TagName { ...blockProps }>
-						{ __( 'Search results:' ) }
-					</TagName>
-				) }
+
+				<TagName { ...blockProps }>
+					{ showSearchTerm
+						? __( 'Search results for: "search term"' )
+						: __( 'Search results' ) }
+				</TagName>
 			</>
 		);
 	}
+
 	return (
 		<>
 			<BlockControls group="block">

--- a/packages/block-library/src/query-title/index.php
+++ b/packages/block-library/src/query-title/index.php
@@ -20,15 +20,23 @@ function render_block_core_query_title( $attributes ) {
 	$is_search  = is_search();
 	if ( ! $type ||
 		( 'archive' === $type && ! $is_archive ) ||
-		( 'search' === $type && ! $is_search ) 
+		( 'search' === $type && ! $is_search )
 		) {
 		return '';
 	}
 	$title = '';
 	if ( $is_archive ) {
 		$title = get_the_archive_title();
-	} else if ( $is_search ) {
-		$title = __( 'Search results:' );
+	} elseif ( $is_search ) {
+		if ( isset( $attributes['showSearchTerm'] ) && $attributes['showSearchTerm'] !== false ) {
+			/* translators: %s is the search term. */
+			$title = sprintf(
+				__( 'Search results for: "%s"' ),
+				get_search_query()
+			);
+		} else {
+			$title = __( 'Search results:' );
+		}
 	}
 
 	$tag_name           = isset( $attributes['level'] ) ? 'h' . (int) $attributes['level'] : 'h1';

--- a/packages/block-library/src/query-title/index.php
+++ b/packages/block-library/src/query-title/index.php
@@ -17,13 +17,20 @@
 function render_block_core_query_title( $attributes ) {
 	$type       = isset( $attributes['type'] ) ? $attributes['type'] : null;
 	$is_archive = is_archive();
-	if ( ! $type || ( 'archive' === $type && ! $is_archive ) ) {
+	$is_search  = is_search();
+	if ( ! $type ||
+		( 'archive' === $type && ! $is_archive ) ||
+		( 'search' === $type && ! $is_search ) 
+		) {
 		return '';
 	}
 	$title = '';
 	if ( $is_archive ) {
 		$title = get_the_archive_title();
+	} else if ( $is_search ) {
+		$title = __( 'Search results:' );
 	}
+
 	$tag_name           = isset( $attributes['level'] ) ? 'h' . (int) $attributes['level'] : 'h1';
 	$align_class_name   = empty( $attributes['textAlign'] ) ? '' : "has-text-align-{$attributes['textAlign']}";
 	$wrapper_attributes = get_block_wrapper_attributes( array( 'class' => $align_class_name ) );

--- a/packages/block-library/src/query-title/index.php
+++ b/packages/block-library/src/query-title/index.php
@@ -28,9 +28,9 @@ function render_block_core_query_title( $attributes ) {
 	if ( $is_archive ) {
 		$title = get_the_archive_title();
 	} elseif ( $is_search ) {
-		if ( isset( $attributes['showSearchTerm'] ) && $attributes['showSearchTerm'] !== false ) {
-			/* translators: %s is the search term. */
+		if ( isset( $attributes['showSearchTerm'] ) && $attributes['showSearchTerm'] ) {
 			$title = sprintf(
+				/* translators: %s is the search term. */
 				__( 'Search results for: "%s"' ),
 				get_search_query()
 			);

--- a/packages/block-library/src/query-title/index.php
+++ b/packages/block-library/src/query-title/index.php
@@ -27,15 +27,16 @@ function render_block_core_query_title( $attributes ) {
 	$title = '';
 	if ( $is_archive ) {
 		$title = get_the_archive_title();
-	} elseif ( $is_search ) {
+	}
+	if ( $is_search ) {
+		$title = __( 'Search results' );
+
 		if ( isset( $attributes['showSearchTerm'] ) && $attributes['showSearchTerm'] ) {
 			$title = sprintf(
 				/* translators: %s is the search term. */
 				__( 'Search results for: "%s"' ),
 				get_search_query()
 			);
-		} else {
-			$title = __( 'Search results:' );
 		}
 	}
 

--- a/packages/block-library/src/query-title/variations.js
+++ b/packages/block-library/src/query-title/variations.js
@@ -17,6 +17,19 @@ const variations = [
 		},
 		scope: [ 'inserter' ],
 	},
+	{
+		isDefault: false,
+		name: 'search-title',
+		title: __( 'Search Results Title' ),
+		description: __(
+			'Display the search results title based on the queried object.'
+		),
+		icon: title,
+		attributes: {
+			type: 'search',
+		},
+		scope: [ 'inserter' ],
+	},
 ];
 
 /**

--- a/test/integration/fixtures/blocks/core__query-title.json
+++ b/test/integration/fixtures/blocks/core__query-title.json
@@ -3,7 +3,8 @@
 		"name": "core/query-title",
 		"isValid": true,
 		"attributes": {
-			"level": 1
+			"level": 1,
+			"showSearchTerm": true
 		},
 		"innerBlocks": []
 	}


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->
Adds a new variation to the query title block that displays the texts Search results: or Search results for: "term",
depending on settings.
On the front, the text is only visible on the search template.

Partial for #33476

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
The variation is a small improvement that means users do not need to hard code the search results title.
Allows users to display the search term in the title.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
The block does not automatically detect if it is on a search results page: It is a variation that uses the `type` attribute on the query title block, and the variation needs to be selected.
This method was chosen because it is already used for the Archive title variation.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->

1. Apply the PR
2. Enable a theme with support for full site editing
3. If the theme does not already have a search template, create one.
4. Add two search results titles to the template, one with the option "Show search term in title" enabled. Save.
5. View the search results page on the front.

## Screenshots or screencast <!-- if applicable -->
![The search results title block variation displays a title for the search results page, with or without the search term](https://user-images.githubusercontent.com/7422055/180713586-069f8b85-edbb-4454-b688-958e01ddf69b.png)


