### PR TITLE
Lodash: Remove completely from `@wordpress/create-block` package

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16842,7 +16842,6 @@
 				"execa": "^4.0.2",
 				"fast-glob": "^3.2.7",
 				"inquirer": "^7.1.0",
-				"lodash": "^4.17.21",
 				"make-dir": "^3.0.0",
 				"mustache": "^4.0.0",
 				"npm-package-arg": "^8.1.5",

--- a/packages/create-block/lib/check-system-requirements.js
+++ b/packages/create-block/lib/check-system-requirements.js
@@ -4,7 +4,6 @@
 const inquirer = require( 'inquirer' );
 const checkSync = require( 'check-node-version' );
 const tools = require( 'check-node-version/tools' );
-const { forEach } = require( 'lodash' );
 const { promisify } = require( 'util' );
 
 /**
@@ -21,13 +20,15 @@ async function checkSystemRequirements( engines ) {
 		log.error( 'Minimum system requirements not met!' );
 		log.info( '' );
 
-		forEach( result.versions, ( { isSatisfied, wanted }, name ) => {
-			if ( ! isSatisfied ) {
-				log.error(
-					`Error: Wanted ${ name } version ${ wanted.raw } (${ wanted.range })`
-				);
+		Object.entries( result.versions ).forEach(
+			( [ name, { isSatisfied, wanted } ] ) => {
+				if ( ! isSatisfied ) {
+					log.error(
+						`Error: Wanted ${ name } version ${ wanted.raw } (${ wanted.range })`
+					);
+				}
 			}
-		} );
+		);
 
 		log.info( '' );
 		log.error( 'The program may not complete correctly if you continue.' );
@@ -46,13 +47,16 @@ async function checkSystemRequirements( engines ) {
 			log.error( 'Cancelled.' );
 			log.info( '' );
 
-			forEach( result.versions, ( { isSatisfied, wanted }, name ) => {
-				if ( ! isSatisfied ) {
-					log.info(
-						tools[ name ].getInstallInstructions( wanted.raw )
-					);
+			Object.entries( result.versions ).forEach(
+				( [ name, { isSatisfied, wanted } ] ) => {
+					if ( ! isSatisfied ) {
+						log.info(
+							tools[ name ].getInstallInstructions( wanted.raw )
+						);
+					}
 				}
-			} );
+			);
+
 			process.exit( 1 );
 		}
 	}

--- a/packages/create-block/lib/index.js
+++ b/packages/create-block/lib/index.js
@@ -4,7 +4,6 @@
 const inquirer = require( 'inquirer' );
 const { capitalCase } = require( 'change-case' );
 const program = require( 'commander' );
-const { pickBy } = require( 'lodash' );
 
 /**
  * Internal dependencies
@@ -77,8 +76,8 @@ program
 			try {
 				const pluginTemplate = await getPluginTemplate( templateName );
 				const defaultValues = getDefaultValues( pluginTemplate );
-				const optionsValues = pickBy(
-					{
+				const optionsValues = Object.fromEntries(
+					Object.entries( {
 						plugin,
 						category,
 						description,
@@ -86,8 +85,7 @@ program
 						title,
 						wpScripts,
 						wpEnv,
-					},
-					( value ) => value !== undefined
+					} ).filter( ( [ , value ] ) => value !== undefined )
 				);
 
 				if ( slug ) {

--- a/packages/create-block/lib/init-block.js
+++ b/packages/create-block/lib/init-block.js
@@ -1,7 +1,6 @@
 /**
  * External dependencies
  */
-const { omitBy } = require( 'lodash' );
 const { dirname, join } = require( 'path' );
 const makeDir = require( 'make-dir' );
 const { writeFile } = require( 'fs' ).promises;
@@ -41,8 +40,8 @@ async function initBlockJSON( {
 	await writeFile(
 		outputFile,
 		JSON.stringify(
-			omitBy(
-				{
+			Object.fromEntries(
+				Object.entries( {
 					$schema,
 					apiVersion,
 					name: namespace + '/' + slug,
@@ -57,8 +56,7 @@ async function initBlockJSON( {
 					editorScript,
 					editorStyle,
 					style,
-				},
-				( value ) => ! value
+				} ).filter( ( [ , value ] ) => !! value )
 			),
 			null,
 			'\t'

--- a/packages/create-block/lib/init-package-json.js
+++ b/packages/create-block/lib/init-package-json.js
@@ -2,7 +2,6 @@
  * External dependencies
  */
 const { command } = require( 'execa' );
-const { isEmpty, omitBy } = require( 'lodash' );
 const npmPackageArg = require( 'npm-package-arg' );
 const { join } = require( 'path' );
 const writePkg = require( 'write-pkg' );
@@ -32,8 +31,8 @@ module.exports = async ( {
 
 	await writePkg(
 		cwd,
-		omitBy(
-			{
+		Object.fromEntries(
+			Object.entries( {
 				name: slug,
 				version,
 				description,
@@ -54,8 +53,7 @@ module.exports = async ( {
 					...( wpEnv && { env: 'wp-env' } ),
 					...customScripts,
 				},
-			},
-			isEmpty
+			} ).filter( ( [ , value ] ) => !! value )
 		)
 	);
 

--- a/packages/create-block/lib/prompts.js
+++ b/packages/create-block/lib/prompts.js
@@ -1,9 +1,4 @@
 /**
- * External dependencies
- */
-const { isEmpty } = require( 'lodash' );
-
-/**
  * Capitalizes the first letter in a string.
  *
  * @param {string} str The string whose first letter the function will capitalize.
@@ -66,7 +61,7 @@ const dashicon = {
 	message:
 		'The dashicon to make it easier to identify your block (optional):',
 	validate( input ) {
-		if ( ! isEmpty( input ) && ! /^[a-z][a-z0-9\-]*$/.test( input ) ) {
+		if ( input.length && ! /^[a-z][a-z0-9\-]*$/.test( input ) ) {
 			return 'Invalid dashicon name specified. Visit https://developer.wordpress.org/resource/dashicons/ to discover available names.';
 		}
 

--- a/packages/create-block/package.json
+++ b/packages/create-block/package.json
@@ -39,7 +39,6 @@
 		"execa": "^4.0.2",
 		"fast-glob": "^3.2.7",
 		"inquirer": "^7.1.0",
-		"lodash": "^4.17.21",
 		"make-dir": "^3.0.0",
 		"mustache": "^4.0.0",
 		"npm-package-arg": "^8.1.5",


### PR DESCRIPTION
## What?
This PR removes all of the Lodash from the `@wordpress/create-block` package, including the `lodash` dependency altogether. There are just a few usages and conversion is pretty straightforward. 

## Why?

Lodash is known to unnecessarily inflate the bundle size of packages, and in most cases, it can be replaced with native language functionality. See these for more information and rationale:

* https://github.com/WordPress/gutenberg/issues/16938#issuecomment-602837246
* https://github.com/WordPress/gutenberg/issues/17025
* https://github.com/WordPress/gutenberg/issues/39495 

While this PR doesn't affect bundle size at all (because this package's code is not bundled), it still is a step forward in the direction of completely getting rid of Lodash in Gutenberg.

## How?

We're using native JS functionality - `pickBy` and `omitBy` are replaced with `Object.fromEntries( Object.entries().filter() )`, `forEach()` for an object is also replaced by `Object.entries().forEach()`, and `isEmpty` is replaced with a simpler alternative due to the fact that we don't need the granularity.

## Testing Instructions

* Run `npx @wordpress/create-block` and go through the prompts to verify everything still works well.
* Run `npx @wordpress/create-block example-block --title My Example Block` (and maybe some additional arguments) and verify everything still works well.
* Install an older Node version (`nvm install v10.24.1`)
* Run `npx @wordpress/create-block` and verify you're still getting the minimum system requirements error.
* Verify all checks pass (specifically the Create Block ones)