### PR TITLE
List: Add missing typography block supports

### DIFF
--- a/packages/block-library/src/list/block.json
+++ b/packages/block-library/src/list/block.json
@@ -40,12 +40,13 @@
 		"className": false,
 		"typography": {
 			"fontSize": true,
-			"__experimentalFontFamily": true,
 			"lineHeight": true,
-			"__experimentalFontStyle": true,
+			"__experimentalFontFamily": true,
 			"__experimentalFontWeight": true,
-			"__experimentalLetterSpacing": true,
+			"__experimentalFontStyle": true,
 			"__experimentalTextTransform": true,
+			"__experimentalTextDecoration": true,
+			"__experimentalLetterSpacing": true,
 			"__experimentalDefaultControls": {
 				"fontSize": true
 			}


### PR DESCRIPTION
Related:
- https://github.com/WordPress/gutenberg/issues/43241
- https://github.com/WordPress/gutenberg/issues/43242

## What?

Adds missing letter-spacing support to the List block.

## Why?

- Improves consistency of our design tools across blocks.

## How?

- Opts into missing letter spacing typography support.

## Testing Instructions

1. Edit a post, and add a List block with multiple items.
2. Select the List block and confirm the letter spacing control is available.
3. Test various typography settings ensuring styles are applied in the editor.
4. Save and confirm the application on the frontend.
5. Switch to the site editor and select a page with a List.
6. Navigate to Global Styles > Blocks > List > Typography and apply typography styles there.
7. Confirm the selected styles are reflected in the preview and on the frontend.

## Screenshots or screencast <!-- if applicable -->


https://user-images.githubusercontent.com/60436221/185078060-05f9b44b-80ac-4f31-81c1-745980047ce5.mp4


