### PR TITLE
Post Author Biography: Add missing typography support

### DIFF
--- a/packages/block-library/src/post-author-biography/block.json
+++ b/packages/block-library/src/post-author-biography/block.json
@@ -32,6 +32,7 @@
 			"__experimentalFontWeight": true,
 			"__experimentalFontStyle": true,
 			"__experimentalTextTransform": true,
+			"__experimentalTextDecoration": true,
 			"__experimentalLetterSpacing": true,
 			"__experimentalDefaultControls": {
 				"fontSize": true


### PR DESCRIPTION
Related:
- https://github.com/WordPress/gutenberg/issues/43241
- https://github.com/WordPress/gutenberg/issues/43242

## What?

Adds missing text-decoration typography support to the Post Author Biography block.

## Why?

- Improves consistency of our design tools across blocks.

## How?

- Opts into missing text-decoration typography support.

## Testing Instructions

1. Edit a post, add a Post Author Biography block, and select it.
2. Check that the text-decoration controls are now available.
2. Test various typography settings ensuring styles are applied in the editor.
3. Save and confirm the application on the frontend.
4. Style the Post Author Biography block via theme.json to add a text-decoration style.
5. Confirm the theme.json style applies correctly in the editor and frontend.

Example theme.json snippet.

```json
			"core/post-author-biography": {
				"typography": {
					"textDecoration": "line-through"
				}
			}
```

## Screenshots or screencast <!-- if applicable -->

https://user-images.githubusercontent.com/60436221/185097737-2e005cfb-f9a6-4bbe-ba77-1fd9aede8d96.mp4


