### PR TITLE
[`@wordpress/notices`] Add `removeAllNotices` action to allow all notices to be removed from a given context

### DIFF
--- a/docs/reference-guides/data/data-core-notices.md
+++ b/docs/reference-guides/data/data-core-notices.md
@@ -261,6 +261,50 @@ _Returns_
 
 -   `Object`: Action object.
 
+### removeAllNotices
+
+Removes all notices from a given context. Defaults to the default context.
+
+_Usage_
+
+import { \_\_ } from '@wordpress/i18n';
+import { useDispatch, useSelect } from '@wordpress/data';
+import { store as noticesStore } from '@wordpress/notices';
+import { Button } from '@wordpress/components';
+
+export const ExampleComponent = () => {
+const notices = useSelect( ( select ) =>
+select( noticesStore ).getNotices()
+);
+const { removeNotices } = useDispatch( noticesStore );
+return (
+\<>
+
+    		<ul>
+    			{ notices.map( ( notice ) => (
+    				<li key={ notice.id }>{ notice.content }</li>
+    			) ) }
+    		</ul>
+    		<Button
+    			onClick={ () =>
+    				removeAllNotices()
+    			}
+    		>
+    			{ __( 'Clear all notices', 'woo-gutenberg-products-block' ) }
+    		</Button>
+    	</>
+    );
+
+};
+
+_Parameters_
+
+-   _context_ `string`: The context to remove all notices from.
+
+_Returns_
+
+-   `Object`: Action object.
+
 ### removeNotice
 
 Returns an action object used in signalling that a notice is to be removed.

--- a/docs/reference-guides/data/data-core-notices.md
+++ b/docs/reference-guides/data/data-core-notices.md
@@ -267,35 +267,31 @@ Removes all notices from a given context. Defaults to the default context.
 
 _Usage_
 
-import { \_\_ } from '@wordpress/i18n';
+```js
+import { __ } from '@wordpress/i18n';
 import { useDispatch, useSelect } from '@wordpress/data';
 import { store as noticesStore } from '@wordpress/notices';
 import { Button } from '@wordpress/components';
 
 export const ExampleComponent = () => {
-const notices = useSelect( ( select ) =>
-select( noticesStore ).getNotices()
-);
-const { removeNotices } = useDispatch( noticesStore );
-return (
-\<>
-
-    		<ul>
-    			{ notices.map( ( notice ) => (
-    				<li key={ notice.id }>{ notice.content }</li>
-    			) ) }
-    		</ul>
-    		<Button
-    			onClick={ () =>
-    				removeAllNotices()
-    			}
-    		>
-    			{ __( 'Clear all notices', 'woo-gutenberg-products-block' ) }
-    		</Button>
-    	</>
-    );
-
+	const notices = useSelect( ( select ) =>
+		select( noticesStore ).getNotices()
+	);
+	const { removeNotices } = useDispatch( noticesStore );
+	return (
+		<>
+			<ul>
+				{ notices.map( ( notice ) => (
+					<li key={ notice.id }>{ notice.content }</li>
+				) ) }
+			</ul>
+			<Button onClick={ () => removeAllNotices() }>
+				{ __( 'Clear all notices', 'woo-gutenberg-products-block' ) }
+			</Button>
+		</>
+	);
 };
+```
 
 _Parameters_
 

--- a/docs/reference-guides/data/data-core-notices.md
+++ b/docs/reference-guides/data/data-core-notices.md
@@ -288,6 +288,12 @@ export const ExampleComponent = () => {
 			<Button onClick={ () => removeAllNotices() }>
 				{ __( 'Clear all notices', 'woo-gutenberg-products-block' ) }
 			</Button>
+			<Button onClick={ () => removeAllNotices( 'snackbar' ) }>
+				{ __(
+					'Clear all snackbar notices',
+					'woo-gutenberg-products-block'
+				) }
+			</Button>
 		</>
 	);
 };
@@ -295,6 +301,7 @@ export const ExampleComponent = () => {
 
 _Parameters_
 
+-   _noticeType_ `string`: The context to remove all notices from.
 -   _context_ `string`: The context to remove all notices from.
 
 _Returns_

--- a/packages/notices/CHANGELOG.md
+++ b/packages/notices/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### New Feature
 
 -   Add a new action `removeNotices` which allows bulk removal of notices by their IDs. ([#39940](https://github.com/WordPress/gutenberg/pull/39940))
+-   Add a new action `removeAllNotices` which removes all notices from a given context. ([#44059](https://github.com/WordPress/gutenberg/pull/44059))
 
 ## 4.2.0 (2023-05-24)
 

--- a/packages/notices/src/store/actions.js
+++ b/packages/notices/src/store/actions.js
@@ -317,7 +317,8 @@ export function removeNotice( id, context = DEFAULT_CONTEXT ) {
 /**
  * Removes all notices from a given context. Defaults to the default context.
  *
- * @param {string} context The context to remove all notices from.
+ * @param {string} noticeType The context to remove all notices from.
+ * @param {string} context    The context to remove all notices from.
  *
  * @example
  * ```js
@@ -345,6 +346,13 @@ export function removeNotice( id, context = DEFAULT_CONTEXT ) {
  * 			>
  * 				{ __( 'Clear all notices', 'woo-gutenberg-products-block' ) }
  * 			</Button>
+ * 			<Button
+ * 				onClick={ () =>
+ * 					removeAllNotices( 'snackbar' )
+ * 				}
+ * 			>
+ * 				{ __( 'Clear all snackbar notices', 'woo-gutenberg-products-block' ) }
+ * 			</Button>
  * 		</>
  * 	);
  * };
@@ -352,9 +360,13 @@ export function removeNotice( id, context = DEFAULT_CONTEXT ) {
  *
  * @return {Object} 	   Action object.
  */
-export function removeAllNotices( context = DEFAULT_CONTEXT ) {
+export function removeAllNotices(
+	noticeType = 'default',
+	context = DEFAULT_CONTEXT
+) {
 	return {
 		type: 'REMOVE_ALL_NOTICES',
+		noticeType,
 		context,
 	};
 }

--- a/packages/notices/src/store/actions.js
+++ b/packages/notices/src/store/actions.js
@@ -320,6 +320,7 @@ export function removeNotice( id, context = DEFAULT_CONTEXT ) {
  * @param {string} context The context to remove all notices from.
  *
  * @example
+ * ```js
  * import { __ } from '@wordpress/i18n';
  * import { useDispatch, useSelect } from '@wordpress/data';
  * import { store as noticesStore } from '@wordpress/notices';
@@ -347,6 +348,7 @@ export function removeNotice( id, context = DEFAULT_CONTEXT ) {
  * 		</>
  * 	);
  * };
+ * ```
  *
  * @return {Object} 	   Action object.
  */

--- a/packages/notices/src/store/actions.js
+++ b/packages/notices/src/store/actions.js
@@ -315,6 +315,49 @@ export function removeNotice( id, context = DEFAULT_CONTEXT ) {
 }
 
 /**
+ * Removes all notices from a given context. Defaults to the default context.
+ *
+ * @param {string} context The context to remove all notices from.
+ *
+ * @example
+ * import { __ } from '@wordpress/i18n';
+ * import { useDispatch, useSelect } from '@wordpress/data';
+ * import { store as noticesStore } from '@wordpress/notices';
+ * import { Button } from '@wordpress/components';
+ *
+ * export const ExampleComponent = () => {
+ * 	const notices = useSelect( ( select ) =>
+ * 		select( noticesStore ).getNotices()
+ * 	);
+ * 	const { removeNotices } = useDispatch( noticesStore );
+ * 	return (
+ * 		<>
+ * 			<ul>
+ * 				{ notices.map( ( notice ) => (
+ * 					<li key={ notice.id }>{ notice.content }</li>
+ * 				) ) }
+ * 			</ul>
+ * 			<Button
+ * 				onClick={ () =>
+ * 					removeAllNotices()
+ * 				}
+ * 			>
+ * 				{ __( 'Clear all notices', 'woo-gutenberg-products-block' ) }
+ * 			</Button>
+ * 		</>
+ * 	);
+ * };
+ *
+ * @return {Object} 	   Action object.
+ */
+export function removeAllNotices( context = DEFAULT_CONTEXT ) {
+	return {
+		type: 'REMOVE_ALL_NOTICES',
+		context,
+	};
+}
+
+/**
  * Returns an action object used in signalling that several notices are to be removed.
  *
  * @param {string[]} ids                List of unique notice identifiers.

--- a/packages/notices/src/store/reducer.js
+++ b/packages/notices/src/store/reducer.js
@@ -28,7 +28,7 @@ const notices = onSubKey( 'context' )( ( state = [], action ) => {
 			return state.filter( ( { id } ) => ! action.ids.includes( id ) );
 
 		case 'REMOVE_ALL_NOTICES':
-			return [];
+			return state.filter( ( { type } ) => type !== action.noticeType );
 	}
 
 	return state;

--- a/packages/notices/src/store/reducer.js
+++ b/packages/notices/src/store/reducer.js
@@ -26,6 +26,9 @@ const notices = onSubKey( 'context' )( ( state = [], action ) => {
 
 		case 'REMOVE_NOTICES':
 			return state.filter( ( { id } ) => ! action.ids.includes( id ) );
+
+		case 'REMOVE_ALL_NOTICES':
+			return [];
 	}
 
 	return state;

--- a/packages/notices/src/store/test/actions.js
+++ b/packages/notices/src/store/test/actions.js
@@ -8,6 +8,7 @@ import {
 	createErrorNotice,
 	createWarningNotice,
 	removeNotice,
+	removeAllNotices,
 	removeNotices,
 } from '../actions';
 import { DEFAULT_CONTEXT, DEFAULT_STATUS } from '../constants';
@@ -235,6 +236,24 @@ describe( 'actions', () => {
 			expect( removeNotices( ids, context ) ).toEqual( {
 				type: 'REMOVE_NOTICES',
 				ids,
+				context,
+			} );
+		} );
+	} );
+
+	describe( 'removeAllNotices', () => {
+		it( 'should return action', () => {
+			expect( removeAllNotices() ).toEqual( {
+				type: 'REMOVE_ALL_NOTICES',
+				context: DEFAULT_CONTEXT,
+			} );
+		} );
+
+		it( 'should return action with custom context', () => {
+			const context = 'foo';
+
+			expect( removeAllNotices( context ) ).toEqual( {
+				type: 'REMOVE_ALL_NOTICES',
 				context,
 			} );
 		} );

--- a/packages/notices/src/store/test/actions.js
+++ b/packages/notices/src/store/test/actions.js
@@ -245,6 +245,7 @@ describe( 'actions', () => {
 		it( 'should return action', () => {
 			expect( removeAllNotices() ).toEqual( {
 				type: 'REMOVE_ALL_NOTICES',
+				noticeType: 'default',
 				context: DEFAULT_CONTEXT,
 			} );
 		} );
@@ -252,9 +253,18 @@ describe( 'actions', () => {
 		it( 'should return action with custom context', () => {
 			const context = 'foo';
 
-			expect( removeAllNotices( context ) ).toEqual( {
+			expect( removeAllNotices( 'default', context ) ).toEqual( {
 				type: 'REMOVE_ALL_NOTICES',
+				noticeType: 'default',
 				context,
+			} );
+		} );
+
+		it( 'should return action with type', () => {
+			expect( removeAllNotices( 'snackbar' ) ).toEqual( {
+				type: 'REMOVE_ALL_NOTICES',
+				noticeType: 'snackbar',
+				context: DEFAULT_CONTEXT,
 			} );
 		} );
 	} );

--- a/packages/notices/src/store/test/reducer.js
+++ b/packages/notices/src/store/test/reducer.js
@@ -7,7 +7,12 @@ import deepFreeze from 'deep-freeze';
  * Internal dependencies
  */
 import reducer from '../reducer';
-import { createNotice, removeNotice, removeNotices, removeAllNotices } from '../actions';
+import {
+	createNotice,
+	removeNotice,
+	removeNotices,
+	removeAllNotices,
+} from '../actions';
 import { getNotices } from '../selectors';
 import { DEFAULT_CONTEXT } from '../constants';
 

--- a/packages/notices/src/store/test/reducer.js
+++ b/packages/notices/src/store/test/reducer.js
@@ -234,7 +234,7 @@ describe( 'reducer', () => {
 		} );
 
 		let state = reducer( original, action );
-		state = reducer( state, removeAllNotices( 'bar' ) );
+		state = reducer( state, removeAllNotices( 'default', 'bar' ) );
 
 		expect( state ).toEqual( {
 			bar: [],
@@ -248,6 +248,39 @@ describe( 'reducer', () => {
 					isDismissible: true,
 					actions: [],
 					type: 'default',
+					icon: null,
+					explicitDismiss: false,
+					onDismiss: undefined,
+				},
+			],
+		} );
+	} );
+
+	it( 'should remove all notices of a given type', () => {
+		let action = createNotice( 'error', 'save error', {
+			id: 'global-error',
+		} );
+		const original = deepFreeze( reducer( undefined, action ) );
+
+		action = createNotice( 'success', 'successfully saved', {
+			type: 'snackbar',
+			id: 'snackbar-success',
+		} );
+
+		let state = reducer( original, action );
+		state = reducer( state, removeAllNotices( 'default' ) );
+
+		expect( state ).toEqual( {
+			[ DEFAULT_CONTEXT ]: [
+				{
+					id: 'snackbar-success',
+					content: 'successfully saved',
+					spokenMessage: 'successfully saved',
+					__unstableHTML: undefined,
+					status: 'success',
+					isDismissible: true,
+					actions: [],
+					type: 'snackbar',
 					icon: null,
 					explicitDismiss: false,
 					onDismiss: undefined,

--- a/packages/notices/src/store/test/reducer.js
+++ b/packages/notices/src/store/test/reducer.js
@@ -7,7 +7,7 @@ import deepFreeze from 'deep-freeze';
  * Internal dependencies
  */
 import reducer from '../reducer';
-import { createNotice, removeNotice, removeNotices } from '../actions';
+import { createNotice, removeNotice, removeNotices, removeAllNotices } from '../actions';
 import { getNotices } from '../selectors';
 import { DEFAULT_CONTEXT } from '../constants';
 
@@ -196,6 +196,53 @@ describe( 'reducer', () => {
 					id: 'error-message',
 					content: 'save error (2)',
 					spokenMessage: 'save error (2)',
+					__unstableHTML: undefined,
+					status: 'error',
+					isDismissible: true,
+					actions: [],
+					type: 'default',
+					icon: null,
+					explicitDismiss: false,
+					onDismiss: undefined,
+				},
+			],
+		} );
+	} );
+
+	it( 'should remove all notices', () => {
+		let action = createNotice( 'error', 'save error' );
+		const original = deepFreeze( reducer( undefined, action ) );
+
+		action = createNotice( 'success', 'successfully saved' );
+		let state = reducer( original, action );
+		state = reducer( state, removeAllNotices() );
+
+		expect( state ).toEqual( {
+			[ DEFAULT_CONTEXT ]: [],
+		} );
+	} );
+
+	it( 'should remove all notices in a given context but leave other contexts intact', () => {
+		let action = createNotice( 'error', 'save error', {
+			context: 'foo',
+			id: 'foo-error',
+		} );
+		const original = deepFreeze( reducer( undefined, action ) );
+
+		action = createNotice( 'success', 'successfully saved', {
+			context: 'bar',
+		} );
+
+		let state = reducer( original, action );
+		state = reducer( state, removeAllNotices( 'bar' ) );
+
+		expect( state ).toEqual( {
+			bar: [],
+			foo: [
+				{
+					id: 'foo-error',
+					content: 'save error',
+					spokenMessage: 'save error',
 					__unstableHTML: undefined,
 					status: 'error',
 					isDismissible: true,


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Add a `removeAllNotices` action to allow all notices to be removed from a context without requiring knowledge of each of their IDs.

## Why?
When clearing notices you currently need to know each notice's ID and remove it individually resulting in several different actions being dispatched to the store.

#39940 proposes the addition of `removeNotices` where the IDs of multiple notices to be removed can be specified, however this still requires the caller to know the IDs of all notices.

This action further streamlines the use-case of removing all notices from a context by not requiring any IDs, and instead just emptying the context entirely.

## How?
The reducer will return an empty array when this action is dispatched.

## Testing Instructions
1. Please run `npm run test` and check all unit tests pass.
2. Run the following code in your console:
```js
wp.data.dispatch( 'core/notices' ).createNotice( 'error', 'Test 1' );
wp.data.dispatch( 'core/notices' ).createNotice( 'error', 'Test 2' );
wp.data.dispatch( 'core/notices' ).createNotice( 'error', 'Test 3' );
wp.data.dispatch( 'core/notices' ).removeAllNotices();
wp.data.select( 'core/notices' ).getNotices();
```
3. Expect the select to return an empty array.
4. Run the following code:
```js
wp.data.dispatch( 'core/notices' ).createNotice( 'error', 'Test 1', { context: 'foo' } );
wp.data.dispatch( 'core/notices' ).createNotice( 'error', 'Test 2', { context: 'bar' } );
wp.data.dispatch( 'core/notices' ).removeAllNotices( 'foo' );
wp.data.select( 'core/notices' ).getNotices( 'bar' );
```
5. Expect the select to return an array containing the `Test 1` error.

## Screenshots or screencast <!-- if applicable -->
