### PR TITLE
Merge inner blocks if wrappers are equal

### DIFF
--- a/packages/block-editor/src/components/block-list/block.js
+++ b/packages/block-editor/src/components/block-list/block.js
@@ -345,12 +345,17 @@ const applyWithDispatch = withDispatch( ( dispatch, ownProps, registry ) => {
 				getBlockOrder,
 			} = registry.select( blockEditorStore );
 
+			// For `Delete` or forward merge, we should do the exact same thing
+			// as `Backspace`, but from the other block.
 			if ( forward ) {
 				if ( rootClientId ) {
 					const nextRootClientId =
 						getNextBlockClientId( rootClientId );
 
 					if ( nextRootClientId ) {
+						// If there is a block that follows with the same parent
+						// block name and the same attributes, merge the inner
+						// blocks.
 						if (
 							getBlockName( rootClientId ) ===
 							getBlockName( nextRootClientId )
@@ -390,6 +395,8 @@ const applyWithDispatch = withDispatch( ( dispatch, ownProps, registry ) => {
 					return;
 				}
 
+				// Check if it's possibile to "unwrap" the following block
+				// before trying to merge.
 				const replacement = switchToBlockType(
 					getBlock( nextBlockClientId ),
 					'*'
@@ -410,6 +417,8 @@ const applyWithDispatch = withDispatch( ( dispatch, ownProps, registry ) => {
 					const previousRootClientId =
 						getPreviousBlockClientId( rootClientId );
 
+					// If there is a preceding block with the same parent block
+					// name and the same attributes, merge the inner blocks.
 					if (
 						previousRootClientId &&
 						getBlockName( rootClientId ) ===

--- a/packages/block-editor/src/components/block-list/block.js
+++ b/packages/block-editor/src/components/block-list/block.js
@@ -350,31 +350,35 @@ const applyWithDispatch = withDispatch( ( dispatch, ownProps, registry ) => {
 					const nextRootClientId =
 						getNextBlockClientId( rootClientId );
 
-					if (
-						nextRootClientId &&
-						getBlockName( rootClientId ) ===
-							getBlockName( nextRootClientId )
-					) {
-						const rootAttributes =
-							getBlockAttributes( rootClientId );
-						const previousRootAttributes =
-							getBlockAttributes( nextRootClientId );
-
+					if ( nextRootClientId ) {
 						if (
-							Object.keys( rootAttributes ).every(
-								( key ) =>
-									rootAttributes[ key ] ===
-									previousRootAttributes[ key ]
-							)
+							getBlockName( rootClientId ) ===
+							getBlockName( nextRootClientId )
 						) {
-							registry.batch( () => {
-								moveBlocksToPosition(
-									getBlockOrder( rootClientId ),
-									rootClientId,
-									nextRootClientId
-								);
-								removeBlock( rootClientId, false );
-							} );
+							const rootAttributes =
+								getBlockAttributes( rootClientId );
+							const previousRootAttributes =
+								getBlockAttributes( nextRootClientId );
+
+							if (
+								Object.keys( rootAttributes ).every(
+									( key ) =>
+										rootAttributes[ key ] ===
+										previousRootAttributes[ key ]
+								)
+							) {
+								registry.batch( () => {
+									moveBlocksToPosition(
+										getBlockOrder( rootClientId ),
+										rootClientId,
+										nextRootClientId
+									);
+									removeBlock( rootClientId, false );
+								} );
+								return;
+							}
+						} else {
+							mergeBlocks( rootClientId, nextRootClientId );
 							return;
 						}
 					}
@@ -386,8 +390,6 @@ const applyWithDispatch = withDispatch( ( dispatch, ownProps, registry ) => {
 					return;
 				}
 
-				// Attempt to "unwrap" the block contents when there's no
-				// preceding block to merge with.
 				const replacement = switchToBlockType(
 					getBlock( nextBlockClientId ),
 					'*'
@@ -395,7 +397,7 @@ const applyWithDispatch = withDispatch( ( dispatch, ownProps, registry ) => {
 
 				if ( replacement && replacement.length ) {
 					replaceBlocks( nextBlockClientId, replacement );
-				} else if ( nextBlockClientId ) {
+				} else {
 					mergeBlocks( clientId, nextBlockClientId );
 				}
 			} else {

--- a/packages/block-editor/src/components/block-list/block.js
+++ b/packages/block-editor/src/components/block-list/block.js
@@ -369,11 +369,11 @@ const applyWithDispatch = withDispatch( ( dispatch, ownProps, registry ) => {
 							) {
 								registry.batch( () => {
 									moveBlocksToPosition(
-										getBlockOrder( rootClientId ),
-										rootClientId,
-										nextRootClientId
+										getBlockOrder( nextRootClientId ),
+										nextRootClientId,
+										rootClientId
 									);
-									removeBlock( rootClientId, false );
+									removeBlock( nextRootClientId, false );
 								} );
 								return;
 							}

--- a/packages/block-library/src/list-item/edit.js
+++ b/packages/block-library/src/list-item/edit.js
@@ -60,6 +60,7 @@ export default function ListItemEdit( {
 	setAttributes,
 	onReplace,
 	clientId,
+	mergeBlocks,
 } ) {
 	const { placeholder, content } = attributes;
 	const blockProps = useBlockProps( { ref: useCopy( clientId ) } );
@@ -70,7 +71,7 @@ export default function ListItemEdit( {
 	const useEnterRef = useEnter( { content, clientId } );
 	const useSpaceRef = useSpace( clientId );
 	const onSplit = useSplit( clientId );
-	const onMerge = useMerge( clientId );
+	const onMerge = useMerge( clientId, mergeBlocks );
 	return (
 		<>
 			<li { ...innerBlocksProps }>

--- a/packages/block-library/src/list-item/hooks/use-merge.js
+++ b/packages/block-library/src/list-item/hooks/use-merge.js
@@ -12,7 +12,7 @@ import useOutdentListItem from './use-outdent-list-item';
 
 import { name as listItemName } from '../block.json';
 
-export default function useMerge( clientId ) {
+export default function useMerge( clientId, onMerge ) {
 	const registry = useRegistry();
 	const {
 		getPreviousBlockClientId,
@@ -134,7 +134,7 @@ export default function useMerge( clientId ) {
 					mergeBlocks( trailingId, clientId );
 				} );
 			} else {
-				switchToDefaultBlockType( forward );
+				onMerge( forward );
 			}
 		}
 	};

--- a/packages/block-library/src/list-item/hooks/use-merge.js
+++ b/packages/block-library/src/list-item/hooks/use-merge.js
@@ -3,7 +3,6 @@
  */
 import { useRegistry, useDispatch, useSelect } from '@wordpress/data';
 import { store as blockEditorStore } from '@wordpress/block-editor';
-import { getDefaultBlockName, switchToBlockType } from '@wordpress/blocks';
 
 /**
  * Internal dependencies
@@ -20,9 +19,8 @@ export default function useMerge( clientId, onMerge ) {
 		getBlockOrder,
 		getBlockRootClientId,
 		getBlockName,
-		getBlock,
 	} = useSelect( blockEditorStore );
-	const { mergeBlocks, moveBlocksToPosition, replaceBlock, selectBlock } =
+	const { mergeBlocks, moveBlocksToPosition } =
 		useDispatch( blockEditorStore );
 	const [ , outdentListItem ] = useOutdentListItem( clientId );
 
@@ -79,29 +77,12 @@ export default function useMerge( clientId, onMerge ) {
 		return getBlockOrder( order[ 0 ] )[ 0 ];
 	}
 
-	function switchToDefaultBlockType( forward ) {
-		const rootClientId = getBlockRootClientId( clientId );
-		const replacement = switchToBlockType(
-			getBlock( rootClientId ),
-			getDefaultBlockName()
-		);
-		const indexToSelect = forward ? replacement.length - 1 : 0;
-		const initialPosition = forward ? -1 : 0;
-		registry.batch( () => {
-			replaceBlock( rootClientId, replacement );
-			selectBlock(
-				replacement[ indexToSelect ].clientId,
-				initialPosition
-			);
-		} );
-	}
-
 	return ( forward ) => {
 		if ( forward ) {
 			const nextBlockClientId = getNextId( clientId );
 
 			if ( ! nextBlockClientId ) {
-				switchToDefaultBlockType( forward );
+				onMerge( forward );
 				return;
 			}
 

--- a/packages/block-library/src/list/transforms.js
+++ b/packages/block-library/src/list/transforms.js
@@ -114,6 +114,17 @@ const transforms = {
 				);
 			},
 		} ) ),
+		{
+			type: 'block',
+			blocks: [ '*' ],
+			transform: ( _attributes, childBlocks ) => {
+				return getListContentFlat( childBlocks ).map( ( content ) =>
+					createBlock( 'core/paragraph', {
+						content,
+					} )
+				);
+			},
+		},
 	],
 };
 

--- a/packages/e2e-tests/specs/editor/various/block-switcher.test.js
+++ b/packages/e2e-tests/specs/editor/various/block-switcher.test.js
@@ -82,9 +82,9 @@ describe( 'Block Switcher', () => {
 		await pressKeyWithModifier( 'alt', 'F10' );
 
 		// Verify the block switcher exists.
-		expect( await hasBlockSwitcher() ).toBeFalsy();
+		expect( await hasBlockSwitcher() ).toBeTruthy();
 		// Verify the correct block transforms appear.
-		expect( await getAvailableBlockTransforms() ).toHaveLength( 0 );
+		expect( await getAvailableBlockTransforms() ).toHaveLength( 1 );
 	} );
 
 	describe( 'Conditional tranformation options', () => {

--- a/packages/e2e-tests/specs/editor/various/splitting-merging.test.js
+++ b/packages/e2e-tests/specs/editor/various/splitting-merging.test.js
@@ -237,6 +237,20 @@ describe( 'splitting and merging blocks', () => {
 			await page.keyboard.type( 'item 2' );
 			await pressKeyTimes( 'ArrowUp', 3 );
 			await page.keyboard.press( 'Delete' );
+			expect( await getEditedPostContent() ).toMatchInlineSnapshot( `
+			"<!-- wp:paragraph -->
+			<p>hi</p>
+			<!-- /wp:paragraph -->
+
+			<!-- wp:paragraph -->
+			<p>item 1</p>
+			<!-- /wp:paragraph -->
+
+			<!-- wp:paragraph -->
+			<p>item 2</p>
+			<!-- /wp:paragraph -->"
+		` );
+			await page.keyboard.press( 'Delete' );
 			// Carret should be in the first block and at the proper position.
 			await page.keyboard.type( '-' );
 			expect( await getEditedPostContent() ).toMatchInlineSnapshot( `
@@ -259,15 +273,25 @@ describe( 'splitting and merging blocks', () => {
 			await page.keyboard.press( 'ArrowUp' );
 			await pressKeyTimes( 'ArrowLeft', 6 );
 			await page.keyboard.press( 'Backspace' );
-			// Carret should be in the first block and at the proper position.
-			await page.keyboard.type( '-' );
 			expect( await getEditedPostContent() ).toMatchInlineSnapshot( `
 			"<!-- wp:paragraph -->
 			<p>hi</p>
 			<!-- /wp:paragraph -->
 
 			<!-- wp:paragraph -->
-			<p>-item 1</p>
+			<p>item 1</p>
+			<!-- /wp:paragraph -->
+
+			<!-- wp:paragraph -->
+			<p>item 2</p>
+			<!-- /wp:paragraph -->"
+		` );
+			await page.keyboard.press( 'Backspace' );
+			// Carret should be in the first block and at the proper position.
+			await page.keyboard.type( '-' );
+			expect( await getEditedPostContent() ).toMatchInlineSnapshot( `
+			"<!-- wp:paragraph -->
+			<p>hi-item 1</p>
 			<!-- /wp:paragraph -->
 
 			<!-- wp:paragraph -->

--- a/test/e2e/specs/editor/blocks/list.spec.js
+++ b/test/e2e/specs/editor/blocks/list.spec.js
@@ -1150,4 +1150,50 @@ test.describe( 'List', () => {
 		// Verify no WSOD and content is proper.
 		expect( await editor.getEditedPostContent() ).toMatchSnapshot();
 	} );
+
+	test( 'should merge two list with same attributes', async ( {
+		editor,
+		page,
+	} ) => {
+		await page.click( 'role=button[name="Add default block"i]' );
+		await page.keyboard.type( '* a' );
+		await page.keyboard.press( 'Enter' );
+		await page.keyboard.type( 'b' );
+		await page.keyboard.press( 'Enter' );
+		await page.keyboard.press( 'Enter' );
+		await page.keyboard.type( '* c' );
+
+		await expect.poll( editor.getEditedPostContent ).toBe( `<!-- wp:list -->
+<ul><!-- wp:list-item -->
+<li>a</li>
+<!-- /wp:list-item -->
+
+<!-- wp:list-item -->
+<li>b</li>
+<!-- /wp:list-item --></ul>
+<!-- /wp:list -->
+
+<!-- wp:list -->
+<ul><!-- wp:list-item -->
+<li>c</li>
+<!-- /wp:list-item --></ul>
+<!-- /wp:list -->` );
+
+		await page.keyboard.press( 'ArrowLeft' );
+		await page.keyboard.press( 'Backspace' );
+
+		await expect.poll( editor.getEditedPostContent ).toBe( `<!-- wp:list -->
+<ul><!-- wp:list-item -->
+<li>a</li>
+<!-- /wp:list-item -->
+
+<!-- wp:list-item -->
+<li>b</li>
+<!-- /wp:list-item -->
+
+<!-- wp:list-item -->
+<li>c</li>
+<!-- /wp:list-item --></ul>
+<!-- /wp:list -->` );
+	} );
 } );


### PR DESCRIPTION
Fixes #44436

<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?

Allows inner blocks to be merged if the current and previous wrappers are the same (block name and attributes are equal).

## Why?

This is useful in particular for lists: it allows you to merge list items into the previous list (if the list attributes are the same).
But it is also useful for other blocks like quote and group. If two quotes have the same cite (or no cite), the contents can be merged. And if two group blocks have the same attributes (e.g. same colour), the contents can be merged.

## How?

Extends the `onMerge` function.

## Testing Instructions

There's in total 6 behaviours to test for both list and quote. Set up as following: one paragraph, two separate list blocks, and another paragraph. Undo the action after each step.

* Place the caret at the end of the first paragraph and press Delete. Should unwrap the first list. Undo.
* Place the caret at the start of the first list and press Backspace. Should unwrap the list as well. Undo.
* Place the caret at the end of the first list and press Delete. Should merge the lists. Undo.
* Place the caret at the start of the second list and press Backspace. Should merge the lists as well. Undo.
* Place the caret at the end of the second list and press Delete. Should merge the second paragraph with the list. Undo.
* Place the caret at the start of the second paragraph and press Backspace. Should merge the second paragraph with the list as well.

## Screenshots or screencast <!-- if applicable -->

![list](https://user-images.githubusercontent.com/4710635/194496090-499e3d4d-f118-424f-9c9a-08b303fa4cea.gif)

![quote](https://user-images.githubusercontent.com/4710635/194496668-88c7e541-8136-4df7-bcf3-92061e8544df.gif)
