### PR TITLE
Term Description: Add missing typography supports

### DIFF
--- a/packages/block-library/src/term-description/block.json
+++ b/packages/block-library/src/term-description/block.json
@@ -28,6 +28,12 @@
 		"typography": {
 			"fontSize": true,
 			"lineHeight": true,
+			"__experimentalFontFamily": true,
+			"__experimentalFontWeight": true,
+			"__experimentalFontStyle": true,
+			"__experimentalTextTransform": true,
+			"__experimentalTextDecoration": true,
+			"__experimentalLetterSpacing": true,
 			"__experimentalDefaultControls": {
 				"fontSize": true
 			}


### PR DESCRIPTION
Related:
- https://github.com/WordPress/gutenberg/issues/43241
- https://github.com/WordPress/gutenberg/issues/43242

## What?

Adds missing typography supports to the Term Description block.

## Why?

- Improves consistency of our design tools across blocks.

## How?

Opts into the following missing typography supports.
- font family
- font weight
- font style
- text transform
- text decoration
- letter spacing

## Testing Instructions

1. In the site editor, edit an Archive template.
2. Add a Term Description block and select it.
3. Within the Settings sidebar, adjust typography settings and confirm they are reflected in the preview and frontend.
4. Reset all the block's typography settings.
4. Navigate to Global Styles > Blocks > Term Description > Typography
6. Test applying the new typography styles and confirm they're applied in the preview and on the frontend.
7. Test styling via theme.json

Example theme.json snippet:
```json
			"core/term-description": {
				"typography": {
					"letterSpacing": "2px"
				}
			}
```

## Screenshots or screencast <!-- if applicable -->


https://user-images.githubusercontent.com/60436221/186382710-444ee69a-5fb1-400d-bde1-cdb0af29af8d.mp4


