### PR TITLE
Skip draggable block e2e tests

### DIFF
--- a/packages/e2e-tests/specs/editor/various/draggable-block.test.js
+++ b/packages/e2e-tests/specs/editor/various/draggable-block.test.js
@@ -12,7 +12,7 @@ import {
 	clickBlockAppender,
 } from '@wordpress/e2e-test-utils';
 
-describe( 'Draggable block', () => {
+describe.skip( 'Draggable block', () => {
 	// Tests don't seem to pass if beforeAll and afterAll are used.
 	// Unsure why.
 	beforeEach( async () => {


### PR DESCRIPTION
Draggable block tests are failing consistently and preventing other PRs from being merged.

After a first attempt at fixing them (https://github.com/WordPress/gutenberg/pull/43734), this PR skips them so that they can be looked at without blocking every other PR