### PR TITLE
Theme JSON Resolver: Update cache check to also check that the object is an instance of the Gutenberg version

### DIFF
--- a/lib/experimental/class-wp-theme-json-resolver-gutenberg.php
+++ b/lib/experimental/class-wp-theme-json-resolver-gutenberg.php
@@ -33,6 +33,7 @@ class WP_Theme_JSON_Resolver_Gutenberg extends WP_Theme_JSON_Resolver_6_1 {
 			_deprecated_argument( __METHOD__, '5.9' );
 		}
 
+		// When backporting to core, remove the instanceof Gutenberg class check, as it is only required for the Gutenberg plugin.
 		if ( null === static::$theme || ! static::$theme instanceof WP_Theme_JSON_Gutenberg ) {
 			$theme_json_data = static::read_json_file( static::get_file_path_from_theme( 'theme.json' ) );
 			$theme_json_data = static::translate( $theme_json_data, wp_get_theme()->get( 'TextDomain' ) );

--- a/lib/experimental/class-wp-theme-json-resolver-gutenberg.php
+++ b/lib/experimental/class-wp-theme-json-resolver-gutenberg.php
@@ -33,7 +33,7 @@ class WP_Theme_JSON_Resolver_Gutenberg extends WP_Theme_JSON_Resolver_6_1 {
 			_deprecated_argument( __METHOD__, '5.9' );
 		}
 
-		if ( null === static::$theme ) {
+		if ( null === static::$theme || ! static::$theme instanceof WP_Theme_JSON_Gutenberg ) {
 			$theme_json_data = static::read_json_file( static::get_file_path_from_theme( 'theme.json' ) );
 			$theme_json_data = static::translate( $theme_json_data, wp_get_theme()->get( 'TextDomain' ) );
 			$theme_json_data = gutenberg_add_registered_webfonts_to_theme_json( $theme_json_data );


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Alternative to #42748 to fix the issue of the Theme JSON data being cached from the core version of the resolver class. This issue prevents features that have not yet landed in core, such as fluid typography and blockGap at the theme.json level, from functioning.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

As in #42748 the issue appears to be that by the time the sub-classed Gutenberg version of the Resolver class runs, the core version of the Resolver has already cached the theme data.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

Where #42748 attempted to deal with the problem by adding another static `$theme` variable, this PR updates the cache check so that if doesn't just check whether the `$theme` variable is `null`, but it also checks whether or not it's an instance of the `WP_Theme_JSON_Gutenberg` class, which should help ensure that the cache is invalidated when we expect it to be. Kudos @talldan for the idea, and @scruffian for identifying the original issue.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->

In a blocks-based theme, test that experimental features that have not yet landed in core, work as expected. For example fluid typography, and blockGap at the individual block level in `theme.json`. For an example of the latter, update your `theme.json` file to include the following (ensuring that you're running a theme like TwentyTwentyTwo that sets `settings.spacing.blockGap` to `true` or opts-in to `appearanceTools`):

```
	"styles": {
		"blocks": {
			"core/buttons": {
				"spacing": {
					"blockGap": {
						"top": "3px",
						"left": "15px"
					}
				}
			},
```

Add some blocks to a post or page, and publish it. On the front-end of your site, you should see the spacing takes effect.

## Screenshots or screencast <!-- if applicable -->

| Before (even though spacing is set at the block level, the styles are not output | After (spacing is output correctly) |
| --- | --- |
| ![image](https://user-images.githubusercontent.com/14988353/181422435-e115e9ca-ceda-428e-8a0b-138797ce263b.png) | ![image](https://user-images.githubusercontent.com/14988353/181422450-d8fcaf5d-122b-4818-a61b-2d03625f4a5f.png) |