### PR TITLE
Date settings: check for $wp_locale before using it

### DIFF
--- a/lib/compat/wordpress-6.1/date-settings.php
+++ b/lib/compat/wordpress-6.1/date-settings.php
@@ -19,6 +19,11 @@
 function gutenberg_update_date_settings( $scripts ) {
 	global $wp_locale;
 
+	// A check in case $wp_locale is not set by the time we enqueue scripts.
+	if ( ! isset( $wp_locale ) ) {
+		return;
+	}
+
 	$inline_scripts = $scripts->get_data( 'wp-date', 'after' );
 	if ( $inline_scripts ) {
 		foreach ( $inline_scripts as $index => $inline_script ) {


### PR DESCRIPTION


<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Check if `$wp_locale` is set before trying to access its methods.


## Why?
If a theme attempts to enqueue scripts in an early hook, e.g., `setup_theme`, before the textdomain is loaded and $wp_local set, PHP will throw a warning.

```
Warning: array_values() expects parameter 1 to be array, null given in <b>/home/wpcom/public_html/wp-content/plugins/gutenberg-core/v13.6.0/lib/compat/wordpress-6.1/date-settings.php</b> on line <b>52</b><br />
```

## How?
An `isset` check.

## Testing Instructions

Check that the post publish date works as expected.

Taken from https://github.com/WordPress/gutenberg/pull/41648

## Testing Instructions
1. Create or edit a post.
2. Open the post date. Observe whether the week starts on e.g. Sunday.
3. Go to Settings → General and change the _Week Starts On_ setting.
2. Create or edit a post.
3. Open the post date. Observe that the calendar has changed.

## Screenshots or screencast 
https://user-images.githubusercontent.com/612155/172999235-93c19019-c05a-4d53-b2c4-effd6b72e41f.mp4