### PR TITLE
[Mobile] - List V2 - Prevent error when list is empty

### DIFF
--- a/packages/block-library/src/list/v2/migrate.js
+++ b/packages/block-library/src/list/v2/migrate.js
@@ -30,7 +30,7 @@ export function createListBlockFromDOMElement( listElement ) {
 			const [ nestedList, ...nodes ] = children;
 
 			const hasNestedList =
-				nestedList.tagName === 'UL' || nestedList.tagName === 'OL';
+				nestedList?.tagName === 'UL' || nestedList?.tagName === 'OL';
 			if ( ! hasNestedList ) {
 				return createBlock( 'core/list-item', {
 					content: listItem.innerHTML,


### PR DESCRIPTION
Fixes https://github.com/wordpress-mobile/gutenberg-mobile/issues/5135

## What?
Brings changes from https://github.com/WordPress/gutenberg/pull/43761 since this branch doesn't have the full merge from `trunk` we can't cherry-pick it.

## Why?
Currently, there's a crash in the production app where pasting or opening a post with an empty list would crash the editor.

## How?
Brings the changes from https://github.com/WordPress/gutenberg/pull/43761 which adds a safe check before accessing the `tagName` prop.

## Testing Instructions

**Precondition**: A site with Gutenberg >= 13.8 plugin. (Already available on simple sites).

Another option is to use a self-hosted site and install the latest Gutenberg plugin version >= 13.8.0. You can install the latest version [here](https://github.com/WordPress/gutenberg/releases). List V2 is now enabled by default for mobile.

**NOTE**: Sometimes the new List block won't be shown the first time the editor is opened due to fetching the flag value when opening the editor, so if you still see the old version without inner blocks, close the editor and open it again.

- Open the editor
- Paste the following content:

```
<!-- wp:list -->
<ul><li></li></ul>
<!-- /wp:list -->
```

- **Expect** the editor to not crash and the empty list to be created correctly.

## Screenshots or screencast <!-- if applicable -->

Before | After
-|-
<kbd><img src="https://user-images.githubusercontent.com/4885740/188464731-ca91c2b3-cc6a-4732-9360-961a640a51bd.gif" width="200" /></kbd> | <kbd><img src="https://user-images.githubusercontent.com/4885740/188464748-9931b012-6964-4d63-8c44-91c12768e931.gif" width="200" /></kbd>