### PR TITLE
Template Part: Allow changing properties in focus mode

### DIFF
--- a/packages/edit-site/src/components/template-details/edit-template-title.js
+++ b/packages/edit-site/src/components/template-details/edit-template-title.js
@@ -19,9 +19,13 @@ export default function EditTemplateTitle( { template } ) {
 		<TextControl
 			label={ __( 'Title' ) }
 			value={ forceEmpty ? '' : title }
-			help={ __(
-				'Give the template a title that indicates its purpose, e.g. "Full Width".'
-			) }
+			help={
+				template.type !== 'wp_template_part'
+					? __(
+							'Give the template a title that indicates its purpose, e.g. "Full Width".'
+					  )
+					: null
+			}
 			onChange={ ( newTitle ) => {
 				if ( ! newTitle && ! forceEmpty ) {
 					setForceEmpty( true );

--- a/packages/edit-site/src/components/template-details/index.js
+++ b/packages/edit-site/src/components/template-details/index.js
@@ -78,11 +78,13 @@ export default function TemplateDetails( { template, onClose } ) {
 						{ description }
 					</Text>
 				) }
-
-				{ isTemplatePart && (
-					<TemplatePartAreaSelector id={ template.id } />
-				) }
 			</VStack>
+
+			{ isTemplatePart && (
+				<div className="edit-site-template-details__group">
+					<TemplatePartAreaSelector id={ template.id } />
+				</div>
+			) }
 
 			<TemplateAreas closeTemplateDetailsDropdown={ onClose } />
 

--- a/packages/edit-site/src/components/template-details/index.js
+++ b/packages/edit-site/src/components/template-details/index.js
@@ -6,7 +6,6 @@ import {
 	Button,
 	MenuGroup,
 	MenuItem,
-	__experimentalHeading as Heading,
 	__experimentalText as Text,
 } from '@wordpress/components';
 import { useDispatch, useSelect } from '@wordpress/data';
@@ -58,13 +57,14 @@ export default function TemplateDetails( { template, onClose } ) {
 				{ canEditTitle ? (
 					<EditTemplateTitle template={ template } />
 				) : (
-					<Heading
-						level={ 4 }
+					<Text
+						size={ 16 }
 						weight={ 600 }
 						className="edit-site-template-details__title"
+						as="p"
 					>
 						{ title }
-					</Heading>
+					</Text>
 				) }
 
 				{ description && (

--- a/packages/edit-site/src/components/template-details/index.js
+++ b/packages/edit-site/src/components/template-details/index.js
@@ -6,6 +6,7 @@ import {
 	Button,
 	MenuGroup,
 	MenuItem,
+	__experimentalVStack as VStack,
 	__experimentalText as Text,
 } from '@wordpress/components';
 import { useDispatch, useSelect } from '@wordpress/data';
@@ -19,6 +20,7 @@ import { store as editSiteStore } from '../../store';
 import TemplateAreas from './template-areas';
 import EditTemplateTitle from './edit-template-title';
 import { useLink } from '../routes/link';
+import TemplatePartAreaSelector from './template-part-area-selector';
 
 export default function TemplateDetails( { template, onClose } ) {
 	const { title, description } = useSelect(
@@ -53,7 +55,7 @@ export default function TemplateDetails( { template, onClose } ) {
 
 	return (
 		<div className="edit-site-template-details">
-			<div className="edit-site-template-details__group">
+			<VStack className="edit-site-template-details__group" spacing={ 3 }>
 				{ canEditTitle ? (
 					<EditTemplateTitle template={ template } />
 				) : (
@@ -76,7 +78,11 @@ export default function TemplateDetails( { template, onClose } ) {
 						{ description }
 					</Text>
 				) }
-			</div>
+
+				{ isTemplatePart && (
+					<TemplatePartAreaSelector id={ template.id } />
+				) }
+			</VStack>
 
 			<TemplateAreas closeTemplateDetailsDropdown={ onClose } />
 

--- a/packages/edit-site/src/components/template-details/index.js
+++ b/packages/edit-site/src/components/template-details/index.js
@@ -35,8 +35,13 @@ export default function TemplateDetails( { template, onClose } ) {
 		postId: undefined,
 	} );
 
+	const isTemplatePart = template.type === 'wp_template_part';
+
 	// Only user-created and non-default templates can change the name.
-	const canEditTitle = template.is_custom && ! template.has_theme_file;
+	// But any user-created template part can be renamed.
+	const canEditTitle = isTemplatePart
+		? ! template.has_theme_file
+		: template.is_custom && ! template.has_theme_file;
 
 	if ( ! template ) {
 		return null;

--- a/packages/edit-site/src/components/template-details/style.scss
+++ b/packages/edit-site/src/components/template-details/style.scss
@@ -8,10 +8,6 @@
 		border-top: $border-width solid $gray-400;
 	}
 
-	.edit-site-template-details__title {
-		margin: 0;
-	}
-
 	.edit-site-template-details__description {
 		margin: $grid-unit-15 0 0;
 		color: $gray-700;

--- a/packages/edit-site/src/components/template-details/style.scss
+++ b/packages/edit-site/src/components/template-details/style.scss
@@ -9,7 +9,6 @@
 	}
 
 	.edit-site-template-details__description {
-		margin: $grid-unit-15 0 0;
 		color: $gray-700;
 	}
 

--- a/packages/edit-site/src/components/template-details/template-part-area-selector.js
+++ b/packages/edit-site/src/components/template-details/template-part-area-selector.js
@@ -1,0 +1,38 @@
+/**
+ * WordPress dependencies
+ */
+import { __ } from '@wordpress/i18n';
+import { SelectControl } from '@wordpress/components';
+import { useEntityProp } from '@wordpress/core-data';
+import { useSelect } from '@wordpress/data';
+import { store as editorStore } from '@wordpress/editor';
+
+export default function TemplatePartAreaSelector( { id } ) {
+	const [ area, setArea ] = useEntityProp(
+		'postType',
+		'wp_template_part',
+		'area',
+		id
+	);
+
+	const definedAreas = useSelect(
+		( select ) =>
+			select( editorStore ).__experimentalGetDefaultTemplatePartAreas(),
+		[]
+	);
+
+	const areaOptions = definedAreas.map( ( { label, area: _area } ) => ( {
+		label,
+		value: _area,
+	} ) );
+
+	return (
+		<SelectControl
+			label={ __( 'Area' ) }
+			labelPosition="top"
+			options={ areaOptions }
+			value={ area }
+			onChange={ setArea }
+		/>
+	);
+}


### PR DESCRIPTION
## What?
Resolves #37220.

PR updates the "Template Details" dropdown and enables changing the Template Part title and area.

The title edit field is only displayed for user-created parts while changing the `area` is available for any template part.

## Why?
The user should be able to manage template properties while working in "focus mode."

## How?
* I adjusted the `canEditTitle` condition to include template parts.
* Added a new component for displaying template part area options.

## Testing Instructions
* Go to the Site Editor -> Template Parts
* Create a new template part.
* Confirm you can change the title and area.
* Switch to the theme provided part.
* Confirm that only the area selector is displayed.

## Additional tests
Confirm that template part-related changes don't affect the details dropdown for the Templates.

## Screenshots or screencast <!-- if applicable -->
| Allows changing name | Doesn't allow changing name |
|---|---|
|![CleanShot 2022-08-11 at 17 48 15](https://user-images.githubusercontent.com/240569/184150476-0cf6c542-4b02-438d-9f84-fb1194054b09.png)|![CleanShot 2022-08-11 at 17 48 50](https://user-images.githubusercontent.com/240569/184150532-4dd92ccc-d917-4c63-be59-91ab92c282f0.png)|

