### PR TITLE
Post Content: Add typography supports

### DIFF
--- a/docs/reference-guides/core-blocks.md
+++ b/docs/reference-guides/core-blocks.md
@@ -518,7 +518,7 @@ Displays the contents of a post or page. ([Source](https://github.com/WordPress/
 
 -	**Name:** core/post-content
 -	**Category:** theme
--	**Supports:** align (full, wide), ~~html~~
+-	**Supports:** align (full, wide), typography (fontSize, lineHeight), ~~html~~
 -	**Attributes:** 
 
 ## Post Date

--- a/packages/block-library/src/post-content/block.json
+++ b/packages/block-library/src/post-content/block.json
@@ -10,7 +10,20 @@
 	"supports": {
 		"align": [ "wide", "full" ],
 		"html": false,
-		"__experimentalLayout": true
+		"__experimentalLayout": true,
+		"typography": {
+			"fontSize": true,
+			"lineHeight": true,
+			"__experimentalFontFamily": true,
+			"__experimentalFontWeight": true,
+			"__experimentalFontStyle": true,
+			"__experimentalTextTransform": true,
+			"__experimentalTextDecoration": true,
+			"__experimentalLetterSpacing": true,
+			"__experimentalDefaultControls": {
+				"fontSize": true
+			}
+		}
 	},
 	"editorStyle": "wp-block-post-content-editor"
 }


### PR DESCRIPTION
Related:
- https://github.com/WordPress/gutenberg/issues/43241
- https://github.com/WordPress/gutenberg/issues/43242

## What?

Adds typography supports to the Post Content block.

## Why?

- Improves consistency of our design tools across blocks.
- Provides high-level typographic styling for post content.

## How?

- Opts into all typography supports.
- Makes font size control displayed by default as per majority of blocks currently.

## Testing Instructions

1. In the site editor, edit a template with a Post Content block.
2. Navigate to Global Styles > Blocks > Post Content > Typography.
3. Experiment with typography styles and ensure they are applied in the preview.
4. Confirm styles on the frontend.
5. Reset Global Styles to defaults, select the Post Content block within the preview.
6. On the Block tab of the Settings sidebar, test the typography controls for the individual block.
7. Confirm these work on the frontend as well.

## Screenshots or screencast <!-- if applicable -->

https://user-images.githubusercontent.com/60436221/185265520-6e0285d5-a8bf-4221-9ee1-8e4febecaba0.mp4



