### PR TITLE
Merging blocks: allow x to be merged into wrapper blocks (quote, list, group...)

### DIFF
--- a/packages/block-editor/src/store/actions.js
+++ b/packages/block-editor/src/store/actions.js
@@ -1021,9 +1021,15 @@ export const mergeBlocks =
 				blockB,
 				blockAType.name
 			);
-			if ( blocksWithTheSameType?.length !== 1 ) return;
+			if ( blocksWithTheSameType?.length !== 1 ) {
+				dispatch.selectBlock( blockA.clientId );
+				return;
+			}
 			const [ blockWithSameType ] = blocksWithTheSameType;
-			if ( blockWithSameType.innerBlocks.length < 1 ) return;
+			if ( blockWithSameType.innerBlocks.length < 1 ) {
+				dispatch.selectBlock( blockA.clientId );
+				return;
+			}
 			registry.batch( () => {
 				dispatch.insertBlocks(
 					blockWithSameType.innerBlocks,

--- a/packages/block-editor/src/store/actions.js
+++ b/packages/block-editor/src/store/actions.js
@@ -1023,6 +1023,7 @@ export const mergeBlocks =
 			);
 			if ( blocksWithTheSameType?.length !== 1 ) return;
 			const [ blockWithSameType ] = blocksWithTheSameType;
+			if ( blockWithSameType.innerBlocks.length < 1 ) return;
 			registry.batch( () => {
 				dispatch.insertBlocks(
 					blockWithSameType.innerBlocks,
@@ -1096,14 +1097,6 @@ export const mergeBlocks =
 				: switchToBlockType( cloneB, blockA.name );
 
 		if ( ! blocksWithTheSameType || ! blocksWithTheSameType.length ) {
-			// Fall back to moving the block inside the previous
-			// block.
-			dispatch.moveBlocksToPosition(
-				[ clientIdA ],
-				select.getBlockRootClientId( clientIdA ),
-				clientIdB,
-				0
-			);
 			return;
 		}
 

--- a/packages/block-editor/src/store/actions.js
+++ b/packages/block-editor/src/store/actions.js
@@ -1021,6 +1021,7 @@ export const mergeBlocks =
 				blockB,
 				blockAType.name
 			);
+			// Only focus the previous block if it's not mergeable.
 			if ( blocksWithTheSameType?.length !== 1 ) {
 				dispatch.selectBlock( blockA.clientId );
 				return;
@@ -1102,6 +1103,7 @@ export const mergeBlocks =
 				? [ cloneB ]
 				: switchToBlockType( cloneB, blockA.name );
 
+		// If the block types can not match, do nothing.
 		if ( ! blocksWithTheSameType || ! blocksWithTheSameType.length ) {
 			return;
 		}

--- a/packages/e2e-tests/specs/editor/blocks/__snapshots__/quote.test.js.snap
+++ b/packages/e2e-tests/specs/editor/blocks/__snapshots__/quote.test.js.snap
@@ -114,6 +114,10 @@ exports[`Quote can be split at the end 2`] = `
 "<!-- wp:quote -->
 <blockquote class=\\"wp-block-quote\\"><!-- wp:paragraph -->
 <p>1</p>
+<!-- /wp:paragraph -->
+
+<!-- wp:paragraph -->
+<p></p>
 <!-- /wp:paragraph --></blockquote>
 <!-- /wp:quote -->"
 `;

--- a/packages/e2e-tests/specs/editor/blocks/quote.test.js
+++ b/packages/e2e-tests/specs/editor/blocks/quote.test.js
@@ -143,8 +143,9 @@ describe( 'Quote', () => {
 		expect( await getEditedPostContent() ).toMatchSnapshot();
 
 		await page.keyboard.press( 'Backspace' );
+		await page.keyboard.type( '2' );
 
-		// Expect the paragraph to be deleted.
+		// Expect the paragraph to be merged into the quote block.
 		expect( await getEditedPostContent() ).toMatchSnapshot();
 	} );
 

--- a/test/e2e/specs/editor/blocks/__snapshots__/Group-can-merge-into-group-with-Backspace-1-chromium.txt
+++ b/test/e2e/specs/editor/blocks/__snapshots__/Group-can-merge-into-group-with-Backspace-1-chromium.txt
@@ -1,0 +1,9 @@
+<!-- wp:group -->
+<div class="wp-block-group"><!-- wp:paragraph -->
+<p>1</p>
+<!-- /wp:paragraph --></div>
+<!-- /wp:group -->
+
+<!-- wp:paragraph -->
+<p>2</p>
+<!-- /wp:paragraph -->

--- a/test/e2e/specs/editor/blocks/__snapshots__/Group-can-merge-into-group-with-Backspace-2-chromium.txt
+++ b/test/e2e/specs/editor/blocks/__snapshots__/Group-can-merge-into-group-with-Backspace-2-chromium.txt
@@ -1,0 +1,9 @@
+<!-- wp:group -->
+<div class="wp-block-group"><!-- wp:paragraph -->
+<p>1</p>
+<!-- /wp:paragraph -->
+
+<!-- wp:paragraph -->
+<p>2</p>
+<!-- /wp:paragraph --></div>
+<!-- /wp:group -->

--- a/test/e2e/specs/editor/blocks/group.spec.js
+++ b/test/e2e/specs/editor/blocks/group.spec.js
@@ -58,4 +58,21 @@ test.describe( 'Group', () => {
 
 		expect( await editor.getEditedPostContent() ).toMatchSnapshot();
 	} );
+
+	test( 'can merge into group with Backspace', async ( { editor, page } ) => {
+		await page.keyboard.press( 'Enter' );
+		await page.keyboard.type( '1' );
+		await editor.transformBlockTo( 'core/group' );
+		await page.keyboard.press( 'Enter' );
+		await page.keyboard.type( '2' );
+
+		// Confirm last paragraph is outside of group.
+		expect( await editor.getEditedPostContent() ).toMatchSnapshot();
+
+		// Merge the last paragraph into the group.
+		await page.keyboard.press( 'ArrowLeft' );
+		await page.keyboard.press( 'Backspace' );
+
+		expect( await editor.getEditedPostContent() ).toMatchSnapshot();
+	} );
 } );


### PR DESCRIPTION

<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Allows any block (e.g. paragraph) to be merged into a "wrapper" blocks such as quote, list or group.

The beauty of this PR is that it works for any block and wrapper block combination, as long as there's a transform.

## Why?

Improves editing flow.

## How?

Enhances the `mergeBlocks` action.

## Testing Instructions

Create a quote block. Add some text. Press Enter twice to exit the quote. Type something. Now press Backspace from the start of this block. The text should be merged with the quote.

## Screenshots or screencast <!-- if applicable -->

![list-merge](https://user-images.githubusercontent.com/4710635/181591773-6a34b4ec-ab13-4153-acc7-c64df97f89a7.gif)
![quote-merge](https://user-images.githubusercontent.com/4710635/181591775-94baaa20-78cd-41e3-b36c-befd37a33cc1.gif)
![group-merge](https://user-images.githubusercontent.com/4710635/181591780-3d5ed6e5-77f2-4180-b717-f6a1bdadfdd1.gif)

