### PR TITLE
Lodash: Refactor away from `_.partial()`

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -131,6 +131,7 @@ module.exports = {
 							'nth',
 							'once',
 							'overEvery',
+							'partial',
 							'partialRight',
 							'random',
 							'reject',

--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -37,6 +37,7 @@
 -   `ComboboxControl`: updated to satisfy `react/exhuastive-deps` eslint rule ([#41417](https://github.com/WordPress/gutenberg/pull/41417))
 -   `FormTokenField`: Refactor away from Lodash ([#43744](https://github.com/WordPress/gutenberg/pull/43744/)).
 -   `NavigatorButton`: updated to satisfy `react/exhaustive-deps` eslint rule ([#42051](https://github.com/WordPress/gutenberg/pull/42051))
+-   `TabPanel`: Refactor away from `_.partial()` ([#43895](https://github.com/WordPress/gutenberg/pull/43895/)).
 
 ## 20.0.0 (2022-08-24)
 

--- a/packages/components/src/tab-panel/index.tsx
+++ b/packages/components/src/tab-panel/index.tsx
@@ -2,7 +2,7 @@
  * External dependencies
  */
 import classnames from 'classnames';
-import { partial, find } from 'lodash';
+import { find } from 'lodash';
 
 /**
  * WordPress dependencies
@@ -127,7 +127,7 @@ export function TabPanel( {
 						aria-controls={ `${ instanceId }-${ tab.name }-view` }
 						selected={ tab.name === selected }
 						key={ tab.name }
-						onClick={ partial( handleClick, tab.name ) }
+						onClick={ () => handleClick( tab.name ) }
 					>
 						{ tab.title }
 					</TabButton>

--- a/packages/edit-post/src/components/block-manager/checklist.js
+++ b/packages/edit-post/src/components/block-manager/checklist.js
@@ -1,9 +1,4 @@
 /**
- * External dependencies
- */
-import { partial } from 'lodash';
-
-/**
  * WordPress dependencies
  */
 import { BlockIcon } from '@wordpress/block-editor';
@@ -25,7 +20,9 @@ function BlockTypesChecklist( { blockTypes, value, onItemChange } ) {
 							</>
 						}
 						checked={ value.includes( blockType.name ) }
-						onChange={ partial( onItemChange, blockType.name ) }
+						onChange={ ( ...args ) =>
+							onItemChange( blockType.name, ...args )
+						}
 					/>
 				</li>
 			) ) }

--- a/packages/edit-post/src/components/sidebar/featured-image/index.js
+++ b/packages/edit-post/src/components/sidebar/featured-image/index.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { get, partial } from 'lodash';
+import { get } from 'lodash';
 
 /**
  * WordPress dependencies
@@ -66,7 +66,8 @@ const applyWithDispatch = withDispatch( ( dispatch ) => {
 	const { toggleEditorPanelOpened } = dispatch( editPostStore );
 
 	return {
-		onTogglePanel: partial( toggleEditorPanelOpened, PANEL_NAME ),
+		onTogglePanel: ( ...args ) =>
+			toggleEditorPanelOpened( PANEL_NAME, ...args ),
 	};
 } );
 

--- a/packages/edit-post/src/components/sidebar/page-attributes/index.js
+++ b/packages/edit-post/src/components/sidebar/page-attributes/index.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { get, partial } from 'lodash';
+import { get } from 'lodash';
 
 /**
  * WordPress dependencies
@@ -46,7 +46,8 @@ export function PageAttributes() {
 		return null;
 	}
 
-	const onTogglePanel = partial( toggleEditorPanelOpened, PANEL_NAME );
+	const onTogglePanel = ( ...args ) =>
+		toggleEditorPanelOpened( PANEL_NAME, ...args );
 
 	return (
 		<PageAttributesCheck>


### PR DESCRIPTION
## What?
This PR removes Lodash's `_.partial()` completely and deprecates them. There are just a few usages and conversion is pretty straightforward. 

## Why?

Lodash is known to unnecessarily inflate the bundle size of packages, and in most cases, it can be replaced with native language functionality. See these for more information and rationale:

* https://github.com/WordPress/gutenberg/issues/16938#issuecomment-602837246
* https://github.com/WordPress/gutenberg/issues/17025
* https://github.com/WordPress/gutenberg/issues/39495 

## How?

We're replacing a few usages with their native counterparts. 

## Testing Instructions

* Verify that after selecting some text in a paragraph, the panel for selecting colors still works well and you can switch between solid color and gradients.
* In Preferences -> Blocks of the post editor, verify you can still enable and disable blocks.
* Verify toggling the Featured Image (in a post) and Page Attributes (in a page) panels in the sidebar still can be toggled.
* Verify all checks are green.