### PR TITLE
Add: Content lock ability.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -18666,7 +18666,7 @@
 		"app-root-dir": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/app-root-dir/-/app-root-dir-1.0.2.tgz",
-			"integrity": "sha512-jlpIfsOoNoafl92Sz//64uQHGSyMrD2vYG5d8o2a4qGvyNCvXur7bzIsWtAC/6flI2RYAp3kv8rsfBtaLm7w0g==",
+			"integrity": "sha1-OBh+wt6nV3//Az/8sSFyaS/24Rg=",
 			"dev": true
 		},
 		"app-root-path": {
@@ -26845,7 +26845,7 @@
 		"babel-plugin-add-react-displayname": {
 			"version": "0.0.5",
 			"resolved": "https://registry.npmjs.org/babel-plugin-add-react-displayname/-/babel-plugin-add-react-displayname-0.0.5.tgz",
-			"integrity": "sha512-LY3+Y0XVDYcShHHorshrDbt4KFWL4bSeniCtl4SYZbask+Syngk1uMPCeN9+nSiZo6zX5s0RTq/J9Pnaaf/KHw==",
+			"integrity": "sha1-M51M3be2X9YtHfnbn+BN4TQSK9U=",
 			"dev": true
 		},
 		"babel-plugin-apply-mdx-type-prop": {
@@ -27268,7 +27268,7 @@
 		"batch-processor": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/batch-processor/-/batch-processor-1.0.0.tgz",
-			"integrity": "sha512-xoLQD8gmmR32MeuBHgH0Tzd5PuSZx71ZsbhVxOCRbgktZEPe4SQy7s9Z50uPp0F/f7iw2XmkHN2xkgbMfckMDA==",
+			"integrity": "sha1-dclcMrdI4IUNEMKxaPa9vpiRrOg=",
 			"dev": true
 		},
 		"bcrypt-pbkdf": {
@@ -30558,7 +30558,7 @@
 		"css.escape": {
 			"version": "1.5.1",
 			"resolved": "https://registry.npmjs.org/css.escape/-/css.escape-1.5.1.tgz",
-			"integrity": "sha512-YUifsXXuknHlUsmlgyY0PKzgPOr7/FjCePfHNt0jxm83wHZi44VDMQ7/fGNkjY3/jV1MC+1CmZbaHzugyeRtpg==",
+			"integrity": "sha1-QuJ9T6BK4y+TGktNQZH6nN3ul8s=",
 			"dev": true
 		},
 		"cssesc": {
@@ -36679,7 +36679,7 @@
 		"has-glob": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/has-glob/-/has-glob-1.0.0.tgz",
-			"integrity": "sha512-D+8A457fBShSEI3tFCj65PAbT++5sKiFtdCdOam0gnfBgw9D277OERk+HM9qYJXmdVLZ/znez10SqHN0BBQ50g==",
+			"integrity": "sha1-mqqe7b/7G6OZCnsAEPtnjuAIEgc=",
 			"dev": true,
 			"requires": {
 				"is-glob": "^3.0.0"
@@ -36688,7 +36688,7 @@
 				"is-glob": {
 					"version": "3.1.0",
 					"resolved": "https://registry.npmjs.org/is-glob/-/is-glob-3.1.0.tgz",
-					"integrity": "sha512-UFpDDrPgM6qpnFNI+rh/p3bUaq9hKLZN8bMUWzxmcnZVS3omf4IPK+BrewlnWjO1WmUsMYuSjKh4UJuV4+Lqmw==",
+					"integrity": "sha1-e6WuJCF4BKxwcHuWkiVnSGzD6Eo=",
 					"dev": true,
 					"requires": {
 						"is-extglob": "^2.1.0"
@@ -38502,7 +38502,7 @@
 		"is-window": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/is-window/-/is-window-1.0.2.tgz",
-			"integrity": "sha512-uj00kdXyZb9t9RcAUAwMZAnkBUwdYGhYlt7djMXhfyhUCzwNba50tIiBKR7q0l7tdoBtFVw/3JmLY6fI3rmZmg==",
+			"integrity": "sha1-LIlspT25feRdPDMTOmXYyfVjSA0=",
 			"dev": true
 		},
 		"is-windows": {
@@ -41879,7 +41879,7 @@
 		"js-string-escape": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/js-string-escape/-/js-string-escape-1.0.1.tgz",
-			"integrity": "sha512-Smw4xcfIQ5LVjAOuJCvN/zIodzA/BBSsluuoSykP+lUvScIi4U6RJLfwHet5cxFnCswUjISV8oAXaqaJDY3chg==",
+			"integrity": "sha1-4mJbrbwNZ8dTPp7cEGjFh65BN+8=",
 			"dev": true
 		},
 		"js-tokens": {
@@ -43407,7 +43407,7 @@
 		"lz-string": {
 			"version": "1.4.4",
 			"resolved": "https://registry.npmjs.org/lz-string/-/lz-string-1.4.4.tgz",
-			"integrity": "sha512-0ckx7ZHRPqb0oUm8zNr+90mtf9DQB60H1wMCjBtfi62Kl3a7JbHob6gA2bC+xRvZoOL+1hzUK8jeuEIQE8svEQ==",
+			"integrity": "sha1-wNjq82BZ9wV5bh40SBHPTEmNOiY=",
 			"dev": true
 		},
 		"macos-release": {
@@ -46738,7 +46738,7 @@
 		"num2fraction": {
 			"version": "1.2.2",
 			"resolved": "https://registry.npmjs.org/num2fraction/-/num2fraction-1.2.2.tgz",
-			"integrity": "sha512-Y1wZESM7VUThYY+4W+X4ySH2maqcA+p7UR+w8VWNWVAd6lwuXXWz/w/Cz43J/dI2I+PS6wD5N+bJUF+gjWvIqg==",
+			"integrity": "sha1-b2gragJ6Tp3fpFZM0lidHU5mnt4=",
 			"dev": true
 		},
 		"number-is-nan": {
@@ -47817,7 +47817,7 @@
 		"p-defer": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/p-defer/-/p-defer-1.0.0.tgz",
-			"integrity": "sha512-wB3wfAxZpk2AzOfUMJNL+d36xothRSyj8EXOa4f6GMqYDN9BJaaSISbsk+wS9abmnebVw95C2Kb5t85UmpCxuw==",
+			"integrity": "sha1-n26xgvbJqozXQwBKfU+WsZaw+ww=",
 			"dev": true
 		},
 		"p-event": {
@@ -49156,7 +49156,7 @@
 		"pretty-hrtime": {
 			"version": "1.0.3",
 			"resolved": "https://registry.npmjs.org/pretty-hrtime/-/pretty-hrtime-1.0.3.tgz",
-			"integrity": "sha512-66hKPCr+72mlfiSjlEB1+45IjXSqvVAIy6mocupoww4tBFE9R9IhwwUGoI4G++Tc9Aq+2rxOt0RFU6gPcrte0A==",
+			"integrity": "sha1-t+PqQkNaTJsnWdmeDyAesZWALuE=",
 			"dev": true
 		},
 		"prismjs": {
@@ -51388,7 +51388,7 @@
 		"relateurl": {
 			"version": "0.2.7",
 			"resolved": "https://registry.npmjs.org/relateurl/-/relateurl-0.2.7.tgz",
-			"integrity": "sha512-G08Dxvm4iDN3MLM0EsP62EDV9IuhXPR6blNz6Utcp7zyV3tr4HVNINt6MpaRWbxoOHT3Q7YN2P+jaHX8vUbgog==",
+			"integrity": "sha1-VNvzd+UUQKypCkzSdGANP/LYiKk=",
 			"dev": true
 		},
 		"remark": {

--- a/packages/block-editor/src/components/block-card/index.js
+++ b/packages/block-editor/src/components/block-card/index.js
@@ -8,7 +8,7 @@ import deprecated from '@wordpress/deprecated';
  */
 import BlockIcon from '../block-icon';
 
-function BlockCard( { title, icon, description, blockType } ) {
+function BlockCard( { title, icon, description, blockType, backButton } ) {
 	if ( blockType ) {
 		deprecated( '`blockType` property in `BlockCard component`', {
 			since: '5.7',
@@ -18,7 +18,7 @@ function BlockCard( { title, icon, description, blockType } ) {
 	}
 	return (
 		<div className="block-editor-block-card">
-			<BlockIcon icon={ icon } showColors />
+			{ backButton ? backButton : <BlockIcon icon={ icon } showColors /> }
 			<div className="block-editor-block-card__content">
 				<h2 className="block-editor-block-card__title">{ title }</h2>
 				<span className="block-editor-block-card__description">

--- a/packages/block-editor/src/components/block-edit/edit.js
+++ b/packages/block-editor/src/components/block-edit/edit.js
@@ -31,7 +31,7 @@ import BlockContext from '../block-context';
 const DEFAULT_BLOCK_CONTEXT = {};
 
 export const Edit = ( props ) => {
-	const { attributes = {}, name } = props;
+	const { attributes = {}, name, } = props;
 	const blockType = getBlockType( name );
 	const blockContext = useContext( BlockContext );
 
@@ -59,7 +59,7 @@ export const Edit = ( props ) => {
 	const generatedClassName = hasBlockSupport( blockType, 'className', true )
 		? getBlockDefaultClassName( name )
 		: null;
-	const className = classnames( generatedClassName, attributes.className );
+	const className = classnames( generatedClassName, attributes.className, props.className );
 
 	return (
 		<Component { ...props } context={ context } className={ className } />

--- a/packages/block-editor/src/components/block-edit/edit.js
+++ b/packages/block-editor/src/components/block-edit/edit.js
@@ -31,7 +31,7 @@ import BlockContext from '../block-context';
 const DEFAULT_BLOCK_CONTEXT = {};
 
 export const Edit = ( props ) => {
-	const { attributes = {}, name, } = props;
+	const { attributes = {}, name } = props;
 	const blockType = getBlockType( name );
 	const blockContext = useContext( BlockContext );
 
@@ -59,7 +59,11 @@ export const Edit = ( props ) => {
 	const generatedClassName = hasBlockSupport( blockType, 'className', true )
 		? getBlockDefaultClassName( name )
 		: null;
-	const className = classnames( generatedClassName, attributes.className, props.className );
+	const className = classnames(
+		generatedClassName,
+		attributes.className,
+		props.className
+	);
 
 	return (
 		<Component { ...props } context={ context } className={ className } />

--- a/packages/block-editor/src/components/block-inspector/index.js
+++ b/packages/block-editor/src/components/block-inspector/index.js
@@ -1,7 +1,7 @@
 /**
  * WordPress dependencies
  */
-import { __ } from '@wordpress/i18n';
+import { __, isRTL } from '@wordpress/i18n';
 import {
 	getBlockType,
 	getUnregisteredTypeHandlerName,
@@ -11,8 +11,18 @@ import {
 import {
 	PanelBody,
 	__experimentalUseSlot as useSlot,
+	__experimentalNavigatorProvider as NavigatorProvider,
+	__experimentalNavigatorScreen as NavigatorScreen,
+	__experimentalNavigatorButton as NavigatorButton,
+	__experimentalNavigatorBackButton as NavigatorBackButton,
+	FlexItem,
+	__experimentalHStack as HStack,
+	__experimentalVStack as VStack,
+	__experimentalUseNavigator as useNavigator,
 } from '@wordpress/components';
-import { useSelect } from '@wordpress/data';
+import { useSelect, useDispatch } from '@wordpress/data';
+import { useMemo, useCallback, useEffect, useRef } from '@wordpress/element';
+import { chevronRight, chevronLeft } from '@wordpress/icons';
 
 /**
  * Internal dependencies
@@ -29,19 +39,214 @@ import DefaultStylePicker from '../default-style-picker';
 import BlockVariationTransforms from '../block-variation-transforms';
 import useBlockDisplayInformation from '../use-block-display-information';
 import { store as blockEditorStore } from '../../store';
+import BlockIcon from '../block-icon';
+
+function useContentBlocks( blockTypes, block ) {
+	const contenBlocksObjectAux = useMemo( () => {
+		return blockTypes.reduce( ( result, blockType ) => {
+			if (
+				Object.entries( blockType.attributes ).some(
+					( [ , { __experimentalRole } ] ) =>
+						__experimentalRole === 'content'
+				)
+			) {
+				result[ blockType.name ] = true;
+			}
+			return result;
+		}, {} );
+	}, [ blockTypes ] );
+	const isContentBlock = useCallback(
+		( blockName ) => {
+			return !! contenBlocksObjectAux[ blockName ];
+		},
+		[ blockTypes ]
+	);
+	return useMemo( () => {
+		return getContentBlocks( [ block ], isContentBlock );
+	}, [ block, isContentBlock ] );
+}
+
+function getContentBlocks( blocks, isContentBlock ) {
+	const result = [];
+	for ( const block of blocks ) {
+		if ( isContentBlock( block.name ) ) {
+			result.push( block );
+		}
+		result.push( ...getContentBlocks( block.innerBlocks, isContentBlock ) );
+	}
+	return result;
+}
+
+function BlockInspectorNavigationEffects( { children } ) {
+	const { selectBlock } = useDispatch( blockEditorStore );
+	const { goTo, location } = useNavigator();
+	const lastLocationClientId = useRef();
+	const updatingSelectionTo = useRef();
+	const locationClientId = useMemo( () => {
+		if ( location.path.startsWith( '/block/' ) ) {
+			return location.path.substring( '/block/'.length );
+		}
+	}, [ location.path ] );
+	const selectedBlockId = useSelect( ( select ) => {
+		return select( blockEditorStore ).getSelectedBlockClientId();
+	} );
+	// When the location changes update the selection to match the new location.
+	useEffect( () => {
+		lastLocationClientId.current = locationClientId;
+		if ( locationClientId && selectedBlockId !== locationClientId ) {
+			updatingSelectionTo.current = locationClientId;
+			selectBlock( locationClientId );
+		}
+	}, [ locationClientId ] );
+	// When the selection changes update the location to root if no selection update to match location is in progress.
+	useEffect( () => {
+		if ( updatingSelectionTo.current ) {
+			updatingSelectionTo.current = undefined;
+		} else if ( lastLocationClientId.current ) {
+			goTo( '/' );
+		}
+	}, [ selectedBlockId ] );
+
+	return children;
+}
+
+function BlockNavigationButton( { blockTypes, block, selectedBlock } ) {
+	const blockType = blockTypes.find( ( { name } ) => name === block.name );
+	return (
+		<NavigatorButton
+			path={ `/block/${ block.clientId }` }
+			style={
+				selectedBlock.clientId === block.clientId
+					? { color: 'var(--wp-admin-theme-color)' }
+					: {}
+			}
+		>
+			<HStack justify="flex-start">
+				<BlockIcon icon={ blockType.icon } />
+				<FlexItem>{ blockType.title }</FlexItem>
+			</HStack>
+		</NavigatorButton>
+	);
+}
+
+function BlockNavigatorScreen( { block } ) {
+	return (
+		<NavigatorScreen path={ `/block/${ block.clientId }` }>
+			<BlockInspectorSingleBlock
+				clientId={ block.clientId }
+				blockName={ block.name }
+				backButton={
+					<NavigatorBackButton
+						style={
+							// TODO: This style override is also used in ToolsPanelHeader.
+							// It should be supported out-of-the-box by Button.
+							{ minWidth: 24, padding: 0 }
+						}
+						icon={ isRTL() ? chevronRight : chevronLeft }
+						isSmall
+						aria-label={ __( 'Navigate to the previous view' ) }
+					/>
+				}
+			/>
+		</NavigatorScreen>
+	);
+}
+
+function BlockInspectorAbsorvedBy( { absorvedBy } ) {
+	const { blockTypes, block, selectedBlock } = useSelect(
+		( select ) => {
+			return {
+				blockTypes: select( blocksStore ).getBlockTypes(),
+				block: select( blockEditorStore ).getBlock( absorvedBy ),
+				selectedBlock: select( blockEditorStore ).getSelectedBlock(),
+			};
+		},
+		[ absorvedBy ]
+	);
+	const blockInformation = useBlockDisplayInformation( absorvedBy );
+	const contentBlocks = useContentBlocks( blockTypes, block );
+	const showSelectedBlock =
+		absorvedBy !== selectedBlock.clientId &&
+		! contentBlocks.some(
+			( contentBlock ) => contentBlock.clientId === selectedBlock.clientId
+		);
+	return (
+		<div className="block-editor-block-inspector">
+			<NavigatorProvider initialPath="/">
+				<BlockInspectorNavigationEffects>
+					<NavigatorScreen path="/">
+						<BlockCard { ...blockInformation } />
+						<BlockVariationTransforms
+							blockClientId={ absorvedBy }
+						/>
+						<VStack
+							spacing={ 1 }
+							padding={ 4 }
+							className="block-editor-block-inspector__block-buttons-container"
+						>
+							<h2 className="block-editor-block-card__title">
+								{ __( 'Content' ) }
+							</h2>
+							<BlockNavigationButton
+								selectedBlock={ selectedBlock }
+								block={ block }
+								blockTypes={ blockTypes }
+							/>
+							{ contentBlocks.map( ( contentBlock ) => (
+								<BlockNavigationButton
+									selectedBlock={ selectedBlock }
+									key={ contentBlock.clientId }
+									block={ contentBlock }
+									blockTypes={ blockTypes }
+								/>
+							) ) }
+							{ showSelectedBlock && (
+								<>
+									<h2 className="block-editor-block-card__title">
+										{ __( 'Selected block' ) }
+									</h2>
+									<BlockNavigationButton
+										selectedBlock={ selectedBlock }
+										block={ selectedBlock }
+										blockTypes={ blockTypes }
+									/>
+								</>
+							) }
+							;
+						</VStack>
+					</NavigatorScreen>
+					<BlockNavigatorScreen block={ block } />
+					{ contentBlocks.map( ( contentBlock ) => {
+						return (
+							<BlockNavigatorScreen
+								key={ contentBlock.clientId }
+								block={ contentBlock }
+							/>
+						);
+					} ) }
+					{ showSelectedBlock && (
+						<BlockNavigatorScreen block={ selectedBlock } />
+					) }
+				</BlockInspectorNavigationEffects>
+			</NavigatorProvider>
+		</div>
+	);
+}
 
 const BlockInspector = ( { showNoBlockSelectedMessage = true } ) => {
 	const {
 		count,
-		hasBlockStyles,
 		selectedBlockName,
 		selectedBlockClientId,
 		blockType,
+		absorvedBy,
 	} = useSelect( ( select ) => {
 		const {
 			getSelectedBlockClientId,
 			getSelectedBlockCount,
 			getBlockName,
+			__unstableGetContentLockingParent,
+			getBlockAttributes,
 		} = select( blockEditorStore );
 		const { getBlockStyles } = select( blocksStore );
 
@@ -59,6 +264,10 @@ const BlockInspector = ( { showNoBlockSelectedMessage = true } ) => {
 			selectedBlockName: _selectedBlockName,
 			blockType: _blockType,
 			hasBlockStyles: blockStyles && blockStyles.length > 0,
+			absorvedBy: getBlockAttributes( _selectedBlockClientId )?.lock
+				?.content
+				? _selectedBlockClientId
+				: __unstableGetContentLockingParent( _selectedBlockClientId ),
 		};
 	}, [] );
 
@@ -109,24 +318,30 @@ const BlockInspector = ( { showNoBlockSelectedMessage = true } ) => {
 		}
 		return null;
 	}
+	if ( absorvedBy ) {
+		return <BlockInspectorAbsorvedBy absorvedBy={ absorvedBy } />;
+	}
 	return (
 		<BlockInspectorSingleBlock
 			clientId={ selectedBlockClientId }
 			blockName={ blockType.name }
-			hasBlockStyles={ hasBlockStyles }
 		/>
 	);
 };
 
-const BlockInspectorSingleBlock = ( {
-	clientId,
-	blockName,
-	hasBlockStyles,
-} ) => {
+const BlockInspectorSingleBlock = ( { clientId, blockName, backButton } ) => {
+	const hasBlockStyles = useSelect(
+		( select ) => {
+			const { getBlockStyles } = select( blocksStore );
+			const blockStyles = getBlockStyles( blockName );
+			return blockStyles && blockStyles.length > 0;
+		},
+		[ blockName ]
+	);
 	const blockInformation = useBlockDisplayInformation( clientId );
 	return (
 		<div className="block-editor-block-inspector">
-			<BlockCard { ...blockInformation } />
+			<BlockCard backButton={ backButton } { ...blockInformation } />
 			<BlockVariationTransforms blockClientId={ clientId } />
 			{ hasBlockStyles && (
 				<div>

--- a/packages/block-editor/src/components/block-inspector/index.js
+++ b/packages/block-editor/src/components/block-inspector/index.js
@@ -1,7 +1,7 @@
 /**
  * WordPress dependencies
  */
-import { __, isRTL } from '@wordpress/i18n';
+import { __ } from '@wordpress/i18n';
 import {
 	getBlockType,
 	getUnregisteredTypeHandlerName,
@@ -11,19 +11,13 @@ import {
 import {
 	PanelBody,
 	__experimentalUseSlot as useSlot,
-	__experimentalNavigatorProvider as NavigatorProvider,
-	__experimentalNavigatorScreen as NavigatorScreen,
-	__experimentalNavigatorButton as NavigatorButton,
-	__experimentalNavigatorBackButton as NavigatorBackButton,
 	FlexItem,
 	__experimentalHStack as HStack,
 	__experimentalVStack as VStack,
-	__experimentalUseNavigator as useNavigator,
 	Button,
 } from '@wordpress/components';
 import { useSelect, useDispatch } from '@wordpress/data';
-import { useMemo, useCallback, useEffect, useRef } from '@wordpress/element';
-import { chevronRight, chevronLeft } from '@wordpress/icons';
+import { useMemo, useCallback } from '@wordpress/element';
 
 /**
  * Internal dependencies
@@ -85,8 +79,7 @@ function BlockNavigationButton( { blockTypes, block, selectedBlock } ) {
 		selectedBlock && selectedBlock.clientId === block.clientId;
 	return (
 		<Button
-			disabled={ isSelected }
-			style={ isSelected ? { color: 'var(--wp-admin-theme-color)' } : {} }
+			isPressed={ isSelected }
 			onClick={ () => selectBlock( block.clientId ) }
 		>
 			<HStack justify="flex-start">
@@ -122,16 +115,10 @@ function BlockInspectorAbsorvedBy( { absorvedBy } ) {
 				<h2 className="block-editor-block-card__title">
 					{ __( 'Content' ) }
 				</h2>
-				<BlockNavigationButton
-					selectedBlock={ selectedBlock }
-					block={ block }
-					blockTypes={ blockTypes }
-				/>
 				{ contentBlocks.map( ( contentBlock ) => (
 					<BlockNavigationButton
 						selectedBlock={ selectedBlock }
 						key={ contentBlock.clientId }
-						d
 						block={ contentBlock }
 						blockTypes={ blockTypes }
 					/>

--- a/packages/block-editor/src/components/block-inspector/index.js
+++ b/packages/block-editor/src/components/block-inspector/index.js
@@ -90,23 +90,25 @@ function BlockNavigationButton( { blockTypes, block, selectedBlock } ) {
 	);
 }
 
-function BlockInspectorAbsorvedBy( { absorvedBy } ) {
+function BlockInspectorLockedBlocks( { topLevelLockedBlock } ) {
 	const { blockTypes, block, selectedBlock } = useSelect(
 		( select ) => {
 			return {
 				blockTypes: select( blocksStore ).getBlockTypes(),
-				block: select( blockEditorStore ).getBlock( absorvedBy ),
+				block: select( blockEditorStore ).getBlock(
+					topLevelLockedBlock
+				),
 				selectedBlock: select( blockEditorStore ).getSelectedBlock(),
 			};
 		},
-		[ absorvedBy ]
+		[ topLevelLockedBlock ]
 	);
-	const blockInformation = useBlockDisplayInformation( absorvedBy );
+	const blockInformation = useBlockDisplayInformation( topLevelLockedBlock );
 	const contentBlocks = useContentBlocks( blockTypes, block );
 	return (
 		<div className="block-editor-block-inspector">
 			<BlockCard { ...blockInformation } />
-			<BlockVariationTransforms blockClientId={ absorvedBy } />
+			<BlockVariationTransforms blockClientId={ topLevelLockedBlock } />
 			<VStack
 				spacing={ 1 }
 				padding={ 4 }
@@ -134,7 +136,7 @@ const BlockInspector = ( { showNoBlockSelectedMessage = true } ) => {
 		selectedBlockName,
 		selectedBlockClientId,
 		blockType,
-		absorvedBy,
+		topLevelLockedBlock,
 	} = useSelect( ( select ) => {
 		const {
 			getSelectedBlockClientId,
@@ -159,7 +161,7 @@ const BlockInspector = ( { showNoBlockSelectedMessage = true } ) => {
 			selectedBlockName: _selectedBlockName,
 			blockType: _blockType,
 			hasBlockStyles: blockStyles && blockStyles.length > 0,
-			absorvedBy:
+			topLevelLockedBlock:
 				getTemplateLock( _selectedBlockClientId ) === 'noContent'
 					? _selectedBlockClientId
 					: __unstableGetContentLockingParent(
@@ -215,8 +217,12 @@ const BlockInspector = ( { showNoBlockSelectedMessage = true } ) => {
 		}
 		return null;
 	}
-	if ( absorvedBy ) {
-		return <BlockInspectorAbsorvedBy absorvedBy={ absorvedBy } />;
+	if ( topLevelLockedBlock ) {
+		return (
+			<BlockInspectorLockedBlocks
+				topLevelLockedBlock={ topLevelLockedBlock }
+			/>
+		);
 	}
 	return (
 		<BlockInspectorSingleBlock

--- a/packages/block-editor/src/components/block-inspector/index.js
+++ b/packages/block-editor/src/components/block-inspector/index.js
@@ -116,7 +116,7 @@ function BlockNavigationButton( { blockTypes, block, selectedBlock } ) {
 		<NavigatorButton
 			path={ `/block/${ block.clientId }` }
 			style={
-				selectedBlock.clientId === block.clientId
+				selectedBlock && selectedBlock.clientId === block.clientId
 					? { color: 'var(--wp-admin-theme-color)' }
 					: {}
 			}
@@ -165,11 +165,6 @@ function BlockInspectorAbsorvedBy( { absorvedBy } ) {
 	);
 	const blockInformation = useBlockDisplayInformation( absorvedBy );
 	const contentBlocks = useContentBlocks( blockTypes, block );
-	const showSelectedBlock =
-		absorvedBy !== selectedBlock.clientId &&
-		! contentBlocks.some(
-			( contentBlock ) => contentBlock.clientId === selectedBlock.clientId
-		);
 	return (
 		<div className="block-editor-block-inspector">
 			<NavigatorProvider initialPath="/">
@@ -200,19 +195,6 @@ function BlockInspectorAbsorvedBy( { absorvedBy } ) {
 									blockTypes={ blockTypes }
 								/>
 							) ) }
-							{ showSelectedBlock && (
-								<>
-									<h2 className="block-editor-block-card__title">
-										{ __( 'Selected block' ) }
-									</h2>
-									<BlockNavigationButton
-										selectedBlock={ selectedBlock }
-										block={ selectedBlock }
-										blockTypes={ blockTypes }
-									/>
-								</>
-							) }
-							;
 						</VStack>
 					</NavigatorScreen>
 					<BlockNavigatorScreen block={ block } />
@@ -224,9 +206,6 @@ function BlockInspectorAbsorvedBy( { absorvedBy } ) {
 							/>
 						);
 					} ) }
-					{ showSelectedBlock && (
-						<BlockNavigatorScreen block={ selectedBlock } />
-					) }
 				</BlockInspectorNavigationEffects>
 			</NavigatorProvider>
 		</div>
@@ -246,7 +225,7 @@ const BlockInspector = ( { showNoBlockSelectedMessage = true } ) => {
 			getSelectedBlockCount,
 			getBlockName,
 			__unstableGetContentLockingParent,
-			getBlockAttributes,
+			getTemplateLock,
 		} = select( blockEditorStore );
 		const { getBlockStyles } = select( blocksStore );
 
@@ -264,10 +243,12 @@ const BlockInspector = ( { showNoBlockSelectedMessage = true } ) => {
 			selectedBlockName: _selectedBlockName,
 			blockType: _blockType,
 			hasBlockStyles: blockStyles && blockStyles.length > 0,
-			absorvedBy: getBlockAttributes( _selectedBlockClientId )?.lock
-				?.content
-				? _selectedBlockClientId
-				: __unstableGetContentLockingParent( _selectedBlockClientId ),
+			absorvedBy:
+				getTemplateLock( _selectedBlockClientId ) === 'noContent'
+					? _selectedBlockClientId
+					: __unstableGetContentLockingParent(
+							_selectedBlockClientId
+					  ),
 		};
 	}, [] );
 

--- a/packages/block-editor/src/components/block-inspector/style.scss
+++ b/packages/block-editor/src/components/block-inspector/style.scss
@@ -34,3 +34,17 @@
 	padding: ($grid-unit-20 * 2) $grid-unit-20;
 	text-align: center;
 }
+
+
+.block-editor-block-inspector__block-buttons-container {
+	border-top: $border-width solid $gray-200;
+	padding: $grid-unit-20;
+}
+
+.block-editor-block-inspector__block-type-type {
+	font-weight: 500;
+	&.block-editor-block-inspector__block-type-type {
+		line-height: $button-size-small;
+		margin: 0 0 $grid-unit-05;
+	}
+}

--- a/packages/block-editor/src/components/block-list/block.js
+++ b/packages/block-editor/src/components/block-list/block.js
@@ -140,13 +140,6 @@ function BlockListBlock( {
 			tabIndex: -1,
 		};
 	}
-	console.log( {
-		clientId,
-		name,
-		hasContentLockedParent,
-		isContentBlock,
-		wrapperProps,
-	} );
 	// Determine whether the block has props to apply to the wrapper.
 	if ( blockType?.getEditWrapperProps ) {
 		wrapperProps = mergeWrapperProps(

--- a/packages/block-editor/src/components/block-list/block.js
+++ b/packages/block-editor/src/components/block-list/block.js
@@ -113,7 +113,9 @@ function BlockListBlock( {
 			return {
 				themeSupportsLayout: getSettings().supportsLayout,
 				isContentBlock:
-					select( blocksStore ).__unstableIsContentBlock( name ),
+					select( blocksStore ).__experimentalHasContentRoleAttribute(
+						name
+					),
 				hasContentLockedParent: _hasContentLockedParent,
 				isContentLocking:
 					getTemplateLock( clientId ) === 'noContent' &&
@@ -222,8 +224,12 @@ function BlockListBlock( {
 	const value = {
 		clientId,
 		className: classnames(
-			hasContentLockedParent &&
-				( isContentBlock ? 'is-content-block' : 'is-content-locked' ),
+			{
+				'is-content-locked': isContentLocking,
+				'is-content-locked-temporarily-editing-as-blocks':
+					isTemporarilyEditingAsBlocks,
+				'is-content-block': hasContentLockedParent && isContentBlock,
+			},
 			dataAlign && themeSupportsLayout && `align${ dataAlign }`,
 			className
 		),

--- a/packages/block-editor/src/components/block-list/style.scss
+++ b/packages/block-editor/src/components/block-list/style.scss
@@ -123,6 +123,14 @@
 	padding: 0;
 }
 
+.is-content-locked {
+	pointer-events: none;
+}
+
+.is-content-block {
+	pointer-events: initial;
+}
+
 .block-editor-block-list__layout .block-editor-block-list__block {
 	position: relative;
 

--- a/packages/block-editor/src/components/block-list/style.scss
+++ b/packages/block-editor/src/components/block-list/style.scss
@@ -124,11 +124,12 @@
 }
 
 .is-content-locked {
-	pointer-events: none;
-}
-
-.is-content-block {
-	pointer-events: initial;
+	.block-editor-block-list__block {
+		pointer-events: none;
+	}
+	.is-content-block {
+		pointer-events: initial;
+	}
 }
 
 .block-editor-block-list__layout .block-editor-block-list__block {
@@ -335,6 +336,14 @@
 	.block-editor-block-list__block,
 	&.is-selected,
 	&.is-multi-selected {
+		opacity: 1;
+	}
+}
+
+.is-focus-mode .block-editor-block-list__block.is-content-locked.has-child-selected,
+.is-focus-mode .block-editor-block-list__block.is-content-locked-temporarily-editing-as-blocks.has-child-selected {
+	&,
+	& .block-editor-block-list__block {
 		opacity: 1;
 	}
 }

--- a/packages/block-editor/src/components/block-list/use-block-props/index.js
+++ b/packages/block-editor/src/components/block-list/use-block-props/index.js
@@ -144,11 +144,11 @@ export function useBlockProps(
 	}
 
 	return {
+		tabIndex: 0,
 		...wrapperProps,
 		...props,
 		ref: mergedRefs,
 		id: `block-${ clientId }${ htmlSuffix }`,
-		tabIndex: 0,
 		role: 'document',
 		'aria-label': blockLabel,
 		'data-block': clientId,

--- a/packages/block-editor/src/components/block-parent-selector/index.js
+++ b/packages/block-editor/src/components/block-parent-selector/index.js
@@ -28,16 +28,14 @@ export default function BlockParentSelector() {
 		( select ) => {
 			const {
 				getBlockName,
-				__unstableGetContentLockingParent,
-				getBlockRootClientId,
+				getBlockParents,
 				getSelectedBlockClientId,
 				getSettings,
 			} = select( blockEditorStore );
 			const { hasBlockSupport } = select( blocksStore );
 			const selectedBlockClientId = getSelectedBlockClientId();
-			const _firstParentClientId =
-				__unstableGetContentLockingParent( selectedBlockClientId ) ||
-				getBlockRootClientId( selectedBlockClientId );
+			const parents = getBlockParents( selectedBlockClientId );
+			const _firstParentClientId = parents[ parents.length - 1 ];
 			const parentBlockName = getBlockName( _firstParentClientId );
 			const _parentBlockType = getBlockType( parentBlockName );
 			const settings = getSettings();
@@ -54,7 +52,6 @@ export default function BlockParentSelector() {
 		[]
 	);
 	const blockInformation = useBlockDisplayInformation( firstParentClientId );
-	console.log({ blockInformation, firstParentClientId });
 
 	// Allows highlighting the parent block outline when focusing or hovering
 	// the parent block selector within the child.
@@ -69,7 +66,7 @@ export default function BlockParentSelector() {
 		},
 	} );
 
-	if ( shouldHide || ! firstParentClientId ) {
+	if ( shouldHide || firstParentClientId === undefined ) {
 		return null;
 	}
 

--- a/packages/block-editor/src/components/block-parent-selector/index.js
+++ b/packages/block-editor/src/components/block-parent-selector/index.js
@@ -28,14 +28,16 @@ export default function BlockParentSelector() {
 		( select ) => {
 			const {
 				getBlockName,
-				getBlockParents,
+				__unstableGetContentLockingParent,
+				getBlockRootClientId,
 				getSelectedBlockClientId,
 				getSettings,
 			} = select( blockEditorStore );
 			const { hasBlockSupport } = select( blocksStore );
 			const selectedBlockClientId = getSelectedBlockClientId();
-			const parents = getBlockParents( selectedBlockClientId );
-			const _firstParentClientId = parents[ parents.length - 1 ];
+			const _firstParentClientId =
+				__unstableGetContentLockingParent( selectedBlockClientId ) ||
+				getBlockRootClientId( selectedBlockClientId );
 			const parentBlockName = getBlockName( _firstParentClientId );
 			const _parentBlockType = getBlockType( parentBlockName );
 			const settings = getSettings();
@@ -52,6 +54,7 @@ export default function BlockParentSelector() {
 		[]
 	);
 	const blockInformation = useBlockDisplayInformation( firstParentClientId );
+	console.log({ blockInformation, firstParentClientId });
 
 	// Allows highlighting the parent block outline when focusing or hovering
 	// the parent block selector within the child.
@@ -66,7 +69,7 @@ export default function BlockParentSelector() {
 		},
 	} );
 
-	if ( shouldHide || firstParentClientId === undefined ) {
+	if ( shouldHide || ! firstParentClientId ) {
 		return null;
 	}
 

--- a/packages/block-editor/src/components/block-toolbar/index.js
+++ b/packages/block-editor/src/components/block-toolbar/index.js
@@ -37,6 +37,7 @@ const BlockToolbar = ( { hideDragHandle } ) => {
 		hasReducedUI,
 		isValid,
 		isVisual,
+		isContentLocked,
 	} = useSelect( ( select ) => {
 		const {
 			getBlockName,
@@ -45,6 +46,7 @@ const BlockToolbar = ( { hideDragHandle } ) => {
 			isBlockValid,
 			getBlockRootClientId,
 			getSettings,
+			__unstableGetContentLockingParent,
 		} = select( blockEditorStore );
 		const selectedBlockClientIds = getSelectedBlockClientIds();
 		const selectedBlockClientId = selectedBlockClientIds[ 0 ];
@@ -65,6 +67,9 @@ const BlockToolbar = ( { hideDragHandle } ) => {
 			),
 			isVisual: selectedBlockClientIds.every(
 				( id ) => getBlockMode( id ) === 'visual'
+			),
+			isContentLocked: !! __unstableGetContentLockingParent(
+				selectedBlockClientId
 			),
 		};
 	}, [] );
@@ -113,23 +118,26 @@ const BlockToolbar = ( { hideDragHandle } ) => {
 	return (
 		<div className={ classes }>
 			{ ! isMultiToolbar && ! displayHeaderToolbar && (
-				<BlockParentSelector clientIds={ blockClientIds } />
+				<BlockParentSelector />
 			) }
 			<div ref={ nodeRef } { ...showMoversGestures }>
-				{ ( shouldShowVisualToolbar || isMultiToolbar ) && (
-					<ToolbarGroup className="block-editor-block-toolbar__block-controls">
-						<BlockSwitcher clientIds={ blockClientIds } />
-						{ ! isMultiToolbar && (
-							<BlockLockToolbar
-								clientId={ blockClientIds[ 0 ] }
+				{ ( shouldShowVisualToolbar || isMultiToolbar ) &&
+					! isContentLocked && (
+						<ToolbarGroup className="block-editor-block-toolbar__block-controls">
+							<BlockSwitcher clientIds={ blockClientIds } />
+							{ ! isMultiToolbar && (
+								<BlockLockToolbar
+									clientId={ blockClientIds[ 0 ] }
+								/>
+							) }
+							<BlockMover
+								clientIds={ blockClientIds }
+								hideDragHandle={
+									hideDragHandle || hasReducedUI
+								}
 							/>
-						) }
-						<BlockMover
-							clientIds={ blockClientIds }
-							hideDragHandle={ hideDragHandle || hasReducedUI }
-						/>
-					</ToolbarGroup>
-				) }
+						</ToolbarGroup>
+					) }
 			</div>
 			{ shouldShowVisualToolbar && isMultiToolbar && (
 				<BlockGroupToolbar />
@@ -161,7 +169,9 @@ const BlockToolbar = ( { hideDragHandle } ) => {
 				</>
 			) }
 			<BlockEditVisuallyButton clientIds={ blockClientIds } />
-			<BlockSettingsMenu clientIds={ blockClientIds } />
+			{ ! isContentLocked && (
+				<BlockSettingsMenu clientIds={ blockClientIds } />
+			) }
 		</div>
 	);
 };

--- a/packages/block-editor/src/components/block-toolbar/index.js
+++ b/packages/block-editor/src/components/block-toolbar/index.js
@@ -117,9 +117,9 @@ const BlockToolbar = ( { hideDragHandle } ) => {
 
 	return (
 		<div className={ classes }>
-			{ ! isMultiToolbar && ! displayHeaderToolbar && (
-				<BlockParentSelector />
-			) }
+			{ ! isMultiToolbar &&
+				! displayHeaderToolbar &&
+				! isContentLocked && <BlockParentSelector /> }
 			<div ref={ nodeRef } { ...showMoversGestures }>
 				{ ( shouldShowVisualToolbar || isMultiToolbar ) &&
 					! isContentLocked && (

--- a/packages/block-editor/src/components/block-tools/block-contextual-toolbar.js
+++ b/packages/block-editor/src/components/block-tools/block-contextual-toolbar.js
@@ -20,8 +20,12 @@ import { store as blockEditorStore } from '../../store';
 function BlockContextualToolbar( { focusOnMount, isFixed, ...props } ) {
 	const { blockType, hasParents, showParentSelector } = useSelect(
 		( select ) => {
-			const { getBlockName, getBlockParents, getSelectedBlockClientIds } =
-				select( blockEditorStore );
+			const {
+				getBlockName,
+				getBlockParents,
+				getSelectedBlockClientIds,
+				__unstableGetContentLockingParent,
+			} = select( blockEditorStore );
 			const { getBlockType } = select( blocksStore );
 			const selectedBlockClientIds = getSelectedBlockClientIds();
 			const selectedBlockClientId = selectedBlockClientIds[ 0 ];
@@ -42,7 +46,10 @@ function BlockContextualToolbar( { focusOnMount, isFixed, ...props } ) {
 						'__experimentalParentSelector',
 						true
 					) &&
-					selectedBlockClientIds.length <= 1,
+					selectedBlockClientIds.length <= 1 &&
+					! __unstableGetContentLockingParent(
+						selectedBlockClientId
+					),
 			};
 		},
 		[]

--- a/packages/block-editor/src/components/inner-blocks/README.md
+++ b/packages/block-editor/src/components/inner-blocks/README.md
@@ -125,6 +125,7 @@ Template locking of `InnerBlocks` is similar to [Custom Post Type templates lock
 Template locking allows locking the `InnerBlocks` area for the current template.
 _Options:_
 
+-   `noContent` — prevents all operations. Additionally, the block types that don't have content are hidden from the list view and can't gain focus within the block list.
 -   `'all'` — prevents all operations. It is not possible to insert new blocks. Move existing blocks or delete them.
 -   `'insert'` — prevents inserting or removing blocks, but allows moving existing ones.
 -   `false` — prevents locking from being applied to an `InnerBlocks` area even if a parent block contains locking. ( Boolean )

--- a/packages/block-editor/src/components/inner-blocks/use-inner-block-template-sync.js
+++ b/packages/block-editor/src/components/inner-blocks/use-inner-block-template-sync.js
@@ -19,8 +19,8 @@ import { store as blockEditorStore } from '../../store';
  * This hook makes sure that a block's inner blocks stay in sync with the given
  * block "template". The template is a block hierarchy to which inner blocks must
  * conform. If the blocks get "out of sync" with the template and the template
- * is meant to be locked (e.g. templateLock = "all"), then we replace the inner
- * blocks with the correct value after synchronizing it with the template.
+ * is meant to be locked (e.g. templateLock = "all" or templateLock = "noContent"),
+ * then we replace the inner blocks with the correct value after synchronizing it with the template.
  *
  * @param {string}  clientId                       The block client ID.
  * @param {Object}  template                       The template to match.
@@ -51,9 +51,13 @@ export default function useInnerBlockTemplateSync(
 	// Maintain a reference to the previous value so we can do a deep equality check.
 	const existingTemplate = useRef( null );
 	useLayoutEffect( () => {
-		// Only synchronize innerBlocks with template if innerBlocks are empty or
-		// a locking all exists directly on the block.
-		if ( innerBlocks.length === 0 || templateLock === 'all' ) {
+		// Only synchronize innerBlocks with template if innerBlocks are empty
+		// or a locking "all" or "noContent" exists directly on the block.
+		if (
+			innerBlocks.length === 0 ||
+			templateLock === 'all' ||
+			templateLock === 'noContent'
+		) {
 			const hasTemplateChanged = ! isEqual(
 				template,
 				existingTemplate.current

--- a/packages/block-editor/src/components/inner-blocks/use-nested-settings-update.js
+++ b/packages/block-editor/src/components/inner-blocks/use-nested-settings-update.js
@@ -69,7 +69,9 @@ export default function useNestedSettingsUpdate(
 		const newSettings = {
 			allowedBlocks: _allowedBlocks,
 			templateLock:
-				templateLock === undefined ? parentLock : templateLock,
+				templateLock === undefined || parentLock === 'noContent'
+					? parentLock
+					: templateLock,
 		};
 
 		// These values are not defined for RN, so only include them if they

--- a/packages/block-editor/src/components/list-view/block.js
+++ b/packages/block-editor/src/components/list-view/block.js
@@ -6,7 +6,7 @@ import classnames from 'classnames';
 /**
  * WordPress dependencies
  */
-import { hasBlockSupport, store as blocksStore } from '@wordpress/blocks';
+import { hasBlockSupport } from '@wordpress/blocks';
 import {
 	__experimentalTreeGridCell as TreeGridCell,
 	__experimentalTreeGridItem as TreeGridItem,
@@ -40,7 +40,6 @@ import useBlockDisplayInformation from '../use-block-display-information';
 import { useBlockLock } from '../block-lock';
 
 function ListViewBlock( {
-	renderOnlyContentBlocks,
 	block,
 	isDragged,
 	isSelected,
@@ -68,17 +67,9 @@ function ListViewBlock( {
 	const { toggleBlockHighlight } = useDispatch( blockEditorStore );
 
 	const blockInformation = useBlockDisplayInformation( clientId );
-	const { blockName, shouldRender } = useSelect(
-		( select ) => {
-			const name = select( blockEditorStore ).getBlockName( clientId );
-			return {
-				blockName: name,
-				shouldRender:
-					! renderOnlyContentBlocks ||
-					select( blocksStore ).__unstableIsContentBlock( name ),
-			};
-		},
-		[ clientId, renderOnlyContentBlocks ]
+	const blockName = useSelect(
+		( select ) => select( blockEditorStore ).getBlockName( clientId ),
+		[ clientId ]
 	);
 
 	// When a block hides its toolbar it also hides the block settings menu,
@@ -181,10 +172,6 @@ function ListViewBlock( {
 		},
 		[ clientId, expand, collapse, isExpanded ]
 	);
-
-	if ( ! shouldRender ) {
-		return null;
-	}
 
 	let colSpan;
 	if ( hasRenderedMovers ) {

--- a/packages/block-editor/src/components/list-view/block.js
+++ b/packages/block-editor/src/components/list-view/block.js
@@ -6,7 +6,7 @@ import classnames from 'classnames';
 /**
  * WordPress dependencies
  */
-import { hasBlockSupport } from '@wordpress/blocks';
+import { hasBlockSupport, store as blocksStore } from '@wordpress/blocks';
 import {
 	__experimentalTreeGridCell as TreeGridCell,
 	__experimentalTreeGridItem as TreeGridItem,
@@ -40,6 +40,7 @@ import useBlockDisplayInformation from '../use-block-display-information';
 import { useBlockLock } from '../block-lock';
 
 function ListViewBlock( {
+	renderOnlyContentBlocks,
 	block,
 	isDragged,
 	isSelected,
@@ -67,9 +68,17 @@ function ListViewBlock( {
 	const { toggleBlockHighlight } = useDispatch( blockEditorStore );
 
 	const blockInformation = useBlockDisplayInformation( clientId );
-	const blockName = useSelect(
-		( select ) => select( blockEditorStore ).getBlockName( clientId ),
-		[ clientId ]
+	const { blockName, shouldRender } = useSelect(
+		( select ) => {
+			const name = select( blockEditorStore ).getBlockName( clientId );
+			return {
+				blockName: name,
+				shouldRender:
+					! renderOnlyContentBlocks ||
+					select( blocksStore ).__unstableIsContentBlock( name ),
+			};
+		},
+		[ clientId, renderOnlyContentBlocks ]
 	);
 
 	// When a block hides its toolbar it also hides the block settings menu,
@@ -172,6 +181,10 @@ function ListViewBlock( {
 		},
 		[ clientId, expand, collapse, isExpanded ]
 	);
+
+	if ( ! shouldRender ) {
+		return null;
+	}
 
 	let colSpan;
 	if ( hasRenderedMovers ) {

--- a/packages/block-editor/src/components/list-view/block.js
+++ b/packages/block-editor/src/components/list-view/block.js
@@ -67,8 +67,15 @@ function ListViewBlock( {
 	const { toggleBlockHighlight } = useDispatch( blockEditorStore );
 
 	const blockInformation = useBlockDisplayInformation( clientId );
-	const blockName = useSelect(
-		( select ) => select( blockEditorStore ).getBlockName( clientId ),
+	const { isContentLocked, blockName } = useSelect(
+		( select ) => {
+			const { getBlockName, getTemplateLock } =
+				select( blockEditorStore );
+			return {
+				blockName: getBlockName( clientId ),
+				isContentLocked: getTemplateLock( clientId ) === 'noContent',
+			};
+		},
 		[ clientId ]
 	);
 
@@ -210,7 +217,7 @@ function ListViewBlock( {
 			path={ path }
 			id={ `list-view-block-${ clientId }` }
 			data-block={ clientId }
-			isExpanded={ isExpanded }
+			isExpanded={ isContentLocked ? undefined : isExpanded }
 			aria-selected={ !! isSelected }
 		>
 			<TreeGridCell
@@ -219,7 +226,7 @@ function ListViewBlock( {
 				ref={ cellRef }
 				aria-label={ blockAriaLabel }
 				aria-selected={ !! isSelected }
-				aria-expanded={ isExpanded }
+				aria-expanded={ isContentLocked ? undefined : isExpanded }
 				aria-describedby={ descriptionId }
 			>
 				{ ( { ref, tabIndex, onFocus } ) => (

--- a/packages/block-editor/src/components/list-view/branch.js
+++ b/packages/block-editor/src/components/list-view/branch.js
@@ -110,7 +110,7 @@ function ListViewBranch( props ) {
 		},
 		[ parentId ]
 	);
-	const processedBlocks = useMemo( () => {
+	const filteredBlocks = useMemo( () => {
 		if ( isContentLocked ) {
 			return getIdsTreeFlat( blocks ).filter( Boolean );
 		}
@@ -118,17 +118,17 @@ function ListViewBranch( props ) {
 	}, [ isContentLocked, blocks ] );
 	const { expandedState, draggedClientIds } = useListViewContext();
 
-	const blockCount = processedBlocks.length;
+	const blockCount = filteredBlocks.length;
 	let nextPosition = listPosition;
 
 	return (
 		<>
-			{ processedBlocks.map( ( block, index ) => {
+			{ filteredBlocks.map( ( block, index ) => {
 				const { clientId, innerBlocks } = block;
 
 				if ( index > 0 ) {
 					nextPosition += countBlocks(
-						processedBlocks[ index - 1 ],
+						filteredBlocks[ index - 1 ],
 						expandedState,
 						draggedClientIds,
 						isExpanded

--- a/packages/block-editor/src/components/list-view/branch.js
+++ b/packages/block-editor/src/components/list-view/branch.js
@@ -178,7 +178,6 @@ function ListViewBranch( props ) {
 					<AsyncModeProvider key={ clientId } value={ ! isSelected }>
 						{ showBlock && (
 							<ListViewBlock
-								renderOnlyContentBlocks={ isContentLocked }
 								block={ block }
 								selectBlock={ selectBlock }
 								isSelected={ isSelected }

--- a/packages/block-editor/src/components/list-view/branch.js
+++ b/packages/block-editor/src/components/list-view/branch.js
@@ -75,16 +75,6 @@ const countReducer =
 		return count + 1;
 	};
 
-function getIdsTreeFlat( blocks ) {
-	return blocks.reduce( ( result, { clientId, innerBlocks } ) => {
-		return [
-			...result,
-			{ clientId, innerBlocks: [] },
-			...getIdsTreeFlat( innerBlocks ),
-		];
-	}, [] );
-}
-
 function ListViewBranch( props ) {
 	const {
 		parentId,
@@ -110,9 +100,16 @@ function ListViewBranch( props ) {
 		},
 		[ parentId ]
 	);
+	const flattenBlockTree = ( result, { clientId, innerBlocks } ) => {
+		return [
+			...result,
+			{ clientId, innerBlocks: [] },
+			...innerBlocks.reduce( flattenBlockTree, [] ),
+		];
+	};
 	const filteredBlocks = useMemo( () => {
 		if ( isContentLocked ) {
-			return getIdsTreeFlat( blocks ).filter( Boolean );
+			return blocks.reduce( flattenBlockTree, [] ).filter( Boolean );
 		}
 		return blocks.filter( Boolean );
 	}, [ isContentLocked, blocks ] );

--- a/packages/block-editor/src/components/list-view/branch.js
+++ b/packages/block-editor/src/components/list-view/branch.js
@@ -95,8 +95,8 @@ function ListViewBranch( props ) {
 		( select ) => {
 			return !! (
 				parentId &&
-				select( blockEditorStore ).getBlockAttributes( parentId )?.lock
-					?.content
+				select( blockEditorStore ).getTemplateLock( parentId ) ===
+					'noContent'
 			);
 		},
 		[ parentId ]

--- a/packages/block-editor/src/components/list-view/branch.js
+++ b/packages/block-editor/src/components/list-view/branch.js
@@ -3,8 +3,10 @@
  */
 import { memo } from '@wordpress/element';
 import { AsyncModeProvider, useSelect } from '@wordpress/data';
-import { store as blocksStore } from '@wordpress/blocks';
 
+/**
+ * Internal dependencies
+ */
 /**
  * Internal dependencies
  */
@@ -78,7 +80,6 @@ const countReducer =
 
 function ListViewBranch( props ) {
 	const {
-		parentId,
 		blocks,
 		selectBlock,
 		showBlockMovers,
@@ -89,6 +90,7 @@ function ListViewBranch( props ) {
 		listPosition = 0,
 		fixedListWindow,
 		isExpanded,
+		parentId,
 	} = props;
 
 	const isContentLocked = useSelect(
@@ -101,36 +103,14 @@ function ListViewBranch( props ) {
 		},
 		[ parentId ]
 	);
-	const flattenBlockTree = ( result, { clientId, innerBlocks } ) => {
-		return [
-			...result,
-			{ clientId, innerBlocks: [] },
-			...innerBlocks.reduce( flattenBlockTree, [] ),
-		];
-	};
-	const hasContentRoleAttribute =
-		( select ) =>
-		( { clientId } ) => {
-			const name = select( blockEditorStore ).getBlockName( clientId );
-			const hasContentRole =
-				select( blocksStore ).__unstableIsContentBlock( name );
-			return hasContentRole;
-		};
 
-	const filteredBlocks = useSelect(
-		( select ) => {
-			if ( isContentLocked ) {
-				return blocks
-					.reduce( flattenBlockTree, [] )
-					.filter( hasContentRoleAttribute( select ) )
-					.filter( Boolean );
-			}
-			return blocks.filter( Boolean );
-		},
-		[ isContentLocked, blocks ]
-	);
 	const { expandedState, draggedClientIds } = useListViewContext();
 
+	if ( isContentLocked ) {
+		return null;
+	}
+
+	const filteredBlocks = blocks.filter( Boolean );
 	const blockCount = filteredBlocks.length;
 	let nextPosition = listPosition;
 

--- a/packages/block-editor/src/components/list-view/index.js
+++ b/packages/block-editor/src/components/list-view/index.js
@@ -63,7 +63,6 @@ function ListView(
 ) {
 	const { clientIdsTree, draggedClientIds, selectedClientIds } =
 		useListViewClientIds( blocks );
-	console.log({clientIdsTree});
 	const { visibleBlockCount } = useSelect(
 		( select ) => {
 			const { getGlobalBlockCount, getClientIdsOfDescendants } =

--- a/packages/block-editor/src/components/list-view/index.js
+++ b/packages/block-editor/src/components/list-view/index.js
@@ -63,7 +63,7 @@ function ListView(
 ) {
 	const { clientIdsTree, draggedClientIds, selectedClientIds } =
 		useListViewClientIds( blocks );
-
+	console.log({clientIdsTree});
 	const { visibleBlockCount } = useSelect(
 		( select ) => {
 			const { getGlobalBlockCount, getClientIdsOfDescendants } =

--- a/packages/block-editor/src/components/list-view/use-block-selection.js
+++ b/packages/block-editor/src/components/list-view/use-block-selection.js
@@ -32,7 +32,6 @@ export default function useBlockSelection() {
 	const updateBlockSelection = useCallback(
 		async ( event, clientId, destinationClientId ) => {
 			if ( ! event?.shiftKey ) {
-				await clearSelectedBlock();
 				selectBlock( clientId );
 				return;
 			}

--- a/packages/block-editor/src/components/use-block-drop-zone/index.js
+++ b/packages/block-editor/src/components/use-block-drop-zone/index.js
@@ -92,10 +92,13 @@ export default function useBlockDropZone( {
 } = {} ) {
 	const [ targetBlockIndex, setTargetBlockIndex ] = useState( null );
 
-	const isLockedAll = useSelect(
+	const isLocked = useSelect(
 		( select ) => {
 			const { getTemplateLock } = select( blockEditorStore );
-			return getTemplateLock( targetRootClientId ) === 'all';
+			const templateLock = getTemplateLock( targetRootClientId );
+			return [ 'all', 'noContent' ].some(
+				( lock ) => lock === templateLock
+			);
 		},
 		[ targetRootClientId ]
 	);
@@ -127,7 +130,7 @@ export default function useBlockDropZone( {
 	);
 
 	return useDropZone( {
-		isDisabled: isLockedAll,
+		isDisabled: isLocked,
 		onDrop: onBlockDrop,
 		onDragOver( event ) {
 			// `currentTarget` is only available while the event is being

--- a/packages/block-editor/src/hooks/content-lock-ui.js
+++ b/packages/block-editor/src/hooks/content-lock-ui.js
@@ -1,0 +1,123 @@
+/**
+ * WordPress dependencies
+ */
+import { ToolbarButton, ToolbarGroup } from '@wordpress/components';
+import { createHigherOrderComponent } from '@wordpress/compose';
+import { useDispatch, useSelect } from '@wordpress/data';
+import { addFilter } from '@wordpress/hooks';
+import { __ } from '@wordpress/i18n';
+import { useState, useEffect } from '@wordpress/element';
+
+/**
+ * Internal dependencies
+ */
+import { store as blockEditorStore } from '../store';
+import { BlockControls } from '../components';
+
+function StopEdingAsBlockOnOutsideSelect( {
+	clientId,
+	lock,
+	setIsTemporarlyEditingAsBlocks,
+} ) {
+	const isBlockOrDescendSelected = useSelect(
+		( select ) => {
+			const { isBlockSelected, hasSelectedInnerBlock } =
+				select( blockEditorStore );
+			return (
+				isBlockSelected( clientId ) ||
+				hasSelectedInnerBlock( clientId, true )
+			);
+		},
+		[ clientId ]
+	);
+	const { __unstableMarkNextChangeAsNotPersistent, updateBlockAttributes } =
+		useDispatch( blockEditorStore );
+	useEffect( () => {
+		if ( ! isBlockOrDescendSelected ) {
+			__unstableMarkNextChangeAsNotPersistent();
+			updateBlockAttributes( clientId, {
+				lock: {
+					...lock,
+					content: true,
+				},
+			} );
+			setIsTemporarlyEditingAsBlocks( false );
+		}
+	}, [ isBlockOrDescendSelected ] );
+	return null;
+}
+
+export const withBlockControls = createHigherOrderComponent(
+	( BlockEdit ) => ( props ) => {
+		const [ isTemporarlyEditingAsBlocks, setIsTemporarlyEditingAsBlocks ] =
+			useState( false );
+		const lock = useSelect(
+			( select ) =>
+				select( blockEditorStore ).getBlockAttributes( props.clientId )
+					.lock,
+			[ props.clientId ]
+		);
+		const isContentLocked = lock?.content === true;
+		const {
+			__unstableMarkNextChangeAsNotPersistent,
+			updateBlockAttributes,
+		} = useDispatch( blockEditorStore );
+		if ( ! isContentLocked && ! isTemporarlyEditingAsBlocks ) {
+			return <BlockEdit { ...props } />;
+		}
+		return (
+			<>
+				{ isTemporarlyEditingAsBlocks && ! isContentLocked && (
+					<StopEdingAsBlockOnOutsideSelect
+						clientId={ props.clientId }
+						lock={ lock }
+						setIsTemporarlyEditingAsBlocks={
+							setIsTemporarlyEditingAsBlocks
+						}
+					/>
+				) }
+				<BlockControls group="other">
+					<ToolbarGroup>
+						<ToolbarButton
+							onClick={ () => {
+								if (
+									isTemporarlyEditingAsBlocks &&
+									! isContentLocked
+								) {
+									__unstableMarkNextChangeAsNotPersistent();
+									updateBlockAttributes( props.clientId, {
+										lock: {
+											...lock,
+											content: true,
+										},
+									} );
+									setIsTemporarlyEditingAsBlocks( false );
+								} else {
+									const newLock = { ...lock };
+									delete newLock.content;
+									__unstableMarkNextChangeAsNotPersistent();
+									updateBlockAttributes( props.clientId, {
+										lock: newLock,
+									} );
+									setIsTemporarlyEditingAsBlocks( true );
+								}
+							} }
+						>
+							{ isTemporarlyEditingAsBlocks && ! isContentLocked
+								? __( ' Finish editing as blocks' )
+								: __( 'Edit as Blocks' ) }
+						</ToolbarButton>
+					</ToolbarGroup>
+				</BlockControls>
+				<BlockEdit { ...props } />
+			</>
+		);
+	},
+	'withToolbarControls'
+);
+
+addFilter(
+	'editor.BlockEdit',
+	'core/style/with-block-controls',
+	withBlockControls
+);

--- a/packages/block-editor/src/hooks/content-lock-ui.js
+++ b/packages/block-editor/src/hooks/content-lock-ui.js
@@ -16,7 +16,6 @@ import { BlockControls } from '../components';
 
 function StopEditingAsBlocksOnOutsideSelect( {
 	clientId,
-	lock,
 	setIsEditingAsBlocks,
 } ) {
 	const isBlockOrDescendantSelected = useSelect(
@@ -36,10 +35,7 @@ function StopEditingAsBlocksOnOutsideSelect( {
 		if ( ! isBlockOrDescendantSelected ) {
 			__unstableMarkNextChangeAsNotPersistent();
 			updateBlockAttributes( clientId, {
-				lock: {
-					...lock,
-					content: true,
-				},
+				templateLock: 'noContent',
 			} );
 			setIsEditingAsBlocks( false );
 		}
@@ -50,13 +46,12 @@ function StopEditingAsBlocksOnOutsideSelect( {
 export const withBlockControls = createHigherOrderComponent(
 	( BlockEdit ) => ( props ) => {
 		const [ isEditingAsBlocks, setIsEditingAsBlocks ] = useState( false );
-		const lock = useSelect(
+		const templateLock = useSelect(
 			( select ) =>
-				select( blockEditorStore ).getBlockAttributes( props.clientId )
-					.lock,
+				select( blockEditorStore ).getTemplateLock( props.clientId ),
 			[ props.clientId ]
 		);
-		const isContentLocked = lock?.content === true;
+		const isContentLocked = templateLock === 'noContent';
 		const {
 			__unstableMarkNextChangeAsNotPersistent,
 			updateBlockAttributes,
@@ -71,7 +66,6 @@ export const withBlockControls = createHigherOrderComponent(
 				{ isEditingAsBlocks && ! isContentLocked && (
 					<StopEditingAsBlocksOnOutsideSelect
 						clientId={ props.clientId }
-						lock={ lock }
 						setIsEditingAsBlocks={ setIsEditingAsBlocks }
 					/>
 				) }
@@ -82,18 +76,13 @@ export const withBlockControls = createHigherOrderComponent(
 								if ( isEditingAsBlocks && ! isContentLocked ) {
 									__unstableMarkNextChangeAsNotPersistent();
 									updateBlockAttributes( props.clientId, {
-										lock: {
-											...lock,
-											content: true,
-										},
+										templateLock: 'noContent',
 									} );
 									setIsEditingAsBlocks( false );
 								} else {
-									const newLock = { ...lock };
-									delete newLock.content;
 									__unstableMarkNextChangeAsNotPersistent();
 									updateBlockAttributes( props.clientId, {
-										lock: newLock,
+										templateLock: undefined,
 									} );
 									setIsEditingAsBlocks( true );
 								}

--- a/packages/block-editor/src/hooks/content-lock-ui.js
+++ b/packages/block-editor/src/hooks/content-lock-ui.js
@@ -6,17 +6,21 @@ import { createHigherOrderComponent } from '@wordpress/compose';
 import { useDispatch, useSelect } from '@wordpress/data';
 import { addFilter } from '@wordpress/hooks';
 import { __ } from '@wordpress/i18n';
-import { useState, useEffect } from '@wordpress/element';
+import { useEffect, useRef, useCallback } from '@wordpress/element';
 
 /**
  * Internal dependencies
  */
 import { store as blockEditorStore } from '../store';
 import { BlockControls } from '../components';
+/**
+ * External dependencies
+ */
+import classnames from 'classnames';
 
 function StopEditingAsBlocksOnOutsideSelect( {
 	clientId,
-	setIsEditingAsBlocks,
+	stopEditingAsBlock,
 } ) {
 	const isBlockOrDescendantSelected = useSelect(
 		( select ) => {
@@ -29,15 +33,9 @@ function StopEditingAsBlocksOnOutsideSelect( {
 		},
 		[ clientId ]
 	);
-	const { __unstableMarkNextChangeAsNotPersistent, updateBlockAttributes } =
-		useDispatch( blockEditorStore );
 	useEffect( () => {
 		if ( ! isBlockOrDescendantSelected ) {
-			__unstableMarkNextChangeAsNotPersistent();
-			updateBlockAttributes( clientId, {
-				templateLock: 'noContent',
-			} );
-			setIsEditingAsBlocks( false );
+			stopEditingAsBlock();
 		}
 	}, [ isBlockOrDescendantSelected ] );
 	return null;
@@ -45,19 +43,62 @@ function StopEditingAsBlocksOnOutsideSelect( {
 
 export const withBlockControls = createHigherOrderComponent(
 	( BlockEdit ) => ( props ) => {
-		const [ isEditingAsBlocks, setIsEditingAsBlocks ] = useState( false );
-		const templateLock = useSelect(
-			( select ) =>
-				select( blockEditorStore ).getTemplateLock( props.clientId ),
+		const { getBlockListSettings, getSettings } =
+			useSelect( blockEditorStore );
+		const focusModeToRevert = useRef();
+		const { templateLock, isLockedByParent, isEditingAsBlocks } = useSelect(
+			( select ) => {
+				const {
+					__unstableGetContentLockingParent,
+					getTemplateLock,
+					__unstableGetTemporarilyEditingAsBlocks,
+				} = select( blockEditorStore );
+				return {
+					templateLock: getTemplateLock( props.clientId ),
+					isLockedByParent: !! __unstableGetContentLockingParent(
+						props.clientId
+					),
+					isEditingAsBlocks:
+						__unstableGetTemporarilyEditingAsBlocks() ===
+						props.clientId,
+				};
+			},
 			[ props.clientId ]
 		);
-		const { getBlockListSettings } = useSelect( blockEditorStore );
-		const { updateBlockListSettings } = useDispatch( blockEditorStore );
-		const isContentLocked = templateLock === 'noContent';
+
+		const {
+			updateSettings,
+			updateBlockListSettings,
+			__unstableSetTemporarilyEditingAsBlocks,
+		} = useDispatch( blockEditorStore );
+		const isContentLocked =
+			! isLockedByParent && templateLock === 'noContent';
 		const {
 			__unstableMarkNextChangeAsNotPersistent,
 			updateBlockAttributes,
 		} = useDispatch( blockEditorStore );
+
+		const stopEditingAsBlock = useCallback( () => {
+			__unstableMarkNextChangeAsNotPersistent();
+			updateBlockAttributes( props.clientId, {
+				templateLock: 'noContent',
+			} );
+			updateBlockListSettings( props.clientId, {
+				...getBlockListSettings( props.clientId ),
+				templateLock: 'noContent',
+			} );
+			updateSettings( { focusMode: focusModeToRevert.current } );
+			__unstableSetTemporarilyEditingAsBlocks();
+		}, [
+			props.clientId,
+			focusModeToRevert,
+			updateSettings,
+			updateBlockListSettings,
+			getBlockListSettings,
+			__unstableMarkNextChangeAsNotPersistent,
+			updateBlockAttributes,
+			__unstableSetTemporarilyEditingAsBlocks,
+		] );
 
 		if ( ! isContentLocked && ! isEditingAsBlocks ) {
 			return <BlockEdit { ...props } />;
@@ -68,32 +109,29 @@ export const withBlockControls = createHigherOrderComponent(
 				{ isEditingAsBlocks && ! isContentLocked && (
 					<StopEditingAsBlocksOnOutsideSelect
 						clientId={ props.clientId }
-						setIsEditingAsBlocks={ setIsEditingAsBlocks }
+						stopEditingAsBlock={ stopEditingAsBlock }
 					/>
 				) }
 				<BlockControls group="other">
 					<ToolbarButton
 						onClick={ () => {
 							if ( isEditingAsBlocks && ! isContentLocked ) {
-								updateBlockListSettings( props.clientId, {
-									...getBlockListSettings( props.clientId ),
-									templateLock: 'noContent',
-								} );
-								__unstableMarkNextChangeAsNotPersistent();
-								updateBlockAttributes( props.clientId, {
-									templateLock: 'noContent',
-								} );
-								setIsEditingAsBlocks( false );
+								stopEditingAsBlock();
 							} else {
-								updateBlockListSettings( props.clientId, {
-									...getBlockListSettings( props.clientId ),
-									templateLock: false,
-								} );
 								__unstableMarkNextChangeAsNotPersistent();
 								updateBlockAttributes( props.clientId, {
 									templateLock: undefined,
 								} );
-								setIsEditingAsBlocks( true );
+								updateBlockListSettings( props.clientId, {
+									...getBlockListSettings( props.clientId ),
+									templateLock: false,
+								} );
+								focusModeToRevert.current =
+									getSettings().focusMode;
+								updateSettings( { focusMode: true } );
+								__unstableSetTemporarilyEditingAsBlocks(
+									props.clientId
+								);
 							}
 						} }
 					>
@@ -102,7 +140,14 @@ export const withBlockControls = createHigherOrderComponent(
 							: __( 'Modify' ) }
 					</ToolbarButton>
 				</BlockControls>
-				<BlockEdit { ...props } />
+				<BlockEdit
+					{ ...props }
+					className={ classnames(
+						props.className,
+						isEditingAsBlocks &&
+							'is-content-locked-editing-as-blocks'
+					) }
+				/>
 			</>
 		);
 	},

--- a/packages/block-editor/src/hooks/content-lock-ui.js
+++ b/packages/block-editor/src/hooks/content-lock-ui.js
@@ -72,41 +72,35 @@ export const withBlockControls = createHigherOrderComponent(
 					/>
 				) }
 				<BlockControls group="other">
-					<ToolbarGroup>
-						<ToolbarButton
-							onClick={ () => {
-								if ( isEditingAsBlocks && ! isContentLocked ) {
-									updateBlockListSettings( props.clientId, {
-										...getBlockListSettings(
-											props.clientId
-										),
-										templateLock: 'noContent',
-									} );
-									__unstableMarkNextChangeAsNotPersistent();
-									updateBlockAttributes( props.clientId, {
-										templateLock: 'noContent',
-									} );
-									setIsEditingAsBlocks( false );
-								} else {
-									updateBlockListSettings( props.clientId, {
-										...getBlockListSettings(
-											props.clientId
-										),
-										templateLock: false,
-									} );
-									__unstableMarkNextChangeAsNotPersistent();
-									updateBlockAttributes( props.clientId, {
-										templateLock: undefined,
-									} );
-									setIsEditingAsBlocks( true );
-								}
-							} }
-						>
-							{ isEditingAsBlocks && ! isContentLocked
-								? __( 'Done' )
-								: __( 'Modify' ) }
-						</ToolbarButton>
-					</ToolbarGroup>
+					<ToolbarButton
+						onClick={ () => {
+							if ( isEditingAsBlocks && ! isContentLocked ) {
+								updateBlockListSettings( props.clientId, {
+									...getBlockListSettings( props.clientId ),
+									templateLock: 'noContent',
+								} );
+								__unstableMarkNextChangeAsNotPersistent();
+								updateBlockAttributes( props.clientId, {
+									templateLock: 'noContent',
+								} );
+								setIsEditingAsBlocks( false );
+							} else {
+								updateBlockListSettings( props.clientId, {
+									...getBlockListSettings( props.clientId ),
+									templateLock: false,
+								} );
+								__unstableMarkNextChangeAsNotPersistent();
+								updateBlockAttributes( props.clientId, {
+									templateLock: undefined,
+								} );
+								setIsEditingAsBlocks( true );
+							}
+						} }
+					>
+						{ isEditingAsBlocks && ! isContentLocked
+							? __( 'Done' )
+							: __( 'Modify' ) }
+					</ToolbarButton>
 				</BlockControls>
 				<BlockEdit { ...props } />
 			</>

--- a/packages/block-editor/src/hooks/content-lock-ui.js
+++ b/packages/block-editor/src/hooks/content-lock-ui.js
@@ -1,7 +1,7 @@
 /**
  * WordPress dependencies
  */
-import { ToolbarButton, ToolbarGroup } from '@wordpress/components';
+import { ToolbarButton } from '@wordpress/components';
 import { createHigherOrderComponent } from '@wordpress/compose';
 import { useDispatch, useSelect } from '@wordpress/data';
 import { addFilter } from '@wordpress/hooks';

--- a/packages/block-editor/src/hooks/content-lock-ui.js
+++ b/packages/block-editor/src/hooks/content-lock-ui.js
@@ -51,6 +51,8 @@ export const withBlockControls = createHigherOrderComponent(
 				select( blockEditorStore ).getTemplateLock( props.clientId ),
 			[ props.clientId ]
 		);
+		const { getBlockListSettings } = useSelect( blockEditorStore );
+		const { updateBlockListSettings } = useDispatch( blockEditorStore );
 		const isContentLocked = templateLock === 'noContent';
 		const {
 			__unstableMarkNextChangeAsNotPersistent,
@@ -74,12 +76,24 @@ export const withBlockControls = createHigherOrderComponent(
 						<ToolbarButton
 							onClick={ () => {
 								if ( isEditingAsBlocks && ! isContentLocked ) {
+									updateBlockListSettings( props.clientId, {
+										...getBlockListSettings(
+											props.clientId
+										),
+										templateLock: 'noContent',
+									} );
 									__unstableMarkNextChangeAsNotPersistent();
 									updateBlockAttributes( props.clientId, {
 										templateLock: 'noContent',
 									} );
 									setIsEditingAsBlocks( false );
 								} else {
+									updateBlockListSettings( props.clientId, {
+										...getBlockListSettings(
+											props.clientId
+										),
+										templateLock: false,
+									} );
 									__unstableMarkNextChangeAsNotPersistent();
 									updateBlockAttributes( props.clientId, {
 										templateLock: undefined,
@@ -89,8 +103,8 @@ export const withBlockControls = createHigherOrderComponent(
 							} }
 						>
 							{ isEditingAsBlocks && ! isContentLocked
-								? __( ' Finish editing as blocks' )
-								: __( 'Edit as Blocks' ) }
+								? __( 'Done' )
+								: __( 'Edit' ) }
 						</ToolbarButton>
 					</ToolbarGroup>
 				</BlockControls>

--- a/packages/block-editor/src/hooks/content-lock-ui.js
+++ b/packages/block-editor/src/hooks/content-lock-ui.js
@@ -104,7 +104,7 @@ export const withBlockControls = createHigherOrderComponent(
 						>
 							{ isEditingAsBlocks && ! isContentLocked
 								? __( 'Done' )
-								: __( 'Edit' ) }
+								: __( 'Modify' ) }
 						</ToolbarButton>
 					</ToolbarGroup>
 				</BlockControls>

--- a/packages/block-editor/src/hooks/index.js
+++ b/packages/block-editor/src/hooks/index.js
@@ -15,6 +15,7 @@ import './duotone';
 import './font-size';
 import './border';
 import './layout';
+import './content-lock-ui';
 
 export { useCustomSides } from './dimensions';
 export { getBorderClassesAndStyles, useBorderProps } from './use-border-props';

--- a/packages/block-editor/src/store/actions.js
+++ b/packages/block-editor/src/store/actions.js
@@ -1673,3 +1673,17 @@ export function setBlockVisibility( updates ) {
 		updates,
 	};
 }
+
+/**
+ * Action that sets whether a block is being temporaritly edited as blocks.
+ *
+ * @param {?string} temporarilyEditingAsBlocks The block's clientId being temporaritly edited as blocks.
+ */
+export function __unstableSetTemporarilyEditingAsBlocks(
+	temporarilyEditingAsBlocks
+) {
+	return {
+		type: 'SET_TEMPORARILY_EDITING_AS_BLOCKS',
+		temporarilyEditingAsBlocks,
+	};
+}

--- a/packages/block-editor/src/store/reducer.js
+++ b/packages/block-editor/src/store/reducer.js
@@ -1778,6 +1778,21 @@ export function lastBlockInserted( state = {}, action ) {
 	return state;
 }
 
+/**
+ * Reducer returning the block that is eding temporarily edited as blocks.
+ *
+ * @param {Object} state  Current state.
+ * @param {Object} action Dispatched action.
+ *
+ * @return {Object} Updated state.
+ */
+export function temporarilyEditingAsBlocks( state = '', action ) {
+	if ( action.type === 'SET_TEMPORARILY_EDITING_AS_BLOCKS' ) {
+		return action.temporarilyEditingAsBlocks;
+	}
+	return state;
+}
+
 export default combineReducers( {
 	blocks,
 	isTyping,
@@ -1798,4 +1813,5 @@ export default combineReducers( {
 	automaticChangeStatus,
 	highlightedBlock,
 	lastBlockInserted,
+	temporarilyEditingAsBlocks,
 } );

--- a/packages/block-editor/src/store/selectors.js
+++ b/packages/block-editor/src/store/selectors.js
@@ -1434,6 +1434,10 @@ export function getTemplateLock( state, rootClientId ) {
 		return state.settings.templateLock;
 	}
 
+	if ( getBlockAttributes( state, rootClientId ).lock?.content === true ) {
+		return 'all';
+	}
+
 	const blockListSettings = getBlockListSettings( state, rootClientId );
 	if ( ! blockListSettings ) {
 		return null;
@@ -1593,6 +1597,7 @@ const canInsertBlockTypeUnmemoized = (
 export const canInsertBlockType = createSelector(
 	canInsertBlockTypeUnmemoized,
 	( state, blockName, rootClientId ) => [
+		state.blocks.attributes[ rootClientId ],
 		state.blockListSettings[ rootClientId ],
 		state.blocks.byClientId[ rootClientId ],
 		state.settings.allowedBlockTypes,
@@ -2678,4 +2683,17 @@ export const __unstableGetVisibleBlocks = createSelector(
 		);
 	},
 	( state ) => [ state.blocks.visibility ]
+);
+
+export const __unstableGetContentLockingParent = createSelector(
+	( state, clientId ) => {
+		let current = clientId;
+		while ( !! state.blocks.parents[ current ] ) {
+			current = state.blocks.parents[ current ];
+			if ( getBlockAttributes( state, current )?.lock?.content ) {
+				return current;
+			}
+		}
+	},
+	( state ) => [ state.blocks.parents, state.blocks.attributes ]
 );

--- a/packages/block-editor/src/store/selectors.js
+++ b/packages/block-editor/src/store/selectors.js
@@ -2684,12 +2684,14 @@ export const __unstableGetVisibleBlocks = createSelector(
 export const __unstableGetContentLockingParent = createSelector(
 	( state, clientId ) => {
 		let current = clientId;
+		let result;
 		while ( !! state.blocks.parents[ current ] ) {
 			current = state.blocks.parents[ current ];
 			if ( getTemplateLock( state, current ) === 'noContent' ) {
-				return current;
+				result = current;
 			}
 		}
+		return result;
 	},
 	( state ) => [ state.blocks.parents, state.blocks.attributes ]
 );

--- a/packages/block-editor/src/store/selectors.js
+++ b/packages/block-editor/src/store/selectors.js
@@ -2686,7 +2686,7 @@ export const __unstableGetContentLockingParent = createSelector(
 		let current = clientId;
 		while ( !! state.blocks.parents[ current ] ) {
 			current = state.blocks.parents[ current ];
-			if ( getBlockAttributes( state, current )?.lock?.content ) {
+			if ( getTemplateLock( state, current ) === 'noContent' ) {
 				return current;
 			}
 		}

--- a/packages/block-editor/src/store/selectors.js
+++ b/packages/block-editor/src/store/selectors.js
@@ -1593,7 +1593,6 @@ const canInsertBlockTypeUnmemoized = (
 export const canInsertBlockType = createSelector(
 	canInsertBlockTypeUnmemoized,
 	( state, blockName, rootClientId ) => [
-		state.blocks.attributes[ rootClientId ],
 		state.blockListSettings[ rootClientId ],
 		state.blocks.byClientId[ rootClientId ],
 		state.settings.allowedBlockTypes,

--- a/packages/block-editor/src/store/selectors.js
+++ b/packages/block-editor/src/store/selectors.js
@@ -1434,10 +1434,6 @@ export function getTemplateLock( state, rootClientId ) {
 		return state.settings.templateLock;
 	}
 
-	if ( getBlockAttributes( state, rootClientId ).lock?.content === true ) {
-		return 'all';
-	}
-
 	const blockListSettings = getBlockListSettings( state, rootClientId );
 	if ( ! blockListSettings ) {
 		return null;

--- a/packages/block-editor/src/store/selectors.js
+++ b/packages/block-editor/src/store/selectors.js
@@ -2692,5 +2692,9 @@ export const __unstableGetContentLockingParent = createSelector(
 		}
 		return result;
 	},
-	( state ) => [ state.blocks.parents, state.blocks.attributes ]
+	( state ) => [ state.blocks.parents, state.blockListSettings ]
 );
+
+export function __unstableGetTemporarilyEditingAsBlocks( state ) {
+	return state.temporarilyEditingAsBlocks;
+}

--- a/packages/block-library/src/column/block.json
+++ b/packages/block-library/src/column/block.json
@@ -19,7 +19,7 @@
 		},
 		"templateLock": {
 			"type": [ "string", "boolean" ],
-			"enum": [ "all", "insert", false ]
+			"enum": [ "all", "insert", "noContent", false ]
 		}
 	},
 	"supports": {

--- a/packages/block-library/src/cover/block.json
+++ b/packages/block-library/src/cover/block.json
@@ -73,7 +73,7 @@
 		},
 		"templateLock": {
 			"type": [ "string", "boolean" ],
-			"enum": [ "all", "insert", false ]
+			"enum": [ "all", "insert", "noContent", false ]
 		}
 	},
 	"usesContext": [ "postId", "postType" ],

--- a/packages/block-library/src/group/block.json
+++ b/packages/block-library/src/group/block.json
@@ -14,7 +14,7 @@
 		},
 		"templateLock": {
 			"type": [ "string", "boolean" ],
-			"enum": [ "all", "insert", false ]
+			"enum": [ "all", "insert", "noContent", false ]
 		},
 		"layout": {
 			"type": "object",

--- a/packages/blocks/src/store/selectors.js
+++ b/packages/blocks/src/store/selectors.js
@@ -790,3 +790,13 @@ export const hasChildBlocksWithInserterSupport = ( state, blockName ) => {
 		return hasBlockSupport( state, childBlockName, 'inserter', true );
 	} );
 };
+
+export const __unstableIsContentBlock = createSelector(
+	( state, blockTypeName ) => {
+		const blockType = getBlockType( state, blockTypeName );
+		return Object.entries( blockType.attributes ).some(
+			( [ , { __experimentalRole } ] ) => __experimentalRole === 'content'
+		);
+	},
+	( state, blockTypeName ) => [ state.blockTypes[ blockTypeName ].attributes ]
+);

--- a/packages/blocks/src/store/selectors.js
+++ b/packages/blocks/src/store/selectors.js
@@ -791,7 +791,7 @@ export const hasChildBlocksWithInserterSupport = ( state, blockName ) => {
 	} );
 };
 
-export const __unstableIsContentBlock = createSelector(
+export const __experimentalHasContentRoleAttribute = createSelector(
 	( state, blockTypeName ) => {
 		const blockType = getBlockType( state, blockTypeName );
 		return Object.entries( blockType.attributes ).some(


### PR DESCRIPTION
As shared by @jameskoster in https://github.com/WordPress/gutenberg/pull/42684#issuecomment-1199621547 we are exploring a content lock with the following requirements when a container is 'content locked':

* Non-content child blocks (containers, spacers, columns, etc.) are hidden from the list view, un-clickable on the canvas, and entirely uneditable.
* The Inspector will display a list of all child 'content' blocks. Clicking a block in this list reveals its settings panel. We may need to list the root block as well, but I am not 100% sure.
* The main List View only shows content blocks, all at the same level, regardless of actual nesting.
* Children move and remove is locked.
* Additional child blocks cannot be inserted.
* There is a link in the block toolbar to 'Edit as blocks'. This temporarily toggles off the features outlined above, allowing full edit access, either inline (similar to cropping in the Image block) or in template part focus mode. We should test both approaches.




## Screenshots
![image](https://user-images.githubusercontent.com/11271197/183132649-e20ac31f-bde7-4fd4-83f5-459d192f9f20.png)
![image](https://user-images.githubusercontent.com/11271197/183132683-5fbb410b-8056-4c26-adcf-6f21d065f675.png)
![image](https://user-images.githubusercontent.com/11271197/183133014-d49db0d4-2fe3-405f-b89b-4cb480d1633a.png)

## Sample 
```
<!-- wp:group {"templateLock": "contentOnly", "backgroundColor": "pale-cyan-blue", "layout" :{" type": "default"}} -->
<div class= "wp-block-group has-pale-cyan-blue-background-color has-background"><!-- wp:heading {"style" :{ "typography" :{ "fontStyle": "normal", "fontWeight": "700"}}, "backgroundColor": "pale-pink", "fontSize": "x-large"} -->
<h2 class="has-pale-pink-background-color has-background has-x-large-font-size" style="font-style:normal;font-weight:700">Heading</h2>
<!-- /wp:heading -->

<!-- wp:list -->
<ul><!-- wp:list-item -->
<li>a1</li>
<!-- /wp:list-item -->

<!-- wp:list-item -->
<li>2</li>
<!-- /wp:list-item -->

<!-- wp:list-item -->
<li>3</li>
<!-- /wp:list-item -->

<!-- wp:list-item -->
<li></li>
<!-- /wp:list-item --></ul>
<!-- /wp:list -->

<!-- wp:paragraph {"backgroundColor": "vivid-red", "textColor": "secondary"} -->
<p class="has-secondary-color has-vivid-red-background-color has-text-color has-background">Paragraph</p>
<!-- /wp:paragraph -->

<!-- wp:quote -->
<blockquote class="wp-block-quote"><!-- wp:paragraph -->
<p>sdsds</p>
<!-- /wp:paragraph --><cite>sd</cite></blockquote>
<!-- /wp:quote -->

<!-- wp:image {"align": "center", "width":239, "height":239, "sizeSlug": "large", "style" :{ "border" :{ "width": "18px" }}} -->
<figure class="wp-block-image aligncenter size-large is-resized has-custom-border"><img src="https://s.w.org/style/images/about/WordPress-logotype-wmark.png" alt="" style="border-width:18px" width="239" height="239"/><figcaption class="wp-element-caption">f</figcaption></figure>
<!-- /wp:image -->

<!-- wp:spacer {"height":"28px"} -->
<div style="height:28px" aria-hidden="true" class="wp-block-spacer"></div>
<!-- /wp:spacer -->

<!-- wp:group {"backgroundColor":"secondary"} -->
<div class="wp-block-group has-secondary-background-color has-background"><!-- wp:separator -->
<hr class="wp-block-separator has-alpha-channel-opacity"/>
<!-- /wp:separator -->

<!-- wp:spacer {"height":"55px"} -->
<div style="height:55px" aria-hidden="true" class="wp-block-spacer"></div>
<!-- /wp:spacer -->

<!-- wp:pullquote {"gradient":"blush-bordeaux"} -->
<figure class="wp-block-pullquote has-blush-bordeaux-gradient-background has-background"><blockquote><p>End quote inside another group</p></blockquote></figure>
<!-- /wp:pullquote --></div>
<!-- /wp:group --></div>
<!-- /wp:group -->
```

## Testing

- I pasted the previous sample on the code editor.
- I verified there is no way I could select the image (images will be considered content in the future on another PR I'm making) or spacer blocks by clicking on it or by using keyboard navigation, e.g., arrows and tabs. It looks like the non-content block does not exist.
- I verified the non-content blocks don't appear on the list view.
- I verified the group block was totally locked; I could not insert or move any block inside it.
- I verified I could use Edit as blocks to make the block "normal".
- I verified that If I'm using Edit as blocks and move away to another block outside the group, the group block becomes locked again, and the Edit as blocks stops.
- I verified that If I'm using Edit as blocks and click finish editing as blocks, the group block becomes locked again, and the Edit as blocks stops.

## Missing

UI to add a content block. For now, we can hardcode on the code editor. But a UI could be offered either as part of the lock modal or as part of a UI to create patterns on the editor.