### PR TITLE
Spacing presets: Implement disabling of custom space sizes

### DIFF
--- a/packages/block-editor/src/components/spacing-sizes-control/spacing-input-control.js
+++ b/packages/block-editor/src/components/spacing-sizes-control/spacing-input-control.js
@@ -7,6 +7,7 @@ import classnames from 'classnames';
  * WordPress dependencies
  */
 import { useState, useMemo } from '@wordpress/element';
+import { useSelect } from '@wordpress/data';
 import {
 	Button,
 	RangeControl,
@@ -24,6 +25,7 @@ import { settings } from '@wordpress/icons';
  * Internal dependencies
  */
 import useSetting from '../use-setting';
+import { store as blockEditorStore } from '../../store';
 import {
 	LABELS,
 	getSliderValueFromPreset,
@@ -43,8 +45,15 @@ export default function SpacingInputControl( {
 	let selectListSizes = spacingSizes;
 	const showRangeControl = spacingSizes.length <= 8;
 
+	const disableCustomSpacingSizes = useSelect( ( select ) => {
+		const editorSettings = select( blockEditorStore ).getSettings();
+		return editorSettings?.disableCustomSpacingSizes;
+	} );
+
 	const [ showCustomValueControl, setShowCustomValueControl ] = useState(
-		value !== undefined && ! isValueSpacingPreset( value )
+		! disableCustomSpacingSizes &&
+			value !== undefined &&
+			! isValueSpacingPreset( value )
 	);
 
 	const units = useCustomUnits( {
@@ -171,26 +180,28 @@ export default function SpacingInputControl( {
 				</Text>
 			) }
 
-			<Button
-				label={
-					showCustomValueControl
-						? __( 'Use size preset' )
-						: __( 'Set custom size' )
-				}
-				icon={ settings }
-				onClick={ () => {
-					setShowCustomValueControl( ! showCustomValueControl );
-				} }
-				isPressed={ showCustomValueControl }
-				isSmall
-				className={ classnames( {
-					'components-spacing-sizes-control__custom-toggle-all':
-						side === 'all',
-					'components-spacing-sizes-control__custom-toggle-single':
-						side !== 'all',
-				} ) }
-				iconSize={ 24 }
-			/>
+			{ ! disableCustomSpacingSizes && (
+				<Button
+					label={
+						showCustomValueControl
+							? __( 'Use size preset' )
+							: __( 'Set custom size' )
+					}
+					icon={ settings }
+					onClick={ () => {
+						setShowCustomValueControl( ! showCustomValueControl );
+					} }
+					isPressed={ showCustomValueControl }
+					isSmall
+					className={ classnames( {
+						'components-spacing-sizes-control__custom-toggle-all':
+							side === 'all',
+						'components-spacing-sizes-control__custom-toggle-single':
+							side !== 'all',
+					} ) }
+					iconSize={ 24 }
+				/>
+			) }
 			{ showCustomValueControl && (
 				<>
 					<UnitControl


### PR DESCRIPTION
## What?
Implements the ability to disable custom sizes - at this point just for padding, via the new spacing presets UI.

## Why?
Theme and plugin authors have been asking for the ability to prevent users from adding custom sizes and only allowing them to select from a list of presets

## How?
Wires the `settings.spacing.customSpacingSize` property that was prepared earlier through to the new spacing presets UI.

## Testing Instructions

- Add a Group block and check that in the block padding controls it is possible to toggle between a preset and a custom value
- In theme.json set `settings.spacing.customSpacingSize` to false
- Check the Group block again and make sure that it is now only possible to select a preset value

## Screenshots or screencast 

Before:

https://user-images.githubusercontent.com/3629020/184565347-efc17bb3-a914-442f-9f4f-b923714e6b71.mp4

After:

https://user-images.githubusercontent.com/3629020/184565292-8408fb06-2f97-41fe-948f-38c03e61ebb5.mp4
