### PR TITLE
Fix styles declarations returning before all properties output

### DIFF
--- a/packages/edit-site/src/components/global-styles/test/use-global-styles-output.js
+++ b/packages/edit-site/src/components/global-styles/test/use-global-styles-output.js
@@ -13,6 +13,7 @@ import {
 	getBlockSelectors,
 	toCustomProperties,
 	toStyles,
+	getStylesDeclarations,
 } from '../use-global-styles-output';
 import { ROOT_BLOCK_SELECTOR } from '../utils';
 
@@ -679,6 +680,62 @@ describe( 'global styles renderer', () => {
 					hasLayoutSupport: false,
 				},
 			} );
+		} );
+	} );
+
+	describe( 'getStylesDeclarations', () => {
+		const blockStyles = {
+			spacing: {
+				padding: {
+					top: '33px',
+					right: '33px',
+					bottom: '33px',
+					left: '33px',
+				},
+			},
+			color: {
+				background: 'var:preset|color|light-green-cyan',
+			},
+		};
+
+		it( 'Should output padding variables and other properties if useRootPaddingAwareAlignments is enabled', () => {
+			expect(
+				getStylesDeclarations( blockStyles, 'body', true )
+			).toEqual( [
+				'--wp--style--root--padding-top: 33px',
+				'--wp--style--root--padding-right: 33px',
+				'--wp--style--root--padding-bottom: 33px',
+				'--wp--style--root--padding-left: 33px',
+				'background-color: var(--wp--preset--color--light-green-cyan)',
+			] );
+		} );
+
+		it( 'Should output padding and other properties if useRootPaddingAwareAlignments is disabled', () => {
+			expect(
+				getStylesDeclarations( blockStyles, 'body', false )
+			).toEqual( [
+				'background-color: var(--wp--preset--color--light-green-cyan)',
+				'padding-top: 33px',
+				'padding-right: 33px',
+				'padding-bottom: 33px',
+				'padding-left: 33px',
+			] );
+		} );
+
+		it( 'Should not output padding variables if selector is not root', () => {
+			expect(
+				getStylesDeclarations(
+					blockStyles,
+					'.wp-block-button__link',
+					true
+				)
+			).toEqual( [
+				'background-color: var(--wp--preset--color--light-green-cyan)',
+				'padding-top: 33px',
+				'padding-right: 33px',
+				'padding-bottom: 33px',
+				'padding-left: 33px',
+			] );
 		} );
 	} );
 } );

--- a/packages/edit-site/src/components/global-styles/test/use-global-styles-output.js
+++ b/packages/edit-site/src/components/global-styles/test/use-global-styles-output.js
@@ -696,12 +696,16 @@ describe( 'global styles renderer', () => {
 			color: {
 				background: 'var:preset|color|light-green-cyan',
 			},
+			typography: {
+				fontFamily: 'sans-serif',
+			},
 		};
 
 		it( 'Should output padding variables and other properties if useRootPaddingAwareAlignments is enabled', () => {
 			expect(
 				getStylesDeclarations( blockStyles, 'body', true )
 			).toEqual( [
+				'font-family: sans-serif',
 				'--wp--style--root--padding-top: 33px',
 				'--wp--style--root--padding-right: 33px',
 				'--wp--style--root--padding-bottom: 33px',
@@ -714,6 +718,7 @@ describe( 'global styles renderer', () => {
 			expect(
 				getStylesDeclarations( blockStyles, 'body', false )
 			).toEqual( [
+				'font-family: sans-serif',
 				'background-color: var(--wp--preset--color--light-green-cyan)',
 				'padding-top: 33px',
 				'padding-right: 33px',
@@ -730,6 +735,7 @@ describe( 'global styles renderer', () => {
 					true
 				)
 			).toEqual( [
+				'font-family: sans-serif',
 				'background-color: var(--wp--preset--color--light-green-cyan)',
 				'padding-top: 33px',
 				'padding-right: 33px',

--- a/packages/edit-site/src/components/global-styles/use-global-styles-output.js
+++ b/packages/edit-site/src/components/global-styles/use-global-styles-output.js
@@ -214,9 +214,8 @@ export function getStylesDeclarations(
 			// Root-level padding styles don't currently support strings with CSS shorthand values.
 			// This may change: https://github.com/WordPress/gutenberg/issues/40132.
 			if (
-				( key === '--wp--style--root--padding' &&
-					typeof styleValue === 'string' ) ||
-				! useRootPaddingAlign
+				key === '--wp--style--root--padding' &&
+				( typeof styleValue === 'string' || ! useRootPaddingAlign )
 			) {
 				return declarations;
 			}


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Fixes #42913.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

When `useRootPaddingAwareAlignments` is set, `getStylesDeclarations` returns before all the global style properties are output. This means colour changes in global styles aren't reflected in the editor.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

Change the function logic so it only omits `padding` properties when `useRootPaddingAwareAlignments` is enabled, as well as _not_ outputting the variables if the setting is disabled.

Adds tests to check for correct behaviour.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->

1. In theme.json settings, add `"useRootPaddingAwareAlignments": true`;
2. In the global styles sidebar in the site editor, change the color or background settings;
3. Check that those changes have a visible effect in the editor;
4. Change `"useRootPaddingAwareAlignments"` back to `false`;
5. Check that everything still works as expected.
6. As a bonus, check that either the variables _or_ the padding properties are output for `.editor-styles-wrapper`, but not both.

## Screenshots or screencast <!-- if applicable -->
