### PR TITLE
Remove duplicated 'import' comments

### DIFF
--- a/packages/block-editor/src/components/rich-text/use-enter.js
+++ b/packages/block-editor/src/components/rich-text/use-enter.js
@@ -1,9 +1,6 @@
 /**
  * WordPress dependencies
  */
-/**
- * WordPress dependencies
- */
 import { useRef } from '@wordpress/element';
 import { useRefEffect } from '@wordpress/compose';
 import { ENTER } from '@wordpress/keycodes';

--- a/packages/components/src/dimension-control/index.js
+++ b/packages/components/src/dimension-control/index.js
@@ -6,17 +6,13 @@ import classnames from 'classnames';
 /**
  * WordPress dependencies
  */
-/**
- * Internal dependencies
- */
-import { Icon, SelectControl } from '../';
 import { __ } from '@wordpress/i18n';
-
 import { Fragment } from '@wordpress/element';
 
 /**
  * Internal dependencies
  */
+import { Icon, SelectControl } from '../';
 import sizesTable, { findSizeBySlug } from './sizes';
 
 export function DimensionControl( props ) {

--- a/packages/components/src/navigator/navigator-back-button/hook.ts
+++ b/packages/components/src/navigator/navigator-back-button/hook.ts
@@ -6,9 +6,6 @@ import { useCallback } from '@wordpress/element';
 /**
  * Internal dependencies
  */
-/**
- * Internal dependencies
- */
 import { useContextSystem, WordPressComponentProps } from '../../ui/context';
 import Button from '../../button';
 import useNavigator from '../use-navigator';

--- a/packages/components/src/navigator/navigator-button/hook.ts
+++ b/packages/components/src/navigator/navigator-button/hook.ts
@@ -7,9 +7,6 @@ import { escapeAttribute } from '@wordpress/escape-html';
 /**
  * Internal dependencies
  */
-/**
- * Internal dependencies
- */
 import { useContextSystem, WordPressComponentProps } from '../../ui/context';
 import Button from '../../button';
 import useNavigator from '../use-navigator';

--- a/packages/e2e-test-utils-playwright/src/admin/index.ts
+++ b/packages/e2e-test-utils-playwright/src/admin/index.ts
@@ -6,9 +6,6 @@ import type { Browser, Page, BrowserContext } from '@playwright/test';
 /**
  * Internal dependencies
  */
-/**
- * Internal dependencies
- */
 import { createNewPost } from './create-new-post';
 import { getPageError } from './get-page-error';
 import { visitAdminPage } from './visit-admin-page';

--- a/packages/edit-navigation/src/filters/add-menu-name-editor.js
+++ b/packages/edit-navigation/src/filters/add-menu-name-editor.js
@@ -1,11 +1,12 @@
 /**
  * WordPress dependencies
  */
+import { addFilter } from '@wordpress/hooks';
+import { createHigherOrderComponent } from '@wordpress/compose';
+
 /**
  * Internal dependencies
  */
-import { addFilter } from '@wordpress/hooks';
-import { createHigherOrderComponent } from '@wordpress/compose';
 import NameDisplay from '../components/name-display';
 
 const addMenuNameEditor = createHigherOrderComponent(

--- a/packages/edit-site/src/components/header/mode-switcher/index.js
+++ b/packages/edit-site/src/components/header/mode-switcher/index.js
@@ -9,9 +9,6 @@ import { store as keyboardShortcutsStore } from '@wordpress/keyboard-shortcuts';
 /**
  * Internal dependencies
  */
-/**
- * Internal dependencies
- */
 import { store as editSiteStore } from '../../../store';
 
 /**

--- a/packages/interface/src/components/interface-skeleton/index.js
+++ b/packages/interface/src/components/interface-skeleton/index.js
@@ -6,9 +6,6 @@ import classnames from 'classnames';
 /**
  * WordPress dependencies
  */
-/**
- * WordPress dependencies
- */
 import { forwardRef, useEffect } from '@wordpress/element';
 import { __unstableUseNavigateRegions as useNavigateRegions } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';


### PR DESCRIPTION
## What?
PR removes duplicated import comments. Happens sometimes when copying or mixing WordPress/Internal imports.

## Testing Instructions
Nothing to tests
