### PR TITLE
Manually update changelog and package.json from release automation

### DIFF
--- a/packages/env/CHANGELOG.md
+++ b/packages/env/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## Unreleased
 
+## 5.2.0 (2022-08-16)
+
+### Enhancement
+-   Query parameters can now be used in .zip source URLs.
+
 ## 5.1.1 (2022-08-16)
 
 ### Bug Fix

--- a/packages/env/package.json
+++ b/packages/env/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@wordpress/env",
-	"version": "5.2.0-prerelease",
+	"version": "5.2.0",
 	"description": "A zero-config, self contained local WordPress environment for development and testing.",
 	"author": "The WordPress Contributors",
 	"license": "GPL-2.0-or-later",

--- a/packages/env/package.json
+++ b/packages/env/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@wordpress/env",
-	"version": "5.1.1",
+	"version": "5.2.0-prerelease",
 	"description": "A zero-config, self contained local WordPress environment for development and testing.",
 	"author": "The WordPress Contributors",
 	"license": "GPL-2.0-or-later",


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
In a recent package update, I had updated the changelog for the package I was updating in the wp/latest branch. (I thought this would work according to the docs!) However, since I did that, there was a merge conflict and it couldn't merge that change back to trunk.

This PR manually copies those commits over to trunk by cherry picking them from https://github.com/WordPress/gutenberg/commits/wp/latest and manually resolving the merge conflicts.

