### PR TITLE
Fix navigation select menu focus loss

### DIFF
--- a/packages/block-library/src/navigation/edit/index.js
+++ b/packages/block-library/src/navigation/edit/index.js
@@ -191,7 +191,6 @@ function Navigation( {
 		isNavigationMenuResolved,
 		isNavigationMenuMissing,
 		navigationMenus,
-		navigationMenu,
 		canUserUpdateNavigationMenu,
 		hasResolvedCanUserUpdateNavigationMenu,
 		canUserDeleteNavigationMenu,
@@ -239,8 +238,6 @@ function Navigation( {
 	}, [ navigationMenus ] );
 
 	const navRef = useRef();
-
-	const isDraftNavigationMenu = navigationMenu?.status === 'draft';
 
 	const {
 		convert: convertClassicMenu,
@@ -331,11 +328,6 @@ function Navigation( {
 	] = useState();
 	const [ detectedOverlayColor, setDetectedOverlayColor ] = useState();
 
-	const handleUpdateMenu = ( menuId ) => {
-		setRef( menuId );
-		selectBlock( clientId );
-	};
-
 	useEffect( () => {
 		hideClassicMenuConversionNotice();
 		if ( classicMenuConversionStatus === CLASSIC_MENU_CONVERSION_PENDING ) {
@@ -424,27 +416,6 @@ function Navigation( {
 		canUserCreateNavigationMenu,
 		hasResolvedCanUserCreateNavigationMenu,
 		ref,
-	] );
-
-	const navigationSelectorRef = useRef();
-	const [ shouldFocusNavigationSelector, setShouldFocusNavigationSelector ] =
-		useState( false );
-
-	// Focus support after menu selection.
-	useEffect( () => {
-		if (
-			isDraftNavigationMenu ||
-			! isEntityAvailable ||
-			! shouldFocusNavigationSelector
-		) {
-			return;
-		}
-		navigationSelectorRef?.current?.focus();
-		setShouldFocusNavigationSelector( false );
-	}, [
-		isDraftNavigationMenu,
-		isEntityAvailable,
-		shouldFocusNavigationSelector,
 	] );
 
 	const isResponsive = 'never' !== overlayMenu;
@@ -598,21 +569,16 @@ function Navigation( {
 				<BlockControls>
 					<ToolbarGroup className="wp-block-navigation__toolbar-menu-selector">
 						<NavigationMenuSelector
-							ref={ null }
-							currentMenuId={ null }
+							currentMenuId={ ref }
 							clientId={ clientId }
-							onSelectNavigationMenu={ ( menuId ) => {
-								handleUpdateMenu( menuId );
-								setShouldFocusNavigationSelector( true );
-							} }
+							onSelectNavigationMenu={ setRef }
 							onSelectClassicMenu={ async ( classicMenu ) => {
 								const navMenu = await convertClassicMenu(
 									classicMenu.id,
 									classicMenu.name
 								);
 								if ( navMenu ) {
-									handleUpdateMenu( navMenu.id );
-									setShouldFocusNavigationSelector( true );
+									setRef( navMenu.id );
 								}
 							} }
 							onCreateNew={ () => createNavigationMenu( '', [] ) }
@@ -658,28 +624,22 @@ function Navigation( {
 	}
 
 	// Show a warning if the selected menu is no longer available.
-	// TODO - the user should be able to select a new one?
 	if ( ref && isNavigationMenuMissing ) {
 		return (
 			<TagName { ...blockProps }>
 				<BlockControls>
 					<ToolbarGroup className="wp-block-navigation__toolbar-menu-selector">
 						<NavigationMenuSelector
-							ref={ navigationSelectorRef }
 							currentMenuId={ ref }
 							clientId={ clientId }
-							onSelectNavigationMenu={ ( menuId ) => {
-								handleUpdateMenu( menuId );
-								setShouldFocusNavigationSelector( true );
-							} }
+							onSelectNavigationMenu={ setRef }
 							onSelectClassicMenu={ async ( classicMenu ) => {
 								const navMenu = await convertClassicMenu(
 									classicMenu.id,
 									classicMenu.name
 								);
 								if ( navMenu ) {
-									handleUpdateMenu( navMenu.id );
-									setShouldFocusNavigationSelector( true );
+									setRef( navMenu.id );
 								}
 							} }
 							onCreateNew={ () => createNavigationMenu( '', [] ) }
@@ -740,8 +700,8 @@ function Navigation( {
 						isResolvingCanUserCreateNavigationMenu
 					}
 					onSelectNavigationMenu={ ( menuId ) => {
-						handleUpdateMenu( menuId );
-						setShouldFocusNavigationSelector( true );
+						setRef( menuId );
+						selectBlock( clientId );
 					} }
 					onSelectClassicMenu={ async ( classicMenu ) => {
 						const navMenu = await convertClassicMenu(
@@ -749,8 +709,8 @@ function Navigation( {
 							classicMenu.name
 						);
 						if ( navMenu ) {
-							handleUpdateMenu( navMenu.id );
-							setShouldFocusNavigationSelector( true );
+							setRef( navMenu.id );
+							selectBlock( clientId );
 						}
 					} }
 					onCreateEmpty={ () => createNavigationMenu( '', [] ) }
@@ -763,37 +723,26 @@ function Navigation( {
 		<EntityProvider kind="postType" type="wp_navigation" id={ ref }>
 			<RecursionProvider uniqueId={ recursionId }>
 				<BlockControls>
-					{ ! isDraftNavigationMenu && isEntityAvailable && (
-						<ToolbarGroup className="wp-block-navigation__toolbar-menu-selector">
-							<NavigationMenuSelector
-								ref={ navigationSelectorRef }
-								currentMenuId={ ref }
-								clientId={ clientId }
-								onSelectNavigationMenu={ ( menuId ) => {
-									handleUpdateMenu( menuId );
-									setShouldFocusNavigationSelector( true );
-								} }
-								onSelectClassicMenu={ async ( classicMenu ) => {
-									const navMenu = await convertClassicMenu(
-										classicMenu.id,
-										classicMenu.name
-									);
-									if ( navMenu ) {
-										handleUpdateMenu( navMenu.id );
-										setShouldFocusNavigationSelector(
-											true
-										);
-									}
-								} }
-								onCreateNew={ () =>
-									createNavigationMenu( '', [] )
+					<ToolbarGroup className="wp-block-navigation__toolbar-menu-selector">
+						<NavigationMenuSelector
+							currentMenuId={ ref }
+							clientId={ clientId }
+							onSelectNavigationMenu={ setRef }
+							onSelectClassicMenu={ async ( classicMenu ) => {
+								const navMenu = await convertClassicMenu(
+									classicMenu.id,
+									classicMenu.name
+								);
+								if ( navMenu ) {
+									setRef( navMenu.id );
 								}
-								/* translators: %s: The name of a menu. */
-								actionLabel={ __( "Switch to '%s'" ) }
-								showManageActions
-							/>
-						</ToolbarGroup>
-					) }
+							} }
+							onCreateNew={ () => createNavigationMenu( '', [] ) }
+							/* translators: %s: The name of a menu. */
+							actionLabel={ __( "Switch to '%s'" ) }
+							showManageActions
+						/>
+					</ToolbarGroup>
 				</BlockControls>
 				{ stylingInspectorControls }
 				{ isEntityAvailable && (

--- a/packages/block-library/src/navigation/edit/navigation-menu-selector.js
+++ b/packages/block-library/src/navigation/edit/navigation-menu-selector.js
@@ -10,7 +10,7 @@ import {
 import { __, sprintf } from '@wordpress/i18n';
 import { decodeEntities } from '@wordpress/html-entities';
 import { addQueryArgs } from '@wordpress/url';
-import { forwardRef, useMemo } from '@wordpress/element';
+import { useMemo } from '@wordpress/element';
 
 /**
  * Internal dependencies
@@ -18,18 +18,15 @@ import { forwardRef, useMemo } from '@wordpress/element';
 import useNavigationMenu from '../use-navigation-menu';
 import useNavigationEntities from '../use-navigation-entities';
 
-function NavigationMenuSelector(
-	{
-		currentMenuId,
-		onSelectNavigationMenu,
-		onSelectClassicMenu,
-		onCreateNew,
-		showManageActions = false,
-		actionLabel,
-		toggleProps = {},
-	},
-	forwardedRef
-) {
+export default function NavigationMenuSelector( {
+	currentMenuId,
+	onSelectNavigationMenu,
+	onSelectClassicMenu,
+	onCreateNew,
+	showManageActions = false,
+	actionLabel,
+	toggleProps = {},
+} ) {
 	/* translators: %s: The name of a menu. */
 	const createActionLabel = __( "Create from '%s'" );
 
@@ -78,7 +75,6 @@ function NavigationMenuSelector(
 
 	return (
 		<ToolbarDropdownMenu
-			ref={ forwardedRef }
 			label={ __( 'Select Menu' ) }
 			text={ __( 'Select Menu' ) }
 			icon={ null }
@@ -90,10 +86,7 @@ function NavigationMenuSelector(
 						<MenuGroup label={ __( 'Menus' ) }>
 							<MenuItemsChoice
 								value={ currentMenuId }
-								onSelect={ ( menuId ) => {
-									onClose();
-									onSelectNavigationMenu( menuId );
-								} }
+								onSelect={ onSelectNavigationMenu }
 								choices={ menuChoices }
 							/>
 						</MenuGroup>
@@ -142,5 +135,3 @@ function NavigationMenuSelector(
 		</ToolbarDropdownMenu>
 	);
 }
-
-export default forwardRef( NavigationMenuSelector );

--- a/packages/e2e-tests/specs/editor/blocks/navigation.test.js
+++ b/packages/e2e-tests/specs/editor/blocks/navigation.test.js
@@ -1681,13 +1681,10 @@ Expected mock function not to be called but it was called with: ["POST", "http:/
 			);
 		} );
 
-		// Skip reason: running it in interactive works but selecting and
-		// checking for focus consistently fails in the test.
-		// eslint-disable-next-line jest/no-disabled-tests
-		it.skip( 'should always focus select menu button after item selection', async () => {
+		it( 'keeps focus the menu item after navigation menu selection', async () => {
 			// Create some navigation menus to work with.
 			await createNavigationMenu( {
-				title: 'First navigation',
+				title: 'First Example Navigation',
 				content:
 					'<!-- wp:navigation-link {"label":"WordPress Example Navigation","type":"custom","url":"http://www.wordpress.org/","kind":"custom","isTopLevelLink":true} /-->',
 			} );
@@ -1703,23 +1700,26 @@ Expected mock function not to be called but it was called with: ["POST", "http:/
 			// Insert new block and wait for the insert to complete.
 			await insertBlock( 'Navigation' );
 			await waitForBlock( 'Navigation' );
-
-			const navigationSelector = await page.waitForXPath(
-				"//button[text()='Select Menu']"
-			);
-			await navigationSelector.click();
-
-			const theOption = await page.waitForXPath(
-				"//button[@aria-checked='false'][contains(., 'First navigation')]"
-			);
-			theOption.click();
-
-			// Once the options are closed, does select menu button receive focus?
-			const selectMenuDropdown2 = await page.$(
+			// First select a menu from the block placeholder
+			const selectMenuDropdown = await page.waitForSelector(
 				'[aria-label="Select Menu"]'
 			);
+			await selectMenuDropdown.click();
+			const firstNavigationOption = await page.waitForXPath(
+				'//button[.="First Example Navigation"]'
+			);
+			await firstNavigationOption.click();
 
-			await expect( selectMenuDropdown2 ).toHaveFocus();
+			// Next switch menu using the toolbar.
+			await clickBlockToolbarButton( 'Select Menu' );
+
+			const secondNavigationOption = await page.waitForXPath(
+				'//button[.="Second Example Navigation"]'
+			);
+			await secondNavigationOption.click();
+
+			// The menu item should still have focus.
+			await expect( secondNavigationOption ).toHaveFocus();
 		} );
 	} );
 } );


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Fixes #38169

After #42916, it's now possible to fix this issue properly. The previous temporary fix in #40390 had the trade-off that it wasn't possible to keep the dropdown menu open when switching menus, but with this fix that's now possible.

## How?
This a much bigger change than I anticipated, but it's good that it resulted in more code removed than added.

I had to remove:
- The code added in #40390 that was a temporary solution to the problem.
- Conditional rendering of the menu selector dropdown (I don't think it's needed anymore).
- The `selectBlock` calls when switching menus in some places. This particular point required quite a lot of refactoring, and I found I could delete quite a bit of code anyway.

## Testing Instructions
1. Open the site editor
2. Select a nav block and try switching between nav menus

## Screenshots or screencast <!-- if applicable -->
### Before

https://user-images.githubusercontent.com/677833/182577671-017b32d6-f144-4cc1-98a8-df47c1898c98.mp4


### After

https://user-images.githubusercontent.com/677833/182576892-c00c8fc5-cd06-411b-854e-733d6390ac87.mp4