### PR TITLE
Site editor: fix padding and margin visualizer positioning

### DIFF
--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -13,6 +13,7 @@
 -   `Popover`: enable auto-updating every animation frame ([#43617](https://github.com/WordPress/gutenberg/pull/43617)).
 -   `Popover`: improve the component's performance and reactivity to prop changes by reworking its internals ([#43335](https://github.com/WordPress/gutenberg/pull/43335)).
 -   `NavigatorScreen`: updated to satisfy `react/exhaustive-deps` eslint rule ([#43876](https://github.com/WordPress/gutenberg/pull/43876))
+-   `Popover`: fix positioning when reference and floating elements are both within an iframe ([#43971](https://github.com/WordPress/gutenberg/pull/43971))
 
 ### Enhancements
 

--- a/packages/components/src/popover/index.tsx
+++ b/packages/components/src/popover/index.tsx
@@ -425,7 +425,7 @@ const UnforwardedPopover = (
 			// Reference and floating are in the same document.
 			referenceOwnerDocument === floatingOwnerDocument ||
 			// The reference's document has no view (i.e. window)
-			// or frame element (ie. it's an iframe).
+			// or frame element (ie. it's not an iframe).
 			! referenceOwnerDocument?.defaultView?.frameElement
 		) {
 			frameOffsetRef.current = undefined;

--- a/packages/components/src/popover/index.tsx
+++ b/packages/components/src/popover/index.tsx
@@ -39,7 +39,6 @@ import {
 import {
 	useViewportMatch,
 	useMergeRefs,
-	useRefEffect,
 	__experimentalUseDialog as useDialog,
 } from '@wordpress/compose';
 import { close } from '@wordpress/icons';
@@ -231,9 +230,6 @@ const UnforwardedPopover = (
 	const [ referenceOwnerDocument, setReferenceOwnerDocument ] = useState<
 		Document | undefined
 	>();
-	const [ floatingOwnerDocument, setFloatingOwnerDocument ] = useState<
-		Document | undefined
-	>();
 
 	const anchorRefFallback: RefCallback< HTMLSpanElement > = useCallback(
 		( node ) => {
@@ -423,7 +419,7 @@ const UnforwardedPopover = (
 			// Reference and root documents are the same.
 			referenceOwnerDocument === document ||
 			// Reference and floating are in the same document.
-			referenceOwnerDocument === floatingOwnerDocument ||
+			referenceOwnerDocument === refs?.floating?.current?.ownerDocument ||
 			// The reference's document has no view (i.e. window)
 			// or frame element (ie. it's not an iframe).
 			! referenceOwnerDocument?.defaultView?.frameElement
@@ -445,18 +441,12 @@ const UnforwardedPopover = (
 		return () => {
 			defaultView.removeEventListener( 'resize', updateFrameOffset );
 		};
-	}, [ referenceOwnerDocument, floatingOwnerDocument, update ] );
-
-	const updateFloatingOwnerDocument = useRefEffect( ( node ) => {
-		setFloatingOwnerDocument( node.ownerDocument ?? undefined );
-		return () => setFloatingOwnerDocument( undefined );
-	}, [] );
+	}, [ referenceOwnerDocument, update ] );
 
 	const mergedFloatingRef = useMergeRefs( [
 		floating,
 		dialogRef,
 		forwardedRef,
-		updateFloatingOwnerDocument,
 	] );
 
 	// Disable reason: We care to capture the _bubbled_ events from inputs


### PR DESCRIPTION
## What?
Fixes #41823

TLDR - Ensures `frameOffset` is not applied for popovers that render inline in the site editor's iframe.

Longer explanation:
The site editor has its content within an iframe, and usually most popovers (like the block toolbar) render in the main document. An x/y offset needs to be applied to these popovers so that they're in the correct position on the screen.

There are two situations where this offset doesn't need to be applied. If the popover and its anchor/reference are both not in the iframe (for example, a popover for the block inspector). Or if the popover and its anchor/reference are both in the iframe. The latter is the situation for the padding margin visualizers—they need to be rendered in the site editor's iframe so that they have access to the padding/margin CSS variables for content. But they were still incorrectly receiving the iframe offset.

## How?
Adds an extra check to see if the popover and its reference/anchor element are in the same document. This required gaining access to the floating element's owner document, which adds a little bit of extra code.

## Testing Instructions
1. Open the site editor
2. Insert a cover block
3. Adjust padding / margin
4. The visualizers should match the block position

## Screenshots or screencast <!-- if applicable -->

### Before
![Screen Shot 2022-09-08 at 4 30 22 pm](https://user-images.githubusercontent.com/677833/189074733-250649aa-0dfd-4f43-b31f-7069b448b8ad.png)

### After
![Screen Shot 2022-09-08 at 4 29 51 pm](https://user-images.githubusercontent.com/677833/189074762-73ad1f22-6b16-46a4-a95c-e5355b7644b4.png)

