### PR TITLE
[RNMobile] - Fix failing editor block insertion test on Android 

### DIFF
--- a/packages/react-native-editor/__device-tests__/gutenberg-editor-block-insertion.test.js
+++ b/packages/react-native-editor/__device-tests__/gutenberg-editor-block-insertion.test.js
@@ -2,7 +2,7 @@
  * Internal dependencies
  */
 import { blockNames } from './pages/editor-page';
-import { isAndroid, swipeDown, clickMiddleOfElement } from './helpers/utils';
+import { isAndroid, clickMiddleOfElement } from './helpers/utils';
 import testData from './helpers/test-data';
 
 describe( 'Gutenberg Editor tests for Block insertion', () => {
@@ -95,11 +95,9 @@ describe( 'Gutenberg Editor tests for Block insertion', () => {
 			await editorPage.dismissKeyboard();
 		}
 
-		await swipeDown( editorPage.driver );
 		const titleElement = await editorPage.getTitleElement( {
 			autoscroll: true,
 		} );
-		await titleElement.click();
 		await titleElement.click();
 
 		await editorPage.addNewBlock( blockNames.paragraph );


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
`should be able to insert block at the beginning of post from the title` block insertion test is failing intermittently on Android. After investigation the cause of failure is due to the `swipeDown` action that somehow resulted in a drag and drop action when the test is running on CI. Because of the drag and drop the order of the paragraph blocks no longer match what the test is expecting.

Example of the failures: [1](https://app.circleci.com/pipelines/github/wordpress-mobile/gutenberg-mobile/18290/workflows/c2d832fd-29e3-484a-95ca-e1d0e33deb19/jobs/100273), [2](https://app.circleci.com/pipelines/github/wordpress-mobile/gutenberg-mobile/18289/workflows/2e5a6685-c6fa-43b5-8df8-17f845dd32c7/jobs/100268), [3](https://app.circleci.com/pipelines/github/wordpress-mobile/gutenberg-mobile/18288/workflows/de725e55-b6ab-4a9a-9a0f-699735ea0fd7/jobs/100260)

## Why?
This should hopefully stop the test from failing in the future.

## How?
By removing the `swipeDown` the possibility to have the blocks being drag and drop is removed. There is also an unnecessary additional click on the test that I've also removed.

## Testing Instructions
Run the test locally and in CI and it should now be green. Note that there were failures for iOS test but for other test cases, those test cases are still flaky and will need to be looked at separately.

## Screenshots or screencast <!-- if applicable -->
