### PR TITLE
ComboboxControl: Add flag to remove bottom margin

### DIFF
--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -30,6 +30,7 @@
 -   `BaseControl`: Add `box-sizing` reset style ([#42889](https://github.com/WordPress/gutenberg/pull/42889)).
 -   `BoxControl`: Export `applyValueToSides` util function. ([#42733](https://github.com/WordPress/gutenberg/pull/42733/)).
 -   `AnglePickerControl`: Add `__nextHasNoMarginBottom` prop for opting into the new margin-free styles ([#43160](https://github.com/WordPress/gutenberg/pull/43160/)).
+-   `ComboboxControl`: Add `__nextHasNoMarginBottom` prop for opting into the new margin-free styles ([#43165](https://github.com/WordPress/gutenberg/pull/43165/)).
 
 ### Internal
 

--- a/packages/components/src/combobox-control/index.js
+++ b/packages/components/src/combobox-control/index.js
@@ -46,6 +46,8 @@ const DetectOutside = withFocusOutside(
 );
 
 function ComboboxControl( {
+	/** Start opting into the new margin-free styles that will become the default in a future version. */
+	__nextHasNoMarginBottom = false,
 	__next36pxDefaultSize,
 	value: valueProp,
 	label,
@@ -222,6 +224,7 @@ function ComboboxControl( {
 	return (
 		<DetectOutside onFocusOutside={ onFocusOutside }>
 			<BaseControl
+				__nextHasNoMarginBottom={ __nextHasNoMarginBottom }
 				className={ classnames(
 					className,
 					'components-combobox-control'

--- a/packages/components/src/combobox-control/stories/index.js
+++ b/packages/components/src/combobox-control/stories/index.js
@@ -280,7 +280,7 @@ function Template( { onChange, ...args } ) {
 				value={ value }
 				onChange={ ( ...changeArgs ) => {
 					setValue( ...changeArgs );
-					onChange( ...changeArgs );
+					onChange?.( ...changeArgs );
 				} }
 			/>
 		</>

--- a/packages/components/src/combobox-control/stories/index.js
+++ b/packages/components/src/combobox-control/stories/index.js
@@ -257,6 +257,9 @@ const countries = [
 export default {
 	title: 'Components/ComboboxControl',
 	component: ComboboxControl,
+	argTypes: {
+		__nextHasNoMarginBottom: { control: { type: 'boolean' } },
+	},
 };
 
 const mapCountryOption = ( country ) => ( {

--- a/packages/components/src/combobox-control/stories/index.js
+++ b/packages/components/src/combobox-control/stories/index.js
@@ -259,6 +259,7 @@ export default {
 	component: ComboboxControl,
 	argTypes: {
 		__nextHasNoMarginBottom: { control: { type: 'boolean' } },
+		onChange: { action: 'onChange' },
 	},
 };
 
@@ -269,7 +270,7 @@ const mapCountryOption = ( country ) => ( {
 
 const countryOptions = countries.map( mapCountryOption );
 
-function Template( args ) {
+function Template( { onChange, ...args } ) {
 	const [ value, setValue ] = useState( null );
 
 	return (
@@ -277,9 +278,11 @@ function Template( args ) {
 			<ComboboxControl
 				{ ...args }
 				value={ value }
-				onChange={ setValue }
+				onChange={ ( ...changeArgs ) => {
+					setValue( ...changeArgs );
+					onChange( ...changeArgs );
+				} }
 			/>
-			<p>Value: { value }</p>
 		</>
 	);
 }

--- a/packages/components/src/combobox-control/style.scss
+++ b/packages/components/src/combobox-control/style.scss
@@ -31,7 +31,6 @@ input.components-combobox-control__input[type="text"] {
 	flex-wrap: wrap;
 	align-items: flex-start;
 	width: 100%;
-	margin: 0 0 $grid-unit-10 0;
 	padding: 0;
 
 	&:focus-within {


### PR DESCRIPTION
Part of #38730

## What?

Adds a `__nextHasNoMarginBottom` prop to opt into the new margin-free styles.

## Why?

For easier reuse and consistency in spacing.

## How?

This PR just adds the flags. The in-repo migration and official deprecation tasks will continue to be tracked at #38730.

## Testing Instructions

1. Apply this patch for easier testing in Storybook (it injects a colored div after the component):

    ```diff
    diff --git a/storybook/decorators/with-global-css.js b/storybook/decorators/with-global-css.js
    --- a/storybook/decorators/with-global-css.js
    +++ b/storybook/decorators/with-global-css.js
    @@ -63,6 +63,7 @@ export const WithGlobalCSS = ( Story, context ) => {
 			    ) ) }
    
 			    <Story { ...context } />
    +			<div style={ { height: 50, background: 'lightgray' } } />
 		    </div>
 	    );
     };
    ```
2. `npm run storybook:dev`
3. Check the story for ComboboxControl.
