### PR TITLE
Block Spacing: using spacing controls for block gap values to support presets in the UI

### DIFF
--- a/packages/block-editor/src/components/spacing-sizes-control/spacing-input-control.js
+++ b/packages/block-editor/src/components/spacing-sizes-control/spacing-input-control.js
@@ -216,6 +216,7 @@ export default function SpacingInputControl( {
 						label={ ariaLabel }
 						hideLabelFromVision={ true }
 						className="components-spacing-sizes-control__custom-value-input"
+						style={ { gridColumn: '1' } }
 					/>
 
 					<RangeControl

--- a/packages/block-editor/src/components/spacing-sizes-control/spacing-input-control.js
+++ b/packages/block-editor/src/components/spacing-sizes-control/spacing-input-control.js
@@ -30,6 +30,7 @@ import {
 	LABELS,
 	getSliderValueFromPreset,
 	getCustomValueFromPreset,
+	getPresetValueFromCustomValue,
 	isValueSpacingPreset,
 } from './utils';
 
@@ -42,6 +43,9 @@ export default function SpacingInputControl( {
 	type,
 	minimumCustomValue,
 } ) {
+	// Treat value as a preset value if the passed in value matches the value of one of the spacingSizes.
+	value = getPresetValueFromCustomValue( value, spacingSizes );
+
 	let selectListSizes = spacingSizes;
 	const showRangeControl = spacingSizes.length <= 8;
 

--- a/packages/block-editor/src/components/spacing-sizes-control/test/utils.js
+++ b/packages/block-editor/src/components/spacing-sizes-control/test/utils.js
@@ -167,6 +167,9 @@ describe( 'isValuesDefined', () => {
 	it( 'should return false if values are not defined', () => {
 		expect( isValuesDefined( undefinedValues ) ).toBe( false );
 	} );
+	it( 'should return false if values is passed in as null', () => {
+		expect( isValuesDefined( null ) ).toBe( false );
+	} );
 	const definedValues = {
 		top: 'var:preset|spacing|30',
 		bottom: 'var:preset|spacing|20',

--- a/packages/block-editor/src/components/spacing-sizes-control/test/utils.js
+++ b/packages/block-editor/src/components/spacing-sizes-control/test/utils.js
@@ -4,6 +4,7 @@
 import {
 	isValueSpacingPreset,
 	getCustomValueFromPreset,
+	getPresetValueFromCustomValue,
 	getSpacingPresetCssVar,
 	getSpacingPresetSlug,
 	getSliderValueFromPreset,
@@ -37,6 +38,28 @@ describe( 'getCustomValueFromPreset', () => {
 		expect(
 			getCustomValueFromPreset( 'var:preset|spacing|30', spacingSizes )
 		).toBe( undefined );
+	} );
+} );
+
+describe( 'getPresetValueFromCustomValue', () => {
+	const spacingSizes = [ { name: 'Small', slug: 20, size: '8px' } ];
+	it( 'should return original value if a string in spacing presets var format', () => {
+		expect(
+			getPresetValueFromCustomValue(
+				'var:preset|spacing|80',
+				spacingSizes
+			)
+		).toBe( 'var:preset|spacing|80' );
+	} );
+	it( 'should return value constructed from matching spacingSizes array entry if value matches sizes', () => {
+		expect( getPresetValueFromCustomValue( '8px', spacingSizes ) ).toBe(
+			'var:preset|spacing|20'
+		);
+	} );
+	it( 'should return values as-is if no matching preset in spacingSizes array', () => {
+		expect(
+			getPresetValueFromCustomValue( '1.125rem', spacingSizes )
+		).toBe( '1.125rem' );
 	} );
 } );
 

--- a/packages/block-editor/src/components/spacing-sizes-control/utils.js
+++ b/packages/block-editor/src/components/spacing-sizes-control/utils.js
@@ -44,6 +44,33 @@ export function getCustomValueFromPreset( value, spacingSizes ) {
 }
 
 /**
+ * Converts a custom value to preset value if one can be found.
+ *
+ * Returns value as-is if no match is found.
+ *
+ * @param {string} value        Value to convert
+ * @param {Array}  spacingSizes Array of the current spacing preset objects
+ *
+ * @return {string} The preset value if it can be found.
+ */
+export function getPresetValueFromCustomValue( value, spacingSizes ) {
+	// Return value as-is if it is already a preset;
+	if ( isValueSpacingPreset( value ) ) {
+		return value;
+	}
+
+	const spacingMatch = spacingSizes.find(
+		( size ) => String( size.size ) === String( value )
+	);
+
+	if ( spacingMatch?.slug ) {
+		return `var:preset|spacing|${ spacingMatch.slug }`;
+	}
+
+	return value;
+}
+
+/**
  * Converts a spacing preset into a custom value.
  *
  * @param {string} value Value to convert.

--- a/packages/block-editor/src/components/spacing-sizes-control/utils.js
+++ b/packages/block-editor/src/components/spacing-sizes-control/utils.js
@@ -208,15 +208,15 @@ export function isValuesMixed( values = {}, sides = ALL_SIDES ) {
  * @return {boolean} Whether values are defined.
  */
 export function isValuesDefined( values ) {
-	return (
-		values !== undefined &&
-		! isEmpty(
-			Object.values( values ).filter(
-				// Switching units when input is empty causes values only
-				// containing units. This gives false positive on mixed values
-				// unless filtered.
-				( value ) => !! value && /\d/.test( value )
-			)
+	if ( values === undefined || values === null ) {
+		return false;
+	}
+	return ! isEmpty(
+		Object.values( values ).filter(
+			// Switching units when input is empty causes values only
+			// containing units. This gives false positive on mixed values
+			// unless filtered.
+			( value ) => !! value && /\d/.test( value )
 		)
 	);
 }

--- a/packages/block-editor/src/hooks/dimensions.js
+++ b/packages/block-editor/src/hooks/dimensions.js
@@ -79,15 +79,16 @@ export function DimensionsPanel( props ) {
 		},
 	} );
 
+	const spacingClassnames = classnames( {
+		'tools-panel-item-spacing': spacingSizes && spacingSizes.length > 0,
+	} );
+
 	return (
 		<>
 			<InspectorControls __experimentalGroup="dimensions">
 				{ ! isPaddingDisabled && (
 					<ToolsPanelItem
-						className={ classnames( {
-							'tools-panel-item-spacing':
-								spacingSizes && spacingSizes.length > 0,
-						} ) }
+						className={ spacingClassnames }
 						hasValue={ () => hasPaddingValue( props ) }
 						label={ __( 'Padding' ) }
 						onDeselect={ () => resetPadding( props ) }
@@ -100,10 +101,7 @@ export function DimensionsPanel( props ) {
 				) }
 				{ ! isMarginDisabled && (
 					<ToolsPanelItem
-						className={ classnames( {
-							'tools-panel-item-spacing':
-								spacingSizes && spacingSizes.length > 0,
-						} ) }
+						className={ spacingClassnames }
 						hasValue={ () => hasMarginValue( props ) }
 						label={ __( 'Margin' ) }
 						onDeselect={ () => resetMargin( props ) }
@@ -116,6 +114,7 @@ export function DimensionsPanel( props ) {
 				) }
 				{ ! isGapDisabled && (
 					<ToolsPanelItem
+						className={ spacingClassnames }
 						hasValue={ () => hasGapValue( props ) }
 						label={ __( 'Block spacing' ) }
 						onDeselect={ () => resetGap( props ) }

--- a/packages/block-editor/src/hooks/gap.js
+++ b/packages/block-editor/src/hooks/gap.js
@@ -158,8 +158,8 @@ export function GapEdit( props ) {
 		// If splitOnAxis activated we need to return a BoxControl object to the BoxControl component.
 		if ( !! next && splitOnAxis ) {
 			blockGap = { ...getGapBoxControlValueFromStyle( next ) };
-		} else if ( !! next && next.hasOwnProperty( 'all' ) ) {
-			blockGap = next.all;
+		} else if ( !! next && next.hasOwnProperty( 'top' ) ) {
+			blockGap = next.top;
 		}
 
 		const newStyle = {
@@ -198,7 +198,9 @@ export function GapEdit( props ) {
 				right: gapValue?.left,
 				bottom: gapValue?.top,
 		  }
-		: gapValue?.top;
+		: {
+				top: gapValue?.top,
+		  };
 
 	return Platform.select( {
 		web: (
@@ -231,7 +233,7 @@ export function GapEdit( props ) {
 						values={ boxControlGapValue }
 						onChange={ onChange }
 						label={ __( 'Block spacing' ) }
-						sides={ splitOnAxis ? sides : [ 'all' ] }
+						sides={ splitOnAxis ? sides : [ 'top' ] }
 						units={ units }
 						allowReset={ false }
 						splitOnAxis={ splitOnAxis }

--- a/packages/block-editor/src/hooks/gap.js
+++ b/packages/block-editor/src/hooks/gap.js
@@ -158,7 +158,8 @@ export function GapEdit( props ) {
 		// If splitOnAxis activated we need to return a BoxControl object to the BoxControl component.
 		if ( !! next && splitOnAxis ) {
 			blockGap = { ...getGapBoxControlValueFromStyle( next ) };
-		} else if ( !! next && next.hasOwnProperty( 'top' ) ) {
+		} else if ( next?.hasOwnProperty( 'top' ) ) {
+			// If splitOnAxis is not enabled, treat the 'top' value as the shorthand gap value.
 			blockGap = next.top;
 		}
 
@@ -233,7 +234,7 @@ export function GapEdit( props ) {
 						values={ boxControlGapValue }
 						onChange={ onChange }
 						label={ __( 'Block spacing' ) }
-						sides={ splitOnAxis ? sides : [ 'top' ] }
+						sides={ splitOnAxis ? sides : [ 'top' ] } // Use 'top' as the shorthand property in non-axial configurations.
 						units={ units }
 						allowReset={ false }
 						splitOnAxis={ splitOnAxis }

--- a/packages/block-editor/src/hooks/test/gap.js
+++ b/packages/block-editor/src/hooks/test/gap.js
@@ -27,28 +27,6 @@ describe( 'gap', () => {
 				...blockGapValue,
 			} );
 		} );
-		it( 'should unwrap var: values from a string into a CSS var() function', () => {
-			const expectedValue = {
-				top: 'var(--wp--preset--spacing--60)',
-				left: 'var(--wp--preset--spacing--60)',
-			};
-			expect(
-				getGapBoxControlValueFromStyle( 'var:preset|spacing|60' )
-			).toEqual( expectedValue );
-		} );
-		it( 'should unwrap var: values from an object into a CSS var() function', () => {
-			const expectedValue = {
-				top: 'var(--wp--preset--spacing--20)',
-				left: 'var(--wp--preset--spacing--60)',
-			};
-			const blockGapValue = {
-				top: 'var:preset|spacing|20',
-				left: 'var:preset|spacing|60',
-			};
-			expect( getGapBoxControlValueFromStyle( blockGapValue ) ).toEqual(
-				expectedValue
-			);
-		} );
 	} );
 	describe( 'getGapCSSValue()', () => {
 		it( 'should return `null` if argument is falsey', () => {
@@ -86,16 +64,17 @@ describe( 'gap', () => {
 		} );
 
 		it( 'should unwrap var: values from a string into a CSS var() function', () => {
-			expect(
-				getGapBoxControlValueFromStyle( 'var:preset|spacing|60' )
-			).toEqual( 'var(--wp--preset--spacing--60)' );
+			expect( getGapCSSValue( 'var:preset|spacing|60' ) ).toEqual(
+				'var(--wp--preset--spacing--60)'
+			);
 		} );
+
 		it( 'should unwrap var: values from an object into a CSS var() function and return shorthand values', () => {
 			const blockGapValue = {
 				top: 'var:preset|spacing|20',
 				left: 'var:preset|spacing|60',
 			};
-			expect( getGapBoxControlValueFromStyle( blockGapValue ) ).toEqual(
+			expect( getGapCSSValue( blockGapValue ) ).toEqual(
 				'var(--wp--preset--spacing--20) var(--wp--preset--spacing--60)'
 			);
 		} );

--- a/packages/block-editor/src/hooks/test/gap.js
+++ b/packages/block-editor/src/hooks/test/gap.js
@@ -84,5 +84,20 @@ describe( 'gap', () => {
 				'88px 1px'
 			);
 		} );
+
+		it( 'should unwrap var: values from a string into a CSS var() function', () => {
+			expect(
+				getGapBoxControlValueFromStyle( 'var:preset|spacing|60' )
+			).toEqual( 'var(--wp--preset--spacing--60)' );
+		} );
+		it( 'should unwrap var: values from an object into a CSS var() function and return shorthand values', () => {
+			const blockGapValue = {
+				top: 'var:preset|spacing|20',
+				left: 'var:preset|spacing|60',
+			};
+			expect( getGapBoxControlValueFromStyle( blockGapValue ) ).toEqual(
+				'var(--wp--preset--spacing--20) var(--wp--preset--spacing--60)'
+			);
+		} );
 	} );
 } );

--- a/packages/block-editor/src/layouts/constrained.js
+++ b/packages/block-editor/src/layouts/constrained.js
@@ -120,11 +120,18 @@ export default {
 		const blockGapStyleValue = getGapCSSValue( style?.spacing?.blockGap );
 		// If a block's block.json skips serialization for spacing or
 		// spacing.blockGap, don't apply the user-defined value to the styles.
-		const blockGapValue =
-			blockGapStyleValue?.top &&
-			! shouldSkipSerialization( blockName, 'spacing', 'blockGap' )
-				? blockGapStyleValue?.top
-				: '';
+		// const blockGapValue =
+		// 	blockGapStyleValue?.top &&
+		// 	! shouldSkipSerialization( blockName, 'spacing', 'blockGap' )
+		// 		? blockGapStyleValue?.top
+		// 		: '';
+
+		// This isn't _quite_ the right fix. We need to account for split values, and reference `top` if it's provided directly.
+		const blockGapValue = blockGapStyleValue;
+		console.log(
+			'blockGapStyleValue in constrained layout',
+			blockGapStyleValue
+		);
 
 		let output =
 			!! contentSize || !! wideSize

--- a/packages/block-editor/src/layouts/constrained.js
+++ b/packages/block-editor/src/layouts/constrained.js
@@ -118,20 +118,18 @@ export default {
 	} ) {
 		const { contentSize, wideSize } = layout;
 		const blockGapStyleValue = getGapCSSValue( style?.spacing?.blockGap );
+
 		// If a block's block.json skips serialization for spacing or
 		// spacing.blockGap, don't apply the user-defined value to the styles.
-		// const blockGapValue =
-		// 	blockGapStyleValue?.top &&
-		// 	! shouldSkipSerialization( blockName, 'spacing', 'blockGap' )
-		// 		? blockGapStyleValue?.top
-		// 		: '';
-
-		// This isn't _quite_ the right fix. We need to account for split values, and reference `top` if it's provided directly.
-		const blockGapValue = blockGapStyleValue;
-		console.log(
-			'blockGapStyleValue in constrained layout',
-			blockGapStyleValue
-		);
+		let blockGapValue = '';
+		if ( ! shouldSkipSerialization( blockName, 'spacing', 'blockGap' ) ) {
+			// If an object is provided only use the 'top' value for this kind of gap.
+			if ( blockGapStyleValue?.top ) {
+				blockGapValue = getGapCSSValue( blockGapStyleValue?.top );
+			} else if ( typeof blockGapStyleValue === 'string' ) {
+				blockGapValue = getGapCSSValue( blockGapStyleValue );
+			}
+		}
 
 		let output =
 			!! contentSize || !! wideSize

--- a/packages/block-editor/src/layouts/constrained.js
+++ b/packages/block-editor/src/layouts/constrained.js
@@ -15,7 +15,7 @@ import { getCSSRules } from '@wordpress/style-engine';
  */
 import useSetting from '../components/use-setting';
 import { appendSelectors, getBlockGapCSS, getAlignmentsInfo } from './utils';
-import { getGapBoxControlValueFromStyle } from '../hooks/gap';
+import { getGapCSSValue } from '../hooks/gap';
 import { shouldSkipSerialization } from '../hooks/utils';
 
 export default {
@@ -117,9 +117,7 @@ export default {
 		layoutDefinitions,
 	} ) {
 		const { contentSize, wideSize } = layout;
-		const blockGapStyleValue = getGapBoxControlValueFromStyle(
-			style?.spacing?.blockGap
-		);
+		const blockGapStyleValue = getGapCSSValue( style?.spacing?.blockGap );
 		// If a block's block.json skips serialization for spacing or
 		// spacing.blockGap, don't apply the user-defined value to the styles.
 		const blockGapValue =

--- a/packages/block-editor/src/layouts/flow.js
+++ b/packages/block-editor/src/layouts/flow.js
@@ -30,15 +30,15 @@ export default {
 
 		// If a block's block.json skips serialization for spacing or
 		// spacing.blockGap, don't apply the user-defined value to the styles.
-		// const blockGapValue =
-		// 	blockGapStyleValue?.top &&
-		// 	! shouldSkipSerialization( blockName, 'spacing', 'blockGap' )
-		// 		? blockGapStyleValue?.top
-		// 		: '';
-
-		// This isn't _quite_ the right fix. We need to account for split values, and reference `top` if it's provided directly.
-		const blockGapValue = blockGapStyleValue;
-		console.log( 'blockGapStyleValue in flow layout', blockGapStyleValue );
+		let blockGapValue = '';
+		if ( ! shouldSkipSerialization( blockName, 'spacing', 'blockGap' ) ) {
+			// If an object is provided only use the 'top' value for this kind of gap.
+			if ( blockGapStyleValue?.top ) {
+				blockGapValue = getGapCSSValue( blockGapStyleValue?.top );
+			} else if ( typeof blockGapStyleValue === 'string' ) {
+				blockGapValue = getGapCSSValue( blockGapStyleValue );
+			}
+		}
 
 		let output = '';
 

--- a/packages/block-editor/src/layouts/flow.js
+++ b/packages/block-editor/src/layouts/flow.js
@@ -6,9 +6,8 @@ import { __ } from '@wordpress/i18n';
 /**
  * Internal dependencies
  */
-
 import { getBlockGapCSS, getAlignmentsInfo } from './utils';
-import { getGapBoxControlValueFromStyle } from '../hooks/gap';
+import { getGapCSSValue } from '../hooks/gap';
 import { shouldSkipSerialization } from '../hooks/utils';
 
 export default {
@@ -27,9 +26,8 @@ export default {
 		hasBlockGapSupport,
 		layoutDefinitions,
 	} ) {
-		const blockGapStyleValue = getGapBoxControlValueFromStyle(
-			style?.spacing?.blockGap
-		);
+		const blockGapStyleValue = getGapCSSValue( style?.spacing?.blockGap );
+
 		// If a block's block.json skips serialization for spacing or
 		// spacing.blockGap, don't apply the user-defined value to the styles.
 		const blockGapValue =

--- a/packages/block-editor/src/layouts/flow.js
+++ b/packages/block-editor/src/layouts/flow.js
@@ -30,11 +30,15 @@ export default {
 
 		// If a block's block.json skips serialization for spacing or
 		// spacing.blockGap, don't apply the user-defined value to the styles.
-		const blockGapValue =
-			blockGapStyleValue?.top &&
-			! shouldSkipSerialization( blockName, 'spacing', 'blockGap' )
-				? blockGapStyleValue?.top
-				: '';
+		// const blockGapValue =
+		// 	blockGapStyleValue?.top &&
+		// 	! shouldSkipSerialization( blockName, 'spacing', 'blockGap' )
+		// 		? blockGapStyleValue?.top
+		// 		: '';
+
+		// This isn't _quite_ the right fix. We need to account for split values, and reference `top` if it's provided directly.
+		const blockGapValue = blockGapStyleValue;
+		console.log( 'blockGapStyleValue in flow layout', blockGapStyleValue );
 
 		let output = '';
 

--- a/packages/block-library/src/gallery/gap-styles.js
+++ b/packages/block-library/src/gallery/gap-styles.js
@@ -1,7 +1,10 @@
 /**
  * WordPress dependencies
  */
-import { BlockList } from '@wordpress/block-editor';
+import {
+	BlockList,
+	__experimentalGetGapCSSValue as getGapCSSValue,
+} from '@wordpress/block-editor';
 import { useContext, createPortal } from '@wordpress/element';
 
 export default function GapStyles( { blockGap, clientId } ) {
@@ -17,17 +20,18 @@ export default function GapStyles( { blockGap, clientId } ) {
 	if ( !! blockGap ) {
 		row =
 			typeof blockGap === 'string'
-				? blockGap
-				: blockGap?.top || fallbackValue;
+				? getGapCSSValue( blockGap )
+				: getGapCSSValue( blockGap?.top ) || fallbackValue;
 		column =
 			typeof blockGap === 'string'
-				? blockGap
-				: blockGap?.left || fallbackValue;
+				? getGapCSSValue( blockGap )
+				: getGapCSSValue( blockGap?.left ) || fallbackValue;
 		gapValue = row === column ? row : `${ row } ${ column }`;
 	}
 
+	// The unstable gallery gap calculation requires a real value (such as `0px`) and not `0`.
 	const gap = `#block-${ clientId } {
-		--wp--style--unstable-gallery-gap: ${ column };
+		--wp--style--unstable-gallery-gap: ${ column === '0' ? '0px' : column };
 		gap: ${ gapValue }
 	}`;
 

--- a/packages/block-library/src/gallery/index.php
+++ b/packages/block-library/src/gallery/index.php
@@ -51,8 +51,8 @@ function block_core_gallery_render( $attributes, $content ) {
 	if ( is_array( $gap ) ) {
 		foreach ( $gap as $key => $value ) {
 			// Make sure $value is a string to avoid PHP 8.1 deprecation error in preg_match() when the value is null.
-			$value       = is_string( $value ) ? $value : '';
-			$value       = $value && preg_match( '%[\\\(&=}]|/\*%', $value ) ? null : $value;
+			$value = is_string( $value ) ? $value : '';
+			$value = $value && preg_match( '%[\\\(&=}]|/\*%', $value ) ? null : $value;
 
 			// Get spacing CSS variable from preset value if provided.
 			if ( is_string( $value ) && str_contains( $value, 'var:preset|spacing|' ) ) {

--- a/packages/block-library/src/gallery/index.php
+++ b/packages/block-library/src/gallery/index.php
@@ -52,12 +52,28 @@ function block_core_gallery_render( $attributes, $content ) {
 		foreach ( $gap as $key => $value ) {
 			// Make sure $value is a string to avoid PHP 8.1 deprecation error in preg_match() when the value is null.
 			$value       = is_string( $value ) ? $value : '';
-			$gap[ $key ] = $value && preg_match( '%[\\\(&=}]|/\*%', $value ) ? null : $value;
+			$value       = $value && preg_match( '%[\\\(&=}]|/\*%', $value ) ? null : $value;
+
+			// Get spacing CSS variable from preset value if provided.
+			if ( is_string( $value ) && str_contains( $value, 'var:preset|spacing|' ) ) {
+				$index_to_splice = strrpos( $value, '|' ) + 1;
+				$slug            = _wp_to_kebab_case( substr( $value, $index_to_splice ) );
+				$value           = "var(--wp--preset--spacing--$slug)";
+			}
+
+			$gap[ $key ] = $value;
 		}
 	} else {
 		// Make sure $gap is a string to avoid PHP 8.1 deprecation error in preg_match() when the value is null.
 		$gap = is_string( $gap ) ? $gap : '';
 		$gap = $gap && preg_match( '%[\\\(&=}]|/\*%', $gap ) ? null : $gap;
+
+		// Get spacing CSS variable from preset value if provided.
+		if ( is_string( $gap ) && str_contains( $gap, 'var:preset|spacing|' ) ) {
+			$index_to_splice = strrpos( $gap, '|' ) + 1;
+			$slug            = _wp_to_kebab_case( substr( $gap, $index_to_splice ) );
+			$gap             = "var(--wp--preset--spacing--$slug)";
+		}
 	}
 
 	$class   = wp_unique_id( 'wp-block-gallery-' );
@@ -78,6 +94,11 @@ function block_core_gallery_render( $attributes, $content ) {
 		$gap_row    = isset( $gap_value['top'] ) ? $gap_value['top'] : $fallback_gap;
 		$gap_column = isset( $gap_value['left'] ) ? $gap_value['left'] : $fallback_gap;
 		$gap_value  = $gap_row === $gap_column ? $gap_row : $gap_row . ' ' . $gap_column;
+	}
+
+	// The unstable gallery gap calculation requires a real value (such as `0px`) and not `0`.
+	if ( '0' === $gap_column ) {
+		$gap_column = '0px';
 	}
 
 	// Set the CSS variable to the column value, and the `gap` property to the combined gap value.

--- a/packages/edit-site/src/components/global-styles/utils.js
+++ b/packages/edit-site/src/components/global-styles/utils.js
@@ -79,7 +79,7 @@ export const PRESET_METADATA = [
 	},
 	{
 		path: [ 'spacing', 'spacingSizes' ],
-		valueKey: 'spacingSizes',
+		valueKey: 'size',
 		cssVarInfix: 'spacing',
 		valueFunc: ( { size } ) => size,
 		classes: [],


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Update the block spacing (`blockGap`) controls to use the new spacing controls UI — this enables setting block spacing via spacing presets in addition to custom values. See previous related work in margin (https://github.com/WordPress/gutenberg/pull/43246) and padding (https://github.com/WordPress/gutenberg/pull/42173).

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

To ensure consistency with across spacing UI elements and allow themes to have control over spacing presets, and have that control be reflected in the UI controls for block spacing.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

* Update the block-level blockGap controls to use the `SpacingSizesControl` when spacing sizes are available
* Tweak where the JS parsing of preset values occurs so that it's moved up a level to `getGapCSSValue` from `getGapBoxControlValueFromStyle` (the latter should be raw values, where the former is better suited for outputting the final parsed value — this ensures that the non-parsed value is stored in block comment markup)
* Update the Flow and Constrained layouts to get the correct parsed value for rendering
* Update the ad-hoc gap implementation for the Gallery block (both JS & PHP) to support spacing presets in the gap calculation and style output
* Update Global Styles to use the `SpacingSizesControl` component
* Update the `SpacingSizesControl` to match a passed in value to an existing preset if one exists (the `useStyle` hook in global styles always returns the _value_ for the preset instead of the `var:` form of the preset name)

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->

I ran into a fair few edge cases while implementing this and made some tweaks as I went, so hopefully the below testing instructions should provided a thorough overview of the different conditions under which the block spacing controls are available.

* Test with a Group block in the post editor, adjusting spacing of child blocks (flow/constrained layout)
* Test with a Column block in the post editor, adjusting spacing between columns (flex layout with a single non-axial value)
* Test with a Social Icons block in the post editor, adjusting spacing between icons, including split row / column values (flex layout with axial sides)
* Test with a Gallery block in the post editor, adjusting spacing between images, including split row / column values (flex layout with axial sides and an ad hoc implementation) — double-check that the output looks correct on the site front end
* Ensure that the `0` position values are output correctly in the editor and on the site front end
* Ensure that custom values (e.g. `9px` rather than a preset) work correctly in the editor and on the site front end
* Test root block spacing in global styles
* Check block-level spacing controls in global styles (note that the Gallery block is not supported in global styles, so its control does not appear)

***Work through the above testing conditions with the following settings in theme.json***

1. With `settings.spacing.spacingScale.steps` set to the default (7) so that the range control is used to slide between preset values
2. With `settings.spacing.spacingScale.steps` set to `10` so that it uses the select list of options
3. With `settings.spacing.spacingScale.steps` set to `0` so that it uses the BoxControl for axial sides (e.g. Social Icons and Gallery) and UnitControl for non-axial (Columns, Group, root block spacing in global styles)
4. Check that everything still works if you set `settings.spacing.customSpacingSize` to `false` so that custom options aren't available (you'll need to have `steps` set to at least 1 in order for this setting to work)

<!--
* Ensure the issue of blockGap not working correctly as flagged in https://github.com/WordPress/twentytwentythree/pull/55#discussion_r951428835 is resolved
-->

## Screenshots or screencast <!-- if applicable -->

This also includes a fix for when the custom view only displays a single side, so there is no Unlink button (we need to pass a `gridColumn: 1` rule to the `UnitControl` wrapper:

| Before | After |
| --- | --- |
| <img width="277" alt="image" src="https://user-images.githubusercontent.com/14988353/186070826-828c9b45-d189-43bc-b587-eea145d79bf0.png"> | <img width="276" alt="image" src="https://user-images.githubusercontent.com/14988353/186111203-6686a45e-abec-4326-b0d3-c20cf529030b.png"> |

Block Spacing controls:

https://user-images.githubusercontent.com/14988353/186602927-e66f488d-ab7f-400a-ad7b-18dfdf90dda9.mp4


