### PR TITLE
Quote: unwrap on Backspace at start

### DIFF
--- a/packages/block-editor/src/components/block-list/block.js
+++ b/packages/block-editor/src/components/block-list/block.js
@@ -18,6 +18,7 @@ import {
 	getSaveContent,
 	isUnmodifiedDefaultBlock,
 	serializeRawBlock,
+	switchToBlockType,
 } from '@wordpress/blocks';
 import { withFilters } from '@wordpress/components';
 import {
@@ -292,19 +293,48 @@ const applyWithDispatch = withDispatch( ( dispatch, ownProps, { select } ) => {
 		},
 		onMerge( forward ) {
 			const { clientId } = ownProps;
-			const { getPreviousBlockClientId, getNextBlockClientId } =
-				select( blockEditorStore );
+			const {
+				getPreviousBlockClientId,
+				getNextBlockClientId,
+				getBlockRootClientId,
+				getBlockIndex,
+				getBlockOrder,
+				getBlock,
+			} = select( blockEditorStore );
+			const { moveBlocksToPosition } = dispatch( blockEditorStore );
+			const rootClientId = getBlockRootClientId( clientId );
 
 			if ( forward ) {
 				const nextBlockClientId = getNextBlockClientId( clientId );
 				if ( nextBlockClientId ) {
 					mergeBlocks( clientId, nextBlockClientId );
+				} else {
+					moveBlocksToPosition(
+						[ clientId ],
+						rootClientId,
+						getBlockRootClientId( rootClientId ),
+						getBlockIndex( rootClientId ) + 1
+					);
 				}
 			} else {
 				const previousBlockClientId =
 					getPreviousBlockClientId( clientId );
 				if ( previousBlockClientId ) {
 					mergeBlocks( previousBlockClientId, clientId );
+				} else {
+					moveBlocksToPosition(
+						[ clientId ],
+						rootClientId,
+						getBlockRootClientId( rootClientId ),
+						getBlockIndex( rootClientId )
+					);
+
+					if ( ! getBlockOrder( rootClientId ).length ) {
+						const replacement = switchToBlockType(
+							getBlock( rootClientId ),
+							'*'
+						);
+					}
 				}
 			}
 		},

--- a/packages/block-editor/src/components/block-list/block.js
+++ b/packages/block-editor/src/components/block-list/block.js
@@ -306,12 +306,14 @@ const applyWithDispatch = withDispatch( ( dispatch, ownProps, { select } ) => {
 					getPreviousBlockClientId( clientId );
 				if ( previousBlockClientId ) {
 					mergeBlocks( previousBlockClientId, clientId );
-				} else {
+				} else if ( rootClientId ) {
+					// Attempt to "unwrap" the block contents when there's no
+					// preceding block to merge with.
 					const replacement = switchToBlockType(
 						getBlock( rootClientId ),
 						'*'
 					);
-					if ( replacement ) {
+					if ( replacement && replacement.length ) {
 						replaceBlocks( rootClientId, replacement, 0 );
 					}
 				}

--- a/packages/block-editor/src/components/block-list/block.js
+++ b/packages/block-editor/src/components/block-list/block.js
@@ -292,29 +292,14 @@ const applyWithDispatch = withDispatch( ( dispatch, ownProps, { select } ) => {
 			insertBlocks( blocks, index + 1, rootClientId );
 		},
 		onMerge( forward ) {
-			const { clientId } = ownProps;
-			const {
-				getPreviousBlockClientId,
-				getNextBlockClientId,
-				getBlockRootClientId,
-				getBlockIndex,
-				getBlockOrder,
-				getBlock,
-			} = select( blockEditorStore );
-			const { moveBlocksToPosition } = dispatch( blockEditorStore );
-			const rootClientId = getBlockRootClientId( clientId );
+			const { clientId, rootClientId } = ownProps;
+			const { getPreviousBlockClientId, getNextBlockClientId, getBlock } =
+				select( blockEditorStore );
 
 			if ( forward ) {
 				const nextBlockClientId = getNextBlockClientId( clientId );
 				if ( nextBlockClientId ) {
 					mergeBlocks( clientId, nextBlockClientId );
-				} else {
-					moveBlocksToPosition(
-						[ clientId ],
-						rootClientId,
-						getBlockRootClientId( rootClientId ),
-						getBlockIndex( rootClientId ) + 1
-					);
 				}
 			} else {
 				const previousBlockClientId =
@@ -322,18 +307,12 @@ const applyWithDispatch = withDispatch( ( dispatch, ownProps, { select } ) => {
 				if ( previousBlockClientId ) {
 					mergeBlocks( previousBlockClientId, clientId );
 				} else {
-					moveBlocksToPosition(
-						[ clientId ],
-						rootClientId,
-						getBlockRootClientId( rootClientId ),
-						getBlockIndex( rootClientId )
+					const replacement = switchToBlockType(
+						getBlock( rootClientId ),
+						'*'
 					);
-
-					if ( ! getBlockOrder( rootClientId ).length ) {
-						const replacement = switchToBlockType(
-							getBlock( rootClientId ),
-							'*'
-						);
+					if ( replacement ) {
+						replaceBlocks( rootClientId, replacement, 0 );
 					}
 				}
 			}

--- a/packages/e2e-tests/specs/editor/blocks/quote.test.js
+++ b/packages/e2e-tests/specs/editor/blocks/quote.test.js
@@ -147,4 +147,50 @@ describe( 'Quote', () => {
 		// Expect the paragraph to be deleted.
 		expect( await getEditedPostContent() ).toMatchSnapshot();
 	} );
+
+	it( 'can be unwrapped on Backspace', async () => {
+		await insertBlock( 'Quote' );
+
+		expect( await getEditedPostContent() ).toMatchInlineSnapshot( `
+		"<!-- wp:quote -->
+		<blockquote class=\\"wp-block-quote\\"><!-- wp:paragraph -->
+		<p></p>
+		<!-- /wp:paragraph --></blockquote>
+		<!-- /wp:quote -->"
+	` );
+
+		await page.keyboard.press( 'Backspace' );
+
+		expect( await getEditedPostContent() ).toMatchInlineSnapshot( `""` );
+	} );
+
+	it( 'can be unwrapped with content on Backspace', async () => {
+		await insertBlock( 'Quote' );
+		await page.keyboard.type( '1' );
+		await page.keyboard.press( 'ArrowRight' );
+		await page.keyboard.type( '2' );
+
+		expect( await getEditedPostContent() ).toMatchInlineSnapshot( `
+		"<!-- wp:quote -->
+		<blockquote class=\\"wp-block-quote\\"><!-- wp:paragraph -->
+		<p>1</p>
+		<!-- /wp:paragraph --><cite>2</cite></blockquote>
+		<!-- /wp:quote -->"
+	` );
+
+		await page.keyboard.press( 'ArrowLeft' );
+		await page.keyboard.press( 'ArrowUp' );
+		await page.keyboard.press( 'ArrowUp' );
+		await page.keyboard.press( 'Backspace' );
+
+		expect( await getEditedPostContent() ).toMatchInlineSnapshot( `
+		"<!-- wp:paragraph -->
+		<p>1</p>
+		<!-- /wp:paragraph -->
+
+		<!-- wp:paragraph -->
+		<p>2</p>
+		<!-- /wp:paragraph -->"
+	` );
+	} );
 } );


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?

When that caret is at the start of a Quote, Backspace should unwrap the quoted blocks.
It also works with other blocks like Group (as long as they have an unwrap transform defined).

## Why?

Feature parity with Quote v1.
Writing flow.

## How?

Enhancing the `onMerge` function passed to blocks.

## Testing Instructions

Create a quote with a paragraph and citation. Place the caret at the start of the paragraph and press Backspace. The paragraph and cite should be unwrapped.

## Screenshots or screencast <!-- if applicable -->

![quote-unwrap](https://user-images.githubusercontent.com/4710635/181731298-3d8fa5b9-fe91-49a2-bf11-683f5236cf18.gif)

