### PR TITLE
Layout: Fix blockGap output when using a falsy 0 value

### DIFF
--- a/lib/block-supports/layout.php
+++ b/lib/block-supports/layout.php
@@ -46,7 +46,7 @@ function gutenberg_get_layout_style( $selector, $layout, $has_block_gap_support 
 			if ( is_array( $gap_value ) ) {
 				$gap_value = isset( $gap_value['top'] ) ? $gap_value['top'] : null;
 			}
-			if ( $gap_value && ! $should_skip_gap_serialization ) {
+			if ( null !== $gap_value && ! $should_skip_gap_serialization ) {
 				array_push(
 					$layout_styles,
 					array(
@@ -129,7 +129,7 @@ function gutenberg_get_layout_style( $selector, $layout, $has_block_gap_support 
 			if ( is_array( $gap_value ) ) {
 				$gap_value = isset( $gap_value['top'] ) ? $gap_value['top'] : null;
 			}
-			if ( $gap_value && ! $should_skip_gap_serialization ) {
+			if ( null !== $gap_value && ! $should_skip_gap_serialization ) {
 				// Get spacing CSS variable from preset value if provided.
 				if ( is_string( $gap_value ) && str_contains( $gap_value, 'var:preset|spacing|' ) ) {
 					$index_to_splice = strrpos( $gap_value, '|' ) + 1;

--- a/lib/block-supports/layout.php
+++ b/lib/block-supports/layout.php
@@ -198,7 +198,7 @@ function gutenberg_get_layout_style( $selector, $layout, $has_block_gap_support 
 			}
 			$gap_value = trim( $combined_gap_value );
 
-			if ( $gap_value && ! $should_skip_gap_serialization ) {
+			if ( null !== $gap_value && ! $should_skip_gap_serialization ) {
 				$layout_styles[] = array(
 					'selector'     => $selector,
 					'declarations' => array( 'gap' => $gap_value ),

--- a/lib/compat/wordpress-6.1/class-wp-theme-json-6-1.php
+++ b/lib/compat/wordpress-6.1/class-wp-theme-json-6-1.php
@@ -1345,7 +1345,7 @@ class WP_Theme_JSON_6_1 extends WP_Theme_JSON_6_0 {
 				}
 			}
 
-			if ( $block_gap_value ) {
+			if ( null !== $block_gap_value ) {
 				foreach ( $layout_definitions as $layout_definition_key => $layout_definition ) {
 					// Allow skipping default layout for themes that opt-in to block styles, but opt-out of blockGap.
 					if ( ! $has_block_gap_support && 'default' === $layout_definition_key ) {


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

This fixes an issue exposed by https://github.com/WordPress/gutenberg/pull/43466 where block gap values of `0` applied at the individual block level would not be output in server-rendering due to them using a falsy value.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

Previously, custom values of `0` were being stored as `0px` which is a non-falsy string. However, `0` as a string is falsy in PHP so the output was being skipped.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

Do a non-null check instead of a truthy check for blockGap before outputting the layout styles.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->

1. In a post or page, add a Group block with a couple of child blocks, and set block spacing to the `0` preset value.
2. On the site frontend, check that the `0` spacing is being applied between child elements
3. Repeat with the Social Icons block

Or, test with the following block markup

<details>

<summary>Test block markup</summary>

```html
<!-- wp:group {"layout":{"type":"constrained"},"style":{"spacing":{"blockGap":"0"}}} -->
<div class="wp-block-group"><!-- wp:paragraph -->
<p>A paragraph</p>
<!-- /wp:paragraph -->

<!-- wp:paragraph -->
<p>A paragraph</p>
<!-- /wp:paragraph --></div>
<!-- /wp:group -->

<!-- wp:group {"layout":{"type":"default"},"style":{"spacing":{"blockGap":"0"}}} -->
<div class="wp-block-group"><!-- wp:paragraph -->
<p>A paragraph</p>
<!-- /wp:paragraph -->

<!-- wp:paragraph -->
<p>A paragraph</p>
<!-- /wp:paragraph --></div>
<!-- /wp:group -->

<!-- wp:social-links {"style":{"spacing":{"blockGap":{"top":"0","left":"0"}}}} -->
<ul class="wp-block-social-links"><!-- wp:social-link {"url":"wordpress.org","service":"wordpress"} /-->

<!-- wp:social-link {"url":"wordpress.org","service":"wordpress"} /-->

<!-- wp:social-link {"url":"wordpress.org","service":"wordpress"} /--></ul>
<!-- /wp:social-links -->
```

</details>


## Screenshots or screencast <!-- if applicable -->

With this PR applied, the output should look like the following:

<img width="1065" alt="image" src="https://user-images.githubusercontent.com/14988353/187840610-0e2bab42-460c-4744-a103-48cfd4e1dfb3.png">
