### PR TITLE
Block Editor: Refactor `BlockTitle` tests to `@testing-library/react`

### DIFF
--- a/packages/block-editor/src/components/block-title/test/index.js
+++ b/packages/block-editor/src/components/block-title/test/index.js
@@ -122,6 +122,7 @@ describe( 'BlockTitle', () => {
 
 		render( <BlockTitle clientId="id-name-with-label" /> );
 
+		expect( screen.queryByText( 'Test Label' ) ).not.toBeInTheDocument();
 		expect( screen.getByText( 'Reuse me!' ) ).toBeVisible();
 	} );
 
@@ -133,6 +134,7 @@ describe( 'BlockTitle', () => {
 
 		render( <BlockTitle clientId="id-name-with-label" /> );
 
+		expect( screen.queryByText( 'Test Label' ) ).not.toBeInTheDocument();
 		expect(
 			screen.getByText( 'A Custom Label like a Block Variation Label' )
 		).toBeVisible();

--- a/packages/block-editor/src/components/block-title/test/index.js
+++ b/packages/block-editor/src/components/block-title/test/index.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { shallow } from 'enzyme';
+import { render, screen } from '@testing-library/react';
 
 /**
  * WordPress dependencies
@@ -73,9 +73,9 @@ describe( 'BlockTitle', () => {
 			attributes: null,
 		} ) );
 
-		const wrapper = shallow( <BlockTitle /> );
+		const { container } = render( <BlockTitle /> );
 
-		expect( wrapper.type() ).toBe( null );
+		expect( container ).toBeEmptyDOMElement();
 	} );
 
 	it( 'renders nothing if block type does not exist', () => {
@@ -83,11 +83,12 @@ describe( 'BlockTitle', () => {
 			name: 'name-not-exists',
 			attributes: null,
 		} ) );
-		const wrapper = shallow(
+
+		const { container } = render(
 			<BlockTitle clientId="afd1cb17-2c08-4e7a-91be-007ba7ddc3a1" />
 		);
 
-		expect( wrapper.type() ).toBe( null );
+		expect( container ).toBeEmptyDOMElement();
 	} );
 
 	it( 'renders title if block type exists', () => {
@@ -96,9 +97,9 @@ describe( 'BlockTitle', () => {
 			attributes: null,
 		} ) );
 
-		const wrapper = shallow( <BlockTitle clientId="id-name-exists" /> );
+		render( <BlockTitle clientId="id-name-exists" /> );
 
-		expect( wrapper.text() ).toBe( 'Block Title' );
+		expect( screen.getByText( 'Block Title' ) ).toBeVisible();
 	} );
 
 	it( 'renders label if it is set', () => {
@@ -107,9 +108,9 @@ describe( 'BlockTitle', () => {
 			attributes: null,
 		} ) );
 
-		const wrapper = shallow( <BlockTitle clientId="id-name-with-label" /> );
+		render( <BlockTitle clientId="id-name-with-label" /> );
 
-		expect( wrapper.text() ).toBe( 'Test Label' );
+		expect( screen.getByText( 'Test Label' ) ).toBeVisible();
 	} );
 
 	it( 'should prioritize reusable block title over title', () => {
@@ -119,9 +120,9 @@ describe( 'BlockTitle', () => {
 			attributes: null,
 		} ) );
 
-		const wrapper = shallow( <BlockTitle clientId="id-name-with-label" /> );
+		render( <BlockTitle clientId="id-name-with-label" /> );
 
-		expect( wrapper.text() ).toBe( 'Reuse me!' );
+		expect( screen.getByText( 'Reuse me!' ) ).toBeVisible();
 	} );
 
 	it( 'should prioritize block label over title', () => {
@@ -130,11 +131,11 @@ describe( 'BlockTitle', () => {
 			attributes: null,
 		} ) );
 
-		const wrapper = shallow( <BlockTitle clientId="id-name-with-label" /> );
+		render( <BlockTitle clientId="id-name-with-label" /> );
 
-		expect( wrapper.text() ).toBe(
-			'A Custom Label like a Block Variation Label'
-		);
+		expect(
+			screen.getByText( 'A Custom Label like a Block Variation Label' )
+		).toBeVisible();
 	} );
 
 	it( 'should default to block information title if no reusable title or block name is available', () => {
@@ -143,9 +144,9 @@ describe( 'BlockTitle', () => {
 			attributes: null,
 		} ) );
 
-		const wrapper = shallow( <BlockTitle clientId="id-name-with-label" /> );
+		render( <BlockTitle clientId="id-name-with-label" /> );
 
-		expect( wrapper.text() ).toBe( 'Block With Label' );
+		expect( screen.getByText( 'Block With Label' ) ).toBeVisible();
 	} );
 
 	it( 'truncates the label with custom truncate length', () => {
@@ -154,14 +155,14 @@ describe( 'BlockTitle', () => {
 			attributes: null,
 		} ) );
 
-		const wrapper = shallow(
+		render(
 			<BlockTitle
 				clientId="id-name-with-long-label"
 				maximumLength={ 12 }
 			/>
 		);
 
-		expect( wrapper.text() ).toBe( 'This is a...' );
+		expect( screen.getByText( 'This is a...' ) ).toBeVisible();
 	} );
 
 	it( 'should not truncate the label if maximum length is undefined', () => {
@@ -170,12 +171,12 @@ describe( 'BlockTitle', () => {
 			attributes: null,
 		} ) );
 
-		const wrapper = shallow(
-			<BlockTitle clientId="id-name-with-long-label" />
-		);
+		render( <BlockTitle clientId="id-name-with-long-label" /> );
 
-		expect( wrapper.text() ).toBe(
-			'This is a longer label than typical for blocks to have.'
-		);
+		expect(
+			screen.getByText(
+				'This is a longer label than typical for blocks to have.'
+			)
+		).toBeVisible();
 	} );
 } );


### PR DESCRIPTION
## What?
We've recently started refactoring `enzyme` tests to `@testing-library/react`.

This PR refactors the `<BlockTitle />` block editor component tests from `enzyme` to `@testing-library/react`.

## Why?
`@testing-library/react` provides a better way to write tests for accessible components that is closer to the way the user experiences them.

Note that the purpose of this PR is not to improve or enrich the tests themselves, but rather to migrate them `@testing-library/react`. Our primary motivation is unblocking the upgrade to React 18. 

## How?
We're straightforwardly replacing `enzyme` tests with `@testing-library/react` ones, using `jest-dom` matchers and mocks to avoid testing unrelated implementation details.

## Testing Instructions
Verify tests pass: ` npm run test:unit packages/block-editor/src/components/block-title/test/index.js`
