### PR TITLE
Query No Results: Add typography supports

### DIFF
--- a/docs/reference-guides/core-blocks.md
+++ b/docs/reference-guides/core-blocks.md
@@ -617,7 +617,7 @@ Contains the block elements used to render content when no query results are fou
 
 -	**Name:** core/query-no-results
 -	**Category:** theme
--	**Supports:** align, color (background, gradients, link, text), ~~html~~, ~~reusable~~
+-	**Supports:** align, color (background, gradients, link, text), typography (fontSize, lineHeight), ~~html~~, ~~reusable~~
 -	**Attributes:** 
 
 ## Pagination

--- a/packages/block-library/src/query-no-results/block.json
+++ b/packages/block-library/src/query-no-results/block.json
@@ -15,6 +15,19 @@
 		"color": {
 			"gradients": true,
 			"link": true
+		},
+		"typography": {
+			"fontSize": true,
+			"lineHeight": true,
+			"__experimentalFontFamily": true,
+			"__experimentalFontWeight": true,
+			"__experimentalFontStyle": true,
+			"__experimentalTextTransform": true,
+			"__experimentalTextDecoration": true,
+			"__experimentalLetterSpacing": true,
+			"__experimentalDefaultControls": {
+				"fontSize": true
+			}
 		}
 	}
 }


### PR DESCRIPTION
Related:
- https://github.com/WordPress/gutenberg/issues/43241
- https://github.com/WordPress/gutenberg/issues/43242

## What?

Adds typography supports to the **Query No Results** block.

## Why?

- Improves consistency of our design tools across blocks.

## How?

- Opts into all typography supports.
- Makes font size control displayed by default as per majority of blocks currently.

## Testing Instructions

1. In the site editor, edit a template with a Query block, and add content to its No Results block.
2. Adjust the Query settings so that no posts will be matched.
3. Navigate to Global Styles > Blocks > Query No Results > Typography.
4. Experiment with typography styles and ensure they are applied to the No Results block in the preview.
5. Save and confirm styles on the frontend.
6. Select the Query No Results block within the preview.
7. On the Block tab of the Settings sidebar, test the typography controls for the individual block.
8. Reset the individual and global styles for the No Results block.
9. Add typography styles for the `core/query-no-results` block to your theme.json and confirm they work.

Example theme.json snippet:
```json
			"core/query-no-results": {
				"typography": {
					"fontWeight": "100",
					"textTransform": "uppercase"
				}
			}
```


## Screenshots or screencast <!-- if applicable -->


https://user-images.githubusercontent.com/60436221/186364100-f3e0304c-aa60-4de4-a2c7-0a12987cdd5c.mp4


