### PR TITLE
Updating versions in WP for 6.0.2

### DIFF
--- a/docs/contributors/versions-in-wordpress.md
+++ b/docs/contributors/versions-in-wordpress.md
@@ -6,6 +6,7 @@ If anything looks incorrect here, please bring it up in #core-editor in [WordPre
 
 | Gutenberg Versions | WordPress Version |
 | ------------------ | ----------------- |
+| 12.0-13.0          | 6.0.2             |
 | 12.0-13.0          | 6.0.1             |
 | 12.0-13.0          | 6.0               |
 | 10.8-11.9          | 5.9.3             |


### PR DESCRIPTION
## What?

Updating versions in WordPress doc in light of 6.0.2 update. 

## Why?

To keep the doc up to date :) 

## How?

Minor text change!
