### PR TITLE
ColorPalette: Make popover style consistent

### DIFF
--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -22,6 +22,7 @@
 
 -   `CustomGradientPicker`, `GradientPicker`: Add `__nextHasNoMargin` prop for opting into the new margin-free styles ([#43387](https://github.com/WordPress/gutenberg/pull/43387)).
 -   `ToolsPanel`: Tighten grid gaps ([#43424](https://github.com/WordPress/gutenberg/pull/43424)).
+-   `ColorPalette`: Make popover style consistent ([#43570](https://github.com/WordPress/gutenberg/pull/43570)).
 -   `ToggleGroupControl`: Improve TypeScript documentation ([#43265](https://github.com/WordPress/gutenberg/pull/43265)).
 -   `ComboboxControl`: Normalize hyphen-like characters to an ASCII hyphen ([#42942](https://github.com/WordPress/gutenberg/pull/42942)).
 -   `FormTokenField`: Refactor away from `_.difference()` ([#43224](https://github.com/WordPress/gutenberg/pull/43224/)).

--- a/packages/components/src/color-palette/index.js
+++ b/packages/components/src/color-palette/index.js
@@ -22,6 +22,7 @@ import { VStack } from '../v-stack';
 import { Flex, FlexItem } from '../flex';
 import { Truncate } from '../truncate';
 import { ColorHeading } from './styles';
+import DropdownContentWrapper from '../dropdown/dropdown-content-wrapper';
 
 extend( [ namesPlugin, a11yPlugin ] );
 
@@ -202,11 +203,13 @@ export default function ColorPalette( {
 	const Component = showMultiplePalettes ? MultiplePalettes : SinglePalette;
 
 	const renderCustomColorPicker = () => (
-		<ColorPicker
-			color={ value }
-			onChange={ ( color ) => onChange( color ) }
-			enableAlpha={ enableAlpha }
-		/>
+		<DropdownContentWrapper paddingSize="none">
+			<ColorPicker
+				color={ value }
+				onChange={ ( color ) => onChange( color ) }
+				enableAlpha={ enableAlpha }
+			/>
+		</DropdownContentWrapper>
 	);
 
 	const colordColor = colord( value );

--- a/packages/components/src/color-palette/style.scss
+++ b/packages/components/src/color-palette/style.scss
@@ -31,20 +31,6 @@
 	}
 }
 
-.components-dropdown__content.components-color-palette__custom-color-dropdown-content .components-popover__content {
-	overflow: visible;
-	box-shadow: 0 4px 4px rgba(0, 0, 0, 0.05);
-	border: none;
-	outline: none;
-	border-radius: $radius-block-ui;
-	padding: 0;
-
-	.react-colorful__saturation {
-		border-top-right-radius: $radius-block-ui;
-		border-top-left-radius: $radius-block-ui;
-	}
-}
-
 .components-color-palette__custom-color-name {
 	text-align: left;
 }

--- a/packages/components/src/color-palette/test/__snapshots__/index.js.snap
+++ b/packages/components/src/color-palette/test/__snapshots__/index.js.snap
@@ -1,10 +1,17 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`ColorPalette Dropdown .renderContent should render dropdown content 1`] = `
-<ColorPicker
-  color="#f00"
-  onChange={[Function]}
-/>
+<DropdownContentWrapperDiv
+  className="components-dropdown-content-wrapper"
+  data-wp-c16t={true}
+  data-wp-component="DropdownContentWrapper"
+  paddingSize="none"
+>
+  <LegacyAdapter
+    color="#f00"
+    onChange={[Function]}
+  />
+</DropdownContentWrapperDiv>
 `;
 
 exports[`ColorPalette Dropdown .renderToggle should render dropdown content 1`] = `


### PR DESCRIPTION
Closes #41787

## What?

Make the ColorPalette popover styles consistent with the other standard popovers. Namely, the border and the shadow styles.

## Why?

For consistency.

## How?

Remove overrides and use the `DropdownContentWrapper` to remove paddings.

## Testing Instructions

1. `npm run storybook:dev` and see the ColorPalette story.
2. Click on the main swatch button to open the popover.

## Screenshots or screencast <!-- if applicable -->

| Before | After |
|--------|-------|
|<img src="https://user-images.githubusercontent.com/555336/186392479-dcc9d496-01f8-485b-ba49-a2ddccf51ea8.png" alt="Inconsistent popover style" width="400">|<img src="https://user-images.githubusercontent.com/555336/186392488-41954de6-bb80-4361-9697-de4724e2cf70.png" alt="Popover style that matches other standard popovers" width="400">|

Here's a screenshot of it side-by-side with the ColorGradientControl:

<img width="546" alt="ColorGradientControl with a ColorPalette popover beside it" src="https://user-images.githubusercontent.com/555336/186392532-775bc4c4-6bcf-4480-a5db-db78b804dcf4.png">


