### PR TITLE
Popover: make sure that ownerDocument is always defined

### DIFF
--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Bug Fix
 
+-   `Popover`: make sure that `ownerDocument` is always defined ([#42886](https://github.com/WordPress/gutenberg/pull/42886)).
 -   `ExternalLink`: Check if the link is an internal anchor link and prevent anchor links from being opened. ([#42259](https://github.com/WordPress/gutenberg/pull/42259)).
 -   `BorderControl`: Ensure box-sizing is reset for the control ([#42754](https://github.com/WordPress/gutenberg/pull/42754)).
 -   `InputControl`: Fix acceptance of falsy values in controlled updates ([#42484](https://github.com/WordPress/gutenberg/pull/42484/)).

--- a/packages/components/src/popover/index.js
+++ b/packages/components/src/popover/index.js
@@ -162,25 +162,26 @@ const Popover = (
 		: placement;
 
 	const ownerDocument = useMemo( () => {
+		let documentToReturn;
+
 		if ( anchorRef?.top ) {
-			return anchorRef?.top.ownerDocument;
+			documentToReturn = anchorRef?.top.ownerDocument;
 		} else if ( anchorRef?.startContainer ) {
-			return anchorRef.startContainer.ownerDocument;
+			documentToReturn = anchorRef.startContainer.ownerDocument;
 		} else if ( anchorRef?.current ) {
-			return anchorRef.current.ownerDocument;
+			documentToReturn = anchorRef.current.ownerDocument;
 		} else if ( anchorRef ) {
 			// This one should be deprecated.
-			return anchorRef.ownerDocument;
+			documentToReturn = anchorRef.ownerDocument;
 		} else if ( anchorRect && anchorRect?.ownerDocument ) {
-			return anchorRect.ownerDocument;
+			documentToReturn = anchorRect.ownerDocument;
 		} else if ( getAnchorRect ) {
-			return (
+			documentToReturn =
 				getAnchorRect( anchorRefFallback.current )?.ownerDocument ??
-				document
-			);
+				document;
 		}
 
-		return document;
+		return documentToReturn ?? document;
 	}, [ anchorRef, anchorRect, getAnchorRect ] );
 
 	/**

--- a/packages/components/src/popover/index.js
+++ b/packages/components/src/popover/index.js
@@ -176,9 +176,9 @@ const Popover = (
 		} else if ( anchorRect && anchorRect?.ownerDocument ) {
 			documentToReturn = anchorRect.ownerDocument;
 		} else if ( getAnchorRect ) {
-			documentToReturn =
-				getAnchorRect( anchorRefFallback.current )?.ownerDocument ??
-				document;
+			documentToReturn = getAnchorRect(
+				anchorRefFallback.current
+			)?.ownerDocument;
 		}
 
 		return documentToReturn ?? document;

--- a/packages/components/src/popover/test/index.js
+++ b/packages/components/src/popover/test/index.js
@@ -1,7 +1,12 @@
 /**
  * External dependencies
  */
-import { act, render } from '@testing-library/react';
+import { act, render, screen } from '@testing-library/react';
+
+/**
+ * WordPress dependencies
+ */
+import { useRef } from '@wordpress/element';
 
 /**
  * Internal dependencies
@@ -43,5 +48,22 @@ describe( 'Popover', () => {
 		} );
 
 		expect( result.container.querySelector( 'span' ) ).toMatchSnapshot();
+	} );
+
+	it( 'should render correctly when anchorRef is provided', () => {
+		const PopoverWithAnchor = ( args ) => {
+			const anchorRef = useRef( null );
+
+			return (
+				<div>
+					<p ref={ anchorRef }>Anchor</p>
+					<Popover { ...args } anchorRef={ anchorRef } />
+				</div>
+			);
+		};
+
+		render( <PopoverWithAnchor>Popover content</PopoverWithAnchor> );
+
+		expect( screen.getByText( 'Popover content' ) ).toBeInTheDocument();
 	} );
 } );


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

In the `Popover` component, the computation of `ownerDocument` from the anchor could sometimes produce an `undefined` value — which then would cause runtime errors in other parts of the component.

This PR adds a fix which ensures that `ownerDocument` is always defined.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

The `ownerDocument` could sometimes be `undefined` when the consumer of the `Popover` uses a "modern style" ref (i.e. by using the `useRef` hook) and passes that value through the `anchorRef` prop.

For more details on how the bug was initially discovered, see https://github.com/WordPress/gutenberg/pull/42874#discussion_r935239671

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

The logic has been slightly changed to make sure that the current `document` is used as a fallback value in case `ownerDocument` was `undefined`. 

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->

Here's a patch to add a Storybook example that uses a "modern style" ref as the Popover's `anchorRef`

<details>
<summary>Click to expand</summary>

```diff
diff --git a/packages/components/src/popover/stories/index.js b/packages/components/src/popover/stories/index.js
index 0025e66fe0..cc690f0aef 100644
--- a/packages/components/src/popover/stories/index.js
+++ b/packages/components/src/popover/stories/index.js
@@ -6,7 +6,7 @@ import { boolean, select, text } from '@storybook/addon-knobs';
 /**
  * WordPress dependencies
  */
-import { useState } from '@wordpress/element';
+import { useState, useRef } from '@wordpress/element';
 
 /**
  * Internal dependencies
@@ -165,3 +165,30 @@ function DynamicHeightPopover() {
 export const dynamicHeight = () => {
 	return <DynamicHeightPopover />;
 };
+
+export const TestPopoverAnchorRef = ( args ) => {
+	const anchorRef = useRef( null );
+
+	return (
+		<div
+			style={ {
+				width: '400px',
+				height: '400px',
+				margin: 'auto',
+				display: 'flex',
+				justifyContent: 'center',
+				alignItems: 'center',
+			} }
+		>
+			<p
+				style={ { padding: '8px', background: 'salmon' } }
+				ref={ anchorRef }
+			>
+				Popover&apos;s anchor
+			</p>
+			<Popover { ...args } anchorRef={ anchorRef }>
+				Popover&apos;s content
+			</Popover>
+		</div>
+	);
+};
```
</details>

Apply the patch on `trunk` and notice how the Storybook example generates an error. Then, apply the same patch on this PR's branch and notice how the Storybook example works as expected.

Finally, do a general smoke tests across the codebase to make sure that no regressions are introduced.
