### PR TITLE
Components: refactor `NavigatorScreen` to pass `exhaustive-deps`

### DIFF
--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -7,6 +7,7 @@
 -   `Button`, `Icon`: Fix `iconSize` prop doesn't work with some icons ([#43821](https://github.com/WordPress/gutenberg/pull/43821)).
 -   `Popover`: enable auto-updating every animation frame ([#43617](https://github.com/WordPress/gutenberg/pull/43617)).
 -   `Popover`: improve the component's performance and reactivity to prop changes by reworking its internals ([#43335](https://github.com/WordPress/gutenberg/pull/43335)).
+-   `NavigatorScreen`: updated to satisfy `react/exhaustive-deps` eslint rule ([#43876](https://github.com/WordPress/gutenberg/pull/43876))
 
 ### Enhancements
 

--- a/packages/components/src/navigator/navigator-screen/component.tsx
+++ b/packages/components/src/navigator/navigator-screen/component.tsx
@@ -104,7 +104,12 @@ function NavigatorScreen( props: Props, forwardedRef: ForwardedRef< any > ) {
 		}
 
 		elementToFocus.focus();
-	}, [ isInitialLocation, isMatch ] );
+	}, [
+		isInitialLocation,
+		isMatch,
+		location.isBack,
+		previousLocation?.focusTargetSelector,
+	] );
 
 	const mergedWrapperRef = useMergeRefs( [ forwardedRef, wrapperRef ] );
 


### PR DESCRIPTION
## What?
Updates the `NavigatorScreen` component pass the `exhaustive-deps` eslint rule.

## Why?
Part of the effort in https://github.com/WordPress/gutenberg/pull/41166 to apply `exhuastive-deps` to the Components package

## How?
Adding `location.isBack` and `previousLocation?.focusTargetSelector` to the `useEffect` deps array.

This does cause some additional renders on navigation between screens, but they don't appear problematic in my tests. I think they're happening because each time you navigate the `locationHistory changes`. This [triggers an update to the `goTo` and `goBack` values that are being drawn from context](https://github.com/WordPress/gutenberg/blob/33d84b036592a5bf31af05b7710f3b2b14163dc4/packages/components/src/navigator/navigator-provider/component.tsx#L44). This, in turn, causes an update to the context value as a whole (`goTo` and `goBack` both appear in the `useMemo` dep array for `navigatorContextValue`). Updating the `navigatorContextValue` means that even if it didn't change on this particular render, all `location` values are being redeclared, which will trigger a re-render thanks to our new dependencies.

All of that said, I know `Navigator` is your brainchild @ciampo so please let me know if that logic sounds flawed! 🙂 

## Testing Instructions
1. From your local Gutenberg directory, run `npx eslint --rule 'react-hooks/exhaustive-deps: warn' packages/components/src/navigatior/navigator-screen`
2. Confirm that the linter returns no errors or warnings
4. Confirm `navigator` unit tests still pass
5. Run Storybook locally, confirm the `Navigator` component stories and/or docs still work as expected