### PR TITLE
Use the style-engine in global styles

### DIFF
--- a/lib/compat/wordpress-6.2/get-global-styles-and-settings.php
+++ b/lib/compat/wordpress-6.2/get-global-styles-and-settings.php
@@ -165,7 +165,15 @@ function gutenberg_get_global_stylesheet( $types = array() ) {
 	if ( $can_use_cached ) {
 		wp_cache_set( $cache_key, $stylesheet, $cache_group );
 	}
-	return $stylesheet;
+
+	$processor = new WP_Style_Engine_Processor_Gutenberg();
+	$processor->add_css_string( $stylesheet );
+
+	return $processor->get_css(
+		array(
+			'prettify' => defined( 'SCRIPT_DEBUG' ) && SCRIPT_DEBUG,
+		)
+	);
 }
 
 /**

--- a/packages/style-engine/class-wp-style-engine-css-declarations.php
+++ b/packages/style-engine/class-wp-style-engine-css-declarations.php
@@ -182,7 +182,7 @@ class WP_Style_Engine_CSS_Declarations {
 		foreach ( $declarations_array as $property => $value ) {
 			$filtered_declaration = static::filter_declaration( $property, $value, $spacer );
 			if ( $filtered_declaration ) {
-				$declarations_output .= "{$indent}{$filtered_declaration}$suffix";
+				$declarations_output .= "{$indent}{$filtered_declaration};$suffix";
 			}
 		}
 

--- a/packages/style-engine/class-wp-style-engine-css-declarations.php
+++ b/packages/style-engine/class-wp-style-engine-css-declarations.php
@@ -185,6 +185,11 @@ class WP_Style_Engine_CSS_Declarations {
 				$declarations_output .= "{$indent}{$filtered_declaration};$suffix";
 			}
 		}
+
+		if ( $should_prettify ) {
+			// Remove empty lines.
+			$declarations_output = str_replace( "\n\n", "\n", $declarations_output );
+		}
 		return $declarations_output;
 	}
 

--- a/packages/style-engine/class-wp-style-engine-css-declarations.php
+++ b/packages/style-engine/class-wp-style-engine-css-declarations.php
@@ -197,6 +197,6 @@ class WP_Style_Engine_CSS_Declarations {
 	 * @return string The sanitized property name.
 	 */
 	protected function sanitize_property( $property ) {
-		return trim( sanitize_key( $property ) );
+		return sanitize_key( $property );
 	}
 }

--- a/packages/style-engine/class-wp-style-engine-css-declarations.php
+++ b/packages/style-engine/class-wp-style-engine-css-declarations.php
@@ -186,10 +186,6 @@ class WP_Style_Engine_CSS_Declarations {
 			}
 		}
 
-		if ( $should_prettify ) {
-			// Remove empty lines.
-			$declarations_output = str_replace( "\n\n", "\n", $declarations_output );
-		}
 		return $declarations_output;
 	}
 

--- a/packages/style-engine/class-wp-style-engine-css-declarations.php
+++ b/packages/style-engine/class-wp-style-engine-css-declarations.php
@@ -182,16 +182,11 @@ class WP_Style_Engine_CSS_Declarations {
 		foreach ( $declarations_array as $property => $value ) {
 			$filtered_declaration = static::filter_declaration( $property, $value, $spacer );
 			if ( $filtered_declaration ) {
-				$declarations_output .= "{$indent}{$filtered_declaration};$suffix";
+				$declarations_output .= "{$indent}{$filtered_declaration}$suffix";
 			}
 		}
 
-		// Trim if there's no indentation.
-		if ( $should_prettify && 0 === $indent_count ) {
-			$declarations_output = trim( $declarations_output );
-		}
-
-		return $declarations_output;
+		return rtrim( $declarations_output );
 	}
 
 	/**

--- a/packages/style-engine/class-wp-style-engine-css-declarations.php
+++ b/packages/style-engine/class-wp-style-engine-css-declarations.php
@@ -186,6 +186,11 @@ class WP_Style_Engine_CSS_Declarations {
 			}
 		}
 
+		// Trim if there's no indentation.
+		if ( $should_prettify && 0 === $indent_count ) {
+			$declarations_output = trim( $declarations_output );
+		}
+
 		return $declarations_output;
 	}
 

--- a/packages/style-engine/class-wp-style-engine-css-declarations.php
+++ b/packages/style-engine/class-wp-style-engine-css-declarations.php
@@ -180,6 +180,10 @@ class WP_Style_Engine_CSS_Declarations {
 		$spacer              = $should_prettify ? ' ' : '';
 
 		foreach ( $declarations_array as $property => $value ) {
+			if ( 0 === strpos( $property, '--' ) ) { // Account for CSS variables.
+				$declarations_output .= "{$indent}{$property}:{$spacer}{$value};$suffix";
+				continue;
+			}
 			$filtered_declaration = static::filter_declaration( $property, $value, $spacer );
 			if ( $filtered_declaration ) {
 				$declarations_output .= "{$indent}{$filtered_declaration};$suffix";

--- a/packages/style-engine/class-wp-style-engine-css-declarations.php
+++ b/packages/style-engine/class-wp-style-engine-css-declarations.php
@@ -185,7 +185,7 @@ class WP_Style_Engine_CSS_Declarations {
 				$declarations_output .= "{$indent}{$filtered_declaration};$suffix";
 			}
 		}
-		return rtrim( $declarations_output );
+		return $declarations_output;
 	}
 
 	/**
@@ -197,5 +197,20 @@ class WP_Style_Engine_CSS_Declarations {
 	 */
 	protected function sanitize_property( $property ) {
 		return sanitize_key( $property );
+	}
+
+	/**
+	 * Sanitize values.
+	 *
+	 * @param string $value The CSS value.
+	 *
+	 * @return string The sanitized value.
+	 */
+	protected function sanitize_value( $value ) {
+		// Escape HTML.
+		$value = esc_html( $value );
+		// Fix quotes to account for URLs.
+		$value = str_replace( array( '&#039;', '&#39;', '&#034;', '&#34;', '&quot;', '&apos;' ), array( "'", "'", '"', '"', '"', "'" ), $value );
+		return trim( $value );
 	}
 }

--- a/packages/style-engine/class-wp-style-engine-css-declarations.php
+++ b/packages/style-engine/class-wp-style-engine-css-declarations.php
@@ -199,19 +199,4 @@ class WP_Style_Engine_CSS_Declarations {
 	protected function sanitize_property( $property ) {
 		return trim( sanitize_key( $property ) );
 	}
-
-	/**
-	 * Sanitize values.
-	 *
-	 * @param string $value The CSS value.
-	 *
-	 * @return string The sanitized value.
-	 */
-	protected function sanitize_value( $value ) {
-		// Escape HTML.
-		$value = esc_html( $value );
-		// Fix quotes to account for URLs.
-		$value = str_replace( array( '&#039;', '&#39;', '&#034;', '&#34;', '&quot;', '&apos;' ), array( "'", "'", '"', '"', '"', "'" ), $value );
-		return trim( $value );
-	}
 }

--- a/packages/style-engine/class-wp-style-engine-css-declarations.php
+++ b/packages/style-engine/class-wp-style-engine-css-declarations.php
@@ -197,7 +197,7 @@ class WP_Style_Engine_CSS_Declarations {
 	 * @return string The sanitized property name.
 	 */
 	protected function sanitize_property( $property ) {
-		return sanitize_key( $property );
+		return trim( sanitize_key( $property ) );
 	}
 
 	/**

--- a/packages/style-engine/class-wp-style-engine-processor.php
+++ b/packages/style-engine/class-wp-style-engine-processor.php
@@ -79,6 +79,40 @@ class WP_Style_Engine_Processor {
 	}
 
 	/**
+	 * Adds rules from a plain CSS string.
+	 *
+	 * @param string $css_string The CSS string to add.
+	 */
+	public function add_css_string( $css_string ) {
+		$css_array = array();
+		// Split CSS by rules.
+		$css_rules = explode( '}', $css_string );
+		// Loop rules and get the selectors.
+		foreach ( $css_rules as $css_rule ) {
+			$rule_parts = explode( '{', $css_rule );
+			if ( 2 !== count( $rule_parts ) ) {
+				continue;
+			}
+			$selector = trim( $rule_parts[0] );
+			if ( empty( $selector ) ) {
+				continue;
+			}
+			if ( ! isset( $css_array[ $selector ] ) ) {
+				$css_array[ $selector ] = new WP_Style_Engine_CSS_Rule( $selector );
+			}
+			$declarations = explode( ';', $rule_parts[1] );
+			foreach ( $declarations as $declaration ) {
+				$declaration_parts = explode( ':', $declaration );
+				if ( 2 !== count( $declaration_parts ) ) {
+					continue;
+				}
+				$css_array[ $selector ]->add_declarations( array( $declaration_parts[0] => $declaration_parts[1] ) );
+			}
+		}
+		$this->add_rules( $css_array );
+	}
+
+	/**
 	 * Get the CSS rules as a string.
 	 *
 	 * @param array $options   {

--- a/packages/style-engine/class-wp-style-engine-processor.php
+++ b/packages/style-engine/class-wp-style-engine-processor.php
@@ -87,28 +87,39 @@ class WP_Style_Engine_Processor {
 		$css_array = array();
 		// Split CSS by rules.
 		$css_rules = explode( '}', $css_string );
-		// Loop rules and get the selectors.
+
 		foreach ( $css_rules as $css_rule ) {
 			$rule_parts = explode( '{', $css_rule );
 			if ( 2 !== count( $rule_parts ) ) {
 				continue;
 			}
+			// Get the selector.
 			$selector = trim( $rule_parts[0] );
 			if ( empty( $selector ) ) {
 				continue;
 			}
+
+			// Create the rule object.
 			if ( ! isset( $css_array[ $selector ] ) ) {
 				$css_array[ $selector ] = new WP_Style_Engine_CSS_Rule( $selector );
 			}
-			$declarations = explode( ';', $rule_parts[1] );
+
+			// Get the declarations.
+			$declarations       = explode( ';', $rule_parts[1] );
+			$declarations_array = array();
 			foreach ( $declarations as $declaration ) {
 				$declaration_parts = explode( ':', $declaration );
 				if ( 2 !== count( $declaration_parts ) ) {
 					continue;
 				}
-				$css_array[ $selector ]->add_declarations( array( $declaration_parts[0] => $declaration_parts[1] ) );
+				$declarations_array[ $declaration_parts[0] ] = $declaration_parts[1];
 			}
+
+			// Add the declarations to the rule.
+			$css_array[ $selector ]->add_declarations( $declarations_array );
 		}
+
+		// Add the rules to the processor.
 		$this->add_rules( $css_array );
 	}
 

--- a/phpunit/class-wp-theme-json-test.php
+++ b/phpunit/class-wp-theme-json-test.php
@@ -215,7 +215,7 @@ class WP_Theme_JSON_Gutenberg_Test extends WP_UnitTestCase {
 
 		// Note the `base-layout-styles` includes a fallback gap for the Columns block for backwards compatibility.
 		$this->assertEquals(
-			':where(.is-layout-flex){gap: 0.5em;}body .is-layout-flow > .alignleft{float: left;margin-inline-start: 0;margin-inline-end: 2em;}body .is-layout-flow > .alignright{float: right;margin-inline-start: 2em;margin-inline-end: 0;}body .is-layout-flow > .aligncenter{margin-left: auto !important;margin-right: auto !important;}body .is-layout-flex{display: flex;}body .is-layout-flex{flex-wrap: wrap;align-items: center;}:where(.wp-block-columns.is-layout-flex){gap: 2em;}',
+			':where(.is-layout-flex){gap:0.5em;}body .is-layout-flow > .alignleft{float:left;margin-inline-start:0;margin-inline-end:2em;}body .is-layout-flow > .alignright{float:right;margin-inline-start:2em;margin-inline-end:0;}body .is-layout-flow > .aligncenter{margin-left:auto !important;margin-right:auto !important;}body .is-layout-flex{display:flex;flex-wrap:wrap;align-items:center;}:where(.wp-block-columns.is-layout-flex){gap:2em;}',
 			$stylesheet
 		);
 	}
@@ -575,7 +575,7 @@ class WP_Theme_JSON_Gutenberg_Test extends WP_UnitTestCase {
 
 		$base_styles = 'body { margin: 0;}.wp-site-blocks > .alignleft { float: left; margin-right: 2em; }.wp-site-blocks > .alignright { float: right; margin-left: 2em; }.wp-site-blocks > .aligncenter { justify-content: center; margin-left: auto; margin-right: auto; }';
 
-		$element_styles = 'a:where(:not(.wp-element-button)){background-color: red;color: green;}a:where(:not(.wp-element-button)):hover{background-color: green;color: red;font-size: 10em;text-transform: uppercase;}a:where(:not(.wp-element-button)):focus{background-color: black;color: yellow;}';
+		$element_styles = 'a:where(:not(.wp-element-button)){background-color:red;color:green;}a:where(:not(.wp-element-button)):hover{background-color:green;color:red;font-size:10em;text-transform:uppercase;}a:where(:not(.wp-element-button)):focus{background-color:black;color:yellow;}';
 
 		$expected = $base_styles . $element_styles;
 
@@ -614,7 +614,7 @@ class WP_Theme_JSON_Gutenberg_Test extends WP_UnitTestCase {
 
 		$base_styles = 'body { margin: 0;}.wp-site-blocks > .alignleft { float: left; margin-right: 2em; }.wp-site-blocks > .alignright { float: right; margin-left: 2em; }.wp-site-blocks > .aligncenter { justify-content: center; margin-left: auto; margin-right: auto; }';
 
-		$element_styles = 'a:where(:not(.wp-element-button)):hover{background-color: green;color: red;font-size: 10em;text-transform: uppercase;}a:where(:not(.wp-element-button)):focus{background-color: black;color: yellow;}';
+		$element_styles = 'a:where(:not(.wp-element-button)):hover{background-color:green;color:red;font-size:10em;text-transform:uppercase;}a:where(:not(.wp-element-button)):focus{background-color:black;color:yellow;}';
 
 		$expected = $base_styles . $element_styles;
 
@@ -653,7 +653,7 @@ class WP_Theme_JSON_Gutenberg_Test extends WP_UnitTestCase {
 
 		$base_styles = 'body { margin: 0;}.wp-site-blocks > .alignleft { float: left; margin-right: 2em; }.wp-site-blocks > .alignright { float: right; margin-left: 2em; }.wp-site-blocks > .aligncenter { justify-content: center; margin-left: auto; margin-right: auto; }';
 
-		$element_styles = 'h4{background-color: red;color: green;}';
+		$element_styles = 'h4{background-color:red;color:green;}';
 
 		$expected = $base_styles . $element_styles;
 
@@ -692,7 +692,7 @@ class WP_Theme_JSON_Gutenberg_Test extends WP_UnitTestCase {
 
 		$base_styles = 'body { margin: 0;}.wp-site-blocks > .alignleft { float: left; margin-right: 2em; }.wp-site-blocks > .alignright { float: right; margin-left: 2em; }.wp-site-blocks > .aligncenter { justify-content: center; margin-left: auto; margin-right: auto; }';
 
-		$element_styles = 'a:where(:not(.wp-element-button)){background-color: red;color: green;}a:where(:not(.wp-element-button)):hover{background-color: green;color: red;}';
+		$element_styles = 'a:where(:not(.wp-element-button)){background-color:red;color:green;}a:where(:not(.wp-element-button)):hover{background-color:green;color:red;}';
 
 		$expected = $base_styles . $element_styles;
 
@@ -740,7 +740,7 @@ class WP_Theme_JSON_Gutenberg_Test extends WP_UnitTestCase {
 
 		$base_styles = 'body { margin: 0;}.wp-site-blocks > .alignleft { float: left; margin-right: 2em; }.wp-site-blocks > .alignright { float: right; margin-left: 2em; }.wp-site-blocks > .aligncenter { justify-content: center; margin-left: auto; margin-right: auto; }';
 
-		$element_styles = '.wp-block-group a:where(:not(.wp-element-button)){background-color: red;color: green;}.wp-block-group a:where(:not(.wp-element-button)):hover{background-color: green;color: red;font-size: 10em;text-transform: uppercase;}.wp-block-group a:where(:not(.wp-element-button)):focus{background-color: black;color: yellow;}';
+		$element_styles = '.wp-block-group a:where(:not(.wp-element-button)){background-color:red;color:green;}.wp-block-group a:where(:not(.wp-element-button)):hover{background-color:green;color:red;font-size:10em;text-transform:uppercase;}.wp-block-group a:where(:not(.wp-element-button)):focus{background-color:black;color:yellow;}';
 
 		$expected = $base_styles . $element_styles;
 
@@ -787,7 +787,7 @@ class WP_Theme_JSON_Gutenberg_Test extends WP_UnitTestCase {
 
 		$base_styles = 'body { margin: 0;}.wp-site-blocks > .alignleft { float: left; margin-right: 2em; }.wp-site-blocks > .alignright { float: right; margin-left: 2em; }.wp-site-blocks > .aligncenter { justify-content: center; margin-left: auto; margin-right: auto; }';
 
-		$element_styles = 'a:where(:not(.wp-element-button)){background-color: red;color: green;}a:where(:not(.wp-element-button)):hover{background-color: green;color: red;}.wp-block-group a:where(:not(.wp-element-button)):hover{background-color: black;color: yellow;}';
+		$element_styles = 'a:where(:not(.wp-element-button)){background-color:red;color:green;}a:where(:not(.wp-element-button)):hover{background-color:green;color:red;}.wp-block-group a:where(:not(.wp-element-button)):hover{background-color:black;color:yellow;}';
 
 		$expected = $base_styles . $element_styles;
 

--- a/phpunit/class-wp-theme-json-test.php
+++ b/phpunit/class-wp-theme-json-test.php
@@ -215,7 +215,7 @@ class WP_Theme_JSON_Gutenberg_Test extends WP_UnitTestCase {
 
 		// Note the `base-layout-styles` includes a fallback gap for the Columns block for backwards compatibility.
 		$this->assertEquals(
-			':where(.is-layout-flex){gap:0.5em;}body .is-layout-flow > .alignleft{float:left;margin-inline-start:0;margin-inline-end:2em;}body .is-layout-flow > .alignright{float:right;margin-inline-start:2em;margin-inline-end:0;}body .is-layout-flow > .aligncenter{margin-left:auto !important;margin-right:auto !important;}body .is-layout-flex{display:flex;flex-wrap:wrap;align-items:center;}:where(.wp-block-columns.is-layout-flex){gap:2em;}',
+			':where(.is-layout-flex){gap: 0.5em;}body .is-layout-flow > .alignleft{float: left;margin-inline-start: 0;margin-inline-end: 2em;}body .is-layout-flow > .alignright{float: right;margin-inline-start: 2em;margin-inline-end: 0;}body .is-layout-flow > .aligncenter{margin-left: auto !important;margin-right: auto !important;}body .is-layout-flex{display: flex;}body .is-layout-flex{flex-wrap: wrap;align-items: center;}:where(.wp-block-columns.is-layout-flex){gap: 2em;}',
 			$stylesheet
 		);
 	}
@@ -575,7 +575,7 @@ class WP_Theme_JSON_Gutenberg_Test extends WP_UnitTestCase {
 
 		$base_styles = 'body { margin: 0;}.wp-site-blocks > .alignleft { float: left; margin-right: 2em; }.wp-site-blocks > .alignright { float: right; margin-left: 2em; }.wp-site-blocks > .aligncenter { justify-content: center; margin-left: auto; margin-right: auto; }';
 
-		$element_styles = 'a:where(:not(.wp-element-button)){background-color:red;color:green;}a:where(:not(.wp-element-button)):hover{background-color:green;color:red;font-size:10em;text-transform:uppercase;}a:where(:not(.wp-element-button)):focus{background-color:black;color:yellow;}';
+		$element_styles = 'a:where(:not(.wp-element-button)){background-color: red;color: green;}a:where(:not(.wp-element-button)):hover{background-color: green;color: red;font-size: 10em;text-transform: uppercase;}a:where(:not(.wp-element-button)):focus{background-color: black;color: yellow;}';
 
 		$expected = $base_styles . $element_styles;
 
@@ -614,7 +614,7 @@ class WP_Theme_JSON_Gutenberg_Test extends WP_UnitTestCase {
 
 		$base_styles = 'body { margin: 0;}.wp-site-blocks > .alignleft { float: left; margin-right: 2em; }.wp-site-blocks > .alignright { float: right; margin-left: 2em; }.wp-site-blocks > .aligncenter { justify-content: center; margin-left: auto; margin-right: auto; }';
 
-		$element_styles = 'a:where(:not(.wp-element-button)):hover{background-color:green;color:red;font-size:10em;text-transform:uppercase;}a:where(:not(.wp-element-button)):focus{background-color:black;color:yellow;}';
+		$element_styles = 'a:where(:not(.wp-element-button)):hover{background-color: green;color: red;font-size: 10em;text-transform: uppercase;}a:where(:not(.wp-element-button)):focus{background-color: black;color: yellow;}';
 
 		$expected = $base_styles . $element_styles;
 
@@ -653,7 +653,7 @@ class WP_Theme_JSON_Gutenberg_Test extends WP_UnitTestCase {
 
 		$base_styles = 'body { margin: 0;}.wp-site-blocks > .alignleft { float: left; margin-right: 2em; }.wp-site-blocks > .alignright { float: right; margin-left: 2em; }.wp-site-blocks > .aligncenter { justify-content: center; margin-left: auto; margin-right: auto; }';
 
-		$element_styles = 'h4{background-color:red;color:green;}';
+		$element_styles = 'h4{background-color: red;color: green;}';
 
 		$expected = $base_styles . $element_styles;
 
@@ -692,7 +692,7 @@ class WP_Theme_JSON_Gutenberg_Test extends WP_UnitTestCase {
 
 		$base_styles = 'body { margin: 0;}.wp-site-blocks > .alignleft { float: left; margin-right: 2em; }.wp-site-blocks > .alignright { float: right; margin-left: 2em; }.wp-site-blocks > .aligncenter { justify-content: center; margin-left: auto; margin-right: auto; }';
 
-		$element_styles = 'a:where(:not(.wp-element-button)){background-color:red;color:green;}a:where(:not(.wp-element-button)):hover{background-color:green;color:red;}';
+		$element_styles = 'a:where(:not(.wp-element-button)){background-color: red;color: green;}a:where(:not(.wp-element-button)):hover{background-color: green;color: red;}';
 
 		$expected = $base_styles . $element_styles;
 
@@ -740,7 +740,7 @@ class WP_Theme_JSON_Gutenberg_Test extends WP_UnitTestCase {
 
 		$base_styles = 'body { margin: 0;}.wp-site-blocks > .alignleft { float: left; margin-right: 2em; }.wp-site-blocks > .alignright { float: right; margin-left: 2em; }.wp-site-blocks > .aligncenter { justify-content: center; margin-left: auto; margin-right: auto; }';
 
-		$element_styles = '.wp-block-group a:where(:not(.wp-element-button)){background-color:red;color:green;}.wp-block-group a:where(:not(.wp-element-button)):hover{background-color:green;color:red;font-size:10em;text-transform:uppercase;}.wp-block-group a:where(:not(.wp-element-button)):focus{background-color:black;color:yellow;}';
+		$element_styles = '.wp-block-group a:where(:not(.wp-element-button)){background-color: red;color: green;}.wp-block-group a:where(:not(.wp-element-button)):hover{background-color: green;color: red;font-size: 10em;text-transform: uppercase;}.wp-block-group a:where(:not(.wp-element-button)):focus{background-color: black;color: yellow;}';
 
 		$expected = $base_styles . $element_styles;
 
@@ -787,7 +787,7 @@ class WP_Theme_JSON_Gutenberg_Test extends WP_UnitTestCase {
 
 		$base_styles = 'body { margin: 0;}.wp-site-blocks > .alignleft { float: left; margin-right: 2em; }.wp-site-blocks > .alignright { float: right; margin-left: 2em; }.wp-site-blocks > .aligncenter { justify-content: center; margin-left: auto; margin-right: auto; }';
 
-		$element_styles = 'a:where(:not(.wp-element-button)){background-color:red;color:green;}a:where(:not(.wp-element-button)):hover{background-color:green;color:red;}.wp-block-group a:where(:not(.wp-element-button)):hover{background-color:black;color:yellow;}';
+		$element_styles = 'a:where(:not(.wp-element-button)){background-color: red;color: green;}a:where(:not(.wp-element-button)):hover{background-color: green;color: red;}.wp-block-group a:where(:not(.wp-element-button)):hover{background-color: black;color: yellow;}';
 
 		$expected = $base_styles . $element_styles;
 


### PR DESCRIPTION
## What?
Runs the global styles through the style-engine's processor to optimize styles.

## Why?
Optimizes the CSS: Removes duplicates, combines selectors where appropriate, sanitizes styles.
The result is a reduction in the size of global-styles without losing anything ♻️ 🌍 🚀 
Also implements prettifying the styles when `SCRIPT_DEBUG` is `true` to facilitate debugging 🎉 

This PR is a simple method to get started with the style-engine inside global styles, without refactoring global-styles which is something that will be done in the future.

## How?
This is just the 1st step towards refactoring global-styles to use the style-engine.
Instead of refactoring the whole thing, this PR introduces a method to parse CSS in the `WP_Style_Engine_Processor` class, and optimize it.

