### PR TITLE
Revert "Add block variations for individual template parts"

### DIFF
--- a/packages/block-editor/src/components/inserter-list-item/index.js
+++ b/packages/block-editor/src/components/inserter-list-item/index.js
@@ -11,7 +11,6 @@ import {
 	createBlock,
 	createBlocksFromInnerBlocksTemplate,
 } from '@wordpress/blocks';
-import { __experimentalTruncate as Truncate } from '@wordpress/components';
 import { ENTER } from '@wordpress/keycodes';
 
 /**
@@ -136,9 +135,7 @@ function InserterListItem( {
 							<BlockIcon icon={ item.icon } showColors />
 						</span>
 						<span className="block-editor-block-types-list__item-title">
-							<Truncate numberOfLines={ 3 }>
-								{ item.title }
-							</Truncate>
+							{ item.title }
 						</span>
 					</InserterListboxItem>
 				</div>

--- a/packages/block-editor/src/components/inserter/preview-panel.js
+++ b/packages/block-editor/src/components/inserter/preview-panel.js
@@ -5,6 +5,7 @@ import {
 	isReusableBlock,
 	createBlock,
 	getBlockFromExample,
+	getBlockType,
 } from '@wordpress/blocks';
 import { __ } from '@wordpress/i18n';
 
@@ -15,24 +16,31 @@ import BlockCard from '../block-card';
 import BlockPreview from '../block-preview';
 
 function InserterPreviewPanel( { item } ) {
-	const { name, title, icon, description, initialAttributes, example } = item;
+	const { name, title, icon, description, initialAttributes } = item;
+	const hoveredItemBlockType = getBlockType( name );
 	const isReusable = isReusableBlock( item );
 	return (
 		<div className="block-editor-inserter__preview-container">
 			<div className="block-editor-inserter__preview">
-				{ isReusable || example ? (
+				{ isReusable || hoveredItemBlockType?.example ? (
 					<div className="block-editor-inserter__preview-content">
 						<BlockPreview
 							__experimentalPadding={ 16 }
-							viewportWidth={ example?.viewportWidth ?? 500 }
+							viewportWidth={
+								hoveredItemBlockType.example?.viewportWidth ??
+								500
+							}
 							blocks={
-								example
+								hoveredItemBlockType.example
 									? getBlockFromExample( item.name, {
 											attributes: {
-												...example.attributes,
+												...hoveredItemBlockType.example
+													.attributes,
 												...initialAttributes,
 											},
-											innerBlocks: example.innerBlocks,
+											innerBlocks:
+												hoveredItemBlockType.example
+													.innerBlocks,
 									  } )
 									: createBlock( name, initialAttributes )
 							}

--- a/packages/block-library/src/template-part/index.php
+++ b/packages/block-library/src/template-part/index.php
@@ -159,11 +159,11 @@ function render_block_core_template_part( $attributes ) {
 }
 
 /**
- * Returns an array of area variation objects for the template part block.
+ * Returns an array of variation objects for the template part block.
  *
  * @return array Array containing the block variation objects.
  */
-function build_template_part_block_area_variations() {
+function build_template_part_block_variations() {
 	$variations    = array();
 	$defined_areas = get_allowed_block_template_part_areas();
 	foreach ( $defined_areas as $area ) {
@@ -181,60 +181,6 @@ function build_template_part_block_area_variations() {
 		}
 	}
 	return $variations;
-}
-
-/**
- * Returns an array of instance variation objects for the template part block
- *
- * @return array Array containing the block variation objects.
- */
-function build_template_part_block_instance_variations() {
-	$variations     = array();
-	$template_parts = get_block_templates(
-		array(
-			'post_type' => 'wp_template_part',
-		),
-		'wp_template_part'
-	);
-
-	$defined_areas = get_allowed_block_template_part_areas();
-	$icon_by_area  = array_combine( array_column( $defined_areas, 'area' ), array_column( $defined_areas, 'icon' ) );
-
-	foreach ( $template_parts as $template_part ) {
-		$variations[] = array(
-			'name'        => sanitize_title( $template_part->slug ),
-			'title'       => $template_part->title,
-			// If there's no description for the template part don't show the
-			// block description. This is a bit hacky, but prevent the fallback
-			// by using a non-breaking space so that the value of description
-			// isn't falsey.
-			'description' => $template_part->description || '&nbsp;',
-			'attributes'  => array(
-				'slug'  => $template_part->slug,
-				'theme' => $template_part->theme,
-				'area'  => $template_part->area,
-			),
-			'scope'       => array( 'inserter' ),
-			'icon'        => $icon_by_area[ $template_part->area ],
-			'example'     => array(
-				'attributes' => array(
-					'slug'  => $template_part->slug,
-					'theme' => $template_part->theme,
-					'area'  => $template_part->area,
-				),
-			),
-		);
-	}
-	return $variations;
-}
-
-/**
- * Returns an array of all template part block variations.
- *
- * @return array Array containing the block variation objects.
- */
-function build_template_part_block_variations() {
-	return array_merge( build_template_part_block_area_variations(), build_template_part_block_instance_variations() );
 }
 
 /**


### PR DESCRIPTION
Reverts WordPress/gutenberg#42454
It seems like this recently merged PR is breaking several `theme.json` features working previously.

I haven't tested this extensively but, for example, these features are no longer working:
- Some styles for blocks are no longer applied. Example:
```
    "styles": {
        "blocks": {
            "core/button": {
                "border": {
		    "radius": "999px",
                    "width": "1.5px",
                    "style": "solid",
                    "color": "red"
		},
```

- Fluid typography API no longer works. The font sizes are rendered statically:
```
--wp--preset--font-size--header-two: 2.5rem;
```

After reverting the mentioned PR these functionalities work again as before, so I propose to revert it until further testing.

