### PR TITLE
Layout: Fix undefined index notice when attempting to check layout type

### DIFF
--- a/lib/block-supports/layout.php
+++ b/lib/block-supports/layout.php
@@ -297,7 +297,11 @@ function gutenberg_render_layout_support_flag( $block_content, $block ) {
 		$used_layout['type'] = 'constrained';
 	}
 
-	if ( gutenberg_get_global_settings( array( 'useRootPaddingAwareAlignments' ) ) && 'constrained' === $used_layout['type'] ) {
+	if (
+		gutenberg_get_global_settings( array( 'useRootPaddingAwareAlignments' ) ) &&
+		isset( $used_layout['type'] ) &&
+		'constrained' === $used_layout['type']
+	) {
 		$class_names[] = 'has-global-padding';
 	}
 


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Fixes an issue introduced in: https://github.com/WordPress/gutenberg/pull/43689

Add an additional `isset()` check before checking the layout type in `layout.php` to prevent a PHP notice about an undefined index

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

For blocks that don't have a type set, an undefined index notice is currently being output when rendering a post or page

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

Add an additional `isset()` check to prevent the notice from being output

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->

With TwentyTwentyTwo theme, go to view the site, and the PHP notices should not appear in `debug.log` with this PR applied.

Ensure that the fix from https://github.com/WordPress/gutenberg/pull/43689 still appears to be working correctly.

## Screenshots or screencast <!-- if applicable -->

Before, I was seeing lots of the following notice:

![image](https://user-images.githubusercontent.com/14988353/187832529-dc3f3b84-1720-4768-8d1d-f0190b1ca4b5.png)

After, the notice should no longer be output.