### PR TITLE
Lodash: Refactor away from `_.escapeRegExp()`

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,7 +1,6 @@
 /**
  * External dependencies
  */
-const { escapeRegExp } = require( 'lodash' );
 const glob = require( 'glob' ).sync;
 const { join } = require( 'path' );
 
@@ -17,7 +16,8 @@ const { version } = require( './package' );
  * @type {string}
  */
 const majorMinorRegExp =
-	escapeRegExp( version.replace( /\.\d+$/, '' ) ) + '(\\.\\d+)?';
+	version.replace( /\.\d+$/, '' ).replace( /[\\^$.*+?()[\]{}|]/g, '\\$&' ) +
+	'(\\.\\d+)?';
 
 /**
  * The list of patterns matching files used only for development purposes.
@@ -94,6 +94,7 @@ module.exports = {
 							'differenceWith',
 							'dropRight',
 							'each',
+							'escapeRegExp',
 							'extend',
 							'findIndex',
 							'findKey',

--- a/bin/plugin/commands/changelog.js
+++ b/bin/plugin/commands/changelog.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-const { groupBy, escapeRegExp, flow } = require( 'lodash' );
+const { groupBy, flow } = require( 'lodash' );
 const Octokit = require( '@octokit/rest' );
 const { sprintf } = require( 'sprintf-js' );
 const semver = require( 'semver' );
@@ -184,6 +184,17 @@ const REWORD_TERMS = {
 	config: 'configuration',
 	docs: 'documentation',
 };
+
+/**
+ * Escapes the RegExp special characters.
+ *
+ * @param {string} string Input string.
+ *
+ * @return {string} Regex-escaped string.
+ */
+function escapeRegExp( string ) {
+	return string.replace( /[\\^$.*+?()[\]{}|]/g, '\\$&' );
+}
 
 /**
  * Returns candidates based on whether the given labels

--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -68,6 +68,8 @@
 -   `TreeGrid`: Refactor away from `_.includes()` ([#43518](https://github.com/WordPress/gutenberg/pull/43518/)).
 -   `FormTokenField`: use `KeyboardEvent.code`, refactor tests to modern RTL and `user-event` ([#43442](https://github.com/WordPress/gutenberg/pull/43442/)).
 -   `DropdownMenu`: use `KeyboardEvent.code`, refactor tests to model RTL and `user-event` ([#43439](https://github.com/WordPress/gutenberg/pull/43439/)).
+-   `Autocomplete`: Refactor away from `_.escapeRegExp()` ([#43629](https://github.com/WordPress/gutenberg/pull/43629/)).
+-   `TextHighlight`: Refactor away from `_.escapeRegExp()` ([#43629](https://github.com/WordPress/gutenberg/pull/43629/)).
 
 ### Experimental
 

--- a/packages/components/src/autocomplete/get-default-use-items.js
+++ b/packages/components/src/autocomplete/get-default-use-items.js
@@ -1,13 +1,18 @@
 /**
  * External dependencies
  */
-import { debounce, escapeRegExp } from 'lodash';
+import { debounce } from 'lodash';
 import removeAccents from 'remove-accents';
 
 /**
  * WordPress dependencies
  */
 import { useLayoutEffect, useState } from '@wordpress/element';
+
+/**
+ * Internal dependencies
+ */
+import { escapeRegExp } from '../utils/strings';
 
 function filterOptions( search, options = [], maxResults = 10 ) {
 	const filtered = [];

--- a/packages/components/src/autocomplete/index.js
+++ b/packages/components/src/autocomplete/index.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { escapeRegExp, find } from 'lodash';
+import { find } from 'lodash';
 import removeAccents from 'remove-accents';
 
 /**
@@ -34,6 +34,7 @@ import { speak } from '@wordpress/a11y';
  * Internal dependencies
  */
 import { getAutoCompleterUI } from './autocompleter-ui';
+import { escapeRegExp } from '../utils/strings';
 
 /**
  * A raw completer option.

--- a/packages/components/src/text-highlight/index.tsx
+++ b/packages/components/src/text-highlight/index.tsx
@@ -1,9 +1,4 @@
 /**
- * External dependencies
- */
-import { escapeRegExp } from 'lodash';
-
-/**
  * WordPress dependencies
  */
 import { createInterpolateElement } from '@wordpress/element';
@@ -11,6 +6,7 @@ import { createInterpolateElement } from '@wordpress/element';
 /**
  * Internal dependencies
  */
+import { escapeRegExp } from '../utils/strings';
 import type { TextHighlightProps } from './types';
 
 /**

--- a/packages/components/src/utils/strings.ts
+++ b/packages/components/src/utils/strings.ts
@@ -70,3 +70,14 @@ export const normalizeTextString = ( value: string ): string => {
 		.toLocaleLowerCase()
 		.replace( ALL_UNICODE_DASH_CHARACTERS, '-' );
 };
+
+/**
+ * Escapes the RegExp special characters.
+ *
+ * @param {string} string Input string.
+ *
+ * @return {string} Regex-escaped string.
+ */
+export function escapeRegExp( string: string ): string {
+	return string.replace( /[\\^$.*+?()[\]{}|]/g, '\\$&' );
+}

--- a/tools/webpack/blocks.js
+++ b/tools/webpack/blocks.js
@@ -2,7 +2,6 @@
  * External dependencies
  */
 const CopyWebpackPlugin = require( 'copy-webpack-plugin' );
-const { escapeRegExp } = require( 'lodash' );
 const { join, sep } = require( 'path' );
 const fastGlob = require( 'fast-glob' );
 
@@ -29,6 +28,17 @@ const blockViewRegex = new RegExp(
  * the block will still call the core function when updates are back ported.
  */
 const prefixFunctions = [ 'build_query_vars_from_query_block' ];
+
+/**
+ * Escapes the RegExp special characters.
+ *
+ * @param {string} string Input string.
+ *
+ * @return {string} Regex-escaped string.
+ */
+function escapeRegExp( string ) {
+	return string.replace( /[\\^$.*+?()[\]{}|]/g, '\\$&' );
+}
 
 const createEntrypoints = () => {
 	/*


### PR DESCRIPTION
## What?
This PR removes the `_.escapeRegExp()` usage completely and deprecates the function. 

## Why?

Lodash is known to unnecessarily inflate the bundle size of packages, and in most cases, it can be replaced with native language functionality. See these for more information and rationale:

* https://github.com/WordPress/gutenberg/issues/16938#issuecomment-602837246
* https://github.com/WordPress/gutenberg/issues/17025
* https://github.com/WordPress/gutenberg/issues/39495 

## How?

Usages are just a few, so we're either creating a custom inline function that we reuse or directly running the replacement when it's more convenient to do it inline. It might feel repetitive to do this a few times throughout the codebase, but for a one-liner function, it's definitely better to do it that way rather than introducing yet another helper function into yet another dependency package.

## Testing Instructions
* Verify changelog script still works well: `npm run other:changelog`
* Verify the test instructions here still work well: #5491
* Verify that autocomplete (in Storybook or while adding tags for a post for example) still works well. 
* Verify that the search results when setting a text to be a link still display the search term as highlighted.
* Verify that when building Gutenberg, all assets for blocks are still created properly.
* Verify all tests still pass.