### PR TITLE
PHPCS: Exclude PHPUnit tests from file and class name sniffs (for Core parity)

### DIFF
--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -87,5 +87,14 @@
 	<!-- Ignore filename error since it requires WP core build process change -->
 	<rule ref="WordPress.Files.FileName.InvalidClassFileName">
 		<exclude-pattern>./packages/block-serialization-default-parser/parser.php</exclude-pattern>
+		<exclude-pattern>/phpunit/*</exclude-pattern>
+	</rule>
+
+	<!-- Exclude PHPUnit tests from file and class name sniffs (for Core parity). -->
+	<rule ref="WordPress.Files.FileName.NotHyphenatedLowercase">
+		<exclude-pattern>/phpunit/*</exclude-pattern>
+	</rule>
+	<rule ref="PEAR.NamingConventions.ValidClassName.Invalid">
+		<exclude-pattern>/phpunit/*</exclude-pattern>
 	</rule>
 </ruleset>


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->
Use Core's file and class name sniffs exclusions for the PHPUnit tests.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

To reduce the effort of backporting tests to Core by increasing parity to [WordPress Coding Standards](https://make.wordpress.org/core/handbook/testing/automated-testing/writing-phpunit-tests/#test-classes).

Test Classes and files in Core require the following:
>Test class names should reflect the filepath, with underscores replacing directory separators and TitleCase replacing camelCase. Thus, the class `Tests_Comment_GetCommentClass()`, which contains tests for the `get_comment_class()` function, is located in `tests/comment/getCommentClass.php`.

So a test file is named as: `group/funcName.php` or `group/className.php`.

Core's tests include the same exclusions in [its `phpcs.xml.dist` file](https://github.com/WordPress/wordpress-develop/blob/trunk/phpcs.xml.dist#L310-L316).

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

## Testing Instructions

Before applying the patch:
1. Rename the `class-wp-webfonts-test.php` file to `wpWebfonts.php`.
2. Rename its class from `WP_Webfonts_Test` to `Tests_Webfonts_WpWebfonts`.
3. In terminal, run the linter on this file: `npm run lint:php phpunit/wpWebfonts.php`.

Results: `WordPress.Files.FileName.NotHyphenatedLowercase` linting error.
![Screen Shot 2022-08-10 at 4 04 28 PM](https://user-images.githubusercontent.com/7284611/184019898-ba65088f-9e0a-4a6a-b7a1-86d070ec2520.png)

After applying the patch:
Rerun step 3 above. Results: No linting errors.
![Screen Shot 2022-08-10 at 4 07 05 PM](https://user-images.githubusercontent.com/7284611/184020195-49d75424-ef98-424e-b710-d955403d64b0.png)
