### PR TITLE
Comments block: Remove empty block wrapper

### DIFF
--- a/packages/block-library/src/comments/index.php
+++ b/packages/block-library/src/comments/index.php
@@ -39,6 +39,7 @@ function render_block_core_comments( $attributes, $content, $block ) {
 		return '';
 	}
 
+	// If this isn't the legacy block, we need to render the static version of this block.
 	$is_legacy = 'core/post-comments' === $block->name || ! empty( $attributes['legacy'] );
 	if ( ! $is_legacy ) {
 		return $block->render( array( 'dynamic' => false ) );

--- a/packages/block-library/src/comments/index.php
+++ b/packages/block-library/src/comments/index.php
@@ -24,11 +24,6 @@
 function render_block_core_comments( $attributes, $content, $block ) {
 	global $post;
 
-	$is_legacy = 'core/post-comments' === $block->name || ! empty( $attributes['legacy'] );
-	if ( ! $is_legacy ) {
-		return $block->render( array( 'dynamic' => false ) );
-	}
-
 	$post_id = $block->context['postId'];
 	if ( ! isset( $post_id ) ) {
 		return '';
@@ -42,6 +37,11 @@ function render_block_core_comments( $attributes, $content, $block ) {
 	// Return early if there are no comments and comments are closed.
 	if ( ! comments_open( $post_id ) && get_comments( $comment_args ) === 0 ) {
 		return '';
+	}
+
+	$is_legacy = 'core/post-comments' === $block->name || ! empty( $attributes['legacy'] );
+	if ( ! $is_legacy ) {
+		return $block->render( array( 'dynamic' => false ) );
 	}
 
 	$post_before = $post;

--- a/phpunit/blocks/render-comments-test.php
+++ b/phpunit/blocks/render-comments-test.php
@@ -1,0 +1,46 @@
+<?php
+/**
+ * Comments block rendering tests.
+ *
+ * @package WordPress
+ * @subpackage Blocks
+ */
+
+/**
+ * Tests for the Comments block.
+ *
+ * @group blocks
+ */
+class Tests_Blocks_RenderComments extends WP_UnitTestCase {
+	/**
+	 * @var WP_Post
+	 */
+	protected static $post_with_comments_disabled;
+
+	public static function wpSetUpBeforeClass( WP_UnitTest_Factory $factory ) {
+		$args                              = array(
+			'comment_status' => 'closed',
+		);
+		self::$post_with_comments_disabled = self::factory()->post->create_and_get( $args );
+	}
+
+	public static function wpTearDownAfterClass() {
+		wp_delete_post( self::$post_with_comments_disabled->ID, true );
+	}
+
+	/**
+	 * @covers ::render_block_core_comments
+	 */
+	public function test_render_block_core_comments_empty_output_if_comments_disabled() {
+		$attributes    = array();
+		$parsed_blocks = parse_blocks(
+			'<!-- wp:comments --><div class="wp-block-comments"><!-- wp:comments-title /--></div><!-- /wp:comments -->'
+		);
+		$parsed_block  = $parsed_blocks[0];
+		$context       = array( 'postId' => self::$post_with_comments_disabled->ID );
+		$block         = new WP_Block( $parsed_block, $context, $this->registry );
+
+		$rendered = gutenberg_render_block_core_comments( $attributes, '', $block );
+		$this->assertEmpty( $rendered );
+	}
+};

--- a/phpunit/blocks/render-comments-test.php
+++ b/phpunit/blocks/render-comments-test.php
@@ -17,7 +17,7 @@ class Tests_Blocks_RenderComments extends WP_UnitTestCase {
 	 */
 	protected static $post_with_comments_disabled;
 
-	public static function wpSetUpBeforeClass( WP_UnitTest_Factory $factory ) {
+	public static function wpSetUpBeforeClass() {
 		$args                              = array(
 			'comment_status' => 'closed',
 		);


### PR DESCRIPTION
## What?

If posting comments is disabled for a given post (and the post doesn't have any comments yet), we used to render an empty `<div class="wp-comments"> </div>` block wrapper. This PR removes that empty wrapper.

This fixes #41957. _(Note that the block used to be called "Comments Query Loop" at the time but has since been renamed to just "Comments".)_

## Why?
The empty wrapper would get in the way of some layouts, see #41957.

## How?

Moving the check that bails early upon no comments further up in the block's `index.php`.

## Testing Instructions

1. Publish a page or post
2. In the Post sidebar, uncheck "Allow comments"
3. View front end

## Screenshots or screencast <!-- if applicable -->

| Before | After |
|--------|------|
| ![image](https://user-images.githubusercontent.com/96308/185398843-6b1b5eec-f6a3-4738-b68a-4ced12a2bc2d.png) | ![image](https://user-images.githubusercontent.com/96308/185406293-0d80c921-eb70-4730-81a0-6e944b32edff.png) |
