### PR TITLE
Block list: update block list view preferences name for consistency

### DIFF
--- a/packages/edit-site/src/index.js
+++ b/packages/edit-site/src/index.js
@@ -65,7 +65,7 @@ export function reinitializeEditor( target, settings ) {
 			keepCaretInsideBlock: false,
 			welcomeGuide: true,
 			welcomeGuideStyles: true,
-			shouldListViewOpenByDefault: false,
+			showListViewByDefault: false,
 		} );
 
 		// Check if the block list view should be open by default.


### PR DESCRIPTION
## What?

Follow up on https://github.com/WordPress/gutenberg/pull/40757

Whoops, it looks like the preferences variable name was wrong in the defaults list for the site editor.

It was supposed to be `showListViewByDefault`, not `shouldListViewOpenByDefault`.

## Why?
There were no repercussions because it was off by default, but let's make things consistent.

## How?
With a keyboard and a cup of tea.

## Testing Instructions

- Run `localStorage.clear()` in your browser console.
- Open up the site editor. Notice the block list sidebar is not open by default.
- Open the preferences modal and turn on Always open list view
- Refresh page.
- Wait a bit.
- Check that the block list sidebar is open.

