### PR TITLE
Post Navigation Link: Add missing typography supports

### DIFF
--- a/packages/block-library/src/post-navigation-link/block.json
+++ b/packages/block-library/src/post-navigation-link/block.json
@@ -36,10 +36,11 @@
 			"fontSize": true,
 			"lineHeight": true,
 			"__experimentalFontFamily": true,
-			"__experimentalFontStyle": true,
 			"__experimentalFontWeight": true,
-			"__experimentalLetterSpacing": true,
+			"__experimentalFontStyle": true,
 			"__experimentalTextTransform": true,
+			"__experimentalTextDecoration": true,
+			"__experimentalLetterSpacing": true,
 			"__experimentalDefaultControls": {
 				"fontSize": true
 			}


### PR DESCRIPTION
Related:
- https://github.com/WordPress/gutenberg/issues/43241
- https://github.com/WordPress/gutenberg/issues/43242

## What?

Adds missing typography support to the Post Navigation Link block.

## Why?

- Improves consistency of our design tools across blocks.

## How?

- Opts into missing typography supports.

## Testing Instructions

1. Edit a post, add a Previous Post or Next Post link, and select it.
2. Confirm the text-decoration control is available.
3. Test text decoration can be applied and displays correctly within the editor and on the frontend.
4. Clear the text decoration style from the block.
4. Style the Post Navigation Link block via theme.json to add a text-decoration style.
5. Reload editor and confirm the theme.json style applies correctly as well as on the frontend.

Example theme.json snippet.

```json
			"core/post-navigation-link": {
				"typography": {
					"textDecoration": "line-through"
				}
			}
```

## Screenshots or screencast <!-- if applicable -->

https://user-images.githubusercontent.com/60436221/185275561-086c0e88-dec7-43d8-aeb1-d6e0c7c5b1e5.mp4


