### PR TITLE
Global Styles: Remove main content layout padding in preview

### DIFF
--- a/packages/edit-site/src/components/global-styles/preview.js
+++ b/packages/edit-site/src/components/global-styles/preview.js
@@ -79,13 +79,13 @@ const StylesPreview = ( { label, isFocused } ) => {
 		)
 		.slice( 0, 2 );
 
-	// Reset leaked styles from WP common.css.
+	// Reset leaked styles from WP common.css and remove main content layout padding.
 	const editorStyles = useMemo( () => {
 		if ( styles ) {
 			return [
 				...styles,
 				{
-					css: 'body{min-width: 0;}',
+					css: 'body{min-width: 0;padding: 0;}',
 					isGlobalStyles: true,
 				},
 			];


### PR DESCRIPTION
Fix #43572

## What?
This PR removes the main content layout padding in the global styles preview.

## Why?
In the global style preview, the body tag of the iframe is given various styles that represent the actual style based on the `.editor-styles-wrapper` class. This is the expected behavior, but with respect to `padding`, it is a factor that destroys the preview style.

## How?
Reset padding to 0 only in the global style preview panel.

## Testing Instructions
- Define the following styles in the `styles.spacing` property of `theme.json`:

```json
{
	"version": 2,
	"styles": {
		"spacing": {
			"padding": {
				"top": "100px",
				"right": "var(--wp--preset--spacing--30)",
				"bottom": "0px",
				"left": "var(--wp--preset--spacing--30)"
			}
		}
	}
}
```

- Open the site editor and confirm that the padding is applied correctly to the main content.
- Open the global styles menu.
- Confirm that no padding is applied to the global style preview panel and that it is displayed in the correct layout.
- Click on "Browse styles" and confirm that no padding is applied to the variation panel as well.
- Return to the previous menu and change the value of padding from the Layout menu button.
- Confirm that when you change the value of padding, it is reflected in the main content, but not applied to the global style preview.

## Screenshots or screencast 

| On trunk | On this branch |
|---|---|
| ![trunk_active](https://user-images.githubusercontent.com/54422211/186626522-d3f5172d-2362-433c-9c91-5922fa3db5e1.png) | ![branch_active](https://user-images.githubusercontent.com/54422211/186626891-5ceecb9f-7dac-497b-b5aa-e4638ad67c2a.png) |
| ![trunk_variation](https://user-images.githubusercontent.com/54422211/186626550-c2256c4d-6e80-4502-8416-5a3b5dc8750b.png) | ![branch_variation](https://user-images.githubusercontent.com/54422211/186626751-bccf6644-777f-4048-9a0e-2402f370e33d.png) |


