### PR TITLE
Writing flow: Improve keyboard navigation on certain input types

### DIFF
--- a/packages/block-editor/src/components/writing-flow/test/index.js
+++ b/packages/block-editor/src/components/writing-flow/test/index.js
@@ -19,6 +19,9 @@ describe( 'isNavigationCandidate', () => {
 		elements.inputCheckbox = document.createElement( 'input' );
 		elements.inputCheckbox.setAttribute( 'type', 'checkbox' );
 
+		elements.inputNumber = document.createElement( 'input' );
+		elements.inputNumber.setAttribute( 'type', 'number' );
+
 		elements.contentEditable = document.createElement( 'p' );
 		elements.contentEditable.contentEditable = true;
 	} );
@@ -41,6 +44,18 @@ describe( 'isNavigationCandidate', () => {
 				elements.inputText,
 				keyCode,
 				true
+			);
+
+			expect( result ).toBe( false );
+		} );
+	} );
+
+	it( 'should return false if vertically navigating inputs with vertial support like number', () => {
+		[ UP, DOWN ].forEach( ( keyCode ) => {
+			const result = isNavigationCandidate(
+				elements.inputNumber,
+				keyCode,
+				false
 			);
 
 			expect( result ).toBe( false );

--- a/packages/block-editor/src/components/writing-flow/use-arrow-nav.js
+++ b/packages/block-editor/src/components/writing-flow/use-arrow-nav.js
@@ -32,19 +32,32 @@ import { store as blockEditorStore } from '../../store';
  */
 export function isNavigationCandidate( element, keyCode, hasModifier ) {
 	const isVertical = keyCode === UP || keyCode === DOWN;
+	const { tagName } = element;
+	const elementType = element.getAttribute( 'type' );
 
-	// Currently, all elements support unmodified vertical navigation.
+	// Native inputs should not navigate vertically, unless they are simple types that don't need up/down arrow keys.
 	if ( isVertical && ! hasModifier ) {
+		if ( tagName === 'INPUT' ) {
+			const vertiaclInputTypes = [
+				'date',
+				'datetime-local',
+				'month',
+				'number',
+				'range',
+				'time',
+				'week',
+			];
+			return ! vertiaclInputTypes.includes( elementType );
+		}
 		return true;
 	}
-
-	const { tagName } = element;
 
 	// Native inputs should not navigate horizontally, unless they are simple types that don't need left/right arrow keys.
 	if ( tagName === 'INPUT' ) {
 		const simpleInputTypes = [
 			'button',
 			'checkbox',
+			'number',
 			'color',
 			'file',
 			'image',
@@ -52,7 +65,7 @@ export function isNavigationCandidate( element, keyCode, hasModifier ) {
 			'reset',
 			'submit',
 		];
-		return simpleInputTypes.includes( element.getAttribute( 'type' ) );
+		return simpleInputTypes.includes( elementType );
 	}
 
 	// Native textareas should not navigate horizontally.

--- a/packages/block-editor/src/components/writing-flow/use-arrow-nav.js
+++ b/packages/block-editor/src/components/writing-flow/use-arrow-nav.js
@@ -38,7 +38,7 @@ export function isNavigationCandidate( element, keyCode, hasModifier ) {
 	// Native inputs should not navigate vertically, unless they are simple types that don't need up/down arrow keys.
 	if ( isVertical && ! hasModifier ) {
 		if ( tagName === 'INPUT' ) {
-			const vertiaclInputTypes = [
+			const verticalInputTypes = [
 				'date',
 				'datetime-local',
 				'month',
@@ -47,7 +47,7 @@ export function isNavigationCandidate( element, keyCode, hasModifier ) {
 				'time',
 				'week',
 			];
-			return ! vertiaclInputTypes.includes( elementType );
+			return ! verticalInputTypes.includes( elementType );
 		}
 		return true;
 	}

--- a/test/e2e/specs/editor/various/toolbar-roving-tabindex.spec.js
+++ b/test/e2e/specs/editor/various/toolbar-roving-tabindex.spec.js
@@ -96,6 +96,7 @@ test.describe( 'Toolbar roving tabindex', () => {
 		pageUtils,
 	} ) => {
 		await editor.insertBlock( { name: 'core/table' } );
+		await page.keyboard.press( 'ArrowLeft' );
 		await ToolbarRovingTabindexUtils.testBlockToolbarKeyboardNavigation(
 			'Block: Table',
 			'Table'


### PR DESCRIPTION
Fix #40608
Follow-up on #41538

## What?
This PR improves arrow key actions on some input fields on the block editor.

## Why?

### Vertical keystrokes

Currently, [vertical navigation takes precedence in all elements for up/down key operations.](https://github.com/WordPress/gutenberg/blob/3b6a399cf5f2f82ea49a422d97adf46e8ef5dc01/packages/block-editor/src/components/writing-flow/use-arrow-nav.js#L36-L39)
Therefore, as reported in #40608, using the up/down keys to manipulate the number of rows/columns in a table block ignores the native event that increases/decreases the number and loses focus.

### Horizontal keystrokes

In #41538, only simple input fields that don't require left and right arrow keys are allowed to navigate horizontally.
However, the input `number` field is not allowed, so navigation with the left/right keys is not possible when the focus is on a row/column field in a table block.

## How?

### Vertical keystrokes

Referring to [the MDN page](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input), I have given preference to native operation on all input elements that we believe accept up/down keys.

Ideally, up/down keys should be accepted for non-input elements such as the `ComboboxControl` component (reported in #38548), but in this case, we are limiting it to pure input elements.

### Horizontal keystrokes

I added the number type to the input elements which are allowed to navigate horizontally with left and right keys.
This allows left/right navigation from the row/column input field in the table block.

## Testing Instructions

### Vertical keystrokes

To test the behavior on the block editor, rewrite the edit component of the code block as follows

`packages/block-library/src/code/edit.js`

```javascript
import { useBlockProps } from '@wordpress/block-editor';
export default function CodeEdit() {
	const blockProps = useBlockProps();

	return (
		<div { ...blockProps }>
			<input type="date" />
			<input type="datetime-local" />
			<input type="month" />
			<input type="number" />
			<input type="range" />
			<input type="week" />
			<input type="time" />
		</div>
	);
}

```
Use the tab, enter and arrow keys to confirm you can control all input elements without losing focus.

https://user-images.githubusercontent.com/54422211/187038275-a047d55b-89cf-4859-b0e3-ea86a3d55b94.mp4

### Horizontal keystrokes

- Insert a table block.
- Use the left and right keys to confirm that navigation movement is enabled.

https://user-images.githubusercontent.com/54422211/187056654-bbb52a15-e646-4a1f-bff0-f28b7e137395.mp4




