### PR TITLE
Lodash: Refactor away from `_.camelCase()`

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -79,6 +79,7 @@ module.exports = {
 					{
 						name: 'lodash',
 						importNames: [
+							'camelCase',
 							'capitalize',
 							'chunk',
 							'clamp',

--- a/package-lock.json
+++ b/package-lock.json
@@ -16472,6 +16472,7 @@
 				"@wordpress/notices": "file:packages/notices",
 				"@wordpress/plugins": "file:packages/plugins",
 				"@wordpress/url": "file:packages/url",
+				"change-case": "^4.1.2",
 				"lodash": "^4.17.21"
 			}
 		},
@@ -16652,6 +16653,7 @@
 				"@wordpress/i18n": "file:packages/i18n",
 				"@wordpress/is-shallow-equal": "file:packages/is-shallow-equal",
 				"@wordpress/shortcode": "file:packages/shortcode",
+				"change-case": "^4.1.2",
 				"colord": "^2.7.0",
 				"hpq": "^1.3.0",
 				"is-plain-obj": "^4.1.0",
@@ -16702,6 +16704,7 @@
 				"@wordpress/primitives": "file:packages/primitives",
 				"@wordpress/rich-text": "file:packages/rich-text",
 				"@wordpress/warning": "file:packages/warning",
+				"change-case": "^4.1.2",
 				"classnames": "^2.3.1",
 				"colord": "^2.7.0",
 				"dom-scroll-into-view": "^1.2.1",

--- a/packages/block-directory/package.json
+++ b/packages/block-directory/package.json
@@ -44,6 +44,7 @@
 		"@wordpress/notices": "file:../notices",
 		"@wordpress/plugins": "file:../plugins",
 		"@wordpress/url": "file:../url",
+		"change-case": "^4.1.2",
 		"lodash": "^4.17.21"
 	},
 	"peerDependencies": {

--- a/packages/block-directory/src/store/resolvers.js
+++ b/packages/block-directory/src/store/resolvers.js
@@ -1,7 +1,8 @@
 /**
  * External dependencies
  */
-import { camelCase, mapKeys } from 'lodash';
+import { camelCase } from 'change-case';
+import { mapKeys } from 'lodash';
 
 /**
  * WordPress dependencies

--- a/packages/blocks/package.json
+++ b/packages/blocks/package.json
@@ -41,6 +41,7 @@
 		"@wordpress/i18n": "file:../i18n",
 		"@wordpress/is-shallow-equal": "file:../is-shallow-equal",
 		"@wordpress/shortcode": "file:../shortcode",
+		"change-case": "^4.1.2",
 		"colord": "^2.7.0",
 		"hpq": "^1.3.0",
 		"is-plain-obj": "^4.1.0",

--- a/packages/blocks/src/api/registration.js
+++ b/packages/blocks/src/api/registration.js
@@ -3,7 +3,8 @@
 /**
  * External dependencies
  */
-import { camelCase, isEmpty, mapKeys, pick, pickBy } from 'lodash';
+import { camelCase } from 'change-case';
+import { isEmpty, mapKeys, pick, pickBy } from 'lodash';
 
 /**
  * WordPress dependencies

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -53,6 +53,7 @@
 		"@wordpress/primitives": "file:../primitives",
 		"@wordpress/rich-text": "file:../rich-text",
 		"@wordpress/warning": "file:../warning",
+		"change-case": "^4.1.2",
 		"classnames": "^2.3.1",
 		"colord": "^2.7.0",
 		"dom-scroll-into-view": "^1.2.1",

--- a/packages/components/src/mobile/global-styles-context/utils.native.js
+++ b/packages/components/src/mobile/global-styles-context/utils.native.js
@@ -1,7 +1,8 @@
 /**
  * External dependencies
  */
-import { find, get, camelCase, has } from 'lodash';
+import { camelCase } from 'change-case';
+import { find, get, has } from 'lodash';
 import { Dimensions } from 'react-native';
 
 /**


### PR DESCRIPTION
## What?
This PR removes the `_.camelCase()` usage completely and deprecates the function. 

## Why?

Lodash is known to unnecessarily inflate the bundle size of packages, and in most cases, it can be replaced with native language functionality. See these for more information and rationale:

* https://github.com/WordPress/gutenberg/issues/16938#issuecomment-602837246
* https://github.com/WordPress/gutenberg/issues/17025
* https://github.com/WordPress/gutenberg/issues/39495 

## How?

Similar to #42427, we're suggesting to use the `change-case` library, which offers modular functions for all the casing functions we use from Lodash (like `snakeCase`, `capitalize`, `startCase`, `camelCase`, `kebabCase` ), at a small price (the methods are small themselves), and has TS support. The benefit of using that external library for all those case conversion functions is that we won't have to maintain our own versions of them, and those are already broadly used and tested.

In particular, we replace a few of `camelCase()` Lodash usages in favor of the `change-case` one (`camelCase`).

As noted in https://github.com/WordPress/gutenberg/issues/17025#issuecomment-1186883437 we still need to do our best to deduplicate the packages that occur more than a couple of times, and `change-case` is a good candidate for that. As part of #17025, this will be done in another PR.

## Testing Instructions
* Open the header toolbar inserter.
* Search for "heading"
* Make sure server-side blocks are still registered correctly (try Heading for example).
* Scroll down to reveal the "Available to install" blocks, and make sure that list loads correctly.
* RN: Verify testing instructions from #34144 still work.
* Verify all tests still pass.