### PR TITLE
Audio: Display upload error notices using snackbars

### DIFF
--- a/packages/block-library/src/audio/edit.js
+++ b/packages/block-library/src/audio/edit.js
@@ -13,7 +13,6 @@ import {
 	SelectControl,
 	Spinner,
 	ToggleControl,
-	withNotices,
 } from '@wordpress/components';
 import {
 	BlockControls,
@@ -28,9 +27,10 @@ import {
 } from '@wordpress/block-editor';
 import { useEffect } from '@wordpress/element';
 import { __, _x } from '@wordpress/i18n';
-import { useSelect } from '@wordpress/data';
+import { useDispatch, useSelect } from '@wordpress/data';
 import { audio as icon } from '@wordpress/icons';
 import { createBlock, getDefaultBlockName } from '@wordpress/blocks';
+import { store as noticesStore } from '@wordpress/notices';
 
 /**
  * Internal dependencies
@@ -42,11 +42,9 @@ const ALLOWED_MEDIA_TYPES = [ 'audio' ];
 function AudioEdit( {
 	attributes,
 	className,
-	noticeOperations,
 	setAttributes,
 	onReplace,
 	isSelected,
-	noticeUI,
 	insertBlocksAfter,
 } ) {
 	const { id, autoplay, caption, loop, preload, src } = attributes;
@@ -93,9 +91,9 @@ function AudioEdit( {
 		}
 	}
 
+	const { createErrorNotice } = useDispatch( noticesStore );
 	function onUploadError( message ) {
-		noticeOperations.removeAllNotices();
-		noticeOperations.createErrorNotice( message );
+		createErrorNotice( message, { type: 'snackbar' } );
 	}
 
 	function getAutoplayHelp( checked ) {
@@ -134,7 +132,6 @@ function AudioEdit( {
 					accept="audio/*"
 					allowedTypes={ ALLOWED_MEDIA_TYPES }
 					value={ attributes }
-					notices={ noticeUI }
 					onError={ onUploadError }
 				/>
 			</div>
@@ -222,4 +219,5 @@ function AudioEdit( {
 		</>
 	);
 }
-export default withNotices( AudioEdit );
+
+export default AudioEdit;


### PR DESCRIPTION
## What?
Similar to #43767, #43890.

Update Audio block to use snackbars for error notices

## Why?
> Placeholders are great, but as patterns and templating opportunities have improved, it's become apparent how often the placeholders will be shown in narrow/small contexts, making it all the more necessary that critical information be extracted and shown elsewhere, so it doesn't just get hidden by responsive rules.

https://github.com/WordPress/gutenberg/pull/43767#issuecomment-1235281407 - @jasmussen

## Testing Instructions
1. Open a Post or Page.
2. Insert an Audio block.
3. Try uploading a non-audio file.
4. Confirm that the error message is displayed as snackbar.

## Screenshots or screencast <!-- if applicable -->

![CleanShot 2022-09-06 at 11 32 11](https://user-images.githubusercontent.com/240569/188576069-ce37b726-1f9e-4c5b-9af1-473cb3047239.png)
