### PR TITLE
Lodash: Refactor away from `_.startCase()`

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -132,6 +132,7 @@ module.exports = {
 							'reverse',
 							'size',
 							'snakeCase',
+							'startCase',
 							'startsWith',
 							'stubFalse',
 							'stubTrue',

--- a/package-lock.json
+++ b/package-lock.json
@@ -16608,6 +16608,7 @@
 				"@wordpress/server-side-render": "file:packages/server-side-render",
 				"@wordpress/url": "file:packages/url",
 				"@wordpress/viewport": "file:packages/viewport",
+				"change-case": "^4.1.2",
 				"classnames": "^2.3.1",
 				"colord": "^2.7.0",
 				"fast-average-color": "4.3.0",

--- a/packages/block-library/package.json
+++ b/packages/block-library/package.json
@@ -60,6 +60,7 @@
 		"@wordpress/server-side-render": "file:../server-side-render",
 		"@wordpress/url": "file:../url",
 		"@wordpress/viewport": "file:../viewport",
+		"change-case": "^4.1.2",
 		"classnames": "^2.3.1",
 		"colord": "^2.7.0",
 		"fast-average-color": "4.3.0",

--- a/packages/block-library/src/template-part/index.js
+++ b/packages/block-library/src/template-part/index.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { startCase } from 'lodash';
+import { capitalCase } from 'change-case';
 
 /**
  * WordPress dependencies
@@ -41,7 +41,8 @@ export const settings = {
 		}
 
 		return (
-			decodeEntities( entity.title?.rendered ) || startCase( entity.slug )
+			decodeEntities( entity.title?.rendered ) ||
+			capitalCase( entity.slug )
 		);
 	},
 	edit,

--- a/packages/create-block/lib/index.js
+++ b/packages/create-block/lib/index.js
@@ -2,8 +2,9 @@
  * External dependencies
  */
 const inquirer = require( 'inquirer' );
+const { capitalCase } = require( 'change-case' );
 const program = require( 'commander' );
-const { pickBy, startCase } = require( 'lodash' );
+const { pickBy } = require( 'lodash' );
 
 /**
  * Internal dependencies
@@ -91,7 +92,7 @@ program
 						...defaultValues,
 						slug,
 						// Transforms slug to title as a fallback.
-						title: startCase( slug ),
+						title: capitalCase( slug ),
 						...optionsValues,
 					};
 					await scaffold( pluginTemplate, answers );


### PR DESCRIPTION
## What?
This PR removes the `_.startCase()` usage completely and deprecates the function. 

## Why?

Lodash is known to unnecessarily inflate the bundle size of packages, and in most cases, it can be replaced with native language functionality. See these for more information and rationale:

* https://github.com/WordPress/gutenberg/issues/16938#issuecomment-602837246
* https://github.com/WordPress/gutenberg/issues/17025
* https://github.com/WordPress/gutenberg/issues/39495 

## How?

Similar to #42427, we're suggesting to use the `change-case` library, which offers modular functions for all the casing functions we use from Lodash (like `snakeCase`, `capitalize`, `startCase`, `camelCase`, `kebabCase` ), at a small price (the methods are small themselves), and has TS support. The benefit of using that external library for all those case conversion functions is that we won't have to maintain our own versions of them, and those are already broadly used and tested.

In particular, we replace a few of `startCase()` Lodash usages in favor of the `change-case` one (`capitalCase`).

## Testing Instructions
* Verify that you can still access and edit a template part normally.
* Verify create-block still works: `npx @wordpress/create-block test-block`  - should be good if you get this message (keep an eye on the block title):

```
Done: WordPress plugin "Test Block" bootstrapped in the "test-block" directory.
```