### PR TITLE
Block toolbar: use Popover's new anchor prop

### DIFF
--- a/packages/block-editor/src/components/block-popover/index.js
+++ b/packages/block-editor/src/components/block-popover/index.js
@@ -57,7 +57,7 @@ function BlockPopover(
 				// Get the biggest rectangle that encompasses completely the currently
 				// selected element and the last selected element:
 				// - for top/left coordinates, use the smaller numbers
-				// - for the bottom/right coordinates, use the larget numbers
+				// - for the bottom/right coordinates, use the largest numbers
 				const left = Math.min( selectedBCR.left, lastSelectedBCR.left );
 				const top = Math.min( selectedBCR.top, lastSelectedBCR.top );
 				const right = Math.max(

--- a/packages/block-editor/src/components/block-popover/index.js
+++ b/packages/block-editor/src/components/block-popover/index.js
@@ -47,14 +47,40 @@ function BlockPopover(
 		};
 	}, [ selectedElement, lastSelectedElement, __unstableRefreshSize ] );
 
+	const popoverAnchor = useMemo(
+		() => ( {
+			getBoundingClientRect() {
+				const selectedBCR = selectedElement.getBoundingClientRect();
+				const lastSelectedBCR =
+					lastSelectedElement.getBoundingClientRect();
+
+				// Get the biggest rectangle that encompasses completely the currently
+				// selected element and the last selected element:
+				// - for top/left coordinates, use the smaller numbers
+				// - for the bottom/right coordinates, use the larget numbers
+				const left = Math.min( selectedBCR.left, lastSelectedBCR.left );
+				const top = Math.min( selectedBCR.top, lastSelectedBCR.top );
+				const right = Math.max(
+					selectedBCR.right,
+					lastSelectedBCR.right
+				);
+				const bottom = Math.max(
+					selectedBCR.bottom,
+					lastSelectedBCR.bottom
+				);
+				const width = right - left;
+				const height = bottom - top;
+
+				return new window.DOMRect( left, top, width, height );
+			},
+			ownerDocument: selectedElement.ownerDocument,
+		} ),
+		[ selectedElement, lastSelectedElement ]
+	);
+
 	if ( ! selectedElement || ( bottomClientId && ! lastSelectedElement ) ) {
 		return null;
 	}
-
-	const anchorRef = {
-		top: selectedElement,
-		bottom: lastSelectedElement,
-	};
 
 	return (
 		<Popover
@@ -62,7 +88,7 @@ function BlockPopover(
 			animate={ false }
 			position="top right left"
 			focusOnMount={ false }
-			anchorRef={ anchorRef }
+			anchor={ popoverAnchor }
 			// Render in the old slot if needed for backward compatibility,
 			// otherwise render in place (not in the default popover slot).
 			__unstableSlotName={ __unstablePopoverSlot || null }


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Refactor the way the block toolbar Popover's anchor is defined, using the new `anchor` prop

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

See #43691 for more context

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

The logic for showing the popover is the same, but is now part of the block toolbar component.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->

In the editor, select blocks (both single block, and multiple block selections) and make sure that:

 - the behaviour is the same as on `trunk`
 - there's no warning in the console when a new block is selected

**Unit test failures caused by console warnings are expected. The reviews on this PR should focus on the specific refactor to `anchor` prop. This PR will be merged into #43691, so there will be another chance in that PR to give a final review.**