### PR TITLE
Document Settings: Display pretty permalink for draft posts

### DIFF
--- a/packages/editor/src/components/post-url/label.js
+++ b/packages/editor/src/components/post-url/label.js
@@ -15,7 +15,7 @@ export default function PostURLLabel() {
 
 export function usePostURLLabel() {
 	const postLink = useSelect(
-		( select ) => select( editorStore ).getCurrentPost().link,
+		( select ) => select( editorStore ).getPermalink(),
 		[]
 	);
 	return filterURLForDisplay( safeDecodeURIComponent( postLink ) );


### PR DESCRIPTION
## What?
Fixes #43161.

PR updates the `usePostURLLabel` hook to display pretty permalinks for draft and schedule posts. If the "Plain" permalink setting is set, it will fall back to the ID-based link.

## How?
I swapped the selector to use `getPermalink`, which handles all the logic for us. 

## Testing Instructions
* Create or open a draft post.
* Confirm that the pretty permalink is displayed as a button label in the Document Settings.

## Screenshots or screencast <!-- if applicable -->

| Pretty Permalinks Enabled | Plain Permalinks Enabled |
| --- | --- |
|![CleanShot 2022-08-25 at 13 05 35](https://user-images.githubusercontent.com/240569/186625704-81b6171d-8c34-4489-b3a1-65c007aea3a7.png)|![CleanShot 2022-08-25 at 13 05 56](https://user-images.githubusercontent.com/240569/186625715-241b722a-dc49-47c9-90f7-3a599ff12e63.png)|

