### PR TITLE
Calendar: add color block supports

### DIFF
--- a/docs/reference-guides/core-blocks.md
+++ b/docs/reference-guides/core-blocks.md
@@ -68,7 +68,7 @@ A calendar of your site’s posts. ([Source](https://github.com/WordPress/gutenb
 
 -	**Name:** core/calendar
 -	**Category:** widgets
--	**Supports:** align
+-	**Supports:** align, color (background, gradients, link, text)
 -	**Attributes:** month, year
 
 ## Categories List

--- a/packages/block-library/src/calendar/block.json
+++ b/packages/block-library/src/calendar/block.json
@@ -16,7 +16,19 @@
 		}
 	},
 	"supports": {
-		"align": true
+		"align": true,
+		"color": {
+			"text": true,
+			"background": true,
+			"gradients": true,
+			"link": true,
+			"__experimentalDefaultControls": {
+				"text": false,
+				"background": true,
+				"gradients": false,
+				"link": false
+			}
+		}
 	},
 	"style": "wp-block-calendar"
 }

--- a/packages/block-library/src/calendar/style.scss
+++ b/packages/block-library/src/calendar/style.scss
@@ -18,6 +18,9 @@
 
 	table th {
 		font-weight: 400;
+	}
+
+	&:not(.has-background) th {
 		background: $gray-300;
 	}
 
@@ -25,8 +28,10 @@
 		text-decoration: underline;
 	}
 
-	table tbody,
-	table caption {
-		color: #40464d;
+	&:not(.has-text-color) {
+		tbody,
+		caption {
+			color: #40464d;
+		}
 	}
 }


### PR DESCRIPTION
Related:
- https://github.com/WordPress/gutenberg/issues/43241
- https://github.com/WordPress/gutenberg/issues/43245

## What?

Enabling full color block supports for the calendar block.

Because the gallery block has a hardcoded background color for `th` and a hardcoded color for `tbody` and `caption`, this PR updates the CSS to limit these hardcoded colors where there's no `has-text` or `has-background` classes.

## ⚠⚠⚠ Note: updating the colors with custom values doesn't work reliably. 

When selecting a preset color, followed by a custom color, the block doesn't rerender.

I've pinpointed it to the use of [useDebounce in the ServerSideRender component](916abc45e6682f4bdb70888aa41e98aa395/packages/server-side-render/src/server-side-render.js#L145).

The debounced function is called, but it doesn't fire. I suspect that it's cancelled too early [here](https://github.com/WordPress/gutenberg/blob/33d84b036592a5bf31af05b7710f3b2b14163dc4/packages/compose/src/hooks/use-debounce/index.js). 

Maybe there's an equality check that's failing, because if add a `_key: Math.random()` to the top level of the attributes, or as part of the GET query args via [urlQueryArgs](https://github.com/WordPress/gutenberg/blob/71635329224c3dcc148258b7b0e855acf3b5d733/packages/server-side-render/README.md#urlqueryargs) it works.

The effect is easier to see if both `"color.background"` and `"color.gradients"` block supports are opted into.

## Why?

To add the option to provide a background color to gallery blocks.
To create consistency across blocks.

## How?

Adding the relevant block supports in block.json

## Testing Instructions


1. Load the block editor with a calendar block. Make sure you have some recently published posts.
2. Confirm the colors control panel is there and has a background control.
3. Add background color or gradient, link text and text colors
4. Save and confirm the styles appear on the frontend

https://user-images.githubusercontent.com/6458278/185034103-a732aa0a-2c5b-4581-b783-988b027b78de.mp4


