### PR TITLE
[Mobile] - Fix dynamic React Native version

### DIFF
--- a/packages/react-native-editor/android/app/build.gradle
+++ b/packages/react-native-editor/android/app/build.gradle
@@ -170,16 +170,17 @@ android {
 }
 
 dependencies {
+    def packageJson = '../../package.json'
+
     implementation("org.wordpress-mobile.gutenberg-mobile:react-native-bridge", {
         exclude group: 'org.wordpress', module: 'utils'
     })
     implementation 'androidx.appcompat:appcompat:1.2.0'
     //noinspection GradleDynamicVersion
-    implementation "com.facebook.react:react-native:+"  // From node_modules
+    implementation "com.facebook.react:react-native:${extractPackageVersion(packageJson, 'react-native', 'dependencies')}" // From node_modules
 
     implementation "androidx.swiperefreshlayout:swiperefreshlayout:1.0.0"
 
-    def packageJson = '../../package.json'
     implementation "org.wordpress-mobile:react-native-svg:${extractPackageVersion(packageJson, 'react-native-svg', 'dependencies')}"
     implementation "com.github.wordpress-mobile:react-native-video:${extractPackageVersion(packageJson, 'react-native-video', 'dependencies')}"
     implementation "com.github.wordpress-mobile:react-native-linear-gradient:${extractPackageVersion(packageJson, 'react-native-linear-gradient', 'dependencies')}"

--- a/packages/react-native-editor/android/gradle.properties
+++ b/packages/react-native-editor/android/gradle.properties
@@ -11,6 +11,7 @@
 # The setting is particularly useful for tweaking memory settings.
 # Default value: -Xmx10248m -XX:MaxPermSize=256m
 # org.gradle.jvmargs=-Xmx2048m -XX:MaxPermSize=512m -XX:+HeapDumpOnOutOfMemoryError -Dfile.encoding=UTF-8
+org.gradle.jvmargs=-Xmx6g -XX:+HeapDumpOnOutOfMemoryError
 
 # When configured, Gradle will run in incubating parallel mode.
 # This option should only be used with decoupled projects. More details, visit


### PR DESCRIPTION
## What?
The E2E tests started to fail in `trunk` after a newer React Native version was deployed in the `react-native-mirror-publisher` repo.

## Why?
While we are working on the React Native Upgrade, we deployed a newer version that started being pulled into the latest trunk when it shouldn't. Since we weren't setting a specific version like we are doing for [react-native-aztec](https://github.com/WordPress/gutenberg/blob/trunk/packages/react-native-aztec/android/build.gradle#L98) and [react-native-bridge](https://github.com/WordPress/gutenberg/blob/trunk/packages/react-native-bridge/android/react-native-bridge/build.gradle#L66).

## How?
Now it will fetch the current React Native version from the `package.json` file.

It also sets the `org.gradle.jvmargs` configuration to prevent `outOfMemory` errors. This matches the [current setting](https://github.com/wordpress-mobile/WordPress-Android/blob/trunk/gradle.properties-example#L5) WordPress Android has.

## Testing Instructions
E2E should pass correctly

## Screenshots or screencast <!-- if applicable -->
N/A