### PR TITLE
Mark which attributes of the embed should be considered content

### DIFF
--- a/packages/block-library/src/embed/block.json
+++ b/packages/block-library/src/embed/block.json
@@ -8,18 +8,22 @@
 	"textdomain": "default",
 	"attributes": {
 		"url": {
-			"type": "string"
+			"type": "string",
+			"__experimentalRole": "content"
 		},
 		"caption": {
 			"type": "string",
 			"source": "html",
-			"selector": "figcaption"
+			"selector": "figcaption",
+			"__experimentalRole": "content"
 		},
 		"type": {
-			"type": "string"
+			"type": "string",
+			"__experimentalRole": "content"
 		},
 		"providerNameSlug": {
-			"type": "string"
+			"type": "string",
+			"__experimentalRole": "content"
 		},
 		"allowResponsive": {
 			"type": "boolean",
@@ -27,11 +31,13 @@
 		},
 		"responsive": {
 			"type": "boolean",
-			"default": false
+			"default": false,
+			"__experimentalRole": "content"
 		},
 		"previewable": {
 			"type": "boolean",
-			"default": true
+			"default": true,
+			"__experimentalRole": "content"
 		}
 	},
 	"supports": {


### PR DESCRIPTION
Adds relevant content role attributes to the video block, making the block a "content block" for content locking purposes.
Follows what was done in https://github.com/WordPress/gutenberg/pull/43280 for images.