### PR TITLE
Query Pagination: Correctly position the  "next" link on the first page.

### DIFF
--- a/packages/block-library/src/query-pagination/style.scss
+++ b/packages/block-library/src/query-pagination/style.scss
@@ -17,11 +17,13 @@ $pagination-margin: 0.5em;
 	// This moves the next link to the right side of the container,
 	// which is important when it's the only block displayed
 	// and the block has a "space-between" justification.
-	&.is-content-justification-space-between > .wp-block-query-pagination-next {
-		margin-inline-start: auto;
-	}
-	&.is-content-justification-space-between > .wp-block-query-pagination-previous {
-		margin-inline-end: auto;
+	&.is-content-justification-space-between {
+		> .wp-block-query-pagination-next:last-child {
+			margin-inline-start: auto;
+		}
+		> .wp-block-query-pagination-previous:first-child {
+			margin-inline-end: auto;
+		}
 	}
 
 

--- a/packages/block-library/src/query-pagination/style.scss
+++ b/packages/block-library/src/query-pagination/style.scss
@@ -20,6 +20,10 @@ $pagination-margin: 0.5em;
 	&.is-content-justification-space-between > .wp-block-query-pagination-next {
 		margin-inline-start: auto;
 	}
+	&.is-content-justification-space-between > .wp-block-query-pagination-previous {
+		margin-inline-end: auto;
+	}
+
 
 	.wp-block-query-pagination-previous-arrow {
 		margin-right: 1ch;

--- a/packages/block-library/src/query-pagination/style.scss
+++ b/packages/block-library/src/query-pagination/style.scss
@@ -18,7 +18,7 @@ $pagination-margin: 0.5em;
 	// which is important when it's the only block displayed
 	// and the block has a "space-between" justification.
 	&.is-content-justification-space-between > .wp-block-query-pagination-next {
-		margin-left: auto;
+		margin-inline-start: auto;
 	}
 
 	.wp-block-query-pagination-previous-arrow {

--- a/packages/block-library/src/query-pagination/style.scss
+++ b/packages/block-library/src/query-pagination/style.scss
@@ -13,6 +13,10 @@ $pagination-margin: 0.5em;
 			margin-right: 0;
 		}
 	}
+	&.is-content-justification-space-between > .wp-block-query-pagination-next {
+		margin-left: auto;
+	}
+
 	.wp-block-query-pagination-previous-arrow {
 		margin-right: 1ch;
 		display: inline-block; // Needed so that the transform works.

--- a/packages/block-library/src/query-pagination/style.scss
+++ b/packages/block-library/src/query-pagination/style.scss
@@ -13,6 +13,10 @@ $pagination-margin: 0.5em;
 			margin-right: 0;
 		}
 	}
+
+	// This moves the next link to the right side of the container,
+	// which is important when it's the only block displayed
+	// and the block has a "space-between" justification.
 	&.is-content-justification-space-between > .wp-block-query-pagination-next {
 		margin-left: auto;
 	}


### PR DESCRIPTION
## What?
This is an alternative to https://github.com/WordPress/gutenberg/pull/40553, and https://github.com/WordPress/gutenberg/pull/36681 and fixes https://github.com/WordPress/gutenberg/issues/34997.

The solution here only covers one case, which is:
- Using the Pagination block
- With the space between setting selected
- And with the page numbers block removed

In this scenario, the next page link is aligned to the left, which is not good UX:
<img width="693" alt="Screenshot 2022-07-28 at 08 55 14" src="https://user-images.githubusercontent.com/275961/181452464-6f4d1abb-4ac2-405d-b6de-c87e0d6efcc3.png">

## How?
This PR just adds a `margin-inline-start: auto` to the next link in this scenario, so that it moves to the right, like so:
<img width="672" alt="Screenshot 2022-07-28 at 08 55 54" src="https://user-images.githubusercontent.com/275961/181452729-dd624639-56da-4af9-af39-7c388218d85b.png">

This covers the main use case of this block.

## Testing Instructions
- Switch to a theme that uses the pagination block without page numbers, and a "space between" alignment (e.g. Rainfall)
- Confirm that on the first page the "Next" link is on the right of the column
- Check that this doesn't break any other situations

@WordPress/block-themers 

