### PR TITLE
AnglePickerControl: Deprecate margin bottom

### DIFF
--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Breaking Changes
 
--   `AnglePickerControl`: Deprecate bottom margin style. Add a `__nextHasNoMargin` prop to start opting into the margin-free styles that will become the default in a future version, currently scheduled to be WordPress 6.4 ([#43867](https://github.com/WordPress/gutenberg/pull/43867)).
+-   `AnglePickerControl`: Deprecate bottom margin style. Add a `__nextHasNoMarginBottom` prop to start opting into the margin-free styles that will become the default in a future version, currently scheduled to be WordPress 6.4 ([#43867](https://github.com/WordPress/gutenberg/pull/43867)).
 
 ### Bug Fix
 

--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Breaking Changes
+
+-   `AnglePickerControl`: Deprecate bottom margin style. Add a `__nextHasNoMargin` prop to start opting into the margin-free styles that will become the default in a future version, currently scheduled to be WordPress 6.4 ([#43867](https://github.com/WordPress/gutenberg/pull/43867)).
+
 ### Bug Fix
 
 -   `Popover`: enable auto-updating every animation frame ([#43617](https://github.com/WordPress/gutenberg/pull/43617)).

--- a/packages/components/src/angle-picker-control/README.md
+++ b/packages/components/src/angle-picker-control/README.md
@@ -11,7 +11,7 @@ import { AnglePickerControl } from '@wordpress/components';
 
 const MyAnglePicker = () => {
 	const [ angle, setAngle ] = useState();
-	return <AnglePickerControl value={ angle } onChange={ setAngle } />;
+	return <AnglePickerControl value={ angle } onChange={ setAngle } __nextHasNoMarginBottom />;
 };
 ```
 
@@ -39,3 +39,11 @@ A function that receives the new value of the input.
 
 -   Type: `function`
 -   Required: Yes
+
+### __nextHasNoMarginBottom
+
+Start opting into the new margin-free styles that will become the default in a future version, currently scheduled to be WordPress 6.4. (The prop can be safely removed once this happens.)
+
+-   Type: `boolean`
+-   Required: No
+-   Default: `false`

--- a/packages/components/src/angle-picker-control/index.js
+++ b/packages/components/src/angle-picker-control/index.js
@@ -6,6 +6,7 @@ import classnames from 'classnames';
 /**
  * WordPress dependencies
  */
+import deprecated from '@wordpress/deprecated';
 import { __ } from '@wordpress/i18n';
 
 /**
@@ -27,6 +28,17 @@ export default function AnglePickerControl( {
 	onChange,
 	value,
 } ) {
+	if ( ! __nextHasNoMarginBottom ) {
+		deprecated(
+			'Bottom margin styles for wp.components.AnglePickerControl',
+			{
+				since: '6.1',
+				version: '6.4',
+				hint: 'Set the `__nextHasNoMarginBottom` prop to true to start opting into the new styles, which will become the default in a future version.',
+			}
+		);
+	}
+
 	const handleOnNumberChange = ( unprocessedValue ) => {
 		const inputValue =
 			unprocessedValue !== '' ? parseInt( unprocessedValue, 10 ) : 0;

--- a/packages/components/src/angle-picker-control/stories/index.js
+++ b/packages/components/src/angle-picker-control/stories/index.js
@@ -11,9 +11,6 @@ import AnglePickerControl from '../';
 export default {
 	title: 'Components/AnglePickerControl',
 	component: AnglePickerControl,
-	argTypes: {
-		__nextHasNoMarginBottom: { control: { type: 'boolean' } },
-	},
 };
 
 const AnglePickerWithState = ( args ) => {
@@ -24,3 +21,6 @@ const AnglePickerWithState = ( args ) => {
 };
 
 export const Default = AnglePickerWithState.bind( {} );
+Default.args = {
+	__nextHasNoMarginBottom: true,
+};


### PR DESCRIPTION
Part of #39358

## What?

Officially deprecates the bottom margin from AnglePickerControl.

## Why?

Better reusability.

## How?

Follows the [style deprecation guide](https://github.com/WordPress/gutenberg/blob/trunk/packages/components/CONTRIBUTING.md#deprecating-styles).

## Testing Instructions

✅ All usages of AnglePickerControl in the repo should have a truthy `__nextHasNoMarginBottom` prop.

## ✍️ Dev Note


### Components with deprecated margin styles

A number of UI components currently ship with styles that give them top and/or bottom margins. This can make it hard to reuse them in arbitrary layouts, where you want different amounts of gap or margin between components.

To better suit modern layout needs, we will gradually deprecate these outer margins. A deprecation will begin with an opt-in period where you can choose to apply the new margin-free styles on a given component instance. Eventually in a future version, the margins will be completely removed.

In WordPress 6.1, the outer margins on the following components have been deprecated.

- `AnglePickerControl`
- `FontSizePicker`
- `GradientPicker`
- `CustomGradientPicker`

To start opting into the new margin-free styles, set the `__nextHasNoMarginBottom` prop to `true`.

```jsx
<AnglePickerControl
  value={ angle }
  onChange={ setAngle }
  __nextHasNoMarginBottom={ true }
/>
```