### PR TITLE
BoxControl: Export `applyValueToSides` util function

### DIFF
--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -18,6 +18,7 @@
 -   `ResizableBox`: Make tooltip background match `Tooltip` component's ([#42800](https://github.com/WordPress/gutenberg/pull/42800)).
 -   `UnitControl`: Update unit dropdown design for the large size variant ([#42000](https://github.com/WordPress/gutenberg/pull/42000)).
 -   `BaseControl`: Add `box-sizing` reset style ([#42889](https://github.com/WordPress/gutenberg/pull/42889)).
+-   `BoxControl`: Export `applyValueToSides` util function. ([#42733](https://github.com/WordPress/gutenberg/pull/42733/)).
 
 ### Internal
 

--- a/packages/components/src/box-control/all-input-control.js
+++ b/packages/components/src/box-control/all-input-control.js
@@ -3,8 +3,8 @@
  */
 import UnitControl from './unit-control';
 import {
-	ALL_SIDES,
 	LABELS,
+	applyValueToSides,
 	getAllValue,
 	isValuesMixed,
 	isValuesDefined,
@@ -32,34 +32,10 @@ export default function AllInputControl( {
 		onFocus( event, { side: 'all' } );
 	};
 
-	// Applies a value to an object representing top, right, bottom and left
-	// sides while taking into account any custom side configuration.
-	const applyValueToSides = ( currentValues, newValue ) => {
-		const newValues = { ...currentValues };
-
-		if ( sides?.length ) {
-			sides.forEach( ( side ) => {
-				if ( side === 'vertical' ) {
-					newValues.top = newValue;
-					newValues.bottom = newValue;
-				} else if ( side === 'horizontal' ) {
-					newValues.left = newValue;
-					newValues.right = newValue;
-				} else {
-					newValues[ side ] = newValue;
-				}
-			} );
-		} else {
-			ALL_SIDES.forEach( ( side ) => ( newValues[ side ] = newValue ) );
-		}
-
-		return newValues;
-	};
-
 	const handleOnChange = ( next ) => {
 		const isNumeric = ! isNaN( parseFloat( next ) );
 		const nextValue = isNumeric ? next : undefined;
-		const nextValues = applyValueToSides( values, nextValue );
+		const nextValues = applyValueToSides( values, nextValue, sides );
 
 		onChange( nextValues );
 	};
@@ -67,7 +43,7 @@ export default function AllInputControl( {
 	// Set selected unit so it can be used as fallback by unlinked controls
 	// when individual sides do not have a value containing a unit.
 	const handleOnUnitChange = ( unit ) => {
-		const newUnits = applyValueToSides( selectedUnits, unit );
+		const newUnits = applyValueToSides( selectedUnits, unit, sides );
 		setSelectedUnits( newUnits );
 	};
 

--- a/packages/components/src/box-control/index.js
+++ b/packages/components/src/box-control/index.js
@@ -173,3 +173,5 @@ export default function BoxControl( {
 		</Root>
 	);
 }
+
+export { applyValueToSides } from './utils';

--- a/packages/components/src/box-control/utils.js
+++ b/packages/components/src/box-control/utils.js
@@ -194,3 +194,35 @@ export function normalizeSides( sides ) {
 
 	return filteredSides;
 }
+
+/**
+ * Applies a value to an object representing top, right, bottom and left sides
+ * while taking into account any custom side configuration.
+ *
+ * @param {Object}        currentValues The current values for each side.
+ * @param {string|number} newValue      The value to apply to the sides object.
+ * @param {string[]}      sides         Array defining valid sides.
+ *
+ * @return {Object} Object containing the updated values for each side.
+ */
+export function applyValueToSides( currentValues, newValue, sides ) {
+	const newValues = { ...currentValues };
+
+	if ( sides?.length ) {
+		sides.forEach( ( side ) => {
+			if ( side === 'vertical' ) {
+				newValues.top = newValue;
+				newValues.bottom = newValue;
+			} else if ( side === 'horizontal' ) {
+				newValues.left = newValue;
+				newValues.right = newValue;
+			} else {
+				newValues[ side ] = newValue;
+			}
+		} );
+	} else {
+		ALL_SIDES.forEach( ( side ) => ( newValues[ side ] = newValue ) );
+	}
+
+	return newValues;
+}

--- a/packages/components/src/index.js
+++ b/packages/components/src/index.js
@@ -30,7 +30,10 @@ export {
 	isEmptyBorder as __experimentalIsEmptyBorder,
 } from './border-box-control';
 export { BorderControl as __experimentalBorderControl } from './border-control';
-export { default as __experimentalBoxControl } from './box-control';
+export {
+	default as __experimentalBoxControl,
+	applyValueToSides as __experimentalApplyValueToSides,
+} from './box-control';
 export { default as Button } from './button';
 export { default as ButtonGroup } from './button-group';
 export {


### PR DESCRIPTION
Related: 
- https://github.com/WordPress/gutenberg/pull/42173

## What?

Makes the `applyValueToSides` function within the `BoxControl` a util which can then be exported via the components package.

## Why?

The new spacing sizes control being created within the block-editor could avoid code duplication if this was available. 

**Note: The spacing sizes control is very much a bespoke solution to the needs of the editor and as such, wasn't deemed generic enough for the components package itself.**

## How?

- Moves the `applyValueToSides` function out of the `BoxControl`
- Updates the function to accept a new arg `sides`
- Exports the util function from the components package

## Testing Instructions

1. Ensure the `BoxControl`'s unit tests still pass
2. Fire up Storybook and ensure the `BoxControl` is still working correctly
3. Double check the `BoxControl` behaves in the editor.
