### PR TITLE
Components: refactor `NavigationMenu` to ignore `exhaustive-deps`

### DIFF
--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Internal
+
+-   `NavigationMenu` updated to ignore `react/exhaustive-deps` eslint rule ([#44090](https://github.com/WordPress/gutenberg/pull/44090)).
+
 ## 21.0.0 (2022-09-13)
 
 ### Breaking Changes

--- a/packages/components/src/navigation/menu/menu-title-search.js
+++ b/packages/components/src/navigation/menu/menu-title-search.js
@@ -52,6 +52,8 @@ function MenuTitleSearch( {
 			count
 		);
 		debouncedSpeak( resultsFoundMessage );
+		// Ignore exhaustive-deps rule for now.
+		// eslint-disable-next-line react-hooks/exhaustive-deps
 	}, [ items, search ] );
 
 	const onClose = () => {

--- a/packages/components/src/navigation/menu/menu-title-search.js
+++ b/packages/components/src/navigation/menu/menu-title-search.js
@@ -52,7 +52,7 @@ function MenuTitleSearch( {
 			count
 		);
 		debouncedSpeak( resultsFoundMessage );
-		// Ignore exhaustive-deps rule for now.
+		// Ignore exhaustive-deps rule for now. See https://github.com/WordPress/gutenberg/pull/44090
 		// eslint-disable-next-line react-hooks/exhaustive-deps
 	}, [ items, search ] );
 

--- a/packages/components/src/navigation/menu/use-navigation-tree-menu.js
+++ b/packages/components/src/navigation/menu/use-navigation-tree-menu.js
@@ -21,7 +21,7 @@ export const useNavigationTreeMenu = ( props ) => {
 		return () => {
 			removeMenu( key );
 		};
-		// Ignore exhaustive-deps rule for now.
+		// Ignore exhaustive-deps rule for now. See https://github.com/WordPress/gutenberg/pull/44090
 		// eslint-disable-next-line react-hooks/exhaustive-deps
 	}, [] );
 };

--- a/packages/components/src/navigation/menu/use-navigation-tree-menu.js
+++ b/packages/components/src/navigation/menu/use-navigation-tree-menu.js
@@ -21,5 +21,7 @@ export const useNavigationTreeMenu = ( props ) => {
 		return () => {
 			removeMenu( key );
 		};
+		// Ignore exhaustive-deps rule for now.
+		// eslint-disable-next-line react-hooks/exhaustive-deps
 	}, [] );
 };


### PR DESCRIPTION
## What?
Refactor the NavigationMenu components/hooks to ignore the `exhaustive-deps` eslint rule.

## Why?
Similar to #41639, because `Navigator` is preferred over `Navigation`, it doesn't make sense to invest time in refactoring the latter component. If `Navigation` is used more in the future, this can be revisited.

## How?
Identified the two warnings and added inline ignore statements

## Testing Instructions

1. From your local Gutenberg directory, run `npx eslint --rule 'react-hooks/exhaustive-deps: warn' packages/components/src/navigation/menu`
2. Confirm that the linter returns no errors

