### PR TITLE
Fix: Inexistent parameter passed to parseUnitFunction.

### DIFF
--- a/packages/block-editor/src/utils/parse-css-unit-to-px.js
+++ b/packages/block-editor/src/utils/parse-css-unit-to-px.js
@@ -221,7 +221,7 @@ export function getPxFromCssUnit( cssUnit, options = {} ) {
 	let parsedUnit = parseUnit( cssUnit );
 
 	if ( ! parsedUnit.unit ) {
-		parsedUnit = parseUnitFunction( cssUnit, options );
+		parsedUnit = parseUnitFunction( cssUnit );
 	}
 
 	if ( isMathExpression( cssUnit ) && ! parsedUnit.unit ) {


### PR DESCRIPTION
The function parseUnitFunction does not receives an option parameter.
