### PR TITLE
Post title: fix pasting into existing content

### DIFF
--- a/packages/editor/src/components/post-title/index.js
+++ b/packages/editor/src/components/post-title/index.js
@@ -19,7 +19,12 @@ import { ENTER } from '@wordpress/keycodes';
 import { useSelect, useDispatch } from '@wordpress/data';
 import { pasteHandler } from '@wordpress/blocks';
 import { store as blockEditorStore } from '@wordpress/block-editor';
-import { __unstableUseRichText as useRichText } from '@wordpress/rich-text';
+import {
+	__unstableUseRichText as useRichText,
+	create,
+	toHTMLString,
+	insert,
+} from '@wordpress/rich-text';
 import { useMergeRefs } from '@wordpress/compose';
 
 /**
@@ -169,7 +174,16 @@ function PostTitle( _, forwardedRef ) {
 				onInsertBlockAfter( content );
 			}
 		} else {
-			onUpdate( content );
+			const value = {
+				...create( { html: title } ),
+				...selection,
+			};
+			const newValue = insert( value, create( { html: content } ) );
+			onUpdate( toHTMLString( { value: newValue } ) );
+			setSelection( {
+				start: newValue.start,
+				end: newValue.end,
+			} );
 		}
 	}
 

--- a/test/e2e/specs/editor/various/copy-cut-paste.spec.js
+++ b/test/e2e/specs/editor/various/copy-cut-paste.spec.js
@@ -416,4 +416,20 @@ test.describe( 'Copy/cut/paste', () => {
 			await page.evaluate( () => document.activeElement.innerHTML )
 		).toMatchSnapshot();
 	} );
+
+	test( 'should paste single line in post title with existing content', async ( {
+		page,
+		pageUtils,
+	} ) => {
+		await page.keyboard.type( 'ab' );
+		await page.keyboard.press( 'ArrowLeft' );
+		await pageUtils.setClipboardData( {
+			html: '<span style="border: 1px solid black">x</span>',
+		} );
+		await pageUtils.pressKeyWithModifier( 'primary', 'v' );
+		// Expect the span to be filtered out.
+		expect(
+			await page.evaluate( () => document.activeElement.innerHTML )
+		).toBe( 'axb' );
+	} );
 } );

--- a/test/e2e/specs/editor/various/copy-cut-paste.spec.js
+++ b/test/e2e/specs/editor/various/copy-cut-paste.spec.js
@@ -427,9 +427,10 @@ test.describe( 'Copy/cut/paste', () => {
 			html: '<span style="border: 1px solid black">x</span>',
 		} );
 		await pageUtils.pressKeyWithModifier( 'primary', 'v' );
-		// Expect the span to be filtered out.
+		// Ensure the selection is correct.
+		await page.keyboard.type( 'y' );
 		expect(
 			await page.evaluate( () => document.activeElement.innerHTML )
-		).toBe( 'axb' );
+		).toBe( 'axyb' );
 	} );
 } );


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?

Fixes #43066.

## Why?

Currently existing content is replaced.

## How?

Using rich text tools.

## Testing Instructions

Create a post and enter a title. Paste in the middle of the title.

## Screenshots or screencast <!-- if applicable -->
