### PR TITLE
Lodash: Remove `_.omit()` from deprecated blocks

### DIFF
--- a/packages/block-library/src/button/deprecated.js
+++ b/packages/block-library/src/button/deprecated.js
@@ -1,7 +1,6 @@
 /**
  * External dependencies
  */
-import { omit } from 'lodash';
 import classnames from 'classnames';
 
 /**
@@ -70,33 +69,33 @@ const migrateCustomColorsAndGradients = ( attributes ) => {
 	if ( attributes.customGradient ) {
 		style.color.gradient = attributes.customGradient;
 	}
+
+	const {
+		customTextColor,
+		customBackgroundColor,
+		customGradient,
+		...restAttributes
+	} = attributes;
+
 	return {
-		...omit( attributes, [
-			'customTextColor',
-			'customBackgroundColor',
-			'customGradient',
-		] ),
+		...restAttributes,
 		style,
 	};
 };
 
 const oldColorsMigration = ( attributes ) => {
-	return migrateCustomColorsAndGradients(
-		omit(
-			{
-				...attributes,
-				customTextColor:
-					attributes.textColor && '#' === attributes.textColor[ 0 ]
-						? attributes.textColor
-						: undefined,
-				customBackgroundColor:
-					attributes.color && '#' === attributes.color[ 0 ]
-						? attributes.color
-						: undefined,
-			},
-			[ 'color', 'textColor' ]
-		)
-	);
+	const { color, textColor, ...restAttributes } = {
+		...attributes,
+		customTextColor:
+			attributes.textColor && '#' === attributes.textColor[ 0 ]
+				? attributes.textColor
+				: undefined,
+		customBackgroundColor:
+			attributes.color && '#' === attributes.color[ 0 ]
+				? attributes.color
+				: undefined,
+	};
+	return migrateCustomColorsAndGradients( restAttributes );
 };
 
 const blockAttributes = {

--- a/packages/block-library/src/columns/deprecated.js
+++ b/packages/block-library/src/columns/deprecated.js
@@ -1,7 +1,6 @@
 /**
  * External dependencies
  */
-import { omit } from 'lodash';
 import classnames from 'classnames';
 
 /**
@@ -49,8 +48,12 @@ const migrateCustomColors = ( attributes ) => {
 	if ( attributes.customBackgroundColor ) {
 		style.color.background = attributes.customBackgroundColor;
 	}
+
+	const { customTextColor, customBackgroundColor, ...restAttributes } =
+		attributes;
+
 	return {
-		...omit( attributes, [ 'customTextColor', 'customBackgroundColor' ] ),
+		...restAttributes,
 		style,
 		isStackedOnMobile: true,
 	};
@@ -168,9 +171,11 @@ export default [
 				createBlock( 'core/column', {}, columnBlocks )
 			);
 
+			const { columns: ignoredColumns, ...restAttributes } = attributes;
+
 			return [
 				{
-					...omit( attributes, [ 'columns' ] ),
+					...restAttributes,
 					isStackedOnMobile: true,
 				},
 				migratedInnerBlocks,
@@ -194,8 +199,9 @@ export default [
 			},
 		},
 		migrate( attributes, innerBlocks ) {
+			const { columns, ...restAttributes } = attributes;
 			attributes = {
-				...omit( attributes, [ 'columns' ] ),
+				...restAttributes,
 				isStackedOnMobile: true,
 			};
 

--- a/packages/block-library/src/cover/deprecated.js
+++ b/packages/block-library/src/cover/deprecated.js
@@ -1,7 +1,6 @@
 /**
  * External dependencies
  */
-import { omit } from 'lodash';
 import classnames from 'classnames';
 
 /**
@@ -1120,8 +1119,10 @@ const v3 = {
 			dimRatio: ! attributes.url ? 100 : attributes.dimRatio,
 		};
 
+		const { title, contentAlign, ...restAttributes } = newAttribs;
+
 		return [
-			omit( newAttribs, [ 'title', 'contentAlign' ] ),
+			restAttributes,
 			[
 				createBlock( 'core/paragraph', {
 					content: attributes.title,
@@ -1202,8 +1203,11 @@ const v2 = {
 			...attributes,
 			dimRatio: ! attributes.url ? 100 : attributes.dimRatio,
 		};
+
+		const { title, contentAlign, align, ...restAttributes } = newAttribs;
+
 		return [
-			omit( newAttribs, [ 'title', 'contentAlign', 'align' ] ),
+			restAttributes,
 			[
 				createBlock( 'core/paragraph', {
 					content: attributes.title,
@@ -1259,8 +1263,11 @@ const v1 = {
 			...attributes,
 			dimRatio: ! attributes.url ? 100 : attributes.dimRatio,
 		};
+
+		const { title, contentAlign, align, ...restAttributes } = newAttribs;
+
 		return [
-			omit( newAttribs, [ 'title', 'contentAlign', 'align' ] ),
+			restAttributes,
 			[
 				createBlock( 'core/paragraph', {
 					content: attributes.title,

--- a/packages/block-library/src/gallery/deprecated.js
+++ b/packages/block-library/src/gallery/deprecated.js
@@ -2,7 +2,7 @@
  * External dependencies
  */
 import classnames from 'classnames';
-import { map, some, omit } from 'lodash';
+import { map, some } from 'lodash';
 
 /**
  * WordPress dependencies
@@ -95,9 +95,11 @@ function runV2Migration( attributes ) {
 		return getImageBlock( image, attributes.sizeSlug, linkTo );
 	} );
 
+	const { images, ids, ...restAttributes } = attributes;
+
 	return [
 		{
-			...omit( attributes, [ 'images', 'ids' ] ),
+			...restAttributes,
 			linkTo,
 			allowResize: false,
 		},

--- a/packages/block-library/src/group/deprecated.js
+++ b/packages/block-library/src/group/deprecated.js
@@ -2,7 +2,6 @@
  * External dependencies
  */
 import classnames from 'classnames';
-import { omit } from 'lodash';
 
 /**
  * WordPress dependencies
@@ -31,8 +30,12 @@ const migrateAttributes = ( attributes ) => {
 	if ( attributes.customBackgroundColor ) {
 		style.color.background = attributes.customBackgroundColor;
 	}
+
+	const { customTextColor, customBackgroundColor, ...restAttributes } =
+		attributes;
+
 	return {
-		...omit( attributes, [ 'customTextColor', 'customBackgroundColor' ] ),
+		...restAttributes,
 		style,
 	};
 };

--- a/packages/block-library/src/heading/deprecated.js
+++ b/packages/block-library/src/heading/deprecated.js
@@ -2,7 +2,6 @@
  * External dependencies
  */
 import classnames from 'classnames';
-import { omit } from 'lodash';
 
 /**
  * WordPress dependencies
@@ -46,8 +45,11 @@ const migrateCustomColors = ( attributes ) => {
 			text: attributes.customTextColor,
 		},
 	};
+
+	const { customTextColor, ...restAttributes } = attributes;
+
 	return {
-		...omit( attributes, [ 'customTextColor' ] ),
+		...restAttributes,
 		style,
 	};
 };

--- a/packages/block-library/src/media-text/deprecated.js
+++ b/packages/block-library/src/media-text/deprecated.js
@@ -2,7 +2,7 @@
  * External dependencies
  */
 import classnames from 'classnames';
-import { isEmpty, omit } from 'lodash';
+import { isEmpty } from 'lodash';
 
 /**
  * WordPress dependencies
@@ -42,8 +42,9 @@ const migrateCustomColors = ( attributes ) => {
 			background: attributes.customBackgroundColor,
 		},
 	};
+	const { customBackgroundColor, ...restAttributes } = attributes;
 	return {
-		...omit( attributes, [ 'customBackgroundColor' ] ),
+		...restAttributes,
 		style,
 	};
 };

--- a/packages/block-library/src/navigation/deprecated.js
+++ b/packages/block-library/src/navigation/deprecated.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { mapValues, omit } from 'lodash';
+import { mapValues } from 'lodash';
 
 /**
  * WordPress dependencies
@@ -552,8 +552,10 @@ const deprecated = [
 			inserter: true,
 		},
 		migrate: compose( migrateIdToRef, ( attributes ) => {
+			const { rgbTextColor, rgbBackgroundColor, ...restAttributes } =
+				attributes;
 			return {
-				...omit( attributes, [ 'rgbTextColor', 'rgbBackgroundColor' ] ),
+				...restAttributes,
 				customTextColor: attributes.textColor
 					? undefined
 					: attributes.rgbTextColor,

--- a/packages/block-library/src/paragraph/deprecated.js
+++ b/packages/block-library/src/paragraph/deprecated.js
@@ -2,7 +2,6 @@
  * External dependencies
  */
 import classnames from 'classnames';
-import { omit } from 'lodash';
 
 /**
  * WordPress dependencies
@@ -74,21 +73,27 @@ const migrateCustomColorsAndFontSizes = ( attributes ) => {
 	if ( attributes.customFontSize ) {
 		style.typography = { fontSize: attributes.customFontSize };
 	}
+
+	const {
+		customTextColor,
+		customBackgroundColor,
+		customFontSize,
+		...restAttributes
+	} = attributes;
+
 	return {
-		...omit( attributes, [
-			'customTextColor',
-			'customBackgroundColor',
-			'customFontSize',
-		] ),
+		...restAttributes,
 		style,
 	};
 };
+
+const { style, ...restBlockAttributes } = blockAttributes;
 
 const deprecated = [
 	{
 		supports,
 		attributes: {
-			...omit( blockAttributes, [ 'style' ] ),
+			...restBlockAttributes,
 			customTextColor: {
 				type: 'string',
 			},
@@ -153,7 +158,7 @@ const deprecated = [
 	{
 		supports,
 		attributes: {
-			...omit( blockAttributes, [ 'style' ] ),
+			...restBlockAttributes,
 			customTextColor: {
 				type: 'string',
 			},
@@ -218,7 +223,7 @@ const deprecated = [
 	{
 		supports,
 		attributes: {
-			...omit( blockAttributes, [ 'style' ] ),
+			...restBlockAttributes,
 			customTextColor: {
 				type: 'string',
 			},
@@ -284,15 +289,12 @@ const deprecated = [
 	},
 	{
 		supports,
-		attributes: omit(
-			{
-				...blockAttributes,
-				fontSize: {
-					type: 'number',
-				},
+		attributes: {
+			...restBlockAttributes,
+			fontSize: {
+				type: 'number',
 			},
-			[ 'style' ]
-		),
+		},
 		save( { attributes } ) {
 			const {
 				width,
@@ -325,25 +327,21 @@ const deprecated = [
 			);
 		},
 		migrate( attributes ) {
-			return migrateCustomColorsAndFontSizes(
-				omit( {
-					...attributes,
-					customFontSize: Number.isFinite( attributes.fontSize )
-						? attributes.fontSize
+			return migrateCustomColorsAndFontSizes( {
+				...attributes,
+				customFontSize: Number.isFinite( attributes.fontSize )
+					? attributes.fontSize
+					: undefined,
+				customTextColor:
+					attributes.textColor && '#' === attributes.textColor[ 0 ]
+						? attributes.textColor
 						: undefined,
-					customTextColor:
-						attributes.textColor &&
-						'#' === attributes.textColor[ 0 ]
-							? attributes.textColor
-							: undefined,
-					customBackgroundColor:
-						attributes.backgroundColor &&
-						'#' === attributes.backgroundColor[ 0 ]
-							? attributes.backgroundColor
-							: undefined,
-				} ),
-				[ 'fontSize', 'textColor', 'backgroundColor', 'style' ]
-			);
+				customBackgroundColor:
+					attributes.backgroundColor &&
+					'#' === attributes.backgroundColor[ 0 ]
+						? attributes.backgroundColor
+						: undefined,
+			} );
 		},
 	},
 	{

--- a/packages/block-library/src/query/deprecated.js
+++ b/packages/block-library/src/query/deprecated.js
@@ -1,9 +1,4 @@
 /**
- * External dependencies
- */
-import { omit } from 'lodash';
-
-/**
  * WordPress dependencies
  */
 import {
@@ -14,9 +9,8 @@ import {
 
 const migrateToTaxQuery = ( attributes ) => {
 	const { query } = attributes;
-	const newQuery = {
-		...omit( query, [ 'categoryIds', 'tagIds' ] ),
-	};
+	const { categoryIds, tagIds, ...newQuery } = query;
+
 	if ( query.categoryIds?.length || query.tagIds?.length ) {
 		newQuery.taxQuery = {
 			category: !! query.categoryIds?.length
@@ -121,8 +115,9 @@ const deprecated = [
 		},
 		migrate( attributes ) {
 			const withTaxQuery = migrateToTaxQuery( attributes );
+			const { layout, ...restWithTaxQuery } = withTaxQuery;
 			return {
-				...omit( withTaxQuery, [ 'layout' ] ),
+				...restWithTaxQuery,
 				displayLayout: withTaxQuery.layout,
 			};
 		},

--- a/packages/block-library/src/quote/deprecated.js
+++ b/packages/block-library/src/quote/deprecated.js
@@ -2,7 +2,6 @@
  * External dependencies
  */
 import classnames from 'classnames';
-import { omit } from 'lodash';
 
 /**
  * WordPress dependencies
@@ -11,11 +10,11 @@ import { createBlock, parseWithAttributeSchema } from '@wordpress/blocks';
 import { RichText, useBlockProps } from '@wordpress/block-editor';
 
 export const migrateToQuoteV2 = ( attributes ) => {
-	const { value } = attributes;
+	const { value, ...restAttributes } = attributes;
 
 	return [
 		{
-			...omit( attributes, [ 'value' ] ),
+			...restAttributes,
 		},
 		value
 			? parseWithAttributeSchema( value, {
@@ -151,8 +150,9 @@ const v1 = {
 
 	migrate( attributes ) {
 		if ( attributes.style === 2 ) {
+			const { style, ...restAttributes } = attributes;
 			return migrateToQuoteV2( {
-				...omit( attributes, [ 'style' ] ),
+				...restAttributes,
 				className: attributes.className
 					? attributes.className + ' is-style-large'
 					: 'is-style-large',
@@ -205,8 +205,9 @@ const v0 = {
 
 	migrate( attributes ) {
 		if ( ! isNaN( parseInt( attributes.style ) ) ) {
+			const { style, ...restAttributes } = attributes;
 			return migrateToQuoteV2( {
-				...omit( attributes, [ 'style' ] ),
+				...restAttributes,
 			} );
 		}
 

--- a/packages/block-library/src/separator/deprecated.js
+++ b/packages/block-library/src/separator/deprecated.js
@@ -2,7 +2,6 @@
  * External dependencies
  */
 import classnames from 'classnames';
-import { omit } from 'lodash';
 
 /**
  * WordPress dependencies
@@ -42,9 +41,9 @@ const v1 = {
 		return <hr { ...useBlockProps.save( { className, style } ) } />;
 	},
 	migrate( attributes ) {
-		const { color, customColor } = attributes;
+		const { color, customColor, ...restAttributes } = attributes;
 		return {
-			...omit( attributes, [ 'color', 'customColor' ] ),
+			...restAttributes,
 			backgroundColor: color ? color : undefined,
 			opacity: 'css',
 			style: customColor


### PR DESCRIPTION
## What?
This PR removes the `_.omit()` usage from all deprecated blocks. 

## Why?

Lodash is known to unnecessarily inflate the bundle size of packages, and in most cases, it can be replaced with native language functionality. See these for more information and rationale:

* https://github.com/WordPress/gutenberg/issues/16938#issuecomment-602837246
* https://github.com/WordPress/gutenberg/issues/17025
* https://github.com/WordPress/gutenberg/issues/39495 

## How?

`_.omit()` is generally safe and easy to replace with object destructuring with spread and rest syntax. Changes are extremely straightforward and similar so I've decided to place them all in a single PR.

## Testing Instructions
Verify the older versions of these blocks still work well:
* Button
* Columns
* Cover
* Gallery
* Group
* Heading
* MediaText
* Navigation
* Paragraph
* Query
* Quote
* Separator