### PR TITLE
[Block Library - Query Loop]: Honour intended post type when previewing patterns and when replacing with patterns

### DIFF
--- a/packages/block-library/src/post-template/block.json
+++ b/packages/block-library/src/post-template/block.json
@@ -12,7 +12,8 @@
 		"query",
 		"queryContext",
 		"displayLayout",
-		"templateSlug"
+		"templateSlug",
+		"previewPostType"
 	],
 	"supports": {
 		"reusable": false,

--- a/packages/block-library/src/post-template/edit.js
+++ b/packages/block-library/src/post-template/edit.js
@@ -89,6 +89,7 @@ export default function PostTemplateEdit( {
 		queryContext = [ { page: 1 } ],
 		templateSlug,
 		displayLayout: { type: layoutType = 'flex', columns = 1 } = {},
+		previewPostType,
 	},
 } ) {
 	const [ { page } ] = queryContext;
@@ -156,8 +157,11 @@ export default function PostTemplateEdit( {
 					postType = query.postType;
 				}
 			}
+			// When we preview Query Loop blocks we should prefer the current
+			// block's postType, which is passed through block context.
+			const usedPostType = previewPostType || postType;
 			return {
-				posts: getEntityRecords( 'postType', postType, query ),
+				posts: getEntityRecords( 'postType', usedPostType, query ),
 				blocks: getBlocks( clientId ),
 			};
 		},
@@ -177,6 +181,7 @@ export default function PostTemplateEdit( {
 			templateSlug,
 			taxQuery,
 			parents,
+			previewPostType,
 		]
 	);
 	const blockContexts = useMemo(

--- a/packages/block-library/src/query/edit/index.js
+++ b/packages/block-library/src/query/edit/index.js
@@ -2,7 +2,7 @@
  * WordPress dependencies
  */
 import { useSelect, useDispatch } from '@wordpress/data';
-import { store as blocksStore, cloneBlock } from '@wordpress/blocks';
+import { store as blocksStore } from '@wordpress/blocks';
 import { useInstanceId } from '@wordpress/compose';
 import { useState, useEffect } from '@wordpress/element';
 import {
@@ -30,7 +30,7 @@ import QueryToolbar from './query-toolbar';
 import QueryInspectorControls from './inspector-controls';
 import QueryPlaceholder from './query-placeholder';
 import { DEFAULTS_POSTS_PER_PAGE } from '../constants';
-import { getFirstQueryClientIdFromBlocks } from '../utils';
+import { getTransformedBlocksFromPattern } from '../utils';
 
 const TEMPLATE = [ [ 'core/post-template' ] ];
 export function QueryContent( {
@@ -177,6 +177,7 @@ function QueryPatternSetup( {
 			<QueryPlaceholder
 				clientId={ clientId }
 				name={ name }
+				attributes={ attributes }
 				setAttributes={ setAttributes }
 				icon={ icon }
 				label={ label }
@@ -215,7 +216,7 @@ function QueryPatternSetup( {
 }
 
 const QueryEdit = ( props ) => {
-	const { clientId, name } = props;
+	const { clientId, name, attributes } = props;
 	const [ isPatternSelectionModalOpen, setIsPatternSelectionModalOpen ] =
 		useState( false );
 	const { replaceBlock, selectBlock } = useDispatch( blockEditorStore );
@@ -226,12 +227,13 @@ const QueryEdit = ( props ) => {
 	);
 	const Component = hasInnerBlocks ? QueryContent : QueryPatternSetup;
 	const onBlockPatternSelect = ( blocks ) => {
-		const clonedBlocks = blocks.map( ( block ) => cloneBlock( block ) );
-		const firstQueryClientId =
-			getFirstQueryClientIdFromBlocks( clonedBlocks );
-		replaceBlock( clientId, clonedBlocks );
-		if ( firstQueryClientId ) {
-			selectBlock( firstQueryClientId );
+		const { newBlocks, queryClientIds } = getTransformedBlocksFromPattern(
+			blocks,
+			attributes
+		);
+		replaceBlock( clientId, newBlocks );
+		if ( queryClientIds[ 0 ] ) {
+			selectBlock( queryClientIds[ 0 ] );
 		}
 	};
 	return (

--- a/packages/block-library/src/query/edit/index.js
+++ b/packages/block-library/src/query/edit/index.js
@@ -4,9 +4,10 @@
 import { useSelect, useDispatch } from '@wordpress/data';
 import { store as blocksStore } from '@wordpress/blocks';
 import { useInstanceId } from '@wordpress/compose';
-import { useState, useEffect } from '@wordpress/element';
+import { useState, useEffect, useMemo } from '@wordpress/element';
 import {
 	BlockControls,
+	BlockContextProvider,
 	InspectorControls,
 	useBlockProps,
 	useSetting,
@@ -236,6 +237,14 @@ const QueryEdit = ( props ) => {
 			selectBlock( queryClientIds[ 0 ] );
 		}
 	};
+	// When we preview Query Loop blocks we should prefer the current
+	// block's postType, which is passed through block context.
+	const blockPreviewContext = useMemo(
+		() => ( {
+			previewPostType: attributes.query.postType,
+		} ),
+		[ attributes.query.postType ]
+	);
 	return (
 		<>
 			<Component
@@ -253,11 +262,13 @@ const QueryEdit = ( props ) => {
 						setIsPatternSelectionModalOpen( false )
 					}
 				>
-					<BlockPatternSetup
-						blockName={ name }
-						clientId={ clientId }
-						onBlockPatternSelect={ onBlockPatternSelect }
-					/>
+					<BlockContextProvider value={ blockPreviewContext }>
+						<BlockPatternSetup
+							blockName={ name }
+							clientId={ clientId }
+							onBlockPatternSelect={ onBlockPatternSelect }
+						/>
+					</BlockContextProvider>
 				</Modal>
 			) }
 		</>

--- a/packages/block-library/src/query/edit/query-placeholder.js
+++ b/packages/block-library/src/query/edit/query-placeholder.js
@@ -12,7 +12,14 @@ import {
 	store as blocksStore,
 } from '@wordpress/blocks';
 
-function QueryPlaceholder( { clientId, name, setAttributes, icon, label } ) {
+function QueryPlaceholder( {
+	clientId,
+	name,
+	attributes,
+	setAttributes,
+	icon,
+	label,
+} ) {
 	const { defaultVariation, scopeVariations } = useSelect(
 		( select ) => {
 			const {
@@ -39,7 +46,15 @@ function QueryPlaceholder( { clientId, name, setAttributes, icon, label } ) {
 				variations={ scopeVariations }
 				onSelect={ ( nextVariation = defaultVariation ) => {
 					if ( nextVariation.attributes ) {
-						setAttributes( nextVariation.attributes );
+						setAttributes( {
+							...nextVariation.attributes,
+							query: {
+								...nextVariation.attributes.query,
+								postType:
+									attributes.query.postType ||
+									nextVariation.attributes.query.postType,
+							},
+						} );
 					}
 					if ( nextVariation.innerBlocks ) {
 						replaceInnerBlocks(

--- a/packages/block-library/src/query/utils.js
+++ b/packages/block-library/src/query/utils.js
@@ -13,12 +13,6 @@ import { decodeEntities } from '@wordpress/html-entities';
 import { cloneBlock } from '@wordpress/blocks';
 
 /**
- * @typedef TransformedBlocksFromPattern
- * @property {WPBlock[]} newBlocks      The cloned/transformed blocks.
- * @property {string[]}  queryClientIds All the Query Loop clients from `newBlocks`.
- */
-
-/**
  * @typedef IHasNameAndId
  * @property {string|number} id   The entity's id.
  * @property {string}        name The entity's name.
@@ -145,7 +139,7 @@ export const useTaxonomies = ( postType ) => {
  *
  * @param {WPBlock[]}        blocks               The list of blocks to look through and transform(mutate).
  * @param {Record<string,*>} queryBlockAttributes The existing Query Loop's attributes.
- * @return {TransformedBlocksFromPattern} The first found Query Loop's clientId.
+ * @return {{ newBlocks: WPBlock[], queryClientIds: string[] }} An object with the cloned/transformed blocks and all the Query Loop clients from these blocks.
  */
 export const getTransformedBlocksFromPattern = (
 	blocks,


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Part of: https://github.com/WordPress/gutenberg/issues/42533

From the issue:
>Currently in Query Loop and Template Parts we use the pattern setup flow, where a user can choose and insert directly a semantic pattern or some default block variation(scope: block).

> The problem here is that patterns and the scope block variations have different attributes and this results to override the Posts List variation attributes.

>The problem is for any block that uses pattern setup flow like Template Part, but is not visible there because that block's variations only contain the area attribute which is also the one used in calculating the active variation(in isActive function).

>We need to find a good way to preserve some important attributes(or part of them if is an object like query) and in general make sure that these retained attributes do no affect the presentation/design.

>This also applies to the `replace` with pattern flow.
<!-- In a few words, what is the PR actually doing? -->





## How?
This PR doesn't explore some generic solution(we might not even need one) as Query Loop is quite complex and I think it's okay to have some specific handling to accommodate this, and also become a lot more flexible and open to extension by third parties in the future.

In the pattern setup and replace flow, and the block variations(`scope`) flow I'm updating the Query Loop blocks to be inserted by retaining the existing `query.postType` and `query.inherit` options. These two properties are fundamental for the expected functionality of the block and don't affect its design and presentation.

What this means in practice is that if we have a Query Loop with `postType: product` and choose to `replace` with another patterns(we want to update the design), the `postType and inherit` properties will be retained.

<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

## Testing Instructions
#### Replace flow
1. In a Query Loop change the `postType` to anything than `post`, as is the one used by most patterns.
2. Click `replace` in block toolbar and select another pattern
3. Observe that `postType and inherit` are retained.

#### Scope block variations
1. Update the postType to something else(ex `page`) to the Posts List (inserter) variation [here](https://github.com/WordPress/gutenberg/blob/trunk/packages/block-library/src/query/variations.js#L46).
2. Insert a `Posts List` block and choose `start blank`.
3. Select any of them and observe that the `postType` is retained

## Screenshots or screencast <!-- if applicable -->


https://user-images.githubusercontent.com/16275880/185621050-63a6ae85-2b30-45ee-aad2-138dad8f82ee.mov



