### PR TITLE
Navigation: Try to improve the appender in an empty block

### DIFF
--- a/packages/block-editor/src/components/default-block-appender/style.scss
+++ b/packages/block-editor/src/components/default-block-appender/style.scss
@@ -47,6 +47,45 @@
 
 
 /**
+ * Flex container appender appearance.
+ * This renders dashed boxes in flex containers (row/stack style) to indicate their direction.
+ */
+
+.is-layout-flex.block-editor-block-list__block .block-list-appender:only-child {
+	gap: inherit;
+
+	&,
+	.block-editor-default-block-appender__content,
+	.block-editor-button-block-appender,
+	.block-editor-inserter {
+		display: inherit;
+		width: 100%;
+		flex-direction: inherit;
+		flex: 1;
+		box-sizing: border-box;
+	}
+
+	&::after {
+		content: "";
+		display: flex;
+		border: $border-width dashed currentColor;
+		opacity: 0.4;
+		border-radius: $radius-block-ui;
+		flex: 1;
+		pointer-events: none;
+		min-height: $grid-unit-60 - $border-width - $border-width;
+	}
+
+	// Let the parent be selectable in the placeholder area.
+	pointer-events: none;
+	.block-editor-inserter,
+	.block-editor-button-block-appender {
+		pointer-events: all;
+	}
+}
+
+
+/**
  * Fixed position appender.
  * These styles apply to all in-canvas inserters that exist inside nesting containers.
  */

--- a/packages/block-editor/src/components/default-block-appender/style.scss
+++ b/packages/block-editor/src/components/default-block-appender/style.scss
@@ -47,45 +47,6 @@
 
 
 /**
- * Flex container appender appearance.
- * This renders dashed boxes in flex containers (row/stack style) to indicate their direction.
- */
-
-.is-layout-flex.block-editor-block-list__block .block-list-appender:only-child {
-	gap: inherit;
-
-	&,
-	.block-editor-default-block-appender__content,
-	.block-editor-button-block-appender,
-	.block-editor-inserter {
-		display: inherit;
-		width: 100%;
-		flex-direction: inherit;
-		flex: 1;
-		box-sizing: border-box;
-	}
-
-	&::after {
-		content: "";
-		display: flex;
-		border: $border-width dashed currentColor;
-		opacity: 0.4;
-		border-radius: $radius-block-ui;
-		flex: 1;
-		pointer-events: none;
-		min-height: $grid-unit-60 - $border-width - $border-width;
-	}
-
-	// Let the parent be selectable in the placeholder area.
-	pointer-events: none;
-	.block-editor-inserter,
-	.block-editor-button-block-appender {
-		pointer-events: all;
-	}
-}
-
-
-/**
  * Fixed position appender.
  * These styles apply to all in-canvas inserters that exist inside nesting containers.
  */

--- a/packages/block-library/src/navigation/editor.scss
+++ b/packages/block-library/src/navigation/editor.scss
@@ -200,9 +200,9 @@ $color-control-label-height: 20px;
 
 // Override inner padding on default appender.
 // This should be a temporary fix, to be replaced by improvements to
-// the sibling inserter.
+// the sibling inserter. Or by the dropdown appender that is used in Group, instead of the "Button block appender".
 // See https://github.com/WordPress/gutenberg/issues/37572.
-.wp-block-navigation .block-editor-button-block-appender {
+.wp-block-navigation .wp-block + .block-list-appender .block-editor-button-block-appender {
 	background-color: $gray-900;
 	color: $white;
 


### PR DESCRIPTION
## What?

When you create a new navigation menu (Switch menu > Create menu at the moment), you get a big black plus:
<img width="926" alt="Screenshot 2022-08-10 at 10 34 19" src="https://user-images.githubusercontent.com/1204802/183866480-bfc175ca-aa80-403c-81c9-af396e358cda.png">

This PR fixes that by scoping some rules and moving some code around, and also fixes the black plus:

<img width="736" alt="Screenshot 2022-08-10 at 11 21 33" src="https://user-images.githubusercontent.com/1204802/183867564-bd173db7-7953-4ff2-adb3-16e013889217.png">

There's an opportunity for a better fix there, as the nav block at the moment uses the "button block appender". It does this so that the appender can be permanently visible in submenus (see #37572 for more conversation). But this is a divergence that would be good to revisit.

## Testing Instructions

Please test the nav block with empty, full menus, submenus, with and without responsive.

Edit: Updated description per new goals as of https://github.com/WordPress/gutenberg/pull/43115#issuecomment-1213044977
