### PR TITLE
Spacer: add spacing block supports 

### DIFF
--- a/docs/reference-guides/core-blocks.md
+++ b/docs/reference-guides/core-blocks.md
@@ -770,7 +770,7 @@ Add white space between blocks and customize its height. ([Source](https://githu
 
 -	**Name:** core/spacer
 -	**Category:** design
--	**Supports:** anchor
+-	**Supports:** anchor, spacing (margin)
 -	**Attributes:** height, width
 
 ## Table

--- a/packages/block-library/src/spacer/block.json
+++ b/packages/block-library/src/spacer/block.json
@@ -17,7 +17,13 @@
 	},
 	"usesContext": [ "orientation" ],
 	"supports": {
-		"anchor": true
+		"anchor": true,
+		"spacing": {
+			"margin": [ "top", "bottom" ],
+			"__experimentalDefaultControls": {
+				"margin": true
+			}
+		}
 	},
 	"editorStyle": "wp-block-spacer-editor",
 	"style": "wp-block-spacer"


### PR DESCRIPTION
Related:
- https://github.com/WordPress/gutenberg/issues/43241
- https://github.com/WordPress/gutenberg/issues/43243

## What?

Enabling axial margin support for the spacer block.

## Why?

To create consistency across blocks.

## How?

Adding the relevant block supports in block.json

## Testing Instructions


1. Load the block editor and add a Video block. Add some content or use the example block code below.
2. Confirm that the dimensions control panel is there and the margin control is shown by default.
3. Add margins / axial margins.
4. Save and confirm the styles appear on the frontend. 
5. Test the new support works for the block via theme.json and global styles. See example JSON below.


```json
	"styles": {
		"blocks": {
			"core/spacer": {
				"spacing": {
					"margin": {
						"top": "120px",
						"bottom": "140px"
					}
				}
			}
		}
	}
```



https://user-images.githubusercontent.com/6458278/185367077-9c363974-a6fe-44e1-8583-b908c89f8005.mp4





