### PR TITLE
Image: Try different resting state for placeholder.

### DIFF
--- a/packages/block-library/src/image/edit.js
+++ b/packages/block-library/src/image/edit.js
@@ -8,7 +8,7 @@ import { get, has, isEmpty, omit, pick } from 'lodash';
  * WordPress dependencies
  */
 import { getBlobByURL, isBlobURL, revokeBlobURL } from '@wordpress/blob';
-import { withNotices } from '@wordpress/components';
+import { withNotices, Placeholder } from '@wordpress/components';
 import { useSelect } from '@wordpress/data';
 import {
 	BlockAlignmentControl,
@@ -27,6 +27,17 @@ import { image as icon } from '@wordpress/icons';
  * Internal dependencies
  */
 import Image from './image';
+
+const placeholder = ( content ) => {
+	return (
+		<Placeholder
+			className="block-editor-media-placeholder"
+			withIllustration={ true }
+		>
+			{ content }
+		</Placeholder>
+	);
+};
 
 /**
  * Module constants
@@ -344,6 +355,7 @@ export function ImageEdit( {
 				onSelectURL={ onSelectURL }
 				notices={ noticeUI }
 				onError={ onUploadError }
+				placeholder={ placeholder }
 				accept="image/*"
 				allowedTypes={ ALLOWED_MEDIA_TYPES }
 				value={ { id, src } }

--- a/packages/block-library/src/image/editor.scss
+++ b/packages/block-library/src/image/editor.scss
@@ -24,6 +24,13 @@
 		color: currentColor;
 		background: transparent;
 
+		// Fade out the diagonal placeholder onselect.
+		svg > path {
+			opacity: 1;
+			transition: opacity 0.1s linear;
+			@include reduce-motion("transition");
+		}
+
 		// Position buttons.
 		.components-placeholder__fieldset {
 			width: auto;
@@ -51,9 +58,15 @@
 	}
 
 	// Show upload button on block selection.
-	&.is-selected .components-button.components-button {
-		opacity: 1;
-		visibility: visible;
+	&.is-selected {
+		svg > path {
+			opacity: 0;
+		}
+
+		.components-button.components-button {
+			opacity: 1;
+			visibility: visible;
+		}
 	}
 }
 

--- a/packages/block-library/src/image/editor.scss
+++ b/packages/block-library/src/image/editor.scss
@@ -1,3 +1,63 @@
+// Give the featured image placeholder the appearance of a literal image placeholder.
+// @todo: this CSS is similar to that of the Site Logo. That makes it an opportunity
+// to create a new component for placeholders meant to inherit some theme styles.
+.wp-block-image.wp-block-image {
+	// Inherit border radius from style variations.
+	// @todo: this doesn't work yet, it needs for the radius and border to be applied also in the setup state.
+	// https://github.com/WordPress/gutenberg/pull/42847
+	.components-placeholder,
+	.components-resizable-box__container {
+		border-radius: inherit;
+	}
+
+	// Style the placeholder.
+	.wp-block-post-featured-image__placeholder,
+	.components-placeholder {
+		justify-content: center;
+		align-items: center;
+		box-shadow: none;
+		padding: 0;
+
+		// Draw the dashed outline.
+		// By setting the dashed border to currentColor, we ensure it's visible
+		// against any background color.
+		color: currentColor;
+		background: transparent;
+
+		// Position buttons.
+		.components-placeholder__fieldset {
+			width: auto;
+			gap: $grid-unit-15;
+		}
+
+		.components-button.components-button {
+			display: flex;
+			position: relative;
+			visibility: hidden;
+			margin: 0;
+
+			// Animation.
+			opacity: 0;
+			transition: opacity 0.1s linear;
+			@include reduce-motion("transition");
+		}
+
+		.components-button.components-button > svg {
+			color: $white;
+		}
+
+		// Show default placeholder height when not resized.
+		min-height: 200px;
+	}
+
+	// Show upload button on block selection.
+	&.is-selected .components-button.components-button {
+		opacity: 1;
+		visibility: visible;
+	}
+}
+
+
 figure.wp-block-image:not(.wp-block) {
 	margin: 0;
 }
@@ -14,13 +74,12 @@ figure.wp-block-image:not(.wp-block) {
 		display: inline;
 	}
 
-	// Shown while image is being uploaded
+	// Shown while image is being uploaded.
 	.components-spinner {
 		position: absolute;
 		top: 50%;
 		left: 50%;
-		margin-top: -9px;
-		margin-left: -9px;
+		transform: translate(-50%, -50%);
 	}
 }
 


### PR DESCRIPTION
## What?

Initial work to fix #41142. Makes the image block placeholder look more like a literal placeholder, while aiming to keep existing functionality intact.

Currently, the image block placeholder has a dark border and looks like a form field:

<img width="1392" alt="before" src="https://user-images.githubusercontent.com/1204802/184114652-101a2d35-a9f6-45fb-98a1-145b977e74ab.png">

This PR takes the placeholder state in the direction of the Featured Image block, and makes the resting state appear like a classic, literal placeholder:
<img width="740" alt="Screenshot 2022-08-11 at 12 30 40" src="https://user-images.githubusercontent.com/1204802/184114864-5e26091d-e4ca-4e44-a5bc-938291bdd711.png">

This PR is a work in progress, as it needs to also enable inheriting properties as set by the inspector (radius, border, style), and leave room for feedback.

Longer term, but probably beyond the scope of this PR, width and height options should be available, and reflected in the setup state.

## Why?

From #41142:

> Chatting [..] about the effort of populating the Pattern Directory, it makes sense to also pursue more common layouts, displaying them as wireframes, in addition to more opinionated combinations of image and copy. Because of that, the way the images blocks get displayed is important.

## Testing Instructions

Insert an image block, and test that it behaves as it does today, but with the leaner placeholder style.