### PR TITLE
Add tsconfig.json to core-data package

### DIFF
--- a/packages/core-data/src/selectors.ts
+++ b/packages/core-data/src/selectors.ts
@@ -24,7 +24,7 @@ import type * as ET from './entity-types';
 // It makes the selectors slightly more safe, but is intended to evolve
 // into a more detailed representation over time.
 // See https://github.com/WordPress/gutenberg/pull/40025#discussion_r865410589 for more context.
-interface State {
+export interface State {
 	autosaves: Record< string | number, Array< unknown > >;
 	blockPatterns: Array< unknown >;
 	blockPatternCategories: Array< unknown >;

--- a/packages/core-data/tsconfig.json
+++ b/packages/core-data/tsconfig.json
@@ -1,0 +1,21 @@
+{
+	"extends": "../../tsconfig.base.json",
+	"compilerOptions": {
+		"rootDir": "src",
+		"declarationDir": "build-types",
+		"noUnusedParameters": false,
+		"checkJs": false,
+		"noImplicitAny": false
+	},
+	"references": [
+		{ "path": "../api-fetch" },
+		{ "path": "../data" },
+		{ "path": "../deprecated" },
+		{ "path": "../element" },
+		{ "path": "../html-entities" },
+		{ "path": "../i18n" },
+		{ "path": "../is-shallow-equal" },
+		{ "path": "../url" }
+	],
+	"include": [ "src/**/*" ]
+}

--- a/packages/data/src/types.ts
+++ b/packages/data/src/types.ts
@@ -63,7 +63,10 @@ export type DispatchFunction = < StoreNameOrDescriptor >(
 	? ActionCreatorsOf< ConfigOf< StoreNameOrDescriptor > >
 	: any;
 
-export type MapSelect = ( select: SelectFunction, registry: DataRegistry ) => any;
+export type MapSelect = (
+	select: SelectFunction,
+	registry: DataRegistry
+) => any;
 
 export type SelectFunction = < S >( store: S ) => CurriedSelectorsOf< S >;
 

--- a/packages/data/src/types.ts
+++ b/packages/data/src/types.ts
@@ -63,7 +63,7 @@ export type DispatchFunction = < StoreNameOrDescriptor >(
 	? ActionCreatorsOf< ConfigOf< StoreNameOrDescriptor > >
 	: any;
 
-export type MapSelect = ( select: SelectFunction ) => any;
+export type MapSelect = ( select: SelectFunction, registry: DataRegistry ) => any;
 
 export type SelectFunction = < S >( store: S ) => CurriedSelectorsOf< S >;
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -8,6 +8,7 @@
 		{ "path": "packages/block-editor" },
 		{ "path": "packages/components" },
 		{ "path": "packages/compose" },
+		{ "path": "packages/core-data" },
 		{ "path": "packages/data" },
 		{ "path": "packages/date" },
 		{ "path": "packages/deprecated" },


### PR DESCRIPTION
## What?
This PR adds `tsconfig.json` to the `@wordpress/core-data`. It's a logical next step after adding all the useful [TypeScript types](https://github.com/WordPress/gutenberg/pull/43515).

## Testing Instructions
Confirm the checks are green

cc @gziolo @dmsnell @sarayourfriend 
