### PR TITLE
Document Settings: Decode the post URL for the button label

### DIFF
--- a/packages/editor/src/components/post-url/label.js
+++ b/packages/editor/src/components/post-url/label.js
@@ -2,7 +2,7 @@
  * WordPress dependencies
  */
 import { useSelect } from '@wordpress/data';
-import { filterURLForDisplay } from '@wordpress/url';
+import { filterURLForDisplay, safeDecodeURIComponent } from '@wordpress/url';
 
 /**
  * Internal dependencies
@@ -18,5 +18,5 @@ export function usePostURLLabel() {
 		( select ) => select( editorStore ).getCurrentPost().link,
 		[]
 	);
-	return filterURLForDisplay( postLink );
+	return filterURLForDisplay( safeDecodeURIComponent( postLink ) );
 }


### PR DESCRIPTION
## What?
Fixes #42897.

PR decodes the post URL for the button label.

## How?
Adds `safeDecodeURIComponent` to the `usePostURLLabel` hook.

## Testing Instructions
1. Create a post
2. Paste title with non-Latin characters - `ქართული ბმული`
3. Publish the post
4. Confirm that the button label uses decoded URL

## Screenshots or screencast <!-- if applicable -->
| Before | After |
| --- | --- |
|![CleanShot 2022-08-03 at 16 35 38](https://user-images.githubusercontent.com/240569/182610782-192738af-0715-4ee2-a3e8-ac2794acfdf8.png)|![CleanShot 2022-08-03 at 16 19 48](https://user-images.githubusercontent.com/240569/182610794-d7cb4278-c35c-4e5b-8d12-078c961851c2.png)|



