### PR TITLE
Post Terms: Add missing typography supports

### DIFF
--- a/packages/block-library/src/post-terms/block.json
+++ b/packages/block-library/src/post-terms/block.json
@@ -39,12 +39,14 @@
 			}
 		},
 		"typography": {
-			"lineHeight": true,
 			"fontSize": true,
-			"__experimentalFontStyle": true,
+			"lineHeight": true,
+			"__experimentalFontFamily": true,
 			"__experimentalFontWeight": true,
-			"__experimentalLetterSpacing": true,
+			"__experimentalFontStyle": true,
 			"__experimentalTextTransform": true,
+			"__experimentalTextDecoration": true,
+			"__experimentalLetterSpacing": true,
 			"__experimentalDefaultControls": {
 				"fontSize": true
 			}


### PR DESCRIPTION
Related:
- https://github.com/WordPress/gutenberg/issues/43241
- https://github.com/WordPress/gutenberg/issues/43242

## What?

Adds missing typography support to the Post Terms block.

## Why?

- Improves consistency of our design tools across blocks.

## How?

- Opts into missing typography supports.

## Testing Instructions

1. Within the site editor, edit a template with Post Terms blocks e.g. Single with Tags/Categories.
2. Select the Post Terms block and within the Settings sidebar, try out the text decoration support.
3. Navigate to Global Styles > Blocks > Post Terms > Typography
3. Try applying a new font family to Post Terms and confirm it's correctly applied in the preview and frontend.

## Screenshots or screencast <!-- if applicable -->

https://user-images.githubusercontent.com/60436221/185273285-54c33769-abd5-4911-86cd-2770fc1f4fee.mp4


