### PR TITLE
Lodash: Refactor away from `_.xor()`

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -152,6 +152,7 @@ module.exports = {
 							'upperFirst',
 							'values',
 							'words',
+							'xor',
 							'zip',
 						],
 						message:

--- a/packages/blocks/src/api/validation/index.js
+++ b/packages/blocks/src/api/validation/index.js
@@ -2,7 +2,7 @@
  * External dependencies
  */
 import { Tokenizer } from 'simple-html-tokenizer';
-import { xor, isEqual, includes } from 'lodash';
+import { isEqual, includes } from 'lodash';
 
 /**
  * WordPress dependencies
@@ -410,9 +410,17 @@ export const isEqualAttributesOfName = {
 	class: ( actual, expected ) => {
 		// Class matches if members are the same, even if out of order or
 		// superfluous whitespace between.
-		return ! xor(
-			...[ actual, expected ].map( getTextPiecesSplitOnWhitespace )
-		).length;
+		const [ actualPieces, expectedPieces ] = [ actual, expected ].map(
+			getTextPiecesSplitOnWhitespace
+		);
+		const actualDiff = actualPieces.filter(
+			( c ) => ! expectedPieces.includes( c )
+		);
+		const expectedDiff = expectedPieces.filter(
+			( c ) => ! actualPieces.includes( c )
+		);
+
+		return new Set( [ ...actualDiff, ...expectedDiff ] ).size === 0;
 	},
 	style: ( actual, expected ) => {
 		return isEqual( ...[ actual, expected ].map( getStyleProperties ) );

--- a/packages/blocks/src/api/validation/index.js
+++ b/packages/blocks/src/api/validation/index.js
@@ -420,7 +420,7 @@ export const isEqualAttributesOfName = {
 			( c ) => ! actualPieces.includes( c )
 		);
 
-		return new Set( [ ...actualDiff, ...expectedDiff ] ).size === 0;
+		return actualDiff.length === 0 && expectedDiff.length === 0;
 	},
 	style: ( actual, expected ) => {
 		return isEqual( ...[ actual, expected ].map( getStyleProperties ) );

--- a/packages/keycodes/src/index.js
+++ b/packages/keycodes/src/index.js
@@ -358,7 +358,7 @@ export const isKeyboardEvent = mapValues( modifiers, ( getModifiers ) => {
 			( mod ) => ! mods.includes( mod )
 		);
 
-		if ( new Set( [ ...modsDiff, ...eventModsDiff ] ).size > 0 ) {
+		if ( modsDiff.length > 0 || eventModsDiff.length > 0 ) {
 			return false;
 		}
 

--- a/packages/keycodes/src/index.js
+++ b/packages/keycodes/src/index.js
@@ -13,7 +13,7 @@
  * External dependencies
  */
 import { capitalCase } from 'change-case';
-import { get, mapValues, includes, xor } from 'lodash';
+import { get, mapValues, includes } from 'lodash';
 
 /**
  * WordPress dependencies
@@ -353,7 +353,12 @@ export const isKeyboardEvent = mapValues( modifiers, ( getModifiers ) => {
 		const mods = getModifiers( _isApple );
 		const eventMods = getEventModifiers( event );
 
-		if ( xor( mods, eventMods ).length ) {
+		const modsDiff = mods.filter( ( mod ) => ! eventMods.includes( mod ) );
+		const eventModsDiff = eventMods.filter(
+			( mod ) => ! mods.includes( mod )
+		);
+
+		if ( new Set( [ ...modsDiff, ...eventModsDiff ] ).size > 0 ) {
 			return false;
 		}
 


### PR DESCRIPTION
## What?
This PR removes the `_.xor()` usage completely and deprecates the function. 

## Why?

Lodash is known to unnecessarily inflate the bundle size of packages, and in most cases, it can be replaced with native language functionality. See these for more information and rationale:

* https://github.com/WordPress/gutenberg/issues/16938#issuecomment-602837246
* https://github.com/WordPress/gutenberg/issues/17025
* https://github.com/WordPress/gutenberg/issues/39495 

## How?

`_.xor( x, y )` is easily replacible by getting the difference between arrays, one by one, then combining them into one into a `Set` to unique-ify the differences between the two arrays. 

## Testing Instructions
Verify tests still pass: 

```
npm run test:unit packages/blocks/src/api/test/validation.js packages/keycodes/src/test/index.js
```