### PR TITLE
Site Logo: Fix border radius regression

### DIFF
--- a/packages/block-library/src/site-logo/editor.scss
+++ b/packages/block-library/src/site-logo/editor.scss
@@ -44,6 +44,7 @@
 		justify-content: center;
 		align-items: center;
 		padding: 0;
+		border-radius: inherit;
 
 		// Provide a minimum size for the placeholder, for when the logo is resized.
 		// @todo: resizing is currently only possible by adding an image, resizing,


### PR DESCRIPTION
## What?

When set to "Rounded", the Site Logo should be rounded even in the setup state. This has regressed recently:
<img width="494" alt="Screenshot 2022-08-30 at 13 36 45" src="https://user-images.githubusercontent.com/1204802/187427181-2f1eb5ed-8378-4dbe-8228-5621e6f4ae47.png">

This PR fixes it:


<img width="518" alt="Screenshot 2022-08-30 at 13 37 40" src="https://user-images.githubusercontent.com/1204802/187427201-e5c9fe63-bc1f-44c4-8b77-41a28ebed00e.png">

## Testing Instructions

Insert a site logo in placeholder state, set it to "Rounded" in the inspector, and observe that it's rounded.