### PR TITLE
Post Template: Don't fetch settings and templates for non-admin users

### DIFF
--- a/packages/edit-post/src/components/sidebar/post-template/form.js
+++ b/packages/edit-post/src/components/sidebar/post-template/form.js
@@ -25,29 +25,26 @@ export default function PostTemplateForm( { onClose } ) {
 		canCreate,
 		canEdit,
 	} = useSelect( ( select ) => {
+		const { canUser, getEntityRecord, getEntityRecords } =
+			select( coreStore );
 		const editorSettings = select( editorStore ).getEditorSettings();
-		const siteSettings = select( coreStore ).getEntityRecord(
-			'root',
-			'site'
-		);
+		const siteSettings = canUser( 'read', 'settings' )
+			? getEntityRecord( 'root', 'site' )
+			: undefined;
 		const _isPostsPage =
 			select( editorStore ).getCurrentPostId() ===
 			siteSettings?.page_for_posts;
-		const canCreateTemplates = select( coreStore ).canUser(
-			'create',
-			'templates'
-		);
+		const canCreateTemplates = canUser( 'create', 'templates' );
+
 		return {
 			isPostsPage: _isPostsPage,
 			availableTemplates: editorSettings.availableTemplates,
-			fetchedTemplates: select( coreStore ).getEntityRecords(
-				'postType',
-				'wp_template',
-				{
-					post_type: select( editorStore ).getCurrentPostType(),
-					per_page: -1,
-				}
-			),
+			fetchedTemplates: canCreateTemplates
+				? getEntityRecords( 'postType', 'wp_template', {
+						post_type: select( editorStore ).getCurrentPostType(),
+						per_page: -1,
+				  } )
+				: undefined,
 			selectedTemplateSlug:
 				select( editorStore ).getEditedPostAttribute( 'template' ),
 			canCreate:


### PR DESCRIPTION
## What?
A follow-up to #42705, also see #42413.

## Why?
The editor should check permission before making requests when data isn't available for everyone.

## How?
* Added `canUser( 'read', 'settings' )` check before fetching site settings.
* Check against `canCreateTemplates` before fetching the templates.

## Testing Instructions

1. Login to the test site with an Editor role.
2. Open a Post or Page.
3. Open post template selection popup.
4. Open the DevTools network tab and confirm there're no 403 requests.

## Screenshots or screencast <!-- if applicable -->

![CleanShot 2022-08-01 at 12 33 35](https://user-images.githubusercontent.com/240569/182107873-9569fbc5-d3c8-4d29-80d9-e244c31a34c8.png)

