### PR TITLE
Add padding and margin support to the gallery block

### DIFF
--- a/docs/reference-guides/core-blocks.md
+++ b/docs/reference-guides/core-blocks.md
@@ -266,7 +266,7 @@ Display multiple images in a rich gallery. ([Source](https://github.com/WordPres
 
 -	**Name:** core/gallery
 -	**Category:** media
--	**Supports:** align, anchor, color (background, gradients, ~~text~~), spacing (blockGap), units (em, px, rem, vh, vw), ~~html~~
+-	**Supports:** align, anchor, color (background, gradients, ~~text~~), spacing (blockGap, margin, padding), units (em, px, rem, vh, vw), ~~html~~
 -	**Attributes:** allowResize, caption, columns, fixedHeight, ids, imageCrop, images, linkTarget, linkTo, shortCodeTransforms, sizeSlug
 
 ## Group

--- a/packages/block-library/src/gallery/block.json
+++ b/packages/block-library/src/gallery/block.json
@@ -110,6 +110,8 @@
 		"html": false,
 		"units": [ "px", "em", "rem", "vh", "vw" ],
 		"spacing": {
+			"margin": true,
+			"padding": true,
 			"blockGap": [ "horizontal", "vertical" ],
 			"__experimentalSkipSerialization": [ "blockGap" ],
 			"__experimentalDefaultControls": {


### PR DESCRIPTION
Related:

- https://github.com/WordPress/gutenberg/issues/43241
- https://github.com/WordPress/gutenberg/issues/43243

## What?
Add padding and margin support to the Gallery block. 

## Why?
To create consistency across blocks.

## How?
Added the relevant block supports in block.json

## Testing Instructions
1. Insert a new Gallery block. 
2. Confirm the Dimension control panel allows you to add both padding and margin.
3. Adding padding and margin. 
4. In global styles add padding and margin to the Gallery block and check it is applied in site editor, block editor and frontend 

## Screenshots or screencast 

https://user-images.githubusercontent.com/3629020/188993711-53f3ac05-5a60-4277-b7f4-09e1d6d2016f.mp4




