### PR TITLE
Code Block: Fix duplicate background color

### DIFF
--- a/packages/block-library/src/code/editor.scss
+++ b/packages/block-library/src/code/editor.scss
@@ -1,0 +1,3 @@
+.wp-block-code code {
+	background: none;
+}

--- a/packages/block-library/src/editor.scss
+++ b/packages/block-library/src/editor.scss
@@ -5,6 +5,7 @@
 @import "./button/editor.scss";
 @import "./buttons/editor.scss";
 @import "./categories/editor.scss";
+@import "./code/editor.scss";
 @import "./columns/editor.scss";
 @import "./comments/editor.scss";
 @import "./comment-author-avatar/editor.scss";


### PR DESCRIPTION
Fix: #43587

## What?
This PR fixes duplicate background color when padding and gradient backgrounds are set on code blocks.

## Why?
This problem is caused by the fact that the background color of the code tag is inherited in [the reset CSS](https://github.com/WordPress/gutenberg/blob/ccc584c0b8a2d312852a7de38b8dec4d53131bf2/packages/block-library/src/reset.scss#L44-L50).

## How?
In the cover block editor style, I have set the background of the child code block to `none`.

## Testing Instructions
- Insert the code block.
- Apply padding and gradient background color.
- Confirm that no breaks occur in the gradient color.

## Screenshots or screencast <!-- if applicable -->

### On trunk

![trunk](https://user-images.githubusercontent.com/54422211/186610950-cfc88fa6-99e2-437a-9532-b36d0f155536.png)

### On this branch

![branch](https://user-images.githubusercontent.com/54422211/186610972-8fc38759-e572-4a32-b141-baa6c40ab1d5.png)


