### PR TITLE
Comment Date: Add spacing support

### DIFF
--- a/docs/reference-guides/core-blocks.md
+++ b/docs/reference-guides/core-blocks.md
@@ -140,7 +140,7 @@ Displays the date on which the comment was posted. ([Source](https://github.com/
 
 -	**Name:** core/comment-date
 -	**Category:** theme
--	**Supports:** color (background, gradients, link, text), typography (fontSize, lineHeight), ~~html~~
+-	**Supports:** color (background, gradients, link, text), spacing (margin, padding), typography (fontSize, lineHeight), ~~html~~
 -	**Attributes:** format, isLink
 
 ## Comment Edit Link

--- a/packages/block-library/src/comment-date/block.json
+++ b/packages/block-library/src/comment-date/block.json
@@ -28,6 +28,10 @@
 				"link": true
 			}
 		},
+		"spacing": {
+			"margin": true,
+			"padding": true
+		},
 		"typography": {
 			"fontSize": true,
 			"lineHeight": true,


### PR DESCRIPTION
Related:

- https://github.com/WordPress/gutenberg/issues/43241
- https://github.com/WordPress/gutenberg/issues/43243

## What?
Add padding and margin support to the Comment Date block. 

## Why?
To create consistency across blocks.

## How?
Added the relevant block supports in block.json

Note that `box-sizing: border-box` was not applied to this block like in [other implementations](https://github.com/WordPress/gutenberg/pull/43646/files). Since the Comment Date block is always contained within the Comments Template, `box-sizing: border-box` did not seem to be needed in my testing.

## Testing Instructions
1. Insert a new Comments Date block. 
2. Confirm the Dimension control panel allows you to add both padding and margin.
3. Adding padding and margin. 

## Screenshots or screencast 
![comment-date-spacing](https://user-images.githubusercontent.com/4832319/186980166-50c88d6f-efc0-4250-beb4-f21302515347.gif)

The visualizers in the Site Editor are a little wonky, but not related to this PR. 
