### PR TITLE
Fix error in with handling spacing preset slugs

### DIFF
--- a/lib/compat/wordpress-6.1/class-wp-theme-json-6-1.php
+++ b/lib/compat/wordpress-6.1/class-wp-theme-json-6-1.php
@@ -1212,7 +1212,7 @@ class WP_Theme_JSON_6_1 extends WP_Theme_JSON_6_0 {
 			$below_sizes[] = array(
 				/* translators: %s: Multiple of t-shirt sizing, eg. 2X-Small */
 				'name' => $x === $steps_mid_point - 1 ? __( 'Small', 'gutenberg' ) : sprintf( __( '%sX-Small', 'gutenberg' ), strval( $x_small_count ) ),
-				'slug' => $slug,
+				'slug' => (string) $slug,
 				'size' => round( $current_step, 2 ) . $unit,
 			);
 
@@ -1231,7 +1231,7 @@ class WP_Theme_JSON_6_1 extends WP_Theme_JSON_6_0 {
 
 		$below_sizes[] = array(
 			'name' => __( 'Medium', 'gutenberg' ),
-			'slug' => 50,
+			'slug' => '50',
 			'size' => $spacing_scale['mediumStep'] . $unit,
 		);
 
@@ -1249,7 +1249,7 @@ class WP_Theme_JSON_6_1 extends WP_Theme_JSON_6_0 {
 			$above_sizes[] = array(
 				/* translators: %s: Multiple of t-shirt sizing, eg. 2X-Large */
 				'name' => 0 === $x ? __( 'Large', 'gutenberg' ) : sprintf( __( '%sX-Large', 'gutenberg' ), strval( $x_large_count ) ),
-				'slug' => $slug,
+				'slug' => (string) $slug,
 				'size' => round( $current_step, 2 ) . $unit,
 			);
 

--- a/packages/block-editor/src/components/spacing-sizes-control/test/utils.js
+++ b/packages/block-editor/src/components/spacing-sizes-control/test/utils.js
@@ -57,7 +57,7 @@ describe( 'getSpacingPresetSlug', () => {
 		expect( getSpacingPresetSlug( 'default' ) ).toBe( 'default' );
 	} );
 	it( 'should return the int value of the slug portion of a valid preset var', () => {
-		expect( getSpacingPresetSlug( 'var:preset|spacing|20' ) ).toBe( 20 );
+		expect( getSpacingPresetSlug( 'var:preset|spacing|20' ) ).toBe( '20' );
 	} );
 } );
 

--- a/packages/block-editor/src/components/spacing-sizes-control/utils.js
+++ b/packages/block-editor/src/components/spacing-sizes-control/utils.js
@@ -36,7 +36,9 @@ export function getCustomValueFromPreset( value, spacingSizes ) {
 	}
 
 	const slug = getSpacingPresetSlug( value );
-	const spacingSize = spacingSizes.find( ( size ) => size.slug === slug );
+	const spacingSize = spacingSizes.find(
+		( size ) => String( size.slug ) === slug
+	);
 
 	return spacingSize?.size;
 }
@@ -100,7 +102,7 @@ export function getSliderValueFromPreset( presetValue, spacingSizes ) {
 			? '0'
 			: getSpacingPresetSlug( presetValue );
 	const sliderValue = spacingSizes.findIndex( ( spacingSize ) => {
-		return spacingSize.slug === slug;
+		return String( spacingSize.slug ) === slug;
 	} );
 
 	// Returning NaN rather than undefined as undefined makes range control thumb sit in center

--- a/packages/block-editor/src/components/spacing-sizes-control/utils.js
+++ b/packages/block-editor/src/components/spacing-sizes-control/utils.js
@@ -100,7 +100,7 @@ export function getSliderValueFromPreset( presetValue, spacingSizes ) {
 			? '0'
 			: getSpacingPresetSlug( presetValue );
 	const sliderValue = spacingSizes.findIndex( ( spacingSize ) => {
-		return spacingSize.slug === slug;
+		return parseInt( spacingSize.slug, 10 ) === slug;
 	} );
 
 	// Returning NaN rather than undefined as undefined makes range control thumb sit in center

--- a/packages/block-editor/src/components/spacing-sizes-control/utils.js
+++ b/packages/block-editor/src/components/spacing-sizes-control/utils.js
@@ -80,7 +80,7 @@ export function getSpacingPresetSlug( value ) {
 
 	const slug = value.match( /var:preset\|spacing\|(.+)/ );
 
-	return slug ? parseInt( slug[ 1 ], 10 ) : undefined;
+	return slug ? slug[ 1 ] : undefined;
 }
 
 /**
@@ -100,7 +100,7 @@ export function getSliderValueFromPreset( presetValue, spacingSizes ) {
 			? '0'
 			: getSpacingPresetSlug( presetValue );
 	const sliderValue = spacingSizes.findIndex( ( spacingSize ) => {
-		return parseInt( spacingSize.slug, 10 ) === slug;
+		return spacingSize.slug === slug;
 	} );
 
 	// Returning NaN rather than undefined as undefined makes range control thumb sit in center

--- a/phpunit/class-wp-theme-json-test.php
+++ b/phpunit/class-wp-theme-json-test.php
@@ -806,7 +806,7 @@ class WP_Theme_JSON_Gutenberg_Test extends WP_UnitTestCase {
 				'expected_output' => array(
 					array(
 						'name' => 'Medium',
-						'slug' => 50,
+						'slug' => '50',
 						'size' => '4rem',
 					),
 				),
@@ -823,12 +823,12 @@ class WP_Theme_JSON_Gutenberg_Test extends WP_UnitTestCase {
 				'expected_output' => array(
 					array(
 						'name' => 'Medium',
-						'slug' => 50,
+						'slug' => '50',
 						'size' => '4rem',
 					),
 					array(
 						'name' => 'Large',
-						'slug' => 60,
+						'slug' => '60',
 						'size' => '5.5rem',
 					),
 				),
@@ -845,17 +845,17 @@ class WP_Theme_JSON_Gutenberg_Test extends WP_UnitTestCase {
 				'expected_output' => array(
 					array(
 						'name' => 'Small',
-						'slug' => 40,
+						'slug' => '40',
 						'size' => '2.5rem',
 					),
 					array(
 						'name' => 'Medium',
-						'slug' => 50,
+						'slug' => '50',
 						'size' => '4rem',
 					),
 					array(
 						'name' => 'Large',
-						'slug' => 60,
+						'slug' => '60',
 						'size' => '5.5rem',
 					),
 				),
@@ -872,22 +872,22 @@ class WP_Theme_JSON_Gutenberg_Test extends WP_UnitTestCase {
 				'expected_output' => array(
 					array(
 						'name' => 'Small',
-						'slug' => 40,
+						'slug' => '40',
 						'size' => '2.5rem',
 					),
 					array(
 						'name' => 'Medium',
-						'slug' => 50,
+						'slug' => '50',
 						'size' => '4rem',
 					),
 					array(
 						'name' => 'Large',
-						'slug' => 60,
+						'slug' => '60',
 						'size' => '5.5rem',
 					),
 					array(
 						'name' => 'X-Large',
-						'slug' => 70,
+						'slug' => '70',
 						'size' => '7rem',
 					),
 				),
@@ -904,27 +904,27 @@ class WP_Theme_JSON_Gutenberg_Test extends WP_UnitTestCase {
 				'expected_output' => array(
 					array(
 						'name' => 'Small',
-						'slug' => 40,
+						'slug' => '40',
 						'size' => '2.5rem',
 					),
 					array(
 						'name' => 'Medium',
-						'slug' => 50,
+						'slug' => '50',
 						'size' => '5rem',
 					),
 					array(
 						'name' => 'Large',
-						'slug' => 60,
+						'slug' => '60',
 						'size' => '7.5rem',
 					),
 					array(
 						'name' => 'X-Large',
-						'slug' => 70,
+						'slug' => '70',
 						'size' => '10rem',
 					),
 					array(
 						'name' => '2X-Large',
-						'slug' => 80,
+						'slug' => '80',
 						'size' => '12.5rem',
 					),
 				),
@@ -941,27 +941,27 @@ class WP_Theme_JSON_Gutenberg_Test extends WP_UnitTestCase {
 				'expected_output' => array(
 					array(
 						'name' => 'X-Small',
-						'slug' => 30,
+						'slug' => '30',
 						'size' => '0.67rem',
 					),
 					array(
 						'name' => 'Small',
-						'slug' => 40,
+						'slug' => '40',
 						'size' => '1rem',
 					),
 					array(
 						'name' => 'Medium',
-						'slug' => 50,
+						'slug' => '50',
 						'size' => '1.5rem',
 					),
 					array(
 						'name' => 'Large',
-						'slug' => 60,
+						'slug' => '60',
 						'size' => '2.25rem',
 					),
 					array(
 						'name' => 'X-Large',
-						'slug' => 70,
+						'slug' => '70',
 						'size' => '3.38rem',
 					),
 				),
@@ -978,27 +978,27 @@ class WP_Theme_JSON_Gutenberg_Test extends WP_UnitTestCase {
 				'expected_output' => array(
 					array(
 						'name' => 'X-Small',
-						'slug' => 30,
+						'slug' => '30',
 						'size' => '0.09rem',
 					),
 					array(
 						'name' => 'Small',
-						'slug' => 40,
+						'slug' => '40',
 						'size' => '0.38rem',
 					),
 					array(
 						'name' => 'Medium',
-						'slug' => 50,
+						'slug' => '50',
 						'size' => '1.5rem',
 					),
 					array(
 						'name' => 'Large',
-						'slug' => 60,
+						'slug' => '60',
 						'size' => '6rem',
 					),
 					array(
 						'name' => 'X-Large',
-						'slug' => 70,
+						'slug' => '70',
 						'size' => '24rem',
 					),
 				),

--- a/schemas/json/theme.json
+++ b/schemas/json/theme.json
@@ -243,7 +243,7 @@
 										"type": "string"
 									},
 									"slug": {
-										"description": "Unique identifier for the space size preset.",
+										"description": "Unique identifier for the space size preset. For best cross theme compatibility these should be in the form '10','20','30','40','50','60', etc. with '50' representing the 'Medium' size step.",
 										"type": "string"
 									},
 									"size": {

--- a/schemas/json/theme.json
+++ b/schemas/json/theme.json
@@ -243,8 +243,8 @@
 										"type": "string"
 									},
 									"slug": {
-										"description": "Kebab-case unique identifier for the space size preset.",
-										"type": "string"
+										"description": "Unique identifier for the space size preset.",
+										"type": "integer"
 									},
 									"size": {
 										"description": "CSS space-size value, including units.",

--- a/schemas/json/theme.json
+++ b/schemas/json/theme.json
@@ -244,7 +244,7 @@
 									},
 									"slug": {
 										"description": "Unique identifier for the space size preset.",
-										"type": "integer"
+										"type": "string"
 									},
 									"size": {
 										"description": "CSS space-size value, including units.",


### PR DESCRIPTION
## What?
Update theme.json spacing presets slugs to be compared as strings in the presets UI

## Why?
The theme.json schema specified slugs as strings, which is a more standard format, in some places they were being compared as ints. Although the default format of 10,20,30 etc for slugs was decided on to allow for fallback to nearest values in a future iteration the slugs can be parsed to ints at that point so can be left as a string format elsewhere.

Fixes: #43234

## How?
Update the generated spacingSizes slug values to be strings.

## Testing Instructions
Add spacing.spacingSizes to a theme.json file with string slugs, eg: 

```
"spacing": {
		"spacingSizes": [
			{
				"name": "50",
				"slug": "50",
				"size": "2rem"
			},
			{
				"name": "XL",
				"slug": "60",
				"size": "4rem"
			},
			{
				"name": "2XL",
				"slug": "70",
				"size": "clamp(2rem, 10vw, 20rem)"
			}
		]
}
```
- Add a Group block and in the dimensions panel check that the padding range control works as expected.

## Screenshots or screencast 

Before:

![184583776-68adf46f-7966-4048-8300-c111972f85ca](https://user-images.githubusercontent.com/1813435/184684946-014302ef-14d2-495d-b8a1-2eb8e8b9c52f.gif)


After:

https://user-images.githubusercontent.com/3629020/184727668-6b585129-1041-4624-acb3-717b94967bbf.mp4


