### PR TITLE
Post Date: Add spacing support

### DIFF
--- a/docs/reference-guides/core-blocks.md
+++ b/docs/reference-guides/core-blocks.md
@@ -527,7 +527,7 @@ Add the date of this post. ([Source](https://github.com/WordPress/gutenberg/tree
 
 -	**Name:** core/post-date
 -	**Category:** theme
--	**Supports:** color (background, gradients, link, text), typography (fontSize, lineHeight), ~~html~~
+-	**Supports:** color (background, gradients, link, text), spacing (margin, padding), typography (fontSize, lineHeight), ~~html~~
 -	**Attributes:** displayType, format, isLink, textAlign
 
 ## Post Excerpt

--- a/packages/block-library/src/post-date/block.json
+++ b/packages/block-library/src/post-date/block.json
@@ -34,6 +34,10 @@
 				"link": true
 			}
 		},
+		"spacing": {
+			"margin": true,
+			"padding": true
+		},
 		"typography": {
 			"fontSize": true,
 			"lineHeight": true,

--- a/packages/block-library/src/post-date/style.scss
+++ b/packages/block-library/src/post-date/style.scss
@@ -1,0 +1,4 @@
+.wp-block-post-date {
+	// This block has customizable padding, border-box makes that more predictable.
+	box-sizing: border-box;
+}

--- a/packages/block-library/src/style.scss
+++ b/packages/block-library/src/style.scss
@@ -27,6 +27,7 @@
 @import "./paragraph/style.scss";
 @import "./post-author/style.scss";
 @import "./post-comments-form/style.scss";
+@import "./post-date/style.scss";
 @import "./post-excerpt/style.scss";
 @import "./post-featured-image/style.scss";
 @import "./post-terms/style.scss";


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

Related:

* https://github.com/WordPress/gutenberg/issues/43241
* https://github.com/WordPress/gutenberg/issues/43243

## What?
<!-- In a few words, what is the PR actually doing? -->

Enabling spacing support for the Post Date block (hidden by default).

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

To create consistency across blocks. Padding and Margin can be quite useful for blocks like Post Date that are used in layouts for post templates.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

* Opt-in to Padding and Margin
* Because the Post Date block is rendered in a `div` element that stretches full width, also add a `box-sizing: border-box` rule for consistency with other blocks that opt-in to padding. (e.g. this ensure that the padding settings of Post Date will line up nicely with a Group block that has padding in TwentyTwentyTwo theme)

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->

1. Load the block editor and add a Post Date block adjacent to another block (e.g. between two paragraphs, or beneath a heading).
2. Confirm that the dimensions control panel is there.
3. Add margin and padding.
4. (Note that left/right margins will not appear to do anything because alignment rules take precedence — this is a known peculiarity of the margin block support, but it's still useful to have all controls available, particularly for when Post Date is used within a Row block)
5. Save and confirm the styles appear on the site frontend
6. Test that new support works for the block via global styles. Note a caveat here about margin styles in global styles as raised in: https://github.com/WordPress/gutenberg/issues/43404

## Screenshots or screencast <!-- if applicable -->

This screengrab demonstrates the usefulness of being able to adjust a single margin side when the block is used within a Row block:

![2022-08-19 16 05 58](https://user-images.githubusercontent.com/14988353/185555129-820533f8-c86b-45c7-aca2-9439b437a481.gif)

