### PR TITLE
Block Preview: Add ability for previews to render block patterns.

### DIFF
--- a/packages/block-editor/src/components/block-preview/index.js
+++ b/packages/block-editor/src/components/block-preview/index.js
@@ -19,6 +19,7 @@ import LiveBlockPreview from './live';
 import AutoHeightBlockPreview from './auto';
 import { store as blockEditorStore } from '../../store';
 import { BlockListItems } from '../block-list';
+import { getBlockPreviewPatterns, getPatternsFromBlocks } from './patterns';
 
 export function BlockPreview( {
 	blocks,
@@ -34,9 +35,12 @@ export function BlockPreview( {
 	);
 	const settings = useMemo( () => {
 		const _settings = { ...originalSettings };
-		_settings.__experimentalBlockPatterns = [];
+		_settings.__experimentalBlockPatterns = getBlockPreviewPatterns(
+			_settings.__experimentalBlockPatterns,
+			getPatternsFromBlocks( blocks )
+		);
 		return _settings;
-	}, [ originalSettings ] );
+	}, [ originalSettings, blocks ] );
 	const renderedBlocks = useMemo( () => castArray( blocks ), [ blocks ] );
 	if ( ! blocks || blocks.length === 0 ) {
 		return null;
@@ -97,8 +101,14 @@ export function useBlockPreview( {
 	const disabledRef = useDisabled();
 	const ref = useMergeRefs( [ props.ref, disabledRef ] );
 	const settings = useMemo(
-		() => ( { ...originalSettings, __experimentalBlockPatterns: [] } ),
-		[ originalSettings ]
+		() => ( {
+			...originalSettings,
+			__experimentalBlockPatterns: getBlockPreviewPatterns(
+				originalSettings.__experimentalBlockPatterns,
+				getPatternsFromBlocks( blocks )
+			),
+		} ),
+		[ originalSettings, blocks ]
 	);
 	const renderedBlocks = useMemo( () => castArray( blocks ), [ blocks ] );
 

--- a/packages/block-editor/src/components/block-preview/patterns.js
+++ b/packages/block-editor/src/components/block-preview/patterns.js
@@ -1,0 +1,142 @@
+/**
+ * Gets all of the patterns needed for block preview.
+ *
+ * @param {Object[]} allPatterns       All registered patterns.
+ * @param {Set}      patternsToPreview Patterns found in blocks.
+ * @return {Object[]} Array of pattern data for block preview.
+ */
+export function getBlockPreviewPatterns( allPatterns, patternsToPreview ) {
+	// Return early if no patterns are in the preview.
+	if ( patternsToPreview.size === 0 ) {
+		return [];
+	}
+
+	if ( allPatterns.length === 0 ) {
+		return [];
+	}
+
+	let patterns = allPatterns.filter( ( pattern ) =>
+		patternsToPreview.has( pattern.name )
+	);
+
+	let currentPatterns = patternsToPreview;
+
+	currentPatterns = patterns.reduce( ( set, pattern ) => {
+		const innerPatterns = getPatternsWithinPattern(
+			pattern,
+			allPatterns,
+			currentPatterns
+		);
+
+		innerPatterns.forEach( ( patternName ) => set.add( patternName ) );
+
+		return set;
+	}, currentPatterns );
+
+	patterns = allPatterns.filter( ( pattern ) =>
+		currentPatterns.has( pattern.name )
+	);
+
+	return patterns;
+}
+
+/**
+ * Search for patterns recursively within pattern.
+ *
+ * @param {Object}   pattern         The pattern to look at.
+ * @param {Object[]} allPatterns     All registered patterns.
+ * @param {Set}      currentPatterns Set of patterns we already know exist for blocks.
+ * @return {Set} Set of patterns that exist for blocks.
+ */
+function getPatternsWithinPattern(
+	pattern,
+	allPatterns,
+	currentPatterns = new Set()
+) {
+	if ( ! pattern.content || ! pattern.content.length ) {
+		return new Set();
+	}
+
+	const regex = /wp:pattern\s*{.*"slug":\s*"(.*)"/g;
+
+	const match = Array.from( pattern.content.matchAll( regex ) );
+
+	if ( ! match || ! match.length || ! Array.isArray( match ) ) {
+		return new Set();
+	}
+
+	const patternsWithin = match.reduce( ( set, regexMatch ) => {
+		// Add capture group for slug.
+		set.add( regexMatch[ 1 ] );
+
+		return set;
+	}, new Set() );
+
+	const allPatternsWithin = allPatterns
+		.filter( ( innerPattern ) => patternsWithin.has( innerPattern.name ) )
+		// Avoid circular refrences by filtering out any patterns to be included already.
+		.filter(
+			( innerPattern ) => ! currentPatterns.has( innerPattern.name )
+		);
+
+	// Add new patterns to currentPatterns list of patterns we have already included.
+	allPatternsWithin.forEach( ( innerPattern ) =>
+		currentPatterns.add( innerPattern.name )
+	);
+
+	if ( allPatternsWithin && allPatternsWithin.length ) {
+		allPatternsWithin.forEach( ( innerPattern ) => {
+			const innerPatterns = getPatternsWithinPattern(
+				innerPattern,
+				allPatterns,
+				currentPatterns
+			);
+
+			innerPatterns.forEach( ( patt ) => currentPatterns.add( patt ) );
+		} );
+	}
+
+	return currentPatterns;
+}
+
+/**
+ * Gets a set of patterns found in blocks.
+ *
+ * @param {Object[]} blocks Blocks to check.
+ * @return {Set} Set of patterns found.
+ */
+export function getPatternsFromBlocks( blocks ) {
+	if ( ! blocks || ! blocks.length || ! Array.isArray( blocks ) ) {
+		return new Set();
+	}
+
+	// Merge sets of patterns.
+	return blocks.reduce( ( set, block ) => {
+		const patterns = getPatternsFromBlock( block );
+
+		patterns.forEach( ( patternName ) => set.add( patternName ) );
+
+		return set;
+	}, new Set() );
+}
+
+/**
+ * Finds the patterns in a block recursively checking inner blocks.
+ *
+ * @param {Object} block    The block to inspect
+ * @param {Set}    patterns Set of patterns already found.
+ * @return {Set} Set of found patterns in blocks.
+ */
+function getPatternsFromBlock( block, patterns = new Set() ) {
+	if ( block.name === 'core/pattern' ) {
+		patterns.add( block.attributes.slug );
+	}
+
+	if ( block.innerBlocks && block.innerBlocks.length ) {
+		block.innerBlocks.forEach( ( innerBlock ) => {
+			patterns = getPatternsFromBlock( innerBlock, patterns );
+		} );
+	}
+
+	return patterns;
+}

--- a/packages/block-editor/src/components/block-preview/test/index.js
+++ b/packages/block-editor/src/components/block-preview/test/index.js
@@ -11,11 +11,16 @@ import {
 	unregisterBlockType,
 	createBlock,
 } from '@wordpress/blocks';
+import {
+	registerCoreBlocks,
+	__experimentalGetCoreBlocks,
+} from '@wordpress/block-library';
 
 /**
  * Internal dependencies
  */
 import { useBlockPreview } from '../';
+import { getBlockPreviewPatterns, getPatternsFromBlocks } from '../patterns';
 
 jest.mock( '@wordpress/dom', () => {
 	const focus = jest.requireActual( '../../../../../dom/src' ).focus;
@@ -48,6 +53,272 @@ jest.mock( '@wordpress/dom', () => {
 } );
 
 jest.useRealTimers();
+
+describe( 'getPatternsFromBlocks', () => {
+	beforeAll( () => {
+		registerBlockType( 'core/test', {
+			save: () => (
+				<div>
+					Test block save view
+					<button>Button</button>
+				</div>
+			),
+			edit: () => (
+				<div>
+					Test block edit view
+					<button>Button</button>
+				</div>
+			),
+			category: 'text',
+			title: 'test block',
+		} );
+
+		registerCoreBlocks();
+	} );
+
+	afterAll( () => {
+		unregisterBlockType( 'core/test' );
+
+		const allBlocks = __experimentalGetCoreBlocks();
+
+		allBlocks.forEach( ( block ) => {
+			unregisterBlockType( block.name );
+		} );
+	} );
+
+	it( 'will return an empty set of patterns present in blocks', async () => {
+		const blocks = [];
+		blocks.push( createBlock( 'core/test' ) );
+
+		expect( getPatternsFromBlocks( blocks ).size ).toBe( 0 );
+	} );
+
+	it( 'will return a set of patterns present in blocks', async () => {
+		const blocks = [];
+		blocks.push( createBlock( 'core/test' ) );
+		blocks.push( createBlock( 'core/pattern', { slug: 'test/test' } ) );
+
+		const patternsFromBlocks = getPatternsFromBlocks( blocks );
+
+		expect( patternsFromBlocks.size ).toBe( 1 );
+		expect( patternsFromBlocks.has( 'test/test' ) ).toBe( true );
+	} );
+
+	it( 'will return a set of patterns present in blocks by traversing tree', async () => {
+		const blocks = [];
+		blocks.push(
+			createBlock( 'core/group', {}, [
+				createBlock( 'core/pattern', { slug: 'test/test2' } ),
+			] )
+		);
+		blocks.push( createBlock( 'core/pattern', { slug: 'test/test' } ) );
+
+		const patternsFromBlocks = getPatternsFromBlocks( blocks );
+
+		expect( patternsFromBlocks.size ).toBe( 2 );
+		expect( patternsFromBlocks.has( 'test/test' ) ).toBe( true );
+		expect( patternsFromBlocks.has( 'test/test2' ) ).toBe( true );
+	} );
+} );
+
+describe( 'getBlockPreviewPatterns', () => {
+	it( 'will return an empty set of patterns when no patterns are set', async () => {
+		const patterns = [];
+		const patternsToPreview = [ 'test/test' ];
+
+		expect(
+			getBlockPreviewPatterns( patterns, patternsToPreview ).length
+		).toBe( 0 );
+	} );
+
+	it( 'will return an empty set of patterns when no patterns were found in preview', async () => {
+		const patterns = [
+			{
+				title: 'Test Pattern',
+				content:
+					'<!-- wp:group --><div class="wp-block-group"></div><!-- /wp:group -->',
+			},
+		];
+		const patternsToPreview = new Set();
+
+		expect(
+			getBlockPreviewPatterns( patterns, patternsToPreview ).length
+		).toBe( 0 );
+	} );
+
+	it( 'will return a set of patterns when patterns are found within block preview', async () => {
+		const patterns = [
+			{
+				name: 'test/test',
+				title: 'Test Pattern',
+				content:
+					'<!-- wp:group --><div class="wp-block-group"></div><!-- /wp:group -->',
+			},
+		];
+		const patternsToPreview = new Set( [ 'test/test' ] );
+
+		const patternsInPreview = getBlockPreviewPatterns(
+			patterns,
+			patternsToPreview
+		);
+
+		expect( patternsInPreview.length ).toBe( 1 );
+		expect( patternsInPreview[ 0 ] ).toBe( patterns[ 0 ] );
+	} );
+
+	it( 'will return a set of patterns when patterns are found within block preview and nested patterns are found.', async () => {
+		const patterns = [
+			{
+				name: 'test/test',
+				title: 'Test Pattern',
+				content:
+					'<!-- wp:group --><div class="wp-block-group"></div><!-- /wp:group -->',
+			},
+			{
+				name: 'test/nest',
+				title: 'Test Pattern',
+				content:
+					'<!-- wp:group --><div class="wp-block-group"><!-- wp:pattern {"slug":"test/test"} /--></div><!-- /wp:group -->',
+			},
+		];
+		const patternsToPreview = new Set( [ 'test/nest' ] );
+
+		const patternsInPreview = getBlockPreviewPatterns(
+			patterns,
+			patternsToPreview
+		);
+
+		expect( patternsInPreview.length ).toBe( 2 );
+		expect( patternsInPreview[ 0 ] ).toBe( patterns[ 0 ] );
+		expect( patternsInPreview[ 1 ] ).toBe( patterns[ 1 ] );
+	} );
+
+	it( 'will return a set of patterns when patterns are found within block preview and nested patterns are found recursively.', async () => {
+		const patterns = [
+			{
+				name: 'test/base',
+				title: 'Test Pattern',
+				content:
+					'<!-- wp:group --><div class="wp-block-group"></div><!-- /wp:group -->',
+			},
+			{
+				name: 'test/test',
+				title: 'Test Pattern',
+				content:
+					'<!-- wp:group --><div class="wp-block-group"><!-- wp:pattern {"slug":"test/base"} /--></div><!-- /wp:group -->',
+			},
+			{
+				name: 'test/nest',
+				title: 'Test Pattern',
+				content:
+					'<!-- wp:group --><div class="wp-block-group"><!-- wp:pattern {"slug":"test/test"} /--></div><!-- /wp:group -->',
+			},
+		];
+		const patternsToPreview = new Set( [ 'test/nest' ] );
+
+		const patternsInPreview = getBlockPreviewPatterns(
+			patterns,
+			patternsToPreview
+		);
+
+		expect( patternsInPreview.length ).toBe( 3 );
+		expect( patternsInPreview[ 0 ] ).toBe( patterns[ 0 ] );
+		expect( patternsInPreview[ 1 ] ).toBe( patterns[ 1 ] );
+		expect( patternsInPreview[ 2 ] ).toBe( patterns[ 2 ] );
+	} );
+
+	it( 'will return a set of patterns when patterns are found within block preview and nested patterns are found recursively but duplicate patterns are found.', async () => {
+		const patterns = [
+			{
+				name: 'test/base',
+				title: 'Test Pattern',
+				content:
+					'<!-- wp:group --><div class="wp-block-group"></div><!-- /wp:group -->',
+			},
+			{
+				name: 'test/base2',
+				title: 'Test Pattern',
+				content:
+					'<!-- wp:group --><div class="wp-block-group"><!-- wp:pattern {"slug":"test/base"} /--></div><!-- /wp:group -->',
+			},
+			{
+				name: 'test/test',
+				title: 'Test Pattern',
+				content:
+					'<!-- wp:group --><div class="wp-block-group"><!-- wp:pattern {"slug":"test/base"} /--><!-- wp:pattern {"slug":"test/base2"} /--></div><!-- /wp:group -->',
+			},
+			{
+				name: 'test/nest',
+				title: 'Test Pattern',
+				content:
+					'<!-- wp:group --><div class="wp-block-group"><!-- wp:pattern {"slug":"test/test"} /--></div><!-- /wp:group -->',
+			},
+		];
+		const patternsToPreview = new Set( [ 'test/nest' ] );
+
+		const patternsInPreview = getBlockPreviewPatterns(
+			patterns,
+			patternsToPreview
+		);
+
+		expect( patternsInPreview.length ).toBe( 4 );
+		expect( patternsInPreview[ 0 ] ).toBe( patterns[ 0 ] );
+		expect( patternsInPreview[ 1 ] ).toBe( patterns[ 1 ] );
+		expect( patternsInPreview[ 2 ] ).toBe( patterns[ 2 ] );
+		expect( patternsInPreview[ 3 ] ).toBe( patterns[ 3 ] );
+	} );
+
+	it( 'will return a set of patterns when patterns are found within block preview but nested patterns are not found.', async () => {
+		const patterns = [
+			{
+				name: 'test/test',
+				title: 'Test Pattern',
+				content:
+					'<!-- wp:group --><div class="wp-block-group"></div><!-- /wp:group -->',
+			},
+			{
+				name: 'test/nest',
+				title: 'Test Pattern',
+				content:
+					'<!-- wp:group --><div class="wp-block-group"></div><!-- /wp:group -->',
+			},
+		];
+		const patternsToPreview = new Set( [ 'test/nest' ] );
+
+		const patternsInPreview = getBlockPreviewPatterns(
+			patterns,
+			patternsToPreview
+		);
+
+		expect( patternsInPreview.length ).toBe( 1 );
+		expect( patternsInPreview[ 0 ] ).toBe( patterns[ 1 ] );
+	} );
+
+	it( 'will return a set of patterns when patterns are found within block preview but pattern content is empty.', async () => {
+		const patterns = [
+			{
+				name: 'test/test',
+				title: 'Test Pattern',
+				content:
+					'<!-- wp:group --><div class="wp-block-group"></div><!-- /wp:group -->',
+			},
+			{
+				name: 'test/nest',
+				title: 'Test Pattern',
+				content: '',
+			},
+		];
+		const patternsToPreview = new Set( [ 'test/nest' ] );
+
+		const patternsInPreview = getBlockPreviewPatterns(
+			patterns,
+			patternsToPreview
+		);
+
+		expect( patternsInPreview.length ).toBe( 1 );
+		expect( patternsInPreview[ 0 ] ).toBe( patterns[ 1 ] );
+	} );
+} );
 
 describe( 'useBlockPreview', () => {
 	beforeAll( () => {


### PR DESCRIPTION
Fixes #39732.

<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Adds support to render block patterns in block previews with minimal performance cost. Tests added for verification of behavior.

## Why?
Site builders should be able to reuse patterns within other patterns and have the display render in the block preview. This will allow for more maintainable and reusable theme patterns.

## How?
This will traverse the blocks in the block preview. If no pattern blocks are found we don't do anything and result is memoized. This means that performance will be the same as it currently is with only the added cost of quickly traversing the blocks in the pattern, which is very fast. For the majority of patterns performance will look exactly the same as it is right now. If pattern(s) are found they will be added to the preview. Then each pattern is checked for the existence of patterns within that pattern recursively to find all patterns needed to render the preview. This way block previews will always render with the minimum set of patterns they need to render to minimize parsing handled by the `BlockList` component.

## Testing Instructions
1. Register a pattern with a `core/pattern` block in it that points to a pattern with content in it. If you are using twenty-twenty-two you can do a pattern with content equal to: `<!-- wp:pattern {"slug":"twentytwentytwo/footer-blog"} /-->` This pattern will now have a pattern within its own content.
2. Open a post or add a new post.
3. Open the inserter and open the patterns tab.
4. Find the pattern you registered in the explorer.
5. Once found, verify that the rendered pattern preview matches the pattern that you referenced in the content. 
