### PR TITLE
Display post template selection for non-admin users

### DIFF
--- a/packages/edit-post/src/components/sidebar/post-template/index.js
+++ b/packages/edit-post/src/components/sidebar/post-template/index.js
@@ -27,7 +27,11 @@ export default function PostTemplate() {
 		const hasTemplates =
 			!! settings.availableTemplates &&
 			Object.keys( settings.availableTemplates ).length > 0;
-		if ( ! hasTemplates && ! settings.supportsTemplateMode ) {
+		if ( hasTemplates ) {
+			return true;
+		}
+
+		if ( ! settings.supportsTemplateMode ) {
 			return false;
 		}
 


### PR DESCRIPTION
## What?
Fixes #42696.

PR adjusts the `isVisible` check so non-admin users can select post/page templates.

## Why?
This is a regression. In the previous version of Gutenberg (and Classic Editor), non-admin users could select post templates.

## Testing Instructions
Using TT2 theme.

1. Create a user with an Editor role.
2. Open a post with the new user.
3. Confirm that the template selection component is displayed.
4. Confirm that there's no "Add template" action.
