### PR TITLE
Lodash: Remove `_.omit()` from `@wordpress/blocks`

### DIFF
--- a/packages/blocks/src/api/parser/apply-block-deprecated-versions.js
+++ b/packages/blocks/src/api/parser/apply-block-deprecated-versions.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { omit, castArray } from 'lodash';
+import { castArray } from 'lodash';
 
 /**
  * Internal dependencies
@@ -10,6 +10,7 @@ import { DEPRECATED_ENTRY_KEYS } from '../constants';
 import { validateBlock } from '../validation';
 import { getBlockAttributes } from './get-block-attributes';
 import { applyBuiltInValidationFixes } from './apply-built-in-validation-fixes';
+import { omit } from '../utils';
 
 /**
  * Function that takes no arguments and always returns false.

--- a/packages/blocks/src/api/parser/fix-custom-classname.js
+++ b/packages/blocks/src/api/parser/fix-custom-classname.js
@@ -1,9 +1,4 @@
 /**
- * External dependencies
- */
-import { omit } from 'lodash';
-
-/**
  * Internal dependencies
  */
 import { hasBlockSupport } from '../registration';
@@ -52,9 +47,8 @@ export function fixCustomClassname( blockAttributes, blockType, innerHTML ) {
 		// attributes, with the exception of `className`. This will determine
 		// the default set of classes. From there, any difference in innerHTML
 		// can be considered as custom classes.
-		const attributesSansClassName = omit( blockAttributes, [
-			'className',
-		] );
+		const { className: omittedClassName, ...attributesSansClassName } =
+			blockAttributes;
 		const serialized = getSaveContent( blockType, attributesSansClassName );
 		const defaultClasses = getHTMLRootElementClasses( serialized );
 		const actualClasses = getHTMLRootElementClasses( innerHTML );

--- a/packages/blocks/src/api/test/registration.js
+++ b/packages/blocks/src/api/test/registration.js
@@ -31,13 +31,11 @@ import {
 	unstable__bootstrapServerSideBlockDefinitions, // eslint-disable-line camelcase
 } from '../registration';
 import { BLOCK_ICON_DEFAULT, DEPRECATED_ENTRY_KEYS } from '../constants';
+import { omit } from '../utils';
 import { store as blocksStore } from '../../store';
 
 const noop = () => {};
-const omit = ( obj, keys ) =>
-	Object.fromEntries(
-		Object.entries( obj ).filter( ( [ key ] ) => ! keys.includes( key ) )
-	);
+
 const pick = ( obj, keys ) =>
 	Object.fromEntries(
 		Object.entries( obj ).filter( ( [ key ] ) => keys.includes( key ) )

--- a/packages/blocks/src/api/utils.js
+++ b/packages/blocks/src/api/utils.js
@@ -304,3 +304,17 @@ export function __experimentalGetBlockAttributesNamesByRole( name, role ) {
 			attributes[ attributeName ]?.__experimentalRole === role
 	);
 }
+
+/**
+ * Return a new object with the specified keys omitted.
+ *
+ * @param {Object} object Original object.
+ * @param {Array}  keys   Keys to be omitted.
+ *
+ * @return {Object} Object with omitted keys.
+ */
+export function omit( object, keys ) {
+	return Object.fromEntries(
+		Object.entries( object ).filter( ( [ key ] ) => ! keys.includes( key ) )
+	);
+}

--- a/packages/blocks/src/store/actions.js
+++ b/packages/blocks/src/store/actions.js
@@ -2,7 +2,7 @@
  * External dependencies
  */
 import { isPlainObject } from 'is-plain-object';
-import { castArray, omit, pick, some } from 'lodash';
+import { castArray, pick, some } from 'lodash';
 
 /**
  * WordPress dependencies
@@ -12,7 +12,7 @@ import { applyFilters } from '@wordpress/hooks';
 /**
  * Internal dependencies
  */
-import { isValidIcon, normalizeIconObject } from '../api/utils';
+import { isValidIcon, normalizeIconObject, omit } from '../api/utils';
 import { DEPRECATED_ENTRY_KEYS } from '../api/constants';
 
 /** @typedef {import('../api/registration').WPBlockVariation} WPBlockVariation */

--- a/packages/blocks/src/store/reducer.js
+++ b/packages/blocks/src/store/reducer.js
@@ -1,13 +1,18 @@
 /**
  * External dependencies
  */
-import { filter, find, get, isEmpty, map, mapValues, omit } from 'lodash';
+import { filter, find, get, isEmpty, map, mapValues } from 'lodash';
 
 /**
  * WordPress dependencies
  */
 import { combineReducers } from '@wordpress/data';
 import { __ } from '@wordpress/i18n';
+
+/**
+ * Internal dependencies
+ */
+import { omit } from '../api/utils';
 
 /**
  * @typedef {Object} WPBlockCategory


### PR DESCRIPTION
## What?
This PR removes most of the remaining `_.omit()` usage from the `@wordpress/blocks` package.

## Why?

Lodash is known to unnecessarily inflate the bundle size of packages, and in most cases, it can be replaced with native language functionality. See these for more information and rationale:

* https://github.com/WordPress/gutenberg/issues/16938#issuecomment-602837246
* https://github.com/WordPress/gutenberg/issues/17025
* https://github.com/WordPress/gutenberg/issues/39495 

## How?

`_.omit()` is easily replaceable by destructuring with `...rest` parameters in most cases. For the rest where we have a dynamic list of keys to omit, we already had a helper in one of the test files, we just moved it to `utils` and utilized it. 

## Testing Instructions
* Verify all tests still pass.
* Smoke test the editor just in case.