### PR TITLE
Fix template part focus mode resizable editor height

### DIFF
--- a/packages/edit-site/src/components/block-editor/resizable-editor.js
+++ b/packages/edit-site/src/components/block-editor/resizable-editor.js
@@ -77,7 +77,7 @@ function ResizableEditor( { enableResizing, settings, children, ...props } ) {
 
 						setHeight( iframe.contentDocument.body.scrollHeight );
 						timeoutId = null;
-					}, 100 );
+					}, 40 );
 				}
 			}
 

--- a/packages/edit-site/src/components/block-editor/resizable-editor.js
+++ b/packages/edit-site/src/components/block-editor/resizable-editor.js
@@ -57,20 +57,27 @@ function ResizableEditor( { enableResizing, settings, children, ...props } ) {
 				return;
 			}
 
-			let animationFrame = null;
+			let timeoutId = null;
 
 			function resizeHeight() {
-				if ( ! animationFrame ) {
+				if ( ! timeoutId ) {
 					// Throttle the updates on animation frame.
-					animationFrame = iframe.contentWindow.requestAnimationFrame(
-						() => {
-							setHeight(
-								iframe.contentDocument.documentElement
-									.scrollHeight
-							);
-							animationFrame = null;
+					timeoutId = iframe.contentWindow.setTimeout( () => {
+						const { readyState } = iframe.contentDocument;
+
+						// Continue deferring the timeout until the document is ready.
+						// Only then will it have a height.
+						if (
+							readyState !== 'interactive' &&
+							readyState !== 'complete'
+						) {
+							resizeHeight();
+							return;
 						}
-					);
+
+						setHeight( iframe.contentDocument.body.scrollHeight );
+						timeoutId = null;
+					}, 100 );
 				}
 			}
 
@@ -84,9 +91,7 @@ function ResizableEditor( { enableResizing, settings, children, ...props } ) {
 				);
 				// Observing the <html> rather than the <body> because the latter
 				// gets destroyed and remounted after initialization in <Iframe>.
-				resizeObserver.observe(
-					iframe.contentDocument.documentElement
-				);
+				resizeObserver.observe( iframe.contentDocument.body );
 
 				resizeHeight();
 			}
@@ -97,7 +102,7 @@ function ResizableEditor( { enableResizing, settings, children, ...props } ) {
 			registerObserver();
 
 			return () => {
-				iframe.contentWindow?.cancelAnimationFrame( animationFrame );
+				iframe.contentWindow?.clearTimeout( timeoutId );
 				resizeObserver?.disconnect();
 				iframe.removeEventListener( 'load', registerObserver );
 			};
@@ -153,7 +158,7 @@ function ResizableEditor( { enableResizing, settings, children, ...props } ) {
 			} }
 		>
 			<Iframe
-				style={ enableResizing ? undefined : deviceStyles }
+				style={ enableResizing ? { height } : deviceStyles }
 				head={
 					<>
 						<EditorStyles styles={ settings.styles } />

--- a/packages/edit-site/src/components/block-editor/resizable-editor.js
+++ b/packages/edit-site/src/components/block-editor/resizable-editor.js
@@ -61,7 +61,9 @@ function ResizableEditor( { enableResizing, settings, children, ...props } ) {
 
 			function resizeHeight() {
 				if ( ! timeoutId ) {
-					// Throttle the updates on timeout.
+					// Throttle the updates on timeout. This code previously
+					// used `requestAnimationFrame`, but that seems to not
+					// always work before an iframe is ready.
 					timeoutId = iframe.contentWindow.setTimeout( () => {
 						const { readyState } = iframe.contentDocument;
 
@@ -77,7 +79,9 @@ function ResizableEditor( { enableResizing, settings, children, ...props } ) {
 
 						setHeight( iframe.contentDocument.body.scrollHeight );
 						timeoutId = null;
-					}, 40 );
+
+						// 30 frames per second.
+					}, 1000 / 30 );
 				}
 			}
 
@@ -89,8 +93,9 @@ function ResizableEditor( { enableResizing, settings, children, ...props } ) {
 				resizeObserver = new iframe.contentWindow.ResizeObserver(
 					resizeHeight
 				);
-				// Observing the <html> rather than the <body> because the latter
-				// gets destroyed and remounted after initialization in <Iframe>.
+
+				// Observe the body, since the `html` element seems to always
+				// have a height of `100%`.
 				resizeObserver.observe( iframe.contentDocument.body );
 
 				resizeHeight();

--- a/packages/edit-site/src/components/block-editor/resizable-editor.js
+++ b/packages/edit-site/src/components/block-editor/resizable-editor.js
@@ -61,7 +61,7 @@ function ResizableEditor( { enableResizing, settings, children, ...props } ) {
 
 			function resizeHeight() {
 				if ( ! timeoutId ) {
-					// Throttle the updates on animation frame.
+					// Throttle the updates on timeout.
 					timeoutId = iframe.contentWindow.setTimeout( () => {
 						const { readyState } = iframe.contentDocument;
 

--- a/test/e2e/specs/site-editor/template-part.spec.js
+++ b/test/e2e/specs/site-editor/template-part.spec.js
@@ -300,4 +300,34 @@ test.describe( 'Template Part', () => {
 
 		await expect( paragraph ).toBeVisible();
 	} );
+
+	// Check for regressions of https://github.com/WordPress/gutenberg/issues/42226.
+	test( 'has an editor with a resizable box and iframe height that matches the content height', async ( {
+		admin,
+		editor,
+		page,
+	} ) => {
+		await admin.visitSiteEditor( {
+			postId: 'emptytheme//header',
+			postType: 'wp_template_part',
+		} );
+
+		// Ensure content has loaded before testing heights.
+		await editor.canvas.waitForLoadState( 'networkidle' );
+
+		const blockList = editor.canvas.locator(
+			'.edit-site-block-editor__block-list'
+		);
+		const iframe = await editor.canvas.frameElement();
+		const resizableBox = page.locator(
+			'.components-resizable-box__container'
+		);
+
+		const blockListRect = await blockList.boundingBox();
+		const iframeRect = await iframe.boundingBox();
+		const resizableBoxRect = await resizableBox.boundingBox();
+
+		expect( iframeRect.height ).toBe( blockListRect.height );
+		expect( resizableBoxRect.height ).toBe( blockListRect.height );
+	} );
 } );

--- a/test/e2e/specs/site-editor/template-part.spec.js
+++ b/test/e2e/specs/site-editor/template-part.spec.js
@@ -300,34 +300,4 @@ test.describe( 'Template Part', () => {
 
 		await expect( paragraph ).toBeVisible();
 	} );
-
-	// Check for regressions of https://github.com/WordPress/gutenberg/issues/42226.
-	test( 'has an editor with a resizable box and iframe height that matches the content height', async ( {
-		admin,
-		editor,
-		page,
-	} ) => {
-		await admin.visitSiteEditor( {
-			postId: 'emptytheme//header',
-			postType: 'wp_template_part',
-		} );
-
-		// Ensure content has loaded before testing heights.
-		await editor.canvas.waitForLoadState( 'networkidle' );
-
-		const blockList = editor.canvas.locator(
-			'.edit-site-block-editor__block-list'
-		);
-		const iframe = await editor.canvas.frameElement();
-		const resizableBox = page.locator(
-			'.components-resizable-box__container'
-		);
-
-		const blockListRect = await blockList.boundingBox();
-		const iframeRect = await iframe.boundingBox();
-		const resizableBoxRect = await resizableBox.boundingBox();
-
-		expect( iframeRect.height ).toBe( blockListRect.height );
-		expect( resizableBoxRect.height ).toBe( blockListRect.height );
-	} );
 } );


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Fixes #42226

It seems like #38855 switching the iframe to standards mode changed a few aspects of how the iframe behaves:
- The document isn't ready immediately, and I think this results in a strange issue where `requestAnimationFrame` doesn't work. I could see it would get triggered but the callback never called. Possibly it doesn't work until the document is ready. The code that sets the height was within a `requestAnimationFrame` for throttling, so that was the first issue. I've switched to `setTimeout`
- `iframe.contentDocument.documentElement.scrollHeight` always seems to be whatever the pixel value is for `100%` height in standards mode. I've switched to `iframe.contentDocument.body.scrollHeight`.
- The timeout needs to continue being deferred until the document is ready. Otherwise `iframe.contentDocument.body` isn't defined and an error is thrown.
- The iframe itself needs a height, otherwise it will have the wrong height when the resize handles are used.

## Testing Instructions
<strike>Adds an e2e test</strike> (I did write an e2e test for this, but it was too unstable, I couldn't find a way to wait for the focus mode to finish loading and resizing, it's now removed)

1. Open the site editor.
2. Select a template part and click the 'Edit' button on the toolbar

Expected: the editable area should be the height of the content
In trunk: the editable area is the height of the viewport

## Screenshots or screencast <!-- if applicable -->
### Before

https://user-images.githubusercontent.com/677833/185577675-fe8897b3-a55e-4d90-a633-b51dc87e9618.mp4

### After

https://user-images.githubusercontent.com/677833/185577437-838d83bd-ee26-4a7c-929c-18fb127b66ca.mp4


