### PR TITLE
Hide all floating block UI when typing

### DIFF
--- a/packages/block-editor/src/components/block-tools/index.js
+++ b/packages/block-editor/src/components/block-tools/index.js
@@ -139,21 +139,15 @@ export default function BlockTools( {
 					__unstableContentRef={ __unstableContentRef }
 				/>
 				{ /* Used for the inline rich text toolbar. */ }
-				{ ! isTyping && (
-					<Popover.Slot
-						name="block-toolbar"
-						ref={ blockToolbarRef }
-					/>
-				) }
+
+				<Popover.Slot name="block-toolbar" ref={ blockToolbarRef } />
 				{ children }
 				{ /* Used for inline rich text popovers. */ }
-				{ ! isTyping && (
-					<Popover.Slot
-						name="__unstable-block-tools-after"
-						ref={ blockToolbarAfterRef }
-					/>
-				) }
-				{ ! isTyping && isZoomOutMode && (
+				<Popover.Slot
+					name="__unstable-block-tools-after"
+					ref={ blockToolbarAfterRef }
+				/>
+				{ isZoomOutMode && (
 					<ZoomOutModeInserters
 						__unstableContentRef={ __unstableContentRef }
 					/>

--- a/packages/block-editor/src/components/block-tools/index.js
+++ b/packages/block-editor/src/components/block-tools/index.js
@@ -139,7 +139,6 @@ export default function BlockTools( {
 					__unstableContentRef={ __unstableContentRef }
 				/>
 				{ /* Used for the inline rich text toolbar. */ }
-
 				<Popover.Slot name="block-toolbar" ref={ blockToolbarRef } />
 				{ children }
 				{ /* Used for inline rich text popovers. */ }

--- a/packages/block-editor/src/components/block-tools/index.js
+++ b/packages/block-editor/src/components/block-tools/index.js
@@ -135,11 +135,9 @@ export default function BlockTools( {
 					) }
 				{ /* Even if the toolbar is fixed, the block popover is still
 					needed for navigation and zoom-out mode. */ }
-				{ ! isTyping && (
-					<SelectedBlockPopover
-						__unstableContentRef={ __unstableContentRef }
-					/>
-				) }
+				<SelectedBlockPopover
+					__unstableContentRef={ __unstableContentRef }
+				/>
 				{ /* Used for the inline rich text toolbar. */ }
 				{ ! isTyping && (
 					<Popover.Slot

--- a/packages/block-editor/src/components/block-tools/index.js
+++ b/packages/block-editor/src/components/block-tools/index.js
@@ -20,6 +20,17 @@ import BlockContextualToolbar from './block-contextual-toolbar';
 import usePopoverScroll from '../block-popover/use-popover-scroll';
 import ZoomOutModeInserters from './zoom-out-mode-inserters';
 
+function selector( select ) {
+	const { __unstableGetEditorMode, getSettings, isTyping } =
+		select( blockEditorStore );
+
+	return {
+		isZoomOutMode: __unstableGetEditorMode() === 'zoom-out',
+		hasFixedToolbar: getSettings().hasFixedToolbar,
+		isTyping: isTyping(),
+	};
+}
+
 /**
  * Renders block tools (the block toolbar, select/navigation mode toolbar, the
  * insertion point and a slot for the inline rich text toolbar). Must be wrapped
@@ -35,15 +46,10 @@ export default function BlockTools( {
 	...props
 } ) {
 	const isLargeViewport = useViewportMatch( 'medium' );
-	const { hasFixedToolbar, isZoomOutMode } = useSelect( ( select ) => {
-		const { __unstableGetEditorMode, getSettings } =
-			select( blockEditorStore );
-
-		return {
-			isZoomOutMode: __unstableGetEditorMode() === 'zoom-out',
-			hasFixedToolbar: getSettings().hasFixedToolbar,
-		};
-	}, [] );
+	const { hasFixedToolbar, isZoomOutMode, isTyping } = useSelect(
+		selector,
+		[]
+	);
 	const isMatch = useShortcutEventMatch();
 	const { getSelectedBlockClientIds, getBlockRootClientId } =
 		useSelect( blockEditorStore );
@@ -118,7 +124,7 @@ export default function BlockTools( {
 		// eslint-disable-next-line jsx-a11y/no-static-element-interactions
 		<div { ...props } onKeyDown={ onKeyDown }>
 			<InsertionPointOpenRef.Provider value={ useRef( false ) }>
-				{ ! isZoomOutMode && (
+				{ ! isTyping && ! isZoomOutMode && (
 					<InsertionPoint
 						__unstableContentRef={ __unstableContentRef }
 					/>
@@ -129,18 +135,27 @@ export default function BlockTools( {
 					) }
 				{ /* Even if the toolbar is fixed, the block popover is still
 					needed for navigation and zoom-out mode. */ }
-				<SelectedBlockPopover
-					__unstableContentRef={ __unstableContentRef }
-				/>
+				{ ! isTyping && (
+					<SelectedBlockPopover
+						__unstableContentRef={ __unstableContentRef }
+					/>
+				) }
 				{ /* Used for the inline rich text toolbar. */ }
-				<Popover.Slot name="block-toolbar" ref={ blockToolbarRef } />
+				{ ! isTyping && (
+					<Popover.Slot
+						name="block-toolbar"
+						ref={ blockToolbarRef }
+					/>
+				) }
 				{ children }
 				{ /* Used for inline rich text popovers. */ }
-				<Popover.Slot
-					name="__unstable-block-tools-after"
-					ref={ blockToolbarAfterRef }
-				/>
-				{ isZoomOutMode && (
+				{ ! isTyping && (
+					<Popover.Slot
+						name="__unstable-block-tools-after"
+						ref={ blockToolbarAfterRef }
+					/>
+				) }
+				{ ! isTyping && isZoomOutMode && (
 					<ZoomOutModeInserters
 						__unstableContentRef={ __unstableContentRef }
 					/>

--- a/packages/block-editor/src/components/block-tools/selected-block-popover.js
+++ b/packages/block-editor/src/components/block-tools/selected-block-popover.js
@@ -27,14 +27,12 @@ function selector( select ) {
 		__unstableGetEditorMode,
 		isMultiSelecting,
 		hasMultiSelection,
-		isTyping,
 		getSettings,
 		getLastMultiSelectedBlockClientId,
 	} = select( blockEditorStore );
 	return {
 		editorMode: __unstableGetEditorMode(),
 		isMultiSelecting: isMultiSelecting(),
-		isTyping: isTyping(),
 		hasFixedToolbar: getSettings().hasFixedToolbar,
 		lastClientId: hasMultiSelection()
 			? getLastMultiSelectedBlockClientId()
@@ -50,13 +48,8 @@ function SelectedBlockPopover( {
 	__unstablePopoverSlot,
 	__unstableContentRef,
 } ) {
-	const {
-		editorMode,
-		isMultiSelecting,
-		isTyping,
-		hasFixedToolbar,
-		lastClientId,
-	} = useSelect( selector, [] );
+	const { editorMode, isMultiSelecting, hasFixedToolbar, lastClientId } =
+		useSelect( selector, [] );
 	const isInsertionPointVisible = useSelect(
 		( select ) => {
 			const {
@@ -80,7 +73,7 @@ function SelectedBlockPopover( {
 	const { stopTyping } = useDispatch( blockEditorStore );
 
 	const showEmptyBlockSideInserter =
-		! isTyping && editorMode === 'edit' && isEmptyDefaultBlock;
+		editorMode === 'edit' && isEmptyDefaultBlock;
 	const shouldShowBreadcrumb =
 		editorMode === 'navigation' || editorMode === 'zoom-out';
 	const shouldShowContextualToolbar =
@@ -88,8 +81,7 @@ function SelectedBlockPopover( {
 		! hasFixedToolbar &&
 		isLargeViewport &&
 		! isMultiSelecting &&
-		! showEmptyBlockSideInserter &&
-		! isTyping;
+		! showEmptyBlockSideInserter;
 	const canFocusHiddenToolbar =
 		editorMode === 'edit' &&
 		! shouldShowContextualToolbar &&

--- a/packages/block-editor/src/components/block-tools/selected-block-popover.js
+++ b/packages/block-editor/src/components/block-tools/selected-block-popover.js
@@ -27,12 +27,14 @@ function selector( select ) {
 		__unstableGetEditorMode,
 		isMultiSelecting,
 		hasMultiSelection,
+		isTyping,
 		getSettings,
 		getLastMultiSelectedBlockClientId,
 	} = select( blockEditorStore );
 	return {
 		editorMode: __unstableGetEditorMode(),
 		isMultiSelecting: isMultiSelecting(),
+		isTyping: isTyping(),
 		hasFixedToolbar: getSettings().hasFixedToolbar,
 		lastClientId: hasMultiSelection()
 			? getLastMultiSelectedBlockClientId()
@@ -48,8 +50,13 @@ function SelectedBlockPopover( {
 	__unstablePopoverSlot,
 	__unstableContentRef,
 } ) {
-	const { editorMode, isMultiSelecting, hasFixedToolbar, lastClientId } =
-		useSelect( selector, [] );
+	const {
+		editorMode,
+		isMultiSelecting,
+		isTyping,
+		hasFixedToolbar,
+		lastClientId,
+	} = useSelect( selector, [] );
 	const isInsertionPointVisible = useSelect(
 		( select ) => {
 			const {
@@ -73,7 +80,7 @@ function SelectedBlockPopover( {
 	const { stopTyping } = useDispatch( blockEditorStore );
 
 	const showEmptyBlockSideInserter =
-		editorMode === 'edit' && isEmptyDefaultBlock;
+		! isTyping && editorMode === 'edit' && isEmptyDefaultBlock;
 	const shouldShowBreadcrumb =
 		editorMode === 'navigation' || editorMode === 'zoom-out';
 	const shouldShowContextualToolbar =
@@ -81,7 +88,8 @@ function SelectedBlockPopover( {
 		! hasFixedToolbar &&
 		isLargeViewport &&
 		! isMultiSelecting &&
-		! showEmptyBlockSideInserter;
+		! showEmptyBlockSideInserter &&
+		! isTyping;
 	const canFocusHiddenToolbar =
 		editorMode === 'edit' &&
 		! shouldShowContextualToolbar &&

--- a/test/e2e/specs/editor/various/writing-flow.spec.js
+++ b/test/e2e/specs/editor/various/writing-flow.spec.js
@@ -700,6 +700,9 @@ test.describe( 'Writing Flow', () => {
 		const x = paragraphRect.x + ( 2 * paragraphRect.width ) / 3;
 		const y = paragraphRect.y + paragraphRect.height + 1;
 
+		// The typing observer requires two mouse moves to dectect and actual
+		// move.
+		await page.mouse.move( x - 1, y - 1 );
 		await page.mouse.move( x, y );
 
 		const inserter = page.locator( 'role=button[name="Add block"i]' );


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?

When tying all floating UI should be hidden. Currently only the block toolbar is hidden.

## Why?

Consistency

## How?

Move the isTyping check one level up to use it to hide other UI as well.

## Testing Instructions

Hover in between blocks to show the inserter and type. The inserter should disappear.

## Screenshots or screencast <!-- if applicable -->
