### PR TITLE
Fix spinner causing a flash when loading site editor

### DIFF
--- a/packages/components/src/spinner/index.tsx
+++ b/packages/components/src/spinner/index.tsx
@@ -23,6 +23,8 @@ export function UnforwardedSpinner(
 		<StyledSpinner
 			className={ classNames( 'components-spinner', className ) }
 			viewBox="0 0 100 100"
+			width="16"
+			height="16"
 			xmlns="http://www.w3.org/2000/svg"
 			role="presentation"
 			focusable="false"


### PR DESCRIPTION
## What?

Working on a separate issue, I noticed that when you are loading the Site Editor and it features the Site Logo, the spinner component will briefly fill virtually the entire screen with a black circle.

## Why?

The black circle happens because the CSS that styles the SVG spinner component, and indeed everything else, is not yet loaded. Observe:

![flash](https://user-images.githubusercontent.com/1204802/184623086-b7e3e679-9078-4047-aec3-3a4e07ec4212.gif)


## How?

This happens because the SVG in the spinner did not have any explicit width/height applied, letting it scale with its aspect ratio to fill the width of the screen. This PR adds the same width and height back to the spinner, so at least it doesn't break boundaries:

![after](https://user-images.githubusercontent.com/1204802/184623154-d3c82878-bd6a-4cd1-9d98-c75066e0cdc9.gif)

## Testing Instructions

Test loading the site editor, and be sure the content you load features a Site Logo block.