### PR TITLE
Lodash: Refactor away from `_.deburr()`

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -85,6 +85,7 @@ module.exports = {
 							'compact',
 							'concat',
 							'countBy',
+							'deburr',
 							'defaults',
 							'defaultTo',
 							'delay',

--- a/package-lock.json
+++ b/package-lock.json
@@ -16658,6 +16658,7 @@
 				"lodash": "^4.17.21",
 				"memize": "^1.1.0",
 				"rememo": "^4.0.0",
+				"remove-accents": "^0.4.2",
 				"showdown": "^1.9.1",
 				"simple-html-tokenizer": "^0.5.7",
 				"uuid": "^8.3.0"

--- a/packages/blocks/package.json
+++ b/packages/blocks/package.json
@@ -47,6 +47,7 @@
 		"lodash": "^4.17.21",
 		"memize": "^1.1.0",
 		"rememo": "^4.0.0",
+		"remove-accents": "^0.4.2",
 		"showdown": "^1.9.1",
 		"simple-html-tokenizer": "^0.5.7",
 		"uuid": "^8.3.0"

--- a/packages/blocks/src/store/selectors.js
+++ b/packages/blocks/src/store/selectors.js
@@ -2,7 +2,8 @@
  * External dependencies
  */
 import createSelector from 'rememo';
-import { deburr, filter, flow, get, includes, map, some } from 'lodash';
+import removeAccents from 'remove-accents';
+import { filter, flow, get, includes, map, some } from 'lodash';
 
 /** @typedef {import('../api/registration').WPBlockVariation} WPBlockVariation */
 /** @typedef {import('../api/registration').WPBlockVariationScope} WPBlockVariationScope */
@@ -688,7 +689,7 @@ export function isMatchingSearchTerm( state, nameOrType, searchTerm ) {
 	const getNormalizedSearchTerm = flow( [
 		// Disregard diacritics.
 		//  Input: "média"
-		deburr,
+		( term ) => removeAccents( term ?? '' ),
 
 		// Lowercase.
 		//  Input: "MEDIA"


### PR DESCRIPTION
## What?
This PR removes the `_.deburr()` usage completely and deprecates the function in favor of `remove-accents` that we've been using in other packages already.

## Why?

Lodash is known to unnecessarily inflate the bundle size of packages, and in most cases, it can be replaced with native language functionality. See these for more information and rationale:

* https://github.com/WordPress/gutenberg/issues/16938#issuecomment-602837246
* https://github.com/WordPress/gutenberg/issues/17025
* https://github.com/WordPress/gutenberg/issues/39495 

## How?

Like in other PRs, we replace `deburr()` with `removeAccents()` and add any necessary checks (the nullish coalescing in this case).

## Testing Instructions
* In Editor settings, click Preferences, and under Blocks, verify the block search form still works.
* Verify all tests still pass, particularly `npm run test:unit packages/blocks/src/store/test/selectors.js`