### PR TITLE
Gallery Block: Use `wp_enqueue_block_support_styles()`

### DIFF
--- a/packages/block-library/src/gallery/index.php
+++ b/packages/block-library/src/gallery/index.php
@@ -104,7 +104,7 @@ function block_core_gallery_render( $attributes, $content ) {
 	// Set the CSS variable to the column value, and the `gap` property to the combined gap value.
 	$style = '.wp-block-gallery.' . $class . '{ --wp--style--unstable-gallery-gap: ' . $gap_column . '; gap: ' . $gap_value . '}';
 
-	gutenberg_enqueue_block_support_styles( $style, 11 );
+	wp_enqueue_block_support_styles( $style, 11 );
 	return $content;
 }
 /**

--- a/tools/webpack/blocks.js
+++ b/tools/webpack/blocks.js
@@ -143,7 +143,11 @@ module.exports = {
 							// block will still call the core function when updates are back ported.
 							content = content.replace(
 								new RegExp( prefixFunctions.join( '|' ), 'g' ),
-								( match ) => `${ prefix }${ match }`
+								( match ) =>
+									`${ prefix }${ match.replace(
+										/^wp_/,
+										''
+									) }`
 							);
 
 							// Within content, search for any function definitions. For

--- a/tools/webpack/blocks.js
+++ b/tools/webpack/blocks.js
@@ -27,7 +27,10 @@ const blockViewRegex = new RegExp(
  * but have been declared elsewhere. This way we can call Gutenberg override functions, but
  * the block will still call the core function when updates are back ported.
  */
-const prefixFunctions = [ 'build_query_vars_from_query_block' ];
+const prefixFunctions = [
+	'build_query_vars_from_query_block',
+	'wp_enqueue_block_support_styles',
+];
 
 /**
  * Escapes the RegExp special characters.


### PR DESCRIPTION
## What?
In the Gallery Block, use `wp_enqueue_block_support_styles()`.

Alternative approach to #43779, based on @gziolo's suggestion: https://github.com/WordPress/gutenberg/pull/43779#issuecomment-1236924960

## Why?
To enable us to use the two-argument version of `wp_enqueue_block_support_styles()` (which has been backported to Core [here](https://github.com/WordPress/wordpress-develop/pull/3158)), and eventually remove the `gutenberg_enqueue_block_support_styles()` shim.

## How?
When used within the Gutenberg plugin, we have some code in the Webpack config that will change any occurrence of `wp_enqueue_block_support_styles()` to `gutenberg_enqueue_block_support_styles()` to use the version of the function that supports the second argument (`$priority`).

## Testing Instructions
Verify that the Gallery block still works.

Furthermore, run `npm run build`. Inspect `build/block-library/blocks/gallery.php`, and verify that it has a call to `gutenberg_enqueue_block_support_styles()` (instead of `wp_enqueue_block_support_styles()`).
