### PR TITLE
Style engine: run compiled inline CSS through esc attr

### DIFF
--- a/packages/style-engine/class-wp-style-engine.php
+++ b/packages/style-engine/class-wp-style-engine.php
@@ -395,7 +395,7 @@ class WP_Style_Engine {
 			if ( ! $should_skip_css_vars && ! empty( $style_definition['css_vars'] ) ) {
 				$css_var = static::get_css_var_value( $style_value, $style_definition['css_vars'] );
 				if ( static::is_valid_style_value( $css_var ) ) {
-					$css_declarations[ $style_property_keys['default'] ] = esc_attr( $css_var );
+					$css_declarations[ $style_property_keys['default'] ] = $css_var;
 				}
 			}
 			return $css_declarations;
@@ -418,14 +418,14 @@ class WP_Style_Engine {
 				$individual_property = sprintf( $style_property_keys['individual'], _wp_to_kebab_case( $key ) );
 
 				if ( $individual_property && static::is_valid_style_value( $value ) ) {
-					$css_declarations[ $individual_property ] = esc_attr( $value );
+					$css_declarations[ $individual_property ] = $value;
 				}
 			}
 
 			return $css_declarations;
 		}
 
-		$css_declarations[ $style_property_keys['default'] ] = esc_attr( $style_value );
+		$css_declarations[ $style_property_keys['default'] ] = $style_value;
 		return $css_declarations;
 	}
 
@@ -498,7 +498,7 @@ class WP_Style_Engine {
 		}
 
 		$css_declarations = new WP_Style_Engine_CSS_Declarations( $css_declarations );
-		return $css_declarations->get_declarations_string();
+		return esc_attr( $css_declarations->get_declarations_string() );
 	}
 
 	/**

--- a/packages/style-engine/class-wp-style-engine.php
+++ b/packages/style-engine/class-wp-style-engine.php
@@ -472,7 +472,7 @@ class WP_Style_Engine {
 					$value = static::get_css_var_value( $value, $individual_property_definition['css_vars'] );
 				}
 				$individual_css_property                      = sprintf( $style_definition['property_keys']['individual'], $individual_property_key );
-				$css_declarations[ $individual_css_property ] = esc_attr( $value );
+				$css_declarations[ $individual_css_property ] = $value;
 			}
 		}
 		return $css_declarations;
@@ -497,6 +497,7 @@ class WP_Style_Engine {
 			return $css_rule->get_css();
 		}
 
+		// There is no selector, so the assumption is a declarations string in a style attribute.
 		$css_declarations = new WP_Style_Engine_CSS_Declarations( $css_declarations );
 		return esc_attr( $css_declarations->get_declarations_string() );
 	}

--- a/packages/style-engine/class-wp-style-engine.php
+++ b/packages/style-engine/class-wp-style-engine.php
@@ -395,7 +395,7 @@ class WP_Style_Engine {
 			if ( ! $should_skip_css_vars && ! empty( $style_definition['css_vars'] ) ) {
 				$css_var = static::get_css_var_value( $style_value, $style_definition['css_vars'] );
 				if ( static::is_valid_style_value( $css_var ) ) {
-					$css_declarations[ $style_property_keys['default'] ] = $css_var;
+					$css_declarations[ $style_property_keys['default'] ] = esc_attr( $css_var );
 				}
 			}
 			return $css_declarations;
@@ -418,14 +418,14 @@ class WP_Style_Engine {
 				$individual_property = sprintf( $style_property_keys['individual'], _wp_to_kebab_case( $key ) );
 
 				if ( $individual_property && static::is_valid_style_value( $value ) ) {
-					$css_declarations[ $individual_property ] = $value;
+					$css_declarations[ $individual_property ] = esc_attr( $value );
 				}
 			}
 
 			return $css_declarations;
 		}
 
-		$css_declarations[ $style_property_keys['default'] ] = $style_value;
+		$css_declarations[ $style_property_keys['default'] ] = esc_attr( $style_value );
 		return $css_declarations;
 	}
 
@@ -472,7 +472,7 @@ class WP_Style_Engine {
 					$value = static::get_css_var_value( $value, $individual_property_definition['css_vars'] );
 				}
 				$individual_css_property                      = sprintf( $style_definition['property_keys']['individual'], $individual_property_key );
-				$css_declarations[ $individual_css_property ] = $value;
+				$css_declarations[ $individual_css_property ] = esc_attr( $value );
 			}
 		}
 		return $css_declarations;

--- a/packages/style-engine/phpunit/class-wp-style-engine-test.php
+++ b/packages/style-engine/phpunit/class-wp-style-engine-test.php
@@ -92,10 +92,10 @@ class WP_Style_Engine_Test extends WP_UnitTestCase {
 				),
 				'options'         => null,
 				'expected_output' => array(
-					'css'          => 'color:#ffffff;000000;',
+					'css'          => 'color:#ffffff;background-color:#&#039;000000;',
 					'declarations' => array(
 						'color'            => '#ffffff',
-						'background-color' => '#&#039;000000',
+						'background-color' => '#\'000000',
 					),
 					'classnames'   => 'has-text-color has-background',
 				),

--- a/packages/style-engine/phpunit/class-wp-style-engine-test.php
+++ b/packages/style-engine/phpunit/class-wp-style-engine-test.php
@@ -83,6 +83,24 @@ class WP_Style_Engine_Test extends WP_UnitTestCase {
 				'expected_output' => array(),
 			),
 
+			'inline_with_escaped_attributes'               => array(
+				'block_styles'    => array(
+					'color' => array(
+						'text'       => '#ffffff',
+						'background' => '#\'000000',
+					),
+				),
+				'options'         => null,
+				'expected_output' => array(
+					'css'          => 'color:#ffffff;000000;',
+					'declarations' => array(
+						'color'            => '#ffffff',
+						'background-color' => '#&#039;000000',
+					),
+					'classnames'   => 'has-text-color has-background',
+				),
+			),
+
 			'valid_inline_css_and_classnames_as_default_context' => array(
 				'block_styles'    => array(
 					'color'   => array(


### PR DESCRIPTION


## What?
Runs compiled CSS through [esc_attr](https://developer.wordpress.org/reference/functions/esc_attr/) where there is no selector, and the assumption is that the output will be used in an HTML style tag.

## Why?
Escape early.

## How?
[esc_attr](https://developer.wordpress.org/reference/functions/esc_attr/)


## Testing
`npm run test:unit:php /var/www/html/wp-content/plugins/gutenberg/packages/style-engine/phpunit/class-wp-style-engine-test.php`