### PR TITLE
Core Data: Stop sending duplicate requests in canUser resolver

### DIFF
--- a/packages/core-data/src/resolvers.js
+++ b/packages/core-data/src/resolvers.js
@@ -283,29 +283,24 @@ export const canUser =
 	async ( { dispatch, registry } ) => {
 		const { hasStartedResolution } = registry.select( STORE_NAME );
 
-		let resourcePath;
-		let retrievedActions;
-		if ( id ) {
-			retrievedActions = [ 'create', 'read', 'update', 'delete' ];
-			resourcePath = `${ resource }/${ id }`;
+		const resourcePath = id ? `${ resource }/${ id }` : resource;
+		const retrievedActions = id
+			? [ 'create', 'read', 'update', 'delete' ]
+			: [ 'create', 'read' ];
 
-			// Prevent resolving the same resource twice.
-			for ( const relatedAction of retrievedActions ) {
-				if ( relatedAction === requestedAction ) {
-					continue;
-				}
-				const isAlreadyResolving = hasStartedResolution( 'canUser', [
-					relatedAction,
-					resource,
-					id,
-				] );
-				if ( isAlreadyResolving ) {
-					return;
-				}
+		// Prevent resolving the same resource twice.
+		for ( const relatedAction of retrievedActions ) {
+			if ( relatedAction === requestedAction ) {
+				continue;
 			}
-		} else {
-			retrievedActions = [ 'create', 'read' ];
-			resourcePath = resource;
+			const isAlreadyResolving = hasStartedResolution( 'canUser', [
+				relatedAction,
+				resource,
+				id,
+			] );
+			if ( isAlreadyResolving ) {
+				return;
+			}
 		}
 
 		if ( ! retrievedActions.includes( requestedAction ) ) {

--- a/packages/core-data/src/resolvers.js
+++ b/packages/core-data/src/resolvers.js
@@ -304,7 +304,7 @@ export const canUser =
 				}
 			}
 		} else {
-			retrievedActions = [ 'create' ];
+			retrievedActions = [ 'create', 'read' ];
 			resourcePath = resource;
 		}
 

--- a/packages/core-data/src/resolvers.js
+++ b/packages/core-data/src/resolvers.js
@@ -273,52 +273,87 @@ export const getEmbedPreview =
  * Checks whether the current user can perform the given action on the given
  * REST resource.
  *
- * @param {string}  action   Action to check. One of: 'create', 'read', 'update',
- *                           'delete'.
- * @param {string}  resource REST resource to check, e.g. 'media' or 'posts'.
- * @param {?string} id       ID of the rest resource to check.
+ * @param {string}  requestedAction Action to check. One of: 'create', 'read', 'update',
+ *                                  'delete'.
+ * @param {string}  resource        REST resource to check, e.g. 'media' or 'posts'.
+ * @param {?string} id              ID of the rest resource to check.
  */
 export const canUser =
-	( action, resource, id ) =>
-	async ( { dispatch } ) => {
-		const methods = {
-			create: 'POST',
-			read: 'GET',
-			update: 'PUT',
-			delete: 'DELETE',
-		};
+	( requestedAction, resource, id ) =>
+	async ( { dispatch, registry } ) => {
+		const { hasStartedResolution } = registry.select( STORE_NAME );
 
-		const method = methods[ action ];
-		if ( ! method ) {
-			throw new Error( `'${ action }' is not a valid action.` );
+		let resourcePath;
+		let retrievedActions;
+		if ( id ) {
+			retrievedActions = [ 'create', 'read', 'update', 'delete' ];
+			resourcePath = `${ resource }/${ id }`;
+
+			// Prevent resolving the same resource twice.
+			for ( const relatedAction of retrievedActions ) {
+				if ( relatedAction === requestedAction ) {
+					continue;
+				}
+				const isAlreadyResolving = hasStartedResolution( 'canUser', [
+					relatedAction,
+					resource,
+					id,
+				] );
+				if ( isAlreadyResolving ) {
+					return;
+				}
+			}
+		} else {
+			retrievedActions = [ 'create' ];
+			resourcePath = resource;
 		}
 
-		const path = id
-			? `/wp/v2/${ resource }/${ id }`
-			: `/wp/v2/${ resource }`;
+		if ( ! retrievedActions.includes( requestedAction ) ) {
+			throw new Error( `'${ requestedAction }' is not a valid action.` );
+		}
 
-		let response;
+		let permissions;
 		try {
-			response = await apiFetch( {
-				path,
-				method: 'OPTIONS',
-				parse: false,
-			} );
+			permissions = await checkAllowedActions( resourcePath );
 		} catch ( error ) {
 			// Do nothing if our OPTIONS request comes back with an API error (4xx or
 			// 5xx). The previously determined isAllowed value will remain in the store.
 			return;
 		}
 
-		// Optional chaining operator is used here because the API requests don't
-		// return the expected result in the native version. Instead, API requests
-		// only return the result, without including response properties like the headers.
-		const allowHeader = response.headers?.get( 'allow' );
-		const key = [ action, resource, id ].filter( Boolean ).join( '/' );
-		const isAllowed =
-			allowHeader?.includes?.( method ) || allowHeader?.allow === method;
-		dispatch.receiveUserPermission( key, isAllowed );
+		for ( const action of retrievedActions ) {
+			dispatch.receiveUserPermission(
+				`${ action }/${ resourcePath }`,
+				permissions[ action ]
+			);
+		}
 	};
+
+const checkAllowedActions = async ( path ) => {
+	const methods = {
+		create: 'POST',
+		read: 'GET',
+		update: 'PUT',
+		delete: 'DELETE',
+	};
+	const response = await apiFetch( {
+		path: `/wp/v2/${ path }`,
+		method: 'OPTIONS',
+		parse: false,
+	} );
+
+	// Optional chaining operator is used here because the API requests don't
+	// return the expected result in the native version. Instead, API requests
+	// only return the result, without including response properties like the headers.
+	const allowHeader = response.headers?.get( 'allow' );
+	const allowedMethods = allowHeader?.allow || allowHeader || '';
+
+	const permissions = {};
+	for ( const [ actionName, methodName ] of Object.entries( methods ) ) {
+		permissions[ actionName ] = allowedMethods.includes( methodName );
+	}
+	return permissions;
+};
 
 /**
  * Checks whether the current user can perform the given action on the given

--- a/packages/core-data/src/resolvers.js
+++ b/packages/core-data/src/resolvers.js
@@ -288,6 +288,10 @@ export const canUser =
 			? [ 'create', 'read', 'update', 'delete' ]
 			: [ 'create', 'read' ];
 
+		if ( ! retrievedActions.includes( requestedAction ) ) {
+			throw new Error( `'${ requestedAction }' is not a valid action.` );
+		}
+
 		// Prevent resolving the same resource twice.
 		for ( const relatedAction of retrievedActions ) {
 			if ( relatedAction === requestedAction ) {
@@ -301,10 +305,6 @@ export const canUser =
 			if ( isAlreadyResolving ) {
 				return;
 			}
-		}
-
-		if ( ! retrievedActions.includes( requestedAction ) ) {
-			throw new Error( `'${ requestedAction }' is not a valid action.` );
 		}
 
 		let response;

--- a/packages/core-data/src/resolvers.js
+++ b/packages/core-data/src/resolvers.js
@@ -284,9 +284,7 @@ export const canUser =
 		const { hasStartedResolution } = registry.select( STORE_NAME );
 
 		const resourcePath = id ? `${ resource }/${ id }` : resource;
-		const retrievedActions = id
-			? [ 'create', 'read', 'update', 'delete' ]
-			: [ 'create', 'read' ];
+		const retrievedActions = [ 'create', 'read', 'update', 'delete' ];
 
 		if ( ! retrievedActions.includes( requestedAction ) ) {
 			throw new Error( `'${ requestedAction }' is not a valid action.` );

--- a/packages/core-data/src/test/resolvers.js
+++ b/packages/core-data/src/test/resolvers.js
@@ -291,7 +291,13 @@ describe( 'getEmbedPreview', () => {
 } );
 
 describe( 'canUser', () => {
+	let registry;
 	beforeEach( async () => {
+		registry = {
+			select: jest.fn( () => ( {
+				hasStartedResolution: () => false,
+			} ) ),
+		};
 		triggerFetch.mockReset();
 	} );
 
@@ -304,7 +310,7 @@ describe( 'canUser', () => {
 			Promise.reject( { status: 404 } )
 		);
 
-		await canUser( 'create', 'media' )( { dispatch } );
+		await canUser( 'create', 'media' )( { dispatch, registry } );
 
 		expect( triggerFetch ).toHaveBeenCalledWith( {
 			path: '/wp/v2/media',
@@ -324,7 +330,7 @@ describe( 'canUser', () => {
 			headers: new Map( [ [ 'allow', 'GET' ] ] ),
 		} ) );
 
-		await canUser( 'create', 'media' )( { dispatch } );
+		await canUser( 'create', 'media' )( { dispatch, registry } );
 
 		expect( triggerFetch ).toHaveBeenCalledWith( {
 			path: '/wp/v2/media',
@@ -347,7 +353,7 @@ describe( 'canUser', () => {
 			headers: new Map( [ [ 'allow', 'POST, GET, PUT, DELETE' ] ] ),
 		} ) );
 
-		await canUser( 'create', 'media' )( { dispatch } );
+		await canUser( 'create', 'media' )( { dispatch, registry } );
 
 		expect( triggerFetch ).toHaveBeenCalledWith( {
 			path: '/wp/v2/media',
@@ -370,7 +376,7 @@ describe( 'canUser', () => {
 			headers: new Map( [ [ 'allow', 'POST, GET, PUT, DELETE' ] ] ),
 		} ) );
 
-		await canUser( 'create', 'blocks', 123 )( { dispatch } );
+		await canUser( 'create', 'blocks', 123 )( { dispatch, registry } );
 
 		expect( triggerFetch ).toHaveBeenCalledWith( {
 			path: '/wp/v2/blocks/123',
@@ -380,6 +386,46 @@ describe( 'canUser', () => {
 
 		expect( dispatch.receiveUserPermission ).toHaveBeenCalledWith(
 			'create/blocks/123',
+			true
+		);
+	} );
+
+	it( 'runs apiFetch only once per resource', async () => {
+		const dispatch = Object.assign( jest.fn(), {
+			receiveUserPermission: jest.fn(),
+		} );
+
+		registry = {
+			select: () => ( {
+				hasStartedResolution: ( _, [ action ] ) => action === 'create',
+			} ),
+		};
+
+		triggerFetch.mockImplementation( () => ( {
+			headers: new Map( [ [ 'allow', 'POST, GET, PUT, DELETE' ] ] ),
+		} ) );
+
+		await canUser( 'create', 'blocks', 123 )( { dispatch, registry } );
+		await canUser( 'read', 'blocks', 123 )( { dispatch, registry } );
+		await canUser( 'update', 'blocks', 123 )( { dispatch, registry } );
+		await canUser( 'delete', 'blocks', 123 )( { dispatch, registry } );
+
+		expect( triggerFetch ).toHaveBeenCalledTimes( 1 );
+
+		expect( dispatch.receiveUserPermission ).toHaveBeenCalledWith(
+			'create/blocks/123',
+			true
+		);
+		expect( dispatch.receiveUserPermission ).toHaveBeenCalledWith(
+			'read/blocks/123',
+			true
+		);
+		expect( dispatch.receiveUserPermission ).toHaveBeenCalledWith(
+			'update/blocks/123',
+			true
+		);
+		expect( dispatch.receiveUserPermission ).toHaveBeenCalledWith(
+			'delete/blocks/123',
 			true
 		);
 	} );

--- a/packages/core-data/src/test/resolvers.js
+++ b/packages/core-data/src/test/resolvers.js
@@ -420,6 +420,44 @@ describe( 'canUser', () => {
 		);
 	} );
 
+	it( 'retrieves all permissions even when ID is not given', async () => {
+		const dispatch = Object.assign( jest.fn(), {
+			receiveUserPermission: jest.fn(),
+		} );
+
+		registry = {
+			select: () => ( {
+				hasStartedResolution: ( _, [ action ] ) => action === 'read',
+			} ),
+		};
+
+		triggerFetch.mockImplementation( () => ( {
+			headers: new Map( [ [ 'allow', 'POST, GET' ] ] ),
+		} ) );
+
+		await canUser( 'create', 'blocks' )( { dispatch, registry } );
+		await canUser( 'read', 'blocks' )( { dispatch, registry } );
+		await canUser( 'update', 'blocks' )( { dispatch, registry } );
+		await canUser( 'delete', 'blocks' )( { dispatch, registry } );
+
+		expect( dispatch.receiveUserPermission ).toHaveBeenCalledWith(
+			'create/blocks',
+			true
+		);
+		expect( dispatch.receiveUserPermission ).toHaveBeenCalledWith(
+			'read/blocks',
+			true
+		);
+		expect( dispatch.receiveUserPermission ).toHaveBeenCalledWith(
+			'update/blocks',
+			false
+		);
+		expect( dispatch.receiveUserPermission ).toHaveBeenCalledWith(
+			'delete/blocks',
+			false
+		);
+	} );
+
 	it( 'runs apiFetch only once per resource ID', async () => {
 		const dispatch = Object.assign( jest.fn(), {
 			receiveUserPermission: jest.fn(),

--- a/packages/core-data/src/test/resolvers.js
+++ b/packages/core-data/src/test/resolvers.js
@@ -397,6 +397,36 @@ describe( 'canUser', () => {
 
 		registry = {
 			select: () => ( {
+				hasStartedResolution: ( _, [ action ] ) => action === 'read',
+			} ),
+		};
+
+		triggerFetch.mockImplementation( () => ( {
+			headers: new Map( [ [ 'allow', 'POST, GET' ] ] ),
+		} ) );
+
+		await canUser( 'create', 'blocks' )( { dispatch, registry } );
+		await canUser( 'read', 'blocks' )( { dispatch, registry } );
+
+		expect( triggerFetch ).toHaveBeenCalledTimes( 1 );
+
+		expect( dispatch.receiveUserPermission ).toHaveBeenCalledWith(
+			'create/blocks',
+			true
+		);
+		expect( dispatch.receiveUserPermission ).toHaveBeenCalledWith(
+			'read/blocks',
+			true
+		);
+	} );
+
+	it( 'runs apiFetch only once per resource ID', async () => {
+		const dispatch = Object.assign( jest.fn(), {
+			receiveUserPermission: jest.fn(),
+		} );
+
+		registry = {
+			select: () => ( {
 				hasStartedResolution: ( _, [ action ] ) => action === 'create',
 			} ),
 		};


### PR DESCRIPTION
## What?

The following snippet issues three identical HTTP requests:

```js
canUser( 'pages', 'update', 10 );
canUser( 'pages', 'read', 10 );
canUser( 'pages', 'delete', 10 );
```

Each time, the `canUser` resolver sends a simple OPTIONS request to the `/wp/v2/pages/10`.

This PR caches and reuses the results retrieved the first time. It follows up on an [observation @Mamaduka got after stabilizing the `useResourcePermissions` hook](https://github.com/WordPress/gutenberg/pull/43268#issuecomment-1221950456):

> When using this hook, even if you only check for single permission, it will still make multiple calls to the same endpoint.

## Testing Instructions

It's hard to test this in a browser so I added a test case to check how many API calls are issued. Confirm it makes sense and passes.

cc @Mamaduka @gziolo 
