### PR TITLE
Global Styles: Add block spacing to root block support UI

### DIFF
--- a/packages/edit-site/src/components/global-styles/dimensions-panel.js
+++ b/packages/edit-site/src/components/global-styles/dimensions-panel.js
@@ -204,7 +204,8 @@ function useMarginProps( name ) {
 function useBlockGapProps( name ) {
 	const [ gapValue, setGapValue ] = useStyle( 'spacing.blockGap', name );
 	const resetGapValue = () => setGapValue( undefined );
-	const hasGapValue = () => !! gapValue;
+	const [ userSetGapValue ] = useStyle( 'spacing.blockGap', name, 'user' );
+	const hasGapValue = () => !! userSetGapValue;
 	return {
 		gapValue,
 		setGapValue,

--- a/packages/edit-site/src/components/global-styles/dimensions-panel.js
+++ b/packages/edit-site/src/components/global-styles/dimensions-panel.js
@@ -160,8 +160,9 @@ function usePaddingProps( name ) {
 		setRawPadding( padding );
 	};
 	const resetPaddingValue = () => setPaddingValues( {} );
-	const hasPaddingValue = () =>
-		!! paddingValues && Object.keys( paddingValues ).length;
+	const [ userSetPaddingValue ] = useStyle( 'spacing.padding', name, 'user' );
+	// The `hasPaddingValue` check does not need a parsed value, as `userSetPaddingValue` will be `undefined` if not set.
+	const hasPaddingValue = () => !! userSetPaddingValue;
 
 	return {
 		paddingValues,

--- a/packages/edit-site/src/components/global-styles/hooks.js
+++ b/packages/edit-site/src/components/global-styles/hooks.js
@@ -170,6 +170,7 @@ const ROOT_BLOCK_SUPPORTS = [
 	'padding',
 	'contentSize',
 	'wideSize',
+	'blockGap',
 ];
 
 export function getSupportedGlobalStylesPanels( name ) {


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Add `blockGap` / block spacing to the root Layout global styles panel.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

Now that the Layout refactor in https://github.com/WordPress/gutenberg/pull/40875 has resolved the hierarchy of blockGap style output, we should be able to safely add back in the UI for the root level control.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

* Add `blockGap` to the list of `ROOT_BLOCK_SUPPORTS`
* Update `hasGapValue` and `hasPaddingValue` checks so that they check against whether or not a user value has been provided. This resolves an issue at the root level for both style value types where the ToolsPanel dropdown menu would still display the item as though it had a value even after it has been reset.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->

1. In the Global Styles UI within the site editor, select Layout and adjust the block spacing control, ensuring the spacing changes correctly in the site editor and once saved, the results are correct on the site frontend
2. Check that resetting values in the ToolsPanel generally works as expected.
3. Check that the panel is hidden if `settings.spacing.blockGap` is set to either `null` or `false`
4. Check that the _Padding_ and _Block spacing_ controls still work correctly at the block level, e.g. via the Columns block in global styles

## Screenshots or screencast <!-- if applicable -->

![2022-08-01 16 49 00](https://user-images.githubusercontent.com/14988353/182089161-b5aed503-bce2-4dd0-bcaa-d1bde57dfe7f.gif)