### PR TITLE
Comments Pagination Previous: Add missing typography supports

### DIFF
--- a/packages/block-library/src/comments-pagination-previous/block.json
+++ b/packages/block-library/src/comments-pagination-previous/block.json
@@ -26,10 +26,12 @@
 		"typography": {
 			"fontSize": true,
 			"lineHeight": true,
-			"__experimentalFontStyle": true,
+			"__experimentalFontFamily": true,
 			"__experimentalFontWeight": true,
-			"__experimentalLetterSpacing": true,
+			"__experimentalFontStyle": true,
 			"__experimentalTextTransform": true,
+			"__experimentalTextDecoration": true,
+			"__experimentalLetterSpacing": true,
 			"__experimentalDefaultControls": {
 				"fontSize": true
 			}


### PR DESCRIPTION
Related:
- https://github.com/WordPress/gutenberg/issues/43241
- https://github.com/WordPress/gutenberg/issues/43242

## What?

Adds missing typography support to the Comments Pagination Previous block.

## Why?

- Adds missing typography styling for the Comments Pagination Previous block.
- Improves consistency of our design tools across blocks.

## How?

- Opts into remaining typography supports.

## Testing Instructions

1. Edit a post with several comments, add a Comments block and select the pagination's previous link.
2. Test various typography settings ensuring styles are applied in the editor.
3. Save and confirm the application on the frontend.
4. Switch to the site editor, and select a page or template with a Comments block.
5. Navigate to Global Styles > Blocks > Comments Pagination Previous > Typography and apply typography styles there.
6. Confirm the selected styles are reflected in the preview and on the frontend.

## Screenshots or screencast <!-- if applicable -->


https://user-images.githubusercontent.com/60436221/185013567-67767f61-9a6b-4b54-b53a-950bf0148ec5.mp4




