### PR TITLE
Editor: Simplify 'findOrCreateTerm' method logic

### DIFF
--- a/packages/editor/src/components/post-taxonomies/flat-term-selector.js
+++ b/packages/editor/src/components/post-taxonomies/flat-term-selector.js
@@ -13,14 +13,13 @@ import { useSelect, useDispatch } from '@wordpress/data';
 import { store as coreStore } from '@wordpress/core-data';
 import { useDebounce } from '@wordpress/compose';
 import apiFetch from '@wordpress/api-fetch';
-import { addQueryArgs } from '@wordpress/url';
 import { speak } from '@wordpress/a11y';
 
 /**
  * Internal dependencies
  */
 import { store as editorStore } from '../../store';
-import { unescapeString, unescapeTerm, unescapeTerms } from '../../utils/terms';
+import { unescapeString, unescapeTerm } from '../../utils/terms';
 import MostUsedTerms from './most-used-terms';
 
 /**
@@ -64,24 +63,14 @@ function findOrCreateTerm( termName, restBase, namespace ) {
 		data: { name: escapedTermName },
 	} )
 		.catch( ( error ) => {
-			const errorCode = error.code;
-			if ( errorCode === 'term_exists' ) {
-				// If the terms exist, fetch it instead of creating a new one.
-				const addRequest = apiFetch( {
-					path: addQueryArgs( `/${ namespace }/${ restBase }`, {
-						...DEFAULT_QUERY,
-						search: escapedTermName,
-					} ),
-				} ).then( unescapeTerms );
-
-				return addRequest.then( ( searchResult ) => {
-					return find( searchResult, ( result ) =>
-						isSameTermName( result.name, termName )
-					);
-				} );
+			if ( error.code !== 'term_exists' ) {
+				return Promise.reject( error );
 			}
 
-			return Promise.reject( error );
+			return Promise.resolve( {
+				id: error.data.term_id,
+				name: termName,
+			} );
 		} )
 		.then( unescapeTerm );
 }


### PR DESCRIPTION
## What?
Fixes #40850.

PR updates the `findOrCreateTerm` method and removes additional API call for searching existing term. The search request could fail when matches exceed the hardcoded limit and using unbound queries for search can have performance costs.

Updated logic:

* If hander fails and error code `error.code !== 'term_exists'`, we return rejected promise with that error.
* If the error code is `term_exists`. Error response already contains `term_id`; we use this to return resolved promise.

## Testing Instructions
1. Use testing instructions from https://github.com/WordPress/gutenberg/issues/40850#issuecomment-1140369903.
2. Confirm that there's no `TypeError: Cannot read properties of undefined (reading name)` error.
3. The 400 response is expected because of the `term_exists` error.

## Screenshots or screencast <!-- if applicable -->

https://user-images.githubusercontent.com/240569/187885663-190ca7cf-fd46-4ca7-be9f-a3fa510f1942.mp4

