### PR TITLE
Group/Stack/Row: Scope the dashed placeholder rules.

### DIFF
--- a/packages/block-library/src/group/editor.scss
+++ b/packages/block-library/src/group/editor.scss
@@ -24,7 +24,7 @@
 }
 
 // Affect the appender of the Row and Stack variants.
-.is-layout-flex.block-editor-block-list__block .block-list-appender:only-child {
+.wp-block-group.is-layout-flex.block-editor-block-list__block > .block-list-appender:only-child {
 	gap: inherit;
 
 	&,


### PR DESCRIPTION
## What?

This is a followup to an older PR that added dashed indicators to Stack and Row variants to indicate their direction in the resting state, and to provide an easy way to select them. This:
<img width="723" alt="Screenshot 2022-08-12 at 09 12 16" src="https://user-images.githubusercontent.com/1204802/184303702-01179921-cecb-4306-a8b2-fb30672ccde9.png">

The rules were unscoped, so they could bleed into other cases. I.e. if _any_ parent container had `is-layout-flex`, all appenders inside would be affected by the rules:

<img width="859" alt="Screenshot 2022-08-12 at 09 13 08" src="https://user-images.githubusercontent.com/1204802/184303876-46517614-71ce-40f7-9c65-e73de753633c.png">

This PR fixes that by scoping the rules:

<img width="845" alt="Screenshot 2022-08-12 at 09 12 53" src="https://user-images.githubusercontent.com/1204802/184303892-2e619877-b1e6-4c72-8811-f6e17d07dbd1.png">

## Testing Instructions

Test that the Group, Row and Stack blocks when empty appear as they already do in trunk. But also test that the Columns block doesn't have any extra dashed lines output. It should look like this:

<img width="753" alt="Screenshot 2022-08-12 at 09 16 47" src="https://user-images.githubusercontent.com/1204802/184304274-0019089a-5fad-42f2-95b1-4eb012001497.png">

See also: #43115 and #40664, which will both need a rebase and change based on this PR.