### PR TITLE
Site Title and Tagline: Add text decoration support

### DIFF
--- a/packages/block-library/src/site-tagline/block.json
+++ b/packages/block-library/src/site-tagline/block.json
@@ -31,6 +31,7 @@
 			"lineHeight": true,
 			"__experimentalFontFamily": true,
 			"__experimentalTextTransform": true,
+			"__experimentalTextDecoration": true,
 			"__experimentalFontStyle": true,
 			"__experimentalFontWeight": true,
 			"__experimentalLetterSpacing": true,

--- a/packages/block-library/src/site-title/block.json
+++ b/packages/block-library/src/site-title/block.json
@@ -47,6 +47,7 @@
 			"lineHeight": true,
 			"__experimentalFontFamily": true,
 			"__experimentalTextTransform": true,
+			"__experimentalTextDecoration": true,
 			"__experimentalFontStyle": true,
 			"__experimentalFontWeight": true,
 			"__experimentalLetterSpacing": true,


### PR DESCRIPTION
Related:
- https://github.com/WordPress/gutenberg/issues/43241
- https://github.com/WordPress/gutenberg/issues/43242

## What?

Adds missing text-decoration block support to Site Title and Site Tagline blocks.

## Why?

- Improves consistency of our design tools across blocks.

## How?

- Opts into missing text-decoration typography support for Site Title and Site Tagline blocks.

## Testing Instructions

1. Edit a post, add both a Site Title and Site Tagline block.
2. Select the Site Title block and ensure the text decoration control isn't displayed by default.
3. Confirm text decoration for the Site Title block works in both the editor and frontend.
4. Repeat steps 2-3 for the Site Tagline block.
5. Confirm that you can set text decoration in the global styles for both Site Title and Site Tagline.
6. Test that you can apply text decoration to both blocks via theme.json

Example theme.json snippet:
```json
			"core/site-title": {
				"typography": {
					"textDecoration": "line-through"
				}
			},
			"core/site-tagline": {
				"typography": {
					"textDecoration": "line-through"
				}
			}
```

## Screenshots or screencast <!-- if applicable -->


https://user-images.githubusercontent.com/60436221/189089036-2a5095e9-fc6f-43e3-b7d2-0633f148609c.mp4


