### PR TITLE
Lodash: Refactor away from `_.has()`

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -102,6 +102,7 @@ module.exports = {
 							'flatten',
 							'flattenDeep',
 							'fromPairs',
+							'has',
 							'identity',
 							'invoke',
 							'isArray',

--- a/packages/block-editor/src/hooks/align.js
+++ b/packages/block-editor/src/hooks/align.js
@@ -2,7 +2,7 @@
  * External dependencies
  */
 import classnames from 'classnames';
-import { has, without } from 'lodash';
+import { without } from 'lodash';
 
 /**
  * WordPress dependencies
@@ -87,7 +87,7 @@ export function getValidAlignments(
  */
 export function addAttribute( settings ) {
 	// Allow blocks to specify their own attribute definition with default values if needed.
-	if ( has( settings.attributes, [ 'align', 'type' ] ) ) {
+	if ( 'type' in ( settings.attributes?.align ?? {} ) ) {
 		return settings;
 	}
 	if ( hasBlockSupport( settings, 'align' ) ) {

--- a/packages/block-editor/src/hooks/anchor.js
+++ b/packages/block-editor/src/hooks/anchor.js
@@ -1,9 +1,4 @@
 /**
- * External dependencies
- */
-import { has } from 'lodash';
-
-/**
  * WordPress dependencies
  */
 import { addFilter } from '@wordpress/hooks';
@@ -42,7 +37,7 @@ const ANCHOR_SCHEMA = {
  */
 export function addAttribute( settings ) {
 	// Allow blocks to specify their own attribute definition with default values if needed.
-	if ( has( settings.attributes, [ 'anchor', 'type' ] ) ) {
+	if ( 'type' in ( settings.attributes?.anchor ?? {} ) ) {
 		return settings;
 	}
 	if ( hasBlockSupport( settings, 'anchor' ) ) {

--- a/packages/block-editor/src/hooks/layout.js
+++ b/packages/block-editor/src/hooks/layout.js
@@ -2,7 +2,7 @@
  * External dependencies
  */
 import classnames from 'classnames';
-import { has, kebabCase } from 'lodash';
+import { kebabCase } from 'lodash';
 
 /**
  * WordPress dependencies
@@ -246,7 +246,7 @@ function LayoutTypeSwitcher( { type, onChange } ) {
  * @return {Object} Filtered block settings.
  */
 export function addAttribute( settings ) {
-	if ( has( settings.attributes, [ 'layout', 'type' ] ) ) {
+	if ( 'type' in ( settings.attributes?.layout ?? {} ) ) {
 		return settings;
 	}
 	if ( hasBlockSupport( settings, layoutBlockSupportKey ) ) {

--- a/packages/block-editor/src/hooks/lock.js
+++ b/packages/block-editor/src/hooks/lock.js
@@ -1,9 +1,4 @@
 /**
- * External dependencies
- */
-import { has } from 'lodash';
-
-/**
  * WordPress dependencies
  */
 import { addFilter } from '@wordpress/hooks';
@@ -17,7 +12,7 @@ import { addFilter } from '@wordpress/hooks';
  */
 export function addAttribute( settings ) {
 	// Allow blocks to specify their own attribute definition with default values if needed.
-	if ( has( settings.attributes, [ 'lock', 'type' ] ) ) {
+	if ( 'type' in ( settings.attributes?.lock ?? {} ) ) {
 		return settings;
 	}
 	// Gracefully handle if settings.attributes is undefined.

--- a/packages/block-library/src/image/edit.js
+++ b/packages/block-library/src/image/edit.js
@@ -2,7 +2,7 @@
  * External dependencies
  */
 import classnames from 'classnames';
-import { get, has, isEmpty, omit, pick } from 'lodash';
+import { get, isEmpty, omit, pick } from 'lodash';
 
 /**
  * WordPress dependencies
@@ -98,8 +98,8 @@ export const isExternalImage = ( id, url ) => url && ! id && ! isBlobURL( url );
  */
 function hasDefaultSize( image, defaultSize ) {
 	return (
-		has( image, [ 'sizes', defaultSize, 'url' ] ) ||
-		has( image, [ 'media_details', 'sizes', defaultSize, 'source_url' ] )
+		'url' in ( image?.sizes?.[ defaultSize ] ?? {} ) ||
+		'source_url' in ( image?.media_details?.sizes?.[ defaultSize ] ?? {} )
 	);
 }
 

--- a/packages/blocks/src/api/utils.js
+++ b/packages/blocks/src/api/utils.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { every, has, reduce } from 'lodash';
+import { every, reduce } from 'lodash';
 import { colord, extend } from 'colord';
 import namesPlugin from 'colord/plugins/names';
 import a11yPlugin from 'colord/plugins/a11y';
@@ -99,7 +99,7 @@ export function normalizeIconObject( icon ) {
 		return { src: icon };
 	}
 
-	if ( has( icon, [ 'background' ] ) ) {
+	if ( 'background' in icon ) {
 		const colordBgColor = colord( icon.background );
 		const getColorContrast = ( iconColor ) =>
 			colordBgColor.contrast( iconColor );

--- a/packages/components/src/mobile/global-styles-context/utils.native.js
+++ b/packages/components/src/mobile/global-styles-context/utils.native.js
@@ -2,7 +2,7 @@
  * External dependencies
  */
 import { camelCase } from 'change-case';
-import { find, get, has } from 'lodash';
+import { find, get } from 'lodash';
 import { Dimensions } from 'react-native';
 
 /**
@@ -224,7 +224,12 @@ export function parseStylesVariables( styles, mappedValues, customValues ) {
 			const customValuesData = customValues ?? JSON.parse( stylesBase );
 			stylesBase = stylesBase.replace( regex, ( _$1, $2 ) => {
 				const path = $2.split( '--' );
-				if ( has( customValuesData, path ) ) {
+				if (
+					path.reduce(
+						( prev, curr ) => prev && prev[ curr ],
+						customValuesData
+					)
+				) {
 					return get( customValuesData, path );
 				}
 

--- a/packages/data/src/redux-store/metadata/reducer.ts
+++ b/packages/data/src/redux-store/metadata/reducer.ts
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { omit, has } from 'lodash';
+import { omit } from 'lodash';
 import EquivalentKeyMap from 'equivalent-key-map';
 import type { Reducer } from 'redux';
 
@@ -126,7 +126,7 @@ const isResolved = ( state: Record< string, State > = {}, action: Action ) => {
 		case 'INVALIDATE_RESOLUTION_FOR_STORE':
 			return {};
 		case 'INVALIDATE_RESOLUTION_FOR_STORE_SELECTOR':
-			return has( state, [ action.selectorName ] )
+			return action.selectorName in state
 				? omit( state, [ action.selectorName ] )
 				: state;
 		case 'START_RESOLUTION':

--- a/packages/edit-site/src/components/global-styles/hooks.js
+++ b/packages/edit-site/src/components/global-styles/hooks.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { get, cloneDeep, set, isEqual, has } from 'lodash';
+import { get, cloneDeep, set, isEqual } from 'lodash';
 
 /**
  * WordPress dependencies
@@ -210,10 +210,8 @@ export function getSupportedGlobalStylesPanels( name ) {
 		// unset, we still enable it.
 		if ( STYLE_PROPERTY[ styleName ].requiresOptOut ) {
 			if (
-				has(
-					blockType.supports,
-					STYLE_PROPERTY[ styleName ].support[ 0 ]
-				) &&
+				STYLE_PROPERTY[ styleName ].support[ 0 ] in
+					blockType.supports &&
 				get(
 					blockType.supports,
 					STYLE_PROPERTY[ styleName ].support

--- a/packages/editor/src/components/post-featured-image/index.js
+++ b/packages/editor/src/components/post-featured-image/index.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { has, get } from 'lodash';
+import { get } from 'lodash';
 
 /**
  * WordPress dependencies
@@ -59,7 +59,7 @@ function getMediaDetails( media, postId ) {
 		media.id,
 		postId
 	);
-	if ( has( media, [ 'media_details', 'sizes', defaultSize ] ) ) {
+	if ( defaultSize in ( media?.media_details?.sizes ?? {} ) ) {
 		return {
 			mediaWidth: media.media_details.sizes[ defaultSize ].width,
 			mediaHeight: media.media_details.sizes[ defaultSize ].height,
@@ -74,7 +74,7 @@ function getMediaDetails( media, postId ) {
 		media.id,
 		postId
 	);
-	if ( has( media, [ 'media_details', 'sizes', fallbackSize ] ) ) {
+	if ( fallbackSize in ( media?.media_details?.sizes ?? {} ) ) {
 		return {
 			mediaWidth: media.media_details.sizes[ fallbackSize ].width,
 			mediaHeight: media.media_details.sizes[ fallbackSize ].height,


### PR DESCRIPTION
## What?
This PR removes the `_.has()` usage completely and deprecates the function. 

## Why?

Lodash is known to unnecessarily inflate the bundle size of packages, and in most cases, it can be replaced with native language functionality. See these for more information and rationale:

* https://github.com/WordPress/gutenberg/issues/16938#issuecomment-602837246
* https://github.com/WordPress/gutenberg/issues/17025
* https://github.com/WordPress/gutenberg/issues/39495 

## How?

We're refactoring `has()` in favor of the [in operator](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/in). We're adding extra safety by always falling back to an object when the lookup is deeper than 1 level. The one case where we have a dynamic path to check we're handling by a simple `reduce()` call inline.

## Testing Instructions
* Verify all the following block editor features still work:
  * Alignment
  * Setting text to be a link
  * Layout
  * Locking
* Verify the image block still works with images that have already been uploaded. 
* RN: Verify global styles still work in parsing existing styles (colors, gradients, and custom values).
* Verify the supported panels in global styles are still the same as in `trunk`.
* Verify setting a featured image still works the same way as on `trunk`.
* Verify all tests still pass, including:
  * Unit tests: `npm run test:unit`
  * RN tests: `npm run native test`