### PR TITLE
Add justification controls to constrained layout

### DIFF
--- a/lib/block-supports/layout.php
+++ b/lib/block-supports/layout.php
@@ -67,8 +67,9 @@ function gutenberg_get_layout_style( $selector, $layout, $has_block_gap_support 
 			}
 		}
 	} elseif ( 'constrained' === $layout_type ) {
-		$content_size = isset( $layout['contentSize'] ) ? $layout['contentSize'] : '';
-		$wide_size    = isset( $layout['wideSize'] ) ? $layout['wideSize'] : '';
+		$content_size    = isset( $layout['contentSize'] ) ? $layout['contentSize'] : '';
+		$wide_size       = isset( $layout['wideSize'] ) ? $layout['wideSize'] : '';
+		$justify_content = isset( $layout['justifyContent'] ) ? $layout['justifyContent'] : 'center';
 
 		$all_max_width_value  = $content_size ? $content_size : $wide_size;
 		$wide_max_width_value = $wide_size ? $wide_size : $content_size;
@@ -78,6 +79,9 @@ function gutenberg_get_layout_style( $selector, $layout, $has_block_gap_support 
 		$all_max_width_value  = wp_strip_all_tags( explode( ';', $all_max_width_value )[0] );
 		$wide_max_width_value = wp_strip_all_tags( explode( ';', $wide_max_width_value )[0] );
 
+		$margin_left  = 'left' === $justify_content ? '0 !important' : 'auto !important';
+		$margin_right = 'right' === $justify_content ? '0 !important' : 'auto !important';
+
 		if ( $content_size || $wide_size ) {
 			array_push(
 				$layout_styles,
@@ -85,8 +89,8 @@ function gutenberg_get_layout_style( $selector, $layout, $has_block_gap_support 
 					'selector'     => "$selector > :where(:not(.alignleft):not(.alignright):not(.alignfull))",
 					'declarations' => array(
 						'max-width'    => $all_max_width_value,
-						'margin-left'  => 'auto !important',
-						'margin-right' => 'auto !important',
+						'margin-left'  => $margin_left,
+						'margin-right' => $margin_right,
 					),
 				),
 				array(
@@ -123,6 +127,20 @@ function gutenberg_get_layout_style( $selector, $layout, $has_block_gap_support 
 					);
 				}
 			}
+		}
+
+		if ( 'left' === $justify_content ) {
+			$layout_styles[] = array(
+				'selector'     => "$selector > :where(:not(.alignleft):not(.alignright):not(.alignfull))",
+				'declarations' => array( 'margin-left' => '0 !important' ),
+			);
+		}
+
+		if ( 'right' === $justify_content ) {
+			$layout_styles[] = array(
+				'selector'     => "$selector > :where(:not(.alignleft):not(.alignright):not(.alignfull))",
+				'declarations' => array( 'margin-right' => '0 !important' ),
+			);
 		}
 
 		if ( $has_block_gap_support ) {

--- a/packages/block-editor/src/hooks/layout.js
+++ b/packages/block-editor/src/hooks/layout.js
@@ -160,6 +160,7 @@ function LayoutPanel( { setAttributes, attributes, name: blockName } ) {
 					{ showInheritToggle && (
 						<>
 							<ToggleControl
+								className="block-editor-hooks__toggle-control"
 								label={ __( 'Inner blocks use content width' ) }
 								checked={
 									layoutType?.name === 'constrained' ||

--- a/packages/block-editor/src/hooks/layout.scss
+++ b/packages/block-editor/src/hooks/layout.scss
@@ -1,6 +1,6 @@
 .block-editor-hooks__layout-controls {
 	display: flex;
-	margin-bottom: $grid-unit-20;
+	margin-bottom: $grid-unit-10;
 
 	.block-editor-hooks__layout-controls-unit {
 		display: flex;
@@ -19,7 +19,9 @@
 }
 
 .block-editor-hooks__layout-controls-helptext {
+	color: $gray-700;
 	font-size: $helptext-font-size;
+	margin-bottom: $grid-unit-20;
 }
 
 .block-editor-hooks__flex-layout-justification-controls,

--- a/packages/block-editor/src/hooks/layout.scss
+++ b/packages/block-editor/src/hooks/layout.scss
@@ -31,3 +31,7 @@
 		margin-bottom: $grid-unit-10;
 	}
 }
+
+.block-editor-hooks__toggle-control.block-editor-hooks__toggle-control {
+	margin-bottom: $grid-unit-20;
+}

--- a/packages/block-editor/src/layouts/constrained.js
+++ b/packages/block-editor/src/layouts/constrained.js
@@ -2,9 +2,10 @@
  * WordPress dependencies
  */
 import {
-	Button,
 	__experimentalUseCustomUnits as useCustomUnits,
 	__experimentalUnitControl as UnitControl,
+	__experimentalToggleGroupControl as ToggleGroupControl,
+	__experimentalToggleGroupControlOptionIcon as ToggleGroupControlOptionIcon,
 } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 import {
@@ -109,48 +110,28 @@ export default {
 						<Icon icon={ stretchWide } />
 					</div>
 				</div>
-				<div className="block-editor-hooks__layout-controls-reset">
-					<Button
-						variant="secondary"
-						isSmall
-						disabled={ ! contentSize && ! wideSize }
-						onClick={ () =>
-							onChange( {
-								contentSize: undefined,
-								wideSize: undefined,
-								inherit: false,
-							} )
-						}
-					>
-						{ __( 'Reset' ) }
-					</Button>
-				</div>
-
 				<p className="block-editor-hooks__layout-controls-helptext">
 					{ __(
 						'Customize the width for all elements that are assigned to the center or wide columns.'
 					) }
 				</p>
-				<fieldset className="block-editor-hooks__flex-layout-justification-controls">
-					<legend>{ __( 'Justification' ) }</legend>
-					<div>
-						{ justificationOptions.map(
-							( { value, icon, label } ) => {
-								return (
-									<Button
-										key={ value }
-										label={ label }
-										icon={ icon }
-										isPressed={ justifyContent === value }
-										onClick={ () =>
-											onJustificationChange( value )
-										}
-									/>
-								);
-							}
-						) }
-					</div>
-				</fieldset>
+				<ToggleGroupControl
+					__experimentalIsBorderless
+					label={ __( 'Justification' ) }
+					value={ justifyContent }
+					onChange={ onJustificationChange }
+				>
+					{ justificationOptions.map( ( { value, icon, label } ) => {
+						return (
+							<ToggleGroupControlOptionIcon
+								key={ value }
+								value={ value }
+								icon={ icon }
+								label={ label }
+							/>
+						);
+					} ) }
+				</ToggleGroupControl>
 			</>
 		);
 	},


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

Fixes #43650.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

Adds justification controls to the "constrained" layout type. These change the `margin` values on the block children so block content can be aligned left or right.

Note that setting justification to "right" does not right-align any text content, only the child blocks themselves.

Note also that when setting "left" or "right" justification on a Post Content block, the post editor view won't reflect that layout because we don't yet have a way to access the Post Content block settings from the post editor.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->
1. In the Post Content block sidebar Layout section, toggle on "Inner blocks use content width";
2. Check that "Justification" controls are added to the bottom of the Layout section;
3. Change justification value and check that new value is reflected in the editor and on the front end.

## Screenshots or screencast <!-- if applicable -->

Before (content centred):
<img width="1121" alt="Screen Shot 2022-09-12 at 1 51 16 pm" src="https://user-images.githubusercontent.com/8096000/189570942-4df107e5-cb6e-41f4-be8c-0a12ce1d07a4.png">

After (content left-aligned):
<img width="1108" alt=" wat" src="https://user-images.githubusercontent.com/8096000/189570995-5baed65c-41e1-412a-b8b3-54735b5526a6.png">



