### PR TITLE
Navigation block: use new anchor prop for Popover

### DIFF
--- a/packages/block-library/src/navigation-link/edit.js
+++ b/packages/block-library/src/navigation-link/edit.js
@@ -844,7 +844,7 @@ export default function NavigationLinkEdit( {
 						<Popover
 							position="bottom center"
 							onClose={ () => setIsLinkOpen( false ) }
-							anchorRef={ listItemRef.current }
+							anchor={ listItemRef.current }
 							__unstableShift
 						>
 							<LinkControl

--- a/packages/block-library/src/navigation-link/edit.js
+++ b/packages/block-library/src/navigation-link/edit.js
@@ -844,7 +844,8 @@ export default function NavigationLinkEdit( {
 						<Popover
 							position="bottom center"
 							onClose={ () => setIsLinkOpen( false ) }
-							anchor={ listItemRef.current }
+							// `anchor` should never be `null`
+							anchor={ listItemRef.current ?? undefined }
 							__unstableShift
 						>
 							<LinkControl

--- a/packages/block-library/src/navigation-submenu/edit.js
+++ b/packages/block-library/src/navigation-submenu/edit.js
@@ -629,7 +629,7 @@ export default function NavigationSubmenuEdit( {
 						<Popover
 							position="bottom center"
 							onClose={ () => setIsLinkOpen( false ) }
-							anchorRef={ listItemRef.current }
+							anchor={ listItemRef.current }
 							__unstableShift
 						>
 							<LinkControl

--- a/packages/block-library/src/navigation-submenu/edit.js
+++ b/packages/block-library/src/navigation-submenu/edit.js
@@ -629,7 +629,8 @@ export default function NavigationSubmenuEdit( {
 						<Popover
 							position="bottom center"
 							onClose={ () => setIsLinkOpen( false ) }
-							anchor={ listItemRef.current }
+							// `anchor` should never be `null`
+							anchor={ listItemRef.current ?? undefined }
 							__unstableShift
 						>
 							<LinkControl


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Refactor the way the Navigation and Navigation Sumenu blocks pass an anchor to Popover, using the new `anchor` prop

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

See #43691 for more context

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

Swap `anchorRef` with `anchor`

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->

<!--
In the editor, open various popovers and make sure that:

 - the behaviour is the same as on `trunk`
 - there's no warning in the console when a new block is selected
 -->

In the editor:

- add a Navigation block and click on "Add a link".
- a popover should open as expected, allowing you to insert a URL
- add a new Navigation link, then convert the link to a submenu
- add links to the submenu, and make sure that the same popover allowing you to edit the link's URL is opened as expected


https://user-images.githubusercontent.com/1083581/187965284-dec59c6c-5411-4f5c-b75d-f73491817713.mp4

