### PR TITLE
BlockInspector, ComplementaryArea: Fix overscoped `p` style

### DIFF
--- a/packages/block-editor/src/components/block-inspector/style.scss
+++ b/packages/block-editor/src/components/block-inspector/style.scss
@@ -1,5 +1,5 @@
 .block-editor-block-inspector {
-	p {
+	p:not(.components-base-control__help) {
 		margin-top: 0;
 	}
 

--- a/packages/interface/src/components/complementary-area/style.scss
+++ b/packages/interface/src/components/complementary-area/style.scss
@@ -31,7 +31,7 @@
 		}
 	}
 
-	p {
+	p:not(.components-base-control__help) {
 		margin-top: 0;
 	}
 


### PR DESCRIPTION
## What?

Fixes an overscoped `p` margin-top style in the editor sidebar.

## Why?

A [regression in the Drop cap control](https://github.com/WordPress/gutenberg/pull/43717#issuecomment-1235311164) was reported.

## How?

I considered a couple approaches where this would be addressed in the ToggleControl component itself, like replacing the `p` with a `div`, or using a div wrapper and adding whitespace with VStack. However, these add extra complexity because we still need to maintain the legacy margin bottom behavior, and it can also easily break other style overrides.

So in the end, I think the approach in this PR is probably the least bad.

## Testing Instructions

First, change this `isDropCapFeatureEnabled` variable to `true`:

https://github.com/WordPress/gutenberg/blob/4e4149890cfa0c349f0bc9ef40e90aa63fb94d9a/packages/block-library/src/paragraph/edit.js#L83

1. `npm run dev`
2. Insert a Paragraph block in the editor.
3. Add the Drop cap setting from the Typography section in the Inspector.

## Screenshots or screencast <!-- if applicable -->

| Before | After |
|--------|-------|
|<img src="https://user-images.githubusercontent.com/555336/188485675-58835bfd-c669-4aaf-94a8-5bc7b5d6a6a2.png" alt="Drop cap control before fix" width="400">|<img src="https://user-images.githubusercontent.com/555336/188485686-d76c6e94-a521-4611-b58c-160e0a212023.png" alt="Drop cap control after fix" width="400">|

