### PR TITLE
Image: Fix unclickable buttons.

### DIFF
--- a/packages/block-library/src/image/editor.scss
+++ b/packages/block-library/src/image/editor.scss
@@ -15,6 +15,10 @@
 		> svg {
 			opacity: 0;
 		}
+
+		.components-placeholder__illustration {
+			display: none;
+		}
 	}
 
 	// Remove the transition while we still have a legacy placeholder style.


### PR DESCRIPTION
## What?

Quick followup to #43180 which was merged this morning. A bug was present in that which made the placeholder buttons inside only tabbable, not clickable.

This PR fixes that so they are in fact also clickable:

![clickable](https://user-images.githubusercontent.com/1204802/185351031-82b80df0-4c16-42ff-8c98-e4bd1a0330ef.gif)

## Testing Instructions

Insert an image placeholder, the buttons inside should be both clickable and tabbable.