### PR TITLE
Navigation block: Create classic menus empty

### DIFF
--- a/packages/block-library/src/navigation/edit/index.js
+++ b/packages/block-library/src/navigation/edit/index.js
@@ -209,7 +209,7 @@ function Navigation( {
 	// - the user is creating a new menu.
 	// - there are no menus to choose from.
 	// This attempts to pick the first menu if there is a single Navigation Post. If more
-	// than 1 exists then no attempt to automatically pick a menu is made.
+	// than 1 exists then use the most recent.
 	// The aim is for the block to "just work" from a user perspective using existing data.
 	useEffect( () => {
 		if (

--- a/packages/block-library/src/navigation/edit/index.js
+++ b/packages/block-library/src/navigation/edit/index.js
@@ -247,6 +247,7 @@ function Navigation( {
 		status: classicMenuConversionStatus,
 		error: classicMenuConversionError,
 		value: classicMenuConversionResult,
+		classicInnerBlocks: classicMenuConversionInnerBlocks,
 	} = useConvertClassicToBlockMenu( clientId );
 
 	const isConvertingClassicMenu =
@@ -359,6 +360,8 @@ function Navigation( {
 			showClassicMenuConversionNotice(
 				__( 'Classic menu imported successfully.' )
 			);
+
+			replaceInnerBlocks( clientId, classicMenuConversionInnerBlocks );
 		}
 
 		if ( classicMenuConversionStatus === CLASSIC_MENU_CONVERSION_ERROR ) {
@@ -370,6 +373,7 @@ function Navigation( {
 		classicMenuConversionStatus,
 		classicMenuConversionResult,
 		classicMenuConversionError,
+		classicMenuConversionInnerBlocks,
 	] );
 
 	// Spacer block needs orientation from context. This is a patch until

--- a/packages/block-library/src/navigation/edit/index.js
+++ b/packages/block-library/src/navigation/edit/index.js
@@ -6,13 +6,7 @@ import classnames from 'classnames';
 /**
  * WordPress dependencies
  */
-import {
-	useState,
-	useEffect,
-	useRef,
-	useCallback,
-	Platform,
-} from '@wordpress/element';
+import { useState, useEffect, useRef, Platform } from '@wordpress/element';
 import {
 	InspectorControls,
 	BlockControls,
@@ -29,7 +23,7 @@ import {
 } from '@wordpress/block-editor';
 import { EntityProvider } from '@wordpress/core-data';
 
-import { useDispatch, useRegistry } from '@wordpress/data';
+import { useDispatch } from '@wordpress/data';
 import {
 	PanelBody,
 	ToggleControl,
@@ -41,6 +35,7 @@ import {
 } from '@wordpress/components';
 import { __, sprintf } from '@wordpress/i18n';
 import { speak } from '@wordpress/a11y';
+import { createBlock } from '@wordpress/blocks';
 
 /**
  * Internal dependencies
@@ -100,7 +95,6 @@ function Navigation( {
 
 	const ref = attributes.ref;
 
-	const registry = useRegistry();
 	const setRef = ( postId ) => {
 		setAttributes( { ref: postId } );
 	};
@@ -210,19 +204,37 @@ function Navigation( {
 	const navMenuResolvedButMissing =
 		hasResolvedNavigationMenus && isNavigationMenuMissing;
 
-	// Attempt to retrieve and prioritize any existing navigation menu unless
-	// a specific ref is allocated or the user is explicitly creating a new menu. The aim is
-	// for the block to "just work" from a user perspective using existing data.
+	// Attempt to retrieve and prioritize any existing navigation menu unless:
+	// - the are uncontrolled inner blocks already present in the block.
+	// - the user is creating a new menu.
+	// - there are no menus to choose from.
+	// This attempts to pick the first menu if there is a single Navigation Post. If more
+	// than 1 exists then no attempt to automatically pick a menu is made.
+	// The aim is for the block to "just work" from a user perspective using existing data.
 	useEffect( () => {
 		if (
+			hasUncontrolledInnerBlocks ||
 			isCreatingNavigationMenu ||
 			ref ||
-			! navigationMenus?.length ||
-			navigationMenus?.length > 1
+			! navigationMenus?.length
 		) {
 			return;
 		}
 
+		navigationMenus.sort( ( menuA, menuB ) => {
+			const menuADate = new Date( menuA.date );
+			const menuBDate = new Date( menuB.date );
+			return menuADate.getTime() < menuBDate.getTime();
+		} );
+
+		/**
+		 *  This fallback displays (both in editor and on front)
+		 *  a list of pages only if no menu (user assigned or
+		 *  automatically picked) is available.
+		 *  The fallback should not request a save (entity dirty state)
+		 *  nor to be undoable, hence why it is marked as non persistent
+		 */
+		__unstableMarkNextChangeAsNotPersistent();
 		setRef( navigationMenus[ 0 ].id );
 	}, [ navigationMenus ] );
 
@@ -254,6 +266,17 @@ function Navigation( {
 		! isConvertingClassicMenu &&
 		hasResolvedNavigationMenus &&
 		! hasUncontrolledInnerBlocks;
+
+	if ( isPlaceholder && ! ref ) {
+		/**
+		 *  this fallback only displays (both in editor and on front)
+		 *  the list of pages block if not menu is available
+		 *  we don't want the fallback to request a save
+		 *  nor to be undoable, hence we mark it non persistent
+		 */
+		__unstableMarkNextChangeAsNotPersistent();
+		replaceInnerBlocks( clientId, [ createBlock( 'core/page-list' ) ] );
+	}
 
 	const isEntityAvailable =
 		! isNavigationMenuMissing && isNavigationMenuResolved;
@@ -441,17 +464,6 @@ function Navigation( {
 		shouldFocusNavigationSelector,
 	] );
 
-	const resetToEmptyBlock = useCallback( () => {
-		registry.batch( () => {
-			setAttributes( {
-				ref: undefined,
-			} );
-			if ( ! ref ) {
-				replaceInnerBlocks( clientId, [] );
-			}
-		} );
-	}, [ clientId, ref ] );
-
 	const isResponsive = 'never' !== overlayMenu;
 
 	const overlayMenuPreviewClasses = classnames(
@@ -600,6 +612,27 @@ function Navigation( {
 	if ( hasUnsavedBlocks ) {
 		return (
 			<TagName { ...blockProps }>
+				<BlockControls>
+					<ToolbarGroup className="wp-block-navigation__toolbar-menu-selector">
+						<NavigationMenuSelector
+							ref={ null }
+							currentMenuId={ null }
+							clientId={ clientId }
+							onSelectNavigationMenu={ ( menuId ) => {
+								handleUpdateMenu( menuId );
+								setShouldFocusNavigationSelector( true );
+							} }
+							onSelectClassicMenu={ ( classicMenu ) => {
+								convert( classicMenu.id, classicMenu.name );
+								setShouldFocusNavigationSelector( true );
+							} }
+							onCreateNew={ () => createNavigationMenu( '', [] ) }
+							/* translators: %s: The name of a menu. */
+							actionLabel={ __( "Switch to '%s'" ) }
+							showManageActions
+						/>
+					</ToolbarGroup>
+				</BlockControls>
 				{ stylingInspectorControls }
 				<ResponsiveWrapper
 					id={ clientId }
@@ -639,16 +672,40 @@ function Navigation( {
 	// TODO - the user should be able to select a new one?
 	if ( ref && isNavigationMenuMissing ) {
 		return (
-			<div { ...blockProps }>
+			<TagName { ...blockProps }>
+				<BlockControls>
+					<ToolbarGroup className="wp-block-navigation__toolbar-menu-selector">
+						<NavigationMenuSelector
+							ref={ navigationSelectorRef }
+							currentMenuId={ ref }
+							clientId={ clientId }
+							onSelectNavigationMenu={ ( menuId ) => {
+								handleUpdateMenu( menuId );
+								setShouldFocusNavigationSelector( true );
+							} }
+							onSelectClassicMenu={ ( classicMenu ) => {
+								convert( classicMenu.id, classicMenu.name );
+								setShouldFocusNavigationSelector( true );
+							} }
+							onCreateNew={ () => createNavigationMenu( '', [] ) }
+							/* translators: %s: The name of a menu. */
+							actionLabel={ __( "Switch to '%s'" ) }
+							showManageActions
+						/>
+					</ToolbarGroup>
+				</BlockControls>
 				<Warning>
 					{ __(
 						'Navigation menu has been deleted or is unavailable. '
 					) }
-					<Button onClick={ resetToEmptyBlock } variant="link">
+					<Button
+						onClick={ () => createNavigationMenu( '', [] ) }
+						variant="link"
+					>
 						{ __( 'Create a new menu?' ) }
 					</Button>
 				</Warning>
-			</div>
+			</TagName>
 		);
 	}
 
@@ -666,7 +723,17 @@ function Navigation( {
 		? CustomPlaceholder
 		: Placeholder;
 
-	if ( isPlaceholder ) {
+	/**
+	 * Historically the navigation block has supported custom placeholders.
+	 * Even though the current UX tries as hard as possible not to
+	 * end up in a placeholder state, the block continues to support
+	 * this extensibility point, via a CustomPlaceholder.
+	 * When CustomPlaceholder is present it becomes the default fallback
+	 * for an empty navigation block, instead of the default fallbacks.
+	 *
+	 */
+
+	if ( isPlaceholder && CustomPlaceholder ) {
 		return (
 			<TagName { ...blockProps }>
 				<PlaceholderComponent
@@ -709,7 +776,9 @@ function Navigation( {
 									convert( classicMenu.id, classicMenu.name );
 									setShouldFocusNavigationSelector( true );
 								} }
-								onCreateNew={ resetToEmptyBlock }
+								onCreateNew={ () =>
+									createNavigationMenu( '', [] )
+								}
 								/* translators: %s: The name of a menu. */
 								actionLabel={ __( "Switch to '%s'" ) }
 								showManageActions
@@ -728,7 +797,7 @@ function Navigation( {
 							canUserDeleteNavigationMenu && (
 								<NavigationMenuDeleteControl
 									onDelete={ ( deletedMenuTitle = '' ) => {
-										resetToEmptyBlock();
+										replaceInnerBlocks( clientId, [] );
 										showNavigationMenuStatusNotice(
 											sprintf(
 												// translators: %s: the name of a menu (e.g. Header navigation).

--- a/packages/block-library/src/navigation/edit/index.js
+++ b/packages/block-library/src/navigation/edit/index.js
@@ -284,7 +284,7 @@ function Navigation( {
 	// "loading" state:
 	// - there is a menu creation process in progress.
 	// - there is a classic menu conversion process in progress.
-	// OR
+	// OR:
 	// - there is a ref attribute pointing to a Navigation Post
 	// - the Navigation Post isn't available (hasn't resolved) yet.
 	const isLoading =

--- a/packages/block-library/src/navigation/edit/use-convert-classic-menu-to-block-menu.js
+++ b/packages/block-library/src/navigation/edit/use-convert-classic-menu-to-block-menu.js
@@ -25,6 +25,7 @@ function useConvertClassicToBlockMenu( clientId ) {
 	const [ status, setStatus ] = useState( CLASSIC_MENU_CONVERSION_IDLE );
 	const [ value, setValue ] = useState( null );
 	const [ error, setError ] = useState( null );
+	const [ classicInnerBlocks, setClassicInnerBlocks ] = useState( null );
 
 	async function convertClassicMenuToBlockMenu( menuId, menuName ) {
 		let navigationMenu;
@@ -65,13 +66,11 @@ function useConvertClassicToBlockMenu( clientId ) {
 
 		// 2. Convert the classic items into blocks.
 		const { innerBlocks } = menuItemsToBlocks( classicMenuItems );
+		setClassicInnerBlocks( innerBlocks );
 
 		// 3. Create the `wp_navigation` Post with the blocks.
 		try {
-			navigationMenu = await createNavigationMenu(
-				menuName,
-				innerBlocks
-			);
+			navigationMenu = await createNavigationMenu( menuName, [] );
 		} catch ( err ) {
 			throw new Error(
 				sprintf(
@@ -100,7 +99,7 @@ function useConvertClassicToBlockMenu( clientId ) {
 			setValue( null );
 			setError( null );
 
-			convertClassicMenuToBlockMenu( menuId, menuName )
+			return convertClassicMenuToBlockMenu( menuId, menuName )
 				.then( ( navMenu ) => {
 					setValue( navMenu );
 					setStatus( CLASSIC_MENU_CONVERSION_SUCCESS );
@@ -130,6 +129,7 @@ function useConvertClassicToBlockMenu( clientId ) {
 		status,
 		value,
 		error,
+		classicInnerBlocks,
 	};
 }
 

--- a/packages/block-library/src/navigation/editor.scss
+++ b/packages/block-library/src/navigation/editor.scss
@@ -520,6 +520,7 @@ body.editor-styles-wrapper
 // so focus is applied naturally on the block container.
 // It's important the right container has focus, otherwise you can't press
 // "Delete" to remove the block.
+.wp-block-navigation__responsive-container,
 .wp-block-navigation__responsive-close {
 	@include break-small() {
 		pointer-events: none;

--- a/packages/block-library/src/navigation/index.php
+++ b/packages/block-library/src/navigation/index.php
@@ -255,7 +255,7 @@ function block_core_navigation_render_submenu_icon() {
  * @return WP_Post|null the first non-empty Navigation or null.
  */
 function block_core_navigation_get_most_recently_published_navigation() {
-	// We default to the most recently created
+	// We default to the most recently created menu.
 	$parsed_args = array(
 		'post_type'      => 'wp_navigation',
 		'no_found_rows'  => true,
@@ -266,7 +266,7 @@ function block_core_navigation_get_most_recently_published_navigation() {
 	);
 
 	$navigation_post = new WP_Query( $parsed_args );
-	if( count( $navigation_post->posts )  > 0 ) {
+	if ( count( $navigation_post->posts ) > 0 ) {
 		return $navigation_post->posts[0];
 	}
 

--- a/packages/block-library/src/navigation/index.php
+++ b/packages/block-library/src/navigation/index.php
@@ -262,7 +262,7 @@ function block_core_navigation_get_most_recently_published_navigation() {
 		'order'          => 'DESC',
 		'orderby'        => 'date',
 		'post_status'    => 'publish',
-		'posts_per_page' => 1, // Try the first 20 posts.
+		'posts_per_page' => 1, // get only the most recent
 	);
 
 	$navigation_post = new WP_Query( $parsed_args );

--- a/packages/block-library/src/navigation/index.php
+++ b/packages/block-library/src/navigation/index.php
@@ -250,7 +250,7 @@ function block_core_navigation_render_submenu_icon() {
 
 
 /**
- * Finds the most recent published `wp_navigation` Post.
+ * Finds the most recently published `wp_navigation` Post.
  *
  * @return WP_Post|null the first non-empty Navigation or null.
  */

--- a/packages/block-library/src/navigation/index.php
+++ b/packages/block-library/src/navigation/index.php
@@ -250,29 +250,24 @@ function block_core_navigation_render_submenu_icon() {
 
 
 /**
- * Finds the first non-empty `wp_navigation` Post.
+ * Finds the most recent published `wp_navigation` Post.
  *
  * @return WP_Post|null the first non-empty Navigation or null.
  */
-function block_core_navigation_get_first_non_empty_navigation() {
-	// Order and orderby args set to mirror those in `wp_get_nav_menus`
-	// see:
-	// - https://github.com/WordPress/wordpress-develop/blob/ba943e113d3b31b121f77a2d30aebe14b047c69d/src/wp-includes/nav-menu.php#L613-L619.
-	// - https://developer.wordpress.org/reference/classes/wp_query/#order-orderby-parameters.
+function block_core_navigation_get_most_recently_published_navigation() {
+	// We default to the most recently created
 	$parsed_args = array(
 		'post_type'      => 'wp_navigation',
 		'no_found_rows'  => true,
-		'order'          => 'ASC',
-		'orderby'        => 'name',
+		'order'          => 'DESC',
+		'orderby'        => 'date',
 		'post_status'    => 'publish',
-		'posts_per_page' => 20, // Try the first 20 posts.
+		'posts_per_page' => 1, // Try the first 20 posts.
 	);
 
-	$navigation_posts = new WP_Query( $parsed_args );
-	foreach ( $navigation_posts->posts as $navigation_post ) {
-		if ( has_blocks( $navigation_post ) ) {
-			return $navigation_post;
-		}
+	$navigation_post = new WP_Query( $parsed_args );
+	if( count( $navigation_post->posts )  > 0 ) {
+		return $navigation_post->posts[0];
 	}
 
 	return null;
@@ -325,7 +320,7 @@ function block_core_navigation_get_fallback_blocks() {
 
 	// Default to a list of Pages.
 
-	$navigation_post = block_core_navigation_get_first_non_empty_navigation();
+	$navigation_post = block_core_navigation_get_most_recently_published_navigation();
 
 	// Prefer using the first non-empty Navigation as fallback if available.
 	if ( $navigation_post ) {

--- a/packages/block-library/src/navigation/index.php
+++ b/packages/block-library/src/navigation/index.php
@@ -262,7 +262,7 @@ function block_core_navigation_get_most_recently_published_navigation() {
 		'order'          => 'DESC',
 		'orderby'        => 'date',
 		'post_status'    => 'publish',
-		'posts_per_page' => 1, // get only the most recent
+		'posts_per_page' => 1, // get only the most recent.
 	);
 
 	$navigation_post = new WP_Query( $parsed_args );

--- a/packages/e2e-tests/specs/editor/blocks/__snapshots__/navigation.test.js.snap
+++ b/packages/e2e-tests/specs/editor/blocks/__snapshots__/navigation.test.js.snap
@@ -2,7 +2,7 @@
 
 exports[`Navigation Creating and restarting converts uncontrolled inner blocks to an entity when modifications are made to the blocks 1`] = `"<!-- wp:navigation-link {\\"label\\":\\"A Test Page\\",\\"type\\":\\"page\\",\\"id\\":[number],\\"url\\":\\"http://localhost:8889/?page_id=[number]\\",\\"kind\\":\\"post-type\\"} /-->"`;
 
-exports[`Navigation Placeholder placeholder actions allows a navigation block to be created from existing menus 1`] = `
+exports[`Navigation Placeholder menu selector actions allows a navigation block to be created from existing menus 1`] = `
 "<!-- wp:navigation-link {\\"label\\":\\"Home\\",\\"type\\":\\"custom\\",\\"url\\":\\"http://localhost:8889/\\",\\"kind\\":\\"custom\\"} /-->
 
 <!-- wp:navigation-submenu {\\"label\\":\\"About\\",\\"type\\":\\"page\\",\\"id\\":[number],\\"url\\":\\"http://localhost:8889/?page_id=[number]\\",\\"kind\\":\\"post-type\\"} -->
@@ -29,8 +29,6 @@ exports[`Navigation Placeholder placeholder actions allows a navigation block to
 <!-- wp:navigation-link {\\"label\\":\\"Google\\",\\"type\\":\\"custom\\",\\"url\\":\\"https://google.com\\",\\"kind\\":\\"custom\\"} /-->
 <!-- /wp:navigation-submenu -->"
 `;
-
-exports[`Navigation Placeholder placeholder actions creates an empty navigation block when the selected existing menu is also empty 1`] = `""`;
 
 exports[`Navigation allows an empty navigation block to be created and manually populated using a mixture of internal and external links 1`] = `
 "<!-- wp:navigation-link {\\"label\\":\\"WP\\",\\"url\\":\\"https://wordpress.org\\",\\"kind\\":\\"custom\\",\\"isTopLevelLink\\":true} /-->


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
This is an attempt to fix #42850

## Why?
When you create a new navigation menu from a classic menu then a new wp_navigation CPT is created, which is already populated with the content of the classic navigation. The upshot of this is that as soon as the classic navigation is created the fallback behaviour of the block is changed and the classic menu is used instead of page list (as described in https://github.com/WordPress/gutenberg/issues/42799)

## How?
When we create a new "classic" wp_navigation CPT we do it without any innerblocks, so its empty. This means that the fallback behaviour is unchanged. We then populate the inner blocks with the navigation items that were returned from the API. This should mark the block as "dirty" for the entity saving flow, so it feels like it should be a simpler approach. 

## Testing Instructions

To replicate the issue

1. Remove all navigation menus from wp-admin/edit.php?post_type=wp_navigation
2. Ensure you have a classic menu (you will need to switch to a classic theme to create one if you don't have one)
3. Create a navigation block without any inner blocks (if you're using a navigation block in a theme you'll probably need to remove the blocks from the template).
4. Check that you see a page list fallback on your site
5. Select the block and click on "Classic menus > primary`, or whatever it is called.
6. Now reload the frontend of your site and check that the fallback has changed to the classic menu.

With this PR enabled
6. The fallback is unchanged
7.  (not working from this point) You should see the classic menu inner blocks in the editor
8. When you go to save you have the option to save the new CPT
9. When you have saved the frontend now displays the classic navigation menu items.