### PR TITLE
Fix drag and drop indicator before first block and after last block

### DIFF
--- a/packages/block-editor/src/components/block-popover/inbetween.js
+++ b/packages/block-editor/src/components/block-popover/inbetween.js
@@ -154,7 +154,10 @@ function BlockPopoverInbetween( {
 
 	const popoverScrollRef = usePopoverScroll( __unstableContentRef );
 
-	if ( ! previousElement || ! nextElement || ! isVisible ) {
+	// If there's either a previous or a next element, show the inbetween popover.
+	// Note that drag and drop uses the inbetween popover to show the drop indicator
+	// before the first block and after the last block.
+	if ( ( ! previousElement && ! nextElement ) || ! isVisible ) {
 		return null;
 	}
 

--- a/packages/e2e-tests/specs/editor/various/__snapshots__/draggable-block.test.js.snap
+++ b/packages/e2e-tests/specs/editor/various/__snapshots__/draggable-block.test.js.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`Draggable block should drag and drop 1`] = `
+exports[`Draggable block can drag and drop to the bottom of a block list 1`] = `
 "<!-- wp:paragraph -->
 <p>1</p>
 <!-- /wp:paragraph -->
@@ -10,7 +10,27 @@ exports[`Draggable block should drag and drop 1`] = `
 <!-- /wp:paragraph -->"
 `;
 
-exports[`Draggable block should drag and drop 2`] = `
+exports[`Draggable block can drag and drop to the bottom of a block list 2`] = `
+"<!-- wp:paragraph -->
+<p>2</p>
+<!-- /wp:paragraph -->
+
+<!-- wp:paragraph -->
+<p>1</p>
+<!-- /wp:paragraph -->"
+`;
+
+exports[`Draggable block can drag and drop to the top of a block list 1`] = `
+"<!-- wp:paragraph -->
+<p>1</p>
+<!-- /wp:paragraph -->
+
+<!-- wp:paragraph -->
+<p>2</p>
+<!-- /wp:paragraph -->"
+`;
+
+exports[`Draggable block can drag and drop to the top of a block list 2`] = `
 "<!-- wp:paragraph -->
 <p>2</p>
 <!-- /wp:paragraph -->

--- a/packages/e2e-tests/specs/editor/various/draggable-block.test.js
+++ b/packages/e2e-tests/specs/editor/various/draggable-block.test.js
@@ -7,28 +7,37 @@ import {
 	deactivatePlugin,
 	activatePlugin,
 	showBlockToolbar,
+	setBrowserViewport,
+	waitForWindowDimensions,
 } from '@wordpress/e2e-test-utils';
 
 describe( 'Draggable block', () => {
-	beforeAll( async () => {
-		await page.setDragInterception( true );
+	// Tests don't seem to pass if beforeAll and afterAll are used.
+	// Unsure why.
+	beforeEach( async () => {
 		await deactivatePlugin(
 			'gutenberg-test-plugin-disables-the-css-animations'
 		);
+
+		// Set the viewport at a larger size than normal to ensure scrolling doesn't occur.
+		// Scrolling can interfere with the drag coordinates.
+		await page.setViewport( { width: 960, height: 1024 } );
+		await waitForWindowDimensions( 960, 1024 );
+		await createNewPost();
+		await page.setDragInterception( true );
 	} );
 
-	afterAll( async () => {
+	afterEach( async () => {
 		await page.setDragInterception( false );
+
+		// Reset the viewport to normal large size.
+		await setBrowserViewport( 'large' );
 		await activatePlugin(
 			'gutenberg-test-plugin-disables-the-css-animations'
 		);
 	} );
 
-	beforeEach( async () => {
-		await createNewPost();
-	} );
-
-	it( 'should drag and drop', async () => {
+	it( 'can drag and drop to the top of a block list', async () => {
 		await page.keyboard.press( 'Enter' );
 		await page.keyboard.type( '1' );
 		await page.keyboard.press( 'Enter' );
@@ -43,15 +52,75 @@ describe( 'Draggable block', () => {
 		);
 		const dragHandlePoint = await dragHandle.clickablePoint();
 
-		const paragraph = await page.$( '[data-type="core/paragraph"]' );
-		const paragraphPoint = await paragraph.clickablePoint();
-		const paragraphRect = await paragraph.boundingBox();
-
-		await page.mouse.dragAndDrop( dragHandlePoint, {
-			x: paragraphPoint.x,
+		const firstParagraph = await page.$( '[data-type="core/paragraph"]' );
+		const targetPoint = await firstParagraph.clickablePoint();
+		const targetRect = await firstParagraph.boundingBox();
+		const target = {
+			x: targetPoint.x,
 			// Drag to the top half.
-			y: paragraphPoint.y - paragraphRect.height / 4,
-		} );
+			y: targetPoint.y - targetRect.height * 0.25,
+		};
+
+		const dragData = await page.mouse.drag( dragHandlePoint, target );
+		await page.mouse.dragEnter( target, dragData );
+		await page.mouse.dragOver( target, dragData );
+
+		// Wait for the insertion point to be visible.
+		const insertionPoint = await page.waitForSelector(
+			'.block-editor-block-list__insertion-point'
+		);
+
+		// Expect the insertion point to be visible above the first paragraph.
+		const insertionPointBoundingBox = await insertionPoint.boundingBox();
+		expect( insertionPointBoundingBox.y ).toBeLessThan( target.y );
+
+		await page.mouse.drop( target, dragData );
+
+		expect( await getEditedPostContent() ).toMatchSnapshot();
+	} );
+
+	it( 'can drag and drop to the bottom of a block list', async () => {
+		await page.keyboard.press( 'Enter' );
+		await page.keyboard.type( '1' );
+		await page.keyboard.press( 'Enter' );
+		await page.keyboard.type( '2' );
+		await page.keyboard.press( 'ArrowUp' );
+
+		// Confirm correct setup.
+		expect( await getEditedPostContent() ).toMatchSnapshot();
+
+		const [ , secondParagraph ] = await page.$$(
+			'[data-type="core/paragraph"]'
+		);
+
+		await showBlockToolbar();
+		const dragHandle = await page.waitForSelector(
+			'.block-editor-block-mover__drag-handle'
+		);
+		const dragHandlePoint = await dragHandle.clickablePoint();
+
+		const targetPoint = await secondParagraph.clickablePoint();
+		const targetRect = await secondParagraph.boundingBox();
+		const target = {
+			x: targetPoint.x,
+			// Drag to the bottom half.
+			y: targetPoint.y + targetRect.height * 0.25,
+		};
+
+		const dragData = await page.mouse.drag( dragHandlePoint, target );
+		await page.mouse.dragEnter( target, dragData );
+		await page.mouse.dragOver( target, dragData );
+
+		// Wait for the insertion point to be visible.
+		const insertionPoint = await page.waitForSelector(
+			'.block-editor-block-list__insertion-point'
+		);
+
+		// Expect the insertion point to be visible below the first paragraph.
+		const insertionPointBoundingBox = await insertionPoint.boundingBox();
+		expect( insertionPointBoundingBox.y ).toBeGreaterThan( target.y );
+
+		await page.mouse.drop( target, dragData );
 
 		expect( await getEditedPostContent() ).toMatchSnapshot();
 	} );


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Reported in #43127, Partial fix for #32880

Fixes the drag and drop insertion point indicator at the start and end of block lists, which had regressed again.

This time adds e2e tests to prevent future regressions.

I did try writing these tests in Playwright, but the drag and drop utilities there are not quite as fully-featured as puppeteer's.

## How?
The fix is easy, just changes some boolean logic around how the in-between inserter renders.

I think the regression keeps happening because contributors are trying to optimize performance but don't realise they're introducing a bug. Hopefully the added comments and tests will prevent this in future.

## Testing Instructions
1. Insert two blocks
2. Try dragging the first to the end
3. Try dragging the last to the start
4. The blue insertion point should indicate the drop position correctly.

Note - if you drag too far (outside the bounds of the block list) dropping a block won't work and the insertion point won't be visible. This is already captured as an issue in #32880. It's a more complicate issue to fix.

Also worth testing:
1. Insert two blocks
2. Hover between the blocks (without dragging)
3. The blue in-between inserter should be visible
4. Hover at the start and end of the block list
5. The blue in-between inserter shouldn't be visible

## Screenshots or screencast <!-- if applicable -->

### Before

https://user-images.githubusercontent.com/677833/184066912-1408762a-904b-4f15-af0a-662e94347996.mp4

### After

https://user-images.githubusercontent.com/677833/184066776-e652c013-ece4-434f-8ea6-d438cf712a05.mp4


