### PR TITLE
Search Block: Remove margins from the input

### DIFF
--- a/packages/block-library/src/search/style.scss
+++ b/packages/block-library/src/search/style.scss
@@ -34,6 +34,8 @@
 .wp-block-search__input {
 	padding: 8px;
 	flex-grow: 1;
+	margin-left: 0;
+	margin-right: 0;
 	min-width: 3em;
 	border: 1px solid #949494;
 	font-size: inherit;


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
In Safari, input field have margins by default. To achieve a consistent design across all browsers we should remove these margins. This PR remove the left and right margins on the input.

Before:
<img width="1411" alt="Screenshot 2022-08-04 at 08 08 15" src="https://user-images.githubusercontent.com/275961/182785458-8d294a13-6030-428c-b9b8-63df36dcd2d5.png">


After:
<img width="1380" alt="Screenshot 2022-08-04 at 08 06 19" src="https://user-images.githubusercontent.com/275961/182785205-c33d9370-436f-480e-9ec8-b02fe7914556.png">


## Testing Instructions
- Add a search block to a post and view it in Safari.
- Notice that there is no gap between the input and the button

@WordPress/block-themers 
