### PR TITLE
Post Terms: Add spacing support

### DIFF
--- a/docs/reference-guides/core-blocks.md
+++ b/docs/reference-guides/core-blocks.md
@@ -572,7 +572,7 @@ Post terms. ([Source](https://github.com/WordPress/gutenberg/tree/trunk/packages
 
 -	**Name:** core/post-terms
 -	**Category:** theme
--	**Supports:** color (background, gradients, link, text), typography (fontSize, lineHeight), ~~html~~
+-	**Supports:** color (background, gradients, link, text), spacing (margin, padding), typography (fontSize, lineHeight), ~~html~~
 -	**Attributes:** prefix, separator, suffix, term, textAlign
 
 ## Post Title

--- a/packages/block-library/src/post-terms/block.json
+++ b/packages/block-library/src/post-terms/block.json
@@ -38,6 +38,10 @@
 				"link": true
 			}
 		},
+		"spacing": {
+			"margin": true,
+			"padding": true
+		},
 		"typography": {
 			"fontSize": true,
 			"lineHeight": true,

--- a/packages/block-library/src/post-terms/style.scss
+++ b/packages/block-library/src/post-terms/style.scss
@@ -1,3 +1,5 @@
 .wp-block-post-terms__separator {
 	white-space: pre-wrap;
+	// This block has customizable padding, border-box makes that more predictable.
+	box-sizing: border-box;
 }

--- a/packages/block-library/src/post-terms/style.scss
+++ b/packages/block-library/src/post-terms/style.scss
@@ -1,5 +1,8 @@
-.wp-block-post-terms__separator {
-	white-space: pre-wrap;
+.wp-block-post-terms {
 	// This block has customizable padding, border-box makes that more predictable.
 	box-sizing: border-box;
+
+	.wp-block-post-terms__separator {
+		white-space: pre-wrap;
+	}
 }


### PR DESCRIPTION
Related:

- https://github.com/WordPress/gutenberg/issues/43241
- https://github.com/WordPress/gutenberg/issues/43243

## What?
Add padding and margin support to the Post Terms block. 

## Why?
To create consistency across blocks.

## How?
Added the relevant block supports in block.json

## Testing Instructions
1. Insert a new Post Terms block. 
2. Confirm the Dimension control panel allows you to add both padding and margin.
3. Adding padding and margin. 

## Screenshots or screencast 
![post-term-spacing](https://user-images.githubusercontent.com/4832319/186952372-b3253609-cd7a-4121-8bb0-39ef3bb3f4c5.gif)

