### PR TITLE
BorderControl: Add box sizing reset

### DIFF
--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 ## Unreleased
 
+### Bug Fix
+
+-   `BorderControl`: Ensure box-sizing is reset for the control ([#42754](https://github.com/WordPress/gutenberg/pull/42754)).
+
+### Enhancements
+
+-   Add `box-sizing` reset style mixin to utils ([#42754](https://github.com/WordPress/gutenberg/pull/42754)).
+
 ## 19.16.0 (2022-07-27)
 
 ### Bug Fix

--- a/packages/components/src/border-control/styles.ts
+++ b/packages/components/src/border-control/styles.ts
@@ -6,7 +6,7 @@ import { css } from '@emotion/react';
 /**
  * Internal dependencies
  */
-import { COLORS, CONFIG, rtl } from '../utils';
+import { COLORS, CONFIG, boxSizingReset, rtl } from '../utils';
 import { space } from '../ui/utils/space';
 import {
 	StyledField,
@@ -31,6 +31,7 @@ export const borderControl = css`
 	border: 0;
 	padding: 0;
 	margin: 0;
+	${ boxSizingReset }
 `;
 
 export const innerWrapper = () => css`

--- a/packages/components/src/utils/box-sizing.ts
+++ b/packages/components/src/utils/box-sizing.ts
@@ -1,0 +1,14 @@
+/**
+ * External dependencies
+ */
+import { css } from '@emotion/react';
+
+export const boxSizingReset = css`
+	box-sizing: border-box;
+
+	*,
+	*::before,
+	*::after {
+		box-sizing: inherit;
+	}
+`;

--- a/packages/components/src/utils/style-mixins.js
+++ b/packages/components/src/utils/style-mixins.js
@@ -1,3 +1,4 @@
+export { boxSizingReset } from './box-sizing';
 export { rgba } from './colors';
 export { reduceMotion } from './reduce-motion';
 export { rtl } from './rtl';


### PR DESCRIPTION
Related:
- https://github.com/WordPress/gutenberg/issues/42415
- https://github.com/WordPress/gutenberg/pull/42747

## What?

- Adds a `boxSizingReset` style to be used as a "mixin" for Emotion css/styled-components.
- Uses the new `boxSizingReset` to reset the `BorderControl`s box-sizing

**Note: There's every chance that there's a better approach to a box sizing reset, so I'm happy to abandon this if desired.**

## Why?
- Makes the border control's styling self-sufficient

## How?

- Creates a new Emotion CSS style: `boxSizingReset` 
- Exports the style via the component packages `utils`/`style-mixins`
- Adds the box-sizing reset to the `BorderControl`'s root style.

## Testing Instructions
1. Checkout https://github.com/WordPress/gutenberg/commit/a43e996b059a787e8f73af2a8f4eec3273828dbb from this PR (i.e. BorderControl doesn't reset box-sizing)
2. Confirm in storybook the `BorderControl` and `BorderBoxControl`'s color indicator is broken
3. Checkout the latest commit on this branch and confirm in storybook that the color indicator displays correctly

## Screenshots or screencast <!-- if applicable -->

| Before | After |
|---|---|
| <img width="290" alt="Screen Shot 2022-07-28 at 12 47 06 pm" src="https://user-images.githubusercontent.com/60436221/181411764-7ea1d66b-8420-4715-980d-09da8893692f.png"> | <img width="293" alt="Screen Shot 2022-07-28 at 12 47 41 pm" src="https://user-images.githubusercontent.com/60436221/181411782-0660aa67-c804-4ade-b4a4-d4905d03197b.png"> |
 