### PR TITLE
Layout: Ensure defaultEditorStyles are still output in Classic themes

### DIFF
--- a/lib/compat/wordpress-6.1/block-editor-settings.php
+++ b/lib/compat/wordpress-6.1/block-editor-settings.php
@@ -83,7 +83,7 @@ function gutenberg_get_block_editor_settings( $settings ) {
 			// If there is no `theme.json` file, ensure base layout styles are still available.
 			$block_classes = array(
 				'css'            => 'base-layout-styles',
-				'__unstableType' => 'theme',
+				'__unstableType' => 'base-layout',
 				'isGlobalStyles' => true,
 			);
 			$actual_css    = gutenberg_get_global_stylesheet( array( $block_classes['css'] ) );


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Fixes https://github.com/WordPress/gutenberg/issues/42902

When outputting base layout styles in a theme that otherwise does not output theme global styles, ensure the `type` of the base layout styles is not set to `theme` so that it isn't considered as theme styles by the check in https://github.com/WordPress/gutenberg/blob/9f0e6be1c2ded47186ac4c009c798fa50d005177/packages/edit-post/src/editor.js#L178

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

As of #40875, base layout styles are output as part of the Theme JSON class — in order to support Classic themes using the default editor styles, we need to ensure that the base layout styles are not considered "theme" styles by the above check. Otherwise themes that do not provide their own editor styles will not have default editor styles to ensure elements in the editor look pleasing.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

When outputting base layout styles for Classic themes, use a different `__unstableType` so that it isn't treated as theme styles. These styles get appended into the presets styles as part of the following line, which is the desired behaviour: https://github.com/WordPress/gutenberg/blob/9f0e6be1c2ded47186ac4c009c798fa50d005177/packages/edit-post/src/editor.js#L174

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->

1. In an older Classic theme like Dara (https://wordpress.org/themes/dara/), test that the editor styles now look correct
2. Test that Social Icons and Columns blocks render correctly
3. In a Blocks-based theme, smoke test that Layout styles for Columns, Group, and Buttons still work as expected

## Screenshots or screencast <!-- if applicable -->

With Dara theme applied

| Before | After |
| --- | --- |
| <img width="955" alt="image" src="https://user-images.githubusercontent.com/14988353/182519681-879fdba9-017f-4ba9-88be-beaf62c3339c.png"> | <img width="954" alt="image" src="https://user-images.githubusercontent.com/14988353/182519577-b521c62c-1784-40e3-8342-63cd0bec00fe.png"> |
