### PR TITLE
Handbook: Fix format api example link

### DIFF
--- a/docs/how-to-guides/format-api.md
+++ b/docs/how-to-guides/format-api.md
@@ -18,7 +18,7 @@ You will need:
 -   A minimal plugin activated and setup ready to edit
 -   JavaScript setup for building and enqueuing
 
-The [complete format-api example](https://github.com/WordPress/gutenberg-examples/tree/trunk/format-api) is available that you can use as a reference for your setup.
+The [complete format-api example](https://github.com/WordPress/gutenberg-examples/tree/trunk/non-block-examples/format-api) is available that you can use as a reference for your setup.
 
 ## Step-by-step guide
 


### PR DESCRIPTION
### This PR fixes issue: [43476](https://github.com/WordPress/gutenberg/issues/43476)