### PR TITLE
skip navigation block e2e tests

### DIFF
--- a/packages/e2e-tests/specs/editor/blocks/navigation.test.js
+++ b/packages/e2e-tests/specs/editor/blocks/navigation.test.js
@@ -278,8 +278,9 @@ async function waitForBlock( blockName ) {
 }
 
 // Disable reason - these tests are to be re-written.
+// Skipped temporarily due to issues with GH actions: https://wordpress.slack.com/archives/C02QB2JS7/p1661331673166269.
 // eslint-disable-next-line jest/no-disabled-tests
-describe( 'Navigation', () => {
+describe.skip( 'Navigation', () => {
 	const contributorUsername = `contributoruser_${ ++uniqueId }`;
 	let contributorPassword;
 


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->
This disables the Navigation block e2e tests

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
Looks like these tests are failing consistently and they need to be reworked anyway. They are causing things like the RC build action to get stuck because we are triggering the repo limit. [Here](https://wordpress.slack.com/archives/C02QB2JS7/p1661331673166269) is the discussion about this.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
Skipping the tests :D

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->

Locally you can run `npm run test:e2e -- packages/e2e-tests/specs/editor/blocks/navigation.test.js` and will see the tests being skipped

## Screenshots or screencast <!-- if applicable -->

<img width="1062" alt="Screenshot 2022-08-24 at 12 24 25" src="https://user-images.githubusercontent.com/3593343/186399377-aab50e81-6a89-4fc6-99a9-02fe3c8afdf3.png">

