### PR TITLE
Add stale issue workflow for flaky test reports

### DIFF
--- a/.github/workflows/stale-issue-add-needs-testing.yml
+++ b/.github/workflows/stale-issue-add-needs-testing.yml
@@ -1,4 +1,4 @@
-name: 'Mark old flaky tests issues as stale'
+name: 'Mark old issues as needs confirmation'
 on:
     schedule:
         - cron: '45 1 * * *'

--- a/.github/workflows/stale-issue-add-needs-testing.yml
+++ b/.github/workflows/stale-issue-add-needs-testing.yml
@@ -1,4 +1,4 @@
-name: 'Mark old issues as needs confirmation'
+name: 'Mark old flaky tests issues as stale'
 on:
     schedule:
         - cron: '45 1 * * *'

--- a/.github/workflows/stale-issue-flaky-test.yml
+++ b/.github/workflows/stale-issue-flaky-test.yml
@@ -1,4 +1,4 @@
-name: 'Mark issues stale after needs testing for 30 days'
+name: 'Mark old flaky tests issues as stale'
 on:
     schedule:
         - cron: '20 1 * * *'

--- a/.github/workflows/stale-issue-flaky-test.yml
+++ b/.github/workflows/stale-issue-flaky-test.yml
@@ -16,5 +16,4 @@ jobs:
                   days-before-stale: 30
                   days-before-close: 1
                   only-labels: '[Type] Flaky Test'
-                  skip-stale-issue-message: true
                   stale-issue-label: '[Status] Stale'

--- a/.github/workflows/stale-issue-flaky-test.yml
+++ b/.github/workflows/stale-issue-flaky-test.yml
@@ -1,0 +1,20 @@
+name: 'Mark issues stale after needs testing for 30 days'
+on:
+    schedule:
+        - cron: '20 1 * * *'
+
+jobs:
+    stale:
+        runs-on: ubuntu-latest
+        if: ${{ github.repository == 'WordPress/gutenberg' }}
+
+        steps:
+            - uses: actions/stale@996798eb71ef485dc4c7b4d3285842d714040c4a # v3.0.17
+              with:
+                  repo-token: ${{ secrets.GITHUB_TOKEN }}
+                  stale-issue-message: 'This issue has gone 30 days without any activity.'
+                  days-before-stale: 30
+                  days-before-close: 1
+                  only-labels: '[Type] Flaky Test'
+                  skip-stale-issue-message: true
+                  stale-issue-label: '[Status] Stale'


### PR DESCRIPTION
Fixes #37968

## What?
PR adds a new workflow to check issues with the "[Type] Flaky Test" label and no activity in the past 30 days. Detected issues will be labeled "Stale" and closed in one day without activity.

## Why?
I think it's safe to assume that the flaky tests report with no activity in the past 30 days might be resolved or was a false report due to some specific conditions.

## Testing Instructions
The GitHub workflows are a bit hard to test, so verify settings based on the `actions/stale` docs - https://github.com/actions/stale/tree/v3.0.17#readme.
