### PR TITLE
Add block nesting governance schema updates and docs

### DIFF
--- a/docs/how-to-guides/themes/theme-json.md
+++ b/docs/how-to-guides/themes/theme-json.md
@@ -587,6 +587,46 @@ Note that the name of the variable is created by adding `--` in between each nes
 
 #### Settings examples
 
+- Enable a specifc colour for a nested block, from the color palette:
+
+```json
+{
+	"version": 2,
+	"settings": {
+		"color": {
+			"palette": [
+				{
+					"slug": "red",
+					"name": "Red",
+					"color": "#ce0808"
+				},
+				{
+					"slug": "light",
+					"name": "Light",
+					"color": "#f5f7f9"
+				}
+			]
+		},
+		"blocks": {
+			"core/quote": {
+				"core/heading": {
+					"color": {
+						"text": true,
+						"palette": [
+							{
+								"slug": "red",
+								"name": "Red",
+								"color": "#ce0808"
+							}
+						]
+					}
+				}
+			}
+		}
+	}
+}
+```
+
 - Enable custom colors only for the paragraph block:
 
 ```json

--- a/docs/reference-guides/theme-json-reference/theme-json-living.md
+++ b/docs/reference-guides/theme-json-reference/theme-json-living.md
@@ -139,10 +139,10 @@ Border styles.
 | radius | undefined |  |
 | style | string |  |
 | width | string |  |
-| top | undefined |  |
-| right | undefined |  |
-| bottom | undefined |  |
-| left | undefined |  |
+| top | object | color, style, width |
+| right | object | color, style, width |
+| bottom | object | color, style, width |
+| left | object | color, style, width |
 
 ---
 

--- a/schemas/json/theme.json
+++ b/schemas/json/theme.json
@@ -919,60 +919,76 @@
 							"type": "string"
 						},
 						"top": {
-							"color": {
-								"description": "Sets the `border-top-color` CSS property.",
-								"type": "string"
+							"type": "object",
+							"properties": {
+								"color": {
+									"description": "Sets the `border-top-color` CSS property.",
+									"type": "string"
+								},
+								"style": {
+									"description": "Sets the `border-top-style` CSS property.",
+									"type": "string"
+								},
+								"width": {
+									"description": "Sets the `border-top-width` CSS property.",
+									"type": "string"
+								}
 							},
-							"style": {
-								"description": "Sets the `border-top-style` CSS property.",
-								"type": "string"
-							},
-							"width": {
-								"description": "Sets the `border-top-width` CSS property.",
-								"type": "string"
-							}
+							"additionalProperties": false
 						},
 						"right": {
-							"color": {
-								"description": "Sets the `border-right-color` CSS property.",
-								"type": "string"
+							"type": "object",
+							"properties": {
+								"color": {
+									"description": "Sets the `border-right-color` CSS property.",
+									"type": "string"
+								},
+								"style": {
+									"description": "Sets the `border-right-style` CSS property.",
+									"type": "string"
+								},
+								"width": {
+									"description": "Sets the `border-right-width` CSS property.",
+									"type": "string"
+								}
 							},
-							"style": {
-								"description": "Sets the `border-right-style` CSS property.",
-								"type": "string"
-							},
-							"width": {
-								"description": "Sets the `border-right-width` CSS property.",
-								"type": "string"
-							}
+							"additionalProperties": false
 						},
 						"bottom": {
-							"color": {
-								"description": "Sets the `border-bottom-color` CSS property.",
-								"type": "string"
+							"type": "object",
+							"properties": {
+								"color": {
+									"description": "Sets the `border-bottom-color` CSS property.",
+									"type": "string"
+								},
+								"style": {
+									"description": "Sets the `border-bottom-style` CSS property.",
+									"type": "string"
+								},
+								"width": {
+									"description": "Sets the `border-bottom-width` CSS property.",
+									"type": "string"
+								}
 							},
-							"style": {
-								"description": "Sets the `border-bottom-style` CSS property.",
-								"type": "string"
-							},
-							"width": {
-								"description": "Sets the `border-bottom-width` CSS property.",
-								"type": "string"
-							}
+							"additionalProperties": false
 						},
 						"left": {
-							"color": {
-								"description": "Sets the `border-left-color` CSS property.",
-								"type": "string"
+							"type": "object",
+							"properties": {
+								"color": {
+									"description": "Sets the `border-left-color` CSS property.",
+									"type": "string"
+								},
+								"style": {
+									"description": "Sets the `border-left-style` CSS property.",
+									"type": "string"
+								},
+								"width": {
+									"description": "Sets the `border-left-width` CSS property.",
+									"type": "string"
+								}
 							},
-							"style": {
-								"description": "Sets the `border-left-style` CSS property.",
-								"type": "string"
-							},
-							"width": {
-								"description": "Sets the `border-left-width` CSS property.",
-								"type": "string"
-							}
+							"additionalProperties": false
 						}
 					},
 					"additionalProperties": false

--- a/schemas/json/theme.json
+++ b/schemas/json/theme.json
@@ -1,6 +1,6 @@
 {
 	"title": "JSON schema for WordPress block theme global settings and styles",
-	"$schema": "http://json-schema.org/draft-04/schema#",
+	"$schema": "http://json-schema.org/draft-07/schema#",
 	"definitions": {
 		"//": {
 			"explainer": "https://developer.wordpress.org/themes/advanced-topics/theme-json/",
@@ -546,25 +546,33 @@
 				{ "$ref": "#/definitions/settingsPropertiesCustom" }
 			]
 		},
-		"settingsPropertiesComplete": {
+		"settingsPropertiesNames": {
+			"enum": [
+				"appearanceTools",
+				"border",
+				"color",
+				"layout",
+				"spacing",
+				"typography",
+				"custom"
+			]
+		},
+		"settingsPropertiesNested": {
 			"type": "object",
 			"allOf": [
 				{
 					"$ref": "#/definitions/settingsProperties"
 				},
 				{
-					"properties": {
-						"appearanceTools": {},
-						"border": {},
-						"color": {},
-						"layout": {},
-						"spacing": {},
-						"typography": {},
-						"custom": {}
-					},
-					"additionalProperties": false
+					"$ref": "#/definitions/settingsBlocksPropertiesComplete"
 				}
-			]
+			],
+			"propertyNames": {
+				"anyOf": [
+					{ "$ref": "#/definitions/settingsPropertiesNames" },
+					{ "$ref": "#/definitions/settingsBlocksNames" }
+				]
+			}
 		},
 		"settingsBlocksPropertiesComplete": {
 			"type": "object",
@@ -573,13 +581,13 @@
 					"description": "Archive block. Display a monthly archive of your posts. This block has no block-level settings"
 				},
 				"core/audio": {
-					"$ref": "#/definitions/settingsPropertiesComplete"
+					"$ref": "#/definitions/settingsPropertiesNested"
 				},
 				"core/avatar": {
-					"$ref": "#/definitions/settingsPropertiesComplete"
+					"$ref": "#/definitions/settingsPropertiesNested"
 				},
 				"core/block": {
-					"$ref": "#/definitions/settingsPropertiesComplete"
+					"$ref": "#/definitions/settingsPropertiesNested"
 				},
 				"core/button": {
 					"type": "object",
@@ -613,246 +621,332 @@
 					]
 				},
 				"core/buttons": {
-					"$ref": "#/definitions/settingsPropertiesComplete"
+					"$ref": "#/definitions/settingsPropertiesNested"
 				},
 				"core/calendar": {
-					"$ref": "#/definitions/settingsPropertiesComplete"
+					"$ref": "#/definitions/settingsPropertiesNested"
 				},
 				"core/categories": {
-					"$ref": "#/definitions/settingsPropertiesComplete"
+					"$ref": "#/definitions/settingsPropertiesNested"
 				},
 				"core/code": {
-					"$ref": "#/definitions/settingsPropertiesComplete"
+					"$ref": "#/definitions/settingsPropertiesNested"
 				},
 				"core/column": {
-					"$ref": "#/definitions/settingsPropertiesComplete"
+					"$ref": "#/definitions/settingsPropertiesNested"
 				},
 				"core/columns": {
-					"$ref": "#/definitions/settingsPropertiesComplete"
+					"$ref": "#/definitions/settingsPropertiesNested"
 				},
 				"core/comment-author-name": {
-					"$ref": "#/definitions/settingsPropertiesComplete"
+					"$ref": "#/definitions/settingsPropertiesNested"
 				},
 				"core/comment-content": {
-					"$ref": "#/definitions/settingsPropertiesComplete"
+					"$ref": "#/definitions/settingsPropertiesNested"
 				},
 				"core/comment-date": {
-					"$ref": "#/definitions/settingsPropertiesComplete"
+					"$ref": "#/definitions/settingsPropertiesNested"
 				},
 				"core/comment-edit-link": {
-					"$ref": "#/definitions/settingsPropertiesComplete"
+					"$ref": "#/definitions/settingsPropertiesNested"
 				},
 				"core/comment-reply-link": {
-					"$ref": "#/definitions/settingsPropertiesComplete"
+					"$ref": "#/definitions/settingsPropertiesNested"
 				},
 				"core/comment-template": {
-					"$ref": "#/definitions/settingsPropertiesComplete"
+					"$ref": "#/definitions/settingsPropertiesNested"
 				},
 				"core/comments": {
-					"$ref": "#/definitions/settingsPropertiesComplete"
+					"$ref": "#/definitions/settingsPropertiesNested"
 				},
 				"core/cover": {
-					"$ref": "#/definitions/settingsPropertiesComplete"
+					"$ref": "#/definitions/settingsPropertiesNested"
 				},
 				"core/embed": {
-					"$ref": "#/definitions/settingsPropertiesComplete"
+					"$ref": "#/definitions/settingsPropertiesNested"
 				},
 				"core/file": {
-					"$ref": "#/definitions/settingsPropertiesComplete"
+					"$ref": "#/definitions/settingsPropertiesNested"
 				},
 				"core/freeform": {
-					"$ref": "#/definitions/settingsPropertiesComplete"
+					"$ref": "#/definitions/settingsPropertiesNested"
 				},
 				"core/gallery": {
-					"$ref": "#/definitions/settingsPropertiesComplete"
+					"$ref": "#/definitions/settingsPropertiesNested"
 				},
 				"core/group": {
-					"$ref": "#/definitions/settingsPropertiesComplete"
+					"$ref": "#/definitions/settingsPropertiesNested"
 				},
 				"core/heading": {
-					"$ref": "#/definitions/settingsPropertiesComplete"
+					"$ref": "#/definitions/settingsPropertiesNested"
 				},
 				"core/home-link": {
-					"$ref": "#/definitions/settingsPropertiesComplete"
+					"$ref": "#/definitions/settingsPropertiesNested"
 				},
 				"core/html": {
-					"$ref": "#/definitions/settingsPropertiesComplete"
+					"$ref": "#/definitions/settingsPropertiesNested"
 				},
 				"core/image": {
-					"$ref": "#/definitions/settingsPropertiesComplete"
+					"$ref": "#/definitions/settingsPropertiesNested"
 				},
 				"core/latest-comments": {
-					"$ref": "#/definitions/settingsPropertiesComplete"
+					"$ref": "#/definitions/settingsPropertiesNested"
 				},
 				"core/latest-posts": {
-					"$ref": "#/definitions/settingsPropertiesComplete"
+					"$ref": "#/definitions/settingsPropertiesNested"
 				},
 				"core/list": {
-					"$ref": "#/definitions/settingsPropertiesComplete"
+					"$ref": "#/definitions/settingsPropertiesNested"
 				},
 				"core/loginout": {
-					"$ref": "#/definitions/settingsPropertiesComplete"
+					"$ref": "#/definitions/settingsPropertiesNested"
 				},
 				"core/media-text": {
-					"$ref": "#/definitions/settingsPropertiesComplete"
+					"$ref": "#/definitions/settingsPropertiesNested"
 				},
 				"core/missing": {
-					"$ref": "#/definitions/settingsPropertiesComplete"
+					"$ref": "#/definitions/settingsPropertiesNested"
 				},
 				"core/more": {
-					"$ref": "#/definitions/settingsPropertiesComplete"
+					"$ref": "#/definitions/settingsPropertiesNested"
 				},
 				"core/navigation": {
-					"$ref": "#/definitions/settingsPropertiesComplete"
+					"$ref": "#/definitions/settingsPropertiesNested"
 				},
 				"core/navigation-link": {
-					"$ref": "#/definitions/settingsPropertiesComplete"
+					"$ref": "#/definitions/settingsPropertiesNested"
 				},
 				"core/nextpage": {
-					"$ref": "#/definitions/settingsPropertiesComplete"
+					"$ref": "#/definitions/settingsPropertiesNested"
 				},
 				"core/page-list": {
-					"$ref": "#/definitions/settingsPropertiesComplete"
+					"$ref": "#/definitions/settingsPropertiesNested"
 				},
 				"core/paragraph": {
-					"$ref": "#/definitions/settingsPropertiesComplete"
+					"$ref": "#/definitions/settingsPropertiesNested"
 				},
 				"core/post-author": {
-					"$ref": "#/definitions/settingsPropertiesComplete"
+					"$ref": "#/definitions/settingsPropertiesNested"
 				},
 				"core/post-comments": {
-					"$ref": "#/definitions/settingsPropertiesComplete"
+					"$ref": "#/definitions/settingsPropertiesNested"
 				},
 				"core/post-comments-count": {
-					"$ref": "#/definitions/settingsPropertiesComplete"
+					"$ref": "#/definitions/settingsPropertiesNested"
 				},
 				"core/post-comments-form": {
-					"$ref": "#/definitions/settingsPropertiesComplete"
+					"$ref": "#/definitions/settingsPropertiesNested"
 				},
 				"core/post-comments-link": {
-					"$ref": "#/definitions/settingsPropertiesComplete"
+					"$ref": "#/definitions/settingsPropertiesNested"
 				},
 				"core/post-content": {
-					"$ref": "#/definitions/settingsPropertiesComplete"
+					"$ref": "#/definitions/settingsPropertiesNested"
 				},
 				"core/post-date": {
-					"$ref": "#/definitions/settingsPropertiesComplete"
+					"$ref": "#/definitions/settingsPropertiesNested"
 				},
 				"core/post-excerpt": {
-					"$ref": "#/definitions/settingsPropertiesComplete"
+					"$ref": "#/definitions/settingsPropertiesNested"
 				},
 				"core/post-featured-image": {
-					"$ref": "#/definitions/settingsPropertiesComplete"
+					"$ref": "#/definitions/settingsPropertiesNested"
 				},
 				"core/post-navigation-link": {
-					"$ref": "#/definitions/settingsPropertiesComplete"
+					"$ref": "#/definitions/settingsPropertiesNested"
 				},
 				"core/post-template": {
-					"$ref": "#/definitions/settingsPropertiesComplete"
+					"$ref": "#/definitions/settingsPropertiesNested"
 				},
 				"core/post-terms": {
-					"$ref": "#/definitions/settingsPropertiesComplete"
+					"$ref": "#/definitions/settingsPropertiesNested"
 				},
 				"core/post-title": {
-					"$ref": "#/definitions/settingsPropertiesComplete"
+					"$ref": "#/definitions/settingsPropertiesNested"
 				},
 				"core/preformatted": {
-					"$ref": "#/definitions/settingsPropertiesComplete"
+					"$ref": "#/definitions/settingsPropertiesNested"
 				},
 				"core/pullquote": {
-					"$ref": "#/definitions/settingsPropertiesComplete"
+					"$ref": "#/definitions/settingsPropertiesNested"
 				},
 				"core/query": {
-					"$ref": "#/definitions/settingsPropertiesComplete"
+					"$ref": "#/definitions/settingsPropertiesNested"
 				},
 				"core/query-pagination": {
-					"$ref": "#/definitions/settingsPropertiesComplete"
+					"$ref": "#/definitions/settingsPropertiesNested"
 				},
 				"core/query-pagination-next": {
-					"$ref": "#/definitions/settingsPropertiesComplete"
+					"$ref": "#/definitions/settingsPropertiesNested"
 				},
 				"core/query-pagination-numbers": {
-					"$ref": "#/definitions/settingsPropertiesComplete"
+					"$ref": "#/definitions/settingsPropertiesNested"
 				},
 				"core/query-pagination-previous": {
-					"$ref": "#/definitions/settingsPropertiesComplete"
+					"$ref": "#/definitions/settingsPropertiesNested"
 				},
 				"core/query-title": {
-					"$ref": "#/definitions/settingsPropertiesComplete"
+					"$ref": "#/definitions/settingsPropertiesNested"
 				},
 				"core/quote": {
-					"$ref": "#/definitions/settingsPropertiesComplete"
+					"$ref": "#/definitions/settingsPropertiesNested"
 				},
 				"core/rss": {
-					"$ref": "#/definitions/settingsPropertiesComplete"
+					"$ref": "#/definitions/settingsPropertiesNested"
 				},
 				"core/search": {
-					"$ref": "#/definitions/settingsPropertiesComplete"
+					"$ref": "#/definitions/settingsPropertiesNested"
 				},
 				"core/separator": {
-					"$ref": "#/definitions/settingsPropertiesComplete"
+					"$ref": "#/definitions/settingsPropertiesNested"
 				},
 				"core/shortcode": {
-					"$ref": "#/definitions/settingsPropertiesComplete"
+					"$ref": "#/definitions/settingsPropertiesNested"
 				},
 				"core/site-logo": {
-					"$ref": "#/definitions/settingsPropertiesComplete"
+					"$ref": "#/definitions/settingsPropertiesNested"
 				},
 				"core/site-tagline": {
-					"$ref": "#/definitions/settingsPropertiesComplete"
+					"$ref": "#/definitions/settingsPropertiesNested"
 				},
 				"core/site-title": {
-					"$ref": "#/definitions/settingsPropertiesComplete"
+					"$ref": "#/definitions/settingsPropertiesNested"
 				},
 				"core/social-link": {
-					"$ref": "#/definitions/settingsPropertiesComplete"
+					"$ref": "#/definitions/settingsPropertiesNested"
 				},
 				"core/social-links": {
-					"$ref": "#/definitions/settingsPropertiesComplete"
+					"$ref": "#/definitions/settingsPropertiesNested"
 				},
 				"core/spacer": {
-					"$ref": "#/definitions/settingsPropertiesComplete"
+					"$ref": "#/definitions/settingsPropertiesNested"
 				},
 				"core/table": {
-					"$ref": "#/definitions/settingsPropertiesComplete"
+					"$ref": "#/definitions/settingsPropertiesNested"
 				},
 				"core/table-of-contents": {
-					"$ref": "#/definitions/settingsPropertiesComplete"
+					"$ref": "#/definitions/settingsPropertiesNested"
 				},
 				"core/tag-cloud": {
-					"$ref": "#/definitions/settingsPropertiesComplete"
+					"$ref": "#/definitions/settingsPropertiesNested"
 				},
 				"core/template-part": {
-					"$ref": "#/definitions/settingsPropertiesComplete"
+					"$ref": "#/definitions/settingsPropertiesNested"
 				},
 				"core/term-description": {
-					"$ref": "#/definitions/settingsPropertiesComplete"
+					"$ref": "#/definitions/settingsPropertiesNested"
 				},
 				"core/text-columns": {
-					"$ref": "#/definitions/settingsPropertiesComplete"
+					"$ref": "#/definitions/settingsPropertiesNested"
 				},
 				"core/verse": {
-					"$ref": "#/definitions/settingsPropertiesComplete"
+					"$ref": "#/definitions/settingsPropertiesNested"
 				},
 				"core/video": {
-					"$ref": "#/definitions/settingsPropertiesComplete"
+					"$ref": "#/definitions/settingsPropertiesNested"
 				},
 				"core/widget-area": {
-					"$ref": "#/definitions/settingsPropertiesComplete"
+					"$ref": "#/definitions/settingsPropertiesNested"
 				},
 				"core/legacy-widget": {
-					"$ref": "#/definitions/settingsPropertiesComplete"
+					"$ref": "#/definitions/settingsPropertiesNested"
 				},
 				"core/widget-group": {
-					"$ref": "#/definitions/settingsPropertiesComplete"
+					"$ref": "#/definitions/settingsPropertiesNested"
 				}
 			},
 			"patternProperties": {
 				"^[a-z][a-z0-9-]*/[a-z][a-z0-9-]*$": {
-					"$ref": "#/definitions/settingsPropertiesComplete"
+					"$ref": "#/definitions/settingsPropertiesNested"
 				}
-			},
-			"additionalProperties": false
+			}
+		},
+		"settingsBlocksNames": {
+			"enum": [
+				"core/archives",
+				"core/audio",
+				"core/avatar",
+				"core/block",
+				"core/button",
+				"core/buttons",
+				"core/calendar",
+				"core/categories",
+				"core/code",
+				"core/column",
+				"core/columns",
+				"core/comment-author-name",
+				"core/comment-content",
+				"core/comment-date",
+				"core/comment-edit-link",
+				"core/comment-reply-link",
+				"core/comment-template",
+				"core/comments",
+				"core/cover",
+				"core/embed",
+				"core/file",
+				"core/freeform",
+				"core/gallery",
+				"core/group",
+				"core/heading",
+				"core/home-link",
+				"core/html",
+				"core/image",
+				"core/latest-comments",
+				"core/latest-posts",
+				"core/list",
+				"core/loginout",
+				"core/media-text",
+				"core/missing",
+				"core/more",
+				"core/navigation",
+				"core/navigation-link",
+				"core/nextpage",
+				"core/page-list",
+				"core/paragraph",
+				"core/post-author",
+				"core/post-comments",
+				"core/post-comments-count",
+				"core/post-comments-form",
+				"core/post-comments-link",
+				"core/post-content",
+				"core/post-date",
+				"core/post-excerpt",
+				"core/post-featured-image",
+				"core/post-navigation-link",
+				"core/post-template",
+				"core/post-terms",
+				"core/post-title",
+				"core/preformatted",
+				"core/pullquote",
+				"core/query",
+				"core/query-pagination",
+				"core/query-pagination-next",
+				"core/query-pagination-numbers",
+				"core/query-pagination-previous",
+				"core/query-title",
+				"core/quote",
+				"core/rss",
+				"core/search",
+				"core/separator",
+				"core/shortcode",
+				"core/site-logo",
+				"core/site-tagline",
+				"core/site-title",
+				"core/social-link",
+				"core/social-links",
+				"core/spacer",
+				"core/table",
+				"core/table-of-contents",
+				"core/tag-cloud",
+				"core/template-part",
+				"core/term-description",
+				"core/text-columns",
+				"core/verse",
+				"core/video",
+				"core/widget-area",
+				"core/legacy-widget",
+				"core/widget-group"
+			]
 		},
 		"settingsCustomAdditionalProperties": {
 			"type": "object",

--- a/schemas/json/theme.json
+++ b/schemas/json/theme.json
@@ -581,7 +581,7 @@
 					"$ref": "#/definitions/settingsPropertiesComplete"
 				},
 				"core/block": {
-					"$ref": "#/definitions/settingsPropertiesComplete"
+					"$ref": "#/definitions/settingsNestedPropertiesComplete"
 				},
 				"core/button": {
 					"type": "object",
@@ -623,7 +623,7 @@
 					]
 				},
 				"core/buttons": {
-					"$ref": "#/definitions/settingsPropertiesComplete"
+					"$ref": "#/definitions/settingsNestedPropertiesComplete"
 				},
 				"core/calendar": {
 					"$ref": "#/definitions/settingsPropertiesComplete"
@@ -635,10 +635,10 @@
 					"$ref": "#/definitions/settingsPropertiesComplete"
 				},
 				"core/column": {
-					"$ref": "#/definitions/settingsPropertiesComplete"
+					"$ref": "#/definitions/settingsNestedPropertiesComplete"
 				},
 				"core/columns": {
-					"$ref": "#/definitions/settingsPropertiesComplete"
+					"$ref": "#/definitions/settingsNestedPropertiesComplete"
 				},
 				"core/comment-author-name": {
 					"$ref": "#/definitions/settingsPropertiesComplete"
@@ -656,13 +656,13 @@
 					"$ref": "#/definitions/settingsPropertiesComplete"
 				},
 				"core/comment-template": {
-					"$ref": "#/definitions/settingsPropertiesComplete"
+					"$ref": "#/definitions/settingsNestedPropertiesComplete"
 				},
 				"core/comments": {
-					"$ref": "#/definitions/settingsPropertiesComplete"
+					"$ref": "#/definitions/settingsNestedPropertiesComplete"
 				},
 				"core/cover": {
-					"$ref": "#/definitions/settingsPropertiesComplete"
+					"$ref": "#/definitions/settingsNestedPropertiesComplete"
 				},
 				"core/embed": {
 					"$ref": "#/definitions/settingsPropertiesComplete"
@@ -674,16 +674,16 @@
 					"$ref": "#/definitions/settingsPropertiesComplete"
 				},
 				"core/gallery": {
-					"$ref": "#/definitions/settingsPropertiesComplete"
+					"$ref": "#/definitions/settingsNestedPropertiesComplete"
 				},
 				"core/group": {
-					"$ref": "#/definitions/settingsPropertiesComplete"
+					"$ref": "#/definitions/settingsNestedPropertiesComplete"
 				},
 				"core/heading": {
 					"$ref": "#/definitions/settingsPropertiesComplete"
 				},
 				"core/home-link": {
-					"$ref": "#/definitions/settingsPropertiesComplete"
+					"$ref": "#/definitions/settingsNestedPropertiesComplete"
 				},
 				"core/html": {
 					"$ref": "#/definitions/settingsPropertiesComplete"
@@ -698,13 +698,13 @@
 					"$ref": "#/definitions/settingsPropertiesComplete"
 				},
 				"core/list": {
-					"$ref": "#/definitions/settingsPropertiesComplete"
+					"$ref": "#/definitions/settingsNestedPropertiesComplete"
 				},
 				"core/loginout": {
 					"$ref": "#/definitions/settingsPropertiesComplete"
 				},
 				"core/media-text": {
-					"$ref": "#/definitions/settingsPropertiesComplete"
+					"$ref": "#/definitions/settingsNestedPropertiesComplete"
 				},
 				"core/missing": {
 					"$ref": "#/definitions/settingsPropertiesComplete"
@@ -713,10 +713,10 @@
 					"$ref": "#/definitions/settingsPropertiesComplete"
 				},
 				"core/navigation": {
-					"$ref": "#/definitions/settingsPropertiesComplete"
+					"$ref": "#/definitions/settingsNestedPropertiesComplete"
 				},
 				"core/navigation-link": {
-					"$ref": "#/definitions/settingsPropertiesComplete"
+					"$ref": "#/definitions/settingsNestedPropertiesComplete"
 				},
 				"core/nextpage": {
 					"$ref": "#/definitions/settingsPropertiesComplete"
@@ -731,19 +731,19 @@
 					"$ref": "#/definitions/settingsPropertiesComplete"
 				},
 				"core/post-comments": {
-					"$ref": "#/definitions/settingsPropertiesComplete"
+					"$ref": "#/definitions/settingsNestedPropertiesComplete"
 				},
 				"core/post-comments-count": {
-					"$ref": "#/definitions/settingsPropertiesComplete"
+					"$ref": "#/definitions/settingsNestedPropertiesComplete"
 				},
 				"core/post-comments-form": {
-					"$ref": "#/definitions/settingsPropertiesComplete"
+					"$ref": "#/definitions/settingsNestedPropertiesComplete"
 				},
 				"core/post-comments-link": {
-					"$ref": "#/definitions/settingsPropertiesComplete"
+					"$ref": "#/definitions/settingsNestedPropertiesComplete"
 				},
 				"core/post-content": {
-					"$ref": "#/definitions/settingsPropertiesComplete"
+					"$ref": "#/definitions/settingsNestedPropertiesComplete"
 				},
 				"core/post-date": {
 					"$ref": "#/definitions/settingsPropertiesComplete"
@@ -758,7 +758,7 @@
 					"$ref": "#/definitions/settingsPropertiesComplete"
 				},
 				"core/post-template": {
-					"$ref": "#/definitions/settingsPropertiesComplete"
+					"$ref": "#/definitions/settingsNestedPropertiesComplete"
 				},
 				"core/post-terms": {
 					"$ref": "#/definitions/settingsPropertiesComplete"
@@ -773,25 +773,25 @@
 					"$ref": "#/definitions/settingsPropertiesComplete"
 				},
 				"core/query": {
-					"$ref": "#/definitions/settingsPropertiesComplete"
+					"$ref": "#/definitions/settingsNestedPropertiesComplete"
 				},
 				"core/query-pagination": {
-					"$ref": "#/definitions/settingsPropertiesComplete"
+					"$ref": "#/definitions/settingsNestedPropertiesComplete"
 				},
 				"core/query-pagination-next": {
-					"$ref": "#/definitions/settingsPropertiesComplete"
+					"$ref": "#/definitions/settingsNestedPropertiesComplete"
 				},
 				"core/query-pagination-numbers": {
-					"$ref": "#/definitions/settingsPropertiesComplete"
+					"$ref": "#/definitions/settingsNestedPropertiesComplete"
 				},
 				"core/query-pagination-previous": {
-					"$ref": "#/definitions/settingsPropertiesComplete"
+					"$ref": "#/definitions/settingsNestedPropertiesComplete"
 				},
 				"core/query-title": {
-					"$ref": "#/definitions/settingsPropertiesComplete"
+					"$ref": "#/definitions/settingsNestedPropertiesComplete"
 				},
 				"core/quote": {
-					"$ref": "#/definitions/settingsPropertiesComplete"
+					"$ref": "#/definitions/settingsNestedPropertiesComplete"
 				},
 				"core/rss": {
 					"$ref": "#/definitions/settingsPropertiesComplete"
@@ -818,7 +818,7 @@
 					"$ref": "#/definitions/settingsPropertiesComplete"
 				},
 				"core/social-links": {
-					"$ref": "#/definitions/settingsPropertiesComplete"
+					"$ref": "#/definitions/settingsNestedPropertiesComplete"
 				},
 				"core/spacer": {
 					"$ref": "#/definitions/settingsPropertiesComplete"
@@ -833,7 +833,7 @@
 					"$ref": "#/definitions/settingsPropertiesComplete"
 				},
 				"core/template-part": {
-					"$ref": "#/definitions/settingsPropertiesComplete"
+					"$ref": "#/definitions/settingsNestedPropertiesComplete"
 				},
 				"core/term-description": {
 					"$ref": "#/definitions/settingsPropertiesComplete"
@@ -859,7 +859,7 @@
 			},
 			"patternProperties": {
 				"^[a-z][a-z0-9-]*/[a-z][a-z0-9-]*$": {
-					"$ref": "#/definitions/settingsPropertiesComplete"
+					"$ref": "#/definitions/settingsNestedPropertiesComplete"
 				}
 			}
 		},

--- a/schemas/json/theme.json
+++ b/schemas/json/theme.json
@@ -575,13 +575,13 @@
 					"additionalProperties": false
 				},
 				"core/audio": {
-					"$ref": "#/definitions/settingsPropertiesNestedComplete"
+					"$ref": "#/definitions/settingsPropertiesComplete"
 				},
 				"core/avatar": {
-					"$ref": "#/definitions/settingsPropertiesNestedComplete"
+					"$ref": "#/definitions/settingsPropertiesComplete"
 				},
 				"core/block": {
-					"$ref": "#/definitions/settingsPropertiesNestedComplete"
+					"$ref": "#/definitions/settingsPropertiesComplete"
 				},
 				"core/button": {
 					"type": "object",
@@ -623,243 +623,243 @@
 					]
 				},
 				"core/buttons": {
-					"$ref": "#/definitions/settingsPropertiesNestedComplete"
+					"$ref": "#/definitions/settingsPropertiesComplete"
 				},
 				"core/calendar": {
-					"$ref": "#/definitions/settingsPropertiesNestedComplete"
+					"$ref": "#/definitions/settingsPropertiesComplete"
 				},
 				"core/categories": {
-					"$ref": "#/definitions/settingsPropertiesNestedComplete"
+					"$ref": "#/definitions/settingsPropertiesComplete"
 				},
 				"core/code": {
-					"$ref": "#/definitions/settingsPropertiesNestedComplete"
+					"$ref": "#/definitions/settingsPropertiesComplete"
 				},
 				"core/column": {
-					"$ref": "#/definitions/settingsPropertiesNestedComplete"
+					"$ref": "#/definitions/settingsPropertiesComplete"
 				},
 				"core/columns": {
-					"$ref": "#/definitions/settingsPropertiesNestedComplete"
+					"$ref": "#/definitions/settingsPropertiesComplete"
 				},
 				"core/comment-author-name": {
-					"$ref": "#/definitions/settingsPropertiesNestedComplete"
+					"$ref": "#/definitions/settingsPropertiesComplete"
 				},
 				"core/comment-content": {
-					"$ref": "#/definitions/settingsPropertiesNestedComplete"
+					"$ref": "#/definitions/settingsPropertiesComplete"
 				},
 				"core/comment-date": {
-					"$ref": "#/definitions/settingsPropertiesNestedComplete"
+					"$ref": "#/definitions/settingsPropertiesComplete"
 				},
 				"core/comment-edit-link": {
-					"$ref": "#/definitions/settingsPropertiesNestedComplete"
+					"$ref": "#/definitions/settingsPropertiesComplete"
 				},
 				"core/comment-reply-link": {
-					"$ref": "#/definitions/settingsPropertiesNestedComplete"
+					"$ref": "#/definitions/settingsPropertiesComplete"
 				},
 				"core/comment-template": {
-					"$ref": "#/definitions/settingsPropertiesNestedComplete"
+					"$ref": "#/definitions/settingsPropertiesComplete"
 				},
 				"core/comments": {
-					"$ref": "#/definitions/settingsPropertiesNestedComplete"
+					"$ref": "#/definitions/settingsPropertiesComplete"
 				},
 				"core/cover": {
-					"$ref": "#/definitions/settingsPropertiesNestedComplete"
+					"$ref": "#/definitions/settingsPropertiesComplete"
 				},
 				"core/embed": {
-					"$ref": "#/definitions/settingsPropertiesNestedComplete"
+					"$ref": "#/definitions/settingsPropertiesComplete"
 				},
 				"core/file": {
-					"$ref": "#/definitions/settingsPropertiesNestedComplete"
+					"$ref": "#/definitions/settingsPropertiesComplete"
 				},
 				"core/freeform": {
-					"$ref": "#/definitions/settingsPropertiesNestedComplete"
+					"$ref": "#/definitions/settingsPropertiesComplete"
 				},
 				"core/gallery": {
-					"$ref": "#/definitions/settingsPropertiesNestedComplete"
+					"$ref": "#/definitions/settingsPropertiesComplete"
 				},
 				"core/group": {
-					"$ref": "#/definitions/settingsPropertiesNestedComplete"
+					"$ref": "#/definitions/settingsPropertiesComplete"
 				},
 				"core/heading": {
-					"$ref": "#/definitions/settingsPropertiesNestedComplete"
+					"$ref": "#/definitions/settingsPropertiesComplete"
 				},
 				"core/home-link": {
-					"$ref": "#/definitions/settingsPropertiesNestedComplete"
+					"$ref": "#/definitions/settingsPropertiesComplete"
 				},
 				"core/html": {
-					"$ref": "#/definitions/settingsPropertiesNestedComplete"
+					"$ref": "#/definitions/settingsPropertiesComplete"
 				},
 				"core/image": {
-					"$ref": "#/definitions/settingsPropertiesNestedComplete"
+					"$ref": "#/definitions/settingsPropertiesComplete"
 				},
 				"core/latest-comments": {
-					"$ref": "#/definitions/settingsPropertiesNestedComplete"
+					"$ref": "#/definitions/settingsPropertiesComplete"
 				},
 				"core/latest-posts": {
-					"$ref": "#/definitions/settingsPropertiesNestedComplete"
+					"$ref": "#/definitions/settingsPropertiesComplete"
 				},
 				"core/list": {
-					"$ref": "#/definitions/settingsPropertiesNestedComplete"
+					"$ref": "#/definitions/settingsPropertiesComplete"
 				},
 				"core/loginout": {
-					"$ref": "#/definitions/settingsPropertiesNestedComplete"
+					"$ref": "#/definitions/settingsPropertiesComplete"
 				},
 				"core/media-text": {
-					"$ref": "#/definitions/settingsPropertiesNestedComplete"
+					"$ref": "#/definitions/settingsPropertiesComplete"
 				},
 				"core/missing": {
-					"$ref": "#/definitions/settingsPropertiesNestedComplete"
+					"$ref": "#/definitions/settingsPropertiesComplete"
 				},
 				"core/more": {
-					"$ref": "#/definitions/settingsPropertiesNestedComplete"
+					"$ref": "#/definitions/settingsPropertiesComplete"
 				},
 				"core/navigation": {
-					"$ref": "#/definitions/settingsPropertiesNestedComplete"
+					"$ref": "#/definitions/settingsPropertiesComplete"
 				},
 				"core/navigation-link": {
-					"$ref": "#/definitions/settingsPropertiesNestedComplete"
+					"$ref": "#/definitions/settingsPropertiesComplete"
 				},
 				"core/nextpage": {
-					"$ref": "#/definitions/settingsPropertiesNestedComplete"
+					"$ref": "#/definitions/settingsPropertiesComplete"
 				},
 				"core/page-list": {
-					"$ref": "#/definitions/settingsPropertiesNestedComplete"
+					"$ref": "#/definitions/settingsPropertiesComplete"
 				},
 				"core/paragraph": {
-					"$ref": "#/definitions/settingsPropertiesNestedComplete"
+					"$ref": "#/definitions/settingsPropertiesComplete"
 				},
 				"core/post-author": {
-					"$ref": "#/definitions/settingsPropertiesNestedComplete"
+					"$ref": "#/definitions/settingsPropertiesComplete"
 				},
 				"core/post-comments": {
-					"$ref": "#/definitions/settingsPropertiesNestedComplete"
+					"$ref": "#/definitions/settingsPropertiesComplete"
 				},
 				"core/post-comments-count": {
-					"$ref": "#/definitions/settingsPropertiesNestedComplete"
+					"$ref": "#/definitions/settingsPropertiesComplete"
 				},
 				"core/post-comments-form": {
-					"$ref": "#/definitions/settingsPropertiesNestedComplete"
+					"$ref": "#/definitions/settingsPropertiesComplete"
 				},
 				"core/post-comments-link": {
-					"$ref": "#/definitions/settingsPropertiesNestedComplete"
+					"$ref": "#/definitions/settingsPropertiesComplete"
 				},
 				"core/post-content": {
-					"$ref": "#/definitions/settingsPropertiesNestedComplete"
+					"$ref": "#/definitions/settingsPropertiesComplete"
 				},
 				"core/post-date": {
-					"$ref": "#/definitions/settingsPropertiesNestedComplete"
+					"$ref": "#/definitions/settingsPropertiesComplete"
 				},
 				"core/post-excerpt": {
-					"$ref": "#/definitions/settingsPropertiesNestedComplete"
+					"$ref": "#/definitions/settingsPropertiesComplete"
 				},
 				"core/post-featured-image": {
-					"$ref": "#/definitions/settingsPropertiesNestedComplete"
+					"$ref": "#/definitions/settingsPropertiesComplete"
 				},
 				"core/post-navigation-link": {
-					"$ref": "#/definitions/settingsPropertiesNestedComplete"
+					"$ref": "#/definitions/settingsPropertiesComplete"
 				},
 				"core/post-template": {
-					"$ref": "#/definitions/settingsPropertiesNestedComplete"
+					"$ref": "#/definitions/settingsPropertiesComplete"
 				},
 				"core/post-terms": {
-					"$ref": "#/definitions/settingsPropertiesNestedComplete"
+					"$ref": "#/definitions/settingsPropertiesComplete"
 				},
 				"core/post-title": {
-					"$ref": "#/definitions/settingsPropertiesNestedComplete"
+					"$ref": "#/definitions/settingsPropertiesComplete"
 				},
 				"core/preformatted": {
-					"$ref": "#/definitions/settingsPropertiesNestedComplete"
+					"$ref": "#/definitions/settingsPropertiesComplete"
 				},
 				"core/pullquote": {
-					"$ref": "#/definitions/settingsPropertiesNestedComplete"
+					"$ref": "#/definitions/settingsPropertiesComplete"
 				},
 				"core/query": {
-					"$ref": "#/definitions/settingsPropertiesNestedComplete"
+					"$ref": "#/definitions/settingsPropertiesComplete"
 				},
 				"core/query-pagination": {
-					"$ref": "#/definitions/settingsPropertiesNestedComplete"
+					"$ref": "#/definitions/settingsPropertiesComplete"
 				},
 				"core/query-pagination-next": {
-					"$ref": "#/definitions/settingsPropertiesNestedComplete"
+					"$ref": "#/definitions/settingsPropertiesComplete"
 				},
 				"core/query-pagination-numbers": {
-					"$ref": "#/definitions/settingsPropertiesNestedComplete"
+					"$ref": "#/definitions/settingsPropertiesComplete"
 				},
 				"core/query-pagination-previous": {
-					"$ref": "#/definitions/settingsPropertiesNestedComplete"
+					"$ref": "#/definitions/settingsPropertiesComplete"
 				},
 				"core/query-title": {
-					"$ref": "#/definitions/settingsPropertiesNestedComplete"
+					"$ref": "#/definitions/settingsPropertiesComplete"
 				},
 				"core/quote": {
-					"$ref": "#/definitions/settingsPropertiesNestedComplete"
+					"$ref": "#/definitions/settingsPropertiesComplete"
 				},
 				"core/rss": {
-					"$ref": "#/definitions/settingsPropertiesNestedComplete"
+					"$ref": "#/definitions/settingsPropertiesComplete"
 				},
 				"core/search": {
-					"$ref": "#/definitions/settingsPropertiesNestedComplete"
+					"$ref": "#/definitions/settingsPropertiesComplete"
 				},
 				"core/separator": {
-					"$ref": "#/definitions/settingsPropertiesNestedComplete"
+					"$ref": "#/definitions/settingsPropertiesComplete"
 				},
 				"core/shortcode": {
-					"$ref": "#/definitions/settingsPropertiesNestedComplete"
+					"$ref": "#/definitions/settingsPropertiesComplete"
 				},
 				"core/site-logo": {
-					"$ref": "#/definitions/settingsPropertiesNestedComplete"
+					"$ref": "#/definitions/settingsPropertiesComplete"
 				},
 				"core/site-tagline": {
-					"$ref": "#/definitions/settingsPropertiesNestedComplete"
+					"$ref": "#/definitions/settingsPropertiesComplete"
 				},
 				"core/site-title": {
-					"$ref": "#/definitions/settingsPropertiesNestedComplete"
+					"$ref": "#/definitions/settingsPropertiesComplete"
 				},
 				"core/social-link": {
-					"$ref": "#/definitions/settingsPropertiesNestedComplete"
+					"$ref": "#/definitions/settingsPropertiesComplete"
 				},
 				"core/social-links": {
-					"$ref": "#/definitions/settingsPropertiesNestedComplete"
+					"$ref": "#/definitions/settingsPropertiesComplete"
 				},
 				"core/spacer": {
-					"$ref": "#/definitions/settingsPropertiesNestedComplete"
+					"$ref": "#/definitions/settingsPropertiesComplete"
 				},
 				"core/table": {
-					"$ref": "#/definitions/settingsPropertiesNestedComplete"
+					"$ref": "#/definitions/settingsPropertiesComplete"
 				},
 				"core/table-of-contents": {
-					"$ref": "#/definitions/settingsPropertiesNestedComplete"
+					"$ref": "#/definitions/settingsPropertiesComplete"
 				},
 				"core/tag-cloud": {
-					"$ref": "#/definitions/settingsPropertiesNestedComplete"
+					"$ref": "#/definitions/settingsPropertiesComplete"
 				},
 				"core/template-part": {
-					"$ref": "#/definitions/settingsPropertiesNestedComplete"
+					"$ref": "#/definitions/settingsPropertiesComplete"
 				},
 				"core/term-description": {
-					"$ref": "#/definitions/settingsPropertiesNestedComplete"
+					"$ref": "#/definitions/settingsPropertiesComplete"
 				},
 				"core/text-columns": {
-					"$ref": "#/definitions/settingsPropertiesNestedComplete"
+					"$ref": "#/definitions/settingsPropertiesComplete"
 				},
 				"core/verse": {
-					"$ref": "#/definitions/settingsPropertiesNestedComplete"
+					"$ref": "#/definitions/settingsPropertiesComplete"
 				},
 				"core/video": {
-					"$ref": "#/definitions/settingsPropertiesNestedComplete"
+					"$ref": "#/definitions/settingsPropertiesComplete"
 				},
 				"core/widget-area": {
-					"$ref": "#/definitions/settingsPropertiesNestedComplete"
+					"$ref": "#/definitions/settingsPropertiesComplete"
 				},
 				"core/legacy-widget": {
-					"$ref": "#/definitions/settingsPropertiesNestedComplete"
+					"$ref": "#/definitions/settingsPropertiesComplete"
 				},
 				"core/widget-group": {
-					"$ref": "#/definitions/settingsPropertiesNestedComplete"
+					"$ref": "#/definitions/settingsPropertiesComplete"
 				}
 			},
 			"patternProperties": {
 				"^[a-z][a-z0-9-]*/[a-z][a-z0-9-]*$": {
-					"$ref": "#/definitions/settingsPropertiesNestedComplete"
+					"$ref": "#/definitions/settingsPropertiesComplete"
 				}
 			}
 		},
@@ -964,7 +964,7 @@
 				}
 			]
 		},
-		"settingsPropertiesNestedComplete": {
+		"settingsNestedPropertiesComplete": {
 			"type": "object",
 			"allOf": [
 				{

--- a/schemas/json/theme.json
+++ b/schemas/json/theme.json
@@ -578,7 +578,9 @@
 			"type": "object",
 			"properties": {
 				"core/archives": {
-					"description": "Archive block. Display a monthly archive of your posts. This block has no block-level settings"
+					"type": "object",
+					"description": "Archive block. Display a monthly archive of your posts. This block has no block-level settings",
+					"additionalProperties": false
 				},
 				"core/audio": {
 					"$ref": "#/definitions/settingsPropertiesNested"

--- a/schemas/json/theme.json
+++ b/schemas/json/theme.json
@@ -433,7 +433,6 @@
 												},
 												"fontWeight": {
 													"description": "List of available font weights, separated by a space.",
-													"type": "string",
 													"default": "400",
 													"oneOf": [
 														{

--- a/schemas/json/theme.json
+++ b/schemas/json/theme.json
@@ -570,8 +570,7 @@
 			"type": "object",
 			"properties": {
 				"core/archives": {
-					"description": "Archive block. Display a monthly archive of your posts. This block has no block-level settings",
-					"additionalProperties": false
+					"description": "Archive block. Display a monthly archive of your posts. This block has no block-level settings"
 				},
 				"core/audio": {
 					"$ref": "#/definitions/settingsPropertiesComplete"

--- a/schemas/json/theme.json
+++ b/schemas/json/theme.json
@@ -1,6 +1,6 @@
 {
 	"title": "JSON schema for WordPress block theme global settings and styles",
-	"$schema": "http://json-schema.org/draft-07/schema#",
+	"$schema": "http://json-schema.org/draft-04/schema#",
 	"definitions": {
 		"//": {
 			"explainer": "https://developer.wordpress.org/themes/advanced-topics/theme-json/",
@@ -546,35 +546,27 @@
 				{ "$ref": "#/definitions/settingsPropertiesCustom" }
 			]
 		},
-		"settingsPropertiesNames": {
-			"enum": [
-				"appearanceTools",
-				"border",
-				"color",
-				"layout",
-				"spacing",
-				"typography",
-				"custom"
-			]
-		},
-		"settingsPropertiesNested": {
+		"settingsPropertiesComplete": {
 			"type": "object",
 			"allOf": [
 				{
 					"$ref": "#/definitions/settingsProperties"
 				},
 				{
-					"$ref": "#/definitions/settingsBlocksPropertiesComplete"
+					"properties": {
+						"appearanceTools": {},
+						"border": {},
+						"color": {},
+						"layout": {},
+						"spacing": {},
+						"typography": {},
+						"custom": {}
+					},
+					"additionalProperties": false
 				}
-			],
-			"propertyNames": {
-				"anyOf": [
-					{ "$ref": "#/definitions/settingsPropertiesNames" },
-					{ "$ref": "#/definitions/settingsBlocksNames" }
-				]
-			}
+			]
 		},
-		"settingsBlocksPropertiesComplete": {
+		"settingsBlocksProperties": {
 			"type": "object",
 			"properties": {
 				"core/archives": {
@@ -583,13 +575,13 @@
 					"additionalProperties": false
 				},
 				"core/audio": {
-					"$ref": "#/definitions/settingsPropertiesNested"
+					"$ref": "#/definitions/settingsPropertiesNestedComplete"
 				},
 				"core/avatar": {
-					"$ref": "#/definitions/settingsPropertiesNested"
+					"$ref": "#/definitions/settingsPropertiesNestedComplete"
 				},
 				"core/block": {
-					"$ref": "#/definitions/settingsPropertiesNested"
+					"$ref": "#/definitions/settingsPropertiesNestedComplete"
 				},
 				"core/button": {
 					"type": "object",
@@ -613,341 +605,475 @@
 								}
 							}
 						},
-						{ "$ref": "#/definitions/settingsPropertiesColor" },
-						{ "$ref": "#/definitions/settingsPropertiesLayout" },
-						{ "$ref": "#/definitions/settingsPropertiesSpacing" },
+						{
+							"$ref": "#/definitions/settingsPropertiesColor"
+						},
+						{
+							"$ref": "#/definitions/settingsPropertiesLayout"
+						},
+						{
+							"$ref": "#/definitions/settingsPropertiesSpacing"
+						},
 						{
 							"$ref": "#/definitions/settingsPropertiesTypography"
 						},
-						{ "$ref": "#/definitions/settingsPropertiesCustom" }
+						{
+							"$ref": "#/definitions/settingsPropertiesCustom"
+						}
 					]
 				},
 				"core/buttons": {
-					"$ref": "#/definitions/settingsPropertiesNested"
+					"$ref": "#/definitions/settingsPropertiesNestedComplete"
 				},
 				"core/calendar": {
-					"$ref": "#/definitions/settingsPropertiesNested"
+					"$ref": "#/definitions/settingsPropertiesNestedComplete"
 				},
 				"core/categories": {
-					"$ref": "#/definitions/settingsPropertiesNested"
+					"$ref": "#/definitions/settingsPropertiesNestedComplete"
 				},
 				"core/code": {
-					"$ref": "#/definitions/settingsPropertiesNested"
+					"$ref": "#/definitions/settingsPropertiesNestedComplete"
 				},
 				"core/column": {
-					"$ref": "#/definitions/settingsPropertiesNested"
+					"$ref": "#/definitions/settingsPropertiesNestedComplete"
 				},
 				"core/columns": {
-					"$ref": "#/definitions/settingsPropertiesNested"
+					"$ref": "#/definitions/settingsPropertiesNestedComplete"
 				},
 				"core/comment-author-name": {
-					"$ref": "#/definitions/settingsPropertiesNested"
+					"$ref": "#/definitions/settingsPropertiesNestedComplete"
 				},
 				"core/comment-content": {
-					"$ref": "#/definitions/settingsPropertiesNested"
+					"$ref": "#/definitions/settingsPropertiesNestedComplete"
 				},
 				"core/comment-date": {
-					"$ref": "#/definitions/settingsPropertiesNested"
+					"$ref": "#/definitions/settingsPropertiesNestedComplete"
 				},
 				"core/comment-edit-link": {
-					"$ref": "#/definitions/settingsPropertiesNested"
+					"$ref": "#/definitions/settingsPropertiesNestedComplete"
 				},
 				"core/comment-reply-link": {
-					"$ref": "#/definitions/settingsPropertiesNested"
+					"$ref": "#/definitions/settingsPropertiesNestedComplete"
 				},
 				"core/comment-template": {
-					"$ref": "#/definitions/settingsPropertiesNested"
+					"$ref": "#/definitions/settingsPropertiesNestedComplete"
 				},
 				"core/comments": {
-					"$ref": "#/definitions/settingsPropertiesNested"
+					"$ref": "#/definitions/settingsPropertiesNestedComplete"
 				},
 				"core/cover": {
-					"$ref": "#/definitions/settingsPropertiesNested"
+					"$ref": "#/definitions/settingsPropertiesNestedComplete"
 				},
 				"core/embed": {
-					"$ref": "#/definitions/settingsPropertiesNested"
+					"$ref": "#/definitions/settingsPropertiesNestedComplete"
 				},
 				"core/file": {
-					"$ref": "#/definitions/settingsPropertiesNested"
+					"$ref": "#/definitions/settingsPropertiesNestedComplete"
 				},
 				"core/freeform": {
-					"$ref": "#/definitions/settingsPropertiesNested"
+					"$ref": "#/definitions/settingsPropertiesNestedComplete"
 				},
 				"core/gallery": {
-					"$ref": "#/definitions/settingsPropertiesNested"
+					"$ref": "#/definitions/settingsPropertiesNestedComplete"
 				},
 				"core/group": {
-					"$ref": "#/definitions/settingsPropertiesNested"
+					"$ref": "#/definitions/settingsPropertiesNestedComplete"
 				},
 				"core/heading": {
-					"$ref": "#/definitions/settingsPropertiesNested"
+					"$ref": "#/definitions/settingsPropertiesNestedComplete"
 				},
 				"core/home-link": {
-					"$ref": "#/definitions/settingsPropertiesNested"
+					"$ref": "#/definitions/settingsPropertiesNestedComplete"
 				},
 				"core/html": {
-					"$ref": "#/definitions/settingsPropertiesNested"
+					"$ref": "#/definitions/settingsPropertiesNestedComplete"
 				},
 				"core/image": {
-					"$ref": "#/definitions/settingsPropertiesNested"
+					"$ref": "#/definitions/settingsPropertiesNestedComplete"
 				},
 				"core/latest-comments": {
-					"$ref": "#/definitions/settingsPropertiesNested"
+					"$ref": "#/definitions/settingsPropertiesNestedComplete"
 				},
 				"core/latest-posts": {
-					"$ref": "#/definitions/settingsPropertiesNested"
+					"$ref": "#/definitions/settingsPropertiesNestedComplete"
 				},
 				"core/list": {
-					"$ref": "#/definitions/settingsPropertiesNested"
+					"$ref": "#/definitions/settingsPropertiesNestedComplete"
 				},
 				"core/loginout": {
-					"$ref": "#/definitions/settingsPropertiesNested"
+					"$ref": "#/definitions/settingsPropertiesNestedComplete"
 				},
 				"core/media-text": {
-					"$ref": "#/definitions/settingsPropertiesNested"
+					"$ref": "#/definitions/settingsPropertiesNestedComplete"
 				},
 				"core/missing": {
-					"$ref": "#/definitions/settingsPropertiesNested"
+					"$ref": "#/definitions/settingsPropertiesNestedComplete"
 				},
 				"core/more": {
-					"$ref": "#/definitions/settingsPropertiesNested"
+					"$ref": "#/definitions/settingsPropertiesNestedComplete"
 				},
 				"core/navigation": {
-					"$ref": "#/definitions/settingsPropertiesNested"
+					"$ref": "#/definitions/settingsPropertiesNestedComplete"
 				},
 				"core/navigation-link": {
-					"$ref": "#/definitions/settingsPropertiesNested"
+					"$ref": "#/definitions/settingsPropertiesNestedComplete"
 				},
 				"core/nextpage": {
-					"$ref": "#/definitions/settingsPropertiesNested"
+					"$ref": "#/definitions/settingsPropertiesNestedComplete"
 				},
 				"core/page-list": {
-					"$ref": "#/definitions/settingsPropertiesNested"
+					"$ref": "#/definitions/settingsPropertiesNestedComplete"
 				},
 				"core/paragraph": {
-					"$ref": "#/definitions/settingsPropertiesNested"
+					"$ref": "#/definitions/settingsPropertiesNestedComplete"
 				},
 				"core/post-author": {
-					"$ref": "#/definitions/settingsPropertiesNested"
+					"$ref": "#/definitions/settingsPropertiesNestedComplete"
 				},
 				"core/post-comments": {
-					"$ref": "#/definitions/settingsPropertiesNested"
+					"$ref": "#/definitions/settingsPropertiesNestedComplete"
 				},
 				"core/post-comments-count": {
-					"$ref": "#/definitions/settingsPropertiesNested"
+					"$ref": "#/definitions/settingsPropertiesNestedComplete"
 				},
 				"core/post-comments-form": {
-					"$ref": "#/definitions/settingsPropertiesNested"
+					"$ref": "#/definitions/settingsPropertiesNestedComplete"
 				},
 				"core/post-comments-link": {
-					"$ref": "#/definitions/settingsPropertiesNested"
+					"$ref": "#/definitions/settingsPropertiesNestedComplete"
 				},
 				"core/post-content": {
-					"$ref": "#/definitions/settingsPropertiesNested"
+					"$ref": "#/definitions/settingsPropertiesNestedComplete"
 				},
 				"core/post-date": {
-					"$ref": "#/definitions/settingsPropertiesNested"
+					"$ref": "#/definitions/settingsPropertiesNestedComplete"
 				},
 				"core/post-excerpt": {
-					"$ref": "#/definitions/settingsPropertiesNested"
+					"$ref": "#/definitions/settingsPropertiesNestedComplete"
 				},
 				"core/post-featured-image": {
-					"$ref": "#/definitions/settingsPropertiesNested"
+					"$ref": "#/definitions/settingsPropertiesNestedComplete"
 				},
 				"core/post-navigation-link": {
-					"$ref": "#/definitions/settingsPropertiesNested"
+					"$ref": "#/definitions/settingsPropertiesNestedComplete"
 				},
 				"core/post-template": {
-					"$ref": "#/definitions/settingsPropertiesNested"
+					"$ref": "#/definitions/settingsPropertiesNestedComplete"
 				},
 				"core/post-terms": {
-					"$ref": "#/definitions/settingsPropertiesNested"
+					"$ref": "#/definitions/settingsPropertiesNestedComplete"
 				},
 				"core/post-title": {
-					"$ref": "#/definitions/settingsPropertiesNested"
+					"$ref": "#/definitions/settingsPropertiesNestedComplete"
 				},
 				"core/preformatted": {
-					"$ref": "#/definitions/settingsPropertiesNested"
+					"$ref": "#/definitions/settingsPropertiesNestedComplete"
 				},
 				"core/pullquote": {
-					"$ref": "#/definitions/settingsPropertiesNested"
+					"$ref": "#/definitions/settingsPropertiesNestedComplete"
 				},
 				"core/query": {
-					"$ref": "#/definitions/settingsPropertiesNested"
+					"$ref": "#/definitions/settingsPropertiesNestedComplete"
 				},
 				"core/query-pagination": {
-					"$ref": "#/definitions/settingsPropertiesNested"
+					"$ref": "#/definitions/settingsPropertiesNestedComplete"
 				},
 				"core/query-pagination-next": {
-					"$ref": "#/definitions/settingsPropertiesNested"
+					"$ref": "#/definitions/settingsPropertiesNestedComplete"
 				},
 				"core/query-pagination-numbers": {
-					"$ref": "#/definitions/settingsPropertiesNested"
+					"$ref": "#/definitions/settingsPropertiesNestedComplete"
 				},
 				"core/query-pagination-previous": {
-					"$ref": "#/definitions/settingsPropertiesNested"
+					"$ref": "#/definitions/settingsPropertiesNestedComplete"
 				},
 				"core/query-title": {
-					"$ref": "#/definitions/settingsPropertiesNested"
+					"$ref": "#/definitions/settingsPropertiesNestedComplete"
 				},
 				"core/quote": {
-					"$ref": "#/definitions/settingsPropertiesNested"
+					"$ref": "#/definitions/settingsPropertiesNestedComplete"
 				},
 				"core/rss": {
-					"$ref": "#/definitions/settingsPropertiesNested"
+					"$ref": "#/definitions/settingsPropertiesNestedComplete"
 				},
 				"core/search": {
-					"$ref": "#/definitions/settingsPropertiesNested"
+					"$ref": "#/definitions/settingsPropertiesNestedComplete"
 				},
 				"core/separator": {
-					"$ref": "#/definitions/settingsPropertiesNested"
+					"$ref": "#/definitions/settingsPropertiesNestedComplete"
 				},
 				"core/shortcode": {
-					"$ref": "#/definitions/settingsPropertiesNested"
+					"$ref": "#/definitions/settingsPropertiesNestedComplete"
 				},
 				"core/site-logo": {
-					"$ref": "#/definitions/settingsPropertiesNested"
+					"$ref": "#/definitions/settingsPropertiesNestedComplete"
 				},
 				"core/site-tagline": {
-					"$ref": "#/definitions/settingsPropertiesNested"
+					"$ref": "#/definitions/settingsPropertiesNestedComplete"
 				},
 				"core/site-title": {
-					"$ref": "#/definitions/settingsPropertiesNested"
+					"$ref": "#/definitions/settingsPropertiesNestedComplete"
 				},
 				"core/social-link": {
-					"$ref": "#/definitions/settingsPropertiesNested"
+					"$ref": "#/definitions/settingsPropertiesNestedComplete"
 				},
 				"core/social-links": {
-					"$ref": "#/definitions/settingsPropertiesNested"
+					"$ref": "#/definitions/settingsPropertiesNestedComplete"
 				},
 				"core/spacer": {
-					"$ref": "#/definitions/settingsPropertiesNested"
+					"$ref": "#/definitions/settingsPropertiesNestedComplete"
 				},
 				"core/table": {
-					"$ref": "#/definitions/settingsPropertiesNested"
+					"$ref": "#/definitions/settingsPropertiesNestedComplete"
 				},
 				"core/table-of-contents": {
-					"$ref": "#/definitions/settingsPropertiesNested"
+					"$ref": "#/definitions/settingsPropertiesNestedComplete"
 				},
 				"core/tag-cloud": {
-					"$ref": "#/definitions/settingsPropertiesNested"
+					"$ref": "#/definitions/settingsPropertiesNestedComplete"
 				},
 				"core/template-part": {
-					"$ref": "#/definitions/settingsPropertiesNested"
+					"$ref": "#/definitions/settingsPropertiesNestedComplete"
 				},
 				"core/term-description": {
-					"$ref": "#/definitions/settingsPropertiesNested"
+					"$ref": "#/definitions/settingsPropertiesNestedComplete"
 				},
 				"core/text-columns": {
-					"$ref": "#/definitions/settingsPropertiesNested"
+					"$ref": "#/definitions/settingsPropertiesNestedComplete"
 				},
 				"core/verse": {
-					"$ref": "#/definitions/settingsPropertiesNested"
+					"$ref": "#/definitions/settingsPropertiesNestedComplete"
 				},
 				"core/video": {
-					"$ref": "#/definitions/settingsPropertiesNested"
+					"$ref": "#/definitions/settingsPropertiesNestedComplete"
 				},
 				"core/widget-area": {
-					"$ref": "#/definitions/settingsPropertiesNested"
+					"$ref": "#/definitions/settingsPropertiesNestedComplete"
 				},
 				"core/legacy-widget": {
-					"$ref": "#/definitions/settingsPropertiesNested"
+					"$ref": "#/definitions/settingsPropertiesNestedComplete"
 				},
 				"core/widget-group": {
-					"$ref": "#/definitions/settingsPropertiesNested"
+					"$ref": "#/definitions/settingsPropertiesNestedComplete"
 				}
 			},
 			"patternProperties": {
 				"^[a-z][a-z0-9-]*/[a-z][a-z0-9-]*$": {
-					"$ref": "#/definitions/settingsPropertiesNested"
+					"$ref": "#/definitions/settingsPropertiesNestedComplete"
 				}
 			}
 		},
-		"settingsBlocksNames": {
-			"enum": [
-				"core/archives",
-				"core/audio",
-				"core/avatar",
-				"core/block",
-				"core/button",
-				"core/buttons",
-				"core/calendar",
-				"core/categories",
-				"core/code",
-				"core/column",
-				"core/columns",
-				"core/comment-author-name",
-				"core/comment-content",
-				"core/comment-date",
-				"core/comment-edit-link",
-				"core/comment-reply-link",
-				"core/comment-template",
-				"core/comments",
-				"core/cover",
-				"core/embed",
-				"core/file",
-				"core/freeform",
-				"core/gallery",
-				"core/group",
-				"core/heading",
-				"core/home-link",
-				"core/html",
-				"core/image",
-				"core/latest-comments",
-				"core/latest-posts",
-				"core/list",
-				"core/loginout",
-				"core/media-text",
-				"core/missing",
-				"core/more",
-				"core/navigation",
-				"core/navigation-link",
-				"core/nextpage",
-				"core/page-list",
-				"core/paragraph",
-				"core/post-author",
-				"core/post-comments",
-				"core/post-comments-count",
-				"core/post-comments-form",
-				"core/post-comments-link",
-				"core/post-content",
-				"core/post-date",
-				"core/post-excerpt",
-				"core/post-featured-image",
-				"core/post-navigation-link",
-				"core/post-template",
-				"core/post-terms",
-				"core/post-title",
-				"core/preformatted",
-				"core/pullquote",
-				"core/query",
-				"core/query-pagination",
-				"core/query-pagination-next",
-				"core/query-pagination-numbers",
-				"core/query-pagination-previous",
-				"core/query-title",
-				"core/quote",
-				"core/rss",
-				"core/search",
-				"core/separator",
-				"core/shortcode",
-				"core/site-logo",
-				"core/site-tagline",
-				"core/site-title",
-				"core/social-link",
-				"core/social-links",
-				"core/spacer",
-				"core/table",
-				"core/table-of-contents",
-				"core/tag-cloud",
-				"core/template-part",
-				"core/term-description",
-				"core/text-columns",
-				"core/verse",
-				"core/video",
-				"core/widget-area",
-				"core/legacy-widget",
-				"core/widget-group"
+		"settingsBlocksPropertiesComplete": {
+			"type": "object",
+			"allOf": [
+				{
+					"$ref": "#/definitions/settingsBlocksProperties"
+				},
+				{
+					"properties": {
+						"core/archives": {},
+						"core/audio": {},
+						"core/avatar": {},
+						"core/block": {},
+						"core/button": {},
+						"core/buttons": {},
+						"core/calendar": {},
+						"core/categories": {},
+						"core/code": {},
+						"core/column": {},
+						"core/columns": {},
+						"core/comment-author-name": {},
+						"core/comment-content": {},
+						"core/comment-date": {},
+						"core/comment-edit-link": {},
+						"core/comment-reply-link": {},
+						"core/comment-template": {},
+						"core/comments": {},
+						"core/cover": {},
+						"core/embed": {},
+						"core/file": {},
+						"core/freeform": {},
+						"core/gallery": {},
+						"core/group": {},
+						"core/heading": {},
+						"core/home-link": {},
+						"core/html": {},
+						"core/image": {},
+						"core/latest-comments": {},
+						"core/latest-posts": {},
+						"core/list": {},
+						"core/loginout": {},
+						"core/media-text": {},
+						"core/missing": {},
+						"core/more": {},
+						"core/navigation": {},
+						"core/navigation-link": {},
+						"core/nextpage": {},
+						"core/page-list": {},
+						"core/paragraph": {},
+						"core/post-author": {},
+						"core/post-comments": {},
+						"core/post-comments-count": {},
+						"core/post-comments-form": {},
+						"core/post-comments-link": {},
+						"core/post-content": {},
+						"core/post-date": {},
+						"core/post-excerpt": {},
+						"core/post-featured-image": {},
+						"core/post-navigation-link": {},
+						"core/post-template": {},
+						"core/post-terms": {},
+						"core/post-title": {},
+						"core/preformatted": {},
+						"core/pullquote": {},
+						"core/query": {},
+						"core/query-pagination": {},
+						"core/query-pagination-next": {},
+						"core/query-pagination-numbers": {},
+						"core/query-pagination-previous": {},
+						"core/query-title": {},
+						"core/quote": {},
+						"core/rss": {},
+						"core/search": {},
+						"core/separator": {},
+						"core/shortcode": {},
+						"core/site-logo": {},
+						"core/site-tagline": {},
+						"core/site-title": {},
+						"core/social-link": {},
+						"core/social-links": {},
+						"core/spacer": {},
+						"core/table": {},
+						"core/table-of-contents": {},
+						"core/tag-cloud": {},
+						"core/template-part": {},
+						"core/term-description": {},
+						"core/text-columns": {},
+						"core/verse": {},
+						"core/video": {},
+						"core/widget-area": {},
+						"core/legacy-widget": {},
+						"core/widget-group": {}
+					},
+					"patternProperties": {
+						"^[a-z][a-z0-9-]*/[a-z][a-z0-9-]*$": {
+							"$ref": "#/definitions/settingsPropertiesComplete"
+						}
+					},
+					"additionalProperties": false
+				}
+			]
+		},
+		"settingsPropertiesNestedComplete": {
+			"type": "object",
+			"allOf": [
+				{
+					"$ref": "#/definitions/settingsProperties"
+				},
+				{
+					"$ref": "#/definitions/settingsBlocksProperties"
+				},
+				{
+					"properties": {
+						"appearanceTools": {},
+						"border": {},
+						"color": {},
+						"layout": {},
+						"spacing": {},
+						"typography": {},
+						"custom": {},
+
+						"core/archives": {},
+						"core/audio": {},
+						"core/avatar": {},
+						"core/block": {},
+						"core/button": {},
+						"core/buttons": {},
+						"core/calendar": {},
+						"core/categories": {},
+						"core/code": {},
+						"core/column": {},
+						"core/columns": {},
+						"core/comment-author-name": {},
+						"core/comment-content": {},
+						"core/comment-date": {},
+						"core/comment-edit-link": {},
+						"core/comment-reply-link": {},
+						"core/comment-template": {},
+						"core/comments": {},
+						"core/cover": {},
+						"core/embed": {},
+						"core/file": {},
+						"core/freeform": {},
+						"core/gallery": {},
+						"core/group": {},
+						"core/heading": {},
+						"core/home-link": {},
+						"core/html": {},
+						"core/image": {},
+						"core/latest-comments": {},
+						"core/latest-posts": {},
+						"core/list": {},
+						"core/loginout": {},
+						"core/media-text": {},
+						"core/missing": {},
+						"core/more": {},
+						"core/navigation": {},
+						"core/navigation-link": {},
+						"core/nextpage": {},
+						"core/page-list": {},
+						"core/paragraph": {},
+						"core/post-author": {},
+						"core/post-comments": {},
+						"core/post-comments-count": {},
+						"core/post-comments-form": {},
+						"core/post-comments-link": {},
+						"core/post-content": {},
+						"core/post-date": {},
+						"core/post-excerpt": {},
+						"core/post-featured-image": {},
+						"core/post-navigation-link": {},
+						"core/post-template": {},
+						"core/post-terms": {},
+						"core/post-title": {},
+						"core/preformatted": {},
+						"core/pullquote": {},
+						"core/query": {},
+						"core/query-pagination": {},
+						"core/query-pagination-next": {},
+						"core/query-pagination-numbers": {},
+						"core/query-pagination-previous": {},
+						"core/query-title": {},
+						"core/quote": {},
+						"core/rss": {},
+						"core/search": {},
+						"core/separator": {},
+						"core/shortcode": {},
+						"core/site-logo": {},
+						"core/site-tagline": {},
+						"core/site-title": {},
+						"core/social-link": {},
+						"core/social-links": {},
+						"core/spacer": {},
+						"core/table": {},
+						"core/table-of-contents": {},
+						"core/tag-cloud": {},
+						"core/template-part": {},
+						"core/term-description": {},
+						"core/text-columns": {},
+						"core/verse": {},
+						"core/video": {},
+						"core/widget-area": {},
+						"core/legacy-widget": {},
+						"core/widget-group": {}
+					},
+					"patternProperties": {
+						"^[a-z][a-z0-9-]*/[a-z][a-z0-9-]*$": {
+							"$ref": "#/definitions/settingsPropertiesComplete"
+						}
+					},
+					"additionalProperties": false
+				}
 			]
 		},
 		"settingsCustomAdditionalProperties": {

--- a/schemas/json/theme.json
+++ b/schemas/json/theme.json
@@ -380,18 +380,25 @@
 									},
 									"fluid": {
 										"description": "Specifics the minimum and maximum font size value of a fluid font size. Set to `false` to bypass fluid calculations and use the static `size` value.",
-										"type": [ "object", "boolean" ],
-										"properties": {
-											"min": {
-												"description": "A min font size for fluid font size calculations in px, rem or em.",
-												"type": "string"
+										"oneOf": [
+											{
+												"type": "object",
+												"properties": {
+													"min": {
+														"description": "A min font size for fluid font size calculations in px, rem or em.",
+														"type": "string"
+													},
+													"max": {
+														"description": "A max font size for fluid font size calculations in px, rem or em.",
+														"type": "string"
+													}
+												},
+												"additionalProperties": false
 											},
-											"max": {
-												"description": "A max font size for fluid font size calculations in px, rem or em.",
-												"type": "string"
+											{
+												"type": "boolean"
 											}
-										},
-										"additionalProperties": false
+										]
 									}
 								},
 								"additionalProperties": false

--- a/schemas/json/theme.json
+++ b/schemas/json/theme.json
@@ -871,6 +871,7 @@
 			}
 		},
 		"stylesProperties": {
+			"type": "object",
 			"properties": {
 				"border": {
 					"description": "Border styles.",

--- a/schemas/json/theme.json
+++ b/schemas/json/theme.json
@@ -8,6 +8,7 @@
 			"reference": "https://developer.wordpress.org/block-editor/how-to-guides/themes/theme-json/"
 		},
 		"settingsPropertiesAppearanceTools": {
+			"type": "object",
 			"properties": {
 				"appearanceTools": {
 					"description": "Setting that enables the following UI tools:\n\n- border: color, radius, style, width\n- color: link\n- spacing: blockGap, margin, padding\n- typography: lineHeight",
@@ -26,6 +27,7 @@
 			}
 		},
 		"settingsPropertiesBorder": {
+			"type": "object",
 			"properties": {
 				"border": {
 					"description": "Settings related to borders.",
@@ -57,6 +59,7 @@
 			}
 		},
 		"settingsPropertiesColor": {
+			"type": "object",
 			"properties": {
 				"color": {
 					"description": "Settings related to colors.",
@@ -186,6 +189,7 @@
 			}
 		},
 		"settingsPropertiesLayout": {
+			"type": "object",
 			"properties": {
 				"layout": {
 					"description": "Settings related to layout.",
@@ -205,6 +209,7 @@
 			}
 		},
 		"settingsPropertiesSpacing": {
+			"type": "object",
 			"properties": {
 				"spacing": {
 					"description": "Settings related to spacing.",
@@ -305,6 +310,7 @@
 			}
 		},
 		"settingsPropertiesTypography": {
+			"type": "object",
 			"properties": {
 				"typography": {
 					"description": "Settings related to typography.",
@@ -515,6 +521,7 @@
 			}
 		},
 		"settingsPropertiesCustom": {
+			"type": "object",
 			"properties": {
 				"custom": {
 					"description": "Generate custom CSS custom properties of the form `--wp--custom--{key}--{nested-key}: {value};`. `camelCased` keys are transformed to `kebab-case` as to follow the CSS property naming schema. Keys at different depth levels are separated by `--`, so keys should not include `--` in the name.",
@@ -570,11 +577,13 @@
 					"$ref": "#/definitions/settingsPropertiesComplete"
 				},
 				"core/button": {
+					"type": "object",
 					"allOf": [
 						{
 							"$ref": "#/definitions/settingsPropertiesAppearanceTools"
 						},
 						{
+							"type": "object",
 							"properties": {
 								"border": {
 									"description": "Settings related to borders.\nGutenberg plugin required.",

--- a/test/integration/theme-schema.test.js
+++ b/test/integration/theme-schema.test.js
@@ -8,11 +8,19 @@ import Ajv from 'ajv-draft-04';
  */
 import themeSchema from '../../schemas/json/theme.json';
 
+const baseThemeJson = {
+	version: 2,
+};
+
 describe( 'theme.json schema', () => {
-	const ajv = new Ajv();
+	const ajv = new Ajv( {
+		// Used for matching unknown blocks without repeating core blocks names
+		// in settings.blocks and settings.styles
+		allowMatchingProperties: true,
+	} );
 
 	test( 'schema valid', () => {
-		const result = ajv.validate( themeSchema, {} ) || ajv.errors;
+		const result = ajv.validate( themeSchema, baseThemeJson ) || ajv.errors;
 
 		expect( result ).toBe( true );
 	} );

--- a/test/integration/theme-schema.test.js
+++ b/test/integration/theme-schema.test.js
@@ -8,19 +8,19 @@ import Ajv from 'ajv';
  */
 import themeSchema from '../../schemas/json/theme.json';
 
-const baseThemeJson = {
-	version: 2,
-};
-
 describe( 'theme.json schema', () => {
 	const ajv = new Ajv( {
 		// Used for matching unknown blocks without repeating core blocks names
-		// in settings.blocks and settings.styles
+		// with patternProperties in settings.blocks and settings.styles
 		allowMatchingProperties: true,
 	} );
 
-	test( 'schema valid', () => {
-		const result = ajv.validate( themeSchema, baseThemeJson ) || ajv.errors;
+	it( 'validates', async () => {
+		const result =
+			ajv.validate(
+				'http://json-schema.org/draft-07/schema#',
+				themeSchema
+			) || ajv.errors;
 
 		expect( result ).toBe( true );
 	} );

--- a/test/integration/theme-schema.test.js
+++ b/test/integration/theme-schema.test.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import Ajv from 'ajv-draft-04';
+import Ajv from 'ajv';
 
 /**
  * Internal dependencies

--- a/test/integration/theme-schema.test.js
+++ b/test/integration/theme-schema.test.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import Ajv from 'ajv';
+import Ajv from 'ajv-draft-04';
 
 /**
  * Internal dependencies
@@ -15,13 +15,9 @@ describe( 'theme.json schema', () => {
 		allowMatchingProperties: true,
 	} );
 
-	it( 'validates', async () => {
-		const result =
-			ajv.validate(
-				'http://json-schema.org/draft-07/schema#',
-				themeSchema
-			) || ajv.errors;
+	it( 'compiles in strict mode', async () => {
+		const result = ajv.compile( themeSchema );
 
-		expect( result ).toBe( true );
+		expect( result.errors ).toBe( null );
 	} );
 } );

--- a/test/integration/theme-schema.test.js
+++ b/test/integration/theme-schema.test.js
@@ -1,0 +1,19 @@
+/**
+ * External dependencies
+ */
+import Ajv from 'ajv-draft-04';
+
+/**
+ * Internal dependencies
+ */
+import themeSchema from '../../schemas/json/theme.json';
+
+describe( 'theme.json schema', () => {
+	const ajv = new Ajv();
+
+	test( 'schema valid', () => {
+		const result = ajv.validate( themeSchema, {} ) || ajv.errors;
+
+		expect( result ).toBe( true );
+	} );
+} );


### PR DESCRIPTION
This PR contains the schema updates to theme.json used in the block nesting implementation in https://github.com/WordPress/gutenberg/pull/43796. That PR allows for nesting blocks in theme.json like this:

```js
// theme.json → settings
"blocks": {
    "core/child-block": {
        "color": {
            "text": false,
        },
    },
    "core/parent-block": {
        "core/child-block": {
            "color": {
                "text": true,
            },
        },
    },
},
```

With the setup above, a `core/child-block` will have `color.text === true` when nested in a `core/parent-block`. We've added this as a separate PR, since these schema changes are a bit more controversial and might be a different discussion.

## What?

There are a handful of related changes bundled here:

1. Add schema validation in `theme-schema.test.js` based on existing [block schema tests](https://github.com/WordPress/gutenberg/blob/trunk/test/integration/blocks-schema.test.js). The existing schema failed validation with [Ajv's strict mode](https://ajv.js.org/strict-mode.html) against `draft-04`, mostly due to some missing `type` identifiers and a handful of other small changes.
2. Fix the existing strict mode errors.
3. Update the schema to support nested block settings.
4. Update relevant docs related to the schema.

## Why?

Block nesting support has been added to support the `theme.json` parsing and block editor changes in https://github.com/WordPress/gutenberg/pull/43796.

While we were updating the schema, it seemed like a good idea to put the existing `schemas/json/theme.json` file under test to ensure nothing was getting broken. Since the existing schema did not pass Ajv's `draft-04` validation, some minor changes were made to fix the errors. These are covered in the **How** section.

## How

### Validation changes

As discussed above, some minor changes were made to the original schema to make it validate correctly against `draft-04`. To view the original errors, check out the [`add/theme-schema-updates-and-docs` branch of the related fork](https://github.com/alecgeatches/gutenberg/pull/11) and use the `7bc6ee9` commit to view the original errors. Running the test gives this validation result:

<details>
  
<summary>Click to expand</summary>
  
```bash
$ npx wp-scripts test-unit-js --config test/unit/jest.config.js --no-cache theme-schema.test.js
 FAIL  test/integration/theme-schema.test.js
  ● theme.json schema › schema valid

    strict mode: property core/archives matches pattern ^[a-z][a-z0-9-]*/[a-z][a-z0-9-]*$ (use allowMatchingProperties)

      13 |
      14 |      test( 'schema valid', () => {
    > 15 |              const result = ajv.validate( themeSchema, {} ) || ajv.errors;
         |                                 ^
      16 |
      17 |              expect( result ).toBe( true );
      18 |      } );

      at checkStrictMode (node_modules/ajv/lib/compile/util.ts:211:28)
      at checkMatchingProperties (node_modules/ajv/lib/vocabularies/applicator/patternProperties.ts:54:26)
      at validatePatternProperties (node_modules/ajv/lib/vocabularies/applicator/patternProperties.ts:40:30)
      ...
      at Ajv.compile (node_modules/ajv/lib/core.ts:370:34)
      at Ajv.validate (node_modules/ajv/lib/core.ts:346:16)
      at Object.<anonymous> (test/integration/theme-schema.test.js:15:22)
          at runMicrotasks (<anonymous>)

  ● theme.json schema › schema valid

    expect(jest.fn()).not.toHaveWarned(expected)

    Expected mock function not to be called but it was called with:
    ["strict mode: missing type \"object\" for keyword \"properties\" at \"#/definitions/settingsPropertiesAppearanceTools\" (strictTypes)"]
    ["strict mode: missing type \"object\" for keyword \"properties\" at \"#/definitions/settingsPropertiesBorder\" (strictTypes)"]
    ["strict mode: missing type \"object\" for keyword \"properties\" at \"#/definitions/settingsPropertiesColor\" (strictTypes)"]
    ["strict mode: missing type \"object\" for keyword \"properties\" at \"#/definitions/settingsPropertiesLayout\" (strictTypes)"]
    ["strict mode: missing type \"object\" for keyword \"properties\" at \"#/definitions/settingsPropertiesSpacing\" (strictTypes)"]
    ["strict mode: missing type \"object\" for keyword \"properties\" at \"#/definitions/settingsPropertiesTypography\" (strictTypes)"]
    ["strict mode: use allowUnionTypes to allow union type keyword at \"#/definitions/settingsPropertiesTypography/properties/typography/properties/fontSizes/items/properties/fluid\" (strictTypes)"]
    ["strict mode: type \"integer\" not allowed by context \"string\" at \"#/definitions/settingsPropertiesTypography/properties/typography/properties/fontFamilies/items/properties/fontFace/items/properties/fontWeight/oneOf/1\" (strictTypes)"]
    ["strict mode: missing type \"object\" for keyword \"properties\" at \"#\" (strictTypes)"]
    ["strict mode: missing type \"object\" for keyword \"additionalProperties\" at \"#/properties/core~1archives\" (strictTypes)"]
    ["strict mode: missing type \"object\" for keyword \"properties\" at \"#/definitions/settingsPropertiesAppearanceTools\" (strictTypes)"]
    ["strict mode: missing type \"object\" for keyword \"properties\" at \"#/properties/core~1button/allOf/1\" (strictTypes)"]
    ["strict mode: missing type \"object\" for keyword \"properties\" at \"#/definitions/settingsPropertiesColor\" (strictTypes)"]
    ["strict mode: missing type \"object\" for keyword \"properties\" at \"#/definitions/settingsPropertiesLayout\" (strictTypes)"]
    ["strict mode: missing type \"object\" for keyword \"properties\" at \"#/definitions/settingsPropertiesSpacing\" (strictTypes)"]
    ["strict mode: missing type \"object\" for keyword \"properties\" at \"#/definitions/settingsPropertiesTypography\" (strictTypes)"]
    ["strict mode: use allowUnionTypes to allow union type keyword at \"#/definitions/settingsPropertiesTypography/properties/typography/properties/fontSizes/items/properties/fluid\" (strictTypes)"]
    ["strict mode: type \"integer\" not allowed by context \"string\" at \"#/definitions/settingsPropertiesTypography/properties/typography/properties/fontFamilies/items/properties/fontFace/items/properties/fontWeight/oneOf/1\" (strictTypes)"]

      30 |      function assertExpectedCalls() {
      31 |              if ( spy.assertionsNumber === 0 && spy.mock.calls.length > 0 ) {
    > 32 |                      expect( console ).not[ matcherName ]();
         |                      ^
      33 |              }
      34 |      }
      35 |

      at Object.assertExpectedCalls (packages/jest-console/src/index.js:32:4)
          at runMicrotasks (<anonymous>)
      at TestScheduler.scheduleTests (node_modules/@jest/core/build/TestScheduler.js:333:13)
      at runJest (node_modules/@jest/core/build/runJest.js:404:19)
      at _run10000 (node_modules/@jest/core/build/cli/index.js:320:7)
      at runCLI (node_modules/@jest/core/build/cli/index.js:173:3)

Test Suites: 1 failed, 1 total
Tests:       1 failed, 1 total
Snapshots:   0 total
Time:        2.093 s
Ran all test suites matching /theme-schema.test.js/i.
```
  
</details>

Those individual fixes are documented in these commits:

1. [Fix missing property object types](https://github.com/alecgeatches/gutenberg/pull/11/commits/ce7e75abba02817a4b1495ea146f275fcbd7b182) for errors like:

    ```
    strict mode: missing type "object" for keyword "properties" at "#/definitions/settingsPropertiesAppearanceTools" (strictTypes)
    ```
2. [Remove type conflict in fontWeight](https://github.com/alecgeatches/gutenberg/pull/11/commits/66bf0b8e6e3afa8ba23f6ddb4d6fe6a3b8deb47c) for this error:

    ```
    strict mode: type "integer" not allowed by context "string" at "#/definitions/settingsPropertiesTypography/properties/typography/properties/fontFamilies/items/properties/fontFace/items/properties/fontWeight/oneOf/1" (strictTypes)
    ```
3. [Refactor fontSizes.fluid into non-union type](https://github.com/alecgeatches/gutenberg/pull/11/commits/5700764827356bfaee1e201c2d3eb7ec151a5716) for this error:

    ```
    strict mode: use allowUnionTypes to allow union type keyword at "#/definitions/settingsPropertiesTypography/properties/typography/properties/fontSizes/items/properties/fluid" (strictTypes)
    ```
4. [Fix core/archives non-property block having additionalProperties: false](https://github.com/alecgeatches/gutenberg/pull/11/commits/6095a7ab7210ae9ebb3f119283c8c0a1d6886d58) for this error:

    ```
    strict mode: missing type "object" for keyword "additionalProperties" at "#/properties/core/archives" (strictTypes)
    ```
5. Some additional fixes in [Fix stylesProperties type](https://github.com/alecgeatches/gutenberg/pull/11/commits/cd3e2b33f501bb11d8c4f99cd32d3f9977b2b4c4) and [Fix styleProperties border direction properties](https://github.com/alecgeatches/gutenberg/pull/11/commits/441f338b6a09d65f9312923662edda49d7757e8c) that cropped up after the previous fixes, mostly addressing additional `properties` object types missing. This also fixes the `border` [autogenerated documentation](https://github.com/alecgeatches/gutenberg/blob/add/theme-schema-updates-and-docs/docs/reference-guides/theme-json-reference/theme-json-living.md#border-1) for `top`/`bottom`/`left`/`right`.

<div id="nested-styling-changes"></div>

### Nested styling changes

To support nested styling, some new definitions were added:

1. `settingsBlocksPropertiesComplete` now wraps a `settingsBlocksProperties` definition using the style mentioned [in the current PR by @ajlende](https://github.com/WordPress/gutenberg/pull/43801#pullrequestreview-1095163035).
2. `settingsNestedPropertiesComplete` was added, which wraps `settingsProperties` and `settingsBlocksProperties`.
3. In `settingsBlocksProperties`, blocks which support nesting [use `settingsNestedPropertiesComplete`](https://github.com/WordPress/gutenberg/pull/43801/commits/7749202fc687d5e91206707ba430d4e13238ee5d), and all other core blocks default to using `settingsProperties`.

There is some duplication due to `draft-04` compatibility. For example, the `core/archives` block settings definitions are repeated in these places:

- `settingsBlocksProperties` (used by `settingsBlocksPropertiesComplete` and `settingsNestedPropertiesComplete`).
- `settingsBlocksPropertiesComplete` (used by the top level `settings.blocks` definition)
- `settingsNestedPropertiesComplete` (used by blocks that support nesting)

As far as we're aware, this is the most succinct way to represent these nested properties in `draft-04`. The previous version of this PR used `draft-07` and `propertyNames`, but after discussion with @ajlende it's been rewritten to be `draft-04` compatible.

## Testing Instructions

To test theme validation, run:

```bash
npx wp-scripts test-unit-js --config test/unit/jest.config.js --no-cache theme-schema.test.js
```

Schema changes are manually testable by editing an existing theme.json file and setting the schema to the new `theme.json` schema in this branch:

```js
{
	"$schema": "/<full-path-to>/gutenberg/schemas/json/theme.json",
	"version": 2,
	"settings": {
            /* ... */
        }
}
```

## Screenshots or screencast

Here's a quick demo showing nested block settings working with the `draft-07` schema with autocompletion in VS Code:

https://user-images.githubusercontent.com/17870752/188370303-d5d2aca6-9ba7-4eeb-be32-c61f3168b526.mp4