### PR TITLE
Components: Add contextConnectWithoutRef() to bypass ref forwarding

### DIFF
--- a/packages/components/src/ui/context/context-connect.ts
+++ b/packages/components/src/ui/context/context-connect.ts
@@ -57,7 +57,7 @@ export function contextConnect<
 export function contextConnectWithoutRef< P >(
 	Component: ( props: P ) => JSX.Element | null,
 	namespace: string
-): WordPressComponentFromProps< P, false > {
+) {
 	return _contextConnect( Component, namespace );
 }
 
@@ -65,12 +65,16 @@ export function contextConnectWithoutRef< P >(
 // The hope is that we can improve render performance by removing functional
 // component wrappers.
 function _contextConnect<
-	C extends ( props: any, ref: ForwardedRef< any > ) => JSX.Element | null
+	C extends ( props: any, ref: ForwardedRef< any > ) => JSX.Element | null,
+	O extends ContextConnectOptions
 >(
 	Component: C,
 	namespace: string,
-	options?: ContextConnectOptions
-): WordPressComponentFromProps< Parameters< C >[ 0 ] > {
+	options?: O
+): WordPressComponentFromProps<
+	Parameters< C >[ 0 ],
+	O[ 'forwardsRef' ] extends true ? true : false
+> {
 	const WrappedComponent = options?.forwardsRef
 		? forwardRef< any, Parameters< C >[ 0 ] >( Component )
 		: Component;

--- a/packages/components/src/ui/context/context-connect.ts
+++ b/packages/components/src/ui/context/context-connect.ts
@@ -38,7 +38,7 @@ export function contextConnect< P >(
 		warn( 'contextConnect: Please provide a namespace' );
 	}
 
-	// @ts-ignore internal property
+	// @ts-expect-error internal property
 	let mergedNamespace = WrappedComponent[ CONNECT_STATIC_NAMESPACE ] || [
 		namespace,
 	];
@@ -55,16 +55,11 @@ export function contextConnect< P >(
 
 	WrappedComponent.displayName = namespace;
 
-	// @ts-ignore internal property
-	WrappedComponent[ CONNECT_STATIC_NAMESPACE ] = [
-		...new Set( mergedNamespace ),
-	];
-
-	// @ts-ignore WordPressComponent property
-	WrappedComponent.selector = `.${ getStyledClassNameFromKey( namespace ) }`;
-
-	// @ts-ignore
-	return WrappedComponent;
+	// @ts-expect-error
+	return Object.assign( WrappedComponent, {
+		[ CONNECT_STATIC_NAMESPACE ]: [ ...new Set( mergedNamespace ) ],
+		selector: `.${ getStyledClassNameFromKey( namespace ) }`,
+	} );
 }
 
 /**

--- a/packages/components/src/ui/context/context-connect.ts
+++ b/packages/components/src/ui/context/context-connect.ts
@@ -54,10 +54,10 @@ export function contextConnect<
  * @param  namespace The namespace to register the component under.
  * @return The connected WordPressComponent
  */
-export function contextConnectWithoutRef(
-	Component: ( props: any ) => JSX.Element | null,
+export function contextConnectWithoutRef< P >(
+	Component: ( props: P ) => JSX.Element | null,
 	namespace: string
-) {
+): WordPressComponentFromProps< P, false > {
 	return _contextConnect( Component, namespace );
 }
 

--- a/packages/components/src/ui/context/context-connect.ts
+++ b/packages/components/src/ui/context/context-connect.ts
@@ -6,7 +6,7 @@ import type { ForwardedRef, ReactChild, ReactNode } from 'react';
 /**
  * WordPress dependencies
  */
-import { forwardRef, memo } from '@wordpress/element';
+import { forwardRef } from '@wordpress/element';
 import warn from '@wordpress/warning';
 
 /**
@@ -15,11 +15,6 @@ import warn from '@wordpress/warning';
 import { CONNECT_STATIC_NAMESPACE } from './constants';
 import { getStyledClassNameFromKey } from './get-styled-class-name-from-key';
 import type { WordPressComponentFromProps } from '.';
-
-type ContextConnectOptions = {
-	/** Defaults to `false`. */
-	memo?: boolean;
-};
 
 /**
  * Forwards ref (React.ForwardRef) and "Connects" (or registers) a component
@@ -31,21 +26,13 @@ type ContextConnectOptions = {
  *
  * @param  Component The component to register into the Context system.
  * @param  namespace The namespace to register the component under.
- * @param  options
  * @return The connected WordPressComponent
  */
 export function contextConnect< P >(
 	Component: ( props: P, ref: ForwardedRef< any > ) => JSX.Element | null,
-	namespace: string,
-	options: ContextConnectOptions = {}
+	namespace: string
 ): WordPressComponentFromProps< P > {
-	const { memo: memoProp = false } = options;
-
-	let WrappedComponent = forwardRef( Component );
-	if ( memoProp ) {
-		// @ts-ignore
-		WrappedComponent = memo( WrappedComponent );
-	}
+	const WrappedComponent = forwardRef< any, P >( Component );
 
 	if ( typeof namespace === 'undefined' ) {
 		warn( 'contextConnect: Please provide a namespace' );

--- a/packages/components/src/ui/context/context-connect.ts
+++ b/packages/components/src/ui/context/context-connect.ts
@@ -94,7 +94,8 @@ function _contextConnect<
 		mergedNamespace = [ ...mergedNamespace, namespace ];
 	}
 
-	// @ts-expect-error
+	// @ts-expect-error We can't rely on inferred types here because of the
+	// `as` prop polymorphism we're handling in https://github.com/WordPress/gutenberg/blob/9620bae6fef4fde7cc2b7833f416e240207cda29/packages/components/src/ui/context/wordpress-component.ts#L32-L33
 	return Object.assign( WrappedComponent, {
 		[ CONNECT_STATIC_NAMESPACE ]: [ ...new Set( mergedNamespace ) ],
 		displayName: namespace,

--- a/packages/components/src/ui/context/context-connect.ts
+++ b/packages/components/src/ui/context/context-connect.ts
@@ -16,6 +16,9 @@ import { CONNECT_STATIC_NAMESPACE } from './constants';
 import { getStyledClassNameFromKey } from './get-styled-class-name-from-key';
 import type { WordPressComponentFromProps } from '.';
 
+type AcceptsTwoArgs< F extends ( ...args: any ) => any > =
+	Parameters< F >[ 'length' ] extends 2 ? {} : never;
+
 /**
  * Forwards ref (React.ForwardRef) and "Connects" (or registers) a component
  * within the Context system under a specified namespace.
@@ -28,11 +31,15 @@ import type { WordPressComponentFromProps } from '.';
  * @param  namespace The namespace to register the component under.
  * @return The connected WordPressComponent
  */
-export function contextConnect< P >(
-	Component: ( props: P, ref: ForwardedRef< any > ) => JSX.Element | null,
+export function contextConnect<
+	C extends ( props: any, ref: ForwardedRef< any > ) => JSX.Element | null
+>(
+	Component: C & AcceptsTwoArgs< C >,
 	namespace: string
-): WordPressComponentFromProps< P > {
-	const WrappedComponent = forwardRef< any, P >( Component );
+): WordPressComponentFromProps< Parameters< C >[ 0 ] > {
+	const WrappedComponent = forwardRef< any, Parameters< C >[ 0 ] >(
+		Component
+	);
 
 	if ( typeof namespace === 'undefined' ) {
 		warn( 'contextConnect: Please provide a namespace' );

--- a/packages/components/src/ui/context/test/context-connect.tsx
+++ b/packages/components/src/ui/context/test/context-connect.tsx
@@ -7,13 +7,17 @@ import type { ForwardedRef } from 'react';
  * Internal dependencies
  */
 import { contextConnect, contextConnectWithoutRef } from '../context-connect';
+import type { WordPressComponentProps } from '../wordpress-component';
 
 // Static TypeScript tests
 describe( 'ref forwarding', () => {
-	const ComponentWithRef = ( props: {}, ref: ForwardedRef< any > ) => (
-		<div { ...props } ref={ ref } />
-	);
-	const ComponentWithoutRef = ( props: {} ) => <div { ...props } />;
+	const ComponentWithRef = (
+		props: WordPressComponentProps< {}, 'div' >,
+		ref: ForwardedRef< any >
+	) => <div { ...props } ref={ ref } />;
+	const ComponentWithoutRef = (
+		props: WordPressComponentProps< {}, 'div' >
+	) => <div { ...props } />;
 
 	it( 'should not trigger a TS error if components are passed to the correct connect* functions', () => {
 		contextConnect( ComponentWithRef, 'Foo' );
@@ -30,5 +34,22 @@ describe( 'ref forwarding', () => {
 
 		// @ts-expect-error This should error
 		contextConnectWithoutRef( ComponentWithRef, 'Foo' );
+	} );
+
+	it( 'should result in a component with the correct prop types', () => {
+		const AcceptsRef = contextConnect( ComponentWithRef, 'Foo' );
+
+		<AcceptsRef ref={ null } />;
+
+		// @ts-expect-error An unaccepted prop should trigger an error
+		<AcceptsRef foo={ null } />;
+
+		const NoRef = contextConnectWithoutRef( ComponentWithoutRef, 'Foo' );
+
+		// @ts-expect-error The ref prop should trigger an error
+		<NoRef ref={ null } />;
+
+		// @ts-expect-error An unaccepted prop should trigger an error
+		<NoRef foo={ null } />;
 	} );
 } );

--- a/packages/components/src/ui/context/test/context-connect.tsx
+++ b/packages/components/src/ui/context/test/context-connect.tsx
@@ -1,0 +1,34 @@
+/**
+ * External dependencies
+ */
+import type { ForwardedRef } from 'react';
+
+/**
+ * Internal dependencies
+ */
+import { contextConnect, contextConnectWithoutRef } from '../context-connect';
+
+// Static TypeScript tests
+describe( 'ref forwarding', () => {
+	const ComponentWithRef = ( props: {}, ref: ForwardedRef< any > ) => (
+		<div { ...props } ref={ ref } />
+	);
+	const ComponentWithoutRef = ( props: {} ) => <div { ...props } />;
+
+	it( 'should not trigger a TS error if components are passed to the correct connect* functions', () => {
+		contextConnect( ComponentWithRef, 'Foo' );
+		contextConnectWithoutRef( ComponentWithoutRef, 'Foo' );
+	} );
+
+	it( 'should trigger a TS error if components are passed to the wrong connect* functions', () => {
+		// Wrapped in a thunk because React.forwardRef() will throw a console warning if this is executed
+		// eslint-disable-next-line no-unused-expressions
+		() => {
+			// @ts-expect-error This should error
+			contextConnect( ComponentWithoutRef, 'Foo' );
+		};
+
+		// @ts-expect-error This should error
+		contextConnectWithoutRef( ComponentWithRef, 'Foo' );
+	} );
+} );


### PR DESCRIPTION
## What?

Adds a separate `contextConnectWithoutRef()` function so components can bypass the `forwardRef()` wrapping.

## Why?

Not all components need to forward refs.

## How?

Moves the existing `contextConnect` function to a private internal function, and instead exposes two separate functions `contextConnect` and `contextConnectWithoutRef`. TypeScript will now error when a ref-less function is passed to `contextConnect`, and will surface a helpful warning message.

Previously, passing a ref-less function to `contextConnect` would cause dev mode React to throw a warning at runtime. This could be hard to notice if there are no render tests for the component.

## Testing Instructions

✅ Types build without error