### PR TITLE
Columns Block: Add typography supports

### DIFF
--- a/docs/reference-guides/core-blocks.md
+++ b/docs/reference-guides/core-blocks.md
@@ -104,7 +104,7 @@ Display content in multiple columns, with blocks added to each column. ([Source]
 
 -	**Name:** core/columns
 -	**Category:** design
--	**Supports:** align (full, wide), anchor, color (background, gradients, link, text), spacing (blockGap, margin, padding), ~~html~~
+-	**Supports:** align (full, wide), anchor, color (background, gradients, link, text), spacing (blockGap, margin, padding), typography (fontSize, lineHeight), ~~html~~
 -	**Attributes:** isStackedOnMobile, verticalAlignment
 
 ## Comment Author Avatar (deprecated)

--- a/packages/block-library/src/columns/block.json
+++ b/packages/block-library/src/columns/block.json
@@ -57,6 +57,19 @@
 				"style": true,
 				"width": true
 			}
+		},
+		"typography": {
+			"fontSize": true,
+			"lineHeight": true,
+			"__experimentalFontFamily": true,
+			"__experimentalFontWeight": true,
+			"__experimentalFontStyle": true,
+			"__experimentalTextTransform": true,
+			"__experimentalTextDecoration": true,
+			"__experimentalLetterSpacing": true,
+			"__experimentalDefaultControls": {
+				"fontSize": true
+			}
 		}
 	},
 	"editorStyle": "wp-block-columns-editor",


### PR DESCRIPTION
Related:
- https://github.com/WordPress/gutenberg/issues/43241
- https://github.com/WordPress/gutenberg/issues/43242
- https://github.com/WordPress/gutenberg/pull/43252

## What?

Adopts typography supports for the Columns block.

## Why?

- Allows users to set typography styles that can apply across columns.
- Advances efforts towards increased consistency of design tools across blocks.

## How?

- Opts into all typography block supports
- Only exposes font size control as a default. Matches most common configuration to date.

## Testing Instructions

1. Open post editor and add a Columns block. 
2. Select a column configuration and add a paragraph to each column.
3. Select the Columns block and trial adjusting all the available typography controls.
4. Confirm styles are applied in the editor. Then save and check the frontend.
5. Switch to the site editor and navigate to Global Styles > Blocks > Columns > Typography.
6. Trial typography changes here and confirm these are applied in the preview as well as post editor/frontend.

## Screenshots or screencast <!-- if applicable -->

https://user-images.githubusercontent.com/60436221/184835739-91d839e5-6103-41c6-9754-10e4dd4e26be.mp4


