### PR TITLE
Tooltip: refactor using Popover's new anchor prop

### DIFF
--- a/packages/components/src/tooltip/index.js
+++ b/packages/components/src/tooltip/index.js
@@ -9,7 +9,6 @@ import {
 	concatChildren,
 	useEffect,
 	useState,
-	useCallback,
 } from '@wordpress/element';
 import { useDebounce, useMergeRefs } from '@wordpress/compose';
 
@@ -131,11 +130,11 @@ function Tooltip( props ) {
 	// Create a reference to the Tooltip's child, to be passed to the Popover
 	// so that the Tooltip can be correctly positioned. Also, merge with the
 	// existing ref for the first child, so that its ref is preserved.
-	const childRef = useCallback( ( node ) => {
-		setPopoverAnchor( node ?? undefined );
-	}, [] );
 	const existingChildRef = Children.toArray( children )[ 0 ]?.ref;
-	const mergedChildRefs = useMergeRefs( [ childRef, existingChildRef ] );
+	const mergedChildRefs = useMergeRefs( [
+		setPopoverAnchor,
+		existingChildRef,
+	] );
 
 	const createMouseDown = ( event ) => {
 		// In firefox, the mouse down event is also fired when the select
@@ -258,7 +257,8 @@ function Tooltip( props ) {
 		: getRegularElement;
 
 	const popoverData = {
-		anchor: popoverAnchor,
+		// `anchor` should never be `null`
+		anchor: popoverAnchor ?? undefined,
 		isOver,
 		offset: 4,
 		position,

--- a/packages/components/src/tooltip/index.js
+++ b/packages/components/src/tooltip/index.js
@@ -9,7 +9,7 @@ import {
 	concatChildren,
 	useEffect,
 	useState,
-	useRef,
+	useCallback,
 } from '@wordpress/element';
 import { useDebounce, useMergeRefs } from '@wordpress/compose';
 
@@ -124,11 +124,16 @@ function Tooltip( props ) {
 	const [ isMouseDown, setIsMouseDown ] = useState( false );
 	const [ isOver, setIsOver ] = useState( false );
 	const delayedSetIsOver = useDebounce( setIsOver, delay );
+	// Using internal state (instead of a ref) for the popover anchor to make sure
+	// that the component re-renders when the anchor updates.
+	const [ popoverAnchor, setPopoverAnchor ] = useState();
 
 	// Create a reference to the Tooltip's child, to be passed to the Popover
 	// so that the Tooltip can be correctly positioned. Also, merge with the
 	// existing ref for the first child, so that its ref is preserved.
-	const childRef = useRef( null );
+	const childRef = useCallback( ( node ) => {
+		setPopoverAnchor( node ?? undefined );
+	}, [] );
 	const existingChildRef = Children.toArray( children )[ 0 ]?.ref;
 	const mergedChildRefs = useMergeRefs( [ childRef, existingChildRef ] );
 
@@ -253,7 +258,7 @@ function Tooltip( props ) {
 		: getRegularElement;
 
 	const popoverData = {
-		anchor: childRef.current,
+		anchor: popoverAnchor,
 		isOver,
 		offset: 4,
 		position,

--- a/packages/components/src/tooltip/index.js
+++ b/packages/components/src/tooltip/index.js
@@ -60,7 +60,7 @@ const getRegularElement = ( {
 };
 
 const addPopoverToGrandchildren = ( {
-	anchorRef,
+	anchor,
 	grandchildren,
 	isOver,
 	offset,
@@ -78,7 +78,7 @@ const addPopoverToGrandchildren = ( {
 				aria-hidden="true"
 				animate={ false }
 				offset={ offset }
-				anchorRef={ anchorRef }
+				anchor={ anchor }
 				__unstableShift
 			>
 				{ text }
@@ -253,7 +253,7 @@ function Tooltip( props ) {
 		: getRegularElement;
 
 	const popoverData = {
-		anchorRef: childRef,
+		anchor: childRef.current,
 		isOver,
 		offset: 4,
 		position,


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Refactor the way the `Tooltip` component passes an anchor to `Popover`, using the new `anchor` prop

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

See #43691 for more context

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

- Swap `anchorRef` with `anchor`
- Use internal state and a callback ref to make sure that the component re-renders when the anchor changes (including updating after the initial render, when the anchor's ref is still unset)

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->

In Storybook open `Tooltip` stories and make sure that stories work as expected.

Make sure that tooltips work as expected across the editor.

Make sure that Tooltip unit tests pass.