### PR TITLE
Separator: disable the contrastChecker via block.json

### DIFF
--- a/docs/reference-guides/core-blocks.md
+++ b/docs/reference-guides/core-blocks.md
@@ -707,7 +707,7 @@ Create a break between ideas or sections with a horizontal separator. ([Source](
 
 -	**Name:** core/separator
 -	**Category:** design
--	**Supports:** align (center, full, wide), anchor, color (background, gradients, ~~text~~), spacing (margin)
+-	**Supports:** align (center, full, wide), anchor, color (background, gradients, ~~contrastChecker~~, ~~text~~), spacing (margin)
 -	**Attributes:** opacity
 
 ## Shortcode

--- a/docs/reference-guides/core-blocks.md
+++ b/docs/reference-guides/core-blocks.md
@@ -707,7 +707,7 @@ Create a break between ideas or sections with a horizontal separator. ([Source](
 
 -	**Name:** core/separator
 -	**Category:** design
--	**Supports:** align (center, full, wide), anchor, color (background, gradients, ~~text~~), spacing (margin)
+-	**Supports:** align (center, full, wide), anchor, color (background, gradients, ~~enableContrastChecker~~, ~~text~~), spacing (margin)
 -	**Attributes:** opacity
 
 ## Shortcode

--- a/docs/reference-guides/core-blocks.md
+++ b/docs/reference-guides/core-blocks.md
@@ -707,7 +707,7 @@ Create a break between ideas or sections with a horizontal separator. ([Source](
 
 -	**Name:** core/separator
 -	**Category:** design
--	**Supports:** align (center, full, wide), anchor, color (background, gradients, ~~contrastChecker~~, ~~text~~), spacing (margin)
+-	**Supports:** align (center, full, wide), anchor, color (background, gradients, ~~text~~), spacing (margin)
 -	**Attributes:** opacity
 
 ## Shortcode

--- a/packages/block-editor/src/hooks/color.js
+++ b/packages/block-editor/src/hooks/color.js
@@ -450,16 +450,15 @@ export function ColorEdit( props ) {
 		};
 	};
 
-	const isWebAndColorNotGradient =
-		Platform.OS === 'web' && ! gradient && ! style?.color?.gradient;
-
 	const defaultColorControls = getBlockSupport( props.name, [
 		COLOR_SUPPORT_KEY,
 		'__experimentalDefaultControls',
 	] );
 
 	const enableContrastChecking =
-		isWebAndColorNotGradient &&
+		Platform.OS === 'web' &&
+		! gradient &&
+		! style?.color?.gradient &&
 		// Contrast checking is enabled by default.
 		// Deactivating it requires `__experimentalCheckContrast` to have
 		// an explicit value of `false`.

--- a/packages/block-editor/src/hooks/color.js
+++ b/packages/block-editor/src/hooks/color.js
@@ -292,7 +292,7 @@ const getLinkColorFromAttributeValue = ( colors, value ) => {
 export function ColorEdit( props ) {
 	const { name: blockName, attributes } = props;
 	// Some color settings have a special handling for deprecated flags in `useSetting`,
-	// so we can't unwrap them by doing conwst { ... } = useSetting('color')
+	// so we can't unwrap them by doing const { ... } = useSetting('color')
 	// until https://github.com/WordPress/gutenberg/issues/37094 is fixed.
 	const userPalette = useSetting( 'color.palette.custom' );
 	const themePalette = useSetting( 'color.palette.theme' );

--- a/packages/block-editor/src/hooks/color.js
+++ b/packages/block-editor/src/hooks/color.js
@@ -460,7 +460,10 @@ export function ColorEdit( props ) {
 
 	const enableContrastChecking =
 		isWebAndColorNotGradient &&
-		true ===
+		// Contrast checking is enabled by default.
+		// Deactivating it requires `__experimentalCheckContrast` to have
+		// an explicit value of `false`.
+		false !==
 			getBlockSupport( props.name, [
 				COLOR_SUPPORT_KEY,
 				'__experimentalCheckContrast',

--- a/packages/block-editor/src/hooks/color.js
+++ b/packages/block-editor/src/hooks/color.js
@@ -463,7 +463,7 @@ export function ColorEdit( props ) {
 		true ===
 			getBlockSupport( props.name, [
 				COLOR_SUPPORT_KEY,
-				'contrastChecker',
+				'__experimentalCheckContrast',
 			] );
 
 	return (

--- a/packages/block-editor/src/hooks/color.js
+++ b/packages/block-editor/src/hooks/color.js
@@ -292,7 +292,7 @@ const getLinkColorFromAttributeValue = ( colors, value ) => {
 export function ColorEdit( props ) {
 	const { name: blockName, attributes } = props;
 	// Some color settings have a special handling for deprecated flags in `useSetting`,
-	// so we can't unwrap them by doing const { ... } = useSetting('color')
+	// so we can't unwrap them by doing conwst { ... } = useSetting('color')
 	// until https://github.com/WordPress/gutenberg/issues/37094 is fixed.
 	const userPalette = useSetting( 'color.palette.custom' );
 	const themePalette = useSetting( 'color.palette.theme' );
@@ -450,13 +450,21 @@ export function ColorEdit( props ) {
 		};
 	};
 
-	const enableContrastChecking =
+	const isWebAndColorNotGradient =
 		Platform.OS === 'web' && ! gradient && ! style?.color?.gradient;
 
 	const defaultColorControls = getBlockSupport( props.name, [
 		COLOR_SUPPORT_KEY,
 		'__experimentalDefaultControls',
 	] );
+
+	const enableContrastChecking =
+		isWebAndColorNotGradient &&
+		true ===
+			getBlockSupport( props.name, [
+				COLOR_SUPPORT_KEY,
+				'contrastChecker',
+			] );
 
 	return (
 		<ColorPanel

--- a/packages/block-editor/src/hooks/color.js
+++ b/packages/block-editor/src/hooks/color.js
@@ -460,12 +460,12 @@ export function ColorEdit( props ) {
 		! gradient &&
 		! style?.color?.gradient &&
 		// Contrast checking is enabled by default.
-		// Deactivating it requires `__experimentalCheckContrast` to have
+		// Deactivating it requires `enableContrastChecker` to have
 		// an explicit value of `false`.
 		false !==
 			getBlockSupport( props.name, [
 				COLOR_SUPPORT_KEY,
-				'__experimentalCheckContrast',
+				'enableContrastChecker',
 			] );
 
 	return (

--- a/packages/block-library/src/separator/block.json
+++ b/packages/block-library/src/separator/block.json
@@ -17,7 +17,7 @@
 		"anchor": true,
 		"align": [ "center", "wide", "full" ],
 		"color": {
-			"contrastChecker": false,
+			"__experimentalCheckContrast": false,
 			"__experimentalSkipSerialization": true,
 			"gradients": true,
 			"background": true,

--- a/packages/block-library/src/separator/block.json
+++ b/packages/block-library/src/separator/block.json
@@ -17,6 +17,7 @@
 		"anchor": true,
 		"align": [ "center", "wide", "full" ],
 		"color": {
+			"contrastChecker": false,
 			"__experimentalSkipSerialization": true,
 			"gradients": true,
 			"background": true,

--- a/packages/block-library/src/separator/block.json
+++ b/packages/block-library/src/separator/block.json
@@ -17,7 +17,7 @@
 		"anchor": true,
 		"align": [ "center", "wide", "full" ],
 		"color": {
-			"__experimentalCheckContrast": false,
+			"enableContrastChecker": false,
 			"__experimentalSkipSerialization": true,
 			"gradients": true,
 			"background": true,

--- a/schemas/json/block.json
+++ b/schemas/json/block.json
@@ -278,6 +278,11 @@
 							"type": "boolean",
 							"description": "This property adds block controls which allow the user to set text color in a block.\n\nWhen color support is declared, this property is enabled by default (along with background), so simply setting color will enable text color.\n\nText color presets are sourced from the editor-color-palette theme support.\n\nWhen the block declares support for color.text, the attributes definition is extended to include two new attributes: textColor and style",
 							"default": true
+						},
+						"contrastChecker": {
+							"type": "boolean",
+							"description": "Used to control the contrast checker widget in the block editor UI. The contrast checker appears only if the block declares support for color. It tests the readability of color combinations and warns if there is a potential issue. The property is enabled by default.",
+							"default": true
 						}
 					}
 				},

--- a/schemas/json/block.json
+++ b/schemas/json/block.json
@@ -278,6 +278,11 @@
 							"type": "boolean",
 							"description": "This property adds block controls which allow the user to set text color in a block.\n\nWhen color support is declared, this property is enabled by default (along with background), so simply setting color will enable text color.\n\nText color presets are sourced from the editor-color-palette theme support.\n\nWhen the block declares support for color.text, the attributes definition is extended to include two new attributes: textColor and style",
 							"default": true
+						},
+						"enableContrastChecker": {
+							"type": "boolean",
+							"description": "Determines whether the contrast checker widget displays in the block editor UI.\n\nThe contrast checker appears only if the block declares support for color. It tests the readability of color combinations and warns if there is a potential issue. The property is enabled by default.\n\nSet to `false` to explicitly disable.",
+							"default": true
 						}
 					}
 				},

--- a/schemas/json/block.json
+++ b/schemas/json/block.json
@@ -278,11 +278,6 @@
 							"type": "boolean",
 							"description": "This property adds block controls which allow the user to set text color in a block.\n\nWhen color support is declared, this property is enabled by default (along with background), so simply setting color will enable text color.\n\nText color presets are sourced from the editor-color-palette theme support.\n\nWhen the block declares support for color.text, the attributes definition is extended to include two new attributes: textColor and style",
 							"default": true
-						},
-						"contrastChecker": {
-							"type": "boolean",
-							"description": "Used to control the contrast checker widget in the block editor UI. The contrast checker appears only if the block declares support for color. It tests the readability of color combinations and warns if there is a potential issue. The property is enabled by default.",
-							"default": true
 						}
 					}
 				},


### PR DESCRIPTION
## What and How?

This PR adds a property `__experimentalCheckContrast` to a block.json's `supports.color` to disable the contrastChecker in the UI.

Context:
- https://github.com/WordPress/gutenberg/pull/38428#discussion_r805468375
- https://github.com/WordPress/gutenberg/issues/37549#issuecomment-1038576610
- https://github.com/WordPress/gutenberg/pull/43293#issuecomment-1217558733

## Why?
There are scenarios where the contrast checker is not appropriate ([Separator block](https://github.com/WordPress/gutenberg/pull/38428#discussion_r805468375)), or a block has its own color implementation in combination with color block supports ([Social links block](https://github.com/WordPress/gutenberg/pull/43293#issuecomment-1217558733)).

## Testing Instructions

Add a separator block and change the color so that it's the same or similar to the background.

Here is some dummy HTML:

```html
<!-- wp:separator {"style":{"color":{"background":"#fefefe"}},"className":"is-style-wide"} -->
<hr class="wp-block-separator has-text-color has-alpha-channel-opacity has-background is-style-wide" style="background-color:#fefefe;color:#fefefe"/>
<!-- /wp:separator -->
```

Make sure your theme has a white background for the above test code.

Before:
<img width="281" alt="Screen Shot 2022-08-18 at 4 26 18 pm" src="https://user-images.githubusercontent.com/6458278/185309274-812fbb0d-4735-43a9-ac49-68796d373b4b.png">

After:
<img width="276" alt="Screen Shot 2022-08-18 at 4 26 50 pm" src="https://user-images.githubusercontent.com/6458278/185309263-961de779-ddb5-4ba5-b4de-c101f79aae57.png">

