### PR TITLE
WIP: Try to fix Popover obstructs blocks

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2836,28 +2836,6 @@
 				}
 			}
 		},
-		"@floating-ui/core": {
-			"version": "0.6.2",
-			"resolved": "https://registry.npmjs.org/@floating-ui/core/-/core-0.6.2.tgz",
-			"integrity": "sha512-jktYRmZwmau63adUG3GKOAVCofBXkk55S/zQ94XOorAHhwqFIOFAy1rSp2N0Wp6/tGbe9V3u/ExlGZypyY17rg=="
-		},
-		"@floating-ui/dom": {
-			"version": "0.4.5",
-			"resolved": "https://registry.npmjs.org/@floating-ui/dom/-/dom-0.4.5.tgz",
-			"integrity": "sha512-b+prvQgJt8pieaKYMSJBXHxX/DYwdLsAWxKYqnO5dO2V4oo/TYBZJAUQCVNjTWWsrs6o4VDrNcP9+E70HAhJdw==",
-			"requires": {
-				"@floating-ui/core": "^0.6.2"
-			}
-		},
-		"@floating-ui/react-dom": {
-			"version": "0.6.3",
-			"resolved": "https://registry.npmjs.org/@floating-ui/react-dom/-/react-dom-0.6.3.tgz",
-			"integrity": "sha512-hC+pS5D6AgS2wWjbmSQ6UR6Kpy+drvWGJIri6e1EDGADTPsCaa4KzCgmCczHrQeInx9tqs81EyDmbKJYY2swKg==",
-			"requires": {
-				"@floating-ui/dom": "^0.4.5",
-				"use-isomorphic-layout-effect": "^1.1.1"
-			}
-		},
 		"@gar/promisify": {
 			"version": "1.1.3",
 			"resolved": "https://registry.npmjs.org/@gar/promisify/-/promisify-1.1.3.tgz",
@@ -16684,7 +16662,7 @@
 				"@emotion/serialize": "^1.0.2",
 				"@emotion/styled": "^11.6.0",
 				"@emotion/utils": "1.0.0",
-				"@floating-ui/react-dom": "0.6.3",
+				"@floating-ui/react-dom": "1.0.0",
 				"@use-gesture/react": "^10.2.6",
 				"@wordpress/a11y": "file:packages/a11y",
 				"@wordpress/compose": "file:packages/compose",
@@ -16729,6 +16707,27 @@
 						"@emotion/unitless": "^0.7.5",
 						"@emotion/utils": "^1.0.0",
 						"csstype": "^3.0.2"
+					}
+				},
+				"@floating-ui/core": {
+					"version": "1.0.1",
+					"resolved": "https://registry.npmjs.org/@floating-ui/core/-/core-1.0.1.tgz",
+					"integrity": "sha512-bO37brCPfteXQfFY0DyNDGB3+IMe4j150KFQcgJ5aBP295p9nBGeHEs/p0czrRbtlHq4Px/yoPXO/+dOCcF4uA=="
+				},
+				"@floating-ui/dom": {
+					"version": "1.0.1",
+					"resolved": "https://registry.npmjs.org/@floating-ui/dom/-/dom-1.0.1.tgz",
+					"integrity": "sha512-wBDiLUKWU8QNPNOTAFHiIAkBv1KlHauG2AhqjSeh2H+wR8PX+AArXfz8NkRexH5PgMJMmSOS70YS89AbWYh5dA==",
+					"requires": {
+						"@floating-ui/core": "^1.0.1"
+					}
+				},
+				"@floating-ui/react-dom": {
+					"version": "1.0.0",
+					"resolved": "https://registry.npmjs.org/@floating-ui/react-dom/-/react-dom-1.0.0.tgz",
+					"integrity": "sha512-uiOalFKPG937UCLm42RxjESTWUVpbbatvlphQAU6bsv+ence6IoVG8JOUZcy8eW81NkU+Idiwvx10WFLmR4MIg==",
+					"requires": {
+						"@floating-ui/dom": "^1.0.0"
 					}
 				},
 				"colord": {
@@ -58025,7 +58024,8 @@
 		"use-isomorphic-layout-effect": {
 			"version": "1.1.1",
 			"resolved": "https://registry.npmjs.org/use-isomorphic-layout-effect/-/use-isomorphic-layout-effect-1.1.1.tgz",
-			"integrity": "sha512-L7Evj8FGcwo/wpbv/qvSfrkHFtOpCzvM5yl2KVyDJoylVuSvzphiiasmjgQPttIGBAy2WKiBNR98q8w7PiNgKQ=="
+			"integrity": "sha512-L7Evj8FGcwo/wpbv/qvSfrkHFtOpCzvM5yl2KVyDJoylVuSvzphiiasmjgQPttIGBAy2WKiBNR98q8w7PiNgKQ==",
+			"dev": true
 		},
 		"use-latest": {
 			"version": "1.2.0",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -36,7 +36,7 @@
 		"@emotion/serialize": "^1.0.2",
 		"@emotion/styled": "^11.6.0",
 		"@emotion/utils": "1.0.0",
-		"@floating-ui/react-dom": "0.6.3",
+		"@floating-ui/react-dom": "1.0.0",
 		"@use-gesture/react": "^10.2.6",
 		"@wordpress/a11y": "file:../a11y",
 		"@wordpress/compose": "file:../compose",

--- a/packages/components/src/popover/index.js
+++ b/packages/components/src/popover/index.js
@@ -241,6 +241,8 @@ const Popover = (
 						frameOffset[ mainAxis ] + normalizedOffset;
 					const mainDimension = mainAxis === 'y' ? 'height' : 'width';
 					if (
+						// TODO: does this make sense only for top positioned popovers?
+						currentPlacement.startsWith( 'top' ) &&
 						// If the reference has no height we don't need to do anything.
 						referenceRect[ mainDimension ] &&
 						referenceRect[ mainAxis ] < 0 &&


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Partially based on https://github.com/WordPress/gutenberg/pull/42950 for `Popover: fix shifting behavior to avoid popover overlapping its anchor`. This PR attempts to also handle the `left` [placement issue
](https://github.com/WordPress/gutenberg/pull/42950#issuecomment-1209674636).

Also tries to solve: `Block Toolbar Regression - Toolbar obstructs selected blocks`(https://github.com/WordPress/gutenberg/issues/41575)
<!-- In a few words, what is the PR actually doing? -->

I've updated floating-ui to the latest version as I needed it for [this change](https://github.com/floating-ui/floating-ui/commit/70a5be5ffa11ef1fa910a8309f770a61cd69665c#diff-321bb60777b4ad851aaedfa4edc5d4a55e0599d8a22988521fea6a5278b92262R170).




