### PR TITLE
Pseudo elements supports on button elements

### DIFF
--- a/lib/compat/wordpress-6.1/class-wp-theme-json-6-1.php
+++ b/lib/compat/wordpress-6.1/class-wp-theme-json-6-1.php
@@ -22,6 +22,7 @@ class WP_Theme_JSON_6_1 extends WP_Theme_JSON_6_0 {
 	 */
 	const VALID_ELEMENT_PSEUDO_SELECTORS = array(
 		'link' => array( ':hover', ':focus', ':active', ':visited' ),
+		'button' => array( ':hover', ':focus', ':active', ':visited' )
 	);
 
 	/**
@@ -481,9 +482,19 @@ class WP_Theme_JSON_6_1 extends WP_Theme_JSON_6_0 {
 					foreach ( static::VALID_ELEMENT_PSEUDO_SELECTORS[ $element ] as $pseudo_selector ) {
 
 						if ( isset( $theme_json['styles']['elements'][ $element ][ $pseudo_selector ] ) ) {
+
+							$element_selector = [];
+							// This converts selectors like '.wp-element-button, .wp-block-button__link'
+							// to an array, so that the pseudo selector is added to both parts of the selector.
+							$el_selectors = explode( ',', static::ELEMENTS[ $element ] );
+							foreach ( $el_selectors as $el_selector_item ) {
+								$element_selector[] = $el_selector_item . $pseudo_selector;
+							}
+							$element_selector = implode( ',', $element_selector );
+
 							$nodes[] = array(
 								'path'     => array( 'styles', 'elements', $element ),
-								'selector' => static::ELEMENTS[ $element ] . $pseudo_selector,
+								'selector' => $element_selector,
 							);
 						}
 					}
@@ -566,9 +577,19 @@ class WP_Theme_JSON_6_1 extends WP_Theme_JSON_6_0 {
 					if ( array_key_exists( $element, static::VALID_ELEMENT_PSEUDO_SELECTORS ) ) {
 						foreach ( static::VALID_ELEMENT_PSEUDO_SELECTORS[ $element ] as $pseudo_selector ) {
 							if ( isset( $theme_json['styles']['blocks'][ $name ]['elements'][ $element ][ $pseudo_selector ] ) ) {
+
+								$block_selector = [];
+								// This converts selectors like '.wp-element-button, .wp-block-button__link'
+								// to an array, so that the pseudo selector is added to both parts of the selector.
+								$bl_selectors = explode( ',', $selectors[ $name ]['elements'][ $element ] );
+								foreach ( $bl_selectors as $bl_selector_item ) {
+									$block_selector[] = $bl_selector_item . $pseudo_selector;
+								}
+								$block_selector = implode( ',', $block_selector );
+
 								$nodes[] = array(
 									'path'     => array( 'styles', 'blocks', $name, 'elements', $element ),
-									'selector' => $selectors[ $name ]['elements'][ $element ] . $pseudo_selector,
+									'selector' => $block_selector,
 								);
 							}
 						}

--- a/lib/compat/wordpress-6.1/class-wp-theme-json-6-1.php
+++ b/lib/compat/wordpress-6.1/class-wp-theme-json-6-1.php
@@ -21,8 +21,8 @@ class WP_Theme_JSON_6_1 extends WP_Theme_JSON_6_0 {
 	 * Note: this will effect both top level and block level elements.
 	 */
 	const VALID_ELEMENT_PSEUDO_SELECTORS = array(
-		'link' => array( ':hover', ':focus', ':active', ':visited' ),
-		'button' => array( ':hover', ':focus', ':active', ':visited' )
+		'link'   => array( ':hover', ':focus', ':active', ':visited' ),
+		'button' => array( ':hover', ':focus', ':active', ':visited' ),
 	);
 
 	/**
@@ -334,20 +334,20 @@ class WP_Theme_JSON_6_1 extends WP_Theme_JSON_6_0 {
 		),
 	);
 
-	/* 
+	/**
 	 * This converts selectors like '.wp-element-button, .wp-block-button__link'
 	 * to an array, so that the block selector is added to both parts of the selector.
-	 * 
-	 * @param string $element The string with all the element's selectors
-	 * @param string $selector The string we want to append to the selectors
-	 * @param string $position The position we wand to append the selector in 
+	 *
+	 * @param string $element The string with all the element's selectors.
+	 * @param string $selector The string we want to append to the selectors.
+	 * @param string $position The position we wand to append the selector in.
 	 * @return string element selector.
 	 */
 	private static function appendToSelector( $element, $selector, $position = 0 ) {
 		$element_selector = array();
-		$el_selectors = explode( ',', $element );
+		$el_selectors     = explode( ',', $element );
 		foreach ( $el_selectors as $el_selector_item ) {
-			if($position == 0) {
+			if ( 0 === $position ) {
 				$element_selector[] = $selector . $el_selector_item;
 			} else {
 				$element_selector[] = $el_selector_item . $selector;
@@ -440,7 +440,7 @@ class WP_Theme_JSON_6_1 extends WP_Theme_JSON_6_0 {
 						break;
 					}
 
-					$element_selector = static::appendToSelector($el_selector, $selector . ' ', 0);
+					$element_selector = static::appendToSelector( $el_selector, $selector . ' ', 0 );
 				}
 				static::$blocks_metadata[ $block_name ]['elements'][ $el_name ] = $element_selector;
 			}
@@ -501,8 +501,8 @@ class WP_Theme_JSON_6_1 extends WP_Theme_JSON_6_0 {
 
 						if ( isset( $theme_json['styles']['elements'][ $element ][ $pseudo_selector ] ) ) {
 
-							$element_selector = [];
-							$element_selector = static::appendToSelector(static::ELEMENTS[ $element ], $pseudo_selector, 1);
+							$element_selector = array();
+							$element_selector = static::appendToSelector( static::ELEMENTS[ $element ], $pseudo_selector, 1 );
 
 							$nodes[] = array(
 								'path'     => array( 'styles', 'elements', $element ),
@@ -590,8 +590,8 @@ class WP_Theme_JSON_6_1 extends WP_Theme_JSON_6_0 {
 						foreach ( static::VALID_ELEMENT_PSEUDO_SELECTORS[ $element ] as $pseudo_selector ) {
 							if ( isset( $theme_json['styles']['blocks'][ $name ]['elements'][ $element ][ $pseudo_selector ] ) ) {
 
-								$block_selector = [];
-								$block_selector = static::appendToSelector($selectors[ $name ]['elements'][ $element ], $pseudo_selector, 1);
+								$block_selector = array();
+								$block_selector = static::appendToSelector( $selectors[ $name ]['elements'][ $element ], $pseudo_selector, 1 );
 
 								$nodes[] = array(
 									'path'     => array( 'styles', 'blocks', $name, 'elements', $element ),

--- a/lib/compat/wordpress-6.1/class-wp-theme-json-6-1.php
+++ b/lib/compat/wordpress-6.1/class-wp-theme-json-6-1.php
@@ -334,6 +334,29 @@ class WP_Theme_JSON_6_1 extends WP_Theme_JSON_6_0 {
 		),
 	);
 
+	/* 
+	 * This converts selectors like '.wp-element-button, .wp-block-button__link'
+	 * to an array, so that the block selector is added to both parts of the selector.
+	 * 
+	 * @param string $element The string with all the element's selectors
+	 * @param string $selector The string we want to append to the selectors
+	 * @param string $position The position we wand to append the selector in 
+	 * @return string element selector.
+	 */
+	private static function appendToSelector( $element, $selector, $position = 0 ) {
+		$element_selector = array();
+		$el_selectors = explode( ',', $element );
+		foreach ( $el_selectors as $el_selector_item ) {
+			if($position == 0) {
+				$element_selector[] = $selector . $el_selector_item;
+			} else {
+				$element_selector[] = $el_selector_item . $selector;
+			}
+		}
+		$element_selector = implode( ',', $element_selector );
+		return $element_selector;
+	}
+
 	/**
 	 * Returns the metadata for each block.
 	 *
@@ -417,14 +440,9 @@ class WP_Theme_JSON_6_1 extends WP_Theme_JSON_6_0 {
 						break;
 					}
 
-					// This converts selectors like '.wp-element-button, .wp-block-button__link'
-					// to an array, so that the block selector is added to both parts of the selector.
-					$el_selectors = explode( ',', $el_selector );
-					foreach ( $el_selectors as $el_selector_item ) {
-						$element_selector[] = $selector . ' ' . $el_selector_item;
-					}
+					$element_selector = static::appendToSelector($el_selector, $selector . ' ', 0);
 				}
-				static::$blocks_metadata[ $block_name ]['elements'][ $el_name ] = implode( ',', $element_selector );
+				static::$blocks_metadata[ $block_name ]['elements'][ $el_name ] = $element_selector;
 			}
 		}
 
@@ -484,13 +502,7 @@ class WP_Theme_JSON_6_1 extends WP_Theme_JSON_6_0 {
 						if ( isset( $theme_json['styles']['elements'][ $element ][ $pseudo_selector ] ) ) {
 
 							$element_selector = [];
-							// This converts selectors like '.wp-element-button, .wp-block-button__link'
-							// to an array, so that the pseudo selector is added to both parts of the selector.
-							$el_selectors = explode( ',', static::ELEMENTS[ $element ] );
-							foreach ( $el_selectors as $el_selector_item ) {
-								$element_selector[] = $el_selector_item . $pseudo_selector;
-							}
-							$element_selector = implode( ',', $element_selector );
+							$element_selector = static::appendToSelector(static::ELEMENTS[ $element ], $pseudo_selector, 1);
 
 							$nodes[] = array(
 								'path'     => array( 'styles', 'elements', $element ),
@@ -579,13 +591,7 @@ class WP_Theme_JSON_6_1 extends WP_Theme_JSON_6_0 {
 							if ( isset( $theme_json['styles']['blocks'][ $name ]['elements'][ $element ][ $pseudo_selector ] ) ) {
 
 								$block_selector = [];
-								// This converts selectors like '.wp-element-button, .wp-block-button__link'
-								// to an array, so that the pseudo selector is added to both parts of the selector.
-								$bl_selectors = explode( ',', $selectors[ $name ]['elements'][ $element ] );
-								foreach ( $bl_selectors as $bl_selector_item ) {
-									$block_selector[] = $bl_selector_item . $pseudo_selector;
-								}
-								$block_selector = implode( ',', $block_selector );
+								$block_selector = static::appendToSelector($selectors[ $name ]['elements'][ $element ], $pseudo_selector, 1);
 
 								$nodes[] = array(
 									'path'     => array( 'styles', 'blocks', $name, 'elements', $element ),


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->
Implements pseudo element support on the button element.
Related https://github.com/WordPress/gutenberg/issues/38277

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
Support for pseudo elements on the link element [has been around for a bit](https://github.com/WordPress/gutenberg/pull/41786) and it looks like it's working fine, extending that to buttons seems like the logic next step and it will help with the next default theme development.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
I just needed to add a line to the array of supported elements and fixed a bug where multiple selectors weren't taken into account when applying the actual pseudo element to the styles.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->

Needs to apply https://github.com/WordPress/gutenberg/pull/43022 because of current bugs with CSS loading order

I tested this on emptytheme with the following markup and theme.json:

```
<!-- wp:buttons -->
<div class="wp-block-buttons"><!-- wp:button -->
<div class="wp-block-button"><a class="wp-block-button__link wp-element-button">Normal button</a></div>
<!-- /wp:button --></div>
<!-- /wp:buttons -->

<!-- wp:search {"label":"Search","buttonText":"Search"} /-->

<!-- wp:search {"label":"Search","showLabel":false,"buttonText":"Search","buttonUseIcon":true} /-->

<!-- wp:search {"label":"Search","showLabel":false,"buttonText":"Search","buttonPosition":"button-inside"} /-->

<!-- wp:search {"label":"Search","showLabel":false,"buttonText":"Search","buttonPosition":"button-inside","buttonUseIcon":true} /-->

<!-- wp:file {"id":68,"href":"http://maggie.local/wp-content/uploads/2022/04/Screenshot-2022-06-28-at-15.39.15.png"} -->
<div class="wp-block-file"><a id="wp-block-file--media-01f5fb0f-c96b-4331-993a-e05df1128f87" href="http://maggie.local/wp-content/uploads/2022/04/Screenshot-2022-06-28-at-15.39.15.png">Screenshot 2022-06-28 at 15.39.15</a><a href="http://maggie.local/wp-content/uploads/2022/04/Screenshot-2022-06-28-at-15.39.15.png" class="wp-block-file__button wp-element-button" download aria-describedby="wp-block-file--media-01f5fb0f-c96b-4331-993a-e05df1128f87">Download</a></div>
<!-- /wp:file -->
```

```
"styles": {
	"elements": {
		"button": {
			"color": {
				"background": "green"
			},
			":hover": {
				"color": {

					"background": "blue",
					"text": "hotpink"
				}
			}
		}
	}
}	
```

## Screenshots or screencast <!-- if applicable -->

![Screen Capture on 2022-08-10 at 10-33-18](https://user-images.githubusercontent.com/3593343/183854829-a902b574-5a8a-49b7-b910-373ac79f1460.gif)

/cc @WordPress/block-themers 
