### PR TITLE
Layout: add arg to enqueue layout styles

### DIFF
--- a/lib/block-supports/layout.php
+++ b/lib/block-supports/layout.php
@@ -35,7 +35,7 @@ function gutenberg_register_layout_support( $block_type ) {
  * @param boolean $should_skip_gap_serialization Whether to skip applying the user-defined value set in the editor.
  * @param string  $fallback_gap_value            The block gap value to apply.
  * @param array   $block_spacing                 Custom spacing set on the block.
- * @param boolean $should_enqueue              Whether to enqueue the styles for rendering.
+ * @param boolean $should_enqueue                Whether to enqueue the styles for rendering.
  *
  * @return string                                CSS style.
  */
@@ -224,12 +224,11 @@ function gutenberg_get_layout_style( $selector, $layout, $has_block_gap_support 
 		// Add to the style engine store to enqueue and render layout styles.
 		// Return compiled layout styles to retain backwards compatibility.
 		// Since https://github.com/WordPress/gutenberg/pull/42452 we no longer call wp_enqueue_block_support_styles in this block supports file.
-		$stylesheet_options = $should_enqueue ? array(
-			'context' => 'block-supports',
-		) : null;
 		return gutenberg_style_engine_get_stylesheet_from_css_rules(
 			$layout_styles,
-			$stylesheet_options
+			$should_enqueue ? array(
+				'context' => 'block-supports',
+			) : null
 		);
 	}
 

--- a/lib/block-supports/layout.php
+++ b/lib/block-supports/layout.php
@@ -35,10 +35,11 @@ function gutenberg_register_layout_support( $block_type ) {
  * @param boolean $should_skip_gap_serialization Whether to skip applying the user-defined value set in the editor.
  * @param string  $fallback_gap_value            The block gap value to apply.
  * @param array   $block_spacing                 Custom spacing set on the block.
+ * @param boolean $should_enqueue              Whether to enqueue the styles for rendering.
  *
  * @return string                                CSS style.
  */
-function gutenberg_get_layout_style( $selector, $layout, $has_block_gap_support = false, $gap_value = null, $should_skip_gap_serialization = false, $fallback_gap_value = '0.5em', $block_spacing = null ) {
+function gutenberg_get_layout_style( $selector, $layout, $has_block_gap_support = false, $gap_value = null, $should_skip_gap_serialization = false, $fallback_gap_value = '0.5em', $block_spacing = null, $should_enqueue = false ) {
 	$layout_type   = isset( $layout['type'] ) ? $layout['type'] : 'default';
 	$layout_styles = array();
 	if ( 'default' === $layout_type ) {
@@ -223,11 +224,12 @@ function gutenberg_get_layout_style( $selector, $layout, $has_block_gap_support 
 		// Add to the style engine store to enqueue and render layout styles.
 		// Return compiled layout styles to retain backwards compatibility.
 		// Since https://github.com/WordPress/gutenberg/pull/42452 we no longer call wp_enqueue_block_support_styles in this block supports file.
+		$stylesheet_options = $should_enqueue ? array(
+			'context' => 'block-supports',
+		) : null;
 		return gutenberg_style_engine_get_stylesheet_from_css_rules(
 			$layout_styles,
-			array(
-				'context' => 'block-supports',
-			)
+			$stylesheet_options
 		);
 	}
 
@@ -321,7 +323,7 @@ function gutenberg_render_layout_support_flag( $block_content, $block ) {
 		// If a block's block.json skips serialization for spacing or spacing.blockGap,
 		// don't apply the user-defined value to the styles.
 		$should_skip_gap_serialization = gutenberg_should_skip_block_supports_serialization( $block_type, 'spacing', 'blockGap' );
-		$style                         = gutenberg_get_layout_style( ".$block_classname.$container_class", $used_layout, $has_block_gap_support, $gap_value, $should_skip_gap_serialization, $fallback_gap_value, $block_spacing );
+		$style                         = gutenberg_get_layout_style( ".$block_classname.$container_class", $used_layout, $has_block_gap_support, $gap_value, $should_skip_gap_serialization, $fallback_gap_value, $block_spacing, true );
 
 		// Only add container class and enqueue block support styles if unique styles were generated.
 		if ( ! empty( $style ) ) {

--- a/phpunit/block-supports/layout-test.php
+++ b/phpunit/block-supports/layout-test.php
@@ -7,6 +7,18 @@
  */
 
 class WP_Block_Supports_Layout_Test extends WP_UnitTestCase {
+	/**
+	 * Clean up global scope.
+	 *
+	 * @global WP_Scripts $wp_scripts
+	 * @global WP_Styles $wp_styles
+	 */
+	public function clean_up_global_scope() {
+		global $wp_styles;
+		$wp_styles = null;
+		parent::clean_up_global_scope();
+	}
+
 	function set_up() {
 		parent::set_up();
 		$this->theme_root     = realpath( __DIR__ . '/../data/themedir1' );
@@ -100,5 +112,53 @@ class WP_Block_Supports_Layout_Test extends WP_UnitTestCase {
 		$expected      = '<figure class="wp-block-image alignright size-full is-style-round my-custom-classname"><img src="/my-image.jpg"/></figure>';
 
 		$this->assertSame( $expected, gutenberg_restore_image_outer_container( $block_content, $block ) );
+	}
+
+	/**
+	 * Tests that layout CSS is enqueued.
+	 */
+	public function test_should_not_enqueue_stored_styles() {
+		global $wp_styles;
+		gutenberg_get_layout_style(
+			'.tested',
+			array(
+				'type'        => 'default',
+				'contentSize' => '800px',
+				'wideSize'    => '1000px',
+			),
+			true,
+			null,
+			false,
+			'0.5em',
+			null,
+			false
+		);
+		gutenberg_enqueue_stored_styles();
+
+		$this->assertNull( $wp_styles );
+	}
+
+	/**
+	 * Tests that layout CSS is enqueued.
+	 */
+	public function test_enqueue_stored_layout_styles() {
+		global $wp_styles;
+		$layout_styles = gutenberg_get_layout_style(
+			'.test',
+			array(
+				'type'        => 'default',
+				'contentSize' => '800px',
+				'wideSize'    => '1000px',
+			),
+			true,
+			null,
+			false,
+			'0.5em',
+			null,
+			true
+		);
+		gutenberg_enqueue_stored_styles();
+
+		$this->assertEquals( array( $layout_styles ), $wp_styles->get_data( 'core-block-supports', 'after' ) );
 	}
 }


### PR DESCRIPTION
We might not need this.


## What?
Add _another_ arg to `gutenberg_get_layout_style` to prevent enqueuing.

## Why?
3rd parties might want to call `gutenberg_get_layout_style` to get layout styles, in which case they would want the styles only, not to have them enqueued, which they already are in `gutenberg_render_layout_support_flag`



## Testing Instructions

Insert some blocks that opt into layout support, e.g., group blocks.

<details>

<summary>Example block code</summary>

```html
<!-- wp:group {"style":{"spacing":{"blockGap":"165px"}},"backgroundColor":"pale-pink"} -->
<div class="wp-block-group has-pale-pink-background-color has-background"><!-- wp:group {"backgroundColor":"vivid-green-cyan","layout":{"type":"flex","orientation":"vertical"}} -->
<div class="wp-block-group has-vivid-green-cyan-background-color has-background"><!-- wp:paragraph -->
<p>Test</p>
<!-- /wp:paragraph --></div>
<!-- /wp:group -->

<!-- wp:group {"backgroundColor":"vivid-green-cyan","layout":{"type":"flex","flexWrap":"nowrap","justifyContent":"right"}} -->
<div class="wp-block-group has-vivid-green-cyan-background-color has-background"><!-- wp:paragraph -->
<p>Test</p>
<!-- /wp:paragraph --></div>
<!-- /wp:group -->

<!-- wp:group {"backgroundColor":"vivid-green-cyan","layout":{"type":"default"}} -->
<div class="wp-block-group has-vivid-green-cyan-background-color has-background"><!-- wp:paragraph -->
<p>Test</p>
<!-- /wp:paragraph --></div>
<!-- /wp:group -->

<!-- wp:group {"backgroundColor":"vivid-green-cyan","layout":{"type":"default"}} -->
<div class="wp-block-group has-vivid-green-cyan-background-color has-background"><!-- wp:paragraph -->
<p>Test</p>
<!-- /wp:paragraph --></div>
<!-- /wp:group --></div>
<!-- /wp:group -->

```

</details>
Check that the layout styles are still being generated and enqueued on the frontend.

You should see the following in the frontend source:


```html
<style id='core-block-supports-inline-css'>
/**
 * Core styles: block-supports
 */
.wp-block-group.wp-container-1 {
	flex-direction: column;
	align-items: flex-start;
}
.wp-block-group.wp-container-2 {
	flex-wrap: nowrap;
	justify-content: flex-end;
}
.wp-block-group.wp-container-5 > * {
	margin-block-start: 0;
	margin-block-end: 0;
}
.wp-block-group.wp-container-5.wp-block-group.wp-container-5 > * + * {
	margin-block-start: 165px;
	margin-block-end: 0;
}
.wp-block-post-content.wp-container-6 > :where(:not(.alignleft):not(.alignright):not(.alignfull)) {
	max-width: 840px;
	margin-left: auto !important;
	margin-right: auto !important;
}
.wp-block-post-content.wp-container-6 > .alignwide {
	max-width: 1100px;
}
.wp-block-post-content.wp-container-6 .alignfull {
	max-width: none;
}

</style>
```


