### PR TITLE
Components: Refactor `Slot`/`Fill` tests to `@testing-library/react`

### DIFF
--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -53,6 +53,7 @@
 -   `withFilters`: Refactor tests to `@testing-library/react` ([#44017](https://github.com/WordPress/gutenberg/pull/44017)).
 -   `IsolatedEventContainer`: Refactor tests to `@testing-library/react` ([#44073](https://github.com/WordPress/gutenberg/pull/44073)).
 -   `KeyboardShortcuts`: Refactor tests to `@testing-library/react` ([#44075](https://github.com/WordPress/gutenberg/pull/44075)).
+-   `Slot`/`Fill`: Refactor tests to `@testing-library/react` ([#44084](https://github.com/WordPress/gutenberg/pull/44084)).
 
 ## 20.0.0 (2022-08-24)
 

--- a/packages/components/src/slot-fill/test/index.js
+++ b/packages/components/src/slot-fill/test/index.js
@@ -1,28 +1,85 @@
 /**
  * External dependencies
  */
-import { shallow } from 'enzyme';
+import { render, screen, within } from '@testing-library/react';
 
 /**
  * Internal dependencies
  */
-import { createSlotFill, Fill, Slot } from '../';
+import { createSlotFill, Provider as SlotFillProvider } from '../';
 
 describe( 'createSlotFill', () => {
-	const SLOT_NAME = 'MySlotFill';
-	const MySlotFill = createSlotFill( SLOT_NAME );
+	test( 'should render all slot fills in order of rendering', () => {
+		const PostSidebar = createSlotFill( 'PostSidebar' );
 
-	test( 'should match snapshot for Fill', () => {
-		const wrapper = shallow( <MySlotFill.Fill /> );
+		render(
+			<SlotFillProvider>
+				<PostSidebar.Fill>
+					<p>Post Section 1</p>
+				</PostSidebar.Fill>
+				<PostSidebar.Fill>
+					<p>Post Section 2</p>
+				</PostSidebar.Fill>
+				<div title="Post Sidebar">
+					<PostSidebar.Slot />
+				</div>
+			</SlotFillProvider>
+		);
 
-		expect( wrapper.type() ).toBe( Fill );
-		expect( wrapper.prop( 'name' ) ).toBe( SLOT_NAME );
+		const postSidebar = screen.getByTitle( 'Post Sidebar' );
+		const postSections =
+			within( postSidebar ).getAllByText( /Post Section \d/ );
+
+		expect( postSidebar ).toBeVisible();
+		expect( postSections ).toHaveLength( 2 );
+		postSections.forEach( ( postSection, index ) => {
+			expect( postSection ).toBeVisible();
+			expect( postSection ).toHaveTextContent(
+				`Post Section ${ index + 1 }`
+			);
+		} );
 	} );
 
-	test( 'should match snapshot for Slot', () => {
-		const wrapper = shallow( <MySlotFill.Slot /> );
+	test( 'should support separate multiple slots and fills', () => {
+		const PostSidebar = createSlotFill( 'PostSidebar' );
+		const PageSidebar = createSlotFill( 'PageSidebar' );
 
-		expect( wrapper.type() ).toBe( Slot );
-		expect( wrapper.prop( 'name' ) ).toBe( SLOT_NAME );
+		render(
+			<SlotFillProvider>
+				<PostSidebar.Fill>
+					<p>Post Section</p>
+				</PostSidebar.Fill>
+				<PageSidebar.Fill>
+					<p>Page Section</p>
+				</PageSidebar.Fill>
+				<div title="Post Sidebar">
+					<PostSidebar.Slot />
+				</div>
+				<div title="Page Sidebar">
+					<PageSidebar.Slot />
+				</div>
+			</SlotFillProvider>
+		);
+
+		const postSidebar = screen.getByTitle( 'Post Sidebar' );
+
+		expect( postSidebar ).toBeVisible();
+		expect(
+			within( postSidebar ).getByText( 'Post Section' )
+		).toBeVisible();
+
+		const pageSidebar = screen.getByTitle( 'Page Sidebar' );
+
+		expect( pageSidebar ).toBeVisible();
+		expect(
+			within( pageSidebar ).getByText( 'Page Section' )
+		).toBeVisible();
+
+		expect(
+			within( postSidebar ).queryByText( 'Page Section' )
+		).not.toBeInTheDocument();
+		expect(
+			within( pageSidebar ).queryByText( 'Post Section' )
+		).not.toBeInTheDocument();
 	} );
 } );


### PR DESCRIPTION
## What?
We've recently started refactoring `enzyme` tests to `@testing-library/react`.

This PR refactors the `Slot`/`Fill` tests from `enzyme` to `@testing-library/react`.

## Why?
`@testing-library/react` provides a better way to write tests for accessible components that is closer to the way the user experiences them.

## How?
We're straightforwardly replacing `enzyme` tests with `@testing-library/react` ones, using `jest-dom` matchers and mocks to avoid testing unrelated implementation details. We're also adding a few more scenarios for better coverage.

## Testing Instructions
Verify tests pass: `npm run test:unit packages/components/src/slot-fill/test/index.js`
