### PR TITLE
Update a broken link to the format-api example

### DIFF
--- a/docs/how-to-guides/format-api.md
+++ b/docs/how-to-guides/format-api.md
@@ -234,4 +234,4 @@ Reference documentation used in this guide:
 
 The guide showed you how to add a button to the toolbar and have it apply a format to the selected text. Try it out and see what you can build with it in your next plugin.
 
-Download the [format-api example](https://github.com/WordPress/gutenberg-examples/tree/trunk/format-api) from the [gutenberg-examples](https://github.com/WordPress/gutenberg-examples) repository.
+Download the [format-api example](https://github.com/WordPress/gutenberg-examples/tree/trunk/non-block-examples/format-api) from the [gutenberg-examples](https://github.com/WordPress/gutenberg-examples) repository.


### PR DESCRIPTION
## What?
As identified in https://github.com/WordPress/Documentation-Issue-Tracker/issues/408, there was a broken link on the `Formatting Toolbar API` page.

## Why?
The link taking users to the gutenberg-examples repo should actually take them to the correct location instead of 404ing.

## How?
Updates an outdated GitHub link with the current working link.

## Testing Instructions
1. Load the documentation page for the Formatting Toolbar API.
2. Follow the link at the very bottom of the page that prompts users to "Download the format-api example from the gutenberg-examples repository."
3. See that the updated URL for this link directs users to the correct portion of the GitHub repo.
