### PR TITLE
Lodash: Remove completely from `@wordpress/edit-widgets` package

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17131,8 +17131,7 @@
 				"@wordpress/reusable-blocks": "file:packages/reusable-blocks",
 				"@wordpress/url": "file:packages/url",
 				"@wordpress/widgets": "file:packages/widgets",
-				"classnames": "^2.3.1",
-				"lodash": "^4.17.21"
+				"classnames": "^2.3.1"
 			}
 		},
 		"@wordpress/editor": {

--- a/packages/edit-widgets/package.json
+++ b/packages/edit-widgets/package.json
@@ -51,8 +51,7 @@
 		"@wordpress/reusable-blocks": "file:../reusable-blocks",
 		"@wordpress/url": "file:../url",
 		"@wordpress/widgets": "file:../widgets",
-		"classnames": "^2.3.1",
-		"lodash": "^4.17.21"
+		"classnames": "^2.3.1"
 	},
 	"peerDependencies": {
 		"react": "^17.0.0",

--- a/packages/edit-widgets/src/components/keyboard-shortcut-help-modal/shortcut.js
+++ b/packages/edit-widgets/src/components/keyboard-shortcut-help-modal/shortcut.js
@@ -1,9 +1,4 @@
 /**
- * External dependencies
- */
-import { castArray } from 'lodash';
-
-/**
  * WordPress dependencies
  */
 import { Fragment } from '@wordpress/element';
@@ -20,13 +15,14 @@ function KeyCombination( { keyCombination, forceAriaLabel } ) {
 				keyCombination.character
 		  )
 		: keyCombination.character;
+	const shortcuts = Array.isArray( shortcut ) ? shortcut : [ shortcut ];
 
 	return (
 		<kbd
 			className="edit-widgets-keyboard-shortcut-help-modal__shortcut-key-combination"
 			aria-label={ forceAriaLabel || ariaLabel }
 		>
-			{ castArray( shortcut ).map( ( character, index ) => {
+			{ shortcuts.map( ( character, index ) => {
 				if ( character === '+' ) {
 					return <Fragment key={ index }>{ character }</Fragment>;
 				}

--- a/packages/edit-widgets/src/components/more-menu/tools-more-menu-group.js
+++ b/packages/edit-widgets/src/components/more-menu/tools-more-menu-group.js
@@ -1,9 +1,4 @@
 /**
- * External dependencies
- */
-import { isEmpty } from 'lodash';
-
-/**
  * WordPress dependencies
  */
 import { createSlotFill } from '@wordpress/components';
@@ -14,7 +9,7 @@ const { Fill: ToolsMoreMenuGroup, Slot } = createSlotFill(
 
 ToolsMoreMenuGroup.Slot = ( { fillProps } ) => (
 	<Slot fillProps={ fillProps }>
-		{ ( fills ) => ! isEmpty( fills ) && fills }
+		{ ( fills ) => fills.length > 0 && fills }
 	</Slot>
 );
 

--- a/packages/edit-widgets/src/components/notices/index.js
+++ b/packages/edit-widgets/src/components/notices/index.js
@@ -1,9 +1,4 @@
 /**
- * External dependencies
- */
-import { filter } from 'lodash';
-
-/**
  * WordPress dependencies
  */
 import { NoticeList, SnackbarList } from '@wordpress/components';
@@ -18,17 +13,15 @@ function Notices() {
 		};
 	}, [] );
 
-	const dismissibleNotices = filter( notices, {
-		isDismissible: true,
-		type: 'default',
-	} );
-	const nonDismissibleNotices = filter( notices, {
-		isDismissible: false,
-		type: 'default',
-	} );
-	const snackbarNotices = filter( notices, {
-		type: 'snackbar',
-	} );
+	const dismissibleNotices = notices.filter(
+		( { isDismissible, type } ) => isDismissible && type === 'default'
+	);
+	const nonDismissibleNotices = notices.filter(
+		( { isDismissible, type } ) => ! isDismissible && type === 'default'
+	);
+	const snackbarNotices = notices.filter(
+		( { type } ) => type === 'snackbar'
+	);
 
 	return (
 		<>


### PR DESCRIPTION
## What?
This PR removes all of the Lodash occurrences from the `@wordpress/edit-widgets` package, and Lodash as a dependency altogether. 

## Why?

Lodash is known to unnecessarily inflate the bundle size of packages, and in most cases, it can be replaced with native language functionality. See these for more information and rationale:

* https://github.com/WordPress/gutenberg/issues/16938#issuecomment-602837246
* https://github.com/WordPress/gutenberg/issues/17025
* https://github.com/WordPress/gutenberg/issues/39495

While this PR doesn't affect bundle size at all (because this package's code is not bundled), it still is a step forward in the direction of completely getting rid of Lodash in Gutenberg. 

## How?
We're replacing every Lodash call with native functionality. 

## Testing Instructions

* Make sure you're working with a theme that supports widgets (has 1 or more sidebars defined).
* Verify keyboard shortcuts modal still works well.
* Verify notices still work well.
* To verify `ToolsMoreMenuGroup` still works well, register a few fills there (there are none by default).