### PR TITLE
Improves the UX of menu management in the navigation block

### DIFF
--- a/packages/block-library/src/navigation/edit/index.js
+++ b/packages/block-library/src/navigation/edit/index.js
@@ -31,6 +31,7 @@ import {
 	__experimentalToggleGroupControl as ToggleGroupControl,
 	__experimentalToggleGroupControlOption as ToggleGroupControlOption,
 	__experimentalToolsPanel as ToolsPanel,
+	__experimentalToolsPanelItem as ToolsPanelItem,
 	ToolbarGroup,
 	Button,
 	Spinner,
@@ -808,6 +809,14 @@ function Navigation( {
 				</BlockControls>
 				<InspectorControls>
 					<ToolsPanel label={ __( 'Menu details' ) }>
+						<ToolsPanelItem
+							hasValue={ () => true }
+							label={ 'Some tool' }
+							onDeselect={ () => null }
+							isShownByDefault={ true }
+						>
+							<p>What?</p>
+						</ToolsPanelItem>
 						<ListView blocks={ innerBlocks } />
 					</ToolsPanel>
 				</InspectorControls>

--- a/packages/block-library/src/navigation/edit/index.js
+++ b/packages/block-library/src/navigation/edit/index.js
@@ -20,6 +20,7 @@ import {
 	getColorClassName,
 	Warning,
 	__experimentalUseBlockOverlayActive as useBlockOverlayActive,
+	__experimentalListView as ListView,
 } from '@wordpress/block-editor';
 import { EntityProvider } from '@wordpress/core-data';
 
@@ -29,6 +30,7 @@ import {
 	ToggleControl,
 	__experimentalToggleGroupControl as ToggleGroupControl,
 	__experimentalToggleGroupControlOption as ToggleGroupControlOption,
+	__experimentalToolsPanel as ToolsPanel,
 	ToolbarGroup,
 	Button,
 	Spinner,
@@ -804,6 +806,11 @@ function Navigation( {
 						</ToolbarGroup>
 					) }
 				</BlockControls>
+				<InspectorControls>
+					<ToolsPanel label={ __( 'Menu details' ) }>
+						<ListView blocks={ innerBlocks } />
+					</ToolsPanel>
+				</InspectorControls>
 				{ stylingInspectorControls }
 				{ isEntityAvailable && (
 					<InspectorControls __experimentalGroup="advanced">

--- a/packages/block-library/src/navigation/edit/index.js
+++ b/packages/block-library/src/navigation/edit/index.js
@@ -605,16 +605,15 @@ function Navigation( {
 							/* translators: %s: The name of a menu. */
 							actionLabel={ __( "Switch to '%s'" ) }
 						/>
-						{ hasManagePermissions && (
-							<Button
-								variant="link"
-								href={ addQueryArgs( 'edit.php', {
-									post_type: 'wp_navigation',
-								} ) }
-							>
-								{ __( 'Manage menus' ) }
-							</Button>
-						) }
+						<Button
+							variant="link"
+							disabled={ ! hasManagePermissions }
+							href={ addQueryArgs( 'edit.php', {
+								post_type: 'wp_navigation',
+							} ) }
+						>
+							{ __( 'Manage menus' ) }
+						</Button>
 					</PanelBody>
 				</InspectorControls>
 				{ stylingInspectorControls }
@@ -679,16 +678,15 @@ function Navigation( {
 							/* translators: %s: The name of a menu. */
 							actionLabel={ __( "Switch to '%s'" ) }
 						/>
-						{ hasManagePermissions && (
-							<Button
-								variant="link"
-								href={ addQueryArgs( 'edit.php', {
-									post_type: 'wp_navigation',
-								} ) }
-							>
-								{ __( 'Manage menus' ) }
-							</Button>
-						) }
+						<Button
+							variant="link"
+							disabled={ ! hasManagePermissions }
+							href={ addQueryArgs( 'edit.php', {
+								post_type: 'wp_navigation',
+							} ) }
+						>
+							{ __( 'Manage menus' ) }
+						</Button>
 					</PanelBody>
 				</InspectorControls>
 				<Warning>
@@ -783,16 +781,15 @@ function Navigation( {
 							/* translators: %s: The name of a menu. */
 							actionLabel={ __( "Switch to '%s'" ) }
 						/>
-						{ hasManagePermissions && (
-							<Button
-								variant="link"
-								href={ addQueryArgs( 'edit.php', {
-									post_type: 'wp_navigation',
-								} ) }
-							>
-								{ __( 'Manage menus' ) }
-							</Button>
-						) }
+						<Button
+							variant="link"
+							disabled={ ! hasManagePermissions }
+							href={ addQueryArgs( 'edit.php', {
+								post_type: 'wp_navigation',
+							} ) }
+						>
+							{ __( 'Manage menus' ) }
+						</Button>
 					</PanelBody>
 				</InspectorControls>
 				{ stylingInspectorControls }

--- a/packages/block-library/src/navigation/edit/index.js
+++ b/packages/block-library/src/navigation/edit/index.js
@@ -682,7 +682,7 @@ function Navigation( {
 					<PanelBody title={ __( 'Menu' ) }>
 						<NavigationMenuSelector
 							ref={ navigationSelectorRef }
-							currentMenuId={ ref }
+							currentMenuId={ null }
 							clientId={ clientId }
 							onSelectNavigationMenu={ ( menuId ) => {
 								handleUpdateMenu( menuId );

--- a/packages/block-library/src/navigation/edit/index.js
+++ b/packages/block-library/src/navigation/edit/index.js
@@ -428,6 +428,8 @@ function Navigation( {
 		ref,
 	] );
 
+	const hasManagePermissions =
+		canUserCreateNavigationMenu || canUserUpdateNavigationMenu;
 	const navigationSelectorRef = useRef();
 	const [ shouldFocusNavigationSelector, setShouldFocusNavigationSelector ] =
 		useState( false );
@@ -625,16 +627,17 @@ function Navigation( {
 							onCreateNew={ () => createNavigationMenu( '', [] ) }
 							/* translators: %s: The name of a menu. */
 							actionLabel={ __( "Switch to '%s'" ) }
-							showManageActions
 						/>
-						<Button
-							variant="link"
-							href={ addQueryArgs( 'edit.php', {
-								post_type: 'wp_navigation',
-							} ) }
-						>
-							{ __( 'Manage menus' ) }
-						</Button>
+						{ hasManagePermissions && (
+							<Button
+								variant="link"
+								href={ addQueryArgs( 'edit.php', {
+									post_type: 'wp_navigation',
+								} ) }
+							>
+								{ __( 'Manage menus' ) }
+							</Button>
+						) }
 					</PanelBody>
 				</InspectorControls>
 				{ stylingInspectorControls }
@@ -701,16 +704,17 @@ function Navigation( {
 							onCreateNew={ () => createNavigationMenu( '', [] ) }
 							/* translators: %s: The name of a menu. */
 							actionLabel={ __( "Switch to '%s'" ) }
-							showManageActions
 						/>
-						<Button
-							variant="link"
-							href={ addQueryArgs( 'edit.php', {
-								post_type: 'wp_navigation',
-							} ) }
-						>
-							{ __( 'Manage menus' ) }
-						</Button>
+						{ hasManagePermissions && (
+							<Button
+								variant="link"
+								href={ addQueryArgs( 'edit.php', {
+									post_type: 'wp_navigation',
+								} ) }
+							>
+								{ __( 'Manage menus' ) }
+							</Button>
+						) }
 					</PanelBody>
 				</InspectorControls>
 				<Warning>
@@ -809,16 +813,17 @@ function Navigation( {
 							onCreateNew={ () => createNavigationMenu( '', [] ) }
 							/* translators: %s: The name of a menu. */
 							actionLabel={ __( "Switch to '%s'" ) }
-							showManageActions
 						/>
-						<Button
-							variant="link"
-							href={ addQueryArgs( 'edit.php', {
-								post_type: 'wp_navigation',
-							} ) }
-						>
-							{ __( 'Manage menus' ) }
-						</Button>
+						{ hasManagePermissions && (
+							<Button
+								variant="link"
+								href={ addQueryArgs( 'edit.php', {
+									post_type: 'wp_navigation',
+								} ) }
+							>
+								{ __( 'Manage menus' ) }
+							</Button>
+						) }
 					</PanelBody>
 				</InspectorControls>
 				{ stylingInspectorControls }

--- a/packages/block-library/src/navigation/edit/index.js
+++ b/packages/block-library/src/navigation/edit/index.js
@@ -602,12 +602,18 @@ function Navigation( {
 								}
 							} }
 							onCreateNew={ createUntitledEmptyNavigationMenu }
+							createNavigationMenuIsSuccess={
+								createNavigationMenuIsSuccess
+							}
 							/* translators: %s: The name of a menu. */
 							actionLabel={ __( "Switch to '%s'" ) }
 						/>
 						<Button
 							variant="link"
-							disabled={ ! hasManagePermissions }
+							disabled={
+								! hasManagePermissions ||
+								! hasResolvedNavigationMenus
+							}
 							href={ addQueryArgs( 'edit.php', {
 								post_type: 'wp_navigation',
 							} ) }
@@ -675,12 +681,18 @@ function Navigation( {
 								}
 							} }
 							onCreateNew={ createUntitledEmptyNavigationMenu }
+							createNavigationMenuIsSuccess={
+								createNavigationMenuIsSuccess
+							}
 							/* translators: %s: The name of a menu. */
 							actionLabel={ __( "Switch to '%s'" ) }
 						/>
 						<Button
 							variant="link"
-							disabled={ ! hasManagePermissions }
+							disabled={
+								! hasManagePermissions ||
+								! hasResolvedNavigationMenus
+							}
 							href={ addQueryArgs( 'edit.php', {
 								post_type: 'wp_navigation',
 							} ) }
@@ -778,12 +790,18 @@ function Navigation( {
 								}
 							} }
 							onCreateNew={ createUntitledEmptyNavigationMenu }
+							createNavigationMenuIsSuccess={
+								createNavigationMenuIsSuccess
+							}
 							/* translators: %s: The name of a menu. */
 							actionLabel={ __( "Switch to '%s'" ) }
 						/>
 						<Button
 							variant="link"
-							disabled={ ! hasManagePermissions }
+							disabled={
+								! hasManagePermissions ||
+								! hasResolvedNavigationMenus
+							}
 							href={ addQueryArgs( 'edit.php', {
 								post_type: 'wp_navigation',
 							} ) }

--- a/packages/block-library/src/navigation/edit/index.js
+++ b/packages/block-library/src/navigation/edit/index.js
@@ -808,12 +808,13 @@ function Navigation( {
 					) }
 				</BlockControls>
 				<InspectorControls>
-					<ToolsPanel label={ __( 'Menu details' ) }>
+					<ToolsPanel label={ __( 'Menu items' ) }>
 						<ToolsPanelItem
-							hasValue={ () => true }
+							hasValue={ () => false }
 							label={ 'Some tool' }
+							onSelect={ () => null }
 							onDeselect={ () => null }
-							isShownByDefault={ true }
+							isShownByDefault={ false }
 						>
 							<p>What?</p>
 						</ToolsPanelItem>

--- a/packages/block-library/src/navigation/edit/index.js
+++ b/packages/block-library/src/navigation/edit/index.js
@@ -147,7 +147,9 @@ function Navigation( {
 		}
 
 		if ( createNavigationMenuIsSuccess ) {
-			handleUpdateMenu( createNavigationMenuPost.id, true );
+			handleUpdateMenu( createNavigationMenuPost.id, {
+				focusNavigationBlock: true,
+			} );
 
 			showNavigationMenuStatusNotice(
 				__( `Navigation Menu successfully created.` )
@@ -332,7 +334,11 @@ function Navigation( {
 	] = useState();
 	const [ detectedOverlayColor, setDetectedOverlayColor ] = useState();
 
-	const handleUpdateMenu = ( menuId, focusNavigationBlock = false ) => {
+	const handleUpdateMenu = (
+		menuId,
+		options = { focusNavigationBlock: false }
+	) => {
+		const { focusNavigationBlock } = options;
 		setRef( menuId );
 		if ( focusNavigationBlock ) {
 			selectBlock( clientId );
@@ -598,7 +604,9 @@ function Navigation( {
 									classicMenu.name
 								);
 								if ( navMenu ) {
-									handleUpdateMenu( navMenu.id, true );
+									handleUpdateMenu( navMenu.id, {
+										focusNavigationBlock: true,
+									} );
 								}
 							} }
 							onCreateNew={ createUntitledEmptyNavigationMenu }
@@ -677,7 +685,9 @@ function Navigation( {
 									classicMenu.name
 								);
 								if ( navMenu ) {
-									handleUpdateMenu( navMenu.id, true );
+									handleUpdateMenu( navMenu.id, {
+										focusNavigationBlock: true,
+									} );
 								}
 							} }
 							onCreateNew={ createUntitledEmptyNavigationMenu }
@@ -760,7 +770,9 @@ function Navigation( {
 							classicMenu.name
 						);
 						if ( navMenu ) {
-							handleUpdateMenu( navMenu.id, true );
+							handleUpdateMenu( navMenu.id, {
+								focusNavigationBlock: true,
+							} );
 						}
 					} }
 					onCreateEmpty={ createUntitledEmptyNavigationMenu }
@@ -786,12 +798,17 @@ function Navigation( {
 									classicMenu.name
 								);
 								if ( navMenu ) {
-									handleUpdateMenu( navMenu.id, true );
+									handleUpdateMenu( navMenu.id, {
+										focusNavigationBlock: true,
+									} );
 								}
 							} }
 							onCreateNew={ createUntitledEmptyNavigationMenu }
 							createNavigationMenuIsSuccess={
 								createNavigationMenuIsSuccess
+							}
+							createNavigationMenuIsError={
+								createNavigationMenuIsError
 							}
 							/* translators: %s: The name of a menu. */
 							actionLabel={ __( "Switch to '%s'" ) }

--- a/packages/block-library/src/navigation/edit/index.js
+++ b/packages/block-library/src/navigation/edit/index.js
@@ -135,6 +135,10 @@ function Navigation( {
 		isError: createNavigationMenuIsError,
 	} = useCreateNavigationMenu( clientId );
 
+	const createUntitledEmptyNavigationMenu = () => {
+		createNavigationMenu( '' );
+	};
+
 	useEffect( () => {
 		hideNavigationMenuStatusNotice();
 
@@ -143,8 +147,7 @@ function Navigation( {
 		}
 
 		if ( createNavigationMenuIsSuccess ) {
-			setRef( createNavigationMenuPost.id );
-			selectBlock( clientId );
+			handleUpdateMenu( createNavigationMenuPost.id, true );
 
 			showNavigationMenuStatusNotice(
 				__( `Navigation Menu successfully created.` )
@@ -157,7 +160,6 @@ function Navigation( {
 			);
 		}
 	}, [
-		createNavigationMenu,
 		createNavigationMenuStatus,
 		createNavigationMenuError,
 		createNavigationMenuPost,
@@ -193,7 +195,6 @@ function Navigation( {
 		isNavigationMenuResolved,
 		isNavigationMenuMissing,
 		navigationMenus,
-		navigationMenu,
 		canUserUpdateNavigationMenu,
 		hasResolvedCanUserUpdateNavigationMenu,
 		canUserDeleteNavigationMenu,
@@ -241,8 +242,6 @@ function Navigation( {
 	}, [ navigationMenus ] );
 
 	const navRef = useRef();
-
-	const isDraftNavigationMenu = navigationMenu?.status === 'draft';
 
 	const {
 		convert: convertClassicMenu,
@@ -333,9 +332,11 @@ function Navigation( {
 	] = useState();
 	const [ detectedOverlayColor, setDetectedOverlayColor ] = useState();
 
-	const handleUpdateMenu = ( menuId ) => {
+	const handleUpdateMenu = ( menuId, focusNavigationBlock = false ) => {
 		setRef( menuId );
-		selectBlock( clientId );
+		if ( focusNavigationBlock ) {
+			selectBlock( clientId );
+		}
 	};
 
 	useEffect( () => {
@@ -430,27 +431,6 @@ function Navigation( {
 
 	const hasManagePermissions =
 		canUserCreateNavigationMenu || canUserUpdateNavigationMenu;
-	const navigationSelectorRef = useRef();
-	const [ shouldFocusNavigationSelector, setShouldFocusNavigationSelector ] =
-		useState( false );
-
-	// Focus support after menu selection.
-	useEffect( () => {
-		if (
-			isDraftNavigationMenu ||
-			! isEntityAvailable ||
-			! shouldFocusNavigationSelector
-		) {
-			return;
-		}
-		navigationSelectorRef?.current?.focus();
-		setShouldFocusNavigationSelector( false );
-	}, [
-		isDraftNavigationMenu,
-		isEntityAvailable,
-		shouldFocusNavigationSelector,
-	] );
-
 	const isResponsive = 'never' !== overlayMenu;
 
 	const overlayMenuPreviewClasses = classnames(
@@ -607,12 +587,10 @@ function Navigation( {
 				<InspectorControls>
 					<PanelBody title={ __( 'Menu' ) }>
 						<NavigationMenuSelector
-							ref={ navigationSelectorRef }
 							currentMenuId={ ref }
 							clientId={ clientId }
 							onSelectNavigationMenu={ ( menuId ) => {
 								handleUpdateMenu( menuId );
-								setShouldFocusNavigationSelector( true );
 							} }
 							onSelectClassicMenu={ async ( classicMenu ) => {
 								const navMenu = await convertClassicMenu(
@@ -620,11 +598,10 @@ function Navigation( {
 									classicMenu.name
 								);
 								if ( navMenu ) {
-									handleUpdateMenu( navMenu.id );
-									setShouldFocusNavigationSelector( true );
+									handleUpdateMenu( navMenu.id, true );
 								}
 							} }
-							onCreateNew={ () => createNavigationMenu( '', [] ) }
+							onCreateNew={ createUntitledEmptyNavigationMenu }
 							/* translators: %s: The name of a menu. */
 							actionLabel={ __( "Switch to '%s'" ) }
 						/>
@@ -684,12 +661,10 @@ function Navigation( {
 				<InspectorControls>
 					<PanelBody title={ __( 'Menu' ) }>
 						<NavigationMenuSelector
-							ref={ navigationSelectorRef }
 							currentMenuId={ null }
 							clientId={ clientId }
 							onSelectNavigationMenu={ ( menuId ) => {
 								handleUpdateMenu( menuId );
-								setShouldFocusNavigationSelector( true );
 							} }
 							onSelectClassicMenu={ async ( classicMenu ) => {
 								const navMenu = await convertClassicMenu(
@@ -697,11 +672,10 @@ function Navigation( {
 									classicMenu.name
 								);
 								if ( navMenu ) {
-									handleUpdateMenu( navMenu.id );
-									setShouldFocusNavigationSelector( true );
+									handleUpdateMenu( navMenu.id, true );
 								}
 							} }
-							onCreateNew={ () => createNavigationMenu( '', [] ) }
+							onCreateNew={ createUntitledEmptyNavigationMenu }
 							/* translators: %s: The name of a menu. */
 							actionLabel={ __( "Switch to '%s'" ) }
 						/>
@@ -722,7 +696,7 @@ function Navigation( {
 						'Navigation menu has been deleted or is unavailable. '
 					) }
 					<Button
-						onClick={ () => createNavigationMenu( '', [] ) }
+						onClick={ createUntitledEmptyNavigationMenu }
 						variant="link"
 					>
 						{ __( 'Create a new menu?' ) }
@@ -769,7 +743,6 @@ function Navigation( {
 					}
 					onSelectNavigationMenu={ ( menuId ) => {
 						handleUpdateMenu( menuId );
-						setShouldFocusNavigationSelector( true );
 					} }
 					onSelectClassicMenu={ async ( classicMenu ) => {
 						const navMenu = await convertClassicMenu(
@@ -777,11 +750,10 @@ function Navigation( {
 							classicMenu.name
 						);
 						if ( navMenu ) {
-							handleUpdateMenu( navMenu.id );
-							setShouldFocusNavigationSelector( true );
+							handleUpdateMenu( navMenu.id, true );
 						}
 					} }
-					onCreateEmpty={ () => createNavigationMenu( '', [] ) }
+					onCreateEmpty={ createUntitledEmptyNavigationMenu }
 				/>
 			</TagName>
 		);
@@ -793,12 +765,10 @@ function Navigation( {
 				<InspectorControls>
 					<PanelBody title={ __( 'Menu' ) }>
 						<NavigationMenuSelector
-							ref={ navigationSelectorRef }
 							currentMenuId={ ref }
 							clientId={ clientId }
 							onSelectNavigationMenu={ ( menuId ) => {
 								handleUpdateMenu( menuId );
-								setShouldFocusNavigationSelector( true );
 							} }
 							onSelectClassicMenu={ async ( classicMenu ) => {
 								const navMenu = await convertClassicMenu(
@@ -806,11 +776,10 @@ function Navigation( {
 									classicMenu.name
 								);
 								if ( navMenu ) {
-									handleUpdateMenu( navMenu.id );
-									setShouldFocusNavigationSelector( true );
+									handleUpdateMenu( navMenu.id, true );
 								}
 							} }
-							onCreateNew={ () => createNavigationMenu( '', [] ) }
+							onCreateNew={ createUntitledEmptyNavigationMenu }
 							/* translators: %s: The name of a menu. */
 							actionLabel={ __( "Switch to '%s'" ) }
 						/>

--- a/packages/block-library/src/navigation/edit/index.js
+++ b/packages/block-library/src/navigation/edit/index.js
@@ -7,9 +7,9 @@ import classnames from 'classnames';
  * WordPress dependencies
  */
 import { useState, useEffect, useRef, Platform } from '@wordpress/element';
+import { addQueryArgs } from '@wordpress/url';
 import {
 	InspectorControls,
-	BlockControls,
 	useBlockProps,
 	__experimentalRecursionProvider as RecursionProvider,
 	__experimentalUseHasRecursion as useHasRecursion,
@@ -20,7 +20,6 @@ import {
 	getColorClassName,
 	Warning,
 	__experimentalUseBlockOverlayActive as useBlockOverlayActive,
-	__experimentalListView as ListView,
 } from '@wordpress/block-editor';
 import { EntityProvider } from '@wordpress/core-data';
 
@@ -30,9 +29,6 @@ import {
 	ToggleControl,
 	__experimentalToggleGroupControl as ToggleGroupControl,
 	__experimentalToggleGroupControlOption as ToggleGroupControlOption,
-	__experimentalToolsPanel as ToolsPanel,
-	__experimentalToolsPanelItem as ToolsPanelItem,
-	ToolbarGroup,
 	Button,
 	Spinner,
 } from '@wordpress/components';
@@ -606,11 +602,11 @@ function Navigation( {
 	if ( hasUnsavedBlocks ) {
 		return (
 			<TagName { ...blockProps }>
-				<BlockControls>
-					<ToolbarGroup className="wp-block-navigation__toolbar-menu-selector">
+				<InspectorControls>
+					<PanelBody title={ __( 'Menu' ) }>
 						<NavigationMenuSelector
-							ref={ null }
-							currentMenuId={ null }
+							ref={ navigationSelectorRef }
+							currentMenuId={ ref }
 							clientId={ clientId }
 							onSelectNavigationMenu={ ( menuId ) => {
 								handleUpdateMenu( menuId );
@@ -631,8 +627,16 @@ function Navigation( {
 							actionLabel={ __( "Switch to '%s'" ) }
 							showManageActions
 						/>
-					</ToolbarGroup>
-				</BlockControls>
+						<Button
+							variant="link"
+							href={ addQueryArgs( 'edit.php', {
+								post_type: 'wp_navigation',
+							} ) }
+						>
+							{ __( 'Manage menus' ) }
+						</Button>
+					</PanelBody>
+				</InspectorControls>
 				{ stylingInspectorControls }
 				<ResponsiveWrapper
 					id={ clientId }
@@ -674,8 +678,8 @@ function Navigation( {
 	if ( ref && isNavigationMenuMissing ) {
 		return (
 			<TagName { ...blockProps }>
-				<BlockControls>
-					<ToolbarGroup className="wp-block-navigation__toolbar-menu-selector">
+				<InspectorControls>
+					<PanelBody title={ __( 'Menu' ) }>
 						<NavigationMenuSelector
 							ref={ navigationSelectorRef }
 							currentMenuId={ ref }
@@ -699,8 +703,16 @@ function Navigation( {
 							actionLabel={ __( "Switch to '%s'" ) }
 							showManageActions
 						/>
-					</ToolbarGroup>
-				</BlockControls>
+						<Button
+							variant="link"
+							href={ addQueryArgs( 'edit.php', {
+								post_type: 'wp_navigation',
+							} ) }
+						>
+							{ __( 'Manage menus' ) }
+						</Button>
+					</PanelBody>
+				</InspectorControls>
 				<Warning>
 					{ __(
 						'Navigation menu has been deleted or is unavailable. '
@@ -774,52 +786,40 @@ function Navigation( {
 	return (
 		<EntityProvider kind="postType" type="wp_navigation" id={ ref }>
 			<RecursionProvider uniqueId={ recursionId }>
-				<BlockControls>
-					{ ! isDraftNavigationMenu && isEntityAvailable && (
-						<ToolbarGroup className="wp-block-navigation__toolbar-menu-selector">
-							<NavigationMenuSelector
-								ref={ navigationSelectorRef }
-								currentMenuId={ ref }
-								clientId={ clientId }
-								onSelectNavigationMenu={ ( menuId ) => {
-									handleUpdateMenu( menuId );
-									setShouldFocusNavigationSelector( true );
-								} }
-								onSelectClassicMenu={ async ( classicMenu ) => {
-									const navMenu = await convertClassicMenu(
-										classicMenu.id,
-										classicMenu.name
-									);
-									if ( navMenu ) {
-										handleUpdateMenu( navMenu.id );
-										setShouldFocusNavigationSelector(
-											true
-										);
-									}
-								} }
-								onCreateNew={ () =>
-									createNavigationMenu( '', [] )
-								}
-								/* translators: %s: The name of a menu. */
-								actionLabel={ __( "Switch to '%s'" ) }
-								showManageActions
-							/>
-						</ToolbarGroup>
-					) }
-				</BlockControls>
 				<InspectorControls>
-					<ToolsPanel label={ __( 'Menu items' ) }>
-						<ToolsPanelItem
-							hasValue={ () => false }
-							label={ 'Some tool' }
-							onSelect={ () => null }
-							onDeselect={ () => null }
-							isShownByDefault={ false }
+					<PanelBody title={ __( 'Menu' ) }>
+						<NavigationMenuSelector
+							ref={ navigationSelectorRef }
+							currentMenuId={ ref }
+							clientId={ clientId }
+							onSelectNavigationMenu={ ( menuId ) => {
+								handleUpdateMenu( menuId );
+								setShouldFocusNavigationSelector( true );
+							} }
+							onSelectClassicMenu={ async ( classicMenu ) => {
+								const navMenu = await convertClassicMenu(
+									classicMenu.id,
+									classicMenu.name
+								);
+								if ( navMenu ) {
+									handleUpdateMenu( navMenu.id );
+									setShouldFocusNavigationSelector( true );
+								}
+							} }
+							onCreateNew={ () => createNavigationMenu( '', [] ) }
+							/* translators: %s: The name of a menu. */
+							actionLabel={ __( "Switch to '%s'" ) }
+							showManageActions
+						/>
+						<Button
+							variant="link"
+							href={ addQueryArgs( 'edit.php', {
+								post_type: 'wp_navigation',
+							} ) }
 						>
-							<p>What?</p>
-						</ToolsPanelItem>
-						<ListView blocks={ innerBlocks } />
-					</ToolsPanel>
+							{ __( 'Manage menus' ) }
+						</Button>
+					</PanelBody>
 				</InspectorControls>
 				{ stylingInspectorControls }
 				{ isEntityAvailable && (

--- a/packages/block-library/src/navigation/edit/navigation-menu-selector.js
+++ b/packages/block-library/src/navigation/edit/navigation-menu-selector.js
@@ -9,7 +9,7 @@ import {
 } from '@wordpress/components';
 import { __, sprintf } from '@wordpress/i18n';
 import { decodeEntities } from '@wordpress/html-entities';
-import { forwardRef, useMemo } from '@wordpress/element';
+import { forwardRef, useMemo, useState } from '@wordpress/element';
 
 /**
  * Internal dependencies
@@ -48,14 +48,14 @@ function NavigationMenuSelector(
 		canSwitchNavigationMenu,
 	} = useNavigationMenu();
 
-	let selectorLabel = '';
+	const [ selectorLabel, setSelectorLabel ] = useState( '' );
 
 	const menuChoices = useMemo( () => {
 		return (
 			navigationMenus?.map( ( { id, title } ) => {
 				const label = decodeEntities( title.rendered );
 				if ( id === currentMenuId ) {
-					selectorLabel = label;
+					setSelectorLabel( label );
 				}
 				return {
 					value: id,
@@ -64,7 +64,7 @@ function NavigationMenuSelector(
 				};
 			} ) || []
 		);
-	}, [ navigationMenus ] );
+	}, [ currentMenuId ] );
 
 	const hasNavigationMenus = !! navigationMenus?.length;
 	const hasClassicMenus = !! classicMenus?.length;

--- a/packages/block-library/src/navigation/edit/navigation-menu-selector.js
+++ b/packages/block-library/src/navigation/edit/navigation-menu-selector.js
@@ -24,7 +24,6 @@ function NavigationMenuSelector(
 		onSelectNavigationMenu,
 		onSelectClassicMenu,
 		onCreateNew,
-		showManageActions = false,
 		actionLabel,
 		toggleProps = {},
 	},
@@ -98,7 +97,7 @@ function NavigationMenuSelector(
 	const showSelectMenus =
 		( ( canSwitchNavigationMenu || canUserCreateNavigationMenu ) &&
 			( hasNavigationMenus || hasClassicMenus ) ) ||
-		( hasManagePermissions && showManageActions );
+		hasManagePermissions;
 
 	if ( ! showSelectMenus ) {
 		return null;
@@ -150,7 +149,7 @@ function NavigationMenuSelector(
 						</MenuGroup>
 					) }
 
-					{ showManageActions && hasManagePermissions && (
+					{ hasManagePermissions && (
 						<MenuGroup label={ __( 'Tools' ) }>
 							{ canUserCreateNavigationMenu && (
 								<MenuItem onClick={ onCreateNew }>

--- a/packages/block-library/src/navigation/edit/navigation-menu-selector.js
+++ b/packages/block-library/src/navigation/edit/navigation-menu-selector.js
@@ -9,7 +9,7 @@ import {
 } from '@wordpress/components';
 import { __, sprintf } from '@wordpress/i18n';
 import { decodeEntities } from '@wordpress/html-entities';
-import { forwardRef, useMemo, useState } from '@wordpress/element';
+import { forwardRef, useEffect, useMemo, useState } from '@wordpress/element';
 
 /**
  * Internal dependencies
@@ -64,7 +64,7 @@ function NavigationMenuSelector(
 				};
 			} ) || []
 		);
-	}, [ currentMenuId ] );
+	}, [ currentMenuId, navigationMenus ] );
 
 	const hasNavigationMenus = !! navigationMenus?.length;
 	const hasClassicMenus = !! classicMenus?.length;
@@ -72,6 +72,14 @@ function NavigationMenuSelector(
 	const showClassicMenus = !! canUserCreateNavigationMenu;
 	const hasManagePermissions =
 		canUserCreateNavigationMenu || canUserUpdateNavigationMenu;
+
+	useEffect( () => {
+		if ( ! ( hasNavigationMenus && hasClassicMenus ) ) {
+			setSelectorLabel( __( 'No menus. Create one?' ) );
+		} else if ( currentMenuId === null ) {
+			setSelectorLabel( __( 'Select another menu' ) );
+		}
+	}, [ currentMenuId, hasNavigationMenus, hasClassicMenus ] );
 
 	// Show the selector if:
 	// - has switch or create permissions and there are block or classic menus.

--- a/packages/block-library/src/navigation/edit/navigation-menu-selector.js
+++ b/packages/block-library/src/navigation/edit/navigation-menu-selector.js
@@ -85,12 +85,12 @@ function NavigationMenuSelector(
 		canUserCreateNavigationMenu || canUserUpdateNavigationMenu;
 
 	useEffect( () => {
-		if ( ! ( hasNavigationMenus && hasClassicMenus ) ) {
+		if ( ! hasNavigationMenus ) {
 			setSelectorLabel( __( 'No menus. Create one?' ) );
 		} else if ( currentMenuId === null ) {
 			setSelectorLabel( __( 'Select another menu' ) );
 		}
-	}, [ currentMenuId, hasNavigationMenus, hasClassicMenus ] );
+	}, [ currentMenuId, hasNavigationMenus ] );
 
 	// Show the selector if:
 	// - has switch or create permissions and there are block or classic menus.

--- a/packages/block-library/src/navigation/edit/navigation-menu-selector.js
+++ b/packages/block-library/src/navigation/edit/navigation-menu-selector.js
@@ -5,11 +5,10 @@ import {
 	MenuGroup,
 	MenuItem,
 	MenuItemsChoice,
-	ToolbarDropdownMenu,
+	DropdownMenu,
 } from '@wordpress/components';
 import { __, sprintf } from '@wordpress/i18n';
 import { decodeEntities } from '@wordpress/html-entities';
-import { addQueryArgs } from '@wordpress/url';
 import { forwardRef, useMemo } from '@wordpress/element';
 
 /**
@@ -33,6 +32,11 @@ function NavigationMenuSelector(
 	/* translators: %s: The name of a menu. */
 	const createActionLabel = __( "Create from '%s'" );
 
+	toggleProps = {
+		...toggleProps,
+		className: 'wp-block-navigation__navigation-selector-button',
+	};
+
 	actionLabel = actionLabel || createActionLabel;
 
 	const { menus: classicMenus } = useNavigationEntities();
@@ -44,10 +48,15 @@ function NavigationMenuSelector(
 		canSwitchNavigationMenu,
 	} = useNavigationMenu();
 
+	let selectorLabel = '';
+
 	const menuChoices = useMemo( () => {
 		return (
 			navigationMenus?.map( ( { id, title } ) => {
 				const label = decodeEntities( title.rendered );
+				if ( id === currentMenuId ) {
+					selectorLabel = label;
+				}
 				return {
 					value: id,
 					label,
@@ -77,10 +86,11 @@ function NavigationMenuSelector(
 	}
 
 	return (
-		<ToolbarDropdownMenu
+		<DropdownMenu
+			className="wp-block-navigation__navigation-selector"
 			ref={ forwardedRef }
-			label={ __( 'Select Menu' ) }
-			text={ __( 'Select Menu' ) }
+			label={ selectorLabel }
+			text={ selectorLabel }
 			icon={ null }
 			toggleProps={ toggleProps }
 		>
@@ -128,18 +138,11 @@ function NavigationMenuSelector(
 									{ __( 'Create new menu' ) }
 								</MenuItem>
 							) }
-							<MenuItem
-								href={ addQueryArgs( 'edit.php', {
-									post_type: 'wp_navigation',
-								} ) }
-							>
-								{ __( 'Manage menus' ) }
-							</MenuItem>
 						</MenuGroup>
 					) }
 				</>
 			) }
-		</ToolbarDropdownMenu>
+		</DropdownMenu>
 	);
 }
 

--- a/packages/block-library/src/navigation/edit/navigation-menu-selector.js
+++ b/packages/block-library/src/navigation/edit/navigation-menu-selector.js
@@ -7,6 +7,7 @@ import {
 	MenuItemsChoice,
 	DropdownMenu,
 } from '@wordpress/components';
+import { Icon, chevronUp, chevronDown } from '@wordpress/icons';
 import { __, sprintf } from '@wordpress/i18n';
 import { decodeEntities } from '@wordpress/html-entities';
 import { forwardRef, useEffect, useMemo, useState } from '@wordpress/element';
@@ -32,9 +33,21 @@ function NavigationMenuSelector(
 	/* translators: %s: The name of a menu. */
 	const createActionLabel = __( "Create from '%s'" );
 
+	const [ selectorLabel, setSelectorLabel ] = useState( '' );
+	const [ isPressed, setIsPressed ] = useState( false );
+
 	toggleProps = {
 		...toggleProps,
 		className: 'wp-block-navigation__navigation-selector-button',
+		children: (
+			<Icon
+				icon={ isPressed ? chevronUp : chevronDown }
+				className="wp-block-navigation__navigation-selector-button__icon"
+			/>
+		),
+		onClick: () => {
+			setIsPressed( ! isPressed );
+		},
 	};
 
 	actionLabel = actionLabel || createActionLabel;
@@ -47,8 +60,6 @@ function NavigationMenuSelector(
 		canUserUpdateNavigationMenu,
 		canSwitchNavigationMenu,
 	} = useNavigationMenu();
-
-	const [ selectorLabel, setSelectorLabel ] = useState( '' );
 
 	const menuChoices = useMemo( () => {
 		return (

--- a/packages/block-library/src/navigation/edit/navigation-menu-selector.js
+++ b/packages/block-library/src/navigation/edit/navigation-menu-selector.js
@@ -10,7 +10,7 @@ import {
 import { Icon, chevronUp, chevronDown } from '@wordpress/icons';
 import { __, sprintf } from '@wordpress/i18n';
 import { decodeEntities } from '@wordpress/html-entities';
-import { forwardRef, useEffect, useMemo, useState } from '@wordpress/element';
+import { useEffect, useMemo, useState } from '@wordpress/element';
 
 /**
  * Internal dependencies
@@ -18,17 +18,14 @@ import { forwardRef, useEffect, useMemo, useState } from '@wordpress/element';
 import useNavigationMenu from '../use-navigation-menu';
 import useNavigationEntities from '../use-navigation-entities';
 
-function NavigationMenuSelector(
-	{
-		currentMenuId,
-		onSelectNavigationMenu,
-		onSelectClassicMenu,
-		onCreateNew,
-		actionLabel,
-		toggleProps = {},
-	},
-	forwardedRef
-) {
+function NavigationMenuSelector( {
+	currentMenuId,
+	onSelectNavigationMenu,
+	onSelectClassicMenu,
+	onCreateNew,
+	actionLabel,
+	toggleProps = {},
+} ) {
 	/* translators: %s: The name of a menu. */
 	const createActionLabel = __( "Create from '%s'" );
 
@@ -106,20 +103,18 @@ function NavigationMenuSelector(
 	return (
 		<DropdownMenu
 			className="wp-block-navigation__navigation-selector"
-			ref={ forwardedRef }
 			label={ selectorLabel }
 			text={ selectorLabel }
 			icon={ null }
 			toggleProps={ toggleProps }
 		>
-			{ ( { onClose } ) => (
+			{ () => (
 				<>
 					{ showNavigationMenus && hasNavigationMenus && (
 						<MenuGroup label={ __( 'Menus' ) }>
 							<MenuItemsChoice
 								value={ currentMenuId }
 								onSelect={ ( menuId ) => {
-									onClose();
 									onSelectNavigationMenu( menuId );
 								} }
 								choices={ menuChoices }
@@ -133,7 +128,6 @@ function NavigationMenuSelector(
 								return (
 									<MenuItem
 										onClick={ () => {
-											onClose();
 											onSelectClassicMenu( menu );
 										} }
 										key={ menu.id }
@@ -164,4 +158,4 @@ function NavigationMenuSelector(
 	);
 }
 
-export default forwardRef( NavigationMenuSelector );
+export default NavigationMenuSelector;

--- a/packages/block-library/src/navigation/editor.scss
+++ b/packages/block-library/src/navigation/editor.scss
@@ -627,15 +627,11 @@ body.editor-styles-wrapper
 .wp-block-navigation__navigation-selector-button {
 	width: 100%;
 	border: 1px solid;
+	justify-content: space-between;
 }
 
 .wp-block-navigation__navigation-selector-button--createnew {
 	width: 100%;
 	border: 1px solid;
 	margin-bottom: $grid-unit-20;
-}
-
-.wp-block-navigation__navigation-selector-button__icon {
-	position: absolute;
-	right: $grid-unit-30;
 }

--- a/packages/block-library/src/navigation/editor.scss
+++ b/packages/block-library/src/navigation/editor.scss
@@ -620,18 +620,18 @@ body.editor-styles-wrapper
  * Navigation selector styles
  */
 .wp-block-navigation__navigation-selector {
-	width: 100%;
 	margin-bottom: $grid-unit-20;
+	width: 100%;
 }
 
 .wp-block-navigation__navigation-selector-button {
-	width: 100%;
 	border: 1px solid;
 	justify-content: space-between;
+	width: 100%;
 }
 
 .wp-block-navigation__navigation-selector-button--createnew {
-	width: 100%;
 	border: 1px solid;
 	margin-bottom: $grid-unit-20;
+	width: 100%;
 }

--- a/packages/block-library/src/navigation/editor.scss
+++ b/packages/block-library/src/navigation/editor.scss
@@ -615,3 +615,27 @@ body.editor-styles-wrapper
 	// Override the default padding of ToggleGroupControlOption.
 	padding: 0 3px;
 }
+
+/**
+ * Navigation selector styles
+ */
+.wp-block-navigation__navigation-selector {
+	width: 100%;
+	margin-bottom: $grid-unit-20;
+}
+
+.wp-block-navigation__navigation-selector-button {
+	width: 100%;
+	border: 1px solid;
+}
+
+.wp-block-navigation__navigation-selector-button--createnew {
+	width: 100%;
+	border: 1px solid;
+	margin-bottom: $grid-unit-20;
+}
+
+.wp-block-navigation__navigation-selector-button__icon {
+	position: absolute;
+	right: $grid-unit-30;
+}

--- a/packages/block-library/src/navigation/style.scss
+++ b/packages/block-library/src/navigation/style.scss
@@ -694,6 +694,12 @@ button.wp-block-navigation-item__content {
 	border: 1px solid;
 }
 
+.wp-block-navigation__navigation-selector-button--createnew {
+	width: 100%;
+	border: 1px solid;
+	margin-bottom: $grid-unit-20;
+}
+
 .wp-block-navigation__navigation-selector-button__icon {
 	position: absolute;
 	right: $grid-unit-30;

--- a/packages/block-library/src/navigation/style.scss
+++ b/packages/block-library/src/navigation/style.scss
@@ -684,27 +684,6 @@ button.wp-block-navigation-item__content {
 	}
 }
 
-.wp-block-navigation__navigation-selector {
-	width: 100%;
-	margin-bottom: $grid-unit-20;
-}
-
-.wp-block-navigation__navigation-selector-button {
-	width: 100%;
-	border: 1px solid;
-}
-
-.wp-block-navigation__navigation-selector-button--createnew {
-	width: 100%;
-	border: 1px solid;
-	margin-bottom: $grid-unit-20;
-}
-
-.wp-block-navigation__navigation-selector-button__icon {
-	position: absolute;
-	right: $grid-unit-30;
-}
-
 // Prevent scrolling of the parent content when the modal is open.
 html.has-modal-open {
 	overflow: hidden;

--- a/packages/block-library/src/navigation/style.scss
+++ b/packages/block-library/src/navigation/style.scss
@@ -694,6 +694,11 @@ button.wp-block-navigation-item__content {
 	border: 1px solid;
 }
 
+.wp-block-navigation__navigation-selector-button__icon {
+	position: absolute;
+	right: $grid-unit-30;
+}
+
 // Prevent scrolling of the parent content when the modal is open.
 html.has-modal-open {
 	overflow: hidden;

--- a/packages/block-library/src/navigation/style.scss
+++ b/packages/block-library/src/navigation/style.scss
@@ -684,6 +684,16 @@ button.wp-block-navigation-item__content {
 	}
 }
 
+.wp-block-navigation__navigation-selector {
+	width: 100%;
+	margin-bottom: $grid-unit-20;
+}
+
+.wp-block-navigation__navigation-selector-button {
+	width: 100%;
+	border: 1px solid;
+}
+
 // Prevent scrolling of the parent content when the modal is open.
 html.has-modal-open {
 	overflow: hidden;


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Closes #42257, #42602,  #38169

## Why?
Simplifying the UX of the navigation block. The crowding of the block toolbar with all kinds of disconnected actions does not appear as a good path. 

## How?
A few tweaks:

- [x] move the items in the "select menu" block control to the block's inspector as follows:
  - [x] the list of menus as a dropdown in an inspector panel
  - [X] the manage menus action as a link button below the selector

**Optional:**
- [ ] add a list view representing the tree of InnerBlocks of the navigation block to the block's inspector
  - [ ] allow adding new menu items from the list view representation
  - [ ] disable inner block selection from the list view
  - [ ] cull some of the useless list view item options (e.g. make template part)


**To do**

- [x] There has to be a chevron link in the dropdown toggle
- [x] The label of the currently selected menu does not update on change
- [x] The label of the currently selected menu does not update if menu is renamed from advanced
- [x] Use a visually hidden label to explain this is a menu switcher
- [x] Default to a button if there are no block menus and no classic menus
- [x] Rename "Loading options ..." to "Loading ..."
- [x] Rename "Select another menu" to "Select menu"
- [x] Removed [disabled](https://github.com/WordPress/gutenberg/pull/42987#discussion_r962116873) and implement `isBusy`
- [ ] Update the navigation tests according to the new UI of the block

## Testing Instructions
1. Check out this PR
2. Add a navigation block
3. Behold the amazing UX
4. Test that:

- the menu can be switched to another menu
- importing classic menus work
- new menus can be created
- renaming menus in advanced is immediately reflected in the control
- keyboard navigation works as expected
- screen readers announce this control properly

## Screenshots or screencast <!-- if applicable -->

https://user-images.githubusercontent.com/107534/187418826-c999c81d-64f2-42d5-97c1-063b149ce367.mp4


