### PR TITLE
Fix navigation block undefined index error on frontend

### DIFF
--- a/packages/block-library/src/navigation/index.php
+++ b/packages/block-library/src/navigation/index.php
@@ -377,7 +377,7 @@ function block_core_navigation_from_block_get_post_ids( $block ) {
 	}
 
 	if ( 'core/navigation-link' === $block->name || 'core/navigation-submenu' === $block->name ) {
-		if ( $block->attributes && isset( $block->attributes['kind'] ) && 'post-type' === $block->attributes['kind'] ) {
+		if ( $block->attributes && isset( $block->attributes['kind'] ) && 'post-type' === $block->attributes['kind'] && isset( $block->attributes['id'] ) ) {
 			$post_ids[] = $block->attributes['id'];
 		}
 	}


### PR DESCRIPTION
## What?
The navigation block can throw an error on the frontend if the user adds one of the navigation link post type block variations without choosing a post to link to.

## Why?
The function `block_core_navigation_from_block_get_post_ids` tries to access the `id` property of the `attributes` array, but if the user hasn't set a post for a link this property won't be in the array.

## How?
Adds some extra guarding to the `if` statement within the function.

## Testing Instructions
1. Insert a navigation block.
2. Create a new menu
3. Add a link to the navigation block normally
4. With the link you just added selected, open the inserter sidebar and add a Page Link block, but don't choose a page
5. Save everything
6. View the site

In `trunk`: See a PHP error
In this PR: No PHP error

## Screenshots or screencast <!-- if applicable -->
### Before

![Screen Shot 2022-08-17 at 2 35 15 pm](https://user-images.githubusercontent.com/677833/185050971-75b637c1-620a-473e-9b36-c885585cfac3.png)

### After

![Screen Shot 2022-08-17 at 2 35 03 pm](https://user-images.githubusercontent.com/677833/185050996-ebf5569f-a4e1-4b9e-8bbc-922898940a76.png)

