### PR TITLE
Preview tests: Wait for the post-status change

### DIFF
--- a/test/e2e/specs/editor/various/preview.spec.js
+++ b/test/e2e/specs/editor/various/preview.spec.js
@@ -184,6 +184,11 @@ test.describe( 'Preview', () => {
 		// FIXME: The confirmation dialog is not named yet.
 		await page.click( 'role=dialog >> role=button[name="OK"i]' );
 
+		// Wait for the status change
+		await expect(
+			page.locator( 'role=button[name="Publish"i]' )
+		).toBeVisible();
+
 		// Change the title.
 		await editorPage.type( 'role=textbox[name="Add title"i]', ' Draft' );
 

--- a/test/e2e/specs/editor/various/preview.spec.js
+++ b/test/e2e/specs/editor/various/preview.spec.js
@@ -190,7 +190,7 @@ test.describe( 'Preview', () => {
 		).toBeVisible();
 
 		const previewToggle = page.locator(
-			'role=button[name="View"i][expanded=true]'
+			'role=button[name="View"i][expanded]'
 		);
 
 		// Close "View" dropdown if open.

--- a/test/e2e/specs/editor/various/preview.spec.js
+++ b/test/e2e/specs/editor/various/preview.spec.js
@@ -184,7 +184,7 @@ test.describe( 'Preview', () => {
 		// FIXME: The confirmation dialog is not named yet.
 		await page.click( 'role=dialog >> role=button[name="OK"i]' );
 
-		// Wait for the status change
+		// Wait for the status change.
 		await expect(
 			page.locator( 'role=button[name="Publish"i]' )
 		).toBeVisible();

--- a/test/e2e/specs/editor/various/preview.spec.js
+++ b/test/e2e/specs/editor/various/preview.spec.js
@@ -185,6 +185,7 @@ test.describe( 'Preview', () => {
 		await page.click( 'role=dialog >> role=button[name="OK"i]' );
 
 		// Wait for the status change.
+		// @see https://github.com/WordPress/gutenberg/pull/43933
 		await expect(
 			page.locator( 'role=button[name="Publish"i]' )
 		).toBeVisible();

--- a/test/e2e/specs/editor/various/preview.spec.js
+++ b/test/e2e/specs/editor/various/preview.spec.js
@@ -190,15 +190,6 @@ test.describe( 'Preview', () => {
 			page.locator( 'role=button[name="Publish"i]' )
 		).toBeVisible();
 
-		const previewToggle = page.locator(
-			'role=button[name="View"i][expanded]'
-		);
-
-		// Close "View" dropdown if open.
-		if ( await previewToggle.isVisible() ) {
-			await previewToggle.click();
-		}
-
 		// Change the title.
 		await editorPage.type( 'role=textbox[name="Add title"i]', ' Draft' );
 

--- a/test/e2e/specs/editor/various/preview.spec.js
+++ b/test/e2e/specs/editor/various/preview.spec.js
@@ -189,6 +189,15 @@ test.describe( 'Preview', () => {
 			page.locator( 'role=button[name="Publish"i]' )
 		).toBeVisible();
 
+		const previewToggle = page.locator(
+			'role=button[name="View"i][expanded=true]'
+		);
+
+		// Close "View" dropdown if open.
+		if ( await previewToggle.isVisible() ) {
+			await previewToggle.click();
+		}
+
 		// Change the title.
 		await editorPage.type( 'role=textbox[name="Add title"i]', ' Draft' );
 


### PR DESCRIPTION
## What?
PR tries to fix #37976.

I'm having trouble reproducing failure locally, so this is a bit of a wild guess based on the traces I examined. A few examples I checked showed that post-status switching is still in flight when test types ` Draft`.

It might be safer to wait for the actual status change before running the last part of the tests.

An example trace could be found here - https://github.com/WordPress/gutenberg/actions/runs/2969205018.

Use `npx playwright show-trace <path-to-trace-zip>` for viewing them.

## Testing Instructions

```
npm run test:e2e:playwright -- test/e2e/specs/editor/various/preview.spec.js
```

## Screenshots or screencast <!-- if applicable -->

![CleanShot 2022-09-05 at 23 11 16](https://user-images.githubusercontent.com/240569/188503875-0b4cfd62-2e8b-4c8f-bb20-2272e2c86893.png)

