### PR TITLE
Inserter: Avoid warning when CRA is displayed

### DIFF
--- a/packages/block-directory/src/components/downloadable-blocks-panel/no-results.js
+++ b/packages/block-directory/src/components/downloadable-blocks-panel/no-results.js
@@ -17,14 +17,11 @@ function DownloadableBlocksNoResults() {
 			</div>
 			<div className="block-editor-inserter__tips">
 				<Tip>
-					<div>
-						<p>
-							{ __( 'Interested in creating your own block?' ) }
-						</p>
-						<ExternalLink href="https://developer.wordpress.org/block-editor/">
-							{ __( 'Get started here' ) }.
-						</ExternalLink>
-					</div>
+					{ __( 'Interested in creating your own block?' ) }
+					<br />
+					<ExternalLink href="https://developer.wordpress.org/block-editor/">
+						{ __( 'Get started here' ) }.
+					</ExternalLink>
 				</Tip>
 			</div>
 		</>


### PR DESCRIPTION
## What?
A follow-up for #41112

PR fixes warning when CRA tip is displayed.

```
Warning: validateDOMNesting(...): <p> cannot appear as a descendant of <p>.
```

## Why?
The `Tip` component wraps its children in a paragraph, so we're limited in what elements can be passed as children.

## How?
Removed wrapper `div` and paragraph and used `<br />` for linebreak.

## Testing Instructions
1. Open a Post or Page.
2. Open the block inserter.
3. Search for a block that is not registered or available in the plugin directory ("nonexisting" worked for me).
4. Confirm mentioned error doesn't appear in the DevTools console.

## Screenshot

![CleanShot 2022-07-27 at 10 43 31](https://user-images.githubusercontent.com/240569/181179523-0ecb2e55-b8c4-4819-bda9-40752f8a5f87.png)


