### PR TITLE
Fix Nav block invalid permissions warning by avoiding using trashed wp_navigation posts.

### DIFF
--- a/lib/compat/wordpress-6.1/class-gutenberg-rest-navigation-controller.php
+++ b/lib/compat/wordpress-6.1/class-gutenberg-rest-navigation-controller.php
@@ -1,0 +1,39 @@
+<?php
+/**
+ * REST API: Gutenberg_REST_Navigation_Controller class
+ *
+ * @package    Gutenberg
+ * @subpackage REST_API
+ */
+
+class Gutenberg_REST_Navigation_Controller extends WP_REST_Posts_Controller {
+
+	/**
+	 * Overide WP_REST_Posts_Controller function to query for
+	 * `wp_navigation` posts by post_name / slug instead of ID.
+	 *
+	 * @param string $id the slug of the Navigation post.
+	 * @return WP_Post|null
+	 */
+	protected function get_post( $id ) {
+
+		$result = parent::get_post( $id );
+
+		if ( is_wp_error( $result ) ) {
+			return $result;
+		}
+
+		$post = $result;
+
+		if ( 'publish' !== $post->post_status || 'draft' !== $post->post_status ) {
+			return new WP_Error(
+				'rest_post_invalid_id',
+				__( 'Invalid post ID.' ),
+				array( 'status' => 404 )
+			);
+		} else {
+			return $post;
+		}
+
+	}
+}

--- a/lib/compat/wordpress-6.1/class-gutenberg-rest-navigation-controller.php
+++ b/lib/compat/wordpress-6.1/class-gutenberg-rest-navigation-controller.php
@@ -9,10 +9,10 @@
 class Gutenberg_REST_Navigation_Controller extends WP_REST_Posts_Controller {
 
 	/**
-	 * Overide WP_REST_Posts_Controller function to query for
-	 * `wp_navigation` posts by post_name / slug instead of ID.
+	 * Overide WP_REST_Posts_Controller function to discard
+	 * certain post statuses and treat as missing.
 	 *
-	 * @param string $id the slug of the Navigation post.
+	 * @param int $id the ID of the Navigation post.
 	 * @return WP_Post|null
 	 */
 	protected function get_post( $id ) {

--- a/lib/compat/wordpress-6.1/class-gutenberg-rest-navigation-controller.php
+++ b/lib/compat/wordpress-6.1/class-gutenberg-rest-navigation-controller.php
@@ -25,14 +25,14 @@ class Gutenberg_REST_Navigation_Controller extends WP_REST_Posts_Controller {
 
 		$post = $result;
 
-		if ( 'publish' !== $post->post_status || 'draft' !== $post->post_status ) {
+		if ( 'publish' === $post->post_status || 'draft' === $post->post_status ) {
+			return $post;
+		} else {
 			return new WP_Error(
 				'rest_post_invalid_id',
 				__( 'Invalid post ID.' ),
 				array( 'status' => 404 )
 			);
-		} else {
-			return $post;
 		}
 
 	}

--- a/lib/compat/wordpress-6.1/rest-api.php
+++ b/lib/compat/wordpress-6.1/rest-api.php
@@ -43,3 +43,17 @@ function gutenberg_register_gutenberg_rest_block_patterns() {
 	$block_patterns->register_routes();
 }
 add_action( 'rest_api_init', 'gutenberg_register_gutenberg_rest_block_patterns', 100 );
+
+
+
+function gutenberg_update_navigation_rest_controller( $args, $post_type ) {
+	if ( in_array( $post_type, array( 'wp_navigation' ), true ) ) {
+		// Original set in
+		// https://github.com/WordPress/wordpress-develop/blob/6cbed78c94b9d8c6a9b4c8b472b88ee0cd56528c/src/wp-includes/post.php#L528.
+		$args['rest_controller_class'] = 'Gutenberg_REST_Navigation_Controller';
+	}
+	return $args;
+}
+add_filter( 'register_post_type_args', 'gutenberg_update_navigation_rest_controller', 10, 2 );
+
+

--- a/lib/load.php
+++ b/lib/load.php
@@ -47,6 +47,7 @@ if ( class_exists( 'WP_REST_Controller' ) ) {
 	// WordPress 6.1 compat.
 	require_once __DIR__ . '/compat/wordpress-6.1/class-gutenberg-rest-block-patterns-controller.php';
 	require_once __DIR__ . '/compat/wordpress-6.1/class-gutenberg-rest-templates-controller.php';
+	require_once __DIR__ . '/compat/wordpress-6.1/class-gutenberg-rest-navigation-controller.php';
 	require_once __DIR__ . '/compat/wordpress-6.1/rest-api.php';
 
 	// Experimental.

--- a/packages/block-library/src/navigation/edit/index.js
+++ b/packages/block-library/src/navigation/edit/index.js
@@ -207,6 +207,9 @@ function Navigation( {
 		hasResolvedCanUserCreateNavigationMenu,
 	} = useNavigationMenu( ref );
 
+	const navMenuResolvedButMissing =
+		hasResolvedNavigationMenus && isNavigationMenuMissing;
+
 	// Attempt to retrieve and prioritize any existing navigation menu unless
 	// a specific ref is allocated or the user is explicitly creating a new menu. The aim is
 	// for the block to "just work" from a user perspective using existing data.
@@ -386,6 +389,7 @@ function Navigation( {
 		if ( isSelected || isInnerBlockSelected ) {
 			if (
 				ref &&
+				! navMenuResolvedButMissing &&
 				hasResolvedCanUserUpdateNavigationMenu &&
 				! canUserUpdateNavigationMenu
 			) {


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

Please note there is now a JS alternative to this PR in https://github.com/WordPress/gutenberg/pull/42982.

## What?
This PR fixes the Nav block to avoid it showing a permissions warning for posts which don't exist. 

First reported in https://github.com/WordPress/gutenberg/pull/42735#pullrequestreview-1060340532. 

Here's a video of the bug:


https://user-images.githubusercontent.com/444434/182644853-2cca1d57-199d-4ed7-9483-7348565857af.mp4



## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

Currently the Navigation block has a `ref` which points at a Post ID of type `wp_navigation`. If this post is deleted and moved to Trash then technically it still exists but it has a `post_status` of `trashed`.

We look up Navigation posts using `getEntityRecord` which ends up in the [`get_item()` functino of the `WP_REST_Posts_Controller` class](https://github.com/WordPress/wordpress-develop/blob/4def4f82a22827bd81de8b18150962ee726af717/src/wp-includes/rest-api/endpoints/class-wp-rest-posts-controller.php#L561).

This method calls the `get_post` method _of the class_ and simply looks up by postId. This means we cannot filter the result to return only published posts.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

This PR creates a custom `Gutenberg_REST_Navigation_Controller` which overloads the `get_post` method to throw an error if the post found by the parent (i.e. `WP_REST_Posts_Controller::get_post()`) method has a status which is not either:

- publish
- draft

This ultimately means that **trashed posts will no longer be found** and returned by API calls **even if they exist**. This means that `getEntityRecord` will not find a post with a given ID if it has been trashed.

We then modify the `edit` code of the Nav block to first check if the Nav post **exists** _before_ displaying permission based messages.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->

- In Post Editor
- Add Nav block
- Create Navigation add some items and then save the Post you are editing.
- In another tab, go to http://localhost:8888/wp-admin/edit.php?post_type=wp_navigation and delete the Navigation.
- Back in the Editor tab, reload the editor.
- See warning message `Navigation menu has been deleted or is unavailable`.
- Click on the block.
- You should **not** see a permission based warning message - that's cos the post doesn't exist (or rather the API said it doesn't)!
- 

## Screenshots or screencast <!-- if applicable -->

https://user-images.githubusercontent.com/444434/182644219-35c62dde-8e63-4d18-a6f8-64a78853581a.mp4


