### PR TITLE
Block Templates: Add the custom templates info for the template posts

### DIFF
--- a/lib/compat/wordpress-6.1/block-template-utils.php
+++ b/lib/compat/wordpress-6.1/block-template-utils.php
@@ -121,6 +121,13 @@ function gutenberg_get_block_templates( $query = array(), $template_type = 'wp_t
 			continue;
 		}
 
+		if ( $post_type &&
+			isset( $template->post_types ) &&
+			! in_array( $post_type, $template->post_types, true )
+		) {
+			continue;
+		}
+
 		$query_result[] = $template;
 	}
 	if ( ! isset( $query['wp_id'] ) ) {
@@ -264,8 +271,8 @@ function gutenberg_build_block_template_result_from_post( $post ) {
 	$is_wp_suggestion = get_post_meta( $post->ID, 'is_wp_suggestion', true );
 
 	$theme          = $terms[0]->name;
-	$has_theme_file = wp_get_theme()->get_stylesheet() === $theme &&
-		null !== _get_block_template_file( $post->post_type, $post->post_name );
+	$template_file  = _get_block_template_file( $post->post_type, $post->post_name );
+	$has_theme_file = wp_get_theme()->get_stylesheet() === $theme && null !== $template_file;
 
 	$template                 = new WP_Block_Template();
 	$template->wp_id          = $post->ID;
@@ -286,6 +293,10 @@ function gutenberg_build_block_template_result_from_post( $post ) {
 	// We keep this check for existent templates that are part of the template hierarchy.
 	if ( 'wp_template' === $post->post_type && isset( $default_template_types[ $template->slug ] ) ) {
 		$template->is_custom = false;
+	}
+
+	if ( 'wp_template' === $post->post_type && $has_theme_file && isset( $template_file['postTypes'] ) ) {
+		$template->post_types = $template_file['postTypes'];
 	}
 
 	if ( 'wp_template_part' === $post->post_type ) {


### PR DESCRIPTION
## What?
Fixes #43557.

PR updates `_build_block_template_result_from_post` to include `postTypes` details defined in theme.json for modified custom templates. Also, add logic to the `get_block_templates` for skipping these templates when post type argument is provided.

## Testing Instructions
Using TT2 theme.

1. Go to the Site Editor.
2. Modify the "Page (No Separators)" template.
3. Open a post.
4. Confirm "Page (No Separators)" isn't available in Template dropdown.

## Screenshots or screencast <!-- if applicable -->

![CleanShot 2022-08-25 at 11 11 34](https://user-images.githubusercontent.com/240569/186599105-f4359115-ba26-41b4-ab31-dfa15d566083.png)

