### PR TITLE
Query Pagination: Avoid creating a new allowedBlocks array on every render

### DIFF
--- a/packages/block-library/src/query-pagination/edit.js
+++ b/packages/block-library/src/query-pagination/edit.js
@@ -22,6 +22,11 @@ const TEMPLATE = [
 	[ 'core/query-pagination-numbers' ],
 	[ 'core/query-pagination-next' ],
 ];
+const ALLOWED_BLOCKS = [
+	'core/query-pagination-previous',
+	'core/query-pagination-numbers',
+	'core/query-pagination-next',
+];
 
 const getDefaultBlockLayout = ( blockTypeOrName ) => {
 	const layoutBlockSupportConfig = getBlockSupport(
@@ -55,11 +60,7 @@ export default function QueryPaginationEdit( {
 	const blockProps = useBlockProps();
 	const innerBlocksProps = useInnerBlocksProps( blockProps, {
 		template: TEMPLATE,
-		allowedBlocks: [
-			'core/query-pagination-previous',
-			'core/query-pagination-numbers',
-			'core/query-pagination-next',
-		],
+		allowedBlocks: ALLOWED_BLOCKS,
 		__experimentalLayout: usedLayout,
 	} );
 	return (


### PR DESCRIPTION
## What?
Use constant for the `allowedBlocks` setting to avoid creating a new array on every render. Passing a new array can fail shallow equality and trigger settings updates.

Similar to #30374, #44011.

## Testing Instructions
The Query Pagination block should work as before.
