### PR TITLE
Term description: add spacing block supports

### DIFF
--- a/docs/reference-guides/core-blocks.md
+++ b/docs/reference-guides/core-blocks.md
@@ -815,7 +815,7 @@ Display the description of categories, tags and custom taxonomies when viewing a
 
 -	**Name:** core/term-description
 -	**Category:** theme
--	**Supports:** align (full, wide), color (background, link, text), typography (fontSize, lineHeight), ~~html~~
+-	**Supports:** align (full, wide), color (background, link, text), spacing (margin, padding), typography (fontSize, lineHeight), ~~html~~
 -	**Attributes:** textAlign
 
 ## Text Columns (deprecated)

--- a/packages/block-library/src/term-description/block.json
+++ b/packages/block-library/src/term-description/block.json
@@ -21,6 +21,10 @@
 				"text": true
 			}
 		},
+		"spacing": {
+			"padding": true,
+			"margin": true
+		},
 		"typography": {
 			"fontSize": true,
 			"lineHeight": true,


### PR DESCRIPTION
Related:
- https://github.com/WordPress/gutenberg/issues/43241
- https://github.com/WordPress/gutenberg/issues/43243

## What?

Enabling spacing support for the Term description block

## Why?

To create consistency across blocks.

## How?

Adding the relevant block supports in block.json

## Testing Instructions


1. Make sure you have some posts with tags or categories
2. Load the site editor and create / edit the archive template
3. Add a Term description block. 
4. Confirm that the dimensions control panel is there
5. Add margin and padding.
6. Save and go to a term's archive page, e.g., `http://localhost:8888/?tag=good-tag` and confirm the styles appear on the frontend.
7. Test the new support works for the block via theme.json and global styles. See example JSON below.



```json
	"styles": {
		"blocks": {
			"core/term-description": {
				"spacing": {
					"padding": "122px",
					"margin": "22px"
				}
			}
		}
	}
```


<img width="833" alt="Screen Shot 2022-08-18 at 8 33 58 pm" src="https://user-images.githubusercontent.com/6458278/185377194-6f33c3d6-01e9-47fb-ad77-87a1f408853a.png">


<img width="1116" alt="Screen Shot 2022-08-18 at 8 45 05 pm" src="https://user-images.githubusercontent.com/6458278/185377185-adc2b75d-66d4-4c8f-8d5e-8796f3a2e9ec.png">
