### PR TITLE
Enable alpha (opacity) in Global Styles color pickers.

### DIFF
--- a/packages/components/src/palette-edit/index.js
+++ b/packages/components/src/palette-edit/index.js
@@ -163,6 +163,7 @@ function Option( {
 					{ ! isGradient && (
 						<ColorPicker
 							color={ value }
+							enableAlpha
 							onChange={ ( newColor ) =>
 								onChange( {
 									...element,


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Enables alpha (opacity) in Global Styles color pickers which fixes #42999 and #43041

## Why?
Alpha was enabled previously at the block level but not in Global Styles. This PR corrects that and establishes consistency.

## How?
Simply add `enableAlpha` to the `ColorPicker` component that is used in Global Styles.

## Testing Instructions
1. Navigate to the Site Editor and the Global Styles panel. 
2. Navigate to the Colors panel and edit a color and you will now see the alpha (opacity) slider. 

## Screenshots or screencast <!-- if applicable -->
![image](https://user-images.githubusercontent.com/4832319/183253681-17378237-8fab-4c8a-9438-20c92ec9b2ca.png)

