### PR TITLE
MaybeCategoryPanel: Update category selector

### DIFF
--- a/packages/editor/src/components/post-publish-panel/maybe-category-panel.js
+++ b/packages/editor/src/components/post-publish-panel/maybe-category-panel.js
@@ -27,13 +27,11 @@ function MaybeCategoryPanel() {
 			'root',
 			'site'
 		)?.default_category;
-		const defaultCategory = select( coreStore ).getEntityRecords(
+		const defaultCategory = select( coreStore ).getEntityRecord(
 			'taxonomy',
 			'category',
-			{
-				id: defaultCategoryId,
-			}
-		)?.[ 0 ];
+			defaultCategoryId
+		);
 		const postTypeSupportsCategories =
 			categoriesTaxonomy &&
 			some( categoriesTaxonomy.types, ( type ) => type === postType );


### PR DESCRIPTION
## What?
PR updates selector used in MaybeCategoryPanel.

## Why?
Since #41955, we've got a default category ID, so we can use `getEntityRecord` for fetching the entity.

## Testing Instructions
1. Create a Post.
2. Try to publish without setting a category.
3. Confirm that the suggestion panel is shown.

## Screenshots or screencast <!-- if applicable -->

![CleanShot 2022-07-25 at 10 05 57](https://user-images.githubusercontent.com/240569/180709262-8930260b-2660-4021-a927-0c1f86c3fda1.png)

