### PR TITLE
Edit Post: Refactor `BrowserURL` tests to `@testing-library/react`

### DIFF
--- a/packages/edit-post/src/components/browser-url/test/index.js
+++ b/packages/edit-post/src/components/browser-url/test/index.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { shallow } from 'enzyme';
+import { render } from '@testing-library/react';
 
 /**
  * Internal dependencies
@@ -40,24 +40,19 @@ describe( 'BrowserURL', () => {
 	} );
 
 	it( 'not update URL if post is auto-draft', () => {
-		const wrapper = shallow( <BrowserURL /> );
-		wrapper.setProps( {
-			postId: 1,
-			postStatus: 'auto-draft',
-		} );
+		const { rerender } = render( <BrowserURL /> );
+
+		rerender( <BrowserURL postId={ 1 } postStatus="auto-draft" /> );
 
 		expect( replaceStateSpy ).not.toHaveBeenCalled();
 	} );
 
 	it( 'update URL if post is no longer auto-draft', () => {
-		const wrapper = shallow( <BrowserURL /> );
-		wrapper.setProps( {
-			postId: 1,
-			postStatus: 'auto-draft',
-		} );
-		wrapper.setProps( {
-			postStatus: 'draft',
-		} );
+		const { rerender } = render( <BrowserURL /> );
+
+		rerender( <BrowserURL postId={ 1 } postStatus="auto-draft" /> );
+
+		rerender( <BrowserURL postId={ 1 } postStatus="draft" /> );
 
 		expect( replaceStateSpy ).toHaveBeenCalledWith(
 			{ id: 1 },
@@ -67,29 +62,25 @@ describe( 'BrowserURL', () => {
 	} );
 
 	it( 'not update URL if history is already set', () => {
-		const wrapper = shallow( <BrowserURL /> );
-		wrapper.setProps( {
-			postId: 1,
-			postStatus: 'draft',
-		} );
+		const { rerender } = render( <BrowserURL /> );
+
+		rerender( <BrowserURL postId={ 1 } postStatus="draft" /> );
+
+		rerender( <BrowserURL postId={ 1 } postStatus="draft" /> );
+
 		replaceStateSpy.mockReset();
-		wrapper.setProps( {
-			postId: 1,
-		} );
 
 		expect( replaceStateSpy ).not.toHaveBeenCalled();
 	} );
 
 	it( 'update URL if post ID changes', () => {
-		const wrapper = shallow( <BrowserURL /> );
-		wrapper.setProps( {
-			postId: 1,
-			postStatus: 'draft',
-		} );
+		const { rerender } = render( <BrowserURL /> );
+
+		rerender( <BrowserURL postId={ 1 } postStatus="draft" /> );
+
 		replaceStateSpy.mockReset();
-		wrapper.setProps( {
-			postId: 2,
-		} );
+
+		rerender( <BrowserURL postId={ 2 } postStatus="draft" /> );
 
 		expect( replaceStateSpy ).toHaveBeenCalledWith(
 			{ id: 2 },
@@ -99,8 +90,8 @@ describe( 'BrowserURL', () => {
 	} );
 
 	it( 'renders nothing', () => {
-		const wrapper = shallow( <BrowserURL /> );
+		const { container } = render( <BrowserURL /> );
 
-		expect( wrapper.type() ).toBeNull();
+		expect( container ).toBeEmptyDOMElement();
 	} );
 } );

--- a/packages/edit-post/src/components/browser-url/test/index.js
+++ b/packages/edit-post/src/components/browser-url/test/index.js
@@ -66,9 +66,9 @@ describe( 'BrowserURL', () => {
 
 		rerender( <BrowserURL postId={ 1 } postStatus="draft" /> );
 
-		rerender( <BrowserURL postId={ 1 } postStatus="draft" /> );
-
 		replaceStateSpy.mockReset();
+
+		rerender( <BrowserURL postId={ 1 } postStatus="draft" /> );
 
 		expect( replaceStateSpy ).not.toHaveBeenCalled();
 	} );


### PR DESCRIPTION
## What?
We've recently started refactoring `enzyme` tests to `@testing-library/react`.

This PR refactors the `<BrowserURL />` component tests from `enzyme` to `@testing-library/react`.

## Why?
`@testing-library/react` provides a better way to write tests for accessible components that is closer to the way the user experiences them.

## How?
We're straightforwardly replacing `enzyme` tests with `@testing-library/react` ones, using `jest-dom` matchers and mocks to avoid testing unrelated implementation details.

## Testing Instructions
Verify tests pass: `npm run test:unit packages/edit-post/src/components/browser-url/test/index.js`
