### PR TITLE
Format Library: Add missing keyboard shortcut description in customizer widget

### DIFF
--- a/packages/customize-widgets/src/components/keyboard-shortcut-help-modal/config.js
+++ b/packages/customize-widgets/src/components/keyboard-shortcut-help-modal/config.js
@@ -32,4 +32,8 @@ export const textFormattingShortcuts = [
 		keyCombination: { modifier: 'access', character: 'd' },
 		description: __( 'Strikethrough the selected text.' ),
 	},
+	{
+		keyCombination: { modifier: 'access', character: 'x' },
+		description: __( 'Make the selected text inline code.' ),
+	},
 ];


### PR DESCRIPTION
This PR adds the missing shortcut in the keyboard shortcut (inline code) modal of the Customizer widget.

## What?
<!-- In a few words, what is the PR actually doing? -->

## Why?
I compared the following four files for shortcuts displayed in the modal and found a shortcut (inline code) that is not displayed in the customizer widget only:

- https://github.com/WordPress/gutenberg/blob/trunk/packages/customize-widgets/src/components/keyboard-shortcut-help-modal/config.js
- https://github.com/WordPress/gutenberg/blob/trunk/packages/edit-post/src/components/keyboard-shortcut-help-modal/config.js
- https://github.com/WordPress/gutenberg/blob/trunk/packages/edit-site/src/components/keyboard-shortcut-help-modal/config.js
- https://github.com/WordPress/gutenberg/blob/trunk/packages/edit-widgets/src/components/keyboard-shortcut-help-modal/config.js

## How?
Added shortcut definitions so that they are exactly the same as other keyboard shortcut modals.

## Testing Instructions
- Activate the classic theme
- Go to Appearance > Customize
- Go to Widgets 
- Open the keyboard shortcuts modal from the options menu
- At the bottom of the modal window, confirm that the shortcut about inline code has been added, just like in other editors.

## Screenshots or screencast 
This screenshot is on a Windows OS.

![keyboard_shortcut](https://user-images.githubusercontent.com/54422211/183244425-d8679547-abc5-4fcf-ad10-1f330f0d2073.png)

