### PR TITLE
Remove the emoji characters to fix the handbook rendering

### DIFF
--- a/docs/contributors/code/auto-cherry-picking.md
+++ b/docs/contributors/code/auto-cherry-picking.md
@@ -39,12 +39,12 @@ Fetching commit IDs... Done!
 Trying to cherry-pick one by one...
 
 Cherry-picking round 1:
-   ✅  cherry-pick commit: afe9b757b4  for PR: #41198 – Site Editor: Set min-width for...
+    cherry-pick commit: afe9b757b4  for PR: #41198 – Site Editor: Set min-width for...
 Cherry-picking finished!
 
 Summary:
-   ✅  1 PRs got cherry-picked cleanly
-   ✅  0 PRs failed
+    1 PRs got cherry-picked cleanly
+    0 PRs failed
 
 About to push to origin/wp/6.2
 Do you want to proceed? (Y/n)
@@ -60,7 +60,7 @@ Either way, here's what happens once you proceed past the cherry-picking stage:
 ```
 Pushing to origin/wp/6.2
 Commenting and removing labels...
-✅ 41198: I just cherry-picked this PR to the wp/6.2 branch to get it included in the next release: afe9b757b4
+  41198: I just cherry-picked this PR to the wp/6.2 branch to get it included in the next release: afe9b757b4
 Done!
 ```
 


### PR DESCRIPTION
The handbook doesn't handle the emoji characters inside of code snippets correctly:

<img width="657" alt="CleanShot 2022-08-05 at 15 32 03@2x" src="https://user-images.githubusercontent.com/205419/183087999-c3c4dda1-464a-4aff-9c36-5e2d93d1d9ee.png">

Therefore I'm removing them from the document.

cc @gziolo @dmsnell @georgeh in case this is relevant for markdown processing.
