### PR TITLE
Disabled blocks passed to BlockTypesList are no longer draggable

### DIFF
--- a/packages/block-editor/src/components/block-types-list/index.js
+++ b/packages/block-editor/src/components/block-types-list/index.js
@@ -41,7 +41,7 @@ function BlockTypesList( {
 							) }
 							onSelect={ onSelect }
 							onHover={ onHover }
-							isDraggable={ isDraggable }
+							isDraggable={ isDraggable && !item.isDisabled }
 							isFirst={ i === 0 && j === 0 }
 						/>
 					) ) }

--- a/packages/block-editor/src/components/block-types-list/index.js
+++ b/packages/block-editor/src/components/block-types-list/index.js
@@ -41,7 +41,7 @@ function BlockTypesList( {
 							) }
 							onSelect={ onSelect }
 							onHover={ onHover }
-							isDraggable={ isDraggable && !item.isDisabled }
+							isDraggable={ isDraggable && ! item.isDisabled }
 							isFirst={ i === 0 && j === 0 }
 						/>
 					) ) }


### PR DESCRIPTION
Resolves #42749

Related https://github.com/impress-org/givewp-next-gen/pull/44

<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

This PR prevents disabled items in the `BlockTypesList` from being draggable.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

Items that are disabled should not be draggable.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

This PR accounts for an item's `isDisabled` property value when assigning `isDraggable` to the corresponding `InserterListItem`.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->

1. Create an item object for consumption by the `BlockTypesList`
2. Set `isDisabled` on that object to `true`.
3. Pass the item in an array to the `BlockTypesList` component.
4. The rendered item should not be draggable.

## Screenshots or screencast <!-- if applicable -->

### Before
![Peek 2022-07-27 16-21](https://user-images.githubusercontent.com/10858303/181365162-1e46617e-310f-4736-b33b-8f22fdb8ad7d.gif)

### After
![Peek 2022-07-27 16-22](https://user-images.githubusercontent.com/10858303/181365175-cb1e035a-ca32-4f0f-86cf-188f9fdf9a0d.gif)
