### PR TITLE
Spacing presets: Prevent % spacing size units being stripped by sanitize_title

### DIFF
--- a/lib/compat/wordpress-6.1/class-wp-theme-json-6-1.php
+++ b/lib/compat/wordpress-6.1/class-wp-theme-json-6-1.php
@@ -1164,7 +1164,7 @@ class WP_Theme_JSON_6_1 extends WP_Theme_JSON_6_0 {
 			return null;
 		}
 
-		$unit            = sanitize_title( $spacing_scale['unit'] );
+		$unit            = '%' === $spacing_scale['unit'] ? $spacing_scale['unit'] : sanitize_title( $spacing_scale['unit'] );
 		$current_step    = $spacing_scale['mediumStep'];
 		$steps_mid_point = round( ( ( $spacing_scale['steps'] ) / 2 ), 0 );
 		$x_small_count   = null;

--- a/lib/compat/wordpress-6.1/class-wp-theme-json-6-1.php
+++ b/lib/compat/wordpress-6.1/class-wp-theme-json-6-1.php
@@ -1164,7 +1164,7 @@ class WP_Theme_JSON_6_1 extends WP_Theme_JSON_6_0 {
 			return null;
 		}
 
-		$unit            = '%' === $spacing_scale['unit'] ? $spacing_scale['unit'] : sanitize_title( $spacing_scale['unit'] );
+		$unit            = '%' === $spacing_scale['unit'] ? '%' : sanitize_title( $spacing_scale['unit'] );
 		$current_step    = $spacing_scale['mediumStep'];
 		$steps_mid_point = round( ( ( $spacing_scale['steps'] ) / 2 ), 0 );
 		$x_small_count   = null;


### PR DESCRIPTION
## What?
Fixes bug with `%` unit setting in spacingScale values in theme.json not working

## Why?
`%` is supposed to be a valid unit for spacing sizes. sanitize_title`

## How?
Adds a ternary to prevent a spacing sizes preset unit of `%` being passed through `sanitize_title`

## Testing Instructions
- Modify the unit in `lib/compat/wordpress-6.1/theme.json` in `settings.spacing.spacingScale.unit` to `%`
- Add the following block code to editor, and make sure percentage padding values show correctly in editor and frontend
```
<!-- wp:group {"style":{"spacing":{"padding":{"top":"var:preset|spacing|40","right":"var:preset|spacing|70","bottom":"var:preset|spacing|30","left":"var:preset|spacing|50"}}},"backgroundColor":"vivid-red","textColor":"background"} -->
<div class="wp-block-group has-background-color has-vivid-red-background-color has-text-color has-background" style="padding-top:var(--wp--preset--spacing--40);padding-right:var(--wp--preset--spacing--70);padding-bottom:var(--wp--preset--spacing--30);padding-left:var(--wp--preset--spacing--50)"><!-- wp:paragraph -->
<p>Percent should work</p>
<!-- /wp:paragraph --></div>
<!-- /wp:group -->
```

## Screenshots 

Before:
<img width="660" alt="Screen Shot 2022-08-10 at 10 29 31 AM" src="https://user-images.githubusercontent.com/3629020/183772965-87625420-0ab8-4be9-98c4-96a7cdc7129e.png">

After:
<img width="649" alt="Screen Shot 2022-08-10 at 10 28 43 AM" src="https://user-images.githubusercontent.com/3629020/183772990-e6cb331c-e1eb-4ac5-a460-9b70292ff616.png">


