### PR TITLE
[Docs] Replace useState with edit in useEntityRecord usage examples

### DIFF
--- a/packages/core-data/README.md
+++ b/packages/core-data/README.md
@@ -777,9 +777,12 @@ function PageRenameForm( { id } ) {
 	const { createSuccessNotice, createErrorNotice } =
 		useDispatch( noticeStore );
 
-	const setTitle = useCallback( ( title ) => {
-		page.edit( { title } );
-	} );
+	const setTitle = useCallback(
+		( title ) => {
+			page.edit( { title } );
+		},
+		[ page.edit ]
+	);
 
 	if ( page.isResolving ) {
 		return 'Loading...';

--- a/packages/core-data/README.md
+++ b/packages/core-data/README.md
@@ -779,7 +779,7 @@ function PageRenameForm( { id } ) {
 
 	const setTitle = useCallback( ( title ) => {
 		page.edit( { title } );
-	}, [ page.edit ] );
+	} );
 
 	if ( page.isResolving ) {
 		return 'Loading...';

--- a/packages/core-data/README.md
+++ b/packages/core-data/README.md
@@ -779,7 +779,7 @@ function PageRenameForm( { id } ) {
 
 	const setTitle = useCallback( ( title ) => {
 		page.edit( { title } );
-	} );
+	}, [ page.edit ] );
 
 	if ( page.isResolving ) {
 		return 'Loading...';

--- a/packages/core-data/README.md
+++ b/packages/core-data/README.md
@@ -765,8 +765,8 @@ application, the page and the resolution details will be retrieved from
 the store state using `getEntityRecord()`, or resolved if missing.
 
 ```js
-import { useState } from '@wordpress/data';
 import { useDispatch } from '@wordpress/data';
+import { useCallback } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import { TextControl } from '@wordpress/components';
 import { store as noticeStore } from '@wordpress/notices';
@@ -774,9 +774,12 @@ import { useEntityRecord } from '@wordpress/core-data';
 
 function PageRenameForm( { id } ) {
 	const page = useEntityRecord( 'postType', 'page', id );
-	const [ title, setTitle ] = useState( () => page.record.title.rendered );
 	const { createSuccessNotice, createErrorNotice } =
 		useDispatch( noticeStore );
+
+	const setTitle = useCallback( ( title ) => {
+		page.edit( { title } );
+	} );
 
 	if ( page.isResolving ) {
 		return 'Loading...';
@@ -784,7 +787,6 @@ function PageRenameForm( { id } ) {
 
 	async function onRename( event ) {
 		event.preventDefault();
-		page.edit( { title } );
 		try {
 			await page.save();
 			createSuccessNotice( __( 'Page renamed.' ), {
@@ -799,7 +801,7 @@ function PageRenameForm( { id } ) {
 		<form onSubmit={ onRename }>
 			<TextControl
 				label={ __( 'Name' ) }
-				value={ title }
+				value={ page.editedRecord.title }
 				onChange={ setTitle }
 			/>
 			<button type="submit">{ __( 'Save' ) }</button>

--- a/packages/core-data/src/hooks/use-entity-record.ts
+++ b/packages/core-data/src/hooks/use-entity-record.ts
@@ -98,7 +98,7 @@ export interface Options {
  *
  * 	const setTitle = useCallback( ( title ) => {
  * 		page.edit( { title } );
- * 	} );
+ * 	}, [ page.edit ] );
  *
  * 	if ( page.isResolving ) {
  * 		return 'Loading...';

--- a/packages/core-data/src/hooks/use-entity-record.ts
+++ b/packages/core-data/src/hooks/use-entity-record.ts
@@ -84,8 +84,8 @@ export interface Options {
  *
  * @example
  * ```js
- * import { useState } from '@wordpress/data';
  * import { useDispatch } from '@wordpress/data';
+ * import { useCallback } from '@wordpress/element';
  * import { __ } from '@wordpress/i18n';
  * import { TextControl } from '@wordpress/components';
  * import { store as noticeStore } from '@wordpress/notices';
@@ -93,9 +93,12 @@ export interface Options {
  *
  * function PageRenameForm( { id } ) {
  * 	const page = useEntityRecord( 'postType', 'page', id );
- * 	const [ title, setTitle ] = useState( () => page.record.title.rendered );
  * 	const { createSuccessNotice, createErrorNotice } =
  * 		useDispatch( noticeStore );
+ *
+ * 	const setTitle = useCallback( ( title ) => {
+ * 		page.edit( { title } );
+ * 	} );
  *
  * 	if ( page.isResolving ) {
  * 		return 'Loading...';
@@ -103,7 +106,6 @@ export interface Options {
  *
  * 	async function onRename( event ) {
  * 		event.preventDefault();
- * 		page.edit( { title } );
  * 		try {
  * 			await page.save();
  * 			createSuccessNotice( __( 'Page renamed.' ), {
@@ -118,7 +120,7 @@ export interface Options {
  * 		<form onSubmit={ onRename }>
  * 			<TextControl
  * 				label={ __( 'Name' ) }
- * 				value={ title }
+ * 				value={ page.editedRecord.title }
  * 				onChange={ setTitle }
  * 			/>
  * 			<button type="submit">{ __( 'Save' ) }</button>


### PR DESCRIPTION
## What?
The usage example added in [Add mutations data and helper functions to useEntityRecord](https://github.com/WordPress/gutenberg/pull/39595#discussion_r939951526) proposes storing updates via `useState`.  However, the new mutation helpers can store them directly in the entity record. This PR updates the example to do just that.

cc @gziolo 
