### PR TITLE
Limit contrast checker to only blocks that have at least one color defined

### DIFF
--- a/packages/block-editor/src/hooks/color-panel.js
+++ b/packages/block-editor/src/hooks/color-panel.js
@@ -26,9 +26,10 @@ export default function ColorPanel( {
 	const [ detectedColor, setDetectedColor ] = useState();
 	const [ detectedLinkColor, setDetectedLinkColor ] = useState();
 	const ref = useBlockRef( clientId );
+	const definedColors = settings.filter( ( setting ) => setting?.colorValue );
 
 	useEffect( () => {
-		if ( ! enableContrastChecking ) {
+		if ( ! enableContrastChecking || ! definedColors.length ) {
 			return;
 		}
 
@@ -37,7 +38,7 @@ export default function ColorPanel( {
 		}
 		setDetectedColor( getComputedStyle( ref.current ).color );
 
-		const firstLinkElement = ref.current?.querySelector( ':scope > a' );
+		const firstLinkElement = ref.current?.querySelector( 'a' );
 		if ( firstLinkElement && !! firstLinkElement.innerText ) {
 			setDetectedLinkColor( getComputedStyle( firstLinkElement ).color );
 		}

--- a/packages/block-editor/src/hooks/color-panel.js
+++ b/packages/block-editor/src/hooks/color-panel.js
@@ -37,7 +37,7 @@ export default function ColorPanel( {
 		}
 		setDetectedColor( getComputedStyle( ref.current ).color );
 
-		const firstLinkElement = ref.current?.querySelector( 'a' );
+		const firstLinkElement = ref.current?.querySelector( ':scope > a' );
 		if ( firstLinkElement && !! firstLinkElement.innerText ) {
 			setDetectedLinkColor( getComputedStyle( firstLinkElement ).color );
 		}


### PR DESCRIPTION
## What?
Limits the scope of `link` color check in the contrast checker to direct children of current block

## Why?
Currently it gets the first link found at any depth of nesting within a block and compares it against the computed background color of current block, ignoring all other backgrounds that may be set between the two, this results in both false positives and false negatives [as noted here](https://github.com/WordPress/gutenberg/issues/43537).
Fixes: #43537

## How?
Adds a direct child scope to the link query selector `':scope > a'`
 
**N.B.** This isn't a perfect solution as it means the link contrast color will not be checked in cases where the link `a` tag is not a direct child of the parent block when colors are not explicitly set. At the moment it may be a case of deciding which is the least confusing as I can't think of a perfect fix.

## Testing Instructions

- Add a paragraph block with a link and set both good and back color contrast options and make sure contrast checker shows as expected
- Add a Group block and set combinations of good and bad link and background color combinations and make sure contrast checker displays as expected
- Add a Query loop block and set a dark background and light link color on the Post title block nested in it, then select the parent Query block and check that contrast warning is not showng

## Screenshots or screencast 

Before:

https://user-images.githubusercontent.com/3629020/186568690-ae9c1bf0-f7cb-4331-a314-276a6c0ee0de.mp4

After:

https://user-images.githubusercontent.com/3629020/186568728-be482aaa-c5db-4f55-80e1-ef0f18a81365.mp4




