### PR TITLE
Edit navigation: use Popover's new anchor prop

### DIFF
--- a/packages/edit-navigation/src/components/header/menu-actions.js
+++ b/packages/edit-navigation/src/components/header/menu-actions.js
@@ -7,7 +7,7 @@ import {
 	__experimentalText as Text,
 } from '@wordpress/components';
 import { chevronDown } from '@wordpress/icons';
-import { useRef } from '@wordpress/element';
+import { useCallback, useState } from '@wordpress/element';
 import { decodeEntities } from '@wordpress/html-entities';
 
 /**
@@ -19,11 +19,15 @@ import { useMenuEntityProp, useSelectedMenuId } from '../../hooks';
 export default function MenuActions( { menus, isLoading } ) {
 	const [ selectedMenuId, setSelectedMenuId ] = useSelectedMenuId();
 	const [ menuName ] = useMenuEntityProp( 'name', selectedMenuId );
+	const [ popoverAnchor, setPopoverAnchor ] = useState();
 
 	// The title ref is passed to the popover as the anchorRef so that the
 	// dropdown is centered over the whole title area rather than just one
 	// part of it.
-	const titleRef = useRef();
+	const titleCallbackRef = useCallback( ( node ) => {
+		// The popover `anchor` prop can not be `null`.
+		setPopoverAnchor( node ?? undefined );
+	}, [] );
 
 	if ( isLoading ) {
 		return (
@@ -36,7 +40,7 @@ export default function MenuActions( { menus, isLoading } ) {
 	return (
 		<div className="edit-navigation-menu-actions">
 			<div
-				ref={ titleRef }
+				ref={ titleCallbackRef }
 				className="edit-navigation-menu-actions__subtitle-wrapper"
 			>
 				<Text
@@ -63,7 +67,7 @@ export default function MenuActions( { menus, isLoading } ) {
 						className:
 							'edit-navigation-menu-actions__switcher-dropdown',
 						position: 'bottom center',
-						anchorRef: titleRef.current,
+						anchor: popoverAnchor,
 					} }
 				>
 					{ ( { onClose } ) => (


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Refactor the way the MenuActions components in the Edit Navigation package passes an anchor to Popover, using the new `anchor` prop

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

See #43691 for more context

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

- Swap `anchorRef` with `anchor`
- Make sure that `undefined` is used instead of `null` for the `anchor` prop
- Use callback ref + internal state to make sure that the component re-renders when the anchor updates

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->

It's the first time I work on the `edit-navigation` package and I'm not quite sure how to find this piece of UI in gutenberg, maybe folks can help out here.
