### PR TITLE
Gallery: Display upload error notices using snackbars

### DIFF
--- a/packages/block-library/src/gallery/edit.js
+++ b/packages/block-library/src/gallery/edit.js
@@ -13,7 +13,6 @@ import {
 	PanelBody,
 	SelectControl,
 	ToggleControl,
-	withNotices,
 	RangeControl,
 	Spinner,
 } from '@wordpress/components';
@@ -80,9 +79,7 @@ function GalleryEdit( props ) {
 		attributes,
 		className,
 		clientId,
-		noticeOperations,
 		isSelected,
-		noticeUI,
 		insertBlocksAfter,
 	} = props;
 
@@ -95,7 +92,8 @@ function GalleryEdit( props ) {
 		selectBlock,
 		clearSelectedBlock,
 	} = useDispatch( blockEditorStore );
-	const { createSuccessNotice } = useDispatch( noticesStore );
+	const { createSuccessNotice, createErrorNotice } =
+		useDispatch( noticesStore );
 
 	const { getBlock, getSettings, preferredStyle } = useSelect( ( select ) => {
 		const settings = select( blockEditorStore ).getSettings();
@@ -244,12 +242,11 @@ function GalleryEdit( props ) {
 			: selectedImages;
 
 		if ( ! imageArray.every( isValidFileType ) ) {
-			noticeOperations.removeAllNotices();
-			noticeOperations.createErrorNotice(
+			createErrorNotice(
 				__(
 					'If uploading to a gallery all files need to be image formats'
 				),
-				{ id: 'gallery-upload-invalid-file' }
+				{ id: 'gallery-upload-invalid-file', type: 'snackbar' }
 			);
 		}
 
@@ -316,8 +313,7 @@ function GalleryEdit( props ) {
 	}
 
 	function onUploadError( message ) {
-		noticeOperations.removeAllNotices();
-		noticeOperations.createErrorNotice( message );
+		createErrorNotice( message, { type: 'snackbar' } );
 	}
 
 	function setLinkTo( value ) {
@@ -470,7 +466,6 @@ function GalleryEdit( props ) {
 			allowedTypes={ ALLOWED_MEDIA_TYPES }
 			multiple
 			onError={ onUploadError }
-			notices={ noticeUI }
 			{ ...mediaPlaceholderProps }
 		/>
 	);
@@ -560,7 +555,6 @@ function GalleryEdit( props ) {
 					addToGallery={ hasImageIds }
 				/>
 			</BlockControls>
-			{ noticeUI }
 			{ Platform.isWeb && (
 				<GapStyles
 					blockGap={ attributes.style?.spacing?.blockGap }
@@ -581,7 +575,6 @@ function GalleryEdit( props ) {
 		</>
 	);
 }
-export default compose( [
-	withNotices,
-	withViewportMatch( { isNarrow: '< small' } ),
-] )( GalleryEdit );
+export default compose( [ withViewportMatch( { isNarrow: '< small' } ) ] )(
+	GalleryEdit
+);


### PR DESCRIPTION
## What?
Similar to #43767, #43890.

Update Gallery block to use snackbars for error notices. The block is already using snackbars for success notices.

## Why?
> Placeholders are great, but as patterns and templating opportunities have improved, it's become apparent how often the placeholders will be shown in narrow/small contexts, making it all the more necessary that critical information be extracted and shown elsewhere, so it doesn't just get hidden by responsive rules.

https://github.com/WordPress/gutenberg/pull/43767#issuecomment-1235281407 - @jasmussen

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

## Testing Instructions
1. Open a Post or Page.
2. Insert a Video block.
3. Try uploading an unsupported file type.
4. Confirm that the error message is displayed as snackbar.

## Screenshots or screencast <!-- if applicable -->

![CleanShot 2022-09-07 at 14 29 46](https://user-images.githubusercontent.com/240569/188857091-3ef122ca-26c4-43ef-b270-7bda2959c089.png)
