### PR TITLE
Lodash: Remove completely from `e2e-test-utils-playwright`  package

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16978,8 +16978,7 @@
 				"@wordpress/keycodes": "file:packages/keycodes",
 				"@wordpress/url": "file:packages/url",
 				"change-case": "^4.1.2",
-				"form-data": "^4.0.0",
-				"lodash": "^4.17.21"
+				"form-data": "^4.0.0"
 			}
 		},
 		"@wordpress/e2e-tests": {

--- a/packages/e2e-test-utils-playwright/package.json
+++ b/packages/e2e-test-utils-playwright/package.json
@@ -35,8 +35,7 @@
 		"@wordpress/keycodes": "file:../keycodes",
 		"@wordpress/url": "file:../url",
 		"change-case": "^4.1.2",
-		"form-data": "^4.0.0",
-		"lodash": "^4.17.21"
+		"form-data": "^4.0.0"
 	},
 	"peerDependencies": {
 		"@playwright/test": ">=1"

--- a/packages/e2e-test-utils-playwright/src/request-utils/plugins.ts
+++ b/packages/e2e-test-utils-playwright/src/request-utils/plugins.ts
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { kebabCase } from 'lodash';
+import { paramCase as kebabCase } from 'change-case';
 
 /**
  * Internal dependencies


### PR DESCRIPTION
## What?
This PR removes all of the Lodash from the `@wordpress/e2e-test-utils-playwright` package, including the `lodash` dependency altogether. There is just a single usage and conversion is pretty straightforward. 

## Why?

Lodash is known to unnecessarily inflate the bundle size of packages, and in most cases, it can be replaced with native language functionality. See these for more information and rationale:

* https://github.com/WordPress/gutenberg/issues/16938#issuecomment-602837246
* https://github.com/WordPress/gutenberg/issues/17025
* https://github.com/WordPress/gutenberg/issues/39495 

While this PR doesn't affect bundle size at all (because this package's code is not bundled), it still is a step forward in the direction of completely getting rid of Lodash in Gutenberg.

## How?
We're dealing with straightforwardly replacing only`kebabCase`, we've already been replacing with `change-case`'s  `paramCase`.

## Testing Instructions

* Verify all playwright e2e tests still pass: `npm run test:e2e:playwright`