### PR TITLE
Fix drag and drop performance when dragging over the insertion point

### DIFF
--- a/packages/block-editor/src/components/block-popover/inbetween.js
+++ b/packages/block-editor/src/components/block-popover/inbetween.js
@@ -180,6 +180,7 @@ function BlockPopoverInbetween( {
 			{ ...props }
 			className={ classnames(
 				'block-editor-block-popover',
+				'block-editor-block-popover__inbetween',
 				props.className
 			) }
 			__unstableForcePosition

--- a/packages/block-editor/src/components/block-popover/style.scss
+++ b/packages/block-editor/src/components/block-popover/style.scss
@@ -32,11 +32,20 @@
 	// Disable pointer events for dragging and dropping.
 	// Without this the insertion point interferes with the
 	// drop zone.
-	// Pointer events are enabled for the inserter button
-	// elsewhere in the codebase (see BlockTools.)
 	pointer-events: none;
 
 	* {
 		pointer-events: none;
+	}
+
+	// Re-enable pointer events when the inbetween inserter has a '+' button.
+	//
+	// Needs specificity, do not simplify.
+	.is-with-inserter {
+		pointer-events: all;
+
+		* {
+			pointer-events: all;
+		}
 	}
 }

--- a/packages/block-editor/src/components/block-popover/style.scss
+++ b/packages/block-editor/src/components/block-popover/style.scss
@@ -18,11 +18,22 @@
 
 		// Allow clicking through the toolbar holder.
 		pointer-events: none;
+	}
 
-		// Position the block toolbar.
-		> * {
+	&:not(.block-editor-block-popover__inbetween) .components-popover__content {
+		* {
 			pointer-events: all;
 		}
 	}
 }
 
+.components-popover.block-editor-block-popover__inbetween {
+	// Disable pointer events when dragging and dropping.
+	// Without this the insertion point interferes with the
+	// drop zone.
+	pointer-events: none;
+
+	* {
+		pointer-events: none;
+	}
+}

--- a/packages/block-editor/src/components/block-popover/style.scss
+++ b/packages/block-editor/src/components/block-popover/style.scss
@@ -20,6 +20,7 @@
 		pointer-events: none;
 	}
 
+	// Enable pointer events for the toolbar's content.
 	&:not(.block-editor-block-popover__inbetween) .components-popover__content {
 		* {
 			pointer-events: all;
@@ -28,9 +29,11 @@
 }
 
 .components-popover.block-editor-block-popover__inbetween {
-	// Disable pointer events when dragging and dropping.
+	// Disable pointer events for dragging and dropping.
 	// Without this the insertion point interferes with the
 	// drop zone.
+	// Pointer events are enabled for the inserter button
+	// elsewhere in the codebase (see BlockTools.)
 	pointer-events: none;
 
 	* {

--- a/packages/block-editor/src/components/block-tools/style.scss
+++ b/packages/block-editor/src/components/block-tools/style.scss
@@ -8,6 +8,20 @@
 	bottom: 0;
 	left: 0;
 	right: 0;
+
+	// Re-enable pointer events for the '+' button inserter
+	// and all its children.
+	// Pointer events are disabled elsewhere for the parent popover
+	// for when the insertion point is used as a drag and drop indicator.
+	//
+	// Needs specificity, do not simplify.
+	&.is-with-inserter .block-editor-block-list__insertion-point-inserter {
+		pointer-events: all;
+
+		* {
+			pointer-events: all;
+		}
+	}
 }
 
 .block-editor-block-list__insertion-point-indicator {

--- a/packages/block-editor/src/components/block-tools/style.scss
+++ b/packages/block-editor/src/components/block-tools/style.scss
@@ -8,20 +8,6 @@
 	bottom: 0;
 	left: 0;
 	right: 0;
-
-	// Re-enable pointer events for the '+' button inserter
-	// and all its children.
-	// Pointer events are disabled elsewhere for the parent popover
-	// for when the insertion point is used as a drag and drop indicator.
-	//
-	// Needs specificity, do not simplify.
-	&.is-with-inserter .block-editor-block-list__insertion-point-inserter {
-		pointer-events: all;
-
-		* {
-			pointer-events: all;
-		}
-	}
 }
 
 .block-editor-block-list__insertion-point-indicator {


### PR DESCRIPTION
## What?
Fixes #42363

Solves a drag and drop performance issue when dragging over the insertion point.

## Why?
The changes in #40441 were a little over-enthusiastic in removing `pointer-events: none` from the insertion point.

For drag and drop, `pointer-events: none` is pretty important, it prevents the insertion point from intercepting drag events and lets the block drop zone receive them. Without it, the insertion point continuously toggles between being hidden and shown causing performance to degrade.

## How?
Adds `pointer-events: none` again. 

`pointer-events: none` needs to be set from the root of the popover and that can only be done in block popover styles. However the block popover is a generic component now, so pointer events only need to be disabled when it's not an inbetween popover, hence the added `block-editor-block-popover__inbetween` classname.

Pointer events are enabled when the insertion point `is-with-inserter`—it has the '+' button that displays when hovering between blocks (and not dragging).

## Testing Instructions
1. Test that the in-between inserter works as a block inserter and receives click events.
2. Try dragging and dropping a block and hovering around the grey space left by the block—there should be no performance issues.

Note that the first bug I described in https://github.com/WordPress/gutenberg/issues/42363#issuecomment-1198902708 is still present.

## Screenshots or screencast <!-- if applicable -->

https://user-images.githubusercontent.com/677833/181727537-2caaf15a-2c88-453e-bcd3-08f523cb49a2.mp4


