### PR TITLE
Update incorrect quote e2e test snapshot

### DIFF
--- a/packages/e2e-tests/specs/editor/blocks/__snapshots__/quote.test.js.snap
+++ b/packages/e2e-tests/specs/editor/blocks/__snapshots__/quote.test.js.snap
@@ -117,7 +117,7 @@ exports[`Quote can be split at the end 2`] = `
 <!-- /wp:paragraph -->
 
 <!-- wp:paragraph -->
-<p></p>
+<p>2</p>
 <!-- /wp:paragraph --></blockquote>
 <!-- /wp:quote -->"
 `;


### PR DESCRIPTION
## What?
Closes #42814

## Why?
The snapshot was committed with the wrong data. The test types a '2' character:
https://github.com/WordPress/gutenberg/blob/3a2e02b1c04790513e9c0c6b976b0e11b194ccb8/packages/e2e-tests/specs/editor/blocks/quote.test.js#L146-L149

But that's missing from the snapshot that was committed in #42780:
https://github.com/WordPress/gutenberg/blob/3a2e02b1c04790513e9c0c6b976b0e11b194ccb8/packages/e2e-tests/specs/editor/blocks/__snapshots__/quote.test.js.snap#L101-L111

## How?
Updates the snapshot.

It's likely this test is flakey and when the original snapshot that was generated in the PR was an instance where the test failed.

So I fully expect it to be reported as flakey again, and if that happens it might be worth skipping the test.