### PR TITLE
Font size picker: use t-shirt sizes for the ToggleGroupControl component

### DIFF
--- a/packages/components/src/font-size-picker/index.js
+++ b/packages/components/src/font-size-picker/index.js
@@ -22,6 +22,7 @@ import {
 import {
 	getFontSizeOptions,
 	getSelectedOption,
+	splitValueAndUnitFromSize,
 	isSimpleCssValue,
 	CUSTOM_FONT_SIZE,
 } from './utils';
@@ -53,6 +54,9 @@ function FontSizePicker(
 	 * The main font size UI displays a toggle group when the presets are less
 	 * than six and a select control when they are more.
 	 */
+	const fontSizesContainComplexValues = fontSizes.some(
+		( { size: sizeArg } ) => ! isSimpleCssValue( sizeArg )
+	);
 	const shouldUseSelectControl = fontSizes.length > 5;
 	const options = useMemo(
 		() =>
@@ -84,8 +88,17 @@ function FontSizePicker(
 				`(${ selectedOption?.size })`
 			);
 		}
-		// The `hint` for toggle group control.
-		return selectedOption.label;
+
+		// Calculate the `hint` for toggle group control.
+		let hint = selectedOption.name;
+		if (
+			! fontSizesContainComplexValues &&
+			typeof selectedOption.size === 'string'
+		) {
+			const [ , unit ] = splitValueAndUnitFromSize( selectedOption.size );
+			hint += `(${ unit })`;
+		}
+		return hint;
 	}, [
 		showCustomValueControl,
 		selectedOption?.name,
@@ -93,6 +106,7 @@ function FontSizePicker(
 		value,
 		isCustomValue,
 		shouldUseSelectControl,
+		fontSizesContainComplexValues,
 	] );
 
 	if ( ! options ) {

--- a/packages/components/src/font-size-picker/index.js
+++ b/packages/components/src/font-size-picker/index.js
@@ -85,7 +85,7 @@ function FontSizePicker(
 			);
 		}
 		// The `hint` for toggle group control.
-		return selectedOption.name;
+		return selectedOption.label;
 	}, [
 		showCustomValueControl,
 		selectedOption?.name,

--- a/packages/components/src/font-size-picker/index.js
+++ b/packages/components/src/font-size-picker/index.js
@@ -22,7 +22,6 @@ import {
 import {
 	getFontSizeOptions,
 	getSelectedOption,
-	splitValueAndUnitFromSize,
 	isSimpleCssValue,
 	CUSTOM_FONT_SIZE,
 } from './utils';
@@ -54,24 +53,15 @@ function FontSizePicker(
 	 * The main font size UI displays a toggle group when the presets are less
 	 * than six and a select control when they are more.
 	 */
-	const fontSizesContainComplexValues = fontSizes.some(
-		( { size: sizeArg } ) => ! isSimpleCssValue( sizeArg )
-	);
 	const shouldUseSelectControl = fontSizes.length > 5;
 	const options = useMemo(
 		() =>
 			getFontSizeOptions(
 				shouldUseSelectControl,
 				fontSizes,
-				disableCustomFontSizes,
-				fontSizesContainComplexValues
+				disableCustomFontSizes
 			),
-		[
-			shouldUseSelectControl,
-			fontSizes,
-			disableCustomFontSizes,
-			fontSizesContainComplexValues,
-		]
+		[ shouldUseSelectControl, fontSizes, disableCustomFontSizes ]
 	);
 	const selectedOption = getSelectedOption( fontSizes, value );
 	const isCustomValue = selectedOption.slug === CUSTOM_FONT_SIZE;
@@ -94,16 +84,8 @@ function FontSizePicker(
 				`(${ selectedOption?.size })`
 			);
 		}
-		// Calculate the `hint` for toggle group control.
-		let hint = selectedOption.name;
-		if (
-			! fontSizesContainComplexValues &&
-			typeof selectedOption.size === 'string'
-		) {
-			const [ , unit ] = splitValueAndUnitFromSize( selectedOption.size );
-			hint += `(${ unit })`;
-		}
-		return hint;
+		// The `hint` for toggle group control.
+		return selectedOption.name;
 	}, [
 		showCustomValueControl,
 		selectedOption?.name,
@@ -111,7 +93,6 @@ function FontSizePicker(
 		value,
 		isCustomValue,
 		shouldUseSelectControl,
-		fontSizesContainComplexValues,
 	] );
 
 	if ( ! options ) {

--- a/packages/components/src/font-size-picker/test/index.js
+++ b/packages/components/src/font-size-picker/test/index.js
@@ -205,7 +205,7 @@ describe( 'FontSizePicker', () => {
 				expect( element ).toBeInTheDocument();
 				expect( element.children[ 0 ].textContent ).toBe( 'L' );
 			} );
-			it( 'should use incremental sequence of t-shirt as labels if we have complex css', () => {
+			it( 'should use incremental sequence of t-shirt sizes as labels if we have complex css', () => {
 				const fontSizes = [
 					...options,
 					{
@@ -222,7 +222,7 @@ describe( 'FontSizePicker', () => {
 				);
 				const largeElement = screen.getByLabelText( 'Large' );
 				expect( largeElement ).toBeInTheDocument();
-				expect( largeElement.children[ 0 ].textContent ).toBe( 'L' );
+				expect( largeElement ).toHaveTextContent( 'L' );
 
 				const extraLargeElement =
 					screen.getByLabelText( 'Extra Large' );

--- a/packages/components/src/font-size-picker/test/index.js
+++ b/packages/components/src/font-size-picker/test/index.js
@@ -193,7 +193,7 @@ describe( 'FontSizePicker', () => {
 			expect( element ).toHaveLength( fontSizes.length + 2 );
 		} );
 		describe( 'segmented control', () => {
-			it( 'should use numeric labels for simple css values', () => {
+			it( 'should use t-shirt labels for simple css values', () => {
 				const fontSizes = [ ...options ];
 				render(
 					<FontSizePicker
@@ -203,9 +203,9 @@ describe( 'FontSizePicker', () => {
 				);
 				const element = screen.getByLabelText( 'Large' );
 				expect( element ).toBeInTheDocument();
-				expect( element.children[ 0 ].textContent ).toBe( '1.7' );
+				expect( element.children[ 0 ].textContent ).toBe( 'L' );
 			} );
-			it( 'should use incremental sequence of numbers as labels if we have complex css', () => {
+			it( 'should use incremental sequence of t-shirt as labels if we have complex css', () => {
 				const fontSizes = [
 					...options,
 					{
@@ -220,9 +220,16 @@ describe( 'FontSizePicker', () => {
 						value={ fontSizes[ 0 ].size }
 					/>
 				);
-				const element = screen.getByLabelText( 'Large' );
-				expect( element ).toBeInTheDocument();
-				expect( element.children[ 0 ].textContent ).toBe( '3' );
+				const largeElement = screen.getByLabelText( 'Large' );
+				expect( largeElement ).toBeInTheDocument();
+				expect( largeElement.children[ 0 ].textContent ).toBe( 'L' );
+
+				const extraLargeElement =
+					screen.getByLabelText( 'Extra Large' );
+				expect( extraLargeElement ).toBeInTheDocument();
+				expect( extraLargeElement.children[ 0 ].textContent ).toBe(
+					'XL'
+				);
 			} );
 		} );
 	} );

--- a/packages/components/src/font-size-picker/test/utils.js
+++ b/packages/components/src/font-size-picker/test/utils.js
@@ -1,7 +1,11 @@
 /**
  * Internal dependencies
  */
-import { isSimpleCssValue, splitValueAndUnitFromSize } from '../utils';
+import {
+	isSimpleCssValue,
+	splitValueAndUnitFromSize,
+	getToggleGroupOptions,
+} from '../utils';
 
 const simpleCSSCases = [
 	// Test integers and non-integers.
@@ -71,4 +75,87 @@ describe( 'splitValueAndUnitFromSize', () => {
 			expect( unit ).toBe( expectedUnit );
 		}
 	);
+} );
+
+describe( 'getToggleGroupOptions', () => {
+	test( 'should assign t-shirt sizes by default up until the aliases length', () => {
+		const optionsArray = [
+			{
+				slug: '1',
+				size: '1',
+				name: '1',
+			},
+			{
+				slug: '2',
+				size: '2',
+				name: '2',
+			},
+			{
+				slug: '3',
+				size: '3',
+				name: '3',
+			},
+			{
+				slug: '4',
+				size: '4',
+				name: '4',
+			},
+			{
+				slug: '5',
+				size: '5',
+				name: '5',
+			},
+			{
+				slug: '6',
+				size: '6px',
+				name: '6',
+			},
+		];
+		expect(
+			getToggleGroupOptions( optionsArray, [
+				'S',
+				'M',
+				'L',
+				'XL',
+				'XXL',
+			] )
+		).toEqual( [
+			{
+				key: '1',
+				value: '1',
+				label: 'S',
+				name: '1',
+			},
+			{
+				key: '2',
+				value: '2',
+				label: 'M',
+				name: '2',
+			},
+			{
+				key: '3',
+				value: '3',
+				label: 'L',
+				name: '3',
+			},
+			{
+				key: '4',
+				value: '4',
+				label: 'XL',
+				name: '4',
+			},
+			{
+				key: '5',
+				value: '5',
+				label: 'XXL',
+				name: '5',
+			},
+			{
+				key: '6',
+				value: '6px',
+				label: '6px',
+				name: '6',
+			},
+		] );
+	} );
 } );

--- a/packages/components/src/font-size-picker/test/utils.js
+++ b/packages/components/src/font-size-picker/test/utils.js
@@ -105,11 +105,6 @@ describe( 'getToggleGroupOptions', () => {
 				size: '5',
 				name: '5',
 			},
-			{
-				slug: '6',
-				size: '6px',
-				name: '6',
-			},
 		];
 		expect(
 			getToggleGroupOptions( optionsArray, [
@@ -149,12 +144,6 @@ describe( 'getToggleGroupOptions', () => {
 				value: '5',
 				label: 'XXL',
 				name: '5',
-			},
-			{
-				key: '6',
-				value: '6px',
-				label: '6px',
-				name: '6',
 			},
 		] );
 	} );

--- a/packages/components/src/font-size-picker/utils.js
+++ b/packages/components/src/font-size-picker/utils.js
@@ -15,13 +15,11 @@ const CUSTOM_FONT_SIZE_OPTION = {
 };
 
 /**
- * In case we have at most five font sizes, where at least one the them
- * contain a complex css value(clamp, var, etc..) show a incremental sequence
- * of numbers as a label of the font size. We do this because complex css values
- * cannot be caluclated properly and the incremental sequence of numbers as labels
- * can help the user better mentally map the different available font sizes.
+ * In case we have at most five font sizes, show a `T-shirt size`
+ * alias as a label of the font size. The label assumes that the font sizes
+ * are ordered accordingly - from smallest to largest.
  */
-const FONT_SIZES_ALIASES = [ '1', '2', '3', '4', '5' ];
+const FONT_SIZES_ALIASES = [ 'S', 'M', 'L', 'XL', 'XXL' ];
 
 /**
  * Helper util to split a font size to its numeric value
@@ -59,21 +57,19 @@ export function isSimpleCssValue( value ) {
  * @param {boolean}  useSelectControl               Whether to use a select control.
  * @param {Object[]} optionsArray                   Array of available font sizes objects.
  * @param {*}        disableCustomFontSizes         Flag that indicates if custom font sizes are disabled.
- * @param {boolean}  optionsContainComplexCssValues Whether font sizes contain at least one complex css value(clamp, var, etc..).
  * @return {Object[]|null} Array of font sizes in proper format for the used control.
  */
 export function getFontSizeOptions(
 	useSelectControl,
 	optionsArray,
-	disableCustomFontSizes,
-	optionsContainComplexCssValues
+	disableCustomFontSizes
 ) {
 	if ( disableCustomFontSizes && ! optionsArray.length ) {
 		return null;
 	}
 	return useSelectControl
 		? getSelectOptions( optionsArray, disableCustomFontSizes )
-		: getToggleGroupOptions( optionsArray, optionsContainComplexCssValues );
+		: getToggleGroupOptions( optionsArray );
 }
 
 function getSelectOptions( optionsArray, disableCustomFontSizes ) {
@@ -91,16 +87,14 @@ function getSelectOptions( optionsArray, disableCustomFontSizes ) {
 	} ) );
 }
 
-function getToggleGroupOptions( optionsArray, optionsContainComplexCssValues ) {
+function getToggleGroupOptions( optionsArray ) {
 	return optionsArray.map( ( { slug, size, name }, index ) => {
-		let label = optionsContainComplexCssValues
-			? FONT_SIZES_ALIASES[ index ]
-			: size;
-		if ( ! optionsContainComplexCssValues && typeof size === 'string' ) {
-			const [ numericValue ] = splitValueAndUnitFromSize( size );
-			label = numericValue;
-		}
-		return { key: slug, value: size, label, name };
+		return {
+			key: slug,
+			value: size,
+			label: FONT_SIZES_ALIASES[ index ],
+			name,
+		};
 	} );
 }
 

--- a/packages/components/src/font-size-picker/utils.js
+++ b/packages/components/src/font-size-picker/utils.js
@@ -87,12 +87,22 @@ function getSelectOptions( optionsArray, disableCustomFontSizes ) {
 	} ) );
 }
 
-function getToggleGroupOptions( optionsArray ) {
+/**
+ * Build options for the toggle group options.
+ *
+ * @param {Array}    optionsArray An array of font size options.
+ * @param {string[]} labelAliases An array of alternative labels.
+ * @return {Array}   Remapped optionsArray.
+ */
+export function getToggleGroupOptions(
+	optionsArray,
+	labelAliases = FONT_SIZES_ALIASES
+) {
 	return optionsArray.map( ( { slug, size, name }, index ) => {
 		return {
 			key: slug,
 			value: size,
-			label: FONT_SIZES_ALIASES[ index ],
+			label: labelAliases[ index ] || size,
 			name,
 		};
 	} );

--- a/packages/components/src/font-size-picker/utils.js
+++ b/packages/components/src/font-size-picker/utils.js
@@ -19,7 +19,18 @@ const CUSTOM_FONT_SIZE_OPTION = {
  * alias as a label of the font size. The label assumes that the font sizes
  * are ordered accordingly - from smallest to largest.
  */
-const FONT_SIZES_ALIASES = [ 'S', 'M', 'L', 'XL', 'XXL' ];
+const FONT_SIZES_ALIASES = [
+	/* translators: S stands for 'small' and is a size label. */
+	__( 'S' ),
+	/* translators: M stands for 'medium' and is a size label. */
+	__( 'M' ),
+	/* translators: L stands for 'large' and is a size label. */
+	__( 'L' ),
+	/* translators: XL stands for 'extra large' and is a size label. */
+	__( 'XL' ),
+	/* translators: XXL stands for 'extra extra large' and is a size label. */
+	__( 'XXL' ),
+];
 
 /**
  * Helper util to split a font size to its numeric value
@@ -54,10 +65,10 @@ export function isSimpleCssValue( value ) {
  * Return font size options in the proper format depending
  * on the currently used control (select, toggle group).
  *
- * @param {boolean}  useSelectControl               Whether to use a select control.
- * @param {Object[]} optionsArray                   Array of available font sizes objects.
- * @param {*}        disableCustomFontSizes         Flag that indicates if custom font sizes are disabled.
- * @return {Object[]|null} Array of font sizes in proper format for the used control.
+ * @param {boolean}  useSelectControl       Whether to use a select control.
+ * @param {Object[]} optionsArray           Array of available font sizes objects.
+ * @param {boolean}  disableCustomFontSizes Flag that indicates if custom font sizes are disabled.
+ * @return {Object[]|null}                  Array of font sizes in proper format for the used control.
  */
 export function getFontSizeOptions(
 	useSelectControl,

--- a/packages/components/src/font-size-picker/utils.js
+++ b/packages/components/src/font-size-picker/utils.js
@@ -102,7 +102,7 @@ export function getToggleGroupOptions(
 		return {
 			key: slug,
 			value: size,
-			label: labelAliases[ index ] || size,
+			label: labelAliases[ index ],
 			name,
 		};
 	} );


### PR DESCRIPTION
## What?


A very quick POC PR.

- Use t-shirt sizes for the first 5 font sizes, where there are fewer than font sizes in total.
- Remove unused code.

The t-shirt sizes do not take into account the order of or the values of the font sizes. 

The first five font sizes, however they are ordered will be labelled according to the t-shirt aliases: `[ 'S', 'M', 'L', 'XL', 'XXL' ]`

Related PRs:
- https://github.com/WordPress/gutenberg/pull/37038

## Why?

For context see:
- https://github.com/WordPress/gutenberg/issues/34345#issuecomment-1207717106

## How?
Looking at a previous commit that attempted to do something similar: https://github.com/WordPress/gutenberg/pull/37038/commits/9a83492afd6361879ab430f186249db44700cc96


## Testing Instructions
Use emptytheme or another theme.json that has fewer than 6 font sizes defined.


<details>

<summary>Example theme.json</summary>

```json
{
	"version": 2,
	"settings": {
		"appearanceTools": true,
		"layout": {
			"contentSize": "840px",
			"wideSize": "1100px"
		},
		"typography": {
			"fluid": true,
			"fontSizes": [
				{
					"size": "clamp(36.00rem, calc(32.00rem + 10.00vw), 40.00rem)",
					"slug": "small",
					"fluid": false,
					"name": "NOT small"
				},
				{
					"size": "4rem",
					"slug": "medium",
					"name": "Not medium"
				},
				{
					"size": "10px",
					"slug": "largish",
					"name": "Largish"
				},
				{
					"size": "13px",
					"fluid": false,
					"slug": "largey",
					"name": "NotXtra Large"
				},
				{
					"size": "14px",
					"fluid": false,
					"slug": "colossal",
					"name": "Colossal"
				}
			]
		}
	}
}
```

</details>

Open up the editor.
Insert a text block.
Check the font size picker.


https://user-images.githubusercontent.com/6458278/183573364-2136bb84-740f-4c27-8862-02576fb49032.mp4


