### PR TITLE
Lodash: Remove `_.omit()` from `@wordpress/data`

### DIFF
--- a/packages/data/src/redux-store/index.js
+++ b/packages/data/src/redux-store/index.js
@@ -2,7 +2,7 @@
  * External dependencies
  */
 import { createStore, applyMiddleware } from 'redux';
-import { flowRight, get, mapValues, omit } from 'lodash';
+import { flowRight, get, mapValues } from 'lodash';
 import combineReducers from 'turbo-combine-reducers';
 import EquivalentKeyMap from 'equivalent-key-map';
 
@@ -334,16 +334,17 @@ function mapActions( actions, store ) {
  * @return {Object} Selectors mapped to their resolution functions.
  */
 function mapResolveSelectors( selectors, store ) {
-	const storeSelectors = omit( selectors, [
-		'getIsResolving',
-		'hasStartedResolution',
-		'hasFinishedResolution',
-		'hasResolutionFailed',
-		'isResolving',
-		'getCachedResolvers',
-		'getResolutionState',
-		'getResolutionError',
-	] );
+	const {
+		getIsResolving,
+		hasStartedResolution,
+		hasFinishedResolution,
+		hasResolutionFailed,
+		isResolving,
+		getCachedResolvers,
+		getResolutionState,
+		getResolutionError,
+		...storeSelectors
+	} = selectors;
 
 	return mapValues( storeSelectors, ( selector, selectorName ) => {
 		// If the selector doesn't have a resolver, just convert the return value

--- a/packages/data/src/redux-store/metadata/reducer.ts
+++ b/packages/data/src/redux-store/metadata/reducer.ts
@@ -1,7 +1,6 @@
 /**
  * External dependencies
  */
-import { omit } from 'lodash';
 import EquivalentKeyMap from 'equivalent-key-map';
 import type { Reducer } from 'redux';
 
@@ -125,10 +124,16 @@ const isResolved = ( state: Record< string, State > = {}, action: Action ) => {
 	switch ( action.type ) {
 		case 'INVALIDATE_RESOLUTION_FOR_STORE':
 			return {};
-		case 'INVALIDATE_RESOLUTION_FOR_STORE_SELECTOR':
-			return action.selectorName in state
-				? omit( state, [ action.selectorName ] )
-				: state;
+		case 'INVALIDATE_RESOLUTION_FOR_STORE_SELECTOR': {
+			if ( action.selectorName in state ) {
+				const {
+					[ action.selectorName ]: removedSelector,
+					...restState
+				} = state;
+				return restState;
+			}
+			return state;
+		}
 		case 'START_RESOLUTION':
 		case 'FINISH_RESOLUTION':
 		case 'FAIL_RESOLUTION':


### PR DESCRIPTION
## What?
This PR removes most of the remaining `_.omit()` usage from the `@wordpress/data` package.

## Why?

Lodash is known to unnecessarily inflate the bundle size of packages, and in most cases, it can be replaced with native language functionality. See these for more information and rationale:

* https://github.com/WordPress/gutenberg/issues/16938#issuecomment-602837246
* https://github.com/WordPress/gutenberg/issues/17025
* https://github.com/WordPress/gutenberg/issues/39495 

## How?

`_.omit()` is easily replaceable by destructuring with `...rest` parameters. 

## Testing Instructions
* Verify all tests still pass: `npm run test:unit packages/data`.
* Smoke test the post and site editors for regressions.