### PR TITLE
Archives: Add typography support

### DIFF
--- a/docs/reference-guides/core-blocks.md
+++ b/docs/reference-guides/core-blocks.md
@@ -14,7 +14,7 @@ Display a date archive of your posts. ([Source](https://github.com/WordPress/gut
 
 -	**Name:** core/archives
 -	**Category:** widgets
--	**Supports:** align, spacing (margin, padding), ~~html~~
+-	**Supports:** align, spacing (margin, padding), typography (fontSize, lineHeight), ~~html~~
 -	**Attributes:** displayAsDropdown, showLabel, showPostCounts, type
 
 ## Audio

--- a/packages/block-library/src/archives/block.json
+++ b/packages/block-library/src/archives/block.json
@@ -30,6 +30,19 @@
 		"spacing": {
 			"margin": true,
 			"padding": true
+		},
+		"typography": {
+			"fontSize": true,
+			"lineHeight": true,
+			"__experimentalFontFamily": true,
+			"__experimentalFontWeight": true,
+			"__experimentalFontStyle": true,
+			"__experimentalTextTransform": true,
+			"__experimentalTextDecoration": true,
+			"__experimentalLetterSpacing": true,
+			"__experimentalDefaultControls": {
+				"fontSize": true
+			}
 		}
 	},
 	"editorStyle": "wp-block-archives-editor"


### PR DESCRIPTION
Related:
- https://github.com/WordPress/gutenberg/issues/43241
- https://github.com/WordPress/gutenberg/issues/43242

## What?

Adds typography support to the Archives block.

## Why?

- Allows for typographic styling of Archives block links.
- Improves consistency of our design tools across blocks.

## How?

- Opts into all typography supports.
- Only the font size control will display by default.

## Testing Instructions

1. Edit a post, add an Archives block and select it.
2. The font size control should be displayed by default.
2. Test various typography settings ensuring styles are applied in the editor.
3. Save and confirm the application on the frontend.
4. Switch to the site editor, and select a page or template with an Archives block.
5. Navigate to Global Styles > Blocks > Archives > Typography and apply typography styles there.
6. Confirm the selected styles are reflected in the preview and on the frontend.

## Screenshots or screencast <!-- if applicable -->


https://user-images.githubusercontent.com/60436221/188813675-0c6bb897-8365-4ff9-96f7-33c7d57c6cbd.mp4

