### PR TITLE
Navigation: Update to use translate instead of top.

### DIFF
--- a/packages/block-library/src/navigation/style.scss
+++ b/packages/block-library/src/navigation/style.scss
@@ -433,11 +433,11 @@ button.wp-block-navigation-item__content {
 @keyframes overlay-menu__fade-in-animation {
 	from {
 		opacity: 0;
-		top: 0.5em;
+		transform: translateY(0.5em);
 	}
 	to {
 		opacity: 1;
-		top: 0;
+		transform: translateY(0);
 	}
 }
 .wp-block-navigation__responsive-container {


### PR DESCRIPTION
## What?

Followup to https://github.com/WordPress/gutenberg/pull/43851#issuecomment-1239085370. Replaces `top` with `translateY` for more perfromant animation. Translate always renders on the GPU even if the element wasn't already, so it's a safer bet.

## Testing Instructions

Same instructions as #43851.