### PR TITLE
List: restore values attribute

### DIFF
--- a/docs/reference-guides/core-blocks.md
+++ b/docs/reference-guides/core-blocks.md
@@ -339,7 +339,7 @@ Create a bulleted or numbered list. ([Source](https://github.com/WordPress/guten
 -	**Name:** core/list
 -	**Category:** text
 -	**Supports:** __unstablePasteTextInline, anchor, color (background, gradients, link, text), spacing (margin, padding), typography (fontSize, lineHeight), ~~className~~
--	**Attributes:** ordered, placeholder, reversed, start, type, values
+-	**Attributes:** ordered, placeholder, reversed, start, type
 
 ## List item
 

--- a/packages/block-editor/src/store/selectors.js
+++ b/packages/block-editor/src/store/selectors.js
@@ -105,7 +105,27 @@ export function getBlockAttributes( state, clientId ) {
 		return null;
 	}
 
-	return state.blocks.attributes[ clientId ];
+	const attributes = state.blocks.attributes[ clientId ];
+
+	const { deprecatedAttributes } = getBlockType(
+		getBlockName( state, clientId )
+	);
+
+	if ( deprecatedAttributes ) {
+		for ( const key in deprecatedAttributes ) {
+			if ( ! attributes.hasOwnProperty( key ) ) {
+				Object.defineProperty( attributes, key, {
+					get() {
+						return deprecatedAttributes[ key ](
+							getBlock( state, clientId )
+						);
+					},
+				} );
+			}
+		}
+	}
+
+	return attributes;
 }
 
 /**

--- a/packages/block-library/src/list/block.json
+++ b/packages/block-library/src/list/block.json
@@ -13,15 +13,6 @@
 			"default": false,
 			"__experimentalRole": "content"
 		},
-		"values": {
-			"type": "string",
-			"source": "html",
-			"selector": "ol,ul",
-			"multiline": "li",
-			"__unstableMultilineWrapperTags": [ "ol", "ul" ],
-			"default": "",
-			"__experimentalRole": "content"
-		},
 		"type": {
 			"type": "string"
 		},

--- a/packages/block-library/src/list/edit.js
+++ b/packages/block-library/src/list/edit.js
@@ -52,14 +52,16 @@ function useMigrateOnLoad( attributes, clientId ) {
 
 	useEffect( () => {
 		// As soon as the block is loaded, migrate it to the new version.
-
-		if ( ! attributes.values ) {
+		if (
+			! attributes.hasOwnProperty( 'values' ) ||
+			Object.getOwnPropertyDescriptor( attributes, 'values' ).get
+		) {
 			return;
 		}
 
 		const [ newAttributes, newInnerBlocks ] = migrateToListV2( attributes );
 
-		deprecated( 'Value attribute on the list block', {
+		deprecated( 'Values attribute on the list block', {
 			since: '6.0',
 			version: '6.5',
 			alternative: 'inner blocks',
@@ -69,7 +71,7 @@ function useMigrateOnLoad( attributes, clientId ) {
 			updateBlockAttributes( clientId, newAttributes );
 			replaceInnerBlocks( clientId, newInnerBlocks );
 		} );
-	}, [ attributes.values ] );
+	}, [] );
 }
 
 function useOutdentList( clientId ) {

--- a/packages/block-library/src/list/index.js
+++ b/packages/block-library/src/list/index.js
@@ -3,12 +3,13 @@
  */
 import { list as icon } from '@wordpress/icons';
 import { __ } from '@wordpress/i18n';
+import deprecated from '@wordpress/deprecated';
 
 /**
  * Internal dependencies
  */
 import initBlock from '../utils/init-block';
-import deprecated from './deprecated';
+import deprecatedVersions from './deprecated';
 import edit from './edit';
 import metadata from './block.json';
 import save from './save';
@@ -17,6 +18,33 @@ import transforms from './transforms';
 const { name } = metadata;
 
 export { metadata, name };
+
+function computeDeprecatedNestedListValues( block ) {
+	if ( ! block ) return '';
+	const tagName = block.attributes.ordered ? 'ol' : 'ul';
+	return `<${ tagName }>${ computeDeprecatedValues( block ) }</${ tagName }>`;
+}
+
+function computeDeprecatedValues( block ) {
+	deprecated( 'Values attribute on the list block', {
+		since: '6.0',
+		version: '6.5',
+		alternative: 'inner blocks',
+	} );
+
+	return block.innerBlocks
+		.map( ( innerBlock ) => {
+			return (
+				'<li>' +
+				innerBlock.attributes.content +
+				computeDeprecatedNestedListValues(
+					innerBlock.innerBlocks?.[ 0 ]
+				) +
+				'</li>'
+			);
+		} )
+		.join( '' );
+}
 
 const settings = {
 	icon,
@@ -47,7 +75,10 @@ const settings = {
 	transforms,
 	edit,
 	save,
-	deprecated,
+	deprecated: deprecatedVersions,
+	deprecatedAttributes: {
+		values: computeDeprecatedValues,
+	},
 };
 
 export { settings };


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?

Transforms created by third party blocks might be relying on the old value, as well other custom functionality like quoting selected text on PR. For the latter, it would be good to have someone test if this solution works.

This PR restores the old `values` attribute as a getter (only computed when needed, based on the new attributes).

## Why?

Backward compatibility .

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->

## Screenshots or screencast <!-- if applicable -->
