### PR TITLE
Writing flow: fix Shift+Arrow partial selection for lists & quote

### DIFF
--- a/packages/block-editor/src/components/writing-flow/use-arrow-nav.js
+++ b/packages/block-editor/src/components/writing-flow/use-arrow-nav.js
@@ -17,6 +17,7 @@ import { useRefEffect } from '@wordpress/compose';
 /**
  * Internal dependencies
  */
+import { getBlockClientId } from '../../utils/dom';
 import { store as blockEditorStore } from '../../store';
 
 /**
@@ -146,6 +147,15 @@ export default function useArrowNav() {
 			verticalRect = null;
 		}
 
+		function isClosestTabbableABlock( target, isReverse ) {
+			const closestTabbable = getClosestTabbable(
+				target,
+				isReverse,
+				node
+			);
+			return closestTabbable && getBlockClientId( closestTabbable );
+		}
+
 		function onKeyDown( event ) {
 			const { keyCode, target } = event;
 			const isUp = keyCode === UP;
@@ -230,7 +240,10 @@ export default function useArrowNav() {
 			const { keepCaretInsideBlock } = getSettings();
 
 			if ( isShift ) {
-				if ( isNavEdge( target, isReverse ) ) {
+				if (
+					isClosestTabbableABlock( target, isReverse ) &&
+					isNavEdge( target, isReverse )
+				) {
 					node.contentEditable = true;
 					// Firefox doesn't automatically move focus.
 					node.focus();

--- a/packages/block-editor/src/components/writing-flow/use-arrow-nav.js
+++ b/packages/block-editor/src/components/writing-flow/use-arrow-nav.js
@@ -17,7 +17,6 @@ import { useRefEffect } from '@wordpress/compose';
 /**
  * Internal dependencies
  */
-import { isInSameBlock } from '../../utils/dom';
 import { store as blockEditorStore } from '../../store';
 
 /**
@@ -130,11 +129,8 @@ export function getClosestTabbable(
 
 export default function useArrowNav() {
 	const {
-		getSelectedBlockClientId,
 		getMultiSelectedBlocksStartClientId,
 		getMultiSelectedBlocksEndClientId,
-		getPreviousBlockClientId,
-		getNextBlockClientId,
 		getSettings,
 		hasMultiSelection,
 		__unstableIsFullySelected,
@@ -148,28 +144,6 @@ export default function useArrowNav() {
 
 		function onMouseDown() {
 			verticalRect = null;
-		}
-
-		/**
-		 * Returns true if the given target field is the last in its block which
-		 * can be considered for tab transition. For example, in a block with
-		 * two text fields, this would return true when reversing from the first
-		 * of the two fields, but false when reversing from the second.
-		 *
-		 * @param {Element} target    Currently focused text field.
-		 * @param {boolean} isReverse True if considering as the first field.
-		 *
-		 * @return {boolean} Whether field is at edge for tab transition.
-		 */
-		function isTabbableEdge( target, isReverse ) {
-			const closestTabbable = getClosestTabbable(
-				target,
-				isReverse,
-				node
-			);
-			return (
-				! closestTabbable || ! isInSameBlock( target, closestTabbable )
-			);
 		}
 
 		function onKeyDown( event ) {
@@ -254,25 +228,9 @@ export default function useArrowNav() {
 			// next, which is the exact reverse of LTR.
 			const isReverseDir = isRTL( target ) ? ! isReverse : isReverse;
 			const { keepCaretInsideBlock } = getSettings();
-			const selectedBlockClientId = getSelectedBlockClientId();
 
 			if ( isShift ) {
-				const selectionEndClientId =
-					getMultiSelectedBlocksEndClientId();
-				const selectionBeforeEndClientId = getPreviousBlockClientId(
-					selectionEndClientId || selectedBlockClientId
-				);
-				const selectionAfterEndClientId = getNextBlockClientId(
-					selectionEndClientId || selectedBlockClientId
-				);
-
-				if (
-					// Ensure that there is a target block.
-					( ( isReverse && selectionBeforeEndClientId ) ||
-						( ! isReverse && selectionAfterEndClientId ) ) &&
-					isTabbableEdge( target, isReverse ) &&
-					isNavEdge( target, isReverse )
-				) {
+				if ( isNavEdge( target, isReverse ) ) {
 					node.contentEditable = true;
 					// Firefox doesn't automatically move focus.
 					node.focus();


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?

Allows Shift+Arrow(Up|Down) keyboard partial selection for a variety of situations.

## Why?

It should be possible to selection multiple blocks with the keyboard from any block.

## How?

Currently there's some conditions that prevent selection from happening. These condition where around before the introduction of partial selection, but they don't make sense anymore. Whenever the user tries to Shift+Arrow select form any editable element and selection reaches the edge, we should allow selection outside that box. The selection observer then selects the appropriate blocks in the store.

## Testing Instructions

Create a v2 List and select across list items with the keyboard. Also try nested lists.
Create a Quote block with some content and try to multi select the previous or following block from inside the quote with the keyboard.

## Screenshots or screencast <!-- if applicable -->

![quote-partial](https://user-images.githubusercontent.com/4710635/182333632-6c17bb75-174b-4c88-ba17-ffc5f90b2272.gif)

![list-partial](https://user-images.githubusercontent.com/4710635/182333788-a85a1d2e-8a08-4364-a631-b7bf4ff5a241.gif)

