### PR TITLE
RadioControl: Clean up CSS

### DIFF
--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -19,6 +19,7 @@
 
 ### Internal
 
+-   `RadioControl`: Clean up styles to use less custom CSS ([#43868](https://github.com/WordPress/gutenberg/pull/43868)).
 -   Remove unused `normalizeArrowKey` utility function ([#43640](https://github.com/WordPress/gutenberg/pull/43640/)).
 -   `ToggleGroupControl`: Rename `__experimentalIsIconGroup` prop to `__experimentalIsBorderless` ([#43771](https://github.com/WordPress/gutenberg/pull/43771/)).
 -   Refactor `FocalPointPicker` to function component ([#39168](https://github.com/WordPress/gutenberg/pull/39168)).

--- a/packages/components/src/radio-control/index.tsx
+++ b/packages/components/src/radio-control/index.tsx
@@ -15,6 +15,7 @@ import { useInstanceId } from '@wordpress/compose';
 import BaseControl from '../base-control';
 import type { WordPressComponentProps } from '../ui/context';
 import type { RadioControlProps } from './types';
+import { VStack } from '../v-stack';
 
 /**
  * Render a user interface to select the user type using radio inputs.
@@ -65,35 +66,38 @@ export function RadioControl(
 
 	return (
 		<BaseControl
+			__nextHasNoMarginBottom
 			label={ label }
 			id={ id }
 			hideLabelFromVision={ hideLabelFromVision }
 			help={ help }
 			className={ classnames( className, 'components-radio-control' ) }
 		>
-			{ options.map( ( option, index ) => (
-				<div
-					key={ `${ id }-${ index }` }
-					className="components-radio-control__option"
-				>
-					<input
-						id={ `${ id }-${ index }` }
-						className="components-radio-control__input"
-						type="radio"
-						name={ id }
-						value={ option.value }
-						onChange={ onChangeValue }
-						checked={ option.value === selected }
-						aria-describedby={
-							!! help ? `${ id }__help` : undefined
-						}
-						{ ...additionalProps }
-					/>
-					<label htmlFor={ `${ id }-${ index }` }>
-						{ option.label }
-					</label>
-				</div>
-			) ) }
+			<VStack spacing={ 1 }>
+				{ options.map( ( option, index ) => (
+					<div
+						key={ `${ id }-${ index }` }
+						className="components-radio-control__option"
+					>
+						<input
+							id={ `${ id }-${ index }` }
+							className="components-radio-control__input"
+							type="radio"
+							name={ id }
+							value={ option.value }
+							onChange={ onChangeValue }
+							checked={ option.value === selected }
+							aria-describedby={
+								!! help ? `${ id }__help` : undefined
+							}
+							{ ...additionalProps }
+						/>
+						<label htmlFor={ `${ id }-${ index }` }>
+							{ option.label }
+						</label>
+					</div>
+				) ) }
+			</VStack>
 		</BaseControl>
 	);
 }

--- a/packages/components/src/radio-control/style.scss
+++ b/packages/components/src/radio-control/style.scss
@@ -1,20 +1,3 @@
-.components-radio-control {
-	display: flex;
-	flex-direction: column;
-
-	.components-base-control__help {
-		margin-top: 0;
-	}
-
-	.components-base-control__field {
-		margin-bottom: 0;
-	}
-}
-
-.components-radio-control__option:not(:last-child) {
-	margin-bottom: 4px;
-}
-
 .components-radio-control__input[type="radio"] {
 	@include radio-control;
 	margin-top: 0;


### PR DESCRIPTION
Part of #38730

## What?

Clean up the styles in RadioControl so it uses less custom CSS.

Note that this component already had it's margin-bottom removed internally via style overrides 😄 So there's nothing to deprecate here, just cleanup.

## Why?

Less code and less overrides. This is also a necessary step to officially deprecate the bottom margin from BaseControl.

## How?

- Replaces a self-written flexbox with VStack.
- Replaces the margin overrides with a `__nextHasNoMargin` prop on the BaseControl.

## Testing Instructions

`npm run storybook:dev` and check the RadioControl story. There shouldn't be any visual changes.