### PR TITLE
Gallery: register styles with style engine

### DIFF
--- a/lib/compat/wordpress-6.1/script-loader.php
+++ b/lib/compat/wordpress-6.1/script-loader.php
@@ -19,10 +19,14 @@
  *
  * @link https://core.trac.wordpress.org/ticket/53494.
  *
+ * @deprecated 6.1 Block supports styles are now stored for enqueuing via the style engine API. See: packages/style-engine/README.md.
+ *
  * @param string $style String containing the CSS styles to be added.
  * @param int    $priority To set the priority for the add_action.
  */
 function gutenberg_enqueue_block_support_styles( $style, $priority = 10 ) {
+	_deprecated_function( __FUNCTION__, '6.1' );
+
 	$action_hook_name = 'wp_footer';
 	if ( wp_is_block_theme() ) {
 		$action_hook_name = 'wp_head';

--- a/lib/compat/wordpress-6.1/script-loader.php
+++ b/lib/compat/wordpress-6.1/script-loader.php
@@ -6,41 +6,6 @@
  */
 
 /**
- * This function takes care of adding inline styles
- * in the proper place, depending on the theme in use.
- *
- * This method was added to core in 5.9.1, but with a single param ($style). The second param ($priority) was
- * added post 6.0, so the 6.1 release needs to have wp_enqueue_block_support_styles updated to include this param.
- *
- * For block themes, it's loaded in the head.
- * For classic ones, it's loaded in the body
- * because the wp_head action  happens before
- * the render_block.
- *
- * @link https://core.trac.wordpress.org/ticket/53494.
- *
- * @deprecated 6.1 Block supports styles are now stored for enqueuing via the style engine API. See: packages/style-engine/README.md.
- *
- * @param string $style String containing the CSS styles to be added.
- * @param int    $priority To set the priority for the add_action.
- */
-function gutenberg_enqueue_block_support_styles( $style, $priority = 10 ) {
-	_deprecated_function( __FUNCTION__, '6.1' );
-
-	$action_hook_name = 'wp_footer';
-	if ( wp_is_block_theme() ) {
-		$action_hook_name = 'wp_head';
-	}
-	add_action(
-		$action_hook_name,
-		static function () use ( $style ) {
-			echo "<style>$style</style>\n";
-		},
-		$priority
-	);
-}
-
-/**
  * This applies a filter to the list of style nodes that comes from `get_style_nodes` in WP_Theme_JSON.
  * This particular filter removes all of the blocks from the array.
  *

--- a/lib/compat/wordpress-6.2/script-loader.php
+++ b/lib/compat/wordpress-6.2/script-loader.php
@@ -28,3 +28,38 @@ function gutenberg_register_vendor_scripts_62( $scripts ) {
 	$script->deps = array_merge( $script->deps, array( 'wp-inert-polyfill' ) );
 }
 add_action( 'wp_default_scripts', 'gutenberg_register_vendor_scripts_62' );
+
+/**
+ * This function takes care of adding inline styles
+ * in the proper place, depending on the theme in use.
+ *
+ * This method was added to core in 5.9.1, but with a single param ($style). The second param ($priority) was
+ * added post 6.0, so the 6.1 release needs to have wp_enqueue_block_support_styles updated to include this param.
+ *
+ * For block themes, it's loaded in the head.
+ * For classic ones, it's loaded in the body
+ * because the wp_head action  happens before
+ * the render_block.
+ *
+ * @link https://core.trac.wordpress.org/ticket/53494.
+ *
+ * @deprecated 6.2 Block supports styles are now stored for enqueuing via the style engine API. See: packages/style-engine/README.md.
+ *
+ * @param string $style String containing the CSS styles to be added.
+ * @param int    $priority To set the priority for the add_action.
+ */
+function gutenberg_enqueue_block_support_styles( $style, $priority = 10 ) {
+	_deprecated_function( __FUNCTION__, '6.2' );
+
+	$action_hook_name = 'wp_footer';
+	if ( wp_is_block_theme() ) {
+		$action_hook_name = 'wp_head';
+	}
+	add_action(
+		$action_hook_name,
+		static function () use ( $style ) {
+			echo "<style>$style</style>\n";
+		},
+		$priority
+	);
+}

--- a/packages/block-library/src/gallery/index.php
+++ b/packages/block-library/src/gallery/index.php
@@ -102,9 +102,22 @@ function block_core_gallery_render( $attributes, $content ) {
 	}
 
 	// Set the CSS variable to the column value, and the `gap` property to the combined gap value.
-	$style = '.wp-block-gallery.' . $class . '{ --wp--style--unstable-gallery-gap: ' . $gap_column . '; gap: ' . $gap_value . '}';
+	$gallery_styles   = array();
+	$gallery_styles[] = array(
+		'selector'     => ".wp-block-gallery.{$class}",
+		'declarations' => array(
+			'--wp--style--unstable-gallery-gap' => $gap_column,
+			'gap'                               => $gap_value,
+		),
+	);
 
-	wp_enqueue_block_support_styles( $style, 11 );
+	gutenberg_style_engine_get_stylesheet_from_css_rules(
+		$gallery_styles,
+		array(
+			'context' => 'block-supports',
+			'enqueue' => true,
+		)
+	);
 	return $content;
 }
 /**

--- a/packages/block-library/src/gallery/index.php
+++ b/packages/block-library/src/gallery/index.php
@@ -115,7 +115,6 @@ function block_core_gallery_render( $attributes, $content ) {
 		$gallery_styles,
 		array(
 			'context' => 'block-supports',
-			'enqueue' => true,
 		)
 	);
 	return $content;

--- a/packages/block-library/src/gallery/index.php
+++ b/packages/block-library/src/gallery/index.php
@@ -76,13 +76,10 @@ function block_core_gallery_render( $attributes, $content ) {
 		}
 	}
 
-	$class   = wp_unique_id( 'wp-block-gallery-' );
-	$content = preg_replace(
-		'/' . preg_quote( 'class="', '/' ) . '/',
-		'class="' . $class . ' ',
-		$content,
-		1
-	);
+	$unique_gallery_classname = wp_unique_id( 'wp-block-gallery-' );
+	$processed_content        = new WP_HTML_Tag_Processor( $content );
+	$processed_content->next_tag();
+	$processed_content->add_class( $unique_gallery_classname );
 
 	// --gallery-block--gutter-size is deprecated. --wp--style--gallery-gap-default should be used by themes that want to set a default
 	// gap on the gallery.
@@ -104,7 +101,7 @@ function block_core_gallery_render( $attributes, $content ) {
 	// Set the CSS variable to the column value, and the `gap` property to the combined gap value.
 	$gallery_styles   = array();
 	$gallery_styles[] = array(
-		'selector'     => ".wp-block-gallery.{$class}",
+		'selector'     => ".wp-block-gallery.{$unique_gallery_classname}",
 		'declarations' => array(
 			'--wp--style--unstable-gallery-gap' => $gap_column,
 			'gap'                               => $gap_value,
@@ -117,7 +114,7 @@ function block_core_gallery_render( $attributes, $content ) {
 			'context' => 'block-supports',
 		)
 	);
-	return $content;
+	return (string) $processed_content;
 }
 /**
  * Registers the `core/gallery` block on server.


### PR DESCRIPTION
Depends on:

- https://github.com/WordPress/gutenberg/pull/43071
- https://github.com/WordPress/gutenberg/pull/44962

## What?
Update gallery to use style engine enqueuing, and also `WP_HTML_Tag_Processor` to add the unique class.

## Why?

- To batch styles in one style tag.
- Also, `gutenberg_enqueue_block_support_styles()` will soon be deprecated.

## Testing Instructions

Since https://core.trac.wordpress.org/ticket/56353 WordPress supports CSS custom vars. It will be shipped with 6.1. 

For sites running < 6.1 Gutenberg allows specific CSS properties only. See: https://github.com/WordPress/gutenberg/pull/43071


1. Create a new gallery, add your favourite holiday pics.
2. Apply a block gap value to your gallery and publish!
3. Check that your gallery appears as you'd expect it to on the frontend, and that it has the following styles (with your block gap value):

```html
<style id='block-supports-inline-css'>
/* ...some styles */
.wp-block-gallery.wp-block-gallery-1 {
	--wp--style--unstable-gallery-gap: 107px;
	gap: 107px;
}
/* ...some styles */
</style>
```

Test in classic and block themes.

<img width="500" alt="Screen Shot 2022-08-09 at 10 09 43 am" src="https://user-images.githubusercontent.com/6458278/183535489-91d194f2-c651-4fa9-8b33-10d73f9b99a2.png">

