### PR TITLE
Fix blank screen on templates page

### DIFF
--- a/packages/edit-site/src/components/add-new-template/utils.js
+++ b/packages/edit-site/src/components/add-new-template/utils.js
@@ -119,7 +119,7 @@ export function usePostTypeArchiveMenuItems() {
 			postTypesWithArchives
 				?.filter(
 					( postType ) =>
-						! existingTemplates.some(
+						! ( existingTemplates || [] ).some(
 							( existingTemplate ) =>
 								existingTemplate.slug ===
 								'archive-' + postType.slug


### PR DESCRIPTION
Fixes the bug reported https://github.com/WordPress/gutenberg/pull/42746#issuecomment-1226988143

