### PR TITLE
Navigation: use `code` instead of `keyCode` for keyboard events

### DIFF
--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 -   Refactor `FocalPointPicker` to function component ([#39168](https://github.com/WordPress/gutenberg/pull/39168)).
 -   `Guide`: use `code` instead of `keyCode` for keyboard events ([#43604](https://github.com/WordPress/gutenberg/pull/43604/)).
+-   `Navigation`: use `code` instead of `keyCode` for keyboard events ([#43644](https://github.com/WordPress/gutenberg/pull/43644/)).
 
 ## 20.0.0 (2022-08-24)
 

--- a/packages/components/src/navigation/menu/menu-title-search.js
+++ b/packages/components/src/navigation/menu/menu-title-search.js
@@ -3,7 +3,6 @@
  */
 import { useEffect, useRef } from '@wordpress/element';
 import { __, _n, sprintf } from '@wordpress/i18n';
-import { ESCAPE } from '@wordpress/keycodes';
 
 /**
  * Internal dependencies
@@ -61,7 +60,7 @@ function MenuTitleSearch( {
 	};
 
 	function onKeyDown( event ) {
-		if ( event.keyCode === ESCAPE && ! event.defaultPrevented ) {
+		if ( event.code === 'Escape' && ! event.defaultPrevented ) {
 			event.preventDefault();
 			onClose();
 		}


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Use the `code` property instead of `keyCode` for keyboard events in the `Navigation` component.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

[`keyCode`](https://developer.mozilla.org/en-US/docs/Web/API/KeyboardEvent/keyCode) is deprecated, and replaced by [`code`](https://developer.mozilla.org/en-US/docs/Web/API/KeyboardEvent/code)

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

Simply used the value for the `Escape` key as per [the documentation](https://developer.mozilla.org/en-US/docs/Web/API/UI_Events/Keyboard_event_code_values)

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->

In Storybook, visit the "Search" example for the `Navigation` component.

Click on the magnifying glass to open the search input, and make sure that pressing the `Escape` key will close that input.

(The text in that input won't show because its color is white — this looks like a bug that can also [be reproduced in `trunk`](https://wordpress.github.io/gutenberg/?path=/story/components-experimental-navigation--search))