### PR TITLE
Lodash: Remove completely from `@wordpress/i18n` package

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17454,7 +17454,6 @@
 				"@babel/runtime": "^7.16.0",
 				"@wordpress/hooks": "file:packages/hooks",
 				"gettext-parser": "^1.3.1",
-				"lodash": "^4.17.21",
 				"memize": "^1.1.0",
 				"sprintf-js": "^1.1.1",
 				"tannin": "^1.2.0"

--- a/packages/i18n/package.json
+++ b/packages/i18n/package.json
@@ -32,7 +32,6 @@
 		"@babel/runtime": "^7.16.0",
 		"@wordpress/hooks": "file:../hooks",
 		"gettext-parser": "^1.3.1",
-		"lodash": "^4.17.21",
 		"memize": "^1.1.0",
 		"sprintf-js": "^1.1.1",
 		"tannin": "^1.2.0"

--- a/packages/i18n/tools/pot-to-php.js
+++ b/packages/i18n/tools/pot-to-php.js
@@ -4,7 +4,6 @@
  * External dependencies
  */
 const gettextParser = require( 'gettext-parser' );
-const { isEmpty } = require( 'lodash' );
 const fs = require( 'fs' );
 
 const TAB = '\t';
@@ -47,8 +46,8 @@ function convertTranslationToPHP( translation, textdomain, context = '' ) {
 	let original = translation.msgid;
 	const comments = translation.comments;
 
-	if ( ! isEmpty( comments ) ) {
-		if ( ! isEmpty( comments.reference ) ) {
+	if ( Object.values( comments ).length ) {
+		if ( comments.reference ) {
 			// All references are split by newlines, add a // Reference prefix to make them tidy.
 			php +=
 				TAB +
@@ -59,7 +58,7 @@ function convertTranslationToPHP( translation, textdomain, context = '' ) {
 				NEWLINE;
 		}
 
-		if ( ! isEmpty( comments.translator ) ) {
+		if ( comments.translator ) {
 			// All extracted comments are split by newlines, add a tab to line them up nicely.
 			const translator = comments.translator
 				.split( NEWLINE )
@@ -68,7 +67,7 @@ function convertTranslationToPHP( translation, textdomain, context = '' ) {
 			php += TAB + `/* ${ translator } */${ NEWLINE }`;
 		}
 
-		if ( ! isEmpty( comments.extracted ) ) {
+		if ( comments.extracted ) {
 			php +=
 				TAB + `/* translators: ${ comments.extracted } */${ NEWLINE }`;
 		}
@@ -77,8 +76,8 @@ function convertTranslationToPHP( translation, textdomain, context = '' ) {
 	if ( '' !== original ) {
 		original = escapeSingleQuotes( original );
 
-		if ( isEmpty( translation.msgid_plural ) ) {
-			if ( isEmpty( context ) ) {
+		if ( ! translation.msgid_plural ) {
+			if ( ! context ) {
 				php += TAB + `__( '${ original }', '${ textdomain }' )`;
 			} else {
 				php +=
@@ -88,7 +87,7 @@ function convertTranslationToPHP( translation, textdomain, context = '' ) {
 		} else {
 			const plural = escapeSingleQuotes( translation.msgid_plural );
 
-			if ( isEmpty( context ) ) {
+			if ( ! context ) {
 				php +=
 					TAB +
 					`_n_noop( '${ original }', '${ plural }', '${ textdomain }' )`;


### PR DESCRIPTION
## What?
This PR removes all of the Lodash from the `@wordpress/i18n` package, including the `lodash` dependency altogether.

## Why?

Lodash is known to unnecessarily inflate the bundle size of packages, and in most cases, it can be replaced with native language functionality. See these for more information and rationale:

* https://github.com/WordPress/gutenberg/issues/16938#issuecomment-602837246
* https://github.com/WordPress/gutenberg/issues/17025
* https://github.com/WordPress/gutenberg/issues/39495 

## How?
We're dealing with straightforwardly replacing `isEmpty()` against a predictable data structure, where sometimes it will be a string, and sometimes - an object.

## Testing Instructions

* Grab a `.pot` file (or [generate one](https://developer.wordpress.org/plugins/internationalization/localization/#generating-the-pot-file)).
* Verify `packages/i18n/tools/pot-to-php.js PATH_TO_POT foobar.php` still works well and exports all translations to the provided PHP file.