### PR TITLE
Lodash: Refactor away from `_.unionBy()`

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -149,6 +149,7 @@ module.exports = {
 							'toString',
 							'trim',
 							'truncate',
+							'unionBy',
 							'uniq',
 							'uniqBy',
 							'uniqueId',

--- a/packages/block-library/src/block/test/edit.native.js
+++ b/packages/block-library/src/block/test/edit.native.js
@@ -70,6 +70,10 @@ describe( 'Reusable block', () => {
 				response = [ reusableBlockMock1, reusableBlockMock2 ];
 			} else if ( path.startsWith( '/wp/v2/blocks/1' ) ) {
 				response = reusableBlockMock1;
+			} else if (
+				path.startsWith( '/wp/v2/block-patterns/categories' )
+			) {
+				response = [];
 			}
 			return Promise.resolve( response );
 		} );

--- a/packages/block-library/src/embed/test/index.native.js
+++ b/packages/block-library/src/embed/test/index.native.js
@@ -129,6 +129,10 @@ const mockEmbedResponses = ( mockedResponses ) => {
 			] );
 		}
 
+		if ( path.startsWith( '/wp/v2/block-patterns/categories' ) ) {
+			return Promise.resolve( [] );
+		}
+
 		const matchedEmbedResponse = mockedResponses.find(
 			( mockedResponse ) =>
 				path ===
@@ -698,6 +702,9 @@ describe( 'Embed block', () => {
 						response = RICH_TEXT_EMBED_SUCCESS_RESPONSE;
 					}
 				}
+				if ( path.startsWith( '/wp/v2/block-patterns/categories' ) ) {
+					response = [];
+				}
 				return Promise.resolve( response );
 			} );
 
@@ -724,6 +731,9 @@ describe( 'Embed block', () => {
 		it( 'converts to link if preview request failed', async () => {
 			// Return bad response for requests to oembed endpoint.
 			fetchRequest.mockImplementation( ( { path } ) => {
+				if ( path.startsWith( '/wp/v2/block-patterns/categories' ) ) {
+					return Promise.resolve( [] );
+				}
 				const isEmbedRequest = path.startsWith( '/oembed/1.0/proxy' );
 				return Promise.resolve(
 					isEmbedRequest ? MOCK_BAD_WORDPRESS_RESPONSE : {}
@@ -761,6 +771,10 @@ describe( 'Embed block', () => {
 					response = MOCK_BAD_WORDPRESS_RESPONSE;
 				} else if ( matchesPath( successURL ) ) {
 					response = RICH_TEXT_EMBED_SUCCESS_RESPONSE;
+				} else if (
+					path.startsWith( '/wp/v2/block-patterns/categories' )
+				) {
+					response = [];
 				}
 
 				return Promise.resolve( response );
@@ -1048,6 +1062,9 @@ describe( 'Embed block', () => {
 	it( 'displays cannot embed on the placeholder if preview data is null', async () => {
 		// Return null response for requests to oembed endpoint.
 		fetchRequest.mockImplementation( ( { path } ) => {
+			if ( path.startsWith( '/wp/v2/block-patterns/categories' ) ) {
+				return Promise.resolve( [] );
+			}
 			const isEmbedRequest = path.startsWith( '/oembed/1.0/proxy' );
 			return Promise.resolve( isEmbedRequest ? EMBED_NULL_RESPONSE : {} );
 		} );

--- a/packages/edit-site/src/components/block-editor/index.js
+++ b/packages/edit-site/src/components/block-editor/index.js
@@ -2,7 +2,6 @@
  * External dependencies
  */
 import classnames from 'classnames';
-import { unionBy } from 'lodash';
 
 /**
  * WordPress dependencies
@@ -80,16 +79,25 @@ export default function BlockEditor( { setIsInserterOpen } ) {
 	);
 
 	const blockPatterns = useMemo(
-		() => unionBy( settingsBlockPatterns, restBlockPatterns, 'name' ),
+		() =>
+			[
+				...( settingsBlockPatterns || [] ),
+				...( restBlockPatterns || [] ),
+			].filter(
+				( x, index, arr ) =>
+					index === arr.findIndex( ( y ) => x.name === y.name )
+			),
 		[ settingsBlockPatterns, restBlockPatterns ]
 	);
 
 	const blockPatternCategories = useMemo(
 		() =>
-			unionBy(
-				settingsBlockPatternCategories,
-				restBlockPatternCategories,
-				'name'
+			[
+				...( settingsBlockPatternCategories || [] ),
+				...( restBlockPatternCategories || [] ),
+			].filter(
+				( x, index, arr ) =>
+					index === arr.findIndex( ( y ) => x.name === y.name )
 			),
 		[ settingsBlockPatternCategories, restBlockPatternCategories ]
 	);

--- a/packages/editor/src/components/provider/use-block-editor-settings.js
+++ b/packages/editor/src/components/provider/use-block-editor-settings.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { pick, unionBy } from 'lodash';
+import { pick } from 'lodash';
 
 /**
  * WordPress dependencies
@@ -77,16 +77,25 @@ function useBlockEditorSettings( settings, hasTemplate ) {
 	);
 
 	const blockPatterns = useMemo(
-		() => unionBy( settingsBlockPatterns, restBlockPatterns, 'name' ),
+		() =>
+			[
+				...( settingsBlockPatterns || [] ),
+				...( restBlockPatterns || [] ),
+			].filter(
+				( x, index, arr ) =>
+					index === arr.findIndex( ( y ) => x.name === y.name )
+			),
 		[ settingsBlockPatterns, restBlockPatterns ]
 	);
 
 	const blockPatternCategories = useMemo(
 		() =>
-			unionBy(
-				settingsBlockPatternCategories,
-				restBlockPatternCategories,
-				'name'
+			[
+				...( settingsBlockPatternCategories || [] ),
+				...( restBlockPatternCategories || [] ),
+			].filter(
+				( x, index, arr ) =>
+					index === arr.findIndex( ( y ) => x.name === y.name )
 			),
 		[ settingsBlockPatternCategories, restBlockPatternCategories ]
 	);


### PR DESCRIPTION
## What?
This PR removes the `_.unionBy()` usage completely and deprecates the function. 

## Why?

Lodash is known to unnecessarily inflate the bundle size of packages, and in most cases, it can be replaced with native language functionality. See these for more information and rationale:

* https://github.com/WordPress/gutenberg/issues/16938#issuecomment-602837246
* https://github.com/WordPress/gutenberg/issues/17025
* https://github.com/WordPress/gutenberg/issues/39495 

## How?

`_.unionBy()` is easily replacible with a native filter implementation. We're also fixing a few tests - namely, improving the response for the block pattern category endpoint to return an array instead of an object, which corresponds more properly to the original endpoint schema.

## Testing Instructions
* Smoke test the post and site editors and verify nothing breaks after initial loading.
* Verify all checks are still green.