### PR TITLE
Image: Display transformation error notice using snackbars

### DIFF
--- a/packages/block-library/src/image/transforms.js
+++ b/packages/block-library/src/image/transforms.js
@@ -151,7 +151,10 @@ const transforms = {
 						__(
 							'If uploading to a gallery all files need to be image formats'
 						),
-						{ id: 'gallery-transform-invalid-file' }
+						{
+							id: 'gallery-transform-invalid-file',
+							type: 'snackbar',
+						}
 					);
 				}
 				return every(


### PR DESCRIPTION
## What?
A follow-up to #43946.

Updates error notice type for the Image block transformation to "snackbar".

## Testing Instructions
1. Open a Post or Page.
2.  Try dragging and dropping multiple files into the content area, where at least one file isn't an image.
3. Confirm that the error message is displayed as snackbar.

## Screenshots or screencast <!-- if applicable -->

![CleanShot 2022-09-09 at 17 40 22](https://user-images.githubusercontent.com/240569/189364329-cccc325f-7c32-425a-a734-6ba08a01ba5f.png)
