### PR TITLE
FocalPointPicker: use KeyboardEvent.code, partially refactor tests to modern RTL and user-event

### DIFF
--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -38,6 +38,7 @@
 -   `ColorPalette`: Refactor away from `_.uniq()` ([#43330](https://github.com/WordPress/gutenberg/pull/43330/)).
 -   `Guide`: Refactor away from `_.times()` ([#43374](https://github.com/WordPress/gutenberg/pull/43374/)).
 -   `Modal`: use `KeyboardEvent.code` instead of deprecated `KeyboardEvent.keyCode`. improve unit tests ([#43429](https://github.com/WordPress/gutenberg/pull/43429/)).
+-   `FocalPointPicker`: use `KeyboardEvent.code`, partially refactor tests to modern RTL and `user-event` ([#43441](https://github.com/WordPress/gutenberg/pull/43441/)).
 
 ### Experimental
 -   `FormTokenField`: add `__experimentalAutoSelectFirstMatch` prop to auto select the first matching suggestion on typing ([#42527](https://github.com/WordPress/gutenberg/pull/42527/)).

--- a/packages/components/src/focal-point-picker/index.js
+++ b/packages/components/src/focal-point-picker/index.js
@@ -9,7 +9,6 @@ import classnames from 'classnames';
 import { __ } from '@wordpress/i18n';
 import { Component, createRef } from '@wordpress/element';
 import { withInstanceId } from '@wordpress/compose';
-import { UP, DOWN, LEFT, RIGHT } from '@wordpress/keycodes';
 
 /**
  * Internal dependencies
@@ -171,15 +170,21 @@ export class FocalPointPicker extends Component {
 		this.props.onDragEnd?.( event );
 	}
 	onKeyDown( event ) {
-		const { keyCode, shiftKey } = event;
-		if ( ! [ UP, DOWN, LEFT, RIGHT ].includes( keyCode ) ) return;
+		const { code, shiftKey } = event;
+		if (
+			! [ 'ArrowUp', 'ArrowDown', 'ArrowLeft', 'ArrowRight' ].includes(
+				code
+			)
+		)
+			return;
 
 		event.preventDefault();
 
 		const next = { ...this.state.percentages };
 		const step = shiftKey ? 0.1 : 0.01;
-		const delta = keyCode === UP || keyCode === LEFT ? -1 * step : step;
-		const axis = keyCode === UP || keyCode === DOWN ? 'y' : 'x';
+		const delta =
+			code === 'ArrowUp' || code === 'ArrowLeft' ? -1 * step : step;
+		const axis = code === 'ArrowUp' || code === 'ArrowDown' ? 'y' : 'x';
 		const value = parseFloat( next[ axis ] ) + delta;
 
 		next[ axis ] = roundClamp( value, 0, 1, step );

--- a/packages/components/src/focal-point-picker/test/index.js
+++ b/packages/components/src/focal-point-picker/test/index.js
@@ -42,6 +42,8 @@ describe( 'FocalPointPicker', () => {
 
 			const draggableArea = screen.getByRole( 'button' );
 
+			// `user-event` is not capable of testing drag interactions properly.
+			// we could consider using playwright instead.
 			fireEvent.mouseDown( draggableArea );
 
 			expect( mockOnDrag ).not.toHaveBeenCalled();
@@ -69,6 +71,8 @@ describe( 'FocalPointPicker', () => {
 
 			const dragArea = screen.getByRole( 'button' );
 
+			// `user-event` is not capable of testing drag interactions properly.
+			// we could consider using playwright instead.
 			fireEvent.mouseDown( dragArea );
 			fireEvent.mouseMove( dragArea );
 			fireEvent.mouseUp( dragArea );


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Refactor the `FocalPointPicker` component to rely on `code` instead of `keyCode` for keyboard events

Since some tests were failing because they were relying on `fireEvent`, I went ahead and refactored them to using `userEvent` (where possible) and with "modern" RTL style (i.e. avoiding implementation details).

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

[`keyCode`](https://developer.mozilla.org/en-US/docs/Web/API/KeyboardEvent/keyCode) is deprecated, and replaced by [`code`](https://developer.mozilla.org/en-US/docs/Web/API/KeyboardEvent/code)

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

Easy swap of values

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->

On Storybook, play around with the component and use the arrow keys while focusing the interactive part to move the focal point selection