### PR TITLE
Post Author: Add missing typography supports

### DIFF
--- a/packages/block-library/src/post-author/block.json
+++ b/packages/block-library/src/post-author/block.json
@@ -35,10 +35,12 @@
 		"typography": {
 			"fontSize": true,
 			"lineHeight": true,
-			"__experimentalFontStyle": true,
+			"__experimentalFontFamily": true,
 			"__experimentalFontWeight": true,
-			"__experimentalLetterSpacing": true,
+			"__experimentalFontStyle": true,
 			"__experimentalTextTransform": true,
+			"__experimentalTextDecoration": true,
+			"__experimentalLetterSpacing": true,
 			"__experimentalDefaultControls": {
 				"fontSize": true
 			}


### PR DESCRIPTION
Depends On:
- https://github.com/WordPress/gutenberg/pull/43300
- The above PR fixes early return for blocks with duotone support but no duotone styles, preventing any further generation of global styles for the current block type.

Related:
- https://github.com/WordPress/gutenberg/issues/43241
- https://github.com/WordPress/gutenberg/issues/43242

## What?

Adds missing font-family and text-decoration typography support to the Post Author block.

## Why?

- Improves consistency of our design tools across blocks.

## How?

- Opts into missing font-family and text-decoration typography support.

## Testing Instructions

1. Edit a post, add a Post Author block, and select it.
2. Check that the font-family and text-decoration controls are now available.
2. Test various typography settings ensuring styles are applied in the editor.
3. Save and confirm the application on the frontend.
4. Apply the changes from https://github.com/WordPress/gutenberg/pull/43300 to this branch (fixes duotone bug breaking global styles)
4. Switch to the site editor and add a Post Author to a page or template.
5. Navigate to Global Styles > Blocks > Post Author > Typography and apply typography styles there.
6. Confirm the selected styles are reflected in the preview and on the frontend.

## Screenshots or screencast <!-- if applicable -->

https://user-images.githubusercontent.com/60436221/185095989-65f0af6c-219d-49f9-88ae-bb4aeb0c72e5.mp4


