### PR TITLE
Site Title: Use home_url instead of get_bloginfo

### DIFF
--- a/packages/block-library/src/site-title/index.php
+++ b/packages/block-library/src/site-title/index.php
@@ -21,15 +21,15 @@ function render_block_core_site_title( $attributes ) {
 	$tag_name         = 'h1';
 	$align_class_name = empty( $attributes['textAlign'] ) ? '' : "has-text-align-{$attributes['textAlign']}";
 
-	$aria_current = is_home() || ( is_front_page() && 'page' === get_option( 'show_on_front' ) ) ? ' aria-current="page"' : '';
-
 	if ( isset( $attributes['level'] ) ) {
 		$tag_name = 0 === $attributes['level'] ? 'p' : 'h' . (int) $attributes['level'];
 	}
 
 	if ( $attributes['isLink'] ) {
-		$link_target = ! empty( $attributes['linkTarget'] ) ? $attributes['linkTarget'] : '_self';
-		$site_title  = sprintf(
+		$aria_current = is_home() || ( is_front_page() && 'page' === get_option( 'show_on_front' ) ) ? ' aria-current="page"' : '';
+		$link_target  = ! empty( $attributes['linkTarget'] ) ? $attributes['linkTarget'] : '_self';
+
+		$site_title = sprintf(
 			'<a href="%1$s" target="%2$s" rel="home"%3$s>%4$s</a>',
 			esc_url( home_url() ),
 			esc_attr( $link_target ),

--- a/packages/block-library/src/site-title/index.php
+++ b/packages/block-library/src/site-title/index.php
@@ -28,15 +28,14 @@ function render_block_core_site_title( $attributes ) {
 	}
 
 	if ( $attributes['isLink'] ) {
-		$link_attrs = array(
-			'href="' . esc_url( get_bloginfo( 'url' ) ) . '"',
-			'rel="' . esc_attr( 'home' ) . '"',
+		$link_target = ! empty( $attributes['linkTarget'] ) ? $attributes['linkTarget'] : '_self';
+		$site_title  = sprintf(
+			'<a href="%1$s" target="%2$s" rel="home"%3$s>%4$s</a>',
+			esc_url( home_url() ),
+			esc_attr( $link_target ),
 			$aria_current,
+			esc_html( $site_title )
 		);
-		if ( '_blank' === $attributes['linkTarget'] ) {
-			$link_attrs[] = 'target="_blank"';
-		}
-		$site_title = sprintf( '<a %1$s>%2$s</a>', implode( ' ', $link_attrs ), esc_html( $site_title ) );
 	}
 	$wrapper_attributes = get_block_wrapper_attributes( array( 'class' => $align_class_name ) );
 


### PR DESCRIPTION
## What?
PR updates the Site Title block to use `home_url` instead of `get_bloginfo` when linking is enabled.

I also made the following small code quality changes:

* Moved `aria-current` check inside the `isLink` condition. There's no need to perform this check if the Site Title isn't linked.
* Removed escaping for static `rel` value.
* Moved link attributes inside `sprintf`.  

## Testing Instructions
The Site Title block should work as before.
