### PR TITLE
Element: Remove `enzyme` from `platform` test

### DIFF
--- a/packages/element/src/test/platform.js
+++ b/packages/element/src/test/platform.js
@@ -1,8 +1,4 @@
 /**
- * External dependencies
- */
-import { shallow } from 'enzyme';
-/**
  * Internal dependencies
  */
 import Platform from '../platform';
@@ -10,10 +6,10 @@ import Platform from '../platform';
 describe( 'Platform', () => {
 	it( 'is chooses the right thing', () => {
 		const element = Platform.select( {
-			web: shallow( <div></div> ),
-			native: shallow( <button></button> ),
+			web: <div />,
+			native: <button />,
 		} );
 
-		expect( element.type() ).toBe( 'div' );
+		expect( element ).toEqual( <div /> );
 	} );
 } );


### PR DESCRIPTION
## What?
This PR refactors the `@wordpress/element` Platform.select() tests to no longer use `enzyme`. 

## Why?
Migrating away from `enzyme` is important as `enzyme` is one of the blockers for upgrading to React 18.

## How?

This utility doesn't need to be rendered in order to be tested, so we're just directly testing against it.

## Testing Instructions
Verify tests pass: `npm run test:unit packages/element/src/test/platform.js`