### PR TITLE
Post Featured Image: Add border support applied to inner img

### DIFF
--- a/packages/block-library/src/post-featured-image/block.json
+++ b/packages/block-library/src/post-featured-image/block.json
@@ -42,6 +42,18 @@
 			"text": false,
 			"background": false
 		},
+		"__experimentalBorder": {
+			"color": true,
+			"radius": true,
+			"width": true,
+			"__experimentalSelector": "img",
+			"__experimentalSkipSerialization": true,
+			"__experimentalDefaultControls": {
+				"color": true,
+				"radius": true,
+				"width": true
+			}
+		},
 		"html": false,
 		"spacing": {
 			"margin": true,

--- a/packages/block-library/src/post-featured-image/block.json
+++ b/packages/block-library/src/post-featured-image/block.json
@@ -46,7 +46,7 @@
 			"color": true,
 			"radius": true,
 			"width": true,
-			"__experimentalSelector": "img",
+			"__experimentalSelector": "img, .block-editor-media-placeholder",
 			"__experimentalSkipSerialization": true,
 			"__experimentalDefaultControls": {
 				"color": true,

--- a/packages/block-library/src/post-featured-image/edit.js
+++ b/packages/block-library/src/post-featured-image/edit.js
@@ -1,4 +1,9 @@
 /**
+ * External dependencies
+ */
+import classnames from 'classnames';
+
+/**
  * WordPress dependencies
  */
 import { useEntityProp, store as coreStore } from '@wordpress/core-data';
@@ -30,17 +35,6 @@ import { store as noticesStore } from '@wordpress/notices';
 import DimensionControls from './dimension-controls';
 
 const ALLOWED_MEDIA_TYPES = [ 'image' ];
-
-const placeholder = ( content ) => {
-	return (
-		<Placeholder
-			className="block-editor-media-placeholder"
-			withIllustration={ true }
-		>
-			{ content }
-		</Placeholder>
-	);
-};
 
 function getMediaSourceUrlBySizeSlug( media, slug ) {
 	return (
@@ -97,6 +91,21 @@ function PostFeaturedImageDisplay( {
 		style: { width, height },
 	} );
 	const borderProps = useBorderProps( attributes );
+
+	const placeholder = ( content ) => {
+		return (
+			<Placeholder
+				className={ classnames(
+					'block-editor-media-placeholder',
+					borderProps.className
+				) }
+				withIllustration={ true }
+				style={ borderProps.style }
+			>
+				{ content }
+			</Placeholder>
+		);
+	};
 
 	const onSelectImage = ( value ) => {
 		if ( value?.id ) {
@@ -245,8 +254,21 @@ function PostFeaturedImageDisplay( {
 
 export default function PostFeaturedImageEdit( props ) {
 	const blockProps = useBlockProps();
+	const borderProps = useBorderProps( props.attributes );
+
 	if ( ! props.context?.postId ) {
-		return <div { ...blockProps }>{ placeholder() }</div>;
+		return (
+			<div { ...blockProps }>
+				<Placeholder
+					className={ classnames(
+						'block-editor-media-placeholder',
+						borderProps.className
+					) }
+					withIllustration={ true }
+					style={ borderProps.style }
+				/>
+			</div>
+		);
 	}
 	return <PostFeaturedImageDisplay { ...props } />;
 }

--- a/packages/block-library/src/post-featured-image/edit.js
+++ b/packages/block-library/src/post-featured-image/edit.js
@@ -18,6 +18,7 @@ import {
 	MediaReplaceFlow,
 	useBlockProps,
 	store as blockEditorStore,
+	__experimentalUseBorderProps as useBorderProps,
 } from '@wordpress/block-editor';
 import { __, sprintf } from '@wordpress/i18n';
 import { upload } from '@wordpress/icons';
@@ -95,6 +96,7 @@ function PostFeaturedImageDisplay( {
 	const blockProps = useBlockProps( {
 		style: { width, height },
 	} );
+	const borderProps = useBorderProps( attributes );
 
 	const onSelectImage = ( value ) => {
 		if ( value?.id ) {
@@ -165,6 +167,11 @@ function PostFeaturedImageDisplay( {
 	}
 
 	const label = __( 'Add a featured image' );
+	const imageStyles = {
+		...borderProps.style,
+		height,
+		objectFit: height && scale,
+	};
 
 	if ( ! featuredImage ) {
 		image = (
@@ -196,6 +203,7 @@ function PostFeaturedImageDisplay( {
 			placeholder()
 		) : (
 			<img
+				className={ borderProps.className }
 				src={ mediaUrl }
 				alt={
 					media.alt_text
@@ -206,7 +214,7 @@ function PostFeaturedImageDisplay( {
 						  )
 						: __( 'Featured image' )
 				}
-				style={ { height, objectFit: height && scale } }
+				style={ imageStyles }
 			/>
 		);
 	}

--- a/packages/block-library/src/post-featured-image/editor.scss
+++ b/packages/block-library/src/post-featured-image/editor.scss
@@ -35,6 +35,47 @@
 
 		// Show default placeholder height when not resized.
 		min-height: 200px;
+
+		// Compromise to allow the SVG to somewhat follow any border radius
+		// applied to the post featured image block and its placeholder.
+		> svg {
+			border-radius: inherit;
+		}
+
+		// The following override the default placeholder styles that remove
+		// its border so that a user selection for border color or width displays
+		// a visual border.
+		&:where(.has-border-color) {
+			border-style: solid;
+		}
+		&:where([style*="border-top-color"]) {
+			border-top-style: solid;
+		}
+		&:where([style*="border-right-color"]) {
+			border-right-style: solid;
+		}
+		&:where([style*="border-bottom-color"]) {
+			border-bottom-style: solid;
+		}
+		&:where([style*="border-left-color"]) {
+			border-left-style: solid;
+		}
+
+		&:where([style*="border-width"]) {
+			border-style: solid;
+		}
+		&:where([style*="border-top-width"]) {
+			border-top-style: solid;
+		}
+		&:where([style*="border-right-width"]) {
+			border-right-style: solid;
+		}
+		&:where([style*="border-bottom-width"]) {
+			border-bottom-style: solid;
+		}
+		&:where([style*="border-left-width"]) {
+			border-left-style: solid;
+		}
 	}
 
 	// Provide a minimum size for the placeholder when resized.

--- a/packages/block-library/src/post-featured-image/editor.scss
+++ b/packages/block-library/src/post-featured-image/editor.scss
@@ -36,12 +36,6 @@
 		// Show default placeholder height when not resized.
 		min-height: 200px;
 
-		// Compromise to allow the SVG to somewhat follow any border radius
-		// applied to the post featured image block and its placeholder.
-		> svg {
-			border-radius: inherit;
-		}
-
 		// The following override the default placeholder styles that remove
 		// its border so that a user selection for border color or width displays
 		// a visual border.

--- a/packages/block-library/src/post-featured-image/index.php
+++ b/packages/block-library/src/post-featured-image/index.php
@@ -19,10 +19,15 @@ function render_block_core_post_featured_image( $attributes, $content, $block ) 
 	}
 	$post_ID = $block->context['postId'];
 
-	$is_link        = isset( $attributes['isLink'] ) && $attributes['isLink'];
-	$size_slug      = isset( $attributes['sizeSlug'] ) ? $attributes['sizeSlug'] : 'post-thumbnail';
-	$post_title     = trim( strip_tags( get_the_title( $post_ID ) ) );
-	$attr           = $is_link ? array( 'alt' => $post_title ) : array();
+	$is_link    = isset( $attributes['isLink'] ) && $attributes['isLink'];
+	$size_slug  = isset( $attributes['sizeSlug'] ) ? $attributes['sizeSlug'] : 'post-thumbnail';
+	$post_title = trim( strip_tags( get_the_title( $post_ID ) ) );
+	$attr       = get_block_core_post_featured_image_border_attributes( $attributes );
+
+	if ( $is_link ) {
+		$attr['alt'] = $post_title;
+	}
+
 	$featured_image = get_the_post_thumbnail( $post_ID, $size_slug, $attr );
 	if ( ! $featured_image ) {
 		return '';
@@ -53,6 +58,54 @@ function render_block_core_post_featured_image( $attributes, $content, $block ) 
 	}
 
 	return "<figure $wrapper_attributes>$featured_image</figure>";
+}
+
+/**
+ * Generates class names and styles to apply the border support styles for
+ * the Post Featured Image block.
+ *
+ * @param array $attributes The block attributes.
+ * @return array The border-related classnames and styles for the block.
+ */
+function get_block_core_post_featured_image_border_attributes( $attributes ) {
+	$border_styles = array();
+	$sides         = array( 'top', 'right', 'bottom', 'left' );
+
+	// Border radius.
+	if ( isset( $attributes['style']['border']['radius'] ) ) {
+		$border_styles['radius'] = $attributes['style']['border']['radius'];
+	}
+
+	// Border style.
+	if ( isset( $attributes['style']['border']['style'] ) ) {
+		$border_styles['style'] = $attributes['style']['border']['style'];
+	}
+
+	// Border width.
+	if ( isset( $attributes['style']['border']['width'] ) ) {
+		$border_styles['width'] = $attributes['style']['border']['width'];
+	}
+
+	// Border color.
+	$preset_color           = array_key_exists( 'borderColor', $attributes ) ? "var:preset|color|{$attributes['borderColor']}" : null;
+	$custom_color           = _wp_array_get( $attributes, array( 'style', 'border', 'color' ), null );
+	$border_styles['color'] = $preset_color ? $preset_color : $custom_color;
+
+	// Individual border styles e.g. top, left etc.
+	foreach ( $sides as $side ) {
+		$border                 = _wp_array_get( $attributes, array( 'style', 'border', $side ), null );
+		$border_styles[ $side ] = array(
+			'color' => isset( $border['color'] ) ? $border['color'] : null,
+			'style' => isset( $border['style'] ) ? $border['style'] : null,
+			'width' => isset( $border['width'] ) ? $border['width'] : null,
+		);
+	}
+
+	$border_attributes = gutenberg_style_engine_get_styles( array( 'border' => $border_styles ) );
+	return array(
+		'class' => $border_attributes['classnames'],
+		'style' => $border_attributes['css'],
+	);
 }
 
 /**

--- a/packages/block-library/src/post-featured-image/style.scss
+++ b/packages/block-library/src/post-featured-image/style.scss
@@ -9,6 +9,7 @@
 		width: 100%;
 		height: auto;
 		vertical-align: bottom;
+		box-sizing: border-box;
 	}
 
 	&.alignwide img,

--- a/packages/components/src/placeholder/style.scss
+++ b/packages/components/src/placeholder/style.scss
@@ -219,4 +219,5 @@
 	stroke-dasharray: 3;
 	border-width: inherit;
 	border-style: inherit;
+	border-color: transparent;
 }

--- a/packages/components/src/placeholder/style.scss
+++ b/packages/components/src/placeholder/style.scss
@@ -217,7 +217,4 @@
 	height: 100%;
 	stroke: currentColor;
 	stroke-dasharray: 3;
-	border-width: inherit;
-	border-style: inherit;
-	border-color: transparent;
 }


### PR DESCRIPTION
Related: 
- https://github.com/WordPress/gutenberg/pull/42765


## What?

Adopts border block support for the Post Featured Image block and applies those classes/styles to the inner `img` element.

## Why?

This is a step towards reducing the gap between what you can control with the Image block and the Post Featured Image block. In terms of the bigger picture, it is part of providing more consistent design tools across blocks.

## How?

- Opts into border block support
- Skips serialization of the border block support so classes and styles can be applied on the inner `img` instead of the block wrapper
- Uses new "feature-level" selector flag to allow Global Styles and Theme.json to generate their styles targeting the inner image
- Leverages the style engine to generate the border classes and styles to be applied to the block during server-side rendering.
- Borders are also applied to the block's placeholder

## Testing Instructions

1. Edit a post, add a Post Featured Image block, and select it.
2. Trial configuring various combinations of borders on the block. The borders should display correctly.
3. Save and confirm the borders display on the frontend.
4. Back in the block editor, clear your block's border styles and save.
5. Switch to the site editor and navigate to Global Styles > Blocks > Post Featured Image > Layouts.
6. Try configuring the border options there and check they are reflected in the preview. 
7. Save the global styles and confirm they are applied in both the block editor and frontend.
8. Reset your global styles and add a default border for the Post Featured Image block in your theme.json
9. Confirm the theme.json border works appropriately.

##### Example snippet

```json
	"styles": {
		"blocks": {
			"core/post-featured-image": {
				"border": {
					"color": "fuchsia",
					"width": "0.5em",
					"style": "solid",
					"radius": "50px"
				}
			}
		},
	},
```

## Screenshots or screencast <!-- if applicable -->

<details>
<summary><strong>Post Editor - With Image</strong></summary>

<video src="https://user-images.githubusercontent.com/60436221/182126495-d8198ebe-7db9-4788-8125-f078bc8c7fe2.mp4" />
</details>

<details>
<summary><strong>Post Editor - Placeholders</strong></summary>

<video src="https://user-images.githubusercontent.com/60436221/183343439-d0045dd4-872d-4f40-8256-f3b1426972d0.mp4" />
</details>

<details>
<summary><strong>Site / Template Editor</strong></summary>

<video src="https://user-images.githubusercontent.com/60436221/183343449-da1b348c-8410-4e75-b93b-00e580be49e1.mp4" />
</details>


