### PR TITLE
Navigation: Try removing :where rules for padding and changing the default behavior

### DIFF
--- a/packages/block-library/src/navigation/style.scss
+++ b/packages/block-library/src/navigation/style.scss
@@ -154,10 +154,7 @@ $navigation-icon-size: 24px;
 // Styles for submenu flyout.
 // These are separated out with reduced specificity to allow better inheritance from Global Styles.
 .wp-block-navigation .has-child {
-	// We use :where to keep specificity minimal, yet still scope it to only the navigation block.
-	// That way if padding is set in theme.json, it still wins.
-	// https://css-tricks.com/almanac/selectors/w/where/
-	:where(.wp-block-navigation__submenu-container) {
+	.wp-block-navigation__submenu-container {
 		background-color: inherit;
 		color: inherit;
 		position: absolute;
@@ -233,7 +230,7 @@ $navigation-icon-size: 24px;
 
 	// Custom menu items.
 	// Show submenus on hover unless they open on click.
-	&:where(:not(.open-on-click)):hover > .wp-block-navigation__submenu-container {
+	&:not(.open-on-click):hover > .wp-block-navigation__submenu-container {
 		visibility: visible;
 		overflow: visible;
 		opacity: 1;
@@ -243,7 +240,7 @@ $navigation-icon-size: 24px;
 	}
 
 	// Keep submenus open when focus is within.
-	&:where(:not(.open-on-click):not(.open-on-hover-click)):focus-within > .wp-block-navigation__submenu-container {
+	&:not(.open-on-click):not(.open-on-hover-click):focus-within > .wp-block-navigation__submenu-container {
 		visibility: visible;
 		overflow: visible;
 		opacity: 1;

--- a/packages/block-library/src/navigation/style.scss
+++ b/packages/block-library/src/navigation/style.scss
@@ -45,9 +45,6 @@ $navigation-icon-size: 24px;
 	// but still allow them to be overridden by user-set colors.
 	.wp-block-navigation-item__content {
 		display: block;
-
-		// Set the default menu item padding to zero, to allow text-only buttons.
-		padding: 0;
 	}
 
 	// The following rules provide class based application of user selected text
@@ -336,36 +333,6 @@ button.wp-block-navigation-item__content {
 	gap: inherit;
 }
 
-// Menu items with background.
-// We use :where to keep specificity minimal, yet still scope it to only the navigation block.
-// That way if padding is set in theme.json, it still wins.
-// https://css-tricks.com/almanac/selectors/w/where/
-.wp-block-navigation:where(.has-background) {
-	&,
-	.wp-block-navigation .wp-block-page-list,
-	.wp-block-navigation__container {
-		gap: inherit;
-	}
-}
-
-/**
- * Paddings
- */
-
-// We use :where to keep specificity minimal, yet still scope it to only the navigation block.
-// That way if padding is set in theme.json, it still wins.
-// https://css-tricks.com/almanac/selectors/w/where/
-
-// When the menu has a background, items have paddings, reduce margins to compensate.
-// Treat margins and paddings differently when the block has a background.
-.wp-block-navigation:where(.has-background) .wp-block-navigation-item__content {
-	padding: 0.5em 1em;
-}
-
-// Provide a default padding for submenus who should always have some, regardless of the top level menu items.
-.wp-block-navigation :where(.wp-block-navigation__submenu-container) .wp-block-navigation-item__content {
-	padding: 0.5em 1em;
-}
 
 /**
  * Justifications.


### PR DESCRIPTION
## What?

Followup to #42964 and merges into it. 

This is a separate PR in order to not block the other one, which may be more important.

## Why?

As noted in #42964, customizing the padding of menu items using theme.json is currently broken. Example code:

```
	"blocks": {
		"core/navigation-link": {
			"elements" : {
				"link": {
					"spacing": {
						"padding" : {
							"top" : "1.5em",
							"right": "2em",
							"bottom": "1.5em",
							"left": "2em"
						}
					}
				}
			}
		}
	},
```

This PR enables that to work. 

![after](https://user-images.githubusercontent.com/1204802/182800871-0b764998-0ab8-4e88-b04a-598c6e99673d.gif)

## How?

The main change is removing the default menu item padding that the block ships with. Meaning that if you apply a background color to the main navigation block, no padding is added, text sits flush against the edge:

<img width="739" alt="main change" src="https://user-images.githubusercontent.com/1204802/182801028-a196eff1-3a14-4664-9327-0b31936ce551.png">

**This includes padding for submenu items**:

![submenus](https://user-images.githubusercontent.com/1204802/182801914-854e07b4-68cb-4efb-91c1-a5817643e885.gif)

That is the main tradeoff of this PR. Could we mitigate this with surfacing the padding control for the main navigation block in the inspector?

A side benefit of removing that default padding, outside of enabling theme.json to work, is that it removes additional `:where` rules. See #39230 for more.

## Testing Instructions

Please follow the same testing instructions as those outlined in #42964, but with the added testing of submenus in themes that do not customize navigation item paddings.