### PR TITLE
Block Editor Handbook: Added missing codetabs end marker

### DIFF
--- a/docs/how-to-guides/block-tutorial/writing-your-first-block-type.md
+++ b/docs/how-to-guides/block-tutorial/writing-your-first-block-type.md
@@ -161,6 +161,7 @@ Create the asset file to load the dependencies for the scripts. The name of this
 	);
 ```
 
+{% end %}
 
 ### Step 5: Confirm
 


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->
This PR adds a `{% end %}` marker to one of the block handbook pages that was leading to the codetabs displaying incorrectly.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
In [Step 4 of Create your first block](https://developer.wordpress.org/block-editor/how-to-guides/block-tutorial/writing-your-first-block-type/#step-4-build-or-add-dependency) the codetabs are displaying incorrectly due to a missing `{% end %}` marker.

## Testing Instructions
There are no testing instructions since the documentation is built separately before being pushed to developer.wordpress.org. `{% codetabs %}` and other layout markers aren't processed before this.

If there are ways to test this please do let me know!

## Screenshots or screencast <!-- if applicable -->
<img width="711" alt="Screenshot 2022-08-12 at 14 27 31" src="https://user-images.githubusercontent.com/22053773/184353899-74280a1d-26d7-4b92-aca2-938f6cb535db.png">