### PR TITLE
Create Block: Remove i18n references from save properties

### DIFF
--- a/packages/create-block/lib/templates/block/save.js.mustache
+++ b/packages/create-block/lib/templates/block/save.js.mustache
@@ -1,11 +1,4 @@
 /**
- * Retrieves the translation of text.
- *
- * @see https://developer.wordpress.org/block-editor/reference-guides/packages/packages-i18n/
- */
-import { __ } from '@wordpress/i18n';
-
-/**
  * React hook that is used to mark the block wrapper element.
  * It provides all the necessary props like the class name.
  *

--- a/packages/create-block/lib/templates/block/save.js.mustache
+++ b/packages/create-block/lib/templates/block/save.js.mustache
@@ -25,10 +25,7 @@ import { useBlockProps } from '@wordpress/block-editor';
 export default function save() {
 	return (
 		<p { ...useBlockProps.save() }>
-			{ __(
-				'{{title}} – hello from the saved content!',
-				'{{textdomain}}'
-			) }
+			{ '{{title}} – hello from the saved content!' }
 		</p>
 	);
 }

--- a/packages/create-block/lib/templates/es5/index.js.mustache
+++ b/packages/create-block/lib/templates/es5/index.js.mustache
@@ -108,7 +108,7 @@
 			return el(
 				'p',
 				useBlockProps.save(),
-				__( '{{title}} – hello from the saved content!', '{{textdomain}}' )
+				'{{title}} – hello from the saved content!',
 			);
 		},
 	} );


### PR DESCRIPTION
## What?
This PR removes the save property `__()` reference.

## Why?
As point out by @talldan in https://github.com/WordPress/gutenberg/pull/42745#discussion_r931737976, the save property cannot contain internationalization as it could cause errors in the block editor if the block was saved in one language and then loaded in another
## How?
Removes the references to `__()`