### PR TITLE
Fix: Content blocks with nested blocks always appear as top level.

### DIFF
--- a/packages/block-editor/src/components/block-inspector/index.js
+++ b/packages/block-editor/src/components/block-inspector/index.js
@@ -143,7 +143,6 @@ const BlockInspector = ( { showNoBlockSelectedMessage = true } ) => {
 			getSelectedBlockCount,
 			getBlockName,
 			__unstableGetContentLockingParent,
-			getTemplateLock,
 		} = select( blockEditorStore );
 
 		const _selectedBlockClientId = getSelectedBlockClientId();
@@ -157,12 +156,9 @@ const BlockInspector = ( { showNoBlockSelectedMessage = true } ) => {
 			selectedBlockClientId: _selectedBlockClientId,
 			selectedBlockName: _selectedBlockName,
 			blockType: _blockType,
-			topLevelLockedBlock:
-				getTemplateLock( _selectedBlockClientId ) === 'contentOnly'
-					? _selectedBlockClientId
-					: __unstableGetContentLockingParent(
-							_selectedBlockClientId
-					  ),
+			topLevelLockedBlock: __unstableGetContentLockingParent(
+				_selectedBlockClientId
+			),
 		};
 	}, [] );
 


### PR DESCRIPTION
This PR fixes a bug where content blocks that also have inner blocks(e.g: media & text and list) always appear wrongly as  the top-level block that is locking.


## Testing Instructions
I added the following block:
```
<!-- wp:group {"templateLock":"noContent","layout":{"type":"constrained"},"align":"wide","style":{"color":{"background":"#d32b55"},"spacing":{"padding":{"top":"var:preset|spacing|70","right":"var:preset|spacing|70","bottom":"var:preset|spacing|70","left":"var:preset|spacing|70"},"blockGap":"0"}}} -->
<div class="wp-block-group alignwide has-background" style="background-color:#d32b55;padding-top:var(--wp--preset--spacing--70);padding-right:var(--wp--preset--spacing--70);padding-bottom:var(--wp--preset--spacing--70);padding-left:var(--wp--preset--spacing--70)"><!-- wp:media-text {"mediaType":"image","mediaWidth":48} -->
<div class="wp-block-media-text alignwide is-stacked-on-mobile" style="grid-template-columns:48% auto"><figure class="wp-block-media-text__media"><img src="https://s.w.org/style/images/about/WordPress-logotype-wmark.png" alt=""/></figure><div class="wp-block-media-text__content"><!-- wp:paragraph {"placeholder":"Content…"} -->
<p>Paragraph inside media & text</p>
<!-- /wp:paragraph --></div></div>
<!-- /wp:media-text -->

<!-- wp:list -->
<ul><!-- wp:list-item -->
<li>1</li>
<!-- /wp:list-item -->

<!-- wp:list-item -->
<li>2</li>
<!-- /wp:list-item -->

<!-- wp:list-item -->
<li>3</li>
<!-- /wp:list-item --></ul>
<!-- /wp:list --></div>
<!-- /wp:group -->

```

I selected the paragraph inside media & text and the list items and verified the group always appear as the top level block (on master, media & text and list wrongly appear as top level on the content locking tab). 