### PR TITLE
Table: Add missing typography supports

### DIFF
--- a/packages/block-library/src/table/block.json
+++ b/packages/block-library/src/table/block.json
@@ -141,10 +141,12 @@
 		"typography": {
 			"fontSize": true,
 			"lineHeight": true,
+			"__experimentalFontFamily": true,
 			"__experimentalFontStyle": true,
 			"__experimentalFontWeight": true,
 			"__experimentalLetterSpacing": true,
 			"__experimentalTextTransform": true,
+			"__experimentalTextDecoration": true,
 			"__experimentalDefaultControls": {
 				"fontSize": true
 			}


### PR DESCRIPTION
Related:
- https://github.com/WordPress/gutenberg/issues/43241
- https://github.com/WordPress/gutenberg/issues/43242

## What?

Adds missing typography supports to the Table block.

## Why?

- Improves consistency of our design tools across blocks.

## How?

- Opts into missing font-family and text-decoration typography support.

## Testing Instructions

1. Edit a post, add a Table block, select it and enter some content.
2. Check that the font-family and text-decoration controls are now available.
2. Test various typography settings ensuring styles are applied in the editor.
3. Save and confirm their application on the frontend.
4. Test styling via theme.json and global styles (Note: Text decoration is deliberately not available in Global Styles).

Example theme.json snippet:
```json
			"core/table": {
				"typography": {
					"fontFamily": "var(--wp--preset--font-family--source-serif-pro)",
					"textDecoration": "line-through"
				}
			}
```

## Screenshots or screencast <!-- if applicable -->



https://user-images.githubusercontent.com/60436221/189092261-bc80cd7c-ee32-47b6-8668-c2121354649e.mp4

