### PR TITLE
Lodash: Remove `_.first()` and `_.last()` from block tools and `useSelectAll` hook

### DIFF
--- a/packages/block-editor/src/components/block-tools/index.js
+++ b/packages/block-editor/src/components/block-tools/index.js
@@ -1,9 +1,4 @@
 /**
- * External dependencies
- */
-import { first, last } from 'lodash';
-
-/**
  * WordPress dependencies
  */
 import { useSelect, useDispatch } from '@wordpress/data';
@@ -59,14 +54,14 @@ export default function BlockTools( {
 			const clientIds = getSelectedBlockClientIds();
 			if ( clientIds.length ) {
 				event.preventDefault();
-				const rootClientId = getBlockRootClientId( first( clientIds ) );
+				const rootClientId = getBlockRootClientId( clientIds[ 0 ] );
 				moveBlocksUp( clientIds, rootClientId );
 			}
 		} else if ( isMatch( 'core/block-editor/move-down', event ) ) {
 			const clientIds = getSelectedBlockClientIds();
 			if ( clientIds.length ) {
 				event.preventDefault();
-				const rootClientId = getBlockRootClientId( first( clientIds ) );
+				const rootClientId = getBlockRootClientId( clientIds[ 0 ] );
 				moveBlocksDown( clientIds, rootClientId );
 			}
 		} else if ( isMatch( 'core/block-editor/duplicate', event ) ) {
@@ -85,13 +80,13 @@ export default function BlockTools( {
 			const clientIds = getSelectedBlockClientIds();
 			if ( clientIds.length ) {
 				event.preventDefault();
-				insertAfterBlock( last( clientIds ) );
+				insertAfterBlock( clientIds[ clientIds.length - 1 ] );
 			}
 		} else if ( isMatch( 'core/block-editor/insert-before', event ) ) {
 			const clientIds = getSelectedBlockClientIds();
 			if ( clientIds.length ) {
 				event.preventDefault();
-				insertBeforeBlock( first( clientIds ) );
+				insertBeforeBlock( clientIds[ 0 ] );
 			}
 		} else if ( isMatch( 'core/block-editor/unselect', event ) ) {
 			const clientIds = getSelectedBlockClientIds();

--- a/packages/block-editor/src/components/writing-flow/use-select-all.js
+++ b/packages/block-editor/src/components/writing-flow/use-select-all.js
@@ -1,9 +1,4 @@
 /**
- * External dependencies
- */
-import { first, last } from 'lodash';
-
-/**
  * WordPress dependencies
  */
 import { isEntirelySelected } from '@wordpress/dom';
@@ -55,7 +50,10 @@ export default function useSelectAll() {
 				return;
 			}
 
-			multiSelect( first( blockClientIds ), last( blockClientIds ) );
+			multiSelect(
+				blockClientIds[ 0 ],
+				blockClientIds[ blockClientIds.length - 1 ]
+			);
 		}
 
 		node.addEventListener( 'keydown', onKeyDown );


### PR DESCRIPTION
## What?
This PR removes Lodash's `_.first()` and `_.last()` from the block tools and `useSelectAll` hook. There are just a few usages and conversion is pretty straightforward. 

## Why?

Lodash is known to unnecessarily inflate the bundle size of packages, and in most cases, it can be replaced with native language functionality. See these for more information and rationale:

* https://github.com/WordPress/gutenberg/issues/16938#issuecomment-602837246
* https://github.com/WordPress/gutenberg/issues/17025
* https://github.com/WordPress/gutenberg/issues/39495 

## How?

We're replacing a few usages with their native counterparts. 

## Testing Instructions

* Verify keyboard shortcuts for moving a block up and down, and inserting a block before and after still work.
* Verify you can still select all blocks in the editor with CMD+A (Ctrl+A).
* Verify all checks are green.