### PR TITLE
Lodash: Refactor away from `BlockMover`

### DIFF
--- a/packages/block-editor/src/components/block-mover/button.js
+++ b/packages/block-editor/src/components/block-mover/button.js
@@ -2,7 +2,6 @@
  * External dependencies
  */
 import classnames from 'classnames';
-import { castArray, first, last } from 'lodash';
 
 /**
  * WordPress dependencies
@@ -62,7 +61,10 @@ const BlockMoverButton = forwardRef(
 		ref
 	) => {
 		const instanceId = useInstanceId( BlockMoverButton );
-		const blocksCount = castArray( clientIds ).length;
+		const normalizedClientIds = Array.isArray( clientIds )
+			? clientIds
+			: [ clientIds ];
+		const blocksCount = normalizedClientIds.length;
 
 		const {
 			blockType,
@@ -81,12 +83,11 @@ const BlockMoverButton = forwardRef(
 					getBlock,
 					getBlockListSettings,
 				} = select( blockEditorStore );
-				const normalizedClientIds = castArray( clientIds );
-				const firstClientId = first( normalizedClientIds );
+				const firstClientId = normalizedClientIds[ 0 ];
 				const blockRootClientId = getBlockRootClientId( firstClientId );
 				const firstBlockIndex = getBlockIndex( firstClientId );
 				const lastBlockIndex = getBlockIndex(
-					last( normalizedClientIds )
+					normalizedClientIds[ normalizedClientIds.length - 1 ]
 				);
 				const blockOrder = getBlockOrder( blockRootClientId );
 				const block = getBlock( firstClientId );

--- a/packages/block-editor/src/components/block-mover/index.js
+++ b/packages/block-editor/src/components/block-mover/index.js
@@ -1,7 +1,6 @@
 /**
  * External dependencies
  */
-import { first, last, castArray } from 'lodash';
 import classnames from 'classnames';
 
 /**
@@ -30,13 +29,15 @@ function BlockMover( { clientIds, hideDragHandle } ) {
 				getBlockOrder,
 				getBlockRootClientId,
 			} = select( blockEditorStore );
-			const normalizedClientIds = castArray( clientIds );
-			const firstClientId = first( normalizedClientIds );
-			const _rootClientId = getBlockRootClientId(
-				first( normalizedClientIds )
-			);
+			const normalizedClientIds = Array.isArray( clientIds )
+				? clientIds
+				: [ clientIds ];
+			const firstClientId = normalizedClientIds[ 0 ];
+			const _rootClientId = getBlockRootClientId( firstClientId );
 			const firstIndex = getBlockIndex( firstClientId );
-			const lastIndex = getBlockIndex( last( normalizedClientIds ) );
+			const lastIndex = getBlockIndex(
+				normalizedClientIds[ normalizedClientIds.length - 1 ]
+			);
 			const blockOrder = getBlockOrder( _rootClientId );
 
 			return {

--- a/packages/block-editor/src/components/block-mover/index.native.js
+++ b/packages/block-editor/src/components/block-mover/index.native.js
@@ -1,7 +1,6 @@
 /**
  * External dependencies
  */
-import { first, last, partial, castArray } from 'lodash';
 import { Platform } from 'react-native';
 
 /**
@@ -149,12 +148,16 @@ export default compose(
 			getBlockRootClientId,
 			getBlockOrder,
 		} = select( blockEditorStore );
-		const normalizedClientIds = castArray( clientIds );
-		const firstClientId = first( normalizedClientIds );
+		const normalizedClientIds = Array.isArray( clientIds )
+			? clientIds
+			: [ clientIds ];
+		const firstClientId = normalizedClientIds[ 0 ];
 		const rootClientId = getBlockRootClientId( firstClientId );
 		const blockOrder = getBlockOrder( rootClientId );
 		const firstIndex = getBlockIndex( firstClientId );
-		const lastIndex = getBlockIndex( last( normalizedClientIds ) );
+		const lastIndex = getBlockIndex(
+			normalizedClientIds[ normalizedClientIds.length - 1 ]
+		);
 
 		return {
 			firstIndex,
@@ -169,15 +172,19 @@ export default compose(
 		const { moveBlocksDown, moveBlocksUp, moveBlocksToPosition } =
 			dispatch( blockEditorStore );
 		return {
-			onMoveDown: partial( moveBlocksDown, clientIds, rootClientId ),
-			onMoveUp: partial( moveBlocksUp, clientIds, rootClientId ),
-			onLongMove: ( targetIndex ) =>
-				partial(
-					moveBlocksToPosition,
-					clientIds,
-					rootClientId,
-					targetIndex
-				),
+			onMoveDown: ( ...args ) =>
+				moveBlocksDown( clientIds, rootClientId, ...args ),
+			onMoveUp: ( ...args ) =>
+				moveBlocksUp( clientIds, rootClientId, ...args ),
+			onLongMove:
+				( targetIndex ) =>
+				( ...args ) =>
+					moveBlocksToPosition(
+						clientIds,
+						rootClientId,
+						targetIndex,
+						...args
+					),
 		};
 	} ),
 	withInstanceId


### PR DESCRIPTION
## What?
This PR removes all of the Lodash from the `BlockMover` component. There are just a few usages and conversion is pretty straightforward. 

## Why?

Lodash is known to unnecessarily inflate the bundle size of packages, and in most cases, it can be replaced with native language functionality. See these for more information and rationale:

* https://github.com/WordPress/gutenberg/issues/16938#issuecomment-602837246
* https://github.com/WordPress/gutenberg/issues/17025
* https://github.com/WordPress/gutenberg/issues/39495 

## How?

We're replacing a few usages with their native counterparts. 

## Testing Instructions

* Open the post editor, and insert a few blocks.
* Verify moving blocks up and down still works well.
* Verify dragging and dropping blocks still works well.
* RN: Verify "Change block position" -> "Move to top" and "Move to bottom" still work well.
* Verify all checks are green.