### PR TITLE
Comment Edit Link: Add missing typography support

### DIFF
--- a/packages/block-library/src/comment-edit-link/block.json
+++ b/packages/block-library/src/comment-edit-link/block.json
@@ -35,7 +35,11 @@
 			"__experimentalFontWeight": true,
 			"__experimentalFontStyle": true,
 			"__experimentalTextTransform": true,
-			"__experimentalLetterSpacing": true
+			"__experimentalTextDecoration": true,
+			"__experimentalLetterSpacing": true,
+			"__experimentalDefaultControls": {
+				"fontSize": true
+			}
 		}
 	}
 }


### PR DESCRIPTION
Related:
- https://github.com/WordPress/gutenberg/issues/43241
- https://github.com/WordPress/gutenberg/issues/43242

## What?

- Adds missing text-decoration support to the Comment Edit Link.
- Makes font size a default control to match other text related blocks

## Why?

While there might not be a lot of value in text-decoration styles for the comment edit link, adding this helps us ensure consistent design tools across blocks.

## How?

- Opts into text decoration support.
- Makes font size a default control

## Testing Instructions

1. Load the block editor with a post containing comments
2. Add a comments block to the post and select the comment's edit link
3. Confirm font size is now displayed by default
4. Confirm the text decoration control is now available within the Typography panel's ellipsis menu
5. Experiment with the typography settings
6. Save and confirm the styles appear on the frontend
7. Test the new support works for the block via theme.json and global styles.

## Screenshots or screencast <!-- if applicable -->


https://user-images.githubusercontent.com/60436221/184860186-c8925e20-91e3-4f98-9da0-f1e3987f55de.mp4




