### PR TITLE
Add: Absorb block UI on parent mechanism.

### DIFF
--- a/packages/block-editor/src/components/block-card/index.js
+++ b/packages/block-editor/src/components/block-card/index.js
@@ -8,7 +8,7 @@ import deprecated from '@wordpress/deprecated';
  */
 import BlockIcon from '../block-icon';
 
-function BlockCard( { title, icon, description, blockType } ) {
+function BlockCard( { title, icon, description, blockType, backButton } ) {
 	if ( blockType ) {
 		deprecated( '`blockType` property in `BlockCard component`', {
 			since: '5.7',
@@ -18,7 +18,7 @@ function BlockCard( { title, icon, description, blockType } ) {
 	}
 	return (
 		<div className="block-editor-block-card">
-			<BlockIcon icon={ icon } showColors />
+			{ backButton ? backButton : <BlockIcon icon={ icon } showColors /> }
 			<div className="block-editor-block-card__content">
 				<h2 className="block-editor-block-card__title">{ title }</h2>
 				<span className="block-editor-block-card__description">

--- a/packages/block-editor/src/components/block-inspector/index.js
+++ b/packages/block-editor/src/components/block-inspector/index.js
@@ -1,7 +1,7 @@
 /**
  * WordPress dependencies
  */
-import { __ } from '@wordpress/i18n';
+import { __, isRTL } from '@wordpress/i18n';
 import {
 	getBlockType,
 	getUnregisteredTypeHandlerName,
@@ -11,8 +11,18 @@ import {
 import {
 	PanelBody,
 	__experimentalUseSlot as useSlot,
+	__experimentalNavigatorProvider as NavigatorProvider,
+	__experimentalNavigatorScreen as NavigatorScreen,
+	__experimentalNavigatorButton as NavigatorButton,
+	__experimentalNavigatorBackButton as NavigatorBackButton,
+	FlexItem,
+	__experimentalHStack as HStack,
+	__experimentalVStack as VStack,
+	__experimentalUseNavigator as useNavigator,
 } from '@wordpress/components';
-import { useSelect } from '@wordpress/data';
+import { useSelect, useDispatch } from '@wordpress/data';
+import { useMemo, useCallback, useEffect, useRef } from '@wordpress/element';
+import { chevronRight, chevronLeft } from '@wordpress/icons';
 
 /**
  * Internal dependencies
@@ -29,38 +39,247 @@ import DefaultStylePicker from '../default-style-picker';
 import BlockVariationTransforms from '../block-variation-transforms';
 import useBlockDisplayInformation from '../use-block-display-information';
 import { store as blockEditorStore } from '../../store';
+import BlockIcon from '../block-icon';
+
+function useAbsorvingUI( clientId ) {
+	return useSelect( ( select ) => {
+		const { getBlockParents, getBlockAttributes } =
+			select( blockEditorStore );
+		if ( getBlockAttributes( clientId ).absorveDescendentUI ) {
+			return clientId;
+		}
+		const parentIds = getBlockParents( clientId, true );
+		for ( const parentId of parentIds ) {
+			if ( getBlockAttributes( parentId ).absorveDescendentUI ) {
+				return parentId;
+			}
+		}
+	} );
+}
+
+function useContentBlocks( blockTypes, block ) {
+	const contenBlocksObjectAux = useMemo( () => {
+		return blockTypes.reduce( ( result, blockType ) => {
+			if (
+				Object.entries( blockType.attributes ).some(
+					( [ , { __experimentalRole } ] ) =>
+						__experimentalRole === 'content'
+				)
+			) {
+				result[ blockType.name ] = true;
+			}
+			return result;
+		}, {} );
+	}, [ blockTypes ] );
+	const isContentBlock = useCallback(
+		( blockName ) => {
+			return !! contenBlocksObjectAux[ blockName ];
+		},
+		[ blockTypes ]
+	);
+	return useMemo( () => {
+		return getContentBlocks( [ block ], isContentBlock );
+	}, [ block, isContentBlock ] );
+}
+
+function getContentBlocks( blocks, isContentBlock ) {
+	const result = [];
+	for ( const block of blocks ) {
+		if ( isContentBlock( block.name ) ) {
+			result.push( block );
+		}
+		result.push( ...getContentBlocks( block.innerBlocks, isContentBlock ) );
+	}
+	return result;
+}
+
+function BlockInspectorNavigationEffects( { children } ) {
+	const { selectBlock } = useDispatch( blockEditorStore );
+	const { goTo, location } = useNavigator();
+	const lastLocationClientId = useRef();
+	const updatingSelectionTo = useRef();
+	const locationClientId = useMemo( () => {
+		if ( location.path.startsWith( '/block/' ) ) {
+			return location.path.substring( '/block/'.length );
+		}
+	}, [ location.path ] );
+	const selectedBlockId = useSelect( ( select ) => {
+		return select( blockEditorStore ).getSelectedBlockClientId();
+	} );
+	// When the location changes update the selection to match the new location.
+	useEffect( () => {
+		lastLocationClientId.current = locationClientId;
+		if ( locationClientId && selectedBlockId !== locationClientId ) {
+			updatingSelectionTo.current = locationClientId;
+			selectBlock( locationClientId );
+		}
+	}, [ locationClientId ] );
+	// When the selection changes update the location to root if no selection update to match location is in progress.
+	useEffect( () => {
+		if ( updatingSelectionTo.current ) {
+			updatingSelectionTo.current = undefined;
+		} else if ( lastLocationClientId.current ) {
+			goTo( '/' );
+		}
+	}, [ selectedBlockId ] );
+
+	return children;
+}
+
+function BlockNavigationButton( { blockTypes, block, selectedBlock } ) {
+	const blockType = blockTypes.find( ( { name } ) => name === block.name );
+	return (
+		<NavigatorButton
+			path={ `/block/${ block.clientId }` }
+			style={
+				selectedBlock.clientId === block.clientId
+					? { color: 'var(--wp-admin-theme-color)' }
+					: {}
+			}
+		>
+			<HStack justify="flex-start">
+				<BlockIcon icon={ blockType.icon } />
+				<FlexItem>{ blockType.title }</FlexItem>
+			</HStack>
+		</NavigatorButton>
+	);
+}
+
+function BlockNavigatorScreen( { block } ) {
+	return (
+		<NavigatorScreen path={ `/block/${ block.clientId }` }>
+			<BlockInspectorSingleBlock
+				clientId={ block.clientId }
+				blockName={ block.name }
+				backButton={
+					<NavigatorBackButton
+						style={
+							// TODO: This style override is also used in ToolsPanelHeader.
+							// It should be supported out-of-the-box by Button.
+							{ minWidth: 24, padding: 0 }
+						}
+						icon={ isRTL() ? chevronRight : chevronLeft }
+						isSmall
+						aria-label={ __( 'Navigate to the previous view' ) }
+					/>
+				}
+			/>
+		</NavigatorScreen>
+	);
+}
+
+function BlockInspectorAbsorvedBy( { absorvedBy } ) {
+	const { blockTypes, block, selectedBlock } = useSelect(
+		( select ) => {
+			return {
+				blockTypes: select( blocksStore ).getBlockTypes(),
+				block: select( blockEditorStore ).getBlock( absorvedBy ),
+				selectedBlock: select( blockEditorStore ).getSelectedBlock(),
+			};
+		},
+		[ absorvedBy ]
+	);
+	const blockInformation = useBlockDisplayInformation( absorvedBy );
+	const contentBlocks = useContentBlocks( blockTypes, block );
+	const showSelectedBlock =
+		absorvedBy !== selectedBlock.clientId &&
+		! contentBlocks.some(
+			( contentBlock ) => contentBlock.clientId === selectedBlock.clientId
+		);
+	return (
+		<div className="block-editor-block-inspector">
+			<NavigatorProvider initialPath="/">
+				<BlockInspectorNavigationEffects>
+					<NavigatorScreen path="/">
+						<BlockCard { ...blockInformation } />
+						<BlockVariationTransforms
+							blockClientId={ absorvedBy }
+						/>
+						<VStack
+							spacing={ 1 }
+							padding={ 4 }
+							className="block-editor-block-inspector__block-buttons-container"
+						>
+							<h2 className="block-editor-block-card__title">
+								{ __( 'Parent' ) }
+							</h2>
+							<BlockNavigationButton
+								selectedBlock={ selectedBlock }
+								block={ block }
+								blockTypes={ blockTypes }
+							/>
+							<h2 className="block-editor-block-card__title">
+								{ __( 'Content' ) }
+							</h2>
+							{ contentBlocks.map( ( contentBlock ) => (
+								<BlockNavigationButton
+									selectedBlock={ selectedBlock }
+									key={ contentBlock.clientId }
+									block={ contentBlock }
+									blockTypes={ blockTypes }
+								/>
+							) ) }
+							{ showSelectedBlock && (
+								<>
+									<h2 className="block-editor-block-card__title">
+										{ __( 'Selected block' ) }
+									</h2>
+									<BlockNavigationButton
+										selectedBlock={ selectedBlock }
+										block={ selectedBlock }
+										blockTypes={ blockTypes }
+									/>
+								</>
+							) }
+							;
+						</VStack>
+					</NavigatorScreen>
+					<BlockNavigatorScreen block={ block } />
+					{ contentBlocks.map( ( contentBlock ) => {
+						return (
+							<BlockNavigatorScreen
+								key={ contentBlock.clientId }
+								block={ contentBlock }
+							/>
+						);
+					} ) }
+					{ showSelectedBlock && (
+						<BlockNavigatorScreen block={ selectedBlock } />
+					) }
+				</BlockInspectorNavigationEffects>
+			</NavigatorProvider>
+		</div>
+	);
+}
 
 const BlockInspector = ( { showNoBlockSelectedMessage = true } ) => {
-	const {
-		count,
-		hasBlockStyles,
-		selectedBlockName,
-		selectedBlockClientId,
-		blockType,
-	} = useSelect( ( select ) => {
-		const {
-			getSelectedBlockClientId,
-			getSelectedBlockCount,
-			getBlockName,
-		} = select( blockEditorStore );
-		const { getBlockStyles } = select( blocksStore );
+	const { count, selectedBlockName, selectedBlockClientId, blockType } =
+		useSelect( ( select ) => {
+			const {
+				getSelectedBlockClientId,
+				getSelectedBlockCount,
+				getBlockName,
+			} = select( blockEditorStore );
+			const { getBlockStyles } = select( blocksStore );
 
-		const _selectedBlockClientId = getSelectedBlockClientId();
-		const _selectedBlockName =
-			_selectedBlockClientId && getBlockName( _selectedBlockClientId );
-		const _blockType =
-			_selectedBlockName && getBlockType( _selectedBlockName );
-		const blockStyles =
-			_selectedBlockName && getBlockStyles( _selectedBlockName );
+			const _selectedBlockClientId = getSelectedBlockClientId();
+			const _selectedBlockName =
+				_selectedBlockClientId &&
+				getBlockName( _selectedBlockClientId );
+			const _blockType =
+				_selectedBlockName && getBlockType( _selectedBlockName );
+			const blockStyles =
+				_selectedBlockName && getBlockStyles( _selectedBlockName );
 
-		return {
-			count: getSelectedBlockCount(),
-			selectedBlockClientId: _selectedBlockClientId,
-			selectedBlockName: _selectedBlockName,
-			blockType: _blockType,
-			hasBlockStyles: blockStyles && blockStyles.length > 0,
-		};
-	}, [] );
+			return {
+				count: getSelectedBlockCount(),
+				selectedBlockClientId: _selectedBlockClientId,
+				selectedBlockName: _selectedBlockName,
+				blockType: _blockType,
+				hasBlockStyles: blockStyles && blockStyles.length > 0,
+			};
+		}, [] );
+	const absorvedBy = useAbsorvingUI( selectedBlockClientId );
 
 	if ( count > 1 ) {
 		return (
@@ -109,24 +328,30 @@ const BlockInspector = ( { showNoBlockSelectedMessage = true } ) => {
 		}
 		return null;
 	}
+	if ( absorvedBy ) {
+		return <BlockInspectorAbsorvedBy absorvedBy={ absorvedBy } />;
+	}
 	return (
 		<BlockInspectorSingleBlock
 			clientId={ selectedBlockClientId }
 			blockName={ blockType.name }
-			hasBlockStyles={ hasBlockStyles }
 		/>
 	);
 };
 
-const BlockInspectorSingleBlock = ( {
-	clientId,
-	blockName,
-	hasBlockStyles,
-} ) => {
+const BlockInspectorSingleBlock = ( { clientId, blockName, backButton } ) => {
+	const hasBlockStyles = useSelect(
+		( select ) => {
+			const { getBlockStyles } = select( blocksStore );
+			const blockStyles = getBlockStyles( blockName );
+			return blockStyles && blockStyles.length > 0;
+		},
+		[ blockName ]
+	);
 	const blockInformation = useBlockDisplayInformation( clientId );
 	return (
 		<div className="block-editor-block-inspector">
-			<BlockCard { ...blockInformation } />
+			<BlockCard backButton={ backButton } { ...blockInformation } />
 			<BlockVariationTransforms blockClientId={ clientId } />
 			{ hasBlockStyles && (
 				<div>

--- a/packages/block-editor/src/components/block-inspector/style.scss
+++ b/packages/block-editor/src/components/block-inspector/style.scss
@@ -34,3 +34,17 @@
 	padding: ($grid-unit-20 * 2) $grid-unit-20;
 	text-align: center;
 }
+
+
+.block-editor-block-inspector__block-buttons-container {
+	border-top: $border-width solid $gray-200;
+	padding: $grid-unit-20;
+}
+
+.block-editor-block-inspector__block-type-type {
+	font-weight: 500;
+	&.block-editor-block-inspector__block-type-type {
+		line-height: $button-size-small;
+		margin: 0 0 $grid-unit-05;
+	}
+}

--- a/packages/block-editor/src/components/block-list/use-block-props/use-block-class-names.js
+++ b/packages/block-editor/src/components/block-list/use-block-props/use-block-class-names.js
@@ -34,6 +34,7 @@ export function useBlockClassNames( clientId ) {
 				hasSelectedInnerBlock,
 				isTyping,
 				__unstableIsFullySelected,
+				getBlockAttributes,
 			} = select( blockEditorStore );
 			const { outlineMode } = getSettings();
 			const isDragging = isBlockBeingDragged( clientId );
@@ -48,7 +49,10 @@ export function useBlockClassNames( clientId ) {
 			const isMultiSelected = isBlockMultiSelected( clientId );
 			return classnames( {
 				'is-selected': isSelected,
-				'is-highlighted': isBlockHighlighted( clientId ),
+				'is-highlighted':
+					isBlockHighlighted( clientId ) ||
+					( getBlockAttributes( clientId ).absorveDescendentUI &&
+						isAncestorOfSelectedBlock ),
 				'is-multi-selected': isMultiSelected,
 				'is-partially-selected':
 					isMultiSelected && ! __unstableIsFullySelected(),

--- a/packages/block-library/src/group/block.json
+++ b/packages/block-library/src/group/block.json
@@ -15,6 +15,10 @@
 		"templateLock": {
 			"type": [ "string", "boolean" ],
 			"enum": [ "all", "insert", false ]
+		},
+		"absorveDescendentUI": {
+			"type": "boolean",
+			"default": false
 		}
 	},
 	"supports": {


### PR DESCRIPTION
Part of https://github.com/WordPress/gutenberg/issues/39281.

This PR implements a mechanism where a block, e.g., pattern, group, etc., can specify it absorbs the UI of the descendants.

If a block is absorbing the UI of the children, there are some changes happening:
- The block absorbing the UI will always appear highlighted if the block or any descendent is selected, making it look like there is a single block. The toolbar still goes to the selected block to be consistent with what happens on images; the toolbar of the caption is close to the caption.
- The block inspector, instead of showing the information of the selected block, shows the list of blocks with content so the user can navigate very fast between the relevant blocks in a pattern with a complex structure. When clicking on a block, the block gets selected, and the inspector of that block appears with a button to navigate back easily. It is still possible to go to the inspector of a non-content block because the Ui always renders a button to open the selected block even if it is not content.


A block is a content block if any of its attributes have a content role no matter where on the hierarchy that block is. I guess if we have schemas for patterns, we can also rely on schema information, and we could also try to expand the roles we consider content, e.g., in some cases, an image could be content of a pattern. 

![image](https://user-images.githubusercontent.com/11271197/180845288-18de7741-abc8-4057-8888-e1702d7eeec0.png)


https://user-images.githubusercontent.com/11271197/180845572-00d19bc4-8bcc-4a84-995e-59c81fde1e9e.mp4


https://user-images.githubusercontent.com/11271197/180845603-4e6a8f50-01c3-4114-a641-9131d6def36d.mp4

cc: @mtias, @jameskoster, @mcsf Any feedback on this exploration? What do you think should be the next steps to explore, or what can we improve on this try?

## API

To mark a block is absorbing thethe  UI a block needs to define absorveDescendentUI attribute as true. For now only group supports this. The attribute needs to be added to the code editor. We don't yet have any UI for it.

This allows us to test the behavior in a simple way.
In the future, how we specify absorbing behavior is something we need to find out. Should it happen only for pattern blocks? Should it happen for all patterns or just some patterns?
I used the group because the pattern block for now still does not supports saved innerblocks, so the group is a good target to test this behavior.


## Testing Instructions
Paste the following block into the editor and interact with it:
```
<!-- wp:group {"absorveDescendentUI":true,"backgroundColor":"pale-cyan-blue","layout":{"type":"default"}} -->
<div class="wp-block-group has-pale-cyan-blue-background-color has-background"><!-- wp:heading {"style":{"typography":{"fontStyle":"normal","fontWeight":"700"}},"backgroundColor":"pale-pink","fontSize":"x-large"} -->
<h2 class="has-pale-pink-background-color has-background has-x-large-font-size" style="font-style:normal;font-weight:700">Heading</h2>
<!-- /wp:heading -->

<!-- wp:paragraph {"backgroundColor":"vivid-red","textColor":"secondary"} -->
<p class="has-secondary-color has-vivid-red-background-color has-text-color has-background">Paragraph</p>
<!-- /wp:paragraph -->

<!-- wp:image {"align":"center","width":239,"height":239,"sizeSlug":"large","style":{"border":{"width":"18px"}}} -->
<figure class="wp-block-image aligncenter size-large is-resized has-custom-border"><img src="https://s.w.org/style/images/about/WordPress-logotype-wmark.png" alt="" style="border-width:18px" width="239" height="239"/></figure>
<!-- /wp:image -->

<!-- wp:spacer {"height":"28px"} -->
<div style="height:28px" aria-hidden="true" class="wp-block-spacer"></div>
<!-- /wp:spacer -->

<!-- wp:group {"backgroundColor":"secondary"} -->
<div class="wp-block-group has-secondary-background-color has-background"><!-- wp:separator -->
<hr class="wp-block-separator has-alpha-channel-opacity"/>
<!-- /wp:separator -->

<!-- wp:spacer {"height":"55px"} -->
<div style="height:55px" aria-hidden="true" class="wp-block-spacer"></div>
<!-- /wp:spacer -->

<!-- wp:pullquote {"gradient":"blush-bordeaux"} -->
<figure class="wp-block-pullquote has-blush-bordeaux-gradient-background has-background"><blockquote><p>End quote inside another group</p></blockquote></figure>
<!-- /wp:pullquote --></div>
<!-- /wp:group --></div>
<!-- /wp:group -->

<!-- wp:paragraph -->
<p>dsfhfghjghjhg</p>
<!-- /wp:paragraph -->
```

Verify the behavior is the one described above and shown in the screenshots/videos.