### PR TITLE
Home Link: Add typography support

### DIFF
--- a/docs/reference-guides/core-blocks.md
+++ b/docs/reference-guides/core-blocks.md
@@ -293,7 +293,7 @@ Create a link that always points to the homepage of the site. Usually not necess
 
 -	**Name:** core/home-link
 -	**Category:** design
--	**Supports:** ~~html~~, ~~reusable~~
+-	**Supports:** typography (fontSize, lineHeight), ~~html~~, ~~reusable~~
 -	**Attributes:** label
 
 ## Custom HTML

--- a/packages/block-library/src/home-link/block.json
+++ b/packages/block-library/src/home-link/block.json
@@ -23,7 +23,20 @@
 	],
 	"supports": {
 		"reusable": false,
-		"html": false
+		"html": false,
+		"typography": {
+			"fontSize": true,
+			"lineHeight": true,
+			"__experimentalFontFamily": true,
+			"__experimentalFontWeight": true,
+			"__experimentalFontStyle": true,
+			"__experimentalTextTransform": true,
+			"__experimentalTextDecoration": true,
+			"__experimentalLetterSpacing": true,
+			"__experimentalDefaultControls": {
+				"fontSize": true
+			}
+		}
 	},
 	"editorStyle": "wp-block-home-link-editor",
 	"style": "wp-block-home-link"


### PR DESCRIPTION
Related:
- https://github.com/WordPress/gutenberg/issues/43241
- https://github.com/WordPress/gutenberg/issues/43242

## What?

Adds typography support to the Home Link block.

## Why?

- Improves consistency of our design tools across blocks.
- Allows applying typographic styles to the Home link independent of other navigation links.

## How?

- Opts into typography supports.
- Makes only the font size control displayed by default

## Testing Instructions

1. Edit a post, add a Navigation block with a menu including a Home Link.
2. Select the Home Link block and confirm font size control displayed by default.
3. Test various typography settings ensuring styles are applied in the editor.
4. Save and confirm the application on the frontend.
5. Switch to the site editor and select a page with a Navigation block including a Home Link.
6. Navigate to Global Styles > Blocks > Home Link > Typography and apply typography styles there.
7. Confirm the selected styles are reflected in the preview and on the frontend.

## Screenshots or screencast <!-- if applicable -->


https://user-images.githubusercontent.com/60436221/185061693-ebc87b19-2436-423a-b0a3-d4b092441520.mp4


