### PR TITLE
adding center align css for social icon issue

### DIFF
--- a/packages/block-library/src/social-links/editor.scss
+++ b/packages/block-library/src/social-links/editor.scss
@@ -87,7 +87,8 @@
 }
 
 // Center flex items. This has an equivalent in style.scss.
-.wp-block[data-align="center"] > .wp-block-social-links {
+.wp-block[data-align="center"] > .wp-block-social-links,
+.wp-block.wp-block-social-links.aligncenter {
 	justify-content: center;
 }
 


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->
Social icons block has center align issue in some themes like Twenty Twenty-Two and TT1 Blocks. And by discussing with core member @sabernhardt, we conclude that this issue is of block not of the theme.

PR will fix: https://github.com/WordPress/gutenberg/issues/43048

I created this PR because @sabernhardt, told me some changes. So I created a new PR with those changes. Please review it. 

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
In themes like Twenty Twenty-Two and TT1 Blocks, the justify-content: flex-start; style is added to the container class so it was overriding the social icon block center CSS.

/* block-library/style.css */
.wp-block-social-links.aligncenter {
display: flex;
justify-content: center;
}

So to fix this issue, I created a strong hierarchy to override the justify-content: flex-start; style.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->
1. Activate the Twenty Twenty-Two theme.
2. Create a new post and insert a social icon block. Note: If you add the social icons block in the Site Editor, the option to align left/center/right is not always available.
3. Select "Align center" in the dropdown. This does not center the icons in the editor.

## Screenshots or screencast <!-- if applicable -->
