### PR TITLE
Pullquote block: remove font definition from the default block styles

### DIFF
--- a/packages/block-library/src/pullquote/block.json
+++ b/packages/block-library/src/pullquote/block.json
@@ -63,7 +63,7 @@
 		},
 		"__experimentalStyle": {
 			"typography": {
-				"fontSize": "1.25rem",
+				"fontSize": "1.5em",
 				"lineHeight": "1.6"
 			}
 		}

--- a/packages/block-library/src/pullquote/block.json
+++ b/packages/block-library/src/pullquote/block.json
@@ -60,6 +60,12 @@
 				"style": true,
 				"width": true
 			}
+		},
+		"__experimentalStyle": {
+			"typography": {
+				"fontSize": "1.25rem",
+				"lineHeight": "1.6"
+			}
 		}
 	},
 	"editorStyle": "wp-block-pullquote-editor",

--- a/packages/block-library/src/pullquote/editor.scss
+++ b/packages/block-library/src/pullquote/editor.scss
@@ -9,7 +9,6 @@
 
 .wp-block-pullquote {
 	& blockquote p {
-		font-size: 28px;
 		line-height: 1.6;
 	}
 }

--- a/packages/block-library/src/pullquote/editor.scss
+++ b/packages/block-library/src/pullquote/editor.scss
@@ -1,18 +1,3 @@
-.wp-block-pullquote.has-text-align-left,
-.wp-block-pullquote.has-text-align-right,
-.wp-block[data-align="left"] > .wp-block-pullquote,
-.wp-block[data-align="right"] > .wp-block-pullquote {
-	& p {
-		font-size: 20px;
-	}
-}
-
-.wp-block-pullquote {
-	& blockquote p {
-		line-height: 1.6;
-	}
-}
-
 // .is-style-solid-color is deprecated.
 .wp-block-pullquote.is-style-solid-color {
 	& blockquote p {

--- a/packages/block-library/src/pullquote/style.scss
+++ b/packages/block-library/src/pullquote/style.scss
@@ -16,15 +16,6 @@
 	&.alignleft,
 	&.alignright {
 		max-width: $content-width * 0.5;
-
-		p {
-			font-size: 1.25em;
-		}
-	}
-
-	p {
-		font-size: 1.75em;
-		line-height: 1.6;
 	}
 
 	cite,


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->
Pullquote block: remove font definition from the default block styles to make it customizable using theme.json
## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
Because currently the font settings from a theme's theme.json file, such as font size and line height, are being overridden by the default block styles. 

Currently it doesn't work well because the theme.json targets .`wp-block-pullquote` and the built-in block css targets `.wp-block-pullquote p`   so the theme.json definition is overridden.

So if we set this in theme.json
```
"core/pullquote": {
	"typography": {
		"fontSize": "3rem"
	}
}
```
We get that size modified by the relative `em` unit specified by the block CSS with a more specific selector.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
In this PR I'm removing the CSS definitions from the block CSS and adding it to block.json
.
## Testing Instructions
1. Set emptytheme to discard other styles problems.
2. Add a pullquote block to a post
3. Change the font settings for the pullquote block in your theme `theme.json` file
```
	"styles": {
		"blocks": {
			"core/pullquote": {
				"typography": {
					"fontSize": "3rem"
				}
			}
		}
	}
```
4. Check if the font size is applied to the block.

## Screenshots or screencast <!-- if applicable -->

**Before:**

https://user-images.githubusercontent.com/1310626/184396962-d5a06ce9-c93a-4891-a90e-625dc9fb3383.mp4





**After:**

https://user-images.githubusercontent.com/1310626/184395570-ba6af43e-8406-4996-8e20-302b082ef879.mp4


