### PR TITLE
Components: Retire `LIGHT_GRAY` color object

### DIFF
--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -25,6 +25,9 @@
 -   `SearchControl`: Add `__nextHasNoMargin` prop for opting into the new margin-free styles ([#43871](https://github.com/WordPress/gutenberg/pull/43871)).
 -   `CardHeader`, `CardBody`, `CardFooter`: Tweak `isShady` background colors to be consistent with the grays in `@wordpress/base-styles` ([#43719](https://github.com/WordPress/gutenberg/pull/43719)).
 -   `InputControl`, `SelectControl`: Tweak `disabled` colors to be consistent with the grays in `@wordpress/base-styles` ([#43719](https://github.com/WordPress/gutenberg/pull/43719)).
+-   `FocalPointPicker`: Tweak media placeholder background color to be consistent with the grays in `@wordpress/base-styles` ([#43994](https://github.com/WordPress/gutenberg/pull/43994)).
+-   `RangeControl`: Tweak rail, track, and mark colors to be consistent with the grays in `@wordpress/base-styles` ([#43994](https://github.com/WordPress/gutenberg/pull/43994)).
+-   `UnitControl`: Tweak unit dropdown hover color to be consistent with the grays in `@wordpress/base-styles` ([#43994](https://github.com/WordPress/gutenberg/pull/43994)).
 -   `Popover`: stabilize `__unstableShift` to `shift` ([#43845](https://github.com/WordPress/gutenberg/pull/43845)).
 
 ### Internal

--- a/packages/components/src/alignment-matrix-control/styles/alignment-matrix-control-styles.js
+++ b/packages/components/src/alignment-matrix-control/styles/alignment-matrix-control-styles.js
@@ -45,7 +45,7 @@ export const Row = styled.div`
 
 const pointActive = ( { isActive } ) => {
 	const boxShadow = isActive ? `0 0 0 2px ${ COLORS.gray[ 900 ] }` : null;
-	const pointColor = isActive ? COLORS.gray[ 900 ] : COLORS.lightGray[ 800 ];
+	const pointColor = isActive ? COLORS.gray[ 900 ] : COLORS.gray[ 400 ];
 	const pointColorHover = isActive ? COLORS.gray[ 900 ] : COLORS.ui.theme;
 
 	return css`

--- a/packages/components/src/focal-point-picker/styles/focal-point-picker-style.ts
+++ b/packages/components/src/focal-point-picker/styles/focal-point-picker-style.ts
@@ -42,7 +42,7 @@ export const MediaContainer = styled.div`
 `;
 
 export const MediaPlaceholder = styled.div`
-	background: ${ COLORS.lightGray[ 300 ] };
+	background: ${ COLORS.gray[ 100 ] };
 	box-sizing: border-box;
 	height: ${ INITIAL_BOUNDS.height }px;
 	max-width: 280px;

--- a/packages/components/src/range-control/styles/range-control-styles.ts
+++ b/packages/components/src/range-control/styles/range-control-styles.ts
@@ -101,7 +101,7 @@ const trackBackgroundColor = ( { disabled, trackColor }: TrackProps ) => {
 	let background = trackColor || 'currentColor';
 
 	if ( disabled ) {
-		background = COLORS.lightGray[ 800 ];
+		background = COLORS.gray[ 400 ];
 	}
 
 	return css( { background } );
@@ -132,7 +132,7 @@ const markFill = ( { disabled, isFilled }: RangeMarkProps ) => {
 	let backgroundColor = isFilled ? 'currentColor' : COLORS.gray[ 300 ];
 
 	if ( disabled ) {
-		backgroundColor = COLORS.lightGray[ 800 ];
+		backgroundColor = COLORS.gray[ 400 ];
 	}
 
 	return css( {
@@ -171,7 +171,7 @@ export const MarkLabel = styled.span`
 const thumbColor = ( { disabled }: ThumbProps ) =>
 	disabled
 		? css`
-				background-color: ${ COLORS.lightGray[ 800 ] };
+				background-color: ${ COLORS.gray[ 400 ] };
 		  `
 		: css`
 				background-color: var( --wp-admin-theme-color );

--- a/packages/components/src/range-control/styles/range-control-styles.ts
+++ b/packages/components/src/range-control/styles/range-control-styles.ts
@@ -76,7 +76,7 @@ const railBackgroundColor = ( { disabled, railColor }: RailProps ) => {
 	let background = railColor || '';
 
 	if ( disabled ) {
-		background = COLORS.lightGray[ 400 ];
+		background = COLORS.ui.backgroundDisabled;
 	}
 
 	return css( { background } );

--- a/packages/components/src/range-control/styles/range-control-styles.ts
+++ b/packages/components/src/range-control/styles/range-control-styles.ts
@@ -83,7 +83,7 @@ const railBackgroundColor = ( { disabled, railColor }: RailProps ) => {
 };
 
 export const Rail = styled.span`
-	background-color: ${ COLORS.lightGray[ 600 ] };
+	background-color: ${ COLORS.gray[ 300 ] };
 	left: 0;
 	pointer-events: none;
 	right: 0;
@@ -129,7 +129,7 @@ export const MarksWrapper = styled.span`
 `;
 
 const markFill = ( { disabled, isFilled }: RangeMarkProps ) => {
-	let backgroundColor = isFilled ? 'currentColor' : COLORS.lightGray[ 600 ];
+	let backgroundColor = isFilled ? 'currentColor' : COLORS.gray[ 300 ];
 
 	if ( disabled ) {
 		backgroundColor = COLORS.lightGray[ 800 ];
@@ -152,12 +152,12 @@ export const Mark = styled.span`
 
 const markLabelFill = ( { isFilled }: RangeMarkProps ) => {
 	return css( {
-		color: isFilled ? COLORS.gray[ 700 ] : COLORS.lightGray[ 600 ],
+		color: isFilled ? COLORS.gray[ 700 ] : COLORS.gray[ 300 ],
 	} );
 };
 
 export const MarkLabel = styled.span`
-	color: ${ COLORS.lightGray[ 600 ] };
+	color: ${ COLORS.gray[ 300 ] };
 	left: 0;
 	font-size: 11px;
 	position: absolute;

--- a/packages/components/src/unit-control/styles/unit-control-styles.ts
+++ b/packages/components/src/unit-control/styles/unit-control-styles.ts
@@ -113,7 +113,7 @@ const unitSelectSizes = ( { selectSize = 'default' }: SelectProps ) => {
 			${ rtl( { borderTopLeftRadius: 0, borderBottomLeftRadius: 0 } )() }
 
 			&:not(:disabled):hover {
-				background-color: ${ COLORS.lightGray[ 300 ] };
+				background-color: ${ COLORS.gray[ 100 ] };
 			}
 
 			&:focus {

--- a/packages/components/src/utils/colors-values.js
+++ b/packages/components/src/utils/colors-values.js
@@ -26,7 +26,6 @@ const GRAY = {
 const LIGHT_GRAY = {
 	800: '#b5bcc2',
 	600: '#d7dade',
-	400: '#e8eaeb', // Good for "readonly" input fields and special text selection.
 };
 
 // Matches @wordpress/base-styles

--- a/packages/components/src/utils/colors-values.js
+++ b/packages/components/src/utils/colors-values.js
@@ -25,7 +25,6 @@ const GRAY = {
 // TODO: Replace usages of these with the equivalents in `GRAY`
 const LIGHT_GRAY = {
 	800: '#b5bcc2',
-	600: '#d7dade',
 };
 
 // Matches @wordpress/base-styles

--- a/packages/components/src/utils/colors-values.js
+++ b/packages/components/src/utils/colors-values.js
@@ -27,7 +27,6 @@ const LIGHT_GRAY = {
 	800: '#b5bcc2',
 	600: '#d7dade',
 	400: '#e8eaeb', // Good for "readonly" input fields and special text selection.
-	300: '#edeff0',
 };
 
 // Matches @wordpress/base-styles

--- a/packages/components/src/utils/colors-values.js
+++ b/packages/components/src/utils/colors-values.js
@@ -22,11 +22,6 @@ const GRAY = {
 	100: '#f0f0f0',
 };
 
-// TODO: Replace usages of these with the equivalents in `GRAY`
-const LIGHT_GRAY = {
-	800: '#b5bcc2',
-};
-
 // Matches @wordpress/base-styles
 const ALERT = {
 	yellow: '#f0b849',
@@ -61,10 +56,6 @@ export const COLORS = Object.freeze( {
 	 * The main gray color object.
 	 */
 	gray: GRAY,
-	/**
-	 * @deprecated Try to use `gray` instead.
-	 */
-	lightGray: LIGHT_GRAY,
 	white,
 	alert: ALERT,
 	ui: UI,


### PR DESCRIPTION
Closes #40392

## What?

Replaces the following colors:

- `LIGHT_GRAY[ 800 ]` `#b5bcc2` → `GRAY[ 400 ]` `#cccccc`
- `LIGHT_GRAY[ 600 ]` `#d7dade` → `GRAY[ 300 ]` `#dddddd`
- `LIGHT_GRAY[ 400 ]` `#e8eaeb` → `GRAY[ 100 ]` `#f0f0f0`
- `LIGHT_GRAY[ 300 ]` `#edeff0` → `GRAY[ 100 ]` `#f0f0f0`

Affected components:

- FocalPointPicker (background color of media placeholder when no image/video is loaded)
- RangeControl (rail, track, marks)
- UnitControl (hover color of unit select when in default size variant)

## Why?

We want to consolidate our grays to the canonical gray scale in `@wordpress/base-styles`.

## How?

Replace with the closest colors in the main GRAY object.

## Testing Instructions

1. `npm run storybook:dev`
2. Check the stories for the affected components.

## Screenshots

| Before | After |
|--------|-------|
|![FocalPointPicker media placeholder, before](https://user-images.githubusercontent.com/555336/189184954-d1355b8d-a11e-4a09-bc62-dfad4c11d951.png)|![FocalPointPicker media placeholder, after](https://user-images.githubusercontent.com/555336/189185200-216a219d-b099-401e-a946-19971cab2097.png)|
|![RangeControl, before](https://user-images.githubusercontent.com/555336/189185719-7a215606-f943-45eb-a133-c0f29118b6fb.png)|![RangeControl, after](https://user-images.githubusercontent.com/555336/189185602-8b71995f-e2ca-4183-8874-74d9372a02c4.png)|
|![RangeControl disabled, before](https://user-images.githubusercontent.com/555336/189185972-d0d5f850-90a2-48e0-ab4c-44405e1c026e.png)|![RangeControl disabled, after](https://user-images.githubusercontent.com/555336/189186047-623df424-a89f-408c-a2fc-de6dedaae11f.png)|
|![UnitControl unit dropdown hover, before](https://user-images.githubusercontent.com/555336/189186405-3212ae8b-b4f7-4d51-8c29-e6bff3903370.png)|![UnitControl unit dropdown hover, after](https://user-images.githubusercontent.com/555336/189186294-7332ae06-7864-41b2-88c1-f361986e181d.png)|