### PR TITLE
Embed Block: Remove incorrect comments about block variations

### DIFF
--- a/packages/block-library/src/embed/variations.js
+++ b/packages/block-library/src/embed/variations.js
@@ -29,6 +29,13 @@ import {
 	embedPocketCastsIcon,
 } from './icons';
 
+/** @typedef {import('@wordpress/blocks').WPBlockVariation} WPBlockVariation */
+
+/**
+ * The embed provider services.
+ *
+ * @type {WPBlockVariation[]}
+ */
 const variations = [
 	{
 		name: 'twitter',

--- a/packages/block-library/src/embed/variations.js
+++ b/packages/block-library/src/embed/variations.js
@@ -29,13 +29,6 @@ import {
 	embedPocketCastsIcon,
 } from './icons';
 
-/** @typedef {import('@wordpress/blocks').WPBlockVariation} WPBlockVariation */
-
-/**
- * Template option choices for predefined columns layouts.
- *
- * @type {WPBlockVariation[]}
- */
 const variations = [
 	{
 		name: 'twitter',


### PR DESCRIPTION
## What?
This PR removes incorrect comment about block variations on `variations.js`.

## Why?
I found that this comment does not correctly describe the variation.
Perhaps it was copied from [a comment in the column block](https://github.com/WordPress/gutenberg/blob/a1dcea4b61e880206d24ebdedbb3aba5194dcdd2/packages/block-library/src/columns/variations.js#L9-L13).

## How?
Only the column block has comments about the `variation` variable.
For simple variations, I think the comment was unnecessary and removed it.

## Testing Instructions
There is no impact on the code.