### PR TITLE
Lodash: Remove from block templates API

### DIFF
--- a/packages/blocks/src/api/templates.js
+++ b/packages/blocks/src/api/templates.js
@@ -1,9 +1,4 @@
 /**
- * External dependencies
- */
-import { every, map, get, mapValues } from 'lodash';
-
-/**
  * WordPress dependencies
  */
 import { renderToString } from '@wordpress/element';
@@ -26,7 +21,7 @@ import { getBlockType } from './registration';
 export function doBlocksMatchTemplate( blocks = [], template = [] ) {
 	return (
 		blocks.length === template.length &&
-		every( template, ( [ name, , innerBlocksTemplate ], index ) => {
+		template.every( ( [ name, , innerBlocksTemplate ], index ) => {
 			const block = blocks[ index ];
 			return (
 				name === block.name &&
@@ -55,8 +50,7 @@ export function synchronizeBlocksWithTemplate( blocks = [], template ) {
 		return blocks;
 	}
 
-	return map(
-		template,
+	return template.map(
 		( [ name, attributes, innerBlocksTemplate ], index ) => {
 			const block = blocks[ index ];
 
@@ -74,14 +68,21 @@ export function synchronizeBlocksWithTemplate( blocks = [], template ) {
 
 			const blockType = getBlockType( name );
 			const isHTMLAttribute = ( attributeDefinition ) =>
-				get( attributeDefinition, [ 'source' ] ) === 'html';
+				attributeDefinition?.source === 'html';
 			const isQueryAttribute = ( attributeDefinition ) =>
-				get( attributeDefinition, [ 'source' ] ) === 'query';
+				attributeDefinition?.source === 'query';
 
 			const normalizeAttributes = ( schema, values ) => {
-				return mapValues( values, ( value, key ) => {
-					return normalizeAttribute( schema[ key ], value );
-				} );
+				if ( ! values ) {
+					return {};
+				}
+
+				return Object.fromEntries(
+					Object.entries( values ).map( ( [ key, value ] ) => [
+						key,
+						normalizeAttribute( schema[ key ], value ),
+					] )
+				);
 			};
 			const normalizeAttribute = ( definition, value ) => {
 				if ( isHTMLAttribute( definition ) && Array.isArray( value ) ) {
@@ -104,7 +105,7 @@ export function synchronizeBlocksWithTemplate( blocks = [], template ) {
 			};
 
 			const normalizedAttributes = normalizeAttributes(
-				get( blockType, [ 'attributes' ], {} ),
+				blockType?.attributes ?? {},
 				attributes
 			);
 


### PR DESCRIPTION
## What?
This PR removes Lodash usage from the block templates API. 

## Why?

Lodash is known to unnecessarily inflate the bundle size of packages, and in most cases, it can be replaced with native language functionality. See these for more information and rationale:

* https://github.com/WordPress/gutenberg/issues/16938#issuecomment-602837246
* https://github.com/WordPress/gutenberg/issues/17025
* https://github.com/WordPress/gutenberg/issues/39495 

## How?

We're replacing all Lodash usage with native functionality.

## Testing Instructions
* Verify all tests still pass: `npm run test:unit packages/blocks`
* Smoke test the editor and verify block templates still work correctly.