### PR TITLE
Navigation: Fix `current-menu-item` class logic

### DIFF
--- a/packages/block-library/src/navigation-link/index.php
+++ b/packages/block-library/src/navigation-link/index.php
@@ -150,7 +150,7 @@ function render_block_core_navigation_link( $attributes, $content, $block ) {
 
 	$css_classes = trim( implode( ' ', $classes ) );
 	$has_submenu = count( $block->inner_blocks ) > 0;
-	$is_active   = ! empty( $attributes['id'] ) && ( get_the_ID() === $attributes['id'] );
+	$is_active   = ! empty( $attributes['id'] ) && ( get_the_ID() === (int) $attributes['id'] );
 
 	$wrapper_attributes = get_block_wrapper_attributes(
 		array(

--- a/packages/block-library/src/navigation-submenu/index.php
+++ b/packages/block-library/src/navigation-submenu/index.php
@@ -148,7 +148,7 @@ function render_block_core_navigation_submenu( $attributes, $content, $block ) {
 
 	$css_classes = trim( implode( ' ', $classes ) );
 	$has_submenu = count( $block->inner_blocks ) > 0;
-	$is_active   = ! empty( $attributes['id'] ) && ( get_the_ID() === $attributes['id'] );
+	$is_active   = ! empty( $attributes['id'] ) && ( get_the_ID() === (int) $attributes['id'] );
 
 	$show_submenu_indicators = isset( $block->context['showSubmenuIcon'] ) && $block->context['showSubmenuIcon'];
 	$open_on_click           = isset( $block->context['openSubmenusOnClick'] ) && $block->context['openSubmenusOnClick'];


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->
This PR ensures that we are comparing the menu item `id` as an integer against `get_the_ID()`, which is also an integer.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
I noticed that the `current-menu-item` class was no longer being added to the current menu item element in the navigation link block. We need this class to identify the current menu item on the front end (e.g. for styling).

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
It looks like we were previously comparing `get_the_ID()` to the menu item's attribute `id` using a triple `===`, which also compares the data type. As the menu item `id` is a string, comparing these two values would never be true. By adding `(int)` to the menu item's `$attribute['id']`, we can successfully compare the type as well as the value.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->
1. Add a navigation block with links to existing internal pages
2. Navigate to a page that's included in the navigation
3. Check that the `current-menu-item` class is added to the `<li>` of the current page in the navigation block markup

## Screenshots or screencast <!-- if applicable -->
Before:
![image](https://user-images.githubusercontent.com/1645628/182135271-4c3059f2-343a-4cad-8491-11096b0cbce7.png)

After:
![image](https://user-images.githubusercontent.com/1645628/182134989-0963f6fd-b005-40d0-a7c9-68ee33a3769b.png)
