### PR TITLE
Group: Fix click-first state

### DIFF
--- a/packages/block-editor/src/components/button-block-appender/style.scss
+++ b/packages/block-editor/src/components/button-block-appender/style.scss
@@ -31,3 +31,28 @@
 		color: $black;
 	}
 }
+
+// When the appender shows up in empty container blocks, such as Group and Columns, add an extra click state.
+.block-list-appender:only-child {
+	.is-layout-constrained.block-editor-block-list__block:not(.is-selected) > &,
+	.is-layout-flow.block-editor-block-list__block:not(.is-selected) > & {
+		pointer-events: none;
+
+		&::after {
+			content: "";
+			position: absolute;
+			top: 0;
+			right: 0;
+			bottom: 0;
+			left: 0;
+			border: $border-width dashed currentColor;
+			opacity: 0.4;
+			border-radius: $radius-block-ui;
+			pointer-events: none;
+		}
+
+		.block-editor-inserter {
+			visibility: hidden;
+		}
+	}
+}

--- a/packages/block-library/src/group/editor.scss
+++ b/packages/block-library/src/group/editor.scss
@@ -53,29 +53,3 @@
 		pointer-events: all;
 	}
 }
-
-// Show an unselected empty group button as a dashed outline instead of the appender button.
-// This effectively adds a selectable-to-delete state.
-.is-layout-constrained.block-editor-block-list__block:not(.is-selected),
-.is-layout-flow.block-editor-block-list__block:not(.is-selected) {
-	> .block-list-appender:only-child {
-		pointer-events: none;
-
-		&::after {
-			content: "";
-			position: absolute;
-			top: 0;
-			right: 0;
-			bottom: 0;
-			left: 0;
-			border: $border-width dashed currentColor;
-			opacity: 0.4;
-			border-radius: $radius-block-ui;
-			pointer-events: none;
-		}
-
-		.block-editor-inserter {
-			visibility: hidden;
-		}
-	}
-}

--- a/packages/block-library/src/group/editor.scss
+++ b/packages/block-library/src/group/editor.scss
@@ -56,6 +56,7 @@
 
 // Show an unselected empty group button as a dashed outline instead of the appender button.
 // This effectively adds a selectable-to-delete state.
+.is-layout-constrained.block-editor-block-list__block:not(.is-selected),
 .is-layout-flow.block-editor-block-list__block:not(.is-selected) {
 	> .block-list-appender:only-child {
 		pointer-events: none;

--- a/packages/e2e-tests/specs/editor/various/inserting-blocks.test.js
+++ b/packages/e2e-tests/specs/editor/various/inserting-blocks.test.js
@@ -279,6 +279,8 @@ describe( 'Inserting blocks', () => {
 		await insertBlock( 'Group' );
 		await insertBlock( 'Paragraph' );
 		await page.keyboard.type( 'Paragraph after group' );
+		// Click the Group first to make the appender inside it clickable.
+		await page.click( '[data-type="core/group"]' );
 		await page.click( '[data-type="core/group"] [aria-label="Add block"]' );
 		const browseAll = await page.waitForXPath(
 			'//button[text()="Browse all"]'
@@ -295,6 +297,8 @@ describe( 'Inserting blocks', () => {
 		await insertBlock( 'Group' );
 		await insertBlock( 'Paragraph' );
 		await page.keyboard.type( 'Text' );
+		// Click the Group first to make the appender inside it clickable.
+		await page.click( '[data-type="core/group"]' );
 		await page.click( '[data-type="core/group"] [aria-label="Add block"]' );
 		await page.waitForSelector( INSERTER_SEARCH_SELECTOR );
 		await page.focus( INSERTER_SEARCH_SELECTOR );


### PR DESCRIPTION
## What?

#40664 added a clickable state for an empty group. Recent architecture changes made that code break, so there isn't a clickable state anymore:

<img width="760" alt="before" src="https://user-images.githubusercontent.com/1204802/186140220-7b4ab524-a779-49cd-b288-38d80d573831.png">

This PR fixes it:

![after](https://user-images.githubusercontent.com/1204802/186140238-016693d2-57aa-4869-8fa4-4015b5722e7d.gif)


## Testing Instructions

Insert an empty group block and verify it has a clickable state.