### PR TITLE
Navigation Menu Sidebar: Remove unnecessary Fragment

### DIFF
--- a/packages/edit-site/src/components/sidebar/navigation-menu-sidebar/navigation-menu.js
+++ b/packages/edit-site/src/components/sidebar/navigation-menu-sidebar/navigation-menu.js
@@ -48,9 +48,5 @@ export default function NavigationMenu( { innerBlocks, id } ) {
 			}
 		} );
 	}, [ updateBlockListSettings, innerBlocks ] );
-	return (
-		<>
-			<ListView id={ id } />
-		</>
-	);
+	return <ListView id={ id } />;
 }


### PR DESCRIPTION
## What?
A minor PR removes unnecessary `React.Fragment` from Navigation Menu Sidebar component.

## Why?
No need to use `React.Fragment` here.

## Testing Instructions

Confirm Navigation Menu Sidebar loads without an error in the Site Editor.
