### PR TITLE
Add icons for different types of suggestions in LinkControl

### DIFF
--- a/packages/block-editor/src/components/link-control/search-item.js
+++ b/packages/block-editor/src/components/link-control/search-item.js
@@ -9,7 +9,44 @@ import classnames from 'classnames';
 import { safeDecodeURI, filterURLForDisplay } from '@wordpress/url';
 import { __ } from '@wordpress/i18n';
 import { Button, TextHighlight } from '@wordpress/components';
-import { Icon, globe } from '@wordpress/icons';
+import {
+	Icon,
+	globe,
+	page,
+	tag,
+	postList,
+	category,
+	file,
+} from '@wordpress/icons';
+
+function SearchItemIcon( { isURL, suggestion } ) {
+	let icon = null;
+
+	if ( isURL ) {
+		icon = globe;
+	} else if ( suggestion.type === 'post' ) {
+		icon = postList;
+	} else if ( suggestion.type === 'page' ) {
+		icon = page;
+	} else if ( suggestion.type === 'post_tag' ) {
+		icon = tag;
+	} else if ( suggestion.type === 'category' ) {
+		icon = category;
+	} else if ( suggestion.type === 'attachment' ) {
+		icon = file;
+	}
+
+	if ( icon ) {
+		return (
+			<Icon
+				className="block-editor-link-control__search-item-icon"
+				icon={ icon }
+			/>
+		);
+	}
+
+	return null;
+}
 
 export const LinkControlSearchItem = ( {
 	itemProps,
@@ -30,12 +67,7 @@ export const LinkControlSearchItem = ( {
 				'is-entity': ! isURL,
 			} ) }
 		>
-			{ isURL && (
-				<Icon
-					className="block-editor-link-control__search-item-icon"
-					icon={ globe }
-				/>
-			) }
+			<SearchItemIcon suggestion={ suggestion } isURL={ isURL } />
 
 			<span className="block-editor-link-control__search-item-header">
 				<span className="block-editor-link-control__search-item-title">

--- a/packages/block-editor/src/components/link-control/search-item.js
+++ b/packages/block-editor/src/components/link-control/search-item.js
@@ -19,21 +19,21 @@ import {
 	file,
 } from '@wordpress/icons';
 
+const ICONS_MAP = {
+	post: postList,
+	page,
+	post_tag: tag,
+	category,
+	attachment: file,
+};
+
 function SearchItemIcon( { isURL, suggestion } ) {
 	let icon = null;
 
 	if ( isURL ) {
 		icon = globe;
-	} else if ( suggestion.type === 'post' ) {
-		icon = postList;
-	} else if ( suggestion.type === 'page' ) {
-		icon = page;
-	} else if ( suggestion.type === 'post_tag' ) {
-		icon = tag;
-	} else if ( suggestion.type === 'category' ) {
-		icon = category;
-	} else if ( suggestion.type === 'attachment' ) {
-		icon = file;
+	} else if ( suggestion.type in ICONS_MAP ) {
+		icon = ICONS_MAP[ suggestion.type ];
 	}
 
 	if ( icon ) {


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->
Add icons for different types of suggestions in `<LinkControl>`.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
An idea grabbed from https://github.com/WordPress/gutenberg/issues/38121#issuecomment-1018249500. Seems like a free win to create a better UX IMO. WDYT?

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
Leveraging `@wordpress/icons`.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->
1. Create a navigation block and add a new link to open the LinkControl dropdown (or any other ways)
2. Type to search for different suggestions
3. Notice the icons in front of the result

## Screenshots or screencast <!-- if applicable -->

![image](https://user-images.githubusercontent.com/7753001/189063651-3932b46c-a2fa-4bf4-a6ec-31c94c991c08.png) ![image](https://user-images.githubusercontent.com/7753001/189063716-8b3a296d-6238-49ac-ad73-774fea252ef2.png) ![image](https://user-images.githubusercontent.com/7753001/189063774-09ebdeec-18cb-43c6-a848-17e29d6ec95f.png) ![image](https://user-images.githubusercontent.com/7753001/189069084-c51f42c0-3155-4a84-8245-f75716119831.png)

