### PR TITLE
Comments: Add typography support

### DIFF
--- a/docs/reference-guides/core-blocks.md
+++ b/docs/reference-guides/core-blocks.md
@@ -176,7 +176,7 @@ An advanced block that allows displaying post comments using different visual co
 
 -	**Name:** core/comments
 -	**Category:** theme
--	**Supports:** align (full, wide), color (background, gradients, link, text), ~~html~~
+-	**Supports:** align (full, wide), color (background, gradients, link, text), typography (fontSize, lineHeight), ~~html~~
 -	**Attributes:** legacy, tagName
 
 ## Comments Pagination

--- a/packages/block-library/src/comments/block.json
+++ b/packages/block-library/src/comments/block.json
@@ -27,6 +27,19 @@
 				"text": true,
 				"link": true
 			}
+		},
+		"typography": {
+			"fontSize": true,
+			"lineHeight": true,
+			"__experimentalFontFamily": true,
+			"__experimentalFontWeight": true,
+			"__experimentalFontStyle": true,
+			"__experimentalTextTransform": true,
+			"__experimentalTextDecoration": true,
+			"__experimentalLetterSpacing": true,
+			"__experimentalDefaultControls": {
+				"fontSize": true
+			}
 		}
 	},
 	"editorStyle": "wp-block-comments-editor",


### PR DESCRIPTION
Related:
- https://github.com/WordPress/gutenberg/issues/43241
- https://github.com/WordPress/gutenberg/issues/43242

## What?

Adds typography support to the Comments block.

## Why?

- Improves consistency of our design tools across blocks.
- Adds higher level typography styling for the inner blocks of the Comments block.

## How?

- Opts into all typography supports.
- Only the font size control will display by default.

## Testing Instructions

1. Load the editor, add a Comments block and select it.
2. Test various typography settings ensuring styles are applied in the editor.
3. Save and confirm application on the frontend.
4. Switch to the site editor, select a page or template with a Comments block.
5. Navigate to Global Styles > Blocks > Comments > Typography and apply typography styles there.
6. Confirm the selected styles are reflected in the preview and on the frontend.

## Screenshots or screencast <!-- if applicable -->

https://user-images.githubusercontent.com/60436221/185009234-af5ef6dc-8865-4368-959b-006a0d751a44.mp4


