### PR TITLE
Query Pagination: Add typography support

### DIFF
--- a/docs/reference-guides/core-blocks.md
+++ b/docs/reference-guides/core-blocks.md
@@ -626,7 +626,7 @@ Displays a paginated navigation to next/previous set of posts, when applicable. 
 
 -	**Name:** core/query-pagination
 -	**Category:** theme
--	**Supports:** align, color (background, gradients, link, text), ~~html~~, ~~reusable~~
+-	**Supports:** align, color (background, gradients, link, text), typography (fontSize, lineHeight), ~~html~~, ~~reusable~~
 -	**Attributes:** paginationArrow
 
 ## Next Page

--- a/packages/block-library/src/query-pagination/block.json
+++ b/packages/block-library/src/query-pagination/block.json
@@ -36,6 +36,19 @@
 			"default": {
 				"type": "flex"
 			}
+		},
+		"typography": {
+			"fontSize": true,
+			"lineHeight": true,
+			"__experimentalFontFamily": true,
+			"__experimentalFontWeight": true,
+			"__experimentalFontStyle": true,
+			"__experimentalTextTransform": true,
+			"__experimentalTextDecoration": true,
+			"__experimentalLetterSpacing": true,
+			"__experimentalDefaultControls": {
+				"fontSize": true
+			}
 		}
 	},
 	"editorStyle": "wp-block-query-pagination-editor",


### PR DESCRIPTION
Related:
- https://github.com/WordPress/gutenberg/issues/43241
- https://github.com/WordPress/gutenberg/issues/43242

## What?

Adds typography support to the Query Pagination block.

## Why?

- Improves consistency of our design tools across blocks.
- Adds higher level typography styling for the inner blocks of the Query Pagination block.

## How?

- Opts into all typography supports.
- Only the font size control will display by default.

## Testing Instructions

1. In the site editor, edit a template with a Query block.
2. Navigate to Global Styles > Blocks > Query Pagination > Typography and apply typography styles there.
3. Confirm the Query Pagination block within the preview updates accordingly.
4. Save and check the styling is correct on the frontend.
5. Back in the site editor, select the Query Pagination block.
6. Navigate to the Settings sidebar and the block tab.
7. Adjust the block's typography settings here and confirm they are reflected in the preview.
8. Save and check the frontend again.
9. Clear your customizations.
10. Test that the block can be styled via theme.json.


Example theme.json snippet:
```json
			"core/query-pagination": {
				"typography": {
					"fontWeight": "100"
				}
			}
```

## Screenshots or screencast <!-- if applicable -->



https://user-images.githubusercontent.com/60436221/186367483-ac40069f-850a-4602-a576-e0b4483d5906.mp4



