### PR TITLE
Fix: script name error in main package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -291,7 +291,7 @@
 		"storybook:dev": "concurrently \"npm run dev:packages\" \"start-storybook -c ./storybook -p 50240\"",
 		"test": "npm-run-all lint test:unit",
 		"test:create-block": "bash ./bin/test-create-block.sh",
-		"test:e2e": "wp-scripts test:e2e --config packages/e2e-tests/jest.config.js",
+		"test:e2e": "wp-scripts test-e2e --config packages/e2e-tests/jest.config.js",
 		"test:e2e:debug": "wp-scripts --inspect-brk test-e2e --config packages/e2e-tests/jest.config.js --puppeteer-devtools",
 		"test:e2e:playwright": "playwright test --config test/e2e/playwright.config.ts",
 		"test:e2e:watch": "npm run test:e2e -- --watch",


### PR DESCRIPTION

## What?
This PR corrects an erroneous renaming caused by the standardization of script names done by #42368.

## How?
Renamed `wp-scripts test:e2e` to `wp-scripts test-e2e`