### PR TITLE
Disable movement when previous blocks are locked

### DIFF
--- a/packages/block-editor/src/components/block-mover/button.js
+++ b/packages/block-editor/src/components/block-mover/button.js
@@ -80,6 +80,7 @@ const BlockMoverButton = forwardRef(
 					getBlockOrder,
 					getBlock,
 					getBlockListSettings,
+					canMoveBlocks,
 				} = select( blockEditorStore );
 				const normalizedClientIds = castArray( clientIds );
 				const firstClientId = first( normalizedClientIds );
@@ -90,17 +91,20 @@ const BlockMoverButton = forwardRef(
 				);
 				const blockOrder = getBlockOrder( blockRootClientId );
 				const block = getBlock( firstClientId );
-				const isFirstBlock = firstBlockIndex === 0;
+				const blocksBefore = blockOrder.slice( 0, firstBlockIndex );
+				const isFirstUnlockedBlock =
+					firstBlockIndex === 0 || ! canMoveBlocks( blocksBefore );
 				const isLastBlock = lastBlockIndex === blockOrder.length - 1;
 				const { orientation: blockListOrientation } =
 					getBlockListSettings( blockRootClientId ) || {};
 
 				return {
 					blockType: block ? getBlockType( block.name ) : null,
-					isDisabled: direction === 'up' ? isFirstBlock : isLastBlock,
+					isDisabled:
+						direction === 'up' ? isFirstUnlockedBlock : isLastBlock,
 					rootClientId: blockRootClientId,
 					firstIndex: firstBlockIndex,
-					isFirst: isFirstBlock,
+					isFirst: isFirstUnlockedBlock,
 					isLast: isLastBlock,
 					orientation: moverOrientation || blockListOrientation,
 				};

--- a/test/e2e/specs/editor/various/block-mover.spec.js
+++ b/test/e2e/specs/editor/various/block-mover.spec.js
@@ -83,14 +83,10 @@ test.describe( 'block mover', () => {
 		await page.focus( 'text=Second Paragraph' );
 		await editor.showBlockToolbar();
 
-		// Ensure no block mover exists when only one block exists on the page.
-		const moveDownButton = page.locator(
-			'role=toolbar[name="Block tools"i] >> role=button[name="Move down"i]'
-		);
+		// Ensure the up button is disabled.
 		const moveUpButton = page.locator(
 			'role=toolbar[name="Block tools"i] >> role=button[name="Move up"i]'
 		);
-		await expect( moveDownButton ).toBeHidden();
-		await expect( moveUpButton ).toBeHidden();
+		await expect( moveUpButton ).toBeDisabled();
 	} );
 } );

--- a/test/e2e/specs/editor/various/block-mover.spec.js
+++ b/test/e2e/specs/editor/various/block-mover.spec.js
@@ -61,7 +61,7 @@ test.describe( 'block mover', () => {
 		await expect( moveUpButton ).toBeHidden();
 	} );
 
-	test.only( 'should hide block mover when blocks above it are locked', async ( {
+	test( 'should hide block mover when blocks above it are locked', async ( {
 		editor,
 		page,
 	} ) => {

--- a/test/e2e/specs/editor/various/block-mover.spec.js
+++ b/test/e2e/specs/editor/various/block-mover.spec.js
@@ -60,4 +60,37 @@ test.describe( 'block mover', () => {
 		await expect( moveDownButton ).toBeHidden();
 		await expect( moveUpButton ).toBeHidden();
 	} );
+
+	test.only( 'should hide block mover when blocks above it are locked', async ( {
+		editor,
+		page,
+	} ) => {
+		// Create a single block on the page and lock it
+		await editor.insertBlock( {
+			name: 'core/paragraph',
+			attributes: { content: 'First Paragraph' },
+		} );
+		await editor.clickBlockOptionsMenuItem( 'Lock' );
+		await page.click( 'role=checkbox[name="Disable movement"]' );
+		await page.click( 'role=button[name="Apply"]' );
+
+		// Add a second block
+		await editor.insertBlock( {
+			name: 'core/paragraph',
+			attributes: { content: 'Second Paragraph' },
+		} );
+		// Select a block so the block mover has the possibility of being rendered.
+		await page.focus( 'text=Second Paragraph' );
+		await editor.showBlockToolbar();
+
+		// Ensure no block mover exists when only one block exists on the page.
+		const moveDownButton = page.locator(
+			'role=toolbar[name="Block tools"i] >> role=button[name="Move down"i]'
+		);
+		const moveUpButton = page.locator(
+			'role=toolbar[name="Block tools"i] >> role=button[name="Move up"i]'
+		);
+		await expect( moveDownButton ).toBeHidden();
+		await expect( moveUpButton ).toBeHidden();
+	} );
 } );


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
This PR will disable block movement via the up arrow when all the previous blocks are locked

## Why?
It feels unintuitive to allow the movement, and has been brought up previously:
Closes https://github.com/WordPress/gutenberg/issues/43232

## How?
When active, it will check whether itself is the first unlocked block in the list, and if so, disable movement.

## Testing Instructions
1. Add two blocks
2. Lock the first
3. Attempt to move the second block up - it should not be possible and the icon should be disabled

## Screenshots or screencast <!-- if applicable -->

![ezgif com-gif-maker](https://user-images.githubusercontent.com/1478421/187008811-31ca28ed-d75b-44a7-9653-9d199c25ba50.gif)

## Caveats
- Dragging the block above it will still be possible - didn't see a clear enough path to solve that