### PR TITLE
Block Inserter: Try using callback ref for initial search focus

### DIFF
--- a/packages/block-editor/src/components/inserter/menu.js
+++ b/packages/block-editor/src/components/inserter/menu.js
@@ -174,11 +174,15 @@ function InserterMenu(
 	);
 
 	const searchRef = useRef();
-	useImperativeHandle( ref, () => ( {
-		focusSearch: () => {
-			searchRef.current.focus();
-		},
-	} ) );
+	useImperativeHandle(
+		ref,
+		() => ( {
+			focusSearch: () => {
+				searchRef.current.focus();
+			},
+		} ),
+		[]
+	);
 
 	return (
 		<div className="block-editor-inserter__menu">

--- a/packages/edit-post/src/components/secondary-sidebar/inserter-sidebar.js
+++ b/packages/edit-post/src/components/secondary-sidebar/inserter-sidebar.js
@@ -10,7 +10,7 @@ import {
 	__experimentalUseDialog as useDialog,
 } from '@wordpress/compose';
 import { __ } from '@wordpress/i18n';
-import { useEffect, useRef } from '@wordpress/element';
+import { useCallback } from '@wordpress/element';
 
 /**
  * Internal dependencies
@@ -34,11 +34,7 @@ export default function InserterSidebar() {
 		onClose: () => setIsInserterOpened( false ),
 		focusOnMount: null,
 	} );
-
-	const libraryRef = useRef();
-	useEffect( () => {
-		libraryRef.current.focusSearch();
-	}, [] );
+	const libraryRef = useCallback( ( node ) => node?.focusSearch(), [] );
 
 	return (
 		<div

--- a/packages/edit-site/src/components/secondary-sidebar/inserter-sidebar.js
+++ b/packages/edit-site/src/components/secondary-sidebar/inserter-sidebar.js
@@ -10,7 +10,7 @@ import {
 	__experimentalUseDialog as useDialog,
 } from '@wordpress/compose';
 import { __ } from '@wordpress/i18n';
-import { useEffect, useRef } from '@wordpress/element';
+import { useCallback } from '@wordpress/element';
 
 /**
  * Internal dependencies
@@ -30,11 +30,7 @@ export default function InserterSidebar() {
 		onClose: () => setIsInserterOpened( false ),
 		focusOnMount: null,
 	} );
-
-	const libraryRef = useRef();
-	useEffect( () => {
-		libraryRef.current.focusSearch();
-	}, [] );
+	const libraryRef = useCallback( ( node ) => node?.focusSearch(), [] );
 
 	return (
 		<div


### PR DESCRIPTION
## What?
A follow-up to #37793.

A small code quality improvement. Replace `useEffect/useRef` with callback ref.

## Why?
The callback ref will be called when the component mounts and unmounts; I think it makes it more suitable for this action.

## Testing Instructions
1. Open a Post or Page.
2. Open block inserter.
3. Focus should still be placed on Search input.

## Screenshots or screencast <!-- if applicable -->

https://user-images.githubusercontent.com/240569/181175741-4e680535-2f22-4c2a-9a1b-e5570424c749.mp4
