### PR TITLE
Global styles: resolve dynamic refs

### DIFF
--- a/packages/edit-site/src/components/global-styles/test/use-global-styles-output.js
+++ b/packages/edit-site/src/components/global-styles/test/use-global-styles-output.js
@@ -756,5 +756,57 @@ describe( 'global styles renderer', () => {
 				'font-family: sans-serif',
 			] );
 		} );
+
+		it( 'Should resolve dynamic references', () => {
+			const blockStylesWithRef = {
+				color: {
+					background: {
+						ref: 'styles.color.text',
+					},
+					text: 'king-crimson',
+				},
+			};
+			const tree = {
+				styles: blockStylesWithRef,
+			};
+			expect(
+				getStylesDeclarations(
+					blockStylesWithRef,
+					'.wp-selector',
+					true,
+					tree
+				)
+			).toEqual( [
+				'color: king-crimson',
+				'background-color: king-crimson',
+			] );
+		} );
+
+		it( 'Should skip dynamic references that point to other dynamic references', () => {
+			const blockStylesWithRef = {
+				spacing: {
+					padding: {
+						ref: 'styles.spacing.margin',
+					},
+					margin: {
+						ref: 'styles.typography.letterSpacing',
+					},
+				},
+				typography: {
+					letterSpacing: '20px',
+				},
+			};
+			const tree = {
+				styles: blockStylesWithRef,
+			};
+			expect(
+				getStylesDeclarations(
+					blockStylesWithRef,
+					'.wp-selector',
+					false,
+					tree
+				)
+			).toEqual( [ 'margin: 20px', 'letter-spacing: 20px' ] );
+		} );
 	} );
 } );

--- a/packages/edit-site/src/components/global-styles/test/use-global-styles-output.js
+++ b/packages/edit-site/src/components/global-styles/test/use-global-styles-output.js
@@ -777,8 +777,8 @@ describe( 'global styles renderer', () => {
 					tree
 				)
 			).toEqual( [
-				'color: king-crimson',
 				'background-color: king-crimson',
+				'color: king-crimson',
 			] );
 		} );
 

--- a/packages/edit-site/src/components/global-styles/test/utils.js
+++ b/packages/edit-site/src/components/global-styles/test/utils.js
@@ -1,7 +1,11 @@
 /**
  * Internal dependencies
  */
-import { getPresetVariableFromValue, getValueFromVariable } from '../utils';
+import {
+	getPresetVariableFromValue,
+	getValueFromVariable,
+	resolveDynamicRef,
+} from '../utils';
 
 describe( 'editor utils', () => {
 	const themeJson = {
@@ -163,7 +167,7 @@ describe( 'editor utils', () => {
 				expect( actual ).toBe( stylesWithRefs.styles.color.text );
 			} );
 
-			it( 'returns the originally provided value where value is dynamic reference and reference does not exist', () => {
+			it( 'returns the originally provided variable where value is dynamic reference and reference does not exist', () => {
 				const stylesWithRefs = {
 					...themeJson,
 					styles: {
@@ -178,10 +182,12 @@ describe( 'editor utils', () => {
 					ref: 'styles.color.text',
 				} );
 
-				expect( actual ).toBe( stylesWithRefs.styles.color.text );
+				expect( actual ).toEqual( {
+					ref: 'styles.color.text',
+				} );
 			} );
 
-			it( 'returns the originally provided value where value is dynamic reference', () => {
+			it( 'returns the originally provided variable where value is dynamic reference', () => {
 				const stylesWithRefs = {
 					...themeJson,
 					styles: {
@@ -199,7 +205,49 @@ describe( 'editor utils', () => {
 					ref: 'styles.color.text',
 				} );
 
-				expect( actual ).toBe( stylesWithRefs.styles.color.text );
+				expect( actual ).toEqual( {
+					ref: 'styles.color.text',
+				} );
+			} );
+		} );
+	} );
+
+	describe( 'resolveDynamicRef', () => {
+		it( 'returns the resolved value', () => {
+			const tree = {
+				styles: {
+					typography: {
+						letterSpacing: '20px',
+					},
+				},
+			};
+			expect(
+				resolveDynamicRef(
+					{
+						ref: 'styles.typography.letterSpacing',
+					},
+					tree
+				)
+			).toEqual( '20px' );
+		} );
+
+		it( 'returns the originally provided value where a value cannot be found', () => {
+			const tree = {
+				styles: {
+					typography: {
+						letterSpacing: '20px',
+					},
+				},
+			};
+			expect(
+				resolveDynamicRef(
+					{
+						ref: 'styles.spacing.margin',
+					},
+					tree
+				)
+			).toEqual( {
+				ref: 'styles.spacing.margin',
 			} );
 		} );
 	} );

--- a/packages/edit-site/src/components/global-styles/test/utils.js
+++ b/packages/edit-site/src/components/global-styles/test/utils.js
@@ -182,12 +182,10 @@ describe( 'editor utils', () => {
 					ref: 'styles.color.text',
 				} );
 
-				expect( actual ).toEqual( {
-					ref: 'styles.color.text',
-				} );
+				expect( actual ).toEqual( '' );
 			} );
 
-			it( 'returns the originally provided variable where value is dynamic reference', () => {
+			it( 'returns an empty string where value is dynamic reference', () => {
 				const stylesWithRefs = {
 					...themeJson,
 					styles: {
@@ -205,9 +203,7 @@ describe( 'editor utils', () => {
 					ref: 'styles.color.text',
 				} );
 
-				expect( actual ).toEqual( {
-					ref: 'styles.color.text',
-				} );
+				expect( actual ).toEqual( '' );
 			} );
 		} );
 	} );
@@ -229,6 +225,26 @@ describe( 'editor utils', () => {
 					tree
 				)
 			).toEqual( '20px' );
+		} );
+
+		it( 'returns empty string if reference to another ref is found', () => {
+			const tree = {
+				styles: {
+					typography: {
+						letterSpacing: {
+							ref: 'styles.typography.fontSize',
+						},
+					},
+				},
+			};
+			expect(
+				resolveDynamicRef(
+					{
+						ref: 'styles.typography.letterSpacing',
+					},
+					tree
+				)
+			).toEqual( '' );
 		} );
 
 		it( 'returns the originally provided value where a value cannot be found', () => {

--- a/packages/edit-site/src/components/global-styles/use-global-styles-output.js
+++ b/packages/edit-site/src/components/global-styles/use-global-styles-output.js
@@ -213,11 +213,11 @@ export function getStylesDeclarations(
 				return declarations;
 			}
 			const pathToValue = value;
-			let styleValue = get( blockStyles, pathToValue, false );
+			let styleValue = get( blockStyles, pathToValue, '' );
 
 			if (
 				first( pathToValue ) === 'elements' ||
-				// The style engine cannoresolveDynamicReft handle dynamic refs yet.
+				// The style engine cannot handle dynamic refs yet.
 				( useEngine && ! styleValue?.ref )
 			) {
 				return declarations;
@@ -225,7 +225,7 @@ export function getStylesDeclarations(
 
 			styleValue = resolveDynamicRef( styleValue, tree );
 			// If get() finds no style value or the ref points to another ref (invalid), return.
-			if ( styleValue === false || !! styleValue?.ref ) {
+			if ( styleValue === '' || !! styleValue?.ref ) {
 				return declarations;
 			}
 

--- a/packages/edit-site/src/components/global-styles/utils.js
+++ b/packages/edit-site/src/components/global-styles/utils.js
@@ -319,7 +319,7 @@ export function scopeSelector( scope, selector ) {
  *
  * @param {string|*} styleValue An incoming style value.
  * @param {Object}   tree       GlobalStylesContext config, e.g., user, base or merged. Represents the theme.json tree.
- * @return {string|*} The value of the dynamic ref, if found. If not found, `false`.
+ * @return {string|*} The value of the dynamic ref, if found. If not found, returns `styleValue`. If a reference to another ref is found, returns an empty string.
  */
 export function resolveDynamicRef( styleValue, tree ) {
 	const ref = get( styleValue, [ 'ref' ], false );
@@ -327,7 +327,10 @@ export function resolveDynamicRef( styleValue, tree ) {
 		const resolvedValue = get( tree, ref.split( '.' ) );
 		// Presence of another ref indicates a reference to another dynamic value.
 		// Pointing to another dynamic value is not supported.
-		if ( !! resolvedValue && ! resolvedValue?.ref ) {
+		if ( !! resolvedValue?.ref ) {
+			return '';
+		}
+		if ( !! resolvedValue ) {
 			return resolvedValue;
 		}
 	}


### PR DESCRIPTION
## What?
A follow up for https://github.com/WordPress/gutenberg/pull/43166

## Why?
To clean up how we resolve dynamic refs in the editor, remove duplicated code.

Also, because the style engine doesn't yet handle dynamic refs, moving the logic outside the `getCSSRules` loop. 

`margin` and probably some other props were being skipped because of this.

## How?
This commit adds a utility function to resolve dynamic refs and add conditions to prevent recursive refs.

## Testing Instructions

I'm using empty theme to test!

Here is some test theme.json

```json
{
	"version": 2,
	"styles": {
		"color": {
			"text": {
				"ref": "styles.color.background"
			},
			"background": {
				"ref": "styles.color.text"
			}
		},
		"typography": {
			"letterSpacing": {
				"ref": "styles.spacing.blockGap"
			}
		},
		"spacing": {
			"margin": {
				"ref": "styles.spacing.blockGap"
			},
			"blockGap": "11px"
		}
	}
}


```

What  we want to do is make sure the editor styles in `.editor-styles-wrapper` are displayed as they are on the frontend.

<img width="187" alt="Screen Shot 2022-08-16 at 3 41 19 pm" src="https://user-images.githubusercontent.com/6458278/184806071-814212ff-8d7f-49ef-a055-31476fa00cf8.png">


You'll see a PHP warning:

```
Notice: Function get_property_value was called <strong>incorrectly</strong>. Your theme.json file uses a dynamic value ({"ref":"styles.color.background"}) for the path at ["color","background"]. However, the value at ["color","background"] is also a dynamic value (pointing to styles.color.background) and pointing to another dynamic value is not supported. Please update ["color","background"] to point directly to styles.color.background. Please see <a href="https://wordpress.org/support/article/debugging-in-wordpress/">Debugging in WordPress</a> for more information. (This message was added in version 6.1.0.) in /var/www/html/wp-includes/functions.php on line 5831
```

This is expected because of the recursive reference. 

Check that the test case in https://github.com/WordPress/gutenberg/pull/43166 is still valid. That is, make sure the editor doesn't crash. 😄 

Run the tests!

`npm run test:unit`