### PR TITLE
Add docs for useRootPaddingAwareAlignments in theme.json

### DIFF
--- a/docs/reference-guides/theme-json-reference/theme-json-living.md
+++ b/docs/reference-guides/theme-json-reference/theme-json-living.md
@@ -28,6 +28,15 @@ Setting that enables the following UI tools:
 
 ---
 
+### useRootPaddingAwareAlignments
+
+Enables root padding (the values from `styles.spacing.padding`) to be applied to the contents of full-width blocks instead of the root block.
+
+Please note that when using this setting, `styles.spacing.padding` should always be set as an object with `top`, `right`, `bottom`, `left` values declared separately.
+
+
+---
+
 ### border
 
 Settings related to borders.

--- a/docs/reference-guides/theme-json-reference/theme-json-living.md
+++ b/docs/reference-guides/theme-json-reference/theme-json-living.md
@@ -30,6 +30,8 @@ Setting that enables the following UI tools:
 
 ### useRootPaddingAwareAlignments
 
+_**Note:** Since WordPress 6.1._
+
 Enables root padding (the values from `styles.spacing.padding`) to be applied to the contents of full-width blocks instead of the root block.
 
 Please note that when using this setting, `styles.spacing.padding` should always be set as an object with `top`, `right`, `bottom`, `left` values declared separately.

--- a/schemas/json/theme.json
+++ b/schemas/json/theme.json
@@ -16,6 +16,15 @@
 				}
 			}
 		},
+		"settingsPropertiesUseRootPaddingAwareAlignments": {
+			"properties": {
+				"useRootPaddingAwareAlignments": {
+					"description": "Enables root padding (the values from `styles.spacing.padding`) to be applied to the contents of full-width blocks instead of the root block.\n\nPlease note that when using this setting, `styles.spacing.padding` should always be set as an object with `top`, `right`, `bottom`, `left` values declared separately.",
+					"type": "boolean",
+					"default": false
+				}
+			}
+		},
 		"settingsPropertiesBorder": {
 			"properties": {
 				"border": {

--- a/schemas/json/theme.json
+++ b/schemas/json/theme.json
@@ -19,7 +19,7 @@
 		"settingsPropertiesUseRootPaddingAwareAlignments": {
 			"properties": {
 				"useRootPaddingAwareAlignments": {
-					"description": "Enables root padding (the values from `styles.spacing.padding`) to be applied to the contents of full-width blocks instead of the root block.\n\nPlease note that when using this setting, `styles.spacing.padding` should always be set as an object with `top`, `right`, `bottom`, `left` values declared separately.",
+					"description": "_**Note:** Since WordPress 6.1._\n\nEnables root padding (the values from `styles.spacing.padding`) to be applied to the contents of full-width blocks instead of the root block.\n\nPlease note that when using this setting, `styles.spacing.padding` should always be set as an object with `top`, `right`, `bottom`, `left` values declared separately.",
 					"type": "boolean",
 					"default": false
 				}


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Partially addresses #42978. 

Adds documentation for the `useRootPaddingAwareAlignments` feature in theme.json.


## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->

## Screenshots or screencast <!-- if applicable -->
