### PR TITLE
Buttons: Update selectors to work better with button elements

### DIFF
--- a/lib/blocks.php
+++ b/lib/blocks.php
@@ -199,7 +199,7 @@ function gutenberg_register_core_block_assets( $block_name ) {
 		wp_register_style(
 			"wp-block-{$block_name}",
 			gutenberg_url( $style_path ),
-			array( 'global-styles' ),
+			array(),
 			$default_version
 		);
 		wp_style_add_data( "wp-block-{$block_name}", 'rtl', 'replace' );
@@ -207,7 +207,7 @@ function gutenberg_register_core_block_assets( $block_name ) {
 		// Add a reference to the stylesheet's path to allow calculations for inlining styles in `wp_head`.
 		wp_style_add_data( "wp-block-{$block_name}", 'path', gutenberg_dir_path() . $style_path );
 	} else {
-		wp_register_style( "wp-block-{$block_name}", false, array( 'global-styles' ) );
+		wp_register_style( "wp-block-{$block_name}", false, array() );
 	}
 
 	// If the current theme supports wp-block-styles, dequeue the full stylesheet
@@ -246,7 +246,7 @@ function gutenberg_register_core_block_assets( $block_name ) {
 				wp_register_style(
 					"wp-block-{$block_name}",
 					gutenberg_url( $theme_style_path ),
-					array( 'global-styles' ),
+					array(),
 					$default_version
 				);
 				wp_style_add_data( "wp-block-{$block_name}", 'path', gutenberg_dir_path() . $theme_style_path );

--- a/packages/block-library/src/button/block.json
+++ b/packages/block-library/src/button/block.json
@@ -89,7 +89,7 @@
 				"radius": true
 			}
 		},
-		"__experimentalSelector": ".wp-block-button__link"
+		"__experimentalSelector": ".wp-block-button .wp-block-button__link"
 	},
 	"styles": [
 		{ "name": "fill", "label": "Fill", "isDefault": true },

--- a/packages/block-library/src/button/style.scss
+++ b/packages/block-library/src/button/style.scss
@@ -102,18 +102,18 @@ $blocks-block__margin: 0.5em;
 	border-radius: 0 !important;
 }
 
-.is-style-outline > :where(.wp-block-button__link),
-:where(.wp-block-button__link).is-style-outline {
+.wp-block-button.is-style-outline > .wp-block-button__link,
+.wp-block-button .wp-block-button__link.is-style-outline {
 	border: 2px solid currentColor;
 	padding: 0.667em 1.333em;
 }
 
-.is-style-outline > .wp-block-button__link:not(.has-text-color),
-.wp-block-button__link.is-style-outline:not(.has-text-color) {
+.wp-block-button.is-style-outline > .wp-block-button__link:not(.has-text-color),
+.wp-block-button .wp-block-button__link.is-style-outline:not(.has-text-color) {
 	color: currentColor;
 }
 
-.is-style-outline > .wp-block-button__link:not(.has-background),
-.wp-block-button__link.is-style-outline:not(.has-background) {
+.wp-block-button.is-style-outline > .wp-block-button__link:not(.has-background),
+.wp-block-button .wp-block-button__link.is-style-outline:not(.has-background) {
 	background-color: transparent;
 }


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
This is another attempt to fix https://github.com/WordPress/gutenberg/issues/42097, which is significantly simpler than https://github.com/WordPress/gutenberg/pull/42991.

## Why?
The aim is to ensure that button outline style appear the same in the frontend and the editor.

## How?
In https://github.com/WordPress/gutenberg/pull/41934 we made some changes to the way that block styles were loaded, so that they are dependent on global styles, and therefore load later. The is problematic, as it doesn't match the order that styles load in the post and site editor, and that is hard to change (see https://github.com/WordPress/gutenberg/pull/42991).

The proposal here is to revert that change, and instead handle the discrepancy using CSS specificity.

This change adds a `.wp-block-button` class to the selector for block buttons, so that it will be stronger than the `.wp-element-button` selector. It makes a similar change to the outline button styles to ensure that they are stronger than the theme.json settings.

## Testing Instructions

Here's some sample markup:

```
<!-- wp:buttons -->
<div class="wp-block-buttons"><!-- wp:button -->
<div class="wp-block-button"><a class="wp-block-button__link wp-element-button">button 1</a></div>
<!-- /wp:button -->

<!-- wp:button -->
<div class="wp-block-button"><a class="wp-block-button__link wp-element-button">button 2</a></div>
<!-- /wp:button -->

<!-- wp:button -->
<div class="wp-block-button"><a class="wp-block-button__link wp-element-button">button 3</a></div>
<!-- /wp:button -->

<!-- wp:button -->
<div class="wp-block-button"><a class="wp-block-button__link wp-element-button">button 4</a></div>
<!-- /wp:button -->

<!-- wp:button -->
<div class="wp-block-button"><a class="wp-block-button__link wp-element-button">button 5</a></div>
<!-- /wp:button -->

<!-- wp:button -->
<div class="wp-block-button"><a class="wp-block-button__link wp-element-button">button 6</a></div>
<!-- /wp:button -->

<!-- wp:button -->
<div class="wp-block-button"><a class="wp-block-button__link wp-element-button">button 7</a></div>
<!-- /wp:button -->

<!-- wp:button {"className":"is-style-outline"} -->
<div class="wp-block-button is-style-outline"><a class="wp-block-button__link wp-element-button">outline button</a></div>
<!-- /wp:button --></div>
<!-- /wp:buttons -->

<!-- wp:heading -->
<h2>Search block</h2>
<!-- /wp:heading -->

<!-- wp:search {"label":"Search","buttonText":"Search button"} /-->

<!-- wp:heading -->
<h2>File block</h2>
<!-- /wp:heading -->

<!-- wp:file {"id":177,"href":"http://localhost:4759/wp-content/uploads/2022/06/site-logo.mov"} -->
<div class="wp-block-file"><a id="wp-block-file--media-28fd4c5c-e2de-4996-b33a-fc5a8cafd02b" href="http://localhost:4759/wp-content/uploads/2022/06/site-logo.mov">site-logo</a><a href="http://localhost:4759/wp-content/uploads/2022/06/site-logo.mov" class="wp-block-file__button wp-element-button" download aria-describedby="wp-block-file--media-28fd4c5c-e2de-4996-b33a-fc5a8cafd02b">Download</a></div>
<!-- /wp:file -->
```

Scenario 1: Button element rules in theme.json
- Check a theme that only uses button element rules (e.g. Rainfall)
<img width="807" alt="Screenshot 2022-08-05 at 10 53 24" src="https://user-images.githubusercontent.com/275961/183052695-f0472796-dd50-4610-b84e-f2cdc044c86a.png">

Scenario 2: Button block rules in theme.json
- Check a theme that only uses button block rules (e.g. Remote)
<img width="1440" alt="Screenshot 2022-08-05 at 10 22 05" src="https://user-images.githubusercontent.com/275961/183053358-b55cb1be-43f3-4c39-90f9-9b30ddca93d0.png">

Scenario 3: Button element and block rules in theme.json
- Add this to the rainfall theme.json:
```
			"core/button": {
				"color": {
					"background": "hotpink",
					"text": "green"
				}
			},
```
<img width="801" alt="Screenshot 2022-08-05 at 11 01 05" src="https://user-images.githubusercontent.com/275961/183054126-8ddc4d4d-1012-4aeb-800d-9d8c4de5bbc9.png">


In all three scenarios check both normal buttons and outline buttons. Also check that things look the same in the frontend, the site editor and the post editor.

## Questions
There is an open question here about how block style variations should interact with theme.json settings - should the block styles take precedence, or the setting from theme.json? Either way we still need to make changes here to ensure the behaviour is the same in the editor and the frontend. In https://github.com/WordPress/gutenberg/issues/35438 the intention seems to be that block style variations are overridden by theme.json, but the problem I see with that is that, for example, outline buttons for example will start to look the same as regular buttons. My view is that the style variation should take precedence, which is what I have done in this PR, but I'm open to rethink that. cc @oandregal @mtias 