### PR TITLE
Fix the Save buttons labelling and tooltip

### DIFF
--- a/packages/edit-post/src/components/header/style.scss
+++ b/packages/edit-post/src/components/header/style.scss
@@ -145,18 +145,6 @@
 			padding-right: $grid-unit-15;
 		}
 	}
-
-	// The post saved state button has a custom label only on small breakpoint
-	.editor-post-save-draft.editor-post-save-draft {
-		&::after {
-			content: none;
-		}
-		@include break-small {
-			&::after {
-				content: attr(aria-label);
-			}
-		}
-	}
 }
 
 .edit-post-header__dropdown {

--- a/packages/edit-post/src/components/header/style.scss
+++ b/packages/edit-post/src/components/header/style.scss
@@ -145,6 +145,13 @@
 			padding-right: $grid-unit-15;
 		}
 	}
+
+	.editor-post-save-draft.editor-post-save-draft,
+	.editor-post-saved-state.editor-post-saved-state {
+		&::after {
+			content: none;
+		}
+	}
 }
 
 .edit-post-header__dropdown {

--- a/packages/edit-site/src/components/save-button/index.js
+++ b/packages/edit-site/src/components/save-button/index.js
@@ -41,7 +41,18 @@ export default function SaveButton() {
 			isBusy={ isSaving }
 			onClick={ disabled ? undefined : () => setIsSaveViewOpened( true ) }
 			label={ label }
+			/*
+			 * We want the tooltip to show the keyboard shortcut only when the
+			 * button does something, i.e. when it's not disabled.
+			 */
 			shortcut={ disabled ? undefined : displayShortcut.primary( 's' ) }
+			/*
+			 * Displaying the keyboard shortcut conditionally makes the tooltip
+			 * itself show conditionally. This would trigger a full-rerendering
+			 * of the button that we want to avoid. By setting `showTooltip`,
+			 & the tooltip is always rendered even when there's no keyboard shortcut.
+			 */
+			showTooltip
 		>
 			{ label }
 		</Button>

--- a/packages/edit-site/src/components/save-button/index.js
+++ b/packages/edit-site/src/components/save-button/index.js
@@ -5,6 +5,7 @@ import { useSelect, useDispatch } from '@wordpress/data';
 import { Button } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 import { store as coreStore } from '@wordpress/core-data';
+import { displayShortcut } from '@wordpress/keycodes';
 
 /**
  * Internal dependencies
@@ -29,6 +30,8 @@ export default function SaveButton() {
 
 	const disabled = ! isDirty || isSaving;
 
+	const label = __( 'Save' );
+
 	return (
 		<Button
 			variant="primary"
@@ -37,8 +40,10 @@ export default function SaveButton() {
 			aria-expanded={ isSaveViewOpen }
 			isBusy={ isSaving }
 			onClick={ disabled ? undefined : () => setIsSaveViewOpened( true ) }
+			label={ label }
+			shortcut={ disabled ? undefined : displayShortcut.primary( 's' ) }
 		>
-			{ __( 'Save' ) }
+			{ label }
 		</Button>
 	);
 }

--- a/packages/editor/src/components/post-saved-state/index.js
+++ b/packages/editor/src/components/post-saved-state/index.js
@@ -151,10 +151,12 @@ export default function PostSavedState( {
 					: undefined
 			}
 			onClick={ isDisabled ? undefined : () => savePost() }
-			shortcut={ displayShortcut.primary( 's' ) }
-			variant={ isLargeViewport ? 'tertiary' : undefined }
+			shortcut={
+				isSavedState ? undefined : displayShortcut.primary( 's' )
+			}
+			variant="tertiary"
 			icon={ isLargeViewport ? undefined : cloudUpload }
-			label={ showIconLabels ? undefined : label }
+			label={ text }
 			aria-disabled={ isDisabled }
 		>
 			{ isSavedState && <Icon icon={ isSaved ? check : cloud } /> }

--- a/packages/editor/src/components/post-saved-state/index.js
+++ b/packages/editor/src/components/post-saved-state/index.js
@@ -151,9 +151,7 @@ export default function PostSavedState( {
 					: undefined
 			}
 			onClick={ isDisabled ? undefined : () => savePost() }
-			shortcut={
-				isSavedState ? undefined : displayShortcut.primary( 's' )
-			}
+			shortcut={ isDisabled ? undefined : displayShortcut.primary( 's' ) }
 			variant="tertiary"
 			icon={ isLargeViewport ? undefined : cloudUpload }
 			label={ text }

--- a/packages/editor/src/components/post-saved-state/index.js
+++ b/packages/editor/src/components/post-saved-state/index.js
@@ -154,7 +154,8 @@ export default function PostSavedState( {
 			shortcut={ isDisabled ? undefined : displayShortcut.primary( 's' ) }
 			variant="tertiary"
 			icon={ isLargeViewport ? undefined : cloudUpload }
-			label={ text }
+			// Make sure the aria-label has always a value, as the default `text` is undefined on small screens.
+			label={ text || label }
 			aria-disabled={ isDisabled }
 		>
 			{ isSavedState && <Icon icon={ isSaved ? check : cloud } /> }

--- a/packages/editor/src/components/post-saved-state/index.js
+++ b/packages/editor/src/components/post-saved-state/index.js
@@ -151,7 +151,18 @@ export default function PostSavedState( {
 					: undefined
 			}
 			onClick={ isDisabled ? undefined : () => savePost() }
+			/*
+			 * We want the tooltip to show the keyboard shortcut only when the
+			 * button does something, i.e. when it's not disabled.
+			 */
 			shortcut={ isDisabled ? undefined : displayShortcut.primary( 's' ) }
+			/*
+			 * Displaying the keyboard shortcut conditionally makes the tooltip
+			 * itself show conditionally. This would trigger a full-rerendering
+			 * of the button that we want to avoid. By setting `showTooltip`,
+			 & the tooltip is always rendered even when there's no keyboard shortcut.
+			 */
+			showTooltip
 			variant="tertiary"
 			icon={ isLargeViewport ? undefined : cloudUpload }
 			// Make sure the aria-label has always a value, as the default `text` is undefined on small screens.

--- a/packages/editor/src/components/post-saved-state/test/__snapshots__/index.js.snap
+++ b/packages/editor/src/components/post-saved-state/test/__snapshots__/index.js.snap
@@ -3,6 +3,7 @@
 exports[`PostSavedState returns a disabled button if the post is not saveable 1`] = `
 <button
   aria-disabled="true"
+  aria-label="Save draft"
   class="components-button is-tertiary has-icon"
   type="button"
 >

--- a/packages/editor/src/components/post-saved-state/test/__snapshots__/index.js.snap
+++ b/packages/editor/src/components/post-saved-state/test/__snapshots__/index.js.snap
@@ -3,8 +3,7 @@
 exports[`PostSavedState returns a disabled button if the post is not saveable 1`] = `
 <button
   aria-disabled="true"
-  aria-label="Save draft"
-  class="components-button has-icon"
+  class="components-button is-tertiary has-icon"
   type="button"
 >
   <svg


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->
Fixes https://github.com/WordPress/gutenberg/issues/42819

## What?
<!-- In a few words, what is the PR actually doing? -->
Post editor: based on the post saved state, the Save button aria-label may mismatch the button visible text and provide an incorrect information to assistive technology users. For example. when the post is saved, the visible text is 'Saved' but the aria-label is still 'Save draft'. Also, when the 'Show button text labels' preferences is enabled, the tooltip shows only the keyboard shortcut, which looks broken visually.

Site editor: the Save button does have an associated keyboard shortcut. However, the shortcut isn't exposed visually. For consistency, it should.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
Mismatching visible text and aria-label are a serious accessibility problem, as they provide users with inconsistent information. Also, the tooltip should work consistently for all buttons and when there's a associated keyboard shortcut, they should display both the label and the shortcut.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
Post Editor save button:
- Makes the button aria-label always match the visible text.
- Always sets a `label` prop so that the button tooltip works also when 'Show button text labels' is enabled.
- Does not show the tooltip when the button is disabled, for example when the post state is 'Saved' and the button doesn't do anything.
- Makes the button 'tertiary' also on small screens, for consistency.

Site editor save button:
- Sets a `label` prop so that the save button tooltip works.
- Adds the `shortcut` prop to display the available keyboard shortcut within the tooltip.
- The tooltip will show only when the button is not disabled.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->
**Post editor**
- Edit a post.
- Check that, when the post is saved, the 'Saved' button tooltip doesn't show a keyboard shortcut.
- Check the same thing when saving a post as Pending.
- Make some changes to the post so that the 'Saved' button gets enabled.
- Check the button does show a tooltip with the label and the keyboard shortcut.
- Check that the button aria-label always matches the visible text, also when saving and auto-saving.
- Check everything else work as expected.
- Go to Options > Preferences, and enable 'Show button text labels'.
- Repeat the steps above and check everything works as expected.

**Site editor**
- Edit a template.
- Check that when the template is saved, the 'Save' button tooltip doesn't show a keyboard shortcut.
- Make a change to the template  so that the 'Save' button gets enabled.
- Check the 'Save' button does show a tooltip with the label and the keyboard shortcut.
- Go to Options > Preferences, and enable 'Show button text labels'.
- Repeat the steps above and check everything works as expected.

## Screenshots or screencast <!-- if applicable -->

Post editor with 'Show button text labels' enabled, before:

<img width="428" alt="before" src="https://user-images.githubusercontent.com/1682452/188899106-f23a6229-816a-4ae2-9ea1-bc7724dde40e.png">

Post editor with 'Show button text labels' enabled, after:

<img width="400" alt="after" src="https://user-images.githubusercontent.com/1682452/188899185-e9036d9e-adbc-4792-b7e6-035d6234dc6d.png">
