### PR TITLE
Components: Refactor `withSpokenMessages` tests to `@testing-library`

### DIFF
--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -26,6 +26,7 @@
 -   `DateTimePicker`, `TimePicker`, `DatePicker`: Switch from `moment` to `date-fns` ([#43005](https://github.com/WordPress/gutenberg/pull/43005)).
 -   `DatePicker`: Switch from `react-dates` to `use-lilius` ([#43005](https://github.com/WordPress/gutenberg/pull/43005)).
 -   `convertLTRToRTL()`: Refactor away from `_.mapKeys()` ([#43258](https://github.com/WordPress/gutenberg/pull/43258/)).
+-   `withSpokenMessages`: Update to use `@testing-library/react` ([#43273](https://github.com/WordPress/gutenberg/pull/43273)).
 -   `FormTokenField`: Refactor away from `_.uniq()` ([#43330](https://github.com/WordPress/gutenberg/pull/43330/)).
 -   `contextConnect`: Refactor away from `_.uniq()` ([#43330](https://github.com/WordPress/gutenberg/pull/43330/)).
 -   `ColorPalette`: Refactor away from `_.uniq()` ([#43330](https://github.com/WordPress/gutenberg/pull/43330/)).

--- a/packages/components/src/higher-order/with-spoken-messages/test/index.js
+++ b/packages/components/src/higher-order/with-spoken-messages/test/index.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { render } from 'enzyme';
+import { render } from '@testing-library/react';
 
 /**
  * Internal dependencies


### PR DESCRIPTION
_Are you ready to see the smallest `enzyme` to `@testing-library/react` migration PR?_ 

## What?
This PR refactors the tests of `withSpokenMessages` HoC from `enzyme` to `@testing-library/react`

## Why?
We've been aiming to have all our component tests resemble user behavior as much as possible, so this is a step in that direction.

## How?
We're just updating the test to use a different `render` function, the rest is fine as-is.

## Testing Instructions
Verify tests still pass: `npm run test:unit packages/components/src/higher-order/with-spoken-messages/test/index.js`