### PR TITLE
Docs: fix required status of `onSelectUrl` prop of `MediaReplaceFlow` component

### DIFF
--- a/packages/block-editor/src/components/media-replace-flow/README.md
+++ b/packages/block-editor/src/components/media-replace-flow/README.md
@@ -54,7 +54,7 @@ Callback used when media is replaced from the Media Library or when a new media 
 Callback used when media is replaced with an URL. It is called with one argument `newURL` which is a `string` containing the new URL.
 
 -   Type: `func`
--   Required: Yes
+-   Required: No
 
 ### onError
 


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Fix documaentation of the `MediaReplaceFlow` component to indicate that the `onSelectUrl` prop is not actually required.

Looking at the sourcecode the code checks for the presence of the prop and only renders the media url field if the callback function was provided. https://github.com/WordPress/gutenberg/blob/6465552e337314a158b1b5ac81c7b1a08573510e/packages/block-editor/src/components/media-replace-flow/index.js#L207-L228

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

Because the current documentation is misleading
