### PR TITLE
Navigation: Try adding minimal animation to overlay.

### DIFF
--- a/packages/block-library/src/navigation/style.scss
+++ b/packages/block-library/src/navigation/style.scss
@@ -431,6 +431,16 @@ button.wp-block-navigation-item__content {
  * Mobile menu.
  */
 
+@keyframes overlay-menu__fade-in-animation {
+	from {
+		opacity: 0;
+		top: 0.5em;
+	}
+	to {
+		opacity: 1;
+		top: 0;
+	}
+}
 .wp-block-navigation__responsive-container {
 	display: none;
 	position: fixed;
@@ -467,6 +477,11 @@ button.wp-block-navigation-item__content {
 		display: flex; // Needs to be set to override "none".
 		flex-direction: column;
 		background-color: inherit;
+
+		// Animation.
+		animation: overlay-menu__fade-in-animation 0.1s ease-out;
+		animation-fill-mode: forwards;
+		@include reduce-motion("animation");
 
 		// Try to inherit any root paddings set, so the X can align to a top-right aligned menu.
 		padding-top: var(--wp--style--root--padding-top, 2rem);
@@ -675,7 +690,8 @@ button.wp-block-navigation-item__content {
 }
 
 // Adjust open dialog top margin when admin-bar is visible.
-.has-modal-open .admin-bar .wp-block-navigation__responsive-dialog {
+// Needs to be scoped to .is-menu-open, or it will shift the position of any other navigations that may be present.
+.has-modal-open .admin-bar .is-menu-open .wp-block-navigation__responsive-dialog {
 	margin-top: $admin-bar-height-big;
 
 	// Handle smaller admin-bar.


### PR DESCRIPTION
## What?

Fixes #43524. 

This PR does two things:

1. It adds a very fast and subtle animation (disable for folks with reduce-motion enabled) to the overlay menu that opens when clicking the menu button.
2. It fixes a very rare exotic bug where if you have both a burger menu, and an un-collapsed but responsive menu on the page, the second menu won't shift vertically when the overlay opens.

The animation is fast, 0.1s, in order for it to feel generic and actionable, but still intentional. It's hard to see in this GIF:
![status](https://user-images.githubusercontent.com/1204802/188429417-ce71c71b-cc5e-4f18-a3b1-b9d40ebc7c8e.gif)

Here's a video variant with hopefully better framerate:

https://user-images.githubusercontent.com/1204802/188429449-df800c07-584c-4647-8ff2-831df29ee9c7.mov

## Testing Instructions

Insert a navigation menu, ensure it collapses to an overlay. Open the overlay and test that it animates upwards and fades in.