### PR TITLE
Fix group block layout performance

### DIFF
--- a/packages/block-library/src/group/edit.js
+++ b/packages/block-library/src/group/edit.js
@@ -1,8 +1,7 @@
 /**
  * WordPress dependencies
  */
-import { useSelect, useDispatch } from '@wordpress/data';
-import { useEffect } from '@wordpress/element';
+import { useSelect } from '@wordpress/data';
 import {
 	InnerBlocks,
 	useBlockProps,
@@ -69,16 +68,6 @@ function GroupEdit( { attributes, setAttributes, clientId } ) {
 			__experimentalLayout: layoutSupportEnabled ? usedLayout : undefined,
 		}
 	);
-
-	const { __unstableMarkNextChangeAsNotPersistent } =
-		useDispatch( blockEditorStore );
-	const { type: layoutType = null } = layout;
-	useEffect( () => {
-		if ( layoutType ) {
-			__unstableMarkNextChangeAsNotPersistent();
-			setAttributes( { layout: { ...layout, type: layoutType } } );
-		}
-	}, [ layoutType ] );
 
 	return (
 		<>

--- a/packages/e2e-tests/specs/editor/plugins/__snapshots__/cpt-locking.test.js.snap
+++ b/packages/e2e-tests/specs/editor/plugins/__snapshots__/cpt-locking.test.js.snap
@@ -41,7 +41,7 @@ exports[`cpt locking template_lock all should not error when deleting the cotent
 `;
 
 exports[`cpt locking template_lock all unlocked group should allow blocks to be moved 1`] = `
-"<!-- wp:group {\\"templateLock\\":false,\\"layout\\":{\\"type\\":\\"constrained\\"}} -->
+"<!-- wp:group {\\"templateLock\\":false} -->
 <div class=\\"wp-block-group\\"><!-- wp:paragraph {\\"placeholder\\":\\"Add a description\\"} -->
 <p>p1</p>
 <!-- /wp:paragraph -->
@@ -55,7 +55,7 @@ exports[`cpt locking template_lock all unlocked group should allow blocks to be 
 `;
 
 exports[`cpt locking template_lock all unlocked group should allow blocks to be removed 1`] = `
-"<!-- wp:group {\\"templateLock\\":false,\\"layout\\":{\\"type\\":\\"constrained\\"}} -->
+"<!-- wp:group {\\"templateLock\\":false} -->
 <div class=\\"wp-block-group\\"><!-- wp:quote -->
 <blockquote class=\\"wp-block-quote\\"><!-- wp:paragraph -->
 <p></p>

--- a/packages/e2e-tests/specs/editor/various/__snapshots__/block-grouping.test.js.snap
+++ b/packages/e2e-tests/specs/editor/various/__snapshots__/block-grouping.test.js.snap
@@ -1,7 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`Block Grouping Group creation creates a group from multiple blocks of different types via block transforms 1`] = `
-"<!-- wp:group {\\"layout\\":{\\"type\\":\\"constrained\\"}} -->
+"<!-- wp:group -->
 <div class=\\"wp-block-group\\"><!-- wp:heading -->
 <h2>Group Heading</h2>
 <!-- /wp:heading -->
@@ -17,7 +17,7 @@ exports[`Block Grouping Group creation creates a group from multiple blocks of d
 `;
 
 exports[`Block Grouping Group creation creates a group from multiple blocks of the same type via block transforms 1`] = `
-"<!-- wp:group {\\"layout\\":{\\"type\\":\\"constrained\\"}} -->
+"<!-- wp:group -->
 <div class=\\"wp-block-group\\"><!-- wp:paragraph -->
 <p>First Paragraph</p>
 <!-- /wp:paragraph -->
@@ -33,7 +33,7 @@ exports[`Block Grouping Group creation creates a group from multiple blocks of t
 `;
 
 exports[`Block Grouping Group creation creates a group from multiple blocks of the same type via options toolbar 1`] = `
-"<!-- wp:group {\\"layout\\":{\\"type\\":\\"constrained\\"}} -->
+"<!-- wp:group -->
 <div class=\\"wp-block-group\\"><!-- wp:paragraph -->
 <p>First Paragraph</p>
 <!-- /wp:paragraph -->
@@ -49,7 +49,7 @@ exports[`Block Grouping Group creation creates a group from multiple blocks of t
 `;
 
 exports[`Block Grouping Group creation groups and ungroups multiple blocks of different types via options toolbar 1`] = `
-"<!-- wp:group {\\"layout\\":{\\"type\\":\\"constrained\\"}} -->
+"<!-- wp:group -->
 <div class=\\"wp-block-group\\"><!-- wp:heading -->
 <h2>Group Heading</h2>
 <!-- /wp:heading -->
@@ -79,7 +79,7 @@ exports[`Block Grouping Group creation groups and ungroups multiple blocks of di
 `;
 
 exports[`Block Grouping Preserving selected blocks attributes preserves width alignment settings of selected blocks 1`] = `
-"<!-- wp:group {\\"layout\\":{\\"type\\":\\"constrained\\"},\\"align\\":\\"full\\"} -->
+"<!-- wp:group {\\"align\\":\\"full\\"} -->
 <div class=\\"wp-block-group alignfull\\"><!-- wp:heading -->
 <h2>Group Heading</h2>
 <!-- /wp:heading -->

--- a/packages/e2e-tests/specs/editor/various/__snapshots__/block-hierarchy-navigation.test.js.snap
+++ b/packages/e2e-tests/specs/editor/various/__snapshots__/block-hierarchy-navigation.test.js.snap
@@ -51,7 +51,7 @@ exports[`Navigating the block hierarchy should navigate using the list view side
 `;
 
 exports[`Navigating the block hierarchy should select the wrapper div for a group 1`] = `
-"<!-- wp:group {\\"layout\\":{\\"type\\":\\"constrained\\"}} -->
+"<!-- wp:group -->
 <div class=\\"wp-block-group\\"><!-- wp:paragraph -->
 <p>just a paragraph</p>
 <!-- /wp:paragraph -->

--- a/packages/e2e-tests/specs/editor/various/__snapshots__/inserting-blocks.test.js.snap
+++ b/packages/e2e-tests/specs/editor/various/__snapshots__/inserting-blocks.test.js.snap
@@ -54,7 +54,7 @@ lines preserved[/myshortcode]
 `;
 
 exports[`Inserting blocks inserts a block in proper place after having clicked \`Browse All\` from block appender 1`] = `
-"<!-- wp:group {\\"layout\\":{\\"type\\":\\"constrained\\"}} -->
+"<!-- wp:group -->
 <div class=\\"wp-block-group\\"><!-- wp:paragraph -->
 <p>Paragraph inside group</p>
 <!-- /wp:paragraph --></div>

--- a/packages/e2e-tests/specs/editor/various/__snapshots__/keep-styles-on-block-transforms.test.js.snap
+++ b/packages/e2e-tests/specs/editor/various/__snapshots__/keep-styles-on-block-transforms.test.js.snap
@@ -21,7 +21,7 @@ exports[`Keep styles on block transforms Should keep the font size during a tran
 `;
 
 exports[`Keep styles on block transforms Should not include styles in the group block when grouping a block 1`] = `
-"<!-- wp:group {\\"layout\\":{\\"type\\":\\"constrained\\"}} -->
+"<!-- wp:group -->
 <div class=\\"wp-block-group\\"><!-- wp:paragraph {\\"fontSize\\":\\"large\\"} -->
 <p class=\\"has-large-font-size\\">Line 1 to be made large</p>
 <!-- /wp:paragraph --></div>

--- a/packages/e2e-tests/specs/editor/various/__snapshots__/multi-block-selection.test.js.snap
+++ b/packages/e2e-tests/specs/editor/various/__snapshots__/multi-block-selection.test.js.snap
@@ -251,7 +251,7 @@ exports[`Multi-block selection should preserve dragged selection on move 1`] = `
 `;
 
 exports[`Multi-block selection should properly select multiple blocks if selected nested blocks belong to different parent 1`] = `
-"<!-- wp:group {\\"layout\\":{\\"type\\":\\"constrained\\"}} -->
+"<!-- wp:group -->
 <div class=\\"wp-block-group\\"><!-- wp:paragraph -->
 <p>first</p>
 <!-- /wp:paragraph -->
@@ -261,7 +261,7 @@ exports[`Multi-block selection should properly select multiple blocks if selecte
 <!-- /wp:paragraph --></div>
 <!-- /wp:group -->
 
-<!-- wp:group {\\"layout\\":{\\"type\\":\\"constrained\\"}} -->
+<!-- wp:group -->
 <div class=\\"wp-block-group\\"><!-- wp:paragraph -->
 <p>second</p>
 <!-- /wp:paragraph -->

--- a/packages/e2e-tests/specs/editor/various/block-grouping.test.js
+++ b/packages/e2e-tests/specs/editor/various/block-grouping.test.js
@@ -148,8 +148,8 @@ describe( 'Block Grouping', () => {
 			await clickBlockToolbarButton( 'Options' );
 			await clickMenuItem( 'Group' );
 			expect( await getEditedPostContent() ).toMatchInlineSnapshot( `
-			"<!-- wp:group {\\"layout\\":{\\"type\\":\\"constrained\\"}} -->
-			<div class=\\"wp-block-group\\"><!-- wp:group {\\"layout\\":{\\"type\\":\\"constrained\\"}} -->
+			"<!-- wp:group -->
+			<div class=\\"wp-block-group\\"><!-- wp:group -->
 			<div class=\\"wp-block-group\\"><!-- wp:paragraph -->
 			<p>1</p>
 			<!-- /wp:paragraph --></div>

--- a/packages/e2e-tests/specs/editor/various/multi-block-selection.test.js
+++ b/packages/e2e-tests/specs/editor/various/multi-block-selection.test.js
@@ -359,7 +359,7 @@ describe( 'Multi-block selection', () => {
 		await page.mouse.up();
 		await page.keyboard.type( 'hi' );
 		expect( await getEditedPostContent() ).toMatchInlineSnapshot( `
-		"<!-- wp:group {\\"layout\\":{\\"type\\":\\"constrained\\"}} -->
+		"<!-- wp:group -->
 		<div class=\\"wp-block-group\\"><!-- wp:paragraph -->
 		<p>hih text in group</p>
 		<!-- /wp:paragraph --></div>

--- a/test/e2e/specs/editor/blocks/__snapshots__/Group-can-be-created-using-the-block-inserter-1-chromium.txt
+++ b/test/e2e/specs/editor/blocks/__snapshots__/Group-can-be-created-using-the-block-inserter-1-chromium.txt
@@ -1,3 +1,3 @@
-<!-- wp:group {"layout":{"type":"constrained"}} -->
+<!-- wp:group -->
 <div class="wp-block-group"></div>
 <!-- /wp:group -->

--- a/test/e2e/specs/editor/blocks/__snapshots__/Group-can-be-created-using-the-slash-inserter-1-chromium.txt
+++ b/test/e2e/specs/editor/blocks/__snapshots__/Group-can-be-created-using-the-slash-inserter-1-chromium.txt
@@ -1,3 +1,3 @@
-<!-- wp:group {"layout":{"type":"constrained"}} -->
+<!-- wp:group -->
 <div class="wp-block-group"></div>
 <!-- /wp:group -->

--- a/test/e2e/specs/editor/blocks/__snapshots__/Group-can-have-other-blocks-appended-to-it-using-the-button-appender-1-chromium.txt
+++ b/test/e2e/specs/editor/blocks/__snapshots__/Group-can-have-other-blocks-appended-to-it-using-the-button-appender-1-chromium.txt
@@ -1,4 +1,4 @@
-<!-- wp:group {"layout":{"type":"constrained"}} -->
+<!-- wp:group -->
 <div class="wp-block-group"><!-- wp:paragraph -->
 <p>Group Block with a Paragraph</p>
 <!-- /wp:paragraph --></div>

--- a/test/e2e/specs/editor/blocks/__snapshots__/Group-can-merge-into-group-with-Backspace-1-chromium.txt
+++ b/test/e2e/specs/editor/blocks/__snapshots__/Group-can-merge-into-group-with-Backspace-1-chromium.txt
@@ -1,4 +1,4 @@
-<!-- wp:group {"layout":{"type":"constrained"}} -->
+<!-- wp:group -->
 <div class="wp-block-group"><!-- wp:paragraph -->
 <p>1</p>
 <!-- /wp:paragraph --></div>

--- a/test/e2e/specs/editor/blocks/__snapshots__/Group-can-merge-into-group-with-Backspace-2-chromium.txt
+++ b/test/e2e/specs/editor/blocks/__snapshots__/Group-can-merge-into-group-with-Backspace-2-chromium.txt
@@ -1,4 +1,4 @@
-<!-- wp:group {"layout":{"type":"constrained"}} -->
+<!-- wp:group -->
 <div class="wp-block-group"><!-- wp:paragraph -->
 <p>1</p>
 <!-- /wp:paragraph -->


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Fixes #43760

The group block seemed to be causing an infinite looping to occur when it's used inside a template part. Duplicating the template part would cause the site editor to freeze.

It's hard to ascertain exactly why it happens. The way the group block was updating an attribute in an effect seemed to be causing `useBlockSync` to trigger, which would then also trigger the effect again, ad infinitum.

## How?
The effect in the group block wasn't needed. It was being used to serialize the group block's default layout attribute.

After reading the comment thread here - https://github.com/WordPress/gutenberg/pull/42763/files#r968097246, I realised this was added because the default layout type attribute couldn't be read on the `$parsed_block`. The problem is fixed by using the `WP_Block` instance, which applies default values via a `__get` method when reading the `$block->attributes` property.

## Testing Instructions

### Group block
1. Add a group block and a paragraph inside the group block
2. Save and inspect the group block on the frontend
3. It should have the 'is-layout-constrained' class name.

### Template part block
1. Using Twenty Twenty Two, open the site editor to the Home template
2. Duplicate the 'Header (Dark, small)' template part block in the canvas
3. It should be duplicated with no lag or errors