### PR TITLE
[useEntityRecord] Pass the correct kind, name, and recordId to getEditedEntityRecord

### DIFF
--- a/packages/core-data/src/hooks/test/use-entity-record.js
+++ b/packages/core-data/src/hooks/test/use-entity-record.js
@@ -71,7 +71,7 @@ describe( 'useEntityRecord', () => {
 
 		expect( data ).toEqual( {
 			edit: expect.any( Function ),
-			editedRecord: {},
+			editedRecord: { hello: 'world', id: 1 },
 			hasEdits: false,
 			record: { hello: 'world', id: 1 },
 			save: expect.any( Function ),
@@ -79,5 +79,45 @@ describe( 'useEntityRecord', () => {
 			isResolving: false,
 			status: 'SUCCESS',
 		} );
+	} );
+
+	it( 'applies edits to the entity record', async () => {
+		// Provide response
+		triggerFetch.mockImplementation( () => TEST_RECORD );
+
+		let widget;
+		const TestComponent = () => {
+			widget = useEntityRecord( 'root', 'widget', 1 );
+			return <div />;
+		};
+		render(
+			<RegistryProvider value={ registry }>
+				<TestComponent />
+			</RegistryProvider>
+		);
+
+		await act( async () => {
+			jest.advanceTimersByTime( 1 );
+		} );
+
+		expect( widget ).toEqual( {
+			edit: expect.any( Function ),
+			editedRecord: { hello: 'world', id: 1 },
+			hasEdits: false,
+			record: { hello: 'world', id: 1 },
+			save: expect.any( Function ),
+			hasResolved: true,
+			isResolving: false,
+			status: 'SUCCESS',
+		} );
+
+		await act( async () => {
+			widget.edit( { hello: 'foo' } );
+			jest.advanceTimersByTime( 1 );
+		} );
+
+		expect( widget.hasEdits ).toEqual( true );
+		expect( widget.record ).toEqual( { hello: 'world', id: 1 } );
+		expect( widget.editedRecord ).toEqual( { hello: 'foo', id: 1 } );
 	} );
 } );

--- a/packages/core-data/src/hooks/use-entity-record.ts
+++ b/packages/core-data/src/hooks/use-entity-record.ts
@@ -163,8 +163,16 @@ export default function useEntityRecord< RecordType >(
 
 	const { editedRecord, hasEdits } = useSelect(
 		( select ) => ( {
-			editedRecord: select( coreStore ).getEditedEntityRecord(),
-			hasEdits: select( coreStore ).hasEditsForEntityRecord(),
+			editedRecord: select( coreStore ).getEditedEntityRecord(
+				kind,
+				name,
+				recordId
+			),
+			hasEdits: select( coreStore ).hasEditsForEntityRecord(
+				kind,
+				name,
+				recordId
+			),
 		} ),
 		[ kind, name, recordId ]
 	);


### PR DESCRIPTION
## What?
`useEntityRecord` somehow did not pass the kind, name, and recordId to `getEditedEntityRecord` and `hasEditsForEntityRecord`. This PR solves that.

## Testing Instructions
Confirm the tests pass – this PR added a regression test.

cc @gziolo 
