### PR TITLE
Gallery Block: Use `wp_enqueue_block_support_styles()` if possible

### DIFF
--- a/packages/block-library/src/gallery/index.php
+++ b/packages/block-library/src/gallery/index.php
@@ -104,7 +104,17 @@ function block_core_gallery_render( $attributes, $content ) {
 	// Set the CSS variable to the column value, and the `gap` property to the combined gap value.
 	$style = '.wp-block-gallery.' . $class . '{ --wp--style--unstable-gallery-gap: ' . $gap_column . '; gap: ' . $gap_value . '}';
 
-	gutenberg_enqueue_block_support_styles( $style, 11 );
+	// If we're on WordPress >= 6.1, we can use `wp_enqueue_block_support_styles`, as it supports
+	// `$priority` as its second argument. Otherwise, we have to fall back to using our
+	// `gutenberg_enqueue_block_support_styles` shim.
+	if (
+		function_exists( 'wp_enqueue_block_support_styles' ) &&
+		2 === count( ( new ReflectionFunction( 'wp_enqueue_block_support_styles' ) )->getParameters() )
+	) {
+		wp_enqueue_block_support_styles( $style, 11 );
+	} else {
+		gutenberg_enqueue_block_support_styles( $style, 11 );
+	}
 	return $content;
 }
 /**


### PR DESCRIPTION
## What?
In the Gallery Block, use `wp_enqueue_block_support_styles()` if it's available, and if it supports the `$priority` arg.

## Why?
To enable us to use the two-argument version of `wp_enqueue_block_support_styles()` (currently being backported to Core [here](https://github.com/WordPress/wordpress-develop/pull/3158)), and eventually remove the `gutenberg_enqueue_block_support_styles()` shim.

## How?
By checking if the function exists, and if it supports two arguments.

## Testing Instructions
Verify that the Gallery block still works.
