### PR TITLE
Build Tools: Fix typo in performance tests workflow

### DIFF
--- a/.github/workflows/performance.yml
+++ b/.github/workflows/performance.yml
@@ -1,4 +1,4 @@
-name: Performances Tests
+name: Performance Tests
 
 on:
     pull_request:


### PR DESCRIPTION
## What?
This is a minor typo fix that addresses the name of the GitHub action workflow related to performance tests.

## Why?
No major reason, just a minor typo fix. Spotted while working on #43148 and observing the PR checks.

## How?
We're just fixing the typo.

## Testing Instructions
Verify the performance tests job still passes. 

## Screenshots or screencast <!-- if applicable -->
![Screenshot 2022-08-11 at 17 19 34](https://user-images.githubusercontent.com/8436925/184155399-ea95e508-29c9-4772-9d00-9a8bf1796844.png)

