### PR TITLE
Fix legacy widget form positioning in customizer

### DIFF
--- a/packages/widgets/src/blocks/legacy-widget/edit/form.js
+++ b/packages/widgets/src/blocks/legacy-widget/edit/form.js
@@ -103,8 +103,10 @@ export default function Form( {
 				) }
 				<Popover
 					focusOnMount={ false }
-					position="middle right"
+					placement="right"
+					offset={ 48 }
 					__unstableForcePosition
+					__unstableShift
 				>
 					<div
 						ref={ ref }

--- a/packages/widgets/src/blocks/legacy-widget/edit/form.js
+++ b/packages/widgets/src/blocks/legacy-widget/edit/form.js
@@ -104,7 +104,7 @@ export default function Form( {
 				<Popover
 					focusOnMount={ false }
 					placement="right"
-					offset={ 48 }
+					offset={ 32 }
 					__unstableForcePosition
 					__unstableShift
 				>

--- a/packages/widgets/src/blocks/legacy-widget/editor.scss
+++ b/packages/widgets/src/blocks/legacy-widget/editor.scss
@@ -5,7 +5,9 @@
 	background: $white;
 	border-radius: $radius-block-ui;
 	border: 1px solid $gray-900;
-	padding: $grid-unit-15 - 1px; //Subtract the border width.
+	padding: $grid-unit-15 - 1px; // Subtract the border width.
+	max-height: calc(100vh - 2px); // Subtract the border width (both top and bottom).
+	overflow-y: scroll;
 
 	.wp-block-legacy-widget__edit-form-title {
 		color: $black;


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Fixes issues with the legacy widget form popover in the customizer as mentioned in this comment - https://github.com/WordPress/gutenberg/pull/42971#pullrequestreview-1062895404.

## Why?
Since the refactor of the Popover component this has been a buggy. Users are unable to access the full form if it takes up more than the height of the browser window.

## How?
- Adds the `__unstableShift` prop to ensure the popover remains in the viewport
- Adds an `offset` prop to move the popover to the right more
- Switches `position` for `placement`.
- Adds CSS to make the popover contents the height of the viewport, and scroll when overflowing

## Testing Instructions
1. Install a plugin like the SiteOrigin Widgets Bundle that adds a lot of legacy widget types
2. Use a non-block based theme (like Twenty Twenty One)
3. Go to Appearance > Widgets
4. Add a SiteOrigin Google Maps block

## Screenshots or screencast <!-- if applicable -->

### Before

https://user-images.githubusercontent.com/677833/185040177-79e25c4a-d919-4672-a129-dd70ad22f06a.mp4

### After

https://user-images.githubusercontent.com/677833/185039811-f996fb81-e210-4cc7-86eb-790f678dd288.mp4
