### PR TITLE
Column Block: Adopt typography supports

### DIFF
--- a/docs/reference-guides/core-blocks.md
+++ b/docs/reference-guides/core-blocks.md
@@ -95,7 +95,7 @@ A single column within a columns block. ([Source](https://github.com/WordPress/g
 
 -	**Name:** core/column
 -	**Category:** text
--	**Supports:** anchor, color (background, gradients, link, text), spacing (blockGap, padding), ~~html~~, ~~reusable~~
+-	**Supports:** anchor, color (background, gradients, link, text), spacing (blockGap, padding), typography (fontSize, lineHeight), ~~html~~, ~~reusable~~
 -	**Attributes:** allowedBlocks, templateLock, verticalAlignment, width
 
 ## Columns

--- a/packages/block-library/src/column/block.json
+++ b/packages/block-library/src/column/block.json
@@ -51,6 +51,19 @@
 				"width": true
 			}
 		},
+		"typography": {
+			"fontSize": true,
+			"lineHeight": true,
+			"__experimentalFontFamily": true,
+			"__experimentalFontWeight": true,
+			"__experimentalFontStyle": true,
+			"__experimentalTextTransform": true,
+			"__experimentalTextDecoration": true,
+			"__experimentalLetterSpacing": true,
+			"__experimentalDefaultControls": {
+				"fontSize": true
+			}
+		},
 		"__experimentalLayout": true
 	}
 }


### PR DESCRIPTION
Related:
- https://github.com/WordPress/gutenberg/issues/43241
- https://github.com/WordPress/gutenberg/issues/43242
- https://github.com/WordPress/gutenberg/pull/43253

## What?

Opts into typography block supports for the Column block.

## Why?

- Allows a user to set typography styles at the column level rather than have to do it to every inner block. Mileage will still vary based on block styles.
- Contributes towards efforts to increase consistency in terms of design tools across blocks.

## How?

- Opts into all available typography block supports.
- Only exposes the font size control by default as that seems the most common configuration across blocks at the moment. It will be addressed further as part of follow-ups for https://github.com/WordPress/gutenberg/issues/43241

## Testing Instructions

1. Load the site editor and navigate to Global Styles > Blocks > Column > Typography.
2. Adjust styles and confirm they are applied in the preview (this likely won't really be desired but illustrates that theme.json / global styles application of column typography works).
3. Save and check column styles are correct on frontend.
4. Optionally, clear those global styles. Then load the block editor.
5. Add a columns block and select columns configuration. 
6. Add multiple paragraphs to a single column.
7. Select that column block and play around with all typography styles. They should be applied correctly in the editor and frontend.

## Screenshots or screencast <!-- if applicable -->

https://user-images.githubusercontent.com/60436221/184832811-41551892-3aaf-4144-8e8e-53cd5e82b93c.mp4



