### PR TITLE
Cover: Prevent typography support styles from affecting placeholder

### DIFF
--- a/packages/block-library/src/cover/edit/index.js
+++ b/packages/block-library/src/cover/edit/index.js
@@ -246,6 +246,17 @@ function CoverEdit( {
 	);
 
 	if ( ! useFeaturedImage && ! hasInnerBlocks && ! hasBackground ) {
+		const {
+			textDecoration,
+			textTransform,
+			fontSize,
+			fontWeight,
+			fontStyle,
+			lineHeight,
+			letterSpacing,
+			...styles
+		} = blockProps.style;
+
 		return (
 			<>
 				{ blockControls }
@@ -256,6 +267,7 @@ function CoverEdit( {
 						'is-placeholder',
 						blockProps.className
 					) }
+					style={ styles }
 				>
 					<CoverPlaceholder
 						onSelectMedia={ onSelectMedia }

--- a/packages/components/src/placeholder/style.scss
+++ b/packages/components/src/placeholder/style.scss
@@ -2,7 +2,7 @@
 .components-placeholder.components-placeholder {
 	box-sizing: border-box;
 	position: relative;
-	padding: 1em;
+	padding: $grid-unit-20;
 	min-height: 200px;
 	width: 100%;
 	text-align: left;


### PR DESCRIPTION
Follow up to: 
- https://github.com/WordPress/gutenberg/pull/43298

## What?

Prevents typography support styles from applying to the Cover block's placeholder.

## Why?

Styling the placeholder's text doesn't really provide any insight to the user as to what their block would look like. It primarily just gets in the way and looks broken.

## How?

- Strips typography support styles before applying them to the block's wrapper element around its primary placeholder.
- Switches placeholder padding to be `px` instead of `em` to avoid font size increasing the padding.

## Todo

- [ ] Find a solution to theme.json and global styles affecting placeholder
- [ ] Find better option than switching placeholder padding from `em` to `px`
- [ ] Maybe explore skipping serialization for typography styles and apply them manually to the block as needed but on the same element (block's root). Then also use feature level selectors so that the theme.json/global styles will not apply when `is-placeholder` is present.

## Alternative Approaches Considered

##### Resetting typographic styles for the placeholder via CSS.

This would work, except that text decoration is rendered differently and can't effectively be reset once it has been applied to a parent. If we have to exclude text decoration styles manually, we might as well strip the others from ever being applied on the block as well.

## Testing Instructions

TBA.

## Screenshots or screencast <!-- if applicable -->

TBA.