### PR TITLE
Comments Title: Add missing typography supports

### DIFF
--- a/packages/block-library/src/comments-title/block.json
+++ b/packages/block-library/src/comments-title/block.json
@@ -49,10 +49,12 @@
 		"typography": {
 			"fontSize": true,
 			"lineHeight": true,
-			"__experimentalFontStyle": true,
-			"__experimentalFontWeight": true,
 			"__experimentalFontFamily": true,
+			"__experimentalFontWeight": true,
+			"__experimentalFontStyle": true,
 			"__experimentalTextTransform": true,
+			"__experimentalTextDecoration": true,
+			"__experimentalLetterSpacing": true,
 			"__experimentalDefaultControls": {
 				"fontSize": true,
 				"__experimentalFontFamily": true,


### PR DESCRIPTION
Related:
- https://github.com/WordPress/gutenberg/issues/43241
- https://github.com/WordPress/gutenberg/issues/43242

## What?

Adds missing typography support to the Comments Title block.

## Why?

- Improves consistency of our design tools across blocks.

## How?

- Opts into missing typography supports.

## Testing Instructions

1. Edit a post with several comments, add a Comments block and select the Comments Title.
2. Test various typography settings ensuring styles are applied in the editor.
3. Save and confirm the application on the frontend.
4. Switch to the site editor, and select a page or template with a Comments block.
5. Navigate to Global Styles > Blocks > Comments Title > Typography and apply typography styles there.
6. Confirm the selected styles are reflected in the preview and on the frontend.

## Screenshots or screencast <!-- if applicable -->

https://user-images.githubusercontent.com/60436221/185014127-2ef3568a-694b-4b04-998f-0ed9eb0ef2cf.mp4


