### PR TITLE
Editor: Add 'isDeletingPost' selector

### DIFF
--- a/docs/reference-guides/data/data-core-editor.md
+++ b/docs/reference-guides/data/data-core-editor.md
@@ -758,6 +758,18 @@ _Returns_
 
 -   `boolean`: Whether current post is scheduled to be posted.
 
+### isDeletingPost
+
+Returns true if the post is currently being deleted, or false otherwise.
+
+_Parameters_
+
+-   _state_ `Object`: Editor state.
+
+_Returns_
+
+-   `boolean`: Whether post is being deleted.
+
 ### isEditedPostAutosaveable
 
 Returns true if the post can be autosaved, or false otherwise.

--- a/packages/editor/src/components/post-trash/index.js
+++ b/packages/editor/src/components/post-trash/index.js
@@ -11,10 +11,11 @@ import { useSelect, useDispatch } from '@wordpress/data';
 import { store as editorStore } from '../../store';
 
 export default function PostTrash() {
-	const { isNew, postId } = useSelect( ( select ) => {
+	const { isNew, isDeleting, postId } = useSelect( ( select ) => {
 		const store = select( editorStore );
 		return {
 			isNew: store.isEditedPostNew(),
+			isDeleting: store.isDeletingPost(),
 			postId: store.getCurrentPostId(),
 		};
 	}, [] );
@@ -29,7 +30,9 @@ export default function PostTrash() {
 			className="editor-post-trash"
 			isDestructive
 			variant="secondary"
-			onClick={ () => trashPost() }
+			isBusy={ isDeleting }
+			aria-disabled={ isDeleting }
+			onClick={ isDeleting ? undefined : () => trashPost() }
 		>
 			{ __( 'Move to trash' ) }
 		</Button>

--- a/packages/editor/src/store/actions.js
+++ b/packages/editor/src/store/actions.js
@@ -247,6 +247,7 @@ export const trashPost =
 		registry.dispatch( noticesStore ).removeNotice( TRASH_POST_NOTICE_ID );
 		const { rest_base: restBase, rest_namespace: restNamespace = 'wp/v2' } =
 			postType;
+		dispatch( { type: 'REQUEST_POST_DELETE_START' } );
 		try {
 			const post = select.getCurrentPost();
 			await apiFetch( {
@@ -262,6 +263,7 @@ export const trashPost =
 					...getNotificationArgumentsForTrashFail( { error } )
 				);
 		}
+		dispatch( { type: 'REQUEST_POST_DELETE_FINISH' } );
 	};
 
 /**

--- a/packages/editor/src/store/reducer.js
+++ b/packages/editor/src/store/reducer.js
@@ -142,6 +142,26 @@ export function saving( state = {}, action ) {
 }
 
 /**
+ * Reducer returning deleting post request state.
+ *
+ * @param {Object} state  Current state.
+ * @param {Object} action Dispatched action.
+ *
+ * @return {Object} Updated state.
+ */
+export function deleting( state = {}, action ) {
+	switch ( action.type ) {
+		case 'REQUEST_POST_DELETE_START':
+		case 'REQUEST_POST_DELETE_FINISH':
+			return {
+				pending: action.type === 'REQUEST_POST_DELETE_START',
+			};
+	}
+
+	return state;
+}
+
+/**
  * Post Lock State.
  *
  * @typedef {Object} PostLockState
@@ -263,6 +283,7 @@ export default combineReducers( {
 	postId,
 	postType,
 	saving,
+	deleting,
 	postLock,
 	template,
 	postSavingLock,

--- a/packages/editor/src/store/selectors.js
+++ b/packages/editor/src/store/selectors.js
@@ -673,6 +673,17 @@ export function isEditedPostDateFloating( state ) {
 }
 
 /**
+ * Returns true if the post is currently being deleted, or false otherwise.
+ *
+ * @param {Object} state Editor state.
+ *
+ * @return {boolean} Whether post is being deleted.
+ */
+export function isDeletingPost( state ) {
+	return !! state.deleting.pending;
+}
+
+/**
  * Returns true if the post is currently being saved, or false otherwise.
  *
  * @param {Object} state Global application state.

--- a/packages/editor/src/store/test/actions.js
+++ b/packages/editor/src/store/test/actions.js
@@ -294,6 +294,48 @@ describe( 'Post actions', () => {
 			const { status } = registry.select( editorStore ).getCurrentPost();
 			expect( status ).toBe( 'trash' );
 		} );
+
+		it( 'sets deleting state', async () => {
+			const post = {
+				id: postId,
+				type: 'post',
+				content: 'foo',
+				status: 'publish',
+			};
+
+			const dispatch = Object.assign( jest.fn(), {
+				savePost: jest.fn(),
+			} );
+			const select = {
+				getCurrentPostType: () => 'post',
+				getCurrentPost: () => post,
+			};
+			const registry = {
+				dispatch: () => ( {
+					removeNotice: jest.fn(),
+					createErrorNotice: jest.fn(),
+				} ),
+				resolveSelect: () => ( {
+					getPostType: () => ( {
+						rest_namespace: 'wp/v2',
+						rest_base: 'posts',
+					} ),
+				} ),
+			};
+
+			apiFetch.setFetchHandler( async () => {
+				return { ...post, status: 'trash' };
+			} );
+
+			await actions.trashPost()( { select, dispatch, registry } );
+
+			expect( dispatch ).toHaveBeenCalledWith( {
+				type: 'REQUEST_POST_DELETE_START',
+			} );
+			expect( dispatch ).toHaveBeenCalledWith( {
+				type: 'REQUEST_POST_DELETE_FINISH',
+			} );
+		} );
 	} );
 } );
 


### PR DESCRIPTION
## What?
Resolves #43863
Fixes #15755.

PR introduces a new `isDeletingPost` selector for the editor store to check if the current post is being deleted.

## Why?
There's a long-standing issue where users on slow networks can click the "Move to trash" button multiple times, which results in failure notices. See #15755.

To fix this, the editor needs a way to signal the components that the post is being deleted.

Initially, I tried to refactor the `trashPost` action to use `deleteEntityRecord`, so we could use `isDeletingEntityRecord`. But some of the logic in the editor relies on `getCurrentPost` to be available even when a post is trashed, and `deleteEntityRecord` also removes records from the store.

A good example of this will be the `BrowserURL` component, which handles page redirection when the post status is changed to `trash`. However, there probably are more cases that I've not found yet.

## How?
The trash post now dispatches two new actions - `REQUEST_POST_DELETE_START` and `REQUEST_POST_DELETE_FINISH`.

## Testing Instructions
Unit tests are passing.

```
npm run test:unit packages/editor/src/store/test/actions.js
```