### PR TITLE
Fix: Site logo rounded.

### DIFF
--- a/packages/block-library/src/site-logo/editor.scss
+++ b/packages/block-library/src/site-logo/editor.scss
@@ -39,6 +39,11 @@
 		width: 120px;
 	}
 
+	// Inherit radius.
+	.components-resizable-box__container {
+		border-radius: inherit;
+	}
+
 	// Style the placeholder.
 	.components-placeholder {
 		justify-content: center;

--- a/packages/components/src/placeholder/style.scss
+++ b/packages/components/src/placeholder/style.scss
@@ -189,6 +189,10 @@
 
 	.components-placeholder__fieldset {
 		width: auto;
+
+		// Unset intrinsic margins.
+		margin-left: 0;
+		margin-right: 0;
 	}
 
 	// Show placeholder buttons on block selection.


### PR DESCRIPTION
## What?

Placeholders have recently been refactored and simplified. As a result, the radius inheritance of the site logo set to "rounded" broke, in the editor only:
<img width="363" alt="Screenshot 2022-09-01 at 09 52 09" src="https://user-images.githubusercontent.com/1204802/187861697-8fd552ad-edce-4067-b9f0-9fd97c37a27d.png">

This PR fixes it:

<img width="341" alt="Screenshot 2022-09-01 at 09 41 44" src="https://user-images.githubusercontent.com/1204802/187861713-2ec6d1ed-0d22-46bd-881e-1c2aab5f4cb1.png">

It also fixes an issue where the fieldset inside has intrinsic margins that made it slightly oval:

<img width="347" alt="Screenshot 2022-09-01 at 09 43 18" src="https://user-images.githubusercontent.com/1204802/187861795-4010d07f-d728-4016-ae0e-a61838a26b10.png">

<img width="309" alt="Screenshot 2022-09-01 at 09 49 50" src="https://user-images.githubusercontent.com/1204802/187861810-cb149c5c-bd66-4feb-870d-cbf381e07648.png">

## Testing Instructions

Test TT3, or a site header that uses a very small site logo.

Set that to rounded. Test that the placeholder, and the resulting logo if you add an image, are both perfect circles.