### PR TITLE
Fix block settings dropdown positioning when scrolling in the site editor

### DIFF
--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -17,6 +17,7 @@
 -   `Popover`: make sure offset middleware always applies the latest frame offset values ([#43329](https://github.com/WordPress/gutenberg/pull/43329/)).
 -   `Dropdown`: anchor popover to the dropdown wrapper (instead of the toggle) ([#43377](https://github.com/WordPress/gutenberg/pull/43377/)).
 -   `Guide`: Fix error when rendering with no pages ([#43380](https://github.com/WordPress/gutenberg/pull/43380/)).
+-   `Popover`: Ensure position is correct when a nested popover's parent references an element in an iframe and the iframe is scrolled ([#43544](https://github.com/WordPress/gutenberg/pull/43544/)).
 
 ### Enhancements
 

--- a/packages/components/src/popover/index.js
+++ b/packages/components/src/popover/index.js
@@ -469,6 +469,8 @@ const Popover = (
 	let content = (
 		<RootReferenceDocumentProvider
 			// Don't overwrite the root document if it's already set.
+			// This ensures only the reference document from the very
+			// root popover is provided.
 			value={ rootReferenceDocument ?? referenceOwnerDocument }
 		>
 			{

--- a/packages/components/src/popover/index.js
+++ b/packages/components/src/popover/index.js
@@ -49,9 +49,9 @@ import {
 	placementToMotionAnimationProps,
 } from './utils';
 import {
-	useRootDocumentContext,
-	RootDocumentProvider,
-} from './root-document-context';
+	useRootReferenceDocument,
+	RootReferenceDocumentProvider,
+} from './root-reference-document-context';
 
 /**
  * Name of slot in which popover should fill.
@@ -438,7 +438,7 @@ const Popover = (
 	// position. This covers cases where a popover is a child of another
 	// popover, and the first popover in the chain references an element
 	// in an iframe.
-	const rootReferenceDocument = useRootDocumentContext();
+	const rootReferenceDocument = useRootReferenceDocument();
 	useLayoutEffect( () => {
 		// Return early if the root document is the same as the owner document,
 		// as the scroll event will be listened to in other code.
@@ -467,7 +467,7 @@ const Popover = (
 	] );
 
 	let content = (
-		<RootDocumentProvider
+		<RootReferenceDocumentProvider
 			// Don't overwrite the root document if it's already set.
 			value={ rootReferenceDocument ?? referenceOwnerDocument }
 		>
@@ -533,7 +533,7 @@ const Popover = (
 					</div>
 				) }
 			</MaybeAnimatedWrapper>
-		</RootDocumentProvider>
+		</RootReferenceDocumentProvider>
 	);
 
 	if ( slot.ref ) {

--- a/packages/components/src/popover/root-document-context.js
+++ b/packages/components/src/popover/root-document-context.js
@@ -1,0 +1,9 @@
+/**
+ * WordPress dependencies
+ */
+import { createContext, useContext } from '@wordpress/element';
+
+const RootDocumentContext = createContext( undefined );
+
+export const useRootDocumentContext = () => useContext( RootDocumentContext );
+export const RootDocumentProvider = RootDocumentContext.Provider;

--- a/packages/components/src/popover/root-document-context.js
+++ b/packages/components/src/popover/root-document-context.js
@@ -1,8 +1,0 @@
-/**
- * WordPress dependencies
- */
-import { createContext, useContext } from '@wordpress/element';
-
-const RootDocumentContext = createContext( undefined );
-export const useRootDocumentContext = () => useContext( RootDocumentContext );
-export const RootDocumentProvider = RootDocumentContext.Provider;

--- a/packages/components/src/popover/root-document-context.js
+++ b/packages/components/src/popover/root-document-context.js
@@ -4,6 +4,5 @@
 import { createContext, useContext } from '@wordpress/element';
 
 const RootDocumentContext = createContext( undefined );
-
 export const useRootDocumentContext = () => useContext( RootDocumentContext );
 export const RootDocumentProvider = RootDocumentContext.Provider;

--- a/packages/components/src/popover/root-reference-document-context.js
+++ b/packages/components/src/popover/root-reference-document-context.js
@@ -1,0 +1,10 @@
+/**
+ * WordPress dependencies
+ */
+import { createContext, useContext } from '@wordpress/element';
+
+const RootReferenceDocumentContext = createContext( undefined );
+export const useRootReferenceDocument = () =>
+	useContext( RootReferenceDocumentContext );
+export const RootReferenceDocumentProvider =
+	RootReferenceDocumentContext.Provider;


### PR DESCRIPTION
## What?
Fixes #42725

(best reviewed using the 'Hide whitespace' option)

## Why?
To describe the bug requires a bit of background.

The site editor uses an iframe for its content, and all blocks are within the iframe.

Popovers are outside the iframe in the main document. Whenever the iframe is scrolled, popovers that are anchored to blocks (like the the block toolbar) listen for the scroll event and update their position on the screen to match where the block is. You have this situation:

```
Block in iframe
      |
      | (popover is anchored to element within an iframe, and listens to iframe scroll events)
      |
Popover outside of iframe
```

This bug happens because the block settings menu dropdown is a nested popover. It's anchored to another popover (the block toolbar) that isn't in an iframe, so it doesn't know to listen for scroll events.
```
Block in iframe
      |
      | (popover is anchored to element within an iframe, and listens to iframe scroll events)
      |
Popover outside of iframe
      |
      | (popover is anchored to element that's not in an iframe, so it doesn't listen to scroll events)
      |
Another popover outside of iframe
```

## How?
I could only think of one feasible way to solve this bug, which is to add a context provider that stores the root (reference) document for nested popovers, allowing them to also listen for scroll events.

## Testing Instructions
1. Open the site editor
2. Ensure there's enough content/blocks that there's a scroll bar
3. Select a block
4. From the block toolbar, open the block settings menu (three dots icon)
5. Scroll up and down

Expected: the toolbar and settings menu should stay anchored to the block

## Screenshots or screencast <!-- if applicable -->

### Before

https://user-images.githubusercontent.com/677833/186352175-21a885e2-d77b-4c14-bbc2-aeae583e6c7b.mp4

### After

https://user-images.githubusercontent.com/677833/186351847-45654fa0-bf14-4d68-9f21-67473dfa46e4.mp4
