### PR TITLE
Lodash: Refactor away from `_.forEach()`

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -103,6 +103,7 @@ module.exports = {
 							'flatMap',
 							'flatten',
 							'flattenDeep',
+							'forEach',
 							'fromPairs',
 							'has',
 							'identity',

--- a/packages/babel-plugin-makepot/index.js
+++ b/packages/babel-plugin-makepot/index.js
@@ -33,7 +33,7 @@
  */
 
 const { po } = require( 'gettext-parser' );
-const { pick, reduce, forEach, isEqual, merge, isEmpty } = require( 'lodash' );
+const { pick, reduce, isEqual, merge, isEmpty } = require( 'lodash' );
 const { relative, sep } = require( 'path' );
 const { writeFileSync } = require( 'fs' );
 
@@ -122,7 +122,7 @@ function getExtractedComment( path, _originalNodeLine ) {
 	}
 
 	let comment;
-	forEach( node.leadingComments, ( commentNode ) => {
+	Object.values( node.leadingComments ?? {} ).forEach( ( commentNode ) => {
 		let line = 0;
 		if ( commentNode && commentNode.loc && commentNode.loc.end ) {
 			line = commentNode.loc.end.line;
@@ -333,41 +333,35 @@ module.exports = () => {
 									strings[ file ][ context ]
 								);
 
-								forEach(
-									sortedTranslations,
-									( translation ) => {
-										const { msgctxt = '', msgid } =
-											translation;
-										if (
-											! memo.hasOwnProperty( msgctxt )
-										) {
-											memo[ msgctxt ] = {};
-										}
-
-										// Merge references if translation already exists.
-										if (
-											isSameTranslation(
-												translation,
-												memo[ msgctxt ][ msgid ]
-											)
-										) {
-											translation.comments.reference = [
-												...new Set(
-													[
-														memo[ msgctxt ][ msgid ]
-															.comments.reference,
-														translation.comments
-															.reference,
-													]
-														.join( '\n' )
-														.split( '\n' )
-												),
-											].join( '\n' );
-										}
-
-										memo[ msgctxt ][ msgid ] = translation;
+								sortedTranslations.forEach( ( translation ) => {
+									const { msgctxt = '', msgid } = translation;
+									if ( ! memo.hasOwnProperty( msgctxt ) ) {
+										memo[ msgctxt ] = {};
 									}
-								);
+
+									// Merge references if translation already exists.
+									if (
+										isSameTranslation(
+											translation,
+											memo[ msgctxt ][ msgid ]
+										)
+									) {
+										translation.comments.reference = [
+											...new Set(
+												[
+													memo[ msgctxt ][ msgid ]
+														.comments.reference,
+													translation.comments
+														.reference,
+												]
+													.join( '\n' )
+													.split( '\n' )
+											),
+										].join( '\n' );
+									}
+
+									memo[ msgctxt ][ msgid ] = translation;
+								} );
 							}
 
 							return memo;

--- a/packages/block-editor/src/hooks/utils.js
+++ b/packages/block-editor/src/hooks/utils.js
@@ -1,16 +1,7 @@
 /**
  * External dependencies
  */
-import {
-	pickBy,
-	isEmpty,
-	mapValues,
-	forEach,
-	get,
-	setWith,
-	clone,
-	every,
-} from 'lodash';
+import { pickBy, isEmpty, mapValues, get, setWith, clone, every } from 'lodash';
 
 /**
  * WordPress dependencies
@@ -77,7 +68,7 @@ export function transformStyles(
 		}
 	}
 	let returnBlock = result;
-	forEach( activeSupports, ( isActive, support ) => {
+	Object.entries( activeSupports ).forEach( ( [ support, isActive ] ) => {
 		if ( isActive ) {
 			migrationPaths[ support ].forEach( ( path ) => {
 				const styleValue = get( referenceBlockAttributes, path );

--- a/packages/block-library/src/gallery/v1/edit.js
+++ b/packages/block-library/src/gallery/v1/edit.js
@@ -1,17 +1,7 @@
 /**
  * External dependencies
  */
-import {
-	every,
-	filter,
-	find,
-	forEach,
-	get,
-	isEmpty,
-	map,
-	reduce,
-	some,
-} from 'lodash';
+import { every, filter, find, get, isEmpty, map, reduce, some } from 'lodash';
 
 /**
  * WordPress dependencies
@@ -346,7 +336,7 @@ function GalleryEdit( props ) {
 			every( images, ( { url } ) => isBlobURL( url ) )
 		) {
 			const filesList = map( images, ( { url } ) => getBlobByURL( url ) );
-			forEach( images, ( { url } ) => revokeBlobURL( url ) );
+			images.forEach( ( { url } ) => revokeBlobURL( url ) );
 			mediaUpload( {
 				filesList,
 				onFileChange: onSelectImages,

--- a/packages/block-library/src/post-author/edit.js
+++ b/packages/block-library/src/post-author/edit.js
@@ -1,7 +1,6 @@
 /**
  * External dependencies
  */
-import { forEach } from 'lodash';
 import classnames from 'classnames';
 
 /**
@@ -51,7 +50,7 @@ function PostAuthorEdit( {
 
 	const avatarSizes = [];
 	if ( authorDetails ) {
-		forEach( authorDetails.avatar_urls, ( url, size ) => {
+		Object.keys( authorDetails.avatar_urls ).forEach( ( size ) => {
 			avatarSizes.push( {
 				value: size,
 				label: `${ size } x ${ size }`,

--- a/packages/components/src/modal/aria-helper.js
+++ b/packages/components/src/modal/aria-helper.js
@@ -1,10 +1,5 @@
 // @ts-nocheck
 
-/**
- * External dependencies
- */
-import { forEach } from 'lodash';
-
 const LIVE_REGION_ARIA_ROLES = new Set( [
 	'alert',
 	'status',
@@ -32,8 +27,8 @@ export function hideApp( unhiddenElement ) {
 	if ( isHidden ) {
 		return;
 	}
-	const elements = document.body.children;
-	forEach( elements, ( element ) => {
+	const elements = Array.from( document.body.children );
+	elements.forEach( ( element ) => {
 		if ( element === unhiddenElement ) {
 			return;
 		}
@@ -70,7 +65,7 @@ export function showApp() {
 	if ( ! isHidden ) {
 		return;
 	}
-	forEach( hiddenElements, ( element ) => {
+	hiddenElements.forEach( ( element ) => {
 		element.removeAttribute( 'aria-hidden' );
 	} );
 	hiddenElements = [];

--- a/packages/compose/src/higher-order/with-global-events/index.js
+++ b/packages/compose/src/higher-order/with-global-events/index.js
@@ -1,9 +1,4 @@
 /**
- * External dependencies
- */
-import { forEach } from 'lodash';
-
-/**
  * WordPress dependencies
  */
 import { Component, forwardRef } from '@wordpress/element';
@@ -57,13 +52,13 @@ export default function withGlobalEvents( eventTypesToHandlers ) {
 			}
 
 			componentDidMount() {
-				forEach( eventTypesToHandlers, ( _, eventType ) => {
+				Object.keys( eventTypesToHandlers ).forEach( ( eventType ) => {
 					listener.add( eventType, this );
 				} );
 			}
 
 			componentWillUnmount() {
-				forEach( eventTypesToHandlers, ( _, eventType ) => {
+				Object.keys( eventTypesToHandlers ).forEach( ( eventType ) => {
 					listener.remove( eventType, this );
 				} );
 			}

--- a/packages/compose/src/higher-order/with-global-events/listener.js
+++ b/packages/compose/src/higher-order/with-global-events/listener.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { forEach, without } from 'lodash';
+import { without } from 'lodash';
 
 /**
  * Class responsible for orchestrating event handling on the global window,
@@ -40,9 +40,11 @@ class Listener {
 	}
 
 	handleEvent( /** @type {any} */ event ) {
-		forEach( this.listeners[ event.type ], ( instance ) => {
-			instance.handleEvent( event );
-		} );
+		this.listeners[ event.type ]?.forEach(
+			( /** @type {any} */ instance ) => {
+				instance.handleEvent( event );
+			}
+		);
 	}
 }
 

--- a/packages/data/src/registry.js
+++ b/packages/data/src/registry.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { mapValues, forEach } from 'lodash';
+import { mapValues } from 'lodash';
 
 /**
  * WordPress dependencies
@@ -293,10 +293,10 @@ export function createRegistry( storeConfigs = {}, parent = null ) {
 
 	function batch( callback ) {
 		emitter.pause();
-		forEach( stores, ( store ) => store.emitter.pause() );
+		Object.values( stores ).forEach( ( store ) => store.emitter.pause() );
 		callback();
 		emitter.resume();
-		forEach( stores, ( store ) => store.emitter.resume() );
+		Object.values( stores ).forEach( ( store ) => store.emitter.resume() );
 	}
 
 	let registry = {

--- a/packages/edit-post/src/editor.js
+++ b/packages/edit-post/src/editor.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { forEach, map, without } from 'lodash';
+import { map, without } from 'lodash';
 
 /**
  * WordPress dependencies
@@ -162,7 +162,7 @@ function Editor( {
 	const styles = useMemo( () => {
 		const themeStyles = [];
 		const presetStyles = [];
-		forEach( settings.styles, ( style ) => {
+		settings.styles?.forEach( ( style ) => {
 			if ( ! style.__unstableType || style.__unstableType === 'theme' ) {
 				themeStyles.push( style );
 			} else {

--- a/packages/edit-site/src/components/global-styles/use-global-styles-output.js
+++ b/packages/edit-site/src/components/global-styles/use-global-styles-output.js
@@ -1,16 +1,7 @@
 /**
  * External dependencies
  */
-import {
-	first,
-	forEach,
-	get,
-	isEmpty,
-	kebabCase,
-	pickBy,
-	reduce,
-	set,
-} from 'lodash';
+import { first, get, isEmpty, kebabCase, pickBy, reduce, set } from 'lodash';
 
 /**
  * WordPress dependencies
@@ -457,7 +448,7 @@ export const getNodesWithStyles = ( tree, blockSelectors ) => {
 		} );
 	}
 
-	forEach( ELEMENTS, ( selector, name ) => {
+	Object.entries( ELEMENTS ).forEach( ( [ name, selector ] ) => {
 		if ( !! tree.styles?.elements[ name ] ) {
 			nodes.push( {
 				styles: tree.styles?.elements[ name ],
@@ -467,42 +458,53 @@ export const getNodesWithStyles = ( tree, blockSelectors ) => {
 	} );
 
 	// Iterate over blocks: they can have styles & elements.
-	forEach( tree.styles?.blocks, ( node, blockName ) => {
-		const blockStyles = pickStyleKeys( node );
-		if ( !! blockStyles && !! blockSelectors?.[ blockName ]?.selector ) {
-			nodes.push( {
-				duotoneSelector: blockSelectors[ blockName ].duotoneSelector,
-				fallbackGapValue: blockSelectors[ blockName ].fallbackGapValue,
-				hasLayoutSupport: blockSelectors[ blockName ].hasLayoutSupport,
-				selector: blockSelectors[ blockName ].selector,
-				styles: blockStyles,
-				featureSelectors: blockSelectors[ blockName ].featureSelectors,
-			} );
-		}
-
-		forEach( node?.elements, ( value, elementName ) => {
+	Object.entries( tree.styles?.blocks ?? {} ).forEach(
+		( [ blockName, node ] ) => {
+			const blockStyles = pickStyleKeys( node );
 			if (
-				!! value &&
-				!! blockSelectors?.[ blockName ] &&
-				!! ELEMENTS?.[ elementName ]
+				!! blockStyles &&
+				!! blockSelectors?.[ blockName ]?.selector
 			) {
 				nodes.push( {
-					styles: value,
-					selector: blockSelectors[ blockName ].selector
-						.split( ',' )
-						.map( ( sel ) => {
-							const elementSelectors =
-								ELEMENTS[ elementName ].split( ',' );
-							return elementSelectors.map(
-								( elementSelector ) =>
-									sel + ' ' + elementSelector
-							);
-						} )
-						.join( ',' ),
+					duotoneSelector:
+						blockSelectors[ blockName ].duotoneSelector,
+					fallbackGapValue:
+						blockSelectors[ blockName ].fallbackGapValue,
+					hasLayoutSupport:
+						blockSelectors[ blockName ].hasLayoutSupport,
+					selector: blockSelectors[ blockName ].selector,
+					styles: blockStyles,
+					featureSelectors:
+						blockSelectors[ blockName ].featureSelectors,
 				} );
 			}
-		} );
-	} );
+
+			Object.entries( node?.elements ?? {} ).forEach(
+				( [ elementName, value ] ) => {
+					if (
+						!! value &&
+						!! blockSelectors?.[ blockName ] &&
+						!! ELEMENTS?.[ elementName ]
+					) {
+						nodes.push( {
+							styles: value,
+							selector: blockSelectors[ blockName ].selector
+								.split( ',' )
+								.map( ( sel ) => {
+									const elementSelectors =
+										ELEMENTS[ elementName ].split( ',' );
+									return elementSelectors.map(
+										( elementSelector ) =>
+											sel + ' ' + elementSelector
+									);
+								} )
+								.join( ',' ),
+						} );
+					}
+				}
+			);
+		}
+	);
 
 	return nodes;
 };
@@ -537,17 +539,19 @@ export const getNodesWithSettings = ( tree, blockSelectors ) => {
 	}
 
 	// Blocks.
-	forEach( tree.settings?.blocks, ( node, blockName ) => {
-		const blockPresets = pickPresets( node );
-		const blockCustom = node.custom;
-		if ( ! isEmpty( blockPresets ) || !! blockCustom ) {
-			nodes.push( {
-				presets: blockPresets,
-				custom: blockCustom,
-				selector: blockSelectors[ blockName ].selector,
-			} );
+	Object.entries( tree.settings?.blocks ?? {} ).forEach(
+		( [ blockName, node ] ) => {
+			const blockPresets = pickPresets( node );
+			const blockCustom = node.custom;
+			if ( ! isEmpty( blockPresets ) || !! blockCustom ) {
+				nodes.push( {
+					presets: blockPresets,
+					custom: blockCustom,
+					selector: blockSelectors[ blockName ].selector,
+				} );
+			}
 		}
-	} );
+	);
 
 	return nodes;
 };

--- a/packages/viewport/src/listener.js
+++ b/packages/viewport/src/listener.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { reduce, forEach, debounce, mapValues } from 'lodash';
+import { reduce, debounce, mapValues } from 'lodash';
 
 /**
  * WordPress dependencies
@@ -38,15 +38,17 @@ const addDimensionsEventListener = ( breakpoints, operators ) => {
 	const queries = reduce(
 		breakpoints,
 		( result, width, name ) => {
-			forEach( operators, ( condition, operator ) => {
-				const list = window.matchMedia(
-					`(${ condition }: ${ width }px)`
-				);
-				list.addListener( setIsMatching );
+			Object.entries( operators ).forEach(
+				( [ operator, condition ] ) => {
+					const list = window.matchMedia(
+						`(${ condition }: ${ width }px)`
+					);
+					list.addListener( setIsMatching );
 
-				const key = [ operator, name ].join( ' ' );
-				result[ key ] = list;
-			} );
+					const key = [ operator, name ].join( ' ' );
+					result[ key ] = list;
+				}
+			);
 
 			return result;
 		},

--- a/packages/viewport/src/listener.native.js
+++ b/packages/viewport/src/listener.native.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { forEach, reduce } from 'lodash';
+import { reduce } from 'lodash';
 import { Dimensions } from 'react-native';
 
 /**
@@ -29,10 +29,12 @@ const addDimensionsEventListener = ( breakpoints, operators ) => {
 		const matches = reduce(
 			breakpoints,
 			( result, width, name ) => {
-				forEach( operators, ( condition, operator ) => {
-					const key = [ operator, name ].join( ' ' );
-					result[ key ] = matchWidth( condition, width );
-				} );
+				Object.entries( operators ).forEach(
+					( [ operator, condition ] ) => {
+						const key = [ operator, name ].join( ' ' );
+						result[ key ] = matchWidth( condition, width );
+					}
+				);
 
 				return result;
 			},


### PR DESCRIPTION
## What?
This PR removes the `_.forEach()` usage completely and deprecates the function. 

## Why?

Lodash is known to unnecessarily inflate the bundle size of packages, and in most cases, it can be replaced with native language functionality. See these for more information and rationale:

* https://github.com/WordPress/gutenberg/issues/16938#issuecomment-602837246
* https://github.com/WordPress/gutenberg/issues/17025
* https://github.com/WordPress/gutenberg/issues/39495 

## How?

We're essentially replacing with `Array.prototype.forEach()`, with a few specifics in mind:

* When working with objects we:
  * Make sure to fall back to an empty object when it can be nullish.
  * Convert to an array, with:
    * `Object.entries()` when we use both the object keys and values.
    * `Object.keys()` when we use only the object keys.
    * `Object.values()` when we use only the object values.

The PR might look a little on the large side, but that's mostly because lots of the indentation needs to change after the minor changes, so most of it consists of whitespace changes.

## Testing Instructions
* To verify the change in `@wordpress/babel-plugin-makepot` works, run `npm run test:unit packages/babel-plugin-makepot/test/index.js` and verify they still pass.
* As you transform some text from a paragraph from a heading block, verify the font size remains as it was.
* Verify upload of images in a Gallery v1 block still works.
* Verify Post Author block still properly displays the avatar of the currently edited post.
* Verify opening and closing of modals still works as before.
* To verify the changes on `withGlobalEvents` work, verify its tests still pass: `npm run test:unit packages/compose/src/higher-order/with-global-events/test/index.js`
* To verify the change in `@wordpress/data` registry still works, verify these tests still pass: `npm run test:unit packages/data/src/test/registry.js`
* Verify theme and all other styles are still properly applied to the editor (you could compare a long post with `trunk` and ensure nothing has changed).
* Smoke test global styles in the site editor and verify the corresponding tests still pass: `npm run test:unit packages/edit-site/src/components/global-styles`
* Verify everything behaves the same way on resize, and viewport package tests still pass: `npm run test:unit packages/viewport`
* Verify all other tests still pass and all checks are green.