### PR TITLE
Ensure pagination numbers have an href in block edit function

### DIFF
--- a/packages/block-library/src/comments-pagination-numbers/edit.js
+++ b/packages/block-library/src/comments-pagination-numbers/edit.js
@@ -3,9 +3,18 @@
  */
 import { useBlockProps } from '@wordpress/block-editor';
 
-const PaginationItem = ( { content, tag: Tag = 'a', extraClass = '' } ) => (
-	<Tag className={ `page-numbers ${ extraClass }` }>{ content }</Tag>
-);
+const PaginationItem = ( { content, tag: Tag = 'a', extraClass = '' } ) =>
+	Tag === 'a' ? (
+		<Tag
+			className={ `page-numbers ${ extraClass }` }
+			href="#comments-pagination-numbers-pseudo-link"
+			onClick={ ( event ) => event.preventDefault() }
+		>
+			{ content }
+		</Tag>
+	) : (
+		<Tag className={ `page-numbers ${ extraClass }` }>{ content }</Tag>
+	);
 
 export default function CommentsPaginationNumbersEdit() {
 	return (


### PR DESCRIPTION
## What?
More accurately show comment pagination numbers in the block edit function by ensuring any links have an href.

## Why?
When an `href` isn't defined, the link can appear styled differently in some themes, in a way that seems like it would never happen on the frontend (each anchor would always have an href).

## How?
Specify an anchor href, using the same approach as the comments pagination next/before blocks. Adds an event handler that prevents clicks on these links.

## Testing Instructions
1. For testing I used 'Empty theme' that's bundled with the Gutenberg dev environment
2. Open the site editor and using the 'W' sidebar open the Singular template
3. Add a comments block

Expected: pagination numbers look like visitable links
In trunk:  pagination numbers don't look like visitable links

## Screenshots or screencast <!-- if applicable -->
### Before - pagination numbers don't look like visitable links

![Screen Shot 2022-08-18 at 1 05 10 pm](https://user-images.githubusercontent.com/677833/185298794-b87482dd-44cd-4262-85f3-052720917af7.png)

### After - pagination numbers look like visitable links

![Screen Shot 2022-08-18 at 1 05 34 pm](https://user-images.githubusercontent.com/677833/185299122-7535218a-0981-4990-9750-43d4f5338826.png)


