### PR TITLE
wp-env runs docker commands with same UID as host to prevent filesystem permission issues

### DIFF
--- a/packages/env/lib/commands/run.js
+++ b/packages/env/lib/commands/run.js
@@ -2,6 +2,7 @@
  * External dependencies
  */
 const { spawn } = require( 'child_process' );
+const os = require("os");
 
 /**
  * Internal dependencies
@@ -53,6 +54,8 @@ function spawnCommandDirectly( { container, command, config, spinner } ) {
 		'-f',
 		config.dockerComposeConfigPath,
 		'run',
+		'-u',
+		os.userInfo().uid,
 		'--rm',
 		container,
 		...command.split( ' ' ), // The command will fail if passed as a complete string.

--- a/packages/env/lib/commands/run.js
+++ b/packages/env/lib/commands/run.js
@@ -2,7 +2,7 @@
  * External dependencies
  */
 const { spawn } = require( 'child_process' );
-const os = require("os");
+const os = require('os');
 
 /**
  * Internal dependencies


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Pass the UID of the user running wp-env down to the docker-compose run instance.

## Why?
Files created inside the docker instance have permission issues since they are created with user 0:0 (root).
Closes #42866

## How?
Files created inside the container will have the same UID as the host.

## Testing Instructions
I have not tested this yet. Looking into it now, any help here would be appreciated.

## Screenshots or screencast <!-- if applicable -->
