### PR TITLE
Jest Preset: Improve `is-plain-obj` transformation ignore

### DIFF
--- a/packages/jest-preset-default/CHANGELOG.md
+++ b/packages/jest-preset-default/CHANGELOG.md
@@ -6,6 +6,10 @@
 
 -   Increase the minimum Node.js version to 14 ([#43141](https://github.com/WordPress/gutenberg/pull/43141)).
 
+### Bug Fix
+
+-   Jest Preset: Improve `is-plain-obj` transformation ignore ([#43271](https://github.com/WordPress/gutenberg/pull/43271)).
+
 ## 8.5.1 (2022-08-12)
 
 ### Bug Fix

--- a/packages/jest-preset-default/jest-preset.js
+++ b/packages/jest-preset-default/jest-preset.js
@@ -29,5 +29,5 @@ module.exports = {
 	transform: {
 		'\\.[jt]sx?$': require.resolve( 'babel-jest' ),
 	},
-	transformIgnorePatterns: [ 'node_modules/(?!(is-plain-obj))' ],
+	transformIgnorePatterns: [ 'node_modules/(?:(?!is-plain-obj/).)*$' ],
 };

--- a/packages/scripts/CHANGELOG.md
+++ b/packages/scripts/CHANGELOG.md
@@ -6,6 +6,10 @@
 
 -   Increase the minimum Node.js version to 14 and minimum npm version to 6.14.4 ([#43141](https://github.com/WordPress/gutenberg/pull/43141)).
 
+### Bug Fix
+
+-   Jest Preset: Improve `is-plain-obj` transformation ignore ([#43271](https://github.com/WordPress/gutenberg/pull/43271)).
+
 ## 23.7.1 (2022-08-12)
 
 ### Bug Fix


### PR DESCRIPTION
## What?
This PR improves the `is-plain-obj` transform ignore rule, as a follow-up to #43179. See https://github.com/WordPress/gutenberg/issues/43132#issuecomment-1216498124

## Why?
We need to support the cases where `is-plain-obj` is a dependency of a package that is a dependency of a project that uses `@wordpress/scripts`.

## How?
We're making the regex more flexible so it would ignore node modules but `is-plain-obj`, regardless of where it is in the path.

## Testing Instructions
* Verify all unit tests still pass.
* See https://github.com/WordPress/gutenberg/issues/43132#issuecomment-1216267129 for additional testing