### PR TITLE
Packages: Replace `is-plain-obj` with `is-plain-object`

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -28961,6 +28961,16 @@
 				"is-plain-object": "^2.0.4",
 				"kind-of": "^6.0.2",
 				"shallow-clone": "^3.0.0"
+			},
+			"dependencies": {
+				"is-plain-object": {
+					"version": "2.0.4",
+					"resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-2.0.4.tgz",
+					"integrity": "sha512-h5PpgXkWitc38BBMYawTYMWJHFZJVnBquFE57xFpjB8pJFiF6gZ+bU+WyI/yqXiFR5mdLsgYNaPe8uao6Uv9Og==",
+					"requires": {
+						"isobject": "^3.0.1"
+					}
+				}
 			}
 		},
 		"clone-regexp": {
@@ -34480,6 +34490,16 @@
 					"integrity": "sha512-arnXMxT1hhoKo9k1LZdmlNyJdDDfy2v0fXjFlmok4+i8ul/6WlbVge9bhM74OpNPQPMGUToDtz+KXa1PneJxOA==",
 					"requires": {
 						"is-plain-object": "^2.0.4"
+					},
+					"dependencies": {
+						"is-plain-object": {
+							"version": "2.0.4",
+							"resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-2.0.4.tgz",
+							"integrity": "sha512-h5PpgXkWitc38BBMYawTYMWJHFZJVnBquFE57xFpjB8pJFiF6gZ+bU+WyI/yqXiFR5mdLsgYNaPe8uao6Uv9Og==",
+							"requires": {
+								"isobject": "^3.0.1"
+							}
+						}
 					}
 				}
 			}
@@ -38400,12 +38420,9 @@
 			}
 		},
 		"is-plain-object": {
-			"version": "2.0.4",
-			"resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-2.0.4.tgz",
-			"integrity": "sha512-h5PpgXkWitc38BBMYawTYMWJHFZJVnBquFE57xFpjB8pJFiF6gZ+bU+WyI/yqXiFR5mdLsgYNaPe8uao6Uv9Og==",
-			"requires": {
-				"isobject": "^3.0.1"
-			}
+			"version": "5.0.0",
+			"resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-5.0.0.tgz",
+			"integrity": "sha512-VRSzKkbMm5jMDoKLbltAkFQ5Qr7VDiTFGXxYFXXowVj387GeGNOCsOH6Msy00SGZ3Fp84b1Naa1psqgcCIEP5Q=="
 		},
 		"is-potential-custom-element-name": {
 			"version": "1.0.1",
@@ -44290,6 +44307,17 @@
 						"kind-of": "^3.0.2",
 						"lazy-cache": "^1.0.3",
 						"shallow-clone": "^0.1.2"
+					},
+					"dependencies": {
+						"is-plain-object": {
+							"version": "2.0.4",
+							"resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-2.0.4.tgz",
+							"integrity": "sha512-h5PpgXkWitc38BBMYawTYMWJHFZJVnBquFE57xFpjB8pJFiF6gZ+bU+WyI/yqXiFR5mdLsgYNaPe8uao6Uv9Og==",
+							"dev": true,
+							"requires": {
+								"isobject": "^3.0.1"
+							}
+						}
 					}
 				},
 				"kind-of": {
@@ -45609,6 +45637,16 @@
 					"integrity": "sha512-arnXMxT1hhoKo9k1LZdmlNyJdDDfy2v0fXjFlmok4+i8ul/6WlbVge9bhM74OpNPQPMGUToDtz+KXa1PneJxOA==",
 					"requires": {
 						"is-plain-object": "^2.0.4"
+					},
+					"dependencies": {
+						"is-plain-object": {
+							"version": "2.0.4",
+							"resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-2.0.4.tgz",
+							"integrity": "sha512-h5PpgXkWitc38BBMYawTYMWJHFZJVnBquFE57xFpjB8pJFiF6gZ+bU+WyI/yqXiFR5mdLsgYNaPe8uao6Uv9Og==",
+							"requires": {
+								"isobject": "^3.0.1"
+							}
+						}
 					}
 				}
 			}
@@ -52856,6 +52894,14 @@
 					"integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
 					"requires": {
 						"is-extendable": "^0.1.0"
+					}
+				},
+				"is-plain-object": {
+					"version": "2.0.4",
+					"resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-2.0.4.tgz",
+					"integrity": "sha512-h5PpgXkWitc38BBMYawTYMWJHFZJVnBquFE57xFpjB8pJFiF6gZ+bU+WyI/yqXiFR5mdLsgYNaPe8uao6Uv9Og==",
+					"requires": {
+						"isobject": "^3.0.1"
 					}
 				}
 			}

--- a/package-lock.json
+++ b/package-lock.json
@@ -16656,7 +16656,7 @@
 				"change-case": "^4.1.2",
 				"colord": "^2.7.0",
 				"hpq": "^1.3.0",
-				"is-plain-obj": "^4.1.0",
+				"is-plain-object": "^5.0.0",
 				"lodash": "^4.17.21",
 				"memize": "^1.1.0",
 				"rememo": "^4.0.0",
@@ -16670,6 +16670,11 @@
 					"version": "2.8.0",
 					"resolved": "https://registry.npmjs.org/colord/-/colord-2.8.0.tgz",
 					"integrity": "sha512-kNkVV4KFta3TYQv0bzs4xNwLaeag261pxgzGQSh4cQ1rEhYjcTJfFRP0SDlbhLONg0eSoLzrDd79PosjbltufA=="
+				},
+				"is-plain-object": {
+					"version": "5.0.0",
+					"resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-5.0.0.tgz",
+					"integrity": "sha512-VRSzKkbMm5jMDoKLbltAkFQ5Qr7VDiTFGXxYFXXowVj387GeGNOCsOH6Msy00SGZ3Fp84b1Naa1psqgcCIEP5Q=="
 				}
 			}
 		},
@@ -16891,12 +16896,19 @@
 				"@wordpress/priority-queue": "file:packages/priority-queue",
 				"@wordpress/redux-routine": "file:packages/redux-routine",
 				"equivalent-key-map": "^0.2.2",
-				"is-plain-obj": "^4.1.0",
+				"is-plain-object": "^5.0.0",
 				"is-promise": "^4.0.0",
 				"lodash": "^4.17.21",
 				"redux": "^4.1.2",
 				"turbo-combine-reducers": "^1.0.2",
 				"use-memo-one": "^1.1.1"
+			},
+			"dependencies": {
+				"is-plain-object": {
+					"version": "5.0.0",
+					"resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-5.0.0.tgz",
+					"integrity": "sha512-VRSzKkbMm5jMDoKLbltAkFQ5Qr7VDiTFGXxYFXXowVj387GeGNOCsOH6Msy00SGZ3Fp84b1Naa1psqgcCIEP5Q=="
+				}
 			}
 		},
 		"@wordpress/data-controls": {
@@ -17181,9 +17193,16 @@
 				"@types/react-dom": "^17.0.11",
 				"@wordpress/escape-html": "file:packages/escape-html",
 				"change-case": "^4.1.2",
-				"is-plain-obj": "^4.1.0",
+				"is-plain-object": "^5.0.0",
 				"react": "^17.0.2",
 				"react-dom": "^17.0.2"
+			},
+			"dependencies": {
+				"is-plain-object": {
+					"version": "5.0.0",
+					"resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-5.0.0.tgz",
+					"integrity": "sha512-VRSzKkbMm5jMDoKLbltAkFQ5Qr7VDiTFGXxYFXXowVj387GeGNOCsOH6Msy00SGZ3Fp84b1Naa1psqgcCIEP5Q=="
+				}
 			}
 		},
 		"@wordpress/env": {
@@ -17579,7 +17598,14 @@
 		},
 		"@wordpress/npm-package-json-lint-config": {
 			"version": "file:packages/npm-package-json-lint-config",
-			"dev": true
+			"dev": true,
+			"dependencies": {
+				"is-plain-object": {
+					"version": "5.0.0",
+					"resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-5.0.0.tgz",
+					"integrity": "sha512-VRSzKkbMm5jMDoKLbltAkFQ5Qr7VDiTFGXxYFXXowVj387GeGNOCsOH6Msy00SGZ3Fp84b1Naa1psqgcCIEP5Q=="
+				}
+			}
 		},
 		"@wordpress/nux": {
 			"version": "file:packages/nux",
@@ -17747,10 +17773,17 @@
 			"version": "file:packages/redux-routine",
 			"requires": {
 				"@babel/runtime": "^7.16.0",
-				"is-plain-obj": "^4.1.0",
+				"is-plain-object": "^5.0.0",
 				"is-promise": "^4.0.0",
 				"lodash": "^4.17.21",
 				"rungen": "^0.3.2"
+			},
+			"dependencies": {
+				"is-plain-object": {
+					"version": "5.0.0",
+					"resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-5.0.0.tgz",
+					"integrity": "sha512-VRSzKkbMm5jMDoKLbltAkFQ5Qr7VDiTFGXxYFXXowVj387GeGNOCsOH6Msy00SGZ3Fp84b1Naa1psqgcCIEP5Q=="
+				}
 			}
 		},
 		"@wordpress/report-flaky-tests": {
@@ -38365,11 +38398,6 @@
 					}
 				}
 			}
-		},
-		"is-plain-obj": {
-			"version": "4.1.0",
-			"resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-4.1.0.tgz",
-			"integrity": "sha512-+Pgi+vMuUNkJyExiMBt5IlFoMyKnr5zhJ4Uspz58WOhBF5QoIZkFyNHIbBAtHwzVAgk5RtndVNsDRN61/mmDqg=="
 		},
 		"is-plain-object": {
 			"version": "2.0.4",

--- a/package-lock.json
+++ b/package-lock.json
@@ -38419,11 +38419,6 @@
 				}
 			}
 		},
-		"is-plain-object": {
-			"version": "5.0.0",
-			"resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-5.0.0.tgz",
-			"integrity": "sha512-VRSzKkbMm5jMDoKLbltAkFQ5Qr7VDiTFGXxYFXXowVj387GeGNOCsOH6Msy00SGZ3Fp84b1Naa1psqgcCIEP5Q=="
-		},
 		"is-potential-custom-element-name": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/is-potential-custom-element-name/-/is-potential-custom-element-name-1.0.1.tgz",

--- a/package-lock.json
+++ b/package-lock.json
@@ -16670,11 +16670,6 @@
 					"version": "2.8.0",
 					"resolved": "https://registry.npmjs.org/colord/-/colord-2.8.0.tgz",
 					"integrity": "sha512-kNkVV4KFta3TYQv0bzs4xNwLaeag261pxgzGQSh4cQ1rEhYjcTJfFRP0SDlbhLONg0eSoLzrDd79PosjbltufA=="
-				},
-				"is-plain-object": {
-					"version": "5.0.0",
-					"resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-5.0.0.tgz",
-					"integrity": "sha512-VRSzKkbMm5jMDoKLbltAkFQ5Qr7VDiTFGXxYFXXowVj387GeGNOCsOH6Msy00SGZ3Fp84b1Naa1psqgcCIEP5Q=="
 				}
 			}
 		},
@@ -16902,13 +16897,6 @@
 				"redux": "^4.1.2",
 				"turbo-combine-reducers": "^1.0.2",
 				"use-memo-one": "^1.1.1"
-			},
-			"dependencies": {
-				"is-plain-object": {
-					"version": "5.0.0",
-					"resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-5.0.0.tgz",
-					"integrity": "sha512-VRSzKkbMm5jMDoKLbltAkFQ5Qr7VDiTFGXxYFXXowVj387GeGNOCsOH6Msy00SGZ3Fp84b1Naa1psqgcCIEP5Q=="
-				}
 			}
 		},
 		"@wordpress/data-controls": {
@@ -17196,13 +17184,6 @@
 				"is-plain-object": "^5.0.0",
 				"react": "^17.0.2",
 				"react-dom": "^17.0.2"
-			},
-			"dependencies": {
-				"is-plain-object": {
-					"version": "5.0.0",
-					"resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-5.0.0.tgz",
-					"integrity": "sha512-VRSzKkbMm5jMDoKLbltAkFQ5Qr7VDiTFGXxYFXXowVj387GeGNOCsOH6Msy00SGZ3Fp84b1Naa1psqgcCIEP5Q=="
-				}
 			}
 		},
 		"@wordpress/env": {
@@ -17598,14 +17579,7 @@
 		},
 		"@wordpress/npm-package-json-lint-config": {
 			"version": "file:packages/npm-package-json-lint-config",
-			"dev": true,
-			"dependencies": {
-				"is-plain-object": {
-					"version": "5.0.0",
-					"resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-5.0.0.tgz",
-					"integrity": "sha512-VRSzKkbMm5jMDoKLbltAkFQ5Qr7VDiTFGXxYFXXowVj387GeGNOCsOH6Msy00SGZ3Fp84b1Naa1psqgcCIEP5Q=="
-				}
-			}
+			"dev": true
 		},
 		"@wordpress/nux": {
 			"version": "file:packages/nux",
@@ -17777,13 +17751,6 @@
 				"is-promise": "^4.0.0",
 				"lodash": "^4.17.21",
 				"rungen": "^0.3.2"
-			},
-			"dependencies": {
-				"is-plain-object": {
-					"version": "5.0.0",
-					"resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-5.0.0.tgz",
-					"integrity": "sha512-VRSzKkbMm5jMDoKLbltAkFQ5Qr7VDiTFGXxYFXXowVj387GeGNOCsOH6Msy00SGZ3Fp84b1Naa1psqgcCIEP5Q=="
-				}
 			}
 		},
 		"@wordpress/report-flaky-tests": {
@@ -38418,6 +38385,11 @@
 					}
 				}
 			}
+		},
+		"is-plain-object": {
+			"version": "5.0.0",
+			"resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-5.0.0.tgz",
+			"integrity": "sha512-VRSzKkbMm5jMDoKLbltAkFQ5Qr7VDiTFGXxYFXXowVj387GeGNOCsOH6Msy00SGZ3Fp84b1Naa1psqgcCIEP5Q=="
 		},
 		"is-potential-custom-element-name": {
 			"version": "1.0.1",

--- a/packages/blocks/CHANGELOG.md
+++ b/packages/blocks/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Bug Fix
+
+-   Packages: Replace `is-plain-obj` with `is-plain-object` ([#43511](https://github.com/WordPress/gutenberg/pull/43511)).
+
 ## 11.14.0 (2022-08-10)
 
 ## 11.13.0 (2022-07-27)

--- a/packages/blocks/package.json
+++ b/packages/blocks/package.json
@@ -44,7 +44,7 @@
 		"change-case": "^4.1.2",
 		"colord": "^2.7.0",
 		"hpq": "^1.3.0",
-		"is-plain-obj": "^4.1.0",
+		"is-plain-object": "^5.0.0",
 		"lodash": "^4.17.21",
 		"memize": "^1.1.0",
 		"rememo": "^4.0.0",

--- a/packages/blocks/src/store/actions.js
+++ b/packages/blocks/src/store/actions.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import isPlainObject from 'is-plain-obj';
+import { isPlainObject } from 'is-plain-object';
 import { castArray, omit, pick, some } from 'lodash';
 
 /**

--- a/packages/data/CHANGELOG.md
+++ b/packages/data/CHANGELOG.md
@@ -6,6 +6,10 @@
 
 –   Add TypeScript types to the built package (via "types": "build-types" in the package.json)
 
+### Bug Fix
+
+-   Packages: Replace `is-plain-obj` with `is-plain-object` ([#43511](https://github.com/WordPress/gutenberg/pull/43511)).
+
 ## 6.15.0 (2022-08-10)
 
 ## 6.14.0 (2022-07-27)

--- a/packages/data/package.json
+++ b/packages/data/package.json
@@ -36,7 +36,7 @@
 		"@wordpress/priority-queue": "file:../priority-queue",
 		"@wordpress/redux-routine": "file:../redux-routine",
 		"equivalent-key-map": "^0.2.2",
-		"is-plain-obj": "^4.1.0",
+		"is-plain-object": "^5.0.0",
 		"is-promise": "^4.0.0",
 		"lodash": "^4.17.21",
 		"redux": "^4.1.2",

--- a/packages/data/src/plugins/persistence/index.js
+++ b/packages/data/src/plugins/persistence/index.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import isPlainObject from 'is-plain-obj';
+import { isPlainObject } from 'is-plain-object';
 import { merge } from 'lodash';
 
 /**

--- a/packages/element/CHANGELOG.md
+++ b/packages/element/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Bug Fix
+
+-   Packages: Replace `is-plain-obj` with `is-plain-object` ([#43511](https://github.com/WordPress/gutenberg/pull/43511)).
+
 ## 4.13.0 (2022-08-10)
 
 ## 4.12.0 (2022-07-27)

--- a/packages/element/package.json
+++ b/packages/element/package.json
@@ -33,7 +33,7 @@
 		"@types/react-dom": "^17.0.11",
 		"@wordpress/escape-html": "file:../escape-html",
 		"change-case": "^4.1.2",
-		"is-plain-obj": "^4.1.0",
+		"is-plain-object": "^5.0.0",
 		"react": "^17.0.2",
 		"react-dom": "^17.0.2"
 	},

--- a/packages/element/src/serialize.js
+++ b/packages/element/src/serialize.js
@@ -28,7 +28,7 @@
 /**
  * External dependencies
  */
-import isPlainObject from 'is-plain-obj';
+import { isPlainObject } from 'is-plain-object';
 import { paramCase as kebabCase } from 'change-case';
 
 /**

--- a/packages/jest-preset-default/CHANGELOG.md
+++ b/packages/jest-preset-default/CHANGELOG.md
@@ -6,6 +6,10 @@
 
 -   Increase the minimum Node.js version to 14 ([#43141](https://github.com/WordPress/gutenberg/pull/43141)).
 
+### Bug Fix
+
+-   Packages: Replace `is-plain-obj` with `is-plain-object` ([#43511](https://github.com/WordPress/gutenberg/pull/43511)).
+
 ## 8.5.2 (2022-08-17)
 
 ### Bug Fix

--- a/packages/jest-preset-default/jest-preset.js
+++ b/packages/jest-preset-default/jest-preset.js
@@ -29,5 +29,4 @@ module.exports = {
 	transform: {
 		'\\.[jt]sx?$': require.resolve( 'babel-jest' ),
 	},
-	transformIgnorePatterns: [ 'node_modules/(?:(?!is-plain-obj/).)*$' ],
 };

--- a/packages/npm-package-json-lint-config/CHANGELOG.md
+++ b/packages/npm-package-json-lint-config/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Bug Fix
 
--   Packages: Replace `is-plain-obj` with `is-plain-object` ([#43511](https://github.com/WordPress/gutenberg/pull/43511)).
+-   Packages: Replace `is-plain-obj` with native functionality ([#43511](https://github.com/WordPress/gutenberg/pull/43511)).
 
 ## 4.0.0 (2021-01-21)
 

--- a/packages/npm-package-json-lint-config/CHANGELOG.md
+++ b/packages/npm-package-json-lint-config/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Bug Fix
+
+-   Packages: Replace `is-plain-obj` with `is-plain-object` ([#43511](https://github.com/WordPress/gutenberg/pull/43511)).
+
 ## 4.0.0 (2021-01-21)
 
 ### Breaking Change

--- a/packages/npm-package-json-lint-config/test/index.test.js
+++ b/packages/npm-package-json-lint-config/test/index.test.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import isPlainObject from 'is-plain-obj';
+import { isPlainObject } from 'is-plain-object';
 
 /**
  * Internal dependencies

--- a/packages/npm-package-json-lint-config/test/index.test.js
+++ b/packages/npm-package-json-lint-config/test/index.test.js
@@ -1,19 +1,16 @@
 /**
- * External dependencies
- */
-import { isPlainObject } from 'is-plain-object';
-
-/**
  * Internal dependencies
  */
 import config from '../';
 
 describe( 'npm-package-json-lint config tests', () => {
 	it( 'should be an object', () => {
-		expect( isPlainObject( config ) ).toBeTruthy();
+		expect( config ).not.toBeNull();
+		expect( typeof config ).toBe( 'object' );
 	} );
 
 	it( 'should have rules property as an object', () => {
-		expect( isPlainObject( config.rules ) ).toBeTruthy();
+		expect( config.rules ).not.toBeNull();
+		expect( typeof config.rules ).toBe( 'object' );
 	} );
 } );

--- a/packages/prettier-config/CHANGELOG.md
+++ b/packages/prettier-config/CHANGELOG.md
@@ -6,6 +6,10 @@
 
 -   Increase the minimum Node.js version to 14 ([#43141](https://github.com/WordPress/gutenberg/pull/43141)).
 
+### Bug Fix
+
+-   Packages: Replace `is-plain-obj` with `is-plain-object` ([#43511](https://github.com/WordPress/gutenberg/pull/43511)).
+
 ## 1.2.0 (2022-04-21)
 
 ### Enhancement

--- a/packages/prettier-config/CHANGELOG.md
+++ b/packages/prettier-config/CHANGELOG.md
@@ -8,7 +8,7 @@
 
 ### Bug Fix
 
--   Packages: Replace `is-plain-obj` with `is-plain-object` ([#43511](https://github.com/WordPress/gutenberg/pull/43511)).
+-   Packages: Replace `is-plain-obj` with native functionality ([#43511](https://github.com/WordPress/gutenberg/pull/43511)).
 
 ## 1.2.0 (2022-04-21)
 

--- a/packages/prettier-config/test/index.js
+++ b/packages/prettier-config/test/index.js
@@ -1,15 +1,11 @@
 /**
- * External dependencies
- */
-import isPlainObject from 'is-plain-obj';
-
-/**
  * Internal dependencies
  */
 import config from '../lib/';
 
 describe( 'prettier config tests', () => {
 	it( 'should be an object', () => {
-		expect( isPlainObject( config ) ).toBeTruthy();
+		expect( config ).not.toBeNull();
+		expect( typeof config ).toBe( 'object' );
 	} );
 } );

--- a/packages/redux-routine/CHANGELOG.md
+++ b/packages/redux-routine/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Bug Fix
+
+-   Packages: Replace `is-plain-obj` with `is-plain-object` ([#43511](https://github.com/WordPress/gutenberg/pull/43511)).
+
 ## 4.15.0 (2022-08-10)
 
 ## 4.14.0 (2022-07-27)

--- a/packages/redux-routine/package.json
+++ b/packages/redux-routine/package.json
@@ -30,7 +30,7 @@
 	"sideEffects": false,
 	"dependencies": {
 		"@babel/runtime": "^7.16.0",
-		"is-plain-obj": "^4.1.0",
+		"is-plain-object": "^5.0.0",
 		"is-promise": "^4.0.0",
 		"lodash": "^4.17.21",
 		"rungen": "^0.3.2"

--- a/packages/redux-routine/src/is-action.js
+++ b/packages/redux-routine/src/is-action.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import isPlainObject from 'is-plain-obj';
+import { isPlainObject } from 'is-plain-object';
 
 /* eslint-disable jsdoc/valid-types */
 /**

--- a/packages/scripts/CHANGELOG.md
+++ b/packages/scripts/CHANGELOG.md
@@ -7,6 +7,10 @@
 -   Increase the minimum Node.js version to 14 and minimum npm version to 6.14.4 ([#43141](https://github.com/WordPress/gutenberg/pull/43141)).
 -   The bundled `@wordpress/eslint-plugin` package got updated to the new major version and the default linting for Jest unit tests is now handled in the default config in this package ([#43272](https://github.com/WordPress/gutenberg/pull/43272)).
 
+### Bug Fix
+
+-   Packages: Replace `is-plain-obj` with `is-plain-object` ([#43511](https://github.com/WordPress/gutenberg/pull/43511)).
+
 ## 23.7.2 (2022-08-17)
 
 ### Bug Fix

--- a/test/native/jest.config.js
+++ b/test/native/jest.config.js
@@ -65,7 +65,7 @@ module.exports = {
 		// See: https://github.com/wordpress-mobile/gutenberg-mobile/pull/257#discussion_r234978268
 		// There is no overloading in jest so we need to rewrite the config from react-native-jest-preset:
 		// https://github.com/facebook/react-native/blob/HEAD/jest-preset.json#L20
-		'node_modules/(?!(simple-html-tokenizer|is-plain-obj|(jest-)?react-native|@react-native|react-clone-referenced-element|@react-navigation))',
+		'node_modules/(?!(simple-html-tokenizer|(jest-)?react-native|@react-native|react-clone-referenced-element|@react-navigation))',
 	],
 	snapshotSerializers: [ '@emotion/jest/serializer' ],
 	reporters: [ 'default', 'jest-junit' ],


### PR DESCRIPTION
## What?
In this PR we're replacing `is-plain-obj` with `is-plain-object`.

Fixes #43434.

## Why?
Because the former is ESM-only and this causes problems in CommonJS environments.

Prior attempts to address this were inconclusive: #43179 and #43271.

## How?
Just replacing the package everywhere, they're basically drop-in replacements.

@gziolo we'll need to prepare some new package releases once this lands.

## Testing Instructions
* Verify all tests pass and checks are green.
* Smoke test all editors.
