### PR TITLE
Add post-install script to wp-env

### DIFF
--- a/packages/env/lib/cli.js
+++ b/packages/env/lib/cli.js
@@ -101,7 +101,7 @@ module.exports = function cli() {
 	yargs.parserConfiguration( { 'unknown-options-as-args': true } );
 
 	yargs.command(
-		'start',
+		'start [postInstallScriptArgs..]',
 		wpGreen(
 			chalk`Starts WordPress for development on port {bold.underline ${ terminalLink(
 				'8888',
@@ -112,6 +112,11 @@ module.exports = function cli() {
 			) }} (override with WP_ENV_TESTS_PORT). The current working directory must be a WordPress installation, a plugin, a theme, or contain a .wp-env.json file. After first install, use the '--update' flag to download updates to mapped sources and to re-apply WordPress configuration options.`
 		),
 		( args ) => {
+			args.positional( 'postInstallScriptArgs', {
+				type: 'array',
+				describe:
+					'Arguments to pass to a postinstall script, if one is defined.',
+			} );
 			args.option( 'update', {
 				type: 'boolean',
 				describe:

--- a/packages/env/lib/config/config.js
+++ b/packages/env/lib/config/config.js
@@ -27,6 +27,7 @@ const md5 = require( '../md5' );
  * @property {boolean}                          detectedLocalConfig     If true, wp-env detected local config and used it.
  * @property {Object.<string, WPServiceConfig>} env                     Specific config for different environments.
  * @property {boolean}                          debug                   True if debug mode is enabled.
+ * @property {?string}                          postInstallScript       A user script to execute after WordPress is installed.
  */
 
 /**
@@ -112,15 +113,16 @@ module.exports = async function readConfig( configPath ) {
 		},
 	};
 
+	// This is mostly unused, as individual options are assigned to the individual services.
+	const rootConfig = mergeWpServiceConfigs( [
+		defaultConfiguration,
+		baseConfig,
+		overrideConfig,
+	] );
+
 	// A quick validation before merging on a service by service level allows us
 	// to check the root configuration options and provide more helpful errors.
-	validateConfig(
-		mergeWpServiceConfigs( [
-			defaultConfiguration,
-			baseConfig,
-			overrideConfig,
-		] )
-	);
+	validateConfig( rootConfig );
 
 	// A unique array of the environments specified in the config options.
 	// Needed so that we can override settings per-environment, rather than
@@ -174,6 +176,9 @@ module.exports = async function readConfig( configPath ) {
 		workDirectoryPath,
 		detectedLocalConfig,
 		env,
+		postInstallScript: rootConfig.postInstallScript
+			? path.resolve( process.cwd(), rootConfig.postInstallScript )
+			: undefined,
 	} );
 };
 

--- a/packages/env/lib/config/validate-config.js
+++ b/packages/env/lib/config/validate-config.js
@@ -1,4 +1,9 @@
 'use strict';
+/**
+ * External dependencies
+ */
+const fs = require( 'fs' );
+const path = require( 'path' );
 
 /**
  * @typedef {import('./config').WPServiceConfig} WPServiceConfig
@@ -81,6 +86,26 @@ function validateConfig( config, envLocation ) {
 		throw new ValidationError(
 			`Invalid .wp-env.json: "${ envPrefix }phpVersion" must be a string of the format "0.0".`
 		);
+	}
+
+	if (
+		config.postInstallScript !== undefined &&
+		typeof config.postInstallScript !== 'string'
+	) {
+		throw new ValidationError(
+			`Invalid .wp-env.json: "${ envPrefix }postInstallScript" must be a string or undefined.`
+		);
+	}
+
+	if ( config.postInstallScript ) {
+		const script = path.resolve( process.cwd(), config.postInstallScript );
+		try {
+			fs.accessSync( script, fs.constants.X_OK );
+		} catch ( e ) {
+			throw new ValidationError(
+				`Invalid .wp-env.json: the postInstallScript "${ script }" is not executable. It either does not exist or has incorrect permissions.`
+			);
+		}
 	}
 
 	return config;


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Adds a post install script to wp-env. This can be used for 3rd parties to write extra startup behavior -- such as importing a database or setting up things with wp cli. This script is executed after WordPress finishes configuring. It executes on first install and on any future updates to the config or WordPress. (E.g. it can be triggered with `--update`)

Any arguments added to `wp-env start` which aren't already used are passed to this script. So if you write `wp-env start --update hello foo bar --option=1 --verbose`, the arguments to the post install script (`$@`) will be `hello foo bar --option=1`, since verbose and update are both used by wp-env start.

## Why?
TBD, link some existing issues

## How?
A new .wp-env.json config option "postInstallScript" only allowed in the root config. (e.g. not available per-environment.)

## Testing Instructions
1. Checkout this branch
2. Add a test shell script somewhere which prints the arguments and make it executable.
3. Add "postInstallScript": path/to/script to your .wp-env.override.json. The path should be relative to the .wp-env.json config.

## Screenshots or screencast <!-- if applicable -->
