### PR TITLE
Fix naming collisions with WordPress 6.1

### DIFF
--- a/lib/compat/wordpress-6.1/blocks.php
+++ b/lib/compat/wordpress-6.1/blocks.php
@@ -102,6 +102,77 @@ function gutenberg_block_type_metadata_view_script( $settings, $metadata ) {
 }
 add_filter( 'block_type_metadata_settings', 'gutenberg_block_type_metadata_view_script', 10, 2 );
 
+/**
+ * Enqueues a frontend script for a specific block.
+ *
+ * Scripts enqueued using this function will only get printed
+ * when the block gets rendered on the frontend.
+ *
+ * @since 6.1.0
+ *
+ * @param string $block_name The block name, including namespace.
+ * @param array  $args       An array of arguments [handle,src,deps,ver,media,textdomain].
+ *
+ * @return void
+ */
+function gutenberg_enqueue_block_view_script( $block_name, $args ) {
+	$args = wp_parse_args(
+		$args,
+		array(
+			'handle'     => '',
+			'src'        => '',
+			'deps'       => array(),
+			'ver'        => false,
+			'in_footer'  => false,
+
+			// Additional args to allow translations for the script's textdomain.
+			'textdomain' => '',
+		)
+	);
+
+	/**
+	 * Callback function to register and enqueue scripts.
+	 *
+	 * @param string $content When the callback is used for the render_block filter,
+	 *                        the content needs to be returned so the function parameter
+	 *                        is to ensure the content exists.
+	 * @return string Block content.
+	 */
+	$callback = static function( $content, $block ) use ( $args, $block_name ) {
+
+		// Sanity check.
+		if ( empty( $block['blockName'] ) || $block_name !== $block['blockName'] ) {
+			return $content;
+		}
+
+		// Register the stylesheet.
+		if ( ! empty( $args['src'] ) ) {
+			wp_register_script( $args['handle'], $args['src'], $args['deps'], $args['ver'], $args['in_footer'] );
+		}
+
+		// Enqueue the stylesheet.
+		wp_enqueue_script( $args['handle'] );
+
+		// If a textdomain is defined, use it to set the script translations.
+		if ( ! empty( $args['textdomain'] ) && in_array( 'wp-i18n', $args['deps'], true ) ) {
+			wp_set_script_translations( $args['handle'], $args['textdomain'], $args['domainpath'] );
+		}
+
+		return $content;
+	};
+
+	/*
+	 * The filter's callback here is an anonymous function because
+	 * using a named function in this case is not possible.
+	 *
+	 * The function cannot be unhooked, however, users are still able
+	 * to dequeue the script registered/enqueued by the callback
+	 * which is why in this case, using an anonymous function
+	 * was deemed acceptable.
+	 */
+	add_filter( 'render_block', $callback, 10, 2 );
+}
+
 if ( ! function_exists( 'wp_enqueue_block_view_script' ) ) {
 	/**
 	 * Enqueues a frontend script for a specific block.
@@ -114,64 +185,12 @@ if ( ! function_exists( 'wp_enqueue_block_view_script' ) ) {
 	 * @param string $block_name The block name, including namespace.
 	 * @param array  $args       An array of arguments [handle,src,deps,ver,media,textdomain].
 	 *
+	 * @deprecated 6.1.0 Please use gutenberg_enqueue_block_view_script instead.
+	 *
 	 * @return void
 	 */
 	function wp_enqueue_block_view_script( $block_name, $args ) {
-		$args = wp_parse_args(
-			$args,
-			array(
-				'handle'     => '',
-				'src'        => '',
-				'deps'       => array(),
-				'ver'        => false,
-				'in_footer'  => false,
-
-				// Additional args to allow translations for the script's textdomain.
-				'textdomain' => '',
-			)
-		);
-
-		/**
-		 * Callback function to register and enqueue scripts.
-		 *
-		 * @param string $content When the callback is used for the render_block filter,
-		 *                        the content needs to be returned so the function parameter
-		 *                        is to ensure the content exists.
-		 * @return string Block content.
-		 */
-		$callback = static function( $content, $block ) use ( $args, $block_name ) {
-
-			// Sanity check.
-			if ( empty( $block['blockName'] ) || $block_name !== $block['blockName'] ) {
-				return $content;
-			}
-
-			// Register the stylesheet.
-			if ( ! empty( $args['src'] ) ) {
-				wp_register_script( $args['handle'], $args['src'], $args['deps'], $args['ver'], $args['in_footer'] );
-			}
-
-			// Enqueue the stylesheet.
-			wp_enqueue_script( $args['handle'] );
-
-			// If a textdomain is defined, use it to set the script translations.
-			if ( ! empty( $args['textdomain'] ) && in_array( 'wp-i18n', $args['deps'], true ) ) {
-				wp_set_script_translations( $args['handle'], $args['textdomain'], $args['domainpath'] );
-			}
-
-			return $content;
-		};
-
-		/*
-		 * The filter's callback here is an anonymous function because
-		 * using a named function in this case is not possible.
-		 *
-		 * The function cannot be unhooked, however, users are still able
-		 * to dequeue the script registered/enqueued by the callback
-		 * which is why in this case, using an anonymous function
-		 * was deemed acceptable.
-		 */
-		add_filter( 'render_block', $callback, 10, 2 );
+		return gutenberg_enqueue_block_view_script( $block_name, $args );
 	}
 }
 

--- a/lib/compat/wordpress-6.1/blocks.php
+++ b/lib/compat/wordpress-6.1/blocks.php
@@ -102,77 +102,6 @@ function gutenberg_block_type_metadata_view_script( $settings, $metadata ) {
 }
 add_filter( 'block_type_metadata_settings', 'gutenberg_block_type_metadata_view_script', 10, 2 );
 
-/**
- * Enqueues a frontend script for a specific block.
- *
- * Scripts enqueued using this function will only get printed
- * when the block gets rendered on the frontend.
- *
- * @since 6.1.0
- *
- * @param string $block_name The block name, including namespace.
- * @param array  $args       An array of arguments [handle,src,deps,ver,media,textdomain].
- *
- * @return void
- */
-function gutenberg_enqueue_block_view_script( $block_name, $args ) {
-	$args = wp_parse_args(
-		$args,
-		array(
-			'handle'     => '',
-			'src'        => '',
-			'deps'       => array(),
-			'ver'        => false,
-			'in_footer'  => false,
-
-			// Additional args to allow translations for the script's textdomain.
-			'textdomain' => '',
-		)
-	);
-
-	/**
-	 * Callback function to register and enqueue scripts.
-	 *
-	 * @param string $content When the callback is used for the render_block filter,
-	 *                        the content needs to be returned so the function parameter
-	 *                        is to ensure the content exists.
-	 * @return string Block content.
-	 */
-	$callback = static function( $content, $block ) use ( $args, $block_name ) {
-
-		// Sanity check.
-		if ( empty( $block['blockName'] ) || $block_name !== $block['blockName'] ) {
-			return $content;
-		}
-
-		// Register the stylesheet.
-		if ( ! empty( $args['src'] ) ) {
-			wp_register_script( $args['handle'], $args['src'], $args['deps'], $args['ver'], $args['in_footer'] );
-		}
-
-		// Enqueue the stylesheet.
-		wp_enqueue_script( $args['handle'] );
-
-		// If a textdomain is defined, use it to set the script translations.
-		if ( ! empty( $args['textdomain'] ) && in_array( 'wp-i18n', $args['deps'], true ) ) {
-			wp_set_script_translations( $args['handle'], $args['textdomain'], $args['domainpath'] );
-		}
-
-		return $content;
-	};
-
-	/*
-	 * The filter's callback here is an anonymous function because
-	 * using a named function in this case is not possible.
-	 *
-	 * The function cannot be unhooked, however, users are still able
-	 * to dequeue the script registered/enqueued by the callback
-	 * which is why in this case, using an anonymous function
-	 * was deemed acceptable.
-	 */
-	add_filter( 'render_block', $callback, 10, 2 );
-}
-
 if ( ! function_exists( 'wp_enqueue_block_view_script' ) ) {
 	/**
 	 * Enqueues a frontend script for a specific block.
@@ -185,12 +114,64 @@ if ( ! function_exists( 'wp_enqueue_block_view_script' ) ) {
 	 * @param string $block_name The block name, including namespace.
 	 * @param array  $args       An array of arguments [handle,src,deps,ver,media,textdomain].
 	 *
-	 * @deprecated 6.1.0 Please use gutenberg_enqueue_block_view_script instead.
-	 *
 	 * @return void
 	 */
 	function wp_enqueue_block_view_script( $block_name, $args ) {
-		gutenberg_enqueue_block_view_script( $block_name, $args );
+		$args = wp_parse_args(
+			$args,
+			array(
+				'handle'     => '',
+				'src'        => '',
+				'deps'       => array(),
+				'ver'        => false,
+				'in_footer'  => false,
+
+				// Additional args to allow translations for the script's textdomain.
+				'textdomain' => '',
+			)
+		);
+
+		/**
+		 * Callback function to register and enqueue scripts.
+		 *
+		 * @param string $content When the callback is used for the render_block filter,
+		 *                        the content needs to be returned so the function parameter
+		 *                        is to ensure the content exists.
+		 * @return string Block content.
+		 */
+		$callback = static function( $content, $block ) use ( $args, $block_name ) {
+
+			// Sanity check.
+			if ( empty( $block['blockName'] ) || $block_name !== $block['blockName'] ) {
+				return $content;
+			}
+
+			// Register the stylesheet.
+			if ( ! empty( $args['src'] ) ) {
+				wp_register_script( $args['handle'], $args['src'], $args['deps'], $args['ver'], $args['in_footer'] );
+			}
+
+			// Enqueue the stylesheet.
+			wp_enqueue_script( $args['handle'] );
+
+			// If a textdomain is defined, use it to set the script translations.
+			if ( ! empty( $args['textdomain'] ) && in_array( 'wp-i18n', $args['deps'], true ) ) {
+				wp_set_script_translations( $args['handle'], $args['textdomain'], $args['domainpath'] );
+			}
+
+			return $content;
+		};
+
+		/*
+		 * The filter's callback here is an anonymous function because
+		 * using a named function in this case is not possible.
+		 *
+		 * The function cannot be unhooked, however, users are still able
+		 * to dequeue the script registered/enqueued by the callback
+		 * which is why in this case, using an anonymous function
+		 * was deemed acceptable.
+		 */
+		add_filter( 'render_block', $callback, 10, 2 );
 	}
 }
 

--- a/lib/compat/wordpress-6.1/blocks.php
+++ b/lib/compat/wordpress-6.1/blocks.php
@@ -190,7 +190,7 @@ if ( ! function_exists( 'wp_enqueue_block_view_script' ) ) {
 	 * @return void
 	 */
 	function wp_enqueue_block_view_script( $block_name, $args ) {
-		return gutenberg_enqueue_block_view_script( $block_name, $args );
+		gutenberg_enqueue_block_view_script( $block_name, $args );
 	}
 }
 

--- a/lib/compat/wordpress-6.1/script-loader.php
+++ b/lib/compat/wordpress-6.1/script-loader.php
@@ -104,7 +104,7 @@ function gutenberg_enqueue_stored_styles() {
  * @param array $nodes The nodes to filter.
  * @return array A filtered array of style nodes.
  */
-function filter_out_block_nodes( $nodes ) {
+function gutenberg_filter_out_block_nodes( $nodes ) {
 	return array_filter(
 		$nodes,
 		function( $node ) {
@@ -144,7 +144,7 @@ function gutenberg_enqueue_global_styles() {
 	 * This removes the CSS from the global-styles stylesheet and adds it to the inline CSS for each block.
 	 * This filter has to be registered before we call gutenberg_get_global_stylesheet();
 	 */
-	add_filter( 'gutenberg_get_style_nodes', 'filter_out_block_nodes', 10, 1 );
+	add_filter( 'gutenberg_get_style_nodes', 'gutenberg_filter_out_block_nodes', 10, 1 );
 
 	$stylesheet = gutenberg_get_global_stylesheet();
 	if ( empty( $stylesheet ) ) {


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
This PR aims to rename Gutenberg functions that have naming collisions with Core.

## Why?
All PHP functions located in the `lib/compat` folder should use the `gutenberg_` prefix.

## How?
This PR doesn't modify existing functionality, but can be considered as refactoring.
It renames existing methods to ensure good naming practices.

## Testing Instructions
No testing is needed. 
This PR refactors existing code.
As an additional precaution, make sure that the unit tests pass.

## Screenshots or screencast <!-- if applicable -->
