### PR TITLE
Editor: Refactor `PostPublishButton` tests to `@testing-library/react`

### DIFF
--- a/packages/editor/src/components/post-publish-button/test/index.js
+++ b/packages/editor/src/components/post-publish-button/test/index.js
@@ -1,12 +1,8 @@
 /**
  * External dependencies
  */
-import { shallow } from 'enzyme';
-
-/**
- * WordPress dependencies
- */
-import { Button } from '@wordpress/components';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 
 /**
  * Internal dependencies
@@ -16,27 +12,27 @@ import { PostPublishButton } from '../';
 describe( 'PostPublishButton', () => {
 	describe( 'aria-disabled', () => {
 		it( 'should be true if post is currently saving', () => {
-			const wrapper = shallow(
-				<PostPublishButton isPublishable isSaveable isSaving />
-			);
+			render( <PostPublishButton isPublishable isSaveable isSaving /> );
 
-			expect( wrapper.find( Button ).prop( 'aria-disabled' ) ).toBe(
-				true
+			expect( screen.getByRole( 'button' ) ).toHaveAttribute(
+				'aria-disabled',
+				'true'
 			);
 		} );
 
 		it( 'should be true if forceIsSaving is true', () => {
-			const wrapper = shallow(
+			render(
 				<PostPublishButton isPublishable isSaveable forceIsSaving />
 			);
 
-			expect( wrapper.find( Button ).prop( 'aria-disabled' ) ).toBe(
-				true
+			expect( screen.getByRole( 'button' ) ).toHaveAttribute(
+				'aria-disabled',
+				'true'
 			);
 		} );
 
 		it( 'should be true if post is not publishable and not forceIsDirty', () => {
-			const wrapper = shallow(
+			render(
 				<PostPublishButton
 					isSaveable
 					isPublishable={ false }
@@ -44,23 +40,23 @@ describe( 'PostPublishButton', () => {
 				/>
 			);
 
-			expect( wrapper.find( Button ).prop( 'aria-disabled' ) ).toBe(
-				true
+			expect( screen.getByRole( 'button' ) ).toHaveAttribute(
+				'aria-disabled',
+				'true'
 			);
 		} );
 
 		it( 'should be true if post is not saveable', () => {
-			const wrapper = shallow(
-				<PostPublishButton isPublishable isSaveable={ false } />
-			);
+			render( <PostPublishButton isPublishable isSaveable={ false } /> );
 
-			expect( wrapper.find( Button ).prop( 'aria-disabled' ) ).toBe(
-				true
+			expect( screen.getByRole( 'button' ) ).toHaveAttribute(
+				'aria-disabled',
+				'true'
 			);
 		} );
 
 		it( 'should be true if post saving is locked', () => {
-			const wrapper = shallow(
+			render(
 				<PostPublishButton
 					isPublishable
 					isSaveable
@@ -68,13 +64,14 @@ describe( 'PostPublishButton', () => {
 				/>
 			);
 
-			expect( wrapper.find( Button ).prop( 'aria-disabled' ) ).toBe(
-				true
+			expect( screen.getByRole( 'button' ) ).toHaveAttribute(
+				'aria-disabled',
+				'true'
 			);
 		} );
 
 		it( 'should be false if post is saveable but not publishable and forceIsDirty is true', () => {
-			const wrapper = shallow(
+			render(
 				<PostPublishButton
 					isSaveable
 					isPublishable={ false }
@@ -82,113 +79,128 @@ describe( 'PostPublishButton', () => {
 				/>
 			);
 
-			expect( wrapper.find( Button ).prop( 'aria-disabled' ) ).toBe(
-				false
+			expect( screen.getByRole( 'button' ) ).toHaveAttribute(
+				'aria-disabled',
+				'false'
 			);
 		} );
 
 		it( 'should be false if post is publishave and saveable', () => {
-			const wrapper = shallow(
-				<PostPublishButton isPublishable isSaveable />
-			);
+			render( <PostPublishButton isPublishable isSaveable /> );
 
-			expect( wrapper.find( Button ).prop( 'aria-disabled' ) ).toBe(
-				false
+			expect( screen.getByRole( 'button' ) ).toHaveAttribute(
+				'aria-disabled',
+				'false'
 			);
 		} );
 	} );
 
 	describe( 'publish status', () => {
-		it( 'should be pending for contributor', () => {
+		it( 'should be pending for contributor', async () => {
+			const user = userEvent.setup( {
+				advanceTimers: jest.advanceTimersByTime,
+			} );
 			const onStatusChange = jest.fn();
 			const onSave = jest.fn();
-			const wrapper = shallow(
+			render(
 				<PostPublishButton
 					hasPublishAction={ false }
 					onStatusChange={ onStatusChange }
 					onSave={ onSave }
-					isSaveable={ true }
-					isPublishable={ true }
+					isSaveable
+					isPublishable
 				/>
 			);
 
-			wrapper.find( Button ).simulate( 'click' );
+			await user.click( screen.getByRole( 'button' ) );
 
 			expect( onStatusChange ).toHaveBeenCalledWith( 'pending' );
 		} );
 
-		it( 'should be future for scheduled post', () => {
+		it( 'should be future for scheduled post', async () => {
+			const user = userEvent.setup( {
+				advanceTimers: jest.advanceTimersByTime,
+			} );
 			const onStatusChange = jest.fn();
 			const onSave = jest.fn();
-			const wrapper = shallow(
+			render(
 				<PostPublishButton
-					hasPublishAction={ true }
+					hasPublishAction
 					onStatusChange={ onStatusChange }
 					onSave={ onSave }
 					isBeingScheduled
-					isSaveable={ true }
-					isPublishable={ true }
+					isSaveable
+					isPublishable
 				/>
 			);
 
-			wrapper.find( Button ).simulate( 'click' );
+			await user.click( screen.getByRole( 'button' ) );
 
 			expect( onStatusChange ).toHaveBeenCalledWith( 'future' );
 		} );
 
-		it( 'should be private for private visibility', () => {
+		it( 'should be private for private visibility', async () => {
+			const user = userEvent.setup( {
+				advanceTimers: jest.advanceTimersByTime,
+			} );
 			const onStatusChange = jest.fn();
 			const onSave = jest.fn();
-			const wrapper = shallow(
+			render(
 				<PostPublishButton
-					hasPublishAction={ true }
+					hasPublishAction
 					onStatusChange={ onStatusChange }
 					onSave={ onSave }
 					visibility="private"
-					isSaveable={ true }
-					isPublishable={ true }
+					isSaveable
+					isPublishable
 				/>
 			);
 
-			wrapper.find( Button ).simulate( 'click' );
+			await user.click( screen.getByRole( 'button' ) );
 
 			expect( onStatusChange ).toHaveBeenCalledWith( 'private' );
 		} );
 
-		it( 'should be publish otherwise', () => {
+		it( 'should be publish otherwise', async () => {
+			const user = userEvent.setup( {
+				advanceTimers: jest.advanceTimersByTime,
+			} );
 			const onStatusChange = jest.fn();
 			const onSave = jest.fn();
-			const wrapper = shallow(
+			render(
 				<PostPublishButton
-					hasPublishAction={ true }
+					hasPublishAction
 					onStatusChange={ onStatusChange }
 					onSave={ onSave }
-					isSaveable={ true }
-					isPublishable={ true }
+					isSaveable
+					isPublishable
 				/>
 			);
 
-			wrapper.find( Button ).simulate( 'click' );
+			await user.click( screen.getByRole( 'button' ) );
 
 			expect( onStatusChange ).toHaveBeenCalledWith( 'publish' );
 		} );
 	} );
 
 	describe( 'click', () => {
-		it( 'should save with status', () => {
+		it( 'should save with status', async () => {
+			const user = userEvent.setup( {
+				advanceTimers: jest.advanceTimersByTime,
+			} );
 			const onStatusChange = jest.fn();
 			const onSave = jest.fn();
-			const wrapper = shallow(
+			render(
 				<PostPublishButton
-					hasPublishAction={ true }
+					hasPublishAction
 					onStatusChange={ onStatusChange }
 					onSave={ onSave }
-					isSaveable={ true }
-					isPublishable={ true }
+					isSaveable
+					isPublishable
 				/>
 			);
 
-			wrapper.find( Button ).simulate( 'click' );
+			await user.click( screen.getByRole( 'button' ) );
 
 			expect( onStatusChange ).toHaveBeenCalledWith( 'publish' );
 			expect( onSave ).toHaveBeenCalled();
@@ -196,8 +208,8 @@ describe( 'PostPublishButton', () => {
 	} );
 
 	it( 'should have save modifier class', () => {
-		const wrapper = shallow( <PostPublishButton isSaving isPublished /> );
+		render( <PostPublishButton isSaving isPublished /> );
 
-		expect( wrapper.find( Button ).prop( 'isBusy' ) ).toBe( true );
+		expect( screen.getByRole( 'button' ) ).toHaveClass( 'is-busy' );
 	} );
 } );

--- a/packages/editor/src/components/post-publish-button/test/index.js
+++ b/packages/editor/src/components/post-publish-button/test/index.js
@@ -14,10 +14,9 @@ describe( 'PostPublishButton', () => {
 		it( 'should be true if post is currently saving', () => {
 			render( <PostPublishButton isPublishable isSaveable isSaving /> );
 
-			expect( screen.getByRole( 'button' ) ).toHaveAttribute(
-				'aria-disabled',
-				'true'
-			);
+			expect(
+				screen.getByRole( 'button', { name: 'Submit for Review' } )
+			).toHaveAttribute( 'aria-disabled', 'true' );
 		} );
 
 		it( 'should be true if forceIsSaving is true', () => {
@@ -25,10 +24,9 @@ describe( 'PostPublishButton', () => {
 				<PostPublishButton isPublishable isSaveable forceIsSaving />
 			);
 
-			expect( screen.getByRole( 'button' ) ).toHaveAttribute(
-				'aria-disabled',
-				'true'
-			);
+			expect(
+				screen.getByRole( 'button', { name: 'Submit for Review' } )
+			).toHaveAttribute( 'aria-disabled', 'true' );
 		} );
 
 		it( 'should be true if post is not publishable and not forceIsDirty', () => {
@@ -40,19 +38,17 @@ describe( 'PostPublishButton', () => {
 				/>
 			);
 
-			expect( screen.getByRole( 'button' ) ).toHaveAttribute(
-				'aria-disabled',
-				'true'
-			);
+			expect(
+				screen.getByRole( 'button', { name: 'Submit for Review' } )
+			).toHaveAttribute( 'aria-disabled', 'true' );
 		} );
 
 		it( 'should be true if post is not saveable', () => {
 			render( <PostPublishButton isPublishable isSaveable={ false } /> );
 
-			expect( screen.getByRole( 'button' ) ).toHaveAttribute(
-				'aria-disabled',
-				'true'
-			);
+			expect(
+				screen.getByRole( 'button', { name: 'Submit for Review' } )
+			).toHaveAttribute( 'aria-disabled', 'true' );
 		} );
 
 		it( 'should be true if post saving is locked', () => {
@@ -64,10 +60,9 @@ describe( 'PostPublishButton', () => {
 				/>
 			);
 
-			expect( screen.getByRole( 'button' ) ).toHaveAttribute(
-				'aria-disabled',
-				'true'
-			);
+			expect(
+				screen.getByRole( 'button', { name: 'Submit for Review' } )
+			).toHaveAttribute( 'aria-disabled', 'true' );
 		} );
 
 		it( 'should be false if post is saveable but not publishable and forceIsDirty is true', () => {
@@ -79,19 +74,17 @@ describe( 'PostPublishButton', () => {
 				/>
 			);
 
-			expect( screen.getByRole( 'button' ) ).toHaveAttribute(
-				'aria-disabled',
-				'false'
-			);
+			expect(
+				screen.getByRole( 'button', { name: 'Submit for Review' } )
+			).toHaveAttribute( 'aria-disabled', 'false' );
 		} );
 
 		it( 'should be false if post is publishave and saveable', () => {
 			render( <PostPublishButton isPublishable isSaveable /> );
 
-			expect( screen.getByRole( 'button' ) ).toHaveAttribute(
-				'aria-disabled',
-				'false'
-			);
+			expect(
+				screen.getByRole( 'button', { name: 'Submit for Review' } )
+			).toHaveAttribute( 'aria-disabled', 'false' );
 		} );
 	} );
 
@@ -112,7 +105,9 @@ describe( 'PostPublishButton', () => {
 				/>
 			);
 
-			await user.click( screen.getByRole( 'button' ) );
+			await user.click(
+				screen.getByRole( 'button', { name: 'Submit for Review' } )
+			);
 
 			expect( onStatusChange ).toHaveBeenCalledWith( 'pending' );
 		} );
@@ -134,7 +129,9 @@ describe( 'PostPublishButton', () => {
 				/>
 			);
 
-			await user.click( screen.getByRole( 'button' ) );
+			await user.click(
+				screen.getByRole( 'button', { name: 'Submit for Review' } )
+			);
 
 			expect( onStatusChange ).toHaveBeenCalledWith( 'future' );
 		} );
@@ -156,7 +153,9 @@ describe( 'PostPublishButton', () => {
 				/>
 			);
 
-			await user.click( screen.getByRole( 'button' ) );
+			await user.click(
+				screen.getByRole( 'button', { name: 'Submit for Review' } )
+			);
 
 			expect( onStatusChange ).toHaveBeenCalledWith( 'private' );
 		} );
@@ -177,7 +176,9 @@ describe( 'PostPublishButton', () => {
 				/>
 			);
 
-			await user.click( screen.getByRole( 'button' ) );
+			await user.click(
+				screen.getByRole( 'button', { name: 'Submit for Review' } )
+			);
 
 			expect( onStatusChange ).toHaveBeenCalledWith( 'publish' );
 		} );
@@ -200,7 +201,9 @@ describe( 'PostPublishButton', () => {
 				/>
 			);
 
-			await user.click( screen.getByRole( 'button' ) );
+			await user.click(
+				screen.getByRole( 'button', { name: 'Submit for Review' } )
+			);
 
 			expect( onStatusChange ).toHaveBeenCalledWith( 'publish' );
 			expect( onSave ).toHaveBeenCalled();
@@ -210,6 +213,8 @@ describe( 'PostPublishButton', () => {
 	it( 'should have save modifier class', () => {
 		render( <PostPublishButton isSaving isPublished /> );
 
-		expect( screen.getByRole( 'button' ) ).toHaveClass( 'is-busy' );
+		expect(
+			screen.getByRole( 'button', { name: 'Submit for Review' } )
+		).toHaveClass( 'is-busy' );
 	} );
 } );


### PR DESCRIPTION
## What?
We've recently started refactoring `enzyme` tests to `@testing-library/react`.

This PR refactors the `<PostPublishButton />` component tests from `enzyme` to `@testing-library/react`.

## Why?
`@testing-library/react` provides a better way to write tests for accessible components that is closer to the way the user experiences them.

## How?
We're straightforwardly replacing `enzyme` tests with `@testing-library/react` ones, using `jest-dom` matchers and mocks to avoid testing unrelated implementation details.

## Testing Instructions
Verify tests pass: `npm run test:unit packages/editor/src/components/post-publish-button/test/index.js`
