### PR TITLE
Post Comments Link: Add missing typography supports

### DIFF
--- a/packages/block-library/src/post-comments-link/block.json
+++ b/packages/block-library/src/post-comments-link/block.json
@@ -26,10 +26,12 @@
 		"typography": {
 			"fontSize": true,
 			"lineHeight": true,
-			"__experimentalFontStyle": true,
+			"__experimentalFontFamily": true,
 			"__experimentalFontWeight": true,
-			"__experimentalLetterSpacing": true,
+			"__experimentalFontStyle": true,
 			"__experimentalTextTransform": true,
+			"__experimentalTextDecoration": true,
+			"__experimentalLetterSpacing": true,
 			"__experimentalDefaultControls": {
 				"fontSize": true
 			}


### PR DESCRIPTION
Related:
- https://github.com/WordPress/gutenberg/issues/43241
- https://github.com/WordPress/gutenberg/issues/43242

## What?

Adds missing typography supports to the Post Comments Link block.

## Why?

- Improves consistency of our design tools across blocks.

## How?

- Opts into missing font-family and text-decoration typography support.

## Testing Instructions

1. In the site editor, add a Post Comments Links block to a template e.g Index page's posts.
2. Navigate to Global Styles > Blocks > Post Comments Link > Typography.
3. Apply a different font family and save. (Note, text decoration cannot be styled globally at this stage)
4. Confirm font family style is applied to the count on the frontend.
5. Reset Global Styles to defaults, select the Post Comments Link block within the preview.
6. On the Block tab of the Settings sidebar, toggle on and test font-family and text decoration.

## Screenshots or screencast <!-- if applicable -->

https://user-images.githubusercontent.com/60436221/185261017-e45b160b-9526-4908-a943-a0a46ace3f11.mp4


