### PR TITLE
Lodash: Refactor away from `_.sortBy()`

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -134,6 +134,7 @@ module.exports = {
 							'reverse',
 							'size',
 							'snakeCase',
+							'sortBy',
 							'startCase',
 							'startsWith',
 							'stubFalse',

--- a/bin/plugin/commands/changelog.js
+++ b/bin/plugin/commands/changelog.js
@@ -823,17 +823,9 @@ function getContributorPropsMarkdownList( ftcPRs ) {
  * @return {IssuesListForRepoResponseItem[]} The sorted list of pull requests.
  */
 function sortByUsername( items ) {
-	return [ ...items ].sort( ( a, b ) => {
-		const usernameA = a.user.login.toLowerCase();
-		const usernameB = b.user.login.toLowerCase();
-		if ( usernameA < usernameB ) {
-			return -1;
-		}
-		if ( usernameA > usernameB ) {
-			return 1;
-		}
-		return 0;
-	} );
+	return [ ...items ].sort( ( a, b ) =>
+		a.user.login.toLowerCase().localeCompare( b.user.login.toLowerCase() )
+	);
 }
 
 /**

--- a/bin/plugin/commands/changelog.js
+++ b/bin/plugin/commands/changelog.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-const { groupBy, escapeRegExp, flow, sortBy } = require( 'lodash' );
+const { groupBy, escapeRegExp, flow } = require( 'lodash' );
 const Octokit = require( '@octokit/rest' );
 const { sprintf } = require( 'sprintf-js' );
 const semver = require( 'semver' );
@@ -823,7 +823,17 @@ function getContributorPropsMarkdownList( ftcPRs ) {
  * @return {IssuesListForRepoResponseItem[]} The sorted list of pull requests.
  */
 function sortByUsername( items ) {
-	return sortBy( items, ( item ) => item.user.login.toLowerCase() );
+	return [ ...items ].sort( ( a, b ) => {
+		const usernameA = a.user.login.toLowerCase();
+		const usernameB = b.user.login.toLowerCase();
+		if ( usernameA < usernameB ) {
+			return -1;
+		}
+		if ( usernameA > usernameB ) {
+			return 1;
+		}
+		return 0;
+	} );
 }
 
 /**

--- a/packages/babel-plugin-makepot/index.js
+++ b/packages/babel-plugin-makepot/index.js
@@ -197,17 +197,9 @@ function isSameTranslation( a, b ) {
  * @return {Array} Sorted translations.
  */
 function sortByReference( translations = [] ) {
-	return [ ...translations ].sort( ( a, b ) => {
-		const referenceA = a.comments.reference;
-		const referenceB = b.comments.reference;
-		if ( referenceA < referenceB ) {
-			return -1;
-		}
-		if ( referenceA > referenceB ) {
-			return 1;
-		}
-		return 0;
-	} );
+	return [ ...translations ].sort( ( a, b ) =>
+		a.comments.reference.localeCompare( b.comments.reference )
+	);
 }
 
 module.exports = () => {

--- a/packages/babel-plugin-makepot/index.js
+++ b/packages/babel-plugin-makepot/index.js
@@ -33,15 +33,7 @@
  */
 
 const { po } = require( 'gettext-parser' );
-const {
-	pick,
-	reduce,
-	forEach,
-	sortBy,
-	isEqual,
-	merge,
-	isEmpty,
-} = require( 'lodash' );
+const { pick, reduce, forEach, isEqual, merge, isEmpty } = require( 'lodash' );
 const { relative, sep } = require( 'path' );
 const { writeFileSync } = require( 'fs' );
 
@@ -196,6 +188,28 @@ function isSameTranslation( a, b ) {
 	);
 }
 
+/**
+ * Sorts multiple translation objects by their reference.
+ * The reference is where they occur, in the format `file:line`.
+ *
+ * @param {Array} translations Array of translations to sort.
+ *
+ * @return {Array} Sorted translations.
+ */
+function sortByReference( translations = [] ) {
+	return [ ...translations ].sort( ( a, b ) => {
+		const referenceA = a.comments.reference;
+		const referenceB = b.comments.reference;
+		if ( referenceA < referenceB ) {
+			return -1;
+		}
+		if ( referenceA > referenceB ) {
+			return 1;
+		}
+		return 0;
+	} );
+}
+
 module.exports = () => {
 	const strings = {};
 	let nplurals = 2,
@@ -323,9 +337,8 @@ module.exports = () => {
 						( memo, file ) => {
 							for ( const context in strings[ file ] ) {
 								// Within the same file, sort translations by line.
-								const sortedTranslations = sortBy(
-									strings[ file ][ context ],
-									'comments.reference'
+								const sortedTranslations = sortByReference(
+									strings[ file ][ context ]
 								);
 
 								forEach(

--- a/packages/block-library/src/index.native.js
+++ b/packages/block-library/src/index.native.js
@@ -2,7 +2,6 @@
  * External dependencies
  */
 import { Platform } from 'react-native';
-import { sortBy } from 'lodash';
 
 /**
  * WordPress dependencies
@@ -161,16 +160,32 @@ export const registerBlock = ( block ) => {
 const registerBlockVariations = ( block ) => {
 	const { metadata, settings, name } = block;
 
-	sortBy( settings.variations, 'title' ).forEach( ( v ) => {
-		registerBlockType( `${ name }-${ v.name }`, {
-			...metadata,
-			name: `${ name }-${ v.name }`,
-			...settings,
-			icon: v.icon(),
-			title: v.title,
-			variations: [],
+	if ( ! settings.variations ) {
+		return;
+	}
+
+	[ ...settings.variations ]
+		.sort( ( a, b ) => {
+			const variationA = a.title;
+			const variationB = b.title;
+			if ( variationA < variationB ) {
+				return -1;
+			}
+			if ( variationA > variationB ) {
+				return 1;
+			}
+			return 0;
+		} )
+		.forEach( ( v ) => {
+			registerBlockType( `${ name }-${ v.name }`, {
+				...metadata,
+				name: `${ name }-${ v.name }`,
+				...settings,
+				icon: v.icon(),
+				title: v.title,
+				variations: [],
+			} );
 		} );
-	} );
 };
 
 // Only enable code block for development

--- a/packages/block-library/src/index.native.js
+++ b/packages/block-library/src/index.native.js
@@ -165,17 +165,7 @@ const registerBlockVariations = ( block ) => {
 	}
 
 	[ ...settings.variations ]
-		.sort( ( a, b ) => {
-			const variationA = a.title;
-			const variationB = b.title;
-			if ( variationA < variationB ) {
-				return -1;
-			}
-			if ( variationA > variationB ) {
-				return 1;
-			}
-			return 0;
-		} )
+		.sort( ( a, b ) => a.title.localeCompare( b.title ) )
 		.forEach( ( v ) => {
 			registerBlockType( `${ name }-${ v.name }`, {
 				...metadata,

--- a/packages/block-library/src/navigation/menu-items-to-blocks.js
+++ b/packages/block-library/src/navigation/menu-items-to-blocks.js
@@ -1,9 +1,4 @@
 /**
- * External dependencies
- */
-import { sortBy } from 'lodash';
-
-/**
  * WordPress dependencies
  */
 import { createBlock, parse } from '@wordpress/blocks';
@@ -40,7 +35,9 @@ function mapMenuItemsToBlocks( menuItems ) {
 	let mapping = {};
 
 	// The menuItem should be in menu_order sort order.
-	const sortedItems = sortBy( menuItems, 'menu_order' );
+	const sortedItems = [ ...menuItems ].sort(
+		( a, b ) => a.menu_order - b.menu_order
+	);
 
 	const innerBlocks = sortedItems.map( ( menuItem ) => {
 		if ( menuItem.type === 'block' ) {

--- a/packages/block-library/src/page-list/edit.js
+++ b/packages/block-library/src/page-list/edit.js
@@ -134,15 +134,7 @@ function usePageData() {
 		// https://core.trac.wordpress.org/ticket/39037
 		const sortedPages = [ ...( pages ?? [] ) ].sort( ( a, b ) => {
 			if ( a.menu_order === b.menu_order ) {
-				const titleA = a.title.rendered;
-				const titleB = b.title.rendered;
-				if ( titleA < titleB ) {
-					return -1;
-				}
-				if ( titleA > titleB ) {
-					return 1;
-				}
-				return 0;
+				return a.title.rendered.localeCompare( b.title.rendered );
 			}
 			return a.menu_order - b.menu_order;
 		} );

--- a/packages/block-library/src/page-list/edit.js
+++ b/packages/block-library/src/page-list/edit.js
@@ -2,7 +2,6 @@
  * External dependencies
  */
 import classnames from 'classnames';
-import { sortBy } from 'lodash';
 
 /**
  * WordPress dependencies
@@ -133,7 +132,20 @@ function usePageData() {
 		// TODO: Once the REST API supports passing multiple values to
 		// 'orderby', this can be removed.
 		// https://core.trac.wordpress.org/ticket/39037
-		const sortedPages = sortBy( pages, [ 'menu_order', 'title.rendered' ] );
+		const sortedPages = [ ...( pages ?? [] ) ].sort( ( a, b ) => {
+			if ( a.menu_order === b.menu_order ) {
+				const titleA = a.title.rendered;
+				const titleB = b.title.rendered;
+				if ( titleA < titleB ) {
+					return -1;
+				}
+				if ( titleA > titleB ) {
+					return 1;
+				}
+				return 0;
+			}
+			return a.menu_order - b.menu_order;
+		} );
 		const pagesByParentId = sortedPages.reduce( ( accumulator, page ) => {
 			const { parent } = page;
 			if ( accumulator.has( parent ) ) {

--- a/packages/edit-navigation/src/components/block-placeholder/menu-items-to-blocks.js
+++ b/packages/edit-navigation/src/components/block-placeholder/menu-items-to-blocks.js
@@ -1,9 +1,4 @@
 /**
- * External dependencies
- */
-import { sortBy } from 'lodash';
-
-/**
  * WordPress dependencies
  */
 import { createBlock } from '@wordpress/blocks';
@@ -41,7 +36,9 @@ function mapMenuItemsToBlocks( menuItems ) {
 	let mapping = {};
 
 	// The menuItem should be in menu_order sort order.
-	const sortedItems = sortBy( menuItems, 'menu_order' );
+	const sortedItems = [ ...menuItems ].sort(
+		( a, b ) => a.menu_order - b.menu_order
+	);
 
 	const innerBlocks = sortedItems.map( ( menuItem ) => {
 		const attributes = menuItemToBlockAttributes( menuItem );

--- a/packages/edit-navigation/src/store/transform.js
+++ b/packages/edit-navigation/src/store/transform.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { get, omit, sortBy } from 'lodash';
+import { get, omit } from 'lodash';
 
 /**
  * WordPress dependencies
@@ -168,7 +168,9 @@ export function menuItemsToBlocks( menuItems ) {
  */
 function mapMenuItemsToBlocks( menuItems ) {
 	// The menuItem should be in menu_order sort order.
-	const sortedItems = sortBy( menuItems, 'menu_order' );
+	const sortedItems = [ ...menuItems ].sort(
+		( a, b ) => a.menu_order - b.menu_order
+	);
 
 	const blocks = sortedItems.map( ( menuItem ) => {
 		if ( menuItem.type === 'block' ) {


### PR DESCRIPTION
## What?
This PR removes the `_.sortBy()` usage completely and deprecates the function. 

## Why?

Lodash is known to unnecessarily inflate the bundle size of packages, and in most cases, it can be replaced with native language functionality. See these for more information and rationale:

* https://github.com/WordPress/gutenberg/issues/16938#issuecomment-602837246
* https://github.com/WordPress/gutenberg/issues/17025
* https://github.com/WordPress/gutenberg/issues/39495 

## How?

We're using the native `Array.prototype.sort()` function with some custom comparison functions which are pretty straightforward to write.

In Lodash, this is one one of the useful functions, as it saves a little boilerplate necessary for the sorting, which is especially handy for multiple criteria. Here, we only have a single use for that, and refactoring it is pretty straightforward.

However, the function is also pretty complex, as it supports objects (which we don't need here and is confusing since it grabs an object and returns an array), and flattens the input collection, which we also don't need. 

We can totally abstract this to a helper function, but given the usages here I just think it's not necessary.

## Testing Instructions
* Run `npm run other:changelog` and verify changelog is still built correctly. Specifically, verify the list of contributors is still sorted by the username alphabetically.
* Verify all block variations are registered correctly for RN.
* Verify navigation block still works well, particularly page items are sorted by their menu order.
* Verify page list block still works well and lists pages properly, sorted by their menu order and title.
* For testing `@wordpress/babel-plugin-makepot` - cc @swisspidy - what's a good way to test this one nowadays?
