### PR TITLE
Reset focalPoint after replacing the cover image

### DIFF
--- a/packages/block-library/src/cover/shared.js
+++ b/packages/block-library/src/cover/shared.js
@@ -72,8 +72,9 @@ export function attributesFromMedia( setAttributes, dimRatio ) {
 			id: media.id,
 			alt: media?.alt,
 			backgroundType: mediaType,
+			focalPoint: undefined,
 			...( mediaType === VIDEO_BACKGROUND_TYPE
-				? { focalPoint: undefined, hasParallax: undefined }
+				? { hasParallax: undefined }
 				: {} ),
 		} );
 	};


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Reset the `focalPoint` value after replacing image media on the cover block.

Resolves #28859

## Testing Instructions
Follow the video instructions:


https://user-images.githubusercontent.com/1044309/182187298-e28622a3-9cff-4042-8b0c-81b004339d9e.mp4



