### PR TITLE
Border Support: Fix disabling of border style control

### DIFF
--- a/packages/block-editor/src/hooks/border.js
+++ b/packages/block-editor/src/hooks/border.js
@@ -268,10 +268,10 @@ export function BorderPanel( props ) {
 					<BorderBoxControl
 						colors={ colors }
 						enableAlpha={ true }
+						enableStyle={ isStyleSupported }
 						onChange={ onBorderChange }
-						popoverPlacement="left-start"
 						popoverOffset={ 40 }
-						showStyle={ isStyleSupported }
+						popoverPlacement="left-start"
 						value={ hydratedBorder }
 						__experimentalHasMultipleOrigins={ true }
 						__experimentalIsRenderedInSidebar={ true }

--- a/packages/edit-site/src/components/global-styles/border-panel.js
+++ b/packages/edit-site/src/components/global-styles/border-panel.js
@@ -179,11 +179,11 @@ export default function BorderPanel( { name } ) {
 					<BorderBoxControl
 						colors={ colors }
 						enableAlpha={ true }
+						enableStyle={ showBorderStyle }
 						onChange={ onBorderChange }
-						showStyle={ showBorderStyle }
-						value={ border }
-						popoverPlacement="left-start"
 						popoverOffset={ 40 }
+						popoverPlacement="left-start"
+						value={ border }
 						__experimentalHasMultipleOrigins={ true }
 						__experimentalIsRenderedInSidebar={ true }
 					/>


### PR DESCRIPTION
## What?

Fixes the prop used to toggle the border style control within the border block support's `BorderBoxControl`.

## Why?

This bug prevents disabling of the border style control by theme or block authors.

## How?

Changes incorrect `showStyle` prop to `enableStyle`

## Testing Instructions

1. On trunk, edit the Group block's border support to opt out of border style.
2. Within the block editor, add a group block, select it and click the border control's color/style button.
3. Note that the border style buttons are still within the popover.
4. Within the site editor, navigate to Global Styles > Blocks > Group > Layout
5. Click on the border control's color/style button and again note the presence of the border style control stll.
6. Checkout this PR and confirm in both editors the border style control is no longer displayed.
7. Ensure the border control and the resulting styles still function as you'd expect without style support.

## Screenshots or screencast <!-- if applicable -->
| Before | After |
|---|---|
| <img width="604" alt="Screen Shot 2022-08-10 at 4 15 44 pm" src="https://user-images.githubusercontent.com/60436221/183829833-732fbbf4-0f74-43a7-b4b3-cbe58872d31a.png"> | <img width="585" alt="Screen Shot 2022-08-10 at 4 16 19 pm" src="https://user-images.githubusercontent.com/60436221/183829862-cba470ab-da34-48fd-8607-dd2f17479205.png"> |

 