### PR TITLE
Migrate is-typing test to playwright 

### DIFF
--- a/test/e2e/specs/editor/various/is-typing.spec.js
+++ b/test/e2e/specs/editor/various/is-typing.spec.js
@@ -12,7 +12,7 @@ test.describe( 'isTyping', () => {
 	} );
 
 	test( 'should hide the toolbar when typing', async ( { page, editor } ) => {
-		const blockToolbar = 'role=toolbar[name="Block tools"i]';
+		const blockToolbar = page.locator( 'role=toolbar[name="Block tools"i]' );
 
 		await page.click( 'role=button[name="Add default block"i]' );
 
@@ -20,19 +20,19 @@ test.describe( 'isTyping', () => {
 		await page.keyboard.type( 'Type' );
 
 		// Toolbar is hidden
-		await expect( page.locator( blockToolbar ) ).toBeHidden();
+		await expect( blockToolbar ).toBeHidden();
 
 		// Moving the mouse shows the toolbar.
 		await editor.showBlockToolbar();
 
 		// Toolbar is visible.
-		expect( page.locator( blockToolbar ) ).not.toBe( null );
+		expect( blockToolbar ).not.toBe( null );
 
 		// Typing again hides the toolbar
 		await page.keyboard.type( ' and continue' );
 
 		// Toolbar is hidden again
-		await expect( page.locator( blockToolbar ) ).toBeHidden();
+		await expect( blockToolbar ).toBeHidden();
 	} );
 
 	test( 'should not close the dropdown when typing in it', async ( {

--- a/test/e2e/specs/editor/various/is-typing.spec.js
+++ b/test/e2e/specs/editor/various/is-typing.spec.js
@@ -1,9 +1,6 @@
 /**
  * WordPress dependencies
  */
-/**
- * WordPress dependencies
- */
 const { test, expect } = require( '@wordpress/e2e-test-utils-playwright' );
 
 test.describe( 'isTyping', () => {

--- a/test/e2e/specs/editor/various/is-typing.spec.js
+++ b/test/e2e/specs/editor/various/is-typing.spec.js
@@ -1,6 +1,9 @@
 /**
  * WordPress dependencies
  */
+/**
+ * WordPress dependencies
+ */
 const { test, expect } = require( '@wordpress/e2e-test-utils-playwright' );
 
 test.describe( 'isTyping', () => {
@@ -9,7 +12,7 @@ test.describe( 'isTyping', () => {
 	} );
 
 	test( 'should hide the toolbar when typing', async ( { page, editor } ) => {
-		const blockToolbarSelector = '.block-editor-block-toolbar';
+		const blockToolbar = 'role=toolbar[name="Block tools"i]';
 
 		await page.click( 'role=button[name="Add default block"i]' );
 
@@ -17,19 +20,19 @@ test.describe( 'isTyping', () => {
 		await page.keyboard.type( 'Type' );
 
 		// Toolbar is hidden
-		await expect( page.locator( blockToolbarSelector ) ).toBeHidden();
+		await expect( page.locator( blockToolbar ) ).toBeHidden();
 
 		// Moving the mouse shows the toolbar.
 		await editor.showBlockToolbar();
 
 		// Toolbar is visible.
-		expect( page.locator( blockToolbarSelector ) ).not.toBe( null );
+		expect( page.locator( blockToolbar ) ).not.toBe( null );
 
 		// Typing again hides the toolbar
 		await page.keyboard.type( ' and continue' );
 
 		// Toolbar is hidden again
-		await expect( page.locator( blockToolbarSelector ) ).toBeHidden();
+		await expect( page.locator( blockToolbar ) ).toBeHidden();
 	} );
 
 	test( 'should not close the dropdown when typing in it', async ( {

--- a/test/e2e/specs/editor/various/is-typing.spec.js
+++ b/test/e2e/specs/editor/various/is-typing.spec.js
@@ -1,46 +1,46 @@
 /**
  * WordPress dependencies
  */
-import {
-	clickBlockAppender,
-	createNewPost,
-	showBlockToolbar,
-} from '@wordpress/e2e-test-utils';
+/**
+ * WordPress dependencies
+ */
+const { test, expect } = require( '@wordpress/e2e-test-utils-playwright' );
 
-describe( 'isTyping', () => {
-	beforeEach( async () => {
-		await createNewPost();
+test.describe( 'isTyping', () => {
+	test.beforeEach( async ( { admin } ) => {
+		await admin.createNewPost();
 	} );
 
-	it( 'should hide the toolbar when typing', async () => {
+	test( 'should hide the toolbar when typing', async ( { page, editor } ) => {
 		const blockToolbarSelector = '.block-editor-block-toolbar';
 
-		await clickBlockAppender();
+		await page.click( 'role=button[name="Add default block"i]' );
 
 		// Type in a paragraph.
 		await page.keyboard.type( 'Type' );
 
 		// Toolbar is hidden
-		let blockToolbar = await page.$( blockToolbarSelector );
-		expect( blockToolbar ).toBe( null );
+		await expect( page.locator( blockToolbarSelector ) ).toBeHidden();
 
 		// Moving the mouse shows the toolbar.
-		await showBlockToolbar();
+		await editor.showBlockToolbar();
 
 		// Toolbar is visible.
-		blockToolbar = await page.$( blockToolbarSelector );
-		expect( blockToolbar ).not.toBe( null );
+		expect( page.locator( blockToolbarSelector ) ).not.toBe( null );
 
 		// Typing again hides the toolbar
 		await page.keyboard.type( ' and continue' );
 
 		// Toolbar is hidden again
-		blockToolbar = await page.$( blockToolbarSelector );
-		expect( blockToolbar ).toBe( null );
+		await expect( page.locator( blockToolbarSelector ) ).toBeHidden();
 	} );
 
-	it( 'should not close the dropdown when typing in it', async () => {
+	test( 'should not close the dropdown when typing in it', async ( {
+		page,
+		editor,
+	} ) => {
 		// Adds a Dropdown with an input to all blocks.
+		const wp = '';
 		await page.evaluate( () => {
 			const { Dropdown, ToolbarButton, Fill } = wp.components;
 			const { createElement: el, Fragment } = wp.element;
@@ -80,13 +80,13 @@ describe( 'isTyping', () => {
 			);
 		} );
 
-		await clickBlockAppender();
+		await page.click( 'role=button[name="Add default block"i]' );
 
 		// Type in a paragraph.
 		await page.keyboard.type( 'Type' );
 
 		// Show Toolbar.
-		await showBlockToolbar();
+		await editor.showBlockToolbar();
 
 		// Open the dropdown.
 		await page.click( '.dropdown-open' );
@@ -95,7 +95,6 @@ describe( 'isTyping', () => {
 		await page.type( '.dropdown-input', 'Random' );
 
 		// The input should still be visible.
-		const input = await page.$( '.dropdown-input' );
-		expect( input ).not.toBe( null );
+		await expect( page.locator( '.dropdown-input' ) ).toBeVisible();
 	} );
 } );


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->
## What?
<!-- In a few words, what is the PR actually doing? -->
Part of https://github.com/WordPress/gutenberg/issues/38851.
Migrate [is-typing.test.js ](https://github.com/WordPress/gutenberg/blob/trunk/packages/e2e-tests/specs/editor/various/is-typing.test.js) to its Playwright version.
## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
Part of https://github.com/WordPress/gutenberg/issues/38851.
## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
See[ MIGRATION.md](https://github.com/WordPress/gutenberg/blob/trunk/test/e2e/MIGRATION.md) for migration steps.
## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->
Run` npm run test-e2e:playwright test/e2e/specs/editor/various/is-typing.spec.js`