### PR TITLE
List v2: copy list wrapper when copying list items

### DIFF
--- a/packages/block-editor/src/components/copy-handler/index.js
+++ b/packages/block-editor/src/components/copy-handler/index.js
@@ -6,6 +6,7 @@ import {
 	serialize,
 	pasteHandler,
 	store as blocksStore,
+	createBlock,
 } from '@wordpress/blocks';
 import {
 	documentHasSelection,
@@ -155,6 +156,23 @@ export function useClipboardHandler() {
 						);
 						blocks = [ head, ...inBetweenBlocks, tail ];
 					}
+
+					const wrapperBlockName = event.clipboardData.getData(
+						'__unstableWrapperBlockName'
+					);
+
+					if ( wrapperBlockName ) {
+						blocks = createBlock(
+							wrapperBlockName,
+							JSON.parse(
+								event.clipboardData.getData(
+									'__unstableWrapperBlockAttributes'
+								)
+							),
+							blocks
+						);
+					}
+
 					const serialized = serialize( blocks );
 
 					event.clipboardData.setData(

--- a/packages/block-library/src/list-item/edit.js
+++ b/packages/block-library/src/list-item/edit.js
@@ -27,6 +27,7 @@ import {
 	useOutdentListItem,
 	useSplit,
 	useMerge,
+	useCopy,
 } from './hooks';
 import { convertToListItems } from './utils';
 
@@ -71,7 +72,7 @@ export default function ListItemEdit( {
 	const onMerge = useMerge( clientId );
 	return (
 		<>
-			<li { ...innerBlocksProps }>
+			<li { ...innerBlocksProps } ref={ useCopy( clientId ) }>
 				<RichText
 					ref={ useMergeRefs( [ useEnterRef, useSpaceRef ] ) }
 					identifier="content"

--- a/packages/block-library/src/list-item/edit.js
+++ b/packages/block-library/src/list-item/edit.js
@@ -62,7 +62,7 @@ export default function ListItemEdit( {
 	clientId,
 } ) {
 	const { placeholder, content } = attributes;
-	const blockProps = useBlockProps();
+	const blockProps = useBlockProps( { ref: useCopy( clientId ) } );
 	const innerBlocksProps = useInnerBlocksProps( blockProps, {
 		allowedBlocks: [ 'core/list' ],
 	} );
@@ -72,7 +72,7 @@ export default function ListItemEdit( {
 	const onMerge = useMerge( clientId );
 	return (
 		<>
-			<li { ...innerBlocksProps } ref={ useCopy( clientId ) }>
+			<li { ...innerBlocksProps }>
 				<RichText
 					ref={ useMergeRefs( [ useEnterRef, useSpaceRef ] ) }
 					identifier="content"

--- a/packages/block-library/src/list-item/hooks/index.js
+++ b/packages/block-library/src/list-item/hooks/index.js
@@ -4,3 +4,4 @@ export { default as useEnter } from './use-enter';
 export { default as useSpace } from './use-space';
 export { default as useSplit } from './use-split';
 export { default as useMerge } from './use-merge';
+export { default as useCopy } from './use-copy';

--- a/packages/block-library/src/list-item/hooks/use-copy.js
+++ b/packages/block-library/src/list-item/hooks/use-copy.js
@@ -1,0 +1,36 @@
+/**
+ * WordPress dependencies
+ */
+import { useRefEffect } from '@wordpress/compose';
+import { store as blockEditorStore } from '@wordpress/block-editor';
+import { useSelect } from '@wordpress/data';
+
+export default function useCopy( clientId ) {
+	const { getBlockRootClientId, getBlockName, getBlockAttributes } =
+		useSelect( blockEditorStore );
+
+	return useRefEffect( ( node ) => {
+		function onCopy( event ) {
+			// The event propagates through all nested lists, so don't override
+			// when copying nested list items.
+			if ( event.clipboardData.getData( '__unstableWrapperBlockName' ) ) {
+				return;
+			}
+
+			const rootClientId = getBlockRootClientId( clientId );
+			event.clipboardData.setData(
+				'__unstableWrapperBlockName',
+				getBlockName( rootClientId )
+			);
+			event.clipboardData.setData(
+				'__unstableWrapperBlockAttributes',
+				JSON.stringify( getBlockAttributes( rootClientId ) )
+			);
+		}
+
+		node.addEventListener( 'copy', onCopy );
+		return () => {
+			node.removeEventListener( 'copy', onCopy );
+		};
+	}, [] );
+}


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?

Currently when copying one or multiple list items (or all), they are copied with the list wrapper.

## Why?

List items must be copied with a wrapper to be valid HTML.
Currently copied list items can't be pasted outside of lists.

## How?

Signals to the copy handler that a wrapper block needs to be created by setting extra clipboard data.

## Testing Instructions

Enable experimental list v2.
Create a list with list items. Select a single or a few list items. Copy them and paste them in an empty paragraph. What is pasted should be a list (including the correct attributes).

## Screenshots or screencast <!-- if applicable -->

![list-item-copy](https://user-images.githubusercontent.com/4710635/182188077-c0e71937-77ad-4952-b110-b2d4bf725302.gif)
