### PR TITLE
Tag cloud: add spacing block supports

### DIFF
--- a/docs/reference-guides/core-blocks.md
+++ b/docs/reference-guides/core-blocks.md
@@ -797,7 +797,7 @@ A cloud of your most used tags. ([Source](https://github.com/WordPress/gutenberg
 
 -	**Name:** core/tag-cloud
 -	**Category:** widgets
--	**Supports:** align, ~~html~~
+-	**Supports:** align, spacing (margin, padding), ~~html~~
 -	**Attributes:** largestFontSize, numberOfTags, showTagCounts, smallestFontSize, taxonomy
 
 ## Template Part

--- a/packages/block-library/src/tag-cloud/block.json
+++ b/packages/block-library/src/tag-cloud/block.json
@@ -36,7 +36,11 @@
 	],
 	"supports": {
 		"html": false,
-		"align": true
+		"align": true,
+		"spacing": {
+			"margin": true,
+			"padding": true
+		}
 	},
 	"editorStyle": "wp-block-tag-cloud-editor"
 }


### PR DESCRIPTION
Related:
- https://github.com/WordPress/gutenberg/issues/43241
- https://github.com/WordPress/gutenberg/issues/43243

## What?

Enabling spacing support for the Tag cloud block

## Why?

To create consistency across blocks.

## How?

Adding the relevant block supports in block.json

## Testing Instructions


1. Create a few posts, add a few tags.
2. Load the block editor and add a Tag cloud block. 
3. Confirm that the dimensions control panel is there
4. Add margin and padding.
5. Save and confirm the styles appear on the frontend.
6. Test the new support works for the block via theme.json and global styles. See example JSON below.


```json
	"styles": {
		"blocks": {
			"core/tag-cloud": {
				"spacing": {
					"padding": "122px",
					"margin": "22px"
				}
			}
		}
	}
```


<img width="712" alt="Screen Shot 2022-08-18 at 8 05 21 pm" src="https://user-images.githubusercontent.com/6458278/185369885-a64537f8-b93a-4da6-a127-40c5a5922d6c.png">




