### PR TITLE
`Tooltip (Experimental)`, `CustomSelectControl`, `TimePicker`: Add missing font sizes styles which were necessary in non-WordPress contexts

### DIFF
--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 -   `BorderControl`: Ensure box-sizing is reset for the control ([#42754](https://github.com/WordPress/gutenberg/pull/42754)).
 -   `InputControl`: Fix acceptance of falsy values in controlled updates ([#42484](https://github.com/WordPress/gutenberg/pull/42484/)).
+-   `Tooltip (Experimental)`, `CustomSelectControl`, `TimePicker`: Add missing font-size styles which were necessary in non-WordPress contexts ([#42844](https://github.com/WordPress/gutenberg/pull/42844/)).
 
 ### Enhancements
 

--- a/packages/components/src/custom-select-control/style.scss
+++ b/packages/components/src/custom-select-control/style.scss
@@ -1,5 +1,6 @@
 .components-custom-select-control {
 	position: relative;
+	font-size: $default-font-size;
 }
 
 .components-custom-select-control__label {

--- a/packages/components/src/date-time/time/styles.ts
+++ b/packages/components/src/date-time/time/styles.ts
@@ -17,7 +17,9 @@ import NumberControl from '../../number-control';
 import SelectControl from '../../select-control';
 import { Select } from '../../select-control/styles/select-control-styles';
 
-export const Wrapper = styled.div``;
+export const Wrapper = styled.div`
+	font-size: ${ CONFIG.fontSize };
+`;
 
 export const Fieldset = styled.fieldset`
 	border: 0;

--- a/packages/components/src/ui/tooltip/styles.js
+++ b/packages/components/src/ui/tooltip/styles.js
@@ -20,6 +20,7 @@ export const TooltipContent = css`
 	outline: none;
 	transform-origin: top center;
 	transition: opacity ${ CONFIG.transitionDurationFastest } ease;
+	font-size: ${ CONFIG.fontSize };
 
 	&[data-enter] {
 		opacity: 1;

--- a/packages/components/src/ui/tooltip/test/__snapshots__/index.js.snap
+++ b/packages/components/src/ui/tooltip/test/__snapshots__/index.js.snap
@@ -9,6 +9,7 @@ exports[`props should render correctly 1`] = `
   transform-origin: top center;
   -webkit-transition: opacity 100ms ease;
   transition: opacity 100ms ease;
+  font-size: 13px;
 }
 
 .emotion-0[data-enter] {


### PR DESCRIPTION
Part of #42781

## What?

Adds an explicit font size to components that didn't have them.

## Why?

#42747 uncovered that some components rely on a `font-size: 13px` being set in the surrounding CSS context. This is not a given, and we need that font-size to be explicitly set in each component for them to be self-sufficient. (See #42781 for further reasoning.)

## How?

Add a `font-size` declaration to the highest-level wrapper possible, so inheritance can take care of the rest. This way we don't have to over-specify, and will cover any future additions to component internals.

## Testing Instructions

1. `npm run storybook:dev`
2. Make sure the global CSS injector is set to the "Font only" setting

   <img src="https://user-images.githubusercontent.com/555336/182080911-5d4b1673-5128-450a-9841-6c47f8c40980.png" alt="CSS injector add-on in Storybook toolbar" width="200">

3. Check these stories:
   - [Tooltip (Experimental)](http://localhost:50240/?path=/story/components-experimental-tooltip--default)
   - [CustomSelectControl With Hints](http://localhost:50240/?path=/story/components-customselectcontrol--with-hints)
   - [TimePicker](http://localhost:50240/?path=/story/components-timepicker--default)




## Screenshots or screencast <!-- if applicable -->

| Before | After |
|--------|-------|
|![TimePicker with wrong font size](https://user-images.githubusercontent.com/555336/182078544-bb72f130-8eaa-4405-8631-4f18dc7cbd1b.png)|![TimePicker with correct font size](https://user-images.githubusercontent.com/555336/182078486-c7dba326-3315-490c-8873-288fc7ffca1a.png)|
|![Tooltip with wrong font size](https://user-images.githubusercontent.com/555336/182078751-15f5d3cf-6a2c-4fb0-b69e-1e14879ff990.png)|![Tooltip with correct font size](https://user-images.githubusercontent.com/555336/182078805-62fab056-61f8-488c-8b53-12063e3c5ed2.png)|
|![CustomSelectControl with wrong font size](https://user-images.githubusercontent.com/555336/182079139-44653ec4-3b57-4acb-979a-10e31ad16c4b.png)|![CustomSelectControl with correct font size](https://user-images.githubusercontent.com/555336/182079034-9cfdc5d4-6993-4e0c-a50a-a00002703879.png)|
