### PR TITLE
Calendar: Add typography supports (except text-decoration)

### DIFF
--- a/docs/reference-guides/core-blocks.md
+++ b/docs/reference-guides/core-blocks.md
@@ -68,7 +68,7 @@ A calendar of your site’s posts. ([Source](https://github.com/WordPress/gutenb
 
 -	**Name:** core/calendar
 -	**Category:** widgets
--	**Supports:** align
+-	**Supports:** align, typography (fontSize, lineHeight)
 -	**Attributes:** month, year
 
 ## Categories List

--- a/packages/block-library/src/calendar/block.json
+++ b/packages/block-library/src/calendar/block.json
@@ -16,7 +16,19 @@
 		}
 	},
 	"supports": {
-		"align": true
+		"align": true,
+		"typography": {
+			"fontSize": true,
+			"lineHeight": true,
+			"__experimentalFontFamily": true,
+			"__experimentalFontWeight": true,
+			"__experimentalFontStyle": true,
+			"__experimentalTextTransform": true,
+			"__experimentalLetterSpacing": true,
+			"__experimentalDefaultControls": {
+				"fontSize": true
+			}
+		}
 	},
 	"style": "wp-block-calendar"
 }


### PR DESCRIPTION
Related:
- https://github.com/WordPress/gutenberg/issues/43241
- https://github.com/WordPress/gutenberg/issues/43242

## What?

Adds typography support to the Calendar block (except text-decoration).

**Note: Text decoration support was deliberately omitted as it would conflict with how the Calendar block displays dates with active links etc**

## Why?

- Allows for typographic styling of the Calendar block.
- Improves consistency of our design tools across blocks.

## How?

- Opts into all typography supports except text-decoration.
- Only the font size control will display by default.

## Testing Instructions

1. Edit a post, add an Calendar block and select it.
2. The font size control should be displayed by default.
3. Test various typography settings ensuring styles are applied in the editor.
4. Confirm text decoration support isn't available,
5. Save and confirm the application of styles on the frontend.
6. Switch to the site editor, and select a page or template with an Calendar block.
7. Navigate to Global Styles > Blocks > Calendar > Typography and apply typography styles there.
8. Confirm the selected styles are reflected in the preview and on the frontend.
9. Test theme.json styling of the block.

Example theme.json snippet
```json
			"core/calendar": {
				"typography": {
					"fontFamily": "var(--wp--preset--font-family--source-serif-pro)",
					"fontWeight": "100",
					"fontStyle": "italic",
					"lineHeight": "var(--wp--custom--typography--line-height--tiny)",
					"fontSize": "var(--wp--custom--typography--font-size--gigantic)",
					"letterSpacing": "2px"
				}
			},
```


## Screenshots or screencast <!-- if applicable -->



https://user-images.githubusercontent.com/60436221/189061687-bd093243-d823-45db-b9ab-53dd4451f606.mp4



