### PR TITLE
Typography: add explicit bypass for fluid font size calculation

### DIFF
--- a/lib/block-supports/typography.php
+++ b/lib/block-supports/typography.php
@@ -378,6 +378,7 @@ function gutenberg_get_typography_font_size_value( $preset, $should_use_fluid_ty
 	// Font sizes.
 	$fluid_font_size_settings = isset( $preset['fluid'] ) ? $preset['fluid'] : null;
 
+	// A font size has explicitly bypassed fluid calculations.
 	if ( false === $fluid_font_size_settings ) {
 		return $preset['size'];
 	}

--- a/lib/block-supports/typography.php
+++ b/lib/block-supports/typography.php
@@ -378,6 +378,10 @@ function gutenberg_get_typography_font_size_value( $preset, $should_use_fluid_ty
 	// Font sizes.
 	$fluid_font_size_settings = isset( $preset['fluid'] ) ? $preset['fluid'] : null;
 
+	if ( false === $fluid_font_size_settings ) {
+		return $preset['size'];
+	}
+
 	// Try to grab explicit min and max fluid font sizes.
 	$minimum_font_size_raw = isset( $fluid_font_size_settings['min'] ) ? $fluid_font_size_settings['min'] : null;
 	$maximum_font_size_raw = isset( $fluid_font_size_settings['max'] ) ? $fluid_font_size_settings['max'] : null;

--- a/packages/edit-site/src/components/global-styles/test/typography-utils.js
+++ b/packages/edit-site/src/components/global-styles/test/typography-utils.js
@@ -15,6 +15,17 @@ describe( 'typography utils', () => {
 					typographySettings: undefined,
 					expected: '28px',
 				},
+				// Should return non-fluid value when fluid is `false`.
+				{
+					preset: {
+						size: '28px',
+						fluid: false,
+					},
+					typographySettings: {
+						fluid: true,
+					},
+					expected: '28px',
+				},
 				// Should return fluid value.
 				{
 					preset: {
@@ -38,6 +49,20 @@ describe( 'typography utils', () => {
 					expected:
 						'clamp(21px, 1.3125rem + ((1vw - 7.68px) * 2.524), 42px)',
 				},
+
+				// Should return default fluid values with null values.
+				{
+					preset: {
+						size: '28px',
+						fluid: null,
+					},
+					typographySettings: {
+						fluid: true,
+					},
+					expected:
+						'clamp(21px, 1.3125rem + ((1vw - 7.68px) * 2.524), 42px)',
+				},
+
 				// Should return size with invalid fluid units.
 				{
 					preset: {

--- a/packages/edit-site/src/components/global-styles/typography-utils.js
+++ b/packages/edit-site/src/components/global-styles/typography-utils.js
@@ -35,6 +35,11 @@ export function getTypographyFontSizeValue( preset, typographySettings ) {
 	const DEFAULT_SCALE_FACTOR = 1;
 
 	// Font sizes.
+	// A font size has explicitly bypassed fluid calculations.
+	if ( false === preset?.fluid ) {
+		return defaultSize;
+	}
+
 	const fluidFontSizeSettings = preset?.fluid || {};
 
 	// Try to grab explicit min and max fluid font sizes.

--- a/phpunit/block-supports/typography-test.php
+++ b/phpunit/block-supports/typography-test.php
@@ -226,7 +226,7 @@ class WP_Block_Supports_Typography_Test extends WP_UnitTestCase {
 	 */
 	public function data_generate_font_size_preset_fixtures() {
 		return array(
-			'default_return_value'                 => array(
+			'default_return_value'                        => array(
 				'font_size_preset'            => array(
 					'size' => '28px',
 				),
@@ -234,7 +234,16 @@ class WP_Block_Supports_Typography_Test extends WP_UnitTestCase {
 				'expected_output'             => '28px',
 			),
 
-			'return_fluid_value'                   => array(
+			'default_return_value_when_fluid_is_false'    => array(
+				'font_size_preset'            => array(
+					'size'  => '28px',
+					'fluid' => false,
+				),
+				'should_use_fluid_typography' => true,
+				'expected_output'             => '28px',
+			),
+
+			'return_fluid_value'                          => array(
 				'font_size_preset'            => array(
 					'size' => '1.75rem',
 				),
@@ -251,7 +260,16 @@ class WP_Block_Supports_Typography_Test extends WP_UnitTestCase {
 				'expected_output'             => 'clamp(21px, 1.3125rem + ((1vw - 7.68px) * 2.524), 42px)',
 			),
 
-			'return_size_with_invalid_fluid_units' => array(
+			'return_default_fluid_values_with_null_value' => array(
+				'font_size_preset'            => array(
+					'size'  => '28px',
+					'fluid' => null,
+				),
+				'should_use_fluid_typography' => true,
+				'expected_output'             => 'clamp(21px, 1.3125rem + ((1vw - 7.68px) * 2.524), 42px)',
+			),
+
+			'return_size_with_invalid_fluid_units'        => array(
 				'font_size_preset'            => array(
 					'size'  => '10em',
 					'fluid' => array(
@@ -263,7 +281,7 @@ class WP_Block_Supports_Typography_Test extends WP_UnitTestCase {
 				'expected_output'             => '10em',
 			),
 
-			'return_fluid_clamp_value'             => array(
+			'return_fluid_clamp_value'                    => array(
 				'font_size_preset'            => array(
 					'size'  => '28px',
 					'fluid' => array(

--- a/schemas/json/theme.json
+++ b/schemas/json/theme.json
@@ -364,7 +364,8 @@
 										"type": "string"
 									},
 									"fluid": {
-										"type": "object",
+										"description": "Specifics the minimum and maximum font size value of a fluid font size. Set to `false` to bypass fluid calculations and use the static `size` value.",
+										"type": [ "object", "boolean" ],
 										"properties": {
 											"min": {
 												"description": "A min font size for fluid font size calculations in px, rem or em.",


### PR DESCRIPTION
Resolves https://github.com/WordPress/gutenberg/issues/42698

Related to:

- https://github.com/WordPress/gutenberg/pull/39529

## What?
Allowing for an explicit `false` value in the fluid font size property to bypass fluid calculations for a specific font.

## Why?
So that theme authors can select which font sizes receive fluid treatment when `settings.typography.fluid` is set to `true`.

## How?
Checking for `"fluid" === false` before performing fluid font size calculations and, if found, returning the static font size.

## Testing Instructions

Enable fluid typography. 

Add some font sizes to your theme.json (see example theme.json below)

For one or two sizes, set `fluid` to `false`. E.g., 

```json
				{
					"size": "2.25rem",
					"fluid": false,
					"slug": "x-large",
					"name": "Extra large"
				},
```

Add some text to a post and set your font sizes (see example HTML below)

For all sizes with `"fluid": false,`, the font size should be static and reflect the size value regardless of viewport width.

Here, the `Extra large` heading is static:

![2022-07-28 15 11 13](https://user-images.githubusercontent.com/6458278/181425584-d16f3f87-0b0f-438e-8e95-e3cf3f8c4f26.gif)


<details>

<summary>Example HTML block code</summary>

```html

<!-- wp:paragraph {"fontSize":"colossal"} -->
<p class="has-colossal-font-size">Heading 1 - Colossal</p>
<!-- /wp:paragraph -->

<!-- wp:paragraph {"fontSize":"gigantic"} -->
<p class="has-gigantic-font-size">Heading 2 - Gigantic</p>
<!-- /wp:paragraph -->

<!-- wp:paragraph {"fontSize":"huge"} -->
<p class="has-huge-font-size">Heading 3 - Huge</p>
<!-- /wp:paragraph -->

<!-- wp:paragraph {"fontSize":"x-large"} -->
<p class="has-x-large-font-size">Heading 4 - Extra large</p>
<!-- /wp:paragraph -->

<!-- wp:paragraph {"fontSize":"large"} -->
<p class="has-large-font-size">Heading 5 - Large</p>
<!-- /wp:paragraph -->

<!-- wp:paragraph {"fontSize":"medium"} -->
<p class="has-medium-font-size">Heading 6 - Medium</p>
<!-- /wp:paragraph -->

<!-- wp:paragraph -->
<p>Paragraph text Paragraph text Paragraph text Paragraph text Paragraph text Paragraph text Paragraph text Paragraph text Paragraph text Paragraph text Paragraph text Paragraph text Paragraph text Paragraph text Paragraph text Paragraph text Paragraph text Paragraph text Paragraph text Paragraph text Paragraph text </p>
<!-- /wp:paragraph -->

<!-- wp:list -->
<ul><li>List text - small</li><li>List text - small</li><li>List text - small</li><li>List text - small</li><li>List text - small</li></ul>
<!-- /wp:list -->

<!-- wp:cover {"customOverlayColor":"#ff7b00","isDark":false} -->
<div class="wp-block-cover is-light"><span aria-hidden="true" class="wp-block-cover__background has-background-dim-100 has-background-dim" style="background-color:#ff7b00"></span><div class="wp-block-cover__inner-container"><!-- wp:paragraph {"align":"center","placeholder":"Write title…","fontSize":"colossal"} -->
<p class="has-text-align-center has-colossal-font-size">Cover block - Colossal</p>
<!-- /wp:paragraph --></div></div>
<!-- /wp:cover -->
```

</details>

<details>

<summary>Example theme.json</summary>

```json
{
	"version": 2,
	"settings": {
		"appearanceTools": true,
		"layout": {
			"contentSize": "840px",
			"wideSize": "1100px"
		},
		"typography": {
			"fluid": true,
			"fontSizes": [
				{
					"size": ".9rem",
					"fluid": {
						"min": "0.9rem",
						"max": "1.1"
					},
					"slug": "small",
					"name": "Small"
				},
				{
					"size": "1rem",
					"fluid": {
						"min": "1rem",
						"max": "1.3rem"
					},
					"slug": "medium",
					"name": "Medium"
				},
				{
					"size": "1.75rem",
					"slug": "large",
					"name": "Large"
				},
				{
					"size": "2.25rem",
					"fluid": false,
					"slug": "x-large",
					"name": "Extra large"
				},
				{
					"size": "3.5rem",
					"slug": "huge",
					"name": "Huge"
				},
				{
					"size": "4.25rem",
					"slug": "gigantic",
					"name": "Gigantic"
				},
				{
					"size": "5.75rem",
					"slug": "colossal",
					"name": "Colossal"
				}
			]
		}
	}
}
```

</details>

Check that things work in the site editor too (See https://github.com/WordPress/gutenberg/pull/42688)

### Unit tests
```
npm run test-unit packages/edit-site/src/components/global-styles/test/typography-utils.js                                                                       
```

```
npm run test-unit-php /var/www/html/wp-content/plugins/gutenberg/phpunit/block-supports/typography-test.php
```