### PR TITLE
Fixing broken layout styles for themes using theme.json settings on blocks that require layout styles

### DIFF
--- a/lib/compat/wordpress-6.1/class-wp-theme-json-6-1.php
+++ b/lib/compat/wordpress-6.1/class-wp-theme-json-6-1.php
@@ -1345,7 +1345,8 @@ class WP_Theme_JSON_6_1 extends WP_Theme_JSON_6_0 {
 				}
 			}
 
-			if ( null !== $block_gap_value ) {
+			// If the block should have custom gap, add the gap styles.
+			if ( null !== $block_gap_value && false !== $block_gap_value && '' !== $block_gap_value ) {
 				foreach ( $layout_definitions as $layout_definition_key => $layout_definition ) {
 					// Allow skipping default layout for themes that opt-in to block styles, but opt-out of blockGap.
 					if ( ! $has_block_gap_support && 'default' === $layout_definition_key ) {

--- a/lib/compat/wordpress-6.1/class-wp-theme-json-6-1.php
+++ b/lib/compat/wordpress-6.1/class-wp-theme-json-6-1.php
@@ -968,7 +968,7 @@ class WP_Theme_JSON_6_1 extends WP_Theme_JSON_6_0 {
 	 * @return string Style property value.
 	 */
 	protected static function get_property_value( $styles, $path, $theme_json = null ) {
-		$value = _wp_array_get( $styles, $path, '' );
+		$value = _wp_array_get( $styles, $path );
 
 		// This converts references to a path to the value at that path
 		// where the values is an array with a "ref" key, pointing to a path.
@@ -988,7 +988,7 @@ class WP_Theme_JSON_6_1 extends WP_Theme_JSON_6_0 {
 			}
 		}
 
-		if ( '' === $value || is_array( $value ) ) {
+		if ( is_array( $value ) ) {
 			return $value;
 		}
 

--- a/phpunit/class-wp-theme-json-test.php
+++ b/phpunit/class-wp-theme-json-test.php
@@ -45,6 +45,163 @@ class WP_Theme_JSON_Gutenberg_Test extends WP_UnitTestCase {
 	 *
 	 * @param array $layout_definitions Layout definitions as stored in core theme.json.
 	 */
+	public function test_get_stylesheet_generates_layout_styles_with_block_accepting_layout_settings( $layout_definitions ) {
+		$theme_json = new WP_Theme_JSON_Gutenberg(
+			array(
+				'version'  => WP_Theme_JSON_Gutenberg::LATEST_SCHEMA,
+				'settings' => array(
+					'layout'  => array(
+						'definitions' => $layout_definitions,
+					),
+					'spacing' => array(
+						'blockGap' => true,
+					),
+				),
+				'styles'   => array(
+					'spacing' => array(
+						'blockGap' => '1rem',
+					),
+					'blocks'=> array(
+						// This block accepts layout settings but the theme.json doesn't define them so they global layouts styles are used.
+						'core/post-content' => array( 
+							'color' => array(
+								'text' => 'gray', 
+							),
+						),
+					),
+				),
+			),
+			'default'
+		);
+
+		$this->assertEquals(
+			'body { margin: 0;}.wp-site-blocks > .alignleft { float: left; margin-right: 2em; }.wp-site-blocks > .alignright { float: right; margin-left: 2em; }.wp-site-blocks > .aligncenter { justify-content: center; margin-left: auto; margin-right: auto; }.wp-site-blocks > * { margin-block-start: 0; margin-block-end: 0; }.wp-site-blocks > * + * { margin-block-start: 1rem; }body { --wp--style--block-gap: 1rem; }body .is-layout-flow > *{margin-block-start: 0;margin-block-end: 0;}body .is-layout-flow > * + *{margin-block-start: 1rem;margin-block-end: 0;}body .is-layout-flex{gap: 1rem;}body .is-layout-flow > .alignleft{float: left;margin-inline-start: 0;margin-inline-end: 2em;}body .is-layout-flow > .alignright{float: right;margin-inline-start: 2em;margin-inline-end: 0;}body .is-layout-flow > .aligncenter{margin-left: auto !important;margin-right: auto !important;}body .is-layout-flex{display: flex;}body .is-layout-flex{flex-wrap: wrap;align-items: center;}.wp-block-post-content{color: gray;}',
+			$theme_json->get_stylesheet()
+		);
+	}
+
+	/**
+	 * @dataProvider data_get_layout_definitions
+	 *
+	 * @param array $layout_definitions Layout definitions as stored in core theme.json.
+	 */
+	public function test_get_stylesheet_generates_layout_styles_with_block_accepting_layout_settings_zero_string( $layout_definitions ) {
+		$theme_json = new WP_Theme_JSON_Gutenberg(
+			array(
+				'version'  => WP_Theme_JSON_Gutenberg::LATEST_SCHEMA,
+				'settings' => array(
+					'layout'  => array(
+						'definitions' => $layout_definitions,
+					),
+					'spacing' => array(
+						'blockGap' => true,
+					),
+				),
+				'styles'   => array(
+					'spacing' => array(
+						'blockGap' => '1rem',
+					),
+					'blocks'=> array(
+						'core/post-content' => array(
+							'spacing' => array(
+								'blockGap' => '0', // '0' should not be ignored or defaulted to '1rem'.
+							),
+						),
+					),
+				),
+			),
+			'default'
+		);
+
+		$this->assertEquals(
+			'body { margin: 0;}.wp-site-blocks > .alignleft { float: left; margin-right: 2em; }.wp-site-blocks > .alignright { float: right; margin-left: 2em; }.wp-site-blocks > .aligncenter { justify-content: center; margin-left: auto; margin-right: auto; }.wp-site-blocks > * { margin-block-start: 0; margin-block-end: 0; }.wp-site-blocks > * + * { margin-block-start: 1rem; }body { --wp--style--block-gap: 1rem; }body .is-layout-flow > *{margin-block-start: 0;margin-block-end: 0;}body .is-layout-flow > * + *{margin-block-start: 1rem;margin-block-end: 0;}body .is-layout-flex{gap: 1rem;}body .is-layout-flow > .alignleft{float: left;margin-inline-start: 0;margin-inline-end: 2em;}body .is-layout-flow > .alignright{float: right;margin-inline-start: 2em;margin-inline-end: 0;}body .is-layout-flow > .aligncenter{margin-left: auto !important;margin-right: auto !important;}body .is-layout-flex{display: flex;}body .is-layout-flex{flex-wrap: wrap;align-items: center;}.wp-block-post-content.is-layout-flow > *{margin-block-start: 0;margin-block-end: 0;}.wp-block-post-content.is-layout-flow > * + *{margin-block-start: 0;margin-block-end: 0;}.wp-block-post-content.is-layout-flex{gap: 0;}',
+			$theme_json->get_stylesheet()
+		);
+	}
+
+	/**
+	 * @dataProvider data_get_layout_definitions
+	 *
+	 * @param array $layout_definitions Layout definitions as stored in core theme.json.
+	 */
+	public function test_get_stylesheet_generates_layout_styles_with_block_accepting_layout_settings_zero_int( $layout_definitions ) {
+		$theme_json = new WP_Theme_JSON_Gutenberg(
+			array(
+				'version'  => WP_Theme_JSON_Gutenberg::LATEST_SCHEMA,
+				'settings' => array(
+					'layout'  => array(
+						'definitions' => $layout_definitions,
+					),
+					'spacing' => array(
+						'blockGap' => true,
+					),
+				),
+				'styles'   => array(
+					'spacing' => array(
+						'blockGap' => '1rem',
+					),
+					'blocks'=> array(
+						'core/post-content' => array(
+							'spacing' => array(
+								'blockGap' => 0, // 0 should not be ignored or defaulted to '1rem'.
+							),
+						),
+					),
+				),
+			),
+			'default'
+		);
+
+		$this->assertEquals(
+			'body { margin: 0;}.wp-site-blocks > .alignleft { float: left; margin-right: 2em; }.wp-site-blocks > .alignright { float: right; margin-left: 2em; }.wp-site-blocks > .aligncenter { justify-content: center; margin-left: auto; margin-right: auto; }.wp-site-blocks > * { margin-block-start: 0; margin-block-end: 0; }.wp-site-blocks > * + * { margin-block-start: 1rem; }body { --wp--style--block-gap: 1rem; }body .is-layout-flow > *{margin-block-start: 0;margin-block-end: 0;}body .is-layout-flow > * + *{margin-block-start: 1rem;margin-block-end: 0;}body .is-layout-flex{gap: 1rem;}body .is-layout-flow > .alignleft{float: left;margin-inline-start: 0;margin-inline-end: 2em;}body .is-layout-flow > .alignright{float: right;margin-inline-start: 2em;margin-inline-end: 0;}body .is-layout-flow > .aligncenter{margin-left: auto !important;margin-right: auto !important;}body .is-layout-flex{display: flex;}body .is-layout-flex{flex-wrap: wrap;align-items: center;}.wp-block-post-content.is-layout-flow > *{margin-block-start: 0;margin-block-end: 0;}.wp-block-post-content.is-layout-flow > * + *{margin-block-start: 0;margin-block-end: 0;}.wp-block-post-content.is-layout-flex{gap: 0;}',
+			$theme_json->get_stylesheet()
+		);
+	}
+
+	/**
+	 * @dataProvider data_get_layout_definitions
+	 *
+	 * @param array $layout_definitions Layout definitions as stored in core theme.json.
+	 */
+	public function test_get_stylesheet_generates_layout_styles_with_block_accepting_layout_settings_false( $layout_definitions ) {
+		$theme_json = new WP_Theme_JSON_Gutenberg(
+			array(
+				'version'  => WP_Theme_JSON_Gutenberg::LATEST_SCHEMA,
+				'settings' => array(
+					'layout'  => array(
+						'definitions' => $layout_definitions,
+					),
+					'spacing' => array(
+						'blockGap' => true,
+					),
+				),
+				'styles'   => array(
+					'spacing' => array(
+						'blockGap' => '1rem',
+					),
+					'blocks'=> array(
+						'core/post-content' => array(
+							'spacing' => array(
+								'blockGap' => false, // '0' should be ignored and defaulted to the global gap ('1rem').
+							),
+						),
+					),
+				),
+			),
+			'default'
+		);
+
+		$this->assertEquals(
+			'body { margin: 0;}.wp-site-blocks > .alignleft { float: left; margin-right: 2em; }.wp-site-blocks > .alignright { float: right; margin-left: 2em; }.wp-site-blocks > .aligncenter { justify-content: center; margin-left: auto; margin-right: auto; }.wp-site-blocks > * { margin-block-start: 0; margin-block-end: 0; }.wp-site-blocks > * + * { margin-block-start: 1rem; }body { --wp--style--block-gap: 1rem; }body .is-layout-flow > *{margin-block-start: 0;margin-block-end: 0;}body .is-layout-flow > * + *{margin-block-start: 1rem;margin-block-end: 0;}body .is-layout-flex{gap: 1rem;}body .is-layout-flow > .alignleft{float: left;margin-inline-start: 0;margin-inline-end: 2em;}body .is-layout-flow > .alignright{float: right;margin-inline-start: 2em;margin-inline-end: 0;}body .is-layout-flow > .aligncenter{margin-left: auto !important;margin-right: auto !important;}body .is-layout-flex{display: flex;}body .is-layout-flex{flex-wrap: wrap;align-items: center;}.wp-block-post-content.is-layout-flow > *{margin-block-start: 0;margin-block-end: 0;}.wp-block-post-content.is-layout-flow > * + *{margin-block-start: 0;margin-block-end: 0;}.wp-block-post-content.is-layout-flex{gap: 0;}',
+			$theme_json->get_stylesheet()
+		);
+	}
+
+	/**
+	 * @dataProvider data_get_layout_definitions
+	 *
+	 * @param array $layout_definitions Layout definitions as stored in core theme.json.
+	 */
 	public function test_get_stylesheet_generates_layout_styles_with_spacing_presets( $layout_definitions ) {
 		$theme_json = new WP_Theme_JSON_Gutenberg(
 			array(

--- a/phpunit/class-wp-theme-json-test.php
+++ b/phpunit/class-wp-theme-json-test.php
@@ -182,7 +182,7 @@ class WP_Theme_JSON_Gutenberg_Test extends WP_UnitTestCase {
 					'blocks'=> array(
 						'core/post-content' => array(
 							'spacing' => array(
-								'blockGap' => false, // '0' should be ignored and defaulted to the global gap ('1rem').
+								'blockGap' => false, // false should be ignored and defaulted to the global gap ('1rem').
 							),
 						),
 					),
@@ -192,7 +192,7 @@ class WP_Theme_JSON_Gutenberg_Test extends WP_UnitTestCase {
 		);
 
 		$this->assertEquals(
-			'body { margin: 0;}.wp-site-blocks > .alignleft { float: left; margin-right: 2em; }.wp-site-blocks > .alignright { float: right; margin-left: 2em; }.wp-site-blocks > .aligncenter { justify-content: center; margin-left: auto; margin-right: auto; }.wp-site-blocks > * { margin-block-start: 0; margin-block-end: 0; }.wp-site-blocks > * + * { margin-block-start: 1rem; }body { --wp--style--block-gap: 1rem; }body .is-layout-flow > *{margin-block-start: 0;margin-block-end: 0;}body .is-layout-flow > * + *{margin-block-start: 1rem;margin-block-end: 0;}body .is-layout-flex{gap: 1rem;}body .is-layout-flow > .alignleft{float: left;margin-inline-start: 0;margin-inline-end: 2em;}body .is-layout-flow > .alignright{float: right;margin-inline-start: 2em;margin-inline-end: 0;}body .is-layout-flow > .aligncenter{margin-left: auto !important;margin-right: auto !important;}body .is-layout-flex{display: flex;}body .is-layout-flex{flex-wrap: wrap;align-items: center;}.wp-block-post-content.is-layout-flow > *{margin-block-start: 0;margin-block-end: 0;}.wp-block-post-content.is-layout-flow > * + *{margin-block-start: 0;margin-block-end: 0;}.wp-block-post-content.is-layout-flex{gap: 0;}',
+			'body { margin: 0;}.wp-site-blocks > .alignleft { float: left; margin-right: 2em; }.wp-site-blocks > .alignright { float: right; margin-left: 2em; }.wp-site-blocks > .aligncenter { justify-content: center; margin-left: auto; margin-right: auto; }.wp-site-blocks > * { margin-block-start: 0; margin-block-end: 0; }.wp-site-blocks > * + * { margin-block-start: 1rem; }body { --wp--style--block-gap: 1rem; }body .is-layout-flow > *{margin-block-start: 0;margin-block-end: 0;}body .is-layout-flow > * + *{margin-block-start: 1rem;margin-block-end: 0;}body .is-layout-flex{gap: 1rem;}body .is-layout-flow > .alignleft{float: left;margin-inline-start: 0;margin-inline-end: 2em;}body .is-layout-flow > .alignright{float: right;margin-inline-start: 2em;margin-inline-end: 0;}body .is-layout-flow > .aligncenter{margin-left: auto !important;margin-right: auto !important;}body .is-layout-flex{display: flex;}body .is-layout-flex{flex-wrap: wrap;align-items: center;}',
 			$theme_json->get_stylesheet()
 		);
 	}

--- a/phpunit/class-wp-theme-json-test.php
+++ b/phpunit/class-wp-theme-json-test.php
@@ -45,7 +45,7 @@ class WP_Theme_JSON_Gutenberg_Test extends WP_UnitTestCase {
 	 *
 	 * @param array $layout_definitions Layout definitions as stored in core theme.json.
 	 */
-	public function test_get_stylesheet_generates_layout_styles_with_block_accepting_layout_settings( $layout_definitions ) {
+	public function test_get_stylesheet_generates_valid_block_gap_values_and_skips_null_or_false_values( $layout_definitions ) {
 		$theme_json = new WP_Theme_JSON_Gutenberg(
 			array(
 				'version'  => WP_Theme_JSON_Gutenberg::LATEST_SCHEMA,
@@ -61,128 +61,25 @@ class WP_Theme_JSON_Gutenberg_Test extends WP_UnitTestCase {
 					'spacing' => array(
 						'blockGap' => '1rem',
 					),
-					'blocks'=> array(
-						// This block accepts layout settings but the theme.json doesn't define them so they global layouts styles are used.
-						'core/post-content' => array( 
+					'blocks'  => array(
+						'core/post-content' => array(
 							'color' => array(
-								'text' => 'gray', 
+								'text' => 'gray', // This value should not render block layout styles.
 							),
 						),
-					),
-				),
-			),
-			'default'
-		);
-
-		$this->assertEquals(
-			'body { margin: 0;}.wp-site-blocks > .alignleft { float: left; margin-right: 2em; }.wp-site-blocks > .alignright { float: right; margin-left: 2em; }.wp-site-blocks > .aligncenter { justify-content: center; margin-left: auto; margin-right: auto; }.wp-site-blocks > * { margin-block-start: 0; margin-block-end: 0; }.wp-site-blocks > * + * { margin-block-start: 1rem; }body { --wp--style--block-gap: 1rem; }body .is-layout-flow > *{margin-block-start: 0;margin-block-end: 0;}body .is-layout-flow > * + *{margin-block-start: 1rem;margin-block-end: 0;}body .is-layout-flex{gap: 1rem;}body .is-layout-flow > .alignleft{float: left;margin-inline-start: 0;margin-inline-end: 2em;}body .is-layout-flow > .alignright{float: right;margin-inline-start: 2em;margin-inline-end: 0;}body .is-layout-flow > .aligncenter{margin-left: auto !important;margin-right: auto !important;}body .is-layout-flex{display: flex;}body .is-layout-flex{flex-wrap: wrap;align-items: center;}.wp-block-post-content{color: gray;}',
-			$theme_json->get_stylesheet()
-		);
-	}
-
-	/**
-	 * @dataProvider data_get_layout_definitions
-	 *
-	 * @param array $layout_definitions Layout definitions as stored in core theme.json.
-	 */
-	public function test_get_stylesheet_generates_layout_styles_with_block_accepting_layout_settings_zero_string( $layout_definitions ) {
-		$theme_json = new WP_Theme_JSON_Gutenberg(
-			array(
-				'version'  => WP_Theme_JSON_Gutenberg::LATEST_SCHEMA,
-				'settings' => array(
-					'layout'  => array(
-						'definitions' => $layout_definitions,
-					),
-					'spacing' => array(
-						'blockGap' => true,
-					),
-				),
-				'styles'   => array(
-					'spacing' => array(
-						'blockGap' => '1rem',
-					),
-					'blocks'=> array(
-						'core/post-content' => array(
+						'core/social-links' => array(
 							'spacing' => array(
-								'blockGap' => '0', // '0' should not be ignored or defaulted to '1rem'.
+								'blockGap' => '0', // This value should render block layout gap as zero.
 							),
 						),
-					),
-				),
-			),
-			'default'
-		);
-
-		$this->assertEquals(
-			'body { margin: 0;}.wp-site-blocks > .alignleft { float: left; margin-right: 2em; }.wp-site-blocks > .alignright { float: right; margin-left: 2em; }.wp-site-blocks > .aligncenter { justify-content: center; margin-left: auto; margin-right: auto; }.wp-site-blocks > * { margin-block-start: 0; margin-block-end: 0; }.wp-site-blocks > * + * { margin-block-start: 1rem; }body { --wp--style--block-gap: 1rem; }body .is-layout-flow > *{margin-block-start: 0;margin-block-end: 0;}body .is-layout-flow > * + *{margin-block-start: 1rem;margin-block-end: 0;}body .is-layout-flex{gap: 1rem;}body .is-layout-flow > .alignleft{float: left;margin-inline-start: 0;margin-inline-end: 2em;}body .is-layout-flow > .alignright{float: right;margin-inline-start: 2em;margin-inline-end: 0;}body .is-layout-flow > .aligncenter{margin-left: auto !important;margin-right: auto !important;}body .is-layout-flex{display: flex;}body .is-layout-flex{flex-wrap: wrap;align-items: center;}.wp-block-post-content.is-layout-flow > *{margin-block-start: 0;margin-block-end: 0;}.wp-block-post-content.is-layout-flow > * + *{margin-block-start: 0;margin-block-end: 0;}.wp-block-post-content.is-layout-flex{gap: 0;}',
-			$theme_json->get_stylesheet()
-		);
-	}
-
-	/**
-	 * @dataProvider data_get_layout_definitions
-	 *
-	 * @param array $layout_definitions Layout definitions as stored in core theme.json.
-	 */
-	public function test_get_stylesheet_generates_layout_styles_with_block_accepting_layout_settings_zero_int( $layout_definitions ) {
-		$theme_json = new WP_Theme_JSON_Gutenberg(
-			array(
-				'version'  => WP_Theme_JSON_Gutenberg::LATEST_SCHEMA,
-				'settings' => array(
-					'layout'  => array(
-						'definitions' => $layout_definitions,
-					),
-					'spacing' => array(
-						'blockGap' => true,
-					),
-				),
-				'styles'   => array(
-					'spacing' => array(
-						'blockGap' => '1rem',
-					),
-					'blocks'=> array(
-						'core/post-content' => array(
+						'core/buttons'      => array(
 							'spacing' => array(
-								'blockGap' => 0, // 0 should not be ignored or defaulted to '1rem'.
+								'blockGap' => 0, // This value should render block layout gap as zero.
 							),
 						),
-					),
-				),
-			),
-			'default'
-		);
-
-		$this->assertEquals(
-			'body { margin: 0;}.wp-site-blocks > .alignleft { float: left; margin-right: 2em; }.wp-site-blocks > .alignright { float: right; margin-left: 2em; }.wp-site-blocks > .aligncenter { justify-content: center; margin-left: auto; margin-right: auto; }.wp-site-blocks > * { margin-block-start: 0; margin-block-end: 0; }.wp-site-blocks > * + * { margin-block-start: 1rem; }body { --wp--style--block-gap: 1rem; }body .is-layout-flow > *{margin-block-start: 0;margin-block-end: 0;}body .is-layout-flow > * + *{margin-block-start: 1rem;margin-block-end: 0;}body .is-layout-flex{gap: 1rem;}body .is-layout-flow > .alignleft{float: left;margin-inline-start: 0;margin-inline-end: 2em;}body .is-layout-flow > .alignright{float: right;margin-inline-start: 2em;margin-inline-end: 0;}body .is-layout-flow > .aligncenter{margin-left: auto !important;margin-right: auto !important;}body .is-layout-flex{display: flex;}body .is-layout-flex{flex-wrap: wrap;align-items: center;}.wp-block-post-content.is-layout-flow > *{margin-block-start: 0;margin-block-end: 0;}.wp-block-post-content.is-layout-flow > * + *{margin-block-start: 0;margin-block-end: 0;}.wp-block-post-content.is-layout-flex{gap: 0;}',
-			$theme_json->get_stylesheet()
-		);
-	}
-
-	/**
-	 * @dataProvider data_get_layout_definitions
-	 *
-	 * @param array $layout_definitions Layout definitions as stored in core theme.json.
-	 */
-	public function test_get_stylesheet_generates_layout_styles_with_block_accepting_layout_settings_false( $layout_definitions ) {
-		$theme_json = new WP_Theme_JSON_Gutenberg(
-			array(
-				'version'  => WP_Theme_JSON_Gutenberg::LATEST_SCHEMA,
-				'settings' => array(
-					'layout'  => array(
-						'definitions' => $layout_definitions,
-					),
-					'spacing' => array(
-						'blockGap' => true,
-					),
-				),
-				'styles'   => array(
-					'spacing' => array(
-						'blockGap' => '1rem',
-					),
-					'blocks'=> array(
-						'core/post-content' => array(
+						'core/columns'      => array(
 							'spacing' => array(
-								'blockGap' => false, // false should be ignored and defaulted to the global gap ('1rem').
+								'blockGap' => false, // This value should be ignored. The block will use the global layout value.
 							),
 						),
 					),
@@ -192,7 +89,7 @@ class WP_Theme_JSON_Gutenberg_Test extends WP_UnitTestCase {
 		);
 
 		$this->assertEquals(
-			'body { margin: 0;}.wp-site-blocks > .alignleft { float: left; margin-right: 2em; }.wp-site-blocks > .alignright { float: right; margin-left: 2em; }.wp-site-blocks > .aligncenter { justify-content: center; margin-left: auto; margin-right: auto; }.wp-site-blocks > * { margin-block-start: 0; margin-block-end: 0; }.wp-site-blocks > * + * { margin-block-start: 1rem; }body { --wp--style--block-gap: 1rem; }body .is-layout-flow > *{margin-block-start: 0;margin-block-end: 0;}body .is-layout-flow > * + *{margin-block-start: 1rem;margin-block-end: 0;}body .is-layout-flex{gap: 1rem;}body .is-layout-flow > .alignleft{float: left;margin-inline-start: 0;margin-inline-end: 2em;}body .is-layout-flow > .alignright{float: right;margin-inline-start: 2em;margin-inline-end: 0;}body .is-layout-flow > .aligncenter{margin-left: auto !important;margin-right: auto !important;}body .is-layout-flex{display: flex;}body .is-layout-flex{flex-wrap: wrap;align-items: center;}',
+			'body { margin: 0;}.wp-site-blocks > .alignleft { float: left; margin-right: 2em; }.wp-site-blocks > .alignright { float: right; margin-left: 2em; }.wp-site-blocks > .aligncenter { justify-content: center; margin-left: auto; margin-right: auto; }.wp-site-blocks > * { margin-block-start: 0; margin-block-end: 0; }.wp-site-blocks > * + * { margin-block-start: 1rem; }body { --wp--style--block-gap: 1rem; }body .is-layout-flow > *{margin-block-start: 0;margin-block-end: 0;}body .is-layout-flow > * + *{margin-block-start: 1rem;margin-block-end: 0;}body .is-layout-flex{gap: 1rem;}body .is-layout-flow > .alignleft{float: left;margin-inline-start: 0;margin-inline-end: 2em;}body .is-layout-flow > .alignright{float: right;margin-inline-start: 2em;margin-inline-end: 0;}body .is-layout-flow > .aligncenter{margin-left: auto !important;margin-right: auto !important;}body .is-layout-flex{display: flex;}body .is-layout-flex{flex-wrap: wrap;align-items: center;}.wp-block-post-content{color: gray;}.wp-block-social-links.is-layout-flow > *{margin-block-start: 0;margin-block-end: 0;}.wp-block-social-links.is-layout-flow > * + *{margin-block-start: 0;margin-block-end: 0;}.wp-block-social-links.is-layout-flex{gap: 0;}.wp-block-buttons.is-layout-flow > *{margin-block-start: 0;margin-block-end: 0;}.wp-block-buttons.is-layout-flow > * + *{margin-block-start: 0;margin-block-end: 0;}.wp-block-buttons.is-layout-flex{gap: 0;}',
 			$theme_json->get_stylesheet()
 		);
 	}


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
The function `get_property_value`  from `WP_Theme_JSON_6_1` class returns an empty string instead of `NULL`  when a property is not set. So when we call this function to get the styles, of a block that needs layout settings, the block gap value is an empty string instead of null and that prevents that the value is fallback to the correct value.

Let's see a example:
When Gutenberg calls `get_property_value` to get the layout styles of the `core/post-content` block, with [`$block_gap_value = static::get_property_value( $node, array( 'spacing', 'blockGap' ) )`](https://github.com/WordPress/gutenberg/blob/a6548830648dd26f96871898e31a9d1040abcb50/lib/compat/wordpress-6.1/class-wp-theme-json-6-1.php#L1333), `$block_gap_value` value is an empty string instead of NULL.This is causing that, for example, the default layout block gap value is not properly set for `core/post-content` block, ending in invalid CSS being rendered. 



## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
Because returning an empty string is causing problems while rendering layout styles resulting in the rendering of invalid CSS. This problem is described in https://github.com/WordPress/gutenberg/issues/43924.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
This PR makes `NULL` the default result of `get_property_value()`.

If this looks like an acceptable solution for the problem probably I should add some PHP unit tests. 

## Testing Instructions
1. Activate any theme using settings for `core/post-content` in `theme.json` as [TT3](https://github.com/WordPress/twentytwentythree/blob/29150922040eb2b7e6aed00e3d1bb14459e41997/theme.json#L322-L330).
2. Add a few elements to a post, for example, a few paragraphs.
3. Save the post and navigate the frontend
4. Check that there is no invalid CSS rendered and that the block gap between post elements is there.


## Screenshots or screencast <!-- if applicable -->
| Before | After  |
| --- | --- |
| ![layout](https://user-images.githubusercontent.com/1310626/188730373-1ac90369-d8fa-48d1-b8f5-9e62b2d10073.png) | ![layout after](https://user-images.githubusercontent.com/1310626/188730868-d091daee-ce79-4ca5-a857-37966b06b44d.png) |

Fixes: https://github.com/WordPress/gutenberg/issues/43924