### PR TITLE
Lodash: Remove completely from `@wordpress/docgen` package

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16935,7 +16935,6 @@
 			"requires": {
 				"@babel/core": "^7.16.0",
 				"comment-parser": "^1.1.1",
-				"lodash": "^4.17.21",
 				"mdast-util-inject": "1.1.0",
 				"optionator": "0.8.2",
 				"remark": "10.0.1",

--- a/packages/docgen/lib/get-export-entries.js
+++ b/packages/docgen/lib/get-export-entries.js
@@ -1,9 +1,4 @@
 /**
- * External dependencies
- */
-const { get } = require( 'lodash' );
-
-/**
  * Returns the export entry records of the given export statement.
  * Unlike [the standard](http://www.ecma-international.org/ecma-262/9.0/#exportentry-record),
  * the `importName` and the `localName` are merged together.
@@ -31,7 +26,7 @@ module.exports = ( token ) => {
 					name = t.declaration.left.name;
 					break;
 				default:
-					name = get( t.declaration, [ 'id', 'name' ], '*default*' );
+					name = t.declaration.id?.name ?? '*default*';
 			}
 			return name;
 		};
@@ -64,7 +59,7 @@ module.exports = ( token ) => {
 			name.push( {
 				localName: specifier.local.name,
 				exportName: specifier.exported.name,
-				module: get( token.source, [ 'value' ], null ),
+				module: token.source?.value ?? null,
 				lineStart: specifier.loc.start.line,
 				lineEnd: specifier.loc.end.line,
 			} )

--- a/packages/docgen/lib/get-intermediate-representation.js
+++ b/packages/docgen/lib/get-intermediate-representation.js
@@ -1,9 +1,4 @@
 /**
- * External dependencies
- */
-const { get } = require( 'lodash' );
-
-/**
  * Internal dependencies
  */
 const getExportEntries = require( './get-export-entries' );
@@ -154,8 +149,8 @@ module.exports = (
 			ir.push( {
 				path,
 				name: entry.exportName,
-				description: get( doc, [ 'description' ], UNDOCUMENTED ),
-				tags: get( doc, [ 'tags' ], [] ),
+				description: doc?.description ?? UNDOCUMENTED,
+				tags: doc?.tags ?? [],
 				lineStart: entry.lineStart,
 				lineEnd: entry.lineEnd,
 			} );

--- a/packages/docgen/lib/get-leading-comments.js
+++ b/packages/docgen/lib/get-leading-comments.js
@@ -1,9 +1,4 @@
 /**
- * External dependencies
- */
-const { last } = require( 'lodash' );
-
-/**
  * Function that returns the leading comment
  * of a Espree node.
  *
@@ -14,7 +9,10 @@ const { last } = require( 'lodash' );
 module.exports = ( declaration ) => {
 	let comments;
 	if ( declaration.leadingComments ) {
-		const lastComment = last( declaration.leadingComments );
+		const lastComment =
+			declaration.leadingComments[
+				declaration.leadingComments.length - 1
+			];
 		if ( lastComment ) {
 			comments = lastComment.value;
 		}

--- a/packages/docgen/lib/index.js
+++ b/packages/docgen/lib/index.js
@@ -3,7 +3,6 @@
  */
 const fs = require( 'fs' );
 const path = require( 'path' );
-const { last } = require( 'lodash' );
 
 /**
  * Internal dependencies
@@ -60,7 +59,10 @@ const processFile = ( rootDir, inputFile ) => {
 		const result = engine(
 			relativePath,
 			data,
-			getIRFromRelativePath( rootDir, last( currentFileStack ) )
+			getIRFromRelativePath(
+				rootDir,
+				currentFileStack[ currentFileStack.length - 1 ]
+			)
 		);
 		currentFileStack.pop();
 		return result;

--- a/packages/docgen/package.json
+++ b/packages/docgen/package.json
@@ -29,7 +29,6 @@
 	"dependencies": {
 		"@babel/core": "^7.16.0",
 		"comment-parser": "^1.1.1",
-		"lodash": "^4.17.21",
 		"mdast-util-inject": "1.1.0",
 		"optionator": "0.8.2",
 		"remark": "10.0.1",


### PR DESCRIPTION
## What?
This PR removes all of the Lodash from the `@wordpress/docgen` package, including the `lodash` dependency altogether. There are just a few usages and conversion is pretty straightforward. 

## Why?

Lodash is known to unnecessarily inflate the bundle size of packages, and in most cases, it can be replaced with native language functionality. See these for more information and rationale:

* https://github.com/WordPress/gutenberg/issues/16938#issuecomment-602837246
* https://github.com/WordPress/gutenberg/issues/17025
* https://github.com/WordPress/gutenberg/issues/39495 

## How?
We're dealing with straightforwardly replacing a few methods, namely:

#### `get`

We're using optional chaining and nullish coalescing.

#### `last`

Straightforward to replace with `x[ x.length - 1 ]` on the target array.

## Testing Instructions

* Verify docgen still works: `npx docgen packages/block-library/src/index.js` or `npx docgen packages/block-editor/src/index.js`
* Verify all tests still pass: `npm run test:unit packages/docgen`