### PR TITLE
Skip flaky navigation block permissions test

### DIFF
--- a/packages/e2e-tests/specs/editor/blocks/navigation.test.js
+++ b/packages/e2e-tests/specs/editor/blocks/navigation.test.js
@@ -1317,9 +1317,10 @@ Expected mock function not to be called but it was called with: ["POST", "http:/
 			await switchUserToAdmin();
 		} );
 
-		it( 'shows a warning if user does not have permission to create navigation menus', async () => {
+		it.skip( 'shows a warning if user does not have permission to create navigation menus', async () => {
 			const noticeText =
 				'You do not have permission to create Navigation Menus.';
+
 			// Switch to a Contributor role user - they should not have
 			// permission to update Navigations.
 			await loginUser( contributorUsername, contributorPassword );


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
See #37604

This test has been failing regularly. I haven't been able to understand why. It passes ok locally most of the time. As discussed on #37604, there seem to be two errors that happen regularly:
- The expected 403 error sometimes doesn't happen. Not sure why. Possibly there are times when the test completes before the error is logged.
- The admin user is logged in instead of a contributor, so the snackbar with the permissions message doesn't show.

Anyway, I've been finding this failing test a real drain on my productivity, and others probably are too, so I think it's best to skip it.