### PR TITLE
@wordpress/date: Rename __experimentalGetSettings() to getSettings()

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16912,6 +16912,7 @@
 			"version": "file:packages/date",
 			"requires": {
 				"@babel/runtime": "^7.16.0",
+				"@wordpress/deprecated": "file:packages/deprecated",
 				"moment": "^2.22.1",
 				"moment-timezone": "^0.5.31"
 			}

--- a/packages/block-editor/src/components/publish-date-time-picker/index.js
+++ b/packages/block-editor/src/components/publish-date-time-picker/index.js
@@ -4,7 +4,7 @@
 import { DateTimePicker } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 import { forwardRef } from '@wordpress/element';
-import { __experimentalGetSettings as getSettings } from '@wordpress/date';
+import { getSettings } from '@wordpress/date';
 
 /**
  * Internal dependencies

--- a/packages/block-library/src/comment-date/edit.js
+++ b/packages/block-library/src/comment-date/edit.js
@@ -2,10 +2,7 @@
  * WordPress dependencies
  */
 import { useEntityProp } from '@wordpress/core-data';
-import {
-	dateI18n,
-	__experimentalGetSettings as getDateSettings,
-} from '@wordpress/date';
+import { dateI18n, getSettings as getDateSettings } from '@wordpress/date';
 import {
 	InspectorControls,
 	useBlockProps,

--- a/packages/block-library/src/latest-posts/edit.js
+++ b/packages/block-library/src/latest-posts/edit.js
@@ -19,7 +19,7 @@ import {
 	ToolbarGroup,
 } from '@wordpress/components';
 import { __, sprintf } from '@wordpress/i18n';
-import { dateI18n, format, __experimentalGetSettings } from '@wordpress/date';
+import { dateI18n, format, getSettings } from '@wordpress/date';
 import {
 	InspectorControls,
 	BlockAlignmentToolbar,
@@ -422,7 +422,7 @@ export default function LatestPostsEdit( { attributes, setAttributes } ) {
 		},
 	];
 
-	const dateFormat = __experimentalGetSettings().formats.date;
+	const dateFormat = getSettings().formats.date;
 
 	return (
 		<div>

--- a/packages/block-library/src/post-date/edit.js
+++ b/packages/block-library/src/post-date/edit.js
@@ -8,10 +8,7 @@ import classnames from 'classnames';
  */
 import { useEntityProp, store as coreStore } from '@wordpress/core-data';
 import { useRef } from '@wordpress/element';
-import {
-	dateI18n,
-	__experimentalGetSettings as getDateSettings,
-} from '@wordpress/date';
+import { dateI18n, getSettings as getDateSettings } from '@wordpress/date';
 import {
 	AlignmentControl,
 	BlockControls,

--- a/packages/components/src/date-time/date/index.tsx
+++ b/packages/components/src/date-time/date/index.tsx
@@ -22,7 +22,7 @@ import {
  */
 import { __, _n, sprintf, isRTL } from '@wordpress/i18n';
 import { arrowLeft, arrowRight } from '@wordpress/icons';
-import { dateI18n, __experimentalGetSettings } from '@wordpress/date';
+import { dateI18n, getSettings } from '@wordpress/date';
 import { useState, useRef, useEffect } from '@wordpress/element';
 
 /**
@@ -322,7 +322,7 @@ function Day( {
 }
 
 function getDayLabel( date: Date, isSelected: boolean, numEvents: number ) {
-	const { formats } = __experimentalGetSettings();
+	const { formats } = getSettings();
 	const localizedDate = dateI18n(
 		formats.date,
 		date,

--- a/packages/components/src/date-time/time/timezone.tsx
+++ b/packages/components/src/date-time/time/timezone.tsx
@@ -2,7 +2,7 @@
  * WordPress dependencies
  */
 import { __ } from '@wordpress/i18n';
-import { __experimentalGetSettings as getDateSettings } from '@wordpress/date';
+import { getSettings as getDateSettings } from '@wordpress/date';
 
 /**
  * Internal dependencies

--- a/packages/date/CHANGELOG.md
+++ b/packages/date/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+## Deprecations
+
+-   `__experimentalGetSettings` has been renamed to `getSettings`.
+
 ## 4.16.0 (2022-08-24)
 
 ## 4.15.0 (2022-08-10)

--- a/packages/date/README.md
+++ b/packages/date/README.md
@@ -82,6 +82,14 @@ _Returns_
 
 -   `Date`: Date
 
+### getSettings
+
+Returns the currently defined date settings.
+
+_Returns_
+
+-   `DateSettings`: Settings, including locale data.
+
 ### gmdate
 
 Formats a date (like `date()` in PHP), in the UTC timezone.

--- a/packages/date/package.json
+++ b/packages/date/package.json
@@ -27,6 +27,7 @@
 	"types": "build-types",
 	"dependencies": {
 		"@babel/runtime": "^7.16.0",
+		"@wordpress/deprecated": "file:../deprecated",
 		"moment": "^2.22.1",
 		"moment-timezone": "^0.5.31"
 	},

--- a/packages/date/src/index.js
+++ b/packages/date/src/index.js
@@ -5,6 +5,11 @@ import momentLib from 'moment';
 import 'moment-timezone/moment-timezone';
 import 'moment-timezone/moment-timezone-utils';
 
+/**
+ * WordPress dependencies
+ */
+import deprecated from '@wordpress/deprecated';
+
 /** @typedef {import('moment').Moment} Moment */
 /** @typedef {import('moment').LocaleSpecification} MomentLocaleSpecification */
 
@@ -202,8 +207,22 @@ export function setSettings( dateSettings ) {
  *
  * @return {DateSettings} Settings, including locale data.
  */
-export function __experimentalGetSettings() {
+export function getSettings() {
 	return settings;
+}
+
+/**
+ * Returns the currently defined date settings.
+ *
+ * @deprecated
+ * @return {DateSettings} Settings, including locale data.
+ */
+export function __experimentalGetSettings() {
+	deprecated( 'wp.date.__experimentalGetSettings', {
+		since: '6.1',
+		alternative: 'wp.date.getSettings',
+	} );
+	return getSettings();
 }
 
 function setupWPTimezone() {

--- a/packages/date/src/test/index.js
+++ b/packages/date/src/test/index.js
@@ -2,7 +2,7 @@
  * Internal dependencies
  */
 import {
-	__experimentalGetSettings,
+	getSettings,
 	date as dateNoI18n,
 	dateI18n,
 	getDate,
@@ -28,7 +28,7 @@ describe( 'isInTheFuture', () => {
 	} );
 
 	it( 'should ignore the timezone', () => {
-		const settings = __experimentalGetSettings();
+		const settings = getSettings();
 
 		// Set a timezone in the future.
 		setSettings( {
@@ -75,7 +75,7 @@ describe( 'Function date', () => {
 	] )(
 		'should format date as "%s", ignoring locale settings',
 		( formatString, expected ) => {
-			const settings = __experimentalGetSettings();
+			const settings = getSettings();
 
 			// Simulate different locale.
 			const l10n = settings.l10n;
@@ -110,7 +110,7 @@ describe( 'Function date', () => {
 	);
 
 	it( 'should format date into a date that uses site’s timezone, if no timezone was provided and there’s a site timezone set', () => {
-		const settings = __experimentalGetSettings();
+		const settings = getSettings();
 
 		// Simulate different timezone.
 		setSettings( {
@@ -136,7 +136,7 @@ describe( 'Function date', () => {
 	} );
 
 	it( 'should format date into a date that uses site’s UTC offset setting, if no timezone was provided and there isn’t a timezone set in the site', () => {
-		const settings = __experimentalGetSettings();
+		const settings = getSettings();
 
 		// Simulate different timezone.
 		setSettings( {
@@ -162,7 +162,7 @@ describe( 'Function date', () => {
 	} );
 
 	it( 'should format date into a date that uses the given timezone, if said timezone is valid', () => {
-		const settings = __experimentalGetSettings();
+		const settings = getSettings();
 
 		// Simulate different timezone.
 		setSettings( {
@@ -183,7 +183,7 @@ describe( 'Function date', () => {
 	} );
 
 	it( 'should format date into a date that uses the given UTC offset, if given timezone is actually a UTC offset', () => {
-		const settings = __experimentalGetSettings();
+		const settings = getSettings();
 
 		// Simulate different timezone.
 		setSettings( {
@@ -246,7 +246,7 @@ describe( 'Function gmdate', () => {
 	] )(
 		'should format date as "%s", ignoring locale settings',
 		( formatString, expected ) => {
-			const settings = __experimentalGetSettings();
+			const settings = getSettings();
 
 			// Simulate different locale.
 			const l10n = settings.l10n;
@@ -281,7 +281,7 @@ describe( 'Function gmdate', () => {
 	);
 
 	it( 'should format date into a UTC date', () => {
-		const settings = __experimentalGetSettings();
+		const settings = getSettings();
 
 		// Simulate different timezone.
 		setSettings( {
@@ -325,7 +325,7 @@ describe( 'Function dateI18n', () => {
 	] )(
 		'should format date as "%s", using locale settings',
 		( formatString, expected ) => {
-			const settings = __experimentalGetSettings();
+			const settings = getSettings();
 
 			// Simulate different locale.
 			const l10n = settings.l10n;
@@ -361,7 +361,7 @@ describe( 'Function dateI18n', () => {
 	);
 
 	it( 'should format date into a date that uses site’s timezone, if no timezone was provided and there’s a site timezone set', () => {
-		const settings = __experimentalGetSettings();
+		const settings = getSettings();
 
 		// Simulate different timezone.
 		setSettings( {
@@ -387,7 +387,7 @@ describe( 'Function dateI18n', () => {
 	} );
 
 	it( 'should format date into a date that uses site’s UTC offset setting, if no timezone was provided and there isn’t a timezone set in the site', () => {
-		const settings = __experimentalGetSettings();
+		const settings = getSettings();
 
 		// Simulate different timezone.
 		setSettings( {
@@ -413,7 +413,7 @@ describe( 'Function dateI18n', () => {
 	} );
 
 	it( 'should format date into a date that uses the given timezone, if said timezone is valid', () => {
-		const settings = __experimentalGetSettings();
+		const settings = getSettings();
 
 		// Simulate different timezone.
 		setSettings( {
@@ -434,7 +434,7 @@ describe( 'Function dateI18n', () => {
 	} );
 
 	it( 'should format date into a date that uses the given UTC offset, if given timezone is actually a UTC offset', () => {
-		const settings = __experimentalGetSettings();
+		const settings = getSettings();
 
 		// Simulate different timezone.
 		setSettings( {
@@ -466,7 +466,7 @@ describe( 'Function dateI18n', () => {
 	} );
 
 	it( 'should format date into a UTC date if `gmt` is set to `true`', () => {
-		const settings = __experimentalGetSettings();
+		const settings = getSettings();
 
 		// Simulate different timezone.
 		setSettings( {
@@ -487,7 +487,7 @@ describe( 'Function dateI18n', () => {
 	} );
 
 	it( 'should format date into a date that uses site’s timezone if `gmt` is set to `false`', () => {
-		const settings = __experimentalGetSettings();
+		const settings = getSettings();
 
 		// Simulate different timezone.
 		setSettings( {
@@ -535,7 +535,7 @@ describe( 'Function gmdateI18n', () => {
 	] )(
 		'should format date as "%s", using locale settings',
 		( formatString, expected ) => {
-			const settings = __experimentalGetSettings();
+			const settings = getSettings();
 
 			// Simulate different locale.
 			const l10n = settings.l10n;
@@ -570,7 +570,7 @@ describe( 'Function gmdateI18n', () => {
 	);
 
 	it( 'should format date into a UTC date', () => {
-		const settings = __experimentalGetSettings();
+		const settings = getSettings();
 
 		// Simulate different timezone.
 		setSettings( {
@@ -592,7 +592,7 @@ describe( 'Function gmdateI18n', () => {
 
 describe( 'Moment.js Localization', () => {
 	it( 'should change the relative time strings', () => {
-		const settings = __experimentalGetSettings();
+		const settings = getSettings();
 
 		// Change the locale strings for tests.
 		setSettings( {
@@ -608,7 +608,7 @@ describe( 'Moment.js Localization', () => {
 		} );
 
 		// Get the freshly changed setings.
-		const newSettings = __experimentalGetSettings();
+		const newSettings = getSettings();
 
 		// Test the unchanged values.
 		expect( newSettings.l10n.locale ).toBe( settings.l10n.locale );

--- a/packages/editor/src/components/post-schedule/index.js
+++ b/packages/editor/src/components/post-schedule/index.js
@@ -1,7 +1,7 @@
 /**
  * WordPress dependencies
  */
-import { __experimentalGetSettings } from '@wordpress/date';
+import { getSettings } from '@wordpress/date';
 import { useDispatch, useSelect } from '@wordpress/data';
 import { __experimentalPublishDateTimePicker as PublishDateTimePicker } from '@wordpress/block-editor';
 import { useState, useMemo } from '@wordpress/element';
@@ -61,7 +61,7 @@ export default function PostSchedule( { onClose } ) {
 		[ eventsByPostType ]
 	);
 
-	const settings = __experimentalGetSettings();
+	const settings = getSettings();
 
 	// To know if the current timezone is a 12 hour time with look for "a" in the time format
 	// We also make sure this a is not escaped by a "/"

--- a/packages/editor/src/components/post-schedule/label.js
+++ b/packages/editor/src/components/post-schedule/label.js
@@ -2,7 +2,7 @@
  * WordPress dependencies
  */
 import { __, _x, sprintf, isRTL } from '@wordpress/i18n';
-import { __experimentalGetSettings, getDate, dateI18n } from '@wordpress/date';
+import { getSettings, getDate, dateI18n } from '@wordpress/date';
 import { useSelect } from '@wordpress/data';
 
 /**
@@ -95,7 +95,7 @@ export function getPostScheduleLabel(
 }
 
 function getTimezoneAbbreviation() {
-	const { timezone } = __experimentalGetSettings();
+	const { timezone } = getSettings();
 
 	if ( timezone.abbr && isNaN( Number( timezone.abbr ) ) ) {
 		return timezone.abbr;
@@ -106,7 +106,7 @@ function getTimezoneAbbreviation() {
 }
 
 function isTimezoneSameAsSiteTimezone( date ) {
-	const { timezone } = __experimentalGetSettings();
+	const { timezone } = getSettings();
 
 	const siteOffset = Number( timezone.offset );
 	const dateOffset = -1 * ( date.getTimezoneOffset() / 60 );

--- a/packages/editor/src/components/post-schedule/test/label.js
+++ b/packages/editor/src/components/post-schedule/test/label.js
@@ -1,7 +1,7 @@
 /**
  * WordPress dependencies
  */
-import { __experimentalGetSettings, setSettings } from '@wordpress/date';
+import { getSettings, setSettings } from '@wordpress/date';
 
 /**
  * Internal dependencies
@@ -15,7 +15,7 @@ describe( 'getFullPostScheduleLabel', () => {
 	} );
 
 	it( "should show site's timezone abbr", () => {
-		const settings = __experimentalGetSettings();
+		const settings = getSettings();
 
 		setSettings( {
 			...settings,
@@ -29,7 +29,7 @@ describe( 'getFullPostScheduleLabel', () => {
 	} );
 
 	it( "should show site's timezone offset", () => {
-		const settings = __experimentalGetSettings();
+		const settings = getSettings();
 
 		setSettings( {
 			...settings,
@@ -67,7 +67,7 @@ describe( 'getPostScheduleLabel', () => {
 	} );
 
 	it( "should show today if date is same day as now and user timezone equals site's timezone", () => {
-		const settings = __experimentalGetSettings();
+		const settings = getSettings();
 
 		setSettings( {
 			...settings,
@@ -86,7 +86,7 @@ describe( 'getPostScheduleLabel', () => {
 	} );
 
 	it( "should show tomorrow if date is same day as now + 1 day and user timezone equals site's timezone", () => {
-		const settings = __experimentalGetSettings();
+		const settings = getSettings();
 
 		setSettings( {
 			...settings,
@@ -105,7 +105,7 @@ describe( 'getPostScheduleLabel', () => {
 	} );
 
 	it( "should hide year if date is same year as now and user timezone equals site's timezone", () => {
-		const settings = __experimentalGetSettings();
+		const settings = getSettings();
 
 		setSettings( {
 			...settings,
@@ -124,7 +124,7 @@ describe( 'getPostScheduleLabel', () => {
 	} );
 
 	it( "should show year if date is not same year as now and user timezone equals site's timezone", () => {
-		const settings = __experimentalGetSettings();
+		const settings = getSettings();
 
 		setSettings( {
 			...settings,


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Part of https://github.com/WordPress/gutenberg/issues/43635.

Marks `wp.date.getSettings` as non-experimental by renaming `__experimentalGetSettings` to `getSettings`.

## Why?
`__experimentalGetSettings` has been around for years and is used very frequently.

## How?
Officially our policy is to remove the old `__experimental` function when stabilising it. In this case I think we need to keep it around forever as it is widely used.

https://wpdirectory.net/search/01GC8AFWJX4K6H42FMG1F8R0YF

## Testing Instructions
`npm run test`
`npm run test-e2e`

## Screenshots or screencast <!-- if applicable -->
