### PR TITLE
Editor: Refactor `PostSlug` tests to `@testing-library/react`

### DIFF
--- a/packages/editor/src/components/post-slug/test/index.js
+++ b/packages/editor/src/components/post-slug/test/index.js
@@ -1,12 +1,8 @@
 /**
  * External dependencies
  */
-import { shallow } from 'enzyme';
-
-/**
- * WordPress dependencies
- */
-import { TextControl } from '@wordpress/components';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 
 /**
  * Internal dependencies
@@ -14,28 +10,19 @@ import { TextControl } from '@wordpress/components';
 import { PostSlug } from '../';
 
 describe( 'PostSlug', () => {
-	describe( '#render()', () => {
-		it( 'should update internal slug', () => {
-			const wrapper = shallow( <PostSlug postSlug="index" /> );
-
-			wrapper.find( TextControl ).prop( 'onChange' )( 'single' );
-
-			expect( wrapper.state().editedSlug ).toEqual( 'single' );
+	it( 'should update slug with sanitized input', async () => {
+		const user = userEvent.setup( {
+			advanceTimers: jest.advanceTimersByTime,
 		} );
+		const onUpdateSlug = jest.fn();
 
-		it( 'should update slug', () => {
-			const onUpdateSlug = jest.fn();
-			const wrapper = shallow(
-				<PostSlug postSlug="index" onUpdateSlug={ onUpdateSlug } />
-			);
+		render( <PostSlug postSlug="index" onUpdateSlug={ onUpdateSlug } /> );
 
-			wrapper.find( TextControl ).prop( 'onBlur' )( {
-				target: {
-					value: 'single',
-				},
-			} );
+		const input = screen.getByRole( 'textbox', { name: 'Slug' } );
+		await user.clear( input );
+		await user.type( input, 'Foo Bar-Baz 9!' );
+		input.blur();
 
-			expect( onUpdateSlug ).toHaveBeenCalledWith( 'single' );
-		} );
+		expect( onUpdateSlug ).toHaveBeenCalledWith( 'foo-bar-baz-9' );
 	} );
 } );


### PR DESCRIPTION
## What?
We've recently started refactoring `enzyme` tests to `@testing-library/react`.

This PR refactors the `<PostSlug />` component tests from `enzyme` to `@testing-library/react`.

## Why?
`@testing-library/react` provides a better way to write tests for accessible components that is closer to the way the user experiences them.

## How?
We're straightforwardly replacing `enzyme` tests with `@testing-library/react` ones, using `jest-dom` matchers and mocks to avoid testing unrelated implementation details.

## Testing Instructions
Verify tests pass: `npm run test:unit packages/editor/src/components/post-slug/test/index.js`
