### PR TITLE
Multi-select: Add transition to reduce chance of flash.

### DIFF
--- a/packages/block-editor/src/components/block-list/style.scss
+++ b/packages/block-editor/src/components/block-list/style.scss
@@ -192,7 +192,9 @@
 		bottom: 0;
 		left: 0;
 		border-radius: $radius-block-ui;
-		box-shadow: 0 0 0 var(--wp-admin-border-width-focus) transparent;
+		box-shadow: 0 0 0 0 transparent;
+		transition: box-shadow 0.1s linear;
+		@include reduce-motion("transition");
 	}
 
 	// Warnings


### PR DESCRIPTION
## What?

While working on #43313, I realized that as you are making a text-selection between two paragraphs, in the very brief time when the cursor is between the two paragraphs, the blue multi-select style flashes in:

![before](https://user-images.githubusercontent.com/1204802/186135811-20332b22-a248-405a-9623-81700a364f17.gif)

This happens because in the space between those two blocks, one block is _selected_ but not yet _partially selected_, which invokes the blue line.

By adding a small transition, we effectively eliminate this flash:

![after](https://user-images.githubusercontent.com/1204802/186136029-99e072b5-ba90-4463-9c92-80c915dfc432.gif)

## Why?

For basic text editing this makes for a clearer experience.

## Testing Instructions

Please test partial selections between text, as well as multi selections between random blocks. Outside of the .1s transition, the behavior should be the same.