### PR TITLE
Add Letter spacing and Letter case to Global Styles

### DIFF
--- a/packages/block-editor/src/components/text-transform-control/index.js
+++ b/packages/block-editor/src/components/text-transform-control/index.js
@@ -10,58 +10,60 @@ import {
 } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 import {
+	reset,
 	formatCapitalize,
 	formatLowercase,
 	formatUppercase,
 } from '@wordpress/icons';
 
-const TEXT_TRANSFORMS = [
-	{
-		name: __( 'Uppercase' ),
-		value: 'uppercase',
-		icon: formatUppercase,
-	},
-	{
-		name: __( 'Lowercase' ),
-		value: 'lowercase',
-		icon: formatLowercase,
-	},
-	{
-		name: __( 'Capitalize' ),
-		value: 'capitalize',
-		icon: formatCapitalize,
-	},
-];
-
 /**
  * Control to facilitate text transform selections.
  *
- * @param {Object}   props          Component props.
- * @param {string}   props.value    Currently selected text transform.
- * @param {Function} props.onChange Handles change in text transform selection.
+ * @param {Object}   props            Component props.
+ * @param {string}   props.value      Currently selected text transform.
+ * @param {Function} props.onChange   Handles change in text transform selection.
+ * @param {boolean}  [props.showNone] Whether to display the 'None' option.
  *
  * @return {WPElement} Text transform control.
  */
-export default function TextTransformControl( { value, onChange, ...props } ) {
+export default function TextTransformControl( {
+	value,
+	onChange,
+	showNone,
+	...props
+} ) {
 	return (
 		<ToggleGroupControl
 			{ ...props }
 			className="block-editor-text-transform-control"
-			__experimentalIsBorderless
 			label={ __( 'Letter case' ) }
-			value={ value }
-			onChange={ onChange }
+			value={ value ?? 'none' }
+			onChange={ ( nextValue ) => {
+				onChange( nextValue === 'none' ? undefined : nextValue );
+			} }
 		>
-			{ TEXT_TRANSFORMS.map( ( textTransform ) => {
-				return (
-					<ToggleGroupControlOptionIcon
-						key={ textTransform.value }
-						value={ textTransform.value }
-						icon={ textTransform.icon }
-						label={ textTransform.name }
-					/>
-				);
-			} ) }
+			{ showNone && (
+				<ToggleGroupControlOptionIcon
+					value="none"
+					icon={ reset }
+					label={ __( 'None' ) }
+				/>
+			) }
+			<ToggleGroupControlOptionIcon
+				value="uppercase"
+				icon={ formatUppercase }
+				label={ __( 'Uppercase' ) }
+			/>
+			<ToggleGroupControlOptionIcon
+				value="lowercase"
+				icon={ formatLowercase }
+				label={ __( 'Lowercase' ) }
+			/>
+			<ToggleGroupControlOptionIcon
+				value="capitalize"
+				icon={ formatCapitalize }
+				label={ __( 'Capitalize' ) }
+			/>
 		</ToggleGroupControl>
 	);
 }

--- a/packages/edit-site/src/components/global-styles/hooks.js
+++ b/packages/edit-site/src/components/global-styles/hooks.js
@@ -168,7 +168,6 @@ const ROOT_BLOCK_SUPPORTS = [
 	'fontWeight',
 	'lineHeight',
 	'textDecoration',
-	'textTransform',
 	'padding',
 	'contentSize',
 	'wideSize',

--- a/packages/edit-site/src/components/global-styles/typography-panel.js
+++ b/packages/edit-site/src/components/global-styles/typography-panel.js
@@ -53,12 +53,16 @@ function useHasAppearanceControl( name ) {
 	return hasFontStyles || hasFontWeights;
 }
 
-function useHasLetterSpacingControl( name ) {
+function useHasLetterSpacingControl( name, element ) {
+	const setting = useSetting( 'typography.letterSpacing', name )[ 0 ];
+	if ( ! setting ) {
+		return false;
+	}
+	if ( ! name && element === 'heading' ) {
+		return true;
+	}
 	const supports = getSupportedGlobalStylesPanels( name );
-	return (
-		useSetting( 'typography.letterSpacing', name )[ 0 ] &&
-		supports.includes( 'letterSpacing' )
-	);
+	return supports.includes( 'letterSpacing' );
 }
 
 export default function TypographyPanel( { name, element } ) {
@@ -84,7 +88,7 @@ export default function TypographyPanel( { name, element } ) {
 		supports.includes( 'fontWeight' );
 	const hasLineHeightEnabled = useHasLineHeightControl( name );
 	const hasAppearanceControl = useHasAppearanceControl( name );
-	const hasLetterSpacingControl = useHasLetterSpacingControl( name );
+	const hasLetterSpacingControl = useHasLetterSpacingControl( name, element );
 
 	/* Disable font size controls when the option to style all headings is selected. */
 	let hasFontSizeEnabled = supports.includes( 'fontSize' );

--- a/packages/edit-site/src/components/global-styles/typography-panel.js
+++ b/packages/edit-site/src/components/global-styles/typography-panel.js
@@ -6,6 +6,7 @@ import {
 	__experimentalFontFamilyControl as FontFamilyControl,
 	__experimentalFontAppearanceControl as FontAppearanceControl,
 	__experimentalLetterSpacingControl as LetterSpacingControl,
+	__experimentalTextTransformControl as TextTransformControl,
 } from '@wordpress/block-editor';
 import {
 	PanelBody,
@@ -65,6 +66,18 @@ function useHasLetterSpacingControl( name, element ) {
 	return supports.includes( 'letterSpacing' );
 }
 
+function useHasTextTransformControl( name, element ) {
+	const setting = useSetting( 'typography.textTransform', name )[ 0 ];
+	if ( ! setting ) {
+		return false;
+	}
+	if ( ! name && element === 'heading' ) {
+		return true;
+	}
+	const supports = getSupportedGlobalStylesPanels( name );
+	return supports.includes( 'textTransform' );
+}
+
 export default function TypographyPanel( { name, element } ) {
 	const [ selectedLevel, setCurrentTab ] = useState( 'heading' );
 	const supports = getSupportedGlobalStylesPanels( name );
@@ -89,6 +102,7 @@ export default function TypographyPanel( { name, element } ) {
 	const hasLineHeightEnabled = useHasLineHeightControl( name );
 	const hasAppearanceControl = useHasAppearanceControl( name );
 	const hasLetterSpacingControl = useHasLetterSpacingControl( name, element );
+	const hasTextTransformControl = useHasTextTransformControl( name, element );
 
 	/* Disable font size controls when the option to style all headings is selected. */
 	let hasFontSizeEnabled = supports.includes( 'fontSize' );
@@ -119,6 +133,10 @@ export default function TypographyPanel( { name, element } ) {
 	);
 	const [ letterSpacing, setLetterSpacing ] = useStyle(
 		prefix + 'typography.letterSpacing',
+		name
+	);
+	const [ textTransform, setTextTransform ] = useStyle(
+		prefix + 'typography.textTransform',
 		name
 	);
 	const [ backgroundColor ] = useStyle( prefix + 'color.background', name );
@@ -250,6 +268,14 @@ export default function TypographyPanel( { name, element } ) {
 						onChange={ setLetterSpacing }
 						size="__unstable-large"
 						__unstableInputWidth="auto"
+					/>
+				) }
+				{ hasTextTransformControl && (
+					<TextTransformControl
+						value={ textTransform }
+						onChange={ setTextTransform }
+						size="__unstable-large"
+						__nextHasNoMarginBottom
 					/>
 				) }
 			</Grid>

--- a/packages/edit-site/src/components/global-styles/typography-panel.js
+++ b/packages/edit-site/src/components/global-styles/typography-panel.js
@@ -166,7 +166,12 @@ export default function TypographyPanel( { name, element } ) {
 			>
 				Aa
 			</div>
-			<Grid columns={ 2 } rowGap={ 16 } columnGap={ 8 }>
+			<Grid
+				columns={ 2 }
+				rowGap={ 16 }
+				columnGap={ 8 }
+				templateColumns="repeat(2, minmax(0, 1fr))"
+			>
 				{ element === 'heading' && (
 					<div className="edit-site-typography-panel__full-width-control">
 						<ToggleGroupControl
@@ -274,6 +279,8 @@ export default function TypographyPanel( { name, element } ) {
 					<TextTransformControl
 						value={ textTransform }
 						onChange={ setTextTransform }
+						showNone
+						isBlock
 						size="__unstable-large"
 						__nextHasNoMarginBottom
 					/>


### PR DESCRIPTION
## What?
Two changes:

- Makes _Letter spacing_ (`LetterSpacingControl`) appear in Global Styles → Typography → Headings.
- Adds _Letter case_ (`TextTransformControl`) to Global Styles, and makes it appear in Global Styles → Typography → Headings.

This branch includes the commits in https://github.com/WordPress/gutenberg/pull/43328. Once that PR lands I'll rebase this one. In the meantime, only focus on dcfb5ee1d531077830de31c1583703155556c43b and c133c2f26bba8db61e75168049d3b6a226477f46.

## Why?
So that the Typography panel in Global Styles looks closer to what was designed in Figma. See https://github.com/WordPress/gutenberg/issues/34345#issuecomment-1217390408.

In particular, I'm implementing this suggestion from @mtias https://github.com/WordPress/gutenberg/issues/34345#issuecomment-1217479784:

> They should be available for headings in the global context

## How?
_Letter spacing_ was already set up in Global Styles, just not enabled for headings at the global level. To fix this I added a special condition to `useHasLetterSpacingControl`.

_Letter case_ was not in Global Styles at all. The control already exists so it's just a matter of rendering them in `TypographyPanel` in a manner similar to what we do for _Letter spacing_.

## Testing Instructions
1. Go to Editor → Global Styles → Typography.
2. Check that _Letter spacing_ and _Letter case_ appears in the Heading section but no other sections, and that modifying them works.
2. Go to Global Styles → Blocks.
3. Check that _Letter spacing_ and _Letter case_ appears in the Typography panel for blocks that support these controls, and that modifying them works.

## Screenshots or screencast
https://user-images.githubusercontent.com/612155/185303829-85ff0e19-c410-44f7-afa0-7fecbd0e937d.mp4

## To do
- [ ] Rebase when https://github.com/WordPress/gutenberg/pull/43328 merges.
- [ ] Come up with solution for unsetting _Letter case_.