### PR TITLE
Fix asserting Post Format without opening the document settings sidebar

### DIFF
--- a/test/e2e/specs/editor/various/new-post.spec.js
+++ b/test/e2e/specs/editor/various/new-post.spec.js
@@ -19,6 +19,7 @@ test.describe( 'new editor state', () => {
 	test( 'should show the New Post page in Gutenberg', async ( {
 		admin,
 		page,
+		editor,
 	} ) => {
 		await admin.createNewPost();
 
@@ -35,6 +36,7 @@ test.describe( 'new editor state', () => {
 		).toBeVisible();
 
 		// Should display the Post Formats UI.
+		await editor.openDocumentSettingsSidebar();
 		await expect(
 			page.locator( 'role=combobox[name="Post Format"i]' )
 		).toBeVisible();


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->
Fix a flaky test where we're asserting "Post Format" without having the document settings sidebar opened.

Close https://github.com/WordPress/gutenberg/issues/40442.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
Fix a flaky e2e test.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
By calling `openDocumentSettingsSidebar` before asserting it.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->
CI should pass.
