### PR TITLE
Post Template: Add typography supports

### DIFF
--- a/docs/reference-guides/core-blocks.md
+++ b/docs/reference-guides/core-blocks.md
@@ -563,7 +563,7 @@ Contains the block elements used to render a post, like the title, date, feature
 
 -	**Name:** core/post-template
 -	**Category:** theme
--	**Supports:** align, ~~html~~, ~~reusable~~
+-	**Supports:** align, typography (fontSize, lineHeight), ~~html~~, ~~reusable~~
 -	**Attributes:** 
 
 ## Post Terms

--- a/packages/block-library/src/post-template/block.json
+++ b/packages/block-library/src/post-template/block.json
@@ -20,6 +20,19 @@
 		"align": true,
 		"__experimentalLayout": {
 			"allowEditing": false
+		},
+		"typography": {
+			"fontSize": true,
+			"lineHeight": true,
+			"__experimentalFontFamily": true,
+			"__experimentalFontWeight": true,
+			"__experimentalFontStyle": true,
+			"__experimentalTextTransform": true,
+			"__experimentalTextDecoration": true,
+			"__experimentalLetterSpacing": true,
+			"__experimentalDefaultControls": {
+				"fontSize": true
+			}
 		}
 	},
 	"style": "wp-block-post-template",


### PR DESCRIPTION
Related:
- https://github.com/WordPress/gutenberg/issues/43241
- https://github.com/WordPress/gutenberg/issues/43242

## What?

Adds typography supports to the Post Template block.

## Why?

- Improves consistency of our design tools across blocks.

## How?

- Opts into all typography supports.
- Makes font size control displayed by default as per the majority of blocks currently.

## Testing Instructions

1. In the site editor, edit a template with a Post Template block, e.g. via a Query Loop.
2. Navigate to Global Styles > Blocks > Post Template > Typography.
3. Experiment with typography styles and ensure they are applied in the preview. (Note: Some inner blocks will have their own default styles that won't inherit from Post Template)
4. Confirm styles on the frontend.
5. Reset Global Styles to defaults, and select the Post Template block within the preview.
6. On the Block tab of the Settings sidebar, test the typography controls for the individual block.

## Screenshots or screencast <!-- if applicable -->


https://user-images.githubusercontent.com/60436221/185269510-f006e2ac-0a3c-475f-9991-8041df02dcd4.mp4


