### PR TITLE
Compose: Refactor `withInstanceId` HoC tests to `@testing-library/react`

### DIFF
--- a/packages/compose/src/higher-order/with-instance-id/test/index.js
+++ b/packages/compose/src/higher-order/with-instance-id/test/index.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { render } from 'enzyme';
+import { render, screen } from '@testing-library/react';
 
 /**
  * Internal dependencies
@@ -10,13 +10,17 @@ import withInstanceId from '../';
 
 describe( 'withInstanceId', () => {
 	const DumpComponent = withInstanceId( ( { instanceId } ) => {
-		return <div>{ instanceId }</div>;
+		return <div data-testid="wrapper">{ instanceId }</div>;
 	} );
 
 	it( 'should generate a new instanceId for each instance', () => {
-		const dumb1 = render( <DumpComponent /> );
-		const dumb2 = render( <DumpComponent /> );
-		// Unrendered element.
-		expect( dumb1.text() ).not.toBe( dumb2.text() );
+		render( <DumpComponent /> );
+		render( <DumpComponent /> );
+
+		const elements = screen.getAllByTestId( 'wrapper' );
+
+		expect( elements[ 0 ] ).not.toHaveTextContent(
+			elements[ 1 ].textContent
+		);
 	} );
 } );


### PR DESCRIPTION
## What?
We've recently started refactoring `enzyme` tests to `@testing-library/react`.

This PR refactors the `withInstanceId()` high-order component tests from `enzyme` to `@testing-library/react`.

## Why?
`@testing-library/react` provides a better way to write tests for accessible components that is closer to the way the user experiences them.

## How?
We're straightforwardly replacing `enzyme` tests with `@testing-library/react` ones, using `jest-dom` matchers and mocks to avoid testing unrelated implementation details. 

## Testing Instructions
Verify tests pass: `npm run test:unit packages/compose/src/higher-order/with-instance-id/test/index.js`
