### PR TITLE
Fix: Non boolean usage on react output.

### DIFF
--- a/packages/block-editor/src/components/link-control/link-preview.js
+++ b/packages/block-editor/src/components/link-control/link-preview.js
@@ -123,9 +123,11 @@ export default function LinkPreview( {
 				<ViewerSlot fillProps={ value } />
 			</div>
 
-			{ ( ( hasRichData &&
-				( richData?.image || richData?.description ) ) ||
-				isFetching ) && (
+			{ !! (
+				( hasRichData &&
+					( richData?.image || richData?.description ) ) ||
+				isFetching
+			) && (
 				<div className="block-editor-link-control__search-item-bottom">
 					{ ( richData?.image || isFetching ) && (
 						<div


### PR DESCRIPTION
hasRichData is not boolean "richData && Object.keys( richData ).length;" so it may have a value of 0 and when equal to 0 (false) react will unexpectedly output 0 instead of nothing. This PR makes the condition a boolean to make sure we don't output anything when false.
