### PR TITLE
Add padding and margin support to the Image block

### DIFF
--- a/docs/reference-guides/core-blocks.md
+++ b/docs/reference-guides/core-blocks.md
@@ -311,7 +311,7 @@ Insert an image to make a visual statement. ([Source](https://github.com/WordPre
 
 -	**Name:** core/image
 -	**Category:** media
--	**Supports:** anchor, color (~~background~~, ~~text~~)
+-	**Supports:** anchor, color (~~background~~, ~~text~~), spacing (margin, padding)
 -	**Attributes:** align, alt, caption, height, href, id, linkClass, linkDestination, linkTarget, rel, sizeSlug, title, url, width
 
 ## Latest Comments

--- a/packages/block-library/src/image/block.json
+++ b/packages/block-library/src/image/block.json
@@ -100,6 +100,10 @@
 				"radius": true,
 				"width": true
 			}
+		},
+		"spacing": {
+			"margin": true,
+			"padding": true
 		}
 	},
 	"styles": [

--- a/packages/block-library/src/image/block.json
+++ b/packages/block-library/src/image/block.json
@@ -104,7 +104,8 @@
 		"spacing": {
 			"__experimentalSkipSerialization": true,
 			"margin": true,
-			"padding": true
+			"padding": true,
+			"__experimentalSelector": "img"
 		}
 	},
 	"styles": [

--- a/packages/block-library/src/image/block.json
+++ b/packages/block-library/src/image/block.json
@@ -102,6 +102,7 @@
 			}
 		},
 		"spacing": {
+			"__experimentalSkipSerialization": true,
 			"margin": true,
 			"padding": true
 		}

--- a/packages/block-library/src/image/edit.js
+++ b/packages/block-library/src/image/edit.js
@@ -356,6 +356,7 @@ export function ImageEdit( {
 		<figure
 			{ ...blockProps }
 			style={ {
+				...blockProps.style,
 				...marginStyles,
 			} }
 		>

--- a/packages/block-library/src/image/edit.js
+++ b/packages/block-library/src/image/edit.js
@@ -18,6 +18,7 @@ import {
 	useBlockProps,
 	store as blockEditorStore,
 	__experimentalUseBorderProps as useBorderProps,
+	__experimentalGetSpacingClassesAndStyles as useSpacingProps,
 } from '@wordpress/block-editor';
 import { useEffect, useRef, useState } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
@@ -326,6 +327,17 @@ export function ImageEdit( {
 	);
 
 	const borderProps = useBorderProps( attributes );
+	const spacingProps = useSpacingProps( attributes );
+	const marginStyles = Object.fromEntries(
+		Object.entries( spacingProps?.style ).filter( ( [ key ] ) =>
+			key.includes( 'margin' )
+		)
+	);
+	const paddingStyles = Object.fromEntries(
+		Object.entries( spacingProps?.style ).filter( ( [ key ] ) =>
+			key.includes( 'padding' )
+		)
+	);
 
 	const classes = classnames( className, {
 		'is-transient': temporaryURL,
@@ -341,7 +353,12 @@ export function ImageEdit( {
 	} );
 
 	return (
-		<figure { ...blockProps }>
+		<figure
+			{ ...blockProps }
+			style={ {
+				...marginStyles,
+			} }
+		>
 			{ ( temporaryURL || url ) && (
 				<Image
 					temporaryURL={ temporaryURL }
@@ -357,6 +374,7 @@ export function ImageEdit( {
 					context={ context }
 					clientId={ clientId }
 					isContentLocked={ isContentLocked }
+					paddingStyles={ paddingStyles }
 				/>
 			) }
 			{ ! url && ! isContentLocked && (

--- a/packages/block-library/src/image/image.js
+++ b/packages/block-library/src/image/image.js
@@ -70,6 +70,7 @@ export default function Image( {
 	context,
 	clientId,
 	isContentLocked,
+	paddingStyles,
 } ) {
 	const {
 		url = '',
@@ -459,7 +460,7 @@ export default function Image( {
 				} }
 				ref={ imageRef }
 				className={ borderProps.className }
-				style={ borderProps.style }
+				style={ { ...borderProps.style, ...paddingStyles } }
 			/>
 			{ temporaryURL && <Spinner /> }
 		</>

--- a/packages/block-library/src/image/save.js
+++ b/packages/block-library/src/image/save.js
@@ -12,6 +12,7 @@ import {
 	useBlockProps,
 	__experimentalGetElementClassName,
 	__experimentalGetBorderClassesAndStyles as getBorderClassesAndStyles,
+	__experimentalGetSpacingClassesAndStyles as getSpacingClassesAndStyles,
 } from '@wordpress/block-editor';
 
 export default function save( { attributes } ) {
@@ -33,7 +34,17 @@ export default function save( { attributes } ) {
 
 	const newRel = isEmpty( rel ) ? undefined : rel;
 	const borderProps = getBorderClassesAndStyles( attributes );
-
+	const spacingProps = getSpacingClassesAndStyles( attributes );
+	const marginStyles = Object.fromEntries(
+		Object.entries( spacingProps?.style ).filter( ( [ key ] ) =>
+			key.includes( 'margin' )
+		)
+	);
+	const paddingStyles = Object.fromEntries(
+		Object.entries( spacingProps?.style ).filter( ( [ key ] ) =>
+			key.includes( 'padding' )
+		)
+	);
 	const classes = classnames( {
 		[ `align${ align }` ]: align,
 		[ `size-${ sizeSlug }` ]: sizeSlug,
@@ -51,7 +62,7 @@ export default function save( { attributes } ) {
 			src={ url }
 			alt={ alt }
 			className={ imageClasses || undefined }
-			style={ borderProps.style }
+			style={ { ...borderProps.style, ...paddingStyles } }
 			width={ width }
 			height={ height }
 			title={ title }
@@ -83,7 +94,10 @@ export default function save( { attributes } ) {
 	);
 
 	return (
-		<figure { ...useBlockProps.save( { className: classes } ) }>
+		<figure
+			{ ...useBlockProps.save( { className: classes } ) }
+			style={ marginStyles }
+		>
 			{ figure }
 		</figure>
 	);

--- a/packages/block-library/src/image/save.js
+++ b/packages/block-library/src/image/save.js
@@ -92,12 +92,9 @@ export default function save( { attributes } ) {
 			) }
 		</>
 	);
-
+	const { style, ...props } = useBlockProps.save( { className: classes } );
 	return (
-		<figure
-			{ ...useBlockProps.save( { className: classes } ) }
-			style={ marginStyles }
-		>
+		<figure { ...props } style={ { ...style, ...marginStyles } }>
 			{ figure }
 		</figure>
 	);


### PR DESCRIPTION
Related:

- https://github.com/WordPress/gutenberg/issues/43241
- https://github.com/WordPress/gutenberg/issues/43243

## What?
Add padding and margin support to the Image block. 

## Why?
To create consistency across blocks.

## How?
Added the relevant block supports in block.json

## Testing Instructions
1. Insert a new Image block. 
2. Confirm the Dimension control panel allows you to add both padding and margin.
3. Add padding and margin and check it is applied in editor and frontend.
4. In global styles add padding and margin to the Image block and check it is applied in site editor, block editor and frontend 

## Screenshots or screencast 

https://user-images.githubusercontent.com/3629020/189002032-6e19c620-f2dd-4735-b0b0-fa868f85e243.mp4



