### PR TITLE
Style engine: prettify combined selectors

### DIFF
--- a/packages/style-engine/class-wp-style-engine-css-rule.php
+++ b/packages/style-engine/class-wp-style-engine-css-rule.php
@@ -117,6 +117,13 @@ class WP_Style_Engine_CSS_Rule {
 		$declarations_indent = $should_prettify ? $indent_count + 1 : 0;
 		$new_line            = $should_prettify ? "\n" : '';
 		$space               = $should_prettify ? ' ' : '';
-		return $rule_indent . $this->get_selector() . "{$space}{{$new_line}" . $this->declarations->get_declarations_string( $should_prettify, $declarations_indent ) . "{$new_line}{$rule_indent}}";
+		$selector            = $should_prettify ? str_replace( ',', ",\n", $this->get_selector() ) : $this->get_selector();
+		$css_declarations    = $this->declarations->get_declarations_string( $should_prettify, $declarations_indent );
+
+		if ( empty( $css_declarations ) ) {
+			return '';
+		}
+
+		return "{$rule_indent}{$selector}{$space}{{$new_line}{$css_declarations}{$new_line}{$rule_indent}}";
 	}
 }

--- a/packages/style-engine/class-wp-style-engine-processor.php
+++ b/packages/style-engine/class-wp-style-engine-processor.php
@@ -65,6 +65,7 @@ class WP_Style_Engine_Processor {
 	 *
 	 * @param array $options array(
 	 *    'optimize' => (boolean) Whether to optimize the CSS output, e.g., combine rules.
+	 *    'prettify' => (boolean) Whether to add new lines to output.
 	 * );.
 	 *
 	 * @return string The computed CSS.

--- a/packages/style-engine/phpunit/class-wp-style-engine-css-rule-test.php
+++ b/packages/style-engine/phpunit/class-wp-style-engine-css-rule-test.php
@@ -95,6 +95,18 @@ class WP_Style_Engine_CSS_Rule_Test extends WP_UnitTestCase {
 	}
 
 	/**
+	 * Should return empty string with no declarations.
+	 */
+	public function test_get_css_no_declarations() {
+		$selector           = '.holmes';
+		$input_declarations = array();
+		$css_declarations   = new WP_Style_Engine_CSS_Declarations( $input_declarations );
+		$css_rule           = new WP_Style_Engine_CSS_Rule( $selector, $css_declarations );
+
+		$this->assertSame( '', $css_rule->get_css() );
+	}
+
+	/**
 	 * Should generate prettified CSS rules.
 	 */
 	public function test_get_prettified_css() {

--- a/packages/style-engine/phpunit/class-wp-style-engine-css-rules-store-test.php
+++ b/packages/style-engine/phpunit/class-wp-style-engine-css-rules-store-test.php
@@ -85,7 +85,7 @@ class WP_Style_Engine_CSS_Rules_Store_Test extends WP_UnitTestCase {
 		$new_pie_store = WP_Style_Engine_CSS_Rules_Store::get_store( 'meat-pie' );
 		$selector      = '.wp-block-sauce a:hover';
 		$store_rule    = $new_pie_store->add_rule( $selector );
-		$expected      = "$selector{}";
+		$expected      = '';
 		$this->assertEquals( $expected, $store_rule->get_css() );
 
 		$pie_declarations = array(

--- a/packages/style-engine/phpunit/class-wp-style-engine-processor-test.php
+++ b/packages/style-engine/phpunit/class-wp-style-engine-processor-test.php
@@ -70,14 +70,14 @@ class WP_Style_Engine_Processor_Test extends WP_UnitTestCase {
 		$a_wonderful_processor = new WP_Style_Engine_Processor();
 		$a_wonderful_processor->add_rules( array( $a_wonderful_css_rule, $a_very_wonderful_css_rule, $a_more_wonderful_css_rule ) );
 
-		$expected = '.a-wonderful-rule,
-.a-very_wonderful-rule {
-	color: var(--wonderful-color);
-	background-color: orange;
-}
-.a-more-wonderful-rule {
+		$expected = '.a-more-wonderful-rule {
 	font-family: Wonderful sans;
 	font-size: 1em;
+	background-color: orange;
+}
+.a-wonderful-rule,
+.a-very_wonderful-rule {
+	color: var(--wonderful-color);
 	background-color: orange;
 }
 ';

--- a/packages/style-engine/phpunit/class-wp-style-engine-processor-test.php
+++ b/packages/style-engine/phpunit/class-wp-style-engine-processor-test.php
@@ -52,6 +52,13 @@ class WP_Style_Engine_Processor_Test extends WP_UnitTestCase {
 				'background-color' => 'orange',
 			)
 		);
+		$a_very_wonderful_css_rule = new WP_Style_Engine_CSS_Rule( '.a-very_wonderful-rule' );
+		$a_very_wonderful_css_rule->add_declarations(
+			array(
+				'color'            => 'var(--wonderful-color)',
+				'background-color' => 'orange',
+			)
+		);
 		$a_more_wonderful_css_rule = new WP_Style_Engine_CSS_Rule( '.a-more-wonderful-rule' );
 		$a_more_wonderful_css_rule->add_declarations(
 			array(
@@ -61,9 +68,10 @@ class WP_Style_Engine_Processor_Test extends WP_UnitTestCase {
 			)
 		);
 		$a_wonderful_processor = new WP_Style_Engine_Processor();
-		$a_wonderful_processor->add_rules( array( $a_wonderful_css_rule, $a_more_wonderful_css_rule ) );
+		$a_wonderful_processor->add_rules( array( $a_wonderful_css_rule, $a_very_wonderful_css_rule, $a_more_wonderful_css_rule ) );
 
-		$expected = '.a-wonderful-rule {
+		$expected = '.a-wonderful-rule,
+.a-very_wonderful-rule {
 	color: var(--wonderful-color);
 	background-color: orange;
 }


### PR DESCRIPTION

## What?
A follow up to
- https://github.com/WordPress/gutenberg/pull/42909

This PR:
- Inserts a new line after combined selectors
- Returns empty string where no declarations are found in a CSS rule
- Adds tests for both


## Why?

The difference in prettified output is:

### Trunk
```css
.wp-block-column.wp-container-9 > :where(:not(.alignleft):not(.alignright):not(.alignfull)),.wp-block-column.wp-container-13 > :where(:not(.alignleft):not(.alignright):not(.alignfull)),.wp-block-column.wp-container-17 > :where(:not(.alignleft):not(.alignright):not(.alignfull)) {
	max-width: 26px;
	margin-left: auto !important;
	margin-right: auto !important;
}
```

### This PR
```css
.wp-block-column.wp-container-9 > :where(:not(.alignleft):not(.alignright):not(.alignfull)),
.wp-block-column.wp-container-13 > :where(:not(.alignleft):not(.alignright):not(.alignfull)),
.wp-block-column.wp-container-17 > :where(:not(.alignleft):not(.alignright):not(.alignfull)) {
	max-width: 26px;
	margin-left: auto !important;
	margin-right: auto !important;
}
```


## How?
Adding a `\n` after each `,` in the selector string.

## Testing Instructions

Run the tests:
`npm run tests-unit-php`

Check the source of a page that has a bunch of similar layout blocks (e.g., group blocks).

The selectors should be stacked in development, not printed in a line.
