### PR TITLE
Navigation: Remove unneeded gap:inherit rule on wrapper element of navigation block

### DIFF
--- a/packages/block-library/src/navigation/style.scss
+++ b/packages/block-library/src/navigation/style.scss
@@ -326,7 +326,6 @@ button.wp-block-navigation-item__content {
 .wp-block-navigation__responsive-container,
 .wp-block-navigation__responsive-close,
 .wp-block-navigation__responsive-dialog,
-.wp-block-navigation,
 .wp-block-navigation .wp-block-page-list,
 .wp-block-navigation__container,
 .wp-block-navigation__responsive-container-content {


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Fixes #42955 

Remove the `gap: inherit` rule for the root Navigation block classname selector.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

The Layout block support provides default gap rules for blocks that opt-in to Layout support. For classic themes, in order to ensure that the Layout support does not erroneously override theme styles, the specificity of the default / fallback gap styles are intentionally lower (as introduced in https://github.com/WordPress/gutenberg/pull/42665).

However, it appears that the Navigation block currently sets `gap: inherit` which overrides this rule. As far as I can tell, the `wp-block-navigation` rule here is a hold-over from back when the block needed to provide its own explicit styles. The inherit rule should only apply to children (or child elements) of the navigation block, and not the root / wrapper element.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

* Remove `.wp-block-navigation` from the list of classnames where the Navigation block applies the `gap: inherit` rule

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->

* Insert a Navigation block with a few links within it.
* Without this PR, on a Classic theme (e.g. TwentyTwentyOne), observe on the site frontend that there are no gaps between elements (as described in #42955)
* With this PR applied, the default/fallback gap style should no longer be overridden by the `gap: inherit` rule
* Double check that the gap still cascades correctly for child blocks of the Navigation block, and that gap still behaves correctly for blocks-based themes.

## Screenshots or screencast <!-- if applicable -->

| Before | After |
| --- | --- |
| <img width="646" alt="image" src="https://user-images.githubusercontent.com/14988353/187055910-b2b98ad1-f9d7-4b61-a30d-bac360d7a2a5.png"> | <img width="660" alt="image" src="https://user-images.githubusercontent.com/14988353/187055914-9ae60c55-2c9b-4d30-96e0-84c86a0d1484.png"> |
