### PR TITLE
Categories List Block: escape home_url()

### DIFF
--- a/packages/block-library/src/categories/index.php
+++ b/packages/block-library/src/categories/index.php
@@ -15,6 +15,7 @@
 function render_block_core_categories( $attributes ) {
 	static $block_id = 0;
 	$block_id++;
+
 	$args = array(
 		'echo'         => false,
 		'hierarchical' => ! empty( $attributes['showHierarchy'] ),

--- a/packages/block-library/src/categories/index.php
+++ b/packages/block-library/src/categories/index.php
@@ -15,7 +15,6 @@
 function render_block_core_categories( $attributes ) {
 	static $block_id = 0;
 	$block_id++;
-
 	$args = array(
 		'echo'         => false,
 		'hierarchical' => ! empty( $attributes['showHierarchy'] ),
@@ -76,7 +75,7 @@ function build_dropdown_script_block_core_categories( $dropdown_id ) {
 		var dropdown = document.getElementById( '<?php echo esc_js( $dropdown_id ); ?>' );
 		function onCatChange() {
 			if ( dropdown.options[ dropdown.selectedIndex ].value > 0 ) {
-				location.href = "<?php echo home_url(); ?>/?cat=" + dropdown.options[ dropdown.selectedIndex ].value;
+				location.href = "<?php echo esc_url( home_url() ); ?>/?cat=" + dropdown.options[ dropdown.selectedIndex ].value;
 			}
 		}
 		dropdown.onchange = onCatChange;


### PR DESCRIPTION
Fix #43812

## What?
This PR escapes the `home_url()` in the callback function in the Category List block.

## Why?
To improve security and code quality.

## How?
Apply `esc_url()`


## Testing Instructions

- Register some categories.
- On th block editor, insert "**Categories List**" block (not "**Categories**" block. The label of the `core/categories` block is "Categories List").
- Enable "Display as dropdown" and "Show empty categories".
- On the front end, confirm that when the drop-down is changed, it correctly transitions to the category page.
