### PR TITLE
Group: Add missing typography supports

### DIFF
--- a/packages/block-library/src/group/block.json
+++ b/packages/block-library/src/group/block.json
@@ -56,10 +56,12 @@
 		"typography": {
 			"fontSize": true,
 			"lineHeight": true,
-			"__experimentalFontStyle": true,
+			"__experimentalFontFamily": true,
 			"__experimentalFontWeight": true,
-			"__experimentalLetterSpacing": true,
+			"__experimentalFontStyle": true,
 			"__experimentalTextTransform": true,
+			"__experimentalTextDecoration": true,
+			"__experimentalLetterSpacing": true,
 			"__experimentalDefaultControls": {
 				"fontSize": true
 			}


### PR DESCRIPTION
Related:
- https://github.com/WordPress/gutenberg/issues/43241
- https://github.com/WordPress/gutenberg/issues/43242

## What?

Adds missing typography support to the Group block.

## Why?

- Improves consistency of our design tools across blocks.

## How?

- Opts into missing typography supports.

## Testing Instructions

1. Edit a post, add a Group block with multiple paragraphs inside it.
2. Select the Group block and confirm font family and text decoration controls are available.
3. Test various typography settings ensuring styles are applied in the editor.
4. Save and confirm the application on the frontend.
5. Switch to the site editor.
6. Navigate to Global Styles > Blocks > Group > Typography and apply typography styles there.
7. Confirm the selected styles are reflected in the preview and on the frontend.

## Screenshots or screencast <!-- if applicable -->

https://user-images.githubusercontent.com/60436221/185063923-69241f80-e16d-47f5-9bae-fde814d5729e.mp4



