### PR TITLE
[data] Export the type for the combineReducers export

### DIFF
--- a/packages/data/README.md
+++ b/packages/data/README.md
@@ -342,6 +342,10 @@ const store = createReduxStore( 'my-shop', {
 register( store );
 ```
 
+_Type_
+
+-   `Function`
+
 _Parameters_
 
 -   _reducers_ `Object`: An object whose values correspond to different reducing functions that need to be combined into one.

--- a/packages/data/README.md
+++ b/packages/data/README.md
@@ -344,7 +344,7 @@ register( store );
 
 _Type_
 
--   `Function`
+-   `import('./types').combineReducers`
 
 _Parameters_
 

--- a/packages/data/src/index.js
+++ b/packages/data/src/index.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import combineReducers from 'turbo-combine-reducers';
+import turboCombineReducers from 'turbo-combine-reducers';
 
 /**
  * Internal dependencies
@@ -43,6 +43,7 @@ export { plugins };
  * The combineReducers helper function turns an object whose values are different
  * reducing functions into a single reducing function you can pass to registerReducer.
  *
+ * @type  {Function}
  * @param {Object} reducers An object whose values correspond to different reducing
  *                          functions that need to be combined into one.
  *
@@ -77,6 +78,7 @@ export { plugins };
  * @return {Function} A reducer that invokes every reducer inside the reducers
  *                    object, and constructs a state object with the same shape.
  */
+const combineReducers = turboCombineReducers;
 export { combineReducers };
 
 /**

--- a/packages/data/src/index.js
+++ b/packages/data/src/index.js
@@ -43,7 +43,7 @@ export { plugins };
  * The combineReducers helper function turns an object whose values are different
  * reducing functions into a single reducing function you can pass to registerReducer.
  *
- * @type  {Function}
+ * @type  {import('./types').combineReducers}
  * @param {Object} reducers An object whose values correspond to different reducing
  *                          functions that need to be combined into one.
  *
@@ -78,8 +78,7 @@ export { plugins };
  * @return {Function} A reducer that invokes every reducer inside the reducers
  *                    object, and constructs a state object with the same shape.
  */
-const combineReducers = turboCombineReducers;
-export { combineReducers };
+export const combineReducers = turboCombineReducers;
 
 /**
  * Given a store descriptor, returns an object of the store's selectors.

--- a/packages/data/src/types.ts
+++ b/packages/data/src/types.ts
@@ -1,3 +1,9 @@
+/**
+ * External dependencies
+ */
+// eslint-disable-next-line no-restricted-imports
+import type { combineReducers as reduxCombineReducers } from 'redux';
+
 type MapOf< T > = { [ name: string ]: T };
 
 export type ActionCreator = Function | Generator;
@@ -97,3 +103,5 @@ type SelectorsOf< Config extends AnyConfig > = Config extends ReduxStoreConfig<
 >
 	? { [ name in keyof Selectors ]: Function }
 	: never;
+
+export type combineReducers = typeof reduxCombineReducers;


### PR DESCRIPTION
## What?
The `combineReducers` is exported, but has no type defined which causes an error it in the generated `index.d.ts`:

<img width="318" alt="CleanShot 2022-08-23 at 13 25 19@2x" src="https://user-images.githubusercontent.com/205419/186146303-318a2b12-4bf1-455c-9a54-1f136ad0de34.png">

This PR provides a rudimentary type definition to fix the error:

<img width="339" alt="CleanShot 2022-08-23 at 13 26 11@2x" src="https://user-images.githubusercontent.com/205419/186146469-aca92ffb-f619-44d2-8776-30446fd09098.png">

## Why?
The TypeScript type definitions were bundled with the package in https://github.com/WordPress/gutenberg/pull/43315

cc @gziolo 

