### PR TITLE
Block Editor: Refactor `BlockVerticalAlignmentUI` tests to `@testing-library/react`

### DIFF
--- a/packages/block-editor/src/components/block-vertical-alignment-control/test/__snapshots__/index.js.snap
+++ b/packages/block-editor/src/components/block-vertical-alignment-control/test/__snapshots__/index.js.snap
@@ -1,69 +1,109 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`BlockVerticalAlignmentUI should match snapshot 1`] = `
-<ToolbarGroup
-  controls={
-    Array [
-      Object {
-        "icon": <SVG
+exports[`BlockVerticalAlignmentUI should match snapshot when controls are hidden 1`] = `
+<div>
+  <div
+    class="components-dropdown components-dropdown-menu components-toolbar"
+    tabindex="-1"
+  >
+    <button
+      aria-expanded="false"
+      aria-haspopup="true"
+      aria-label="Change vertical alignment"
+      class="components-button components-dropdown-menu__toggle has-icon"
+      data-toolbar-item="true"
+      type="button"
+    >
+      <svg
+        aria-hidden="true"
+        focusable="false"
+        height="24"
+        viewBox="0 0 24 24"
+        width="24"
+        xmlns="http://www.w3.org/2000/svg"
+      >
+        <path
+          d="M9 20h6V9H9v11zM4 4v1.5h16V4H4z"
+        />
+      </svg>
+    </button>
+  </div>
+</div>
+`;
+
+exports[`BlockVerticalAlignmentUI should match snapshot when controls are visible 1`] = `
+<div>
+  <div
+    class="components-toolbar"
+    icon="[object Object]"
+    label="Change vertical alignment"
+  >
+    <div>
+      <button
+        aria-label="Align top"
+        aria-pressed="true"
+        class="components-button components-toolbar__control is-pressed has-icon"
+        data-toolbar-item="true"
+        type="button"
+      >
+        <svg
+          aria-hidden="true"
+          focusable="false"
+          height="24"
           viewBox="0 0 24 24"
+          width="24"
           xmlns="http://www.w3.org/2000/svg"
         >
-          <Path
+          <path
             d="M9 20h6V9H9v11zM4 4v1.5h16V4H4z"
           />
-        </SVG>,
-        "isActive": true,
-        "onClick": [Function],
-        "role": "menuitemradio",
-        "title": "Align top",
-      },
-      Object {
-        "icon": <SVG
+        </svg>
+      </button>
+    </div>
+    <div>
+      <button
+        aria-label="Align middle"
+        aria-pressed="false"
+        class="components-button components-toolbar__control has-icon"
+        data-toolbar-item="true"
+        type="button"
+      >
+        <svg
+          aria-hidden="true"
+          focusable="false"
+          height="24"
           viewBox="0 0 24 24"
+          width="24"
           xmlns="http://www.w3.org/2000/svg"
         >
-          <Path
+          <path
             d="M20 11h-5V4H9v7H4v1.5h5V20h6v-7.5h5z"
           />
-        </SVG>,
-        "isActive": false,
-        "onClick": [Function],
-        "role": "menuitemradio",
-        "title": "Align middle",
-      },
-      Object {
-        "icon": <SVG
+        </svg>
+      </button>
+    </div>
+    <div>
+      <button
+        aria-label="Align bottom"
+        aria-pressed="false"
+        class="components-button components-toolbar__control has-icon"
+        data-toolbar-item="true"
+        type="button"
+      >
+        <svg
+          aria-hidden="true"
+          focusable="false"
+          height="24"
           viewBox="0 0 24 24"
+          width="24"
           xmlns="http://www.w3.org/2000/svg"
         >
-          <Path
+          <path
             d="M15 4H9v11h6V4zM4 18.5V20h16v-1.5H4z"
           />
-        </SVG>,
-        "isActive": false,
-        "onClick": [Function],
-        "role": "menuitemradio",
-        "title": "Align bottom",
-      },
-    ]
-  }
-  icon={
-    <SVG
-      viewBox="0 0 24 24"
-      xmlns="http://www.w3.org/2000/svg"
-    >
-      <Path
-        d="M9 20h6V9H9v11zM4 4v1.5h16V4H4z"
-      />
-    </SVG>
-  }
-  isCollapsed={true}
-  label="Change vertical alignment"
-  popoverProps={
-    Object {
-      "isAlternate": true,
-    }
-  }
-/>
+        </svg>
+      </button>
+    </div>
+  </div>
+</div>
 `;

--- a/packages/block-editor/src/components/block-vertical-alignment-control/test/index.js
+++ b/packages/block-editor/src/components/block-vertical-alignment-control/test/index.js
@@ -1,7 +1,8 @@
 /**
  * External dependencies
  */
-import { shallow } from 'enzyme';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 
 /**
  * Internal dependencies
@@ -12,44 +13,112 @@ describe( 'BlockVerticalAlignmentUI', () => {
 	const alignment = 'top';
 	const onChange = jest.fn();
 
-	const wrapper = shallow(
-		<BlockVerticalAlignmentUI
-			isToolbar
-			value={ alignment }
-			onChange={ onChange }
-		/>
-	);
-
-	const controls = wrapper.props().controls;
-
 	afterEach( () => {
 		onChange.mockClear();
 	} );
 
-	it( 'should match snapshot', () => {
-		expect( wrapper ).toMatchSnapshot();
+	test( 'should match snapshot when controls are hidden', () => {
+		const { container } = render(
+			<BlockVerticalAlignmentUI
+				isToolbar
+				value={ alignment }
+				onChange={ onChange }
+			/>
+		);
+		expect( container ).toMatchSnapshot();
 	} );
 
-	it( 'should call onChange with undefined, when the control is already active', () => {
-		const activeControl = controls.find( ( { title } ) =>
-			title.toLowerCase().includes( alignment )
+	test( 'should match snapshot when controls are visible', () => {
+		const { container } = render(
+			<BlockVerticalAlignmentUI
+				isToolbar
+				value={ alignment }
+				onChange={ onChange }
+				isCollapsed={ false }
+			/>
 		);
-		activeControl.onClick();
+		expect( container ).toMatchSnapshot();
+	} );
 
-		expect( activeControl.isActive ).toBe( true );
+	test( 'should expand controls when toggled', async () => {
+		const user = userEvent.setup( {
+			advanceTimers: jest.advanceTimersByTime,
+		} );
+
+		render(
+			<BlockVerticalAlignmentUI
+				isToolbar
+				value={ alignment }
+				onChange={ onChange }
+			/>
+		);
+
+		expect(
+			screen.queryByRole( 'menuitemradio', {
+				name: /^Align \w+$/,
+			} )
+		).not.toBeInTheDocument();
+
+		await user.click(
+			screen.getByRole( 'button', {
+				name: 'Change vertical alignment',
+			} )
+		);
+
+		expect(
+			screen.getAllByRole( 'menuitemradio', {
+				name: /^Align \w+$/,
+			} )
+		).toHaveLength( 3 );
+	} );
+
+	it( 'should call onChange with undefined, when the control is already active', async () => {
+		const user = userEvent.setup( {
+			advanceTimers: jest.advanceTimersByTime,
+		} );
+
+		render(
+			<BlockVerticalAlignmentUI
+				isToolbar
+				value={ alignment }
+				onChange={ onChange }
+				isCollapsed={ false }
+			/>
+		);
+
+		const activeControl = screen.getByRole( 'button', {
+			name: `Align ${ alignment }`,
+			pressed: true,
+		} );
+
+		await user.click( activeControl );
+
 		expect( onChange ).toHaveBeenCalledTimes( 1 );
 		expect( onChange ).toHaveBeenCalledWith( undefined );
 	} );
 
-	it( 'should call onChange with alignment value when the control is inactive', () => {
+	it( 'should call onChange with alignment value when the control is inactive', async () => {
 		// note "middle" alias for "center"
-		const inactiveCenterControl = controls.find( ( { title } ) =>
-			title.toLowerCase().includes( 'middle' )
+		const user = userEvent.setup( {
+			advanceTimers: jest.advanceTimersByTime,
+		} );
+
+		render(
+			<BlockVerticalAlignmentUI
+				isToolbar
+				value={ alignment }
+				onChange={ onChange }
+				isCollapsed={ false }
+			/>
 		);
 
-		inactiveCenterControl.onClick();
+		const inactiveControl = screen.getByRole( 'button', {
+			name: 'Align middle',
+			pressed: false,
+		} );
 
-		expect( inactiveCenterControl.isActive ).toBe( false );
+		await user.click( inactiveControl );
+
 		expect( onChange ).toHaveBeenCalledTimes( 1 );
 		expect( onChange ).toHaveBeenCalledWith( 'center' );
 	} );

--- a/packages/block-editor/src/components/block-vertical-alignment-control/ui.js
+++ b/packages/block-editor/src/components/block-vertical-alignment-control/ui.js
@@ -47,11 +47,12 @@ function BlockVerticalAlignmentUI( {
 		BLOCK_ALIGNMENTS_CONTROLS[ DEFAULT_CONTROL ];
 
 	const UIComponent = isToolbar ? ToolbarGroup : ToolbarDropdownMenu;
-	const extraProps = isToolbar ? { isCollapsed } : {};
+	const extraProps = isToolbar
+		? { isCollapsed }
+		: { popoverProps: { POPOVER_PROPS } };
 
 	return (
 		<UIComponent
-			popoverProps={ POPOVER_PROPS }
 			icon={
 				activeAlignment
 					? activeAlignment.icon


### PR DESCRIPTION
## What?
We've recently started refactoring `enzyme` tests to `@testing-library/react`.

This PR refactors the `BlockVerticalAlignmentUI` tests from `enzyme` to `@testing-library/react`.

## Why?
`@testing-library/react` provides a better way to write tests for accessible components that is closer to the way the user experiences them.

## How?
We're straightforwardly replacing `enzyme` tests with `@testing-library/react` ones, using `jest-dom` matchers and mocks to avoid testing unrelated implementation details.

Ideally, we should not be using snapshot tests here, however, the purpose of this PR is not to improve or enrich the tests themselves, but rather to migrate them `@testing-library/react`. Our primary motivation is unblocking the upgrade to React 18. Still, we're improving the tests a bit and adding a new one to test the toggling of controls visibility.

Finally, we're fixing a bug - we were always passing the `popoverProps` to `ToolbarGroup`, however, we were getting his error:

![Screenshot 2022-09-09 at 15 09 34](https://user-images.githubusercontent.com/8436925/189346928-bc2c725e-f114-4914-9e3b-bb13f6e5674d.png)

Instead, we meant to pass them only to the `ToolbarDropdownMenu`, which we're doing as a fix.

## Testing Instructions
Verify tests pass: `npm run test:unit packages/block-editor/src/components/block-vertical-alignment-control/test/index.js`
