### PR TITLE
Fix jsx-a11y label-has-associated-control configuration.

### DIFF
--- a/packages/eslint-plugin/configs/jsx-a11y.js
+++ b/packages/eslint-plugin/configs/jsx-a11y.js
@@ -2,6 +2,12 @@ module.exports = {
 	extends: [ 'plugin:jsx-a11y/recommended' ],
 	plugins: [ 'jsx-a11y' ],
 	rules: {
+		'jsx-a11y/label-has-associated-control': [
+			'error',
+			{
+				assert: 'htmlFor',
+			},
+		],
 		'jsx-a11y/media-has-caption': 'off',
 		'jsx-a11y/no-noninteractive-tabindex': 'off',
 		'jsx-a11y/role-has-required-aria-props': 'off',


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->
Follow up to https://github.com/WordPress/gutenberg/pull/42654

## What?
<!-- In a few words, what is the PR actually doing? -->
https://github.com/WordPress/gutenberg/pull/42654 removed the deprecated jsx-a11y rule `label-has-for` in favor of the new rule `label-has-associated-control` but it also changed the rule configuration. This PR seeks to restore the original configuration.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
The configuration of the new rule `label-has-associated-control` is not equivalent to the one of the previous `label-has-for`, where it was required to associate labels to inputs by using for/id attributes. As established long time ago, we avoid wrapping labels because old assistive technology may not fully support that.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
Makes the rule explicitly validate only the association with for/id attributes by passing the `assert` option. From the rule docs:

https://github.com/jsx-eslint/eslint-plugin-jsx-a11y/blob/main/docs/rules/label-has-associated-control.md
> `assert` asserts that the label has htmlFor, a nested label, both or either. Available options: 'htmlFor', 'nesting', 'both', 'either'. (Note: the default is 'both').

## Testing Instructions
- Alter a component, for example: `packages/components/src/toggle-control/index.js`, and remove the `htmlFor` prop.
- Run `npm run lint-js` and see it errors.
- Alter again the component and make the `<label>` element wrap  the `<FormToggle>` component.
- Run `npm run lint-js` and see it errors.
- Remove the changes to the altered component.
- Run `npm run lint-js` and see it passes.

## Screenshots or screencast <!-- if applicable -->
