### PR TITLE
Docs: Add example of BlockControls to Format API how to guide

### DIFF
--- a/docs/how-to-guides/format-api.md
+++ b/docs/how-to-guides/format-api.md
@@ -78,7 +78,7 @@ registerFormatType( 'my-custom-format/sample-output', {
 } );
 ```
 
-Let's check that everything is working as expected. Build and reload and then select a paragraph block. Confirm the new button was added to the format toolbar.
+Let's check that everything is working as expected. Build and reload and then select any block containing text like for example the paragraph block. Confirm the new button was added to the format toolbar.
 
 ![Toolbar with custom button](https://developer.wordpress.org/files/2021/12/format-api-toolbar.png)
 
@@ -131,7 +131,7 @@ Use the `className` option when registering to add your own custom class to the 
 
 ### Step 4: Show the button only for specific blocks (Optional)
 
-By default, the button is rendered on every rich text toolbar (image captions, buttons, paragraphs, etc). You can render the button only on blocks of a certain type by using `wp.data.select`.
+By default, the button is rendered on every rich text toolbar (image captions, buttons, paragraphs, etc). You can render the button only on blocks of a certain type by using [the data API](https://developer.wordpress.org/block-editor/reference-guides/packages/packages-data/#api).
 
 Here is an example that only shows the button for Paragraph blocks:
 

--- a/docs/how-to-guides/format-api.md
+++ b/docs/how-to-guides/format-api.md
@@ -78,7 +78,7 @@ registerFormatType( 'my-custom-format/sample-output', {
 } );
 ```
 
-Let's check that everything is working as expected. Build and reload and then select a text block. Confirm the new button was added to the format toolbar.
+Let's check that everything is working as expected. Build and reload and then select a paragraph block. Confirm the new button was added to the format toolbar.
 
 ![Toolbar with custom button](https://developer.wordpress.org/files/2021/12/format-api-toolbar.png)
 
@@ -125,13 +125,13 @@ registerFormatType( 'my-custom-format/sample-output', {
 
 Confirm it is working: first build and reload, then make a text selection and click the button. Your browser will likely display that selection differently than the surrounding text.
 
-You can also confirm by switching to HTML view (Code editor Ctrl+Shift+Alt+M) and see the text selection wrapped with `<samp>` HTML tags.
+You can also confirm by switching to HTML view (Code editor `Ctrl+Shift+Alt+M`) and see the text selection wrapped with `<samp>` HTML tags.
 
 Use the `className` option when registering to add your own custom class to the tag. You can use that class and custom CSS to target that element and style as you wish.
 
 ### Step 4: Show the button only for specific blocks (Optional)
 
-By default, the button is rendered on every rich text toolbar (image captions, buttons, paragraphs, etc). You can render the button only on blocks of a certain type by using `wp.data.withSelect` together with `wp.compose.ifCondition`.
+By default, the button is rendered on every rich text toolbar (image captions, buttons, paragraphs, etc). You can render the button only on blocks of a certain type by using `wp.data.select`.
 
 Here is an example that only shows the button for Paragraph blocks:
 
@@ -170,6 +170,44 @@ registerFormatType( 'my-custom-format/sample-output', {
 	tagName: 'samp',
 	className: null,
 	edit: ConditionalButton,
+} );
+```
+
+### Step5: Add a button outside of the dropdown
+
+Using the `RichTextToolbarButton` component, the button is added to the default dropdown menu. You can add the button directly to the toolbar by using the `BlockControls` component.
+
+```js
+import { registerFormatType, toggleFormat } from '@wordpress/rich-text';
+import { BlockControls } from '@wordpress/block-editor';
+import { ToolbarGroup, ToolbarButton } from '@wordpress/components';
+
+const MyCustomButton = ( { isActive, onChange, value } ) => {
+	return (
+		<BlockControls>
+			<ToolbarGroup>
+				<ToolbarButton
+					icon="editor-code"
+					title="Sample output"
+					onClick={ () => {
+						onChange(
+							toggleFormat( value, {
+								type: 'my-custom-format/sample-output',
+							} )
+						);
+					} }
+					isActive={ isActive }
+				/>
+			</ToolbarGroup>
+		</BlockControls>
+	);
+};
+
+registerFormatType( 'my-custom-format/sample-output', {
+	title: 'Sample output',
+	tagName: 'samp',
+	className: null,
+	edit: MyCustomButton,
 } );
 ```
 

--- a/docs/how-to-guides/format-api.md
+++ b/docs/how-to-guides/format-api.md
@@ -173,7 +173,7 @@ registerFormatType( 'my-custom-format/sample-output', {
 } );
 ```
 
-### Step5: Add a button outside of the dropdown
+### Step5: Add a button outside of the dropdown (Optional)
 
 Using the `RichTextToolbarButton` component, the button is added to the default dropdown menu. You can add the button directly to the toolbar by using the `BlockControls` component.
 

--- a/docs/how-to-guides/format-api.md
+++ b/docs/how-to-guides/format-api.md
@@ -131,7 +131,7 @@ Use the `className` option when registering to add your own custom class to the 
 
 ### Step 4: Show the button only for specific blocks (Optional)
 
-By default, the button is rendered on every rich text toolbar (image captions, buttons, paragraphs, etc). You can render the button only on blocks of a certain type by using [the data API](https://developer.wordpress.org/block-editor/reference-guides/packages/packages-data/#api).
+By default, the button is rendered on every rich text toolbar (image captions, buttons, paragraphs, etc). You can render the button only on blocks of a certain type by using [the data API](https://developer.wordpress.org/block-editor/reference-guides/packages/packages-data).
 
 Here is an example that only shows the button for Paragraph blocks:
 


### PR DESCRIPTION
Fixes #14881, #29181
Follow-up on #37298

## What?
This PR adds a example of `BlockControls` to [Format API how to guide](https://developer.wordpress.org/block-editor/how-to-guides/format-api/).
In addition, I have made a few minor corrections to the description that I believe are inconsistent with the code.

## Why?
`registerFormatType` can add a custom format to the default drop-down menu via `RichTextToolbarButton`, as shown in this document. But as some people asked in #14881 and #29181, I think we also need an advanced example, using BlockControl to add a button directly to the toolbar.

## How?
I've added a code example as an optional step.

## Testing Instructions

Create a simple plugin and build as follows:

`test.php`

```php
<?php
/**
 * Plugin Name: Test
 */
add_action( 'enqueue_block_editor_assets', function () {
	$asset_file = include( plugin_dir_path( __FILE__ ) . '/build/index.asset.php' );
	wp_enqueue_script(
		'test',
		plugin_dir_url( __FILE__ ) . 'build/index.js',
		$asset_file['dependencies']
	);
} );
```

`src/index.js` (same as the code example in the updated document)

```javascript
import { registerFormatType, toggleFormat } from '@wordpress/rich-text';
import { BlockControls } from '@wordpress/block-editor';
import { ToolbarGroup, ToolbarButton } from '@wordpress/components';

const MyCustomButton = ( { isActive, onChange, value } ) => {
	return (
		<BlockControls>
			<ToolbarGroup>
				<ToolbarButton
					icon="editor-code"
					title="Sample output"
					onClick={ () => {
						onChange(
							toggleFormat( value, {
								type: 'my-custom-format/sample-output',
							} )
						);
					} }
					isActive={ isActive }
				/>
			</ToolbarGroup>
		</BlockControls>
	);
};

registerFormatType( 'my-custom-format/sample-output', {
	title: 'Sample output',
	tagName: 'samp',
	className: null,
	edit: MyCustomButton,
} );
```

## Screenshots or screencast

![capture](https://user-images.githubusercontent.com/54422211/186442220-b4b01d09-c10a-4561-97b1-fa23528c3289.png)

