### PR TITLE
Lodash: Remove _`.omit()` from block library

### DIFF
--- a/packages/block-library/src/gallery/v1/gallery-image.js
+++ b/packages/block-library/src/gallery/v1/gallery-image.js
@@ -2,7 +2,7 @@
  * External dependencies
  */
 import classnames from 'classnames';
-import { get, omit } from 'lodash';
+import { get } from 'lodash';
 
 /**
  * WordPress dependencies
@@ -111,14 +111,18 @@ class GalleryImage extends Component {
 		// written by the user, make sure the text is not overwritten.
 		if ( isTemporaryImage( id, url ) ) {
 			if ( alt ) {
-				mediaAttributes = omit( mediaAttributes, [ 'alt' ] );
+				const { alt: omittedAlt, ...restMediaAttributes } =
+					mediaAttributes;
+				mediaAttributes = restMediaAttributes;
 			}
 		}
 
 		// If a caption text was meanwhile written by the user,
 		// make sure the text is not overwritten by empty captions.
 		if ( caption && ! get( mediaAttributes, [ 'caption' ] ) ) {
-			mediaAttributes = omit( mediaAttributes, [ 'caption' ] );
+			const { caption: omittedCaption, ...restMediaAttributes } =
+				mediaAttributes;
+			mediaAttributes = restMediaAttributes;
 		}
 
 		setAttributes( mediaAttributes );

--- a/packages/block-library/src/image/edit.js
+++ b/packages/block-library/src/image/edit.js
@@ -2,7 +2,7 @@
  * External dependencies
  */
 import classnames from 'classnames';
-import { get, isEmpty, omit, pick } from 'lodash';
+import { get, isEmpty, pick } from 'lodash';
 
 /**
  * WordPress dependencies
@@ -179,7 +179,9 @@ export function ImageEdit( {
 		// If a caption text was meanwhile written by the user,
 		// make sure the text is not overwritten by empty captions.
 		if ( captionRef.current && ! get( mediaAttributes, [ 'caption' ] ) ) {
-			mediaAttributes = omit( mediaAttributes, [ 'caption' ] );
+			const { caption: omittedCaption, ...restMediaAttributes } =
+				mediaAttributes;
+			mediaAttributes = restMediaAttributes;
 		}
 
 		let additionalAttributes;

--- a/packages/block-library/src/list/utils.js
+++ b/packages/block-library/src/list/utils.js
@@ -1,9 +1,4 @@
 /**
- * External dependencies
- */
-import { omit } from 'lodash';
-
-/**
  * WordPress dependencies
  */
 import { createBlock } from '@wordpress/blocks';
@@ -77,9 +72,11 @@ export function migrateToListV2( attributes ) {
 
 	const listBlock = createListBlockFromDOMElement( list );
 
+	const { values: omittedValues, ...restAttributes } = attributes;
+
 	return [
 		{
-			...omit( attributes, [ 'values' ] ),
+			...restAttributes,
 			...listBlock.attributes,
 		},
 		listBlock.innerBlocks,


### PR DESCRIPTION
## What?
This PR removes most of the remaining `_.omit()` usage from the `@wordpress/block-library` package.

## Why?

Lodash is known to unnecessarily inflate the bundle size of packages, and in most cases, it can be replaced with native language functionality. See these for more information and rationale:

* https://github.com/WordPress/gutenberg/issues/16938#issuecomment-602837246
* https://github.com/WordPress/gutenberg/issues/17025
* https://github.com/WordPress/gutenberg/issues/39495 

## How?

`_.omit()` is easily replaceable by destructuring with `...rest` parameters. 

## Testing Instructions
* Gallery v1 block: Verify that if you change an image by uploading a new one, the original caption written by the user is preserved.
* Image block: Verify that if you change the image, the original caption written by the user is preserved.
* List: Verify migrating from v1 (rich text) to v2 (inner blocks) still works well.