### PR TITLE
Paragraph: Rework ParagraphRTLControl intro direction control

### DIFF
--- a/packages/block-library/src/paragraph/edit.js
+++ b/packages/block-library/src/paragraph/edit.js
@@ -6,9 +6,9 @@ import classnames from 'classnames';
 /**
  * WordPress dependencies
  */
-import { __, _x, isRTL } from '@wordpress/i18n';
+import { __ } from '@wordpress/i18n';
 import {
-	ToolbarButton,
+	ToolbarDropdownMenu,
 	ToggleControl,
 	__experimentalToolsPanelItem as ToolsPanelItem,
 } from '@wordpress/components';
@@ -21,7 +21,7 @@ import {
 	useSetting,
 } from '@wordpress/block-editor';
 import { createBlock } from '@wordpress/blocks';
-import { formatLtr } from '@wordpress/icons';
+import { formatLtr, formatRtl } from '@wordpress/icons';
 
 /**
  * Internal dependencies
@@ -30,18 +30,43 @@ import { useOnEnter } from './use-enter';
 
 const name = 'core/paragraph';
 
-function ParagraphRTLControl( { direction, setDirection } ) {
+const DEFAULT_DIRECTION_CONTROLS = [
+	{
+		icon: formatLtr,
+		title: __( 'Left to right' ),
+		direction: 'ltr',
+	},
+	{
+		icon: formatRtl,
+		title: __( 'Right to left' ),
+		direction: 'rtl',
+	},
+];
+
+function ParagraphDirectionControl( { direction, setDirection } ) {
+	const icon = direction === 'rtl' ? formatRtl : formatLtr;
+
 	return (
-		isRTL() && (
-			<ToolbarButton
-				icon={ formatLtr }
-				title={ _x( 'Left to right', 'editor button' ) }
-				isActive={ direction === 'ltr' }
-				onClick={ () => {
-					setDirection( direction === 'ltr' ? undefined : 'ltr' );
-				} }
-			/>
-		)
+		<ToolbarDropdownMenu
+			icon={ icon }
+			label={ __( 'Direction' ) }
+			toggleProps={ { describedBy: __( 'Change text direction' ) } }
+			popoverProps={ { position: 'bottom right', isAlternate: true } }
+			controls={ DEFAULT_DIRECTION_CONTROLS.map( ( control ) => {
+				const isActive = control.direction === direction;
+
+				return {
+					...control,
+					isActive,
+					onClick: () =>
+						setDirection(
+							direction === control.direction
+								? undefined
+								: control.direction
+						),
+				};
+			} ) }
+		/>
 	);
 }
 
@@ -73,7 +98,7 @@ function ParagraphBlock( {
 						setAttributes( { align: newAlign } )
 					}
 				/>
-				<ParagraphRTLControl
+				<ParagraphDirectionControl
 					direction={ direction }
 					setDirection={ ( newDirection ) =>
 						setAttributes( { direction: newDirection } )


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->
Replace `ParagraphRTLControl` component, that's being conditionally rendered only when block editor's UI set to RTL language, by paragraph direction control, that's being always rendered to allow overriding the `dir` attribute.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->

## Screenshots or screencast <!-- if applicable -->
![CleanShot 2022-09-12 at 16 36 50](https://user-images.githubusercontent.com/2722412/189670259-3ddd8de8-06f2-4857-9bb8-2135bafad0e8.png)