### PR TITLE
Use slug instead of id for ref in Navigation block

### DIFF
--- a/docs/reference-guides/core-blocks.md
+++ b/docs/reference-guides/core-blocks.md
@@ -393,7 +393,7 @@ A collection of blocks that allow visitors to get around your site. ([Source](ht
 -	**Name:** core/navigation
 -	**Category:** theme
 -	**Supports:** align (full, wide), inserter, spacing (blockGap, units), typography (fontSize, lineHeight), ~~html~~
--	**Attributes:** __unstableLocation, backgroundColor, customBackgroundColor, customOverlayBackgroundColor, customOverlayTextColor, customTextColor, hasIcon, icon, maxNestingLevel, openSubmenusOnClick, overlayBackgroundColor, overlayMenu, overlayTextColor, ref, rgbBackgroundColor, rgbTextColor, showSubmenuIcon, templateLock, textColor
+-	**Attributes:** __unstableLocation, backgroundColor, customBackgroundColor, customOverlayBackgroundColor, customOverlayTextColor, customTextColor, hasIcon, icon, maxNestingLevel, openSubmenusOnClick, overlayBackgroundColor, overlayMenu, overlayTextColor, ref, rgbBackgroundColor, rgbTextColor, showSubmenuIcon, slug, templateLock, textColor
 
 ## Custom Link
 

--- a/lib/compat/wordpress-6.1/class-gutenberg-rest-navigation-controller.php
+++ b/lib/compat/wordpress-6.1/class-gutenberg-rest-navigation-controller.php
@@ -1,0 +1,117 @@
+<?php
+/**
+ * REST API: Gutenberg_REST_Templates_Controller class
+ *
+ * @package    Gutenberg
+ * @subpackage REST_API
+ */
+
+/**
+ * Base Templates REST API Controller.
+ */
+class Gutenberg_REST_Navigation_Controller extends WP_REST_Posts_Controller {
+
+	/**
+	 * Registers the controllers routes.
+	 *
+	 * @return void
+	 */
+	public function register_routes() {
+
+		parent::register_routes();
+
+		// Lists a single nav item based on the given id or slug.
+		register_rest_route(
+			$this->namespace,
+			'/' . $this->rest_base . '/((?P<id>[\d]+)|(?P<slug>[\w\-]+))',
+			array(
+				'args'        => array(
+					'slug' => array(
+						'description' => __( 'The slug identifier for a Navigation', 'gutenberg' ),
+						'type'        => 'string',
+					),
+				),
+				array(
+					'methods'             => WP_REST_Server::READABLE,
+					'callback'            => array( $this, 'get_item' ),
+					'permission_callback' => array( $this, 'get_item_permissions_check' ),
+					'args'                => $this->get_endpoint_args_for_item_schema( WP_REST_Server::READABLE ),
+				),
+				array(
+					'methods'             => WP_REST_Server::EDITABLE,
+					'callback'            => array( $this, 'update_item' ),
+					'permission_callback' => array( $this, 'update_item_permissions_check' ),
+					'args'                => $this->get_endpoint_args_for_item_schema( WP_REST_Server::EDITABLE ),
+				),
+				array(
+					'methods'             => WP_REST_Server::DELETABLE,
+					'callback'            => array( $this, 'delete_item' ),
+					'permission_callback' => array( $this, 'delete_item_permissions_check' ),
+					'args'                => array(
+						'force' => array(
+							'type'        => 'boolean',
+							'default'     => false,
+							'description' => __( 'Whether to bypass Trash and force deletion.' ),
+						),
+					),
+				),
+				'allow_batch' => $this->allow_batch,
+				'schema'      => array( $this, 'get_public_item_schema' ),
+			)
+		);
+	}
+
+	/**
+	 * Overide WP_REST_Posts_Controller parent function to query for
+	 * `wp_navigation` posts by slug (post_name) instead of ID.
+	 *
+	 * This is required to successfully process OPTIONS requests as with
+	 * these the `rest_request_before_callbacks` method which is used to
+	 * map slug to postId does not run which means `get_post` will not
+	 * behave as expected.
+	 *
+	 * The function will continue to delegate to the parent implementation
+	 * if the $id argument is ID-based, thereby ensuring backwards
+	 * compatbility.
+	 *
+	 * It may be possible to remove this implemenation in future releases.
+	 *
+	 * See: https://github.com/WordPress/gutenberg/pull/43703.
+	 *
+	 * @param string $id the slug of the Navigation post.
+	 * @return WP_Post|null
+	 */
+	protected function get_post( $id ) {
+
+		// Handle ID based $id param.
+		if ( is_numeric( $id ) ) {
+			return parent::get_post( $id );
+		}
+
+		// For string based $id the argument is a "slug".
+		// Lookup Post using `post_name` query.
+		$slug = $id;
+
+		$args = array(
+			'name'                   => $slug,
+			'post_type'              => 'wp_navigation',
+			'nopaging'               => true,
+			'posts_per_page'         => '1',
+			'update_post_term_cache' => false,
+			'no_found_rows'          => true,
+		);
+
+		// Query for the Navigation Post by slug (post_name).
+		$query = new WP_Query( $args );
+
+		if ( empty( $query->posts ) ) {
+			return new WP_Error(
+				'rest_post_not_found',
+				__( 'No navigation found.' ),
+				array( 'status' => 404 )
+			);
+		}
+
+		return $query->posts[0];
+	}
+}

--- a/lib/compat/wordpress-6.1/rest-api.php
+++ b/lib/compat/wordpress-6.1/rest-api.php
@@ -93,3 +93,86 @@ function gutenberg_register_has_archive_on_post_types_endpoint() {
 	);
 }
 add_action( 'rest_api_init', 'gutenberg_register_has_archive_on_post_types_endpoint' );
+
+/**
+ * Use custom REST API Controller for Navigation Posts
+ *
+ * @param array $args the post type arguments.
+ * @return array the filtered post type arguments with the new REST Controller set.
+ */
+function gutenberg_update_navigation_rest_controller( $args, $post_type ) {
+	if ( in_array( $post_type, array( 'wp_navigation' ), true ) ) {
+		// Original set in
+		// https://github.com/WordPress/wordpress-develop/blob/6cbed78c94b9d8c6a9b4c8b472b88ee0cd56528c/src/wp-includes/post.php#L528.
+		$args['rest_controller_class'] = 'Gutenberg_REST_Navigation_Controller';
+	}
+	return $args;
+}
+add_filter( 'register_post_type_args', 'gutenberg_update_navigation_rest_controller', 10, 2 );
+
+function gutenberg_transform_slug_to_post_id( $response, $handler, WP_REST_Request $request ) {
+
+	$route = rest_get_route_for_post_type_items( 'wp_navigation' );
+
+	// Ignore non-Navigation REST API requests.
+	if ( ! str_starts_with( $request->get_route(), $route ) ) {
+		return $response;
+	}
+
+	// Get the slug from the request **URL** (not the request body).
+	// PUT requests will have a param of `slug` in both the URL and (potentially)
+	// in the body. In all cases only the slug in the URL should be mapped to a
+	// postId in order that the correct post to be updated can be retrived.
+	// The `slug` within the body should be preserved "as is".
+	$slug = isset( $request->get_url_params()['slug'] ) ? $request->get_url_params()['slug'] : null;
+
+	// If no slug provided assume ID and continue as normal.
+	if ( empty( $slug ) ) {
+		return $response;
+	}
+
+	$args = array(
+		'name'                   => $slug, // query by slug
+		'post_type'              => 'wp_navigation',
+		'nopaging'               => true,
+		'posts_per_page'         => '1',
+		'update_post_term_cache' => false,
+		'no_found_rows'          => true,
+	);
+
+	// Query for the Navigation Post by slug (post_name).
+	$query = new WP_Query( $args );
+
+	if ( empty( $query->posts ) ) {
+		return new WP_Error(
+			'rest_post_not_found',
+			__( 'No navigation found.' ),
+			array( 'status' => 404 )
+		);
+	}
+
+	// Set the post ID based on the slug.
+	$request['id'] = $query->posts[0]->ID;
+
+	return $response;
+}
+add_filter( 'rest_request_before_callbacks', 'gutenberg_transform_slug_to_post_id', 10, 3 );
+
+function gutenberg_update_navigation_rest_route_for_post( $route, WP_Post $post ) {
+
+	if ( $post->post_type !== 'wp_navigation' ) {
+		return $route;
+	}
+
+	$post_type_route = rest_get_route_for_post_type_items( $post->post_type );
+
+	if ( ! $post_type_route ) {
+		return '';
+	}
+
+	// Replace Post ID in route with Post "Slug" (post_name).
+	return sprintf( '%s/%s', $post_type_route, $post->post_name );
+}
+
+
+add_filter( 'rest_route_for_post', 'gutenberg_update_navigation_rest_route_for_post', 10, 2 );

--- a/lib/load.php
+++ b/lib/load.php
@@ -47,6 +47,7 @@ if ( class_exists( 'WP_REST_Controller' ) ) {
 	// WordPress 6.1 compat.
 	require_once __DIR__ . '/compat/wordpress-6.1/class-gutenberg-rest-block-patterns-controller.php';
 	require_once __DIR__ . '/compat/wordpress-6.1/class-gutenberg-rest-templates-controller.php';
+	require_once __DIR__ . '/compat/wordpress-6.1/class-gutenberg-rest-navigation-controller.php';
 	require_once __DIR__ . '/compat/wordpress-6.1/rest-api.php';
 
 	// Experimental.

--- a/packages/block-library/src/navigation/block.json
+++ b/packages/block-library/src/navigation/block.json
@@ -9,7 +9,7 @@
 	"textdomain": "default",
 	"attributes": {
 		"ref": {
-			"type": "number"
+			"type": "string"
 		},
 		"textColor": {
 			"type": "string"

--- a/packages/block-library/src/navigation/block.json
+++ b/packages/block-library/src/navigation/block.json
@@ -9,6 +9,9 @@
 	"textdomain": "default",
 	"attributes": {
 		"ref": {
+			"type": "number"
+		},
+		"slug": {
 			"type": "string"
 		},
 		"textColor": {

--- a/packages/block-library/src/navigation/constants.js
+++ b/packages/block-library/src/navigation/constants.js
@@ -1,0 +1,2 @@
+export const DEFAULT_ENTITY_KIND = 'root';
+export const DEFAULT_ENTITY_TYPE = 'navigation';

--- a/packages/block-library/src/navigation/deprecated.js
+++ b/packages/block-library/src/navigation/deprecated.js
@@ -13,6 +13,7 @@ import { compose } from '@wordpress/compose';
  * Internal dependencies
  */
 import migrateFontFamily from '../utils/migrate-font-family';
+import { isNumeric } from './edit/utils';
 
 const TYPOGRAPHY_PRESET_DEPRECATION_MAP = {
 	fontStyle: 'var:preset|font-style|',
@@ -49,6 +50,130 @@ const migrateWithLayout = ( attributes ) => {
 	}
 
 	return updatedAttributes;
+};
+
+const v7 = {
+	attributes: {
+		ref: {
+			type: 'number',
+		},
+		textColor: {
+			type: 'string',
+		},
+		customTextColor: {
+			type: 'string',
+		},
+		rgbTextColor: {
+			type: 'string',
+		},
+		backgroundColor: {
+			type: 'string',
+		},
+		customBackgroundColor: {
+			type: 'string',
+		},
+		rgbBackgroundColor: {
+			type: 'string',
+		},
+		showSubmenuIcon: {
+			type: 'boolean',
+			default: true,
+		},
+		openSubmenusOnClick: {
+			type: 'boolean',
+			default: false,
+		},
+		overlayMenu: {
+			type: 'string',
+			default: 'mobile',
+		},
+		icon: {
+			type: 'string',
+			default: 'handle',
+		},
+		hasIcon: {
+			type: 'boolean',
+			default: true,
+		},
+		__unstableLocation: {
+			type: 'string',
+		},
+		overlayBackgroundColor: {
+			type: 'string',
+		},
+		customOverlayBackgroundColor: {
+			type: 'string',
+		},
+		overlayTextColor: {
+			type: 'string',
+		},
+		customOverlayTextColor: {
+			type: 'string',
+		},
+		maxNestingLevel: {
+			type: 'number',
+			default: 5,
+		},
+	},
+	supports: {
+		align: [ 'wide', 'full' ],
+		anchor: true,
+		html: false,
+		inserter: true,
+		typography: {
+			fontSize: true,
+			lineHeight: true,
+			__experimentalFontStyle: true,
+			__experimentalFontWeight: true,
+			__experimentalTextTransform: true,
+			__experimentalFontFamily: true,
+			__experimentalLetterSpacing: true,
+			__experimentalTextDecoration: true,
+			__experimentalSkipSerialization: [ 'textDecoration' ],
+			__experimentalDefaultControls: {
+				fontSize: true,
+			},
+		},
+		spacing: {
+			blockGap: true,
+			units: [ 'px', 'em', 'rem', 'vh', 'vw' ],
+			__experimentalDefaultControls: {
+				blockGap: true,
+			},
+		},
+		__experimentalLayout: {
+			allowSwitching: false,
+			allowInheriting: false,
+			allowVerticalAlignment: false,
+			default: {
+				type: 'flex',
+			},
+		},
+		__experimentalStyle: {
+			elements: {
+				link: {
+					color: {
+						text: 'inherit',
+					},
+				},
+			},
+		},
+	},
+	save: ( { attributes } ) => {
+		if ( attributes.ref ) {
+			return;
+		}
+		return <InnerBlocks.Content />;
+	},
+	isEligible: ( { ref } ) => {
+		return isNumeric( ref );
+	},
+	migrate: ( { ref, ...attributes } ) => {
+		return {
+			...attributes,
+			ref: String( ref ),
+		};
+	},
 };
 
 const v6 = {
@@ -353,6 +478,7 @@ const migrateTypographyPresets = function ( attributes ) {
 };
 
 const deprecated = [
+	v7,
 	v6,
 	v5,
 	v4,

--- a/packages/block-library/src/navigation/deprecated.js
+++ b/packages/block-library/src/navigation/deprecated.js
@@ -13,7 +13,6 @@ import { compose } from '@wordpress/compose';
  * Internal dependencies
  */
 import migrateFontFamily from '../utils/migrate-font-family';
-import { isNumeric } from './edit/utils';
 
 const TYPOGRAPHY_PRESET_DEPRECATION_MAP = {
 	fontStyle: 'var:preset|font-style|',
@@ -50,130 +49,6 @@ const migrateWithLayout = ( attributes ) => {
 	}
 
 	return updatedAttributes;
-};
-
-const v7 = {
-	attributes: {
-		ref: {
-			type: 'number',
-		},
-		textColor: {
-			type: 'string',
-		},
-		customTextColor: {
-			type: 'string',
-		},
-		rgbTextColor: {
-			type: 'string',
-		},
-		backgroundColor: {
-			type: 'string',
-		},
-		customBackgroundColor: {
-			type: 'string',
-		},
-		rgbBackgroundColor: {
-			type: 'string',
-		},
-		showSubmenuIcon: {
-			type: 'boolean',
-			default: true,
-		},
-		openSubmenusOnClick: {
-			type: 'boolean',
-			default: false,
-		},
-		overlayMenu: {
-			type: 'string',
-			default: 'mobile',
-		},
-		icon: {
-			type: 'string',
-			default: 'handle',
-		},
-		hasIcon: {
-			type: 'boolean',
-			default: true,
-		},
-		__unstableLocation: {
-			type: 'string',
-		},
-		overlayBackgroundColor: {
-			type: 'string',
-		},
-		customOverlayBackgroundColor: {
-			type: 'string',
-		},
-		overlayTextColor: {
-			type: 'string',
-		},
-		customOverlayTextColor: {
-			type: 'string',
-		},
-		maxNestingLevel: {
-			type: 'number',
-			default: 5,
-		},
-	},
-	supports: {
-		align: [ 'wide', 'full' ],
-		anchor: true,
-		html: false,
-		inserter: true,
-		typography: {
-			fontSize: true,
-			lineHeight: true,
-			__experimentalFontStyle: true,
-			__experimentalFontWeight: true,
-			__experimentalTextTransform: true,
-			__experimentalFontFamily: true,
-			__experimentalLetterSpacing: true,
-			__experimentalTextDecoration: true,
-			__experimentalSkipSerialization: [ 'textDecoration' ],
-			__experimentalDefaultControls: {
-				fontSize: true,
-			},
-		},
-		spacing: {
-			blockGap: true,
-			units: [ 'px', 'em', 'rem', 'vh', 'vw' ],
-			__experimentalDefaultControls: {
-				blockGap: true,
-			},
-		},
-		__experimentalLayout: {
-			allowSwitching: false,
-			allowInheriting: false,
-			allowVerticalAlignment: false,
-			default: {
-				type: 'flex',
-			},
-		},
-		__experimentalStyle: {
-			elements: {
-				link: {
-					color: {
-						text: 'inherit',
-					},
-				},
-			},
-		},
-	},
-	save: ( { attributes } ) => {
-		if ( attributes.ref ) {
-			return;
-		}
-		return <InnerBlocks.Content />;
-	},
-	isEligible: ( { ref } ) => {
-		return isNumeric( ref );
-	},
-	migrate: ( { ref, ...attributes } ) => {
-		return {
-			...attributes,
-			ref: String( ref ),
-		};
-	},
 };
 
 const v6 = {
@@ -478,7 +353,6 @@ const migrateTypographyPresets = function ( attributes ) {
 };
 
 const deprecated = [
-	v7,
 	v6,
 	v5,
 	v4,

--- a/packages/block-library/src/navigation/edit/index.js
+++ b/packages/block-library/src/navigation/edit/index.js
@@ -98,10 +98,10 @@ function Navigation( {
 		icon = 'handle',
 	} = attributes;
 
-	const ref = attributes.ref;
+	const ref = attributes.slug || attributes.ref;
 
 	const setRef = ( postSlug ) => {
-		setAttributes( { ref: postSlug } );
+		setAttributes( { slug: postSlug } );
 	};
 
 	const recursionId = `navigationMenu/${ ref }`;

--- a/packages/block-library/src/navigation/edit/index.js
+++ b/packages/block-library/src/navigation/edit/index.js
@@ -147,7 +147,7 @@ function Navigation( {
 	} = useCreateNavigationMenu( clientId );
 
 	const createUntitledEmptyNavigationMenu = () =>
-		void createNavigationMenu( '', [], generatedSlug );
+		void createNavigationMenu( '', [], null, generatedSlug );
 
 	useEffect( () => {
 		hideNavigationMenuStatusNotice();

--- a/packages/block-library/src/navigation/edit/index.js
+++ b/packages/block-library/src/navigation/edit/index.js
@@ -325,8 +325,9 @@ function Navigation( {
 	const isEntityAvailable =
 		! isNavigationMenuMissing && isNavigationMenuResolved;
 
-	// Migrate numerical ID-based ref to
-	// string slug-based ref.
+	// Migrate the numerical ID-based ref attribute to the
+	// string-based slug attribute. This action soft-deprecates
+	// usage of the ref attribute in favour of the slug attribute.
 	useEffect( () => {
 		if ( isEntityAvailable && isNumeric( ref ) ) {
 			setRef( navigationMenu?.slug );

--- a/packages/block-library/src/navigation/edit/index.js
+++ b/packages/block-library/src/navigation/edit/index.js
@@ -42,6 +42,7 @@ import { close, Icon } from '@wordpress/icons';
  */
 import useNavigationMenu from '../use-navigation-menu';
 import useNavigationEntities from '../use-navigation-entities';
+import useNavigationEntityTypes from '../use-navigation-entity-types';
 import Placeholder from './placeholder';
 import ResponsiveWrapper from './responsive-wrapper';
 import NavigationInnerBlocks from './inner-blocks';
@@ -59,7 +60,8 @@ import useConvertClassicToBlockMenu, {
 } from './use-convert-classic-menu-to-block-menu';
 import useCreateNavigationMenu from './use-create-navigation-menu';
 import { useInnerBlocks } from './use-inner-blocks';
-import { detectColors } from './utils';
+import useGeneratedSlug from './use-generated-slug';
+import { detectColors, isNumeric } from './utils';
 
 function Navigation( {
 	attributes,
@@ -98,13 +100,15 @@ function Navigation( {
 
 	const ref = attributes.ref;
 
-	const setRef = ( postId ) => {
-		setAttributes( { ref: postId } );
+	const setRef = ( postSlug ) => {
+		setAttributes( { ref: postSlug } );
 	};
 
 	const recursionId = `navigationMenu/${ ref }`;
 	const hasAlreadyRendered = useHasRecursion( recursionId );
 	const { editEntityRecord } = useDispatch( coreStore );
+
+	const generatedSlug = useGeneratedSlug( clientId );
 
 	// Preload classic menus, so that they don't suddenly pop-in when viewing
 	// the Select Menu dropdown.
@@ -142,9 +146,8 @@ function Navigation( {
 		isError: createNavigationMenuIsError,
 	} = useCreateNavigationMenu( clientId );
 
-	const createUntitledEmptyNavigationMenu = () => {
-		createNavigationMenu( '' );
-	};
+	const createUntitledEmptyNavigationMenu = () =>
+		void createNavigationMenu( '', [], generatedSlug );
 
 	useEffect( () => {
 		hideNavigationMenuStatusNotice();
@@ -154,7 +157,7 @@ function Navigation( {
 		}
 
 		if ( createNavigationMenuIsSuccess ) {
-			handleUpdateMenu( createNavigationMenuPost.id, {
+			handleUpdateMenu( createNavigationMenuPost.slug, {
 				focusNavigationBlock: true,
 			} );
 
@@ -189,6 +192,7 @@ function Navigation( {
 		replaceInnerBlocks,
 		selectBlock,
 		__unstableMarkNextChangeAsNotPersistent,
+		__unstableMarkAutomaticChange,
 	} = useDispatch( blockEditorStore );
 
 	const [ hasSavedUnsavedInnerBlocks, setHasSavedUnsavedInnerBlocks ] =
@@ -213,6 +217,9 @@ function Navigation( {
 		isResolvingCanUserCreateNavigationMenu,
 		hasResolvedCanUserCreateNavigationMenu,
 	} = useNavigationMenu( ref );
+
+	const [ navigationEntityKind, navigationEntityType ] =
+		useNavigationEntityTypes( ref );
 
 	const navMenuResolvedButMissing =
 		hasResolvedNavigationMenus && isNavigationMenuMissing;
@@ -262,7 +269,7 @@ function Navigation( {
 		 *  nor to be undoable, hence why it is marked as non persistent
 		 */
 		__unstableMarkNextChangeAsNotPersistent();
-		setRef( fallbackNavigationMenus[ 0 ].id );
+		setRef( fallbackNavigationMenus[ 0 ].slug );
 	}, [ navigationMenus ] );
 
 	useEffect( () => {
@@ -318,6 +325,15 @@ function Navigation( {
 	const isEntityAvailable =
 		! isNavigationMenuMissing && isNavigationMenuResolved;
 
+	// Migrate numerical ID-based ref to
+	// string slug-based ref.
+	useEffect( () => {
+		if ( isEntityAvailable && isNumeric( ref ) ) {
+			setRef( navigationMenu?.slug );
+			__unstableMarkAutomaticChange();
+		}
+	}, [ isEntityAvailable, ref, navigationMenu ] );
+
 	// "loading" state:
 	// - there is a menu creation process in progress.
 	// - there is a classic menu conversion process in progress.
@@ -370,11 +386,11 @@ function Navigation( {
 	const [ detectedOverlayColor, setDetectedOverlayColor ] = useState();
 
 	const handleUpdateMenu = (
-		menuId,
+		menuRef,
 		options = { focusNavigationBlock: false }
 	) => {
 		const { focusNavigationBlock } = options;
-		setRef( menuId );
+		setRef( menuRef );
 		if ( focusNavigationBlock ) {
 			selectBlock( clientId );
 		}
@@ -656,8 +672,8 @@ function Navigation( {
 						<NavigationMenuSelector
 							currentMenuId={ ref }
 							clientId={ clientId }
-							onSelectNavigationMenu={ ( menuId ) => {
-								handleUpdateMenu( menuId );
+							onSelectNavigationMenu={ ( menuRef ) => {
+								handleUpdateMenu( menuRef );
 							} }
 							onSelectClassicMenu={ async ( classicMenu ) => {
 								const navMenu = await convertClassicMenu(
@@ -666,7 +682,7 @@ function Navigation( {
 									'draft'
 								);
 								if ( navMenu ) {
-									handleUpdateMenu( navMenu.id, {
+									handleUpdateMenu( navMenu.slug, {
 										focusNavigationBlock: true,
 									} );
 								}
@@ -717,7 +733,7 @@ function Navigation( {
 							// Set some state used as a guard to prevent the creation of multiple posts.
 							setHasSavedUnsavedInnerBlocks( true );
 							// Switch to using the wp_navigation entity.
-							setRef( post.id );
+							setRef( post.slug );
 
 							showNavigationMenuStatusNotice(
 								__( `New Navigation Menu created.` )
@@ -739,8 +755,8 @@ function Navigation( {
 						<NavigationMenuSelector
 							currentMenuId={ null }
 							clientId={ clientId }
-							onSelectNavigationMenu={ ( menuId ) => {
-								handleUpdateMenu( menuId );
+							onSelectNavigationMenu={ ( menuRef ) => {
+								handleUpdateMenu( menuRef );
 							} }
 							onSelectClassicMenu={ async ( classicMenu ) => {
 								const navMenu = await convertClassicMenu(
@@ -749,7 +765,7 @@ function Navigation( {
 									'draft'
 								);
 								if ( navMenu ) {
-									handleUpdateMenu( navMenu.id, {
+									handleUpdateMenu( navMenu.slug, {
 										focusNavigationBlock: true,
 									} );
 								}
@@ -825,8 +841,8 @@ function Navigation( {
 					isResolvingCanUserCreateNavigationMenu={
 						isResolvingCanUserCreateNavigationMenu
 					}
-					onSelectNavigationMenu={ ( menuId ) => {
-						handleUpdateMenu( menuId );
+					onSelectNavigationMenu={ ( menuRef ) => {
+						handleUpdateMenu( menuRef );
 					} }
 					onSelectClassicMenu={ async ( classicMenu ) => {
 						const navMenu = await convertClassicMenu(
@@ -835,7 +851,7 @@ function Navigation( {
 							'draft'
 						);
 						if ( navMenu ) {
-							handleUpdateMenu( navMenu.id, {
+							handleUpdateMenu( navMenu.slug, {
 								focusNavigationBlock: true,
 							} );
 						}
@@ -847,15 +863,19 @@ function Navigation( {
 	}
 
 	return (
-		<EntityProvider kind="postType" type="wp_navigation" id={ ref }>
+		<EntityProvider
+			kind={ navigationEntityKind }
+			type={ navigationEntityType }
+			id={ ref }
+		>
 			<RecursionProvider uniqueId={ recursionId }>
 				<InspectorControls>
 					<PanelBody title={ __( 'Menu' ) }>
 						<NavigationMenuSelector
 							currentMenuId={ ref }
 							clientId={ clientId }
-							onSelectNavigationMenu={ ( menuId ) => {
-								handleUpdateMenu( menuId );
+							onSelectNavigationMenu={ ( menuRef ) => {
+								handleUpdateMenu( menuRef );
 							} }
 							onSelectClassicMenu={ async ( classicMenu ) => {
 								const navMenu = await convertClassicMenu(
@@ -864,7 +884,7 @@ function Navigation( {
 									'draft'
 								);
 								if ( navMenu ) {
-									handleUpdateMenu( navMenu.id, {
+									handleUpdateMenu( navMenu.slug, {
 										focusNavigationBlock: true,
 									} );
 								}
@@ -898,11 +918,16 @@ function Navigation( {
 					<InspectorControls __experimentalGroup="advanced">
 						{ hasResolvedCanUserUpdateNavigationMenu &&
 							canUserUpdateNavigationMenu && (
-								<NavigationMenuNameControl />
+								<NavigationMenuNameControl
+									kind={ navigationEntityKind }
+									type={ navigationEntityType }
+								/>
 							) }
 						{ hasResolvedCanUserDeleteNavigationMenu &&
 							canUserDeleteNavigationMenu && (
 								<NavigationMenuDeleteControl
+									kind={ navigationEntityKind }
+									type={ navigationEntityType }
 									onDelete={ ( deletedMenuTitle = '' ) => {
 										replaceInnerBlocks( clientId, [] );
 										showNavigationMenuStatusNotice(
@@ -943,6 +968,8 @@ function Navigation( {
 							{ isEntityAvailable && (
 								<NavigationInnerBlocks
 									clientId={ clientId }
+									kind={ navigationEntityKind }
+									type={ navigationEntityType }
 									hasCustomPlaceholder={
 										!! CustomPlaceholder
 									}

--- a/packages/block-library/src/navigation/edit/inner-blocks.js
+++ b/packages/block-library/src/navigation/edit/inner-blocks.js
@@ -40,6 +40,8 @@ export default function NavigationInnerBlocks( {
 	clientId,
 	hasCustomPlaceholder,
 	orientation,
+	kind,
+	type,
 	templateLock,
 } ) {
 	const {
@@ -70,10 +72,7 @@ export default function NavigationInnerBlocks( {
 		[ clientId ]
 	);
 
-	const [ blocks, onInput, onChange ] = useEntityBlockEditor(
-		'postType',
-		'wp_navigation'
-	);
+	const [ blocks, onInput, onChange ] = useEntityBlockEditor( kind, type );
 
 	const shouldDirectInsert = useMemo(
 		() =>

--- a/packages/block-library/src/navigation/edit/navigation-menu-delete-control.js
+++ b/packages/block-library/src/navigation/edit/navigation-menu-delete-control.js
@@ -11,11 +11,15 @@ import { useDispatch } from '@wordpress/data';
 import { useState } from '@wordpress/element';
 import { __, sprintf } from '@wordpress/i18n';
 
-export default function NavigationMenuDeleteControl( { onDelete } ) {
+export default function NavigationMenuDeleteControl( {
+	onDelete,
+	kind,
+	type,
+} ) {
 	const [ isConfirmModalVisible, setIsConfirmModalVisible ] =
 		useState( false );
-	const id = useEntityId( 'postType', 'wp_navigation' );
-	const [ title ] = useEntityProp( 'postType', 'wp_navigation', 'title' );
+	const id = useEntityId( kind, type );
+	const [ title ] = useEntityProp( kind, type, 'title' );
 	const { deleteEntityRecord } = useDispatch( coreStore );
 
 	return (
@@ -60,12 +64,9 @@ export default function NavigationMenuDeleteControl( { onDelete } ) {
 							<Button
 								variant="primary"
 								onClick={ () => {
-									deleteEntityRecord(
-										'postType',
-										'wp_navigation',
-										id,
-										{ force: true }
-									);
+									deleteEntityRecord( kind, type, id, {
+										force: true,
+									} );
 									onDelete( title );
 								} }
 							>

--- a/packages/block-library/src/navigation/edit/navigation-menu-name-control.js
+++ b/packages/block-library/src/navigation/edit/navigation-menu-name-control.js
@@ -5,12 +5,8 @@ import { TextControl } from '@wordpress/components';
 import { useEntityProp } from '@wordpress/core-data';
 import { __ } from '@wordpress/i18n';
 
-export default function NavigationMenuNameControl() {
-	const [ title, updateTitle ] = useEntityProp(
-		'postType',
-		'wp_navigation',
-		'title'
-	);
+export default function NavigationMenuNameControl( { kind, type } ) {
+	const [ title, updateTitle ] = useEntityProp( kind, type, 'title' );
 
 	return (
 		<TextControl

--- a/packages/block-library/src/navigation/edit/navigation-menu-selector.js
+++ b/packages/block-library/src/navigation/edit/navigation-menu-selector.js
@@ -49,7 +49,7 @@ function NavigationMenuSelector( {
 		isNavigationMenuResolved,
 		canUserCreateNavigationMenu,
 		canSwitchNavigationMenu,
-	} = useNavigationMenu();
+	} = useNavigationMenu( currentMenuId );
 
 	const [ currentTitle ] = useEntityProp(
 		'postType',
@@ -64,14 +64,14 @@ function NavigationMenuSelector( {
 
 	const menuChoices = useMemo( () => {
 		return (
-			navigationMenus?.map( ( { id, title } ) => {
+			navigationMenus?.map( ( { slug, title } ) => {
 				const label = decodeEntities( title.rendered );
-				if ( id === currentMenuId && ! isCreatingMenu ) {
+				if ( slug === currentMenuId && ! isCreatingMenu ) {
 					setSelectorLabel( currentTitle );
 					setEnableOptions( shouldEnableMenuSelector );
 				}
 				return {
-					value: id,
+					value: slug,
 					label,
 					ariaLabel: sprintf( actionLabel, label ),
 				};
@@ -85,6 +85,14 @@ function NavigationMenuSelector( {
 		isNavigationMenuResolved,
 		hasResolvedNavigationMenus,
 	] );
+
+	// If the currentMenuId is a postId then find it.
+	const menuById = navigationMenus?.find( ( { id } ) => {
+		return Number( id ) === Number( currentMenuId );
+	} );
+
+	// Use the slug of the found menu or assume it's already a slug.
+	const selectedMenuSlug = menuById ? menuById?.slug : currentMenuId;
 
 	const hasNavigationMenus = !! navigationMenus?.length;
 	const hasClassicMenus = !! classicMenus?.length;
@@ -172,9 +180,9 @@ function NavigationMenuSelector( {
 					{ showNavigationMenus && hasNavigationMenus && (
 						<MenuGroup label={ __( 'Menus' ) }>
 							<MenuItemsChoice
-								value={ currentMenuId }
-								onSelect={ ( menuId ) => {
-									onSelectNavigationMenu( menuId );
+								value={ selectedMenuSlug }
+								onSelect={ ( menuRef ) => {
+									onSelectNavigationMenu( menuRef );
 								} }
 								choices={ menuChoices }
 							/>

--- a/packages/block-library/src/navigation/edit/test/utils.js
+++ b/packages/block-library/src/navigation/edit/test/utils.js
@@ -1,0 +1,23 @@
+/**
+ * Internal dependencies
+ */
+import { isNumeric } from '../utils';
+
+describe( 'isNumeric', () => {
+	it.each( [
+		[ 42, true ],
+		[ '42', true ],
+		[ '  42  ', true ],
+		[ '', false ],
+		[ 'some-slug', false ],
+		[ 'some-42-slug-with-trailing-number-42', false ],
+		[ '42-some-42-slug-with-leading-number', false ],
+		[ NaN, false ],
+		[ Infinity, false ],
+	] )(
+		'correctly determines variable type for "%s"',
+		( candidate, expected ) => {
+			expect( isNumeric( candidate ) ).toBe( expected );
+		}
+	);
+} );

--- a/packages/block-library/src/navigation/edit/unsaved-inner-blocks.js
+++ b/packages/block-library/src/navigation/edit/unsaved-inner-blocks.js
@@ -12,11 +12,12 @@ import { useContext, useEffect, useRef, useMemo } from '@wordpress/element';
  */
 import useNavigationMenu from '../use-navigation-menu';
 import useCreateNavigationMenu from './use-create-navigation-menu';
+import { DEFAULT_ENTITY_KIND, DEFAULT_ENTITY_TYPE } from '../constants';
 
 const EMPTY_OBJECT = {};
 const DRAFT_MENU_PARAMS = [
-	'postType',
-	'wp_navigation',
+	DEFAULT_ENTITY_KIND,
+	DEFAULT_ENTITY_TYPE,
 	{ status: 'draft', per_page: -1 },
 ];
 
@@ -104,8 +105,8 @@ export default function UnsavedInnerBlocks( {
 
 				return {
 					isSaving: isSavingEntityRecord(
-						'postType',
-						'wp_navigation'
+						DEFAULT_ENTITY_KIND,
+						DEFAULT_ENTITY_TYPE
 					),
 					draftNavigationMenus: getEntityRecords(
 						...DRAFT_MENU_PARAMS

--- a/packages/block-library/src/navigation/edit/use-create-navigation-menu.js
+++ b/packages/block-library/src/navigation/edit/use-create-navigation-menu.js
@@ -5,11 +5,13 @@ import { serialize } from '@wordpress/blocks';
 import { store as coreStore } from '@wordpress/core-data';
 import { useDispatch } from '@wordpress/data';
 import { useState, useCallback } from '@wordpress/element';
+import apiFetch from '@wordpress/api-fetch';
 
 /**
  * Internal dependencies
  */
 import useGenerateDefaultNavigationTitle from './use-generate-default-navigation-title';
+import { DEFAULT_ENTITY_KIND, DEFAULT_ENTITY_TYPE } from '../constants';
 
 export const CREATE_NAVIGATION_MENU_SUCCESS = 'success';
 export const CREATE_NAVIGATION_MENU_ERROR = 'error';
@@ -27,7 +29,7 @@ export default function useCreateNavigationMenu( clientId ) {
 	// This callback uses data from the two placeholder steps and only creates
 	// a new navigation menu when the user completes the final step.
 	const create = useCallback(
-		async ( title = null, blocks = [], postStatus ) => {
+		async ( title = null, blocks = [], postStatus, slug = '' ) => {
 			// Guard against creating Navigations without a title.
 			// Note you can pass no title, but if one is passed it must be
 			// a string otherwise the title may end up being empty.
@@ -59,12 +61,49 @@ export default function useCreateNavigationMenu( clientId ) {
 			}
 			const record = {
 				title,
+				slug,
 				content: serialize( blocks ),
 				status: postStatus,
 			};
 
+			// wp_navigation entities are keyed by slug in Core Data.
+			// By default saveEntityRecord will apply an optimisation and assume that if the
+			// recordKey is included in the record being saved then this should be a "update"
+			// rather than a "save" request. Therefore it will issue PUT and append the recordKey
+			// to the request path. However this will fail as no record yet exists.
+			// The record being created (see above) optionally includes a slug. This is in order that
+			// any template hierarchy within which the Nav block was position can be persisted
+			// in the slug and retrieved for later usage.
+			// Due to the inclusion of slug in the record being created is it necessary to bypass
+			// saveEntityRecord's inbuilt "optimisations" around PUT vs POST and always issue a POST request.
+			const forceCreateMethod = 'POST';
+
+			// By default saveEntityRecord will apply an optimisation and assume that if the
+			// recordKey is included in the record being saved then this should be a "update"
+			// rather than a "save" request. This function strips the recordKey that is appended to
+			// request path to ensure the request can be routed to the POST handler on the REST API
+			// endpoint. Failured to do this results in a 404.
+			const stripRecordKeyFromRequestPath = ( path, recordKey ) =>
+				path.replace( recordKey, '' );
+
 			// Return affords ability to await on this function directly
-			return saveEntityRecord( 'postType', 'wp_navigation', record )
+			return saveEntityRecord(
+				DEFAULT_ENTITY_KIND,
+				DEFAULT_ENTITY_TYPE,
+				record,
+				{
+					__unstableFetch: ( params ) => {
+						return apiFetch( {
+							...params,
+							path: stripRecordKeyFromRequestPath(
+								params.path,
+								slug
+							),
+							method: forceCreateMethod,
+						} );
+					},
+				}
+			)
 				.then( ( response ) => {
 					setValue( response );
 					setStatus( CREATE_NAVIGATION_MENU_SUCCESS );

--- a/packages/block-library/src/navigation/edit/use-generate-default-navigation-title.js
+++ b/packages/block-library/src/navigation/edit/use-generate-default-navigation-title.js
@@ -10,17 +10,18 @@ import { __, sprintf } from '@wordpress/i18n';
 /**
  * Internal dependencies
  */
+import { DEFAULT_ENTITY_KIND, DEFAULT_ENTITY_TYPE } from '../constants';
 import useTemplatePartAreaLabel from '../use-template-part-area-label';
 
 const DRAFT_MENU_PARAMS = [
-	'postType',
-	'wp_navigation',
+	DEFAULT_ENTITY_KIND,
+	DEFAULT_ENTITY_TYPE,
 	{ status: 'draft', per_page: -1 },
 ];
 
 const PUBLISHED_MENU_PARAMS = [
-	'postType',
-	'wp_navigation',
+	DEFAULT_ENTITY_KIND,
+	DEFAULT_ENTITY_TYPE,
 	{ per_page: -1, status: 'publish' },
 ];
 

--- a/packages/block-library/src/navigation/edit/use-generated-slug.js
+++ b/packages/block-library/src/navigation/edit/use-generated-slug.js
@@ -1,0 +1,37 @@
+/**
+ * WordPress dependencies
+ */
+import { useSelect } from '@wordpress/data';
+import { store as blockEditorStore } from '@wordpress/block-editor';
+
+function useGeneratedSlug( clientId ) {
+	const slug = useSelect(
+		( select ) => {
+			// Use the lack of a clientId as an opportunity to bypass the rest
+			// of this hook.
+			if ( ! clientId ) {
+				return;
+			}
+
+			const { getBlock, getBlockParentsByBlockName } =
+				select( blockEditorStore );
+
+			// Get all/any Template Parts that are parents of this Nav block.
+			const withAscendingResults = true;
+			const parentTemplatePartClientIds = getBlockParentsByBlockName(
+				clientId,
+				'core/template-part',
+				withAscendingResults
+			);
+
+			// Use the slug of the immediate parent if found.
+			return getBlock( parentTemplatePartClientIds[ 0 ] )?.attributes
+				?.slug;
+		},
+		[ clientId ]
+	);
+
+	return slug;
+}
+
+export default useGeneratedSlug;

--- a/packages/block-library/src/navigation/edit/utils.js
+++ b/packages/block-library/src/navigation/edit/utils.js
@@ -28,3 +28,10 @@ export function detectColors(
 
 	setBackground( backgroundColor );
 }
+
+export function isNumeric( v ) {
+	if ( v === null || v === undefined || v === '' ) {
+		return false;
+	}
+	return ! isNaN( v ) && isFinite( v );
+}

--- a/packages/block-library/src/navigation/index.php
+++ b/packages/block-library/src/navigation/index.php
@@ -544,6 +544,7 @@ function render_block_core_navigation( $attributes, $content, $block ) {
 	if (
 		defined( 'IS_GUTENBERG_PLUGIN' ) && IS_GUTENBERG_PLUGIN &&
 		array_key_exists( '__unstableLocation', $attributes ) &&
+		! array_key_exists( 'slug', $attributes ) &&
 		! array_key_exists( 'ref', $attributes ) &&
 		! empty( block_core_navigation_get_menu_items_at_location( $attributes['__unstableLocation'] ) )
 	) {

--- a/packages/block-library/src/navigation/index.php
+++ b/packages/block-library/src/navigation/index.php
@@ -558,7 +558,7 @@ function render_block_core_navigation( $attributes, $content, $block ) {
 	}
 
 	// Load inner blocks from the navigation post.
-	if ( array_key_exists( 'ref', $attributes ) ) {
+	if ( array_key_exists( 'slug', $attributes ) || array_key_exists( 'ref', $attributes ) ) {
 
 		$base_args = array(
 			'post_type'              => 'wp_navigation',
@@ -568,18 +568,20 @@ function render_block_core_navigation( $attributes, $content, $block ) {
 			'no_found_rows'          => true,
 		);
 
-		if ( is_numeric( $attributes['ref'] ) ) {
+		// Prefer query by slug if available, falling
+		// back to Post ID.
+		if ( ! empty( $attributes['slug'] ) ) {
 			$args = array_merge(
 				$base_args,
 				array(
-					'p' => $attributes['ref'], // query by post ID
+					'name' => $attributes['slug'], // query by slug
 				)
 			);
 		} else {
 			$args = array_merge(
 				$base_args,
 				array(
-					'name' => $attributes['ref'], // query by slug
+					'p' => $attributes['ref'], // query by post ID
 				)
 			);
 		}

--- a/packages/block-library/src/navigation/index.php
+++ b/packages/block-library/src/navigation/index.php
@@ -559,10 +559,39 @@ function render_block_core_navigation( $attributes, $content, $block ) {
 
 	// Load inner blocks from the navigation post.
 	if ( array_key_exists( 'ref', $attributes ) ) {
-		$navigation_post = get_post( $attributes['ref'] );
-		if ( ! isset( $navigation_post ) ) {
+
+		$base_args = array(
+			'post_type'              => 'wp_navigation',
+			'nopaging'               => true,
+			'posts_per_page'         => '1',
+			'update_post_term_cache' => false,
+			'no_found_rows'          => true,
+		);
+
+		if ( is_numeric( $attributes['ref'] ) ) {
+			$args = array_merge(
+				$base_args,
+				array(
+					'p' => $attributes['ref'], // query by post ID
+				)
+			);
+		} else {
+			$args = array_merge(
+				$base_args,
+				array(
+					'name' => $attributes['ref'], // query by slug
+				)
+			);
+		}
+
+		// Query for the Navigation Post.
+		$navigation_query = new WP_Query( $args );
+
+		if ( ! isset( $navigation_query->posts[0] ) ) {
 			return '';
 		}
+
+		$navigation_post = $navigation_query->posts[0];
 
 		// Only published posts are valid. If this is changed then a corresponding change
 		// must also be implemented in `use-navigation-menu.js`.

--- a/packages/block-library/src/navigation/use-navigation-entity-types.js
+++ b/packages/block-library/src/navigation/use-navigation-entity-types.js
@@ -1,0 +1,45 @@
+/**
+ * Internal dependencies
+ */
+import { DEFAULT_ENTITY_KIND, DEFAULT_ENTITY_TYPE } from './constants';
+
+function isNumeric( v ) {
+	if ( v === null || v === undefined || v === '' ) {
+		return false;
+	}
+	return ! isNaN( v ) && isFinite( v );
+}
+
+/**
+ * Navigation posts `wp_navigation` can be referenced by slug (post_name) or
+ * by ID (post_id).
+ *
+ * By default all Navigation blocks reference the post by `slug` but the ability
+ * to reference by ID is retained for backwards compatbility purposes.
+ *
+ * There are two entity types in Gutenberg with each one representing Navigation
+ * entities keyed by slug and ID respectively.
+ *
+ * This hook determines the correct entity `kind` and `type` arguments based on
+ * the type of the `ref` given. Numeric IDs use the "legacy" postType kind whereas
+ * the `slug` based version uses a built-in `root` kind.
+ *
+ * See packages/core-data/src/entities.js
+ *
+ * @param {number|string} ref a reference to a Navigation post.
+ * @return {Array} the kind and type entities to use for the given ref type.
+ */
+function useNavigationEntityTypes( ref ) {
+	let kind, type;
+
+	if ( ! ref || ! isNumeric( ref ) ) {
+		kind = DEFAULT_ENTITY_KIND;
+		type = DEFAULT_ENTITY_TYPE;
+	} else {
+		kind = 'postType';
+		type = 'wp_navigation';
+	}
+	return [ kind, type ];
+}
+
+export default useNavigationEntityTypes;

--- a/packages/block-library/src/navigation/use-navigation-menu.js
+++ b/packages/block-library/src/navigation/use-navigation-menu.js
@@ -7,8 +7,15 @@ import {
 } from '@wordpress/core-data';
 import { useSelect } from '@wordpress/data';
 
+/**
+ * Internal dependencies
+ */
+import useNavigationEntityTypes from './use-navigation-entity-types';
+
 export default function useNavigationMenu( ref ) {
 	const permissions = useResourcePermissions( 'navigation', ref );
+
+	const entityConfig = useNavigationEntityTypes( ref );
 
 	return useSelect(
 		( select ) => {
@@ -24,13 +31,13 @@ export default function useNavigationMenu( ref ) {
 				navigationMenus,
 				isResolvingNavigationMenus,
 				hasResolvedNavigationMenus,
-			} = selectNavigationMenus( select, ref );
+			} = selectNavigationMenus( select, ref, entityConfig );
 
 			const {
 				navigationMenu,
 				isNavigationMenuResolved,
 				isNavigationMenuMissing,
-			} = selectExistingMenu( select, ref );
+			} = selectExistingMenu( select, ref, entityConfig );
 
 			return {
 				navigationMenus,
@@ -64,15 +71,12 @@ export default function useNavigationMenu( ref ) {
 	);
 }
 
-function selectNavigationMenus( select ) {
+function selectNavigationMenus( select, _ref, entityConfig ) {
 	const { getEntityRecords, hasFinishedResolution, isResolving } =
 		select( coreStore );
 
-	const args = [
-		'postType',
-		'wp_navigation',
-		{ per_page: -1, status: [ 'publish', 'draft' ] },
-	];
+	const args = [ ...entityConfig, { per_page: -1, status: 'publish' } ];
+
 	return {
 		navigationMenus: getEntityRecords( ...args ),
 		isResolvingNavigationMenus: isResolving( 'getEntityRecords', args ),
@@ -83,7 +87,7 @@ function selectNavigationMenus( select ) {
 	};
 }
 
-function selectExistingMenu( select, ref ) {
+function selectExistingMenu( select, ref, entityConfig ) {
 	if ( ! ref ) {
 		return {
 			isNavigationMenuResolved: false,
@@ -91,10 +95,11 @@ function selectExistingMenu( select, ref ) {
 		};
 	}
 
+	const args = [ ...entityConfig, ref ];
+
 	const { getEntityRecord, getEditedEntityRecord, hasFinishedResolution } =
 		select( coreStore );
 
-	const args = [ 'postType', 'wp_navigation', ref ];
 	const navigationMenu = getEntityRecord( ...args );
 	const editedNavigationMenu = getEditedEntityRecord( ...args );
 	const hasResolvedNavigationMenu = hasFinishedResolution(

--- a/packages/core-data/src/entities.js
+++ b/packages/core-data/src/entities.js
@@ -167,6 +167,28 @@ export const rootEntitiesConfig = [
 		baseURLParams: { context: 'edit' },
 		key: 'plugin',
 	},
+	{
+		// Navigation entities keyed by `slug`.
+		// Note that there is also a separate Navigation `postType` entitiy which
+		// stores `wp_navigation` posts keyed by postId for reasons relating
+		// to backwards compatibility.
+		label: __( 'Navigation Menus' ),
+		name: 'navigation',
+		kind: 'root',
+		baseURL: '/wp/v2/navigation',
+		baseURLParams: { context: 'edit' },
+		key: 'slug',
+		transientEdits: {
+			blocks: true,
+			selection: true,
+		},
+		mergedEdits: { meta: true },
+		rawAttributes: POST_RAW_ATTRIBUTES,
+		getTitle: ( record ) =>
+			record?.title?.rendered || record?.title || String( record.id ),
+		__unstablePrePersist: prePersistPostType,
+		__unstable_rest_base: 'navigation',
+	},
 ];
 
 export const additionalEntityConfigLoaders = [
@@ -181,7 +203,7 @@ export const additionalEntityConfigLoaders = [
  * @param {Object} edits           Edits.
  * @return {Object} Updated edits.
  */
-export const prePersistPostType = ( persistedRecord, edits ) => {
+export function prePersistPostType( persistedRecord, edits ) {
 	const newEdits = {};
 
 	if ( persistedRecord?.status === 'auto-draft' ) {
@@ -202,7 +224,7 @@ export const prePersistPostType = ( persistedRecord, edits ) => {
 	}
 
 	return newEdits;
-};
+}
 
 /**
  * Returns the list of post type entities.

--- a/phpunit/class-gutenberg-rest-navigation-controller-test.php
+++ b/phpunit/class-gutenberg-rest-navigation-controller-test.php
@@ -1,0 +1,253 @@
+<?php
+
+class Gutenberg_REST_Navigation_Controller_Test extends WP_Test_REST_Controller_Testcase {
+	/**
+	 * @var int
+	 */
+	protected static $admin_id;
+
+	/**
+	 * @var int
+	 */
+	protected static $test_navigation_post_id;
+
+	protected static $test_navigation_post_slug = 'test-navigation-post-slug';
+
+	public function set_up() {
+		parent::set_up();
+		switch_theme( 'emptytheme' );
+	}
+
+	/**
+	 * Create fake data before our tests run.
+	 *
+	 * @param WP_UnitTest_Factory $factory Helper that lets us create fake data.
+	 */
+	public static function wpSetupBeforeClass( $factory ) {
+		self::$admin_id = $factory->user->create(
+			array(
+				'role' => 'administrator',
+			)
+		);
+		// This creates the global styles for the current theme.
+		self::$test_navigation_post_id = wp_insert_post(
+			array(
+				'post_content' => '',
+				'post_status'  => 'publish',
+				'post_title'   => __( 'Test Navigation Menu', 'default' ),
+				'post_type'    => 'wp_navigation',
+				'post_name'    => self::$test_navigation_post_slug,
+			),
+			true
+		);
+	}
+
+	public function test_register_routes() {
+		$routes = rest_get_server()->get_routes();
+
+		$this->assertArrayHasKey(
+			'/wp/v2/navigation/((?P<id>[\d]+)|(?P<slug>[\w\-]+))',
+			$routes,
+			'Navigation based on (post) ID or slug route does not exist'
+		);
+	}
+
+	public function test_rest_route_for_post() {
+		$route = \rest_get_route_for_post( self::$test_navigation_post_id );
+
+		$this->assertEquals( '/wp/v2/navigation/' . self::$test_navigation_post_slug, $route );
+	}
+
+	public function test_context_param() {
+		$this->markTestIncomplete();
+	}
+
+	public function test_get_items() {
+		$this->markTestIncomplete();
+	}
+
+	public function test_get_item_by_slug() {
+		wp_set_current_user( self::$admin_id );
+		$request  = new WP_REST_Request( 'GET', '/wp/v2/navigation/' . self::$test_navigation_post_slug );
+		$response = rest_get_server()->dispatch( $request );
+
+		$this->assertSame( 200, $response->get_status() );
+
+		$data = $response->get_data();
+
+		$this->assertEquals(
+			self::$test_navigation_post_id,
+			$data['id']
+		);
+
+		$this->assertEquals(
+			'Test Navigation Menu',
+			$data['title']['rendered']
+		);
+
+		$this->assertEquals(
+			'test-navigation-post-slug',
+			$data['slug']
+		);
+
+		$this->assertEquals(
+			'wp_navigation',
+			$data['type']
+		);
+	}
+
+	public function test_get_item_by_id() {
+		wp_set_current_user( self::$admin_id );
+		$request  = new WP_REST_Request( 'GET', '/wp/v2/navigation/' . self::$test_navigation_post_id );
+		$response = rest_get_server()->dispatch( $request );
+
+		$this->assertSame( 200, $response->get_status() );
+
+		$data = $response->get_data();
+
+		$this->assertEquals(
+			self::$test_navigation_post_id,
+			$data['id']
+		);
+
+		$this->assertEquals(
+			'Test Navigation Menu',
+			$data['title']['rendered']
+		);
+
+		$this->assertEquals(
+			'test-navigation-post-slug',
+			$data['slug']
+		);
+
+		$this->assertEquals(
+			'wp_navigation',
+			$data['type']
+		);
+	}
+
+	public function test_get_item() {
+		$this->markTestIncomplete();
+	}
+
+	public function test_create_item() {
+		wp_set_current_user( self::$admin_id );
+
+		$request = new WP_REST_Request( 'POST', '/wp/v2/navigation' );
+		$request->set_body_params(
+			array(
+				'title'   => 'Freshly created Navigation',
+				'slug'    => 'freshly-created-navigation',
+				'status'  => 'publish',
+				'content' => '',
+			)
+		);
+		$response = rest_get_server()->dispatch( $request );
+		$this->assertSame( 201, $response->get_status() );
+
+		$data = $response->get_data();
+
+		$this->assertEquals(
+			'Freshly created Navigation',
+			$data['title']['rendered']
+		);
+
+		$this->assertEquals(
+			'freshly-created-navigation',
+			$data['slug']
+		);
+
+		$this->assertEquals(
+			'wp_navigation',
+			$data['type']
+		);
+	}
+
+	public function test_update_item() {
+		wp_set_current_user( self::$admin_id );
+
+		$request = new WP_REST_Request( 'PUT', '/wp/v2/navigation/' . self::$test_navigation_post_slug );
+		$request->set_body_params(
+			array(
+				'title' => 'New Nav title',
+				'slug'  => 'the-new-navigation-slug',
+			)
+		);
+		$response = rest_get_server()->dispatch( $request );
+		$data     = $response->get_data();
+
+		$this->assertEquals(
+			self::$test_navigation_post_id,
+			$data['id']
+		);
+
+		$this->assertEquals(
+			'New Nav title',
+			$data['title']['rendered']
+		);
+
+		$this->assertEquals(
+			'the-new-navigation-slug',
+			$data['slug']
+		);
+
+		$this->assertEquals(
+			'wp_navigation',
+			$data['type']
+		);
+	}
+
+	public function test_delete_item() {
+		wp_set_current_user( self::$admin_id );
+		$request  = new WP_REST_Request( 'DELETE', '/wp/v2/navigation/' . self::$test_navigation_post_id );
+		$response = rest_get_server()->dispatch( $request );
+
+		$this->assertSame( 200, $response->get_status() );
+
+		$data = $response->get_data();
+
+		$this->assertEquals(
+			self::$test_navigation_post_id,
+			$data['id']
+		);
+
+		$this->assertEquals(
+			'trash',
+			$data['status']
+		);
+
+		$this->assertEquals(
+			'Test Navigation Menu',
+			$data['title']['rendered']
+		);
+
+		$this->assertEquals(
+			'test-navigation-post-slug__trashed',
+			$data['slug']
+		);
+	}
+
+	public function test_permissions_requests_for_item() {
+		$this->markTestSkipped( 'Skipped as OPTIONS requests do not contain headers when running phpunit' );
+		wp_set_current_user( self::$admin_id );
+		$request  = new WP_REST_Request( 'OPTIONS', '/wp/v2/navigation/' . self::$test_navigation_post_slug );
+		$response = rest_get_server()->dispatch( $request );
+
+		$this->assertSame( 200, $response->get_status() );
+
+		$headers = $response->get_headers();
+
+		$this->assertEquals(
+			'GET, POST, PUT, PATCH, DELETE',
+			$headers['Allow']
+		);
+	}
+
+	public function test_prepare_item() {
+		$this->markTestIncomplete();
+	}
+
+	public function test_get_item_schema() {
+		$this->markTestIncomplete();
+	}
+}


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->




## What?
<!-- In a few words, what is the PR actually doing? -->

In https://github.com/WordPress/gutenberg/issues/38291#issuecomment-1196781907 we discussed why it is important that the Navigation block uses string based `slug` as the way for it to "refer" (via an attribute) to a Navigation post containing it's "items".

This PR seeks to address that by adding a new `slug` attribute and soft deprecating the existing `ref` attribute. This allows the block to use a `slug` to refer to a menu (`wp_navigation` post) and updating the REST API to understand how to handle that.

**Please note**: this PR is deliberately limited in scope. It does _not_ attempt to implement any fallback behaviour relating to pick the "most appropriate" Navigation to use in the absence of an explicit reference. For example, this PR won't fix the situation whereby you switch Themes and the Navigation Menu isn't carried across the to new theme's Navigation block (although this PR does lay the foundation for such an effort).

Addresses part of work towards https://github.com/WordPress/gutenberg/issues/38291

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

See https://github.com/WordPress/gutenberg/issues/38291#issuecomment-1196781907 for full explaination.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

This PR:

- adds a custom REST Controller for requests to `wp/v2/navigation` which adds a new endpoint to handle making requests for individual `wp_navigation` posts by their `post_name` (a.k.a `slug`) or by `post_id` (for backwards compatibility).
- adds test coverage to the endpoint
- adds a new `slug` attribute to the block.
- soft deprecates the block's `ref` attribute.
- updates internals of Nav block to handle using the `navigation` post's `slug` (i.e. `post_name`) as the reference.
- adds _temporary_ fix (relating to https://github.com/WordPress/gutenberg/pull/43703) to `OPTIONS` permissions requests by overloading implementation of `get_post` method within the new Navigation REST Controller.

## Dependencies

- [x] ~https://github.com/WordPress/gutenberg/pull/43703 - without this calls to `canUser` with a `slug` will not provide the correct permissions.~ I've created a workaround for this by overloading the `get_post` method to map slug to ID.

## Todo

- [x] Make it possible to continue to be able to retrieve the Nav Menu by post ID as well as slug (for backwards compat reasons).
- [x] We should consider that [the _endpoint_ may already be in use](https://github.com/WordPress/gutenberg/pull/42940#issuecomment-1205293872). Therefore changing it to expect slugs is considered a breaking change unless we also keep it backwards compatible with IDs.
- [x] [Problem using `saveEntityRecord` for `update` requests](https://github.com/WordPress/gutenberg/pull/42809#issuecomment-1199244509).
- [ ] Data migration - do we want to simply force update all existing blocks to have their `ref` change from ID to slug or do we want to preserve the existing data?
- [x] Ensure `rest_get_route_for_post` is filtered to account for usage of `slug`.
- [x] Fix front of site implementation to fetch Navigations by slug.
- [ ] Create opt out for data migration from postID to slug (just in case).
- [ ] Fix bug with `Select menu` which doesn't pick the correct menu due to being `ID` based.


## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->

### Manual

- on `trunk` create a Navigation Menu using the block. You can use the Post Editor or the Site Editor.
- Check the block has a numerical `ref` attribute corresponding to the Navigation Post's `ID` field.
- Publish your Post.
- check out this PR
- re-open the Post you created with the Navigation block's - you should see the block loads the menu and you can manipulate it as per usual (i.e. edit, update, delete...etc).
- Add a new Navigation block and create a new Navigation Menu using that block.
- Check that the block has a string-based `ref` which corresponds to the `slug` of the Navigation Post. 
- Check you can manipulate the block as per usual (i.e. edit, update, delete...etc).
- Update your Post.
- _Reload_ your post and check that both the ID based and the Slug based Navigation block's load correctly.
- Switch to the front end of your site - check that both Navigations display correctly.



### REST

Run tests using

```
npm run test:unit:php /var/www/html/wp-content/plugins/gutenberg/phpunit/class-gutenberg-rest-navigation-controller-test.php
```

## Screenshots or screencast <!-- if applicable -->


https://user-images.githubusercontent.com/444434/188153247-7e94c651-ba8a-4987-b218-162c7ce655ae.mp4


