### PR TITLE
Create Block: Refactor handling for template variants

### DIFF
--- a/packages/create-block-tutorial-template/CHANGELOG.md
+++ b/packages/create-block-tutorial-template/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Enhancement
+
+-   Add support to the `dynamic` variant ([#41289](https://github.com/WordPress/gutenberg/pull/41289), [#43481](https://github.com/WordPress/gutenberg/pull/43481)).
+
 ## 2.3.0 (2022-06-01)
 
 ### Enhancement

--- a/packages/create-block-tutorial-template/block-templates/index.js.mustache
+++ b/packages/create-block-tutorial-template/block-templates/index.js.mustache
@@ -44,6 +44,7 @@ registerBlockType( metadata.name, {
 	 */
 	edit: Edit,
 	{{#isStaticVariant}}
+
 	/**
 	 * @see ./save.js
 	 */

--- a/packages/create-block-tutorial-template/block-templates/template.php.mustache
+++ b/packages/create-block-tutorial-template/block-templates/template.php.mustache
@@ -1,5 +1,5 @@
 {{#isDynamicVariant}}
 <p <?php echo get_block_wrapper_attributes(); ?>>
-	<?php echo esc_html( $atts['message']) ?>
+	<?php echo esc_html( $attributes['message'] ); ?>
 </p>
 {{/isDynamicVariant}}

--- a/packages/create-block-tutorial-template/plugin-templates/$slug.php.mustache
+++ b/packages/create-block-tutorial-template/plugin-templates/$slug.php.mustache
@@ -37,25 +37,24 @@
  *
  * @see https://developer.wordpress.org/reference/functions/register_block_type/
  */
-{{#isStaticVariant}}
 function {{namespaceSnakeCase}}_{{slugSnakeCase}}_block_init() {
+	{{#isStaticVariant}}
 	register_block_type( __DIR__ . '/build' );
-}
-add_action( 'init', '{{namespaceSnakeCase}}_{{slugSnakeCase}}_block_init' );
-{{/isStaticVariant}}
-{{#isDynamicVariant}}
-function {{namespaceSnakeCase}}_{{slugSnakeCase}}_block_init() {
+	{{/isStaticVariant}}
+	{{#isDynamicVariant}}
 	register_block_type(
 		__DIR__ . '/build',
 		array(
 			'render_callback' => '{{namespaceSnakeCase}}_{{slugSnakeCase}}_render_callback',
 		)
 	);
+	{{/isDynamicVariant}}
 }
 add_action( 'init', '{{namespaceSnakeCase}}_{{slugSnakeCase}}_block_init' );
+{{#isDynamicVariant}}
 
 /**
- * Render callback function
+ * Render callback function.
  *
  * @param array    $attributes The block attributes.
  * @param string   $content    The block content.
@@ -63,7 +62,7 @@ add_action( 'init', '{{namespaceSnakeCase}}_{{slugSnakeCase}}_block_init' );
  *
  * @return string The rendered output.
  */
-function {{namespaceSnakeCase}}_{{slugSnakeCase}}_render_callback( $atts, $content, $block) {
+function {{namespaceSnakeCase}}_{{slugSnakeCase}}_render_callback( $atts, $content, $block ) {
 	ob_start();
 	require plugin_dir_path( __FILE__ ) . 'build/template.php';
 	return ob_get_clean();

--- a/packages/create-block/CHANGELOG.md
+++ b/packages/create-block/CHANGELOG.md
@@ -9,7 +9,7 @@
 ### New Feature
 
 -   Add `--no-plugin` flag to allow scaffolding of a block in an existing plugin ([#41642](https://github.com/WordPress/gutenberg/pull/41642))
--   Introduce the `--variant` flag to allow selection of a variant as defined in the template ([#41289](https://github.com/WordPress/gutenberg/pull/41289)).
+-   Introduce the `--variant` flag to allow selection of a variant as defined in the template ([#41289](https://github.com/WordPress/gutenberg/pull/41289), [#43481](https://github.com/WordPress/gutenberg/pull/43481)).
 
 ## 3.6.0 (2022-07-13)
 

--- a/packages/create-block/lib/prompts.js
+++ b/packages/create-block/lib/prompts.js
@@ -134,16 +134,8 @@ const updateURI = {
 	message: 'A custom update URI for the plugin (optional):',
 };
 
-const variant = {
-	type: 'list',
-	name: 'variant',
-	message: 'The template variant to use for this block:',
-	choices: [],
-};
-
 module.exports = {
 	slug,
-	variant,
 	namespace,
 	title,
 	description,

--- a/packages/create-block/lib/scaffold.js
+++ b/packages/create-block/lib/scaffold.js
@@ -12,10 +12,9 @@ const initWPScripts = require( './init-wp-scripts' );
 const initWPEnv = require( './init-wp-env' );
 const { code, info, success, error } = require( './log' );
 const { writeOutputAsset, writeOutputTemplate } = require( './output' );
-const { getTemplateVariantVars } = require( './templates' );
 
 module.exports = async (
-	{ blockOutputTemplates, pluginOutputTemplates, outputAssets, variants },
+	{ blockOutputTemplates, pluginOutputTemplates, outputAssets },
 	{
 		$schema,
 		apiVersion,
@@ -44,7 +43,7 @@ module.exports = async (
 		editorScript,
 		editorStyle,
 		style,
-		variant,
+		variantVars,
 	}
 ) => {
 	slug = slug.toLowerCase();
@@ -100,8 +99,7 @@ module.exports = async (
 		editorScript,
 		editorStyle,
 		style,
-		...getTemplateVariantVars( variants, variant ),
-		...variants[ variant ],
+		...variantVars,
 	};
 
 	if ( plugin ) {

--- a/packages/create-block/lib/templates/block/index.js.mustache
+++ b/packages/create-block/lib/templates/block/index.js.mustache
@@ -34,6 +34,7 @@ registerBlockType( metadata.name, {
 	 */
 	edit: Edit,
 	{{#isStaticVariant}}
+
 	/**
 	 * @see ./save.js
 	 */

--- a/packages/create-block/lib/templates/es5/$slug.php.mustache
+++ b/packages/create-block/lib/templates/es5/$slug.php.mustache
@@ -68,32 +68,24 @@ function {{namespaceSnakeCase}}_{{slugSnakeCase}}_block_init() {
 		array(),
 		filemtime( "$dir/$style_css" )
 	);
-	{{^isDynamicVariant}}
+
 	register_block_type(
 		'{{namespace}}/{{slug}}',
 		array(
 			'editor_script' => '{{namespace}}-{{slug}}-block-editor',
 			'editor_style'  => '{{namespace}}-{{slug}}-block-editor',
 			'style'         => '{{namespace}}-{{slug}}-block',
-		)
-	);
-	{{/isDynamicVariant}}
-	{{#isDynamicVariant}}
-	register_block_type(
-		'{{namespace}}/{{slug}}',
-		array(
-			'editor_script'   => '{{namespace}}-{{slug}}-block-editor',
-			'editor_style'    => '{{namespace}}-{{slug}}-block-editor',
-			'style'           => '{{namespace}}-{{slug}}-block',
+			{{#isDynamicVariant}}
 			'render_callback' => '{{namespaceSnakeCase}}_{{slugSnakeCase}}_render_callback',
+			{{/isDynamicVariant}}
 		)
 	);
-	{{/isDynamicVariant}}
 }
 add_action( 'init', '{{namespaceSnakeCase}}_{{slugSnakeCase}}_block_init' );
 {{#isDynamicVariant}}
+
 /**
- * Render callback function
+ * Render callback function.
  *
  * @param array    $attributes The block attributes.
  * @param string   $content    The block content.
@@ -101,7 +93,7 @@ add_action( 'init', '{{namespaceSnakeCase}}_{{slugSnakeCase}}_block_init' );
  *
  * @return string The rendered output.
  */
-function {{namespaceSnakeCase}}_{{slugSnakeCase}}_render_callback( $atts, $content, $block) {
+function {{namespaceSnakeCase}}_{{slugSnakeCase}}_render_callback( $attributes, $content, $block ) {
 	ob_start();
 	require plugin_dir_path( __FILE__ ) . '/template.php';
 	return ob_get_clean();

--- a/packages/create-block/lib/templates/es5/index.js.mustache
+++ b/packages/create-block/lib/templates/es5/index.js.mustache
@@ -94,7 +94,9 @@
 				useBlockProps(),
 				__( '{{title}} – hello from the editor!', '{{textdomain}}' )
 			);
-		}{{#isStaticVariant}},
+		},
+		{{#isStaticVariant}}
+
 		/**
 		 * The save function defines the way in which the different attributes should be combined
 		 * into the final markup, which is then serialized by the block editor into `post_content`.

--- a/packages/create-block/lib/templates/plugin/$slug.php.mustache
+++ b/packages/create-block/lib/templates/plugin/$slug.php.mustache
@@ -37,25 +37,24 @@
  *
  * @see https://developer.wordpress.org/reference/functions/register_block_type/
  */
-{{#isStaticVariant}}
 function {{namespaceSnakeCase}}_{{slugSnakeCase}}_block_init() {
+	{{#isStaticVariant}}
 	register_block_type( __DIR__ . '/build' );
-}
-add_action( 'init', '{{namespaceSnakeCase}}_{{slugSnakeCase}}_block_init' );
-{{/isStaticVariant}}
-{{#isDynamicVariant}}
-function {{namespaceSnakeCase}}_{{slugSnakeCase}}_block_init() {
+	{{/isStaticVariant}}
+	{{#isDynamicVariant}}
 	register_block_type(
 		__DIR__ . '/build',
 		array(
 			'render_callback' => '{{namespaceSnakeCase}}_{{slugSnakeCase}}_render_callback',
 		)
 	);
+	{{/isDynamicVariant}}
 }
 add_action( 'init', '{{namespaceSnakeCase}}_{{slugSnakeCase}}_block_init' );
+{{#isDynamicVariant}}
 
 /**
- * Render callback function
+ * Render callback function.
  *
  * @param array    $attributes The block attributes.
  * @param string   $content    The block content.
@@ -63,7 +62,7 @@ add_action( 'init', '{{namespaceSnakeCase}}_{{slugSnakeCase}}_block_init' );
  *
  * @return string The rendered output.
  */
-function {{namespaceSnakeCase}}_{{slugSnakeCase}}_render_callback( $atts, $content, $block) {
+function {{namespaceSnakeCase}}_{{slugSnakeCase}}_render_callback( $attributes, $content, $block ) {
 	ob_start();
 	require plugin_dir_path( __FILE__ ) . 'build/template.php';
 	return ob_get_clean();


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Follow-up for https://github.com/WordPress/gutenberg/pull/41289, where @ryanwelcher added `--variant` flag to allow creation of different block type variants.

This PR improves the handling for the `--variant` CLI argument to ensure it isn't overridden by the prompt coming from the tool.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

Detected that in the interactive mode, the variant selected with the CLI command is ignored (https://github.com/WordPress/gutenberg/pull/41289#discussion_r951200599). In effect, the following command doesn't fully work as expected as you have to select the same value twice:

```bash
npx wp-create-block --variant static
```

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

## Testing Instructions

1. User can select the template variant in the interactive mode:

```bash
npx wp-create-block
```

2. The static variant gets automatically selected when in the quick mode:

```bash
npx wp-create-block static-example
```

3. The static variant gets selected in the interactive mode when provided with CLI command:

```bash
npx wp-create-block --variant static
```

4. The dynamic variant gets selected in the interactive mode when provided with CLI command:

```bash
npx wp-create-block --variant dynamic
```

5. When an invalid variant name is provided, the following error is presented:

<img width="1344" alt="Screenshot 2022-08-22 at 15 14 20" src="https://user-images.githubusercontent.com/699132/185929976-2c65ad55-ede0-4feb-b84f-3091a67ee363.png">

6. When a variant is provided, but the template doesn't support them:

<img width="1402" alt="Screenshot 2022-08-22 at 15 30 14" src="https://user-images.githubusercontent.com/699132/185933039-248067d7-c3b2-4777-8cd0-3eda8d253b6f.png">

