### PR TITLE
Home Link: Properly close tags

### DIFF
--- a/packages/block-library/src/home-link/index.php
+++ b/packages/block-library/src/home-link/index.php
@@ -128,7 +128,7 @@ function render_block_core_home_link( $attributes, $content, $block ) {
 	$aria_current = is_home() || ( is_front_page() && 'page' === get_option( 'show_on_front' ) ) ? ' aria-current="page"' : '';
 
 	return sprintf(
-		'<li %1$s><a class="wp-block-home-link__content wp-block-navigation-item__content" href="%2$s" "rel="home"%3$s>%4$s</a><li>',
+		'<li %1$s><a class="wp-block-home-link__content wp-block-navigation-item__content" href="%2$s" "rel="home"%3$s>%4$s</a></li>',
 		block_core_home_link_build_li_wrapper_attributes( $block->context ),
 		esc_url( home_url() ),
 		$aria_current,


### PR DESCRIPTION
## What?
Fixes #43705.

PR properly closes the list tag. Regression I introduced in #43024 🙈 

## Testing Instructions

1. Open a Post or Page.
2. Insert the Navigation block and add the Home Link block.
3. Confirm the list tag is properly closed (no empty list item after the block).

## Screenshots or screencast <!-- if applicable -->
**Before**
![CleanShot 2022-08-30 at 17 06 56](https://user-images.githubusercontent.com/240569/187445011-c86a5620-ca63-4288-8f88-69b663ec9dcf.png)

**After**
![CleanShot 2022-08-30 at 17 07 14](https://user-images.githubusercontent.com/240569/187445040-da369097-44f3-4238-9f62-6ff8763a68e8.png)
