### PR TITLE
Safeguard for backport of `get_template_hierarchy` function

### DIFF
--- a/lib/compat/wordpress-6.1/block-template-utils.php
+++ b/lib/compat/wordpress-6.1/block-template-utils.php
@@ -367,5 +367,5 @@ if ( ! function_exists( 'get_template_hierarchy' ) ) {
 		}
 		$template_hierarchy[] = 'index';
 		return $template_hierarchy;
-	};
+	}
 }

--- a/lib/compat/wordpress-6.1/block-template-utils.php
+++ b/lib/compat/wordpress-6.1/block-template-utils.php
@@ -308,62 +308,64 @@ function gutenberg_build_block_template_result_from_post( $post ) {
 	return $template;
 }
 
-/**
- * Helper function to get the Template Hierarchy for a given slug.
- * We need to Handle special cases here like `front-page`, `singular` and `archive` templates.
- *
- * Noting that we always add `index` as the last fallback template.
- *
- * @param string  $slug            The template slug to be created.
- * @param boolean $is_custom       Indicates if a template is custom or part of the template hierarchy.
- * @param string  $template_prefix The template prefix for the created template. This is used to extract the main template type ex. in `taxonomy-books` we extract the `taxonomy`.
- *
- * @return array<string> The template hierarchy.
- */
-function get_template_hierarchy( $slug, $is_custom = false, $template_prefix = '' ) {
-	if ( 'index' === $slug ) {
-		return array( 'index' );
-	}
-	if ( $is_custom ) {
-		return array( 'page', 'singular', 'index' );
-	}
-	if ( 'front-page' === $slug ) {
-		return array( 'front-page', 'home', 'index' );
-	}
-	$template_hierarchy = array( $slug );
-	// Most default templates don't have `$template_prefix` assigned.
-	if ( $template_prefix ) {
-		list($type) = explode( '-', $template_prefix );
-		// We need these checks because we always add the `$slug` above.
-		if ( ! in_array( $template_prefix, array( $slug, $type ), true ) ) {
-			$template_hierarchy[] = $template_prefix;
+if ( ! function_exists( 'get_template_hierarchy' ) ) {
+	/**
+	 * Helper function to get the Template Hierarchy for a given slug.
+	 * We need to Handle special cases here like `front-page`, `singular` and `archive` templates.
+	 *
+	 * Noting that we always add `index` as the last fallback template.
+	 *
+	 * @param string  $slug            The template slug to be created.
+	 * @param boolean $is_custom       Indicates if a template is custom or part of the template hierarchy.
+	 * @param string  $template_prefix The template prefix for the created template. This is used to extract the main template type ex. in `taxonomy-books` we extract the `taxonomy`.
+	 *
+	 * @return array<string> The template hierarchy.
+	 */
+	function get_template_hierarchy( $slug, $is_custom = false, $template_prefix = '' ) {
+		if ( 'index' === $slug ) {
+			return array( 'index' );
 		}
-		if ( $slug !== $type ) {
-			$template_hierarchy[] = $type;
+		if ( $is_custom ) {
+			return array( 'page', 'singular', 'index' );
 		}
-	}
-	// Handle `archive` template.
-	if (
-		str_starts_with( $slug, 'author' ) ||
-		str_starts_with( $slug, 'taxonomy' ) ||
-		str_starts_with( $slug, 'category' ) ||
-		str_starts_with( $slug, 'tag' ) ||
-		'date' === $slug
-	) {
-		$template_hierarchy[] = 'archive';
-	}
-	// Handle `single` template.
-	if ( 'attachment' === $slug ) {
-		$template_hierarchy[] = 'single';
-	}
-	// Handle `singular` template.
-	if (
-		str_starts_with( $slug, 'single' ) ||
-		str_starts_with( $slug, 'page' ) ||
-		'attachment' === $slug
-	) {
-		$template_hierarchy[] = 'singular';
-	}
-	$template_hierarchy[] = 'index';
-	return $template_hierarchy;
-};
+		if ( 'front-page' === $slug ) {
+			return array( 'front-page', 'home', 'index' );
+		}
+		$template_hierarchy = array( $slug );
+		// Most default templates don't have `$template_prefix` assigned.
+		if ( $template_prefix ) {
+			list($type) = explode( '-', $template_prefix );
+			// We need these checks because we always add the `$slug` above.
+			if ( ! in_array( $template_prefix, array( $slug, $type ), true ) ) {
+				$template_hierarchy[] = $template_prefix;
+			}
+			if ( $slug !== $type ) {
+				$template_hierarchy[] = $type;
+			}
+		}
+		// Handle `archive` template.
+		if (
+			str_starts_with( $slug, 'author' ) ||
+			str_starts_with( $slug, 'taxonomy' ) ||
+			str_starts_with( $slug, 'category' ) ||
+			str_starts_with( $slug, 'tag' ) ||
+			'date' === $slug
+		) {
+			$template_hierarchy[] = 'archive';
+		}
+		// Handle `single` template.
+		if ( 'attachment' === $slug ) {
+			$template_hierarchy[] = 'single';
+		}
+		// Handle `singular` template.
+		if (
+			str_starts_with( $slug, 'single' ) ||
+			str_starts_with( $slug, 'page' ) ||
+			'attachment' === $slug
+		) {
+			$template_hierarchy[] = 'singular';
+		}
+		$template_hierarchy[] = 'index';
+		return $template_hierarchy;
+	};
+}


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Needed before merging: https://github.com/WordPress/wordpress-develop/pull/3221
