### PR TITLE
FontFamily: Fix server-side attribute registration via typography support

### DIFF
--- a/lib/block-supports/typography.php
+++ b/lib/block-supports/typography.php
@@ -53,6 +53,12 @@ function gutenberg_register_typography_support( $block_type ) {
 			'type' => 'string',
 		);
 	}
+
+	if ( $has_font_family_support && ! array_key_exists( 'fontFamily', $block_type->attributes ) ) {
+		$block_type->attributes['fontFamily'] = array(
+			'type' => 'string',
+		);
+	}
 }
 
 /**


### PR DESCRIPTION
Related:
- https://github.com/WordPress/gutenberg/issues/40461
- https://github.com/WordPress/gutenberg/pull/40468
- https://github.com/WordPress/gutenberg/pull/43935
- https://github.com/WordPress/gutenberg/pull/43452

## What?

Ensures the `fontFamily` attribute is registered for block types on the server side as well. This fixes a `400` error when attempting to change the font family for a server-side rendered block in the editor e.g. Archives, Tag Cloud etc.

## Why?

The attribute registration should be there in the server-side typography block supports as per `fontSize` etc. Fixing this error also unlocks typography support adoption for server-side rendered blocks.

## How?

Adds `fontFamily` to the block type's attributes when the block has font family support.

## Testing Instructions

1. Add typography support to a server-side rendered block e.g. Archives. (see block.json snippet below)
2. Within the editor, add the block you adopted typography support for e.g Archives
3. Within the inspector controls sidebar, switch to a new font
4. Note the 400 error in the dev tools console
5. Checkout this PR and repeat the process
6. The font family should successfully change without any error

```json
		"typography": {
			"__experimentalFontFamily": true
		}
```

## Screenshots or screencast <!-- if applicable -->

| Before | After |
|---|---|
| <video src="https://user-images.githubusercontent.com/60436221/188823964-5401aaef-b5f8-45d4-a8b3-face025c66cf.mp4"/> | <video src="https://user-images.githubusercontent.com/60436221/188824015-65800d62-36e4-4077-8d64-121d38d4884a.mp4" /> |

