### PR TITLE
Comments Pagination: Avoid creating a new allowedBlocks array on every render

### DIFF
--- a/packages/block-library/src/comments-pagination/edit.js
+++ b/packages/block-library/src/comments-pagination/edit.js
@@ -23,6 +23,11 @@ const TEMPLATE = [
 	[ 'core/comments-pagination-numbers' ],
 	[ 'core/comments-pagination-next' ],
 ];
+const ALLOWED_BLOCKS = [
+	'core/comments-pagination-previous',
+	'core/comments-pagination-numbers',
+	'core/comments-pagination-next',
+];
 
 const getDefaultBlockLayout = ( blockTypeOrName ) => {
 	const layoutBlockSupportConfig = getBlockSupport(
@@ -58,11 +63,7 @@ export default function QueryPaginationEdit( {
 	const blockProps = useBlockProps();
 	const innerBlocksProps = useInnerBlocksProps( blockProps, {
 		template: TEMPLATE,
-		allowedBlocks: [
-			'core/comments-pagination-previous',
-			'core/comments-pagination-numbers',
-			'core/comments-pagination-next',
-		],
+		allowedBlocks: ALLOWED_BLOCKS,
 		__experimentalLayout: usedLayout,
 	} );
 


### PR DESCRIPTION
## What?
Use constant for the allowedBlocks setting to avoid creating a new array on every render. Passing a new array can fail shallow equality and trigger settings updates.

Similar to #44020.

## Testing Instructions
The Comments Pagination block should work as before.
