### PR TITLE
Remove duplicate speak calls from navigation block

### DIFF
--- a/packages/block-library/src/navigation/edit/index.js
+++ b/packages/block-library/src/navigation/edit/index.js
@@ -336,14 +336,12 @@ function Navigation( {
 			showClassicMenuConversionNotice(
 				__( 'Classic menu imported successfully.' )
 			);
-			speak( __( 'Classic menu imported successfully.' ) );
 		}
 
 		if ( classicMenuConversionStatus === CLASSIC_MENU_CONVERSION_ERROR ) {
 			showClassicMenuConversionNotice(
 				__( 'Classic menu import failed.' )
 			);
-			speak( __( 'Classic menu import failed.' ) );
 		}
 	}, [
 		classicMenuConversionStatus,


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Removes duplicate `speak` calls from the navigation block.

## Why?
Creating a notice using an action like `createWarningNotice` implicitly calls `speak` (unless the `speak: false` arg is passed), so the separate calls to `speak` aren't required. I don't think there's any negative consequence to calling it twice, so this is a code quality improvement and not a bug fix.

## Testing Instructions
Prerequisites - use a screenreader, and ensure you have some classic menus.
1. Select a navigation block and select a classic menu
2. After some time, hear 'Classic menu imported successfully'