### PR TITLE
Block Locking: prevent override of parent's Template Lock

### DIFF
--- a/packages/block-editor/src/components/block-lock/use-block-lock.js
+++ b/packages/block-editor/src/components/block-lock/use-block-lock.js
@@ -25,18 +25,22 @@ export default function useBlockLock( clientId ) {
 				canLockBlockType,
 				getBlockName,
 				getBlockRootClientId,
+				getTemplateLock,
 			} = select( blockEditorStore );
 			const rootClientId = getBlockRootClientId( clientId );
 
 			const canEdit = canEditBlock( clientId );
 			const canMove = canMoveBlock( clientId, rootClientId );
 			const canRemove = canRemoveBlock( clientId, rootClientId );
+			const parentLock = getTemplateLock( rootClientId );
 
 			return {
 				canEdit,
 				canMove,
 				canRemove,
-				canLock: canLockBlockType( getBlockName( clientId ) ),
+				canLock:
+					canLockBlockType( getBlockName( clientId ) ) &&
+					! parentLock,
 				isLocked: ! canEdit || ! canMove || ! canRemove,
 			};
 		},


### PR DESCRIPTION
## What?
Prevent users from overriding the locks on a block imposed by the parent via `templateLock`.

## Why?
Currently, if a post type or parent block uses `templateLock`, users can override those movement/removal restrictions on individual inner blocks. I feel this is counter-intuitive; if I intend a block's content to be fixed, the user should not be able to override it.

This can actually render the block or entire block editor unusable. For example, say I have a post type with a template set to a single main content block, and set the template_lock to "insert"; the intention is that the main block cannot be removed and nothing can be added above/below it. Currently, the user would be able to override that lock, delete the block, and be left with now way to insert content, because the insert prevention is still in place.

The only current workarounds are to either disable lock support on the applicable blocks, or set the canLockBlocks setting to false. Neither of which are ideal as there may be instances within that same page where locking is permitted on the blocks involved.

## How?
While not comprehensive (as lock overrides can still be set via other means), this PR adds a check to the `useBlockLock` hook to check if there is a parent lock in place when calculating the `canLock` flag, rather than solely on the lock-ability of the block's type. I can see some edge cases where you'd want to programatically allow removing blocks from an otherwise fixed template.

## Testing Instructions
1. Register a post type with a template (e.g. a single paragraph) and `template_lock` set to "insert" or "all"
2. Create a new post of that type, and select the block
3. The Unlock menu/toolbar item should *not* be present, nor should Remove Block from the block menu
4. Use the code editor to manualy add a `lock.remove` override (`{"lock":{"remove":false}}`)
5. The Remove Block option should now be available
