### PR TITLE
Popover: fix and improve opening animation, use framer motion

### DIFF
--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -6,6 +6,10 @@
 
 -   `CustomSelectControl`: Deprecate constrained width style. Add a `__nextUnconstrainedWidth` prop to start opting into the unconstrained width that will become the default in a future version, currently scheduled to be WordPress 6.4 ([#43230](https://github.com/WordPress/gutenberg/pull/43230)).
 
+### Bug Fix
+
+-   `Popover`: fix and improve opening animation ([#43186](https://github.com/WordPress/gutenberg/pull/43186)).
+
 ### Enhancements
 
 -   `ToggleGroupControl`: Improve TypeScript documentation ([#43265](https://github.com/WordPress/gutenberg/pull/43265)).

--- a/packages/components/src/popover/index.js
+++ b/packages/components/src/popover/index.js
@@ -42,7 +42,7 @@ import { Path, SVG } from '@wordpress/primitives';
 import Button from '../button';
 import ScrollLock from '../scroll-lock';
 import { Slot, Fill, useSlot } from '../slot-fill';
-import { placementToMotionAnimationProps } from './utils';
+import { positionToPlacement, placementToMotionAnimationProps } from './utils';
 
 /**
  * Name of slot in which popover should fill.
@@ -113,22 +113,6 @@ const MaybeAnimatedWrapper = forwardRef(
 );
 
 const slotNameContext = createContext();
-
-const positionToPlacement = ( position ) => {
-	const [ x, y, z ] = position.split( ' ' );
-
-	if ( [ 'top', 'bottom' ].includes( x ) ) {
-		let suffix = '';
-		if ( ( !! z && z === 'left' ) || y === 'right' ) {
-			suffix = '-start';
-		} else if ( ( !! z && z === 'right' ) || y === 'left' ) {
-			suffix = '-end';
-		}
-		return x + suffix;
-	}
-
-	return y;
-};
 
 const Popover = (
 	{

--- a/packages/components/src/popover/index.js
+++ b/packages/components/src/popover/index.js
@@ -14,7 +14,7 @@ import {
 	size,
 } from '@floating-ui/react-dom';
 // eslint-disable-next-line no-restricted-imports
-import { motion } from 'framer-motion';
+import { motion, useReducedMotion } from 'framer-motion';
 
 /**
  * WordPress dependencies
@@ -85,12 +85,15 @@ const MaybeAnimatedWrapper = forwardRef(
 		},
 		forwardedRef
 	) => {
+		// In your component
+		const shouldReduceMotion = useReducedMotion();
+
 		const { style: motionInlineStyles, ...otherMotionProps } = useMemo(
 			() => placementToMotionAnimationProps( placement ),
 			[ placement ]
 		);
 
-		if ( shouldAnimate ) {
+		if ( shouldAnimate && ! shouldReduceMotion ) {
 			return (
 				<motion.div
 					style={ {

--- a/packages/components/src/popover/index.js
+++ b/packages/components/src/popover/index.js
@@ -420,7 +420,7 @@ const Popover = (
 		// eslint-disable-next-line jsx-a11y/no-noninteractive-element-interactions
 		// eslint-disable-next-line jsx-a11y/no-static-element-interactions
 		<MaybeAnimatedWrapper
-			shouldAnimate={ animate }
+			shouldAnimate={ animate && ! isExpanded }
 			placement={ computedPlacement }
 			className={ classnames( 'components-popover', className, {
 				'is-expanded': isExpanded,

--- a/packages/components/src/popover/index.js
+++ b/packages/components/src/popover/index.js
@@ -85,7 +85,6 @@ const MaybeAnimatedWrapper = forwardRef(
 		},
 		forwardedRef
 	) => {
-		// In your component
 		const shouldReduceMotion = useReducedMotion();
 
 		const { style: motionInlineStyles, ...otherMotionProps } = useMemo(

--- a/packages/components/src/popover/index.js
+++ b/packages/components/src/popover/index.js
@@ -85,10 +85,12 @@ const MaybeAnimatedWrapper = forwardRef(
 		},
 		forwardedRef
 	) => {
-		if ( shouldAnimate ) {
-			const { style: motionInlineStyles, ...otherMotionProps } =
-				placementToMotionAnimationProps( placement );
+		const { style: motionInlineStyles, ...otherMotionProps } = useMemo(
+			() => placementToMotionAnimationProps( placement ),
+			[ placement ]
+		);
 
+		if ( shouldAnimate ) {
 			return (
 				<motion.div
 					style={ {

--- a/packages/components/src/popover/stories/index.js
+++ b/packages/components/src/popover/stories/index.js
@@ -181,6 +181,7 @@ AllPlacements.args = {
 	),
 	noArrow: false,
 	offset: 10,
+	__unstableForcePosition: true,
 };
 
 export const DynamicHeight = ( { children, ...args } ) => {

--- a/packages/components/src/popover/stories/index.js
+++ b/packages/components/src/popover/stories/index.js
@@ -126,7 +126,14 @@ export const Default = ( args ) => {
 	);
 };
 Default.args = {
-	children: <>Popover&apos;s&nbsp;content</>,
+	children: (
+		<div style={ { width: '280px', whiteSpace: 'normal' } }>
+			Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do
+			eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim
+			ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut
+			aliquip ex ea commodo consequat.
+		</div>
+	),
 };
 
 /**
@@ -166,6 +173,12 @@ AllPlacements.parameters = {
 };
 AllPlacements.args = {
 	...Default.args,
+	children: (
+		<div style={ { width: '280px', whiteSpace: 'normal' } }>
+			Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do
+			eiusmod tempor incididunt ut labore et dolore magna aliqua.
+		</div>
+	),
 	noArrow: false,
 	offset: 10,
 };

--- a/packages/components/src/popover/test/__snapshots__/index.js.snap
+++ b/packages/components/src/popover/test/__snapshots__/index.js.snap
@@ -1,11 +1,11 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`Popover should pass additional props to portaled element 1`] = `
+exports[`Popover Component should pass additional props to portaled element 1`] = `
 <span>
   <div
-    class="components-popover components-animate__appear is-from-left is-from-top"
+    class="components-popover"
     role="tooltip"
-    style="position: absolute;"
+    style="position: absolute; opacity: 0; transform: translateY(-2em) scale(0) translateZ(0); transform-origin: 0% 0% 0;"
     tabindex="-1"
   >
     <div
@@ -17,11 +17,11 @@ exports[`Popover should pass additional props to portaled element 1`] = `
 </span>
 `;
 
-exports[`Popover should render content 1`] = `
+exports[`Popover Component should render content 1`] = `
 <span>
   <div
-    class="components-popover components-animate__appear is-from-left is-from-top"
-    style="position: absolute;"
+    class="components-popover"
+    style="position: absolute; opacity: 0; transform: translateY(-2em) scale(0) translateZ(0); transform-origin: 0% 0% 0;"
     tabindex="-1"
   >
     <div

--- a/packages/components/src/popover/test/index.js
+++ b/packages/components/src/popover/test/index.js
@@ -14,56 +14,62 @@ import { useRef } from '@wordpress/element';
 import Popover from '../';
 
 describe( 'Popover', () => {
-	afterEach( () => {
-		if ( document.activeElement ) {
-			document.activeElement.blur();
-		}
-	} );
-
-	it( 'should allow focus-on-open behavior to be disabled', () => {
-		expect( document.activeElement ).toBe( document.body );
-
-		act( () => {
-			render( <Popover focusOnMount={ false } /> );
-
-			jest.advanceTimersByTime( 1 );
+	describe( 'Component', () => {
+		afterEach( () => {
+			if ( document.activeElement ) {
+				document.activeElement.blur();
+			}
 		} );
 
-		expect( document.activeElement ).toBe( document.body );
-	} );
+		it( 'should allow focus-on-open behavior to be disabled', () => {
+			expect( document.activeElement ).toBe( document.body );
 
-	it( 'should render content', () => {
-		let result;
-		act( () => {
-			result = render( <Popover>Hello</Popover> );
+			act( () => {
+				render( <Popover focusOnMount={ false } /> );
+
+				jest.advanceTimersByTime( 1 );
+			} );
+
+			expect( document.activeElement ).toBe( document.body );
 		} );
 
-		expect( result.container.querySelector( 'span' ) ).toMatchSnapshot();
-	} );
+		it( 'should render content', () => {
+			let result;
+			act( () => {
+				result = render( <Popover>Hello</Popover> );
+			} );
 
-	it( 'should pass additional props to portaled element', () => {
-		let result;
-		act( () => {
-			result = render( <Popover role="tooltip">Hello</Popover> );
+			expect(
+				result.container.querySelector( 'span' )
+			).toMatchSnapshot();
 		} );
 
-		expect( result.container.querySelector( 'span' ) ).toMatchSnapshot();
-	} );
+		it( 'should pass additional props to portaled element', () => {
+			let result;
+			act( () => {
+				result = render( <Popover role="tooltip">Hello</Popover> );
+			} );
 
-	it( 'should render correctly when anchorRef is provided', () => {
-		const PopoverWithAnchor = ( args ) => {
-			const anchorRef = useRef( null );
+			expect(
+				result.container.querySelector( 'span' )
+			).toMatchSnapshot();
+		} );
 
-			return (
-				<div>
-					<p ref={ anchorRef }>Anchor</p>
-					<Popover { ...args } anchorRef={ anchorRef } />
-				</div>
-			);
-		};
+		it( 'should render correctly when anchorRef is provided', () => {
+			const PopoverWithAnchor = ( args ) => {
+				const anchorRef = useRef( null );
 
-		render( <PopoverWithAnchor>Popover content</PopoverWithAnchor> );
+				return (
+					<div>
+						<p ref={ anchorRef }>Anchor</p>
+						<Popover { ...args } anchorRef={ anchorRef } />
+					</div>
+				);
+			};
 
-		expect( screen.getByText( 'Popover content' ) ).toBeInTheDocument();
+			render( <PopoverWithAnchor>Popover content</PopoverWithAnchor> );
+
+			expect( screen.getByText( 'Popover content' ) ).toBeInTheDocument();
+		} );
 	} );
 } );

--- a/packages/components/src/popover/test/index.js
+++ b/packages/components/src/popover/test/index.js
@@ -13,6 +13,8 @@ import { useRef } from '@wordpress/element';
  */
 import Popover from '../';
 
+import { positionToPlacement, placementToMotionAnimationProps } from '../utils';
+
 describe( 'Popover', () => {
 	describe( 'Component', () => {
 		afterEach( () => {
@@ -70,6 +72,91 @@ describe( 'Popover', () => {
 			render( <PopoverWithAnchor>Popover content</PopoverWithAnchor> );
 
 			expect( screen.getByText( 'Popover content' ) ).toBeInTheDocument();
+		} );
+	} );
+
+	describe( 'positionToPlacement', () => {
+		it.each( [
+			[ 'top left', 'top-end' ],
+			[ 'top center', 'top' ],
+			[ 'top right', 'top-start' ],
+			[ 'middle left', 'left' ],
+			[ 'middle center', 'center' ],
+			[ 'middle right', 'right' ],
+			[ 'bottom left', 'bottom-end' ],
+			[ 'bottom center', 'bottom' ],
+			[ 'bottom right', 'bottom-start' ],
+		] )( 'converts `%s` to `%s`', ( inputPosition, expectedPlacement ) => {
+			expect( positionToPlacement( inputPosition ) ).toEqual(
+				expectedPlacement
+			);
+		} );
+	} );
+
+	describe( 'placementToMotionAnimationProps', () => {
+		describe( 'animation origin', () => {
+			it.each( [
+				[ 'top', 0.5, 1 ],
+				[ 'top-start', 0, 1 ],
+				[ 'top-end', 1, 1 ],
+				[ 'right', 0, 0.5 ],
+				[ 'right-start', 0, 0 ],
+				[ 'right-end', 0, 1 ],
+				[ 'bottom', 0.5, 0 ],
+				[ 'bottom-start', 0, 0 ],
+				[ 'bottom-end', 1, 0 ],
+				[ 'left', 1, 0.5 ],
+				[ 'left-start', 1, 0 ],
+				[ 'left-end', 1, 1 ],
+			] )(
+				'for the `%s` placement computes an animation origin of (%d, %d)',
+				( inputPlacement, expectedOriginX, expectedOriginY ) => {
+					expect(
+						placementToMotionAnimationProps( inputPlacement )
+					).toEqual(
+						expect.objectContaining( {
+							style: expect.objectContaining( {
+								originX: expectedOriginX,
+								originY: expectedOriginY,
+							} ),
+						} )
+					);
+				}
+			);
+		} );
+		describe( 'initial translation', () => {
+			it.each( [
+				[ 'top', 'translateY', '2em' ],
+				[ 'top-start', 'translateY', '2em' ],
+				[ 'top-end', 'translateY', '2em' ],
+				[ 'right', 'translateX', '-2em' ],
+				[ 'right-start', 'translateX', '-2em' ],
+				[ 'right-end', 'translateX', '-2em' ],
+				[ 'bottom', 'translateY', '-2em' ],
+				[ 'bottom-start', 'translateY', '-2em' ],
+				[ 'bottom-end', 'translateY', '-2em' ],
+				[ 'left', 'translateX', '2em' ],
+				[ 'left-start', 'translateX', '2em' ],
+				[ 'left-end', 'translateX', '2em' ],
+			] )(
+				'for the `%s` placement computes an initial `%s` of `%s',
+				(
+					inputPlacement,
+					expectedTranslationProp,
+					expectedTranslationValue
+				) => {
+					expect(
+						placementToMotionAnimationProps( inputPlacement )
+					).toEqual(
+						expect.objectContaining( {
+							initial: expect.objectContaining( {
+								[ expectedTranslationProp ]:
+									expectedTranslationValue,
+							} ),
+						} )
+					);
+				}
+			);
 		} );
 	} );
 } );

--- a/packages/components/src/popover/utils.js
+++ b/packages/components/src/popover/utils.js
@@ -1,0 +1,43 @@
+/**
+ * @typedef {import('../animate').AppearOrigin} AppearOrigin
+ * @typedef {import('@floating-ui/react-dom').Placement} FloatingUIPlacement
+ */
+
+/**
+ * @typedef AnimationOrigin
+ * @type {Object}
+ * @property {number} originX A number between 0 and 1 (in RTL direction, 0 is left, 0.5 is center, and 1 is right)
+ * @property {number} originY A number between 0 and 1 (0 is top, 0.5 is center, and 1 is bottom)
+ */
+
+/** @type {Object.<FloatingUIPlacement, {originX: number, originY: number}>} */
+const PLACEMENT_TO_ANIMATION_ORIGIN = {
+	top: { originX: 0.5, originY: 1 }, // open from bottom, center
+	'top-start': { originX: 0, originY: 1 }, // open from bottom, left
+	'top-end': { originX: 1, originY: 1 }, // open from bottom, right
+	right: { originX: 0, originY: 0.5 }, // open from middle, left
+	'right-start': { originX: 0, originY: 0 }, // open from top, left
+	'right-end': { originX: 0, originY: 1 }, // open from bottom, left
+	bottom: { originX: 0.5, originY: 0 }, // open from top, center
+	'bottom-start': { originX: 0, originY: 0 }, // open from top, left
+	'bottom-end': { originX: 1, originY: 0 }, // open from top, right
+	left: { originX: 1, originY: 0.5 }, // open from middle, right
+	'left-start': { originX: 1, originY: 0 }, // open from top, right
+	'left-end': { originX: 1, originY: 1 }, // open from bottom, right
+};
+
+/**
+ * Given the floating-ui `placement`, compute the framer-motion props for the
+ * popover's entry animation.
+ *
+ * @param {FloatingUIPlacement} placement A placement string from floating ui
+ * @return {import('framer-motion').MotionProps} The object containing the motion props
+ */
+export const placementToMotionAnimationProps = ( placement ) => {
+	return {
+		style: PLACEMENT_TO_ANIMATION_ORIGIN[ placement ],
+		initial: { scale: 0 },
+		animate: { scale: 1 },
+		transition: { duration: 0.1, ease: [ 0, 0, 0.2, 1 ] },
+	};
+};

--- a/packages/components/src/popover/utils.js
+++ b/packages/components/src/popover/utils.js
@@ -33,7 +33,7 @@ export const positionToPlacement = ( position ) => {
 /**
  * @typedef AnimationOrigin
  * @type {Object}
- * @property {number} originX A number between 0 and 1 (in RTL direction, 0 is left, 0.5 is center, and 1 is right)
+ * @property {number} originX A number between 0 and 1 (in CSS logical properties jargon, 0 is "start", 0.5 is "center", and 1 is "end")
  * @property {number} originY A number between 0 and 1 (0 is top, 0.5 is center, and 1 is bottom)
  */
 

--- a/packages/components/src/popover/utils.js
+++ b/packages/components/src/popover/utils.js
@@ -61,10 +61,23 @@ const PLACEMENT_TO_ANIMATION_ORIGIN = {
  * @return {import('framer-motion').MotionProps} The object containing the motion props
  */
 export const placementToMotionAnimationProps = ( placement ) => {
+	const translateProp =
+		placement.startsWith( 'top' ) || placement.startsWith( 'bottom' )
+			? 'translateY'
+			: 'translateX';
+	const translateDirection =
+		placement.startsWith( 'top' ) || placement.startsWith( 'left' )
+			? 1
+			: -1;
+
 	return {
 		style: PLACEMENT_TO_ANIMATION_ORIGIN[ placement ],
-		initial: { scale: 0 },
-		animate: { scale: 1 },
+		initial: {
+			opacity: 0,
+			scale: 0,
+			[ translateProp ]: `${ 2 * translateDirection }em`,
+		},
+		animate: { opacity: 1, scale: 1, [ translateProp ]: 0 },
 		transition: { duration: 0.1, ease: [ 0, 0, 0.2, 1 ] },
 	};
 };

--- a/packages/components/src/popover/utils.js
+++ b/packages/components/src/popover/utils.js
@@ -1,7 +1,34 @@
 /**
  * @typedef {import('../animate').AppearOrigin} AppearOrigin
  * @typedef {import('@floating-ui/react-dom').Placement} FloatingUIPlacement
+ * @typedef {	'top left' | 'top center' | 'top right' | 'middle left' | 'middle center' | 'middle right' | 'bottom left' | 'bottom center' | 'bottom right' | 'bottom left' | 'bottom center' | 'bottom right' } LegacyPosition
  */
+
+/**
+ * Converts the `Popover`'s legacy "position" prop to the new "placement" prop
+ * (used by `floating-ui`).
+ *
+ * @param {LegacyPosition} position The legacy position
+ * @return {FloatingUIPlacement} The corresponding placement
+ */
+export const positionToPlacement = ( position ) => {
+	const [ x, y, z ] = position.split( ' ' );
+
+	if ( [ 'top', 'bottom' ].includes( x ) ) {
+		let suffix = '';
+		if ( ( !! z && z === 'left' ) || y === 'right' ) {
+			suffix = '-start';
+		} else if ( ( !! z && z === 'right' ) || y === 'left' ) {
+			suffix = '-end';
+		}
+
+		// @ts-expect-error More TypeScript effort would be required to reconcile `string` and `Placement` types.
+		return x + suffix;
+	}
+
+	// @ts-expect-error More TypeScript effort would be required to reconcile `string` and `Placement` types.
+	return y;
+};
 
 /**
  * @typedef AnimationOrigin


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Tracked in #42770

After the regression introduced by #40740, this PR aims at restoring (and improving) the `Popover`'s opening animation

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

#40740 introduces a few big changes to `Popover` — in particular, it introduced a new `placement` prop (that should replace the legacy `position` prop). Alongside the `placement` prop, #40470 introduced two new functions:

- `positionToPlacement`: a function to "convert" `position` values to `placement` values
- `placementToAnimationOrigin`: a function to associate an animation origin, given the `placement`

This refactor caused the popover to animate unexpectedly (i.e. from the from animation origin ([example](https://github.com/WordPress/gutenberg/pull/42989#issuecomment-1212844061)).

Furthermore, as I looked into solving this issue, I noticed that `Popover` still relied on [the `animate` component](https://github.com/WordPress/gutenberg/blob/bca7d3a76cd45bb51fcdb2092af81974e6393e49/packages/components/src/animate/README.md), which was supposed to be deprecated already some time ago (see #27390).

Finally, I also noticed that the `Popover` was animating even when in its expanded mode, which is supposed to occupy the full screen on mobile — I believe that animating a piece of UI as big as the whole screen with a translate/scale animation could be excessive.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

 - **Switched to `framer-motion`** (instead of the `animate` component) for the `Popover`'s animation
   - Tweaked a few animation parameters compared to the CSS used in the `animate` component:
     - same animation duration: `0.1s`
     - same easing function: `cubic-bezier(0, 0, 0.2, 1)`
     - **added more animation origin options** (e.g. it's now possible to animated from the middle of the `x` and `y` axis)
     - kept the same **translation** amount, but improved it by **allowing for more directions** (e.g the popover can also translate from the bottom and from the right, previously it could only translate from top and left)
     - added a **fade-in animation** (from `0` to `1` opacity)
 - Regardless of the `animate` property, **the popover won't animate when in its expanded state (on mobile)**. This change was caused by two reasons:
   - When expanded, the popover would still have its animation origin computed based on its `placement` — even if the placement isn't really taken into account in the expanded state (the popover is full screen)
   - As said before, since the popover takes the whole screen when expanded on mobile, an opening animation felt overwhelming
   - If we want to keep the animation in the expanded state on mobile, I suggest we look at introducing a special case for its entry animation, which doesn't rely on `placement` and/or is less overwhelming visually.
 - **Completely refactored the `placementToAnimationOrigin` logic**, using a lookup table instead of hard-to-read logic for the animation origin 
 - Moved both `positionToPlacement` and `placementToAnimationOrigin` to a separate `utils.js` file
 - Added **unit tests** for the `positionToPlacement` function and the variable parts of the `placementToAnimationOrigin` function
 - Tweaked the Storybook examples to make it easier to debug placements and animations

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->

For ease of debug, the animation duration can be changes like so:

```diff
diff --git a/packages/components/src/popover/utils.js b/packages/components/src/popover/utils.js
index a5d2814db2..6ae9b77885 100644
--- a/packages/components/src/popover/utils.js
+++ b/packages/components/src/popover/utils.js
@@ -78,6 +78,6 @@ export const placementToMotionAnimationProps = ( placement ) => {
 			[ translateProp ]: `${ 2 * translateDirection }em`,
 		},
 		animate: { opacity: 1, scale: 1, [ translateProp ]: 0 },
-		transition: { duration: 0.1, ease: [ 0, 0, 0.2, 1 ] },
+		transition: { duration: 3, ease: [ 0, 0, 0.2, 1 ] },
 	};
 };
```

### Storybook

Open Storybook and play around with the `Popover` examples. In particular:

- check that, for each `placement` value, the popover animates from the correct animation origin
- check that the rest of the animation parameters are satisfactory (e.g. duration, easing, translation amount, scale amount)
- check that the popover doesn't animate when the `animate` prop is set to `false`
- check that the popover doesn't animate when the `expandOnMobile` prop is set to `true` and the popover is rendered in mobile viewports (even if the `animate` prop is set to `true`)
- check that the popover doesn't animate when the `prefers-reduced-motion` flag is set by the user (even if the `animate` prop is set to `true`)

### In the editor

Do a sanity check across the editor and make sure that the popover behaves (and animates when necessary) as expected

### Known issues

https://github.com/WordPress/gutenberg/issues/42770 has a list of known issues.

Specifically to testing for animation origin, it is possible that the `positionToPlacement` function introduced in #40740 is not converting the position 100% correctly. For the sake of this PR's scope, we should focus on the `placement` to animation origin logic (the `position` to `placement` logic can be tackled separately).

## Screenshots or screencast <!-- if applicable -->

Storybook (normal speed), this PR:

https://user-images.githubusercontent.com/1083581/184363638-6da992b5-b8ad-4a04-b1bc-693eb122352e.mp4

Storybook (slower speed), this PR:

https://user-images.githubusercontent.com/1083581/184364235-a7c0d8fd-216a-4c94-89ef-62b1dcdebcca.mp4


Editor (normal speed), `trunk`: 

https://user-images.githubusercontent.com/1083581/184368363-eaba448a-a1be-458e-b2ff-05a7efede44f.mp4

Editor (normal speed), this PR: 

https://user-images.githubusercontent.com/1083581/184368460-1b6d1252-b997-421d-8af6-bc64b7c8dfb9.mp4


