### PR TITLE
Block Styles: ensure that preview is displayed

### DIFF
--- a/packages/block-editor/src/components/inserter/preview-panel.js
+++ b/packages/block-editor/src/components/inserter/preview-panel.js
@@ -5,6 +5,7 @@ import {
 	isReusableBlock,
 	createBlock,
 	getBlockFromExample,
+	getBlockType,
 } from '@wordpress/blocks';
 import { __ } from '@wordpress/i18n';
 
@@ -17,22 +18,26 @@ import BlockPreview from '../block-preview';
 function InserterPreviewPanel( { item } ) {
 	const { name, title, icon, description, initialAttributes, example } = item;
 	const isReusable = isReusableBlock( item );
+	const hoveredItemBlockType = getBlockType( name );
+	const exampleBlock = example ?? hoveredItemBlockType?.example;
+
 	return (
 		<div className="block-editor-inserter__preview-container">
 			<div className="block-editor-inserter__preview">
-				{ isReusable || example ? (
+				{ isReusable || exampleBlock ? (
 					<div className="block-editor-inserter__preview-content">
 						<BlockPreview
 							__experimentalPadding={ 16 }
-							viewportWidth={ example?.viewportWidth ?? 500 }
+							viewportWidth={ exampleBlock?.viewportWidth ?? 500 }
 							blocks={
-								example
+								exampleBlock
 									? getBlockFromExample( item.name, {
 											attributes: {
-												...example.attributes,
+												...exampleBlock?.attributes,
 												...initialAttributes,
 											},
-											innerBlocks: example.innerBlocks,
+											innerBlocks:
+												exampleBlock?.innerBlocks,
 									  } )
 									: createBlock( name, initialAttributes )
 							}

--- a/packages/block-editor/src/components/inserter/preview-panel.js
+++ b/packages/block-editor/src/components/inserter/preview-panel.js
@@ -18,8 +18,7 @@ import BlockPreview from '../block-preview';
 function InserterPreviewPanel( { item } ) {
 	const { name, title, icon, description, initialAttributes, example } = item;
 	const isReusable = isReusableBlock( item );
-	const hoveredItemBlockType = getBlockType( name );
-	const exampleBlock = example ?? hoveredItemBlockType?.example;
+	const exampleBlock = !! example ? example : getBlockType( name )?.example;
 
 	return (
 		<div className="block-editor-inserter__preview-container">


### PR DESCRIPTION
Fixes https://github.com/WordPress/gutenberg/issues/43836

## What?
Revert to `getBlockType( name )` as example preview block if preview item block properties not available.

## Why?
https://github.com/WordPress/gutenberg/pull/42454 fixed template previews in the site editor but removed the call to `getBlockType( name )` to grab the preview block. 

## How?
See "What?"

## Testing Instructions
1. In the post editor, insert an image or table block. Check that the block style preview show when you over the button.
2. Check template previews in the site editor. Follow the testing steps in https://github.com/WordPress/gutenberg/pull/42454


### Before
<img width="646" alt="Screen Shot 2022-09-06 at 11 17 09 am" src="https://user-images.githubusercontent.com/6458278/188528650-81ad4daa-7e59-45a9-bcc1-d9dc51311f58.png">

### After

#### Block style previews

<img width="659" alt="Screen Shot 2022-09-06 at 11 17 31 am" src="https://user-images.githubusercontent.com/6458278/188528643-68d8903f-d103-4f3a-b200-1753b2a8297d.png">


#### Template previews in the site editor
<img width="624" alt="Screen Shot 2022-09-06 at 11 27 46 am" src="https://user-images.githubusercontent.com/6458278/188528635-10668cbe-3d42-44c5-ba88-b224b64b694e.png">