### PR TITLE
BorderBoxControl: use Popover's new anchor prop

### DIFF
--- a/packages/components/src/border-box-control/border-box-control-split-controls/component.tsx
+++ b/packages/components/src/border-box-control/border-box-control-split-controls/component.tsx
@@ -40,7 +40,7 @@ const BorderBoxControlSplitControls = (
 	const [ popoverAnchor, setPopoverAnchor ] = useState< Element >();
 
 	const containerRef = useCallback( ( node ) => {
-		setPopoverAnchor( node );
+		setPopoverAnchor( node ?? undefined );
 	}, [] );
 
 	useEffect( () => {

--- a/packages/components/src/border-box-control/border-box-control-split-controls/component.tsx
+++ b/packages/components/src/border-box-control/border-box-control-split-controls/component.tsx
@@ -2,7 +2,7 @@
  * WordPress dependencies
  */
 import { __ } from '@wordpress/i18n';
-import { useRef } from '@wordpress/element';
+import { useCallback, useState, useEffect } from '@wordpress/element';
 import { useMergeRefs } from '@wordpress/compose';
 
 /**
@@ -14,7 +14,7 @@ import { Grid } from '../../grid';
 import { contextConnect, WordPressComponentProps } from '../../ui/context';
 import { useBorderBoxControlSplitControls } from './hook';
 
-import type { SplitControlsProps } from '../types';
+import type { SplitControlsProps, PopoverPartialProps } from '../types';
 
 const BorderBoxControlSplitControls = (
 	props: WordPressComponentProps< SplitControlsProps, 'div' >,
@@ -36,16 +36,25 @@ const BorderBoxControlSplitControls = (
 		__next36pxDefaultSize,
 		...otherProps
 	} = useBorderBoxControlSplitControls( props );
-	const containerRef = useRef();
-	const mergedRef = useMergeRefs( [ containerRef, forwardedRef ] );
-	const popoverProps = popoverPlacement
-		? {
+	const [ popoverProps, setPopoverProps ] = useState< PopoverPartialProps >();
+	const [ popoverAnchor, setPopoverAnchor ] = useState< Element >();
+
+	const containerRef = useCallback( ( node ) => {
+		setPopoverAnchor( node );
+	}, [] );
+
+	useEffect( () => {
+		if ( popoverPlacement ) {
+			setPopoverProps( {
 				placement: popoverPlacement,
 				offset: popoverOffset,
-				anchorRef: containerRef,
+				anchor: popoverAnchor,
 				__unstableShift: true,
-		  }
-		: undefined;
+			} );
+		} else {
+			setPopoverProps( undefined );
+		}
+	}, [ popoverPlacement, popoverOffset, popoverAnchor ] );
 
 	const sharedBorderControlProps = {
 		colors,
@@ -57,6 +66,8 @@ const BorderBoxControlSplitControls = (
 		__experimentalIsRenderedInSidebar,
 		__next36pxDefaultSize,
 	};
+
+	const mergedRef = useMergeRefs( [ containerRef, forwardedRef ] );
 
 	return (
 		<Grid { ...otherProps } ref={ mergedRef } gap={ 4 }>

--- a/packages/components/src/border-box-control/border-box-control/component.tsx
+++ b/packages/components/src/border-box-control/border-box-control/component.tsx
@@ -67,7 +67,7 @@ const BorderBoxControl = (
 	const [ popoverAnchor, setPopoverAnchor ] = useState< Element >();
 
 	const containerRef = useCallback( ( node ) => {
-		setPopoverAnchor( node );
+		setPopoverAnchor( node ?? undefined );
 	}, [] );
 
 	useEffect( () => {

--- a/packages/components/src/border-box-control/border-box-control/component.tsx
+++ b/packages/components/src/border-box-control/border-box-control/component.tsx
@@ -2,7 +2,7 @@
  * WordPress dependencies
  */
 import { __ } from '@wordpress/i18n';
-import { useRef } from '@wordpress/element';
+import { useCallback, useState, useEffect } from '@wordpress/element';
 import { useMergeRefs } from '@wordpress/compose';
 
 /**
@@ -18,7 +18,7 @@ import { VisuallyHidden } from '../../visually-hidden';
 import { contextConnect, WordPressComponentProps } from '../../ui/context';
 import { useBorderBoxControl } from './hook';
 
-import type { BorderBoxControlProps } from '../types';
+import type { BorderBoxControlProps, PopoverPartialProps } from '../types';
 import type { LabelProps } from '../../border-control/types';
 
 const BorderLabel = ( props: LabelProps ) => {
@@ -62,16 +62,28 @@ const BorderBoxControl = (
 		__next36pxDefaultSize = false,
 		...otherProps
 	} = useBorderBoxControl( props );
-	const containerRef = useRef();
-	const mergedRef = useMergeRefs( [ containerRef, forwardedRef ] );
-	const popoverProps = popoverPlacement
-		? {
+
+	const [ popoverProps, setPopoverProps ] = useState< PopoverPartialProps >();
+	const [ popoverAnchor, setPopoverAnchor ] = useState< Element >();
+
+	const containerRef = useCallback( ( node ) => {
+		setPopoverAnchor( node );
+	}, [] );
+
+	useEffect( () => {
+		if ( popoverPlacement ) {
+			setPopoverProps( {
 				placement: popoverPlacement,
 				offset: popoverOffset,
-				anchorRef: containerRef,
+				anchor: popoverAnchor,
 				__unstableShift: true,
-		  }
-		: undefined;
+			} );
+		} else {
+			setPopoverProps( undefined );
+		}
+	}, [ popoverPlacement, popoverOffset, popoverAnchor ] );
+
+	const mergedRef = useMergeRefs( [ containerRef, forwardedRef ] );
 
 	return (
 		<View className={ className } { ...otherProps } ref={ mergedRef }>

--- a/packages/components/src/border-box-control/stories/index.js
+++ b/packages/components/src/border-box-control/stories/index.js
@@ -85,6 +85,7 @@ Default.args = {
 		width: '1px',
 	},
 	__next36pxDefaultSize: false,
+	popoverPlacement: 'right-start',
 };
 
 const WrapperView = styled.div`

--- a/packages/components/src/border-box-control/types.ts
+++ b/packages/components/src/border-box-control/types.ts
@@ -1,4 +1,9 @@
 /**
+ * External dependencies
+ */
+import type { Placement, ReferenceType } from '@floating-ui/react-dom';
+
+/**
  * Internal dependencies
  */
 import type { Border, ColorProps, LabelProps } from '../border-control/types';
@@ -13,6 +18,15 @@ export type Borders = {
 export type AnyBorder = Border | Borders | undefined;
 export type BorderProp = keyof Border;
 export type BorderSide = keyof Borders;
+
+// TODO: replace with Popover actual props once the component
+// gets converted to TypeScript
+export type PopoverPartialProps = {
+	placement?: Placement;
+	offset?: number;
+	anchor?: ReferenceType;
+	__unstableShift?: boolean;
+};
 
 export type BorderBoxControlProps = ColorProps &
 	LabelProps & {
@@ -29,7 +43,7 @@ export type BorderBoxControlProps = ColorProps &
 		/**
 		 * The position of the color popovers compared to the control wrapper.
 		 */
-		popoverPlacement?: string;
+		popoverPlacement?: Placement;
 		/**
 		 * The space between the popover and the control wrapper.
 		 */
@@ -103,7 +117,7 @@ export type SplitControlsProps = ColorProps & {
 	/**
 	 * The position of the color popovers compared to the control wrapper.
 	 */
-	popoverPlacement?: string;
+	popoverPlacement?: Placement;
 	/**
 	 * The space between the popover and the control wrapper.
 	 */


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Refactor the way the `BorderBoxControl` component passes an anchor to Popover, using the new `anchor` prop

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

See #43691 for more context

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

- Swap `anchorRef` with `anchor`
- Use internal state and a callback ref to make sure that the component re-renders when the anchor changes (including updating after the initial render, when the anchor's ref is still unset)

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->

In Storybook:

Open the `BorderBoxControl` component and:

- make sure that the popover appears as expected when clicking on the "circle" icon button:
- play around with the `popoverPlacement` prop and make sure that the popover's position updates as expected when changing that prop
  - When a `popoverPlacement` is set, the popover uses _the control group_ as its anchor
  - When a `popoverPlacement` is not set, the popover uses the icon button as its anchor
- click the "link" icon in order to show split controls for each border size, and make sure that:
  - When a `popoverPlacement` is set, the popover uses _the control group_ as its anchor
  - When a `popoverPlacement` is not set, the popover uses each individual icon button as its anchor



In the editor:

- add an image block and select it
- in the sidebar, play with the `BorderBoxControl` component
- make sure that the component behaves like on `trunk`


https://user-images.githubusercontent.com/1083581/187982073-bb83dc6e-94c4-4d96-b518-7880f80da596.mp4



