### PR TITLE
Separator: Remove appearance of "inset" style.

### DIFF
--- a/packages/block-library/src/separator/style.scss
+++ b/packages/block-library/src/separator/style.scss
@@ -3,6 +3,10 @@
 	border-bottom: 1px solid currentColor;
 	// Default, thin style, is stored in theme.scss so it can be opted out of
 
+	// Unset the left and right borders by default, otherwise some browsers will render them as "inset".
+	border-left: none;
+	border-right: none;
+
 	// Dots style
 	&.is-style-dots {
 		// Override any background themes often set on the hr tag for this style.


### PR DESCRIPTION
## What?

By default, the `hr` tag is styled to appear _inset_ by the browser. The browser does this by painting 4 different border colors. For block themes that style the Separator block using theme.json, usually just the color or border width is styled, and it looks good when small:
<img width="1122" alt="Screenshot 2022-09-07 at 13 16 55" src="https://user-images.githubusercontent.com/1204802/188866835-b9521c67-6ff8-4526-9bd0-812caad1f4c0.png">

But if we zoom in, we can see something is off:

<img width="820" alt="Screenshot 2022-09-07 at 13 16 55" src="https://user-images.githubusercontent.com/1204802/188866927-318f8dfb-dfc3-4e67-9558-cadb9345406e.png">

This is more visible if we change the height of the separator in the inspector:
<img width="1094" alt="Screenshot 2022-09-07 at 13 18 10" src="https://user-images.githubusercontent.com/1204802/188866989-04b2bdca-8185-4519-b180-678dbe7786d2.png">

We can here see two borders, left and right, indicating an inset style with a top left light source. An easier way to see this is to use the following in theme.json:

```
	"styles": {
		"blocks": {
			"core/separator": {
				"border": {
					"width": "10px"
				}
			}
		}
	}
```

Then we get this:

<img width="1100" alt="Screenshot 2022-09-07 at 13 20 26" src="https://user-images.githubusercontent.com/1204802/188867181-deb23f70-24e5-4b04-9259-8a648efc4b4b.png">

This PR unsets the left and right border for the separator by default, so the line will always look like a solid line:

<img width="1172" alt="Screenshot 2022-09-07 at 13 21 20" src="https://user-images.githubusercontent.com/1204802/188867252-a13f9a44-f7af-4a58-87ff-05d3ada86c04.png">

You can still set left and right borders of the separator if you like. It just isn't there by default.

## Why?

This feels a more reasonable default to offer.

## Testing Instructions

Insert a separator in a block theme like TT2 or TT3. Customize theme.json as outlined above, and with this PR applied you should see a square separator.