### PR TITLE
Components: Refactor `withFilters` tests to `@testing-library/react`

### DIFF
--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -50,6 +50,7 @@
 -   `Popover`: refactor to TypeScript ([#43823](https://github.com/WordPress/gutenberg/pull/43823/)).
 -   `BorderControl` and `BorderBoxControl`: replace temporary types with `Popover`'s types ([#43823](https://github.com/WordPress/gutenberg/pull/43823/)).
 -   `DimensionControl`: Refactor tests to `@testing-library/react` ([#43916](https://github.com/WordPress/gutenberg/pull/43916)).
+-   `withFilters`: Refactor tests to `@testing-library/react` ([#44017](https://github.com/WordPress/gutenberg/pull/44017)).
 
 ## 20.0.0 (2022-08-24)
 

--- a/packages/components/src/higher-order/with-filters/test/__snapshots__/index.js.snap
+++ b/packages/components/src/higher-order/with-filters/test/__snapshots__/index.js.snap
@@ -1,0 +1,87 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`withFilters should display a component overridden by the filter 1`] = `
+<div>
+  <div>
+    Overridden component
+  </div>
+</div>
+`;
+
+exports[`withFilters should display original component when no filters applied 1`] = `
+<div>
+  <div>
+    My component
+  </div>
+</div>
+`;
+
+exports[`withFilters should display two components composed by the filter 1`] = `
+<div>
+  <div>
+    <div>
+      My component
+    </div>
+    <div>
+      Composed component
+    </div>
+  </div>
+</div>
+`;
+
+exports[`withFilters should not re-render component when new filter added before component was mounted 1`] = `
+<div>
+  <blockquote>
+    <div>
+      Spied component
+    </div>
+  </blockquote>
+</div>
+`;
+
+exports[`withFilters should re-render both components once each when one filter added 1`] = `
+<div>
+  <section>
+    <blockquote>
+      <div>
+        Spied component
+      </div>
+    </blockquote>
+    <blockquote>
+      <div>
+        Spied component
+      </div>
+    </blockquote>
+  </section>
+</div>
+`;
+
+exports[`withFilters should re-render component once when new filter added after component was mounted 1`] = `
+<div>
+  <blockquote>
+    <div>
+      Spied component
+    </div>
+  </blockquote>
+</div>
+`;
+
+exports[`withFilters should re-render component once when two filters added in the same animation frame 1`] = `
+<div>
+  <section>
+    <blockquote>
+      <div>
+        Spied component
+      </div>
+    </blockquote>
+  </section>
+</div>
+`;
+
+exports[`withFilters should re-render component twice when new filter added and removed in two different animation frames 1`] = `
+<div>
+  <div>
+    Spied component
+  </div>
+</div>
+`;


### PR DESCRIPTION
## What?
We've recently started refactoring `enzyme` tests to `@testing-library/react`.

This PR refactors the `withFilters()` HoC tests from `enzyme` to `@testing-library/react`.

## Why?
`@testing-library/react` provides a better way to write tests for accessible components that is closer to the way the user experiences them.

## How?
We're straightforwardly replacing `enzyme` tests with `@testing-library/react` ones, using `jest-dom` matchers and mocks to avoid testing unrelated implementation details.

We're using snapshots since the original tests assert expected markup, and snapshot tests are ideal for that.

## Testing Instructions
* Verify tests pass: `npm run test:unit packages/components/src/higher-order/with-filters/test/index.js`
* Verify snapshots match the expected result from the previous version of the tests. 
