### PR TITLE
Lodash: Remove completely from `@wordpress/e2e-test-utils` package

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16969,7 +16969,6 @@
 				"@wordpress/url": "file:packages/url",
 				"change-case": "^4.1.2",
 				"form-data": "^4.0.0",
-				"lodash": "^4.17.21",
 				"node-fetch": "^2.6.0"
 			}
 		},

--- a/packages/e2e-test-utils/package.json
+++ b/packages/e2e-test-utils/package.json
@@ -35,7 +35,6 @@
 		"@wordpress/url": "file:../url",
 		"change-case": "^4.1.2",
 		"form-data": "^4.0.0",
-		"lodash": "^4.17.21",
 		"node-fetch": "^2.6.0"
 	},
 	"peerDependencies": {

--- a/packages/e2e-test-utils/src/click-menu-item.js
+++ b/packages/e2e-test-utils/src/click-menu-item.js
@@ -1,16 +1,11 @@
 /**
- * External dependencies
- */
-import { first } from 'lodash';
-
-/**
  * Searches for an item in the menu with the text provided and clicks it.
  *
  * @param {string} label The label to search the menu item for.
  */
 export async function clickMenuItem( label ) {
-	const elementToClick = first(
-		await page.$x( `//*[@role="menu"]//*[text()="${ label }"]` )
+	const menuItems = await page.$x(
+		`//*[@role="menu"]//*[text()="${ label }"]`
 	);
-	await elementToClick.click();
+	await menuItems[ 0 ].click();
 }

--- a/packages/e2e-test-utils/src/click-on-more-menu-item.js
+++ b/packages/e2e-test-utils/src/click-on-more-menu-item.js
@@ -1,9 +1,4 @@
 /**
- * External dependencies
- */
-import { first } from 'lodash';
-
-/**
  * Internal dependencies
  */
 import { toggleMoreMenu } from './toggle-more-menu';
@@ -18,10 +13,8 @@ export async function clickOnMoreMenuItem( buttonLabel ) {
 	const moreMenuContainerSelector =
 		'//*[contains(concat(" ", @class, " "), " interface-more-menu-dropdown__content ")]';
 
-	const elementToClick = first(
-		await page.$x(
-			`${ moreMenuContainerSelector }//span[contains(concat(" ", @class, " "), " components-menu-item__item ")][contains(text(), "${ buttonLabel }")]`
-		)
+	const menuItems = await page.$x(
+		`${ moreMenuContainerSelector }//span[contains(concat(" ", @class, " "), " components-menu-item__item ")][contains(text(), "${ buttonLabel }")]`
 	);
-	await elementToClick.click();
+	await menuItems[ 0 ].click();
 }

--- a/packages/e2e-test-utils/src/find-sidebar-panel-toggle-button-with-title.js
+++ b/packages/e2e-test-utils/src/find-sidebar-panel-toggle-button-with-title.js
@@ -1,8 +1,3 @@
-/**
- * External dependencies
- */
-import { first } from 'lodash';
-
 /** @typedef {import('puppeteer-core').ElementHandle} ElementHandle */
 
 /**
@@ -13,9 +8,8 @@ import { first } from 'lodash';
  * @return {?ElementHandle} Object that represents an in-page DOM element.
  */
 export async function findSidebarPanelToggleButtonWithTitle( panelTitle ) {
-	return first(
-		await page.$x(
-			`//div[contains(@class,"edit-post-sidebar")]//button[@class="components-button components-panel__body-toggle"][contains(text(),"${ panelTitle }")]`
-		)
+	const buttons = await page.$x(
+		`//div[contains(@class,"edit-post-sidebar")]//button[@class="components-button components-panel__body-toggle"][contains(text(),"${ panelTitle }")]`
 	);
+	return buttons[ 0 ];
 }

--- a/packages/e2e-test-utils/src/get-all-block-inserter-item-titles.js
+++ b/packages/e2e-test-utils/src/get-all-block-inserter-item-titles.js
@@ -1,9 +1,4 @@
 /**
- * External dependencies
- */
-import { sortBy, uniq } from 'lodash';
-
-/**
  * Returns an array of strings with all inserter item titles.
  *
  * @return {Promise} Promise resolving with an array containing all inserter item titles.
@@ -25,5 +20,5 @@ export async function getAllBlockInserterItemTitles() {
 			return inserterItem.innerText;
 		} );
 	} );
-	return sortBy( uniq( inserterItemTitles ) );
+	return [ ...new Set( inserterItemTitles ) ].sort();
 }

--- a/packages/e2e-test-utils/src/plugins.js
+++ b/packages/e2e-test-utils/src/plugins.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { kebabCase } from 'lodash';
+import { paramCase as kebabCase } from 'change-case';
 
 /**
  * Internal dependencies

--- a/packages/e2e-test-utils/src/preview.js
+++ b/packages/e2e-test-utils/src/preview.js
@@ -1,8 +1,3 @@
-/**
- * External dependencies
- */
-import { last } from 'lodash';
-
 /** @typedef {import('puppeteer-core').Page} Page */
 
 /**
@@ -29,6 +24,6 @@ export async function openPreviewPage( editorPage = page ) {
 		openTabs = await browser.pages();
 	}
 
-	const previewPage = last( openTabs );
+	const previewPage = openTabs[ openTabs.length - 1 ];
 	return previewPage;
 }


### PR DESCRIPTION
## What?
This PR removes all of the Lodash from the `@wordpress/e2e-test-utils` package, including the `lodash` dependency altogether. There are just a few usages and conversion is pretty straightforward. 

## Why?

Lodash is known to unnecessarily inflate the bundle size of packages, and in most cases, it can be replaced with native language functionality. See these for more information and rationale:

* https://github.com/WordPress/gutenberg/issues/16938#issuecomment-602837246
* https://github.com/WordPress/gutenberg/issues/17025
* https://github.com/WordPress/gutenberg/issues/39495 

## How?
We're dealing with straightforwardly replacing a few methods, `first`, `last`, `sortBy` and `uniq`, all of which are easily replacible by native JS functionality. The remaining one, `kebabCase`, we've already been replacing with `change-case`'s  `paramCase`.

## Testing Instructions

* Verify all e2e tests still pass.