### PR TITLE
Prevent query block from looping in classic themes

### DIFF
--- a/packages/block-library/src/post-template/index.php
+++ b/packages/block-library/src/post-template/index.php
@@ -99,9 +99,12 @@ function render_block_core_post_template( $attributes, $content, $block ) {
 		$content     .= '<li class="' . esc_attr( $post_classes ) . '">' . $block_content . '</li>';
 	}
 
-	if ( ! $use_global_query ) {
-		wp_reset_postdata();
-	}
+	/*
+	 * Use this function to restore the context of the template tags
+	 * from a secondary query loop back to the main query loop.
+	 * Since we use two custom loops, it's safest to always restore.
+	*/
+	wp_reset_postdata();
 
 	return sprintf(
 		'<ul %1$s>%2$s</ul>',

--- a/packages/block-library/src/post-template/index.php
+++ b/packages/block-library/src/post-template/index.php
@@ -48,7 +48,7 @@ function render_block_core_post_template( $attributes, $content, $block ) {
 	$use_global_query = ( isset( $block->context['query']['inherit'] ) && $block->context['query']['inherit'] );
 	if ( $use_global_query ) {
 		global $wp_query;
-		$query = $wp_query;
+		$query = clone $wp_query;
 	} else {
 		$query_args = build_query_vars_from_query_block( $block, $page );
 		$query      = new WP_Query( $query_args );


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Closes #43198

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

In classic themes templates depend on `have_posts()` to return `false` to exit the loop. The change added by #40656 
uses the `global WP_Query` to figure out global query when `inherit` is `on`. This in turn loops over the global posts 
object and resets it once it reaches the end. Thus when rendering posts and meeting one post using the query loop block the 
upper most `have_posts` is never false (because the global posts always get reset).

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

An easy and quick fix is to `clone` the global WP_Query. This allows the block to render the loop without resetting the 
global posts. This way the block renders the correct loop but does not interfere with the global loop.


## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->


0. Using this Gutenberg and this PR
1. Activate a classic theme
2. Create a post and add a query block in it
3. Set up the block by clicking:
a) choose
b) then choose again in the modal
4. In the block inspector toggle on "Inherit query from template"
5. Publish the post
6. Visit the post
7. There should be no endless loop, the page should render all right.


## Screenshots or screencast <!-- if applicable -->

N/A
