### PR TITLE
[WIP] Use post_name for query instead of ID

### DIFF
--- a/lib/compat/wordpress-6.1/class-gutenberg-rest-navigation-controller.php
+++ b/lib/compat/wordpress-6.1/class-gutenberg-rest-navigation-controller.php
@@ -21,7 +21,7 @@ class Gutenberg_REST_Navigation_Controller extends WP_REST_Posts_Controller {
 
 		parent::register_routes();
 
-		// Lists/updates a single nav item based on the given id.
+		// Lists a single nav item based on the given id.
 		register_rest_route(
 			$this->namespace,
 			'/' . $this->rest_base . '/(?P<id>[\/\w-]+)',
@@ -32,7 +32,7 @@ class Gutenberg_REST_Navigation_Controller extends WP_REST_Posts_Controller {
 					'permission_callback' => array( $this, 'get_item_permissions_check' ),
 					'args'                => array(
 						'id' => array(
-							'description' => __( 'The id of a navigation', 'gutenberg' ),
+							'description' => __( 'The slug identifier for a avigation', 'gutenberg' ),
 							'type'        => 'string',
 						),
 					),

--- a/lib/compat/wordpress-6.1/class-gutenberg-rest-navigation-controller.php
+++ b/lib/compat/wordpress-6.1/class-gutenberg-rest-navigation-controller.php
@@ -1,0 +1,83 @@
+<?php
+/**
+ * REST API: Gutenberg_REST_Templates_Controller class
+ *
+ * @package    Gutenberg
+ * @subpackage REST_API
+ */
+
+/**
+ * Base Templates REST API Controller.
+ */
+class Gutenberg_REST_Navigation_Controller extends WP_REST_Posts_Controller {
+
+
+	/**
+	 * Registers the controllers routes.
+	 *
+	 * @return void
+	 */
+	public function register_routes() {
+
+		parent::register_routes();
+
+		// Lists/updates a single nav item based on the given id.
+		register_rest_route(
+			$this->namespace,
+			'/' . $this->rest_base . '/(?P<id>[\/\w-]+)',
+			array(
+				array(
+					'methods'             => WP_REST_Server::READABLE,
+					'callback'            => array( $this, 'get_item' ),
+					'permission_callback' => array( $this, 'get_item_permissions_check' ),
+					'args'                => array(
+						'id' => array(
+							'description' => __( 'The id of a navigation', 'gutenberg' ),
+							'type'        => 'string',
+						),
+					),
+				),
+			)
+		);
+	}
+
+
+	/**
+	 * Overide WP_REST_Posts_Controller function to query for
+	 * `wp_navigation` posts by post_name / slug instead of ID.
+	 *
+	 * @param string $id the slug of the Navigation post.
+	 * @return WP_Post|null
+	 */
+	protected function get_post( $id ) {
+
+		$error = new WP_Error(
+			'rest_post_invalid_id',
+			__( 'Invalid post ID.' ),
+			array( 'status' => 404 )
+		);
+
+		if ( ! is_string( $id ) ) {
+			return $error;
+		}
+
+		$args = array(
+			'name'           => $id, // query by slug
+			'post_type'      => array( $this->post_type ),
+			'nopaging'       => true,
+			'posts_per_page' => '-1',
+		);
+
+		// The Query
+		$post = new WP_Query( $args );
+
+		if ( empty( $post ) || empty( $post->post->ID ) || $this->post_type !== $post->post->post_type ) {
+			return $error;
+		}
+
+		return $post->post;
+	}
+
+
+
+}

--- a/lib/compat/wordpress-6.1/rest-api.php
+++ b/lib/compat/wordpress-6.1/rest-api.php
@@ -43,3 +43,17 @@ function gutenberg_register_gutenberg_rest_block_patterns() {
 	$block_patterns->register_routes();
 }
 add_action( 'rest_api_init', 'gutenberg_register_gutenberg_rest_block_patterns', 100 );
+
+
+
+function gutenberg_update_navigation_rest_controller( $args, $post_type ) {
+	if ( in_array( $post_type, array( 'wp_navigation' ), true ) ) {
+		// Original set in
+		// https://github.com/WordPress/wordpress-develop/blob/6cbed78c94b9d8c6a9b4c8b472b88ee0cd56528c/src/wp-includes/post.php#L528.
+		$args['rest_controller_class'] = 'Gutenberg_REST_Navigation_Controller';
+	}
+	return $args;
+}
+add_filter( 'register_post_type_args', 'gutenberg_update_navigation_rest_controller', 10, 2 );
+
+

--- a/lib/load.php
+++ b/lib/load.php
@@ -47,6 +47,7 @@ if ( class_exists( 'WP_REST_Controller' ) ) {
 	// WordPress 6.1 compat.
 	require_once __DIR__ . '/compat/wordpress-6.1/class-gutenberg-rest-block-patterns-controller.php';
 	require_once __DIR__ . '/compat/wordpress-6.1/class-gutenberg-rest-templates-controller.php';
+	require_once __DIR__ . '/compat/wordpress-6.1/class-gutenberg-rest-navigation-controller.php';
 	require_once __DIR__ . '/compat/wordpress-6.1/rest-api.php';
 
 	// Experimental.


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

This is **not RfR**

## What?
<!-- In a few words, what is the PR actually doing? -->

Amends the REST API to accept a string based slug when querying for a single `wp_navigation` post.



## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

See https://github.com/WordPress/gutenberg/issues/38291#issuecomment-1196781907.

Essentially we need the REST API to be able to find a given `wp_navigation` by a slug rather than a post ID. This will ultimately make Navigations more portable across different installs.

Follows a similar path to the Template Parts API.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

Amends the `rest_controller_class` for handling `wp_navigation` to a custom controller `Gutenberg_REST_Navigation_Controller`. This then overides the `get_post` method of the parent classes so that it queries by `post_name` (slug).

It also registers a new GET route which allows for using a string as the ID.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->

- Enable pretty permalinks on your site
- New tab `http://localhost:8888/wp-json/wp/v2/navigation/{{POST_NAME_SLUG_OF_YOUR_NAV_POST}}`
- See Navigation details.

## Screenshots or screencast <!-- if applicable -->
