### PR TITLE
CustomSelectControl: Deprecate constrained width style

### DIFF
--- a/packages/block-editor/src/components/date-format-picker/index.js
+++ b/packages/block-editor/src/components/date-format-picker/index.js
@@ -116,6 +116,7 @@ function NonDefaultControls( { format, onChange } ) {
 		<>
 			<BaseControl className="block-editor-date-format-picker__custom-format-select-control">
 				<CustomSelectControl
+					__nextUnconstrainedWidth
 					label={ __( 'Choose a format' ) }
 					options={ [ ...suggestedOptions, customOption ] }
 					value={

--- a/packages/block-editor/src/components/date-format-picker/style.scss
+++ b/packages/block-editor/src/components/date-format-picker/style.scss
@@ -11,10 +11,6 @@
 	&.components-base-control {
 		margin-bottom: 0;
 	}
-
-	.components-custom-select-control__button {
-		width: 100%;
-	}
 }
 
 .block-editor-date-format-picker__custom-format-select-control__custom-option {

--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Breaking Changes
+
+-   `CustomSelectControl`: Deprecate constrained width style. Add a `__nextUnconstrainedWidth` prop to start opting into the unconstrained width that will become the default in a future version, currently scheduled to be WordPress 6.4 ([#43230](https://github.com/WordPress/gutenberg/pull/43230)).
+
 ### Enhancements
 
 -   `ComboboxControl`: Normalize hyphen-like characters to an ASCII hyphen ([#42942](https://github.com/WordPress/gutenberg/pull/42942)).

--- a/packages/components/src/custom-select-control/README.md
+++ b/packages/components/src/custom-select-control/README.md
@@ -50,6 +50,7 @@ function MyCustomSelectControl() {
 	const [ , setFontSize ] = useState();
 	return (
 		<CustomSelectControl
+			__nextUnconstrainedWidth
 			label="Font Size"
 			options={ options }
 			onChange={ ( { selectedItem } ) => setFontSize( selectedItem ) }
@@ -61,6 +62,7 @@ function MyControlledCustomSelectControl() {
 	const [ fontSize, setFontSize ] = useState( options[ 0 ] );
 	return (
 		<CustomSelectControl
+			__nextUnconstrainedWidth
 			label="Font Size"
 			options={ options }
 			onChange={ ( { selectedItem } ) => setFontSize( selectedItem ) }
@@ -120,6 +122,14 @@ Can be used to externally control the value of the control, like in the `MyContr
 
 -   Type: `Object`
 -   Required: No
+
+#### __nextUnconstrainedWidth
+
+Start opting into the unconstrained width style that will become the default in a future version, currently scheduled to be WordPress 6.4. (The prop can be safely removed once this happens.)
+
+-   Type: `Boolean`
+-   Required: No
+-   Default: `false`
 
 ## Related components
 

--- a/packages/components/src/custom-select-control/index.js
+++ b/packages/components/src/custom-select-control/index.js
@@ -10,6 +10,7 @@ import classnames from 'classnames';
 import { Icon, check } from '@wordpress/icons';
 import { __, sprintf } from '@wordpress/i18n';
 import { useCallback, useState } from '@wordpress/element';
+import deprecated from '@wordpress/deprecated';
 
 /**
  * Internal dependencies
@@ -94,6 +95,17 @@ export default function CustomSelectControl( {
 	} );
 
 	const [ isFocused, setIsFocused ] = useState( false );
+
+	if ( ! __nextUnconstrainedWidth ) {
+		deprecated(
+			'Constrained width styles for wp.components.CustomSelectControl',
+			{
+				since: '6.1',
+				version: '6.4',
+				hint: 'Set the `__nextUnconstrainedWidth` prop to true to start opting into the new styles, which will become the default in a future version',
+			}
+		);
+	}
 
 	function getDescribedBy() {
 		if ( describedBy ) {

--- a/packages/components/src/custom-select-control/stories/index.js
+++ b/packages/components/src/custom-select-control/stories/index.js
@@ -8,7 +8,6 @@ export default {
 	component: CustomSelectControl,
 	argTypes: {
 		__next36pxDefaultSize: { control: { type: 'boolean' } },
-		__nextUnconstrainedWidth: { control: { type: 'boolean' } },
 		size: {
 			control: {
 				type: 'radio',
@@ -20,6 +19,7 @@ export default {
 
 export const Default = CustomSelectControl.bind( {} );
 Default.args = {
+	__nextUnconstrainedWidth: true,
 	label: 'Label',
 	options: [
 		{

--- a/packages/components/src/custom-select-control/test/index.js
+++ b/packages/components/src/custom-select-control/test/index.js
@@ -32,7 +32,10 @@ describe( 'CustomSelectControl', () => {
 				role="none"
 				onKeyDown={ onKeyDown }
 			>
-				<CustomSelectControl options={ options } />
+				<CustomSelectControl
+					options={ options }
+					__nextUnconstrainedWidth
+				/>
 			</div>
 		);
 		const toggleButton = screen.getByRole( 'button' );

--- a/packages/components/src/font-size-picker/style.scss
+++ b/packages/components/src/font-size-picker/style.scss
@@ -29,10 +29,6 @@
 		}
 	}
 
-	.components-custom-select-control__button {
-		width: 100%;
-	}
-
 	// Apply the same height as the isSmall Reset button.
 	.components-font-size-picker__number {
 		@include input-control;

--- a/packages/edit-navigation/src/components/sidebar/style.scss
+++ b/packages/edit-navigation/src/components/sidebar/style.scss
@@ -105,10 +105,7 @@
 	align-items: flex-end;
 	margin-bottom: $grid-unit-15;
 	margin-top: $grid-unit-15;
-	.components-custom-select-control,
-	.components-custom-select-control__button {
-		width: 100%;
-	}
+
 	button {
 		height: 100%;
 		margin-bottom: 8px;

--- a/packages/edit-site/src/components/global-styles/typography-panel.js
+++ b/packages/edit-site/src/components/global-styles/typography-panel.js
@@ -234,7 +234,6 @@ export default function TypographyPanel( { name, element } ) {
 					hasFontStyles={ hasFontStyles }
 					hasFontWeights={ hasFontWeights }
 					size="__unstable-large"
-					__nextUnconstrainedWidth
 				/>
 			) }
 			{ hasLetterSpacingControl && (


### PR DESCRIPTION
## What?

Formally deprecate the 130px min-width style on CustomSelectControl.

All in-repo usage has been migrated, and style hacks have been removed.

## Why?

For easier hack-free styling, and consistency across components.

## Testing Instructions

### CustomSelectControl

1. All usages in the repo should have the `__nextUnconstrainedWidth` prop set to true.
2. A deprecation warning should be printed in the console when the prop is falsy (this can be tested in the Storybook).

### DateFormatPicker

1. In the editor, add a "Post Date" block. The "Choose a format" dropdown you see in the Inspector is the DateFormatPicker.
2. The style hack used here regressed at some point and was no longer full-width, but we can see in the [original PR video](https://github.com/WordPress/gutenberg/pull/39209) that it was supposed to be full-width.

## ✍️ Dev Note 

To improve consistency with `SelectControl`, the CSS styles for `CustomSelectControl` will be changed to take up the full width available, regardless of how short the option strings are. To start opting into these new unconstrained width styles, set the `__nextUnconstrainedWidth` prop to `true`. These styles will become the default in 6.4.

To keep your `CustomSelectControl` similar to the previous styling, add width constraints to a wrapper div.

```css
.my-custom-select-control-wrapper {
  width: fit-content;
  min-width: 130px;
}
```

```jsx
<div className="my-custom-select-control-wrapper">
  <CustomSelectControl __nextUnconstrainedWidth />
</div>
```