### PR TITLE
Writing flow: implement Alt+Arrow

### DIFF
--- a/packages/block-editor/src/components/writing-flow/use-arrow-nav.js
+++ b/packages/block-editor/src/components/writing-flow/use-arrow-nav.js
@@ -275,8 +275,8 @@ export default function useArrowNav() {
 				if ( closestTabbable ) {
 					placeCaretAtVerticalEdge(
 						closestTabbable,
-						// When Alt is pressed, place the at the horizontal edge
-						// and the furthest vertical edge.
+						// When Alt is pressed, place the caret at the furthest
+						// horizontal edge and the furthest vertical edge.
 						altKey ? ! isReverse : isReverse,
 						altKey ? undefined : verticalRect
 					);

--- a/packages/block-editor/src/components/writing-flow/use-arrow-nav.js
+++ b/packages/block-editor/src/components/writing-flow/use-arrow-nav.js
@@ -167,7 +167,8 @@ export default function useArrowNav() {
 		}
 
 		function onKeyDown( event ) {
-			const { keyCode, target } = event;
+			const { keyCode, target, shiftKey, ctrlKey, altKey, metaKey } =
+				event;
 			const isUp = keyCode === UP;
 			const isDown = keyCode === DOWN;
 			const isLeft = keyCode === LEFT;
@@ -176,10 +177,7 @@ export default function useArrowNav() {
 			const isHorizontal = isLeft || isRight;
 			const isVertical = isUp || isDown;
 			const isNav = isHorizontal || isVertical;
-			const isShift = event.shiftKey;
-			const isAlt = event.altKey;
-			const hasModifier =
-				isShift || event.ctrlKey || event.altKey || event.metaKey;
+			const hasModifier = shiftKey || ctrlKey || altKey || metaKey;
 			const isNavEdge = isVertical ? isVerticalEdge : isHorizontalEdge;
 			const { ownerDocument } = node;
 			const { defaultView } = ownerDocument;
@@ -201,7 +199,7 @@ export default function useArrowNav() {
 					return;
 				}
 
-				if ( isShift ) {
+				if ( shiftKey ) {
 					return;
 				}
 
@@ -250,7 +248,7 @@ export default function useArrowNav() {
 			const isReverseDir = isRTL( target ) ? ! isReverse : isReverse;
 			const { keepCaretInsideBlock } = getSettings();
 
-			if ( isShift ) {
+			if ( shiftKey ) {
 				if (
 					isClosestTabbableABlock( target, isReverse ) &&
 					isNavEdge( target, isReverse )
@@ -262,6 +260,9 @@ export default function useArrowNav() {
 			} else if (
 				isVertical &&
 				isVerticalEdge( target, isReverse ) &&
+				// When Alt is pressed, only intercept if the caret is also at
+				// the horizontal edge.
+				( altKey ? isHorizontalEdge( target, isReverseDir ) : true ) &&
 				! keepCaretInsideBlock
 			) {
 				const closestTabbable = getClosestTabbable(
@@ -276,8 +277,8 @@ export default function useArrowNav() {
 						closestTabbable,
 						// When Alt is pressed, place the at the horizontal edge
 						// and the furthest vertical edge.
-						isAlt ? ! isReverse : isReverse,
-						isAlt ? undefined : verticalRect
+						altKey ? ! isReverse : isReverse,
+						altKey ? undefined : verticalRect
 					);
 					event.preventDefault();
 				}

--- a/packages/block-editor/src/components/writing-flow/use-arrow-nav.js
+++ b/packages/block-editor/src/components/writing-flow/use-arrow-nav.js
@@ -177,6 +177,7 @@ export default function useArrowNav() {
 			const isVertical = isUp || isDown;
 			const isNav = isHorizontal || isVertical;
 			const isShift = event.shiftKey;
+			const isAlt = event.altKey;
 			const hasModifier =
 				isShift || event.ctrlKey || event.altKey || event.metaKey;
 			const isNavEdge = isVertical ? isVerticalEdge : isHorizontalEdge;
@@ -273,8 +274,10 @@ export default function useArrowNav() {
 				if ( closestTabbable ) {
 					placeCaretAtVerticalEdge(
 						closestTabbable,
-						isReverse,
-						verticalRect
+						// When Alt is pressed, place the at the horizontal edge
+						// and the furthest vertical edge.
+						isAlt ? ! isReverse : isReverse,
+						isAlt ? undefined : verticalRect
 					);
 					event.preventDefault();
 				}

--- a/test/e2e/specs/editor/various/writing-flow.spec.js
+++ b/test/e2e/specs/editor/various/writing-flow.spec.js
@@ -984,16 +984,7 @@ test.describe( 'Writing Flow', () => {
 		// Create a new paragraph.
 		await page.keyboard.press( 'Enter' );
 		await page.keyboard.type( 'b' );
-
-		await pageUtils.pressKeyWithModifier( 'alt', 'ArrowUp' );
-		await page.keyboard.type( '.' );
-
-		// Expect the "." to be added at the start of the paragraph
-		await expect(
-			page.locator( 'role=document[name="Paragraph block"i] >> nth = 1' )
-		).toHaveText( '.b' );
-
-		await page.keyboard.press( 'Backspace' );
+		await page.keyboard.press( 'ArrowLeft' );
 		await pageUtils.pressKeyWithModifier( 'alt', 'ArrowUp' );
 		await page.keyboard.type( '.' );
 

--- a/test/e2e/specs/editor/various/writing-flow.spec.js
+++ b/test/e2e/specs/editor/various/writing-flow.spec.js
@@ -959,6 +959,49 @@ test.describe( 'Writing Flow', () => {
 			page.locator( 'role=document[name="Paragraph block"i]' )
 		).toHaveText( /^a+\.a$/ );
 	} );
+
+	test( 'should vertically move the caret when pressing Alt', async ( {
+		page,
+		pageUtils,
+	} ) => {
+		await page.keyboard.press( 'Enter' );
+		await page.keyboard.type( 'a' );
+
+		async function getHeight() {
+			return await page.evaluate(
+				() => document.activeElement.offsetHeight
+			);
+		}
+
+		const height = await getHeight();
+
+		// Keep typing until the height of the element increases. We need two
+		// lines.
+		while ( height === ( await getHeight() ) ) {
+			await page.keyboard.type( 'a' );
+		}
+
+		// Create a new paragraph.
+		await page.keyboard.press( 'Enter' );
+		await page.keyboard.type( 'b' );
+
+		await pageUtils.pressKeyWithModifier( 'alt', 'ArrowUp' );
+		await page.keyboard.type( '.' );
+
+		// Expect the "." to be added at the start of the paragraph
+		await expect(
+			page.locator( 'role=document[name="Paragraph block"i] >> nth = 1' )
+		).toHaveText( '.b' );
+
+		await page.keyboard.press( 'Backspace' );
+		await pageUtils.pressKeyWithModifier( 'alt', 'ArrowUp' );
+		await page.keyboard.type( '.' );
+
+		// Expect the "." to be added at the start of the paragraph
+		await expect(
+			page.locator( 'role=document[name="Paragraph block"i] >> nth = 0' )
+		).toHaveText( /^.a+$/ );
+	} );
 } );
 
 class WritingFlowUtils {


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?

Implements Alt+Arrow in writing flow. Currently the caret is placed as if Alt weren't pressed, at the closest edge of the next tabbable element. Instead, the caret should be placed at the furthest edge and also at the furthest horizontal position.

## Why?

As a result, you can quickly press Alt+Arrow Up/Down to navigate blocks of text. This emulates Alt+Arrow Up/Down in normal text editors, where it normally navigates to the previous/next line break or text block.

## How?

Changes the arguments passed to `placeCaretAtVerticalEdge`.

I didn't add behaviour to also stop at line breaks, as this is a bit more challenging. This change on its own should already be a huge improvement.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->

## Screenshots or screencast <!-- if applicable -->
