### PR TITLE
Prevent multiselection via dragging when already dragging blocks

### DIFF
--- a/packages/block-editor/src/components/writing-flow/use-drag-selection.js
+++ b/packages/block-editor/src/components/writing-flow/use-drag-selection.js
@@ -27,7 +27,7 @@ function setContentEditableWrapper( node, value ) {
 export default function useDragSelection() {
 	const { startMultiSelect, stopMultiSelect } =
 		useDispatch( blockEditorStore );
-	const { isSelectionEnabled, hasMultiSelection } =
+	const { isSelectionEnabled, hasMultiSelection, isDraggingBlocks } =
 		useSelect( blockEditorStore );
 	return useRefEffect(
 		( node ) => {
@@ -72,6 +72,12 @@ export default function useDragSelection() {
 			}
 
 			function onMouseLeave( { buttons, target } ) {
+				// Avoid triggering a multi-selection if the user is already
+				// dragging blocks.
+				if ( isDraggingBlocks() ) {
+					return;
+				}
+
 				// The primary button must be pressed to initiate selection.
 				// See https://developer.mozilla.org/en-US/docs/Web/API/MouseEvent/buttons
 				if ( buttons !== 1 ) {


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Fixes #42840.

Recent changes to multi-selection introduced a bug to drag and drop. The gist of it is that multi-selection code was triggering during the block drag and drop, causing the drag and drop operation to visibly reset (I guess because of a focus change, though I'm not entirely sure of the exact underlying root cause).

## How?
Avoid triggering multi select when dragging blocks by adding an early return.

## Testing Instructions
### Dragging and dropping
1. Open the gutenberg demo post
2. Try dragging a paragraph down the post
3. The drag operation should continue to be active

### Multi-selection
1. Open the gutenberg demo post
2. Select a paragraph block and then select text across multiple blocks by click/dragging a text selection
3. It should be possible to select a range of text across blocks, and also multi-select blocks.

## Screenshots or screencast <!-- if applicable -->
### Before

https://user-images.githubusercontent.com/677833/181688729-341cc546-2519-480d-9b62-2e19c230ab96.mp4

### After

https://user-images.githubusercontent.com/677833/182279172-861f2f11-bff5-408f-b14a-42b2a2fe9ef1.mp4

