### PR TITLE
Post Terms: Refactor the usePostTerms hook

### DIFF
--- a/packages/block-library/src/post-terms/edit.js
+++ b/packages/block-library/src/post-terms/edit.js
@@ -58,7 +58,6 @@ export default function PostTermsEdit( {
 	);
 	const { postTerms, hasPostTerms, isLoading } = usePostTerms( {
 		postId,
-		postType,
 		term: selectedTerm,
 	} );
 	const hasPost = postId && postType;

--- a/packages/block-library/src/post-terms/use-post-terms.js
+++ b/packages/block-library/src/post-terms/use-post-terms.js
@@ -1,12 +1,12 @@
 /**
  * WordPress dependencies
  */
-import { useEntityProp, store as coreStore } from '@wordpress/core-data';
+import { store as coreStore } from '@wordpress/core-data';
 import { useSelect } from '@wordpress/data';
 
-export default function usePostTerms( { postId, postType, term } ) {
-	const { rest_base: restBase, slug } = term;
-	const [ termIds ] = useEntityProp( 'postType', postType, restBase, postId );
+export default function usePostTerms( { postId, term } ) {
+	const { slug } = term;
+
 	return useSelect(
 		( select ) => {
 			const visible = term?.visibility?.publicly_queryable;
@@ -17,31 +17,25 @@ export default function usePostTerms( { postId, postType, term } ) {
 					hasPostTerms: false,
 				};
 			}
-			if ( ! termIds ) {
-				// Waiting for post terms to be fetched.
-				return { isLoading: term?.postTerms?.includes( postType ) };
-			}
-			if ( ! termIds.length ) {
-				return { isLoading: false };
-			}
+
 			const { getEntityRecords, isResolving } = select( coreStore );
 			const taxonomyArgs = [
 				'taxonomy',
 				slug,
 				{
-					include: termIds,
+					post: postId,
 					per_page: -1,
 					context: 'view',
 				},
 			];
 			const terms = getEntityRecords( ...taxonomyArgs );
-			const _isLoading = isResolving( 'getEntityRecords', taxonomyArgs );
+
 			return {
 				postTerms: terms,
-				isLoading: _isLoading,
+				isLoading: isResolving( 'getEntityRecords', taxonomyArgs ),
 				hasPostTerms: !! terms?.length,
 			};
 		},
-		[ termIds, term?.visibility?.publicly_queryable ]
+		[ postId, term?.visibility?.publicly_queryable ]
 	);
 }


### PR DESCRIPTION
## What?
PR refactors the `usePostTerms` hook to use [`post` query argument](https://developer.wordpress.org/rest-api/reference/tags/#arguments) for fetching terms assigned to the post.

A minor downside: Since terms are actually assigned after post save, if a block is used in the post editor and terms are assigned via the Document sidebar, they aren't immediately visible in the block.

I don't consider this to be a big issue in this case since the block is meant to be used by templates.

## Testing Instructions
The block should work as before.
