### PR TITLE
[Mobile] - Add new KeyboardEvent.code attribute to RichText onKeyPress event

### DIFF
--- a/packages/react-native-aztec/src/AztecView.js
+++ b/packages/react-native-aztec/src/AztecView.js
@@ -12,7 +12,17 @@ import {
  * WordPress dependencies
  */
 import { Component, createRef } from '@wordpress/element';
-import { ENTER, BACKSPACE } from '@wordpress/keycodes';
+import {
+	BACKSPACE,
+	DELETE,
+	DOWN,
+	ENTER,
+	ESCAPE,
+	LEFT,
+	RIGHT,
+	SPACE,
+	UP,
+} from '@wordpress/keycodes';
 
 /**
  * Internal dependencies
@@ -20,6 +30,19 @@ import { ENTER, BACKSPACE } from '@wordpress/keycodes';
 import * as AztecInputState from './AztecInputState';
 
 const AztecManager = UIManager.getViewManagerConfig( 'RCTAztecView' );
+
+// Used to match KeyboardEvent.code values (from the Web API) with native keycodes.
+const KEYCODES = {
+	[ BACKSPACE ]: 'Backspace',
+	[ DELETE ]: 'Delete',
+	[ DOWN ]: 'ArrowDown',
+	[ ENTER ]: 'Enter',
+	[ ESCAPE ]: 'Escape',
+	[ LEFT ]: 'ArrowLeft',
+	[ RIGHT ]: 'ArrowRight',
+	[ SPACE ]: 'Space',
+	[ UP ]: 'ArrowUp',
+};
 
 class AztecView extends Component {
 	constructor() {
@@ -75,7 +98,7 @@ class AztecView extends Component {
 
 		const { onKeyDown } = this.props;
 
-		const newEvent = { ...event, keyCode: ENTER };
+		const newEvent = { ...event, keyCode: ENTER, code: KEYCODES[ ENTER ] };
 		onKeyDown( newEvent );
 	}
 
@@ -89,6 +112,7 @@ class AztecView extends Component {
 		const newEvent = {
 			...event,
 			keyCode: BACKSPACE,
+			code: KEYCODES[ BACKSPACE ],
 			preventDefault: () => {},
 		};
 		onKeyDown( newEvent );
@@ -100,9 +124,13 @@ class AztecView extends Component {
 		}
 
 		const { onKeyDown } = this.props;
+		const { keyCode } = event.nativeEvent;
 		const newEvent = {
 			...event,
-			keyCode: event.nativeEvent.keyCode,
+			keyCode,
+			...( KEYCODES[ keyCode ] && {
+				code: KEYCODES[ keyCode ],
+			} ),
 			preventDefault: () => {},
 		};
 		onKeyDown( newEvent );


### PR DESCRIPTION
**Related PRs:**
- `Gutenberg Mobile` -> https://github.com/wordpress-mobile/gutenberg-mobile/pull/5114

## What?
This PR adds the `code` attribute to the key events sent from the `AztecView` component.

## Why?

Since [keyCode](https://developer.mozilla.org/en-US/docs/Web/API/KeyboardEvent/keyCode) is deprecated and there's an ongoing effort to replace it with [code](https://developer.mozilla.org/en-US/docs/Web/API/KeyboardEvent/code) values, we are adding this on the native side to match with the web editor.

It also fixes a regression with the [slash inserter](https://github.com/WordPress/gutenberg/pull/43432) (Autocomplete).

## How?

By adding the `code` attribute for the key press events in the `AztecView` component. It matches the native key values with the [Web API values](https://developer.mozilla.org/en-US/docs/Web/API/UI_Events/Keyboard_event_code_values).

## Testing Instructions

- Open the app
- Type `/` in a Paragraph block and type the name of a block
- Tap the return key
- **Expect** the matched block name to be created correctly.

## Screenshots or screencast <!-- if applicable -->

<kbd><img src="https://user-images.githubusercontent.com/4885740/186165670-a870842a-8882-41f2-866c-30eca6fdbd75.gif" width="200" /></kbd>