### PR TITLE
Image: Try different resting state for placeholder, alternate version

### DIFF
--- a/packages/block-library/src/image/edit.js
+++ b/packages/block-library/src/image/edit.js
@@ -28,11 +28,17 @@ import { image as icon } from '@wordpress/icons';
  */
 import Image from './image';
 
+// Much of this description is duplicated from MediaPlaceholder.
 const placeholder = ( content ) => {
 	return (
 		<Placeholder
 			className="block-editor-media-placeholder"
 			withIllustration={ true }
+			icon={ icon }
+			label={ __( 'Image' ) }
+			instructions={ __(
+				'Upload an image file, pick one from your media library, or add one with a URL.'
+			) }
 		>
 			{ content }
 		</Placeholder>

--- a/packages/block-library/src/image/edit.js
+++ b/packages/block-library/src/image/edit.js
@@ -8,7 +8,7 @@ import { get, has, isEmpty, omit, pick } from 'lodash';
  * WordPress dependencies
  */
 import { getBlobByURL, isBlobURL, revokeBlobURL } from '@wordpress/blob';
-import { withNotices } from '@wordpress/components';
+import { withNotices, Placeholder } from '@wordpress/components';
 import { useSelect } from '@wordpress/data';
 import {
 	BlockAlignmentControl,
@@ -27,6 +27,17 @@ import { image as icon } from '@wordpress/icons';
  * Internal dependencies
  */
 import Image from './image';
+
+const placeholder = ( content ) => {
+	return (
+		<Placeholder
+			className="block-editor-media-placeholder"
+			withIllustration={ true }
+		>
+			{ content }
+		</Placeholder>
+	);
+};
 
 /**
  * Module constants
@@ -344,6 +355,7 @@ export function ImageEdit( {
 				onSelectURL={ onSelectURL }
 				notices={ noticeUI }
 				onError={ onUploadError }
+				placeholder={ placeholder }
 				accept="image/*"
 				allowedTypes={ ALLOWED_MEDIA_TYPES }
 				value={ { id, src } }

--- a/packages/block-library/src/image/editor.scss
+++ b/packages/block-library/src/image/editor.scss
@@ -1,53 +1,18 @@
-// Give the featured image placeholder the appearance of a literal image placeholder.
-// @todo: this CSS is similar to that of the Site Logo. That makes it an opportunity
-// to create a new component for placeholders meant to inherit some theme styles.
+// Provide special styling for the placeholder.
+// @todo: this particular minimal style of placeholder could be componentized further.
 .wp-block-image.wp-block-image {
-	// Inherit border radius from style variations.
-	// @todo: this doesn't work yet, it needs for the radius and border to be applied also in the setup state.
-	// https://github.com/WordPress/gutenberg/pull/42847
-	border-radius: $radius-block-ui;
+	// Show legacy Placeholder style on-select.
+	&.is-selected .components-placeholder {
+		// Block UI appearance.
+		color: $gray-900;
+		background-color: $white;
+		box-shadow: inset 0 0 0 $border-width $gray-900;
+		border: none;
 
-	.components-placeholder,
-	.components-resizable-box__container {
-		border-radius: inherit;
-	}
+		// @todo: this should eventually be overridden by a custom border-radius set in the inspector.
+		border-radius: $radius-block-ui;
 
-	// Style the placeholder.
-	.wp-block-post-featured-image__placeholder,
-	.components-placeholder {
-		// Fade out the diagonal placeholder onselect.
-		svg {
-			opacity: 0;
-			transition: opacity 0.1s linear;
-			@include reduce-motion("transition");
-		}
-
-		.components-button.components-button {
-			opacity: 1;
-			transition: opacity 0.1s linear;
-			@include reduce-motion("transition");
-		}
-
-		// Show default placeholder height when not resized.
-		min-height: 200px;
-	}
-
-	// Show controls on select.
-	&:not(.is-selected) {
-
-		.wp-block-post-featured-image__placeholder,
-		.components-placeholder {
-			color: currentColor;
-			background: transparent;
-			border: none;
-			box-shadow: none;
-		}
-
-		svg {
-			opacity: 0.4;
-		}
-
-		.components-button.components-button {
+		> svg {
 			opacity: 0;
 			visibility: hidden;
 		}

--- a/packages/block-library/src/image/editor.scss
+++ b/packages/block-library/src/image/editor.scss
@@ -1,3 +1,60 @@
+// Give the featured image placeholder the appearance of a literal image placeholder.
+// @todo: this CSS is similar to that of the Site Logo. That makes it an opportunity
+// to create a new component for placeholders meant to inherit some theme styles.
+.wp-block-image.wp-block-image {
+	// Inherit border radius from style variations.
+	// @todo: this doesn't work yet, it needs for the radius and border to be applied also in the setup state.
+	// https://github.com/WordPress/gutenberg/pull/42847
+	border-radius: $radius-block-ui;
+
+	.components-placeholder,
+	.components-resizable-box__container {
+		border-radius: inherit;
+	}
+
+	// Style the placeholder.
+	.wp-block-post-featured-image__placeholder,
+	.components-placeholder {
+		// Fade out the diagonal placeholder onselect.
+		svg {
+			opacity: 0;
+			transition: opacity 0.1s linear;
+			@include reduce-motion("transition");
+		}
+
+		.components-button.components-button {
+			opacity: 1;
+			transition: opacity 0.1s linear;
+			@include reduce-motion("transition");
+		}
+
+		// Show default placeholder height when not resized.
+		min-height: 200px;
+	}
+
+	// Show controls on select.
+	&:not(.is-selected) {
+
+		.wp-block-post-featured-image__placeholder,
+		.components-placeholder {
+			color: currentColor;
+			background: transparent;
+			border: none;
+			box-shadow: none;
+		}
+
+		svg {
+			opacity: 0.4;
+		}
+
+		.components-button.components-button {
+			opacity: 0;
+			visibility: hidden;
+		}
+	}
+}
+
+
 figure.wp-block-image:not(.wp-block) {
 	margin: 0;
 }
@@ -14,13 +71,12 @@ figure.wp-block-image:not(.wp-block) {
 		display: inline;
 	}
 
-	// Shown while image is being uploaded
+	// Shown while image is being uploaded.
 	.components-spinner {
 		position: absolute;
 		top: 50%;
 		left: 50%;
-		margin-top: -9px;
-		margin-left: -9px;
+		transform: translate(-50%, -50%);
 	}
 }
 

--- a/packages/block-library/src/image/editor.scss
+++ b/packages/block-library/src/image/editor.scss
@@ -1,16 +1,26 @@
 // Provide special styling for the placeholder.
 // @todo: this particular minimal style of placeholder could be componentized further.
 .wp-block-image.wp-block-image {
-	// Show legacy Placeholder style on-select.
+	// Show custom Placeholder style on-select.
 	&.is-selected .components-placeholder {
 		// Block UI appearance.
 		color: $gray-900;
 		background-color: $white;
 		box-shadow: inset 0 0 0 $border-width $gray-900;
 		border: none;
+		justify-content: center;
+		align-items: center;
 
 		// @todo: this should eventually be overridden by a custom border-radius set in the inspector.
 		border-radius: $radius-block-ui;
+
+		.components-placeholder__fieldset {
+			gap: $grid-unit-15;
+		}
+
+		.components-button {
+			margin: 0;
+		}
 
 		> svg {
 			opacity: 0;

--- a/packages/block-library/src/image/editor.scss
+++ b/packages/block-library/src/image/editor.scss
@@ -1,31 +1,29 @@
 // Provide special styling for the placeholder.
 // @todo: this particular minimal style of placeholder could be componentized further.
 .wp-block-image.wp-block-image {
-	// Show custom Placeholder style on-select.
+	// Show Placeholder style on-select.
 	&.is-selected .components-placeholder {
 		// Block UI appearance.
 		color: $gray-900;
 		background-color: $white;
 		box-shadow: inset 0 0 0 $border-width $gray-900;
 		border: none;
-		justify-content: center;
-		align-items: center;
 
 		// @todo: this should eventually be overridden by a custom border-radius set in the inspector.
 		border-radius: $radius-block-ui;
 
-		.components-placeholder__fieldset {
-			gap: $grid-unit-15;
-		}
-
-		.components-button {
-			margin: 0;
-		}
-
 		> svg {
 			opacity: 0;
-			visibility: hidden;
 		}
+	}
+
+	// Remove the transition while we still have a legacy placeholder style.
+	// Otherwise the content jumps between the 1px placeholder border, and any inherited custom
+	// parent border that may get applied when you deselect.
+	.components-placeholder__label,
+	.components-placeholder__instructions,
+	.components-button {
+		transition: none;
 	}
 }
 

--- a/packages/components/src/placeholder/style.scss
+++ b/packages/components/src/placeholder/style.scss
@@ -185,14 +185,20 @@
 
 	// Show placeholder buttons on block selection.
 	// Note that these can't be display: none; or visibility: hidden;, as that breaks the writing flow.
+	.components-placeholder__label,
+	.components-placeholder__instructions,
 	.components-button {
 		opacity: 0;
 		transition: opacity 0.1s linear;
 		@include reduce-motion("transition");
 	}
 
-	.is-selected > & .components-button {
-		opacity: 1;
+	.is-selected > & {
+		.components-placeholder__label,
+		.components-placeholder__instructions,
+		.components-button {
+			opacity: 1;
+		}
 	}
 
 	// By painting the borders here, we enable them to be replaced by the Border control.


### PR DESCRIPTION
## What?

Alternative to #43143 with the intent to make smaller changes. This one keeps the more classic setup state appearance onselect:

![current state](https://user-images.githubusercontent.com/1204802/184336525-bc786991-9e2f-4c51-b407-0378ebcad894.gif)

## Why?

With Featured Image, Site Logo and soon Image sharing a variety of implementations of this appearance, and further discussion ongoing in https://github.com/WordPress/gutenberg/pull/42847#issuecomment-1212891163 as to how to visually style that state, I wanted to see if we could land a smaller interim step.

## Testing Instructions

Insert an image block and observe the new resting state.