### PR TITLE
Link autocompleter: enable for all blocks

### DIFF
--- a/packages/block-editor/src/components/autocomplete/index.js
+++ b/packages/block-editor/src/components/autocomplete/index.js
@@ -32,16 +32,13 @@ const EMPTY_ARRAY = [];
 function useCompleters( { completers = EMPTY_ARRAY } ) {
 	const { name } = useBlockEditContext();
 	return useMemo( () => {
-		let filteredCompleters = completers;
+		let filteredCompleters = [ ...completers, linkAutocompleter ];
 
 		if (
 			name === getDefaultBlockName() ||
 			getBlockSupport( name, '__experimentalSlashInserter', false )
 		) {
-			filteredCompleters = filteredCompleters.concat( [
-				blockAutocompleter,
-				linkAutocompleter,
-			] );
+			filteredCompleters = [ ...filteredCompleters, blockAutocompleter ];
 		}
 
 		if ( hasFilter( 'editor.Autocomplete.completers' ) ) {


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?

Currently the links autocomplete is enabled only for blocks that enabled `__experimentalSlashInserter`. This PR enables it for all blocks.

I think ideally this autocomplete should also be part of the link format, but that can be looked into separately.

## Why?

Fixes #43923.

## How?

## Testing Instructions

Created a list and type `[[`.

## Screenshots or screencast <!-- if applicable -->
