### PR TITLE
Editor: Refactor a few component tests to `@testing-library/react`

### DIFF
--- a/packages/editor/src/components/post-last-revision/test/check.js
+++ b/packages/editor/src/components/post-last-revision/test/check.js
@@ -36,6 +36,6 @@ describe( 'PostLastRevisionCheck', () => {
 			</PostLastRevisionCheck>
 		);
 
-		expect( screen.queryByText( 'Children' ) ).toBeVisible();
+		expect( screen.getByText( 'Children' ) ).toBeVisible();
 	} );
 } );

--- a/packages/editor/src/components/post-last-revision/test/check.js
+++ b/packages/editor/src/components/post-last-revision/test/check.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { shallow } from 'enzyme';
+import { render, screen } from '@testing-library/react';
 
 /**
  * Internal dependencies
@@ -10,32 +10,32 @@ import { PostLastRevisionCheck } from '../check';
 
 describe( 'PostLastRevisionCheck', () => {
 	it( 'should not render anything if the last revision ID is unknown', () => {
-		const wrapper = shallow(
+		render(
 			<PostLastRevisionCheck revisionsCount={ 2 }>
 				Children
 			</PostLastRevisionCheck>
 		);
 
-		expect( wrapper.type() ).toBe( null );
+		expect( screen.queryByText( 'Children' ) ).not.toBeInTheDocument();
 	} );
 
 	it( 'should not render anything if there is only one revision', () => {
-		const wrapper = shallow(
+		render(
 			<PostLastRevisionCheck lastRevisionId={ 1 } revisionsCount={ 1 }>
 				Children
 			</PostLastRevisionCheck>
 		);
 
-		expect( wrapper.type() ).toBe( null );
+		expect( screen.queryByText( 'Children' ) ).not.toBeInTheDocument();
 	} );
 
 	it( 'should render if there are two revisions', () => {
-		const wrapper = shallow(
+		render(
 			<PostLastRevisionCheck lastRevisionId={ 1 } revisionsCount={ 2 }>
 				Children
 			</PostLastRevisionCheck>
 		);
 
-		expect( wrapper.text() ).not.toBe( null );
+		expect( screen.queryByText( 'Children' ) ).toBeVisible();
 	} );
 } );

--- a/packages/editor/src/components/post-pending-status/test/check.js
+++ b/packages/editor/src/components/post-pending-status/test/check.js
@@ -24,6 +24,6 @@ describe( 'PostPendingStatusCheck', () => {
 				status
 			</PostPendingStatusCheck>
 		);
-		expect( screen.queryByText( 'status' ) ).toBeVisible();
+		expect( screen.getByText( 'status' ) ).toBeVisible();
 	} );
 } );

--- a/packages/editor/src/components/post-pending-status/test/check.js
+++ b/packages/editor/src/components/post-pending-status/test/check.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { shallow } from 'enzyme';
+import { render, screen } from '@testing-library/react';
 
 /**
  * Internal dependencies
@@ -10,20 +10,20 @@ import { PostPendingStatusCheck } from '../check';
 
 describe( 'PostPendingStatusCheck', () => {
 	it( "should not render anything if the user doesn't have the right capabilities", () => {
-		const wrapper = shallow(
+		render(
 			<PostPendingStatusCheck hasPublishAction={ false }>
 				status
 			</PostPendingStatusCheck>
 		);
-		expect( wrapper.type() ).toBe( null );
+		expect( screen.queryByText( 'status' ) ).not.toBeInTheDocument();
 	} );
 
 	it( 'should render if the user has the correct capability', () => {
-		const wrapper = shallow(
+		render(
 			<PostPendingStatusCheck hasPublishAction={ true }>
 				status
 			</PostPendingStatusCheck>
 		);
-		expect( wrapper.type() ).not.toBe( null );
+		expect( screen.queryByText( 'status' ) ).toBeVisible();
 	} );
 } );

--- a/packages/editor/src/components/post-schedule/test/check.js
+++ b/packages/editor/src/components/post-schedule/test/check.js
@@ -22,6 +22,6 @@ describe( 'PostScheduleCheck', () => {
 		render(
 			<PostScheduleCheck hasPublishAction={ true }>yes</PostScheduleCheck>
 		);
-		expect( screen.queryByText( 'yes' ) ).toBeVisible();
+		expect( screen.getByText( 'yes' ) ).toBeVisible();
 	} );
 } );

--- a/packages/editor/src/components/post-schedule/test/check.js
+++ b/packages/editor/src/components/post-schedule/test/check.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { shallow } from 'enzyme';
+import { render, screen } from '@testing-library/react';
 
 /**
  * Internal dependencies
@@ -10,18 +10,18 @@ import { PostScheduleCheck } from '../check';
 
 describe( 'PostScheduleCheck', () => {
 	it( "should not render anything if the user doesn't have the right capabilities", () => {
-		const wrapper = shallow(
+		render(
 			<PostScheduleCheck hasPublishAction={ false }>
 				yes
 			</PostScheduleCheck>
 		);
-		expect( wrapper.type() ).toBe( null );
+		expect( screen.queryByText( 'yes' ) ).not.toBeInTheDocument();
 	} );
 
 	it( 'should render if the user has the correct capability', () => {
-		const wrapper = shallow(
+		render(
 			<PostScheduleCheck hasPublishAction={ true }>yes</PostScheduleCheck>
 		);
-		expect( wrapper.type() ).not.toBe( null );
+		expect( screen.queryByText( 'yes' ) ).toBeVisible();
 	} );
 } );

--- a/packages/editor/src/components/post-slug/test/check.js
+++ b/packages/editor/src/components/post-slug/test/check.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { shallow } from 'enzyme';
+import { render, screen } from '@testing-library/react';
 
 /**
  * Internal dependencies
@@ -10,8 +10,8 @@ import PostSlugCheck from '../check';
 
 describe( 'PostSlugCheck', () => {
 	it( 'should render control', () => {
-		const wrapper = shallow( <PostSlugCheck>slug</PostSlugCheck> );
+		render( <PostSlugCheck>slug</PostSlugCheck> );
 
-		expect( wrapper.type() ).not.toBe( null );
+		expect( screen.queryByText( 'slug' ) ).toBeVisible();
 	} );
 } );

--- a/packages/editor/src/components/post-slug/test/check.js
+++ b/packages/editor/src/components/post-slug/test/check.js
@@ -12,6 +12,6 @@ describe( 'PostSlugCheck', () => {
 	it( 'should render control', () => {
 		render( <PostSlugCheck>slug</PostSlugCheck> );
 
-		expect( screen.queryByText( 'slug' ) ).toBeVisible();
+		expect( screen.getByText( 'slug' ) ).toBeVisible();
 	} );
 } );

--- a/packages/editor/src/components/post-sticky/test/index.js
+++ b/packages/editor/src/components/post-sticky/test/index.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { shallow } from 'enzyme';
+import { render, screen } from '@testing-library/react';
 
 /**
  * Internal dependencies
@@ -10,29 +10,33 @@ import { PostStickyCheck } from '../check';
 
 describe( 'PostSticky', () => {
 	it( 'should not render anything if the post type is not "post"', () => {
-		const wrapper = shallow(
+		render(
 			<PostStickyCheck postType="page" hasStickyAction={ true }>
 				Can Toggle Sticky
 			</PostStickyCheck>
 		);
-		expect( wrapper.type() ).toBe( null );
+		expect(
+			screen.queryByText( 'Can Toggle Sticky' )
+		).not.toBeInTheDocument();
 	} );
 
 	it( "should not render anything if post doesn't support stickying", () => {
-		const wrapper = shallow(
+		render(
 			<PostStickyCheck postType="post" hasStickyAction={ false }>
 				Can Toggle Sticky
 			</PostStickyCheck>
 		);
-		expect( wrapper.type() ).toBe( null );
+		expect(
+			screen.queryByText( 'Can Toggle Sticky' )
+		).not.toBeInTheDocument();
 	} );
 
 	it( 'should render if the post supports stickying', () => {
-		const wrapper = shallow(
+		render(
 			<PostStickyCheck postType="post" hasStickyAction={ true }>
 				Can Toggle Sticky
 			</PostStickyCheck>
 		);
-		expect( wrapper.type() ).not.toBe( null );
+		expect( screen.queryByText( 'Can Toggle Sticky' ) ).toBeVisible();
 	} );
 } );

--- a/packages/editor/src/components/post-sticky/test/index.js
+++ b/packages/editor/src/components/post-sticky/test/index.js
@@ -37,6 +37,6 @@ describe( 'PostSticky', () => {
 				Can Toggle Sticky
 			</PostStickyCheck>
 		);
-		expect( screen.queryByText( 'Can Toggle Sticky' ) ).toBeVisible();
+		expect( screen.getByText( 'Can Toggle Sticky' ) ).toBeVisible();
 	} );
 } );

--- a/packages/editor/src/components/post-visibility/test/check.js
+++ b/packages/editor/src/components/post-visibility/test/check.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { shallow } from 'enzyme';
+import { render, screen } from '@testing-library/react';
 
 /**
  * Internal dependencies
@@ -9,19 +9,27 @@ import { shallow } from 'enzyme';
 import { PostVisibilityCheck } from '../check';
 
 describe( 'PostVisibilityCheck', () => {
-	const render = ( { canEdit } ) => ( canEdit ? 'yes' : 'no' );
+	const renderProp = ( { canEdit } ) => ( canEdit ? 'yes' : 'no' );
 
 	it( "should not render the edit link if the user doesn't have the right capability", () => {
-		const wrapper = shallow(
-			<PostVisibilityCheck hasPublishAction={ false } render={ render } />
+		render(
+			<PostVisibilityCheck
+				hasPublishAction={ false }
+				render={ renderProp }
+			/>
 		);
-		expect( wrapper.text() ).toBe( 'no' );
+		expect( screen.queryByText( 'yes' ) ).not.toBeInTheDocument();
+		expect( screen.queryByText( 'no' ) ).toBeVisible();
 	} );
 
 	it( 'should render if the user has the correct capability', () => {
-		const wrapper = shallow(
-			<PostVisibilityCheck hasPublishAction={ true } render={ render } />
+		render(
+			<PostVisibilityCheck
+				hasPublishAction={ true }
+				render={ renderProp }
+			/>
 		);
-		expect( wrapper.text() ).toBe( 'yes' );
+		expect( screen.queryByText( 'no' ) ).not.toBeInTheDocument();
+		expect( screen.queryByText( 'yes' ) ).toBeVisible();
 	} );
 } );

--- a/packages/editor/src/components/post-visibility/test/check.js
+++ b/packages/editor/src/components/post-visibility/test/check.js
@@ -19,7 +19,7 @@ describe( 'PostVisibilityCheck', () => {
 			/>
 		);
 		expect( screen.queryByText( 'yes' ) ).not.toBeInTheDocument();
-		expect( screen.queryByText( 'no' ) ).toBeVisible();
+		expect( screen.getByText( 'no' ) ).toBeVisible();
 	} );
 
 	it( 'should render if the user has the correct capability', () => {
@@ -30,6 +30,6 @@ describe( 'PostVisibilityCheck', () => {
 			/>
 		);
 		expect( screen.queryByText( 'no' ) ).not.toBeInTheDocument();
-		expect( screen.queryByText( 'yes' ) ).toBeVisible();
+		expect( screen.getByText( 'yes' ) ).toBeVisible();
 	} );
 } );


### PR DESCRIPTION
## What?
We've recently started refactoring `enzyme` tests to `@testing-library/react`.

This PR refactors a few of the simpler editor component tests from `enzyme` to `@testing-library/react`. I've specifically picked the most straightforward ones that boil down to "should render" or "should not render".

## Why?
`@testing-library/react` provides a better way to write tests for accessible components that is closer to the way the user experiences them.

## How?
We're straightforwardly replacing `enzyme` tests with `@testing-library/react` ones, using `jest-dom` matches and screen queries.

## Testing Instructions
Verify tests pass: `npm run test:unit packages/editor/src/components`