### PR TITLE
Template for specific category: only load posts from that category in post template block

### DIFF
--- a/packages/block-library/src/post-template/edit.js
+++ b/packages/block-library/src/post-template/edit.js
@@ -96,7 +96,7 @@ export default function PostTemplateEdit( {
 	const [ activeBlockContextId, setActiveBlockContextId ] = useState();
 
 	let categorySlug = null;
-	if ( templateSlug.startsWith( 'category-' ) ) {
+	if ( templateSlug?.startsWith( 'category-' ) ) {
 		categorySlug = templateSlug.replace( 'category-', '' );
 	}
 	const { records: categories, hasResolved: hasResolvedCategories } =
@@ -199,6 +199,8 @@ export default function PostTemplateEdit( {
 			taxQuery,
 			parents,
 			previewPostType,
+			categories,
+			categorySlug,
 			hasResolvedCategories,
 		]
 	);


### PR DESCRIPTION
## What

This PR makes the post template block to load only the posts from a specific category when the 1) the query block is set to inherit the filters from the template and 2) the user is editing the template of a specific category.

## Why 

We want to present the users with the contextual data they're editing. Part of https://github.com/WordPress/gutenberg/issues/41947

## How?

This PR continues the work started at #27128 (allow query to inherit from template) and #27972 (introduce `templateSlug` data to decouple from edit-site).

It inspects the value of the existing `templateSlug` and if it's `category-<slug>` it uses that info to prepare the query.

## Testing Instructions

- I've tested this using TwentyTwentyTwo.
- Create some categories in your site and assign some posts to them.
- I've added the category in the title of the post for make verification easier.
- Go to site editor and create a new template for one of the items you've created.
- Verify that the query block in site editor loads only the posts from that category.
- Inspect the query inspector and unselect the "Inherit query from template" toggle. Verify that the post list contains now items from all categories.

[Gravação de ecrã a partir de 30-08-2022 12:13:24.webm](https://user-images.githubusercontent.com/583546/187411764-8497a763-3d11-465d-8f49-976afdf5254a.webm)

