### PR TITLE
Navigation: Try making it possible for themes to have the X overlay the = icon

### DIFF
--- a/packages/block-library/src/navigation/style.scss
+++ b/packages/block-library/src/navigation/style.scss
@@ -468,8 +468,11 @@ button.wp-block-navigation-item__content {
 		flex-direction: column;
 		background-color: inherit;
 
-		// Use em units to apply padding, so themes can more easily style this in various ways.
-		padding: 2rem;
+		// Try to inherit any root paddings set, so the X can align to a top-right aligned menu.
+		padding-top: var(--wp--style--root--padding-top, 2rem);
+		padding-right: var(--wp--style--root--padding-right, 2rem);
+		padding-bottom: var(--wp--style--root--padding-bottom, 2rem);
+		padding-left: var(--wp--style--root--padding-left, 2rem);
 
 		// Allow modal to scroll.
 		overflow: auto;
@@ -645,6 +648,11 @@ button.wp-block-navigation-item__content {
 // The menu adds wrapping containers.
 .wp-block-navigation__responsive-close {
 	width: 100%;
+
+	// Try to inherit content-width when defined, so the X can align to a top-right aligned menu.
+	max-width: var(--wp--style--global--content-size, 100%);
+	margin-left: auto;
+	margin-right: auto;
 
 	// This element is not keyboard accessible, and is focusable only using the mouse.
 	// It is part of the MicroModal library that adds a scrim outside of a modal dialog that is not fullscreen,

--- a/packages/block-library/src/navigation/style.scss
+++ b/packages/block-library/src/navigation/style.scss
@@ -649,8 +649,8 @@ button.wp-block-navigation-item__content {
 .wp-block-navigation__responsive-close {
 	width: 100%;
 
-	// Try to inherit content-width when defined, so the X can align to a top-right aligned menu.
-	max-width: var(--wp--style--global--content-size, 100%);
+	// Try to inherit wide-width when defined, so the X can align to a top-right aligned menu.
+	max-width: var(--wp--style--global--wide-size, 100%);
 	margin-left: auto;
 	margin-right: auto;
 


### PR DESCRIPTION
## What?

Fixes #43523, even if more work can be done in the future (for an animated icon or otherwise).

When the navigation block is set to collapse into a modal overlay, right now it is impossible for a theme to perfectly ensure that the X to close perfectly overlaps the = menu icon. This is trunk:

![trunk](https://user-images.githubusercontent.com/1204802/186410240-dafc4066-cac0-46bb-9844-f9d316099d48.gif)

Simply to ensure a consistent experience, this should be possible. This PR makes it possible under these circumstances:

* The theme opts into root paddings (#42085), by adding `"useRootPaddingAwareAlignments": true` in theme.json under settings, and paddings to go with that either in global styles or under styles > spacing.
* The Header template part contains a group that inherits layout, with navigation inside that.
* The collapsing navigation block sits in the top right corner of the header, justified right.

![overlap](https://user-images.githubusercontent.com/1204802/186409391-7665933f-c079-434d-8191-f8dc7bff3352.gif)

## How?

The code to accomplish this should work, as it simply taps into the root padding values _if they are there_, but falls back to base values if they are not. I'd appreciate a sanity check on this approach, however, and alternatives if there are better ones.

## Testing Instructions

This one is a bit tricky to test as the theme has to use the root paddings. I believe that [Archeo](https://github.com/Automattic/themes/tree/trunk/archeo) does this, so that could be a theme to test.

Combine that with ensuring the navigation collapses to a burger, and is top-right & justified right in the header template part in the site editor. Then verify the X overlaps the = at all times.

Also test with a theme that does not opt into root paddings, and check that the fallback values work as intended.