### PR TITLE
[Block Editor]: Better block transforms organization

### DIFF
--- a/packages/block-editor/src/components/block-switcher/block-transformations-menu.js
+++ b/packages/block-editor/src/components/block-switcher/block-transformations-menu.js
@@ -7,13 +7,60 @@ import {
 	getBlockMenuDefaultClassName,
 	switchToBlockType,
 } from '@wordpress/blocks';
-import { useState } from '@wordpress/element';
+import { useState, useMemo } from '@wordpress/element';
 
 /**
  * Internal dependencies
  */
 import BlockIcon from '../block-icon';
 import PreviewBlockPopover from './preview-block-popover';
+
+/**
+ * Helper hook to group transformations to display them in a specific order in the UI.
+ * For now we group only priority content driven transformations(ex. paragraph -> heading).
+ *
+ * Later on we could also group 'layout' transformations(ex. paragraph -> group) and
+ * display them in different sections.
+ *
+ * @param {Object[]} possibleBlockTransformations The available block transformations.
+ * @return {Record<string, Object[]>} The grouped block transformations.
+ */
+function useGroupedTransforms( possibleBlockTransformations ) {
+	const priorityContentTranformationBlocks = {
+		'core/paragraph': 1,
+		'core/heading': 2,
+		'core/list': 3,
+		'core/quote': 4,
+	};
+	const transformations = useMemo( () => {
+		const priorityTextTranformsNames = Object.keys(
+			priorityContentTranformationBlocks
+		);
+		return possibleBlockTransformations.reduce(
+			( accumulator, item ) => {
+				const { name } = item;
+				if ( priorityTextTranformsNames.includes( name ) ) {
+					accumulator.priorityTextTransformations.push( item );
+				} else {
+					accumulator.restTransformations.push( item );
+				}
+				return accumulator;
+			},
+			{ priorityTextTransformations: [], restTransformations: [] }
+		);
+	}, [ possibleBlockTransformations ] );
+
+	// Order the priority text transformations.
+	transformations.priorityTextTransformations.sort(
+		( { name: currentName }, { name: nextName } ) => {
+			return priorityContentTranformationBlocks[ currentName ] <
+				priorityContentTranformationBlocks[ nextName ]
+				? -1
+				: 1;
+		}
+	);
+	return transformations;
+}
 
 const BlockTransformationsMenu = ( {
 	className,
@@ -23,6 +70,11 @@ const BlockTransformationsMenu = ( {
 } ) => {
 	const [ hoveredTransformItemName, setHoveredTransformItemName ] =
 		useState();
+
+	const { priorityTextTransformations, restTransformations } =
+		useGroupedTransforms( possibleBlockTransformations );
+	const needsTextTransformationsSeparator =
+		priorityTextTransformations.length && restTransformations.length;
 	return (
 		<MenuGroup label={ __( 'Transform to' ) } className={ className }>
 			{ hoveredTransformItemName && (
@@ -33,31 +85,48 @@ const BlockTransformationsMenu = ( {
 					) }
 				/>
 			) }
-			{ possibleBlockTransformations.map( ( item ) => {
-				const { name, icon, title, isDisabled } = item;
-				return (
-					<MenuItem
-						key={ name }
-						className={ getBlockMenuDefaultClassName( name ) }
-						onClick={ ( event ) => {
-							event.preventDefault();
-							onSelect( name );
-						} }
-						disabled={ isDisabled }
-						onMouseLeave={ () =>
-							setHoveredTransformItemName( null )
-						}
-						onMouseEnter={ () =>
-							setHoveredTransformItemName( name )
-						}
-					>
-						<BlockIcon icon={ icon } showColors />
-						{ title }
-					</MenuItem>
-				);
-			} ) }
+			{ priorityTextTransformations.map( ( item ) => (
+				<BlockTranformationItem
+					key={ item.name }
+					item={ item }
+					onSelect={ onSelect }
+					setHoveredTransformItemName={ setHoveredTransformItemName }
+				/>
+			) ) }
+			{ !! needsTextTransformationsSeparator && <hr /> }
+			{ restTransformations.map( ( item ) => (
+				<BlockTranformationItem
+					key={ item.name }
+					item={ item }
+					onSelect={ onSelect }
+					setHoveredTransformItemName={ setHoveredTransformItemName }
+				/>
+			) ) }
 		</MenuGroup>
 	);
 };
+
+function BlockTranformationItem( {
+	item,
+	onSelect,
+	setHoveredTransformItemName,
+} ) {
+	const { name, icon, title, isDisabled } = item;
+	return (
+		<MenuItem
+			className={ getBlockMenuDefaultClassName( name ) }
+			onClick={ ( event ) => {
+				event.preventDefault();
+				onSelect( name );
+			} }
+			disabled={ isDisabled }
+			onMouseLeave={ () => setHoveredTransformItemName( null ) }
+			onMouseEnter={ () => setHoveredTransformItemName( name ) }
+		>
+			<BlockIcon icon={ icon } showColors />
+			{ title }
+		</MenuItem>
+	);
+}
 
 export default BlockTransformationsMenu;

--- a/packages/block-editor/src/components/block-switcher/block-transformations-menu.js
+++ b/packages/block-editor/src/components/block-switcher/block-transformations-menu.js
@@ -108,7 +108,9 @@ const BlockTransformationsMenu = ( {
 				{ ! hasBothContentTransformations && restTransformItems }
 			</MenuGroup>
 			{ !! hasBothContentTransformations && (
-				<MenuGroup>{ restTransformItems }</MenuGroup>
+				<MenuGroup className={ className }>
+					{ restTransformItems }
+				</MenuGroup>
 			) }
 		</>
 	);

--- a/packages/block-editor/src/components/block-switcher/block-transformations-menu.js
+++ b/packages/block-editor/src/components/block-switcher/block-transformations-menu.js
@@ -73,38 +73,61 @@ const BlockTransformationsMenu = ( {
 
 	const { priorityTextTransformations, restTransformations } =
 		useGroupedTransforms( possibleBlockTransformations );
-	const needsTextTransformationsSeparator =
+	// We have to check if both content transformations(priority and rest) are set
+	// in order to create a separate MenuGroup for them.
+	const hasBothContentTransformations =
 		priorityTextTransformations.length && restTransformations.length;
+	const restTransformItems = !! restTransformations.length && (
+		<RestTransformationItems
+			restTransformations={ restTransformations }
+			onSelect={ onSelect }
+			setHoveredTransformItemName={ setHoveredTransformItemName }
+		/>
+	);
 	return (
-		<MenuGroup label={ __( 'Transform to' ) } className={ className }>
-			{ hoveredTransformItemName && (
-				<PreviewBlockPopover
-					blocks={ switchToBlockType(
-						blocks,
-						hoveredTransformItemName
-					) }
-				/>
+		<>
+			<MenuGroup label={ __( 'Transform to' ) } className={ className }>
+				{ hoveredTransformItemName && (
+					<PreviewBlockPopover
+						blocks={ switchToBlockType(
+							blocks,
+							hoveredTransformItemName
+						) }
+					/>
+				) }
+				{ priorityTextTransformations.map( ( item ) => (
+					<BlockTranformationItem
+						key={ item.name }
+						item={ item }
+						onSelect={ onSelect }
+						setHoveredTransformItemName={
+							setHoveredTransformItemName
+						}
+					/>
+				) ) }
+				{ ! hasBothContentTransformations && restTransformItems }
+			</MenuGroup>
+			{ !! hasBothContentTransformations && (
+				<MenuGroup>{ restTransformItems }</MenuGroup>
 			) }
-			{ priorityTextTransformations.map( ( item ) => (
-				<BlockTranformationItem
-					key={ item.name }
-					item={ item }
-					onSelect={ onSelect }
-					setHoveredTransformItemName={ setHoveredTransformItemName }
-				/>
-			) ) }
-			{ !! needsTextTransformationsSeparator && <hr /> }
-			{ restTransformations.map( ( item ) => (
-				<BlockTranformationItem
-					key={ item.name }
-					item={ item }
-					onSelect={ onSelect }
-					setHoveredTransformItemName={ setHoveredTransformItemName }
-				/>
-			) ) }
-		</MenuGroup>
+		</>
 	);
 };
+
+function RestTransformationItems( {
+	restTransformations,
+	onSelect,
+	setHoveredTransformItemName,
+} ) {
+	return restTransformations.map( ( item ) => (
+		<BlockTranformationItem
+			key={ item.name }
+			item={ item }
+			onSelect={ onSelect }
+			setHoveredTransformItemName={ setHoveredTransformItemName }
+		/>
+	) );
+}
 
 function BlockTranformationItem( {
 	item,


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Part of: https://github.com/WordPress/gutenberg/issues/40208

This PR just prioritizes some 'content' (ex. paragraph -> heading) block transformations in the available transformations list.
<!-- In a few words, what is the PR actually doing? -->



## Testing Instructions
1. in block editor insert blocks
2. observe that in blocks that support `paragraph, heading, list, quote` transforms, they are prioritized in a separate menu group


## Screenshots or screencast <!-- if applicable -->

<img width="497" alt="Screenshot 2022-09-12 at 12 19 57 PM" src="https://user-images.githubusercontent.com/16275880/189618284-fe07f661-ecf1-43dd-bba3-d9949d4dfcdc.png">

