### PR TITLE
Post Excerpt: Add missing typography supports

### DIFF
--- a/packages/block-library/src/post-excerpt/block.json
+++ b/packages/block-library/src/post-excerpt/block.json
@@ -37,10 +37,12 @@
 		"typography": {
 			"fontSize": true,
 			"lineHeight": true,
-			"__experimentalFontStyle": true,
+			"__experimentalFontFamily": true,
 			"__experimentalFontWeight": true,
-			"__experimentalLetterSpacing": true,
+			"__experimentalFontStyle": true,
 			"__experimentalTextTransform": true,
+			"__experimentalTextDecoration": true,
+			"__experimentalLetterSpacing": true,
 			"__experimentalDefaultControls": {
 				"fontSize": true
 			}


### PR DESCRIPTION
Related:
- https://github.com/WordPress/gutenberg/issues/43241
- https://github.com/WordPress/gutenberg/issues/43242

## What?

Adds missing typography supports to the Post Excerpt block.

## Why?

- Improves consistency of our design tools across blocks.

## How?

- Opts into missing font-family, text-decoration typography support.

## Testing Instructions

1. Edit a post, add a Post Excerpt block, and select it.
2. Check that the font-family & text-decoration controls are now available.
2. Test various typography settings ensuring styles are applied in the editor.
3. Save and confirm the application on the frontend.
4. Switch to the site editor, selecting a template with the Post Excerpt block e.g. Index.
5. Navigate to Global Styles > Blocks > Post Excerpt > Typography
6. Test applying a new font-family and confirm its applied in the preview and on the frontend.

## Screenshots or screencast <!-- if applicable -->

https://user-images.githubusercontent.com/60436221/185267622-5b686d8e-c9bb-4c51-bf72-b83135652395.mp4


