### PR TITLE
Site Editor: Fix error in compileStyleValue

### DIFF
--- a/packages/edit-site/src/components/global-styles/use-global-styles-output.js
+++ b/packages/edit-site/src/components/global-styles/use-global-styles-output.js
@@ -49,7 +49,11 @@ function compileStyleValue( uncompiledValue ) {
 	const VARIABLE_REFERENCE_PREFIX = 'var:';
 	const VARIABLE_PATH_SEPARATOR_TOKEN_ATTRIBUTE = '|';
 	const VARIABLE_PATH_SEPARATOR_TOKEN_STYLE = '--';
-	if ( uncompiledValue?.startsWith( VARIABLE_REFERENCE_PREFIX ) ) {
+
+	if (
+		typeof uncompiledValue === 'string' &&
+		uncompiledValue.startsWith( VARIABLE_REFERENCE_PREFIX )
+	) {
 		const variable = uncompiledValue
 			.slice( VARIABLE_REFERENCE_PREFIX.length )
 			.split( VARIABLE_PATH_SEPARATOR_TOKEN_ATTRIBUTE )

--- a/packages/edit-site/src/components/global-styles/use-global-styles-output.js
+++ b/packages/edit-site/src/components/global-styles/use-global-styles-output.js
@@ -50,10 +50,7 @@ function compileStyleValue( uncompiledValue ) {
 	const VARIABLE_PATH_SEPARATOR_TOKEN_ATTRIBUTE = '|';
 	const VARIABLE_PATH_SEPARATOR_TOKEN_STYLE = '--';
 
-	if (
-		typeof uncompiledValue === 'string' &&
-		uncompiledValue.startsWith( VARIABLE_REFERENCE_PREFIX )
-	) {
+	if ( uncompiledValue?.startsWith?.( VARIABLE_REFERENCE_PREFIX ) ) {
 		const variable = uncompiledValue
 			.slice( VARIABLE_REFERENCE_PREFIX.length )
 			.split( VARIABLE_PATH_SEPARATOR_TOKEN_ATTRIBUTE )


### PR DESCRIPTION
## What?
Regression after #43019.

RR fixes `uncompiledValue.startsWith is not a function` error in `compileStyleValue`.

## Why?
Based on theme config the `uncompiledValue` can be an integer, and this causes an error.

## How?
Updated condition to check the uncompiledValue type.

## Testing Instructions
I noticed the error when visiting the site editor using [Stewart](https://wordpress.org/themes/stewart/) theme.

1. Using the Stewart theme visit the Site Editor.
2. Confirm there're no JS errors.

## Screenshots or screencast <!-- if applicable -->

![CleanShot 2022-08-10 at 14 17 25](https://user-images.githubusercontent.com/240569/183878125-7305787f-e424-4145-9feb-a68c0c7d0308.png)

