### PR TITLE
Fixed Categories (List) block center alignment in editor side

### DIFF
--- a/packages/block-library/src/categories/editor.scss
+++ b/packages/block-library/src/categories/editor.scss
@@ -5,3 +5,6 @@
 		margin-top: 6px;
 	}
 }
+[data-align="center"] .wp-block-categories{
+    text-align: center;
+}


### PR DESCRIPTION
Categories block center alignment setting is not reflecting on editor side.

Activate the Twenty Eleven Theme
Add Categories Block (or "Categories List" block if Gutenberg plugin is activated)
Select the "Display as dropdown" option in the sidebar
Change the alignment to center