### PR TITLE
Add comments for the repeated move commands in draggable e2e tests

### DIFF
--- a/test/e2e/specs/editor/various/draggable-blocks.spec.js
+++ b/test/e2e/specs/editor/various/draggable-blocks.spec.js
@@ -53,9 +53,14 @@ test.describe( 'Draggable block', () => {
 			'role=document[name="Paragraph block"i] >> text=1'
 		);
 		const firstParagraphBound = await firstParagraph.boundingBox();
-		await page.mouse.move( firstParagraphBound.x, firstParagraphBound.y, {
-			steps: 10,
-		} );
+		// Call the move function twice to make sure the `dragOver` event is sent.
+		// @see https://github.com/microsoft/playwright/issues/17153
+		for ( let i = 0; i < 2; i += 1 ) {
+			await page.mouse.move(
+				firstParagraphBound.x,
+				firstParagraphBound.y
+			);
+		}
 
 		await expect(
 			page.locator( 'data-testid=block-draggable-chip >> visible=true' )
@@ -118,11 +123,14 @@ test.describe( 'Draggable block', () => {
 			'role=document[name="Paragraph block"i] >> text=2'
 		);
 		const secondParagraphBound = await secondParagraph.boundingBox();
-		await page.mouse.move(
-			secondParagraphBound.x,
-			secondParagraphBound.y + secondParagraphBound.height * 0.75,
-			{ steps: 10 }
-		);
+		// Call the move function twice to make sure the `dragOver` event is sent.
+		// @see https://github.com/microsoft/playwright/issues/17153
+		for ( let i = 0; i < 2; i += 1 ) {
+			await page.mouse.move(
+				secondParagraphBound.x,
+				secondParagraphBound.y + secondParagraphBound.height * 0.75
+			);
+		}
 
 		await expect(
 			page.locator( 'data-testid=block-draggable-chip >> visible=true' )


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->
A follow-up to https://github.com/WordPress/gutenberg/pull/43798. Add some code comments for the weird `steps` in the `mouse` commands.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
Code quality.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
See https://github.com/microsoft/playwright/issues/17153 for more info.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->
CI should pass
