### PR TITLE
Latest Posts: Add typography supports

### DIFF
--- a/docs/reference-guides/core-blocks.md
+++ b/docs/reference-guides/core-blocks.md
@@ -329,7 +329,7 @@ Display a list of your most recent posts. ([Source](https://github.com/WordPress
 
 -	**Name:** core/latest-posts
 -	**Category:** widgets
--	**Supports:** align, ~~html~~
+-	**Supports:** align, typography (fontSize, lineHeight), ~~html~~
 -	**Attributes:** addLinkToFeaturedImage, categories, columns, displayAuthor, displayFeaturedImage, displayPostContent, displayPostContentRadio, displayPostDate, excerptLength, featuredImageAlign, featuredImageSizeHeight, featuredImageSizeSlug, featuredImageSizeWidth, order, orderBy, postLayout, postsToShow, selectedAuthor
 
 ## List

--- a/packages/block-library/src/latest-posts/block.json
+++ b/packages/block-library/src/latest-posts/block.json
@@ -84,7 +84,20 @@
 	},
 	"supports": {
 		"align": true,
-		"html": false
+		"html": false,
+		"typography": {
+			"fontSize": true,
+			"lineHeight": true,
+			"__experimentalFontFamily": true,
+			"__experimentalFontWeight": true,
+			"__experimentalFontStyle": true,
+			"__experimentalTextTransform": true,
+			"__experimentalTextDecoration": true,
+			"__experimentalLetterSpacing": true,
+			"__experimentalDefaultControls": {
+				"fontSize": true
+			}
+		}
 	},
 	"editorStyle": "wp-block-latest-posts-editor",
 	"style": "wp-block-latest-posts"


### PR DESCRIPTION
Related:
- https://github.com/WordPress/gutenberg/issues/43241
- https://github.com/WordPress/gutenberg/issues/43242
- https://github.com/WordPress/gutenberg/pull/29623

## What?

Adds typography supports to the Latest Posts block at the root block level. 

This is an alternative approach to specifically targeting post titles only as per https://github.com/WordPress/gutenberg/pull/29623. 

It is worth considering whether we should start by applying typography settings at the root level or for specific inner blocks. Should we decide on the later, leveraging feature level selectors would likely be our best bet where we could easily target not just the title but dates and authors as well, excluding any post content or excerpt.

## Why?

- Improves consistency of our design tools across blocks.
- Provides high level control over the typography of all elements making up the Latest Posts block.

## How?

- Opts into all typography supports.
- Makes font size control displayed by default as per majority of blocks currently.

## Testing Instructions

1. Edit a post, add a Latest Posts block, and select it.
2. Adjust its typography via the sidebar.
3. Experiment with all the various toggles for the Latest Posts block e.g. displaying excerpts or full post content, author names, post dates etc.
3. Ensure the selected styles are reflected in both the editor and frontend.
4. Reset the blocks styles and save.
4. Load the site editor and navigate to Global Styles > Blocks > Latest Posts > Typography.
5. Double check that adjusted typography settings are reflected in the preview and are applied on frontend after saving.
6. Confirm that theme.json styling of the Latest Posts works as expected.
7. See if you can replicate issue raised here: https://github.com/WordPress/gutenberg/pull/29623#issuecomment-792742446

Example theme.json snippet:
```json
			"core/latest-posts": {
				"typography": {
					"fontWeight": "100",
					"textTransform": "uppercase"
				}
			}
```

## Screenshots or screencast <!-- if applicable -->


https://user-images.githubusercontent.com/60436221/186302315-62aed041-50f5-4e7c-b705-6e56cde059cf.mp4


