### PR TITLE
Pasting: Dismiss pasted image if file:// schema detected

### DIFF
--- a/packages/block-editor/src/utils/pasting.js
+++ b/packages/block-editor/src/utils/pasting.js
@@ -70,7 +70,16 @@ export function shouldDismissPastedFiles( files, html /*, plainText */ ) {
 		// other elements found, like <figure>, but we assume that the user's
 		// intention is to paste the actual image file.
 		const IMAGE_TAG = /<\s*img\b/gi;
-		return html.match( IMAGE_TAG )?.length !== 1;
+		if ( html.match( IMAGE_TAG )?.length !== 1 ) return true;
+
+		// Even when there is exactly one <img> tag in the HTML payload, we
+		// choose to weed out local images, i.e. those whose source starts with
+		// "file://". These payloads occur in specific configurations, such as
+		// when copying an entire document from Microsoft Word, that contains
+		// text and exactly one image, and pasting that content using Google
+		// Chrome.
+		const IMG_WITH_LOCAL_SRC = /<\s*img\b[^>]*\bsrc="file:\/\//i;
+		if ( html.match( IMG_WITH_LOCAL_SRC ) ) return true;
 	}
 
 	return false;

--- a/packages/block-editor/src/utils/test/pasting.js
+++ b/packages/block-editor/src/utils/test/pasting.js
@@ -81,4 +81,14 @@ describe( 'shouldDismissPastedFiles', () => {
 			)
 		).toBe( true );
 	} );
+
+	it( 'should return true when pasting an image-containing MS Word document via Chrome', () => {
+		expect(
+			shouldDismissPastedFiles(
+				[ mocks.pngImageFile ],
+				'<p>A</p><img src="file:////.../clip_image001.png" alt="..."><p>B</p>',
+				'A\nB'
+			)
+		).toBe( true );
+	} );
 } );


### PR DESCRIPTION
## What?

Fixes #42783

This isn't the fix that I would like, and I am not sure that it should be merged.

IMO, the underlying issue is that Google Chrome (and Chromium derivatives, including Microsoft Edge) decides to attach to the clipboard data the fallback snapshot provided by Microsoft Word. Other browsers ignore that data, only passing attachments of type `text/plain`, `text/html`, and sometimes `text/rtf`.

## Why?

Quoting the bug report from the parent issue:

In short:

* copying a document from **Microsoft Word**
* said document contains text and **exactly one image**
* pasting onto the block editor using **Google Chrome** or **Microsoft Edge**
* results in the pasting of a Word-generated snapshot of the copied document, which is unexpected
  * the expected result would be the insertion of blocks corresponding to the copied content

Gutenberg should ignore that attached snapshot.

## How?

This PR extends the `shouldDismissPastedFiles` predicate to detect cases where the image tag found in the pasted HTML payload has a source with schema `file://`. For example, `{ html: '<p>text</p><img src="file:///some/local/path">' }`. Notes:

* I wonder what kind of false positives this might catch, though.
* Ideally, looking at `clipboardData.files` would be enough and we wouldn't have to guess based on `clipboardData.getData( 'text/html' )`. However, I haven't spotted any (meta)data in there that we could use.

## Testing Instructions

See parent issue.

## Caveat

I'm confident that this PR fixes that particular edge case, but it makes assumptions that I don't like, potentially creating new classes of false positives.

There's always the possibility of filing an issue / asking around in the Chromium project, to determine whether we could consider this a browser bug.