### PR TITLE
FocalPointControl: Add flag to remove bottom margin

### DIFF
--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -19,6 +19,7 @@
 
 -   `ToggleControl`: Add `__nextHasNoMargin` prop for opting into the new margin-free styles ([#43717](https://github.com/WordPress/gutenberg/pull/43717)).
 -   `CheckboxControl`: Add `__nextHasNoMargin` prop for opting into the new margin-free styles ([#43720](https://github.com/WordPress/gutenberg/pull/43720)).
+-   `FocalPointControl`: Add `__nextHasNoMargin` prop for opting into the new margin-free styles ([#43996](https://github.com/WordPress/gutenberg/pull/43996)).
 -   `TextControl`, `TextareaControl`: Add `__nextHasNoMargin` prop for opting into the new margin-free styles ([#43782](https://github.com/WordPress/gutenberg/pull/43782)).
 -   `RangeControl`: Tweak dark gray marking color to be consistent with the grays in `@wordpress/base-styles` ([#43773](https://github.com/WordPress/gutenberg/pull/43773)).
 -   `UnitControl`: Tweak unit dropdown color to be consistent with the grays in `@wordpress/base-styles` ([#43773](https://github.com/WordPress/gutenberg/pull/43773)).

--- a/packages/components/src/focal-point-picker/controls.tsx
+++ b/packages/components/src/focal-point-picker/controls.tsx
@@ -22,6 +22,7 @@ const TEXTCONTROL_MAX = 100;
 const noop = () => {};
 
 export default function FocalPointPickerControls( {
+	__nextHasNoMarginBottom,
 	onChange = noop,
 	point = {
 		x: 0.5,
@@ -45,7 +46,10 @@ export default function FocalPointPickerControls( {
 	};
 
 	return (
-		<ControlWrapper className="focal-point-picker__controls">
+		<ControlWrapper
+			className="focal-point-picker__controls"
+			__nextHasNoMarginBottom={ __nextHasNoMarginBottom }
+		>
 			<FocalPointUnitControl
 				label={ __( 'Left' ) }
 				value={ [ valueX, '%' ].join( '' ) }

--- a/packages/components/src/focal-point-picker/controls.tsx
+++ b/packages/components/src/focal-point-picker/controls.tsx
@@ -23,6 +23,7 @@ const noop = () => {};
 
 export default function FocalPointPickerControls( {
 	__nextHasNoMarginBottom,
+	hasHelpText,
 	onChange = noop,
 	point = {
 		x: 0.5,
@@ -49,6 +50,7 @@ export default function FocalPointPickerControls( {
 		<ControlWrapper
 			className="focal-point-picker__controls"
 			__nextHasNoMarginBottom={ __nextHasNoMarginBottom }
+			hasHelpText={ hasHelpText }
 		>
 			<FocalPointUnitControl
 				label={ __( 'Left' ) }

--- a/packages/components/src/focal-point-picker/index.tsx
+++ b/packages/components/src/focal-point-picker/index.tsx
@@ -240,7 +240,7 @@ export function FocalPointPicker( {
 	return (
 		<BaseControl
 			{ ...restProps }
-			__nextHasNoMarginBottom
+			__nextHasNoMarginBottom={ __nextHasNoMarginBottom }
 			label={ label }
 			id={ id }
 			help={ help }
@@ -273,6 +273,7 @@ export function FocalPointPicker( {
 			</MediaWrapper>
 			<Controls
 				__nextHasNoMarginBottom={ __nextHasNoMarginBottom }
+				hasHelpText={ !! help }
 				point={ { x, y } }
 				onChange={ ( value ) => {
 					onChange?.( getFinalValue( value ) );

--- a/packages/components/src/focal-point-picker/index.tsx
+++ b/packages/components/src/focal-point-picker/index.tsx
@@ -83,6 +83,7 @@ const GRID_OVERLAY_TIMEOUT = 600;
  * ```
  */
 export function FocalPointPicker( {
+	__nextHasNoMarginBottom,
 	autoPlay = true,
 	className,
 	help,
@@ -239,6 +240,7 @@ export function FocalPointPicker( {
 	return (
 		<BaseControl
 			{ ...restProps }
+			__nextHasNoMarginBottom
 			label={ label }
 			id={ id }
 			help={ help }
@@ -270,6 +272,7 @@ export function FocalPointPicker( {
 				</MediaContainer>
 			</MediaWrapper>
 			<Controls
+				__nextHasNoMarginBottom={ __nextHasNoMarginBottom }
 				point={ { x, y } }
 				onChange={ ( value ) => {
 					onChange?.( getFinalValue( value ) );

--- a/packages/components/src/focal-point-picker/styles/focal-point-picker-style.ts
+++ b/packages/components/src/focal-point-picker/styles/focal-point-picker-style.ts
@@ -1,6 +1,7 @@
 /**
  * External dependencies
  */
+import { css } from '@emotion/react';
 import styled from '@emotion/styled';
 
 /**
@@ -9,6 +10,7 @@ import styled from '@emotion/styled';
 import { Flex } from '../../flex';
 import UnitControl from '../../unit-control';
 import { COLORS } from '../../utils';
+import type { FocalPointPickerControlsProps } from '../types';
 import { INITIAL_BOUNDS } from '../utils';
 
 export const MediaWrapper = styled.div`
@@ -54,9 +56,22 @@ export const StyledUnitControl = styled( UnitControl )`
 	width: 100px;
 `;
 
+const deprecatedBottomMargin = ( {
+	__nextHasNoMarginBottom,
+}: Pick< FocalPointPickerControlsProps, '__nextHasNoMarginBottom' > ) => {
+	return ! __nextHasNoMarginBottom
+		? css`
+				margin-bottom: 8px; // margin from BaseControl
+				padding-bottom: 1em; // padding from ControlWrapper
+		  `
+		: undefined;
+};
+
 export const ControlWrapper = styled( Flex )`
 	max-width: 320px;
-	padding: 1em 0;
+	padding-top: 1em;
+
+	${ deprecatedBottomMargin }
 `;
 
 export const GridView = styled.div`

--- a/packages/components/src/focal-point-picker/styles/focal-point-picker-style.ts
+++ b/packages/components/src/focal-point-picker/styles/focal-point-picker-style.ts
@@ -58,11 +58,20 @@ export const StyledUnitControl = styled( UnitControl )`
 
 const deprecatedBottomMargin = ( {
 	__nextHasNoMarginBottom,
-}: Pick< FocalPointPickerControlsProps, '__nextHasNoMarginBottom' > ) => {
+}: FocalPointPickerControlsProps ) => {
 	return ! __nextHasNoMarginBottom
 		? css`
-				margin-bottom: 8px; // margin from BaseControl
-				padding-bottom: 1em; // padding from ControlWrapper
+				padding-bottom: 1em;
+		  `
+		: undefined;
+};
+
+const extraHelpTextMargin = ( {
+	hasHelpText = false,
+}: FocalPointPickerControlsProps ) => {
+	return hasHelpText
+		? css`
+				padding-bottom: 1em;
 		  `
 		: undefined;
 };
@@ -71,6 +80,7 @@ export const ControlWrapper = styled( Flex )`
 	max-width: 320px;
 	padding-top: 1em;
 
+	${ extraHelpTextMargin }
 	${ deprecatedBottomMargin }
 `;
 

--- a/packages/components/src/focal-point-picker/types.ts
+++ b/packages/components/src/focal-point-picker/types.ts
@@ -62,6 +62,11 @@ export type FocalPointPickerProps = Pick<
 
 export type FocalPointPickerControlsProps = {
 	__nextHasNoMarginBottom?: boolean;
+	/**
+	 * A bit of extra bottom margin will be added if a `help` text
+	 * needs to be rendered under it.
+	 */
+	hasHelpText: boolean;
 	onChange?: ( value: FocalPoint ) => void;
 	point?: FocalPoint;
 };

--- a/packages/components/src/focal-point-picker/types.ts
+++ b/packages/components/src/focal-point-picker/types.ts
@@ -21,6 +21,12 @@ export type FocalPointPickerProps = Pick<
 	'help' | 'hideLabelFromVision' | 'label'
 > & {
 	/**
+	 * Start opting into the new margin-free styles that will become the default in a future version.
+	 *
+	 * @default false
+	 */
+	__nextHasNoMarginBottom?: boolean;
+	/**
 	 * Autoplays HTML5 video. This only applies to video sources (`url`).
 	 *
 	 * @default true
@@ -55,6 +61,7 @@ export type FocalPointPickerProps = Pick<
 };
 
 export type FocalPointPickerControlsProps = {
+	__nextHasNoMarginBottom?: boolean;
 	onChange?: ( value: FocalPoint ) => void;
 	point?: FocalPoint;
 };


### PR DESCRIPTION
Part of #38730

## What?

Adds a `__nextHasNoMarginBottom` prop to remove the bottom margin.

## Why?

Better reusability.

## How?

Passes through the prop to BaseControl, as well as some special handling on `ControlWrapper`, where there was some additional bottom margin being added.

## Testing Instructions

`npm run storybook:dev` and see the story for FocalPointControl.