### PR TITLE
Add spacing presets to the spacer block

### DIFF
--- a/packages/block-editor/README.md
+++ b/packages/block-editor/README.md
@@ -549,6 +549,17 @@ _Parameters_
 _Returns_
 
 -   `WPComponent`: The component to be rendered.
+### getSpacingPresetCssVar
+
+Converts a spacing preset into a custom value.
+
+_Parameters_
+
+-   _value_ `string`: Value to convert.
+
+_Returns_
+
+-   `string`: CSS var string for given spacing preset value.
 
 ### InnerBlocks
 
@@ -569,6 +580,18 @@ Undocumented declaration.
 _Related_
 
 -   <https://github.com/WordPress/gutenberg/blob/HEAD/packages/block-editor/src/components/inspector-controls/README.md>
+
+### isValueSpacingPreset
+
+Checks is given value is a spacing preset.
+
+_Parameters_
+
+-   _value_ `string`: Value to check
+
+_Returns_
+
+-   `boolean`: Return true if value is string in format var:preset|spacing|.
 
 ### JustifyContentControl
 

--- a/packages/block-editor/README.md
+++ b/packages/block-editor/README.md
@@ -517,6 +517,18 @@ _Returns_
 
 -   `string`: returns the cssUnit value in a simple px format.
 
+### getSpacingPresetCssVar
+
+Converts a spacing preset into a custom value.
+
+_Parameters_
+
+-   _value_ `string`: Value to convert.
+
+_Returns_
+
+-   `string | undefined`: CSS var string for given spacing preset value.
+
 ### getTypographyClassesAndStyles
 
 Provides the CSS class names and inline styles for a block's typography support
@@ -549,17 +561,6 @@ _Parameters_
 _Returns_
 
 -   `WPComponent`: The component to be rendered.
-### getSpacingPresetCssVar
-
-Converts a spacing preset into a custom value.
-
-_Parameters_
-
--   _value_ `string`: Value to convert.
-
-_Returns_
-
--   `string`: CSS var string for given spacing preset value.
 
 ### InnerBlocks
 

--- a/packages/block-editor/src/components/index.js
+++ b/packages/block-editor/src/components/index.js
@@ -92,7 +92,10 @@ export { default as URLPopover } from './url-popover';
 export { __experimentalImageURLInputUI } from './url-popover/image-url-input-ui';
 export { default as withColorContext } from './color-palette/with-color-context';
 export { default as __experimentalSpacingSizesControl } from './spacing-sizes-control';
-
+export {
+	getSpacingPresetCssVar,
+	isValueSpacingPreset,
+} from './spacing-sizes-control/utils';
 /*
  * Content Related Components
  */

--- a/packages/block-editor/src/components/spacing-sizes-control/index.js
+++ b/packages/block-editor/src/components/spacing-sizes-control/index.js
@@ -32,6 +32,7 @@ export default function SpacingSizesControl( {
 	onMouseOver,
 	onMouseOut,
 } ) {
+	console.log( 'values', values );
 	const spacingSizes = [
 		{ name: 0, slug: '0', size: 0 },
 		...( useSetting( 'spacing.spacingSizes' ) || [] ),

--- a/packages/block-editor/src/components/spacing-sizes-control/index.js
+++ b/packages/block-editor/src/components/spacing-sizes-control/index.js
@@ -32,7 +32,6 @@ export default function SpacingSizesControl( {
 	onMouseOver,
 	onMouseOut,
 } ) {
-	console.log( 'values', values );
 	const spacingSizes = [
 		{ name: 0, slug: '0', size: 0 },
 		...( useSetting( 'spacing.spacingSizes' ) || [] ),

--- a/packages/block-editor/src/components/spacing-sizes-control/spacing-input-control.js
+++ b/packages/block-editor/src/components/spacing-sizes-control/spacing-input-control.js
@@ -20,6 +20,7 @@ import {
 } from '@wordpress/components';
 import { __, sprintf } from '@wordpress/i18n';
 import { settings } from '@wordpress/icons';
+import { usePrevious } from '@wordpress/compose';
 
 /**
  * Internal dependencies
@@ -70,6 +71,15 @@ export default function SpacingInputControl( {
 			value !== undefined &&
 			! isValueSpacingPreset( value )
 	);
+
+	const previousValue = usePrevious( value );
+	if (
+		isValueSpacingPreset( previousValue ) &&
+		! isValueSpacingPreset( value ) &&
+		showCustomValueControl !== true
+	) {
+		setShowCustomValueControl( true );
+	}
 
 	const units = useCustomUnits( {
 		availableUnits: useSetting( 'spacing.units' ) || [ 'px', 'em', 'rem' ],

--- a/packages/block-editor/src/components/spacing-sizes-control/spacing-input-control.js
+++ b/packages/block-editor/src/components/spacing-sizes-control/spacing-input-control.js
@@ -74,7 +74,7 @@ export default function SpacingInputControl( {
 
 	const previousValue = usePrevious( value );
 	if (
-		isValueSpacingPreset( previousValue ) &&
+		previousValue !== value &&
 		! isValueSpacingPreset( value ) &&
 		showCustomValueControl !== true
 	) {

--- a/packages/block-editor/src/components/spacing-sizes-control/style.scss
+++ b/packages/block-editor/src/components/spacing-sizes-control/style.scss
@@ -94,7 +94,9 @@
 		grid-column: 1;
 	}
 
-	.components-range-control {
+	.components-base-control.components-range-control {
+		margin-bottom: $grid-unit-20;
+		margin-top: 0;
 		height: 40px;
 		/* Vertically center the RangeControl until it has true 40px height. */
 		display: flex;

--- a/packages/block-editor/src/components/spacing-sizes-control/style.scss
+++ b/packages/block-editor/src/components/spacing-sizes-control/style.scss
@@ -55,6 +55,7 @@
 		grid-row: 1 / 1;
 		align-self: center;
 		margin-left: $grid-unit-05;
+		margin-bottom: $grid-unit-10;
 	}
 
 	.components-spacing-sizes-control__custom-toggle-all {

--- a/packages/block-editor/src/components/spacing-sizes-control/style.scss
+++ b/packages/block-editor/src/components/spacing-sizes-control/style.scss
@@ -2,7 +2,7 @@
 	display: grid;
 	grid-template-columns: auto 1fr auto;
 	align-items: center;
-	grid-template-rows: 16px auto;
+	grid-template-rows: $grid-unit-30 auto;
 }
 
 .component-spacing-sizes-control {

--- a/packages/block-editor/src/components/spacing-sizes-control/style.scss
+++ b/packages/block-editor/src/components/spacing-sizes-control/style.scss
@@ -19,7 +19,7 @@
 	}
 
 	.components-base-control__label {
-		margin-bottom: 0;
+		margin-bottom: $grid-unit-10;
 		height: $grid-unit-20;
 	}
 
@@ -85,22 +85,20 @@
 	.components-spacing-sizes-control__custom-value-range {
 		grid-column: span 2;
 		margin-left: $grid-unit-20;
-		margin-top: 8px;
 	}
 
-	.components-spacing-sizes-control__custom-value-input {
+	.components-base-control.components-spacing-sizes-control__custom-value-input {
 		width: 124px;
-		margin-top: 8px;
 		grid-column: 1;
+		margin-bottom: 0;
 	}
 
 	.components-base-control.components-range-control {
-		margin-bottom: $grid-unit-20;
-		margin-top: 0;
 		height: 40px;
 		/* Vertically center the RangeControl until it has true 40px height. */
 		display: flex;
 		align-items: center;
+		margin-bottom: 0;
 
 		> .components-base-control__field {
 			/* Fixes RangeControl contents when the outer wrapper is flex */
@@ -110,7 +108,6 @@
 
 	.components-spacing-sizes-control__range-control {
 		grid-column: span 3;
-		margin-top: 8px;
 	}
 
 	.components-range-control__mark {

--- a/packages/block-library/src/spacer/controls.js
+++ b/packages/block-library/src/spacer/controls.js
@@ -17,7 +17,6 @@ import {
 } from '@wordpress/components';
 import { useInstanceId } from '@wordpress/compose';
 import { View } from '@wordpress/primitives';
-import { Platform } from '@wordpress/element';
 
 /**
  * Internal dependencies
@@ -58,9 +57,7 @@ function DimensionInput( { label, onChange, isResizing, value = '' } ) {
 
 	return (
 		<>
-			{ ( ! spacingSizes ||
-				spacingSizes?.length === 0 ||
-				Platform.isNative ) && (
+			{ ( ! spacingSizes || spacingSizes?.length === 0 ) && (
 				<BaseControl label={ label } id={ inputId }>
 					<UnitControl
 						id={ inputId }

--- a/packages/block-library/src/spacer/controls.js
+++ b/packages/block-library/src/spacer/controls.js
@@ -16,6 +16,7 @@ import {
 	__experimentalParseQuantityAndUnitFromRawValue as parseQuantityAndUnitFromRawValue,
 } from '@wordpress/components';
 import { useInstanceId } from '@wordpress/compose';
+import { View } from '@wordpress/primitives';
 
 /**
  * Internal dependencies
@@ -71,7 +72,7 @@ function DimensionInput( { label, onChange, isResizing, value = '' } ) {
 			) }
 
 			{ spacingSizes?.length > 0 && (
-				<div className="tools-panel-item-spacing">
+				<View className="tools-panel-item-spacing">
 					<SpacingSizesControl
 						values={ { all: computedValue } }
 						onChange={ handleOnChange }
@@ -81,7 +82,7 @@ function DimensionInput( { label, onChange, isResizing, value = '' } ) {
 						allowReset={ false }
 						splitOnAxis={ false }
 					/>
-				</div>
+				</View>
 			) }
 		</>
 	);

--- a/packages/block-library/src/spacer/controls.js
+++ b/packages/block-library/src/spacer/controls.js
@@ -17,6 +17,7 @@ import {
 } from '@wordpress/components';
 import { useInstanceId } from '@wordpress/compose';
 import { View } from '@wordpress/primitives';
+import { Platform } from '@wordpress/element';
 
 /**
  * Internal dependencies
@@ -57,7 +58,9 @@ function DimensionInput( { label, onChange, isResizing, value = '' } ) {
 
 	return (
 		<>
-			{ ( ! spacingSizes || spacingSizes?.length === 0 ) && (
+			{ ( ! spacingSizes ||
+				spacingSizes?.length === 0 ||
+				Platform.isNative ) && (
 				<BaseControl label={ label } id={ inputId }>
 					<UnitControl
 						id={ inputId }

--- a/packages/block-library/src/spacer/controls.js
+++ b/packages/block-library/src/spacer/controls.js
@@ -2,11 +2,16 @@
  * WordPress dependencies
  */
 import { __ } from '@wordpress/i18n';
-import { InspectorControls, useSetting } from '@wordpress/block-editor';
 import {
+	InspectorControls,
+	useSetting,
+	__experimentalSpacingSizesControl as SpacingSizesControl,
+	isValueSpacingPreset,
+} from '@wordpress/block-editor';
+import {
+	UnitControl,
 	PanelBody,
 	__experimentalUseCustomUnits as useCustomUnits,
-	__experimentalUnitControl as UnitControl,
 	__experimentalParseQuantityAndUnitFromRawValue as parseQuantityAndUnitFromRawValue,
 } from '@wordpress/components';
 import { useInstanceId } from '@wordpress/compose';
@@ -18,7 +23,6 @@ import { MIN_SPACER_SIZE } from './constants';
 
 function DimensionInput( { label, onChange, isResizing, value = '' } ) {
 	const inputId = useInstanceId( UnitControl, 'block-spacer-height-input' );
-
 	// In most contexts the spacer size cannot meaningfully be set to a
 	// percentage, since this is relative to the parent container. This
 	// unit is disabled from the UI.
@@ -38,28 +42,40 @@ function DimensionInput( { label, onChange, isResizing, value = '' } ) {
 	} );
 
 	const handleOnChange = ( unprocessedValue ) => {
-		onChange( unprocessedValue );
+		onChange( unprocessedValue.all );
 	};
 
 	// Force the unit to update to `px` when the Spacer is being resized.
 	const [ parsedQuantity, parsedUnit ] =
 		parseQuantityAndUnitFromRawValue( value );
-	const computedValue = [
-		parsedQuantity,
-		isResizing ? 'px' : parsedUnit,
-	].join( '' );
+	const computedValue = isValueSpacingPreset( value )
+		? value
+		: [ parsedQuantity, isResizing ? 'px' : parsedUnit ].join( '' );
 
 	return (
-		<UnitControl
-			label={ label }
-			id={ inputId }
-			isResetValueOnUnitChange
-			min={ MIN_SPACER_SIZE }
-			onChange={ handleOnChange }
-			__unstableInputWidth={ '80px' }
-			value={ computedValue }
-			units={ units }
-		/>
+		<>
+			<UnitControl
+				label={ label }
+				id={ inputId }
+				isResetValueOnUnitChange
+				min={ MIN_SPACER_SIZE }
+				onChange={ handleOnChange }
+				__unstableInputWidth={ '80px' }
+				value={ computedValue }
+				units={ units }
+			/>
+			<div className="tools-panel-item-spacing">
+				<SpacingSizesControl
+					values={ { all: computedValue } }
+					onChange={ handleOnChange }
+					label={ label }
+					sides={ [ 'all' ] }
+					units={ units }
+					allowReset={ false }
+					splitOnAxis={ false }
+				/>
+			</div>
+		</>
 	);
 }
 

--- a/packages/block-library/src/spacer/controls.js
+++ b/packages/block-library/src/spacer/controls.js
@@ -9,10 +9,10 @@ import {
 	isValueSpacingPreset,
 } from '@wordpress/block-editor';
 import {
-	UnitControl,
 	BaseControl,
 	PanelBody,
 	__experimentalUseCustomUnits as useCustomUnits,
+	__experimentalUnitControl as UnitControl,
 	__experimentalParseQuantityAndUnitFromRawValue as parseQuantityAndUnitFromRawValue,
 } from '@wordpress/components';
 import { useInstanceId } from '@wordpress/compose';
@@ -26,7 +26,6 @@ import { MIN_SPACER_SIZE } from './constants';
 function DimensionInput( { label, onChange, isResizing, value = '' } ) {
 	const inputId = useInstanceId( UnitControl, 'block-spacer-height-input' );
 	const spacingSizes = useSetting( 'spacing.spacingSizes' );
-
 	// In most contexts the spacer size cannot meaningfully be set to a
 	// percentage, since this is relative to the parent container. This
 	// unit is disabled from the UI.

--- a/packages/block-library/src/spacer/controls.js
+++ b/packages/block-library/src/spacer/controls.js
@@ -10,6 +10,7 @@ import {
 } from '@wordpress/block-editor';
 import {
 	UnitControl,
+	BaseControl,
 	PanelBody,
 	__experimentalUseCustomUnits as useCustomUnits,
 	__experimentalParseQuantityAndUnitFromRawValue as parseQuantityAndUnitFromRawValue,
@@ -23,6 +24,7 @@ import { MIN_SPACER_SIZE } from './constants';
 
 function DimensionInput( { label, onChange, isResizing, value = '' } ) {
 	const inputId = useInstanceId( UnitControl, 'block-spacer-height-input' );
+	const spacingSizes = useSetting( 'spacing.spacingSizes' );
 	// In most contexts the spacer size cannot meaningfully be set to a
 	// percentage, since this is relative to the parent container. This
 	// unit is disabled from the UI.
@@ -54,27 +56,33 @@ function DimensionInput( { label, onChange, isResizing, value = '' } ) {
 
 	return (
 		<>
-			<UnitControl
-				label={ label }
-				id={ inputId }
-				isResetValueOnUnitChange
-				min={ MIN_SPACER_SIZE }
-				onChange={ handleOnChange }
-				__unstableInputWidth={ '80px' }
-				value={ computedValue }
-				units={ units }
-			/>
-			<div className="tools-panel-item-spacing">
-				<SpacingSizesControl
-					values={ { all: computedValue } }
-					onChange={ handleOnChange }
-					label={ label }
-					sides={ [ 'all' ] }
-					units={ units }
-					allowReset={ false }
-					splitOnAxis={ false }
-				/>
-			</div>
+			{ ( ! spacingSizes || spacingSizes?.length === 0 ) && (
+				<BaseControl label={ label } id={ inputId }>
+					<UnitControl
+						id={ inputId }
+						isResetValueOnUnitChange
+						min={ MIN_SPACER_SIZE }
+						onChange={ handleOnChange }
+						style={ { maxWidth: 80 } }
+						value={ computedValue }
+						units={ units }
+					/>
+				</BaseControl>
+			) }
+
+			{ spacingSizes?.length > 0 && (
+				<div className="tools-panel-item-spacing">
+					<SpacingSizesControl
+						values={ { all: computedValue } }
+						onChange={ handleOnChange }
+						label={ label }
+						sides={ [ 'all' ] }
+						units={ units }
+						allowReset={ false }
+						splitOnAxis={ false }
+					/>
+				</div>
+			) }
 		</>
 	);
 }

--- a/packages/block-library/src/spacer/controls.js
+++ b/packages/block-library/src/spacer/controls.js
@@ -26,6 +26,7 @@ import { MIN_SPACER_SIZE } from './constants';
 function DimensionInput( { label, onChange, isResizing, value = '' } ) {
 	const inputId = useInstanceId( UnitControl, 'block-spacer-height-input' );
 	const spacingSizes = useSetting( 'spacing.spacingSizes' );
+
 	// In most contexts the spacer size cannot meaningfully be set to a
 	// percentage, since this is relative to the parent container. This
 	// unit is disabled from the UI.

--- a/packages/block-library/src/spacer/edit.js
+++ b/packages/block-library/src/spacer/edit.js
@@ -6,7 +6,7 @@ import classnames from 'classnames';
 /**
  * WordPress dependencies
  */
-import { useBlockProps } from '@wordpress/block-editor';
+import { useBlockProps, getSpacingPresetCssVar } from '@wordpress/block-editor';
 import { ResizableBox } from '@wordpress/components';
 import { useState, useEffect } from '@wordpress/element';
 import { View } from '@wordpress/primitives';
@@ -114,10 +114,12 @@ const SpacerEdit = ( {
 		height:
 			inheritedOrientation === 'horizontal'
 				? 24
-				: temporaryHeight || height || undefined,
+				: temporaryHeight ||
+				  getSpacingPresetCssVar( height ) ||
+				  undefined,
 		width:
 			inheritedOrientation === 'horizontal'
-				? temporaryWidth || width || undefined
+				? temporaryWidth || getSpacingPresetCssVar( width ) || undefined
 				: undefined,
 		// In vertical flex containers, the spacer shrinks to nothing without a minimum width.
 		minWidth:

--- a/packages/block-library/src/spacer/edit.js
+++ b/packages/block-library/src/spacer/edit.js
@@ -6,10 +6,15 @@ import classnames from 'classnames';
 /**
  * WordPress dependencies
  */
-import { useBlockProps, getSpacingPresetCssVar } from '@wordpress/block-editor';
+import {
+	useBlockProps,
+	getSpacingPresetCssVar,
+	store as blockEditorStore,
+} from '@wordpress/block-editor';
 import { ResizableBox } from '@wordpress/components';
 import { useState, useEffect } from '@wordpress/element';
 import { View } from '@wordpress/primitives';
+import { useSelect } from '@wordpress/data';
 
 /**
  * Internal dependencies
@@ -79,7 +84,12 @@ const SpacerEdit = ( {
 	toggleSelection,
 	context,
 	__unstableParentLayout: parentLayout,
+	className,
 } ) => {
+	const disableCustomSpacingSizes = useSelect( ( select ) => {
+		const editorSettings = select( blockEditorStore ).getSettings();
+		return editorSettings?.disableCustomSpacingSizes;
+	} );
 	const { orientation } = context;
 	const { orientation: parentOrientation, type } = parentLayout || {};
 	// If the spacer is inside a flex container, it should either inherit the orientation
@@ -191,7 +201,14 @@ const SpacerEdit = ( {
 
 	return (
 		<>
-			<View { ...useBlockProps( { style } ) }>
+			<View
+				{ ...useBlockProps( {
+					style,
+					className: classnames( className, {
+						'custom-sizes-disabled': disableCustomSpacingSizes,
+					} ),
+				} ) }
+			>
 				{ resizableBoxWithOrientation( inheritedOrientation ) }
 			</View>
 			<SpacerControls

--- a/packages/block-library/src/spacer/editor.scss
+++ b/packages/block-library/src/spacer/editor.scss
@@ -17,7 +17,8 @@
 }
 
 .wp-block-spacer.is-hovered .block-library-spacer__resize-container,
-.block-library-spacer__resize-container.has-show-handle {
+.block-library-spacer__resize-container.has-show-handle,
+.wp-block-spacer.is-selected.custom-sizes-disabled {
 	background: rgba($black, 0.1);
 
 	.is-dark-theme & {

--- a/packages/block-library/src/spacer/save.js
+++ b/packages/block-library/src/spacer/save.js
@@ -1,15 +1,15 @@
 /**
  * WordPress dependencies
  */
-import { useBlockProps } from '@wordpress/block-editor';
+import { useBlockProps, getSpacingPresetCssVar } from '@wordpress/block-editor';
 
 export default function save( { attributes: { height, width } } ) {
 	return (
 		<div
 			{ ...useBlockProps.save( {
 				style: {
-					height,
-					width,
+					height: getSpacingPresetCssVar( height ),
+					width: getSpacingPresetCssVar( width ),
 				},
 				'aria-hidden': true,
 			} ) }

--- a/packages/block-library/src/spacer/save.js
+++ b/packages/block-library/src/spacer/save.js
@@ -2,14 +2,21 @@
  * WordPress dependencies
  */
 import { useBlockProps, getSpacingPresetCssVar } from '@wordpress/block-editor';
+import { Platform } from '@wordpress/element';
 
 export default function save( { attributes: { height, width } } ) {
+	const currentHeight = Platform.isWeb
+		? getSpacingPresetCssVar( height )
+		: height;
+	const currentWidth = Platform.isWeb
+		? getSpacingPresetCssVar( width )
+		: width;
 	return (
 		<div
 			{ ...useBlockProps.save( {
 				style: {
-					height: getSpacingPresetCssVar( height ),
-					width: getSpacingPresetCssVar( width ),
+					height: currentHeight,
+					width: currentWidth,
 				},
 				'aria-hidden': true,
 			} ) }

--- a/packages/block-library/src/spacer/save.js
+++ b/packages/block-library/src/spacer/save.js
@@ -2,21 +2,14 @@
  * WordPress dependencies
  */
 import { useBlockProps, getSpacingPresetCssVar } from '@wordpress/block-editor';
-import { Platform } from '@wordpress/element';
 
 export default function save( { attributes: { height, width } } ) {
-	const currentHeight = Platform.isWeb
-		? getSpacingPresetCssVar( height )
-		: height;
-	const currentWidth = Platform.isWeb
-		? getSpacingPresetCssVar( width )
-		: width;
 	return (
 		<div
 			{ ...useBlockProps.save( {
 				style: {
-					height: currentHeight,
-					width: currentWidth,
+					height: getSpacingPresetCssVar( height ),
+					width: getSpacingPresetCssVar( width ),
 				},
 				'aria-hidden': true,
 			} ) }


### PR DESCRIPTION
## What?
Adds spacing presets to the spacer block


## Why?
This has been requested by theme authors to allow better control of spacing across a site

## How?
Adds the new  spacing presets control to the Spacer block

## Testing Instructions

- Add a Spacer block in a post and make sure it can be edited with spacing presets and custom settings, both in the right panel and by dragging resizable box. Also test a horizontal spacer in the Navigation block
- In theme.json set `settings.spacing.spacingScale.steps` to 0 and make sure only the custom sizing option appears
- In theme.json set `settings.spacing.customSpacingSize` to false and check that custom sizing and resizable box do not show in Spacer block 

## Screenshots or screencast 

https://user-images.githubusercontent.com/3629020/189553124-1385721f-2684-4833-a4cf-bb224cefd3d9.mp4


