### PR TITLE
Layout: Try adding centralised attribute-based styles defined via classnames

### DIFF
--- a/lib/compat/wordpress-6.1/theme.json
+++ b/lib/compat/wordpress-6.1/theme.json
@@ -261,7 +261,90 @@
 								"gap": null
 							}
 						}
-					]
+					],
+					"attributeStyles": {
+						"flexWrap": [
+							{
+								"className": "is-$slug",
+								"selector": ".is-$slug",
+								"validValues": [ "nowrap", "wrap" ],
+								"property": "flex-wrap",
+								"values": {
+									"nowrap": "nowrap",
+									"wrap": "wrap"
+								}
+							}
+						],
+						"orientation": [
+							{
+								"className": "is-$slug",
+								"selector": ".is-$slug",
+								"validValues": [ "vertical" ],
+								"property": "flex-direction",
+								"values": {
+									"vertical": "column"
+								},
+								"rules": {
+									"align-items": "flex-start"
+								}
+							}
+						],
+						"justifyContent": [
+							{
+								"className": "is-content-justification-$slug",
+								"selector": ".is-content-justification-$slug",
+								"dependsOn": {
+									"orientation": [ "horizontal", null ]
+								},
+								"property": "justify-content",
+								"validValues": [
+									"left",
+									"right",
+									"center",
+									"space-between"
+								],
+								"values": {
+									"left": "flex-start",
+									"right": "flex-end",
+									"center": "center"
+								}
+							},
+							{
+								"className": "is-content-justification-$slug",
+								"selector": ".is-vertical.is-content-justification-$slug",
+								"dependsOn": {
+									"orientation": [ "vertical" ]
+								},
+								"property": "justify-content",
+								"validValues": [
+									"left",
+									"right",
+									"center",
+									"space-between"
+								],
+								"values": {
+									"left": "flex-start",
+									"right": "flex-end",
+									"center": "center"
+								}
+							}
+						],
+						"verticalAlignment": [
+							{
+								"className": "is-vertical-alignment-$slug",
+								"selector": ".is-vertical-alignment-$slug",
+								"dependsOn": {
+									"orientation": [ "horizontal", null ]
+								},
+								"property": "align-items",
+								"values": {
+									"top": "flex-start",
+									"center": "center",
+									"bottom": "flex-end"
+								}
+							}
+						]
+					}
 				}
 			}
 		},

--- a/lib/compat/wordpress-6.1/theme.json
+++ b/lib/compat/wordpress-6.1/theme.json
@@ -306,7 +306,8 @@
 								"values": {
 									"left": "flex-start",
 									"right": "flex-end",
-									"center": "center"
+									"center": "center",
+									"space-between": "space-between"
 								}
 							},
 							{
@@ -316,12 +317,7 @@
 									"orientation": [ "vertical" ]
 								},
 								"property": "justify-content",
-								"validValues": [
-									"left",
-									"right",
-									"center",
-									"space-between"
-								],
+								"validValues": [ "left", "right", "center" ],
 								"values": {
 									"left": "flex-start",
 									"right": "flex-end",


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

🚧 🚧 🚧 🚧 WIP: This is an exploration for now and is likely to change quite a bit 🚧 🚧 🚧 🚧 

Following on from https://github.com/WordPress/gutenberg/pull/40875 and as part of #39336, this PR looks at seeing if we can define those Layout attributes that are of a controlled set (e.g. content justification) in the `theme.json` layout definitions, and then output those definitions as preset-like rules.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

Continue the de-duplication of style output generated by the Layout block support, and make it easier to add / define additional layout properties in the future.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

TBC

## To-do

* [ ] Add all attributes to the centralised layout definitions
* [ ] Generate classnames in `layout.php` based on these definitions
* [ ] Generate CSS rules in the Theme JSON class based on these definitions

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->

TBC

## Screenshots or screencast <!-- if applicable -->
