### PR TITLE
Post Comments Count: Prevent text-decoration from affecting warning

### DIFF
--- a/packages/block-library/src/post-comments-count/edit.js
+++ b/packages/block-library/src/post-comments-count/edit.js
@@ -17,18 +17,6 @@ import apiFetch from '@wordpress/api-fetch';
 import { addQueryArgs } from '@wordpress/url';
 import { __ } from '@wordpress/i18n';
 
-const NoCommentsWarning = ( { style, ...props } ) => {
-	// Text decoration is stripped as it can't be reset as per other styles.
-	const { textDecoration, ...blockStyles } = style || {};
-	return (
-		<div { ...props } style={ blockStyles }>
-			<Warning>
-				{ __( 'Post Comments Count block: post not found.' ) }
-			</Warning>
-		</div>
-	);
-};
-
 export default function PostCommentsCountEdit( {
 	attributes,
 	context,
@@ -61,6 +49,14 @@ export default function PostCommentsCountEdit( {
 		} );
 	}, [ postId ] );
 
+	const hasPostAndComments = postId && commentsCount !== undefined;
+	const blockStyles = {
+		...blockProps.style,
+		textDecoration: hasPostAndComments
+			? blockProps.style?.textDecoration
+			: undefined,
+	};
+
 	return (
 		<>
 			<BlockControls group="block">
@@ -71,11 +67,15 @@ export default function PostCommentsCountEdit( {
 					} }
 				/>
 			</BlockControls>
-			{ postId && commentsCount !== undefined ? (
-				<div { ...blockProps }>{ commentsCount }</div>
-			) : (
-				<NoCommentsWarning { ...blockProps } />
-			) }
+			<div { ...blockProps } style={ blockStyles }>
+				{ hasPostAndComments ? (
+					commentsCount
+				) : (
+					<Warning>
+						{ __( 'Post Comments Count block: post not found.' ) }
+					</Warning>
+				) }
+			</div>
 		</>
 	);
 }

--- a/packages/block-library/src/post-comments-count/edit.js
+++ b/packages/block-library/src/post-comments-count/edit.js
@@ -17,6 +17,18 @@ import apiFetch from '@wordpress/api-fetch';
 import { addQueryArgs } from '@wordpress/url';
 import { __ } from '@wordpress/i18n';
 
+const NoCommentsWarning = ( { style, ...props } ) => {
+	// Text decoration is stripped as it can't be reset as per other styles.
+	const { textDecoration, ...blockStyles } = style || {};
+	return (
+		<div { ...props } style={ blockStyles }>
+			<Warning>
+				{ __( 'Post Comments Count block: post not found.' ) }
+			</Warning>
+		</div>
+	);
+};
+
 export default function PostCommentsCountEdit( {
 	attributes,
 	context,
@@ -59,15 +71,11 @@ export default function PostCommentsCountEdit( {
 					} }
 				/>
 			</BlockControls>
-			<div { ...blockProps }>
-				{ postId && commentsCount !== undefined ? (
-					commentsCount
-				) : (
-					<Warning>
-						{ __( 'Post Comments Count block: post not found.' ) }
-					</Warning>
-				) }
-			</div>
+			{ postId && commentsCount !== undefined ? (
+				<div { ...blockProps }>{ commentsCount }</div>
+			) : (
+				<NoCommentsWarning { ...blockProps } />
+			) }
 		</>
 	);
 }


### PR DESCRIPTION
Related:
- https://github.com/WordPress/gutenberg/pull/43321

## What?

Prevents `text-decoration` support styles from being applied to the block's warning.

## Why?

Text decoration is rendered differently than other typographic styles and can't be reset via CSS once applied to a parent.

## How?

Given the warning is only displayed in the editor while the block is rendered outside a post context, we can avoid applying the text decoration to the block's wrapper when it contains the warning.

## Testing Instructions

1. Open the site editor and add a Post Comments Block outside of a post context e.g. between the header and query loop on home page template.
2. Select the Post Comments Block and toggle on the text decoration control from the typography panel in the sidebar.
3. Try both decoration options ensuring that neither are applied to the text within the block's warning.
4. Move the block within a post context e.g. within the Post Template of a Query Loop. Or, alternatively, create a second block.
5. Confirm that the text-decoration is applied to the comments count
6. Check the text-decoration style matches on the frontend.

## Screenshots or screencast <!-- if applicable -->


| Before | After |
|---|---|
| <video src="https://user-images.githubusercontent.com/60436221/186070598-13257f01-e074-4e59-bd1c-d18849e72a6e.mp4" /> | <video src="https://user-images.githubusercontent.com/60436221/186077537-45cb337c-1353-4679-88e4-692f4cec4d5c.mp4" /> |





