### PR TITLE
Comments Pagination Numbers: Add typography support

### DIFF
--- a/docs/reference-guides/core-blocks.md
+++ b/docs/reference-guides/core-blocks.md
@@ -203,7 +203,7 @@ Displays a list of page numbers for comments pagination. ([Source](https://githu
 
 -	**Name:** core/comments-pagination-numbers
 -	**Category:** theme
--	**Supports:** ~~html~~, ~~reusable~~
+-	**Supports:** typography (fontSize, lineHeight), ~~html~~, ~~reusable~~
 -	**Attributes:** 
 
 ## Previous Page

--- a/packages/block-library/src/comments-pagination-numbers/block.json
+++ b/packages/block-library/src/comments-pagination-numbers/block.json
@@ -10,6 +10,19 @@
 	"usesContext": [ "postId" ],
 	"supports": {
 		"reusable": false,
-		"html": false
+		"html": false,
+		"typography": {
+			"fontSize": true,
+			"lineHeight": true,
+			"__experimentalFontFamily": true,
+			"__experimentalFontWeight": true,
+			"__experimentalFontStyle": true,
+			"__experimentalTextTransform": true,
+			"__experimentalTextDecoration": true,
+			"__experimentalLetterSpacing": true,
+			"__experimentalDefaultControls": {
+				"fontSize": true
+			}
+		}
 	}
 }


### PR DESCRIPTION
Related:
- https://github.com/WordPress/gutenberg/issues/43241
- https://github.com/WordPress/gutenberg/issues/43242

## What?

Adds typography support to the Comments Pagination Numbers block.

## Why?

- Adds typography styling for the Comments Pagination Numbers block.
- Improves consistency of our design tools across blocks.
- Allows numbers to be styled the same as the previous and next links

## How?

- Opts into typography supports.
- Sets the font size as the only control displayed by default.

## Testing Instructions

1. Edit a post with several comments, add a Comments block and select the pagination's numbers.
2. Check that the font size control displays by default.
2. Test various typography settings ensuring styles are applied in the editor.
3. Save and confirm the application on the frontend.
4. Switch to the site editor, and select a page or template with a Comments block.
5. Navigate to Global Styles > Blocks > Comments Pagination Numbers > Typography and apply typography styles there.
6. Confirm the selected styles are reflected in the preview and on the frontend.

## Screenshots or screencast <!-- if applicable -->

https://user-images.githubusercontent.com/60436221/185013032-2783cd87-b7ed-4874-858e-5d636113cedd.mp4


