### PR TITLE
Fix no-results grammar.

### DIFF
--- a/packages/block-library/src/query-no-results/edit.js
+++ b/packages/block-library/src/query-no-results/edit.js
@@ -9,7 +9,7 @@ const TEMPLATE = [
 		'core/paragraph',
 		{
 			placeholder: __(
-				'Add text or blocks that will display when the query returns no results.'
+				'Add text or blocks that will display when a query returns no results.'
 			),
 		},
 	],


### PR DESCRIPTION
## What?

Addresses parts of the feedback in #40240, with https://github.com/WordPress/gutenberg/issues/40240#issuecomment-1101083472 applied.

## Why?

It's a tiny fix.

## Testing Instructions

Test a query loop with a no results block inside, you can see the text there.