### PR TITLE
Tag Cloudf: Fixed alignment issue when align center

### DIFF
--- a/packages/block-library/src/tag-cloud/style.scss
+++ b/packages/block-library/src/tag-cloud/style.scss
@@ -1,6 +1,7 @@
 .wp-block-tag-cloud {
 	&.aligncenter {
 		text-align: center;
+		justify-content: center;
 	}
 
 	&.alignfull {


### PR DESCRIPTION
I have solved the issue which is mentioned in #43016 
1)Activate the Twenty Twenty-Two theme.
2)Add the tag cloud block and select taxonomies from list
3)Now set the center alignment. You can see it will not be in center alignment.

