### PR TITLE
Layout: merge CSS rule for block gap

### DIFF
--- a/lib/block-supports/layout.php
+++ b/lib/block-supports/layout.php
@@ -108,17 +108,15 @@ function gutenberg_get_layout_style( $selector, $layout, $has_block_gap_support 
 				array_push(
 					$layout_styles,
 					array(
-						'selector'     => "$selector > *",
+						'selector'     => "$selector > *,$selector > * + *",
 						'declarations' => array(
-							'margin-block-start' => '0',
-							'margin-block-end'   => '0',
+							'margin-block-end' => '0',
 						),
 					),
 					array(
 						'selector'     => "$selector > * + *",
 						'declarations' => array(
 							'margin-block-start' => $gap_value,
-							'margin-block-end'   => '0',
 						),
 					)
 				);

--- a/lib/block-supports/layout.php
+++ b/lib/block-supports/layout.php
@@ -108,15 +108,17 @@ function gutenberg_get_layout_style( $selector, $layout, $has_block_gap_support 
 				array_push(
 					$layout_styles,
 					array(
-						'selector'     => "$selector > *,$selector > * + *",
+						'selector'     => "$selector > *",
 						'declarations' => array(
-							'margin-block-end' => '0',
+							'margin-block-start' => '0',
+							'margin-block-end'   => '0',
 						),
 					),
 					array(
-						'selector'     => "$selector > * + *",
+						'selector'     => "$selector$selector > * + *",
 						'declarations' => array(
 							'margin-block-start' => $gap_value,
+							'margin-block-end'   => '0',
 						),
 					)
 				);


### PR DESCRIPTION
Resolves https://github.com/WordPress/gutenberg/issues/43046

Alternative to
- https://github.com/WordPress/gutenberg/pull/43051

## What?

In the layout abstraction, merge `$selector > *,$selector > * + *` selectors, only set `margin-block-start` if a gap value is available.

```css

.wp-block-group.wp-container-1 > * + * {
	margin-block-start: 137px;
}
.wp-block-group.wp-container-2 > * + * {
	margin-block-start: 71px;
}
.wp-block-column.wp-container-3 > * + * {
	margin-block-start: 120px;
}
.wp-block-group.wp-container-5 > * + * {
	margin-block-start: 118px;
}
/* some styles... */
.wp-block-group.wp-container-1 > *,
.wp-block-group.wp-container-1 > * + *,
.wp-block-group.wp-container-2 > *,
.wp-block-group.wp-container-2 > * + *,
.wp-block-column.wp-container-3 > *,
.wp-block-column.wp-container-3 > * + *,
.wp-block-group.wp-container-5 > *,
.wp-block-group.wp-container-5 > * + * {
	margin-block-end: 0;
}

```

## Why?
So that the style engine optimization engine prints out the rules separately. 

**Note**: this doesn't address to root cause, that is, the style engine doesn't care about the order of rules when combining selectors. Combined selectors are printed at the bottom of the stylesheet.


## Testing Instructions


(Taken from #43046)

1. Using trunk or [Gutenberg Nightly](https://gutenbergtimes.com/need-a-zip-from-master/#nightly), add a Columns block with a single Column block.
2. Add two Paragraph blocks and then Group the Paragraph blocks.
3. Set the Block Spacing on the Column block to 40px.
4. On the Group block inside of the Column block, set the Block Spacing 20px.
5. Check that the correct block gap is applied to the inner elements of the Group block.

<details>

<summary>Example block code </summary>

```html
<!-- wp:columns {"style":{"spacing":{"blockGap":"1px"}}} -->
<div class="wp-block-columns"><!-- wp:column {"width":"100%"} -->
<div class="wp-block-column" style="flex-basis:100%"><!-- wp:group {"style":{"color":{"background":"#9eebbc"},"spacing":{"blockGap":"137px"}},"layout":{"contentSize":"342px"}} -->
<div class="wp-block-group has-background" style="background-color:#9eebbc"><!-- wp:paragraph {"style":{"elements":{"link":{"color":{"text":"#cd31d6"}}}}} -->
<p class="has-link-color"><a href="https://word">Test</a></p>
<!-- /wp:paragraph -->

<!-- wp:paragraph -->
<p>Test</p>
<!-- /wp:paragraph --></div>
<!-- /wp:group --></div>
<!-- /wp:column --></div>
<!-- /wp:columns -->

<!-- wp:columns {"style":{"spacing":{"blockGap":"1px"}}} -->
<div class="wp-block-columns"><!-- wp:column {"width":"100%"} -->
<div class="wp-block-column" style="flex-basis:100%"><!-- wp:group {"style":{"color":{"background":"#1a4a2d"},"spacing":{"blockGap":"118px"}},"layout":{"contentSize":"342px"}} -->
<div class="wp-block-group has-background" style="background-color:#1a4a2d"><!-- wp:paragraph {"style":{"elements":{"link":{"color":{"text":"#cd31d6"}}}}} -->
<p class="has-link-color"><a href="https://word">Test</a></p>
<!-- /wp:paragraph -->

<!-- wp:paragraph -->
<p>Test</p>
<!-- /wp:paragraph --></div>
<!-- /wp:group --></div>
<!-- /wp:column --></div>
<!-- /wp:columns -->
```

</details>

### Trunk 
<img width="884" alt="Screen Shot 2022-08-08 at 8 42 43 am" src="https://user-images.githubusercontent.com/6458278/183314506-2c1a5fd8-a0c1-491d-a051-c172af5c1077.png">

### This PR

<img width="868" alt="Screen Shot 2022-08-08 at 8 43 01 am" src="https://user-images.githubusercontent.com/6458278/183314505-9515fb6a-d2b8-45ff-bf94-d7afe09754e7.png">