### PR TITLE
Remove leftovers from previous iterations in block inspector

### DIFF
--- a/packages/block-editor/src/components/block-card/index.js
+++ b/packages/block-editor/src/components/block-card/index.js
@@ -8,7 +8,7 @@ import deprecated from '@wordpress/deprecated';
  */
 import BlockIcon from '../block-icon';
 
-function BlockCard( { title, icon, description, blockType, backButton } ) {
+function BlockCard( { title, icon, description, blockType } ) {
 	if ( blockType ) {
 		deprecated( '`blockType` property in `BlockCard component`', {
 			since: '5.7',
@@ -18,7 +18,7 @@ function BlockCard( { title, icon, description, blockType, backButton } ) {
 	}
 	return (
 		<div className="block-editor-block-card">
-			{ backButton ? backButton : <BlockIcon icon={ icon } showColors /> }
+			<BlockIcon icon={ icon } showColors />
 			<div className="block-editor-block-card__content">
 				<h2 className="block-editor-block-card__title">{ title }</h2>
 				<span className="block-editor-block-card__description">

--- a/packages/block-editor/src/components/block-inspector/index.js
+++ b/packages/block-editor/src/components/block-inspector/index.js
@@ -145,22 +145,18 @@ const BlockInspector = ( { showNoBlockSelectedMessage = true } ) => {
 			__unstableGetContentLockingParent,
 			getTemplateLock,
 		} = select( blockEditorStore );
-		const { getBlockStyles } = select( blocksStore );
 
 		const _selectedBlockClientId = getSelectedBlockClientId();
 		const _selectedBlockName =
 			_selectedBlockClientId && getBlockName( _selectedBlockClientId );
 		const _blockType =
 			_selectedBlockName && getBlockType( _selectedBlockName );
-		const blockStyles =
-			_selectedBlockName && getBlockStyles( _selectedBlockName );
 
 		return {
 			count: getSelectedBlockCount(),
 			selectedBlockClientId: _selectedBlockClientId,
 			selectedBlockName: _selectedBlockName,
 			blockType: _blockType,
-			hasBlockStyles: blockStyles && blockStyles.length > 0,
 			topLevelLockedBlock:
 				getTemplateLock( _selectedBlockClientId ) === 'noContent'
 					? _selectedBlockClientId

--- a/packages/block-editor/src/components/block-inspector/index.js
+++ b/packages/block-editor/src/components/block-inspector/index.js
@@ -232,7 +232,7 @@ const BlockInspector = ( { showNoBlockSelectedMessage = true } ) => {
 	);
 };
 
-const BlockInspectorSingleBlock = ( { clientId, blockName, backButton } ) => {
+const BlockInspectorSingleBlock = ( { clientId, blockName } ) => {
 	const hasBlockStyles = useSelect(
 		( select ) => {
 			const { getBlockStyles } = select( blocksStore );
@@ -244,7 +244,7 @@ const BlockInspectorSingleBlock = ( { clientId, blockName, backButton } ) => {
 	const blockInformation = useBlockDisplayInformation( clientId );
 	return (
 		<div className="block-editor-block-inspector">
-			<BlockCard backButton={ backButton } { ...blockInformation } />
+			<BlockCard { ...blockInformation } />
 			<BlockVariationTransforms blockClientId={ clientId } />
 			{ hasBlockStyles && (
 				<div>

--- a/packages/block-editor/src/components/block-inspector/style.scss
+++ b/packages/block-editor/src/components/block-inspector/style.scss
@@ -40,11 +40,3 @@
 	border-top: $border-width solid $gray-200;
 	padding: $grid-unit-20;
 }
-
-.block-editor-block-inspector__block-type-type {
-	font-weight: 500;
-	&.block-editor-block-inspector__block-type-type {
-		line-height: $button-size-small;
-		margin: 0 0 $grid-unit-05;
-	}
-}


### PR DESCRIPTION
Follow-up to https://github.com/WordPress/gutenberg/pull/43037

The original PR went through a few iterations and, by the time it was merged, there were some leftovers of previous ideas we no longer need. This PR removes them.

## How to test

See testing instructions in the original PR. Verify that the inspector still works as intended.
