### PR TITLE
Context System: Don't explicitly set `undefined` value to `children`

### DIFF
--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Bug Fix
 
--   Allow rendering `Icon` via `as` prop ([#42686](https://github.com/WordPress/gutenberg/pull/42686)).
+-   Context System: Stop explicitly setting `undefined` to the `children` prop. This fixes a bug where `Icon` could not be correctly rendered via the `as` prop of a context-connected component ([#42686](https://github.com/WordPress/gutenberg/pull/42686)).
 -   `Popover`, `Dropdown`: Fix width when `expandOnMobile` is enabled ([#42635](https://github.com/WordPress/gutenberg/pull/42635/)).
 -   `CustomSelectControl`: Fix font size and hover/focus style inconsistencies with `SelectControl` ([#42460](https://github.com/WordPress/gutenberg/pull/42460/)).
 -   `AnglePickerControl`: Fix gap between elements in RTL mode ([#42534](https://github.com/WordPress/gutenberg/pull/42534)).

--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Bug Fix
 
+-   Allow rendering `Icon` via `as` prop ([#42686](https://github.com/WordPress/gutenberg/pull/42686)).
 -   `Popover`, `Dropdown`: Fix width when `expandOnMobile` is enabled ([#42635](https://github.com/WordPress/gutenberg/pull/42635/)).
 -   `CustomSelectControl`: Fix font size and hover/focus style inconsistencies with `SelectControl` ([#42460](https://github.com/WordPress/gutenberg/pull/42460/)).
 -   `AnglePickerControl`: Fix gap between elements in RTL mode ([#42534](https://github.com/WordPress/gutenberg/pull/42534)).

--- a/packages/components/src/ui/context/test/context-system-provider.js
+++ b/packages/components/src/ui/context/test/context-system-provider.js
@@ -148,15 +148,18 @@ describe( 'children', () => {
 			</View>
 		);
 		const ConnectedComponent = contextConnect( Component, 'Component' );
+		const NormalComponent = ( props ) => <div { ...props }>Inherent</div>;
 
 		render(
 			<ContextSystemProvider>
 				<ConnectedComponent />
 				<ConnectedComponent>Explicit children</ConnectedComponent>
+				<NormalComponent />
+				<NormalComponent>Explicit children</NormalComponent>
 			</ContextSystemProvider>
 		);
 
-		expect( screen.getAllByText( 'Inherent' ) ).toHaveLength( 2 );
+		expect( screen.getAllByText( 'Inherent' ) ).toHaveLength( 4 );
 	} );
 
 	describe( 'when connected component does a `cloneElement()`', () => {

--- a/packages/components/src/ui/context/use-context-system.js
+++ b/packages/components/src/ui/context/use-context-system.js
@@ -71,8 +71,13 @@ export function useContextSystem( props, namespace ) {
 		finalComponentProps[ key ] = overrideProps[ key ];
 	}
 
-	// @ts-ignore
-	finalComponentProps.children = rendered;
+	// Setting an `undefined` explicitly can cause unintended overwrites
+	// when a `cloneElement()` is involved.
+	if ( rendered !== undefined ) {
+		// @ts-ignore
+		finalComponentProps.children = rendered;
+	}
+
 	finalComponentProps.className = classes;
 
 	return finalComponentProps;


### PR DESCRIPTION
Fixes #42380 

## What?

Prevents the Context System from explicitly setting an `undefined` value to `children`.

## Why?

There was a problem where an `Icon` component could not be rendered via the `as` prop.

```jsx
import { __experimentalView as View } from '@wordpress/components';
import { Icon, positionCenter } from '@wordpress/icons';

// The `<path>` inside the SVG won't be rendered
export const Default = () => <View as={ Icon } icon={ positionCenter } />;
```

At first glance, this seemed like a general issue with context-connected components and the `as` prop. However, after going through a bunch of test cases, the problem was narrowed down to a relatively specific condition — when the underlying component uses a `cloneElement()` to create the output.

There are some subtle differences in how `undefined` children are treated depending on how they are undefined. This is usually not a problem, except for when a `cloneElement()` call overrides the original element's `children` with `props.children=undefined`:

https://github.com/WordPress/gutenberg/blob/a256669f31307d16de22784d74b106564b909c27/packages/icons/src/icon/index.js#L17-L23

## How?

Several test cases related to the `children` prop were added to the unit tests for the Context System. This helps us understand what the existing behavior is, and should give us sufficient confidence that the fix in this PR does not have unexpected side effects.

## Testing Instructions

In Storybook, try making a `<View as={ Icon }>` story like in the code snippet above. The icon SVG should render correctly after the fix in this PR.