### PR TITLE
Block Styles: Truncate long button labels

### DIFF
--- a/packages/block-editor/src/components/block-styles/index.js
+++ b/packages/block-editor/src/components/block-styles/index.js
@@ -11,7 +11,7 @@ import { useState, useLayoutEffect } from '@wordpress/element';
 import { useViewportMatch } from '@wordpress/compose';
 import {
 	Button,
-	__experimentalText as Text,
+	__experimentalTruncate as Truncate,
 	Slot,
 	Fill,
 } from '@wordpress/components';
@@ -117,15 +117,12 @@ function BlockStyles( {
 							onClick={ () => onSelectStylePreview( style ) }
 							aria-current={ activeStyle.name === style.name }
 						>
-							<Text
-								as="span"
-								limit={ 12 }
-								ellipsizeMode="tail"
+							<Truncate
+								numberOfLines={ 1 }
 								className="block-editor-block-styles__item-text"
-								truncate
 							>
 								{ buttonText }
-							</Text>
+							</Truncate>
 						</Button>
 					);
 				} ) }

--- a/packages/block-editor/src/components/block-styles/style.scss
+++ b/packages/block-editor/src/components/block-styles/style.scss
@@ -43,16 +43,6 @@
 		display: inline-block;
 		width: calc(50% - #{$grid-unit-05});
 
-		&-text {
-			word-break: break-all;
-			// The Button component is white-space: nowrap, and that won't work with line-clamp.
-			white-space: normal;
-
-			// Without this, the ellipsis can sometimes be partially hidden by the Button padding.
-			text-align: start;
-			text-align-last: center;
-		}
-
 		&:focus,
 		&:hover {
 			color: var(--wp-admin-theme-color);
@@ -73,6 +63,16 @@
 		&.is-active:focus {
 			box-shadow: inset 0 0 0 1px $white, 0 0 0 2px var(--wp-admin-theme-color);
 		}
+	}
+
+	.block-editor-block-styles__item-text {
+		word-break: break-all;
+		// The Button component is white-space: nowrap, and that won't work with line-clamp.
+		white-space: normal;
+
+		// Without this, the ellipsis can sometimes be partially hidden by the Button padding.
+		text-align: start;
+		text-align-last: center;
 	}
 }
 

--- a/packages/block-editor/src/components/block-styles/style.scss
+++ b/packages/block-editor/src/components/block-styles/style.scss
@@ -43,6 +43,16 @@
 		display: inline-block;
 		width: calc(50% - #{$grid-unit-05});
 
+		&-text {
+			word-break: break-all;
+			// The Button component is white-space: nowrap, and that won't work with line-clamp.
+			white-space: normal;
+
+			// Without this, the ellipsis can sometimes be partially hidden by the Button padding.
+			text-align: start;
+			text-align-last: center;
+		}
+
 		&:focus,
 		&:hover {
 			color: var(--wp-admin-theme-color);


### PR DESCRIPTION
Resolves #40463
Related #40807 #41455

<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->
Changed character limit to be calculated from character width.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
https://github.com/WordPress/gutenberg/issues/40463#issuecomment-1116900354 is used to calculate the width of the character count using the string-width package.
https://github.com/WordPress/gutenberg/issues/40463#issuecomment-1116900354

## Before
![before](https://user-images.githubusercontent.com/42362903/182834735-bc326b16-66be-4411-8dcc-394fc4ccc5c4.png)

## After
![after](https://user-images.githubusercontent.com/42362903/182834771-1a506787-306a-4ade-a4d4-40e197805c22.png)

## Testing Instructions
1. Refer to the following code to add a block style.
```PHP
function twenty_twenty_two_register_block_styles() {
	// Hello,Hello,…
	register_block_style(
		'core/image',
		array(
			'name'  => 'twentytwentytwo-image-1',
			'label' => esc_html__( 'Hello,Hello,Hello', 'twentytwentyone' ),
		)
	);

	// Hola,Hola,Ho…
	register_block_style(
		'core/image',
		array(
			'name'  => 'twentytwentytwo-image-2',
			'label' => esc_html__( 'Hola,Hola,Hola', 'twentytwentyone' ),
		)
	);

	// こんにちは,こんにちは
	register_block_style(
		'core/image',
		array(
			'name'  => 'twentytwentytwo-image-3',
			'label' => esc_html__( 'こんにちは,こんにちは', 'twentytwentyone' ),
		)
	);

	// 你好,你好,你好,你好
	register_block_style(
		'core/image',
		array(
			'name'  => 'twentytwentytwo-image-4',
			'label' => esc_html__( '你好,你好,你好,你好', 'twentytwentyone' ),
		)
	);

	// Hello,こんにちは
	register_block_style(
		'core/image',
		array(
			'name'  => 'twentytwentytwo-image-5',
			'label' => esc_html__( 'Hello,こんにちは', 'twentytwentyone' ),
		)
	);
}
add_action( 'init', 'twenty_twenty_two_register_block_styles' );
```
2. Go to the block editor and place the image block.

3. Open the side panel and look at the style preview.

## Screenshots or screencast <!-- if applicable -->
