### PR TITLE
Styles API: Fixed selectors for nested elements

### DIFF
--- a/lib/compat/wordpress-6.1/class-wp-theme-json-6-1.php
+++ b/lib/compat/wordpress-6.1/class-wp-theme-json-6-1.php
@@ -456,13 +456,11 @@ class WP_Theme_JSON_6_1 extends WP_Theme_JSON_6_0 {
 						$element_selector = array( $el_selector );
 						break;
 					}
-
-					$element_selector = static::append_to_selector( $el_selector, $selector . ' ', 'left' );
+					$element_selector[] = static::append_to_selector( $el_selector, $selector . ' ', 'left' );
 				}
-				static::$blocks_metadata[ $block_name ]['elements'][ $el_name ] = $element_selector;
+				static::$blocks_metadata[ $block_name ]['elements'][ $el_name ] = implode( ',', $element_selector );
 			}
 		}
-
 		return static::$blocks_metadata;
 	}
 

--- a/phpunit/class-wp-theme-json-test.php
+++ b/phpunit/class-wp-theme-json-test.php
@@ -249,6 +249,134 @@ class WP_Theme_JSON_Gutenberg_Test extends WP_UnitTestCase {
 			),
 		);
 	}
+
+	public function test_get_stylesheet() {
+		$theme_json = new WP_Theme_JSON_Gutenberg(
+			array(
+				'version'  => WP_Theme_JSON_Gutenberg::LATEST_SCHEMA,
+				'settings' => array(
+					'color'      => array(
+						'text'    => 'value',
+						'palette' => array(
+							array(
+								'slug'  => 'grey',
+								'color' => 'grey',
+							),
+						),
+					),
+					'typography' => array(
+						'fontFamilies' => array(
+							array(
+								'slug'       => 'small',
+								'fontFamily' => '14px',
+							),
+							array(
+								'slug'       => 'big',
+								'fontFamily' => '41px',
+							),
+						),
+					),
+					'misc'       => 'value',
+					'blocks'     => array(
+						'core/group' => array(
+							'custom' => array(
+								'base-font'   => 16,
+								'line-height' => array(
+									'small'  => 1.2,
+									'medium' => 1.4,
+									'large'  => 1.8,
+								),
+							),
+						),
+					),
+				),
+				'styles'   => array(
+					'color'    => array(
+						'text' => 'var:preset|color|grey',
+					),
+					'misc'     => 'value',
+					'elements' => array(
+						'link' => array(
+							'color' => array(
+								'text'       => '#111',
+								'background' => '#333',
+							),
+						),
+					),
+					'blocks'   => array(
+						'core/group'     => array(
+							'border'   => array(
+								'radius' => '10px',
+							),
+							'elements' => array(
+								'link' => array(
+									'color' => array(
+										'text' => '#111',
+									),
+								),
+							),
+							'spacing'  => array(
+								'padding' => '24px',
+							),
+						),
+						'core/heading'   => array(
+							'color'    => array(
+								'text' => '#123456',
+							),
+							'elements' => array(
+								'link' => array(
+									'color'      => array(
+										'text'       => '#111',
+										'background' => '#333',
+									),
+									'typography' => array(
+										'fontSize' => '60px',
+									),
+								),
+							),
+						),
+						'core/post-date' => array(
+							'color'    => array(
+								'text' => '#123456',
+							),
+							'elements' => array(
+								'link' => array(
+									'color' => array(
+										'background' => '#777',
+										'text'       => '#555',
+									),
+								),
+							),
+						),
+						'core/image'     => array(
+							'border'  => array(
+								'radius' => array(
+									'topLeft'     => '10px',
+									'bottomRight' => '1em',
+								),
+							),
+							'spacing' => array(
+								'margin' => array(
+									'bottom' => '30px',
+								),
+							),
+						),
+					),
+				),
+				'misc'     => 'value',
+			)
+		);
+
+		$variables = 'body{--wp--preset--color--grey: grey;--wp--preset--font-family--small: 14px;--wp--preset--font-family--big: 41px;}.wp-block-group{--wp--custom--base-font: 16;--wp--custom--line-height--small: 1.2;--wp--custom--line-height--medium: 1.4;--wp--custom--line-height--large: 1.8;}';
+		$styles    = 'body{color: var(--wp--preset--color--grey);}body { margin: 0;}.wp-site-blocks > .alignleft { float: left; margin-right: 2em; }.wp-site-blocks > .alignright { float: right; margin-left: 2em; }.wp-site-blocks > .aligncenter { justify-content: center; margin-left: auto; margin-right: auto; }a:where(:not(.wp-element-button)){background-color: #333;color: #111;}.wp-block-group{border-radius: 10px;padding: 24px;}.wp-block-group a:where(:not(.wp-element-button)){color: #111;}h1,h2,h3,h4,h5,h6{color: #123456;}h1 a:where(:not(.wp-element-button)),h2 a:where(:not(.wp-element-button)),h3 a:where(:not(.wp-element-button)),h4 a:where(:not(.wp-element-button)),h5 a:where(:not(.wp-element-button)),h6 a:where(:not(.wp-element-button)){background-color: #333;color: #111;font-size: 60px;}.wp-block-post-date{color: #123456;}.wp-block-post-date a:where(:not(.wp-element-button)){background-color: #777;color: #555;}.wp-block-image{margin-bottom: 30px;}.wp-block-image img, .wp-block-image .wp-block-image__crop-area{border-top-left-radius: 10px;border-bottom-right-radius: 1em;}';
+		$presets   = '.has-grey-color{color: var(--wp--preset--color--grey) !important;}.has-grey-background-color{background-color: var(--wp--preset--color--grey) !important;}.has-grey-border-color{border-color: var(--wp--preset--color--grey) !important;}.has-small-font-family{font-family: var(--wp--preset--font-family--small) !important;}.has-big-font-family{font-family: var(--wp--preset--font-family--big) !important;}';
+		$all       = $variables . $styles . $presets;
+		$this->assertEquals( $all, $theme_json->get_stylesheet() );
+		$this->assertEquals( $styles, $theme_json->get_stylesheet( array( 'styles' ) ) );
+		$this->assertEquals( $presets, $theme_json->get_stylesheet( array( 'presets' ) ) );
+		$this->assertEquals( $variables, $theme_json->get_stylesheet( array( 'variables' ) ) );
+	}
+
 	function test_get_stylesheet_handles_whitelisted_element_pseudo_selectors() {
 		$theme_json = new WP_Theme_JSON_Gutenberg(
 			array(


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->
This PR solves an issue that was uncovered while [backporting](https://github.com/WordPress/wordpress-develop/pull/3206) the changes to the  Elements API. 

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
 [A failing test](https://github.com/WordPress/wordpress-develop/runs/8225562537?check_suite_focus=true#step:19:280) was found that is present in core but not on GB, this test shows that if a theme defines styles for a link inside the heading block, only the last selector of the list of headings will apply those styles (h6).

This PR is bringing the test that was failing on core to GB, since it definitely proved useful in this particular case.


## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
The code was assuming an array of selectors for the elements but then it was overriding it with a string, only saving the last one in the list. This PR fixes that, applying the link selector to all the headings.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->

On your theme (I used emptytheme) add this to theme.json:

```
	"styles": {
		"blocks": {
			"core/heading":{
				"elements": {
					"link": {
						"color": {
							"text": "red"
						}
					}
				}
			}
		}
	}
```

Post headings with links. Before this PR, only h6 will be red; after this PR, all of them show red links.

--

Can someone explain why we don't have the same tests in both core and GB? Or at least why the tests in core aren't running for GB commits. Having that core test would have caught this bug on the original PR, not in the backport one.
