### PR TITLE
Comment pagination numbers: add background color

### DIFF
--- a/docs/reference-guides/core-blocks.md
+++ b/docs/reference-guides/core-blocks.md
@@ -203,7 +203,7 @@ Displays a list of page numbers for comments pagination. ([Source](https://githu
 
 -	**Name:** core/comments-pagination-numbers
 -	**Category:** theme
--	**Supports:** typography (fontSize, lineHeight), ~~html~~, ~~reusable~~
+-	**Supports:** color (background, gradients, ~~text~~), typography (fontSize, lineHeight), ~~html~~, ~~reusable~~
 -	**Attributes:** 
 
 ## Previous Page

--- a/packages/block-library/src/comments-pagination-numbers/block.json
+++ b/packages/block-library/src/comments-pagination-numbers/block.json
@@ -11,6 +11,13 @@
 	"supports": {
 		"reusable": false,
 		"html": false,
+		"color": {
+			"gradients": true,
+			"text": false,
+			"__experimentalDefaultControls": {
+				"background": true
+			}
+		},
 		"typography": {
 			"fontSize": true,
 			"lineHeight": true,


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->
Updates the block supports to include background color.
Related: https://github.com/WordPress/gutenberg/issues/43245

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
To match the settings of the comments pagination next and previous inner blocks.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
By updating the block support and documentation.

## Testing Instructions

1. First make sure that your test installation has some comments, and that comment pagination is enabled in the WordPress admin area under Settings, Discussion, "Break comments into pages"
2. Create or open a post or page template in the site editor and add a comments block.
3. In the comments block, locate the nested comment pagination numbers block.
4. Confirm if the block has background color and background gradient settings in the block sidebar. Change the color.
5. Save and view the front, confirm if the color is applied on the front.

Add the example code below to `theme.json` under `styles.blocks`.
Confirm that the color displays correctly in the editor and front, and that the colors can be changed in the block settings sidebar.

```
"core/comments-pagination-numbers": {
	"color": {
			"background": "green"
	}
}
```

Continue to test the block's background and gradient color in the global styles sidebar in the site editor.

