### PR TITLE
Comment Reply Link: Add spacing support

### DIFF
--- a/docs/reference-guides/core-blocks.md
+++ b/docs/reference-guides/core-blocks.md
@@ -158,7 +158,7 @@ Displays a link to reply to a comment. ([Source](https://github.com/WordPress/gu
 
 -	**Name:** core/comment-reply-link
 -	**Category:** theme
--	**Supports:** color (background, gradients, link, ~~text~~), typography (fontSize, lineHeight), ~~html~~
+-	**Supports:** color (background, gradients, link, ~~text~~), spacing (margin, padding), typography (fontSize, lineHeight), ~~html~~
 -	**Attributes:** textAlign
 
 ## Comment Template

--- a/packages/block-library/src/comment-reply-link/block.json
+++ b/packages/block-library/src/comment-reply-link/block.json
@@ -23,6 +23,10 @@
 				"link": true
 			}
 		},
+		"spacing": {
+			"margin": true,
+			"padding": true
+		},
 		"typography": {
 			"fontSize": true,
 			"lineHeight": true,


### PR DESCRIPTION
Related:

- https://github.com/WordPress/gutenberg/issues/43241
- https://github.com/WordPress/gutenberg/issues/43243

## What?
Add padding and margin support to the Comment Reply Link block. 

## Why?
To create consistency across blocks.

## How?
Added the relevant block supports in block.json

Note that `box-sizing: border-box` was not applied to this block like in [other implementations](https://github.com/WordPress/gutenberg/pull/43646/files). Since the Comment Reply Link block is always contained within the Comments Template, `box-sizing: border-box` did not seem to be needed in my testing.

## Testing Instructions
1. Insert a new Comments Reply Link block. 
2. Confirm the Dimension control panel allows you to add both padding and margin.
3. Adding padding and margin. 

## Screenshots or screencast 
![comment-reply-link-spacing](https://user-images.githubusercontent.com/4832319/186981696-8da11fd5-9cc9-4c6d-8d90-3c3c0624c49b.gif)

The visualizers in the Site Editor are a little wonky, but not related to this PR. 
