### PR TITLE
List: improve writing flow

### DIFF
--- a/packages/block-editor/src/components/writing-flow/use-arrow-nav.js
+++ b/packages/block-editor/src/components/writing-flow/use-arrow-nav.js
@@ -101,11 +101,6 @@ export function getClosestTabbable(
 	}
 
 	function isTabCandidate( node ) {
-		// Skip if the current node is the only child.
-		if ( node.children.length === 1 && node.firstElementChild === target ) {
-			return;
-		}
-
 		// Skip if there's only one child that is content editable (and thus a
 		// better candidate).
 		if (

--- a/packages/block-editor/src/components/writing-flow/use-arrow-nav.js
+++ b/packages/block-editor/src/components/writing-flow/use-arrow-nav.js
@@ -17,7 +17,7 @@ import { useRefEffect } from '@wordpress/compose';
 /**
  * Internal dependencies
  */
-import { getBlockClientId } from '../../utils/dom';
+import { getBlockClientId, isInSameBlock } from '../../utils/dom';
 import { store as blockEditorStore } from '../../store';
 
 /**
@@ -105,6 +105,7 @@ export function getClosestTabbable(
 		// better candidate).
 		if (
 			node.children.length === 1 &&
+			isInSameBlock( node, node.firstElementChild ) &&
 			node.firstElementChild.getAttribute( 'contenteditable' ) === 'true'
 		) {
 			return;

--- a/packages/block-editor/src/components/writing-flow/use-arrow-nav.js
+++ b/packages/block-editor/src/components/writing-flow/use-arrow-nav.js
@@ -101,6 +101,20 @@ export function getClosestTabbable(
 	}
 
 	function isTabCandidate( node ) {
+		// Skip if the current node is the only child.
+		if ( node.children.length === 1 && node.firstElementChild === target ) {
+			return;
+		}
+
+		// Skip if there's only one child that is content editable (and thus a
+		// better candidate).
+		if (
+			node.children.length === 1 &&
+			node.firstElementChild.getAttribute( 'contenteditable' ) === 'true'
+		) {
+			return;
+		}
+
 		// Not a candidate if the node is not tabbable.
 		if ( ! focus.tabbable.isTabbableIndex( node ) ) {
 			return false;

--- a/packages/block-library/src/list-item/edit.js
+++ b/packages/block-library/src/list-item/edit.js
@@ -65,6 +65,7 @@ export default function ListItemEdit( {
 	const blockProps = useBlockProps( { ref: useCopy( clientId ) } );
 	const innerBlocksProps = useInnerBlocksProps( blockProps, {
 		allowedBlocks: [ 'core/list' ],
+		renderAppender: false,
 	} );
 	const useEnterRef = useEnter( { content, clientId } );
 	const useSpaceRef = useSpace( clientId );

--- a/packages/e2e-tests/specs/editor/plugins/inner-blocks-allowed-blocks.test.js
+++ b/packages/e2e-tests/specs/editor/plugins/inner-blocks-allowed-blocks.test.js
@@ -77,7 +77,6 @@ describe( 'Allowed Blocks Setting on InnerBlocks', () => {
 		await insertButton.click();
 		// Select the list wrapper so the image is inserable.
 		await page.keyboard.press( 'ArrowUp' );
-		await page.keyboard.press( 'ArrowUp' );
 		await insertBlock( 'Image' );
 		await closeGlobalBlockInserter();
 		await page.waitForSelector( '.product[data-number-of-children="2"]' );

--- a/packages/e2e-tests/specs/editor/various/block-switcher.test.js
+++ b/packages/e2e-tests/specs/editor/various/block-switcher.test.js
@@ -19,7 +19,6 @@ describe( 'Block Switcher', () => {
 		await insertBlock( 'List' );
 		await page.keyboard.type( 'List content' );
 		await page.keyboard.press( 'ArrowUp' );
-		await page.keyboard.press( 'ArrowUp' );
 		await pressKeyWithModifier( 'alt', 'F10' );
 
 		// Verify the block switcher exists.
@@ -46,7 +45,6 @@ describe( 'Block Switcher', () => {
 		// Insert a list block.
 		await insertBlock( 'List' );
 		await page.keyboard.type( 'List content' );
-		await page.keyboard.press( 'ArrowUp' );
 		await page.keyboard.press( 'ArrowUp' );
 		await pressKeyWithModifier( 'alt', 'F10' );
 
@@ -81,7 +79,6 @@ describe( 'Block Switcher', () => {
 		await insertBlock( 'List' );
 		await page.keyboard.type( 'List content' );
 		await page.keyboard.press( 'ArrowUp' );
-		await page.keyboard.press( 'ArrowUp' );
 		await pressKeyWithModifier( 'alt', 'F10' );
 
 		// Verify the block switcher exists.
@@ -96,7 +93,6 @@ describe( 'Block Switcher', () => {
 				await insertBlock( 'List' );
 				await page.keyboard.type( 'List content' );
 				await page.keyboard.press( 'ArrowUp' );
-				await page.keyboard.press( 'ArrowUp' );
 				await insertBlock( 'Heading' );
 				await page.keyboard.type( 'I am a header' );
 				await page.keyboard.down( 'Shift' );
@@ -109,7 +105,6 @@ describe( 'Block Switcher', () => {
 			it( 'Should NOT show Columns transform only if selected blocks are more than max limit(6)', async () => {
 				await insertBlock( 'List' );
 				await page.keyboard.type( 'List content' );
-				await page.keyboard.press( 'ArrowUp' );
 				await page.keyboard.press( 'ArrowUp' );
 				await insertBlock( 'Heading' );
 				await page.keyboard.type( 'I am a header' );

--- a/packages/e2e-tests/specs/editor/various/splitting-merging.test.js
+++ b/packages/e2e-tests/specs/editor/various/splitting-merging.test.js
@@ -235,7 +235,7 @@ describe( 'splitting and merging blocks', () => {
 			await page.keyboard.type( 'item 1' );
 			await page.keyboard.press( 'Enter' );
 			await page.keyboard.type( 'item 2' );
-			await pressKeyTimes( 'ArrowUp', 5 );
+			await pressKeyTimes( 'ArrowUp', 3 );
 			await page.keyboard.press( 'Delete' );
 			// Carret should be in the first block and at the proper position.
 			await page.keyboard.type( '-' );
@@ -256,7 +256,6 @@ describe( 'splitting and merging blocks', () => {
 			await page.keyboard.type( 'item 1' );
 			await page.keyboard.press( 'Enter' );
 			await page.keyboard.type( 'item 2' );
-			await page.keyboard.press( 'ArrowUp' );
 			await page.keyboard.press( 'ArrowUp' );
 			await pressKeyTimes( 'ArrowLeft', 6 );
 			await page.keyboard.press( 'Backspace' );

--- a/test/e2e/specs/editor/blocks/list.spec.js
+++ b/test/e2e/specs/editor/blocks/list.spec.js
@@ -333,7 +333,7 @@ test.describe( 'List', () => {
 		await page.keyboard.press( 'Enter' );
 		await editor.clickBlockToolbarButton( 'Indent' );
 		await page.keyboard.type( 'two' );
-		await pageUtils.pressKeyTimes( 'ArrowUp', 5 );
+		await pageUtils.pressKeyTimes( 'ArrowUp', 4 );
 		await editor.transformBlockTo( 'core/paragraph' );
 
 		await expect.poll( editor.getEditedPostContent ).toBe(
@@ -419,7 +419,6 @@ test.describe( 'List', () => {
 		await page.keyboard.press( 'Enter' );
 		await page.keyboard.type( 'two' );
 		await page.keyboard.press( 'ArrowUp' );
-		await page.keyboard.press( 'ArrowUp' );
 		await page.keyboard.press( 'Enter' );
 
 		await expect.poll( editor.getEditedPostContent ).toBe(
@@ -492,7 +491,6 @@ test.describe( 'List', () => {
 		await page.keyboard.type( '1. one' );
 		await page.keyboard.press( 'Enter' );
 		await page.keyboard.type( 'two' );
-		await page.keyboard.press( 'ArrowUp' );
 		await page.keyboard.press( 'ArrowUp' );
 		await page.keyboard.press( 'Enter' );
 		await page.keyboard.press( 'Enter' );
@@ -682,7 +680,7 @@ test.describe( 'List', () => {
 
 		// To do: investigate why the toolbar is not showing up right after
 		// outdenting.
-		await page.keyboard.press( 'ArrowUp' );
+		await page.keyboard.press( 'ArrowLeft' );
 		await editor.clickBlockToolbarButton( 'Outdent' );
 
 		await expect.poll( editor.getEditedPostContent ).toBe(
@@ -781,7 +779,6 @@ test.describe( 'List', () => {
 		await page.keyboard.type( 'b' );
 		await page.keyboard.press( 'Enter' );
 		await page.keyboard.type( 'c' );
-		await page.keyboard.press( 'ArrowUp' );
 		await page.keyboard.press( 'ArrowUp' );
 		await pageUtils.pressKeyWithModifier( 'shift', 'Enter' );
 
@@ -924,7 +921,7 @@ test.describe( 'List', () => {
 		await page.keyboard.type( '* 1' );
 		await page.keyboard.press( 'Enter' );
 		await page.keyboard.type( ' a' );
-		await pageUtils.pressKeyTimes( 'ArrowUp', 3 );
+		await pageUtils.pressKeyTimes( 'ArrowUp', 2 );
 		await page.keyboard.press( 'Enter' );
 		// The caret should land in the second item.
 		await page.keyboard.type( '2' );
@@ -1025,6 +1022,7 @@ test.describe( 'List', () => {
 
 		// Again create a new paragraph.
 		await page.keyboard.press( 'Enter' );
+		await page.keyboard.press( 'Enter' );
 
 		// Move to the end of the list.
 		await page.keyboard.press( 'ArrowLeft' );
@@ -1057,7 +1055,6 @@ test.describe( 'List', () => {
 		await page.keyboard.type( '* 1' );
 		await page.keyboard.press( 'Enter' );
 		await page.keyboard.type( '2' );
-		await page.keyboard.press( 'ArrowUp' );
 		await page.keyboard.press( 'ArrowUp' );
 		await page.keyboard.press( 'Backspace' );
 		await page.keyboard.press( 'Backspace' );


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?

Currently, when using Arrow keys, the list item wrapper is selected before placing the caret inside the list. This is different from how the previous version worked and it now takes more key presses to navigate through a list.

This happens because we have an extra div wrapper in list items to handle nested lists. While #41655, would fix this, we need a temporary solution for now.

## Why?

Writing flow is worse than before.

## How?

I changed writing flow to skip tubbable elements if that element only contains one child that is editable.

## Testing Instructions

We have pretty good e2e coverage and we'll need to update those tests.

## Screenshots or screencast <!-- if applicable -->
