### PR TITLE
Fixed broken external link to Mozilla Developer Docs

### DIFF
--- a/docs/reference-guides/block-api/block-attributes.md
+++ b/docs/reference-guides/block-api/block-attributes.md
@@ -250,7 +250,7 @@ Attribute available in the block:
 
 ### `html` source
 
-Use `html` to extract the inner HTML from markup. Note that text is returned according to the rules of [`innerHTML`](https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/innerHTML).
+Use `html` to extract the inner HTML from markup. Note that text is returned according to the rules of [`innerHTML`](https://developer.mozilla.org/en-US/docs/Web/API/Element/innerHTML).
 
 Saved content:
 ```html


### PR DESCRIPTION
Replaced broken external link to Mozilla Developer docs- Line 253

<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->
Removed broken link to developer.mozilla.org with the correct one: https://developer.mozilla.org/en-US/docs/Web/API/Element/innerHTML
## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
Removing a link that no longer exists and replacing with the correct one.
## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
Removing a link that no longer exists and replacing with the correct one.
## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->
Navigate to https://developer.wordpress.org/block-editor/reference-guides/block-api/block-attributes/#html-source and visit the external link. It forwards to a 404 page.
## Screenshots or screencast <!-- if applicable -->
