### PR TITLE
Navigation: Overlay: Fix link inheritance

### DIFF
--- a/packages/block-library/src/navigation/style.scss
+++ b/packages/block-library/src/navigation/style.scss
@@ -452,6 +452,10 @@ button.wp-block-navigation-item__content {
 	right: 0;
 	bottom: 0;
 
+	.wp-block-navigation-link a {
+		color: inherit;
+	}
+
 	.wp-block-navigation__responsive-container-content {
 		display: flex;
 		flex-wrap: var(--navigation-layout-wrap, wrap);


### PR DESCRIPTION
## What?
The implementation of link color in the navigation block doesn't work well with link color in other blocks, so that the link color setting from parent blocks overrides the navigation block setting. The ideal solution here is to add link color support to both the navigation block and the navigation overlay, but this is big piece of work. In the meantime this PR adds a quick fix to the overlay CSS to ensure that the link colors are preserved.

## Testing Instructions
- Add a group block and set a link color
- Add a navigation block to the group block and set an overlay text color
- Check that the links in the overlay are the ones from the navigation block, not those from the group.

## Screenshots or screencast <!-- if applicable -->
Before:
![before](https://user-images.githubusercontent.com/275961/182612805-ef1b7c08-d454-4f9e-80ec-99c534367de2.gif)

After:
![after](https://user-images.githubusercontent.com/275961/182612849-2beb0932-d537-4734-b347-a1120154726e.gif)

@WordPress/block-themers 
