### PR TITLE
Layout: Fix issue with fallback gap styles where gap was being output for constrained layout type

### DIFF
--- a/lib/compat/wordpress-6.1/class-wp-theme-json-6-1.php
+++ b/lib/compat/wordpress-6.1/class-wp-theme-json-6-1.php
@@ -1358,8 +1358,8 @@ class WP_Theme_JSON_6_1 extends WP_Theme_JSON_6_0 {
 			// If the block should have custom gap, add the gap styles.
 			if ( null !== $block_gap_value && false !== $block_gap_value && '' !== $block_gap_value ) {
 				foreach ( $layout_definitions as $layout_definition_key => $layout_definition ) {
-					// Allow skipping default layout for themes that opt-in to block styles, but opt-out of blockGap.
-					if ( ! $has_block_gap_support && 'default' === $layout_definition_key ) {
+					// Allow outputting fallback gap styles for flex layout type when block gap support isn't available.
+					if ( ! $has_block_gap_support && 'flex' !== $layout_definition_key ) {
 						continue;
 					}
 

--- a/packages/edit-site/src/components/global-styles/use-global-styles-output.js
+++ b/packages/edit-site/src/components/global-styles/use-global-styles-output.js
@@ -321,8 +321,8 @@ export function getLayoutStyles( {
 	if ( gapValue && tree?.settings?.layout?.definitions ) {
 		Object.values( tree.settings.layout.definitions ).forEach(
 			( { className, name, spacingStyles } ) => {
-				// Allow skipping default layout for themes that opt-in to block styles, but opt-out of blockGap.
-				if ( ! hasBlockGapSupport && 'default' === name ) {
+				// Allow outputting fallback gap styles for flex layout type when block gap support isn't available.
+				if ( ! hasBlockGapSupport && 'flex' !== name ) {
 					return;
 				}
 


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Ensure that fallback gap styles are only output for the `flex` layout type, so that in Classic themes (or themes that do not opt-in to block gap) we do not output the gap styles for the constrained layout type.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

In https://github.com/WordPress/gutenberg/pull/42763 we didn't factor in that the existing logic for fallback gap was outputting fallback gap styles for layout types that are _not_ default. Because the constrained layout type behaves in much the same way as the default layout type, we need to update the logic for the fallback gap so that it only applies to the flex layout type. The reason the fallback exists is primarily so that blocks like Buttons, Social Icons, and Columns render with a pleasing default gap. Vertically oriented blocks using the default and constrained layout types do not need the same kind of fallback gap to be output.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

Update the checks for default layout type that skip block gap output to instead be "not `flex`" instead.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->

Here is some test markup for looking at blocks within a constrained layout type:

<details>

<summary>Test markup of paragraphs in a group block</summary>

```html
<!-- wp:group {"layout":{"type":"constrained"}} -->
<div class="wp-block-group"><!-- wp:paragraph -->
<p>A paragraph in a group</p>
<!-- /wp:paragraph -->

<!-- wp:paragraph -->
<p>Another paragraph in a group</p>
<!-- /wp:paragraph -->

<!-- wp:paragraph -->
<p>And another one</p>
<!-- /wp:paragraph --></div>
<!-- /wp:group -->
```

</details>


In a Classic theme, prior to this PR, note that low specificity vertical gap (top margin) styles are being output in the editor (and also on the front end, but usually they're overridden by something with higher specificity).

With this PR applied, the constrained layout gap rules should no longer be output.

With blocks-based themes that use block gap (e.g. TwentyTwentyTwo), the gap should be the same as prior to this PR.

## Screenshots or screencast <!-- if applicable -->

| Before (note that constrained layout gap rules are applied) | After (note that the constrained layout gap rules no longer exist, the classic.css rules are applied for margins) |
| --- | --- |
| <img width="1240" alt="image" src="https://user-images.githubusercontent.com/14988353/189263632-cfde6253-d9c5-42a2-8109-d50cf0564265.png"> | <img width="1240" src="https://user-images.githubusercontent.com/14988353/189263469-aa8043cb-c126-4191-b10e-9b2a9d5596af.png" /> |
