### PR TITLE
Theme JSON: Add a static $blocks_metadata data definition to the Gutenberg instance of WP_Theme_JSON

### DIFF
--- a/lib/compat/wordpress-6.1/class-wp-theme-json-6-1.php
+++ b/lib/compat/wordpress-6.1/class-wp-theme-json-6-1.php
@@ -15,7 +15,6 @@
  * @access private
  */
 class WP_Theme_JSON_6_1 extends WP_Theme_JSON_6_0 {
-
 	/**
 	 * Define which defines which pseudo selectors are enabled for
 	 * which elements.

--- a/lib/experimental/class-wp-theme-json-gutenberg.php
+++ b/lib/experimental/class-wp-theme-json-gutenberg.php
@@ -15,5 +15,17 @@
  * @access private
  */
 class WP_Theme_JSON_Gutenberg extends WP_Theme_JSON_6_1 {
-
+	/**
+	 * Holds block metadata extracted from block.json
+	 * to be shared among all instances so we don't
+	 * process it twice.
+	 *
+	 * It is necessary to redefine $blocks_metadata here so that it
+	 * doesn't get inherited from an earlier instantiation of the
+	 * parent class.
+	 *
+	 * @since 5.8.0
+	 * @var array
+	 */
+	protected static $blocks_metadata = null;
 }


### PR DESCRIPTION

## What?
Redeclares the static $blocks_metadata variable

## Why?
To ensure that the latest version of $blocks_metadata is used, not the old one from core.

## How?
By declaring `static $blocks_metadata` on the Gutenberg version of this class we ensure that Gutenberg version of the static variable is used when we create an instance of the class, rather than inheriting the one defined on the parent class in core, which has some differences.

## Testing Instructions
Look for this code in the frontend:
`.wp-block-navigation a{color: inherit;}`

With this PR you should see the updated element selector for this block:
`.wp-block-navigation a:where(:not(.wp-element-button)){color: inherit;}`

