### PR TITLE
Navigation: Page List fix missing padding.

### DIFF
--- a/packages/block-library/src/navigation/style.scss
+++ b/packages/block-library/src/navigation/style.scss
@@ -341,16 +341,17 @@ button.wp-block-navigation-item__content {
 // We use :where to keep specificity minimal, yet still scope it to only the navigation block.
 // That way if padding is set in theme.json, it still wins.
 // https://css-tricks.com/almanac/selectors/w/where/
+// Note: .wp-block-navigation-item targets both Page List and custom menu items. .wp-block-navigation-link targets only custom.
 
 // When the menu has a background, items have paddings, reduce margins to compensate.
 // Treat margins and paddings differently when the block has a background.
-:where(.wp-block-navigation.has-background .wp-block-navigation-link a:not(.wp-element-button)),
+:where(.wp-block-navigation.has-background .wp-block-navigation-item a:not(.wp-element-button)),
 :where(.wp-block-navigation.has-background .wp-block-navigation-submenu a:not(.wp-element-button)) {
 	padding: 0.5em 1em;
 }
 
 // Provide a default padding for submenus who should always have some, regardless of the top level menu items.
-:where(.wp-block-navigation .wp-block-navigation__submenu-container .wp-block-navigation-link a:not(.wp-element-button)),
+:where(.wp-block-navigation .wp-block-navigation__submenu-container .wp-block-navigation-item a:not(.wp-element-button)),
 :where(.wp-block-navigation .wp-block-navigation__submenu-container .wp-block-navigation-submenu a:not(.wp-element-button)) {
 	padding: 0.5em 1em;
 }


### PR DESCRIPTION
## What?

Fixes #43348. 

## Why?

#42967 caused a small regression by targetting `.wp-block-navigation-link` for padding, which only exists in custom menu items (it's the old name), where it should have targetted `.wp-block-navigation-item` which exists for both page list and custom menu items..

This PR fixes that.

## Testing Instructions

Test nav menus with and without page list, with submenu items, with and without backgrounds, and page list versions should look identical, editor and frontend, to custom items.

## Screenshots or screencast <!-- if applicable -->

Before:
<img width="744" alt="page list before" src="https://user-images.githubusercontent.com/1204802/185343042-9923fd99-c8b9-4055-935e-5e77a191c441.png">
<img width="634" alt="custom before" src="https://user-images.githubusercontent.com/1204802/185343070-12227ed7-6849-4619-91cc-2636e5fb8b2e.png">

<img width="760" alt="custom w  background before" src="https://user-images.githubusercontent.com/1204802/185343082-019d8ccf-c7bb-4671-b62f-7b1c56bf971e.png">
<img width="759" alt="page list w  background before" src="https://user-images.githubusercontent.com/1204802/185343096-7731701a-b505-44d9-802b-b3eefe3a741c.png">

After:

<img width="728" alt="custom after" src="https://user-images.githubusercontent.com/1204802/185343115-f8e37667-6f9a-47e2-9678-8146b4880b0e.png">
<img width="720" alt="page list after" src="https://user-images.githubusercontent.com/1204802/185343121-5a024928-c54b-40c6-b2d8-742a7ffd89d3.png">
<img width="773" alt="custom w background after" src="https://user-images.githubusercontent.com/1204802/185343131-108bc3cb-df55-4831-8cad-f445fa13ff36.png">
<img width="760" alt="page list w background after" src="https://user-images.githubusercontent.com/1204802/185343142-68b633bf-d833-45da-9a35-3bf1f09987d7.png">

