### PR TITLE
[WiP] E2E: Clear session storage before creating new post

### DIFF
--- a/packages/e2e-test-utils/README.md
+++ b/packages/e2e-test-utils/README.md
@@ -64,6 +64,10 @@ _Returns_
 
 Clears the local storage.
 
+### clearSessionStorage
+
+Clears the session storage.
+
 ### clickBlockAppender
 
 Clicks the default block appender.

--- a/packages/e2e-test-utils/src/clear-session-storage.js
+++ b/packages/e2e-test-utils/src/clear-session-storage.js
@@ -1,0 +1,6 @@
+/**
+ * Clears the session storage.
+ */
+export async function clearSessionStorage() {
+	await page.evaluate( () => window.sessionStorage.clear() );
+}

--- a/packages/e2e-test-utils/src/create-new-post.js
+++ b/packages/e2e-test-utils/src/create-new-post.js
@@ -2,6 +2,7 @@
  * WordPress dependencies
  */
 import { addQueryArgs } from '@wordpress/url';
+import { clearSessionStorage } from '@wordpress/e2e-test-utils';
 
 /**
  * Internal dependencies
@@ -25,6 +26,8 @@ export async function createNewPost( {
 	excerpt,
 	showWelcomeGuide = false,
 } = {} ) {
+	await clearSessionStorage();
+
 	const query = addQueryArgs( '', {
 		post_type: postType,
 		post_title: title,

--- a/packages/e2e-test-utils/src/index.js
+++ b/packages/e2e-test-utils/src/index.js
@@ -8,6 +8,7 @@ export { arePrePublishChecksEnabled } from './are-pre-publish-checks-enabled';
 export { changeSiteTimezone } from './change-site-timezone';
 export { canvas } from './canvas';
 export { clearLocalStorage } from './clear-local-storage';
+export { clearSessionStorage } from './clear-session-storage';
 export { clickBlockAppender } from './click-block-appender';
 export { clickBlockToolbarButton } from './click-block-toolbar-button';
 export { clickButton } from './click-button';

--- a/packages/e2e-tests/specs/editor/various/autosave.test.js
+++ b/packages/e2e-tests/specs/editor/various/autosave.test.js
@@ -2,6 +2,7 @@
  * WordPress dependencies
  */
 import {
+	clearSessionStorage,
 	clickBlockAppender,
 	createNewPost,
 	getEditedPostContent,
@@ -35,10 +36,6 @@ async function sleep( durationInSeconds ) {
 	// of waiting for a given amount of time.
 	// eslint-disable-next-line no-restricted-syntax
 	await page.waitForTimeout( durationInSeconds * 1000 );
-}
-
-async function clearSessionStorage() {
-	await page.evaluate( () => window.sessionStorage.clear() );
 }
 
 async function readSessionStorageAutosave( postId ) {

--- a/packages/e2e-tests/specs/editor/various/draggable-block.test.js
+++ b/packages/e2e-tests/specs/editor/various/draggable-block.test.js
@@ -12,7 +12,7 @@ import {
 	clickBlockAppender,
 } from '@wordpress/e2e-test-utils';
 
-describe.skip( 'Draggable block', () => {
+describe( 'Draggable block', () => {
 	// Tests don't seem to pass if beforeAll and afterAll are used.
 	// Unsure why.
 	beforeEach( async () => {


### PR DESCRIPTION
This should prevent the autosave draft backup banned from popping up. Also, it provides more isolation between tests.

<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

https://github.com/WordPress/gutenberg/issues/43737

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->

## Screenshots or screencast <!-- if applicable -->
