### PR TITLE
Update: Make it possible to change list items even if parent is template locked

### DIFF
--- a/packages/block-library/src/list/edit.js
+++ b/packages/block-library/src/list/edit.js
@@ -130,6 +130,7 @@ export default function Edit( { attributes, setAttributes, clientId, style } ) {
 	const innerBlocksProps = useInnerBlocksProps( blockProps, {
 		allowedBlocks: [ 'core/list-item' ],
 		template: TEMPLATE,
+		templateLock: false,
 		templateInsertUpdatesSelection: true,
 		...( Platform.isNative && {
 			marginVertical: NATIVE_MARGIN_SPACING,


### PR DESCRIPTION
Previous as the list block was a single block, it was possible to add and remove list items even if the list block was nested in a block with templateLock="All". Now, if a list is nested inside a block with templateLock we can not add or remove list items.
This is change that may break some blocks using inner blocks. This PR fixes the issue by using templateLock="False" on the list. 


## Testing Instructions
Pasted the following blocks on the code editor:
```
<!-- wp:group {"templateLock":"all","layout":{"type":"constrained"},"lock":{"move":true,"remove":true}} -->
<div class="wp-block-group"><!-- wp:list -->
<ul><!-- wp:list-item -->
<li>1</li>
<!-- /wp:list-item -->

<!-- wp:list-item -->
<li>2</li>
<!-- /wp:list-item --></ul>
<!-- /wp:list --></div>
<!-- /wp:group -->

```
Verified I could add more list items e.g: by pressing enter (on trunk I can't).