### PR TITLE
Keycodes: Fix display of symbols in keyboard shortcut modal

### DIFF
--- a/packages/keycodes/src/index.js
+++ b/packages/keycodes/src/index.js
@@ -233,7 +233,13 @@ export const displayShortcutList = mapValues( modifiers, ( modifier ) => {
 			/** @type {string[]} */ ( [] )
 		);
 
-		const capitalizedCharacter = capitalCase( character );
+		// Symbols (`,.) are removed by the default regular expression,
+		// so override the rule to allow symbols used for shortcuts.
+		// see: https://github.com/blakeembrey/change-case#options
+		const capitalizedCharacter = capitalCase( character, {
+			stripRegexp: /[^A-Z0-9`,\.]/gi,
+		} );
+
 		return [ ...modifierKeys, capitalizedCharacter ];
 	};
 } );


### PR DESCRIPTION
Fix #43136

## What?
This PR fixes a problem with symbols not being displayed in the keyboard shortcut modal.

## Why?
In #42465, the library was changed from `lodash` to `change-case` in the capitalization of display labels, but as noted in [this comment](https://github.com/WordPress/gutenberg/issues/43136#issuecomment-1211559476), the symbol is removed in `change-case.capitalCase`.
This is because non-numeric and non-alphabetic characters are eliminated, as indicated in [the default options for change-case](https://github.com/blakeembrey/change-case#options).

> stripRegexp RegExp used to remove extraneous characters (default: /[^A-Z0-9]/gi).

## How?
Override default rules so that the following symbols are not removed:

- , (Comma)
- . (Period)
- ` (Backtick)

This rule matches the list of symbols that are converted to strings in aria-label.

https://github.com/WordPress/gutenberg/blob/4151405324213025c7ddfc469fd0cff91219aecb/packages/keycodes/src/index.js#L289-L294

## Testing Instructions

- Open the post / site / widget / customize-widget editor.
- Open keyboard shortcuts moda from options menu.
- For shortcuts that contain symbols, confirm that the symbols aren't deleted.