### PR TITLE
Fix/42097

### DIFF
--- a/lib/client-assets.php
+++ b/lib/client-assets.php
@@ -293,7 +293,7 @@ function gutenberg_register_packages_styles( $styles ) {
 		$styles,
 		'wp-block-library',
 		gutenberg_url( 'build/block-library/' . $block_library_filename . '.css' ),
-		array(),
+		array( 'global-styles-css-custom-properties' ),
 		$version
 	);
 	$styles->add_data( 'wp-block-library', 'rtl', 'replace' );

--- a/lib/compat/wordpress-6.0/client-assets.php
+++ b/lib/compat/wordpress-6.0/client-assets.php
@@ -41,9 +41,12 @@ add_action( 'wp_default_scripts', 'gutenberg_register_vendor_scripts' );
 function gutenberg_resolve_assets() {
 	global $pagenow;
 
+	gutenberg_enqueue_global_styles();
+
 	$script_handles = array();
 	$style_handles  = array(
 		'wp-block-editor',
+		'global-styles',
 		'wp-block-library',
 		'wp-edit-blocks',
 	);

--- a/packages/block-editor/src/components/editor-styles/index.js
+++ b/packages/block-editor/src/components/editor-styles/index.js
@@ -72,14 +72,18 @@ export default function EditorStyles( { styles } ) {
 		[ styles ]
 	);
 
-	return (
+	/*return (
 		<>
 			{ /* Use an empty style element to have a document reference,
-			     but this could be any element. */ }
+			     but this could be any element. *//* }
 			<style ref={ useDarkThemeBodyClassName( styles ) } />
 			{ transformedStyles.map( ( css, index ) => (
 				<style key={ index }>{ css }</style>
 			) ) }
 		</>
-	);
+	);*/
+
+	const editorStylesCSS = transformedStyles.map( ( css, index ) => css ).join();
+	document.getElementById( 'global-styles-css-custom-properties-inline-css' ).innerHTML = editorStylesCSS;
+	return <p>hello</p>;
 }

--- a/packages/block-library/src/button/style.scss
+++ b/packages/block-library/src/button/style.scss
@@ -102,8 +102,8 @@ $blocks-block__margin: 0.5em;
 	border-radius: 0 !important;
 }
 
-.is-style-outline > :where(.wp-block-button__link),
-:where(.wp-block-button__link).is-style-outline {
+.is-style-outline > .wp-block-button__link,
+.wp-block-button__link.is-style-outline {
 	border: 2px solid currentColor;
 	padding: 0.667em 1.333em;
 }


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

🚧🚧🚧🚧🚧🚧 *Still a WIP* 🚧🚧🚧🚧🚧🚧🚧🚧🚧🚧

## What?
In https://github.com/WordPress/gutenberg/pull/41934 we made global-styles a dependency of blocks, so that the global styles load first. This is because we output the block level user settings as part of the inline CSS for each block, so it needs to load after the main Global Styles CSS.

Note: I am still thinking about whether this is indeed the correct approach.

We need to make the same change in the Post and Site editors so we have a consistent view in all places.

Fixes #42097

## How?
This is quite complex and there are several different things we need to do.
1. We need to make the global-styles a dependency of the wp-block-library CSS, so that it loads sooner.
2. In the post editor we don't load global styles, only the `global-styles-css-custom-properties`, so we inject editor styles into this. We should probably only do this for global styles not the other editor styles.
3. In the Site Editor we load the styles differently again. This PR moves them to the header, rather than loading them with JS
4. In the button block we need to raise the specificity of the outline border so it can overwrite the theme.json setting.



## Testing Instructions
TBD
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->

## Screenshots or screencast <!-- if applicable -->
TBD