### PR TITLE
navigation block: fix empty site-log `li` element in the dom

### DIFF
--- a/packages/block-library/src/navigation/index.php
+++ b/packages/block-library/src/navigation/index.php
@@ -556,7 +556,7 @@ function render_block_core_navigation( $attributes, $content, $block ) {
 			$is_list_open       = false;
 			$inner_blocks_html .= '</ul>';
 		}
-		if ( 'core/site-title' === $inner_block->name || 'core/site-logo' === $inner_block->name ) {
+		if ( 'core/site-title' === $inner_block->name || ( 'core/site-logo' === $inner_block->name && $inner_block->render() ) ) {
 			$inner_blocks_html .= '<li class="wp-block-navigation-item">' . $inner_block->render() . '</li>';
 		} else {
 			$inner_blocks_html .= $inner_block->render();

--- a/packages/block-library/src/navigation/index.php
+++ b/packages/block-library/src/navigation/index.php
@@ -556,10 +556,11 @@ function render_block_core_navigation( $attributes, $content, $block ) {
 			$is_list_open       = false;
 			$inner_blocks_html .= '</ul>';
 		}
-		if ( 'core/site-title' === $inner_block->name || ( 'core/site-logo' === $inner_block->name && $inner_block->render() ) ) {
-			$inner_blocks_html .= '<li class="wp-block-navigation-item">' . $inner_block->render() . '</li>';
+		$inner_block_content = $inner_block->render();
+		if ( 'core/site-title' === $inner_block->name || ( 'core/site-logo' === $inner_block->name && $inner_block_content ) ) {
+			$inner_blocks_html .= '<li class="wp-block-navigation-item">' . $inner_block_content . '</li>';
 		} else {
-			$inner_blocks_html .= $inner_block->render();
+			$inner_blocks_html .= $inner_block_content;
 		}
 	}
 


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->
Add a condition to verify that the site-logo is not null. 

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
Don't create a `li` element in the dom when the site-logo is empty. If there is an empty `li` tag, it will add some extra space on the frontend.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
An empty condition is added if `core/site-logo` is non-empty then add a `li` element in the dom or else it will continue the rest of the statements.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->
- Add a navigation block with two items.
- Place a site logo block between the two items. The site logo block should not have an image assigned.
- Save and view the front.
- Confirm that there is no larger space between the two menu items.
- View the page source to confirm that there is no empty `<li></li>` 

Fixes: https://github.com/WordPress/gutenberg/issues/43470
