### PR TITLE
Block Editor: Replace `aria-owns` with `aria-controls` in `URLInput`

### DIFF
--- a/packages/block-editor/src/components/link-control/test/index.js
+++ b/packages/block-editor/src/components/link-control/test/index.js
@@ -88,9 +88,9 @@ function getURLInput() {
 
 function getSearchResults( container ) {
 	const input = getURLInput();
-	// The input has `aria-owns` to indicate that it owns (and is related to)
+	// The input has `aria-controls` to indicate that it owns (and is related to)
 	// the search results with `role="listbox"`.
-	const relatedSelector = input.getAttribute( 'aria-owns' );
+	const relatedSelector = input.getAttribute( 'aria-controls' );
 
 	// Select by relationship as well as role.
 	return container.querySelectorAll(

--- a/packages/block-editor/src/components/url-input/index.js
+++ b/packages/block-editor/src/components/url-input/index.js
@@ -462,7 +462,7 @@ class URLInput extends Component {
 			'aria-label': label ? undefined : __( 'URL' ), // Ensure input always has an accessible label
 			'aria-expanded': showSuggestions,
 			'aria-autocomplete': 'list',
-			'aria-owns': suggestionsListboxId,
+			'aria-controls': suggestionsListboxId,
 			'aria-activedescendant':
 				selectedSuggestion !== null
 					? `${ suggestionOptionIdPrefix }-${ selectedSuggestion }`


### PR DESCRIPTION
## What?
Replace `aria-owns` with `aria-controls` as per [this suggestion](https://github.com/WordPress/gutenberg/pull/43147#discussion_r945498693).

## Why?
In the newest ARIA specs, the recommended property for comboboxes is `aria-controls`.

## How?
We're simply replacing `aria-owns` with `aria-controls` and updating a test.

## Testing Instructions
Verify all tests still pass.
