### PR TITLE
[Documentation] Adding `@example` entries to the public API exposed in `core/blocks`

### DIFF
--- a/packages/blocks/README.md
+++ b/packages/blocks/README.md
@@ -685,6 +685,25 @@ _Returns_
 
 Registers a new block collection to group blocks in the same namespace in the inserter.
 
+_Usage_
+
+```js
+import { __ } from '@wordpress/i18n';
+import { registerBlockCollection, registerBlockType } from '@wordpress/blocks';
+
+// Register the collection.
+registerBlockCollection( 'my-collection', {
+	title: __( 'Custom Collection' ),
+} );
+
+// Register a block in the same namespace to add it to the collection.
+registerBlockType( 'my-collection/block-name', {
+	title: __( 'My First Block' ),
+	edit: () => <div>{ __( 'Hello from the editor!' ) }</div>,
+	save: () => <div>{ __( 'Hello from the saved content!' ) }</div>,
+} );
+```
+
 _Parameters_
 
 -   _namespace_ `string`: The namespace to group blocks by in the inserter; corresponds to the block namespace.
@@ -872,6 +891,23 @@ _Parameters_
 ### unregisterBlockType
 
 Unregisters a block.
+
+_Usage_
+
+```js
+import { __ } from '@wordpress/i18n';
+import { unregisterBlockType } from '@wordpress/blocks';
+
+const ExampleComponent = () => {
+	return (
+		<Button
+			onClick={ () => unregisterBlockType( 'my-collection/block-name' ) }
+		>
+			{ __( 'Unregister my custom block.' ) }
+		</Button>
+	);
+};
+```
 
 _Parameters_
 

--- a/packages/blocks/README.md
+++ b/packages/blocks/README.md
@@ -903,7 +903,7 @@ import { setGroupingBlockName } from '@wordpress/blocks';
 const ExampleComponent = () => {
 	return (
 		<Button onClick={ () => setGroupingBlockName( 'core/columns' ) }>
-			{ __( 'Set the default block to Heading' ) }
+			{ __( 'Set the default grouping block to Columns' ) }
 		</Button>
 	);
 };

--- a/packages/blocks/README.md
+++ b/packages/blocks/README.md
@@ -739,7 +739,7 @@ import { registerBlockType } from '@wordpress/blocks';
 registerBlockType( 'namespace/block-name', {
 	title: __( 'My First Block' ),
 	edit: () => <div>{ __( 'Hello from the editor!' ) }</div>,
-	save: () => <div>{ __( 'Hello from the saved content!' ) }</div>,
+	save: () => <div>Hello from the saved content!</div>,
 } );
 ```
 

--- a/packages/blocks/README.md
+++ b/packages/blocks/README.md
@@ -383,14 +383,6 @@ _Returns_
 
 -   `(WPBlockVariation[]|void)`: Block variations.
 
-### getCategories
-
-Returns all the block categories.
-
-_Returns_
-
--   `WPBlockCategory[]`: Block categories.
-
 ### getChildBlockNames
 
 Returns an array with the child blocks of a given block.
@@ -803,6 +795,11 @@ Sets the block categories.
 _Usage_
 
 ```js
+import { __ } from '@wordpress/i18n';
+import { store as blocksStore, setCategories } from '@wordpress/blocks';
+import { useSelect } from '@wordpress/data';
+import { Button } from '@wordpress/components';
+
 const ExampleComponent = () => {
 	// Retrieve the list of current categories.
 	const blockCategories = useSelect(
@@ -983,6 +980,26 @@ _Parameters_
 ### updateCategory
 
 Updates a category.
+
+_Usage_
+
+```js
+import { __ } from '@wordpress/i18n';
+import { updateCategory } from '@wordpress/blocks';
+import { Button } from '@wordpress/components';
+
+const ExampleComponent = () => {
+	return (
+		<Button
+			onClick={ () => {
+				updateCategory( 'text', { title: __( 'Written Word' ) } );
+			} }
+		>
+			{ __( 'Update Text category title' ) }
+		</Button>
+	);
+};
+```
 
 _Parameters_
 

--- a/packages/blocks/README.md
+++ b/packages/blocks/README.md
@@ -907,7 +907,7 @@ import { setGroupingBlockName } from '@wordpress/blocks';
 const ExampleComponent = () => {
 	return (
 		<Button onClick={ () => setGroupingBlockName( 'core/columns' ) }>
-			{ __( 'Set the default grouping block to Columns' ) }
+			{ __( 'Set the default block to Heading' ) }
 		</Button>
 	);
 };

--- a/packages/blocks/README.md
+++ b/packages/blocks/README.md
@@ -707,6 +707,29 @@ _Parameters_
 
 Registers a new block style variation for the given block.
 
+_Usage_
+
+```js
+import { __ } from '@wordpress/i18n';
+import { registerBlockStyle } from '@wordpress/blocks';
+import { Button } from '@wordpress/components';
+
+const ExampleComponent = () => {
+	return (
+		<Button
+			onClick={ () => {
+				registerBlockStyle( 'core/quote', {
+					name: 'fancy-quote',
+					label: __( 'Fancy Quote' ),
+				} );
+			} }
+		>
+			{ __( 'Add a new block style for core/quote' ) }
+		</Button>
+	);
+};
+```
+
 _Parameters_
 
 -   _blockName_ `string`: Name of block (example: “core/latest-posts”).
@@ -933,6 +956,26 @@ _Returns_
 ### unregisterBlockStyle
 
 Unregisters a block style variation for the given block.
+
+_Usage_
+
+```js
+import { __ } from '@wordpress/i18n';
+import { unregisterBlockStyle } from '@wordpress/blocks';
+import { Button } from '@wordpress/components';
+
+const ExampleComponent = () => {
+	return (
+		<Button
+			onClick={ () => {
+				unregisterBlockStyle( 'core/quote', 'plain' );
+			} }
+		>
+			{ __( 'Remove the "Plain" block style for core/quote' ) }
+		</Button>
+	);
+};
+```
 
 _Parameters_
 

--- a/packages/blocks/README.md
+++ b/packages/blocks/README.md
@@ -370,19 +370,6 @@ _Returns_
 
 -   `Array`: Block settings.
 
-### getBlockVariations
-
-Returns an array with the variations of a given block type.
-
-_Parameters_
-
--   _blockName_ `string`: Name of block (example: “core/columns”).
--   _scope_ `[WPBlockVariationScope]`: Block variation scope name.
-
-_Returns_
-
--   `(WPBlockVariation[]|void)`: Block variations.
-
 ### getChildBlockNames
 
 Returns an array with the child blocks of a given block.
@@ -769,6 +756,30 @@ _Returns_
 
 Registers a new block variation for the given block type.
 
+_Usage_
+
+```js
+import { __ } from '@wordpress/i18n';
+import { registerBlockVariation } from '@wordpress/blocks';
+import { Button } from '@wordpress/components';
+
+const ExampleComponent = () => {
+	return (
+		<Button
+			onClick={ () => {
+				registerBlockVariation( 'core/embed', {
+					name: 'custom',
+					title: __( 'My Custom Embed' ),
+					attributes: { providerNameSlug: 'custom' },
+				} );
+			} }
+		>
+			__( 'Add a custom variation for core/embed' ) }
+		</Button>
+	);
+};
+```
+
 _Parameters_
 
 -   _blockName_ `string`: Name of the block (example: “core/columns”).
@@ -1014,6 +1025,26 @@ _Returns_
 ### unregisterBlockVariation
 
 Unregisters a block variation defined for the given block type.
+
+_Usage_
+
+```js
+import { __ } from '@wordpress/i18n';
+import { unregisterBlockVariation } from '@wordpress/blocks';
+import { Button } from '@wordpress/components';
+
+const ExampleComponent = () => {
+	return (
+		<Button
+			onClick={ () => {
+				unregisterBlockVariation( 'core/embed', 'youtube' );
+			} }
+		>
+			{ __( 'Remove the YouTube variation from core/embed' ) }
+		</Button>
+	);
+};
+```
 
 _Parameters_
 

--- a/packages/blocks/README.md
+++ b/packages/blocks/README.md
@@ -679,7 +679,7 @@ registerBlockCollection( 'my-collection', {
 registerBlockType( 'my-collection/block-name', {
 	title: __( 'My First Block' ),
 	edit: () => <div>{ __( 'Hello from the editor!' ) }</div>,
-	save: () => <div>{ __( 'Hello from the saved content!' ) }</div>,
+	save: () => <div>'Hello from the saved content!</div>,
 } );
 ```
 
@@ -693,6 +693,8 @@ _Parameters_
 ### registerBlockStyle
 
 Registers a new block style variation for the given block.
+
+For more information on connecting the styles with CSS [the official documentation](/docs/reference-guides/block-api/block-styles.md#styles)
 
 _Usage_
 
@@ -739,7 +741,7 @@ import { registerBlockType } from '@wordpress/blocks';
 registerBlockType( 'namespace/block-name', {
 	title: __( 'My First Block' ),
 	edit: () => <div>{ __( 'Hello from the editor!' ) }</div>,
-	save: () => <div>{ __( 'Hello from the saved content!' ) }</div>,
+	save: () => <div>Hello from the saved content!</div>,
 } );
 ```
 
@@ -755,6 +757,8 @@ _Returns_
 ### registerBlockVariation
 
 Registers a new block variation for the given block type.
+
+For more information on block variations see [the official documentation ](/docs/reference-guides/block-api/block-variations.md)
 
 _Usage_
 

--- a/packages/blocks/README.md
+++ b/packages/blocks/README.md
@@ -707,6 +707,21 @@ Registers a new block provided a unique name and an object defining its
 behavior. Once registered, the block is made available as an option to any
 editor interface where blocks are implemented.
 
+For more in-depth information on registering a custom block see the [Create a block tutorial](docs/how-to-guides/block-tutorial/README.md)
+
+_Usage_
+
+```js
+import { __ } from '@wordpress/i18n';
+import { registerBlockType } from '@wordpress/blocks';
+
+registerBlockType( 'namespace/block-name', {
+	title: __( 'My First Block' ),
+	edit: () => <div>{ __( 'Hello from the editor!' ) }</div>,
+	save: () => <div>{ __( 'Hello from the saved content!' ) }</div>,
+} );
+```
+
 _Parameters_
 
 -   _blockNameOrMetadata_ `string|Object`: Block type name or its metadata.

--- a/packages/blocks/README.md
+++ b/packages/blocks/README.md
@@ -800,6 +800,32 @@ _Returns_
 
 Sets the block categories.
 
+_Usage_
+
+```js
+const ExampleComponent = () => {
+	// Retrieve the list of current categories.
+	const blockCategories = useSelect(
+		( select ) => select( blocksStore ).getCategories(),
+		[]
+	);
+
+	return (
+		<Button
+			onClick={ () => {
+				// Add a custom category to the existing list.
+				setCategories( [
+					...blockCategories,
+					{ title: 'Custom Category', slug: 'custom-category' },
+				] );
+			} }
+		>
+			{ __( 'Add a new custom block category' ) }
+		</Button>
+	);
+};
+```
+
 _Parameters_
 
 -   _categories_ `WPBlockCategory[]`: Block categories.

--- a/packages/blocks/README.md
+++ b/packages/blocks/README.md
@@ -808,6 +808,20 @@ _Parameters_
 
 Assigns the default block name.
 
+_Usage_
+
+```js
+import { setDefaultBlockName } from '@wordpress/blocks';
+
+const ExampleComponent = () => {
+	return (
+		<Button onClick={ () => setDefaultBlockName( 'core/heading' ) }>
+			{ __( 'Set the default block to Heading' ) }
+		</Button>
+	);
+};
+```
+
 _Parameters_
 
 -   _name_ `string`: Block name.
@@ -823,6 +837,20 @@ _Parameters_
 ### setGroupingBlockName
 
 Assigns name of block for handling block grouping interactions.
+
+_Usage_
+
+```js
+import { setGroupingBlockName } from '@wordpress/blocks';
+
+const ExampleComponent = () => {
+	return (
+		<Button onClick={ () => setGroupingBlockName( 'core/columns' ) }>
+			{ __( 'Set the default block to Heading' ) }
+		</Button>
+	);
+};
+```
 
 _Parameters_
 

--- a/packages/blocks/src/api/categories.js
+++ b/packages/blocks/src/api/categories.js
@@ -12,6 +12,9 @@ import { store as blocksStore } from '../store';
 
 /**
  * Returns all the block categories.
+ * Ignored from documentation as the recommended usage is via useSelect from @wordpress/data.
+ *
+ * @ignore
  *
  * @return {WPBlockCategory[]} Block categories.
  */
@@ -26,6 +29,11 @@ export function getCategories() {
  *
  * @example
  * ```js
+ * import { __ } from '@wordpress/i18n';
+ * import { store as blocksStore, setCategories } from '@wordpress/blocks';
+ * import { useSelect } from '@wordpress/data';
+ * import { Button } from '@wordpress/components';
+ *
  * const ExampleComponent = () => {
  *     // Retrieve the list of current categories.
  *     const blockCategories = useSelect(
@@ -59,6 +67,25 @@ export function setCategories( categories ) {
  * @param {string}          slug     Block category slug.
  * @param {WPBlockCategory} category Object containing the category properties
  *                                   that should be updated.
+ *
+ * @example
+ * ```js
+ * import { __ } from '@wordpress/i18n';
+ * import { updateCategory } from '@wordpress/blocks';
+ * import { Button } from '@wordpress/components';
+ *
+ * const ExampleComponent = () => {
+ *     return (
+ *         <Button
+ *             onClick={ () => {
+ *                 updateCategory( 'text', { title: __( 'Written Word' ) } );
+ *             } }
+ *         >
+ *             { __( 'Update Text category title' ) }
+ *         </Button>
+ * )    ;
+ * };
+ * ```
  */
 export function updateCategory( slug, category ) {
 	dispatch( blocksStore ).updateCategory( slug, category );

--- a/packages/blocks/src/api/categories.js
+++ b/packages/blocks/src/api/categories.js
@@ -23,6 +23,31 @@ export function getCategories() {
  * Sets the block categories.
  *
  * @param {WPBlockCategory[]} categories Block categories.
+ *
+ * @example
+ * ```js
+ * const ExampleComponent = () => {
+ *     // Retrieve the list of current categories.
+ *     const blockCategories = useSelect(
+ *         ( select ) => select( blocksStore ).getCategories(),
+ *         []
+ *     );
+ *
+ *     return (
+ *         <Button
+ *             onClick={ () => {
+ *                 // Add a custom category to the existing list.
+ *                 setCategories( [
+ *                     ...blockCategories,
+ *                     { title: 'Custom Category', slug: 'custom-category' },
+ *                 ] );
+ *             } }
+ *         >
+ *             { __( 'Add a new custom block category' ) }
+ *         </Button>
+ *     );
+ * };
+ * ```
  */
 export function setCategories( categories ) {
 	dispatch( blocksStore ).setCategories( categories );

--- a/packages/blocks/src/api/registration.js
+++ b/packages/blocks/src/api/registration.js
@@ -244,7 +244,7 @@ function getBlockSettingsFromMetadata( { textdomain, ...metadata } ) {
  * registerBlockType( 'namespace/block-name', {
  *     title: __( 'My First Block' ),
  *     edit: () => <div>{ __( 'Hello from the editor!' ) }</div>,
- *     save: () => <div>{ __( 'Hello from the saved content!' ) }</div>,
+ *     save: () => <div>Hello from the saved content!</div>,
  * } );
  * ```
  *

--- a/packages/blocks/src/api/registration.js
+++ b/packages/blocks/src/api/registration.js
@@ -477,6 +477,20 @@ export function getUnregisteredTypeHandlerName() {
  * Assigns the default block name.
  *
  * @param {string} name Block name.
+ *
+ * @example
+ * ```js
+ * import { setDefaultBlockName } from '@wordpress/blocks';
+ *
+ * const ExampleComponent = () => {
+ *
+ *     return (
+ *         <Button onClick={ () => setDefaultBlockName( 'core/heading' ) }>
+ *             { __( 'Set the default block to Heading' ) }
+ *         </Button>
+ *     );
+ * };
+ * ```
  */
 export function setDefaultBlockName( name ) {
 	dispatch( blocksStore ).setDefaultBlockName( name );
@@ -486,6 +500,20 @@ export function setDefaultBlockName( name ) {
  * Assigns name of block for handling block grouping interactions.
  *
  * @param {string} name Block name.
+ *
+ * @example
+ * ```js
+ * import { setGroupingBlockName } from '@wordpress/blocks';
+ *
+ * const ExampleComponent = () => {
+ *
+ *     return (
+ *         <Button onClick={ () => setGroupingBlockName( 'core/columns' ) }>
+ *             { __( 'Set the default block to Heading' ) }
+ *         </Button>
+ *     );
+ * };
+ * ```
  */
 export function setGroupingBlockName( name ) {
 	dispatch( blocksStore ).setGroupingBlockName( name );

--- a/packages/blocks/src/api/registration.js
+++ b/packages/blocks/src/api/registration.js
@@ -707,6 +707,9 @@ export const unregisterBlockStyle = ( blockName, styleVariationName ) => {
 
 /**
  * Returns an array with the variations of a given block type.
+ * Ignored from documentation as the recommended usage is via useSelect from @wordpress/data.
+ *
+ * @ignore
  *
  * @param {string}                blockName Name of block (example: “core/columns”).
  * @param {WPBlockVariationScope} [scope]   Block variation scope name.
@@ -722,6 +725,29 @@ export const getBlockVariations = ( blockName, scope ) => {
  *
  * @param {string}           blockName Name of the block (example: “core/columns”).
  * @param {WPBlockVariation} variation Object describing a block variation.
+ *
+ * @example
+ * ```js
+ * import { __ } from '@wordpress/i18n';
+ * import { registerBlockVariation } from '@wordpress/blocks';
+ * import { Button } from '@wordpress/components';
+ *
+ * const ExampleComponent = () => {
+ *     return (
+ *         <Button
+ *             onClick={ () => {
+ *                 registerBlockVariation( 'core/embed', {
+ *                     name: 'custom',
+ *                     title: __( 'My Custom Embed' ),
+ *                     attributes: { providerNameSlug: 'custom' },
+ *                 } );
+ *             } }
+ *          >
+ *              __( 'Add a custom variation for core/embed' ) }
+ *         </Button>
+ *     );
+ * };
+ * ```
  */
 export const registerBlockVariation = ( blockName, variation ) => {
 	dispatch( blocksStore ).addBlockVariations( blockName, variation );
@@ -732,6 +758,25 @@ export const registerBlockVariation = ( blockName, variation ) => {
  *
  * @param {string} blockName     Name of the block (example: “core/columns”).
  * @param {string} variationName Name of the variation defined for the block.
+ *
+ * @example
+ * ```js
+ * import { __ } from '@wordpress/i18n';
+ * import { unregisterBlockVariation } from '@wordpress/blocks';
+ * import { Button } from '@wordpress/components';
+ *
+ * const ExampleComponent = () => {
+ *     return (
+ *         <Button
+ *             onClick={ () => {
+ *                 unregisterBlockVariation( 'core/embed', 'youtube' );
+ *             } }
+ *         >
+ *             { __( 'Remove the YouTube variation from core/embed' ) }
+ *         </Button>
+ *     );
+ * };
+ * ```
  */
 export const unregisterBlockVariation = ( blockName, variationName ) => {
 	dispatch( blocksStore ).removeBlockVariations( blockName, variationName );

--- a/packages/blocks/src/api/registration.js
+++ b/packages/blocks/src/api/registration.js
@@ -357,6 +357,24 @@ function translateBlockSettingUsingI18nSchema(
  * @param {Object} settings        The block collection settings.
  * @param {string} settings.title  The title to display in the block inserter.
  * @param {Object} [settings.icon] The icon to display in the block inserter.
+ *
+ * @example
+ * ```js
+ * import { __ } from '@wordpress/i18n';
+ * import { registerBlockCollection, registerBlockType } from '@wordpress/blocks';
+ *
+ * // Register the collection.
+ * registerBlockCollection( 'my-collection', {
+ *     title: __( 'Custom Collection' ),
+ * } );
+ *
+ * // Register a block in the same namespace to add it to the collection.
+ * registerBlockType( 'my-collection/block-name', {
+ *     title: __( 'My First Block' ),
+ *     edit: () => <div>{ __( 'Hello from the editor!' ) }</div>,
+ *     save: () => <div>{ __( 'Hello from the saved content!' ) }</div>,
+ * } );
+ * ```
  */
 export function registerBlockCollection( namespace, { title, icon } ) {
 	dispatch( blocksStore ).addBlockCollection( namespace, title, icon );
@@ -376,6 +394,24 @@ export function unregisterBlockCollection( namespace ) {
  * Unregisters a block.
  *
  * @param {string} name Block name.
+ *
+ * @example
+ * ```js
+ * import { __ } from '@wordpress/i18n';
+ * import { unregisterBlockType } from '@wordpress/blocks';
+ *
+ * const ExampleComponent = () => {
+ *     return (
+ *         <Button
+ *             onClick={ () =>
+ *                 unregisterBlockType( 'my-collection/block-name' )
+ *             }
+ *         >
+ *             { __( 'Unregister my custom block.' ) }
+ *         </Button>
+ *     );
+ * };
+ * ```
  *
  * @return {?WPBlockType} The previous block value, if it has been successfully
  *                    unregistered; otherwise `undefined`.

--- a/packages/blocks/src/api/registration.js
+++ b/packages/blocks/src/api/registration.js
@@ -231,8 +231,22 @@ function getBlockSettingsFromMetadata( { textdomain, ...metadata } ) {
  * behavior. Once registered, the block is made available as an option to any
  * editor interface where blocks are implemented.
  *
+ * For more in-depth information on registering a custom block see the [Create a block tutorial](docs/how-to-guides/block-tutorial/README.md)
+ *
  * @param {string|Object} blockNameOrMetadata Block type name or its metadata.
  * @param {Object}        settings            Block settings.
+ *
+ * @example
+ * ```js
+ * import { __ } from '@wordpress/i18n';
+ * import { registerBlockType } from '@wordpress/blocks'
+ *
+ * registerBlockType( 'namespace/block-name', {
+ *     title: __( 'My First Block' ),
+ *     edit: () => <div>{ __( 'Hello from the editor!' ) }</div>,
+ *     save: () => <div>{ __( 'Hello from the saved content!' ) }</div>,
+ * } );
+ * ```
  *
  * @return {?WPBlockType} The block, if it has been successfully registered;
  *                    otherwise `undefined`.

--- a/packages/blocks/src/api/registration.js
+++ b/packages/blocks/src/api/registration.js
@@ -385,6 +385,12 @@ export function registerBlockCollection( namespace, { title, icon } ) {
  *
  * @param {string} namespace The namespace to group blocks by in the inserter; corresponds to the block namespace
  *
+ * @example
+ * ```js
+ * import { unregisterBlockCollection } from '@wordpress/blocks';
+ *
+ * unregisterBlockCollection( 'my-collection' );
+ * ```
  */
 export function unregisterBlockCollection( namespace ) {
 	dispatch( blocksStore ).removeBlockCollection( namespace );

--- a/packages/blocks/src/api/registration.js
+++ b/packages/blocks/src/api/registration.js
@@ -244,7 +244,7 @@ function getBlockSettingsFromMetadata( { textdomain, ...metadata } ) {
  * registerBlockType( 'namespace/block-name', {
  *     title: __( 'My First Block' ),
  *     edit: () => <div>{ __( 'Hello from the editor!' ) }</div>,
- *     save: () => <div>{ __( 'Hello from the saved content!' ) }</div>,
+ *     save: () => <div>Hello from the saved content!</div>,
  * } );
  * ```
  *
@@ -372,7 +372,7 @@ function translateBlockSettingUsingI18nSchema(
  * registerBlockType( 'my-collection/block-name', {
  *     title: __( 'My First Block' ),
  *     edit: () => <div>{ __( 'Hello from the editor!' ) }</div>,
- *     save: () => <div>{ __( 'Hello from the saved content!' ) }</div>,
+ *     save: () => <div>'Hello from the saved content!</div>,
  * } );
  * ```
  */
@@ -653,6 +653,8 @@ export const hasChildBlocksWithInserterSupport = ( blockName ) => {
 /**
  * Registers a new block style variation for the given block.
  *
+ * For more information on connecting the styles with CSS [the official documentation](/docs/reference-guides/block-api/block-styles.md#styles)
+ *
  * @param {string} blockName      Name of block (example: “core/latest-posts”).
  * @param {Object} styleVariation Object containing `name` which is the class name applied to the block and `label` which identifies the variation to the user.
  *
@@ -661,6 +663,7 @@ export const hasChildBlocksWithInserterSupport = ( blockName ) => {
  * import { __ } from '@wordpress/i18n';
  * import { registerBlockStyle } from '@wordpress/blocks';
  * import { Button } from '@wordpress/components';
+ *
  *
  * const ExampleComponent = () => {
  *     return (
@@ -728,6 +731,8 @@ export const getBlockVariations = ( blockName, scope ) => {
 
 /**
  * Registers a new block variation for the given block type.
+ *
+ * For more information on block variations see [the official documentation ](/docs/reference-guides/block-api/block-variations.md)
  *
  * @param {string}           blockName Name of the block (example: “core/columns”).
  * @param {WPBlockVariation} variation Object describing a block variation.

--- a/packages/blocks/src/api/registration.js
+++ b/packages/blocks/src/api/registration.js
@@ -649,6 +649,28 @@ export const hasChildBlocksWithInserterSupport = ( blockName ) => {
  *
  * @param {string} blockName      Name of block (example: “core/latest-posts”).
  * @param {Object} styleVariation Object containing `name` which is the class name applied to the block and `label` which identifies the variation to the user.
+ *
+ * @example
+ * ```js
+ * import { __ } from '@wordpress/i18n';
+ * import { registerBlockStyle } from '@wordpress/blocks';
+ * import { Button } from '@wordpress/components';
+ *
+ * const ExampleComponent = () => {
+ *     return (
+ *         <Button
+ *             onClick={ () => {
+ *                 registerBlockStyle( 'core/quote', {
+ *                     name: 'fancy-quote',
+ *                     label: __( 'Fancy Quote' ),
+ *                 } );
+ *             } }
+ *         >
+ *             { __( 'Add a new block style for core/quote' ) }
+ *         </Button>
+ *     );
+ * };
+ * ```
  */
 export const registerBlockStyle = ( blockName, styleVariation ) => {
 	dispatch( blocksStore ).addBlockStyles( blockName, styleVariation );
@@ -659,6 +681,25 @@ export const registerBlockStyle = ( blockName, styleVariation ) => {
  *
  * @param {string} blockName          Name of block (example: “core/latest-posts”).
  * @param {string} styleVariationName Name of class applied to the block.
+ *
+ * @example
+ * ```js
+ * import { __ } from '@wordpress/i18n';
+ * import { unregisterBlockStyle } from '@wordpress/blocks';
+ * import { Button } from '@wordpress/components';
+ *
+ * const ExampleComponent = () => {
+ *     return (
+ *     <Button
+ *         onClick={ () => {
+ *             unregisterBlockStyle( 'core/quote', 'plain' );
+ *         } }
+ *     >
+ *         { __( 'Remove the "Plain" block style for core/quote' ) }
+ *     </Button>
+ *     );
+ * };
+ * ```
  */
 export const unregisterBlockStyle = ( blockName, styleVariationName ) => {
 	dispatch( blocksStore ).removeBlockStyles( blockName, styleVariationName );


### PR DESCRIPTION
## What?
Based on the discussion in https://github.com/WordPress/gutenberg/pull/42637#pullrequestreview-1051940588, this PR adds examples for the public API that is exposed for the `core/blocks` package. Part of the effort in #42125

## Why?
The actions that were documented originally [here](https://developer.wordpress.org/block-editor/reference-guides/data/data-core-blocks/), have been marked as `@ignore` to discourage their use in favor of the public API available [here](https://developer.wordpress.org/block-editor/reference-guides/packages/packages-blocks/). We still need examples for these functions.
