### PR TITLE
Lodash: Refactor away from `_.startsWith()`

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -128,6 +128,7 @@ module.exports = {
 							'reverse',
 							'size',
 							'snakeCase',
+							'startsWith',
 							'stubFalse',
 							'stubTrue',
 							'sum',

--- a/packages/block-editor/src/components/link-control/is-url-like.js
+++ b/packages/block-editor/src/components/link-control/is-url-like.js
@@ -1,9 +1,4 @@
 /**
- * External dependencies
- */
-import { startsWith } from 'lodash';
-
-/**
  * WordPress dependencies
  */
 import { isURL } from '@wordpress/url';
@@ -20,6 +15,6 @@ import { isURL } from '@wordpress/url';
  * @return {boolean} whether or not the value is potentially a URL.
  */
 export default function isURLLike( val ) {
-	const isInternal = startsWith( val, '#' );
+	const isInternal = val.startsWith( '#' );
 	return isURL( val ) || ( val && val.includes( 'www.' ) ) || isInternal;
 }

--- a/packages/block-editor/src/components/link-control/is-url-like.js
+++ b/packages/block-editor/src/components/link-control/is-url-like.js
@@ -15,6 +15,6 @@ import { isURL } from '@wordpress/url';
  * @return {boolean} whether or not the value is potentially a URL.
  */
 export default function isURLLike( val ) {
-	const isInternal = val.startsWith( '#' );
+	const isInternal = val?.startsWith( '#' );
 	return isURL( val ) || ( val && val.includes( 'www.' ) ) || isInternal;
 }

--- a/packages/block-editor/src/components/link-control/use-search-handler.js
+++ b/packages/block-editor/src/components/link-control/use-search-handler.js
@@ -6,11 +6,6 @@ import { useCallback } from '@wordpress/element';
 import { useSelect } from '@wordpress/data';
 
 /**
- * External dependencies
- */
-import { startsWith } from 'lodash';
-
-/**
  * Internal dependencies
  */
 import isURLLike from './is-url-like';
@@ -38,7 +33,7 @@ export const handleDirectEntry = ( val ) => {
 		type = TEL_TYPE;
 	}
 
-	if ( startsWith( val, '#' ) ) {
+	if ( val.startsWith( '#' ) ) {
 		type = INTERNAL_TYPE;
 	}
 

--- a/packages/block-editor/src/components/link-control/use-search-handler.js
+++ b/packages/block-editor/src/components/link-control/use-search-handler.js
@@ -33,7 +33,7 @@ export const handleDirectEntry = ( val ) => {
 		type = TEL_TYPE;
 	}
 
-	if ( val.startsWith( '#' ) ) {
+	if ( val?.startsWith( '#' ) ) {
 		type = INTERNAL_TYPE;
 	}
 

--- a/packages/blocks/src/api/serializer.js
+++ b/packages/blocks/src/api/serializer.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { isEmpty, reduce, castArray, startsWith } from 'lodash';
+import { isEmpty, reduce, castArray } from 'lodash';
 
 /**
  * WordPress dependencies
@@ -320,7 +320,7 @@ export function getCommentDelimitedContent(
 		: '';
 
 	// Strip core blocks of their namespace prefix.
-	const blockName = startsWith( rawBlockName, 'core/' )
+	const blockName = rawBlockName?.startsWith( 'core/' )
 		? rawBlockName.slice( 5 )
 		: rawBlockName;
 

--- a/packages/components/src/mobile/global-styles-context/utils.native.js
+++ b/packages/components/src/mobile/global-styles-context/utils.native.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { find, startsWith, get, camelCase, has } from 'lodash';
+import { find, get, camelCase, has } from 'lodash';
 import { Dimensions } from 'react-native';
 
 /**
@@ -104,7 +104,7 @@ export function getBlockColors(
 
 	// Custom colors.
 	Object.entries( blockStyleAttributes ).forEach( ( [ key, value ] ) => {
-		const isCustomColor = startsWith( value, '#' );
+		const isCustomColor = value?.startsWith?.( '#' );
 		let styleKey = key;
 
 		if ( BLOCK_STYLE_ATTRIBUTES_MAPPING[ styleKey ] ) {

--- a/packages/edit-site/src/components/global-styles/use-global-styles-output.js
+++ b/packages/edit-site/src/components/global-styles/use-global-styles-output.js
@@ -10,7 +10,6 @@ import {
 	pickBy,
 	reduce,
 	set,
-	startsWith,
 } from 'lodash';
 
 /**
@@ -50,7 +49,7 @@ function compileStyleValue( uncompiledValue ) {
 	const VARIABLE_REFERENCE_PREFIX = 'var:';
 	const VARIABLE_PATH_SEPARATOR_TOKEN_ATTRIBUTE = '|';
 	const VARIABLE_PATH_SEPARATOR_TOKEN_STYLE = '--';
-	if ( startsWith( uncompiledValue, VARIABLE_REFERENCE_PREFIX ) ) {
+	if ( uncompiledValue?.startsWith( VARIABLE_REFERENCE_PREFIX ) ) {
 		const variable = uncompiledValue
 			.slice( VARIABLE_REFERENCE_PREFIX.length )
 			.split( VARIABLE_PATH_SEPARATOR_TOKEN_ATTRIBUTE )

--- a/test/integration/full-content/full-content.test.js
+++ b/test/integration/full-content/full-content.test.js
@@ -2,7 +2,7 @@
  * External dependencies
  */
 import glob from 'fast-glob';
-import { startsWith, get } from 'lodash';
+import { get } from 'lodash';
 import { format } from 'util';
 
 /**
@@ -237,7 +237,7 @@ describe( 'full post content fixture', () => {
 					.filter(
 						( basename ) =>
 							basename === nameToFilename ||
-							startsWith( basename, nameToFilename + '__' )
+							basename.startsWith( nameToFilename + '__' )
 					)
 					.map( ( basename ) => {
 						const { filename: htmlFixtureFileName } =


### PR DESCRIPTION
## What?
This PR removes the `_.startsWith()` usage completely and deprecates the function. 

## Why?

Lodash is known to unnecessarily inflate the bundle size of packages, and in most cases, it can be replaced with native language functionality. See these for more information and rationale:

* https://github.com/WordPress/gutenberg/issues/16938#issuecomment-602837246
* https://github.com/WordPress/gutenberg/issues/17025
* https://github.com/WordPress/gutenberg/issues/39495 

## How?

Removing `_.startsWith()` is straightforward in favor of the native `String.prototype.startsWith()`, then we need to add additional optional chaining where the value may be nullish.

## Testing Instructions
* In the editor, select some text, and click the Link button to make it link.
* Verify searching and adding a link still works.
* Smoke test the site editor and post editor.
* Verify all tests still pass.