### PR TITLE
Categories List: Add spacing support

### DIFF
--- a/docs/reference-guides/core-blocks.md
+++ b/docs/reference-guides/core-blocks.md
@@ -77,7 +77,7 @@ Display a list of all categories. ([Source](https://github.com/WordPress/gutenbe
 
 -	**Name:** core/categories
 -	**Category:** widgets
--	**Supports:** align, typography (fontSize, lineHeight), ~~html~~
+-	**Supports:** align, spacing (margin, padding), typography (fontSize, lineHeight), ~~html~~
 -	**Attributes:** displayAsDropdown, showEmpty, showHierarchy, showOnlyTopLevel, showPostCounts
 
 ## Code

--- a/packages/block-library/src/categories/block.json
+++ b/packages/block-library/src/categories/block.json
@@ -31,6 +31,10 @@
 	"supports": {
 		"align": true,
 		"html": false,
+		"spacing": {
+			"margin": true,
+			"padding": true
+		},
 		"typography": {
 			"fontSize": true,
 			"lineHeight": true,

--- a/packages/block-library/src/categories/style.scss
+++ b/packages/block-library/src/categories/style.scss
@@ -1,4 +1,7 @@
 .wp-block-categories {
+	// This block has customizable padding, border-box makes that more predictable.
+	box-sizing: border-box;
+
 	&.alignleft {
 		/*rtl:ignore*/
 		margin-right: 2em;


### PR DESCRIPTION
Related:

- https://github.com/WordPress/gutenberg/issues/43241
- https://github.com/WordPress/gutenberg/issues/43243

## What?
Add padding and margin support to the Categories List block. 

## Why?
To create consistency across blocks.

## How?
Added the relevant block supports in block.json

## Testing Instructions
1. Insert a new Categories List block. 
2. Confirm the Dimension control panel allows you to add both padding and margin.
3. Adding padding and margin. 

## Screenshots or screencast 
![categories-spacing](https://user-images.githubusercontent.com/4832319/186956113-394d8599-cebf-4e48-b9bd-3550d85dc2b8.gif)

