### PR TITLE
Fix GitHub Actions failure due to duplicate functions

### DIFF
--- a/lib/compat/wordpress-6.1/get-global-styles-and-settings.php
+++ b/lib/compat/wordpress-6.1/get-global-styles-and-settings.php
@@ -5,44 +5,46 @@
  * @package gutenberg
  */
 
-/**
- * Adds global style rules to the inline style for each block.
- */
-function wp_add_global_styles_for_blocks() {
-	$tree        = WP_Theme_JSON_Resolver_Gutenberg::get_merged_data();
-	$block_nodes = $tree->get_styles_block_nodes();
-	foreach ( $block_nodes as $metadata ) {
-		$block_css = $tree->get_styles_for_block( $metadata );
+if ( ! function_exists( 'wp_add_global_styles_for_blocks' ) ) {
+	/**
+	 * Adds global style rules to the inline style for each block.
+	 */
+	function wp_add_global_styles_for_blocks() {
+		$tree        = WP_Theme_JSON_Resolver_Gutenberg::get_merged_data();
+		$block_nodes = $tree->get_styles_block_nodes();
+		foreach ( $block_nodes as $metadata ) {
+			$block_css = $tree->get_styles_for_block( $metadata );
 
-		if ( ! wp_should_load_separate_core_block_assets() ) {
-			wp_add_inline_style( 'global-styles', $block_css );
-			continue;
-		}
+			if ( ! wp_should_load_separate_core_block_assets() ) {
+				wp_add_inline_style( 'global-styles', $block_css );
+				continue;
+			}
 
-		if ( isset( $metadata['name'] ) ) {
-			$block_name = str_replace( 'core/', '', $metadata['name'] );
-			// These block styles are added on block_render.
-			// This hooks inline CSS to them so that they are loaded conditionally
-			// based on whether or not the block is used on the page.
-			wp_add_inline_style( 'wp-block-' . $block_name, $block_css );
-		}
-
-		// The likes of block element styles from theme.json do not have  $metadata['name'] set.
-		if ( ! isset( $metadata['name'] ) && ! empty( $metadata['path'] ) ) {
-			$result = array_values(
-				array_filter(
-					$metadata['path'],
-					function ( $item ) {
-						if ( str_contains( $item, 'core/' ) ) {
-							return true;
-						}
-						return false;
-					}
-				)
-			);
-			if ( isset( $result[0] ) ) {
-				$block_name = str_replace( 'core/', '', $result[0] );
+			if ( isset( $metadata['name'] ) ) {
+				$block_name = str_replace( 'core/', '', $metadata['name'] );
+				// These block styles are added on block_render.
+				// This hooks inline CSS to them so that they are loaded conditionally
+				// based on whether or not the block is used on the page.
 				wp_add_inline_style( 'wp-block-' . $block_name, $block_css );
+			}
+
+			// The likes of block element styles from theme.json do not have  $metadata['name'] set.
+			if ( ! isset( $metadata['name'] ) && ! empty( $metadata['path'] ) ) {
+				$result = array_values(
+					array_filter(
+						$metadata['path'],
+						function ( $item ) {
+							if ( str_contains( $item, 'core/' ) ) {
+								return true;
+							}
+							return false;
+						}
+					)
+				);
+				if ( isset( $result[0] ) ) {
+					$block_name = str_replace( 'core/', '', $result[0] );
+					wp_add_inline_style( 'wp-block-' . $block_name, $block_css );
+				}
 			}
 		}
 	}

--- a/lib/compat/wordpress-6.1/get-global-styles-and-settings.php
+++ b/lib/compat/wordpress-6.1/get-global-styles-and-settings.php
@@ -5,46 +5,44 @@
  * @package gutenberg
  */
 
-if ( ! function_exists( 'wp_add_global_styles_for_blocks' ) ) {
-	/**
-	 * Adds global style rules to the inline style for each block.
-	 */
-	function wp_add_global_styles_for_blocks() {
-		$tree        = WP_Theme_JSON_Resolver_Gutenberg::get_merged_data();
-		$block_nodes = $tree->get_styles_block_nodes();
-		foreach ( $block_nodes as $metadata ) {
-			$block_css = $tree->get_styles_for_block( $metadata );
+/**
+ * Adds global style rules to the inline style for each block.
+ */
+function gutenberg_add_global_styles_for_blocks() {
+	$tree        = WP_Theme_JSON_Resolver_Gutenberg::get_merged_data();
+	$block_nodes = $tree->get_styles_block_nodes();
+	foreach ( $block_nodes as $metadata ) {
+		$block_css = $tree->get_styles_for_block( $metadata );
 
-			if ( ! wp_should_load_separate_core_block_assets() ) {
-				wp_add_inline_style( 'global-styles', $block_css );
-				continue;
-			}
+		if ( ! wp_should_load_separate_core_block_assets() ) {
+			wp_add_inline_style( 'global-styles', $block_css );
+			continue;
+		}
 
-			if ( isset( $metadata['name'] ) ) {
-				$block_name = str_replace( 'core/', '', $metadata['name'] );
-				// These block styles are added on block_render.
-				// This hooks inline CSS to them so that they are loaded conditionally
-				// based on whether or not the block is used on the page.
-				wp_add_inline_style( 'wp-block-' . $block_name, $block_css );
-			}
+		if ( isset( $metadata['name'] ) ) {
+			$block_name = str_replace( 'core/', '', $metadata['name'] );
+			// These block styles are added on block_render.
+			// This hooks inline CSS to them so that they are loaded conditionally
+			// based on whether or not the block is used on the page.
+			wp_add_inline_style( 'wp-block-' . $block_name, $block_css );
+		}
 
-			// The likes of block element styles from theme.json do not have  $metadata['name'] set.
-			if ( ! isset( $metadata['name'] ) && ! empty( $metadata['path'] ) ) {
-				$result = array_values(
-					array_filter(
-						$metadata['path'],
-						function ( $item ) {
-							if ( str_contains( $item, 'core/' ) ) {
-								return true;
-							}
-							return false;
+		// The likes of block element styles from theme.json do not have  $metadata['name'] set.
+		if ( ! isset( $metadata['name'] ) && ! empty( $metadata['path'] ) ) {
+			$result = array_values(
+				array_filter(
+					$metadata['path'],
+					function ( $item ) {
+						if ( str_contains( $item, 'core/' ) ) {
+							return true;
 						}
-					)
-				);
-				if ( isset( $result[0] ) ) {
-					$block_name = str_replace( 'core/', '', $result[0] );
-					wp_add_inline_style( 'wp-block-' . $block_name, $block_css );
-				}
+						return false;
+					}
+				)
+			);
+			if ( isset( $result[0] ) ) {
+				$block_name = str_replace( 'core/', '', $result[0] );
+				wp_add_inline_style( 'wp-block-' . $block_name, $block_css );
 			}
 		}
 	}

--- a/lib/compat/wordpress-6.1/script-loader.php
+++ b/lib/compat/wordpress-6.1/script-loader.php
@@ -156,9 +156,7 @@ function gutenberg_enqueue_global_styles() {
 	wp_enqueue_style( 'global-styles' );
 
 	// add each block as an inline css.
-	if ( ! function_exists( 'wp_add_global_styles_for_blocks' ) ) {
-		wp_add_global_styles_for_blocks();
-	}
+	gutenberg_add_global_styles_for_blocks();
 }
 
 remove_action( 'wp_enqueue_scripts', 'wp_enqueue_global_styles' );

--- a/lib/compat/wordpress-6.1/script-loader.php
+++ b/lib/compat/wordpress-6.1/script-loader.php
@@ -156,7 +156,9 @@ function gutenberg_enqueue_global_styles() {
 	wp_enqueue_style( 'global-styles' );
 
 	// add each block as an inline css.
-	wp_add_global_styles_for_blocks();
+	if ( ! function_exists( 'wp_add_global_styles_for_blocks' ) ) {
+		wp_add_global_styles_for_blocks();
+	}
 }
 
 remove_action( 'wp_enqueue_scripts', 'wp_enqueue_global_styles' );


### PR DESCRIPTION
## What?
This PR checks for redeclarations in the `wp_add_global_styles_for_blocks` function and resolves Fatal errors in gitHub Actions.
In some actions, the following Fatal Error occurs:

```bash
Fatal error: Cannot redeclare wp_add_global_styles_for_blocks() (previously declared in /var/www/html/wp-includes/global-styles-and-settings.php:202) in /var/www/html/wp-content/plugins/plugin/lib/compat/wordpress-6.1/get-global-styles-and-settings.php on line 11
```

## Why?
A backport was done on [Changeset 54118](https://core.trac.wordpress.org/changeset/54118) in WordPress core and `wp_add_global_styles_for_blocks` was added.
I believe this problem occurred because the function is not checked on the Gutenberg.

## How?
I followed [this best practice](https://github.com/WordPress/gutenberg/tree/trunk/lib#wrap-functions-and-classes-with--function_exists-and--class_exists) and added checks by `function_exists`.

## Testing Instructions
~~In this PR, confirm that all tests pass.~~
Confrim that all tests pass, except for the performance test where trunk is used.
