### PR TITLE
Media & Text: Display upload error notices using snackbars

### DIFF
--- a/packages/block-library/src/media-text/media-container.js
+++ b/packages/block-library/src/media-text/media-container.js
@@ -6,7 +6,7 @@ import classnames from 'classnames';
 /**
  * WordPress dependencies
  */
-import { ResizableBox, Spinner, withNotices } from '@wordpress/components';
+import { ResizableBox, Spinner } from '@wordpress/components';
 import {
 	BlockControls,
 	BlockIcon,
@@ -19,6 +19,7 @@ import { useViewportMatch } from '@wordpress/compose';
 import { useDispatch } from '@wordpress/data';
 import { forwardRef } from '@wordpress/element';
 import { isBlobURL } from '@wordpress/blob';
+import { store as noticesStore } from '@wordpress/notices';
 
 /**
  * Internal dependencies
@@ -73,16 +74,11 @@ function ToolbarEditButton( { mediaId, mediaUrl, onSelectMedia } ) {
 	);
 }
 
-function PlaceholderContainer( {
-	className,
-	noticeOperations,
-	noticeUI,
-	mediaUrl,
-	onSelectMedia,
-} ) {
+function PlaceholderContainer( { className, mediaUrl, onSelectMedia } ) {
+	const { createErrorNotice } = useDispatch( noticesStore );
+
 	const onUploadError = ( message ) => {
-		noticeOperations.removeAllNotices();
-		noticeOperations.createErrorNotice( message );
+		createErrorNotice( message, { type: 'snackbar' } );
 	};
 
 	return (
@@ -95,7 +91,6 @@ function PlaceholderContainer( {
 			onSelect={ onSelectMedia }
 			accept="image/*,video/*"
 			allowedTypes={ ALLOWED_MEDIA_TYPES }
-			notices={ noticeUI }
 			onError={ onUploadError }
 			disableMediaButtons={ mediaUrl }
 		/>
@@ -186,4 +181,4 @@ function MediaContainer( props, ref ) {
 	return <PlaceholderContainer { ...props } />;
 }
 
-export default withNotices( forwardRef( MediaContainer ) );
+export default forwardRef( MediaContainer );


### PR DESCRIPTION
## What?
Update Media & Text block to use snackbars for error notices.

## Why?
> Placeholders are great, but as patterns and templating opportunities have improved, it's become apparent how often the placeholders will be shown in narrow/small contexts, making it all the more necessary that critical information be extracted and shown elsewhere, so it doesn't just get hidden by responsive rules.

https://github.com/WordPress/gutenberg/pull/43767#issuecomment-1235281407 - @jasmussen

## Testing Instructions

1. Create an empty image - touch empty.png
2. Open a post or page
3. Insert a Media & Text block
4. Drag and drop the newly created empty image.
5. Confirm that the error message is displayed as snackbar.

## Screenshots or screencast <!-- if applicable -->

![CleanShot 2022-09-06 at 11 10 01](https://user-images.githubusercontent.com/240569/188570437-db413818-2367-4643-a1f6-ed1e2869c534.png)
