### PR TITLE
PHPUnit: turns on PHP notices and deprecations

### DIFF
--- a/.wp-env.json
+++ b/.wp-env.json
@@ -4,6 +4,9 @@
 	"themes": [ "./test/emptytheme" ],
 	"env": {
 		"tests": {
+			"config": {
+				"WP_DEBUG": true
+			},
 			"mappings": {
 				"wp-content/plugins/gutenberg": ".",
 				"wp-content/mu-plugins": "./packages/e2e-tests/mu-plugins",

--- a/.wp-env.json
+++ b/.wp-env.json
@@ -4,9 +4,6 @@
 	"themes": [ "./test/emptytheme" ],
 	"env": {
 		"tests": {
-			"config": {
-				"WP_DEBUG": true
-			},
 			"mappings": {
 				"wp-content/plugins/gutenberg": ".",
 				"wp-content/mu-plugins": "./packages/e2e-tests/mu-plugins",

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -5,6 +5,7 @@
 	convertErrorsToExceptions="true"
 	convertNoticesToExceptions="true"
 	convertWarningsToExceptions="true"
+	convertDeprecationsToExceptions="true"
 	>
 	<php>
 		<env name="WORDPRESS_TABLE_PREFIX" value="wptests_" />

--- a/phpunit/blocks/render-last-posts-test.php
+++ b/phpunit/blocks/render-last-posts-test.php
@@ -24,6 +24,10 @@ class Tests_Blocks_RenderLastPosts extends WP_UnitTestCase {
 	 * @var array
 	 */
 	protected static $attachment_ids;
+	/**
+	 * @var array|null
+	 */
+	private $original_block_supports;
 
 	public static function wpSetUpBeforeClass( WP_UnitTest_Factory $factory ) {
 		self::$sticky_post = $factory->post->create_and_get(
@@ -49,6 +53,21 @@ class Tests_Blocks_RenderLastPosts extends WP_UnitTestCase {
 		}
 	}
 
+	public function set_up() {
+		parent::set_up();
+
+		$this->original_block_supports      = WP_Block_Supports::$block_to_render;
+		WP_Block_Supports::$block_to_render = array(
+			'attrs'     => array(),
+			'blockName' => '',
+		);
+	}
+
+	public function tear_down() {
+		WP_Block_Supports::$block_to_render = $this->original_block_supports;
+		parent::tear_down();
+	}
+
 	/**
 	 * @covers ::render_block_core_latest_posts
 	 */
@@ -56,10 +75,13 @@ class Tests_Blocks_RenderLastPosts extends WP_UnitTestCase {
 		$action = new MockAction();
 		add_filter( 'update_post_metadata_cache', array( $action, 'filter' ), 10, 2 );
 		$attributes = array(
-			'displayFeaturedImage' => true,
-			'postsToShow'          => 5,
-			'orderBy'              => 'date',
-			'order'                => 'DESC',
+			'displayFeaturedImage'   => true,
+			'postsToShow'            => 5,
+			'orderBy'                => 'date',
+			'order'                  => 'DESC',
+			'excerptLength'          => 0,
+			'featuredImageSizeSlug'  => '',
+			'addLinkToFeaturedImage' => false,
 		);
 
 		gutenberg_render_block_core_latest_posts( $attributes );
@@ -75,10 +97,13 @@ class Tests_Blocks_RenderLastPosts extends WP_UnitTestCase {
 		$action = new MockAction();
 		add_filter( 'update_post_metadata_cache', array( $action, 'filter' ), 10, 2 );
 		$attributes = array(
-			'displayFeaturedImage' => false,
-			'postsToShow'          => 5,
-			'orderBy'              => 'date',
-			'order'                => 'DESC',
+			'displayFeaturedImage'   => false,
+			'postsToShow'            => 5,
+			'orderBy'                => 'date',
+			'order'                  => 'DESC',
+			'excerptLength'          => 0,
+			'featuredImageSizeSlug'  => '',
+			'addLinkToFeaturedImage' => false,
 		);
 
 		gutenberg_render_block_core_latest_posts( $attributes );

--- a/phpunit/bootstrap.php
+++ b/phpunit/bootstrap.php
@@ -5,9 +5,21 @@
  * @package Gutenberg
  */
 
-// Test with WordPress debug mode (default).
+// Debug settings for parity with WordPress Core's PHPUnit tests.
 if ( ! defined( 'WP_DEBUG' ) ) {
 	define( 'WP_DEBUG', true );
+}
+if ( ! defined( 'LOCAL_WP_DEBUG_LOG' ) ) {
+	define( 'LOCAL_WP_DEBUG_LOG', true );
+}
+if ( ! defined( 'LOCAL_WP_DEBUG_DISPLAY' ) ) {
+	define( 'LOCAL_WP_DEBUG_DISPLAY', true );
+}
+if ( ! defined( 'LOCAL_SCRIPT_DEBUG' ) ) {
+	define( 'LOCAL_SCRIPT_DEBUG', true );
+}
+if ( ! defined( 'LOCAL_WP_ENVIRONMENT_TYPE' ) ) {
+	define( 'LOCAL_WP_ENVIRONMENT_TYPE', 'local' );
 }
 
 // Require composer dependencies.

--- a/phpunit/bootstrap.php
+++ b/phpunit/bootstrap.php
@@ -5,6 +5,11 @@
  * @package Gutenberg
  */
 
+// Test with WordPress debug mode (default).
+if ( ! defined( 'WP_DEBUG' ) ) {
+	define( 'WP_DEBUG', true );
+}
+
 // Require composer dependencies.
 require_once dirname( __DIR__ ) . '/vendor/autoload.php';
 

--- a/phpunit/class-block-library-navigation-link-test.php
+++ b/phpunit/class-block-library-navigation-link-test.php
@@ -18,6 +18,10 @@ class Block_Library_Navigation_Link_Test extends WP_UnitTestCase {
 
 	private static $pages;
 	private static $terms;
+	/**
+	 * @var array|null
+	 */
+	private $original_block_supports;
 
 	public static function wpSetUpBeforeClass() {
 
@@ -88,6 +92,21 @@ class Block_Library_Navigation_Link_Test extends WP_UnitTestCase {
 		foreach ( self::$terms as $term_to_delete ) {
 			wp_delete_term( $term_to_delete->term_id, $term_to_delete->taxonomy );
 		}
+	}
+
+	public function set_up() {
+		parent::set_up();
+
+		$this->original_block_supports      = WP_Block_Supports::$block_to_render;
+		WP_Block_Supports::$block_to_render = array(
+			'attrs'     => array(),
+			'blockName' => '',
+		);
+	}
+
+	public function tear_down() {
+		WP_Block_Supports::$block_to_render = $this->original_block_supports;
+		parent::tear_down();
 	}
 
 	function test_returns_link_when_post_is_published() {

--- a/phpunit/class-wp-theme-json-test.php
+++ b/phpunit/class-wp-theme-json-test.php
@@ -736,66 +736,7 @@ class WP_Theme_JSON_Gutenberg_Test extends WP_UnitTestCase {
 	 */
 	function data_generate_spacing_scale_fixtures() {
 		return array(
-			'empty_spacing_scale'                       => array(
-				'spacing_scale'   => array(),
-				'expected_output' => null,
-			),
-
-			'invalid_spacing_scale_values_missing_operator' => array(
-				'spacingScale'    => array(
-					'operator'   => '',
-					'increment'  => 1.5,
-					'steps'      => 1,
-					'mediumStep' => 4,
-					'unit'       => 'rem',
-				),
-				'expected_output' => null,
-			),
-
-			'invalid_spacing_scale_values_non_numeric_increment' => array(
-				'spacingScale'    => array(
-					'operator'   => '+',
-					'increment'  => 'add two to previous value',
-					'steps'      => 1,
-					'mediumStep' => 4,
-					'unit'       => 'rem',
-				),
-				'expected_output' => null,
-			),
-
-			'invalid_spacing_scale_values_non_numeric_steps' => array(
-				'spacingScale'    => array(
-					'operator'   => '+',
-					'increment'  => 1.5,
-					'steps'      => 'spiral staircase preferred',
-					'mediumStep' => 4,
-					'unit'       => 'rem',
-				),
-				'expected_output' => null,
-			),
-
-			'invalid_spacing_scale_values_non_numeric_medium_step' => array(
-				'spacingScale'    => array(
-					'operator'   => '+',
-					'increment'  => 1.5,
-					'steps'      => 5,
-					'mediumStep' => 'That which is just right',
-					'unit'       => 'rem',
-				),
-				'expected_output' => null,
-			),
-
-			'invalid_spacing_scale_values_missing_unit' => array(
-				'spacingScale'    => array(
-					'operator'   => '+',
-					'increment'  => 1.5,
-					'steps'      => 5,
-					'mediumStep' => 4,
-				),
-				'expected_output' => null,
-			),
-
-			'one_step_spacing_scale'                    => array(
+			'one_step_spacing_scale' => array(
 				'spacingScale'    => array(
 					'operator'   => '+',
 					'increment'  => 1.5,
@@ -1002,6 +943,94 @@ class WP_Theme_JSON_Gutenberg_Test extends WP_UnitTestCase {
 						'size' => '24rem',
 					),
 				),
+			),
+		);
+	}
+
+	/**
+	 * Tests generating the spacing presets array based on the spacing scale provided.
+	 *
+	 * @dataProvider data_set_spacing_sizes_when_invalid
+	 */
+	public function test_set_spacing_sizes_when_invalid( $spacing_scale, $expected_output ) {
+		$this->expectNotice();
+		$this->expectNoticeMessage( 'Some of the theme.json settings.spacing.spacingScale values are invalid' );
+
+		$theme_json = new WP_Theme_JSON_Gutenberg(
+			array(
+				'version'  => 2,
+				'settings' => array(
+					'spacing' => array(
+						'spacingScale' => $spacing_scale,
+					),
+				),
+			)
+		);
+
+		$theme_json->set_spacing_sizes();
+		$this->assertSame( $expected_output, _wp_array_get( $theme_json->get_raw_data(), array( 'settings', 'spacing', 'spacingSizes', 'default' ) ) );
+	}
+
+	/**
+	 * Data provider for spacing scale tests.
+	 *
+	 * @return array
+	 */
+	function data_set_spacing_sizes_when_invalid() {
+		return array(
+
+			'invalid_spacing_scale_values_missing_operator' => array(
+				'spacingScale'    => array(
+					'operator'   => '',
+					'increment'  => 1.5,
+					'steps'      => 1,
+					'mediumStep' => 4,
+					'unit'       => 'rem',
+				),
+				'expected_output' => null,
+			),
+
+			'invalid_spacing_scale_values_non_numeric_increment' => array(
+				'spacingScale'    => array(
+					'operator'   => '+',
+					'increment'  => 'add two to previous value',
+					'steps'      => 1,
+					'mediumStep' => 4,
+					'unit'       => 'rem',
+				),
+				'expected_output' => null,
+			),
+
+			'invalid_spacing_scale_values_non_numeric_steps' => array(
+				'spacingScale'    => array(
+					'operator'   => '+',
+					'increment'  => 1.5,
+					'steps'      => 'spiral staircase preferred',
+					'mediumStep' => 4,
+					'unit'       => 'rem',
+				),
+				'expected_output' => null,
+			),
+
+			'invalid_spacing_scale_values_non_numeric_medium_step' => array(
+				'spacingScale'    => array(
+					'operator'   => '+',
+					'increment'  => 1.5,
+					'steps'      => 5,
+					'mediumStep' => 'That which is just right',
+					'unit'       => 'rem',
+				),
+				'expected_output' => null,
+			),
+
+			'invalid_spacing_scale_values_missing_unit' => array(
+				'spacingScale'    => array(
+					'operator'   => '+',
+					'increment'  => 1.5,
+					'steps'      => 5,
+					'mediumStep' => 4,
+				),
+				'expected_output' => null,
 			),
 		);
 	}

--- a/phpunit/class-wp-webfonts-test.php
+++ b/phpunit/class-wp-webfonts-test.php
@@ -323,6 +323,8 @@ class WP_Webfonts_Test extends WP_UnitTestCase {
 	 * @covers WP_Webfonts::validate_webfont
 	 */
 	public function test_validate_webfont() {
+		$this->expectNotice();
+
 		// Test empty array.
 		$this->assertFalse( wp_webfonts()->validate_webfont( array() ) );
 


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

Part of #43333

## What?

* Turns on debug constants to allow notices and deprecations to be found and tested. 
* Adds `expectNotice()` assertion when a notice is expected to happen.
* Adds test set up for needed to avoid unnecessary notices.
* Moves testing of invalid datasets (which would throw a notice or deprecation) to a separate test and data provider to clearly identify intent. (further aligns test structures with Core).

This PR brings closer parity to Core which also turns on debug constants such as `WP_Debug` and uses `expectNotice()`.

## Why?

Reasons:
* Reduce backporting effort by getting tests Core-ready long before backporting starts.
* Increase parity with WordPress Core's PHPUnit test set up where notices and deprecations are turned on and tested.
* Promote discovery of potential issues and incompatibilities earlier and continuously through the development and testing cycles.

PHP notices and deprecations provide helpful information for identifying issues and/or code changes.

For example:
* notices can inform of missing keys or attempting to use a non-array as an array.
* deprecations alert of code changes that need attention such as data type incompatibilities with PHP native functions, incorrect configuration patterns, etc.

Once backported, _Core's tests will fail_ if there are deprecations or notices thrown, as its test suite turns on debug. By catching these here in Gutenberg's repo, it provides information for resolution before backporting to Core. Why is necessary? In many instances, source code needs changing including adding defensive guarding. Finding these issues during development allows time for investigation and consideration of design intent to properly remedy the issue.

## How?

Adds `convertDeprecationsToExceptions="true"` to `php.xml` configuration.

Adds the following debug constants to the PHPUnit `bootstrap.php` file: `WP_Debug` , `LOCAL_WP_DEBUG_LOG`, `LOCAL_WP_DEBUG_DISPLAY`, `LOCAL_SCRIPT_DEBUG`.

Changes are in the test suite only. Issues within the source code need individual consideration for what the code should do before it attempts to run the code that triggers the notice or deprecation.

### FAQ

- Why not set these constants in `.wp-env.json` file?

[This PR tried that and found](https://github.com/WordPress/gutenberg/pull/43102/commits/66804c80b8cc551a1c5db4b94ab7a0eed6624e2a) that deprecation notices are being thrown in the e2e tests. This PR is focused on PHPUnit only. Adding deprecation expectations to the e2e tests is outside the scope of this PR.

- Are users affected by notices or deprecations?

Yes and no. Their site will continue running. But unexpected results may happen as the code does not have what it needs to process. The deprecations and notices are identifying where that a problem exists and needs attention.