### PR TITLE
Use page list instead of placeholder as fallback

### DIFF
--- a/packages/block-library/src/navigation/edit/index.js
+++ b/packages/block-library/src/navigation/edit/index.js
@@ -283,7 +283,7 @@ function Navigation( {
 	// "loading" state:
 	// - there is a menu creation process in progress.
 	// - there is a classic menu conversion process in progress.
-	// OR
+	// OR:
 	// - there is a ref attribute pointing to a Navigation Post
 	// - the Navigation Post isn't available (hasn't resolved) yet.
 	const isLoading =

--- a/packages/block-library/src/navigation/edit/index.js
+++ b/packages/block-library/src/navigation/edit/index.js
@@ -269,9 +269,9 @@ function Navigation( {
 	if ( isPlaceholder && ! ref ) {
 		/**
 		 *  this fallback only displays (both in editor and on front)
-		 *  the list of pages block if not menu is available
-		 *  we don't want the fallback to request a save
-		 *  nor to be undoable, hence we mark it non persistent
+		 *  the list of pages block if no menu is available as a fallback.
+		 *  We don't want the fallback to request a save,
+		 *  nor to be undoable, hence we mark it non persistent.
 		 */
 		__unstableMarkNextChangeAsNotPersistent();
 		replaceInnerBlocks( clientId, [ createBlock( 'core/page-list' ) ] );

--- a/packages/block-library/src/navigation/edit/index.js
+++ b/packages/block-library/src/navigation/edit/index.js
@@ -209,7 +209,7 @@ function Navigation( {
 	// - the user is creating a new menu.
 	// - there are no menus to choose from.
 	// This attempts to pick the first menu if there is a single Navigation Post. If more
-	// than 1 exists then no attempt to automatically pick a menu is made.
+	// than 1 exists then use the most recent.
 	// The aim is for the block to "just work" from a user perspective using existing data.
 	useEffect( () => {
 		if (

--- a/packages/block-library/src/navigation/edit/index.js
+++ b/packages/block-library/src/navigation/edit/index.js
@@ -605,12 +605,15 @@ function Navigation( {
 								handleUpdateMenu( menuId );
 								setShouldFocusNavigationSelector( true );
 							} }
-							onSelectClassicMenu={ ( classicMenu ) => {
-								convertClassicMenu(
+							onSelectClassicMenu={ async ( classicMenu ) => {
+								const navMenu = await convertClassicMenu(
 									classicMenu.id,
 									classicMenu.name
 								);
-								setShouldFocusNavigationSelector( true );
+								if ( navMenu ) {
+									handleUpdateMenu( navMenu.id );
+									setShouldFocusNavigationSelector( true );
+								}
 							} }
 							onCreateNew={ () => createNavigationMenu( '', [] ) }
 							/* translators: %s: The name of a menu. */
@@ -669,12 +672,15 @@ function Navigation( {
 								handleUpdateMenu( menuId );
 								setShouldFocusNavigationSelector( true );
 							} }
-							onSelectClassicMenu={ ( classicMenu ) => {
-								convertClassicMenu(
+							onSelectClassicMenu={ async ( classicMenu ) => {
+								const navMenu = await convertClassicMenu(
 									classicMenu.id,
 									classicMenu.name
 								);
-								setShouldFocusNavigationSelector( true );
+								if ( navMenu ) {
+									handleUpdateMenu( navMenu.id );
+									setShouldFocusNavigationSelector( true );
+								}
 							} }
 							onCreateNew={ () => createNavigationMenu( '', [] ) }
 							/* translators: %s: The name of a menu. */

--- a/packages/block-library/src/navigation/edit/index.js
+++ b/packages/block-library/src/navigation/edit/index.js
@@ -295,38 +295,30 @@ function Navigation( {
 	const textDecoration = attributes.style?.typography?.textDecoration;
 
 	const hasBlockOverlay = useBlockOverlayActive( clientId );
-	const blockProps = useBlockProps(
-		{
-			ref: navRef,
-			className: classnames( className, {
-				'items-justified-right': justifyContent === 'right',
-				'items-justified-space-between':
-					justifyContent === 'space-between',
-				'items-justified-left': justifyContent === 'left',
-				'items-justified-center': justifyContent === 'center',
-				'is-vertical': orientation === 'vertical',
-				'no-wrap': flexWrap === 'nowrap',
-				'is-responsive': 'never' !== overlayMenu,
-				'has-text-color': !! textColor.color || !! textColor?.class,
-				[ getColorClassName( 'color', textColor?.slug ) ]:
-					!! textColor?.slug,
-				'has-background':
-					!! backgroundColor.color || backgroundColor.class,
-				[ getColorClassName(
-					'background-color',
-					backgroundColor?.slug
-				) ]: !! backgroundColor?.slug,
-				[ `has-text-decoration-${ textDecoration }` ]: textDecoration,
-				'block-editor-block-content-overlay': hasBlockOverlay,
-			} ),
-			style: {
-				color: ! textColor?.slug && textColor?.color,
-				backgroundColor:
-					! backgroundColor?.slug && backgroundColor?.color,
-			},
+	const blockProps = useBlockProps( {
+		ref: navRef,
+		className: classnames( className, {
+			'items-justified-right': justifyContent === 'right',
+			'items-justified-space-between': justifyContent === 'space-between',
+			'items-justified-left': justifyContent === 'left',
+			'items-justified-center': justifyContent === 'center',
+			'is-vertical': orientation === 'vertical',
+			'no-wrap': flexWrap === 'nowrap',
+			'is-responsive': 'never' !== overlayMenu,
+			'has-text-color': !! textColor.color || !! textColor?.class,
+			[ getColorClassName( 'color', textColor?.slug ) ]:
+				!! textColor?.slug,
+			'has-background': !! backgroundColor.color || backgroundColor.class,
+			[ getColorClassName( 'background-color', backgroundColor?.slug ) ]:
+				!! backgroundColor?.slug,
+			[ `has-text-decoration-${ textDecoration }` ]: textDecoration,
+			'block-editor-block-content-overlay': hasBlockOverlay,
+		} ),
+		style: {
+			color: ! textColor?.slug && textColor?.color,
+			backgroundColor: ! backgroundColor?.slug && backgroundColor?.color,
 		},
-		{ __unstableIsDisabled: hasBlockOverlay }
-	);
+	} );
 
 	// Turn on contrast checker for web only since it's not supported on mobile yet.
 	const enableContrastChecking = Platform.OS === 'web';

--- a/packages/block-library/src/navigation/edit/index.js
+++ b/packages/block-library/src/navigation/edit/index.js
@@ -614,7 +614,10 @@ function Navigation( {
 								setShouldFocusNavigationSelector( true );
 							} }
 							onSelectClassicMenu={ ( classicMenu ) => {
-								convert( classicMenu.id, classicMenu.name );
+								convertClassicMenu(
+									classicMenu.id,
+									classicMenu.name
+								);
 								setShouldFocusNavigationSelector( true );
 							} }
 							onCreateNew={ () => createNavigationMenu( '', [] ) }
@@ -675,7 +678,10 @@ function Navigation( {
 								setShouldFocusNavigationSelector( true );
 							} }
 							onSelectClassicMenu={ ( classicMenu ) => {
-								convert( classicMenu.id, classicMenu.name );
+								convertClassicMenu(
+									classicMenu.id,
+									classicMenu.name
+								);
 								setShouldFocusNavigationSelector( true );
 							} }
 							onCreateNew={ () => createNavigationMenu( '', [] ) }

--- a/packages/block-library/src/navigation/edit/unsaved-inner-blocks.js
+++ b/packages/block-library/src/navigation/edit/unsaved-inner-blocks.js
@@ -63,6 +63,7 @@ export default function UnsavedInnerBlocks( {
 	// from the original inner blocks from the post content then the
 	// user has made changes to the inner blocks. At this point the inner
 	// blocks can be considered "dirty".
+	// We also make sure the current innerBlocks had a chance to be set.
 	const innerBlocksAreDirty =
 		!! originalBlocks.current && blocks !== originalBlocks.current;
 

--- a/packages/block-library/src/navigation/edit/unsaved-inner-blocks.js
+++ b/packages/block-library/src/navigation/edit/unsaved-inner-blocks.js
@@ -63,7 +63,8 @@ export default function UnsavedInnerBlocks( {
 	// from the original inner blocks from the post content then the
 	// user has made changes to the inner blocks. At this point the inner
 	// blocks can be considered "dirty".
-	const innerBlocksAreDirty = blocks !== originalBlocks.current;
+	const innerBlocksAreDirty =
+		!! originalBlocks.current && blocks !== originalBlocks.current;
 
 	const shouldDirectInsert = useMemo(
 		() =>

--- a/packages/block-library/src/navigation/editor.scss
+++ b/packages/block-library/src/navigation/editor.scss
@@ -520,6 +520,7 @@ body.editor-styles-wrapper
 // so focus is applied naturally on the block container.
 // It's important the right container has focus, otherwise you can't press
 // "Delete" to remove the block.
+.wp-block-navigation__responsive-container,
 .wp-block-navigation__responsive-close {
 	@include break-small() {
 		pointer-events: none;

--- a/packages/block-library/src/navigation/index.php
+++ b/packages/block-library/src/navigation/index.php
@@ -255,7 +255,7 @@ function block_core_navigation_render_submenu_icon() {
  * @return WP_Post|null the first non-empty Navigation or null.
  */
 function block_core_navigation_get_most_recently_published_navigation() {
-	// We default to the most recently created
+	// We default to the most recently created menu.
 	$parsed_args = array(
 		'post_type'      => 'wp_navigation',
 		'no_found_rows'  => true,
@@ -266,7 +266,7 @@ function block_core_navigation_get_most_recently_published_navigation() {
 	);
 
 	$navigation_post = new WP_Query( $parsed_args );
-	if( count( $navigation_post->posts )  > 0 ) {
+	if ( count( $navigation_post->posts ) > 0 ) {
 		return $navigation_post->posts[0];
 	}
 

--- a/packages/block-library/src/navigation/index.php
+++ b/packages/block-library/src/navigation/index.php
@@ -262,7 +262,7 @@ function block_core_navigation_get_most_recently_published_navigation() {
 		'order'          => 'DESC',
 		'orderby'        => 'date',
 		'post_status'    => 'publish',
-		'posts_per_page' => 1, // Try the first 20 posts.
+		'posts_per_page' => 1, // get only the most recent
 	);
 
 	$navigation_post = new WP_Query( $parsed_args );

--- a/packages/block-library/src/navigation/index.php
+++ b/packages/block-library/src/navigation/index.php
@@ -250,7 +250,7 @@ function block_core_navigation_render_submenu_icon() {
 
 
 /**
- * Finds the most recent published `wp_navigation` Post.
+ * Finds the most recently published `wp_navigation` Post.
  *
  * @return WP_Post|null the first non-empty Navigation or null.
  */

--- a/packages/block-library/src/navigation/index.php
+++ b/packages/block-library/src/navigation/index.php
@@ -250,29 +250,24 @@ function block_core_navigation_render_submenu_icon() {
 
 
 /**
- * Finds the first non-empty `wp_navigation` Post.
+ * Finds the most recent published `wp_navigation` Post.
  *
  * @return WP_Post|null the first non-empty Navigation or null.
  */
-function block_core_navigation_get_first_non_empty_navigation() {
-	// Order and orderby args set to mirror those in `wp_get_nav_menus`
-	// see:
-	// - https://github.com/WordPress/wordpress-develop/blob/ba943e113d3b31b121f77a2d30aebe14b047c69d/src/wp-includes/nav-menu.php#L613-L619.
-	// - https://developer.wordpress.org/reference/classes/wp_query/#order-orderby-parameters.
+function block_core_navigation_get_most_recently_published_navigation() {
+	// We default to the most recently created
 	$parsed_args = array(
 		'post_type'      => 'wp_navigation',
 		'no_found_rows'  => true,
-		'order'          => 'ASC',
-		'orderby'        => 'name',
+		'order'          => 'DESC',
+		'orderby'        => 'date',
 		'post_status'    => 'publish',
-		'posts_per_page' => 20, // Try the first 20 posts.
+		'posts_per_page' => 1, // Try the first 20 posts.
 	);
 
-	$navigation_posts = new WP_Query( $parsed_args );
-	foreach ( $navigation_posts->posts as $navigation_post ) {
-		if ( has_blocks( $navigation_post ) ) {
-			return $navigation_post;
-		}
+	$navigation_post = new WP_Query( $parsed_args );
+	if( count( $navigation_post->posts )  > 0 ) {
+		return $navigation_post->posts[0];
 	}
 
 	return null;
@@ -325,7 +320,7 @@ function block_core_navigation_get_fallback_blocks() {
 
 	// Default to a list of Pages.
 
-	$navigation_post = block_core_navigation_get_first_non_empty_navigation();
+	$navigation_post = block_core_navigation_get_most_recently_published_navigation();
 
 	// Prefer using the first non-empty Navigation as fallback if available.
 	if ( $navigation_post ) {

--- a/packages/block-library/src/navigation/index.php
+++ b/packages/block-library/src/navigation/index.php
@@ -262,7 +262,7 @@ function block_core_navigation_get_most_recently_published_navigation() {
 		'order'          => 'DESC',
 		'orderby'        => 'date',
 		'post_status'    => 'publish',
-		'posts_per_page' => 1, // get only the most recent
+		'posts_per_page' => 1, // get only the most recent.
 	);
 
 	$navigation_post = new WP_Query( $parsed_args );

--- a/packages/e2e-tests/specs/editor/blocks/__snapshots__/navigation.test.js.snap
+++ b/packages/e2e-tests/specs/editor/blocks/__snapshots__/navigation.test.js.snap
@@ -30,6 +30,8 @@ exports[`Navigation Placeholder menu selector actions allows a navigation block 
 <!-- /wp:navigation-submenu -->"
 `;
 
+exports[`Navigation Placeholder menu selector actions creates an empty navigation block when the selected existing menu is also empty 1`] = `""`;
+
 exports[`Navigation allows an empty navigation block to be created and manually populated using a mixture of internal and external links 1`] = `
 "<!-- wp:navigation-link {\\"label\\":\\"WP\\",\\"url\\":\\"https://wordpress.org\\",\\"kind\\":\\"custom\\",\\"isTopLevelLink\\":true} /-->
 

--- a/packages/e2e-tests/specs/editor/blocks/__snapshots__/navigation.test.js.snap
+++ b/packages/e2e-tests/specs/editor/blocks/__snapshots__/navigation.test.js.snap
@@ -2,7 +2,7 @@
 
 exports[`Navigation Creating and restarting converts uncontrolled inner blocks to an entity when modifications are made to the blocks 1`] = `"<!-- wp:navigation-link {\\"label\\":\\"A Test Page\\",\\"type\\":\\"page\\",\\"id\\":[number],\\"url\\":\\"http://localhost:8889/?page_id=[number]\\",\\"kind\\":\\"post-type\\"} /-->"`;
 
-exports[`Navigation Placeholder placeholder actions allows a navigation block to be created from existing menus 1`] = `
+exports[`Navigation Placeholder menu selector actions allows a navigation block to be created from existing menus 1`] = `
 "<!-- wp:navigation-link {\\"label\\":\\"Home\\",\\"type\\":\\"custom\\",\\"url\\":\\"http://localhost:8889/\\",\\"kind\\":\\"custom\\"} /-->
 
 <!-- wp:navigation-submenu {\\"label\\":\\"About\\",\\"type\\":\\"page\\",\\"id\\":[number],\\"url\\":\\"http://localhost:8889/?page_id=[number]\\",\\"kind\\":\\"post-type\\"} -->
@@ -29,8 +29,6 @@ exports[`Navigation Placeholder placeholder actions allows a navigation block to
 <!-- wp:navigation-link {\\"label\\":\\"Google\\",\\"type\\":\\"custom\\",\\"url\\":\\"https://google.com\\",\\"kind\\":\\"custom\\"} /-->
 <!-- /wp:navigation-submenu -->"
 `;
-
-exports[`Navigation Placeholder placeholder actions creates an empty navigation block when the selected existing menu is also empty 1`] = `""`;
 
 exports[`Navigation allows an empty navigation block to be created and manually populated using a mixture of internal and external links 1`] = `
 "<!-- wp:navigation-link {\\"label\\":\\"WP\\",\\"url\\":\\"https://wordpress.org\\",\\"kind\\":\\"custom\\",\\"isTopLevelLink\\":true} /-->

--- a/packages/e2e-tests/specs/editor/blocks/navigation.test.js
+++ b/packages/e2e-tests/specs/editor/blocks/navigation.test.js
@@ -189,7 +189,7 @@ async function selectClassicMenu( optionText ) {
 	const navigationSelector = await page.waitForXPath(
 		"//button[text()='Select Menu']"
 	);
-	navigationSelector.click();
+	await navigationSelector.click();
 
 	const theOption = await page.waitForXPath(
 		'//button[contains(., "' + optionText + '")]'
@@ -454,12 +454,12 @@ Expected mock function not to be called but it was called with: ["POST", "http:/
 			const navigationSelector = await page.waitForXPath(
 				"//button[text()='Select Menu']"
 			);
-			navigationSelector.click();
+			await navigationSelector.click();
 
 			const createNewMenuButton = await page.waitForXPath(
 				'//button[contains(., "Create new menu")]'
 			);
-			createNewMenuButton.click();
+			await createNewMenuButton.click();
 
 			// Check for the spinner to be present whilst loading.
 			await navBlock.waitForSelector( '.components-spinner' );
@@ -486,12 +486,12 @@ Expected mock function not to be called but it was called with: ["POST", "http:/
 				const navigationSelector = await page.waitForXPath(
 					"//button[text()='Select Menu']"
 				);
-				navigationSelector.click();
+				await navigationSelector.click();
 
 				const createNewMenuButton = await page.waitForXPath(
 					'//button[contains(., "Create new menu")]'
 				);
-				createNewMenuButton.click();
+				await createNewMenuButton.click();
 
 				// Wait for Navigation creation to complete.
 				await page.waitForXPath(
@@ -565,7 +565,7 @@ Expected mock function not to be called but it was called with: ["POST", "http:/
 				const navigationSelector = await page.waitForXPath(
 					"//button[text()='Select Menu']"
 				);
-				navigationSelector.click();
+				await navigationSelector.click();
 
 				await page.waitForXPath(
 					'//button[contains(., "Create new menu")]'
@@ -593,12 +593,12 @@ Expected mock function not to be called but it was called with: ["POST", "http:/
 		const navigationSelector = await page.waitForXPath(
 			"//button[text()='Select Menu']"
 		);
-		navigationSelector.click();
+		await navigationSelector.click();
 
 		const createNewMenuButton = await page.waitForXPath(
 			'//button[contains(., "Create new menu")]'
 		);
-		createNewMenuButton.click();
+		await createNewMenuButton.click();
 
 		await page.waitForNetworkIdle();
 
@@ -677,12 +677,12 @@ Expected mock function not to be called but it was called with: ["POST", "http:/
 		const navigationSelector = await page.waitForXPath(
 			"//button[text()='Select Menu']"
 		);
-		navigationSelector.click();
+		await navigationSelector.click();
 
 		const createNewMenuButton = await page.waitForXPath(
 			'//button[contains(., "Create new menu")]'
 		);
-		createNewMenuButton.click();
+		await createNewMenuButton.click();
 
 		await page.waitForNetworkIdle();
 
@@ -758,12 +758,12 @@ Expected mock function not to be called but it was called with: ["POST", "http:/
 		const navigationSelector = await page.waitForXPath(
 			"//button[text()='Select Menu']"
 		);
-		navigationSelector.click();
+		await navigationSelector.click();
 
 		const createNewMenuButton = await page.waitForXPath(
 			'//button[contains(., "Create new menu")]'
 		);
-		createNewMenuButton.click();
+		await createNewMenuButton.click();
 
 		await page.waitForNetworkIdle();
 
@@ -823,12 +823,12 @@ Expected mock function not to be called but it was called with: ["POST", "http:/
 		const navigationSelector = await page.waitForXPath(
 			"//button[text()='Select Menu']"
 		);
-		navigationSelector.click();
+		await navigationSelector.click();
 
 		const createNewMenuButton = await page.waitForXPath(
 			'//button[contains(., "Create new menu")]'
 		);
-		createNewMenuButton.click();
+		await createNewMenuButton.click();
 
 		await page.waitForNetworkIdle();
 
@@ -932,12 +932,12 @@ Expected mock function not to be called but it was called with: ["POST", "http:/
 		const navigationSelector = await page.waitForXPath(
 			"//button[text()='Select Menu']"
 		);
-		navigationSelector.click();
+		await navigationSelector.click();
 
 		const createNewMenuButton = await page.waitForXPath(
 			'//button[contains(., "Create new menu")]'
 		);
-		createNewMenuButton.click();
+		await createNewMenuButton.click();
 
 		await page.waitForNetworkIdle();
 
@@ -991,12 +991,12 @@ Expected mock function not to be called but it was called with: ["POST", "http:/
 			const navigationSelector = await page.waitForXPath(
 				"//button[text()='Select Menu']"
 			);
-			navigationSelector.click();
+			await navigationSelector.click();
 
 			const createNewMenuButton = await page.waitForXPath(
 				'//button[contains(., "Create new menu")]'
 			);
-			createNewMenuButton.click();
+			await createNewMenuButton.click();
 
 			await page.waitForNetworkIdle();
 
@@ -1139,12 +1139,12 @@ Expected mock function not to be called but it was called with: ["POST", "http:/
 			const navigationSelector = await page.waitForXPath(
 				"//button[text()='Select Menu']"
 			);
-			navigationSelector.click();
+			await navigationSelector.click();
 
 			const createNewMenuButton = await page.waitForXPath(
 				'//button[contains(., "Create new menu")]'
 			);
-			createNewMenuButton.click();
+			await createNewMenuButton.click();
 
 			await page.waitForNetworkIdle();
 
@@ -1189,12 +1189,12 @@ Expected mock function not to be called but it was called with: ["POST", "http:/
 			const newNavigationSelector = await page.waitForXPath(
 				"//button[text()='Select Menu']"
 			);
-			newNavigationSelector.click();
+			await newNavigationSelector.click();
 
 			const newCreateNewMenuButton = await page.waitForXPath(
 				'//button[contains(., "Create new menu")]'
 			);
-			newCreateNewMenuButton.click();
+			await newCreateNewMenuButton.click();
 
 			await page.waitForNetworkIdle();
 
@@ -1226,12 +1226,12 @@ Expected mock function not to be called but it was called with: ["POST", "http:/
 		const navigationSelector = await page.waitForXPath(
 			"//button[text()='Select Menu']"
 		);
-		navigationSelector.click();
+		await navigationSelector.click();
 
 		const createNewMenuButton = await page.waitForXPath(
 			'//button[contains(., "Create new menu")]'
 		);
-		createNewMenuButton.click();
+		await createNewMenuButton.click();
 
 		await page.waitForNetworkIdle();
 
@@ -1287,7 +1287,42 @@ Expected mock function not to be called but it was called with: ["POST", "http:/
 	it( 'loads the frontend script only once even when multiple navigation blocks are present', async () => {
 		await createNewPost();
 		await insertBlock( 'Navigation' );
+
+		const navigationSelector = await page.waitForXPath(
+			"//button[text()='Select Menu']"
+		);
+		await navigationSelector.click();
+
+		const createNewMenuButton = await page.waitForXPath(
+			'//button[contains(., "Create new menu")]'
+		);
+		await createNewMenuButton.click();
+
+		await page.waitForNetworkIdle();
+
+		// Await "success" notice.
+		await page.waitForXPath(
+			'//div[@class="components-snackbar__content"][contains(text(), "Navigation Menu successfully created.")]'
+		);
+
 		await insertBlock( 'Navigation' );
+
+		const newNavigationSelector = await page.waitForXPath(
+			"//button[text()='Select Menu']"
+		);
+		await newNavigationSelector.click();
+
+		const newCreateNewMenuButton = await page.waitForXPath(
+			'//button[contains(., "Create new menu")]'
+		);
+		await newCreateNewMenuButton.click();
+
+		await page.waitForNetworkIdle();
+
+		// Await "success" notice.
+		await page.waitForXPath(
+			'//div[@class="components-snackbar__content"][contains(text(), "Navigation Menu successfully created.")]'
+		);
 
 		const previewPage = await openPreviewPage();
 		await previewPage.bringToFront();
@@ -1313,12 +1348,12 @@ Expected mock function not to be called but it was called with: ["POST", "http:/
 			const navigationSelector = await page.waitForXPath(
 				"//button[text()='Select Menu']"
 			);
-			navigationSelector.click();
+			await navigationSelector.click();
 
 			const createNewMenuButton = await page.waitForXPath(
 				'//button[contains(., "Create new menu")]'
 			);
-			createNewMenuButton.click();
+			await createNewMenuButton.click();
 
 			await page.waitForNetworkIdle();
 
@@ -1352,12 +1387,12 @@ Expected mock function not to be called but it was called with: ["POST", "http:/
 			const navigationSelector = await page.waitForXPath(
 				"//button[text()='Select Menu']"
 			);
-			navigationSelector.click();
+			await navigationSelector.click();
 
 			const createNewMenuButton = await page.waitForXPath(
 				'//button[contains(., "Create new menu")]'
 			);
-			createNewMenuButton.click();
+			await createNewMenuButton.click();
 
 			await page.waitForNetworkIdle();
 
@@ -1417,7 +1452,7 @@ Expected mock function not to be called but it was called with: ["POST", "http:/
 			const createNewMenuButton = await page.waitForXPath(
 				'//button[contains(., "Create new menu")]'
 			);
-			createNewMenuButton.click();
+			await createNewMenuButton.click();
 
 			await page.waitForNetworkIdle();
 
@@ -1610,7 +1645,7 @@ Expected mock function not to be called but it was called with: ["POST", "http:/
 			const navigationSelector = await page.waitForXPath(
 				"//button[text()='Select Menu']"
 			);
-			navigationSelector.click();
+			await navigationSelector.click();
 
 			await page.waitForXPath(
 				'//button[@aria-checked="true"][contains(., "Second Example Navigation")]'
@@ -1628,17 +1663,15 @@ Expected mock function not to be called but it was called with: ["POST", "http:/
 
 			await insertBlock( 'Navigation' );
 
-			await waitForBlock( 'Navigation' );
-
 			const navigationSelector = await page.waitForXPath(
 				"//button[text()='Select Menu']"
 			);
-			navigationSelector.click();
+			await navigationSelector.click();
 
 			const createNewMenuButton = await page.waitForXPath(
 				'//button[contains(., "Create new menu")]'
 			);
-			createNewMenuButton.click();
+			await createNewMenuButton.click();
 
 			await page.waitForNetworkIdle();
 
@@ -1674,7 +1707,7 @@ Expected mock function not to be called but it was called with: ["POST", "http:/
 			const navigationSelector = await page.waitForXPath(
 				"//button[text()='Select Menu']"
 			);
-			navigationSelector.click();
+			await navigationSelector.click();
 
 			const theOption = await page.waitForXPath(
 				"//button[@aria-checked='false'][contains(., 'First navigation')]"

--- a/packages/e2e-tests/specs/editor/blocks/navigation.test.js
+++ b/packages/e2e-tests/specs/editor/blocks/navigation.test.js
@@ -154,7 +154,7 @@ async function updateActiveNavigationLink( { url, label, type } ) {
 		);
 		await input.type( url );
 
-		const suggestionPath = `//button[contains(@class, 'block-editor-link-control__search-item') and contains(@class, '${ typeClasses[ type ] }')]/span/span[@class='block-editor-link-control__search-item-title']/mark[text()="${ url }"]`;
+		const suggestionPath = `//button[contains(@class, 'block-editor-link-control__search-item') and contains(@class, '${ typeClasses[ type ] }') and contains(., "${ url }")]`;
 
 		// Wait for the autocomplete suggestion item to appear.
 		await page.waitForXPath( suggestionPath );
@@ -548,6 +548,8 @@ Expected mock function not to be called but it was called with: ["POST", "http:/
 				await insertBlock( 'Navigation' );
 				await selectClassicMenu( 'Test Menu 1' );
 
+				await page.waitForNetworkIdle();
+
 				// Wait for the appender so that we know the navigation menu was created.
 				await page.waitForSelector(
 					'nav[aria-label="Block: Navigation"] button[aria-label="Add block"]'
@@ -586,6 +588,8 @@ Expected mock function not to be called but it was called with: ["POST", "http:/
 		await createNewPost();
 		await insertBlock( 'Navigation' );
 
+		await showBlockToolbar();
+
 		const navigationSelector = await page.waitForXPath(
 			"//button[text()='Select Menu']"
 		);
@@ -595,6 +599,8 @@ Expected mock function not to be called but it was called with: ["POST", "http:/
 			'//button[contains(., "Create new menu")]'
 		);
 		createNewMenuButton.click();
+
+		await page.waitForNetworkIdle();
 
 		// Await "success" notice.
 		await page.waitForXPath(
@@ -678,6 +684,8 @@ Expected mock function not to be called but it was called with: ["POST", "http:/
 		);
 		createNewMenuButton.click();
 
+		await page.waitForNetworkIdle();
+
 		// Await "success" notice.
 		await page.waitForXPath(
 			'//div[@class="components-snackbar__content"][contains(text(), "Navigation Menu successfully created.")]'
@@ -757,6 +765,8 @@ Expected mock function not to be called but it was called with: ["POST", "http:/
 		);
 		createNewMenuButton.click();
 
+		await page.waitForNetworkIdle();
+
 		// Await "success" notice.
 		await page.waitForXPath(
 			'//div[@class="components-snackbar__content"][contains(text(), "Navigation Menu successfully created.")]'
@@ -819,6 +829,8 @@ Expected mock function not to be called but it was called with: ["POST", "http:/
 			'//button[contains(., "Create new menu")]'
 		);
 		createNewMenuButton.click();
+
+		await page.waitForNetworkIdle();
 
 		// Await "success" notice.
 		await page.waitForXPath(
@@ -927,6 +939,8 @@ Expected mock function not to be called but it was called with: ["POST", "http:/
 		);
 		createNewMenuButton.click();
 
+		await page.waitForNetworkIdle();
+
 		// Await "success" notice.
 		await page.waitForXPath(
 			'//div[@class="components-snackbar__content"][contains(text(), "Navigation Menu successfully created.")]'
@@ -983,6 +997,8 @@ Expected mock function not to be called but it was called with: ["POST", "http:/
 				'//button[contains(., "Create new menu")]'
 			);
 			createNewMenuButton.click();
+
+			await page.waitForNetworkIdle();
 
 			// Await "success" notice.
 			await page.waitForXPath(
@@ -1130,6 +1146,8 @@ Expected mock function not to be called but it was called with: ["POST", "http:/
 			);
 			createNewMenuButton.click();
 
+			await page.waitForNetworkIdle();
+
 			// Await "success" notice.
 			await page.waitForXPath(
 				'//div[@class="components-snackbar__content"][contains(text(), "Navigation Menu successfully created.")]'
@@ -1178,6 +1196,8 @@ Expected mock function not to be called but it was called with: ["POST", "http:/
 			);
 			newCreateNewMenuButton.click();
 
+			await page.waitForNetworkIdle();
+
 			// Await "success" notice.
 			await page.waitForXPath(
 				'//div[@class="components-snackbar__content"][contains(text(), "Navigation Menu successfully created.")]'
@@ -1212,6 +1232,8 @@ Expected mock function not to be called but it was called with: ["POST", "http:/
 			'//button[contains(., "Create new menu")]'
 		);
 		createNewMenuButton.click();
+
+		await page.waitForNetworkIdle();
 
 		// Await "success" notice.
 		await page.waitForXPath(
@@ -1298,6 +1320,8 @@ Expected mock function not to be called but it was called with: ["POST", "http:/
 			);
 			createNewMenuButton.click();
 
+			await page.waitForNetworkIdle();
+
 			// Await "success" notice.
 			await page.waitForXPath(
 				'//div[@class="components-snackbar__content"][contains(text(), "Navigation Menu successfully created.")]'
@@ -1334,6 +1358,8 @@ Expected mock function not to be called but it was called with: ["POST", "http:/
 				'//button[contains(., "Create new menu")]'
 			);
 			createNewMenuButton.click();
+
+			await page.waitForNetworkIdle();
 
 			// Await "success" notice.
 			await page.waitForXPath(
@@ -1386,15 +1412,14 @@ Expected mock function not to be called but it was called with: ["POST", "http:/
 			await createNewPost();
 			await insertBlock( 'Navigation' );
 
-			const navigationSelector = await page.waitForXPath(
-				"//button[text()='Select Menu']"
-			);
-			navigationSelector.click();
+			await clickBlockToolbarButton( 'Select Menu' );
 
 			const createNewMenuButton = await page.waitForXPath(
 				'//button[contains(., "Create new menu")]'
 			);
 			createNewMenuButton.click();
+
+			await page.waitForNetworkIdle();
 
 			// Await "success" notice.
 			await page.waitForXPath(
@@ -1614,6 +1639,8 @@ Expected mock function not to be called but it was called with: ["POST", "http:/
 				'//button[contains(., "Create new menu")]'
 			);
 			createNewMenuButton.click();
+
+			await page.waitForNetworkIdle();
 
 			// Await "success" notice.
 			await page.waitForXPath(

--- a/packages/e2e-tests/specs/editor/blocks/navigation.test.js
+++ b/packages/e2e-tests/specs/editor/blocks/navigation.test.js
@@ -194,7 +194,7 @@ async function selectClassicMenu( optionText ) {
 	const theOption = await page.waitForXPath(
 		'//button[contains(., "' + optionText + '")]'
 	);
-	theOption.click();
+	await theOption.click();
 
 	await page.waitForResponse(
 		( response ) =>


### PR DESCRIPTION
Closes #42563

- [x] Default to a page list block when the navigation block is empty and no menus exist
  - [x] Add test for this
  - [x] Update tests that assume empty nav defaults to placeholder
    - [x] Update `selectClassicMenu` to pull the block toolbar instead of placeholder
  - [x] Update the front end to default to a page list block when the navigation block is empty and no menus exist
- [x] Show "empty placeholder" when deleting the selected menu from the block
  - [ ] Add test for this
- [x] Default to the most recently created menu if multiple menus exist
  - [x] Add test for this
- [x] Default to the only menu if only one menu exists
  - [x] Add test for this
- [x] 🐛 deleting the fallback page list block results in a menu being created, i think this is correct **for now**
- [x] 🐛 inserting two blocks when there are no menus (fallback on page list) automatically creates a new menu
- [ ] 🐛 responsive navigation blocks don't allow the fallback page list to be selected via mouse click, , opened #43227

<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

This makes the navigation block default to a page list in the editor when loading an empty navigation block (one that has no uncontrolled blocks nor any ref).

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

We do this so that the editor respects the fallback of the front end, which is a page list.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

We use a similar technique to the one used in the pattern block which does not add the pattern before it is edited.

## Testing Instructions

1. Use a theme that has a template part with an empty navigation block (e.g. Vivre)
2. Load the template part in the site editor
3. Make sure you delete ALL your navigation menus
4. You should see a page list block for navigation

## Screenshots or screencast <!-- if applicable -->

N/A