### PR TITLE
getTemplateInfo: Return stable reference to an empty object

### DIFF
--- a/packages/editor/src/store/selectors.js
+++ b/packages/editor/src/store/selectors.js
@@ -1599,7 +1599,7 @@ export const __experimentalGetDefaultTemplateType = createSelector(
  */
 export function __experimentalGetTemplateInfo( state, template ) {
 	if ( ! template ) {
-		return {};
+		return EMPTY_OBJECT;
 	}
 
 	const { description, slug, title, area } = template;


### PR DESCRIPTION
## What?
PR updates `__experimentalGetTemplateInfo` selector to return stable reference to an empty object, when template is undefined.

## Why?
It's good practice to return similar share object constant when bailing early. Returning new object can cause unnecessary rerenders.

## How?
Use shared `EMPTY_OBJECT` constant.

## Testing Instructions
Nothing to test.
