### PR TITLE
Change shortcut text for redo tooltip on Windows

### DIFF
--- a/packages/customize-widgets/src/components/header/index.js
+++ b/packages/customize-widgets/src/components/header/index.js
@@ -7,10 +7,10 @@ import classnames from 'classnames';
  * WordPress dependencies
  */
 import { createPortal, useState, useEffect } from '@wordpress/element';
-import { __, _x, isRTL } from '@wordpress/i18n';
+import { __, _x, sprintf, isRTL } from '@wordpress/i18n';
 import { ToolbarButton } from '@wordpress/components';
 import { NavigableToolbar } from '@wordpress/block-editor';
-import { displayShortcut } from '@wordpress/keycodes';
+import { displayShortcut, isAppleOS } from '@wordpress/keycodes';
 import { plus, undo as undoIcon, redo as redoIcon } from '@wordpress/icons';
 
 /**
@@ -30,6 +30,15 @@ function Header( {
 		sidebar.hasUndo(),
 		sidebar.hasRedo(),
 	] );
+
+	const shortcut = isAppleOS()
+		? displayShortcut.primaryShift( 'z' )
+		: sprintf(
+				// translators: %1$s: Shortcut text. %2$s: Shortcut text.
+				'%1$s or %2$s',
+				displayShortcut.primaryShift( 'z' ),
+				displayShortcut.primary( 'y' )
+		  );
 
 	useEffect( () => {
 		return sidebar.subscribeHistory( () => {
@@ -64,7 +73,7 @@ function Header( {
 						icon={ ! isRTL() ? redoIcon : undoIcon }
 						/* translators: button label text should, if possible, be under 16 characters. */
 						label={ __( 'Redo' ) }
-						shortcut={ displayShortcut.primaryShift( 'z' ) }
+						shortcut={ shortcut }
 						// If there are no undo levels we don't want to actually disable this
 						// button, because it will remove focus for keyboard users.
 						// See: https://github.com/WordPress/gutenberg/issues/3486

--- a/packages/customize-widgets/src/components/header/index.js
+++ b/packages/customize-widgets/src/components/header/index.js
@@ -7,7 +7,7 @@ import classnames from 'classnames';
  * WordPress dependencies
  */
 import { createPortal, useState, useEffect } from '@wordpress/element';
-import { __, _x, sprintf, isRTL } from '@wordpress/i18n';
+import { __, _x, isRTL } from '@wordpress/i18n';
 import { ToolbarButton } from '@wordpress/components';
 import { NavigableToolbar } from '@wordpress/block-editor';
 import { displayShortcut, isAppleOS } from '@wordpress/keycodes';
@@ -33,12 +33,7 @@ function Header( {
 
 	const shortcut = isAppleOS()
 		? displayShortcut.primaryShift( 'z' )
-		: sprintf(
-				// translators: %1$s: Shortcut text. %2$s: Shortcut text.
-				'%1$s or %2$s',
-				displayShortcut.primaryShift( 'z' ),
-				displayShortcut.primary( 'y' )
-		  );
+		: displayShortcut.primary( 'y' );
 
 	useEffect( () => {
 		return sidebar.subscribeHistory( () => {

--- a/packages/edit-navigation/src/components/header/redo-button.js
+++ b/packages/edit-navigation/src/components/header/redo-button.js
@@ -1,14 +1,23 @@
 /**
  * WordPress dependencies
  */
-import { __, isRTL } from '@wordpress/i18n';
+import { __, sprintf, isRTL } from '@wordpress/i18n';
 import { ToolbarButton } from '@wordpress/components';
 import { useSelect, useDispatch } from '@wordpress/data';
 import { redo as redoIcon, undo as undoIcon } from '@wordpress/icons';
-import { displayShortcut } from '@wordpress/keycodes';
+import { displayShortcut, isAppleOS } from '@wordpress/keycodes';
 import { store as coreStore } from '@wordpress/core-data';
 
 export default function RedoButton() {
+	const shortcut = isAppleOS()
+		? displayShortcut.primaryShift( 'z' )
+		: sprintf(
+				// translators: %1$s: Shortcut text. %2$s: Shortcut text.
+				'%1$s or %2$s',
+				displayShortcut.primaryShift( 'z' ),
+				displayShortcut.primary( 'y' )
+		  );
+
 	const hasRedo = useSelect(
 		( select ) => select( coreStore ).hasRedo(),
 		[]
@@ -18,7 +27,7 @@ export default function RedoButton() {
 		<ToolbarButton
 			icon={ ! isRTL() ? redoIcon : undoIcon }
 			label={ __( 'Redo' ) }
-			shortcut={ displayShortcut.primaryShift( 'z' ) }
+			shortcut={ shortcut }
 			// If there are no undo levels we don't want to actually disable this
 			// button, because it will remove focus for keyboard users.
 			// See: https://github.com/WordPress/gutenberg/issues/3486

--- a/packages/edit-navigation/src/components/header/redo-button.js
+++ b/packages/edit-navigation/src/components/header/redo-button.js
@@ -1,7 +1,7 @@
 /**
  * WordPress dependencies
  */
-import { __, sprintf, isRTL } from '@wordpress/i18n';
+import { __, isRTL } from '@wordpress/i18n';
 import { ToolbarButton } from '@wordpress/components';
 import { useSelect, useDispatch } from '@wordpress/data';
 import { redo as redoIcon, undo as undoIcon } from '@wordpress/icons';
@@ -11,12 +11,7 @@ import { store as coreStore } from '@wordpress/core-data';
 export default function RedoButton() {
 	const shortcut = isAppleOS()
 		? displayShortcut.primaryShift( 'z' )
-		: sprintf(
-				// translators: %1$s: Shortcut text. %2$s: Shortcut text.
-				'%1$s or %2$s',
-				displayShortcut.primaryShift( 'z' ),
-				displayShortcut.primary( 'y' )
-		  );
+		: displayShortcut.primary( 'y' );
 
 	const hasRedo = useSelect(
 		( select ) => select( coreStore ).hasRedo(),

--- a/packages/edit-site/src/components/header/undo-redo/redo.js
+++ b/packages/edit-site/src/components/header/undo-redo/redo.js
@@ -1,15 +1,24 @@
 /**
  * WordPress dependencies
  */
-import { __, isRTL } from '@wordpress/i18n';
+import { __, sprintf, isRTL } from '@wordpress/i18n';
 import { Button } from '@wordpress/components';
 import { useSelect, useDispatch } from '@wordpress/data';
 import { redo as redoIcon, undo as undoIcon } from '@wordpress/icons';
-import { displayShortcut } from '@wordpress/keycodes';
+import { displayShortcut, isAppleOS } from '@wordpress/keycodes';
 import { store as coreStore } from '@wordpress/core-data';
 import { forwardRef } from '@wordpress/element';
 
 function RedoButton( props, ref ) {
+	const shortcut = isAppleOS()
+		? displayShortcut.primaryShift( 'z' )
+		: sprintf(
+				// translators: %1$s: Shortcut text. %2$s: Shortcut text.
+				'%1$s or %2$s',
+				displayShortcut.primaryShift( 'z' ),
+				displayShortcut.primary( 'y' )
+		  );
+
 	const hasRedo = useSelect(
 		( select ) => select( coreStore ).hasRedo(),
 		[]
@@ -21,7 +30,7 @@ function RedoButton( props, ref ) {
 			ref={ ref }
 			icon={ ! isRTL() ? redoIcon : undoIcon }
 			label={ __( 'Redo' ) }
-			shortcut={ displayShortcut.primaryShift( 'z' ) }
+			shortcut={ shortcut }
 			// If there are no undo levels we don't want to actually disable this
 			// button, because it will remove focus for keyboard users.
 			// See: https://github.com/WordPress/gutenberg/issues/3486

--- a/packages/edit-site/src/components/header/undo-redo/redo.js
+++ b/packages/edit-site/src/components/header/undo-redo/redo.js
@@ -1,7 +1,7 @@
 /**
  * WordPress dependencies
  */
-import { __, sprintf, isRTL } from '@wordpress/i18n';
+import { __, isRTL } from '@wordpress/i18n';
 import { Button } from '@wordpress/components';
 import { useSelect, useDispatch } from '@wordpress/data';
 import { redo as redoIcon, undo as undoIcon } from '@wordpress/icons';
@@ -12,12 +12,7 @@ import { forwardRef } from '@wordpress/element';
 function RedoButton( props, ref ) {
 	const shortcut = isAppleOS()
 		? displayShortcut.primaryShift( 'z' )
-		: sprintf(
-				// translators: %1$s: Shortcut text. %2$s: Shortcut text.
-				'%1$s or %2$s',
-				displayShortcut.primaryShift( 'z' ),
-				displayShortcut.primary( 'y' )
-		  );
+		: displayShortcut.primary( 'y' );
 
 	const hasRedo = useSelect(
 		( select ) => select( coreStore ).hasRedo(),

--- a/packages/edit-widgets/src/components/header/undo-redo/redo.js
+++ b/packages/edit-widgets/src/components/header/undo-redo/redo.js
@@ -1,14 +1,23 @@
 /**
  * WordPress dependencies
  */
-import { __, isRTL } from '@wordpress/i18n';
+import { __, sprintf, isRTL } from '@wordpress/i18n';
 import { ToolbarButton } from '@wordpress/components';
 import { useSelect, useDispatch } from '@wordpress/data';
 import { redo as redoIcon, undo as undoIcon } from '@wordpress/icons';
-import { displayShortcut } from '@wordpress/keycodes';
+import { displayShortcut, isAppleOS } from '@wordpress/keycodes';
 import { store as coreStore } from '@wordpress/core-data';
 
 export default function RedoButton() {
+	const shortcut = isAppleOS()
+		? displayShortcut.primaryShift( 'z' )
+		: sprintf(
+				// translators: %1$s: Shortcut text. %2$s: Shortcut text.
+				'%1$s or %2$s',
+				displayShortcut.primaryShift( 'z' ),
+				displayShortcut.primary( 'y' )
+		  );
+
 	const hasRedo = useSelect(
 		( select ) => select( coreStore ).hasRedo(),
 		[]
@@ -18,7 +27,7 @@ export default function RedoButton() {
 		<ToolbarButton
 			icon={ ! isRTL() ? redoIcon : undoIcon }
 			label={ __( 'Redo' ) }
-			shortcut={ displayShortcut.primaryShift( 'z' ) }
+			shortcut={ shortcut }
 			// If there are no undo levels we don't want to actually disable this
 			// button, because it will remove focus for keyboard users.
 			// See: https://github.com/WordPress/gutenberg/issues/3486

--- a/packages/edit-widgets/src/components/header/undo-redo/redo.js
+++ b/packages/edit-widgets/src/components/header/undo-redo/redo.js
@@ -1,7 +1,7 @@
 /**
  * WordPress dependencies
  */
-import { __, sprintf, isRTL } from '@wordpress/i18n';
+import { __, isRTL } from '@wordpress/i18n';
 import { ToolbarButton } from '@wordpress/components';
 import { useSelect, useDispatch } from '@wordpress/data';
 import { redo as redoIcon, undo as undoIcon } from '@wordpress/icons';
@@ -11,12 +11,7 @@ import { store as coreStore } from '@wordpress/core-data';
 export default function RedoButton() {
 	const shortcut = isAppleOS()
 		? displayShortcut.primaryShift( 'z' )
-		: sprintf(
-				// translators: %1$s: Shortcut text. %2$s: Shortcut text.
-				'%1$s or %2$s',
-				displayShortcut.primaryShift( 'z' ),
-				displayShortcut.primary( 'y' )
-		  );
+		: displayShortcut.primary( 'y' );
 
 	const hasRedo = useSelect(
 		( select ) => select( coreStore ).hasRedo(),

--- a/packages/editor/src/components/editor-history/redo.js
+++ b/packages/editor/src/components/editor-history/redo.js
@@ -1,7 +1,7 @@
 /**
  * WordPress dependencies
  */
-import { __, sprintf, isRTL } from '@wordpress/i18n';
+import { __, isRTL } from '@wordpress/i18n';
 import { Button } from '@wordpress/components';
 import { useSelect, useDispatch } from '@wordpress/data';
 import { displayShortcut, isAppleOS } from '@wordpress/keycodes';
@@ -16,12 +16,7 @@ import { store as editorStore } from '../../store';
 function EditorHistoryRedo( props, ref ) {
 	const shortcut = isAppleOS()
 		? displayShortcut.primaryShift( 'z' )
-		: sprintf(
-				// translators: %1$s: Shortcut text. %2$s: Shortcut text.
-				'%1$s or %2$s',
-				displayShortcut.primaryShift( 'z' ),
-				displayShortcut.primary( 'y' )
-		  );
+		: displayShortcut.primary( 'y' );
 
 	const hasRedo = useSelect(
 		( select ) => select( editorStore ).hasEditorRedo(),

--- a/packages/editor/src/components/editor-history/redo.js
+++ b/packages/editor/src/components/editor-history/redo.js
@@ -1,10 +1,10 @@
 /**
  * WordPress dependencies
  */
-import { __, isRTL } from '@wordpress/i18n';
+import { __, sprintf, isRTL } from '@wordpress/i18n';
 import { Button } from '@wordpress/components';
 import { useSelect, useDispatch } from '@wordpress/data';
-import { displayShortcut } from '@wordpress/keycodes';
+import { displayShortcut, isAppleOS } from '@wordpress/keycodes';
 import { redo as redoIcon, undo as undoIcon } from '@wordpress/icons';
 import { forwardRef } from '@wordpress/element';
 
@@ -14,6 +14,15 @@ import { forwardRef } from '@wordpress/element';
 import { store as editorStore } from '../../store';
 
 function EditorHistoryRedo( props, ref ) {
+	const shortcut = isAppleOS()
+		? displayShortcut.primaryShift( 'z' )
+		: sprintf(
+				// translators: %1$s: Shortcut text. %2$s: Shortcut text.
+				'%1$s or %2$s',
+				displayShortcut.primaryShift( 'z' ),
+				displayShortcut.primary( 'y' )
+		  );
+
 	const hasRedo = useSelect(
 		( select ) => select( editorStore ).hasEditorRedo(),
 		[]
@@ -26,7 +35,7 @@ function EditorHistoryRedo( props, ref ) {
 			icon={ ! isRTL() ? redoIcon : undoIcon }
 			/* translators: button label text should, if possible, be under 16 characters. */
 			label={ __( 'Redo' ) }
-			shortcut={ displayShortcut.primaryShift( 'z' ) }
+			shortcut={ shortcut }
 			// If there are no redo levels we don't want to actually disable this
 			// button, because it will remove focus for keyboard users.
 			// See: https://github.com/WordPress/gutenberg/issues/3486


### PR DESCRIPTION
Follow up on #42627

## What?
~~This PR adds Ctrl+Y text for redo tooltip on Windows.~~
This PR changes the shortcut text for redo tooltip from `Ctrl + Shift + Z` to `Ctrl + Y` on Windows.

## Why?
In #42627, a new shortcut `Ctrl + Y` has been added on Windows.
It was correctly displayed in the keyboard modal window but was not included in the tooltip when the Redo button was focused.

## How?
~~I considered simply separating the text with a slash, but I ran it through a `sprintf` function because the meaning may not be conveyed in some languages.~~
I replaced it with `Ctrl+Y`, which is the default redo command in Windows.

## Testing Instructions
These tooptips are shown in following 5 area.
On Macs, please make sure the text has not changed.

### Post Editor

![post-editor](https://user-images.githubusercontent.com/54422211/182296955-04bd19fe-855d-4550-a149-7e654b34198f.png)

### Site Editor

![site-editor](https://user-images.githubusercontent.com/54422211/182296974-3fc3a44e-e5f2-4f00-9ed5-c89268f9d5bd.png)

### Widget Editor

![widget-editor](https://user-images.githubusercontent.com/54422211/182296998-35308426-3992-41f8-9d24-ada0bf341e3f.png)

### Customizer 

![customizer-widget](https://user-images.githubusercontent.com/54422211/182297011-022cf1eb-a4f1-4524-8c4c-499795b2b864.png)

### Edit Navigation

I couldn't figure out how to access this, but I believe it should appear correctly.