### PR TITLE
Fix block transform preview height

### DIFF
--- a/packages/block-editor/src/components/block-preview/auto.js
+++ b/packages/block-editor/src/components/block-preview/auto.js
@@ -92,6 +92,7 @@ function AutoBlockPreview( {
 							__experimentalPadding + 'px';
 
 						// Necessary for contentResizeListener to work.
+						bodyElement.style.boxSizing = 'border-box';
 						bodyElement.style.position = 'absolute';
 						bodyElement.style.width = '100%';
 					}, [] ) }

--- a/packages/block-editor/src/components/block-preview/auto.js
+++ b/packages/block-editor/src/components/block-preview/auto.js
@@ -91,7 +91,7 @@ function AutoBlockPreview( {
 						bodyElement.style.padding =
 							__experimentalPadding + 'px';
 
-						// necessary for contentResizeListener to work.
+						// Necessary for contentResizeListener to work.
 						bodyElement.style.position = 'absolute';
 						bodyElement.style.width = '100%';
 					}, [] ) }

--- a/packages/block-editor/src/components/block-preview/auto.js
+++ b/packages/block-editor/src/components/block-preview/auto.js
@@ -92,7 +92,8 @@ function AutoBlockPreview( {
 							__experimentalPadding + 'px';
 
 						// necessary for contentResizeListener to work.
-						bodyElement.style.position = 'relative';
+						bodyElement.style.position = 'absolute';
+						bodyElement.style.width = '100%';
 					}, [] ) }
 					aria-hidden
 					tabIndex={ -1 }


### PR DESCRIPTION
## What?
Fixes #43829

This is possibly a regression from #38516, though it may also be related to changes to `useResizeObserver`. It's hard to say—it seems unusual that #38516 was merged quite a while ago, but this issue has only just been spotted.

## How?
#38516 added a `position` of `relative` for the iframe's body element to fix an issue with pattern previews. It did this because the react resize aware docs suggest to do this (https://github.com/FezVrasta/react-resize-aware#usage):
> Heads up!: Make sure to assign a position != initial to the HTMLElement you want to target (relative, absolute, or fixed will work).

I think the problem with `relative` is that the listener doesn't take margin into account since the margin collapses.

Using a position like `absolute` seems to fix things since margin won't collapse in an absolute container (https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_Box_Model/Mastering_margin_collapsing). Changing to `absolute` required setting a `width: 100%` as otherwise blocks like `cover` wouldn't take up full width.

## Testing Instructions
1. Add a paragraph with some text
2. Click the block icon on the toolbar
3. Hover the 'Heading' item

Expected: The heading block should be fully visible in the preview

Also test that this didn't regress block pattern previews as described in https://github.com/WordPress/gutenberg/issues/38501, since this PR changes the fix for that issue.

## Screenshots or screencast <!-- if applicable -->

### Before

![Screen Shot 2022-09-12 at 5 34 16 pm](https://user-images.githubusercontent.com/677833/189621628-8a02cd07-68d0-4fb3-a5ae-10e808605397.png)


### After

![Screen Shot 2022-09-12 at 5 33 24 pm](https://user-images.githubusercontent.com/677833/189621645-a06aceaf-c697-4475-b28b-16b87d7ed626.png)