### PR TITLE
Lodash: Refactor away from `_.uniqBy()`

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -140,6 +140,7 @@ module.exports = {
 							'toString',
 							'trim',
 							'truncate',
+							'uniqBy',
 							'uniqueId',
 							'uniqWith',
 							'values',

--- a/bin/plugin/commands/changelog.js
+++ b/bin/plugin/commands/changelog.js
@@ -1,14 +1,7 @@
 /**
  * External dependencies
  */
-const {
-	groupBy,
-	escapeRegExp,
-	uniq,
-	flow,
-	sortBy,
-	uniqBy,
-} = require( 'lodash' );
+const { groupBy, escapeRegExp, uniq, flow, sortBy } = require( 'lodash' );
 const Octokit = require( '@octokit/rest' );
 const { sprintf } = require( 'sprintf-js' );
 const semver = require( 'semver' );
@@ -838,7 +831,17 @@ function sortByUsername( items ) {
  * @return {IssuesListForRepoResponseItem[]} The list of pull requests unique per user.
  */
 function getUniqueByUsername( items ) {
-	return uniqBy( items, ( item ) => item.user.login );
+	/**
+	 * @type {IssuesListForRepoResponseItem[]} List of pull requests.
+	 */
+	const EMPTY_PR_LIST = [];
+
+	return items.reduce( ( acc, item ) => {
+		if ( ! acc.some( ( i ) => i.user.login === item.user.login ) ) {
+			acc.push( item );
+		}
+		return acc;
+	}, EMPTY_PR_LIST );
 }
 
 /**

--- a/packages/blocks/src/store/reducer.js
+++ b/packages/blocks/src/store/reducer.js
@@ -1,16 +1,7 @@
 /**
  * External dependencies
  */
-import {
-	filter,
-	find,
-	get,
-	isEmpty,
-	map,
-	mapValues,
-	omit,
-	uniqBy,
-} from 'lodash';
+import { filter, find, get, isEmpty, map, mapValues, omit } from 'lodash';
 
 /**
  * WordPress dependencies
@@ -49,6 +40,16 @@ function keyBlockTypesByName( types ) {
 		} ),
 		{}
 	);
+}
+
+// Filter items to ensure they're unique by their name.
+function getUniqueItemsByName( items ) {
+	return items.reduce( ( acc, currentItem ) => {
+		if ( ! acc.some( ( item ) => item.name === currentItem.name ) ) {
+			acc.push( currentItem );
+		}
+		return acc;
+	}, [] );
 }
 
 /**
@@ -113,34 +114,27 @@ export function blockStyles( state = {}, action ) {
 				...state,
 				...mapValues(
 					keyBlockTypesByName( action.blockTypes ),
-					( blockType ) => {
-						return uniqBy(
-							[
-								...get( blockType, [ 'styles' ], [] ).map(
-									( style ) => ( {
-										...style,
-										source: 'block',
-									} )
-								),
-								...get( state, [ blockType.name ], [] ).filter(
-									( { source } ) => 'block' !== source
-								),
-							],
-							( style ) => style.name
-						);
-					}
+					( blockType ) =>
+						getUniqueItemsByName( [
+							...get( blockType, [ 'styles' ], [] ).map(
+								( style ) => ( {
+									...style,
+									source: 'block',
+								} )
+							),
+							...get( state, [ blockType.name ], [] ).filter(
+								( { source } ) => 'block' !== source
+							),
+						] )
 				),
 			};
 		case 'ADD_BLOCK_STYLES':
 			return {
 				...state,
-				[ action.blockName ]: uniqBy(
-					[
-						...get( state, [ action.blockName ], [] ),
-						...action.styles,
-					],
-					( style ) => style.name
-				),
+				[ action.blockName ]: getUniqueItemsByName( [
+					...get( state, [ action.blockName ], [] ),
+					...action.styles,
+				] ),
 			};
 		case 'REMOVE_BLOCK_STYLES':
 			return {
@@ -171,33 +165,27 @@ export function blockVariations( state = {}, action ) {
 				...mapValues(
 					keyBlockTypesByName( action.blockTypes ),
 					( blockType ) => {
-						return uniqBy(
-							[
-								...get( blockType, [ 'variations' ], [] ).map(
-									( variation ) => ( {
-										...variation,
-										source: 'block',
-									} )
-								),
-								...get( state, [ blockType.name ], [] ).filter(
-									( { source } ) => 'block' !== source
-								),
-							],
-							( variation ) => variation.name
-						);
+						return getUniqueItemsByName( [
+							...get( blockType, [ 'variations' ], [] ).map(
+								( variation ) => ( {
+									...variation,
+									source: 'block',
+								} )
+							),
+							...get( state, [ blockType.name ], [] ).filter(
+								( { source } ) => 'block' !== source
+							),
+						] );
 					}
 				),
 			};
 		case 'ADD_BLOCK_VARIATIONS':
 			return {
 				...state,
-				[ action.blockName ]: uniqBy(
-					[
-						...get( state, [ action.blockName ], [] ),
-						...action.variations,
-					],
-					( variation ) => variation.name
-				),
+				[ action.blockName ]: getUniqueItemsByName( [
+					...get( state, [ action.blockName ], [] ),
+					...action.variations,
+				] ),
 			};
 		case 'REMOVE_BLOCK_VARIATIONS':
 			return {

--- a/packages/editor/src/components/post-taxonomies/flat-term-selector.js
+++ b/packages/editor/src/components/post-taxonomies/flat-term-selector.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { escape as escapeString, find, get, uniqBy } from 'lodash';
+import { escape as escapeString, find, get } from 'lodash';
 
 /**
  * WordPress dependencies
@@ -202,7 +202,15 @@ export function FlatTermSelector( { slug } ) {
 			...( terms ?? [] ),
 			...( searchResults ?? [] ),
 		];
-		const uniqueTerms = uniqBy( termNames, ( term ) => term.toLowerCase() );
+		const uniqueTerms = termNames.reduce( ( acc, name ) => {
+			if (
+				! acc.some( ( n ) => n.toLowerCase() === name.toLowerCase() )
+			) {
+				acc.push( name );
+			}
+			return acc;
+		}, [] );
+
 		const newTermNames = uniqueTerms.filter(
 			( termName ) =>
 				! find( availableTerms, ( term ) =>


### PR DESCRIPTION
## What?
This PR removes the `_.uniqBy()` usage completely and deprecates the function.

## Why?

Lodash is known to unnecessarily inflate the bundle size of packages, and in most cases, it can be replaced with native language functionality. See these for more information and rationale:

* https://github.com/WordPress/gutenberg/issues/16938#issuecomment-602837246
* https://github.com/WordPress/gutenberg/issues/17025
* https://github.com/WordPress/gutenberg/issues/39495 

## How?

The existing 3 use cases are pretty simple and straightforward, so we're replacing them with custom `Array.prototype.reduce()` alternatives. 

## Testing Instructions
* Start writing a new post.
* Input the following tags into "Tags" in the sidebar: `x`, `Y`, `test`, `X`, `y`.
* Verify that the tags that remain are: `x`, `Y`, `test`.
* Type `npm run other:changelog` and verify it still outputs a changelog into your terminal.
* Verify the blocks store reducer tests still pass: `npm run test:unit packages/blocks/src/store/test/reducer.js`