### PR TITLE
(Custom)GradientPicker: Remove and deprecate outer margins

### DIFF
--- a/packages/block-editor/src/components/colors-gradients/control.js
+++ b/packages/block-editor/src/components/colors-gradients/control.js
@@ -92,6 +92,7 @@ function ColorGradientControlInner( {
 		),
 		[ TAB_GRADIENT.value ]: (
 			<GradientPicker
+				__nextHasNoMargin
 				value={ gradientValue }
 				onChange={
 					canChooseAColor

--- a/packages/components/src/custom-gradient-picker/index.js
+++ b/packages/components/src/custom-gradient-picker/index.js
@@ -6,6 +6,7 @@ import classnames from 'classnames';
 /**
  * WordPress dependencies
  */
+import deprecated from '@wordpress/deprecated';
 import { __ } from '@wordpress/i18n';
 
 /**
@@ -124,6 +125,17 @@ export default function CustomGradientPicker( {
 		color: getStopCssColor( colorStop ),
 		position: parseInt( colorStop.length.value ),
 	} ) );
+
+	if ( ! __nextHasNoMargin ) {
+		deprecated(
+			'Outer margin styles for wp.components.CustomGradientPicker',
+			{
+				since: '6.1',
+				version: '6.4',
+				hint: 'Set the `__nextHasNoMargin` prop to true to start opting into the new styles, which will become the default in a future version',
+			}
+		);
+	}
 
 	return (
 		<VStack

--- a/packages/components/src/custom-gradient-picker/stories/index.js
+++ b/packages/components/src/custom-gradient-picker/stories/index.js
@@ -28,3 +28,6 @@ const CustomGradientPickerWithState = ( props ) => {
 };
 
 export const Default = CustomGradientPickerWithState.bind( {} );
+Default.args = {
+	__nextHasNoMargin: true,
+};

--- a/packages/components/src/gradient-picker/README.md
+++ b/packages/components/src/gradient-picker/README.md
@@ -17,6 +17,7 @@ const myGradientPicker = () => {
 
 	return (
 		<GradientPicker
+			__nextHasNoMargin
 			value={ gradient }
 			onChange={ ( currentGradient ) => setGradient( currentGradient ) }
 			gradients={ [
@@ -92,3 +93,11 @@ If true, the gradient picker will not be displayed and only defined gradients fr
 -   Type: `Boolean`
 -   Required: No
 -   Default: false
+
+### __nextHasNoMargin
+
+Start opting into the new margin-free styles that will become the default in a future version, currently scheduled to be WordPress 6.4. (The prop can be safely removed once this happens.)
+
+-   Type: `Boolean`
+-   Required: No
+-   Default: `false`

--- a/packages/components/src/gradient-picker/index.js
+++ b/packages/components/src/gradient-picker/index.js
@@ -8,6 +8,7 @@ import { map } from 'lodash';
  */
 import { __, sprintf } from '@wordpress/i18n';
 import { useCallback, useMemo } from '@wordpress/element';
+import deprecated from '@wordpress/deprecated';
 
 /**
  * Internal dependencies
@@ -119,6 +120,14 @@ export default function GradientPicker( {
 		__experimentalHasMultipleOrigins && gradients?.length
 			? MultipleOrigin
 			: SingleOrigin;
+
+	if ( ! __nextHasNoMargin ) {
+		deprecated( 'Outer margin styles for wp.components.GradientPicker', {
+			since: '6.1',
+			version: '6.4',
+			hint: 'Set the `__nextHasNoMargin` prop to true to start opting into the new styles, which will become the default in a future version',
+		} );
+	}
 
 	// Can be removed when deprecation period is over
 	const deprecatedMarginSpacerProps = ! __nextHasNoMargin

--- a/packages/components/src/gradient-picker/stories/index.js
+++ b/packages/components/src/gradient-picker/stories/index.js
@@ -74,6 +74,7 @@ const Template = ( { onChange, ...props } ) => {
 
 export const Default = Template.bind( {} );
 Default.args = {
+	__nextHasNoMargin: true,
 	gradients: GRADIENTS,
 };
 

--- a/packages/components/src/palette-edit/index.js
+++ b/packages/components/src/palette-edit/index.js
@@ -173,16 +173,19 @@ function Option( {
 						/>
 					) }
 					{ isGradient && (
-						<CustomGradientPicker
-							__experimentalIsRenderedInSidebar
-							value={ value }
-							onChange={ ( newGradient ) =>
-								onChange( {
-									...element,
-									gradient: newGradient,
-								} )
-							}
-						/>
+						<div className="components-palette-edit__popover-gradient-picker">
+							<CustomGradientPicker
+								__nextHasNoMargin
+								__experimentalIsRenderedInSidebar
+								value={ value }
+								onChange={ ( newGradient ) =>
+									onChange( {
+										...element,
+										gradient: newGradient,
+									} )
+								}
+							/>
+						</div>
 					) }
 				</Popover>
 			) }
@@ -451,6 +454,7 @@ export default function PaletteEdit( {
 					{ ! isEditing &&
 						( isGradient ? (
 							<GradientPicker
+								__nextHasNoMargin
 								gradients={ gradients }
 								onChange={ () => {} }
 								clearable={ false }

--- a/packages/components/src/palette-edit/style.scss
+++ b/packages/components/src/palette-edit/style.scss
@@ -1,14 +1,6 @@
-.components-palette-edit__popover {
-	.components-custom-gradient-picker__gradient-bar {
-		margin-top: 0;
-	}
-	.components-custom-gradient-picker__ui-line {
-		margin-bottom: 0;
-	}
-	.components-custom-gradient-picker {
-		width: 280px;
-		padding: 8px;
-	}
+.components-palette-edit__popover-gradient-picker {
+	width: 280px;
+	padding: 8px;
 }
 .components-dropdown-menu__menu {
 	.components-palette-edit__menu-button {


### PR DESCRIPTION
Part of #43014 #39358

## What?

- Remove the unwanted margins in ColorGradientControl and PaletteEdit, which were coming from GradientPicker.
- Add deprecation notices for the margins in CustomGradientPicker/GradientPicker.

## Why?

Better reusability.

## How?

Follows the [style deprecation procedure](https://github.com/WordPress/gutenberg/blob/trunk/packages/components/CONTRIBUTING.md#deprecating-styles).

## Testing Instructions

1. `npm run dev`
2. ColorGradientControl (Editor ▸ Code block ▸ Color ▸ Background ▸ Gradient) should have its extra bottom margin removed.
3. PaletteEdit (Global Styles ▸ Colors ▸ Palette ▸ Gradient ▸ Custom, and hit the `+` button to show the affected popover) should have its extra bottom margin removed.

## Screenshots or screencast <!-- if applicable -->

| Before | After |
|--------|-------|
|<img width="291" alt="ColorGradientControl with extra margin" src="https://user-images.githubusercontent.com/555336/185649311-edf5c7ec-cf73-43a8-a5b7-895a509af10a.png">|<img width="297" alt="ColorGradientControl" src="https://user-images.githubusercontent.com/555336/185649291-d8e8e369-65b4-403a-8dac-cfb2b4c0bd35.png">|
|<img width="317" alt="PaletteEdit with extra margin" src="https://user-images.githubusercontent.com/555336/185649676-b64556b5-6ac7-4972-a97b-75b670df668a.png">|<img width="316" alt="PaletteEdit" src="https://user-images.githubusercontent.com/555336/185649665-5930d429-908c-4efd-88e8-b9529f1d6b2b.png">|

## ✍️ Dev Note

Consolidated with Dev Note on #43867.