### PR TITLE
Editor: Fix typo in translation string

### DIFF
--- a/packages/editor/src/components/post-locked-modal/index.js
+++ b/packages/editor/src/components/post-locked-modal/index.js
@@ -197,7 +197,7 @@ export default function PostLockedModal() {
 								? sprintf(
 										/* translators: %s: user's display name */
 										__(
-											'<strong>%s</strong> now has editing control of this posts (<PreviewLink />). Don’t worry, your changes up to this moment have been saved.'
+											'<strong>%s</strong> now has editing control of this post (<PreviewLink />). Don’t worry, your changes up to this moment have been saved.'
 										),
 										userDisplayName
 								  )


### PR DESCRIPTION
## What?
Fix typo in translation string.

## Why?
The string mentions the plural "posts" when it should be referring the actual current "post" the user is loosing edit control on the editor page.

Fixes #42672


## Testing Instructions

1. Edit a post.
2. Let another user take over the post.
3. See the message on the first user post editor.
