### PR TITLE
Fix 'Mark issues stale after needs testing for 30 days' workflow

### DIFF
--- a/.github/workflows/stale-issue-mark-stale.yml
+++ b/.github/workflows/stale-issue-mark-stale.yml
@@ -12,6 +12,7 @@ jobs:
             - uses: actions/stale@996798eb71ef485dc4c7b4d3285842d714040c4a # v3.0.17
               with:
                   repo-token: ${{ secrets.GITHUB_TOKEN }}
+                  stale-issue-message: "Hi,\nThis issue has gone 30 days without any activity. This means it is time for a check-in to make sure it is still relevant. If you are still experiencing this issue with the latest versions, you can help the project by responding to confirm the problem and by providing any updated reproduction steps.\nThanks for helping out."
                   days-before-stale: 30
                   days-before-close: -1
                   only-labels: 'Needs Testing'


### PR DESCRIPTION
## What?
PR fixes 'Mark issues stale after needs testing for 30 days' workflow by adding `stale-issue-message`.

## Why?
I noticed that this workflow wasn't labeling the issues. After checking the logs and the `actions/stale`, it looks like the stale message is required even when skipping the commenting on the issue.

## How?
I added the stale issue message — a modified version of the "no activity" workflow.

## Testing Instructions
Not an easy one to test since it uses GitHub workflow. Best to review logic in the `actions/stale`:

* Why workflow skipped the issues - https://github.com/actions/stale/blob/v3.0.17/src/classes/issues-processor.ts#L133-L136
* Commenting is skipped based on `skip-stale-issue-message` - https://github.com/actions/stale/blob/v3.0.17/src/classes/issues-processor.ts#L451-L462
