### PR TITLE
Spacing presets: Add support for margins

### DIFF
--- a/packages/block-editor/src/components/spacing-sizes-control/all-input-control.js
+++ b/packages/block-editor/src/components/spacing-sizes-control/all-input-control.js
@@ -19,7 +19,7 @@ export default function AllInputControl( {
 } ) {
 	const allValue = getAllRawValue( values );
 	const hasValues = isValuesDefined( values );
-	const isMixed = hasValues && isValuesMixed( values );
+	const isMixed = hasValues && isValuesMixed( values, sides );
 
 	const handleOnChange = ( next ) => {
 		const nextValues = applyValueToSides( values, next, sides );

--- a/packages/block-editor/src/components/spacing-sizes-control/index.js
+++ b/packages/block-editor/src/components/spacing-sizes-control/index.js
@@ -43,7 +43,7 @@ export default function SpacingSizesControl( {
 	const hasOneSide = sides?.length === 1;
 
 	const [ isLinked, setIsLinked ] = useState(
-		! hasInitialValue || ! isValuesMixed( inputValues ) || hasOneSide
+		! hasInitialValue || ! isValuesMixed( inputValues, sides ) || hasOneSide
 	);
 
 	const toggleLinked = () => {

--- a/packages/block-editor/src/components/spacing-sizes-control/utils.js
+++ b/packages/block-editor/src/components/spacing-sizes-control/utils.js
@@ -159,13 +159,14 @@ export function getAllRawValue( values = {} ) {
  * Checks to determine if values are mixed.
  *
  * @param {Object} values Box values.
+ * @param {Array}  sides  Sides that values relate to.
  *
  * @return {boolean} Whether values are mixed.
  */
-export function isValuesMixed( values = {} ) {
+export function isValuesMixed( values = {}, sides = ALL_SIDES ) {
 	return (
 		( Object.values( values ).length >= 1 &&
-			Object.values( values ).length < 4 ) ||
+			Object.values( values ).length < sides.length ) ||
 		new Set( Object.values( values ) ).size > 1
 	);
 }

--- a/packages/block-editor/src/hooks/dimensions.js
+++ b/packages/block-editor/src/hooks/dimensions.js
@@ -100,6 +100,10 @@ export function DimensionsPanel( props ) {
 				) }
 				{ ! isMarginDisabled && (
 					<ToolsPanelItem
+						className={ classnames( {
+							'tools-panel-item-spacing':
+								spacingSizes && spacingSizes.length > 0,
+						} ) }
 						hasValue={ () => hasMarginValue( props ) }
 						label={ __( 'Margin' ) }
 						onDeselect={ () => resetMargin( props ) }

--- a/packages/block-editor/src/hooks/margin.js
+++ b/packages/block-editor/src/hooks/margin.js
@@ -28,6 +28,11 @@ import {
 } from './dimensions';
 import { cleanEmptyObject } from './utils';
 import BlockPopover from '../components/block-popover';
+import SpacingSizesControl from '../components/spacing-sizes-control';
+import {
+	getSpacingPresetCssVar,
+	isValueSpacingPreset,
+} from '../components/spacing-sizes-control/utils';
 
 /**
  * Determines if there is margin support.
@@ -101,6 +106,8 @@ export function MarginEdit( props ) {
 		setAttributes,
 	} = props;
 
+	const spacingSizes = useSetting( 'spacing.spacingSizes' );
+
 	const units = useCustomUnits( {
 		availableUnits: useSetting( 'spacing.units' ) || [
 			'%',
@@ -135,15 +142,28 @@ export function MarginEdit( props ) {
 	return Platform.select( {
 		web: (
 			<>
-				<BoxControl
-					values={ style?.spacing?.margin }
-					onChange={ onChange }
-					label={ __( 'Margin' ) }
-					sides={ sides }
-					units={ units }
-					allowReset={ false }
-					splitOnAxis={ splitOnAxis }
-				/>
+				{ ( ! spacingSizes || spacingSizes?.length === 0 ) && (
+					<BoxControl
+						values={ style?.spacing?.margin }
+						onChange={ onChange }
+						label={ __( 'Margin' ) }
+						sides={ sides }
+						units={ units }
+						allowReset={ false }
+						splitOnAxis={ splitOnAxis }
+					/>
+				) }
+				{ spacingSizes?.length > 0 && (
+					<SpacingSizesControl
+						values={ style?.spacing?.margin }
+						onChange={ onChange }
+						label={ __( 'Margin' ) }
+						sides={ sides }
+						units={ units }
+						allowReset={ false }
+						splitOnAxis={ false }
+					/>
+				) }
 			</>
 		),
 		native: null,
@@ -154,10 +174,18 @@ export function MarginVisualizer( { clientId, attributes } ) {
 	const margin = attributes?.style?.spacing?.margin;
 	const style = useMemo( () => {
 		return {
-			borderTopWidth: margin?.top ?? 0,
-			borderRightWidth: margin?.right ?? 0,
-			borderBottomWidth: margin?.bottom ?? 0,
-			borderLeftWidth: margin?.left ?? 0,
+			borderTopWidth: isValueSpacingPreset( margin?.top )
+				? getSpacingPresetCssVar( margin?.top )
+				: margin?.top,
+			borderRightWidth: isValueSpacingPreset( margin?.right )
+				? getSpacingPresetCssVar( margin?.right )
+				: margin?.right,
+			borderBottomWidth: isValueSpacingPreset( margin?.bottom )
+				? getSpacingPresetCssVar( margin?.bottom )
+				: margin?.bottom,
+			borderLeftWidth: isValueSpacingPreset( margin?.left )
+				? getSpacingPresetCssVar( margin?.left )
+				: margin?.left,
 			top: margin?.top ? `-${ margin.top }` : 0,
 			right: margin?.right ? `-${ margin.right }` : 0,
 			bottom: margin?.bottom ? `-${ margin.bottom }` : 0,

--- a/packages/block-editor/src/hooks/margin.js
+++ b/packages/block-editor/src/hooks/margin.js
@@ -29,10 +29,7 @@ import {
 import { cleanEmptyObject } from './utils';
 import BlockPopover from '../components/block-popover';
 import SpacingSizesControl from '../components/spacing-sizes-control';
-import {
-	getSpacingPresetCssVar,
-	isValueSpacingPreset,
-} from '../components/spacing-sizes-control/utils';
+import { getCustomValueFromPreset } from '../components/spacing-sizes-control/utils';
 
 /**
  * Determines if there is margin support.
@@ -172,24 +169,31 @@ export function MarginEdit( props ) {
 
 export function MarginVisualizer( { clientId, attributes } ) {
 	const margin = attributes?.style?.spacing?.margin;
+	const spacingSizes = useSetting( 'spacing.spacingSizes' );
+
 	const style = useMemo( () => {
+		const marginTop = margin?.top
+			? getCustomValueFromPreset( margin?.top, spacingSizes )
+			: 0;
+		const marginRight = margin?.right
+			? getCustomValueFromPreset( margin?.right, spacingSizes )
+			: 0;
+		const marginBottom = margin?.bottom
+			? getCustomValueFromPreset( margin?.bottom, spacingSizes )
+			: 0;
+		const marginLeft = margin?.left
+			? getCustomValueFromPreset( margin?.left, spacingSizes )
+			: 0;
+
 		return {
-			borderTopWidth: isValueSpacingPreset( margin?.top )
-				? getSpacingPresetCssVar( margin?.top )
-				: margin?.top,
-			borderRightWidth: isValueSpacingPreset( margin?.right )
-				? getSpacingPresetCssVar( margin?.right )
-				: margin?.right,
-			borderBottomWidth: isValueSpacingPreset( margin?.bottom )
-				? getSpacingPresetCssVar( margin?.bottom )
-				: margin?.bottom,
-			borderLeftWidth: isValueSpacingPreset( margin?.left )
-				? getSpacingPresetCssVar( margin?.left )
-				: margin?.left,
-			top: margin?.top ? `-${ margin.top }` : 0,
-			right: margin?.right ? `-${ margin.right }` : 0,
-			bottom: margin?.bottom ? `-${ margin.bottom }` : 0,
-			left: margin?.left ? `-${ margin.left }` : 0,
+			borderTopWidth: marginTop,
+			borderRightWidth: marginRight,
+			borderBottomWidth: marginBottom,
+			borderLeftWidth: marginLeft,
+			top: marginTop !== 0 ? `-${ marginTop }` : 0,
+			right: marginRight !== 0 ? `-${ marginRight }` : 0,
+			bottom: marginBottom !== 0 ? `-${ marginBottom }` : 0,
+			left: marginLeft !== 0 ? `-${ marginLeft }` : 0,
 		};
 	}, [ margin ] );
 

--- a/packages/edit-site/src/components/global-styles/dimensions-panel.js
+++ b/packages/edit-site/src/components/global-styles/dimensions-panel.js
@@ -435,16 +435,32 @@ export default function DimensionsPanel( { name } ) {
 					label={ __( 'Margin' ) }
 					onDeselect={ resetMarginValue }
 					isShownByDefault={ true }
+					className={ classnames( {
+						'tools-panel-item-spacing': showSpacingPresetsControl,
+					} ) }
 				>
-					<BoxControl
-						values={ marginValues }
-						onChange={ setMarginValues }
-						label={ __( 'Margin' ) }
-						sides={ marginSides }
-						units={ units }
-						allowReset={ false }
-						splitOnAxis={ isAxialMargin }
-					/>
+					{ ! showSpacingPresetsControl && (
+						<BoxControl
+							values={ marginValues }
+							onChange={ setMarginValues }
+							label={ __( 'Margin' ) }
+							sides={ marginSides }
+							units={ units }
+							allowReset={ false }
+							splitOnAxis={ isAxialMargin }
+						/>
+					) }
+					{ showSpacingPresetsControl && (
+						<SpacingSizesControl
+							values={ marginValues }
+							onChange={ setMarginValues }
+							label={ __( 'Margin' ) }
+							sides={ marginSides }
+							units={ units }
+							allowReset={ false }
+							splitOnAxis={ isAxialMargin }
+						/>
+					) }
 				</ToolsPanelItem>
 			) }
 			{ showGapControl && (


### PR DESCRIPTION
## What?
Adds the new spacing presets option to the margin controls

## Why?
They think it is unfair that padding are the only control to have this new functionality

## How?
Adds the SpacingSizesControl component to the margin controls in blocks tools panel and global styles

## Testing Instructions

- Add a Group block and add the optional Margins support in the block Tools panel
- Adjust the margins using both the presets slider and the custom setting control
- Make sure the margins are applied as expected in the editor and frontend

## Screenshots or screencast 

https://user-images.githubusercontent.com/3629020/184801641-9c7bbd70-b236-4a2c-ad91-f90c5f332f17.mp4


