### PR TITLE
Adds an option to remove text decoration

### DIFF
--- a/packages/block-editor/src/components/text-decoration-control/index.js
+++ b/packages/block-editor/src/components/text-decoration-control/index.js
@@ -10,10 +10,15 @@ import {
 	__experimentalToggleGroupControl as ToggleGroupControl,
 	__experimentalToggleGroupControlOptionIcon as ToggleGroupControlOptionIcon,
 } from '@wordpress/components';
-import { formatStrikethrough, formatUnderline } from '@wordpress/icons';
+import { formatStrikethrough, formatUnderline, reset } from '@wordpress/icons';
 import { __ } from '@wordpress/i18n';
 
 const TEXT_DECORATIONS = [
+	{
+		name: __( 'None' ),
+		value: 'none',
+		icon: reset,
+	},
 	{
 		name: __( 'Underline' ),
 		value: 'underline',


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->
Introduces an option to remove text decoration settings for blocks that support it.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
Because you should be able to change your mind.


## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
Not great, adds a new option that sets it to none, but with a bad icon.


## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->

1. Open the site editor
2. Select a paragraph
3. In the inspector under Typography click the dotted menu
4. Click Decoration
5. In the panel named Decoration there should be three options
6. The first one should unselect the other two

## Screenshots or screencast <!-- if applicable -->

https://user-images.githubusercontent.com/107534/189181230-0fe90863-ba0e-4c0c-a760-bb3b61366b60.mp4

