### PR TITLE
Popover: stabilize __unstableShift prop to shift

### DIFF
--- a/packages/block-editor/src/components/block-popover/index.js
+++ b/packages/block-editor/src/components/block-popover/index.js
@@ -68,7 +68,7 @@ function BlockPopover(
 			__unstableSlotName={ __unstablePopoverSlot || null }
 			resize={ false }
 			flip={ false }
-			__unstableShift
+			shift
 			{ ...props }
 			className={ classnames(
 				'block-editor-block-popover',

--- a/packages/block-editor/src/components/block-tools/use-block-toolbar-popover-props.js
+++ b/packages/block-editor/src/components/block-tools/use-block-toolbar-popover-props.js
@@ -16,7 +16,7 @@ import { __unstableUseBlockElement as useBlockElement } from '../block-list/use-
 // top of the viewport.
 const DEFAULT_PROPS = {
 	flip: false,
-	__unstableShift: true,
+	shift: true,
 };
 
 // When there isn't enough height between the top of the block and the editor
@@ -26,7 +26,7 @@ const DEFAULT_PROPS = {
 // otherwise the toolbar will be off-screen.
 const RESTRICTED_HEIGHT_PROPS = {
 	flip: true,
-	__unstableShift: false,
+	shift: false,
 };
 
 /**

--- a/packages/block-editor/src/components/colors-gradients/dropdown.js
+++ b/packages/block-editor/src/components/colors-gradients/dropdown.js
@@ -120,7 +120,7 @@ export default function ColorGradientSettingsDropdown( {
 		popoverProps = {
 			placement: 'left-start',
 			offset: 36,
-			__unstableShift: true,
+			shift: true,
 		};
 	}
 

--- a/packages/block-editor/src/components/url-popover/index.js
+++ b/packages/block-editor/src/components/url-popover/index.js
@@ -33,7 +33,7 @@ function URLPopover( {
 			className="block-editor-url-popover"
 			focusOnMount={ focusOnMount }
 			position={ position }
-			__unstableShift
+			shift
 			{ ...popoverProps }
 		>
 			<div className="block-editor-url-popover__input-container">

--- a/packages/block-editor/src/components/url-popover/test/__snapshots__/index.js.snap
+++ b/packages/block-editor/src/components/url-popover/test/__snapshots__/index.js.snap
@@ -2,10 +2,10 @@
 
 exports[`URLPopover matches the snapshot in its default state 1`] = `
 <ForwardRef(Popover)
-  __unstableShift={true}
   className="block-editor-url-popover"
   focusOnMount="firstElement"
   position="bottom center"
+  shift={true}
 >
   <div
     className="block-editor-url-popover__input-container"
@@ -39,10 +39,10 @@ exports[`URLPopover matches the snapshot in its default state 1`] = `
 
 exports[`URLPopover matches the snapshot when the settings are toggled open 1`] = `
 <ForwardRef(Popover)
-  __unstableShift={true}
   className="block-editor-url-popover"
   focusOnMount="firstElement"
   position="bottom center"
+  shift={true}
 >
   <div
     className="block-editor-url-popover__input-container"
@@ -83,10 +83,10 @@ exports[`URLPopover matches the snapshot when the settings are toggled open 1`] 
 
 exports[`URLPopover matches the snapshot when there are no settings 1`] = `
 <ForwardRef(Popover)
-  __unstableShift={true}
   className="block-editor-url-popover"
   focusOnMount="firstElement"
   position="bottom center"
+  shift={true}
 >
   <div
     className="block-editor-url-popover__input-container"

--- a/packages/block-library/src/button/edit.js
+++ b/packages/block-library/src/button/edit.js
@@ -221,7 +221,7 @@ function ButtonEdit( props ) {
 					anchorRef={ ref?.current }
 					focusOnMount={ isEditingURL ? 'firstElement' : false }
 					__unstableSlotName={ '__unstable-block-tools-after' }
-					__unstableShift
+					shift
 				>
 					<LinkControl
 						className="wp-block-navigation-link__inline-link-input"

--- a/packages/block-library/src/navigation-link/edit.js
+++ b/packages/block-library/src/navigation-link/edit.js
@@ -845,7 +845,7 @@ export default function NavigationLinkEdit( {
 							position="bottom center"
 							onClose={ () => setIsLinkOpen( false ) }
 							anchorRef={ listItemRef.current }
-							__unstableShift
+							shift
 						>
 							<LinkControl
 								hasTextControl

--- a/packages/block-library/src/navigation-submenu/edit.js
+++ b/packages/block-library/src/navigation-submenu/edit.js
@@ -630,7 +630,7 @@ export default function NavigationSubmenuEdit( {
 							position="bottom center"
 							onClose={ () => setIsLinkOpen( false ) }
 							anchorRef={ listItemRef.current }
-							__unstableShift
+							shift
 						>
 							<LinkControl
 								className="wp-block-navigation-link__inline-link-input"

--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -9,13 +9,14 @@
 
 ### Enhancements
 
--   `ToggleControl`: Add `__nextHasNoMargin` prop for opting into the new margin-free styles ([#43717](https://github.com/WordPress/gutenberg/pull/43717)). 
+-   `ToggleControl`: Add `__nextHasNoMargin` prop for opting into the new margin-free styles ([#43717](https://github.com/WordPress/gutenberg/pull/43717)).
 -   `CheckboxControl`: Add `__nextHasNoMargin` prop for opting into the new margin-free styles ([#43720](https://github.com/WordPress/gutenberg/pull/43720)).
 -   `TextControl`, `TextareaControl`: Add `__nextHasNoMargin` prop for opting into the new margin-free styles ([#43782](https://github.com/WordPress/gutenberg/pull/43782)).
 -   `RangeControl`: Tweak dark gray marking color to be consistent with the grays in `@wordpress/base-styles` ([#43773](https://github.com/WordPress/gutenberg/pull/43773)).
 -   `UnitControl`: Tweak unit dropdown color to be consistent with the grays in `@wordpress/base-styles` ([#43773](https://github.com/WordPress/gutenberg/pull/43773)).
 -   `CardHeader`, `CardBody`, `CardFooter`: Tweak `isShady` background colors to be consistent with the grays in `@wordpress/base-styles` ([#43719](https://github.com/WordPress/gutenberg/pull/43719)).
 -   `InputControl`, `SelectControl`: Tweak `disabled` colors to be consistent with the grays in `@wordpress/base-styles` ([#43719](https://github.com/WordPress/gutenberg/pull/43719)).
+-   `Popover`: stabilize `__unstableShift` to `shift` ([#43845](https://github.com/WordPress/gutenberg/pull/43845)).
 
 ### Internal
 
@@ -23,7 +24,7 @@
 -   `ToggleGroupControl`: Rename `__experimentalIsIconGroup` prop to `__experimentalIsBorderless` ([#43771](https://github.com/WordPress/gutenberg/pull/43771/)).
 -   Refactor `FocalPointPicker` to function component ([#39168](https://github.com/WordPress/gutenberg/pull/39168)).
 -   `Guide`: use `code` instead of `keyCode` for keyboard events ([#43604](https://github.com/WordPress/gutenberg/pull/43604/)).
--   `ToggleControl`: Convert to TypeScript and streamline CSS ([#43717](https://github.com/WordPress/gutenberg/pull/43717)). 
+-   `ToggleControl`: Convert to TypeScript and streamline CSS ([#43717](https://github.com/WordPress/gutenberg/pull/43717)).
 -   `Navigation`: use `code` instead of `keyCode` for keyboard events ([#43644](https://github.com/WordPress/gutenberg/pull/43644/)).
 -   `ComboboxControl`: Add unit tests ([#42403](https://github.com/WordPress/gutenberg/pull/42403)).
 -   `NavigableContainer`: use `code` instead of `keyCode` for keyboard events, rewrite tests using RTL and `user-event` ([#43606](https://github.com/WordPress/gutenberg/pull/43606/)).

--- a/packages/components/src/border-box-control/border-box-control-split-controls/component.tsx
+++ b/packages/components/src/border-box-control/border-box-control-split-controls/component.tsx
@@ -43,7 +43,7 @@ const BorderBoxControlSplitControls = (
 				placement: popoverPlacement,
 				offset: popoverOffset,
 				anchorRef: containerRef,
-				__unstableShift: true,
+				shift: true,
 		  }
 		: undefined;
 

--- a/packages/components/src/border-box-control/border-box-control/component.tsx
+++ b/packages/components/src/border-box-control/border-box-control/component.tsx
@@ -69,7 +69,7 @@ const BorderBoxControl = (
 				placement: popoverPlacement,
 				offset: popoverOffset,
 				anchorRef: containerRef,
-				__unstableShift: true,
+				shift: true,
 		  }
 		: undefined;
 

--- a/packages/components/src/color-palette/index.js
+++ b/packages/components/src/color-palette/index.js
@@ -120,7 +120,7 @@ export function CustomColorPickerDropdown( {
 } ) {
 	const popoverProps = useMemo(
 		() => ( {
-			__unstableShift: true,
+			shift: true,
 			...( isRenderedInSidebar
 				? {
 						// When in the sidebar: open to the left (stacking),

--- a/packages/components/src/color-palette/test/__snapshots__/index.js.snap
+++ b/packages/components/src/color-palette/test/__snapshots__/index.js.snap
@@ -366,9 +366,9 @@ exports[`ColorPalette Dropdown should render it correctly 1`] = `
   contentClassName="components-color-palette__custom-color-dropdown-content"
   popoverProps={
     Object {
-      "__unstableShift": true,
       "offset": 8,
       "placement": "bottom",
+      "shift": true,
     }
   }
   renderContent={[Function]}
@@ -744,9 +744,9 @@ exports[`ColorPalette should render a dynamic toolbar of colors 1`] = `
             contentClassName="components-color-palette__custom-color-dropdown-content"
             popoverProps={
               Object {
-                "__unstableShift": true,
                 "offset": 8,
                 "placement": "bottom",
+                "shift": true,
               }
             }
             renderContent={[Function]}

--- a/packages/components/src/popover/README.md
+++ b/packages/components/src/popover/README.md
@@ -91,6 +91,14 @@ Adjusts the height of the `Popover` to prevent overflow.
 -   Required: No
 -   Default: `true`
 
+### shift
+
+Enables the `Popover` to shift in order to stay in view when meeting the viewport edges.
+
+-   Type: `Boolean`
+-   Required: No
+-   Default: `false`
+
 ### offset
 
 The distance (in pixels) between the anchor and popover.

--- a/packages/components/src/popover/index.js
+++ b/packages/components/src/popover/index.js
@@ -6,7 +6,7 @@ import classnames from 'classnames';
 import {
 	useFloating,
 	flip as flipMiddleware,
-	shift,
+	shift as shiftMiddleware,
 	autoUpdate,
 	arrow,
 	offset as offsetMiddleware,
@@ -162,7 +162,8 @@ const Popover = (
 		__unstableSlotName = SLOT_NAME,
 		flip = true,
 		resize = true,
-		__unstableShift = false,
+		shift = false,
+		__unstableShift,
 		__unstableForcePosition,
 		...contentProps
 	},
@@ -186,6 +187,18 @@ const Popover = (
 		// to `false` to replicate `__unstableForcePosition`.
 		flip = ! __unstableForcePosition;
 		resize = ! __unstableForcePosition;
+	}
+
+	let shouldShift = shift;
+	if ( __unstableShift !== undefined ) {
+		deprecated( '`__unstableShift` prop in Popover component', {
+			since: '6.1',
+			version: '6.3',
+			alternative: '`shift` prop`',
+		} );
+
+		// Back-compat.
+		shouldShift = __unstableShift;
 	}
 
 	const arrowRef = useRef( null );
@@ -262,8 +275,8 @@ const Popover = (
 					},
 			  } )
 			: undefined,
-		__unstableShift
-			? shift( {
+		shouldShift
+			? shiftMiddleware( {
 					crossAxis: true,
 					limiter: limitShift(),
 					padding: 1, // Necessary to avoid flickering at the edge of the viewport.

--- a/packages/components/src/popover/stories/index.js
+++ b/packages/components/src/popover/stories/index.js
@@ -75,7 +75,7 @@ export default {
 		__unstableSlotName: { control: { type: null } },
 		resize: { control: { type: 'boolean' } },
 		flip: { control: { type: 'boolean' } },
-		__unstableShift: { control: { type: 'boolean' } },
+		shift: { control: { type: 'boolean' } },
 	},
 };
 

--- a/packages/components/src/tooltip/index.js
+++ b/packages/components/src/tooltip/index.js
@@ -79,7 +79,7 @@ const addPopoverToGrandchildren = ( {
 				animate={ false }
 				offset={ offset }
 				anchorRef={ anchorRef }
-				__unstableShift
+				shift
 			>
 				{ text }
 				<Shortcut

--- a/packages/format-library/src/link/inline.js
+++ b/packages/format-library/src/link/inline.js
@@ -227,7 +227,7 @@ function InlineLinkUI( {
 			focusOnMount={ focusOnMount.current }
 			onClose={ stopAddingLink }
 			position="bottom center"
-			__unstableShift
+			shift
 		>
 			<LinkControl
 				key={ forceRemountKey }

--- a/packages/widgets/src/blocks/legacy-widget/edit/form.js
+++ b/packages/widgets/src/blocks/legacy-widget/edit/form.js
@@ -107,7 +107,7 @@ export default function Form( {
 					offset={ 32 }
 					resize={ false }
 					flip={ false }
-					__unstableShift
+					shift
 				>
 					<div
 						ref={ ref }


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## Dev note

See the dev note in https://github.com/WordPress/gutenberg/pull/44195

## What?
<!-- In a few words, what is the PR actually doing? -->

Closes https://github.com/WordPress/gutenberg/issues/43191

Stabilize `__unstableShift` by adding a new `shift` prop. The unstable prop is marked and deprecated and will be supported until the release of WordPress 6.3

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

See https://github.com/WordPress/gutenberg/issues/43191

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

- Added new `shift` prop
- Added deprecation notice for `__unstableShift` prop, while still supporting the legacy prop.
- Updated docs
- Refactored all `__unstableShift` instances in the repo to use `shift` instead 

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->

- Make sure Storybook examples and popovers in the editor behave as on `trunk`
- Make sure that the `__unstableShift` is not used anymore in the codebase
