### PR TITLE
Experiment: Client-side navigation of the Query Loop block using directives

### DIFF
--- a/packages/block-library/package.json
+++ b/packages/block-library/package.json
@@ -64,6 +64,7 @@
 		"lodash": "^4.17.21",
 		"memize": "^1.1.0",
 		"micromodal": "^0.4.10",
+		"preact": "^10.10.6",
 		"remove-accents": "^0.4.2"
 	},
 	"peerDependencies": {

--- a/packages/block-library/src/post-featured-image/index.php
+++ b/packages/block-library/src/post-featured-image/index.php
@@ -36,7 +36,7 @@ function render_block_core_post_featured_image( $attributes, $content, $block ) 
 	if ( $is_link ) {
 		$link_target    = $attributes['linkTarget'];
 		$rel            = ! empty( $attributes['rel'] ) ? 'rel="' . esc_attr( $attributes['rel'] ) . '"' : '';
-		$featured_image = sprintf( '<a href="%1$s" target="%2$s" %3$s>%4$s</a>', get_the_permalink( $post_ID ), esc_attr( $link_target ), $rel, $featured_image );
+		$featured_image = sprintf( '<a wp-client-navigation=\'{"prefetch":true}\' href="%1$s" target="%2$s" %3$s>%4$s</a>', get_the_permalink( $post_ID ), esc_attr( $link_target ), $rel, $featured_image );
 	}
 
 	$has_width  = ! empty( $attributes['width'] );

--- a/packages/block-library/src/post-template/index.php
+++ b/packages/block-library/src/post-template/index.php
@@ -107,7 +107,7 @@ function render_block_core_post_template( $attributes, $content, $block ) {
 	wp_reset_postdata();
 
 	return sprintf(
-		'<ul %1$s>%2$s</ul>',
+		'<ul %1$s>%2$s</ul><div class="animation"></div>',
 		$wrapper_attributes,
 		$content
 	);

--- a/packages/block-library/src/post-template/style.scss
+++ b/packages/block-library/src/post-template/style.scss
@@ -24,9 +24,31 @@
 		@include break-small {
 			@for $i from 2 through 6 {
 				&.is-flex-container.columns-#{ $i } > li {
-					width: calc((100% / #{ $i }) - 1.25em + (1.25em / #{ $i }));
+					width: calc((100% / #{$i}) - 1.25em + (1.25em / #{$i}));
 				}
 			}
 		}
+	}
+}
+
+div.animation {
+	width: 20px;
+	height: 20px;
+	background: #f00;
+	position: relative;
+	animation: animate 3s infinite;
+	animation-direction: alternate;
+}
+
+@keyframes animate {
+	0% {
+		background: #f00;
+		left: 0;
+		top: 0;
+	}
+	100% {
+		background: #ff0;
+		left: 300px;
+		top: 0;
 	}
 }

--- a/packages/block-library/src/post-title/index.php
+++ b/packages/block-library/src/post-title/index.php
@@ -35,7 +35,7 @@ function render_block_core_post_title( $attributes, $content, $block ) {
 
 	if ( isset( $attributes['isLink'] ) && $attributes['isLink'] ) {
 		$rel   = ! empty( $attributes['rel'] ) ? 'rel="' . esc_attr( $attributes['rel'] ) . '"' : '';
-		$title = sprintf( '<a href="%1$s" target="%2$s" %3$s>%4$s</a>', get_the_permalink( $post_ID ), esc_attr( $attributes['linkTarget'] ), $rel, $title );
+		$title = sprintf( '<a wp-client-navigation=\'{"prefetch":true}\' href="%1$s" target="%2$s" %3$s>%4$s</a>', get_the_permalink( $post_ID ), esc_attr( $attributes['linkTarget'] ), $rel, $title );
 	}
 	$wrapper_attributes = get_block_wrapper_attributes( array( 'class' => $align_class_name ) );
 

--- a/packages/block-library/src/query-pagination-next/index.php
+++ b/packages/block-library/src/query-pagination-next/index.php
@@ -48,7 +48,7 @@ function render_block_core_query_pagination_next( $attributes, $content, $block 
 		$custom_query_max_pages = (int) $custom_query->max_num_pages;
 		if ( $custom_query_max_pages && $custom_query_max_pages !== $page ) {
 			$content = sprintf(
-				'<a key="next" href="%1$s" %2$s>%3$s</a>',
+				'<a key="next" wp-client-navigation=\'{"prefetch": "load", "scroll": false}\' href="%1$s" %2$s>%3$s</a>',
 				esc_url( add_query_arg( $page_key, $page + 1 ) ),
 				$wrapper_attributes,
 				$label

--- a/packages/block-library/src/query-pagination-next/index.php
+++ b/packages/block-library/src/query-pagination-next/index.php
@@ -48,7 +48,7 @@ function render_block_core_query_pagination_next( $attributes, $content, $block 
 		$custom_query_max_pages = (int) $custom_query->max_num_pages;
 		if ( $custom_query_max_pages && $custom_query_max_pages !== $page ) {
 			$content = sprintf(
-				'<a key="next" wp-client-navigation=\'{"prefetch": "load", "scroll": false}\' href="%1$s" %2$s>%3$s</a>',
+				'<a key="next" wp-client-navigation=\'{"prefetch": "eager", "scroll": false}\' href="%1$s" %2$s>%3$s</a>',
 				esc_url( add_query_arg( $page_key, $page + 1 ) ),
 				$wrapper_attributes,
 				$label

--- a/packages/block-library/src/query-pagination-next/index.php
+++ b/packages/block-library/src/query-pagination-next/index.php
@@ -48,7 +48,7 @@ function render_block_core_query_pagination_next( $attributes, $content, $block 
 		$custom_query_max_pages = (int) $custom_query->max_num_pages;
 		if ( $custom_query_max_pages && $custom_query_max_pages !== $page ) {
 			$content = sprintf(
-				'<a href="%1$s" %2$s>%3$s</a>',
+				'<a key="next" href="%1$s" %2$s>%3$s</a>',
 				esc_url( add_query_arg( $page_key, $page + 1 ) ),
 				$wrapper_attributes,
 				$label

--- a/packages/block-library/src/query-pagination-numbers/index.php
+++ b/packages/block-library/src/query-pagination-numbers/index.php
@@ -81,7 +81,7 @@ function render_block_core_query_pagination_numbers( $attributes, $content, $blo
 		return '';
 	}
 	return sprintf(
-		'<div %1$s>%2$s</div>',
+		'<div key="numbers" %1$s>%2$s</div>',
 		$wrapper_attributes,
 		$content
 	);

--- a/packages/block-library/src/query-pagination-previous/index.php
+++ b/packages/block-library/src/query-pagination-previous/index.php
@@ -38,7 +38,7 @@ function render_block_core_query_pagination_previous( $attributes, $content, $bl
 		remove_filter( 'previous_posts_link_attributes', $filter_link_attributes );
 	} elseif ( 1 !== $page ) {
 		$content = sprintf(
-			'<a key="previous" href="%1$s" %2$s>%3$s</a>',
+			'<a key="previous" wp-client-navigation=\'{"prefetch": "load", "scroll": false}\' href="%1$s" %2$s>%3$s</a>',
 			esc_url( add_query_arg( $page_key, $page - 1 ) ),
 			$wrapper_attributes,
 			$label

--- a/packages/block-library/src/query-pagination-previous/index.php
+++ b/packages/block-library/src/query-pagination-previous/index.php
@@ -38,7 +38,7 @@ function render_block_core_query_pagination_previous( $attributes, $content, $bl
 		remove_filter( 'previous_posts_link_attributes', $filter_link_attributes );
 	} elseif ( 1 !== $page ) {
 		$content = sprintf(
-			'<a key="previous" wp-client-navigation=\'{"prefetch": "load", "scroll": false}\' href="%1$s" %2$s>%3$s</a>',
+			'<a key="previous" wp-client-navigation=\'{"prefetch": "eager", "scroll": false}\' href="%1$s" %2$s>%3$s</a>',
 			esc_url( add_query_arg( $page_key, $page - 1 ) ),
 			$wrapper_attributes,
 			$label

--- a/packages/block-library/src/query-pagination-previous/index.php
+++ b/packages/block-library/src/query-pagination-previous/index.php
@@ -38,7 +38,7 @@ function render_block_core_query_pagination_previous( $attributes, $content, $bl
 		remove_filter( 'previous_posts_link_attributes', $filter_link_attributes );
 	} elseif ( 1 !== $page ) {
 		$content = sprintf(
-			'<a href="%1$s" %2$s>%3$s</a>',
+			'<a key="previous" href="%1$s" %2$s>%3$s</a>',
 			esc_url( add_query_arg( $page_key, $page - 1 ) ),
 			$wrapper_attributes,
 			$label

--- a/packages/block-library/src/query-pagination/block.json
+++ b/packages/block-library/src/query-pagination/block.json
@@ -52,5 +52,6 @@
 		}
 	},
 	"editorStyle": "wp-block-query-pagination-editor",
-	"style": "wp-block-query-pagination"
+	"style": "wp-block-query-pagination",
+	"viewScript": "file:./view.min.js"
 }

--- a/packages/block-library/src/query-pagination/directives.js
+++ b/packages/block-library/src/query-pagination/directives.js
@@ -1,0 +1,39 @@
+/**
+ * External dependencies
+ */
+import { options } from 'preact';
+
+// WordPress Directives.
+const directives = {};
+
+// Make them extensible.
+export const directive = ( name, cb ) => {
+	directives[ name ] = cb;
+};
+
+// Preact Option Hooks. See https://preactjs.com/guide/v10/options/
+const hooks = [
+	[ 'vnode', 'onCreate', 'vnode' ],
+	[ '__b', 'onDiff', 'diff' ],
+	[ 'diffed', 'onDiffed', 'diffed' ],
+	[ 'unmount', 'onUnmount', 'unmount' ],
+	[ '__r', 'onRender', 'render' ],
+	[ '__h', 'onHook', 'hook' ],
+	[ '__e', 'onCatchError', 'catchError' ],
+	[ '__c', 'onCommit', 'commit' ],
+];
+
+// Run the directive callbacks.
+hooks.forEach( ( [ key, hook ] ) => {
+	const old = options[ key ];
+	options[ key ] = ( vnode ) => {
+		const wp = vnode.props.wp;
+		if ( wp ) {
+			for ( const d in wp ) {
+				// For each directive, run the callback.
+				directives[ d ]?.[ hook ]?.( vnode );
+			}
+		}
+		if ( old ) old( vnode );
+	};
+} );

--- a/packages/block-library/src/query-pagination/index.php
+++ b/packages/block-library/src/query-pagination/index.php
@@ -18,6 +18,8 @@ function render_block_core_query_pagination( $attributes, $content ) {
 		return '';
 	}
 
+	wp_enqueue_script( 'wp-block-query-pagination-view' );
+
 	$wrapper_attributes = get_block_wrapper_attributes(
 		array(
 			'aria-label' => __( 'Pagination' ),

--- a/packages/block-library/src/query-pagination/router.js
+++ b/packages/block-library/src/query-pagination/router.js
@@ -1,0 +1,98 @@
+/**
+ * External dependencies
+ */
+import { hydrate, render } from 'preact';
+
+/**
+ * Internal dependencies
+ */
+import { toVdom } from './vdom';
+
+// The root to render the vdom (document.body).
+let rootFragment;
+
+// The cache of visited and prefetched pages.
+const pages = new Map();
+
+// For wrapperless hydration of document.body.
+// See https://gist.github.com/developit/f4c67a2ede71dc2fab7f357f39cff28c
+const createRootFragment = ( parent, replaceNode ) => {
+	replaceNode = [].concat( replaceNode );
+	const s = replaceNode[ replaceNode.length - 1 ].nextSibling;
+	function insert( c, r ) {
+		parent.insertBefore( c, r || s );
+	}
+	return ( parent.__k = {
+		nodeType: 1,
+		parentNode: parent,
+		firstChild: replaceNode[ 0 ],
+		childNodes: replaceNode,
+		insertBefore: insert,
+		appendChild: insert,
+		removeChild( c ) {
+			parent.removeChild( c );
+		},
+	} );
+};
+
+// Helper function to await until the CPU is idle.
+const idle = () =>
+	new Promise( ( resolve ) => window.requestIdleCallback( resolve ) );
+
+// Fetch a new page and convert it to a static virtual DOM.
+const fetchPage = async ( url ) => {
+	const html = await window.fetch( url ).then( ( res ) => res.text() );
+	await idle(); // Wait until CPU is idle to do the parsing and vdom.
+	const dom = new window.DOMParser().parseFromString( html, 'text/html' );
+	return toVdom( dom.body );
+};
+
+// Prefetch a page. We store the promise to avoid triggering a second fetch for
+// a page if a fetching has already started.
+export const prefetch = ( url ) => {
+	if ( ! pages.has( url ) ) {
+		pages.set( url, fetchPage( url ) );
+	}
+};
+
+// Return the vdom of a page.
+const getPage = async ( url ) => {
+	prefetch( url );
+	return await pages.get( url );
+};
+
+// Navigate to a new page.
+export const navigate = async ( url ) => {
+	const vdom = await getPage( url );
+	render( vdom, rootFragment );
+};
+
+// Listen to the back and forward buttons and restore the page if it's in the
+// cache.
+window.addEventListener( 'popstate', async () => {
+	const url = window.location.pathname + window.location.search;
+	if ( pages.has( url ) ) {
+		const vdom = await pages.get( url );
+		render( vdom, rootFragment );
+	}
+} );
+
+// Initialize the router with the initial DOM.
+document.addEventListener( 'DOMContentLoaded', async () => {
+	// We don't use the hash part because it should have the same HTML.
+	const url = window.location.pathname + window.location.search;
+
+	// Create the root fragment to hydrate everything.
+	rootFragment = createRootFragment(
+		document.documentElement,
+		document.body
+	);
+
+	await idle(); // Wait until the CPU is idle to do the hydration.
+	const vdom = toVdom( document.body );
+	pages.set( url, Promise.resolve( vdom ) );
+	hydrate( vdom, rootFragment );
+
+	// eslint-disable-next-line no-console
+	console.log( 'hydrated!' );
+} );

--- a/packages/block-library/src/query-pagination/vdom.js
+++ b/packages/block-library/src/query-pagination/vdom.js
@@ -5,12 +5,9 @@ import { h } from 'preact';
 
 // Convert DOM nodes to static virtual DOM nodes.
 export const toVdom = ( node ) => {
-	if ( node.nodeType === 3 ) {
-		return node.data;
-	}
-	if ( node.nodeType === 8 || node.localName === 'script' ) {
-		return null;
-	}
+	if ( node.nodeType === 3 ) return node.data;
+	if ( node.nodeType === 8 ) return null;
+	if ( node.localName === 'script' ) return h( 'script' );
 
 	const props = {},
 		a = node.attributes;

--- a/packages/block-library/src/query-pagination/vdom.js
+++ b/packages/block-library/src/query-pagination/vdom.js
@@ -1,0 +1,46 @@
+/**
+ * External dependencies
+ */
+import { h } from 'preact';
+
+// Convert DOM nodes to static virtual DOM nodes.
+export const toVdom = ( node ) => {
+	if ( node.nodeType === 3 ) {
+		return node.data;
+	}
+	if ( node.nodeType === 8 || node.localName === 'script' ) {
+		return null;
+	}
+
+	const props = {},
+		a = node.attributes;
+
+	for ( let i = 0; i < a.length; i++ ) {
+		if ( a[ i ].name.startsWith( 'wp-' ) ) {
+			props.wp = props.wp || {};
+			let value = a[ i ].value;
+			try {
+				value = JSON.parse( value );
+			} catch ( e ) {}
+			props.wp[ renameDirective( a[ i ].name ) ] = value;
+		} else {
+			props[ a[ i ].name ] = a[ i ].value;
+		}
+	}
+
+	return h(
+		node.localName,
+		props,
+		[].map.call( node.childNodes, toVdom ).filter( exists )
+	);
+};
+
+// Rename WordPress Directives from `wp-some-directive` to `someDirective`.
+const renameDirective = ( s ) =>
+	s
+		.toLowerCase()
+		.replace( /^wp-/, '' )
+		.replace( /-(.)/g, ( _, chr ) => chr.toUpperCase() );
+
+// Filter the truthy.
+const exists = ( i ) => i;

--- a/packages/block-library/src/query-pagination/view.js
+++ b/packages/block-library/src/query-pagination/view.js
@@ -24,6 +24,10 @@ function createRootFragment( parent, replaceNode ) {
 	} );
 }
 
+// Helper function to await until the CPU is idle.
+const idle = () =>
+	new Promise( ( resolve ) => window.requestIdleCallback( resolve ) );
+
 let rootFragment;
 const f = ( i ) => i;
 
@@ -63,6 +67,7 @@ const pages = new Map();
 // Fetch a new page and convert it to a static virtual DOM.
 const fetchAndVdom = async ( url ) => {
 	const html = await window.fetch( url ).then( ( res ) => res.text() );
+	await idle();
 	const dom = new window.DOMParser().parseFromString( html, 'text/html' );
 	return toVdom( dom.body );
 };
@@ -163,7 +168,7 @@ options.diffed = ( vnode ) => {
 	}
 };
 
-document.addEventListener( 'DOMContentLoaded', () => {
+document.addEventListener( 'DOMContentLoaded', async () => {
 	// Create the root fragment to hydrate everything.
 	rootFragment = createRootFragment(
 		document.documentElement,
@@ -171,8 +176,7 @@ document.addEventListener( 'DOMContentLoaded', () => {
 	);
 
 	// Wait until the CPU is idle to do the hydration.
-	window.requestIdleCallback( () => {
-		const vdom = getInitialVdom();
-		hydrate( vdom, rootFragment );
-	} );
+	await idle();
+	const vdom = getInitialVdom();
+	hydrate( vdom, rootFragment );
 } );

--- a/packages/block-library/src/query-pagination/view.js
+++ b/packages/block-library/src/query-pagination/view.js
@@ -178,5 +178,11 @@ document.addEventListener( 'DOMContentLoaded', async () => {
 	// Wait until the CPU is idle to do the hydration.
 	await idle();
 	const vdom = getInitialVdom();
-	hydrate( vdom, rootFragment );
+	setTimeout( () => {
+		// Delay hydration artificially to make sure the hydration doesn't destroy
+		// the nodes (animation doesn't jump).
+		hydrate( vdom, rootFragment );
+		// eslint-disable-next-line no-console
+		console.log( 'hydrated!' );
+	}, 3000 );
 } );

--- a/packages/block-library/src/query-pagination/view.js
+++ b/packages/block-library/src/query-pagination/view.js
@@ -24,15 +24,12 @@ directive( 'clientNavigation', ( props ) => {
 	} );
 
 	// Don't do anything if it's falsy.
-	if ( !! clientNavigation ) {
+	if ( clientNavigation !== false ) {
 		props.onclick = async ( event ) => {
 			event.preventDefault();
 
 			// Fetch the page (or return it from cache).
 			await navigate( href );
-
-			// Update the URL.
-			window.history.pushState( {}, '', href );
 
 			// Update the scroll, depending on the option. True by default.
 			if ( clientNavigation?.scroll === 'smooth' ) {

--- a/packages/block-library/src/query-pagination/view.js
+++ b/packages/block-library/src/query-pagination/view.js
@@ -1,0 +1,89 @@
+/**
+ * External dependencies
+ */
+import { h, hydrate, render } from 'preact';
+
+function createRootFragment( parent, replaceNode ) {
+	replaceNode = [].concat( replaceNode );
+	const s = replaceNode[ replaceNode.length - 1 ].nextSibling;
+	function insert( c, r ) {
+		parent.insertBefore( c, r || s );
+	}
+	return ( parent.__k = {
+		nodeType: 1,
+		parentNode: parent,
+		firstChild: replaceNode[ 0 ],
+		childNodes: replaceNode,
+		insertBefore: insert,
+		appendChild: insert,
+		removeChild( c ) {
+			parent.removeChild( c );
+		},
+	} );
+}
+
+const f = ( i ) => i;
+
+// Convert a DOM node to a static virtual DOM node.
+function toVdom( node ) {
+	if ( node.nodeType === 3 ) {
+		return node.data;
+	}
+	if ( node.nodeType === 8 || node.localName === 'script' ) {
+		return null;
+	}
+
+	const props = {},
+		a = node.attributes;
+
+	for ( let i = 0; i < a.length; i++ ) {
+		props[ a[ i ].name ] = a[ i ].value;
+	}
+
+	return h(
+		node.localName,
+		props,
+		[].map.call( node.childNodes, toVdom ).filter( f )
+	);
+}
+
+document.addEventListener( 'DOMContentLoaded', () => {
+	const rootFragment = createRootFragment(
+		document.documentElement,
+		document.body
+	);
+
+	const fetchURL = async ( e ) => {
+		e.preventDefault();
+
+		// Fetch the HTML of the new page.
+		const url = e.target.href;
+		const html = await window
+			.fetch( e.target.href )
+			.then( ( d ) => d.text() );
+
+		const dom = new window.DOMParser().parseFromString( html, 'text/html' );
+		const vdom = toVdom( dom.body );
+
+		render( vdom, rootFragment );
+
+		// Change the browser URL.
+		window.history.pushState( {}, '', url );
+
+		// Scroll to the top to simulate page load. Optional.
+		// window.scrollTo( { top: 0, left: 0, behavior: 'smooth' } );
+	};
+
+	window.requestIdleCallback( () => {
+		const vdom = toVdom( document.body );
+		hydrate( vdom, rootFragment );
+	} );
+
+	const next = document.querySelector( '.wp-block-query-pagination-next' );
+	const previous = document.querySelector(
+		'.wp-block-query-pagination-previous'
+	);
+
+	next?.addEventListener( 'click', fetchURL );
+	previous?.addEventListener( 'click', fetchURL );
+} );

--- a/packages/block-library/src/query-pagination/view.js
+++ b/packages/block-library/src/query-pagination/view.js
@@ -78,6 +78,14 @@ const fetchPage = async ( url ) => {
 	return await pages.get( url );
 };
 
+window.addEventListener( 'popstate', async () => {
+	const url = window.location.pathname + window.location.search;
+	if ( pages.has( url ) ) {
+		const vdom = await pages.get( url );
+		render( vdom, rootFragment );
+	}
+} );
+
 wpDirectives[ 'wp-client-navigation' ] = ( { element, value } ) => {
 	if ( value ) {
 		if ( value.prefetch ) {

--- a/packages/block-library/src/query-pagination/view.js
+++ b/packages/block-library/src/query-pagination/view.js
@@ -1,40 +1,45 @@
 /**
+ * External dependencies
+ */
+import { useEffect } from 'preact/hooks';
+
+/**
  * Internal dependencies
  */
 import { prefetch, navigate } from './router';
 import { directive } from './directives';
 
 // The `wp-client-navigation` directive.
-directive( 'clientNavigation', {
-	onDiff: ( { props } ) => {
-		const {
-			wp: { clientNavigation },
-			href,
-		} = props;
+directive( 'clientNavigation', ( props ) => {
+	const {
+		wp: { clientNavigation },
+		href,
+	} = props;
 
+	useEffect( () => {
 		// Prefetch the page if it is in the directive options.
 		if ( clientNavigation?.prefetch ) {
 			prefetch( href );
 		}
+	} );
 
-		// Don't do anything if it's falsy.
-		if ( !! clientNavigation ) {
-			props.onclick = async ( event ) => {
-				event.preventDefault();
+	// Don't do anything if it's falsy.
+	if ( !! clientNavigation ) {
+		props.onclick = async ( event ) => {
+			event.preventDefault();
 
-				// Fetch the page (or return it from cache).
-				await navigate( href );
+			// Fetch the page (or return it from cache).
+			await navigate( href );
 
-				// Update the URL.
-				window.history.pushState( {}, '', href );
+			// Update the URL.
+			window.history.pushState( {}, '', href );
 
-				// Update the scroll, depending on the option. True by default.
-				if ( clientNavigation?.scroll === 'smooth' ) {
-					window.scrollTo( { top: 0, left: 0, behavior: 'smooth' } );
-				} else if ( clientNavigation?.scroll !== false ) {
-					window.scrollTo( 0, 0 );
-				}
-			};
-		}
-	},
+			// Update the scroll, depending on the option. True by default.
+			if ( clientNavigation?.scroll === 'smooth' ) {
+				window.scrollTo( { top: 0, left: 0, behavior: 'smooth' } );
+			} else if ( clientNavigation?.scroll !== false ) {
+				window.scrollTo( 0, 0 );
+			}
+		};
+	}
 } );

--- a/packages/block-library/src/query-pagination/view.js
+++ b/packages/block-library/src/query-pagination/view.js
@@ -1,120 +1,11 @@
 /**
- * External dependencies
+ * Internal dependencies
  */
-import { h, hydrate, render, options } from 'preact';
-
-// For wrapperless hydration of document.body.
-// See https://gist.github.com/developit/f4c67a2ede71dc2fab7f357f39cff28c
-function createRootFragment( parent, replaceNode ) {
-	replaceNode = [].concat( replaceNode );
-	const s = replaceNode[ replaceNode.length - 1 ].nextSibling;
-	function insert( c, r ) {
-		parent.insertBefore( c, r || s );
-	}
-	return ( parent.__k = {
-		nodeType: 1,
-		parentNode: parent,
-		firstChild: replaceNode[ 0 ],
-		childNodes: replaceNode,
-		insertBefore: insert,
-		appendChild: insert,
-		removeChild( c ) {
-			parent.removeChild( c );
-		},
-	} );
-}
-
-let rootFragment;
-
-// Helper function to await until the CPU is idle.
-const idle = () =>
-	new Promise( ( resolve ) => window.requestIdleCallback( resolve ) );
-
-// Helper function to rename the WordPress Directives from `wp-xx-yy` to `xxYY`.
-const renameDirective = ( s ) =>
-	s
-		.toLowerCase()
-		.replace( /^wp-/, '' )
-		.replace( /-(.)/g, ( _, chr ) => chr.toUpperCase() );
-
-// Convert DOM nodes to static virtual DOM nodes.
-function toVdom( node ) {
-	if ( node.nodeType === 3 ) {
-		return node.data;
-	}
-	if ( node.nodeType === 8 || node.localName === 'script' ) {
-		return null;
-	}
-
-	const props = {},
-		a = node.attributes;
-
-	for ( let i = 0; i < a.length; i++ ) {
-		if ( a[ i ].name.startsWith( 'wp-' ) ) {
-			props.wp = props.wp || {};
-			let value = a[ i ].value;
-			try {
-				value = JSON.parse( value );
-			} catch ( e ) {}
-			props.wp[ renameDirective( a[ i ].name ) ] = value;
-		} else {
-			props[ a[ i ].name ] = a[ i ].value;
-		}
-	}
-
-	return h(
-		node.localName,
-		props,
-		[].map.call( node.childNodes, toVdom ).filter( exists )
-	);
-}
-const exists = ( i ) => i;
-
-/* A minimalistic Router */
-
-// The cache of visited or prefetched pages.
-const pages = new Map();
-
-// Fetch a new page and convert it to a static virtual DOM.
-const fetchAndVdom = async ( url ) => {
-	const html = await window.fetch( url ).then( ( res ) => res.text() );
-	await idle();
-	const dom = new window.DOMParser().parseFromString( html, 'text/html' );
-	return toVdom( dom.body );
-};
-
-// Retrieve a page from the cache or trigger a new fetch. We store promises to
-// avoid fetching a page if a fetching has already started.
-const fetchPage = async ( url ) => {
-	if ( ! pages.has( url ) ) {
-		pages.set( url, fetchAndVdom( url ) );
-	}
-	return await pages.get( url );
-};
-
-// Convert the initial DOM into a static virtual DOM and save it in the cache.
-const getInitialVdom = () => {
-	const vdom = toVdom( document.body );
-	const url = window.location.pathname + window.location.search;
-	pages.set( url, Promise.resolve( vdom ) );
-	return vdom;
-};
-
-// Listen to the back and forward buttons and restore the page if it's in the
-// cache.
-window.addEventListener( 'popstate', async () => {
-	const url = window.location.pathname + window.location.search;
-	if ( pages.has( url ) ) {
-		const vdom = await pages.get( url );
-		render( vdom, rootFragment );
-	}
-} );
-
-/* WordPress Directives */
-const wpDirectives = {};
+import { prefetch, navigate } from './router';
+import { directive } from './directives';
 
 // The `wp-client-navigation` directive.
-wpDirectives.clientNavigation = {
+directive( 'clientNavigation', {
 	onDiff: ( { props } ) => {
 		const {
 			wp: { clientNavigation },
@@ -123,7 +14,7 @@ wpDirectives.clientNavigation = {
 
 		// Prefetch the page if it is in the directive options.
 		if ( clientNavigation?.prefetch ) {
-			fetchPage( href );
+			prefetch( href );
 		}
 
 		// Don't do anything if it's falsy.
@@ -132,9 +23,7 @@ wpDirectives.clientNavigation = {
 				event.preventDefault();
 
 				// Fetch the page (or return it from cache).
-				const vdom = await fetchPage( href );
-				// Render the new page.
-				render( vdom, rootFragment );
+				await navigate( href );
 
 				// Update the URL.
 				window.history.pushState( {}, '', href );
@@ -148,48 +37,4 @@ wpDirectives.clientNavigation = {
 			};
 		}
 	},
-};
-
-// Preact Option Hooks. See https://preactjs.com/guide/v10/options/
-const hooks = {
-	vnode: [ 'vnode', 'onCreate' ],
-	diff: [ '__b', 'onDiff' ],
-	diffed: [ 'diffed', 'onDiffed' ],
-	unmount: [ 'unmount', 'onUnmount' ],
-	// render: [ '__r', 'onRender' ],
-	// hook: [ '__h', 'onHook' ],
-	// catchError: [ '__e', 'onCatchError' ],
-	// commit: [ '__c', 'onCommit' ],
-};
-
-// Run the directive callbacks.
-Object.entries( hooks ).forEach( ( [ name, [ key, hook ] ] ) => {
-	const old = options[ key ];
-	options[ key ] = ( vnode ) => {
-		const wp = vnode.props.wp;
-		if ( wp ) {
-			// eslint-disable-next-line no-console
-			console.log( name, vnode );
-			for ( const directive in wp ) {
-				// For each directive, run the callback.
-				wpDirectives[ directive ]?.[ hook ]?.( vnode );
-			}
-		}
-		if ( old ) old( vnode );
-	};
-} );
-
-document.addEventListener( 'DOMContentLoaded', async () => {
-	// Create the root fragment to hydrate everything.
-	rootFragment = createRootFragment(
-		document.documentElement,
-		document.body
-	);
-
-	// Wait until the CPU is idle to do the hydration.
-	await idle();
-	const vdom = getInitialVdom();
-	hydrate( vdom, rootFragment );
-	// eslint-disable-next-line no-console
-	console.log( 'hydrated!' );
 } );

--- a/packages/block-library/src/query-pagination/view.js
+++ b/packages/block-library/src/query-pagination/view.js
@@ -58,15 +58,22 @@ const wpDirectives = {};
 
 const pages = new Map();
 
-const fetchUrl = async ( url ) => {
+const fetchAndVdom = async ( url ) => {
 	const html = await window.fetch( url ).then( ( res ) => res.text() );
 	const dom = new window.DOMParser().parseFromString( html, 'text/html' );
 	return toVdom( dom.body );
 };
 
+const getInitialVdom = () => {
+	const vdom = toVdom( document.body );
+	const url = window.location.pathname + window.location.search;
+	pages.set( url, Promise.resolve( vdom ) );
+	return vdom;
+};
+
 const fetchPage = async ( url ) => {
 	if ( ! pages.has( url ) ) {
-		pages.set( url, fetchUrl( url ) );
+		pages.set( url, fetchAndVdom( url ) );
 	}
 	return await pages.get( url );
 };
@@ -133,7 +140,7 @@ document.addEventListener( 'DOMContentLoaded', () => {
 	);
 
 	window.requestIdleCallback( () => {
-		const vdom = toVdom( document.body );
+		const vdom = getInitialVdom();
 		hydrate( vdom, rootFragment );
 	} );
 } );


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->
This is an experiment to implement client-side navigations in the Query Loop block.

It's an alternative to https://github.com/WordPress/gutenberg/pull/38713 based on our experiments with [Directives hydration](https://github.com/WordPress/block-hydration-experiments/issues/60).

- https://github.com/WordPress/block-hydration-experiments/issues/60

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

To be able to implement patterns that improve the user experience.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
It fetches the HTML of the next page and diffs the DOMs using Preact's virtual DOM.

This is just a quick experiment. @darerodz and I are working on an implementation of this algorithm that can also hydrate interactive components: 

- https://github.com/WordPress/block-hydration-experiments/issues/64 

It's also worth noting that this approach can work for any page navigation, not only those of the Query Loop block.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->
Create a post or page with a Query Loop and navigate using the Next or Previous buttons. 

~~As long as the next/previous links are preserved in the DOM, the vDOM diffing is intelligent enough not to destroy them, and the event handlers keep working. But on the first and last page, the links disappear from the DOM and lose the event handler. I haven't done anything to reattach the event listeners because I want to test using directives instead.~~

EDIT: This is working fine after we switched to directives.

## Screenshots or screencast <!-- if applicable -->

https://user-images.githubusercontent.com/3305402/189376315-5401dc0a-426d-47bd-b9e9-253bc0b6b229.mp4


## Next steps

I'll probably use this to test more patterns:

- [x] Attach event handlers using a directive
- [x] Prefetch URL