### PR TITLE
fix sanitization for style-engine declarations

### DIFF
--- a/packages/style-engine/phpunit/class-wp-style-engine-css-declarations-test.php
+++ b/packages/style-engine/phpunit/class-wp-style-engine-css-declarations-test.php
@@ -120,8 +120,7 @@ class WP_Style_Engine_CSS_Declarations_Test extends WP_UnitTestCase {
 		$this->assertSame(
 			'	color: red;
 	border-top-left-radius: 99px;
-	text-decoration: underline;
-',
+	text-decoration: underline;',
 			$css_declarations->get_declarations_string( true, 1 )
 		);
 	}
@@ -140,8 +139,7 @@ class WP_Style_Engine_CSS_Declarations_Test extends WP_UnitTestCase {
 		$this->assertSame(
 			'		color: red;
 		border-top-left-radius: 99px;
-		text-decoration: underline;
-',
+		text-decoration: underline;',
 			$css_declarations->get_declarations_string( true, 2 )
 		);
 	}

--- a/packages/style-engine/phpunit/class-wp-style-engine-css-declarations-test.php
+++ b/packages/style-engine/phpunit/class-wp-style-engine-css-declarations-test.php
@@ -120,7 +120,8 @@ class WP_Style_Engine_CSS_Declarations_Test extends WP_UnitTestCase {
 		$this->assertSame(
 			'	color: red;
 	border-top-left-radius: 99px;
-	text-decoration: underline;',
+	text-decoration: underline;
+',
 			$css_declarations->get_declarations_string( true, 1 )
 		);
 	}
@@ -139,7 +140,8 @@ class WP_Style_Engine_CSS_Declarations_Test extends WP_UnitTestCase {
 		$this->assertSame(
 			'		color: red;
 		border-top-left-radius: 99px;
-		text-decoration: underline;',
+		text-decoration: underline;
+',
 			$css_declarations->get_declarations_string( true, 2 )
 		);
 	}


### PR DESCRIPTION
## What?
Fixes #42948

This PR is a partial from #42893, specifically the part of that PR regarding the sanitization of CSS delcarations in the style engine.

## Why?
Some things need to bypass the `safecss_filter_attr` call, and the sanitization of values is further improved here.
