### PR TITLE
Add documentation for keyboard shortcut selecting text across multiple blocks

### DIFF
--- a/docs/explanations/faq.md
+++ b/docs/explanations/faq.md
@@ -220,7 +220,7 @@ This is the canonical list of keyboard shortcuts:
 			<td><kbd>Esc</kbd></td>
 		</tr>
 		<tr>
-			<td>Select text between multiple blocks.</td>
+			<td>Select text across multiple blocks.</td>
 			<td></td>
 			<td><kbd>Shift</kbd>+<kbd>Arrow (⇦, ⇧, ⇨, ⇩)</kbd></td>
 		</tr>

--- a/docs/explanations/faq.md
+++ b/docs/explanations/faq.md
@@ -219,6 +219,11 @@ This is the canonical list of keyboard shortcuts:
 			<td><kbd>Esc</kbd></td>
 			<td><kbd>Esc</kbd></td>
 		</tr>
+		<tr>
+			<td>Select text between multiple blocks.</td>
+			<td></td>
+			<td><kbd>Shift</kbd>+<kbd>Arrow (⇦, ⇧, ⇨, ⇩)</kbd></td>
+		</tr>
 	</tbody>
 </table>
 

--- a/packages/block-editor/src/components/keyboard-shortcuts/index.js
+++ b/packages/block-editor/src/components/keyboard-shortcuts/index.js
@@ -94,6 +94,16 @@ function KeyboardShortcutsRegister() {
 		} );
 
 		registerShortcut( {
+			name: 'core/block-editor/multi-text-selection',
+			category: 'selection',
+			description: __( 'Select text between multiple blocks.' ),
+			keyCombination: {
+				modifier: 'shift',
+				character: 'arrow',
+			},
+		} );
+
+		registerShortcut( {
 			name: 'core/block-editor/focus-toolbar',
 			category: 'global',
 			description: __( 'Navigate to the nearest toolbar.' ),

--- a/packages/block-editor/src/components/keyboard-shortcuts/index.js
+++ b/packages/block-editor/src/components/keyboard-shortcuts/index.js
@@ -96,7 +96,7 @@ function KeyboardShortcutsRegister() {
 		registerShortcut( {
 			name: 'core/block-editor/multi-text-selection',
 			category: 'selection',
-			description: __( 'Select text between multiple blocks.' ),
+			description: __( 'Select text across multiple blocks.' ),
 			keyCombination: {
 				modifier: 'shift',
 				character: 'arrow',

--- a/packages/edit-post/src/components/keyboard-shortcut-help-modal/test/__snapshots__/index.js.snap
+++ b/packages/edit-post/src/components/keyboard-shortcut-help-modal/test/__snapshots__/index.js.snap
@@ -272,6 +272,35 @@ exports[`KeyboardShortcutHelpModal should match snapshot when the modal is activ
               </kbd>
             </div>
           </li>
+          <li
+            class="edit-post-keyboard-shortcut-help-modal__shortcut"
+          >
+            <div
+              class="edit-post-keyboard-shortcut-help-modal__shortcut-description"
+            >
+              Select text across multiple blocks.
+            </div>
+            <div
+              class="edit-post-keyboard-shortcut-help-modal__shortcut-term"
+            >
+              <kbd
+                aria-label="Shift + Arrow"
+                class="edit-post-keyboard-shortcut-help-modal__shortcut-key-combination"
+              >
+                <kbd
+                  class="edit-post-keyboard-shortcut-help-modal__shortcut-key"
+                >
+                  Shift
+                </kbd>
+                +
+                <kbd
+                  class="edit-post-keyboard-shortcut-help-modal__shortcut-key"
+                >
+                  Arrow
+                </kbd>
+              </kbd>
+            </div>
+          </li>
         </ul>
       </section>
       <section


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Addresses https://github.com/WordPress/gutenberg/issues/41168, implementing documentation for the keyboard shortcut for selecting text across multiple blocks (without selecting all of a blocks' text). Feature was originally implemented in https://github.com/WordPress/gutenberg/pull/38892.

## How?
Adds missing documentation on selecting text between blocks to editor 'Keyboard shortcuts' modal and the 'Are there keyboard shortcuts for Gutenberg' documentation.

## Testing Instructions
1. Open Gutenberg editor
2. Press shift+alt+h to open Keyboard Shortcuts modal or open the modal by clicking the 3 vertical dots menu and selecting 'Keyboard shortcuts'
3. Verify the section about selecting text between multiple blocks is added.
4. Open the 'Are there keyboard shortcuts for Gutenberg' doc and verify new section about selecting text between multiple blocks has been added.

![Screen Shot 2022-08-11 at 2 40 43 PM](https://user-images.githubusercontent.com/7133400/184215022-523cbdc7-099a-4ddf-a746-8808b22e1e4c.png)