### PR TITLE
Style engine: add optimize flag and combine functions into wp_style_engine_get_stylesheet 

### DIFF
--- a/lib/block-supports/elements.php
+++ b/lib/block-supports/elements.php
@@ -92,9 +92,6 @@ function gutenberg_render_elements_support_styles( $pre_render, $block ) {
 
 	/*
 	* For now we only care about link color.
-	* This code in the future when we have a public API
-	* should take advantage of WP_Theme_JSON_Gutenberg::compute_style_properties
-	* and work for any element and style.
 	*/
 	$skip_link_color_serialization = gutenberg_should_skip_block_supports_serialization( $block_type, 'color', 'link' );
 

--- a/lib/block-supports/layout.php
+++ b/lib/block-supports/layout.php
@@ -204,11 +204,15 @@ function gutenberg_get_layout_style( $selector, $layout, $has_block_gap_support 
 
 	if ( ! empty( $layout_styles ) ) {
 		// Add to the style engine store to enqueue and render layout styles.
-		gutenberg_style_engine_add_to_store( 'layout-block-supports', $layout_styles );
-
 		// Return compiled layout styles to retain backwards compatibility.
 		// Since https://github.com/WordPress/gutenberg/pull/42452 we no longer call wp_enqueue_block_support_styles in this block supports file.
-		return gutenberg_style_engine_get_stylesheet_from_css_rules( $layout_styles );
+		return gutenberg_style_engine_get_stylesheet(
+			$layout_styles,
+			array(
+				'context' => 'layout-block-supports',
+				'enqueue' => true,
+			)
+		);
 	}
 
 	return '';

--- a/lib/block-supports/layout.php
+++ b/lib/block-supports/layout.php
@@ -206,7 +206,7 @@ function gutenberg_get_layout_style( $selector, $layout, $has_block_gap_support 
 		// Add to the style engine store to enqueue and render layout styles.
 		// Return compiled layout styles to retain backwards compatibility.
 		// Since https://github.com/WordPress/gutenberg/pull/42452 we no longer call wp_enqueue_block_support_styles in this block supports file.
-		return gutenberg_style_engine_get_stylesheet(
+		return gutenberg_style_engine_get_stylesheet_from_css_rules(
 			$layout_styles,
 			array(
 				'context' => 'layout-block-supports',

--- a/packages/style-engine/class-wp-style-engine-processor.php
+++ b/packages/style-engine/class-wp-style-engine-processor.php
@@ -63,16 +63,27 @@ class WP_Style_Engine_Processor {
 	/**
 	 * Get the CSS rules as a string.
 	 *
+	 * @param array $options array(
+	 *    'optimize' => (boolean) Whether to optimize the CSS output, e.g., combine rules.
+	 * );.
+	 *
 	 * @return string The computed CSS.
 	 */
-	public function get_css() {
+	public function get_css( $options = array() ) {
+		$defaults = array(
+			'optimize' => true,
+		);
+		$options  = wp_parse_args( $options, $defaults );
+
 		// If we have stores, get the rules from them.
 		foreach ( $this->stores as $store ) {
 			$this->add_rules( $store->get_all_rules() );
 		}
 
 		// Combine CSS selectors that have identical declarations.
-		$this->combine_rules_selectors();
+		if ( true === $options['optimize'] ) {
+			$this->combine_rules_selectors();
+		}
 
 		// Build the CSS.
 		$css = '';

--- a/packages/style-engine/class-wp-style-engine.php
+++ b/packages/style-engine/class-wp-style-engine.php
@@ -679,7 +679,7 @@ function wp_style_engine_get_styles( $block_styles, $options = array() ) {
  *
  * @return string A compiled CSS string.
  */
-function wp_style_engine_get_stylesheet( $css_rules, $options = array() ) {
+function wp_style_engine_get_stylesheet_from_css_rules( $css_rules, $options = array() ) {
 	if ( ! class_exists( 'WP_Style_Engine' ) || empty( $css_rules ) ) {
 		return '';
 	}

--- a/packages/style-engine/class-wp-style-engine.php
+++ b/packages/style-engine/class-wp-style-engine.php
@@ -666,10 +666,12 @@ function wp_style_engine_get_styles( $block_styles, $options = array() ) {
  *
  * @access public
  *
- * @param string $store_key A valid store key.
- * @param array  $css_rules array(
- *     'selector'         => (string) A CSS selector.
- *     'declarations' => (boolean) An array of CSS definitions, e.g., array( "$property" => "$value" ).
+ * @param string       $store_key A valid store key.
+ * @param array<array> $css_rules array(
+ *     array(
+ *         'selector'         => (string) A CSS selector.
+ *         declarations' => (boolean) An array of CSS definitions, e.g., array( "$property" => "$value" ).
+ *     )
  * );.
  *
  * @return WP_Style_Engine_CSS_Rules_Store|null.

--- a/packages/style-engine/class-wp-style-engine.php
+++ b/packages/style-engine/class-wp-style-engine.php
@@ -679,7 +679,7 @@ function wp_style_engine_get_styles( $block_styles, $options = array() ) {
  *
  * @return string A compiled CSS string.
  */
-function wp_style_engine_get_stylesheet( $css_rules, $options ) {
+function wp_style_engine_get_stylesheet( $css_rules, $options = array() ) {
 	if ( ! class_exists( 'WP_Style_Engine' ) || empty( $css_rules ) ) {
 		return '';
 	}

--- a/packages/style-engine/phpunit/class-wp-style-engine-processor-test.php
+++ b/packages/style-engine/phpunit/class-wp-style-engine-processor-test.php
@@ -35,7 +35,10 @@ class WP_Style_Engine_Processor_Test extends WP_UnitTestCase {
 		);
 		$a_nice_processor = new WP_Style_Engine_Processor();
 		$a_nice_processor->add_rules( array( $a_nice_css_rule, $a_nicer_css_rule ) );
-		$this->assertEquals( '.a-nice-rule {color: var(--nice-color); background-color: purple;}.a-nicer-rule {font-family: Nice sans; font-size: 1em; background-color: purple;}', $a_nice_processor->get_css() );
+		$this->assertEquals(
+			'.a-nice-rule {color: var(--nice-color); background-color: purple;}.a-nicer-rule {font-family: Nice sans; font-size: 1em; background-color: purple;}',
+			$a_nice_processor->get_css()
+		);
 	}
 
 	/**
@@ -58,7 +61,10 @@ class WP_Style_Engine_Processor_Test extends WP_UnitTestCase {
 		);
 		$a_nice_renderer = new WP_Style_Engine_Processor();
 		$a_nice_renderer->add_store( $a_nice_store );
-		$this->assertEquals( '.a-nice-rule {color: var(--nice-color); background-color: purple;}.a-nicer-rule {font-family: Nice sans; font-size: 1em; background-color: purple;}', $a_nice_renderer->get_css() );
+		$this->assertEquals(
+			'.a-nice-rule {color: var(--nice-color); background-color: purple;}.a-nicer-rule {font-family: Nice sans; font-size: 1em; background-color: purple;}',
+			$a_nice_renderer->get_css()
+		);
 	}
 
 	/**
@@ -84,7 +90,10 @@ class WP_Style_Engine_Processor_Test extends WP_UnitTestCase {
 			)
 		);
 		$an_excellent_processor->add_rules( $another_excellent_rule );
-		$this->assertEquals( '.an-excellent-rule {color: var(--excellent-color); border-style: dotted; border-color: brown;}', $an_excellent_processor->get_css() );
+		$this->assertEquals(
+			'.an-excellent-rule {color: var(--excellent-color); border-style: dotted; border-color: brown;}',
+			$an_excellent_processor->get_css()
+		);
 
 		$yet_another_excellent_rule = new WP_Style_Engine_CSS_Rule( '.an-excellent-rule' );
 		$yet_another_excellent_rule->add_declarations(
@@ -95,7 +104,10 @@ class WP_Style_Engine_Processor_Test extends WP_UnitTestCase {
 			)
 		);
 		$an_excellent_processor->add_rules( $yet_another_excellent_rule );
-		$this->assertEquals( '.an-excellent-rule {color: var(--excellent-color); border-style: dashed; border-color: brown; border-width: 2px;}', $an_excellent_processor->get_css() );
+		$this->assertEquals(
+			'.an-excellent-rule {color: var(--excellent-color); border-style: dashed; border-color: brown; border-width: 2px;}',
+			$an_excellent_processor->get_css()
+		);
 	}
 
 	/**
@@ -129,7 +141,10 @@ class WP_Style_Engine_Processor_Test extends WP_UnitTestCase {
 		$a_sweet_processor = new WP_Style_Engine_Processor();
 		$a_sweet_processor->add_rules( array( $a_sweet_rule, $a_sweeter_rule, $the_sweetest_rule ) );
 
-		$this->assertEquals( '.a-sweet-rule {color: var(--sweet-color); background-color: purple;}#an-even-sweeter-rule > marquee {color: var(--sweet-color); background-color: purple;}.the-sweetest-rule-of-all a {color: var(--sweet-color); background-color: purple;}', $a_sweet_processor->get_css( array( 'optimize' => false ) ) );
+		$this->assertEquals(
+			'.a-sweet-rule {color: var(--sweet-color); background-color: purple;}#an-even-sweeter-rule > marquee {color: var(--sweet-color); background-color: purple;}.the-sweetest-rule-of-all a {color: var(--sweet-color); background-color: purple;}',
+			$a_sweet_processor->get_css( array( 'optimize' => false ) )
+		);
 	}
 
 	/**
@@ -155,7 +170,10 @@ class WP_Style_Engine_Processor_Test extends WP_UnitTestCase {
 		$a_sweet_processor = new WP_Style_Engine_Processor();
 		$a_sweet_processor->add_rules( array( $a_sweet_rule, $a_sweeter_rule ) );
 
-		$this->assertEquals( '.a-sweet-rule,#an-even-sweeter-rule > marquee {color: var(--sweet-color); background-color: purple;}', $a_sweet_processor->get_css() );
+		$this->assertEquals(
+			'.a-sweet-rule,#an-even-sweeter-rule > marquee {color: var(--sweet-color); background-color: purple;}',
+			$a_sweet_processor->get_css()
+		);
 	}
 		/**
 		 * Should combine and store CSS rules.
@@ -194,6 +212,9 @@ class WP_Style_Engine_Processor_Test extends WP_UnitTestCase {
 		);
 		$a_lovely_processor->add_rules( $a_perfectly_lovely_rule );
 
-		$this->assertEquals( '.a-lovely-rule,.a-lovelier-rule,.a-most-lovely-rule,.a-perfectly-lovely-rule {border-color: purple;}', $a_lovely_processor->get_css() );
+		$this->assertEquals(
+			'.a-lovely-rule,.a-lovelier-rule,.a-most-lovely-rule,.a-perfectly-lovely-rule {border-color: purple;}',
+			$a_lovely_processor->get_css()
+		);
 	}
 }

--- a/packages/style-engine/phpunit/class-wp-style-engine-processor-test.php
+++ b/packages/style-engine/phpunit/class-wp-style-engine-processor-test.php
@@ -42,7 +42,7 @@ class WP_Style_Engine_Processor_Test extends WP_UnitTestCase {
 	 * Should compile CSS rules from the store.
 	 */
 	public function test_return_store_rules_as_css() {
-		$a_nice_store = WP_Style_Engine_CSS_Rules_Store_Gutenberg::get_store( 'nice' );
+		$a_nice_store = WP_Style_Engine_CSS_Rules_Store::get_store( 'nice' );
 		$a_nice_store->add_rule( '.a-nice-rule' )->add_declarations(
 			array(
 				'color'            => 'var(--nice-color)',

--- a/packages/style-engine/phpunit/class-wp-style-engine-processor-test.php
+++ b/packages/style-engine/phpunit/class-wp-style-engine-processor-test.php
@@ -56,7 +56,7 @@ class WP_Style_Engine_Processor_Test extends WP_UnitTestCase {
 				'background-color' => 'purple',
 			)
 		);
-		$a_nice_renderer = new WP_Style_Engine_Processor_Gutenberg();
+		$a_nice_renderer = new WP_Style_Engine_Processor();
 		$a_nice_renderer->add_store( $a_nice_store );
 		$this->assertEquals( '.a-nice-rule {color: var(--nice-color); background-color: purple;}.a-nicer-rule {font-family: Nice sans; font-size: 1em; background-color: purple;}', $a_nice_renderer->get_css() );
 	}
@@ -96,6 +96,40 @@ class WP_Style_Engine_Processor_Test extends WP_UnitTestCase {
 		);
 		$an_excellent_processor->add_rules( $yet_another_excellent_rule );
 		$this->assertEquals( '.an-excellent-rule {color: var(--excellent-color); border-style: dashed; border-color: brown; border-width: 2px;}', $an_excellent_processor->get_css() );
+	}
+
+	/**
+	 * Should print out uncombined selectors duplicate CSS rules.
+	 */
+	public function test_output_verbose_css_rules() {
+		$a_sweet_rule = new WP_Style_Engine_CSS_Rule(
+			'.a-sweet-rule',
+			array(
+				'color'            => 'var(--sweet-color)',
+				'background-color' => 'purple',
+			)
+		);
+
+		$a_sweeter_rule = new WP_Style_Engine_CSS_Rule(
+			'#an-even-sweeter-rule > marquee',
+			array(
+				'color'            => 'var(--sweet-color)',
+				'background-color' => 'purple',
+			)
+		);
+
+		$the_sweetest_rule = new WP_Style_Engine_CSS_Rule(
+			'.the-sweetest-rule-of-all a',
+			array(
+				'color'            => 'var(--sweet-color)',
+				'background-color' => 'purple',
+			)
+		);
+
+		$a_sweet_processor = new WP_Style_Engine_Processor();
+		$a_sweet_processor->add_rules( array( $a_sweet_rule, $a_sweeter_rule, $the_sweetest_rule ) );
+
+		$this->assertEquals( '.a-sweet-rule {color: var(--sweet-color); background-color: purple;}#an-even-sweeter-rule > marquee {color: var(--sweet-color); background-color: purple;}.the-sweetest-rule-of-all a {color: var(--sweet-color); background-color: purple;}', $a_sweet_processor->get_css( array( 'optimize' => false ) ) );
 	}
 
 	/**

--- a/packages/style-engine/phpunit/class-wp-style-engine-test.php
+++ b/packages/style-engine/phpunit/class-wp-style-engine-test.php
@@ -560,7 +560,7 @@ class WP_Style_Engine_Test extends WP_UnitTestCase {
 				),
 			),
 		);
-		$compiled_stylesheet = wp_style_engine_get_stylesheet(
+		$compiled_stylesheet = wp_style_engine_get_stylesheet_from_css_rules(
 			$css_rules,
 			array(
 				'context' => 'test-store',
@@ -609,7 +609,7 @@ class WP_Style_Engine_Test extends WP_UnitTestCase {
 			),
 		);
 
-		$compiled_stylesheet = wp_style_engine_get_stylesheet( $css_rules );
+		$compiled_stylesheet = wp_style_engine_get_stylesheet_from_css_rules( $css_rules );
 		$this->assertSame( '.saruman {color: white; height: 100px; border-style: solid; align-self: unset;}.gandalf {color: grey; height: 90px; border-style: dotted; align-self: safe center;}.radagast {color: brown; height: 60px; border-style: dashed; align-self: stretch;}', $compiled_stylesheet );
 	}
 
@@ -653,7 +653,7 @@ class WP_Style_Engine_Test extends WP_UnitTestCase {
 			),
 		);
 
-		$compiled_stylesheet = wp_style_engine_get_stylesheet( $css_rules );
+		$compiled_stylesheet = wp_style_engine_get_stylesheet_from_css_rules( $css_rules );
 		$this->assertSame( '.gandalf {color: white; height: 190px; border-style: dotted; padding: 10px; margin-bottom: 100px;}.dumbledore,.rincewind {color: grey; height: 90px; border-style: dotted;}', $compiled_stylesheet );
 	}
 }

--- a/packages/style-engine/phpunit/class-wp-style-engine-test.php
+++ b/packages/style-engine/phpunit/class-wp-style-engine-test.php
@@ -540,14 +540,39 @@ class WP_Style_Engine_Test extends WP_UnitTestCase {
 	 * Tests adding rules to a store and retrieving a generated stylesheet.
 	 */
 	public function test_add_to_store() {
-		$store = wp_style_engine_add_to_store( 'test-store', array() );
-
-		// wp_style_engine_add_to_store returns a store object.
-		$this->assertInstanceOf( 'WP_Style_Engine_CSS_Rules_Store', $store );
+		$css_rules           = array(
+			array(
+				'selector'     => '.frodo',
+				'declarations' => array(
+					'color'        => 'brown',
+					'height'       => '10px',
+					'width'        => '30px',
+					'border-style' => 'dotted',
+				),
+			),
+			array(
+				'selector'     => '.samwise',
+				'declarations' => array(
+					'color'        => 'brown',
+					'height'       => '20px',
+					'width'        => '50px',
+					'border-style' => 'solid',
+				),
+			),
+		);
+		$compiled_stylesheet = wp_style_engine_get_stylesheet(
+			$css_rules,
+			array(
+				'context' => 'test-store',
+				'enqueue' => true,
+			)
+		);
 
 		// Check that the style engine knows about the store.
-		$stored_store = WP_Style_Engine::get_instance()::get_store( 'test-store' );
+		$style_engine = WP_Style_Engine::get_instance();
+		$stored_store = $style_engine::get_store( 'test-store' );
 		$this->assertInstanceOf( 'WP_Style_Engine_CSS_Rules_Store', $stored_store );
+		$this->assertSame( $compiled_stylesheet, $style_engine::compile_stylesheet_from_css_rules( $stored_store->get_all_rules() ) );
 	}
 
 	/**
@@ -584,7 +609,7 @@ class WP_Style_Engine_Test extends WP_UnitTestCase {
 			),
 		);
 
-		$compiled_stylesheet = wp_style_engine_get_stylesheet_from_css_rules( $css_rules );
+		$compiled_stylesheet = wp_style_engine_get_stylesheet( $css_rules );
 		$this->assertSame( '.saruman {color: white; height: 100px; border-style: solid; align-self: unset;}.gandalf {color: grey; height: 90px; border-style: dotted; align-self: safe center;}.radagast {color: brown; height: 60px; border-style: dashed; align-self: stretch;}', $compiled_stylesheet );
 	}
 
@@ -628,7 +653,7 @@ class WP_Style_Engine_Test extends WP_UnitTestCase {
 			),
 		);
 
-		$compiled_stylesheet = wp_style_engine_get_stylesheet_from_css_rules( $css_rules );
+		$compiled_stylesheet = wp_style_engine_get_stylesheet( $css_rules );
 		$this->assertSame( '.gandalf {color: white; height: 190px; border-style: dotted; padding: 10px; margin-bottom: 100px;}.dumbledore,.rincewind {color: grey; height: 90px; border-style: dotted;}', $compiled_stylesheet );
 	}
 }


### PR DESCRIPTION
## What?

A follow up to:
- https://github.com/WordPress/gutenberg/pull/42452

This PR:

1. adds an 'optimize' option to `WP_Style_Engine_Processor->get_css()` which allows for bypassing the selector combination optimizeation
2. merges `wp_style_engine_get_stylesheet_from_css_rules()` and `wp_style_engine_add_to_store()` into `wp_style_engine_get_stylesheet()`

## Why and how?

1. Allows outputting verbose styles in the event of bugs, or just if consumers desire it.
2. Use a single interface to both store and output compiled stylesheets from multiple rules.

## Testing Instructions

For the optimize flag:

```php
npm run test-unit-php
```

For the merged function:

<details>

<summary>Example</summary>

```html
<!-- wp:group {"style":{"color":{"background":"#ee6b6b"}},"layout":{"type":"flex","flexWrap":"nowrap","justifyContent":"space-between","orientation":"vertical"}} -->
<div class="wp-block-group has-background" style="background-color:#ee6b6b"><!-- wp:paragraph -->
<p>Test</p>
<!-- /wp:paragraph -->

<!-- wp:paragraph -->
<p>Test</p>
<!-- /wp:paragraph --></div>
<!-- /wp:group -->

<!-- wp:group {"style":{"color":{"background":"#c4cce6"}},"layout":{"contentSize":"342px"}} -->
<div class="wp-block-group has-background" style="background-color:#c4cce6"><!-- wp:paragraph -->
<p>Test</p>
<!-- /wp:paragraph --></div>
<!-- /wp:group -->
```

</details>

The frontend should appear as expected:

<img width="720" alt="Screen Shot 2022-08-02 at 1 59 31 pm" src="https://user-images.githubusercontent.com/6458278/182288954-baa3aadd-0827-4c45-bded-a3dc1eeb5d4b.png">

The styles should be output correctly:

```html
<style id='layout-block-supports-inline-css'>
.wp-block-navigation.wp-container-3 {justify-content: flex-end;}.wp-block-group.wp-container-7 {flex-wrap: nowrap; align-items: flex-start;}.wp-block-group.wp-container-8 > :where(:not(.alignleft):not(.alignright):not(.alignfull)) {max-width: 342px; margin-left: auto !important; margin-right: auto !important;}.wp-block-group.wp-container-8 > .alignwide {max-width: 342px;}.wp-block-group.wp-container-4,.wp-block-group.wp-container-13 {justify-content: space-between;}.wp-block-group.wp-container-5 > :where(:not(.alignleft):not(.alignright):not(.alignfull)),.wp-block-group.wp-container-6 > :where(:not(.alignleft):not(.alignright):not(.alignfull)),.wp-block-post-content.wp-container-9 > :where(:not(.alignleft):not(.alignright):not(.alignfull)),.wp-block-group.wp-container-11 > :where(:not(.alignleft):not(.alignright):not(.alignfull)),.wp-block-group.wp-container-14 > :where(:not(.alignleft):not(.alignright):not(.alignfull)),.wp-block-group.wp-container-15 > :where(:not(.alignleft):not(.alignright):not(.alignfull)) {max-width: 650px; margin-left: auto !important; margin-right: auto !important;}.wp-block-group.wp-container-5 > .alignwide,.wp-block-group.wp-container-6 > .alignwide,.wp-block-post-content.wp-container-9 > .alignwide,.wp-block-group.wp-container-11 > .alignwide,.wp-block-group.wp-container-14 > .alignwide,.wp-block-group.wp-container-15 > .alignwide {max-width: 1000px;}.wp-block-group.wp-container-5 .alignfull,.wp-block-group.wp-container-6 .alignfull,.wp-block-group.wp-container-8 .alignfull,.wp-block-post-content.wp-container-9 .alignfull,.wp-block-group.wp-container-11 .alignfull,.wp-block-group.wp-container-14 .alignfull,.wp-block-group.wp-container-15 .alignfull {max-width: none;}
</style>
```

[gutenberg_get_layout_style() should return](https://github.com/WordPress/gutenberg/blob/10a99189e9c681b06e43ad8c2828944a5ee01a95/lib/block-supports/layout.php#L209) the compiled CSS for the single block only (and not the cumulated stylesheet)


