### PR TITLE
Add visual cue for group block in Block List View for tagName selected.

### DIFF
--- a/packages/block-editor/src/components/list-view/block-select-button.js
+++ b/packages/block-editor/src/components/list-view/block-select-button.js
@@ -94,6 +94,11 @@ function ListViewBlockSelectButton(
 							{ blockInformation.anchor }
 						</span>
 					) }
+					{ blockInformation?.tagName && (
+						<span className="block-editor-list-view-block-select-button__tag-name">
+							{ '<' + blockInformation.tagName + '>' }
+						</span>
+					) }
 					{ isLocked && (
 						<span className="block-editor-list-view-block-select-button__lock">
 							<Icon icon={ lock } />

--- a/packages/block-editor/src/components/list-view/style.scss
+++ b/packages/block-editor/src/components/list-view/style.scss
@@ -312,7 +312,8 @@
 		}
 	}
 
-	.block-editor-list-view-block-select-button__anchor {
+	.block-editor-list-view-block-select-button__anchor,
+	.block-editor-list-view-block-select-button__tag-name {
 		background: rgba($black, 0.1);
 		border-radius: $radius-block-ui;
 		display: inline-block;
@@ -322,7 +323,8 @@
 		text-overflow: ellipsis;
 	}
 
-	&.is-selected .block-editor-list-view-block-select-button__anchor {
+	&.is-selected .block-editor-list-view-block-select-button__anchor,
+	&.is-selected .block-editor-list-view-block-select-button__tag-name {
 		background: rgba($black, 0.3);
 	}
 

--- a/packages/block-editor/src/components/use-block-display-information/index.js
+++ b/packages/block-editor/src/components/use-block-display-information/index.js
@@ -20,6 +20,7 @@ import { store as blockEditorStore } from '../../store';
  * @property {WPIcon} icon        Block type icon.
  * @property {string} description A detailed block type description.
  * @property {string} anchor      HTML anchor.
+ * @property {string} tagName     HTML tagName of element.
  */
 
 /**
@@ -63,6 +64,7 @@ export default function useBlockDisplayInformation( clientId ) {
 				icon: match.icon || blockType.icon,
 				description: match.description || blockType.description,
 				anchor: attributes?.anchor,
+				tagName: attributes?.tagName,
 			};
 		},
 		[ clientId ]


### PR DESCRIPTION
Fixes #42610.

## What?
Adds the tagName to the group block in the List View of blocks.

## Why?
Helps bring more clarity to the type of group being used. You will more easily know which group is which by seeing the tagName.

## How?
Modifies ListViewBlockSelectButton to add in a tagName if set, which same treatment as an anchor element. Adds tagName to  useBlockDisplayInformation return value to have it present in component.

## Testing Instructions
1. Create a group block.
2. Open the List View of blocks.
3. Verify that the tagName for the group is displaying.
4. Change tag for the group block.
5. Verify that the tag updates according to the selection from step 4.
