### PR TITLE
Heading: Add missing typography support

### DIFF
--- a/packages/block-library/src/heading/block.json
+++ b/packages/block-library/src/heading/block.json
@@ -50,6 +50,7 @@
 			"__experimentalFontWeight": true,
 			"__experimentalLetterSpacing": true,
 			"__experimentalTextTransform": true,
+			"__experimentalTextDecoration": true,
 			"__experimentalDefaultControls": {
 				"fontSize": true,
 				"fontAppearance": true,


### PR DESCRIPTION
Related:
- https://github.com/WordPress/gutenberg/issues/43241
- https://github.com/WordPress/gutenberg/issues/43242

## What?

Adds missing typography support to the Heading block.

## Why?

- Improves consistency of our design tools across blocks.

## How?

- Opts into missing text-decoration typography support.

## Testing Instructions

1. Edit a post, add a Heading block, and select it
2. Check that the text-decoration control is now available
2. Ensure text decoration is applied both in the editor and frontend
3. Test styling via theme.json (Note: Text decoration isn't available in Global Styles)

Example theme.json snippet:
```json
			"core/heading": {
				"typography": {
					"textDecoration": "underline"
				}
			},
```

## Screenshots or screencast <!-- if applicable -->


