### PR TITLE
[Block Library - Post Title]: Do not add `rel` attribute if empty

### DIFF
--- a/packages/block-library/src/post-title/index.php
+++ b/packages/block-library/src/post-title/index.php
@@ -34,7 +34,8 @@ function render_block_core_post_title( $attributes, $content, $block ) {
 	}
 
 	if ( isset( $attributes['isLink'] ) && $attributes['isLink'] ) {
-		$title = sprintf( '<a href="%1$s" target="%2$s" rel="%3$s">%4$s</a>', get_the_permalink( $post_ID ), esc_attr( $attributes['linkTarget'] ), esc_attr( $attributes['rel'] ), $title );
+		$rel   = ! empty( $attributes['rel'] ) ? 'rel="' . esc_attr( $attributes['rel'] ) . '"' : '';
+		$title = sprintf( '<a href="%1$s" target="%2$s" %3$s>%4$s</a>', get_the_permalink( $post_ID ), esc_attr( $attributes['linkTarget'] ), $rel, $title );
 	}
 	$wrapper_attributes = get_block_wrapper_attributes( array( 'class' => $align_class_name ) );
 


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Observed in: https://github.com/WordPress/gutenberg/pull/42853

This PR doesn't add the `rel` attribute in the front-end if it's empty. I'm not sure though if this is the right approach or we should add a default 🤔 --cc @afercia if you have any feedback
<!-- In a few words, what is the PR actually doing? -->


## Testing Instructions
1. Post Title blocks should work as before
2. If the `rel` attribute is empty it shouldn't be added in the element

### Before 
<img width="594" alt="before" src="https://user-images.githubusercontent.com/16275880/182155726-a8a49f2d-fe57-4fec-b1f8-7ae983fdc1cc.png">



### After
<img width="594" alt="after" src="https://user-images.githubusercontent.com/16275880/182155746-f5cb0c0a-4fbf-49c1-8667-89a9aa13c07a.png">


