### PR TITLE
Spacing presets: Add check for 0 spacing steps

### DIFF
--- a/lib/compat/wordpress-6.1/class-wp-theme-json-6-1.php
+++ b/lib/compat/wordpress-6.1/class-wp-theme-json-6-1.php
@@ -1148,6 +1148,11 @@ class WP_Theme_JSON_6_1 extends WP_Theme_JSON_6_0 {
 	public function set_spacing_sizes() {
 		$spacing_scale = _wp_array_get( $this->theme_json, array( 'settings', 'spacing', 'spacingScale' ), array() );
 
+		// If theme authors want to prevent the generation of the core spacing scale they can set their theme.json spacingScale.steps to 0.
+		if ( 0 === $spacing_scale['steps'] ) {
+			return null;
+		}
+
 		if ( ! is_numeric( $spacing_scale['steps'] )
 			|| ! $spacing_scale['steps'] > 0
 			|| ! isset( $spacing_scale['mediumStep'] )

--- a/lib/compat/wordpress-6.1/class-wp-theme-json-6-1.php
+++ b/lib/compat/wordpress-6.1/class-wp-theme-json-6-1.php
@@ -1148,13 +1148,7 @@ class WP_Theme_JSON_6_1 extends WP_Theme_JSON_6_0 {
 	public function set_spacing_sizes() {
 		$spacing_scale = _wp_array_get( $this->theme_json, array( 'settings', 'spacing', 'spacingScale' ), array() );
 
-		// If theme authors want to prevent the generation of the core spacing scale they can set their theme.json spacingScale.steps to 0.
-		if ( 0 === $spacing_scale['steps'] ) {
-			return null;
-		}
-
 		if ( ! is_numeric( $spacing_scale['steps'] )
-			|| ! $spacing_scale['steps'] > 0
 			|| ! isset( $spacing_scale['mediumStep'] )
 			|| ! isset( $spacing_scale['unit'] )
 			|| ! isset( $spacing_scale['operator'] )
@@ -1166,6 +1160,11 @@ class WP_Theme_JSON_6_1 extends WP_Theme_JSON_6_0 {
 			if ( ! empty( $spacing_scale ) ) {
 				trigger_error( __( 'Some of the theme.json settings.spacing.spacingScale values are invalid', 'gutenberg' ), E_USER_NOTICE );
 			}
+			return null;
+		}
+
+		// If theme authors want to prevent the generation of the core spacing scale they can set their theme.json spacingScale.steps to 0.
+		if ( 0 === $spacing_scale['steps'] ) {
 			return null;
 		}
 


### PR DESCRIPTION
## What?
Adds an early return from `set_spacing_sizes` if spacing.spaceScale.steps === 0.

## Why?
Theme authors should be able to set this to 0 to prevent the generation of the core default spacing presets, and currently doing so causing an `invalid valid` error notice to be thrown.

## How?
If pacing.spaceScale.steps === 0 return from method before spaceScale settings are validated

## Testing Instructions

-  Add the following to your themes `theme.json` file settings section:
```json
    "spacing": {
      "spacingScale": {
        "steps": 0
      }
    }
```
- Load the editor or frontend and make double check that there are no `--wp--preset--spacing--*` CSS properties defined in the page source and that there is no PHP notice at the top of the page.


## Screenshots or screencast 

Before:
<img width="1539" alt="Screen Shot 2022-08-10 at 3 38 41 PM" src="https://user-images.githubusercontent.com/3629020/183807867-7c68301d-55f2-425e-b6af-b6773a0350d0.png">

After:
<img width="807" alt="Screen Shot 2022-08-10 at 3 37 42 PM" src="https://user-images.githubusercontent.com/3629020/183807889-3496176a-93e7-4d11-8cd6-e6012a5e7323.png">



