### PR TITLE
Placeholder: Refactor and simplify dashed placeholders used for Featured Image & Site Logo

### DIFF
--- a/packages/block-library/src/post-featured-image/editor.scss
+++ b/packages/block-library/src/post-featured-image/editor.scss
@@ -1,19 +1,11 @@
-// Give the featured image placeholder the appearance of a literal image placeholder.
-// @todo: this CSS is similar to that of the Site Logo. That makes it an opportunity
-// to create a new component for placeholders meant to inherit some theme styles.
+// Provide special styling for the placeholder.
+// @todo: this particular minimal style of placeholder could be componentized further.
 .wp-block-post-featured-image.wp-block-post-featured-image {
-	// Inherit border radius from style variations.
-	.components-placeholder,
-	.components-resizable-box__container {
-		border-radius: inherit;
-	}
-
 	// Style the placeholder.
 	.wp-block-post-featured-image__placeholder,
 	.components-placeholder {
 		justify-content: center;
 		align-items: center;
-		box-shadow: none;
 		padding: 0;
 
 		// Hide the upload button, as it's also available in the media library.
@@ -21,32 +13,8 @@
 			display: none;
 		}
 
-		// Position the spinner.
-		.components-placeholder__preview {
-			position: absolute;
-			top: $grid-unit-05;
-			right: $grid-unit-05;
-			bottom: $grid-unit-05;
-			left: $grid-unit-05;
-			background: rgba($white, 0.8);
-			display: flex;
-			align-items: center;
-			justify-content: center;
-		}
-
-		// Draw the dashed outline.
-		// By setting the dashed border to currentColor, we ensure it's visible
-		// against any background color.
-		color: currentColor;
-		background: transparent;
-
 		// Style the upload button.
-		.components-placeholder__fieldset {
-			width: auto;
-		}
-
 		.components-button.components-button {
-			color: inherit;
 			padding: 0;
 			display: flex;
 			justify-content: center;
@@ -55,16 +23,14 @@
 			height: $grid-unit-60;
 			border-radius: 50%;
 			position: relative;
-			visibility: hidden;
-
-			// Animation.
-			background: transparent;
-			transition: all 0.1s linear;
-			@include reduce-motion("transition");
-		}
-
-		.components-button.components-button > svg {
+			background: var(--wp-admin-theme-color);
+			border-color: var(--wp-admin-theme-color);
+			border-style: solid;
 			color: $white;
+
+			> svg {
+				color: inherit;
+			}
 		}
 
 		// Show default placeholder height when not resized.
@@ -79,16 +45,6 @@
 		min-width: $grid-unit-60;
 		height: 100%;
 		width: 100%;
-	}
-
-	// Show upload button on block selection.
-	&.is-selected .components-button.components-button {
-		background: var(--wp-admin-theme-color);
-		border-color: var(--wp-admin-theme-color);
-		border-style: solid;
-		color: $white;
-		opacity: 1;
-		visibility: visible;
 	}
 }
 

--- a/packages/block-library/src/site-logo/editor.scss
+++ b/packages/block-library/src/site-logo/editor.scss
@@ -31,13 +31,8 @@
 }
 
 // Provide special styling for the placeholder.
+// @todo: this particular minimal style of placeholder could be componentized further.
 .wp-block-site-logo.wp-block-site-logo {
-	// Inherit border radius from style variations.
-	.components-placeholder,
-	.components-resizable-box__container {
-		border-radius: inherit;
-	}
-
 	// Match the default logo size.
 	&.is-default-size .components-placeholder {
 		height: 120px;
@@ -46,10 +41,8 @@
 
 	// Style the placeholder.
 	.components-placeholder {
-		display: flex;
 		justify-content: center;
 		align-items: center;
-		box-shadow: none;
 		padding: 0;
 
 		// Provide a minimum size for the placeholder, for when the logo is resized.
@@ -66,52 +59,17 @@
 			display: none;
 		}
 
-		// Position the spinner.
-		.components-placeholder__preview {
-			position: absolute;
-			top: $grid-unit-05;
-			right: $grid-unit-05;
-			bottom: $grid-unit-05;
-			left: $grid-unit-05;
-			background: rgba($white, 0.8);
-			display: flex;
-			align-items: center;
-			justify-content: center;
-		}
-
 		// Hide items.
 		.components-drop-zone__content-text {
 			display: none;
 		}
 
-		// Draw the dashed outline.
-		// By setting the dashed border to currentColor, we ensure it's visible
-		// against any background color.
-		color: currentColor;
-		background: transparent;
-		&::before {
-			content: "";
-			display: block;
-			position: absolute;
-			top: 0;
-			right: 0;
-			bottom: 0;
-			left: 0;
-			border: $border-width dashed currentColor;
-			opacity: 0.4;
-			pointer-events: none;
-
-			// Inherit border radius from style variations.
-			border-radius: inherit;
-		}
-
-		// Style the upload button.
 		.components-placeholder__fieldset {
 			width: auto;
 		}
 
+		// Style the upload button.
 		.components-button.components-button {
-			color: inherit;
 			padding: 0;
 			display: flex;
 			justify-content: center;
@@ -120,26 +78,14 @@
 			height: $grid-unit-60;
 			border-radius: 50%;
 			position: relative;
-			visibility: hidden;
-
-			// Animation.
-			background: transparent;
-			transition: all 0.1s linear;
-			@include reduce-motion("transition");
-		}
-
-		.components-button.components-button > svg {
+			background: var(--wp-admin-theme-color);
+			border-color: var(--wp-admin-theme-color);
+			border-style: solid;
 			color: $white;
-		}
-	}
 
-	// Show upload button on block selection.
-	&.is-selected .components-button.components-button {
-		background: var(--wp-admin-theme-color);
-		border-color: var(--wp-admin-theme-color);
-		border-style: solid;
-		color: $white;
-		opacity: 1;
-		visibility: visible;
+			> svg {
+				color: inherit;
+			}
+		}
 	}
 }

--- a/packages/block-library/src/site-logo/editor.scss
+++ b/packages/block-library/src/site-logo/editor.scss
@@ -64,10 +64,6 @@
 			display: none;
 		}
 
-		.components-placeholder__fieldset {
-			width: auto;
-		}
-
 		// Style the upload button.
 		.components-button.components-button {
 			padding: 0;

--- a/packages/components/src/placeholder/style.scss
+++ b/packages/components/src/placeholder/style.scss
@@ -177,7 +177,6 @@
 	display: flex;
 	box-shadow: none;
 	background: none;
-	border: none;
 	min-width: 100px;
 
 	.components-placeholder__fieldset {
@@ -196,6 +195,10 @@
 		opacity: 1;
 		visibility: visible;
 	}
+
+	// By painting the borders here, we enable them to be replaced by the Border control.
+	border: $border-width dashed currentColor;
+	overflow: hidden;
 }
 
 // Position the spinner.
@@ -206,17 +209,15 @@
 }
 
 .components-placeholder__illustration {
-	border-radius: inherit;
-	border: $border-width dashed currentColor;
-	box-sizing: border-box;
+	box-sizing: content-box;
 	position: absolute;
-	top: 0;
-	right: 0;
-	bottom: 0;
-	left: 0;
+	top: 50%;
+	left: 50%;
+	transform: translate(-50%, -50%);
 	width: 100%;
 	height: 100%;
 	stroke: currentColor;
 	stroke-dasharray: 3;
-	opacity: 0.4;
+	border-width: inherit;
+	border-style: inherit;
 }

--- a/packages/components/src/placeholder/style.scss
+++ b/packages/components/src/placeholder/style.scss
@@ -26,13 +26,6 @@
 	background-color: $white;
 	box-shadow: inset 0 0 0 $border-width $gray-900;
 	outline: 1px solid transparent; // Shown for Windows 10 High Contrast mode.
-
-	&.has-illustration {
-		background: none;
-		border: none;
-		box-shadow: none;
-		min-width: 100px;
-	}
 }
 
 .components-placeholder__error,
@@ -175,8 +168,39 @@
 	}
 }
 
-// Style the placeholder illustration.
+
+/**
+ * Dashed style placeholders
+ */
+
+// @todo
+// These styles are only applied after the has-illustration gets added.
+// This is mainly an issue in terms of Site Logo which has a brief flash of the square placeholder.
+.components-placeholder.has-illustration {
+	color: inherit;
+	border-radius: inherit;
+	display: flex;
+	box-shadow: none;
+	background: none;
+	border: none;
+	min-width: 100px;
+
+	// Show placeholder buttons on block selection.
+	.components-button {
+		visibility: hidden;
+		opacity: 0;
+		transition: opacity 0.1s linear;
+		@include reduce-motion("transition");
+	}
+
+	.is-selected > & .components-button {
+		opacity: 1;
+		visibility: visible;
+	}
+}
+
 .components-placeholder__illustration {
+	border-radius: inherit;
 	border: $border-width dashed currentColor;
 	box-sizing: border-box;
 	position: absolute;

--- a/packages/components/src/placeholder/style.scss
+++ b/packages/components/src/placeholder/style.scss
@@ -105,11 +105,6 @@
 	width: 100%;
 }
 
-.components-placeholder__preview img {
-	margin: 3%;
-	width: 50%;
-}
-
 .components-placeholder__fieldset .components-button {
 	margin-right: $grid-unit-15;
 	margin-bottom: $grid-unit-15; // If buttons wrap we need vertical space between.
@@ -185,6 +180,10 @@
 	border: none;
 	min-width: 100px;
 
+	.components-placeholder__fieldset {
+		width: auto;
+	}
+
 	// Show placeholder buttons on block selection.
 	.components-button {
 		visibility: hidden;
@@ -197,6 +196,13 @@
 		opacity: 1;
 		visibility: visible;
 	}
+}
+
+// Position the spinner.
+// @todo these rules should ideally live with the spinner component itself.
+.components-placeholder__preview {
+	display: flex;
+	justify-content: center;
 }
 
 .components-placeholder__illustration {


### PR DESCRIPTION
## What?

Site Logo and Featured Image blocks feature a new style of placeholder, a more literal one that is meant to inherit colors, radius, dimensions and more from its surroundings. These:

<img width="758" alt="Screenshot 2022-08-15 at 12 55 34" src="https://user-images.githubusercontent.com/1204802/184623397-45d2cedf-6552-46fd-ba2c-3d261921ca95.png">

This PR does a few things:

* It extracts all reusable pieces from Featured Image and Site Logo, and stores them in the main placeholder component CSS file.
* It fixes an issue where the Site Logo did not properly inherit radius (see the square site logo in the screenshot above)
* It refactors some of the code to be simpler, for example the code to show/hide controls inside the placeholder.
* Finally it removed the semitransparency that was applied to the dashed line, making the line fully opaque.

Here's the end result, 3 GIFs showing the same dashed outlines as before, on 3 different background colors:
![pink](https://user-images.githubusercontent.com/1204802/184623748-0cf52b34-eb8d-424d-886c-ac7b6bc4f4b3.gif)

![default](https://user-images.githubusercontent.com/1204802/184623751-84e61b28-d8f3-494b-9bed-6fe0d15b833b.gif)

![dark](https://user-images.githubusercontent.com/1204802/184623760-892a8329-d6d3-42d8-bb22-03b0ecace71f.gif)

## Why?

**The opacity** change is made for two reasons. In part, it enhances contrast a bit. Secondly, it solves an issue where adding border-support to this placeholder revealed an inherited radius issue, [discussed in depth here](https://github.com/WordPress/gutenberg/pull/42847#issuecomment-1207678135). For such a border inheritance to work, the border has to be fully opaque (to put it shortly, we can't do `rgba(currentColor, 0.4)`).

**The refactor** was done because we are increasingly seeing a need for placeholders to inherit qualities from their surroundings. By reducing duplicated code, we can more simply expand this style of placeholders, for example to the Image block which could be next. See #41142, #43180 and https://github.com/WordPress/twentytwentythree/issues/30.

## Testing Instructions

Test site logo, featured image blocks, ideally in a variety of color schemes and in context of other blocks, and outside of a more opaque border, things should look the same.