### PR TITLE
Layout: fix flex direction column

### DIFF
--- a/lib/block-supports/layout.php
+++ b/lib/block-supports/layout.php
@@ -184,9 +184,9 @@ function gutenberg_get_layout_style( $selector, $layout, $has_block_gap_support 
 				);
 			}
 		} else {
-			$layout_styles[ $selector ] = array(
-				'flex-direction' => 'column',
-				'align-items'    => 'flex-start',
+			$layout_styles[] = array(
+				'selector'     => $selector,
+				'declarations' => array( 'flex-direction' => 'column' ),
 			);
 			if ( ! empty( $layout['justifyContent'] ) && array_key_exists( $layout['justifyContent'], $justify_content_options ) ) {
 				$layout_styles[] = array(


### PR DESCRIPTION
Fixes: https://github.com/WordPress/gutenberg/issues/42938

## What?
Fixing stacked (column/vertical) orientation of the row block.

## Why?
The row element with stack orientation doesn't work since https://github.com/WordPress/gutenberg/pull/42452 was merged.
Currently, the CSS related to the flex-direction is not rendered in the frontend.

## How?
This PR fixes the styles engine to render the CSS to the flex-direction in the frontend.

## Testing Instructions
- Add a Row element
- Add two paragraphs inside the row element
- Select stack orientation in the row element
- Save the post and verify in the frontend that the elements are not vertically stacked.

## Screenshots or screencast <!-- if applicable -->
Before:
![image](https://user-images.githubusercontent.com/1310626/182638178-c8f46e29-bd4f-4cd0-a55d-efca60382e91.png)

After:
![image](https://user-images.githubusercontent.com/1310626/182638231-65d06e9e-a422-4ecf-a333-74b65e1a84d2.png)


Fixes: https://github.com/WordPress/gutenberg/issues/42938