### PR TITLE
Typography block supports: sync with 6.1 backport

### DIFF
--- a/lib/block-supports/typography.php
+++ b/lib/block-supports/typography.php
@@ -168,16 +168,21 @@ function gutenberg_apply_typography_support( $block_type, $block_attributes ) {
 }
 
 /**
- * Note: this method is for backwards compatibility.
- * It mostly replaces `gutenberg_typography_get_css_variable_inline_style()`.
- *
  * Generates an inline style value for a typography feature e.g. text decoration,
  * text transform, and font style.
  *
- * @param string $style_value    A raw style value for a single typography feature from a block's style attribute.
- * @param string $css_property   Slug for the CSS property the inline style sets.
+ * Note: This function is for backwards compatibility.
+ * * It is necessary to parse older blocks whose typography styles contain presets.
+ * * It mostly replaces the deprecated `wp_typography_get_css_variable_inline_style()`,
+ *   but skips compiling a CSS declaration as the style engine takes over this role.
  *
- * @return string?             A CSS inline style value.
+ * @link https://github.com/wordpress/gutenberg/pull/27555
+ *
+ * @since 6.1.0
+ *
+ * @param string $style_value  A raw style value for a single typography feature from a block's style attribute.
+ * @param string $css_property Slug for the CSS property the inline style sets.
+ * @return string A CSS inline style value.
  */
 function gutenberg_typography_get_preset_inline_style_value( $style_value, $css_property ) {
 	// If the style value is not a preset CSS variable go no further.
@@ -185,10 +190,12 @@ function gutenberg_typography_get_preset_inline_style_value( $style_value, $css_
 		return $style_value;
 	}
 
-	// For backwards compatibility.
-	// Presets were removed in https://github.com/WordPress/gutenberg/pull/27555.
-	// We have a preset CSS variable as the style.
-	// Get the style value from the string and return CSS style.
+	/*
+	 * For backwards compatibility.
+	 * Presets were removed in WordPress/gutenberg#27555.
+	 * We have a preset CSS variable as the style.
+	 * Get the style value from the string and return CSS style.
+	 */
 	$index_to_splice = strrpos( $style_value, '|' ) + 1;
 	$slug            = _wp_to_kebab_case( substr( $style_value, $index_to_splice ) );
 
@@ -197,13 +204,15 @@ function gutenberg_typography_get_preset_inline_style_value( $style_value, $css_
 }
 
 /**
- * Deprecated.
- * This method is no longer used and will have to be deprecated in Core.
+ * This method is no longer used and has been deprecated in Core since 6.1.0.
  *
- * It can be deleted once migrated to the next WordPress version.
+ * It can be deleted once Gutenberg's minimum supported WordPress version is >= 6.1
  *
  * Generates an inline style for a typography feature e.g. text decoration,
  * text transform, and font style.
+ *
+ * @since 5.8.0
+ * @deprecated 6.1.0
  *
  * @param array  $attributes   Block's attributes.
  * @param string $feature      Key for the feature within the typography styles.


### PR DESCRIPTION
## What?
~Removing deprecated function and updating comments to sync with 6.1 Core backport PR https://github.com/WordPress/wordpress-develop/pull/3203~

 `wp_typography_get_css_variable_inline_style` was only deprecated in 6.1, and the Gutenberg plugin supports a [minimum of 6.0.](https://github.com/WordPress/gutenberg/pull/46102)

This PR now only updates the comments instead of removing the method.

## Why?

To make it clear in the comments that we can remove `gutenberg_typography_get_css_variable_inline_style` once the min supported version of WP in the plugin is 6.1. 😄 


