### PR TITLE
[Block Library - Query Loop]: Pass extra query args in REST API call for accurate preview for extenders

### DIFF
--- a/packages/block-library/src/post-template/edit.js
+++ b/packages/block-library/src/post-template/edit.js
@@ -85,6 +85,13 @@ export default function PostTemplateEdit( {
 			inherit,
 			taxQuery,
 			parents,
+			pages,
+			// We gather extra query args to pass to the REST API call.
+			// This way extenders of Query Loop can add their own query args,
+			// and have accurate previews in the editor.
+			// Noting though that these args should either be supported by the
+			// REST API or be handled by custom REST filters like `rest_{$this->post_type}_query`.
+			...restQueryArgs
 		} = {},
 		queryContext = [ { page: 1 } ],
 		templateSlug,
@@ -178,7 +185,10 @@ export default function PostTemplateEdit( {
 			// block's postType, which is passed through block context.
 			const usedPostType = previewPostType || postType;
 			return {
-				posts: getEntityRecords( 'postType', usedPostType, query ),
+				posts: getEntityRecords( 'postType', usedPostType, {
+					...query,
+					...restQueryArgs,
+				} ),
 				blocks: getBlocks( clientId ),
 			};
 		},
@@ -198,6 +208,7 @@ export default function PostTemplateEdit( {
 			templateSlug,
 			taxQuery,
 			parents,
+			restQueryArgs,
 			previewPostType,
 			categories,
 			categorySlug,


### PR DESCRIPTION


<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Related to the php  [query_loop_block_query_vars](https://github.com/WordPress/gutenberg/pull/43590) filter added recently. This PR allows the Query Loop to be extended by third party devs, by passing extra query args in the REST API call.

This way we can have accurate previews in the editor.

#### Notes 

Noting though that these args should either be supported by the REST API or be handled by custom REST filters like `rest_{$this->post_type}_query`.
<!-- In a few words, what is the PR actually doing? -->


## Testing Instructions
1. Everything should work as before with no regressions
2. If you add extra args in the `query` attribute of a Query Loop, should be passed in the REST API call.

