### PR TITLE
Style engine: pass CSS formatting options from global functions

### DIFF
--- a/packages/style-engine/class-wp-style-engine.php
+++ b/packages/style-engine/class-wp-style-engine.php
@@ -505,13 +505,17 @@ class WP_Style_Engine {
 	 * Returns a compiled stylesheet from stored CSS rules.
 	 *
 	 * @param WP_Style_Engine_CSS_Rule[] $css_rules An array of WP_Style_Engine_CSS_Rule objects from a store or otherwise.
+	 * @param array                      $options array(
+	 *    'optimize' => (boolean) Whether to optimize the CSS output, e.g., combine rules.
+	 *    'prettify' => (boolean) Whether to add new lines to output.
+	 * );.
 	 *
 	 * @return string A compiled stylesheet from stored CSS rules.
 	 */
-	public static function compile_stylesheet_from_css_rules( $css_rules ) {
+	public static function compile_stylesheet_from_css_rules( $css_rules, $options = array() ) {
 		$processor = new WP_Style_Engine_Processor();
 		$processor->add_rules( $css_rules );
-		return $processor->get_css();
+		return $processor->get_css( $options );
 	}
 }
 
@@ -591,6 +595,8 @@ function wp_style_engine_get_styles( $block_styles, $options = array() ) {
  * @param array<string> $options array(
  *     'context' => (string|null) An identifier describing the origin of the style object, e.g., 'block-supports' or 'global-styles'. Default is 'block-supports'.
  *                  When set, the style engine will attempt to store the CSS rules.
+ *    'optimize' => (boolean) Whether to optimize the CSS output, e.g., combine rules.
+ *    'prettify' => (boolean) Whether to add new lines to output.
  * );.
  *
  * @return string A compiled CSS string.
@@ -624,7 +630,7 @@ function wp_style_engine_get_stylesheet_from_css_rules( $css_rules, $options = a
 		return '';
 	}
 
-	return WP_Style_Engine::compile_stylesheet_from_css_rules( $css_rule_objects );
+	return WP_Style_Engine::compile_stylesheet_from_css_rules( $css_rule_objects, $options );
 }
 
 /**
@@ -633,13 +639,16 @@ function wp_style_engine_get_stylesheet_from_css_rules( $css_rules, $options = a
  * @access public
  *
  * @param string $store_name A valid store name.
- *
+ * @param array  $options    array(
+ *    'optimize' => (boolean) Whether to optimize the CSS output, e.g., combine rules.
+ *    'prettify' => (boolean) Whether to add new lines to output.
+ * );.
  * @return string A compiled CSS string.
  */
-function wp_style_engine_get_stylesheet_from_context( $store_name ) {
+function wp_style_engine_get_stylesheet_from_context( $store_name, $options = array() ) {
 	if ( ! class_exists( 'WP_Style_Engine' ) || empty( $store_name ) ) {
 		return '';
 	}
 
-	return WP_Style_Engine::compile_stylesheet_from_css_rules( WP_Style_Engine::get_store( $store_name )->get_all_rules() );
+	return WP_Style_Engine::compile_stylesheet_from_css_rules( WP_Style_Engine::get_store( $store_name )->get_all_rules(), $options );
 }

--- a/packages/style-engine/phpunit/class-wp-style-engine-processor-test.php
+++ b/packages/style-engine/phpunit/class-wp-style-engine-processor-test.php
@@ -37,7 +37,7 @@ class WP_Style_Engine_Processor_Test extends WP_UnitTestCase {
 		$a_nice_processor->add_rules( array( $a_nice_css_rule, $a_nicer_css_rule ) );
 		$this->assertEquals(
 			'.a-nice-rule{color:var(--nice-color);background-color:purple;}.a-nicer-rule{font-family:Nice sans;font-size:1em;background-color:purple;}',
-			$a_nice_processor->get_css()
+			$a_nice_processor->get_css( array( 'prettify' => false ) )
 		);
 	}
 
@@ -109,7 +109,7 @@ class WP_Style_Engine_Processor_Test extends WP_UnitTestCase {
 		$a_nice_renderer->add_store( $a_nice_store );
 		$this->assertEquals(
 			'.a-nice-rule{color:var(--nice-color);background-color:purple;}.a-nicer-rule{font-family:Nice sans;font-size:1em;background-color:purple;}',
-			$a_nice_renderer->get_css()
+			$a_nice_renderer->get_css( array( 'prettify' => false ) )
 		);
 	}
 
@@ -138,7 +138,7 @@ class WP_Style_Engine_Processor_Test extends WP_UnitTestCase {
 		$an_excellent_processor->add_rules( $another_excellent_rule );
 		$this->assertEquals(
 			'.an-excellent-rule{color:var(--excellent-color);border-style:dotted;border-color:brown;}',
-			$an_excellent_processor->get_css()
+			$an_excellent_processor->get_css( array( 'prettify' => false ) )
 		);
 
 		$yet_another_excellent_rule = new WP_Style_Engine_CSS_Rule( '.an-excellent-rule' );
@@ -152,7 +152,7 @@ class WP_Style_Engine_Processor_Test extends WP_UnitTestCase {
 		$an_excellent_processor->add_rules( $yet_another_excellent_rule );
 		$this->assertEquals(
 			'.an-excellent-rule{color:var(--excellent-color);border-style:dashed;border-color:brown;border-width:2px;}',
-			$an_excellent_processor->get_css()
+			$an_excellent_processor->get_css( array( 'prettify' => false ) )
 		);
 	}
 
@@ -189,7 +189,12 @@ class WP_Style_Engine_Processor_Test extends WP_UnitTestCase {
 
 		$this->assertEquals(
 			'.a-sweet-rule{color:var(--sweet-color);background-color:purple;}#an-even-sweeter-rule > marquee{color:var(--sweet-color);background-color:purple;}.the-sweetest-rule-of-all a{color:var(--sweet-color);background-color:purple;}',
-			$a_sweet_processor->get_css( array( 'optimize' => false ) )
+			$a_sweet_processor->get_css(
+				array(
+					'optimize' => false,
+					'prettify' => false,
+				)
+			)
 		);
 	}
 
@@ -218,7 +223,7 @@ class WP_Style_Engine_Processor_Test extends WP_UnitTestCase {
 
 		$this->assertEquals(
 			'.a-sweet-rule,#an-even-sweeter-rule > marquee{color:var(--sweet-color);background-color:purple;}',
-			$a_sweet_processor->get_css()
+			$a_sweet_processor->get_css( array( 'prettify' => false ) )
 		);
 	}
 		/**
@@ -240,7 +245,7 @@ class WP_Style_Engine_Processor_Test extends WP_UnitTestCase {
 			)
 		);
 		$a_lovely_processor->add_rules( $a_lovelier_rule );
-		$this->assertEquals( '.a-lovely-rule,.a-lovelier-rule{border-color:purple;}', $a_lovely_processor->get_css() );
+		$this->assertEquals( '.a-lovely-rule,.a-lovelier-rule{border-color:purple;}', $a_lovely_processor->get_css( array( 'prettify' => false ) ) );
 
 		$a_most_lovely_rule = new WP_Style_Engine_CSS_Rule(
 			'.a-most-lovely-rule',
@@ -260,7 +265,7 @@ class WP_Style_Engine_Processor_Test extends WP_UnitTestCase {
 
 		$this->assertEquals(
 			'.a-lovely-rule,.a-lovelier-rule,.a-most-lovely-rule,.a-perfectly-lovely-rule{border-color:purple;}',
-			$a_lovely_processor->get_css()
+			$a_lovely_processor->get_css( array( 'prettify' => false ) )
 		);
 	}
 }

--- a/packages/style-engine/phpunit/class-wp-style-engine-test.php
+++ b/packages/style-engine/phpunit/class-wp-style-engine-test.php
@@ -612,7 +612,7 @@ class WP_Style_Engine_Test extends WP_UnitTestCase {
 			),
 		);
 
-		$compiled_stylesheet = wp_style_engine_get_stylesheet_from_css_rules( $css_rules );
+		$compiled_stylesheet = wp_style_engine_get_stylesheet_from_css_rules( $css_rules, array( 'prettify' => false ) );
 		$this->assertSame( '.saruman{color:white;height:100px;border-style:solid;align-self:unset;}.gandalf{color:grey;height:90px;border-style:dotted;align-self:safe center;}.radagast{color:brown;height:60px;border-style:dashed;align-self:stretch;}', $compiled_stylesheet );
 	}
 
@@ -656,7 +656,7 @@ class WP_Style_Engine_Test extends WP_UnitTestCase {
 			),
 		);
 
-		$compiled_stylesheet = wp_style_engine_get_stylesheet_from_css_rules( $css_rules );
+		$compiled_stylesheet = wp_style_engine_get_stylesheet_from_css_rules( $css_rules, array( 'prettify' => false ) );
 		$this->assertSame( '.gandalf{color:white;height:190px;border-style:dotted;padding:10px;margin-bottom:100px;}.dumbledore,.rincewind{color:grey;height:90px;border-style:dotted;}', $compiled_stylesheet );
 	}
 }


### PR DESCRIPTION
## What?
Allowing passing 'prettify' option from global functions.

## Why?
So we can better control testing and allow user overrides.

For example, core tests have `SCRIPT_DEBUG` enabled so we'd want to be able to override this for unit testing.

See: https://github.com/WordPress/wordpress-develop/pull/3199

## Testing Instructions
The tests should pass!
