### PR TITLE
Post Title: Add padding support

### DIFF
--- a/docs/reference-guides/core-blocks.md
+++ b/docs/reference-guides/core-blocks.md
@@ -581,7 +581,7 @@ Displays the title of a post, page, or any other content-type. ([Source](https:/
 
 -	**Name:** core/post-title
 -	**Category:** theme
--	**Supports:** align (full, wide), color (background, gradients, link, text), spacing (margin), typography (fontSize, lineHeight), ~~html~~
+-	**Supports:** align (full, wide), color (background, gradients, link, text), spacing (margin, padding), typography (fontSize, lineHeight), ~~html~~
 -	**Attributes:** isLink, level, linkTarget, rel, textAlign
 
 ## Preformatted

--- a/packages/block-library/src/post-title/block.json
+++ b/packages/block-library/src/post-title/block.json
@@ -42,7 +42,8 @@
 			}
 		},
 		"spacing": {
-			"margin": true
+			"margin": true,
+			"padding": true
 		},
 		"typography": {
 			"fontSize": true,

--- a/packages/block-library/src/post-title/style.scss
+++ b/packages/block-library/src/post-title/style.scss
@@ -1,5 +1,7 @@
 .wp-block-post-title {
 	word-break: break-word;
+	// This block has customizable padding, border-box makes that more predictable.
+	box-sizing: border-box;
 
 	a {
 		display: inline-block;


### PR DESCRIPTION
Related:

- https://github.com/WordPress/gutenberg/issues/43241
- https://github.com/WordPress/gutenberg/issues/43243

## What?
Add padding support to the Post Title block. 

## Why?
To create consistency across blocks. This also allows users to override padding applied to Post Title blocks when there is a background color.

## How?
Added the relevant block support in block.json

## Testing Instructions
1. Insert a new Post Title block. 
2. Confirm the Dimension control panel allows you to add padding.
3. Adding padding and configure. 

## Screenshots or screencast 
![post-title-padding](https://user-images.githubusercontent.com/4832319/185806014-d70d6441-812e-4ce4-b4a9-fbcce35e809a.gif)

