### PR TITLE
List Item: Adopt typography supports

### DIFF
--- a/docs/reference-guides/core-blocks.md
+++ b/docs/reference-guides/core-blocks.md
@@ -347,7 +347,7 @@ Create a list item. ([Source](https://github.com/WordPress/gutenberg/tree/trunk/
 
 -	**Name:** core/list-item
 -	**Category:** text
--	**Supports:** ~~className~~
+-	**Supports:** typography (fontSize, lineHeight), ~~className~~
 -	**Attributes:** content, placeholder
 
 ## Login/out

--- a/packages/block-library/src/list-item/block.json
+++ b/packages/block-library/src/list-item/block.json
@@ -21,6 +21,19 @@
 	},
 	"supports": {
 		"className": false,
-		"__experimentalSelector": "li"
+		"__experimentalSelector": "li",
+		"typography": {
+			"fontSize": true,
+			"lineHeight": true,
+			"__experimentalFontFamily": true,
+			"__experimentalFontWeight": true,
+			"__experimentalFontStyle": true,
+			"__experimentalTextTransform": true,
+			"__experimentalTextDecoration": true,
+			"__experimentalLetterSpacing": true,
+			"__experimentalDefaultControls": {
+				"fontSize": true
+			}
+		}
 	}
 }


### PR DESCRIPTION
Related:
- https://github.com/WordPress/gutenberg/issues/43241
- https://github.com/WordPress/gutenberg/issues/43242

## What?

Adds all typography support to the List Item block.

## Why?

- Improves consistency of our design tools across blocks.

## How?

- Opts into all typography support.

## Testing Instructions

1. Make sure you have the "List block v2" Gutenberg experiment turned on.
    - <img width="1474" alt="Screen Shot 2022-08-17 at 7 01 53 pm" src="https://user-images.githubusercontent.com/60436221/185080506-d27d0380-ad17-4d2b-a7de-3513a9f66288.png">
2. Edit a post, add a List block with multiple items, and select an item.
3. Test various typography settings ensuring styles are applied in the editor.
4. Save and confirm the application on the frontend.
5. Switch to the site editor and add a List with items to a page or template.
6. Navigate to Global Styles > Blocks > List Item > Typography and apply typography styles there.
7. Confirm the selected styles are reflected in the preview and on the frontend.

## Screenshots or screencast <!-- if applicable -->


https://user-images.githubusercontent.com/60436221/185080473-0dc12445-83c7-4f8a-949a-090692f95e1f.mp4


