### PR TITLE
Fix Post Featured Image border attributes

### DIFF
--- a/packages/block-library/src/post-featured-image/index.php
+++ b/packages/block-library/src/post-featured-image/index.php
@@ -101,11 +101,15 @@ function get_block_core_post_featured_image_border_attributes( $attributes ) {
 		);
 	}
 
-	$border_attributes = gutenberg_style_engine_get_styles( array( 'border' => $border_styles ) );
-	return array(
-		'class' => array_key_exists( 'classnames', $border_attributes ) ? $border_attributes['classnames'] : '',
-		'style' => array_key_exists( 'css', $border_attributes ) ? $border_attributes['css'] : '',
-	);
+	$styles     = gutenberg_style_engine_get_styles( array( 'border' => $border_styles ) );
+	$attributes = array();
+	if ( ! empty( $styles['classnames'] ) ) {
+		$attributes['class'] = $styles['classnames'];
+	}
+	if ( ! empty( $styles['css'] ) ) {
+		$attributes['style'] = $styles['css'];
+	}
+	return $attributes;
 }
 
 /**

--- a/packages/block-library/src/post-featured-image/index.php
+++ b/packages/block-library/src/post-featured-image/index.php
@@ -103,8 +103,8 @@ function get_block_core_post_featured_image_border_attributes( $attributes ) {
 
 	$border_attributes = gutenberg_style_engine_get_styles( array( 'border' => $border_styles ) );
 	return array(
-		'class' => $border_attributes['classnames'],
-		'style' => $border_attributes['css'],
+		'class' => array_key_exists( 'classnames', $border_attributes ) ? $border_attributes['classnames'] : '',
+		'style' => array_key_exists( 'css', $border_attributes ) ? $border_attributes['css'] : '',
 	);
 }
 


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Adds checks for the border attributes in Post Featured Image if they exist. Introduced here: https://github.com/WordPress/gutenberg/pull/42847

Without the checks there are php notices when a Post Featured Image has no border attributes.

```


Notice: Undefined index: classnames in /var/www/html/wp-content/plugins/gutenberg/build/block-library/blocks/post-featured-image.php on line 106
--
Notice: Undefined index: css in /var/www/html/wp-content/plugins/gutenberg/build/block-library/blocks/post-featured-image.php on line 107

```