### PR TITLE
Placeholders: Make dashed style a mixin, and apply across.

### DIFF
--- a/packages/base-styles/_mixins.scss
+++ b/packages/base-styles/_mixins.scss
@@ -202,7 +202,7 @@
 	}
 }
 
-@mixin dashed-placeholder-style() {
+@mixin placeholder-style() {
 	border: $border-width dashed currentColor;
 	border-radius: $radius-block-ui;
 }

--- a/packages/base-styles/_mixins.scss
+++ b/packages/base-styles/_mixins.scss
@@ -202,6 +202,11 @@
 	}
 }
 
+@mixin dashed-placeholder-style() {
+	border: $border-width dashed currentColor;
+	border-radius: $radius-block-ui;
+}
+
 /**
  * Allows users to opt-out of animations via OS-level preferences.
  */
@@ -226,7 +231,6 @@
 			animation-delay: 0s;
 		}
 	}
-
 }
 
 @mixin input-control {
@@ -371,6 +375,7 @@
  * Reset default styles for JavaScript UI based pages.
  * This is a WP-admin agnostic reset
  */
+
 @mixin reset {
 	box-sizing: border-box;
 
@@ -384,6 +389,7 @@
 /**
  * Reset the WP Admin page styles for Gutenberg-like pages.
  */
+
 @mixin wp-admin-reset( $content-container ) {
 	background: $white;
 

--- a/packages/block-editor/src/components/button-block-appender/style.scss
+++ b/packages/block-editor/src/components/button-block-appender/style.scss
@@ -46,9 +46,7 @@
 			bottom: 0;
 			left: 0;
 			pointer-events: none;
-
-			// Dashed placeholder style.
-			@include dashed-placeholder-style();
+			@include placeholder-style();
 		}
 
 		.block-editor-inserter {

--- a/packages/block-editor/src/components/button-block-appender/style.scss
+++ b/packages/block-editor/src/components/button-block-appender/style.scss
@@ -45,10 +45,10 @@
 			right: 0;
 			bottom: 0;
 			left: 0;
-			border: $border-width dashed currentColor;
-			opacity: 0.4;
-			border-radius: $radius-block-ui;
 			pointer-events: none;
+
+			// Dashed placeholder style.
+			@include dashed-placeholder-style();
 		}
 
 		.block-editor-inserter {

--- a/packages/block-library/src/group/editor.scss
+++ b/packages/block-library/src/group/editor.scss
@@ -42,9 +42,7 @@
 		flex: 1 0 $grid-unit-60;
 		pointer-events: none;
 		min-height: $grid-unit-60 - $border-width - $border-width;
-
-		// Dashed placeholder style.
-		@include dashed-placeholder-style();
+		@include placeholder-style();
 	}
 
 	// Let the parent be selectable in the placeholder area.

--- a/packages/block-library/src/group/editor.scss
+++ b/packages/block-library/src/group/editor.scss
@@ -39,12 +39,12 @@
 	&::after {
 		content: "";
 		display: flex;
-		border: $border-width dashed currentColor;
-		opacity: 0.4;
-		border-radius: $radius-block-ui;
 		flex: 1 0 $grid-unit-60;
 		pointer-events: none;
 		min-height: $grid-unit-60 - $border-width - $border-width;
+
+		// Dashed placeholder style.
+		@include dashed-placeholder-style();
 	}
 
 	// Let the parent be selectable in the placeholder area.

--- a/packages/block-library/src/navigation/editor.scss
+++ b/packages/block-library/src/navigation/editor.scss
@@ -291,9 +291,7 @@ $color-control-label-height: 20px;
 		bottom: 0;
 		left: 0;
 		pointer-events: none;
-
-		// Dashed placeholder style.
-		@include dashed-placeholder-style();
+		@include placeholder-style();
 
 		// Inherit border radius from style variations.
 		border-radius: inherit;

--- a/packages/block-library/src/navigation/editor.scss
+++ b/packages/block-library/src/navigation/editor.scss
@@ -290,9 +290,10 @@ $color-control-label-height: 20px;
 		right: 0;
 		bottom: 0;
 		left: 0;
-		border: $border-width dashed currentColor;
-		opacity: 0.4;
 		pointer-events: none;
+
+		// Dashed placeholder style.
+		@include dashed-placeholder-style();
 
 		// Inherit border radius from style variations.
 		border-radius: inherit;
@@ -300,7 +301,6 @@ $color-control-label-height: 20px;
 
 	> svg {
 		fill: currentColor;
-		opacity: 0.4;
 	}
 }
 

--- a/packages/components/src/placeholder/style.scss
+++ b/packages/components/src/placeholder/style.scss
@@ -210,8 +210,7 @@
 	}
 
 	// By painting the borders here, we enable them to be replaced by the Border control.
-	// Dashed placeholder style.
-	@include dashed-placeholder-style();
+	@include placeholder-style();
 	overflow: hidden;
 }
 

--- a/packages/components/src/placeholder/style.scss
+++ b/packages/components/src/placeholder/style.scss
@@ -177,9 +177,6 @@
 	box-shadow: none;
 	min-width: 100px;
 
-	// Radius fallback value.
-	border-radius: $radius-block-ui;
-
 	// Blur the background so layered dashed placeholders are still visually separate.
 	// We also provide a semitransparent background so as to allow duotones to sheen through.
 	backdrop-filter: blur(100px);
@@ -213,7 +210,8 @@
 	}
 
 	// By painting the borders here, we enable them to be replaced by the Border control.
-	border: $border-width dashed currentColor;
+	// Dashed placeholder style.
+	@include dashed-placeholder-style();
 	overflow: hidden;
 }
 


### PR DESCRIPTION
## What?

As placeholders in the dashed-outline style have received polish in the last week, an opacity differential has stood out:

<img width="728" alt="before" src="https://user-images.githubusercontent.com/1204802/186138299-7e5da06c-6b5b-4246-91c0-72447207df85.png">

This PR makes the styles the same across, and extracts the particular dash-style into a mixin so it has a better chance to stay in sync across changes:

<img width="748" alt="after" src="https://user-images.githubusercontent.com/1204802/186138397-e0fad7f9-4295-4d25-b2d1-83fe9dea233a.png">

## Testing Instructions

Test placeholders with the new dashed style, Image, Featured Image, Site Logo, and Columns. Dashed styles should look the same.

I noticed a regression with Group, separate from this PR, which I'll follow up on.
