### PR TITLE
Post Author Name: Add missing typography supports

### DIFF
--- a/packages/block-library/src/post-author-name/block.json
+++ b/packages/block-library/src/post-author-name/block.json
@@ -43,7 +43,11 @@
 			"__experimentalFontWeight": true,
 			"__experimentalFontStyle": true,
 			"__experimentalTextTransform": true,
-			"__experimentalLetterSpacing": true
+			"__experimentalTextDecoration": true,
+			"__experimentalLetterSpacing": true,
+			"__experimentalDefaultControls": {
+				"fontSize": true
+			}
 		}
 	}
 }


### PR DESCRIPTION
Related:
- https://github.com/WordPress/gutenberg/issues/43241
- https://github.com/WordPress/gutenberg/issues/43242

## What?

Adds missing text-decoration typography support to the Post Author Name block.

## Why?

- Improves consistency of our design tools across blocks.

## How?

- Opts into missing text-decoration typography support.
- Sets the font size control to display by default matching most other blocks.

## Testing Instructions

1. Edit a post, add a Post Author Name block, and select it.
2. Check that the text-decoration controls are now available.
2. Test various typography settings ensuring styles are applied in the editor.
3. Save and confirm the application on the frontend.
4. Style the Post Author Name block via theme.json to add a text-decoration style.
5. Confirm the theme.json style applies correctly in the editor and frontend.

Example theme.json snippet.

```json
			"core/post-author-name": {
				"typography": {
					"textDecoration": "line-through"
				}
			}
```

## Screenshots or screencast <!-- if applicable -->

https://user-images.githubusercontent.com/60436221/185098703-3c271cdd-330c-4f92-b04d-afc91ae6eb93.mp4


