### PR TITLE
Block Library: Fix error in useClientWidth

### DIFF
--- a/packages/block-library/src/image/use-client-width.js
+++ b/packages/block-library/src/image/use-client-width.js
@@ -7,7 +7,7 @@ export default function useClientWidth( ref, dependencies ) {
 	const [ clientWidth, setClientWidth ] = useState();
 
 	function calculateClientWidth() {
-		setClientWidth( ref.current.clientWidth );
+		setClientWidth( ref.current?.clientWidth );
 	}
 
 	useEffect( calculateClientWidth, dependencies );


### PR DESCRIPTION
## What?
Fixes #43562.

PR fixes following error in `useClientWidth` hook:

```
Uncaught TypeError: Cannot read properties of null (reading 'clientWidth') at calculateClientWidth (use-client-width.js:10:31)
```

## Why?
The `ref.current` can be null when unmounting.

## Testing Instructions
I had trouble finding a consistent way to reproduce the issue, but steps from the issue often work.

1. Open a new post page.
2. Open the block inserter.
3. Scroll to where the Design Category is visible and move the mouse pointer over the Columns block.
4. Move the mouse pointer over the Buttons block.
