### PR TITLE
RichText: Check if the embed block can be inserted

### DIFF
--- a/packages/block-editor/src/components/rich-text/index.js
+++ b/packages/block-editor/src/components/rich-text/index.js
@@ -159,6 +159,18 @@ function RichTextWrapper(
 	// retreived from the store on merge.
 	// To do: fix this somehow.
 	const { selectionStart, selectionEnd, isSelected } = useSelect( selector );
+	const canInsertEmbed = useSelect(
+		( select ) => {
+			const { canInsertBlockType, getBlockRootClientId } =
+				select( blockEditorStore );
+
+			return canInsertBlockType(
+				'core/embed',
+				getBlockRootClientId( clientId )
+			);
+		},
+		[ clientId ]
+	);
 	const { selectionChange } = useDispatch( blockEditorStore );
 	const multilineTag = getMultilineTag( multiline );
 	const adjustedAllowedFormats = getAllowedFormats( {
@@ -393,7 +405,8 @@ function RichTextWrapper(
 						onReplace,
 						onSplit,
 						onSplitMiddle,
-						__unstableEmbedURLOnPaste,
+						__unstableEmbedURLOnPaste:
+							canInsertEmbed && __unstableEmbedURLOnPaste,
 						multilineTag,
 						preserveWhiteSpace,
 						pastePlainText,


### PR DESCRIPTION
## What?
Resolves #11245.
Resolves #27835.

PR fixes the embeddable link pasting issue for the `RichText` component with `__unstableEmbedURLOnPaste` enabled when the Embed block isn't allowed for the post type.

## Why?
The `__unstableEmbedURLOnPaste` setting wasn't considering if the embed block could be inserted.

## How?
Add a selector to check if the `embed` block type can be inserted. The `__unstableEmbedURLOnPaste` option for `usePasteHandler` hook now is derived based on both `canInsertEmbed && __unstableEmbedURLOnPaste` values.

## Testing Instructions
1. Open a Post or Page.
2. Disable embeds from Preferences > Blocks
3. Try pasting the embeddable link (YouTube, Vimeo, or Spotify) in an empty paragraph block.
4. The regular link should be pasted into the paragraph.

Alternatively, you can disable the block via filter:

```php
add_filter( 'allowed_block_types_all', function( $allowed_block_types, $context ) {
	if ( $context->post && $context->post->post_type === 'page' ) {
		return array(
			'core/paragraph',
			'core/heading',
			'core/list',
			'core/quote',
			'core/table'
		);
	}

	return $allowed_block_types;
}, 10, 2 );
```

## Screenshots or screencast <!-- if applicable -->


https://user-images.githubusercontent.com/240569/188798297-c19ae716-a393-4d0d-a602-df44fe4b1196.mp4


