### PR TITLE
Comments Pagination: Add typography support

### DIFF
--- a/docs/reference-guides/core-blocks.md
+++ b/docs/reference-guides/core-blocks.md
@@ -185,7 +185,7 @@ Displays a paginated navigation to next/previous set of comments, when applicabl
 
 -	**Name:** core/comments-pagination
 -	**Category:** theme
--	**Supports:** align, color (background, gradients, link, text), ~~html~~, ~~reusable~~
+-	**Supports:** align, color (background, gradients, link, text), typography (fontSize, lineHeight), ~~html~~, ~~reusable~~
 -	**Attributes:** paginationArrow
 
 ## Next Page

--- a/packages/block-library/src/comments-pagination/block.json
+++ b/packages/block-library/src/comments-pagination/block.json
@@ -35,6 +35,19 @@
 			"default": {
 				"type": "flex"
 			}
+		},
+		"typography": {
+			"fontSize": true,
+			"lineHeight": true,
+			"__experimentalFontFamily": true,
+			"__experimentalFontWeight": true,
+			"__experimentalFontStyle": true,
+			"__experimentalTextTransform": true,
+			"__experimentalTextDecoration": true,
+			"__experimentalLetterSpacing": true,
+			"__experimentalDefaultControls": {
+				"fontSize": true
+			}
 		}
 	},
 	"editorStyle": "wp-block-comments-pagination-editor",


### PR DESCRIPTION
Related:
- https://github.com/WordPress/gutenberg/issues/43241
- https://github.com/WordPress/gutenberg/issues/43242

## What?

Adds typography support to the Comments Pagination block.

## Why?

- Improves consistency of our design tools across blocks.
- Adds higher level typography styling for the inner blocks of the Comments Pagination block.

## How?

- Opts into all typography supports.
- Only the font size control will display by default.

## Testing Instructions

1. Edit a post with several comments, add a Comments block and select it.
2. The font size control should be displayed by default.
2. Test various typography settings ensuring styles are applied in the editor.
3. Save and confirm the application on the frontend.
4. Switch to the site editor, and select a page or template with a Comments block.
5. Navigate to Global Styles > Blocks > Comments Pagination > Typography and apply typography styles there.
6. Confirm the selected styles are reflected in the preview and on the frontend.

## Screenshots or screencast <!-- if applicable -->

https://user-images.githubusercontent.com/60436221/185010585-9294a737-9bc5-48fc-8a46-dd1589752498.mp4


