### PR TITLE
Use str_starts_with

### DIFF
--- a/lib/client-assets.php
+++ b/lib/client-assets.php
@@ -122,7 +122,7 @@ function gutenberg_override_translation_file( $file, $handle ) {
 	}
 
 	// Ignore scripts whose handle does not have the "wp-" prefix.
-	if ( 'wp-' !== substr( $handle, 0, 3 ) ) {
+	if ( ! str_starts_with( $handle, 'wp-' ) ) {
 		return $file;
 	}
 

--- a/lib/experimental/class-wp-webfonts-provider-local.php
+++ b/lib/experimental/class-wp-webfonts-provider-local.php
@@ -117,7 +117,7 @@ class WP_Webfonts_Provider_Local extends WP_Webfonts_Provider {
 
 		foreach ( $webfont['src'] as $url ) {
 			// Add data URIs first.
-			if ( 0 === strpos( trim( $url ), 'data:' ) ) {
+			if ( str_starts_with( trim( $url ), 'data:' ) ) {
 				$src_ordered[] = array(
 					'url'    => $url,
 					'format' => 'data',
@@ -232,7 +232,7 @@ class WP_Webfonts_Provider_Local extends WP_Webfonts_Provider {
 
 		foreach ( $value as $item ) {
 
-			if ( 0 === strpos( $item['url'], get_site_url() ) ) {
+			if ( str_starts_with( $item['url'], get_site_url() ) ) {
 				$item['url'] = wp_make_link_relative( $item['url'] );
 			}
 


### PR DESCRIPTION
## What?
The `str_starts_with` function is available is PHP 8+. A polyfill for the function exists in WP 5.9+, so we should use that function instead of previous implementations.