### PR TITLE
Archives: Add a control to make block's dropdown label invisible

### DIFF
--- a/docs/reference-guides/core-blocks.md
+++ b/docs/reference-guides/core-blocks.md
@@ -15,7 +15,7 @@ Display a date archive of your posts. ([Source](https://github.com/WordPress/gut
 -	**Name:** core/archives
 -	**Category:** widgets
 -	**Supports:** align, ~~html~~
--	**Attributes:** displayAsDropdown, showPostCounts, type
+-	**Attributes:** displayAsDropdown, showLabel, showPostCounts, type
 
 ## Audio
 

--- a/packages/block-library/src/archives/block.json
+++ b/packages/block-library/src/archives/block.json
@@ -11,6 +11,10 @@
 			"type": "boolean",
 			"default": false
 		},
+		"showLabel": {
+			"type": "boolean",
+			"default": true
+		},
 		"showPostCounts": {
 			"type": "boolean",
 			"default": false

--- a/packages/block-library/src/archives/edit.js
+++ b/packages/block-library/src/archives/edit.js
@@ -12,7 +12,7 @@ import { InspectorControls, useBlockProps } from '@wordpress/block-editor';
 import ServerSideRender from '@wordpress/server-side-render';
 
 export default function ArchivesEdit( { attributes, setAttributes } ) {
-	const { showPostCounts, displayAsDropdown, type } = attributes;
+	const { showLabel, showPostCounts, displayAsDropdown, type } = attributes;
 
 	return (
 		<>
@@ -27,6 +27,17 @@ export default function ArchivesEdit( { attributes, setAttributes } ) {
 							} )
 						}
 					/>
+					{ displayAsDropdown && (
+						<ToggleControl
+							label={ __( 'Show label' ) }
+							checked={ showLabel }
+							onChange={ () =>
+								setAttributes( {
+									showLabel: ! showLabel,
+								} )
+							}
+						/>
+					) }
 					<ToggleControl
 						label={ __( 'Show post counts' ) }
 						checked={ showPostCounts }

--- a/packages/block-library/src/archives/index.php
+++ b/packages/block-library/src/archives/index.php
@@ -62,7 +62,9 @@ function render_block_core_archives( $attributes ) {
 				break;
 		}
 
-		$block_content = '<label for="' . esc_attr( $dropdown_id ) . '">' . esc_html( $title ) . '</label>
+		$show_label = ( empty( $attributes['showLabel'] ) ) ? ' screen-reader-text' : '';
+
+		$block_content = '<label for="' . esc_attr( $dropdown_id ) . '" class="wp-block-archives__label' . $show_label . '">' . esc_html( $title ) . '</label>
 	<select id="' . esc_attr( $dropdown_id ) . '" name="archive-dropdown" onchange="document.location.href=this.options[this.selectedIndex].value;">
 	<option value="">' . esc_html( $label ) . '</option>' . $archives . '</select>';
 

--- a/packages/block-library/src/archives/index.php
+++ b/packages/block-library/src/archives/index.php
@@ -62,11 +62,11 @@ function render_block_core_archives( $attributes ) {
 				break;
 		}
 
-		$show_label = ( empty( $attributes['showLabel'] ) ) ? ' screen-reader-text' : '';
+		$show_label = empty( $attributes['showLabel'] ) ? ' screen-reader-text' : '';
 
-		$block_content = '<label for="' . esc_attr( $dropdown_id ) . '" class="wp-block-archives__label' . $show_label . '">' . esc_html( $title ) . '</label>
-	<select id="' . esc_attr( $dropdown_id ) . '" name="archive-dropdown" onchange="document.location.href=this.options[this.selectedIndex].value;">
-	<option value="">' . esc_html( $label ) . '</option>' . $archives . '</select>';
+		$block_content = '<label for="' . $dropdown_id . '" class="wp-block-archives__label' . $show_label . '">' . esc_html( $title ) . '</label>
+		<select id="' . $dropdown_id . '" name="archive-dropdown" onchange="document.location.href=this.options[this.selectedIndex].value;">
+		<option value="">' . esc_html( $label ) . '</option>' . $archives . '</select>';
 
 		return sprintf(
 			'<div %1$s>%2$s</div>',

--- a/test/integration/fixtures/blocks/core__archives.json
+++ b/test/integration/fixtures/blocks/core__archives.json
@@ -4,6 +4,7 @@
 		"isValid": true,
 		"attributes": {
 			"displayAsDropdown": false,
+			"showLabel": true,
 			"showPostCounts": false,
 			"type": "monthly"
 		},

--- a/test/integration/fixtures/blocks/core__archives__showPostCounts.json
+++ b/test/integration/fixtures/blocks/core__archives__showPostCounts.json
@@ -4,6 +4,7 @@
 		"isValid": true,
 		"attributes": {
 			"displayAsDropdown": false,
+			"showLabel": true,
 			"showPostCounts": true,
 			"type": "monthly"
 		},


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->
Make it optional to show the label above the archive block drop down.
Hide the label with a screen-reader-text class if the user chooses to not display the label.
Fixes https://github.com/WordPress/gutenberg/issues/41208

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
The early version of the block did not have a visible label. Once the label was added, it was not possible to hide it again without custom CSS.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
Add a new block attribute and a control for hiding the label.
The label is shown by default.
The option to hide it is only available if the "display as dropdown" option is enabled.

## Testing Instructions

1. Add an archives block in either editor.
2. Confirm that the the option "Show label" is enabled by default.
3. Confirm that toggling the "Display as dropdown" or "Show label" off hides the label.
4. Confirm that when visually hidden, the label is still present in the markup.
5. Please view the front of the website and check that the label hides and displays correctly.

## Screenshots or screencast <!-- if applicable -->
![Archives block with the new option to hide the visual label in the sidebar.](https://user-images.githubusercontent.com/7422055/183070610-5b1efae3-2ab0-4fe7-953f-405e69ee87c6.png)

