### PR TITLE
Columns: Add axial block spacing to Columns block.

### DIFF
--- a/packages/block-library/src/columns/block.json
+++ b/packages/block-library/src/columns/block.json
@@ -28,9 +28,11 @@
 			}
 		},
 		"spacing": {
-			"blockGap": {
-				"__experimentalDefault": "2em"
-			},
+			"blockGap": [
+				{ "__experimentalDefault": "2em" },
+				"horizontal",
+				"vertical"
+			],
 			"margin": [ "top", "bottom" ],
 			"padding": true,
 			"__experimentalDefaultControls": {


### PR DESCRIPTION
Fixes: https://github.com/WordPress/gutenberg/issues/43942 

## What?
Added axial (vertical and horizontal) block spacing to the Columns block.

## Why?
This functionality was recently added to the Social Links block, and this provides a way to control the vertical block spacing when Column blocks collapse, notably on mobile.

## How?
Add the relevant supports in block.json

## Testing Instructions
1. Add a Columns block with a couple of columns
2. Set both vertical and horizontal block spacing, ensuring each is different. 
3. Notice how the spacing changes when the columns collapse on mobile. (See gif below). 

## Screenshots or screencast 
![spacing-columns](https://user-images.githubusercontent.com/4832319/189550510-aaadde91-0f69-411a-8221-a10b079fae31.gif)


