### PR TITLE
Fixed button right alignment issue in wp-5.9 version

### DIFF
--- a/packages/block-library/src/buttons/style.scss
+++ b/packages/block-library/src/buttons/style.scss
@@ -63,7 +63,8 @@ $blocks-block__margin: 0.5em;
 		.is-content-justification-right,
 		.is-content-justification-left,
 		.is-content-justification-center
-	) .wp-block-button.aligncenter {
+	) .wp-block-button.aligncenter,
+	.wp-block-button.alignright {
 	/* stylelint-enable indentation */
 		margin-left: auto;
 		margin-right: auto;
@@ -75,3 +76,8 @@ $blocks-block__margin: 0.5em;
 .wp-block-button.aligncenter {
 	text-align: center;
 }
+
+.wp-block-button.alignright {
+	text-align: right;
+}
+


### PR DESCRIPTION
## What?
In this PR i have fixed the issue which is mentioned in #39937

## Why?
I have added solution for button right alignment issue.

## Testing Instructions
1)Activate the Twenty Twenty Two theme.
)Add the button block on the editor side of the Post or Page.
3)Try to change the alignment.
4)You will notice that we can make it center and left align but not right align.the on

