### PR TITLE
Query Pagination Next: Add missing typography supports

### DIFF
--- a/packages/block-library/src/query-pagination-next/block.json
+++ b/packages/block-library/src/query-pagination-next/block.json
@@ -26,10 +26,12 @@
 		"typography": {
 			"fontSize": true,
 			"lineHeight": true,
-			"__experimentalFontStyle": true,
+			"__experimentalFontFamily": true,
 			"__experimentalFontWeight": true,
-			"__experimentalLetterSpacing": true,
+			"__experimentalFontStyle": true,
 			"__experimentalTextTransform": true,
+			"__experimentalTextDecoration": true,
+			"__experimentalLetterSpacing": true,
 			"__experimentalDefaultControls": {
 				"fontSize": true
 			}


### PR DESCRIPTION
Related:
- https://github.com/WordPress/gutenberg/issues/43241
- https://github.com/WordPress/gutenberg/issues/43242

## What?

Adds missing typography supports to the Query Pagination Next block.

## Why?

- Improves consistency of our design tools across blocks.

## How?

- Opts into missing font-family, text-decoration typography support.

## Testing Instructions

1. Edit a post, add a Query block, and select the Query Pagination Next block within it.
2. Check that the font-family & text-decoration controls are now available.
2. Test various typography settings ensuring styles are applied in the editor.
3. Save and confirm the application on the frontend.
4. Switch to the site editor, add a new Query block to the template.
5. Navigate to Global Styles > Blocks > Next Page > Typography (first "Next Page" in Blocks, name conflict will be addressed separately)
6. Test applying a new font-family and confirm its applied in the preview and on the frontend.
7. Test styling via theme.json

Example theme.json snippet:
```json
			"core/query-pagination-next": {
				"typography": {
					"textDecoration": "line-through"
				}
			}
```

## Screenshots or screencast <!-- if applicable -->


https://user-images.githubusercontent.com/60436221/186371390-3aaed1cb-f264-4f1e-ba7c-84a46f1a247a.mp4


