### PR TITLE
Theme.json: Fix schema for useRootPaddingAwareAlignments

### DIFF
--- a/docs/reference-guides/theme-json-reference/theme-json-living.md
+++ b/docs/reference-guides/theme-json-reference/theme-json-living.md
@@ -4,7 +4,7 @@
 >
 > There're related documents you may be interested in: the [theme.json v1](/docs/reference-guides/theme-json-reference/theme-json-v1.md) specification and the [reference to migrate from theme.json v1 to v2](/docs/reference-guides/theme-json-reference/theme-json-migrations.md).
 
-This reference guide lists the settings and style properties defined in the theme.json schema. See the [theme.json how to guide](/docs/how-to-guides/themes/theme-json.md) for examples and guide on how to use the theme.json file in your theme. 
+This reference guide lists the settings and style properties defined in the theme.json schema. See the [theme.json how to guide](/docs/how-to-guides/themes/theme-json.md) for examples and guide on how to use the theme.json file in your theme.
 
 ## Schema
 

--- a/schemas/json/theme.json
+++ b/schemas/json/theme.json
@@ -1113,7 +1113,6 @@
 				}
 			]
 		},
-
 		"stylesElementsPropertiesComplete": {
 			"type": "object",
 			"properties": {
@@ -1475,6 +1474,9 @@
 				{
 					"properties": {
 						"appearanceTools": {},
+						"useRootPaddingAwareAlignments": {
+							"$ref": "#/definitions/settingsPropertiesUseRootPaddingAwareAlignments/properties/useRootPaddingAwareAlignments"
+						},
 						"color": {},
 						"layout": {},
 						"spacing": {},


### PR DESCRIPTION
Fix #43624
Follow-up on #43463

## What?
This PR fixes a problem in theme.json where the `settings.useRootPaddingAwareAlignments` key is not allowed in the schema and enables autocompletion.

## Why?
This is because a definition for this property exists but does not refer to it.

## How?
Added references to existing definitions.

Such references may seem strange, but in order to automatically generate theme.json living reference, each section of `definitions` must have a `properties` key even if the type is a `boolean` value. Therefore, I followed the tree of definitions to refer to the correct definition.

## Testing Instructions

Create a JSON file that references the JSON schema for this branch, such as:

```json
{
	"$schema": "https://raw.githubusercontent.com/WordPress/gutenberg/fix/theme-json-schema-root-padding/schemas/json/theme.json",
	"version": 2,
	"settings": {
	}
}
```

Under the settings property, confirm that the key is included in the candidates.

![autocomplete_1](https://user-images.githubusercontent.com/54422211/186885595-3489975d-b6ef-4c76-b7cb-002fd01cc218.png)

confirm that the key is not allowed lower down in the hierarchy.

![autocomplete_2](https://user-images.githubusercontent.com/54422211/186885699-17dca80d-2137-44bf-9e2b-da27269a2030.png)


