### PR TITLE
Update scaffold.js

### DIFF
--- a/packages/create-block/lib/scaffold.js
+++ b/packages/create-block/lib/scaffold.js
@@ -144,7 +144,7 @@ module.exports = async (
 	success(
 		plugin
 			? `Done: WordPress plugin ${ title } bootstrapped in the ${ slug } directory.`
-			: `Done: Block "${ title }" bootstrapped in the ${ slug }directory.`
+			: `Done: Block "${ title }" bootstrapped in the ${ slug } directory.`
 	);
 
 	if ( plugin && wpScripts ) {


### PR DESCRIPTION
Minor string "bug" fix

<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Adding a space in the success message when generating a block-only block

## Why?
Because otherwise it looks like this:

`Done: Block "No Plugin" bootstrapped in the wp-block-namedirectory`

## How?
Adding the space

## Testing Instructions
1. Run npx @wordpress/create-block --no-plugin
2. Follow the prompts, and inspect the success message once the code is scaffolded.
