### PR TITLE
[data] Add type signature for useDispatch

### DIFF
--- a/packages/data/README.md
+++ b/packages/data/README.md
@@ -749,11 +749,11 @@ const SaleButton = ( { children } ) => {
 
 _Parameters_
 
--   _storeNameOrDescriptor_ `[T]`: Optionally provide the name of the store or its descriptor from which to retrieve action creators. If not provided, the registry.dispatch function is returned instead.
+-   _storeNameOrDescriptor_ `[StoreNameOrDescriptor]`: Optionally provide the name of the store or its descriptor from which to retrieve action creators. If not provided, the registry.dispatch function is returned instead.
 
 _Returns_
 
--   `UseDispatchReturn<T>`: A custom react hook.
+-   `UseDispatchReturn<StoreNameOrDescriptor>`: A custom react hook.
 
 ### useRegistry
 

--- a/packages/data/README.md
+++ b/packages/data/README.md
@@ -749,11 +749,11 @@ const SaleButton = ( { children } ) => {
 
 _Parameters_
 
--   _storeNameOrDescriptor_ `[string|StoreDescriptor]`: Optionally provide the name of the store or its descriptor from which to retrieve action creators. If not provided, the registry.dispatch function is returned instead.
+-   _storeNameOrDescriptor_ `[T]`: Optionally provide the name of the store or its descriptor from which to retrieve action creators. If not provided, the registry.dispatch function is returned instead.
 
 _Returns_
 
--   `Function`: A custom react hook.
+-   `UseDispatchReturn<T>`: A custom react hook.
 
 ### useRegistry
 

--- a/packages/data/src/components/use-dispatch/use-dispatch.js
+++ b/packages/data/src/components/use-dispatch/use-dispatch.js
@@ -3,7 +3,14 @@
  */
 import useRegistry from '../registry-provider/use-registry';
 
-/** @typedef {import('../../types').StoreDescriptor} StoreDescriptor */
+/**
+ * @typedef {import('../../types').StoreDescriptor<C>} StoreDescriptor
+ * @template C
+ */
+/**
+ * @typedef {import('../../types').UseDispatchReturn<T>} UseDispatchReturn
+ * @template T
+ */
 
 /**
  * A custom react hook returning the current registry dispatch actions creators.
@@ -11,11 +18,12 @@ import useRegistry from '../registry-provider/use-registry';
  * Note: The component using this hook must be within the context of a
  * RegistryProvider.
  *
- * @param {string|StoreDescriptor} [storeNameOrDescriptor] Optionally provide the name of the
- *                                                         store or its descriptor from which to
- *                                                         retrieve action creators. If not
- *                                                         provided, the registry.dispatch
- *                                                         function is returned instead.
+ * @template {undefined | string | StoreDescriptor<any>} [T=undefined]
+ * @param {T} [storeNameOrDescriptor] Optionally provide the name of the
+ *                                    store or its descriptor from which to
+ *                                    retrieve action creators. If not
+ *                                    provided, the registry.dispatch
+ *                                    function is returned instead.
  *
  * @example
  * This illustrates a pattern where you may need to retrieve dynamic data from
@@ -48,7 +56,7 @@ import useRegistry from '../registry-provider/use-registry';
  * //
  * // <SaleButton>Start Sale!</SaleButton>
  * ```
- * @return {Function}  A custom react hook.
+ * @return {UseDispatchReturn<T>} A custom react hook.
  */
 const useDispatch = ( storeNameOrDescriptor ) => {
 	const { dispatch } = useRegistry();

--- a/packages/data/src/components/use-dispatch/use-dispatch.js
+++ b/packages/data/src/components/use-dispatch/use-dispatch.js
@@ -4,12 +4,12 @@
 import useRegistry from '../registry-provider/use-registry';
 
 /**
- * @typedef {import('../../types').StoreDescriptor<C>} StoreDescriptor
- * @template C
+ * @typedef {import('../../types').StoreDescriptor<StoreConfig>} StoreDescriptor
+ * @template StoreConfig
  */
 /**
- * @typedef {import('../../types').UseDispatchReturn<T>} UseDispatchReturn
- * @template T
+ * @typedef {import('../../types').UseDispatchReturn<StoreNameOrDescriptor>} UseDispatchReturn
+ * @template StoreNameOrDescriptor
  */
 
 /**
@@ -18,12 +18,12 @@ import useRegistry from '../registry-provider/use-registry';
  * Note: The component using this hook must be within the context of a
  * RegistryProvider.
  *
- * @template {undefined | string | StoreDescriptor<any>} [T=undefined]
- * @param {T} [storeNameOrDescriptor] Optionally provide the name of the
- *                                    store or its descriptor from which to
- *                                    retrieve action creators. If not
- *                                    provided, the registry.dispatch
- *                                    function is returned instead.
+ * @template {undefined | string | StoreDescriptor<any>} [StoreNameOrDescriptor=undefined]
+ * @param {StoreNameOrDescriptor} [storeNameOrDescriptor] Optionally provide the name of the
+ *                                                        store or its descriptor from which to
+ *                                                        retrieve action creators. If not
+ *                                                        provided, the registry.dispatch
+ *                                                        function is returned instead.
  *
  * @example
  * This illustrates a pattern where you may need to retrieve dynamic data from
@@ -56,7 +56,7 @@ import useRegistry from '../registry-provider/use-registry';
  * //
  * // <SaleButton>Start Sale!</SaleButton>
  * ```
- * @return {UseDispatchReturn<T>} A custom react hook.
+ * @return {UseDispatchReturn<StoreNameOrDescriptor>} A custom react hook.
  */
 const useDispatch = ( storeNameOrDescriptor ) => {
 	const { dispatch } = useRegistry();

--- a/packages/data/src/types.ts
+++ b/packages/data/src/types.ts
@@ -50,14 +50,18 @@ export type UseSelectReturn< F extends MapSelect | StoreDescriptor< any > > =
 		? CurriedSelectorsOf< F >
 		: never;
 
-export type UseDispatchReturn< S extends undefined | StoreDescriptor< any > > =
-	S extends StoreDescriptor< any >
-		? ActionCreatorsOf< ConfigOf< S > >
-		: < T >(
-				store: T
-		  ) => T extends StoreDescriptor< any >
-				? ActionCreatorsOf< ConfigOf< T > >
-				: any;
+export type UseDispatchReturn< StoreNameOrDescriptor > =
+	StoreNameOrDescriptor extends StoreDescriptor< any >
+		? ActionCreatorsOf< ConfigOf< StoreNameOrDescriptor > >
+		: StoreNameOrDescriptor extends undefined
+		? DispatchFunction
+		: any;
+
+export type DispatchFunction = < StoreNameOrDescriptor >(
+	store: StoreNameOrDescriptor
+) => StoreNameOrDescriptor extends StoreDescriptor< any >
+	? ActionCreatorsOf< ConfigOf< StoreNameOrDescriptor > >
+	: any;
 
 export type MapSelect = ( select: SelectFunction ) => any;
 

--- a/packages/data/src/types.ts
+++ b/packages/data/src/types.ts
@@ -50,6 +50,15 @@ export type UseSelectReturn< F extends MapSelect | StoreDescriptor< any > > =
 		? CurriedSelectorsOf< F >
 		: never;
 
+export type UseDispatchReturn< S extends undefined | StoreDescriptor< any > > =
+	S extends StoreDescriptor< any >
+		? ActionCreatorsOf< ConfigOf< S > >
+		: < T >(
+				store: T
+		  ) => T extends StoreDescriptor< any >
+				? ActionCreatorsOf< ConfigOf< T > >
+				: any;
+
 export type MapSelect = ( select: SelectFunction ) => any;
 
 export type SelectFunction = < S >( store: S ) => CurriedSelectorsOf< S >;
@@ -91,9 +100,11 @@ export interface DataEmitter {
 
 // Type Helpers.
 
-type ActionCreatorsOf< Config extends AnyConfig > =
+export type ConfigOf< S > = S extends StoreDescriptor< infer C > ? C : never;
+
+export type ActionCreatorsOf< Config extends AnyConfig > =
 	Config extends ReduxStoreConfig< any, infer ActionCreators, any >
-		? { [ name in keyof ActionCreators ]: Function | Generator }
+		? ActionCreators
 		: never;
 
 type SelectorsOf< Config extends AnyConfig > = Config extends ReduxStoreConfig<


### PR DESCRIPTION
## What?
Adds a TypeScript signature for `useDispatch` of `@wordpress/data`. This provides autocompletion for TypeScript code:

<img width="642" alt="CleanShot 2022-08-23 at 17 11 57@2x" src="https://user-images.githubusercontent.com/205419/186195256-4137ee97-e9a5-4901-9217-aa63d4b21bcf.png">

## Testing Instructions

1. Apply this PR
2. Paste the following code at the end of the `use-dispatch.js`:

```js
import createReduxStore from "../../redux-store";

const config = {
	reducer: () => null,
	selectors: {},
	actions: {
		/**
		 * @param {string} singleArg
		 * @return {number}
		 */
		testAction: ( singleArg ) => 1,
	},
};

const store = createReduxStore( 'STORE_NAME', config );

useDispatch( store );
```

3. Test the autocompletion


cc @gziolo 
