### PR TITLE
Try: Fix cover flex issue in the editor.

### DIFF
--- a/packages/block-library/src/cover/editor.scss
+++ b/packages/block-library/src/cover/editor.scss
@@ -47,10 +47,6 @@
 		margin: 0;
 	}
 
-	.block-editor-block-list__layout {
-		width: 100%;
-	}
-
 	// The .wp-block-cover class is used just to increase selector specificity.
 	.wp-block-cover__inner-container {
 		// Avoid text align inherit from cover image align.


### PR DESCRIPTION
## What?

Fixes #34909, props @alaczek for the code in https://github.com/WordPress/gutenberg/issues/34909#issuecomment-1218990288.

Flex containers inside a cover behaved strangely, only in the editor:

<img width="857" alt="before" src="https://user-images.githubusercontent.com/1204802/185593562-51ccc0b1-6253-4dfb-93ed-31f9d9d2169e.png">

This PR removes the problematic code, which was introduced in #13822, fixing it:

<img width="936" alt="after" src="https://user-images.githubusercontent.com/1204802/185593638-16934f37-044d-44f2-9779-f990e63ae1b0.png">

It is unclear what the purpose of the previous code was, but it would be good to test with a variety of cover-specific patterns and content inside, to verify that nothing breaks as a result of this removal.

## Testing Instructions

Sample code to test:

```
<!-- wp:cover {"customOverlayColor":"#7749f9","contentPosition":"center center","align":"wide","style":{"spacing":{"padding":{"top":"8vh","right":"5vh","bottom":"8vh","left":"5vh"}}}} -->
<div class="wp-block-cover alignwide" style="padding-top:8vh;padding-right:5vh;padding-bottom:8vh;padding-left:5vh"><span aria-hidden="true" class="wp-block-cover__background has-background-dim-100 has-background-dim" style="background-color:#7749f9"></span><div class="wp-block-cover__inner-container"><!-- wp:group {"style":{"spacing":{"blockGap":"64px"},"border":{"radius":"100px"}},"backgroundColor":"secondary","layout":{"inherit":true}} -->
<div class="wp-block-group has-secondary-background-color has-background" style="border-radius:100px"><!-- wp:group {"layout":{"type":"flex","flexWrap":"nowrap","justifyContent":"left"}} -->
<div class="wp-block-group"><!-- wp:social-links {"className":"is-style-default"} -->
<ul class="wp-block-social-links is-style-default"><!-- wp:social-link {"url":"#","service":"instagram"} /--></ul>
<!-- /wp:social-links -->

<!-- wp:paragraph -->
<p><a href="#">Instagram</a></p>
<!-- /wp:paragraph --></div>
<!-- /wp:group --></div>
<!-- /wp:group --></div></div>
<!-- /wp:cover -->
```

Instagram link should look good.