### PR TITLE
Table: add spacing block supports

### DIFF
--- a/docs/reference-guides/core-blocks.md
+++ b/docs/reference-guides/core-blocks.md
@@ -779,7 +779,7 @@ Create structured content in rows and columns to display information. ([Source](
 
 -	**Name:** core/table
 -	**Category:** text
--	**Supports:** align, anchor, color (background, gradients, text), typography (fontSize, lineHeight)
+-	**Supports:** align, anchor, color (background, gradients, text), spacing (margin, padding), typography (fontSize, lineHeight)
 -	**Attributes:** body, caption, foot, hasFixedLayout, head
 
 ## Table of Contents

--- a/packages/block-library/src/table/block.json
+++ b/packages/block-library/src/table/block.json
@@ -134,6 +134,10 @@
 				"text": true
 			}
 		},
+		"spacing": {
+			"margin": true,
+			"padding": true
+		},
 		"typography": {
 			"fontSize": true,
 			"lineHeight": true,


### PR DESCRIPTION
Related:
- https://github.com/WordPress/gutenberg/issues/43241
- https://github.com/WordPress/gutenberg/issues/43243

## What?

Enabling spacing support for the table block

## Why?

To create consistency across blocks.

## How?

Adding the relevant block supports in block.json

## Testing Instructions


1. Load the block editor with a table block. Add some content or use the example block code below.
2. Confirm that the dimensions control panel is there
3. Add margin and padding.
4. Save and confirm the styles appear on the frontend.
5. Test the new support works for the block via theme.json and global styles. See example JSON below.

<details>

<summary>Example block code</summary>

```html
<!-- wp:table -->
<figure class="wp-block-table"><table><tbody><tr><td>Boots</td><td>Shoes</td></tr><tr><td>1</td><td>2</td></tr></tbody></table></figure>
<!-- /wp:table -->

```

</details>

```json
	"styles": {
		"blocks": {
			"core/table": {
				"spacing": {
					"padding": "122px",
					"margin": "22px"
				}
			}
		}
	}
```
<img width="1094" alt="Screen Shot 2022-08-18 at 8 31 05 pm" src="https://user-images.githubusercontent.com/6458278/185374331-037d8fed-34e6-4ecf-a3c5-394acb42e04d.png">

