### PR TITLE
Block inbetween inserter: use Popover's new anchor prop

### DIFF
--- a/packages/block-editor/src/components/block-popover/inbetween.js
+++ b/packages/block-editor/src/components/block-popover/inbetween.js
@@ -7,7 +7,7 @@ import classnames from 'classnames';
  * WordPress dependencies
  */
 import { useSelect } from '@wordpress/data';
-import { useCallback, useMemo, createContext } from '@wordpress/element';
+import { useMemo, createContext } from '@wordpress/element';
 import { Popover } from '@wordpress/components';
 import { isRTL } from '@wordpress/i18n';
 
@@ -91,66 +91,81 @@ function BlockPopoverInbetween( {
 		};
 	}, [ previousElement, nextElement, isVertical ] );
 
-	const getAnchorRect = useCallback( () => {
+	const popoverAnchor = useMemo( () => {
 		if ( ( ! previousElement && ! nextElement ) || ! isVisible ) {
-			return {};
+			return undefined;
 		}
 
 		const { ownerDocument } = previousElement || nextElement;
 
-		const previousRect = previousElement
-			? previousElement.getBoundingClientRect()
-			: null;
-		const nextRect = nextElement
-			? nextElement.getBoundingClientRect()
-			: null;
+		return {
+			ownerDocument,
+			getBoundingClientRect() {
+				const previousRect = previousElement
+					? previousElement.getBoundingClientRect()
+					: null;
+				const nextRect = nextElement
+					? nextElement.getBoundingClientRect()
+					: null;
 
-		if ( isVertical ) {
-			if ( isRTL() ) {
+				if ( isVertical ) {
+					if ( isRTL() ) {
+						return {
+							top: previousRect
+								? previousRect.bottom
+								: nextRect.top,
+							left: previousRect
+								? previousRect.right
+								: nextRect.right,
+							right: previousRect
+								? previousRect.left
+								: nextRect.left,
+							bottom: nextRect
+								? nextRect.top
+								: previousRect.bottom,
+							height: 0,
+							width: 0,
+						};
+					}
+
+					return {
+						top: previousRect ? previousRect.bottom : nextRect.top,
+						left: previousRect ? previousRect.left : nextRect.left,
+						right: previousRect
+							? previousRect.right
+							: nextRect.right,
+						bottom: nextRect ? nextRect.top : previousRect.bottom,
+						height: 0,
+						width: 0,
+					};
+				}
+
+				if ( isRTL() ) {
+					return {
+						top: previousRect ? previousRect.top : nextRect.top,
+						left: previousRect ? previousRect.left : nextRect.right,
+						right: nextRect ? nextRect.right : previousRect.left,
+						bottom: previousRect
+							? previousRect.bottom
+							: nextRect.bottom,
+						height: 0,
+						width: 0,
+					};
+				}
+
 				return {
-					top: previousRect ? previousRect.bottom : nextRect.top,
-					left: previousRect ? previousRect.right : nextRect.right,
-					right: previousRect ? previousRect.left : nextRect.left,
-					bottom: nextRect ? nextRect.top : previousRect.bottom,
+					top: previousRect ? previousRect.top : nextRect.top,
+					left: previousRect ? previousRect.right : nextRect.left,
+					right: nextRect ? nextRect.left : previousRect.right,
+					bottom: previousRect
+						? previousRect.bottom
+						: nextRect.bottom,
 					height: 0,
 					width: 0,
-					ownerDocument,
 				};
-			}
-
-			return {
-				top: previousRect ? previousRect.bottom : nextRect.top,
-				left: previousRect ? previousRect.left : nextRect.left,
-				right: previousRect ? previousRect.right : nextRect.right,
-				bottom: nextRect ? nextRect.top : previousRect.bottom,
-				height: 0,
-				width: 0,
-				ownerDocument,
-			};
-		}
-
-		if ( isRTL() ) {
-			return {
-				top: previousRect ? previousRect.top : nextRect.top,
-				left: previousRect ? previousRect.left : nextRect.right,
-				right: nextRect ? nextRect.right : previousRect.left,
-				bottom: previousRect ? previousRect.bottom : nextRect.bottom,
-				height: 0,
-				width: 0,
-				ownerDocument,
-			};
-		}
-
-		return {
-			top: previousRect ? previousRect.top : nextRect.top,
-			left: previousRect ? previousRect.right : nextRect.left,
-			right: nextRect ? nextRect.left : previousRect.right,
-			bottom: previousRect ? previousRect.bottom : nextRect.bottom,
-			height: 0,
-			width: 0,
-			ownerDocument,
+			},
 		};
-	}, [ previousElement, nextElement ] );
+	}, [ previousElement, nextElement, isVisible ] );
 
 	const popoverScrollRef = usePopoverScroll( __unstableContentRef );
 
@@ -172,7 +187,7 @@ function BlockPopoverInbetween( {
 		<Popover
 			ref={ popoverScrollRef }
 			animate={ false }
-			getAnchorRect={ getAnchorRect }
+			anchor={ popoverAnchor }
 			focusOnMount={ false }
 			// Render in the old slot if needed for backward compatibility,
 			// otherwise render in place (not in the default popover slot).

--- a/packages/block-editor/src/components/block-popover/inbetween.js
+++ b/packages/block-editor/src/components/block-popover/inbetween.js
@@ -89,7 +89,7 @@ function BlockPopoverInbetween( {
 				? previousElement.offsetHeight
 				: nextElement.offsetHeight,
 		};
-	}, [ previousElement, nextElement, isVertical ] );
+	}, [ previousElement, nextElement, isVisible, isVertical ] );
 
 	const popoverAnchor = useMemo( () => {
 		if ( ( ! previousElement && ! nextElement ) || ! isVisible ) {
@@ -137,7 +137,7 @@ function BlockPopoverInbetween( {
 				return new window.DOMRect( left, top, 0, 0 );
 			},
 		};
-	}, [ previousElement, nextElement, isVisible ] );
+	}, [ previousElement, nextElement, isVisible, isVertical ] );
 
 	const popoverScrollRef = usePopoverScroll( __unstableContentRef );
 

--- a/packages/block-editor/src/components/block-popover/inbetween.js
+++ b/packages/block-editor/src/components/block-popover/inbetween.js
@@ -101,68 +101,40 @@ function BlockPopoverInbetween( {
 		return {
 			ownerDocument,
 			getBoundingClientRect() {
-				const previousRect = previousElement
+				const prevRect = previousElement
 					? previousElement.getBoundingClientRect()
 					: null;
 				const nextRect = nextElement
 					? nextElement.getBoundingClientRect()
 					: null;
 
+				let left = 0;
+				let top = 0;
+
 				if ( isVertical ) {
+					// vertical
+					top = prevRect ? prevRect.bottom : nextRect.top;
+
 					if ( isRTL() ) {
-						return {
-							top: previousRect
-								? previousRect.bottom
-								: nextRect.top,
-							left: previousRect
-								? previousRect.right
-								: nextRect.right,
-							right: previousRect
-								? previousRect.left
-								: nextRect.left,
-							bottom: nextRect
-								? nextRect.top
-								: previousRect.bottom,
-							height: 0,
-							width: 0,
-						};
+						// vertical, rtl
+						left = prevRect ? prevRect.right : nextRect.right;
+					} else {
+						// vertical, ltr
+						left = prevRect ? prevRect.left : nextRect.left;
 					}
+				} else {
+					top = prevRect ? prevRect.top : nextRect.top;
 
-					return {
-						top: previousRect ? previousRect.bottom : nextRect.top,
-						left: previousRect ? previousRect.left : nextRect.left,
-						right: previousRect
-							? previousRect.right
-							: nextRect.right,
-						bottom: nextRect ? nextRect.top : previousRect.bottom,
-						height: 0,
-						width: 0,
-					};
+					if ( isRTL() ) {
+						// non vertical, rtl
+						left = prevRect ? prevRect.left : nextRect.right;
+					} else {
+						// non vertical, ltr
+						left = prevRect ? prevRect.right : nextRect.left;
+					}
 				}
 
-				if ( isRTL() ) {
-					return {
-						top: previousRect ? previousRect.top : nextRect.top,
-						left: previousRect ? previousRect.left : nextRect.right,
-						right: nextRect ? nextRect.right : previousRect.left,
-						bottom: previousRect
-							? previousRect.bottom
-							: nextRect.bottom,
-						height: 0,
-						width: 0,
-					};
-				}
-
-				return {
-					top: previousRect ? previousRect.top : nextRect.top,
-					left: previousRect ? previousRect.right : nextRect.left,
-					right: nextRect ? nextRect.left : previousRect.right,
-					bottom: previousRect
-						? previousRect.bottom
-						: nextRect.bottom,
-					height: 0,
-					width: 0,
-				};
+				return new window.DOMRect( left, top, 0, 0 );
 			},
 		};
 	}, [ previousElement, nextElement, isVisible ] );


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Refactor the way the block inbetween inserter Popover's anchor is defined, using the new `anchor` prop

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

See #43691 for more context

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

The logic for showing the popover is the same, but is now part of the block toolbar component.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->

In the editor, hover over the space inbetween blocks, in order to trigger to cause the inbetween inserter to appear and make sure that:

 - the behavior is the same as on `trunk`
 - there's no warning in the console when the inbetween inserter popover is rendered

**Unit test failures caused by console warnings are expected. The reviews on this PR should focus on the specific refactor to `anchor` prop. This PR will be merged into #43691, so there will be another chance in that PR to give a final review.**