### PR TITLE
Buttons: Add typography supports to button/s blocks

### DIFF
--- a/docs/reference-guides/core-blocks.md
+++ b/docs/reference-guides/core-blocks.md
@@ -50,7 +50,7 @@ Prompt visitors to take action with a button-style link. ([Source](https://githu
 
 -	**Name:** core/button
 -	**Category:** design
--	**Supports:** align, anchor, color (background, gradients, text), spacing (padding), typography (fontSize), ~~alignWide~~, ~~reusable~~
+-	**Supports:** align, anchor, color (background, gradients, text), spacing (padding), typography (fontSize, lineHeight), ~~alignWide~~, ~~reusable~~
 -	**Attributes:** backgroundColor, gradient, linkTarget, placeholder, rel, text, textColor, title, url, width
 
 ## Buttons
@@ -59,7 +59,7 @@ Prompt visitors to take action with a group of button-style links. ([Source](htt
 
 -	**Name:** core/buttons
 -	**Category:** design
--	**Supports:** align (full, wide), anchor, spacing (blockGap, margin)
+-	**Supports:** align (full, wide), anchor, spacing (blockGap, margin), typography (fontSize, lineHeight)
 -	**Attributes:** 
 
 ## Calendar

--- a/packages/block-library/src/button/block.json
+++ b/packages/block-library/src/button/block.json
@@ -68,8 +68,13 @@
 		},
 		"typography": {
 			"fontSize": true,
+			"lineHeight": true,
 			"__experimentalFontFamily": true,
+			"__experimentalFontWeight": true,
+			"__experimentalFontStyle": true,
 			"__experimentalTextTransform": true,
+			"__experimentalTextDecoration": true,
+			"__experimentalLetterSpacing": true,
 			"__experimentalDefaultControls": {
 				"fontSize": true
 			}

--- a/packages/block-library/src/button/editor.scss
+++ b/packages/block-library/src/button/editor.scss
@@ -75,3 +75,7 @@
 div[data-type="core/button"] {
 	display: table;
 }
+
+.editor-styles-wrapper .wp-block-button[style*="text-decoration"] .wp-block-button__link {
+	text-decoration: inherit;
+}

--- a/packages/block-library/src/button/style.scss
+++ b/packages/block-library/src/button/style.scss
@@ -34,6 +34,10 @@ $blocks-block__margin: 0.5em;
 	padding: calc(0.667em + 2px) calc(1.333em + 2px);
 }
 
+.wp-block-button[style*="text-decoration"] .wp-block-button__link {
+	text-decoration: inherit;
+}
+
 // Increased specificity needed to override margins.
 .wp-block-buttons > .wp-block-button {
 	&.has-custom-width {

--- a/packages/block-library/src/buttons/block.json
+++ b/packages/block-library/src/buttons/block.json
@@ -18,6 +18,19 @@
 				"blockGap": true
 			}
 		},
+		"typography": {
+			"fontSize": true,
+			"lineHeight": true,
+			"__experimentalFontFamily": true,
+			"__experimentalFontWeight": true,
+			"__experimentalFontStyle": true,
+			"__experimentalTextTransform": true,
+			"__experimentalTextDecoration": true,
+			"__experimentalLetterSpacing": true,
+			"__experimentalDefaultControls": {
+				"fontSize": true
+			}
+		},
 		"__experimentalLayout": {
 			"allowSwitching": false,
 			"allowInheriting": false,

--- a/packages/block-library/src/buttons/edit.js
+++ b/packages/block-library/src/buttons/edit.js
@@ -1,4 +1,9 @@
 /**
+ * External dependencies
+ */
+import classnames from 'classnames';
+
+/**
  * WordPress dependencies
  */
 import {
@@ -30,8 +35,13 @@ const DEFAULT_BLOCK = {
 	],
 };
 
-function ButtonsEdit( { attributes: { layout = {} } } ) {
-	const blockProps = useBlockProps();
+function ButtonsEdit( { attributes, className } ) {
+	const { fontSize, layout = {}, style } = attributes;
+	const blockProps = useBlockProps( {
+		className: classnames( className, {
+			'has-custom-font-size': fontSize || style?.typography?.fontSize,
+		} ),
+	} );
 	const preferredStyle = useSelect( ( select ) => {
 		const preferredStyleVariations =
 			select( blockEditorStore ).getSettings()

--- a/packages/block-library/src/buttons/editor.scss
+++ b/packages/block-library/src/buttons/editor.scss
@@ -54,6 +54,12 @@ $blocks-block__margin: 0.5em;
 			margin-bottom: 0;
 		}
 	}
+
+	.editor-styles-wrapper &.has-custom-font-size {
+		.wp-block-button__link {
+			font-size: inherit;
+		}
+	}
 }
 
 .wp-block[data-align="center"] > .wp-block-buttons {

--- a/packages/block-library/src/buttons/save.js
+++ b/packages/block-library/src/buttons/save.js
@@ -1,9 +1,20 @@
 /**
+ * External dependencies
+ */
+import classnames from 'classnames';
+
+/**
  * WordPress dependencies
  */
 import { useBlockProps, useInnerBlocksProps } from '@wordpress/block-editor';
 
-export default function save() {
-	const innerBlocksProps = useInnerBlocksProps.save( useBlockProps.save() );
+export default function save( { attributes, className } ) {
+	const { fontSize, style } = attributes;
+	const blockProps = useBlockProps.save( {
+		className: classnames( className, {
+			'has-custom-font-size': fontSize || style?.typography?.fontSize,
+		} ),
+	} );
+	const innerBlocksProps = useInnerBlocksProps.save( blockProps );
 	return <div { ...innerBlocksProps } />;
 }

--- a/packages/block-library/src/buttons/style.scss
+++ b/packages/block-library/src/buttons/style.scss
@@ -69,6 +69,19 @@ $blocks-block__margin: 0.5em;
 		margin-right: auto;
 		width: 100%;
 	}
+
+	&[style*="text-decoration"] {
+		.wp-block-button,
+		.wp-block-button__link {
+			text-decoration: inherit;
+		}
+	}
+
+	&.has-custom-font-size {
+		.wp-block-button__link {
+			font-size: inherit;
+		}
+	}
 }
 
 // Legacy buttons that did not come in a wrapping container.


### PR DESCRIPTION
Related:
- https://github.com/WordPress/gutenberg/issues/43242
- https://github.com/WordPress/gutenberg/pull/43649
- https://github.com/WordPress/gutenberg/pull/41435

## What?

- Opts into all typography supports for the `Buttons` block
- Opts into missing typography supports for the `Button` block

**_Note: This PR is very similar to [#43649](https://github.com/WordPress/gutenberg/pull/43649) & [#41435](https://github.com/WordPress/gutenberg/pull/41435) but combines the changes for both blocks to facilitate easier testing and ensuring the two "opt-ins" play nice together._**

## Why?

- Opting into typography support for the `Buttons` block allows styles to be set once for for all buttons in a given group
- Helps improve consistency across our design tools (See [#43242](https://github.com/WordPress/gutenberg/issues/43242) for more info)

## How?

- Opts into all typography supports for `Buttons` block
- Opts into missing typography supports for `Button` block
- Adds a custom CSS class name to the `Buttons` block if a font size is selected. This allows such blocks to apply styles to the inner button link to inherit font size.
- Adds additional styles to detect when a `Button` or `Buttons` block has text-decoration applied and style the inner button links to inherit that style.

## Testing Instructions
1. Add a `Buttons` block to a post and select it
2. Within the typography panel of the inspector controls sidebar, toggle on all typography controls
3. Experiment with various typography settings and ensure they are reflected on the buttons within the editor
4. Save the post and confirm the styles are present on the frontend
5. Back in the editor, select an individual `Button` block and repeat the same process as with its parent block.
6. The individual button's styles should override those you set on the parent `Buttons` block in both the editor and front end.
7. Test theme.json and global styles styling of `Button` blocks continues to work.
8. In the interests of thoroughness, style the `Buttons` block via theme.json together with styles for the `Button` block and ensure that the `Button` block styles take precedence.

Example: Theme.json snippet. (
```json
			"core/buttons": {
				"typography": {
					"lineHeight": "2em",
					"letterSpacing": "2px",
					"textTransform": "uppercase",
					"fontWeight": "300",
					"fontStyle": "italic"
				}
			},
```

**Note: Given the `Button` block's styles these might override theme.json/global styles generated for the `Buttons` block (e.g. text-decoration). I think this is ok for now and shouldn't block this PR given styling `Button` blocks globally is essentially the same as styling a `Buttons` block and having that apply to the inner `Button` blocks. A `Button` block can only be added within a `Buttons` block anyway.**

## Screenshots or screencast <!-- if applicable -->

https://user-images.githubusercontent.com/60436221/188804763-832a6c84-cde2-45d3-88fb-b00b825c08b9.mp4

