### PR TITLE
Prevent the default browser behaviour for dropped files from running 

### DIFF
--- a/packages/block-editor/src/components/iframe/index.js
+++ b/packages/block-editor/src/components/iframe/index.js
@@ -201,9 +201,15 @@ function Iframe(
 	const [ contentResizeListener, { height: contentHeight } ] =
 		useResizeObserver();
 	const setRef = useRefEffect( ( node ) => {
+		let iFrameDocument;
+		// Prevent the default browser action for files dropped outside of dropzones.
+		function preventFileDropDefault( event ) {
+			event.preventDefault();
+		}
 		function setDocumentIfReady() {
 			const { contentDocument, ownerDocument } = node;
 			const { readyState, documentElement } = contentDocument;
+			iFrameDocument = contentDocument;
 
 			if ( readyState !== 'interactive' && readyState !== 'complete' ) {
 				return false;
@@ -228,13 +234,33 @@ function Iframe(
 			contentDocument.dir = ownerDocument.dir;
 			documentElement.removeChild( contentDocument.head );
 			documentElement.removeChild( contentDocument.body );
+			contentDocument.addEventListener(
+				'dragover',
+				preventFileDropDefault,
+				false
+			);
+			contentDocument.addEventListener(
+				'drop',
+				preventFileDropDefault,
+				false
+			);
 			return true;
 		}
 
 		// Document set with srcDoc is not immediately ready.
 		node.addEventListener( 'load', setDocumentIfReady );
 
-		return () => node.removeEventListener( 'load', setDocumentIfReady );
+		return () => {
+			node.removeEventListener( 'load', setDocumentIfReady );
+			iFrameDocument?.removeEventListener(
+				'dragover',
+				preventFileDropDefault
+			);
+			iFrameDocument?.removeEventListener(
+				'drop',
+				preventFileDropDefault
+			);
+		};
 	}, [] );
 
 	const headRef = useRefEffect( ( element ) => {

--- a/packages/block-editor/src/components/iframe/index.js
+++ b/packages/block-editor/src/components/iframe/index.js
@@ -234,12 +234,13 @@ function Iframe(
 			contentDocument.dir = ownerDocument.dir;
 			documentElement.removeChild( contentDocument.head );
 			documentElement.removeChild( contentDocument.body );
-			contentDocument.addEventListener(
+
+			iFrameDocument.addEventListener(
 				'dragover',
 				preventFileDropDefault,
 				false
 			);
-			contentDocument.addEventListener(
+			iFrameDocument.addEventListener(
 				'drop',
 				preventFileDropDefault,
 				false

--- a/packages/edit-post/src/index.js
+++ b/packages/edit-post/src/index.js
@@ -177,6 +177,10 @@ export function initializeEditor(
 		} );
 	}
 
+	// Prevent the default browser action for files dropped outside of dropzones.
+	window.addEventListener( 'dragover', ( e ) => e.preventDefault(), false );
+	window.addEventListener( 'drop', ( e ) => e.preventDefault(), false );
+
 	render(
 		<Editor
 			settings={ settings }

--- a/packages/edit-site/src/index.js
+++ b/packages/edit-site/src/index.js
@@ -107,6 +107,10 @@ export function reinitializeEditor( target, settings ) {
 		}
 	}
 
+	// Prevent the default browser action for files dropped outside of dropzones.
+	window.addEventListener( 'dragover', ( e ) => e.preventDefault(), false );
+	window.addEventListener( 'drop', ( e ) => e.preventDefault(), false );
+
 	render( <EditSiteApp reboot={ reboot } />, target );
 }
 


### PR DESCRIPTION
## What?
Prevents the default browse actions from running (usually opens file in a new window) if a file is dropped outside of editor dropzones.

As a follow-on to this it would be good to extend the existing dropzones within the canvas so dropping creates blocks in a wider range of areas, and this prevention of the behaviour only kicks in when dropped in obvious error spots like the top toolbar.

## Why?
It is unlikely that a user will ever be expecting a file dropped in the editor window to open that file in a new tab, and doing so is disruptive to the editing workflow.

## How?
Adds drop and dragover event listeners to the window to prevent the default action on these events that bubble up past valid drop zones.

## Testing Instructions

- Open the post editor
- Try dragging and dropping files outside of the normal dropzones and make sure the files are not opened in new tab
- Try dragging and dropping files into the normal editor dropzones and make sure it works as expected

## Screenshots or screencast 

Before:

https://user-images.githubusercontent.com/3629020/186032864-59068c0e-e35f-4006-afb6-3cb698da6c13.mp4

After:

https://user-images.githubusercontent.com/3629020/186032892-ac2d6ad2-2093-4a17-8104-da08096640ca.mp4



