### PR TITLE
Update unstaged docs error message

### DIFF
--- a/bin/api-docs/are-api-docs-unstaged.js
+++ b/bin/api-docs/are-api-docs-unstaged.js
@@ -35,7 +35,7 @@ const getUnstagedReadmes = () =>
 				'\n',
 				'Some API docs may be out of date:',
 				unstagedReadmes.toString(),
-				'Either build and stage them with npm run docs:blocks or continue with --no-verify.',
+				'Either build and stage them with npm run docs:build or continue with --no-verify.',
 				'\n'
 			)
 		);


### PR DESCRIPTION
## What?
PR updates the error message for unstaged API docs to suggest `docs:build` instead of `docs:blocks`.

## Why?
The `docs:blocks` will build only for blocks, while `docs:build` runs a general build.

## Testing Instructions
Update doc block for data selector or actions. Try committing without regeneration docs, and confirm the correct message.
