### PR TITLE
Customize widgets: Fix top contents cutoff in keyboard shortcuts

### DIFF
--- a/packages/customize-widgets/src/components/keyboard-shortcut-help-modal/style.scss
+++ b/packages/customize-widgets/src/components/keyboard-shortcut-help-modal/style.scss
@@ -3,11 +3,6 @@
 		margin: 0 0 2rem 0;
 	}
 
-	&__main-shortcuts .customize-widgets-keyboard-shortcut-help-modal__shortcut-list {
-		// Push the shortcut to be flush with top modal header.
-		margin-top: -$grid-unit-30 -$border-width;
-	}
-
 	&__section-title {
 		font-size: 0.9rem;
 		font-weight: 600;


### PR DESCRIPTION
## What?
This PR fix top contents cutoff in keyboard shortcuts in the customize widgets.

## Why?
I took the diff between the styles of edit-post or edit-site and found that only customizer-widgets had negative margins in the upper direction.

## How?
I have removed this style.
I looked at #31970 where this style was applied and could not find any reason why this style was needed.

## Testing Instructions

### Trunk

![trunk](https://user-images.githubusercontent.com/54422211/185418948-d88c264c-9295-4994-bdd4-e88ea0bf3c42.png)

### After fixed

![fixed](https://user-images.githubusercontent.com/54422211/185418970-378cc043-e13d-4e78-8d98-62e25d17c0ea.png)