### PR TITLE
Fix display of width controls for legacy layouts

### DIFF
--- a/packages/block-editor/src/hooks/layout.js
+++ b/packages/block-editor/src/hooks/layout.js
@@ -141,6 +141,9 @@ function LayoutPanel( { setAttributes, attributes, name: blockName } ) {
 
 	const constrainedType = getLayoutType( 'constrained' );
 
+	const displayControlsForLegacyLayouts =
+		! usedLayout.type && ( contentSize || inherit );
+
 	const onChangeType = ( newType ) =>
 		setAttributes( { layout: { type: newType } } );
 	const onChangeLayout = ( newLayout ) =>
@@ -200,7 +203,7 @@ function LayoutPanel( { setAttributes, attributes, name: blockName } ) {
 							layoutBlockSupport={ layoutBlockSupport }
 						/>
 					) }
-					{ constrainedType && !! contentSize && (
+					{ constrainedType && displayControlsForLegacyLayouts && (
 						<constrainedType.inspectorControls
 							layout={ usedLayout }
 							onChange={ onChangeLayout }


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Fixes display of custom content/wide width controls for blocks that have legacy "inherit" and "contentSize" attributes.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->

Try the following test markup:

```
<!-- wp:query {"queryId":0,"query":{"perPage":10,"pages":0,"offset":0,"postType":"post","order":"desc","orderBy":"date","author":"","search":"","exclude":[],"sticky":"","inherit":false},"tagName":"main","displayLayout":{"type":"list"},"style":{"elements":{"link":{"color":{"text":"#5f1c1c"}}}},"backgroundColor":"luminous-vivid-amber","textColor":"black","layout":{"inherit":true}} -->
<main class="wp-block-query has-black-color has-luminous-vivid-amber-background-color has-text-color has-background has-link-color"><!-- wp:heading -->
<h2>My query loop</h2>
<!-- /wp:heading -->

<!-- wp:post-template {"align":"wide"} -->
<!-- wp:post-title {"isLink":true} /-->

<!-- wp:post-excerpt /-->
<!-- /wp:post-template -->

<!-- wp:query-pagination {"paginationArrow":"arrow","align":"wide","layout":{"type":"flex","justifyContent":"space-between"}} -->
<!-- wp:query-pagination-previous {"fontSize":"small"} /-->

<!-- wp:query-pagination-numbers /-->

<!-- wp:query-pagination-next {"fontSize":"small"} /-->
<!-- /wp:query-pagination --></main>
<!-- /wp:query -->
```
and
```
<!-- wp:columns -->
<div class="wp-block-columns"><!-- wp:column {"layout":{"contentSize":"340px"}} -->
<div class="wp-block-column"></div>
<!-- /wp:column -->

<!-- wp:column -->
<div class="wp-block-column"></div>
<!-- /wp:column -->

<!-- wp:column -->
<div class="wp-block-column"></div>
<!-- /wp:column --></div>
<!-- /wp:columns -->
```

Check that both the Query block and the first Column in the Columns block display the "content" and "wide" controls in the sidebar Layout section.

Also chech that the bug reported [here](https://github.com/WordPress/gutenberg/issues/33374#issuecomment-1230204864) is fixed:

1. Add a Group block;
2. Add a value to the "content" field;
3. Check that "content" and "wide" fields aren't duplicated.

## Screenshots or screencast <!-- if applicable -->

<img width="281" alt="Screen Shot 2022-08-30 at 9 37 58 am" src="https://user-images.githubusercontent.com/8096000/187317110-d884c013-3c03-4250-9495-bfbfc04b7c48.png">
