### PR TITLE
Group block: update description to remove "layout" 

### DIFF
--- a/packages/block-library/src/group/variations.js
+++ b/packages/block-library/src/group/variations.js
@@ -8,7 +8,7 @@ const variations = [
 	{
 		name: 'group',
 		title: __( 'Group' ),
-		description: __( 'Gather blocks in a layout container.' ),
+		description: __( 'Gather blocks in a container.' ),
 		attributes: { layout: { type: 'constrained' } },
 		scope: [ 'transform' ],
 		isActive: ( blockAttributes ) =>


### PR DESCRIPTION
Resolves: https://github.com/WordPress/gutenberg/issues/41640


## What how and why?
Remove tautological reference to layout.


## Testing Instructions

1. Insert a group block.
2. Check the description.
3. It should be **"Gather blocks in a container."**

## Screenshots or screencast <!-- if applicable -->


| Before | After |
| ------------- | ------------- |
| <img width="281" alt="Screen Shot 2022-08-23 at 2 41 58 pm" src="https://user-images.githubusercontent.com/6458278/186071549-4ebc6fb1-74ba-46e2-8529-4429e19fd3a3.png">  | <img width="282" alt="Screen Shot 2022-08-23 at 2 43 04 pm" src="https://user-images.githubusercontent.com/6458278/186071541-79302b9c-ddcf-4546-979c-89e9a786d8d3.png">  |

