### PR TITLE
Lodash: Remove completely from `@wordpress/format-library` package

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17431,8 +17431,7 @@
 				"@wordpress/i18n": "file:packages/i18n",
 				"@wordpress/icons": "file:packages/icons",
 				"@wordpress/rich-text": "file:packages/rich-text",
-				"@wordpress/url": "file:packages/url",
-				"lodash": "^4.17.21"
+				"@wordpress/url": "file:packages/url"
 			}
 		},
 		"@wordpress/hooks": {

--- a/packages/format-library/package.json
+++ b/packages/format-library/package.json
@@ -36,8 +36,7 @@
 		"@wordpress/i18n": "file:../i18n",
 		"@wordpress/icons": "file:../icons",
 		"@wordpress/rich-text": "file:../rich-text",
-		"@wordpress/url": "file:../url",
-		"lodash": "^4.17.21"
+		"@wordpress/url": "file:../url"
 	},
 	"peerDependencies": {
 		"react": "^17.0.0",

--- a/packages/format-library/src/link/index.native.js
+++ b/packages/format-library/src/link/index.native.js
@@ -86,7 +86,7 @@ export const link = {
 					let endIndex = value.end;
 
 					while (
-						value.formats[ startIndex ].find(
+						value.formats[ startIndex ]?.find(
 							( format ) => format?.type === startFormat.type
 						)
 					) {
@@ -96,7 +96,7 @@ export const link = {
 					endIndex++;
 
 					while (
-						value.formats[ endIndex ].find(
+						value.formats[ endIndex ]?.find(
 							( format ) => format?.type === startFormat.type
 						)
 					) {

--- a/packages/format-library/src/link/index.native.js
+++ b/packages/format-library/src/link/index.native.js
@@ -1,7 +1,6 @@
 /**
  * External dependencies
  */
-import { find } from 'lodash';
 import Clipboard from '@react-native-clipboard/clipboard';
 
 /**
@@ -86,13 +85,21 @@ export const link = {
 					let startIndex = value.start;
 					let endIndex = value.end;
 
-					while ( find( value.formats[ startIndex ], startFormat ) ) {
+					while (
+						value.formats[ startIndex ].find(
+							( format ) => format?.type === startFormat.type
+						)
+					) {
 						startIndex--;
 					}
 
 					endIndex++;
 
-					while ( find( value.formats[ endIndex ], startFormat ) ) {
+					while (
+						value.formats[ endIndex ].find(
+							( format ) => format?.type === startFormat.type
+						)
+					) {
 						endIndex++;
 					}
 

--- a/packages/format-library/src/text-color/index.js
+++ b/packages/format-library/src/text-color/index.js
@@ -1,9 +1,4 @@
 /**
- * External dependencies
- */
-import { isEmpty } from 'lodash';
-
-/**
  * WordPress dependencies
  */
 import { __ } from '@wordpress/i18n';
@@ -82,7 +77,7 @@ function TextColorEdit( {
 		[ value, colors ]
 	);
 
-	const hasColorsToChoose = ! isEmpty( colors ) || ! allowCustomControl;
+	const hasColorsToChoose = colors.length || ! allowCustomControl;
 	if ( ! hasColorsToChoose && ! isActive ) {
 		return null;
 	}

--- a/packages/format-library/src/text-color/index.native.js
+++ b/packages/format-library/src/text-color/index.native.js
@@ -1,7 +1,6 @@
 /**
  * External dependencies
  */
-import { isEmpty } from 'lodash';
 import { View } from 'react-native';
 
 /**
@@ -89,7 +88,7 @@ function TextColorEdit( {
 		[ value, colors ]
 	);
 
-	const hasColorsToChoose = ! isEmpty( colors ) || ! allowCustomControl;
+	const hasColorsToChoose = colors.length || ! allowCustomControl;
 
 	const onPressButton = useCallback( () => {
 		if ( hasColorsToChoose ) {

--- a/packages/format-library/src/text-color/inline.js
+++ b/packages/format-library/src/text-color/inline.js
@@ -1,9 +1,4 @@
 /**
- * External dependencies
- */
-import { get } from 'lodash';
-
-/**
  * WordPress dependencies
  */
 import { useCallback, useMemo } from '@wordpress/element';
@@ -112,7 +107,7 @@ function setColors( value, name, colorSettings, colors ) {
 function ColorPicker( { name, property, value, onChange } ) {
 	const colors = useSelect( ( select ) => {
 		const { getSettings } = select( blockEditorStore );
-		return get( getSettings(), [ 'colors' ], [] );
+		return getSettings().colors ?? [];
 	}, [] );
 	const onColorChange = useCallback(
 		( color ) => {


### PR DESCRIPTION
## What?
This PR removes all of the Lodash from the `@wordpress/format-library` package, including the `lodash` dependency altogether. There are just a few usages and conversion is pretty straightforward. 

## Why?

Lodash is known to unnecessarily inflate the bundle size of packages, and in most cases, it can be replaced with native language functionality. See these for more information and rationale:

* https://github.com/WordPress/gutenberg/issues/16938#issuecomment-602837246
* https://github.com/WordPress/gutenberg/issues/17025
* https://github.com/WordPress/gutenberg/issues/39495 

## How?

We're replacing a few usages with their native counterparts. 

## Testing Instructions

* On both web and mobile, make sure to test: 
  * Setting text color in a paragraph block (see #36028 for testing details on mobile)
  * Setting a text to be a link in a paragraph block (see #12249 for testing details on mobile)
* Verify all checks are green.