### PR TITLE
ESLint Plugin: Remove all rules targeting test files from recommended presets

### DIFF
--- a/packages/block-editor/src/components/duotone/components.js
+++ b/packages/block-editor/src/components/duotone/components.js
@@ -11,9 +11,9 @@ import { __unstableGetValuesFromColors as getValuesFromColors } from './index';
 /**
  * SVG and stylesheet needed for rendering the duotone filter.
  *
- * @param {Object}   props          Duotone props.
- * @param {string}   props.selector Selector to apply the filter to.
- * @param {string}   props.id       Unique id for this duotone filter.
+ * @param {Object} props          Duotone props.
+ * @param {string} props.selector Selector to apply the filter to.
+ * @param {string} props.id       Unique id for this duotone filter.
  *
  * @return {WPElement} Duotone element.
  */
@@ -29,8 +29,8 @@ ${ selector } {
 /**
  * Stylesheet for disabling a global styles duotone filter.
  *
- * @param {Object}   props          Duotone props.
- * @param {string}   props.selector Selector to disable the filter for.
+ * @param {Object} props          Duotone props.
+ * @param {string} props.selector Selector to disable the filter for.
  *
  * @return {WPElement} Filter none style element.
  */

--- a/packages/block-editor/src/hooks/duotone.js
+++ b/packages/block-editor/src/hooks/duotone.js
@@ -35,10 +35,10 @@ extend( [ namesPlugin ] );
 /**
  * SVG and stylesheet needed for rendering the duotone filter.
  *
- * @param {Object} props Duotone props.
- * @param {string} props.selector Selector to apply the filter to.
- * @param {string} props.id Unique id for this duotone filter.
- * @param {string[]|"unset"} props.colors Array of RGB color strings ordered from dark to light.
+ * @param {Object}           props          Duotone props.
+ * @param {string}           props.selector Selector to apply the filter to.
+ * @param {string}           props.id       Unique id for this duotone filter.
+ * @param {string[]|"unset"} props.colors   Array of RGB color strings ordered from dark to light.
  *
  * @return {WPElement} Duotone element.
  */

--- a/packages/docgen/lib/get-type-annotation.js
+++ b/packages/docgen/lib/get-type-annotation.js
@@ -394,7 +394,7 @@ function getTypeAnnotation( typeAnnotation ) {
  *
  * @param {ASTNode} token Contains either a function or a call to a function-wrapper.
  *
- * TODO: Remove the special-casing here once we're able to infer the types from TypeScript itself.
+ *                        TODO: Remove the special-casing here once we're able to infer the types from TypeScript itself.
  */
 function unwrapWrappedSelectors( token ) {
 	if ( babelTypes.isFunctionDeclaration( token ) ) {

--- a/packages/edit-site/src/components/global-styles/use-global-styles-output.js
+++ b/packages/edit-site/src/components/global-styles/use-global-styles-output.js
@@ -190,7 +190,7 @@ function flattenTree( input = {}, prefix, token ) {
  *
  * @param {boolean} useRootPaddingAlign Whether to use CSS custom properties in root selector.
  *
- * @param {Object}  tree				A theme.json tree containing layout definitions.
+ * @param {Object}  tree                A theme.json tree containing layout definitions.
  *
  * @return {Array} An array of style declarations.
  */

--- a/packages/eslint-plugin/CHANGELOG.md
+++ b/packages/eslint-plugin/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Breaking Change
 
 -   Increase the minimum Node.js version to 14 and minimum npm version to 6.14.4 ([#43141](https://github.com/WordPress/gutenberg/pull/43141)).
+-   Remove all rules targeting test files from the `recommended` and `recommended-with-formatting` presets when Jest package is installed ([#43272](https://github.com/WordPress/gutenberg/pull/43272)).
 
 ## 12.8.0 (2022-07-27)
 

--- a/packages/eslint-plugin/README.md
+++ b/packages/eslint-plugin/README.md
@@ -44,15 +44,15 @@ There is also `recommended-with-formatting` ruleset for projects that want to en
 
 Alternatively, you can opt-in to only the more granular rulesets offered by the plugin. These include:
 
--   `custom`
--   `es5`
--   `esnext`
--   `jsdoc`
--   `jsx-a11y`
--   `react`
--   `i18n`
--   `test-e2e`
--   `test-unit`
+-   `custom` – custom rules for WordPress development.
+-   `es5` – rules for legacy ES5 environments.
+-   `esnext` – rules for ES2015+ environments.
+-   `i18n` – rules for internationalization.
+-   `jsdoc` – rules for JSDoc comments.
+-   `jsx-a11y` – rules for accessibility in JSX.
+-   `react` – rules for React components.
+-   `test-e2e` – rules for end-to-end tests written in Puppeteer.
+-   `test-unit`– rules for unit tests written in Jest.
 
 For example, if your project does not use React, you could consider extending including only the ESNext rules in your project using the following `extends` definition:
 

--- a/packages/eslint-plugin/configs/recommended-with-formatting.js
+++ b/packages/eslint-plugin/configs/recommended-with-formatting.js
@@ -1,10 +1,5 @@
-/**
- * Internal dependencies
- */
-const { isPackageInstalled } = require( '../utils' );
-
 // Exclude bundled WordPress packages from the list.
-const wpPackagesRegExp = '^@wordpress/(?!(icons|interface))';
+const wpPackagesRegExp = '^@wordpress/(?!(icons|interface|style-engine))';
 
 const config = {
 	extends: [
@@ -44,24 +39,5 @@ const config = {
 		'import/named': 'warn',
 	},
 };
-
-// Don't apply Jest config if Playwright is installed.
-if (
-	isPackageInstalled( 'jest' ) &&
-	! isPackageInstalled( '@playwright/test' )
-) {
-	config.overrides = [
-		{
-			// Unit test files and their helpers only.
-			files: [ '**/@(test|__tests__)/**/*.js', '**/?(*.)test.js' ],
-			extends: [ require.resolve( './test-unit.js' ) ],
-		},
-		{
-			// End-to-end test files and their helpers only.
-			files: [ '**/specs/**/*.js', '**/?(*.)spec.js' ],
-			extends: [ require.resolve( './test-e2e.js' ) ],
-		},
-	];
-}
 
 module.exports = config;

--- a/packages/react-native-editor/__device-tests__/helpers/utils.js
+++ b/packages/react-native-editor/__device-tests__/helpers/utils.js
@@ -515,9 +515,9 @@ const waitForMediaLibrary = async ( driver ) => {
 /**
  * @param {string} driver
  * @param {string} elementLocator
- * @param {number} maxIteration - Default value is 25
+ * @param {number} maxIteration    - Default value is 25
  * @param {string} elementToReturn - Options are allElements, lastElement, firstElement. Defaults to "firstElement"
- * @param {number} iteration - Default value is 0
+ * @param {number} iteration       - Default value is 0
  * @return {string} - Returns the first element found, empty string if not found
  */
 const waitForVisible = async (
@@ -567,7 +567,7 @@ const waitForVisible = async (
 /**
  * @param {string} driver
  * @param {string} elementLocator
- * @param {number} maxIteration - Default value is 25, can be adjusted to be less to wait for element to not be visible
+ * @param {number} maxIteration    - Default value is 25, can be adjusted to be less to wait for element to not be visible
  * @param {string} elementToReturn - Options are allElements, lastElement, firstElement. Defaults to "firstElement"
  * @return {boolean} - Returns true if element is found, false otherwise
  */

--- a/packages/scripts/CHANGELOG.md
+++ b/packages/scripts/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Breaking Change
 
 -   Increase the minimum Node.js version to 14 and minimum npm version to 6.14.4 ([#43141](https://github.com/WordPress/gutenberg/pull/43141)).
+-   The bundled `@wordpress/eslint-plugin` package got updated to the new major version and the default linting for Jest unit tests is now handled in the default config in this package ([#43272](https://github.com/WordPress/gutenberg/pull/43272)).
 
 ## 23.7.1 (2022-08-12)
 

--- a/packages/scripts/config/.eslintrc.js
+++ b/packages/scripts/config/.eslintrc.js
@@ -6,6 +6,13 @@ const { hasBabelConfig } = require( '../utils' );
 const eslintConfig = {
 	root: true,
 	extends: [ 'plugin:@wordpress/eslint-plugin/recommended' ],
+	overrides: [
+		{
+			// Unit test files and their helpers only.
+			files: [ '**/@(test|__tests__)/**/*.js', '**/?(*.)test.js' ],
+			extends: [ 'plugin:@wordpress/eslint-plugin/test-unit' ],
+		},
+	],
 };
 
 if ( ! hasBabelConfig() ) {

--- a/packages/style-engine/src/styles/utils.ts
+++ b/packages/style-engine/src/styles/utils.ts
@@ -51,11 +51,11 @@ export function generateRule(
 /**
  * Returns a JSON representation of the generated CSS rules taking into account box model properties, top, right, bottom, left.
  *
- * @param style                Style object.
- * @param options              Options object with settings to adjust how the styles are generated.
- * @param path                 An array of strings representing the path to the style value in the style object.
- * @param ruleKeys             An array of CSS property keys and patterns.
- * @param individualProperties The "sides" or individual properties for which to generate rules.
+ * @param  style                Style object.
+ * @param  options              Options object with settings to adjust how the styles are generated.
+ * @param  path                 An array of strings representing the path to the style value in the style object.
+ * @param  ruleKeys             An array of CSS property keys and patterns.
+ * @param  individualProperties The "sides" or individual properties for which to generate rules.
  *
  * @return GeneratedCSSRule[]  CSS rules.
  */


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Follow up for #38570.
Fixes https://github.com/WordPress/gutenberg/issues/42952.

This PR ensures that rules for e2e tests are no longer applied by default when using the recommended config from `@wordpress/eslint-plugin` or with `@wordpress/scripts`. We are in the transition phase where both Playwright and Puppeteer are in use. In addition to that, the old config conflicts in the project that use different tooling like Cypress.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

From #42952.

> Using WP-Scripts in combination with Cypress for E2E testing will result in false positives for Jest related rules as the Jest config is unable to pick up Cypress assertions.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

I removed all rules covering Jest test framework from the recommended settings in `@wordpress/eslint-plugin`: `recommended` and `recommended-with-formatting`.

I expanded the existing documentation in the README file in `@wordpress/eslint-plugin` for the rulesets in case someone wants to enable those rules in their project.

I ensured that rules for unit tests are enabled by default in WP projects only when using `@wordpress/scripts`. This avoids conflicts with tests written for the Playwright in the Gutenberg plugin that match the same pattern.