### PR TITLE
Try to fix the popover position when changing to `show button text labels`

### DIFF
--- a/packages/edit-post/src/components/header/more-menu/index.js
+++ b/packages/edit-post/src/components/header/more-menu/index.js
@@ -9,6 +9,7 @@ import {
 	PinnedItems,
 } from '@wordpress/interface';
 import { useViewportMatch } from '@wordpress/compose';
+import { useRef } from '@wordpress/element';
 
 /**
  * Internal dependencies
@@ -19,6 +20,7 @@ import ToolsMoreMenuGroup from '../tools-more-menu-group';
 import WritingMenu from '../writing-menu';
 
 const MoreMenu = ( { showIconLabels } ) => {
+	const anchorRef = useRef();
 	const isLargeViewport = useViewportMatch( 'large' );
 
 	return (
@@ -27,6 +29,7 @@ const MoreMenu = ( { showIconLabels } ) => {
 				showTooltip: ! showIconLabels,
 				...( showIconLabels && { variant: 'tertiary' } ),
 			} }
+			popoverProps={ { anchorRef: anchorRef?.current?.firstChild } }
 		>
 			{ ( { onClose } ) => (
 				<>


### PR DESCRIPTION
No sure about this one..
Related PR: https://github.com/WordPress/gutenberg/pull/41361

### Before


https://user-images.githubusercontent.com/16275880/185146541-182b9c49-ba41-4cc8-8eaf-dee0b3324cf6.mov



### After

https://user-images.githubusercontent.com/16275880/185146548-58c28f5e-e0ec-45e1-9a28-b4712f3d4722.mov


