### PR TITLE
Layout: Fix has-global-padding classname for constrained layouts without contentSize

### DIFF
--- a/lib/block-supports/layout.php
+++ b/lib/block-supports/layout.php
@@ -291,14 +291,13 @@ function gutenberg_render_layout_support_flag( $block_content, $block ) {
 	$block_classname    = wp_get_block_default_classname( $block['blockName'] );
 	$container_class    = wp_unique_id( 'wp-container-' );
 	$layout_classname   = '';
-	$use_global_padding = gutenberg_get_global_settings( array( 'useRootPaddingAwareAlignments' ) ) && ( isset( $used_layout['inherit'] ) && $used_layout['inherit'] || isset( $used_layout['contentSize'] ) && $used_layout['contentSize'] );
 
 	// Set the correct layout type for blocks using legacy content width.
 	if ( isset( $used_layout['inherit'] ) && $used_layout['inherit'] || isset( $used_layout['contentSize'] ) && $used_layout['contentSize'] ) {
 		$used_layout['type'] = 'constrained';
 	}
 
-	if ( $use_global_padding ) {
+	if ( gutenberg_get_global_settings( array( 'useRootPaddingAwareAlignments' ) ) && 'constrained' === $used_layout['type'] ) {
 		$class_names[] = 'has-global-padding';
 	}
 

--- a/packages/block-editor/src/hooks/layout.js
+++ b/packages/block-editor/src/hooks/layout.js
@@ -63,7 +63,12 @@ function useLayoutClasses( layout, layoutDefinitions ) {
 		);
 	}
 
-	if ( ( layout?.inherit || layout?.contentSize ) && rootPaddingAlignment ) {
+	if (
+		( layout?.inherit ||
+			layout?.contentSize ||
+			layout?.type === 'constrained' ) &&
+		rootPaddingAlignment
+	) {
 		layoutClassnames.push( 'has-global-padding' );
 	}
 


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Fixes https://github.com/WordPress/gutenberg/issues/43673

For the constrained layout type, if `settings.useRootPaddingAwareAlignments` is set to `true` then ensure that `has-global-classname` is always output irrespective of whether or not `contentSize` is explicitly set.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

Prior to the introduction of the constrained layout type, there was always a `contentSize` value if content sizes were in use — however with the new constrained layout type, if no value is set, then it defaults to outputting rules using the global CSS variable, so the logic for when to output the `has-global-padding` classname needed to be updated.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

* In `layout.php` always output `has-global-padding` if the inferred layout type is `constrained` and the root padding aware alignments flag is set to `true`
* In `layout.js` update the logic for outputting `has-global-padding` to include a `constrained` layout type check.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->

1. Set `settings.useRootPaddingAwareAlignments` to `false` and ensure that the `has-global-padding` classname is _not_ output for the Group block, irrespective of whether or not it has a contentSize applied
2. Set `settings.useRootPaddingAwareAlignments` to `true`, and so long as the `Inner blocks respect content width` toggle is switched on (the constrained layout type is in use), then the `has-global-padding` classname should be output, irrespective of whether or not a custom `contentSize` is provided

## Screenshots or screencast <!-- if applicable -->

With this PR applied, classnames should be output as expected:

<img width="657" alt="image" src="https://user-images.githubusercontent.com/14988353/187317997-e146a6c5-0c7b-4cbf-81db-54ecf56a9889.png">

