### PR TITLE
Site Editor: fix focus outline cut off in code editor

### DIFF
--- a/packages/edit-site/src/components/code-editor/style.scss
+++ b/packages/edit-site/src/components/code-editor/style.scss
@@ -6,14 +6,13 @@
 
 	&__body {
 		width: 100%;
-		padding: 0 $grid-unit-15 $grid-unit-15 $grid-unit-15;
+		padding: $grid-unit-15;
 		max-width: $break-xlarge;
 		margin-left: auto;
 		margin-right: auto;
 
 		@include break-large() {
-			padding: $grid-unit-20 $grid-unit-30 #{ $grid-unit-60 * 2 } $grid-unit-30;
-			padding: 0 $grid-unit-30 $grid-unit-30 $grid-unit-30;
+			padding: $grid-unit-30;
 		}
 	}
 


### PR DESCRIPTION
Fix #42979
## What?
This PR fixes a problem with focus outlines cut off when switching to code editor mode in the site editor.

## Why?
This problem occurs because the code editor and the toolbar on top (`.edit-site-code-editor__toolbar`) are adjacent to each other.

## How?
I added appropriate padding to the upper side.

## Screenshots or screencast

| View | On trunk | On this branch |
| --- | --- | --- |
| Desktop | ![trunk-desktop](https://user-images.githubusercontent.com/54422211/187078550-9e522ccd-8c1b-4e72-940d-5dee92f5d093.png) | ![branch-desktop](https://user-images.githubusercontent.com/54422211/187078851-b4459ead-d537-4994-abe6-657e4b7d819a.png) |
| Mobile | ![trunk-mobile](https://user-images.githubusercontent.com/54422211/187078559-977436ff-fa7f-4e6c-98e0-a3625ad8a79a.png) | ![branch-mobile](https://user-images.githubusercontent.com/54422211/187078867-a4c5229c-8963-48cd-8d76-f12bbec286d3.png) |