### PR TITLE
Refactor popover to use separate flip and resize props instead of forcePosition

### DIFF
--- a/packages/block-editor/src/components/block-popover/inbetween.js
+++ b/packages/block-editor/src/components/block-popover/inbetween.js
@@ -186,7 +186,8 @@ function BlockPopoverInbetween( {
 				'block-editor-block-popover__inbetween',
 				props.className
 			) }
-			__unstableForcePosition
+			__unstableResize={ false }
+			__unstableFlip={ false }
 		>
 			<div style={ style }>{ children }</div>
 		</Popover>

--- a/packages/block-editor/src/components/block-popover/inbetween.js
+++ b/packages/block-editor/src/components/block-popover/inbetween.js
@@ -186,8 +186,8 @@ function BlockPopoverInbetween( {
 				'block-editor-block-popover__inbetween',
 				props.className
 			) }
-			__unstableResize={ false }
-			__unstableFlip={ false }
+			resize={ false }
+			flip={ false }
 		>
 			<div style={ style }>{ children }</div>
 		</Popover>

--- a/packages/block-editor/src/components/block-popover/index.js
+++ b/packages/block-editor/src/components/block-popover/index.js
@@ -66,8 +66,8 @@ function BlockPopover(
 			// Render in the old slot if needed for backward compatibility,
 			// otherwise render in place (not in the default popover slot).
 			__unstableSlotName={ __unstablePopoverSlot || null }
-			__unstableResize={ false }
-			__unstableFlip={ false }
+			resize={ false }
+			flip={ false }
 			__unstableShift
 			{ ...props }
 			className={ classnames(

--- a/packages/block-editor/src/components/block-popover/index.js
+++ b/packages/block-editor/src/components/block-popover/index.js
@@ -66,7 +66,8 @@ function BlockPopover(
 			// Render in the old slot if needed for backward compatibility,
 			// otherwise render in place (not in the default popover slot).
 			__unstableSlotName={ __unstablePopoverSlot || null }
-			__unstableForcePosition
+			__unstableResize={ false }
+			__unstableFlip={ false }
 			__unstableShift
 			{ ...props }
 			className={ classnames(

--- a/packages/block-editor/src/components/block-tools/use-block-toolbar-popover-props.js
+++ b/packages/block-editor/src/components/block-tools/use-block-toolbar-popover-props.js
@@ -14,14 +14,19 @@ import { __unstableUseBlockElement as useBlockElement } from '../block-list/use-
 // By default the toolbar sets the `shift` prop. If the user scrolls the page
 // down the toolbar will stay on screen by adopting a sticky position at the
 // top of the viewport.
-const DEFAULT_PROPS = { __unstableForcePosition: true, __unstableShift: true };
+const DEFAULT_PROPS = {
+	__unstableResize: false,
+	__unstableFlip: false,
+	__unstableShift: true,
+};
 
 // When there isn't enough height between the top of the block and the editor
 // canvas, the `shift` prop is set to `false`, as it will cause the block to be
-// obscured. The `flip` behavior is enabled (by setting `forcePosition` to
-// `false`), which positions the toolbar below the block.
+// obscured. The `flip` behavior is enabled, which positions the toolbar below
+// the block.
 const RESTRICTED_HEIGHT_PROPS = {
-	__unstableForcePosition: false,
+	__unstableResize: false,
+	__unstableFlip: true,
 	__unstableShift: false,
 };
 

--- a/packages/block-editor/src/components/block-tools/use-block-toolbar-popover-props.js
+++ b/packages/block-editor/src/components/block-tools/use-block-toolbar-popover-props.js
@@ -15,8 +15,8 @@ import { __unstableUseBlockElement as useBlockElement } from '../block-list/use-
 // down the toolbar will stay on screen by adopting a sticky position at the
 // top of the viewport.
 const DEFAULT_PROPS = {
-	__unstableResize: false,
-	__unstableFlip: false,
+	resize: false,
+	flip: false,
 	__unstableShift: true,
 };
 
@@ -25,8 +25,8 @@ const DEFAULT_PROPS = {
 // obscured. The `flip` behavior is enabled, which positions the toolbar below
 // the block.
 const RESTRICTED_HEIGHT_PROPS = {
-	__unstableResize: false,
-	__unstableFlip: true,
+	resize: false,
+	flip: true,
 	__unstableShift: false,
 };
 

--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -83,6 +83,7 @@
 ### Experimental
 
 -   `FormTokenField`: add `__experimentalAutoSelectFirstMatch` prop to auto select the first matching suggestion on typing ([#42527](https://github.com/WordPress/gutenberg/pull/42527/)).
+-   `Popover`: Refactor `__unstableForcePosition` to separate `__unstableFlip` and `__unstableResize` props ([#43546](https://github.com/WordPress/gutenberg/pull/43546/)).
 
 ## 19.17.0 (2022-08-10)
 

--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -43,6 +43,7 @@
 -   `FormTokenField`: Refactor away from `_.difference()` ([#43224](https://github.com/WordPress/gutenberg/pull/43224/)).
 -   `Autocomplete`: use `KeyboardEvent.code` instead of `KeyboardEvent.keyCode` ([#43432](https://github.com/WordPress/gutenberg/pull/43432/)).
 -   `ConfirmDialog`: replace (almost) every usage of `fireEvent` with `@testing-library/user-event`  ([#43429](https://github.com/WordPress/gutenberg/pull/43429/)).
+-   `Popover`: Introduce new `flip` and `resize` props ([#43546](https://github.com/WordPress/gutenberg/pull/43546/)).
 
 ### Internal
 
@@ -83,7 +84,7 @@
 ### Experimental
 
 -   `FormTokenField`: add `__experimentalAutoSelectFirstMatch` prop to auto select the first matching suggestion on typing ([#42527](https://github.com/WordPress/gutenberg/pull/42527/)).
--   `Popover`: Refactor `__unstableForcePosition` to separate `__unstableFlip` and `__unstableResize` props ([#43546](https://github.com/WordPress/gutenberg/pull/43546/)).
+-   `Popover`: Deprecate `__unstableForcePosition`, now replaced by new `flip` and `resize` props ([#43546](https://github.com/WordPress/gutenberg/pull/43546/)).
 
 ## 19.17.0 (2022-08-10)
 

--- a/packages/components/src/popover/README.md
+++ b/packages/components/src/popover/README.md
@@ -71,6 +71,26 @@ Each of these base placements has an alignment in the form -start and -end. For 
 -   Required: No
 -   Default: `"bottom-start"`
 
+### flip
+
+Specifies whether the `Popover` should flip across its axis if there isn't space for it in the normal placement.
+
+When the using a 'top' placement, the `Popover` will switch to a 'bottom' placement. When using a 'left' placement, the popover will switch to a 'right' placement.
+
+The `Popover` will retain its alignment of 'start' or 'end' when flipping.
+
+-   Type: `Boolean`
+-   Required: No
+-   Default: `true`
+
+### resize
+
+Adjusts the height of the `Popover` to prevent overflow.
+
+-   Type: `Boolean`
+-   Required: No
+-   Default: `true`
+
 ### offset
 
 The distance (in pixels) between the anchor and popover.

--- a/packages/components/src/popover/index.js
+++ b/packages/components/src/popover/index.js
@@ -143,7 +143,8 @@ const Popover = (
 		expandOnMobile,
 		onFocusOutside,
 		__unstableSlotName = SLOT_NAME,
-		__unstableForcePosition = false,
+		__unstableFlip = true,
+		__unstableResize = true,
 		__unstableShift = false,
 		...contentProps
 	},
@@ -232,10 +233,9 @@ const Popover = (
 				crossAxis: frameOffsetRef.current[ crossAxis ],
 			};
 		} ),
-		__unstableForcePosition ? undefined : flip(),
-		__unstableForcePosition
-			? undefined
-			: size( {
+		__unstableFlip ? flip() : undefined,
+		__unstableResize
+			? size( {
 					apply( sizeProps ) {
 						const { availableHeight } = sizeProps;
 						if ( ! refs.floating.current ) return;
@@ -245,7 +245,8 @@ const Popover = (
 							overflow: 'auto',
 						} );
 					},
-			  } ),
+			  } )
+			: undefined,
 		__unstableShift
 			? shift( {
 					crossAxis: true,

--- a/packages/components/src/popover/index.js
+++ b/packages/components/src/popover/index.js
@@ -146,6 +146,7 @@ const Popover = (
 		__unstableFlip = true,
 		__unstableResize = true,
 		__unstableShift = false,
+		__unstableForcePosition = false,
 		...contentProps
 	},
 	forwardedRef
@@ -155,6 +156,20 @@ const Popover = (
 			since: '6.1',
 			version: '6.3',
 		} );
+	}
+
+	if ( __unstableForcePosition ) {
+		deprecated( '__unstableForcePosition prop in Popover component', {
+			since: '6.1',
+			version: '6.3',
+			alternative:
+				'`__unstableFlip={ false }` and  `__unstableResize={ false }`',
+		} );
+
+		// Back-compat, set the `__unstableFlip` and `__unstableResize` props
+		// to `false` to replicate `__unstableForcePosition`.
+		__unstableFlip = false;
+		__unstableResize = false;
 	}
 
 	const arrowRef = useRef( null );

--- a/packages/components/src/popover/index.js
+++ b/packages/components/src/popover/index.js
@@ -146,7 +146,7 @@ const Popover = (
 		flip = true,
 		resize = true,
 		__unstableShift = false,
-		__unstableForcePosition = false,
+		__unstableForcePosition,
 		...contentProps
 	},
 	forwardedRef
@@ -158,7 +158,7 @@ const Popover = (
 		} );
 	}
 
-	if ( __unstableForcePosition ) {
+	if ( __unstableForcePosition !== undefined ) {
 		deprecated( '__unstableForcePosition prop in Popover component', {
 			since: '6.1',
 			version: '6.3',
@@ -167,8 +167,8 @@ const Popover = (
 
 		// Back-compat, set the `flip` and `resize` props
 		// to `false` to replicate `__unstableForcePosition`.
-		flip = false;
-		resize = false;
+		flip = ! __unstableForcePosition;
+		resize = ! __unstableForcePosition;
 	}
 
 	const arrowRef = useRef( null );

--- a/packages/components/src/popover/index.js
+++ b/packages/components/src/popover/index.js
@@ -5,7 +5,7 @@
 import classnames from 'classnames';
 import {
 	useFloating,
-	flip,
+	flip as flipMiddleware,
 	shift,
 	autoUpdate,
 	arrow,
@@ -143,8 +143,8 @@ const Popover = (
 		expandOnMobile,
 		onFocusOutside,
 		__unstableSlotName = SLOT_NAME,
-		__unstableFlip = true,
-		__unstableResize = true,
+		flip = true,
+		resize = true,
 		__unstableShift = false,
 		__unstableForcePosition = false,
 		...contentProps
@@ -162,14 +162,13 @@ const Popover = (
 		deprecated( '__unstableForcePosition prop in Popover component', {
 			since: '6.1',
 			version: '6.3',
-			alternative:
-				'`__unstableFlip={ false }` and  `__unstableResize={ false }`',
+			alternative: '`flip={ false }` and  `resize={ false }`',
 		} );
 
-		// Back-compat, set the `__unstableFlip` and `__unstableResize` props
+		// Back-compat, set the `flip` and `resize` props
 		// to `false` to replicate `__unstableForcePosition`.
-		__unstableFlip = false;
-		__unstableResize = false;
+		flip = false;
+		resize = false;
 	}
 
 	const arrowRef = useRef( null );
@@ -248,8 +247,8 @@ const Popover = (
 				crossAxis: frameOffsetRef.current[ crossAxis ],
 			};
 		} ),
-		__unstableFlip ? flip() : undefined,
-		__unstableResize
+		flip ? flipMiddleware() : undefined,
+		resize
 			? size( {
 					apply( sizeProps ) {
 						const { availableHeight } = sizeProps;

--- a/packages/components/src/popover/stories/index.js
+++ b/packages/components/src/popover/stories/index.js
@@ -73,7 +73,8 @@ export default {
 			options: AVAILABLE_POSITIONS,
 		},
 		__unstableSlotName: { control: { type: null } },
-		__unstableForcePosition: { control: { type: 'boolean' } },
+		__unstableResize: { control: { type: 'boolean' } },
+		__unstableFlip: { control: { type: 'boolean' } },
 		__unstableShift: { control: { type: 'boolean' } },
 	},
 };
@@ -180,7 +181,8 @@ AllPlacements.args = {
 	),
 	noArrow: false,
 	offset: 10,
-	__unstableForcePosition: true,
+	__unstableResize: false,
+	__unstableFlip: false,
 };
 
 export const DynamicHeight = ( { children, ...args } ) => {

--- a/packages/components/src/popover/stories/index.js
+++ b/packages/components/src/popover/stories/index.js
@@ -73,8 +73,8 @@ export default {
 			options: AVAILABLE_POSITIONS,
 		},
 		__unstableSlotName: { control: { type: null } },
-		__unstableResize: { control: { type: 'boolean' } },
-		__unstableFlip: { control: { type: 'boolean' } },
+		resize: { control: { type: 'boolean' } },
+		flip: { control: { type: 'boolean' } },
 		__unstableShift: { control: { type: 'boolean' } },
 	},
 };
@@ -181,8 +181,8 @@ AllPlacements.args = {
 	),
 	noArrow: false,
 	offset: 10,
-	__unstableResize: false,
-	__unstableFlip: false,
+	resize: false,
+	flip: false,
 };
 
 export const DynamicHeight = ( { children, ...args } ) => {

--- a/packages/widgets/src/blocks/legacy-widget/edit/form.js
+++ b/packages/widgets/src/blocks/legacy-widget/edit/form.js
@@ -105,8 +105,8 @@ export default function Form( {
 					focusOnMount={ false }
 					placement="right"
 					offset={ 32 }
-					__unstableResize={ false }
-					__unstableFlip={ false }
+					resize={ false }
+					flip={ false }
 					__unstableShift
 				>
 					<div

--- a/packages/widgets/src/blocks/legacy-widget/edit/form.js
+++ b/packages/widgets/src/blocks/legacy-widget/edit/form.js
@@ -105,7 +105,8 @@ export default function Form( {
 					focusOnMount={ false }
 					placement="right"
 					offset={ 32 }
-					__unstableForcePosition
+					__unstableResize={ false }
+					__unstableFlip={ false }
 					__unstableShift
 				>
 					<div


### PR DESCRIPTION
## Dev note

See the dev note in https://github.com/WordPress/gutenberg/pull/44195

## What?
Closes #43191

Deprecates `__unstableForcePosition` replacing it with new `flip` and `resize` props.

## Why?
One of the difficulties with `forcePosition` is that it's hard to say what it actually does.

`flip` and `resize` are easier to understand, and more closely match floating-ui's terms.

This is also needed to fix issue #43541 since there needs to be a way to disable `resize` while still enabling `flip`.

## How?
Splits the prop into two separate props that default to `true`.

## Testing Instructions
This shouldn't cause any differences in the UI, but it's worth testing each affected popover.

### Legacy widget form
1. Enable a classic (non-block-based theme like Twenty Twenty One)
2. Install the SiteOrigin Widgets Bundle plugin
3. Go to Customize > Widgets
4. Insert a SiteOrigin Google Maps block
5. The form appears in a popover should be correctly positioned (as in trunk)

### Block Popover Inbetween
1. Try hovering your mouse between blocks
2. The inbetween inserter should appear correctly (as in trunk)
3. Try dragging and dropping a block
4. The drop indicator should show correctly (as in trunk)

### Block Popover
1. The block toolbar should be positioned (as in `trunk`)
2. Try adjust padding/margin for a block
3. The visualizer should appear correctly (note that this is currently buggy in the site editor, but that's not introduced in this PR)
