### PR TITLE
Navigation: add current-menu-item also for archive links

### DIFF
--- a/packages/block-library/src/navigation-link/index.php
+++ b/packages/block-library/src/navigation-link/index.php
@@ -150,7 +150,7 @@ function render_block_core_navigation_link( $attributes, $content, $block ) {
 
 	$css_classes = trim( implode( ' ', $classes ) );
 	$has_submenu = count( $block->inner_blocks ) > 0;
-	$is_active   = ! empty( $attributes['id'] ) && ( get_the_ID() === (int) $attributes['id'] );
+	$is_active   = ! empty( $attributes['id'] ) && ( get_queried_object_id() === (int) $attributes['id'] );
 
 	$wrapper_attributes = get_block_wrapper_attributes(
 		array(


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->
Makes sure that  the `current-menu-item` class is added to navigation links for archives, not only for single post items.
Closes https://github.com/WordPress/gutenberg/issues/43260
Closes #43843

Props @Andrew-Starr

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
The` current-menu-item ` class was missing from this type of link.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
The CSS class is added after a comparison between the `id` attribute and `get_the_ID`.
This pr changes `get_the_ID` to `get_queried_object_id()` to include archive pages.

## Testing Instructions
Make sure that the test install has categories and tags assigned.
1. Add a navigation block with navigation links to a single post, single page, a category archive and a tag archive.
2. On the front of the website, visit each navigation link and confirm that the list item has the `current_menu_item` class when you view that page.

## Screenshots or screencast <!-- if applicable -->
