### PR TITLE
Fix block switcher preview scrollbar

### DIFF
--- a/packages/block-editor/src/components/block-switcher/style.scss
+++ b/packages/block-editor/src/components/block-switcher/style.scss
@@ -119,8 +119,10 @@
 	.block-editor-block-switcher__preview {
 		width: 300px;
 		height: auto;
-		max-height: 500px;
-		padding: $grid-unit-20;
+		// Subtract margin from max-height.
+		max-height: calc(500px - #{$grid-unit-40});
+		margin: $grid-unit-20;
+		overflow: hidden;
 	}
 }
 


### PR DESCRIPTION
## What?
Fixes the scrollbar issue mentioned in #43829. A scrollbar shouldn't be visible on block previews.

## How?
Sets `overflow: hidden`.

I think this bug is related to changes to the popover component, where `overflow: auto` is set on popover content in some instances:
https://github.com/WordPress/gutenberg/blob/c011452ebbe7c4c506aa50aee77178849fa49324/packages/components/src/popover/index.tsx#L305

The block switcher previews already have a max-height of 500px, so it seems sensible to set `overflow: hidden` as part of that, and it's a better idea for the component to handle that itself rather than relying on another component's implicit behavior.

This also required changing from `padding` to `margin`, which seems correct anyway.

## Testing Instructions
1. Open the gutenberg demo post
2. Select the first paragraph
3. Open the block switcher and hover over 'Heading'

Expected: The preview should not have a scrollbar.

## Screenshots or screencast <!-- if applicable -->

### Before

![Screen Shot 2022-09-12 at 6 21 31 pm](https://user-images.githubusercontent.com/677833/189630754-bde3a526-f19e-4bd3-bfe1-9a248eb6c7cf.png)


### After

![Screen Shot 2022-09-12 at 6 21 13 pm](https://user-images.githubusercontent.com/677833/189630805-65bdd56d-2e50-4ba9-9458-ac6f8339ac36.png)

