### PR TITLE
Prerelease E2E Test Utils for Playwright

### DIFF
--- a/docs/manifest.json
+++ b/docs/manifest.json
@@ -1554,6 +1554,12 @@
 		"parent": "packages"
 	},
 	{
+		"title": "@wordpress/e2e-test-utils-playwright",
+		"slug": "packages-e2e-test-utils-playwright",
+		"markdown_source": "../packages/e2e-test-utils-playwright/README.md",
+		"parent": "packages"
+	},
+	{
 		"title": "@wordpress/e2e-test-utils",
 		"slug": "packages-e2e-test-utils",
 		"markdown_source": "../packages/e2e-test-utils/README.md",

--- a/packages/e2e-test-utils-playwright/CHANGELOG.md
+++ b/packages/e2e-test-utils-playwright/CHANGELOG.md
@@ -1,5 +1,5 @@
 <!-- Learn how to maintain this file at https://github.com/WordPress/gutenberg/tree/HEAD/packages#maintaining-changelogs. -->
 
-## Unreleased
+## Prerelease
 
--- Initial version of the package.
+- Initial version of the package.

--- a/packages/e2e-test-utils-playwright/CHANGELOG.md
+++ b/packages/e2e-test-utils-playwright/CHANGELOG.md
@@ -1,5 +1,5 @@
 <!-- Learn how to maintain this file at https://github.com/WordPress/gutenberg/tree/HEAD/packages#maintaining-changelogs. -->
 
-## Prerelease
+## Unreleased
 
 - Initial version of the package.

--- a/packages/e2e-test-utils-playwright/README.md
+++ b/packages/e2e-test-utils-playwright/README.md
@@ -4,9 +4,9 @@ End-To-End (E2E) Playwright test utils for WordPress.
 
 _It works properly with the minimum version of Gutenberg `9.2.0` or the minimum version of WordPress `5.6.0`._
 
-> ⚠️ **Prerelease Note**
->
-> This package is still under active development. Documentation might not be up-to-date, and the `v0.x` or `prerelease` version can introduce breaking changes without a detailed migration guide. Early adopters are encouraged to use a [lock file](https://docs.npmjs.com/cli/v9/configuring-npm/package-lock-json) to prevent unexpected breakages.
+<div class="callout callout-alert">
+This package is still under active development. "Prerelease" means that documentation might not be up-to-date, and the `v0.x` or `prerelease` version can introduce breaking changes without a detailed migration guide. Early adopters are encouraged to use a [lock file](https://docs.npmjs.com/cli/v9/configuring-npm/package-lock-json) to prevent unexpected breakages.
+</div>
 
 ## Installation
 

--- a/packages/e2e-test-utils-playwright/README.md
+++ b/packages/e2e-test-utils-playwright/README.md
@@ -4,6 +4,10 @@ End-To-End (E2E) Playwright test utils for WordPress.
 
 _It works properly with the minimum version of Gutenberg `9.2.0` or the minimum version of WordPress `5.6.0`._
 
+> ⚠️ **Prerelease Note**
+>
+> This package is still under active development. Documentation might not be up-to-date, and the `v0.x` or `prerelease` version can introduce breaking changes without a detailed migration guide. Early adopters are encouraged to use a [lock file](https://docs.npmjs.com/cli/v9/configuring-npm/package-lock-json) to prevent unexpected breakages.
+
 ## Installation
 
 Install the module

--- a/packages/e2e-test-utils-playwright/README.md
+++ b/packages/e2e-test-utils-playwright/README.md
@@ -5,7 +5,7 @@ End-To-End (E2E) Playwright test utils for WordPress.
 _It works properly with the minimum version of Gutenberg `9.2.0` or the minimum version of WordPress `5.6.0`._
 
 <div class="callout callout-alert">
-This package is still under active development. "Prerelease" means that documentation might not be up-to-date, and the `v0.x` or `prerelease` version can introduce breaking changes without a detailed migration guide. Early adopters are encouraged to use a [lock file](https://docs.npmjs.com/cli/v9/configuring-npm/package-lock-json) to prevent unexpected breakages.
+This package is still under active development. Documentation might not be up-to-date, and the `v0.x` version can introduce breaking changes without a detailed migration guide. Early adopters are encouraged to use a [lock file](https://docs.npmjs.com/cli/v9/configuring-npm/package-lock-json) to prevent unexpected breakages.
 </div>
 
 ## Installation

--- a/packages/e2e-test-utils-playwright/package.json
+++ b/packages/e2e-test-utils-playwright/package.json
@@ -1,7 +1,6 @@
 {
 	"name": "@wordpress/e2e-test-utils-playwright",
-	"version": "0.0.0",
-	"private": true,
+	"version": "1.0.0-prerelease",
 	"description": "End-To-End (E2E) test utils for WordPress.",
 	"author": "The WordPress Contributors",
 	"license": "GPL-2.0-or-later",

--- a/packages/e2e-test-utils-playwright/package.json
+++ b/packages/e2e-test-utils-playwright/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@wordpress/e2e-test-utils-playwright",
-	"version": "1.0.0-prerelease",
+	"version": "0.1.0-prerelease",
 	"description": "End-To-End (E2E) test utils for WordPress.",
 	"author": "The WordPress Contributors",
 	"license": "GPL-2.0-or-later",


### PR DESCRIPTION
## What?

Closes #45725.

Marks the `@wordpress/e2e-test-utils-playwright` package for **prerelease**, to publish on next Gutenberg package release.

## Why?
[It was requested in Make WordPress Slack](https://wordpress.slack.com/archives/C03B0H5J0/p1660667391174779) whether this package could be made public for easier integration outside Gutenberg. Due to its relative stability, it was agreed that it could be published as a prerelease version.

## How?
This PR marks `package.json` as prerelease, and removes the private flag, so that it may be published along with other public-facing packages. It also updates the changelog to denote the prerelease status.

## Testing Instructions
Verify that the package is made public after the next Gutenberg package release (e.g. [search on npmjs.com](https://www.npmjs.com/search?q=%40wordpress%2Fe2e-test-utils-playwright)).

Props @juhi123, @talldan, @kevin940726.
