### PR TITLE
[WIP] Navigation Submenu: Add typography support

### DIFF
--- a/docs/reference-guides/core-blocks.md
+++ b/docs/reference-guides/core-blocks.md
@@ -410,7 +410,7 @@ Add a submenu to your navigation. ([Source](https://github.com/WordPress/gutenbe
 
 -	**Name:** core/navigation-submenu
 -	**Category:** design
--	**Supports:** ~~html~~, ~~reusable~~
+-	**Supports:** typography (fontSize, lineHeight), ~~html~~, ~~reusable~~
 -	**Attributes:** description, id, isTopLevelItem, kind, label, opensInNewTab, rel, title, type, url
 
 ## Page Break

--- a/packages/block-library/src/navigation-submenu/block.json
+++ b/packages/block-library/src/navigation-submenu/block.json
@@ -58,7 +58,20 @@
 	],
 	"supports": {
 		"reusable": false,
-		"html": false
+		"html": false,
+		"typography": {
+			"fontSize": true,
+			"lineHeight": true,
+			"__experimentalFontFamily": true,
+			"__experimentalFontWeight": true,
+			"__experimentalFontStyle": true,
+			"__experimentalTextTransform": true,
+			"__experimentalTextDecoration": true,
+			"__experimentalLetterSpacing": true,
+			"__experimentalDefaultControls": {
+				"fontSize": true
+			}
+		}
 	},
 	"editorStyle": "wp-block-navigation-submenu-editor",
 	"style": "wp-block-navigation-submenu"


### PR DESCRIPTION
Related:
- https://github.com/WordPress/gutenberg/issues/43241
- https://github.com/WordPress/gutenberg/issues/43242

⚠️ 🚧  **Application of text decoration styles needs work as they won't get inherited by submenu navigation links.**  🚧 ⚠️ 

We could possibly skip the text-decoration support now if we maintain the other typography styles on the block wrapper in future. An alternate option might be to skip serialization of the typography styles but manually apply all but the text-decoration class names and styles to the wrapper.

## What?

Adds typography supports to the Navigation block.

## Why?

- Improves consistency of our design tools across blocks.
- Allows typography styling of navigation submenus independent of the Navigation block's styles.

## How?

- Opts into all typography supports.
- Makes font size control displayed by default as per majority of blocks currently.

## Testing Instructions

1. In the site editor, edit a template with a Navigation block, and add a submenu complete with a few links.
2. Navigate to Global Styles > Blocks > Navigation Submenu > Typography.
3. Experiment with typography styles and ensure they are applied to the Navigation Submenu blocks in the preview.
4. Select your Navigation Submenu block and switch to the settings sidebar.
5. Within the typography panel, configure some overriding styles. These should be reflected in the preview.
6. Save and confirm styles on the frontend.
7. For bonus points you can also test theme.json to be thorough.

Example theme.json snippet:
```json
			"core/navigation-submenu": {
				"typography": {
					"fontWeight": "100",
					"textTransform": "uppercase"
				}
			}
```

## Screenshots or screencast <!-- if applicable -->


