### PR TITLE
Add inherit content size to base styles

### DIFF
--- a/lib/block-supports/layout.php
+++ b/lib/block-supports/layout.php
@@ -193,12 +193,8 @@ function gutenberg_render_layout_support_flag( $block_content, $block ) {
 			return $block_content;
 		}
 
-		if ( isset( $global_layout_settings['contentSize'] ) && $global_layout_settings['contentSize'] ) {
+		if ( isset( $global_layout_settings['contentSize'] ) && $global_layout_settings['contentSize'] || isset( $global_layout_settings['wideSize'] ) && $global_layout_settings['wideSize'] ) {
 			$class_names[] = 'has-global-content-size';
-		}
-
-		if ( isset( $global_layout_settings['wideSize'] ) && $global_layout_settings['wideSize'] ) {
-			$class_names[] = 'has-global-wide-size';
 		}
 	}
 

--- a/lib/compat/wordpress-6.1/class-wp-theme-json-6-1.php
+++ b/lib/compat/wordpress-6.1/class-wp-theme-json-6-1.php
@@ -753,7 +753,9 @@ class WP_Theme_JSON_6_1 extends WP_Theme_JSON_6_0 {
 			*/
 			if ( isset( $settings['layout']['contentSize'] ) && $settings['layout']['contentSize'] || isset( $settings['layout']['wideSize'] ) && $settings['layout']['wideSize'] ) {
 				$content_size = isset( $settings['layout']['contentSize'] ) ? $settings['layout']['contentSize'] : $settings['layout']['wideSize'];
+				$content_size = static::is_safe_css_declaration( 'max-width', $content_size ) ? $content_size : 'initial';
 				$wide_size    = isset( $settings['layout']['wideSize'] ) ? $settings['layout']['wideSize'] : $settings['layout']['contentSize'];
+				$wide_size    = static::is_safe_css_declaration( 'max-width', $wide_size ) ? $wide_size : 'initial';
 				$block_rules .= '--wp--style--global--content-size: ' . $content_size . ';';
 				$block_rules .= '--wp--style--global--wide-size: ' . $wide_size . ';';
 			}

--- a/lib/compat/wordpress-6.1/class-wp-theme-json-6-1.php
+++ b/lib/compat/wordpress-6.1/class-wp-theme-json-6-1.php
@@ -736,16 +736,29 @@ class WP_Theme_JSON_6_1 extends WP_Theme_JSON_6_0 {
 			}
 		}
 
-		/*
-		 * Reset default browser margin on the root body element.
-		 * This is set on the root selector **before** generating the ruleset
-		 * from the `theme.json`. This is to ensure that if the `theme.json` declares
-		 * `margin` in its `spacing` declaration for the `body` element then these
-		 * user-generated values take precedence in the CSS cascade.
-		 * @link https://github.com/WordPress/gutenberg/issues/36147.
-		 */
 		if ( static::ROOT_BLOCK_SELECTOR === $selector ) {
-			$block_rules .= 'body { margin: 0; }';
+			/*
+			* Reset default browser margin on the root body element.
+			* This is set on the root selector **before** generating the ruleset
+			* from the `theme.json`. This is to ensure that if the `theme.json` declares
+			* `margin` in its `spacing` declaration for the `body` element then these
+			* user-generated values take precedence in the CSS cascade.
+			* @link https://github.com/WordPress/gutenberg/issues/36147.
+			*/
+			$block_rules .= 'body { margin: 0;';
+
+			/*
+			* If there are content and wide widths in theme.json, output them
+			* as custom properties on the body element so all blocks can use them.
+			*/
+			if ( isset( $settings['layout']['contentSize'] ) && $settings['layout']['contentSize'] ) {
+				$block_rules .= '--wp--style--global--content-size: ' . $settings['layout']['contentSize'] . ';';
+			}
+			if ( isset( $settings['layout']['wideSize'] ) && $settings['layout']['wideSize'] ) {
+				$block_rules .= '--wp--style--global--wide-size: ' . $settings['layout']['wideSize'] . ';';
+			}
+
+			$block_rules .= '}';
 		}
 
 		// 2. Generate and append the rules that use the general selector.
@@ -1264,7 +1277,7 @@ class WP_Theme_JSON_6_1 extends WP_Theme_JSON_6_0 {
 		$has_fallback_gap_support = ! $has_block_gap_support; // This setting isn't useful yet: it exists as a placeholder for a future explicit fallback gap styles support.
 		$node                     = _wp_array_get( $this->theme_json, $block_metadata['path'], array() );
 		$layout_definitions       = _wp_array_get( $this->theme_json, array( 'settings', 'layout', 'definitions' ), array() );
-		$layout_selector_pattern  = '/^[a-zA-Z0-9\-\.\ *+>]*$/'; // Allow alphanumeric classnames, spaces, wildcard, sibling, and child combinator selectors.
+		$layout_selector_pattern  = '/^[a-zA-Z0-9\-\.\ *+>:\(\)]*$/'; // Allow alphanumeric classnames, spaces, wildcard, sibling, child combinator and pseudo class selectors.
 
 		// Gap styles will only be output if the theme has block gap support, or supports a fallback gap.
 		// Default layout gap styles will be skipped for themes that do not explicitly opt-in to blockGap with a `true` or `false` value.

--- a/lib/compat/wordpress-6.1/class-wp-theme-json-6-1.php
+++ b/lib/compat/wordpress-6.1/class-wp-theme-json-6-1.php
@@ -751,11 +751,11 @@ class WP_Theme_JSON_6_1 extends WP_Theme_JSON_6_0 {
 			* If there are content and wide widths in theme.json, output them
 			* as custom properties on the body element so all blocks can use them.
 			*/
-			if ( isset( $settings['layout']['contentSize'] ) && $settings['layout']['contentSize'] ) {
-				$block_rules .= '--wp--style--global--content-size: ' . $settings['layout']['contentSize'] . ';';
-			}
-			if ( isset( $settings['layout']['wideSize'] ) && $settings['layout']['wideSize'] ) {
-				$block_rules .= '--wp--style--global--wide-size: ' . $settings['layout']['wideSize'] . ';';
+			if ( isset( $settings['layout']['contentSize'] ) && $settings['layout']['contentSize'] || isset( $settings['layout']['wideSize'] ) && $settings['layout']['wideSize'] ) {
+				$content_size = isset( $settings['layout']['contentSize'] ) ? $settings['layout']['contentSize'] : $settings['layout']['wideSize'];
+				$wide_size    = isset( $settings['layout']['wideSize'] ) ? $settings['layout']['wideSize'] : $settings['layout']['contentSize'];
+				$block_rules .= '--wp--style--global--content-size: ' . $content_size . ';';
+				$block_rules .= '--wp--style--global--wide-size: ' . $wide_size . ';';
 			}
 
 			$block_rules .= '}';

--- a/lib/compat/wordpress-6.1/theme.json
+++ b/lib/compat/wordpress-6.1/theme.json
@@ -215,6 +215,20 @@
 								"margin-left": "auto !important",
 								"margin-right": "auto !important"
 							}
+						},
+						{
+							"selector": ":where(.has-global-content-size) > :where(:not(.alignleft):not(.alignright):not(.alignfull))",
+							"rules": {
+								"max-width": "var(--wp--style--global--content-size)",
+								"margin-left": "auto !important",
+								"margin-right": "auto !important"
+							}
+						},
+						{
+							"selector": ":where(.has-global-wide-size) > .alignwide",
+							"rules": {
+								"max-width": "var(--wp--style--global--wide-size)"
+							}
 						}
 					],
 					"spacingStyles": [

--- a/lib/compat/wordpress-6.1/theme.json
+++ b/lib/compat/wordpress-6.1/theme.json
@@ -225,7 +225,7 @@
 							}
 						},
 						{
-							"selector": ":where(.has-global-wide-size) > .alignwide",
+							"selector": ":where(.has-global-content-size) > .alignwide",
 							"rules": {
 								"max-width": "var(--wp--style--global--wide-size)"
 							}

--- a/packages/block-editor/src/hooks/layout.js
+++ b/packages/block-editor/src/hooks/layout.js
@@ -64,7 +64,6 @@ function useLayoutClasses( layout, layoutDefinitions ) {
 	}
 	if ( layout?.inherit ) {
 		layoutClassnames.push( 'has-global-content-size' );
-		layoutClassnames.push( 'has-global-wide-size' );
 	}
 
 	if ( ( layout?.inherit || layout?.contentSize ) && rootPaddingAlignment ) {

--- a/packages/block-editor/src/hooks/layout.js
+++ b/packages/block-editor/src/hooks/layout.js
@@ -62,6 +62,10 @@ function useLayoutClasses( layout, layoutDefinitions ) {
 			layoutDefinitions?.[ layout?.type || 'default' ]?.className
 		);
 	}
+	if ( layout?.inherit ) {
+		layoutClassnames.push( 'has-global-content-size' );
+		layoutClassnames.push( 'has-global-wide-size' );
+	}
 
 	if ( ( layout?.inherit || layout?.contentSize ) && rootPaddingAlignment ) {
 		layoutClassnames.push( 'has-global-padding' );
@@ -275,7 +279,7 @@ export const withLayoutStyles = createHigherOrderComponent(
 		const { default: defaultBlockLayout } =
 			getBlockSupport( name, layoutBlockSupportKey ) || {};
 		const usedLayout = layout?.inherit
-			? defaultThemeLayout
+			? { ...defaultThemeLayout, ...layout }
 			: layout || defaultBlockLayout || {};
 		const layoutClasses = shouldRenderLayoutStyles
 			? useLayoutClasses( usedLayout, defaultThemeLayout?.definitions )

--- a/packages/block-editor/src/layouts/flow.js
+++ b/packages/block-editor/src/layouts/flow.js
@@ -116,7 +116,7 @@ export default {
 		hasBlockGapSupport,
 		layoutDefinitions,
 	} ) {
-		const { contentSize, wideSize } = layout;
+		const { contentSize, wideSize, inherit = false } = layout;
 		const blockGapStyleValue = getGapBoxControlValueFromStyle(
 			style?.spacing?.blockGap
 		);
@@ -129,7 +129,7 @@ export default {
 				: '';
 
 		let output =
-			!! contentSize || !! wideSize
+			( !! contentSize || !! wideSize ) && ! inherit
 				? `
 					${ appendSelectors(
 						selector,
@@ -141,9 +141,6 @@ export default {
 					}
 					${ appendSelectors( selector, '> .alignwide' ) }  {
 						max-width: ${ wideSize ?? contentSize };
-					}
-					${ appendSelectors( selector, '> .alignfull' ) } {
-						max-width: none;
 					}
 				`
 				: '';


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Companion to #42582; adds styles required for containers that use default content size to base styles, so that those containers don't need generated classes anymore.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

If we're going to set content size by default on some blocks, it makes sense that the required styles be defined as base styles.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->

## Screenshots or screencast <!-- if applicable -->
