### PR TITLE
Comments Block (legacy): Don't render empty block wrapper

### DIFF
--- a/packages/block-library/src/comments/index.php
+++ b/packages/block-library/src/comments/index.php
@@ -62,6 +62,10 @@ function render_block_core_comments( $attributes, $content, $block ) {
 	$output = ob_get_clean();
 	$post   = $post_before;
 
+	if ( empty( $output ) ) {
+		return '';
+	}
+
 	$classnames = array();
 	// Adds the old class name for styles' backwards compatibility.
 	if ( isset( $attributes['legacy'] ) ) {


### PR DESCRIPTION
## What?

Follow-up to @DAreRodz https://github.com/WordPress/gutenberg/pull/41807#issuecomment-1192804470:

> Another thing I've noticed is that the block renders in those cases where the `comments_template()`'s output is empty. This should be a quick fix. 🙂 

## Why?

To avoid an empty block wrapper for no content.

## How?

By adding a check if `comments_template()`'s return value is `empty()`, and returning an empty string if it is.

## Testing Instructions
TDB

## Screenshots or screencast
