### PR TITLE
Better handling of loading states for navigation selector

### DIFF
--- a/packages/block-library/src/navigation/edit/navigation-menu-selector.js
+++ b/packages/block-library/src/navigation/edit/navigation-menu-selector.js
@@ -133,6 +133,8 @@ function NavigationMenuSelector( {
 			</>
 		),
 		isBusy: ! enableOptions,
+		disabled: ! enableOptions,
+		__experimentalIsFocusable: true,
 		onClick: () => {
 			setIsPressed( ! isPressed );
 		},

--- a/packages/block-library/src/navigation/edit/navigation-menu-selector.js
+++ b/packages/block-library/src/navigation/edit/navigation-menu-selector.js
@@ -143,9 +143,10 @@ function NavigationMenuSelector( {
 	if ( ! hasNavigationMenus && ! hasClassicMenus ) {
 		return (
 			<Button
-				{ ...toggleProps }
 				className="wp-block-navigation__navigation-selector-button--createnew"
+				isBusy={ ! enableOptions }
 				disabled={ ! enableOptions }
+				__experimentalIsFocusable
 				onClick={ () => {
 					onCreateNew();
 					setIsCreatingMenu( true );


### PR DESCRIPTION
Closes #43901


## What?

- disables the button of the `Dropdown` toggle
- disables the button to create new menu
- enables focus preservation on disabled buttons
- handles multiple clicks


## Why?
In #42987 the control to switch the menu used by a Navigation block only shows busy UI but it remains clickable. This 

## How?
Implementing both `isBusy` and `disabled` but with the addition of `__experimentalIsFocusable`.


## Testing Instructions
- switch to this PR
- delete all menus (classic and block)
- add a post
- add a navigation block
- there should be a button to create a navigation in the inspector
- set using inspector tools a low throttle for Network
- click the button
- **it should show the busy UI and NOT be clickable**
- save all changes
- in the inspector of the navigation block there should be a dropdown
- click it and select create new menu
- **it should show the busy UI and NOT be clickable**
