### PR TITLE
Global Styles: add padding when no tabs in the background panel

### DIFF
--- a/packages/edit-site/src/components/global-styles/screen-background-color.js
+++ b/packages/edit-site/src/components/global-styles/screen-background-color.js
@@ -1,4 +1,9 @@
 /**
+ * External dependencies
+ */
+import classnames from 'classnames';
+
+/**
  * WordPress dependencies
  */
 import { __ } from '@wordpress/i18n';
@@ -98,7 +103,13 @@ function ScreenBackgroundColor( { name, variationPath = '' } ) {
 				) }
 			/>
 			<ColorGradientControl
-				className="edit-site-screen-background-color__control"
+				className={ classnames(
+					'edit-site-screen-background-color__control',
+					{
+						'has-no-tabs':
+							! hasBackgroundColor || ! hasGradientColor,
+					}
+				) }
 				colors={ colorsPerOrigin }
 				gradients={ gradientsPerOrigin }
 				disableCustomColors={ ! areCustomSolidsEnabled }

--- a/packages/edit-site/src/components/global-styles/style.scss
+++ b/packages/edit-site/src/components/global-styles/style.scss
@@ -88,6 +88,12 @@ $block-preview-height: 150px;
 	padding: $grid-unit-20;
 }
 
+.edit-site-screen-background-color__control {
+	.block-editor-color-gradient-control__panel {
+		padding: $grid-unit-20;
+	}
+}
+
 .edit-site-global-styles-variations_item {
 	box-sizing: border-box;
 

--- a/packages/edit-site/src/components/global-styles/style.scss
+++ b/packages/edit-site/src/components/global-styles/style.scss
@@ -84,14 +84,9 @@ $block-preview-height: 150px;
 
 .edit-site-screen-text-color__control,
 .edit-site-screen-link-color__control,
-.edit-site-screen-button-color__control {
+.edit-site-screen-button-color__control,
+.edit-site-screen-background-color__control.has-no-tabs {
 	padding: $grid-unit-20;
-}
-
-.edit-site-screen-background-color__control {
-	.block-editor-color-gradient-control__panel {
-		padding: $grid-unit-20;
-	}
 }
 
 .edit-site-global-styles-variations_item {


### PR DESCRIPTION
## What?
This PR adds `padding` when there are no tabs in the global style background panel.

Currently, if a block supports only either a normal background color or a gradient color, tabs are not displayed, resulting in no padding on either side:

![gradient-panel](https://user-images.githubusercontent.com/54422211/212317563-c35cce89-211b-4541-848d-70fac52240c3.png)

## Why?
In the block color popover, this problem doesn't occur even when one of the background colors is not supported:

![popover](https://user-images.githubusercontent.com/54422211/212317970-0f6571ea-1c5b-498e-a440-3a0453f899fd.png)

This is because padding is explicitly specified in the tab panel within the dropdown content:

https://github.com/WordPress/gutenberg/blob/2d44f063833189b81e2208a7036e2a094a1f1f54/packages/block-editor/src/components/colors-gradients/style.scss#L49-L51

I believe a similar approach should be taken for the global-style background panel.

## How?
I used the wrapper `.edit-site-screen-background-color__control` as a selector to add padding.

## Testing Instructions

First, enable Empty Theme and update theme.json with the following definition. This definition changes the color panel as follows:

- Paragraph Block: Supports only normal background color
- Heading Block: Supports only gradient background color

<details>
<summary>test/emptytheme/theme.json</summary>

```
{
	"$schema": "https://schemas.wp.org/trunk/theme.json",
	"version": 2,
	"settings": {
		"appearanceTools": true,
		"layout": {
			"contentSize": "840px",
			"wideSize": "1100px"
		},
		"blocks": {
			"core/paragraph": {
				"color": {
					"customGradient": false,
					"gradients": [],
					"defaultGradients": false
				}
			},
			"core/heading": {
				"color": {
					"background": false
				}
			}
		}
	},
	"patterns": [ "short-text-surrounded-by-round-images", "partner-logos" ]
}
```
</details>

- Open the site editor.
- Access global styles menu > blocks > {Paragraph | Heading | List } > colors > background.
- Confirm that there is padding on both sides of the tab content, with or without tabs.

## Screenshots or screencast

https://user-images.githubusercontent.com/54422211/212320304-4eb24bab-0889-4b3e-b8b8-746212891db0.mp4

