### PR TITLE
Elements: check value and whitelist before building style nodes

### DIFF
--- a/lib/compat/wordpress-6.1/class-wp-theme-json-6-1.php
+++ b/lib/compat/wordpress-6.1/class-wp-theme-json-6-1.php
@@ -491,7 +491,7 @@ class WP_Theme_JSON_6_1 extends WP_Theme_JSON_6_0 {
 
 		if ( isset( $theme_json['styles']['elements'] ) ) {
 			foreach ( self::ELEMENTS as $element => $selector ) {
-				if ( ! isset( $theme_json['styles']['elements'][ $element ] ) ) {
+				if ( ! isset( $theme_json['styles']['elements'][ $element ] ) || empty( static::ELEMENTS[ $element ] ) ) {
 					continue;
 				}
 

--- a/lib/compat/wordpress-6.1/class-wp-theme-json-6-1.php
+++ b/lib/compat/wordpress-6.1/class-wp-theme-json-6-1.php
@@ -491,7 +491,7 @@ class WP_Theme_JSON_6_1 extends WP_Theme_JSON_6_0 {
 
 		if ( isset( $theme_json['styles']['elements'] ) ) {
 			foreach ( self::ELEMENTS as $element => $selector ) {
-				if ( ! isset( $theme_json['styles']['elements'][ $element ] ) || empty( static::ELEMENTS[ $element ] ) ) {
+				if ( ! isset( $theme_json['styles']['elements'][ $element ] ) || ! array_key_exists( $element, static::ELEMENTS ) ) {
 					continue;
 				}
 


### PR DESCRIPTION
Core patch, just in case:

- https://github.com/WordPress/wordpress-develop/pull/3138

## What?
In `WP_Theme_JSON::get_style_nodes()`

- Check for elements values in theme.json before creating a node
- Check for element name in the whitelist before creating a node

Context: https://github.com/WordPress/gutenberg/pull/41160#discussion_r955121443

## Why?
If an element does not exist in the `static::ELEMENTS` whitelist, PHP will complain about `Notice: Undefined index`.

This won't fix the current notice in core, but is a preparatory patch for the 6.1 migration.


## Testing Instructions
Check that the tests pass.

To check manually that things are still working, here's some test theme.json

```json
{
	"version": 2,
	"settings": {
		"appearanceTools": true,
		"layout": {
			"contentSize": "840px",
			"wideSize": "1100px"
		}
	},
	"styles": {
		"elements": {
			"button": {
				"color": {
					"background": "green"
				}
			}
		}
	}
}
```

Using this JSON, your buttons should have a green background.