### PR TITLE
Image URL Input: use new anchor prop for Popover

### DIFF
--- a/packages/block-editor/src/components/url-popover/image-url-input-ui.js
+++ b/packages/block-editor/src/components/url-popover/image-url-input-ui.js
@@ -250,7 +250,8 @@ const ImageURLInputUI = ( {
 			/>
 			{ isOpen && (
 				<URLPopover
-					anchor={ buttonRef.current }
+					// `anchor` should never be `null`
+					anchor={ buttonRef.current ?? undefined }
 					onFocusOutside={ onFocusOutside() }
 					onClose={ closeLinkUI }
 					renderSettings={ () => advancedOptions }

--- a/packages/block-editor/src/components/url-popover/image-url-input-ui.js
+++ b/packages/block-editor/src/components/url-popover/image-url-input-ui.js
@@ -250,7 +250,7 @@ const ImageURLInputUI = ( {
 			/>
 			{ isOpen && (
 				<URLPopover
-					anchorRef={ buttonRef }
+					anchor={ buttonRef.current }
 					onFocusOutside={ onFocusOutside() }
 					onClose={ closeLinkUI }
 					renderSettings={ () => advancedOptions }


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Refactor the way the Image URL Input component passes an anchor to Popover, using the new `anchor` prop

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

See #43691 for more context

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

Swap `anchorRef` with `anchor`

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->

<!--
In the editor, open various popovers and make sure that:

 - the behaviour is the same as on `trunk`
 - there's no warning in the console when a new block is selected
 -->

In the editor (both post editor and site editor):

- add an image block and select an image.
- Select the image, and press the "link" icon in the block toolbar
- a popover should open as expected, allowing you to insert a URL

![Screenshot 2022-09-01 at 17 57 27](https://user-images.githubusercontent.com/1083581/187960099-a4fa115a-6637-4fc7-a205-377201177cbf.png)

