### PR TITLE
Create Block: update document links in templates

### DIFF
--- a/packages/create-block-tutorial-template/block-templates/edit.js.mustache
+++ b/packages/create-block-tutorial-template/block-templates/edit.js.mustache
@@ -9,7 +9,7 @@ import { TextControl } from '@wordpress/components';
  * React hook that is used to mark the block wrapper element.
  * It provides all the necessary props like the class name.
  *
- * @see https://developer.wordpress.org/block-editor/packages/packages-block-editor/#useBlockProps
+ * @see https://developer.wordpress.org/block-editor/reference-guides/packages/packages-block-editor/#useblockprops
  */
 import { useBlockProps } from '@wordpress/block-editor';
 
@@ -17,7 +17,7 @@ import { useBlockProps } from '@wordpress/block-editor';
  * The edit function describes the structure of your block in the context of the
  * editor. This represents what the editor will render when the block is used.
  *
- * @see https://developer.wordpress.org/block-editor/developers/block-api/block-edit-save/#edit
+ * @see https://developer.wordpress.org/block-editor/reference-guides/block-api/block-edit-save/#edit
  *
  * @param {Object}   props               Properties passed to the function.
  * @param {Object}   props.attributes    Available block attributes.

--- a/packages/create-block-tutorial-template/block-templates/save.js.mustache
+++ b/packages/create-block-tutorial-template/block-templates/save.js.mustache
@@ -2,7 +2,7 @@
  * React hook that is used to mark the block wrapper element.
  * It provides all the necessary props like the class name.
  *
- * @see https://developer.wordpress.org/block-editor/packages/packages-block-editor/#useBlockProps
+ * @see https://developer.wordpress.org/block-editor/reference-guides/packages/packages-block-editor/#useblockprops
  */
 import { useBlockProps } from '@wordpress/block-editor';
 
@@ -11,7 +11,7 @@ import { useBlockProps } from '@wordpress/block-editor';
  * be combined into the final markup, which is then serialized by the block
  * editor into `post_content`.
  *
- * @see https://developer.wordpress.org/block-editor/developers/block-api/block-edit-save/#save
+ * @see https://developer.wordpress.org/block-editor/reference-guides/block-api/block-edit-save/#save
  *
  * @param {Object} props            Properties passed to the function.
  * @param {Object} props.attributes Available block attributes.

--- a/packages/create-block/lib/templates/block/edit.js.mustache
+++ b/packages/create-block/lib/templates/block/edit.js.mustache
@@ -1,7 +1,7 @@
 /**
  * Retrieves the translation of text.
  *
- * @see https://developer.wordpress.org/block-editor/packages/packages-i18n/
+ * @see https://developer.wordpress.org/block-editor/reference-guides/packages/packages-i18n/
  */
 import { __ } from '@wordpress/i18n';
 
@@ -9,7 +9,7 @@ import { __ } from '@wordpress/i18n';
  * React hook that is used to mark the block wrapper element.
  * It provides all the necessary props like the class name.
  *
- * @see https://developer.wordpress.org/block-editor/packages/packages-block-editor/#useBlockProps
+ * @see https://developer.wordpress.org/block-editor/reference-guides/packages/packages-block-editor/#useblockprops
  */
 import { useBlockProps } from '@wordpress/block-editor';
 
@@ -25,7 +25,7 @@ import './editor.scss';
  * The edit function describes the structure of your block in the context of the
  * editor. This represents what the editor will render when the block is used.
  *
- * @see https://developer.wordpress.org/block-editor/developers/block-api/block-edit-save/#edit
+ * @see https://developer.wordpress.org/block-editor/reference-guides/block-api/block-edit-save/#edit
  *
  * @return {WPElement} Element to render.
  */

--- a/packages/create-block/lib/templates/block/save.js.mustache
+++ b/packages/create-block/lib/templates/block/save.js.mustache
@@ -1,7 +1,7 @@
 /**
  * Retrieves the translation of text.
  *
- * @see https://developer.wordpress.org/block-editor/packages/packages-i18n/
+ * @see https://developer.wordpress.org/block-editor/reference-guides/packages/packages-i18n/
  */
 import { __ } from '@wordpress/i18n';
 
@@ -9,7 +9,7 @@ import { __ } from '@wordpress/i18n';
  * React hook that is used to mark the block wrapper element.
  * It provides all the necessary props like the class name.
  *
- * @see https://developer.wordpress.org/block-editor/packages/packages-block-editor/#useBlockProps
+ * @see https://developer.wordpress.org/block-editor/reference-guides/packages/packages-block-editor/#useblockprops
  */
 import { useBlockProps } from '@wordpress/block-editor';
 
@@ -18,7 +18,7 @@ import { useBlockProps } from '@wordpress/block-editor';
  * be combined into the final markup, which is then serialized by the block
  * editor into `post_content`.
  *
- * @see https://developer.wordpress.org/block-editor/developers/block-api/block-edit-save/#save
+ * @see https://developer.wordpress.org/block-editor/reference-guides/block-api/block-edit-save/#save
  *
  * @return {WPElement} Element to render.
  */

--- a/packages/create-block/lib/templates/es5/index.js.mustache
+++ b/packages/create-block/lib/templates/es5/index.js.mustache
@@ -16,14 +16,14 @@
 	/**
 	 * Retrieves the translation of text.
 	 *
-	 * @see https://developer.wordpress.org/block-editor/packages/packages-i18n/
+	 * @see https://developer.wordpress.org/block-editor/reference-guides/packages/packages-i18n/
 	 */
 	var __ = wp.i18n.__;
 
 	/**
 	 * This hook is used to mark the block wrapper element.
 	 *
-	 * @see https://developer.wordpress.org/block-editor/packages/packages-block-editor/#useBlockProps
+	 * @see https://developer.wordpress.org/block-editor/reference-guides/packages/packages-block-editor/#useblockprops
 	 */
 	var useBlockProps = wp.blockEditor.useBlockProps;
 
@@ -84,7 +84,7 @@
 		 * The edit function describes the structure of your block in the context of the editor.
 		 * This represents what the editor will render when the block is used.
 		 *
-		 * @see https://developer.wordpress.org/block-editor/developers/block-api/block-edit-save/#edit
+		 * @see https://developer.wordpress.org/block-editor/reference-guides/block-api/block-edit-save/#edit
 		 *
 		 * @return {WPElement} Element to render.
 		 */
@@ -100,7 +100,7 @@
 		 * The save function defines the way in which the different attributes should be combined
 		 * into the final markup, which is then serialized by the block editor into `post_content`.
 		 *
-		 * @see https://developer.wordpress.org/block-editor/developers/block-api/block-edit-save/#save
+		 * @see https://developer.wordpress.org/block-editor/reference-guides/block-api/block-edit-save/#save
 		 *
 		 * @return {WPElement} Element to render.
 		 */


### PR DESCRIPTION
## What?
This PR updates the document links in the template file that `create-block` generates by default and `create-block-tutorial-template`.

## Why?
I found the following links are redirected and one anchor link doesn't work properly:

- https://developer.wordpress.org/block-editor/packages/packages-block-editor/#useBlockProps > redirected to https://developer.wordpress.org/block-editor/reference-guides/packages/packages-block-editor/#useBlockProps (Incorrect anchor)
- https://developer.wordpress.org/block-editor/developers/block-api/block-edit-save/#edit > redirected to  https://developer.wordpress.org/block-editor/reference-guides/block-api/block-edit-save/#edit
- https://developer.wordpress.org/block-editor/developers/block-api/block-edit-save/#save > redirected to https://developer.wordpress.org/block-editor/reference-guides/block-api/block-edit-save/#save
- https://developer.wordpress.org/block-editor/packages/packages-i18n/ > redirected to  https://developer.wordpress.org/block-editor/reference-guides/packages/packages-i18n/

## How?
Just update links.

## Testing Instructions
- Run `node ./path/to/gutenberg/node_modules/.bin/wp-create-block gutenpride`
- Confirm that there are no redirects and the anchor links work correctly when you open document links listed in files in the `gutenpride` directory.
