### PR TITLE
fixed the group block alignment issue when background color is selected

### DIFF
--- a/packages/block-library/src/group/style.scss
+++ b/packages/block-library/src/group/style.scss
@@ -1,4 +1,5 @@
 .wp-block-group {
 	// This block has customizable padding, border-box makes that more predictable.
 	box-sizing: border-box;
+	overflow: auto;
 }


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->
This PR can solve the issue: https://github.com/WordPress/gutenberg/issues/39344 and https://github.com/WordPress/gutenberg/issues/40131. The issue is in the group block when we add some blocks like image block in the group block and the background color is selected and we give left or right alignment then the group block is not working properly. Attaching the video link for a better understanding of the issue. 

Video link: https://www.loom.com/share/1af8bccffeb34067af5906947fc05ed9

My PR is working for all the cases like in this issue: https://github.com/WordPress/gutenberg/issues/40131. The same thing is happening for the Social icons block. In my ticket, the issue is happening when the image block is added to the group block and in this case, it is happening when the Social icons block is added to the group block. I checked it and found that issue is in the group block So I created PR for group block alignment.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

When we add some block like image block in group block and give the alignment left or right to group block then group block is not wrapping the image block in it. So I added the overflow auto CSS in group block. Now it is working for all blocks.

## Testing Instructions
1. Add group block and set some background color to group block.
2. Add an image in the group block.
3. Set the image size to see the left and right alignment effects properly.
4. Now set the image in the left or right-align. And you will see the issue clearly.

## Screenshots or screencast <!-- if applicable -->
