### PR TITLE
[Mobile] - Cover block - Add Unit tests

### DIFF
--- a/packages/block-library/src/cover/test/__snapshots__/edit.native.js.snap
+++ b/packages/block-library/src/cover/test/__snapshots__/edit.native.js.snap
@@ -31,3 +31,67 @@ exports[`color settings toggles between solid colors and gradients 1`] = `
 <!-- /wp:paragraph --></div></div>
 <!-- /wp:cover -->"
 `;
+
+exports[`minimum height settings changes the height value between units 1`] = `
+"<!-- wp:cover {\\"url\\":\\"https://cldup.com/cXyG__fTLN.jpg\\",\\"id\\":10710,\\"dimRatio\\":50,\\"overlayColor\\":\\"foreground\\",\\"minHeight\\":50,\\"minHeightUnit\\":\\"px\\",\\"isDark\\":false} -->
+<div class=\\"wp-block-cover is-light\\" style=\\"min-height:50px\\"><span aria-hidden=\\"true\\" class=\\"wp-block-cover__background has-foreground-background-color has-background-dim\\"></span><img class=\\"wp-block-cover__image-background wp-image-10710\\" alt=\\"\\" src=\\"https://cldup.com/cXyG__fTLN.jpg\\" data-object-fit=\\"cover\\"/><div class=\\"wp-block-cover__inner-container\\"><!-- wp:paragraph {\\"align\\":\\"center\\",\\"placeholder\\":\\"Write title…\\",\\"fontSize\\":\\"large\\"} -->
+<p class=\\"has-text-align-center has-large-font-size\\"></p>
+<!-- /wp:paragraph --></div></div>
+<!-- /wp:cover -->"
+`;
+
+exports[`minimum height settings changes the height value to 20(vw) 1`] = `
+"<!-- wp:cover {\\"url\\":\\"https://cldup.com/cXyG__fTLN.jpg\\",\\"id\\":10710,\\"dimRatio\\":50,\\"overlayColor\\":\\"foreground\\",\\"minHeight\\":20,\\"minHeightUnit\\":\\"vw\\",\\"isDark\\":false} -->
+<div class=\\"wp-block-cover is-light\\" style=\\"min-height:20vw\\"><span aria-hidden=\\"true\\" class=\\"wp-block-cover__background has-foreground-background-color has-background-dim\\"></span><img class=\\"wp-block-cover__image-background wp-image-10710\\" alt=\\"\\" src=\\"https://cldup.com/cXyG__fTLN.jpg\\" data-object-fit=\\"cover\\"/><div class=\\"wp-block-cover__inner-container\\"><!-- wp:paragraph {\\"align\\":\\"center\\",\\"placeholder\\":\\"Write title…\\",\\"fontSize\\":\\"large\\"} -->
+<p class=\\"has-text-align-center has-large-font-size\\"></p>
+<!-- /wp:paragraph --></div></div>
+<!-- /wp:cover -->"
+`;
+
+exports[`minimum height settings disables the decrease button when reaching the minimum value for Pixels (px) 1`] = `
+"<!-- wp:cover {\\"url\\":\\"https://cldup.com/cXyG__fTLN.jpg\\",\\"id\\":10710,\\"dimRatio\\":50,\\"overlayColor\\":\\"foreground\\",\\"minHeight\\":50,\\"minHeightUnit\\":\\"px\\",\\"isDark\\":false} -->
+<div class=\\"wp-block-cover is-light\\" style=\\"min-height:50px\\"><span aria-hidden=\\"true\\" class=\\"wp-block-cover__background has-foreground-background-color has-background-dim\\"></span><img class=\\"wp-block-cover__image-background wp-image-10710\\" alt=\\"\\" src=\\"https://cldup.com/cXyG__fTLN.jpg\\" data-object-fit=\\"cover\\"/><div class=\\"wp-block-cover__inner-container\\"><!-- wp:paragraph {\\"align\\":\\"center\\",\\"placeholder\\":\\"Write title…\\",\\"fontSize\\":\\"large\\"} -->
+<p class=\\"has-text-align-center has-large-font-size\\"></p>
+<!-- /wp:paragraph --></div></div>
+<!-- /wp:cover -->"
+`;
+
+exports[`minimum height settings disables the decrease button when reaching the minimum value for Relative to parent font size (em) 1`] = `
+"<!-- wp:cover {\\"url\\":\\"https://cldup.com/cXyG__fTLN.jpg\\",\\"id\\":10710,\\"dimRatio\\":50,\\"overlayColor\\":\\"foreground\\",\\"minHeight\\":1,\\"minHeightUnit\\":\\"em\\",\\"isDark\\":false} -->
+<div class=\\"wp-block-cover is-light\\" style=\\"min-height:1em\\"><span aria-hidden=\\"true\\" class=\\"wp-block-cover__background has-foreground-background-color has-background-dim\\"></span><img class=\\"wp-block-cover__image-background wp-image-10710\\" alt=\\"\\" src=\\"https://cldup.com/cXyG__fTLN.jpg\\" data-object-fit=\\"cover\\"/><div class=\\"wp-block-cover__inner-container\\"><!-- wp:paragraph {\\"align\\":\\"center\\",\\"placeholder\\":\\"Write title…\\",\\"fontSize\\":\\"large\\"} -->
+<p class=\\"has-text-align-center has-large-font-size\\"></p>
+<!-- /wp:paragraph --></div></div>
+<!-- /wp:cover -->"
+`;
+
+exports[`minimum height settings disables the decrease button when reaching the minimum value for Relative to root font size (rem) 1`] = `
+"<!-- wp:cover {\\"url\\":\\"https://cldup.com/cXyG__fTLN.jpg\\",\\"id\\":10710,\\"dimRatio\\":50,\\"overlayColor\\":\\"foreground\\",\\"minHeight\\":1,\\"minHeightUnit\\":\\"rem\\",\\"isDark\\":false} -->
+<div class=\\"wp-block-cover is-light\\" style=\\"min-height:1rem\\"><span aria-hidden=\\"true\\" class=\\"wp-block-cover__background has-foreground-background-color has-background-dim\\"></span><img class=\\"wp-block-cover__image-background wp-image-10710\\" alt=\\"\\" src=\\"https://cldup.com/cXyG__fTLN.jpg\\" data-object-fit=\\"cover\\"/><div class=\\"wp-block-cover__inner-container\\"><!-- wp:paragraph {\\"align\\":\\"center\\",\\"placeholder\\":\\"Write title…\\",\\"fontSize\\":\\"large\\"} -->
+<p class=\\"has-text-align-center has-large-font-size\\"></p>
+<!-- /wp:paragraph --></div></div>
+<!-- /wp:cover -->"
+`;
+
+exports[`minimum height settings disables the decrease button when reaching the minimum value for Viewport height (vh) 1`] = `
+"<!-- wp:cover {\\"url\\":\\"https://cldup.com/cXyG__fTLN.jpg\\",\\"id\\":10710,\\"dimRatio\\":50,\\"overlayColor\\":\\"foreground\\",\\"minHeight\\":1,\\"minHeightUnit\\":\\"vh\\",\\"isDark\\":false} -->
+<div class=\\"wp-block-cover is-light\\" style=\\"min-height:1vh\\"><span aria-hidden=\\"true\\" class=\\"wp-block-cover__background has-foreground-background-color has-background-dim\\"></span><img class=\\"wp-block-cover__image-background wp-image-10710\\" alt=\\"\\" src=\\"https://cldup.com/cXyG__fTLN.jpg\\" data-object-fit=\\"cover\\"/><div class=\\"wp-block-cover__inner-container\\"><!-- wp:paragraph {\\"align\\":\\"center\\",\\"placeholder\\":\\"Write title…\\",\\"fontSize\\":\\"large\\"} -->
+<p class=\\"has-text-align-center has-large-font-size\\"></p>
+<!-- /wp:paragraph --></div></div>
+<!-- /wp:cover -->"
+`;
+
+exports[`minimum height settings disables the decrease button when reaching the minimum value for Viewport width (vw) 1`] = `
+"<!-- wp:cover {\\"url\\":\\"https://cldup.com/cXyG__fTLN.jpg\\",\\"id\\":10710,\\"dimRatio\\":50,\\"overlayColor\\":\\"foreground\\",\\"minHeight\\":1,\\"minHeightUnit\\":\\"vw\\",\\"isDark\\":false} -->
+<div class=\\"wp-block-cover is-light\\" style=\\"min-height:1vw\\"><span aria-hidden=\\"true\\" class=\\"wp-block-cover__background has-foreground-background-color has-background-dim\\"></span><img class=\\"wp-block-cover__image-background wp-image-10710\\" alt=\\"\\" src=\\"https://cldup.com/cXyG__fTLN.jpg\\" data-object-fit=\\"cover\\"/><div class=\\"wp-block-cover__inner-container\\"><!-- wp:paragraph {\\"align\\":\\"center\\",\\"placeholder\\":\\"Write title…\\",\\"fontSize\\":\\"large\\"} -->
+<p class=\\"has-text-align-center has-large-font-size\\"></p>
+<!-- /wp:paragraph --></div></div>
+<!-- /wp:cover -->"
+`;
+
+exports[`when an image is attached updates background opacity 1`] = `
+"<!-- wp:cover {\\"url\\":\\"https://cldup.com/cXyG__fTLN.jpg\\",\\"id\\":10710,\\"dimRatio\\":15,\\"overlayColor\\":\\"foreground\\",\\"isDark\\":false} -->
+<div class=\\"wp-block-cover is-light\\"><span aria-hidden=\\"true\\" class=\\"wp-block-cover__background has-foreground-background-color has-background-dim-20 has-background-dim\\"></span><img class=\\"wp-block-cover__image-background wp-image-10710\\" alt=\\"\\" src=\\"https://cldup.com/cXyG__fTLN.jpg\\" data-object-fit=\\"cover\\"/><div class=\\"wp-block-cover__inner-container\\"><!-- wp:paragraph {\\"align\\":\\"center\\",\\"placeholder\\":\\"Write title…\\",\\"fontSize\\":\\"large\\"} -->
+<p class=\\"has-text-align-center has-large-font-size\\"></p>
+<!-- /wp:paragraph --></div></div>
+<!-- /wp:cover -->"
+`;

--- a/packages/block-library/src/cover/test/edit.native.js
+++ b/packages/block-library/src/cover/test/edit.native.js
@@ -9,6 +9,8 @@ import {
 	fireEvent,
 	waitFor,
 	within,
+	getBlock,
+	openBlockSettings,
 } from 'test/helpers';
 
 /**
@@ -41,11 +43,11 @@ jest.mock( '@wordpress/compose', () => ( {
 	) ),
 } ) );
 
-const COVER_BLOCK_PLACEHOLDER_HTML = `<!-- wp:cover -->
-<div class="wp-block-cover"><span aria-hidden="true" class="has-background-dim-100 wp-block-cover__gradient-background has-background-dim"></span><div class="wp-block-cover__inner-container"></div></div>
+const COVER_BLOCK_PLACEHOLDER_HTML = `<!-- wp:cover {"isDark":false} -->
+<div class="wp-block-cover is-light"><span aria-hidden="true" class="wp-block-cover__background has-background-dim-100 has-background-dim"></span><div class="wp-block-cover__inner-container"></div></div>
 <!-- /wp:cover -->`;
-const COVER_BLOCK_SOLID_COLOR_HTML = `<!-- wp:cover {"overlayColor":"cyan-bluish-gray"} -->
-<div class="wp-block-cover"><span aria-hidden="true" class="has-cyan-bluish-gray-background-color has-background-dim-100 wp-block-cover__gradient-background has-background-dim"></span><div class="wp-block-cover__inner-container"><!-- wp:paragraph {"align":"center","placeholder":"Write title…"} -->
+const COVER_BLOCK_SOLID_COLOR_HTML = `<!-- wp:cover {"overlayColor":"cyan-bluish-gray","isDark":false} -->
+<div class="wp-block-cover is-light"><span aria-hidden="true" class="wp-block-cover__background has-cyan-bluish-gray-background-color has-background-dim-100 has-background-dim"></span><div class="wp-block-cover__inner-container"><!-- wp:paragraph {"align":"center","placeholder":"Write title…"} -->
 <p class="has-text-align-center"></p>
 <!-- /wp:paragraph --></div></div>
 <!-- /wp:cover -->`;
@@ -302,24 +304,17 @@ describe( 'when an image is attached', () => {
 	} );
 
 	it( 'updates background opacity', async () => {
-		const { getByTestId, getByA11yLabel } = await initializeEditor( {
+		const screen = await initializeEditor( {
 			initialHtml: COVER_BLOCK_IMAGE_HTML,
 		} );
+		const { getByA11yLabel } = screen;
 
-		const coverBlock = await waitFor( () =>
-			getByA11yLabel( /Cover Block\. Row 1/ )
-		);
+		// Get block
+		const coverBlock = await getBlock( screen, 'Cover' );
 		fireEvent.press( coverBlock );
 
 		// Open block settings
-		fireEvent.press( getByA11yLabel( 'Open Settings' ) );
-		await waitFor(
-			() => getByTestId( 'block-settings-modal' ).props.isVisible
-		);
-
-		// Wait for Block Settings to be visible.
-		const blockSettingsModal = getByTestId( 'block-settings-modal' );
-		await waitFor( () => blockSettingsModal.props.isVisible );
+		await openBlockSettings( screen );
 
 		// Update Opacity attribute
 		const opacityControl = getByA11yLabel( /Opacity/ );
@@ -581,21 +576,17 @@ describe( 'color settings', () => {
 
 describe( 'minimum height settings', () => {
 	it( 'changes the height value to 20(vw)', async () => {
-		const { getByTestId, getByA11yLabel, getByText, getByDisplayValue } =
-			await initializeEditor( {
-				initialHtml: COVER_BLOCK_IMAGE_HTML,
-			} );
+		const screen = await initializeEditor( {
+			initialHtml: COVER_BLOCK_IMAGE_HTML,
+		} );
+		const { getByText, getByDisplayValue } = screen;
 
-		const coverBlock = await waitFor( () =>
-			getByA11yLabel( /Cover Block\. Row 1/ )
-		);
+		// Get block
+		const coverBlock = await getBlock( screen, 'Cover' );
 		fireEvent.press( coverBlock );
 
 		// Open block settings
-		fireEvent.press( getByA11yLabel( 'Open Settings' ) );
-		await waitFor(
-			() => getByTestId( 'block-settings-modal' ).props.isVisible
-		);
+		await openBlockSettings( screen );
 
 		// Set vw unit
 		fireEvent.press( getByText( 'px' ) );
@@ -610,25 +601,17 @@ describe( 'minimum height settings', () => {
 	} );
 
 	it( 'changes the height value between units', async () => {
-		const { getByTestId, getByA11yLabel, getByText } =
-			await initializeEditor( {
-				initialHtml: COVER_BLOCK_CUSTOM_HEIGHT_HTML,
-			} );
+		const screen = await initializeEditor( {
+			initialHtml: COVER_BLOCK_CUSTOM_HEIGHT_HTML,
+		} );
+		const { getByText } = screen;
 
-		const coverBlock = await waitFor( () =>
-			getByA11yLabel( /Cover Block\. Row 1/ )
-		);
+		// Get block
+		const coverBlock = await getBlock( screen, 'Cover' );
 		fireEvent.press( coverBlock );
 
 		// Open block settings
-		fireEvent.press( getByA11yLabel( 'Open Settings' ) );
-		await waitFor(
-			() => getByTestId( 'block-settings-modal' ).props.isVisible
-		);
-
-		// Wait for Block Settings to be visible.
-		const blockSettingsModal = getByTestId( 'block-settings-modal' );
-		await waitFor( () => blockSettingsModal.props.isVisible );
+		await openBlockSettings( screen );
 
 		// Set the pixel unit
 		fireEvent.press( getByText( 'vw' ) );
@@ -649,27 +632,17 @@ describe( 'minimum height settings', () => {
 		test.each( testData )(
 			'for %s',
 			async ( unitName, value, minValue ) => {
-				const { getByTestId, getByA11yLabel, getByText } =
-					await initializeEditor( {
-						initialHtml: COVER_BLOCK_CUSTOM_HEIGHT_HTML,
-					} );
+				const screen = await initializeEditor( {
+					initialHtml: COVER_BLOCK_CUSTOM_HEIGHT_HTML,
+				} );
+				const { getByA11yLabel, getByText } = screen;
 
-				const coverBlock = await waitFor( () =>
-					getByA11yLabel( /Cover Block\. Row 1/ )
-				);
+				// Get block
+				const coverBlock = await getBlock( screen, 'Cover' );
 				fireEvent.press( coverBlock );
 
 				// Open block settings
-				fireEvent.press( getByA11yLabel( 'Open Settings' ) );
-				await waitFor(
-					() => getByTestId( 'block-settings-modal' ).props.isVisible
-				);
-
-				// Wait for Block Settings to be visible.
-				const blockSettingsModal = getByTestId(
-					'block-settings-modal'
-				);
-				await waitFor( () => blockSettingsModal.props.isVisible );
+				await openBlockSettings( screen );
 
 				// Set the unit name
 				fireEvent.press( getByText( 'vw' ) );


### PR DESCRIPTION
**Related PRs**: https://github.com/wordpress-mobile/test-cases/pull/120

## What?
We are adding some unit tests for the Cover block.

## Why?
These tests were done manually in each release so now we are moving some of them into unit tests.

## How?
By adding the following tests:

```
  when an image is attached
    updates background opacity
  minimum height settings
    changes the height value to 20(vw)
    changes the height value between units
    disables the decrease button when reaching the minimum value
        for Pixels (px)
        for Relative to parent font size (em)
        for Relative to root font size (rem)
        for Viewport width (vw)
        for Viewport height (vh)
```

It also updates the HTML mocks to the current format.

## Testing Instructions
CI checks should pass

## Screenshots or screencast <!-- if applicable -->
N/A