### PR TITLE
Replace the OPTIONS requests with a faster HEAD request in canUser resolver

### DIFF
--- a/packages/core-data/src/resolvers.js
+++ b/packages/core-data/src/resolvers.js
@@ -309,11 +309,11 @@ export const canUser =
 		try {
 			response = await apiFetch( {
 				path: `/wp/v2/${ resourcePath }`,
-				method: 'OPTIONS',
+				method: 'HEAD',
 				parse: false,
 			} );
 		} catch ( error ) {
-			// Do nothing if our OPTIONS request comes back with an API error (4xx or
+			// Do nothing if our HEAD request comes back with an API error (4xx or
 			// 5xx). The previously determined isAllowed value will remain in the store.
 			return;
 		}

--- a/packages/core-data/src/test/resolvers.js
+++ b/packages/core-data/src/test/resolvers.js
@@ -314,7 +314,7 @@ describe( 'canUser', () => {
 
 		expect( triggerFetch ).toHaveBeenCalledWith( {
 			path: '/wp/v2/media',
-			method: 'OPTIONS',
+			method: 'HEAD',
 			parse: false,
 		} );
 
@@ -334,7 +334,7 @@ describe( 'canUser', () => {
 
 		expect( triggerFetch ).toHaveBeenCalledWith( {
 			path: '/wp/v2/media',
-			method: 'OPTIONS',
+			method: 'HEAD',
 			parse: false,
 		} );
 
@@ -357,7 +357,7 @@ describe( 'canUser', () => {
 
 		expect( triggerFetch ).toHaveBeenCalledWith( {
 			path: '/wp/v2/media',
-			method: 'OPTIONS',
+			method: 'HEAD',
 			parse: false,
 		} );
 
@@ -380,7 +380,7 @@ describe( 'canUser', () => {
 
 		expect( triggerFetch ).toHaveBeenCalledWith( {
 			path: '/wp/v2/blocks/123',
-			method: 'OPTIONS',
+			method: 'HEAD',
 			parse: false,
 		} );
 


### PR DESCRIPTION
@TimothyBJacobs [noted](https://github.com/WordPress/gutenberg/pull/43480#issuecomment-1231013981):

> While an OPTIONS response is cheaper than a full GET, a proper HEAD should be even faster. Right now, the REST API server will just throw away the response body.

This PR is an attempt at just switching the http method to see if the CI checks will pass.

At the moment, this PR is blocked as the HEAD method won't work for all relevant requests, see https://core.trac.wordpress.org/ticket/56481 for more details 