### PR TITLE
Popover: enable auto-updating every animation frame

### DIFF
--- a/packages/block-editor/src/components/block-popover/index.js
+++ b/packages/block-editor/src/components/block-popover/index.js
@@ -66,8 +66,6 @@ function BlockPopover(
 			// Render in the old slot if needed for backward compatibility,
 			// otherwise render in place (not in the default popover slot).
 			__unstableSlotName={ __unstablePopoverSlot || null }
-			// Observe movement for block animations (especially horizontal).
-			__unstableObserveElement={ selectedElement }
 			__unstableForcePosition
 			__unstableShift
 			{ ...props }

--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Bug Fix
+
+-   `Popover`: enable auto-updating every animation frame ([#43617](https://github.com/WordPress/gutenberg/pull/43617)).
+
 ### Internal
 
 -   Refactor `FocalPointPicker` to function component ([#39168](https://github.com/WordPress/gutenberg/pull/39168)).

--- a/packages/components/src/popover/index.js
+++ b/packages/components/src/popover/index.js
@@ -374,7 +374,10 @@ const Popover = (
 		return autoUpdate(
 			resultingReferenceRef,
 			refs.floating.current,
-			update
+			update,
+			{
+				animationFrame: true,
+			}
 		);
 		// 'reference' and 'refs.floating' are refs and don't need to be listed
 		// as dependencies (see https://github.com/WordPress/gutenberg/pull/41612)

--- a/packages/components/src/popover/index.js
+++ b/packages/components/src/popover/index.js
@@ -143,7 +143,6 @@ const Popover = (
 		expandOnMobile,
 		onFocusOutside,
 		__unstableSlotName = SLOT_NAME,
-		__unstableObserveElement,
 		__unstableForcePosition = false,
 		__unstableShift = false,
 		...contentProps
@@ -383,19 +382,6 @@ const Popover = (
 		// as dependencies (see https://github.com/WordPress/gutenberg/pull/41612)
 		// eslint-disable-next-line react-hooks/exhaustive-deps
 	}, [ anchorRef, anchorRect, getAnchorRect, update ] );
-
-	// This is only needed for a smooth transition when moving blocks.
-	useLayoutEffect( () => {
-		if ( ! __unstableObserveElement ) {
-			return;
-		}
-		const observer = new window.MutationObserver( update );
-		observer.observe( __unstableObserveElement, { attributes: true } );
-
-		return () => {
-			observer.disconnect();
-		};
-	}, [ __unstableObserveElement, update ] );
 
 	// If the reference element is in a different ownerDocument (e.g. iFrame),
 	// we need to manually update the floating's position as the reference's owner

--- a/packages/components/src/popover/stories/index.js
+++ b/packages/components/src/popover/stories/index.js
@@ -73,7 +73,6 @@ export default {
 			options: AVAILABLE_POSITIONS,
 		},
 		__unstableSlotName: { control: { type: null } },
-		__unstableObserveElement: { control: { type: null } },
 		__unstableForcePosition: { control: { type: 'boolean' } },
 		__unstableShift: { control: { type: 'boolean' } },
 	},


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## Dev note

See the dev note in https://github.com/WordPress/gutenberg/pull/44195

## What?
<!-- In a few words, what is the PR actually doing? -->

Fixes #42725

This PR changes the way `floating-ui` auto-updates the popover's position by enabling the `animationFrame` option. This means that the popover position is recalculated every animation frame (see [the docs](https://floating-ui.com/docs/autoupdate#animationframe) for more details).

This has a few benefits:

 - The "second gen" popovers are updated correctly without needing to add additional event listeners (see #42725)
 - The `__unstableObserveElement` prop (and the associated `MutationObserver`) are not necessary anymore, and can be removed
 - The `scroll` event listener added to the `iframe` is not necessary anymore, and can be removed
 - Popovers tracking anchors across different frames (i.e the block toolbar in the site editor) are less laggy, since they are updated every animation frame

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

Currently, the `Popover` element adds some custom event listeners to the anchor and its `onwerDocument` when the anchor is in a different document from the popover (i.e. in an iframe, which is the case for the block toolbar in the site editor).

These events don't cover all edge cases, and are therefore prone to causing regressions when other parts of the `Popover` are updated.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

By setting the `animationFrame` option to `true` when calling the `autoUpdate` function from `floating-ui`

## What is not included in this PR

The changes in this PR were inspired by the work done in https://github.com/WordPress/gutenberg/pull/43335, but I've deliberately decided to keep this PR as small as possible to make it easier to review.

I plan on iterate on `Popover` improvements in https://github.com/WordPress/gutenberg/pull/43335, where I'm exploring / going to explore the following ideas:

- calling `autoUpdate` only as part of the `useFloating` function call (and not in the `useLayoutEffect` hook, like it is at the moment)
- leverage more internal state and references, in order to have the `Popover` component update correctly and more frequently in more scenarios (e.g. prop change, ref changes...)
- update the `reference` within the same `useLayoutEffect` where the reference itself is computed
- use `ResizeObserver` instead of listening to the `resize` event
- see if it's possible to simplify computing the `ownerDocument`

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->

- In the site editor, select a block. From the the block toolbar, open any submenu (like the the settings menu) that causes a second popover to open
- scroll the document, and make sure that both popovers update their position correctly

Check that the remaining popovers behave as expected, without any regressions..

## Screenshots or screencast <!-- if applicable -->

https://user-images.githubusercontent.com/1083581/186689790-e553fb3e-8c44-4ded-bdc2-8b753304a147.mp4


