### PR TITLE
Fix clicking on top of the publish panel in meta box e2e test

### DIFF
--- a/test/e2e/specs/editor/plugins/wp-editor-meta-box.spec.js
+++ b/test/e2e/specs/editor/plugins/wp-editor-meta-box.spec.js
@@ -31,6 +31,11 @@ test.describe( 'WP Editor Meta Boxes', () => {
 
 		await editor.publishPost();
 
+		// Close the publish panel so that it won't cover the tinymce editor.
+		await page.click(
+			'role=region[name="Editor publish"i] >> role=button[name="Close panel"i]'
+		);
+
 		await expect( page.locator( '.edit-post-layout' ) ).toBeVisible();
 
 		await page.click( 'role=button[name="Text"i]' );


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->
Fix clicking on top of the publish panel in meta box e2e test. This is likely caused by a recent change though.

Close https://github.com/WordPress/gutenberg/issues/43174.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
To fix flaky e2e tests.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
Close the publish panel before interacting with the meta box input.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->
```sh
npm run test:e2e:playwright -- meta-box
```
