### PR TITLE
Separator: Fix block CSS classes in the editor

### DIFF
--- a/packages/block-library/src/separator/edit.js
+++ b/packages/block-library/src/separator/edit.js
@@ -37,7 +37,7 @@ export default function SeparatorEdit( { attributes, setAttributes } ) {
 			'has-css-opacity': opacity === 'css',
 			'has-alpha-channel-opacity': opacity === 'alpha-channel',
 		},
-		colorProps.classname
+		colorProps.className
 	);
 
 	const styles = {

--- a/packages/block-library/src/separator/test/edit.js
+++ b/packages/block-library/src/separator/test/edit.js
@@ -66,7 +66,8 @@ describe( 'Separator block edit method', () => {
 		expect( useBlockProps ).toHaveBeenCalledWith( {
 			// For backwards compatibility the has-text-color class is also added even though it is only needed for
 			// is-style-dots as this class was always added to v1 blocks, so may be expected by themes and plugins.
-			className: 'has-text-color has-alpha-channel-opacity',
+			className:
+				'has-text-color has-alpha-channel-opacity has-background',
 			style: {
 				backgroundColor: '#ff0000',
 				color: '#ff0000',
@@ -85,7 +86,8 @@ describe( 'Separator block edit method', () => {
 		};
 		render( <SeparatorEdit { ...props } /> );
 		expect( useBlockProps ).toHaveBeenCalledWith( {
-			className: 'has-text-color has-alpha-channel-opacity',
+			className:
+				'has-text-color has-alpha-channel-opacity has-background',
 			style: {
 				backgroundColor: '#ff0000',
 				color: '#ff0000',
@@ -106,7 +108,7 @@ describe( 'Separator block edit method', () => {
 		// background color classes are added by useBlockProps which has to be mocked.
 		expect( useBlockProps ).toHaveBeenCalledWith( {
 			className:
-				'has-text-color has-banana-color has-alpha-channel-opacity',
+				'has-text-color has-banana-color has-alpha-channel-opacity has-banana-background-color has-background',
 			style: undefined,
 		} );
 	} );


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->
Partial for [#41194](https://github.com/WordPress/gutenberg/issues/41194)

Fixes a typo (?) in the `SeparatorEdit` function where `classname` was used instead of `className`.
The problem lead to missing CSS class names, which meant that the separator block did not show the correct colors in the editor.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
The separator block did not show the correct colors in the editor.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
Fixes the typo so that the correct classes are output for the block, depending on the selected color.

Before:
`block-editor-block-list__block wp-block has-alpha-channel-opacity is-selected wp-block-separator`

After:
`block-editor-block-list__block wp-block has-alpha-channel-opacity has-purple-to-red-gradient-background has-background wp-block-separator`

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->

Please test with your chosen theme, classic or FSE, which has support for gradients, and with Twenty Twenty-One.

1. Add a few separator blocks of each variation, in either editor:
Each variation should have one each of the color options: a color from the palette, a custom color using the color picker, and a gradient.
2. Confirm if the color shows correctly in the editor and front: **With the exception of the gradient color for the dots, which is not adressed in this PR.**

## Screenshots or screencast <!-- if applicable -->
Before, the selected color was not visible.
![the selected separator does not show the selected color, event though a pale pink gradient is selected](https://user-images.githubusercontent.com/7422055/181472436-144b31c1-7258-490e-8255-808740ad81ca.png)

After: It is still difficult to see the color when the block is selected, but it is used:
![The gradient that is selected for the block is used](https://user-images.githubusercontent.com/7422055/181473139-a5841375-1d81-497b-8e2c-454c9dd8dda9.png)

