### PR TITLE
List View Expander: Fix icon in RTL mode

### DIFF
--- a/packages/block-editor/src/components/list-view/expander.js
+++ b/packages/block-editor/src/components/list-view/expander.js
@@ -1,7 +1,9 @@
 /**
  * WordPress dependencies
  */
-import { chevronRightSmall, Icon } from '@wordpress/icons';
+import { chevronRightSmall, chevronLeftSmall, Icon } from '@wordpress/icons';
+import { isRTL } from '@wordpress/i18n';
+
 export default function ListViewExpander( { onClick } ) {
 	return (
 		// Keyboard events are handled by TreeGrid see: components/src/tree-grid/index.js
@@ -18,7 +20,7 @@ export default function ListViewExpander( { onClick } ) {
 			onClick={ ( event ) => onClick( event, { forceToggle: true } ) }
 			aria-hidden="true"
 		>
-			<Icon icon={ chevronRightSmall } />
+			<Icon icon={ isRTL() ? chevronLeftSmall : chevronRightSmall } />
 		</span>
 	);
 }

--- a/packages/icons/src/index.js
+++ b/packages/icons/src/index.js
@@ -34,6 +34,7 @@ export { default as chartBar } from './library/chart-bar';
 export { default as check } from './library/check';
 export { default as chevronDown } from './library/chevron-down';
 export { default as chevronLeft } from './library/chevron-left';
+export { default as chevronLeftSmall } from './library/chevron-left-small';
 export { default as chevronRight } from './library/chevron-right';
 export { default as chevronRightSmall } from './library/chevron-right-small';
 export { default as chevronUp } from './library/chevron-up';

--- a/packages/icons/src/library/chevron-left-small.js
+++ b/packages/icons/src/library/chevron-left-small.js
@@ -1,0 +1,12 @@
+/**
+ * WordPress dependencies
+ */
+import { SVG, Path } from '@wordpress/primitives';
+
+const chevronLeftSmall = (
+	<SVG xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24">
+		<Path d="m13.1 16-3.4-4 3.4-4 1.1 1-2.6 3 2.6 3-1.1 1z" />
+	</SVG>
+);
+
+export default chevronLeftSmall;


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Fix the icon in the List View to work in RTL languages

## Why?
In RTL the icon faces the wrong way and on click it rotates to upward position instead of downward like in LTR

## How?
Add `chevronLeftSmall` icon from the WordPress Figma file and use that in RTL mode.

## Testing Instructions
1. Open a page
2. Insert a block that has child blocks.
3. Open the List View and confirm everything looks the same as before.
4. Changee to a RTL language
5. Open the post and make sure the List View has a left arrow icon and rotates the correct way when clicked on.

## Screenshots or screencast <!-- if applicable -->
| Before | After |
| - | - |
| ![list-rtl](https://user-images.githubusercontent.com/1415747/182960664-76bdeca9-c181-41af-843e-ddef68622954.gif) | ![list-rtl-fixed](https://user-images.githubusercontent.com/1415747/182960720-279e6219-4703-44bf-81bb-99e1e543df6e.gif)  |