### PR TITLE
Simplify the inserter styles and scrollable

### DIFF
--- a/packages/base-styles/_z-index.scss
+++ b/packages/base-styles/_z-index.scss
@@ -15,9 +15,6 @@ $z-layers: (
 	".edit-post-sidebar__panel-tab.is-active": 1,
 
 	// These next three share a stacking context
-	".block-editor-inserter__tabs .components-tab-panel__tab-content": 0, // lower scrolling content
-	".block-editor-inserter__tabs .components-tab-panel__tabs": 1, // higher sticky element
-	".block-editor-inserter__search": 1, // higher sticky element
 	".block-library-template-part__selection-search": 1, // higher sticky element
 
 	// These next two share a stacking context

--- a/packages/block-editor/src/components/inserter/menu.js
+++ b/packages/block-editor/src/components/inserter/menu.js
@@ -1,4 +1,9 @@
 /**
+ * External dependencies
+ */
+import classnames from 'classnames';
+
+/**
  * WordPress dependencies
  */
 import {
@@ -181,23 +186,28 @@ function InserterMenu(
 		},
 	} ) );
 
+	const showAsTabs = ! filterValue && ( showPatterns || hasReusableBlocks );
+
 	return (
 		<div className="block-editor-inserter__menu">
-			<div className="block-editor-inserter__main-area">
-				{ /* The following div is necessary to fix the sticky position of the search form. */ }
-				<div className="block-editor-inserter__content">
-					<SearchControl
-						className="block-editor-inserter__search"
-						onChange={ ( value ) => {
-							if ( hoveredItem ) setHoveredItem( null );
-							setFilterValue( value );
-						} }
-						value={ filterValue }
-						label={ __( 'Search for blocks and patterns' ) }
-						placeholder={ __( 'Search' ) }
-						ref={ searchRef }
-					/>
-					{ !! filterValue && (
+			<div
+				className={ classnames( 'block-editor-inserter__main-area', {
+					'show-as-tabs': showAsTabs,
+				} ) }
+			>
+				<SearchControl
+					className="block-editor-inserter__search"
+					onChange={ ( value ) => {
+						if ( hoveredItem ) setHoveredItem( null );
+						setFilterValue( value );
+					} }
+					value={ filterValue }
+					label={ __( 'Search for blocks and patterns' ) }
+					placeholder={ __( 'Search' ) }
+					ref={ searchRef }
+				/>
+				{ !! filterValue && (
+					<div className="block-editor-inserter__no-tab-container">
 						<InserterSearchResults
 							filterValue={ filterValue }
 							onSelect={ onSelect }
@@ -211,21 +221,22 @@ function InserterMenu(
 							showBlockDirectory
 							shouldFocusBlock={ shouldFocusBlock }
 						/>
-					) }
-					{ ! filterValue && ( showPatterns || hasReusableBlocks ) && (
-						<InserterTabs
-							showPatterns={ showPatterns }
-							showReusableBlocks={ hasReusableBlocks }
-							prioritizePatterns={ prioritizePatterns }
-						>
-							{ getCurrentTab }
-						</InserterTabs>
-					) }
-					{ ! filterValue &&
-						! showPatterns &&
-						! hasReusableBlocks &&
-						blocksTab }
-				</div>
+					</div>
+				) }
+				{ showAsTabs && (
+					<InserterTabs
+						showPatterns={ showPatterns }
+						showReusableBlocks={ hasReusableBlocks }
+						prioritizePatterns={ prioritizePatterns }
+					>
+						{ getCurrentTab }
+					</InserterTabs>
+				) }
+				{ ! filterValue && ! showAsTabs && (
+					<div className="block-editor-inserter__no-tab-container">
+						{ blocksTab }
+					</div>
+				) }
 			</div>
 			{ showInserterHelpPanel && hoveredItem && (
 				<InserterPreviewPanel item={ hoveredItem } />

--- a/packages/block-editor/src/components/inserter/stories/fixtures.js
+++ b/packages/block-editor/src/components/inserter/stories/fixtures.js
@@ -1,0 +1,44 @@
+export const patterns = [
+	{
+		categories: [ 'featured', 'text' ],
+		content:
+			'<!-- wp:heading {"align":"wide","style":{"typography":{"fontSize":"48px","lineHeight":"1.1"}}} -->\n<h2 class="alignwide" id="we-re-a-studio-in-berlin-with-an-international-practice-in-architecture-urban-planning-and-interior-design-we-believe-in-sharing-knowledge-and-promoting-dialogue-to-increase-the-creative-potential-of-collaboration" style="font-size:48px;line-height:1.1">We\'re a studio in Berlin with an international practice in architecture, urban planning and interior design. We believe in sharing knowledge and promoting dialogue to increase the creative potential of collaboration.</h2>\n<!-- /wp:heading -->',
+		description: 'Heading text',
+		keywords: [ 'large text', 'title' ],
+		name: 'heading',
+		title: 'Heading',
+	},
+];
+
+export const patternCategories = [
+	{
+		name: 'featured',
+		label: 'Featured',
+	},
+	{
+		name: 'text',
+		label: 'Text',
+	},
+];
+
+export const reusableBlocks = [
+	{
+		content: {
+			raw: '\x3C!-- wp:paragraph -->\n<p>This is reusable</p>\n\x3C!-- /wp:paragraph -->',
+			protected: false,
+			block_version: 1,
+		},
+		date: '2022-09-12T13:28:06',
+		date_gmt: '2022-09-12T13:28:06',
+		id: 70,
+		link: 'http://localhost:8888/?p=70',
+		modified: '2022-09-12T13:28:06',
+		modified_gmt: '2022-09-12T13:28:06',
+		password: '',
+		slug: 'simple-paragraph',
+		status: 'publish',
+		template: '',
+		title: { raw: 'Simple paragraph' },
+		type: 'wp_block',
+	},
+];

--- a/packages/block-editor/src/components/inserter/stories/index.js
+++ b/packages/block-editor/src/components/inserter/stories/index.js
@@ -1,0 +1,90 @@
+/**
+ * Internal dependencies
+ */
+import BlockLibrary from '../library';
+import BlockEditorProvider from '../../provider';
+import { patternCategories, patterns, reusableBlocks } from './fixtures';
+import Inserter from '../';
+
+export default { title: 'BlockEditor/Inserter' };
+
+export const libraryWithoutPatterns = () => {
+	const wrapperStyle = {
+		margin: '24px',
+		height: 400,
+		border: '1px solid #f3f3f3',
+		display: 'inline-block',
+	};
+	return (
+		<BlockEditorProvider>
+			<div style={ wrapperStyle }>
+				<BlockLibrary showInserterHelpPanel />
+			</div>
+		</BlockEditorProvider>
+	);
+};
+
+export const libraryWithPatterns = () => {
+	const wrapperStyle = {
+		margin: '24px',
+		height: 400,
+		border: '1px solid #f3f3f3',
+		display: 'inline-block',
+	};
+	return (
+		<BlockEditorProvider
+			settings={ {
+				__experimentalBlockPatternCategories: patternCategories,
+				__experimentalBlockPatterns: patterns,
+			} }
+		>
+			<div style={ wrapperStyle }>
+				<BlockLibrary showInserterHelpPanel />
+			</div>
+		</BlockEditorProvider>
+	);
+};
+
+export const libraryWithPatternsAndReusableBlocks = () => {
+	const wrapperStyle = {
+		margin: '24px',
+		height: 400,
+		border: '1px solid #f3f3f3',
+		display: 'inline-block',
+	};
+	return (
+		<BlockEditorProvider
+			settings={ {
+				__experimentalBlockPatternCategories: patternCategories,
+				__experimentalBlockPatterns: patterns,
+				__experimentalReusableBlocks: reusableBlocks,
+			} }
+		>
+			<div style={ wrapperStyle }>
+				<BlockLibrary showInserterHelpPanel />
+			</div>
+		</BlockEditorProvider>
+	);
+};
+
+export const quickInserter = () => {
+	const wrapperStyle = {
+		margin: '24px',
+		height: 400,
+		border: '1px solid #f3f3f3',
+		display: 'inline-block',
+	};
+	return (
+		<BlockEditorProvider
+			settings={ {
+				__experimentalBlockPatternCategories: patternCategories,
+				__experimentalBlockPatterns: patterns,
+				__experimentalReusableBlocks: reusableBlocks,
+			} }
+		>
+			<div style={ wrapperStyle }>
+				<Inserter __experimentalIsQuick />
+			</div>
+		</BlockEditorProvider>
+	);
+};

--- a/packages/block-editor/src/components/inserter/style.scss
+++ b/packages/block-editor/src/components/inserter/style.scss
@@ -16,8 +16,20 @@ $block-inserter-tabs-height: 44px;
 	}
 }
 
-.block-editor-inserter__content {
+.block-editor-inserter__main-area {
 	position: relative;
+	display: flex;
+	flex-direction: column;
+	height: 100%;
+	gap: $grid-unit-20;
+	width: auto;
+	@include break-medium {
+		width: $block-inserter-width;
+	}
+
+	&.show-as-tabs {
+		gap: 0;
+	}
 }
 
 .block-editor-inserter__popover.is-quick {
@@ -78,15 +90,6 @@ $block-inserter-tabs-height: 44px;
 	overflow: visible;
 }
 
-.block-editor-inserter__main-area {
-	width: auto;
-	overflow-y: auto;
-	height: 100%;
-	@include break-medium {
-		width: $block-inserter-width;
-	}
-}
-
 .block-editor-inserter__inline-elements {
 	margin-top: -1px;
 }
@@ -100,11 +103,7 @@ $block-inserter-tabs-height: 44px;
 }
 
 .block-editor-inserter__search {
-	background: $white;
 	padding: $grid-unit-20 $grid-unit-20 0 $grid-unit-20;
-	position: sticky;
-	top: 0;
-	z-index: z-index(".block-editor-inserter__search");
 
 	.components-search-control__icon {
 		right: $grid-unit-10 + ($grid-unit-60 - $icon-size) * 0.5;
@@ -116,15 +115,12 @@ $block-inserter-tabs-height: 44px;
 }
 
 .block-editor-inserter__tabs {
+	flex-grow: 1;
 	display: flex;
 	flex-direction: column;
+	overflow: hidden;
 
 	.components-tab-panel__tabs {
-		position: sticky;
-		// Computed based off the search input height and paddings
-		top: $grid-unit-20 + $grid-unit-60;
-		background: $white;
-		z-index: z-index(".block-editor-inserter__tabs .components-tab-panel__tabs");
 		border-bottom: $border-width solid $gray-300;
 
 		.components-tab-panel__tabs-item {
@@ -137,10 +133,13 @@ $block-inserter-tabs-height: 44px;
 		display: flex;
 		flex-grow: 1;
 		flex-direction: column;
-		// Make a stacking context that keeps all descendents behind the sticky tabs
-		position: relative;
-		z-index: z-index(".block-editor-inserter__tabs .components-tab-panel__tab-content");
+		overflow-y: auto;
 	}
+}
+
+.block-editor-inserter__no-tab-container {
+	overflow-y: auto;
+	flex-grow: 1;
 }
 
 .block-editor-inserter__panel-header {
@@ -173,11 +172,6 @@ $block-inserter-tabs-height: 44px;
 
 .block-editor-inserter__panel-dropdown select {
 	border: none;
-}
-
-.block-editor-inserter__block-list {
-	flex-grow: 1;
-	position: relative;
 }
 
 .block-editor-inserter__reusable-blocks-panel {


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What and Why?

In #44028 there's a need to add a button at the bottom of the inserter, this is only possible properly if the container of the tab grows to cover all the available space. In order to do that, we also need to move the "scrollable area" of the inserter to be the "tab content" instead of being the whole inserter. This PR achieves this refactoring.

I've also added some Storybook stories which will allow us to work easily on the inserter in isolation.

## Testing Instructions

1- Open the main inserter
2- Notice the scrolling behavior is a bit different
3- Try playing with the inserter in different situations, there should be no regression.

You can also run `npm run storybook:dev` and play with the different inserter stories.

## Screenshots or screencast <!-- if applicable -->

<img width="390" alt="Screen Shot 2022-09-12 at 2 49 48 PM" src="https://user-images.githubusercontent.com/272444/189672032-8bb7fc83-311d-4b05-93eb-6a2f530f0be1.png">
