### PR TITLE
Style Engine: Try adding blockGap support

### DIFF
--- a/lib/block-supports/layout.php
+++ b/lib/block-supports/layout.php
@@ -152,20 +152,6 @@ function gutenberg_get_layout_style( $selector, $layout, $has_block_gap_support 
 			);
 		}
 
-		if ( $has_block_gap_support ) {
-			if ( is_array( $gap_value ) ) {
-				$gap_row    = isset( $gap_value['top'] ) ? $gap_value['top'] : $fallback_gap_value;
-				$gap_column = isset( $gap_value['left'] ) ? $gap_value['left'] : $fallback_gap_value;
-				$gap_value  = $gap_row === $gap_column ? $gap_row : $gap_row . ' ' . $gap_column;
-			}
-			if ( $gap_value && ! $should_skip_gap_serialization ) {
-				$layout_styles[] = array(
-					'selector'     => $selector,
-					'declarations' => array( 'gap' => $gap_value ),
-				);
-			}
-		}
-
 		if ( 'horizontal' === $layout_orientation ) {
 			/**
 			 * Add this style only if is not empty for backwards compatibility,

--- a/packages/style-engine/class-wp-style-engine-css-declarations.php
+++ b/packages/style-engine/class-wp-style-engine-css-declarations.php
@@ -54,8 +54,10 @@ class WP_Style_Engine_CSS_Declarations {
 			return;
 		}
 
+		// error_log( print_r( $value, true ) );
+
 		// Trim the value. If empty, bail early.
-		$value = trim( $value );
+		// $value = trim( $value );
 		if ( '' === $value ) {
 			return;
 		}

--- a/packages/style-engine/class-wp-style-engine-css-rule.php
+++ b/packages/style-engine/class-wp-style-engine-css-rule.php
@@ -109,17 +109,24 @@ class WP_Style_Engine_CSS_Rule {
 	 * @return string
 	 */
 	public function get_css( $should_prettify = false, $indent_count = 0 ) {
+		// Do not prettify inline styles.
+		if ( empty( $this->get_selector() ) ) {
+			$should_prettify = false;
+		}
+
+		$selector            = $should_prettify ? str_replace( ',', ",\n", $this->get_selector() ) : $this->get_selector();
 		$rule_indent         = $should_prettify ? str_repeat( "\t", $indent_count ) : '';
 		$declarations_indent = $should_prettify ? $indent_count + 1 : 0;
 		$new_line            = $should_prettify ? "\n" : '';
 		$space               = $should_prettify ? ' ' : '';
-		$selector            = $should_prettify ? str_replace( ',', ",\n", $this->get_selector() ) : $this->get_selector();
 		$css_declarations    = $this->declarations->get_declarations_string( $should_prettify, $declarations_indent );
+		$opening_brace       = ! empty( $selector ) ? '{' : '';
+		$closing_brace       = ! empty( $selector ) ? '}' : '';
 
 		if ( empty( $css_declarations ) ) {
 			return '';
 		}
 
-		return "{$rule_indent}{$selector}{$space}{{$new_line}{$css_declarations}{$new_line}{$rule_indent}}";
+		return "{$rule_indent}{$selector}{$space}{$opening_brace}{$new_line}{$css_declarations}{$new_line}{$rule_indent}{$closing_brace}";
 	}
 }

--- a/packages/style-engine/class-wp-style-engine.php
+++ b/packages/style-engine/class-wp-style-engine.php
@@ -533,7 +533,7 @@ class WP_Style_Engine {
 
 		if ( 'spacingStyles' === $layout_prop ) {
 			// TODO: Convert $style_value from array to string if it's an array.
-			if ( $should_skip_css_vars ) {
+			if ( ! $should_skip_css_vars ) {
 				// Set a CSS var if there is a valid preset value.
 				if ( is_string( $value ) && strpos( $value, 'var:' ) !== false && ! $should_skip_css_vars && ! empty( $individual_property_definition['css_vars'] ) ) {
 					$value = static::get_css_var_value( $value, $individual_property_definition['css_vars'] );

--- a/packages/style-engine/phpunit/class-wp-style-engine-css-rule-test.php
+++ b/packages/style-engine/phpunit/class-wp-style-engine-css-rule-test.php
@@ -124,4 +124,20 @@ class WP_Style_Engine_CSS_Rule_Test extends WP_UnitTestCase {
 
 		$this->assertSame( $expected, $css_rule->get_css( true ) );
 	}
+
+	/**
+	 * Should generate declarations string without braces when no selector is provided.
+	 */
+	public function test_get_css_without_selector() {
+		$selector           = '';
+		$input_declarations = array(
+			'margin-top' => '10px',
+			'font-size'  => '2rem',
+		);
+		$css_declarations   = new WP_Style_Engine_CSS_Declarations( $input_declarations );
+		$css_rule           = new WP_Style_Engine_CSS_Rule( $selector, $css_declarations );
+		$expected           = "{$css_declarations->get_declarations_string()}";
+
+		$this->assertSame( $expected, $css_rule->get_css() );
+	}
 }


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

🚧 🚧 🚧 🚧 This is just a WIP for now, it does not actually work yet 🚧 🚧 🚧 🚧 

The goal with this PR is to explore whether we can migrate the blockGap / block spacing logic over to the style engine, so that we can get the style engine to handle parsing to CSS variables. Hopefully we will also be able to reduce some duplication between `layout.php` and global styles in the longer term.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->

## Screenshots or screencast <!-- if applicable -->
