### PR TITLE
Fix playwright's `openDocumentSettingsSidebar` util not opening the sidebar

### DIFF
--- a/packages/e2e-test-utils-playwright/src/editor/open-document-settings-sidebar.ts
+++ b/packages/e2e-test-utils-playwright/src/editor/open-document-settings-sidebar.ts
@@ -2,7 +2,7 @@
  * Internal dependencies
  */
 import type { Editor } from './index';
-const { expect } = require( '../test' );
+import { expect } from '../test';
 
 /**
  * Clicks on the button in the header which opens Document Settings sidebar when it is closed.
@@ -10,15 +10,21 @@ const { expect } = require( '../test' );
  * @param {Editor} this
  */
 export async function openDocumentSettingsSidebar( this: Editor ) {
-	const editorSettings = this.page.locator(
-		'role=region[name="Editor settings"i]'
+	const editorSettingsButton = this.page.locator(
+		'role=region[name="Editor top bar"i] >> role=button[name="Settings"i]'
 	);
 
-	if ( ! ( await editorSettings.isVisible() ) ) {
-		await this.page.click(
-			'role=region[name="Editor top bar"i] >> role=button[name="Settings"i]'
-		);
+	const isEditorSettingsOpened =
+		( await editorSettingsButton.getAttribute( 'aria-expanded' ) ) ===
+		'true';
 
-		await expect( editorSettings ).toBeVisible();
+	if ( ! isEditorSettingsOpened ) {
+		await editorSettingsButton.click();
+
+		await expect(
+			this.page.locator(
+				'role=region[name="Editor settings"i] >> role=button[name^="Close settings"i]'
+			)
+		).toBeVisible();
 	}
 }


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->
Fix `openDocumentSettingsSidebar` util not opening the sidebar.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
Hopefully fixes https://github.com/WordPress/gutenberg/issues/34832.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
The original implementation relies on `toBeVisible()` of the `role=region[name="Editor settings"i]` selector. But it'll always return `true` even if the settings panel isn't opened.

This PR changes the implementation to look for `aria-expanded` instead.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->
CI should pass.

