### PR TITLE
Block Editor: Refactor `MediaPlaceholder` tests to `@testing-library/react`

### DIFF
--- a/packages/block-editor/src/components/media-placeholder/test/index.js
+++ b/packages/block-editor/src/components/media-placeholder/test/index.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { mount } from 'enzyme';
+import { render } from '@testing-library/react';
 
 /**
  * Internal dependencies
@@ -13,6 +13,6 @@ jest.mock( '@wordpress/data/src/components/use-select', () => () => ( {} ) );
 
 describe( 'MediaPlaceholder', () => {
 	it( 'renders successfully when allowedTypes property is not specified', () => {
-		expect( () => mount( <MediaPlaceholder /> ) ).not.toThrow();
+		expect( () => render( <MediaPlaceholder multiple /> ) ).not.toThrow();
 	} );
 } );


### PR DESCRIPTION
## What?
We've recently started refactoring `enzyme` tests to `@testing-library/react`.

This PR refactors the `<MediaPlaceholder />` component tests (it's just a single test) from `enzyme` to `@testing-library/react`.

## Why?
`@testing-library/react` provides a better way to write tests for accessible components that is closer to the way the user experiences them.

## How?
We're straightforwardly replacing `enzyme` tests with `@testing-library/react` ones. We're also adding the `multiple` prop to the rendered component because that's the only instance when it might fail from a missing `allowedTypes` prop (which the test is ultimately aiming to assert).

## Testing Instructions
* Verify tests pass: `npm run test:unit packages/block-editor/src/components/media-placeholder/test/index.js`
* To verify that the test catches the necessary failure, delete this code and verify tests fail:

https://github.com/WordPress/gutenberg/blob/6cdd6ae673a6492d8ef69d38264384f953621a75/packages/block-editor/src/components/media-placeholder/index.js#L95-L97
