### PR TITLE
Query Title: Add padding support

### DIFF
--- a/docs/reference-guides/core-blocks.md
+++ b/docs/reference-guides/core-blocks.md
@@ -662,7 +662,7 @@ Display the query title. ([Source](https://github.com/WordPress/gutenberg/tree/t
 
 -	**Name:** core/query-title
 -	**Category:** theme
--	**Supports:** align (full, wide), color (background, gradients, text), spacing (margin), typography (fontSize, lineHeight), ~~html~~
+-	**Supports:** align (full, wide), color (background, gradients, text), spacing (margin, padding), typography (fontSize, lineHeight), ~~html~~
 -	**Attributes:** level, showPrefix, showSearchTerm, textAlign, type
 
 ## Quote

--- a/packages/block-library/src/query-title/block.json
+++ b/packages/block-library/src/query-title/block.json
@@ -37,7 +37,8 @@
 			}
 		},
 		"spacing": {
-			"margin": true
+			"margin": true,
+			"padding": true
 		},
 		"typography": {
 			"fontSize": true,

--- a/packages/block-library/src/query-title/block.json
+++ b/packages/block-library/src/query-title/block.json
@@ -55,5 +55,5 @@
 			}
 		}
 	},
-	"editorStyle": "wp-block-query-title-editor"
+	"style": "wp-block-query-title"
 }

--- a/packages/block-library/src/query-title/style.scss
+++ b/packages/block-library/src/query-title/style.scss
@@ -1,0 +1,4 @@
+.wp-block-query-title {
+	// This block has customizable padding, border-box makes that more predictable.
+	box-sizing: border-box;
+}

--- a/packages/block-library/src/style.scss
+++ b/packages/block-library/src/style.scss
@@ -35,6 +35,7 @@
 @import "./pullquote/style.scss";
 @import "./post-template/style.scss";
 @import "./query-pagination/style.scss";
+@import "./query-title/style.scss";
 @import "./quote/style.scss";
 @import "./read-more/style.scss";
 @import "./rss/style.scss";


### PR DESCRIPTION
Related:

- https://github.com/WordPress/gutenberg/issues/43241
- https://github.com/WordPress/gutenberg/issues/43243

## What?
Add padding support to the Query Title block. 

## Why?
To create consistency across blocks. This also allows users to override padding applied to Query Title blocks when there is a background color.

## How?
Added the relevant block support in block.json

## Testing Instructions
1. Insert a new Query Title block. 
2. Confirm the Dimension control panel allows you to add padding.
3. Adding padding and configure. 

## Screenshots or screencast 
![query-title-padding](https://user-images.githubusercontent.com/4832319/185806317-8efc0a1c-2f4b-4130-bafd-7fc8b74df167.gif)

(Note the padding visualizers are a bit wonky still in the Site Editor, but I don't think that should hold up this PR)

