### PR TITLE
Fix the horizontal block list drop indicator when dragging to the start

### DIFF
--- a/packages/block-editor/src/components/block-popover/inbetween.js
+++ b/packages/block-editor/src/components/block-popover/inbetween.js
@@ -48,7 +48,9 @@ function BlockPopoverInbetween( {
 				isBlockVisible,
 			} = select( blockEditorStore );
 
-			const _rootClientId = getBlockRootClientId( previousClientId );
+			const _rootClientId = getBlockRootClientId(
+				previousClientId ?? nextClientId
+			);
 			return {
 				orientation:
 					getBlockListSettings( _rootClientId )?.orientation ||

--- a/test/e2e/specs/editor/various/draggable-blocks.spec.js
+++ b/test/e2e/specs/editor/various/draggable-blocks.spec.js
@@ -240,4 +240,87 @@ test.describe( 'Draggable block', () => {
 <!-- /wp:paragraph --></div>
 <!-- /wp:group -->` );
 	} );
+
+	test( 'can drag and drop to the end of a horizontal block list', async ( {
+		editor,
+		page,
+	} ) => {
+		// Insert a row.
+		await editor.insertBlock( {
+			name: 'core/group',
+			attributes: {
+				layout: { type: 'flex', flexWrap: 'nowrap' },
+			},
+			innerBlocks: [
+				{
+					name: 'core/paragraph',
+					attributes: {
+						content: '1',
+					},
+				},
+				{
+					name: 'core/paragraph',
+					attributes: {
+						content: '2',
+					},
+				},
+			],
+		} );
+
+		await page.focus( 'role=document[name="Paragraph block"i] >> text=1' );
+		await editor.showBlockToolbar();
+
+		const dragHandle = page.locator(
+			'role=toolbar[name="Block tools"i] >> role=button[name="Drag"i][include-hidden]'
+		);
+		// Hover to the center of the drag handle.
+		await dragHandle.hover();
+		// Start dragging.
+		await page.mouse.down();
+
+		// Move to and hover on the bottom half of the paragraph block to trigger the indicator.
+		const secondParagraph = page.locator(
+			'role=document[name="Paragraph block"i] >> text=2'
+		);
+		const secondParagraphBound = await secondParagraph.boundingBox();
+		// Call the move function twice to make sure the `dragOver` event is sent.
+		// @see https://github.com/microsoft/playwright/issues/17153
+		for ( let i = 0; i < 2; i += 1 ) {
+			await page.mouse.move(
+				secondParagraphBound.x + secondParagraphBound.width * 0.75,
+				secondParagraphBound.y
+			);
+		}
+
+		await expect(
+			page.locator( 'data-testid=block-draggable-chip >> visible=true' )
+		).toBeVisible();
+
+		const indicator = page.locator(
+			'data-testid=block-list-insertion-point-indicator'
+		);
+		await expect( indicator ).toBeVisible();
+		// Expect the indicator to be below the second paragraph.
+		await expect
+			.poll( () =>
+				indicator.boundingBox().then( ( { x, width } ) => x + width )
+			)
+			.toBeGreaterThan(
+				secondParagraphBound.x + secondParagraphBound.width
+			);
+
+		// Drop the paragraph block.
+		await page.mouse.up();
+
+		await expect.poll( editor.getEditedPostContent )
+			.toBe( `<!-- wp:group {"layout":{"type":"flex","flexWrap":"nowrap"}} -->
+<div class="wp-block-group"><!-- wp:paragraph -->
+<p>2</p>
+<!-- /wp:paragraph -->
+
+<!-- wp:paragraph -->
+<p>1</p>
+<!-- /wp:paragraph --></div>
+<!-- /wp:group -->` );
+	} );
 } );

--- a/test/e2e/specs/editor/various/draggable-blocks.spec.js
+++ b/test/e2e/specs/editor/various/draggable-blocks.spec.js
@@ -18,7 +18,7 @@ test.describe( 'Draggable block', () => {
 		await admin.createNewPost();
 	} );
 
-	test( 'can drag and drop to the top of a block list', async ( {
+	test( 'can drag and drop to the top of a vertical block list', async ( {
 		editor,
 		page,
 	} ) => {
@@ -88,7 +88,7 @@ test.describe( 'Draggable block', () => {
 <!-- /wp:paragraph -->` );
 	} );
 
-	test( 'can drag and drop to the bottom of a block list', async ( {
+	test( 'can drag and drop to the bottom of a vertical block list', async ( {
 		editor,
 		page,
 	} ) => {
@@ -160,5 +160,84 @@ test.describe( 'Draggable block', () => {
 <!-- wp:paragraph -->
 <p>1</p>
 <!-- /wp:paragraph -->` );
+	} );
+
+	test( 'can drag and drop to the start of a horizontal block list', async ( {
+		editor,
+		page,
+	} ) => {
+		// Insert a row.
+		await editor.insertBlock( {
+			name: 'core/group',
+			attributes: {
+				layout: { type: 'flex', flexWrap: 'nowrap' },
+			},
+			innerBlocks: [
+				{
+					name: 'core/paragraph',
+					attributes: {
+						content: '1',
+					},
+				},
+				{
+					name: 'core/paragraph',
+					attributes: {
+						content: '2',
+					},
+				},
+			],
+		} );
+
+		await page.focus( 'role=document[name="Paragraph block"i] >> text=2' );
+		await editor.showBlockToolbar();
+
+		const dragHandle = page.locator(
+			'role=toolbar[name="Block tools"i] >> role=button[name="Drag"i][include-hidden]'
+		);
+		// Hover to the center of the drag handle.
+		await dragHandle.hover();
+		// Start dragging.
+		await page.mouse.down();
+
+		// Move to and hover on the bottom half of the paragraph block to trigger the indicator.
+		const firstParagraph = page.locator(
+			'role=document[name="Paragraph block"i] >> text=1'
+		);
+		const firstParagraphBound = await firstParagraph.boundingBox();
+		// Call the move function twice to make sure the `dragOver` event is sent.
+		// @see https://github.com/microsoft/playwright/issues/17153
+		for ( let i = 0; i < 2; i += 1 ) {
+			await page.mouse.move(
+				firstParagraphBound.x + firstParagraphBound.width * 0.25,
+				firstParagraphBound.y
+			);
+		}
+
+		await expect(
+			page.locator( 'data-testid=block-draggable-chip >> visible=true' )
+		).toBeVisible();
+
+		const indicator = page.locator(
+			'data-testid=block-list-insertion-point-indicator'
+		);
+		await expect( indicator ).toBeVisible();
+		// Expect the indicator to be below the second paragraph.
+		await expect
+			.poll( () => indicator.boundingBox().then( ( { x } ) => x ) )
+			.toBeLessThan( firstParagraphBound.x );
+
+		// Drop the paragraph block.
+		await page.mouse.up();
+
+		await expect.poll( editor.getEditedPostContent )
+			.toBe( `<!-- wp:group {"layout":{"type":"flex","flexWrap":"nowrap"}} -->
+<div class="wp-block-group"><!-- wp:paragraph -->
+<p>2</p>
+<!-- /wp:paragraph -->
+
+<!-- wp:paragraph -->
+<p>1</p>
+<!-- /wp:paragraph --></div>
+<!-- /wp:group -->` );
 	} );
 } );

--- a/test/e2e/specs/editor/various/draggable-blocks.spec.js
+++ b/test/e2e/specs/editor/various/draggable-blocks.spec.js
@@ -199,7 +199,7 @@ test.describe( 'Draggable block', () => {
 		// Start dragging.
 		await page.mouse.down();
 
-		// Move to and hover on the bottom half of the paragraph block to trigger the indicator.
+		// Move to and hover on the left half of the paragraph block to trigger the indicator.
 		const firstParagraph = page.locator(
 			'role=document[name="Paragraph block"i] >> text=1'
 		);
@@ -221,7 +221,7 @@ test.describe( 'Draggable block', () => {
 			'data-testid=block-list-insertion-point-indicator'
 		);
 		await expect( indicator ).toBeVisible();
-		// Expect the indicator to be below the second paragraph.
+		// Expect the indicator to be to the left of the first paragraph.
 		await expect
 			.poll( () => indicator.boundingBox().then( ( { x } ) => x ) )
 			.toBeLessThan( firstParagraphBound.x );
@@ -278,7 +278,7 @@ test.describe( 'Draggable block', () => {
 		// Start dragging.
 		await page.mouse.down();
 
-		// Move to and hover on the bottom half of the paragraph block to trigger the indicator.
+		// Move to and hover on the right half of the paragraph block to trigger the indicator.
 		const secondParagraph = page.locator(
 			'role=document[name="Paragraph block"i] >> text=2'
 		);
@@ -300,7 +300,7 @@ test.describe( 'Draggable block', () => {
 			'data-testid=block-list-insertion-point-indicator'
 		);
 		await expect( indicator ).toBeVisible();
-		// Expect the indicator to be below the second paragraph.
+		// Expect the indicator to be to the right of the second paragraph.
 		await expect
 			.poll( () =>
 				indicator.boundingBox().then( ( { x, width } ) => x + width )


### PR DESCRIPTION
## What?
Fixes this comment - https://github.com/WordPress/gutenberg/issues/32880#issuecomment-1239088246

## Why?
This wasn't working, as when dragging to the start of a block list `previousClientId` is `undefined`, and that's being used to get the `rootClientId`. The `rootClientId` is used to determine the block list orientation, and so the inserter was trying to use horizontal block list styles.

## How?
Use the `nextClientId` to get the `rootClientId` when `previousClientId` is `undefined`.

## Testing Instructions
1. Add a row
2. Add some paragraphs to the row with some short text in each one
3. Try dragging one of the paragraphs to the start of the row, the blue line drop indicator should be shown

## Screenshots or screencast <!-- if applicable -->
### Before
![Screen Shot 2022-09-07 at 5 41 00 pm](https://user-images.githubusercontent.com/677833/188846725-f9ac2409-38bf-4cbc-907b-9c66428fd1fe.png)

### After
![Screen Shot 2022-09-07 at 5 38 39 pm](https://user-images.githubusercontent.com/677833/188846337-9f22726e-0cf3-4bcd-bcad-b232cc8d7fc0.png)
