### PR TITLE
List v2: fix Cmd+A

### DIFF
--- a/packages/block-editor/src/components/writing-flow/use-select-all.js
+++ b/packages/block-editor/src/components/writing-flow/use-select-all.js
@@ -19,7 +19,7 @@ import { store as blockEditorStore } from '../../store';
 export default function useSelectAll() {
 	const { getBlockOrder, getSelectedBlockClientIds, getBlockRootClientId } =
 		useSelect( blockEditorStore );
-	const { multiSelect } = useDispatch( blockEditorStore );
+	const { multiSelect, selectBlock } = useDispatch( blockEditorStore );
 	const isMatch = useShortcutEventMatch();
 
 	return useRefEffect( ( node ) => {
@@ -53,6 +53,7 @@ export default function useSelectAll() {
 			const lastClientId = last( blockClientIds );
 
 			if ( firstClientId === lastClientId ) {
+				selectBlock( firstClientId );
 				return;
 			}
 


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?

Fixes Cmd+A from a nested list item.

## Why?

It doesn't work right now.

## How?

Fix an early return without doing anything.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->

With experimental List v2 on, try Cmd A multiple times from a nested list item.

## Screenshots or screencast <!-- if applicable -->

![list-cmd-a](https://user-images.githubusercontent.com/4710635/182174040-96b6c13a-7ab1-4c1f-892b-742e33e7fe91.gif)

