### PR TITLE
Polish placeholder radius and enable duotone on image setup state

### DIFF
--- a/packages/block-library/src/image/block.json
+++ b/packages/block-library/src/image/block.json
@@ -85,7 +85,7 @@
 	"supports": {
 		"anchor": true,
 		"color": {
-			"__experimentalDuotone": "img",
+			"__experimentalDuotone": "img, .components-placeholder",
 			"text": false,
 			"background": false
 		},

--- a/packages/block-library/src/image/editor.scss
+++ b/packages/block-library/src/image/editor.scss
@@ -9,6 +9,9 @@
 		box-shadow: inset 0 0 0 $border-width $gray-900;
 		border: none;
 
+		// Disable any duotone filter applied in the selected state.
+		filter: none;
+
 		// @todo: this should eventually be overridden by a custom border-radius set in the inspector.
 		border-radius: $radius-block-ui;
 

--- a/packages/components/src/placeholder/style.scss
+++ b/packages/components/src/placeholder/style.scss
@@ -173,10 +173,12 @@
 // This is mainly an issue in terms of Site Logo which has a brief flash of the square placeholder.
 .components-placeholder.has-illustration {
 	color: inherit;
-	border-radius: inherit;
 	display: flex;
 	box-shadow: none;
 	min-width: 100px;
+
+	// Radius fallback value.
+	border-radius: $radius-block-ui;
 
 	// Blur the background so layered dashed placeholders are still visually separate.
 	// We also provide a semitransparent background so as to allow duotones to sheen through.


### PR DESCRIPTION
## What?

This PR does two things. First off, it provides a default border radius for the dashed-style placeholder that matches that of every other placeholder, 2px. But any custom radius/border set still shows:

<img width="659" alt="Screenshot 2022-08-19 at 13 33 53" src="https://user-images.githubusercontent.com/1204802/185610379-de91e777-bf41-46a4-bdde-27e06cb287c8.png">

Props to @aaronrobertshaw for foundational work!

It also enables Duotone to be visible in the setup state:

![duotone applied onselect](https://user-images.githubusercontent.com/1204802/185610482-e7ae17d2-e300-4f38-9d1d-5e57d8c08a32.gif)

The strength of this duotone filter showing in the dashed/blurred style is something we can tweak to get the balance just right. Take it for a spin and let me know your thoughts.

## Why?

It is useful for patterns to include blocks in their empty/setup states. In these placeholder states, the more of their surroundings these blocks can inherit, the better the preview of the end result.

## Testing Instructions

Please test inserting an empty image block, then applying a duotone filter. It should be visible in the unselected state only.