### PR TITLE
Layout: Re-instate alignwide and alignfull in flow layout get alignments

### DIFF
--- a/packages/block-editor/src/layouts/flow.js
+++ b/packages/block-editor/src/layouts/flow.js
@@ -65,12 +65,21 @@ export default {
 				info: alignmentInfo[ alignment ],
 			} ) );
 		}
+		const { contentSize, wideSize } = layout;
 
 		const alignments = [
 			{ name: 'left' },
 			{ name: 'center' },
 			{ name: 'right' },
 		];
+
+		if ( contentSize ) {
+			alignments.unshift( { name: 'full' } );
+		}
+
+		if ( wideSize ) {
+			alignments.unshift( { name: 'wide', info: alignmentInfo.wide } );
+		}
 
 		alignments.unshift( { name: 'none', info: alignmentInfo.none } );
 


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Try re-instating wide and full alignments in `getAlignments` in the `flow` layout if contentSize or wideSize is present in the layout object.

Existing blocks that already have `contentSize` or `wideSize` set in the layout object appear to still need to have this logic in place in order to be able to correctly render out the `alignwide` or `alignfull` classname within the site editor.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

This resolves an issue with the Post Template block not rendering the wide width in existing templates in the site editor, where that block is rendering correctly on the site's frontend.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

Re-instate a few of the lines removed in https://github.com/WordPress/gutenberg/pull/42763. This should hopefully fix the issue without unintentionally exposing wide / full controls where we don't expect them.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->

Use the following block markup at the root level in the site editor:

<details>

<summary>Test markup</summary>

```html
<!-- wp:query {"queryId":0,"query":{"perPage":10,"pages":0,"offset":0,"postType":"post","order":"desc","orderBy":"date","author":"","search":"","exclude":[],"sticky":"","inherit":true},"tagName":"main","displayLayout":{"type":"list"},"layout":{"inherit":true}} -->
<main class="wp-block-query"><!-- wp:post-template {"align":"wide"} -->
<!-- wp:group {"layout":{"type":"constrained"}} -->
<div class="wp-block-group"><!-- wp:post-title {"isLink":true,"align":"wide","fontSize":"var(\u002d\u002dwp\u002d\u002dcustom\u002d\u002dtypography\u002d\u002dfont-size\u002d\u002dhuge, clamp(2.25rem, 4vw, 2.75rem))"} /-->

<!-- wp:post-featured-image {"isLink":true,"align":"wide","style":{"spacing":{"margin":{"top":"calc(1.75 * var(\u002d\u002dwp\u002d\u002dstyle\u002d\u002dblock-gap))"}}}} /-->

<!-- wp:post-comments-count {"style":{"typography":{"fontStyle":"italic","fontWeight":"900","lineHeight":2.9,"textDecoration":"line-through","textTransform":"uppercase","letterSpacing":"13px"}},"fontSize":"large","fontFamily":"source-serif-pro"} /-->

<!-- wp:columns {"align":"wide"} -->
<div class="wp-block-columns alignwide"><!-- wp:column {"width":"650px"} -->
<div class="wp-block-column" style="flex-basis:650px"><!-- wp:post-excerpt /-->

<!-- wp:post-date {"format":"F j, Y","isLink":true,"style":{"typography":{"fontStyle":"italic","fontWeight":"400"}},"fontSize":"small"} /--></div>
<!-- /wp:column -->

<!-- wp:column {"width":""} -->
<div class="wp-block-column"></div>
<!-- /wp:column --></div>
<!-- /wp:columns -->

<!-- wp:spacer {"height":"112px"} -->
<div style="height:112px" aria-hidden="true" class="wp-block-spacer"></div>
<!-- /wp:spacer --></div>
<!-- /wp:group -->
<!-- /wp:post-template -->

<!-- wp:query-pagination {"paginationArrow":"arrow","align":"wide","layout":{"type":"flex","justifyContent":"space-between"}} -->
<!-- wp:query-pagination-previous {"fontSize":"small"} /-->

<!-- wp:query-pagination-numbers /-->

<!-- wp:query-pagination-next {"fontSize":"small"} /-->
<!-- /wp:query-pagination --></main>
<!-- /wp:query -->
```

</details>

With this markup applied, observe how prior to this PR, the contents of the Query loop are rendered in the limited width of `contentSize` as opposed to wide width. However, on the site's frontend, the `alignwide` classname is applied to the post template's `ul` element.

With this PR applied, it should be rendered in wide width. If you inspect the markup in the site editor, the `ul` element should now have the `alignwide` classname.

## Screenshots or screencast <!-- if applicable -->

| Before | After |
| --- | --- |
| ![image](https://user-images.githubusercontent.com/14988353/186092097-de707cae-9e6e-4b86-bed7-6eaa6e4895e2.png) | ![image](https://user-images.githubusercontent.com/14988353/186092266-7fbe711f-75d2-4c58-b1e7-7725155b6602.png) |
