### PR TITLE
Lodash: Remove completely from `eslint-plugin` package

### DIFF
--- a/packages/eslint-plugin/docs/rules/dependency-group.md
+++ b/packages/eslint-plugin/docs/rules/dependency-group.md
@@ -11,7 +11,7 @@ Specifically, this ensures that:
 Examples of **incorrect** code for this rule:
 
 ```js
-import { get } from 'lodash';
+import { camelCase } from 'change-case';
 import { Component } from '@wordpress/element';
 import edit from './edit';
 ```
@@ -22,7 +22,7 @@ Examples of **correct** code for this rule:
 /*
  * External dependencies
  */
-import { get } from 'lodash';
+import { camelCase } from 'change-case';
 
 /*
  * WordPress dependencies

--- a/packages/eslint-plugin/rules/__tests__/dependency-group.js
+++ b/packages/eslint-plugin/rules/__tests__/dependency-group.js
@@ -22,7 +22,7 @@ ruleTester.run( 'dependency-group', rule, {
 /**
  * External dependencies
  */
-import { get } from 'lodash';
+import { camelCase } from 'change-case';
 import classnames from 'classnames';
 
 /**
@@ -40,7 +40,7 @@ import edit from './edit';`,
 /**
  * External dependencies
  */
-const { get } = require( 'lodash' );
+const { camelCase } = require( 'change-case' );
 const classnames = require( 'classnames' );
 
 /**
@@ -57,7 +57,7 @@ const edit = require( './edit' );`,
 	invalid: [
 		{
 			code: `
-import { get } from 'lodash';
+import { camelCase } from 'change-case';
 import classnames from 'classnames';
 /*
  * wordpress dependencies.
@@ -82,7 +82,7 @@ import edit from './edit';`,
 /**
  * External dependencies
  */
-import { get } from 'lodash';
+import { camelCase } from 'change-case';
 import classnames from 'classnames';
 /**
  * WordPress dependencies
@@ -95,7 +95,7 @@ import edit from './edit';`,
 		},
 		{
 			code: `
-const { get } = require( 'lodash' );
+const { camelCase } = require( 'change-case' );
 const classnames = require( 'classnames' );
 /*
  * wordpress dependencies.
@@ -120,7 +120,7 @@ const edit = require( './edit' );`,
 /**
  * External dependencies
  */
-const { get } = require( 'lodash' );
+const { camelCase } = require( 'change-case' );
 const classnames = require( 'classnames' );
 /**
  * WordPress dependencies

--- a/packages/eslint-plugin/rules/__tests__/no-unsafe-wp-apis.js
+++ b/packages/eslint-plugin/rules/__tests__/no-unsafe-wp-apis.js
@@ -21,15 +21,15 @@ const options = [
 
 ruleTester.run( 'no-unsafe-wp-apis', rule, {
 	valid: [
-		{ code: "import _ from 'lodash';", options },
-		{ code: "import { map } from 'lodash';", options },
-		{ code: "import { __experimentalFoo } from 'lodash';", options },
-		{ code: "import { __unstableFoo } from 'lodash';", options },
-		{ code: "import _, { __unstableFoo } from 'lodash';", options },
-		{ code: "import * as _ from 'lodash';", options },
+		{ code: "import _ from 'change-case';", options },
+		{ code: "import { camelCase } from 'change-case';", options },
+		{ code: "import { __experimentalFoo } from 'change-case';", options },
+		{ code: "import { __unstableFoo } from 'change-case';", options },
+		{ code: "import _, { __unstableFoo } from 'change-case';", options },
+		{ code: "import * as _ from 'change-case';", options },
 
 		{ code: "import _ from './x';", options },
-		{ code: "import { map } from './x';", options },
+		{ code: "import { camelCase } from './x';", options },
 		{ code: "import { __experimentalFoo } from './x';", options },
 		{ code: "import { __unstableFoo } from './x';", options },
 		{ code: "import _, { __unstableFoo } from './x';", options },


### PR DESCRIPTION
## What?
This PR removes all of the Lodash occurrences from the `@wordpress/eslint-plugin` package. While Lodash is used for docs and testing there and not as a real dependency, our goal is to completely remove Lodash from the repo, so this includes documentation and tests as well. This package accounts for roughly 10% of the `_.get()` usages, so it's nice to see the number drop down a bit.

## Why?

Lodash is known to unnecessarily inflate the bundle size of packages, and in most cases, it can be replaced with native language functionality. See these for more information and rationale:

* https://github.com/WordPress/gutenberg/issues/16938#issuecomment-602837246
* https://github.com/WordPress/gutenberg/issues/17025
* https://github.com/WordPress/gutenberg/issues/39495

While this PR doesn't affect bundle size at all (because this package's code is not bundled), it still is a step forward in the direction of completely getting rid of Lodash in Gutenberg. 

## How?
We're replaced all Lodash usages with ones from `change-case`.

## Testing Instructions

* Verify all tests still pass: `npm run test:unit packages/eslint-plugin`