### PR TITLE
Layout: Fix toggling off inner blocks content width setting for legacy markup

### DIFF
--- a/packages/block-editor/src/hooks/layout.js
+++ b/packages/block-editor/src/hooks/layout.js
@@ -172,7 +172,9 @@ function LayoutPanel( { setAttributes, attributes, name: blockName } ) {
 										layout: {
 											type:
 												layoutType?.name ===
-												'constrained'
+													'constrained' ||
+												!! inherit ||
+												!! contentSize
 													? 'default'
 													: 'constrained',
 										},

--- a/packages/block-editor/src/hooks/layout.js
+++ b/packages/block-editor/src/hooks/layout.js
@@ -143,11 +143,10 @@ function LayoutPanel( { setAttributes, attributes, name: blockName } ) {
 		return null;
 	}
 	const layoutType = getLayoutType( type );
-
 	const constrainedType = getLayoutType( 'constrained' );
-
 	const displayControlsForLegacyLayouts =
 		! usedLayout.type && ( contentSize || inherit );
+	const hasContentSizeOrLegacySettings = !! inherit || !! contentSize;
 
 	const onChangeType = ( newType ) =>
 		setAttributes( { layout: { type: newType } } );
@@ -164,8 +163,7 @@ function LayoutPanel( { setAttributes, attributes, name: blockName } ) {
 								label={ __( 'Inner blocks use content width' ) }
 								checked={
 									layoutType?.name === 'constrained' ||
-									!! inherit ||
-									!! contentSize
+									hasContentSizeOrLegacySettings
 								}
 								onChange={ () =>
 									setAttributes( {
@@ -173,16 +171,15 @@ function LayoutPanel( { setAttributes, attributes, name: blockName } ) {
 											type:
 												layoutType?.name ===
 													'constrained' ||
-												!! inherit ||
-												!! contentSize
+												hasContentSizeOrLegacySettings
 													? 'default'
 													: 'constrained',
 										},
 									} )
 								}
 								help={
-									!! inherit ||
-									layoutType?.name === 'constrained'
+									layoutType?.name === 'constrained' ||
+									hasContentSizeOrLegacySettings
 										? __(
 												'Nested blocks use content width with options for full and wide widths.'
 										  )


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

In the Layout support's `Inner blocks use content width` toggle, ensure that the logic for which layout type to set also factors in whether `inherit` or `contentSize` is set for legacy markup that uses the `default` layout type.

This ensures that for legacy markup (e.g. the Column block) if you go to toggle off the control, it will toggle _off_ when first clicked.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

Without this change, for some legacy markup, if you go to toggle off the control, it appears not to really do anything at first (it's actually updating the layout type from default to `constrained`). To resolve this, in the `onChange` callback, let's factor in `inherit` and `contentSize` settings in the same way as we do for the checked status.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

* In the `Inner blocks use content width` toggle's `onChange` handler, treat the existence of `inherit` or `contentSize` as signalling that toggling should update the layout attribute to be an empty `default` layout object.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->

Using the following legacy markup, go to toggle off the `Inner blocks use content width` control on the right column:

<details>

<summary>Test markup (the right column has content size)</summary>

```html
<!-- wp:columns {"align":"full"} -->
<div class="wp-block-columns alignfull"><!-- wp:column {"width":"33.33%"} -->
<div class="wp-block-column" style="flex-basis:33.33%"><!-- wp:paragraph -->
<p>Column A</p>
<!-- /wp:paragraph --></div>
<!-- /wp:column -->

<!-- wp:column {"width":"66.66%","layout":{"contentSize":"200px","wideSize":"250px"}} -->
<div class="wp-block-column" style="flex-basis:66.66%"><!-- wp:paragraph -->
<p>Column B (custom width)</p>
<!-- /wp:paragraph -->

<!-- wp:cover {"overlayColor":"primary","minHeight":50} -->
<div class="wp-block-cover" style="min-height:50px"><span aria-hidden="true" class="wp-block-cover__background has-primary-background-color has-background-dim-100 has-background-dim"></span><div class="wp-block-cover__inner-container"><!-- wp:paragraph {"align":"center","placeholder":"Write title…","fontSize":"large"} -->
<p class="has-text-align-center has-large-font-size">A cover in a column</p>
<!-- /wp:paragraph --></div></div>
<!-- /wp:cover -->

<!-- wp:cover {"overlayColor":"primary","minHeight":50} -->
<div class="wp-block-cover" style="min-height:50px"><span aria-hidden="true" class="wp-block-cover__background has-primary-background-color has-background-dim-100 has-background-dim"></span><div class="wp-block-cover__inner-container"><!-- wp:paragraph {"align":"center","placeholder":"Write title…","fontSize":"large"} -->
<p class="has-text-align-center has-large-font-size">A cover in a column</p>
<!-- /wp:paragraph --></div></div>
<!-- /wp:cover --></div>
<!-- /wp:column --></div>
<!-- /wp:columns -->
```
</details>

Test that toggling the control still works as expected for existing Group, Query or individual Column blocks.

## Screenshots or screencast <!-- if applicable -->

Note that in the before clip, the first click on the toggle clears out the content size, but does not visually set the toggle to false (this is because what's actually happening is that the layout object is being updated to be an empty constrained type). In the after clip, the logic is updated so that it treats the default layout type + contentSize as the same as a constrained layout type, so the toggle is effectively switched off when first clicked.

| Before | After |
| --- | --- |
| ![2022-09-06 16 06 00](https://user-images.githubusercontent.com/14988353/188559010-ee575797-c7ab-4a5b-8d52-508c93246aa5.gif) | ![2022-09-06 16 03 49](https://user-images.githubusercontent.com/14988353/188558750-0aa4675c-8ab9-498a-ae9f-d343d25f370a.gif) |
