### PR TITLE
Verse: Add missing typography supports

### DIFF
--- a/packages/block-library/src/verse/block.json
+++ b/packages/block-library/src/verse/block.json
@@ -38,6 +38,7 @@
 			"__experimentalFontWeight": true,
 			"__experimentalLetterSpacing": true,
 			"__experimentalTextTransform": true,
+			"__experimentalTextDecoration": true,
 			"__experimentalDefaultControls": {
 				"fontSize": true,
 				"fontAppearance": true


### PR DESCRIPTION
Related:
- https://github.com/WordPress/gutenberg/issues/43241
- https://github.com/WordPress/gutenberg/issues/43242

## What?

Adds missing typography supports to the Verse block.

## Why?

- Improves consistency of our design tools across blocks.

## How?

- Opts into missing text-decoration typography support.

## Testing Instructions

1. Edit a post, add a Verse block, select it and enter some content.
2. Check that the text-decoration controls are now available.
2. Test various typography settings ensuring styles are applied in the editor.
3. Save and confirm their application on the frontend.
4. Test styling via theme.json

Example theme.json snippet:
```json
			"core/verse": {
				"typography": {
					"textDecoration": "line-through"
				}
			}
```

## Screenshots or screencast <!-- if applicable -->


https://user-images.githubusercontent.com/60436221/186384937-7d6c0958-a431-4573-9d5a-995675f9cee3.mp4


