### PR TITLE
Storybook: Support dashicons for testing

### DIFF
--- a/packages/components/src/icon/stories/index.js
+++ b/packages/components/src/icon/stories/index.js
@@ -13,6 +13,7 @@ import { wordpress } from '@wordpress/icons';
  * Internal dependencies
  */
 import Icon from '../';
+import { VStack } from '../../v-stack';
 
 export default {
 	title: 'Components/Icon',
@@ -106,5 +107,22 @@ export const withAnSVG = () => {
 				</SVG>
 			}
 		/>
+	);
+};
+
+/**
+ * Although it's preferred to use icons from the `@wordpress/icons` package, Dashicons are still supported,
+ * as long as you are in a context where the Dashicons stylesheet is loaded. To simulate that here,
+ * use the Global CSS Injector in the Storybook toolbar at the top and select the "WordPress" preset.
+ */
+export const withADashicon = () => {
+	return (
+		<VStack>
+			<Icon icon="wordpress" />
+			<small>
+				This won’t show an icon if the Dashicons stylesheet isn’t
+				loaded.
+			</small>
+		</VStack>
 	);
 };

--- a/storybook/decorators/with-global-css.js
+++ b/storybook/decorators/with-global-css.js
@@ -39,6 +39,8 @@ const config = {
 			// that affect wp-components
 			'https://wordpress.org/gutenberg/wp-admin/css/common.min.css',
 			'https://wordpress.org/gutenberg/wp-admin/css/forms.min.css',
+			// Icon components need to support dashicons for backwards compatibility
+			'https://wordpress.org/gutenberg/wp-includes/css/dashicons.min.css',
 		],
 		// In wp-admin, these classes are added to the body element,
 		// which is used as a class scope for some relevant styles in the external

--- a/storybook/preview.js
+++ b/storybook/preview.js
@@ -29,7 +29,10 @@ export const globalTypes = {
 			items: [
 				{ value: 'none', title: 'None' },
 				{ value: 'basic', title: 'Font only' },
-				{ value: 'wordpress', title: 'WordPress (common/forms)' },
+				{
+					value: 'wordpress',
+					title: 'WordPress (common, forms, dashicons)',
+				},
 			],
 		},
 	},


### PR DESCRIPTION
Closes #43700

## What?

Adds the dashicons stylesheet to the "WordPress" preset in the Global CSS Injector.

## Why?

Some components need to support dashicons for backward compatibility. We should be able to test that in Storybook.

## Testing Instructions

1. `npm run storybook:dev`
2. In the Storybook toolbar, find the Global CSS Injector in the toolbar and select the "WordPress" preset.
3. Go to the "With A Dashicon" story for the Icon component.


## Screen Recording

https://user-images.githubusercontent.com/555336/187515998-c3789347-faa5-4b64-973a-22193246015f.mp4

