### PR TITLE
Popover: Move eslint-disable comment to the correct deps array

### DIFF
--- a/packages/components/src/popover/index.js
+++ b/packages/components/src/popover/index.js
@@ -187,10 +187,6 @@ const Popover = (
 		}
 
 		return documentToReturn ?? document;
-
-		// 'reference' and 'refs.floating' are refs and don't need to be listed
-		// as dependencies (see https://github.com/WordPress/gutenberg/pull/41612)
-		// eslint-disable-next-line react-hooks/exhaustive-deps
 	}, [ anchorRef, anchorRect, getAnchorRect ] );
 
 	/**
@@ -372,6 +368,9 @@ const Popover = (
 			refs.floating.current,
 			update
 		);
+		// 'reference' and 'refs.floating' are refs and don't need to be listed
+		// as dependencies (see https://github.com/WordPress/gutenberg/pull/41612)
+		// eslint-disable-next-line react-hooks/exhaustive-deps
 	}, [ anchorRef, anchorRect, getAnchorRect, update ] );
 
 	// This is only needed for a smooth transition when moving blocks.


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Part of #41166

Implement the suggestion from https://github.com/WordPress/gutenberg/pull/43267#discussion_r946660349 (which got applied to the wrong dependency array)

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

See https://github.com/WordPress/gutenberg/pull/41612

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

Move eslint-disable comment to the correct hook dep array

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->

Run `npx eslint --rule 'react-hooks/exhaustive-deps: warn' packages/components/src/popover/`, make sure no warning is written to console