### PR TITLE
Style engine: remove `enqueue` flag

### DIFF
--- a/lib/block-supports/elements.php
+++ b/lib/block-supports/elements.php
@@ -106,7 +106,6 @@ function gutenberg_render_elements_support_styles( $pre_render, $block ) {
 		array(
 			'selector' => ".$class_name a",
 			'context'  => 'block-supports',
-			'enqueue'  => true,
 		)
 	);
 

--- a/lib/block-supports/layout.php
+++ b/lib/block-supports/layout.php
@@ -78,7 +78,6 @@ function gutenberg_get_layout_style( $selector, $layout, $has_block_gap_support 
 				$block_spacing_values = gutenberg_style_engine_get_styles(
 					array(
 						'spacing' => $block_spacing,
-						'context' => 'block-supports',
 					)
 				);
 

--- a/lib/block-supports/layout.php
+++ b/lib/block-supports/layout.php
@@ -78,6 +78,7 @@ function gutenberg_get_layout_style( $selector, $layout, $has_block_gap_support 
 				$block_spacing_values = gutenberg_style_engine_get_styles(
 					array(
 						'spacing' => $block_spacing,
+						'context' => 'block-supports',
 					)
 				);
 
@@ -210,7 +211,6 @@ function gutenberg_get_layout_style( $selector, $layout, $has_block_gap_support 
 			$layout_styles,
 			array(
 				'context' => 'block-supports',
-				'enqueue' => true,
 			)
 		);
 	}

--- a/packages/style-engine/README.md
+++ b/packages/style-engine/README.md
@@ -2,6 +2,27 @@
 
 The Style Engine powering global styles and block customizations.
 
+## Important
+
+This Package is considered experimental at the moment. The idea is to have a package used to generate styles based on a
+style object that is consistent between: backend, frontend, block style object and theme.json.
+
+Because this package is experimental and still in development it does not yet generate a `wp.styleEngine` global. To get
+there, the following tasks need to be completed:
+
+**TODO List:**
+
+-   Add style definitions for all the currently supported styles in blocks and theme.json.
+-   The CSS variable shortcuts for values (for presets...)
+-   Support generating styles in the frontend. (Ongoing)
+-   Support generating styles in the backend (block supports and theme.json stylesheet). (Ongoing)
+-   Refactor all block styles to use the style engine server side. (Ongoing)
+-   Consolidate global and block style rendering and enqueuing
+-   Refactor all blocks to consistently use the "style" attribute for all customizations (get rid of the preset specific
+    attributes).
+
+See [Tracking: Add a Style Engine to manage rendering block styles #38167](https://github.com/WordPress/gutenberg/issues/38167)
+
 ## Backend API
 
 ### wp_style_engine_get_styles()
@@ -17,8 +38,7 @@ _Parameters_
 -   _$block_styles_ `array` A block's `attributes.style` object or the top level styles in theme.json
 -   _$options_ `array<string|boolean>` An array of options to determine the output.
     -   _context_ `string` An identifier describing the origin of the style object, e.g., 'block-supports' or '
-        global-styles'. Default is 'block-supports'.
-    -   _enqueue_ `boolean` When `true` will attempt to store and enqueue for rendering in a `style` tag on the site frontend.
+        global-styles'. Default is 'block-supports'. When both `context` and `selector` are set, the style engine will store the CSS rules using the `context` as a key.
     -   _convert_vars_to_classnames_ `boolean` Whether to skip converting CSS var:? values to var( --wp--preset--\* )
         values. Default is `false`.
     -   _selector_ `string` When a selector is passed, `generate()` will return a full CSS rule `$selector { ...rules }`,
@@ -41,8 +61,7 @@ To enqueue a style for rendering in the site's frontend, the `$options` array re
 
 1.  **selector (string)** - this is the CSS selector for your block style CSS declarations.
 2.  **context (string)** - this tells the style engine where to store the styles. Styles in the same context will be
-    batched together and printed in the same HTML style tag. The default is `'block-supports'`.
-3.  **enqueue (boolean)** - tells the style engine to store the styles.
+    stored together.
 
 `wp_style_engine_get_styles` will return the compiled CSS and CSS declarations array.
 
@@ -57,7 +76,6 @@ $styles = wp_style_engine_get_styles(
     array(
         'selector' => '.a-selector',
         'context'  => 'block-supports',
-        'enqueue'  => true,
     )
 );
 print_r( $styles );
@@ -81,8 +99,7 @@ _Parameters_
 -   _$css_rules_ `array<array>`
 -   _$options_ `array<string|boolean>` An array of options to determine the output.
     -   _context_ `string` An identifier describing the origin of the style object, e.g., 'block-supports' or '
-        global-styles'. Default is 'block-supports'.
-    -   _enqueue_ `boolean` When `true` will store using the `context` value as a key.
+        global-styles'. When set, the style engine will store the CSS rules using the `context` value as a key.
 
 _Returns_
 `string` A compiled CSS string based on `$css_rules`.
@@ -113,7 +130,6 @@ $stylesheet = wp_style_engine_get_stylesheet_from_css_rules(
     $styles,
     array(
         'context'  => 'block-supports', // Indicates that these styles should be stored with block supports CSS.
-        'enqueue'  => true, // Render the styles for output.
     )
 );
 print_r( $stylesheet ); // .wp-pumpkin, .wp-kumquat {color:orange}.wp-tomato{color:red;padding:100px}
@@ -125,12 +141,14 @@ Returns compiled CSS from a store, if found.
 
 _Parameters_
 
--   _$store_key_ `string` An identifier describing the origin of the style object, e.g., 'block-supports' or ' global-styles'. Default is 'block-supports'.
+-   _$store_name_ `string` An identifier describing the origin of the style object, e.g., 'block-supports' or ' global-styles'. Default is 'block-supports'.
 
 _Returns_
 `string` A compiled CSS string from the stored CSS rules.
 
 #### Usage
+
+A use case would be to fetch the stylesheet, which contains all the compiled CSS rules from the store, and enqueue it for rendering on the frontend.
 
 ```php
 // First register some styles.
@@ -152,6 +170,11 @@ $stylesheet = wp_style_engine_get_stylesheet_from_css_rules(
 // Later, fetch compiled rules from store.
 $stylesheet = gutenberg_style_engine_get_stylesheet_from_store( 'fruit-styles' );
 print_r( $stylesheet ); // .wp-apple{color:green;}
+if ( ! empty( $stylesheet ) ) {
+    wp_register_style( 'my-stylesheet', false, array(), true, true );
+    wp_add_inline_style( 'my-stylesheet', $stylesheet );
+    wp_enqueue_style( 'my-stylesheet' );
+}
 ```
 
 ## Installation (JS only)
@@ -166,56 +189,6 @@ _This package assumes that your code will run in an **ES2015+** environment. If 
 limited or no support for such language features and APIs, you should
 include [the polyfill shipped in `@wordpress/babel-preset-default`](https://github.com/WordPress/gutenberg/tree/HEAD/packages/babel-preset-default#polyfill)
 in your code._
-
-## Important
-
-This Package is considered experimental at the moment. The idea is to have a package used to generate styles based on a
-style object that is consistent between: backend, frontend, block style object and theme.json.
-
-Because this package is experimental and still in development it does not yet generate a `wp.styleEngine` global. To get
-there, the following tasks need to be completed:
-
-**TODO List:**
-
--   Add style definitions for all the currently supported styles in blocks and theme.json.
--   The CSS variable shortcuts for values (for presets...)
--   Support generating styles in the frontend. (Ongoing)
--   Support generating styles in the backend (block supports and theme.json stylesheet). (Ongoing)
--   Refactor all block styles to use the style engine server side. (Ongoing)
--   Consolidate global and block style rendering and enqueuing
--   Refactor all blocks to consistently use the "style" attribute for all customizations (get rid of the preset specific
-    attributes).
-
-See [Tracking: Add a Style Engine to manage rendering block styles #38167](https://github.com/WordPress/gutenberg/issues/38167)
-
-## Glossary
-
-A guide to the terms and variable names referenced by the Style Engine package.
-
-<dl>
-  <dt>Block style (Gutenberg internal)</dt>
-  <dd>An object comprising a block's style attribute that contains a block's style values. E.g., <code>{ spacing: { margin: '10px' }, color: { ... }, ...  }</code></dd>
-  <dt>Global styles (Gutenberg internal)</dt>
-  <dd>A merged block styles object containing values from a theme's theme.json and user styles settings.</dd>
-  <dt>CSS declaration or (CSS property declaration)</dt>
-  <dd>A CSS property paired with a CSS value. E.g., <code>color: pink</code> </dd>
-  <dt>CSS declarations block</dt>
-  <dd>A set of CSS declarations usually paired with a CSS selector to create a CSS rule.</dd>
-  <dt>CSS property</dt>
-  <dd>Identifiers that describe stylistic, modifiable features of an HTML element. E.g., <code>border</code>, <code>font-size</code>, <code>width</code>...</dd>
-  <dt>CSS rule</dt>
-  <dd>A CSS selector followed by a CSS declarations block inside a set of curly braces. Usually found in a CSS stylesheet.</dd>
-  <dt>CSS selector</dt>
-   <dd>The first component of a CSS rule, a CSS selector is a pattern of elements, classnames or other terms that define the element to which the rule&rsquo;s CSS definitions apply. E.g., <code>p.my-cool-classname > span</code>. See <a href="https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_Selectors" target="_blank">MDN CSS selectors article</a>.</dd>
-  <dt>CSS stylesheet</dt>
-  <dd>A collection of CSS rules contained within a file or within an <a href="https://developer.mozilla.org/en-US/docs/Web/HTML/Element/style" target="_blank">HTML style tag</a>.</dd>
-  <dt>CSS value</dt>
-  <dd>The value of a CSS property. The value determines how the property is modified. E.g., the <code>10vw</code> in <code>height: 10vw</code>.</dd>
-  <dt>CSS variables (vars) or CSS custom properties</dt>
-  <dd>Properties, whose values can be reused in other CSS declarations. Set using custom property notation (e.g., <code>--wp--preset--olive: #808000;</code>) and  accessed using the <code>var()</code> function (e.g., <code>color: var( --wp--preset--olive );</code>). See <a href="https://developer.mozilla.org/en-US/docs/Web/CSS/Using_CSS_custom_properties" target="_blank">MDN article on CSS custom properties</a>.</dd>
-  <dt>Inline styles</dt>
-  <dd>Inline styles are CSS declarations that affect a single HTML element, contained within a style attribute</dd>
-</dl>
 
 ## Usage
 
@@ -248,5 +221,38 @@ _Returns_
 -   `GeneratedCSSRule[]`: generated styles.
 
 <!-- END TOKEN(Autogenerated API docs) -->
+
+## Glossary
+
+A guide to the terms and variable names referenced by the Style Engine package.
+
+<dl>
+  <dt>Block style (Gutenberg internal)</dt>
+  <dd>An object comprising a block's style attribute that contains a block's style values. E.g., <code>{ spacing: { margin: '10px' }, color: { ... }, ...  }</code></dd>
+  <dt>CSS declaration or (CSS property declaration)</dt>
+  <dd>A CSS property paired with a CSS value. E.g., <code>color: pink</code> </dd>
+  <dt>CSS declarations block</dt>
+  <dd>A set of CSS declarations usually paired with a CSS selector to create a CSS rule.</dd>
+  <dt>CSS property</dt>
+  <dd>Identifiers that describe stylistic, modifiable features of an HTML element. E.g., <code>border</code>, <code>font-size</code>, <code>width</code>...</dd>
+  <dt>CSS rule</dt>
+  <dd>A CSS selector followed by a CSS declarations block inside a set of curly braces. Usually found in a CSS stylesheet.</dd>
+  <dt>CSS selector</dt>
+   <dd>The first component of a CSS rule, a CSS selector is a pattern of elements, classnames or other terms that define the element to which the rule&rsquo;s CSS definitions apply. E.g., <code>p.my-cool-classname > span</code>. See <a href="https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_Selectors" target="_blank">MDN CSS selectors article</a>.</dd>
+  <dt>CSS stylesheet</dt>
+  <dd>A collection of CSS rules contained within a file or within an <a href="https://developer.mozilla.org/en-US/docs/Web/HTML/Element/style" target="_blank">HTML style tag</a>.</dd>
+  <dt>CSS value</dt>
+  <dd>The value of a CSS property. The value determines how the property is modified. E.g., the <code>10vw</code> in <code>height: 10vw</code>.</dd>
+  <dt>CSS variables (vars) or CSS custom properties</dt>
+  <dd>Properties, whose values can be reused in other CSS declarations. Set using custom property notation (e.g., <code>--wp--preset--olive: #808000;</code>) and  accessed using the <code>var()</code> function (e.g., <code>color: var( --wp--preset--olive );</code>). See <a href="https://developer.mozilla.org/en-US/docs/Web/CSS/Using_CSS_custom_properties" target="_blank">MDN article on CSS custom properties</a>.</dd>
+  <dt>Global styles (Gutenberg internal)</dt>
+  <dd>A merged block styles object containing values from a theme's theme.json and user styles settings.</dd>
+  <dt>Inline styles</dt>
+  <dd>Inline styles are CSS declarations that affect a single HTML element, contained within a style attribute</dd>
+  <dt>Processor</dt>
+  <dd>Performs compilation and optimization on stored CSS rules. See the class `WP_Style_Engine_Processor`.</dd>
+  <dt>Store</dt>
+  <dd>A data object that contains related styles. See the class `WP_Style_Engine_CSS_Rules_Store`.</dd>
+</dl>
 
 <br/><br/><p align="center"><img src="https://s.w.org/style/images/codeispoetry.png?1" alt="Code is Poetry." /></p>

--- a/packages/style-engine/class-wp-style-engine-css-rules-store.php
+++ b/packages/style-engine/class-wp-style-engine-css-rules-store.php
@@ -47,9 +47,12 @@ class WP_Style_Engine_CSS_Rules_Store {
 	 *
 	 * @param string $store_name The name of the store.
 	 *
-	 * @return WP_Style_Engine_CSS_Rules_Store
+	 * @return WP_Style_Engine_CSS_Rules_Store|void
 	 */
 	public static function get_store( $store_name = 'default' ) {
+		if ( ! is_string( $store_name ) || empty( $store_name ) ) {
+			return;
+		}
 		if ( ! isset( static::$stores[ $store_name ] ) ) {
 			static::$stores[ $store_name ] = new static();
 			// Set the store name.
@@ -111,7 +114,7 @@ class WP_Style_Engine_CSS_Rules_Store {
 	 *
 	 * @param string $selector The CSS selector.
 	 *
-	 * @return WP_Style_Engine_CSS_Rule|null Returns a WP_Style_Engine_CSS_Rule object, or null if the selector is empty.
+	 * @return WP_Style_Engine_CSS_Rule|void Returns a WP_Style_Engine_CSS_Rule object, or null if the selector is empty.
 	 */
 	public function add_rule( $selector ) {
 

--- a/packages/style-engine/phpunit/class-wp-style-engine-css-rules-store-test.php
+++ b/packages/style-engine/phpunit/class-wp-style-engine-css-rules-store-test.php
@@ -30,6 +30,20 @@ class WP_Style_Engine_CSS_Rules_Store_Test extends WP_UnitTestCase {
 	}
 
 	/**
+	 * Should not create a new store with invalid $store_name.
+	 */
+	public function test_store_name_required() {
+		$not_a_store = WP_Style_Engine_CSS_Rules_Store::get_store( '' );
+		$this->assertEmpty( $not_a_store );
+
+		$also_not_a_store = WP_Style_Engine_CSS_Rules_Store::get_store( 123 );
+		$this->assertEmpty( $also_not_a_store );
+
+		$definitely_not_a_store = WP_Style_Engine_CSS_Rules_Store::get_store( null );
+		$this->assertEmpty( $definitely_not_a_store );
+	}
+
+	/**
 	 * Should return previously created store when the same selector key is passed.
 	 */
 	public function test_get_store() {

--- a/packages/style-engine/phpunit/class-wp-style-engine-test.php
+++ b/packages/style-engine/phpunit/class-wp-style-engine-test.php
@@ -133,22 +133,6 @@ class WP_Style_Engine_Test extends WP_UnitTestCase {
 				),
 			),
 
-			'invalid_context'                              => array(
-				'block_styles'    => array(
-					'color'   => array(
-						'text' => 'var:preset|color|sugar',
-					),
-					'spacing' => array(
-						'padding' => '20000px',
-					),
-				),
-				'options'         => array(
-					'convert_vars_to_classnames' => true,
-					'context'                    => 'i-love-doughnuts',
-				),
-				'expected_output' => array(),
-			),
-
 			'inline_valid_box_model_style'                 => array(
 				'block_styles'    => array(
 					'spacing' => array(
@@ -511,7 +495,7 @@ class WP_Style_Engine_Test extends WP_UnitTestCase {
 	/**
 	 * Tests adding rules to a store and retrieving a generated stylesheet.
 	 */
-	public function test_enqueue_block_styles_store() {
+	public function test_store_block_styles_using_context() {
 		$block_styles = array(
 			'spacing' => array(
 				'padding' => array(
@@ -526,7 +510,6 @@ class WP_Style_Engine_Test extends WP_UnitTestCase {
 		$generated_styles = wp_style_engine_get_styles(
 			$block_styles,
 			array(
-				'enqueue'  => true,
 				'context'  => 'block-supports',
 				'selector' => 'article',
 			)
@@ -534,6 +517,28 @@ class WP_Style_Engine_Test extends WP_UnitTestCase {
 		$store            = WP_Style_Engine::get_store( 'block-supports' );
 		$rule             = $store->get_all_rules()['article'];
 		$this->assertSame( $generated_styles['css'], $rule->get_css() );
+	}
+
+	/**
+	 * Tests adding rules to a store and retrieving a generated stylesheet.
+	 */
+	public function test_does_not_store_block_styles_without_context() {
+		$block_styles = array(
+			'typography' => array(
+				'fontSize' => '999px',
+			),
+		);
+
+		wp_style_engine_get_styles(
+			$block_styles,
+			array(
+				'selector' => '#font-size-rulez',
+			)
+		);
+
+		$all_stores = WP_Style_Engine_CSS_Rules_Store_Gutenberg::get_stores();
+
+		$this->assertEmpty( $all_stores );
 	}
 
 	/**
@@ -564,7 +569,6 @@ class WP_Style_Engine_Test extends WP_UnitTestCase {
 			$css_rules,
 			array(
 				'context' => 'test-store',
-				'enqueue' => true,
 			)
 		);
 


### PR DESCRIPTION

## What?
Follow up to https://github.com/WordPress/gutenberg/pull/42880#discussion_r938365560

This PR:

- Removes `enqueue` flag in favour of `context` to indicate that the style engine should store CSS rules.
- Renames $store_key to $store_name for consistency
- Updates tests and README.md
- Checks for valid `$store_name` in `WP_Style_Engine_CSS_Rules_Store`

## Why?
Since moving enqueuing to Gutenberg in https://github.com/WordPress/gutenberg/pull/42880, we no longer need to tell the style engine to "enqueue" styles.

## Testing Instructions

Test in both classic and block themes.

Create some content in a post with link colors and several "layout blocks", e.g., Group and Column.



<details>

<summary>Here's some test HTML:</summary>

```html
<!-- wp:group {"style":{"color":{"background":"#ee6b6b"},"elements":{"link":{"color":{"text":"var:preset|color|vivid-cyan-blue"}}}},"layout":{"type":"flex","flexWrap":"nowrap","justifyContent":"space-between","orientation":"vertical"}} -->
<div class="wp-block-group has-background has-link-color" style="background-color:#ee6b6b"><!-- wp:paragraph {"style":{"elements":{"link":{"color":{"text":"var:preset|color|white"}}}}} -->
<p class="has-link-color"><a href="https://word">Test</a></p>
<!-- /wp:paragraph -->

<!-- wp:paragraph {"style":{"elements":{"link":{"color":{"text":"#eaf1f6"}}}}} -->
<p class="has-link-color"><a href="https://word">Test</a></p>
<!-- /wp:paragraph --></div>
<!-- /wp:group -->

<!-- wp:group {"style":{"color":{"background":"#c4cce6"}},"layout":{"contentSize":"342px"}} -->
<div class="wp-block-group has-background" style="background-color:#c4cce6"><!-- wp:paragraph {"style":{"elements":{"link":{"color":{"text":"var:preset|color|vivid-red"}}}}} -->
<p class="has-link-color"><a href="https://word">Test</a></p>
<!-- /wp:paragraph --></div>
<!-- /wp:group -->

<!-- wp:group {"style":{"color":{"background":"#9eebbc"}},"layout":{"contentSize":"342px"}} -->
<div class="wp-block-group has-background" style="background-color:#9eebbc"><!-- wp:paragraph {"style":{"elements":{"link":{"color":{"text":"#cd31d6"}}}}} -->
<p class="has-link-color"><a href="https://word">Test</a></p>
<!-- /wp:paragraph --></div>
<!-- /wp:group -->
```


</details>

Check that elements and layouts styles are enqueued.

<img width="902" alt="Screen Shot 2022-08-02 at 3 42 30 pm" src="https://user-images.githubusercontent.com/6458278/182300370-058392c3-8adf-4f51-abee-3d62b438845b.png">

Expected CSS output. For classic themes this style tag should appear at the bottom of the page. For block themes, in the head.

```html
<style id='block-supports-styles-inline-css'>
.wp-elements-bfe89bcbd3fbf76f9bf93ac884528d9a a {color: var(--wp--preset--color--vivid-cyan-blue);}.wp-elements-85694c8ee6aa1fb95efca209b615f0b0 a {color: var(--wp--preset--color--white);}.wp-elements-6ac1c4acebd6a433ed64dc4e6b0eb185 a {color: #eaf1f6;}.wp-elements-469734e762a60395c96370480f3c9414 a {color: var(--wp--preset--color--vivid-red);}.wp-elements-9307c4f13980ac2b051b4fcf5f7b28fa a {color: #cd31d6;}.wp-block-group.wp-container-1 {flex-wrap: nowrap; align-items: flex-start;}.wp-block-post-content.wp-container-4 > :where(:not(.alignleft):not(.alignright):not(.alignfull)) {max-width: 840px; margin-left: auto !important; margin-right: auto !important;}.wp-block-post-content.wp-container-4 > .alignwide {max-width: 1100px;}.wp-block-group.wp-container-2 > :where(:not(.alignleft):not(.alignright):not(.alignfull)),.wp-block-group.wp-container-3 > :where(:not(.alignleft):not(.alignright):not(.alignfull)) {max-width: 342px; margin-left: auto !important; margin-right: auto !important;}.wp-block-group.wp-container-2 > .alignwide,.wp-block-group.wp-container-3 > .alignwide {max-width: 342px;}.wp-block-group.wp-container-2 .alignfull,.wp-block-group.wp-container-3 .alignfull,.wp-block-post-content.wp-container-4 .alignfull {max-width: none;}
</style>
```



Run the tests!

`npm run test:unit:php`