### PR TITLE
`PaletteEditListView`: add missing deps to `useEffect` dep array

### DIFF
--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -50,6 +50,7 @@
 -   `Popover`: refactor to TypeScript ([#43823](https://github.com/WordPress/gutenberg/pull/43823/)).
 -   `BorderControl` and `BorderBoxControl`: replace temporary types with `Popover`'s types ([#43823](https://github.com/WordPress/gutenberg/pull/43823/)).
 -   `DimensionControl`: Refactor tests to `@testing-library/react` ([#43916](https://github.com/WordPress/gutenberg/pull/43916)).
+-   `PaletteEditListView`: updated to satisfy `react/exhaustive-deps` eslint rule ([#43911](https://github.com/WordPress/gutenberg/pull/43911))
 
 ## 20.0.0 (2022-08-24)
 

--- a/packages/components/src/palette-edit/index.js
+++ b/packages/components/src/palette-edit/index.js
@@ -229,7 +229,7 @@ function PaletteEditListView( {
 				onChange( newElements.length ? newElements : undefined );
 			}
 		};
-	}, [] );
+	}, [ onChange, slugPrefix ] );
 
 	const debounceOnChange = useDebounce( onChange, 100 );
 


### PR DESCRIPTION
## What?

Updates the `PaletteEditListView` component to satisfy the `exhaustive-deps` eslint rule

## Why?

Part of the effort in https://github.com/WordPress/gutenberg/pull/41166 to apply `exhaustive-deps` to the Components package

## How?

Add the `onChange` prop & `slugPrefix` to the `useCallback` dependency array.

## Testing Instructions

1. From your local Gutenberg directory, run `npx eslint --rule 'react-hooks/exhaustive-deps: warn' packages/components/src/palette-edit`
2. Confirm that the linter returns no errors
3. Confirm unit tests still pass
