### PR TITLE
Font size picker: add a fallback for the name property

### DIFF
--- a/packages/components/src/font-size-picker/test/utils.js
+++ b/packages/components/src/font-size-picker/test/utils.js
@@ -103,7 +103,6 @@ describe( 'getToggleGroupOptions', () => {
 			{
 				slug: '5',
 				size: '5',
-				name: '5',
 			},
 		];
 		expect(
@@ -143,7 +142,7 @@ describe( 'getToggleGroupOptions', () => {
 				key: '5',
 				value: '5',
 				label: 'XXL',
-				name: '5',
+				name: 'XXL',
 			},
 		] );
 	} );

--- a/packages/components/src/font-size-picker/utils.js
+++ b/packages/components/src/font-size-picker/utils.js
@@ -114,7 +114,7 @@ export function getToggleGroupOptions(
 			key: slug,
 			value: size,
 			label: labelAliases[ index ],
-			name,
+			name: name || labelAliases[ index ],
 		};
 	} );
 }


### PR DESCRIPTION
## What?
Using the label as a fallback for "name" in the font size toggle group control options.  Props to @jasmussen for spotting in https://github.com/WordPress/gutenberg/pull/43074#issuecomment-1232868793

## Why?
Before, if "name" was not defined the value was `undefined`. Who would have thought?!

It was only obvious on the fifth element since the name fields were inherited from the [default theme.json](https://github.com/WordPress/gutenberg/blob/93e29bbe5ff854b59f1aa1841b505281aaeabd7d/lib/compat/wordpress-6.1/theme.json#L357).

## How?
See "What". Also updated unit tests.

## Testing Instructions

Where there are five font sizes or fewer, the `<ToggleGroupControl />` displays with t-shirt sizes. Example JSON below.

Check that the "name" property is filled for each `<ToggleGroupControlOption />` (and, more importantly, the fifth font size XXL)

I wasn't sure where the `name` value manifested itself, so I was using React Developer Tools to inspect the component and check the props.


<details>

<summary>Example theme.json</summary>

```json
{
	"version": 2,
	"settings": {
		"appearanceTools": true,
		"typography": {
			"fontSizes": [
				{
					"fluid": {
						"min": "0.875rem",
						"max": "1rem"
					},
					"size": "1rem",
					"slug": "small"
				},
				{
					"fluid": {
						"min": "1rem",
						"max": "1.125rem"
					},
					"size": "1.125rem",
					"slug": "medium"
				},
				{
					"size": "1.75rem",
					"slug": "large",
					"fluid": false
				},
				{
					"size": "2.25rem",
					"slug": "x-large",
					"fluid": false
				},
				{
					"size": "10rem",
					"slug": "xx-large",
					"fluid": {
						"min": "4rem",
						"max": "12rem"
					}
				}
			]
		}
	}
}


```

</details>

### Before
<img width="1208" alt="Screen Shot 2022-09-02 at 8 01 43 am" src="https://user-images.githubusercontent.com/6458278/188022700-ffb2763b-4ea1-45a8-be35-0f9a20cac48b.png">

### After
<img width="1147" alt="Screen Shot 2022-09-02 at 8 00 41 am" src="https://user-images.githubusercontent.com/6458278/188022706-e29209dc-b437-48dd-8dc5-9b224096ca35.png">

