### PR TITLE
Edit Post: use Popover's new anchor prop

### DIFF
--- a/packages/edit-post/src/components/sidebar/post-schedule/index.js
+++ b/packages/edit-post/src/components/sidebar/post-schedule/index.js
@@ -12,7 +12,7 @@ import {
 
 export default function PostSchedule() {
 	// Use internal state instead of a ref to make sure that the component
-	// re-renders when then anchor's ref updates.
+	// re-renders when the anchor's ref updates.
 	const [ popoverAnchor, setPopoverAnchor ] = useState();
 
 	return (

--- a/packages/edit-post/src/components/sidebar/post-schedule/index.js
+++ b/packages/edit-post/src/components/sidebar/post-schedule/index.js
@@ -3,7 +3,7 @@
  */
 import { __, sprintf } from '@wordpress/i18n';
 import { PanelRow, Dropdown, Button } from '@wordpress/components';
-import { useCallback, useState } from '@wordpress/element';
+import { useState } from '@wordpress/element';
 import {
 	PostSchedule as PostScheduleForm,
 	PostScheduleCheck,
@@ -14,20 +14,19 @@ export default function PostSchedule() {
 	// Use internal state instead of a ref to make sure that the component
 	// re-renders when then anchor's ref updates.
 	const [ popoverAnchor, setPopoverAnchor ] = useState();
-	const rowCallbackRef = useCallback( ( node ) => {
-		// Fall back to `undefined` in case the ref is `null`.
-		setPopoverAnchor( node ?? undefined );
-	}, [] );
 
 	return (
 		<PostScheduleCheck>
 			<PanelRow
 				className="edit-post-post-schedule"
-				ref={ rowCallbackRef }
+				ref={ setPopoverAnchor }
 			>
 				<span>{ __( 'Publish' ) }</span>
 				<Dropdown
-					popoverProps={ { anchor: popoverAnchor } }
+					popoverProps={ {
+						// `anchor` can not be `null`
+						anchor: popoverAnchor ?? undefined,
+					} }
 					position="bottom left"
 					contentClassName="edit-post-post-schedule__dialog"
 					focusOnMount

--- a/packages/edit-post/src/components/sidebar/post-schedule/index.js
+++ b/packages/edit-post/src/components/sidebar/post-schedule/index.js
@@ -13,7 +13,7 @@ import {
 export default function PostSchedule() {
 	// Use internal state instead of a ref to make sure that the component
 	// re-renders when the anchor's ref updates.
-	const [ popoverAnchor, setPopoverAnchor ] = useState();
+	const [ popoverAnchor, setPopoverAnchor ] = useState( null );
 
 	return (
 		<PostScheduleCheck>
@@ -23,10 +23,7 @@ export default function PostSchedule() {
 			>
 				<span>{ __( 'Publish' ) }</span>
 				<Dropdown
-					popoverProps={ {
-						// `anchor` can not be `null`
-						anchor: popoverAnchor ?? undefined,
-					} }
+					popoverProps={ { anchor: popoverAnchor } }
 					position="bottom left"
 					contentClassName="edit-post-post-schedule__dialog"
 					focusOnMount

--- a/packages/edit-post/src/components/sidebar/post-schedule/index.js
+++ b/packages/edit-post/src/components/sidebar/post-schedule/index.js
@@ -3,7 +3,7 @@
  */
 import { __, sprintf } from '@wordpress/i18n';
 import { PanelRow, Dropdown, Button } from '@wordpress/components';
-import { useRef } from '@wordpress/element';
+import { useCallback, useState } from '@wordpress/element';
 import {
 	PostSchedule as PostScheduleForm,
 	PostScheduleCheck,
@@ -11,13 +11,23 @@ import {
 } from '@wordpress/editor';
 
 export default function PostSchedule() {
-	const anchorRef = useRef();
+	// Use internal state instead of a ref to make sure that the component
+	// re-renders when then anchor's ref updates.
+	const [ popoverAnchor, setPopoverAnchor ] = useState();
+	const rowCallbackRef = useCallback( ( node ) => {
+		// Fall back to `undefined` in case the ref is `null`.
+		setPopoverAnchor( node ?? undefined );
+	}, [] );
+
 	return (
 		<PostScheduleCheck>
-			<PanelRow className="edit-post-post-schedule" ref={ anchorRef }>
+			<PanelRow
+				className="edit-post-post-schedule"
+				ref={ rowCallbackRef }
+			>
 				<span>{ __( 'Publish' ) }</span>
 				<Dropdown
-					popoverProps={ { anchorRef } }
+					popoverProps={ { anchor: popoverAnchor } }
 					position="bottom left"
 					contentClassName="edit-post-post-schedule__dialog"
 					focusOnMount

--- a/packages/edit-post/src/components/sidebar/post-schedule/style.scss
+++ b/packages/edit-post/src/components/sidebar/post-schedule/style.scss
@@ -15,7 +15,7 @@
 	white-space: normal;
 	height: auto;
 
-	// This span is added by the Popover in Tooltip when no anchorRef is
+	// This span is added by the Popover in Tooltip when no anchor is
 	// provided. We set its width to 0 so that it does not cause the button text
 	// to wrap to a new line when displaying the tooltip. A better fix would be
 	// to pass anchorRef and avoid the need for a span alltogether, which is

--- a/packages/edit-post/src/components/sidebar/post-template/index.js
+++ b/packages/edit-post/src/components/sidebar/post-template/index.js
@@ -17,7 +17,7 @@ import { store as editPostStore } from '../../../store';
 export default function PostTemplate() {
 	// Use internal state instead of a ref to make sure that the component
 	// re-renders when then anchor's ref updates.
-	const [ popoverAnchor, setPopoverAnchor ] = useState();
+	const [ popoverAnchor, setPopoverAnchor ] = useState( null );
 
 	const isVisible = useSelect( ( select ) => {
 		const postTypeSlug = select( editorStore ).getCurrentPostType();
@@ -51,10 +51,7 @@ export default function PostTemplate() {
 		<PanelRow className="edit-post-post-template" ref={ setPopoverAnchor }>
 			<span>{ __( 'Template' ) }</span>
 			<Dropdown
-				popoverProps={ {
-					// `anchor` can not be `null`
-					anchor: popoverAnchor ?? undefined,
-				} }
+				popoverProps={ { anchor: popoverAnchor } }
 				position="bottom left"
 				className="edit-post-post-template__dropdown"
 				contentClassName="edit-post-post-template__dialog"

--- a/packages/edit-post/src/components/sidebar/post-template/index.js
+++ b/packages/edit-post/src/components/sidebar/post-template/index.js
@@ -1,7 +1,7 @@
 /**
  * WordPress dependencies
  */
-import { useRef } from '@wordpress/element';
+import { useCallback, useState } from '@wordpress/element';
 import { PanelRow, Dropdown, Button } from '@wordpress/components';
 import { __, sprintf } from '@wordpress/i18n';
 import { useSelect } from '@wordpress/data';
@@ -15,7 +15,13 @@ import PostTemplateForm from './form';
 import { store as editPostStore } from '../../../store';
 
 export default function PostTemplate() {
-	const anchorRef = useRef();
+	// Use internal state instead of a ref to make sure that the component
+	// re-renders when then anchor's ref updates.
+	const [ popoverAnchor, setPopoverAnchor ] = useState();
+	const rowCallbackRef = useCallback( ( node ) => {
+		// Fall back to `undefined` in case the ref is `null`.
+		setPopoverAnchor( node ?? undefined );
+	}, [] );
 
 	const isVisible = useSelect( ( select ) => {
 		const postTypeSlug = select( editorStore ).getCurrentPostType();
@@ -46,10 +52,10 @@ export default function PostTemplate() {
 	}
 
 	return (
-		<PanelRow className="edit-post-post-template" ref={ anchorRef }>
+		<PanelRow className="edit-post-post-template" ref={ rowCallbackRef }>
 			<span>{ __( 'Template' ) }</span>
 			<Dropdown
-				popoverProps={ { anchorRef } }
+				popoverProps={ { anchor: popoverAnchor } }
 				position="bottom left"
 				className="edit-post-post-template__dropdown"
 				contentClassName="edit-post-post-template__dialog"

--- a/packages/edit-post/src/components/sidebar/post-template/index.js
+++ b/packages/edit-post/src/components/sidebar/post-template/index.js
@@ -1,7 +1,7 @@
 /**
  * WordPress dependencies
  */
-import { useCallback, useState } from '@wordpress/element';
+import { useState } from '@wordpress/element';
 import { PanelRow, Dropdown, Button } from '@wordpress/components';
 import { __, sprintf } from '@wordpress/i18n';
 import { useSelect } from '@wordpress/data';
@@ -18,10 +18,6 @@ export default function PostTemplate() {
 	// Use internal state instead of a ref to make sure that the component
 	// re-renders when then anchor's ref updates.
 	const [ popoverAnchor, setPopoverAnchor ] = useState();
-	const rowCallbackRef = useCallback( ( node ) => {
-		// Fall back to `undefined` in case the ref is `null`.
-		setPopoverAnchor( node ?? undefined );
-	}, [] );
 
 	const isVisible = useSelect( ( select ) => {
 		const postTypeSlug = select( editorStore ).getCurrentPostType();
@@ -52,10 +48,13 @@ export default function PostTemplate() {
 	}
 
 	return (
-		<PanelRow className="edit-post-post-template" ref={ rowCallbackRef }>
+		<PanelRow className="edit-post-post-template" ref={ setPopoverAnchor }>
 			<span>{ __( 'Template' ) }</span>
 			<Dropdown
-				popoverProps={ { anchor: popoverAnchor } }
+				popoverProps={ {
+					// `anchor` can not be `null`
+					anchor: popoverAnchor ?? undefined,
+				} }
 				position="bottom left"
 				className="edit-post-post-template__dropdown"
 				contentClassName="edit-post-post-template__dialog"

--- a/packages/edit-post/src/components/sidebar/post-url/index.js
+++ b/packages/edit-post/src/components/sidebar/post-url/index.js
@@ -1,7 +1,7 @@
 /**
  * WordPress dependencies
  */
-import { useRef } from '@wordpress/element';
+import { useCallback, useState } from '@wordpress/element';
 import { PanelRow, Dropdown, Button } from '@wordpress/components';
 import { __, sprintf } from '@wordpress/i18n';
 import {
@@ -11,13 +11,20 @@ import {
 } from '@wordpress/editor';
 
 export default function PostURL() {
-	const anchorRef = useRef();
+	// Use internal state instead of a ref to make sure that the component
+	// re-renders when then anchor's ref updates.
+	const [ popoverAnchor, setPopoverAnchor ] = useState();
+	const rowCallbackRef = useCallback( ( node ) => {
+		// Fall back to `undefined` in case the ref is `null`.
+		setPopoverAnchor( node ?? undefined );
+	}, [] );
+
 	return (
 		<PostURLCheck>
-			<PanelRow className="edit-post-post-url" ref={ anchorRef }>
+			<PanelRow className="edit-post-post-url" ref={ rowCallbackRef }>
 				<span>{ __( 'URL' ) }</span>
 				<Dropdown
-					popoverProps={ { anchorRef } }
+					popoverProps={ { anchor: popoverAnchor } }
 					position="bottom left"
 					className="edit-post-post-url__dropdown"
 					contentClassName="edit-post-post-url__dialog"

--- a/packages/edit-post/src/components/sidebar/post-url/index.js
+++ b/packages/edit-post/src/components/sidebar/post-url/index.js
@@ -13,17 +13,14 @@ import {
 export default function PostURL() {
 	// Use internal state instead of a ref to make sure that the component
 	// re-renders when then anchor's ref updates.
-	const [ popoverAnchor, setPopoverAnchor ] = useState();
+	const [ popoverAnchor, setPopoverAnchor ] = useState( null );
 
 	return (
 		<PostURLCheck>
 			<PanelRow className="edit-post-post-url" ref={ setPopoverAnchor }>
 				<span>{ __( 'URL' ) }</span>
 				<Dropdown
-					popoverProps={ {
-						// `anchor` can not be `null`
-						anchor: popoverAnchor ?? undefined,
-					} }
+					popoverProps={ { anchor: popoverAnchor } }
 					position="bottom left"
 					className="edit-post-post-url__dropdown"
 					contentClassName="edit-post-post-url__dialog"

--- a/packages/edit-post/src/components/sidebar/post-url/index.js
+++ b/packages/edit-post/src/components/sidebar/post-url/index.js
@@ -1,7 +1,7 @@
 /**
  * WordPress dependencies
  */
-import { useCallback, useState } from '@wordpress/element';
+import { useState } from '@wordpress/element';
 import { PanelRow, Dropdown, Button } from '@wordpress/components';
 import { __, sprintf } from '@wordpress/i18n';
 import {
@@ -14,17 +14,16 @@ export default function PostURL() {
 	// Use internal state instead of a ref to make sure that the component
 	// re-renders when then anchor's ref updates.
 	const [ popoverAnchor, setPopoverAnchor ] = useState();
-	const rowCallbackRef = useCallback( ( node ) => {
-		// Fall back to `undefined` in case the ref is `null`.
-		setPopoverAnchor( node ?? undefined );
-	}, [] );
 
 	return (
 		<PostURLCheck>
-			<PanelRow className="edit-post-post-url" ref={ rowCallbackRef }>
+			<PanelRow className="edit-post-post-url" ref={ setPopoverAnchor }>
 				<span>{ __( 'URL' ) }</span>
 				<Dropdown
-					popoverProps={ { anchor: popoverAnchor } }
+					popoverProps={ {
+						// `anchor` can not be `null`
+						anchor: popoverAnchor ?? undefined,
+					} }
 					position="bottom left"
 					className="edit-post-post-url__dropdown"
 					contentClassName="edit-post-post-url__dialog"

--- a/packages/edit-post/src/components/sidebar/post-visibility/index.js
+++ b/packages/edit-post/src/components/sidebar/post-visibility/index.js
@@ -9,22 +9,18 @@ import {
 	PostVisibilityCheck,
 	usePostVisibilityLabel,
 } from '@wordpress/editor';
-import { useCallback, useState } from '@wordpress/element';
+import { useState } from '@wordpress/element';
 
 export function PostVisibility() {
 	// Use internal state instead of a ref to make sure that the component
 	// re-renders when then anchor's ref updates.
 	const [ popoverAnchor, setPopoverAnchor ] = useState();
-	const rowCallbackRef = useCallback( ( node ) => {
-		// Fall back to `undefined` in case the ref is `null`.
-		setPopoverAnchor( node ?? undefined );
-	}, [] );
 
 	return (
 		<PostVisibilityCheck
 			render={ ( { canEdit } ) => (
 				<PanelRow
-					ref={ rowCallbackRef }
+					ref={ setPopoverAnchor }
 					className="edit-post-post-visibility"
 				>
 					<span>{ __( 'Visibility' ) }</span>
@@ -41,7 +37,8 @@ export function PostVisibility() {
 								// Anchor the popover to the middle of the
 								// entire row so that it doesn't move around
 								// when the label changes.
-								anchor: popoverAnchor,
+								// `anchor` can not be `null`
+								anchor: popoverAnchor ?? undefined,
 							} }
 							focusOnMount
 							renderToggle={ ( { isOpen, onToggle } ) => (

--- a/packages/edit-post/src/components/sidebar/post-visibility/index.js
+++ b/packages/edit-post/src/components/sidebar/post-visibility/index.js
@@ -14,7 +14,7 @@ import { useState } from '@wordpress/element';
 export function PostVisibility() {
 	// Use internal state instead of a ref to make sure that the component
 	// re-renders when then anchor's ref updates.
-	const [ popoverAnchor, setPopoverAnchor ] = useState();
+	const [ popoverAnchor, setPopoverAnchor ] = useState( null );
 
 	return (
 		<PostVisibilityCheck
@@ -37,8 +37,7 @@ export function PostVisibility() {
 								// Anchor the popover to the middle of the
 								// entire row so that it doesn't move around
 								// when the label changes.
-								// `anchor` can not be `null`
-								anchor: popoverAnchor ?? undefined,
+								anchor: popoverAnchor,
 							} }
 							focusOnMount
 							renderToggle={ ( { isOpen, onToggle } ) => (

--- a/packages/edit-post/src/components/sidebar/post-visibility/index.js
+++ b/packages/edit-post/src/components/sidebar/post-visibility/index.js
@@ -9,14 +9,24 @@ import {
 	PostVisibilityCheck,
 	usePostVisibilityLabel,
 } from '@wordpress/editor';
-import { useRef } from '@wordpress/element';
+import { useCallback, useState } from '@wordpress/element';
 
 export function PostVisibility() {
-	const rowRef = useRef();
+	// Use internal state instead of a ref to make sure that the component
+	// re-renders when then anchor's ref updates.
+	const [ popoverAnchor, setPopoverAnchor ] = useState();
+	const rowCallbackRef = useCallback( ( node ) => {
+		// Fall back to `undefined` in case the ref is `null`.
+		setPopoverAnchor( node ?? undefined );
+	}, [] );
+
 	return (
 		<PostVisibilityCheck
 			render={ ( { canEdit } ) => (
-				<PanelRow ref={ rowRef } className="edit-post-post-visibility">
+				<PanelRow
+					ref={ rowCallbackRef }
+					className="edit-post-post-visibility"
+				>
 					<span>{ __( 'Visibility' ) }</span>
 					{ ! canEdit && (
 						<span>
@@ -31,7 +41,7 @@ export function PostVisibility() {
 								// Anchor the popover to the middle of the
 								// entire row so that it doesn't move around
 								// when the label changes.
-								anchorRef: rowRef.current,
+								anchor: popoverAnchor,
 							} }
 							focusOnMount
 							renderToggle={ ( { isOpen, onToggle } ) => (


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Refactor the way components in the  `edit-post` package pass an anchor to `Popover`, using the new `anchor` prop

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

See #43691 for more context

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

- Swap `anchorRef` with `anchor`
- Use internal state and a callback ref to make sure that the components re-render when the anchor changes (including updating after the initial render, when the anchor's ref is still unset)

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->

- Open a post in the post editor, and (if not open) open the sidebar by pressing on the settings button (cog) in the header.
- Select the "Post" tab at the top of the sidebar
- Play around with the "Visibility", "Publish", "URL" and "Template" settings under the "Summary" section. When clicking on each of those buttons, a popover should appear with the appropriate contents, as it currently happens on `trunk`.


https://user-images.githubusercontent.com/1083581/188120126-65583240-eef3-45b6-a802-bb6e4f3d8bb8.mp4

