### PR TITLE
List v2: remove quote transforms as removed by Quote v2

### DIFF
--- a/packages/block-library/src/list/transforms.js
+++ b/packages/block-library/src/list/transforms.js
@@ -163,23 +163,6 @@ const transforms = {
 		},
 		{
 			type: 'block',
-			blocks: [ 'core/pullquote' ],
-			transform: ( { values, anchor } ) => {
-				return createBlock( 'core/pullquote', {
-					value: toHTMLString( {
-						value: create( {
-							html: values,
-							multilineTag: 'li',
-							multilineWrapperTags: [ 'ul', 'ol' ],
-						} ),
-						multilineTag: 'p',
-					} ),
-					anchor,
-				} );
-			},
-		},
-		{
-			type: 'block',
 			blocks: [ 'core/table-of-contents' ],
 			transform: () => {
 				return createBlock( 'core/table-of-contents' );

--- a/packages/block-library/src/list/v2/transforms.js
+++ b/packages/block-library/src/list/v2/transforms.js
@@ -9,13 +9,8 @@ import { flatMap } from 'lodash';
 /**
  * WordPress dependencies
  */
-import { createBlock, switchToBlockType } from '@wordpress/blocks';
-import {
-	__UNSTABLE_LINE_SEPARATOR,
-	create,
-	split,
-	toHTMLString,
-} from '@wordpress/rich-text';
+import { createBlock } from '@wordpress/blocks';
+import { create, split, toHTMLString } from '@wordpress/rich-text';
 
 /**
  * Internal dependencies
@@ -83,26 +78,6 @@ const transforms = {
 				);
 			},
 		},
-		{
-			type: 'block',
-			blocks: [ 'core/quote', 'core/pullquote' ],
-			transform: ( { value, anchor } ) => {
-				return createBlock(
-					'core/list',
-					{
-						anchor,
-					},
-					split(
-						create( { html: value, multilineTag: 'p' } ),
-						__UNSTABLE_LINE_SEPARATOR
-					).map( ( result ) => {
-						return createBlock( 'core/list-item', {
-							content: toHTMLString( { value: result } ),
-						} );
-					} )
-				);
-			},
-		},
 		...[ '*', '-' ].map( ( prefix ) => ( {
 			type: 'prefix',
 			prefix,
@@ -144,19 +119,6 @@ const transforms = {
 					createBlock( block, {
 						content,
 					} )
-				);
-			},
-		} ) ),
-		...[ 'core/quote', 'core/pullquote' ].map( ( block ) => ( {
-			type: 'block',
-			blocks: [ block ],
-			transform: ( attributes, innerBlocks ) => {
-				return switchToBlockType(
-					switchToBlockType(
-						createBlock( 'core/list', attributes, innerBlocks ),
-						'core/paragraph'
-					),
-					block
 				);
 			},
 		} ) ),

--- a/packages/e2e-tests/specs/editor/various/block-switcher.test.js
+++ b/packages/e2e-tests/specs/editor/various/block-switcher.test.js
@@ -29,7 +29,7 @@ describe( 'Block Switcher', () => {
 				'Group',
 				'Paragraph',
 				'Heading',
-				'Pullquote',
+				'Quote',
 				'Columns',
 				'Table of Contents',
 			] )
@@ -55,7 +55,6 @@ describe( 'Block Switcher', () => {
 			expect.arrayContaining( [
 				'Group',
 				'Paragraph',
-				'Pullquote',
 				'Heading',
 				'Table of Contents',
 			] )


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?

Removes the Quote <=> List transforms as they no longer make sense.
See https://github.com/WordPress/gutenberg/pull/25892/files#r803141389.
These transforms were largely removed with Quote v2, but we took over List features form Quote v1 (before v2 was merged).

## Why?

* It doesn't make sense for a list to be converted to a pull quote, especially if we're thinking of changing pull quote to be a single inline Rich Text area. It seems we don't want to be changing pull quote to use nested blocks.
* The quote specific transforms were removed in #25892. There's no need for a dedicated transform because there's a wildcard transform that allows mixed blocks to be wrapped in a quote.

## How?

Just a removal.

## Testing Instructions

Lists can still be transformed to Quote (resulting in a quoted list) and the quoted list can still be unwrapped.

## Screenshots or screencast <!-- if applicable -->
