### PR TITLE
Popover: make sure offset middleware always applies the latest frame offset values

### DIFF
--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -12,6 +12,7 @@
 -   `Popover`: fix and improve opening animation ([#43186](https://github.com/WordPress/gutenberg/pull/43186)).
 -   `Popover`: fix incorrect deps in hooks resulting in incorrect positioning after calling `update` ([#43267](https://github.com/WordPress/gutenberg/pull/43267/)).
 -   `FontSizePicker`: Fix excessive margin between label and input ([#43304](https://github.com/WordPress/gutenberg/pull/43304)).
+-   `Popover`: make sure offset middleware always applies the latest frame offset values ([#43329](https://github.com/WordPress/gutenberg/pull/43329/)).
 
 ### Enhancements
 

--- a/packages/components/src/popover/index.js
+++ b/packages/components/src/popover/index.js
@@ -166,7 +166,7 @@ const Popover = (
 		? positionToPlacement( position )
 		: placementProp;
 
-	const ownerDocument = useMemo( () => {
+	const referenceOwnerDocument = useMemo( () => {
 		let documentToReturn;
 
 		if ( anchorRef?.top ) {
@@ -195,7 +195,7 @@ const Popover = (
 	 * Store the offset in a ref, due to constraints with floating-ui:
 	 * https://floating-ui.com/docs/react-dom#variables-inside-middleware-functions.
 	 */
-	const frameOffset = useRef( getFrameOffset( ownerDocument ) );
+	const frameOffset = useRef( getFrameOffset( referenceOwnerDocument ) );
 
 	const middleware = [
 		frameOffset.current || offset
@@ -390,19 +390,20 @@ const Popover = (
 	// we need to manually update the floating's position as the reference's owner
 	// document scrolls. Also update the frame offset if the view resizes.
 	useLayoutEffect( () => {
-		if ( ownerDocument === document ) {
+		if ( referenceOwnerDocument === document ) {
 			return;
 		}
 
-		const { defaultView } = ownerDocument;
+		const { defaultView } = referenceOwnerDocument;
 
-		ownerDocument.addEventListener( 'scroll', update );
+		referenceOwnerDocument.addEventListener( 'scroll', update );
 
 		let updateFrameOffset;
-		const hasFrameElement = !! ownerDocument?.defaultView?.frameElement;
+		const hasFrameElement =
+			!! referenceOwnerDocument?.defaultView?.frameElement;
 		if ( hasFrameElement ) {
 			updateFrameOffset = () => {
-				frameOffset.current = getFrameOffset( ownerDocument );
+				frameOffset.current = getFrameOffset( referenceOwnerDocument );
 				update();
 			};
 			updateFrameOffset();
@@ -410,13 +411,13 @@ const Popover = (
 		}
 
 		return () => {
-			ownerDocument.removeEventListener( 'scroll', update );
+			referenceOwnerDocument.removeEventListener( 'scroll', update );
 
 			if ( updateFrameOffset ) {
 				defaultView.removeEventListener( 'resize', updateFrameOffset );
 			}
 		};
-	}, [ ownerDocument, update ] );
+	}, [ referenceOwnerDocument, update ] );
 
 	const mergedFloatingRef = useMergeRefs( [
 		floating,

--- a/packages/components/src/popover/index.js
+++ b/packages/components/src/popover/index.js
@@ -195,41 +195,39 @@ const Popover = (
 	 * Store the offset in a ref, due to constraints with floating-ui:
 	 * https://floating-ui.com/docs/react-dom#variables-inside-middleware-functions.
 	 */
-	const frameOffset = useRef( getFrameOffset( referenceOwnerDocument ) );
+	const frameOffset = useRef();
 
 	const middleware = [
-		frameOffset.current || offset
-			? offsetMiddleware( ( { placement: currentPlacement } ) => {
-					if ( ! frameOffset.current ) {
-						return offset;
-					}
+		offsetMiddleware( ( { placement: currentPlacement } ) => {
+			if ( ! frameOffset.current ) {
+				return offset ?? 0;
+			}
 
-					const isTopBottomPlacement =
-						currentPlacement.includes( 'top' ) ||
-						currentPlacement.includes( 'bottom' );
+			const isTopBottomPlacement =
+				currentPlacement.includes( 'top' ) ||
+				currentPlacement.includes( 'bottom' );
 
-					// The main axis should represent the gap between the
-					// floating element and the reference element. The cross
-					// axis is always perpendicular to the main axis.
-					const mainAxis = isTopBottomPlacement ? 'y' : 'x';
-					const crossAxis = mainAxis === 'x' ? 'y' : 'x';
+			// The main axis should represent the gap between the
+			// floating element and the reference element. The cross
+			// axis is always perpendicular to the main axis.
+			const mainAxis = isTopBottomPlacement ? 'y' : 'x';
+			const crossAxis = mainAxis === 'x' ? 'y' : 'x';
 
-					// When the popover is before the reference, subtract the offset,
-					// of the main axis else add it.
-					const hasBeforePlacement =
-						currentPlacement.includes( 'top' ) ||
-						currentPlacement.includes( 'left' );
-					const mainAxisModifier = hasBeforePlacement ? -1 : 1;
-					const normalizedOffset = offset ? offset : 0;
+			// When the popover is before the reference, subtract the offset,
+			// of the main axis else add it.
+			const hasBeforePlacement =
+				currentPlacement.includes( 'top' ) ||
+				currentPlacement.includes( 'left' );
+			const mainAxisModifier = hasBeforePlacement ? -1 : 1;
+			const normalizedOffset = offset ? offset : 0;
 
-					return {
-						mainAxis:
-							normalizedOffset +
-							frameOffset.current[ mainAxis ] * mainAxisModifier,
-						crossAxis: frameOffset.current[ crossAxis ],
-					};
-			  } )
-			: undefined,
+			return {
+				mainAxis:
+					normalizedOffset +
+					frameOffset.current[ mainAxis ] * mainAxisModifier,
+				crossAxis: frameOffset.current[ crossAxis ],
+			};
+		} ),
 		__unstableForcePosition ? undefined : flip(),
 		__unstableForcePosition
 			? undefined
@@ -391,6 +389,7 @@ const Popover = (
 	// document scrolls. Also update the frame offset if the view resizes.
 	useLayoutEffect( () => {
 		if ( referenceOwnerDocument === document ) {
+			frameOffset.current = undefined;
 			return;
 		}
 

--- a/packages/components/src/popover/index.js
+++ b/packages/components/src/popover/index.js
@@ -195,11 +195,11 @@ const Popover = (
 	 * Store the offset in a ref, due to constraints with floating-ui:
 	 * https://floating-ui.com/docs/react-dom#variables-inside-middleware-functions.
 	 */
-	const frameOffset = useRef();
+	const frameOffsetRef = useRef();
 
 	const middleware = [
 		offsetMiddleware( ( { placement: currentPlacement } ) => {
-			if ( ! frameOffset.current ) {
+			if ( ! frameOffsetRef.current ) {
 				return offset ?? 0;
 			}
 
@@ -224,8 +224,8 @@ const Popover = (
 			return {
 				mainAxis:
 					normalizedOffset +
-					frameOffset.current[ mainAxis ] * mainAxisModifier,
-				crossAxis: frameOffset.current[ crossAxis ],
+					frameOffsetRef.current[ mainAxis ] * mainAxisModifier,
+				crossAxis: frameOffsetRef.current[ crossAxis ],
 			};
 		} ),
 		__unstableForcePosition ? undefined : flip(),
@@ -389,7 +389,7 @@ const Popover = (
 	// document scrolls. Also update the frame offset if the view resizes.
 	useLayoutEffect( () => {
 		if ( referenceOwnerDocument === document ) {
-			frameOffset.current = undefined;
+			frameOffsetRef.current = undefined;
 			return;
 		}
 
@@ -402,7 +402,9 @@ const Popover = (
 			!! referenceOwnerDocument?.defaultView?.frameElement;
 		if ( hasFrameElement ) {
 			updateFrameOffset = () => {
-				frameOffset.current = getFrameOffset( referenceOwnerDocument );
+				frameOffsetRef.current = getFrameOffset(
+					referenceOwnerDocument
+				);
 				update();
 			};
 			updateFrameOffset();

--- a/packages/components/src/popover/stories/index.js
+++ b/packages/components/src/popover/stories/index.js
@@ -244,7 +244,7 @@ export const WithSlotOutsideIframe = ( args ) => {
 				<Iframe
 					style={ {
 						width: '100%',
-						height: '100%',
+						height: '400px',
 					} }
 				>
 					<div
@@ -258,7 +258,7 @@ export const WithSlotOutsideIframe = ( args ) => {
 								padding: '8px',
 								background: 'salmon',
 								maxWidth: '200px',
-								marginTop: '30px',
+								marginTop: '100px',
 								marginLeft: 'auto',
 								marginRight: 'auto',
 							} }


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Tracked in #42770

Fixes a regression introduced by #43172 and #43267 where the `Popover` would sometimes not position correctly compared to its anchor

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

The cause of this regression is that when `frameOffset` was refactored to be a ref object, we didn't take into account the fact that the `offset` middleware was being added based (also) on `frameOffset.current` — and therefore, since the value of `frameOffset.current` wouldn't cause a re-render when changing (it's a ref), the `offset` middleware would not be correctly added / removed.

(see https://github.com/WordPress/gutenberg/pull/43329#discussion_r948061871 for more details)

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

This PR makes the `offset` middleware always present in the middleware chain, removing the conditional check. This ensures that the middleware runs every time — the resulting offset will be still based off `frameOffset.current` anyway. 

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->

- Open Storybook and make sure that the examples work as expected

- In both the site editor and the post editor:
  - Make sure that popovers position gets updated as expected
  - In particular, make sure that the popover are updated when scrolling / resizing / opening side menus etc

**Known issues:**

The iframe storybook example is still not behaving as expected (it never did since its introduction), but it's getting better every time. The reason for this may be related to the `anchorRef` object and the fact that its changes don't always trigger hook runs as they should.

## Screenshots

`trunk`:

https://user-images.githubusercontent.com/1083581/185173516-88ae2e88-7dce-4529-acd2-4d33879b92f8.mp4

This PR:

https://user-images.githubusercontent.com/1083581/185173288-8b6c87ae-6f69-4293-ae3a-f466740b9f12.mp4


