### PR TITLE
ComboboxControl: add support for uncontrolled mode

### DIFF
--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -40,6 +40,7 @@
 -   `RadioControl`: Refactor away from `_.isEmpty()` ([#42468](https://github.com/WordPress/gutenberg/pull/42468)).
 -   `SelectControl`: Refactor away from `_.isEmpty()` ([#42468](https://github.com/WordPress/gutenberg/pull/42468)).
 -   `ComboboxControl`: Replace `keyboardEvent.keyCode` with `keyboardEvent.code`([#42569](https://github.com/WordPress/gutenberg/pull/42569)).
+-   `ComboboxControl`: Add support for uncontrolled mode ([#42752](https://github.com/WordPress/gutenberg/pull/42752)).
 
 ## 19.15.0 (2022-07-13)
 

--- a/packages/components/src/combobox-control/index.js
+++ b/packages/components/src/combobox-control/index.js
@@ -29,6 +29,7 @@ import BaseControl from '../base-control';
 import Button from '../button';
 import { FlexBlock, FlexItem } from '../flex';
 import withFocusOutside from '../higher-order/with-focus-outside';
+import { useControlledValue } from '../utils/hooks';
 
 const noop = () => {};
 
@@ -46,10 +47,10 @@ const DetectOutside = withFocusOutside(
 
 function ComboboxControl( {
 	__next36pxDefaultSize,
-	value,
+	value: valueProp,
 	label,
 	options,
-	onChange,
+	onChange: onChangeProp,
 	onFilterValueChange = noop,
 	hideLabelFromVision,
 	help,
@@ -59,6 +60,11 @@ function ComboboxControl( {
 		selected: __( 'Item selected.' ),
 	},
 } ) {
+	const [ value, setValue ] = useControlledValue( {
+		value: valueProp,
+		onChange: onChangeProp,
+	} );
+
 	const currentOption = options.find( ( option ) => option.value === value );
 	const currentLabel = currentOption?.label ?? '';
 	// Use a custom prefix when generating the `instanceId` to avoid having
@@ -92,7 +98,7 @@ function ComboboxControl( {
 	}, [ inputValue, options, value ] );
 
 	const onSuggestionSelected = ( newSelectedSuggestion ) => {
-		onChange( newSelectedSuggestion.value );
+		setValue( newSelectedSuggestion.value );
 		speak( messages.selected, 'assertive' );
 		setSelectedSuggestion( newSelectedSuggestion );
 		setInputValue( '' );
@@ -172,7 +178,7 @@ function ComboboxControl( {
 	};
 
 	const handleOnReset = () => {
-		onChange( null );
+		setValue( null );
 		inputContainer.current.focus();
 	};
 


### PR DESCRIPTION
## What?
Related: https://github.com/WordPress/gutenberg/pull/42403

Add the ability to implement `ComboboxControl` as an uncontrolled component

## Why?
While working on the above PR, @ciampo and I noticed that `ComboboxControl` doesn't currently work as an uncontrolled component. When no `value` prop is defined, there's nothing to pass to the `input` element's value attribute, so it ends up being undefined.

## How?
The wizardry of the `useControlledValue()` hook allows us to use a passed in value prop when the component is controlled, but fall back to managing this state internally in the absence of a prop.

## Testing Instructions
After applying this patch, add the following test snippet to the end of `packages/components/src/combobox-control/stories/index.js`:

```
function UncontrolledTest( args ) {
	return (
		<>
			<ComboboxControl
				{ ...args }
				onChange={ ( value ) => console.log( value ) }
				label="Select a country"
				options={ countryOptions }
			/>
		</>
	);
}
export const uncontrolledTest = UncontrolledTest.bind( {} );
uncontrolledTest.args = {};
```

This will add an _Uncontrolled Test_ story in Storybook. Launch Storybook locally and unsure that story works as expected. In the console, confirm that the abbreviation for the selected country is logged when you select it (this confirms the `onChange` function is being called).