### PR TITLE
ColorPicker: fix layout overflow

### DIFF
--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -12,6 +12,7 @@
 -   `TextControl`, `TextareaControl`, `ToggleGroupControl`: Add `box-sizing` reset style ([#42889](https://github.com/WordPress/gutenberg/pull/42889)).
 -   `Popover`: fix arrow placement and design ([#42874](https://github.com/WordPress/gutenberg/pull/42874/)).
 -   `Popover`: fix minor glitch in arrow [#42903](https://github.com/WordPress/gutenberg/pull/42903)).
+-   `ColorPicker`: fix layout overflow [#42992](https://github.com/WordPress/gutenberg/pull/42992)).
 
 ### Enhancements
 

--- a/packages/components/src/color-picker/styles.ts
+++ b/packages/components/src/color-picker/styles.ts
@@ -11,6 +11,7 @@ import InnerSelectControl from '../select-control';
 import InnerRangeControl from '../range-control';
 import { StyledField } from '../base-control/styles/base-control-styles';
 import { space } from '../ui/utils/space';
+import { boxSizingReset } from '../utils';
 import Button from '../button';
 import { Flex } from '../flex';
 import { HStack } from '../h-stack';
@@ -58,6 +59,7 @@ export const AuxiliaryColorArtefactWrapper = styled.div`
 `;
 
 export const AuxiliaryColorArtefactHStackHeader = styled( HStack )`
+	${ boxSizingReset };
 	padding-left: ${ space( 4 ) };
 	padding-right: ${ space( 4 ) };
 `;

--- a/packages/components/src/color-picker/styles.ts
+++ b/packages/components/src/color-picker/styles.ts
@@ -59,7 +59,6 @@ export const AuxiliaryColorArtefactWrapper = styled.div`
 `;
 
 export const AuxiliaryColorArtefactHStackHeader = styled( HStack )`
-	${ boxSizingReset };
 	padding-left: ${ space( 4 ) };
 	padding-right: ${ space( 4 ) };
 `;
@@ -72,6 +71,8 @@ export const ColorInputWrapper = styled( Flex )`
 `;
 
 export const ColorfulWrapper = styled.div`
+	${ boxSizingReset };
+
 	width: 216px;
 
 	.react-colorful {


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

This fixes a layout issue with `ColorPicker`, where the "copy to clipboard" button would end up being rendered further right than intended, causing the whole picker to scroll when embedded inside a popover

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

Fixing a layout bug.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

The issue can be fixed by adding the `box-sizing` reset to the specific wrapper, although we should probably understand if we should apply the fix in a more generic way (i.e. to the `HStack` or even the `Flex` components) (cc @mirka )

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->

In Storybook:

- look at the "copy to clipboard" button in the ColorPicker component, and make sure that its parent wrapper doesn't extend beyond 100% width of its container.
- in the GradientPicker example, click on color stops in the gradient bar, and make sure that the popover with the colorpicker doesn't have horizontal scrollbars


## Screenshots or screencast <!-- if applicable -->

| trunk | this PR |
|---|---|
| ![Screenshot 2022-08-04 at 22 08 37](https://user-images.githubusercontent.com/1083581/182944395-1ada1ffe-6fba-46b8-bd6a-a9666f5cd7e6.png) | ![Screenshot 2022-08-04 at 22 17 55](https://user-images.githubusercontent.com/1083581/182944659-cba5b2da-4742-4e27-8abd-a296dec7d3d4.png) | 
| ![Screenshot 2022-08-04 at 22 08 57](https://user-images.githubusercontent.com/1083581/182944397-f9876f0b-2d0d-4ed0-8689-ea0bd7690417.png) | ![Screenshot 2022-08-04 at 22 08 24](https://user-images.githubusercontent.com/1083581/182944393-8a77a1b1-6f24-416d-97a4-7acb54c7f704.png)  |

