### PR TITLE
Navigation: Set the icon control to full width.

### DIFF
--- a/packages/block-library/src/navigation/edit/overlay-menu-preview.js
+++ b/packages/block-library/src/navigation/edit/overlay-menu-preview.js
@@ -28,32 +28,28 @@ export default function OverlayMenuPreview( { setAttributes, hasIcon, icon } ) {
 			<ToggleGroupControl
 				label={ __( 'Icon' ) }
 				value={ icon }
-				help={ __( 'Choose an icon or add your own.' ) }
 				onChange={ ( value ) => setAttributes( { icon: value } ) }
+				isBlock
 			>
 				<ToggleGroupControlOption
 					value="handle"
 					aria-label={ __( 'handle' ) }
 					label={ <OverlayMenuIcon icon="handle" /> }
-					className="wp-block-navigation__icon-button"
 				/>
 				<ToggleGroupControlOption
 					value="menu"
 					aria-label={ __( 'menu' ) }
 					label={ <OverlayMenuIcon icon="menu" /> }
-					className="wp-block-navigation__icon-button"
 				/>
 				<ToggleGroupControlOption
 					value="more-vertical"
 					aria-label={ __( 'more vertical' ) }
 					label={ <OverlayMenuIcon icon="more-vertical" /> }
-					className="wp-block-navigation__icon-button"
 				/>
 				<ToggleGroupControlOption
 					value="more-horizontal"
 					aria-label={ __( 'more horizontal' ) }
 					label={ <OverlayMenuIcon icon="more-horizontal" /> }
-					className="wp-block-navigation__icon-button"
 				/>
 			</ToggleGroupControl>
 		</>

--- a/packages/block-library/src/navigation/editor.scss
+++ b/packages/block-library/src/navigation/editor.scss
@@ -610,12 +610,6 @@ body.editor-styles-wrapper
 	display: none;
 }
 
-
-.components-toggle-group-control-option-base.wp-block-navigation__icon-button {
-	// Override the default padding of ToggleGroupControlOption.
-	padding: 0 3px;
-}
-
 /**
  * Navigation selector styles
  */


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->
A follow-up to https://github.com/WordPress/gutenberg/pull/43674. Set the icon control to full width.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

See https://github.com/WordPress/gutenberg/issues/37930#issuecomment-1234032159 for the latest design.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
Use the `isBlock` prop.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->
1. Go to the Site Editor
2. Select a Header block
3. Click on the display in the block settings sidebar to open the preview
4. See that the icon control is full width

## Screenshots or screencast <!-- if applicable -->

Before | After
--- | ---
![before](https://user-images.githubusercontent.com/7753001/188404562-f36ce1d6-50ab-49a6-98c5-f72d234e1faf.png) | ![after](https://user-images.githubusercontent.com/7753001/188404165-c13b11cc-9039-47e9-9677-f4570ccd2ea2.png)
