### PR TITLE
Lodash: Refactor away from `_.upperFirst()`

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -147,6 +147,7 @@ module.exports = {
 							'uniqBy',
 							'uniqueId',
 							'uniqWith',
+							'upperFirst',
 							'values',
 							'words',
 							'zip',

--- a/packages/block-editor/src/components/colors/with-colors.js
+++ b/packages/block-editor/src/components/colors/with-colors.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { kebabCase, reduce, upperFirst } from 'lodash';
+import { kebabCase, reduce } from 'lodash';
 
 /**
  * WordPress dependencies
@@ -19,6 +19,16 @@ import {
 	getMostReadableColor,
 } from './utils';
 import useSetting from '../use-setting';
+
+/**
+ * Capitalizes the first letter in a string.
+ *
+ * @param {string} str The string whose first letter the function will capitalize.
+ *
+ * @return {string} Capitalized string.
+ */
+const upperFirst = ( [ firstLetter, ...rest ] ) =>
+	firstLetter.toUpperCase() + rest.join( '' );
 
 /**
  * Higher order component factory for injecting the `colorsArray` argument as

--- a/packages/block-editor/src/components/font-sizes/with-font-sizes.js
+++ b/packages/block-editor/src/components/font-sizes/with-font-sizes.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { find, pickBy, reduce, some, upperFirst } from 'lodash';
+import { find, pickBy, reduce, some } from 'lodash';
 
 /**
  * WordPress dependencies
@@ -16,6 +16,16 @@ import { getFontSize, getFontSizeClass } from './utils';
 import useSetting from '../use-setting';
 
 const DEFAULT_FONT_SIZES = [];
+
+/**
+ * Capitalizes the first letter in a string.
+ *
+ * @param {string} str The string whose first letter the function will capitalize.
+ *
+ * @return {string} Capitalized string.
+ */
+const upperFirst = ( [ firstLetter, ...rest ] ) =>
+	firstLetter.toUpperCase() + rest.join( '' );
 
 /**
  * Higher-order component, which handles font size logic for class generation,

--- a/packages/create-block/lib/prompts.js
+++ b/packages/create-block/lib/prompts.js
@@ -1,7 +1,17 @@
 /**
  * External dependencies
  */
-const { isEmpty, upperFirst } = require( 'lodash' );
+const { isEmpty } = require( 'lodash' );
+
+/**
+ * Capitalizes the first letter in a string.
+ *
+ * @param {string} str The string whose first letter the function will capitalize.
+ *
+ * @return {string} Capitalized string.
+ */
+const upperFirst = ( [ firstLetter, ...rest ] ) =>
+	firstLetter.toUpperCase() + rest.join( '' );
 
 // Block metadata.
 const slug = {


### PR DESCRIPTION
## What?
This PR removes the `_.upperFirst()` usage completely and deprecates the function. 

With `kebabCase()`, this is one of the last remaining case handling functions we need to decouple from Lodash.

## Why?

Lodash is known to unnecessarily inflate the bundle size of packages, and in most cases, it can be replaced with native language functionality. See these for more information and rationale:

* https://github.com/WordPress/gutenberg/issues/16938#issuecomment-602837246
* https://github.com/WordPress/gutenberg/issues/17025
* https://github.com/WordPress/gutenberg/issues/39495 

## How?

In particular, we replace a few of `upperFirst()` Lodash usages in favor of a custom inline function that handles it.

We could have used `change-case` as in #42427, however, it would require using a separate dependency (`upperCaseFirst` is not included in the primary `change-case` package, it has its own package), so we're making a compromise to inline the function because of its simplicity, in order to not have to add another dependency just for this.

## Testing Instructions
* Verify you can still change colors and font sizes of a Table block correctly.
* Verify creating a block still works: `npx @wordpress/create-block test-block`
* Verify all tests still pass.