### PR TITLE
taxonomy-controls.js: Change REST context to "view" when fetching taxonomy terms.

### DIFF
--- a/packages/block-library/src/query/edit/inspector-controls/taxonomy-controls.js
+++ b/packages/block-library/src/query/edit/inspector-controls/taxonomy-controls.js
@@ -38,7 +38,7 @@ export const useTaxonomiesInfo = ( postType ) => {
 	const taxonomiesInfo = useSelect(
 		( select ) => {
 			const { getEntityRecords } = select( coreStore );
-			const termsQuery = { per_page: MAX_FETCHED_TERMS };
+			const termsQuery = { context: 'view', per_page: MAX_FETCHED_TERMS };
 			const _taxonomiesInfo = taxonomies?.map( ( { slug, name } ) => {
 				const _terms = getEntityRecords( 'taxonomy', slug, termsQuery );
 				return {


### PR DESCRIPTION
## What?
taxonomy-controls.js: Change REST context to "view" when fetching taxonomy terms.

## Why?
When the **query-loop** block is used for a post type and a custom taxonomy exists but `edit_terms` permission isn't granted,
the following request is issued `/wp-json/wp/v2/my_taxonomy?per_page=100&context=`**`edit`** resulting in a **403** and keeping the
taxonomy selector to appear although it's just a read operation on terms.

## How?
Changing `getEntityRecords( 'taxonomy', slug, termsQuery );` to pass `context=view`

## Testing Instructions
1. Create a new, restricted taxonomy, associated with `post` having particular permissions:
```
                'capabilities'      => [
                    'manage_terms' => '',
                    'edit_terms'   => '',
                    'delete_terms' => '',
                    'assign_terms' => 'edit_posts',
                ],
```
2. Open a Post or Page
3. Insert a Query Loop
4. The taxonomy does not appear without this change.

## Somehow related
Not unlike #37368 or #33569 and related to #33003 / #37489