### PR TITLE
Lodash: Remove from block registration API

### DIFF
--- a/packages/blocks/src/api/registration.js
+++ b/packages/blocks/src/api/registration.js
@@ -4,7 +4,6 @@
  * External dependencies
  */
 import { camelCase } from 'change-case';
-import { isEmpty, pick, pickBy } from 'lodash';
 
 /**
  * WordPress dependencies
@@ -174,12 +173,11 @@ export function unstable__bootstrapServerSideBlockDefinitions( definitions ) {
 		}
 
 		serverSideBlockDefinitions[ blockName ] = Object.fromEntries(
-			Object.entries(
-				pickBy(
-					definitions[ blockName ],
-					( value ) => value !== null && value !== undefined
+			Object.entries( definitions[ blockName ] )
+				.filter(
+					( [ , value ] ) => value !== null && value !== undefined
 				)
-			).map( ( [ key, value ] ) => [ camelCase( key ), value ] )
+				.map( ( [ key, value ] ) => [ camelCase( key ), value ] )
 		);
 	}
 }
@@ -211,7 +209,11 @@ function getBlockSettingsFromMetadata( { textdomain, ...metadata } ) {
 		'variations',
 	];
 
-	const settings = pick( metadata, allowedFields );
+	const settings = Object.fromEntries(
+		Object.entries( metadata ).filter( ( [ key ] ) =>
+			allowedFields.includes( key )
+		)
+	);
 
 	if ( textdomain ) {
 		Object.keys( i18nBlockSchema ).forEach( ( key ) => {
@@ -321,7 +323,7 @@ function translateBlockSettingUsingI18nSchema(
 	}
 	if (
 		Array.isArray( i18nSchema ) &&
-		! isEmpty( i18nSchema ) &&
+		i18nSchema.length &&
 		Array.isArray( settingValue )
 	) {
 		return settingValue.map( ( value ) =>
@@ -334,7 +336,7 @@ function translateBlockSettingUsingI18nSchema(
 	}
 	if (
 		isObject( i18nSchema ) &&
-		! isEmpty( i18nSchema ) &&
+		Object.entries( i18nSchema ).length &&
 		isObject( settingValue )
 	) {
 		return Object.keys( settingValue ).reduce( ( accumulator, key ) => {


### PR DESCRIPTION
## What?
This PR removes Lodash usage from the block registration API. 

## Why?

Lodash is known to unnecessarily inflate the bundle size of packages, and in most cases, it can be replaced with native language functionality. See these for more information and rationale:

* https://github.com/WordPress/gutenberg/issues/16938#issuecomment-602837246
* https://github.com/WordPress/gutenberg/issues/17025
* https://github.com/WordPress/gutenberg/issues/39495 

## How?

We're replacing all Lodash usage with native functionality.

## Testing Instructions
* Verify all tests still pass: `npm run test:unit packages/blocks`
* Smoke test the editor and verify blocks are still registered properly.