### PR TITLE
Fix: Site logo rounded on mobile.

### DIFF
--- a/packages/block-library/src/site-logo/editor.scss
+++ b/packages/block-library/src/site-logo/editor.scss
@@ -40,6 +40,7 @@
 	}
 
 	// Inherit radius.
+	> div, // A 60px width div shown only in the editor on mobile.
 	.components-resizable-box__container {
 		border-radius: inherit;
 	}


### PR DESCRIPTION
## What?

Followup to #43762. Turns out on mobile, only in the editor, there's an additional wrapping div around the site logo, which needs inheritance. This PR adds that.

Before:

<img width="690" alt="before" src="https://user-images.githubusercontent.com/1204802/188628448-3e94f72c-4061-49ae-a62f-832e8ed4d16b.png">

After:

<img width="677" alt="after" src="https://user-images.githubusercontent.com/1204802/188628469-174478ad-7036-4941-831a-539932f1fae8.png">

Is there a way to e2e test this.

## Testing Instructions

* Insert a site logo, add an image, save.
* Set the site logo to the rounded style.
* Make the viewport mobile small, either via the dropdown or resize the browser to < 600px. 

The site logo should remain round.