### PR TITLE
Style engine: permit wp custom CSS properties

### DIFF
--- a/packages/style-engine/class-wp-style-engine-css-declarations.php
+++ b/packages/style-engine/class-wp-style-engine-css-declarations.php
@@ -17,6 +17,21 @@ if ( class_exists( 'WP_Style_Engine_CSS_Declarations' ) ) {
  * @access private
  */
 class WP_Style_Engine_CSS_Declarations {
+	/**
+	 * An array of valid CSS custom properties.
+	 * CSS custom properties are permitted by safecss_filter_attr()
+	 * since WordPress 6.1. See: https://core.trac.wordpress.org/ticket/56353.
+	 *
+	 * This whitelist exists so that the Gutenberg plugin maintains
+	 * backwards compatibility with versions of WordPress < 6.1.
+	 *
+	 * It does not need to be backported to future versions of WordPress.
+	 *
+	 * @var array
+	 */
+	const VALID_CUSTOM_PROPERTIES = array(
+		'--wp--style--unstable-gallery-gap',
+	);
 
 	/**
 	 * An array of CSS declarations (property => value pairs).
@@ -125,6 +140,22 @@ class WP_Style_Engine_CSS_Declarations {
 	 */
 	protected static function filter_declaration( $property, $value, $spacer = '' ) {
 		$filtered_value = wp_strip_all_tags( $value, true );
+
+		/**
+		 * Allows CSS custom properties starting with `--wp--`.
+		 *
+		 * CSS custom properties are permitted by safecss_filter_attr()
+		 * since WordPress 6.1. See: https://core.trac.wordpress.org/ticket/56353.
+		 *
+		 * This condition exists so that the Gutenberg plugin maintains
+		 * backwards compatibility with versions of WordPress < 6.1.
+		 *
+		 * It does not need to be backported to future versions of WordPress.
+		 */
+		if ( in_array( $property, static::VALID_CUSTOM_PROPERTIES, true ) ) {
+			return "{$property}:{$spacer}{$filtered_value}";
+		}
+
 		if ( '' !== $filtered_value ) {
 			return safecss_filter_attr( "{$property}:{$spacer}{$filtered_value}" );
 		}

--- a/packages/style-engine/class-wp-style-engine-css-declarations.php
+++ b/packages/style-engine/class-wp-style-engine-css-declarations.php
@@ -29,8 +29,8 @@ class WP_Style_Engine_CSS_Declarations {
 	 *
 	 * @var array
 	 */
-	const VALID_CUSTOM_PROPERTIES = array(
-		'--wp--style--unstable-gallery-gap',
+	protected static $valid_custom_declarations = array(
+		'--wp--style--unstable-gallery-gap' => 'gap',
 	);
 
 	/**
@@ -142,7 +142,7 @@ class WP_Style_Engine_CSS_Declarations {
 		$filtered_value = wp_strip_all_tags( $value, true );
 
 		/**
-		 * Allows CSS custom properties starting with `--wp--`.
+		 * Allows a specific list of CSS custom properties starting with `--wp--`.
 		 *
 		 * CSS custom properties are permitted by safecss_filter_attr()
 		 * since WordPress 6.1. See: https://core.trac.wordpress.org/ticket/56353.
@@ -152,8 +152,9 @@ class WP_Style_Engine_CSS_Declarations {
 		 *
 		 * It does not need to be backported to future versions of WordPress.
 		 */
-		if ( in_array( $property, static::VALID_CUSTOM_PROPERTIES, true ) ) {
-			return "{$property}:{$spacer}{$filtered_value}";
+		if ( isset( static::$valid_custom_declarations[ $property ] ) ) {
+			return safecss_filter_attr( static::$valid_custom_declarations[ $property ] . ":{$spacer}{$value}" ) ?
+				"{$property}:{$spacer}{$value}" : '';
 		}
 
 		if ( '' !== $filtered_value ) {

--- a/packages/style-engine/class-wp-style-engine-css-declarations.php
+++ b/packages/style-engine/class-wp-style-engine-css-declarations.php
@@ -152,7 +152,7 @@ class WP_Style_Engine_CSS_Declarations {
 		 *
 		 * It does not need to be backported to future versions of WordPress.
 		 */
-		if ( isset( static::$valid_custom_declarations[ $property ] ) ) {
+		if ( '' !== $filtered_value && isset( static::$valid_custom_declarations[ $property ] ) ) {
 			return safecss_filter_attr( static::$valid_custom_declarations[ $property ] . ":{$spacer}{$value}" ) ?
 				"{$property}:{$spacer}{$value}" : '';
 		}

--- a/phpunit/style-engine/class-wp-style-engine-css-declarations-test.php
+++ b/phpunit/style-engine/class-wp-style-engine-css-declarations-test.php
@@ -121,22 +121,24 @@ class WP_Style_Engine_CSS_Declarations_Test extends WP_UnitTestCase {
 
 
 	/**
-	 * Tests that calc, clamp, min, max, and minmax CSS functions are allowed.
+	 * Tests that calc, clamp, min, max, minmax CSS functions and --wp--* CSS custom properties are allowed.
 	 *
 	 * @covers ::get_declarations_string
 	 * @covers ::filter_declaration
 	 */
 	public function test_should_allow_css_functions_and_strip_unsafe_css_values() {
 		$input_declarations                        = array(
-			'background'       => 'var(--wp--preset--color--primary, 10px)', // Simple var().
-			'font-size'        => 'clamp(36.00rem, calc(32.00rem + 10.00vw), 40.00rem)', // Nested clamp().
-			'width'            => 'min(150vw, 100px)',
-			'min-width'        => 'max(150vw, 100px)',
-			'max-width'        => 'minmax(400px, 50%)',
-			'padding'          => 'calc(80px * -1)',
-			'background-image' => 'url("https://wordpress.org")',
-			'line-height'      => 'url("https://wordpress.org")',
-			'margin'           => 'illegalfunction(30px)',
+			'background'                        => 'var(--wp--preset--color--primary, 10px)', // Simple var().
+			'font-size'                         => 'clamp(36.00rem, calc(32.00rem + 10.00vw), 40.00rem)', // Nested clamp().
+			'width'                             => 'min(150vw, 100px)',
+			'min-width'                         => 'max(150vw, 100px)',
+			'max-width'                         => 'minmax(400px, 50%)',
+			'padding'                           => 'calc(80px * -1)',
+			'background-image'                  => 'url("https://wordpress.org")',
+			'line-height'                       => 'url("https://wordpress.org")',
+			'margin'                            => 'illegalfunction(30px)',
+			'--wp--style--unstable-gallery-gap' => '12em',
+			'/::border-[<width>]'               => '2000.75em',
 		);
 		$css_declarations                          = new WP_Style_Engine_CSS_Declarations_Gutenberg( $input_declarations );
 		$safecss_filter_attr_allow_css_mock_action = new MockAction();
@@ -146,13 +148,13 @@ class WP_Style_Engine_CSS_Declarations_Test extends WP_UnitTestCase {
 		$css_declarations_string = $css_declarations->get_declarations_string();
 
 		$this->assertSame(
-			9,
+			11,
 			$safecss_filter_attr_allow_css_mock_action->get_call_count(),
 			'"safecss_filter_attr_allow_css" filters were not applied to CSS declaration values.'
 		);
 
 		$this->assertSame(
-			'background:var(--wp--preset--color--primary, 10px);font-size:clamp(36.00rem, calc(32.00rem + 10.00vw), 40.00rem);width:min(150vw, 100px);min-width:max(150vw, 100px);max-width:minmax(400px, 50%);padding:calc(80px * -1);background-image:url("https://wordpress.org");',
+			'background:var(--wp--preset--color--primary, 10px);font-size:clamp(36.00rem, calc(32.00rem + 10.00vw), 40.00rem);width:min(150vw, 100px);min-width:max(150vw, 100px);max-width:minmax(400px, 50%);padding:calc(80px * -1);background-image:url("https://wordpress.org");--wp--style--unstable-gallery-gap:12em;border-width:2000.75em;',
 			$css_declarations_string,
 			'Unsafe values were not removed'
 		);
@@ -212,26 +214,6 @@ class WP_Style_Engine_CSS_Declarations_Test extends WP_UnitTestCase {
 				'should_prettify' => true,
 				'indent_count'    => 2,
 			),
-		);
-	}
-
-	/**
-	 * Tests allows --wp--* CSS custom properties.
-	 */
-	public function test_should_allow_wp_custom_properties() {
-		$input_declarations = array(
-			'--wp--love-your-work'                => 'url("https://wordpress.org")',
-			'--wp--style--unstable-gallery-gap'   => '12em',
-			'--wp-yeah-nah'                       => '100%',
-			'--wp--preset--here-is-a-potato'      => '88px',
-			'--wp--style--/::target-[<nonsense>]' => '2000.75em',
-			'--wp--style--block-gap'              => '2em',
-		);
-		$css_declarations   = new WP_Style_Engine_CSS_Declarations( $input_declarations );
-
-		$this->assertSame(
-			'--wp--style--unstable-gallery-gap:12em;',
-			$css_declarations->get_declarations_string()
 		);
 	}
 

--- a/phpunit/style-engine/class-wp-style-engine-css-declarations-test.php
+++ b/phpunit/style-engine/class-wp-style-engine-css-declarations-test.php
@@ -216,6 +216,26 @@ class WP_Style_Engine_CSS_Declarations_Test extends WP_UnitTestCase {
 	}
 
 	/**
+	 * Tests allows --wp--* CSS custom properties.
+	 */
+	public function test_should_allow_wp_custom_properties() {
+		$input_declarations = array(
+			'--wp--love-your-work'                => 'url("https://wordpress.org")',
+			'--wp--style--unstable-gallery-gap'   => '12em',
+			'--wp-yeah-nah'                       => '100%',
+			'--wp--preset--here-is-a-potato'      => '88px',
+			'--wp--style--/::target-[<nonsense>]' => '2000.75em',
+			'--wp--style--block-gap'              => '2em',
+		);
+		$css_declarations   = new WP_Style_Engine_CSS_Declarations( $input_declarations );
+
+		$this->assertSame(
+			'--wp--style--unstable-gallery-gap:12em;',
+			$css_declarations->get_declarations_string()
+		);
+	}
+
+	/**
 	 * Tests removing a single declaration.
 	 *
 	 * @covers ::remove_declaration

--- a/phpunit/style-engine/class-wp-style-engine-css-declarations-test.php
+++ b/phpunit/style-engine/class-wp-style-engine-css-declarations-test.php
@@ -121,12 +121,12 @@ class WP_Style_Engine_CSS_Declarations_Test extends WP_UnitTestCase {
 
 
 	/**
-	 * Tests that calc, clamp, min, max, minmax CSS functions and --wp--* CSS custom properties are allowed.
+	 * Tests that calc, clamp, min, max, minmax CSS functions and CSS custom properties are allowed.
 	 *
 	 * @covers ::get_declarations_string
 	 * @covers ::filter_declaration
 	 */
-	public function test_should_allow_css_functions_and_strip_unsafe_css_values() {
+	public function test_should_allow_css_functions_and_custom_properties_and_strip_unsafe_css_values() {
 		$input_declarations                        = array(
 			'background'                        => 'var(--wp--preset--color--primary, 10px)', // Simple var().
 			'font-size'                         => 'clamp(36.00rem, calc(32.00rem + 10.00vw), 40.00rem)', // Nested clamp().


### PR DESCRIPTION
## What?
A slight variation on @aristath's idea to add a [custom CSS property check in the style engine](https://github.com/WordPress/gutenberg/pull/42968/files#diff-61444ce62da486f16b8c34c539914f066258bb42d46c46495dac5733d7939e10R134).

## How
Adds an array `VALID_CUSTOM_PROPERTIES` of valid CSS custom properties to check against.

## Why?
CSS custom properties don't pass the tests in `safecss_filter_attr()` at [if ( in_array( $css_selector, $allowed_attr, true ) ) {](https://github.com/WordPress/wordpress-develop/blob/cab053271e272a21b4d140e50ac0d6a78094ecd5/src/wp-includes/kses.php#L2429).


## Testing Instructions

Run
```bash
npm run test:unit:php /var/www/html/wp-content/plugins/gutenberg/packages/style-engine/phpunit/class-wp-style-engine-css-declarations-test.php
```
