### PR TITLE
[Site Editor]: New archive-$postType templates get proper fallback content

### DIFF
--- a/packages/edit-site/src/components/add-new-template/utils.js
+++ b/packages/edit-site/src/components/add-new-template/utils.js
@@ -157,6 +157,7 @@ export function usePostTypeArchiveMenuItems() {
 						icon: postType.icon?.startsWith( 'dashicons-' )
 							? postType.icon.slice( 10 )
 							: archive,
+						templatePrefix: 'archive',
 					};
 				} ) || [],
 		[ postTypesWithArchives, existingTemplates, needsUniqueIdentifier ]


### PR DESCRIPTION


<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Follow up of: https://github.com/WordPress/gutenberg/pull/42746

In new archive templates make sure they get the proper fallback if available - in this case from `archive` template.
<!-- In a few words, what is the PR actually doing? -->

## Testing Instructions
1. In site editor create an `archive-$postType` template
2. If `archive` template exists, should get that content instead of `index`.

