### PR TITLE
Fix dynamic references on the site editor

### DIFF
--- a/packages/edit-site/src/components/global-styles/hooks.js
+++ b/packages/edit-site/src/components/global-styles/hooks.js
@@ -17,7 +17,7 @@ import {
 /**
  * Internal dependencies
  */
-import { getValueFromVariable, getPresetVariableFromValue } from './utils';
+import { getValueFromVariableOrRef, getPresetVariableFromValue } from './utils';
 import { GlobalStylesContext } from './context';
 
 const EMPTY_CONFIG = { settings: {}, styles: {} };
@@ -127,22 +127,22 @@ export function useStyle( path, blockName, source = 'all' ) {
 	let result;
 	switch ( source ) {
 		case 'all':
-			result = getValueFromVariable(
-				mergedConfig.settings,
+			result = getValueFromVariableOrRef(
+				mergedConfig,
 				blockName,
 				get( userConfig, finalPath ) ?? get( baseConfig, finalPath )
 			);
 			break;
 		case 'user':
-			result = getValueFromVariable(
-				mergedConfig.settings,
+			result = getValueFromVariableOrRef(
+				mergedConfig,
 				blockName,
 				get( userConfig, finalPath )
 			);
 			break;
 		case 'base':
-			result = getValueFromVariable(
-				baseConfig.settings,
+			result = getValueFromVariableOrRef(
+				baseConfig,
 				blockName,
 				get( baseConfig, finalPath )
 			);

--- a/packages/edit-site/src/components/global-styles/hooks.js
+++ b/packages/edit-site/src/components/global-styles/hooks.js
@@ -17,7 +17,7 @@ import {
 /**
  * Internal dependencies
  */
-import { getValueFromVariableOrRef, getPresetVariableFromValue } from './utils';
+import { getValueFromVariable, getPresetVariableFromValue } from './utils';
 import { GlobalStylesContext } from './context';
 
 const EMPTY_CONFIG = { settings: {}, styles: {} };
@@ -127,21 +127,21 @@ export function useStyle( path, blockName, source = 'all' ) {
 	let result;
 	switch ( source ) {
 		case 'all':
-			result = getValueFromVariableOrRef(
+			result = getValueFromVariable(
 				mergedConfig,
 				blockName,
 				get( userConfig, finalPath ) ?? get( baseConfig, finalPath )
 			);
 			break;
 		case 'user':
-			result = getValueFromVariableOrRef(
+			result = getValueFromVariable(
 				mergedConfig,
 				blockName,
 				get( userConfig, finalPath )
 			);
 			break;
 		case 'base':
-			result = getValueFromVariableOrRef(
+			result = getValueFromVariable(
 				baseConfig,
 				blockName,
 				get( baseConfig, finalPath )

--- a/packages/edit-site/src/components/global-styles/test/utils.js
+++ b/packages/edit-site/src/components/global-styles/test/utils.js
@@ -110,7 +110,7 @@ describe( 'editor utils', () => {
 		describe( 'when provided an invalid variable', () => {
 			it( 'returns the originally provided value', () => {
 				const actual = getValueFromVariable(
-					styles.settings,
+					styles,
 					'root',
 					undefined
 				);
@@ -122,7 +122,7 @@ describe( 'editor utils', () => {
 		describe( 'when provided a preset variable', () => {
 			it( 'retrieves the correct preset value', () => {
 				const actual = getValueFromVariable(
-					styles.settings,
+					styles,
 					'root',
 					'var:preset|color|primary'
 				);
@@ -134,7 +134,7 @@ describe( 'editor utils', () => {
 		describe( 'when provided a custom variable', () => {
 			it( 'retrieves the correct custom value', () => {
 				const actual = getValueFromVariable(
-					styles.settings,
+					styles,
 					'root',
 					'var(--wp--custom--color--secondary)'
 				);

--- a/packages/edit-site/src/components/global-styles/use-global-styles-output.js
+++ b/packages/edit-site/src/components/global-styles/use-global-styles-output.js
@@ -184,9 +184,9 @@ function flattenTree( input = {}, prefix, token ) {
 /**
  * Resolves ref into the value it is pointing to.
  *
- * @param {Object} refObj      The reference we are pointing to.
+ * @param {Object} refObj      The reference in the block styles tree.
  *
- * @param {string} blockStyles Block styles.
+ * @param {string} blockStyles The tree of block styles.
  *
  * @return {string} The resolved referenced value.
  */

--- a/packages/edit-site/src/components/global-styles/use-global-styles-output.js
+++ b/packages/edit-site/src/components/global-styles/use-global-styles-output.js
@@ -182,26 +182,6 @@ function flattenTree( input = {}, prefix, token ) {
 }
 
 /**
- * Resolves ref into the value it is pointing to.
- *
- * @param {Object} refObj      The reference in the block styles tree.
- *
- * @param {string} blockStyles The tree of block styles.
- *
- * @return {string} The resolved referenced value.
- */
-function resolveRefValue( refObj, blockStyles ) {
-	if ( ! refObj.ref ) {
-		return refObj;
-	}
-
-	const refPath = refObj.ref.split( '.' );
-	const styleValue = get( blockStyles, refPath );
-
-	return styleValue;
-}
-
-/**
  * Transform given style tree into a set of style declarations.
  *
  * @param {Object}  blockStyles         Block styles.
@@ -211,6 +191,7 @@ function resolveRefValue( refObj, blockStyles ) {
  * @param {boolean} useRootPaddingAlign Whether to use CSS custom properties in root selector.
  *
  * @param {Object}  tree				A theme.json tree containing layout definitions.
+ *
  * @return {Array} An array of style declarations.
  */
 export function getStylesDeclarations(
@@ -293,8 +274,9 @@ export function getStylesDeclarations(
 			? rule.key
 			: kebabCase( rule.key );
 		let ruleValue = rule.value;
-		if ( typeof ruleValue !== 'string' ) {
-			ruleValue = resolveRefValue( rule.value, tree );
+		if ( typeof ruleValue !== 'string' && ruleValue?.ref ) {
+			const refPath = ruleValue.ref.split( '.' );
+			ruleValue = get( tree, refPath );
 		}
 		output.push( `${ cssProperty }: ${ compileStyleValue( ruleValue ) }` );
 	} );

--- a/packages/edit-site/src/components/global-styles/utils.js
+++ b/packages/edit-site/src/components/global-styles/utils.js
@@ -192,7 +192,7 @@ function getValueFromPresetVariable(
 	}
 
 	const presetObject = findInPresetsBy(
-		features,
+		features.settings,
 		blockName,
 		metadata.path,
 		'slug',
@@ -210,8 +210,8 @@ function getValueFromPresetVariable(
 
 function getValueFromCustomVariable( features, blockName, variable, path ) {
 	const result =
-		get( features, [ 'blocks', blockName, 'custom', ...path ] ) ??
-		get( features, [ 'custom', ...path ] );
+		get( features.settings, [ 'blocks', blockName, 'custom', ...path ] ) ??
+		get( features.settings, [ 'custom', ...path ] );
 	if ( ! result ) {
 		return variable;
 	}
@@ -219,36 +219,14 @@ function getValueFromCustomVariable( features, blockName, variable, path ) {
 	return getValueFromVariable( features, blockName, result );
 }
 
-export function getValueFromVariableOrRef(
-	themeJSONObject,
-	blockName,
-	variable
-) {
-	if ( typeof variable !== 'string' && variable?.ref ) {
-		variable = getValueFromRef( themeJSONObject, variable );
-	}
-	return getValueFromVariable(
-		themeJSONObject.settings,
-		blockName,
-		variable
-	);
-}
-
-function getValueFromRef( themeJSONObject, variable ) {
-	if (
-		typeof variable !== 'string' &&
-		variable?.ref &&
-		typeof variable.ref === 'string'
-	) {
-		const refPath = variable.ref.split( '.' );
-		variable = get( themeJSONObject, refPath );
-	}
-	return variable;
-}
-
 export function getValueFromVariable( features, blockName, variable ) {
 	if ( ! variable || typeof variable !== 'string' ) {
-		return variable;
+		if ( variable?.ref && typeof variable?.ref === 'string' ) {
+			const refPath = variable.ref.split( '.' );
+			variable = get( features, refPath );
+		} else {
+			return variable;
+		}
 	}
 	const USER_VALUE_PREFIX = 'var:';
 	const THEME_VALUE_PREFIX = 'var(--wp--';

--- a/packages/edit-site/src/components/global-styles/utils.js
+++ b/packages/edit-site/src/components/global-styles/utils.js
@@ -219,6 +219,26 @@ function getValueFromCustomVariable( features, blockName, variable, path ) {
 	return getValueFromVariable( features, blockName, result );
 }
 
+export function getValueFromVariableOrRef(
+	themeJSONObject,
+	blockName,
+	variable
+) {
+	if (
+		typeof variable !== 'string' &&
+		variable?.ref &&
+		typeof variable.ref === 'string'
+	) {
+		const refPath = variable.ref.split( '.' );
+		variable = get( themeJSONObject, refPath );
+	}
+	return getValueFromVariable(
+		themeJSONObject.settings,
+		blockName,
+		variable
+	);
+}
+
 export function getValueFromVariable( features, blockName, variable ) {
 	if ( ! variable || typeof variable !== 'string' ) {
 		return variable;

--- a/packages/edit-site/src/components/global-styles/utils.js
+++ b/packages/edit-site/src/components/global-styles/utils.js
@@ -224,6 +224,17 @@ export function getValueFromVariableOrRef(
 	blockName,
 	variable
 ) {
+	if ( typeof variable !== 'string' && variable?.ref ) {
+		variable = getValueFromRef( themeJSONObject, variable );
+	}
+	return getValueFromVariable(
+		themeJSONObject.settings,
+		blockName,
+		variable
+	);
+}
+
+function getValueFromRef( themeJSONObject, variable ) {
 	if (
 		typeof variable !== 'string' &&
 		variable?.ref &&
@@ -232,11 +243,7 @@ export function getValueFromVariableOrRef(
 		const refPath = variable.ref.split( '.' );
 		variable = get( themeJSONObject, refPath );
 	}
-	return getValueFromVariable(
-		themeJSONObject.settings,
-		blockName,
-		variable
-	);
+	return variable;
 }
 
 export function getValueFromVariable( features, blockName, variable ) {


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->
Fixes https://github.com/WordPress/gutenberg/issues/42890

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
https://github.com/WordPress/gutenberg/pull/41696/files implemented references on the frontend but they weren't being resolved in the site editor. In particular, they were breaking Global Styles.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
I created a function that resolved the references into the actual values being referenced. I'm not sure if this is the best place or best method to do this, but it solves the editor crashing because of the bug and keeps the editor consistent with the frontend. A next step would be to discuss how we want to surface this link to the users like @oandregal [mentioned](https://github.com/WordPress/gutenberg/issues/42890#issuecomment-1202318335). 

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->

With this PR checked, follow the instructions from https://github.com/WordPress/gutenberg/issues/42890 and see that the site editor doesn't crash when visiting the links section. 

## Screenshots or screencast <!-- if applicable -->

Rainfall uses refs for links too, you can test it there and see it doesn't crash:

<img width="1611" alt="Screenshot 2022-08-04 at 13 13 50" src="https://user-images.githubusercontent.com/3593343/182837087-1d65cb33-86ea-4a31-bc88-ae6b31a930a4.png">

