### PR TITLE
Comment Date: Add missing typography support

### DIFF
--- a/packages/block-library/src/comment-date/block.json
+++ b/packages/block-library/src/comment-date/block.json
@@ -35,6 +35,7 @@
 			"__experimentalFontWeight": true,
 			"__experimentalFontStyle": true,
 			"__experimentalTextTransform": true,
+			"__experimentalTextDecoration": true,
 			"__experimentalLetterSpacing": true,
 			"__experimentalDefaultControls": {
 				"fontSize": true


### PR DESCRIPTION
Related:
- https://github.com/WordPress/gutenberg/issues/43241
- https://github.com/WordPress/gutenberg/issues/43242

## What?

Adds missing text-decoration support to the Comment Date block.

## Why?

While there might not be a lot of value in text-decoration styles for the comment date block, adding this helps us ensure consistent design tools across blocks.

## How?

- Opts into text decoration support.

## Testing Instructions

1. Load the block editor with a post containing comments
2. Add a comments block to the post and select the comment's date
3. Confirm the text decoration control is now available within the Typography panel's ellipsis menu
4. Experiment with the typography settings
5. Save and confirm the styles appear on the frontend
6. Test the new support works for the block via theme.json and global styles.

## Screenshots or screencast <!-- if applicable -->

https://user-images.githubusercontent.com/60436221/184854263-74912ae6-8c10-4c37-811f-79d0798bb3b1.mp4


