### PR TITLE
Comments Reply Link: Add missing typography support

### DIFF
--- a/packages/block-library/src/comment-reply-link/block.json
+++ b/packages/block-library/src/comment-reply-link/block.json
@@ -30,7 +30,11 @@
 			"__experimentalFontWeight": true,
 			"__experimentalFontStyle": true,
 			"__experimentalTextTransform": true,
-			"__experimentalLetterSpacing": true
+			"__experimentalTextDecoration": true,
+			"__experimentalLetterSpacing": true,
+			"__experimentalDefaultControls": {
+				"fontSize": true
+			}
 		},
 		"html": false
 	}


### PR DESCRIPTION
Related:
- https://github.com/WordPress/gutenberg/issues/43241
- https://github.com/WordPress/gutenberg/issues/43242

## What?

- Adds missing text-decoration support to the Comments Reply Link.
- Makes font size a default control to match other text-related blocks

## Why?

While there might not be a lot of value in text-decoration styles for the comment reply link, adding this helps us ensure consistent design tools across blocks.

## How?

- Opts into text decoration support.
- Makes font size a default control

## Testing Instructions

1. Load the block editor with a post containing comments
2. Add a comments block to the post and select the comment's reply link
3. Confirm font size is now displayed by default
4. Confirm the text decoration control is now available within the Typography panel's ellipsis menu
5. Experiment with the typography settings
6. Save and confirm the styles appear on the frontend
7. Test the new support works for the block via theme.json and global styles.

## Screenshots or screencast <!-- if applicable -->


https://user-images.githubusercontent.com/60436221/184861421-55334f02-ddde-42f5-80c3-086c87ddbe0e.mp4





