### PR TITLE
Try: Polish link/unlink buttons

### DIFF
--- a/packages/block-editor/src/components/border-radius-control/linked-button.js
+++ b/packages/block-editor/src/components/border-radius-control/linked-button.js
@@ -6,20 +6,20 @@ import { link, linkOff } from '@wordpress/icons';
 import { __ } from '@wordpress/i18n';
 
 export default function LinkedButton( { isLinked, ...props } ) {
-	const label = isLinked ? __( 'Unlink Radii' ) : __( 'Link Radii' );
+	const label = isLinked ? __( 'Unlink radii' ) : __( 'Link radii' );
 
 	return (
 		<Tooltip text={ label }>
-			<Button
-				{ ...props }
-				className="component-border-radius-control__linked-button"
-				isPrimary={ isLinked }
-				isSecondary={ ! isLinked }
-				isSmall
-				icon={ isLinked ? link : linkOff }
-				iconSize={ 16 }
-				aria-label={ label }
-			/>
+			<span>
+				<Button
+					{ ...props }
+					className="component-border-radius-control__linked-button"
+					isSmall
+					icon={ isLinked ? link : linkOff }
+					iconSize={ 24 }
+					aria-label={ label }
+				/>
+			</span>
 		</Tooltip>
 	);
 }

--- a/packages/block-editor/src/components/border-radius-control/linked-button.js
+++ b/packages/block-editor/src/components/border-radius-control/linked-button.js
@@ -8,6 +8,7 @@ import { __ } from '@wordpress/i18n';
 export default function LinkedButton( { isLinked, ...props } ) {
 	const label = isLinked ? __( 'Unlink radii' ) : __( 'Link radii' );
 
+	// TODO: Remove span after merging https://github.com/WordPress/gutenberg/pull/44198
 	return (
 		<Tooltip text={ label }>
 			<span>

--- a/packages/block-editor/src/components/spacing-sizes-control/linked-button.js
+++ b/packages/block-editor/src/components/spacing-sizes-control/linked-button.js
@@ -6,16 +6,15 @@ import { __ } from '@wordpress/i18n';
 import { Button, Tooltip } from '@wordpress/components';
 
 export default function LinkedButton( { isLinked, onClick } ) {
-	const label = isLinked ? __( 'Unlink Sides' ) : __( 'Link Sides' );
+	const label = isLinked ? __( 'Unlink sides' ) : __( 'Link sides' );
 
 	return (
 		<Tooltip text={ label }>
 			<span className="component-spacing-sizes-control__linked-button">
 				<Button
-					variant={ isLinked ? 'primary' : 'secondary' }
 					isSmall
 					icon={ isLinked ? link : linkOff }
-					iconSize={ 16 }
+					iconSize={ 24 }
 					aria-label={ label }
 					onClick={ onClick }
 				/>

--- a/packages/block-editor/src/components/spacing-sizes-control/style.scss
+++ b/packages/block-editor/src/components/spacing-sizes-control/style.scss
@@ -46,8 +46,11 @@
 		grid-column: 2 / 2;
 		grid-row: 1 / 1;
 		justify-self: end;
-		margin-right: $grid-unit-05;
 		padding: 0;
+	}
+
+	.component-spacing-sizes-control__linked-button ~ .components-spacing-sizes-control__custom-toggle-all {
+		margin-right: $grid-unit-05;
 	}
 
 	.components-spacing-sizes-control__custom-toggle-single {

--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Bug Fix
+
+-   The `LinkedButton` to unlink sides in `BoxControl`, `BorderBoxControl` and `BorderRadiusControl` have changed from a rectangular primary button to an icon-only button, with a sentence case tooltip, and default-size icon for better legibility. The `Button` component has been fixed so when `isSmall` and `icon` props are set, and no text is present, the button shape is square rather than rectangular.
+
 ### New Features
 
 -   `Popover`: added new `anchor` prop, supposed to supersede all previous anchor-related props (`anchorRef`, `anchorRect`, `getAnchorRect`). These older anchor-related props are now marked as deprecated and are scheduled to be removed in WordPress 6.3 ([#43691](https://github.com/WordPress/gutenberg/pull/43691)).

--- a/packages/components/src/border-box-control/border-box-control-linked-button/component.tsx
+++ b/packages/components/src/border-box-control/border-box-control-linked-button/component.tsx
@@ -28,10 +28,9 @@ const BorderBoxControlLinkedButton = (
 			<View className={ className }>
 				<Button
 					{ ...buttonProps }
-					variant={ isLinked ? 'primary' : 'secondary' }
 					isSmall
 					icon={ isLinked ? link : linkOff }
-					iconSize={ 16 }
+					iconSize={ 24 }
 					aria-label={ label }
 					ref={ forwardedRef }
 				/>

--- a/packages/components/src/border-box-control/styles.ts
+++ b/packages/components/src/border-box-control/styles.ts
@@ -23,7 +23,8 @@ export const BorderBoxControlLinkedButton = (
 ) => {
 	return css`
 		flex: 0;
-		flex-basis: 36px;
+		flex-basis: 24px;
+		line-height: 22px;
 		margin-top: ${ __next36pxDefaultSize ? '6px' : '3px' };
 	`;
 };

--- a/packages/components/src/border-box-control/styles.ts
+++ b/packages/components/src/border-box-control/styles.ts
@@ -24,7 +24,7 @@ export const BorderBoxControlLinkedButton = (
 	return css`
 		flex: 0;
 		flex-basis: 24px;
-		line-height: 22px;
+		line-height: 0;
 		margin-top: ${ __next36pxDefaultSize ? '6px' : '3px' };
 	`;
 };

--- a/packages/components/src/box-control/linked-button.js
+++ b/packages/components/src/box-control/linked-button.js
@@ -11,7 +11,7 @@ import Button from '../button';
 import Tooltip from '../tooltip';
 
 export default function LinkedButton( { isLinked, ...props } ) {
-	const label = isLinked ? __( 'Unlink Sides' ) : __( 'Link Sides' );
+	const label = isLinked ? __( 'Unlink sides' ) : __( 'Link sides' );
 
 	return (
 		<Tooltip text={ label }>
@@ -19,10 +19,9 @@ export default function LinkedButton( { isLinked, ...props } ) {
 				<Button
 					{ ...props }
 					className="component-box-control__linked-button"
-					variant={ isLinked ? 'primary' : 'secondary' }
 					isSmall
 					icon={ isLinked ? link : linkOff }
-					iconSize={ 16 }
+					iconSize={ 24 }
 					aria-label={ label }
 				/>
 			</span>

--- a/packages/components/src/box-control/linked-button.js
+++ b/packages/components/src/box-control/linked-button.js
@@ -13,16 +13,19 @@ import Tooltip from '../tooltip';
 export default function LinkedButton( { isLinked, ...props } ) {
 	const label = isLinked ? __( 'Unlink sides' ) : __( 'Link sides' );
 
+	// TODO: Remove span after merging https://github.com/WordPress/gutenberg/pull/44198
 	return (
 		<Tooltip text={ label }>
-			<Button
-				{ ...props }
-				className="component-box-control__linked-button"
-				isSmall
-				icon={ isLinked ? link : linkOff }
-				iconSize={ 24 }
-				aria-label={ label }
-			/>
+			<span>
+				<Button
+					{ ...props }
+					className="component-box-control__linked-button"
+					isSmall
+					icon={ isLinked ? link : linkOff }
+					iconSize={ 24 }
+					aria-label={ label }
+				/>
+			</span>
 		</Tooltip>
 	);
 }

--- a/packages/components/src/box-control/linked-button.js
+++ b/packages/components/src/box-control/linked-button.js
@@ -15,16 +15,14 @@ export default function LinkedButton( { isLinked, ...props } ) {
 
 	return (
 		<Tooltip text={ label }>
-			<span>
-				<Button
-					{ ...props }
-					className="component-box-control__linked-button"
-					isSmall
-					icon={ isLinked ? link : linkOff }
-					iconSize={ 24 }
-					aria-label={ label }
-				/>
-			</span>
+			<Button
+				{ ...props }
+				className="component-box-control__linked-button"
+				isSmall
+				icon={ isLinked ? link : linkOff }
+				iconSize={ 24 }
+				aria-label={ label }
+			/>
 		</Tooltip>
 	);
 }

--- a/packages/components/src/box-control/test/index.js
+++ b/packages/components/src/box-control/test/index.js
@@ -162,7 +162,7 @@ describe( 'BoxControl', () => {
 		} );
 	} );
 
-	describe( 'Unlinked Sides', () => {
+	describe( 'Unlinked sides', () => {
 		it( 'should update a single side value when unlinked', async () => {
 			let state = {};
 			const setState = ( newState ) => ( state = newState );
@@ -174,7 +174,7 @@ describe( 'BoxControl', () => {
 				/>
 			);
 			const user = setupUser();
-			const unlink = screen.getByLabelText( /Unlink Sides/ );
+			const unlink = screen.getByLabelText( /Unlink sides/ );
 
 			await user.click( unlink );
 
@@ -207,7 +207,7 @@ describe( 'BoxControl', () => {
 				/>
 			);
 			const user = setupUser();
-			const unlink = screen.getByLabelText( /Unlink Sides/ );
+			const unlink = screen.getByLabelText( /Unlink sides/ );
 
 			await user.click( unlink );
 
@@ -240,7 +240,7 @@ describe( 'BoxControl', () => {
 			await user.selectOptions( allUnitSelect, [ 'em' ] );
 
 			// Unlink the controls.
-			await user.click( screen.getByLabelText( /Unlink Sides/ ) );
+			await user.click( screen.getByLabelText( /Unlink sides/ ) );
 
 			// Confirm that each individual control has the selected unit
 			const unlinkedSelects = screen.getAllByDisplayValue( 'em' );
@@ -257,7 +257,7 @@ describe( 'BoxControl', () => {
 			await user.selectOptions( allUnitSelect, [ 'vw' ] );
 
 			// Unlink the controls.
-			await user.click( screen.getByLabelText( /Unlink Sides/ ) );
+			await user.click( screen.getByLabelText( /Unlink sides/ ) );
 
 			// Confirm that each individual control has the selected unit
 			const unlinkedSelects = screen.getAllByDisplayValue( 'vw' );

--- a/packages/components/src/button/style.scss
+++ b/packages/components/src/button/style.scss
@@ -288,14 +288,15 @@
 	}
 
 	&.is-small {
-		height: 24px;
+		height: $icon-size;
 		line-height: 22px;
-		padding: 0 8px;
+		padding: 0;
 		font-size: 11px;
 
 		&.has-icon:not(.has-text) {
-			padding: 0 8px;
-			width: 24px;
+			padding: 0;
+			width: $icon-size;
+			min-width: $icon-size;
 		}
 	}
 

--- a/packages/components/src/button/style.scss
+++ b/packages/components/src/button/style.scss
@@ -290,7 +290,7 @@
 	&.is-small {
 		height: $icon-size;
 		line-height: 22px;
-		padding: 0;
+		padding: 0 8px;
 		font-size: 11px;
 
 		&.has-icon:not(.has-text) {


### PR DESCRIPTION
## What?

The link/unlink buttons used across the interface are blue, rectangular, and uses a scaled and blurry/illegible icon:

![before](https://user-images.githubusercontent.com/1204802/188103583-50fec796-1690-414f-9d7b-82d21aa56d69.gif)

This PR changes those to be plain 24x24 icon buttons toggles:

<img width="300" alt="Screenshot 2022-09-02 at 10 53 34" src="https://user-images.githubusercontent.com/1204802/188103697-2e89bf8d-526d-445f-8520-4c942aa872cd.png">

![after](https://user-images.githubusercontent.com/1204802/188103703-e0c78924-065b-4e76-9de3-7fe2b075cce3.gif)

## Why?

Instead of having a separate style just for link/unlink buttons, this focuses in on an existing icon button style already in use, it reduces prominence, and it makes the icon more legible.

## How?

The PR changes the style of the buttons in a few places, and it touches some legacy inherited CSS. It seems like there's an opportunity for a singular link/unlink component, but this at least takes some steps towards it.

## Testing Instructions

Please test border, radius, padding controls and observe the link/unlink button being correctly scaled (24x24) and positioned.

Because this touches on some older styles for "small" buttons, it would be good to look up any instances of _buttons with text that use the isSmall prop_, and see that those still look correct.