### PR TITLE
Mark which attributes of the image should be considered content

### DIFF
--- a/packages/block-library/src/image/block.json
+++ b/packages/block-library/src/image/block.json
@@ -16,31 +16,36 @@
 			"type": "string",
 			"source": "attribute",
 			"selector": "img",
-			"attribute": "src"
+			"attribute": "src",
+			"__experimentalRole": "content"
 		},
 		"alt": {
 			"type": "string",
 			"source": "attribute",
 			"selector": "img",
 			"attribute": "alt",
-			"default": ""
+			"default": "",
+			"__experimentalRole": "content"
 		},
 		"caption": {
 			"type": "string",
 			"source": "html",
-			"selector": "figcaption"
+			"selector": "figcaption",
+			"__experimentalRole": "content"
 		},
 		"title": {
 			"type": "string",
 			"source": "attribute",
 			"selector": "img",
-			"attribute": "title"
+			"attribute": "title",
+			"__experimentalRole": "content"
 		},
 		"href": {
 			"type": "string",
 			"source": "attribute",
 			"selector": "figure > a",
-			"attribute": "href"
+			"attribute": "href",
+			"__experimentalRole": "content"
 		},
 		"rel": {
 			"type": "string",
@@ -55,7 +60,8 @@
 			"attribute": "class"
 		},
 		"id": {
-			"type": "number"
+			"type": "number",
+			"__experimentalRole": "content"
 		},
 		"width": {
 			"type": "number"


### PR DESCRIPTION
Related https://github.com/WordPress/gutenberg/pull/43037 https://github.com/WordPress/gutenberg/pull/43038

This PR marks which attributes of the image block should be considered content. This affects two features:

- The ongoing https://github.com/WordPress/gutenberg/pull/43037 By adding these markers the image block will be listed in the ListView when the "content lock" is active.
- The "transform to patterns" feature. This PR changes how certain fields are treated.
  - Before: all user-edited attributes are migrated, including style ones such as border radius.
  - After: only the content attributes of the block are migrated.

Before (the radius set by the user is maintained) | After (the radius set by the user is ignored)
--- | ---
<video src="https://user-images.githubusercontent.com/583546/184936933-43361316-efc7-4e8e-afcd-a2ed42ff2b8f.webm" /> | <video src="https://user-images.githubusercontent.com/583546/184936969-02b0d60b-c96e-465e-b270-1aa52326923a.webm" />
