### PR TITLE
Block Library: Refactor core blocks to use HTML Tag Processor

### DIFF
--- a/packages/block-library/src/cover/index.php
+++ b/packages/block-library/src/cover/index.php
@@ -56,10 +56,10 @@ function render_block_core_cover( $attributes, $content ) {
 			$styles .= $height;
 		}
 
-		$walker = new WP_HTML_Walker( $content );
-		$walker->next_tag();
-		$walker->set_attribute( 'style', $styles );
-		$content = (string) $walker;
+		$processor = new WP_HTML_Tag_Processor( $content );
+		$processor->next_tag();
+		$processor->set_attribute( 'style', $styles );
+		$content = $processor->get_updated_html();
 	}
 
 	return $content;

--- a/packages/block-library/src/cover/index.php
+++ b/packages/block-library/src/cover/index.php
@@ -56,12 +56,10 @@ function render_block_core_cover( $attributes, $content ) {
 			$styles .= $height;
 		}
 
-		$content = preg_replace(
-			'/class=\".*?\"/',
-			'${0} style="' . $styles . '"',
-			$content,
-			1
-		);
+		$w = new WP_HTML_Walker( $content );
+		$w->next_tag();
+		$w->set_attribute( 'styles', $styles );
+		$content = (string) $w;
 	}
 
 	return $content;

--- a/packages/block-library/src/cover/index.php
+++ b/packages/block-library/src/cover/index.php
@@ -56,10 +56,10 @@ function render_block_core_cover( $attributes, $content ) {
 			$styles .= $height;
 		}
 
-		$w = new WP_HTML_Walker( $content );
-		$w->next_tag();
-		$w->set_attribute( 'styles', $styles );
-		$content = (string) $w;
+		$walker = new WP_HTML_Walker( $content );
+		$walker->next_tag();
+		$walker->set_attribute( 'style', $styles );
+		$content = (string) $walker;
 	}
 
 	return $content;

--- a/packages/block-library/src/image/index.php
+++ b/packages/block-library/src/image/index.php
@@ -19,10 +19,10 @@ function render_block_core_image( $attributes, $content ) {
 		// to provide backwards compatibility for the Gallery Block,
 		// which now wraps Image Blocks within innerBlocks.
 		// The data-id attribute is added in a core/gallery `render_block_data` hook.
-		$data_id_attribute = 'data-id="' . esc_attr( $attributes['data-id'] ) . '"';
-		if ( ! str_contains( $content, $data_id_attribute ) ) {
-			$content = str_replace( '<img', '<img ' . $data_id_attribute . ' ', $content );
-		}
+		$processor = new WP_HTML_Tag_Processor( $content );
+		$processor->next_tag( 'img' );
+		$processor->set_tag_attribute( 'data-id', esc_attr( $attributes['data-id'] ) );
+		$content = (string) $processor;
 	}
 	return $content;
 }

--- a/packages/block-library/src/image/index.php
+++ b/packages/block-library/src/image/index.php
@@ -21,8 +21,8 @@ function render_block_core_image( $attributes, $content ) {
 		// The data-id attribute is added in a core/gallery `render_block_data` hook.
 		$processor = new WP_HTML_Tag_Processor( $content );
 		$processor->next_tag( 'img' );
-		$processor->set_tag_attribute( 'data-id', esc_attr( $attributes['data-id'] ) );
-		$content = (string) $processor;
+		$processor->set_attribute( 'data-id', $attributes['data-id'] );
+		$content = $processor->get_updated_html();
 	}
 	return $content;
 }

--- a/packages/block-library/src/site-logo/index.php
+++ b/packages/block-library/src/site-logo/index.php
@@ -39,8 +39,13 @@ function render_block_core_site_logo( $attributes ) {
 	if ( $attributes['isLink'] && '_blank' === $attributes['linkTarget'] ) {
 		// Add the link target after the rel="home".
 		// Add an aria-label for informing that the page opens in a new tab.
-		$aria_label  = 'aria-label="' . esc_attr__( '(Home link, opens in a new tab)' ) . '"';
-		$custom_logo = str_replace( 'rel="home"', 'rel="home" target="' . esc_attr( $attributes['linkTarget'] ) . '"' . $aria_label, $custom_logo );
+		$walker = new WP_HTML_Walker( $custom_logo );
+		$walker->next_tag( 'a' );
+		if ( 'home' === $walker->get_attribute( 'rel' ) ) {
+			$walker->set_attribute( 'aria-label', '(Home link, opens in a new tab)' );
+			$walker->set_attribute( 'target', $attributes['linkTarget'] );
+		}
+		$custom_logo = (string) $walker;
 	}
 
 	$classnames = array();

--- a/packages/block-library/src/site-logo/index.php
+++ b/packages/block-library/src/site-logo/index.php
@@ -39,13 +39,13 @@ function render_block_core_site_logo( $attributes ) {
 	if ( $attributes['isLink'] && '_blank' === $attributes['linkTarget'] ) {
 		// Add the link target after the rel="home".
 		// Add an aria-label for informing that the page opens in a new tab.
-		$walker = new WP_HTML_Walker( $custom_logo );
-		$walker->next_tag( 'a' );
-		if ( 'home' === $walker->get_attribute( 'rel' ) ) {
-			$walker->set_attribute( 'aria-label', '(Home link, opens in a new tab)' );
-			$walker->set_attribute( 'target', $attributes['linkTarget'] );
+		$processor = new WP_HTML_Tag_Processor( $custom_logo );
+		$processor->next_tag( 'a' );
+		if ( 'home' === $processor->get_attribute( 'rel' ) ) {
+			$processor->set_attribute( 'aria-label', __( '(Home link, opens in a new tab)' ) );
+			$processor->set_attribute( 'target', $attributes['linkTarget'] );
 		}
-		$custom_logo = (string) $walker;
+		$custom_logo = $processor->get_updated_html();
 	}
 
 	$classnames = array();

--- a/packages/block-library/src/social-link/index.php
+++ b/packages/block-library/src/social-link/index.php
@@ -59,15 +59,15 @@ function render_block_core_social_link( $attributes, $content, $block ) {
 	$link .= esc_html( $label );
 	$link .= '</span></a></li>';
 
-	$w = new WP_HTML_Tag_Processor( $link );
-	$w->next_tag( 'a' );
+	$processor = new WP_HTML_Tag_Processor( $link );
+	$processor->next_tag( 'a' );
 	if ( $open_in_new_tab ) {
-		$w->set_attribute( 'rel', esc_attr( $rel ) . ' noopener nofollow' );
-		$w->set_attribute( 'target', '_blank' );
+		$processor->set_attribute( 'rel', esc_attr( $rel ) . ' noopener nofollow' );
+		$processor->set_attribute( 'target', '_blank' );
 	} elseif ( '' !== $rel ) {
-		$w->set_attribute( 'rel', esc_attr( $rel ) );
+		$processor->set_attribute( 'rel', esc_attr( $rel ) );
 	}
-	return $w;
+	return $processor->get_updated_html();
 }
 
 /**


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

The full proposal for the new HTM Tag Processor API is available at https://make.wordpress.org/core/2022/08/19/a-new-system-for-simply-and-reliably-updating-html-attributes/.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

This branch presents the usage of the new HTML Tag Processor API introduced by @adamziel and @dmsnell in https://github.com/WordPress/gutenberg/pull/42485.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

Updated core blocks:

- Cover
- Image
- Site Logo
- Social Link (code style changes only)

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->

All updated core blocks should work as before.