### PR TITLE
Table of Contents: Add typography support

### DIFF
--- a/docs/reference-guides/core-blocks.md
+++ b/docs/reference-guides/core-blocks.md
@@ -788,7 +788,7 @@ Summarize your post with a list of headings. Add HTML anchors to Heading blocks 
 
 -	**Name:** core/table-of-contents
 -	**Category:** layout
--	**Supports:** color (background, gradients, link, text), spacing (margin, padding), ~~html~~
+-	**Supports:** color (background, gradients, link, text), spacing (margin, padding), typography (fontSize, lineHeight), ~~html~~
 -	**Attributes:** headings, onlyIncludeCurrentPage
 
 ## Tag Cloud

--- a/packages/block-library/src/table-of-contents/block.json
+++ b/packages/block-library/src/table-of-contents/block.json
@@ -31,6 +31,19 @@
 		"spacing": {
 			"margin": true,
 			"padding": true
+		},
+		"typography": {
+			"fontSize": true,
+			"lineHeight": true,
+			"__experimentalFontFamily": true,
+			"__experimentalFontWeight": true,
+			"__experimentalFontStyle": true,
+			"__experimentalTextTransform": true,
+			"__experimentalTextDecoration": true,
+			"__experimentalLetterSpacing": true,
+			"__experimentalDefaultControls": {
+				"fontSize": true
+			}
 		}
 	},
 	"example": {}


### PR DESCRIPTION
Related:
- https://github.com/WordPress/gutenberg/issues/43241
- https://github.com/WordPress/gutenberg/issues/43242

## What?

Adds typography supports to the Table of Contents block.

## Why?

- Improves consistency of our design tools across blocks.

## How?

- Opts into all typography supports.
- Makes font size control displayed by default as per majority of blocks currently.

## Testing Instructions

1. Edit a post, add a Table of Contents block along with several headings of varied levels.
2. Select the Table of Contents block and adjust its typography via the sidebar.
3. Ensure the selected styles are reflected in both the editor and frontend.
4. Reset the blocks styles and save.
4. Load the site editor and navigate to Global Styles > Blocks > Table of Contents > Typography.
5. Double check that adjusted typography settings are reflected in the preview and are applied on frontend after saving.
6. Confirm that theme.json styling of the Table of Contents works as expected.

Example theme.json snippet:
```json
			"core/table-of-contents": {
				"typography": {
					"fontWeight": "100",
					"textTransform": "uppercase"
				}
			}
```

## Screenshots or screencast <!-- if applicable -->


https://user-images.githubusercontent.com/60436221/186122868-742bd141-bb8e-45fb-9d45-89b2e708a4f5.mp4


