### PR TITLE
Draggable block tests: click block inserter instead of pressing Enter key

### DIFF
--- a/packages/e2e-tests/specs/editor/various/draggable-block.test.js
+++ b/packages/e2e-tests/specs/editor/various/draggable-block.test.js
@@ -9,6 +9,7 @@ import {
 	showBlockToolbar,
 	setBrowserViewport,
 	waitForWindowDimensions,
+	clickBlockAppender,
 } from '@wordpress/e2e-test-utils';
 
 describe( 'Draggable block', () => {
@@ -38,7 +39,7 @@ describe( 'Draggable block', () => {
 	} );
 
 	it( 'can drag and drop to the top of a block list', async () => {
-		await page.keyboard.press( 'Enter' );
+		await clickBlockAppender();
 		await page.keyboard.type( '1' );
 		await page.keyboard.press( 'Enter' );
 		await page.keyboard.type( '2' );
@@ -80,7 +81,7 @@ describe( 'Draggable block', () => {
 	} );
 
 	it( 'can drag and drop to the bottom of a block list', async () => {
-		await page.keyboard.press( 'Enter' );
+		await clickBlockAppender();
 		await page.keyboard.type( '1' );
 		await page.keyboard.press( 'Enter' );
 		await page.keyboard.type( '2' );


### PR DESCRIPTION
Currently the "draggable block" e2e tests seem to fail very often — this PR aims at making those tests more resilient.

Previously, the tests assumed that the keyboard focus would always be in the post title, and therefore pressing `Enter` would move the keyboard focus to the first block. This assumption is probably not always true, and can lead to test failures.

This PR replaces the pressing of the `Enter` key with a call to `clickBlockAppender()`

## Testing instructions

The `Draggable block can drag and drop to the top of a block list` and `Draggable block can drag and drop to the bottom of a block list` tests both pass
