### PR TITLE
Calendar: Prevent attribute styles/classes from printing twice

### DIFF
--- a/packages/block-library/src/calendar/edit.js
+++ b/packages/block-library/src/calendar/edit.js
@@ -33,7 +33,7 @@ const getYearMonth = memoize( ( date ) => {
 	};
 } );
 
-export default function CalendarEdit( { attributes } ) {
+export default function CalendarEdit() {
 	const blockProps = useBlockProps();
 	const { date, hasPosts, hasPostsResolved } = useSelect( ( select ) => {
 		const { getEntityRecords, hasFinishedResolution } = select( coreStore );
@@ -95,7 +95,7 @@ export default function CalendarEdit( { attributes } ) {
 			<Disabled>
 				<ServerSideRender
 					block="core/calendar"
-					attributes={ { ...attributes, ...getYearMonth( date ) } }
+					attributes={ { ...getYearMonth( date ) } }
 				/>
 			</Disabled>
 		</div>


### PR DESCRIPTION
Fixes https://github.com/WordPress/gutenberg/issues/43652

## What?
In the Editor, styles and classes generated by block attributes are generated twice for the Calendar block, once on the block wrapper and again on the server-side rendered component. This PR stops that from happening.

## Why?
Up until recently, the Calendar block had no attributes other than `className`. Therefore, this bug was not much of an issue. However, as we start adding [dimension](https://github.com/WordPress/gutenberg/pull/43654) and [color support](https://github.com/WordPress/gutenberg/pull/42029), issues emerge. 

In the case of spacing controls, padding and margin get applied twice. Therefore we cannot implement this functionality without first fixing this issue. 

## How?
Remove the attributes provided to the server-side rendered component.

## Testing Instructions
1. Add a Calendar block.
2. Set a custom class
3. Confirm that this custom class is only applied to the wrapper `div`.

Note there is still an issue where the classname for the block is printed twice. 

## Screenshots or screencast 

I added the custom class `table-class` to a Calendar block. Before this PR, it is printed twice. Afterward, only on the wrapper `div`.

Before:
![image](https://user-images.githubusercontent.com/4832319/186971939-dee671a3-b023-4b9d-b330-f2ad938d2a79.png)

After:
![image](https://user-images.githubusercontent.com/4832319/186971819-cb31eb51-9ab3-4251-a5e0-7055110e0fc8.png)

