### PR TITLE
Components: Retire `LIGHT_GRAY[ 200 ]` and `DARK_GRAY[ 150 ]`

### DIFF
--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -12,6 +12,11 @@
 -   `ToggleControl`: Add `__nextHasNoMargin` prop for opting into the new margin-free styles ([#43717](https://github.com/WordPress/gutenberg/pull/43717)). 
 -   `CheckboxControl`: Add `__nextHasNoMargin` prop for opting into the new margin-free styles ([#43720](https://github.com/WordPress/gutenberg/pull/43720)).
 
+### Enhancements
+
+-   `CardHeader`, `CardBody`, `CardFooter`: Tweak `isShady` background colors to be consistent with the grays in `@wordpress/base-styles` ([#43719](https://github.com/WordPress/gutenberg/pull/43719)).
+-   `InputControl`, `SelectControl`: Tweak `disabled` colors to be consistent with the grays in `@wordpress/base-styles` ([#43719](https://github.com/WordPress/gutenberg/pull/43719)).
+
 ### Internal
 
 -   Remove unused `normalizeArrowKey` utility function ([#43640](https://github.com/WordPress/gutenberg/pull/43640/)).

--- a/packages/components/src/card/styles.ts
+++ b/packages/components/src/card/styles.ts
@@ -115,5 +115,5 @@ export const cardPaddings = {
 };
 
 export const shady = css`
-	background-color: ${ COLORS.lightGray[ 200 ] };
+	background-color: ${ COLORS.ui.backgroundDisabled };
 `;

--- a/packages/components/src/card/test/__snapshots__/index.tsx.snap
+++ b/packages/components/src/card/test/__snapshots__/index.tsx.snap
@@ -26,7 +26,7 @@ Snapshot Diff:
   <div>
     <div
 -     class="components-card__body components-card-body css-1nwhnu3-View-Body-borderRadius-medium e19lxcc00"
-+     class="components-card__body components-card-body css-kqnlb3-View-Body-borderRadius-medium-shady e19lxcc00"
++     class="components-card__body components-card-body css-1nhkags-View-Body-borderRadius-medium-shady e19lxcc00"
       data-wp-c16t="true"
       data-wp-component="CardBody"
     >
@@ -43,7 +43,7 @@ Snapshot Diff:
   <div>
     <div
 -     class="components-flex components-card__footer components-card-footer css-p1v47q-View-Flex-sx-Base-sx-Items-ItemsRow-Footer-borderRadius-borderColor-medium e19lxcc00"
-+     class="components-flex components-card__footer components-card-footer css-1xx98hc-View-Flex-sx-Base-sx-Items-ItemsRow-Footer-borderRadius-borderColor-medium-shady e19lxcc00"
++     class="components-flex components-card__footer components-card-footer css-skr34d-View-Flex-sx-Base-sx-Items-ItemsRow-Footer-borderRadius-borderColor-medium-shady e19lxcc00"
       data-wp-c16t="true"
       data-wp-component="CardFooter"
     >
@@ -77,7 +77,7 @@ Snapshot Diff:
   <div>
     <div
 -     class="components-flex components-card__header components-card-header css-1g5oj2q-View-Flex-sx-Base-sx-Items-ItemsRow-Header-borderRadius-borderColor-medium e19lxcc00"
-+     class="components-flex components-card__header components-card-header css-121pfkj-View-Flex-sx-Base-sx-Items-ItemsRow-Header-borderRadius-borderColor-medium-shady e19lxcc00"
++     class="components-flex components-card__header components-card-header css-1gv9wvv-View-Flex-sx-Base-sx-Items-ItemsRow-Header-borderRadius-borderColor-medium-shady e19lxcc00"
       data-wp-c16t="true"
       data-wp-component="CardHeader"
     >

--- a/packages/components/src/utils/colors-values.js
+++ b/packages/components/src/utils/colors-values.js
@@ -25,7 +25,6 @@ const GRAY = {
 const DARK_GRAY = {
 	500: '#555d66', // Use this most of the time for dark items.
 	300: '#6c7781', // Lightest gray that can be used for AA text contrast.
-	150: '#8d96a0', // Lightest gray that can be used for AA non-text contrast.
 };
 
 const LIGHT_GRAY = {
@@ -56,7 +55,7 @@ const UI = {
 	borderHover: GRAY[ 700 ],
 	borderFocus: ADMIN.themeDark10,
 	borderDisabled: GRAY[ 400 ],
-	textDisabled: DARK_GRAY[ 150 ], // TODO: Replace with WordPress gray
+	textDisabled: GRAY[ 600 ],
 	textDark: white,
 
 	// Matches @wordpress/base-styles

--- a/packages/components/src/utils/colors-values.js
+++ b/packages/components/src/utils/colors-values.js
@@ -33,7 +33,6 @@ const LIGHT_GRAY = {
 	600: '#d7dade',
 	400: '#e8eaeb', // Good for "readonly" input fields and special text selection.
 	300: '#edeff0',
-	200: '#f3f4f5',
 };
 
 // Matches @wordpress/base-styles
@@ -52,7 +51,7 @@ const ADMIN = {
 const UI = {
 	theme: ADMIN.theme,
 	background: white,
-	backgroundDisabled: LIGHT_GRAY[ 200 ], // TODO: Replace with WordPress gray
+	backgroundDisabled: GRAY[ 100 ],
 	border: GRAY[ 700 ],
 	borderHover: GRAY[ 700 ],
 	borderFocus: ADMIN.themeDark10,

--- a/packages/components/src/utils/colors-values.js
+++ b/packages/components/src/utils/colors-values.js
@@ -22,11 +22,13 @@ const GRAY = {
 	100: '#f0f0f0',
 };
 
+// TODO: Replace usages of these with the equivalents in `GRAY`
 const DARK_GRAY = {
 	500: '#555d66', // Use this most of the time for dark items.
 	300: '#6c7781', // Lightest gray that can be used for AA text contrast.
 };
 
+// TODO: Replace usages of these with the equivalents in `GRAY`
 const LIGHT_GRAY = {
 	800: '#b5bcc2',
 	600: '#d7dade',


### PR DESCRIPTION
Part of #40392

## What?

Replaces the following colors:

- `LIGHT_GRAY[ 200 ]` → `GRAY[ 100 ]`
- `DARK_GRAY[ 150 ]` → `GRAY[ 600 ]`

Affected components:

- CardHeader, CardBody, CardFooter (With the `isShady` prop. Not used anywhere in the repo.)
- InputControl (With the `disabled` prop.)
- SelectControl (With the `disabled` prop.)

## Why?

We want to consolidate our grays to the canonical gray scale in `@wordpress/base-styles`.

## How?

Replace with the closest colors in the main GRAY object.

## Testing Instructions

1. `npm run storybook:dev`
2. Check the stories for the affected components. For the Card subcomponents, you can tweak the story code and add `isShady` props if you want.

## Screenshots or screencast <!-- if applicable -->

| Before | After |
|--------|-------|
|<img src="https://user-images.githubusercontent.com/555336/187503781-7eeae946-916f-4885-a847-9bf4390dd29c.png" alt="Disabled InputControl, before this change" width="400">|<img src="https://user-images.githubusercontent.com/555336/187503788-fb6a4c26-3e55-428f-8930-46cfb632ff2f.png" alt="Disabled InputControl, with the new colors" width="400">|

