### PR TITLE
Social Icons: Add missing padding support, update margin support

### DIFF
--- a/docs/reference-guides/core-blocks.md
+++ b/docs/reference-guides/core-blocks.md
@@ -761,7 +761,7 @@ Display icons linking to your social media profiles or sites. ([Source](https://
 
 -	**Name:** core/social-links
 -	**Category:** widgets
--	**Supports:** align (center, left, right), anchor, color (background, gradients, ~~enableContrastChecker~~, ~~text~~), spacing (blockGap, margin, units)
+-	**Supports:** align (center, left, right), anchor, color (background, gradients, ~~enableContrastChecker~~, ~~text~~), spacing (blockGap, margin, padding, units)
 -	**Attributes:** customIconBackgroundColor, customIconColor, iconBackgroundColor, iconBackgroundColorValue, iconColor, iconColorValue, openInNewTab, showLabels, size
 
 ## Spacer

--- a/packages/block-library/src/social-links/block.json
+++ b/packages/block-library/src/social-links/block.json
@@ -67,7 +67,8 @@
 		},
 		"spacing": {
 			"blockGap": [ "horizontal", "vertical" ],
-			"margin": [ "top", "bottom" ],
+			"margin": true,
+			"padding": true,
 			"units": [ "px", "em", "rem", "vh", "vw" ],
 			"__experimentalDefaultControls": {
 				"blockGap": true

--- a/packages/block-library/src/social-links/style.scss
+++ b/packages/block-library/src/social-links/style.scss
@@ -1,4 +1,7 @@
 .wp-block-social-links {
+	// This block has customizable padding, border-box makes that more predictable.
+	box-sizing: border-box;
+
 	padding-left: 0;
 	padding-right: 0;
 	// Some themes set text-indent on all <ul>


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

Related:

* https://github.com/WordPress/gutenberg/issues/43241
* https://github.com/WordPress/gutenberg/issues/43243

## What?
<!-- In a few words, what is the PR actually doing? -->

Add padding support for the Social Icons block, update margin to be all sides for consistency with other blocks.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

To create consistency across blocks.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

* Added the relevant block supports in `block.json`
* Added `box-sizing: border-box` rule so that the padding matches adjacent blocks like Group

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->

1. Create a new post
2. Insert a Social Icons block and add some icons to it.
3. Add Padding to the block

Also, test in Global Styles as well.

1. Go to Appearance > Editor (beta)
2. Add a Social Icons block to the template and add some child icons
3. Navigate to the Global Styles and choose Social Icons
4. Configure padding and verify that the padding is applied correctly

**Note:** There is an outstanding issues with specificity of margin styles as raised in #43404 and discussed in comparable PRs (e.g. here: https://github.com/WordPress/gutenberg/pull/43520#pullrequestreview-1096870277) — the idea with this PR is to create consistency in the opt-ins, and for us to look into seeing if we can improve the margin specificity issues separately.

## Screenshots or screencast <!-- if applicable -->

![2022-09-06 14 48 53](https://user-images.githubusercontent.com/14988353/188549919-73893e73-550f-4729-adc0-387f50ac9492.gif)
