### PR TITLE
Rich text: fix error when attempting to remove placeholder on composition start

### DIFF
--- a/packages/rich-text/src/component/use-input-and-selection.js
+++ b/packages/rich-text/src/component/use-input-and-selection.js
@@ -253,7 +253,7 @@ export function useInputAndSelection( props ) {
 			// during composition, the placeholder doesn't get removed. There's
 			// no need to re-add it, when the value is updated on compositionend
 			// it will be re-added when the value is empty.
-			element.querySelector( `[${ PLACEHOLDER_ATTR_NAME }]` ).remove();
+			element.querySelector( `[${ PLACEHOLDER_ATTR_NAME }]` )?.remove();
 		}
 
 		function onCompositionEnd() {


### PR DESCRIPTION

<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?

Introduced in #41970.

Fixes an error when composing characters in empty rich text without placeholder.

This is a really stupid mistake in retrospect. We should didn't check if ``element.querySelector( `[${ PLACEHOLDER_ATTR_NAME }]` )`` is null before removing it. I don't think there's any instances by default where we don't have a placeholder, and composition from an empty rich text is rare and cannot be e2e tested.

## Why?

Bug fix.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->

## Screenshots or screencast <!-- if applicable -->
