### PR TITLE
Edit site Actions: use new anchor prop for Popover

### DIFF
--- a/packages/edit-site/src/components/header/document-actions/index.js
+++ b/packages/edit-site/src/components/header/document-actions/index.js
@@ -19,7 +19,7 @@ import {
 	__experimentalText as Text,
 } from '@wordpress/components';
 import { chevronDown } from '@wordpress/icons';
-import { useRef } from '@wordpress/element';
+import { useCallback, useState } from '@wordpress/element';
 import { store as blockEditorStore } from '@wordpress/block-editor';
 
 function getBlockDisplayText( block ) {
@@ -73,10 +73,15 @@ export default function DocumentActions( {
 } ) {
 	const { label } = useSecondaryText();
 
-	// The title ref is passed to the popover as the anchorRef so that the
-	// dropdown is centered over the whole title area rather than just one
-	// part of it.
-	const titleRef = useRef();
+	// Use internal state instead of a ref to make sure that the component
+	// re-renders when then anchor's ref updates.
+	const [ popoverAnchor, setPopoverAnchor ] = useState();
+	const titleWrapperCallbackRef = useCallback( ( node ) => {
+		// Use the title wrapper as the popover anchor so that the dropdown is
+		// centered over the whole title area rather than just one part of it.
+		// Fall back to `undefined` in case the ref is `null`.
+		setPopoverAnchor( node ?? undefined );
+	}, [] );
 
 	// Return a simple loading indicator until we have information to show.
 	if ( ! isLoaded ) {
@@ -103,7 +108,7 @@ export default function DocumentActions( {
 			} ) }
 		>
 			<div
-				ref={ titleRef }
+				ref={ titleWrapperCallbackRef }
 				className="edit-site-document-actions__title-wrapper"
 			>
 				<Text
@@ -131,7 +136,7 @@ export default function DocumentActions( {
 				{ dropdownContent && (
 					<Dropdown
 						popoverProps={ {
-							anchorRef: titleRef.current,
+							anchor: popoverAnchor,
 						} }
 						position="bottom center"
 						renderToggle={ ( { isOpen, onToggle } ) => (


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Refactor the way the `DocumentActions` component in the  `edit-site` package passes an anchor to `Popover`, using the new `anchor` prop

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

See #43691 for more context

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

- Swap `anchorRef` with `anchor`
- Use internal state and a callback ref to make sure that the component re-renders when the anchor changes (including updating after the initial render, when the anchor's ref is still unset)

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->

- Open the site editor and click on the down caret icon in the header toolbar to show template details
- Make sure that the popover that is shown as the result of the button click looks and behaves as expects (and as on `trunk`)

![Screenshot 2022-09-02 at 12 44 44](https://user-images.githubusercontent.com/1083581/188123326-7f0a14cc-339a-486a-83cd-2464f628c572.png)

