### PR TITLE
Fix block toolbar offset in site editor when toggling sidebars

### DIFF
--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -19,6 +19,7 @@
 -   `Popover`: anchor correctly to parent node when no explicit anchor is passed ([#42971](https://github.com/WordPress/gutenberg/pull/42971)).
 -   `ColorPalette`: forward correctly `popoverProps` in the `CustomColorPickerDropdown` component [#42989](https://github.com/WordPress/gutenberg/pull/42989)).
 -   `ColorPalette`, `CustomGradientBar`: restore correct color picker popover position [#42989](https://github.com/WordPress/gutenberg/pull/42989)).
+-   `Popover`: fix iframe offset not updating when iframe resizes ([#42971](https://github.com/WordPress/gutenberg/pull/43172)).
 
 ### Enhancements
 

--- a/packages/components/src/popover/index.js
+++ b/packages/components/src/popover/index.js
@@ -405,15 +405,8 @@ const Popover = (
 			return;
 		}
 
-		const { defaultView } = ownerDocument;
-
-		defaultView.addEventListener( 'resize', update );
 		ownerDocument.addEventListener( 'scroll', update );
-
-		return () => {
-			defaultView.removeEventListener( 'resize', update );
-			ownerDocument.removeEventListener( 'scroll', update );
-		};
+		return () => ownerDocument.removeEventListener( 'scroll', update );
 	}, [ ownerDocument ] );
 
 	/** @type {false | string} */

--- a/packages/components/src/popover/index.js
+++ b/packages/components/src/popover/index.js
@@ -188,8 +188,8 @@ const Popover = (
 	/**
 	 * Offsets the position of the popover when the anchor is inside an iframe.
 	 *
-	 * Store the offset in a ref, due to constraints with floating-ui
-	 * (see: https://floating-ui.com/docs/react-dom#variables-inside-middleware-functions)
+	 * Store the offset in a ref, due to constraints with floating-ui:
+	 * https://floating-ui.com/docs/react-dom#variables-inside-middleware-functions.
 	 */
 	const frameOffset = useRef();
 	useLayoutEffect( () => {

--- a/packages/components/src/popover/index.js
+++ b/packages/components/src/popover/index.js
@@ -194,7 +194,7 @@ const Popover = (
 	const frameOffset = useRef();
 
 	const middleware = [
-		frameOffset || offset
+		frameOffset.current || offset
 			? offsetMiddleware( ( { placement: currentPlacement } ) => {
 					if ( ! frameOffset.current ) {
 						return offset;


### PR DESCRIPTION
## What?
See #42770

Fixes a bug in the site editor, where the block toolbar would be offset incorrectly after inserting a block from the global inserter

## Why?
In the site editor, part of the way popovers position themselves correctly is by offsetting their position against the editor canvas iframe.

When opening the inserter sidebar and inserting a block, the iframe is moved to the left to make space for the sidebar. The inserted block's toolbar iframe offset is calculated using this position that's shifted to the left.

When closing the sidebar, this offset isn't recalculated, as there's no `resize` event listener.

## How?
Adds a resize event listener for the iframe offset.

## Testing Instructions
1. Open the site editor.
2. Open the main inserter sidebar
3. Insert a block
4. Close the sidebar

Expected: the block's toolbar position should be correct (aligned to the left side of the block.

## Screenshots or screencast <!-- if applicable -->

### Before

https://user-images.githubusercontent.com/677833/184321624-ea762163-b298-46f6-b488-20684627c671.mp4

### After

https://user-images.githubusercontent.com/677833/184321285-c9836a37-7e59-49d3-992b-c4024e484054.mp4


