### PR TITLE
Query Pagination Numbers: Add missing typography supports

### DIFF
--- a/packages/block-library/src/query-pagination-numbers/block.json
+++ b/packages/block-library/src/query-pagination-numbers/block.json
@@ -21,10 +21,12 @@
 		"typography": {
 			"fontSize": true,
 			"lineHeight": true,
-			"__experimentalFontStyle": true,
+			"__experimentalFontFamily": true,
 			"__experimentalFontWeight": true,
-			"__experimentalLetterSpacing": true,
+			"__experimentalFontStyle": true,
 			"__experimentalTextTransform": true,
+			"__experimentalTextDecoration": true,
+			"__experimentalLetterSpacing": true,
 			"__experimentalDefaultControls": {
 				"fontSize": true
 			}


### PR DESCRIPTION
Related:
- https://github.com/WordPress/gutenberg/issues/43241
- https://github.com/WordPress/gutenberg/issues/43242

## What?

Adds missing typography supports to the Query Pagination Numbers block.

## Why?

- Improves consistency of our design tools across blocks.

## How?

- Opts into missing font-family, text-decoration typography support.

## Testing Instructions

1. Edit a post, add a Query block, and select the Query Pagination Numbers block within it.
2. Check that the font-family & text-decoration controls are now available.
2. Test various typography settings ensuring styles are applied in the editor.
3. Save and confirm the application on the frontend.
4. Switch to the site editor, add a new Query block to the template.
5. Navigate to Global Styles > Blocks > Page Numbers > Typography (first "Page Numbers" in Blocks, name conflict will be addressed separately)
6. Test applying a new font-family and confirm its applied in the preview and on the frontend.
7. Test styling via theme.json

Example theme.json snippet:
```json
			"core/query-pagination-numbers": {
				"typography": {
					"textDecoration": "line-through"
				}
			}
```

## Screenshots or screencast <!-- if applicable -->


https://user-images.githubusercontent.com/60436221/186374387-57732072-5a55-4be6-bbb1-6870efa061d9.mp4


