### PR TITLE
[Site Editor] Archive-PostType template UI

### DIFF
--- a/lib/compat/wordpress-6.1/rest-api.php
+++ b/lib/compat/wordpress-6.1/rest-api.php
@@ -61,3 +61,35 @@ function gutenberg_add_site_icon_url_to_index( WP_REST_Response $response ) {
 	return $response;
 }
 add_action( 'rest_index', 'gutenberg_add_site_icon_url_to_index' );
+
+/**
+ * Returns the has_archive post type field.
+ *
+ * @param array  $type       The response data.
+ * @param string $field_name The field name. The function handles field has_archive.
+ */
+function gutenberg_get_post_type_has_archive_field( $type, $field_name ) {
+	if ( ! empty( $type ) && ! empty( $type['slug'] ) && 'has_archive' === $field_name ) {
+		$post_type_object = get_post_type_object( $type['slug'] );
+		return $post_type_object->has_archive;
+	}
+}
+
+/**
+ * Registers the has_archive post type REST API field.
+ */
+function gutenberg_register_has_archive_on_post_types_endpoint() {
+	register_rest_field(
+		'type',
+		'has_archive',
+		array(
+			'get_callback' => 'gutenberg_get_post_type_has_archive_field',
+			'schema'       => array(
+				'description' => __( 'If the value is a string, the value will be used as the archive slug. If the value is false the post type has no archive.', 'gutenberg' ),
+				'type'        => array( 'string', 'boolean' ),
+				'context'     => array( 'view', 'edit' ),
+			),
+		)
+	);
+}
+add_action( 'rest_api_init', 'gutenberg_register_has_archive_on_post_types_endpoint' );

--- a/packages/edit-site/src/components/add-new-template/new-template.js
+++ b/packages/edit-site/src/components/add-new-template/new-template.js
@@ -41,6 +41,7 @@ import {
 	useTaxonomiesMenuItems,
 	usePostTypeMenuItems,
 	useAuthorMenuItem,
+	usePostTypeArchiveMenuItems,
 } from './utils';
 import AddCustomGenericTemplateModal from './add-custom-generic-template-modal';
 import { useHistory } from '../routes';
@@ -301,6 +302,7 @@ function useMissingTemplates(
 	} );
 	const missingTemplates = [
 		...enhancedMissingDefaultTemplateTypes,
+		...usePostTypeArchiveMenuItems(),
 		...postTypesMenuItems,
 		...taxonomiesMenuItems,
 	];


### PR DESCRIPTION
This PR adds an option to create an archive-posttype template on the site editor UI.
It uses the same UI as Single Posts and Taxonomies.

Part of: https://github.com/WordPress/gutenberg/issues/37407

## Testing Instructions
I verified I could create archive templates for posts and pages, and the UI shown below appears on the add new template menu.

![image](https://user-images.githubusercontent.com/11271197/181343936-a12f5503-da40-4183-aec4-b144ad16f7fd.png)

