### PR TITLE
Components: Refactor `IsolatedEventContainer` tests to `@testing-library/react`

### DIFF
--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -51,6 +51,7 @@
 -   `BorderControl` and `BorderBoxControl`: replace temporary types with `Popover`'s types ([#43823](https://github.com/WordPress/gutenberg/pull/43823/)).
 -   `DimensionControl`: Refactor tests to `@testing-library/react` ([#43916](https://github.com/WordPress/gutenberg/pull/43916)).
 -   `withFilters`: Refactor tests to `@testing-library/react` ([#44017](https://github.com/WordPress/gutenberg/pull/44017)).
+-   `IsolatedEventContainer`: Refactor tests to `@testing-library/react` ([#44073](https://github.com/WordPress/gutenberg/pull/44073)).
 -   `KeyboardShortcuts`: Refactor tests to `@testing-library/react` ([#44075](https://github.com/WordPress/gutenberg/pull/44075)).
 
 ## 20.0.0 (2022-08-24)

--- a/packages/components/src/isolated-event-container/test/index.js
+++ b/packages/components/src/isolated-event-container/test/index.js
@@ -1,7 +1,8 @@
 /**
  * External dependencies
  */
-import { shallow } from 'enzyme';
+import { render, screen, within } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 
 /**
  * Internal dependencies
@@ -9,21 +10,62 @@ import { shallow } from 'enzyme';
 import IsolatedEventContainer from '../';
 
 describe( 'IsolatedEventContainer', () => {
-	it( 'should pass props to container', () => {
-		const isolated = shallow(
-			<IsolatedEventContainer className="test" onClick="click" />
+	it( 'should pass props to container', async () => {
+		const user = userEvent.setup( {
+			advanceTimers: jest.advanceTimersByTime,
+		} );
+		const clickHandler = jest.fn();
+		render(
+			<IsolatedEventContainer
+				data-testid="container"
+				className="test"
+				onClick={ clickHandler }
+			/>
 		);
 
-		expect( isolated.hasClass( 'test' ) ).toBe( true );
-		expect( isolated.prop( 'onClick' ) ).toBe( 'click' );
+		const container = screen.getByTestId( 'container' );
+		expect( container ).toHaveClass( 'test' );
+
+		await user.click( container );
+
+		expect( clickHandler ).toHaveBeenCalledTimes( 1 );
 		expect( console ).toHaveWarned();
 	} );
 
-	it( 'should stop mousedown event propagation', () => {
-		const isolated = shallow( <IsolatedEventContainer /> );
-		const event = { stopPropagation: jest.fn() };
+	it( 'should render children', async () => {
+		render(
+			<IsolatedEventContainer data-testid="container">
+				<p data-testid="child" />
+			</IsolatedEventContainer>
+		);
 
-		isolated.simulate( 'mousedown', event );
-		expect( event.stopPropagation ).toHaveBeenCalled();
+		expect(
+			within( screen.getByTestId( 'container' ) ).getByTestId( 'child' )
+		).toBeVisible();
+	} );
+
+	it( 'should stop mousedown event propagation', async () => {
+		const user = userEvent.setup( {
+			advanceTimers: jest.advanceTimersByTime,
+		} );
+
+		const mousedownHandler = jest.fn();
+		const keydownHandler = jest.fn();
+		render(
+			<button
+				onMouseDown={ mousedownHandler }
+				onKeyDown={ keydownHandler }
+			>
+				<IsolatedEventContainer data-testid="container" />
+			</button>
+		);
+
+		const container = screen.getByTestId( 'container' );
+
+		await user.click( container );
+		await user.keyboard( '[Enter]' );
+
+		expect( mousedownHandler ).not.toHaveBeenCalled();
+		expect( keydownHandler ).toHaveBeenCalledTimes( 1 );
 	} );
 } );

--- a/packages/components/src/isolated-event-container/test/index.js
+++ b/packages/components/src/isolated-event-container/test/index.js
@@ -44,7 +44,7 @@ describe( 'IsolatedEventContainer', () => {
 		).toBeVisible();
 	} );
 
-	it( 'should stop mousedown event propagation', async () => {
+	it( 'should stop event propagation only for mousedown, but not for keydown', async () => {
 		const user = userEvent.setup( {
 			advanceTimers: jest.advanceTimersByTime,
 		} );

--- a/packages/components/src/isolated-event-container/test/index.js
+++ b/packages/components/src/isolated-event-container/test/index.js
@@ -17,13 +17,13 @@ describe( 'IsolatedEventContainer', () => {
 		const clickHandler = jest.fn();
 		render(
 			<IsolatedEventContainer
-				data-testid="container"
+				title="Container"
 				className="test"
 				onClick={ clickHandler }
 			/>
 		);
 
-		const container = screen.getByTestId( 'container' );
+		const container = screen.getByTitle( 'Container' );
 		expect( container ).toHaveClass( 'test' );
 
 		await user.click( container );
@@ -34,13 +34,13 @@ describe( 'IsolatedEventContainer', () => {
 
 	it( 'should render children', async () => {
 		render(
-			<IsolatedEventContainer data-testid="container">
-				<p data-testid="child" />
+			<IsolatedEventContainer title="Container">
+				<p>Child</p>
 			</IsolatedEventContainer>
 		);
 
 		expect(
-			within( screen.getByTestId( 'container' ) ).getByTestId( 'child' )
+			within( screen.getByTitle( 'Container' ) ).getByText( 'Child' )
 		).toBeVisible();
 	} );
 
@@ -56,11 +56,11 @@ describe( 'IsolatedEventContainer', () => {
 				onMouseDown={ mousedownHandler }
 				onKeyDown={ keydownHandler }
 			>
-				<IsolatedEventContainer data-testid="container" />
+				<IsolatedEventContainer title="Container" />
 			</button>
 		);
 
-		const container = screen.getByTestId( 'container' );
+		const container = screen.getByTitle( 'Container' );
 
 		await user.click( container );
 		await user.keyboard( '[Enter]' );


### PR DESCRIPTION
## What?
We've recently started refactoring `enzyme` tests to `@testing-library/react`.

This PR refactors the `IsolatedEventContainer` tests from `enzyme` to `@testing-library/react`.

## Why?
`@testing-library/react` provides a better way to write tests for accessible components that is closer to the way the user experiences them.

## How?
We're straightforwardly replacing `enzyme` tests with `@testing-library/react` ones, using `jest-dom` matchers and mocks to avoid testing unrelated implementation details.

## Testing Instructions
Verify tests pass: `npm run test:unit packages/components/src/isolated-event-container/test/index.js`
