### PR TITLE
Try: Gap tweaks to navigation

### DIFF
--- a/packages/block-library/src/navigation/style.scss
+++ b/packages/block-library/src/navigation/style.scss
@@ -326,7 +326,6 @@ button.wp-block-navigation-item__content {
 .wp-block-navigation__responsive-container,
 .wp-block-navigation__responsive-close,
 .wp-block-navigation__responsive-dialog,
-.wp-block-navigation,
 .wp-block-navigation .wp-block-page-list,
 .wp-block-navigation__container,
 .wp-block-navigation__responsive-container-content {


### PR DESCRIPTION
## What?

Hopefully fixes #42955. 

A default gap is not provided for navigation in classic themes:

<img width="833" alt="Screenshot 2022-08-19 at 13 01 30" src="https://user-images.githubusercontent.com/1204802/185605203-41d56818-3bb8-4601-ab1e-e086bc0516af.png">

This PR fixes that by removing an inheritance rule that _appears_ to be unnecessary:

<img width="785" alt="Screenshot 2022-08-19 at 13 01 00" src="https://user-images.githubusercontent.com/1204802/185605312-803e4e6c-af41-4adf-807d-e5fb761765d3.png">

## Testing Instructions

Please test as many variations of navigation as you can!