### PR TITLE
Calendar: Add spacing support

### DIFF
--- a/docs/reference-guides/core-blocks.md
+++ b/docs/reference-guides/core-blocks.md
@@ -68,7 +68,7 @@ A calendar of your site’s posts. ([Source](https://github.com/WordPress/gutenb
 
 -	**Name:** core/calendar
 -	**Category:** widgets
--	**Supports:** align
+-	**Supports:** align, spacing (margin, padding)
 -	**Attributes:** month, year
 
 ## Categories List

--- a/packages/block-library/src/calendar/block.json
+++ b/packages/block-library/src/calendar/block.json
@@ -16,7 +16,11 @@
 		}
 	},
 	"supports": {
-		"align": true
+		"align": true,
+		"spacing": {
+			"margin": true,
+			"padding": true
+		}
 	},
 	"style": "wp-block-calendar"
 }

--- a/packages/block-library/src/calendar/style.scss
+++ b/packages/block-library/src/calendar/style.scss
@@ -1,5 +1,7 @@
 .wp-block-calendar {
 	text-align: center;
+	// This block has customizable padding, border-box makes that more predictable.
+	box-sizing: border-box;
 
 	th,
 	tbody td {


### PR DESCRIPTION
Related:

- https://github.com/WordPress/gutenberg/issues/43241
- https://github.com/WordPress/gutenberg/issues/43243

Relies on:

- https://github.com/WordPress/gutenberg/pull/43653

## What?
Add padding and margin support to the Calendar block. 

## Why?
To create consistency across blocks.

## How?
Added the relevant block supports in block.json

## Testing Instructions
1. Insert a new Calendar block. 
2. Confirm the Dimension control panel allows you to add both padding and margin.
3. Adding padding and margin. 

⚠️ Note that there is an issue in the Calendar block about how attributes are applied. They actually get applied twice. I have [created a separate PR](https://github.com/WordPress/gutenberg/pull/43653) to address this. Once that is merged, this PR should be good to go.

## Screenshots or screencast 
![post-term-spacing](https://user-images.githubusercontent.com/4832319/186952372-b3253609-cd7a-4121-8bb0-39ef3bb3f4c5.gif)

