### PR TITLE
REST API: Add the missing 'site_icon_url' to the index

### DIFF
--- a/lib/compat/wordpress-6.1/rest-api.php
+++ b/lib/compat/wordpress-6.1/rest-api.php
@@ -43,3 +43,19 @@ function gutenberg_register_gutenberg_rest_block_patterns() {
 	$block_patterns->register_routes();
 }
 add_action( 'rest_api_init', 'gutenberg_register_gutenberg_rest_block_patterns', 100 );
+
+/**
+ * Exposes the site logo URL through the WordPress REST API.
+ *
+ * This is used for fetching this information when user has no rights
+ * to update settings.
+ *
+ * @param WP_REST_Response $response REST API response.
+ * @return WP_REST_Response $response REST API response.
+ */
+function gutenberg_add_site_icon_url_to_index( WP_REST_Response $response ) {
+	$response->data['site_icon_url'] = get_site_icon_url();
+
+	return $response;
+}
+add_action( 'rest_index', 'gutenberg_add_site_icon_url_to_index' );

--- a/lib/compat/wordpress-6.1/rest-api.php
+++ b/lib/compat/wordpress-6.1/rest-api.php
@@ -50,6 +50,8 @@ add_action( 'rest_api_init', 'gutenberg_register_gutenberg_rest_block_patterns',
  * This is used for fetching this information when user has no rights
  * to update settings.
  *
+ * Note: Backports into wp-includes/rest-api/class-wp-rest-server.php file.
+ *
  * @param WP_REST_Response $response REST API response.
  * @return WP_REST_Response $response REST API response.
  */


### PR DESCRIPTION
## What?
Fixes #42943.
Regressed in #41306.

Fixes bug when site logo doesn't replace WordPress logo in the toolbar. We forgot to backport the `site_icon_url` REST index into the core.

## Why?
It was feature regression.

## How?
Adds the `site_icon_url` index using `rest_index`. Alternatively, we can update components to use the `site_icon` ID and the fetch image on the client side.

## Testing Instructions
1. Go to Appearance > Editor.
2. Add a Site Logo block.
3. Add a logo.
4. In the block settings for the Site Logo block, toggle on the "Use as site icon" option.
5. Refresh and confirm that the W icon updates in the Navigation button.

## Screenshots or screencast <!-- if applicable -->

![CleanShot 2022-08-04 at 09 30 28](https://user-images.githubusercontent.com/240569/182770203-52684954-0880-4033-9766-1945a8d99379.png)

