### PR TITLE
[Experiment] Backports script

### DIFF
--- a/bin/backports.mjs
+++ b/bin/backports.mjs
@@ -20,7 +20,10 @@ async function getCommits( file ) {
 
 const prRegex = /\(#([0-9]+)\)$/;
 const ghRoot = 'https://github.com/WordPress/gutenberg/commits/trunk/';
-const backportDirectories = [ 'lib/compat/wordpress-6.1/' ];
+const backportDirectories = [
+	'lib/block-supports/',
+	'lib/compat/wordpress-6.1/',
+];
 
 backportDirectories.forEach( async ( backportDir ) => {
 	console.log( `### ${ backportDir }\n` );

--- a/bin/backports.mjs
+++ b/bin/backports.mjs
@@ -5,7 +5,7 @@ import SimpleGit from 'simple-git';
 import { dirname, join as pathJoin } from 'path';
 import { fileURLToPath } from 'url';
 import { promises as fsPromises } from 'fs';
-import { Octokit } from '@octokit/rest';
+import Octokit from '@octokit/rest';
 
 const __dirname = dirname( fileURLToPath( import.meta.url ) );
 

--- a/bin/backports.mjs
+++ b/bin/backports.mjs
@@ -1,7 +1,6 @@
 /**
  * External dependencies
  */
-import Diff from 'diff';
 import SimpleGit from 'simple-git';
 import { dirname } from 'path';
 import { fileURLToPath } from 'url';
@@ -18,33 +17,10 @@ async function getCommits( file ) {
 	return log.all;
 }
 
-function matchFilename( file ) {
-	if ( file.startsWith( 'lib/compat/wordpress-6.1/' ) ) {
-		return file.replace( 'lib/compat/wordpress-6.1/', 'src/wp-includes/' );
-	}
-	return file;
-}
-
 const log = await getCommits( 'lib/compat/wordpress-6.1/' );
 
 const prRegex = /\(#([0-9]+)\)$/;
 const prs = log.map( ( { message } ) => message.match( prRegex )?.[ 1 ] );
 console.log( prs );
 
-const hash = log[ 1 ].hash;
 
-const diff = await simpleGit.show( hash );
-
-//console.log( diff );
-
-const parsedDiff = Diff.parsePatch( diff );
-
-//console.log( parsedDiff[ 0 ] );
-
-const fileName = parsedDiff[ 0 ].oldFileName.replace( /a\//, '' );
-
-console.log( matchFilename( fileName ) );
-
-parsedDiff[ 0 ].newFileName = 'b/../wordpress-develop/' + matchFilename( fileName );
-
-console.log( parsedDiff );

--- a/bin/backports.mjs
+++ b/bin/backports.mjs
@@ -39,6 +39,7 @@ const ghCommitsRoot = 'https://github.com/WordPress/gutenberg/commits/trunk/';
 const backportDirectories = [
 	'lib/block-supports/',
 	`lib/compat/wordpress-${ wpVersion }/`,
+	'lib/experimental/',
 ];
 
 for ( const backportDir of backportDirectories ) {

--- a/bin/backports.mjs
+++ b/bin/backports.mjs
@@ -35,7 +35,7 @@ backportDirectories.forEach( async ( backportDir ) => {
 			continue;
 		}
 
-		console.log( `- ${ file }` );
+		console.log( `- [${ file }](${ ghRoot }${ path })` );
 		const log = await getCommits( path );
 
 		const prs = log.map(

--- a/bin/backports.mjs
+++ b/bin/backports.mjs
@@ -7,16 +7,26 @@ import { fileURLToPath } from 'url';
 import { promises as fsPromises } from 'fs';
 import Octokit from '@octokit/rest';
 
+/**
+ * Internal dependencies
+ */
+import { getPreviousMajorVersion } from './plugin/lib/version.js';
+
 const __dirname = dirname( fileURLToPath( import.meta.url ) );
 
 const simpleGit = SimpleGit( dirname( __dirname ) );
-
 const octokit = new Octokit();
+
+const wpVersion = '6.1';
+const previousWpVersion = getPreviousMajorVersion( wpVersion ).replace(
+	/\.0$/,
+	''
+);
 
 async function getCommits( file ) {
 	const options = {
 		file,
-		from: 'wp/6.0',
+		from: `wp/${ previousWpVersion }`,
 		to: 'HEAD',
 	};
 	const log = await simpleGit.log( options );
@@ -28,7 +38,7 @@ const ghTreeRoot = 'https://github.com/WordPress/gutenberg/tree/trunk/';
 const ghCommitsRoot = 'https://github.com/WordPress/gutenberg/commits/trunk/';
 const backportDirectories = [
 	'lib/block-supports/',
-	'lib/compat/wordpress-6.1/',
+	`lib/compat/wordpress-${ wpVersion }/`,
 ];
 
 for ( const backportDir of backportDirectories ) {

--- a/bin/backports.mjs
+++ b/bin/backports.mjs
@@ -22,14 +22,15 @@ async function getCommits( file ) {
 }
 
 const prRegex = /\(#([0-9]+)\)$/;
-const ghRoot = 'https://github.com/WordPress/gutenberg/commits/trunk/';
+const ghTreeRoot = 'https://github.com/WordPress/gutenberg/tree/trunk/';
+const ghCommitsRoot = 'https://github.com/WordPress/gutenberg/commits/trunk/';
 const backportDirectories = [
 	'lib/block-supports/',
 	'lib/compat/wordpress-6.1/',
 ];
 
 for ( const backportDir of backportDirectories ) {
-	console.log( `### ${ backportDir }\n` );
+	console.log( `### [${ backportDir }](${ ghTreeRoot }${ backportDir })\n` );
 	const files = await fsPromises.readdir( backportDir );
 	for ( const file of files ) {
 		const path = pathJoin( backportDir, file );
@@ -38,7 +39,7 @@ for ( const backportDir of backportDirectories ) {
 			continue;
 		}
 
-		console.log( `- [${ file }](${ ghRoot }${ path })` );
+		console.log( `- [${ file }](${ ghCommitsRoot }${ path })` );
 		const log = await getCommits( path );
 
 		const prNumbers = log.map(

--- a/bin/backports.mjs
+++ b/bin/backports.mjs
@@ -1,0 +1,50 @@
+/**
+ * External dependencies
+ */
+import Diff from 'diff';
+import SimpleGit from 'simple-git';
+import { dirname } from 'path';
+import { fileURLToPath } from 'url';
+
+const __dirname = dirname( fileURLToPath( import.meta.url ) );
+
+const simpleGit = SimpleGit( dirname( __dirname ) );
+
+async function getCommits( file ) {
+	const options = {
+		file,
+	};
+	const log = await simpleGit.log( options );
+	return log.all;
+}
+
+function matchFilename( file ) {
+	if ( file.startsWith( 'lib/compat/wordpress-6.1/' ) ) {
+		return file.replace( 'lib/compat/wordpress-6.1/', 'src/wp-includes/' );
+	}
+	return file;
+}
+
+const log = await getCommits( 'lib/compat/wordpress-6.1/' );
+
+const prRegex = /\(#([0-9]+)\)$/;
+const prs = log.map( ( { message } ) => message.match( prRegex )?.[ 1 ] );
+console.log( prs );
+
+const hash = log[ 1 ].hash;
+
+const diff = await simpleGit.show( hash );
+
+//console.log( diff );
+
+const parsedDiff = Diff.parsePatch( diff );
+
+//console.log( parsedDiff[ 0 ] );
+
+const fileName = parsedDiff[ 0 ].oldFileName.replace( /a\//, '' );
+
+console.log( matchFilename( fileName ) );
+
+parsedDiff[ 0 ].newFileName = 'b/../wordpress-develop/' + matchFilename( fileName );
+
+console.log( parsedDiff );

--- a/bin/backports.mjs
+++ b/bin/backports.mjs
@@ -16,6 +16,8 @@ const octokit = new Octokit();
 async function getCommits( file ) {
 	const options = {
 		file,
+		from: 'wp/6.0',
+		to: 'HEAD',
 	};
 	const log = await simpleGit.log( options );
 	return log.all;

--- a/bin/plugin/lib/test/version.js
+++ b/bin/plugin/lib/test/version.js
@@ -1,10 +1,10 @@
 /**
  * Internal dependencies
  */
-import { getNextMajorVersion } from '../version';
+import { getNextMajorVersion, getPreviousMajorVersion } from '../version';
 
 describe( 'getNextMajorVersion', () => {
-	it( 'increases the minor number by default', () => {
+	it( 'increments the minor number by default', () => {
 		const result = getNextMajorVersion( '7.3.4-rc.1' );
 
 		expect( result ).toBe( '7.4.0' );
@@ -14,5 +14,19 @@ describe( 'getNextMajorVersion', () => {
 		const result = getNextMajorVersion( '7.9.0' );
 
 		expect( result ).toBe( '8.0.0' );
+	} );
+} );
+
+describe( 'getPreviousMajorVersion', () => {
+	it( 'decrements the minor number by default', () => {
+		const result = getPreviousMajorVersion( '7.4.0' );
+
+		expect( result ).toBe( '7.3.0' );
+	} );
+
+	it( 'follows the WordPress versioning scheme', () => {
+		const result = getPreviousMajorVersion( '8.0.0' );
+
+		expect( result ).toBe( '7.9.0' );
 	} );
 } );

--- a/bin/plugin/lib/version.js
+++ b/bin/plugin/lib/version.js
@@ -4,7 +4,7 @@
 
 /**
  * Follow the WordPress version guidelines to compute
- * the version to be used By default, increase the "minor"
+ * the version to be used By default, increment the "minor"
  * number but if we reach 9, bump to the next major.
  *
  * @param {string} version Current version.
@@ -18,6 +18,23 @@ function getNextMajorVersion( version ) {
 	return major + '.' + ( minor + 1 ) + '.0';
 }
 
+/**
+ * Follow the WordPress version guidelines to compute
+ * the version to be used. By default, decrement the "minor"
+ * number but if we reach 0, decrease to the next major.
+ *
+ * @param {string} version Current version.
+ * @return {string} Previous Major Version.
+ */
+function getPreviousMajorVersion( version ) {
+	const [ major, minor ] = version.split( '.' ).map( Number );
+	if ( minor === 0 ) {
+		return major - 1 + '.9.0';
+	}
+	return major + '.' + ( minor - 1 ) + '.0';
+}
+
 module.exports = {
 	getNextMajorVersion,
+	getPreviousMajorVersion,
 };


### PR DESCRIPTION
## What?
First attempt at writing a script to help with backporting PHP files to `wordpress-develop`.

The goal is to either auto-generate a list like [this](https://github.com/WordPress/gutenberg/issues/39889) (including PR numbers and authors), or even automatically file PRs against `wordpress-develop` 🙀 

## Why?

https://user-images.githubusercontent.com/96308/185350463-78079c27-22ce-44eb-ab76-b4883cd631b0.mp4

## How?

🪄🔮 

## Testing Instructions

```
node bin/backports.mjs
```

## Screenshots or screencast <!-- if applicable -->

TBD

## TODO

- [ ] Integrate with `bin/cli`. (Maybe move `backports.mjs` to `lib/plugin`?)
- [ ] Allow setting token via cmd line
- [ ] Allow setting WP version via cmd line (or infer automatically?)
