### PR TITLE
Comment Template: Adopt typography supports

### DIFF
--- a/docs/reference-guides/core-blocks.md
+++ b/docs/reference-guides/core-blocks.md
@@ -167,7 +167,7 @@ Contains the block elements used to display a comment, like the title, date, aut
 
 -	**Name:** core/comment-template
 -	**Category:** design
--	**Supports:** align, ~~html~~, ~~reusable~~
+-	**Supports:** align, typography (fontSize, lineHeight), ~~html~~, ~~reusable~~
 -	**Attributes:** 
 
 ## Comments

--- a/packages/block-library/src/comment-template/block.json
+++ b/packages/block-library/src/comment-template/block.json
@@ -11,7 +11,20 @@
 	"supports": {
 		"reusable": false,
 		"html": false,
-		"align": true
+		"align": true,
+		"typography": {
+			"fontSize": true,
+			"lineHeight": true,
+			"__experimentalFontFamily": true,
+			"__experimentalFontWeight": true,
+			"__experimentalFontStyle": true,
+			"__experimentalTextTransform": true,
+			"__experimentalTextDecoration": true,
+			"__experimentalLetterSpacing": true,
+			"__experimentalDefaultControls": {
+				"fontSize": true
+			}
+		}
 	},
 	"style": "wp-block-comment-template"
 }


### PR DESCRIPTION
Related:
- https://github.com/WordPress/gutenberg/issues/43241
- https://github.com/WordPress/gutenberg/issues/43242

## What?

Adopts all typography supports for the Comment Template block.

## Why?

- Improves consistency of our design tools across blocks.
- Allows typographic styles to be applied in one go to all the inner comment template blocks.

## How?

- Opts into all typography block supports.
- Makes the font size control displayed by default to match most common config.

## Testing Instructions

1. Open a post with comments in the editor, add a comments block and select it.
2. Confirm font size control is displayed by default. Then test various typography settings.
3. Save and confirm styling on the frontend.
4. Switch to the site editor and navigate to Global Styles > Blocks > Comment Template > Typography and apply typography styles there.
5. Confirm the selected styles are reflected in the preview and on the frontend.

## Screenshots or screencast <!-- if applicable -->

https://user-images.githubusercontent.com/60436221/184863927-5a4de816-4766-410c-81db-57f57cd593bf.mp4


