### PR TITLE
Typography Panel: Fix font appearance control width

### DIFF
--- a/packages/block-editor/src/components/font-appearance-control/index.js
+++ b/packages/block-editor/src/components/font-appearance-control/index.js
@@ -213,6 +213,7 @@ export default function FontAppearanceControl( props ) {
 				onChange={ ( { selectedItem } ) =>
 					onChange( selectedItem.style )
 				}
+				__nextUnconstrainedWidth
 			/>
 		)
 	);

--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -12,6 +12,7 @@
 -   `TextControl`, `TextareaControl`, `ToggleGroupControl`: Add `box-sizing` reset style ([#42889](https://github.com/WordPress/gutenberg/pull/42889)).
 -   `Popover`: fix arrow placement and design ([#42874](https://github.com/WordPress/gutenberg/pull/42874/)).
 -   `Popover`: fix minor glitch in arrow [#42903](https://github.com/WordPress/gutenberg/pull/42903)).
+-   `ToolsPanel`: Constrain grid columns to 50% max-width ([#42795](https://github.com/WordPress/gutenberg/pull/42795)).
 
 ### Enhancements
 

--- a/packages/components/src/tools-panel/styles.ts
+++ b/packages/components/src/tools-panel/styles.ts
@@ -16,6 +16,9 @@ import { COLORS, CONFIG } from '../utils';
 import { space } from '../ui/utils/space';
 
 const toolsPanelGrid = {
+	columns: ( columns: number ) => css`
+		grid-template-columns: ${ `repeat( ${ columns }, minmax(0, 1fr) )` };
+	`,
 	spacing: css`
 		column-gap: ${ space( 4 ) };
 		row-gap: ${ space( 6 ) };
@@ -27,7 +30,8 @@ const toolsPanelGrid = {
 	},
 };
 
-export const ToolsPanel = css`
+export const ToolsPanel = ( columns: number ) => css`
+	${ toolsPanelGrid.columns( columns ) };
 	${ toolsPanelGrid.spacing };
 
 	border-top: ${ CONFIG.borderWidth } solid ${ COLORS.gray[ 300 ] };
@@ -45,8 +49,8 @@ export const ToolsPanelWithInnerWrapper = ( columns: number ) => {
 	return css`
 		> div:not( :first-of-type ) {
 			display: grid;
-			grid-template-columns: ${ `repeat( ${ columns }, 1fr )` };
-			${ toolsPanelGrid.spacing }
+			${ toolsPanelGrid.columns( columns ) };
+			${ toolsPanelGrid.spacing };
 			${ toolsPanelGrid.item.fullWidth }
 		}
 	`;

--- a/packages/components/src/tools-panel/styles.ts
+++ b/packages/components/src/tools-panel/styles.ts
@@ -31,8 +31,8 @@ const toolsPanelGrid = {
 };
 
 export const ToolsPanel = ( columns: number ) => css`
-	${ toolsPanelGrid.columns( columns ) };
-	${ toolsPanelGrid.spacing };
+	${ toolsPanelGrid.columns( columns ) }
+	${ toolsPanelGrid.spacing }
 
 	border-top: ${ CONFIG.borderWidth } solid ${ COLORS.gray[ 300 ] };
 	margin-top: -1px;
@@ -49,8 +49,8 @@ export const ToolsPanelWithInnerWrapper = ( columns: number ) => {
 	return css`
 		> div:not( :first-of-type ) {
 			display: grid;
-			${ toolsPanelGrid.columns( columns ) };
-			${ toolsPanelGrid.spacing };
+			${ toolsPanelGrid.columns( columns ) }
+			${ toolsPanelGrid.spacing }
 			${ toolsPanelGrid.item.fullWidth }
 		}
 	`;

--- a/packages/components/src/tools-panel/test/__snapshots__/index.js.snap
+++ b/packages/components/src/tools-panel/test/__snapshots__/index.js.snap
@@ -5,6 +5,7 @@ exports[`ToolsPanel first and last panel items should apply first/last classes t
   display: grid;
   gap: calc( 4px * 3 );
   grid-template-columns: repeat( 2, 1fr );
+  grid-template-columns: repeat( 2, minmax(0, 1fr) );
   -webkit-column-gap: calc(4px * 4);
   column-gap: calc(4px * 4);
   row-gap: calc(4px * 6);
@@ -15,7 +16,7 @@ exports[`ToolsPanel first and last panel items should apply first/last classes t
 
 .emotion-0>div:not( :first-of-type ) {
   display: grid;
-  grid-template-columns: repeat( 2, 1fr );
+  grid-template-columns: repeat( 2, minmax(0, 1fr) );
   -webkit-column-gap: calc(4px * 4);
   column-gap: calc(4px * 4);
   row-gap: calc(4px * 6);

--- a/packages/components/src/tools-panel/tools-panel/hook.ts
+++ b/packages/components/src/tools-panel/tools-panel/hook.ts
@@ -190,7 +190,12 @@ export function useToolsPanel(
 			areAllOptionalControlsHidden &&
 			styles.ToolsPanelHiddenInnerWrapper;
 
-		return cx( styles.ToolsPanel, wrapperStyle, emptyStyle, className );
+		return cx(
+			styles.ToolsPanel( DEFAULT_COLUMNS ),
+			wrapperStyle,
+			emptyStyle,
+			className
+		);
 	}, [
 		areAllOptionalControlsHidden,
 		className,


### PR DESCRIPTION
Related:
- https://github.com/WordPress/gutenberg/pull/42789

## What?

Prevents the `CustomSelectControl` within the font appearance control from forcing a minimum width of `130px`.

**Note: The downside here is slightly less width for the items in the select's dropdown. We can enlarge that separately however, for the time being, I've left it to be consistent.**

## Why?

When the `CustomSelectControl` has a min-width of `130px`, this forces the typography panel's columns to no longer be a 50/50 split, and once all control labels are capitalized as part of https://github.com/WordPress/gutenberg/pull/42789 other typography controls may have their labels truncated.

## How?

- Passes the new `__nextUnconstrainedWidth` prop to the font appearance control's `CustomSelectControl` to avoid the style forcing `min-width: 130px`.

## Testing Instructions

1. Checkout https://github.com/WordPress/gutenberg/pull/42789
2. In the editor, add a block with lots of typography options e.g. Group or Site Title
3. In the sidebar, enable the font appearance and letter spacing controls for the typography panel. Notice the truncation of the letter spacing label and the greater than 50% share the font appearance control takes up.
4. Now, apply this PR's changes to https://github.com/WordPress/gutenberg/pull/42789
5. Confirm that the font appearance control only takes up 50% of the available width and the letter spacing label is no longer truncated.

## Screenshots or screencast <!-- if applicable -->
| Before | After |
|---|---|
| <img width="276" alt="Screen Shot 2022-07-29 at 3 00 21 pm" src="https://user-images.githubusercontent.com/60436221/181687289-a0b4e97f-1db6-405f-a6e3-3c714e2d4226.png"> | <img width="278" alt="Screen Shot 2022-07-29 at 2 59 21 pm" src="https://user-images.githubusercontent.com/60436221/181687294-229b00f9-fac3-42ae-b647-bf35e696c226.png"> |

