### PR TITLE
Prefer _x() for i18n context in core patterns

### DIFF
--- a/lib/compat/wordpress-6.1/block-patterns/footer-with-background-color-and-three-columns.php
+++ b/lib/compat/wordpress-6.1/block-patterns/footer-with-background-color-and-three-columns.php
@@ -29,11 +29,11 @@ return array(
 					
 					<!-- wp:column -->
 					<div class="wp-block-column"><!-- wp:paragraph -->
-					<p><strong>' . __( 'Where We Are', 'gutenberg' ) . '</strong></p>
+					<p><strong>' . _x( 'Where We Are', 'sample content', 'gutenberg' ) . '</strong></p>
 					<!-- /wp:paragraph -->
 					
 					<!-- wp:paragraph -->
-					<p>' . __( '2020 Lomita Blvd, <br>Torrance, CA 90101<br>United States', 'gutenberg' ) . '</p>
+					<p>' . _x( '2020 Lomita Blvd, <br>Torrance, CA 90101<br>United States', 'sample content', 'gutenberg' ) . '</p>
 					<!-- /wp:paragraph --></div>
 					<!-- /wp:column --></div>
 					<!-- /wp:columns -->


### PR DESCRIPTION
Follows up on #43157

## What?

One of the block patterns introduced in #43157, `footer-with-background-color-and-three-columns.php`, includes sample content made localisable using the `__()` function. This PR replaces those calls with `_x(..., 'sample content', ...)` in order to provide that context to translators.