### PR TITLE
Lodash: Refactor away from `_.maxBy()`

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -114,6 +114,7 @@ module.exports = {
 							'keyBy',
 							'keys',
 							'lowerCase',
+							'maxBy',
 							'memoize',
 							'negate',
 							'noop',

--- a/packages/block-editor/src/components/colors/utils.js
+++ b/packages/block-editor/src/components/colors/utils.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { find, kebabCase, maxBy } from 'lodash';
+import { find, kebabCase } from 'lodash';
 import { colord, extend } from 'colord';
 import namesPlugin from 'colord/plugins/names';
 import a11yPlugin from 'colord/plugins/a11y';
@@ -77,6 +77,9 @@ export function getColorClassName( colorContextName, colorSlug ) {
  */
 export function getMostReadableColor( colors, colorValue ) {
 	const colordColor = colord( colorValue );
-	return maxBy( colors, ( { color } ) => colordColor.contrast( color ) )
+	const getColorContrast = ( { color } ) => colordColor.contrast( color );
+
+	const maxContrast = Math.max( ...colors.map( getColorContrast ) );
+	return colors.find( ( color ) => getColorContrast( color ) === maxContrast )
 		.color;
 }

--- a/packages/blocks/src/api/utils.js
+++ b/packages/blocks/src/api/utils.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { every, has, reduce, maxBy } from 'lodash';
+import { every, has, reduce } from 'lodash';
 import { colord, extend } from 'colord';
 import namesPlugin from 'colord/plugins/names';
 import a11yPlugin from 'colord/plugins/a11y';
@@ -101,13 +101,17 @@ export function normalizeIconObject( icon ) {
 
 	if ( has( icon, [ 'background' ] ) ) {
 		const colordBgColor = colord( icon.background );
+		const getColorContrast = ( iconColor ) =>
+			colordBgColor.contrast( iconColor );
+		const maxContrast = Math.max( ...ICON_COLORS.map( getColorContrast ) );
 
 		return {
 			...icon,
 			foreground: icon.foreground
 				? icon.foreground
-				: maxBy( ICON_COLORS, ( iconColor ) =>
-						colordBgColor.contrast( iconColor )
+				: ICON_COLORS.find(
+						( iconColor ) =>
+							getColorContrast( iconColor ) === maxContrast
 				  ),
 			shadowColor: colordBgColor.alpha( 0.3 ).toRgbString(),
 		};


### PR DESCRIPTION
## What?
This PR removes the `_.maxBy()` usage completely and deprecates the function. 

## Why?

Lodash is known to unnecessarily inflate the bundle size of packages, and in most cases, it can be replaced with native language functionality. See these for more information and rationale:

* https://github.com/WordPress/gutenberg/issues/16938#issuecomment-602837246
* https://github.com/WordPress/gutenberg/issues/17025
* https://github.com/WordPress/gutenberg/issues/39495 

## How?

We're replacing it with a custom implementation that first finds the max value, and then the first element with that max value.

## Testing Instructions
* Verify tests still pass: `npm run test-unit packages/block-editor/src/components/colors/test/utils.js`
* Verify tests still pass: `npm run test-unit packages/blocks/src/api/test/registration.js`