### PR TITLE
Block Editor: Fix spinner position in URLInput component

### DIFF
--- a/packages/block-editor/src/components/url-input/style.scss
+++ b/packages/block-editor/src/components/url-input/style.scss
@@ -45,9 +45,9 @@ $input-size: 300px;
 
 	.components-spinner {
 		position: absolute;
-		right: $input-padding;
-		bottom: $input-padding + $grid-unit-10 + 1;
 		margin: 0;
+		top: calc(50% - #{$spinner-size} / 2);
+		right: $grid-unit;
 	}
 }
 

--- a/packages/block-editor/src/components/url-popover/style.scss
+++ b/packages/block-editor/src/components/url-popover/style.scss
@@ -72,9 +72,6 @@
 	.block-editor-url-input .components-base-control__field {
 		margin-bottom: 0;
 	}
-	.block-editor-url-input .components-spinner {
-		bottom: $input-padding + 1;
-	}
 }
 
 .block-editor-url-popover__link-viewer-url {


### PR DESCRIPTION
## What?
Fixes #37070.

PR fixes the spinner position inside the `URLInput` component and removes broken/unused styles.

## Testing Instructions
1. Open a Post or Page.
2. Insert an Image block and select the image.
3. Trottle network to 3G.
4. Open the "Insert link" popup for the image.
5. Search for a post title to display the spinner

## Screenshots or screencast <!-- if applicable -->
**Before**
![CleanShot 2022-08-22 at 14 09 37](https://user-images.githubusercontent.com/240569/185897570-8140a8bd-29ef-4c4a-bf61-00192a1d12ee.png)
**After**
![CleanShot 2022-08-22 at 14 08 14](https://user-images.githubusercontent.com/240569/185897581-2aaad2e1-0042-4bda-9633-91bf35fb9713.png)

