### PR TITLE
Typography block supports: call tear_down in tests and format PHP doc blocks

### DIFF
--- a/lib/block-supports/typography.php
+++ b/lib/block-supports/typography.php
@@ -234,11 +234,13 @@ function gutenberg_typography_get_css_variable_inline_style( $attributes, $featu
  * @access private
  *
  * @param string $raw_value Raw size value from theme.json.
- * @param array  $options    array(
- *      'coerce_to'        => (string) Coerce the value to rem or px. Default `'rem'`.
- *      'root_size_value'  => (number) Value of root font size for rem|em <-> px conversion. Default `16`.
- *      'acceptable_units' => (array)  An array of font size units. Default `[ 'rem', 'px', 'em' ]`;
- *  );.
+ * @param array  $options   {
+ *     Optional. An associative array of options. Default is empty array.
+ *
+ *     @type string        $coerce_to        Coerce the value to rem or px. Default `'rem'`.
+ *     @type int           $root_size_value  Value of root font size for rem|em <-> px conversion. Default `16`.
+ *     @type array<string> $acceptable_units An array of font size units. Default `[ 'rem', 'px', 'em' ]`;
+ * }
  * @return array An array consisting of `'value'` and `'unit'` properties.
  */
 function gutenberg_get_typography_value_and_unit( $raw_value, $options = array() ) {
@@ -289,13 +291,15 @@ function gutenberg_get_typography_value_and_unit( $raw_value, $options = array()
  *
  * @access private
  *
- * @param array $args array(
- *     'maximum_viewport_width' => (string) Maximum size up to which type will have fluidity.
- *     'minimum_viewport_width' => (string) Minimum viewport size from which type will have fluidity.
- *     'maximum_font_size'      => (string) Maximum font size for any clamp() calculation.
- *     'minimum_font_size'      => (string) Minimum font size for any clamp() calculation.
- *     'scale_factor'           => (number) A scale factor to determine how fast a font scales within boundaries.
- * );.
+ * @param array $args {
+ *     Optional. An associative array of values to calculate a fluid formula for font size. Default is empty array.
+ *
+ *     @type string $maximum_viewport_width Maximum size up to which type will have fluidity.
+ *     @type string $minimum_viewport_width Minimum viewport size from which type will have fluidity.
+ *     @type string $maximum_font_size      Maximum font size for any clamp() calculation.
+ *     @type string $minimum_font_size      Minimum font size for any clamp() calculation.
+ *     @type int    $scale_factor           A scale factor to determine how fast a font scales within boundaries.
+ * }
  * @return string|null A font-size value using clamp().
  */
 function gutenberg_get_computed_fluid_typography_value( $args = array() ) {
@@ -361,8 +365,15 @@ function gutenberg_get_computed_fluid_typography_value( $args = array() ) {
  * Returns a font-size value based on a given font-size preset.
  * Takes into account fluid typography parameters and attempts to return a css formula depending on available, valid values.
  *
- * @param array   $preset                      fontSizes preset value as seen in theme.json.
- * @param boolean $should_use_fluid_typography An override to switch fluid typography "on". Can be used for unit testing.
+ * @param array $preset                     {
+ *     Required. fontSizes preset value as seen in theme.json.
+ *
+ *     @type string $name Name of the font size preset.
+ *     @type string $slug Kebab-case unique identifier for the font size preset.
+ *     @type string $size CSS font-size value, including units where applicable.
+ * }
+ * @param bool  $should_use_fluid_typography An override to switch fluid typography "on". Can be used for unit testing. Default is `false`.
+ *
  * @return string Font-size value.
  */
 function gutenberg_get_typography_font_size_value( $preset, $should_use_fluid_typography = false ) {

--- a/phpunit/block-supports/typography-test.php
+++ b/phpunit/block-supports/typography-test.php
@@ -1,29 +1,40 @@
 <?php
-
 /**
- * Test the typography block supports.
+ * Tests the typography block supports.
  *
  * @package Gutenberg
  */
-
 class WP_Block_Supports_Typography_Test extends WP_UnitTestCase {
 	/**
+	 * Stores the current test block name.
+	 *
 	 * @var string|null
 	 */
 	private $test_block_name;
 
+	/**
+	 * Sets up tests.
+	 */
 	function set_up() {
 		parent::set_up();
 		$this->test_block_name = null;
 	}
 
+	/**
+	 * Tears down tests.
+	 */
 	function tear_down() {
 		unregister_block_type( $this->test_block_name );
 		$this->test_block_name = null;
 		parent::tear_down();
 	}
 
-	function test_font_size_slug_with_numbers_is_kebab_cased_properly() {
+	/**
+	 * Tests whether slugs with numbers are kebab cased.
+	 *
+	 * @covers ::wp_apply_typography_support
+	 */
+	function test_should_kebab_case_font_size_slug_with_numbers() {
 		$this->test_block_name = 'test/font-size-slug-with-numbers';
 		register_block_type(
 			$this->test_block_name,
@@ -52,7 +63,12 @@ class WP_Block_Supports_Typography_Test extends WP_UnitTestCase {
 		$this->assertSame( $expected, $actual );
 	}
 
-	function test_font_family_with_legacy_inline_styles_using_a_value() {
+	/**
+	 * Tests legacy inline styles for font family.
+	 *
+	 * @covers ::wp_apply_typography_support
+	 */
+	function test_should_generate_font_family_with_legacy_inline_styles_using_a_value() {
 		$this->test_block_name = 'test/font-family-with-inline-styles-using-value';
 		register_block_type(
 			$this->test_block_name,
@@ -80,7 +96,12 @@ class WP_Block_Supports_Typography_Test extends WP_UnitTestCase {
 		$this->assertSame( $expected, $actual );
 	}
 
-	function test_typography_with_skipped_serialization_block_supports() {
+	/**
+	 * Tests skipping serialization.
+	 *
+	 * @covers ::wp_apply_typography_support
+	 */
+	function test_should_skip_serialization_for_typography_block_supports() {
 		$this->test_block_name = 'test/typography-with-skipped-serialization-block-supports';
 		register_block_type(
 			$this->test_block_name,
@@ -121,7 +142,12 @@ class WP_Block_Supports_Typography_Test extends WP_UnitTestCase {
 		$this->assertSame( $expected, $actual );
 	}
 
-	function test_letter_spacing_with_individual_skipped_serialization_block_supports() {
+	/**
+	 * Tests skipping serialization of individual block supports properties.
+	 *
+	 * @covers ::wp_apply_typography_support
+	 */
+	function test_should_skip_serialization_for_letter_spacing_block_supports() {
 		$this->test_block_name = 'test/letter-spacing-with-individual-skipped-serialization-block-supports';
 		register_block_type(
 			$this->test_block_name,
@@ -152,7 +178,12 @@ class WP_Block_Supports_Typography_Test extends WP_UnitTestCase {
 		$this->assertSame( $expected, $actual );
 	}
 
-	function test_font_family_with_legacy_inline_styles_using_a_css_var() {
+	/**
+	 * Tests legacy css var inline styles for font family.
+	 *
+	 * @covers ::wp_apply_typography_support
+	 */
+	function test_should_generate_css_var_for_font_family_with_legacy_inline_styles() {
 		$this->test_block_name = 'test/font-family-with-inline-styles-using-css-var';
 		register_block_type(
 			$this->test_block_name,
@@ -180,7 +211,12 @@ class WP_Block_Supports_Typography_Test extends WP_UnitTestCase {
 		$this->assertSame( $expected, $actual );
 	}
 
-	function test_font_family_with_class() {
+	/**
+	 * Tests that a classname is generated for font family.
+	 *
+	 * @covers ::wp_apply_typography_support
+	 */
+	function test_should_generate_classname_for_font_family() {
 		$this->test_block_name = 'test/font-family-with-class';
 		register_block_type(
 			$this->test_block_name,
@@ -211,7 +247,21 @@ class WP_Block_Supports_Typography_Test extends WP_UnitTestCase {
 	/**
 	 * Tests generating font size values, including fluid formulae, from fontSizes preset.
 	 *
+	 * @covers ::wp_get_typography_font_size_value
+	 * @covers ::wp_get_typography_value_and_unit
+	 * @covers ::wp_get_computed_fluid_typography_value
+	 *
 	 * @dataProvider data_generate_font_size_preset_fixtures
+	 *
+	 * @param array  $font_size_preset                     {
+	 *      Required. fontSizes preset value as seen in theme.json.
+	 *
+	 *     @type string $name Name of the font size preset.
+	 *     @type string $slug Kebab-case unique identifier for the font size preset.
+	 *     @type string $size CSS font-size value, including units where applicable.
+	 * }
+	 * @param bool   $should_use_fluid_typography An override to switch fluid typography "on". Can be used for unit testing.
+	 * @param string $expected_output Expected output of gutenberg_get_typography_font_size_value().
 	 */
 	function test_gutenberg_get_typography_font_size_value( $font_size_preset, $should_use_fluid_typography, $expected_output ) {
 		$actual = gutenberg_get_typography_font_size_value( $font_size_preset, $should_use_fluid_typography );
@@ -220,7 +270,7 @@ class WP_Block_Supports_Typography_Test extends WP_UnitTestCase {
 	}
 
 	/**
-	 * Data provider.
+	 * Data provider for test_wp_get_typography_font_size_value.
 	 *
 	 * @return array
 	 */


### PR DESCRIPTION

## What?

- Standardizing PHP doc comments for tests and new methods.
- Replaced parent::set_up(); with parent::tear_down();.

## Why?
I found some issues while backporting to Core: https://github.com/WordPress/wordpress-develop/pull/3203



## Testing Instructions
Tests should pass!
No typos! 🤞 
