### PR TITLE
Transforms: add group unwrap

### DIFF
--- a/packages/block-library/src/group/transforms.js
+++ b/packages/block-library/src/group/transforms.js
@@ -47,6 +47,13 @@ const transforms = {
 			},
 		},
 	],
+	to: [
+		{
+			type: 'block',
+			blocks: [ '*' ],
+			transform: ( attributes, innerBlocks ) => innerBlocks,
+		},
+	],
 };
 
 export default transforms;

--- a/packages/blocks/src/api/factory.js
+++ b/packages/blocks/src/api/factory.js
@@ -210,6 +210,7 @@ const isPossibleTransformForSource = ( transform, direction, blocks ) => {
 	// a Grouping block.
 	if (
 		! isMultiBlock &&
+		direction === 'from' &&
 		isContainerGroupBlock( sourceBlock.name ) &&
 		isContainerGroupBlock( transform.blockName )
 	) {
@@ -555,9 +556,14 @@ export function switchToBlockType( blocks, name ) {
 		return null;
 	}
 
-	const hasSwitchedBlock =
-		name === '*' ||
-		some( transformationResults, ( result ) => result.name === name );
+	if ( name === '*' ) {
+		return transformationResults;
+	}
+
+	const hasSwitchedBlock = some(
+		transformationResults,
+		( result ) => result.name === name
+	);
 
 	// Ensure that at least one block object returned by the transformation has
 	// the expected "destination" block type.

--- a/packages/blocks/src/api/factory.js
+++ b/packages/blocks/src/api/factory.js
@@ -555,6 +555,8 @@ export function switchToBlockType( blocks, name ) {
 		return null;
 	}
 
+	// When unwrapping blocks (`switchToBlockType( wrapperblocks, '*' )`), do
+	// not run filters on the unwrapped blocks. They shoud remain as they are.
 	if ( name === '*' ) {
 		return transformationResults;
 	}

--- a/packages/blocks/src/api/factory.js
+++ b/packages/blocks/src/api/factory.js
@@ -491,8 +491,7 @@ export function switchToBlockType( blocks, name ) {
 			transformationsTo,
 			( t ) =>
 				t.type === 'block' &&
-				( isWildcardBlockTransform( t ) ||
-					t.blocks.indexOf( name ) !== -1 ) &&
+				t.blocks.indexOf( name ) !== -1 &&
 				( ! isMultiBlock || t.isMultiBlock ) &&
 				maybeCheckTransformIsMatch( t, blocksArray )
 		) ||

--- a/packages/e2e-tests/specs/editor/blocks/group.test.js
+++ b/packages/e2e-tests/specs/editor/blocks/group.test.js
@@ -6,6 +6,8 @@ import {
 	searchForBlock,
 	getEditedPostContent,
 	createNewPost,
+	pressKeyWithModifier,
+	transformBlockTo,
 } from '@wordpress/e2e-test-utils';
 
 describe( 'Group', () => {
@@ -39,5 +41,38 @@ describe( 'Group', () => {
 		await page.keyboard.type( 'Group Block with a Paragraph' );
 
 		expect( await getEditedPostContent() ).toMatchSnapshot();
+	} );
+
+	it( 'can wrap in group and unwrap group', async () => {
+		await clickBlockAppender();
+		await page.keyboard.type( '1' );
+		await page.keyboard.press( 'Enter' );
+		await page.keyboard.type( '2' );
+		await pressKeyWithModifier( 'shift', 'ArrowUp' );
+		await transformBlockTo( 'Group' );
+
+		expect( await getEditedPostContent() ).toMatchInlineSnapshot( `
+			"<!-- wp:group -->
+			<div class=\\"wp-block-group\\"><!-- wp:paragraph -->
+			<p>1</p>
+			<!-- /wp:paragraph -->
+
+			<!-- wp:paragraph -->
+			<p>2</p>
+			<!-- /wp:paragraph --></div>
+			<!-- /wp:group -->"
+		` );
+
+		await transformBlockTo( 'Unwrap' );
+
+		expect( await getEditedPostContent() ).toMatchInlineSnapshot( `
+			"<!-- wp:paragraph -->
+			<p>1</p>
+			<!-- /wp:paragraph -->
+
+			<!-- wp:paragraph -->
+			<p>2</p>
+			<!-- /wp:paragraph -->"
+		` );
 	} );
 } );


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?

Since #25892 we now allow an unwrap transform (which is a "to" `*` transform). This means that the nested blocks will be unwrapped.

This is also useful for the group block. Currently there's no way to ungroup from the block switcher, although there's a dedicated button in the block settings menu.

This PR also fixes an issue with the Quote unwrap where backgound color etc. of the quote would be transferred to the children.

## Why?

It's easier to find the transform in the dedicated menu for transforms (the block switcher).

## How?

## Testing Instructions

Create a group blocks. Try unwrapping contents via the block switcher.

## Screenshots or screencast <!-- if applicable -->
