### PR TITLE
Lodash: Remove completely from `@wordpress/dom` package

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16948,8 +16948,7 @@
 			"version": "file:packages/dom",
 			"requires": {
 				"@babel/runtime": "^7.16.0",
-				"@wordpress/deprecated": "^3.8.0",
-				"lodash": "^4.17.21"
+				"@wordpress/deprecated": "^3.8.0"
 			}
 		},
 		"@wordpress/dom-ready": {

--- a/packages/dom/package.json
+++ b/packages/dom/package.json
@@ -29,8 +29,7 @@
 	"sideEffects": false,
 	"dependencies": {
 		"@babel/runtime": "^7.16.0",
-		"@wordpress/deprecated": "^3.8.0",
-		"lodash": "^4.17.21"
+		"@wordpress/deprecated": "^3.8.0"
 	},
 	"publishConfig": {
 		"access": "public"

--- a/packages/dom/src/dom/clean-node-list.js
+++ b/packages/dom/src/dom/clean-node-list.js
@@ -1,9 +1,4 @@
 /**
- * External dependencies
- */
-import { includes } from 'lodash';
-
-/**
  * Internal dependencies
  */
 import isEmpty from './is-empty';
@@ -70,7 +65,7 @@ export default function cleanNodeList( nodeList, doc, schema, inline ) {
 						Array.from( node.attributes ).forEach( ( { name } ) => {
 							if (
 								name !== 'class' &&
-								! includes( attributes, name )
+								! attributes.includes( name )
 							) {
 								node.removeAttribute( name );
 							}

--- a/packages/dom/src/tabbable.js
+++ b/packages/dom/src/tabbable.js
@@ -1,9 +1,4 @@
 /**
- * External dependencies
- */
-import { without, first, last } from 'lodash';
-
-/**
  * Internal dependencies
  */
 import { find as findFocusable } from './focusable';
@@ -74,7 +69,7 @@ function createStatefulCollapseRadioGroup() {
 		// the element which had previously been considered the chosen one.
 		if ( hasChosen ) {
 			const hadChosenElement = CHOSEN_RADIO_BY_NAME[ name ];
-			result = without( result, hadChosenElement );
+			result = result.filter( ( e ) => e !== hadChosenElement );
 		}
 
 		CHOSEN_RADIO_BY_NAME[ name ] = element;
@@ -174,7 +169,8 @@ export function findPrevious( element ) {
 	// Remove all focusables after and including `element`.
 	focusables.length = index;
 
-	return last( filterTabbable( focusables ) );
+	const tabbable = filterTabbable( focusables );
+	return tabbable[ tabbable.length - 1 ];
 }
 
 /**
@@ -182,6 +178,8 @@ export function findPrevious( element ) {
  *
  * @param {Element} element The focusable element after which to look. Defaults
  *                          to the active element.
+ *
+ * @return {Element|undefined} Next tabbable element.
  */
 export function findNext( element ) {
 	const focusables = findFocusable( element.ownerDocument.body );
@@ -190,5 +188,5 @@ export function findNext( element ) {
 	// Remove all focusables before and including `element`.
 	const remaining = focusables.slice( index + 1 );
 
-	return first( filterTabbable( remaining ) );
+	return filterTabbable( remaining )[ 0 ];
 }


### PR DESCRIPTION
## What?
This PR removes all of the Lodash from the `@wordpress/dom` package, including the `lodash` dependency altogether. There are just a few usages and conversion is pretty straightforward. 

## Why?

Lodash is known to unnecessarily inflate the bundle size of packages, and in most cases, it can be replaced with native language functionality. See these for more information and rationale:

* https://github.com/WordPress/gutenberg/issues/16938#issuecomment-602837246
* https://github.com/WordPress/gutenberg/issues/17025
* https://github.com/WordPress/gutenberg/issues/39495 

## How?
We're dealing with straightforwardly replacing a few methods, namely:

#### `omit`

We're using destructuring with rest props, which nicely handles the omission.

#### `includes`

Simple enough to replace with `Array.prototype.includes` when run on a value that's always an array.

#### `without`

Straightforward to replace with `Array.prototype.filter` with a negated condition.

#### `first`

Straightforward to replace with `[ 0 ]` on the target array.

#### `last`

Straightforward to replace with `x[ x.length - 1 ]` on the target array.

## Testing Instructions

* Verify all tests still pass: `npm run test-unit packages/dom`
* Verify tabbing and shift-tabbing inside the editor, inserter, sidebar, and so on still works the same way as before.
* Paste `<p>Test<strong>x</strong>something<p>` in the editor and verify the bold is preserved.
* Paste `<p>Test<u>x</u>something<p>` in the editor and verify the `u` is removed.
* Additionally, smoke test the editor a bit. 