### PR TITLE
ResizableBox: Change tooltip background to match other tooltips

### DIFF
--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -9,6 +9,7 @@
 ### Enhancements
 
 -   Add `box-sizing` reset style mixin to utils ([#42754](https://github.com/WordPress/gutenberg/pull/42754)).
+-   `ResizableBox`: Make tooltip background match `Tooltip` component's ([#42800](https://github.com/WordPress/gutenberg/pull/42800)).
 
 ## 19.16.0 (2022-07-27)
 

--- a/packages/components/src/resizable-box/resize-tooltip/styles/resize-tooltip.styles.js
+++ b/packages/components/src/resizable-box/resize-tooltip/styles/resize-tooltip.styles.js
@@ -30,7 +30,7 @@ export const TooltipWrapper = styled.div`
 `;
 
 export const Tooltip = styled.div`
-	background: ${ COLORS.ui.border };
+	background: ${ COLORS.gray[ 900 ] };
 	border-radius: 2px;
 	box-sizing: border-box;
 	font-size: 12px;


### PR DESCRIPTION
Related: 
- https://github.com/WordPress/gutenberg/pull/23522

## What?

- Updates the tooltip background for the `ResizableBox` to match the primary `Tooltip` component and others such as the `RangeControl`.

## Why?

Consistency is good?

_This addresses a [suggestion](https://github.com/WordPress/gutenberg/pull/23522#pullrequestreview-1054940855) that arose through the review of https://github.com/WordPress/gutenberg/pull/23522. We can easily close this if there is a design rationale to have differing background colors for tooltips._

## How?

- Changed the `ResizableBox` tooltip's background color to the same `COLORS.gray[ 900 ]` value as the `Tooltip` component.

## Testing Instructions
1. Fire up storybook and confirm that the ResizableBox's tooltip color is the same as `Tooltip`, `RangeControl` etc.
2. Confirm the tooltip backgrounds are consistent in the editor as well.

## Screenshots or screencast <!-- if applicable -->

#### Storybook Examples
| ResizableBox | Tooltips |
|---|---|
| <video src="https://user-images.githubusercontent.com/60436221/181703976-1d56a767-b27d-4d6d-886d-8f137cee2b38.mp4" /> | <video src="https://user-images.githubusercontent.com/60436221/181703930-e09f2a61-e372-4918-ae35-fc828f146630.mp4" /> |

#### Editor Demo

| Before | After |
|---|---|
| <video src="https://user-images.githubusercontent.com/60436221/181705006-029c0332-ac09-4be1-b120-35da815faa5d.mp4" /> | <video src="https://user-images.githubusercontent.com/60436221/181703906-f6179899-a3e2-4a99-a075-2a0c807a401d.mp4" /> |


