### PR TITLE
Fix featured image being unselectable using arrow keys.

### DIFF
--- a/packages/components/src/placeholder/style.scss
+++ b/packages/components/src/placeholder/style.scss
@@ -184,8 +184,8 @@
 	}
 
 	// Show placeholder buttons on block selection.
+	// Note that these can't be display: none; or visibility: hidden;, as that breaks the writing flow.
 	.components-button {
-		visibility: hidden;
 		opacity: 0;
 		transition: opacity 0.1s linear;
 		@include reduce-motion("transition");
@@ -193,7 +193,6 @@
 
 	.is-selected > & .components-button {
 		opacity: 1;
-		visibility: visible;
 	}
 
 	// By painting the borders here, we enable them to be replaced by the Border control.


### PR DESCRIPTION
## What?

While working on #43180, a failing test for that PR revealed a flaw in the dashed placeholder code that made it unselectable using arrow keys:

![before](https://user-images.githubusercontent.com/1204802/185113032-5e6e3842-93fb-4599-86f6-5e3727ea422d.gif)

As it turns out, this is because when the block is unselected and `visibility: hidden;` is applied to hide the placeholder contents until select, the placeholder shows up as empty. Which makes the writing flow not have any elements to focus inside.

This PR removes that, fixing the issue:


![fixed](https://user-images.githubusercontent.com/1204802/185113301-fa5ae399-0942-41f4-821c-6b414d6d3944.gif)

## Testing Instructions

* Insert a Featured Image
* Insert a paragraph with text below
* Set focus in the paragraph and press the up arrow key
* The featured image should be selected.