### PR TITLE
File: Display upload error notices using snackbars

### DIFF
--- a/packages/block-library/src/file/edit.js
+++ b/packages/block-library/src/file/edit.js
@@ -9,7 +9,6 @@ import classnames from 'classnames';
 import { getBlobByURL, isBlobURL, revokeBlobURL } from '@wordpress/blob';
 import {
 	__unstableGetAnimateClassName as getAnimateClassName,
-	withNotices,
 	ResizableBox,
 	ToolbarButton,
 } from '@wordpress/components';
@@ -60,14 +59,7 @@ function ClipboardToolbarButton( { text, disabled } ) {
 	);
 }
 
-function FileEdit( {
-	attributes,
-	isSelected,
-	setAttributes,
-	noticeUI,
-	noticeOperations,
-	clientId,
-} ) {
+function FileEdit( { attributes, isSelected, setAttributes, clientId } ) {
 	const {
 		id,
 		fileId,
@@ -91,6 +83,7 @@ function FileEdit( {
 		[ id ]
 	);
 
+	const { createErrorNotice } = useDispatch( noticesStore );
 	const { toggleSelection, __unstableMarkNextChangeAsNotPersistent } =
 		useDispatch( blockEditorStore );
 
@@ -137,8 +130,7 @@ function FileEdit( {
 
 	function onUploadError( message ) {
 		setAttributes( { href: undefined } );
-		noticeOperations.removeAllNotices();
-		noticeOperations.createErrorNotice( message );
+		createErrorNotice( message, { type: 'snackbar' } );
 	}
 
 	function changeLinkDestinationOption( newHref ) {
@@ -207,7 +199,6 @@ function FileEdit( {
 						),
 					} }
 					onSelect={ onSelectFile }
-					notices={ noticeUI }
 					onError={ onUploadError }
 					accept="*"
 				/>
@@ -321,4 +312,4 @@ function FileEdit( {
 	);
 }
 
-export default withNotices( FileEdit );
+export default FileEdit;


### PR DESCRIPTION
## What?
Similar to https://github.com/WordPress/gutenberg/pull/43767, https://github.com/WordPress/gutenberg/pull/43890.

Update File block to use snackbars for error notices.

## Why?
> Placeholders are great, but as patterns and templating opportunities have improved, it's become apparent how often the placeholders will be shown in narrow/small contexts, making it all the more necessary that critical information be extracted and shown elsewhere, so it doesn't just get hidden by responsive rules.

https://github.com/WordPress/gutenberg/pull/43767#issuecomment-1235281407 - @jasmussen

## Testing Instructions

1. Open a Post or Page.
2. Insert a File block.
3. Try uploading an unsupported file type like SVG.
4. Confirm that the error message is displayed as snackbar.

## Screenshots or screencast <!-- if applicable -->

![CleanShot 2022-09-06 at 12 09 59](https://user-images.githubusercontent.com/240569/188582569-737aedd3-cfe7-411e-a302-0fcb9323de72.png)

