### PR TITLE
[RNMobile] List block v2: Fix text color inconsistencies with list items

### DIFF
--- a/packages/block-library/src/list-item/list-style-type.native.js
+++ b/packages/block-library/src/list-item/list-style-type.native.js
@@ -8,7 +8,7 @@ import { View, Text } from 'react-native';
  */
 import { Icon } from '@wordpress/components';
 import { Platform } from '@wordpress/element';
-import { withPreferredColorScheme } from '@wordpress/compose';
+import { usePreferredColorSchemeStyle } from '@wordpress/compose';
 
 /**
  * Internal dependencies
@@ -90,10 +90,9 @@ function IconList( { fontSize, color, defaultFontSize, indentationLevel } ) {
 	);
 }
 
-function ListStyleType( {
+export default function ListStyleType( {
 	blockIndex,
 	indentationLevel,
-	getStylesFromColorScheme,
 	numberOfListItems,
 	ordered,
 	reversed,
@@ -112,7 +111,7 @@ function ListStyleType( {
 		10
 	);
 
-	const colorWithPreferredScheme = getStylesFromColorScheme(
+	const colorWithPreferredScheme = usePreferredColorSchemeStyle(
 		styles[ 'wp-block-list-item__list-item--default' ],
 		styles[ 'wp-block-list-item__list-item--default--dark' ]
 	);
@@ -145,5 +144,3 @@ function ListStyleType( {
 		/>
 	);
 }
-
-export default withPreferredColorScheme( ListStyleType );

--- a/packages/block-library/src/list-item/list-style-type.native.js
+++ b/packages/block-library/src/list-item/list-style-type.native.js
@@ -8,6 +8,7 @@ import { View, Text } from 'react-native';
  */
 import { Icon } from '@wordpress/components';
 import { Platform } from '@wordpress/element';
+import { withPreferredColorScheme } from '@wordpress/compose';
 
 /**
  * Internal dependencies
@@ -89,9 +90,10 @@ function IconList( { fontSize, color, defaultFontSize, indentationLevel } ) {
 	);
 }
 
-export default function ListStyleType( {
+function ListStyleType( {
 	blockIndex,
 	indentationLevel,
+	getStylesFromColorScheme,
 	numberOfListItems,
 	ordered,
 	reversed,
@@ -109,9 +111,15 @@ export default function ListStyleType( {
 		style?.fontSize ? style.fontSize : defaultFontSize,
 		10
 	);
+
+	const colorWithPreferredScheme = getStylesFromColorScheme(
+		styles[ 'wp-block-list-item__list-item--default' ],
+		styles[ 'wp-block-list-item__list-item--default--dark' ]
+	);
+
 	const defaultColor = style?.baseColors?.color?.text
 		? style.baseColors.color.text
-		: styles[ 'wp-block-list-item__list-item--default' ].color;
+		: colorWithPreferredScheme.color;
 	const color = style?.color ? style.color : defaultColor;
 
 	if ( ordered ) {
@@ -137,3 +145,5 @@ export default function ListStyleType( {
 		/>
 	);
 }
+
+export default withPreferredColorScheme( ListStyleType );

--- a/packages/block-library/src/list-item/style.native.scss
+++ b/packages/block-library/src/list-item/style.native.scss
@@ -28,6 +28,11 @@
 	font-size: $editor-font-size;
 }
 
+.wp-block-list-item__list-item--default--dark {
+	color: $white;
+	font-size: $editor-font-size;
+}
+
 .wp-block-list-item__list-item-ordered--default {
 	margin-top: 2;
 }

--- a/packages/block-library/src/list-item/style.native.scss
+++ b/packages/block-library/src/list-item/style.native.scss
@@ -30,7 +30,6 @@
 
 .wp-block-list-item__list-item--default--dark {
 	color: $white;
-	font-size: $editor-font-size;
 }
 
 .wp-block-list-item__list-item-ordered--default {


### PR DESCRIPTION
## What?
Addresses the following:
- https://github.com/wordpress-mobile/gutenberg-mobile/pull/5096
- https://github.com/WordPress/gutenberg/issues/43146

## Why?
The issue creates a UI inconsistency when using list items in dark mode while using standard themes.  (This issue does not affect block themes.)

## How?
Adds a default base color to the list item when dark mode is selected while using a standard theme.

## Testing Instructions
1. Make sure List block v2 in Experiments is enabled (> Gutenberg 13.8.2)
2. Open the editor in the WordPress app using a standard theme.
3. Add a new list block
4. Create the following list:
    - One
    - Two
        - Three
    - Four
5. Switch to dark mode
6. Observe that the bullets are visible in dark mode
7. Select the (Two/Three) block
8. Tap on the indent button
9. Observe that the text color is correct for the site's theme

