### PR TITLE
Style Engine: Tweak Declarations filtering logic slightly

### DIFF
--- a/packages/style-engine/class-wp-style-engine-css-declarations.php
+++ b/packages/style-engine/class-wp-style-engine-css-declarations.php
@@ -121,7 +121,7 @@ class WP_Style_Engine_CSS_Declarations {
 	 */
 	protected static function filter_declaration( $property, $value, $spacer = '' ) {
 		$filtered_value = wp_strip_all_tags( $value, true );
-		if ( ! empty( $filtered_value ) ) {
+		if ( '' !== $filtered_value ) {
 			return safecss_filter_attr( "{$property}:{$spacer}{$filtered_value}" );
 		}
 		return '';

--- a/packages/style-engine/class-wp-style-engine-css-declarations.php
+++ b/packages/style-engine/class-wp-style-engine-css-declarations.php
@@ -120,7 +120,11 @@ class WP_Style_Engine_CSS_Declarations {
 	 * @return string The filtered declaration as a single string.
 	 */
 	protected static function filter_declaration( $property, $value, $spacer = '' ) {
-		return safecss_filter_attr( "{$property}:{$spacer}{$value}" );
+		$filtered_value = wp_strip_all_tags( $value, true );
+		if ( ! empty( $filtered_value ) ) {
+			return safecss_filter_attr( "{$property}:{$spacer}{$filtered_value}" );
+		}
+		return '';
 	}
 
 	/**

--- a/packages/style-engine/phpunit/class-wp-style-engine-css-declarations-test.php
+++ b/packages/style-engine/phpunit/class-wp-style-engine-css-declarations-test.php
@@ -152,6 +152,7 @@ class WP_Style_Engine_CSS_Declarations_Test extends WP_UnitTestCase {
 			'color'        => 'url("https://wordpress.org")',
 			'font-size'    => '<red/>',
 			'margin-right' => '10em',
+			'padding'      => '</style>',
 			'potato'       => 'uppercase',
 		);
 		$css_declarations   = new WP_Style_Engine_CSS_Declarations( $input_declarations );

--- a/packages/style-engine/phpunit/class-wp-style-engine-css-declarations-test.php
+++ b/packages/style-engine/phpunit/class-wp-style-engine-css-declarations-test.php
@@ -150,6 +150,7 @@ class WP_Style_Engine_CSS_Declarations_Test extends WP_UnitTestCase {
 	public function test_remove_unsafe_properties_and_values() {
 		$input_declarations = array(
 			'color'        => 'url("https://wordpress.org")',
+			'font-size'    => '<red/>',
 			'margin-right' => '10em',
 			'potato'       => 'uppercase',
 		);


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Follow up to #43004, to tweak the declarations filtering logic slightly (use `wp_strip_all_tags`).

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

Code quality follow-up and tweaks.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

In the `filter_declaration` method add `wp_strip_all_tags` before calling `safecss_filter_attr`

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->

Follow testing instructions from #43004 and make sure style output still looks good.