### PR TITLE
Theme JSON: Allow caching of different types of theme.json files at different levels of the class

### DIFF
--- a/lib/experimental/class-wp-theme-json-resolver-gutenberg.php
+++ b/lib/experimental/class-wp-theme-json-resolver-gutenberg.php
@@ -17,6 +17,18 @@
  */
 class WP_Theme_JSON_Resolver_Gutenberg extends WP_Theme_JSON_Resolver_6_1 {
 	/**
+	 * Container for data coming from the theme.
+	 *
+	 * This needs to be defined on the Gutenberg version of this file
+	 * otherwise calls to the core version of this file end up caching
+	 * an old version of the theme.json.
+	 *
+	 * @since 5.8.0
+	 * @var WP_Theme_JSON
+	 */
+	protected static $theme = null;
+
+	/**
 	 * Returns the theme's data.
 	 *
 	 * Data from theme.json will be backfilled from existing


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
When a core function calls `get_theme_data` it saves a version of the the theme data on the parent class (WP_Theme_JSON_Resolver). Then when a Gutenberg function tries to overload theme data by adding new properties (for example fluid typography) the version of the theme.json data from core is used, which filters out these new properties.

This PR adds $theme as a static variable on the `WP_Theme_JSON_Resolver_Gutenberg` class, so that it has its own version of the cached data, rather than using cores.

## Why?
This came up in https://github.com/WordPress/gutenberg/pull/42454, which calls `get_block_templates` which is a core function that calls `get_theme_data` internally. That was forcing Gutenberg to use the old version of theme.json, so newer features were broken.

## How?
We define the static `$theme` variable on the `WP_Theme_JSON_Resolver_Gutenberg` class.

## Testing Instructions
- Using trunk try adding fluid typography to your theme.json (settings > typography > fluid: true).
- Notice that your typography isn't fluid
- Switch to this branch
- Notice that you now have fluid typography

@WordPress/block-themers 