### PR TITLE
List v2: add `__experimentalEnableListBlockV2` flag for mobile

### DIFF
--- a/lib/experimental/block-editor-settings-mobile.php
+++ b/lib/experimental/block-editor-settings-mobile.php
@@ -29,6 +29,8 @@ function gutenberg_get_block_editor_settings_mobile( $settings ) {
 		// To tell mobile that the site uses quote v2 (inner blocks).
 		// See https://github.com/WordPress/gutenberg/pull/25892.
 		$settings['__experimentalEnableQuoteBlockV2'] = true;
+		// To be set to true when the web makes quote v2 (inner blocks) the default.
+		$settings['__experimentalEnableListBlockV2'] = gutenberg_is_list_v2_enabled();
 	}
 
 	return $settings;

--- a/lib/experimental/blocks.php
+++ b/lib/experimental/blocks.php
@@ -6,10 +6,20 @@
  */
 
 /**
+ * Returns whether list v2 is enabled by the user.
+ *
+ * @return boolean
+ */
+function gutenberg_is_list_v2_enabled() {
+	$gutenberg_experiments = get_option( 'gutenberg-experiments' );
+	return $gutenberg_experiments && array_key_exists( 'gutenberg-list-v2', $gutenberg_experiments );
+}
+
+/**
  * Sets a global JS variable used to trigger the availability of the experimental blocks.
  */
 function gutenberg_enable_experimental_blocks() {
-	if ( get_option( 'gutenberg-experiments' ) && array_key_exists( 'gutenberg-list-v2', get_option( 'gutenberg-experiments' ) ) ) {
+	if ( gutenberg_is_list_v2_enabled() ) {
 		wp_add_inline_script( 'wp-block-library', 'window.__experimentalEnableListBlockV2 = true', 'before' );
 	}
 }

--- a/lib/experimental/class-wp-rest-block-editor-settings-controller.php
+++ b/lib/experimental/class-wp-rest-block-editor-settings-controller.php
@@ -162,6 +162,12 @@ class WP_REST_Block_Editor_Settings_Controller extends WP_REST_Controller {
 					'context'     => array( 'mobile' ),
 				),
 
+				'__experimentalEnableListBlockV2'        => array(
+					'description' => __( 'Whether the V2 of the list block that uses inner blocks should be enabled.', 'gutenberg' ),
+					'type'        => 'boolean',
+					'context'     => array( 'mobile' ),
+				),
+
 				'alignWide'                              => array(
 					'description' => __( 'Enable/Disable Wide/Full Alignments.', 'gutenberg' ),
 					'type'        => 'boolean',


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?

Adds a flag for mobile to know if the site supports List v2.
See #40089, but for List v2 this time.
See #42624 for request.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

Mobile needs to know when to load the v1 and the v2 of the list block.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

By adding a `__experimentalEnableQuoteBlockV2` flag to the block editor settings endpoint.

## Testing Instructions

- Comment lines 22 and 23 [here](https://github.com/WordPress/gutenberg/blob/69e18aa2d3d12b6d2d5993b034e106328c2be9e6/lib/experimental/block-editor-settings-mobile.php#L22) so the code runs for any request, and not only for a 'mobile' request. 
- Go to "Gutenberg > Experiments" and enable the list v2 experiment.
- Load the post editor, open the devtools, and execute `wp.apiFetch({path: '/wp-block-editor/v1/settings/', method: 'GET'})`. The expected result is that the flag `__experimentalEnableListBlockV2` is present and is `true`.
- Go to "Gutenberg > Experiments" and disable the list v2 experiment.
- Load the post editor, open the devtools, and execute `wp.apiFetch({path: '/wp-block-editor/v1/settings/', method: 'GET'})`. The expected result is that the flag `__experimentalEnableListBlockV2 ` is present and is `false`.

## Screenshots or screencast <!-- if applicable -->
