### PR TITLE
Categories List: Add typography support

### DIFF
--- a/docs/reference-guides/core-blocks.md
+++ b/docs/reference-guides/core-blocks.md
@@ -77,7 +77,7 @@ Display a list of all categories. ([Source](https://github.com/WordPress/gutenbe
 
 -	**Name:** core/categories
 -	**Category:** widgets
--	**Supports:** align, ~~html~~
+-	**Supports:** align, typography (fontSize, lineHeight), ~~html~~
 -	**Attributes:** displayAsDropdown, showEmpty, showHierarchy, showOnlyTopLevel, showPostCounts
 
 ## Code

--- a/packages/block-library/src/categories/block.json
+++ b/packages/block-library/src/categories/block.json
@@ -30,7 +30,20 @@
 	},
 	"supports": {
 		"align": true,
-		"html": false
+		"html": false,
+		"typography": {
+			"fontSize": true,
+			"lineHeight": true,
+			"__experimentalFontFamily": true,
+			"__experimentalFontWeight": true,
+			"__experimentalFontStyle": true,
+			"__experimentalTextTransform": true,
+			"__experimentalTextDecoration": true,
+			"__experimentalLetterSpacing": true,
+			"__experimentalDefaultControls": {
+				"fontSize": true
+			}
+		}
 	},
 	"editorStyle": "wp-block-categories-editor",
 	"style": "wp-block-categories"


### PR DESCRIPTION
Related:
- https://github.com/WordPress/gutenberg/issues/43241
- https://github.com/WordPress/gutenberg/issues/43242

## What?

Adds typography support to the Categories block.

## Why?

- Allows some typography control over the categories list
- Increases consistency in terms of available design tools across blocks

## How?

- Opts into all typography supports
- Only exposes the font size control by default as this is the most common config.

## Testing Instructions

1. Load the block editor, add a categories list block and select it
2. Within the sidebar experiment with various typography settings (note the list's inner links will have their own underline style. Can address in a follow-up)
3. Your selected styles should appear both in the editor and the frontend after saving
4. Switch to the site editor, ensure a categories list block is on the page/template in question.
5. Navigate to Global Styles > Blocks > Categories List > Typography and confirm these styles get applied


## Screenshots or screencast <!-- if applicable -->

https://user-images.githubusercontent.com/60436221/184839725-fb774d38-624a-422a-ba2c-12959165f328.mp4


