### PR TITLE
Lodash: Remove completely from `@wordpress/element` package

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17182,8 +17182,8 @@
 				"@types/react": "^17.0.37",
 				"@types/react-dom": "^17.0.11",
 				"@wordpress/escape-html": "file:packages/escape-html",
+				"change-case": "^4.1.2",
 				"is-plain-obj": "^4.1.0",
-				"lodash": "^4.17.21",
 				"react": "^17.0.2",
 				"react-dom": "^17.0.2"
 			}
@@ -28436,7 +28436,6 @@
 			"version": "4.1.2",
 			"resolved": "https://registry.npmjs.org/camel-case/-/camel-case-4.1.2.tgz",
 			"integrity": "sha512-gxGWBrTT1JuMx6R+o5PTXMmUnhnVzLQ9SNutD4YqKtI6ap897t3tKECYla6gCWEkplXnlNybEkZg9GEGxKFCgw==",
-			"dev": true,
 			"requires": {
 				"pascal-case": "^3.1.2",
 				"tslib": "^2.0.3"
@@ -28498,7 +28497,6 @@
 			"version": "1.0.4",
 			"resolved": "https://registry.npmjs.org/capital-case/-/capital-case-1.0.4.tgz",
 			"integrity": "sha512-ds37W8CytHgwnhGGTi88pcPyR15qoNkOpYwmMMfnWqqWgESapLqvDx6huFjQ5vqWSn2Z06173XNA7LtMOeUh1A==",
-			"dev": true,
 			"requires": {
 				"no-case": "^3.0.4",
 				"tslib": "^2.0.3",
@@ -28597,7 +28595,6 @@
 			"version": "4.1.2",
 			"resolved": "https://registry.npmjs.org/change-case/-/change-case-4.1.2.tgz",
 			"integrity": "sha512-bSxY2ws9OtviILG1EiY5K7NNxkqg/JnRnFxLtKQ96JaviiIxi7djMrSd0ECT9AC+lttClmYwKw53BWpOMblo7A==",
-			"dev": true,
 			"requires": {
 				"camel-case": "^4.1.2",
 				"capital-case": "^1.0.4",
@@ -29673,7 +29670,6 @@
 			"version": "3.0.4",
 			"resolved": "https://registry.npmjs.org/constant-case/-/constant-case-3.0.4.tgz",
 			"integrity": "sha512-I2hSBi7Vvs7BEuJDr5dDHfzb/Ruj3FyvFyh7KLilAjNQw3Be+xgqUBA2W6scVEcL0hL1dwPRtIqEPVUCKkSsyQ==",
-			"dev": true,
 			"requires": {
 				"no-case": "^3.0.4",
 				"tslib": "^2.0.3",
@@ -31888,7 +31884,6 @@
 			"version": "3.0.4",
 			"resolved": "https://registry.npmjs.org/dot-case/-/dot-case-3.0.4.tgz",
 			"integrity": "sha512-Kv5nKlh6yRrdrGvxeJ2e5y2eRUpkUosIW4A2AS38zwSz27zu7ufDwQPi5Jhs3XAlGNetl3bmnGhQsMtkKJnj3w==",
-			"dev": true,
 			"requires": {
 				"no-case": "^3.0.4",
 				"tslib": "^2.0.3"
@@ -37300,7 +37295,6 @@
 			"version": "2.0.4",
 			"resolved": "https://registry.npmjs.org/header-case/-/header-case-2.0.4.tgz",
 			"integrity": "sha512-H/vuk5TEEVZwrR0lp2zed9OCo1uAILMlx0JEMgC26rzyJJ3N1v6XkwHHXJQdR2doSjcGPM6OKPYoJgf0plJ11Q==",
-			"dev": true,
 			"requires": {
 				"capital-case": "^1.0.4",
 				"tslib": "^2.0.3"
@@ -43674,7 +43668,6 @@
 			"version": "2.0.2",
 			"resolved": "https://registry.npmjs.org/lower-case/-/lower-case-2.0.2.tgz",
 			"integrity": "sha512-7fm3l3NAF9WfN6W3JOmf5drwpVqX78JtoGJ3A6W0a6ZnldM41w2fV5D490psKFTpMds8TJse/eHLFFsNHHjHgg==",
-			"dev": true,
 			"requires": {
 				"tslib": "^2.0.3"
 			}
@@ -46156,7 +46149,6 @@
 			"version": "3.0.4",
 			"resolved": "https://registry.npmjs.org/no-case/-/no-case-3.0.4.tgz",
 			"integrity": "sha512-fgAN3jGAh+RoxUGZHTSOLJIqUc2wmoBwGR4tbpNAKmmovFoWq0OdRkb0VkldReO2a2iBT/OEulG9XSUc10r3zg==",
-			"dev": true,
 			"requires": {
 				"lower-case": "^2.0.2",
 				"tslib": "^2.0.3"
@@ -48252,7 +48244,6 @@
 			"version": "3.0.4",
 			"resolved": "https://registry.npmjs.org/param-case/-/param-case-3.0.4.tgz",
 			"integrity": "sha512-RXlj7zCYokReqWpOPH9oYivUzLYZ5vAPIfEmCTNViosC78F8F0H9y7T7gG2M39ymgutxF5gcFEsyZQSph9Bp3A==",
-			"dev": true,
 			"requires": {
 				"dot-case": "^3.0.4",
 				"tslib": "^2.0.3"
@@ -48357,7 +48348,6 @@
 			"version": "3.1.2",
 			"resolved": "https://registry.npmjs.org/pascal-case/-/pascal-case-3.1.2.tgz",
 			"integrity": "sha512-uWlGT3YSnK9x3BQJaOdcZwrnV6hPpd8jFH1/ucpiLRPh/2zCVJKS19E4GvYHvaCcACn3foXZ0cLB9Wrx1KGe5g==",
-			"dev": true,
 			"requires": {
 				"no-case": "^3.0.4",
 				"tslib": "^2.0.3"
@@ -48470,7 +48460,6 @@
 			"version": "3.0.4",
 			"resolved": "https://registry.npmjs.org/path-case/-/path-case-3.0.4.tgz",
 			"integrity": "sha512-qO4qCFjXqVTrcbPt/hQfhTQ+VhFsqNKOPtytgNKkKxSoEp3XPUQ8ObFuePylOIok5gjn69ry8XiULxCwot3Wfg==",
-			"dev": true,
 			"requires": {
 				"dot-case": "^3.0.4",
 				"tslib": "^2.0.3"
@@ -53092,7 +53081,6 @@
 			"version": "3.0.4",
 			"resolved": "https://registry.npmjs.org/sentence-case/-/sentence-case-3.0.4.tgz",
 			"integrity": "sha512-8LS0JInaQMCRoQ7YUytAo/xUu5W2XnQxV2HI/6uM6U7CITS1RqPElr30V6uIqyMKM9lJGRVFy5/4CuzcixNYSg==",
-			"dev": true,
 			"requires": {
 				"no-case": "^3.0.4",
 				"tslib": "^2.0.3",
@@ -53538,7 +53526,6 @@
 			"version": "3.0.4",
 			"resolved": "https://registry.npmjs.org/snake-case/-/snake-case-3.0.4.tgz",
 			"integrity": "sha512-LAOh4z89bGQvl9pFfNF8V146i7o7/CqFPbqzYgP+yYzDIDeS9HaNFtXABamRW+AQzEVODcvE79ljJ+8a9YSdMg==",
-			"dev": true,
 			"requires": {
 				"dot-case": "^3.0.4",
 				"tslib": "^2.0.3"
@@ -57867,7 +57854,6 @@
 			"version": "2.0.2",
 			"resolved": "https://registry.npmjs.org/upper-case/-/upper-case-2.0.2.tgz",
 			"integrity": "sha512-KgdgDGJt2TpuwBUIjgG6lzw2GWFRCW9Qkfkiv0DxqHHLYJHmtmdUIKcZd8rHgFSjopVTlw6ggzCm1b8MFQwikg==",
-			"dev": true,
 			"requires": {
 				"tslib": "^2.0.3"
 			}
@@ -57876,7 +57862,6 @@
 			"version": "2.0.2",
 			"resolved": "https://registry.npmjs.org/upper-case-first/-/upper-case-first-2.0.2.tgz",
 			"integrity": "sha512-514ppYHBaKwfJRK/pNC6c/OxfGa0obSnAl106u97Ed0I625Nin96KAjttZF6ZL3e1XLtphxnqrOi9iWgm+u+bg==",
-			"dev": true,
 			"requires": {
 				"tslib": "^2.0.3"
 			}

--- a/packages/element/package.json
+++ b/packages/element/package.json
@@ -32,8 +32,8 @@
 		"@types/react": "^17.0.37",
 		"@types/react-dom": "^17.0.11",
 		"@wordpress/escape-html": "file:../escape-html",
+		"change-case": "^4.1.2",
 		"is-plain-obj": "^4.1.0",
-		"lodash": "^4.17.21",
 		"react": "^17.0.2",
 		"react-dom": "^17.0.2"
 	},

--- a/packages/element/src/serialize.js
+++ b/packages/element/src/serialize.js
@@ -29,7 +29,7 @@
  * External dependencies
  */
 import isPlainObject from 'is-plain-obj';
-import { kebabCase } from 'lodash';
+import { paramCase as kebabCase } from 'change-case';
 
 /**
  * WordPress dependencies


### PR DESCRIPTION
## What?
This PR removes all of the Lodash from the `@wordpress/element` package, including the `lodash` dependency altogether. It's actually a single `kebabCase` usage.

Fixes #16938.

## Why?

Lodash is known to unnecessarily inflate the bundle size of packages, and in most cases, it can be replaced with native language functionality. See these for more information and rationale:

* https://github.com/WordPress/gutenberg/issues/16938#issuecomment-602837246
* https://github.com/WordPress/gutenberg/issues/17025
* https://github.com/WordPress/gutenberg/issues/39495 

## How?
We're dealing with straightforwardly replacing `kebabCase()`, which is straightforward enough to be replaced with `paramCase()` from the `change-case` library that we've already been using for other case transformations around Gutenberg, and it's [small enough](https://bundlephobia.com/package/change-case@4.1.2) and focused only around case transformation.

## Testing Instructions

* Verify unit tests still pass: `npm run test-unit packages/element`
* Smoke test the Post editor and Site editor. 