### PR TITLE
Fix Top toolbar buttons tooltips and style when 'Show button text labels' is enabled

### DIFF
--- a/packages/edit-post/src/components/header/header-toolbar/index.js
+++ b/packages/edit-post/src/components/header/header-toolbar/index.js
@@ -95,6 +95,7 @@ function HeaderToolbar() {
 				onClick={ toggleListView }
 				shortcut={ listViewShortcut }
 				showTooltip={ ! showIconLabels }
+				variant={ showIconLabels ? 'tertiary' : undefined }
 			/>
 		</>
 	);

--- a/packages/edit-site/src/components/header/document-actions/index.js
+++ b/packages/edit-site/src/components/header/document-actions/index.js
@@ -141,6 +141,9 @@ export default function DocumentActions( {
 								aria-expanded={ isOpen }
 								aria-haspopup="true"
 								onClick={ onToggle }
+								variant={
+									showIconLabels ? 'tertiary' : undefined
+								}
 								label={ sprintf(
 									/* translators: %s: the entity to see details about, like "template"*/
 									__( 'Show %s details' ),

--- a/packages/edit-site/src/components/header/index.js
+++ b/packages/edit-site/src/components/header/index.js
@@ -168,6 +168,9 @@ export default function Header( {
 								onClick={ toggleListView }
 								shortcut={ listViewShortcut }
 								showTooltip={ ! showIconLabels }
+								variant={
+									showIconLabels ? 'tertiary' : undefined
+								}
 							/>
 						</>
 					) }
@@ -207,7 +210,7 @@ export default function Header( {
 						isEntitiesSavedStatesOpen={ isEntitiesSavedStatesOpen }
 					/>
 					<PinnedItems.Slot scope="core/edit-site" />
-					<MoreMenu />
+					<MoreMenu showIconLabels={ showIconLabels } />
 				</div>
 			</div>
 		</div>

--- a/packages/edit-site/src/components/header/more-menu/index.js
+++ b/packages/edit-site/src/components/header/more-menu/index.js
@@ -21,7 +21,7 @@ import WelcomeGuideMenuItem from './welcome-guide-menu-item';
 import CopyContentMenuItem from './copy-content-menu-item';
 import ModeSwitcher from '../mode-switcher';
 
-export default function MoreMenu() {
+export default function MoreMenu( { showIconLabels } ) {
 	const [ isModalActive, toggleModal ] = useReducer(
 		( isActive ) => ! isActive,
 		false
@@ -36,7 +36,12 @@ export default function MoreMenu() {
 
 	return (
 		<>
-			<MoreMenuDropdown>
+			<MoreMenuDropdown
+				toggleProps={ {
+					showTooltip: ! showIconLabels,
+					...( showIconLabels && { variant: 'tertiary' } ),
+				} }
+			>
 				{ ( { onClose } ) => (
 					<>
 						<MenuGroup label={ _x( 'View', 'noun' ) }>

--- a/packages/edit-site/src/components/sidebar/default-sidebar.js
+++ b/packages/edit-site/src/components/sidebar/default-sidebar.js
@@ -5,6 +5,12 @@ import {
 	ComplementaryArea,
 	ComplementaryAreaMoreMenuItem,
 } from '@wordpress/interface';
+import { useSelect } from '@wordpress/data';
+
+/**
+ * Internal dependencies
+ */
+import { store as editSiteStore } from '../../store';
 
 export default function DefaultSidebar( {
 	className,
@@ -17,6 +23,11 @@ export default function DefaultSidebar( {
 	headerClassName,
 	panelClassName,
 } ) {
+	const showIconLabels = useSelect(
+		( select ) => select( editSiteStore ).getSettings().showIconLabels,
+		[]
+	);
+
 	return (
 		<>
 			<ComplementaryArea
@@ -29,6 +40,7 @@ export default function DefaultSidebar( {
 				header={ header }
 				headerClassName={ headerClassName }
 				panelClassName={ panelClassName }
+				showIconLabels={ showIconLabels }
 			>
 				{ children }
 			</ComplementaryArea>

--- a/packages/edit-site/src/components/sidebar/plugin-sidebar/index.js
+++ b/packages/edit-site/src/components/sidebar/plugin-sidebar/index.js
@@ -2,6 +2,12 @@
  * WordPress dependencies
  */
 import { ComplementaryArea } from '@wordpress/interface';
+import { useSelect } from '@wordpress/data';
+
+/**
+ * Internal dependencies
+ */
+import { store as editSiteStore } from '../../../store';
 
 /**
  * Renders a sidebar when activated. The contents within the `PluginSidebar` will appear as content within the sidebar.
@@ -69,11 +75,17 @@ import { ComplementaryArea } from '@wordpress/interface';
  * ```
  */
 export default function PluginSidebarEditSite( { className, ...props } ) {
+	const showIconLabels = useSelect(
+		( select ) => select( editSiteStore ).getSettings().showIconLabels,
+		[]
+	);
+
 	return (
 		<ComplementaryArea
 			panelClassName={ className }
 			className="edit-site-sidebar"
 			scope="core/edit-site"
+			showIconLabels={ showIconLabels }
 			{ ...props }
 		/>
 	);


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->
Fixes https://github.com/WordPress/gutenberg/issues/42676

## What?
<!-- In a few words, what is the PR actually doing? -->
Makes the Top toolbar tooltips and style consistent when the 'Show button text labels' preference is enabled.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
When 'Show button text labels' is enabled:
- Only the buttons that are associated with a keyboard shortcut should display a tooltip, to visually expose the shortcut.
- All the other buttons should not show tooltips that just repeat the visible button text.
- All the buttons should use the `tertiary` style, except the 'Publish / Save' buttons. This was missed for some buttons and it was also inconsistent between the Post Editor and the Site Editor.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
- Retrieves the `showIconLabels` preference and passes it where necessary.
- Uses the `showIconLabels` to determine the button tertiary `variant` prop value in a consistent way across buttons and editors.

## Testing Instructions
- Go to the Post Editor,
- Check there are no changes to the Top toolbar buttons tooltips behavior.
- Go to Options > Preferences, and enable 'Show button text labels'.
- Check the Top toolbar button tooltips appear only for buttons that have a keyboard shortcut.
- Check all the Top toolbar buttons have a tertiary style, except 'Publish'.
- Note: the 'Save draft' buttons has a very special behavior, will split it out to a separate issue.
- Check also with a small viewport.
- Go to the Site Editor.
- Check there are no changes to the Top toolbar buttons tooltips behavior.
- Go to Options > Preferences, and enable 'Show button text labels'.
- Check the Top toolbar button tooltips appear only for buttons that have a keyboard shortcut.
- Check all the Top toolbar buttons have a tertiary style, except 'Save'.  
- Check also with a small viewport.

Reminder: the 'Undo' and 'Redo' buttons are disabled by default. Make some changes to add undo/redo history steps and check the buttons have a tertiary style.

## Screenshots or screencast <!-- if applicable -->

For the missing tertiary style, see screenshots on the issue https://github.com/WordPress/gutenberg/issues/42676#issuecomment-1198950663