### PR TITLE
Document `template_lock=noContent` for Custom Post Types

### DIFF
--- a/docs/reference-guides/block-api/block-templates.md
+++ b/docs/reference-guides/block-api/block-templates.md
@@ -115,6 +115,7 @@ add_action( 'init', 'myplugin_register_template' );
 
 _Options:_
 
+-   `noContent` — prevents all operations. Additionally, the block types that don't have content are hidden from the list view and can't gain focus within the block list. Unlike the other lock types, this is not overrideable by children.
 -   `all` — prevents all operations. It is not possible to insert new blocks, move existing blocks, or delete blocks.
 -   `insert` — prevents inserting or removing blocks, but allows moving existing blocks.
 


### PR DESCRIPTION
## What

This PR documents the new lock state `noContent` for `templateLock`. It has been introduced https://github.com/WordPress/gutenberg/pull/43037/#discussion_r961889140 and the same state for inner blocks has been documented https://github.com/WordPress/gutenberg/pull/43825

## Why

We need the documentation to reflect the current state of locking.
