### PR TITLE
Code Block: Add missing typography supports to code block

### DIFF
--- a/packages/block-library/src/code/block.json
+++ b/packages/block-library/src/code/block.json
@@ -18,10 +18,12 @@
 		"typography": {
 			"fontSize": true,
 			"lineHeight": true,
-			"__experimentalFontStyle": true,
+			"__experimentalFontFamily": true,
 			"__experimentalFontWeight": true,
-			"__experimentalLetterSpacing": true,
+			"__experimentalFontStyle": true,
 			"__experimentalTextTransform": true,
+			"__experimentalTextDecoration": true,
+			"__experimentalLetterSpacing": true,
 			"__experimentalDefaultControls": {
 				"fontSize": true
 			}


### PR DESCRIPTION
Related:
- https://github.com/WordPress/gutenberg/issues/43241
- https://github.com/WordPress/gutenberg/issues/43242

## What?

Adopts the remaining typography supports for the Code block.

## Why?

- Improves consistency of our design tools across blocks.

## How?

- Opts into font family and text decoration supports

## Testing Instructions

1. Load the editor, add a code block and select it.
2. Test various typography settings, especially font family and text decoration.
3. Save and confirm application on the frontend.
4. Switch to the site editor and navigate to Global Styles > Blocks > Code > Typography and apply typography styles there.
5. Confirm the selected styles are reflected in the preview and on the frontend.

## Screenshots or screencast <!-- if applicable -->


https://user-images.githubusercontent.com/60436221/184842716-eef3bb4a-15b7-4bfa-a344-16651d85c995.mp4


