### PR TITLE
Heading: Add padding support

### DIFF
--- a/docs/reference-guides/core-blocks.md
+++ b/docs/reference-guides/core-blocks.md
@@ -284,7 +284,7 @@ Introduce new sections and organize content to help visitors (and search engines
 
 -	**Name:** core/heading
 -	**Category:** text
--	**Supports:** __unstablePasteTextInline, align (full, wide), anchor, color (background, gradients, link, text), spacing (margin), typography (fontSize, lineHeight), ~~className~~
+-	**Supports:** __unstablePasteTextInline, align (full, wide), anchor, color (background, gradients, link, text), spacing (margin, padding), typography (fontSize, lineHeight), ~~className~~
 -	**Attributes:** content, level, placeholder, textAlign
 
 ## Home Link

--- a/packages/block-library/src/heading/block.json
+++ b/packages/block-library/src/heading/block.json
@@ -39,7 +39,8 @@
 			}
 		},
 		"spacing": {
-			"margin": true
+			"margin": true,
+			"padding": true
 		},
 		"typography": {
 			"fontSize": true,


### PR DESCRIPTION
Related:

- https://github.com/WordPress/gutenberg/issues/43241
- https://github.com/WordPress/gutenberg/issues/43243

## What?
Add padding support to the Heading block. 

## Why?
To create consistency across blocks. But this also potentially fixes https://github.com/WordPress/gutenberg/issues/40144 since now users can override padding applied to Heading blocks when there is a background color.

## How?
Added the relevant block support in block.json

## Testing Instructions
1. Insert a new heading. 
2. Adding Padding and configure. 

## Screenshots or screencast 
![heading-padding](https://user-images.githubusercontent.com/4832319/185804112-d29d1b14-826f-4bc5-aac8-4a96520d4056.gif)

