### PR TITLE
[WIP] Group: Try setting inherit to true if the block is empty and hasn't set an inherit value yet

### DIFF
--- a/packages/block-library/src/group/edit.js
+++ b/packages/block-library/src/group/edit.js
@@ -1,7 +1,8 @@
 /**
  * WordPress dependencies
  */
-import { useSelect } from '@wordpress/data';
+import { useSelect, useDispatch } from '@wordpress/data';
+import { useEffect } from '@wordpress/element';
 import {
 	InnerBlocks,
 	useBlockProps,
@@ -66,6 +67,19 @@ function GroupEdit( { attributes, setAttributes, clientId } ) {
 			__experimentalLayout: layoutSupportEnabled ? usedLayout : undefined,
 		}
 	);
+
+	const { __unstableMarkNextChangeAsNotPersistent } =
+		useDispatch( blockEditorStore );
+	const { inherit } = layout;
+	useEffect( () => {
+		// If a block has not yet set the `inherit` value to either `true` or `false`,
+		// and it doesn't have any inner blocks, then set it to the desired default value.
+		// This ensures that newly inserted blocks are set to use the root/global content sizes.
+		if ( inherit === undefined && ! hasInnerBlocks ) {
+			__unstableMarkNextChangeAsNotPersistent();
+			setAttributes( { layout: { inherit: true } } );
+		}
+	}, [ hasInnerBlocks, inherit ] );
 
 	return (
 		<>


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

🚧 🚧 🚧 🚧 🚧 

This is just a hacky WIP exploration based on discussion in https://github.com/WordPress/gutenberg/pull/42763#issuecomment-1198956326, and exploring ideas that @tellthemachines originally created in #42582.

The idea in this PR is to see if it's possible for us to effectively switch the default for the Group block's `layout.inherit` value without deprecations or affecting blocks that are already out in the wild and containing content.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

As raised in both #42763 and #42582, each of the approaches results in challenging edge cases, so this PR is just another exploration into the ideas discussed!

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

* In the Group block, check if the block is empty (has no inner blocks) and has not yet set the `inherit` value to either `true` or `false`. If that's the case, then set it to `true`.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->

1. Check that post content containing existing blocks with content are unaffected.
2. Adding a new Group block should default to `inherit` being set to `true` (the full width toggle is off by default)

Here's some test markup:

<details>

<summary>Test Group block markup</summary>

```html
<!-- wp:group {"backgroundColor":"vivid-red","textColor":"background"} -->
<div class="wp-block-group has-background-color has-vivid-red-background-color has-text-color has-background"><!-- wp:paragraph -->
<p>Default Group block (inherit false, not custom size)</p>
<!-- /wp:paragraph --></div>
<!-- /wp:group -->

<!-- wp:group {"backgroundColor":"vivid-red","textColor":"background","layout":{"contentSize":"320px","wideSize":"400px"}} -->
<div class="wp-block-group has-background-color has-vivid-red-background-color has-text-color has-background"><!-- wp:paragraph -->
<p>Default Group block (inherit false, custom size and wide size)</p>
<!-- /wp:paragraph -->

<!-- wp:cover {"overlayColor":"primary","minHeight":212,"minHeightUnit":"px","align":"wide"} -->
<div class="wp-block-cover alignwide" style="min-height:212px"><span aria-hidden="true" class="wp-block-cover__background has-primary-background-color has-background-dim-100 has-background-dim"></span><div class="wp-block-cover__inner-container"><!-- wp:paragraph {"align":"center","placeholder":"Write title…","fontSize":"large"} -->
<p class="has-text-align-center has-large-font-size">A wide cover</p>
<!-- /wp:paragraph --></div></div>
<!-- /wp:cover --></div>
<!-- /wp:group -->

<!-- wp:group {"backgroundColor":"vivid-red","textColor":"background","layout":{"inherit":true}} -->
<div class="wp-block-group has-background-color has-vivid-red-background-color has-text-color has-background"><!-- wp:paragraph -->
<p>Default Group block (inherit true)</p>
<!-- /wp:paragraph -->

<!-- wp:cover {"overlayColor":"primary","minHeight":212,"minHeightUnit":"px","align":"wide"} -->
<div class="wp-block-cover alignwide" style="min-height:212px"><span aria-hidden="true" class="wp-block-cover__background has-primary-background-color has-background-dim-100 has-background-dim"></span><div class="wp-block-cover__inner-container"><!-- wp:paragraph {"align":"center","placeholder":"Write title…","fontSize":"large"} -->
<p class="has-text-align-center has-large-font-size">A wide cover</p>
<!-- /wp:paragraph --></div></div>
<!-- /wp:cover --></div>
<!-- /wp:group -->

<!-- wp:group -->
<div class="wp-block-group"></div>
<!-- /wp:group -->

<!-- wp:group {"layout":{"inherit":true}} -->
<div class="wp-block-group"></div>
<!-- /wp:group -->

<!-- wp:group {"layout":{"contentSize":"320px","wideSize":"400px"}} -->
<div class="wp-block-group"></div>
<!-- /wp:group -->

<!-- wp:paragraph -->
<p>A paragraph not inside anything</p>
<!-- /wp:paragraph -->

```

</details>

## Screenshots or screencast <!-- if applicable -->
