### PR TITLE
[Block Library - Query Loop]: Add `allowedControls` in block variations for better extensibility

### DIFF
--- a/docs/reference-guides/core-blocks.md
+++ b/docs/reference-guides/core-blocks.md
@@ -609,7 +609,7 @@ An advanced block that allows displaying post types based on different query par
 -	**Name:** core/query
 -	**Category:** theme
 -	**Supports:** align (full, wide), color (background, gradients, link, text), ~~html~~
--	**Attributes:** displayLayout, query, queryId, tagName
+-	**Attributes:** displayLayout, namespace, query, queryId, tagName
 
 ## No results
 

--- a/packages/block-library/src/query/block.json
+++ b/packages/block-library/src/query/block.json
@@ -37,6 +37,9 @@
 			"default": {
 				"type": "list"
 			}
+		},
+		"namespace": {
+			"type": "string"
 		}
 	},
 	"providesContext": {

--- a/packages/block-library/src/query/edit/inspector-controls/index.js
+++ b/packages/block-library/src/query/edit/inspector-controls/index.js
@@ -59,8 +59,8 @@ function useAllowedControls( attributes ) {
 }
 
 function isControllAllowed( allowedControls, key ) {
-	// Every controls is allowed if the list is empty or not defined.
-	if ( ! allowedControls?.length ) {
+	// Every controls is allowed if the list is not defined.
+	if ( ! allowedControls ) {
 		return true;
 	}
 	return allowedControls.includes( key );

--- a/packages/block-library/src/query/edit/inspector-controls/index.js
+++ b/packages/block-library/src/query/edit/inspector-controls/index.js
@@ -97,22 +97,40 @@ export default function QueryInspectorControls( {
 		onChangeDebounced();
 		return onChangeDebounced.cancel;
 	}, [ querySearch, onChangeDebounced ] );
+	const showInheritControl = isControllAllowed( allowedControls, 'inherit' );
+	const showPostTypeControl =
+		! inherit && isControllAllowed( allowedControls, 'postType' );
+	const showColumnsControl = displayLayout?.type === 'flex';
+	const showOrderControl =
+		! inherit && isControllAllowed( allowedControls, 'order' );
+	const showStickyControl =
+		! inherit &&
+		showSticky &&
+		isControllAllowed( allowedControls, 'sticky' );
+	const showSettingsPanel =
+		showInheritControl ||
+		showPostTypeControl ||
+		showColumnsControl ||
+		showOrderControl ||
+		showStickyControl;
 	return (
 		<>
-			<InspectorControls>
-				<PanelBody title={ __( 'Settings' ) }>
-					<ToggleControl
-						label={ __( 'Inherit query from template' ) }
-						help={ __(
-							'Toggle to use the global query context that is set with the current template, such as an archive or search. Disable to customize the settings independently.'
+			{ showSettingsPanel && (
+				<InspectorControls>
+					<PanelBody title={ __( 'Settings' ) }>
+						{ showInheritControl && (
+							<ToggleControl
+								label={ __( 'Inherit query from template' ) }
+								help={ __(
+									'Toggle to use the global query context that is set with the current template, such as an archive or search. Disable to customize the settings independently.'
+								) }
+								checked={ !! inherit }
+								onChange={ ( value ) =>
+									setQuery( { inherit: !! value } )
+								}
+							/>
 						) }
-						checked={ !! inherit }
-						onChange={ ( value ) =>
-							setQuery( { inherit: !! value } )
-						}
-					/>
-					{ ! inherit &&
-						isControllAllowed( allowedControls, 'postType' ) && (
+						{ showPostTypeControl && (
 							<SelectControl
 								options={ postTypesSelectOptions }
 								value={ postType }
@@ -123,39 +141,36 @@ export default function QueryInspectorControls( {
 								) }
 							/>
 						) }
-					{ displayLayout?.type === 'flex' && (
-						<>
-							<RangeControl
-								label={ __( 'Columns' ) }
-								value={ displayLayout.columns }
-								onChange={ ( value ) =>
-									setDisplayLayout( { columns: value } )
-								}
-								min={ 2 }
-								max={ Math.max( 6, displayLayout.columns ) }
-							/>
-							{ displayLayout.columns > 6 && (
-								<Notice
-									status="warning"
-									isDismissible={ false }
-								>
-									{ __(
-										'This column count exceeds the recommended amount and may cause visual breakage.'
-									) }
-								</Notice>
-							) }
-						</>
-					) }
-					{ ! inherit &&
-						isControllAllowed( allowedControls, 'order' ) && (
+						{ showColumnsControl && (
+							<>
+								<RangeControl
+									label={ __( 'Columns' ) }
+									value={ displayLayout.columns }
+									onChange={ ( value ) =>
+										setDisplayLayout( { columns: value } )
+									}
+									min={ 2 }
+									max={ Math.max( 6, displayLayout.columns ) }
+								/>
+								{ displayLayout.columns > 6 && (
+									<Notice
+										status="warning"
+										isDismissible={ false }
+									>
+										{ __(
+											'This column count exceeds the recommended amount and may cause visual breakage.'
+										) }
+									</Notice>
+								) }
+							</>
+						) }
+						{ showOrderControl && (
 							<OrderControl
 								{ ...{ order, orderBy } }
 								onChange={ setQuery }
 							/>
 						) }
-					{ ! inherit &&
-						showSticky &&
-						isControllAllowed( allowedControls, 'sticky' ) && (
+						{ showStickyControl && (
 							<StickyControl
 								value={ sticky }
 								onChange={ ( value ) =>
@@ -163,8 +178,9 @@ export default function QueryInspectorControls( {
 								}
 							/>
 						) }
-				</PanelBody>
-			</InspectorControls>
+					</PanelBody>
+				</InspectorControls>
+			) }
 			{ ! inherit && (
 				<InspectorControls>
 					<ToolsPanel

--- a/packages/block-library/src/query/edit/inspector-controls/index.js
+++ b/packages/block-library/src/query/edit/inspector-controls/index.js
@@ -19,9 +19,6 @@ import {
 import { __ } from '@wordpress/i18n';
 import { InspectorControls } from '@wordpress/block-editor';
 import { useEffect, useState, useCallback } from '@wordpress/element';
-import { useSelect } from '@wordpress/data';
-import { store as coreStore } from '@wordpress/core-data';
-import { store as blocksStore } from '@wordpress/blocks';
 
 /**
  * Internal dependencies
@@ -31,40 +28,12 @@ import AuthorControl from './author-control';
 import ParentControl from './parent-control';
 import { TaxonomyControls, useTaxonomiesInfo } from './taxonomy-controls';
 import StickyControl from './sticky-control';
-import { usePostTypes } from '../../utils';
-import { name as queryLoopName } from '../../block.json';
-
-const EMPTY_ARRAY = [];
-
-function useIsPostTypeHierarchical( postType ) {
-	return useSelect(
-		( select ) => {
-			const type = select( coreStore ).getPostType( postType );
-			return type?.viewable && type?.hierarchical;
-		},
-		[ postType ]
-	);
-}
-
-function useAllowedControls( attributes ) {
-	return useSelect(
-		( select ) =>
-			select( blocksStore ).getActiveBlockVariation(
-				queryLoopName,
-				attributes
-			)?.allowControls || EMPTY_ARRAY,
-
-		[ attributes ]
-	);
-}
-
-function isControllAllowed( allowedControls, key ) {
-	// Every controls is allowed if the list is not defined.
-	if ( ! allowedControls ) {
-		return true;
-	}
-	return allowedControls.includes( key );
-}
+import {
+	usePostTypes,
+	useIsPostTypeHierarchical,
+	useAllowedControls,
+	isControllAllowed,
+} from '../../utils';
 
 export default function QueryInspectorControls( {
 	attributes,

--- a/packages/block-library/src/query/edit/inspector-controls/index.js
+++ b/packages/block-library/src/query/edit/inspector-controls/index.js
@@ -32,7 +32,7 @@ import {
 	usePostTypes,
 	useIsPostTypeHierarchical,
 	useAllowedControls,
-	isControllAllowed,
+	isControlAllowed,
 } from '../../utils';
 
 export default function QueryInspectorControls( {
@@ -97,16 +97,16 @@ export default function QueryInspectorControls( {
 		onChangeDebounced();
 		return onChangeDebounced.cancel;
 	}, [ querySearch, onChangeDebounced ] );
-	const showInheritControl = isControllAllowed( allowedControls, 'inherit' );
+	const showInheritControl = isControlAllowed( allowedControls, 'inherit' );
 	const showPostTypeControl =
-		! inherit && isControllAllowed( allowedControls, 'postType' );
+		! inherit && isControlAllowed( allowedControls, 'postType' );
 	const showColumnsControl = displayLayout?.type === 'flex';
 	const showOrderControl =
-		! inherit && isControllAllowed( allowedControls, 'order' );
+		! inherit && isControlAllowed( allowedControls, 'order' );
 	const showStickyControl =
 		! inherit &&
 		showSticky &&
-		isControllAllowed( allowedControls, 'sticky' );
+		isControlAllowed( allowedControls, 'sticky' );
 	const showSettingsPanel =
 		showInheritControl ||
 		showPostTypeControl ||
@@ -197,10 +197,7 @@ export default function QueryInspectorControls( {
 						} }
 					>
 						{ !! taxonomiesInfo?.length &&
-							isControllAllowed(
-								allowedControls,
-								'taxQuery'
-							) && (
+							isControlAllowed( allowedControls, 'taxQuery' ) && (
 								<ToolsPanelItem
 									label={ __( 'Taxonomies' ) }
 									hasValue={ () =>
@@ -218,7 +215,7 @@ export default function QueryInspectorControls( {
 									/>
 								</ToolsPanelItem>
 							) }
-						{ isControllAllowed( allowedControls, 'author' ) && (
+						{ isControlAllowed( allowedControls, 'author' ) && (
 							<ToolsPanelItem
 								hasValue={ () => !! authorIds }
 								label={ __( 'Authors' ) }
@@ -230,7 +227,7 @@ export default function QueryInspectorControls( {
 								/>
 							</ToolsPanelItem>
 						) }
-						{ isControllAllowed( allowedControls, 'search' ) && (
+						{ isControlAllowed( allowedControls, 'search' ) && (
 							<ToolsPanelItem
 								hasValue={ () => !! querySearch }
 								label={ __( 'Keyword' ) }
@@ -244,7 +241,7 @@ export default function QueryInspectorControls( {
 							</ToolsPanelItem>
 						) }
 						{ isPostTypeHierarchical &&
-							! isControllAllowed(
+							! isControlAllowed(
 								allowedControls,
 								'parents'
 							) && (

--- a/packages/block-library/src/query/utils.js
+++ b/packages/block-library/src/query/utils.js
@@ -166,7 +166,7 @@ export function useAllowedControls( attributes ) {
 		[ attributes ]
 	);
 }
-export function isControllAllowed( allowedControls, key ) {
+export function isControlAllowed( allowedControls, key ) {
 	// Every controls is allowed if the list is not defined.
 	if ( ! allowedControls ) {
 		return true;

--- a/packages/block-library/src/query/utils.js
+++ b/packages/block-library/src/query/utils.js
@@ -10,7 +10,12 @@ import { useSelect } from '@wordpress/data';
 import { useMemo } from '@wordpress/element';
 import { store as coreStore } from '@wordpress/core-data';
 import { decodeEntities } from '@wordpress/html-entities';
-import { cloneBlock } from '@wordpress/blocks';
+import { cloneBlock, store as blocksStore } from '@wordpress/blocks';
+
+/**
+ * Internal dependencies
+ */
+import { name as queryLoopName } from './block.json';
 
 /**
  * @typedef IHasNameAndId
@@ -126,6 +131,48 @@ export const useTaxonomies = ( postType ) => {
 	);
 	return taxonomies;
 };
+
+/**
+ * Hook that returns whether a specific post type is hierarchical.
+ *
+ * @param {string} postType The post type to check.
+ * @return {boolean} Whether a specific post type is hierarchical.
+ */
+export function useIsPostTypeHierarchical( postType ) {
+	return useSelect(
+		( select ) => {
+			const type = select( coreStore ).getPostType( postType );
+			return type?.viewable && type?.hierarchical;
+		},
+		[ postType ]
+	);
+}
+
+/**
+ * Hook that returns the query properties' names defined by the active
+ * block variation, to determine which block's filters to show.
+ *
+ * @param {Object} attributes Block attributes.
+ * @return {string[]} An array of the query attributes.
+ */
+export function useAllowedControls( attributes ) {
+	return useSelect(
+		( select ) =>
+			select( blocksStore ).getActiveBlockVariation(
+				queryLoopName,
+				attributes
+			)?.allowControls,
+
+		[ attributes ]
+	);
+}
+export function isControllAllowed( allowedControls, key ) {
+	// Every controls is allowed if the list is not defined.
+	if ( ! allowedControls ) {
+		return true;
+	}
+	return allowedControls.includes( key );
+}
 
 /**
  * Clones a pattern's blocks and then recurses over that list of blocks,

--- a/packages/block-library/src/query/variations.js
+++ b/packages/block-library/src/query/variations.js
@@ -32,30 +32,6 @@ const QUERY_DEFAULT_ATTRIBUTES = {
 
 const variations = [
 	{
-		name: 'products-list',
-		title: __( 'Products List' ),
-		description: __( 'Display a list of your products.' ),
-		attributes: {
-			query: {
-				perPage: 4,
-				pages: 1,
-				offset: 0,
-				postType: 'product',
-				order: 'desc',
-				orderBy: 'date',
-				author: '',
-				search: '',
-				sticky: 'exclude',
-				inherit: false,
-			},
-			namespace: 'wp/query/products',
-		},
-		allowControls: [ 'order', 'taxQuery', 'search' ],
-		isActive: ( blockAttributes, variationAttributes ) =>
-			blockAttributes?.namespace === variationAttributes.namespace,
-		scope: [ 'inserter' ],
-	},
-	{
 		name: 'posts-list',
 		title: __( 'Posts List' ),
 		description: __(

--- a/packages/block-library/src/query/variations.js
+++ b/packages/block-library/src/query/variations.js
@@ -32,6 +32,30 @@ const QUERY_DEFAULT_ATTRIBUTES = {
 
 const variations = [
 	{
+		name: 'products-list',
+		title: __( 'Products List' ),
+		description: __( 'Display a list of your products.' ),
+		attributes: {
+			query: {
+				perPage: 4,
+				pages: 1,
+				offset: 0,
+				postType: 'product',
+				order: 'desc',
+				orderBy: 'date',
+				author: '',
+				search: '',
+				sticky: 'exclude',
+				inherit: false,
+			},
+			namespace: 'wp/query/products',
+		},
+		allowControls: [ 'order', 'taxQuery', 'search' ],
+		isActive: ( blockAttributes, variationAttributes ) =>
+			blockAttributes?.namespace === variationAttributes.namespace,
+		scope: [ 'inserter' ],
+	},
+	{
 		name: 'posts-list',
 		title: __( 'Posts List' ),
 		description: __(


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Related: https://github.com/WordPress/gutenberg/issues/40941

We need to find a good way to allow third party devs to extent Query Loop block  easily and in a consistent way. I don't think(at least for now) that we should add a new general API for block variations. Instead, since Query Loop is a quite complicated block and is quite hard to implement everything that is possible(imagine post meta and their UI handling in a generic way) we could have explicit complex handling of this cases in the block itself.

In this PR I'm proposing and an `allowedControls` property in variations that should handle the hiding/showing of controls. While it's more verbose than a `hideControls` it will be more flexible for extenders if some new control is added to Query Loop block.

In general I think we would need(notes for follow up PRs):
1.  a `namespace` attribute to constrain any changes per variation
2. a way to hide control that are not useful to each variation to make the UI lighter
   1.  possibly augment the ToolsPanel for extenders to just add filters there([exploratory PR](https://github.com/WordPress/gutenberg/pull/43684))
4. allow a variation to tweak the `query` with their own logic(mostly for meta in my mind for now)
   1. Server side(https://github.com/WordPress/gutenberg/pull/43590)
   2. Client side(https://github.com/WordPress/gutenberg/issues/34201) - not necessarily a filter.
5. a way to update/filter the order/orderBy options

## Testing Instructions
1. Install WooCommerce
3. In the editor insert a `Products List` block(added in this PR for testing purposes)

Example `Products List` variation
```
{
	name: 'products-list',
	title: __( 'Products List' ),
	description: __( 'Display a list of your products.' ),
	attributes: {
		query: {
			perPage: 4,
			pages: 1,
			offset: 0,
			postType: 'product',
			order: 'desc',
			orderBy: 'date',
			author: '',
			search: '',
			sticky: 'exclude',
			inherit: false,
		},
		namespace: 'wp/query/products',
	},
	allowControls: [ 'order', 'taxQuery', 'search' ],
	isActive: ( blockAttributes, variationAttributes ) =>
		blockAttributes?.namespace === variationAttributes.namespace,
	scope: [ 'inserter' ],
},
```


Alternatively test with your variations.


## Notes
While exploring the client side preview issues, I realized that the REST API doesn't support `meta_query`. This is a problem of REST API and the way devs do it now, is by adding PHP filters which check for extra custom request params in order to update the query..

### What is missing and not mentioned? 🤔 

--cc @sunyatasattva @gigitux 