### PR TITLE
Avoid reliance on status constants when consuming useCreateNavigationMenu hook

### DIFF
--- a/packages/block-library/src/navigation/edit/index.js
+++ b/packages/block-library/src/navigation/edit/index.js
@@ -60,11 +60,7 @@ import useConvertClassicToBlockMenu, {
 	CLASSIC_MENU_CONVERSION_PENDING,
 	CLASSIC_MENU_CONVERSION_SUCCESS,
 } from './use-convert-classic-menu-to-block-menu';
-import useCreateNavigationMenu, {
-	CREATE_NAVIGATION_MENU_ERROR,
-	CREATE_NAVIGATION_MENU_PENDING,
-	CREATE_NAVIGATION_MENU_SUCCESS,
-} from './use-create-navigation-menu';
+import useCreateNavigationMenu from './use-create-navigation-menu';
 
 const EMPTY_ARRAY = [];
 
@@ -157,19 +153,19 @@ function Navigation( {
 		status: createNavigationMenuStatus,
 		error: createNavigationMenuError,
 		value: createNavigationMenuPost,
+		isPending: isCreatingNavigationMenu,
+		isSuccess: createNavigationMenuIsSuccess,
+		isError: createNavigationMenuIsError,
 	} = useCreateNavigationMenu( clientId );
-
-	const isCreatingNavigationMenu =
-		createNavigationMenuStatus === CREATE_NAVIGATION_MENU_PENDING;
 
 	useEffect( () => {
 		hideNavigationMenuCreateNotice();
 
-		if ( createNavigationMenuStatus === CREATE_NAVIGATION_MENU_PENDING ) {
+		if ( isCreatingNavigationMenu ) {
 			speak( __( `Creating Navigation Menu.` ) );
 		}
 
-		if ( createNavigationMenuStatus === CREATE_NAVIGATION_MENU_SUCCESS ) {
+		if ( createNavigationMenuIsSuccess ) {
 			setRef( createNavigationMenuPost.id );
 			selectBlock( clientId );
 
@@ -178,7 +174,7 @@ function Navigation( {
 			);
 		}
 
-		if ( createNavigationMenuStatus === CREATE_NAVIGATION_MENU_ERROR ) {
+		if ( createNavigationMenuIsError ) {
 			showNavigationMenuCreateNotice(
 				__( 'Failed to create Navigation Menu.' )
 			);

--- a/packages/block-library/src/navigation/edit/use-create-navigation-menu.js
+++ b/packages/block-library/src/navigation/edit/use-create-navigation-menu.js
@@ -88,7 +88,7 @@ export default function useCreateNavigationMenu( clientId ) {
 		error,
 		isIdle: status === CREATE_NAVIGATION_MENU_IDLE,
 		isPending: status === CREATE_NAVIGATION_MENU_PENDING,
-		didSucceed: status === CREATE_NAVIGATION_MENU_SUCCESS,
-		didError: status === CREATE_NAVIGATION_MENU_ERROR,
+		isSuccess: status === CREATE_NAVIGATION_MENU_SUCCESS,
+		isError: status === CREATE_NAVIGATION_MENU_ERROR,
 	};
 }

--- a/packages/block-library/src/navigation/edit/use-create-navigation-menu.js
+++ b/packages/block-library/src/navigation/edit/use-create-navigation-menu.js
@@ -86,5 +86,9 @@ export default function useCreateNavigationMenu( clientId ) {
 		status,
 		value,
 		error,
+		isIdle: status === CREATE_NAVIGATION_MENU_IDLE,
+		isPending: status === CREATE_NAVIGATION_MENU_PENDING,
+		didSucceed: status === CREATE_NAVIGATION_MENU_SUCCESS,
+		didError: status === CREATE_NAVIGATION_MENU_ERROR,
 	};
 }


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

This PR exports named vars from the hook to avoid consumers having to rely on string comparison with constants defined within the hook file.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

Reasons:

- reduces "noise" in the code.
- makes it easier to consume the hook without having to know about the internals

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

Exports named vars for the various statuses instead of asking developers to compare string values of the `status` with hard coded constants.

This:

```js
const {
    status: createNavigationMenuStatus,
} = useCreateNavigationMenu( clientId );


if (status === CREATE_NAVIGATION_MENU_SUCCESS) {
    
}
```

...becomes

```js
const {
  status: createNavigationMenuStatus,
  isSuccess: createNavigationMenuIsSuccess,
} = useCreateNavigationMenu(clientId);


if (createNavigationMenuIsSuccess) {
}
```

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->

## Screenshots or screencast <!-- if applicable -->
