### PR TITLE
InputControl: Add optional Tooltip for inner input field

### DIFF
--- a/packages/components/src/input-control/index.tsx
+++ b/packages/components/src/input-control/index.tsx
@@ -15,7 +15,9 @@ import { useState, forwardRef } from '@wordpress/element';
  */
 import InputBase from './input-base';
 import InputField from './input-field';
-import type { InputControlProps } from './types';
+import Tooltip from '../tooltip';
+import { TooltipWrapper } from './styles/input-control-styles';
+import type { InputControlProps, WithTooltipProps } from './types';
 import { space } from '../ui/utils/space';
 import { useDraft } from './utils';
 
@@ -27,6 +29,18 @@ function useUniqueId( idProp?: string ) {
 
 	return idProp || id;
 }
+
+const WithTooltip = ( { showTooltip, text, children }: WithTooltipProps ) => {
+	if ( showTooltip && text ) {
+		return (
+			<Tooltip text={ text } position="top center">
+				<TooltipWrapper>{ children }</TooltipWrapper>
+			</Tooltip>
+		);
+	}
+
+	return <>{ children }</>;
+};
 
 export function UnforwardedInputControl(
 	{
@@ -44,6 +58,7 @@ export function UnforwardedInputControl(
 		onValidate = noop,
 		onKeyDown = noop,
 		prefix,
+		showTooltip = false,
 		size = 'default',
 		suffix,
 		value,
@@ -62,6 +77,8 @@ export function UnforwardedInputControl(
 		onChange,
 	} );
 
+	const tooltipText = typeof label === 'string' ? label : undefined;
+
 	return (
 		<InputBase
 			__next36pxDefaultSize={ __next36pxDefaultSize }
@@ -79,24 +96,26 @@ export function UnforwardedInputControl(
 			size={ size }
 			suffix={ suffix }
 		>
-			<InputField
-				{ ...props }
-				__next36pxDefaultSize={ __next36pxDefaultSize }
-				className="components-input-control__input"
-				disabled={ disabled }
-				id={ id }
-				isFocused={ isFocused }
-				isPressEnterToChange={ isPressEnterToChange }
-				onKeyDown={ onKeyDown }
-				onValidate={ onValidate }
-				paddingInlineStart={ prefix ? space( 2 ) : undefined }
-				paddingInlineEnd={ suffix ? space( 2 ) : undefined }
-				ref={ ref }
-				setIsFocused={ setIsFocused }
-				size={ size }
-				stateReducer={ stateReducer }
-				{ ...draftHookProps }
-			/>
+			<WithTooltip showTooltip={ showTooltip } text={ tooltipText }>
+				<InputField
+					{ ...props }
+					__next36pxDefaultSize={ __next36pxDefaultSize }
+					className="components-input-control__input"
+					disabled={ disabled }
+					id={ id }
+					isFocused={ isFocused }
+					isPressEnterToChange={ isPressEnterToChange }
+					onKeyDown={ onKeyDown }
+					onValidate={ onValidate }
+					paddingInlineStart={ prefix ? space( 2 ) : undefined }
+					paddingInlineEnd={ suffix ? space( 2 ) : undefined }
+					ref={ ref }
+					setIsFocused={ setIsFocused }
+					size={ size }
+					stateReducer={ stateReducer }
+					{ ...draftHookProps }
+				/>
+			</WithTooltip>
 		</InputBase>
 	);
 }

--- a/packages/components/src/input-control/index.tsx
+++ b/packages/components/src/input-control/index.tsx
@@ -32,6 +32,9 @@ function useUniqueId( idProp?: string ) {
 
 const WithTooltip = ( { showTooltip, text, children }: WithTooltipProps ) => {
 	if ( showTooltip && text ) {
+		// Children are wrapped in a simple `div` (`TooltipWrapper`) to prevent
+		// rendering issue with Tooltips.
+		// See: https://github.com/WordPress/gutenberg/pull/24966#issuecomment-685875026
 		return (
 			<Tooltip text={ text } position="top center">
 				<TooltipWrapper>{ children }</TooltipWrapper>

--- a/packages/components/src/input-control/index.tsx
+++ b/packages/components/src/input-control/index.tsx
@@ -59,6 +59,7 @@ export function UnforwardedInputControl(
 		onKeyDown = noop,
 		prefix,
 		showTooltip = false,
+		tooltipText: tooltipTextProp,
 		size = 'default',
 		suffix,
 		value,
@@ -77,7 +78,9 @@ export function UnforwardedInputControl(
 		onChange,
 	} );
 
-	const tooltipText = typeof label === 'string' ? label : undefined;
+	const tooltipText =
+		tooltipTextProp ||
+		( typeof label === 'string' ? ( label as string ) : undefined );
 
 	return (
 		<InputBase

--- a/packages/components/src/input-control/input-base.tsx
+++ b/packages/components/src/input-control/input-base.tsx
@@ -32,7 +32,7 @@ function useUniqueId( idProp?: string ) {
 	return idProp || id;
 }
 
-// Adapter to map props for the new ui/flex compopnent.
+// Adapter to map props for the new ui/flex component.
 function getUIFlexProps( labelPosition?: LabelPosition ) {
 	const props: { direction?: string; gap?: number; justify?: string } = {};
 	switch ( labelPosition ) {

--- a/packages/components/src/input-control/styles/input-control-styles.tsx
+++ b/packages/components/src/input-control/styles/input-control-styles.tsx
@@ -105,6 +105,10 @@ export const Container = styled.div< ContainerProps >`
 	${ containerWidthStyles }
 `;
 
+export const TooltipWrapper = styled.div`
+	width: 100%;
+`;
+
 type InputProps = {
 	__next36pxDefaultSize?: boolean;
 	disabled?: boolean;

--- a/packages/components/src/input-control/types.ts
+++ b/packages/components/src/input-control/types.ts
@@ -73,13 +73,13 @@ export type WithTooltipProps = {
 	 */
 	children: ReactNode;
 	/**
-	 * Whether or not to wrap children in a Tooltip component.
+	 * Whether or not to wrap children in a tooltip.
 	 *
 	 * @default false
 	 */
 	showTooltip?: boolean;
 	/**
-	 * Text to display within the Tooltip component.
+	 * Text to display within the tooltip.
 	 */
 	text?: string;
 };
@@ -123,7 +123,7 @@ export interface InputFieldProps extends BaseProps {
 	paddingInlineEnd?: CSSProperties[ 'paddingInlineEnd' ];
 	setIsFocused: ( isFocused: boolean ) => void;
 	/**
-	 * Whether to wrap input field in a Tooltip component.
+	 * Whether to wrap input field in a tooltip.
 	 *
 	 * @default false
 	 */

--- a/packages/components/src/input-control/types.ts
+++ b/packages/components/src/input-control/types.ts
@@ -74,8 +74,6 @@ export type WithTooltipProps = {
 	children: ReactNode;
 	/**
 	 * Whether or not to wrap children in a tooltip.
-	 *
-	 * @default false
 	 */
 	showTooltip?: boolean;
 	/**

--- a/packages/components/src/input-control/types.ts
+++ b/packages/components/src/input-control/types.ts
@@ -67,6 +67,23 @@ export type InputChangeCallback<
 	P = {}
 > = ( nextValue: string | undefined, extra: { event: E } & P ) => void;
 
+export type WithTooltipProps = {
+	/**
+	 * React children.
+	 */
+	children: ReactNode;
+	/**
+	 * Whether or not to wrap children in a Tooltip component.
+	 *
+	 * @default false
+	 */
+	showTooltip?: boolean;
+	/**
+	 * Text to display within the Tooltip component.
+	 */
+	text?: string;
+};
+
 export interface InputFieldProps extends BaseProps {
 	/**
 	 * Determines the drag axis.
@@ -105,6 +122,12 @@ export interface InputFieldProps extends BaseProps {
 	paddingInlineStart?: CSSProperties[ 'paddingInlineStart' ];
 	paddingInlineEnd?: CSSProperties[ 'paddingInlineEnd' ];
 	setIsFocused: ( isFocused: boolean ) => void;
+	/**
+	 * Whether to wrap input field in a Tooltip component.
+	 *
+	 * @default false
+	 */
+	showTooltip?: boolean;
 	stateReducer?: StateReducer;
 	/**
 	 * The current value of the input.

--- a/packages/components/src/input-control/types.ts
+++ b/packages/components/src/input-control/types.ts
@@ -130,6 +130,11 @@ export interface InputFieldProps extends BaseProps {
 	showTooltip?: boolean;
 	stateReducer?: StateReducer;
 	/**
+	 * Custom text to display when tooltips are enabled. If not provided enabled
+	 * tooltips will fallback to using the label value.
+	 */
+	tooltipText?: string;
+	/**
 	 * The current value of the input.
 	 */
 	value?: string;

--- a/packages/components/src/unit-control/test/__snapshots__/index.tsx.snap
+++ b/packages/components/src/unit-control/test/__snapshots__/index.tsx.snap
@@ -10,15 +10,15 @@ Snapshot Diff:
     class="components-unit-control-wrapper css-zi0c81-Root e1bagdl33"
   >
     <div
--     class="components-flex components-input-control components-number-control components-unit-control e1bagdl32 ep48uk90 em5sgkm7 css-1njfmeu-View-Flex-sx-Base-sx-Items-ItemsColumn-Root-rootLabelPositionStyles-Input-ValueInput-arrowStyles em57xhy0"
-+     class="components-flex components-input-control components-number-control components-unit-control hello e1bagdl32 ep48uk90 em5sgkm7 css-1njfmeu-View-Flex-sx-Base-sx-Items-ItemsColumn-Root-rootLabelPositionStyles-Input-ValueInput-arrowStyles em57xhy0"
+-     class="components-flex components-input-control components-number-control components-unit-control e1bagdl32 ep48uk90 em5sgkm8 css-1njfmeu-View-Flex-sx-Base-sx-Items-ItemsColumn-Root-rootLabelPositionStyles-Input-ValueInput-arrowStyles em57xhy0"
++     class="components-flex components-input-control components-number-control components-unit-control hello e1bagdl32 ep48uk90 em5sgkm8 css-1njfmeu-View-Flex-sx-Base-sx-Items-ItemsColumn-Root-rootLabelPositionStyles-Input-ValueInput-arrowStyles em57xhy0"
       data-wp-c16t="true"
       data-wp-component="Flex"
     >
       <div
         class="components-flex-item em5sgkm3 css-1fmchc6-View-Item-sx-Base-LabelWrapper em57xhy0"
 @@ -15,11 +15,11 @@
-        class="components-input-control__container css-1sy20aj-Container-containerDisabledStyles-containerMarginStyles-containerWidthStyles em5sgkm6"
+        class="components-input-control__container css-1sy20aj-Container-containerDisabledStyles-containerMarginStyles-containerWidthStyles em5sgkm7"
       >
         <input
           autocomplete="off"


### PR DESCRIPTION
Related: 
- https://github.com/WordPress/gutenberg/issues/42630
- https://github.com/WordPress/gutenberg/pull/42661

## What?

Adds the ability to provide a tooltip for the `InputControl`'s inner input field.

## Why?

This helps avoid the possibility of nested tooltips when the `InputControl` has an interactive prefix or suffix which might have its own tooltip. 

## How?

- Adds new `showTooltip` & `tooltipText` props to the `InputControl` API
- If `showTooltip` is true along with `tooltipText` or a string `label`, the inner `InputField` is wrapped in its own `Tooltip`
- If rendering a `Tooltip` the `InputField` is wrapped in a `div` to [avoid issues](https://github.com/WordPress/gutenberg/pull/24966#issuecomment-685875026)

## Testing Instructions
1. Open up Storybook
2. Confirm the `InputControl` component displays the same on trunk as this PR (with or without `showTooltip` enabled)
3. Enable `showTooltip` in the story controls and confirm the tooltip displays both on hover and via keyboard focus
4. Provide a custom `tooltipText` value via story controls and confirm that text is used in the tooltip.
5. Take a look at the other Storybook examples for `InputControl` and confirm Tooltips
6. Check higher-level components that leverage `InputControl` still function/look correct e.g. `UnitControl` etc.

## Screenshots or screencast <!-- if applicable -->


https://user-images.githubusercontent.com/60436221/182095163-21214525-3654-4ab2-8d45-9e0799c601b6.mp4

<details>
<summary>Original demo without custom tooltip text support</summary>

<video src="https://user-images.githubusercontent.com/60436221/181202708-abe690a4-f160-4a96-b3d7-1dabec8d6b57.mp4" />

</details>


