### PR TITLE
`Disabled`: preserve input values when toggling the `isDisabled` prop

### DIFF
--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -49,7 +49,7 @@
 -   `Popover`: make sure offset middleware always applies the latest frame offset values ([#43329](https://github.com/WordPress/gutenberg/pull/43329/)).
 -   `Dropdown`: anchor popover to the dropdown wrapper (instead of the toggle) ([#43377](https://github.com/WordPress/gutenberg/pull/43377/)).
 -   `Guide`: Fix error when rendering with no pages ([#43380](https://github.com/WordPress/gutenberg/pull/43380/)).
--   `Disabled`: Fixed so that the internal value remains when isDisabled is changed ([#43508](https://github.com/WordPress/gutenberg/pull/43508/))
+-   `Disabled`: preserve input values when toggling the `isDisabled` prop ([#43508](https://github.com/WordPress/gutenberg/pull/43508/))
 
 ### Enhancements
 

--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -49,6 +49,7 @@
 -   `Popover`: make sure offset middleware always applies the latest frame offset values ([#43329](https://github.com/WordPress/gutenberg/pull/43329/)).
 -   `Dropdown`: anchor popover to the dropdown wrapper (instead of the toggle) ([#43377](https://github.com/WordPress/gutenberg/pull/43377/)).
 -   `Guide`: Fix error when rendering with no pages ([#43380](https://github.com/WordPress/gutenberg/pull/43380/)).
+-   `Disabled`: Fixed so that the internal value remains when isDisabled is changed ([#43508](https://github.com/WordPress/gutenberg/pull/43508/))
 
 ### Enhancements
 

--- a/packages/components/src/disabled/index.tsx
+++ b/packages/components/src/disabled/index.tsx
@@ -1,9 +1,4 @@
 /**
- * External dependencies
- */
-import classnames from 'classnames';
-
-/**
  * WordPress dependencies
  */
 import { useDisabled } from '@wordpress/compose';
@@ -12,9 +7,10 @@ import { createContext } from '@wordpress/element';
 /**
  * Internal dependencies
  */
-import { StyledWrapper } from './styles/disabled-styles';
+import { disabledStyles } from './styles/disabled-styles';
 import type { DisabledProps } from './types';
 import type { WordPressComponentProps } from '../ui/context';
+import { useCx } from '../utils';
 
 const Context = createContext< boolean >( false );
 const { Consumer, Provider } = Context;
@@ -56,20 +52,28 @@ function Disabled( {
 	...props
 }: WordPressComponentProps< DisabledProps, 'div' > ) {
 	const ref = useDisabled();
-
+	const cx = useCx();
 	if ( ! isDisabled ) {
-		return <Provider value={ false }>{ children }</Provider>;
+		return (
+			<Provider value={ false }>
+				<div>{ children }</div>
+			</Provider>
+		);
 	}
 
 	return (
 		<Provider value={ true }>
-			<StyledWrapper
+			<div
 				ref={ ref }
-				className={ classnames( className, 'components-disabled' ) }
+				className={ cx(
+					disabledStyles,
+					className,
+					'components-disabled'
+				) }
 				{ ...props }
 			>
 				{ children }
-			</StyledWrapper>
+			</div>
 		</Provider>
 	);
 }

--- a/packages/components/src/disabled/index.tsx
+++ b/packages/components/src/disabled/index.tsx
@@ -1,8 +1,13 @@
 /**
+ * External dependencies
+ */
+import type { HTMLProps } from 'react';
+
+/**
  * WordPress dependencies
  */
 import { useDisabled } from '@wordpress/compose';
-import { createContext } from '@wordpress/element';
+import { createContext, forwardRef } from '@wordpress/element';
 
 /**
  * Internal dependencies
@@ -14,6 +19,15 @@ import { useCx } from '../utils';
 
 const Context = createContext< boolean >( false );
 const { Consumer, Provider } = Context;
+
+// Extracting this ContentWrapper component in order to make it more explicit
+// the same 'ContentWrapper' component is needed so that React can reconcile
+// the dom correctly when switching between disabled/non-disabled (instead
+// of thrashing the previous DOM and therefore losing the form fields values).
+const ContentWrapper = forwardRef<
+	HTMLDivElement,
+	HTMLProps< HTMLDivElement >
+>( ( props, ref ) => <div { ...props } ref={ ref } /> );
 
 /**
  * `Disabled` is a component which disables descendant tabbable elements and prevents pointer interaction.
@@ -56,14 +70,14 @@ function Disabled( {
 	if ( ! isDisabled ) {
 		return (
 			<Provider value={ false }>
-				<div>{ children }</div>
+				<ContentWrapper>{ children }</ContentWrapper>
 			</Provider>
 		);
 	}
 
 	return (
 		<Provider value={ true }>
-			<div
+			<ContentWrapper
 				ref={ ref }
 				className={ cx(
 					disabledStyles,
@@ -73,7 +87,7 @@ function Disabled( {
 				{ ...props }
 			>
 				{ children }
-			</div>
+			</ContentWrapper>
 		</Provider>
 	);
 }

--- a/packages/components/src/disabled/styles/disabled-styles.tsx
+++ b/packages/components/src/disabled/styles/disabled-styles.tsx
@@ -1,9 +1,9 @@
 /**
  * External dependencies
  */
-import styled from '@emotion/styled';
+import { css } from '@emotion/react';
 
-export const StyledWrapper = styled.div`
+export const disabledStyles = css`
 	position: relative;
 	pointer-events: none;
 

--- a/packages/components/src/disabled/test/index.tsx
+++ b/packages/components/src/disabled/test/index.tsx
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { render, screen, waitFor, fireEvent } from '@testing-library/react';
+import { render, screen, waitFor } from '@testing-library/react';
 
 /**
  * Internal dependencies
@@ -146,32 +146,30 @@ describe( 'Disabled', () => {
 			</Disabled>
 		);
 
+		const getInput = () => screen.getByRole( 'textbox' );
+		const getContentEditable = () => screen.getByTitle( 'edit my content' );
+
 		const { rerender } = render( <MaybeDisable isDisabled={ false } /> );
 
-		const getInputValue = () =>
-			screen.getByRole< HTMLInputElement >( 'textbox' ).value;
+		await user.type( getInput(), 'This is input.' );
+		expect( getInput() ).toHaveValue( 'This is input.' );
 
-		const getContentEditableValue = () =>
-			screen.getByTitle( 'edit my content' ).textContent;
-
-		const input = screen.getByRole< HTMLInputElement >( 'textbox' );
-		fireEvent.change( input, { target: { value: 'This is input.' } } );
-		expect( input.value ).toBe( 'This is input.' );
-
-		const contentEditable = screen.getByTitle( 'edit my content' );
-		await user.click( contentEditable );
-		await user.keyboard( 'This is contentEditable.' );
-		expect( contentEditable.textContent ).toBe(
+		await user.type( getContentEditable(), 'This is contentEditable.' );
+		expect( getContentEditable() ).toHaveTextContent(
 			'This is contentEditable.'
 		);
 
 		rerender( <MaybeDisable isDisabled={ true } /> );
-		expect( getInputValue() ).toBe( 'This is input.' );
-		expect( getContentEditableValue() ).toBe( 'This is contentEditable.' );
+		expect( getInput() ).toHaveValue( 'This is input.' );
+		expect( getContentEditable() ).toHaveTextContent(
+			'This is contentEditable.'
+		);
 
 		rerender( <MaybeDisable isDisabled={ false } /> );
-		expect( getInputValue() ).toBe( 'This is input.' );
-		expect( getContentEditableValue() ).toBe( 'This is contentEditable.' );
+		expect( getInput() ).toHaveValue( 'This is input.' );
+		expect( getContentEditable() ).toHaveTextContent(
+			'This is contentEditable.'
+		);
 	} );
 
 	describe( 'Consumer', () => {


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->
There is a bug in the `Disabled` component where changing `isDisabled` resets the form value. This has been fixed.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

https://github.com/WordPress/gutenberg/pull/42708#pullrequestreview-1078596447


## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

## Testing Instructions

1. `npm run storybook:dev`
1. Go to localhost:50240?path=/story/components-disabled--default
1. Change `isDisabled` prop to `false` in controls.
1. Change text box or select.
1. Change `isDisabled` prop to `true` in controls.

## Screenshots or screencast <!-- if applicable -->

https://user-images.githubusercontent.com/1908815/186121476-d5e32793-671c-4aca-8df3-c4cf31131622.mov


