### PR TITLE
Block Editor: Refactor `UrlPopover` tests to `@testing-library/react`

### DIFF
--- a/packages/block-editor/src/components/url-popover/test/__snapshots__/index.js.snap
+++ b/packages/block-editor/src/components/url-popover/test/__snapshots__/index.js.snap
@@ -1,103 +1,131 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`URLPopover matches the snapshot in its default state 1`] = `
-<ForwardRef(Popover)
-  className="block-editor-url-popover"
-  focusOnMount="firstElement"
-  position="bottom center"
-  shift={true}
->
-  <div
-    className="block-editor-url-popover__input-container"
-  >
+<div>
+  <span>
     <div
-      className="block-editor-url-popover__row"
+      class="components-popover block-editor-url-popover"
+      style="position: absolute; opacity: 0; transform: translateY(-2em) scale(0) translateZ(0); transform-origin: 50% 0% 0;"
+      tabindex="-1"
     >
-      <div>
-        Editor
-      </div>
-      <ForwardRef(Button)
-        aria-expanded={false}
-        className="block-editor-url-popover__settings-toggle"
-        icon={
-          <SVG
-            viewBox="0 0 24 24"
-            xmlns="http://www.w3.org/2000/svg"
+      <div
+        class="components-popover__content"
+      >
+        <div
+          class="block-editor-url-popover__input-container"
+        >
+          <div
+            class="block-editor-url-popover__row"
           >
-            <Path
-              d="M17.5 11.6L12 16l-5.5-4.4.9-1.2L12 14l4.5-3.6 1 1.2z"
-            />
-          </SVG>
-        }
-        label="Link settings"
-        onClick={[Function]}
-      />
+            <div>
+              Editor
+            </div>
+            <button
+              aria-expanded="false"
+              aria-label="Link settings"
+              class="components-button block-editor-url-popover__settings-toggle has-icon"
+              type="button"
+            >
+              <svg
+                aria-hidden="true"
+                focusable="false"
+                height="24"
+                viewBox="0 0 24 24"
+                width="24"
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <path
+                  d="M17.5 11.6L12 16l-5.5-4.4.9-1.2L12 14l4.5-3.6 1 1.2z"
+                />
+              </svg>
+            </button>
+          </div>
+        </div>
+      </div>
     </div>
-  </div>
-</ForwardRef(Popover)>
+  </span>
+</div>
 `;
 
 exports[`URLPopover matches the snapshot when the settings are toggled open 1`] = `
-<ForwardRef(Popover)
-  className="block-editor-url-popover"
-  focusOnMount="firstElement"
-  position="bottom center"
-  shift={true}
->
-  <div
-    className="block-editor-url-popover__input-container"
-  >
+<div>
+  <span>
     <div
-      className="block-editor-url-popover__row"
+      class="components-popover block-editor-url-popover"
+      style="position: absolute; opacity: 0; transform: translateY(-2em) scale(0) translateZ(0); transform-origin: 50% 0% 0; left: 0px; top: 0px;"
+      tabindex="-1"
     >
-      <div>
-        Editor
-      </div>
-      <ForwardRef(Button)
-        aria-expanded={true}
-        className="block-editor-url-popover__settings-toggle"
-        icon={
-          <SVG
-            viewBox="0 0 24 24"
-            xmlns="http://www.w3.org/2000/svg"
+      <div
+        class="components-popover__content"
+        style="max-height: 0px; overflow: auto;"
+      >
+        <div
+          class="block-editor-url-popover__input-container"
+        >
+          <div
+            class="block-editor-url-popover__row"
           >
-            <Path
-              d="M17.5 11.6L12 16l-5.5-4.4.9-1.2L12 14l4.5-3.6 1 1.2z"
-            />
-          </SVG>
-        }
-        label="Link settings"
-        onClick={[Function]}
-      />
-    </div>
-    <div
-      className="block-editor-url-popover__row block-editor-url-popover__settings"
-    >
-      <div>
-        Settings
+            <div>
+              Editor
+            </div>
+            <button
+              aria-expanded="true"
+              aria-label="Link settings"
+              class="components-button block-editor-url-popover__settings-toggle has-icon"
+              type="button"
+            >
+              <svg
+                aria-hidden="true"
+                focusable="false"
+                height="24"
+                viewBox="0 0 24 24"
+                width="24"
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <path
+                  d="M17.5 11.6L12 16l-5.5-4.4.9-1.2L12 14l4.5-3.6 1 1.2z"
+                />
+              </svg>
+            </button>
+          </div>
+          <div
+            class="block-editor-url-popover__row block-editor-url-popover__settings"
+          >
+            <div>
+              Settings
+            </div>
+          </div>
+        </div>
       </div>
     </div>
-  </div>
-</ForwardRef(Popover)>
+  </span>
+</div>
 `;
 
 exports[`URLPopover matches the snapshot when there are no settings 1`] = `
-<ForwardRef(Popover)
-  className="block-editor-url-popover"
-  focusOnMount="firstElement"
-  position="bottom center"
-  shift={true}
->
-  <div
-    className="block-editor-url-popover__input-container"
-  >
+<div>
+  <span>
     <div
-      className="block-editor-url-popover__row"
+      class="components-popover block-editor-url-popover"
+      style="position: absolute; opacity: 0; transform: translateY(-2em) scale(0) translateZ(0); transform-origin: 50% 0% 0;"
+      tabindex="-1"
     >
-      <div>
-        Editor
+      <div
+        class="components-popover__content"
+      >
+        <div
+          class="block-editor-url-popover__input-container"
+        >
+          <div
+            class="block-editor-url-popover__row"
+          >
+            <div>
+              Editor
+            </div>
+          </div>
+        </div>
       </div>
     </div>
-  </div>
-</ForwardRef(Popover)>
+  </span>
+</div>
 `;

--- a/packages/block-editor/src/components/url-popover/test/index.js
+++ b/packages/block-editor/src/components/url-popover/test/index.js
@@ -1,7 +1,8 @@
 /**
  * External dependencies
  */
-import { shallow } from 'enzyme';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 
 /**
  * Internal dependencies
@@ -10,38 +11,39 @@ import URLPopover from '../';
 
 describe( 'URLPopover', () => {
 	it( 'matches the snapshot in its default state', () => {
-		const wrapper = shallow(
+		const { container } = render(
 			<URLPopover renderSettings={ () => <div>Settings</div> }>
 				<div>Editor</div>
 			</URLPopover>
 		);
 
-		expect( wrapper ).toMatchSnapshot();
+		expect( container ).toMatchSnapshot();
 	} );
 
-	it( 'matches the snapshot when the settings are toggled open', () => {
-		const wrapper = shallow(
+	it( 'matches the snapshot when the settings are toggled open', async () => {
+		const user = userEvent.setup( {
+			advanceTimers: jest.advanceTimersByTime,
+		} );
+		const { container } = render(
 			<URLPopover renderSettings={ () => <div>Settings</div> }>
 				<div>Editor</div>
 			</URLPopover>
 		);
 
-		const toggleButton = wrapper.find(
-			'.block-editor-url-popover__settings-toggle'
+		await user.click(
+			screen.getByRole( 'button', { name: 'Link settings' } )
 		);
-		expect( toggleButton ).toHaveLength( 1 );
-		toggleButton.simulate( 'click' );
 
-		expect( wrapper ).toMatchSnapshot();
+		expect( container ).toMatchSnapshot();
 	} );
 
 	it( 'matches the snapshot when there are no settings', () => {
-		const wrapper = shallow(
+		const { container } = render(
 			<URLPopover>
 				<div>Editor</div>
 			</URLPopover>
 		);
 
-		expect( wrapper ).toMatchSnapshot();
+		expect( container ).toMatchSnapshot();
 	} );
 } );


### PR DESCRIPTION
## What?
We've recently started refactoring `enzyme` tests to `@testing-library/react`.

This PR refactors the `<UrlPopover />` component tests from `enzyme` to `@testing-library/react`.

## Why?
`@testing-library/react` provides a better way to write tests for accessible components that is closer to the way the user experiences them.

The purpose of this PR is not to improve or enrich the tests themselves, but rather to migrate them. Our main motivation is unblocking the upgrade to React 18.

## How?
We're straightforwardly replacing `enzyme` tests with `@testing-library/react` ones, using `jest-dom` matchers and mocks to avoid testing unrelated implementation details.

## Testing Instructions
Verify tests pass: `npm run test:unit packages/block-editor/src/components/url-popover/test/index.js`
