### PR TITLE
Plugin: Remove 'gutenberg_rest_nonce' method

### DIFF
--- a/lib/init.php
+++ b/lib/init.php
@@ -57,11 +57,3 @@ function gutenberg_menu() {
 	);
 }
 add_action( 'admin_menu', 'gutenberg_menu', 9 );
-
-/**
- * Outputs a WP REST API nonce.
- */
-function gutenberg_rest_nonce() {
-	exit( wp_create_nonce( 'wp_rest' ) );
-}
-add_action( 'wp_ajax_gutenberg_rest_nonce', 'gutenberg_rest_nonce' );


### PR DESCRIPTION
## What?
PR removes unused `gutenberg_rest_nonce` method.

## Why?
I don't think this AJAX callback has been used since #19178. The core version of it ([`wp_ajax_rest_nonce`](https://developer.wordpress.org/reference/functions/wp_ajax_rest_nonce/)) was introduced in WP 5.3

## Testing Instructions
Doesn't affect anything. Just removing dead code.
