### PR TITLE
Add separate callbacks for selecting a classic or navigation menu in the nav block

### DIFF
--- a/packages/block-library/src/navigation/edit/index.js
+++ b/packages/block-library/src/navigation/edit/index.js
@@ -421,24 +421,6 @@ function Navigation( {
 	const navigationSelectorRef = useRef();
 	const [ shouldFocusNavigationSelector, setShouldFocusNavigationSelector ] =
 		useState( false );
-	const handleSelectNavigation = useCallback(
-		( navPostOrClassicMenu ) => {
-			if ( ! navPostOrClassicMenu ) {
-				return;
-			}
-
-			const isClassicMenu =
-				navPostOrClassicMenu.hasOwnProperty( 'auto_add' );
-
-			if ( isClassicMenu ) {
-				convert( navPostOrClassicMenu.id, navPostOrClassicMenu.name );
-			} else {
-				handleUpdateMenu( navPostOrClassicMenu.id );
-			}
-			setShouldFocusNavigationSelector( true );
-		},
-		[ convert, handleUpdateMenu ]
-	);
 
 	// Focus support after menu selection.
 	useEffect( () => {
@@ -693,7 +675,14 @@ function Navigation( {
 					isResolvingCanUserCreateNavigationMenu={
 						isResolvingCanUserCreateNavigationMenu
 					}
-					onFinish={ handleSelectNavigation }
+					onSelectNavigationMenu={ ( menuId ) => {
+						handleUpdateMenu( menuId );
+						setShouldFocusNavigationSelector( true );
+					} }
+					onSelectClassicMenu={ ( classicMenu ) => {
+						convert( classicMenu.id, classicMenu.name );
+						setShouldFocusNavigationSelector( true );
+					} }
 					onCreateEmpty={ () => createNavigationMenu( '', [] ) }
 				/>
 			</TagName>
@@ -710,7 +699,14 @@ function Navigation( {
 								ref={ navigationSelectorRef }
 								currentMenuId={ ref }
 								clientId={ clientId }
-								onSelect={ handleSelectNavigation }
+								onSelectNavigationMenu={ ( menuId ) => {
+									handleUpdateMenu( menuId );
+									setShouldFocusNavigationSelector( true );
+								} }
+								onSelectClassicMenu={ ( classicMenu ) => {
+									convert( classicMenu.id, classicMenu.name );
+									setShouldFocusNavigationSelector( true );
+								} }
 								onCreateNew={ resetToEmptyBlock }
 								/* translators: %s: The name of a menu. */
 								actionLabel={ __( "Switch to '%s'" ) }

--- a/packages/block-library/src/navigation/edit/navigation-menu-selector.js
+++ b/packages/block-library/src/navigation/edit/navigation-menu-selector.js
@@ -10,7 +10,7 @@ import {
 import { __, sprintf } from '@wordpress/i18n';
 import { decodeEntities } from '@wordpress/html-entities';
 import { addQueryArgs } from '@wordpress/url';
-import { forwardRef, useCallback, useMemo } from '@wordpress/element';
+import { forwardRef, useMemo } from '@wordpress/element';
 
 /**
  * Internal dependencies
@@ -21,7 +21,8 @@ import useNavigationEntities from '../use-navigation-entities';
 function NavigationMenuSelector(
 	{
 		currentMenuId,
-		onSelect,
+		onSelectNavigationMenu,
+		onSelectClassicMenu,
 		onCreateNew,
 		showManageActions = false,
 		actionLabel,
@@ -42,24 +43,6 @@ function NavigationMenuSelector(
 		canUserUpdateNavigationMenu,
 		canSwitchNavigationMenu,
 	} = useNavigationMenu();
-
-	const handleSelect = useCallback(
-		( _onClose ) => ( selectedId ) => {
-			_onClose();
-			onSelect(
-				navigationMenus?.find( ( post ) => post.id === selectedId )
-			);
-		},
-		[ navigationMenus ]
-	);
-
-	const handleSelectClassic = useCallback(
-		( _onClose, menu ) => () => {
-			_onClose();
-			onSelect( menu );
-		},
-		[]
-	);
 
 	const menuChoices = useMemo( () => {
 		return (
@@ -83,7 +66,7 @@ function NavigationMenuSelector(
 
 	// Show the selector if:
 	// - has switch or create permissions and there are block or classic menus.
-	// - user has create or update permisisons and component should show the menu actions.
+	// - user has create or update permissions and component should show the menu actions.
 	const showSelectMenus =
 		( ( canSwitchNavigationMenu || canUserCreateNavigationMenu ) &&
 			( hasNavigationMenus || hasClassicMenus ) ) ||
@@ -107,7 +90,10 @@ function NavigationMenuSelector(
 						<MenuGroup label={ __( 'Menus' ) }>
 							<MenuItemsChoice
 								value={ currentMenuId }
-								onSelect={ handleSelect( onClose ) }
+								onSelect={ ( menuId ) => {
+									onClose();
+									onSelectNavigationMenu( menuId );
+								} }
 								choices={ menuChoices }
 							/>
 						</MenuGroup>
@@ -118,10 +104,10 @@ function NavigationMenuSelector(
 								const label = decodeEntities( menu.name );
 								return (
 									<MenuItem
-										onClick={ handleSelectClassic(
-											onClose,
-											menu
-										) }
+										onClick={ () => {
+											onClose();
+											onSelectClassicMenu( menu );
+										} }
 										key={ menu.id }
 										aria-label={ sprintf(
 											createActionLabel,

--- a/packages/block-library/src/navigation/edit/placeholder/index.js
+++ b/packages/block-library/src/navigation/edit/placeholder/index.js
@@ -20,7 +20,8 @@ export default function NavigationPlaceholder( {
 	clientId,
 	canUserCreateNavigationMenu = false,
 	isResolvingCanUserCreateNavigationMenu,
-	onFinish,
+	onSelectNavigationMenu,
+	onSelectClassicMenu,
 	onCreateEmpty,
 } ) {
 	const { isResolvingMenus, hasResolvedMenus } = useNavigationEntities();
@@ -67,7 +68,8 @@ export default function NavigationPlaceholder( {
 						<NavigationMenuSelector
 							currentMenuId={ currentMenuId }
 							clientId={ clientId }
-							onSelect={ onFinish }
+							onSelectNavigationMenu={ onSelectNavigationMenu }
+							onSelectClassicMenu={ onSelectClassicMenu }
 							toggleProps={ {
 								variant: 'tertiary',
 								iconPosition: 'right',


### PR DESCRIPTION
## What?
Refactor of some navigation block code. Separated from #42956.

## Why?
- Makes it easier to run different code in response to user actions. In #42956 the placeholder menu selector needs to work differently to the toolbar menu selector (the former completely updates the block UI and then calls `selectBlock`, the latter doesn't and retains focus). Selecting a classic menu also works differently to a navigation menu, so there are four different behaviors, and this is the most concise way to handle that.
- Simplifies some code. For example the `NavigationMenuSelector` previously did an `Array.find` to find the correct menu item, however this is unnecessary as only the `id` is needed to update the `ref` attribute of the block.
- Removes some `useCallback` hooks. All of these JavaScript functions are very simple and don't do any computation, so `useCallback` isn't needed.
- Removes the need to check if the menu is classic or not using the `auto_add` property, which is potentially brittle if the data returned from the REST API for classic menus changes or navigation menus ever get an `auto_add` property themselves.

## How?
Changes the way the callbacks work for the Navigation Menu selector. The component now has two callbacks, `onSelectNavigationMenu` and `onSelectClassicMenu`.

## Testing Instructions
1. Open the site/post editor
2. Select and existing navigation block (or insert a new one and select an initial menu)
3. Try switching menus using the toolbar dropdown
4. This PR should behave the same as `trunk`.