### PR TITLE
Navigation Link: Add typography support

### DIFF
--- a/docs/reference-guides/core-blocks.md
+++ b/docs/reference-guides/core-blocks.md
@@ -401,7 +401,7 @@ Add a page, link, or another item to your navigation. ([Source](https://github.c
 
 -	**Name:** core/navigation-link
 -	**Category:** design
--	**Supports:** ~~html~~, ~~reusable~~
+-	**Supports:** typography (fontSize, lineHeight), ~~html~~, ~~reusable~~
 -	**Attributes:** description, id, isTopLevelLink, kind, label, opensInNewTab, rel, title, type, url
 
 ## Submenu

--- a/packages/block-library/src/navigation-link/block.json
+++ b/packages/block-library/src/navigation-link/block.json
@@ -58,7 +58,20 @@
 	"supports": {
 		"reusable": false,
 		"html": false,
-		"__experimentalSlashInserter": true
+		"__experimentalSlashInserter": true,
+		"typography": {
+			"fontSize": true,
+			"lineHeight": true,
+			"__experimentalFontFamily": true,
+			"__experimentalFontWeight": true,
+			"__experimentalFontStyle": true,
+			"__experimentalTextTransform": true,
+			"__experimentalTextDecoration": true,
+			"__experimentalLetterSpacing": true,
+			"__experimentalDefaultControls": {
+				"fontSize": true
+			}
+		}
 	},
 	"editorStyle": "wp-block-navigation-link-editor",
 	"style": "wp-block-navigation-link"


### PR DESCRIPTION
Related:
- https://github.com/WordPress/gutenberg/issues/43241
- https://github.com/WordPress/gutenberg/issues/43242

## What?

Adds typography supports to the Navigation Link block.

## Why?

- Improves consistency of our design tools across blocks.
- Allows typographic styling of custom navigation links independent of the parent Navigation block's styles.

## How?

- Opts into all typography supports.
- Makes font size control displayed by default as per the majority of blocks currently.

## Testing Instructions

1. In the site editor, edit a template with a Navigation block and add a couple of custom Navigation Links.
2. Navigate to Global Styles > Blocks > Custom Link > Typography. (Navigation Link block is named Custom Link)
3. Experiment with typography styles and ensure they are applied to the custom Navigation Link blocks in the preview.
4. Select one of your custom Navigation Link blocks and open the settings toolbar.
5. Within the typography panel, configure some overriding styles. These should be reflected in the preview.
6. Save and confirm styles on the frontend.
7. For bonus points, you can also test theme.json to be thorough.

Example theme.json snippet:
```json
			"core/navigation-link": {
				"typography": {
					"fontWeight": "100",
					"textTransform": "uppercase"
				}
			}
```

## Screenshots or screencast <!-- if applicable -->


https://user-images.githubusercontent.com/60436221/189278417-e405caeb-9a6c-4710-8d2a-d86f7b055eda.mp4


