### PR TITLE
Image: Display upload error notices using snackbars

### DIFF
--- a/packages/block-library/src/image/edit.js
+++ b/packages/block-library/src/image/edit.js
@@ -8,8 +8,8 @@ import { get, isEmpty, pick } from 'lodash';
  * WordPress dependencies
  */
 import { getBlobByURL, isBlobURL, revokeBlobURL } from '@wordpress/blob';
-import { withNotices, Placeholder } from '@wordpress/components';
-import { useSelect } from '@wordpress/data';
+import { Placeholder } from '@wordpress/components';
+import { useDispatch, useSelect } from '@wordpress/data';
 import {
 	BlockAlignmentControl,
 	BlockControls,
@@ -22,6 +22,7 @@ import {
 import { useEffect, useRef, useState } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import { image as icon } from '@wordpress/icons';
+import { store as noticesStore } from '@wordpress/notices';
 
 /**
  * Internal dependencies
@@ -108,9 +109,7 @@ export function ImageEdit( {
 	setAttributes,
 	isSelected,
 	className,
-	noticeUI,
 	insertBlocksAfter,
-	noticeOperations,
 	onReplace,
 	context,
 	clientId,
@@ -143,9 +142,9 @@ export function ImageEdit( {
 		return pick( getSettings(), [ 'imageDefaultSize', 'mediaUpload' ] );
 	}, [] );
 
+	const { createErrorNotice } = useDispatch( noticesStore );
 	function onUploadError( message ) {
-		noticeOperations.removeAllNotices();
-		noticeOperations.createErrorNotice( message );
+		createErrorNotice( message, { type: 'snackbar' } );
 		setAttributes( {
 			src: undefined,
 			id: undefined,
@@ -361,7 +360,6 @@ export function ImageEdit( {
 				icon={ <BlockIcon icon={ icon } /> }
 				onSelect={ onSelectImage }
 				onSelectURL={ onSelectURL }
-				notices={ noticeUI }
 				onError={ onUploadError }
 				placeholder={ placeholder }
 				accept="image/*"
@@ -374,4 +372,4 @@ export function ImageEdit( {
 	);
 }
 
-export default withNotices( ImageEdit );
+export default ImageEdit;


### PR DESCRIPTION
## What?
A follow-up to https://github.com/WordPress/gutenberg/pull/43180#issuecomment-1234039528.

PR updates image block `onUploadError` method to use snackbar error notices.

## Why?
The new placeholder state doesn't display Notice UI. Matches behavior of Site Logo and Post Feature Image blocks, which also use alternative placeholder states.

## Testing Instructions
1. Create an empty image - `touch empty.png`
2. Open a post or page
3. Insert an image block
4. Drag and drop the newly created empty image.
5. Confirm that the error message is displayed as snackbar.

## Screenshots or screencast <!-- if applicable -->

https://user-images.githubusercontent.com/240569/187889744-bcb3023b-d33f-4ec2-9898-eb1bb6ffdc6e.mp4


