### PR TITLE
Social Links: Enable alpha on color pickers

### DIFF
--- a/packages/block-library/src/social-links/edit.js
+++ b/packages/block-library/src/social-links/edit.js
@@ -216,6 +216,7 @@ export function SocialLinksEdit( props ) {
 					__experimentalIsRenderedInSidebar
 					title={ __( 'Color' ) }
 					colorSettings={ colorSettings }
+					enableAlpha
 				>
 					{ ! logosOnly && (
 						<ContrastChecker


### PR DESCRIPTION
Related:

- https://github.com/WordPress/gutenberg/issues/43245

## What?
Enable alpha in the color pickers used in the Social Links (Icons) block.

## Why?
To create consistency in the color pickers across blocks.

## How?
Add `enableAlpha` to the `PanelColorSettings` used in the block.

## Testing Instructions
1. Add a Social Icons block to a new page. 
2. Add a few icons.
3. Change the color of the icon and/or background.
4. See that you can now change the transparency (alpha channel) on the colors. 

## Screenshots or screencast
Before:
![image](https://user-images.githubusercontent.com/4832319/185802953-2ab88e54-807f-46d7-a627-ef200ad3dc66.png)

After:
![image](https://user-images.githubusercontent.com/4832319/185802877-a896ca10-491e-4645-a2b1-d55468896c6f.png)
