### PR TITLE
Docs: Fix return type of home link attribute function.

### DIFF
--- a/packages/block-library/src/home-link/index.php
+++ b/packages/block-library/src/home-link/index.php
@@ -89,7 +89,7 @@ function block_core_home_link_build_css_font_sizes( $context ) {
  * Builds an array with classes and style for the li wrapper
  *
  * @param  array $context    Home link block context.
- * @return array The li wrapper attributes.
+ * @return string The li wrapper attributes.
  */
 function block_core_home_link_build_li_wrapper_attributes( $context ) {
 	$colors          = block_core_home_link_build_css_colors( $context );


### PR DESCRIPTION
The function `block_core_home_link_build_li_wrapper_attributes()` returns a `string`, not an `array`, see [get_block_wrapper_attributes()](https://developer.wordpress.org/reference/functions/get_block_wrapper_attributes/) which is used at the end of the function.