### PR TITLE
Mark which attributes of the video should be considered content

### DIFF
--- a/packages/block-library/src/video/block.json
+++ b/packages/block-library/src/video/block.json
@@ -17,7 +17,8 @@
 		"caption": {
 			"type": "string",
 			"source": "html",
-			"selector": "figcaption"
+			"selector": "figcaption",
+			"__experimentalRole": "content"
 		},
 		"controls": {
 			"type": "boolean",
@@ -27,7 +28,8 @@
 			"default": true
 		},
 		"id": {
-			"type": "number"
+			"type": "number",
+			"__experimentalRole": "content"
 		},
 		"loop": {
 			"type": "boolean",
@@ -58,7 +60,8 @@
 			"type": "string",
 			"source": "attribute",
 			"selector": "video",
-			"attribute": "src"
+			"attribute": "src",
+			"__experimentalRole": "content"
 		},
 		"playsInline": {
 			"type": "boolean",
@@ -67,6 +70,7 @@
 			"attribute": "playsinline"
 		},
 		"tracks": {
+			"__experimentalRole": "content",
 			"type": "array",
 			"items": {
 				"type": "object"


### PR DESCRIPTION
Adds relevant content role attributes to the video block, making the block a "content block" for content locking purposes.
Follows what was done in https://github.com/WordPress/gutenberg/pull/43280 for images.