### PR TITLE
Fix site editor toolbar when block is bigger than viewport

### DIFF
--- a/packages/block-editor/src/components/block-tools/selected-block-popover.js
+++ b/packages/block-editor/src/components/block-tools/selected-block-popover.js
@@ -132,6 +132,7 @@ function SelectedBlockPopover( {
 			} ) }
 			__unstablePopoverSlot={ __unstablePopoverSlot }
 			__unstableContentRef={ __unstableContentRef }
+			resize={ false }
 			{ ...popoverProps }
 		>
 			{ shouldShowContextualToolbar && (

--- a/packages/block-editor/src/components/block-tools/use-block-toolbar-popover-props.js
+++ b/packages/block-editor/src/components/block-tools/use-block-toolbar-popover-props.js
@@ -23,7 +23,8 @@ const DEFAULT_PROPS = {
 // When there isn't enough height between the top of the block and the editor
 // canvas, the `shift` prop is set to `false`, as it will cause the block to be
 // obscured. The `flip` behavior is enabled, which positions the toolbar below
-// the block.
+// the block. This only happens if the block is smaller than the viewport, as
+// otherwise the toolbar will be off-screen.
 const RESTRICTED_HEIGHT_PROPS = {
 	resize: false,
 	flip: true,
@@ -47,7 +48,16 @@ function getProps( contentElement, selectedBlockElement, toolbarHeight ) {
 	const blockRect = selectedBlockElement.getBoundingClientRect();
 	const contentRect = contentElement.getBoundingClientRect();
 
-	if ( blockRect.top - contentRect.top > toolbarHeight ) {
+	// The document element's clientHeight represents the viewport height.
+	const viewportHeight =
+		contentElement.ownerDocument.documentElement.clientHeight;
+
+	const hasSpaceForToolbarAbove =
+		blockRect.top - contentRect.top > toolbarHeight;
+	const isBlockTallerThanViewport =
+		blockRect.height > viewportHeight - toolbarHeight;
+
+	if ( hasSpaceForToolbarAbove || isBlockTallerThanViewport ) {
 		return DEFAULT_PROPS;
 	}
 

--- a/packages/block-editor/src/components/block-tools/use-block-toolbar-popover-props.js
+++ b/packages/block-editor/src/components/block-tools/use-block-toolbar-popover-props.js
@@ -15,7 +15,6 @@ import { __unstableUseBlockElement as useBlockElement } from '../block-list/use-
 // down the toolbar will stay on screen by adopting a sticky position at the
 // top of the viewport.
 const DEFAULT_PROPS = {
-	resize: false,
 	flip: false,
 	__unstableShift: true,
 };
@@ -26,7 +25,6 @@ const DEFAULT_PROPS = {
 // the block. This only happens if the block is smaller than the viewport, as
 // otherwise the toolbar will be off-screen.
 const RESTRICTED_HEIGHT_PROPS = {
-	resize: false,
 	flip: true,
 	__unstableShift: false,
 };


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Fixes #43541 (this PR is based on #43546, and that should be merged first)

## Why?
#42887 introduced an issue when the block is larger than the viewport. In this situation floating-ui's 'resize' middleware is making the block toolbar smaller to fit the available space which may make it appear as though the toolbar is behind the block. The toolbar can also sometimes appear off-screen below the block (see the 'before' video).

## How?
To fix this, resize needs to be switched off, which #43546 helps with.

Once that's resolved, the toolbar still often ends up offscreen, so some extra logic needs to be added to `useBlockToolbarPopoverProps` to account for situations where the block is larger than the viewport.

## Testing Instructions
1. Open the site editor
2. Select a block that's larger than the viewport (to make a block this big I usually just duplicate and then group a few blocks)
3. The toolbar should be visible

## Screenshots or screencast <!-- if applicable -->
### Before

https://user-images.githubusercontent.com/677833/186348358-eeb55096-af44-449d-ad8f-e5b71d632dee.mp4

### After

https://user-images.githubusercontent.com/677833/186348588-7f40bd59-6e3c-48a0-83d9-56bb2b4f943f.mp4



