### PR TITLE
Site editor: do not show scrollbar when toolbar overflows the editor wrapper

### DIFF
--- a/packages/edit-site/src/components/editor/style.scss
+++ b/packages/edit-site/src/components/editor/style.scss
@@ -32,6 +32,7 @@ html.wp-toolbar {
 	position: relative;
 	height: 100%;
 	display: block;
+	overflow: hidden;
 
 	iframe {
 		display: block;


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Tracked in #42770

Set `overflow: hidden` on the site editor wrapper to avoid extra scrollbars showing when the block toolbar scroll past the visible editor canvas' viewport.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

When the block toolbar moves "below the fold", a second scrollbar appears — which makes scrolling through the document awkward and, depending on the device and pointer setup, can cause the contents of the site editor to slightly shift sideways.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

Setting `overflow: hidden` on `.edit-site-visual-editor` makes sure that no extra scrollbars are shown.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->

- In the site editor, scroll to the bottom and select one of the last blocks
- Scroll up
- On trunk, a second scrollbar appears when the scrollbar stops shifting up and goes below the fold
- On this PR, the second scrollbar doesn't appear

Make sure no other regressions are caused by this PR

## Screenshots or screencast <!-- if applicable -->

`trunk`


https://user-images.githubusercontent.com/1083581/185180725-ead28109-a1c9-4d24-9f09-db7ffc80721b.mp4



This PR:


https://user-images.githubusercontent.com/1083581/185180645-86b28f70-7d22-4fed-8ab5-f14b1c9e758e.mp4

