### PR TITLE
Comments Content: Add missing typography support

### DIFF
--- a/packages/block-library/src/comment-content/block.json
+++ b/packages/block-library/src/comment-content/block.json
@@ -29,7 +29,11 @@
 			"__experimentalFontWeight": true,
 			"__experimentalFontStyle": true,
 			"__experimentalTextTransform": true,
-			"__experimentalLetterSpacing": true
+			"__experimentalTextDecoration": true,
+			"__experimentalLetterSpacing": true,
+			"__experimentalDefaultControls": {
+				"fontSize": true
+			}
 		},
 		"spacing": {
 			"padding": [ "horizontal", "vertical" ],


### PR DESCRIPTION
Related:
- https://github.com/WordPress/gutenberg/issues/43241
- https://github.com/WordPress/gutenberg/issues/43242

## What?

Adds missing text-decoration support to the Comments Content block.

## Why?

While there might not be a lot of value in text-decoration styles for the comments content block, adding this helps us ensure consistent design tools across blocks.

## How?

- Opts into text decoration support.

## Testing Instructions

1. Load the block editor with a post containing comments
2. Add a comments block to the post and select the comment's content
3. Confirm the text decoration control is now available within the Typography panel's ellipsis menu
4. Experiment with typography settings
5. Save and confirm the styles appear on the frontend
6. Test the new support works for the block via theme.json and global styles.

## Screenshots or screencast <!-- if applicable -->


https://user-images.githubusercontent.com/60436221/184851683-04f79664-1d0d-4832-aeb0-fc305fad4d1b.mp4




