### PR TITLE
Lodash: Refactor away from `BlockActionsMenu` (RN)

### DIFF
--- a/packages/block-editor/src/components/block-mobile-toolbar/block-actions-menu.native.js
+++ b/packages/block-editor/src/components/block-mobile-toolbar/block-actions-menu.native.js
@@ -2,7 +2,7 @@
  * External dependencies
  */
 import { Platform, findNodeHandle } from 'react-native';
-import { partial, first, castArray, last, every } from 'lodash';
+
 /**
  * WordPress dependencies
  */
@@ -307,21 +307,25 @@ export default compose(
 			canInsertBlockType,
 			getTemplateLock,
 		} = select( blockEditorStore );
-		const normalizedClientIds = castArray( clientIds );
+		const normalizedClientIds = Array.isArray( clientIds )
+			? clientIds
+			: [ clientIds ];
 		const block = getBlock( normalizedClientIds );
 		const blockName = getBlockName( normalizedClientIds );
 		const blockType = getBlockType( blockName );
 		const blockTitle = blockType?.title;
-		const firstClientId = first( normalizedClientIds );
+		const firstClientId = normalizedClientIds[ 0 ];
 		const rootClientId = getBlockRootClientId( firstClientId );
 		const blockOrder = getBlockOrder( rootClientId );
 
 		const firstIndex = getBlockIndex( firstClientId );
-		const lastIndex = getBlockIndex( last( normalizedClientIds ) );
+		const lastIndex = getBlockIndex(
+			normalizedClientIds[ normalizedClientIds.length - 1 ]
+		);
 
 		const innerBlocks = getBlocksByClientId( clientIds );
 
-		const canDuplicate = every( innerBlocks, ( innerBlock ) => {
+		const canDuplicate = innerBlocks.every( ( innerBlock ) => {
 			return (
 				!! innerBlock &&
 				hasBlockSupport( innerBlock.name, 'multiple', true ) &&
@@ -336,9 +340,9 @@ export default compose(
 			isExactlyOneBlock && isDefaultBlock && isEmptyContent;
 		const isLocked = !! getTemplateLock( rootClientId );
 
-		const selectedBlockClientId = first( getSelectedBlockClientIds() );
+		const selectedBlockClientId = getSelectedBlockClientIds()[ 0 ];
 		const selectedBlock = selectedBlockClientId
-			? first( getBlocksByClientId( selectedBlockClientId ) )
+			? getBlocksByClientId( selectedBlockClientId )[ 0 ]
 			: undefined;
 		const selectedBlockPossibleTransformations = selectedBlock
 			? getBlockTransformItems( [ selectedBlock ], rootClientId )
@@ -406,8 +410,10 @@ export default compose(
 				duplicateBlock() {
 					return duplicateBlocks( clientIds );
 				},
-				onMoveDown: partial( moveBlocksDown, clientIds, rootClientId ),
-				onMoveUp: partial( moveBlocksUp, clientIds, rootClientId ),
+				onMoveDown: ( ...args ) =>
+					moveBlocksDown( clientIds, rootClientId, ...args ),
+				onMoveUp: ( ...args ) =>
+					moveBlocksUp( clientIds, rootClientId, ...args ),
 				openGeneralSidebar: () =>
 					openGeneralSidebar( 'edit-post/block' ),
 				pasteBlock: ( clipboardBlock ) => {


### PR DESCRIPTION
## What?
This PR removes all of the Lodash from the `BlockActionsMenu` component. There are just a few usages and conversion is pretty straightforward. 

## Why?

Lodash is known to unnecessarily inflate the bundle size of packages, and in most cases, it can be replaced with native language functionality. See these for more information and rationale:

* https://github.com/WordPress/gutenberg/issues/16938#issuecomment-602837246
* https://github.com/WordPress/gutenberg/issues/17025
* https://github.com/WordPress/gutenberg/issues/39495 

## How?

We're replacing a few usages with their native counterparts. 

## Testing Instructions

* RN: Verify all kinds of block actions still work well on mobile - moving a block up and down, duplication, converting to regular blocks, pasting block after a certain one, copying, removing, transforming.
* Verify all checks are still green.