### PR TITLE
Block Editor: Refactor `BlockView` tests to `@testing-library/react`

### DIFF
--- a/packages/block-editor/src/components/block-compare/test/__snapshots__/block-view.js.snap
+++ b/packages/block-editor/src/components/block-compare/test/__snapshots__/block-view.js.snap
@@ -1,40 +1,42 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`BlockView should match snapshot 1`] = `
-<div
-  className="class"
->
+<div>
   <div
-    className="block-editor-block-compare__content"
+    class="class"
   >
-    <h2
-      className="block-editor-block-compare__heading"
-    >
-      title
-    </h2>
     <div
-      className="block-editor-block-compare__html"
+      class="block-editor-block-compare__content"
     >
-      raw
+      <h2
+        class="block-editor-block-compare__heading"
+      >
+        title
+      </h2>
+      <div
+        class="block-editor-block-compare__html"
+      >
+        raw
+      </div>
+      <div
+        class="block-editor-block-compare__preview edit-post-visual-editor"
+      >
+        <div>
+          render
+        </div>
+      </div>
     </div>
     <div
-      className="block-editor-block-compare__preview edit-post-visual-editor"
+      class="block-editor-block-compare__action"
     >
-      <RawHTML>
-        render
-      </RawHTML>
+      <button
+        class="components-button is-secondary"
+        tabindex="0"
+        type="button"
+      >
+        action
+      </button>
     </div>
-  </div>
-  <div
-    className="block-editor-block-compare__action"
-  >
-    <ForwardRef(Button)
-      onClick={[Function]}
-      tabIndex="0"
-      variant="secondary"
-    >
-      action
-    </ForwardRef(Button)>
   </div>
 </div>
 `;

--- a/packages/block-editor/src/components/block-compare/test/block-view.js
+++ b/packages/block-editor/src/components/block-compare/test/block-view.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { shallow } from 'enzyme';
+import { render } from '@testing-library/react';
 
 /**
  * Internal dependencies
@@ -12,7 +12,7 @@ const noop = () => {};
 
 describe( 'BlockView', () => {
 	test( 'should match snapshot', () => {
-		const wrapper = shallow(
+		const { container } = render(
 			<BlockView
 				title="title"
 				rawContent="raw"
@@ -23,6 +23,6 @@ describe( 'BlockView', () => {
 			/>
 		);
 
-		expect( wrapper ).toMatchSnapshot();
+		expect( container ).toMatchSnapshot();
 	} );
 } );


### PR DESCRIPTION
## What?
We've recently started refactoring `enzyme` tests to `@testing-library/react`.

This PR refactors the `<BlockView />` component tests from `enzyme` to `@testing-library/react`.

## Why?
`@testing-library/react` provides a better way to write tests for accessible components that is closer to the way the user experiences them.

Ideally, we should not be using snapshot tests here, however, the purpose of this PR is not to improve or enrich the tests themselves, but rather to migrate them `@testing-library/react`. Our primary motivation is unblocking the upgrade to React 18. 

## How?
We're straightforwardly replacing `enzyme` tests with `@testing-library/react` ones, using `jest-dom` matchers and mocks to avoid testing unrelated implementation details.

## Testing Instructions
Verify tests pass: `npm run test:unit packages/block-editor/src/components/block-compare/test/block-view.js`
