### PR TITLE
Fetch site icon using the ID from REST API index

### DIFF
--- a/lib/compat/wordpress-6.1/rest-api.php
+++ b/lib/compat/wordpress-6.1/rest-api.php
@@ -43,21 +43,3 @@ function gutenberg_register_gutenberg_rest_block_patterns() {
 	$block_patterns->register_routes();
 }
 add_action( 'rest_api_init', 'gutenberg_register_gutenberg_rest_block_patterns', 100 );
-
-/**
- * Exposes the site logo URL through the WordPress REST API.
- *
- * This is used for fetching this information when user has no rights
- * to update settings.
- *
- * Note: Backports into wp-includes/rest-api/class-wp-rest-server.php file.
- *
- * @param WP_REST_Response $response REST API response.
- * @return WP_REST_Response $response REST API response.
- */
-function gutenberg_add_site_icon_url_to_index( WP_REST_Response $response ) {
-	$response->data['site_icon_url'] = get_site_icon_url();
-
-	return $response;
-}
-add_action( 'rest_index', 'gutenberg_add_site_icon_url_to_index' );

--- a/packages/core-data/src/entities.ts
+++ b/packages/core-data/src/entities.ts
@@ -323,7 +323,6 @@ export const rootEntitiesConfig = [
 				'home',
 				'name',
 				'site_icon',
-				'site_icon_url',
 				'site_logo',
 				'timezone_string',
 				'url',

--- a/packages/edit-post/src/components/header/fullscreen-mode-close/index.js
+++ b/packages/edit-post/src/components/header/fullscreen-mode-close/index.js
@@ -30,20 +30,25 @@ function FullscreenModeClose( { showTooltip, icon, href } ) {
 		( select ) => {
 			const { getCurrentPostType } = select( editorStore );
 			const { isFeatureActive } = select( editPostStore );
-			const { getEntityRecord, getPostType, isResolving } =
+			const { getEntityRecord, getMedia, getPostType, isResolving } =
 				select( coreStore );
-			const siteData =
-				getEntityRecord( 'root', '__unstableBase', undefined ) || {};
+			const siteIcon = getEntityRecord(
+				'root',
+				'__unstableBase'
+			)?.site_icon;
 
 			return {
 				isActive: isFeatureActive( 'fullscreenMode' ),
-				isRequestingSiteIcon: isResolving( 'getEntityRecord', [
-					'root',
-					'__unstableBase',
-					undefined,
-				] ),
+				isRequestingSiteIcon: siteIcon
+					? isResolving( 'getMedia', [
+							siteIcon,
+							{ context: 'view' },
+					  ] )
+					: false,
 				postType: getPostType( getCurrentPostType() ),
-				siteIconUrl: siteData.site_icon_url,
+				siteIconUrl: siteIcon
+					? getMedia( siteIcon, { context: 'view' } )?.source_url
+					: null,
 			};
 		},
 		[]

--- a/packages/edit-post/src/components/header/fullscreen-mode-close/test/index.js
+++ b/packages/edit-post/src/components/header/fullscreen-mode-close/test/index.js
@@ -31,7 +31,10 @@ describe( 'FullscreenModeClose', () => {
 					getCurrentPostType: () => {},
 					getPostType: () => true,
 					getEntityRecord: () => ( {
-						site_icon_url: 'https://fakeUrl.com',
+						site_icon: 5,
+					} ),
+					getMedia: () => ( {
+						source_url: 'https://fakeUrl.com',
 					} ),
 				} ) );
 			} );
@@ -52,7 +55,7 @@ describe( 'FullscreenModeClose', () => {
 					getCurrentPostType: () => {},
 					getPostType: () => true,
 					getEntityRecord: () => ( {
-						site_icon_url: '',
+						site_icon: undefined,
 					} ),
 				} ) );
 			} );

--- a/packages/edit-site/src/components/navigation-sidebar/navigation-toggle/index.js
+++ b/packages/edit-site/src/components/navigation-sidebar/navigation-toggle/index.js
@@ -26,18 +26,24 @@ import { store as editSiteStore } from '../../../store';
 function NavigationToggle( { icon } ) {
 	const { isNavigationOpen, isRequestingSiteIcon, siteIconUrl } = useSelect(
 		( select ) => {
-			const { getEntityRecord, isResolving } = select( coreDataStore );
-			const siteData =
-				getEntityRecord( 'root', '__unstableBase', undefined ) || {};
+			const { getEntityRecord, getMedia, isResolving } =
+				select( coreDataStore );
+			const siteIcon = getEntityRecord(
+				'root',
+				'__unstableBase'
+			)?.site_icon;
 
 			return {
 				isNavigationOpen: select( editSiteStore ).isNavigationOpened(),
-				isRequestingSiteIcon: isResolving( 'core', 'getEntityRecord', [
-					'root',
-					'__unstableBase',
-					undefined,
-				] ),
-				siteIconUrl: siteData.site_icon_url,
+				isRequestingSiteIcon: siteIcon
+					? isResolving( 'getMedia', [
+							siteIcon,
+							{ context: 'view' },
+					  ] )
+					: false,
+				siteIconUrl: siteIcon
+					? getMedia( siteIcon, { context: 'view' } )?.source_url
+					: null,
 			};
 		},
 		[]

--- a/packages/edit-site/src/components/navigation-sidebar/navigation-toggle/test/index.js
+++ b/packages/edit-site/src/components/navigation-sidebar/navigation-toggle/test/index.js
@@ -31,7 +31,10 @@ describe( 'NavigationToggle', () => {
 				return cb( () => ( {
 					getCurrentTemplateNavigationPanelSubMenu: () => 'root',
 					getEntityRecord: () => ( {
-						site_icon_url: 'https://fakeUrl.com',
+						site_icon: 5,
+					} ),
+					getMedia: () => ( {
+						source_url: 'https://fakeUrl.com',
 					} ),
 					isResolving: () => false,
 					isNavigationOpened: () => false,
@@ -51,7 +54,7 @@ describe( 'NavigationToggle', () => {
 				return cb( () => ( {
 					getCurrentTemplateNavigationPanelSubMenu: () => 'root',
 					getEntityRecord: () => ( {
-						site_icon_url: '',
+						site_icon: undefined,
 					} ),
 					isResolving: () => false,
 					isNavigationOpened: () => false,

--- a/packages/editor/src/components/post-publish-panel/prepublish.js
+++ b/packages/editor/src/components/post-publish-panel/prepublish.js
@@ -37,9 +37,9 @@ function PostPublishPanelPrepublish( { children } ) {
 	} = useSelect( ( select ) => {
 		const { getCurrentPost, isEditedPostBeingScheduled } =
 			select( editorStore );
-		const { getEntityRecord, isResolving } = select( coreStore );
-		const siteData =
-			getEntityRecord( 'root', '__unstableBase', undefined ) || {};
+		const { getEntityRecord, getMedia, isResolving } = select( coreStore );
+		const siteData = getEntityRecord( 'root', '__unstableBase' ) || {};
+		const siteIcon = siteData.site_icon;
 
 		return {
 			hasPublishAction: get(
@@ -48,12 +48,12 @@ function PostPublishPanelPrepublish( { children } ) {
 				false
 			),
 			isBeingScheduled: isEditedPostBeingScheduled(),
-			isRequestingSiteIcon: isResolving( 'getEntityRecord', [
-				'root',
-				'__unstableBase',
-				undefined,
-			] ),
-			siteIconUrl: siteData.site_icon_url,
+			isRequestingSiteIcon: siteIcon
+				? isResolving( 'getMedia', [ siteIcon, { context: 'view' } ] )
+				: false,
+			siteIconUrl: siteIcon
+				? getMedia( siteIcon, { context: 'view' } )?.source_url
+				: null,
 			siteTitle: siteData.name,
 			siteHome: siteData.home && filterURLForDisplay( siteData.home ),
 		};


### PR DESCRIPTION
## What?
Follow-up #42957.

PR updates method used for fetching site icon to use ID and `getMedia`, instead of adding new REST API index.


## Testing Instructions
* Set site icon; this can be done via Site Logo block.
* Confirm W icon is correctly replaced in the Navigation button.
* Confirm site icon is correctly displayed in Pre publish component.
