### PR TITLE
Lodash: Refactor away from `_.difference()`

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -89,6 +89,7 @@ module.exports = {
 							'defaults',
 							'defaultTo',
 							'delay',
+							'difference',
 							'differenceWith',
 							'dropRight',
 							'each',

--- a/packages/block-editor/src/components/list-view/use-block-selection.js
+++ b/packages/block-editor/src/components/list-view/use-block-selection.js
@@ -1,9 +1,4 @@
 /**
- * External dependencies
- */
-import { difference } from 'lodash';
-
-/**
  * WordPress dependencies
  */
 import { speak } from '@wordpress/a11y';
@@ -126,9 +121,8 @@ export default function useBlockSelection() {
 				return;
 			}
 
-			const selectionDiff = difference(
-				selectedBlocks,
-				updatedSelectedBlocks
+			const selectionDiff = selectedBlocks.filter(
+				( blockId ) => ! updatedSelectedBlocks.includes( blockId )
 			);
 
 			let label;

--- a/packages/blocks/src/api/parser/fix-custom-classname.js
+++ b/packages/blocks/src/api/parser/fix-custom-classname.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { difference, omit } from 'lodash';
+import { omit } from 'lodash';
 
 /**
  * Internal dependencies
@@ -58,7 +58,10 @@ export function fixCustomClassname( blockAttributes, blockType, innerHTML ) {
 		const serialized = getSaveContent( blockType, attributesSansClassName );
 		const defaultClasses = getHTMLRootElementClasses( serialized );
 		const actualClasses = getHTMLRootElementClasses( innerHTML );
-		const customClasses = difference( actualClasses, defaultClasses );
+
+		const customClasses = actualClasses.filter(
+			( className ) => ! defaultClasses.includes( className )
+		);
 
 		if ( customClasses.length ) {
 			blockAttributes.className = customClasses.join( ' ' );

--- a/packages/blocks/src/api/raw-handling/is-inline-content.js
+++ b/packages/blocks/src/api/raw-handling/is-inline-content.js
@@ -1,9 +1,4 @@
 /**
- * External dependencies
- */
-import { difference } from 'lodash';
-
-/**
  * WordPress dependencies
  */
 import { isTextContent } from '@wordpress/dom';
@@ -33,7 +28,9 @@ function isInline( node, contextTag ) {
 	];
 
 	return inlineAllowedTagGroups.some(
-		( tagGroup ) => difference( [ tag, contextTag ], tagGroup ).length === 0
+		( tagGroup ) =>
+			[ tag, contextTag ].filter( ( t ) => ! tagGroup.includes( t ) )
+				.length === 0
 	);
 }
 

--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Enhancements
 
 -   `ComboboxControl`: Normalize hyphen-like characters to an ASCII hyphen ([#42942](https://github.com/WordPress/gutenberg/pull/42942)).
+-   `FormTokenField`: Refactor away from `_.difference()` ([#43224](https://github.com/WordPress/gutenberg/pull/43224/)).
 
 ## 19.17.0 (2022-08-10)
 

--- a/packages/components/src/form-token-field/index.tsx
+++ b/packages/components/src/form-token-field/index.tsx
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { last, clone, uniq, map, difference, some } from 'lodash';
+import { last, clone, uniq, map, some } from 'lodash';
 import classnames from 'classnames';
 import type { KeyboardEvent, MouseEvent, TouchEvent } from 'react';
 
@@ -475,7 +475,9 @@ export function FormTokenField( props: FormTokenFieldProps ) {
 		} );
 
 		if ( match.length === 0 ) {
-			_suggestions = difference( _suggestions, normalizedValue );
+			_suggestions = _suggestions.filter(
+				( suggestion ) => ! normalizedValue.includes( suggestion )
+			);
 		} else {
 			match = match.toLocaleLowerCase();
 

--- a/packages/edit-navigation/src/store/actions.js
+++ b/packages/edit-navigation/src/store/actions.js
@@ -1,9 +1,4 @@
 /**
- * External dependencies
- */
-import { difference } from 'lodash';
-
-/**
  * WordPress dependencies
  */
 import { __, sprintf } from '@wordpress/i18n';
@@ -128,10 +123,15 @@ const batchSaveMenuItems =
 		);
 
 		// Delete menu items.
-		const deletedIds = difference(
-			oldMenuItems.map( ( { id } ) => id ),
-			blocksTreeToList( navBlockAfterUpdates ).map( getRecordIdFromBlock )
-		);
+		const deletedIds = oldMenuItems
+			.map( ( { id } ) => id )
+			.filter(
+				( id ) =>
+					! blocksTreeToList( navBlockAfterUpdates )
+						.map( getRecordIdFromBlock )
+						.includes( id )
+			);
+
 		await dispatch( batchDeleteMenuItems( deletedIds ) );
 
 		return navBlockAfterUpdates;

--- a/packages/edit-post/src/components/block-settings-menu/plugin-block-settings-menu-item.js
+++ b/packages/edit-post/src/components/block-settings-menu/plugin-block-settings-menu-item.js
@@ -1,9 +1,4 @@
 /**
- * External dependencies
- */
-import { difference } from 'lodash';
-
-/**
  * WordPress dependencies
  */
 import { BlockSettingsMenuControls } from '@wordpress/block-editor';
@@ -11,7 +6,7 @@ import { MenuItem } from '@wordpress/components';
 import { compose } from '@wordpress/compose';
 
 const isEverySelectedBlockAllowed = ( selected, allowed ) =>
-	difference( selected, allowed ).length === 0;
+	selected.filter( ( id ) => ! allowed.includes( id ) ).length === 0;
 
 /**
  * Plugins may want to add an item to the menu either for every block


### PR DESCRIPTION
## What?
This PR removes the `_.difference()` usage completely and deprecates the function. 

## Why?

Lodash is known to unnecessarily inflate the bundle size of packages, and in most cases, it can be replaced with native language functionality. See these for more information and rationale:

* https://github.com/WordPress/gutenberg/issues/16938#issuecomment-602837246
* https://github.com/WordPress/gutenberg/issues/17025
* https://github.com/WordPress/gutenberg/issues/39495 

## How?

We're removing each instance with a separate inline implementation, as most of them are simple enough and not worth a separate helper function.

## Testing Instructions
* While editing a post, click List View.
* Make sure the selection of blocks through the list view still works.
* When inputting tags in a post, make sure matching by partial tag name search still works the same way.
* Verify saving the navigation after you've deleted a few items from it still works the same way.
* With a plugin that registers a `PluginBlockSettingsMenuItem`, make sure that still works the same way. I've seen that in Jetpack when a paid block is used but the user is now on a free plan.
* Verify all tests still pass.