### PR TITLE
core-data: Bundle TypeScript types with the data package

### DIFF
--- a/packages/core-data/CHANGELOG.md
+++ b/packages/core-data/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Breaking Changes
+
+–   Add TypeScript types to the built package (via "types": "build-types" in the package.json)
+
 ## 4.14.0 (2022-08-24)
 
 ### New Features

--- a/packages/core-data/package.json
+++ b/packages/core-data/package.json
@@ -25,6 +25,7 @@
 	"main": "build/index.js",
 	"module": "build-module/index.js",
 	"react-native": "src/index",
+	"types": "build-types",
 	"sideEffects": [
 		"{src,build,build-module}/index.js"
 	],


### PR DESCRIPTION
## What?
This PR exposes TypeScript types with the `@wordpress/core-data` package by adding `"types": "build-types"` to package.json.

This would provide autocompletion support to consumers of this package:

<img width="830" alt="CleanShot 2022-08-26 at 18 11 33@2x" src="https://user-images.githubusercontent.com/205419/186947879-91b4aa85-f2d8-480a-a988-3c5e39a7357b.png">

While the types are not 100% complete, they [have been iterated on](https://github.com/WordPress/gutenberg/pull/42238) and already provide value. Exposing them creates an incentive to improve them further as every contribution would immediately benefit `@wordpress/core-data` consumers.

## Why is it a breaking change?

Currently, TypeScript uses the [DefinitelyTyped types for the `@wordpress/core-data`](https://github.com/DefinitelyTyped/DefinitelyTyped/tree/master/types/wordpress__core-data) package. With this PR, it will use the types shipped with the `@wordpress/core-data` itself and ignore the types from DefinitelyTyped. The two are not compatible, hence this PR lists a breaking change in the changelog.

## Test plan
Confirm the checks are all green

cc @gziolo @dmsnell 