### PR TITLE
Fix navigation appender position to prevent obstructing its items

### DIFF
--- a/packages/block-library/src/navigation-link/editor.scss
+++ b/packages/block-library/src/navigation-link/editor.scss
@@ -1,4 +1,12 @@
 /**
+ * Appender
+ */
+
+.wp-block-navigation .block-list-appender {
+	position: relative;
+}
+
+/**
  * Submenus.
  */
 


### PR DESCRIPTION
## What?
Suggest a fix for https://github.com/WordPress/gutenberg/issues/42010.

Closes https://github.com/WordPress/gutenberg/issues/42010

## How?

This PR removes the absolute position for the appended when it is inside of the navigation block.

## Testing Instructions
1. Create a menu and add several items

The aggregator should appear next to the last element, not on top of it.

