### PR TITLE
Popover: fix arrow placement and design

### DIFF
--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -8,6 +8,7 @@
 -   `BorderControl`: Ensure box-sizing is reset for the control ([#42754](https://github.com/WordPress/gutenberg/pull/42754)).
 -   `InputControl`: Fix acceptance of falsy values in controlled updates ([#42484](https://github.com/WordPress/gutenberg/pull/42484/)).
 -   `Tooltip (Experimental)`, `CustomSelectControl`, `TimePicker`: Add missing font-size styles which were necessary in non-WordPress contexts ([#42844](https://github.com/WordPress/gutenberg/pull/42844/)).
+-   `Popover`: fix arrow placement and design ([#42874](https://github.com/WordPress/gutenberg/pull/42874/)).
 
 ### Enhancements
 

--- a/packages/components/src/popover/index.js
+++ b/packages/components/src/popover/index.js
@@ -32,6 +32,7 @@ import {
 } from '@wordpress/compose';
 import { close } from '@wordpress/icons';
 import deprecated from '@wordpress/deprecated';
+import { Path, SVG } from '@wordpress/primitives';
 
 /**
  * Internal dependencies
@@ -47,6 +48,30 @@ import { getAnimateClassName } from '../animate';
  * @type {string}
  */
 const SLOT_NAME = 'Popover';
+
+// An SVG displaying a triangle facing down, filled with a solid
+// color and bordered in such a way to create an arrow-like effect.
+// Keeping the SVG's viewbox squared simplify the arrow positioning
+// calculations.
+const ArrowTriangle = ( props ) => (
+	<SVG
+		{ ...props }
+		xmlns="http://www.w3.org/2000/svg"
+		viewBox={ `0 0 100 100` }
+		className="components-popover__triangle"
+		role="presentation"
+	>
+		<Path
+			className="components-popover__triangle-bg"
+			d="M 0 0 L 50 50 L 100 0"
+		/>
+		<Path
+			className="components-popover__triangle-border"
+			d="M 0 0 L 50 50 L 100 0"
+			vectorEffect="non-scaling-stroke"
+		/>
+	</SVG>
+);
 
 const slotNameContext = createContext();
 
@@ -266,12 +291,7 @@ const Popover = (
 		placement: usedPlacement,
 		middleware: middlewares,
 	} );
-	const staticSide = {
-		top: 'bottom',
-		right: 'left',
-		bottom: 'top',
-		left: 'right',
-	}[ placementData.split( '-' )[ 0 ] ];
+
 	const mergedRefs = useMergeRefs( [ floating, dialogRef, ref ] );
 
 	// Updates references
@@ -407,22 +427,25 @@ const Popover = (
 			<div className="components-popover__content">{ children }</div>
 			{ hasArrow && (
 				<div
-					className="components-popover__arrow"
 					ref={ arrowRef }
+					className={ [
+						'components-popover__arrow',
+						`components-popover__arrow--${
+							placementData.split( '-' )[ 0 ]
+						}`,
+					].join( ' ' ) }
 					style={ {
-						left:
-							! arrowData?.x || Number.isNaN( arrowData?.x )
-								? 0
-								: arrowData.x,
-						top:
-							! arrowData?.y || Number.isNaN( arrowData?.y )
-								? 0
-								: arrowData.y,
-						right: undefined,
-						bottom: undefined,
-						[ staticSide ]: '-4px',
+						left: Number.isFinite( arrowData?.x )
+							? `${ arrowData.x }px`
+							: '',
+						top: Number.isFinite( arrowData?.y )
+							? `${ arrowData.y }px`
+							: '',
+						'--wp-popover-arrow-size': '14px',
 					} }
-				/>
+				>
+					<ArrowTriangle />
+				</div>
 			) }
 		</div>
 	);

--- a/packages/components/src/popover/index.js
+++ b/packages/components/src/popover/index.js
@@ -439,7 +439,6 @@ const Popover = (
 						top: Number.isFinite( arrowData?.y )
 							? `${ arrowData.y }px`
 							: '',
-						'--wp-popover-arrow-size': '14px',
 					} }
 				>
 					<ArrowTriangle />

--- a/packages/components/src/popover/index.js
+++ b/packages/components/src/popover/index.js
@@ -430,9 +430,7 @@ const Popover = (
 					ref={ arrowRef }
 					className={ [
 						'components-popover__arrow',
-						`components-popover__arrow--${
-							placementData.split( '-' )[ 0 ]
-						}`,
+						`is-${ placementData.split( '-' )[ 0 ] }`,
 					].join( ' ' ) }
 					style={ {
 						left: Number.isFinite( arrowData?.x )

--- a/packages/components/src/popover/style.scss
+++ b/packages/components/src/popover/style.scss
@@ -1,3 +1,5 @@
+$arrow-triangle-base-size: 14px;
+
 .components-popover {
 	z-index: z-index(".components-popover");
 
@@ -60,8 +62,8 @@
 
 .components-popover__arrow {
 	position: absolute;
-	width: var(--wp-popover-arrow-size);
-	height: var(--wp-popover-arrow-size);
+	width: $arrow-triangle-base-size;
+	height: $arrow-triangle-base-size;
 	pointer-events: none;
 
 	// Thin line that helps to make sure that the underlying
@@ -80,21 +82,21 @@
 	// Position and rotate the arrow depending on the popover's placement.
 	// The `!important' is necessary to override the inline styles.
 	&.is-top {
-		bottom: calc(-1 * var(--wp-popover-arrow-size)) !important;
+		bottom: -1 * $arrow-triangle-base-size !important;
 		transform: rotate(0);
 	}
 	&.is-right {
 		/*rtl:begin:ignore*/
-		left: calc(-1 * var(--wp-popover-arrow-size)) !important;
+		left: -1 * $arrow-triangle-base-size !important;
 		transform: rotate(90deg);
 	}
 	&.is-bottom {
-		top: calc(-1 * var(--wp-popover-arrow-size)) !important;
+		top: -1 * $arrow-triangle-base-size !important;
 		transform: rotate(180deg);
 	}
 	&.is-left {
 		/*rtl:begin:ignore*/
-		right: calc(-1 * var(--wp-popover-arrow-size)) !important;
+		right: -1 * $arrow-triangle-base-size !important;
 		transform: rotate(-90deg);
 		/*rtl:end:ignore*/
 	}

--- a/packages/components/src/popover/style.scss
+++ b/packages/components/src/popover/style.scss
@@ -60,12 +60,61 @@
 
 .components-popover__arrow {
 	position: absolute;
-	background: $gray-400;
-	width: 8px;
-	height: 8px;
-	transform: rotate(45deg);
-	z-index: -1;
-	.is-alternate & {
-		background: $gray-900;
+	width: var(--wp-popover-arrow-size);
+	height: var(--wp-popover-arrow-size);
+	pointer-events: none;
+
+	// Thin line that helps to make sure that the underlying
+	// popover__content's outline is fully overlapped by the
+	// arrow
+	&::before {
+		content: "";
+		position: absolute;
+		top: -1px;
+		left: 0;
+		height: 2px;
+		width: 100%;
+		background-color: $white;
+	}
+
+	// Position and rotate the arrow depending on the popover's placement.
+	// The `!important' is necessary to override the inline styles.
+	&--top {
+		bottom: calc(-1 * var(--wp-popover-arrow-size)) !important;
+		transform: rotate(0);
+	}
+	&--right {
+		left: calc(-1 * var(--wp-popover-arrow-size)) !important;
+		transform: rotate(90deg);
+	}
+	&--bottom {
+		top: calc(-1 * var(--wp-popover-arrow-size)) !important;
+		transform: rotate(180deg);
+	}
+	&--left {
+		right: calc(-1 * var(--wp-popover-arrow-size)) !important;
+		transform: rotate(-90deg);
+	}
+}
+
+.components-popover__triangle {
+	fill: transparent;
+	position: absolute;
+	height: 100%;
+	width: 100%;
+	stroke-width: $border-width;
+
+	// Same as popover content
+	&-bg {
+		fill: $white;
+		stroke: $white;
+	}
+
+	&-border {
+		stroke: $gray-400;
+	}
+
+	.is-alternate &-border {
+		stroke: $gray-900;
 	}
 }

--- a/packages/components/src/popover/style.scss
+++ b/packages/components/src/popover/style.scss
@@ -101,23 +101,23 @@
 }
 
 .components-popover__triangle {
-	fill: transparent;
 	position: absolute;
 	height: 100%;
 	width: 100%;
+}
+
+.components-popover__triangle-bg {
+	// Fill color is the same as the .components-popover__content's background
+	fill: $white;
+}
+
+.components-popover__triangle-border {
+	// Stroke colors are the same as the .components-popover__content's outline
+	fill: transparent;
 	stroke-width: $border-width;
+	stroke: $gray-400;
 
-	// Same as popover content
-	&-bg {
-		fill: $white;
-		stroke: $white;
-	}
-
-	&-border {
-		stroke: $gray-400;
-	}
-
-	.is-alternate &-border {
+	.is-alternate & {
 		stroke: $gray-900;
 	}
 }

--- a/packages/components/src/popover/style.scss
+++ b/packages/components/src/popover/style.scss
@@ -84,6 +84,7 @@
 		transform: rotate(0);
 	}
 	&--right {
+		/*rtl:begin:ignore*/
 		left: calc(-1 * var(--wp-popover-arrow-size)) !important;
 		transform: rotate(90deg);
 	}
@@ -92,8 +93,10 @@
 		transform: rotate(180deg);
 	}
 	&--left {
+		/*rtl:begin:ignore*/
 		right: calc(-1 * var(--wp-popover-arrow-size)) !important;
 		transform: rotate(-90deg);
+		/*rtl:end:ignore*/
 	}
 }
 

--- a/packages/components/src/popover/style.scss
+++ b/packages/components/src/popover/style.scss
@@ -79,20 +79,20 @@
 
 	// Position and rotate the arrow depending on the popover's placement.
 	// The `!important' is necessary to override the inline styles.
-	&--top {
+	&.is-top {
 		bottom: calc(-1 * var(--wp-popover-arrow-size)) !important;
 		transform: rotate(0);
 	}
-	&--right {
+	&.is-right {
 		/*rtl:begin:ignore*/
 		left: calc(-1 * var(--wp-popover-arrow-size)) !important;
 		transform: rotate(90deg);
 	}
-	&--bottom {
+	&.is-bottom {
 		top: calc(-1 * var(--wp-popover-arrow-size)) !important;
 		transform: rotate(180deg);
 	}
-	&--left {
+	&.is-left {
 		/*rtl:begin:ignore*/
 		right: calc(-1 * var(--wp-popover-arrow-size)) !important;
 		transform: rotate(-90deg);


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

Fixes #42820

## What?
<!-- In a few words, what is the PR actually doing? -->

Fix a regression introduced in #40740 about the `Popover`'s arrow placement.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

The `Popover`'s arrow has currently a few issues:

- it is not always positioned correctly
- it doesn't render with the same background color and border as the popover's contents
- its size is smaller than it used to be before #40740

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

In order to fix the arrow placement, the following changes were implemented:

- fixed a bug in the logic behind validating the arrow's `x` and `y` coordinates received from `useFloating` (mainly switching from `! Number.isNaN` to `Number.isFinite`)
- changed the approach in rendering the arrow's triangle:
  - from a diamond rotated `45deg`, switched to a proper triangle (coded in SVG)
  - Added (back) support for a border color around the triangle, in line with how the design used to be
  - moved some inline styles to SASS styles, using an internal `$arrow-triangle-base-size` SCSS variable

I've also added two extra temporary commits (which I will remove before merging)
  - one adding a Storybook example to easily check that the arrow's placement is correct for all possible placements
  - another one adding a quick change that makes sure that `ownerDocument` is always defined inside `Popover` (this fix should probably be moved to its own separate PR)

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->

- In Storybook: on your machine, visit the new temporary "Positioning" Storybook example and make sure that the arrow's placement and design looks correct for all possible popover placements
- In the WordPress app: on your machine, visit `/wp-admin/site-editor.php?postType=wp_template` and click the "Add New" button in the top right part of the screen. Make sure that the Popover's arrow placement and design look correct (see [this comment](https://github.com/WordPress/gutenberg/issues/42820#issuecomment-1200612126) for more details)
- Try to replicate the bug reported in [the original issue's description](https://github.com/WordPress/gutenberg/issues/42820#issue-1322276575) and confirm that it can't be replicated anymore

For extra thoroughness, you could revert the `Popover: fix arrow logic, use SVG to render triangle` commit in this PR and verify that the bug is not fixed in the scenarios described above.

## Screenshots or screencast <!-- if applicable -->

| Before | After |
|---|---|
|  ![image](https://user-images.githubusercontent.com/1083581/182248194-04c0dd46-b92b-40f4-ab66-791ab39fed31.png) | ![Screenshot 2022-08-01 at 23 19 57](https://user-images.githubusercontent.com/1083581/182248609-fab94cf9-ddb0-4b7a-97c8-6ec9bb7ec117.png) |


**Before:**

https://user-images.githubusercontent.com/1083581/182247869-27cb9797-e8d3-4cd8-a45e-d43d89f52774.mp4


**After:**

https://user-images.githubusercontent.com/1083581/182247281-7f07e868-6305-40b2-9a8c-40b4f0bb2e0b.mp4


