### PR TITLE
Post Comments Count: Add missing typography supports

### DIFF
--- a/packages/block-library/src/post-comments-count/block.json
+++ b/packages/block-library/src/post-comments-count/block.json
@@ -25,8 +25,11 @@
 		"typography": {
 			"fontSize": true,
 			"lineHeight": true,
-			"__experimentalFontStyle": true,
+			"__experimentalFontFamily": true,
 			"__experimentalFontWeight": true,
+			"__experimentalFontStyle": true,
+			"__experimentalTextTransform": true,
+			"__experimentalTextDecoration": true,
 			"__experimentalLetterSpacing": true,
 			"__experimentalDefaultControls": {
 				"fontSize": true


### PR DESCRIPTION
Related:
- https://github.com/WordPress/gutenberg/issues/43241
- https://github.com/WordPress/gutenberg/issues/43242

## What?

Adds missing typography supports to the Post Comments Count block.

## Why?

- Improves consistency of our design tools across blocks.

## How?

- Opts into missing font-family, text-decoration, and text-transform (only for consistency) typography support.

## Testing Instructions

1. In the site editor, add a Post Comments Count block to a template e.g Index page's posts.
2. Navigate to Global Styles > Blocks > Post Comments Count > Typography.
2. Apply a different font family and save.
5. Confirm font family style is applied to the count on the frontend.

## Screenshots or screencast <!-- if applicable -->

https://user-images.githubusercontent.com/60436221/185101599-ebc52960-566c-48ba-af0b-548fbdcf3fa5.mp4


