### PR TITLE
Comments block (legacy mode): Update warning message wording

### DIFF
--- a/packages/block-library/src/comments/edit/comments-legacy.js
+++ b/packages/block-library/src/comments/edit/comments-legacy.js
@@ -57,8 +57,8 @@ export default function CommentsLegacy( {
 			<div { ...blockProps }>
 				<Warning actions={ actions }>
 					{ __(
-						"Comments block: You're currently using the legacy version. " +
-							'The following is just a placeholder -- it might look different on the frontend. ' +
+						"Comments block: You're currently using the legacy version of the block. " +
+							'The following is just a placeholder - the final styling will likely look different. ' +
 							'For a better representation and more customization options, ' +
 							'switch the block to its editable mode.'
 					) }

--- a/packages/block-library/src/comments/edit/comments-legacy.js
+++ b/packages/block-library/src/comments/edit/comments-legacy.js
@@ -57,11 +57,10 @@ export default function CommentsLegacy( {
 			<div { ...blockProps }>
 				<Warning actions={ actions }>
 					{ __(
-						"Comments block: You're currently using this block in legacy mode. " +
-							'The following is just a placeholder, not a real comment. ' +
-							'The final styling may differ because it also depends on the current theme. ' +
-							'For better compatibility with the Block Editor, ' +
-							'please consider switching the block to its editable mode.'
+						"Comments block: You're currently using the legacy version. " +
+							'The following is just a placeholder -- it might look different on the frontend. ' +
+							'For a better representation and more customization options, ' +
+							'switch the block to its editable mode.'
 					) }
 				</Warning>
 				<Placeholder postId={ postId } postType={ postType } />


### PR DESCRIPTION
## What?
Update the wording of the Comments block's legacy mode warning message.

## Why?
The previous message was too long and verbose.

## How?
The new message is based on @annezazu's suggestion from [here](https://github.com/WordPress/gutenberg/issues/43203#issuecomment-1222576114):

> Comments block: You’re currently using the legacy version. What you see is a placeholder with the styling based on the current theme. For the latest updates, switch the block to its editable mode.

I've modified that suggestion a bit:

1. _a placeholder with the styling based on the current theme_: While the styling is partly based on the current theme, the main problem is that the block in the editor still looks quite different from the frontend. (Also note that the message was previously claiming kind of the opposite: _"The final styling may differ because it also depends on the current theme."_
2. _For the latest updates, switch the block to its editable mode._: As a user, having the "latest updates" isn't the most compelling reason for me to change a block 😅

I'm open to changing the copy some more -- I realize it might not be quite there yet 😅 

## Testing Instructions

You need the legacy mode of the Comments block. This is easily accessed by e.g. editing the "Single" template of the TT2 theme, or by manually inserting `<!-- wp:comments {"legacy":true} /--></div>` into the Code Editor.

## Screenshots or screencast

| Before | After |
|--------|------|
| <img width="668" alt="Bildschirmfoto 2022-08-16 um 17 15 56" src="https://user-images.githubusercontent.com/96308/184917164-f35d4fff-592b-4b94-abe1-22c92810b416.png"> | ![image](https://user-images.githubusercontent.com/96308/186190954-4712101b-7c11-44e2-81bf-850edfba9858.png) | 
