### PR TITLE
Rich Text: Eliminate second scan when getting text content

### DIFF
--- a/packages/rich-text/src/get-text-content.js
+++ b/packages/rich-text/src/get-text-content.js
@@ -8,6 +8,11 @@ import {
 
 /** @typedef {import('./create').RichTextValue} RichTextValue */
 
+const pattern = new RegExp(
+	`[${ OBJECT_REPLACEMENT_CHARACTER }${ LINE_SEPARATOR }]`,
+	'g'
+);
+
 /**
  * Get the textual content of a Rich Text value. This is similar to
  * `Element.textContent`.
@@ -17,7 +22,7 @@ import {
  * @return {string} The text content.
  */
 export function getTextContent( { text } ) {
-	return text
-		.replace( new RegExp( OBJECT_REPLACEMENT_CHARACTER, 'g' ), '' )
-		.replace( new RegExp( LINE_SEPARATOR, 'g' ), '\n' );
+	return text.replace( pattern, ( c ) =>
+		c === OBJECT_REPLACEMENT_CHARACTER ? '' : '\n'
+	);
 }


### PR DESCRIPTION
## What?

When calling `getTextContent()` on a `RichTextValue` we have
to make sure we replace any internal-use placeholder values.
Previously we've been making two string-replace passes with
a new `RegExp` on each call to `getTextContext()`.

In this patch we're combining the things we want to replace
into a single `RegExp` pattern so that we can make both
existing substitutions in one pass through the text instead
of two, and we're pre-allocating that `RegExp` at module
boot time so we can avoid creating new instances of it on
every call.

## Why?

Why do multiple things when one thing accomplishes the same result?
Even if the performance isn't affected much (unless it's slower),
there's no need to scan the string twice.

## Todo

 - Attempt to measure any performance impact
 - Verify tests pass