### PR TITLE
Remove the constructor from `WP_REST_Block_Editor_Settings_Controller` and  `WP_Rest_Customizer_Nonces`

### DIFF
--- a/lib/experimental/class-wp-rest-block-editor-settings-controller.php
+++ b/lib/experimental/class-wp-rest-block-editor-settings-controller.php
@@ -16,7 +16,7 @@ class WP_REST_Block_Editor_Settings_Controller extends WP_REST_Controller {
 	/**
 	 * The namespace of this controller's route.
 	 *
-	 * @since 4.7.0
+	 * @since 6.3.0
 	 * @var string
 	 */
 	protected $namespace = 'wp-block-editor/v1';
@@ -24,7 +24,7 @@ class WP_REST_Block_Editor_Settings_Controller extends WP_REST_Controller {
 	/**
 	 * The base of this controller's route.
 	 *
-	 * @since 4.7.0
+	 * @since 6.3.0
 	 * @var string
 	 */
 	protected $rest_base = 'settings';

--- a/lib/experimental/class-wp-rest-block-editor-settings-controller.php
+++ b/lib/experimental/class-wp-rest-block-editor-settings-controller.php
@@ -12,13 +12,22 @@
  * @see WP_REST_Controller
  */
 class WP_REST_Block_Editor_Settings_Controller extends WP_REST_Controller {
+
 	/**
-	 * Constructs the controller.
+	 * The namespace of this controller's route.
+	 *
+	 * @since 4.7.0
+	 * @var string
 	 */
-	public function __construct() {
-		$this->namespace = 'wp-block-editor/v1';
-		$this->rest_base = 'settings';
-	}
+	protected $namespace = 'wp-block-editor/v1';
+
+	/**
+	 * The base of this controller's route.
+	 *
+	 * @since 4.7.0
+	 * @var string
+	 */
+	protected $rest_base = 'settings';
 
 	/**
 	 * Registers the necessary REST API routes.

--- a/lib/experimental/class-wp-rest-block-editor-settings-controller.php
+++ b/lib/experimental/class-wp-rest-block-editor-settings-controller.php
@@ -16,7 +16,6 @@ class WP_REST_Block_Editor_Settings_Controller extends WP_REST_Controller {
 	/**
 	 * The namespace of this controller's route.
 	 *
-	 * @since 6.3.0
 	 * @var string
 	 */
 	protected $namespace = 'wp-block-editor/v1';
@@ -24,7 +23,6 @@ class WP_REST_Block_Editor_Settings_Controller extends WP_REST_Controller {
 	/**
 	 * The base of this controller's route.
 	 *
-	 * @since 6.3.0
 	 * @var string
 	 */
 	protected $rest_base = 'settings';

--- a/lib/experimental/class-wp-rest-customizer-nonces.php
+++ b/lib/experimental/class-wp-rest-customizer-nonces.php
@@ -14,7 +14,6 @@ class WP_Rest_Customizer_Nonces extends WP_REST_Controller {
 	/**
 	 * The namespace of this controller's route.
 	 *
-	 * @since 6.3.0
 	 * @var string
 	 */
 	protected $namespace = '__experimental';
@@ -22,7 +21,6 @@ class WP_Rest_Customizer_Nonces extends WP_REST_Controller {
 	/**
 	 * The base of this controller's route.
 	 *
-	 * @since 6.3.0
 	 * @var string
 	 */
 	protected $rest_base = 'customizer-nonces';

--- a/lib/experimental/class-wp-rest-customizer-nonces.php
+++ b/lib/experimental/class-wp-rest-customizer-nonces.php
@@ -14,7 +14,7 @@ class WP_Rest_Customizer_Nonces extends WP_REST_Controller {
 	/**
 	 * The namespace of this controller's route.
 	 *
-	 * @since 4.7.0
+	 * @since 6.3.0
 	 * @var string
 	 */
 	protected $namespace = '__experimental';
@@ -22,7 +22,7 @@ class WP_Rest_Customizer_Nonces extends WP_REST_Controller {
 	/**
 	 * The base of this controller's route.
 	 *
-	 * @since 4.7.0
+	 * @since 6.3.0
 	 * @var string
 	 */
 	protected $rest_base = 'customizer-nonces';

--- a/lib/experimental/class-wp-rest-customizer-nonces.php
+++ b/lib/experimental/class-wp-rest-customizer-nonces.php
@@ -12,12 +12,20 @@
 class WP_Rest_Customizer_Nonces extends WP_REST_Controller {
 
 	/**
-	 * Constructor.
+	 * The namespace of this controller's route.
+	 *
+	 * @since 4.7.0
+	 * @var string
 	 */
-	public function __construct() {
-		$this->namespace = '__experimental';
-		$this->rest_base = 'customizer-nonces';
-	}
+	protected $namespace = '__experimental';
+
+	/**
+	 * The base of this controller's route.
+	 *
+	 * @since 4.7.0
+	 * @var string
+	 */
+	protected $rest_base = 'customizer-nonces';
 
 	/**
 	 * Registers the necessary REST API routes.


### PR DESCRIPTION
## What?
We use the constructor of the `WP_REST_Block_Editor_Settings_Controller` and `WP_Rest_Customizer_Nonces` classes to set the `namespace` and `rest_base`. However we don't really need the constructor to do that... It's more efficient (and easier to read) to set the class props directly in the object.