### PR TITLE
Social Link: Fix background color on WhatsApp icon.

### DIFF
--- a/packages/block-library/src/social-link/socials-without-bg.scss
+++ b/packages/block-library/src/social-link/socials-without-bg.scss
@@ -144,8 +144,7 @@
 }
 
 .wp-social-link-whatsapp {
-	background-color: #25d366;
-	color: #fff;
+	color: #25d366;
 }
 
 .wp-social-link-wordpress {


### PR DESCRIPTION
Related to comment here: https://github.com/WordPress/gutenberg/pull/42137#issuecomment-1230084478

## What?
Fix the WhatsApp variation of the Social Link block so there is no background color when set to "Logos Only".

## Why?
The background color on the WhatsApp variation of the Social Link block was not set correctly. This PR fixes that.

## How?
Fix the incorrect background color specification.

## Testing Instructions
1. Add a Social Icons block
2. Add a WhatsApp icon
3. Switch to "Logos Only" and confirm that there is no background color.

## Screenshots or screencast

Before:
![image](https://user-images.githubusercontent.com/4832319/187236934-7d370847-74de-4fa7-b9ef-7c565a836154.png)

After:
![image](https://user-images.githubusercontent.com/4832319/187236977-71b800d7-3d73-4f52-b030-2508c394fec4.png)


