### PR TITLE
Duotone: Prevent early return blocking other style generation

### DIFF
--- a/packages/edit-site/src/components/global-styles/use-global-styles-output.js
+++ b/packages/edit-site/src/components/global-styles/use-global-styles-output.js
@@ -638,14 +638,13 @@ export const toStyles = (
 			if ( duotoneSelector ) {
 				const duotoneDeclarations =
 					getStylesDeclarations( duotoneStyles );
-				if ( duotoneDeclarations.length === 0 ) {
-					return;
+				if ( duotoneDeclarations.length > 0 ) {
+					ruleset =
+						ruleset +
+						`${ duotoneSelector }{${ duotoneDeclarations.join(
+							';'
+						) };}`;
 				}
-				ruleset =
-					ruleset +
-					`${ duotoneSelector }{${ duotoneDeclarations.join(
-						';'
-					) };}`;
 			}
 
 			// Process blockGap and layout styles.


### PR DESCRIPTION
Related: 
- https://github.com/WordPress/gutenberg/pull/43298

## What?

Fixes issue where a block with duotone selectors configured but no duotone declarations would exit the generation of the global styles early, blocking any other global styles for the block.

## Why?

- Having global styles generation working properly makes new things possible, e.g. Adding typography supports to the Cover block.

## How?

- Refactors the early exit from duotone style generatino.

## Testing Instructions

1. Test that duotone styles are still generated correctly via theme.json in site editor. See theme.json snippet below.
2. Remove duotone style from theme.json and confirm image block still renders correctly.
3. Bonus points for testing this allows Cover typography styles to work via test instructions in https://github.com/WordPress/gutenberg/pull/43298


