### PR TITLE
Block Editor: Remove `aria-selected` from `LinkPreview`

### DIFF
--- a/packages/block-editor/src/components/link-control/link-preview.js
+++ b/packages/block-editor/src/components/link-control/link-preview.js
@@ -60,7 +60,6 @@ export default function LinkPreview( {
 	return (
 		<div
 			aria-label={ __( 'Currently selected' ) }
-			aria-selected="true"
 			className={ classnames( 'block-editor-link-control__search-item', {
 				'is-current': true,
 				'is-rich': hasRichData,
@@ -68,7 +67,6 @@ export default function LinkPreview( {
 				'is-preview': true,
 				'is-error': isEmptyURL,
 			} ) }
-			role="option"
 		>
 			<div className="block-editor-link-control__search-item-top">
 				<span className="block-editor-link-control__search-item-header">

--- a/packages/block-editor/src/components/link-control/link-preview.js
+++ b/packages/block-editor/src/components/link-control/link-preview.js
@@ -68,6 +68,7 @@ export default function LinkPreview( {
 				'is-preview': true,
 				'is-error': isEmptyURL,
 			} ) }
+			role="option"
 		>
 			<div className="block-editor-link-control__search-item-top">
 				<span className="block-editor-link-control__search-item-header">

--- a/packages/block-editor/src/components/link-control/test/index.js
+++ b/packages/block-editor/src/components/link-control/test/index.js
@@ -283,8 +283,8 @@ describe( 'Basic rendering', () => {
 				/>
 			);
 
-			const linkPreview = screen.queryByRole( 'generic', {
-				name: 'Currently selected',
+			const linkPreview = screen.queryByRole( 'option', {
+				selected: true,
 			} );
 
 			const isPreviewError = linkPreview.classList.contains( 'is-error' );

--- a/packages/block-editor/src/components/link-control/test/index.js
+++ b/packages/block-editor/src/components/link-control/test/index.js
@@ -283,9 +283,7 @@ describe( 'Basic rendering', () => {
 				/>
 			);
 
-			const linkPreview = screen.queryByRole( 'option', {
-				selected: true,
-			} );
+			const linkPreview = getCurrentLink();
 
 			const isPreviewError = linkPreview.classList.contains( 'is-error' );
 			expect( isPreviewError ).toBe( true );


### PR DESCRIPTION
## What?
This PR removes `aria-selected` from the `LinkPreview` component as discussed in [here](https://github.com/WordPress/gutenberg/pull/43147#discussion_r945459705) and later in this PR.

## Why?
Using `aria-selected` should not be used without a role according to the [guidelines](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-selected#associated_roles).

## How?
We're specifically removing `aria-selected` and reflecting the change in a test.

## Testing Instructions
Verify all tests still pass.