### PR TITLE
Tag Cloud: Add typography supports (except font size)

### DIFF
--- a/docs/reference-guides/core-blocks.md
+++ b/docs/reference-guides/core-blocks.md
@@ -797,7 +797,7 @@ A cloud of your most used tags. ([Source](https://github.com/WordPress/gutenberg
 
 -	**Name:** core/tag-cloud
 -	**Category:** widgets
--	**Supports:** align, spacing (margin, padding), ~~html~~
+-	**Supports:** align, spacing (margin, padding), typography (lineHeight), ~~html~~
 -	**Attributes:** largestFontSize, numberOfTags, showTagCounts, smallestFontSize, taxonomy
 
 ## Template Part

--- a/packages/block-library/src/tag-cloud/block.json
+++ b/packages/block-library/src/tag-cloud/block.json
@@ -48,10 +48,7 @@
 			"__experimentalFontStyle": true,
 			"__experimentalTextTransform": true,
 			"__experimentalTextDecoration": true,
-			"__experimentalLetterSpacing": true,
-			"__experimentalDefaultControls": {
-				"fontFamily": true
-			}
+			"__experimentalLetterSpacing": true
 		}
 	},
 	"editorStyle": "wp-block-tag-cloud-editor"

--- a/packages/block-library/src/tag-cloud/block.json
+++ b/packages/block-library/src/tag-cloud/block.json
@@ -47,7 +47,6 @@
 			"__experimentalFontWeight": true,
 			"__experimentalFontStyle": true,
 			"__experimentalTextTransform": true,
-			"__experimentalTextDecoration": true,
 			"__experimentalLetterSpacing": true
 		}
 	},

--- a/packages/block-library/src/tag-cloud/block.json
+++ b/packages/block-library/src/tag-cloud/block.json
@@ -40,6 +40,18 @@
 		"spacing": {
 			"margin": true,
 			"padding": true
+		},
+		"typography": {
+			"lineHeight": true,
+			"__experimentalFontFamily": true,
+			"__experimentalFontWeight": true,
+			"__experimentalFontStyle": true,
+			"__experimentalTextTransform": true,
+			"__experimentalTextDecoration": true,
+			"__experimentalLetterSpacing": true,
+			"__experimentalDefaultControls": {
+				"fontFamily": true
+			}
 		}
 	},
 	"editorStyle": "wp-block-tag-cloud-editor"


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->
Related:

- https://github.com/WordPress/gutenberg/issues/43241
- https://github.com/WordPress/gutenberg/issues/43242

## What?
<!-- In a few words, what is the PR actually doing? -->
- Add typography support to Tag-cloud block (except font size)

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
- Allows typographic styling of Tag Cloud links

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
- Opts into typography support expect font size.

## Testing Instructions
<!-- Please include step-by-step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->

1. Load the editor, add a tag-cloud block and select it.
2. Test various typography settings ensuring styles are applied in the editor.
3. Save and confirm the application on the front end.
4. Test theme.json styling of the block.

Example theme.json snippet

```json
                        "core/tag-cloud": {
				"typography": {
					"letterSpacing": "5px",
					"fontStyle": "italic",
					"fontWeight": 300
				}
			},
```

NOTE: Font size is already present and was merged as a part of https://github.com/WordPress/gutenberg/pull/37311


## Screenshots or screencast <!-- if applicable -->
<img width="973" alt="image" src="https://user-images.githubusercontent.com/21127788/185801244-c27da68e-6bef-4b7a-a975-ac26469949ba.png">
