### PR TITLE
Cover: Fix rendered content PHPDoc type

### DIFF
--- a/packages/block-library/src/cover/index.php
+++ b/packages/block-library/src/cover/index.php
@@ -9,7 +9,7 @@
  * Renders the `core/cover` block on server.
  *
  * @param array $attributes The block attributes.
- * @param array $content    The block rendered content.
+ * @param string $content   The block rendered content.
  *
  * @return string Returns the cover block markup, if useFeaturedImage is true.
  */

--- a/packages/block-library/src/cover/index.php
+++ b/packages/block-library/src/cover/index.php
@@ -8,8 +8,8 @@
 /**
  * Renders the `core/cover` block on server.
  *
- * @param array $attributes The block attributes.
- * @param string $content   The block rendered content.
+ * @param array  $attributes The block attributes.
+ * @param string $content    The block rendered content.
  *
  * @return string Returns the cover block markup, if useFeaturedImage is true.
  */


### PR DESCRIPTION
## What?
Similar to https://github.com/WordPress/gutenberg/pull/37688.

Update PHPDoc type of `$content` to string.
