### PR TITLE
unescapeTerms/unescapeTerm: filter-out values of unexpected type

### DIFF
--- a/packages/editor/src/utils/terms.js
+++ b/packages/editor/src/utils/terms.js
@@ -50,7 +50,7 @@ export const unescapeString = ( arg ) => {
  *
  * @param {Object} term The term object to unescape.
  *
- * @return {Object|false} Term object with name property unescaped or
+ * @return {Object|undefined} Term object with name property unescaped or
  *         undefined if the term is invalid.
  */
 export const unescapeTerm = ( term ) => {

--- a/packages/editor/src/utils/terms.js
+++ b/packages/editor/src/utils/terms.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { groupBy, map, unescape as lodashUnescapeString } from 'lodash';
+import { groupBy, unescape as lodashUnescapeString } from 'lodash';
 
 /**
  * Returns terms in a tree form.
@@ -68,5 +68,5 @@ export const unescapeTerm = ( term ) => {
  * @return {Object[]} Array of term objects unescaped.
  */
 export const unescapeTerms = ( terms ) => {
-	return map( terms, unescapeTerm );
+	return terms.filter( Boolean ).map( unescapeTerm );
 };

--- a/packages/editor/src/utils/terms.js
+++ b/packages/editor/src/utils/terms.js
@@ -50,13 +50,16 @@ export const unescapeString = ( arg ) => {
  *
  * @param {Object} term The term object to unescape.
  *
- * @return {Object} Term object with name property unescaped.
+ * @return {Object|false} Term object with name property unescaped or
+ *         undefined if the term is invalid.
  */
 export const unescapeTerm = ( term ) => {
-	return {
-		...term,
-		name: unescapeString( term.name ),
-	};
+	if ( term && term.name ) {
+		return {
+			...term,
+			name: unescapeString( term.name ),
+		};
+	}
 };
 
 /**
@@ -67,6 +70,5 @@ export const unescapeTerm = ( term ) => {
  *
  * @return {Object[]} Array of term objects unescaped.
  */
-export const unescapeTerms = ( terms ) => {
-	return terms.filter( Boolean ).map( unescapeTerm );
-};
+export const unescapeTerms = ( terms ) =>
+	terms.map( unescapeTerm ).filter( Boolean );

--- a/packages/editor/src/utils/test/terms.js
+++ b/packages/editor/src/utils/test/terms.js
@@ -88,7 +88,7 @@ describe( 'unescapeTerm()', () => {
 
 describe( 'unecapeTerms()', () => {
 	// unescape here means converting HTML entities to the correponding chars
-	it( 'Should unescape the terms and properly handle values of and unexpected type', () => {
+	it( 'Should unescape the terms and properly handle values of an unexpected type', () => {
 		const terms = [
 			{ name: 'Foo &amp;' },
 			{ name: 'Bar &amp;' },

--- a/packages/editor/src/utils/test/terms.js
+++ b/packages/editor/src/utils/test/terms.js
@@ -1,7 +1,7 @@
 /**
  * Internal dependencies
  */
-import { buildTermsTree } from '../terms';
+import { buildTermsTree, unescapeTerm, unescapeTerms } from '../terms';
 
 describe( 'buildTermsTree()', () => {
 	it( 'Should return same array as input with null parent and empty children added if parent is never specified.', () => {
@@ -63,5 +63,46 @@ describe( 'buildTermsTree()', () => {
 		];
 		const termsTreem = buildTermsTree( input );
 		expect( termsTreem ).toEqual( output );
+	} );
+} );
+
+describe( 'unescapeTerm()', () => {
+	// unescape here means converting HTML entities to the correponding chars
+	it( 'Should unescape a term', () => {
+		const term = { name: 'Foo &amp;' };
+
+		const unescapedTerm = unescapeTerm( term );
+
+		expect( unescapedTerm ).toEqual( { name: 'Foo &' } );
+	} );
+
+	it( 'Should return undefined and not raise an exception for values of an unexpected type', () => {
+		const badTerms = [ undefined, { foo: 'bar' }, null, false, 'hay' ];
+
+		for ( const term of badTerms ) {
+			expect( () => unescapeTerm( term ) ).not.toThrowError();
+			expect( unescapeTerm( term ) ).toBeUndefined();
+		}
+	} );
+} );
+
+describe( 'unecapeTerms()', () => {
+	// unescape here means converting HTML entities to the correponding chars
+	it( 'Should unescape the terms and properly handle values of and unexpected type', () => {
+		const terms = [
+			{ name: 'Foo &amp;' },
+			{ name: 'Bar &amp;' },
+			undefined,
+			null,
+			false,
+			{ foo: 'bar' },
+		];
+
+		const escapedTerms = unescapeTerms( terms );
+
+		expect( escapedTerms ).toEqual( [
+			{ name: 'Foo &' },
+			{ name: 'Bar &' },
+		] );
 	} );
 } );


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?

Filters out non-truthy values from the `terms` argument passed to `unescapeTerms`. We're looking to filter out `null` and `undefined` values from it, but we go a bit further: we actually check that the structural type of the value is correct and if it's not, we don't do anything meaning the function will return `undefined` - this `undefined` that is then filtered-out by `unescapedTerms`.*

*Any other consuming code should take care handling a potential `undefined` value being returned from `unescapeTerm`.

As a bonus, we replace lodash's `map` with the native `Array.map` function.

## Why?

Even though it shouldn't receive an array with `undefined` (or `null`) values, we've seen instances of it around the code and when the value is finally `map`'ed to the `unescapeTerm` function, it will fail with a `TypeError: Cannot read properties of undefined (reading name)` because it expects an object of a certain structure, and ends up receiving something else (`undefined`). See this issue: https://github.com/WordPress/gutenberg/issues/40850.

## How?

We keep only truthy values in the `terms` array before `map`ing them against `unescapeTerm`. 

## Testing Instructions

1. Make sure the "most used tags" feature is still working as expected:

![Screenshot from 2022-08-30 16-48-41](https://user-images.githubusercontent.com/81248/187549734-a1eb93c3-c0d9-45dd-b096-0f7fe029135c.png)

2. Follow the steps to reproduce in https://github.com/WordPress/gutenberg/issues/40850. The error shouldn't happen anymore.

## TODO

- [x] Add or fix unit-tests
- [ ] Test manually