### PR TITLE
Update: Add __experimentalRole attributes to media text block.

### DIFF
--- a/packages/block-library/src/media-text/block.json
+++ b/packages/block-library/src/media-text/block.json
@@ -17,20 +17,23 @@
 			"source": "attribute",
 			"selector": "figure img",
 			"attribute": "alt",
-			"default": ""
+			"default": "",
+			"__experimentalRole": "content"
 		},
 		"mediaPosition": {
 			"type": "string",
 			"default": "left"
 		},
 		"mediaId": {
-			"type": "number"
+			"type": "number",
+			"__experimentalRole": "content"
 		},
 		"mediaUrl": {
 			"type": "string",
 			"source": "attribute",
 			"selector": "figure video,figure img",
-			"attribute": "src"
+			"attribute": "src",
+			"__experimentalRole": "content"
 		},
 		"mediaLink": {
 			"type": "string"
@@ -48,7 +51,8 @@
 			"type": "string",
 			"source": "attribute",
 			"selector": "figure a",
-			"attribute": "href"
+			"attribute": "href",
+			"__experimentalRole": "content"
 		},
 		"rel": {
 			"type": "string",
@@ -63,7 +67,8 @@
 			"attribute": "class"
 		},
 		"mediaType": {
-			"type": "string"
+			"type": "string",
+			"__experimentalRole": "content"
 		},
 		"mediaWidth": {
 			"type": "number",


### PR DESCRIPTION
Adds missing __experimentalRole attributes to media text block.
This change also makes the media & text a "content block" and allows to change the image when the block is content locked.