### PR TITLE
Popover: anchor correctly to parent node when no explicit anchor is passed

### DIFF
--- a/packages/block-editor/src/components/url-popover/image-url-input-ui.js
+++ b/packages/block-editor/src/components/url-popover/image-url-input-ui.js
@@ -51,6 +51,7 @@ const ImageURLInputUI = ( {
 	rel,
 } ) => {
 	const [ isOpen, setIsOpen ] = useState( false );
+	const buttonRef = useRef( null );
 	const openLinkUI = useCallback( () => {
 		setIsOpen( true );
 	} );
@@ -245,9 +246,11 @@ const ImageURLInputUI = ( {
 				label={ url ? __( 'Edit link' ) : __( 'Insert link' ) }
 				aria-expanded={ isOpen }
 				onClick={ openLinkUI }
+				ref={ buttonRef }
 			/>
 			{ isOpen && (
 				<URLPopover
+					anchorRef={ buttonRef }
 					onFocusOutside={ onFocusOutside() }
 					onClose={ closeLinkUI }
 					renderSettings={ () => advancedOptions }

--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -13,6 +13,7 @@
 -   `Popover`: fix arrow placement and design ([#42874](https://github.com/WordPress/gutenberg/pull/42874/)).
 -   `Popover`: fix minor glitch in arrow [#42903](https://github.com/WordPress/gutenberg/pull/42903)).
 -   `ToolsPanel`: Constrain grid columns to 50% max-width ([#42795](https://github.com/WordPress/gutenberg/pull/42795)).
+-   `Popover`: anchor correctly to parent node when no explicit anchor is passed ([#42971](https://github.com/WordPress/gutenberg/pull/42971)).
 
 ### Enhancements
 

--- a/packages/components/src/popover/index.js
+++ b/packages/components/src/popover/index.js
@@ -351,7 +351,9 @@ const Popover = (
 				},
 			};
 		} else if ( anchorRefFallback.current ) {
-			resultingReferenceRef = anchorRefFallback.current;
+			// If not explicit ref if passed via props, fallback to
+			// anchoring to the popover's parent node.
+			resultingReferenceRef = anchorRefFallback.current.parentNode;
 		}
 
 		if ( ! resultingReferenceRef ) {

--- a/packages/components/src/popover/index.js
+++ b/packages/components/src/popover/index.js
@@ -351,7 +351,7 @@ const Popover = (
 				},
 			};
 		} else if ( anchorRefFallback.current ) {
-			// If not explicit ref if passed via props, fallback to
+			// If no explicit ref is passed via props, fall back to
 			// anchoring to the popover's parent node.
 			resultingReferenceRef = anchorRefFallback.current.parentNode;
 		}

--- a/packages/components/src/popover/style.scss
+++ b/packages/components/src/popover/style.scss
@@ -65,6 +65,7 @@ $arrow-triangle-base-size: 14px;
 	width: $arrow-triangle-base-size;
 	height: $arrow-triangle-base-size;
 	pointer-events: none;
+	display: flex;
 
 	// Thin line that helps to make sure that the underlying
 	// popover__content's outline is fully overlapped by the
@@ -103,9 +104,8 @@ $arrow-triangle-base-size: 14px;
 }
 
 .components-popover__triangle {
-	position: absolute;
-	height: 100%;
-	width: 100%;
+	display: block;
+	flex: 1;
 }
 
 .components-popover__triangle-bg {


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

This PR fixes a regression introduced by #40740 which caused the popover to position incorrectly when no explicit anchor is passed via props. In this case, the popover is supposed to use its parent node as the anchor — as per the README:

https://github.com/WordPress/gutenberg/blob/8f0c091c92ff28279d55844bca6b941280e9509a/packages/components/src/popover/README.md?plain=1#L3

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

Fixing a regression. Here's how the code used to look like before #40740:

https://github.com/WordPress/gutenberg/blob/b99e6688fba7037ccee46cb6b7d70917a5f2c418/packages/components/src/popover/index.js#L123-L129

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

The fix is simple — instead of using `fallbackAnchor.current` to compute the anchor positioning, we use its parent node (`fallbackAnchor.current.parentNode`).

This change also required a slight tweak with the styles of the arrow's triangle which somehow seemed to conflict with some floating ui's calculation (switched from nested `absolute` positioning to a simpler `display: block`)

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->

### Storybook

- Play around with the different `placement` options in the default Storybook example, and notice how the popover positions itself correctly with respect to the toggle button.
- Repeat the same on `trunk` and notice how the popover anchors itself around a single pixel on screen, instead of the full button.
- Check that there are no regressions in components using `Popover` (e.g. `Tooltip`, `Dropdown`...)

### Editor

**Please do test thoroughly in the editor, as I wasn't always able to "find" all of the popovers listed below while browsing the app in the browser.**

<details>

<summary> This PR should introduce bug fixes (or at least, not cause regressions) for all instances of `Popover` that don't pass an explicit anchor via props. This is what I've found when searching in the codebase: (click to expand)</summary>

- https://github.com/WordPress/gutenberg/blob/5c1e9139c75b72cfd04af15da3a1b5affcc250cf/packages/block-editor/src/components/block-switcher/pattern-transformations-menu.js#L59-L62
- https://github.com/WordPress/gutenberg/blob/d9d06f332d9c5057a19f8ad334625bcbce3e137a/packages/block-editor/src/components/block-switcher/preview-block-popover.js#L16-L20
- https://github.com/WordPress/gutenberg/blob/33d84b036592a5bf31af05b7710f3b2b14163dc4/packages/block-editor/src/components/url-input/index.js#L542
- https://github.com/WordPress/gutenberg/blob/33a9c48fc19b25b45636997e906f04bc06d6cc7e/packages/block-editor/src/components/url-popover/index.js#L32-L38
- https://github.com/WordPress/gutenberg/blob/8b1492131355aa6d42272faba25b841f0cd4509d/packages/nux/src/components/dot-tip/index.js
- https://github.com/WordPress/gutenberg/blob/8b1492131355aa6d42272faba25b841f0cd4509d/packages/widgets/src/blocks/legacy-widget/edit/form.js#L104-L108

`Popover` is also used without an anchor in the `PaletteEdit`, but since the component doesn't have a Storybook example, we'd have to check directly in the editor:
- https://github.com/WordPress/gutenberg/blob/a5ef504432e34afc0792eae62e44d71590c031eb/packages/edit-site/src/components/global-styles/color-palette-panel.js#L49-L76
- https://github.com/WordPress/gutenberg/blob/2224d4f59892aec92718c0e9a48866d28967156d/packages/edit-site/src/components/global-styles/gradients-palette-panel.js#L55-L82

</details>

## Screenshots or screencast <!-- if applicable -->

On `trunk`:

https://user-images.githubusercontent.com/1083581/182825267-e23ba4e2-1367-488e-a0d0-c51f9d5f6358.mp4

On this PR:

https://user-images.githubusercontent.com/1083581/182825039-e8ea5647-88de-4940-a71e-d837a96bbd13.mp4



Editing color palette:

| `trunk` | This PR |
|---|---|
| ![Screenshot 2022-08-04 at 13 02 34](https://user-images.githubusercontent.com/1083581/182832201-4bd8860f-fa90-4a1f-a2f4-df4e4b22610e.png) | ![Screenshot 2022-08-04 at 13 04 07](https://user-images.githubusercontent.com/1083581/182832207-daa2b28e-bf43-42d8-af11-a7eb4fcc4d16.png) |




 