### PR TITLE
Comment Edit Link: Add spacing support

### DIFF
--- a/docs/reference-guides/core-blocks.md
+++ b/docs/reference-guides/core-blocks.md
@@ -149,7 +149,7 @@ Displays a link to edit the comment in the WordPress Dashboard. This link is onl
 
 -	**Name:** core/comment-edit-link
 -	**Category:** theme
--	**Supports:** color (background, gradients, link, ~~text~~), typography (fontSize, lineHeight), ~~html~~
+-	**Supports:** color (background, gradients, link, ~~text~~), spacing (margin, padding), typography (fontSize, lineHeight), ~~html~~
 -	**Attributes:** linkTarget, textAlign
 
 ## Comment Reply Link

--- a/packages/block-library/src/comment-edit-link/block.json
+++ b/packages/block-library/src/comment-edit-link/block.json
@@ -28,6 +28,10 @@
 				"link": true
 			}
 		},
+		"spacing": {
+			"margin": true,
+			"padding": true
+		},
 		"typography": {
 			"fontSize": true,
 			"lineHeight": true,


### PR DESCRIPTION
Related:

- https://github.com/WordPress/gutenberg/issues/43241
- https://github.com/WordPress/gutenberg/issues/43243

## What?
Add padding and margin support to the Comment Edit Link block. 

## Why?
To create consistency across blocks.

## How?
Added the relevant block supports in block.json

Note that `box-sizing: border-box` was not applied to this block like in [other implementations](https://github.com/WordPress/gutenberg/pull/43646/files). Since the Comment Edit Link block is always contained within the Comments Template, `box-sizing: border-box` did not seem to be needed in my testing.

## Testing Instructions
1. Insert a new Comment Edit Link block. 
2. Confirm the Dimension control panel allows you to add both padding and margin.
3. Adding padding and margin. 

## Screenshots or screencast 
![comment-edit-link-spacing](https://user-images.githubusercontent.com/4832319/186980949-86a0f492-7e43-4a53-b3b9-a86f5cb9c9fd.gif)

The visualizers in the Site Editor are a little wonky, but not related to this PR. 
