### PR TITLE
PHP: Use str_starts_with

### DIFF
--- a/lib/compat/wordpress-6.0/block-template-utils.php
+++ b/lib/compat/wordpress-6.0/block-template-utils.php
@@ -18,7 +18,7 @@
 function gutenberg_is_theme_directory_ignored( $path ) {
 	$ignore_list = array( '.DS_Store', '.svn', '.git', '.hg', '.bzr', 'node_modules', 'vendor' );
 	foreach ( $ignore_list as $ignored ) {
-		if ( strpos( $path, $ignored ) === 0 ) {
+		if ( str_starts_with( $path, $ignored ) ) {
 			return true;
 		}
 	}

--- a/lib/compat/wordpress-6.0/edit-form-blocks.php
+++ b/lib/compat/wordpress-6.0/edit-form-blocks.php
@@ -40,7 +40,7 @@ function gutenberg_optimize_preload_paths( $preload_paths ) {
 
 	// modify the preload of `/users/me` to match the real request.
 	foreach ( $preload_paths as $user_index => $user_path ) {
-		if ( is_string( $user_path ) && 0 === strpos( $user_path, '/wp/v2/users/me' ) ) {
+		if ( is_string( $user_path ) && str_starts_with( $user_path, '/wp/v2/users/me' ) ) {
 			$preload_paths[ $user_index ] = '/wp/v2/users/me';
 			break;
 		}

--- a/lib/compat/wordpress-6.1/blocks.php
+++ b/lib/compat/wordpress-6.1/blocks.php
@@ -67,7 +67,7 @@ function gutenberg_block_type_metadata_view_script( $settings, $metadata ) {
 		! isset( $metadata['viewScript'] ) ||
 		! empty( $settings['view_script'] ) ||
 		! isset( $metadata['file'] ) ||
-		strpos( $metadata['file'], gutenberg_dir_path() ) !== 0
+		! str_starts_with( $metadata['file'], gutenberg_dir_path() )
 	) {
 		return $settings;
 	}

--- a/lib/compat/wordpress-6.1/class-wp-theme-json-6-1.php
+++ b/lib/compat/wordpress-6.1/class-wp-theme-json-6-1.php
@@ -881,7 +881,7 @@ class WP_Theme_JSON_6_1 extends WP_Theme_JSON_6_0 {
 		foreach ( $properties as $css_property => $value_path ) {
 			$value = static::get_property_value( $styles, $value_path, $theme_json );
 
-			if ( strpos( $css_property, '--wp--style--root--' ) === 0 && ( static::ROOT_BLOCK_SELECTOR !== $selector || ! $use_root_padding ) ) {
+			if ( str_starts_with( $css_property, '--wp--style--root--' ) && ( static::ROOT_BLOCK_SELECTOR !== $selector || ! $use_root_padding ) ) {
 				continue;
 			}
 			// Root-level padding styles don't currently support strings with CSS shorthand values.
@@ -890,7 +890,7 @@ class WP_Theme_JSON_6_1 extends WP_Theme_JSON_6_0 {
 				continue;
 			}
 
-			if ( strpos( $css_property, '--wp--style--root--' ) === 0 && $use_root_padding ) {
+			if ( str_starts_with( $css_property, '--wp--style--root--' ) && $use_root_padding ) {
 				$root_variable_duplicates[] = substr( $css_property, strlen( '--wp--style--root--' ) );
 			}
 


### PR DESCRIPTION
See #43371

> The str_starts_with function is available is PHP 8+. A polyfill for the function exists in WP 5.9+, so we should use that function instead of previous implementations.