### PR TITLE
Do not show tooltip of the block toolbar buttons when text label preference is enabled.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17309,6 +17309,7 @@
 				"@wordpress/keyboard-shortcuts": "file:packages/keyboard-shortcuts",
 				"@wordpress/keycodes": "file:packages/keycodes",
 				"@wordpress/notices": "file:packages/notices",
+				"@wordpress/preferences": "file:packages/preferences",
 				"@wordpress/rich-text": "file:packages/rich-text",
 				"@wordpress/shortcode": "file:packages/shortcode",
 				"@wordpress/style-engine": "file:packages/style-engine",

--- a/packages/block-editor/package.json
+++ b/packages/block-editor/package.json
@@ -54,6 +54,7 @@
 		"@wordpress/keyboard-shortcuts": "file:../keyboard-shortcuts",
 		"@wordpress/keycodes": "file:../keycodes",
 		"@wordpress/notices": "file:../notices",
+		"@wordpress/preferences": "file:../preferences",
 		"@wordpress/rich-text": "file:../rich-text",
 		"@wordpress/shortcode": "file:../shortcode",
 		"@wordpress/style-engine": "file:../style-engine",

--- a/packages/block-editor/src/components/block-switcher/index.js
+++ b/packages/block-editor/src/components/block-switcher/index.js
@@ -28,7 +28,11 @@ import BlockStylesMenu from './block-styles-menu';
 import PatternTransformationsMenu from './pattern-transformations-menu';
 import useBlockDisplayTitle from '../block-title/use-block-display-title';
 
-export const BlockSwitcherDropdownMenu = ( { clientIds, blocks } ) => {
+export const BlockSwitcherDropdownMenu = ( {
+	clientIds,
+	blocks,
+	showIconLabels,
+} ) => {
 	const { replaceBlocks, multiSelect } = useDispatch( blockEditorStore );
 	const blockInformation = useBlockDisplayInformation( blocks[ 0 ].clientId );
 	const {
@@ -192,6 +196,7 @@ export const BlockSwitcherDropdownMenu = ( { clientIds, blocks } ) => {
 						}
 						toggleProps={ {
 							describedBy: blockSwitcherDescription,
+							showTooltip: ! showIconLabels,
 							...toggleProps,
 						} }
 						menuProps={ { orientation: 'both' } }
@@ -242,7 +247,7 @@ export const BlockSwitcherDropdownMenu = ( { clientIds, blocks } ) => {
 	);
 };
 
-export const BlockSwitcher = ( { clientIds } ) => {
+export const BlockSwitcher = ( { clientIds, showIconLabels } ) => {
 	const blocks = useSelect(
 		( select ) =>
 			select( blockEditorStore ).getBlocksByClientId( clientIds ),
@@ -254,7 +259,11 @@ export const BlockSwitcher = ( { clientIds } ) => {
 	}
 
 	return (
-		<BlockSwitcherDropdownMenu clientIds={ clientIds } blocks={ blocks } />
+		<BlockSwitcherDropdownMenu
+			clientIds={ clientIds }
+			blocks={ blocks }
+			showIconLabels={ showIconLabels }
+		/>
 	);
 };
 

--- a/packages/block-editor/src/components/block-toolbar/index.js
+++ b/packages/block-editor/src/components/block-toolbar/index.js
@@ -16,6 +16,7 @@ import {
 	isTemplatePart,
 } from '@wordpress/blocks';
 import { ToolbarGroup } from '@wordpress/components';
+import { store as preferencesStore } from '@wordpress/preferences';
 
 /**
  * Internal dependencies
@@ -43,6 +44,7 @@ const BlockToolbar = ( { hideDragHandle } ) => {
 		isValid,
 		isVisual,
 		isContentLocked,
+		showIconLabels,
 	} = useSelect( ( select ) => {
 		const {
 			getBlockName,
@@ -75,6 +77,10 @@ const BlockToolbar = ( { hideDragHandle } ) => {
 			),
 			isContentLocked: !! __unstableGetContentLockingParent(
 				selectedBlockClientId
+			),
+			showIconLabels: select( preferencesStore ).get(
+				'core/edit-post',
+				'showIconLabels'
 			),
 		};
 	}, [] );
@@ -131,7 +137,10 @@ const BlockToolbar = ( { hideDragHandle } ) => {
 				{ ( shouldShowVisualToolbar || isMultiToolbar ) &&
 					! isContentLocked && (
 						<ToolbarGroup className="block-editor-block-toolbar__block-controls">
-							<BlockSwitcher clientIds={ blockClientIds } />
+							<BlockSwitcher
+								clientIds={ blockClientIds }
+								showIconLabels={ showIconLabels }
+							/>
 							{ ! isMultiToolbar && (
 								<BlockLockToolbar
 									clientId={ blockClientIds[ 0 ] }


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->
See https://github.com/WordPress/gutenberg/issues/42811

## What?
<!-- In a few words, what is the PR actually doing? -->
This PR is a Proof Of Concept to illustrate a potential approach to address https://github.com/WordPress/gutenberg/issues/42811

When the 'Show button text labels' preference is enabled, the block toolbar buttons show text instead of icons. However, they still display a tooltip (on hover and focus) that just repeats the visible text.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
A tooltip that just repeats the visible text of the buttons is pointless and just clutters the UI. When 'Show button text labels' is enabled, the tooltip should not show, as done for the Top toolbar in https://github.com/WordPress/gutenberg/issues/42676 / https://github.com/WordPress/gutenberg/pull/42815

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
For now, this PR shows a potential approach only for the 'block switcher' dropdown button, which is the first button within the block toolbar. 
- It retrieves the `showIconLabels` preference value from the `preferencesStore`.
- Passes down the `showIconLabels` as value to be used for the `showTooltip` prop.

Feedback on a couple things would be greatly appreciated. Also, any suggestions for a batter approach is very welcome. Problems I see with this approach:
- Is it OK to use the `preferencesStore` and add it to the `block-editor` package? I'm not sure that is desirable.
- With this approach, the `showTooltip` prop needs to be explicitly set on _all_ the buttons of the various components that are used within the block toolbar. This applies to both the post editor and the site editor. There's a lot (dozens?) of components that are used within the toolbar that would need to be changed. Is there any simpler, more generic, approach anyone can think of?


## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->
- Edit a post.
- Go to Options >  Preferences, and enable 'Show button text labels'.
- Select a block to make its toolbar appear.
- Hover (or move focus to) the Block switcher within the toolbar.
- Observe it does not show a tooltip.
- Observe all the other buttons within the toolbar still show a tooltip.
- Disable the 'Show button text labels' preference.
- Hover (or move focus to) the Block switcher again.
- Observe it does show a tooltip.

## Screenshots or screencast <!-- if applicable -->

<img width="765" alt="Screenshot 2022-09-07 at 09 45 53" src="https://user-images.githubusercontent.com/1682452/188820197-438b11f2-2fa1-427c-ab4d-e864d296382e.png">

