### PR TITLE
Lodash: Refactor away from `_.zip()`

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -138,6 +138,7 @@ module.exports = {
 							'uniqueId',
 							'uniqWith',
 							'values',
+							'zip',
 						],
 						message:
 							'This Lodash method is not recommended. Please use native functionality instead. If using `memoize`, please use `memize` instead.',

--- a/packages/core-data/src/batch/create-batch.js
+++ b/packages/core-data/src/batch/create-batch.js
@@ -1,9 +1,4 @@
 /**
- * External dependencies
- */
-import { zip } from 'lodash';
-
-/**
  * Internal dependencies
  */
 import defaultProcessor from './default-processor';
@@ -138,12 +133,8 @@ export default function createBatch( processor = defaultProcessor ) {
 
 			let isSuccess = true;
 
-			for ( const pair of zip( results, queue ) ) {
-				/** @type {{error?: unknown, output?: unknown}} */
-				const result = pair[ 0 ];
-
-				/** @type {{resolve: (value: any) => void; reject: (error: any) => void} | undefined} */
-				const queueItem = pair[ 1 ];
+			results.forEach( ( result, key ) => {
+				const queueItem = queue[ key ];
 
 				if ( result?.error ) {
 					queueItem?.reject( result.error );
@@ -151,7 +142,7 @@ export default function createBatch( processor = defaultProcessor ) {
 				} else {
 					queueItem?.resolve( result?.output ?? result );
 				}
-			}
+			} );
 
 			queue = [];
 

--- a/packages/edit-navigation/src/store/actions.js
+++ b/packages/edit-navigation/src/store/actions.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { difference, zip } from 'lodash';
+import { difference } from 'lodash';
 
 /**
  * WordPress dependencies
@@ -170,7 +170,12 @@ const batchInsertPlaceholderMenuItems =
 			.__experimentalBatch( tasks );
 
 		// Return an updated navigation block with all the IDs in.
-		const blockToResult = new Map( zip( blocksWithoutRecordId, results ) );
+		const blockToResult = new Map(
+			blocksWithoutRecordId.map( ( block, index ) => [
+				block,
+				results[ index ],
+			] )
+		);
 		return mapBlocksTree( navigationBlock, ( block ) => {
 			if ( ! blockToResult.has( block ) ) {
 				return block;

--- a/packages/edit-navigation/src/store/transform.js
+++ b/packages/edit-navigation/src/store/transform.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { get, omit, sortBy, zip } from 'lodash';
+import { get, omit, sortBy } from 'lodash';
 
 /**
  * WordPress dependencies
@@ -199,8 +199,8 @@ function mapMenuItemsToBlocks( menuItems ) {
 		return createBlock( itemBlockName, attributes, nestedBlocks );
 	} );
 
-	return zip( blocks, sortedItems ).map( ( [ block, menuItem ] ) =>
-		addRecordIdToBlock( block, menuItem.id )
+	return blocks.map( ( block, blockIndex ) =>
+		addRecordIdToBlock( block, sortedItems[ blockIndex ].id )
 	);
 }
 


### PR DESCRIPTION
## What?
This PR removes the `_.zip()` usage completely and deprecates the function. 

## Why?

Lodash is known to unnecessarily inflate the bundle size of packages, and in most cases, it can be replaced with native language functionality. See these for more information and rationale:

* https://github.com/WordPress/gutenberg/issues/16938#issuecomment-602837246
* https://github.com/WordPress/gutenberg/issues/17025
* https://github.com/WordPress/gutenberg/issues/39495 

## How?

We're replacing it with a custom implementation that loops through the first array and uses the index to take the same index item from the second array.

## Testing Instructions
* Verify tests still pass: `npm run test-unit packages/core-data/src/batch`
* Verify tests still pass: `npm run test-unit packages/edit-navigation`
* Enable the experimental Navigation Editor on the Gutenberg > Experiments
* If you only have one or no menus, create some new ones using the New Menu button.
* Verify the menu management still works well. 
* Verify saving of block widgets still works correctly.