### PR TITLE
[Style Engine]: Defensive guarding for when style does not define the 'individual' property

### DIFF
--- a/packages/style-engine/class-wp-style-engine.php
+++ b/packages/style-engine/class-wp-style-engine.php
@@ -410,6 +410,11 @@ class WP_Style_Engine {
 		// If the input contains an array, assume box model-like properties
 		// for styles such as margins and padding.
 		if ( is_array( $style_value ) ) {
+			// Bail out early if the `'individual'` property is not defined.
+			if ( ! isset( $style_property_keys['individual'] ) ) {
+				return $css_declarations;
+			}
+
 			foreach ( $style_value as $key => $value ) {
 				if ( is_string( $value ) && strpos( $value, 'var:' ) !== false && ! $should_skip_css_vars && ! empty( $style_definition['css_vars'] ) ) {
 					$value = static::get_css_var_value( $value, $style_definition['css_vars'] );


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

Closes https://github.com/WordPress/gutenberg/issues/43121

## What?
This PR adds defensive guarding to protect against when the style `$property_keys` do not define the `'individual'` property.

## Why?
Prevents a PHP Notice "Undefined index: individual" from being thrown in `WP_Style_Engine::get_css_declarations()` when a style is not an `'individual'`.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

It bails out early by not iterating through the array of `$style_value`. Why? None of that style is `individual`.

## Testing

* Step 1: Turn on `WP_DEBUG` and run the PHPUnit tests. How? 

Add the following code about loading Composer deps in the `phpunit/bootstrap.php` file:
```php
// Test with WordPress debug mode (default).
if ( ! defined( 'WP_DEBUG' ) ) {
	define( 'WP_DEBUG', true );
}
```

* Step 2: Locally run the PHPUnit tests _before_ applying this patch. Notice the following PHP Notice:

```
WP_Style_Engine_Test::test_generate_get_styles with data set "invalid_classnames_options" (array(array(array('friends'), array('tasty'))), array(), array())
Undefined index: individual

/var/www/html/wp-content/plugins/gutenberg/packages/style-engine/class-wp-style-engine.php:422
/var/www/html/wp-content/plugins/gutenberg/packages/style-engine/class-wp-style-engine.php:338
/var/www/html/wp-content/plugins/gutenberg/packages/style-engine/class-wp-style-engine.php:562
/var/www/html/wp-content/plugins/gutenberg/packages/style-engine/phpunit/class-wp-style-engine-test.php:37
phpvfscomposer:///var/www/html/wp-content/plugins/gutenberg/vendor/phpunit/phpunit/phpunit:[52](https://github.com/WordPress/gutenberg/runs/7756878353?check_suite_focus=true#step:7:53)
```

* Step 3: Apply this patch.

* Step 4: Run the PHPUnit tests again. The above PHP Notice is resolved.

## Notes:

PR #41302 turns on debug mode for testing PHP notices and deprecations.