### PR TITLE
Unskip navigation menu selector focus test

### DIFF
--- a/packages/e2e-tests/specs/editor/blocks/navigation.test.js
+++ b/packages/e2e-tests/specs/editor/blocks/navigation.test.js
@@ -1681,10 +1681,7 @@ Expected mock function not to be called but it was called with: ["POST", "http:/
 			);
 		} );
 
-		// Skip reason: running it in interactive works but selecting and
-		// checking for focus consistently fails in the test.
-		// eslint-disable-next-line jest/no-disabled-tests
-		it.skip( 'should always focus select menu button after item selection', async () => {
+		it( 'should always focus select menu button after item selection', async () => {
 			// Create some navigation menus to work with.
 			await createNavigationMenu( {
 				title: 'First navigation',
@@ -1712,7 +1709,7 @@ Expected mock function not to be called but it was called with: ["POST", "http:/
 			const theOption = await page.waitForXPath(
 				"//button[@aria-checked='false'][contains(., 'First navigation')]"
 			);
-			theOption.click();
+			await theOption.click();
 
 			// Once the options are closed, does select menu button receive focus?
 			const selectMenuDropdown2 = await page.$(


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

#42735 introduced a skipped test which should not be skipped, it was part of debugging the big refactor of the navigation test suite.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

The test should not be skipped.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

Unskip it.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->

## Screenshots or screencast <!-- if applicable -->
