### PR TITLE
Cover: Add typography supports

### DIFF
--- a/docs/reference-guides/core-blocks.md
+++ b/docs/reference-guides/core-blocks.md
@@ -230,7 +230,7 @@ Add an image or video with a text overlay — great for headers. ([Source](https
 
 -	**Name:** core/cover
 -	**Category:** media
--	**Supports:** align, anchor, color (~~background~~, ~~text~~), spacing (margin, padding), ~~html~~
+-	**Supports:** align, anchor, color (~~background~~, ~~text~~), spacing (margin, padding), typography (fontSize, lineHeight), ~~html~~
 -	**Attributes:** allowedBlocks, alt, backgroundType, contentPosition, customGradient, customOverlayColor, dimRatio, focalPoint, gradient, hasParallax, id, isDark, isRepeated, minHeight, minHeightUnit, overlayColor, templateLock, url, useFeaturedImage
 
 ## Embed

--- a/packages/block-library/src/cover/block.json
+++ b/packages/block-library/src/cover/block.json
@@ -92,6 +92,19 @@
 			"__experimentalDuotone": "> .wp-block-cover__image-background, > .wp-block-cover__video-background",
 			"text": false,
 			"background": false
+		},
+		"typography": {
+			"fontSize": true,
+			"lineHeight": true,
+			"__experimentalFontFamily": true,
+			"__experimentalFontWeight": true,
+			"__experimentalFontStyle": true,
+			"__experimentalTextTransform": true,
+			"__experimentalTextDecoration": true,
+			"__experimentalLetterSpacing": true,
+			"__experimentalDefaultControls": {
+				"fontSize": true
+			}
 		}
 	},
 	"editorStyle": "wp-block-cover-editor",


### PR DESCRIPTION
Depends on:
- https://github.com/WordPress/gutenberg/pull/43300

Related:
- https://github.com/WordPress/gutenberg/issues/43241
- https://github.com/WordPress/gutenberg/issues/43242

## What?

Adds typography support to the Cover block.

## Why?

- Improves consistency of our design tools across blocks.
- Allows some typographic styling to be set in a single place and applied to all the Cover's inner blocks.

## How?

- Opts into typography supports.

## Testing Instructions

1. Edit a post, add a Cover block with multiple paragraphs inside and select it.
2. Test various typography settings ensuring styles are applied in the editor.
    - Note that by default the Cover block current applies font size to the first paragraph which will take precedence.
3. Save and confirm the application on the frontend.
4. Cherry pick the changes from https://github.com/WordPress/gutenberg/pull/43300 to this branch
5. Switch to the site editor and select a page/template with a Cover block.
6. Navigate to Global Styles > Blocks > Cover > Typography and apply typography styles there.
7. Confirm the selected styles are reflected in the preview and on the frontend.

## Screenshots or screencast <!-- if applicable -->

https://user-images.githubusercontent.com/60436221/185044393-1472f9e7-7ca8-44f7-af42-2544f4ec079b.mp4


