### PR TITLE
Site Editor: Don't disable the Save button

### DIFF
--- a/packages/edit-site/src/components/save-button/index.js
+++ b/packages/edit-site/src/components/save-button/index.js
@@ -30,18 +30,15 @@ export default function SaveButton( {
 	const disabled = ! isDirty || isSaving;
 
 	return (
-		<>
-			<Button
-				variant="primary"
-				className="edit-site-save-button__button"
-				aria-disabled={ disabled }
-				aria-expanded={ isEntitiesSavedStatesOpen }
-				disabled={ disabled }
-				isBusy={ isSaving }
-				onClick={ disabled ? undefined : openEntitiesSavedStates }
-			>
-				{ __( 'Save' ) }
-			</Button>
-		</>
+		<Button
+			variant="primary"
+			className="edit-site-save-button__button"
+			aria-disabled={ disabled }
+			aria-expanded={ isEntitiesSavedStatesOpen }
+			isBusy={ isSaving }
+			onClick={ disabled ? undefined : openEntitiesSavedStates }
+		>
+			{ __( 'Save' ) }
+		</Button>
 	);
 }


### PR DESCRIPTION
## What?
Closes #42802.

PR removes the `disabled` attribute from Site Editor's ave button component.

P.S. I also removed needless `React.Fragment` usage from the component.

## Why?
The button is marked as disabled using the `aria-disabled` prop and by "noop-ing" the event callback.

## Testing Instructions
1. Open Site Editor.
2. Don't make any changes to the template.
3. Inspect the source and confirm the `disabled` attribute is removed.

## Screenshots or screencast <!-- if applicable -->

![CleanShot 2022-08-01 at 08 53 38](https://user-images.githubusercontent.com/240569/182074984-2cd2bad5-f53e-4789-9182-d10ceba121d0.png)

