### PR TITLE
Jest Preset: Ignore `is-plain-obj` transformation

### DIFF
--- a/packages/jest-preset-default/CHANGELOG.md
+++ b/packages/jest-preset-default/CHANGELOG.md
@@ -6,6 +6,10 @@
 
 -   Increase the minimum Node.js version to 14 ([#43141](https://github.com/WordPress/gutenberg/pull/43141)).
 
+### Bug Fix
+
+-   Jest Preset: Ignore `is-plain-obj` transformation ([#43179](https://github.com/WordPress/gutenberg/pull/43179)).
+
 ## 8.0.0 (2022-01-27)
 
 ### Breaking Changes

--- a/packages/jest-preset-default/jest-preset.js
+++ b/packages/jest-preset-default/jest-preset.js
@@ -29,4 +29,5 @@ module.exports = {
 	transform: {
 		'\\.[jt]sx?$': require.resolve( 'babel-jest' ),
 	},
+	transformIgnorePatterns: [ 'node_modules/(?!(is-plain-obj))' ],
 };

--- a/packages/scripts/CHANGELOG.md
+++ b/packages/scripts/CHANGELOG.md
@@ -6,6 +6,10 @@
 
 -   Increase the minimum Node.js version to 14 and minimum npm version to 6.14.4 ([#43141](https://github.com/WordPress/gutenberg/pull/43141)).
 
+### Bug Fix
+
+-   Jest Preset: Ignore `is-plain-obj` transformation ([#43179](https://github.com/WordPress/gutenberg/pull/43179)).
+
 ## 23.6.0 (2022-07-27)
 
 ### Bug Fix

--- a/test/unit/jest.config.js
+++ b/test/unit/jest.config.js
@@ -36,7 +36,6 @@ module.exports = {
 	transform: {
 		'^.+\\.[jt]sx?$': '<rootDir>/test/unit/scripts/babel-transformer.js',
 	},
-	transformIgnorePatterns: [ 'node_modules/(?!(is-plain-obj))' ],
 	snapshotSerializers: [
 		'enzyme-to-json/serializer',
 		'@emotion/jest/serializer',


### PR DESCRIPTION
## What?
This PR moves the `is-plain-obj` transform ignore rule to the jest default preset.

## Why?
`is-plain-obj` is an ESM-only package and since ESM isn't fully supported by Jest, it's not able to run tests on components where that package is imported. 

## How?
We already had a transform ignore rule, we're just moving it to `@wordpress/jest-preset-default` in order for it to be consumed by other packages like `@wordpress/scripts`.

## Testing Instructions
Verify all unit tests still pass.