### PR TITLE
Update: Improve content locking experience.

### DIFF
--- a/packages/block-editor/src/hooks/duotone.js
+++ b/packages/block-editor/src/hooks/duotone.js
@@ -12,6 +12,7 @@ import { getBlockSupport, hasBlockSupport } from '@wordpress/blocks';
 import { createHigherOrderComponent, useInstanceId } from '@wordpress/compose';
 import { addFilter } from '@wordpress/hooks';
 import { useMemo, useContext, createPortal } from '@wordpress/element';
+import { useSelect } from '@wordpress/data';
 
 /**
  * Internal dependencies
@@ -27,6 +28,7 @@ import {
 	__unstableDuotoneStylesheet as DuotoneStylesheet,
 	__unstableDuotoneUnsetStylesheet as DuotoneUnsetStylesheet,
 } from '../components/duotone';
+import { store as blockEditorStore } from '../store';
 
 const EMPTY_ARRAY = [];
 
@@ -157,11 +159,21 @@ const withDuotoneControls = createHigherOrderComponent(
 			props.name,
 			'color.__experimentalDuotone'
 		);
+		const isContentLocked = useSelect(
+			( select ) => {
+				return select(
+					blockEditorStore
+				).__unstableGetContentLockingParent( props.clientId );
+			},
+			[ props.clientId ]
+		);
 
 		return (
 			<>
 				<BlockEdit { ...props } />
-				{ hasDuotoneSupport && <DuotonePanel { ...props } /> }
+				{ hasDuotoneSupport && ! isContentLocked && (
+					<DuotonePanel { ...props } />
+				) }
 			</>
 		);
 	},

--- a/packages/block-library/src/image/edit.js
+++ b/packages/block-library/src/image/edit.js
@@ -137,10 +137,20 @@ export function ImageEdit( {
 	}, [ caption ] );
 
 	const ref = useRef();
-	const { imageDefaultSize, mediaUpload } = useSelect( ( select ) => {
-		const { getSettings } = select( blockEditorStore );
-		return pick( getSettings(), [ 'imageDefaultSize', 'mediaUpload' ] );
-	}, [] );
+	const { imageDefaultSize, mediaUpload, isContentLocked } = useSelect(
+		( select ) => {
+			const { getSettings, __unstableGetContentLockingParent } =
+				select( blockEditorStore );
+			const settings = getSettings();
+			return {
+				imageDefaultSize: settings.imageDefaultSize,
+				mediaUpload: settings.mediaUpload,
+				isContentLocked:
+					!! __unstableGetContentLockingParent( clientId ),
+			};
+		},
+		[]
+	);
 
 	const { createErrorNotice } = useDispatch( noticesStore );
 	function onUploadError( message ) {
@@ -346,9 +356,10 @@ export function ImageEdit( {
 					containerRef={ ref }
 					context={ context }
 					clientId={ clientId }
+					isContentLocked={ isContentLocked }
 				/>
 			) }
-			{ ! url && (
+			{ ! url && ! isContentLocked && (
 				<BlockControls group="block">
 					<BlockAlignmentControl
 						value={ align }

--- a/packages/block-library/src/image/image.js
+++ b/packages/block-library/src/image/image.js
@@ -69,6 +69,7 @@ export default function Image( {
 	containerRef,
 	context,
 	clientId,
+	isContentLocked,
 } ) {
 	const {
 		url = '',
@@ -111,7 +112,7 @@ export default function Image( {
 					),
 			};
 		},
-		[ id, isSelected ]
+		[ id, isSelected, clientId ]
 	);
 	const { canInsertCover, imageEditing, imageSizes, maxWidth, mediaUpload } =
 		useSelect(
@@ -152,7 +153,10 @@ export default function Image( {
 	const [ isEditingImage, setIsEditingImage ] = useState( false );
 	const [ externalBlob, setExternalBlob ] = useState();
 	const clientWidth = useClientWidth( containerRef, [ align ] );
-	const isResizable = allowResize && ! ( isWideAligned && isLargeViewport );
+	const isResizable =
+		allowResize &&
+		! isContentLocked &&
+		! ( isWideAligned && isLargeViewport );
 	const imageSizeOptions = map(
 		filter( imageSizes, ( { slug } ) =>
 			get( image, [ 'media_details', 'sizes', slug, 'source_url' ] )
@@ -309,10 +313,12 @@ export default function Image( {
 	const controls = (
 		<>
 			<BlockControls group="block">
-				<BlockAlignmentControl
-					value={ align }
-					onChange={ updateAlignment }
-				/>
+				{ ! isContentLocked && (
+					<BlockAlignmentControl
+						value={ align }
+						onChange={ updateAlignment }
+					/>
+				) }
 				{ ! multiImageSelection && ! isEditingImage && (
 					<ImageURLInputUI
 						url={ href || '' }


### PR DESCRIPTION
This PR improves the content-locking experience by:
Disabling block alignment on the hook and image block on content-locked blocks.
Disabling the duotone filter on content-locked blocks.


Follow up to https://github.com/WordPress/gutenberg/pull/43037.

cc: @jameskoster 

## Testing Instructions
Pasted the following blocks on the code editor:
```
<!-- wp:group {"templateLock":"noContent","backgroundColor":"pale-cyan-blue","layout":{"type":"default"}} -->
<div class="wp-block-group has-pale-cyan-blue-background-color has-background"><!-- wp:heading {"style":{"typography":{"fontStyle":"normal","fontWeight":"700"}},"backgroundColor":"pale-pink","fontSize":"x-large"} -->
<h2 class="has-pale-pink-background-color has-background has-x-large-font-size" style="font-style:normal;font-weight:700">Heading</h2>
<!-- /wp:heading -->

<!-- wp:paragraph {"backgroundColor":"vivid-red","textColor":"secondary"} -->
<p class="has-secondary-color has-vivid-red-background-color has-text-color has-background">Paragraph</p>
<!-- /wp:paragraph -->

<!-- wp:image {"align":"center","width":239,"height":239,"sizeSlug":"large","style":{"border":{"width":"18px"}}} -->
<figure class="wp-block-image aligncenter size-large is-resized has-custom-border"><img src="https://s.w.org/style/images/about/WordPress-logotype-wmark.png" alt="" style="border-width:18px" width="239" height="239"/></figure>
<!-- /wp:image -->

<!-- wp:spacer {"height":"28px"} -->
<div style="height:28px" aria-hidden="true" class="wp-block-spacer"></div>
<!-- /wp:spacer -->

<!-- wp:group {"backgroundColor":"secondary"} -->
<div class="wp-block-group has-secondary-background-color has-background"><!-- wp:separator -->
<hr class="wp-block-separator has-alpha-channel-opacity"/>
<!-- /wp:separator -->

<!-- wp:spacer {"height":"55px"} -->
<div style="height:55px" aria-hidden="true" class="wp-block-spacer"></div>
<!-- /wp:spacer -->

<!-- wp:pullquote {"gradient":"blush-bordeaux"} -->
<figure class="wp-block-pullquote has-blush-bordeaux-gradient-background has-background"><blockquote><p>End quote inside another group</p></blockquote></figure>
<!-- /wp:pullquote --></div>
<!-- /wp:group --></div>
<!-- /wp:group -->
```
Verified that the image block with the WordPress logo does not has alignment or duotone options.