### PR TITLE
Buttons block: use new Popover anchor prop

### DIFF
--- a/packages/block-library/src/button/edit.js
+++ b/packages/block-library/src/button/edit.js
@@ -218,7 +218,7 @@ function ButtonEdit( props ) {
 						setIsEditingURL( false );
 						richTextRef.current?.focus();
 					} }
-					anchorRef={ ref?.current }
+					anchor={ ref.current }
 					focusOnMount={ isEditingURL ? 'firstElement' : false }
 					__unstableSlotName={ '__unstable-block-tools-after' }
 					__unstableShift

--- a/packages/block-library/src/button/edit.js
+++ b/packages/block-library/src/button/edit.js
@@ -218,7 +218,8 @@ function ButtonEdit( props ) {
 						setIsEditingURL( false );
 						richTextRef.current?.focus();
 					} }
-					anchor={ ref.current }
+					// `anchor` should never be `null`
+					anchor={ ref.current ?? undefined }
 					focusOnMount={ isEditingURL ? 'firstElement' : false }
 					__unstableSlotName={ '__unstable-block-tools-after' }
 					__unstableShift


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Refactor the way the Buttons block edit toolbar passes an anchor to Popover, using the new `anchor` prop

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

See #43691 for more context

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

Swap `anchorRef` with `anchor`

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->

<!--
In the editor, open various popovers and make sure that:

 - the behaviour is the same as on `trunk`
 - there's no warning in the console when a new block is selected
 -->

In the editor (both post editor and site editor):

- add a "Buttons" block
- Select the button, and press the "link" icon in the block toolbar
- a popover should open as expected, allowing you to insert a URL

![Screenshot 2022-09-01 at 18 11 45](https://user-images.githubusercontent.com/1083581/187962177-c5b749d5-b657-4b3e-9338-230d92bbc725.png)
