### PR TITLE
Lodash: Remove from `FormTokenField` component

### DIFF
--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -20,6 +20,7 @@
 -   `ComboboxControl`: Add unit tests ([#42403](https://github.com/WordPress/gutenberg/pull/42403)).
 -   `NavigableContainer`: use `code` instead of `keyCode` for keyboard events, rewrite tests using RTL and `user-event` ([#43606](https://github.com/WordPress/gutenberg/pull/43606/)).
 -   `ComboboxControl`: updated to satisfy `react/exhuastive-deps` eslint rule ([#41417](https://github.com/WordPress/gutenberg/pull/41417))
+-   `FormTokenField`: Refactor away from Lodash ([#43744](https://github.com/WordPress/gutenberg/pull/43744/)).
 
 ## 20.0.0 (2022-08-24)
 

--- a/packages/components/src/form-token-field/index.tsx
+++ b/packages/components/src/form-token-field/index.tsx
@@ -1,7 +1,6 @@
 /**
  * External dependencies
  */
-import { last, clone, map, some } from 'lodash';
 import classnames from 'classnames';
 import type { KeyboardEvent, MouseEvent, TouchEvent } from 'react';
 
@@ -258,7 +257,7 @@ export function FormTokenField( props: FormTokenFieldProps ) {
 		const text = event.value;
 		const separator = tokenizeOnSpace ? /[ ,\t]+/ : /[,\t]+/;
 		const items = text.split( separator );
-		const tokenValue = last( items ) || '';
+		const tokenValue = items[ items.length - 1 ] || '';
 
 		if ( items.length > 1 ) {
 			addNewTokens( items.slice( 0, -1 ) );
@@ -413,7 +412,7 @@ export function FormTokenField( props: FormTokenFieldProps ) {
 		];
 
 		if ( tokensToAdd.length > 0 ) {
-			const newValue = clone( value );
+			const newValue = [ ...value ];
 			newValue.splice( getIndexOfInput(), 0, ...tokensToAdd );
 			onChange( newValue );
 		}
@@ -503,7 +502,7 @@ export function FormTokenField( props: FormTokenFieldProps ) {
 	}
 
 	function valueContainsToken( token: string ) {
-		return some( value, ( item ) => {
+		return value.some( ( item ) => {
 			return getTokenValue( token ) === getTokenValue( item );
 		} );
 	}
@@ -564,7 +563,7 @@ export function FormTokenField( props: FormTokenFieldProps ) {
 	}
 
 	function renderTokensAndInput() {
-		const components = map( value, renderToken );
+		const components = value.map( renderToken );
 		components.splice( getIndexOfInput(), 0, renderInput() );
 
 		return components;

--- a/packages/components/src/form-token-field/suggestions-list.tsx
+++ b/packages/components/src/form-token-field/suggestions-list.tsx
@@ -1,7 +1,6 @@
 /**
  * External dependencies
  */
-import { map } from 'lodash';
 import scrollView from 'dom-scroll-into-view';
 import classnames from 'classnames';
 import type { MouseEventHandler, ReactNode } from 'react';
@@ -114,7 +113,7 @@ export function SuggestionsList< T extends string | { value: string } >( {
 			id={ `components-form-token-suggestions-${ instanceId }` }
 			role="listbox"
 		>
-			{ map( suggestions, ( suggestion, index ) => {
+			{ suggestions.map( ( suggestion, index ) => {
 				const matchText = computeSuggestionMatch( suggestion );
 				const className = classnames(
 					'components-form-token-field__suggestion',


### PR DESCRIPTION
## What?
This PR removes all Lodash usage from the `<FormTokenField />` component.

## Why?

Lodash is known to unnecessarily inflate the bundle size of packages, and in most cases, it can be replaced with native language functionality. See these for more information and rationale:

* https://github.com/WordPress/gutenberg/issues/16938#issuecomment-602837246
* https://github.com/WordPress/gutenberg/issues/17025
* https://github.com/WordPress/gutenberg/issues/39495 

## How?

All usages are straightforwardly replaced with native Array prototype functionality.

## Testing Instructions
* Verify tests still pass: `npm run test:unit packages/components/src/form-token-field`
* Smoke test the `FormTokenField` component in Storybook.