### PR TITLE
Editor: Refactor `PostTaxonomies` tests to `@testing-library/react`

### DIFF
--- a/packages/editor/src/components/post-taxonomies/test/index.js
+++ b/packages/editor/src/components/post-taxonomies/test/index.js
@@ -1,7 +1,14 @@
 /**
  * External dependencies
  */
-import { shallow } from 'enzyme';
+import { render, screen } from '@testing-library/react';
+
+/**
+ * WordPress dependencies
+ */
+import { select } from '@wordpress/data';
+import { store as editorStore } from '@wordpress/editor';
+import { store as coreStore } from '@wordpress/core-data';
 
 /**
  * Internal dependencies
@@ -9,49 +16,104 @@ import { shallow } from 'enzyme';
 import { PostTaxonomies } from '../';
 
 describe( 'PostTaxonomies', () => {
+	const genresTaxonomy = {
+		name: 'Genres',
+		slug: 'genre',
+		types: [ 'book' ],
+		hierarchical: true,
+		rest_base: 'genres',
+		visibility: {
+			show_ui: true,
+		},
+		labels: {
+			add_new_item: 'Add new genre',
+		},
+	};
+
+	const categoriesTaxonomy = {
+		name: 'Categories',
+		slug: 'category',
+		types: [ 'post', 'page' ],
+		hierarchical: true,
+		rest_base: 'categories',
+		visibility: {
+			show_ui: true,
+		},
+		labels: {
+			add_new_item: 'Add new category',
+		},
+	};
+
+	beforeEach( () => {
+		jest.spyOn( select( editorStore ), 'getCurrentPost' ).mockReturnValue( {
+			_links: {
+				'wp:action-create-categories': [
+					{
+						href: 'http://localhost:8889/index.php?rest_route=/wp/v2/foo/create-categories',
+					},
+				],
+				'wp:action-create-genres': [
+					{
+						href: 'http://localhost:8889/index.php?rest_route=/wp/v2/create-genres',
+					},
+				],
+				'wp:action-assign-categories': [
+					{
+						href: 'http://localhost:8889/index.php?rest_route=/wp/v2/foo/assign-categories',
+					},
+				],
+				'wp:action-assign-genres': [
+					{
+						href: 'http://localhost:8889/index.php?rest_route=/wp/v2/assign-genres',
+					},
+				],
+			},
+		} );
+
+		jest.spyOn( select( coreStore ), 'getTaxonomy' ).mockImplementation(
+			( slug ) => {
+				switch ( slug ) {
+					case 'category': {
+						return categoriesTaxonomy;
+					}
+					case 'genre': {
+						return genresTaxonomy;
+					}
+				}
+			}
+		);
+	} );
+
 	it( 'should render no children if taxonomy data not available', () => {
 		const taxonomies = {};
 
-		const wrapper = shallow(
+		const { container } = render(
 			<PostTaxonomies postType="page" taxonomies={ taxonomies } />
 		);
 
-		expect( wrapper.at( 0 ) ).toHaveLength( 0 );
+		expect( container ).toBeEmptyDOMElement();
 	} );
 
 	it( 'should render taxonomy components for taxonomies assigned to post type', () => {
-		const genresTaxonomy = {
-			name: 'Genres',
-			slug: 'genre',
-			types: [ 'book' ],
-			hierarchical: true,
-			rest_base: 'genres',
-			visibility: {
-				show_ui: true,
-			},
-		};
-
-		const categoriesTaxonomy = {
-			name: 'Categories',
-			slug: 'category',
-			types: [ 'post', 'page' ],
-			hierarchical: true,
-			rest_base: 'categories',
-			visibility: {
-				show_ui: true,
-			},
-		};
-
-		const wrapperOne = shallow(
+		const { rerender } = render(
 			<PostTaxonomies
 				postType="book"
 				taxonomies={ [ genresTaxonomy, categoriesTaxonomy ] }
 			/>
 		);
 
-		expect( wrapperOne ).toHaveLength( 1 );
+		expect( screen.getByRole( 'group', { name: 'Genres' } ) ).toBeVisible();
+		expect(
+			screen.queryByRole( 'group', { name: 'Categories' } )
+		).not.toBeInTheDocument();
+		expect(
+			screen.getByRole( 'button', { name: 'Add new genre' } )
+		).toBeVisible();
+		expect(
+			screen.queryByRole( 'button', { name: 'Add new category' } )
+		).not.toBeInTheDocument();
 
-		const wrapperTwo = shallow(
+		rerender(
 			<PostTaxonomies
 				postType="book"
 				taxonomies={ [
@@ -64,28 +126,29 @@ describe( 'PostTaxonomies', () => {
 			/>
 		);
 
-		expect( wrapperTwo ).toHaveLength( 2 );
+		expect( screen.getByRole( 'group', { name: 'Genres' } ) ).toBeVisible();
+		expect(
+			screen.getByRole( 'group', { name: 'Categories' } )
+		).toBeVisible();
+		expect(
+			screen.getByRole( 'button', { name: 'Add new genre' } )
+		).toBeVisible();
+		expect(
+			screen.getByRole( 'button', { name: 'Add new category' } )
+		).toBeVisible();
 	} );
 
 	it( 'should not render taxonomy components that hide their ui', () => {
-		const genresTaxonomy = {
-			name: 'Genres',
-			slug: 'genre',
-			types: [ 'book' ],
-			hierarchical: true,
-			rest_base: 'genres',
-			visibility: {
-				show_ui: true,
-			},
-		};
-
-		const wrapperOne = shallow(
+		const { rerender } = render(
 			<PostTaxonomies postType="book" taxonomies={ [ genresTaxonomy ] } />
 		);
 
-		expect( wrapperOne.at( 0 ) ).toHaveLength( 1 );
+		expect( screen.getByRole( 'group', { name: 'Genres' } ) ).toBeVisible();
+		expect(
+			screen.getByRole( 'button', { name: 'Add new genre' } )
+		).toBeVisible();
 
-		const wrapperTwo = shallow(
+		rerender(
 			<PostTaxonomies
 				postType="book"
 				taxonomies={ [
@@ -97,6 +160,11 @@ describe( 'PostTaxonomies', () => {
 			/>
 		);
 
-		expect( wrapperTwo.at( 0 ) ).toHaveLength( 0 );
+		expect(
+			screen.queryByRole( 'group', { name: 'Genres' } )
+		).not.toBeInTheDocument();
+		expect(
+			screen.queryByRole( 'button', { name: 'Add new genre' } )
+		).not.toBeInTheDocument();
 	} );
 } );


### PR DESCRIPTION
## What?
We've recently started refactoring `enzyme` tests to `@testing-library/react`.

This PR refactors the `PostTaxonomies` tests from `enzyme` to `@testing-library/react`.

## Why?
`@testing-library/react` provides a better way to write tests for accessible components that is closer to the way the user experiences them.

## How?
We're straightforwardly replacing `enzyme` tests with `@testing-library/react` ones, using `jest-dom` matchers and mocks to avoid testing unrelated implementation details.

## Testing Instructions
Verify tests pass: `npm run test:unit packages/editor/src/components/post-taxonomies/test/index.js`
