### PR TITLE
Adds block supports for metadata

### DIFF
--- a/lib/compat/wordpress-6.1/blocks.php
+++ b/lib/compat/wordpress-6.1/blocks.php
@@ -392,3 +392,28 @@ function gutenberg_block_type_metadata_render_template( $settings, $metadata ) {
 	return $settings;
 }
 add_filter( 'block_type_metadata_settings', 'gutenberg_block_type_metadata_render_template', 10, 2 );
+
+/**
+ * Registers the metadata block attribute for block types.
+ *
+ * Once 6.1 is the minimum supported WordPress version for the Gutenberg
+ * plugin, this shim can be removed
+ *
+ * @param array $args Array of arguments for registering a block type.
+ * @return array $args
+ */
+function gutenberg_register_metadata_attribute( $args ) {
+	// Setup attributes if needed.
+	if ( ! isset( $args['attributes'] ) || ! is_array( $args['attributes'] ) ) {
+		$args['attributes'] = array();
+	}
+
+	if ( ! array_key_exists( 'metadata', $args['attributes'] ) ) {
+		$args['attributes']['metadata'] = array(
+			'type' => 'object',
+		);
+	}
+
+	return $args;
+}
+add_filter( 'register_block_type_args', 'gutenberg_register_metadata_attribute' );

--- a/packages/block-editor/src/hooks/index.js
+++ b/packages/block-editor/src/hooks/index.js
@@ -16,6 +16,8 @@ import './font-size';
 import './border';
 import './layout';
 import './content-lock-ui';
+import './metadata';
+import './metadata-name';
 
 export { useCustomSides } from './dimensions';
 export { getBorderClassesAndStyles, useBorderProps } from './use-border-props';

--- a/packages/block-editor/src/hooks/metadata-name.js
+++ b/packages/block-editor/src/hooks/metadata-name.js
@@ -31,7 +31,7 @@ export function addLabelCallback( settings ) {
 		settings.__experimentalLabel = ( attributes, { context } ) => {
 			const { metadata } = attributes;
 
-			// In the list view, use the block's name sattribute as the label.
+			// In the list view, use the block's name attribute as the label.
 			if ( context === 'list-view' && metadata?.name ) {
 				return metadata.name;
 			}

--- a/packages/block-editor/src/hooks/metadata-name.js
+++ b/packages/block-editor/src/hooks/metadata-name.js
@@ -1,0 +1,48 @@
+/**
+ * WordPress dependencies
+ */
+import { addFilter } from '@wordpress/hooks';
+/**
+ * Internal dependencies
+ */
+import { hasBlockMetadataSupport } from './metadata';
+
+/**
+ * Filters registered block settings, adding an `__experimentalLabel` callback if one does not already exist.
+ *
+ * @param {Object} settings Original block settings.
+ *
+ * @return {Object} Filtered block settings.
+ */
+export function addLabelCallback( settings ) {
+	// If blocks provide their own label callback, do not override it.
+	if ( settings.__experimentalLabel ) {
+		return settings;
+	}
+
+	const supportsBlockNaming = hasBlockMetadataSupport(
+		settings,
+		'name',
+		false
+	);
+
+	// Check whether block metadata is supported before using it.
+	if ( supportsBlockNaming ) {
+		settings.__experimentalLabel = ( attributes, { context } ) => {
+			const { metadata } = attributes;
+
+			// In the list view, use the block's name sattribute as the label.
+			if ( context === 'list-view' && metadata?.name ) {
+				return metadata.name;
+			}
+		};
+	}
+
+	return settings;
+}
+
+addFilter(
+	'blocks.registerBlockType',
+	'core/metadata/addLabelCallback',
+	addLabelCallback
+);

--- a/packages/block-editor/src/hooks/metadata-name.js
+++ b/packages/block-editor/src/hooks/metadata-name.js
@@ -23,7 +23,7 @@ export function addLabelCallback( settings ) {
 	const supportsBlockNaming = hasBlockMetadataSupport(
 		settings,
 		'name',
-		false
+		false // default value
 	);
 
 	// Check whether block metadata is supported before using it.

--- a/packages/block-editor/src/hooks/metadata.js
+++ b/packages/block-editor/src/hooks/metadata.js
@@ -1,0 +1,64 @@
+/**
+ * WordPress dependencies
+ */
+import { addFilter } from '@wordpress/hooks';
+import { getBlockSupport } from '@wordpress/blocks';
+
+const META_ATTRIBUTE_NAME = 'metadata';
+
+export function hasBlockMetadataSupport( blockType, feature = '' ) {
+	const support = getBlockSupport( blockType, '__experimentalMetadata' );
+	return !! ( true === support || support?.[ feature ] );
+}
+
+/**
+ * Filters registered block settings, extending attributes to include `metadata`.
+ *
+ * see: https://github.com/WordPress/gutenberg/pull/40393/files#r864632012
+ *
+ * @param {Object} blockTypeSettings Original block settings.
+ * @return {Object} Filtered block settings.
+ */
+export function addMetaAttribute( blockTypeSettings ) {
+	// Allow blocks to specify their own attribute definition with default values if needed.
+	if ( blockTypeSettings?.attributes?.[ META_ATTRIBUTE_NAME ]?.type ) {
+		return blockTypeSettings;
+	}
+
+	const supportsBlockNaming = hasBlockMetadataSupport(
+		blockTypeSettings,
+		'name',
+		false
+	);
+
+	if ( supportsBlockNaming ) {
+		blockTypeSettings.attributes = {
+			...blockTypeSettings.attributes,
+			[ META_ATTRIBUTE_NAME ]: {
+				type: 'object',
+			},
+		};
+	}
+
+	return blockTypeSettings;
+}
+
+export function addSaveProps( extraProps, blockType, attributes ) {
+	if ( hasBlockMetadataSupport( blockType ) ) {
+		extraProps[ META_ATTRIBUTE_NAME ] = attributes[ META_ATTRIBUTE_NAME ];
+	}
+
+	return extraProps;
+}
+
+addFilter(
+	'blocks.registerBlockType',
+	'core/metadata/addMetaAttribute',
+	addMetaAttribute
+);
+
+addFilter(
+	'blocks.getSaveContent.extraProps',
+	'core/metadata/save-props',
+	addSaveProps
+);


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Spin off from/sub PR of https://github.com/WordPress/gutenberg/pull/42605/.

Adds block supports for block `metadata`. 

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

A use case for this is supplied in https://github.com/WordPress/gutenberg/pull/42605/. Essentially the need is to store data which is tied to the block instance. For example a custom name/label for the block.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

Registers new attribute.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->

Aim is to check that adding support in block.json will cause the block support to be truthy.

- Open `packages/block-library/src/group/block.json` and find the `supports` object.
- Add 
```js
"__experimentalMetadata": true,
```
- Save file and rebuild.
- Start a New Post
- Open dev tools console.
- Type `wp.data.select('core/blocks').getBlockSupport('core/group','__experimentalMetadata')`. It should be `true`.
- Type `wp.data.select('core/blocks').getBlockSupport('core/paragraph','__experimentalMetadata')`. It should be `undefined`.


## Screenshots or screencast <!-- if applicable -->

