### PR TITLE
wp-env: Set core source to latest when null

### DIFF
--- a/packages/env/CHANGELOG.md
+++ b/packages/env/CHANGELOG.md
@@ -3,15 +3,17 @@
 ## Unreleased
 
 ### Bug Fix
-- Fix a crash when "core" was set to `null` in a `.wp-env.json` file. We now use the latest stable WordPress version in that case. This also restores the previous behavior of `"core": null` in `.wp-env.override.json`, which was to use the default WordPress version.
+-   Fix a crash when "core" was set to `null` in a `.wp-env.json` file. We now use the latest stable WordPress version in that case. This also restores the previous behavior of `"core": null` in `.wp-env.override.json`, which was to use the default WordPress version.
+
+## 5.1.0 (2022-08-10)
 
 ## 5.1.0 (2022-08-10)
 
 ### Enhancement
-- Previously, wp-env used the WordPress version provided by Docker in the WordPress image for installations which don't specify a WordPress version. Now, wp-env will find the latest stable version on WordPress.org and check out the https://github.com/WordPress/WordPress repository at the tag matching that version. In most cases, this will match what Docker provides. The benefit is that wp-env (and WordPress.org) now controls the default WordPress version rather than Docker.
+-   Previously, wp-env used the WordPress version provided by Docker in the WordPress image for installations which don't specify a WordPress version. Now, wp-env will find the latest stable version on WordPress.org and check out the https://github.com/WordPress/WordPress repository at the tag matching that version. In most cases, this will match what Docker provides. The benefit is that wp-env (and WordPress.org) now controls the default WordPress version rather than Docker.
 
 ### Bug Fix
-- Downloading a default WordPress version also resolves a bug where the wrong WordPress test files were used if no core source was specified in wp-env.json. The current trunk test files were downloaded rather than the stable version. Now, the test files will match the default stable version.
+-   RDownloading a default WordPress version also resolves a bug where the wrong WordPress test files were used if no core source was specified in wp-env.json. The current trunk test files were downloaded rather than the stable version. Now, the test files will match the default stable version.
 
 ## 5.0.0 (2022-07-27)
 

--- a/packages/env/CHANGELOG.md
+++ b/packages/env/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## Unreleased
 
 ### Bug Fix
--   Fix a crash when "core" was set to `null` in a `.wp-env.json` file. We now use the latest stable WordPress version in that case. This also restores the previous behavior of `"core": null` in `.wp-env.override.json`, which was to use the default WordPress version.
+-   Fix a crash when "core" was set to `null` in a `.wp-env.json` file. We now use the latest stable WordPress version in that case. This also restores the previous behavior of `"core": null` in `.wp-env.override.json`, which was to use the latest stable WordPress version.
 
 ## 5.1.0 (2022-08-10)
 

--- a/packages/env/CHANGELOG.md
+++ b/packages/env/CHANGELOG.md
@@ -7,8 +7,6 @@
 
 ## 5.1.0 (2022-08-10)
 
-## 5.1.0 (2022-08-10)
-
 ### Enhancement
 -   Previously, wp-env used the WordPress version provided by Docker in the WordPress image for installations which don't specify a WordPress version. Now, wp-env will find the latest stable version on WordPress.org and check out the https://github.com/WordPress/WordPress repository at the tag matching that version. In most cases, this will match what Docker provides. The benefit is that wp-env (and WordPress.org) now controls the default WordPress version rather than Docker.
 

--- a/packages/env/CHANGELOG.md
+++ b/packages/env/CHANGELOG.md
@@ -13,7 +13,7 @@
 -   Previously, wp-env used the WordPress version provided by Docker in the WordPress image for installations which don't specify a WordPress version. Now, wp-env will find the latest stable version on WordPress.org and check out the https://github.com/WordPress/WordPress repository at the tag matching that version. In most cases, this will match what Docker provides. The benefit is that wp-env (and WordPress.org) now controls the default WordPress version rather than Docker.
 
 ### Bug Fix
--   RDownloading a default WordPress version also resolves a bug where the wrong WordPress test files were used if no core source was specified in wp-env.json. The current trunk test files were downloaded rather than the stable version. Now, the test files will match the default stable version.
+-   Downloading a default WordPress version also resolves a bug where the wrong WordPress test files were used if no core source was specified in wp-env.json. The current trunk test files were downloaded rather than the stable version. Now, the test files will match the default stable version.
 
 ## 5.0.0 (2022-07-27)
 

--- a/packages/env/CHANGELOG.md
+++ b/packages/env/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+### Bug Fix
+- Fix a crash when "core" was set to `null` in a `.wp-env.json` file. We now use the latest stable WordPress version in that case. This also restores the previous behavior of `"core": null` in `.wp-env.override.json`, which was to use the default WordPress version.
+
 ## 5.1.0 (2022-08-10)
 
 ### Enhancement

--- a/packages/env/lib/config/config.js
+++ b/packages/env/lib/config/config.js
@@ -246,7 +246,7 @@ async function getDefaultBaseConfig( configPath ) {
  * @param {WPConfig} config fully parsed configuration object.
  * @return {WPConfig} configuration object with overrides applied.
  */
-async function withOverrides( config ) {
+function withOverrides( config ) {
 	const workDirectoryPath = config.workDirectoryPath;
 	// Override port numbers with environment variables.
 	config.env.development.port =

--- a/packages/env/lib/config/config.js
+++ b/packages/env/lib/config/config.js
@@ -143,7 +143,7 @@ module.exports = async function readConfig( configPath ) {
 	// Merge each of the specified environment-level overrides.
 	const allPorts = new Set(); // Keep track of unique ports for validation.
 	const env = {};
-	for ( const envName in allEnvs ) {
+	for ( const envName of allEnvs ) {
 		env[ envName ] = await parseConfig(
 			validateConfig(
 				mergeWpServiceConfigs( [

--- a/packages/env/lib/config/parse-config.js
+++ b/packages/env/lib/config/parse-config.js
@@ -38,7 +38,10 @@ module.exports = async function parseConfig( config, options ) {
 		port: config.port,
 		phpVersion: config.phpVersion,
 		coreSource: includeTestsPath(
-			parseSourceString( getCoreSourceString( config.core ), options ),
+			parseSourceString(
+				await getCoreSourceString( config.core ),
+				options
+			),
 			options
 		),
 		pluginSources: config.plugins.map( ( sourceString ) =>

--- a/packages/env/lib/wordpress.js
+++ b/packages/env/lib/wordpress.js
@@ -277,13 +277,19 @@ async function readWordPressVersion( coreSource, spinner, debug ) {
  *
  * @return {string} The latest stable version of WordPress, like "6.0.1"
  */
+let CACHED_VERSION;
 async function getLatestWordPressVersion() {
+	if ( CACHED_VERSION ) {
+		return CACHED_VERSION;
+	}
+
 	const versions = await got(
 		'https://api.wordpress.org/core/stable-check/1.0/'
 	).json();
 
 	for ( const [ version, status ] of Object.entries( versions ) ) {
 		if ( status === 'latest' ) {
+			CACHED_VERSION = version;
 			return version;
 		}
 	}

--- a/packages/env/lib/wordpress.js
+++ b/packages/env/lib/wordpress.js
@@ -277,10 +277,11 @@ async function readWordPressVersion( coreSource, spinner, debug ) {
  *
  * @return {string} The latest stable version of WordPress, like "6.0.1"
  */
-let CACHED_VERSION;
+let CACHED_WP_VERSION;
 async function getLatestWordPressVersion() {
-	if ( CACHED_VERSION ) {
-		return CACHED_VERSION;
+	// Avoid extra network requests.
+	if ( CACHED_WP_VERSION ) {
+		return CACHED_WP_VERSION;
 	}
 
 	const versions = await got(
@@ -289,7 +290,7 @@ async function getLatestWordPressVersion() {
 
 	for ( const [ version, status ] of Object.entries( versions ) ) {
 		if ( status === 'latest' ) {
-			CACHED_VERSION = version;
+			CACHED_WP_VERSION = version;
 			return version;
 		}
 	}


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
On trunk, there is a bug where if `.wp-env.json` sets `"core": null`, wp-env will crash. This PR handles that case.

Fixes #43222

## Why?
The object spread operators which merge all of the configurations together override the default "latest version" string with this null value.

## How?
In the overrides section of the config, we check if any of the core source values are still null, and then manually set the versions if needed. This means the core source should never be null.

## Testing Instructions
1. Use the trunk branch to start
2. In Gutenberg's wp-env.json file, change "core" to be `null`
3. Run `npx wp-env start --debug`. Observe that the core source in the printed config file is null and that wp-env crashes.
4. Checkout this branch.
5. Keep the wp-env.json change from step 2.
6. Run `npx wp-env start --debug`. It should start successfully, and you should see a git core source printed in the config file.
