### PR TITLE
ColorPalette, GradientPicker: fix color picker popover positioning

### DIFF
--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -16,6 +16,7 @@
 -   `ToolsPanel`: Constrain grid columns to 50% max-width ([#42795](https://github.com/WordPress/gutenberg/pull/42795)).
 -   `Popover`: anchor correctly to parent node when no explicit anchor is passed ([#42971](https://github.com/WordPress/gutenberg/pull/42971)).
 -   `ColorPalette`: forward correctly `popoverProps` in the `CustomColorPickerDropdown` component [#42989](https://github.com/WordPress/gutenberg/pull/42989)).
+-   `ColorPalette`, `CustomGradientBar`: restore correct color picker popover position [#42989](https://github.com/WordPress/gutenberg/pull/42989)).
 
 ### Enhancements
 

--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -15,6 +15,7 @@
 -   `ColorPicker`: fix layout overflow [#42992](https://github.com/WordPress/gutenberg/pull/42992)).
 -   `ToolsPanel`: Constrain grid columns to 50% max-width ([#42795](https://github.com/WordPress/gutenberg/pull/42795)).
 -   `Popover`: anchor correctly to parent node when no explicit anchor is passed ([#42971](https://github.com/WordPress/gutenberg/pull/42971)).
+-   `ColorPalette`: forward correctly `popoverProps` in the `CustomColorPickerDropdown` component [#42989](https://github.com/WordPress/gutenberg/pull/42989)).
 
 ### Enhancements
 

--- a/packages/components/src/color-palette/index.js
+++ b/packages/components/src/color-palette/index.js
@@ -119,10 +119,11 @@ export function CustomColorPickerDropdown( {
 } ) {
 	const popoverProps = {
 		__unstableShift: true,
+		// Open below the control point (centered aligned) when in the sidebar
 		...( isRenderedInSidebar
 			? {
-					placement: 'bottom-start',
-					offset: 20,
+					placement: 'bottom',
+					offset: 10,
 			  }
 			: {} ),
 		...receivedPopoverProps,

--- a/packages/components/src/color-palette/index.js
+++ b/packages/components/src/color-palette/index.js
@@ -117,15 +117,24 @@ export function CustomColorPickerDropdown( {
 	popoverProps: receivedPopoverProps,
 	...props
 } ) {
-	// Open below the control point (centered aligned).
 	const popoverProps = useMemo(
 		() => ( {
 			__unstableShift: true,
-			placement: 'bottom',
-			offset: 8,
+			...( isRenderedInSidebar
+				? {
+						// When in the sidebar: open to the left (stacking)
+						placement: 'left-start',
+						offset: 20,
+						// anchor?
+				  }
+				: {
+						// Default behavior: open below the anchor
+						placement: 'bottom',
+						offset: 8,
+				  } ),
 			...receivedPopoverProps,
 		} ),
-		[ receivedPopoverProps ]
+		[ isRenderedInSidebar, receivedPopoverProps ]
 	);
 
 	return (

--- a/packages/components/src/color-palette/index.js
+++ b/packages/components/src/color-palette/index.js
@@ -122,10 +122,10 @@ export function CustomColorPickerDropdown( {
 			__unstableShift: true,
 			...( isRenderedInSidebar
 				? {
-						// When in the sidebar: open to the left (stacking)
+						// When in the sidebar: open to the left (stacking),
+						// leaving the same gap as the parent popover.
 						placement: 'left-start',
-						offset: 20,
-						// anchor?
+						offset: 34,
 				  }
 				: {
 						// Default behavior: open below the anchor

--- a/packages/components/src/color-palette/index.js
+++ b/packages/components/src/color-palette/index.js
@@ -119,7 +119,7 @@ export function CustomColorPickerDropdown( {
 } ) {
 	const popoverProps = {
 		__unstableShift: true,
-		// Open below the control point (centered aligned) when in the sidebar
+		// Open below the control point (centered aligned) when in the sidebar.
 		...( isRenderedInSidebar
 			? {
 					placement: 'bottom',

--- a/packages/components/src/color-palette/index.js
+++ b/packages/components/src/color-palette/index.js
@@ -112,19 +112,26 @@ function MultiplePalettes( {
 	);
 }
 
-export function CustomColorPickerDropdown( { isRenderedInSidebar, ...props } ) {
+export function CustomColorPickerDropdown( {
+	isRenderedInSidebar,
+	popoverProps: receivedPopoverProps,
+	...props
+} ) {
+	const popoverProps = {
+		__unstableShift: true,
+		...( isRenderedInSidebar
+			? {
+					placement: 'bottom-start',
+					offset: 20,
+			  }
+			: {} ),
+		...receivedPopoverProps,
+	};
+
 	return (
 		<Dropdown
 			contentClassName="components-color-palette__custom-color-dropdown-content"
-			popoverProps={
-				isRenderedInSidebar
-					? {
-							placement: 'left-start',
-							offset: 20,
-							__unstableShift: true,
-					  }
-					: undefined
-			}
+			popoverProps={ popoverProps }
 			{ ...props }
 		/>
 	);

--- a/packages/components/src/color-palette/index.js
+++ b/packages/components/src/color-palette/index.js
@@ -117,17 +117,16 @@ export function CustomColorPickerDropdown( {
 	popoverProps: receivedPopoverProps,
 	...props
 } ) {
-	const popoverProps = {
-		__unstableShift: true,
-		// Open below the control point (centered aligned) when in the sidebar.
-		...( isRenderedInSidebar
-			? {
-					placement: 'bottom',
-					offset: 10,
-			  }
-			: {} ),
-		...receivedPopoverProps,
-	};
+	// Open below the control point (centered aligned).
+	const popoverProps = useMemo(
+		() => ( {
+			__unstableShift: true,
+			placement: 'bottom',
+			offset: 8,
+			...receivedPopoverProps,
+		} ),
+		[ receivedPopoverProps ]
+	);
 
 	return (
 		<Dropdown

--- a/packages/components/src/color-palette/test/__snapshots__/index.js.snap
+++ b/packages/components/src/color-palette/test/__snapshots__/index.js.snap
@@ -357,6 +357,11 @@ exports[`ColorPalette Dropdown should render it correctly 1`] = `
 
 <Dropdown
   contentClassName="components-color-palette__custom-color-dropdown-content"
+  popoverProps={
+    Object {
+      "__unstableShift": true,
+    }
+  }
   renderContent={[Function]}
   renderToggle={[Function]}
 >
@@ -728,6 +733,11 @@ exports[`ColorPalette should render a dynamic toolbar of colors 1`] = `
         >
           <Dropdown
             contentClassName="components-color-palette__custom-color-dropdown-content"
+            popoverProps={
+              Object {
+                "__unstableShift": true,
+              }
+            }
             renderContent={[Function]}
             renderToggle={[Function]}
           >

--- a/packages/components/src/color-palette/test/__snapshots__/index.js.snap
+++ b/packages/components/src/color-palette/test/__snapshots__/index.js.snap
@@ -360,6 +360,8 @@ exports[`ColorPalette Dropdown should render it correctly 1`] = `
   popoverProps={
     Object {
       "__unstableShift": true,
+      "offset": 8,
+      "placement": "bottom",
     }
   }
   renderContent={[Function]}
@@ -736,6 +738,8 @@ exports[`ColorPalette should render a dynamic toolbar of colors 1`] = `
             popoverProps={
               Object {
                 "__unstableShift": true,
+                "offset": 8,
+                "placement": "bottom",
               }
             }
             renderContent={[Function]}

--- a/packages/components/src/custom-gradient-bar/control-points.js
+++ b/packages/components/src/custom-gradient-bar/control-points.js
@@ -73,11 +73,7 @@ function ControlPointButton( { isOpen, position, color, ...additionalProps } ) {
 	);
 }
 
-function GradientColorPickerDropdown( {
-	isRenderedInSidebar,
-	gradientPickerDomRef,
-	...props
-} ) {
+function GradientColorPickerDropdown( { isRenderedInSidebar, ...props } ) {
 	const popoverProps = useMemo( () => {
 		const result = {
 			className:
@@ -87,7 +83,7 @@ function GradientColorPickerDropdown( {
 			result.placement = 'top';
 		}
 		return result;
-	}, [ gradientPickerDomRef, isRenderedInSidebar ] );
+	}, [ isRenderedInSidebar ] );
 	return (
 		<CustomColorPickerDropdown
 			isRenderedInSidebar={ isRenderedInSidebar }
@@ -161,7 +157,6 @@ function ControlPoints( {
 		return (
 			ignoreMarkerPosition !== initialPosition && (
 				<GradientColorPickerDropdown
-					gradientPickerDomRef={ gradientPickerDomRef }
 					isRenderedInSidebar={ __experimentalIsRenderedInSidebar }
 					key={ index }
 					onClose={ onStopControlPointChange }
@@ -286,12 +281,10 @@ function InsertPoint( {
 	insertPosition,
 	disableAlpha,
 	__experimentalIsRenderedInSidebar,
-	gradientPickerDomRef,
 } ) {
 	const [ alreadyInsertedPoint, setAlreadyInsertedPoint ] = useState( false );
 	return (
 		<GradientColorPickerDropdown
-			gradientPickerDomRef={ gradientPickerDomRef }
 			isRenderedInSidebar={ __experimentalIsRenderedInSidebar }
 			className="components-custom-gradient-picker__inserter"
 			onClose={ () => {

--- a/packages/components/src/custom-gradient-bar/control-points.js
+++ b/packages/components/src/custom-gradient-bar/control-points.js
@@ -82,7 +82,7 @@ function GradientColorPickerDropdown( {
 		const result = {
 			className:
 				'components-custom-gradient-picker__color-picker-popover',
-			position: 'top',
+			placement: 'top',
 		};
 		if ( isRenderedInSidebar ) {
 			result.anchorRef = gradientPickerDomRef;

--- a/packages/components/src/custom-gradient-bar/control-points.js
+++ b/packages/components/src/custom-gradient-bar/control-points.js
@@ -86,6 +86,7 @@ function GradientColorPickerDropdown( {
 		};
 		if ( isRenderedInSidebar ) {
 			result.anchorRef = gradientPickerDomRef;
+			result.placement = 'bottom-start';
 		}
 		return result;
 	}, [ gradientPickerDomRef, isRenderedInSidebar ] );

--- a/packages/components/src/custom-gradient-bar/control-points.js
+++ b/packages/components/src/custom-gradient-bar/control-points.js
@@ -86,7 +86,6 @@ function GradientColorPickerDropdown( {
 		};
 		if ( isRenderedInSidebar ) {
 			result.anchorRef = gradientPickerDomRef.current;
-			result.position = 'bottom left';
 		}
 		return result;
 	}, [ gradientPickerDomRef, isRenderedInSidebar ] );

--- a/packages/components/src/custom-gradient-bar/control-points.js
+++ b/packages/components/src/custom-gradient-bar/control-points.js
@@ -74,16 +74,13 @@ function ControlPointButton( { isOpen, position, color, ...additionalProps } ) {
 }
 
 function GradientColorPickerDropdown( { isRenderedInSidebar, ...props } ) {
-	const popoverProps = useMemo( () => {
-		const result = {
+	const popoverProps = useMemo(
+		() => ( {
 			className:
 				'components-custom-gradient-picker__color-picker-popover',
-		};
-		if ( ! isRenderedInSidebar ) {
-			result.placement = 'top';
-		}
-		return result;
-	}, [ isRenderedInSidebar ] );
+		} ),
+		[]
+	);
 	return (
 		<CustomColorPickerDropdown
 			isRenderedInSidebar={ isRenderedInSidebar }

--- a/packages/components/src/custom-gradient-bar/control-points.js
+++ b/packages/components/src/custom-gradient-bar/control-points.js
@@ -82,11 +82,9 @@ function GradientColorPickerDropdown( {
 		const result = {
 			className:
 				'components-custom-gradient-picker__color-picker-popover',
-			placement: 'top',
 		};
-		if ( isRenderedInSidebar ) {
-			result.anchorRef = gradientPickerDomRef;
-			result.placement = 'bottom-start';
+		if ( ! isRenderedInSidebar ) {
+			result.placement = 'top';
 		}
 		return result;
 	}, [ gradientPickerDomRef, isRenderedInSidebar ] );

--- a/packages/components/src/custom-gradient-bar/control-points.js
+++ b/packages/components/src/custom-gradient-bar/control-points.js
@@ -75,9 +75,19 @@ function ControlPointButton( { isOpen, position, color, ...additionalProps } ) {
 }
 
 function GradientColorPickerDropdown( { isRenderedInSidebar, ...props } ) {
+	// Open the popover below the gradient control/insertion point
+	const popoverProps = useMemo(
+		() => ( {
+			placement: 'bottom',
+			offset: 8,
+		} ),
+		[]
+	);
+
 	return (
 		<CustomColorPickerDropdown
 			isRenderedInSidebar={ isRenderedInSidebar }
+			popoverProps={ popoverProps }
 			{ ...props }
 		/>
 	);

--- a/packages/components/src/custom-gradient-bar/control-points.js
+++ b/packages/components/src/custom-gradient-bar/control-points.js
@@ -17,6 +17,7 @@ import { LEFT, RIGHT } from '@wordpress/keycodes';
  * Internal dependencies
  */
 import Button from '../button';
+import { HStack } from '../h-stack';
 import { ColorPicker } from '../color-picker';
 import { VisuallyHidden } from '../visually-hidden';
 import { CustomColorPickerDropdown } from '../color-palette';
@@ -74,17 +75,9 @@ function ControlPointButton( { isOpen, position, color, ...additionalProps } ) {
 }
 
 function GradientColorPickerDropdown( { isRenderedInSidebar, ...props } ) {
-	const popoverProps = useMemo(
-		() => ( {
-			className:
-				'components-custom-gradient-picker__color-picker-popover',
-		} ),
-		[]
-	);
 	return (
 		<CustomColorPickerDropdown
 			isRenderedInSidebar={ isRenderedInSidebar }
-			popoverProps={ popoverProps }
 			{ ...props }
 		/>
 	);
@@ -246,21 +239,25 @@ function ControlPoints( {
 								} }
 							/>
 							{ ! disableRemove && controlPoints.length > 2 && (
-								<Button
-									className="components-custom-gradient-picker__remove-control-point"
-									onClick={ () => {
-										onChange(
-											removeControlPoint(
-												controlPoints,
-												index
-											)
-										);
-										onClose();
-									} }
-									variant="link"
+								<HStack
+									className="components-custom-gradient-picker__remove-control-point-wrapper"
+									alignment="center"
 								>
-									{ __( 'Remove Control Point' ) }
-								</Button>
+									<Button
+										onClick={ () => {
+											onChange(
+												removeControlPoint(
+													controlPoints,
+													index
+												)
+											);
+											onClose();
+										} }
+										variant="link"
+									>
+										{ __( 'Remove Control Point' ) }
+									</Button>
+								</HStack>
 							) }
 						</>
 					) }

--- a/packages/components/src/custom-gradient-bar/control-points.js
+++ b/packages/components/src/custom-gradient-bar/control-points.js
@@ -85,7 +85,7 @@ function GradientColorPickerDropdown( {
 			position: 'top',
 		};
 		if ( isRenderedInSidebar ) {
-			result.anchorRef = gradientPickerDomRef.current;
+			result.anchorRef = gradientPickerDomRef;
 		}
 		return result;
 	}, [ gradientPickerDomRef, isRenderedInSidebar ] );

--- a/packages/components/src/custom-gradient-bar/index.js
+++ b/packages/components/src/custom-gradient-bar/index.js
@@ -136,9 +136,6 @@ export default function CustomGradientBar( {
 							__experimentalIsRenderedInSidebar={
 								__experimentalIsRenderedInSidebar
 							}
-							gradientPickerDomRef={
-								gradientMarkersContainerDomRef
-							}
 							disableAlpha={ disableAlpha }
 							insertPosition={ gradientBarState.insertPosition }
 							value={ controlPoints }

--- a/packages/components/src/custom-gradient-picker/style.scss
+++ b/packages/components/src/custom-gradient-picker/style.scss
@@ -59,11 +59,8 @@ $components-custom-gradient-picker__padding: $grid-unit-20; // 48px container, 1
 	}
 }
 
-.components-custom-gradient-picker__color-picker-popover .components-custom-gradient-picker__remove-control-point {
-	margin-left: auto;
-	margin-right: auto;
-	display: block;
-	margin-bottom: $grid-unit-10;
+.components-custom-gradient-picker__remove-control-point-wrapper {
+	padding-bottom: $grid-unit-10;
 }
 
 .components-custom-gradient-picker__inserter {


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

This PR aims at improving the positioning of the color picker's popover in all color-related widgets (mostly `ColorPalette`, and `CustomGradientBar` for gradients) after #40740 introduced a regression that stopped the forwarding of `popoverProps` correctly in the `ColorPalette` component (see [change](https://github.com/WordPress/gutenberg/pull/40740/files#diff-b53300a311404baec5a0c0cfc1d898fa89050f29959680b6317243be716c3691)).

This PR also slightly tweaks the positioning of the popover for all cases.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

With this change, the `GradientPicker` component can override `popoverProps` again as it was previously intended.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

 - Take into account the received `popoverProps` in the `CustomColorPickerDropdown` component
 - Popover positioning logic:
   - Make sure that the color picker's popover in gradient bar always opens to the `bottom` of the gradient's control point (centred on the x axis)
   - For all other cases:
     - If the popover is rendered in the sidebar, open the popover to the left of its anchor (this causes the popover to "stack" to the left in case its anchor is another popover)
     - if the popover is not rendered in the sidebar, open the popover to the `bottom` of its anchor (centred on the x axis), like for the gradient control points.
 - Make the popover always `shift`, meaning it can't render outside of the viewport
 - Use the `placement` property, instead of the legacy `position`
 - Bonus: use the `HStack` component instead of custom CSS styles to minimize the amount of style overrides

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->

In Storybook, verify that the popover is always rendered inside the viewport (i.e. shifting behavior is enabled)

In the site editor, try to edit the available gradients palette and focus on the popover positioning for each color stops

## Screenshots or screencast <!-- if applicable -->

_Note: the following screenshots / videos may be out of date. Please refer to the latest comments in this PR for the final popover behavior_

`GradientPicker` in Storybook, `trunk`:

https://user-images.githubusercontent.com/1083581/182940241-1dfee265-c54c-4f59-87af-e77551dd60d9.mp4

`GradientPicker` in Storybook, this PR:

https://user-images.githubusercontent.com/1083581/182940361-509e22c8-4fd1-4fd3-8dbc-b8d904f908c4.mp4

Popover for color stops in gradient picker, site editor, `trunk`: 

https://user-images.githubusercontent.com/1083581/182940472-da0d08ef-dd25-4cab-bd48-1df951fc29ef.mp4

Popover for color stops in gradient picker, site editor,  this PR:

https://user-images.githubusercontent.com/1083581/182940489-92e137c8-8565-49c7-babc-59fdb0c3ad2c.mp4

(@jasmussen , welcome back! I may need some guidance here about what is the expected popover positioning when editing color stops in the site editor — see video above)