### PR TITLE
Style engine: enqueue block supports styles in Gutenberg

### DIFF
--- a/lib/compat/wordpress-6.1/script-loader.php
+++ b/lib/compat/wordpress-6.1/script-loader.php
@@ -41,16 +41,22 @@ function gutenberg_enqueue_block_support_styles( $style, $priority = 10 ) {
 }
 
 /**
- * Fetches, processes and compiles stored block supports styles, then renders them to the page.
+ * Fetches, processes and compiles stored core styles, then combines and renders them to the page.
  * Styles are stored via the style engine API. See: packages/style-engine/README.md
  */
-function gutenberg_enqueue_stored_block_supports_styles() {
-	$styles  = gutenberg_style_engine_get_stylesheet_from_store( 'block-supports' );
-	$styles .= gutenberg_style_engine_get_stylesheet_from_store( 'layout-block-supports' );
+function gutenberg_enqueue_stored_styles() {
+	$core_styles_keys    = array( 'block-supports', 'layout-block-supports' );
+	$compiled_stylesheet = '';
+	foreach ( $core_styles_keys as $style_key ) {
+		$compiled_stylesheet .= gutenberg_style_engine_get_stylesheet_from_store( $style_key );
+	}
+
+	// Combine Core styles.
+	// @TODO check for `defined( 'SCRIPT_DEBUG' ) && SCRIPT_DEBUG` and split them for ease of debugging.
 	if ( ! empty( $styles ) ) {
 		$key = 'block-supports-styles';
 		wp_register_style( $key, false, array(), true, true );
-		wp_add_inline_style( $key, $styles );
+		wp_add_inline_style( $key, $compiled_stylesheet );
 		wp_enqueue_style( $key );
 	}
 }
@@ -128,7 +134,8 @@ remove_action( 'wp_footer', 'wp_enqueue_global_styles' );
 remove_action( 'wp_enqueue_scripts', 'gutenberg_enqueue_global_styles_assets' );
 remove_action( 'wp_footer', 'gutenberg_enqueue_global_styles_assets' );
 
+// Enqueue global styles, and then block supports styles.
 add_action( 'wp_enqueue_scripts', 'gutenberg_enqueue_global_styles' );
 add_action( 'wp_footer', 'gutenberg_enqueue_global_styles', 1 );
-add_action( 'wp_enqueue_scripts', 'gutenberg_enqueue_stored_block_supports_styles' );
-add_action( 'wp_footer', 'gutenberg_enqueue_stored_block_supports_styles', 1 );
+add_action( 'wp_enqueue_scripts', 'gutenberg_enqueue_stored_styles' );
+add_action( 'wp_footer', 'gutenberg_enqueue_stored_styles', 1 );

--- a/lib/compat/wordpress-6.1/script-loader.php
+++ b/lib/compat/wordpress-6.1/script-loader.php
@@ -19,10 +19,14 @@
  *
  * @link https://core.trac.wordpress.org/ticket/53494.
  *
+ * @deprecated 6.1 Block supports styles are now stored for enqueuing via the style engine API. See: packages/style-engine/README.md.
+ *
  * @param string $style String containing the CSS styles to be added.
  * @param int    $priority To set the priority for the add_action.
  */
 function gutenberg_enqueue_block_support_styles( $style, $priority = 10 ) {
+	_deprecated_function( __FUNCTION__, '6.1' );
+
 	$action_hook_name = 'wp_footer';
 	if ( wp_is_block_theme() ) {
 		$action_hook_name = 'wp_head';
@@ -34,6 +38,21 @@ function gutenberg_enqueue_block_support_styles( $style, $priority = 10 ) {
 		},
 		$priority
 	);
+}
+
+/**
+ * Fetches, processes and compiles stored block supports styles, then renders them to the page.
+ * Styles are stored via the style engine API. See: packages/style-engine/README.md
+ */
+function gutenberg_enqueue_stored_block_supports_styles() {
+	$styles  = gutenberg_style_engine_get_stylesheet_from_store( 'block-supports' );
+	$styles .= gutenberg_style_engine_get_stylesheet_from_store( 'layout-block-supports' );
+	if ( ! empty( $styles ) ) {
+		$key = 'block-supports-styles';
+		wp_register_style( $key, false, array(), true, true );
+		wp_add_inline_style( $key, $styles );
+		wp_enqueue_style( $key );
+	}
 }
 
 /**
@@ -111,3 +130,5 @@ remove_action( 'wp_footer', 'gutenberg_enqueue_global_styles_assets' );
 
 add_action( 'wp_enqueue_scripts', 'gutenberg_enqueue_global_styles' );
 add_action( 'wp_footer', 'gutenberg_enqueue_global_styles', 1 );
+add_action( 'wp_enqueue_scripts', 'gutenberg_enqueue_stored_block_supports_styles' );
+add_action( 'wp_footer', 'gutenberg_enqueue_stored_block_supports_styles', 1 );

--- a/lib/compat/wordpress-6.1/script-loader.php
+++ b/lib/compat/wordpress-6.1/script-loader.php
@@ -53,7 +53,7 @@ function gutenberg_enqueue_stored_styles() {
 
 	// Combine Core styles.
 	// @TODO check for `defined( 'SCRIPT_DEBUG' ) && SCRIPT_DEBUG` and split them for ease of debugging.
-	if ( ! empty( $styles ) ) {
+	if ( ! empty( $compiled_stylesheet ) ) {
 		$key = 'block-supports-styles';
 		wp_register_style( $key, false, array(), true, true );
 		wp_add_inline_style( $key, $compiled_stylesheet );

--- a/lib/compat/wordpress-6.1/script-loader.php
+++ b/lib/compat/wordpress-6.1/script-loader.php
@@ -54,7 +54,7 @@ function gutenberg_enqueue_stored_styles() {
 			$compiled_core_stylesheet .= "/**\n * Core styles: $style_key\n */\n";
 		}
 		// Chain core store ids to signify what the styles contain.
-		$style_tag_id             .= $style_tag_id ? '-' . $style_key : $style_key;
+		$style_tag_id             .= '-' . $style_key;
 		$compiled_core_stylesheet .= gutenberg_style_engine_get_stylesheet_from_store( $style_key );
 	}
 

--- a/lib/compat/wordpress-6.1/script-loader.php
+++ b/lib/compat/wordpress-6.1/script-loader.php
@@ -64,6 +64,21 @@ function gutenberg_enqueue_stored_styles() {
 		wp_add_inline_style( $style_tag_id, $compiled_core_stylesheet );
 		wp_enqueue_style( $style_tag_id );
 	}
+
+	// If there are any other stores registered by themes etc, print them out.
+	$additional_stores = WP_Style_Engine_CSS_Rules_Store_Gutenberg::get_stores();
+	foreach ( array_keys( $additional_stores ) as $store_name ) {
+		if ( in_array( $store_name, $core_styles_keys, true ) ) {
+			continue;
+		}
+		$styles = gutenberg_style_engine_get_stylesheet_from_store( $store_name );
+		if ( ! empty( $styles ) ) {
+			$key = "wp-style-engine-$store_name";
+			wp_register_style( $key, false, array(), true, true );
+			wp_add_inline_style( $key, $styles );
+			wp_enqueue_style( $key );
+		}
+	}
 }
 
 /**

--- a/lib/compat/wordpress-6.1/script-loader.php
+++ b/lib/compat/wordpress-6.1/script-loader.php
@@ -19,14 +19,10 @@
  *
  * @link https://core.trac.wordpress.org/ticket/53494.
  *
- * @deprecated 6.1 Block supports styles are now stored for enqueuing via the style engine API. See: packages/style-engine/README.md.
- *
  * @param string $style String containing the CSS styles to be added.
  * @param int    $priority To set the priority for the add_action.
  */
 function gutenberg_enqueue_block_support_styles( $style, $priority = 10 ) {
-	_deprecated_function( __FUNCTION__, '6.1' );
-
 	$action_hook_name = 'wp_footer';
 	if ( wp_is_block_theme() ) {
 		$action_hook_name = 'wp_head';

--- a/lib/compat/wordpress-6.1/script-loader.php
+++ b/lib/compat/wordpress-6.1/script-loader.php
@@ -41,6 +41,20 @@ function gutenberg_enqueue_block_support_styles( $style, $priority = 10 ) {
  * Styles are stored via the style engine API. See: packages/style-engine/README.md
  */
 function gutenberg_enqueue_stored_styles() {
+	$is_block_theme   = wp_is_block_theme();
+	$is_classic_theme = ! $is_block_theme;
+
+	/*
+	 * For block themes, print stored styles in the header.
+	 * For classic themes, in the footer.
+	 */
+	if (
+		( $is_block_theme && doing_action( 'wp_footer' ) ) ||
+		( $is_classic_theme && doing_action( 'wp_enqueue_scripts' ) )
+	) {
+		return;
+	}
+
 	$core_styles_keys         = array( 'block-supports' );
 	$compiled_core_stylesheet = '';
 	$style_tag_id             = 'core';

--- a/lib/compat/wordpress-6.1/script-loader.php
+++ b/lib/compat/wordpress-6.1/script-loader.php
@@ -45,19 +45,24 @@ function gutenberg_enqueue_block_support_styles( $style, $priority = 10 ) {
  * Styles are stored via the style engine API. See: packages/style-engine/README.md
  */
 function gutenberg_enqueue_stored_styles() {
-	$core_styles_keys    = array( 'block-supports', 'layout-block-supports' );
-	$compiled_stylesheet = '';
+	$core_styles_keys         = array( 'block-supports' );
+	$compiled_core_stylesheet = '';
+	$style_tag_id             = 'core';
 	foreach ( $core_styles_keys as $style_key ) {
-		$compiled_stylesheet .= gutenberg_style_engine_get_stylesheet_from_store( $style_key );
+		// Add comment to identify core styles sections in debugging.
+		if ( defined( 'SCRIPT_DEBUG' ) && SCRIPT_DEBUG ) {
+			$compiled_core_stylesheet .= "/**\n * Core styles: $style_key\n */\n";
+		}
+		// Chain core store ids to signify what the styles contain.
+		$style_tag_id             .= $style_tag_id ? '-' . $style_key : $style_key;
+		$compiled_core_stylesheet .= gutenberg_style_engine_get_stylesheet_from_store( $style_key );
 	}
 
 	// Combine Core styles.
-	// @TODO check for `defined( 'SCRIPT_DEBUG' ) && SCRIPT_DEBUG` and split them for ease of debugging.
-	if ( ! empty( $compiled_stylesheet ) ) {
-		$key = 'block-supports-styles';
-		wp_register_style( $key, false, array(), true, true );
-		wp_add_inline_style( $key, $compiled_stylesheet );
-		wp_enqueue_style( $key );
+	if ( ! empty( $compiled_core_stylesheet ) ) {
+		wp_register_style( $style_tag_id, false, array(), true, true );
+		wp_add_inline_style( $style_tag_id, $compiled_core_stylesheet );
+		wp_enqueue_style( $style_tag_id );
 	}
 }
 

--- a/packages/style-engine/README.md
+++ b/packages/style-engine/README.md
@@ -37,7 +37,7 @@ array(
 
 It will return compiled CSS declartions for inline styles, or, where a selector is provided, a complete CSS rule.
 
-To enqueue a style for rendering in the frontend, the `$options` array requires the following:
+To enqueue a style for rendering in the site's frontend, the `$options` array requires the following:
 
 1.  **selector (string)** - this is the CSS selector for your block style CSS declarations.
 2.  **context (string)** - this tells the style engine where to store the styles. Styles in the same context will be

--- a/packages/style-engine/README.md
+++ b/packages/style-engine/README.md
@@ -6,7 +6,7 @@ The Style Engine powering global styles and block customizations.
 
 ### wp_style_engine_get_styles()
 
-Global public interface method to generate styles from a single style object, e.g., the value of
+Global public function to generate styles from a single style object, e.g., the value of
 a [block's attributes.style object](https://developer.wordpress.org/block-editor/reference-guides/theme-json-reference/theme-json-living/#styles)
 or
 the [top level styles in theme.json](https://developer.wordpress.org/block-editor/reference-guides/block-api/block-supports/)
@@ -18,7 +18,7 @@ _Parameters_
 -   _$options_ `array<string|boolean>` An array of options to determine the output.
     -   _context_ `string` An identifier describing the origin of the style object, e.g., 'block-supports' or '
         global-styles'. Default is 'block-supports'.
-    -   _enqueue_ `boolean` When `true` will attempt to store and enqueue for rendering on the frontend.
+    -   _enqueue_ `boolean` When `true` will attempt to store and enqueue for rendering in a `style` tag on the site frontend.
     -   _convert_vars_to_classnames_ `boolean` Whether to skip converting CSS var:? values to var( --wp--preset--\* )
         values. Default is `false`.
     -   _selector_ `string` When a selector is passed, `generate()` will return a full CSS rule `$selector { ...rules }`,

--- a/packages/style-engine/README.md
+++ b/packages/style-engine/README.md
@@ -5,19 +5,27 @@ The Style Engine powering global styles and block customizations.
 ## Backend API
 
 ### wp_style_engine_get_styles()
-Global public interface method to generate styles from a single style object, e.g., the value of a [block's attributes.style object](https://developer.wordpress.org/block-editor/reference-guides/theme-json-reference/theme-json-living/#styles) or the [top level styles in theme.json](https://developer.wordpress.org/block-editor/reference-guides/block-api/block-supports/).
+
+Global public interface method to generate styles from a single style object, e.g., the value of
+a [block's attributes.style object](https://developer.wordpress.org/block-editor/reference-guides/theme-json-reference/theme-json-living/#styles)
+or
+the [top level styles in theme.json](https://developer.wordpress.org/block-editor/reference-guides/block-api/block-supports/)
+.
 
 _Parameters_
-- _$block_styles_ `array` A block's `attributes.style` object or the top level styles in theme.json
-- _$options_ `array<string|boolean>` An array of options to determine the output.
-  - _context_ `string` An identifier describing the origin of the style object, e.g., 'block-supports' or 'global-styles'. Default is 'block-supports'.
-  - _enqueue_ `boolean` When `true` will attempt to store and enqueue for rendering on the frontend.
-  - _convert_vars_to_classnames_ `boolean`  Whether to skip converting CSS var:? values to var( --wp--preset--* ) values. Default is `false`.
-  - _selector_ `string` When a selector is passed, `generate()` will return a full CSS rule `$selector { ...rules }`, otherwise a concatenated string of properties and values.
+
+-   _$block_styles_ `array` A block's `attributes.style` object or the top level styles in theme.json
+-   _$options_ `array<string|boolean>` An array of options to determine the output.
+    -   _context_ `string` An identifier describing the origin of the style object, e.g., 'block-supports' or '
+        global-styles'. Default is 'block-supports'.
+    -   _enqueue_ `boolean` When `true` will attempt to store and enqueue for rendering on the frontend.
+    -   _convert_vars_to_classnames_ `boolean` Whether to skip converting CSS var:? values to var( --wp--preset--\* )
+        values. Default is `false`.
+    -   _selector_ `string` When a selector is passed, `generate()` will return a full CSS rule `$selector { ...rules }`,
+        otherwise a concatenated string of properties and values.
 
 _Returns_
 `array<string|array>|null`
-
 
 ```php
 array(
@@ -31,9 +39,10 @@ It will return compiled CSS declartions for inline styles, or, where a selector 
 
 To enqueue a style for rendering in the frontend, the `$options` array requires the following:
 
-1. **selector (string)** - this is the CSS selector for your block style CSS declarations.
-2. **context (string)** - this tells the style engine where to store the styles. Styles in the same context will be batched together and printed in the same HTML style tag. The default is `'block-supports'`.
-3. **enqueue (boolean)** - tells the style engine to enqueue the styles and print them in the frontend.
+1.  **selector (string)** - this is the CSS selector for your block style CSS declarations.
+2.  **context (string)** - this tells the style engine where to store the styles. Styles in the same context will be
+    batched together and printed in the same HTML style tag. The default is `'block-supports'`.
+3.  **enqueue (boolean)** - tells the style engine to enqueue the styles and print them in the frontend.
 
 `wp_style_engine_get_styles` will return the compiled CSS and CSS declarations array.
 
@@ -68,8 +77,9 @@ Global public interface method to register styles to be enqueued and rendered.
 Use this function to enqueue any CSS rules. It will automatically merge declarations and combine selectors.
 
 _Parameters_
-- _$store_key_ `string` A valid store key.
-- _$css_rules_ `array<array>` 
+
+-   _$store_key_ `string` A valid store key.
+-   _$css_rules_ `array<array>`
 
 _Returns_
 `WP_Style_Engine_CSS_Rules_Store` A store.
@@ -100,24 +110,34 @@ wp_style_engine_add_to_store( 'layout-block-supports', $styles );
 ```
 
 The resulting stylesheet will be:
+
 ```html
-<style id='layout-block-supports-inline-css'>
-.wp-pumpkin, .wp-kumquat {color:orange}.wp-tomato{color:red;padding:100px}
+<style id="layout-block-supports-inline-css">
+	.wp-pumpkin,
+	.wp-kumquat {
+		color: orange;
+	}
+
+	.wp-tomato {
+		color: red;
+		padding: 100px;
+	}
 </style>
 ```
 
 ### wp_style_engine_get_stylesheet_from_css_rules()
 
-Use this function to compile and return a stylesheet for any CSS rules. This function does not enqueue styles, but rather acts as a CSS compiler.
+Use this function to compile and return a stylesheet for any CSS rules. This function does not enqueue styles, but
+rather acts as a CSS compiler.
 
 _Parameters_
-- _$css_rules_ `array<array>` 
+
+-   _$css_rules_ `array<array>`
 
 _Returns_
 `string` A compiled CSS string.
 
 #### Usage
-
 
 ```php
 $styles = array(
@@ -151,13 +171,18 @@ Install the module
 npm install @wordpress/style-engine --save
 ```
 
-_This package assumes that your code will run in an **ES2015+** environment. If you're using an environment that has limited or no support for such language features and APIs, you should include [the polyfill shipped in `@wordpress/babel-preset-default`](https://github.com/WordPress/gutenberg/tree/HEAD/packages/babel-preset-default#polyfill) in your code._
+_This package assumes that your code will run in an **ES2015+** environment. If you're using an environment that has
+limited or no support for such language features and APIs, you should
+include [the polyfill shipped in `@wordpress/babel-preset-default`](https://github.com/WordPress/gutenberg/tree/HEAD/packages/babel-preset-default#polyfill)
+in your code._
 
 ## Important
 
-This Package is considered experimental at the moment. The idea is to have a package used to generate styles based on a style object that is consistent between: backend, frontend, block style object and theme.json.
+This Package is considered experimental at the moment. The idea is to have a package used to generate styles based on a
+style object that is consistent between: backend, frontend, block style object and theme.json.
 
-Because this package is experimental and still in development it does not yet generate a `wp.styleEngine` global. To get there, the following tasks need to be completed:
+Because this package is experimental and still in development it does not yet generate a `wp.styleEngine` global. To get
+there, the following tasks need to be completed:
 
 **TODO List:**
 
@@ -167,7 +192,8 @@ Because this package is experimental and still in development it does not yet ge
 -   Support generating styles in the backend (block supports and theme.json stylesheet). (Ongoing)
 -   Refactor all block styles to use the style engine server side. (Ongoing)
 -   Consolidate global and block style rendering and enqueuing
--   Refactor all blocks to consistently use the "style" attribute for all customizations (get rid of the preset specific attributes).
+-   Refactor all blocks to consistently use the "style" attribute for all customizations (get rid of the preset specific
+    attributes).
 
 See [Tracking: Add a Style Engine to manage rendering block styles #38167](https://github.com/WordPress/gutenberg/issues/38167)
 

--- a/packages/style-engine/README.md
+++ b/packages/style-engine/README.md
@@ -35,7 +35,7 @@ array(
 );
 ```
 
-It will return compiled CSS declartions for inline styles, or, where a selector is provided, a complete CSS rule.
+It will return compiled CSS declarations for inline styles, or, where a selector is provided, a complete CSS rule.
 
 To enqueue a style for rendering in the site's frontend, the `$options` array requires the following:
 

--- a/packages/style-engine/class-wp-style-engine-processor.php
+++ b/packages/style-engine/class-wp-style-engine-processor.php
@@ -128,7 +128,8 @@ class WP_Style_Engine_Processor {
 				unset( $this->css_rules[ $key ] );
 			}
 			// Create a new rule with the combined selectors.
-			$this->css_rules[ implode( ',', $duplicates ) ] = new WP_Style_Engine_CSS_Rule( implode( ',', $duplicates ), $declarations );
+			$duplicate_selectors                     = implode( ',', $duplicates );
+			$this->css_rules[ $duplicate_selectors ] = new WP_Style_Engine_CSS_Rule( $duplicate_selectors, $declarations );
 		}
 	}
 }

--- a/packages/style-engine/class-wp-style-engine.php
+++ b/packages/style-engine/class-wp-style-engine.php
@@ -24,13 +24,6 @@ if ( class_exists( 'WP_Style_Engine' ) ) {
  */
 class WP_Style_Engine {
 	/**
-	 * Container for the main instance of the class.
-	 *
-	 * @var WP_Style_Engine|null
-	 */
-	private static $instance = null;
-
-	/**
 	 * Style definitions that contain the instructions to
 	 * parse/output valid Gutenberg styles from a block's attributes.
 	 * For every style definition, the follow properties are valid:

--- a/packages/style-engine/class-wp-style-engine.php
+++ b/packages/style-engine/class-wp-style-engine.php
@@ -281,10 +281,7 @@ class WP_Style_Engine {
 	/**
 	 * Private constructor to prevent instantiation.
 	 */
-	private function __construct() {
-		// Register the hook callback to render stored styles to the page.
-		static::register_actions( array( __CLASS__, 'process_and_enqueue_stored_styles' ) );
-	}
+	private function __construct() {}
 
 	/**
 	 * Utility method to retrieve the main instance of the class.
@@ -326,58 +323,6 @@ class WP_Style_Engine {
 	 */
 	public static function get_store( $store_key ) {
 		return WP_Style_Engine_CSS_Rules_Store::get_store( $store_key );
-	}
-
-	/**
-	 * Taken from gutenberg_enqueue_block_support_styles()
-	 *
-	 * This function takes care of registering hooks to add inline styles
-	 * in the proper place, depending on the theme in use.
-	 *
-	 * For block themes, it's loaded in the head.
-	 * For classic ones, it's loaded in the body
-	 * because the wp_head action  happens before
-	 * the render_block.
-	 *
-	 * @param callable $callable A user-defined callback function for a WordPress hook.
-	 * @param int      $priority To set the priority for the add_action.
-	 *
-	 * @see gutenberg_enqueue_block_support_styles()
-	 */
-	protected static function register_actions( $callable, $priority = 10 ) {
-		if ( ! $callable ) {
-			return;
-		}
-		add_action( 'wp_enqueue_scripts', $callable );
-		add_action(
-			wp_is_block_theme() ? 'wp_head' : 'wp_footer',
-			$callable,
-			$priority
-		);
-	}
-
-	/**
-	 * Fetches, processes and compiles stored styles, then renders them to the page.
-	 */
-	public static function process_and_enqueue_stored_styles() {
-		$stores = WP_Style_Engine_CSS_Rules_Store::get_stores();
-
-		foreach ( $stores as $key => $store ) {
-			$processor = new WP_Style_Engine_Processor();
-			$processor->add_store( $store );
-			$styles = $processor->get_css(
-				array(
-					'optimize' => false,
-					'prettify' => defined( 'SCRIPT_DEBUG' ) && SCRIPT_DEBUG,
-				)
-			);
-
-			if ( ! empty( $styles ) ) {
-				wp_register_style( $key, false, array(), true, true );
-				wp_add_inline_style( $key, $styles );
-				wp_enqueue_style( $key );
-			}
-		}
 	}
 
 	/**
@@ -610,15 +555,15 @@ class WP_Style_Engine {
  *
  * @access public
  *
- * @param array         $block_styles The style object.
- * @param array<string> $options      array(
+ * @param array                 $block_styles The style object.
+ * @param array<string|boolean> $options      array(
  *     'context'                    => (string) An identifier describing the origin of the style object, e.g., 'block-supports' or 'global-styles'. Default is 'block-supports'.
  *     'enqueue'                    => (boolean) When `true` will attempt to store and enqueue for rendering on the frontend.
  *     'convert_vars_to_classnames' => (boolean) Whether to skip converting CSS var:? values to var( --wp--preset--* ) values. Default is `false`.
  *     'selector'                   => (string) When a selector is passed, `generate()` will return a full CSS rule `$selector { ...rules }`, otherwise a concatenated string of properties and values.
  * );.
  *
- * @return array<string>|null array(
+ * @return array<string|array>|null array(
  *     'css'           => (string) A CSS ruleset or declarations block formatted to be placed in an HTML `style` attribute or tag.
  *     'declarations'  => (array) An array of property/value pairs representing parsed CSS declarations.
  *     'classnames'    => (string) Classnames separated by a space.
@@ -628,19 +573,19 @@ function wp_style_engine_get_styles( $block_styles, $options = array() ) {
 	if ( ! class_exists( 'WP_Style_Engine' ) ) {
 		return array();
 	}
-	$defaults      = array(
+	$defaults = array(
 		'selector'                   => null,
 		'context'                    => 'block-supports',
 		'convert_vars_to_classnames' => false,
 		'enqueue'                    => false,
 	);
+
 	$options       = wp_parse_args( $options, $defaults );
-	$style_engine  = WP_Style_Engine::get_instance();
 	$parsed_styles = null;
 
 	// Block supports styles.
 	if ( 'block-supports' === $options['context'] ) {
-		$parsed_styles = $style_engine::parse_block_styles( $block_styles, $options );
+		$parsed_styles = WP_Style_Engine::parse_block_styles( $block_styles, $options );
 	}
 
 	// Output.
@@ -651,10 +596,10 @@ function wp_style_engine_get_styles( $block_styles, $options = array() ) {
 	}
 
 	if ( ! empty( $parsed_styles['declarations'] ) ) {
-		$styles_output['css']          = $style_engine::compile_css( $parsed_styles['declarations'], $options['selector'] );
+		$styles_output['css']          = WP_Style_Engine::compile_css( $parsed_styles['declarations'], $options['selector'] );
 		$styles_output['declarations'] = $parsed_styles['declarations'];
 		if ( true === $options['enqueue'] ) {
-			$style_engine::store_css_rule( $options['context'], $options['selector'], $parsed_styles['declarations'] );
+			WP_Style_Engine::store_css_rule( $options['context'], $options['selector'], $parsed_styles['declarations'] );
 		}
 	}
 
@@ -694,7 +639,6 @@ function wp_style_engine_get_stylesheet_from_css_rules( $css_rules, $options = a
 		'enqueue' => false,
 	);
 	$options          = wp_parse_args( $options, $defaults );
-	$style_engine     = WP_Style_Engine::get_instance();
 	$css_rule_objects = array();
 
 	foreach ( $css_rules as $css_rule ) {
@@ -703,7 +647,7 @@ function wp_style_engine_get_stylesheet_from_css_rules( $css_rules, $options = a
 		}
 
 		if ( true === $options['enqueue'] ) {
-			$style_engine::store_css_rule( $options['context'], $css_rule['selector'], $css_rule['declarations'] );
+			WP_Style_Engine::store_css_rule( $options['context'], $css_rule['selector'], $css_rule['declarations'] );
 		}
 
 		$css_rule_objects[] = new WP_Style_Engine_CSS_Rule( $css_rule['selector'], $css_rule['declarations'] );
@@ -713,5 +657,24 @@ function wp_style_engine_get_stylesheet_from_css_rules( $css_rules, $options = a
 		return '';
 	}
 
-	return $style_engine::compile_stylesheet_from_css_rules( $css_rule_objects );
+	return WP_Style_Engine::compile_stylesheet_from_css_rules( $css_rule_objects );
+}
+
+/**
+ * Returns compiled CSS from a store, if found.
+ *
+ * @access public
+ *
+ * @param string $store_key A valid store key.
+ *
+ * @return string A compiled CSS string.
+ */
+function wp_style_engine_get_stylesheet_from_store( $store_key ) {
+	if ( ! class_exists( 'WP_Style_Engine' ) || empty( $store_key ) ) {
+		return '';
+	}
+
+	$store = WP_Style_Engine::get_store( $store_key );
+
+	return WP_Style_Engine::compile_stylesheet_from_css_rules( $store->get_all_rules() );
 }

--- a/packages/style-engine/class-wp-style-engine.php
+++ b/packages/style-engine/class-wp-style-engine.php
@@ -279,26 +279,6 @@ class WP_Style_Engine {
 	}
 
 	/**
-	 * Private constructor to prevent instantiation.
-	 */
-	private function __construct() {}
-
-	/**
-	 * Utility method to retrieve the main instance of the class.
-	 *
-	 * The instance will be created if it does not exist yet.
-	 *
-	 * @return WP_Style_Engine The main instance.
-	 */
-	public static function get_instance() {
-		if ( null === static::$instance ) {
-			static::$instance = new static();
-		}
-
-		return static::$instance;
-	}
-
-	/**
 	 * Stores a CSS rule using the provide CSS selector and CSS declarations.
 	 *
 	 * @param string $store_key        A valid store key.

--- a/packages/style-engine/class-wp-style-engine.php
+++ b/packages/style-engine/class-wp-style-engine.php
@@ -538,9 +538,9 @@ class WP_Style_Engine {
  * );.
  *
  * @return array<string|array>|null array(
- *     'css'           => (string) A CSS ruleset or declarations block formatted to be placed in an HTML `style` attribute or tag.
- *     'declarations'  => (array) An array of property/value pairs representing parsed CSS declarations.
- *     'classnames'    => (string) Classnames separated by a space.
+ *     'css'          => (string) A CSS ruleset or declarations block formatted to be placed in an HTML `style` attribute or tag.
+ *     'declarations' => (array) An array of property/value pairs representing parsed CSS declarations.
+ *     'classnames'   => (string) Classnames separated by a space.
  * );
  */
 function wp_style_engine_get_styles( $block_styles, $options = array() ) {
@@ -592,13 +592,13 @@ function wp_style_engine_get_styles( $block_styles, $options = array() ) {
  *
  * @param array<array>  $css_rules array(
  *      array(
- *          'selector'         => (string) A CSS selector.
+ *          'selector'    => (string) A CSS selector.
  *          declarations' => (boolean) An array of CSS definitions, e.g., array( "$property" => "$value" ).
  *      )
  *  );.
  * @param array<string> $options array(
- *     'context'                    => (string) An identifier describing the origin of the style object, e.g., 'block-supports' or 'global-styles'. Default is 'block-supports'.
- *     'enqueue'                    => (boolean) When `true` will attempt to store and enqueue for rendering on the frontend.
+ *     'context' => (string) An identifier describing the origin of the style object, e.g., 'block-supports' or 'global-styles'. Default is 'block-supports'.
+ *     'enqueue' => (boolean) When `true` will attempt to store and enqueue for rendering on the frontend.
  * );.
  *
  * @return string A compiled CSS string.

--- a/packages/style-engine/class-wp-style-engine.php
+++ b/packages/style-engine/class-wp-style-engine.php
@@ -498,6 +498,7 @@ class WP_Style_Engine {
 			return $css_rule->get_css();
 		}
 		$css_declarations = new WP_Style_Engine_CSS_Declarations( $css_declarations );
+
 		return $css_declarations->get_declarations_string();
 	}
 
@@ -511,7 +512,7 @@ class WP_Style_Engine {
 	public static function compile_stylesheet_from_css_rules( $css_rules ) {
 		$processor = new WP_Style_Engine_Processor();
 		$processor->add_rules( $css_rules );
-		return $processor->get_css();
+		return $processor->get_css( array( 'prettify' => defined( 'SCRIPT_DEBUG' ) && SCRIPT_DEBUG ) );
 	}
 }
 

--- a/packages/style-engine/phpunit/class-wp-style-engine-test.php
+++ b/packages/style-engine/phpunit/class-wp-style-engine-test.php
@@ -531,7 +531,7 @@ class WP_Style_Engine_Test extends WP_UnitTestCase {
 				'selector' => 'article',
 			)
 		);
-		$store            = WP_Style_Engine::get_instance()::get_store( 'block-supports' );
+		$store            = WP_Style_Engine::get_store( 'block-supports' );
 		$rule             = $store->get_all_rules()['article'];
 		$this->assertSame( $generated_styles['css'], $rule->get_css() );
 	}
@@ -569,10 +569,9 @@ class WP_Style_Engine_Test extends WP_UnitTestCase {
 		);
 
 		// Check that the style engine knows about the store.
-		$style_engine = WP_Style_Engine::get_instance();
-		$stored_store = $style_engine::get_store( 'test-store' );
+		$stored_store = WP_Style_Engine::get_store( 'test-store' );
 		$this->assertInstanceOf( 'WP_Style_Engine_CSS_Rules_Store', $stored_store );
-		$this->assertSame( $compiled_stylesheet, $style_engine::compile_stylesheet_from_css_rules( $stored_store->get_all_rules() ) );
+		$this->assertSame( $compiled_stylesheet, WP_Style_Engine::compile_stylesheet_from_css_rules( $stored_store->get_all_rules() ) );
 	}
 
 	/**

--- a/phpunit/script-loader.php
+++ b/phpunit/script-loader.php
@@ -1,0 +1,71 @@
+<?php
+/**
+ * Tests script and style loading.
+ *
+ * @package Gutenberg
+ */
+
+class WP_Script_Loader_Test extends WP_UnitTestCase {
+	/**
+	 * Clean up global scope.
+	 *
+	 * @global WP_Scripts $wp_scripts
+	 * @global WP_Styles $wp_styles
+	 */
+	public function clean_up_global_scope() {
+		global $wp_styles;
+		parent::clean_up_global_scope();
+		$wp_styles = null;
+	}
+	/**
+	 * Tests that stored CSS is enqueued.
+	 */
+	public function test_enqueue_stored_styles() {
+		global $wp_styles;
+
+		$core_styles_to_enqueue = array(
+			array(
+				'selector'     => '.saruman',
+				'declarations' => array(
+					'color'        => 'white',
+					'height'       => '100px',
+					'border-style' => 'solid',
+				),
+			),
+		);
+
+		// Enqueue a block supports (core styles).
+		gutenberg_style_engine_get_stylesheet_from_css_rules(
+			$core_styles_to_enqueue,
+			array(
+				'context' => 'block-supports',
+				'enqueue' => true,
+			)
+		);
+
+		$my_styles_to_enqueue = array(
+			array(
+				'selector'     => '.gandalf',
+				'declarations' => array(
+					'color'        => 'grey',
+					'height'       => '90px',
+					'border-style' => 'dotted',
+				),
+			),
+		);
+
+		// Enqueue some other styles.
+		gutenberg_style_engine_get_stylesheet_from_css_rules(
+			$my_styles_to_enqueue,
+			array(
+				'context' => 'my-styles',
+				'enqueue' => true,
+			)
+		);
+
+		gutenberg_enqueue_stored_styles();
+
+		$this->assertEquals( array( '.saruman{color:white;height:100px;border-style:solid;}' ), $wp_styles->get_data( 'core-block-supports', 'after' ) );
+		$this->assertEquals( array( '.gandalf{color:grey;height:90px;border-style:dotted;}' ), $wp_styles->get_data( 'wp-style-engine-my-styles', 'after' ) );
+	}
+}


### PR DESCRIPTION
## What?

A follow up to:
- https://github.com/WordPress/gutenberg/pull/42452

## What?
Let's enqueue stored block supports styles in Gutenberg, rather than in the style engine.

At the same time, we'll combine block style and layout styles into one style tag.

## Why?
This PR follows up on a [discussion](https://github.com/WordPress/gutenberg/pull/42452#discussion_r934132780) in #42452, the substance of which is that it's probably better to give the consumer control over how styles are rendered via hooks / enqueues etc

## How?
Adding a new function in `script-loader.php` - `gutenberg_enqueue_stored_block_supports_styles()` (name to be debated) that grabs block supports styles from the style engine store and enqueues the stylesheet.

## Testing Instructions

Test in both classic and block themes.

Check that elements and layouts styles are enqueued. 

Create a new post and insert some text links and group blocks (or any layout styles) 

Here's some test HTML:

<details>

<summary>Example</summary>

```html
<!-- wp:group {"style":{"color":{"background":"#ee6b6b"},"elements":{"link":{"color":{"text":"var:preset|color|vivid-cyan-blue"}}}},"layout":{"type":"flex","flexWrap":"nowrap","justifyContent":"space-between","orientation":"vertical"}} -->
<div class="wp-block-group has-background has-link-color" style="background-color:#ee6b6b"><!-- wp:paragraph {"style":{"elements":{"link":{"color":{"text":"var:preset|color|white"}}}}} -->
<p class="has-link-color"><a href="https://word">Test</a></p>
<!-- /wp:paragraph -->

<!-- wp:paragraph {"style":{"elements":{"link":{"color":{"text":"#eaf1f6"}}}}} -->
<p class="has-link-color"><a href="https://word">Test</a></p>
<!-- /wp:paragraph --></div>
<!-- /wp:group -->

<!-- wp:group {"style":{"color":{"background":"#c4cce6"}},"layout":{"contentSize":"342px"}} -->
<div class="wp-block-group has-background" style="background-color:#c4cce6"><!-- wp:paragraph {"style":{"elements":{"link":{"color":{"text":"var:preset|color|vivid-red"}}}}} -->
<p class="has-link-color"><a href="https://word">Test</a></p>
<!-- /wp:paragraph --></div>
<!-- /wp:group -->

<!-- wp:group {"style":{"color":{"background":"#9eebbc"}},"layout":{"contentSize":"342px"}} -->
<div class="wp-block-group has-background" style="background-color:#9eebbc"><!-- wp:paragraph {"style":{"elements":{"link":{"color":{"text":"#cd31d6"}}}}} -->
<p class="has-link-color"><a href="https://word">Test</a></p>
<!-- /wp:paragraph --></div>
<!-- /wp:group -->
```


</details>

<img width="902" alt="Screen Shot 2022-08-02 at 3 42 30 pm" src="https://user-images.githubusercontent.com/6458278/182300370-058392c3-8adf-4f51-abee-3d62b438845b.png">

Expected CSS output. For classic themes this style tag should appear at the bottom of the page. For block themes, in the head.

```html
<style id='block-supports-styles-inline-css'>
.wp-elements-bfe89bcbd3fbf76f9bf93ac884528d9a a {color: var(--wp--preset--color--vivid-cyan-blue);}.wp-elements-85694c8ee6aa1fb95efca209b615f0b0 a {color: var(--wp--preset--color--white);}.wp-elements-6ac1c4acebd6a433ed64dc4e6b0eb185 a {color: #eaf1f6;}.wp-elements-469734e762a60395c96370480f3c9414 a {color: var(--wp--preset--color--vivid-red);}.wp-elements-9307c4f13980ac2b051b4fcf5f7b28fa a {color: #cd31d6;}.wp-block-group.wp-container-1 {flex-wrap: nowrap; align-items: flex-start;}.wp-block-post-content.wp-container-4 > :where(:not(.alignleft):not(.alignright):not(.alignfull)) {max-width: 840px; margin-left: auto !important; margin-right: auto !important;}.wp-block-post-content.wp-container-4 > .alignwide {max-width: 1100px;}.wp-block-group.wp-container-2 > :where(:not(.alignleft):not(.alignright):not(.alignfull)),.wp-block-group.wp-container-3 > :where(:not(.alignleft):not(.alignright):not(.alignfull)) {max-width: 342px; margin-left: auto !important; margin-right: auto !important;}.wp-block-group.wp-container-2 > .alignwide,.wp-block-group.wp-container-3 > .alignwide {max-width: 342px;}.wp-block-group.wp-container-2 .alignfull,.wp-block-group.wp-container-3 .alignfull,.wp-block-post-content.wp-container-4 .alignfull {max-width: none;}
</style>
```