### PR TITLE
List View: Ensure long anchors don't cause the List View to extend

### DIFF
--- a/packages/block-editor/src/components/list-view/block-select-button.js
+++ b/packages/block-editor/src/components/list-view/block-select-button.js
@@ -90,8 +90,13 @@ function ListViewBlockSelectButton(
 						<Truncate ellipsizeMode="auto">{ blockTitle }</Truncate>
 					</span>
 					{ blockInformation?.anchor && (
-						<span className="block-editor-list-view-block-select-button__anchor">
-							{ blockInformation.anchor }
+						<span className="block-editor-list-view-block-select-button__anchor-wrapper">
+							<Truncate
+								className="block-editor-list-view-block-select-button__anchor"
+								ellipsizeMode="auto"
+							>
+								{ blockInformation.anchor }
+							</Truncate>
 						</span>
 					) }
 					{ isLocked && (

--- a/packages/block-editor/src/components/list-view/style.scss
+++ b/packages/block-editor/src/components/list-view/style.scss
@@ -312,14 +312,21 @@
 		}
 	}
 
+	.block-editor-list-view-block-select-button__anchor-wrapper {
+		position: relative;
+		max-width: min(110px, 40%);
+		width: 100%;
+	}
+
 	.block-editor-list-view-block-select-button__anchor {
+		position: absolute;
+		right: 0;
+		transform: translateY(-50%);
 		background: rgba($black, 0.1);
 		border-radius: $radius-block-ui;
-		display: inline-block;
 		padding: 2px 6px;
-		max-width: min(100px, 40%);
-		overflow: hidden;
-		text-overflow: ellipsis;
+		max-width: 100%;
+		box-sizing: border-box;
 	}
 
 	&.is-selected .block-editor-list-view-block-select-button__anchor {


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Fixes #43125 where long anchor text would extend the width of the list view even though the text was being truncated. The issue was likely introduced in #41855.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

In the List View, add an additional wrapper around the anchor text, similar to the wrapping of the block title. This ensures that we can us absolute positioning for the anchor text, which prevents the real text content from extending the size of the flexbox. For a description of this kind of problem, there's a helpful CSS Tricks article on the topic: https://css-tricks.com/flexbox-truncated-text/ — in the case of the List View our needs appear to be a little more complex, so the solution in that article `min-content: 0` wasn't quite enough. Still, hopefully it helps explain why the issue exists.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

Add a wrapper to the anchor text in the List View and set the truncated text to use absolute positioning so that it doesn't extend the size of the List View but instead fills the available space.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->

Ensure that long anchor text does not extend the list view as reported in #43125. For ease of testing here's some test markup:

<details>
<summary>Test markup with a variety of different anchor texts</summary>

```html
<!-- wp:paragraph -->
<p id="a-really-long-html-anchor-added-to-a-paragraph-block">A paragraph with long anchor text.</p>
<!-- /wp:paragraph -->

<!-- wp:paragraph -->
<p id="short-anchor">A paragraph with short anchor text.</p>
<!-- /wp:paragraph -->

<!-- wp:paragraph -->
<p id="a-really-long-html-anchor-added-to-a-paragraph-block">A paragraph without anchor text.</p>
<!-- /wp:paragraph -->

<!-- wp:heading {"level":3} -->
<h3>A short heading</h3>
<!-- /wp:heading -->

<!-- wp:heading {"level":3} -->
<h3>A long heading with that gets truncated in the list view due to how long it is</h3>
<!-- /wp:heading -->

<!-- wp:heading -->
<h2 id="a-really-long-piece-of-anchor-text-attached-to-a-heading-block">A long heading with long anchor text attached to it.</h2>
<!-- /wp:heading -->

<!-- wp:heading {"lock":{"move":true,"remove":true}} -->
<h2 id="a-really-long-piece-of-anchor-text-attached-to-a-heading-block">A long heading with long anchor text attached to it, that is locked</h2>
<!-- /wp:heading -->
```

</details>

## Screenshots or screencast <!-- if applicable -->

| Before | After |
| --- | --- |
| <img width="536" alt="image" src="https://user-images.githubusercontent.com/14988353/184053534-0ee95f33-dfe8-42fa-952c-bd1a84b6dad6.png"> | <img width="348" alt="image" src="https://user-images.githubusercontent.com/14988353/184053613-4b3267d5-fc00-43e1-83c7-084456bebf95.png"> |