### PR TITLE
Popover: make more reactive to prop changes, avoid unnecessary updates

### DIFF
--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Bug Fix
 
 -   `Popover`: enable auto-updating every animation frame ([#43617](https://github.com/WordPress/gutenberg/pull/43617)).
+-   `Popover`: improve the component's performance and reactivity to prop changes by reworking its internals ([#43335](https://github.com/WordPress/gutenberg/pull/43335)).
 
 ### Internal
 

--- a/packages/components/src/popover/index.js
+++ b/packages/components/src/popover/index.js
@@ -449,10 +449,16 @@ const Popover = (
 					].join( ' ' ) }
 					style={ {
 						left: Number.isFinite( arrowData?.x )
-							? `${ arrowData.x }px`
+							? `${
+									arrowData.x +
+									( frameOffsetRef.current?.x ?? 0 )
+							  }px`
 							: '',
 						top: Number.isFinite( arrowData?.y )
-							? `${ arrowData.y }px`
+							? `${
+									arrowData.y +
+									( frameOffsetRef.current?.y ?? 0 )
+							  }px`
 							: '',
 					} }
 				>

--- a/packages/components/src/popover/index.js
+++ b/packages/components/src/popover/index.js
@@ -385,7 +385,14 @@ const Popover = (
 		update,
 		placement: computedPlacement,
 		middlewareData: { arrow: arrowData = {} },
-	} = useFloating( { placement: normalizedPlacementFromProps, middleware } );
+	} = useFloating( {
+		placement: normalizedPlacementFromProps,
+		middleware,
+		whileElementsMounted: ( referenceParam, floatingParam, updateParam ) =>
+			autoUpdate( referenceParam, floatingParam, updateParam, {
+				animationFrame: true,
+			} ),
+	} );
 
 	useEffect( () => {
 		offsetRef.current = offsetProp;
@@ -407,18 +414,7 @@ const Popover = (
 		}
 
 		reference( referenceElement );
-
-		if ( ! refs.floating.current ) {
-			return;
-		}
-
-		return autoUpdate( referenceElement, refs.floating.current, update, {
-			animationFrame: true,
-		} );
-		// 'refs.floating' is a ref and doesn't need to be listed
-		// as dependency (see https://github.com/WordPress/gutenberg/pull/41612)
-		// eslint-disable-next-line react-hooks/exhaustive-deps
-	}, [ reference, referenceElement, update ] );
+	}, [ reference, referenceElement ] );
 
 	// If the reference element is in a different ownerDocument (e.g. iFrame),
 	// we need to manually update the floating's position as the reference's owner

--- a/packages/components/src/popover/index.js
+++ b/packages/components/src/popover/index.js
@@ -94,11 +94,20 @@ const MaybeAnimatedWrapper = forwardRef(
 		},
 		forwardedRef
 	) => {
+		// When animating, animate only once (i.e. when the popover is opened), and
+		// do not animate on subsequent prop changes (as it conflicts with
+		// floating-ui's positioning updates).
+		const [ hasAnimatedOnce, setHasAnimatedOnce ] = useState( false );
 		const shouldReduceMotion = useReducedMotion();
 
 		const { style: motionInlineStyles, ...otherMotionProps } = useMemo(
 			() => placementToMotionAnimationProps( placement ),
 			[ placement ]
+		);
+
+		const onAnimationComplete = useCallback(
+			() => setHasAnimatedOnce( true ),
+			[]
 		);
 
 		if ( shouldAnimate && ! shouldReduceMotion ) {
@@ -109,6 +118,10 @@ const MaybeAnimatedWrapper = forwardRef(
 						...receivedInlineStyles,
 					} }
 					{ ...otherMotionProps }
+					onAnimationComplete={ onAnimationComplete }
+					animate={
+						hasAnimatedOnce ? false : otherMotionProps.animate
+					}
 					{ ...props }
 					ref={ forwardedRef }
 				/>

--- a/packages/components/src/popover/index.js
+++ b/packages/components/src/popover/index.js
@@ -26,6 +26,7 @@ import {
 	createContext,
 	useContext,
 	useMemo,
+	useCallback,
 	useEffect,
 } from '@wordpress/element';
 import {
@@ -268,7 +269,7 @@ const Popover = (
 					padding: 1, // Necessary to avoid flickering at the edge of the viewport.
 			  } )
 			: undefined,
-		hasArrow ? arrow( { element: arrowRef } ) : undefined,
+		arrow( { element: arrowRef } ),
 	].filter( ( m ) => !! m );
 	const slotName = useContext( slotNameContext ) || __unstableSlotName;
 	const slot = useSlot( slotName );
@@ -314,6 +315,14 @@ const Popover = (
 		offsetRef.current = offsetProp;
 		update();
 	}, [ offsetProp, update ] );
+
+	const arrowCallbackRef = useCallback(
+		( node ) => {
+			arrowRef.current = node;
+			update();
+		},
+		[ update ]
+	);
 
 	// Update the `reference`'s ref.
 	//
@@ -477,7 +486,7 @@ const Popover = (
 			<div className="components-popover__content">{ children }</div>
 			{ hasArrow && (
 				<div
-					ref={ arrowRef }
+					ref={ arrowCallbackRef }
 					className={ [
 						'components-popover__arrow',
 						`is-${ computedPlacement.split( '-' )[ 0 ] }`,

--- a/packages/components/src/popover/stories/index.js
+++ b/packages/components/src/popover/stories/index.js
@@ -1,7 +1,7 @@
 /**
  * WordPress dependencies
  */
-import { useState, useRef } from '@wordpress/element';
+import { useState, useRef, useEffect } from '@wordpress/element';
 import { __unstableIframe as Iframe } from '@wordpress/block-editor';
 
 /**
@@ -107,18 +107,26 @@ export const Default = ( args ) => {
 	const toggleVisible = () => {
 		setIsVisible( ( state ) => ! state );
 	};
+	const buttonRef = useRef();
+	useEffect( () => {
+		buttonRef.current?.focus();
+	}, [] );
 
 	return (
 		<div
 			style={ {
-				minWidth: '600px',
-				minHeight: '600px',
+				width: '300vw',
+				height: '300vh',
 				display: 'flex',
 				alignItems: 'center',
 				justifyContent: 'center',
 			} }
 		>
-			<Button variant="secondary" onClick={ toggleVisible }>
+			<Button
+				variant="secondary"
+				onClick={ toggleVisible }
+				ref={ buttonRef }
+			>
 				Toggle Popover
 				{ isVisible && <Popover { ...args } /> }
 			</Button>
@@ -246,6 +254,8 @@ export const WithSlotOutsideIframe = ( args ) => {
 					style={ {
 						width: '100%',
 						height: '400px',
+						border: '0',
+						outline: '1px solid purple',
 					} }
 				>
 					<div

--- a/packages/components/src/popover/stories/index.js
+++ b/packages/components/src/popover/stories/index.js
@@ -109,7 +109,10 @@ export const Default = ( args ) => {
 	};
 	const buttonRef = useRef();
 	useEffect( () => {
-		buttonRef.current?.focus();
+		buttonRef.current?.scrollIntoView?.( {
+			block: 'center',
+			inline: 'center',
+		} );
 	}, [] );
 
 	return (

--- a/packages/components/src/popover/utils.js
+++ b/packages/components/src/popover/utils.js
@@ -105,3 +105,101 @@ export const getFrameOffset = ( document ) => {
 	const iframeRect = frameElement.getBoundingClientRect();
 	return { x: iframeRect.left, y: iframeRect.top };
 };
+
+export const getReferenceOwnerDocument = ( {
+	// @ts-ignore
+	anchorRef,
+	// @ts-ignore
+	anchorRect,
+	// @ts-ignore
+	getAnchorRect,
+	// @ts-ignore
+	fallbackReferenceElement,
+	// @ts-ignore
+	fallbackDocument,
+} ) => {
+	// In floating-ui's terms:
+	// - "reference" refers to the popover's anchor element.
+	// - "floating" refers the floating popover's element.
+	// A floating element can also be positioned relative to a virtual element,
+	// instead of a real one. A virtual element is represented by an object
+	// with the `getBoundingClientRect()` function (like real elements).
+	// See https://floating-ui.com/docs/virtual-elements for more info.
+	let resultingReferenceOwnerDoc;
+	if ( anchorRef?.top ) {
+		resultingReferenceOwnerDoc = anchorRef?.top.ownerDocument;
+	} else if ( anchorRef?.startContainer ) {
+		resultingReferenceOwnerDoc = anchorRef.startContainer.ownerDocument;
+	} else if ( anchorRef?.current ) {
+		resultingReferenceOwnerDoc = anchorRef.current.ownerDocument;
+	} else if ( anchorRef ) {
+		// This one should be deprecated.
+		resultingReferenceOwnerDoc = anchorRef.ownerDocument;
+	} else if ( anchorRect && anchorRect?.ownerDocument ) {
+		resultingReferenceOwnerDoc = anchorRect.ownerDocument;
+	} else if ( getAnchorRect ) {
+		resultingReferenceOwnerDoc = getAnchorRect(
+			fallbackReferenceElement
+		)?.ownerDocument;
+	}
+
+	return resultingReferenceOwnerDoc ?? fallbackDocument;
+};
+
+export const getReferenceElement = ( {
+	anchorRef,
+	anchorRect,
+	getAnchorRect,
+	fallbackReferenceElement,
+} ) => {
+	let resultingReferenceElement;
+	if ( anchorRef?.top ) {
+		// Create a virtual element for the ref. The expectation is that
+		// if anchorRef.top is defined, then anchorRef.bottom is defined too.
+		resultingReferenceElement = {
+			getBoundingClientRect() {
+				const topRect = anchorRef.top.getBoundingClientRect();
+				const bottomRect = anchorRef.bottom.getBoundingClientRect();
+				return new window.DOMRect(
+					topRect.x,
+					topRect.y,
+					topRect.width,
+					bottomRect.bottom - topRect.top
+				);
+			},
+		};
+	} else if ( anchorRef?.current ) {
+		// Standard React ref.
+		resultingReferenceElement = anchorRef.current;
+	} else if ( anchorRef ) {
+		// If `anchorRef` holds directly the element's value (no `current` key)
+		// This is a weird scenario and should be deprecated.
+		resultingReferenceElement = anchorRef;
+	} else if ( anchorRect ) {
+		// Create a virtual element for the ref.
+		resultingReferenceElement = {
+			getBoundingClientRect() {
+				return anchorRect;
+			},
+		};
+	} else if ( getAnchorRect ) {
+		// Create a virtual element for the ref.
+		resultingReferenceElement = {
+			getBoundingClientRect() {
+				const rect = getAnchorRect( fallbackReferenceElement );
+				return new window.DOMRect(
+					rect.x ?? rect.left,
+					rect.y ?? rect.top,
+					rect.width ?? rect.right - rect.left,
+					rect.height ?? rect.bottom - rect.top
+				);
+			},
+		};
+	} else if ( fallbackReferenceElement ) {
+		// If no explicit ref is passed via props, fall back to
+		// anchoring to the popover's parent node.
+		resultingReferenceElement = fallbackReferenceElement.parentNode;
+	}
+
+	return resultingReferenceElement;
+};

--- a/packages/components/src/popover/utils.js
+++ b/packages/components/src/popover/utils.js
@@ -147,16 +147,24 @@ export const getReferenceOwnerDocument = ( {
 };
 
 export const getReferenceElement = ( {
+	// @ts-ignore
 	anchorRef,
+	// @ts-ignore
 	anchorRect,
+	// @ts-ignore
 	getAnchorRect,
+	// @ts-ignore
 	fallbackReferenceElement,
 } ) => {
-	let resultingReferenceElement;
+	/** @type {import('@floating-ui/react-dom').ReferenceType | undefined} */
+	let referenceElement;
+
 	if ( anchorRef?.top ) {
 		// Create a virtual element for the ref. The expectation is that
 		// if anchorRef.top is defined, then anchorRef.bottom is defined too.
-		resultingReferenceElement = {
+		// Seems to be used by the block toolbar, when multiple blocks are selected
+		// (top and bottom blocks are used to calculate the resulting rect).
+		referenceElement = {
 			getBoundingClientRect() {
 				const topRect = anchorRef.top.getBoundingClientRect();
 				const bottomRect = anchorRef.bottom.getBoundingClientRect();
@@ -170,21 +178,21 @@ export const getReferenceElement = ( {
 		};
 	} else if ( anchorRef?.current ) {
 		// Standard React ref.
-		resultingReferenceElement = anchorRef.current;
+		referenceElement = anchorRef.current;
 	} else if ( anchorRef ) {
 		// If `anchorRef` holds directly the element's value (no `current` key)
 		// This is a weird scenario and should be deprecated.
-		resultingReferenceElement = anchorRef;
+		referenceElement = anchorRef;
 	} else if ( anchorRect ) {
 		// Create a virtual element for the ref.
-		resultingReferenceElement = {
+		referenceElement = {
 			getBoundingClientRect() {
 				return anchorRect;
 			},
 		};
 	} else if ( getAnchorRect ) {
 		// Create a virtual element for the ref.
-		resultingReferenceElement = {
+		referenceElement = {
 			getBoundingClientRect() {
 				const rect = getAnchorRect( fallbackReferenceElement );
 				return new window.DOMRect(
@@ -198,8 +206,8 @@ export const getReferenceElement = ( {
 	} else if ( fallbackReferenceElement ) {
 		// If no explicit ref is passed via props, fall back to
 		// anchoring to the popover's parent node.
-		resultingReferenceElement = fallbackReferenceElement.parentNode;
+		referenceElement = fallbackReferenceElement.parentNode;
 	}
 
-	return resultingReferenceElement;
+	return referenceElement;
 };


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Tracked in #42770

Rewrite `Popover` internals (especially effect dependencies and forced updates) to make component more reactive to external change, but also to avoid unnecessary updates.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

Looking at `Popover` its code looks quite complex, with many updates fragmented across different hooks with different dependencies. The changes in this PR aim at:

- avoiding unnecessary calculations and re-renders
- making the popover's position update more frequently and more correctly, especially after prop updates
- making the code easier to follow

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

An important concept to understand when working on `Popover` is the difference between:
 - component re-renders (ie. React re-rendering the `Popover` component)
 - floating-ui's "updates" (ie. the floating-ui library recalculating the popover position)

### List of changes:

- **Use internal component state to track the `fallbackReferenceElement` and the `referenceOwnerDocument`**. This is to ensure reactive updates when any of those variables change (as suggested in the [docs](https://floating-ui.com/docs/react-dom#external-reference))
- **Move the recalculation of `referenceOwnerDocument` and of the `reference` element under the same `useLayoutEffect` call**. This ensures that these two updates happen together. The dependency list of the `useLayoutEffect` call has also been updated to include all possible permutations of `anchorRef`. Finally, the code calculating these two values has been moved to a separate file, in order to make the code in the `Popover` shorter and easier to follow.
- **Move the `autoUpdate` call from the `useLayoutEffect` hook to the `whileElementsMounted` option of the `useFloating` hook.** The `autoUpdate` can be an expensive function to call, and instead of calling it explicitly in the `useLayoutEffect` hook, we should let `floating-ui` decide when to call it (this follows the suggestion from the [docs](https://floating-ui.com/docs/react-dom#updating))
- **Rework the code around the `arrow` middleware**. The middleware is not added conditionally (as it already does that internally, based on the value of the arrow `element`), and the arrow ref is now a callback ref which calls `update()`, thus making sure that the popover's arrow is always positioned correctly. (as explained in the [docs](https://floating-ui.com/docs/react-dom#conditional-rendering))
- **Limit the popover animation to happen only once (ie. when the popover is opened)**. Prior to this change, any React re-render had the chance of causing `framer-motion` to animate the popover towards its new placement, which would throw off `floating-ui`'s measurements / calculations.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->

#### In Storybook

 - Make sure that the Storybook examples work as expected. In particular, while the Popover is open, try to change its props (e.g. `offset`, `hasArrow`, `placement`...) and make sure that the popover on screen updates correctly
 - Make sure that the Popover in the `WithSlotOutsideIframe` finally aligns correctly to its anchor inside the iframe

#### In the Editor

 - Make sure there are no regressions compared to the current `trunk` behavior
 - Try to assess if there's any perf improvement

## Screenshots or screencast <!-- if applicable -->

#### Storybook - default story

`trunk` (notice how the popover's position is not correct when changing `placement`)

https://user-images.githubusercontent.com/1083581/187238063-2c7497c1-8a05-48e3-9e98-ec35b6d1a416.mp4

This PR:

https://user-images.githubusercontent.com/1083581/187238051-c0cde69c-be93-40c7-83b1-65c11041dcb9.mp4

#### Storybook - iframe story

`trunk` (notice how the popover is not positioned correctly with respect to its anchor in the iframe)

https://user-images.githubusercontent.com/1083581/187238314-679acbda-6095-4f09-b722-25f0925931b1.mp4

This PR:

https://user-images.githubusercontent.com/1083581/187238320-c3704b0e-f979-4ad3-9593-5ea027a3dd22.mp4