### PR TITLE
Create an alias get_element_class_name to use it in blocks

### DIFF
--- a/lib/compat/wordpress-6.1/theme.php
+++ b/lib/compat/wordpress-6.1/theme.php
@@ -29,3 +29,22 @@ function gutenberg_create_initial_theme_features() {
 	);
 }
 add_action( 'setup_theme', 'gutenberg_create_initial_theme_features', 0 );
+
+
+
+/**
+ * Given an element name, returns a class name.
+ * Alias from WP_Theme_JSON_Gutenberg::get_element_class_name.
+ *
+ * @param string $element The name of the element.
+ *
+ * @return string The name of the class.
+ *
+ * @since 6.1.0
+ */
+function gutenberg_theme_element_class_name( $element ) {
+	if ( ! class_exists( 'WP_Theme_JSON_Gutenberg' ) || ! method_exists( 'WP_Theme_JSON_Gutenberg', 'get_element_class_name' ) ) {
+		return '';
+	}
+	return WP_Theme_JSON_Gutenberg::get_element_class_name( $element );
+}

--- a/lib/compat/wordpress-6.1/theme.php
+++ b/lib/compat/wordpress-6.1/theme.php
@@ -30,21 +30,18 @@ function gutenberg_create_initial_theme_features() {
 }
 add_action( 'setup_theme', 'gutenberg_create_initial_theme_features', 0 );
 
-
-
-/**
- * Given an element name, returns a class name.
- * Alias from WP_Theme_JSON_Gutenberg::get_element_class_name.
- *
- * @param string $element The name of the element.
- *
- * @return string The name of the class.
- *
- * @since 6.1.0
- */
-function gutenberg_theme_element_class_name( $element ) {
-	if ( ! class_exists( 'WP_Theme_JSON_Gutenberg' ) || ! method_exists( 'WP_Theme_JSON_Gutenberg', 'get_element_class_name' ) ) {
-		return '';
+if ( ! function_exists( 'wp_theme_element_class_name' ) ) {
+	/**
+	 * Given an element name, returns a class name.
+	 * Alias from WP_Theme_JSON_Gutenberg::get_element_class_name.
+	 *
+	 * @param string $element The name of the element.
+	 *
+	 * @return string The name of the class.
+	 *
+	 * @since 6.1.0
+	 */
+	function wp_theme_element_class_name( $element ) {
+		return WP_Theme_JSON_Gutenberg::get_element_class_name( $element );
 	}
-	return WP_Theme_JSON_Gutenberg::get_element_class_name( $element );
 }

--- a/packages/block-library/src/comments/index.php
+++ b/packages/block-library/src/comments/index.php
@@ -109,7 +109,7 @@ add_action( 'init', 'register_block_core_comments' );
  */
 function comments_block_form_defaults( $fields ) {
 	if ( wp_is_block_theme() ) {
-		$fields['submit_button'] = '<input name="%1$s" type="submit" id="%2$s" class="%3$s wp-block-button__link ' . WP_Theme_JSON_Gutenberg::get_element_class_name( 'button' ) . '" value="%4$s" />';
+		$fields['submit_button'] = '<input name="%1$s" type="submit" id="%2$s" class="%3$s wp-block-button__link ' . wp_theme_element_class_name( 'button' ) . '" value="%4$s" />';
 		$fields['submit_field']  = '<p class="form-submit wp-block-button">%1$s %2$s</p>';
 	}
 

--- a/packages/block-library/src/post-comments-form/index.php
+++ b/packages/block-library/src/post-comments-form/index.php
@@ -72,7 +72,7 @@ add_action( 'init', 'register_block_core_post_comments_form' );
  */
 function post_comments_form_block_form_defaults( $fields ) {
 	if ( wp_is_block_theme() ) {
-		$fields['submit_button'] = '<input name="%1$s" type="submit" id="%2$s" class="wp-block-button__link ' . WP_Theme_JSON_Gutenberg::get_element_class_name( 'button' ) . '" value="%4$s" />';
+		$fields['submit_button'] = '<input name="%1$s" type="submit" id="%2$s" class="wp-block-button__link ' . wp_theme_element_class_name( 'button' ) . '" value="%4$s" />';
 		$fields['submit_field']  = '<p class="form-submit wp-block-button">%1$s %2$s</p>';
 	}
 

--- a/packages/block-library/src/search/index.php
+++ b/packages/block-library/src/search/index.php
@@ -121,7 +121,7 @@ function render_block_core_search( $attributes ) {
 		}
 
 		// Include the button element class.
-		$button_classes[] = WP_Theme_JSON_Gutenberg::get_element_class_name( 'button' );
+		$button_classes[] = wp_theme_element_class_name( 'button' );
 		$button_markup    = sprintf(
 			'<button type="submit" class="%s" %s %s>%s</button>',
 			esc_attr( implode( ' ', $button_classes ) ),

--- a/phpunit/class-wp-theme-json-test.php
+++ b/phpunit/class-wp-theme-json-test.php
@@ -797,14 +797,14 @@ class WP_Theme_JSON_Gutenberg_Test extends WP_UnitTestCase {
 
 	function test_get_element_class_name_button() {
 		$expected = 'wp-element-button';
-		$actual   = WP_Theme_JSON_Gutenberg::get_element_class_name( 'button' );
+		$actual   = gutenberg_theme_element_class_name( 'button' );
 
 		$this->assertEquals( $expected, $actual );
 	}
 
 	function test_get_element_class_name_invalid() {
 		$expected = '';
-		$actual   = WP_Theme_JSON_Gutenberg::get_element_class_name( 'unknown-element' );
+		$actual   = gutenberg_theme_element_class_name( 'unknown-element' );
 
 		$this->assertEquals( $expected, $actual );
 	}

--- a/phpunit/class-wp-theme-json-test.php
+++ b/phpunit/class-wp-theme-json-test.php
@@ -797,14 +797,14 @@ class WP_Theme_JSON_Gutenberg_Test extends WP_UnitTestCase {
 
 	function test_get_element_class_name_button() {
 		$expected = 'wp-element-button';
-		$actual   = gutenberg_theme_element_class_name( 'button' );
+		$actual   = wp_theme_element_class_name( 'button' );
 
 		$this->assertEquals( $expected, $actual );
 	}
 
 	function test_get_element_class_name_invalid() {
 		$expected = '';
-		$actual   = gutenberg_theme_element_class_name( 'unknown-element' );
+		$actual   = wp_theme_element_class_name( 'unknown-element' );
 
 		$this->assertEquals( $expected, $actual );
 	}

--- a/tools/webpack/blocks.js
+++ b/tools/webpack/blocks.js
@@ -30,6 +30,7 @@ const blockViewRegex = new RegExp(
 const prefixFunctions = [
 	'build_query_vars_from_query_block',
 	'wp_enqueue_block_support_styles',
+	'wp_theme_element_class_name',
 ];
 
 /**

--- a/tools/webpack/blocks.js
+++ b/tools/webpack/blocks.js
@@ -30,7 +30,6 @@ const blockViewRegex = new RegExp(
 const prefixFunctions = [
 	'build_query_vars_from_query_block',
 	'wp_enqueue_block_support_styles',
-	'wp_theme_element_class_name',
 ];
 
 /**


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->
Creates an alias for the internal API class WP_Theme_JSON_Gutenberg

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
Following [the discussion ](https://github.com/WordPress/wordpress-develop/pull/3154#discussion_r962832417) on Sync Gutenberg packages, we noticed that some blocks are using a Class WP_Theme_JSON_Gutenberg method.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->
Go to post or site editor.
Add Search block or Comments Form block. Check that the button has `wp-element-button` class.

## Screenshots or screencast <!-- if applicable -->
