### PR TITLE
Try: Tab style subpixel fix.

### DIFF
--- a/packages/components/src/panel/style.scss
+++ b/packages/components/src/panel/style.scss
@@ -35,8 +35,11 @@
 	justify-content: space-between;
 	align-items: center;
 	padding: 0 $grid-unit-20;
-	height: $grid-unit-60;
 	border-bottom: $border-width solid $gray-300;
+
+	// This helps ensure the correct panel height, including the border, avoiding subpixel rounding issues.
+	box-sizing: content-box;
+	height: $grid-unit-60 - $border-width;
 
 	h2 {
 		margin: 0;


### PR DESCRIPTION
## What?

Followup to #40998 which beautifully reduced the weight of the active tab style. There was a subpixel alignment issue on the active tab in the sidebar only, which this PR hopes to fix. 

Before:

<img width="400" alt="before" src="https://user-images.githubusercontent.com/1204802/182360597-b449348e-b8fe-4d66-a892-5d9515488bea.png">

<img width="604" alt="before zoomed" src="https://user-images.githubusercontent.com/1204802/182360600-165b9428-f118-4743-b873-6f8ed4c91245.png">

After:

<img width="400" alt="after" src="https://user-images.githubusercontent.com/1204802/182360607-165cf66d-20c2-4a1f-b2ae-2e71dea03048.png">

<img width="604" alt="after zoomed" src="https://user-images.githubusercontent.com/1204802/182360612-e58c5730-046a-42c4-8a0a-b747b9838b99.png">

## How?

It's unclear exactly why the button height is a half pixel less tall inside the sidebar compared to the inserter, but as best I can tell it's a rounding math issue.

This PR sets `content-box` on the tabbox container instead, and an explicit height that omits the bottom 1px border, which appears to solve it.

## Testing Instructions

Test any tab in the interface and check no visual regressions. 