### PR TITLE
Updates the content we use for performance testing

### DIFF
--- a/packages/e2e-tests/assets/large-post.html
+++ b/packages/e2e-tests/assets/large-post.html
@@ -7,7 +7,17 @@
 <!-- /wp:paragraph -->
 
 <!-- wp:list -->
-<ul><li>At habetur! Et ego id scilicet nesciebam! Sed ut sit, etiamne post mortem coletur?</li><li>Totum genus hoc Zeno et qui ab eo sunt aut non potuerunt aut noluerunt, certe reliquerunt.</li><li>At quicum ioca seria, ut dicitur, quicum arcana, quicum occulta omnia?</li></ul>
+<ul><!-- wp:list-item -->
+<li>At habetur! Et ego id scilicet nesciebam! Sed ut sit, etiamne post mortem coletur?</li>
+<!-- /wp:list-item -->
+
+<!-- wp:list-item -->
+<li>Totum genus hoc Zeno et qui ab eo sunt aut non potuerunt aut noluerunt, certe reliquerunt.</li>
+<!-- /wp:list-item -->
+
+<!-- wp:list-item -->
+<li>At quicum ioca seria, ut dicitur, quicum arcana, quicum occulta omnia?</li>
+<!-- /wp:list-item --></ul>
 <!-- /wp:list -->
 
 <!-- wp:paragraph -->
@@ -95,7 +105,17 @@
 <!-- /wp:quote -->
 
 <!-- wp:list -->
-<ul><li>Alterum significari idem, ut si diceretur, officia media omnia aut pleraque servantem vivere.</li><li>Quid enim tanto opus est instrumento in optimis artibus comparandis?</li><li>At cum de plurimis eadem dicit, tum certe de maximis.</li></ul>
+<ul><!-- wp:list-item -->
+<li>Alterum significari idem, ut si diceretur, officia media omnia aut pleraque servantem vivere.</li>
+<!-- /wp:list-item -->
+
+<!-- wp:list-item -->
+<li>Quid enim tanto opus est instrumento in optimis artibus comparandis?</li>
+<!-- /wp:list-item -->
+
+<!-- wp:list-item -->
+<li>At cum de plurimis eadem dicit, tum certe de maximis.</li>
+<!-- /wp:list-item --></ul>
 <!-- /wp:list -->
 
 <!-- wp:paragraph -->
@@ -155,7 +175,21 @@
 <!-- /wp:paragraph -->
 
 <!-- wp:list -->
-<ul><li>Etsi qui potest intellegi aut cogitari esse aliquod animal, quod se oderit?</li><li>Summum ením bonum exposuit vacuitatem doloris;</li><li>Satisne ergo pudori consulat, si quis sine teste libidini pareat?</li><li>Quamquam haec quidem praeposita recte et reiecta dicere licebit.</li></ul>
+<ul><!-- wp:list-item -->
+<li>Etsi qui potest intellegi aut cogitari esse aliquod animal, quod se oderit?</li>
+<!-- /wp:list-item -->
+
+<!-- wp:list-item -->
+<li>Summum ením bonum exposuit vacuitatem doloris;</li>
+<!-- /wp:list-item -->
+
+<!-- wp:list-item -->
+<li>Satisne ergo pudori consulat, si quis sine teste libidini pareat?</li>
+<!-- /wp:list-item -->
+
+<!-- wp:list-item -->
+<li>Quamquam haec quidem praeposita recte et reiecta dicere licebit.</li>
+<!-- /wp:list-item --></ul>
 <!-- /wp:list -->
 
 <!-- wp:paragraph -->
@@ -235,7 +269,21 @@
 <!-- /wp:paragraph -->
 
 <!-- wp:list -->
-<ul><li>Ubi ut eam caperet aut quando?</li><li>Quod autem ratione actum est, id officium appellamus.</li><li>Tu enim ista lenius, hic Stoicorum more nos vexat.</li><li>Qui igitur convenit ab alia voluptate dicere naturam proficisci, in alia summum bonum ponere?</li></ul>
+<ul><!-- wp:list-item -->
+<li>Ubi ut eam caperet aut quando?</li>
+<!-- /wp:list-item -->
+
+<!-- wp:list-item -->
+<li>Quod autem ratione actum est, id officium appellamus.</li>
+<!-- /wp:list-item -->
+
+<!-- wp:list-item -->
+<li>Tu enim ista lenius, hic Stoicorum more nos vexat.</li>
+<!-- /wp:list-item -->
+
+<!-- wp:list-item -->
+<li>Qui igitur convenit ab alia voluptate dicere naturam proficisci, in alia summum bonum ponere?</li>
+<!-- /wp:list-item --></ul>
 <!-- /wp:list -->
 
 <!-- wp:paragraph -->
@@ -335,7 +383,29 @@
 <!-- /wp:paragraph -->
 
 <!-- wp:list -->
-<ul><li>Universa enim illorum ratione cum tota vestra confligendum puto.</li><li>Iam enim adesse poterit.</li><li>Haec et tu ita posuisti, et verba vestra sunt.</li><li>Utrum igitur tibi litteram videor an totas paginas commovere?</li><li>Haec bene dicuntur, nec ego repugno, sed inter sese ipsa pugnant.</li><li>Quod si ita sit, cur opera philosophiae sit danda nescio.</li></ul>
+<ul><!-- wp:list-item -->
+<li>Universa enim illorum ratione cum tota vestra confligendum puto.</li>
+<!-- /wp:list-item -->
+
+<!-- wp:list-item -->
+<li>Iam enim adesse poterit.</li>
+<!-- /wp:list-item -->
+
+<!-- wp:list-item -->
+<li>Haec et tu ita posuisti, et verba vestra sunt.</li>
+<!-- /wp:list-item -->
+
+<!-- wp:list-item -->
+<li>Utrum igitur tibi litteram videor an totas paginas commovere?</li>
+<!-- /wp:list-item -->
+
+<!-- wp:list-item -->
+<li>Haec bene dicuntur, nec ego repugno, sed inter sese ipsa pugnant.</li>
+<!-- /wp:list-item -->
+
+<!-- wp:list-item -->
+<li>Quod si ita sit, cur opera philosophiae sit danda nescio.</li>
+<!-- /wp:list-item --></ul>
 <!-- /wp:list -->
 
 <!-- wp:paragraph -->
@@ -371,7 +441,25 @@
 <!-- /wp:paragraph -->
 
 <!-- wp:list -->
-<ul><li>Quod idem cum vestri faciant, non satis magnam tribuunt inventoribus gratiam.</li><li>Quae enim adhuc protulisti, popularia sunt, ego autem a te elegantiora desidero.</li><li>Si longus, levis dictata sunt.</li><li>Sed virtutem ipsam inchoavit, nihil amplius.</li><li>Suo genere perveniant ad extremum;</li></ul>
+<ul><!-- wp:list-item -->
+<li>Quod idem cum vestri faciant, non satis magnam tribuunt inventoribus gratiam.</li>
+<!-- /wp:list-item -->
+
+<!-- wp:list-item -->
+<li>Quae enim adhuc protulisti, popularia sunt, ego autem a te elegantiora desidero.</li>
+<!-- /wp:list-item -->
+
+<!-- wp:list-item -->
+<li>Si longus, levis dictata sunt.</li>
+<!-- /wp:list-item -->
+
+<!-- wp:list-item -->
+<li>Sed virtutem ipsam inchoavit, nihil amplius.</li>
+<!-- /wp:list-item -->
+
+<!-- wp:list-item -->
+<li>Suo genere perveniant ad extremum;</li>
+<!-- /wp:list-item --></ul>
 <!-- /wp:list -->
 
 <!-- wp:paragraph -->
@@ -443,7 +531,25 @@
 <!-- /wp:paragraph -->
 
 <!-- wp:list -->
-<ul><li>Disserendi artem nullam habuit.</li><li>Ita relinquet duas, de quibus etiam atque etiam consideret.</li><li>Et certamen honestum et disputatio splendida! omnis est enim de virtutis dignitate contentio.</li><li>Transfer idem ad modestiam vel temperantiam, quae est moderatio cupiditatum rationi oboediens.</li><li>Sin dicit obscurari quaedam nec apparere, quia valde parva sint, nos quoque concedimus;</li></ul>
+<ul><!-- wp:list-item -->
+<li>Disserendi artem nullam habuit.</li>
+<!-- /wp:list-item -->
+
+<!-- wp:list-item -->
+<li>Ita relinquet duas, de quibus etiam atque etiam consideret.</li>
+<!-- /wp:list-item -->
+
+<!-- wp:list-item -->
+<li>Et certamen honestum et disputatio splendida! omnis est enim de virtutis dignitate contentio.</li>
+<!-- /wp:list-item -->
+
+<!-- wp:list-item -->
+<li>Transfer idem ad modestiam vel temperantiam, quae est moderatio cupiditatum rationi oboediens.</li>
+<!-- /wp:list-item -->
+
+<!-- wp:list-item -->
+<li>Sin dicit obscurari quaedam nec apparere, quia valde parva sint, nos quoque concedimus;</li>
+<!-- /wp:list-item --></ul>
 <!-- /wp:list -->
 
 <!-- wp:quote -->
@@ -467,7 +573,17 @@
 <!-- /wp:paragraph -->
 
 <!-- wp:list -->
-<ul><li>Non potes ergo ista tueri, Torquate, mihi crede, si te ipse et tuas cogitationes et studia perspexeris;</li><li>Quod si ita sit, cur opera philosophiae sit danda nescio.</li><li>Occultum facinus esse potuerit, gaudebit;</li></ul>
+<ul><!-- wp:list-item -->
+<li>Non potes ergo ista tueri, Torquate, mihi crede, si te ipse et tuas cogitationes et studia perspexeris;</li>
+<!-- /wp:list-item -->
+
+<!-- wp:list-item -->
+<li>Quod si ita sit, cur opera philosophiae sit danda nescio.</li>
+<!-- /wp:list-item -->
+
+<!-- wp:list-item -->
+<li>Occultum facinus esse potuerit, gaudebit;</li>
+<!-- /wp:list-item --></ul>
 <!-- /wp:list -->
 
 <!-- wp:paragraph -->
@@ -495,7 +611,17 @@
 <!-- /wp:paragraph -->
 
 <!-- wp:list -->
-<ul><li>Utilitatis causa amicitia est quaesita.</li><li>Cuius similitudine perspecta in formarum specie ac dignitate transitum est ad honestatem dictorum atque factorum.</li><li>Mihi quidem Homerus huius modi quiddam vidisse videatur in iis, quae de Sirenum cantibus finxerit.</li></ul>
+<ul><!-- wp:list-item -->
+<li>Utilitatis causa amicitia est quaesita.</li>
+<!-- /wp:list-item -->
+
+<!-- wp:list-item -->
+<li>Cuius similitudine perspecta in formarum specie ac dignitate transitum est ad honestatem dictorum atque factorum.</li>
+<!-- /wp:list-item -->
+
+<!-- wp:list-item -->
+<li>Mihi quidem Homerus huius modi quiddam vidisse videatur in iis, quae de Sirenum cantibus finxerit.</li>
+<!-- /wp:list-item --></ul>
 <!-- /wp:list -->
 
 <!-- wp:paragraph -->
@@ -523,7 +649,21 @@
 <!-- /wp:paragraph -->
 
 <!-- wp:list -->
-<ul><li>Sit hoc ultimum bonorum, quod nunc a me defenditur;</li><li>Vos autem cum perspicuis dubia debeatis illustrare, dubiis perspicua conamini tollere.</li><li>Ipse Epicurus fortasse redderet, ut Sextus Peducaeus, Sex.</li><li>Non est igitur summum malum dolor.</li></ul>
+<ul><!-- wp:list-item -->
+<li>Sit hoc ultimum bonorum, quod nunc a me defenditur;</li>
+<!-- /wp:list-item -->
+
+<!-- wp:list-item -->
+<li>Vos autem cum perspicuis dubia debeatis illustrare, dubiis perspicua conamini tollere.</li>
+<!-- /wp:list-item -->
+
+<!-- wp:list-item -->
+<li>Ipse Epicurus fortasse redderet, ut Sextus Peducaeus, Sex.</li>
+<!-- /wp:list-item -->
+
+<!-- wp:list-item -->
+<li>Non est igitur summum malum dolor.</li>
+<!-- /wp:list-item --></ul>
 <!-- /wp:list -->
 
 <!-- wp:paragraph -->
@@ -655,7 +795,21 @@
 <!-- /wp:paragraph -->
 
 <!-- wp:list -->
-<ul><li>Cuius quidem, quoniam Stoicus fuit, sententia condemnata mihi videtur esse inanitas ista verborum.</li><li>Vulgo enim dicitur: Iucundi acti labores, nec male Euripidesconcludam, si potero, Latine;</li><li>Ab his oratores, ab his imperatores ac rerum publicarum principes extiterunt.</li><li>Sed tu, ut dignum est tua erga me et philosophiam voluntate ab adolescentulo suscepta, fac ut Metrodori tueare liberos.</li></ul>
+<ul><!-- wp:list-item -->
+<li>Cuius quidem, quoniam Stoicus fuit, sententia condemnata mihi videtur esse inanitas ista verborum.</li>
+<!-- /wp:list-item -->
+
+<!-- wp:list-item -->
+<li>Vulgo enim dicitur: Iucundi acti labores, nec male Euripidesconcludam, si potero, Latine;</li>
+<!-- /wp:list-item -->
+
+<!-- wp:list-item -->
+<li>Ab his oratores, ab his imperatores ac rerum publicarum principes extiterunt.</li>
+<!-- /wp:list-item -->
+
+<!-- wp:list-item -->
+<li>Sed tu, ut dignum est tua erga me et philosophiam voluntate ab adolescentulo suscepta, fac ut Metrodori tueare liberos.</li>
+<!-- /wp:list-item --></ul>
 <!-- /wp:list -->
 
 <!-- wp:paragraph -->
@@ -695,7 +849,21 @@
 <!-- /wp:paragraph -->
 
 <!-- wp:list -->
-<ul><li>Quid turpius quam sapientis vitam ex insipientium sermone pendere?</li><li>Quae quidem vel cum periculo est quaerenda vobis;</li><li>Si longus, levis.</li><li>Fortitudinis quaedam praecepta sunt ac paene leges, quae effeminari virum vetant in dolore.</li></ul>
+<ul><!-- wp:list-item -->
+<li>Quid turpius quam sapientis vitam ex insipientium sermone pendere?</li>
+<!-- /wp:list-item -->
+
+<!-- wp:list-item -->
+<li>Quae quidem vel cum periculo est quaerenda vobis;</li>
+<!-- /wp:list-item -->
+
+<!-- wp:list-item -->
+<li>Si longus, levis.</li>
+<!-- /wp:list-item -->
+
+<!-- wp:list-item -->
+<li>Fortitudinis quaedam praecepta sunt ac paene leges, quae effeminari virum vetant in dolore.</li>
+<!-- /wp:list-item --></ul>
 <!-- /wp:list -->
 
 <!-- wp:quote -->
@@ -707,7 +875,33 @@
 <!-- /wp:quote -->
 
 <!-- wp:list -->
-<ul><li>Ergo et avarus erit, sed finite, et adulter, verum habebit modum, et luxuriosus eodem modo.</li><li>Magno hic ingenio, sed res se tamen sic habet, ut nimis imperiosi philosophi sit vetare meminisse.</li><li>Beatus autem esse in maximarum rerum timore nemo potest.</li><li>Atqui iste locus est, Piso, tibi etiam atque etiam confirmandus, inquam;</li><li>Primum in nostrane potestate est, quid meminerimus?</li><li>Nec lapathi suavitatem acupenseri Galloni Laelius anteponebat, sed suavitatem ipsam neglegebat;</li><li>Est enim effectrix multarum et magnarum voluptatum.</li></ul>
+<ul><!-- wp:list-item -->
+<li>Ergo et avarus erit, sed finite, et adulter, verum habebit modum, et luxuriosus eodem modo.</li>
+<!-- /wp:list-item -->
+
+<!-- wp:list-item -->
+<li>Magno hic ingenio, sed res se tamen sic habet, ut nimis imperiosi philosophi sit vetare meminisse.</li>
+<!-- /wp:list-item -->
+
+<!-- wp:list-item -->
+<li>Beatus autem esse in maximarum rerum timore nemo potest.</li>
+<!-- /wp:list-item -->
+
+<!-- wp:list-item -->
+<li>Atqui iste locus est, Piso, tibi etiam atque etiam confirmandus, inquam;</li>
+<!-- /wp:list-item -->
+
+<!-- wp:list-item -->
+<li>Primum in nostrane potestate est, quid meminerimus?</li>
+<!-- /wp:list-item -->
+
+<!-- wp:list-item -->
+<li>Nec lapathi suavitatem acupenseri Galloni Laelius anteponebat, sed suavitatem ipsam neglegebat;</li>
+<!-- /wp:list-item -->
+
+<!-- wp:list-item -->
+<li>Est enim effectrix multarum et magnarum voluptatum.</li>
+<!-- /wp:list-item --></ul>
 <!-- /wp:list -->
 
 <!-- wp:paragraph -->
@@ -715,7 +909,21 @@
 <!-- /wp:paragraph -->
 
 <!-- wp:list -->
-<ul><li>Eiuro, inquit adridens, iniquum, hac quidem de re;</li><li>At ille pellit, qui permulcet sensum voluptate.</li><li>Primum in nostrane potestate est, quid meminerimus?</li><li>Itaque vides, quo modo loquantur, nova verba fingunt, deserunt usitata.</li></ul>
+<ul><!-- wp:list-item -->
+<li>Eiuro, inquit adridens, iniquum, hac quidem de re;</li>
+<!-- /wp:list-item -->
+
+<!-- wp:list-item -->
+<li>At ille pellit, qui permulcet sensum voluptate.</li>
+<!-- /wp:list-item -->
+
+<!-- wp:list-item -->
+<li>Primum in nostrane potestate est, quid meminerimus?</li>
+<!-- /wp:list-item -->
+
+<!-- wp:list-item -->
+<li>Itaque vides, quo modo loquantur, nova verba fingunt, deserunt usitata.</li>
+<!-- /wp:list-item --></ul>
 <!-- /wp:list -->
 
 <!-- wp:paragraph -->
@@ -731,7 +939,21 @@
 <!-- /wp:paragraph -->
 
 <!-- wp:list -->
-<ul><li>Plane idem, inquit, et maxima quidem, qua fieri nulla maior potest.</li><li>An ea, quae per vinitorem antea consequebatur, per se ipsa curabit?</li><li>Sit sane ista voluptas.</li><li>-delector enim, quamquam te non possum, ut ais, corrumpere, delector, inquam, et familia vestra et nomine.</li></ul>
+<ul><!-- wp:list-item -->
+<li>Plane idem, inquit, et maxima quidem, qua fieri nulla maior potest.</li>
+<!-- /wp:list-item -->
+
+<!-- wp:list-item -->
+<li>An ea, quae per vinitorem antea consequebatur, per se ipsa curabit?</li>
+<!-- /wp:list-item -->
+
+<!-- wp:list-item -->
+<li>Sit sane ista voluptas.</li>
+<!-- /wp:list-item -->
+
+<!-- wp:list-item -->
+<li>-delector enim, quamquam te non possum, ut ais, corrumpere, delector, inquam, et familia vestra et nomine.</li>
+<!-- /wp:list-item --></ul>
 <!-- /wp:list -->
 
 <!-- wp:paragraph -->
@@ -799,7 +1021,21 @@
 <!-- /wp:paragraph -->
 
 <!-- wp:list -->
-<ul><li>Sed haec in pueris;</li><li>Quid igitur dubitamus in tota eius natura quaerere quid sit effectum?</li><li>Sed non alienum est, quo facilius vis verbi intellegatur, rationem huius verbi faciendi Zenonis exponere.</li><li>Graecum enim hunc versum nostis omnes-: Suavis laborum est praeteritorum memoria.</li></ul>
+<ul><!-- wp:list-item -->
+<li>Sed haec in pueris;</li>
+<!-- /wp:list-item -->
+
+<!-- wp:list-item -->
+<li>Quid igitur dubitamus in tota eius natura quaerere quid sit effectum?</li>
+<!-- /wp:list-item -->
+
+<!-- wp:list-item -->
+<li>Sed non alienum est, quo facilius vis verbi intellegatur, rationem huius verbi faciendi Zenonis exponere.</li>
+<!-- /wp:list-item -->
+
+<!-- wp:list-item -->
+<li>Graecum enim hunc versum nostis omnes-: Suavis laborum est praeteritorum memoria.</li>
+<!-- /wp:list-item --></ul>
 <!-- /wp:list -->
 
 <!-- wp:paragraph -->
@@ -815,7 +1051,13 @@
 <!-- /wp:paragraph -->
 
 <!-- wp:list -->
-<ul><li>Ego quoque, inquit, didicerim libentius si quid attuleris, quam te reprehenderim.</li><li>Omnes enim iucundum motum, quo sensus hilaretur.</li></ul>
+<ul><!-- wp:list-item -->
+<li>Ego quoque, inquit, didicerim libentius si quid attuleris, quam te reprehenderim.</li>
+<!-- /wp:list-item -->
+
+<!-- wp:list-item -->
+<li>Omnes enim iucundum motum, quo sensus hilaretur.</li>
+<!-- /wp:list-item --></ul>
 <!-- /wp:list -->
 
 <!-- wp:quote -->
@@ -847,7 +1089,21 @@
 <!-- /wp:paragraph -->
 
 <!-- wp:list -->
-<ul><li>Quid enim dicis omne animal, simul atque sit ortum, applicatum esse ad se diligendum esseque in se conservando occupatum?</li><li>Ampulla enim sit necne sit, quis non iure optimo irrideatur, si laboret?</li><li>Qui non moveatur et offensione turpitudinis et comprobatione honestatis?</li><li>Ergo omni animali illud, quod appetiti positum est in eo, quod naturae est accommodatum.</li></ul>
+<ul><!-- wp:list-item -->
+<li>Quid enim dicis omne animal, simul atque sit ortum, applicatum esse ad se diligendum esseque in se conservando occupatum?</li>
+<!-- /wp:list-item -->
+
+<!-- wp:list-item -->
+<li>Ampulla enim sit necne sit, quis non iure optimo irrideatur, si laboret?</li>
+<!-- /wp:list-item -->
+
+<!-- wp:list-item -->
+<li>Qui non moveatur et offensione turpitudinis et comprobatione honestatis?</li>
+<!-- /wp:list-item -->
+
+<!-- wp:list-item -->
+<li>Ergo omni animali illud, quod appetiti positum est in eo, quod naturae est accommodatum.</li>
+<!-- /wp:list-item --></ul>
 <!-- /wp:list -->
 
 <!-- wp:heading {"level":5} -->
@@ -859,7 +1115,21 @@
 <!-- /wp:paragraph -->
 
 <!-- wp:list -->
-<ul><li>Sunt enim quasi prima elementa naturae, quibus ubertas orationis adhiberi vix potest, nec equidem eam cogito consectari.</li><li>Praeterea et appetendi et refugiendi et omnino rerum gerendarum initia proficiscuntur aut a voluptate aut a dolore.</li><li>Parvi enim primo ortu sic iacent, tamquam omnino sine animo sint.</li><li>Atqui, inquam, Cato, si istud optinueris, traducas me ad te totum licebit.</li></ul>
+<ul><!-- wp:list-item -->
+<li>Sunt enim quasi prima elementa naturae, quibus ubertas orationis adhiberi vix potest, nec equidem eam cogito consectari.</li>
+<!-- /wp:list-item -->
+
+<!-- wp:list-item -->
+<li>Praeterea et appetendi et refugiendi et omnino rerum gerendarum initia proficiscuntur aut a voluptate aut a dolore.</li>
+<!-- /wp:list-item -->
+
+<!-- wp:list-item -->
+<li>Parvi enim primo ortu sic iacent, tamquam omnino sine animo sint.</li>
+<!-- /wp:list-item -->
+
+<!-- wp:list-item -->
+<li>Atqui, inquam, Cato, si istud optinueris, traducas me ad te totum licebit.</li>
+<!-- /wp:list-item --></ul>
 <!-- /wp:list -->
 
 <!-- wp:heading {"level":5} -->
@@ -875,7 +1145,25 @@
 <!-- /wp:paragraph -->
 
 <!-- wp:list -->
-<ul><li>Sic, et quidem diligentius saepiusque ista loquemur inter nos agemusque communiter.</li><li>Dolere malum est: in crucem qui agitur, beatus esse non potest.</li><li>Sed ad bona praeterita redeamus.</li><li>Eodem modo is enim tibi nemo dabit, quod, expetendum sit, id esse laudabile.</li><li>Quid, cum volumus nomina eorum, qui quid gesserint, nota nobis esse, parentes, patriam, multa praeterea minime necessaria?</li></ul>
+<ul><!-- wp:list-item -->
+<li>Sic, et quidem diligentius saepiusque ista loquemur inter nos agemusque communiter.</li>
+<!-- /wp:list-item -->
+
+<!-- wp:list-item -->
+<li>Dolere malum est: in crucem qui agitur, beatus esse non potest.</li>
+<!-- /wp:list-item -->
+
+<!-- wp:list-item -->
+<li>Sed ad bona praeterita redeamus.</li>
+<!-- /wp:list-item -->
+
+<!-- wp:list-item -->
+<li>Eodem modo is enim tibi nemo dabit, quod, expetendum sit, id esse laudabile.</li>
+<!-- /wp:list-item -->
+
+<!-- wp:list-item -->
+<li>Quid, cum volumus nomina eorum, qui quid gesserint, nota nobis esse, parentes, patriam, multa praeterea minime necessaria?</li>
+<!-- /wp:list-item --></ul>
 <!-- /wp:list -->
 
 <!-- wp:paragraph -->
@@ -895,7 +1183,17 @@
 <!-- /wp:paragraph -->
 
 <!-- wp:list -->
-<ul><li>In quibus doctissimi illi veteres inesse quiddam caeleste et divinum putaverunt.</li><li>Graccho, eius fere, aequalí?</li><li>Quacumque enim ingredimur, in aliqua historia vestigium ponimus.</li></ul>
+<ul><!-- wp:list-item -->
+<li>In quibus doctissimi illi veteres inesse quiddam caeleste et divinum putaverunt.</li>
+<!-- /wp:list-item -->
+
+<!-- wp:list-item -->
+<li>Graccho, eius fere, aequalí?</li>
+<!-- /wp:list-item -->
+
+<!-- wp:list-item -->
+<li>Quacumque enim ingredimur, in aliqua historia vestigium ponimus.</li>
+<!-- /wp:list-item --></ul>
 <!-- /wp:list -->
 
 <!-- wp:quote -->
@@ -983,7 +1281,25 @@
 <!-- /wp:paragraph -->
 
 <!-- wp:list -->
-<ul><li>Atque his de rebus et splendida est eorum et illustris oratio.</li><li>Cupiditates non Epicuri divisione finiebat, sed sua satietate.</li><li>Atque his de rebus et splendida est eorum et illustris oratio.</li><li>Etenim si delectamur, cum scribimus, quis est tam invidus, qui ab eo nos abducat?</li><li>Sed quid minus probandum quam esse aliquem beatum nec satis beatum?</li></ul>
+<ul><!-- wp:list-item -->
+<li>Atque his de rebus et splendida est eorum et illustris oratio.</li>
+<!-- /wp:list-item -->
+
+<!-- wp:list-item -->
+<li>Cupiditates non Epicuri divisione finiebat, sed sua satietate.</li>
+<!-- /wp:list-item -->
+
+<!-- wp:list-item -->
+<li>Atque his de rebus et splendida est eorum et illustris oratio.</li>
+<!-- /wp:list-item -->
+
+<!-- wp:list-item -->
+<li>Etenim si delectamur, cum scribimus, quis est tam invidus, qui ab eo nos abducat?</li>
+<!-- /wp:list-item -->
+
+<!-- wp:list-item -->
+<li>Sed quid minus probandum quam esse aliquem beatum nec satis beatum?</li>
+<!-- /wp:list-item --></ul>
 <!-- /wp:list -->
 
 <!-- wp:quote -->
@@ -1035,7 +1351,17 @@
 <!-- /wp:paragraph -->
 
 <!-- wp:list -->
-<ul><li>Atqui reperies, inquit, in hoc quidem pertinacem;</li><li>Contemnit enim disserendi elegantiam, confuse loquitur.</li><li>Neque solum ea communia, verum etiam paria esse dixerunt.</li></ul>
+<ul><!-- wp:list-item -->
+<li>Atqui reperies, inquit, in hoc quidem pertinacem;</li>
+<!-- /wp:list-item -->
+
+<!-- wp:list-item -->
+<li>Contemnit enim disserendi elegantiam, confuse loquitur.</li>
+<!-- /wp:list-item -->
+
+<!-- wp:list-item -->
+<li>Neque solum ea communia, verum etiam paria esse dixerunt.</li>
+<!-- /wp:list-item --></ul>
 <!-- /wp:list -->
 
 <!-- wp:paragraph -->
@@ -1183,7 +1509,25 @@
 <!-- /wp:paragraph -->
 
 <!-- wp:list -->
-<ul><li>Neque solum ea communia, verum etiam paria esse dixerunt.</li><li>Qui autem de summo bono dissentit de tota philosophiae ratione dissentit.</li><li>Non enim, si omnia non sequebatur, idcirco non erat ortus illinc.</li><li>Ut nemo dubitet, eorum omnia officia quo spectare, quid sequi, quid fugere debeant?</li><li>Ab hoc autem quaedam non melius quam veteres, quaedam omnino relicta.</li></ul>
+<ul><!-- wp:list-item -->
+<li>Neque solum ea communia, verum etiam paria esse dixerunt.</li>
+<!-- /wp:list-item -->
+
+<!-- wp:list-item -->
+<li>Qui autem de summo bono dissentit de tota philosophiae ratione dissentit.</li>
+<!-- /wp:list-item -->
+
+<!-- wp:list-item -->
+<li>Non enim, si omnia non sequebatur, idcirco non erat ortus illinc.</li>
+<!-- /wp:list-item -->
+
+<!-- wp:list-item -->
+<li>Ut nemo dubitet, eorum omnia officia quo spectare, quid sequi, quid fugere debeant?</li>
+<!-- /wp:list-item -->
+
+<!-- wp:list-item -->
+<li>Ab hoc autem quaedam non melius quam veteres, quaedam omnino relicta.</li>
+<!-- /wp:list-item --></ul>
 <!-- /wp:list -->
 
 <!-- wp:quote -->
@@ -1203,7 +1547,17 @@
 <!-- /wp:quote -->
 
 <!-- wp:list -->
-<ul><li>Quid est, quod ab ea absolvi et perfici debeat?</li><li>Hoc loco discipulos quaerere videtur, ut, qui asoti esse velint, philosophi ante fiant.</li><li>Omnis enim est natura diligens sui.</li></ul>
+<ul><!-- wp:list-item -->
+<li>Quid est, quod ab ea absolvi et perfici debeat?</li>
+<!-- /wp:list-item -->
+
+<!-- wp:list-item -->
+<li>Hoc loco discipulos quaerere videtur, ut, qui asoti esse velint, philosophi ante fiant.</li>
+<!-- /wp:list-item -->
+
+<!-- wp:list-item -->
+<li>Omnis enim est natura diligens sui.</li>
+<!-- /wp:list-item --></ul>
 <!-- /wp:list -->
 
 <!-- wp:paragraph -->
@@ -1267,7 +1621,21 @@
 <!-- /wp:paragraph -->
 
 <!-- wp:list -->
-<ul><li>Intrandum est igitur in rerum naturam et penitus quid ea postulet pervidendum;</li><li>Cuius quidem, quoniam Stoicus fuit, sententia condemnata mihi videtur esse inanitas ista verborum.</li><li>Quid est, quod ab ea absolvi et perfici debeat?</li><li>Rationis enim perfectio est virtus;</li></ul>
+<ul><!-- wp:list-item -->
+<li>Intrandum est igitur in rerum naturam et penitus quid ea postulet pervidendum;</li>
+<!-- /wp:list-item -->
+
+<!-- wp:list-item -->
+<li>Cuius quidem, quoniam Stoicus fuit, sententia condemnata mihi videtur esse inanitas ista verborum.</li>
+<!-- /wp:list-item -->
+
+<!-- wp:list-item -->
+<li>Quid est, quod ab ea absolvi et perfici debeat?</li>
+<!-- /wp:list-item -->
+
+<!-- wp:list-item -->
+<li>Rationis enim perfectio est virtus;</li>
+<!-- /wp:list-item --></ul>
 <!-- /wp:list -->
 
 <!-- wp:heading {"level":4} -->
@@ -1319,7 +1687,29 @@
 <!-- /wp:paragraph -->
 
 <!-- wp:list -->
-<ul><li>Laelius clamores sofòw ille so lebat Edere compellans gumias ex ordine nostros.</li><li>Ut proverbia non nulla veriora sint quam vestra dogmata.</li><li>Quamquam ab iis philosophiam et omnes ingenuas disciplinas habemus;</li><li>Illud non continuo, ut aeque incontentae.</li><li>Illa sunt similia: hebes acies est cuipiam oculorum, corpore alius senescit;</li><li>Hoc dixerit potius Ennius: Nimium boni est, cui nihil est mali.</li></ul>
+<ul><!-- wp:list-item -->
+<li>Laelius clamores sofòw ille so lebat Edere compellans gumias ex ordine nostros.</li>
+<!-- /wp:list-item -->
+
+<!-- wp:list-item -->
+<li>Ut proverbia non nulla veriora sint quam vestra dogmata.</li>
+<!-- /wp:list-item -->
+
+<!-- wp:list-item -->
+<li>Quamquam ab iis philosophiam et omnes ingenuas disciplinas habemus;</li>
+<!-- /wp:list-item -->
+
+<!-- wp:list-item -->
+<li>Illud non continuo, ut aeque incontentae.</li>
+<!-- /wp:list-item -->
+
+<!-- wp:list-item -->
+<li>Illa sunt similia: hebes acies est cuipiam oculorum, corpore alius senescit;</li>
+<!-- /wp:list-item -->
+
+<!-- wp:list-item -->
+<li>Hoc dixerit potius Ennius: Nimium boni est, cui nihil est mali.</li>
+<!-- /wp:list-item --></ul>
 <!-- /wp:list -->
 
 <!-- wp:paragraph -->
@@ -1347,7 +1737,17 @@
 <!-- /wp:paragraph -->
 
 <!-- wp:list -->
-<ul><li>Quid enim est a Chrysippo praetermissum in Stoicis?</li><li>Quo modo autem philosophus loquitur?</li><li>Qui non moveatur et offensione turpitudinis et comprobatione honestatis?</li></ul>
+<ul><!-- wp:list-item -->
+<li>Quid enim est a Chrysippo praetermissum in Stoicis?</li>
+<!-- /wp:list-item -->
+
+<!-- wp:list-item -->
+<li>Quo modo autem philosophus loquitur?</li>
+<!-- /wp:list-item -->
+
+<!-- wp:list-item -->
+<li>Qui non moveatur et offensione turpitudinis et comprobatione honestatis?</li>
+<!-- /wp:list-item --></ul>
 <!-- /wp:list -->
 
 <!-- wp:heading {"level":6} -->
@@ -1411,7 +1811,13 @@
 <!-- /wp:paragraph -->
 
 <!-- wp:list -->
-<ul><li>Hoc Hieronymus summum bonum esse dixit.</li><li>Etenim nec iustitia nec amicitia esse omnino poterunt, nisi ipsae per se expetuntur.</li></ul>
+<ul><!-- wp:list-item -->
+<li>Hoc Hieronymus summum bonum esse dixit.</li>
+<!-- /wp:list-item -->
+
+<!-- wp:list-item -->
+<li>Etenim nec iustitia nec amicitia esse omnino poterunt, nisi ipsae per se expetuntur.</li>
+<!-- /wp:list-item --></ul>
 <!-- /wp:list -->
 
 <!-- wp:paragraph -->
@@ -1487,11 +1893,51 @@
 <!-- /wp:quote -->
 
 <!-- wp:list -->
-<ul><li>Quem Tiberina descensio festo illo die tanto gaudio affecit, quanto L.</li><li>In quibus doctissimi illi veteres inesse quiddam caeleste et divinum putaverunt.</li><li>Omnes enim iucundum motum, quo sensus hilaretur.</li><li>Quae cum dixisset paulumque institisset, Quid est?</li><li>His enim rebus detractis negat se reperire in asotorum vita quod reprehendat.</li><li>Profectus in exilium Tubulus statim nec respondere ausus;</li><li>Sin kakan malitiam dixisses, ad aliud nos unum certum vitium consuetudo Latina traduceret.</li></ul>
+<ul><!-- wp:list-item -->
+<li>Quem Tiberina descensio festo illo die tanto gaudio affecit, quanto L.</li>
+<!-- /wp:list-item -->
+
+<!-- wp:list-item -->
+<li>In quibus doctissimi illi veteres inesse quiddam caeleste et divinum putaverunt.</li>
+<!-- /wp:list-item -->
+
+<!-- wp:list-item -->
+<li>Omnes enim iucundum motum, quo sensus hilaretur.</li>
+<!-- /wp:list-item -->
+
+<!-- wp:list-item -->
+<li>Quae cum dixisset paulumque institisset, Quid est?</li>
+<!-- /wp:list-item -->
+
+<!-- wp:list-item -->
+<li>His enim rebus detractis negat se reperire in asotorum vita quod reprehendat.</li>
+<!-- /wp:list-item -->
+
+<!-- wp:list-item -->
+<li>Profectus in exilium Tubulus statim nec respondere ausus;</li>
+<!-- /wp:list-item -->
+
+<!-- wp:list-item -->
+<li>Sin kakan malitiam dixisses, ad aliud nos unum certum vitium consuetudo Latina traduceret.</li>
+<!-- /wp:list-item --></ul>
 <!-- /wp:list -->
 
 <!-- wp:list -->
-<ul><li>At cum de plurimis eadem dicit, tum certe de maximis.</li><li>Apparet statim, quae sint officia, quae actiones.</li><li>Nam si propter voluptatem, quae est ista laus, quae possit e macello peti?</li><li>Ut pulsi recurrant?</li></ul>
+<ul><!-- wp:list-item -->
+<li>At cum de plurimis eadem dicit, tum certe de maximis.</li>
+<!-- /wp:list-item -->
+
+<!-- wp:list-item -->
+<li>Apparet statim, quae sint officia, quae actiones.</li>
+<!-- /wp:list-item -->
+
+<!-- wp:list-item -->
+<li>Nam si propter voluptatem, quae est ista laus, quae possit e macello peti?</li>
+<!-- /wp:list-item -->
+
+<!-- wp:list-item -->
+<li>Ut pulsi recurrant?</li>
+<!-- /wp:list-item --></ul>
 <!-- /wp:list -->
 
 <!-- wp:paragraph -->
@@ -1659,7 +2105,21 @@
 <!-- /wp:paragraph -->
 
 <!-- wp:list -->
-<ul><li>Et quod est munus, quod opus sapientiae?</li><li>Quid, si non sensus modo ei sit datus, verum etiam animus hominis?</li><li>Quid vero?</li><li>Quamquam non negatis nos intellegere quid sit voluptas, sed quid ille dicat.</li></ul>
+<ul><!-- wp:list-item -->
+<li>Et quod est munus, quod opus sapientiae?</li>
+<!-- /wp:list-item -->
+
+<!-- wp:list-item -->
+<li>Quid, si non sensus modo ei sit datus, verum etiam animus hominis?</li>
+<!-- /wp:list-item -->
+
+<!-- wp:list-item -->
+<li>Quid vero?</li>
+<!-- /wp:list-item -->
+
+<!-- wp:list-item -->
+<li>Quamquam non negatis nos intellegere quid sit voluptas, sed quid ille dicat.</li>
+<!-- /wp:list-item --></ul>
 <!-- /wp:list -->
 
 <!-- wp:quote -->
@@ -1727,7 +2187,25 @@
 <!-- /wp:paragraph -->
 
 <!-- wp:list -->
-<ul><li>Se omnia, quae secundum naturam sint, b o n a appellare, quae autem contra, m a l a.</li><li>Inscite autem medicinae et gubernationis ultimum cum ultimo sapientiae comparatur.</li><li>Minime vero, inquit ille, consentit.</li><li>Vulgo enim dicitur: Iucundi acti labores, nec male Euripidesconcludam, si potero, Latine;</li><li>Universa enim illorum ratione cum tota vestra confligendum puto.</li></ul>
+<ul><!-- wp:list-item -->
+<li>Se omnia, quae secundum naturam sint, b o n a appellare, quae autem contra, m a l a.</li>
+<!-- /wp:list-item -->
+
+<!-- wp:list-item -->
+<li>Inscite autem medicinae et gubernationis ultimum cum ultimo sapientiae comparatur.</li>
+<!-- /wp:list-item -->
+
+<!-- wp:list-item -->
+<li>Minime vero, inquit ille, consentit.</li>
+<!-- /wp:list-item -->
+
+<!-- wp:list-item -->
+<li>Vulgo enim dicitur: Iucundi acti labores, nec male Euripidesconcludam, si potero, Latine;</li>
+<!-- /wp:list-item -->
+
+<!-- wp:list-item -->
+<li>Universa enim illorum ratione cum tota vestra confligendum puto.</li>
+<!-- /wp:list-item --></ul>
 <!-- /wp:list -->
 
 <!-- wp:heading {"level":5} -->
@@ -1767,11 +2245,51 @@
 <!-- /wp:paragraph -->
 
 <!-- wp:list -->
-<ul><li>Negat enim summo bono afferre incrementum diem.</li><li>Deinde prima illa, quae in congressu solemus: Quid tu, inquit, huc?</li><li>Cuius similitudine perspecta in formarum specie ac dignitate transitum est ad honestatem dictorum atque factorum.</li><li>Si enim non fuit eorum iudicii, nihilo magis hoc non addito illud est iudicatum-.</li><li>Et hanc quidem primam exigam a te operam, ut audias me quae a te dicta sunt refellentem.</li></ul>
+<ul><!-- wp:list-item -->
+<li>Negat enim summo bono afferre incrementum diem.</li>
+<!-- /wp:list-item -->
+
+<!-- wp:list-item -->
+<li>Deinde prima illa, quae in congressu solemus: Quid tu, inquit, huc?</li>
+<!-- /wp:list-item -->
+
+<!-- wp:list-item -->
+<li>Cuius similitudine perspecta in formarum specie ac dignitate transitum est ad honestatem dictorum atque factorum.</li>
+<!-- /wp:list-item -->
+
+<!-- wp:list-item -->
+<li>Si enim non fuit eorum iudicii, nihilo magis hoc non addito illud est iudicatum-.</li>
+<!-- /wp:list-item -->
+
+<!-- wp:list-item -->
+<li>Et hanc quidem primam exigam a te operam, ut audias me quae a te dicta sunt refellentem.</li>
+<!-- /wp:list-item --></ul>
 <!-- /wp:list -->
 
 <!-- wp:list -->
-<ul><li>At hoc in eo M.</li><li>Indicant pueri, in quibus ut in speculis natura cernitur.</li><li>In qua si nihil est praeter rationem, sit in una virtute finis bonorum;</li><li>Hoc etsi multimodis reprehendi potest, tamen accipio, quod dant.</li><li>Atque haec coniunctio confusioque virtutum tamen a philosophis ratione quadam distinguitur.</li><li>Ex ea difficultate illae fallaciloquae, ut ait Accius, malitiae natae sunt.</li></ul>
+<ul><!-- wp:list-item -->
+<li>At hoc in eo M.</li>
+<!-- /wp:list-item -->
+
+<!-- wp:list-item -->
+<li>Indicant pueri, in quibus ut in speculis natura cernitur.</li>
+<!-- /wp:list-item -->
+
+<!-- wp:list-item -->
+<li>In qua si nihil est praeter rationem, sit in una virtute finis bonorum;</li>
+<!-- /wp:list-item -->
+
+<!-- wp:list-item -->
+<li>Hoc etsi multimodis reprehendi potest, tamen accipio, quod dant.</li>
+<!-- /wp:list-item -->
+
+<!-- wp:list-item -->
+<li>Atque haec coniunctio confusioque virtutum tamen a philosophis ratione quadam distinguitur.</li>
+<!-- /wp:list-item -->
+
+<!-- wp:list-item -->
+<li>Ex ea difficultate illae fallaciloquae, ut ait Accius, malitiae natae sunt.</li>
+<!-- /wp:list-item --></ul>
 <!-- /wp:list -->
 
 <!-- wp:paragraph -->
@@ -1827,7 +2345,21 @@
 <!-- /wp:paragraph -->
 
 <!-- wp:list -->
-<ul><li>His similes sunt omnes, qui virtuti student levantur vitiis, levantur erroribus, nisi forte censes Ti.</li><li>Ergo omni animali illud, quod appetiti positum est in eo, quod naturae est accommodatum.</li><li>Igitur neque stultorum quisquam beatus neque sapientium non beatus.</li><li>Tum ille: Ain tandem?</li></ul>
+<ul><!-- wp:list-item -->
+<li>His similes sunt omnes, qui virtuti student levantur vitiis, levantur erroribus, nisi forte censes Ti.</li>
+<!-- /wp:list-item -->
+
+<!-- wp:list-item -->
+<li>Ergo omni animali illud, quod appetiti positum est in eo, quod naturae est accommodatum.</li>
+<!-- /wp:list-item -->
+
+<!-- wp:list-item -->
+<li>Igitur neque stultorum quisquam beatus neque sapientium non beatus.</li>
+<!-- /wp:list-item -->
+
+<!-- wp:list-item -->
+<li>Tum ille: Ain tandem?</li>
+<!-- /wp:list-item --></ul>
 <!-- /wp:list -->
 
 <!-- wp:paragraph -->
@@ -1895,7 +2427,29 @@
 <!-- /wp:paragraph -->
 
 <!-- wp:list -->
-<ul><li>Qui est in parvis malis.</li><li>Sapientem locupletat ipsa natura, cuius divitias Epicurus parabiles esse docuit.</li><li>Quid, si reviviscant Platonis illi et deinceps qui eorum auditores fuerunt, et tecum ita loquantur?</li><li>Non est igitur summum malum dolor.</li><li>In quo etsi est magnus, tamen nova pleraque et perpauca de moribus.</li><li>Et ille ridens: Video, inquit, quid agas;</li></ul>
+<ul><!-- wp:list-item -->
+<li>Qui est in parvis malis.</li>
+<!-- /wp:list-item -->
+
+<!-- wp:list-item -->
+<li>Sapientem locupletat ipsa natura, cuius divitias Epicurus parabiles esse docuit.</li>
+<!-- /wp:list-item -->
+
+<!-- wp:list-item -->
+<li>Quid, si reviviscant Platonis illi et deinceps qui eorum auditores fuerunt, et tecum ita loquantur?</li>
+<!-- /wp:list-item -->
+
+<!-- wp:list-item -->
+<li>Non est igitur summum malum dolor.</li>
+<!-- /wp:list-item -->
+
+<!-- wp:list-item -->
+<li>In quo etsi est magnus, tamen nova pleraque et perpauca de moribus.</li>
+<!-- /wp:list-item -->
+
+<!-- wp:list-item -->
+<li>Et ille ridens: Video, inquit, quid agas;</li>
+<!-- /wp:list-item --></ul>
 <!-- /wp:list -->
 
 <!-- wp:paragraph -->
@@ -1951,7 +2505,29 @@
 <!-- /wp:paragraph -->
 
 <!-- wp:list -->
-<ul><li>Quem Tiberina descensio festo illo die tanto gaudio affecit, quanto L.</li><li>Ergo ita: non posse honeste vivi, nisi honeste vivatur?</li><li>Quodcumque in mentem incideret, et quodcumque tamquam occurreret.</li><li>Itaque primos congressus copulationesque et consuetudinum instituendarum voluntates fieri propter voluptatem;</li><li>Virtutibus igitur rectissime mihi videris et ad consuetudinem nostrae orationis vitia posuisse contraria.</li><li>Aliter enim explicari, quod quaeritur, non potest.</li></ul>
+<ul><!-- wp:list-item -->
+<li>Quem Tiberina descensio festo illo die tanto gaudio affecit, quanto L.</li>
+<!-- /wp:list-item -->
+
+<!-- wp:list-item -->
+<li>Ergo ita: non posse honeste vivi, nisi honeste vivatur?</li>
+<!-- /wp:list-item -->
+
+<!-- wp:list-item -->
+<li>Quodcumque in mentem incideret, et quodcumque tamquam occurreret.</li>
+<!-- /wp:list-item -->
+
+<!-- wp:list-item -->
+<li>Itaque primos congressus copulationesque et consuetudinum instituendarum voluntates fieri propter voluptatem;</li>
+<!-- /wp:list-item -->
+
+<!-- wp:list-item -->
+<li>Virtutibus igitur rectissime mihi videris et ad consuetudinem nostrae orationis vitia posuisse contraria.</li>
+<!-- /wp:list-item -->
+
+<!-- wp:list-item -->
+<li>Aliter enim explicari, quod quaeritur, non potest.</li>
+<!-- /wp:list-item --></ul>
 <!-- /wp:list -->
 
 <!-- wp:heading {"level":4} -->
@@ -2055,7 +2631,21 @@
 <!-- /wp:quote -->
 
 <!-- wp:list -->
-<ul><li>Huic mori optimum esse propter desperationem sapientiae, illi propter spem vivere.</li><li>Ne in odium veniam, si amicum destitero tueri.</li><li>Progredientibus autem aetatibus sensim tardeve potius quasi nosmet ipsos cognoscimus.</li><li>Sed emolumenta communia esse dicuntur, recte autem facta et peccata non habentur communia.</li></ul>
+<ul><!-- wp:list-item -->
+<li>Huic mori optimum esse propter desperationem sapientiae, illi propter spem vivere.</li>
+<!-- /wp:list-item -->
+
+<!-- wp:list-item -->
+<li>Ne in odium veniam, si amicum destitero tueri.</li>
+<!-- /wp:list-item -->
+
+<!-- wp:list-item -->
+<li>Progredientibus autem aetatibus sensim tardeve potius quasi nosmet ipsos cognoscimus.</li>
+<!-- /wp:list-item -->
+
+<!-- wp:list-item -->
+<li>Sed emolumenta communia esse dicuntur, recte autem facta et peccata non habentur communia.</li>
+<!-- /wp:list-item --></ul>
 <!-- /wp:list -->
 
 <!-- wp:heading {"level":3} -->
@@ -2087,7 +2677,13 @@
 <!-- /wp:paragraph -->
 
 <!-- wp:list -->
-<ul><li>Sit, inquam, tam facilis, quam vultis, comparatio voluptatis, quid de dolore dicemus?</li><li>Progredientibus autem aetatibus sensim tardeve potius quasi nosmet ipsos cognoscimus.</li></ul>
+<ul><!-- wp:list-item -->
+<li>Sit, inquam, tam facilis, quam vultis, comparatio voluptatis, quid de dolore dicemus?</li>
+<!-- /wp:list-item -->
+
+<!-- wp:list-item -->
+<li>Progredientibus autem aetatibus sensim tardeve potius quasi nosmet ipsos cognoscimus.</li>
+<!-- /wp:list-item --></ul>
 <!-- /wp:list -->
 
 <!-- wp:paragraph -->
@@ -2127,7 +2723,17 @@
 <!-- /wp:paragraph -->
 
 <!-- wp:list -->
-<ul><li>Hic nihil fuit, quod quaereremus.</li><li>Quid ergo attinet dicere: Nihil haberem, quod reprehenderem, si finitas cupiditates haberent?</li><li>Sin kakan malitiam dixisses, ad aliud nos unum certum vitium consuetudo Latina traduceret.</li></ul>
+<ul><!-- wp:list-item -->
+<li>Hic nihil fuit, quod quaereremus.</li>
+<!-- /wp:list-item -->
+
+<!-- wp:list-item -->
+<li>Quid ergo attinet dicere: Nihil haberem, quod reprehenderem, si finitas cupiditates haberent?</li>
+<!-- /wp:list-item -->
+
+<!-- wp:list-item -->
+<li>Sin kakan malitiam dixisses, ad aliud nos unum certum vitium consuetudo Latina traduceret.</li>
+<!-- /wp:list-item --></ul>
 <!-- /wp:list -->
 
 <!-- wp:paragraph -->
@@ -2135,7 +2741,21 @@
 <!-- /wp:paragraph -->
 
 <!-- wp:list -->
-<ul><li>At Zeno eum non beatum modo, sed etiam divitem dicere ausus est.</li><li>Nihil opus est exemplis hoc facere longius.</li><li>Minime vero istorum quidem, inquit.</li><li>Experiamur igitur, inquit, etsi habet haec Stoicorum ratio difficilius quiddam et obscurius.</li></ul>
+<ul><!-- wp:list-item -->
+<li>At Zeno eum non beatum modo, sed etiam divitem dicere ausus est.</li>
+<!-- /wp:list-item -->
+
+<!-- wp:list-item -->
+<li>Nihil opus est exemplis hoc facere longius.</li>
+<!-- /wp:list-item -->
+
+<!-- wp:list-item -->
+<li>Minime vero istorum quidem, inquit.</li>
+<!-- /wp:list-item -->
+
+<!-- wp:list-item -->
+<li>Experiamur igitur, inquit, etsi habet haec Stoicorum ratio difficilius quiddam et obscurius.</li>
+<!-- /wp:list-item --></ul>
 <!-- /wp:list -->
 
 <!-- wp:paragraph -->
@@ -2159,7 +2779,17 @@
 <!-- /wp:paragraph -->
 
 <!-- wp:list -->
-<ul><li>Nobis Heracleotes ille Dionysius flagitiose descivisse videtur a Stoicis propter oculorum dolorem.</li><li>In quibus doctissimi illi veteres inesse quiddam caeleste et divinum putaverunt.</li><li>Ita multo sanguine profuso in laetitia et in victoria est mortuus.</li></ul>
+<ul><!-- wp:list-item -->
+<li>Nobis Heracleotes ille Dionysius flagitiose descivisse videtur a Stoicis propter oculorum dolorem.</li>
+<!-- /wp:list-item -->
+
+<!-- wp:list-item -->
+<li>In quibus doctissimi illi veteres inesse quiddam caeleste et divinum putaverunt.</li>
+<!-- /wp:list-item -->
+
+<!-- wp:list-item -->
+<li>Ita multo sanguine profuso in laetitia et in victoria est mortuus.</li>
+<!-- /wp:list-item --></ul>
 <!-- /wp:list -->
 
 <!-- wp:heading {"level":4} -->
@@ -2215,7 +2845,17 @@
 <!-- /wp:quote -->
 
 <!-- wp:list -->
-<ul><li>Sed haec ab Antiocho, familiari nostro, dicuntur multo melius et fortius, quam a Stasea dicebantur.</li><li>Tamen aberramus a proposito, et, ne longius, prorsus, inquam, Piso, si ista mala sunt, placet.</li><li>Invidiosum nomen est, infame, suspectum.</li></ul>
+<ul><!-- wp:list-item -->
+<li>Sed haec ab Antiocho, familiari nostro, dicuntur multo melius et fortius, quam a Stasea dicebantur.</li>
+<!-- /wp:list-item -->
+
+<!-- wp:list-item -->
+<li>Tamen aberramus a proposito, et, ne longius, prorsus, inquam, Piso, si ista mala sunt, placet.</li>
+<!-- /wp:list-item -->
+
+<!-- wp:list-item -->
+<li>Invidiosum nomen est, infame, suspectum.</li>
+<!-- /wp:list-item --></ul>
 <!-- /wp:list -->
 
 <!-- wp:heading -->
@@ -2227,11 +2867,47 @@
 <!-- /wp:paragraph -->
 
 <!-- wp:list -->
-<ul><li>Perturbationes autem nulla naturae vi commoventur, omniaque ea sunt opiniones ac iudicia levitatis.</li><li>Ne in odium veniam, si amicum destitero tueri.</li><li>Ita redarguitur ipse a sese, convincunturque scripta eius probitate ipsius ac moribus.</li><li>Non minor, inquit, voluptas percipitur ex vilissimis rebus quam ex pretiosissimis.</li></ul>
+<ul><!-- wp:list-item -->
+<li>Perturbationes autem nulla naturae vi commoventur, omniaque ea sunt opiniones ac iudicia levitatis.</li>
+<!-- /wp:list-item -->
+
+<!-- wp:list-item -->
+<li>Ne in odium veniam, si amicum destitero tueri.</li>
+<!-- /wp:list-item -->
+
+<!-- wp:list-item -->
+<li>Ita redarguitur ipse a sese, convincunturque scripta eius probitate ipsius ac moribus.</li>
+<!-- /wp:list-item -->
+
+<!-- wp:list-item -->
+<li>Non minor, inquit, voluptas percipitur ex vilissimis rebus quam ex pretiosissimis.</li>
+<!-- /wp:list-item --></ul>
 <!-- /wp:list -->
 
 <!-- wp:list -->
-<ul><li>Quid, quod homines infima fortuna, nulla spe rerum gerendarum, opifices denique delectantur historia?</li><li>At habetur! Et ego id scilicet nesciebam! Sed ut sit, etiamne post mortem coletur?</li><li>Introduci enim virtus nullo modo potest, nisi omnia, quae leget quaeque reiciet, unam referentur ad summam.</li><li>Nulla profecto est, quin suam vim retineat a primo ad extremum.</li><li>Haec quo modo conveniant, non sane intellego.</li><li>Multa sunt dicta ab antiquis de contemnendis ac despiciendis rebus humanis;</li></ul>
+<ul><!-- wp:list-item -->
+<li>Quid, quod homines infima fortuna, nulla spe rerum gerendarum, opifices denique delectantur historia?</li>
+<!-- /wp:list-item -->
+
+<!-- wp:list-item -->
+<li>At habetur! Et ego id scilicet nesciebam! Sed ut sit, etiamne post mortem coletur?</li>
+<!-- /wp:list-item -->
+
+<!-- wp:list-item -->
+<li>Introduci enim virtus nullo modo potest, nisi omnia, quae leget quaeque reiciet, unam referentur ad summam.</li>
+<!-- /wp:list-item -->
+
+<!-- wp:list-item -->
+<li>Nulla profecto est, quin suam vim retineat a primo ad extremum.</li>
+<!-- /wp:list-item -->
+
+<!-- wp:list-item -->
+<li>Haec quo modo conveniant, non sane intellego.</li>
+<!-- /wp:list-item -->
+
+<!-- wp:list-item -->
+<li>Multa sunt dicta ab antiquis de contemnendis ac despiciendis rebus humanis;</li>
+<!-- /wp:list-item --></ul>
 <!-- /wp:list -->
 
 <!-- wp:heading {"level":3} -->
@@ -2255,7 +2931,21 @@
 <!-- /wp:paragraph -->
 
 <!-- wp:list -->
-<ul><li>Varietates autem iniurasque fortunae facile veteres philosophorum praeceptis instituta vita superabat.</li><li>Qui autem de summo bono dissentit de tota philosophiae ratione dissentit.</li><li>Iam contemni non poteris.</li><li>Quae diligentissime contra Aristonem dicuntur a Chryippo.</li></ul>
+<ul><!-- wp:list-item -->
+<li>Varietates autem iniurasque fortunae facile veteres philosophorum praeceptis instituta vita superabat.</li>
+<!-- /wp:list-item -->
+
+<!-- wp:list-item -->
+<li>Qui autem de summo bono dissentit de tota philosophiae ratione dissentit.</li>
+<!-- /wp:list-item -->
+
+<!-- wp:list-item -->
+<li>Iam contemni non poteris.</li>
+<!-- /wp:list-item -->
+
+<!-- wp:list-item -->
+<li>Quae diligentissime contra Aristonem dicuntur a Chryippo.</li>
+<!-- /wp:list-item --></ul>
 <!-- /wp:list -->
 
 <!-- wp:heading {"level":6} -->
@@ -2287,11 +2977,47 @@
 <!-- /wp:paragraph -->
 
 <!-- wp:list -->
-<ul><li>Et quidem Arcesilas tuus, etsi fuit in disserendo pertinacior, tamen noster fuit;</li><li>Quo studio cum satiari non possint, omnium ceterarum rerum obliti níhil abiectum, nihil humile cogitant;</li><li>Haec quo modo conveniant, non sane intellego.</li><li>Is ita vivebat, ut nulla tam exquisita posset inveniri voluptas, qua non abundaret.</li><li>Stulti autem malorum memoria torquentur, sapientes bona praeterita grata recordatione renovata delectant.</li></ul>
+<ul><!-- wp:list-item -->
+<li>Et quidem Arcesilas tuus, etsi fuit in disserendo pertinacior, tamen noster fuit;</li>
+<!-- /wp:list-item -->
+
+<!-- wp:list-item -->
+<li>Quo studio cum satiari non possint, omnium ceterarum rerum obliti níhil abiectum, nihil humile cogitant;</li>
+<!-- /wp:list-item -->
+
+<!-- wp:list-item -->
+<li>Haec quo modo conveniant, non sane intellego.</li>
+<!-- /wp:list-item -->
+
+<!-- wp:list-item -->
+<li>Is ita vivebat, ut nulla tam exquisita posset inveniri voluptas, qua non abundaret.</li>
+<!-- /wp:list-item -->
+
+<!-- wp:list-item -->
+<li>Stulti autem malorum memoria torquentur, sapientes bona praeterita grata recordatione renovata delectant.</li>
+<!-- /wp:list-item --></ul>
 <!-- /wp:list -->
 
 <!-- wp:list -->
-<ul><li>Neminem videbis ita laudatum, ut artifex callidus comparandarum voluptatum diceretur.</li><li>Mihi enim erit isdem istis fortasse iam utendum.</li><li>Quamquam ab iis philosophiam et omnes ingenuas disciplinas habemus;</li><li>At enim sequor utilitatem.</li><li>Praetereo multos, in bis doctum hominem et suavem, Hieronymum, quem iam cur Peripateticum appellem nescio.</li></ul>
+<ul><!-- wp:list-item -->
+<li>Neminem videbis ita laudatum, ut artifex callidus comparandarum voluptatum diceretur.</li>
+<!-- /wp:list-item -->
+
+<!-- wp:list-item -->
+<li>Mihi enim erit isdem istis fortasse iam utendum.</li>
+<!-- /wp:list-item -->
+
+<!-- wp:list-item -->
+<li>Quamquam ab iis philosophiam et omnes ingenuas disciplinas habemus;</li>
+<!-- /wp:list-item -->
+
+<!-- wp:list-item -->
+<li>At enim sequor utilitatem.</li>
+<!-- /wp:list-item -->
+
+<!-- wp:list-item -->
+<li>Praetereo multos, in bis doctum hominem et suavem, Hieronymum, quem iam cur Peripateticum appellem nescio.</li>
+<!-- /wp:list-item --></ul>
 <!-- /wp:list -->
 
 <!-- wp:heading {"level":6} -->
@@ -2487,7 +3213,21 @@
 <!-- /wp:paragraph -->
 
 <!-- wp:list -->
-<ul><li>Pudebit te, inquam, illius tabulae, quam Cleanthes sane commode verbis depingere solebat.</li><li>Huic mori optimum esse propter desperationem sapientiae, illi propter spem vivere.</li><li>Quae hic rei publicae vulnera inponebat, eadem ille sanabat.</li><li>Hoc est non modo cor non habere, sed ne palatum quidem.</li></ul>
+<ul><!-- wp:list-item -->
+<li>Pudebit te, inquam, illius tabulae, quam Cleanthes sane commode verbis depingere solebat.</li>
+<!-- /wp:list-item -->
+
+<!-- wp:list-item -->
+<li>Huic mori optimum esse propter desperationem sapientiae, illi propter spem vivere.</li>
+<!-- /wp:list-item -->
+
+<!-- wp:list-item -->
+<li>Quae hic rei publicae vulnera inponebat, eadem ille sanabat.</li>
+<!-- /wp:list-item -->
+
+<!-- wp:list-item -->
+<li>Hoc est non modo cor non habere, sed ne palatum quidem.</li>
+<!-- /wp:list-item --></ul>
 <!-- /wp:list -->
 
 <!-- wp:paragraph -->
@@ -2575,7 +3315,21 @@
 <!-- /wp:paragraph -->
 
 <!-- wp:list -->
-<ul><li>Haec qui audierit, ut ridere non curet, discedet tamen nihilo firmior ad dolorem ferendum, quam venerat.</li><li>Sic, et quidem diligentius saepiusque ista loquemur inter nos agemusque communiter.</li><li>Nec vero sum nescius esse utilitatem in historia, non modo voluptatem.</li><li>Laelius clamores sofòw ille so lebat Edere compellans gumias ex ordine nostros.</li></ul>
+<ul><!-- wp:list-item -->
+<li>Haec qui audierit, ut ridere non curet, discedet tamen nihilo firmior ad dolorem ferendum, quam venerat.</li>
+<!-- /wp:list-item -->
+
+<!-- wp:list-item -->
+<li>Sic, et quidem diligentius saepiusque ista loquemur inter nos agemusque communiter.</li>
+<!-- /wp:list-item -->
+
+<!-- wp:list-item -->
+<li>Nec vero sum nescius esse utilitatem in historia, non modo voluptatem.</li>
+<!-- /wp:list-item -->
+
+<!-- wp:list-item -->
+<li>Laelius clamores sofòw ille so lebat Edere compellans gumias ex ordine nostros.</li>
+<!-- /wp:list-item --></ul>
 <!-- /wp:list -->
 
 <!-- wp:paragraph -->
@@ -2583,7 +3337,21 @@
 <!-- /wp:paragraph -->
 
 <!-- wp:list -->
-<ul><li>Si enim ita est, vide ne facinus facias, cum mori suadeas.</li><li>Quis Aristidem non mortuum diligit?</li><li>Quos quidem tibi studiose et diligenter tractandos magnopere censeo.</li><li>Sin te auctoritas commovebat, nobisne omnibus et Platoni ipsi nescio quem illum anteponebas?</li></ul>
+<ul><!-- wp:list-item -->
+<li>Si enim ita est, vide ne facinus facias, cum mori suadeas.</li>
+<!-- /wp:list-item -->
+
+<!-- wp:list-item -->
+<li>Quis Aristidem non mortuum diligit?</li>
+<!-- /wp:list-item -->
+
+<!-- wp:list-item -->
+<li>Quos quidem tibi studiose et diligenter tractandos magnopere censeo.</li>
+<!-- /wp:list-item -->
+
+<!-- wp:list-item -->
+<li>Sin te auctoritas commovebat, nobisne omnibus et Platoni ipsi nescio quem illum anteponebas?</li>
+<!-- /wp:list-item --></ul>
 <!-- /wp:list -->
 
 <!-- wp:paragraph -->
@@ -2655,7 +3423,13 @@
 <!-- /wp:paragraph -->
 
 <!-- wp:list -->
-<ul><li>Videmusne ut pueri ne verberibus quidem a contemplandis rebus perquirendisque deterreantur?</li><li>Quod si ita se habeat, non possit beatam praestare vitam sapientia.</li></ul>
+<ul><!-- wp:list-item -->
+<li>Videmusne ut pueri ne verberibus quidem a contemplandis rebus perquirendisque deterreantur?</li>
+<!-- /wp:list-item -->
+
+<!-- wp:list-item -->
+<li>Quod si ita se habeat, non possit beatam praestare vitam sapientia.</li>
+<!-- /wp:list-item --></ul>
 <!-- /wp:list -->
 
 <!-- wp:heading {"level":6} -->
@@ -2719,7 +3493,13 @@
 <!-- /wp:paragraph -->
 
 <!-- wp:list -->
-<ul><li>Quando enim Socrates, qui parens philosophiae iure dici potest, quicquam tale fecit?</li><li>Ne vitationem quidem doloris ipsam per se quisquam in rebus expetendis putavit, nisi etiam evitare posset.</li></ul>
+<ul><!-- wp:list-item -->
+<li>Quando enim Socrates, qui parens philosophiae iure dici potest, quicquam tale fecit?</li>
+<!-- /wp:list-item -->
+
+<!-- wp:list-item -->
+<li>Ne vitationem quidem doloris ipsam per se quisquam in rebus expetendis putavit, nisi etiam evitare posset.</li>
+<!-- /wp:list-item --></ul>
 <!-- /wp:list -->
 
 <!-- wp:paragraph -->
@@ -2759,7 +3539,17 @@
 <!-- /wp:paragraph -->
 
 <!-- wp:list -->
-<ul><li>Philosophi autem in suis lectulis plerumque moriuntur.</li><li>Bona autem corporis huic sunt, quod posterius posui, similiora.</li><li>Quae in controversiam veniunt, de iis, si placet, disseramus.</li></ul>
+<ul><!-- wp:list-item -->
+<li>Philosophi autem in suis lectulis plerumque moriuntur.</li>
+<!-- /wp:list-item -->
+
+<!-- wp:list-item -->
+<li>Bona autem corporis huic sunt, quod posterius posui, similiora.</li>
+<!-- /wp:list-item -->
+
+<!-- wp:list-item -->
+<li>Quae in controversiam veniunt, de iis, si placet, disseramus.</li>
+<!-- /wp:list-item --></ul>
 <!-- /wp:list -->
 
 <!-- wp:heading {"level":5} -->
@@ -2787,7 +3577,21 @@
 <!-- /wp:paragraph -->
 
 <!-- wp:list -->
-<ul><li>Zenonis est, inquam, hoc Stoici.</li><li>Cum sciret confestim esse moriendum eamque mortem ardentiore studio peteret, quam Epicurus voluptatem petendam putat.</li><li>Hoc loco discipulos quaerere videtur, ut, qui asoti esse velint, philosophi ante fiant.</li><li>Polemoni et iam ante Aristoteli ea prima visa sunt, quae paulo ante dixi.</li></ul>
+<ul><!-- wp:list-item -->
+<li>Zenonis est, inquam, hoc Stoici.</li>
+<!-- /wp:list-item -->
+
+<!-- wp:list-item -->
+<li>Cum sciret confestim esse moriendum eamque mortem ardentiore studio peteret, quam Epicurus voluptatem petendam putat.</li>
+<!-- /wp:list-item -->
+
+<!-- wp:list-item -->
+<li>Hoc loco discipulos quaerere videtur, ut, qui asoti esse velint, philosophi ante fiant.</li>
+<!-- /wp:list-item -->
+
+<!-- wp:list-item -->
+<li>Polemoni et iam ante Aristoteli ea prima visa sunt, quae paulo ante dixi.</li>
+<!-- /wp:list-item --></ul>
 <!-- /wp:list -->
 
 <!-- wp:quote -->
@@ -2827,11 +3631,39 @@
 <!-- /wp:paragraph -->
 
 <!-- wp:list -->
-<ul><li>Quae rursus dum sibi evelli ex ordine nolunt, horridiores evadunt, asperiores, duriores et oratione et moribus.</li><li>In ipsa enim parum magna vis inest, ut quam optime se habere possit, si nulla cultura adhibeatur.</li><li>Nec vero intermittunt aut admirationem earum rerum, quae sunt ab antiquis repertae, aut investigationem novarum.</li><li>Itaque ab his ordiamur.</li></ul>
+<ul><!-- wp:list-item -->
+<li>Quae rursus dum sibi evelli ex ordine nolunt, horridiores evadunt, asperiores, duriores et oratione et moribus.</li>
+<!-- /wp:list-item -->
+
+<!-- wp:list-item -->
+<li>In ipsa enim parum magna vis inest, ut quam optime se habere possit, si nulla cultura adhibeatur.</li>
+<!-- /wp:list-item -->
+
+<!-- wp:list-item -->
+<li>Nec vero intermittunt aut admirationem earum rerum, quae sunt ab antiquis repertae, aut investigationem novarum.</li>
+<!-- /wp:list-item -->
+
+<!-- wp:list-item -->
+<li>Itaque ab his ordiamur.</li>
+<!-- /wp:list-item --></ul>
 <!-- /wp:list -->
 
 <!-- wp:list -->
-<ul><li>Sic enim censent, oportunitatis esse beate vivere.</li><li>Fortitudinis quaedam praecepta sunt ac paene leges, quae effeminari virum vetant in dolore.</li><li>Quod si ita se habeat, non possit beatam praestare vitam sapientia.</li><li>Quicquid enim a sapientia proficiscitur, id continuo debet expletum esse omnibus suis partibus;</li></ul>
+<ul><!-- wp:list-item -->
+<li>Sic enim censent, oportunitatis esse beate vivere.</li>
+<!-- /wp:list-item -->
+
+<!-- wp:list-item -->
+<li>Fortitudinis quaedam praecepta sunt ac paene leges, quae effeminari virum vetant in dolore.</li>
+<!-- /wp:list-item -->
+
+<!-- wp:list-item -->
+<li>Quod si ita se habeat, non possit beatam praestare vitam sapientia.</li>
+<!-- /wp:list-item -->
+
+<!-- wp:list-item -->
+<li>Quicquid enim a sapientia proficiscitur, id continuo debet expletum esse omnibus suis partibus;</li>
+<!-- /wp:list-item --></ul>
 <!-- /wp:list -->
 
 <!-- wp:paragraph -->
@@ -2915,7 +3747,17 @@
 <!-- /wp:paragraph -->
 
 <!-- wp:list -->
-<ul><li>Magni enim aestimabat pecuniam non modo non contra leges, sed etiam legibus partam.</li><li>Erit enim mecum, si tecum erit.</li><li>Ex rebus enim timiditas, non ex vocabulis nascitur.</li></ul>
+<ul><!-- wp:list-item -->
+<li>Magni enim aestimabat pecuniam non modo non contra leges, sed etiam legibus partam.</li>
+<!-- /wp:list-item -->
+
+<!-- wp:list-item -->
+<li>Erit enim mecum, si tecum erit.</li>
+<!-- /wp:list-item -->
+
+<!-- wp:list-item -->
+<li>Ex rebus enim timiditas, non ex vocabulis nascitur.</li>
+<!-- /wp:list-item --></ul>
 <!-- /wp:list -->
 
 <!-- wp:quote -->
@@ -2943,11 +3785,47 @@
 <!-- /wp:quote -->
 
 <!-- wp:list -->
-<ul><li>Quamquam tu hanc copiosiorem etiam soles dicere.</li><li>Hic ambiguo ludimur.</li><li>Ipse Epicurus fortasse redderet, ut Sextus Peducaeus, Sex.</li><li>Apparet statim, quae sint officia, quae actiones.</li><li>Curium putes loqui, interdum ita laudat, ut quid praeterea sit bonum neget se posse ne suspicari quidem.</li><li>Et non ex maxima parte de tota iudicabis?</li></ul>
+<ul><!-- wp:list-item -->
+<li>Quamquam tu hanc copiosiorem etiam soles dicere.</li>
+<!-- /wp:list-item -->
+
+<!-- wp:list-item -->
+<li>Hic ambiguo ludimur.</li>
+<!-- /wp:list-item -->
+
+<!-- wp:list-item -->
+<li>Ipse Epicurus fortasse redderet, ut Sextus Peducaeus, Sex.</li>
+<!-- /wp:list-item -->
+
+<!-- wp:list-item -->
+<li>Apparet statim, quae sint officia, quae actiones.</li>
+<!-- /wp:list-item -->
+
+<!-- wp:list-item -->
+<li>Curium putes loqui, interdum ita laudat, ut quid praeterea sit bonum neget se posse ne suspicari quidem.</li>
+<!-- /wp:list-item -->
+
+<!-- wp:list-item -->
+<li>Et non ex maxima parte de tota iudicabis?</li>
+<!-- /wp:list-item --></ul>
 <!-- /wp:list -->
 
 <!-- wp:list -->
-<ul><li>Sin laboramus, quis est, qui alienae modum statuat industriae?</li><li>Facit enim ille duo seiuncta ultima bonorum, quae ut essent vera, coniungi debuerunt;</li><li>Qui non moveatur et offensione turpitudinis et comprobatione honestatis?</li><li>Atqui reperies, inquit, in hoc quidem pertinacem;</li></ul>
+<ul><!-- wp:list-item -->
+<li>Sin laboramus, quis est, qui alienae modum statuat industriae?</li>
+<!-- /wp:list-item -->
+
+<!-- wp:list-item -->
+<li>Facit enim ille duo seiuncta ultima bonorum, quae ut essent vera, coniungi debuerunt;</li>
+<!-- /wp:list-item -->
+
+<!-- wp:list-item -->
+<li>Qui non moveatur et offensione turpitudinis et comprobatione honestatis?</li>
+<!-- /wp:list-item -->
+
+<!-- wp:list-item -->
+<li>Atqui reperies, inquit, in hoc quidem pertinacem;</li>
+<!-- /wp:list-item --></ul>
 <!-- /wp:list -->
 
 <!-- wp:paragraph -->
@@ -2983,7 +3861,21 @@
 <!-- /wp:paragraph -->
 
 <!-- wp:list -->
-<ul><li>Nisi enim id faceret, cur Plato Aegyptum peragravit, ut a sacerdotibus barbaris numeros et caelestia acciperet?</li><li>Primum quid tu dicis breve?</li><li>Quid enim me prohiberet Epicureum esse, si probarem, quae ille diceret?</li><li>Conferam tecum, quam cuique verso rem subicias;</li></ul>
+<ul><!-- wp:list-item -->
+<li>Nisi enim id faceret, cur Plato Aegyptum peragravit, ut a sacerdotibus barbaris numeros et caelestia acciperet?</li>
+<!-- /wp:list-item -->
+
+<!-- wp:list-item -->
+<li>Primum quid tu dicis breve?</li>
+<!-- /wp:list-item -->
+
+<!-- wp:list-item -->
+<li>Quid enim me prohiberet Epicureum esse, si probarem, quae ille diceret?</li>
+<!-- /wp:list-item -->
+
+<!-- wp:list-item -->
+<li>Conferam tecum, quam cuique verso rem subicias;</li>
+<!-- /wp:list-item --></ul>
 <!-- /wp:list -->
 
 <!-- wp:paragraph -->
@@ -3015,7 +3907,21 @@
 <!-- /wp:paragraph -->
 
 <!-- wp:list -->
-<ul><li>Ex eorum enim scriptis et institutis cum omnis doctrina liberalis, omnis historia.</li><li>Tum Piso: Quoniam igitur aliquid omnes, quid Lucius noster?</li><li>Quae dici eadem de ceteris virtutibus possunt, quarum omnium fundamenta vos in voluptate tamquam in aqua ponitis.</li><li>Quae est igitur causa istarum angustiarum?</li></ul>
+<ul><!-- wp:list-item -->
+<li>Ex eorum enim scriptis et institutis cum omnis doctrina liberalis, omnis historia.</li>
+<!-- /wp:list-item -->
+
+<!-- wp:list-item -->
+<li>Tum Piso: Quoniam igitur aliquid omnes, quid Lucius noster?</li>
+<!-- /wp:list-item -->
+
+<!-- wp:list-item -->
+<li>Quae dici eadem de ceteris virtutibus possunt, quarum omnium fundamenta vos in voluptate tamquam in aqua ponitis.</li>
+<!-- /wp:list-item -->
+
+<!-- wp:list-item -->
+<li>Quae est igitur causa istarum angustiarum?</li>
+<!-- /wp:list-item --></ul>
 <!-- /wp:list -->
 
 <!-- wp:quote -->
@@ -3059,7 +3965,25 @@
 <!-- /wp:paragraph -->
 
 <!-- wp:list -->
-<ul><li>Non enim, si omnia non sequebatur, idcirco non erat ortus illinc.</li><li>Respondent extrema primis, media utrisque, omnia omnibus.</li><li>Ergo instituto veterum, quo etiam Stoici utuntur, hinc capiamus exordium.</li><li>Mene ergo et Triarium dignos existimas, apud quos turpiter loquare?</li><li>Atque etiam ad iustitiam colendam, ad tuendas amicitias et reliquas caritates quid natura valeat haec una cognitio potest tradere.</li></ul>
+<ul><!-- wp:list-item -->
+<li>Non enim, si omnia non sequebatur, idcirco non erat ortus illinc.</li>
+<!-- /wp:list-item -->
+
+<!-- wp:list-item -->
+<li>Respondent extrema primis, media utrisque, omnia omnibus.</li>
+<!-- /wp:list-item -->
+
+<!-- wp:list-item -->
+<li>Ergo instituto veterum, quo etiam Stoici utuntur, hinc capiamus exordium.</li>
+<!-- /wp:list-item -->
+
+<!-- wp:list-item -->
+<li>Mene ergo et Triarium dignos existimas, apud quos turpiter loquare?</li>
+<!-- /wp:list-item -->
+
+<!-- wp:list-item -->
+<li>Atque etiam ad iustitiam colendam, ad tuendas amicitias et reliquas caritates quid natura valeat haec una cognitio potest tradere.</li>
+<!-- /wp:list-item --></ul>
 <!-- /wp:list -->
 
 <!-- wp:paragraph -->
@@ -3095,7 +4019,21 @@
 <!-- /wp:paragraph -->
 
 <!-- wp:list -->
-<ul><li>Utrum igitur tibi litteram videor an totas paginas commovere?</li><li>Expressa vero in iis aetatibus, quae iam confirmatae sunt.</li><li>Cuius etiam illi hortuli propinqui non memoriam solum mihi afferunt, sed ipsum videntur in conspectu meo ponere.</li><li>Plane idem, inquit, et maxima quidem, qua fieri nulla maior potest.</li></ul>
+<ul><!-- wp:list-item -->
+<li>Utrum igitur tibi litteram videor an totas paginas commovere?</li>
+<!-- /wp:list-item -->
+
+<!-- wp:list-item -->
+<li>Expressa vero in iis aetatibus, quae iam confirmatae sunt.</li>
+<!-- /wp:list-item -->
+
+<!-- wp:list-item -->
+<li>Cuius etiam illi hortuli propinqui non memoriam solum mihi afferunt, sed ipsum videntur in conspectu meo ponere.</li>
+<!-- /wp:list-item -->
+
+<!-- wp:list-item -->
+<li>Plane idem, inquit, et maxima quidem, qua fieri nulla maior potest.</li>
+<!-- /wp:list-item --></ul>
 <!-- /wp:list -->
 
 <!-- wp:paragraph -->
@@ -3103,7 +4041,25 @@
 <!-- /wp:paragraph -->
 
 <!-- wp:list -->
-<ul><li>Tu vero, inquam, ducas licet, si sequetur;</li><li>Quid iudicant sensus?</li><li>Etenim nec iustitia nec amicitia esse omnino poterunt, nisi ipsae per se expetuntur.</li><li>Si enim ad populum me vocas, eum.</li><li>Nec tamen ille erat sapiens quis enim hoc aut quando aut ubi aut unde?</li></ul>
+<ul><!-- wp:list-item -->
+<li>Tu vero, inquam, ducas licet, si sequetur;</li>
+<!-- /wp:list-item -->
+
+<!-- wp:list-item -->
+<li>Quid iudicant sensus?</li>
+<!-- /wp:list-item -->
+
+<!-- wp:list-item -->
+<li>Etenim nec iustitia nec amicitia esse omnino poterunt, nisi ipsae per se expetuntur.</li>
+<!-- /wp:list-item -->
+
+<!-- wp:list-item -->
+<li>Si enim ad populum me vocas, eum.</li>
+<!-- /wp:list-item -->
+
+<!-- wp:list-item -->
+<li>Nec tamen ille erat sapiens quis enim hoc aut quando aut ubi aut unde?</li>
+<!-- /wp:list-item --></ul>
 <!-- /wp:list -->
 
 <!-- wp:paragraph -->
@@ -3119,7 +4075,21 @@
 <!-- /wp:paragraph -->
 
 <!-- wp:list -->
-<ul><li>Ergo adhuc, quantum equidem intellego, causa non videtur fuisse mutandi nominis.</li><li>Profectus in exilium Tubulus statim nec respondere ausus;</li><li>Legimus tamen Diogenem, Antipatrum, Mnesarchum, Panaetium, multos alios in primisque familiarem nostrum Posidonium.</li><li>Verum tamen cum de rebus grandioribus dicas, ipsae res verba rapiunt;</li></ul>
+<ul><!-- wp:list-item -->
+<li>Ergo adhuc, quantum equidem intellego, causa non videtur fuisse mutandi nominis.</li>
+<!-- /wp:list-item -->
+
+<!-- wp:list-item -->
+<li>Profectus in exilium Tubulus statim nec respondere ausus;</li>
+<!-- /wp:list-item -->
+
+<!-- wp:list-item -->
+<li>Legimus tamen Diogenem, Antipatrum, Mnesarchum, Panaetium, multos alios in primisque familiarem nostrum Posidonium.</li>
+<!-- /wp:list-item -->
+
+<!-- wp:list-item -->
+<li>Verum tamen cum de rebus grandioribus dicas, ipsae res verba rapiunt;</li>
+<!-- /wp:list-item --></ul>
 <!-- /wp:list -->
 
 <!-- wp:paragraph -->
@@ -3127,7 +4097,25 @@
 <!-- /wp:paragraph -->
 
 <!-- wp:list -->
-<ul><li>In qua quid est boni praeter summam voluptatem, et eam sempiternam?</li><li>Sin te auctoritas commovebat, nobisne omnibus et Platoni ipsi nescio quem illum anteponebas?</li><li>Sed potestne rerum maior esse dissensio?</li><li>Stoici scilicet.</li><li>Cupit enim dícere nihil posse ad beatam vitam deesse sapienti.</li></ul>
+<ul><!-- wp:list-item -->
+<li>In qua quid est boni praeter summam voluptatem, et eam sempiternam?</li>
+<!-- /wp:list-item -->
+
+<!-- wp:list-item -->
+<li>Sin te auctoritas commovebat, nobisne omnibus et Platoni ipsi nescio quem illum anteponebas?</li>
+<!-- /wp:list-item -->
+
+<!-- wp:list-item -->
+<li>Sed potestne rerum maior esse dissensio?</li>
+<!-- /wp:list-item -->
+
+<!-- wp:list-item -->
+<li>Stoici scilicet.</li>
+<!-- /wp:list-item -->
+
+<!-- wp:list-item -->
+<li>Cupit enim dícere nihil posse ad beatam vitam deesse sapienti.</li>
+<!-- /wp:list-item --></ul>
 <!-- /wp:list -->
 
 <!-- wp:heading {"level":4} -->
@@ -3151,7 +4139,21 @@
 <!-- /wp:paragraph -->
 
 <!-- wp:list -->
-<ul><li>Compensabatur, inquit, cum summis doloribus laetitia.</li><li>Tu vero, inquam, ducas licet, si sequetur;</li><li>Addidisti ad extremum etiam indoctum fuisse.</li><li>Deinde disputat, quod cuiusque generis animantium statui deceat extremum.</li></ul>
+<ul><!-- wp:list-item -->
+<li>Compensabatur, inquit, cum summis doloribus laetitia.</li>
+<!-- /wp:list-item -->
+
+<!-- wp:list-item -->
+<li>Tu vero, inquam, ducas licet, si sequetur;</li>
+<!-- /wp:list-item -->
+
+<!-- wp:list-item -->
+<li>Addidisti ad extremum etiam indoctum fuisse.</li>
+<!-- /wp:list-item -->
+
+<!-- wp:list-item -->
+<li>Deinde disputat, quod cuiusque generis animantium statui deceat extremum.</li>
+<!-- /wp:list-item --></ul>
 <!-- /wp:list -->
 
 <!-- wp:paragraph -->
@@ -3247,7 +4249,21 @@
 <!-- /wp:paragraph -->
 
 <!-- wp:list -->
-<ul><li>Quid, quod homines infima fortuna, nulla spe rerum gerendarum, opifices denique delectantur historia?</li><li>Illo enim addito iuste fit recte factum, per se autem hoc ipsum reddere in officio ponitur.</li><li>Quo igitur, inquit, modo?</li><li>Sed est forma eius disciplinae, sicut fere ceterarum, triplex: una pars est naturae, disserendi altera, vivendi tertia.</li></ul>
+<ul><!-- wp:list-item -->
+<li>Quid, quod homines infima fortuna, nulla spe rerum gerendarum, opifices denique delectantur historia?</li>
+<!-- /wp:list-item -->
+
+<!-- wp:list-item -->
+<li>Illo enim addito iuste fit recte factum, per se autem hoc ipsum reddere in officio ponitur.</li>
+<!-- /wp:list-item -->
+
+<!-- wp:list-item -->
+<li>Quo igitur, inquit, modo?</li>
+<!-- /wp:list-item -->
+
+<!-- wp:list-item -->
+<li>Sed est forma eius disciplinae, sicut fere ceterarum, triplex: una pars est naturae, disserendi altera, vivendi tertia.</li>
+<!-- /wp:list-item --></ul>
 <!-- /wp:list -->
 
 <!-- wp:paragraph -->
@@ -3255,11 +4271,43 @@
 <!-- /wp:paragraph -->
 
 <!-- wp:list -->
-<ul><li>Nam et a te perfici istam disputationem volo, nec tua mihi oratio longa videri potest.</li><li>Audax negotium, dicerem impudens, nisi hoc institutum postea translatum ad philosophos nostros esset.</li><li>Sed in rebus apertissimis nimium longi sumus.</li><li>Itaque dicunt nec dubitant: mihi sic usus est, tibi ut opus est facto, fac.</li><li>Illi enim inter se dissentiunt.</li><li>Sed haec omittamus;</li></ul>
+<ul><!-- wp:list-item -->
+<li>Nam et a te perfici istam disputationem volo, nec tua mihi oratio longa videri potest.</li>
+<!-- /wp:list-item -->
+
+<!-- wp:list-item -->
+<li>Audax negotium, dicerem impudens, nisi hoc institutum postea translatum ad philosophos nostros esset.</li>
+<!-- /wp:list-item -->
+
+<!-- wp:list-item -->
+<li>Sed in rebus apertissimis nimium longi sumus.</li>
+<!-- /wp:list-item -->
+
+<!-- wp:list-item -->
+<li>Itaque dicunt nec dubitant: mihi sic usus est, tibi ut opus est facto, fac.</li>
+<!-- /wp:list-item -->
+
+<!-- wp:list-item -->
+<li>Illi enim inter se dissentiunt.</li>
+<!-- /wp:list-item -->
+
+<!-- wp:list-item -->
+<li>Sed haec omittamus;</li>
+<!-- /wp:list-item --></ul>
 <!-- /wp:list -->
 
 <!-- wp:list -->
-<ul><li>Magni enim aestimabat pecuniam non modo non contra leges, sed etiam legibus partam.</li><li>Nunc haec primum fortasse audientis servire debemus.</li><li>Quodsi vultum tibi, si incessum fingeres, quo gravior viderere, non esses tui similis;</li></ul>
+<ul><!-- wp:list-item -->
+<li>Magni enim aestimabat pecuniam non modo non contra leges, sed etiam legibus partam.</li>
+<!-- /wp:list-item -->
+
+<!-- wp:list-item -->
+<li>Nunc haec primum fortasse audientis servire debemus.</li>
+<!-- /wp:list-item -->
+
+<!-- wp:list-item -->
+<li>Quodsi vultum tibi, si incessum fingeres, quo gravior viderere, non esses tui similis;</li>
+<!-- /wp:list-item --></ul>
 <!-- /wp:list -->
 
 <!-- wp:heading {"level":4} -->
@@ -3331,11 +4379,47 @@
 <!-- /wp:paragraph -->
 
 <!-- wp:list -->
-<ul><li>Sed ad haec, nisi molestum est, habeo quae velim.</li><li>Quod cum ille dixisset et satis disputatum videretur, in oppidum ad Pomponium perreximus omnes.</li><li>Nam neque virtute retinetur ille in vita, nec iis, qui sine virtute sunt, mors est oppetenda.</li><li>Sed emolumenta communia esse dicuntur, recte autem facta et peccata non habentur communia.</li></ul>
+<ul><!-- wp:list-item -->
+<li>Sed ad haec, nisi molestum est, habeo quae velim.</li>
+<!-- /wp:list-item -->
+
+<!-- wp:list-item -->
+<li>Quod cum ille dixisset et satis disputatum videretur, in oppidum ad Pomponium perreximus omnes.</li>
+<!-- /wp:list-item -->
+
+<!-- wp:list-item -->
+<li>Nam neque virtute retinetur ille in vita, nec iis, qui sine virtute sunt, mors est oppetenda.</li>
+<!-- /wp:list-item -->
+
+<!-- wp:list-item -->
+<li>Sed emolumenta communia esse dicuntur, recte autem facta et peccata non habentur communia.</li>
+<!-- /wp:list-item --></ul>
 <!-- /wp:list -->
 
 <!-- wp:list -->
-<ul><li>Esse enim quam vellet iniquus iustus poterat inpune.</li><li>Quod cum accidisset ut alter alterum necopinato videremus, surrexit statim.</li><li>Quae duo sunt, unum facit.</li><li>Nunc ita separantur, ut disiuncta sint, quo nihil potest esse perversius.</li><li>Quod dicit Epicurus etiam de voluptate, quae minime sint voluptates, eas obscurari saepe et obrui.</li><li>Tantum dico, magis fuisse vestrum agere Epicuri diem natalem, quam illius testamento cavere ut ageretur.</li></ul>
+<ul><!-- wp:list-item -->
+<li>Esse enim quam vellet iniquus iustus poterat inpune.</li>
+<!-- /wp:list-item -->
+
+<!-- wp:list-item -->
+<li>Quod cum accidisset ut alter alterum necopinato videremus, surrexit statim.</li>
+<!-- /wp:list-item -->
+
+<!-- wp:list-item -->
+<li>Quae duo sunt, unum facit.</li>
+<!-- /wp:list-item -->
+
+<!-- wp:list-item -->
+<li>Nunc ita separantur, ut disiuncta sint, quo nihil potest esse perversius.</li>
+<!-- /wp:list-item -->
+
+<!-- wp:list-item -->
+<li>Quod dicit Epicurus etiam de voluptate, quae minime sint voluptates, eas obscurari saepe et obrui.</li>
+<!-- /wp:list-item -->
+
+<!-- wp:list-item -->
+<li>Tantum dico, magis fuisse vestrum agere Epicuri diem natalem, quam illius testamento cavere ut ageretur.</li>
+<!-- /wp:list-item --></ul>
 <!-- /wp:list -->
 
 <!-- wp:paragraph -->
@@ -3379,7 +4463,29 @@
 <!-- /wp:paragraph -->
 
 <!-- wp:list -->
-<ul><li>Hoc Hieronymus summum bonum esse dixit.</li><li>De malis autem et bonis ab iis animalibus, quae nondum depravata sint, ait optime iudicari.</li><li>Ex eorum enim scriptis et institutis cum omnis doctrina liberalis, omnis historia.</li><li>Hoc mihi cum tuo fratre convenit.</li><li>Negat enim summo bono afferre incrementum diem.</li><li>Omnia contraria, quos etiam insanos esse vultis.</li></ul>
+<ul><!-- wp:list-item -->
+<li>Hoc Hieronymus summum bonum esse dixit.</li>
+<!-- /wp:list-item -->
+
+<!-- wp:list-item -->
+<li>De malis autem et bonis ab iis animalibus, quae nondum depravata sint, ait optime iudicari.</li>
+<!-- /wp:list-item -->
+
+<!-- wp:list-item -->
+<li>Ex eorum enim scriptis et institutis cum omnis doctrina liberalis, omnis historia.</li>
+<!-- /wp:list-item -->
+
+<!-- wp:list-item -->
+<li>Hoc mihi cum tuo fratre convenit.</li>
+<!-- /wp:list-item -->
+
+<!-- wp:list-item -->
+<li>Negat enim summo bono afferre incrementum diem.</li>
+<!-- /wp:list-item -->
+
+<!-- wp:list-item -->
+<li>Omnia contraria, quos etiam insanos esse vultis.</li>
+<!-- /wp:list-item --></ul>
 <!-- /wp:list -->
 
 <!-- wp:quote -->
@@ -3547,7 +4653,17 @@
 <!-- /wp:paragraph -->
 
 <!-- wp:list -->
-<ul><li>Non modo carum sibi quemque, verum etiam vehementer carum esse?</li><li>Et quoniam haec deducuntur de corpore quid est cur non recte pulchritudo etiam ipsa propter se expetenda ducatur?</li><li>Cum autem venissemus in Academiae non sine causa nobilitata spatia, solitudo erat ea, quam volueramus.</li></ul>
+<ul><!-- wp:list-item -->
+<li>Non modo carum sibi quemque, verum etiam vehementer carum esse?</li>
+<!-- /wp:list-item -->
+
+<!-- wp:list-item -->
+<li>Et quoniam haec deducuntur de corpore quid est cur non recte pulchritudo etiam ipsa propter se expetenda ducatur?</li>
+<!-- /wp:list-item -->
+
+<!-- wp:list-item -->
+<li>Cum autem venissemus in Academiae non sine causa nobilitata spatia, solitudo erat ea, quam volueramus.</li>
+<!-- /wp:list-item --></ul>
 <!-- /wp:list -->
 
 <!-- wp:quote -->
@@ -3623,11 +4739,35 @@
 <!-- /wp:paragraph -->
 
 <!-- wp:list -->
-<ul><li>At ille non pertimuit saneque fidenter: Istis quidem ipsis verbis, inquit;</li><li>Nulla profecto est, quin suam vim retineat a primo ad extremum.</li><li>Pisone in eo gymnasio, quod Ptolomaeum vocatur, unaque nobiscum Q.</li><li>Apud ceteros autem philosophos, qui quaesivit aliquid, tacet;</li></ul>
+<ul><!-- wp:list-item -->
+<li>At ille non pertimuit saneque fidenter: Istis quidem ipsis verbis, inquit;</li>
+<!-- /wp:list-item -->
+
+<!-- wp:list-item -->
+<li>Nulla profecto est, quin suam vim retineat a primo ad extremum.</li>
+<!-- /wp:list-item -->
+
+<!-- wp:list-item -->
+<li>Pisone in eo gymnasio, quod Ptolomaeum vocatur, unaque nobiscum Q.</li>
+<!-- /wp:list-item -->
+
+<!-- wp:list-item -->
+<li>Apud ceteros autem philosophos, qui quaesivit aliquid, tacet;</li>
+<!-- /wp:list-item --></ul>
 <!-- /wp:list -->
 
 <!-- wp:list -->
-<ul><li>Sextilio Rufo, cum is rem ad amicos ita deferret, se esse heredem Q.</li><li>Ergo id est convenienter naturae vivere, a natura discedere.</li><li>Dici enim nihil potest verius.</li></ul>
+<ul><!-- wp:list-item -->
+<li>Sextilio Rufo, cum is rem ad amicos ita deferret, se esse heredem Q.</li>
+<!-- /wp:list-item -->
+
+<!-- wp:list-item -->
+<li>Ergo id est convenienter naturae vivere, a natura discedere.</li>
+<!-- /wp:list-item -->
+
+<!-- wp:list-item -->
+<li>Dici enim nihil potest verius.</li>
+<!-- /wp:list-item --></ul>
 <!-- /wp:list -->
 
 <!-- wp:paragraph -->
@@ -3635,11 +4775,23 @@
 <!-- /wp:paragraph -->
 
 <!-- wp:list -->
-<ul><li>Ex ea difficultate illae fallaciloquae, ut ait Accius, malitiae natae sunt.</li><li>Sit hoc ultimum bonorum, quod nunc a me defenditur;</li></ul>
+<ul><!-- wp:list-item -->
+<li>Ex ea difficultate illae fallaciloquae, ut ait Accius, malitiae natae sunt.</li>
+<!-- /wp:list-item -->
+
+<!-- wp:list-item -->
+<li>Sit hoc ultimum bonorum, quod nunc a me defenditur;</li>
+<!-- /wp:list-item --></ul>
 <!-- /wp:list -->
 
 <!-- wp:list -->
-<ul><li>Quae cum magnifice primo dici viderentur, considerata minus probabantur.</li><li>Satisne igitur videor vim verborum tenere, an sum etiam nunc vel Graece loqui vel Latine docendus?</li></ul>
+<ul><!-- wp:list-item -->
+<li>Quae cum magnifice primo dici viderentur, considerata minus probabantur.</li>
+<!-- /wp:list-item -->
+
+<!-- wp:list-item -->
+<li>Satisne igitur videor vim verborum tenere, an sum etiam nunc vel Graece loqui vel Latine docendus?</li>
+<!-- /wp:list-item --></ul>
 <!-- /wp:list -->
 
 <!-- wp:paragraph -->
@@ -3651,11 +4803,39 @@
 <!-- /wp:paragraph -->
 
 <!-- wp:list -->
-<ul><li>Itaque nostrum est-quod nostrum dico, artis est-ad ea principia, quae accepimus.</li><li>Quamquam haec quidem praeposita recte et reiecta dicere licebit.</li><li>Aliter homines, aliter philosophos loqui putas oportere?</li><li>Habent enim et bene longam et satis litigiosam disputationem.</li><li>Sed non alienum est, quo facilius vis verbi intellegatur, rationem huius verbi faciendi Zenonis exponere.</li><li>Tum Quintus: Est plane, Piso, ut dicis, inquit.</li></ul>
+<ul><!-- wp:list-item -->
+<li>Itaque nostrum est-quod nostrum dico, artis est-ad ea principia, quae accepimus.</li>
+<!-- /wp:list-item -->
+
+<!-- wp:list-item -->
+<li>Quamquam haec quidem praeposita recte et reiecta dicere licebit.</li>
+<!-- /wp:list-item -->
+
+<!-- wp:list-item -->
+<li>Aliter homines, aliter philosophos loqui putas oportere?</li>
+<!-- /wp:list-item -->
+
+<!-- wp:list-item -->
+<li>Habent enim et bene longam et satis litigiosam disputationem.</li>
+<!-- /wp:list-item -->
+
+<!-- wp:list-item -->
+<li>Sed non alienum est, quo facilius vis verbi intellegatur, rationem huius verbi faciendi Zenonis exponere.</li>
+<!-- /wp:list-item -->
+
+<!-- wp:list-item -->
+<li>Tum Quintus: Est plane, Piso, ut dicis, inquit.</li>
+<!-- /wp:list-item --></ul>
 <!-- /wp:list -->
 
 <!-- wp:list -->
-<ul><li>Bonum integritas corporis: misera debilitas.</li><li>Tu quidem reddes;</li></ul>
+<ul><!-- wp:list-item -->
+<li>Bonum integritas corporis: misera debilitas.</li>
+<!-- /wp:list-item -->
+
+<!-- wp:list-item -->
+<li>Tu quidem reddes;</li>
+<!-- /wp:list-item --></ul>
 <!-- /wp:list -->
 
 <!-- wp:heading {"level":6} -->
@@ -3667,7 +4847,25 @@
 <!-- /wp:paragraph -->
 
 <!-- wp:list -->
-<ul><li>Huic ego, si negaret quicquam interesse ad beate vivendum quali uteretur victu, concederem, laudarem etiam;</li><li>Quod praeceptum quia maius erat, quam ut ab homine videretur, idcirco assignatum est deo.</li><li>Videmusne ut pueri ne verberibus quidem a contemplandis rebus perquirendisque deterreantur?</li><li>Scio enim esse quosdam, qui quavis lingua philosophari possint;</li><li>Qua ex cognitione facilior facta est investigatio rerum occultissimarum.</li></ul>
+<ul><!-- wp:list-item -->
+<li>Huic ego, si negaret quicquam interesse ad beate vivendum quali uteretur victu, concederem, laudarem etiam;</li>
+<!-- /wp:list-item -->
+
+<!-- wp:list-item -->
+<li>Quod praeceptum quia maius erat, quam ut ab homine videretur, idcirco assignatum est deo.</li>
+<!-- /wp:list-item -->
+
+<!-- wp:list-item -->
+<li>Videmusne ut pueri ne verberibus quidem a contemplandis rebus perquirendisque deterreantur?</li>
+<!-- /wp:list-item -->
+
+<!-- wp:list-item -->
+<li>Scio enim esse quosdam, qui quavis lingua philosophari possint;</li>
+<!-- /wp:list-item -->
+
+<!-- wp:list-item -->
+<li>Qua ex cognitione facilior facta est investigatio rerum occultissimarum.</li>
+<!-- /wp:list-item --></ul>
 <!-- /wp:list -->
 
 <!-- wp:heading -->
@@ -3731,7 +4929,25 @@
 <!-- /wp:paragraph -->
 
 <!-- wp:list -->
-<ul><li>Sed quid ages tandem, si utilitas ab amicitia, ut fit saepe, defecerit?</li><li>Sed nunc, quod agimus;</li><li>Beatus autem esse in maximarum rerum timore nemo potest.</li><li>An ea, quae per vinitorem antea consequebatur, per se ipsa curabit?</li><li>Sedulo, inquam, faciam.</li></ul>
+<ul><!-- wp:list-item -->
+<li>Sed quid ages tandem, si utilitas ab amicitia, ut fit saepe, defecerit?</li>
+<!-- /wp:list-item -->
+
+<!-- wp:list-item -->
+<li>Sed nunc, quod agimus;</li>
+<!-- /wp:list-item -->
+
+<!-- wp:list-item -->
+<li>Beatus autem esse in maximarum rerum timore nemo potest.</li>
+<!-- /wp:list-item -->
+
+<!-- wp:list-item -->
+<li>An ea, quae per vinitorem antea consequebatur, per se ipsa curabit?</li>
+<!-- /wp:list-item -->
+
+<!-- wp:list-item -->
+<li>Sedulo, inquam, faciam.</li>
+<!-- /wp:list-item --></ul>
 <!-- /wp:list -->
 
 <!-- wp:paragraph -->
@@ -3743,7 +4959,29 @@
 <!-- /wp:paragraph -->
 
 <!-- wp:list -->
-<ul><li>Ab his oratores, ab his imperatores ac rerum publicarum principes extiterunt.</li><li>Quae sunt igitur communia vobis cum antiquis, iis sic utamur quasi concessis;</li><li>Tamen aberramus a proposito, et, ne longius, prorsus, inquam, Piso, si ista mala sunt, placet.</li><li>Sit hoc ultimum bonorum, quod nunc a me defenditur;</li><li>Sed quid attinet de rebus tam apertis plura requirere?</li><li>Nam si propter voluptatem, quae est ista laus, quae possit e macello peti?</li></ul>
+<ul><!-- wp:list-item -->
+<li>Ab his oratores, ab his imperatores ac rerum publicarum principes extiterunt.</li>
+<!-- /wp:list-item -->
+
+<!-- wp:list-item -->
+<li>Quae sunt igitur communia vobis cum antiquis, iis sic utamur quasi concessis;</li>
+<!-- /wp:list-item -->
+
+<!-- wp:list-item -->
+<li>Tamen aberramus a proposito, et, ne longius, prorsus, inquam, Piso, si ista mala sunt, placet.</li>
+<!-- /wp:list-item -->
+
+<!-- wp:list-item -->
+<li>Sit hoc ultimum bonorum, quod nunc a me defenditur;</li>
+<!-- /wp:list-item -->
+
+<!-- wp:list-item -->
+<li>Sed quid attinet de rebus tam apertis plura requirere?</li>
+<!-- /wp:list-item -->
+
+<!-- wp:list-item -->
+<li>Nam si propter voluptatem, quae est ista laus, quae possit e macello peti?</li>
+<!-- /wp:list-item --></ul>
 <!-- /wp:list -->
 
 <!-- wp:paragraph -->
@@ -3783,7 +5021,25 @@
 <!-- /wp:paragraph -->
 
 <!-- wp:list -->
-<ul><li>Minime vero, inquit ille, consentit.</li><li>Sunt enim quasi prima elementa naturae, quibus ubertas orationis adhiberi vix potest, nec equidem eam cogito consectari.</li><li>At coluit ipse amicitias.</li><li>Ex quo illud efficitur, qui bene cenent omnis libenter cenare, qui libenter, non continuo bene.</li><li>Diodorus, eius auditor, adiungit ad honestatem vacuitatem doloris.</li></ul>
+<ul><!-- wp:list-item -->
+<li>Minime vero, inquit ille, consentit.</li>
+<!-- /wp:list-item -->
+
+<!-- wp:list-item -->
+<li>Sunt enim quasi prima elementa naturae, quibus ubertas orationis adhiberi vix potest, nec equidem eam cogito consectari.</li>
+<!-- /wp:list-item -->
+
+<!-- wp:list-item -->
+<li>At coluit ipse amicitias.</li>
+<!-- /wp:list-item -->
+
+<!-- wp:list-item -->
+<li>Ex quo illud efficitur, qui bene cenent omnis libenter cenare, qui libenter, non continuo bene.</li>
+<!-- /wp:list-item -->
+
+<!-- wp:list-item -->
+<li>Diodorus, eius auditor, adiungit ad honestatem vacuitatem doloris.</li>
+<!-- /wp:list-item --></ul>
 <!-- /wp:list -->
 
 <!-- wp:image -->
@@ -3811,7 +5067,13 @@
 <!-- /wp:paragraph -->
 
 <!-- wp:list -->
-<ul><li>Traditur, inquit, ab Epicuro ratio neglegendi doloris.</li><li>Sed tamen omne, quod de re bona dilucide dicitur, mihi praeclare dici videtur.</li></ul>
+<ul><!-- wp:list-item -->
+<li>Traditur, inquit, ab Epicuro ratio neglegendi doloris.</li>
+<!-- /wp:list-item -->
+
+<!-- wp:list-item -->
+<li>Sed tamen omne, quod de re bona dilucide dicitur, mihi praeclare dici videtur.</li>
+<!-- /wp:list-item --></ul>
 <!-- /wp:list -->
 
 <!-- wp:heading -->
@@ -3851,7 +5113,17 @@
 <!-- /wp:paragraph -->
 
 <!-- wp:list -->
-<ul><li>Immo istud quidem, inquam, quo loco quidque, nisi iniquum postulo, arbitratu meo.</li><li>Cur ipse Pythagoras et Aegyptum lustravit et Persarum magos adiit?</li><li>Ergo illi intellegunt quid Epicurus dicat, ego non intellego?</li></ul>
+<ul><!-- wp:list-item -->
+<li>Immo istud quidem, inquam, quo loco quidque, nisi iniquum postulo, arbitratu meo.</li>
+<!-- /wp:list-item -->
+
+<!-- wp:list-item -->
+<li>Cur ipse Pythagoras et Aegyptum lustravit et Persarum magos adiit?</li>
+<!-- /wp:list-item -->
+
+<!-- wp:list-item -->
+<li>Ergo illi intellegunt quid Epicurus dicat, ego non intellego?</li>
+<!-- /wp:list-item --></ul>
 <!-- /wp:list -->
 
 <!-- wp:paragraph -->
@@ -3895,7 +5167,29 @@
 <!-- /wp:paragraph -->
 
 <!-- wp:list -->
-<ul><li>Et ais, si una littera commota sit, fore tota ut labet disciplina.</li><li>Mihi enim satis est, ipsis non satis.</li><li>Sic vester sapiens magno aliquo emolumento commotus cicuta, si opus erit, dimicabit.</li><li>Satisne igitur videor vim verborum tenere, an sum etiam nunc vel Graece loqui vel Latine docendus?</li><li>Tum Torquatus: Prorsus, inquit, assentior;</li><li>Sed quoniam et advesperascit et mihi ad villam revertendum est, nunc quidem hactenus;</li></ul>
+<ul><!-- wp:list-item -->
+<li>Et ais, si una littera commota sit, fore tota ut labet disciplina.</li>
+<!-- /wp:list-item -->
+
+<!-- wp:list-item -->
+<li>Mihi enim satis est, ipsis non satis.</li>
+<!-- /wp:list-item -->
+
+<!-- wp:list-item -->
+<li>Sic vester sapiens magno aliquo emolumento commotus cicuta, si opus erit, dimicabit.</li>
+<!-- /wp:list-item -->
+
+<!-- wp:list-item -->
+<li>Satisne igitur videor vim verborum tenere, an sum etiam nunc vel Graece loqui vel Latine docendus?</li>
+<!-- /wp:list-item -->
+
+<!-- wp:list-item -->
+<li>Tum Torquatus: Prorsus, inquit, assentior;</li>
+<!-- /wp:list-item -->
+
+<!-- wp:list-item -->
+<li>Sed quoniam et advesperascit et mihi ad villam revertendum est, nunc quidem hactenus;</li>
+<!-- /wp:list-item --></ul>
 <!-- /wp:list -->
 
 <!-- wp:paragraph -->
@@ -3939,7 +5233,29 @@
 <!-- /wp:paragraph -->
 
 <!-- wp:list -->
-<ul><li>Nec enim, dum metuit, iustus est, et certe, si metuere destiterit, non erit;</li><li>Ab hoc autem quaedam non melius quam veteres, quaedam omnino relicta.</li><li>Si enim ita est, vide ne facinus facias, cum mori suadeas.</li><li>Nec enim ignoras his istud honestum non summum modo, sed etiam, ut tu vis, solum bonum videri.</li><li>Vos autem cum perspicuis dubia debeatis illustrare, dubiis perspicua conamini tollere.</li><li>Idcirco enim non desideraret, quia, quod dolore caret, id in voluptate est.</li></ul>
+<ul><!-- wp:list-item -->
+<li>Nec enim, dum metuit, iustus est, et certe, si metuere destiterit, non erit;</li>
+<!-- /wp:list-item -->
+
+<!-- wp:list-item -->
+<li>Ab hoc autem quaedam non melius quam veteres, quaedam omnino relicta.</li>
+<!-- /wp:list-item -->
+
+<!-- wp:list-item -->
+<li>Si enim ita est, vide ne facinus facias, cum mori suadeas.</li>
+<!-- /wp:list-item -->
+
+<!-- wp:list-item -->
+<li>Nec enim ignoras his istud honestum non summum modo, sed etiam, ut tu vis, solum bonum videri.</li>
+<!-- /wp:list-item -->
+
+<!-- wp:list-item -->
+<li>Vos autem cum perspicuis dubia debeatis illustrare, dubiis perspicua conamini tollere.</li>
+<!-- /wp:list-item -->
+
+<!-- wp:list-item -->
+<li>Idcirco enim non desideraret, quia, quod dolore caret, id in voluptate est.</li>
+<!-- /wp:list-item --></ul>
 <!-- /wp:list -->
 
 <!-- wp:paragraph -->
@@ -3951,7 +5267,13 @@
 <!-- /wp:paragraph -->
 
 <!-- wp:list -->
-<ul><li>Pisone in eo gymnasio, quod Ptolomaeum vocatur, unaque nobiscum Q.</li><li>Non igitur bene.</li></ul>
+<ul><!-- wp:list-item -->
+<li>Pisone in eo gymnasio, quod Ptolomaeum vocatur, unaque nobiscum Q.</li>
+<!-- /wp:list-item -->
+
+<!-- wp:list-item -->
+<li>Non igitur bene.</li>
+<!-- /wp:list-item --></ul>
 <!-- /wp:list -->
 
 <!-- wp:heading -->
@@ -4031,7 +5353,21 @@
 <!-- /wp:paragraph -->
 
 <!-- wp:list -->
-<ul><li>Qua ex cognitione facilior facta est investigatio rerum occultissimarum.</li><li>Sed quae tandem ista ratio est?</li><li>Tum Piso: Quoniam igitur aliquid omnes, quid Lucius noster?</li><li>Nihil minus, contraque illa hereditate dives ob eamque rem laetus.</li></ul>
+<ul><!-- wp:list-item -->
+<li>Qua ex cognitione facilior facta est investigatio rerum occultissimarum.</li>
+<!-- /wp:list-item -->
+
+<!-- wp:list-item -->
+<li>Sed quae tandem ista ratio est?</li>
+<!-- /wp:list-item -->
+
+<!-- wp:list-item -->
+<li>Tum Piso: Quoniam igitur aliquid omnes, quid Lucius noster?</li>
+<!-- /wp:list-item -->
+
+<!-- wp:list-item -->
+<li>Nihil minus, contraque illa hereditate dives ob eamque rem laetus.</li>
+<!-- /wp:list-item --></ul>
 <!-- /wp:list -->
 
 <!-- wp:quote -->
@@ -4075,7 +5411,17 @@
 <!-- /wp:paragraph -->
 
 <!-- wp:list -->
-<ul><li>Illa sunt similia: hebes acies est cuipiam oculorum, corpore alius senescit;</li><li>Eodem modo is enim tibi nemo dabit, quod, expetendum sit, id esse laudabile.</li><li>Quarum ambarum rerum cum medicinam pollicetur, luxuriae licentiam pollicetur.</li></ul>
+<ul><!-- wp:list-item -->
+<li>Illa sunt similia: hebes acies est cuipiam oculorum, corpore alius senescit;</li>
+<!-- /wp:list-item -->
+
+<!-- wp:list-item -->
+<li>Eodem modo is enim tibi nemo dabit, quod, expetendum sit, id esse laudabile.</li>
+<!-- /wp:list-item -->
+
+<!-- wp:list-item -->
+<li>Quarum ambarum rerum cum medicinam pollicetur, luxuriae licentiam pollicetur.</li>
+<!-- /wp:list-item --></ul>
 <!-- /wp:list -->
 
 <!-- wp:paragraph -->
@@ -4123,7 +5469,21 @@
 <!-- /wp:paragraph -->
 
 <!-- wp:list -->
-<ul><li>Quaesita enim virtus est, non quae relinqueret naturam, sed quae tueretur.</li><li>Plane idem, inquit, et maxima quidem, qua fieri nulla maior potest.</li><li>Quod si ita est, sequitur id ipsum, quod te velle video, omnes semper beatos esse sapientes.</li><li>A villa enim, credo, et: Si ibi te esse scissem, ad te ipse venissem.</li></ul>
+<ul><!-- wp:list-item -->
+<li>Quaesita enim virtus est, non quae relinqueret naturam, sed quae tueretur.</li>
+<!-- /wp:list-item -->
+
+<!-- wp:list-item -->
+<li>Plane idem, inquit, et maxima quidem, qua fieri nulla maior potest.</li>
+<!-- /wp:list-item -->
+
+<!-- wp:list-item -->
+<li>Quod si ita est, sequitur id ipsum, quod te velle video, omnes semper beatos esse sapientes.</li>
+<!-- /wp:list-item -->
+
+<!-- wp:list-item -->
+<li>A villa enim, credo, et: Si ibi te esse scissem, ad te ipse venissem.</li>
+<!-- /wp:list-item --></ul>
 <!-- /wp:list -->
 
 <!-- wp:heading {"level":3} -->
@@ -4167,5 +5527,27 @@
 <!-- /wp:paragraph -->
 
 <!-- wp:list -->
-<ul><li>Eadem fortitudinis ratio reperietur.</li><li>Quid, quod homines infima fortuna, nulla spe rerum gerendarum, opifices denique delectantur historia?</li><li>Cum ageremus, inquit, vitae beatum et eundem supremum diem, scribebamus haec.</li><li>Scientiam pollicentur, quam non erat mirum sapientiae cupido patria esse cariorem.</li><li>Varietates autem iniurasque fortunae facile veteres philosophorum praeceptis instituta vita superabat.</li><li>Quamquam tu hanc copiosiorem etiam soles dicere.</li></ul>
+<ul><!-- wp:list-item -->
+<li>Eadem fortitudinis ratio reperietur.</li>
+<!-- /wp:list-item -->
+
+<!-- wp:list-item -->
+<li>Quid, quod homines infima fortuna, nulla spe rerum gerendarum, opifices denique delectantur historia?</li>
+<!-- /wp:list-item -->
+
+<!-- wp:list-item -->
+<li>Cum ageremus, inquit, vitae beatum et eundem supremum diem, scribebamus haec.</li>
+<!-- /wp:list-item -->
+
+<!-- wp:list-item -->
+<li>Scientiam pollicentur, quam non erat mirum sapientiae cupido patria esse cariorem.</li>
+<!-- /wp:list-item -->
+
+<!-- wp:list-item -->
+<li>Varietates autem iniurasque fortunae facile veteres philosophorum praeceptis instituta vita superabat.</li>
+<!-- /wp:list-item -->
+
+<!-- wp:list-item -->
+<li>Quamquam tu hanc copiosiorem etiam soles dicere.</li>
+<!-- /wp:list-item --></ul>
 <!-- /wp:list -->


### PR DESCRIPTION
## What

Follow up to https://github.com/WordPress/gutenberg/pull/42711 

This PR updates the `large-post.html` content we use in performance tests to use the list v2 format.

## Why

The block editor needs to update the block syntax for an old version of the List blocks included in the Performance Tests. This might impact the final result as the editor needs to do some additional work.

## How

I opened the test content in the block editor and copied the result, which includes the updated list blocks.
