### PR TITLE
`NavigatorScreen`: add missing deps to `useEffect` dep array

### DIFF
--- a/packages/components/src/navigator/navigator-screen/component.tsx
+++ b/packages/components/src/navigator/navigator-screen/component.tsx
@@ -104,7 +104,12 @@ function NavigatorScreen( props: Props, forwardedRef: ForwardedRef< any > ) {
 		}
 
 		elementToFocus.focus();
-	}, [ isInitialLocation, isMatch ] );
+	}, [
+		isInitialLocation,
+		isMatch,
+		location.isBack,
+		previousLocation?.focusTargetSelector,
+	] );
 
 	const mergedWrapperRef = useMergeRefs( [ forwardedRef, wrapperRef ] );
 


### PR DESCRIPTION
## What?

Updates the `NavigatorScreen` component to satisfy the `exhaustive-deps` eslint rule

## Why?

Part of the effort in https://github.com/WordPress/gutenberg/pull/41166 to apply `exhaustive-deps` to the Components package

## How?

Add the `location.isBack` & `previousLocation?.focusTargetSelector` to the `useEffect` dependency array.

## Testing Instructions

1. From your local Gutenberg directory, run `npx eslint --rule 'react-hooks/exhaustive-deps: warn' packages/components/src/navigator/navigator-screen`
2. Confirm that the linter returns no errors
3. Confirm unit tests still pass
4. Run Storybook locally, confirm the components stories and/or docs still work as expected
