### PR TITLE
Popover: fix limitShift logic by adding iframe offset correctly (and a custom shift limiter)

### DIFF
--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -12,7 +12,7 @@
 
 -   `Button`: Remove unexpected `has-text` class when empty children are passed ([#44198](https://github.com/WordPress/gutenberg/pull/44198)).
 -   The `LinkedButton` to unlink sides in `BoxControl`, `BorderBoxControl` and `BorderRadiusControl` have changed from a rectangular primary button to an icon-only button, with a sentence case tooltip, and default-size icon for better legibility. The `Button` component has been fixed so when `isSmall` and `icon` props are set, and no text is present, the button shape is square rather than rectangular.
--   `Popover`: fix shift limit when anchor is inside an iframe [#42950](https://github.com/WordPress/gutenberg/pull/42950)).
+-   `Popover`: fix limitShift logic by adding iframe offset correctly [#42950](https://github.com/WordPress/gutenberg/pull/42950)).
 
 ### Internal
 

--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -12,6 +12,7 @@
 
 -   `Button`: Remove unexpected `has-text` class when empty children are passed ([#44198](https://github.com/WordPress/gutenberg/pull/44198)).
 -   The `LinkedButton` to unlink sides in `BoxControl`, `BorderBoxControl` and `BorderRadiusControl` have changed from a rectangular primary button to an icon-only button, with a sentence case tooltip, and default-size icon for better legibility. The `Button` component has been fixed so when `isSmall` and `icon` props are set, and no text is present, the button shape is square rather than rectangular.
+-   `Popover`: fix shift limit when anchor is inside an iframe [#42950](https://github.com/WordPress/gutenberg/pull/42950)).
 
 ### Internal
 

--- a/packages/components/src/popover/index.tsx
+++ b/packages/components/src/popover/index.tsx
@@ -338,7 +338,42 @@ const UnforwardedPopover = (
 		shouldShift
 			? shiftMiddleware( {
 					crossAxis: true,
-					limiter: limitShift(),
+					limiter: limitShift( {
+						offset: ( { placement: currentPlacement } ) => {
+							// The following calculations are aimed at allowing the floating
+							// element to shift fully below the reference element, when the
+							// reference element is in a different document (i.e. an iFrame).
+							if (
+								referenceOwnerDocument === document ||
+								frameOffsetRef.current === undefined
+							) {
+								return 0;
+							}
+
+							// The main axis (according to floating UI's docs) is the "x" axis
+							// for 'top' and 'bottom' placements, and the "y" axis for 'left'
+							// and 'right' placements.
+							const mainAxis = isTopBottomPlacement(
+								currentPlacement
+							)
+								? 'x'
+								: 'y';
+							const crossAxis = mainAxis === 'x' ? 'y' : 'x';
+
+							const crossAxisModifier = hasBeforePlacement(
+								currentPlacement
+							)
+								? -1
+								: 1;
+
+							return {
+								mainAxis: -frameOffsetRef.current[ mainAxis ],
+								crossAxis:
+									crossAxisModifier *
+									frameOffsetRef.current[ crossAxis ],
+							};
+						},
+					} ),
 					padding: 1, // Necessary to avoid flickering at the edge of the viewport.
 			  } )
 			: undefined,

--- a/packages/components/src/popover/index.tsx
+++ b/packages/components/src/popover/index.tsx
@@ -34,7 +34,6 @@ import {
 	useMemo,
 	useState,
 	useCallback,
-	useEffect,
 } from '@wordpress/element';
 import {
 	useViewportMatch,
@@ -282,11 +281,6 @@ const UnforwardedPopover = (
 	 * https://floating-ui.com/docs/react-dom#variables-inside-middleware-functions.
 	 */
 	const frameOffsetRef = useRef( getFrameOffset( referenceOwnerDocument ) );
-	/**
-	 * Store the offset prop in a ref, due to constraints with floating-ui:
-	 * https://floating-ui.com/docs/react-dom#variables-inside-middleware-functions.
-	 */
-	const offsetRef = useRef( offsetProp );
 
 	const middleware = [
 		// Custom middleware which adjusts the popover's position by taking into
@@ -389,11 +383,6 @@ const UnforwardedPopover = (
 				animationFrame: true,
 			} ),
 	} );
-
-	useEffect( () => {
-		offsetRef.current = offsetProp;
-		update();
-	}, [ offsetProp, update ] );
 
 	const arrowCallbackRef = useCallback(
 		( node ) => {

--- a/packages/components/src/popover/index.tsx
+++ b/packages/components/src/popover/index.tsx
@@ -10,7 +10,6 @@ import {
 	autoUpdate,
 	arrow,
 	offset as offsetMiddleware,
-	limitShift,
 	size,
 	Middleware,
 } from '@floating-ui/react-dom';
@@ -67,6 +66,7 @@ import type {
 	PopoverAnchorRefReference,
 	PopoverAnchorRefTopBottom,
 } from './types';
+import { limitShift as customLimitShift } from './limit-shift';
 
 /**
  * Name of slot in which popover should fill.
@@ -338,42 +338,7 @@ const UnforwardedPopover = (
 		shouldShift
 			? shiftMiddleware( {
 					crossAxis: true,
-					limiter: limitShift( {
-						offset: ( { placement: currentPlacement } ) => {
-							// The following calculations are aimed at allowing the floating
-							// element to shift fully below the reference element, when the
-							// reference element is in a different document (i.e. an iFrame).
-							if (
-								referenceOwnerDocument === document ||
-								frameOffsetRef.current === undefined
-							) {
-								return 0;
-							}
-
-							// The main axis (according to floating UI's docs) is the "x" axis
-							// for 'top' and 'bottom' placements, and the "y" axis for 'left'
-							// and 'right' placements.
-							const mainAxis = isTopBottomPlacement(
-								currentPlacement
-							)
-								? 'x'
-								: 'y';
-							const crossAxis = mainAxis === 'x' ? 'y' : 'x';
-
-							const crossAxisModifier = hasBeforePlacement(
-								currentPlacement
-							)
-								? -1
-								: 1;
-
-							return {
-								mainAxis: -frameOffsetRef.current[ mainAxis ],
-								crossAxis:
-									crossAxisModifier *
-									frameOffsetRef.current[ crossAxis ],
-							};
-						},
-					} ),
+					limiter: customLimitShift(),
 					padding: 1, // Necessary to avoid flickering at the edge of the viewport.
 			  } )
 			: undefined,

--- a/packages/components/src/popover/index.tsx
+++ b/packages/components/src/popover/index.tsx
@@ -57,6 +57,8 @@ import {
 	placementToMotionAnimationProps,
 	getReferenceOwnerDocument,
 	getReferenceElement,
+	isTopBottomPlacement,
+	hasBeforePlacement,
 } from './utils';
 import type { WordPressComponentProps } from '../ui/context';
 import type {
@@ -293,22 +295,19 @@ const UnforwardedPopover = (
 				return offsetRef.current;
 			}
 
-			const isTopBottomPlacement =
-				currentPlacement.includes( 'top' ) ||
-				currentPlacement.includes( 'bottom' );
-
 			// The main axis should represent the gap between the
 			// floating element and the reference element. The cross
 			// axis is always perpendicular to the main axis.
-			const mainAxis = isTopBottomPlacement ? 'y' : 'x';
+			const mainAxis = isTopBottomPlacement( currentPlacement )
+				? 'y'
+				: 'x';
 			const crossAxis = mainAxis === 'x' ? 'y' : 'x';
 
 			// When the popover is before the reference, subtract the offset,
 			// of the main axis else add it.
-			const hasBeforePlacement =
-				currentPlacement.includes( 'top' ) ||
-				currentPlacement.includes( 'left' );
-			const mainAxisModifier = hasBeforePlacement ? -1 : 1;
+			const mainAxisModifier = hasBeforePlacement( currentPlacement )
+				? -1
+				: 1;
 
 			return {
 				mainAxis:

--- a/packages/components/src/popover/limit-shift.ts
+++ b/packages/components/src/popover/limit-shift.ts
@@ -1,0 +1,166 @@
+/**
+ * External dependencies
+ */
+import type {
+	Axis,
+	Coords,
+	Placement,
+	Side,
+	MiddlewareArguments,
+} from '@floating-ui/react-dom';
+
+/**
+ * Temporary re-implementation of the `limitShift` function from `@floating-ui`
+ * which, compared to the original function, also takes into account the offset
+ * from the offset middleware on the main axis.
+ *
+ * All unexported types and functions are also from the `@floating-ui` library,
+ * and have been copied to this file for convenience.
+ */
+
+type LimitShiftOffset =
+	| ( ( args: MiddlewareArguments ) =>
+			| number
+			| {
+					/**
+					 * Offset the limiting of the axis that runs along the alignment of the
+					 * floating element.
+					 */
+					mainAxis?: number;
+					/**
+					 * Offset the limiting of the axis that runs along the side of the
+					 * floating element.
+					 */
+					crossAxis?: number;
+			  } )
+	| number
+	| {
+			/**
+			 * Offset the limiting of the axis that runs along the alignment of the
+			 * floating element.
+			 */
+			mainAxis?: number;
+			/**
+			 * Offset the limiting of the axis that runs along the side of the
+			 * floating element.
+			 */
+			crossAxis?: number;
+	  };
+
+type LimitShiftOptions = {
+	/**
+	 * Offset when limiting starts. `0` will limit when the opposite edges of the
+	 * reference and floating elements are aligned.
+	 * - positive = start limiting earlier
+	 * - negative = start limiting later
+	 */
+	offset: LimitShiftOffset;
+	/**
+	 * Whether to limit the axis that runs along the alignment of the floating
+	 * element.
+	 */
+	mainAxis: boolean;
+	/**
+	 * Whether to limit the axis that runs along the side of the floating element.
+	 */
+	crossAxis: boolean;
+};
+
+function getSide( placement: Placement ): Side {
+	return placement.split( '-' )[ 0 ] as Side;
+}
+
+function getMainAxisFromPlacement( placement: Placement ): Axis {
+	return [ 'top', 'bottom' ].includes( getSide( placement ) ) ? 'x' : 'y';
+}
+
+function getCrossAxis( axis: Axis ): Axis {
+	return axis === 'x' ? 'y' : 'x';
+}
+
+export const limitShift = (
+	options: Partial< LimitShiftOptions > = {}
+): {
+	options: Partial< LimitShiftOffset >;
+	fn: ( middlewareArguments: MiddlewareArguments ) => Coords;
+} => ( {
+	options,
+	fn( middlewareArguments ) {
+		const { x, y, placement, rects, middlewareData } = middlewareArguments;
+		const {
+			offset = 0,
+			mainAxis: checkMainAxis = true,
+			crossAxis: checkCrossAxis = true,
+		} = options;
+
+		const coords = { x, y };
+		const mainAxis = getMainAxisFromPlacement( placement );
+		const crossAxis = getCrossAxis( mainAxis );
+
+		let mainAxisCoord = coords[ mainAxis ];
+		let crossAxisCoord = coords[ crossAxis ];
+
+		const rawOffset =
+			typeof offset === 'function'
+				? offset( middlewareArguments )
+				: offset;
+		const computedOffset =
+			typeof rawOffset === 'number'
+				? { mainAxis: rawOffset, crossAxis: 0 }
+				: { mainAxis: 0, crossAxis: 0, ...rawOffset };
+
+		if ( checkMainAxis ) {
+			const len = mainAxis === 'y' ? 'height' : 'width';
+			const limitMin =
+				rects.reference[ mainAxis ] -
+				rects.floating[ len ] +
+				computedOffset.mainAxis +
+				// Note: the original function doesn't add the main axis offset.
+				( middlewareData.offset?.[ mainAxis ] ?? 0 );
+			const limitMax =
+				rects.reference[ mainAxis ] +
+				rects.reference[ len ] -
+				computedOffset.mainAxis +
+				// Note: the original function doesn't add the main axis offset.
+				( middlewareData.offset?.[ mainAxis ] ?? 0 );
+
+			if ( mainAxisCoord < limitMin ) {
+				mainAxisCoord = limitMin;
+			} else if ( mainAxisCoord > limitMax ) {
+				mainAxisCoord = limitMax;
+			}
+		}
+
+		if ( checkCrossAxis ) {
+			const len = mainAxis === 'y' ? 'width' : 'height';
+			const isOriginSide = [ 'top', 'left' ].includes(
+				getSide( placement )
+			);
+			const limitMin =
+				rects.reference[ crossAxis ] -
+				rects.floating[ len ] +
+				// Note: the original function only adds the cross axis offset here
+				// when `isOriginSide === true`.
+				( middlewareData.offset?.[ crossAxis ] ?? 0 ) +
+				( isOriginSide ? 0 : computedOffset.crossAxis );
+			const limitMax =
+				rects.reference[ crossAxis ] +
+				rects.reference[ len ] +
+				// Note: the original function only adds the cross axis offset here
+				// when `isOriginSide === false`.
+				( middlewareData.offset?.[ crossAxis ] ?? 0 ) -
+				( isOriginSide ? computedOffset.crossAxis : 0 );
+
+			if ( crossAxisCoord < limitMin ) {
+				crossAxisCoord = limitMin;
+			} else if ( crossAxisCoord > limitMax ) {
+				crossAxisCoord = limitMax;
+			}
+		}
+
+		return {
+			[ mainAxis ]: mainAxisCoord,
+			[ crossAxis ]: crossAxisCoord,
+		} as Coords;
+	},
+} );

--- a/packages/components/src/popover/limit-shift.ts
+++ b/packages/components/src/popover/limit-shift.ts
@@ -10,6 +10,33 @@ import type {
 } from '@floating-ui/react-dom';
 
 /**
+ * Parts of this source were derived and modified from `floating-ui`,
+ * released under the MIT license.
+ *
+ * https://github.com/floating-ui/floating-ui
+ *
+ * Copyright (c) 2021 Floating UI contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+/**
  * Custom limiter function for the `shift` middleware.
  * This function is mostly identical default `limitShift` from ``@floating-ui`;
  * the only difference is that, when computing the min/max shift limits, it

--- a/packages/components/src/popover/utils.ts
+++ b/packages/components/src/popover/utils.ts
@@ -240,3 +240,27 @@ export const getReferenceElement = ( {
 	// Convert any `undefined` value to `null`.
 	return referenceElement ?? null;
 };
+
+/**
+ * Checks the placement for a top/bottom value.
+ *
+ * @param  placement
+ * @return Whether the placement is top or bottom
+ */
+export const isTopBottomPlacement = (
+	placement: NonNullable< PopoverProps[ 'placement' ] >
+) =>
+	placement.trim().startsWith( 'top' ) ||
+	placement.trim().startsWith( 'bottom' );
+
+/**
+ * Checks the placement for a top/left value.
+ *
+ * @param  placement
+ * @return Whether the placement is top or left
+ */
+export const hasBeforePlacement = (
+	placement: NonNullable< PopoverProps[ 'placement' ] >
+) =>
+	placement.trim().startsWith( 'top' ) ||
+	placement.trim().startsWith( 'left' );

--- a/packages/components/src/popover/utils.ts
+++ b/packages/components/src/popover/utils.ts
@@ -240,27 +240,3 @@ export const getReferenceElement = ( {
 	// Convert any `undefined` value to `null`.
 	return referenceElement ?? null;
 };
-
-/**
- * Checks the placement for a top/bottom value.
- *
- * @param  placement
- * @return Whether the placement is top or bottom
- */
-export const isTopBottomPlacement = (
-	placement: NonNullable< PopoverProps[ 'placement' ] >
-) =>
-	placement.trim().startsWith( 'top' ) ||
-	placement.trim().startsWith( 'bottom' );
-
-/**
- * Checks the placement for a top/left value.
- *
- * @param  placement
- * @return Whether the placement is top or left
- */
-export const hasBeforePlacement = (
-	placement: NonNullable< PopoverProps[ 'placement' ] >
-) =>
-	placement.trim().startsWith( 'top' ) ||
-	placement.trim().startsWith( 'left' );


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

Tracked in #42770
Follows up to the experimentation done in #42531

## What?
<!-- In a few words, what is the PR actually doing? -->

This PR:
- moves the code that adds a the iframe offset from the `offset` middleware back into its own custom middleware, and
- adds a custom `limitShift` function in order that the iframe offset is taken into account correctly when shifting at the edges of the viewport.



## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

Currently, when the anchor is inside an `iframe` and the `Popover` has shifting enabled, the popover stops its shifting on top of its anchor instead of shifting past it.

The main issue is that the default `limitShift` function [has some custom logic when computing the min/max limits for the shifting popover](https://github.com/floating-ui/floating-ui/blob/1073602c7a42a9ad764fe6330f773c57322a1d65/packages/core/src/middleware/shift.ts#L176-L213). This logic presents some "limitations" (pun not intended) for our case:

- it adds the offset from the `offset` middleware only on the `crossAxis`
- even on the `crossAxis`, it adds that offset conditionally, based on the popover's `placement` ([min](https://github.com/floating-ui/floating-ui/blob/1073602c7a42a9ad764fe6330f773c57322a1d65/packages/core/src/middleware/shift.ts#L200), [max](https://github.com/floating-ui/floating-ui/blob/1073602c7a42a9ad764fe6330f773c57322a1d65/packages/core/src/middleware/shift.ts#L205))

I initially tried compensating for the extra iframe offset via the `offset` option for the default `limitShift` function, but that also doesn't work because that offset is added when computing the max limits, but is subtracted when computing the min limits — while, in our case, we'd _always_ need to add the iframe offset.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

Based on the findings written above, the only solution is to add a custom `limiter` function for the `shift` middleware.

The new function is a modified version of [the default `limitShift` function](https://github.com/floating-ui/floating-ui/blob/1073602c7a42a9ad764fe6330f773c57322a1d65/packages/core/src/middleware/shift.ts#L147-L220). The only change is that we're always adding the extra offset for the `iframe` when computing min/max limits.

Another necessary change was to move the addition of the `iframe` offset to its own custom middleware. This has 2 advantages:

- it removes the complex logic that we had to write for the `offset` middleware
- it allows us to pass the iframe offset amount to the custom `limiter` function as a separate value from the _regular_ `offset`


## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->

No change should be introduced for Popovers where the anchor is inside the same `document` as the popover

The easiest way to test for these changes is to observe the behavior of the block toolbar in the site editor.

Here's what I've tweaking during my tests:
- increasing the height of the toolbar on top of the iframe to test different iframe y offsets
- adding left padding to the iframe's wrapper to test different iframe x offsets
- passing an `offset` number to the popover in the block toolbar
- testing different `placement` options for the popover in the block toolbar (i.e top, bottom, left, right)

To make sure the behavior is the correct / expected one, compare the behavior of the block toolbar in the site editor (with iframe) against the behavior of the block toolbar in the post editor (no iframe).

## Screenshots or screencast <!-- if applicable -->

`trunk`:

https://user-images.githubusercontent.com/1083581/186616098-06f0790a-d3e1-4297-8f9f-1bad0dd92151.mp4

This PR:

https://user-images.githubusercontent.com/1083581/186615624-52d8ab55-4582-4e6e-8479-4602fbaa2569.mp4


