### PR TITLE
NumberControl: Add TypeScript prop types

### DIFF
--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -20,6 +20,7 @@
 
 -   Remove unused `normalizeArrowKey` utility function ([#43640](https://github.com/WordPress/gutenberg/pull/43640/)).
 -   `ToggleGroupControl`: Rename `__experimentalIsIconGroup` prop to `__experimentalIsBorderless` ([#43771](https://github.com/WordPress/gutenberg/pull/43771/)).
+-   `NumberControl`: Add TypeScript types ([#43791](https://github.com/WordPress/gutenberg/pull/43791/)).
 -   Refactor `FocalPointPicker` to function component ([#39168](https://github.com/WordPress/gutenberg/pull/39168)).
 -   `Guide`: use `code` instead of `keyCode` for keyboard events ([#43604](https://github.com/WordPress/gutenberg/pull/43604/)).
 -   `ToggleControl`: Convert to TypeScript and streamline CSS ([#43717](https://github.com/WordPress/gutenberg/pull/43717)). 

--- a/packages/components/src/color-picker/input-with-slider.tsx
+++ b/packages/components/src/color-picker/input-with-slider.tsx
@@ -33,6 +33,7 @@ export const InputWithSlider = ( {
 				label={ label }
 				hideLabelFromVision
 				value={ value }
+				// @ts-expect-error TODO: Resolve discrepancy in NumberControl
 				onChange={ onChange }
 				prefix={
 					<Spacer

--- a/packages/components/src/input-control/types.ts
+++ b/packages/components/src/input-control/types.ts
@@ -165,6 +165,9 @@ export interface InputBaseProps extends BaseProps, FlexProps {
 	 * @default false
 	 */
 	disabled?: boolean;
+	/**
+	 * The class name to be added to the wrapper element.
+	 */
 	className?: string;
 	id?: string;
 	/**

--- a/packages/components/src/number-control/index.tsx
+++ b/packages/components/src/number-control/index.tsx
@@ -91,18 +91,18 @@ function UnforwardedNumberControl(
 				}
 
 				if ( type === inputControlActionTypes.PRESS_UP ) {
-					// @ts-expect-error TODO: Investigate if this is wrong
+					// @ts-expect-error TODO: isValueEmpty() needs to be typed properly
 					nextValue = add( nextValue, incrementalValue );
 				}
 
 				if ( type === inputControlActionTypes.PRESS_DOWN ) {
-					// @ts-expect-error TODO: Investigate if this is wrong
+					// @ts-expect-error TODO: isValueEmpty() needs to be typed properly
 					nextValue = subtract( nextValue, incrementalValue );
 				}
 
-				// @ts-expect-error TODO: Investigate if this is wrong
+				// @ts-expect-error TODO: Resolve discrepancy between `value` types in InputControl based components
 				nextState.value = constrainValue(
-					// @ts-expect-error TODO: Investigate if this is wrong
+					// @ts-expect-error TODO: isValueEmpty() needs to be typed properly
 					nextValue,
 					enableShift ? incrementalValue : undefined
 				);
@@ -112,9 +112,9 @@ function UnforwardedNumberControl(
 			 * Handles drag to update events
 			 */
 			if ( type === inputControlActionTypes.DRAG && isDragEnabled ) {
-				// @ts-expect-error TODO: Investigate
+				// @ts-expect-error TODO: See if reducer actions can be typed better
 				const [ x, y ] = payload.delta;
-				// @ts-expect-error TODO: Investigate
+				// @ts-expect-error TODO: See if reducer actions can be typed better
 				const enableShift = payload.shiftKey && isShiftStepEnabled;
 				const modifier = enableShift
 					? ensureNumber( shiftStep ) * baseStep
@@ -149,9 +149,9 @@ function UnforwardedNumberControl(
 					delta = Math.ceil( Math.abs( delta ) ) * Math.sign( delta );
 					const distance = delta * modifier * directionModifier;
 
-					// @ts-expect-error TODO: Investigate if this is wrong
+					// @ts-expect-error TODO: Resolve discrepancy between `value` types in InputControl based components
 					nextState.value = constrainValue(
-						// @ts-expect-error TODO: Investigate if this is wrong
+						// @ts-expect-error TODO: isValueEmpty() needs to be typed properly
 						add( currentValue, distance ),
 						enableShift ? modifier : undefined
 					);
@@ -168,10 +168,10 @@ function UnforwardedNumberControl(
 				const applyEmptyValue =
 					required === false && currentValue === '';
 
-				// @ts-expect-error TODO: Investigate if this is wrong
+				// @ts-expect-error TODO: Resolve discrepancy between `value` types in InputControl based components
 				nextState.value = applyEmptyValue
 					? currentValue
-					: // @ts-expect-error TODO: Investigate if this is wrong
+					: // @ts-expect-error TODO: isValueEmpty() needs to be typed properly
 					  constrainValue( currentValue );
 			}
 
@@ -194,7 +194,7 @@ function UnforwardedNumberControl(
 			required={ required }
 			step={ step }
 			type={ typeProp }
-			// @ts-expect-error TODO: Resolve discrepancy
+			// @ts-expect-error TODO: Resolve discrepancy between `value` types in InputControl based components
 			value={ valueProp }
 			__unstableStateReducer={ ( state, action ) => {
 				const baseState = numberControlStateReducer( state, action );

--- a/packages/components/src/number-control/index.tsx
+++ b/packages/components/src/number-control/index.tsx
@@ -16,7 +16,7 @@ import { isRTL } from '@wordpress/i18n';
 import { Input } from './styles/number-control-styles';
 import * as inputControlActionTypes from '../input-control/reducer/actions';
 import { add, subtract, roundClamp } from '../utils/math';
-import { isValueEmpty } from '../utils/values';
+import { ensureNumber, isValueEmpty } from '../utils/values';
 import type { WordPressComponentProps } from '../ui/context/wordpress-component';
 import type { NumberControlProps } from './types';
 import type { InputState } from '../input-control/reducer/state';
@@ -42,8 +42,7 @@ function UnforwardedNumberControl(
 	ref: ForwardedRef< any >
 ) {
 	const isStepAny = step === 'any';
-	// @ts-expect-error step should be a number but could be string
-	const baseStep = isStepAny ? 1 : parseFloat( step );
+	const baseStep = isStepAny ? 1 : ensureNumber( step );
 	const baseValue = roundClamp( 0, min, max, baseStep );
 	const constrainValue = ( value: number, stepOverride?: number ) => {
 		// When step is "any" clamp the value, otherwise round and clamp it.
@@ -85,8 +84,7 @@ function UnforwardedNumberControl(
 			const enableShift = event.shiftKey && isShiftStepEnabled;
 
 			const incrementalValue = enableShift
-				? // @ts-expect-error shiftStep should be a number but could be string
-				  parseFloat( shiftStep ) * baseStep
+				? ensureNumber( shiftStep ) * baseStep
 				: baseStep;
 			let nextValue = isValueEmpty( currentValue )
 				? baseValue
@@ -123,8 +121,7 @@ function UnforwardedNumberControl(
 			// @ts-expect-error TODO: Investigate
 			const enableShift = payload.shiftKey && isShiftStepEnabled;
 			const modifier = enableShift
-				? // @ts-expect-error shiftStep should be a number but could be string
-				  parseFloat( shiftStep ) * baseStep
+				? ensureNumber( shiftStep ) * baseStep
 				: baseStep;
 
 			let directionModifier;

--- a/packages/components/src/number-control/index.tsx
+++ b/packages/components/src/number-control/index.tsx
@@ -1,8 +1,8 @@
-// @ts-nocheck
 /**
  * External dependencies
  */
 import classNames from 'classnames';
+import type { ForwardedRef } from 'react';
 
 /**
  * WordPress dependencies
@@ -17,8 +17,11 @@ import { Input } from './styles/number-control-styles';
 import * as inputControlActionTypes from '../input-control/reducer/actions';
 import { add, subtract, roundClamp } from '../utils/math';
 import { isValueEmpty } from '../utils/values';
+import type { WordPressComponentProps } from '../ui/context/wordpress-component';
+import type { NumberControlProps } from './types';
+import type { InputState } from '../input-control/reducer/state';
 
-export function NumberControl(
+function UnforwardedNumberControl(
 	{
 		__unstableStateReducer: stateReducerProp,
 		className,
@@ -35,20 +38,21 @@ export function NumberControl(
 		type: typeProp = 'number',
 		value: valueProp,
 		...props
-	},
-	ref
+	}: WordPressComponentProps< NumberControlProps, 'input', false >,
+	ref: ForwardedRef< any >
 ) {
 	const isStepAny = step === 'any';
+	// @ts-expect-error step should be a number but could be string
 	const baseStep = isStepAny ? 1 : parseFloat( step );
 	const baseValue = roundClamp( 0, min, max, baseStep );
-	const constrainValue = ( value, stepOverride ) => {
+	const constrainValue = ( value: number, stepOverride?: number | null ) => {
 		// When step is "any" clamp the value, otherwise round and clamp it.
 		return isStepAny
 			? Math.min( max, Math.max( min, value ) )
 			: roundClamp( value, min, max, stepOverride ?? baseStep );
 	};
 
-	const autoComplete = typeProp === 'number' ? 'off' : null;
+	const autoComplete = typeProp === 'number' ? 'off' : undefined;
 	const classes = classNames( 'components-number-control', className );
 
 	/**
@@ -56,11 +60,14 @@ export function NumberControl(
 	 * This allows us to tap into actions to transform the (next) state for
 	 * InputControl.
 	 *
-	 * @param {Object} state  State from InputControl
-	 * @param {Object} action Action triggering state change
-	 * @return {Object} The updated state to apply to InputControl
+	 * @return The updated state to apply to InputControl
 	 */
-	const numberControlStateReducer = ( state, action ) => {
+	const numberControlStateReducer = (
+		/** State from InputControl. */
+		state: InputState,
+		/** Action triggering state change. */
+		action: inputControlActionTypes.InputAction
+	) => {
 		const nextState = { ...state };
 
 		const { type, payload } = action;
@@ -74,10 +81,12 @@ export function NumberControl(
 			type === inputControlActionTypes.PRESS_UP ||
 			type === inputControlActionTypes.PRESS_DOWN
 		) {
+			// @ts-expect-error TODO: Investigate if this is wrong
 			const enableShift = event.shiftKey && isShiftStepEnabled;
 
 			const incrementalValue = enableShift
-				? parseFloat( shiftStep ) * baseStep
+				? // @ts-expect-error shiftStep should be a number but could be string
+				  parseFloat( shiftStep ) * baseStep
 				: baseStep;
 			let nextValue = isValueEmpty( currentValue )
 				? baseValue
@@ -88,14 +97,18 @@ export function NumberControl(
 			}
 
 			if ( type === inputControlActionTypes.PRESS_UP ) {
+				// @ts-expect-error TODO: Investigate if this is wrong
 				nextValue = add( nextValue, incrementalValue );
 			}
 
 			if ( type === inputControlActionTypes.PRESS_DOWN ) {
+				// @ts-expect-error TODO: Investigate if this is wrong
 				nextValue = subtract( nextValue, incrementalValue );
 			}
 
+			// @ts-expect-error TODO: Investigate if this is wrong
 			nextState.value = constrainValue(
+				// @ts-expect-error TODO: Investigate if this is wrong
 				nextValue,
 				enableShift ? incrementalValue : null
 			);
@@ -105,10 +118,13 @@ export function NumberControl(
 		 * Handles drag to update events
 		 */
 		if ( type === inputControlActionTypes.DRAG && isDragEnabled ) {
+			// @ts-expect-error TODO: Investigate
 			const [ x, y ] = payload.delta;
+			// @ts-expect-error TODO: Investigate
 			const enableShift = payload.shiftKey && isShiftStepEnabled;
 			const modifier = enableShift
-				? parseFloat( shiftStep ) * baseStep
+				? // @ts-expect-error shiftStep should be a number but could be string
+				  parseFloat( shiftStep ) * baseStep
 				: baseStep;
 
 			let directionModifier;
@@ -140,7 +156,9 @@ export function NumberControl(
 				delta = Math.ceil( Math.abs( delta ) ) * Math.sign( delta );
 				const distance = delta * modifier * directionModifier;
 
+				// @ts-expect-error TODO: Investigate if this is wrong
 				nextState.value = constrainValue(
+					// @ts-expect-error TODO: Investigate if this is wrong
 					add( currentValue, distance ),
 					enableShift ? modifier : null
 				);
@@ -156,9 +174,11 @@ export function NumberControl(
 		) {
 			const applyEmptyValue = required === false && currentValue === '';
 
+			// @ts-expect-error TODO: Investigate if this is wrong
 			nextState.value = applyEmptyValue
 				? currentValue
-				: constrainValue( currentValue );
+				: // @ts-expect-error TODO: Investigate if this is wrong
+				  constrainValue( currentValue );
 		}
 
 		return nextState;
@@ -180,6 +200,7 @@ export function NumberControl(
 			required={ required }
 			step={ step }
 			type={ typeProp }
+			// @ts-expect-error TODO: Resolve discrepancy
 			value={ valueProp }
 			__unstableStateReducer={ ( state, action ) => {
 				const baseState = numberControlStateReducer( state, action );
@@ -189,4 +210,6 @@ export function NumberControl(
 	);
 }
 
-export default forwardRef( NumberControl );
+export const NumberControl = forwardRef( UnforwardedNumberControl );
+
+export default NumberControl;

--- a/packages/components/src/number-control/index.tsx
+++ b/packages/components/src/number-control/index.tsx
@@ -75,8 +75,9 @@ function UnforwardedNumberControl(
 				type === inputControlActionTypes.PRESS_UP ||
 				type === inputControlActionTypes.PRESS_DOWN
 			) {
-				// @ts-expect-error TODO: Investigate if this is wrong
-				const enableShift = event.shiftKey && isShiftStepEnabled;
+				const enableShift =
+					( event as KeyboardEvent | undefined )?.shiftKey &&
+					isShiftStepEnabled;
 
 				const incrementalValue = enableShift
 					? ensureNumber( shiftStep ) * baseStep

--- a/packages/components/src/number-control/index.tsx
+++ b/packages/components/src/number-control/index.tsx
@@ -19,7 +19,6 @@ import { add, subtract, roundClamp } from '../utils/math';
 import { ensureNumber, isValueEmpty } from '../utils/values';
 import type { WordPressComponentProps } from '../ui/context/wordpress-component';
 import type { NumberControlProps } from './types';
-import type { InputState } from '../input-control/reducer/state';
 
 function UnforwardedNumberControl(
 	{
@@ -61,125 +60,122 @@ function UnforwardedNumberControl(
 	 *
 	 * @return The updated state to apply to InputControl
 	 */
-	const numberControlStateReducer = (
-		/** State from InputControl. */
-		state: InputState,
-		/** Action triggering state change. */
-		action: inputControlActionTypes.InputAction
-	) => {
-		const nextState = { ...state };
+	const numberControlStateReducer: NumberControlProps[ '__unstableStateReducer' ] =
+		( state, action ) => {
+			const nextState = { ...state };
 
-		const { type, payload } = action;
-		const event = payload?.event;
-		const currentValue = nextState.value;
+			const { type, payload } = action;
+			const event = payload.event;
+			const currentValue = nextState.value;
 
-		/**
-		 * Handles custom UP and DOWN Keyboard events
-		 */
-		if (
-			type === inputControlActionTypes.PRESS_UP ||
-			type === inputControlActionTypes.PRESS_DOWN
-		) {
-			// @ts-expect-error TODO: Investigate if this is wrong
-			const enableShift = event.shiftKey && isShiftStepEnabled;
-
-			const incrementalValue = enableShift
-				? ensureNumber( shiftStep ) * baseStep
-				: baseStep;
-			let nextValue = isValueEmpty( currentValue )
-				? baseValue
-				: currentValue;
-
-			if ( event?.preventDefault ) {
-				event.preventDefault();
-			}
-
-			if ( type === inputControlActionTypes.PRESS_UP ) {
+			/**
+			 * Handles custom UP and DOWN Keyboard events
+			 */
+			if (
+				type === inputControlActionTypes.PRESS_UP ||
+				type === inputControlActionTypes.PRESS_DOWN
+			) {
 				// @ts-expect-error TODO: Investigate if this is wrong
-				nextValue = add( nextValue, incrementalValue );
-			}
+				const enableShift = event.shiftKey && isShiftStepEnabled;
 
-			if ( type === inputControlActionTypes.PRESS_DOWN ) {
-				// @ts-expect-error TODO: Investigate if this is wrong
-				nextValue = subtract( nextValue, incrementalValue );
-			}
+				const incrementalValue = enableShift
+					? ensureNumber( shiftStep ) * baseStep
+					: baseStep;
+				let nextValue = isValueEmpty( currentValue )
+					? baseValue
+					: currentValue;
 
-			// @ts-expect-error TODO: Investigate if this is wrong
-			nextState.value = constrainValue(
-				// @ts-expect-error TODO: Investigate if this is wrong
-				nextValue,
-				enableShift ? incrementalValue : undefined
-			);
-		}
+				if ( event?.preventDefault ) {
+					event.preventDefault();
+				}
 
-		/**
-		 * Handles drag to update events
-		 */
-		if ( type === inputControlActionTypes.DRAG && isDragEnabled ) {
-			// @ts-expect-error TODO: Investigate
-			const [ x, y ] = payload.delta;
-			// @ts-expect-error TODO: Investigate
-			const enableShift = payload.shiftKey && isShiftStepEnabled;
-			const modifier = enableShift
-				? ensureNumber( shiftStep ) * baseStep
-				: baseStep;
+				if ( type === inputControlActionTypes.PRESS_UP ) {
+					// @ts-expect-error TODO: Investigate if this is wrong
+					nextValue = add( nextValue, incrementalValue );
+				}
 
-			let directionModifier;
-			let delta;
-
-			switch ( dragDirection ) {
-				case 'n':
-					delta = y;
-					directionModifier = -1;
-					break;
-
-				case 'e':
-					delta = x;
-					directionModifier = isRTL() ? -1 : 1;
-					break;
-
-				case 's':
-					delta = y;
-					directionModifier = 1;
-					break;
-
-				case 'w':
-					delta = x;
-					directionModifier = isRTL() ? 1 : -1;
-					break;
-			}
-
-			if ( delta !== 0 ) {
-				delta = Math.ceil( Math.abs( delta ) ) * Math.sign( delta );
-				const distance = delta * modifier * directionModifier;
+				if ( type === inputControlActionTypes.PRESS_DOWN ) {
+					// @ts-expect-error TODO: Investigate if this is wrong
+					nextValue = subtract( nextValue, incrementalValue );
+				}
 
 				// @ts-expect-error TODO: Investigate if this is wrong
 				nextState.value = constrainValue(
 					// @ts-expect-error TODO: Investigate if this is wrong
-					add( currentValue, distance ),
-					enableShift ? modifier : undefined
+					nextValue,
+					enableShift ? incrementalValue : undefined
 				);
 			}
-		}
 
-		/**
-		 * Handles commit (ENTER key press or blur)
-		 */
-		if (
-			type === inputControlActionTypes.PRESS_ENTER ||
-			type === inputControlActionTypes.COMMIT
-		) {
-			const applyEmptyValue = required === false && currentValue === '';
+			/**
+			 * Handles drag to update events
+			 */
+			if ( type === inputControlActionTypes.DRAG && isDragEnabled ) {
+				// @ts-expect-error TODO: Investigate
+				const [ x, y ] = payload.delta;
+				// @ts-expect-error TODO: Investigate
+				const enableShift = payload.shiftKey && isShiftStepEnabled;
+				const modifier = enableShift
+					? ensureNumber( shiftStep ) * baseStep
+					: baseStep;
 
-			// @ts-expect-error TODO: Investigate if this is wrong
-			nextState.value = applyEmptyValue
-				? currentValue
-				: // @ts-expect-error TODO: Investigate if this is wrong
-				  constrainValue( currentValue );
-		}
+				let directionModifier;
+				let delta;
 
-		return nextState;
-	};
+				switch ( dragDirection ) {
+					case 'n':
+						delta = y;
+						directionModifier = -1;
+						break;
+
+					case 'e':
+						delta = x;
+						directionModifier = isRTL() ? -1 : 1;
+						break;
+
+					case 's':
+						delta = y;
+						directionModifier = 1;
+						break;
+
+					case 'w':
+						delta = x;
+						directionModifier = isRTL() ? 1 : -1;
+						break;
+				}
+
+				if ( delta !== 0 ) {
+					delta = Math.ceil( Math.abs( delta ) ) * Math.sign( delta );
+					const distance = delta * modifier * directionModifier;
+
+					// @ts-expect-error TODO: Investigate if this is wrong
+					nextState.value = constrainValue(
+						// @ts-expect-error TODO: Investigate if this is wrong
+						add( currentValue, distance ),
+						enableShift ? modifier : undefined
+					);
+				}
+			}
+
+			/**
+			 * Handles commit (ENTER key press or blur)
+			 */
+			if (
+				type === inputControlActionTypes.PRESS_ENTER ||
+				type === inputControlActionTypes.COMMIT
+			) {
+				const applyEmptyValue =
+					required === false && currentValue === '';
+
+				// @ts-expect-error TODO: Investigate if this is wrong
+				nextState.value = applyEmptyValue
+					? currentValue
+					: // @ts-expect-error TODO: Investigate if this is wrong
+					  constrainValue( currentValue );
+			}
+
+			return nextState;
+		};
 
 	return (
 		<Input

--- a/packages/components/src/number-control/index.tsx
+++ b/packages/components/src/number-control/index.tsx
@@ -45,7 +45,7 @@ function UnforwardedNumberControl(
 	// @ts-expect-error step should be a number but could be string
 	const baseStep = isStepAny ? 1 : parseFloat( step );
 	const baseValue = roundClamp( 0, min, max, baseStep );
-	const constrainValue = ( value: number, stepOverride?: number | null ) => {
+	const constrainValue = ( value: number, stepOverride?: number ) => {
 		// When step is "any" clamp the value, otherwise round and clamp it.
 		return isStepAny
 			? Math.min( max, Math.max( min, value ) )
@@ -110,7 +110,7 @@ function UnforwardedNumberControl(
 			nextState.value = constrainValue(
 				// @ts-expect-error TODO: Investigate if this is wrong
 				nextValue,
-				enableShift ? incrementalValue : null
+				enableShift ? incrementalValue : undefined
 			);
 		}
 
@@ -160,7 +160,7 @@ function UnforwardedNumberControl(
 				nextState.value = constrainValue(
 					// @ts-expect-error TODO: Investigate if this is wrong
 					add( currentValue, distance ),
-					enableShift ? modifier : null
+					enableShift ? modifier : undefined
 				);
 			}
 		}

--- a/packages/components/src/number-control/stories/index.js
+++ b/packages/components/src/number-control/stories/index.js
@@ -14,6 +14,7 @@ export default {
 	argTypes: {
 		onChange: { action: 'onChange' },
 		prefix: { control: { type: 'text' } },
+		step: { control: { type: 'text' } },
 		suffix: { control: { type: 'text' } },
 		type: { control: { type: 'text' } },
 		value: { control: null },

--- a/packages/components/src/number-control/stories/index.js
+++ b/packages/components/src/number-control/stories/index.js
@@ -12,13 +12,10 @@ export default {
 	title: 'Components (Experimental)/NumberControl',
 	component: NumberControl,
 	argTypes: {
-		size: {
-			control: {
-				type: 'select',
-				options: [ 'default', 'small', '__unstable-large' ],
-			},
-		},
 		onChange: { action: 'onChange' },
+		prefix: { control: { type: 'text' } },
+		suffix: { control: { type: 'text' } },
+		type: { control: { type: 'text' } },
 	},
 };
 
@@ -44,16 +41,5 @@ function Template( { onChange, ...props } ) {
 
 export const Default = Template.bind( {} );
 Default.args = {
-	disabled: false,
-	hideLabelFromVision: false,
-	isPressEnterToChange: false,
-	isShiftStepEnabled: true,
-	label: 'Number',
-	min: 0,
-	max: 100,
-	placeholder: '0',
-	required: false,
-	shiftStep: 10,
-	size: 'default',
-	step: '1',
+	label: 'Value',
 };

--- a/packages/components/src/number-control/stories/index.js
+++ b/packages/components/src/number-control/stories/index.js
@@ -16,6 +16,7 @@ export default {
 		prefix: { control: { type: 'text' } },
 		suffix: { control: { type: 'text' } },
 		type: { control: { type: 'text' } },
+		value: { control: null },
 	},
 };
 

--- a/packages/components/src/number-control/types.ts
+++ b/packages/components/src/number-control/types.ts
@@ -1,0 +1,80 @@
+/**
+ * External dependencies
+ */
+import type { HTMLInputTypeAttribute, InputHTMLAttributes } from 'react';
+
+/**
+ * Internal dependencies
+ */
+import type { InputControlProps } from '../input-control/types';
+
+export type NumberControlProps = Omit<
+	InputControlProps,
+	'isDragEnabled' | 'min' | 'max' | 'required' | 'type' | 'value'
+> & {
+	/**
+	 * If true, the default `input` HTML arrows will be hidden.
+	 *
+	 * @default false
+	 */
+	hideHTMLArrows?: boolean;
+	/**
+	 * If true, enables mouse drag gestures.
+	 *
+	 * @default true
+	 */
+	isDragEnabled?: boolean;
+	/**
+	 * If true, pressing `UP` or `DOWN` along with the `SHIFT` key will increment the
+	 * value by the `shiftStep` value.
+	 *
+	 * @default true
+	 */
+	isShiftStepEnabled?: boolean;
+	/**
+	 * The maximum `value` allowed.
+	 *
+	 * @default Infinity
+	 */
+	max?: number;
+	/**
+	 * The minimum `value` allowed.
+	 *
+	 * @default -Infinity
+	 */
+	min?: number;
+	/**
+	 * If `true` enforces a valid number within the control's min/max range.
+	 * If `false` allows an empty string as a valid value.
+	 *
+	 * @default false
+	 */
+	required?: boolean;
+	/**
+	 * Amount to increment by when the `SHIFT` key is held down. This shift value is
+	 * a multiplier to the `step` value. For example, if the `step` value is `5`,
+	 * and `shiftStep` is `10`, each jump would increment/decrement by `50`.
+	 *
+	 * @default 10
+	 */
+	shiftStep?: number;
+	/**
+	 * Amount by which the `value` is changed when incrementing/decrementing.
+	 * It is also a factor in validation as `value` must be a multiple of `step`
+	 * (offset by `min`, if specified) to be valid. Accepts the special string value `any`
+	 * that voids the validation constraint and causes stepping actions to increment/decrement by `1`.
+	 *
+	 * @default 1
+	 */
+	step?: InputHTMLAttributes< HTMLInputElement >[ 'step' ] | 'any';
+	/**
+	 * The `type` attribute of the `input` element.
+	 *
+	 * @default 'number'
+	 */
+	type?: HTMLInputTypeAttribute;
+	/**
+	 * The value of the input.
+	 */
+	value?: number | string;
+};

--- a/packages/components/src/number-control/types.ts
+++ b/packages/components/src/number-control/types.ts
@@ -10,7 +10,7 @@ import type { InputControlProps } from '../input-control/types';
 
 export type NumberControlProps = Omit<
 	InputControlProps,
-	'isDragEnabled' | 'min' | 'max' | 'required' | 'type' | 'value'
+	'isDragEnabled' | 'min' | 'max' | 'required' | 'step' | 'type' | 'value'
 > & {
 	/**
 	 * If true, the default `input` HTML arrows will be hidden.
@@ -66,7 +66,7 @@ export type NumberControlProps = Omit<
 	 *
 	 * @default 1
 	 */
-	step?: InputHTMLAttributes< HTMLInputElement >[ 'step' ] | 'any';
+	step?: InputHTMLAttributes< HTMLInputElement >[ 'step' ];
 	/**
 	 * The `type` attribute of the `input` element.
 	 *

--- a/packages/components/src/number-control/types.ts
+++ b/packages/components/src/number-control/types.ts
@@ -1,9 +1,4 @@
 /**
- * External dependencies
- */
-import type { HTMLInputTypeAttribute, InputHTMLAttributes } from 'react';
-
-/**
  * Internal dependencies
  */
 import type { InputControlProps } from '../input-control/types';
@@ -23,7 +18,7 @@ export type NumberControlProps = Omit<
 	 *
 	 * @default true
 	 */
-	isDragEnabled?: boolean;
+	isDragEnabled?: InputControlProps[ 'isDragEnabled' ];
 	/**
 	 * If true, pressing `UP` or `DOWN` along with the `SHIFT` key will increment the
 	 * value by the `shiftStep` value.
@@ -49,7 +44,7 @@ export type NumberControlProps = Omit<
 	 *
 	 * @default false
 	 */
-	required?: boolean;
+	required?: InputControlProps[ 'required' ];
 	/**
 	 * Amount to increment by when the `SHIFT` key is held down. This shift value is
 	 * a multiplier to the `step` value. For example, if the `step` value is `5`,
@@ -66,13 +61,13 @@ export type NumberControlProps = Omit<
 	 *
 	 * @default 1
 	 */
-	step?: InputHTMLAttributes< HTMLInputElement >[ 'step' ];
+	step?: InputControlProps[ 'step' ];
 	/**
 	 * The `type` attribute of the `input` element.
 	 *
 	 * @default 'number'
 	 */
-	type?: HTMLInputTypeAttribute;
+	type?: InputControlProps[ 'type' ];
 	/**
 	 * The value of the input.
 	 */

--- a/packages/components/src/range-control/index.tsx
+++ b/packages/components/src/range-control/index.tsx
@@ -138,7 +138,8 @@ function UnforwardedRangeControl< IconProps = unknown >(
 		onChange( nextValue );
 	};
 
-	const handleOnChange = ( next: string ) => {
+	const handleOnChange = ( next?: string ) => {
+		// @ts-expect-error TODO: Investigate if this is problematic
 		let nextValue = parseFloat( next );
 		setValue( nextValue );
 
@@ -304,6 +305,7 @@ function UnforwardedRangeControl< IconProps = unknown >(
 						onChange={ handleOnChange }
 						shiftStep={ shiftStep }
 						step={ step }
+						// @ts-expect-error TODO: Investigate if the `null` value is necessary
 						value={ inputSliderValue }
 					/>
 				) }

--- a/packages/components/src/range-control/index.tsx
+++ b/packages/components/src/range-control/index.tsx
@@ -139,7 +139,8 @@ function UnforwardedRangeControl< IconProps = unknown >(
 	};
 
 	const handleOnChange = ( next?: string ) => {
-		// @ts-expect-error TODO: Investigate if this is problematic
+		// @ts-expect-error TODO: Investigate if it's problematic for setValue() to
+		// potentially receive a NaN when next is undefined.
 		let nextValue = parseFloat( next );
 		setValue( nextValue );
 

--- a/packages/components/src/unit-control/index.tsx
+++ b/packages/components/src/unit-control/index.tsx
@@ -46,6 +46,7 @@ function UnforwardedUnitControl(
 	const {
 		__unstableStateReducer: stateReducerProp,
 		autoComplete = 'off',
+		// @ts-expect-error Ensure that children is omitted from restProps
 		children,
 		className,
 		disabled = false,

--- a/packages/components/src/unit-control/index.tsx
+++ b/packages/components/src/unit-control/index.tsx
@@ -259,7 +259,6 @@ function UnforwardedUnitControl(
 	return (
 		<Root className="components-unit-control-wrapper" style={ style }>
 			<ValueInput
-				aria-label={ label }
 				type={ isPressEnterToChange ? 'text' : 'number' }
 				{ ...props }
 				autoComplete={ autoComplete }

--- a/packages/components/src/unit-control/stories/index.tsx
+++ b/packages/components/src/unit-control/stories/index.tsx
@@ -18,24 +18,15 @@ const meta: ComponentMeta< typeof UnitControl > = {
 	component: UnitControl,
 	title: 'Components (Experimental)/UnitControl',
 	argTypes: {
-		__unstableInputWidth: {
-			control: { type: 'text' },
-		},
-		__unstableStateReducer: {
-			control: { type: null },
-		},
-		onChange: {
-			action: 'onChange',
-			control: { type: null },
-		},
-		onUnitChange: {
-			control: { type: null },
-		},
-		value: {
-			control: { type: null },
-		},
+		__unstableInputWidth: { control: { type: 'text' } },
+		__unstableStateReducer: { control: { type: null } },
+		onChange: { control: { type: null } },
+		onUnitChange: { control: { type: null } },
+		prefix: { control: { type: 'text' } },
+		value: { control: { type: null } },
 	},
 	parameters: {
+		actions: { argTypesRegex: '^on.*' },
 		controls: {
 			expanded: true,
 		},

--- a/packages/components/src/unit-control/types.ts
+++ b/packages/components/src/unit-control/types.ts
@@ -67,7 +67,7 @@ export type UnitSelectControlProps = Pick< InputControlProps, 'size' > & {
 };
 
 export type UnitControlProps = Omit< UnitSelectControlProps, 'unit' > &
-	NumberControlProps & {
+	Omit< NumberControlProps, 'hideHTMLArrows' | 'suffix' | 'type' > & {
 		/**
 		 * If `true`, the unit `<select>` is hidden.
 		 *

--- a/packages/components/src/unit-control/types.ts
+++ b/packages/components/src/unit-control/types.ts
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import type { FocusEventHandler, ReactNode, SyntheticEvent } from 'react';
+import type { FocusEventHandler, SyntheticEvent } from 'react';
 
 /**
  * Internal dependencies
@@ -68,10 +68,6 @@ export type UnitSelectControlProps = Pick< InputControlProps, 'size' > & {
 
 export type UnitControlProps = Omit< UnitSelectControlProps, 'unit' > &
 	NumberControlProps & {
-		/**
-		 * The children elements.
-		 */
-		children?: ReactNode;
 		/**
 		 * If `true`, the unit `<select>` is hidden.
 		 *

--- a/packages/components/src/unit-control/types.ts
+++ b/packages/components/src/unit-control/types.ts
@@ -1,22 +1,17 @@
 /**
  * External dependencies
  */
-import type {
-	CSSProperties,
-	FocusEventHandler,
-	ReactNode,
-	SyntheticEvent,
-} from 'react';
+import type { FocusEventHandler, ReactNode, SyntheticEvent } from 'react';
 
 /**
  * Internal dependencies
  */
-import type { StateReducer } from '../input-control/reducer/state';
 import type {
 	InputChangeCallback,
 	InputControlProps,
 	Size as InputSize,
 } from '../input-control/types';
+import type { NumberControlProps } from '../number-control/types';
 
 export type SelectSize = InputSize;
 
@@ -71,14 +66,8 @@ export type UnitSelectControlProps = Pick< InputControlProps, 'size' > & {
 	units?: WPUnitControlUnit[];
 };
 
-// TODO: when available, should (partially) extend `NumberControl` props.
 export type UnitControlProps = Omit< UnitSelectControlProps, 'unit' > &
-	Pick<
-		InputControlProps,
-		'hideLabelFromVision' | 'prefix' | '__next36pxDefaultSize'
-	> & {
-		__unstableStateReducer?: StateReducer;
-		__unstableInputWidth?: CSSProperties[ 'width' ];
+	NumberControlProps & {
 		/**
 		 * The children elements.
 		 */
@@ -90,23 +79,12 @@ export type UnitControlProps = Omit< UnitSelectControlProps, 'unit' > &
 		 */
 		disableUnits?: boolean;
 		/**
-		 * If `true`, the `ENTER` key press is required in order to trigger an `onChange`.
-		 * If enabled, a change is also triggered when tabbing away (`onBlur`).
-		 *
-		 * @default false
-		 */
-		isPressEnterToChange?: boolean;
-		/**
 		 * If `true`, and the selected unit provides a `default` value, this value is set
 		 * when changing units.
 		 *
 		 * @default false
 		 */
 		isResetValueOnUnitChange?: boolean;
-		/**
-		 * If this property is added, a label will be generated using label property as the content.
-		 */
-		label?: string;
 		/**
 		 * Callback when the `unit` changes.
 		 */
@@ -122,21 +100,6 @@ export type UnitControlProps = Omit< UnitSelectControlProps, 'unit' > &
 		 * For example, a `value` of "50%" will set the current unit to `%`.
 		 */
 		value?: string | number;
-		/**
-		 * If true, pressing `UP` or `DOWN` along with the `SHIFT` key will increment
-		 * the value by the `shiftStep` value.
-		 *
-		 * @default true
-		 */
-		isShiftStepEnabled?: boolean;
-		/**
-		 * Amount to increment by when the `SHIFT` key is held down. This shift value
-		 * is a multiplier to the `step` value. For example, if the `step` value is `5`,
-		 * and `shiftStep` is `10`, each jump would increment/decrement by `50`.
-		 *
-		 * @default 10
-		 */
-		shiftStep?: number;
 		/**
 		 * Callback when either the quantity or the unit inputs lose focus.
 		 */

--- a/packages/components/src/utils/values.js
+++ b/packages/components/src/utils/values.js
@@ -99,3 +99,47 @@ export function isValueNumeric( value, locale = window.navigator.language ) {
 			: value;
 	return ! isNaN( parseFloat( valueToCheck ) ) && isFinite( valueToCheck );
 }
+
+/**
+ * Converts a string to a number.
+ *
+ * @param {string} value
+ * @return {number} String as a number.
+ */
+export const stringToNumber = ( value ) => {
+	return parseFloat( value );
+};
+
+/**
+ * Converts a number to a string.
+ *
+ * @param {number} value
+ * @return {string} Number as a string.
+ */
+export const numberToString = ( value ) => {
+	return `${ value }`;
+};
+
+/**
+ * Regardless of the input being a string or a number, returns a number.
+ *
+ * Returns `undefined` in case the string is `undefined` or not a valid numeric value.
+ *
+ * @param {string | number} value
+ * @return {number} The parsed number.
+ */
+export const ensureNumber = ( value ) => {
+	return typeof value === 'string' ? stringToNumber( value ) : value;
+};
+
+/**
+ * Regardless of the input being a string or a number, returns a number.
+ *
+ * Returns `undefined` in case the string is `undefined` or not a valid numeric value.
+ *
+ * @param {string | number} value
+ * @return {string} The converted string, or `undefined` in case the input is `undefined` or `NaN`.
+ */
+export const ensureString = ( value ) => {
+	return typeof value === 'string' ? value : numberToString( value );
+};

--- a/packages/e2e-tests/specs/editor/various/font-size-picker.test.js
+++ b/packages/e2e-tests/specs/editor/various/font-size-picker.test.js
@@ -37,9 +37,7 @@ const toggleCustomInput = async ( showCustomInput ) => {
 };
 
 const clickCustomInput = async () => {
-	const customInput = await page.waitForXPath(
-		"//input[@aria-label='Custom']"
-	);
+	const customInput = await page.waitForXPath( "//input[@type='number']" );
 	return customInput.click();
 };
 


### PR DESCRIPTION
Part of #35744

## What?

Adds "provisional" prop types to NumberControl.

## Why?

In the past, we've had major complications with properly typing NumberControl due to the string/number ambiguity of the values both upstream and downstream. This is why NumberControl is untyped and `@ts-nocheck`ed at the moment.

However, this has started to bottleneck TypeScript migrations for other components that inherit NumberControl props. I think it would be useful to improve the situation a bit by actually defining prop types, even if there are some contradictions that need to be `@ts-ignore`d.

I hope this reads as a constructive baby step forward, rather than a messy pile of bandaids. The benefit is that we can clearly demarcate where the type contradictions are, instead of keeping a huge untyped blackhole in our component chain.

## How?

See inline code comments for minor runtime changes.

## Testing Instructions

`npm run storybook:dev` and see the Docs view for NumberControl and UnitControl.