### PR TITLE
Update theme schema docs

### DIFF
--- a/bin/api-docs/gen-theme-reference.js
+++ b/bin/api-docs/gen-theme-reference.js
@@ -90,15 +90,16 @@ const getSettingsPropertiesMarkup = ( struct ) => {
 		return '';
 	}
 
-	let markup = '| Property  | Type   | Default | Props  |\n';
-	markup += '| ---       | ---    | ---    |---   |\n';
+	let markup = '| Property  | Type   | Default | Props  | Since  |\n';
+	markup += '| ---       | ---    | ---    |---   |---   |\n';
 	ks.forEach( ( key ) => {
 		const def = 'default' in props[ key ] ? props[ key ].default : '';
+		const since = 'since' in props[ key ] ? props[ key ].since : '';
 		const ps =
 			props[ key ].type === 'array'
 				? keys( props[ key ].items.properties ).sort().join( ', ' )
 				: '';
-		markup += `| ${ key } | ${ props[ key ].type } | ${ def } | ${ ps } |\n`;
+		markup += `| ${ key } | ${ props[ key ].type } | ${ def } | ${ ps } | ${ since } |\n`;
 	} );
 
 	return markup;

--- a/docs/reference-guides/theme-json-reference/theme-json-living.md
+++ b/docs/reference-guides/theme-json-reference/theme-json-living.md
@@ -18,6 +18,8 @@ Code editors can pick up the schema and can provide help like tooltips, autocomp
 
 ### appearanceTools
 
+_**Note:** Since WordPress 6.0._
+
 Setting that enables the following UI tools:
 
 - border: color, radius, style, width
@@ -46,9 +48,9 @@ Settings related to borders.
 | Property  | Type   | Default | Props  | Since  |
 | ---       | ---    | ---    |---   |---   |
 | color | boolean | false |  | 5.9 |
-| radius | boolean | false |  |  |
-| style | boolean | false |  |  |
-| width | boolean | false |  |  |
+| radius | boolean | false |  | 5.9 |
+| style | boolean | false |  | 5.9 |
+| width | boolean | false |  | 5.9 |
 
 ---
 
@@ -58,18 +60,18 @@ Settings related to colors.
 
 | Property  | Type   | Default | Props  | Since  |
 | ---       | ---    | ---    |---   |---   |
-| background | boolean | true |  |  |
-| custom | boolean | true |  |  |
-| customDuotone | boolean | true |  |  |
-| customGradient | boolean | true |  |  |
-| defaultDuotone | boolean | true |  |  |
-| defaultGradients | boolean | true |  |  |
-| defaultPalette | boolean | true |  |  |
-| duotone | array |  | colors, name, slug |  |
-| gradients | array |  | gradient, name, slug |  |
-| link | boolean | false |  |  |
-| palette | array |  | color, name, slug |  |
-| text | boolean | true |  |  |
+| background | boolean | true |  | 5.9 |
+| custom | boolean | true |  | 5.8 |
+| customDuotone | boolean | true |  | 5.9 |
+| customGradient | boolean | true |  | 5.8 |
+| defaultDuotone | boolean | true |  | 6.0 |
+| defaultGradients | boolean | true |  | 5.9 |
+| defaultPalette | boolean | true |  | 5.9 |
+| duotone | array |  | colors, name, slug | 5.8 |
+| gradients | array |  | gradient, name, slug | 5.8 |
+| link | boolean | false |  | 5.8 |
+| palette | array |  | color, name, slug | 5.8 |
+| text | boolean | true |  | 5.9 |
 
 ---
 
@@ -79,8 +81,8 @@ Settings related to layout.
 
 | Property  | Type   | Default | Props  | Since  |
 | ---       | ---    | ---    |---   |---   |
-| contentSize | string |  |  |  |
-| wideSize | string |  |  |  |
+| contentSize | string |  |  | 5.8 |
+| wideSize | string |  |  | 5.8 |
 
 ---
 
@@ -90,13 +92,13 @@ Settings related to spacing.
 
 | Property  | Type   | Default | Props  | Since  |
 | ---       | ---    | ---    |---   |---   |
-| blockGap | undefined | null |  |  |
-| margin | boolean | false |  |  |
-| padding | boolean | false |  |  |
-| units | array | px,em,rem,vh,vw,% |  |  |
-| customSpacingSize | boolean | true |  |  |
-| spacingSizes | array |  | name, size, slug |  |
-| spacingScale | object |  |  |  |
+| blockGap | undefined | null |  | 5.9 |
+| margin | boolean | false |  | 5.9 |
+| padding | boolean | false |  | 5.9 |
+| units | array | px,em,rem,vh,vw,% |  | 5.8 |
+| customSpacingSize | boolean | true |  | 6.1 |
+| spacingSizes | array |  | name, size, slug | 6.1 |
+| spacingScale | object |  |  | 6.1 |
 
 ---
 
@@ -106,17 +108,17 @@ Settings related to typography.
 
 | Property  | Type   | Default | Props  | Since  |
 | ---       | ---    | ---    |---   |---   |
-| customFontSize | boolean | true |  |  |
-| fontStyle | boolean | true |  |  |
-| fontWeight | boolean | true |  |  |
-| fluid | boolean |  |  |  |
-| letterSpacing | boolean | true |  |  |
-| lineHeight | boolean | false |  |  |
-| textDecoration | boolean | true |  |  |
-| textTransform | boolean | true |  |  |
-| dropCap | boolean | true |  |  |
-| fontSizes | array |  | fluid, name, size, slug |  |
-| fontFamilies | array |  | fontFace, fontFamily, name, slug |  |
+| customFontSize | boolean | true |  | 5.8 |
+| fontStyle | boolean | true |  | 5.9 |
+| fontWeight | boolean | true |  | 5.9 |
+| fluid | boolean |  |  | 6.1 |
+| letterSpacing | boolean | true |  | 5.9 |
+| lineHeight | boolean | false |  | 5.9 |
+| textDecoration | boolean | true |  | 5.9 |
+| textTransform | boolean | true |  | 5.9 |
+| dropCap | boolean | true |  | 5.8 |
+| fontSizes | array |  | fluid, name, size, slug | 5.8 |
+| fontFamilies | array |  | fontFace, fontFamily, name, slug | 5.9 |
 
 ---
 

--- a/docs/reference-guides/theme-json-reference/theme-json-living.md
+++ b/docs/reference-guides/theme-json-reference/theme-json-living.md
@@ -43,12 +43,12 @@ Please note that when using this setting, `styles.spacing.padding` should always
 
 Settings related to borders.
 
-| Property  | Type   | Default | Props  |
-| ---       | ---    | ---    |---   |
-| color | boolean | false |  |
-| radius | boolean | false |  |
-| style | boolean | false |  |
-| width | boolean | false |  |
+| Property  | Type   | Default | Props  | Since  |
+| ---       | ---    | ---    |---   |---   |
+| color | boolean | false |  | 5.9 |
+| radius | boolean | false |  |  |
+| style | boolean | false |  |  |
+| width | boolean | false |  |  |
 
 ---
 
@@ -56,20 +56,20 @@ Settings related to borders.
 
 Settings related to colors.
 
-| Property  | Type   | Default | Props  |
-| ---       | ---    | ---    |---   |
-| background | boolean | true |  |
-| custom | boolean | true |  |
-| customDuotone | boolean | true |  |
-| customGradient | boolean | true |  |
-| defaultDuotone | boolean | true |  |
-| defaultGradients | boolean | true |  |
-| defaultPalette | boolean | true |  |
-| duotone | array |  | colors, name, slug |
-| gradients | array |  | gradient, name, slug |
-| link | boolean | false |  |
-| palette | array |  | color, name, slug |
-| text | boolean | true |  |
+| Property  | Type   | Default | Props  | Since  |
+| ---       | ---    | ---    |---   |---   |
+| background | boolean | true |  |  |
+| custom | boolean | true |  |  |
+| customDuotone | boolean | true |  |  |
+| customGradient | boolean | true |  |  |
+| defaultDuotone | boolean | true |  |  |
+| defaultGradients | boolean | true |  |  |
+| defaultPalette | boolean | true |  |  |
+| duotone | array |  | colors, name, slug |  |
+| gradients | array |  | gradient, name, slug |  |
+| link | boolean | false |  |  |
+| palette | array |  | color, name, slug |  |
+| text | boolean | true |  |  |
 
 ---
 
@@ -77,10 +77,10 @@ Settings related to colors.
 
 Settings related to layout.
 
-| Property  | Type   | Default | Props  |
-| ---       | ---    | ---    |---   |
-| contentSize | string |  |  |
-| wideSize | string |  |  |
+| Property  | Type   | Default | Props  | Since  |
+| ---       | ---    | ---    |---   |---   |
+| contentSize | string |  |  |  |
+| wideSize | string |  |  |  |
 
 ---
 
@@ -88,15 +88,15 @@ Settings related to layout.
 
 Settings related to spacing.
 
-| Property  | Type   | Default | Props  |
-| ---       | ---    | ---    |---   |
-| blockGap | undefined | null |  |
-| margin | boolean | false |  |
-| padding | boolean | false |  |
-| units | array | px,em,rem,vh,vw,% |  |
-| customSpacingSize | boolean | true |  |
-| spacingSizes | array |  | name, size, slug |
-| spacingScale | object |  |  |
+| Property  | Type   | Default | Props  | Since  |
+| ---       | ---    | ---    |---   |---   |
+| blockGap | undefined | null |  |  |
+| margin | boolean | false |  |  |
+| padding | boolean | false |  |  |
+| units | array | px,em,rem,vh,vw,% |  |  |
+| customSpacingSize | boolean | true |  |  |
+| spacingSizes | array |  | name, size, slug |  |
+| spacingScale | object |  |  |  |
 
 ---
 
@@ -104,19 +104,19 @@ Settings related to spacing.
 
 Settings related to typography.
 
-| Property  | Type   | Default | Props  |
-| ---       | ---    | ---    |---   |
-| customFontSize | boolean | true |  |
-| fontStyle | boolean | true |  |
-| fontWeight | boolean | true |  |
-| fluid | boolean |  |  |
-| letterSpacing | boolean | true |  |
-| lineHeight | boolean | false |  |
-| textDecoration | boolean | true |  |
-| textTransform | boolean | true |  |
-| dropCap | boolean | true |  |
-| fontSizes | array |  | fluid, name, size, slug |
-| fontFamilies | array |  | fontFace, fontFamily, name, slug |
+| Property  | Type   | Default | Props  | Since  |
+| ---       | ---    | ---    |---   |---   |
+| customFontSize | boolean | true |  |  |
+| fontStyle | boolean | true |  |  |
+| fontWeight | boolean | true |  |  |
+| fluid | boolean |  |  |  |
+| letterSpacing | boolean | true |  |  |
+| lineHeight | boolean | false |  |  |
+| textDecoration | boolean | true |  |  |
+| textTransform | boolean | true |  |  |
+| dropCap | boolean | true |  |  |
+| fontSizes | array |  | fluid, name, size, slug |  |
+| fontFamilies | array |  | fontFace, fontFamily, name, slug |  |
 
 ---
 

--- a/schemas/json/theme.json
+++ b/schemas/json/theme.json
@@ -34,7 +34,8 @@
 						"color": {
 							"description": "Allow users to set custom border colors.",
 							"type": "boolean",
-							"default": false
+							"default": false,
+							"since": "5.9"
 						},
 						"radius": {
 							"description": "Allow users to set custom border radius.",

--- a/schemas/json/theme.json
+++ b/schemas/json/theme.json
@@ -10,7 +10,7 @@
 		"settingsPropertiesAppearanceTools": {
 			"properties": {
 				"appearanceTools": {
-					"description": "Setting that enables the following UI tools:\n\n- border: color, radius, style, width\n- color: link\n- spacing: blockGap, margin, padding\n- typography: lineHeight",
+					"description": "_**Note:** Since WordPress 6.0._\n\nSetting that enables the following UI tools:\n\n- border: color, radius, style, width\n- color: link\n- spacing: blockGap, margin, padding\n- typography: lineHeight",
 					"type": "boolean",
 					"default": false
 				}
@@ -40,17 +40,20 @@
 						"radius": {
 							"description": "Allow users to set custom border radius.",
 							"type": "boolean",
-							"default": false
+							"default": false,
+							"since": "5.9"
 						},
 						"style": {
 							"description": "Allow users to set custom border styles.",
 							"type": "boolean",
-							"default": false
+							"default": false,
+							"since": "5.9"
 						},
 						"width": {
 							"description": "Allow users to set custom border widths.",
 							"type": "boolean",
-							"default": false
+							"default": false,
+							"since": "5.9"
 						}
 					},
 					"additionalProperties": false
@@ -66,41 +69,49 @@
 						"background": {
 							"description": "Allow users to set background colors.",
 							"type": "boolean",
-							"default": true
+							"default": true,
+							"since": "5.9"
 						},
 						"custom": {
 							"description": "Allow users to select custom colors.",
 							"type": "boolean",
-							"default": true
+							"default": true,
+							"since": "5.8"
 						},
 						"customDuotone": {
 							"description": "Allow users to create custom duotone filters.",
 							"type": "boolean",
-							"default": true
+							"default": true,
+							"since": "5.9"
 						},
 						"customGradient": {
 							"description": "Allow users to create custom gradients.",
 							"type": "boolean",
-							"default": true
+							"default": true,
+							"since": "5.8"
 						},
 						"defaultDuotone": {
 							"description": "Allow users to choose filters from the default duotone filter presets.",
 							"type": "boolean",
-							"default": true
+							"default": true,
+							"since": "6.0"
 						},
 						"defaultGradients": {
 							"description": "Allow users to choose colors from the default gradients.",
 							"type": "boolean",
-							"default": true
+							"default": true,
+							"since": "5.9"
 						},
 						"defaultPalette": {
 							"description": "Allow users to choose colors from the default palette.",
 							"type": "boolean",
-							"default": true
+							"default": true,
+							"since": "5.9"
 						},
 						"duotone": {
 							"description": "Duotone presets for the duotone picker.\nDoesn't generate classes or properties.",
 							"type": "array",
+							"since": "5.8",
 							"items": {
 								"type": "object",
 								"properties": {
@@ -128,6 +139,7 @@
 						"gradients": {
 							"description": "Gradient presets for the gradient picker.\nGenerates a single class (`.has-{slug}-background`) and custom property (`--wp--preset--gradient--{slug}`) per preset value.",
 							"type": "array",
+							"since": "5.8",
 							"items": {
 								"type": "object",
 								"properties": {
@@ -151,11 +163,13 @@
 						"link": {
 							"description": "Allow users to set link colors.",
 							"type": "boolean",
-							"default": false
+							"default": false,
+							"since": "5.8"
 						},
 						"palette": {
 							"description": "Color palette presets for the color picker.\nGenerates three classes (`.has-{slug}-color`, `.has-{slug}-background-color`, and `.has-{slug}-border-color`) and a single custom property (`--wp--preset--color--{slug}`) per preset value.",
 							"type": "array",
+							"since": "5.8",
 							"items": {
 								"type": "object",
 								"properties": {
@@ -179,7 +193,8 @@
 						"text": {
 							"description": "Allow users to set text colors.",
 							"type": "boolean",
-							"default": true
+							"default": true,
+							"since": "5.9"
 						}
 					},
 					"additionalProperties": false
@@ -194,11 +209,13 @@
 					"properties": {
 						"contentSize": {
 							"description": "Sets the max-width of the content.",
-							"type": "string"
+							"type": "string",
+							"since": "5.8"
 						},
 						"wideSize": {
 							"description": "Sets the max-width of wide (`.alignwide`) content.",
-							"type": "string"
+							"type": "string",
+							"since": "5.8"
 						}
 					},
 					"additionalProperties": false
@@ -217,21 +234,25 @@
 								{ "type": "boolean" },
 								{ "type": "null" }
 							],
-							"default": null
+							"default": null,
+							"since": "5.9"
 						},
 						"margin": {
 							"description": "Allow users to set a custom margin.",
 							"type": "boolean",
-							"default": false
+							"default": false,
+							"since": "5.9"
 						},
 						"padding": {
 							"description": "Allow users to set a custom padding.",
 							"type": "boolean",
-							"default": false
+							"default": false,
+							"since": "5.9"
 						},
 						"units": {
 							"description": "List of units the user can use for spacing values.",
 							"type": "array",
+							"since": "5.8",
 							"items": {
 								"type": "string"
 							},
@@ -240,11 +261,13 @@
 						"customSpacingSize": {
 							"description": "Allow users to set custom space sizes.",
 							"type": "boolean",
-							"default": true
+							"default": true,
+							"since": "6.1"
 						},
 						"spacingSizes": {
 							"description": "Space size presets for the space size selector.\nGenerates a custom property (`--wp--preset--space-size--{slug}`) per preset value.",
 							"type": "array",
+							"since": "6.1",
 							"items": {
 								"type": "object",
 								"properties": {
@@ -267,6 +290,7 @@
 						"spacingScale": {
 							"description": "Space size presets for the space size selector.\nGenerates a custom property (`--wp--preset--space-size--{slug}`) per preset value.",
 							"type": "object",
+							"since": "6.1",
 							"properties": {
 								"operator": {
 									"description": "With + or * depending on whether scale is generated by increment or mulitplier.",
@@ -314,50 +338,60 @@
 						"customFontSize": {
 							"description": "Allow users to set custom font sizes.",
 							"type": "boolean",
-							"default": true
+							"default": true,
+							"since": "5.8"
 						},
 						"fontStyle": {
 							"description": "Allow users to set custom font styles.",
 							"type": "boolean",
-							"default": true
+							"default": true,
+							"since": "5.9"
 						},
 						"fontWeight": {
 							"description": "Allow users to set custom font weights.",
 							"type": "boolean",
-							"default": true
+							"default": true,
+							"since": "5.9"
 						},
 						"fluid": {
 							"description": "Opts into fluid typography.",
-							"type": "boolean"
+							"type": "boolean",
+							"since": "6.1"
 						},
 						"letterSpacing": {
 							"description": "Allow users to set custom letter spacing.",
 							"type": "boolean",
-							"default": true
+							"default": true,
+							"since": "5.9"
 						},
 						"lineHeight": {
 							"description": "Allow users to set custom line height.",
 							"type": "boolean",
-							"default": false
+							"default": false,
+							"since": "5.9"
 						},
 						"textDecoration": {
 							"description": "Allow users to set custom text decorations.",
 							"type": "boolean",
-							"default": true
+							"default": true,
+							"since": "5.9"
 						},
 						"textTransform": {
 							"description": "Allow users to set custom text transforms.",
 							"type": "boolean",
-							"default": true
+							"default": true,
+							"since": "5.9"
 						},
 						"dropCap": {
 							"description": "Enable drop cap.",
 							"type": "boolean",
-							"default": true
+							"default": true,
+							"since": "5.8"
 						},
 						"fontSizes": {
 							"description": "Font size presets for the font size selector.\nGenerates a single class (`.has-{slug}-color`) and custom property (`--wp--preset--font-size--{slug}`) per preset value.",
 							"type": "array",
+							"since": "5.8",
 							"items": {
 								"type": "object",
 								"properties": {
@@ -395,6 +429,7 @@
 						"fontFamilies": {
 							"description": "Font family presets for the font family selector.\nGenerates a single custom property (`--wp--preset--font-family--{slug}`) per preset value.",
 							"type": "array",
+							"since": "5.9",
 							"items": {
 								"type": "object",
 								"properties": {


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->
This PR introduces a new column to the Settings Properties tables for the living theme.json reference that indicates the WordPress version in which the property was introduced.

## Worth Noting
WordPress 5.8 shipped with some properties that were renamed in 5.9. The since values here indicate 5.9 as the since version for those items. That seemed the best solution to me but i'm open to ideas. The areas that are currently expected to land in 6.1 are indicated with that version in the schema. This is also open for discussion. Should anything be rolled back this will need to be adjusted. One possible alternative would be to include the plugin version until code has been merged into core and released. That would require a manual review which might not be the worst thing ever.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
It can be difficult to determine what options are new in the reference documentation. This will make the information about when an option was added to core easily added in a persistently available way with minimal need for maintenance beyond what is already necessary to keep the reference document up to date.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
Added a "since' key to the theme.json schema file for each of the properties that have a table on the living reference doc. Also added the table column to the docs generator to accommodate the new information.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->
1. Change "since value" in `schemas/json/theme.json`
2. Run `npm run docs:build`
3. View/Preview `/docs/reference-guides/theme-json-reference/theme-json-living.md`
4. Confirm change is properly displayed

## Screenshots or screencast <!-- if applicable -->
