### PR TITLE
Components: Refactor `Guide` tests to `@testing-library/react`

### DIFF
--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -15,6 +15,7 @@
 -   Ensure all dependencies allow version ranges ([#43355](https://github.com/WordPress/gutenberg/pull/43355)).
 -   `Popover`: make sure offset middleware always applies the latest frame offset values ([#43329](https://github.com/WordPress/gutenberg/pull/43329/)).
 -   `Dropdown`: anchor popover to the dropdown wrapper (instead of the toggle) ([#43377](https://github.com/WordPress/gutenberg/pull/43377/)).
+-   `Guide`: Fix error when rendering with no pages ([#43380](https://github.com/WordPress/gutenberg/pull/43380/)).
 
 ### Enhancements
 
@@ -37,10 +38,12 @@
 -   `contextConnect`: Refactor away from `_.uniq()` ([#43330](https://github.com/WordPress/gutenberg/pull/43330/)).
 -   `ColorPalette`: Refactor away from `_.uniq()` ([#43330](https://github.com/WordPress/gutenberg/pull/43330/)).
 -   `Guide`: Refactor away from `_.times()` ([#43374](https://github.com/WordPress/gutenberg/pull/43374/)).
+-   `Guide`: Update tests to use `@testing-library/react` ([#43380](https://github.com/WordPress/gutenberg/pull/43380)).
 -   `Modal`: use `KeyboardEvent.code` instead of deprecated `KeyboardEvent.keyCode`. improve unit tests ([#43429](https://github.com/WordPress/gutenberg/pull/43429/)).
 
 ### Experimental
 -   `FormTokenField`: add `__experimentalAutoSelectFirstMatch` prop to auto select the first matching suggestion on typing ([#42527](https://github.com/WordPress/gutenberg/pull/42527/)).
+=======
 
 ## 19.17.0 (2022-08-10)
 

--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -43,7 +43,6 @@
 
 ### Experimental
 -   `FormTokenField`: add `__experimentalAutoSelectFirstMatch` prop to auto select the first matching suggestion on typing ([#42527](https://github.com/WordPress/gutenberg/pull/42527/)).
-=======
 
 ## 19.17.0 (2022-08-10)
 

--- a/packages/components/src/guide/index.js
+++ b/packages/components/src/guide/index.js
@@ -42,7 +42,9 @@ export default function Guide( {
 	useEffect( () => {
 		// Each time we change the current page, start from the first element of the page.
 		// This also solves any focus loss that can happen.
-		focus.tabbable.find( guideContainer.current )?.[ 0 ]?.focus();
+		if ( guideContainer.current ) {
+			focus.tabbable.find( guideContainer.current )?.[ 0 ]?.focus();
+		}
 	}, [ currentPage ] );
 
 	if ( Children.count( children ) ) {

--- a/packages/components/src/guide/test/index.js
+++ b/packages/components/src/guide/test/index.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { fireEvent, render, screen } from '@testing-library/react';
+import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 
 /**
@@ -102,7 +102,10 @@ describe( 'Guide', () => {
 		expect( onFinish ).toHaveBeenCalled();
 	} );
 
-	it( 'calls onFinish when the modal is closed', () => {
+	it( 'calls onFinish when the modal is closed', async () => {
+		const user = userEvent.setup( {
+			advanceTimers: jest.advanceTimersByTime,
+		} );
 		const onFinish = jest.fn();
 		render(
 			<Guide
@@ -111,27 +114,7 @@ describe( 'Guide', () => {
 			/>
 		);
 
-		/**
-		 * Workaround to trigger an Escape keypress event.
-		 *
-		 * @todo Remove this workaround in favor of userEvent.keyboard() or userEvent.type().
-		 *
-		 * This curently doesn't work:
-		 *
-		 * ```
-		 * await user.keyboard( '[Escape]' );
-		 * ```
-		 *
-		 * because the event sent has a `keyCode` of `0`.
-		 *
-		 * To fix this, we'll need to update the Modal component to work with `KeyboardEvent.code`.
-		 *
-		 * @see https://github.com/testing-library/user-event/issues/969
-		 */
-		fireEvent.keyDown( screen.getByRole( 'dialog' ), {
-			key: 'Escape',
-			keyCode: 27,
-		} );
+		await user.keyboard( '[Escape]' );
 
 		expect( onFinish ).toHaveBeenCalled();
 	} );


### PR DESCRIPTION
## What?
We've recently started refactoring `enzyme` tests to `@testing-library/react`.

This PR refactors the `<Guide />` component tests from `enzyme` to `@testing-library/react`.

## Why?
`@testing-library/react` provides a better way to write tests for accessible components that is closer to the way the user experiences them.

## How?
We're straightforwardly replacing `enzyme` tests with `@testing-library/react` ones, using `jest-dom` matchers screen queries.

This also uncovers a bug: when we render `<Guide />` with no pages, we attempt to focus the guide container, however it doesn't exist because we don't render it if no pages exist. This PR fixes that bug by changing the component to focus only if the guide container exists.

## Testing Instructions
* Verify tests pass: `npm run test:unit packages/components/src/guide`
* Verify Guide component still works well in Storybook.
