### PR TITLE
Improve Safari text-selection style.

### DIFF
--- a/packages/block-editor/src/components/block-list/style.scss
+++ b/packages/block-editor/src/components/block-list/style.scss
@@ -5,10 +5,6 @@
 }
 
 /**
- * Notices & Block Selected/Hover Styles.
- */
-
-/**
  * Cross-Block Selection
  */
 
@@ -104,8 +100,28 @@
 			border-color: var(--wp-admin-theme-color);
 		}
 	}
-}
 
+	// Ensure an accurate partial text selection.
+	// To do this, we disable text selection on the main container, then re-enable it only on the
+	// elements that actually get selected.
+	// To keep in mind: user-select is currently inherited to all nodes inside.
+	user-select: none;
+
+	// Re-enable it on components inside.
+	[class^="components-"] {
+		user-select: text;
+	}
+
+	// Re-enable it on editable items.
+	[contenteditable] {
+		user-select: text;
+
+		// Hide the select style pseudo element as it interferes with the style.
+		&.is-partially-selected::after {
+			display: none;
+		}
+	}
+}
 
 .is-block-moving-mode.block-editor-block-list__block-selection-button {
 	// Should be invisible but not unfocusable.

--- a/packages/block-editor/src/components/block-list/style.scss
+++ b/packages/block-editor/src/components/block-list/style.scss
@@ -112,7 +112,8 @@
 		user-select: text;
 	}
 
-	// Re-enable it on editable items.
+	// Re-enable it on editable items and a few others.
+	.block-editor-block-list__block,
 	[contenteditable] {
 		user-select: text;
 

--- a/packages/block-editor/src/components/block-list/style.scss
+++ b/packages/block-editor/src/components/block-list/style.scss
@@ -105,22 +105,17 @@
 	// To do this, we disable text selection on the main container, then re-enable it only on the
 	// elements that actually get selected.
 	// To keep in mind: user-select is currently inherited to all nodes inside.
-	user-select: none;
+
+	// This is a hack to only disable user-select when blocks are selected inside.
+	// @todo: We shouldn't be targetting the label, this is only a POC. Should be replaced with a class.
+	//user-select: none;
+	[aria-label="Multiple selected blocks"] & {
+		user-select: none;
+	}
 
 	// Re-enable it on components inside.
 	[class^="components-"] {
 		user-select: text;
-	}
-
-	// Re-enable it on editable items and a few others.
-	.block-editor-block-list__block,
-	[contenteditable] {
-		user-select: text;
-
-		// Hide the select style pseudo element as it interferes with the style.
-		&.is-partially-selected::after {
-			display: none;
-		}
 	}
 }
 
@@ -134,6 +129,19 @@
 
 .block-editor-block-list__layout .block-editor-block-list__block {
 	position: relative;
+
+	// Re-enable text-selection on editable blocks.
+	user-select: text;
+
+	// Hide the select style pseudo element as it interferes with the style.
+	&.is-partially-selected::after {
+		height: 0;
+	}
+
+	&.is-highlighted::after,
+	&.is-highlighted ~ .is-multi-selected::after {
+		height: auto;
+	}
 
 	// Break long strings of text without spaces so they don't overflow the block.
 	overflow-wrap: break-word;

--- a/packages/block-editor/src/components/block-list/style.scss
+++ b/packages/block-editor/src/components/block-list/style.scss
@@ -105,7 +105,9 @@
 	// To do this, we disable text selection on the main container, then re-enable it only on the
 	// elements that actually get selected.
 	// To keep in mind: user-select is currently inherited to all nodes inside.
-	user-select: none;
+	.has-multi-selection & {
+		user-select: none;
+	}
 
 	// Re-enable it on components inside.
 	[class^="components-"] {

--- a/packages/block-editor/src/components/block-list/style.scss
+++ b/packages/block-editor/src/components/block-list/style.scss
@@ -105,13 +105,7 @@
 	// To do this, we disable text selection on the main container, then re-enable it only on the
 	// elements that actually get selected.
 	// To keep in mind: user-select is currently inherited to all nodes inside.
-
-	// This is a hack to only disable user-select when blocks are selected inside.
-	// @todo: We shouldn't be targetting the label, this is only a POC. Should be replaced with a class.
-	//user-select: none;
-	[aria-label="Multiple selected blocks"] & {
-		user-select: none;
-	}
+	user-select: none;
 
 	// Re-enable it on components inside.
 	[class^="components-"] {

--- a/packages/block-editor/src/components/writing-flow/index.js
+++ b/packages/block-editor/src/components/writing-flow/index.js
@@ -51,12 +51,14 @@ export function useWritingFlow() {
 						return;
 					}
 
+					node.classList.add( 'has-multi-selection' );
 					node.setAttribute(
 						'aria-label',
 						__( 'Multiple selected blocks' )
 					);
 
 					return () => {
+						node.classList.remove( 'has-multi-selection' );
 						node.removeAttribute( 'aria-label' );
 					};
 				},

--- a/packages/block-library/src/paragraph/editor.scss
+++ b/packages/block-library/src/paragraph/editor.scss
@@ -17,3 +17,28 @@
 		}
 	}
 }
+
+
+// Precise partial text selections.
+// @todo: For now, proof of concept. But code needs to be moved to the most appropriate place.
+// Furthermore, this code right now is likely going to affect numerous nested blocks, so
+// it will be important to scope it right!
+// To keep in mind, user-select is currently inherited to all nodes inside.
+// One solution: apply the user-select properties dynamically during selection.
+
+// Disable text selection on the main container.
+// This is necessary to ensure that we can direct the browser towards the content that's actually
+// meant to be selected.
+.block-editor-block-list__layout {
+	user-select: none;
+}
+
+// Re-enable it on Paragraphs.
+.block-editor-rich-text__editable {
+	user-select: text;
+
+	// Hide the select style pseudo element as it interferes with the style.
+	&.is-partially-selected::after {
+		display: none;
+	}
+}

--- a/packages/block-library/src/paragraph/editor.scss
+++ b/packages/block-library/src/paragraph/editor.scss
@@ -17,28 +17,3 @@
 		}
 	}
 }
-
-
-// Precise partial text selections.
-// @todo: For now, proof of concept. But code needs to be moved to the most appropriate place.
-// Furthermore, this code right now is likely going to affect numerous nested blocks, so
-// it will be important to scope it right!
-// To keep in mind, user-select is currently inherited to all nodes inside.
-// One solution: apply the user-select properties dynamically during selection.
-
-// Disable text selection on the main container.
-// This is necessary to ensure that we can direct the browser towards the content that's actually
-// meant to be selected.
-.block-editor-block-list__layout {
-	user-select: none;
-}
-
-// Re-enable it on Paragraphs.
-.block-editor-rich-text__editable {
-	user-select: text;
-
-	// Hide the select style pseudo element as it interferes with the style.
-	&.is-partially-selected::after {
-		display: none;
-	}
-}


### PR DESCRIPTION
## What?

Currently a proof of concept, this PR means to improve the clarity of the partial selection style in Safari and other browsers, where it currently selects not just text, but divs and pseudo elements, resulting in a very broken looking experience:

<img width="1181" alt="before" src="https://user-images.githubusercontent.com/1204802/185081029-3dcfd1a4-5c11-4873-81c0-d39bd8849ad4.png">

By applying `user-select: none;` to elements that are not meant to be shown as selected, and by enabling it again using `user-select: text;`, we are able to ensure that the visible selection style matches what you have actually selected:

<img width="772" alt="after" src="https://user-images.githubusercontent.com/1204802/185081300-681fcac0-0dd3-4f16-8ce3-b43eeb83c08c.png">

## Why?

This is crucially important for the experience, because the current experience mis-represents what you have selected.

## How?

This proof of concept simply places rules that makes this work for partial text selections in the Paragraph block CSS. This is not where I expect the code to live, but it shows how the issue can be fixed.

We'll want to find out how to best apply these properties so that the issue is fixed, but we don't disable text selection for other parts. At the moment ([this appears to be a bug](https://developer.mozilla.org/en-US/docs/Web/CSS/user-select#syntax)), major browsers treat the property as one to be inherited by default, which means we need to unset the property again for any child elements. 

One idea as alluded to in the comments, is to apply the properties during the selection, and manage them that way.


## Testing Instructions

* Use Safari
* In trunk, add two paragraphs to TwentyTwentyTwo, then make a partial selection between them.
* Then try the same with this PR, and observe the difference in selection style.
