### PR TITLE
AlignmentMatrixControl: Fix `width` bug

### DIFF
--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -8,6 +8,7 @@
 
 ### Bug Fix
 
+-   `AlignmentMatrixControl`: Fix the `width` prop so it works as intended ([#43482](https://github.com/WordPress/gutenberg/pull/43482)).
 -   `SelectControl`, `CustomSelectControl`: Truncate long option strings ([#43301](https://github.com/WordPress/gutenberg/pull/43301)).
 -   `Popover`: fix and improve opening animation ([#43186](https://github.com/WordPress/gutenberg/pull/43186)).
 -   `Popover`: fix incorrect deps in hooks resulting in incorrect positioning after calling `update` ([#43267](https://github.com/WordPress/gutenberg/pull/43267/)).

--- a/packages/components/src/alignment-matrix-control/index.js
+++ b/packages/components/src/alignment-matrix-control/index.js
@@ -75,7 +75,7 @@ export default function AlignmentMatrixControl( {
 			as={ Root }
 			className={ classes }
 			role="grid"
-			width={ width }
+			size={ width }
 		>
 			{ GRID.map( ( cells, index ) => (
 				<CompositeGroup


### PR DESCRIPTION
Follow-up to #43438

## What?

Fixes a mistake that passed the public `width` prop to a wrong internal prop, making the `width` prop non-functional.

## Why?

The `width` prop in AlignmentMatrixControl likely never worked, since this only gives the underlying `div` a `width` attribute. The underlying Emotion component (`Root`) is clearly designed to take a `size` prop, so we can pretty confidently say this is the original intent.

For what it's worth, there are no specific mentions of this part in the original PR (#21091).

## Testing Instructions

1. `npm run storybook:dev`
2. Go to the AlignmentMatrixControl story and test the `width` control.
