### PR TITLE
Comment Author Name: Add missing typography support

### DIFF
--- a/packages/block-library/src/comment-author-name/block.json
+++ b/packages/block-library/src/comment-author-name/block.json
@@ -43,7 +43,11 @@
 			"__experimentalFontWeight": true,
 			"__experimentalFontStyle": true,
 			"__experimentalTextTransform": true,
-			"__experimentalLetterSpacing": true
+			"__experimentalTextDecoration": true,
+			"__experimentalLetterSpacing": true,
+			"__experimentalDefaultControls": {
+				"fontSize": true
+			}
 		}
 	}
 }


### PR DESCRIPTION
Related:
- https://github.com/WordPress/gutenberg/issues/43241
- https://github.com/WordPress/gutenberg/issues/43242

## What?

Adds missing text-decoration support to the Comment Author Name.

## Why?

While there might not be a lot of value in text decoration styles for the comment author name block adding this helps us ensure consistent design tools across blocks.

## How?

- Opts into text decoration support.

## Testing Instructions

1. Load the block editor with a post containing comments
2. Add a comments block to the post and select the comment author's name
3. Confirm the text decoration control is now available within the Typography panel's ellipsis menu
4. Experiment with this control both with and without the "Link to author's URL" option toggled
5. Save and confirm the styles appear on the frontend
6. Test the new support works for the block via theme.json and global styles.

## Screenshots or screencast <!-- if applicable -->

https://user-images.githubusercontent.com/60436221/184846491-f532f1ce-caea-4125-98ef-8b5dad1aa6ba.mp4


