### PR TITLE
Block Directory: Modernize `DownloadableBlockListItem` tests

### DIFF
--- a/packages/block-directory/src/components/downloadable-block-list-item/test/index.js
+++ b/packages/block-directory/src/components/downloadable-block-list-item/test/index.js
@@ -1,7 +1,8 @@
 /**
  * External dependencies
  */
-import { render, fireEvent } from '@testing-library/react';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 
 /**
  * WordPress dependencies
@@ -27,11 +28,11 @@ describe( 'DownloadableBlockListItem', () => {
 			isInstallable: true,
 		} ) );
 
-		const { queryByText } = render(
+		render(
 			<DownloadableBlockListItem onClick={ jest.fn() } item={ plugin } />
 		);
-		const author = queryByText( `by ${ plugin.author }` );
-		const description = queryByText( plugin.description );
+		const author = screen.queryByText( `by ${ plugin.author }` );
+		const description = screen.queryByText( plugin.description );
 		expect( author ).not.toBeNull();
 		expect( description ).not.toBeNull();
 	} );
@@ -42,10 +43,10 @@ describe( 'DownloadableBlockListItem', () => {
 			isInstallable: true,
 		} ) );
 
-		const { queryByText } = render(
+		render(
 			<DownloadableBlockListItem onClick={ jest.fn() } item={ plugin } />
 		);
-		const statusLabel = queryByText( 'Installing…' );
+		const statusLabel = screen.queryByText( 'Installing…' );
 		expect( statusLabel ).not.toBeNull();
 	} );
 
@@ -55,27 +56,30 @@ describe( 'DownloadableBlockListItem', () => {
 			isInstallable: false,
 		} ) );
 
-		const { getByRole } = render(
+		render(
 			<DownloadableBlockListItem onClick={ jest.fn() } item={ plugin } />
 		);
-		const button = getByRole( 'option' );
+		const button = screen.getByRole( 'option' );
 		// Keeping it false to avoid focus loss and disable it using aria-disabled.
 		expect( button.disabled ).toBe( false );
 		expect( button.getAttribute( 'aria-disabled' ) ).toBe( 'true' );
 	} );
 
-	it( 'should try to install the block plugin', () => {
+	it( 'should try to install the block plugin', async () => {
+		const user = userEvent.setup( {
+			advanceTimers: jest.advanceTimersByTime,
+		} );
+
 		useSelect.mockImplementation( () => ( {
 			isInstalling: false,
 			isInstallable: true,
 		} ) );
 		const onClick = jest.fn();
-		const { getByRole } = render(
+		render(
 			<DownloadableBlockListItem onClick={ onClick } item={ plugin } />
 		);
 
-		const button = getByRole( 'option' );
-		fireEvent.click( button );
+		await user.click( screen.getByRole( 'option' ) );
 
 		expect( onClick ).toHaveBeenCalledTimes( 1 );
 	} );


### PR DESCRIPTION
## What?
We've recently started refactoring `enzyme` tests to `@testing-library/react` in #42981.

Inspired by that work, in this PR we're modernizing some of the existing `@testing-library/react` tests to follow the library's best practices.

## Why?
Historically, some of the `testing-library` APIs have changed over the latest versions, and there are a few best practices recommended by the library, namely:

* Discouraging `fireEvent` and using `@testing-library/user-event` for dispatching user events and testing interactions.
  * For more info see: 
    * https://kentcdodds.com/blog/common-mistakes-with-react-testing-library#not-using-testing-libraryuser-event
    * https://testing-library.com/docs/user-event/intro
    * https://ph-fritsche.github.io/blog/post/why-userevent
* Using `screen` for queries, rather than the query functions returned by `render()`/`rerender()`.
  * For more info see:
    * https://kentcdodds.com/blog/common-mistakes-with-react-testing-library#not-using-screen

Ideally, we should follow those for all tests, and this PR is a step in that direction.

## How?

We're using `screen` instead of the `render()` queries, and `@testing-library/user-event` instead of `fireEvent()`.

## Testing Instructions
Verify tests pass: `npm run test-unit packages/block-directory/src/components/downloadable-block-list-item/test/index.js`
