### PR TITLE
Limit access to experimental APIs to WordPress codebase with a new experiments package

### DIFF
--- a/docs/manifest.json
+++ b/docs/manifest.json
@@ -1608,6 +1608,12 @@
 		"parent": "packages"
 	},
 	{
+		"title": "@wordpress/experiments",
+		"slug": "packages-experiments",
+		"markdown_source": "../packages/experiments/README.md",
+		"parent": "packages"
+	},
+	{
 		"title": "@wordpress/format-library",
 		"slug": "packages-format-library",
 		"markdown_source": "../packages/format-library/README.md",

--- a/package-lock.json
+++ b/package-lock.json
@@ -17438,6 +17438,12 @@
 				"requireindex": "^1.2.0"
 			}
 		},
+		"@wordpress/experiments": {
+			"version": "file:packages/experiments",
+			"requires": {
+				"@babel/runtime": "^7.16.0"
+			}
+		},
 		"@wordpress/format-library": {
 			"version": "file:packages/format-library",
 			"requires": {

--- a/package.json
+++ b/package.json
@@ -50,6 +50,7 @@
 		"@wordpress/editor": "file:packages/editor",
 		"@wordpress/element": "file:packages/element",
 		"@wordpress/escape-html": "file:packages/escape-html",
+		"@wordpress/experiments": "file:packages/experiments",
 		"@wordpress/format-library": "file:packages/format-library",
 		"@wordpress/hooks": "file:packages/hooks",
 		"@wordpress/html-entities": "file:packages/html-entities",

--- a/packages/experiments/package.json
+++ b/packages/experiments/package.json
@@ -1,0 +1,35 @@
+{
+	"name": "@wordpress/dependency-injection",
+	"version": "0.0.1",
+	"description": "Dependency Injection container for WordPress.",
+	"author": "The WordPress Contributors",
+	"license": "GPL-2.0-or-later",
+	"keywords": [
+		"wordpress",
+		"gutenberg",
+		"dom",
+		"utils"
+	],
+	"homepage": "https://github.com/WordPress/gutenberg/tree/HEAD/packages/dependency-injection/README.md",
+	"repository": {
+		"type": "git",
+		"url": "https://github.com/WordPress/gutenberg.git",
+		"directory": "packages/injection"
+	},
+	"bugs": {
+		"url": "https://github.com/WordPress/gutenberg/issues"
+	},
+	"engines": {
+		"node": ">=12"
+	},
+	"main": "build/index.js",
+	"module": "build-module/index.js",
+	"react-native": "src/index",
+	"sideEffects": false,
+	"dependencies": {
+		"@babel/runtime": "^7.16.0"
+	},
+	"publishConfig": {
+		"access": "public"
+	}
+}

--- a/packages/experiments/src/index.js
+++ b/packages/experiments/src/index.js
@@ -1,0 +1,78 @@
+const CORE_MODULES_USING_EXPERIMENTS = [
+	'@wordpress/data',
+	'@wordpress/block-editor',
+	'@wordpress/block-library',
+	'@wordpress/blocks',
+	'@wordpress/core-data',
+	'@wordpress/date',
+	'@wordpress/edit-site',
+	'@wordpress/edit-widgets',
+];
+
+const registeredExperiments = {};
+/*
+ * Warning for theme and plugin developers.
+ *
+ * The use of experimental developer APIs is intended for use by WordPress Core
+ * and the Gutenberg plugin exclusively.
+ *
+ * Dangerously opting in to using these APIs is NOT RECOMMENDED. Furthermore,
+ * the WordPress Core philosophy to strive to maintain backward compatibility
+ * for third-party developers DOES NOT APPLY to experimental APIs.
+ *
+ * THE CONSENT STRING FOR OPTING IN TO THESE APIS MAY CHANGE AT ANY TIME AND
+ * WITHOUT NOTICE. THIS CHANGE WILL BREAK EXISTING THIRD-PARTY CODE. SUCH A
+ * CHANGE MAY OCCUR IN EITHER A MAJOR OR MINOR RELEASE.
+ */
+const requiredConsent =
+	'I know using unstable features means my plugin or theme will inevitably break on the next WordPress release.';
+
+export const __dangerousOptInToUnstableAPIsOnlyForCoreModules = (
+	consent,
+	moduleName
+) => {
+	if ( ! CORE_MODULES_USING_EXPERIMENTS.includes( moduleName ) ) {
+		throw new Error(
+			`You tried to opt-in to unstable APIs as a module "${ moduleName }". ` +
+				'This feature is only for JavaScript modules shipped with WordPress core. ' +
+				'Please do not use it in plugins and themes as the unstable APIs will be removed ' +
+				'without a warning. If you ignore this error and depend on unstable features, ' +
+				'your product will inevitably break on one of the next WordPress releases.'
+		);
+	}
+	if ( moduleName in registeredExperiments ) {
+		throw new Error(
+			`You tried to opt-in to unstable APIs as a module "${ moduleName }" which is already registered. ` +
+				'This feature is only for JavaScript modules shipped with WordPress core. ' +
+				'Please do not use it in plugins and themes as the unstable APIs will be removed ' +
+				'without a warning. If you ignore this error and depend on unstable features, ' +
+				'your product will inevitably break on one of the next WordPress releases.'
+		);
+	}
+	if ( consent !== requiredConsent ) {
+		throw new Error(
+			`You tried to opt-in to unstable APIs without confirming you know the consequences. ` +
+				'This feature is only for JavaScript modules shipped with WordPress core. ' +
+				'Please do not use it in plugins and themes as the unstable APIs will removed ' +
+				'without a warning. If you ignore this error and depend on unstable features, ' +
+				'your product will inevitably break on the next WordPress release.'
+		);
+	}
+	registeredExperiments[ moduleName ] = {};
+	return {
+		registerExperimentalAPIs: ( experiments ) => {
+			registeredExperiments[ moduleName ] = {
+				...registeredExperiments[ moduleName ],
+				...experiments,
+			};
+		},
+		getExperimentalAPIs: ( targetModuleName ) => {
+			if ( ! ( targetModuleName in registeredExperiments ) ) {
+				throw new Error(
+					`Module ${ targetModuleName } is not registered yet.`
+				);
+			}
+			return registeredExperiments[ targetModuleName ];
+		},
+	};
+};

--- a/packages/experiments/src/index.js
+++ b/packages/experiments/src/index.js
@@ -63,14 +63,14 @@ export const __dangerousOptInToUnstableAPIsOnlyForCoreModules = (
 		apis: {},
 	};
 	return {
-		registerExperimentalAPIs: ( experiments ) => {
+		register: ( experiments ) => {
 			for ( const key in experiments ) {
 				registeredExperiments[ moduleName ].apis[ key ] =
 					experiments[ key ];
 			}
 			return registeredExperiments[ moduleName ].accessKey;
 		},
-		unlockExperimentalAPIs: ( accessKey ) => {
+		unlock: ( accessKey ) => {
 			for ( const experiment of Object.values( registeredExperiments ) ) {
 				if ( experiment.accessKey === accessKey ) {
 					return experiment.apis;

--- a/packages/experiments/src/index.js
+++ b/packages/experiments/src/index.js
@@ -58,21 +58,28 @@ export const __dangerousOptInToUnstableAPIsOnlyForCoreModules = (
 				'your product will inevitably break on the next WordPress release.'
 		);
 	}
-	registeredExperiments[ moduleName ] = {};
+	registeredExperiments[ moduleName ] = {
+		accessKey: {},
+		apis: {},
+	};
 	return {
 		registerExperimentalAPIs: ( experiments ) => {
-			registeredExperiments[ moduleName ] = {
-				...registeredExperiments[ moduleName ],
-				...experiments,
-			};
-		},
-		getExperimentalAPIs: ( targetModuleName ) => {
-			if ( ! ( targetModuleName in registeredExperiments ) ) {
-				throw new Error(
-					`Module ${ targetModuleName } is not registered yet.`
-				);
+			for ( const key in experiments ) {
+				registeredExperiments[ moduleName ].apis[ key ] =
+					experiments[ key ];
 			}
-			return registeredExperiments[ targetModuleName ];
+			return registeredExperiments[ moduleName ].accessKey;
+		},
+		unlockExperimentalAPIs: ( accessKey ) => {
+			for ( const experiment of Object.values( registeredExperiments ) ) {
+				if ( experiment.accessKey === accessKey ) {
+					return experiment.apis;
+				}
+			}
+
+			throw new Error(
+				'There is no registered module matching the specified access key'
+			);
 		},
 	};
 };

--- a/packages/experiments/src/test/index.js
+++ b/packages/experiments/src/test/index.js
@@ -1,0 +1,88 @@
+/**
+ * Internal dependencies
+ */
+import { __dangerousOptInToUnstableAPIsOnlyForCoreModules } from '../';
+
+const requiredConsent =
+	'I know using unstable features means my plugin or theme will inevitably break on the next WordPress release.';
+
+describe( '__dangerousOptInToUnstableAPIsOnlyForCoreModules', () => {
+	it( 'Should require a consent string', () => {
+		expect( () => {
+			__dangerousOptInToUnstableAPIsOnlyForCoreModules(
+				'',
+				'@wordpress/data'
+			);
+		} ).toThrow( /without confirming you know the consequences/ );
+	} );
+	it( 'Should require a valid @wordpress package name', () => {
+		expect( () => {
+			__dangerousOptInToUnstableAPIsOnlyForCoreModules(
+				requiredConsent,
+				'custom_package'
+			);
+		} ).toThrow(
+			/This feature is only for JavaScript modules shipped with WordPress core/
+		);
+	} );
+	it( 'Should not register the same module twice', () => {
+		expect( () => {
+			__dangerousOptInToUnstableAPIsOnlyForCoreModules(
+				requiredConsent,
+				'@wordpress/edit-widgets'
+			);
+			__dangerousOptInToUnstableAPIsOnlyForCoreModules(
+				requiredConsent,
+				'@wordpress/edit-widgets'
+			);
+		} ).toThrow( /is already registered/ );
+	} );
+	it( 'Should grant access to unstable APIs when passed both a consent string and a previously unregistered package name', () => {
+		const unstableAPIs = __dangerousOptInToUnstableAPIsOnlyForCoreModules(
+			requiredConsent,
+			'@wordpress/edit-site'
+		);
+		expect( unstableAPIs.unlockExperimentalAPIs ).toEqual(
+			expect.any( Function )
+		);
+		expect( unstableAPIs.registerExperimentalAPIs ).toEqual(
+			expect.any( Function )
+		);
+	} );
+	it( 'Should register and unlock experimental APIs', () => {
+		// This would live in @wordpress/data:
+		// Opt-in to experimental APIs
+		const dataUnstableAPIs =
+			__dangerousOptInToUnstableAPIsOnlyForCoreModules(
+				requiredConsent,
+				'@wordpress/data'
+			);
+
+		// Register the experimental APIs
+		const dataExperimentalFunctions = {
+			__experimentalFunction: jest.fn(),
+		};
+		const dataAccessKey = dataUnstableAPIs.registerExperimentalAPIs(
+			dataExperimentalFunctions
+		);
+
+		// This would live in @wordpress/core-data:
+		// Register the experimental APIs
+		const coreDataUnstableAPIs =
+			__dangerousOptInToUnstableAPIsOnlyForCoreModules(
+				requiredConsent,
+				'@wordpress/core-data'
+			);
+
+		// Get the experimental APIs registered by @wordpress/data
+		const { __experimentalFunction } =
+			coreDataUnstableAPIs.unlockExperimentalAPIs( dataAccessKey );
+
+		// Call one!
+		__experimentalFunction();
+
+		expect(
+			dataExperimentalFunctions.__experimentalFunction
+		).toHaveBeenCalled();
+	} );
+} );

--- a/packages/experiments/src/test/index.js
+++ b/packages/experiments/src/test/index.js
@@ -42,17 +42,13 @@ describe( '__dangerousOptInToUnstableAPIsOnlyForCoreModules', () => {
 			requiredConsent,
 			'@wordpress/edit-site'
 		);
-		expect( unstableAPIs.unlockExperimentalAPIs ).toEqual(
-			expect.any( Function )
-		);
-		expect( unstableAPIs.registerExperimentalAPIs ).toEqual(
-			expect.any( Function )
-		);
+		expect( unstableAPIs.unlock ).toEqual( expect.any( Function ) );
+		expect( unstableAPIs.register ).toEqual( expect.any( Function ) );
 	} );
 	it( 'Should register and unlock experimental APIs', () => {
 		// This would live in @wordpress/data:
 		// Opt-in to experimental APIs
-		const dataUnstableAPIs =
+		const dataExperiments =
 			__dangerousOptInToUnstableAPIsOnlyForCoreModules(
 				requiredConsent,
 				'@wordpress/data'
@@ -62,13 +58,13 @@ describe( '__dangerousOptInToUnstableAPIsOnlyForCoreModules', () => {
 		const dataExperimentalFunctions = {
 			__experimentalFunction: jest.fn(),
 		};
-		const dataAccessKey = dataUnstableAPIs.registerExperimentalAPIs(
+		const dataAccessKey = dataExperiments.register(
 			dataExperimentalFunctions
 		);
 
 		// This would live in @wordpress/core-data:
 		// Register the experimental APIs
-		const coreDataUnstableAPIs =
+		const coreDataExperiments =
 			__dangerousOptInToUnstableAPIsOnlyForCoreModules(
 				requiredConsent,
 				'@wordpress/core-data'
@@ -76,7 +72,7 @@ describe( '__dangerousOptInToUnstableAPIsOnlyForCoreModules', () => {
 
 		// Get the experimental APIs registered by @wordpress/data
 		const { __experimentalFunction } =
-			coreDataUnstableAPIs.unlockExperimentalAPIs( dataAccessKey );
+			coreDataExperiments.unlock( dataAccessKey );
 
 		// Call one!
 		__experimentalFunction();


### PR DESCRIPTION
# What
This PR proposes a way of making the `__experimental` APIs private as [exposing them to publicly plugin authors is quite controversial.](https://make.wordpress.org/core/2022/08/10/proposal-stop-merging-experimental-apis-from-gutenberg-to-wordpress-core/#respond). 

Tl;dr, the idea is to have a "dealer" that only deals the experimental APIs to WordPress packages.

Each package would start by registering itself:

```js
const { register } = 
	__dangerousOptInToUnstableAPIsOnlyForCoreModules(
		'I know using unstable features means my plugin or theme will inevitably break on the next WordPress release.',
		'@wordpress/blocks'
	);
```

The function name communicates that plugins are not supposed to use it. To make double and triple sure, the first argument must be that exact consent string, and the second argument must be a known `@wordpress` package that hasn't opted in yet – otherwise an error is thrown.

Exposing a new `__experimental` API looks like this:
```js
export __experiments = register( { __unstableGetInnerBlocksProps } )
```

Now here's the interesting part – consuming a registered `__experimental` API requires opting-in first:
```js
// In the @wordpress/block-editor package:
import { __experiments as blocksExperiments } from '@wordpress/blocks';
const { unlock } = 
	__dangerousOptInToUnstableAPIsOnlyForCoreModules(
		'I know using unstable features means my plugin or theme will inevitably break on the next WordPress release.',
		'@wordpress/block-editor'
	);

const { __unstableGetInnerBlocksProps } = unlock( blocksExperiments );
```

`window.wp` is still the recommended way of using the public APIs. A determined developer who would want to use the experimental APIs at all costs would have to:

* Realize a private importing system exists
* Read the code where the risks would be spelled out in capital letters
* Explicitly type out he or she is aware of the consequences
* Pretend to register a `@wordpress` package (and trigger an error as soon as the real package is loaded)

This PR touches 21 files but the important part is the new `@wordpress/experiments` module. Everything else is just a demo that I want to remove before merging this PR. There is no need to migrate the existing `__experimental` APIs to this new system as they are already being publicly exported. Only the future `__experimental` APIs would use this system.

## Notable usage examples

The [usage examples previously shipped with this PR](https://github.com/WordPress/gutenberg/commit/c107cd0729ea3bbf9abe743a39001e0651310a64#diff-2886f0a2b11770e1111405c2f27df87d345afea5c4df1f158c75e858e1f6cf9f) include:

* `@wordpress/data` offers [experimental utils for **private actions and selectors**](https://github.com/WordPress/gutenberg/blob/ca4cac7a2f00da7c9bcc99fc8a394951438a8af3/packages/data/src/index.js#L241-L248)
* `__experimentalReapplyBlockTypeFilters()` [is one such private action](https://github.com/WordPress/gutenberg/blob/ca4cac7a2f00da7c9bcc99fc8a394951438a8af3/packages/blocks/src/index.js#L45-L50) – and [here's where it's used](https://github.com/WordPress/gutenberg/blob/ca4cac7a2f00da7c9bcc99fc8a394951438a8af3/packages/edit-widgets/src/index.js#L103).
* `@wordpress/edit-widgets` uses experiments registered by three different packages
* `@wordpress/data` only registers experimental APIs without requesting any

See [the entire (now removed) commit tree](https://github.com/WordPress/gutenberg/commits/ca4cac7a2f00da7c9bcc99fc8a394951438a8af3).

This PR is an alternative to #41278

## Testing Instructions
Ignore the CI. Let's focus on the discussion – what do you like and dislike about this idea?

CC @gziolo @peterwilsoncc @mcsf @talldan @noisysocks @azaozz @jorgefilipecosta @mtias 