### PR TITLE
Components: Retire `DARK_GRAY` colors

### DIFF
--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -11,9 +11,8 @@
 
 -   `ToggleControl`: Add `__nextHasNoMargin` prop for opting into the new margin-free styles ([#43717](https://github.com/WordPress/gutenberg/pull/43717)). 
 -   `CheckboxControl`: Add `__nextHasNoMargin` prop for opting into the new margin-free styles ([#43720](https://github.com/WordPress/gutenberg/pull/43720)).
-
-### Enhancements
-
+-   `RangeControl`: Tweak dark gray marking color to be consistent with the grays in `@wordpress/base-styles` ([#43773](https://github.com/WordPress/gutenberg/pull/43773)).
+-   `UnitControl`: Tweak unit dropdown color to be consistent with the grays in `@wordpress/base-styles` ([#43773](https://github.com/WordPress/gutenberg/pull/43773)).
 -   `CardHeader`, `CardBody`, `CardFooter`: Tweak `isShady` background colors to be consistent with the grays in `@wordpress/base-styles` ([#43719](https://github.com/WordPress/gutenberg/pull/43719)).
 -   `InputControl`, `SelectControl`: Tweak `disabled` colors to be consistent with the grays in `@wordpress/base-styles` ([#43719](https://github.com/WordPress/gutenberg/pull/43719)).
 

--- a/packages/components/src/range-control/styles/range-control-styles.ts
+++ b/packages/components/src/range-control/styles/range-control-styles.ts
@@ -152,7 +152,7 @@ export const Mark = styled.span`
 
 const markLabelFill = ( { isFilled }: RangeMarkProps ) => {
 	return css( {
-		color: isFilled ? COLORS.darkGray[ 300 ] : COLORS.lightGray[ 600 ],
+		color: isFilled ? COLORS.gray[ 700 ] : COLORS.lightGray[ 600 ],
 	} );
 };
 

--- a/packages/components/src/unit-control/styles/unit-control-styles.ts
+++ b/packages/components/src/unit-control/styles/unit-control-styles.ts
@@ -66,7 +66,7 @@ const baseUnitLabelStyles = ( { selectSize }: SelectProps ) => {
 			box-sizing: border-box;
 			padding: 2px 1px;
 			width: 20px;
-			color: ${ COLORS.darkGray[ 500 ] };
+			color: ${ COLORS.gray[ 800 ] };
 			font-size: 8px;
 			line-height: 1;
 			letter-spacing: -0.5px;

--- a/packages/components/src/utils/colors-values.js
+++ b/packages/components/src/utils/colors-values.js
@@ -24,7 +24,6 @@ const GRAY = {
 
 // TODO: Replace usages of these with the equivalents in `GRAY`
 const DARK_GRAY = {
-	500: '#555d66', // Use this most of the time for dark items.
 	300: '#6c7781', // Lightest gray that can be used for AA text contrast.
 };
 

--- a/packages/components/src/utils/colors-values.js
+++ b/packages/components/src/utils/colors-values.js
@@ -23,11 +23,6 @@ const GRAY = {
 };
 
 // TODO: Replace usages of these with the equivalents in `GRAY`
-const DARK_GRAY = {
-	300: '#6c7781', // Lightest gray that can be used for AA text contrast.
-};
-
-// TODO: Replace usages of these with the equivalents in `GRAY`
 const LIGHT_GRAY = {
 	800: '#b5bcc2',
 	600: '#d7dade',
@@ -65,10 +60,6 @@ const UI = {
 };
 
 export const COLORS = Object.freeze( {
-	/**
-	 * @deprecated Try to use `gray` instead.
-	 */
-	darkGray: DARK_GRAY,
 	/**
 	 * The main gray color object.
 	 */


### PR DESCRIPTION
Part of #40392

## What?

Replaces the following colors:

- `DARK_GRAY[ 500 ]` `#555d66` → `GRAY[ 800 ]` `#2f2f2f`
- `DARK_GRAY[ 300 ]` `#6c7781` → `GRAY[ 700 ]` `#757575`

Affected components:

- RangeControl (the dark gray number markings under the slider)
- UnitControl (the unit dropdown in the default size variant)

## Why?

We want to consolidate our grays to the canonical gray scale in `@wordpress/base-styles`.

## How?

Replace with the closest colors in the main GRAY object.

## Testing Instructions

1. `npm run storybook:dev`
2. Check the stories for the affected components.

## Screenshots

| Before | After |
|--------|-------|
|![RangeControl markings, old color](https://user-images.githubusercontent.com/555336/187906729-c69da1eb-1800-4299-8377-545aeb18b3a7.png)|![RangeControl markings, new color](https://user-images.githubusercontent.com/555336/187906693-684c139e-bbba-4b8a-8a8d-8207a5e3f888.png)|
|![UnitControl with old dropdown color](https://user-images.githubusercontent.com/555336/187907482-5ba67e06-92d2-4dcb-a5b2-2b2de4c97404.png)|![UnitControl with new dropdown color](https://user-images.githubusercontent.com/555336/187907614-e2ce46d4-1862-4fdf-90dd-a452881e2495.png)|