### PR TITLE
URL should not be translatable

### DIFF
--- a/lib/compat/wordpress-6.0/class-gutenberg-rest-pattern-directory-controller.php
+++ b/lib/compat/wordpress-6.0/class-gutenberg-rest-pattern-directory-controller.php
@@ -92,7 +92,7 @@ class Gutenberg_REST_Pattern_Directory_Controller extends WP_REST_Pattern_Direct
 					sprintf(
 					/* translators: %s: Support forums URL. */
 						__( 'An unexpected error occurred. Something may be wrong with WordPress.org or this server&#8217;s configuration. If you continue to have problems, please try the <a href="%s">support forums</a>.', 'gutenberg' ),
-						__( 'https://wordpress.org/support/forums/', 'gutenberg' )
+						esc_url( 'https://wordpress.org/support/forums/' )
 					),
 					array(
 						'response' => wp_remote_retrieve_body( $wporg_response ),


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->
The static URL of anchor tag is passed to translation function

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
This may turns to invalid URL if translated.

