### PR TITLE
fix: Latest Posts categories settings

### DIFF
--- a/packages/components/src/select-control/index.native.js
+++ b/packages/components/src/select-control/index.native.js
@@ -7,7 +7,7 @@ import { memo } from '@wordpress/element';
  */
 import PickerCell from '../mobile/bottom-sheet/picker-cell';
 
-const SelectControl = memo(
+export const SelectControl = memo(
 	( {
 		help,
 		instanceId,


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->
Fix an error thrown in the native editor when opening the _Latest Posts_ block settings.

<details><summary>Error Text</summary>

```
 ERROR  Error: Element type is invalid: expected a string (for built-in components) or a class/function (for composite components) but got: undefined. You likely forgot to export your component from the file it's defined in, or you might have mixed up default and named imports.

Check the render method of `TreeSelect`.

This error is located at:
    in TreeSelect (at category-select.js:24)
    in CategorySelect (at query-controls/index.native.js:76)
    in Unknown (at edit.native.js:220)
    in RCTView (at View.js:32)
    in View (at body.native.js:14)
    in PanelBody (at edit.native.js:219)
    [...truncated for brevity...]
```

</details>

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
Errors and crashes degrade the user experience.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
Add a named export to `SelectControl` so the native module aligns with the web module. The use of a named export was added to code shared between web and native. Because the latter only defined a default export, an error was thrown.

- Named export added: https://github.com/WordPress/gutenberg/pull/40737
- Named export used: https://github.com/WordPress/gutenberg/pull/41536

I am uncertain as to why a named export was added originally. My presumption is that it was recently used so that the import was a local reference, instead of a importing the module's top-level entry file.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->
1. Launch the Demo editor using the local development server.<sup>1</sup>
1. Add a _Latest Posts_ block. 
1. Tap _CUSTOMIZE_ to open the block settings.
1. Verify the app does not crash and the _Category_ field is present.

_1. The relevant Category field is [only displayed](https://github.com/WordPress/gutenberg/commit/75570240f9a2f65f3fe997e5309514212e16d2cf) in the development environment currently._

## Screenshots or screencast <!-- if applicable -->
n/a
