### PR TITLE
Firefox: fix issue where it selects a nearby contentEditable

### DIFF
--- a/packages/rich-text/src/component/use-input-and-selection.js
+++ b/packages/rich-text/src/component/use-input-and-selection.js
@@ -140,6 +140,15 @@ export function useInputAndSelection( props ) {
 			// for the rich text instance that contains the start or end of the
 			// selection.
 			if ( ownerDocument.activeElement !== element ) {
+				// Only process if the active elment is contentEditable, either
+				// this rich text instance or the writing flow parent. Fixes a
+				// bug in Firefox where it strangely selects the closest
+				// contentEditable element, even though the click was outside
+				// any contentEditable element.
+				if ( ownerDocument.activeElement.contentEditable !== 'true' ) {
+					return;
+				}
+
 				if ( ! ownerDocument.activeElement.contains( element ) ) {
 					return;
 				}


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?

Fixes #42535.

## Why?
Bug fix.

## How?

See code comment.

## Testing Instructions
See issue.

## Screenshots or screencast <!-- if applicable -->
