### PR TITLE
Fix: block styles preview is not displayed

### DIFF
--- a/packages/block-editor/src/components/block-styles/preview-panel.js
+++ b/packages/block-editor/src/components/block-styles/preview-panel.js
@@ -1,6 +1,7 @@
 /**
  * WordPress dependencies
  */
+import { getBlockType } from '@wordpress/blocks';
 import { useMemo } from '@wordpress/element';
 
 /**
@@ -15,6 +16,7 @@ export default function BlockStylesPreviewPanel( {
 	className,
 	activeStyle,
 } ) {
+	const example = getBlockType( genericPreviewBlock.name )?.example;
 	const styleClassName = replaceActiveStyle( className, activeStyle, style );
 	const previewBlocks = useMemo( () => {
 		return {
@@ -27,6 +29,7 @@ export default function BlockStylesPreviewPanel( {
 					styleClassName +
 					' block-editor-block-styles__block-preview-container',
 			},
+			example,
 		};
 	}, [ genericPreviewBlock, styleClassName ] );
 

--- a/packages/block-editor/src/components/inserter/preview-panel.js
+++ b/packages/block-editor/src/components/inserter/preview-panel.js
@@ -4,6 +4,7 @@
 import {
 	isReusableBlock,
 	createBlock,
+	getBlockType,
 	getBlockFromExample,
 } from '@wordpress/blocks';
 import { __ } from '@wordpress/i18n';
@@ -15,8 +16,11 @@ import BlockCard from '../block-card';
 import BlockPreview from '../block-preview';
 
 function InserterPreviewPanel( { item } ) {
-	const { name, title, icon, description, initialAttributes, example } = item;
+	const { name, title, icon, description, initialAttributes } = item;
 	const isReusable = isReusableBlock( item );
+	const hoveredItemBlockType = getBlockType( name );
+	const example = item.example || hoveredItemBlockType.example;
+
 	return (
 		<div className="block-editor-inserter__preview-container">
 			<div className="block-editor-inserter__preview">
@@ -27,7 +31,7 @@ function InserterPreviewPanel( { item } ) {
 							viewportWidth={ example?.viewportWidth ?? 500 }
 							blocks={
 								example
-									? getBlockFromExample( item.name, {
+									? getBlockFromExample( name, {
 											attributes: {
 												...example.attributes,
 												...initialAttributes,

--- a/packages/block-editor/src/components/inserter/preview-panel.js
+++ b/packages/block-editor/src/components/inserter/preview-panel.js
@@ -17,7 +17,6 @@ import BlockPreview from '../block-preview';
 function InserterPreviewPanel( { item } ) {
 	const { name, title, icon, description, initialAttributes, example } = item;
 	const isReusable = isReusableBlock( item );
-
 	return (
 		<div className="block-editor-inserter__preview-container">
 			<div className="block-editor-inserter__preview">

--- a/packages/block-editor/src/components/inserter/preview-panel.js
+++ b/packages/block-editor/src/components/inserter/preview-panel.js
@@ -4,7 +4,6 @@
 import {
 	isReusableBlock,
 	createBlock,
-	getBlockType,
 	getBlockFromExample,
 } from '@wordpress/blocks';
 import { __ } from '@wordpress/i18n';
@@ -16,10 +15,8 @@ import BlockCard from '../block-card';
 import BlockPreview from '../block-preview';
 
 function InserterPreviewPanel( { item } ) {
-	const { name, title, icon, description, initialAttributes } = item;
+	const { name, title, icon, description, initialAttributes, example } = item;
 	const isReusable = isReusableBlock( item );
-	const hoveredItemBlockType = getBlockType( name );
-	const example = item.example || hoveredItemBlockType.example;
 
 	return (
 		<div className="block-editor-inserter__preview-container">


### PR DESCRIPTION
Fix ##43836
Follow-up on #42454

## What?
This PR fixes a problem with block style previews not displaying properly.

## Why?
In #42454, the block variation `example` is now referenced to enable a preview of template parts.
However, to preview regular block styles, the main block `example` must be referenced.

## How?
If the `example` of the block variation does not exist, the `example` of the main block is referenced. This will ensure that previews of block variations and block styles are displayed correctly.

## Testing Instructions
Open the Global Inserter and confirm that the template part preview is enabled as before.

![inserter-preview](https://user-images.githubusercontent.com/54422211/188321634-7dcf1c82-23b7-44cc-9cfa-5da0829a6e62.png)

Insert a block with a block style and confirm that the preview displays correctly when you mouse over the style button.

![style-preview](https://user-images.githubusercontent.com/54422211/188321641-f9a9b862-86fb-4a75-b027-bd027db75345.png)
