### PR TITLE
Compose: Introduce an in-house `debounce()` utility, deprecate Lodash version

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -87,6 +87,7 @@ module.exports = {
 							'compact',
 							'concat',
 							'countBy',
+							'debounce',
 							'deburr',
 							'defaults',
 							'defaultTo',

--- a/package-lock.json
+++ b/package-lock.json
@@ -17632,7 +17632,8 @@
 			"version": "file:packages/preferences-persistence",
 			"requires": {
 				"@babel/runtime": "^7.16.0",
-				"@wordpress/api-fetch": "file:packages/api-fetch"
+				"@wordpress/api-fetch": "file:packages/api-fetch",
+				"@wordpress/compose": "file:packages/compose"
 			}
 		},
 		"@wordpress/prettier-config": {

--- a/packages/block-directory/src/plugins/inserter-menu-downloadable-blocks-panel/index.js
+++ b/packages/block-directory/src/plugins/inserter-menu-downloadable-blocks-panel/index.js
@@ -1,12 +1,8 @@
 /**
- * External dependencies
- */
-import { debounce } from 'lodash';
-
-/**
  * WordPress dependencies
  */
 import { __unstableInserterMenuExtension } from '@wordpress/block-editor';
+import { debounce } from '@wordpress/compose';
 import { useState } from '@wordpress/element';
 
 /**

--- a/packages/block-editor/src/components/block-styles/index.js
+++ b/packages/block-editor/src/components/block-styles/index.js
@@ -1,14 +1,13 @@
 /**
  * External dependencies
  */
-import { debounce } from 'lodash';
 import classnames from 'classnames';
 
 /**
  * WordPress dependencies
  */
 import { useState, useLayoutEffect } from '@wordpress/element';
-import { useViewportMatch } from '@wordpress/compose';
+import { debounce, useViewportMatch } from '@wordpress/compose';
 import {
 	Button,
 	__experimentalTruncate as Truncate,

--- a/packages/block-editor/src/components/link-control/test/index.js
+++ b/packages/block-editor/src/components/link-control/test/index.js
@@ -24,8 +24,7 @@ import {
 } from './fixtures';
 
 // Mock debounce() so that it runs instantly.
-jest.mock( 'lodash', () => ( {
-	...jest.requireActual( 'lodash' ),
+jest.mock( '@wordpress/compose/src/utils/debounce', () => ( {
 	debounce: ( fn ) => {
 		fn.cancel = jest.fn();
 		return fn;

--- a/packages/block-editor/src/components/url-input/index.js
+++ b/packages/block-editor/src/components/url-input/index.js
@@ -1,7 +1,6 @@
 /**
  * External dependencies
  */
-import { debounce } from 'lodash';
 import classnames from 'classnames';
 import scrollIntoView from 'dom-scroll-into-view';
 
@@ -18,7 +17,12 @@ import {
 	withSpokenMessages,
 	Popover,
 } from '@wordpress/components';
-import { withInstanceId, withSafeTimeout, compose } from '@wordpress/compose';
+import {
+	compose,
+	debounce,
+	withInstanceId,
+	withSafeTimeout,
+} from '@wordpress/compose';
 import { withSelect } from '@wordpress/data';
 import { isURL } from '@wordpress/url';
 

--- a/packages/block-library/src/buttons/edit.native.js
+++ b/packages/block-library/src/buttons/edit.native.js
@@ -1,7 +1,6 @@
 /**
  * External dependencies
  */
-import { debounce } from 'lodash';
 import { View } from 'react-native';
 
 /**
@@ -14,7 +13,7 @@ import {
 	store as blockEditorStore,
 } from '@wordpress/block-editor';
 import { createBlock, getBlockSupport } from '@wordpress/blocks';
-import { useResizeObserver } from '@wordpress/compose';
+import { debounce, useResizeObserver } from '@wordpress/compose';
 import { useDispatch, useSelect } from '@wordpress/data';
 import { useState, useEffect, useRef, useCallback } from '@wordpress/element';
 import { alignmentHelpers } from '@wordpress/components';

--- a/packages/block-library/src/embed/test/index.native.js
+++ b/packages/block-library/src/embed/test/index.native.js
@@ -39,8 +39,7 @@ jest.mock( 'react-native-modal', () => {
 } );
 
 // Mock debounce to prevent potentially belated state updates.
-jest.mock( 'lodash', () => ( {
-	...jest.requireActual( 'lodash' ),
+jest.mock( '@wordpress/compose/src/utils/debounce', () => ( {
 	debounce: ( fn ) => {
 		fn.cancel = jest.fn();
 		return fn;

--- a/packages/block-library/src/freeform/edit.js
+++ b/packages/block-library/src/freeform/edit.js
@@ -1,9 +1,4 @@
 /**
- * External dependencies
- */
-import { debounce } from 'lodash';
-
-/**
  * WordPress dependencies
  */
 import {
@@ -11,6 +6,7 @@ import {
 	useBlockProps,
 	store as blockEditorStore,
 } from '@wordpress/block-editor';
+import { debounce } from '@wordpress/compose';
 import { useSelect } from '@wordpress/data';
 import { ToolbarGroup } from '@wordpress/components';
 import { useEffect, useRef } from '@wordpress/element';

--- a/packages/block-library/src/query/edit/inspector-controls/index.js
+++ b/packages/block-library/src/query/edit/inspector-controls/index.js
@@ -1,9 +1,4 @@
 /**
- * External dependencies
- */
-import { debounce } from 'lodash';
-
-/**
  * WordPress dependencies
  */
 import {
@@ -18,6 +13,7 @@ import {
 } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 import { InspectorControls } from '@wordpress/block-editor';
+import { debounce } from '@wordpress/compose';
 import { useEffect, useState, useCallback } from '@wordpress/element';
 
 /**

--- a/packages/components/src/autocomplete/get-default-use-items.js
+++ b/packages/components/src/autocomplete/get-default-use-items.js
@@ -1,12 +1,12 @@
 /**
  * External dependencies
  */
-import { debounce } from 'lodash';
 import removeAccents from 'remove-accents';
 
 /**
  * WordPress dependencies
  */
+import { debounce } from '@wordpress/compose';
 import { useLayoutEffect, useState } from '@wordpress/element';
 
 /**

--- a/packages/components/src/higher-order/with-filters/index.js
+++ b/packages/components/src/higher-order/with-filters/index.js
@@ -1,14 +1,14 @@
 /**
  * External dependencies
  */
-import { debounce, without } from 'lodash';
+import { without } from 'lodash';
 
 /**
  * WordPress dependencies
  */
 import { Component } from '@wordpress/element';
 import { addAction, applyFilters, removeAction } from '@wordpress/hooks';
-import { createHigherOrderComponent } from '@wordpress/compose';
+import { createHigherOrderComponent, debounce } from '@wordpress/compose';
 
 const ANIMATION_FRAME_PERIOD = 16;
 

--- a/packages/components/src/mobile/bottom-sheet/bottom-sheet-navigation/navigation-screen.native.js
+++ b/packages/components/src/mobile/bottom-sheet/bottom-sheet-navigation/navigation-screen.native.js
@@ -7,13 +7,12 @@ import {
 	useFocusEffect,
 } from '@react-navigation/native';
 import { View, ScrollView, TouchableHighlight } from 'react-native';
-import { debounce } from 'lodash';
 
 /**
  * WordPress dependencies
  */
 import { BottomSheetContext } from '@wordpress/components';
-
+import { debounce } from '@wordpress/compose';
 import { useRef, useCallback, useContext, useMemo } from '@wordpress/element';
 
 /**

--- a/packages/components/src/mobile/link-picker/link-picker-results.native.js
+++ b/packages/components/src/mobile/link-picker/link-picker-results.native.js
@@ -2,12 +2,12 @@
  * External dependencies
  */
 import { ActivityIndicator, FlatList, View } from 'react-native';
-import { debounce } from 'lodash';
 
 /**
  * WordPress dependencies
  */
 import { BottomSheet, BottomSheetConsumer } from '@wordpress/components';
+import { debounce } from '@wordpress/compose';
 import { useState, useEffect, useRef } from '@wordpress/element';
 import { useSelect } from '@wordpress/data';
 

--- a/packages/compose/CHANGELOG.md
+++ b/packages/compose/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### New Features
 
+-   Compose: Introduce an in-house `debounce()` utility, deprecate Lodash version ([#43943](https://github.com/WordPress/gutenberg/pull/43943)).
 -   Compose: Introduce in-house `compose` and `pipe` utils ([#44112](https://github.com/WordPress/gutenberg/pull/44112)).
 
 ### Internal

--- a/packages/compose/README.md
+++ b/packages/compose/README.md
@@ -93,13 +93,12 @@ always uses timers instead of sometimes using rAF.
 
 Creates a debounced function that delays invoking `func` until after `wait`
 milliseconds have elapsed since the last time the debounced function was
-invoked, or until the next browser frame is drawn. The debounced function
-comes with a `cancel` method to cancel delayed `func` invocations and a
-`flush` method to immediately invoke them. Provide `options` to indicate
-whether `func` should be invoked on the leading and/or trailing edge of the
-`wait` timeout. The `func` is invoked with the last arguments provided to the
-debounced function. Subsequent calls to the debounced function return the
-result of the last `func` invocation.
+invoked. The debounced function comes with a `cancel` method to cancel delayed
+`func` invocations and a `flush` method to immediately invoke them. Provide
+`options` to indicate whether `func` should be invoked on the leading and/or
+trailing edge of the `wait` timeout. The `func` is invoked with the last
+arguments provided to the debounced function. Subsequent calls to the debounced
+function return the result of the last `func` invocation.
 
 **Note:** If `leading` and `trailing` options are `true`, `func` is
 invoked on the trailing edge of the timeout only if the debounced function

--- a/packages/compose/README.md
+++ b/packages/compose/README.md
@@ -86,6 +86,41 @@ _Returns_
 
 -   Component class with generated display name assigned.
 
+### debounce
+
+A simplified and properly typed version of lodash's `debounce`, that
+always uses timers instead of sometimes using rAF.
+
+Creates a debounced function that delays invoking `func` until after `wait`
+milliseconds have elapsed since the last time the debounced function was
+invoked, or until the next browser frame is drawn. The debounced function
+comes with a `cancel` method to cancel delayed `func` invocations and a
+`flush` method to immediately invoke them. Provide `options` to indicate
+whether `func` should be invoked on the leading and/or trailing edge of the
+`wait` timeout. The `func` is invoked with the last arguments provided to the
+debounced function. Subsequent calls to the debounced function return the
+result of the last `func` invocation.
+
+**Note:** If `leading` and `trailing` options are `true`, `func` is
+invoked on the trailing edge of the timeout only if the debounced function
+is invoked more than once during the `wait` timeout.
+
+If `wait` is `0` and `leading` is `false`, `func` invocation is deferred
+until the next tick, similar to `setTimeout` with a timeout of `0`.
+
+_Parameters_
+
+-   _func_ `Function`: The function to debounce.
+-   _wait_ `number`: The number of milliseconds to delay.
+-   _options_ `Partial< DebounceOptions >`: The options object.
+-   _options.leading_ `boolean`: Specify invoking on the leading edge of the timeout.
+-   _options.maxWait_ `number`: The maximum time `func` is allowed to be delayed before it's invoked.
+-   _options.trailing_ `boolean`: Specify invoking on the trailing edge of the timeout.
+
+_Returns_
+
+-   Returns the new debounced function.
+
 ### ifCondition
 
 Higher-order component creator, creating a new component which renders if
@@ -197,7 +232,7 @@ _Returns_
 
 ### useDebounce
 
-Debounces a function with Lodash's `debounce`. A new debounced function will
+Debounces a function similar to Lodash's `debounce`. A new debounced function will
 be returned and any scheduled calls cancelled if any of the arguments change,
 including the function to debounce, so please wrap functions created on
 render in components in `useCallback`.
@@ -210,11 +245,11 @@ _Parameters_
 
 -   _fn_ `TFunc`: The function to debounce.
 -   _wait_ `[number]`: The number of milliseconds to delay.
--   _options_ `[import('lodash').DebounceSettings]`: The options object.
+-   _options_ `[import('../../utils/debounce').DebounceOptions]`: The options object.
 
 _Returns_
 
--   `import('lodash').DebouncedFunc<TFunc>`: Debounced function.
+-   `import('../../utils/debounce').DebouncedFunc<TFunc>`: Debounced function.
 
 ### useDisabled
 

--- a/packages/compose/src/hooks/use-debounce/index.js
+++ b/packages/compose/src/hooks/use-debounce/index.js
@@ -1,7 +1,6 @@
 /**
  * External dependencies
  */
-import { debounce } from 'lodash';
 import { useMemoOne } from 'use-memo-one';
 
 /**
@@ -9,9 +8,13 @@ import { useMemoOne } from 'use-memo-one';
  */
 import { useEffect } from '@wordpress/element';
 
-/* eslint-disable jsdoc/valid-types */
 /**
- * Debounces a function with Lodash's `debounce`. A new debounced function will
+ * Internal dependencies
+ */
+import { debounce } from '../../utils/debounce';
+
+/**
+ * Debounces a function similar to Lodash's `debounce`. A new debounced function will
  * be returned and any scheduled calls cancelled if any of the arguments change,
  * including the function to debounce, so please wrap functions created on
  * render in components in `useCallback`.
@@ -20,15 +23,14 @@ import { useEffect } from '@wordpress/element';
  *
  * @template {(...args: any[]) => void} TFunc
  *
- * @param {TFunc}                             fn        The function to debounce.
- * @param {number}                            [wait]    The number of milliseconds to delay.
- * @param {import('lodash').DebounceSettings} [options] The options object.
- * @return {import('lodash').DebouncedFunc<TFunc>} Debounced function.
+ * @param {TFunc}                                          fn        The function to debounce.
+ * @param {number}                                         [wait]    The number of milliseconds to delay.
+ * @param {import('../../utils/debounce').DebounceOptions} [options] The options object.
+ * @return {import('../../utils/debounce').DebouncedFunc<TFunc>} Debounced function.
  */
 export default function useDebounce( fn, wait, options ) {
-	/* eslint-enable jsdoc/valid-types */
 	const debounced = useMemoOne(
-		() => debounce( fn, wait, options ),
+		() => debounce( fn, wait ?? 0, options ),
 		[ fn, wait, options ]
 	);
 	useEffect( () => () => debounced.cancel(), [ debounced ] );

--- a/packages/compose/src/hooks/use-disabled/index.js
+++ b/packages/compose/src/hooks/use-disabled/index.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { includes, debounce } from 'lodash';
+import { includes } from 'lodash';
 
 /**
  * WordPress dependencies
@@ -11,6 +11,7 @@ import { focus } from '@wordpress/dom';
 /**
  * Internal dependencies
  */
+import { debounce } from '../../utils/debounce';
 import useRefEffect from '../use-ref-effect';
 
 /**
@@ -176,7 +177,7 @@ export default function useDisabled( {
 
 			// Debounce re-disable since disabling process itself will incur
 			// additional mutations which should be ignored.
-			const debouncedDisable = debounce( disable, undefined, {
+			const debouncedDisable = debounce( disable, 0, {
 				leading: true,
 			} );
 			disable();

--- a/packages/compose/src/hooks/use-fixed-window-list/index.js
+++ b/packages/compose/src/hooks/use-fixed-window-list/index.js
@@ -1,14 +1,14 @@
 /**
- * External dependencies
- */
-import { debounce } from 'lodash';
-
-/**
  * WordPress dependencies
  */
 import { useState, useLayoutEffect } from '@wordpress/element';
 import { getScrollContainer } from '@wordpress/dom';
 import { PAGEUP, PAGEDOWN, HOME, END } from '@wordpress/keycodes';
+
+/**
+ * Internal dependencies
+ */
+import { debounce } from '../../utils/debounce';
 
 const DEFAULT_INIT_WINDOW_SIZE = 30;
 

--- a/packages/compose/src/index.js
+++ b/packages/compose/src/index.js
@@ -1,5 +1,7 @@
 // The `createHigherOrderComponent` helper and helper types.
 export * from './utils/create-higher-order-component';
+// The `debounce` helper and its types.
+export * from './utils/debounce';
 
 // The `compose` and `pipe` helpers (inspired by `flowRight` and `flow` from Lodash).
 export { default as compose } from './higher-order/compose';

--- a/packages/compose/src/index.native.js
+++ b/packages/compose/src/index.native.js
@@ -1,5 +1,7 @@
 // The `createHigherOrderComponent` helper and helper types.
 export * from './utils/create-higher-order-component';
+// The `debounce` helper and its types.
+export * from './utils/debounce';
 
 // The `compose` and `pipe` helpers (inspired by `flowRight` and `flow` from Lodash).
 export { default as compose } from './higher-order/compose';

--- a/packages/compose/src/utils/debounce/index.ts
+++ b/packages/compose/src/utils/debounce/index.ts
@@ -37,13 +37,12 @@ export interface DebouncedFunc< T extends ( ...args: any[] ) => any > {
  *
  * Creates a debounced function that delays invoking `func` until after `wait`
  * milliseconds have elapsed since the last time the debounced function was
- * invoked, or until the next browser frame is drawn. The debounced function
- * comes with a `cancel` method to cancel delayed `func` invocations and a
- * `flush` method to immediately invoke them. Provide `options` to indicate
- * whether `func` should be invoked on the leading and/or trailing edge of the
- * `wait` timeout. The `func` is invoked with the last arguments provided to the
- * debounced function. Subsequent calls to the debounced function return the
- * result of the last `func` invocation.
+ * invoked. The debounced function comes with a `cancel` method to cancel delayed
+ * `func` invocations and a `flush` method to immediately invoke them. Provide
+ * `options` to indicate whether `func` should be invoked on the leading and/or
+ * trailing edge of the `wait` timeout. The `func` is invoked with the last
+ * arguments provided to the debounced function. Subsequent calls to the debounced
+ * function return the result of the last `func` invocation.
  *
  * **Note:** If `leading` and `trailing` options are `true`, `func` is
  * invoked on the trailing edge of the timeout only if the debounced function

--- a/packages/compose/src/utils/debounce/index.ts
+++ b/packages/compose/src/utils/debounce/index.ts
@@ -1,3 +1,43 @@
+/**
+ * Parts of this source were derived and modified from lodash,
+ * released under the MIT license.
+ *
+ * https://github.com/lodash/lodash
+ *
+ * Copyright JS Foundation and other contributors <https://js.foundation/>
+ *
+ * Based on Underscore.js, copyright Jeremy Ashkenas,
+ * DocumentCloud and Investigative Reporters & Editors <http://underscorejs.org/>
+ *
+ * This software consists of voluntary contributions made by many
+ * individuals. For exact contribution history, see the revision history
+ * available at https://github.com/lodash/lodash
+ *
+ * The following license applies to all parts of this software except as
+ * documented below:
+ *
+ * ====
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining
+ * a copy of this software and associated documentation files (the
+ * "Software"), to deal in the Software without restriction, including
+ * without limitation the rights to use, copy, modify, merge, publish,
+ * distribute, sublicense, and/or sell copies of the Software, and to
+ * permit persons to whom the Software is furnished to do so, subject to
+ * the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+ * LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+ * OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+ * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
 export interface DebounceOptions {
 	leading: boolean;
 	maxWait: number;

--- a/packages/compose/src/utils/debounce/index.ts
+++ b/packages/compose/src/utils/debounce/index.ts
@@ -1,0 +1,221 @@
+export interface DebounceOptions {
+	leading: boolean;
+	maxWait: number;
+	trailing: boolean;
+}
+
+export interface DebouncedFunc< T extends ( ...args: any[] ) => any > {
+	/**
+	 * Call the original function, but applying the debounce rules.
+	 *
+	 * If the debounced function can be run immediately, this calls it and returns its return
+	 * value.
+	 *
+	 * Otherwise, it returns the return value of the last invocation, or undefined if the debounced
+	 * function was not invoked yet.
+	 */
+	( ...args: Parameters< T > ): ReturnType< T > | undefined;
+
+	/**
+	 * Throw away any pending invocation of the debounced function.
+	 */
+	cancel(): void;
+
+	/**
+	 * If there is a pending invocation of the debounced function, invoke it immediately and return
+	 * its return value.
+	 *
+	 * Otherwise, return the value from the last invocation, or undefined if the debounced function
+	 * was never invoked.
+	 */
+	flush(): ReturnType< T > | undefined;
+}
+
+/**
+ * A simplified and properly typed version of lodash's `debounce`, that
+ * always uses timers instead of sometimes using rAF.
+ *
+ * Creates a debounced function that delays invoking `func` until after `wait`
+ * milliseconds have elapsed since the last time the debounced function was
+ * invoked, or until the next browser frame is drawn. The debounced function
+ * comes with a `cancel` method to cancel delayed `func` invocations and a
+ * `flush` method to immediately invoke them. Provide `options` to indicate
+ * whether `func` should be invoked on the leading and/or trailing edge of the
+ * `wait` timeout. The `func` is invoked with the last arguments provided to the
+ * debounced function. Subsequent calls to the debounced function return the
+ * result of the last `func` invocation.
+ *
+ * **Note:** If `leading` and `trailing` options are `true`, `func` is
+ * invoked on the trailing edge of the timeout only if the debounced function
+ * is invoked more than once during the `wait` timeout.
+ *
+ * If `wait` is `0` and `leading` is `false`, `func` invocation is deferred
+ * until the next tick, similar to `setTimeout` with a timeout of `0`.
+ *
+ * @param {Function}                   func             The function to debounce.
+ * @param {number}                     wait             The number of milliseconds to delay.
+ * @param {Partial< DebounceOptions >} options          The options object.
+ * @param {boolean}                    options.leading  Specify invoking on the leading edge of the timeout.
+ * @param {number}                     options.maxWait  The maximum time `func` is allowed to be delayed before it's invoked.
+ * @param {boolean}                    options.trailing Specify invoking on the trailing edge of the timeout.
+ *
+ * @return Returns the new debounced function.
+ */
+export const debounce = < FunctionT extends ( ...args: unknown[] ) => unknown >(
+	func: FunctionT,
+	wait: number,
+	options?: Partial< DebounceOptions >
+) => {
+	let lastArgs: Parameters< FunctionT > | undefined;
+	let lastThis: unknown | undefined;
+	let maxWait = 0;
+	let result: ReturnType< FunctionT >;
+	let timerId: ReturnType< typeof setTimeout > | undefined;
+	let lastCallTime: number | undefined;
+
+	let lastInvokeTime = 0;
+	let leading = false;
+	let maxing = false;
+	let trailing = true;
+
+	if ( options ) {
+		leading = !! options.leading;
+		maxing = 'maxWait' in options;
+		if ( options.maxWait !== undefined ) {
+			maxWait = Math.max( options.maxWait, wait );
+		}
+		trailing = 'trailing' in options ? !! options.trailing : trailing;
+	}
+
+	function invokeFunc( time: number ) {
+		const args = lastArgs;
+		const thisArg = lastThis;
+
+		lastArgs = undefined;
+		lastThis = undefined;
+		lastInvokeTime = time;
+
+		result = func.apply( thisArg, args! ) as ReturnType< FunctionT >;
+		return result;
+	}
+
+	function startTimer(
+		pendingFunc: () => void,
+		waitTime: number | undefined
+	) {
+		timerId = setTimeout( pendingFunc, waitTime );
+	}
+
+	function cancelTimer() {
+		if ( timerId !== undefined ) {
+			clearTimeout( timerId );
+		}
+	}
+
+	function leadingEdge( time: number ) {
+		// Reset any `maxWait` timer.
+		lastInvokeTime = time;
+		// Start the timer for the trailing edge.
+		startTimer( timerExpired, wait );
+		// Invoke the leading edge.
+		return leading ? invokeFunc( time ) : result;
+	}
+
+	function getTimeSinceLastCall( time: number ) {
+		return time - ( lastCallTime || 0 );
+	}
+
+	function remainingWait( time: number ) {
+		const timeSinceLastCall = getTimeSinceLastCall( time );
+		const timeSinceLastInvoke = time - lastInvokeTime;
+		const timeWaiting = wait - timeSinceLastCall;
+
+		return maxing
+			? Math.min( timeWaiting, maxWait - timeSinceLastInvoke )
+			: timeWaiting;
+	}
+
+	function shouldInvoke( time: number ) {
+		const timeSinceLastCall = getTimeSinceLastCall( time );
+		const timeSinceLastInvoke = time - lastInvokeTime;
+
+		// Either this is the first call, activity has stopped and we're at the
+		// trailing edge, the system time has gone backwards and we're treating
+		// it as the trailing edge, or we've hit the `maxWait` limit.
+		return (
+			lastCallTime === undefined ||
+			timeSinceLastCall >= wait ||
+			timeSinceLastCall < 0 ||
+			( maxing && timeSinceLastInvoke >= maxWait )
+		);
+	}
+
+	function timerExpired() {
+		const time = Date.now();
+		if ( shouldInvoke( time ) ) {
+			return trailingEdge( time );
+		}
+		// Restart the timer.
+		startTimer( timerExpired, remainingWait( time ) );
+		return undefined;
+	}
+
+	function clearTimer() {
+		timerId = undefined;
+	}
+
+	function trailingEdge( time: number ) {
+		clearTimer();
+
+		// Only invoke if we have `lastArgs` which means `func` has been
+		// debounced at least once.
+		if ( trailing && lastArgs ) {
+			return invokeFunc( time );
+		}
+		lastArgs = lastThis = undefined;
+		return result;
+	}
+
+	function cancel() {
+		cancelTimer();
+		lastInvokeTime = 0;
+		clearTimer();
+		lastArgs = lastCallTime = lastThis = undefined;
+	}
+
+	function flush() {
+		return pending() ? trailingEdge( Date.now() ) : result;
+	}
+
+	function pending() {
+		return timerId !== undefined;
+	}
+
+	function debounced( this: unknown, ...args: Parameters< FunctionT > ) {
+		const time = Date.now();
+		const isInvoking = shouldInvoke( time );
+
+		lastArgs = args;
+		lastThis = this;
+		lastCallTime = time;
+
+		if ( isInvoking ) {
+			if ( ! pending() ) {
+				return leadingEdge( lastCallTime );
+			}
+			if ( maxing ) {
+				// Handle invocations in a tight loop.
+				startTimer( timerExpired, wait );
+				return invokeFunc( lastCallTime );
+			}
+		}
+		if ( ! pending() ) {
+			startTimer( timerExpired, wait );
+		}
+		return result;
+	}
+	debounced.cancel = cancel;
+	debounced.flush = flush;
+	debounced.pending = pending;
+	return debounced;
+};

--- a/packages/compose/src/utils/debounce/test/index.ts
+++ b/packages/compose/src/utils/debounce/test/index.ts
@@ -1,0 +1,367 @@
+/**
+ * Internal dependencies
+ */
+import { debounce } from '../index';
+
+const identity = ( value ) => value;
+
+beforeAll( () => {
+	jest.useRealTimers();
+} );
+
+afterAll( () => {
+	jest.useFakeTimers();
+} );
+
+describe( 'debounce', () => {
+	it( 'should debounce a function', () => {
+		return new Promise( ( done ) => {
+			let callCount = 0;
+
+			const debounced = debounce( function ( value ) {
+				++callCount;
+				return value;
+			}, 32 );
+
+			let results = [
+				debounced( 'a' ),
+				debounced( 'b' ),
+				debounced( 'c' ),
+			];
+			expect( results ).toStrictEqual( [
+				undefined,
+				undefined,
+				undefined,
+			] );
+			expect( callCount ).toBe( 0 );
+
+			setTimeout( function () {
+				expect( callCount ).toBe( 1 );
+
+				results = [
+					debounced( 'd' ),
+					debounced( 'e' ),
+					debounced( 'f' ),
+				];
+				expect( results ).toStrictEqual( [ 'c', 'c', 'c' ] );
+				expect( callCount ).toBe( 1 );
+			}, 128 );
+
+			setTimeout( function () {
+				expect( callCount ).toBe( 2 );
+				done( null );
+			}, 256 );
+		} );
+	} );
+
+	it( 'should return the last `func` result on subsequent debounced calls', () => {
+		return new Promise( ( done ) => {
+			const debounced = debounce( identity, 32 );
+			debounced( 'a' );
+
+			setTimeout( function () {
+				expect( debounced( 'b' ) ).not.toBe( 'b' );
+			}, 64 );
+
+			setTimeout( function () {
+				expect( debounced( 'c' ) ).not.toBe( 'c' );
+				done( null );
+			}, 128 );
+		} );
+	} );
+
+	it( 'should not immediately call `func` when `wait` is `0`', () => {
+		return new Promise( ( done ) => {
+			let callCount = 0;
+			const debounced = debounce( function () {
+				++callCount;
+			}, 0 );
+
+			debounced();
+			debounced();
+			expect( callCount ).toBe( 0 );
+
+			setTimeout( function () {
+				expect( callCount ).toBe( 1 );
+				done( null );
+			}, 5 );
+		} );
+	} );
+
+	it( 'should apply default options', () => {
+		return new Promise( ( done ) => {
+			let callCount = 0;
+			const debounced = debounce(
+				function () {
+					callCount++;
+				},
+				32,
+				{}
+			);
+
+			debounced();
+			expect( callCount ).toBe( 0 );
+
+			setTimeout( function () {
+				expect( callCount ).toBe( 1 );
+				done( null );
+			}, 64 );
+		} );
+	} );
+
+	it( 'should support a `leading` option', () => {
+		return new Promise( ( done ) => {
+			const callCounts = [ 0, 0 ];
+
+			const withLeading = debounce(
+				function () {
+					callCounts[ 0 ]++;
+				},
+				32,
+				{ leading: true }
+			);
+
+			const withLeadingAndTrailing = debounce(
+				function () {
+					callCounts[ 1 ]++;
+				},
+				32,
+				{ leading: true }
+			);
+
+			withLeading();
+			expect( callCounts[ 0 ] ).toBe( 1 );
+
+			withLeadingAndTrailing();
+			withLeadingAndTrailing();
+			expect( callCounts[ 1 ] ).toBe( 1 );
+
+			setTimeout( function () {
+				expect( callCounts ).toStrictEqual( [ 1, 2 ] );
+
+				withLeading();
+				expect( callCounts[ 0 ] ).toBe( 2 );
+
+				done( null );
+			}, 64 );
+		} );
+	} );
+
+	it( 'should return the last `func` result for subsequent leading debounced calls', () => {
+		return new Promise( ( done ) => {
+			const debounced = debounce( identity, 32, {
+				leading: true,
+				trailing: false,
+			} );
+			let results = [ debounced( 'a' ), debounced( 'b' ) ];
+
+			expect( results ).toStrictEqual( [ 'a', 'a' ] );
+
+			setTimeout( function () {
+				results = [ debounced( 'c' ), debounced( 'd' ) ];
+				expect( results ).toStrictEqual( [ 'c', 'c' ] );
+				done( null );
+			}, 64 );
+		} );
+	} );
+
+	it( 'should support a `trailing` option', () => {
+		return new Promise( ( done ) => {
+			let withCount = 0;
+			let withoutCount = 0;
+
+			const withTrailing = debounce(
+				function () {
+					withCount++;
+				},
+				32,
+				{ trailing: true }
+			);
+
+			const withoutTrailing = debounce(
+				function () {
+					withoutCount++;
+				},
+				32,
+				{ trailing: false }
+			);
+
+			withTrailing();
+			expect( withCount ).toBe( 0 );
+
+			withoutTrailing();
+			expect( withCount ).toBe( 0 );
+
+			setTimeout( function () {
+				expect( withCount ).toBe( 1 );
+				expect( withoutCount ).toBe( 0 );
+				done( null );
+			}, 64 );
+		} );
+	} );
+
+	it( 'should support a `maxWait` option', () => {
+		return new Promise( ( done ) => {
+			let callCount = 0;
+
+			const debounced = debounce(
+				function ( value ) {
+					++callCount;
+					return value;
+				},
+				32,
+				{ maxWait: 64 }
+			);
+
+			debounced( 42 );
+			debounced( 42 );
+			expect( callCount ).toBe( 0 );
+
+			setTimeout( function () {
+				expect( callCount ).toBe( 1 );
+				debounced( 42 );
+				debounced( 42 );
+				expect( callCount ).toBe( 1 );
+			}, 128 );
+
+			setTimeout( function () {
+				expect( callCount ).toBe( 2 );
+				done( null );
+			}, 256 );
+		} );
+	} );
+
+	it( 'should support `maxWait` in a tight loop', () => {
+		return new Promise( ( done ) => {
+			const limit = 320;
+			let withCount = 0;
+			let withoutCount = 0;
+
+			const withMaxWait = debounce(
+				function () {
+					withCount++;
+				},
+				64,
+				{ maxWait: 128 }
+			);
+
+			const withoutMaxWait = debounce( function () {
+				withoutCount++;
+			}, 96 );
+
+			const start = Date.now();
+			while ( Date.now() - start < limit ) {
+				withMaxWait();
+				withoutMaxWait();
+			}
+			const actual = [ Boolean( withoutCount ), Boolean( withCount ) ];
+			setTimeout( function () {
+				expect( actual ).toStrictEqual( [ false, true ] );
+				done( null );
+			}, 1 );
+		} );
+	} );
+
+	it( 'should queue a trailing call for subsequent debounced calls after `maxWait`', () => {
+		return new Promise( ( done ) => {
+			let callCount = 0;
+
+			const debounced = debounce(
+				function () {
+					++callCount;
+				},
+				200,
+				{ maxWait: 200 }
+			);
+
+			debounced();
+
+			setTimeout( debounced, 190 );
+			setTimeout( debounced, 200 );
+			setTimeout( debounced, 210 );
+
+			setTimeout( function () {
+				expect( callCount ).toBe( 2 );
+				done( null );
+			}, 500 );
+		} );
+	} );
+
+	it( 'should cancel when `cancel` is invoked', () => {
+		return new Promise( ( done ) => {
+			let callCount = 0;
+
+			const debounced = debounce( function () {
+				callCount++;
+			}, 32 );
+
+			debounced();
+
+			setTimeout( function () {
+				debounced.cancel();
+				expect( callCount ).toBe( 0 );
+			}, 16 );
+
+			setTimeout( function () {
+				expect( callCount ).toBe( 0 );
+				done( null );
+			}, 64 );
+		} );
+	} );
+
+	it( 'should cancel `maxDelayed` when `delayed` is invoked', () => {
+		return new Promise( ( done ) => {
+			let callCount = 0;
+
+			const debounced = debounce(
+				function () {
+					callCount++;
+				},
+				32,
+				{ maxWait: 64 }
+			);
+
+			debounced();
+
+			setTimeout( function () {
+				debounced();
+				expect( callCount ).toBe( 1 );
+			}, 128 );
+
+			setTimeout( function () {
+				expect( callCount ).toBe( 2 );
+				done( null );
+			}, 192 );
+		} );
+	} );
+
+	it( 'should invoke the trailing call with the correct arguments and `this` binding', () => {
+		return new Promise( ( done ) => {
+			let actual;
+			let callCount = 0;
+			const object = {};
+
+			const debounced = debounce(
+				function ( ...args ) {
+					actual = [ this ];
+					Array.prototype.push.apply( actual, args );
+					return ++callCount !== 2;
+				},
+				32,
+				{ leading: true, maxWait: 64 }
+			);
+
+			while ( true ) {
+				if ( ! debounced.call( object, 'a' ) ) {
+					break;
+				}
+			}
+
+			setTimeout( function () {
+				expect( callCount ).toBe( 2 );
+				expect( actual ).toStrictEqual( [ object, 'a' ] );
+				done( null );
+			}, 64 );
+		} );
+	} );
+} );

--- a/packages/editor/src/components/page-attributes/parent.js
+++ b/packages/editor/src/components/page-attributes/parent.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { get, unescape as unescapeString, debounce, find } from 'lodash';
+import { get, unescape as unescapeString, find } from 'lodash';
 import removeAccents from 'remove-accents';
 
 /**
@@ -9,6 +9,7 @@ import removeAccents from 'remove-accents';
  */
 import { __ } from '@wordpress/i18n';
 import { ComboboxControl } from '@wordpress/components';
+import { debounce } from '@wordpress/compose';
 import { useState, useMemo } from '@wordpress/element';
 import { useSelect, useDispatch } from '@wordpress/data';
 import { decodeEntities } from '@wordpress/html-entities';

--- a/packages/editor/src/components/post-author/combobox.js
+++ b/packages/editor/src/components/post-author/combobox.js
@@ -1,11 +1,7 @@
 /**
- * External dependencies
- */
-import { debounce } from 'lodash';
-
-/**
  * WordPress dependencies
  */
+import { debounce } from '@wordpress/compose';
 import { useState, useMemo } from '@wordpress/element';
 import { useSelect, useDispatch } from '@wordpress/data';
 import { __ } from '@wordpress/i18n';

--- a/packages/preferences-persistence/package.json
+++ b/packages/preferences-persistence/package.json
@@ -28,7 +28,8 @@
 	"sideEffects": false,
 	"dependencies": {
 		"@babel/runtime": "^7.16.0",
-		"@wordpress/api-fetch": "file:../api-fetch"
+		"@wordpress/api-fetch": "file:../api-fetch",
+		"@wordpress/compose": "file:../compose"
 	},
 	"publishConfig": {
 		"access": "public"

--- a/packages/preferences-persistence/src/create/debounce-async.js
+++ b/packages/preferences-persistence/src/create/debounce-async.js
@@ -6,8 +6,8 @@
  * - The second is never called.
  * - The third happens `delayMS` milliseconds after the first has resolved.
  *
- * This is distinct from `lodash.debounce` in that it waits for promise
- * resolution.
+ * This is distinct from `{ debounce } from @wordpress/compose` in that it
+ * waits for promise resolution.
  *
  * @param {Function} func    A function that returns a promise.
  * @param {number}   delayMS A delay in milliseconds.

--- a/packages/rich-text/src/component/index.native.js
+++ b/packages/rich-text/src/component/index.native.js
@@ -4,7 +4,7 @@
  * External dependencies
  */
 import { View, Platform, Dimensions } from 'react-native';
-import { get, pickBy, debounce } from 'lodash';
+import { get, pickBy } from 'lodash';
 import memize from 'memize';
 import { colord } from 'colord';
 
@@ -18,7 +18,11 @@ import {
 } from '@wordpress/react-native-bridge';
 import { BlockFormatControls, getPxFromCssUnit } from '@wordpress/block-editor';
 import { Component } from '@wordpress/element';
-import { compose, withPreferredColorScheme } from '@wordpress/compose';
+import {
+	compose,
+	debounce,
+	withPreferredColorScheme,
+} from '@wordpress/compose';
 import { withSelect } from '@wordpress/data';
 import { childrenBlock } from '@wordpress/blocks';
 import { decodeEntities } from '@wordpress/html-entities';

--- a/packages/viewport/src/listener.js
+++ b/packages/viewport/src/listener.js
@@ -24,6 +24,7 @@ const addDimensionsEventListener = ( breakpoints, operators ) => {
 			const values = mapValues( queries, ( query ) => query.matches );
 			dispatch( store ).setIsMatching( values );
 		},
+		0,
 		{ leading: true }
 	);
 

--- a/packages/viewport/src/listener.js
+++ b/packages/viewport/src/listener.js
@@ -1,11 +1,12 @@
 /**
  * External dependencies
  */
-import { reduce, debounce, mapValues } from 'lodash';
+import { reduce, mapValues } from 'lodash';
 
 /**
  * WordPress dependencies
  */
+import { debounce } from '@wordpress/compose';
 import { dispatch } from '@wordpress/data';
 
 /**

--- a/packages/widgets/src/blocks/legacy-widget/edit/control.js
+++ b/packages/widgets/src/blocks/legacy-widget/edit/control.js
@@ -1,12 +1,8 @@
 /**
- * External dependencies
- */
-import { debounce } from 'lodash';
-
-/**
  * WordPress dependencies
  */
 import apiFetch from '@wordpress/api-fetch';
+import { debounce } from '@wordpress/compose';
 import { __ } from '@wordpress/i18n';
 
 /**


### PR DESCRIPTION
## What?
This PR introduces an in-house version of the `_.debounce()` function, along with some tests. I've borrowed most of the prior art by @sgomes (kudos for that), as indicated by his co-authorship of the first commit. We also update all `debounce` usages in Gutenberg to use the new version. Finally, we deprecate the original `_.debounce()` function so it will never be seen again in the repo.

## Why?

Lodash is known to unnecessarily inflate the bundle size of packages, and in most cases, it can be replaced with native language functionality. See these for more information and rationale:

* https://github.com/WordPress/gutenberg/issues/16938#issuecomment-602837246
* https://github.com/WordPress/gutenberg/issues/17025
* https://github.com/WordPress/gutenberg/issues/39495 

## How?

We're introducing `debounce` as another utility function in the `@wordpress/compose` package. That nicely gives us the opportunity to type it, which we're essentially doing. It comes with a few tests as well. We're exposing it externally, since it will be used by other packages.

Furthermore, we update all `_.debounce()` calls to use the new utility function, including the `useDebounce()` hook. IMHO, that closes the loop of having an in-house hook for `useDebounce()` but using an external function for the actual debouncing, giving us control on the types and functionality. 

You might ask why we're adding all the custom features (the `options` third argument) when they're not used internally. Well, because `useDebounce()` is exposed externally, and it was supporting all those options, so we have to continue supporting them for backwards compatibility. 

## Testing Instructions
* Verify all checks are green. 
* Smoke test all the editors.
* RN: Do some thorough smoke testing.
* Verify at at least a few locations where we update to the new `debounce()` that it continues to work well, for example:
  * Debounced search of downloadable blocks through the block directory in the inserter.
  * Debounced category selection of block patterns in the inserter.
  * Debounced display of search results when transforming text to be a link.
  * Debounced search when filtering by page name in the Parent Page field in Page Attributes in the sidebar of pages.