### PR TITLE
Navigation: Add missing typography support

### DIFF
--- a/packages/block-library/src/navigation/block.json
+++ b/packages/block-library/src/navigation/block.json
@@ -94,6 +94,7 @@
 			"__experimentalFontWeight": true,
 			"__experimentalTextTransform": true,
 			"__experimentalFontFamily": true,
+			"__experimentalLetterSpacing": true,
 			"__experimentalTextDecoration": true,
 			"__experimentalSkipSerialization": [ "textDecoration" ],
 			"__experimentalDefaultControls": {


### PR DESCRIPTION
Related:
- https://github.com/WordPress/gutenberg/issues/43241
- https://github.com/WordPress/gutenberg/issues/43242

## What?

Adds missing typography supports to the Navigation block.

## Why?

- Improves consistency of our design tools across blocks.

## How?

- Opts into missing letter-spacing typography support.

## Testing Instructions

1. In the site editor, select a navigation block.
2. Navigate to Global Styles > Blocks > Navigation > Typography
3. Adjust the letter-spacing value, ensuring it is reflected in both the preview and the frontend.
2. Switch to the "Settings" sidebar, then select a navigation block.
2. Adjust the letter-spacing control here and ensure it overrides the global style.
4. Clear customizations and test that letter spacing can be applied via theme.json

Example theme.json snippet:
```json
			"core/navigation": {
				"typography": {
					"letterSpacing": "3px"
				}
			}
```

## Screenshots or screencast <!-- if applicable -->

https://user-images.githubusercontent.com/60436221/186312306-a13c0e14-d31c-433f-bb5c-0df36fdc2d82.mp4


