### PR TITLE
Button: Add almost all missing typography supports

### DIFF
--- a/docs/reference-guides/core-blocks.md
+++ b/docs/reference-guides/core-blocks.md
@@ -50,7 +50,7 @@ Prompt visitors to take action with a button-style link. ([Source](https://githu
 
 -	**Name:** core/button
 -	**Category:** design
--	**Supports:** align, anchor, color (background, gradients, text), spacing (padding), typography (fontSize), ~~alignWide~~, ~~reusable~~
+-	**Supports:** align, anchor, color (background, gradients, text), spacing (padding), typography (fontSize, lineHeight), ~~alignWide~~, ~~reusable~~
 -	**Attributes:** backgroundColor, gradient, linkTarget, placeholder, rel, text, textColor, title, url, width
 
 ## Buttons

--- a/packages/block-library/src/button/block.json
+++ b/packages/block-library/src/button/block.json
@@ -68,8 +68,12 @@
 		},
 		"typography": {
 			"fontSize": true,
+			"lineHeight": true,
 			"__experimentalFontFamily": true,
+			"__experimentalFontWeight": true,
+			"__experimentalFontStyle": true,
 			"__experimentalTextTransform": true,
+			"__experimentalLetterSpacing": true,
 			"__experimentalDefaultControls": {
 				"fontSize": true
 			}


### PR DESCRIPTION
Related:
- https://github.com/WordPress/gutenberg/issues/43241
- https://github.com/WordPress/gutenberg/issues/43242

## What?

Adds missing typography supports to the Quote block.

## Why?

- Improves consistency of our design tools across blocks.

## How?

- Opts into the missing line-height, font-weight, font-style, and letter-spacing support.

_Note, that this PR does not include text-decoration. Text decoration is automatically set to none and cannot be overridden by the corresponding block support. How to best implement this, or if it should even be implemented, should be explored in a separate PR._

## Testing Instructions

1. Create a Buttons block and add a few Button blocks
2. Check that the line-height, font-weight, font-style, and letter-spacing controls are now all available.
2. Test various typography settings ensuring styles are applied in the editor.
3. Save and confirm the application on the frontend.
4. Switch to the site editor, and in a template create a Buttons block and add a few Button blocks
5. Navigate to Global Styles > Blocks > Button > Typography
6. Test applying a new typography controls and confirm it's applied in the preview and on the frontend.
7. Test styling via theme.json

## Screenshots
![button-typography](https://user-images.githubusercontent.com/4832319/186964679-50aa81cf-0ad9-40b4-9c3b-ac084ecfa423.gif)


