### PR TITLE
Post Date block: use new anchor prop for Popover

### DIFF
--- a/packages/block-library/src/post-date/edit.js
+++ b/packages/block-library/src/post-date/edit.js
@@ -101,7 +101,10 @@ export default function PostDateEdit( {
 				{ date && ! isDescendentOfQueryLoop && (
 					<ToolbarGroup>
 						<Dropdown
-							popoverProps={ { anchor: timeRef.current } }
+							popoverProps={ {
+								// `anchor` should never be `null`
+								anchor: timeRef.current ?? undefined,
+							} }
 							renderContent={ ( { onClose } ) => (
 								<PublishDateTimePicker
 									currentDate={ date }

--- a/packages/block-library/src/post-date/edit.js
+++ b/packages/block-library/src/post-date/edit.js
@@ -101,7 +101,7 @@ export default function PostDateEdit( {
 				{ date && ! isDescendentOfQueryLoop && (
 					<ToolbarGroup>
 						<Dropdown
-							popoverProps={ { anchorRef: timeRef.current } }
+							popoverProps={ { anchor: timeRef.current } }
 							renderContent={ ( { onClose } ) => (
 								<PublishDateTimePicker
 									currentDate={ date }


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Refactor the way the Post Date block passes an anchor to Popover, using the new `anchor` prop

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

See #43691 for more context

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

Swap `anchorRef` with `anchor`

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->

<!--
In the editor, open various popovers and make sure that:

 - the behaviour is the same as on `trunk`
 - there's no warning in the console when a new block is selected
 -->

In the editor:

- add a Post Date block and click on the "pencil" icon in the block toolbar while the block is selected
- a popover should open as expected, showing the date picker

![Screenshot 2022-09-01 at 18 38 50](https://user-images.githubusercontent.com/1083581/187967606-3ad2a4c2-109f-482e-bbcf-846049339454.png)


