### PR TITLE
Lodash: Remove from blocks API raw handling

### DIFF
--- a/packages/blocks/src/api/raw-handling/figure-content-reducer.js
+++ b/packages/blocks/src/api/raw-handling/figure-content-reducer.js
@@ -1,9 +1,4 @@
 /**
- * External dependencies
- */
-import { has } from 'lodash';
-
-/**
  * WordPress dependencies
  */
 import { isTextContent } from '@wordpress/dom';
@@ -25,7 +20,11 @@ function isFigureContent( node, schema ) {
 		return false;
 	}
 
-	return has( schema, [ 'figure', 'children', tag ] );
+	return (
+		'figure' in schema &&
+		'children' in schema.figure &&
+		tag in schema.figure.children
+	);
 }
 
 /**
@@ -39,7 +38,13 @@ function isFigureContent( node, schema ) {
 function canHaveAnchor( node, schema ) {
 	const tag = node.nodeName.toLowerCase();
 
-	return has( schema, [ 'figure', 'children', 'a', 'children', tag ] );
+	return (
+		'figure' in schema &&
+		'children' in schema.figure &&
+		'a' in schema.figure.children &&
+		'children' in schema.figure.children.a &&
+		tag in schema.figure.children.a.children
+	);
 }
 
 /**

--- a/packages/blocks/src/api/raw-handling/figure-content-reducer.js
+++ b/packages/blocks/src/api/raw-handling/figure-content-reducer.js
@@ -20,11 +20,7 @@ function isFigureContent( node, schema ) {
 		return false;
 	}
 
-	return (
-		'figure' in schema &&
-		'children' in schema.figure &&
-		tag in schema.figure.children
-	);
+	return tag in ( schema?.figure?.children ?? {} );
 }
 
 /**
@@ -38,13 +34,7 @@ function isFigureContent( node, schema ) {
 function canHaveAnchor( node, schema ) {
 	const tag = node.nodeName.toLowerCase();
 
-	return (
-		'figure' in schema &&
-		'children' in schema.figure &&
-		'a' in schema.figure.children &&
-		'children' in schema.figure.children.a &&
-		tag in schema.figure.children.a.children
-	);
+	return tag in ( schema?.figure?.children?.a?.children ?? {} );
 }
 
 /**

--- a/packages/blocks/src/api/raw-handling/get-raw-transforms.js
+++ b/packages/blocks/src/api/raw-handling/get-raw-transforms.js
@@ -1,16 +1,12 @@
 /**
- * External dependencies
- */
-import { filter } from 'lodash';
-
-/**
  * Internal dependencies
  */
 import { getBlockTransforms } from '../factory';
 
 export function getRawTransforms() {
-	return filter( getBlockTransforms( 'from' ), { type: 'raw' } ).map(
-		( transform ) => {
+	return getBlockTransforms( 'from' )
+		.filter( ( { type } ) => type === 'raw' )
+		.map( ( transform ) => {
 			return transform.isMatch
 				? transform
 				: {
@@ -19,6 +15,5 @@ export function getRawTransforms() {
 							transform.selector &&
 							node.matches( transform.selector ),
 				  };
-		}
-	);
+		} );
 }

--- a/packages/blocks/src/api/raw-handling/phrasing-content-reducer.js
+++ b/packages/blocks/src/api/raw-handling/phrasing-content-reducer.js
@@ -1,9 +1,4 @@
 /**
- * External dependencies
- */
-import { includes } from 'lodash';
-
-/**
  * WordPress dependencies
  */
 import { wrap, replaceTag } from '@wordpress/dom';
@@ -33,7 +28,7 @@ export default function phrasingContentReducer( node, doc ) {
 		// fallback.
 		if (
 			textDecorationLine === 'line-through' ||
-			includes( textDecoration, 'line-through' )
+			textDecoration.includes( 'line-through' )
 		) {
 			wrap( doc.createElement( 's' ), node );
 		}


### PR DESCRIPTION
## What?
This PR removes Lodash usage from the block the API for raw handling. 

## Why?

Lodash is known to unnecessarily inflate the bundle size of packages, and in most cases, it can be replaced with native language functionality. See these for more information and rationale:

* https://github.com/WordPress/gutenberg/issues/16938#issuecomment-602837246
* https://github.com/WordPress/gutenberg/issues/17025
* https://github.com/WordPress/gutenberg/issues/39495 

## How?

We're replacing all Lodash usage with native functionality.

## Testing Instructions
* Verify all tests still pass: `npm run test:unit packages/blocks` 
* Verify all integration tests still pass: `npm run test:unit test/integration` 
* Try pasting raw HTML with shortcodes inside the editor and verify it's still handled well.
* Verify converting raw HTML to blocks still works well.