### PR TITLE
Close the dropdown when creating a new menu in the Nav block

### DIFF
--- a/packages/block-library/src/navigation/edit/index.js
+++ b/packages/block-library/src/navigation/edit/index.js
@@ -597,7 +597,9 @@ function Navigation( {
 			<TagName { ...blockProps }>
 				<BlockControls>
 					<ToolbarGroup className="wp-block-navigation__toolbar-menu-selector">
-						{ ! isCreatingNavigationMenu && (
+						{ ! (
+							isCreatingNavigationMenu || isConvertingClassicMenu
+						) && (
 							<NavigationMenuSelector
 								ref={ null }
 								currentMenuId={ null }
@@ -670,7 +672,9 @@ function Navigation( {
 			<TagName { ...blockProps }>
 				<BlockControls>
 					<ToolbarGroup className="wp-block-navigation__toolbar-menu-selector">
-						{ ! isCreatingNavigationMenu && (
+						{ ! (
+							isCreatingNavigationMenu || isConvertingClassicMenu
+						) && (
 							<NavigationMenuSelector
 								ref={ navigationSelectorRef }
 								currentMenuId={ ref }
@@ -777,7 +781,10 @@ function Navigation( {
 				<BlockControls>
 					{ ! isDraftNavigationMenu && isEntityAvailable && (
 						<ToolbarGroup className="wp-block-navigation__toolbar-menu-selector">
-							{ ! isCreatingNavigationMenu && (
+							{ ! (
+								isCreatingNavigationMenu ||
+								isConvertingClassicMenu
+							) && (
 								<NavigationMenuSelector
 									ref={ navigationSelectorRef }
 									currentMenuId={ ref }

--- a/packages/block-library/src/navigation/edit/index.js
+++ b/packages/block-library/src/navigation/edit/index.js
@@ -597,29 +597,35 @@ function Navigation( {
 			<TagName { ...blockProps }>
 				<BlockControls>
 					<ToolbarGroup className="wp-block-navigation__toolbar-menu-selector">
-						<NavigationMenuSelector
-							ref={ null }
-							currentMenuId={ null }
-							clientId={ clientId }
-							onSelectNavigationMenu={ ( menuId ) => {
-								handleUpdateMenu( menuId );
-								setShouldFocusNavigationSelector( true );
-							} }
-							onSelectClassicMenu={ async ( classicMenu ) => {
-								const navMenu = await convertClassicMenu(
-									classicMenu.id,
-									classicMenu.name
-								);
-								if ( navMenu ) {
-									handleUpdateMenu( navMenu.id );
+						{ ! isCreatingNavigationMenu && (
+							<NavigationMenuSelector
+								ref={ null }
+								currentMenuId={ null }
+								clientId={ clientId }
+								onSelectNavigationMenu={ ( menuId ) => {
+									handleUpdateMenu( menuId );
 									setShouldFocusNavigationSelector( true );
+								} }
+								onSelectClassicMenu={ async ( classicMenu ) => {
+									const navMenu = await convertClassicMenu(
+										classicMenu.id,
+										classicMenu.name
+									);
+									if ( navMenu ) {
+										handleUpdateMenu( navMenu.id );
+										setShouldFocusNavigationSelector(
+											true
+										);
+									}
+								} }
+								onCreateNew={ () =>
+									createNavigationMenu( '', [] )
 								}
-							} }
-							onCreateNew={ () => createNavigationMenu( '', [] ) }
-							/* translators: %s: The name of a menu. */
-							actionLabel={ __( "Switch to '%s'" ) }
-							showManageActions
-						/>
+								/* translators: %s: The name of a menu. */
+								actionLabel={ __( "Switch to '%s'" ) }
+								showManageActions
+							/>
+						) }
 					</ToolbarGroup>
 				</BlockControls>
 				{ stylingInspectorControls }
@@ -664,29 +670,35 @@ function Navigation( {
 			<TagName { ...blockProps }>
 				<BlockControls>
 					<ToolbarGroup className="wp-block-navigation__toolbar-menu-selector">
-						<NavigationMenuSelector
-							ref={ navigationSelectorRef }
-							currentMenuId={ ref }
-							clientId={ clientId }
-							onSelectNavigationMenu={ ( menuId ) => {
-								handleUpdateMenu( menuId );
-								setShouldFocusNavigationSelector( true );
-							} }
-							onSelectClassicMenu={ async ( classicMenu ) => {
-								const navMenu = await convertClassicMenu(
-									classicMenu.id,
-									classicMenu.name
-								);
-								if ( navMenu ) {
-									handleUpdateMenu( navMenu.id );
+						{ ! isCreatingNavigationMenu && (
+							<NavigationMenuSelector
+								ref={ navigationSelectorRef }
+								currentMenuId={ ref }
+								clientId={ clientId }
+								onSelectNavigationMenu={ ( menuId ) => {
+									handleUpdateMenu( menuId );
 									setShouldFocusNavigationSelector( true );
+								} }
+								onSelectClassicMenu={ async ( classicMenu ) => {
+									const navMenu = await convertClassicMenu(
+										classicMenu.id,
+										classicMenu.name
+									);
+									if ( navMenu ) {
+										handleUpdateMenu( navMenu.id );
+										setShouldFocusNavigationSelector(
+											true
+										);
+									}
+								} }
+								onCreateNew={ () =>
+									createNavigationMenu( '', [] )
 								}
-							} }
-							onCreateNew={ () => createNavigationMenu( '', [] ) }
-							/* translators: %s: The name of a menu. */
-							actionLabel={ __( "Switch to '%s'" ) }
-							showManageActions
-						/>
+								/* translators: %s: The name of a menu. */
+								actionLabel={ __( "Switch to '%s'" ) }
+								showManageActions
+							/>
+						) }
 					</ToolbarGroup>
 				</BlockControls>
 				<Warning>
@@ -765,33 +777,40 @@ function Navigation( {
 				<BlockControls>
 					{ ! isDraftNavigationMenu && isEntityAvailable && (
 						<ToolbarGroup className="wp-block-navigation__toolbar-menu-selector">
-							<NavigationMenuSelector
-								ref={ navigationSelectorRef }
-								currentMenuId={ ref }
-								clientId={ clientId }
-								onSelectNavigationMenu={ ( menuId ) => {
-									handleUpdateMenu( menuId );
-									setShouldFocusNavigationSelector( true );
-								} }
-								onSelectClassicMenu={ async ( classicMenu ) => {
-									const navMenu = await convertClassicMenu(
-										classicMenu.id,
-										classicMenu.name
-									);
-									if ( navMenu ) {
-										handleUpdateMenu( navMenu.id );
+							{ ! isCreatingNavigationMenu && (
+								<NavigationMenuSelector
+									ref={ navigationSelectorRef }
+									currentMenuId={ ref }
+									clientId={ clientId }
+									onSelectNavigationMenu={ ( menuId ) => {
+										handleUpdateMenu( menuId );
 										setShouldFocusNavigationSelector(
 											true
 										);
+									} }
+									onSelectClassicMenu={ async (
+										classicMenu
+									) => {
+										const navMenu =
+											await convertClassicMenu(
+												classicMenu.id,
+												classicMenu.name
+											);
+										if ( navMenu ) {
+											handleUpdateMenu( navMenu.id );
+											setShouldFocusNavigationSelector(
+												true
+											);
+										}
+									} }
+									onCreateNew={ () =>
+										createNavigationMenu( '', [] )
 									}
-								} }
-								onCreateNew={ () =>
-									createNavigationMenu( '', [] )
-								}
-								/* translators: %s: The name of a menu. */
-								actionLabel={ __( "Switch to '%s'" ) }
-								showManageActions
-							/>
+									/* translators: %s: The name of a menu. */
+									actionLabel={ __( "Switch to '%s'" ) }
+									showManageActions
+								/>
+							) }
 						</ToolbarGroup>
 					) }
 				</BlockControls>

--- a/packages/block-library/src/navigation/edit/navigation-menu-selector.js
+++ b/packages/block-library/src/navigation/edit/navigation-menu-selector.js
@@ -124,7 +124,12 @@ function NavigationMenuSelector(
 					{ showManageActions && hasManagePermissions && (
 						<MenuGroup label={ __( 'Tools' ) }>
 							{ canUserCreateNavigationMenu && (
-								<MenuItem onClick={ onCreateNew }>
+								<MenuItem
+									onClick={ () => {
+										onClose();
+										onCreateNew();
+									} }
+								>
 									{ __( 'Create new menu' ) }
 								</MenuItem>
 							) }


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Fixes the Nav block so that when you click `Create new menu` the UI responds immediately and the dropdown menu is closed.

Also protects against repeatedly triggering the "create" or "convert classic" actions by hiding the dropdown meny entirely if one of these actions is in progress.

**Question**: is it ok to remove the Select Menu from the DOM due to a11y focus concerns?

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

Previously if you click on `Create new menu` under the `Select Menu` dropdown the UI would appear unresponsive in that the dropdown would remain open. Granted thanks to [previous work](https://github.com/WordPress/gutenberg/pull/39219) the block showed some feedback as to the progress but the dropdown obsecured this.

What's worse is that because the `Create new menu` option wasn't disabled, you could simply click the menu option multiple times leading to multiple copies of the same Navigation being created.

You could also do the same with the convert classic menus action.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

This PR calls the `onClose` callback to ensure that the dropdown is closed as soon as you click on the `Create new menu` option. This ensures that the previous problems are removed.

It also ensures that the dropdown menu is not in the DOM if either creating a menu or converting a classic menu.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->

It's worth trying the following on a slow network connection (tip: use dev tools!) to really see the difference between this PR and `trunk`:

1. Add new Nav block.
2. Click `Select menu` and then click `Create new menu`. 
3. Observe the dropdown closes immediately.
4. Observe that the dropdown is no longer accessible in the DOM during the creation process.

Repeat the above but this time try converting a classic menu instead.


## Screenshots or screencast <!-- if applicable -->

https://user-images.githubusercontent.com/444434/186203872-d123db05-6c08-4a7f-b1bf-b6e3f2ea13d8.mov


