### PR TITLE
Rich text: log deprecation message for multiline prop

### DIFF
--- a/packages/block-editor/src/components/rich-text/index.js
+++ b/packages/block-editor/src/components/rich-text/index.js
@@ -117,7 +117,8 @@ function RichTextWrapper(
 ) {
 	if ( multiline ) {
 		deprecated( 'wp.blockEditor.RichText multiline prop', {
-			since: '14.1',
+			since: '6.1',
+			version: '6.2',
 			alternative: 'nested blocks (InnerBlocks)',
 			link: 'https://developer.wordpress.org/block-editor/how-to-guides/block-tutorial/nested-blocks-inner-blocks/',
 		} );

--- a/packages/block-editor/src/components/rich-text/index.js
+++ b/packages/block-editor/src/components/rich-text/index.js
@@ -115,6 +115,14 @@ function RichTextWrapper(
 	},
 	forwardedRef
 ) {
+	if ( multiline ) {
+		deprecated( 'wp.blockEditor.RichText multiline prop', {
+			since: '14.1',
+			alternative: 'nested blocks (InnerBlocks)',
+			link: 'https://developer.wordpress.org/block-editor/how-to-guides/block-tutorial/nested-blocks-inner-blocks/',
+		} );
+	}
+
 	const instanceId = useInstanceId( RichTextWrapper );
 
 	identifier = identifier || instanceId;

--- a/packages/block-editor/src/components/rich-text/index.js
+++ b/packages/block-editor/src/components/rich-text/index.js
@@ -118,7 +118,7 @@ function RichTextWrapper(
 	if ( multiline ) {
 		deprecated( 'wp.blockEditor.RichText multiline prop', {
 			since: '6.1',
-			version: '6.2',
+			version: '6.3',
 			alternative: 'nested blocks (InnerBlocks)',
 			link: 'https://developer.wordpress.org/block-editor/how-to-guides/block-tutorial/nested-blocks-inner-blocks/',
 		} );


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?

Deprecates the `multiline` prop for `RichText`. As of #42711, we're no longer using this in core.

## Why?

Handling multi line content in RichText is quite complex.

* There's 10 out of 28 rich text manipulation functions that are just for multi line handling. 
* There's significant amount of added complexity in the `create` and `toTree` functions to convert between DOM/HTML and the rich text value.

Deprecation would mean that after a WP release we can consider removing this code, which makes rich text easier to maintain and makes refactors easier to do.

For example, #29870 would be much more work if we have to take into account multi line values.

## How?

This PR logs a simple message. We'd also have to write a dev not explaining how to change code to InnerBlocks. It's probably also a good idea to have a dedicated message in the email sent to plugin authors every release for extra awareness.

## Testing Instructions

Edit a block to using RichText multiline and check the console.

## Screenshots or screencast <!-- if applicable -->
