### PR TITLE
Query Title: Add missing typography supports

### DIFF
--- a/packages/block-library/src/query-title/block.json
+++ b/packages/block-library/src/query-title/block.json
@@ -48,6 +48,7 @@
 			"__experimentalFontWeight": true,
 			"__experimentalLetterSpacing": true,
 			"__experimentalTextTransform": true,
+			"__experimentalTextDecoration": true,
 			"__experimentalDefaultControls": {
 				"fontSize": true,
 				"fontAppearance": true,


### PR DESCRIPTION
Related:
- https://github.com/WordPress/gutenberg/issues/43241
- https://github.com/WordPress/gutenberg/issues/43242

## What?

Adds missing typography supports to the Query Title block.

## Why?

- Improves consistency of our design tools across blocks.

## How?

- Opts into missing text-decoration typography support.

## Testing Instructions

1. In the site editor, edit the Archive template and select the Archive Title block.
2. Navigate to the Block tab of the Settings sidebar.
3. Adjust the text-decoration value ensuring it is reflected in both the preview and the frontend.
4. Clear customizations and test that text-decoration can be applied via theme.json

Example theme.json snippet:
```json
			"core/query-title": {
				"typography": {
					"textDecoration": "line-through"
				}
			}
```

## Screenshots or screencast <!-- if applicable -->

https://user-images.githubusercontent.com/60436221/186377151-9de0a4b3-c5ba-4012-b878-880e0d65561b.mp4


