### PR TITLE
Post Author block now includes option to link author archive

### DIFF
--- a/docs/reference-guides/core-blocks.md
+++ b/docs/reference-guides/core-blocks.md
@@ -456,7 +456,7 @@ Display post author details such as name, avatar, and bio. ([Source](https://git
 -	**Name:** core/post-author
 -	**Category:** theme
 -	**Supports:** color (background, gradients, link, text), spacing (margin, padding), typography (fontSize, lineHeight), ~~html~~
--	**Attributes:** avatarSize, byline, showAvatar, showBio, textAlign
+-	**Attributes:** avatarSize, byline, isLink, linkTarget, showAvatar, showBio, textAlign
 
 ## Post Author Biography
 

--- a/packages/block-library/src/post-author/block.json
+++ b/packages/block-library/src/post-author/block.json
@@ -27,6 +27,10 @@
 		"isLink": {
 			"type": "boolean",
 			"default": false
+		},
+		"linkTarget": {
+			"type": "string",
+			"default": "_self"
 		}
 	},
 	"usesContext": [ "postType", "postId", "queryId" ],

--- a/packages/block-library/src/post-author/block.json
+++ b/packages/block-library/src/post-author/block.json
@@ -24,8 +24,9 @@
 		"byline": {
 			"type": "string"
 		},
-		"linked": {
-			"type": "boolean"
+		"isLink": {
+			"type": "boolean",
+			"default": false
 		}
 	},
 	"usesContext": [ "postType", "postId", "queryId" ],

--- a/packages/block-library/src/post-author/block.json
+++ b/packages/block-library/src/post-author/block.json
@@ -23,6 +23,9 @@
 		},
 		"byline": {
 			"type": "string"
+		},
+		"linked": {
+			"type": "boolean"
 		}
 	},
 	"usesContext": [ "postType", "postId", "queryId" ],

--- a/packages/block-library/src/post-author/edit.js
+++ b/packages/block-library/src/post-author/edit.js
@@ -47,7 +47,8 @@ function PostAuthorEdit( {
 
 	const { editEntityRecord } = useDispatch( coreStore );
 
-	const { textAlign, showAvatar, showBio, byline, isLink } = attributes;
+	const { textAlign, showAvatar, showBio, byline, isLink, linkTarget } =
+		attributes;
 	const avatarSizes = [];
 	const authorName = authorDetails?.name || __( 'Post Author' );
 	if ( authorDetails ) {
@@ -124,6 +125,17 @@ function PostAuthorEdit( {
 						checked={ isLink }
 						onChange={ () => setAttributes( { isLink: ! isLink } ) }
 					/>
+					{ isLink && (
+						<ToggleControl
+							label={ __( 'Open in new tab' ) }
+							onChange={ ( value ) =>
+								setAttributes( {
+									linkTarget: value ? '_blank' : '_self',
+								} )
+							}
+							checked={ linkTarget === '_blank' }
+						/>
+					) }
 				</PanelBody>
 			</InspectorControls>
 
@@ -165,7 +177,12 @@ function PostAuthorEdit( {
 					) }
 					<p className="wp-block-post-author__name">
 						{ isLink ? (
-							<a href={ authorDetails?.link }>{ authorName }</a>
+							<a
+								href="#post-author-pseudo-link"
+								onClick={ ( event ) => event.preventDefault() }
+							>
+								{ authorName }
+							</a>
 						) : (
 							authorName
 						) }

--- a/packages/block-library/src/post-author/edit.js
+++ b/packages/block-library/src/post-author/edit.js
@@ -47,7 +47,7 @@ function PostAuthorEdit( {
 
 	const { editEntityRecord } = useDispatch( coreStore );
 
-	const { textAlign, showAvatar, showBio, byline, linked } = attributes;
+	const { textAlign, showAvatar, showBio, byline, isLink } = attributes;
 	const avatarSizes = [];
 	const authorName = authorDetails?.name || __( 'Post Author' );
 	if ( authorDetails ) {
@@ -121,8 +121,8 @@ function PostAuthorEdit( {
 					/>
 					<ToggleControl
 						label={ __( 'Link author name to author page' ) }
-						checked={ linked }
-						onChange={ () => setAttributes( { linked: ! linked } ) }
+						checked={ isLink }
+						onChange={ () => setAttributes( { isLink: ! isLink } ) }
 					/>
 				</PanelBody>
 			</InspectorControls>
@@ -164,7 +164,7 @@ function PostAuthorEdit( {
 						/>
 					) }
 					<p className="wp-block-post-author__name">
-						{ linked ? (
+						{ isLink ? (
 							<a href={ authorDetails?.link }>{ authorName }</a>
 						) : (
 							authorName

--- a/packages/block-library/src/post-author/edit.js
+++ b/packages/block-library/src/post-author/edit.js
@@ -47,9 +47,9 @@ function PostAuthorEdit( {
 
 	const { editEntityRecord } = useDispatch( coreStore );
 
-	const { textAlign, showAvatar, showBio, byline } = attributes;
-
+	const { textAlign, showAvatar, showBio, byline, linked } = attributes;
 	const avatarSizes = [];
+	const authorName = authorDetails?.name || __( 'Post Author' );
 	if ( authorDetails ) {
 		forEach( authorDetails.avatar_urls, ( url, size ) => {
 			avatarSizes.push( {
@@ -119,6 +119,11 @@ function PostAuthorEdit( {
 							setAttributes( { showBio: ! showBio } )
 						}
 					/>
+					<ToggleControl
+						label={ __( 'Link author name to author page' ) }
+						checked={ linked }
+						onChange={ () => setAttributes( { linked: ! linked } ) }
+					/>
 				</PanelBody>
 			</InspectorControls>
 
@@ -159,7 +164,11 @@ function PostAuthorEdit( {
 						/>
 					) }
 					<p className="wp-block-post-author__name">
-						{ authorDetails?.name || __( 'Post Author' ) }
+						{ linked ? (
+							<a href={ authorDetails?.link }>{ authorName }</a>
+						) : (
+							authorName
+						) }
 					</p>
 					{ showBio && (
 						<p className="wp-block-post-author__bio">

--- a/packages/block-library/src/post-author/index.php
+++ b/packages/block-library/src/post-author/index.php
@@ -29,9 +29,12 @@ function render_block_core_post_author( $attributes, $content, $block ) {
 		$attributes['avatarSize']
 	) : null;
 
-	$link        = ! empty( $attributes['isLink'] ) ? get_author_posts_url( $author_id ) : '';
-	$author_name = $link ? '<a href="' . $link . '">' . get_the_author_meta( 'display_name', $author_id ) . '</a>' : get_the_author_meta( 'display_name', $author_id );
-	
+	$link        = get_author_posts_url( $author_id );
+	$author_name = get_the_author_meta( 'display_name', $author_id );
+	if ( ! empty( $attributes['isLink'] && ! empty( $attributes['linkTarget'] ) ) ) {
+		$author_name = sprintf( '<a href="%1s" target="%2s">%2s</a>', esc_url( $link ), esc_attr( $attributes['linkTarget'] ), $author_name );
+	}
+
 	$byline  = ! empty( $attributes['byline'] ) ? $attributes['byline'] : false;
 	$classes = array_merge(
 		isset( $attributes['itemsJustification'] ) ? array( 'items-justified-' . $attributes['itemsJustification'] ) : array(),

--- a/packages/block-library/src/post-author/index.php
+++ b/packages/block-library/src/post-author/index.php
@@ -29,7 +29,7 @@ function render_block_core_post_author( $attributes, $content, $block ) {
 		$attributes['avatarSize']
 	) : null;
 
-	$link        = ! empty( $attributes['linked'] ) ? get_author_posts_url( $author_id ) : '';
+	$link        = ! empty( $attributes['isLink'] ) ? get_author_posts_url( $author_id ) : '';
 	$author_name = $link ? '<a href="' . $link . '">' . get_the_author_meta( 'display_name', $author_id ) . '</a>' : get_the_author_meta( 'display_name', $author_id );
 	
 	$byline  = ! empty( $attributes['byline'] ) ? $attributes['byline'] : false;

--- a/packages/block-library/src/post-author/index.php
+++ b/packages/block-library/src/post-author/index.php
@@ -29,6 +29,9 @@ function render_block_core_post_author( $attributes, $content, $block ) {
 		$attributes['avatarSize']
 	) : null;
 
+	$link        = ! empty( $attributes['linked'] ) ? get_author_posts_url( $author_id ) : '';
+	$author_name = $link ? '<a href="' . $link . '">' . get_the_author_meta( 'display_name', $author_id ) . '</a>' : get_the_author_meta( 'display_name', $author_id );
+	
 	$byline  = ! empty( $attributes['byline'] ) ? $attributes['byline'] : false;
 	$classes = array_merge(
 		isset( $attributes['itemsJustification'] ) ? array( 'items-justified-' . $attributes['itemsJustification'] ) : array(),
@@ -41,7 +44,7 @@ function render_block_core_post_author( $attributes, $content, $block ) {
 	( ! empty( $attributes['showAvatar'] ) ? '<div class="wp-block-post-author__avatar">' . $avatar . '</div>' : '' ) .
 	'<div class="wp-block-post-author__content">' .
 	( ! empty( $byline ) ? '<p class="wp-block-post-author__byline">' . wp_kses_post( $byline ) . '</p>' : '' ) .
-	'<p class="wp-block-post-author__name">' . get_the_author_meta( 'display_name', $author_id ) . '</p>' .
+	'<p class="wp-block-post-author__name">' . $author_name . '</p>' .
 	( ! empty( $attributes['showBio'] ) ? '<p class="wp-block-post-author__bio">' . get_the_author_meta( 'user_description', $author_id ) . '</p>' : '' ) .
 	'</div>' .
 	'</div>';

--- a/test/integration/fixtures/blocks/core__post-author.json
+++ b/test/integration/fixtures/blocks/core__post-author.json
@@ -4,7 +4,9 @@
 		"isValid": true,
 		"attributes": {
 			"avatarSize": 48,
-			"showAvatar": true
+			"showAvatar": true,
+			"isLink": false,
+			"linkTarget": "_self"
 		},
 		"innerBlocks": []
 	}


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->
Adds a toggle option to add a link to the Author's archive page.
## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
Resolves #41554
## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
If the `linked` attribute is `true`
## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->
1. Open the Site Editor
2. Select a template such as Home
3. Add `Post Author` block.
4. Toggle `Link author name to author page`

## Screenshots or screencast <!-- if applicable -->
![Screen Shot 2022-07-25 at 7 52 37 AM](https://user-images.githubusercontent.com/5949352/180771778-c09f42c4-ef80-4054-aa1c-fd2848f77d21.png)

