### PR TITLE
MediaReplaceFlow: Reset default LinkControl margins

### DIFF
--- a/packages/block-editor/src/components/media-replace-flow/style.scss
+++ b/packages/block-editor/src/components/media-replace-flow/style.scss
@@ -27,6 +27,7 @@
 
 		.block-editor-url-input {
 			padding: 0; // Cancel unnecessary default 1px padding in this case.
+			margin: 0; // Reset default LinkControl margins.
 		}
 
 		.components-base-control .components-base-control__field {


### PR DESCRIPTION
## What?
A minor styling fix for the MediaReplaceFlow component.

## Testing Instructions
1. Open a Post or Page.
2. Insert an Image block.
3. Select an image.
4. Open the media replacement dropdown and edit the current media URL.
5. Confirm that input is correctly positioned

## Screenshots or screencast <!-- if applicable -->
| Before | After |
| --- | --- |
|![CleanShot 2022-08-11 at 18 44 24](https://user-images.githubusercontent.com/240569/184163330-3665c69e-6aa9-415b-913e-7cd59c86c6a6.png)|![CleanShot 2022-08-11 at 18 44 03](https://user-images.githubusercontent.com/240569/184163762-6b1f8915-83cc-4074-9783-6e044fdf09b0.png)|



