### PR TITLE
Style Engine: Include 6.1 CSS filter, ensure style engine can output CSS functions like clamp

### DIFF
--- a/lib/compat/wordpress-6.1/blocks.php
+++ b/lib/compat/wordpress-6.1/blocks.php
@@ -26,6 +26,33 @@ function gutenberg_safe_style_attrs_6_1( $attrs ) {
 add_filter( 'safe_style_css', 'gutenberg_safe_style_attrs_6_1' );
 
 /**
+ * Update allowed CSS values to match WordPress 6.1.
+ *
+ * Note: This should be removed when the minimum required WP version is >= 6.1.
+ *
+ * The logic in this function follows that provided in: https://core.trac.wordpress.org/ticket/55966.
+ *
+ * @param boolean $allow_css       Whether or not the current test string is allowed.
+ * @param string  $css_test_string The CSS string to be tested.
+ * @return boolean
+ */
+function gutenberg_safecss_filter_attr_allow_css_6_1( $allow_css, $css_test_string ) {
+	if ( false === $allow_css ) {
+		// Allow some CSS functions.
+		$css_test_string = preg_replace( '/\b(?:calc|min|max|minmax|clamp)\(((?:\([^()]*\)?|[^()])*)\)/', '', $css_test_string );
+
+		// Allow CSS var.
+		$css_test_string = preg_replace( '/\(?var\(--[\w\-\()[\]\,\s]*\)/', '', $css_test_string );
+
+		// Check for any CSS containing \ ( & } = or comments,
+		// except for url(), calc(), or var() usage checked above.
+		$allow_css = ! preg_match( '%[\\\(&=}]|/\*%', $css_test_string );
+	}
+	return $allow_css;
+}
+add_filter( 'safecss_filter_attr_allow_css', 'gutenberg_safecss_filter_attr_allow_css_6_1', 10, 2 );
+
+/**
  * Registers view scripts for core blocks if handling is missing in WordPress core.
  *
  * @since 6.1.0

--- a/packages/style-engine/class-wp-style-engine-css-declarations.php
+++ b/packages/style-engine/class-wp-style-engine-css-declarations.php
@@ -124,13 +124,6 @@ class WP_Style_Engine_CSS_Declarations {
 	 */
 	protected static function filter_declaration( $property, $value, $spacer = '' ) {
 		if ( isset( $property ) && isset( $value ) && '' === trim( $spacer ) ) {
-			// Allow a controlled set of `display` values.
-			if (
-				'display' === $property &&
-				in_array( $value, array( 'block', 'inline', 'inline-block', 'flex', 'inline-flex', 'grid', 'inline-grid' ), true )
-			) {
-				return "{$property}:{$spacer}{$value}";
-			}
 			return safecss_filter_attr( "{$property}:{$spacer}{$value}" );
 		}
 		return '';

--- a/packages/style-engine/class-wp-style-engine-css-declarations.php
+++ b/packages/style-engine/class-wp-style-engine-css-declarations.php
@@ -146,7 +146,7 @@ class WP_Style_Engine_CSS_Declarations {
 
 		foreach ( $declarations_array as $property => $value ) {
 			$spacer               = $should_prettify ? ' ' : '';
-			$filtered_declaration = esc_html( static::filter_declaration( $property, $value, $spacer ) );
+			$filtered_declaration = static::filter_declaration( $property, $value, $spacer );
 			if ( $filtered_declaration ) {
 				$declarations_output .= "{$indent}{$filtered_declaration};$suffix";
 			}

--- a/packages/style-engine/class-wp-style-engine-css-declarations.php
+++ b/packages/style-engine/class-wp-style-engine-css-declarations.php
@@ -123,7 +123,7 @@ class WP_Style_Engine_CSS_Declarations {
 	 * @return string The filtered declaration as a single string.
 	 */
 	protected static function filter_declaration( $property, $value, $spacer = '' ) {
-		if ( isset( $property ) && isset( $value ) && '' === trim( $spacer ) ) {
+		if ( isset( $property ) && isset( $value ) ) {
 			return safecss_filter_attr( "{$property}:{$spacer}{$value}" );
 		}
 		return '';

--- a/packages/style-engine/class-wp-style-engine-css-declarations.php
+++ b/packages/style-engine/class-wp-style-engine-css-declarations.php
@@ -114,6 +114,29 @@ class WP_Style_Engine_CSS_Declarations {
 	}
 
 	/**
+	 * Filters a CSS property + value pair.
+	 *
+	 * @param string $property The CSS property.
+	 * @param string $value    The value to be filtered.
+	 * @param string $spacer   The spacer between the colon and the value. Defaults to an empty string.
+	 *
+	 * @return string The filtered declaration as a single string.
+	 */
+	protected static function filter_declaration( $property, $value, $spacer = '' ) {
+		if ( isset( $property ) && isset( $value ) && '' === trim( $spacer ) ) {
+			// Allow a controlled set of `display` values.
+			if (
+				'display' === $property &&
+				in_array( $value, array( 'block', 'inline', 'inline-block', 'flex', 'inline-flex', 'grid', 'inline-grid' ), true )
+			) {
+				return "{$property}:{$spacer}{$value}";
+			}
+			return safecss_filter_attr( "{$property}:{$spacer}{$value}" );
+		}
+		return '';
+	}
+
+	/**
 	 * Filters and compiles the CSS declarations.
 	 *
 	 * @param boolean $should_prettify Whether to add spacing, new lines and indents.
@@ -130,7 +153,7 @@ class WP_Style_Engine_CSS_Declarations {
 
 		foreach ( $declarations_array as $property => $value ) {
 			$spacer               = $should_prettify ? ' ' : '';
-			$filtered_declaration = esc_html( safecss_filter_attr( "{$property}:{$spacer}{$value}" ) );
+			$filtered_declaration = esc_html( static::filter_declaration( $property, $value, $spacer ) );
 			if ( $filtered_declaration ) {
 				$declarations_output .= "{$indent}{$filtered_declaration};$suffix";
 			}

--- a/packages/style-engine/phpunit/class-wp-style-engine-css-declarations-test.php
+++ b/packages/style-engine/phpunit/class-wp-style-engine-css-declarations-test.php
@@ -149,14 +149,14 @@ class WP_Style_Engine_CSS_Declarations_Test extends WP_UnitTestCase {
 	 */
 	public function test_remove_unsafe_properties_and_values() {
 		$input_declarations = array(
-			'color'        => '<red/>',
+			'color'        => 'url("https://wordpress.org")',
 			'margin-right' => '10em',
 			'potato'       => 'uppercase',
 		);
 		$css_declarations   = new WP_Style_Engine_CSS_Declarations( $input_declarations );
 
 		$this->assertSame(
-			'color:&lt;red/&gt;;margin-right:10em;',
+			'margin-right:10em;',
 			$css_declarations->get_declarations_string()
 		);
 	}
@@ -179,7 +179,7 @@ class WP_Style_Engine_CSS_Declarations_Test extends WP_UnitTestCase {
 		$css_declarations   = new WP_Style_Engine_CSS_Declarations( $input_declarations );
 
 		$this->assertSame(
-			'background:var(--wp--preset--color--primary, 10px);font-size:clamp(36.00rem, calc(32.00rem + 10.00vw), 40.00rem);width:min(150vw, 100px);min-width:max(150vw, 100px);max-width:minmax(400px, 50%);padding:calc(80px * -1);background-image:url(&quot;https://wordpress.org&quot;);',
+			'background:var(--wp--preset--color--primary, 10px);font-size:clamp(36.00rem, calc(32.00rem + 10.00vw), 40.00rem);width:min(150vw, 100px);min-width:max(150vw, 100px);max-width:minmax(400px, 50%);padding:calc(80px * -1);background-image:url("https://wordpress.org");',
 			$css_declarations->get_declarations_string()
 		);
 	}

--- a/packages/style-engine/phpunit/class-wp-style-engine-css-declarations-test.php
+++ b/packages/style-engine/phpunit/class-wp-style-engine-css-declarations-test.php
@@ -150,7 +150,6 @@ class WP_Style_Engine_CSS_Declarations_Test extends WP_UnitTestCase {
 	public function test_remove_unsafe_properties_and_values() {
 		$input_declarations = array(
 			'color'        => '<red/>',
-			'display'      => 'none',
 			'margin-right' => '10em',
 			'potato'       => 'uppercase',
 		);
@@ -167,7 +166,6 @@ class WP_Style_Engine_CSS_Declarations_Test extends WP_UnitTestCase {
 	 */
 	public function test_allow_particular_css_functions() {
 		$input_declarations = array(
-			'display'          => 'flex',
 			'background'       => 'var(--wp--preset--color--primary, 10px)', // Simple var().
 			'font-size'        => 'clamp(36.00rem, calc(32.00rem + 10.00vw), 40.00rem)', // Nested clamp().
 			'width'            => 'min(150vw, 100px)',
@@ -181,7 +179,7 @@ class WP_Style_Engine_CSS_Declarations_Test extends WP_UnitTestCase {
 		$css_declarations   = new WP_Style_Engine_CSS_Declarations( $input_declarations );
 
 		$this->assertSame(
-			'display:flex;background:var(--wp--preset--color--primary, 10px);font-size:clamp(36.00rem, calc(32.00rem + 10.00vw), 40.00rem);width:min(150vw, 100px);min-width:max(150vw, 100px);max-width:minmax(400px, 50%);padding:calc(80px * -1);background-image:url(&quot;https://wordpress.org&quot;);',
+			'background:var(--wp--preset--color--primary, 10px);font-size:clamp(36.00rem, calc(32.00rem + 10.00vw), 40.00rem);width:min(150vw, 100px);min-width:max(150vw, 100px);max-width:minmax(400px, 50%);padding:calc(80px * -1);background-image:url(&quot;https://wordpress.org&quot;);',
 			$css_declarations->get_declarations_string()
 		);
 	}

--- a/packages/style-engine/phpunit/class-wp-style-engine-css-declarations-test.php
+++ b/packages/style-engine/phpunit/class-wp-style-engine-css-declarations-test.php
@@ -150,6 +150,7 @@ class WP_Style_Engine_CSS_Declarations_Test extends WP_UnitTestCase {
 	public function test_remove_unsafe_properties_and_values() {
 		$input_declarations = array(
 			'color'        => '<red/>',
+			'display'      => 'none',
 			'margin-right' => '10em',
 			'potato'       => 'uppercase',
 		);
@@ -157,6 +158,30 @@ class WP_Style_Engine_CSS_Declarations_Test extends WP_UnitTestCase {
 
 		$this->assertSame(
 			'color:&lt;red/&gt;;margin-right:10em;',
+			$css_declarations->get_declarations_string()
+		);
+	}
+
+	/**
+	 * Should allow calc, clamp, min, max, and minmax CSS functions.
+	 */
+	public function test_allow_particular_css_functions() {
+		$input_declarations = array(
+			'display'          => 'flex',
+			'background'       => 'var(--wp--preset--color--primary, 10px)', // Simple var().
+			'font-size'        => 'clamp(36.00rem, calc(32.00rem + 10.00vw), 40.00rem)', // Nested clamp().
+			'width'            => 'min(150vw, 100px)',
+			'min-width'        => 'max(150vw, 100px)',
+			'max-width'        => 'minmax(400px, 50%)',
+			'padding'          => 'calc(80px * -1)',
+			'background-image' => 'url("https://wordpress.org")',
+			'line-height'      => 'url("https://wordpress.org")',
+			'margin'           => 'illegalfunction(30px)',
+		);
+		$css_declarations   = new WP_Style_Engine_CSS_Declarations( $input_declarations );
+
+		$this->assertSame(
+			'display:flex;background:var(--wp--preset--color--primary, 10px);font-size:clamp(36.00rem, calc(32.00rem + 10.00vw), 40.00rem);width:min(150vw, 100px);min-width:max(150vw, 100px);max-width:minmax(400px, 50%);padding:calc(80px * -1);background-image:url(&quot;https://wordpress.org&quot;);',
 			$css_declarations->get_declarations_string()
 		);
 	}

--- a/packages/style-engine/phpunit/class-wp-style-engine-test.php
+++ b/packages/style-engine/phpunit/class-wp-style-engine-test.php
@@ -209,7 +209,7 @@ class WP_Style_Engine_Test extends WP_UnitTestCase {
 				),
 				'options'         => null,
 				'expected_output' => array(
-					'css'          => 'font-family:Roboto,Oxygen-Sans,Ubuntu,sans-serif;font-style:italic;font-weight:800;line-height:1.3;text-decoration:underline;text-transform:uppercase;letter-spacing:2;',
+					'css'          => 'font-size:clamp(2em, 2vw, 4em);font-family:Roboto,Oxygen-Sans,Ubuntu,sans-serif;font-style:italic;font-weight:800;line-height:1.3;text-decoration:underline;text-transform:uppercase;letter-spacing:2;',
 					'declarations' => array(
 						'font-size'       => 'clamp(2em, 2vw, 4em)',
 						'font-family'     => 'Roboto,Oxygen-Sans,Ubuntu,sans-serif',


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Fixes #42948 

A potential alternative to #42968, exploring @Mamaduka's idea from https://github.com/WordPress/gutenberg/pull/42968#discussion_r937716829

The idea here is that to resolve the issue of the style engine stripping values that use `clamp()` we can roll out the proposed updated regex for filtering values from the Trac ticket: https://core.trac.wordpress.org/ticket/55966.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

The idea behind this PR is that the style engine shouldn't have to be doing too much of its own work to determine whether or not a rule is valid. I've added an additional function just in case we need to add further special handling down the track (for display, perhaps?), but for now we're still deferring to `safecss_filter_attr`.

<!--
Hopefully we can still defer most of this to `safecss_filter_attr`, however this PR still adds in special handling for the `display` property. As raised in https://github.com/WordPress/wordpress-develop/pull/2928, we'll need special handling for this property as it isn't intended to be dealt with by the core filter.
-->

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

* Add a filter callback for `safecss_filter_attr_allow_css` that uses the proposed regex from https://core.trac.wordpress.org/ticket/55966 (the changes are viewable in this diff: https://core.trac.wordpress.org/attachment/ticket/55966/55966.2.diff)
* Add another method to the style engine declarations class that accepts a property and value, and then defers to `safecss_filter_attr`

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->

1. Follow the reproduction steps in #42948 and check that this PR allows the expected `clamp()` values
2. Double-check that the copied over regex from https://core.trac.wordpress.org/ticket/55966 looks acceptable and comparable to the core implementation. To review this section, it might be helpful to compare to the existing core implementation over in: https://github.com/WordPress/wordpress-develop/blob/HEAD/src/wp-includes/kses.php#L2469
3. Since this filter applies for all CSS filtering in Gutenberg, rather than just the style engine, confidence check that the change looks acceptable