### PR TITLE
Block editor: Move margins to theme.scss and common.scss

### DIFF
--- a/packages/block-library/src/audio/block.json
+++ b/packages/block-library/src/audio/block.json
@@ -44,11 +44,6 @@
 	"supports": {
 		"anchor": true,
 		"align": true,
-		"__experimentalStyle": {
-			"spacing": {
-				"margin": "0 0 1em 0"
-			}
-		},
 		"spacing": {
 			"margin": true,
 			"padding": true

--- a/packages/block-library/src/audio/theme.scss
+++ b/packages/block-library/src/audio/theme.scss
@@ -1,3 +1,7 @@
 .wp-block-audio figcaption {
 	@include caption-style-theme();
 }
+
+.wp-block-audio {
+	margin: 0 0 1em 0;
+}

--- a/packages/block-library/src/common.scss
+++ b/packages/block-library/src/common.scss
@@ -154,3 +154,10 @@ html :where(img[class*="wp-image-"]) {
 	height: auto;
 	max-width: 100%;
 }
+
+/**
+ * Reset user agent styles for figure element margins.
+ */
+figure {
+	margin: 0 0 1em 0;
+}

--- a/packages/block-library/src/embed/block.json
+++ b/packages/block-library/src/embed/block.json
@@ -35,12 +35,7 @@
 		}
 	},
 	"supports": {
-		"align": true,
-		"__experimentalStyle": {
-			"spacing": {
-				"margin": "0 0 1em 0"
-			}
-		}
+		"align": true
 	},
 	"editorStyle": "wp-block-embed-editor",
 	"style": "wp-block-embed"

--- a/packages/block-library/src/embed/theme.scss
+++ b/packages/block-library/src/embed/theme.scss
@@ -1,3 +1,7 @@
 .wp-block-embed figcaption {
 	@include caption-style-theme();
 }
+
+.wp-block-embed {
+	margin: 0 0 1em 0;
+}

--- a/packages/block-library/src/image/block.json
+++ b/packages/block-library/src/image/block.json
@@ -100,11 +100,6 @@
 				"radius": true,
 				"width": true
 			}
-		},
-		"__experimentalStyle": {
-			"spacing": {
-				"margin": "0 0 1em 0"
-			}
 		}
 	},
 	"styles": [

--- a/packages/block-library/src/image/theme.scss
+++ b/packages/block-library/src/image/theme.scss
@@ -1,3 +1,7 @@
 .wp-block-image figcaption {
 	@include caption-style-theme();
 }
+
+.wp-block-image {
+	margin: 0 0 1em 0;
+}

--- a/packages/block-library/src/table/block.json
+++ b/packages/block-library/src/table/block.json
@@ -160,12 +160,7 @@
 				"width": true
 			}
 		},
-		"__experimentalSelector": ".wp-block-table > table",
-		"__experimentalStyle": {
-			"spacing": {
-				"margin": "0 0 1em 0"
-			}
-		}
+		"__experimentalSelector": ".wp-block-table > table"
 	},
 	"styles": [
 		{

--- a/packages/block-library/src/table/theme.scss
+++ b/packages/block-library/src/table/theme.scss
@@ -1,4 +1,6 @@
 .wp-block-table {
+	margin: "0 0 1em 0";
+
 	thead {
 		border-bottom: 3px solid;
 	}

--- a/packages/block-library/src/video/block.json
+++ b/packages/block-library/src/video/block.json
@@ -80,11 +80,6 @@
 		"spacing": {
 			"margin": true,
 			"padding": true
-		},
-		"__experimentalStyle": {
-			"spacing": {
-				"margin": "0 0 1em 0"
-			}
 		}
 	},
 	"editorStyle": "wp-block-video-editor",

--- a/packages/block-library/src/video/theme.scss
+++ b/packages/block-library/src/video/theme.scss
@@ -1,3 +1,7 @@
 .wp-block-video figcaption {
 	@include caption-style-theme();
 }
+
+.wp-block-video {
+	margin: 0 0 1em 0;
+}


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
This is an alternative to https://github.com/WordPress/gutenberg/pull/43792

This moves margins from the block.json to theme.scss. This means the load order is preserved in the front and backend. 

I have also added a reset to the common.scss file, so that if themes don't want to load opinionated styles they will still get this reset on the figure elements like image and embed.

I'd rather have the margins in theme.scss than style.scss because style.scss should ideally only contain rules that cannot be expressed in theme.json. We could probably get away with only having this rule in common.scss but the specificity will be different, so it's safer to also leave the existing rules in theme.scss as well.

Fixes https://github.com/WordPress/gutenberg/issues/43618

## Why?
So that the editor matches the frontend.

## Testing Instructions
1. Add several images to a post
2. Confirm that in the frontend and in the editor the space between the images is controlled by the owl selector (+) not the block selector (.wp-block-image)
3. Do the same for embed, video, table and audio blocks.
