### PR TITLE
Makepot: Fix translations object handling

### DIFF
--- a/packages/babel-plugin-makepot/CHANGELOG.md
+++ b/packages/babel-plugin-makepot/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Bug Fix
+
+-   Makepot: Fix translations object handling ([#43797](https://github.com/WordPress/gutenberg/pull/43797)).
+
 ## 5.0.0 (2022-08-24)
 
 ### Breaking Change

--- a/packages/babel-plugin-makepot/index.js
+++ b/packages/babel-plugin-makepot/index.js
@@ -330,7 +330,7 @@ module.exports = () => {
 							for ( const context in strings[ file ] ) {
 								// Within the same file, sort translations by line.
 								const sortedTranslations = sortByReference(
-									strings[ file ][ context ]
+									Object.values( strings[ file ][ context ] )
 								);
 
 								forEach(


### PR DESCRIPTION
## What?
This fixes #43793.

## Why?
In https://github.com/WordPress/gutenberg/pull/43479 we broke how we handle translations, incorrectly asserting that they were an array, while they are an object. 

## How?
This PR fixes that by converting the object to an array before sorting it.

This will need a point release.

## Testing Instructions
* Go through the testing instructions of #43793, until `npm run build`.
* In that repo, open `node_modules/@wordpress/babel-plugin-makepot/index.js`
* Change this:

```
const sortedTranslations = sortByReference(
	strings[ file ][ context ]
);
```

to:

```
const sortedTranslations = sortByReference(
	Object.values( strings[ file ][ context ] )
);
```
* Now run `npm run build`
* Verify it builds correctly now:

![Screenshot 2022-09-02 at 10 05 53](https://user-images.githubusercontent.com/8436925/188078615-0d74ab7a-a656-45b1-994b-8c2efe58210e.png)
