### PR TITLE
Core Data: Add canRead to useResourcePermissions

### DIFF
--- a/packages/block-library/src/navigation/test/use-navigation-menu.js
+++ b/packages/block-library/src/navigation/test/use-navigation-menu.js
@@ -56,6 +56,13 @@ function resolveReadPermission( registry, allowed ) {
 	dispatch.finishResolution( 'canUser', [ 'read', 'navigation' ] );
 }
 
+function resolveReadRecordPermission( registry, ref, allowed ) {
+	const dispatch = registry.dispatch( coreStore );
+	dispatch.receiveUserPermission( 'create/navigation', allowed );
+	dispatch.startResolution( 'canUser', [ 'read', 'navigation', ref ] );
+	dispatch.finishResolution( 'canUser', [ 'read', 'navigation', ref ] );
+}
+
 function resolveCreatePermission( registry, allowed ) {
 	const dispatch = registry.dispatch( coreStore );
 	dispatch.receiveUserPermission( 'create/navigation', allowed );
@@ -179,6 +186,7 @@ describe( 'useNavigationMenus', () => {
 	it( 'Should return correct permissions (create, update)', () => {
 		resolveRecords( registry, navigationMenus );
 		resolveCreatePermission( registry, true );
+		resolveReadRecordPermission( registry, 1, true );
 		resolveUpdatePermission( registry, 1, true );
 		resolveDeletePermission( registry, 1, false );
 		expect( useNavigationMenu( 1 ) ).toEqual( {
@@ -202,6 +210,7 @@ describe( 'useNavigationMenus', () => {
 	it( 'Should return correct permissions (delete only)', () => {
 		resolveRecords( registry, navigationMenus );
 		resolveCreatePermission( registry, false );
+		resolveReadRecordPermission( registry, 1, false );
 		resolveUpdatePermission( registry, 1, false );
 		resolveDeletePermission( registry, 1, true );
 		expect( useNavigationMenu( 1 ) ).toEqual( {

--- a/packages/block-library/src/navigation/test/use-navigation-menu.js
+++ b/packages/block-library/src/navigation/test/use-navigation-menu.js
@@ -49,6 +49,13 @@ function resolveRecords( registry, menus ) {
 	} );
 }
 
+function resolveReadPermission( registry, allowed ) {
+	const dispatch = registry.dispatch( coreStore );
+	dispatch.receiveUserPermission( 'create/navigation', allowed );
+	dispatch.startResolution( 'canUser', [ 'read', 'navigation' ] );
+	dispatch.finishResolution( 'canUser', [ 'read', 'navigation' ] );
+}
+
 function resolveCreatePermission( registry, allowed ) {
 	const dispatch = registry.dispatch( coreStore );
 	dispatch.receiveUserPermission( 'create/navigation', allowed );
@@ -105,9 +112,10 @@ describe( 'useNavigationMenus', () => {
 		} );
 	} );
 
-	it( 'Should return information about all menus when ref is missing', () => {
+	it( 'Should return information about all menus when the ref is missing', () => {
 		resolveRecords( registry, navigationMenus );
 		resolveCreatePermission( registry, true );
+		resolveReadPermission( registry, true );
 		expect( useNavigationMenu() ).toEqual( {
 			navigationMenus,
 			navigationMenu: undefined,

--- a/packages/core-data/src/hooks/test/use-resource-permissions.js
+++ b/packages/core-data/src/hooks/test/use-resource-permissions.js
@@ -55,6 +55,7 @@ describe( 'useResourcePermissions', () => {
 			isResolving: false,
 			hasResolved: false,
 			canCreate: false,
+			canRead: false,
 		} );
 
 		// Required to make sure no updates happen outside of act()
@@ -67,6 +68,7 @@ describe( 'useResourcePermissions', () => {
 			isResolving: false,
 			hasResolved: true,
 			canCreate: true,
+			canRead: false,
 		} );
 	} );
 
@@ -86,6 +88,7 @@ describe( 'useResourcePermissions', () => {
 			isResolving: false,
 			hasResolved: false,
 			canCreate: false,
+			canRead: false,
 			canUpdate: false,
 			canDelete: false,
 		} );
@@ -100,6 +103,7 @@ describe( 'useResourcePermissions', () => {
 			isResolving: false,
 			hasResolved: true,
 			canCreate: true,
+			canRead: false,
 			canUpdate: false,
 			canDelete: false,
 		} );

--- a/packages/core-data/src/hooks/use-resource-permissions.ts
+++ b/packages/core-data/src/hooks/use-resource-permissions.ts
@@ -140,9 +140,15 @@ export default function useResourcePermissions< IdType = void >(
 			const update = canUser( 'update', resource, id );
 			const _delete = canUser( 'delete', resource, id );
 			const isResolving =
-				create.isResolving || update.isResolving || _delete.isResolving;
+				read.isResolving ||
+				create.isResolving ||
+				update.isResolving ||
+				_delete.isResolving;
 			const hasResolved =
-				create.hasResolved && update.hasResolved && _delete.hasResolved;
+				read.hasResolved &&
+				create.hasResolved &&
+				update.hasResolved &&
+				_delete.hasResolved;
 
 			let status = Status.Idle;
 			if ( isResolving ) {

--- a/packages/core-data/src/hooks/use-resource-permissions.ts
+++ b/packages/core-data/src/hooks/use-resource-permissions.ts
@@ -116,14 +116,27 @@ export default function useResourcePermissions< IdType = void >(
 			const { canUser } = resolve( coreStore );
 			const create = canUser( 'create', resource );
 			if ( ! id ) {
+				const read = canUser( 'read', resource );
+
+				const isResolving = create.isResolving || read.isResolving;
+				const hasResolved = create.hasResolved && read.hasResolved;
+				let status = Status.Idle;
+				if ( isResolving ) {
+					status = Status.Resolving;
+				} else if ( hasResolved ) {
+					status = Status.Success;
+				}
+
 				return {
-					status: create.status,
-					isResolving: create.isResolving,
-					hasResolved: create.hasResolved,
+					status,
+					isResolving,
+					hasResolved,
 					canCreate: create.hasResolved && create.data,
+					canRead: read.hasResolved && read.data,
 				};
 			}
 
+			const read = canUser( 'read', resource, id );
 			const update = canUser( 'update', resource, id );
 			const _delete = canUser( 'delete', resource, id );
 			const isResolving =
@@ -141,6 +154,7 @@ export default function useResourcePermissions< IdType = void >(
 				status,
 				isResolving,
 				hasResolved,
+				canRead: hasResolved && read.data,
 				canCreate: hasResolved && create.data,
 				canUpdate: hasResolved && update.data,
 				canDelete: hasResolved && _delete.data,
@@ -152,7 +166,7 @@ export default function useResourcePermissions< IdType = void >(
 
 export function __experimentalUseResourcePermissions(
 	resource: string,
-	id?: IdType
+	id?: unknown
 ) {
 	deprecated( `wp.data.__experimentalUseResourcePermissions`, {
 		alternative: 'wp.data.useResourcePermissions',


### PR DESCRIPTION
## What?

Adds `canRead` property to the `useResourcePermissions` hook. WordPress permissions involve `create`, `update`, `delete`, and `read` actions, and that last one was missing.

## Testing Instructions
Confirm the tests are green

cc @gziolo @Mamaduka 