### PR TITLE
Global Styles: Re-add third party blocks

### DIFF
--- a/lib/compat/wordpress-6.1/get-global-styles-and-settings.php
+++ b/lib/compat/wordpress-6.1/get-global-styles-and-settings.php
@@ -20,11 +20,16 @@ function gutenberg_add_global_styles_for_blocks() {
 		}
 
 		if ( isset( $metadata['name'] ) ) {
-			$block_name = str_replace( 'core/', '', $metadata['name'] );
 			// These block styles are added on block_render.
 			// This hooks inline CSS to them so that they are loaded conditionally
 			// based on whether or not the block is used on the page.
-			wp_add_inline_style( 'wp-block-' . $block_name, $block_css );
+			if ( 0 === strpos( $metadata['name'], 'core/' ) ) {
+				$block_name = str_replace( 'core/', '', $metadata['name'] );
+				wp_add_inline_style( 'wp-block-' . $block_name, $block_css );
+			} else {
+				$block_name = str_replace( '/', '-block-', $metadata['name'] );
+				wp_add_inline_style( $block_name, $block_css );
+			}
 		}
 
 		// The likes of block element styles from theme.json do not have  $metadata['name'] set.

--- a/lib/compat/wordpress-6.1/get-global-styles-and-settings.php
+++ b/lib/compat/wordpress-6.1/get-global-styles-and-settings.php
@@ -23,12 +23,12 @@ function gutenberg_add_global_styles_for_blocks() {
 			// These block styles are added on block_render.
 			// This hooks inline CSS to them so that they are loaded conditionally
 			// based on whether or not the block is used on the page.
-			if ( 0 === strpos( $metadata['name'], 'core/' ) ) {
-				$block_name = str_replace( 'core/', '', $metadata['name'] );
-				wp_add_inline_style( 'wp-block-' . $block_name, $block_css );
-			} else {
-				wp_add_inline_style( 'global-styles', $block_css );
+			$stylesheet_handle = 'global-styles';
+			if ( str_starts_with( $metadata['name'], 'core/' ) ) {
+				$block_name        = str_replace( 'core/', '', $metadata['name'] );
+				$stylesheet_handle = 'wp-block-' . $block_name;
 			}
+			wp_add_inline_style( $stylesheet_handle, $block_css );
 		}
 
 		// The likes of block element styles from theme.json do not have  $metadata['name'] set.

--- a/lib/compat/wordpress-6.1/get-global-styles-and-settings.php
+++ b/lib/compat/wordpress-6.1/get-global-styles-and-settings.php
@@ -45,8 +45,8 @@ function gutenberg_add_global_styles_for_blocks() {
 				)
 			);
 			if ( isset( $result[0] ) ) {
-				if ( str_starts_with( $metadata['name'], 'core/' ) ) {
-					$block_name = str_replace( 'core/', '', $result[0] );
+				if ( str_starts_with( $result[0], 'core/' ) ) {
+					$block_name        = str_replace( 'core/', '', $result[0] );
 					$stylesheet_handle = 'wp-block-' . $block_name;
 				}
 				wp_add_inline_style( $stylesheet_handle, $block_css );

--- a/lib/compat/wordpress-6.1/get-global-styles-and-settings.php
+++ b/lib/compat/wordpress-6.1/get-global-styles-and-settings.php
@@ -19,11 +19,11 @@ function gutenberg_add_global_styles_for_blocks() {
 			continue;
 		}
 
+		$stylesheet_handle = 'global-styles';
 		if ( isset( $metadata['name'] ) ) {
 			// These block styles are added on block_render.
 			// This hooks inline CSS to them so that they are loaded conditionally
 			// based on whether or not the block is used on the page.
-			$stylesheet_handle = 'global-styles';
 			if ( str_starts_with( $metadata['name'], 'core/' ) ) {
 				$block_name        = str_replace( 'core/', '', $metadata['name'] );
 				$stylesheet_handle = 'wp-block-' . $block_name;
@@ -45,12 +45,11 @@ function gutenberg_add_global_styles_for_blocks() {
 				)
 			);
 			if ( isset( $result[0] ) ) {
-				if ( 0 === strpos( $metadata['name'], 'core/' ) ) {
+				if ( str_starts_with( $metadata['name'], 'core/' ) ) {
 					$block_name = str_replace( 'core/', '', $result[0] );
-					wp_add_inline_style( 'wp-block-' . $block_name, $block_css );
-				} else {
-					wp_add_inline_style( 'global-styles', $block_css );
+					$stylesheet_handle = 'wp-block-' . $block_name;
 				}
+				wp_add_inline_style( $stylesheet_handle, $block_css );
 			}
 		}
 	}

--- a/lib/compat/wordpress-6.1/get-global-styles-and-settings.php
+++ b/lib/compat/wordpress-6.1/get-global-styles-and-settings.php
@@ -27,8 +27,7 @@ function gutenberg_add_global_styles_for_blocks() {
 				$block_name = str_replace( 'core/', '', $metadata['name'] );
 				wp_add_inline_style( 'wp-block-' . $block_name, $block_css );
 			} else {
-				$block_name = str_replace( '/', '-block-', $metadata['name'] );
-				wp_add_inline_style( $block_name, $block_css );
+				wp_add_inline_style( 'global-styles', $block_css );
 			}
 		}
 
@@ -46,8 +45,12 @@ function gutenberg_add_global_styles_for_blocks() {
 				)
 			);
 			if ( isset( $result[0] ) ) {
-				$block_name = str_replace( 'core/', '', $result[0] );
-				wp_add_inline_style( 'wp-block-' . $block_name, $block_css );
+				if ( 0 === strpos( $metadata['name'], 'core/' ) ) {
+					$block_name = str_replace( 'core/', '', $result[0] );
+					wp_add_inline_style( 'wp-block-' . $block_name, $block_css );
+				} else {
+					wp_add_inline_style( 'global-styles', $block_css );
+				}
 			}
 		}
 	}


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
This outputs Global Styles CSS for third party blocks.

## Why?
Third party blocks should be able to consume Global Styles settings as well as core blocks.

## How?
Since we can't predict the name for CSS files used for third party blocks, we need to add the block CSS to the global-styles inline CSS.

## Testing Instructions
1. Add some third party blocks to a post (I'm using the Woo mini cart and Jetpack Tiled Gallery)
2. Add this code to your theme.json:
```
			"jetpack/tiled-gallery": {
				"color": {
					"background": "yellow"
				}
			},
			"woocommerce/mini-cart": {
				"color": {
					"background": "purple"
				}
			}
```
3. Or use the Global Styles interface to modify the settings for some third party blocks
4. Confirm that the blocks look correct in the frontend and the editor.


## Screenshots or screencast <!-- if applicable -->
<img width="686" alt="Screenshot 2022-09-09 at 09 33 46" src="https://user-images.githubusercontent.com/275961/189307978-b4122057-1898-4d07-9852-a43d94bb23c6.png">

@WordPress/block-themers 

