### PR TITLE
Prevent single Columns blocks transforming into Columns.

### DIFF
--- a/packages/block-library/src/columns/transforms.js
+++ b/packages/block-library/src/columns/transforms.js
@@ -29,9 +29,23 @@ const transforms = {
 					createBlocksFromInnerBlocksTemplate( innerBlocksTemplate )
 				);
 			},
-			isMatch: ( { length: selectedBlocksLength } ) =>
-				selectedBlocksLength &&
-				selectedBlocksLength <= MAXIMUM_SELECTED_BLOCKS,
+			isMatch: ( { length: selectedBlocksLength }, block ) => {
+				// If a user is trying to transform a single Columns block, skip
+				// the transformation. Enabling this functiontionality creates
+				// nested Columns blocks resulting in an unintuitive user experience.
+				// Multiple Columns blocks can still be transformed.
+				if (
+					block.length === 1 &&
+					block[ 0 ].name === 'core/columns'
+				) {
+					return false;
+				}
+
+				return (
+					selectedBlocksLength &&
+					selectedBlocksLength <= MAXIMUM_SELECTED_BLOCKS
+				);
+			},
 		},
 		{
 			type: 'block',

--- a/packages/block-library/src/columns/transforms.js
+++ b/packages/block-library/src/columns/transforms.js
@@ -29,14 +29,14 @@ const transforms = {
 					createBlocksFromInnerBlocksTemplate( innerBlocksTemplate )
 				);
 			},
-			isMatch: ( { length: selectedBlocksLength }, block ) => {
+			isMatch: ( { length: selectedBlocksLength }, blocks ) => {
 				// If a user is trying to transform a single Columns block, skip
 				// the transformation. Enabling this functiontionality creates
 				// nested Columns blocks resulting in an unintuitive user experience.
 				// Multiple Columns blocks can still be transformed.
 				if (
-					block.length === 1 &&
-					block[ 0 ].name === 'core/columns'
+					blocks.length === 1 &&
+					blocks[ 0 ].name === 'core/columns'
 				) {
 					return false;
 				}


### PR DESCRIPTION
Fixes: https://github.com/WordPress/gutenberg/issues/43490

## What?
Disable the ability to transform single Columns blocks into Columns blocks. 

## Why?
Transforming a single Columns block into another Columns block creates an [unintuitive user experience](https://github.com/WordPress/gutenberg/issues/43490) and really should not be offered as a transform option. 

## How?
The transform has been updated to exclude single Columns blocks. You can still transform multiple Columns blocks into a Columns block. See the screenshots for more details. 

## Testing Instructions
1. Add a Columns block and note that Columns no longer appears in the block transform menu. 
2. Add another Columns block.
3. Select both Columns blocks and confirm that you can transform both into a single Columns block as expected.

## Screenshots or screencast <!-- if applicable -->

**Before:**
![image](https://user-images.githubusercontent.com/4832319/186945567-2333a6fd-dfe7-4d90-9ea7-7c0257237195.png)

**After:**
![columns-transform](https://user-images.githubusercontent.com/4832319/186945412-417f207d-595c-4a5b-8a7d-2aca503f02d2.gif)

