### PR TITLE
Fix layout applied to post editor on classic themes

### DIFF
--- a/packages/edit-post/src/components/visual-editor/index.js
+++ b/packages/edit-post/src/components/visual-editor/index.js
@@ -185,9 +185,13 @@ export default function VisualEditor( { styles } ) {
 			// so we add the constrained type.
 			return { ...defaultLayout, type: 'constrained' };
 		}
-		// Set constrained layout for classic themes so all alignments are supported.
-		return { type: 'constrained' };
+		// Set default layout for classic themes so all alignments are supported.
+		return { type: 'default' };
 	}, [ isTemplateMode, themeSupportsLayout, defaultLayout ] );
+
+	const blockListLayoutClass = themeSupportsLayout
+		? 'is-layout-constrained'
+		: 'is-layout-flow';
 
 	const titleRef = useRef();
 	useEffect( () => {
@@ -267,7 +271,7 @@ export default function VisualEditor( { styles } ) {
 								className={
 									isTemplateMode
 										? 'wp-site-blocks'
-										: 'is-layout-constrained' // Ensure root level blocks receive default/flow blockGap styling rules.
+										: blockListLayoutClass // Ensure root level blocks receive default/flow blockGap styling rules.
 								}
 								__experimentalLayout={ layout }
 							/>


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Fixes #43752

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

The wrong layout class was being applied in the post editor when classic themes are in use.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->

1. With TwentyTwenty, add some content in a post;
2. Check that post content has the proper content width.

## Screenshots or screencast <!-- if applicable -->

Before:
<img width="893" alt="Screen Shot 2022-09-01 at 11 21 58 am" src="https://user-images.githubusercontent.com/8096000/187812374-6e0cf4a7-585d-4700-94f6-df4b8f4d5e06.png">

After:

<img width="893" alt="Screen Shot 2022-09-01 at 11 22 07 am" src="https://user-images.githubusercontent.com/8096000/187812389-612857f7-22a2-4aac-bb2a-ac5d77ac284e.png">
