### PR TITLE
Replace clickable div elements with buttons in the Add template modal.

### DIFF
--- a/packages/edit-site/src/components/add-new-template/add-custom-template-modal.js
+++ b/packages/edit-site/src/components/add-new-template/add-custom-template-modal.js
@@ -11,7 +11,6 @@ import {
 	SearchControl,
 	TextHighlight,
 	__experimentalText as Text,
-	__experimentalHeading as Heading,
 	__unstableComposite as Composite,
 	__unstableUseCompositeState as useCompositeState,
 	__unstableCompositeItem as CompositeItem,
@@ -191,15 +190,16 @@ function AddCustomTemplateModal( { onClose, onSelect, entityForSuggestions } ) {
 					>
 						<FlexItem
 							isBlock
+							as={ Button }
 							onClick={ () => {
 								const { slug, title, description } =
 									entityForSuggestions.template;
 								onSelect( { slug, title, description } );
 							} }
 						>
-							<Heading level={ 5 }>
+							<Text as="span" weight={ 600 }>
 								{ entityForSuggestions.labels.all_items }
-							</Heading>
+							</Text>
 							<Text as="span">
 								{
 									// translators: The user is given the choice to set up a template for all items of a post type or taxonomy, or just a specific one.
@@ -209,13 +209,14 @@ function AddCustomTemplateModal( { onClose, onSelect, entityForSuggestions } ) {
 						</FlexItem>
 						<FlexItem
 							isBlock
+							as={ Button }
 							onClick={ () => {
 								setShowSearchEntities( true );
 							} }
 						>
-							<Heading level={ 5 }>
+							<Text as="span" weight={ 600 }>
 								{ entityForSuggestions.labels.singular_name }
-							</Heading>
+							</Text>
 							<Text as="span">
 								{
 									// translators: The user is given the choice to set up a template for all items of a post type or taxonomy, or just a specific one.

--- a/packages/edit-site/src/components/add-new-template/style.scss
+++ b/packages/edit-site/src/components/add-new-template/style.scss
@@ -12,33 +12,45 @@
 
 .edit-site-custom-template-modal {
 	&__contents {
-		> div {
-			text-align: center;
-			cursor: pointer;
+		> .components-button {
 			padding: $grid-unit-30;
-			border: 1px solid $gray-300;
+			box-shadow: inset 0 0 0 $border-width $gray-600;
 			border-radius: $radius-block-ui;
 			width: 256px;
+			height: auto;
 			display: flex;
 			flex-direction: column;
 			gap: $grid-unit;
-			align-items: center;
-			justify-content: center;
+
+			// Show the boundary of the button, in High Contrast Mode.
+			outline: 1px solid transparent;
+
+			span:first-child {
+				color: $gray-900;
+			}
 
 			span {
 				color: $gray-700;
 			}
 
 			&:hover {
-				border-color: var(--wp-admin-theme-color);
+				color: var(--wp-admin-theme-color-darker-10);
+				box-shadow: inset 0 0 0 $border-width var(--wp-admin-theme-color-darker-10);
 
-				h5 {
+				span:first-child {
 					color: var(--wp-admin-theme-color);
 				}
 			}
 
 			&:focus {
 				box-shadow: 0 0 0 var(--wp-admin-border-width-focus) var(--wp-admin-theme-color);
+
+				// Windows High Contrast mode will show this outline, but not the box-shadow.
+				outline: 3px solid transparent;
+
+				span:first-child {
+					color: var(--wp-admin-theme-color);
+				}
 			}
 		}
 	}


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->
Fixes https://github.com/WordPress/gutenberg/issues/42461

## What?
<!-- In a few words, what is the PR actually doing? -->
Click or keyboard event should never, ever, be used on non-interactive elements like a `<div>`. That would render a control that is not operable with a keyboard, as it's not focusable. The general issue has been split out to https://github.com/WordPress/gutenberg/issues/42540. This PR seeks to fix an instance where a `click` event is attached to a `<div>` element in the Add template modal.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
In the Add template modal, the choice between creating a template for all items or for a specific item is not operable with a keyboard.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
- Renders the choices as `Button` components.
- Darkens the buttons grey border, as the visual information (the border) required to identify user interface components must have a contrast ratio of at least 3:1. See https://www.w3.org/TR/WCAG21/#non-text-contrast
- Removes two unnecessary H5 headings that don't make much sense in the headings hierarchy, as they are places after the modal H1.

## Testing Instructions
- Go to the Site editor.
- Make sure you don't have a Category (or a Tag) template.
- Click Toggle navigation and then click Templates to open the Templates list.
- Click Add New and then click Category (or Tag).
- The Add template modal dialog opens.
- Check the two items at the bottom of the dialog are `<button>` elements.
- Check there are no significant visual changes.
- Check there's no H5 heading any longer.
- Check the hover and focus styles.


## Screenshots or screencast <!-- if applicable -->

<img width="515" alt="Screenshot 2022-07-25 at 12 50 52" src="https://user-images.githubusercontent.com/1682452/180760569-c77fbdae-80fc-4410-b67f-e50ccd87f323.png">

