### PR TITLE
[Block Library - Query Loop]: Update posts list variation

### DIFF
--- a/packages/block-library/src/query/variations.js
+++ b/packages/block-library/src/query/variations.js
@@ -34,9 +34,7 @@ const variations = [
 	{
 		name: 'posts-list',
 		title: __( 'Posts List' ),
-		description: __(
-			'Display a list of your most recent posts, excluding sticky posts.'
-		),
+		description: __( 'Display a list of your posts.' ),
 		icon: postList,
 		attributes: {
 			query: {
@@ -52,6 +50,8 @@ const variations = [
 				inherit: false,
 			},
 		},
+		isActive: ( blockAttributes ) =>
+			blockAttributes.query.postType === 'post',
 		scope: [ 'inserter' ],
 	},
 	{


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Related: https://github.com/WordPress/gutenberg/issues/40941, https://github.com/WordPress/gutenberg/issues/42533

Right now we have only one variation that is exposed to the inserter(Posts List) for Query Loop block. This block uses patterns and scope block variations  and we face a couple of problems here:
1.  Patterns and the scope block variations have different attributes and this results to override the Posts List variation attributes. 
2. Right after the insertion of `Posts List` variation the block cannot detect if has an active variation, changing its display name to Query Loop.

This PR handles for now only the second part by adding an `isActive` prop when the postType is `post`. I think differentiating variations based only their `postType` is enough for now, because many query attributes can change(order, orderBy, etc..) which shouldn't affect the main description of the block. Later on we need to explore how to conditionally hide/add controls declaratively and with that we should revisit the `isActive` conditions.

## Testing instructions
1. Insert a Posts List block and observe its display name changes only when we change the post type.

