### PR TITLE
Allow setting Letter case and Decoration to 'None' and add Letter case to Global Styles

### DIFF
--- a/packages/block-editor/src/components/text-decoration-control/index.js
+++ b/packages/block-editor/src/components/text-decoration-control/index.js
@@ -7,10 +7,15 @@ import classnames from 'classnames';
  * WordPress dependencies
  */
 import { BaseControl, Button } from '@wordpress/components';
-import { formatStrikethrough, formatUnderline } from '@wordpress/icons';
+import { reset, formatStrikethrough, formatUnderline } from '@wordpress/icons';
 import { __ } from '@wordpress/i18n';
 
 const TEXT_DECORATIONS = [
+	{
+		name: __( 'None' ),
+		value: 'none',
+		icon: reset,
+	},
 	{
 		name: __( 'Underline' ),
 		value: 'underline',

--- a/packages/block-editor/src/components/text-decoration-control/index.js
+++ b/packages/block-editor/src/components/text-decoration-control/index.js
@@ -6,10 +6,7 @@ import classnames from 'classnames';
 /**
  * WordPress dependencies
  */
-import {
-	__experimentalToggleGroupControl as ToggleGroupControl,
-	__experimentalToggleGroupControlOptionIcon as ToggleGroupControlOptionIcon,
-} from '@wordpress/components';
+import { BaseControl, Button } from '@wordpress/components';
 import { formatStrikethrough, formatUnderline } from '@wordpress/icons';
 import { __ } from '@wordpress/i18n';
 
@@ -40,30 +37,36 @@ export default function TextDecorationControl( {
 	value,
 	onChange,
 	className,
-	...props
 } ) {
 	return (
-		<ToggleGroupControl
-			{ ...props }
+		<fieldset
 			className={ classnames(
 				'block-editor-text-decoration-control',
 				className
 			) }
-			__experimentalIsBorderless
-			label={ __( 'Decoration' ) }
-			value={ value }
-			onChange={ onChange }
 		>
-			{ TEXT_DECORATIONS.map( ( textDecoration ) => {
-				return (
-					<ToggleGroupControlOptionIcon
-						key={ textDecoration.value }
-						value={ textDecoration.value }
-						icon={ textDecoration.icon }
-						label={ textDecoration.name }
-					/>
-				);
-			} ) }
-		</ToggleGroupControl>
+			<BaseControl.VisualLabel as="legend">
+				{ __( 'Decoration' ) }
+			</BaseControl.VisualLabel>
+			<div className="block-editor-text-decoration-control__buttons">
+				{ TEXT_DECORATIONS.map( ( textDecoration ) => {
+					return (
+						<Button
+							key={ textDecoration.value }
+							icon={ textDecoration.icon }
+							label={ textDecoration.name }
+							isPressed={ textDecoration.value === value }
+							onClick={ () => {
+								onChange(
+									textDecoration.value === value
+										? undefined
+										: textDecoration.value
+								);
+							} }
+						/>
+					);
+				} ) }
+			</div>
+		</fieldset>
 	);
 }

--- a/packages/block-editor/src/components/text-decoration-control/style.scss
+++ b/packages/block-editor/src/components/text-decoration-control/style.scss
@@ -5,5 +5,12 @@
 
 	.block-editor-text-decoration-control__buttons {
 		padding: 2px;
+		display: flex;
+	}
+
+	.components-button.has-icon {
+		flex-basis: $button-size;
+		min-width: 0;
+		padding: 0;
 	}
 }

--- a/packages/block-editor/src/components/text-decoration-control/style.scss
+++ b/packages/block-editor/src/components/text-decoration-control/style.scss
@@ -1,0 +1,9 @@
+.block-editor-text-decoration-control {
+	border: 0;
+	margin: 0;
+	padding: 0;
+
+	.block-editor-text-decoration-control__buttons {
+		padding: 2px;
+	}
+}

--- a/packages/block-editor/src/components/text-decoration-control/style.scss
+++ b/packages/block-editor/src/components/text-decoration-control/style.scss
@@ -4,13 +4,15 @@
 	padding: 0;
 
 	.block-editor-text-decoration-control__buttons {
-		padding: 2px;
+		// 4px of padding makes the row 40px high, same as an input.
+		padding: $grid-unit-05 0;
 		display: flex;
 	}
 
 	.components-button.has-icon {
-		flex-basis: $button-size;
-		min-width: 0;
+		height: $grid-unit-40;
+		margin-right: $grid-unit-05;
+		min-width: $grid-unit-40;
 		padding: 0;
 	}
 }

--- a/packages/block-editor/src/components/text-transform-control/index.js
+++ b/packages/block-editor/src/components/text-transform-control/index.js
@@ -4,10 +4,7 @@
 /**
  * WordPress dependencies
  */
-import {
-	__experimentalToggleGroupControl as ToggleGroupControl,
-	__experimentalToggleGroupControlOptionIcon as ToggleGroupControlOptionIcon,
-} from '@wordpress/components';
+import { BaseControl, Button } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 import {
 	formatCapitalize,
@@ -42,26 +39,31 @@ const TEXT_TRANSFORMS = [
  *
  * @return {WPElement} Text transform control.
  */
-export default function TextTransformControl( { value, onChange, ...props } ) {
+export default function TextTransformControl( { value, onChange } ) {
 	return (
-		<ToggleGroupControl
-			{ ...props }
-			className="block-editor-text-transform-control"
-			__experimentalIsBorderless
-			label={ __( 'Letter case' ) }
-			value={ value }
-			onChange={ onChange }
-		>
-			{ TEXT_TRANSFORMS.map( ( textTransform ) => {
-				return (
-					<ToggleGroupControlOptionIcon
-						key={ textTransform.value }
-						value={ textTransform.value }
-						icon={ textTransform.icon }
-						label={ textTransform.name }
-					/>
-				);
-			} ) }
-		</ToggleGroupControl>
+		<fieldset className="block-editor-text-transform-control">
+			<BaseControl.VisualLabel as="legend">
+				{ __( 'Letter case' ) }
+			</BaseControl.VisualLabel>
+			<div className="block-editor-text-transform-control__buttons">
+				{ TEXT_TRANSFORMS.map( ( textTransform ) => {
+					return (
+						<Button
+							key={ textTransform.value }
+							icon={ textTransform.icon }
+							label={ textTransform.name }
+							isPressed={ textTransform.value === value }
+							onClick={ () => {
+								onChange(
+									textTransform.value === value
+										? undefined
+										: textTransform.value
+								);
+							} }
+						/>
+					);
+				} ) }
+			</div>
+		</fieldset>
 	);
 }

--- a/packages/block-editor/src/components/text-transform-control/index.js
+++ b/packages/block-editor/src/components/text-transform-control/index.js
@@ -1,6 +1,8 @@
 /**
  * External dependencies
  */
+import classnames from 'classnames';
+
 /**
  * WordPress dependencies
  */
@@ -39,15 +41,21 @@ const TEXT_TRANSFORMS = [
 /**
  * Control to facilitate text transform selections.
  *
- * @param {Object}   props          Component props.
- * @param {string}   props.value    Currently selected text transform.
- * @param {Function} props.onChange Handles change in text transform selection.
+ * @param {Object}   props           Component props.
+ * @param {string}   props.className Class name to add to the control.
+ * @param {string}   props.value     Currently selected text transform.
+ * @param {Function} props.onChange  Handles change in text transform selection.
  *
  * @return {WPElement} Text transform control.
  */
-export default function TextTransformControl( { value, onChange } ) {
+export default function TextTransformControl( { className, value, onChange } ) {
 	return (
-		<fieldset className="block-editor-text-transform-control">
+		<fieldset
+			className={ classnames(
+				'block-editor-text-transform-control',
+				className
+			) }
+		>
 			<BaseControl.VisualLabel as="legend">
 				{ __( 'Letter case' ) }
 			</BaseControl.VisualLabel>

--- a/packages/block-editor/src/components/text-transform-control/index.js
+++ b/packages/block-editor/src/components/text-transform-control/index.js
@@ -7,12 +7,18 @@
 import { BaseControl, Button } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 import {
+	reset,
 	formatCapitalize,
 	formatLowercase,
 	formatUppercase,
 } from '@wordpress/icons';
 
 const TEXT_TRANSFORMS = [
+	{
+		name: __( 'None' ),
+		value: 'none',
+		icon: reset,
+	},
 	{
 		name: __( 'Uppercase' ),
 		value: 'uppercase',

--- a/packages/block-editor/src/components/text-transform-control/style.scss
+++ b/packages/block-editor/src/components/text-transform-control/style.scss
@@ -4,13 +4,15 @@
 	padding: 0;
 
 	.block-editor-text-transform-control__buttons {
-		padding: 2px;
+		// 4px of padding makes the row 40px high, same as an input.
+		padding: $grid-unit-05 0;
 		display: flex;
 	}
 
 	.components-button.has-icon {
-		flex-basis: $button-size;
-		min-width: 0;
+		height: $grid-unit-40;
+		margin-right: $grid-unit-05;
+		min-width: $grid-unit-40;
 		padding: 0;
 	}
 }

--- a/packages/block-editor/src/components/text-transform-control/style.scss
+++ b/packages/block-editor/src/components/text-transform-control/style.scss
@@ -5,5 +5,12 @@
 
 	.block-editor-text-transform-control__buttons {
 		padding: 2px;
+		display: flex;
+	}
+
+	.components-button.has-icon {
+		flex-basis: $button-size;
+		min-width: 0;
+		padding: 0;
 	}
 }

--- a/packages/block-editor/src/components/text-transform-control/style.scss
+++ b/packages/block-editor/src/components/text-transform-control/style.scss
@@ -1,0 +1,9 @@
+.block-editor-text-transform-control {
+	border: 0;
+	margin: 0;
+	padding: 0;
+
+	.block-editor-text-transform-control__buttons {
+		padding: 2px;
+	}
+}

--- a/packages/block-editor/src/hooks/typography.js
+++ b/packages/block-editor/src/hooks/typography.js
@@ -189,6 +189,19 @@ export function TypographyPanel( props ) {
 					<LineHeightEdit { ...props } />
 				</ToolsPanelItem>
 			) }
+			{ ! isLetterSpacingDisabled && (
+				<ToolsPanelItem
+					className="single-column"
+					hasValue={ () => hasLetterSpacingValue( props ) }
+					label={ __( 'Letter spacing' ) }
+					onDeselect={ () => resetLetterSpacing( props ) }
+					isShownByDefault={ defaultControls?.letterSpacing }
+					resetAllFilter={ createResetAllFilter( 'letterSpacing' ) }
+					panelId={ clientId }
+				>
+					<LetterSpacingEdit { ...props } />
+				</ToolsPanelItem>
+			) }
 			{ ! isTextDecorationDisabled && (
 				<ToolsPanelItem
 					className="single-column"
@@ -204,7 +217,6 @@ export function TypographyPanel( props ) {
 			) }
 			{ ! isTextTransformDisabled && (
 				<ToolsPanelItem
-					className="single-column"
 					hasValue={ () => hasTextTransformValue( props ) }
 					/* translators: Ensure translation is distinct from "Font size" */
 					label={ __( 'Letter case' ) }
@@ -214,19 +226,6 @@ export function TypographyPanel( props ) {
 					panelId={ clientId }
 				>
 					<TextTransformEdit { ...props } />
-				</ToolsPanelItem>
-			) }
-			{ ! isLetterSpacingDisabled && (
-				<ToolsPanelItem
-					className="single-column"
-					hasValue={ () => hasLetterSpacingValue( props ) }
-					label={ __( 'Letter spacing' ) }
-					onDeselect={ () => resetLetterSpacing( props ) }
-					isShownByDefault={ defaultControls?.letterSpacing }
-					resetAllFilter={ createResetAllFilter( 'letterSpacing' ) }
-					panelId={ clientId }
-				>
-					<LetterSpacingEdit { ...props } />
 				</ToolsPanelItem>
 			) }
 		</InspectorControls>

--- a/packages/block-editor/src/style.scss
+++ b/packages/block-editor/src/style.scss
@@ -46,6 +46,8 @@
 @import "./components/responsive-block-control/style.scss";
 @import "./components/rich-text/style.scss";
 @import "./components/skip-to-selected-block/style.scss";
+@import "./components/text-decoration-control/style.scss";
+@import "./components/text-transform-control/style.scss";
 @import "./components/tool-selector/style.scss";
 @import "./components/url-input/style.scss";
 @import "./components/url-popover/style.scss";

--- a/packages/edit-site/src/components/global-styles/hooks.js
+++ b/packages/edit-site/src/components/global-styles/hooks.js
@@ -168,7 +168,6 @@ const ROOT_BLOCK_SUPPORTS = [
 	'fontWeight',
 	'lineHeight',
 	'textDecoration',
-	'textTransform',
 	'padding',
 	'contentSize',
 	'wideSize',

--- a/packages/edit-site/src/components/global-styles/typography-panel.js
+++ b/packages/edit-site/src/components/global-styles/typography-panel.js
@@ -271,14 +271,16 @@ export default function TypographyPanel( { name, element } ) {
 					/>
 				) }
 				{ hasTextTransformControl && (
-					<TextTransformControl
-						value={ textTransform }
-						onChange={ setTextTransform }
-						showNone
-						isBlock
-						size="__unstable-large"
-						__nextHasNoMarginBottom
-					/>
+					<div className="edit-site-typography-panel__full-width-control">
+						<TextTransformControl
+							value={ textTransform }
+							onChange={ setTextTransform }
+							showNone
+							isBlock
+							size="__unstable-large"
+							__nextHasNoMarginBottom
+						/>
+					</div>
 				) }
 			</Grid>
 		</PanelBody>

--- a/packages/edit-site/src/components/global-styles/typography-panel.js
+++ b/packages/edit-site/src/components/global-styles/typography-panel.js
@@ -6,6 +6,7 @@ import {
 	__experimentalFontFamilyControl as FontFamilyControl,
 	__experimentalFontAppearanceControl as FontAppearanceControl,
 	__experimentalLetterSpacingControl as LetterSpacingControl,
+	__experimentalTextTransformControl as TextTransformControl,
 } from '@wordpress/block-editor';
 import {
 	PanelBody,
@@ -65,6 +66,18 @@ function useHasLetterSpacingControl( name, element ) {
 	return supports.includes( 'letterSpacing' );
 }
 
+function useHasTextTransformControl( name, element ) {
+	const setting = useSetting( 'typography.textTransform', name )[ 0 ];
+	if ( ! setting ) {
+		return false;
+	}
+	if ( ! name && element === 'heading' ) {
+		return true;
+	}
+	const supports = getSupportedGlobalStylesPanels( name );
+	return supports.includes( 'textTransform' );
+}
+
 export default function TypographyPanel( { name, element } ) {
 	const [ selectedLevel, setCurrentTab ] = useState( 'heading' );
 	const supports = getSupportedGlobalStylesPanels( name );
@@ -89,6 +102,7 @@ export default function TypographyPanel( { name, element } ) {
 	const hasLineHeightEnabled = useHasLineHeightControl( name );
 	const hasAppearanceControl = useHasAppearanceControl( name );
 	const hasLetterSpacingControl = useHasLetterSpacingControl( name, element );
+	const hasTextTransformControl = useHasTextTransformControl( name, element );
 
 	/* Disable font size controls when the option to style all headings is selected. */
 	let hasFontSizeEnabled = supports.includes( 'fontSize' );
@@ -119,6 +133,10 @@ export default function TypographyPanel( { name, element } ) {
 	);
 	const [ letterSpacing, setLetterSpacing ] = useStyle(
 		prefix + 'typography.letterSpacing',
+		name
+	);
+	const [ textTransform, setTextTransform ] = useStyle(
+		prefix + 'typography.textTransform',
 		name
 	);
 	const [ backgroundColor ] = useStyle( prefix + 'color.background', name );
@@ -250,6 +268,16 @@ export default function TypographyPanel( { name, element } ) {
 						onChange={ setLetterSpacing }
 						size="__unstable-large"
 						__unstableInputWidth="auto"
+					/>
+				) }
+				{ hasTextTransformControl && (
+					<TextTransformControl
+						value={ textTransform }
+						onChange={ setTextTransform }
+						showNone
+						isBlock
+						size="__unstable-large"
+						__nextHasNoMarginBottom
 					/>
 				) }
 			</Grid>


### PR DESCRIPTION
## What?

Alternative to https://github.com/WordPress/gutenberg/pull/43356. Partially reverts https://github.com/WordPress/gutenberg/issues/36735. Closes https://github.com/WordPress/gutenberg/issues/36735 and addresses one of the items in https://github.com/WordPress/gutenberg/issues/34345#issuecomment-1217390408.

This PR does three things:

- Go back to using buttons in `TextTransformControl` and `TextDecorationControl` instead of a `ToggleGroupControl`
- Add _None_ option to `TextTransformControl` and `TextDecorationControl` which allows user to set `text-transform: none` and `text-decoration: none`
- Add `TextTransformControl` to Global Styles

### Why?

We want to add `TextTransformControl` to Global Styles. See https://github.com/WordPress/gutenberg/issues/34345#issuecomment-1217479784.

We also want to allow the user to set `text-transform: none` or `text-decoration: none` explicitly. This allows users to override theme styles at a block level. See https://github.com/WordPress/gutenberg/issues/42766 and https://github.com/WordPress/gutenberg/pull/43356#issuecomment-1241657333.

So, using `TextTransformControl` as an example, the control should support these options:

- Default (no style)
- None (`text-transform: none`)
- Upper case (`text-transform: uppercase`)
- Lower case (`text-transform: lowercase`)
- Capitalize (`text-transform: capitalize`)

Displaying all five options is overwhelming. It is much more intuitive for users if we can display only four buttons (_None_, _Upper case_, _Lower case_ and _Capitalize_) and implement _Default_ using a click-to-unselect mechanism or the ellipsis menu in the Tools Panel. Unfortunately though, `ToggleGroupControl` does not support click-to-unselect as it uses `radio`, and Global Styles does not use Tools Panel.

We switched from a group of buttons to a `ToggleGroupControl` in https://github.com/WordPress/gutenberg/issues/36735 for two reasons:

1. So that `TextTransformControl` and `TextDecorationControl` would have updated 40px styling.
2. To communicate semantically using `role=radio` that these options are mutually exclusive.

(1) can be implemented by styling the group of buttons.

I've been reading about (2) and I don't believe it's actually a big concern. There is little practical difference in terms of what is announced by a screen reader between a group of buttons with `aria-pressed` and a group of `radio`s. Moreover, we should use the markup and semantic roles that most closely resembles the UI. In this case, I believe that `TextTransformControl` and `TextDecorationControl` **is** a group of buttons, because:

- They look more like buttons than radios. (They're squares containing an icon, not unfilled circles with an adjacent label)
- They support button-like behaviour such as deselection 
- They aren't grouped together and therefore I wouldn't expect them to be in the same tab stop (i.e. <kbd>Tab</kbd> should move focus between the buttons)
 - `TextDecorationControl` could in theory support multiple values e.g. `text-decoration: underline strike-through`

https://lea.verou.me/2022/07/button-group/ is a good article that I found on this subject.

## Testing Instructions
1. Go to Editor → Global Styles → Typography.
2. Check that _Letter case_ appears in the Heading section but no other sections, and that modifying it works.
2. Go to Global Styles → Blocks.
3. Check that _Letter case_ appears in the Typography panel for blocks that support these controls, and that modifying them works.
4. `npm run storybook:dev` and see the stories for `TextTransformControl`/`TextDecorationControl`.

## Screenshots or screencast 
https://user-images.githubusercontent.com/612155/189600028-ef8ba1e5-7be4-429a-b7e3-b3e242ecbdbd.mp4