### PR TITLE
Gallery: add background color block supports 

### DIFF
--- a/docs/reference-guides/core-blocks.md
+++ b/docs/reference-guides/core-blocks.md
@@ -266,7 +266,7 @@ Display multiple images in a rich gallery. ([Source](https://github.com/WordPres
 
 -	**Name:** core/gallery
 -	**Category:** media
--	**Supports:** align, anchor, spacing (blockGap), units (em, px, rem, vh, vw), ~~html~~
+-	**Supports:** align, anchor, color (background, gradients, ~~text~~), spacing (blockGap), units (em, px, rem, vh, vw), ~~html~~
 -	**Attributes:** allowResize, caption, columns, fixedHeight, ids, imageCrop, images, linkTarget, linkTo, shortCodeTransforms, sizeSlug
 
 ## Group

--- a/packages/block-library/src/gallery/block.json
+++ b/packages/block-library/src/gallery/block.json
@@ -116,6 +116,11 @@
 				"blockGap": true
 			}
 		},
+		"color": {
+			"text": false,
+			"background": true,
+			"gradients": true
+		},
 		"__experimentalLayout": {
 			"allowSwitching": false,
 			"allowInheriting": false,


### PR DESCRIPTION
Related:
- https://github.com/WordPress/gutenberg/issues/43241
- https://github.com/WordPress/gutenberg/issues/43245

## What?

Enabling background color and gradients for the gallery block.

The background color is displayed by default.

Text is deliberately omitted because it has no effect on captions, and there is otherwise no text in a gallery.

## Why?

To add the option to provide a background color to gallery blocks.
To create consistency across blocks.

## How?

Adding the relevant block supports in block.json

## Testing Instructions


1. Load the block editor with gallery block. 
2. Add some images. You might have to increase the blockGap value to see the background better.
3. Confirm the colors control panel is there and has a background control.
4. Add a background color or gradient
5. Save and confirm the styles appear on the frontend
6. Test the new support works for the block via theme.json and global styles. See example JSON below.

```json
	"styles": {
		"blocks": {
			"core/gallery": {
				"color": {
					"background": "blue"
				}
			}
		}
	},
```


## Screenshots or screencast <!-- if applicable -->


https://user-images.githubusercontent.com/6458278/185026990-4b8c5793-490b-4054-840f-15303222b325.mp4




