### PR TITLE
[Gutenberg Data Tutorial] Adjust the image URLs and whitespace to render correctly in the Handbook

### DIFF
--- a/docs/how-to-guides/data-basics/4-building-a-create-page-form.md
+++ b/docs/how-to-guides/data-basics/4-building-a-create-page-form.md
@@ -1,14 +1,12 @@
-# Part 4: Building a _Create page_ form
+# Part 4: Building a Create page form
 
-In the [previous part](/docs/how-to-guides/data-basics/3-building-an-edit-form.md) we created an *Edit page* feature,
-and in this part we will add a *Create page* feature. Here's a glimpse of what we're going to build:
+In the [previous part](/docs/how-to-guides/data-basics/3-building-an-edit-form.md) we created an *Edit page* feature, and in this part we will add a *Create page* feature. Here's a glimpse of what we're going to build:
 
-![](/docs/how-to-guides/data-basics/media/create-form/create-form-with-text.png)
+![](https://raw.githubusercontent.com/WordPress/gutenberg/HEAD/docs/how-to-guides/data-basics/media/create-form/create-form-with-text.png)
 
 ### Step 1: Add a _Create a new page_ button
 
-Let’s start by building a button to display the _create page_ form. It’s similar to an _Edit_ button we have built in
-the [part 3](/docs/how-to-guides/data-basics/3-building-an-edit-form.md):
+Let’s start by building a button to display the _create page_ form. It’s similar to an _Edit_ button we have built in the [part 3](/docs/how-to-guides/data-basics/3-building-an-edit-form.md):
 
 ```js
 import { useDispatch } from '@wordpress/data';
@@ -61,16 +59,13 @@ function MyFirstApp() {
 
 The final result should look as follows:
 
-![](/docs/how-to-guides/data-basics/media/create-form/create-button.png)
+![](https://raw.githubusercontent.com/WordPress/gutenberg/HEAD/docs/how-to-guides/data-basics/media/create-form/create-button.png)
 
 ### Step 2: Extract a controlled PageForm
 
-Now that the button is in place, we can focus entirely on building the form. This tutorial is about managing data, so we
-will not build a complete page editor. Instead, the form will only contain one field: post title.
+Now that the button is in place, we can focus entirely on building the form. This tutorial is about managing data, so we will not build a complete page editor. Instead, the form will only contain one field: post title.
 
-Luckily, the `EditPageForm` we built in [part three](/docs/how-to-guides/data-basics/3-building-an-edit-form.md) already
-takes us 80% of the way there. The bulk of the user interface is already available, and we will reuse it in
-the `CreatePageForm`. Let’s start by extracting the form UI into a separate component:
+Luckily, the `EditPageForm` we built in [part three](/docs/how-to-guides/data-basics/3-building-an-edit-form.md) already takes us 80% of the way there. The bulk of the user interface is already available, and we will reuse it in the `CreatePageForm`. Let’s start by extracting the form UI into a separate component:
 
 ```js
 export function EditPageForm( { pageId, onCancel, onSaveFinished } ) {
@@ -127,17 +122,15 @@ export function PageForm( { title, onChangeTitle, hasEdits, lastError, isSaving,
 }
 ```
 
-This code quality change should not alter anything about how the application works. Let’s try to edit a page just to be
-sure:
+This code quality change should not alter anything about how the application works. Let’s try to edit a page just to be sure:
 
-![](/docs/how-to-guides/data-basics/media/create-form/edit-page-form.png)
+![](https://raw.githubusercontent.com/WordPress/gutenberg/HEAD/docs/how-to-guides/data-basics/media/create-form/edit-page-form.png)
 
 Great! The edit form is still there, and now we have a building block to power the new `CreatePageForm`.
 
 ### Step 3: Build a CreatePageForm
 
-The only thing that `CreatePageForm` component must do is to provide the following seven properties needed to render
-the `PageForm` component:
+The only thing that `CreatePageForm` component must do is to provide the following seven properties needed to render the `PageForm` component:
 
 * title
 * onChangeTitle
@@ -151,11 +144,9 @@ Let’s see how we can do that:
 
 #### Title, onChangeTitle, hasEdits
 
-The `EditPageForm` updated and saved an existing entity record that lived in the Redux state. Because of that, we relied
-on the `editedEntityRecords` selector.
+The `EditPageForm` updated and saved an existing entity record that lived in the Redux state. Because of that, we relied on the `editedEntityRecords` selector.
 
-In case of the `CreatePageForm` however, there is no pre-existing entity record. There is only an empty form. Anything
-that the user types is local to that form, which means we can keep track of it using the React’s `useState` hook:
+In case of the `CreatePageForm` however, there is no pre-existing entity record. There is only an empty form. Anything that the user types is local to that form, which means we can keep track of it using the React’s `useState` hook:
 
 ```js
 export function CreatePageForm( { onCancel, onSaveFinished } ) {
@@ -174,25 +165,17 @@ export function CreatePageForm( { onCancel, onSaveFinished } ) {
 
 #### onSave, onCancel
 
-In the `EditPageForm`, we dispatched the `saveEditedEntityRecord('postType', 'page', pageId )` action to save the edits
-that lived in the Redux state.
+In the `EditPageForm`, we dispatched the `saveEditedEntityRecord('postType', 'page', pageId )` action to save the edits that lived in the Redux state.
 
-In the `CreatePageForm` however, we do not have any edits in the Redux state, nor we do have a `pageId`. The action we
-need to dispatch in this case is
-called [`saveEntityRecord`](https://developer.wordpress.org/block-editor/reference-guides/data/data-core/#saveentityrecord) (
-without the word _Edited_ in the name) and it accepts an object representing the new entity record instead of a `pageId`
-.
+In the `CreatePageForm` however, we do not have any edits in the Redux state, nor we do have a `pageId`. The action we need to dispatch in this case is called [`saveEntityRecord`](https://developer.wordpress.org/block-editor/reference-guides/data/data-core/#saveentityrecord) (without the word _Edited_ in the name) and it accepts an object representing the new entity record instead of a `pageId`.
 
-The data passed to `saveEntityRecord` is sent via a POST request to the appropriate REST API endpoint. For example,
-dispatching the following action:
+The data passed to `saveEntityRecord` is sent via a POST request to the appropriate REST API endpoint. For example, dispatching the following action:
 
 ```js
 saveEntityRecord( 'postType', 'page', { title: "Test" } );
 ```
 
-Triggers a POST request to
-the [`/wp/v2/pages` WordPress REST API](https://developer.wordpress.org/rest-api/reference/pages/) endpoint with a
-single field in the request body: `title=Test`.
+Triggers a POST request to the [`/wp/v2/pages` WordPress REST API](https://developer.wordpress.org/rest-api/reference/pages/) endpoint with a  single field in the request body: `title=Test`.
 
 Now that we know more about `saveEntityRecord`, let's use it in `CreatePageForm`.
 
@@ -220,9 +203,7 @@ export function CreatePageForm( { onSaveFinished, onCancel } ) {
 }
 ```
 
-There is one more detail to address: our newly created pages are not yet picked up by the `PagesList`. Accordingly to
-the REST API documentation, the `/wp/v2/pages` endpoint creates (`POST` requests) pages with `status=draft` by default,
-but _returns_ (`GET` requests) pages with `status=publish`. The solution is to pass the `status` parameter explicitly:
+There is one more detail to address: our newly created pages are not yet picked up by the `PagesList`. Accordingly to the REST API documentation, the `/wp/v2/pages` endpoint creates (`POST` requests) pages with `status=draft` by default, but _returns_ (`GET` requests) pages with `status=publish`. The solution is to pass the `status` parameter explicitly:
 
 ```js
 export function CreatePageForm( { onSaveFinished, onCancel } ) {
@@ -252,13 +233,9 @@ Go ahead and apply that change to your local `CreatePageForm` component, and let
 
 #### lastError, isSaving
 
-The `EditPageForm`  retrieved the error and progress information via the `getLastEntitySaveError`
-and `isSavingEntityRecord` selectors. In both cases, it passed the following three
-arguments: `( 'postType', 'page', pageId )`.
+The `EditPageForm`  retrieved the error and progress information via the `getLastEntitySaveError` and `isSavingEntityRecord` selectors. In both cases, it passed the following three arguments: `( 'postType', 'page', pageId )`.
 
-In `CreatePageForm` however, we do not have a `pageId`. What now? We can skip the `pageId` argument to retrieve the
-information about the entity record without any id – this will be the newly created one. The `useSelect` call is thus
-very similar to the one from `EditPageForm`:
+In `CreatePageForm` however, we do not have a `pageId`. What now? We can skip the `pageId` argument to retrieve the information about the entity record without any id – this will be the newly created one. The `useSelect` call is thus very similar to the one from `EditPageForm`:
 
 ```js
 export function CreatePageForm( { onCancel, onSaveFinished } ) {
@@ -287,8 +264,8 @@ export function CreatePageForm( { onCancel, onSaveFinished } ) {
 
 And that’s it! Here's what our new form looks like in action:
 
-![](/docs/how-to-guides/data-basics/media/create-form/create-saving.png)
-![](/docs/how-to-guides/data-basics/media/create-form/created-item.png)
+![](https://raw.githubusercontent.com/WordPress/gutenberg/HEAD/docs/how-to-guides/data-basics/media/create-form/create-saving.png)
+![](https://raw.githubusercontent.com/WordPress/gutenberg/HEAD/docs/how-to-guides/data-basics/media/create-form/created-item.png)
 
 ### Wiring it all together
 
@@ -406,7 +383,7 @@ export function PageForm( { title, onChangeTitle, hasEdits, lastError, isSaving,
 
 All that’s left is to refresh the page and enjoy the form:
 
-![](/docs/how-to-guides/data-basics/media/create-form/create-form-with-text.png)
+![](https://raw.githubusercontent.com/WordPress/gutenberg/HEAD/docs/how-to-guides/data-basics/media/create-form/create-form-with-text.png)
 
 ## What's next?
 

--- a/docs/manifest.json
+++ b/docs/manifest.json
@@ -198,7 +198,7 @@
 		"parent": "data-basics"
 	},
 	{
-		"title": "Part 4: Building a _Create page_ form",
+		"title": "Part 4: Building a Create page form",
 		"slug": "4-building-a-create-page-form",
 		"markdown_source": "../docs/how-to-guides/data-basics/4-building-a-create-page-form.md",
 		"parent": "data-basics"


### PR DESCRIPTION
## What?

WordPress handbook has very particular requirements about the Markdown it renders. Here's how the current one is displayed:

<img width="716" alt="CleanShot 2022-08-04 at 11 19 27@2x" src="https://user-images.githubusercontent.com/205419/182811690-c07f8005-a4bc-40a7-aec4-eabf9cd6ae6f.png">

This PR makes the image URLs absolute and removes the mid-paragraph whitespace so that the tutorial can be rendered correctly.
