### PR TITLE
Columns: Add axial block spacing to Columns block (alternate attempt)

### DIFF
--- a/packages/block-library/src/columns/block.json
+++ b/packages/block-library/src/columns/block.json
@@ -28,9 +28,11 @@
 			}
 		},
 		"spacing": {
-			"blockGap": {
-				"__experimentalDefault": "2em"
-			},
+			"blockGap": [
+				{ "__experimentalDefault": "2em" },
+				"horizontal",
+				"vertical"
+			],
 			"margin": [ "top", "bottom" ],
 			"padding": true,
 			"__experimentalDefaultControls": {

--- a/packages/block-library/src/columns/block.json
+++ b/packages/block-library/src/columns/block.json
@@ -28,11 +28,10 @@
 			}
 		},
 		"spacing": {
-			"blockGap": [
-				{ "__experimentalDefault": "2em" },
-				"horizontal",
-				"vertical"
-			],
+			"blockGap": {
+				"__experimentalDefault": "2em",
+				"sides": [ "horizontal", "vertical" ]
+			},
 			"margin": [ "top", "bottom" ],
 			"padding": true,
 			"__experimentalDefaultControls": {


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

This PR is a copy + paste from #44061 as I was unable to push changes to the branch from that PR. All credit to @ndiego for this one!

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

This functionality was recently added to the Social Links block, and this provides a way to control the vertical block spacing when Column blocks collapse, notably on mobile.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

Add the relevant supports in block.json

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->

Add a Columns block with a couple of columns
Set both vertical and horizontal block spacing, ensuring each is different.
Notice how the spacing changes when the columns collapse on mobile. (See gif below).

## Screenshots or screencast <!-- if applicable -->

<img src="https://user-images.githubusercontent.com/4832319/189550510-aaadde91-0f69-411a-8221-a10b079fae31.gif" />