### PR TITLE
Block Editor: Refactor `Warning` tests to `@testing-library/react`

### DIFF
--- a/packages/block-editor/src/components/warning/test/__snapshots__/index.js.snap
+++ b/packages/block-editor/src/components/warning/test/__snapshots__/index.js.snap
@@ -1,25 +1,22 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`Warning should match snapshot 1`] = `
-<div
-  style={
-    Object {
-      "all": "initial",
-      "display": "contents",
-    }
-  }
->
+<div>
   <div
-    className="block-editor-warning"
+    style="display: contents; all: initial;"
   >
     <div
-      className="block-editor-warning__contents"
+      class="block-editor-warning"
     >
-      <p
-        className="block-editor-warning__message"
+      <div
+        class="block-editor-warning__contents"
       >
-        error
-      </p>
+        <p
+          class="block-editor-warning__message"
+        >
+          error
+        </p>
+      </div>
     </div>
   </div>
 </div>

--- a/packages/block-editor/src/components/warning/test/index.js
+++ b/packages/block-editor/src/components/warning/test/index.js
@@ -1,7 +1,8 @@
 /**
  * External dependencies
  */
-import { shallow } from 'enzyme';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 
 /**
  * Internal dependencies
@@ -10,47 +11,49 @@ import Warning from '../index';
 
 describe( 'Warning', () => {
 	it( 'should match snapshot', () => {
-		const wrapper = shallow( <Warning>error</Warning> );
+		const { container } = render( <Warning>error</Warning> );
 
-		expect( wrapper ).toMatchSnapshot();
+		expect( container ).toMatchSnapshot();
 	} );
 
-	it( 'should have valid class', () => {
-		const wrapper = shallow( <Warning /> );
+	it( 'should show primary actions', () => {
+		render(
+			<Warning actions={ <button>Click me</button> }>Message</Warning>
+		);
 
-		expect( wrapper.find( '.block-editor-warning' ) ).toHaveLength( 1 );
-		expect( wrapper.find( '.block-editor-warning__actions' ) ).toHaveLength(
-			0
-		);
-		expect( wrapper.find( '.block-editor-warning__hidden' ) ).toHaveLength(
-			0
-		);
+		expect(
+			screen.getByRole( 'button', { name: 'Click me' } )
+		).toBeVisible();
+
+		expect(
+			screen.queryByRole( 'button', { name: 'More options' } )
+		).not.toBeInTheDocument();
 	} );
 
-	it( 'should show child error message element', () => {
-		const wrapper = shallow(
-			<Warning actions={ <button /> }>Message</Warning>
-		);
+	it( 'should show hidden secondary actions', async () => {
+		const user = userEvent.setup( {
+			advanceTimers: jest.advanceTimersByTime,
+		} );
 
-		const actions = wrapper.find( '.block-editor-warning__actions' );
-		const action = actions.childAt( 0 );
-
-		expect( actions ).toHaveLength( 1 );
-		expect( action.hasClass( 'block-editor-warning__action' ) ).toBe(
-			true
-		);
-		expect( action.childAt( 0 ).type() ).toBe( 'button' );
-	} );
-
-	it( 'should show hidden actions', () => {
-		const wrapper = shallow(
+		render(
 			<Warning secondaryActions={ [ { title: 'test', onClick: null } ] }>
 				Message
 			</Warning>
 		);
 
-		const actions = wrapper.find( '.block-editor-warning__secondary' );
+		const secondaryActionsBtn = screen.getByRole( 'button', {
+			name: 'More options',
+		} );
 
-		expect( actions ).toHaveLength( 1 );
+		expect( secondaryActionsBtn ).toBeVisible();
+		expect(
+			screen.queryByRole( 'menuitem', { name: 'test' } )
+		).not.toBeInTheDocument();
+
+		await user.click( secondaryActionsBtn );
+
+		expect(
+			screen.getByRole( 'menuitem', { name: 'test' } )
+		).toBeInTheDocument();
 	} );
 } );


### PR DESCRIPTION
## What?
We've recently started refactoring `enzyme` tests to `@testing-library/react`.

This PR refactors the `<Warning />` component tests from `enzyme` to `@testing-library/react`.

## Why?
`@testing-library/react` provides a better way to write tests for accessible components that is closer to the way the user experiences them.

Ideally, we should not be using snapshot tests here, however, the purpose of this PR is not to improve or enrich the tests themselves, but rather to migrate them `@testing-library/react`. Our primary motivation is unblocking the upgrade to React 18. 

## How?
We're straightforwardly replacing `enzyme` tests with `@testing-library/react` ones, using `jest-dom` matchers and mocks to avoid testing unrelated implementation details.

## Testing Instructions
Verify tests pass: `npm run test:unit packages/block-editor/src/components/warning/test/index.js`
