### PR TITLE
Paragraph: Add spacing block supports

### DIFF
--- a/docs/reference-guides/core-blocks.md
+++ b/docs/reference-guides/core-blocks.md
@@ -437,7 +437,7 @@ Start with the basic building block of all narrative. ([Source](https://github.c
 
 -	**Name:** core/paragraph
 -	**Category:** text
--	**Supports:** __unstablePasteTextInline, anchor, color (background, gradients, link, text), typography (fontSize, lineHeight), ~~className~~
+-	**Supports:** __unstablePasteTextInline, anchor, color (background, gradients, link, text), spacing (margin, padding), typography (fontSize, lineHeight), ~~className~~
 -	**Attributes:** align, content, direction, dropCap, placeholder
 
 ## Pattern

--- a/packages/block-library/src/paragraph/block.json
+++ b/packages/block-library/src/paragraph/block.json
@@ -41,6 +41,10 @@
 				"text": true
 			}
 		},
+		"spacing": {
+			"margin": true,
+			"padding": true
+		},
 		"typography": {
 			"fontSize": true,
 			"lineHeight": true,


### PR DESCRIPTION
Related:

- https://github.com/WordPress/gutenberg/issues/43241
- https://github.com/WordPress/gutenberg/issues/43243
- https://github.com/WordPress/gutenberg/pull/37300
- Fixes #37299

## What?
Add padding and margin support to the Paragraph block. 

## Why?
Back in 2021, I proposed adding margin support to paragraph blocks. See the discussion in #37300. Well, we have come a long way since then, and given the broader effort to standardize spacing support across blocks, now is the time to add this to paragraphs as well. Also, block theme designers around the world will rejoice 😂

I have closed #37300 in favor of this PR so we can address padding as well. 

## How?
Added the relevant block supports in block.json

## Testing Instructions
1. Insert a Paragraph block. 
2. Confirm that the dimensions control panel is there and there are no defaults.
3. Add padding and margin.

## Screenshots or screencast 
![paragraph-spacing](https://user-images.githubusercontent.com/4832319/185804815-e6c391d3-af61-4aea-bcf0-f09115a7dc95.gif)

