### PR TITLE
ListViewBlock: refactor to have locking data in a single place

### DIFF
--- a/packages/block-editor/src/components/block-lock/use-block-lock.js
+++ b/packages/block-editor/src/components/block-lock/use-block-lock.js
@@ -25,6 +25,7 @@ export default function useBlockLock( clientId ) {
 				canLockBlockType,
 				getBlockName,
 				getBlockRootClientId,
+				getTemplateLock,
 			} = select( blockEditorStore );
 			const rootClientId = getBlockRootClientId( clientId );
 
@@ -37,6 +38,7 @@ export default function useBlockLock( clientId ) {
 				canMove,
 				canRemove,
 				canLock: canLockBlockType( getBlockName( clientId ) ),
+				isContentLocked: getTemplateLock( clientId ) === 'noContent',
 				isLocked: ! canEdit || ! canMove || ! canRemove,
 			};
 		},

--- a/packages/block-editor/src/components/list-view/block.js
+++ b/packages/block-editor/src/components/list-view/block.js
@@ -67,15 +67,8 @@ function ListViewBlock( {
 	const { toggleBlockHighlight } = useDispatch( blockEditorStore );
 
 	const blockInformation = useBlockDisplayInformation( clientId );
-	const { isContentLocked, blockName } = useSelect(
-		( select ) => {
-			const { getBlockName, getTemplateLock } =
-				select( blockEditorStore );
-			return {
-				blockName: getBlockName( clientId ),
-				isContentLocked: getTemplateLock( clientId ) === 'noContent',
-			};
-		},
+	const blockName = useSelect(
+		( select ) => select( blockEditorStore ).getBlockName( clientId ),
 		[ clientId ]
 	);
 
@@ -87,7 +80,7 @@ function ListViewBlock( {
 		'__experimentalToolbar',
 		true
 	);
-	const { isLocked } = useBlockLock( clientId );
+	const { isLocked, isContentLocked } = useBlockLock( clientId );
 	const instanceId = useInstanceId( ListViewBlock );
 	const descriptionId = `list-view-block-select-button__${ instanceId }`;
 	const blockPositionDescription = getBlockPositionDescription(


### PR DESCRIPTION
Follow-up to https://github.com/WordPress/gutenberg/pull/43037

This PR groups refactors the ListViewBlock cod to get the locking data of the block into a single hook. No behavioral changes from the original PR.

## Testing instructions

See the original PR. Verify that the list view still works as expected:

- only the locking parent is visible is the lock is active
- all the blocks are visible if the user is editing the blocks
