### PR TITLE
Button: Try removing hardcoded white.

### DIFF
--- a/packages/block-library/src/button/style.scss
+++ b/packages/block-library/src/button/style.scss
@@ -11,13 +11,6 @@ $blocks-block__margin: 0.5em;
 	word-break: break-word; // overflow-wrap doesn't work well if a link is wrapped in the div, so use word-break here.
 	box-sizing: border-box;
 
-	&:hover,
-	&:focus,
-	&:active,
-	&:visited {
-		color: $white;
-	}
-
 	&.aligncenter {
 		text-align: center;
 	}


### PR DESCRIPTION
## What?

Inspired by https://github.com/WordPress/gutenberg/discussions/43539, this PR tries to remove the hardcoded white color present in the default button CSS. 

## Why?

The less hardcoded colors, the better themeability. I believe that the color used to be necessary because for the default dark gray button style, a white color was needed for contrast. But at the moment, the code appears to be unnecessary at this point (see also potentially related #21561 and #41822). It would be good to verify this further.

## Testing Instructions

Please test the default button style, and the outline style, in a variety of block and classic themes, including empty theme, frontend and editor, and with hover/active/focus styles. There should be no visible change compared to trunk.

Twentyfifteen:
<img width="289" alt="Screenshot 2022-08-24 at 10 14 02" src="https://user-images.githubusercontent.com/1204802/186367742-2f00e350-02e9-4117-b6b8-c9677bc1e37b.png">

Empty theme:

<img width="339" alt="Screenshot 2022-08-24 at 10 14 10" src="https://user-images.githubusercontent.com/1204802/186367768-803713f1-08d3-4b15-97a4-70bf794d6ed5.png">

TT2:

<img width="388" alt="Screenshot 2022-08-24 at 10 14 19" src="https://user-images.githubusercontent.com/1204802/186367790-d933a745-532e-46de-aa0e-13b8a5e9dd55.png">

Twentyseventeen:

<img width="382" alt="Screenshot 2022-08-24 at 10 14 58" src="https://user-images.githubusercontent.com/1204802/186367809-1bc1dd38-6554-47f8-953e-49c4c8e6a2d7.png">

