### PR TITLE
Style engine: disable stylesheet optimization temporarily

### DIFF
--- a/packages/style-engine/class-wp-style-engine.php
+++ b/packages/style-engine/class-wp-style-engine.php
@@ -365,7 +365,12 @@ class WP_Style_Engine {
 		foreach ( $stores as $key => $store ) {
 			$processor = new WP_Style_Engine_Processor();
 			$processor->add_store( $store );
-			$styles = $processor->get_css( array( 'prettify' => defined( 'SCRIPT_DEBUG' ) && SCRIPT_DEBUG ) );
+			$styles = $processor->get_css(
+				array(
+					'optimize' => false,
+					'prettify' => defined( 'SCRIPT_DEBUG' ) && SCRIPT_DEBUG,
+				)
+			);
 
 			if ( ! empty( $styles ) ) {
 				wp_register_style( $key, false, array(), true, true );


### PR DESCRIPTION
Resolves https://github.com/WordPress/gutenberg/issues/43046

Alternative to
- https://github.com/WordPress/gutenberg/pull/43052

## What?

This PR disables stylesheet optimization temporarily pending further testing and refinement.

## Why?
The immediate need is to address https://github.com/WordPress/gutenberg/issues/43046, but it might be worthwhile performing extensive testing before we roll optimization out for block supports and, later, global styles.

In #43046,  where there are combined rules, a nested layout block's gap value is printed at the top of the stylesheet and overwritten, but the combined default below. 

<details>

<summary>Output example</summary>

```css
<style id='block-supports-inline-css'>

/* ... some other styles */

.wp-block-group.wp-container-5 > * + * {
	margin-block-start: 118px; /* ... this is overwritten */
	margin-block-end: 0;
}

.wp-block-group.wp-container-1 > *,
.wp-block-group.wp-container-5 > *,
.wp-block-group.wp-container-8 > * {
	margin-block-start: 0;
	margin-block-end: 0;
}

/* ... some other styles */

</style>

```

</details>

## How?
Setting the `optimize` flag to `false`

## Testing Instructions

(Taken from #43046)

1. Using trunk or [Gutenberg Nightly](https://gutenbergtimes.com/need-a-zip-from-master/#nightly), add a Columns block with a single Column block.
2. Add two Paragraph blocks and then Group the Paragraph blocks.
3. Set the Block Spacing on the Column block to 40px.
4. On the Group block inside of the Column block, set the Block Spacing 20px.
5. Check that the correct block gap is applied to the inner elements of the Group block.

<details>

<summary>Example block code </summary>

```html
<!-- wp:columns {"style":{"spacing":{"blockGap":"1px"}}} -->
<div class="wp-block-columns"><!-- wp:column {"width":"100%"} -->
<div class="wp-block-column" style="flex-basis:100%"><!-- wp:group {"style":{"color":{"background":"#9eebbc"},"spacing":{"blockGap":"137px"}},"layout":{"contentSize":"342px"}} -->
<div class="wp-block-group has-background" style="background-color:#9eebbc"><!-- wp:paragraph {"style":{"elements":{"link":{"color":{"text":"#cd31d6"}}}}} -->
<p class="has-link-color"><a href="https://word">Test</a></p>
<!-- /wp:paragraph -->

<!-- wp:paragraph -->
<p>Test</p>
<!-- /wp:paragraph --></div>
<!-- /wp:group --></div>
<!-- /wp:column --></div>
<!-- /wp:columns -->

<!-- wp:columns {"style":{"spacing":{"blockGap":"1px"}}} -->
<div class="wp-block-columns"><!-- wp:column {"width":"100%"} -->
<div class="wp-block-column" style="flex-basis:100%"><!-- wp:group {"style":{"color":{"background":"#1a4a2d"},"spacing":{"blockGap":"118px"}},"layout":{"contentSize":"342px"}} -->
<div class="wp-block-group has-background" style="background-color:#1a4a2d"><!-- wp:paragraph {"style":{"elements":{"link":{"color":{"text":"#cd31d6"}}}}} -->
<p class="has-link-color"><a href="https://word">Test</a></p>
<!-- /wp:paragraph -->

<!-- wp:paragraph -->
<p>Test</p>
<!-- /wp:paragraph --></div>
<!-- /wp:group --></div>
<!-- /wp:column --></div>
<!-- /wp:columns -->
```

</details>

### Trunk 
<img width="884" alt="Screen Shot 2022-08-08 at 8 42 43 am" src="https://user-images.githubusercontent.com/6458278/183314506-2c1a5fd8-a0c1-491d-a051-c172af5c1077.png">

### This PR

<img width="868" alt="Screen Shot 2022-08-08 at 8 43 01 am" src="https://user-images.githubusercontent.com/6458278/183314505-9515fb6a-d2b8-45ff-bf94-d7afe09754e7.png">



