### PR TITLE
Update: Show parent block as selected when there is content locking

### DIFF
--- a/packages/block-editor/src/components/list-view/block.js
+++ b/packages/block-editor/src/components/list-view/block.js
@@ -58,11 +58,31 @@ function ListViewBlock( {
 	const cellRef = useRef( null );
 	const [ isHovered, setIsHovered ] = useState( false );
 	const { clientId } = block;
+
+	const { isLocked, isContentLocked } = useBlockLock( clientId );
+	const forceSelectionContentLock = useSelect(
+		( select ) => {
+			if ( isSelected ) {
+				return false;
+			}
+			if ( ! isContentLocked ) {
+				return false;
+			}
+			return select( blockEditorStore ).hasSelectedInnerBlock(
+				clientId,
+				true
+			);
+		},
+		[ isContentLocked, clientId, isSelected ]
+	);
+
 	const isFirstSelectedBlock =
-		isSelected && selectedClientIds[ 0 ] === clientId;
+		forceSelectionContentLock ||
+		( isSelected && selectedClientIds[ 0 ] === clientId );
 	const isLastSelectedBlock =
-		isSelected &&
-		selectedClientIds[ selectedClientIds.length - 1 ] === clientId;
+		forceSelectionContentLock ||
+		( isSelected &&
+			selectedClientIds[ selectedClientIds.length - 1 ] === clientId );
 
 	const { toggleBlockHighlight } = useDispatch( blockEditorStore );
 
@@ -80,7 +100,6 @@ function ListViewBlock( {
 		'__experimentalToolbar',
 		true
 	);
-	const { isLocked, isContentLocked } = useBlockLock( clientId );
 	const instanceId = useInstanceId( ListViewBlock );
 	const descriptionId = `list-view-block-select-button__${ instanceId }`;
 	const blockPositionDescription = getBlockPositionDescription(
@@ -181,7 +200,7 @@ function ListViewBlock( {
 	}
 
 	const classes = classnames( {
-		'is-selected': isSelected,
+		'is-selected': isSelected || forceSelectionContentLock,
 		'is-first-selected': isFirstSelectedBlock,
 		'is-last-selected': isLastSelectedBlock,
 		'is-branch-selected': isBranchSelected,
@@ -211,14 +230,14 @@ function ListViewBlock( {
 			id={ `list-view-block-${ clientId }` }
 			data-block={ clientId }
 			isExpanded={ isContentLocked ? undefined : isExpanded }
-			aria-selected={ !! isSelected }
+			aria-selected={ !! isSelected || forceSelectionContentLock }
 		>
 			<TreeGridCell
 				className="block-editor-list-view-block__contents-cell"
 				colSpan={ colSpan }
 				ref={ cellRef }
 				aria-label={ blockAriaLabel }
-				aria-selected={ !! isSelected }
+				aria-selected={ !! isSelected || forceSelectionContentLock }
 				aria-expanded={ isContentLocked ? undefined : isExpanded }
 				aria-describedby={ descriptionId }
 			>
@@ -283,7 +302,7 @@ function ListViewBlock( {
 			{ showBlockActions && (
 				<TreeGridCell
 					className={ listViewBlockSettingsClassName }
-					aria-selected={ !! isSelected }
+					aria-selected={ !! isSelected || forceSelectionContentLock }
 				>
 					{ ( { ref, tabIndex, onFocus } ) => (
 						<BlockSettingsDropdown


### PR DESCRIPTION
Fix: https://github.com/WordPress/gutenberg/issues/43780
 This PR makes sure that when any block within a container is selected, the parent is also selected in List view.
