### PR TITLE
added outline support for blocks via theme.json

### DIFF
--- a/docs/reference-guides/theme-json-reference/theme-json-living.md
+++ b/docs/reference-guides/theme-json-reference/theme-json-living.md
@@ -158,6 +158,19 @@ Color styles.
 
 ---
 
+### outline
+
+Outline styles.
+
+| Property  | Type   |  Props  |
+| ---       | ---    |---   |
+| color | string |  |
+| offset | string |  |
+| style | string |  |
+| width | string |  |
+
+---
+
 ### spacing
 
 Spacing styles.

--- a/lib/compat/wordpress-6.1/class-wp-theme-json-6-1.php
+++ b/lib/compat/wordpress-6.1/class-wp-theme-json-6-1.php
@@ -326,9 +326,9 @@ class WP_Theme_JSON_6_1 extends WP_Theme_JSON_6_0 {
 		'filter'     => array(
 			'duotone' => null,
 		),
-		'outline'     => array(
+		'outline'    => array(
 			'color'  => null,
-			'offset'  => null,
+			'offset' => null,
 			'style'  => null,
 			'width'  => null,
 		),

--- a/lib/compat/wordpress-6.1/class-wp-theme-json-6-1.php
+++ b/lib/compat/wordpress-6.1/class-wp-theme-json-6-1.php
@@ -66,6 +66,10 @@ class WP_Theme_JSON_6_1 extends WP_Theme_JSON_6_0 {
 		'margin-right'                      => array( 'spacing', 'margin', 'right' ),
 		'margin-bottom'                     => array( 'spacing', 'margin', 'bottom' ),
 		'margin-left'                       => array( 'spacing', 'margin', 'left' ),
+		'outline-color'                     => array( 'outline', 'color' ),
+		'outline-offset'                    => array( 'outline', 'offset' ),
+		'outline-style'                     => array( 'outline', 'style' ),
+		'outline-width'                     => array( 'outline', 'width' ),
 		'padding'                           => array( 'spacing', 'padding' ),
 		'padding-top'                       => array( 'spacing', 'padding', 'top' ),
 		'padding-right'                     => array( 'spacing', 'padding', 'right' ),
@@ -321,6 +325,12 @@ class WP_Theme_JSON_6_1 extends WP_Theme_JSON_6_0 {
 		'shadow'     => null,
 		'filter'     => array(
 			'duotone' => null,
+		),
+		'outline'     => array(
+			'color'  => null,
+			'offset'  => null,
+			'style'  => null,
+			'width'  => null,
 		),
 		'spacing'    => array(
 			'margin'   => null,

--- a/packages/style-engine/src/styles/index.ts
+++ b/packages/style-engine/src/styles/index.ts
@@ -4,12 +4,14 @@
 import border from './border';
 import color from './color';
 import shadow from './shadow';
+import outline from './outline';
 import spacing from './spacing';
 import typography from './typography';
 
 export const styleDefinitions = [
 	...border,
 	...color,
+	...outline,
 	...spacing,
 	...typography,
 	...shadow,

--- a/packages/style-engine/src/styles/outline/index.ts
+++ b/packages/style-engine/src/styles/outline/index.ts
@@ -1,0 +1,55 @@
+/**
+ * Internal dependencies
+ */
+import type { GeneratedCSSRule, Style, StyleOptions } from '../../types';
+import { generateRule } from '../utils';
+
+const color = {
+	name: 'color',
+	generate: (
+		style: Style,
+		options: StyleOptions,
+		path: string[] = [ 'outline', 'color' ],
+		ruleKey: string = 'outlineColor'
+	): GeneratedCSSRule[] => {
+		return generateRule( style, options, path, ruleKey );
+	},
+};
+
+const offset = {
+	name: 'offset',
+	generate: (
+		style: Style,
+		options: StyleOptions,
+		path: string[] = [ 'outline', 'offset' ],
+		ruleKey: string = 'outlineColor'
+	): GeneratedCSSRule[] => {
+		return generateRule( style, options, path, ruleKey );
+	},
+};
+
+const outlineStyle = {
+	name: 'style',
+	generate: (
+		style: Style,
+		options: StyleOptions,
+		path: string[] = [ 'outline', 'style' ],
+		ruleKey: string = 'outlineStyle'
+	): GeneratedCSSRule[] => {
+		return generateRule( style, options, path, ruleKey );
+	},
+};
+
+const width = {
+	name: 'width',
+	generate: (
+		style: Style,
+		options: StyleOptions,
+		path: string[] = [ 'outline', 'width' ],
+		ruleKey: string = 'outlineWidth'
+	): GeneratedCSSRule[] => {
+		return generateRule( style, options, path, ruleKey );
+	},
+};
+
+export default [ color, outlineStyle, offset, width ];

--- a/schemas/json/theme.json
+++ b/schemas/json/theme.json
@@ -981,6 +981,29 @@
 					},
 					"additionalProperties": false
 				},
+				"outline": {
+					"description": "Outline styles.",
+					"type": "object",
+					"properties": {
+						"color": {
+							"description": "Sets the `outline-color` CSS property.",
+							"type": "string"
+						},
+						"offset": {
+							"description": "Sets the `outline-offset` CSS property.",
+							"type": "string"
+						},
+						"style": {
+							"description": "Sets the `outline-style` CSS property.",
+							"type": "string"
+						},
+						"width": {
+							"description": "Sets the `outline-width` CSS property.",
+							"type": "string"
+						}
+					},
+					"additionalProperties": false
+				},
 				"spacing": {
 					"description": "Spacing styles.",
 					"type": "object",


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->
This PR adds support for outline for blocks and elements via theme.json

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
This is something themes have to add most of the time using CSS. We should discuss what's the best way to surface this to the UI and which blocks should show the option, but the first step is here to allow themes to set it using theme.json instead of having to write CSS for it.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
I implemented this following the lead of https://github.com/WordPress/gutenberg/pull/41972

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->

I'm testing TT3, with this in theme.json:

```
"elements": {
	"button": {
		"outline": {
			"offset": "3px",
			"width": "3px",
			"style": "dashed",
			"color": "red"
		},
		":hover": {
			"outline": {
				"offset": "3px",
				"width": "3px",
				"style": "solid",
				"color": "blue"
			}
		}
	}
}
```

## Screenshots or screencast <!-- if applicable -->

![Screen Capture on 2022-08-23 at 16-45-03](https://user-images.githubusercontent.com/3593343/186188731-7f8076a1-9733-45c3-8985-34e3b99aff39.gif)


/cc @WordPress/block-themers 