### PR TITLE
Global Styles: Duotone palette doesn't reflect settings in theme.json

### DIFF
--- a/packages/edit-site/src/components/global-styles/gradients-palette-panel.js
+++ b/packages/edit-site/src/components/global-styles/gradients-palette-panel.js
@@ -46,11 +46,13 @@ export default function GradientPalettePanel( { name } ) {
 		name
 	);
 
+	const [ customDuotone ] = useSetting( 'color.duotone.custom' ) || [];
 	const [ defaultDuotone ] = useSetting( 'color.duotone.default' ) || [];
 	const [ themeDuotone ] = useSetting( 'color.duotone.theme' ) || [];
 	const [ defaultDuotoneEnabled ] = useSetting( 'color.defaultDuotone' );
 
 	const duotonePalette = [
+		...( customDuotone || [] ),
 		...( themeDuotone || [] ),
 		...( defaultDuotone && defaultDuotoneEnabled ? defaultDuotone : [] ),
 	];

--- a/packages/edit-site/src/components/global-styles/gradients-palette-panel.js
+++ b/packages/edit-site/src/components/global-styles/gradients-palette-panel.js
@@ -45,7 +45,16 @@ export default function GradientPalettePanel( { name } ) {
 		'color.defaultGradients',
 		name
 	);
-	const [ duotonePalette ] = useSetting( 'color.duotone' ) || [];
+
+	const [ defaultDuotone ] = useSetting( 'color.duotone.default' ) || [];
+	const [ themeDuotone ] = useSetting( 'color.duotone.theme' ) || [];
+	const [ defaultDuotoneEnabled ] = useSetting( 'color.defaultDuotone' );
+
+	const duotonePalette = [
+		...( themeDuotone || [] ),
+		...( defaultDuotone && defaultDuotoneEnabled ? defaultDuotone : [] ),
+	];
+
 	return (
 		<VStack
 			className="edit-site-global-styles-gradient-palette-panel"
@@ -80,17 +89,19 @@ export default function GradientPalettePanel( { name } ) {
 				) }
 				slugPrefix="custom-"
 			/>
-			<div>
-				<Subtitle>{ __( 'Duotone' ) }</Subtitle>
-				<Spacer margin={ 3 } />
-				<DuotonePicker
-					duotonePalette={ duotonePalette }
-					disableCustomDuotone={ true }
-					disableCustomColors={ true }
-					clearable={ false }
-					onChange={ noop }
-				/>
-			</div>
+			{ !! duotonePalette && !! duotonePalette.length && (
+				<div>
+					<Subtitle>{ __( 'Duotone' ) }</Subtitle>
+					<Spacer margin={ 3 } />
+					<DuotonePicker
+						duotonePalette={ duotonePalette }
+						disableCustomDuotone={ true }
+						disableCustomColors={ true }
+						clearable={ false }
+						onChange={ noop }
+					/>
+				</div>
+			) }
 		</VStack>
 	);
 }


### PR DESCRIPTION
Fix: #43384

## What?
This PR ensures that the duotone panel in the global style panel reflects the settings in `theme.json`.

## Why?
Currently, the `settings.color.defaultDuotone` in `theme.json` is not taken into account, so the default duotone palette is always displayed.

## How?
Changed to match the palette of the duotone picker in blocks, taking into account the settings in `theme.json`.

## Testing Instructions
- Open the site editor, and insert the image block.
- Change `settings.color.defaultDuotone` and `settings.color.duotone` in `theme.json` to create different variations.
- Access Styles Menu> Colors > Palette > Gradient panel.
- Open the duotone picker in the image block and confirm that it matches the duotone palette in the Global Style panel.

### Should only show default duotone palette

```json

{
	"$schema": "https://schemas.wp.org/wp/6.0/theme.json",
	"version": 2,
	"settings": {
		"color": {
		}
	}
}

```

![Should only show default duotone palette](https://user-images.githubusercontent.com/54422211/187063867-e59e9e5c-e010-4777-9eb0-b373be7e25b5.png)

### Should not show duotone palette

```json

{
	"$schema": "https://schemas.wp.org/wp/6.0/theme.json",
	"version": 2,
	"settings": {
		"color": {
			"defaultDuotone": false
		}
	}
}

```

![Should not show duotone palette](https://user-images.githubusercontent.com/54422211/187063870-e4fbfc5c-1235-4e95-918b-c29ef14c5470.png)

### Should only show custom duotone palette

```json
{
	"$schema": "https://schemas.wp.org/wp/6.0/theme.json",
	"version": 2,
	"settings": {
		"color": {
			"defaultDuotone": false,
			"duotone": [
				{
					"colors": [ "#ff0000", "#ffff00" ],
					"slug": "red-and-yellow",
					"name": "Red and Yellow"
				},
				{
					"colors": [ "#ff0000", "#00ff00" ],
					"slug": "red-and-green",
					"name": "Red and Green"
				}
			]
		}
	}
}
```

![Should only show custom duotone palette](https://user-images.githubusercontent.com/54422211/187063872-80a84bf3-32a8-486f-91d4-b9ba95304ea3.png)

### Should show both dafult and custom duotone palettes

```json
{
	"$schema": "https://schemas.wp.org/wp/6.0/theme.json",
	"version": 2,
	"settings": {
		"color": {
			"duotone": [
				{
					"colors": [ "#ff0000", "#ffff00" ],
					"slug": "red-and-yellow",
					"name": "Red and Yellow"
				},
				{
					"colors": [ "#ff0000", "#00ff00" ],
					"slug": "red-and-green",
					"name": "Red and Green"
				}
			]
		}
	}
}
```

![Should show both dafult and custom duotone palettes](https://user-images.githubusercontent.com/54422211/187063880-c59092ca-30ea-4fbf-b339-759f2c014ce3.png)