### PR TITLE
[RNMobile] Use default placeholder text color for native List Item

### DIFF
--- a/packages/block-library/src/list-item/edit.native.js
+++ b/packages/block-library/src/list-item/edit.native.js
@@ -99,7 +99,7 @@ export default function ListItemEdit( {
 	// or fallback to default color from stylesheet ($gray, $gray-50)
 	const defaultPlaceholderTextColor = style?.baseColors?.color?.text
 		? style.baseColors.color.text + '9E'
-		: placeholderWithPreferredScheme.color;
+		: placeholderWithPreferredScheme?.color;
 
 	const onSplit = useSplit( clientId );
 	const onMerge = useMerge( clientId );

--- a/packages/block-library/src/list-item/edit.native.js
+++ b/packages/block-library/src/list-item/edit.native.js
@@ -97,8 +97,10 @@ export default function ListItemEdit( {
 		styles[ 'wp-block-list-item__list-item-placeholder--dark' ]
 	);
 
+	const currentTextColor = style?.color || style?.baseColors?.color?.text;
+
 	const defaultPlaceholderTextColor = style?.baseColors?.color?.text
-		? styles.color || style.baseColors.color.text
+		? currentTextColor
 		: defaultPlaceholderFromScheme?.color;
 
 	// Add hex opacity to default placeholder text color and style object

--- a/packages/block-library/src/list-item/edit.native.js
+++ b/packages/block-library/src/list-item/edit.native.js
@@ -89,6 +89,12 @@ export default function ListItemEdit( {
 		useCompactList: true,
 	} );
 
+	// Add 0.62 hex opacity to baseColor text (e.g. #FFFFFF9E)
+	// or fallback to sensible default color
+	const defaultPlaceholderTextColor = style?.baseColors?.color?.text
+		? style.baseColors.color.text + '9E'
+		: '#87a6bc';
+
 	const onSplit = useSplit( clientId );
 	const onMerge = useMerge( clientId );
 	const onLayout = useCallback( ( { nativeEvent } ) => {
@@ -128,6 +134,7 @@ export default function ListItemEdit( {
 						}
 						value={ content }
 						placeholder={ placeholder || __( 'List' ) }
+						placeholderTextColor={ defaultPlaceholderTextColor }
 						onSplit={ onSplit }
 						onMerge={ onMerge }
 						onReplace={ ( blocks, ...args ) => {

--- a/packages/block-library/src/list-item/edit.native.js
+++ b/packages/block-library/src/list-item/edit.native.js
@@ -27,6 +27,8 @@ import { IndentUI } from './edit.js';
 import styles from './style.scss';
 import ListStyleType from './list-style-type';
 
+const OPACITY = '9e';
+
 export default function ListItemEdit( {
 	attributes,
 	setAttributes,
@@ -99,18 +101,18 @@ export default function ListItemEdit( {
 
 	const currentTextColor = style?.color || style?.baseColors?.color?.text;
 
-	const defaultPlaceholderTextColor = style?.baseColors?.color?.text
+	const defaultPlaceholderTextColor = currentTextColor
 		? currentTextColor
 		: defaultPlaceholderFromScheme?.color;
 
 	// Add hex opacity to default placeholder text color and style object
 	const defaultPlaceholderTextColorWithOpacity =
-		defaultPlaceholderTextColor + '9e';
+		defaultPlaceholderTextColor + OPACITY;
 
 	const styleWithPlaceholderOpacity = {
 		...style,
 		...( style.color && {
-			placeholderColor: style.color + '9e',
+			placeholderColor: style.color + OPACITY,
 		} ),
 	};
 

--- a/packages/block-library/src/list-item/edit.native.js
+++ b/packages/block-library/src/list-item/edit.native.js
@@ -111,7 +111,7 @@ export default function ListItemEdit( {
 
 	const styleWithPlaceholderOpacity = {
 		...style,
-		...( style.color && {
+		...( style?.color && {
 			placeholderColor: style.color + OPACITY,
 		} ),
 	};

--- a/packages/block-library/src/list-item/edit.native.js
+++ b/packages/block-library/src/list-item/edit.native.js
@@ -85,21 +85,32 @@ export default function ListItemEdit( {
 	const blockProps = useBlockProps( {
 		...( hasInnerBlocks && styles[ 'wp-block-list-item__nested-blocks' ] ),
 	} );
+
 	const innerBlocksProps = useInnerBlocksProps( blockProps, {
 		allowedBlocks: [ 'core/list' ],
 		useCompactList: true,
 	} );
 
-	const placeholderWithPreferredScheme = usePreferredColorSchemeStyle(
+	// Set default placeholder text color from light/dark scheme or base colors
+	const defaultPlaceholderFromScheme = usePreferredColorSchemeStyle(
 		styles[ 'wp-block-list-item__list-item-placeholder' ],
 		styles[ 'wp-block-list-item__list-item-placeholder--dark' ]
 	);
 
-	// Add 0.62 hex opacity to baseColor text (e.g. #FFFFFF9E)
-	// or fallback to default color from stylesheet ($gray, $gray-50)
 	const defaultPlaceholderTextColor = style?.baseColors?.color?.text
-		? style.baseColors.color.text + '9E'
-		: placeholderWithPreferredScheme?.color;
+		? styles.color || style.baseColors.color.text
+		: defaultPlaceholderFromScheme?.color;
+
+	// Add hex opacity to default placeholder text color and style object
+	const defaultPlaceholderTextColorWithOpacity =
+		defaultPlaceholderTextColor + '9e';
+
+	const styleWithPlaceholderOpacity = {
+		...style,
+		...( style.color && {
+			placeholderColor: style.color + '9e',
+		} ),
+	};
 
 	const onSplit = useSplit( clientId );
 	const onMerge = useMerge( clientId );
@@ -140,13 +151,15 @@ export default function ListItemEdit( {
 						}
 						value={ content }
 						placeholder={ placeholder || __( 'List' ) }
-						placeholderTextColor={ defaultPlaceholderTextColor }
+						placeholderTextColor={
+							defaultPlaceholderTextColorWithOpacity
+						}
 						onSplit={ onSplit }
 						onMerge={ onMerge }
 						onReplace={ ( blocks, ...args ) => {
 							onReplace( convertToListItems( blocks ), ...args );
 						} }
-						style={ style }
+						style={ styleWithPlaceholderOpacity }
 						deleteEnter={ true }
 						containerWidth={ contentWidth }
 					/>

--- a/packages/block-library/src/list-item/edit.native.js
+++ b/packages/block-library/src/list-item/edit.native.js
@@ -14,6 +14,7 @@ import {
 	store as blockEditorStore,
 } from '@wordpress/block-editor';
 import { __ } from '@wordpress/i18n';
+import { usePreferredColorSchemeStyle } from '@wordpress/compose';
 import { useSelect } from '@wordpress/data';
 import { useState, useCallback } from '@wordpress/element';
 
@@ -89,11 +90,16 @@ export default function ListItemEdit( {
 		useCompactList: true,
 	} );
 
+	const placeholderWithPreferredScheme = usePreferredColorSchemeStyle(
+		styles[ 'wp-block-list-item__list-item-placeholder' ],
+		styles[ 'wp-block-list-item__list-item-placeholder--dark' ]
+	);
+
 	// Add 0.62 hex opacity to baseColor text (e.g. #FFFFFF9E)
-	// or fallback to sensible default color
+	// or fallback to default color from stylesheet ($gray, $gray-50)
 	const defaultPlaceholderTextColor = style?.baseColors?.color?.text
 		? style.baseColors.color.text + '9E'
-		: '#87a6bc';
+		: placeholderWithPreferredScheme.color;
 
 	const onSplit = useSplit( clientId );
 	const onMerge = useMerge( clientId );

--- a/packages/block-library/src/list-item/style.native.scss
+++ b/packages/block-library/src/list-item/style.native.scss
@@ -47,3 +47,11 @@
 .wp-block-list-item__list-item-container {
 	margin-right: 8;
 }
+
+.wp-block-list-item__list-item-placeholder {
+	color: $gray;
+}
+
+.wp-block-list-item__list-item-placeholder--dark {
+	color: $gray-50;
+}


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->
Fixes:
- https://github.com/wordpress-mobile/gutenberg-mobile/issues/5098
- https://github.com/wordpress-mobile/gutenberg-mobile/pull/5103

## What?
Adds a default placeholder text color and fallback color for native List Items.

## Why?
To differentiate List Item placeholder text with actual text input. 

## How?
If a base text color is defined, add 0.62 hex opacity to baseColor text (e.g. #FFFFFF9E) to match the user color scheme. Else, fallback to `#87a6bc`, which is the placeholder text color found elsewhere. ([#](https://github.com/WordPress/gutenberg/blob/435119c3bed91c10737a574e072d7482e7e5c6bb/packages/components/src/mobile/bottom-sheet-text-control/index.native.js#L84)) 


## Testing Instructions
1) Make sure List block v2 in Experiments is enabled (> Gutenberg 13.8.2)
2) Create a new post, and add a list block.
3) Before inputting text, note the color of the word "List" should be slightly gray
4) Type some text, and note the text should match the normal text input color, and should appear different from the placeholder text color.

## Screenshots or screencast 

<details>
  <summary>Example</summary>

  https://user-images.githubusercontent.com/643285/185291201-9031ab8d-1482-4dd8-97de-1b049b9e913c.mov

</details>


