### PR TITLE
Add content role to caption attributes - Make new content blocks.

### DIFF
--- a/packages/block-library/src/audio/block.json
+++ b/packages/block-library/src/audio/block.json
@@ -17,7 +17,8 @@
 		"caption": {
 			"type": "string",
 			"source": "html",
-			"selector": "figcaption"
+			"selector": "figcaption",
+			"__experimentalRole": "content"
 		},
 		"id": {
 			"type": "number"

--- a/packages/block-library/src/embed/block.json
+++ b/packages/block-library/src/embed/block.json
@@ -13,7 +13,8 @@
 		"caption": {
 			"type": "string",
 			"source": "html",
-			"selector": "figcaption"
+			"selector": "figcaption",
+			"__experimentalRole": "content"
 		},
 		"type": {
 			"type": "string"

--- a/packages/block-library/src/gallery/block.json
+++ b/packages/block-library/src/gallery/block.json
@@ -74,7 +74,8 @@
 		"caption": {
 			"type": "string",
 			"source": "html",
-			"selector": ".blocks-gallery-caption"
+			"selector": ".blocks-gallery-caption",
+			"__experimentalRole": "content"
 		},
 		"imageCrop": {
 			"type": "boolean",

--- a/packages/block-library/src/image/block.json
+++ b/packages/block-library/src/image/block.json
@@ -28,7 +28,8 @@
 		"caption": {
 			"type": "string",
 			"source": "html",
-			"selector": "figcaption"
+			"selector": "figcaption",
+			"__experimentalRole": "content"
 		},
 		"title": {
 			"type": "string",

--- a/packages/block-library/src/video/block.json
+++ b/packages/block-library/src/video/block.json
@@ -17,7 +17,8 @@
 		"caption": {
 			"type": "string",
 			"source": "html",
-			"selector": "figcaption"
+			"selector": "figcaption",
+			"__experimentalRole": "content"
 		},
 		"controls": {
 			"type": "boolean",


### PR DESCRIPTION
This PR adds __experimentalRole content to the caption attributes of image, gallery, audio, video, and embed blocks.
This change makes sense because the caption is content and it is important because with this change these blocks become content blocks an important concept in future work e.g this PR https://github.com/WordPress/gutenberg/pull/43037.

