### PR TITLE
Navigation block - minor refactor to classic menu conversion code

### DIFF
--- a/packages/block-library/src/navigation/edit/index.js
+++ b/packages/block-library/src/navigation/edit/index.js
@@ -231,10 +231,9 @@ function Navigation( {
 	const isDraftNavigationMenu = navigationMenu?.status === 'draft';
 
 	const {
-		convert,
+		convert: convertClassicMenu,
 		status: classicMenuConversionStatus,
 		error: classicMenuConversionError,
-		value: classicMenuConversionResult,
 	} = useConvertClassicToBlockMenu( clientId );
 
 	const isConvertingClassicMenu =
@@ -328,11 +327,7 @@ function Navigation( {
 			speak( __( 'Classic menu importing.' ) );
 		}
 
-		if (
-			classicMenuConversionStatus === CLASSIC_MENU_CONVERSION_SUCCESS &&
-			classicMenuConversionResult
-		) {
-			handleUpdateMenu( classicMenuConversionResult?.id );
+		if ( classicMenuConversionStatus === CLASSIC_MENU_CONVERSION_SUCCESS ) {
 			showClassicMenuConversionNotice(
 				__( 'Classic menu imported successfully.' )
 			);
@@ -345,11 +340,7 @@ function Navigation( {
 			);
 			speak( __( 'Classic menu import failed.' ) );
 		}
-	}, [
-		classicMenuConversionStatus,
-		classicMenuConversionResult,
-		classicMenuConversionError,
-	] );
+	}, [ classicMenuConversionStatus, classicMenuConversionError ] );
 
 	// Spacer block needs orientation from context. This is a patch until
 	// https://github.com/WordPress/gutenberg/issues/36197 is addressed.
@@ -683,9 +674,15 @@ function Navigation( {
 						handleUpdateMenu( menuId );
 						setShouldFocusNavigationSelector( true );
 					} }
-					onSelectClassicMenu={ ( classicMenu ) => {
-						convert( classicMenu.id, classicMenu.name );
-						setShouldFocusNavigationSelector( true );
+					onSelectClassicMenu={ async ( classicMenu ) => {
+						const navMenu = await convertClassicMenu(
+							classicMenu.id,
+							classicMenu.name
+						);
+						if ( navMenu ) {
+							handleUpdateMenu( navMenu.id );
+							setShouldFocusNavigationSelector( true );
+						}
 					} }
 					onCreateEmpty={ () => createNavigationMenu( '', [] ) }
 				/>
@@ -707,9 +704,17 @@ function Navigation( {
 									handleUpdateMenu( menuId );
 									setShouldFocusNavigationSelector( true );
 								} }
-								onSelectClassicMenu={ ( classicMenu ) => {
-									convert( classicMenu.id, classicMenu.name );
-									setShouldFocusNavigationSelector( true );
+								onSelectClassicMenu={ async ( classicMenu ) => {
+									const navMenu = await convertClassicMenu(
+										classicMenu.id,
+										classicMenu.name
+									);
+									if ( navMenu ) {
+										handleUpdateMenu( navMenu.id );
+										setShouldFocusNavigationSelector(
+											true
+										);
+									}
 								} }
 								onCreateNew={ resetToEmptyBlock }
 								/* translators: %s: The name of a menu. */


### PR DESCRIPTION
## What?
Originally part of #42956, split into a seperate PR as requested

This updates the `convert` function that's returned from the `useConvertClassicToBlockMenu` hook so that it returns a promise that resolves to the created `wp_navigation` menu.

## Why?
Previously, the code used an effect to handle the result of classic menu conversion.

This posed a problem for the changes in #42956. In my PR, I need to handle the outcome differently depending on whether the user converted a menu from the placeholder or whether they converted a menu from the block toolbar. The former calls `selectBlock` as it does in `trunk`, but the latter doesn't (as doing so causes a focus loss).

With the effect, there was no way to determine the source of the conversion. In this PR the code can `await` the menu conversion and then either select the block or not in the event handler.

## Testing Instructions
(Before testing, ensure you have some classic menus)
1. Select a navigation block
2. From the block toolbar, use the 'Select menu' dropdown to select a classic menu
3. The classic menu should be created
4. Use the toolbar's 'Select menu' dropdown again, but this time click 'Create new menu'
5. From the placeholder, use the 'Select menu' dropdown and select a classic menu
6. The classic menu should be created