### PR TITLE
Icons: Fix storybook library icon names

### DIFF
--- a/packages/icons/src/icon/stories/index.js
+++ b/packages/icons/src/icon/stories/index.js
@@ -1,7 +1,7 @@
 /**
  * WordPress dependencies
  */
-import { useState } from '@wordpress/element';
+import { useState, Fragment } from '@wordpress/element';
 
 /**
  * Internal dependencies
@@ -12,9 +12,16 @@ import * as icons from '../../';
 
 const { Icon: _Icon, ...availableIcons } = icons;
 
-export default { title: 'Icons/Icon', component: Icon };
+const meta = {
+	component: Icon,
+	title: 'Icons/Icon',
+	parameters: {
+		controls: { hideNoControlsWarning: true },
+	},
+};
+export default meta;
 
-export const _default = () => {
+export const Default = () => {
 	return (
 		<>
 			<div>
@@ -45,8 +52,8 @@ const LibraryExample = () => {
 		  )
 		: availableIcons;
 	return (
-		<div style={ { padding: '20px' } }>
-			<label htmlFor="filter-icon" style={ { paddingRight: '10px' } }>
+		<div style={ { padding: 20 } }>
+			<label htmlFor="filter-icon" style={ { paddingRight: 10 } }>
 				Filter Icons
 			</label>
 			<input
@@ -57,20 +64,29 @@ const LibraryExample = () => {
 				placeholder="Icon name"
 				onChange={ ( event ) => setFilter( event.target.value ) }
 			/>
-			{ Object.entries( filteredIcons ).map( ( [ name, icon ] ) => {
-				return (
-					<div
-						key={ name }
-						style={ { display: 'flex', alignItems: 'center' } }
-					>
-						<strong style={ { width: '120px' } }>{ name }</strong>
-
-						<Icon icon={ icon } />
-						<Icon icon={ icon } size={ 36 } />
-						<Icon icon={ icon } size={ 48 } />
-					</div>
-				);
-			} ) }
+			<div style={ { marginTop: 20 } }>
+				<div
+					style={ {
+						display: 'inline-grid',
+						alignItems: 'center',
+						gap: 4,
+						gridTemplateColumns: 'auto 24px 36px 48px',
+					} }
+				>
+					{ Object.entries( filteredIcons ).map(
+						( [ name, icon ] ) => {
+							return (
+								<Fragment key={ name }>
+									<strong>{ name }</strong>
+									<Icon icon={ icon } />
+									<Icon icon={ icon } size={ 36 } />
+									<Icon icon={ icon } size={ 48 } />
+								</Fragment>
+							);
+						}
+					) }
+				</div>
+			</div>
 		</div>
 	);
 };


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Make sure the full icon name is visible to the left of the actual icons in storybook.

## Why?
When the icon names is partially behind the icons its hard to read the name.

## How?
Use CSS grid to make the icon name column auto scale so its as wide as the widest name instead of hardcoding a fixed width. This will also prevent this issue in the future.

## Testing Instructions
1. Checkout the storybook icon library story. Scroll down and confirm no names is behind the icons.

## Screenshots or screencast <!-- if applicable -->
| Before | After |
|-|-|
| <img width="304" alt="image" src="https://user-images.githubusercontent.com/1415747/183115327-be9fbcbc-5fad-444e-9f46-5de8d4619f69.png"> | <img width="353" alt="image" src="https://user-images.githubusercontent.com/1415747/183115154-a67f7035-2760-4661-96d9-e10c3e75ef56.png"> |
