### PR TITLE
RFC: Enable full customization of Query Loop block inspector controls

### DIFF
--- a/docs/reference-guides/core-blocks.md
+++ b/docs/reference-guides/core-blocks.md
@@ -609,7 +609,7 @@ An advanced block that allows displaying post types based on different query par
 -	**Name:** core/query
 -	**Category:** theme
 -	**Supports:** align (full, wide), color (background, gradients, link, text), ~~html~~
--	**Attributes:** displayLayout, query, queryId, tagName
+-	**Attributes:** disabledInspectorControls, displayLayout, query, queryId, tagName
 
 ## No results
 

--- a/packages/block-library/src/query/block.json
+++ b/packages/block-library/src/query/block.json
@@ -37,6 +37,9 @@
 			"default": {
 				"type": "list"
 			}
+		},
+		"disabledInspectorControls": {
+			"type": "array"
 		}
 	},
 	"providesContext": {

--- a/packages/block-library/src/query/edit/inspector-controls/columns.js
+++ b/packages/block-library/src/query/edit/inspector-controls/columns.js
@@ -1,0 +1,30 @@
+/**
+ * WordPress dependencies
+ */
+import { Notice, RangeControl } from '@wordpress/components';
+import { __ } from '@wordpress/i18n';
+
+export function Columns( { attributes: { displayLayout }, setDisplayLayout } ) {
+	return (
+		displayLayout?.type === 'flex' && (
+			<>
+				<RangeControl
+					label={ __( 'Columns' ) }
+					value={ displayLayout.columns }
+					onChange={ ( value ) =>
+						setDisplayLayout( { columns: value } )
+					}
+					min={ 2 }
+					max={ Math.max( 6, displayLayout.columns ) }
+				/>
+				{ displayLayout.columns > 6 && (
+					<Notice status="warning" isDismissible={ false }>
+						{ __(
+							'This column count exceeds the recommended amount and may cause visual breakage.'
+						) }
+					</Notice>
+				) }
+			</>
+		)
+	);
+}

--- a/packages/block-library/src/query/edit/inspector-controls/filter-controls.js
+++ b/packages/block-library/src/query/edit/inspector-controls/filter-controls.js
@@ -7,7 +7,6 @@ import {
 } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 import { useState } from '@wordpress/element';
-import { applyFilters } from '@wordpress/hooks';
 
 /**
  * Internal dependencies
@@ -17,13 +16,13 @@ import AuthorControl from './author-control';
 import ParentControl from './parent-control';
 import { TaxonomyControls, useTaxonomiesInfo } from './taxonomy-controls';
 
-export const FILTERS_CONTROLS = applyFilters( 'editor.QueryLoop.filters', {
-	Authors: ( {
-		attributes: {
-			query: { author: authorIds },
-		},
-		setQuery,
-	} ) => (
+export function Authors( {
+	attributes: {
+		query: { author: authorIds },
+	},
+	setQuery,
+} ) {
+	return (
 		<ToolsPanelItem
 			hasValue={ () => !! authorIds }
 			label={ __( 'Authors' ) }
@@ -31,66 +30,69 @@ export const FILTERS_CONTROLS = applyFilters( 'editor.QueryLoop.filters', {
 		>
 			<AuthorControl value={ authorIds } onChange={ setQuery } />
 		</ToolsPanelItem>
-	),
-	Keyword: ( {
-		attributes: {
-			query: { search },
-		},
-	} ) => {
-		const [ querySearch, setQuerySearch ] = useState( search );
+	);
+}
 
-		return (
-			<ToolsPanelItem
-				hasValue={ () => !! querySearch }
+export function Keyword( {
+	attributes: {
+		query: { search },
+	},
+} ) {
+	const [ querySearch, setQuerySearch ] = useState( search );
+
+	return (
+		<ToolsPanelItem
+			hasValue={ () => !! querySearch }
+			label={ __( 'Keyword' ) }
+			onDeselect={ () => setQuerySearch( '' ) }
+		>
+			<TextControl
 				label={ __( 'Keyword' ) }
-				onDeselect={ () => setQuerySearch( '' ) }
-			>
-				<TextControl
-					label={ __( 'Keyword' ) }
-					value={ querySearch }
-					onChange={ setQuerySearch }
-				/>
-			</ToolsPanelItem>
-		);
-	},
-	Parents: ( {
-		attributes: {
-			query: { parents, postType },
-		},
-		setQuery,
-	} ) => {
-		const isPostTypeHierarchical = useIsPostTypeHierarchical( postType );
+				value={ querySearch }
+				onChange={ setQuerySearch }
+			/>
+		</ToolsPanelItem>
+	);
+}
 
-		return isPostTypeHierarchical ? (
-			<ToolsPanelItem
-				hasValue={ () => !! parents?.length }
-				label={ __( 'Parents' ) }
-				onDeselect={ () => setQuery( { parents: [] } ) }
-			>
-				<ParentControl
-					parents={ parents }
-					postType={ postType }
-					onChange={ setQuery }
-				/>
-			</ToolsPanelItem>
-		) : null;
+export function Parents( {
+	attributes: {
+		query: { parents, postType },
 	},
-	Taxonomies: ( { attributes: { query }, setQuery } ) => {
-		const { postType, taxQuery } = query;
-		const taxonomiesInfo = useTaxonomiesInfo( postType );
+	setQuery,
+} ) {
+	const isPostTypeHierarchical = useIsPostTypeHierarchical( postType );
 
-		return !! taxonomiesInfo?.length ? (
-			<ToolsPanelItem
-				label={ __( 'Taxonomies' ) }
-				hasValue={ () =>
-					Object.values( taxQuery || {} ).some(
-						( terms ) => !! terms.length
-					)
-				}
-				onDeselect={ () => setQuery( { taxQuery: null } ) }
-			>
-				<TaxonomyControls onChange={ setQuery } query={ query } />
-			</ToolsPanelItem>
-		) : null;
-	},
-} );
+	return isPostTypeHierarchical ? (
+		<ToolsPanelItem
+			hasValue={ () => !! parents?.length }
+			label={ __( 'Parents' ) }
+			onDeselect={ () => setQuery( { parents: [] } ) }
+		>
+			<ParentControl
+				parents={ parents }
+				postType={ postType }
+				onChange={ setQuery }
+			/>
+		</ToolsPanelItem>
+	) : null;
+}
+
+export function Taxonomies( { attributes: { query }, setQuery } ) {
+	const { postType, taxQuery } = query;
+	const taxonomiesInfo = useTaxonomiesInfo( postType );
+
+	return !! taxonomiesInfo?.length ? (
+		<ToolsPanelItem
+			label={ __( 'Taxonomies' ) }
+			hasValue={ () =>
+				Object.values( taxQuery || {} ).some(
+					( terms ) => !! terms.length
+				)
+			}
+			onDeselect={ () => setQuery( { taxQuery: null } ) }
+		>
+			<TaxonomyControls onChange={ setQuery } query={ query } />
+		</ToolsPanelItem>
+	) : null;
+}

--- a/packages/block-library/src/query/edit/inspector-controls/filter-controls.js
+++ b/packages/block-library/src/query/edit/inspector-controls/filter-controls.js
@@ -1,0 +1,96 @@
+/**
+ * WordPress dependencies
+ */
+import {
+	TextControl,
+	__experimentalToolsPanelItem as ToolsPanelItem,
+} from '@wordpress/components';
+import { __ } from '@wordpress/i18n';
+import { useState } from '@wordpress/element';
+import { applyFilters } from '@wordpress/hooks';
+
+/**
+ * Internal dependencies
+ */
+import { useIsPostTypeHierarchical } from '../../utils';
+import AuthorControl from './author-control';
+import ParentControl from './parent-control';
+import { TaxonomyControls, useTaxonomiesInfo } from './taxonomy-controls';
+
+export const FILTERS_CONTROLS = applyFilters( 'editor.QueryLoop.filters', {
+	Authors: ( {
+		attributes: {
+			query: { author: authorIds },
+		},
+		setQuery,
+	} ) => (
+		<ToolsPanelItem
+			hasValue={ () => !! authorIds }
+			label={ __( 'Authors' ) }
+			onDeselect={ () => setQuery( { author: '' } ) }
+		>
+			<AuthorControl value={ authorIds } onChange={ setQuery } />
+		</ToolsPanelItem>
+	),
+	Keyword: ( {
+		attributes: {
+			query: { search },
+		},
+	} ) => {
+		const [ querySearch, setQuerySearch ] = useState( search );
+
+		return (
+			<ToolsPanelItem
+				hasValue={ () => !! querySearch }
+				label={ __( 'Keyword' ) }
+				onDeselect={ () => setQuerySearch( '' ) }
+			>
+				<TextControl
+					label={ __( 'Keyword' ) }
+					value={ querySearch }
+					onChange={ setQuerySearch }
+				/>
+			</ToolsPanelItem>
+		);
+	},
+	Parents: ( {
+		attributes: {
+			query: { parents, postType },
+		},
+		setQuery,
+	} ) => {
+		const isPostTypeHierarchical = useIsPostTypeHierarchical( postType );
+
+		return isPostTypeHierarchical ? (
+			<ToolsPanelItem
+				hasValue={ () => !! parents?.length }
+				label={ __( 'Parents' ) }
+				onDeselect={ () => setQuery( { parents: [] } ) }
+			>
+				<ParentControl
+					parents={ parents }
+					postType={ postType }
+					onChange={ setQuery }
+				/>
+			</ToolsPanelItem>
+		) : null;
+	},
+	Taxonomies: ( { attributes: { query }, setQuery } ) => {
+		const { postType, taxQuery } = query;
+		const taxonomiesInfo = useTaxonomiesInfo( postType );
+
+		return !! taxonomiesInfo?.length ? (
+			<ToolsPanelItem
+				label={ __( 'Taxonomies' ) }
+				hasValue={ () =>
+					Object.values( taxQuery || {} ).some(
+						( terms ) => !! terms.length
+					)
+				}
+				onDeselect={ () => setQuery( { taxQuery: null } ) }
+			>
+				<TaxonomyControls onChange={ setQuery } query={ query } />
+			</ToolsPanelItem>
+		) : null;
+	},
+} );

--- a/packages/block-library/src/query/edit/inspector-controls/index.js
+++ b/packages/block-library/src/query/edit/inspector-controls/index.js
@@ -15,12 +15,11 @@ import {
 import { __ } from '@wordpress/i18n';
 import { InspectorControls } from '@wordpress/block-editor';
 import { useEffect, useState, useCallback } from '@wordpress/element';
-import { useSelect } from '@wordpress/data';
-import { store as coreStore } from '@wordpress/core-data';
 
 /**
  * Internal dependencies
  */
+import { useIsPostTypeHierarchical } from '../../utils';
 import AuthorControl from './author-control';
 import { Columns } from './columns';
 import { Order } from './order-control';
@@ -29,16 +28,6 @@ import ParentControl from './parent-control';
 import { PostType } from './post-type';
 import { TaxonomyControls, useTaxonomiesInfo } from './taxonomy-controls';
 import { Sticky } from './sticky-control';
-
-function useIsPostTypeHierarchical( postType ) {
-	return useSelect(
-		( select ) => {
-			const type = select( coreStore ).getPostType( postType );
-			return type?.viewable && type?.hierarchical;
-		},
-		[ postType ]
-	);
-}
 
 const INSPECTOR_CONTROLS = {
 	InheritFromTemplate,

--- a/packages/block-library/src/query/edit/inspector-controls/index.js
+++ b/packages/block-library/src/query/edit/inspector-controls/index.js
@@ -13,11 +13,12 @@ import {
 import { __ } from '@wordpress/i18n';
 import { InspectorControls } from '@wordpress/block-editor';
 import { useEffect, useState, useCallback } from '@wordpress/element';
+import { applyFilters } from '@wordpress/hooks';
 
 /**
  * Internal dependencies
  */
-import { FILTERS_CONTROLS } from './filter-controls';
+import * as FILTERS_CONTROLS from './filter-controls';
 import { Columns } from './columns';
 import { Order } from './order-control';
 import { InheritFromTemplate } from './inherit-from-template';
@@ -40,6 +41,7 @@ export default function QueryInspectorControls( props ) {
 
 	const { inherit } = query;
 	const [ querySearch, setQuerySearch ] = useState( query.search );
+
 	const onChangeDebounced = useCallback(
 		debounce( () => {
 			if ( query.search !== querySearch ) {
@@ -48,10 +50,18 @@ export default function QueryInspectorControls( props ) {
 		}, 250 ),
 		[ querySearch, query.search ]
 	);
+
 	useEffect( () => {
 		onChangeDebounced();
 		return onChangeDebounced.cancel;
 	}, [ querySearch, onChangeDebounced ] );
+
+	const FILTERS = applyFilters(
+		'editor.QueryLoop.FilterControls',
+		FILTERS_CONTROLS,
+		props
+	);
+
 	return (
 		<>
 			<InspectorControls>
@@ -81,13 +91,12 @@ export default function QueryInspectorControls( props ) {
 							setQuerySearch( '' );
 						} }
 					>
-						{ Object.entries( FILTERS_CONTROLS ).map(
-							( [ key, Control ] ) =>
-								disabledInspectorControls?.includes?.(
-									key
-								) ? null : (
-									<Control { ...props } />
-								)
+						{ Object.entries( FILTERS ).map( ( [ key, Control ] ) =>
+							disabledInspectorControls?.includes?.(
+								key
+							) ? null : (
+								<Control { ...props } />
+							)
 						) }
 					</ToolsPanel>
 				</InspectorControls>

--- a/packages/block-library/src/query/edit/inspector-controls/index.js
+++ b/packages/block-library/src/query/edit/inspector-controls/index.js
@@ -8,9 +8,7 @@ import { debounce } from 'lodash';
  */
 import {
 	PanelBody,
-	TextControl,
 	__experimentalToolsPanel as ToolsPanel,
-	__experimentalToolsPanelItem as ToolsPanelItem,
 } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 import { InspectorControls } from '@wordpress/block-editor';
@@ -19,14 +17,11 @@ import { useEffect, useState, useCallback } from '@wordpress/element';
 /**
  * Internal dependencies
  */
-import { useIsPostTypeHierarchical } from '../../utils';
-import AuthorControl from './author-control';
+import { FILTERS_CONTROLS } from './filter-controls';
 import { Columns } from './columns';
 import { Order } from './order-control';
 import { InheritFromTemplate } from './inherit-from-template';
-import ParentControl from './parent-control';
 import { PostType } from './post-type';
-import { TaxonomyControls, useTaxonomiesInfo } from './taxonomy-controls';
 import { Sticky } from './sticky-control';
 
 const INSPECTOR_CONTROLS = {
@@ -43,9 +38,7 @@ export default function QueryInspectorControls( props ) {
 		setQuery,
 	} = props;
 
-	const { author: authorIds, postType, inherit, taxQuery, parents } = query;
-	const taxonomiesInfo = useTaxonomiesInfo( postType );
-	const isPostTypeHierarchical = useIsPostTypeHierarchical( postType );
+	const { inherit } = query;
 	const [ querySearch, setQuerySearch ] = useState( query.search );
 	const onChangeDebounced = useCallback(
 		debounce( () => {
@@ -88,57 +81,13 @@ export default function QueryInspectorControls( props ) {
 							setQuerySearch( '' );
 						} }
 					>
-						{ !! taxonomiesInfo?.length && (
-							<ToolsPanelItem
-								label={ __( 'Taxonomies' ) }
-								hasValue={ () =>
-									Object.values( taxQuery || {} ).some(
-										( terms ) => !! terms.length
-									)
-								}
-								onDeselect={ () =>
-									setQuery( { taxQuery: null } )
-								}
-							>
-								<TaxonomyControls
-									onChange={ setQuery }
-									query={ query }
-								/>
-							</ToolsPanelItem>
-						) }
-						<ToolsPanelItem
-							hasValue={ () => !! authorIds }
-							label={ __( 'Authors' ) }
-							onDeselect={ () => setQuery( { author: '' } ) }
-						>
-							<AuthorControl
-								value={ authorIds }
-								onChange={ setQuery }
-							/>
-						</ToolsPanelItem>
-						<ToolsPanelItem
-							hasValue={ () => !! querySearch }
-							label={ __( 'Keyword' ) }
-							onDeselect={ () => setQuerySearch( '' ) }
-						>
-							<TextControl
-								label={ __( 'Keyword' ) }
-								value={ querySearch }
-								onChange={ setQuerySearch }
-							/>
-						</ToolsPanelItem>
-						{ isPostTypeHierarchical && (
-							<ToolsPanelItem
-								hasValue={ () => !! parents?.length }
-								label={ __( 'Parents' ) }
-								onDeselect={ () => setQuery( { parents: [] } ) }
-							>
-								<ParentControl
-									parents={ parents }
-									postType={ postType }
-									onChange={ setQuery }
-								/>
-							</ToolsPanelItem>
+						{ Object.entries( FILTERS_CONTROLS ).map(
+							( [ key, Control ] ) =>
+								disabledInspectorControls?.includes?.(
+									key
+								) ? null : (
+									<Control { ...props } />
+								)
 						) }
 					</ToolsPanel>
 				</InspectorControls>

--- a/packages/block-library/src/query/edit/inspector-controls/inherit-from-template.js
+++ b/packages/block-library/src/query/edit/inspector-controls/inherit-from-template.js
@@ -1,0 +1,23 @@
+/**
+ * WordPress dependencies
+ */
+import { ToggleControl } from '@wordpress/components';
+import { __ } from '@wordpress/i18n';
+
+export function InheritFromTemplate( {
+	attributes: {
+		query: { inherit },
+	},
+	setQuery,
+} ) {
+	return (
+		<ToggleControl
+			label={ __( 'Inherit query from template' ) }
+			help={ __(
+				'Toggle to use the global query context that is set with the current template, such as an archive or search. Disable to customize the settings independently.'
+			) }
+			checked={ !! inherit }
+			onChange={ ( value ) => setQuery( { inherit: !! value } ) }
+		/>
+	);
+}

--- a/packages/block-library/src/query/edit/inspector-controls/order-control.js
+++ b/packages/block-library/src/query/edit/inspector-controls/order-control.js
@@ -39,3 +39,16 @@ function OrderControl( { order, orderBy, onChange } ) {
 }
 
 export default OrderControl;
+
+export function Order( {
+	attributes: {
+		query: { inherit, order, orderBy },
+	},
+	setQuery,
+} ) {
+	return (
+		! inherit && (
+			<OrderControl { ...{ order, orderBy } } onChange={ setQuery } />
+		)
+	);
+}

--- a/packages/block-library/src/query/edit/inspector-controls/post-type.js
+++ b/packages/block-library/src/query/edit/inspector-controls/post-type.js
@@ -1,0 +1,59 @@
+/**
+ * WordPress dependencies
+ */
+import { SelectControl } from '@wordpress/components';
+import { __ } from '@wordpress/i18n';
+
+/**
+ * Internal dependencies
+ */
+import { usePostTypes } from '../../utils';
+
+export function PostType( {
+	attributes: {
+		query: { inherit, postType, taxQuery },
+	},
+	setQuery,
+} ) {
+	const { postTypesSelectOptions, postTypesTaxonomiesMap } = usePostTypes();
+
+	const onPostTypeChange = ( newValue ) => {
+		const updateQuery = { postType: newValue };
+		// We need to dynamically update the `taxQuery` property,
+		// by removing any not supported taxonomy from the query.
+		const supportedTaxonomies = postTypesTaxonomiesMap[ newValue ];
+		const updatedTaxQuery = Object.entries( taxQuery || {} ).reduce(
+			( accumulator, [ taxonomySlug, terms ] ) => {
+				if ( supportedTaxonomies.includes( taxonomySlug ) ) {
+					accumulator[ taxonomySlug ] = terms;
+				}
+				return accumulator;
+			},
+			{}
+		);
+		updateQuery.taxQuery = !! Object.keys( updatedTaxQuery ).length
+			? updatedTaxQuery
+			: undefined;
+
+		if ( newValue !== 'post' ) {
+			updateQuery.sticky = '';
+		}
+		// We need to reset `parents` because they are tied to each post type.
+		updateQuery.parents = [];
+		setQuery( updateQuery );
+	};
+
+	return (
+		! inherit && (
+			<SelectControl
+				options={ postTypesSelectOptions }
+				value={ postType }
+				label={ __( 'Post type' ) }
+				onChange={ onPostTypeChange }
+				help={ __(
+					'WordPress contains different types of content and they are divided into collections called "Post types". By default there are a few different ones such as blog posts and pages, but plugins could add more.'
+				) }
+			/>
+		)
+	);
+}

--- a/packages/block-library/src/query/edit/inspector-controls/sticky-control.js
+++ b/packages/block-library/src/query/edit/inspector-controls/sticky-control.js
@@ -2,6 +2,7 @@
  * WordPress dependencies
  */
 import { SelectControl } from '@wordpress/components';
+import { useEffect, useState } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 
 const stickyOptions = [
@@ -21,5 +22,28 @@ export default function StickyControl( { value, onChange } ) {
 				'Blog posts can be "stickied", a feature that places them at the top of the front page of posts, keeping it there until new sticky posts are published.'
 			) }
 		/>
+	);
+}
+
+export function Sticky( {
+	attributes: {
+		query: { inherit, postType, sticky },
+	},
+	setQuery,
+} ) {
+	const [ showSticky, setShowSticky ] = useState( postType === 'post' );
+
+	useEffect( () => {
+		setShowSticky( postType === 'post' );
+	}, [ postType ] );
+
+	return (
+		! inherit &&
+		showSticky && (
+			<StickyControl
+				value={ sticky }
+				onChange={ ( value ) => setQuery( { sticky: value } ) }
+			/>
+		)
 	);
 }

--- a/packages/block-library/src/query/utils.js
+++ b/packages/block-library/src/query/utils.js
@@ -167,3 +167,19 @@ export const getTransformedBlocksFromPattern = (
 	}
 	return { newBlocks: clonedBlocks, queryClientIds };
 };
+
+/**
+ * Checks if a particular post type is viewable and hierarchical
+ *
+ * @param {string} postType The post type.
+ * @return {boolean} `true` if the Post Type is hierarchical.
+ */
+export function useIsPostTypeHierarchical( postType ) {
+	return useSelect(
+		( select ) => {
+			const type = select( coreStore ).getPostType( postType );
+			return type?.viewable && type?.hierarchical;
+		},
+		[ postType ]
+	);
+}


### PR DESCRIPTION
## What?
This PR enables developers to completely extend the Query Loop block options, deciding which settings should be available and which should not.

## Why?
Developers might want to create Query Loop block variations which are more specific to their environment, and, as such, don't require all of the settings available by default on the Query Loop block. Even further, some of these settings might break block variations.

## How?
This PR proposes a way to enable this customization that is completely backwards compatible, and enables a simple API for developers to hook into and extend the settings.

1. A new attribute called `disabledInspectorControls` has been added to the block. Developers can pass an array of strings corresponding to the keys of the settings that they want to disable to not render them on the inspector sidebar. Since we are not using TypeScript, perhaps adding a clear JSDoc documentation of the keys available by default could be helpful. However, no harm is done if wrong strings are passed, and the block behaves normally when the attribute is an empty array or `undefined`, preserving backwards compatibility.
2. `disabledInspectorControls` also accept a list of strings corresponding to the collapsed filters. However, since filters [have been moved to a `ToolsPanel`](https://github.com/WordPress/gutenberg/pull/42629), in order to allow developers to extend that panel and completely integrate new optional filters to the inspector, a new WordPress filter has been added (provisional name: `editor.QueryLoop.FilterControls`, naming convention inspired by filters found in `components/Autocomplete`).
3. Taking advantage of these changes, all the controls have been refactored out of the `inspector-control/index.js` file into their own file, cutting the size of that file by more than half and making it more readable. Now, it is much clearer what each component is responsible for, and what properties are required, instead of having all the logic mixed into one component.

> **Note**
In the interest of keeping my edits as minimal as possible, I preserved the already existing `default` exports for editor components which had been refactored, and added named exports below them.
>
> Basically, the `default` exports have no knowledge of the context in which they are rendered, which might be a good thing. However, considering they are unlikely to be used in different context, they could arguably contain their rendering logic, and we could simplify the code even further. But I have no strong opinions on this, if we want to leave them as they are and enable reusability in different contexts.

---

@gziolo @ntsekouras I'm publishing this as a Draft PR to get your comments before I submit it for full review, in case you disagree with some of the approach taken here.

## Testing Instructions

> **Warning**
Testing instructions are WIP

1. Smoke test the default Query Loop block and verify all settings and filters still work.
2. Create a Query Loop variation (or just instantiate the block programmatically) by adding the `disabledInspectorControls` attribute, like so:

```
registerBlockVariation( 'core/query', {
  name: 'test/my-query',
  title: 'My Query',
  attributes: {
    disabledInspectorControls: [ 'InheritFromTemplate', 'PostType' ],
  },
  innerBlocks: [
    [
      'core/post-template',
      {},
      [ [ 'core/post-title' ], [ 'core/post-featured-image' ] ],
    ],
    [ 'core/query-pagination' ],
    [ 'core/query-no-results' ],
  ],
  scope: [ 'block', 'inserter' ],
} );
```

3. Add it to the Editor.
4. Verify that the listed settings are not available in the Inspector.
5. Add a WordPress filter to extend the Inspector Filters, like so:

```
const MY_FILTERS = {
  MyFilter: ( props ) => (
    <ToolsPanelItem
      hasValue={ /* ... */ }
      label={ 'My Filter' }
      onDeselect={ /* ... */ }
    >
      <TextControl
        label={ 'My Filter' }
        value={ /* ... */ }
        onChange={ /* ... */ }
      />
    </ToolsPanelItem>
  ),
};

const withMyFilters = ( filtersMap, props ) => {
  return {
    ...filtersMap,
    ...MY_FILTERS,
  }
};

addFilter(
  'editor.QueryLoop.FilterControls',
  'core/query',
  withMyFilters
);
```

6. Verify your filter appears on the Filters `ToolsPanel` dropdown.

## Screenshots or screencast <!-- if applicable -->

![Screenshot 2022-08-29 at 07 40 39](https://user-images.githubusercontent.com/1847066/187130569-95d4edf6-9b9d-47d5-a621-dc9530e4b7ee.png)

Notice the missing settings on the right, and a new filter within the Filters `ToolsPanel`.

