### PR TITLE
Style engine: refer to 'context' rather than 'store' in global function

### DIFF
--- a/lib/compat/wordpress-6.1/script-loader.php
+++ b/lib/compat/wordpress-6.1/script-loader.php
@@ -65,7 +65,7 @@ function gutenberg_enqueue_stored_styles() {
 		}
 		// Chain core store ids to signify what the styles contain.
 		$style_tag_id             .= '-' . $style_key;
-		$compiled_core_stylesheet .= gutenberg_style_engine_get_stylesheet_from_store( $style_key );
+		$compiled_core_stylesheet .= gutenberg_style_engine_get_stylesheet_from_context( $style_key );
 	}
 
 	// Combine Core styles.
@@ -81,7 +81,7 @@ function gutenberg_enqueue_stored_styles() {
 		if ( in_array( $store_name, $core_styles_keys, true ) ) {
 			continue;
 		}
-		$styles = gutenberg_style_engine_get_stylesheet_from_store( $store_name );
+		$styles = gutenberg_style_engine_get_stylesheet_from_context( $store_name );
 		if ( ! empty( $styles ) ) {
 			$key = "wp-style-engine-$store_name";
 			wp_register_style( $key, false, array(), true, true );

--- a/packages/style-engine/README.md
+++ b/packages/style-engine/README.md
@@ -135,9 +135,9 @@ $stylesheet = wp_style_engine_get_stylesheet_from_css_rules(
 print_r( $stylesheet ); // .wp-pumpkin, .wp-kumquat {color:orange}.wp-tomato{color:red;padding:100px}
 ```
 
-### wp_style_engine_get_stylesheet_from_store()
+### wp_style_engine_get_stylesheet_from_context()
 
-Returns compiled CSS from a store, if found.
+Returns compiled CSS from a stored context, if found.
 
 _Parameters_
 
@@ -167,8 +167,8 @@ $stylesheet = wp_style_engine_get_stylesheet_from_css_rules(
     )
 );
 
-// Later, fetch compiled rules from store.
-$stylesheet = gutenberg_style_engine_get_stylesheet_from_store( 'fruit-styles' );
+// Later, fetch compiled rules from context store.
+$stylesheet = gutenberg_style_engine_get_stylesheet_from_context( 'fruit-styles' );
 print_r( $stylesheet ); // .wp-apple{color:green;}
 if ( ! empty( $stylesheet ) ) {
     wp_register_style( 'my-stylesheet', false, array(), true, true );
@@ -229,6 +229,8 @@ A guide to the terms and variable names referenced by the Style Engine package.
 <dl>
   <dt>Block style (Gutenberg internal)</dt>
   <dd>An object comprising a block's style attribute that contains a block's style values. E.g., <code>{ spacing: { margin: '10px' }, color: { ... }, ...  }</code></dd>
+  <dt>Context</dt>
+  <dd>An identifier for a group of styles that share a common origin or purpose, e.g., 'block-supports' or 'global-styles'. The context is also used as a key to fetch CSS rules from the store.</dd>
   <dt>CSS declaration or (CSS property declaration)</dt>
   <dd>A CSS property paired with a CSS value. E.g., <code>color: pink</code> </dd>
   <dt>CSS declarations block</dt>

--- a/packages/style-engine/class-wp-style-engine.php
+++ b/packages/style-engine/class-wp-style-engine.php
@@ -636,7 +636,7 @@ function wp_style_engine_get_stylesheet_from_css_rules( $css_rules, $options = a
  *
  * @return string A compiled CSS string.
  */
-function wp_style_engine_get_stylesheet_from_store( $store_name ) {
+function wp_style_engine_get_stylesheet_from_context( $store_name ) {
 	if ( ! class_exists( 'WP_Style_Engine' ) || empty( $store_name ) ) {
 		return '';
 	}


### PR DESCRIPTION
## What?
Renames user-facing method `wp_style_engine_get_stylesheet_from_store` to `wp_style_engine_get_stylesheet_from_context` since it matches the incoming option parameter 'context'

Props to @noisysocks for the nudge

## Why?
So that the fetching method matches the `context` option.

Also, the assumption is that 'store' is not meaningful on its own.

```php
	// Register block supports styles.
	wp_style_engine_get_styles(
		$block_styles,
		array(
			'selector' => ".$class_name",
			'context'  => 'block-supports', // context!!!
		)
	);

	// Fetch block supports styles from context store.
	$styles = wp_style_engine_get_stylesheet_from_context( 'block-supports' );
```



## Testing Instructions
The tests should pass.
