### PR TITLE
Add cite to theme.json elements

### DIFF
--- a/lib/compat/wordpress-6.1/class-wp-theme-json-6-1.php
+++ b/lib/compat/wordpress-6.1/class-wp-theme-json-6-1.php
@@ -97,6 +97,7 @@ class WP_Theme_JSON_6_1 extends WP_Theme_JSON_6_0 {
 		'h6'      => 'h6',
 		'button'  => '.wp-element-button, .wp-block-button__link', // We have the .wp-block-button__link class so that this will target older buttons that have been serialized.
 		'caption' => '.wp-element-caption, .wp-block-audio figcaption, .wp-block-embed figcaption, .wp-block-gallery figcaption, .wp-block-image figcaption, .wp-block-table figcaption, .wp-block-video figcaption', // The block classes are necessary to target older content that won't use the new class names.
+		'cite'    => 'cite, .wp-block-quote cite, .wp-block-pullquote cite'
 	);
 
 	const __EXPERIMENTAL_ELEMENT_CLASS_NAMES = array(

--- a/lib/compat/wordpress-6.1/class-wp-theme-json-6-1.php
+++ b/lib/compat/wordpress-6.1/class-wp-theme-json-6-1.php
@@ -97,7 +97,7 @@ class WP_Theme_JSON_6_1 extends WP_Theme_JSON_6_0 {
 		'h6'      => 'h6',
 		'button'  => '.wp-element-button, .wp-block-button__link', // We have the .wp-block-button__link class so that this will target older buttons that have been serialized.
 		'caption' => '.wp-element-caption, .wp-block-audio figcaption, .wp-block-embed figcaption, .wp-block-gallery figcaption, .wp-block-image figcaption, .wp-block-table figcaption, .wp-block-video figcaption', // The block classes are necessary to target older content that won't use the new class names.
-		'cite'    => 'cite, .wp-block-quote cite, .wp-block-pullquote cite'
+		'cite'    => 'cite'
 	);
 
 	const __EXPERIMENTAL_ELEMENT_CLASS_NAMES = array(

--- a/lib/compat/wordpress-6.1/class-wp-theme-json-6-1.php
+++ b/lib/compat/wordpress-6.1/class-wp-theme-json-6-1.php
@@ -97,7 +97,7 @@ class WP_Theme_JSON_6_1 extends WP_Theme_JSON_6_0 {
 		'h6'      => 'h6',
 		'button'  => '.wp-element-button, .wp-block-button__link', // We have the .wp-block-button__link class so that this will target older buttons that have been serialized.
 		'caption' => '.wp-element-caption, .wp-block-audio figcaption, .wp-block-embed figcaption, .wp-block-gallery figcaption, .wp-block-image figcaption, .wp-block-table figcaption, .wp-block-video figcaption', // The block classes are necessary to target older content that won't use the new class names.
-		'cite'    => 'cite'
+		'cite'    => 'cite',
 	);
 
 	const __EXPERIMENTAL_ELEMENT_CLASS_NAMES = array(

--- a/packages/blocks/src/api/constants.js
+++ b/packages/blocks/src/api/constants.js
@@ -226,6 +226,7 @@ export const __EXPERIMENTAL_ELEMENTS = {
 	button: '.wp-element-button, .wp-block-button__link',
 	caption:
 		'.wp-element-caption, .wp-block-audio figcaption, .wp-block-embed figcaption, .wp-block-gallery figcaption, .wp-block-image figcaption, .wp-block-table figcaption, .wp-block-video figcaption',
+	cite: 'cite, .wp-block-quote cite, .wp-block-pullquote cite',
 };
 
 export const __EXPERIMENTAL_PATHS_WITH_MERGE = {

--- a/packages/blocks/src/api/constants.js
+++ b/packages/blocks/src/api/constants.js
@@ -226,7 +226,7 @@ export const __EXPERIMENTAL_ELEMENTS = {
 	button: '.wp-element-button, .wp-block-button__link',
 	caption:
 		'.wp-element-caption, .wp-block-audio figcaption, .wp-block-embed figcaption, .wp-block-gallery figcaption, .wp-block-image figcaption, .wp-block-table figcaption, .wp-block-video figcaption',
-	cite: 'cite, .wp-block-quote cite, .wp-block-pullquote cite',
+	cite: 'cite',
 };
 
 export const __EXPERIMENTAL_PATHS_WITH_MERGE = {

--- a/schemas/json/theme.json
+++ b/schemas/json/theme.json
@@ -1163,6 +1163,9 @@
 				},
 				"caption": {
 					"$ref": "#/definitions/stylesPropertiesComplete"
+				},
+				"cite": {
+					"$ref": "#/definitions/stylesPropertiesComplete"
 				}
 			},
 			"additionalProperties": false


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->
Alternative to #42851, without the CSS class names.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
To make it possible to style citations separate from the quote and pullquote.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
This PR adds cite to theme.json elements, and also updates the schema.

## Testing Instructions
Add the following to theme.json:
```
{
	"version": 2,
	"styles": {
		"elements": {
			"cite": {
				"color": {
					"text": "red"
				},
				"typography": {
					"fontSize": "40px",
					"lineHeight": ".7"
				}
			}
		}
	}
}
```

In either editor, add a quote block and a pullquote block.
Confirm that the styles applies correctly in the editors and front.

## Screenshots or screencast <!-- if applicable -->
