### PR TITLE
hasContentRoleAttribute: Check that block type exists

### DIFF
--- a/packages/blocks/src/store/selectors.js
+++ b/packages/blocks/src/store/selectors.js
@@ -794,9 +794,15 @@ export const hasChildBlocksWithInserterSupport = ( state, blockName ) => {
 export const __experimentalHasContentRoleAttribute = createSelector(
 	( state, blockTypeName ) => {
 		const blockType = getBlockType( state, blockTypeName );
+		if ( ! blockType ) {
+			return false;
+		}
+
 		return Object.entries( blockType.attributes ).some(
 			( [ , { __experimentalRole } ] ) => __experimentalRole === 'content'
 		);
 	},
-	( state, blockTypeName ) => [ state.blockTypes[ blockTypeName ].attributes ]
+	( state, blockTypeName ) => [
+		state.blockTypes[ blockTypeName ]?.attributes,
+	]
 );


### PR DESCRIPTION
## What?
PR tried to make the `__experimentalHasContentRoleAttribute` selector more resilient and avoid errors when provided block type doesn't exist.

Discovered while testing #12484.

P.S. This was also crashing the editor if I switched between Visual and Code editors.

## Testing Instructions
1. Open a Post or Page.
2. Insert a Verse Block
3. Unregistered block by running the following snipped in DevTools console - `wp.blocks.unregisterBlockType( 'core/verse' );`
4. Confirm there're no errors in the console.

It can also be tested by running the selector directly with an incorrect block name:

```
wp.data.select('core/blocks').__experimentalHasContentRoleAttribute('core/shuttle');
```
