### PR TITLE
button left and right alignment overlapping issue for editor side solved

### DIFF
--- a/packages/block-library/src/buttons/editor.scss
+++ b/packages/block-library/src/buttons/editor.scss
@@ -54,6 +54,22 @@ $blocks-block__margin: 0.5em;
 			margin-bottom: 0;
 		}
 	}
+	&:not(
+		.is-content-justification-space-between,
+		.is-content-justification-right,
+		.is-content-justification-left,
+		.is-content-justification-center
+	) .wp-block[data-align="left"] {
+		height: auto;
+	}
+	&:not(
+		.is-content-justification-space-between,
+		.is-content-justification-right,
+		.is-content-justification-left,
+		.is-content-justification-center
+	) .wp-block[data-align="right"] {
+		height: auto;
+	}
 }
 
 .wp-block[data-align="center"] > .wp-block-buttons {


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->
solve :- Button block has zero height in editor when using left or right alignment
PR for :- #42790 

