### PR TITLE
Navigation: Try to keep :where just for paddings

### DIFF
--- a/packages/block-library/src/navigation/style.scss
+++ b/packages/block-library/src/navigation/style.scss
@@ -344,12 +344,14 @@ button.wp-block-navigation-item__content {
 
 // When the menu has a background, items have paddings, reduce margins to compensate.
 // Treat margins and paddings differently when the block has a background.
-:where(.wp-block-navigation.has-background .wp-block-navigation-link a:not(.wp-element-button)) {
+:where(.wp-block-navigation.has-background .wp-block-navigation-link a:not(.wp-element-button)),
+:where(.wp-block-navigation.has-background .wp-block-navigation-submenu a:not(.wp-element-button)) {
 	padding: 0.5em 1em;
 }
 
 // Provide a default padding for submenus who should always have some, regardless of the top level menu items.
-:where(.wp-block-navigation .wp-block-navigation__submenu-container .wp-block-navigation-link a:not(.wp-element-button)) {
+:where(.wp-block-navigation .wp-block-navigation__submenu-container .wp-block-navigation-link a:not(.wp-element-button)),
+:where(.wp-block-navigation .wp-block-navigation__submenu-container .wp-block-navigation-submenu a:not(.wp-element-button)) {
 	padding: 0.5em 1em;
 }
 

--- a/packages/block-library/src/navigation/style.scss
+++ b/packages/block-library/src/navigation/style.scss
@@ -45,9 +45,6 @@ $navigation-icon-size: 24px;
 	// but still allow them to be overridden by user-set colors.
 	.wp-block-navigation-item__content {
 		display: block;
-
-		// Set the default menu item padding to zero, to allow text-only buttons.
-		padding: 0;
 	}
 
 	// The following rules provide class based application of user selected text
@@ -336,17 +333,6 @@ button.wp-block-navigation-item__content {
 	gap: inherit;
 }
 
-// Menu items with background.
-// We use :where to keep specificity minimal, yet still scope it to only the navigation block.
-// That way if padding is set in theme.json, it still wins.
-// https://css-tricks.com/almanac/selectors/w/where/
-.wp-block-navigation:where(.has-background) {
-	&,
-	.wp-block-navigation .wp-block-page-list,
-	.wp-block-navigation__container {
-		gap: inherit;
-	}
-}
 
 /**
  * Paddings
@@ -358,14 +344,15 @@ button.wp-block-navigation-item__content {
 
 // When the menu has a background, items have paddings, reduce margins to compensate.
 // Treat margins and paddings differently when the block has a background.
-.wp-block-navigation:where(.has-background) .wp-block-navigation-item__content {
+:where(.wp-block-navigation.has-background .wp-block-navigation-link :not(.wp-element-button)) {
 	padding: 0.5em 1em;
 }
 
 // Provide a default padding for submenus who should always have some, regardless of the top level menu items.
-.wp-block-navigation :where(.wp-block-navigation__submenu-container) .wp-block-navigation-item__content {
+:where(.wp-block-navigation .wp-block-navigation__submenu-container .wp-block-navigation-link :not(.wp-element-button)) {
 	padding: 0.5em 1em;
 }
+
 
 /**
  * Justifications.

--- a/packages/block-library/src/navigation/style.scss
+++ b/packages/block-library/src/navigation/style.scss
@@ -154,10 +154,7 @@ $navigation-icon-size: 24px;
 // Styles for submenu flyout.
 // These are separated out with reduced specificity to allow better inheritance from Global Styles.
 .wp-block-navigation .has-child {
-	// We use :where to keep specificity minimal, yet still scope it to only the navigation block.
-	// That way if padding is set in theme.json, it still wins.
-	// https://css-tricks.com/almanac/selectors/w/where/
-	:where(.wp-block-navigation__submenu-container) {
+	.wp-block-navigation__submenu-container {
 		background-color: inherit;
 		color: inherit;
 		position: absolute;
@@ -233,7 +230,7 @@ $navigation-icon-size: 24px;
 
 	// Custom menu items.
 	// Show submenus on hover unless they open on click.
-	&:where(:not(.open-on-click)):hover > .wp-block-navigation__submenu-container {
+	&:not(.open-on-click):hover > .wp-block-navigation__submenu-container {
 		visibility: visible;
 		overflow: visible;
 		opacity: 1;
@@ -243,7 +240,7 @@ $navigation-icon-size: 24px;
 	}
 
 	// Keep submenus open when focus is within.
-	&:where(:not(.open-on-click):not(.open-on-hover-click)):focus-within > .wp-block-navigation__submenu-container {
+	&:not(.open-on-click):not(.open-on-hover-click):focus-within > .wp-block-navigation__submenu-container {
 		visibility: visible;
 		overflow: visible;
 		opacity: 1;

--- a/packages/block-library/src/navigation/style.scss
+++ b/packages/block-library/src/navigation/style.scss
@@ -344,12 +344,12 @@ button.wp-block-navigation-item__content {
 
 // When the menu has a background, items have paddings, reduce margins to compensate.
 // Treat margins and paddings differently when the block has a background.
-:where(.wp-block-navigation.has-background .wp-block-navigation-link :not(.wp-element-button)) {
+:where(.wp-block-navigation.has-background .wp-block-navigation-link a:not(.wp-element-button)) {
 	padding: 0.5em 1em;
 }
 
 // Provide a default padding for submenus who should always have some, regardless of the top level menu items.
-:where(.wp-block-navigation .wp-block-navigation__submenu-container .wp-block-navigation-link :not(.wp-element-button)) {
+:where(.wp-block-navigation .wp-block-navigation__submenu-container .wp-block-navigation-link a:not(.wp-element-button)) {
 	padding: 0.5em 1em;
 }
 


### PR DESCRIPTION
## What?

Followup to #42964, alternative to #42965.

- 42964 removes `:where` for showing/hiding submenus.
- 42965 also removes `:where` for default paddings, fixing a bug where theme.json padding rules wouldn't affect links

This alternative keeps the `:where` rules in place _just_ for the paddings, so that submenus still have some default padding in their boxes, but can still be overridden by `theme.json` rules such as these:

```
	"blocks": {
		"core/navigation-link": {
			"elements" : {
				"link": {
					"spacing": {
						"padding" : {
							"top" : "1.5em",
							"right": "2em",
							"bottom": "1.5em",
							"left": "2em"
						}
					}
				}
			}
		},
		"core/navigation-submenu": {
			"elements" : {
				"link": {
					"spacing": {
						"padding" : {
							"top" : "1.5em",
							"right": "2em",
							"bottom": "1.5em",
							"left": "2em"
						}
					}
				}
			}
		}
	},
```

The net result is that default paddings for menus and submenus remain working for browsers that support `:where`, and those paddings an be further customized via `theme.json`. With custom rules:

![custom theme json](https://user-images.githubusercontent.com/1204802/182807380-53dc15fe-2f54-4bf8-af3a-dc06e401257a.gif)

Without any custom rules, just the defaults:

![default no custom theme json](https://user-images.githubusercontent.com/1204802/182807413-3cc2c472-cc5e-4377-9edf-52192052f1a5.gif)

## Why?

The main challenge in #39230 is for submenus to open and close across every browser, remaining functional for older browsers. An argument can be made that default padding rules fall in the "graceful degradation" category, since they are mostly decorative.

## Testing Instructions

Please follow testing instructions from #42964, though note that this PR should be safer (if acceptable) than #42965 since navigation block behavior should be mostly unchanged from what it's been for a while.