### PR TITLE
Enable appearance tools via theme_support

### DIFF
--- a/docs/how-to-guides/themes/theme-json.md
+++ b/docs/how-to-guides/themes/theme-json.md
@@ -325,6 +325,7 @@ To retain backward compatibility, the existing `add_theme_support` declarations 
 | `editor-font-sizes`         | Provide the list of font size via `typography.fontSizes`. |
 | `editor-gradient-presets`   | Provide the list of gradients via `color.gradients`.      |
 | `experimental-link-color`   | Set `color.link` to `true`. `experimental-link-color` will be removed when the plugin requires WordPress 5.9 as the minimum version. |
+| `appearance-tools`          | Set `appearanceTools` to `true`.                          |
 
 #### Presets
 

--- a/docs/how-to-guides/themes/theme-support.md
+++ b/docs/how-to-guides/themes/theme-support.md
@@ -463,3 +463,16 @@ where
 - `<link-color>` is either `var(--wp--preset--color--slug)` (if the user selected a preset value) or a raw color value (if the user selected a custom value)
 
 The block will get attached the class `.wp-elements-<uuid>`.
+
+## Appearance Tools
+
+Use this setting to enable the following Global Styles settings:
+
+- border: color, radius, style, width
+- color: link
+- spacing: blockGap, margin, padding
+- typography: lineHeight
+
+```php
+add_theme_support( 'appearance-tools' );
+```

--- a/lib/experimental/class-wp-theme-json-resolver-gutenberg.php
+++ b/lib/experimental/class-wp-theme-json-resolver-gutenberg.php
@@ -93,7 +93,7 @@ class WP_Theme_JSON_Resolver_Gutenberg extends WP_Theme_JSON_Resolver_6_1 {
 			// Classic themes without a theme.json don't support global duotone.
 			$theme_support_data['settings']['color']['defaultDuotone'] = false;
 
-			// Allow themes to enable appearance tools via theme_support
+			// Allow themes to enable appearance tools via theme_support.
 			if ( current_theme_supports( 'appearance-tools' ) ) {
 				$theme_support_data['settings']['appearanceTools'] = true;
 			}

--- a/lib/experimental/class-wp-theme-json-resolver-gutenberg.php
+++ b/lib/experimental/class-wp-theme-json-resolver-gutenberg.php
@@ -29,6 +29,7 @@ class WP_Theme_JSON_Resolver_Gutenberg extends WP_Theme_JSON_Resolver_6_1 {
 	 * @return WP_Theme_JSON_Gutenberg Entity that holds theme data.
 	 */
 	public static function get_theme_data( $deprecated = array(), $settings = array( 'with_supports' => true ) ) {
+
 		if ( ! empty( $deprecated ) ) {
 			_deprecated_argument( __METHOD__, '5.9' );
 		}
@@ -92,6 +93,11 @@ class WP_Theme_JSON_Resolver_Gutenberg extends WP_Theme_JSON_Resolver_6_1 {
 
 			// Classic themes without a theme.json don't support global duotone.
 			$theme_support_data['settings']['color']['defaultDuotone'] = false;
+
+			// Allow themes to enable appearance tools via theme_support
+			if ( current_theme_supports( 'appearance-tools' ) ) {
+				$theme_support_data['settings']['appearanceTools'] = true;
+			}
 		}
 		$with_theme_supports = new WP_Theme_JSON_Gutenberg( $theme_support_data );
 		$with_theme_supports->merge( static::$theme );

--- a/lib/experimental/class-wp-theme-json-resolver-gutenberg.php
+++ b/lib/experimental/class-wp-theme-json-resolver-gutenberg.php
@@ -29,7 +29,6 @@ class WP_Theme_JSON_Resolver_Gutenberg extends WP_Theme_JSON_Resolver_6_1 {
 	 * @return WP_Theme_JSON_Gutenberg Entity that holds theme data.
 	 */
 	public static function get_theme_data( $deprecated = array(), $settings = array( 'with_supports' => true ) ) {
-
 		if ( ! empty( $deprecated ) ) {
 			_deprecated_argument( __METHOD__, '5.9' );
 		}

--- a/packages/core-data/src/entity-types/theme.ts
+++ b/packages/core-data/src/entity-types/theme.ts
@@ -79,7 +79,7 @@ declare module './base-entity-records' {
 			 */
 			'align-wide': boolean;
 			/**
-			 * Wether appearanceTools are enabled in Global Settings
+			 * Wether appearanceTools are enabled in Global Styles
 			 */
 			'appearance-tools': boolean;
 			/**

--- a/packages/core-data/src/entity-types/theme.ts
+++ b/packages/core-data/src/entity-types/theme.ts
@@ -79,7 +79,7 @@ declare module './base-entity-records' {
 			 */
 			'align-wide': boolean;
 			/**
-			 * Wether appearanceTools are enabled in Global Styles
+			 * Whether appearanceTools are enabled in Global Styles.
 			 */
 			'appearance-tools': boolean;
 			/**

--- a/packages/core-data/src/entity-types/theme.ts
+++ b/packages/core-data/src/entity-types/theme.ts
@@ -79,6 +79,10 @@ declare module './base-entity-records' {
 			 */
 			'align-wide': boolean;
 			/**
+			 * Wether appearanceTools are enabled in Global Settings
+			 */
+			'appearance-tools': boolean;
+			/**
 			 * Whether posts and comments RSS feed links are added to head.
 			 */
 			'automatic-feed-links': boolean;


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Allow a theme to enable `appearanceTools` to any theme including classic themes.

## Why?
Appearance tools are options in the block editor and don't require the use of the FSE to take advantage of.  However there's no way to enable those tools for themes that don't use theme.json.

## How?
This checks for the 'appearance-tools' support and if present flags `settings.appearanceTools` as true in the `theme` portion of Global Styles.

## Testing Instructions
Using a theme that does NOT use a theme.json file enable the 'appearanceTools` theme support.

```
add_theme_support( 'appearance-tools' );
```

Add a group block to a new post.  Note the block settings panel includes `Border` settings.

