### PR TITLE
Lodash: Refactor away from `_.cloneDeep()`

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -83,6 +83,7 @@ module.exports = {
 							'capitalize',
 							'chunk',
 							'clamp',
+							'cloneDeep',
 							'compact',
 							'concat',
 							'countBy',

--- a/packages/block-editor/src/components/block-list/test/block-list-context.native.js
+++ b/packages/block-editor/src/components/block-list/test/block-list-context.native.js
@@ -1,9 +1,4 @@
 /**
- * External dependencies
- */
-import { cloneDeep } from 'lodash';
-
-/**
  * Internal dependencies
  */
 import {
@@ -18,6 +13,8 @@ import {
 	PARAGRAPH_BLOCK_LAYOUT_DATA,
 	ROOT_LEVEL_ID,
 } from './fixtures/block-list-context.native';
+
+const cloneObject = ( obj ) => JSON.parse( JSON.stringify( obj ) );
 
 describe( 'findBlockLayoutByClientId', () => {
 	it( "finds a block's layout data at root level", () => {
@@ -66,7 +63,7 @@ describe( 'findBlockLayoutByClientId', () => {
 describe( 'deleteBlockLayoutByClientId', () => {
 	it( "deletes a block's layout data at root level", () => {
 		const { findBlockLayoutByClientId } = DEFAULT_BLOCK_LIST_CONTEXT;
-		const defaultBlockLayouts = cloneDeep( BLOCKS_LAYOUTS_DATA );
+		const defaultBlockLayouts = cloneObject( BLOCKS_LAYOUTS_DATA );
 		const currentBlockLayouts = deleteBlockLayoutByClientId(
 			defaultBlockLayouts,
 			ROOT_LEVEL_ID
@@ -82,7 +79,7 @@ describe( 'deleteBlockLayoutByClientId', () => {
 
 	it( "deletes a nested block's layout data with inner blocks", () => {
 		const { findBlockLayoutByClientId } = DEFAULT_BLOCK_LIST_CONTEXT;
-		const defaultBlockLayouts = cloneDeep( BLOCKS_LAYOUTS_DATA );
+		const defaultBlockLayouts = cloneObject( BLOCKS_LAYOUTS_DATA );
 		const currentBlockLayouts = deleteBlockLayoutByClientId(
 			defaultBlockLayouts,
 			NESTED_WITH_INNER_BLOCKS_ID
@@ -98,7 +95,7 @@ describe( 'deleteBlockLayoutByClientId', () => {
 
 	it( "deletes a deep nested block's layout data", () => {
 		const { findBlockLayoutByClientId } = DEFAULT_BLOCK_LIST_CONTEXT;
-		const defaultBlockLayouts = cloneDeep( BLOCKS_LAYOUTS_DATA );
+		const defaultBlockLayouts = cloneObject( BLOCKS_LAYOUTS_DATA );
 		const currentBlockLayouts = deleteBlockLayoutByClientId(
 			defaultBlockLayouts,
 			DEEP_NESTED_ID
@@ -120,7 +117,7 @@ describe( 'updateBlocksLayouts', () => {
 			findBlockLayoutByClientId,
 			updateBlocksLayouts,
 		} = DEFAULT_BLOCK_LIST_CONTEXT;
-		const currentBlockLayouts = cloneDeep( blocksLayouts );
+		const currentBlockLayouts = cloneObject( blocksLayouts );
 		const BLOCK_CLIENT_ID = PARAGRAPH_BLOCK_LAYOUT_DATA.clientId;
 
 		updateBlocksLayouts( currentBlockLayouts, PARAGRAPH_BLOCK_LAYOUT_DATA );
@@ -142,7 +139,7 @@ describe( 'updateBlocksLayouts', () => {
 		const { findBlockLayoutByClientId, updateBlocksLayouts } =
 			DEFAULT_BLOCK_LIST_CONTEXT;
 		const currentBlockLayouts = {
-			current: cloneDeep( BLOCKS_LAYOUTS_DATA ),
+			current: cloneObject( BLOCKS_LAYOUTS_DATA ),
 		};
 		const PARENT_BLOCK_CLIENT_ID = GROUP_BLOCK_LAYOUT_DATA.clientId;
 
@@ -181,7 +178,7 @@ describe( 'updateBlocksLayouts', () => {
 		const { findBlockLayoutByClientId, updateBlocksLayouts } =
 			DEFAULT_BLOCK_LIST_CONTEXT;
 		const currentBlockLayouts = {
-			current: cloneDeep( BLOCKS_LAYOUTS_DATA ),
+			current: cloneObject( BLOCKS_LAYOUTS_DATA ),
 		};
 
 		// Add block layout data to it's parents inner blocks
@@ -207,7 +204,7 @@ describe( 'updateBlocksLayouts', () => {
 		const { findBlockLayoutByClientId, updateBlocksLayouts } =
 			DEFAULT_BLOCK_LIST_CONTEXT;
 		const currentBlockLayouts = {
-			current: cloneDeep( BLOCKS_LAYOUTS_DATA ),
+			current: cloneObject( BLOCKS_LAYOUTS_DATA ),
 		};
 
 		updateBlocksLayouts( currentBlockLayouts, {
@@ -227,7 +224,7 @@ describe( 'updateBlocksLayouts', () => {
 		const { findBlockLayoutByClientId, updateBlocksLayouts } =
 			DEFAULT_BLOCK_LIST_CONTEXT;
 		const currentBlockLayouts = {
-			current: cloneDeep( BLOCKS_LAYOUTS_DATA ),
+			current: cloneObject( BLOCKS_LAYOUTS_DATA ),
 		};
 
 		updateBlocksLayouts( currentBlockLayouts, {

--- a/packages/block-editor/src/components/block-list/test/block-list-context.native.js
+++ b/packages/block-editor/src/components/block-list/test/block-list-context.native.js
@@ -14,6 +14,7 @@ import {
 	ROOT_LEVEL_ID,
 } from './fixtures/block-list-context.native';
 
+// Deep clone an object to avoid mutating it later.
 const cloneObject = ( obj ) => JSON.parse( JSON.stringify( obj ) );
 
 describe( 'findBlockLayoutByClientId', () => {

--- a/packages/block-library/src/utils/migrate-font-family.js
+++ b/packages/block-library/src/utils/migrate-font-family.js
@@ -1,9 +1,4 @@
 /**
- * External dependencies
- */
-import { cloneDeep } from 'lodash';
-
-/**
  * Internal dependencies
  */
 import cleanEmptyObject from './clean-empty-object';
@@ -21,17 +16,14 @@ export default function ( attributes ) {
 		return attributes;
 	}
 
-	// Clone first so when we delete the fontFamily
-	// below we're not modifying the original
-	// attributes. Because the deprecation may be discarded
-	// we don't want to alter the original attributes.
-	const atts = cloneDeep( attributes );
-	const fontFamily = atts.style.typography.fontFamily.split( '|' ).pop();
-	delete atts.style.typography.fontFamily;
-	atts.style = cleanEmptyObject( atts.style );
+	const { fontFamily, ...typography } = attributes.style.typography;
 
 	return {
-		...atts,
-		fontFamily,
+		...attributes,
+		style: cleanEmptyObject( {
+			...attributes.style,
+			typography,
+		} ),
+		fontFamily: fontFamily.split( '|' ).pop(),
 	};
 }

--- a/packages/components/src/ui/context/context-system-provider.js
+++ b/packages/components/src/ui/context/context-system-provider.js
@@ -76,6 +76,7 @@ function useContextSystemBridge( { value } ) {
 	// that this should be super safe to assume that `useMemo` will only run on actual
 	// changes to the two dependencies, therefore saving us calls to `merge` and `JSON.parse/stringify`!
 	const config = useMemo( () => {
+		// Deep clone `parentContext` to avoid mutating it later.
 		return merge( JSON.parse( JSON.stringify( parentContext ) ), value );
 	}, [ parentContext, value ] );
 

--- a/packages/components/src/ui/context/context-system-provider.js
+++ b/packages/components/src/ui/context/context-system-provider.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { isEqual, merge, cloneDeep } from 'lodash';
+import { isEqual, merge } from 'lodash';
 
 /**
  * WordPress dependencies
@@ -66,7 +66,7 @@ function useContextSystemBridge( { value } ) {
 	// `parentContext` will always be memoized (i.e., the result of this hook itself)
 	// or the default value from when the `ComponentsContext` was originally
 	// initialized (which will never change, it's a static variable)
-	// so this memoization will prevent `merge` and `cloneDeep` from rerunning unless
+	// so this memoization will prevent `merge` and `JSON.parse/stringify` from rerunning unless
 	// the references to `value` change OR the `parentContext` has an actual material change
 	// (because again, it's guaranteed to be memoized or a static reference to the empty object
 	// so we know that the only changes for `parentContext` are material ones... i.e., why we
@@ -74,9 +74,9 @@ function useContextSystemBridge( { value } ) {
 	// need to bother with the `value`). The `useUpdateEffect` above will ensure that we are
 	// correctly warning when the `value` isn't being properly memoized. All of that to say
 	// that this should be super safe to assume that `useMemo` will only run on actual
-	// changes to the two dependencies, therefore saving us calls to `merge` and `cloneDeep`!
+	// changes to the two dependencies, therefore saving us calls to `merge` and `JSON.parse/stringify`!
 	const config = useMemo( () => {
-		return merge( cloneDeep( parentContext ), value );
+		return merge( JSON.parse( JSON.stringify( parentContext ) ), value );
 	}, [ parentContext, value ] );
 
 	return config;

--- a/packages/edit-site/src/components/global-styles/hooks.js
+++ b/packages/edit-site/src/components/global-styles/hooks.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { get, cloneDeep, set, isEqual } from 'lodash';
+import { get, set, isEqual } from 'lodash';
 
 /**
  * WordPress dependencies
@@ -48,7 +48,7 @@ export function useSetting( path, blockName, source = 'all' ) {
 
 	const setSetting = ( newValue ) => {
 		setUserConfig( ( currentConfig ) => {
-			const newUserConfig = cloneDeep( currentConfig );
+			const newUserConfig = JSON.parse( JSON.stringify( currentConfig ) );
 			const pathToSet = PATHS_WITH_MERGE[ path ]
 				? fullPath + '.custom'
 				: fullPath;
@@ -109,7 +109,7 @@ export function useStyle( path, blockName, source = 'all' ) {
 
 	const setStyle = ( newValue ) => {
 		setUserConfig( ( currentConfig ) => {
-			const newUserConfig = cloneDeep( currentConfig );
+			const newUserConfig = JSON.parse( JSON.stringify( currentConfig ) );
 			set(
 				newUserConfig,
 				finalPath,

--- a/packages/edit-site/src/components/global-styles/hooks.js
+++ b/packages/edit-site/src/components/global-styles/hooks.js
@@ -48,6 +48,7 @@ export function useSetting( path, blockName, source = 'all' ) {
 
 	const setSetting = ( newValue ) => {
 		setUserConfig( ( currentConfig ) => {
+			// Deep clone `currentConfig` to avoid mutating it later.
 			const newUserConfig = JSON.parse( JSON.stringify( currentConfig ) );
 			const pathToSet = PATHS_WITH_MERGE[ path ]
 				? fullPath + '.custom'
@@ -109,6 +110,7 @@ export function useStyle( path, blockName, source = 'all' ) {
 
 	const setStyle = ( newValue ) => {
 		setUserConfig( ( currentConfig ) => {
+			// Deep clone `currentConfig` to avoid mutating it later.
 			const newUserConfig = JSON.parse( JSON.stringify( currentConfig ) );
 			set(
 				newUserConfig,


### PR DESCRIPTION
## What?
This PR removes the `_.cloneDeep()` usage completely and deprecates the function. 

## Why?

Lodash is known to unnecessarily inflate the bundle size of packages, and in most cases, it can be replaced with native language functionality. See these for more information and rationale:

* https://github.com/WordPress/gutenberg/issues/16938#issuecomment-602837246
* https://github.com/WordPress/gutenberg/issues/17025
* https://github.com/WordPress/gutenberg/issues/39495 

## How?

We're either refactoring to use different means of native functionality (optional chaining) when possible, or using `JSON.parse( JSON.stringify( object ) )` to workaround the deep cloning.

## Testing Instructions
* Verify the test instructions in #31910 are still good.
* Verify global styles still work the same way.
* Verify all tests still pass, specifically: `npm run test:unit` and `npm run native test`.