### PR TITLE
Block Library: Refactor Calendar block away from `moment`

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16611,7 +16611,6 @@
 				"lodash": "^4.17.21",
 				"memize": "^1.1.0",
 				"micromodal": "^0.4.10",
-				"moment": "^2.22.1",
 				"remove-accents": "^0.4.2"
 			},
 			"dependencies": {

--- a/packages/block-library/package.json
+++ b/packages/block-library/package.json
@@ -66,7 +66,6 @@
 		"lodash": "^4.17.21",
 		"memize": "^1.1.0",
 		"micromodal": "^0.4.10",
-		"moment": "^2.22.1",
 		"remove-accents": "^0.4.2"
 	},
 	"peerDependencies": {

--- a/packages/block-library/src/calendar/edit.js
+++ b/packages/block-library/src/calendar/edit.js
@@ -1,7 +1,6 @@
 /**
  * External dependencies
  */
-import moment from 'moment';
 import memoize from 'memize';
 
 /**
@@ -19,10 +18,10 @@ const getYearMonth = memoize( ( date ) => {
 	if ( ! date ) {
 		return {};
 	}
-	const momentDate = moment( date );
+	const dateObj = new Date( date );
 	return {
-		year: momentDate.year(),
-		month: momentDate.month() + 1,
+		year: dateObj.getFullYear(),
+		month: dateObj.getMonth() + 1,
 	};
 } );
 

--- a/packages/block-library/src/calendar/edit.js
+++ b/packages/block-library/src/calendar/edit.js
@@ -14,6 +14,14 @@ import { useBlockProps } from '@wordpress/block-editor';
 import { store as coreStore } from '@wordpress/core-data';
 import { __ } from '@wordpress/i18n';
 
+/**
+ * Returns the year and month of a specified date.
+ *
+ * @see `WP_REST_Posts_Controller::prepare_date_response()`.
+ *
+ * @param {string} date Date in `ISO8601/RFC3339` format.
+ * @return {Object} Year and date of the specified date.
+ */
 const getYearMonth = memoize( ( date ) => {
 	if ( ! date ) {
 		return {};


### PR DESCRIPTION
## What?
This PR refactors the `Calendar` block to not use `moment` but use native JS functionality instead. We're also removing `moment` as a dependency for the `@wordpress/block-library` package.

## Why?
With [Temporal in Stage 3](https://github.com/tc39/proposal-temporal#status), we should start thinking about migrating away from `moment` in favor of using native browser APIs for better experience and performance. 

This PR doesn't suggest Temporal replacement, but removes one of the few remaining `moment` usages to ease that goal the future.

## How?
Dates used in the Calendar are always in the same format, so we're replacing the `moment` usage with simple a native JS `Date()`. I couldn't think of a good reason to use `moment` there in the first place when we can use native JS.

## Testing Instructions
* Insert a Calendar block in your post.
* Verify it still loads correctly and shows the current month of the current year.
