### PR TITLE
[Mobile] - Disable FastImage on Android

### DIFF
--- a/packages/components/src/mobile/image/index.native.js
+++ b/packages/components/src/mobile/image/index.native.js
@@ -1,12 +1,7 @@
 /**
  * External dependencies
  */
-import {
-	Image as RNImage,
-	Text,
-	View,
-	useWindowDimensions,
-} from 'react-native';
+import { Image as RNImage, Text, View } from 'react-native';
 import FastImage from 'react-native-fast-image';
 
 /**
@@ -16,7 +11,7 @@ import { __ } from '@wordpress/i18n';
 import { Icon } from '@wordpress/components';
 import { image as icon } from '@wordpress/icons';
 import { usePreferredColorSchemeStyle } from '@wordpress/compose';
-import { useEffect, useState, useRef, Platform } from '@wordpress/element';
+import { useEffect, useState, Platform } from '@wordpress/element';
 
 /**
  * Internal dependencies
@@ -59,14 +54,14 @@ const ImageComponent = ( {
 } ) => {
 	const [ imageData, setImageData ] = useState( null );
 	const [ containerSize, setContainerSize ] = useState( null );
-	const [ shouldUseFallback, setShouldUseFallback ] = useState( false );
-	const { height: windowHeight, width: windowWidth } = useWindowDimensions();
-	const isLandscape = useRef( windowWidth > windowHeight );
 
-	const Image = ! shouldUseFastImage ? RNImage : FastImage;
-	const imageResizeMode = ! shouldUseFastImage
-		? resizeMode
-		: FastImage.resizeMode[ resizeMode ];
+	// Disabled for Android due to https://github.com/WordPress/gutenberg/issues/43149
+	const Image =
+		! shouldUseFastImage || Platform.isAndroid ? RNImage : FastImage;
+	const imageResizeMode =
+		! shouldUseFastImage || Platform.isAndroid
+			? resizeMode
+			: FastImage.resizeMode[ resizeMode ];
 
 	useEffect( () => {
 		let isCurrent = true;
@@ -88,21 +83,6 @@ const ImageComponent = ( {
 		}
 		return () => ( isCurrent = false );
 	}, [ url ] );
-
-	// Workaround for Android where changing the orientation breaks FastImage
-	// for now if there's any orientation changes, it will use the fallback
-	// prop to use the default Image component.
-	// https://github.com/WordPress/gutenberg/issues/42869
-	useEffect( () => {
-		if ( Platform.isAndroid && shouldUseFastImage ) {
-			const isCurrentOrientationLandscape = windowWidth > windowHeight;
-
-			if ( isLandscape.current !== isCurrentOrientationLandscape ) {
-				setShouldUseFallback( true );
-				isLandscape.current = isCurrentOrientationLandscape;
-			}
-		}
-	}, [ windowHeight, windowWidth ] );
 
 	const onContainerLayout = ( event ) => {
 		const { height, width } = event.nativeEvent.layout;
@@ -250,7 +230,6 @@ const ImageComponent = ( {
 								resizeMethod: 'scale',
 							} ) }
 							resizeMode={ imageResizeMode }
-							fallback={ shouldUseFallback }
 						/>
 					</View>
 				) }


### PR DESCRIPTION
**Related PRs:**
- `Gutenberg Mobile` -> https://github.com/wordpress-mobile/gutenberg-mobile/pull/5102
- `WordPress iOS` -> https://github.com/wordpress-mobile/WordPress-iOS/pull/19202
- `WordPress Android` -> https://github.com/wordpress-mobile/WordPress-Android/pull/17042

## What?
There's a current issue on Android https://github.com/WordPress/gutenberg/issues/43149 where in some cases the images will disappear with the React Native FastImage library.

## Why?
While we investigate the issue and have a fix that covers all cases we should disable it.

## How?
By disabling FastImage on Android in all cases and only using the built-in React Native Image component.

## Testing Instructions

Test the following cases with the following environments for both iOS and Android:

- [ ] Simple site (public)
- [ ] Simple site (private)
- [ ] Atomic site (public)
- [ ] Atomic site (private) (optional: there's another issue that's already [reported](https://github.com/wordpress-mobile/WordPress-iOS/issues/19055) where media, in general, is not working for Atomic private sites)
- [ ] Self-hosted site (public)
- [ ] Self-hosted site (private) (optional: there's no setting to set a site as private, I tried using the `WP Maintenance Mode` plugin)

### Test case 1 - Image block upload

- Open the app
- Create a new post
- Add an Image block
- Upload an image from the device
- Once the image finish uploading **expect** to see the image visible in the block

### Test case 2 - Gallery block upload

- Open the app
- Create a new post
- Add a Gallery block
- Upload some images from the device
- Once the images finish uploading **expect** to see the images visible in the block

### Test case 3 - Rotate the device with an Image block 

- Open the app
- Create a new post
- Add an Image block
- Upload an image from the device
- Once the image finish uploading **expect** to see the image visible in the block
- Rotate the device
- Expect to image to be visible

## Screenshots or screencast <!-- if applicable -->
N/A