### PR TITLE
Video: Display upload error notices using snackbars

### DIFF
--- a/packages/block-library/src/video/edit.js
+++ b/packages/block-library/src/video/edit.js
@@ -13,7 +13,6 @@ import {
 	Disabled,
 	PanelBody,
 	Spinner,
-	withNotices,
 } from '@wordpress/components';
 import {
 	BlockControls,
@@ -31,9 +30,10 @@ import {
 import { useRef, useEffect } from '@wordpress/element';
 import { __, sprintf } from '@wordpress/i18n';
 import { useInstanceId } from '@wordpress/compose';
-import { useSelect } from '@wordpress/data';
+import { useDispatch, useSelect } from '@wordpress/data';
 import { video as icon } from '@wordpress/icons';
 import { createBlock, getDefaultBlockName } from '@wordpress/blocks';
+import { store as noticesStore } from '@wordpress/notices';
 
 /**
  * Internal dependencies
@@ -48,13 +48,11 @@ const VIDEO_POSTER_ALLOWED_MEDIA_TYPES = [ 'image' ];
 
 function VideoEdit( {
 	isSelected,
-	noticeUI,
 	attributes,
 	className,
 	setAttributes,
 	insertBlocksAfter,
 	onReplace,
-	noticeOperations,
 } ) {
 	const instanceId = useInstanceId( VideoEdit );
 	const videoPlayer = useRef();
@@ -73,9 +71,7 @@ function VideoEdit( {
 				mediaUpload( {
 					filesList: [ file ],
 					onFileChange: ( [ media ] ) => onSelectVideo( media ),
-					onError: ( message ) => {
-						noticeOperations.createErrorNotice( message );
-					},
+					onError: onUploadError,
 					allowedTypes: ALLOWED_MEDIA_TYPES,
 				} );
 			}
@@ -126,9 +122,9 @@ function VideoEdit( {
 		}
 	}
 
+	const { createErrorNotice } = useDispatch( noticesStore );
 	function onUploadError( message ) {
-		noticeOperations.removeAllNotices();
-		noticeOperations.createErrorNotice( message );
+		createErrorNotice( message, { type: 'snackbar' } );
 	}
 
 	const classes = classnames( className, {
@@ -149,7 +145,6 @@ function VideoEdit( {
 					accept="video/*"
 					allowedTypes={ ALLOWED_MEDIA_TYPES }
 					value={ attributes }
-					notices={ noticeUI }
 					onError={ onUploadError }
 				/>
 			</div>
@@ -289,4 +284,4 @@ function VideoEdit( {
 	);
 }
 
-export default withNotices( VideoEdit );
+export default VideoEdit;


### PR DESCRIPTION
## What?
Similar to https://github.com/WordPress/gutenberg/pull/43767, https://github.com/WordPress/gutenberg/pull/43890.

Update Video block to use snackbars for error notices

## Why?
> Placeholders are great, but as patterns and templating opportunities have improved, it's become apparent how often the placeholders will be shown in narrow/small contexts, making it all the more necessary that critical information be extracted and shown elsewhere, so it doesn't just get hidden by responsive rules.

https://github.com/WordPress/gutenberg/pull/43767#issuecomment-1235281407 - @jasmussen

## Testing Instructions
1. Open a Post or Page.
2. Insert a Video block.
3. Try uploading a non-video file.
4. Confirm that the error message is displayed as snackbar.

## Screenshots or screencast <!-- if applicable -->

![CleanShot 2022-09-06 at 11 56 38](https://user-images.githubusercontent.com/240569/188580767-f69605a0-82fe-4cc3-87fd-c4c9adad3e86.png)
