### PR TITLE
List block: prevent error upon pasting when list is empty

### DIFF
--- a/packages/block-library/src/list/utils.js
+++ b/packages/block-library/src/list/utils.js
@@ -25,7 +25,7 @@ export function createListBlockFromDOMElement( listElement ) {
 			const [ nestedList, ...nodes ] = children;
 
 			const hasNestedList =
-				nestedList.tagName === 'UL' || nestedList.tagName === 'OL';
+				nestedList?.tagName === 'UL' || nestedList?.tagName === 'OL';
 			if ( ! hasNestedList ) {
 				return createBlock( 'core/list-item', {
 					content: listItem.innerHTML,

--- a/test/e2e/specs/editor/blocks/__snapshots__/List-can-be-created-by-pasting-an-empty-list-1-chromium.txt
+++ b/test/e2e/specs/editor/blocks/__snapshots__/List-can-be-created-by-pasting-an-empty-list-1-chromium.txt
@@ -1,0 +1,5 @@
+<!-- wp:list -->
+<ul><!-- wp:list-item -->
+<li></li>
+<!-- /wp:list-item --></ul>
+<!-- /wp:list -->

--- a/test/e2e/specs/editor/blocks/list.spec.js
+++ b/test/e2e/specs/editor/blocks/list.spec.js
@@ -1138,7 +1138,7 @@ test.describe( 'List', () => {
 		pageUtils,
 	} ) => {
 		// Open code editor
-		await pageUtils.pressKeyWithModifier( 'secondary', 'M' ); // Emulates CTRL+Shift+Alt + M => open code editor
+		await pageUtils.pressKeyWithModifier( 'secondary', 'M' ); // Emulates CTRL+Shift+Alt + M => toggle code editor
 
 		// Paste empty list block
 		await pageUtils.setClipboardData( {
@@ -1146,6 +1146,9 @@ test.describe( 'List', () => {
 				'<!-- wp:list -->\n<ul><li></li></ul>\n<!-- /wp:list -->',
 		} );
 		await pageUtils.pressKeyWithModifier( 'primary', 'v' );
+
+		// Go back to normal editor
+		await pageUtils.pressKeyWithModifier( 'secondary', 'M' ); // Emulates CTRL+Shift+Alt + M => toggle code editor
 
 		// Verify no WSOD and content is proper.
 		expect( await editor.getEditedPostContent() ).toMatchSnapshot();

--- a/test/e2e/specs/editor/blocks/list.spec.js
+++ b/test/e2e/specs/editor/blocks/list.spec.js
@@ -1132,4 +1132,22 @@ test.describe( 'List', () => {
 <!-- /wp:list -->`
 		);
 	} );
+
+	test( 'can be created by pasting an empty list', async ( {
+		editor,
+		pageUtils,
+	} ) => {
+		// Open code editor
+		await pageUtils.pressKeyWithModifier( 'secondary', 'M' ); // Emulates CTRL+Shift+Alt + M => open code editor
+
+		// Paste empty list block
+		await pageUtils.setClipboardData( {
+			plainText:
+				'<!-- wp:list -->\n<ul><li></li></ul>\n<!-- /wp:list -->',
+		} );
+		await pageUtils.pressKeyWithModifier( 'primary', 'v' );
+
+		// Verify no WSOD and content is proper.
+		expect( await editor.getEditedPostContent() ).toMatchSnapshot();
+	} );
 } );


### PR DESCRIPTION
Fixes https://github.com/WordPress/gutenberg/issues/43753