### PR TITLE
Cover Block: Keep the inner contents in a physical direction even in RTL languages

### DIFF
--- a/packages/block-library/src/cover/edit/block-controls.js
+++ b/packages/block-library/src/cover/edit/block-controls.js
@@ -9,7 +9,7 @@ import {
 	__experimentalBlockAlignmentMatrixControl as BlockAlignmentMatrixControl,
 	__experimentalBlockFullHeightAligmentControl as FullHeightAlignmentControl,
 } from '@wordpress/block-editor';
-import { __, isRTL } from '@wordpress/i18n';
+import { __ } from '@wordpress/i18n';
 
 /**
  * Internal dependencies
@@ -58,27 +58,15 @@ export default function CoverBlockControls( {
 		} );
 	};
 
-	// Flip value horizontally to match the physical direction indicated by
-	// AlignmentMatrixControl with the logical direction indicated by cover
-	// block in RTL languages.
-	const flipHorizontalPosition = ( ltrContentPosition ) => {
-		return isRTL()
-			? ltrContentPosition.replace( /left|right/, ( match ) =>
-					match === 'left' ? 'right' : 'left'
-			  )
-			: ltrContentPosition;
-	};
-
 	return (
 		<>
 			<BlockControls group="block">
 				<BlockAlignmentMatrixControl
 					label={ __( 'Change content position' ) }
-					value={ flipHorizontalPosition( contentPosition ) }
+					value={ contentPosition }
 					onChange={ ( nextPosition ) =>
 						setAttributes( {
-							contentPosition:
-								flipHorizontalPosition( nextPosition ),
+							contentPosition: nextPosition,
 						} )
 					}
 					isDisabled={ ! hasInnerBlocks }

--- a/packages/block-library/src/cover/style.scss
+++ b/packages/block-library/src/cover/style.scss
@@ -1,6 +1,5 @@
 .wp-block-cover-image,
 .wp-block-cover {
-
 	position: relative;
 	background-position: center center;
 	min-height: 430px;

--- a/packages/block-library/src/cover/style.scss
+++ b/packages/block-library/src/cover/style.scss
@@ -1,5 +1,6 @@
 .wp-block-cover-image,
 .wp-block-cover {
+
 	position: relative;
 	background-position: center center;
 	min-height: 430px;
@@ -9,6 +10,8 @@
 	padding: 1em;
 	// This block has customizable padding, border-box makes that more predictable.
 	box-sizing: border-box;
+	// Keep the flex layout direction to the physical direction (LTR) in RTL languages.
+	/*rtl:raw: direction: ltr; */
 
 	/**
 	 * Set a default background color for has-background-dim _unless_ it includes another
@@ -105,6 +108,8 @@
 		width: 100%;
 		z-index: z-index(".wp-block-cover__inner-container");
 		color: $white;
+		// Reset the fixed LTR direction at the root of the block in RTL languages.
+		/*rtl:raw: direction: rtl; */
 	}
 
 	&.is-light {


### PR DESCRIPTION
Fix #43625
Follow-up on #43126

## What?
This PR physically fixes the position of the content in the cover block, regardless of language direction.

## Why?

See: https://github.com/WordPress/gutenberg/issues/43625#issue-1351921559

## How?

I applied `direction: ltr` to the cover block in the RTL language by usin the `rtl:raw` comment.
However, the direction of the language should be taken into account in the inner content, so in `.wp-block-cover__inner-container`, `direction:rtl` is applied only for RTL languages.
At the same time, [the quick fix](https://github.com/WordPress/gutenberg/blob/3b6a399cf5f2f82ea49a422d97adf46e8ef5dc01/packages/block-library/src/cover/edit/block-controls.js#L77-L81) done in #43126 was removed as it was no longer needed.

## Testing Instructions

- Insert a cover block and insert text with a full stop.
- Set the contents inside to either the left or right by using the matrix control.
- Switch the language of the site or the language of the users and change one or both to the RTL language.
- Confirm that the physical direction of the content inside is maintained in both the editor and the front end.

## Screenshots or screencast 

This is an example of setting the inner content to the bottom right.

| Site Llanguage | User language | On trunk | On this branch |
| ---- | ---- | ---- | ---- |
| English | English (Site Default) | ![trunk-english-english](https://user-images.githubusercontent.com/54422211/187018945-f24b5d4c-e519-4801-a731-8e5d427f1c55.png) | ![branch-english-english](https://user-images.githubusercontent.com/54422211/187018787-fda3aa9b-0b04-48e1-8b92-7aedc8b42d3d.png) | 
| English | Arabic | ![trunk-english-arabic](https://user-images.githubusercontent.com/54422211/187018952-8d910363-5161-49cb-a708-bacca4413592.png) | ![branch-english-arabic](https://user-images.githubusercontent.com/54422211/187018791-8e64283b-b25d-4998-8a17-3ba29cd871d6.png) | 
| Arabic | Arabic (Site Default) | ![trunk-arabic-arabic](https://user-images.githubusercontent.com/54422211/187018960-679d4ce1-efe5-4e94-a0fb-49ab1b87adfe.png) | ![branch-arabic-arabic](https://user-images.githubusercontent.com/54422211/187018796-44f7a3de-7a8f-4a6a-bae7-4a68b0954bfe.png) | 
| Arabic | English |  ![trunk-arabic-english](https://user-images.githubusercontent.com/54422211/187018963-e1921276-f36b-42ec-98f0-08f83d002c0c.png) | ![branch-arabic-english](https://user-images.githubusercontent.com/54422211/187018806-32287970-ff17-488e-9e5e-9ac90e6671a6.png) | 

### Impact on Consumers

This change flips the position of the inner contents from left to right on sites where the RTL language is applied. Is this impact acceptable?