### PR TITLE
Content width toggle: Polish wording and appearance

### DIFF
--- a/packages/block-editor/src/hooks/layout.js
+++ b/packages/block-editor/src/hooks/layout.js
@@ -153,9 +153,7 @@ function LayoutPanel( { setAttributes, attributes, name: blockName } ) {
 					{ showInheritToggle && (
 						<>
 							<ToggleControl
-								label={ __(
-									'Inner blocks respect content width'
-								) }
+								label={ __( 'Constrain inner blocks' ) }
 								checked={
 									layoutType?.name === 'constrained' ||
 									!! inherit ||
@@ -172,17 +170,17 @@ function LayoutPanel( { setAttributes, attributes, name: blockName } ) {
 										},
 									} )
 								}
+								help={
+									!! inherit ||
+									layoutType?.name === 'constrained'
+										? __(
+												'Nested blocks use content width with options for full and wide widths.'
+										  )
+										: __(
+												'Nested blocks will fill the width of this container. Toggle to constrain.'
+										  )
+								}
 							/>
-							<p className="block-editor-hooks__layout-controls-helptext">
-								{ !! inherit ||
-								layoutType?.name === 'constrained'
-									? __(
-											'Nested blocks use theme content width with options for full and wide widths.'
-									  )
-									: __(
-											'Nested blocks will fill the width of this container.'
-									  ) }
-							</p>
 						</>
 					) }
 

--- a/packages/block-editor/src/hooks/layout.js
+++ b/packages/block-editor/src/hooks/layout.js
@@ -153,7 +153,7 @@ function LayoutPanel( { setAttributes, attributes, name: blockName } ) {
 					{ showInheritToggle && (
 						<>
 							<ToggleControl
-								label={ __( 'Constrain inner blocks' ) }
+								label={ __( 'Custom width of inner blocks' ) }
 								checked={
 									layoutType?.name === 'constrained' ||
 									!! inherit ||

--- a/packages/block-editor/src/hooks/layout.js
+++ b/packages/block-editor/src/hooks/layout.js
@@ -153,7 +153,7 @@ function LayoutPanel( { setAttributes, attributes, name: blockName } ) {
 					{ showInheritToggle && (
 						<>
 							<ToggleControl
-								label={ __( 'Custom width of inner blocks' ) }
+								label={ __( 'Inner blocks use content width' ) }
 								checked={
 									layoutType?.name === 'constrained' ||
 									!! inherit ||


### PR DESCRIPTION
## What?

The recent changes to the Layout content width toggle has the toggle label wrap on two lines, and has too much space above the help text:

<img width="311" alt="Screenshot 2022-08-30 at 13 40 31" src="https://user-images.githubusercontent.com/1204802/187428646-dce17121-c3b9-4590-bc8f-393584bb7344.png">

This PR rephrases it slightly, and changes the help text to use the component prop:

![after](https://user-images.githubusercontent.com/1204802/187428724-6fba492d-7253-4027-be6d-e7e73176a15d.gif)


## Testing Instructions

Test selecting a group block and toggling the inspector layout control.