### PR TITLE
Dropdown: use Popover's new anchor prop

### DIFF
--- a/packages/components/src/dropdown/index.js
+++ b/packages/components/src/dropdown/index.js
@@ -83,7 +83,10 @@ export default function Dropdown( props ) {
 	}
 
 	const args = { isOpen, onToggle: toggle, onClose: close };
-	const hasAnchorRef =
+	const hasPopoverAnchor =
+		!! popoverProps?.anchor ||
+		// Note: `anchorRef`, `getAnchorRect` and `anchorRect` are deprecated and
+		// be removed from `Popover` from WordPress 6.3
 		!! popoverProps?.anchorRef ||
 		!! popoverProps?.getAnchorRect ||
 		!! popoverProps?.anchorRect;
@@ -110,7 +113,9 @@ export default function Dropdown( props ) {
 					// This value is used to ensure that the dropdowns
 					// align with the editor header by default.
 					offset={ 13 }
-					anchorRef={ ! hasAnchorRef ? containerRef : undefined }
+					anchor={
+						! hasPopoverAnchor ? containerRef.current : undefined
+					}
 					{ ...popoverProps }
 					className={ classnames(
 						'components-dropdown__content',


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Refactor the way the Dropdown component passes an anchor to Popover, using the new `anchor` prop

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

See #43691 for more context

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

When no anchor is being forwarded to `Popover`, use the `anchor` prop instead of `anchorRef`

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->

<!--
In the editor, open various popovers and make sure that:

 - the behaviour is the same as on `trunk`
 - there's no warning in the console when a new block is selected
 -->

`Dropdown` storybook examples work without warnings
`Dropdown` unit tests pass without warnings.

**Unit test failures caused by console warnings are expected. The reviews on this PR should focus on the specific refactor to `anchor` prop. This PR will be merged into #43691, so there will be another chance in that PR to give a final review.**