### PR TITLE
Add: content role to relevant audio block attributes.

### DIFF
--- a/packages/block-library/src/audio/block.json
+++ b/packages/block-library/src/audio/block.json
@@ -12,15 +12,18 @@
 			"type": "string",
 			"source": "attribute",
 			"selector": "audio",
-			"attribute": "src"
+			"attribute": "src",
+			"__experimentalRole": "content"
 		},
 		"caption": {
 			"type": "string",
 			"source": "html",
-			"selector": "figcaption"
+			"selector": "figcaption",
+			"__experimentalRole": "content"
 		},
 		"id": {
-			"type": "number"
+			"type": "number",
+			"__experimentalRole": "content"
 		},
 		"autoplay": {
 			"type": "boolean",


### PR DESCRIPTION
Adds relevant content role attributes to audio block, making the block a "content block" for content locking purposes.
Follows what was done in https://github.com/WordPress/gutenberg/pull/43280 for images.
