### PR TITLE
Combine style-engine stores for block-supports

### DIFF
--- a/lib/block-supports/layout.php
+++ b/lib/block-supports/layout.php
@@ -209,7 +209,7 @@ function gutenberg_get_layout_style( $selector, $layout, $has_block_gap_support 
 		return gutenberg_style_engine_get_stylesheet_from_css_rules(
 			$layout_styles,
 			array(
-				'context' => 'layout-block-supports',
+				'context' => 'block-supports',
 				'enqueue' => true,
 			)
 		);


### PR DESCRIPTION
## What?
Right now we have a separate store for `layout-block-supports` and generic `block-supports`.
The result is that on the frontend the CSS gets printed like this: (notice there are 2 separate `<style>` elements, each one with a different ID)
```css
<style id='block-supports-inline-css'>
.wp-elements-c2d3692c067254e99911402d49af8a7d a {
	color: var(--wp--preset--color--background);
}

</style>
<style id='layout-block-supports-inline-css'>
.wp-block-navigation.wp-container-3 {
	justify-content: flex-end;
}
.wp-block-columns.wp-container-9 {
	flex-wrap: nowrap;
}
.wp-block-group.wp-container-4,.wp-block-query-pagination.wp-container-12,.wp-block-group.wp-container-14 {
	justify-content: space-between;
}
.wp-block-group.wp-container-5 > :where(:not(.alignleft):not(.alignright):not(.alignfull)),.wp-block-group.wp-container-6 > :where(:not(.alignleft):not(.alignright):not(.alignfull)),.wp-block-group.wp-container-10 > :where(:not(.alignleft):not(.alignright):not(.alignfull)),.wp-block-query.wp-container-13 > :where(:not(.alignleft):not(.alignright):not(.alignfull)),.wp-block-group.wp-container-15 > :where(:not(.alignleft):not(.alignright):not(.alignfull)),.wp-block-group.wp-container-16 > :where(:not(.alignleft):not(.alignright):not(.alignfull)) {
	max-width: 650px;
	margin-left: auto !important;
	margin-right: auto !important;
}
.wp-block-group.wp-container-5 > .alignwide,.wp-block-group.wp-container-6 > .alignwide,.wp-block-group.wp-container-10 > .alignwide,.wp-block-query.wp-container-13 > .alignwide,.wp-block-group.wp-container-15 > .alignwide,.wp-block-group.wp-container-16 > .alignwide {
	max-width: 1000px;
}
.wp-block-group.wp-container-5 .alignfull,.wp-block-group.wp-container-6 .alignfull,.wp-block-group.wp-container-10 .alignfull,.wp-block-query.wp-container-13 .alignfull,.wp-block-group.wp-container-15 .alignfull,.wp-block-group.wp-container-16 .alignfull {
	max-width: none;
}
</style>
```

This PR uses the `block-supports` store for layouts as well.
The result is this:
```css
<style id='block-supports-inline-css'>
.wp-elements-c2d3692c067254e99911402d49af8a7d a {
	color: var(--wp--preset--color--background);
}
.wp-block-navigation.wp-container-3 {
	justify-content: flex-end;
}
.wp-block-columns.wp-container-9 {
	flex-wrap: nowrap;
}
.wp-block-group.wp-container-4,.wp-block-query-pagination.wp-container-12,.wp-block-group.wp-container-14 {
	justify-content: space-between;
}
.wp-block-group.wp-container-5 > :where(:not(.alignleft):not(.alignright):not(.alignfull)),.wp-block-group.wp-container-6 > :where(:not(.alignleft):not(.alignright):not(.alignfull)),.wp-block-group.wp-container-10 > :where(:not(.alignleft):not(.alignright):not(.alignfull)),.wp-block-query.wp-container-13 > :where(:not(.alignleft):not(.alignright):not(.alignfull)),.wp-block-group.wp-container-15 > :where(:not(.alignleft):not(.alignright):not(.alignfull)),.wp-block-group.wp-container-16 > :where(:not(.alignleft):not(.alignright):not(.alignfull)) {
	max-width: 650px;
	margin-left: auto !important;
	margin-right: auto !important;
}
.wp-block-group.wp-container-5 > .alignwide,.wp-block-group.wp-container-6 > .alignwide,.wp-block-group.wp-container-10 > .alignwide,.wp-block-query.wp-container-13 > .alignwide,.wp-block-group.wp-container-15 > .alignwide,.wp-block-group.wp-container-16 > .alignwide {
	max-width: 1000px;
}
.wp-block-group.wp-container-5 .alignfull,.wp-block-group.wp-container-6 .alignfull,.wp-block-group.wp-container-10 .alignfull,.wp-block-query.wp-container-13 .alignfull,.wp-block-group.wp-container-15 .alignfull,.wp-block-group.wp-container-16 .alignfull {
	max-width: none;
}
</style>
```
The `<style>` elements get combined and everything else remains the same.

The benefit of doing this is that as we convert all implementations to use the style engine, common selectors and declarations can be combined resulting in further optimizations of our styles. The more we add to the same store, the more it can be optimized.
