### PR TITLE
Fix popover glitch that results in incorrect toolbar positioning in site editor

### DIFF
--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -9,6 +9,7 @@
 ### Bug Fix
 
 -   `Popover`: fix and improve opening animation ([#43186](https://github.com/WordPress/gutenberg/pull/43186)).
+-   `Popover`: fix incorrect deps in hooks resulting in incorrect positioning after calling `update` ([#43267](https://github.com/WordPress/gutenberg/pull/43267/)).
 
 ### Enhancements
 

--- a/packages/components/src/popover/index.js
+++ b/packages/components/src/popover/index.js
@@ -405,7 +405,8 @@ const Popover = (
 		ownerDocument.addEventListener( 'scroll', update );
 
 		let updateFrameOffset;
-		if ( defaultView ) {
+		const hasFrameElement = !! ownerDocument?.defaultView?.frameElement;
+		if ( hasFrameElement ) {
 			updateFrameOffset = () => {
 				frameOffset.current = getFrameOffset( ownerDocument );
 				update();

--- a/packages/components/src/popover/index.js
+++ b/packages/components/src/popover/index.js
@@ -192,6 +192,10 @@ const Popover = (
 		}
 
 		return documentToReturn ?? document;
+
+		// 'reference' and 'refs.floating' are refs and don't need to be listed
+		// as dependencies (see https://github.com/WordPress/gutenberg/pull/41612)
+		// eslint-disable-next-line react-hooks/exhaustive-deps
 	}, [ anchorRef, anchorRect, getAnchorRect ] );
 
 	/**

--- a/packages/components/src/popover/index.js
+++ b/packages/components/src/popover/index.js
@@ -400,6 +400,7 @@ const Popover = (
 			};
 			updateFrameOffset();
 			defaultView.addEventListener( 'resize', updateFrameOffset );
+			update();
 		}
 
 		return () => {

--- a/packages/components/src/popover/index.js
+++ b/packages/components/src/popover/index.js
@@ -42,7 +42,11 @@ import { Path, SVG } from '@wordpress/primitives';
 import Button from '../button';
 import ScrollLock from '../scroll-lock';
 import { Slot, Fill, useSlot } from '../slot-fill';
-import { positionToPlacement, placementToMotionAnimationProps } from './utils';
+import {
+	getFrameOffset,
+	positionToPlacement,
+	placementToMotionAnimationProps,
+} from './utils';
 
 /**
  * Name of slot in which popover should fill.
@@ -117,15 +121,6 @@ const MaybeAnimatedWrapper = forwardRef(
 );
 
 const slotNameContext = createContext();
-
-const getFrameOffset = ( document ) => {
-	const frameElement = document?.defaultView?.frameElement;
-	if ( ! frameElement ) {
-		return;
-	}
-	const iframeRect = frameElement.getBoundingClientRect();
-	return { x: iframeRect.left, y: iframeRect.top };
-};
 
 const Popover = (
 	{

--- a/packages/components/src/popover/index.js
+++ b/packages/components/src/popover/index.js
@@ -397,10 +397,10 @@ const Popover = (
 			updateFrameOffset = () => {
 				const iframeRect = frameElement.getBoundingClientRect();
 				frameOffset.current = { x: iframeRect.left, y: iframeRect.top };
+				update();
 			};
 			updateFrameOffset();
 			defaultView.addEventListener( 'resize', updateFrameOffset );
-			update();
 		}
 
 		return () => {

--- a/packages/components/src/popover/index.js
+++ b/packages/components/src/popover/index.js
@@ -118,6 +118,15 @@ const MaybeAnimatedWrapper = forwardRef(
 
 const slotNameContext = createContext();
 
+const getFrameOffset = ( document ) => {
+	const frameElement = document?.defaultView?.frameElement;
+	if ( ! frameElement ) {
+		return;
+	}
+	const iframeRect = frameElement.getBoundingClientRect();
+	return { x: iframeRect.left, y: iframeRect.top };
+};
+
 const Popover = (
 	{
 		range,
@@ -191,7 +200,7 @@ const Popover = (
 	 * Store the offset in a ref, due to constraints with floating-ui:
 	 * https://floating-ui.com/docs/react-dom#variables-inside-middleware-functions.
 	 */
-	const frameOffset = useRef();
+	const frameOffset = useRef( getFrameOffset( ownerDocument ) );
 
 	const middleware = [
 		frameOffset.current || offset
@@ -388,15 +397,13 @@ const Popover = (
 		}
 
 		const { defaultView } = ownerDocument;
-		const { frameElement } = defaultView;
 
 		ownerDocument.addEventListener( 'scroll', update );
 
 		let updateFrameOffset;
-		if ( frameElement ) {
+		if ( defaultView ) {
 			updateFrameOffset = () => {
-				const iframeRect = frameElement.getBoundingClientRect();
-				frameOffset.current = { x: iframeRect.left, y: iframeRect.top };
+				frameOffset.current = getFrameOffset( ownerDocument );
 				update();
 			};
 			updateFrameOffset();

--- a/packages/components/src/popover/index.js
+++ b/packages/components/src/popover/index.js
@@ -364,7 +364,7 @@ const Popover = (
 			refs.floating.current,
 			update
 		);
-	}, [ anchorRef, anchorRect, getAnchorRect ] );
+	}, [ anchorRef, anchorRect, getAnchorRect, update ] );
 
 	// This is only needed for a smooth transition when moving blocks.
 	useLayoutEffect( () => {
@@ -377,7 +377,7 @@ const Popover = (
 		return () => {
 			observer.disconnect();
 		};
-	}, [ __unstableObserveElement ] );
+	}, [ __unstableObserveElement, update ] );
 
 	// If the reference element is in a different ownerDocument (e.g. iFrame),
 	// we need to manually update the floating's position as the reference's owner
@@ -409,7 +409,7 @@ const Popover = (
 				defaultView.removeEventListener( 'resize', updateFrameOffset );
 			}
 		};
-	}, [ ownerDocument ] );
+	}, [ ownerDocument, update ] );
 
 	const mergedFloatingRef = useMergeRefs( [
 		floating,

--- a/packages/components/src/popover/utils.js
+++ b/packages/components/src/popover/utils.js
@@ -81,3 +81,27 @@ export const placementToMotionAnimationProps = ( placement ) => {
 		transition: { duration: 0.1, ease: [ 0, 0, 0.2, 1 ] },
 	};
 };
+
+/**
+ * @typedef FrameOffset
+ * @type {Object}
+ * @property {number} x A numerical value representing the horizontal offset of the frame.
+ * @property {number} y A numerical value representing the vertical offset of the frame.
+ */
+
+/**
+ * Returns the offset of a document's frame element.
+ *
+ * @param {Document} document A document. This will usually be the document within an iframe.
+ *
+ * @return {FrameOffset|undefined} The offset of the document's frame element,
+ *                                 or undefined if the document has no frame element.
+ */
+export const getFrameOffset = ( document ) => {
+	const frameElement = document?.defaultView?.frameElement;
+	if ( ! frameElement ) {
+		return;
+	}
+	const iframeRect = frameElement.getBoundingClientRect();
+	return { x: iframeRect.left, y: iframeRect.top };
+};


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Fixes https://github.com/WordPress/gutenberg/pull/43172#issuecomment-1216383323

When scrolling in the site editor, the block toolbar jumps to the incorrect position.

The issue seems to be that `Popover` wasn't calling a fresh version of the `update` function when scrolling, it was calling an outdated version because `update` wasn't specified in the hook deps. The bug has been there since the initial refactor to floating-ui, but it has only become apparent since #43172.

Deeper explanation:
Since #43172, on the very first render of a `Popover`, `frameOffset` is undefined. The `update` function seems to be closing over or caching this `undefined` version of `frameOffset`, which results in the `frameOffset` becoming `undefined` again whenever `update` is triggered by the scroll event.

## How?

This fixes things by specifying `update` in the hook deps wherever it's needed.

After this change it mostly works. I still see a little glitchiness, and I think the solution would be to make sure the `offset` middleware has the correct `frameOffset` value on the very first render.

## Testing Instructions
1. Open the site editor (using a template that has enough content so that there's a scrollbar)
2. Select a block and scroll
3. The block toolbar should stay in the correct position.

## Screenshots or screencast <!-- if applicable -->
