### PR TITLE
BlockGap: Add support for spacing presets

### DIFF
--- a/lib/block-supports/layout.php
+++ b/lib/block-supports/layout.php
@@ -105,6 +105,13 @@ function gutenberg_get_layout_style( $selector, $layout, $has_block_gap_support 
 				$gap_value = isset( $gap_value['top'] ) ? $gap_value['top'] : null;
 			}
 			if ( $gap_value && ! $should_skip_gap_serialization ) {
+				// Get spacing CSS variable from preset value if provided.
+				if ( is_string( $gap_value ) && strpos( $gap_value, 'var:preset|spacing|' ) !== false ) {
+					$index_to_splice = strrpos( $gap_value, '|' ) + 1;
+					$slug            = _wp_to_kebab_case( substr( $gap_value, $index_to_splice ) );
+					$gap_value       = "var(--wp--preset--spacing--$slug)";
+				}
+
 				array_push(
 					$layout_styles,
 					array(
@@ -150,12 +157,22 @@ function gutenberg_get_layout_style( $selector, $layout, $has_block_gap_support 
 			);
 		}
 
-		if ( $has_block_gap_support ) {
-			if ( is_array( $gap_value ) ) {
-				$gap_row    = isset( $gap_value['top'] ) ? $gap_value['top'] : $fallback_gap_value;
-				$gap_column = isset( $gap_value['left'] ) ? $gap_value['left'] : $fallback_gap_value;
-				$gap_value  = $gap_row === $gap_column ? $gap_row : $gap_row . ' ' . $gap_column;
+		if ( $has_block_gap_support && isset( $gap_value ) ) {
+			$combined_gap_value = '';
+			$gap_sides          = is_array( $gap_value ) ? array( 'top', 'left' ) : array( 'top' );
+
+			foreach ( $gap_sides as $gap_side ) {
+				$process_value = is_string( $gap_value ) ? $gap_value : _wp_array_get( $gap_value, array( $gap_side ), $fallback_gap_value );
+				// Get spacing CSS variable from preset value if provided.
+				if ( is_string( $process_value ) && strpos( $process_value, 'var:preset|spacing|' ) !== false ) {
+					$index_to_splice = strrpos( $process_value, '|' ) + 1;
+					$slug            = _wp_to_kebab_case( substr( $process_value, $index_to_splice ) );
+					$process_value   = "var(--wp--preset--spacing--$slug)";
+				}
+				$combined_gap_value .= "$process_value ";
 			}
+			$gap_value = trim( $combined_gap_value );
+
 			if ( $gap_value && ! $should_skip_gap_serialization ) {
 				$layout_styles[] = array(
 					'selector'     => $selector,

--- a/lib/compat/wordpress-6.1/class-wp-theme-json-6-1.php
+++ b/lib/compat/wordpress-6.1/class-wp-theme-json-6-1.php
@@ -1308,14 +1308,14 @@ class WP_Theme_JSON_6_1 extends WP_Theme_JSON_6_0 {
 					$block_gap_value = _wp_array_get( $block_type->supports, array( 'spacing', 'blockGap', '__experimentalDefault' ), null );
 				}
 			} else {
-				$block_gap_value = _wp_array_get( $node, array( 'spacing', 'blockGap' ), null );
+				$block_gap_value = static::get_property_value( $node, array( 'spacing', 'blockGap' ) );
 			}
 
 			// Support split row / column values and concatenate to a shorthand value.
 			if ( is_array( $block_gap_value ) ) {
 				if ( isset( $block_gap_value['top'] ) && isset( $block_gap_value['left'] ) ) {
-					$gap_row         = $block_gap_value['top'];
-					$gap_column      = $block_gap_value['left'];
+					$gap_row         = static::get_property_value( $node, array( 'spacing', 'blockGap', 'top' ) );
+					$gap_column      = static::get_property_value( $node, array( 'spacing', 'blockGap', 'left' ) );
 					$block_gap_value = $gap_row === $gap_column ? $gap_row : $gap_row . ' ' . $gap_column;
 				} else {
 					// Skip outputting gap value if not all sides are provided.

--- a/lib/compat/wordpress-6.1/class-wp-theme-json-6-1.php
+++ b/lib/compat/wordpress-6.1/class-wp-theme-json-6-1.php
@@ -793,8 +793,6 @@ class WP_Theme_JSON_6_1 extends WP_Theme_JSON_6_0 {
 		}
 
 		if ( static::ROOT_BLOCK_SELECTOR === $selector ) {
-			$block_gap_value = _wp_array_get( $this->theme_json, array( 'styles', 'spacing', 'blockGap' ), '0.5em' );
-
 			if ( $use_root_padding ) {
 				$block_rules .= '.wp-site-blocks { padding-top: var(--wp--style--root--padding-top); padding-bottom: var(--wp--style--root--padding-bottom); }';
 				$block_rules .= '.has-global-padding { padding-right: var(--wp--style--root--padding-right); padding-left: var(--wp--style--root--padding-left); }';
@@ -808,8 +806,10 @@ class WP_Theme_JSON_6_1 extends WP_Theme_JSON_6_0 {
 
 			$has_block_gap_support = _wp_array_get( $this->theme_json, array( 'settings', 'spacing', 'blockGap' ) ) !== null;
 			if ( $has_block_gap_support ) {
-				$block_rules .= '.wp-site-blocks > * { margin-block-start: 0; margin-block-end: 0; }';
-				$block_rules .= ".wp-site-blocks > * + * { margin-block-start: $block_gap_value; }";
+				$block_gap_value = static::get_property_value( $this->theme_json, array( 'styles', 'spacing', 'blockGap' ) );
+				$block_rules    .= '.wp-site-blocks > * { margin-block-start: 0; margin-block-end: 0; }';
+				$block_rules    .= ".wp-site-blocks > * + * { margin-block-start: $block_gap_value; }";
+
 				// For backwards compatibility, ensure the legacy block gap CSS variable is still available.
 				$block_rules .= "$selector { --wp--style--block-gap: $block_gap_value; }";
 			}

--- a/packages/block-editor/src/hooks/gap.js
+++ b/packages/block-editor/src/hooks/gap.js
@@ -14,6 +14,7 @@ import {
  * Internal dependencies
  */
 import { __unstableUseBlockRef as useBlockRef } from '../components/block-list/use-block-props/use-block-refs';
+import { getSpacingPresetCssVar } from '../components/spacing-sizes-control/utils';
 import useSetting from '../components/use-setting';
 import { AXIAL_SIDES, SPACING_SUPPORT_KEY, useCustomSides } from './dimensions';
 import { cleanEmptyObject } from './utils';
@@ -54,8 +55,12 @@ export function getGapBoxControlValueFromStyle( blockGapValue ) {
 
 	const isValueString = typeof blockGapValue === 'string';
 	return {
-		top: isValueString ? blockGapValue : blockGapValue?.top,
-		left: isValueString ? blockGapValue : blockGapValue?.left,
+		top: isValueString
+			? getSpacingPresetCssVar( blockGapValue )
+			: getSpacingPresetCssVar( blockGapValue?.top ),
+		left: isValueString
+			? getSpacingPresetCssVar( blockGapValue )
+			: getSpacingPresetCssVar( blockGapValue?.left ),
 	};
 }
 

--- a/packages/block-editor/src/hooks/test/gap.js
+++ b/packages/block-editor/src/hooks/test/gap.js
@@ -27,6 +27,28 @@ describe( 'gap', () => {
 				...blockGapValue,
 			} );
 		} );
+		it( 'should unwrap var: values from a string into a CSS var() function', () => {
+			const expectedValue = {
+				top: 'var(--wp--preset--spacing--60)',
+				left: 'var(--wp--preset--spacing--60)',
+			};
+			expect(
+				getGapBoxControlValueFromStyle( 'var:preset|spacing|60' )
+			).toEqual( expectedValue );
+		} );
+		it( 'should unwrap var: values from an object into a CSS var() function', () => {
+			const expectedValue = {
+				top: 'var(--wp--preset--spacing--20)',
+				left: 'var(--wp--preset--spacing--60)',
+			};
+			const blockGapValue = {
+				top: 'var:preset|spacing|20',
+				left: 'var:preset|spacing|60',
+			};
+			expect( getGapBoxControlValueFromStyle( blockGapValue ) ).toEqual(
+				expectedValue
+			);
+		} );
 	} );
 	describe( 'getGapCSSValue()', () => {
 		it( 'should return `null` if argument is falsey', () => {

--- a/packages/block-editor/src/layouts/flex.js
+++ b/packages/block-editor/src/layouts/flex.js
@@ -120,7 +120,7 @@ export default {
 		const blockGapValue =
 			style?.spacing?.blockGap &&
 			! shouldSkipSerialization( blockName, 'spacing', 'blockGap' )
-				? getGapCSSValue( style?.spacing?.blockGap )
+				? getGapCSSValue( style?.spacing?.blockGap, '0.5em' )
 				: undefined;
 		const justifyContent = justifyContentMap[ layout.justifyContent ];
 		const flexWrap = flexWrapOptions.includes( layout.flexWrap )

--- a/phpunit/class-wp-theme-json-test.php
+++ b/phpunit/class-wp-theme-json-test.php
@@ -45,6 +45,39 @@ class WP_Theme_JSON_Gutenberg_Test extends WP_UnitTestCase {
 	 *
 	 * @param array $layout_definitions Layout definitions as stored in core theme.json.
 	 */
+	public function test_get_stylesheet_generates_layout_styles_with_spacing_presets( $layout_definitions ) {
+		$theme_json = new WP_Theme_JSON_Gutenberg(
+			array(
+				'version'  => WP_Theme_JSON_Gutenberg::LATEST_SCHEMA,
+				'settings' => array(
+					'layout'  => array(
+						'definitions' => $layout_definitions,
+					),
+					'spacing' => array(
+						'blockGap' => true,
+					),
+				),
+				'styles'   => array(
+					'spacing' => array(
+						'blockGap' => 'var:preset|spacing|60',
+					),
+				),
+			),
+			'default'
+		);
+
+		// Results also include root site blocks styles.
+		$this->assertEquals(
+			'body { margin: 0; }.wp-site-blocks > .alignleft { float: left; margin-right: 2em; }.wp-site-blocks > .alignright { float: right; margin-left: 2em; }.wp-site-blocks > .aligncenter { justify-content: center; margin-left: auto; margin-right: auto; }.wp-site-blocks > * { margin-block-start: 0; margin-block-end: 0; }.wp-site-blocks > * + * { margin-block-start: var(--wp--preset--spacing--60); }body { --wp--style--block-gap: var(--wp--preset--spacing--60); }body .is-layout-flow > *{margin-block-start: 0;margin-block-end: 0;}body .is-layout-flow > * + *{margin-block-start: var(--wp--preset--spacing--60);margin-block-end: 0;}body .is-layout-flex{gap: var(--wp--preset--spacing--60);}body .is-layout-flow > .alignleft{float: left;margin-inline-start: 0;margin-inline-end: 2em;}body .is-layout-flow > .alignright{float: right;margin-inline-start: 2em;margin-inline-end: 0;}body .is-layout-flow > .aligncenter{margin-left: auto !important;margin-right: auto !important;}body .is-layout-flex{display: flex;}body .is-layout-flex{flex-wrap: wrap;align-items: center;}',
+			$theme_json->get_stylesheet( array( 'styles' ) )
+		);
+	}
+
+	/**
+	 * @dataProvider data_get_layout_definitions
+	 *
+	 * @param array $layout_definitions Layout definitions as stored in core theme.json.
+	 */
 	public function test_get_stylesheet_generates_fallback_gap_layout_styles( $layout_definitions ) {
 		$theme_json = new WP_Theme_JSON_Gutenberg(
 			array(


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

This is an alternative PR to #43076 to see if we can add support for spacing presets to the current blockGap output, without having to tie the implementation to the style engine work.

The objective is that any gap value stored in the form `var:preset|spacing|20` will be output in a form such as `var(--wp--preset--spacing--20)` in all situations where blockGap is output:

* Block editor at the individual block level
* Global styles in the site editor
* Individual block level in the site's rendered front end
* Block-level in global styles in the site's rendered front end
* Root block spacing in the site's rendered front end

***Note:*** This PR does _not_ add in a UI control for adjusting spacing presets — that will be covered in a separate PR. For now, this PR hones in on ensuring that the preset values can be used as valid values in blockGap output.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

While working on #43076, it occurred to me that the changes required involve making tweaks to the style engine that are slightly beyond the scope of implementing the desired feature. In order to see if we can come up with a smaller changeset and a safer PR to merge, I thought it worth exploring to see if hacking in the CSS variable parsing into blockGap output is viable.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

* In global styles, re-use `static::get_property_value` to let the class do the CSS variable parsing
* In `layout.php`, borrow simplified logic from the style engine and include it inline in order to unwrap gap values into a `var()` value
* In the JS implementation, re-use the `getSpacingPresetCssVar` function to ensure gap values are parsed for CSS variables.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->

### 1. Test root blockGap value works correctly in theme.json

In `theme.json`, set `styles.spacing.blockGap` to `"var:preset|spacing|60"`, and check that this spacing value is output correctly in the site editor, post editor for default spacing between paragraphs, and as the default spacing on the site frontend.

<img width="419" alt="image" src="https://user-images.githubusercontent.com/14988353/185045148-d04d890f-010f-468c-a71f-24a9d78dcb69.png">

### 2. Test block level blockGap value works correctly in theme.json

In `theme.json` set blockGap values for social icons and columns blocks:

```
	"styles": {
		"blocks": {
			"core/social-links": {
				"spacing": {
					"blockGap": {
						"top": "var:preset|spacing|40",
						"left": "var:preset|spacing|20"
					}
				}
			},
			"core/columns": {
				"spacing": {
					"blockGap": "var:preset|spacing|20"
				}
			},
```

Then, test that the spacing is rendered correctly in the post editor, site editor, and on the site front end.

<details>
<summary>Here is some test markup</summary>

```html
<!-- wp:group {"layout":{"contentSize":"280px"}} -->
<div class="wp-block-group"><!-- wp:social-links -->
<ul class="wp-block-social-links"><!-- wp:social-link {"url":"wordpress.org","service":"wordpress"} /-->

<!-- wp:social-link {"url":"wordpress.org","service":"wordpress"} /-->

<!-- wp:social-link {"url":"wordpress.org","service":"wordpress"} /-->

<!-- wp:social-link {"url":"wordpress.org","service":"wordpress"} /-->

<!-- wp:social-link {"url":"wordpress.org","service":"wordpress"} /-->

<!-- wp:social-link {"url":"wordpress.org","service":"wordpress"} /-->

<!-- wp:social-link {"url":"wordpress.org","service":"wordpress"} /-->

<!-- wp:social-link {"url":"wordpress.org","service":"wordpress"} /-->

<!-- wp:social-link {"url":"wordpress.org","service":"wordpress"} /-->

<!-- wp:social-link {"url":"wordpress.org","service":"wordpress"} /-->

<!-- wp:social-link {"url":"wordpress.org","service":"wordpress"} /-->

<!-- wp:social-link {"url":"wordpress.org","service":"wordpress"} /-->

<!-- wp:social-link {"url":"wordpress.org","service":"wordpress"} /-->

<!-- wp:social-link {"url":"wordpress.org","service":"wordpress"} /-->

<!-- wp:social-link {"url":"wordpress.org","service":"wordpress"} /-->

<!-- wp:social-link {"url":"wordpress.org","service":"wordpress"} /-->

<!-- wp:social-link {"url":"wordpress.org","service":"wordpress"} /-->

<!-- wp:social-link {"url":"wordpress.org","service":"wordpress"} /--></ul>
<!-- /wp:social-links --></div>
<!-- /wp:group -->

<!-- wp:columns -->
<div class="wp-block-columns"><!-- wp:column {"backgroundColor":"vivid-green-cyan"} -->
<div class="wp-block-column has-vivid-green-cyan-background-color has-background"><!-- wp:paragraph -->
<p>Column A</p>
<!-- /wp:paragraph --></div>
<!-- /wp:column -->

<!-- wp:column {"backgroundColor":"vivid-green-cyan"} -->
<div class="wp-block-column has-vivid-green-cyan-background-color has-background"><!-- wp:paragraph -->
<p>Column B</p>
<!-- /wp:paragraph --></div>
<!-- /wp:column --></div>
<!-- /wp:columns -->
```

</details>

### 3. Test block level blockGap value works in post content

Because we haven't (yet) rolled out the preset-based spacing controls to blockGap, we can't edit this via the UI, but we can manually construct post content that uses the presets. Below is some sample markup, that when inspected in the editor and on the site's front end, should reveal that the parsing is working correctly:

<details

<summary>Test markup that includes spacing presets in its values</summary>

```html
<!-- wp:group {"layout":{"contentSize":"280px"}} -->
<div class="wp-block-group"><!-- wp:social-links {"style":{"spacing":{"blockGap":{"top":"var:preset|spacing|60","left":"var:preset|spacing|20"}}}} -->
<ul class="wp-block-social-links"><!-- wp:social-link {"url":"wordpress.org","service":"wordpress"} /-->

<!-- wp:social-link {"url":"wordpress.org","service":"wordpress"} /-->

<!-- wp:social-link {"url":"wordpress.org","service":"wordpress"} /-->

<!-- wp:social-link {"url":"wordpress.org","service":"wordpress"} /-->

<!-- wp:social-link {"url":"wordpress.org","service":"wordpress"} /-->

<!-- wp:social-link {"url":"wordpress.org","service":"wordpress"} /-->

<!-- wp:social-link {"url":"wordpress.org","service":"wordpress"} /-->

<!-- wp:social-link {"url":"wordpress.org","service":"wordpress"} /-->

<!-- wp:social-link {"url":"wordpress.org","service":"wordpress"} /-->

<!-- wp:social-link {"url":"wordpress.org","service":"wordpress"} /-->

<!-- wp:social-link {"url":"wordpress.org","service":"wordpress"} /-->

<!-- wp:social-link {"url":"wordpress.org","service":"wordpress"} /-->

<!-- wp:social-link {"url":"wordpress.org","service":"wordpress"} /-->

<!-- wp:social-link {"url":"wordpress.org","service":"wordpress"} /-->

<!-- wp:social-link {"url":"wordpress.org","service":"wordpress"} /-->

<!-- wp:social-link {"url":"wordpress.org","service":"wordpress"} /-->

<!-- wp:social-link {"url":"wordpress.org","service":"wordpress"} /-->

<!-- wp:social-link {"url":"wordpress.org","service":"wordpress"} /--></ul>
<!-- /wp:social-links --></div>
<!-- /wp:group -->

<!-- wp:columns {"style":{"spacing":{"blockGap":"var:preset|spacing|60"}}} -->
<div class="wp-block-columns"><!-- wp:column {"backgroundColor":"vivid-green-cyan"} -->
<div class="wp-block-column has-vivid-green-cyan-background-color has-background"><!-- wp:paragraph -->
<p>Column A</p>
<!-- /wp:paragraph --></div>
<!-- /wp:column -->

<!-- wp:column {"backgroundColor":"vivid-green-cyan"} -->
<div class="wp-block-column has-vivid-green-cyan-background-color has-background"><!-- wp:paragraph -->
<p>Column B</p>
<!-- /wp:paragraph --></div>
<!-- /wp:column --></div>
<!-- /wp:columns -->

<!-- wp:group {"style":{"spacing":{"blockGap":"var:preset|spacing|20"}}} -->
<div class="wp-block-group"><!-- wp:paragraph -->
<p>Paragraph</p>
<!-- /wp:paragraph -->

<!-- wp:paragraph -->
<p>Another paragrarph</p>
<!-- /wp:paragraph --></div>
<!-- /wp:group -->
```

In the above markup, ensure that the Social Icons, Columns, and Group blocks all use `var()` rules for their gaps. (In the case of Group, look at `margin-block-start` on the second child of the Group block to confirm)

</details>

To recreate this manually, add blocks such as Social Icons or Columns, add a blockGap value, then go to the code editor view and replace the `px` based values with a string in the form `var:preset|spacing|20` where `20` is a valid preset slug (e.g. `40`, `60`, etc)

## Screenshots or screencast <!-- if applicable -->

<img width="1014" alt="image" src="https://user-images.githubusercontent.com/14988353/185042916-a5eb3d21-69b1-410d-92f1-598e79f1aad0.png">
