### PR TITLE
Fix/select control multiple

### DIFF
--- a/packages/components/src/select-control/index.tsx
+++ b/packages/components/src/select-control/index.tsx
@@ -85,6 +85,15 @@ function UnforwardedSelectControl(
 
 	const classes = classNames( 'components-select-control', className );
 
+	const downArrowWrapper =
+		multiple === false ? (
+			<DownArrowWrapper>
+				<Icon icon={ chevronDown } size={ 18 } />
+			</DownArrowWrapper>
+		) : (
+			Boolean
+		);
+
 	/* eslint-disable jsx-a11y/no-onchange */
 	return (
 		<BaseControl
@@ -100,13 +109,7 @@ function UnforwardedSelectControl(
 				isFocused={ isFocused }
 				label={ label }
 				size={ size }
-				suffix={
-					suffix || (
-						<DownArrowWrapper>
-							<Icon icon={ chevronDown } size={ 18 } />
-						</DownArrowWrapper>
-					)
-				}
+				suffix={ suffix || downArrowWrapper }
 				prefix={ prefix }
 				labelPosition={ labelPosition }
 			>

--- a/packages/components/src/select-control/stories/index.tsx
+++ b/packages/components/src/select-control/stories/index.tsx
@@ -23,6 +23,7 @@ const meta: ComponentMeta< typeof SelectControl > = {
 		prefix: { control: { type: 'text' } },
 		suffix: { control: { type: 'text' } },
 		value: { control: { type: null } },
+		multiple: { control: { type: Array } },
 	},
 	parameters: {
 		controls: { expanded: true },
@@ -86,4 +87,15 @@ export const WithCustomChildren: ComponentStory< typeof SelectControl > = (
 			</optgroup>
 		</SelectControlWithState>
 	);
+};
+
+/**
+ * Select Multiple options
+ */
+export const SelectMultiple = SelectControlWithState.bind( {} );
+SelectMultiple.args = {
+	...Default.args,
+	help: 'Select any number of options.',
+	label: 'Select Multiple',
+	multiple: true,
 };

--- a/packages/components/src/select-control/styles/select-control-styles.ts
+++ b/packages/components/src/select-control/styles/select-control-styles.ts
@@ -11,7 +11,10 @@ import { COLORS, rtl } from '../../utils';
 import type { SelectControlProps } from '../types';
 
 interface SelectProps
-	extends Pick< SelectControlProps, '__next36pxDefaultSize' | 'disabled' > {
+	extends Pick<
+		SelectControlProps,
+		'__next36pxDefaultSize' | 'disabled' | 'multiple'
+	> {
 	// Using `selectSize` instead of `size` to avoid a type conflict with the
 	// `size` HTML attribute of the `select` element.
 	selectSize?: SelectControlProps[ 'size' ];
@@ -49,22 +52,23 @@ const fontSizeStyles = ( { selectSize = 'default' }: SelectProps ) => {
 const sizeStyles = ( {
 	__next36pxDefaultSize,
 	selectSize = 'default',
+	multiple,
 }: SelectProps ) => {
 	const sizes = {
 		default: {
-			height: 36,
+			height: multiple ? 36 * 2 : 36,
 			minHeight: 36,
 			paddingTop: 0,
 			paddingBottom: 0,
 		},
 		small: {
-			height: 24,
+			height: multiple ? 24 * 2 : 24,
 			minHeight: 24,
 			paddingTop: 0,
 			paddingBottom: 0,
 		},
 		'__unstable-large': {
-			height: 40,
+			height: multiple ? 40 * 2 : 40,
 			minHeight: 40,
 			paddingTop: 0,
 			paddingBottom: 0,
@@ -73,7 +77,7 @@ const sizeStyles = ( {
 
 	if ( ! __next36pxDefaultSize ) {
 		sizes.default = {
-			height: 30,
+			height: multiple ? 30 * 2 : 30,
 			minHeight: 30,
 			paddingTop: 0,
 			paddingBottom: 0,
@@ -88,26 +92,31 @@ const sizeStyles = ( {
 const sizePaddings = ( {
 	__next36pxDefaultSize,
 	selectSize = 'default',
+	multiple,
 }: SelectProps ) => {
+	const equalizePadding = ( paddingLeft: number, paddingRight: number ) => {
+		return multiple ? paddingLeft : paddingRight;
+	};
+
 	const sizes = {
 		default: {
 			paddingLeft: 16,
-			paddingRight: 32,
+			paddingRight: equalizePadding( 16, 32 ),
 		},
 		small: {
 			paddingLeft: 8,
-			paddingRight: 24,
+			paddingRight: equalizePadding( 8, 24 ),
 		},
 		'__unstable-large': {
 			paddingLeft: 16,
-			paddingRight: 32,
+			paddingRight: equalizePadding( 16, 32 ),
 		},
 	};
 
 	if ( ! __next36pxDefaultSize ) {
 		sizes.default = {
 			paddingLeft: 8,
-			paddingRight: 24,
+			paddingRight: equalizePadding( 8, 24 ),
 		};
 	}
 


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->
This fix removes the double-arrow from `multiple` select.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
SelectControl component with `multiple` enabled currently displays the double arrow associated with the pop-over. 

Original issue https://github.com/WordPress/gutenberg/issues/27166

This PR builds on the Original PR
https://github.com/WordPress/gutenberg/pull/28817

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? --> 
Conditionally render double arrow if `multiple` isn’t enabled
Also add a storybook option to display `multiple`

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->
Visible on desktop view of storybook
https://wordpress.github.io/gutenberg/?path=/story/components-selectcontrol--default&args=multiple:true

## Screenshots or screencast <!-- if applicable -->

