### PR TITLE
Site Editor: Only mark the 'Site' menu item active when editing a home template

### DIFF
--- a/packages/edit-site/src/components/app/index.js
+++ b/packages/edit-site/src/components/app/index.js
@@ -40,7 +40,7 @@ export default function EditSiteApp( { reboot, homeTemplate } ) {
 				{ ( { params } ) => {
 					const isListPage = getIsListPage( params );
 
-					// The existence of `'front-page` supersedes very other settings.
+					// The existence of a 'front-page' supersedes every other setting.
 					const homeTemplateType =
 						params.postId?.includes( 'front-page' ) ||
 						params.postId === homeTemplate?.postId

--- a/packages/edit-site/src/components/app/index.js
+++ b/packages/edit-site/src/components/app/index.js
@@ -39,7 +39,10 @@ export default function EditSiteApp( { reboot, homeTemplate } ) {
 			<Routes>
 				{ ( { params } ) => {
 					const isListPage = getIsListPage( params );
+
+					// The existence of `'front-page` supersedes very other settings.
 					const homeTemplateType =
+						params.postId?.includes( 'front-page' ) ||
 						params.postId === homeTemplate?.postId
 							? 'site-editor'
 							: undefined;

--- a/packages/edit-site/src/components/app/index.js
+++ b/packages/edit-site/src/components/app/index.js
@@ -17,7 +17,7 @@ import List from '../list';
 import NavigationSidebar from '../navigation-sidebar';
 import getIsListPage from '../../utils/get-is-list-page';
 
-export default function EditSiteApp( { reboot } ) {
+export default function EditSiteApp( { reboot, homeTemplate } ) {
 	const { createErrorNotice } = useDispatch( noticesStore );
 
 	function onPluginAreaError( name ) {
@@ -39,6 +39,10 @@ export default function EditSiteApp( { reboot } ) {
 			<Routes>
 				{ ( { params } ) => {
 					const isListPage = getIsListPage( params );
+					const homeTemplateType =
+						params.postId === homeTemplate?.postId
+							? 'site-editor'
+							: undefined;
 
 					return (
 						<>
@@ -54,7 +58,9 @@ export default function EditSiteApp( { reboot } ) {
 								// Open the navigation sidebar by default when in the list page.
 								isDefaultOpen={ !! isListPage }
 								activeTemplateType={
-									isListPage ? params.postType : undefined
+									isListPage
+										? params.postType
+										: homeTemplateType
 								}
 							/>
 						</>

--- a/packages/edit-site/src/components/navigation-sidebar/navigation-panel/index.js
+++ b/packages/edit-site/src/components/navigation-sidebar/navigation-panel/index.js
@@ -39,7 +39,7 @@ function NavLink( { params, replace, ...props } ) {
 	return <NavigationItem { ...linkProps } { ...props } />;
 }
 
-const NavigationPanel = ( { activeItem = SITE_EDITOR_KEY } ) => {
+const NavigationPanel = ( { activeItem } ) => {
 	const { homeTemplate, isNavigationOpen, isTemplatePartsMode, siteTitle } =
 		useSelect( ( select ) => {
 			const { getEntityRecord } = select( coreDataStore );

--- a/packages/edit-site/src/index.js
+++ b/packages/edit-site/src/index.js
@@ -132,7 +132,13 @@ export function reinitializeEditor( target, settings ) {
 	window.addEventListener( 'dragover', ( e ) => e.preventDefault(), false );
 	window.addEventListener( 'drop', ( e ) => e.preventDefault(), false );
 
-	render( <EditSiteApp reboot={ reboot } />, target );
+	render(
+		<EditSiteApp
+			reboot={ reboot }
+			homeTemplate={ settings.__unstableHomeTemplate }
+		/>,
+		target
+	);
 }
 
 /**


### PR DESCRIPTION
## What?
Fixes #36821.

PR marks the "Site" menu item active only when editing a home template.

## Why?
See #36821.

## How?
Compares if template ID from navigation and editor settings match.

## Testing Instructions
1. Open Site Editor.
2. Confirm that the "Site" menu item is active.
3. Open different page templates (Single, Page) in Editor.
4. Confirm that the "Site" menu isn't active.

## Screenshots or screencast <!-- if applicable -->
![CleanShot 2022-07-29 at 13 20 06](https://user-images.githubusercontent.com/240569/181728054-0fd3a98a-6100-451b-8eff-64f3af1e0532.png)

