### PR TITLE
Social: Include has-visible-labels on edit component

### DIFF
--- a/packages/block-library/src/social-links/edit.js
+++ b/packages/block-library/src/social-links/edit.js
@@ -108,6 +108,7 @@ export function SocialLinksEdit( props ) {
 	// Fallback color values are used maintain selections in case switching
 	// themes and named colors in palette do not match.
 	const className = classNames( size, {
+		'has-visible-labels': showLabels,
 		'has-icon-color': iconColor.color || iconColorValue,
 		'has-icon-background-color':
 			iconBackgroundColor.color || iconBackgroundColorValue,


### PR DESCRIPTION
## What?
Adds the has-visible-labels class on the edit component if showLabels is checked.

## Why?
Styling that relies on this class on the frontend is not reflected in the editor otherwise.