### PR TITLE
Verse: Add margin support

### DIFF
--- a/docs/reference-guides/core-blocks.md
+++ b/docs/reference-guides/core-blocks.md
@@ -833,7 +833,7 @@ Insert poetry. Use special spacing formats. Or quote song lyrics. ([Source](http
 
 -	**Name:** core/verse
 -	**Category:** text
--	**Supports:** anchor, color (background, gradients, link, text), spacing (padding), typography (fontSize, lineHeight)
+-	**Supports:** anchor, color (background, gradients, link, text), spacing (margin, padding), typography (fontSize, lineHeight)
 -	**Attributes:** content, textAlign
 
 ## Video

--- a/packages/block-library/src/verse/block.json
+++ b/packages/block-library/src/verse/block.json
@@ -44,6 +44,7 @@
 			}
 		},
 		"spacing": {
+			"margin": true,
 			"padding": true
 		}
 	},


### PR DESCRIPTION
Related:

- https://github.com/WordPress/gutenberg/issues/43241
- https://github.com/WordPress/gutenberg/issues/43243

## What?
Add margin support to the Verse block. 

## Why?
To create consistency across blocks.

## How?
Added the relevant block support in block.json

## Testing Instructions
1. Insert a new Verse block. 
2. Confirm the Dimension control panel allows you to add margin.
3. Adding margin and configure. 

## Screenshots or screencast 

![verse-margin](https://user-images.githubusercontent.com/4832319/185806766-01ceb650-743d-4030-881d-33777900e853.gif)


