### PR TITLE
Post Date: Add missing typography supports

### DIFF
--- a/packages/block-library/src/post-date/block.json
+++ b/packages/block-library/src/post-date/block.json
@@ -41,6 +41,7 @@
 			"__experimentalFontWeight": true,
 			"__experimentalFontStyle": true,
 			"__experimentalTextTransform": true,
+			"__experimentalTextDecoration": true,
 			"__experimentalLetterSpacing": true,
 			"__experimentalDefaultControls": {
 				"fontSize": true


### PR DESCRIPTION
Related:
- https://github.com/WordPress/gutenberg/issues/43241
- https://github.com/WordPress/gutenberg/issues/43242

## What?

Adds missing typography support to the Post Date block.

## Why?

- Improves consistency of our design tools across blocks.

## How?

- Opts into missing typography supports.

## Testing Instructions

1. Edit a post, add a Post Date block and select it.
2. Test out the text-decoration support ensuring styles are applied in the editor.
3. Save and confirm the application on the frontend.


## Screenshots or screencast <!-- if applicable -->

https://user-images.githubusercontent.com/60436221/185266145-ad6d23a3-9a00-448b-8611-7df7ff2b3295.mp4


