### PR TITLE
Lodash: Remove completely from `@wordpress/redux-routine` package

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17747,7 +17747,6 @@
 				"@babel/runtime": "^7.16.0",
 				"is-plain-object": "^5.0.0",
 				"is-promise": "^4.0.0",
-				"lodash": "^4.17.21",
 				"rungen": "^0.3.2"
 			}
 		},

--- a/packages/redux-routine/CHANGELOG.md
+++ b/packages/redux-routine/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Internal
+
+-   Lodash: Remove completely from `@wordpress/redux-routine` package ([#43741](https://github.com/WordPress/gutenberg/pull/43741)).
+
 ## 4.16.0 (2022-08-24)
 
 ### Bug Fix

--- a/packages/redux-routine/package.json
+++ b/packages/redux-routine/package.json
@@ -32,7 +32,6 @@
 		"@babel/runtime": "^7.16.0",
 		"is-plain-object": "^5.0.0",
 		"is-promise": "^4.0.0",
-		"lodash": "^4.17.21",
 		"rungen": "^0.3.2"
 	},
 	"peerDependencies": {

--- a/packages/redux-routine/src/runtime.ts
+++ b/packages/redux-routine/src/runtime.ts
@@ -2,7 +2,6 @@
  * External dependencies
  */
 import { create, Control } from 'rungen';
-import { map } from 'lodash';
 import isPromise from 'is-promise';
 import type { Dispatch, AnyAction } from 'redux';
 
@@ -24,9 +23,8 @@ export default function createRuntime(
 	> = {},
 	dispatch: Dispatch
 ) {
-	const rungenControls = map(
-		controls,
-		( control, actionType ): Control =>
+	const rungenControls = Object.entries( controls ).map(
+		( [ actionType, control ] ): Control =>
 			( value, next, iterate, yieldNext, yieldError ) => {
 				if ( ! isActionOfType( value, actionType ) ) {
 					return false;


### PR DESCRIPTION
## What?
This PR removes all Lodash from the `@wordpress/redux-routine` package, including the `lodash` dependency. There are just a few usages and conversion is pretty straightforward. 

## Why?

Lodash is known to unnecessarily inflate the bundle size of packages, and in most cases, it can be replaced with native language functionality. See these for more information and rationale:

* https://github.com/WordPress/gutenberg/issues/16938#issuecomment-602837246
* https://github.com/WordPress/gutenberg/issues/17025
* https://github.com/WordPress/gutenberg/issues/39495 

## How?

We're replacing a single `map()` usage with its native counterpart `Array.prototype.map()`. 

## Testing Instructions

* Verify all tests pass and checks are green.
* The best way to thoroughly test that this still works is to use code that uses `@wordpress/data` with generators instead of thunks.