### PR TITLE
Lodash: Remove `_.omit()` from a few other packages

### DIFF
--- a/packages/block-directory/src/store/reducer.js
+++ b/packages/block-directory/src/store/reducer.js
@@ -1,10 +1,4 @@
 /**
- * External dependencies
- */
-
-import { omit } from 'lodash';
-
-/**
  * WordPress dependencies
  */
 import { combineReducers } from '@wordpress/data';
@@ -100,7 +94,8 @@ export const errorNotices = ( state = {}, action ) => {
 				},
 			};
 		case 'CLEAR_ERROR_NOTICE':
-			return omit( state, action.blockId );
+			const { [ action.blockId ]: blockId, ...restState } = state;
+			return restState;
 	}
 	return state;
 };

--- a/packages/customize-widgets/src/utils.js
+++ b/packages/customize-widgets/src/utils.js
@@ -6,11 +6,6 @@ import { serialize, parse, createBlock } from '@wordpress/blocks';
 import { addWidgetIdToBlock } from '@wordpress/widgets';
 
 /**
- * External dependencies
- */
-import { omit } from 'lodash';
-
-/**
  * Convert settingId to widgetId.
  *
  * @param {string} settingId The setting id.
@@ -79,8 +74,10 @@ export function blockToWidget( block, existingWidget = null ) {
 		};
 	}
 
+	const { form, rendered, ...restExistingWidget } = existingWidget || {};
+
 	return {
-		...omit( existingWidget, [ 'form', 'rendered' ] ),
+		...restExistingWidget,
 		...widget,
 	};
 }

--- a/packages/edit-navigation/src/store/transform.js
+++ b/packages/edit-navigation/src/store/transform.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { get, omit } from 'lodash';
+import { get } from 'lodash';
 
 /**
  * WordPress dependencies
@@ -46,7 +46,8 @@ export function blockToMenuItem(
 	blockPosition,
 	menuId
 ) {
-	menuItem = omit( menuItem, 'menus', 'meta', '_links' );
+	const { menus, meta, _links, ...restMenuItem } = menuItem;
+	menuItem = restMenuItem;
 	menuItem.content = get( menuItem.content, 'raw', menuItem.content );
 
 	let attributes;

--- a/packages/edit-site/src/components/block-editor/index.js
+++ b/packages/edit-site/src/components/block-editor/index.js
@@ -2,7 +2,7 @@
  * External dependencies
  */
 import classnames from 'classnames';
-import { omit, unionBy } from 'lodash';
+import { unionBy } from 'lodash';
 
 /**
  * WordPress dependencies
@@ -94,17 +94,19 @@ export default function BlockEditor( { setIsInserterOpen } ) {
 		[ settingsBlockPatternCategories, restBlockPatternCategories ]
 	);
 
-	const settings = useMemo(
-		() => ( {
-			...omit( storedSettings, [
-				'__experimentalAdditionalBlockPatterns',
-				'__experimentalAdditionalBlockPatternCategories',
-			] ),
+	const settings = useMemo( () => {
+		const {
+			__experimentalAdditionalBlockPatterns,
+			__experimentalAdditionalBlockPatternCategories,
+			...restStoredSettings
+		} = storedSettings;
+
+		return {
+			...restStoredSettings,
 			__experimentalBlockPatterns: blockPatterns,
 			__experimentalBlockPatternCategories: blockPatternCategories,
-		} ),
-		[ storedSettings, blockPatterns, blockPatternCategories ]
-	);
+		};
+	}, [ storedSettings, blockPatterns, blockPatternCategories ] );
 
 	const [ blocks, onInput, onChange ] = useEntityBlockEditor(
 		'postType',

--- a/packages/editor/src/components/post-publish-panel/index.js
+++ b/packages/editor/src/components/post-publish-panel/index.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { get, omit } from 'lodash';
+import { get } from 'lodash';
 
 /**
  * WordPress dependencies
@@ -69,11 +69,12 @@ export class PostPublishPanel extends Component {
 			PrePublishExtension,
 			...additionalProps
 		} = this.props;
-		const propsForPanel = omit( additionalProps, [
-			'hasPublishAction',
-			'isDirty',
-			'isPostTypeViewable',
-		] );
+		const {
+			hasPublishAction,
+			isDirty,
+			isPostTypeViewable,
+			...propsForPanel
+		} = additionalProps;
 		const isPublishedOrScheduled =
 			isPublished || ( isScheduled && isBeingScheduled );
 		const isPrePublish = ! isPublishedOrScheduled && ! isSaving;


### PR DESCRIPTION
## What?
This PR removes most of the remaining `_.omit()` usage from a few packages where it occurs only once per package.

## Why?

Lodash is known to unnecessarily inflate the bundle size of packages, and in most cases, it can be replaced with native language functionality. See these for more information and rationale:

* https://github.com/WordPress/gutenberg/issues/16938#issuecomment-602837246
* https://github.com/WordPress/gutenberg/issues/17025
* https://github.com/WordPress/gutenberg/issues/39495 

## How?

`_.omit()` is easily replaceable by destructuring with `...rest` parameters. 

## Testing Instructions
* Verify tests still pass: `npm run test:unit packages/block-directory/src/store/test/reducer.js`
* Go to the block widgets editor for an old site with legacy widgets, and verify transformation to block widgets still works.
* Open the navigation page `wp-admin/admin.php?page=gutenberg-navigation` and verify saving of menu items in navigation still works.
* Verify block editor settings still load correctly - smoke testing should be enough.
* Verify post publish panel (that appears after publishing a post) still looks and works well.
* Verify all checks are still green.