### PR TITLE
Fix PHP Tests: Try removing registry from WP_Block constructor calls

### DIFF
--- a/phpunit/blocks/render-block-navigation-test.php
+++ b/phpunit/blocks/render-block-navigation-test.php
@@ -21,7 +21,7 @@ class Render_Block_Navigation_Test extends WP_UnitTestCase {
 		);
 		$parsed_block  = $parsed_blocks[0];
 		$context       = array();
-		$block         = new WP_Block( $parsed_block, $context, $this->registry );
+		$block         = new WP_Block( $parsed_block, $context );
 
 		$post_ids = gutenberg_block_core_navigation_from_block_get_post_ids( $block );
 		$this->assertSameSets( array( 755 ), $post_ids );
@@ -46,7 +46,7 @@ class Render_Block_Navigation_Test extends WP_UnitTestCase {
 		);
 		$parsed_block  = $parsed_blocks[0];
 		$context       = array();
-		$block         = new WP_Block( $parsed_block, $context, $this->registry );
+		$block         = new WP_Block( $parsed_block, $context );
 
 		$post_ids = gutenberg_block_core_navigation_from_block_get_post_ids( $block );
 		$this->assertSameSets( array( 40, 60, 10, 20, 30 ), $post_ids );
@@ -59,7 +59,7 @@ class Render_Block_Navigation_Test extends WP_UnitTestCase {
 		$parsed_blocks = parse_blocks( '<!-- wp:navigation-submenu {"label":"Test","type":"post","id":789,"url":"http://localhost/blog/test-3","kind":"post-type","isTopLevelItem":true} -->\n<!-- wp:navigation-link {"label":"(no title)","type":"post","id":755,"url":"http://localhost/blog/755","kind":"post-type","isTopLevelLink":false} /-->\n<!-- /wp:navigation-submenu -->' );
 		$parsed_block  = $parsed_blocks[0];
 		$context       = array();
-		$block         = new WP_Block( $parsed_block, $context, $this->registry );
+		$block         = new WP_Block( $parsed_block, $context );
 
 		$post_ids = gutenberg_block_core_navigation_from_block_get_post_ids( $block );
 		$this->assertSameSetsWithIndex( array( 755, 789 ), $post_ids );

--- a/phpunit/blocks/render-comments-test.php
+++ b/phpunit/blocks/render-comments-test.php
@@ -38,7 +38,7 @@ class Tests_Blocks_RenderComments extends WP_UnitTestCase {
 		);
 		$parsed_block  = $parsed_blocks[0];
 		$context       = array( 'postId' => self::$post_with_comments_disabled->ID );
-		$block         = new WP_Block( $parsed_block, $context, $this->registry );
+		$block         = new WP_Block( $parsed_block, $context );
 
 		$rendered = gutenberg_render_block_core_comments( $attributes, '', $block );
 		$this->assertEmpty( $rendered );


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Try to fix the following errors by removing passing in a registry for these four tests:

```
There were 4 errors:

1) Render_Block_Navigation_Test::test_block_core_navigation_get_post_ids_from_block
Undefined property: Render_Block_Navigation_Test::$registry

/var/www/html/wp-content/plugins/gutenberg/phpunit/blocks/render-block-navigation-test.php:24
phpvfscomposer:///var/www/html/wp-content/plugins/gutenberg/vendor/phpunit/phpunit/phpunit:97

2) Render_Block_Navigation_Test::test_block_core_navigation_get_post_ids_from_block_nested
Undefined property: Render_Block_Navigation_Test::$registry

/var/www/html/wp-content/plugins/gutenberg/phpunit/blocks/render-block-navigation-test.php:[49](https://github.com/WordPress/gutenberg/runs/8218697872?check_suite_focus=true#step:8:50)
phpvfscomposer:///var/www/html/wp-content/plugins/gutenberg/vendor/phpunit/phpunit/phpunit:97

3) Render_Block_Navigation_Test::test_block_core_navigation_get_post_ids_from_block_with_submenu
Undefined property: Render_Block_Navigation_Test::$registry

/var/www/html/wp-content/plugins/gutenberg/phpunit/blocks/render-block-navigation-test.php:62
phpvfscomposer:///var/www/html/wp-content/plugins/gutenberg/vendor/phpunit/phpunit/phpunit:97

4) Tests_Blocks_RenderComments::test_render_block_core_comments_empty_output_if_comments_disabled
Undefined property: Tests_Blocks_RenderComments::$registry

/var/www/html/wp-content/plugins/gutenberg/phpunit/blocks/render-comments-test.php:41
phpvfscomposer:///var/www/html/wp-content/plugins/gutenberg/vendor/phpunit/phpunit/phpunit:97
```

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

Tests are currently failing on `trunk` and I'm not sure if we ever needed to pass in the registry for these tests 🤔

I suspect that something upstream means that the registry isn't available in these tests, however from a quick read of the tests, it doesn't look to me like they ever really needed a registry, since the tests are looking at rendered markup rather than testing anything about the registry in particular. But I very well could be missing something!

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

Remove `$this->registry` from the calls to the `WP_Block` constructor

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->

See if `Unit Tests / PHP (pull_request)` CI jobs pass

## Screenshots or screencast <!-- if applicable -->
