### PR TITLE
Add border controls to featured image

### DIFF
--- a/packages/block-library/src/post-featured-image/block.json
+++ b/packages/block-library/src/post-featured-image/block.json
@@ -37,6 +37,12 @@
 		"spacing": {
 			"margin": true,
 			"padding": true
+		},
+		"__experimentalBorder": {
+			"color": true,
+			"radius": true,
+			"style": true,
+			"width": true
 		}
 	},
 	"editorStyle": "wp-block-post-featured-image-editor",


### PR DESCRIPTION
This PR makes it possible to add borders and border-radii to the featured image block:

<img width="1030" alt="Screenshot 2022-07-28 at 10 13 37" src="https://user-images.githubusercontent.com/846565/181468898-93112281-b289-464a-81ee-49d226c07a22.png">

There is a quirk with this (most basic) implementation. The radius is applied to the `figure`, and so the `img` doesn't receive the properties. This feels a bit unexpected when you visit the frontend and see this:

<img width="846" alt="Screenshot 2022-07-28 at 10 11 44" src="https://user-images.githubusercontent.com/846565/181469132-b960d1e0-f03c-453e-9929-b00fb9a4c7aa.png">

Note how the image corners are overlapping the border.

Despite the fact this is working as intended, we may want to consider adding `overflow: hidden` to any block that also has a border radius, to ensure that its contents respect that radius. E.g.:

<img width="1324" alt="Screenshot 2022-07-28 at 10 18 43" src="https://user-images.githubusercontent.com/846565/181470024-a0780e00-d707-49a1-88bd-7a972bd4769d.png">
