### PR TITLE
Navigation: Try removing :where for menu show/hiding

### DIFF
--- a/packages/block-library/src/navigation/style.scss
+++ b/packages/block-library/src/navigation/style.scss
@@ -154,10 +154,7 @@ $navigation-icon-size: 24px;
 // Styles for submenu flyout.
 // These are separated out with reduced specificity to allow better inheritance from Global Styles.
 .wp-block-navigation .has-child {
-	// We use :where to keep specificity minimal, yet still scope it to only the navigation block.
-	// That way if padding is set in theme.json, it still wins.
-	// https://css-tricks.com/almanac/selectors/w/where/
-	:where(.wp-block-navigation__submenu-container) {
+	.wp-block-navigation__submenu-container {
 		background-color: inherit;
 		color: inherit;
 		position: absolute;
@@ -233,7 +230,7 @@ $navigation-icon-size: 24px;
 
 	// Custom menu items.
 	// Show submenus on hover unless they open on click.
-	&:where(:not(.open-on-click)):hover > .wp-block-navigation__submenu-container {
+	&:not(.open-on-click):hover > .wp-block-navigation__submenu-container {
 		visibility: visible;
 		overflow: visible;
 		opacity: 1;
@@ -243,7 +240,7 @@ $navigation-icon-size: 24px;
 	}
 
 	// Keep submenus open when focus is within.
-	&:where(:not(.open-on-click):not(.open-on-hover-click)):focus-within > .wp-block-navigation__submenu-container {
+	&:not(.open-on-click):not(.open-on-hover-click):focus-within > .wp-block-navigation__submenu-container {
 		visibility: visible;
 		overflow: visible;
 		opacity: 1;


### PR DESCRIPTION
## What?

Aims to address #39230.

Global styles outputs CSS rules from theme.json with delicate specificity, just targetting a specific element. In some places, the `:where` selector has been used to reduce specificity of _default_ rules, so that those can exist but still be easily overridden by global styles.

In the case of submenus showing/hiding, this has proven problematic in terms of affecting too fundamental a behavior, with insufficient browser support. See also discussion in #39621.

This PR removes the `:where` selector for submenus, ideally addressing that problem.

## Why?

Why was the `:where` selector added in the first place? It was added to allow us to provide a default padding _when the menu had a background_, so that menu items wouldn't be flush against the edge, like so:

<img width="741" alt="Screenshot 2022-08-04 at 10 14 53" src="https://user-images.githubusercontent.com/1204802/182798513-c91c5714-c0e0-40d1-8f24-be5e55465c76.png">

— while still allowing padding rules set in theme.json to override those default paddings. For example using the following in theme.json:

```
	"blocks": {
		"core/navigation-link": {
			"elements" : {
				"link": {
					"spacing": {
						"padding" : {
							"top" : "1.5em",
							"right": "2em",
							"bottom": "1.5em",
							"left": "2em"
						}
					}
				}
			}
		}
	},
```

However, and perhaps due to changes in how theme.json outputs styles, custom theme.json provided paddings are broken in trunk at the moment. In the following GIF, the above theme.json rules are shown working in the editor, but not on the frontend:

![custom paddings before and after](https://user-images.githubusercontent.com/1204802/182799496-5004b2e7-0802-4f73-9c58-6341e0f19f7c.gif)

The above GIF represents the behavior both fo trunk and of this branch. Given that's the case, presumably we can remove the `:where` selector for menu show/hiding, as the net result would be the same.

I will follow up with a separate PR for a new approach to padding and theme.json.

## Testing Instructions

This needs very thorough testing:

* It needs to be tested across classic and block themes (but please note that TT1 heavily customizes an older version of the navigation block, so that theme requires an extra careful debugging in light of what CSS comes from the theme and what comes from the block. More context in #31878).
* It needs testing across mobile and desktop.

Across that matrix, please also test:

* Open on click vs. hover/focus behaviors
* Test that the original issue reported in #39230 is addressed by this PR.
* Test with and without theme.json customization of menu item paddings and backgrounds. To an extent expect it to be slightly broken both in trunk and in this branch, however this is still good to validate.