### PR TITLE
Global styles: check for recursive dynamic reference in the site editor

### DIFF
--- a/packages/edit-site/src/components/global-styles/test/utils.js
+++ b/packages/edit-site/src/components/global-styles/test/utils.js
@@ -4,7 +4,7 @@
 import { getPresetVariableFromValue, getValueFromVariable } from '../utils';
 
 describe( 'editor utils', () => {
-	const styles = {
+	const themeJson = {
 		version: 1,
 		settings: {
 			color: {
@@ -57,7 +57,7 @@ describe( 'editor utils', () => {
 		describe( 'when a provided global style (e.g. fontFamily, color,etc.) does not exist', () => {
 			it( 'returns the originally provided value', () => {
 				const actual = getPresetVariableFromValue(
-					styles.settings,
+					themeJson.settings,
 					context,
 					'fakePropertyName',
 					value
@@ -69,7 +69,7 @@ describe( 'editor utils', () => {
 		describe( 'when a global style is cleared by the user', () => {
 			it( 'returns an undefined preset variable', () => {
 				const actual = getPresetVariableFromValue(
-					styles.settings,
+					themeJson.settings,
 					context,
 					propertyName,
 					undefined
@@ -83,7 +83,7 @@ describe( 'editor utils', () => {
 				it( 'returns the originally provided value', () => {
 					const customValue = '#6e4545';
 					const actual = getPresetVariableFromValue(
-						styles.settings,
+						themeJson.settings,
 						context,
 						propertyName,
 						customValue
@@ -95,7 +95,7 @@ describe( 'editor utils', () => {
 			describe( 'and it is a preset value', () => {
 				it( 'returns the preset variable', () => {
 					const actual = getPresetVariableFromValue(
-						styles.settings,
+						themeJson.settings,
 						context,
 						propertyName,
 						value
@@ -110,7 +110,7 @@ describe( 'editor utils', () => {
 		describe( 'when provided an invalid variable', () => {
 			it( 'returns the originally provided value', () => {
 				const actual = getValueFromVariable(
-					styles,
+					themeJson,
 					'root',
 					undefined
 				);
@@ -122,7 +122,7 @@ describe( 'editor utils', () => {
 		describe( 'when provided a preset variable', () => {
 			it( 'retrieves the correct preset value', () => {
 				const actual = getValueFromVariable(
-					styles,
+					themeJson,
 					'root',
 					'var:preset|color|primary'
 				);
@@ -134,12 +134,72 @@ describe( 'editor utils', () => {
 		describe( 'when provided a custom variable', () => {
 			it( 'retrieves the correct custom value', () => {
 				const actual = getValueFromVariable(
-					styles,
+					themeJson,
 					'root',
 					'var(--wp--custom--color--secondary)'
 				);
 
 				expect( actual ).toBe( '#a65555' );
+			} );
+		} );
+
+		describe( 'when provided a dynamic reference', () => {
+			it( 'retrieves the referenced value', () => {
+				const stylesWithRefs = {
+					...themeJson,
+					styles: {
+						color: {
+							background: {
+								ref: 'styles.color.text',
+							},
+							text: 'purple-rain',
+						},
+					},
+				};
+				const actual = getValueFromVariable( stylesWithRefs, 'root', {
+					ref: 'styles.color.text',
+				} );
+
+				expect( actual ).toBe( stylesWithRefs.styles.color.text );
+			} );
+
+			it( 'returns where value is dynamic reference and reference does not exist', () => {
+				const stylesWithRefs = {
+					...themeJson,
+					styles: {
+						color: {
+							text: {
+								ref: 'styles.background.text',
+							},
+						},
+					},
+				};
+				const actual = getValueFromVariable( stylesWithRefs, 'root', {
+					ref: 'styles.color.text',
+				} );
+
+				expect( actual ).toBe( stylesWithRefs.styles.color.text );
+			} );
+
+			it( 'returns where value is dynamic reference', () => {
+				const stylesWithRefs = {
+					...themeJson,
+					styles: {
+						color: {
+							background: {
+								ref: 'styles.color.text',
+							},
+							text: {
+								ref: 'styles.background.text',
+							},
+						},
+					},
+				};
+				const actual = getValueFromVariable( stylesWithRefs, 'root', {
+					ref: 'styles.color.text',
+				} );
+
+				expect( actual ).toBe( stylesWithRefs.styles.color.text );
 			} );
 		} );
 	} );

--- a/packages/edit-site/src/components/global-styles/test/utils.js
+++ b/packages/edit-site/src/components/global-styles/test/utils.js
@@ -163,7 +163,7 @@ describe( 'editor utils', () => {
 				expect( actual ).toBe( stylesWithRefs.styles.color.text );
 			} );
 
-			it( 'returns where value is dynamic reference and reference does not exist', () => {
+			it( 'returns the originally provided value where value is dynamic reference and reference does not exist', () => {
 				const stylesWithRefs = {
 					...themeJson,
 					styles: {
@@ -181,7 +181,7 @@ describe( 'editor utils', () => {
 				expect( actual ).toBe( stylesWithRefs.styles.color.text );
 			} );
 
-			it( 'returns where value is dynamic reference', () => {
+			it( 'returns the originally provided value where value is dynamic reference', () => {
 				const stylesWithRefs = {
 					...themeJson,
 					styles: {

--- a/packages/edit-site/src/components/global-styles/use-global-styles-output.js
+++ b/packages/edit-site/src/components/global-styles/use-global-styles-output.js
@@ -277,6 +277,11 @@ export function getStylesDeclarations(
 		if ( typeof ruleValue !== 'string' && ruleValue?.ref ) {
 			const refPath = ruleValue.ref.split( '.' );
 			ruleValue = get( tree, refPath );
+			// Presence of another ref indicates a reference to another dynamic value.
+			// Pointing to another dynamic value is not supported.
+			if ( ! ruleValue || !! ruleValue?.ref ) {
+				return;
+			}
 		}
 		output.push( `${ cssProperty }: ${ compileStyleValue( ruleValue ) }` );
 	} );

--- a/packages/edit-site/src/components/global-styles/utils.js
+++ b/packages/edit-site/src/components/global-styles/utils.js
@@ -222,11 +222,24 @@ function getValueFromCustomVariable( features, blockName, variable, path ) {
 	return getValueFromVariable( features, blockName, result );
 }
 
+/**
+ * Attempts to fetch the value of a theme.json CSS variable.
+ *
+ * @param {Object}   features  GlobalStylesContext config, e.g., user, base or merged. Represents the theme.json tree.
+ * @param {string}   blockName The name of a block as represented in the styles property. E.g., 'root' for root-level, and 'core/${blockName}' for blocks.
+ * @param {string|*} variable  An incoming style value. A CSS var value is expected, but it could be any value.
+ * @return {string|*|{ref}} The value of the CSS var, if found. If not found, the passed variable argument.
+ */
 export function getValueFromVariable( features, blockName, variable ) {
 	if ( ! variable || typeof variable !== 'string' ) {
 		if ( variable?.ref && typeof variable?.ref === 'string' ) {
 			const refPath = variable.ref.split( '.' );
 			variable = get( features, refPath );
+			// Presence of another ref indicates a reference to another dynamic value.
+			// Pointing to another dynamic value is not supported.
+			if ( ! variable || !! variable?.ref ) {
+				return variable;
+			}
 		} else {
 			return variable;
 		}


### PR DESCRIPTION
Fixes https://github.com/WordPress/gutenberg/issues/43154

## What?

This PR checks for a recursive dynamic reference in `getValueFromVariable()` and bails if found. 

## Why?

When clicking on "Styles", the site editor crashes where a dynamic references points to another dynamic reference.

https://user-images.githubusercontent.com/6458278/184270114-79643a1f-0a9a-4717-9738-0833be4efa3e.mp4

```
utils.js:240 Uncaught TypeError: variable.startsWith is not a function
    at getValueFromVariable (utils.js:240:16)
    at useStyle (hooks.js:130:33)
    at StylesPreview (preview.js:58:42)
    at renderWithHooks (react-dom.js?ver=6.1-alpha-53868:15015:20)
    at mountIndeterminateComponent (react-dom.js?ver=6.1-alpha-53868:17841:15)
    at beginWork (react-dom.js?ver=6.1-alpha-53868:19079:18)
    at HTMLUnknownElement.callCallback (react-dom.js?ver=6.1-alpha-53868:3942:16)
    at Object.invokeGuardedCallbackDev (react-dom.js?ver=6.1-alpha-53868:3991:18)
    at invokeGuardedCallback (react-dom.js?ver=6.1-alpha-53868:4053:33)
    at beginWork$1 (react-dom.js?ver=6.1-alpha-53868:23994:9)

```

## Testing Instructions

Add a recursive reference to your theme.json, e.g., 

```json
{
	"version": 2,
	"settings": {
		"appearanceTools": true
	},
	"styles": {
		"color": {
			"background": {
				"ref": "styles.color.text"
			},
			"text": {
				"ref": "styles.color.background"
			}
		}
	}
}
```

Open up the site editor. You should see the https://github.com/WordPress/gutenberg/blob/34932d72320da970a7d7db39c2ca02d1c27b2bf4/lib/compat/wordpress-6.1/class-wp-theme-json-6-1.php#L969 still. 

Click on the "Styles" button.

<img width="308" alt="Screen Shot 2022-08-12 at 11 00 54 am" src="https://user-images.githubusercontent.com/6458278/184270353-8339b21d-f221-4b42-8d21-d794fff31dbe.png">


The editor shouldn't crash.
