### PR TITLE
Navigation: Hide overlay preview settings when the overlay is off

### DIFF
--- a/packages/block-library/src/navigation/edit/index.js
+++ b/packages/block-library/src/navigation/edit/index.js
@@ -484,32 +484,36 @@ function Navigation( {
 			{ hasSubmenuIndicatorSetting && (
 				<PanelBody title={ __( 'Display' ) }>
 					{ isResponsive && (
-						<Button
-							className={ overlayMenuPreviewClasses }
-							onClick={ () => {
-								setOverlayMenuPreview( ! overlayMenuPreview );
-							} }
-						>
-							{ hasIcon && (
-								<>
-									<OverlayMenuIcon icon={ icon } />
-									<Icon icon={ close } />
-								</>
+						<>
+							<Button
+								className={ overlayMenuPreviewClasses }
+								onClick={ () => {
+									setOverlayMenuPreview(
+										! overlayMenuPreview
+									);
+								} }
+							>
+								{ hasIcon && (
+									<>
+										<OverlayMenuIcon icon={ icon } />
+										<Icon icon={ close } />
+									</>
+								) }
+								{ ! hasIcon && (
+									<>
+										<span>{ __( 'Menu' ) }</span>
+										<span>{ __( 'Close' ) }</span>
+									</>
+								) }
+							</Button>
+							{ overlayMenuPreview && (
+								<OverlayMenuPreview
+									setAttributes={ setAttributes }
+									hasIcon={ hasIcon }
+									icon={ icon }
+								/>
 							) }
-							{ ! hasIcon && (
-								<>
-									<span>{ __( 'Menu' ) }</span>
-									<span>{ __( 'Close' ) }</span>
-								</>
-							) }
-						</Button>
-					) }
-					{ overlayMenuPreview && (
-						<OverlayMenuPreview
-							setAttributes={ setAttributes }
-							hasIcon={ hasIcon }
-							icon={ icon }
-						/>
+						</>
 					) }
 					<h3>{ __( 'Overlay Menu' ) }</h3>
 					<ToggleGroupControl


### PR DESCRIPTION
## What?
Fixes #44030.

Updates logic to hide overlay preview settings when the Navigation overaly is disabled.

## How?
I grouped icon settings and the preview settings under a single condition - `isResponsive`.

## Testing Instructions
1. Open a Post or Page.
2. Insert a Navigation block.
3. Open overlay preview settings by clicking the icon.
4. Turn off the overlay.
5. Confirm that the preview setting is also hidden.

## Screenshots or screencast <!-- if applicable -->

https://user-images.githubusercontent.com/240569/189367741-d007368e-881e-4c64-beb7-a642412a97c8.mp4

