### PR TITLE
Block Setttings Menu Controls: Add unstableDisplayLocation prop.

### DIFF
--- a/packages/block-editor/src/components/block-settings-menu-controls/README.md
+++ b/packages/block-editor/src/components/block-settings-menu-controls/README.md
@@ -19,9 +19,9 @@ function ReusableBlocksMenuItems() {
 
 ## Props
 
-### `displayLocation`
+### `__unstableDisplayLocation`
 
 -   **Type:** `String`
 -   **Default:** `undefined`
 
-A string representing the location where the component is being displayed within the UI. This can be used to conditionalize certain behaviors including the display of associated components.
+A string representing the location where the component is being displayed within the UI. This can be used to conditionalize certain behaviors including the display of associated components. This behaviour will likely be refactored to a React.Context implementation.

--- a/packages/block-editor/src/components/block-settings-menu-controls/README.md
+++ b/packages/block-editor/src/components/block-settings-menu-controls/README.md
@@ -16,3 +16,12 @@ function ReusableBlocksMenuItems() {
 	);
 }
 ```
+
+## Props
+
+### `context`
+
+-   **Type:** `String`
+-   **Default:** `undefined`
+
+A string representing the context where the component is being included. This can be used to conditionalise certain beheaviours.

--- a/packages/block-editor/src/components/block-settings-menu-controls/README.md
+++ b/packages/block-editor/src/components/block-settings-menu-controls/README.md
@@ -19,9 +19,9 @@ function ReusableBlocksMenuItems() {
 
 ## Props
 
-### `context`
+### `displayLocation`
 
 -   **Type:** `String`
 -   **Default:** `undefined`
 
-A string representing the context where the component is being included. This can be used to conditionalize certain behaviors.
+A string representing the location where the component is being displayed within the UI. This can be used to conditionalize certain behaviors including the display of associated components.

--- a/packages/block-editor/src/components/block-settings-menu-controls/README.md
+++ b/packages/block-editor/src/components/block-settings-menu-controls/README.md
@@ -24,4 +24,4 @@ function ReusableBlocksMenuItems() {
 -   **Type:** `String`
 -   **Default:** `undefined`
 
-A string representing the context where the component is being included. This can be used to conditionalise certain beheaviours.
+A string representing the context where the component is being included. This can be used to conditionalize certain behaviors.

--- a/packages/block-editor/src/components/block-settings-menu-controls/index.js
+++ b/packages/block-editor/src/components/block-settings-menu-controls/index.js
@@ -28,7 +28,7 @@ const { Fill, Slot } = createSlotFill( 'BlockSettingsMenuControls' );
 const BlockSettingsMenuControlsSlot = ( {
 	fillProps,
 	clientIds = null,
-	displayLocation,
+	__unstableDisplayLocation,
 } ) => {
 	const { selectedBlocks, selectedClientIds, canRemove } = useSelect(
 		( select ) => {
@@ -65,7 +65,7 @@ const BlockSettingsMenuControlsSlot = ( {
 		<Slot
 			fillProps={ {
 				...fillProps,
-				displayLocation,
+				__unstableDisplayLocation,
 				selectedBlocks,
 				selectedClientIds,
 			} }

--- a/packages/block-editor/src/components/block-settings-menu-controls/index.js
+++ b/packages/block-editor/src/components/block-settings-menu-controls/index.js
@@ -28,7 +28,7 @@ const { Fill, Slot } = createSlotFill( 'BlockSettingsMenuControls' );
 const BlockSettingsMenuControlsSlot = ( {
 	fillProps,
 	clientIds = null,
-	context,
+	displayLocation,
 } ) => {
 	const { selectedBlocks, selectedClientIds, canRemove } = useSelect(
 		( select ) => {
@@ -65,7 +65,7 @@ const BlockSettingsMenuControlsSlot = ( {
 		<Slot
 			fillProps={ {
 				...fillProps,
-				context,
+				displayLocation,
 				selectedBlocks,
 				selectedClientIds,
 			} }

--- a/packages/block-editor/src/components/block-settings-menu-controls/index.js
+++ b/packages/block-editor/src/components/block-settings-menu-controls/index.js
@@ -25,7 +25,11 @@ import { store as blockEditorStore } from '../../store';
 
 const { Fill, Slot } = createSlotFill( 'BlockSettingsMenuControls' );
 
-const BlockSettingsMenuControlsSlot = ( { fillProps, clientIds = null } ) => {
+const BlockSettingsMenuControlsSlot = ( {
+	fillProps,
+	clientIds = null,
+	context,
+} ) => {
 	const { selectedBlocks, selectedClientIds, canRemove } = useSelect(
 		( select ) => {
 			const {
@@ -58,7 +62,14 @@ const BlockSettingsMenuControlsSlot = ( { fillProps, clientIds = null } ) => {
 		( isGroupable || isUngroupable ) && canRemove;
 
 	return (
-		<Slot fillProps={ { ...fillProps, selectedBlocks, selectedClientIds } }>
+		<Slot
+			fillProps={ {
+				...fillProps,
+				selectedBlocks,
+				selectedClientIds,
+				context,
+			} }
+		>
 			{ ( fills ) => {
 				if (
 					! fills?.length > 0 &&

--- a/packages/block-editor/src/components/block-settings-menu-controls/index.js
+++ b/packages/block-editor/src/components/block-settings-menu-controls/index.js
@@ -65,9 +65,9 @@ const BlockSettingsMenuControlsSlot = ( {
 		<Slot
 			fillProps={ {
 				...fillProps,
+				context,
 				selectedBlocks,
 				selectedClientIds,
-				context,
 			} }
 		>
 			{ ( fills ) => {

--- a/packages/block-editor/src/components/block-settings-menu/block-settings-dropdown.js
+++ b/packages/block-editor/src/components/block-settings-menu/block-settings-dropdown.js
@@ -51,7 +51,7 @@ export function BlockSettingsDropdown( {
 	clientIds,
 	__experimentalSelectBlock,
 	children,
-	context,
+	displayLocation,
 	...props
 } ) {
 	const blockClientIds = castArray( clientIds );
@@ -290,7 +290,7 @@ export function BlockSettingsDropdown( {
 							<BlockSettingsMenuControls.Slot
 								fillProps={ { onClose } }
 								clientIds={ clientIds }
-								context={ context }
+								displayLocation={ displayLocation }
 							/>
 							{ typeof children === 'function'
 								? children( { onClose } )

--- a/packages/block-editor/src/components/block-settings-menu/block-settings-dropdown.js
+++ b/packages/block-editor/src/components/block-settings-menu/block-settings-dropdown.js
@@ -51,7 +51,7 @@ export function BlockSettingsDropdown( {
 	clientIds,
 	__experimentalSelectBlock,
 	children,
-	displayLocation,
+	__unstableDisplayLocation,
 	...props
 } ) {
 	const blockClientIds = castArray( clientIds );
@@ -290,7 +290,9 @@ export function BlockSettingsDropdown( {
 							<BlockSettingsMenuControls.Slot
 								fillProps={ { onClose } }
 								clientIds={ clientIds }
-								displayLocation={ displayLocation }
+								__unstableDisplayLocation={
+									__unstableDisplayLocation
+								}
 							/>
 							{ typeof children === 'function'
 								? children( { onClose } )

--- a/packages/block-editor/src/components/block-settings-menu/block-settings-dropdown.js
+++ b/packages/block-editor/src/components/block-settings-menu/block-settings-dropdown.js
@@ -51,6 +51,7 @@ export function BlockSettingsDropdown( {
 	clientIds,
 	__experimentalSelectBlock,
 	children,
+	context,
 	...props
 } ) {
 	const blockClientIds = castArray( clientIds );
@@ -289,6 +290,7 @@ export function BlockSettingsDropdown( {
 							<BlockSettingsMenuControls.Slot
 								fillProps={ { onClose } }
 								clientIds={ clientIds }
+								context={ context }
 							/>
 							{ typeof children === 'function'
 								? children( { onClose } )


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Spin off from/sub PR of https://github.com/WordPress/gutenberg/pull/42605/.

Adds a ~`context`~ `displayLocation` prop to the `<BlockSettingsDropdown>` and then on to the `<BlockSettingsMenuControls>` Slot. 

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

This affords the ability to contextually apply functionality inside the "3 dots" menu controls.

For example in https://github.com/WordPress/gutenberg/pull/42605 we only wish to expose the `Rename` menu item inside the list view. The ~`context`~ `displayLocation` prop affords this ability.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

Adds a ~`context`~ `displayLocation` prop to the `<BlockSettingsDropdown>` and then on to the `<BlockSettingsMenuControls>` Slot. 

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->

See https://github.com/WordPress/gutenberg/pull/42605

## Screenshots or screencast <!-- if applicable -->
