### PR TITLE
Allow remote pattern registration in theme.json when core patterns are disabled

### DIFF
--- a/lib/compat/wordpress-6.0/block-patterns.php
+++ b/lib/compat/wordpress-6.0/block-patterns.php
@@ -11,10 +11,6 @@ if ( ! function_exists( '_register_remote_theme_patterns' ) ) {
 	 * `theme.json` file.
 	 */
 	function _register_remote_theme_patterns() {
-		if ( ! get_theme_support( 'core-block-patterns' ) ) {
-			return;
-		}
-
 		if ( ! apply_filters( 'should_load_remote_block_patterns', true ) ) {
 			return;
 		}


### PR DESCRIPTION
_This issue has already been fixed in Core, and will be released in 6.0.2. This PR is just to ensure parity between Core and the 6.0 compat file._

WordPress PR: https://github.com/WordPress/wordpress-develop/pull/2925
Trac ticket: https://core.trac.wordpress.org/ticket/56112
Fixes: https://github.com/WordPress/gutenberg/issues/41282

## What?
Allow remote pattern registration in theme.json when core patterns are disabled in the 6.0.

## Why?
Theme developers want the ability to disable core patterns yet include specific patterns from the Patterns Directory. 

## How?
Remove the core pattern support check. 

## Testing Instructions

