### PR TITLE
Spacing presets: fix/minor issues noted in initial UI PR

### DIFF
--- a/lib/compat/wordpress-6.1/theme.json
+++ b/lib/compat/wordpress-6.1/theme.json
@@ -274,7 +274,7 @@
 			"spacingScale": {
 				"operator": "*",
 				"increment": 1.5,
-				"steps": 0,
+				"steps": 7,
 				"mediumStep": 1.5,
 				"unit": "rem"
 			}

--- a/lib/compat/wordpress-6.1/theme.json
+++ b/lib/compat/wordpress-6.1/theme.json
@@ -274,7 +274,7 @@
 			"spacingScale": {
 				"operator": "*",
 				"increment": 1.5,
-				"steps": 7,
+				"steps": 0,
 				"mediumStep": 1.5,
 				"unit": "rem"
 			}

--- a/packages/block-editor/src/components/spacing-sizes-control/style.scss
+++ b/packages/block-editor/src/components/spacing-sizes-control/style.scss
@@ -59,6 +59,7 @@
 	.components-spacing-sizes-control__custom-toggle-single {
 		&.is-small.has-icon {
 			padding: 0;
+			min-width: $icon-size;
 		}
 	}
 

--- a/packages/block-editor/src/hooks/dimensions.js
+++ b/packages/block-editor/src/hooks/dimensions.js
@@ -1,4 +1,9 @@
 /**
+ * External dependencies
+ */
+import classnames from 'classnames';
+
+/**
  * WordPress dependencies
  */
 import { __experimentalToolsPanelItem as ToolsPanelItem } from '@wordpress/components';
@@ -33,6 +38,7 @@ import {
 	resetPadding,
 	useIsPaddingDisabled,
 } from './padding';
+import useSetting from '../components/use-setting';
 
 export const SPACING_SUPPORT_KEY = 'spacing';
 export const ALL_SIDES = [ 'top', 'right', 'bottom', 'left' ];
@@ -51,6 +57,7 @@ export function DimensionsPanel( props ) {
 	const isMarginDisabled = useIsMarginDisabled( props );
 	const isDisabled = useIsDimensionsDisabled( props );
 	const isSupported = hasDimensionsSupport( props.name );
+	const spacingSizes = useSetting( 'spacing.spacingSizes' );
 
 	if ( isDisabled || ! isSupported ) {
 		return null;
@@ -77,7 +84,10 @@ export function DimensionsPanel( props ) {
 			<InspectorControls __experimentalGroup="dimensions">
 				{ ! isPaddingDisabled && (
 					<ToolsPanelItem
-						className="tools-panel-item-spacing"
+						className={ classnames( {
+							'tools-panel-item-spacing':
+								spacingSizes && spacingSizes.length > 0,
+						} ) }
 						hasValue={ () => hasPaddingValue( props ) }
 						label={ __( 'Padding' ) }
 						onDeselect={ () => resetPadding( props ) }

--- a/packages/edit-site/src/components/global-styles/dimensions-panel.js
+++ b/packages/edit-site/src/components/global-styles/dimensions-panel.js
@@ -69,6 +69,12 @@ function useHasGap( name ) {
 	return settings && supports.includes( 'blockGap' );
 }
 
+function useHasSpacingPresets() {
+	const [ settings ] = useSetting( 'spacing.spacingSizes' );
+
+	return settings && settings.length > 0;
+}
+
 function filterValuesBySides( values, sides ) {
 	if ( ! sides ) {
 		// If no custom side configuration all sides are opted into by default.
@@ -224,6 +230,7 @@ export default function DimensionsPanel( { name } ) {
 	const showPaddingControl = useHasPadding( name );
 	const showMarginControl = useHasMargin( name );
 	const showGapControl = useHasGap( name );
+	const showSpacingPresetsControl = useHasSpacingPresets();
 	const units = useCustomUnits( {
 		availableUnits: useSetting( 'spacing.units', name )[ 0 ] || [
 			'%',
@@ -347,15 +354,28 @@ export default function DimensionsPanel( { name } ) {
 					isShownByDefault={ true }
 					className="tools-panel-item-spacing"
 				>
-					<SpacingSizesControl
-						values={ paddingValues }
-						onChange={ setPaddingValues }
-						label={ __( 'Padding' ) }
-						sides={ paddingSides }
-						units={ units }
-						allowReset={ false }
-						splitOnAxis={ isAxialPadding }
-					/>
+					{ ! showSpacingPresetsControl && (
+						<BoxControl
+							values={ paddingValues }
+							onChange={ setPaddingValues }
+							label={ __( 'Padding' ) }
+							sides={ paddingSides }
+							units={ units }
+							allowReset={ false }
+							splitOnAxis={ isAxialPadding }
+						/>
+					) }
+					{ showSpacingPresetsControl && (
+						<SpacingSizesControl
+							values={ paddingValues }
+							onChange={ setPaddingValues }
+							label={ __( 'Padding' ) }
+							sides={ paddingSides }
+							units={ units }
+							allowReset={ false }
+							splitOnAxis={ isAxialPadding }
+						/>
+					) }
 				</ToolsPanelItem>
 			) }
 			{ showMarginControl && (

--- a/packages/edit-site/src/components/global-styles/dimensions-panel.js
+++ b/packages/edit-site/src/components/global-styles/dimensions-panel.js
@@ -1,4 +1,9 @@
 /**
+ * External dependencies
+ */
+import classnames from 'classnames';
+
+/**
  * WordPress dependencies
  */
 import { __ } from '@wordpress/i18n';
@@ -352,7 +357,9 @@ export default function DimensionsPanel( { name } ) {
 					label={ __( 'Padding' ) }
 					onDeselect={ resetPaddingValue }
 					isShownByDefault={ true }
-					className="tools-panel-item-spacing"
+					className={ classnames( {
+						'tools-panel-item-spacing': showSpacingPresetsControl,
+					} ) }
 				>
 					{ ! showSpacingPresetsControl && (
 						<BoxControl


### PR DESCRIPTION
## What?

- [Makes custom value toggle icon 24px](https://github.com/WordPress/gutenberg/commit/8c9c691e7a39ca0e4d57b65789828716ab242140)
- [Reverts to BoxControl in global style dimensions panel if no spacing presets set](https://github.com/WordPress/gutenberg/commit/fc42537c72b2d5d0267f9de2715e7b1b0bd2454f) 
- [Corrects layout of BoxControl in block and site editor when no spacing presets set](https://github.com/WordPress/gutenberg/commit/bf1d7582139ac45732542c600a5d9e7a9f6bf985)

## Why?
Because we like to tidy up after ourselves :smile: 

## How?
Various ways and means

## Testing Instructions

- Add a group block and in the tools panel make sure the custom value toggle is the same width as the one in the typography control when selected - 24px
- In `theme.json` change the `settings.spacing.spacingScale.steps` value to 0 then check that in the global styles dimensions panel the BlockControl component displays instead of the spacing presets one
- Also check that the BlockControl displays as expected with the Link/Unlink button aligned right

## Screenshots
|                     | Before | After |
|---------------------|--------|-------|
| Icon size           |  <img width="270" alt="icon-size-before" src="https://user-images.githubusercontent.com/3629020/184560264-55f0f272-00a2-4a96-9b15-cbf8d298b9d9.png">      | <img width="267" alt="icon-size-after" src="https://user-images.githubusercontent.com/3629020/184560267-76f2ac17-7797-4ce4-9811-81123e93a48e.png">    |
| No presets          |   <img width="263" alt="box-control-before" src="https://user-images.githubusercontent.com/3629020/184560261-5d2f6722-c8f8-4873-892f-b98d5bc8278c.png">     |    <img width="263" alt="box-layout-after" src="https://user-images.githubusercontent.com/3629020/184560273-11cd9edf-18c0-4a94-a868-be03ba8f47d1.png">   |
| BlockControl layout | <img width="274" alt="box-layout-before" src="https://user-images.githubusercontent.com/3629020/184560258-7c96fd61-7397-48f3-86bc-1180171e5b1f.png">       |   <img width="263" alt="box-layout-after" src="https://user-images.githubusercontent.com/3629020/184560273-11cd9edf-18c0-4a94-a868-be03ba8f47d1.png">   |



