### PR TITLE
Fix: Just another E2E test

### DIFF
--- a/packages/e2e-tests/specs/site-editor/multi-entity-saving.test.js
+++ b/packages/e2e-tests/specs/site-editor/multi-entity-saving.test.js
@@ -207,15 +207,15 @@ describe( 'Multi-entity save flow', () => {
 			await page.keyboard.type( '...' );
 
 			await insertBlock( 'Site Tagline' );
-			// Ensure tagline is retrieved before typing.
+			// Wait for the placeholder.
 			await page.waitForXPath(
-				'//p[contains(text(), "Just another WordPress site")]'
+				'//span[@data-rich-text-placeholder="Write site tagline…"]'
 			);
 			const editableSiteTagLineSelector =
 				'.wp-block-site-tagline[contenteditable="true"]';
 			await page.waitForSelector( editableSiteTagLineSelector );
 			await page.focus( editableSiteTagLineSelector );
-			await page.keyboard.type( '...' );
+			await page.keyboard.type( 'Just another WordPress site' );
 
 			await clickButton( 'Publish' );
 			await page.waitForSelector( savePanelSelector );


### PR DESCRIPTION
## What?
Fixes multi-entity e2e test that started failing after a recent update in WP core.

## Why?
Core removed the default tagline, and this broke our selector - https://github.com/WordPress/wordpress-develop/commit/66dba67484a2e0aaa7bcafc0fa70b33d64448f74).

## How?
Update XPath selector to check for Site Tagline placeholder.

## Testing Instructions
E2E tests should pass.
