### PR TITLE
Fix the default icon for the navigation block

### DIFF
--- a/packages/block-library/src/navigation/edit/index.js
+++ b/packages/block-library/src/navigation/edit/index.js
@@ -92,7 +92,7 @@ function Navigation( {
 			flexWrap = 'wrap',
 		} = {},
 		hasIcon,
-		icon,
+		icon = 'handle',
 	} = attributes;
 
 	const ref = attributes.ref;

--- a/packages/block-library/src/navigation/edit/overlay-menu-icon.js
+++ b/packages/block-library/src/navigation/edit/overlay-menu-icon.js
@@ -5,21 +5,7 @@ import { SVG, Rect } from '@wordpress/primitives';
 import { Icon, menu, moreVertical, moreHorizontal } from '@wordpress/icons';
 
 export default function OverlayMenuIcon( { icon } ) {
-	if ( icon === 'handle' ) {
-		return (
-			<SVG
-				xmlns="http://www.w3.org/2000/svg"
-				viewBox="0 0 24 24"
-				width="24"
-				height="24"
-				aria-hidden="true"
-				focusable="false"
-			>
-				<Rect x="4" y="7.5" width="16" height="1.5" />
-				<Rect x="4" y="15" width="16" height="1.5" />
-			</SVG>
-		);
-	} else if ( icon === 'menu' ) {
+	if ( icon === 'menu' ) {
 		return <Icon icon={ menu } />;
 	} else if ( icon === 'more-vertical' ) {
 		return <Icon icon={ moreVertical } />;
@@ -27,5 +13,17 @@ export default function OverlayMenuIcon( { icon } ) {
 		return <Icon icon={ moreHorizontal } />;
 	}
 
-	return null;
+	return (
+		<SVG
+			xmlns="http://www.w3.org/2000/svg"
+			viewBox="0 0 24 24"
+			width="24"
+			height="24"
+			aria-hidden="true"
+			focusable="false"
+		>
+			<Rect x="4" y="7.5" width="16" height="1.5" />
+			<Rect x="4" y="15" width="16" height="1.5" />
+		</SVG>
+	);
 }

--- a/packages/block-library/src/navigation/index.php
+++ b/packages/block-library/src/navigation/index.php
@@ -611,12 +611,14 @@ function render_block_core_navigation( $attributes, $content, $block ) {
 
 	$should_display_icon_label = isset( $attributes['hasIcon'] ) && true === $attributes['hasIcon'];
 	$toggle_button_icon        = '<svg width="24" height="24" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" aria-hidden="true" focusable="false"><rect x="4" y="7.5" width="16" height="1.5" /><rect x="4" y="15" width="16" height="1.5" /></svg>';
-	if ( 'menu' === $attributes['icon'] ) {
-		$toggle_button_icon = '<svg width="24" height="24" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"><path d="M5 5v1.5h14V5H5zm0 7.8h14v-1.5H5v1.5zM5 19h14v-1.5H5V19z" /></svg>';
-	} elseif ( 'more-vertical' === $attributes['icon'] ) {
-		$toggle_button_icon = '<svg width="24" height="24" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"><path d="M13 19h-2v-2h2v2zm0-6h-2v-2h2v2zm0-6h-2V5h2v2z" /></svg>';
-	} elseif ( 'more-horizontal' === $attributes['icon'] ) {
-		$toggle_button_icon = '<svg width="24" height="24" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"><path d="M11 13h2v-2h-2v2zm-6 0h2v-2H5v2zm12-2v2h2v-2h-2z" /></svg>';
+	if ( isset( $attributes['icon'] ) ) {
+		if ( 'menu' === $attributes['icon'] ) {
+			$toggle_button_icon = '<svg width="24" height="24" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"><path d="M5 5v1.5h14V5H5zm0 7.8h14v-1.5H5v1.5zM5 19h14v-1.5H5V19z" /></svg>';
+		} elseif ( 'more-vertical' === $attributes['icon'] ) {
+			$toggle_button_icon = '<svg width="24" height="24" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"><path d="M13 19h-2v-2h2v2zm0-6h-2v-2h2v2zm0-6h-2V5h2v2z" /></svg>';
+		} elseif ( 'more-horizontal' === $attributes['icon'] ) {
+			$toggle_button_icon = '<svg width="24" height="24" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"><path d="M11 13h2v-2h-2v2zm-6 0h2v-2H5v2zm12-2v2h2v-2h-2z" /></svg>';
+		}
 	}
 	$toggle_button_content       = $should_display_icon_label ? $toggle_button_icon : __( 'Menu' );
 	$toggle_close_button_icon    = '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="24" height="24" aria-hidden="true" focusable="false"><path d="M13 11.8l6.1-6.3-1-1-6.1 6.2-6.1-6.2-1 1 6.1 6.3-6.5 6.7 1 1 6.5-6.6 6.5 6.6 1-1z"></path></svg>';


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->
Fix the default icon for the navigation block. Now the icon always fallback to the "handle" icon to preserve backward-compatibility, and to match both in the editor and in the frontend.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
A follow-up to https://github.com/WordPress/gutenberg/pull/43674#discussion_r969153941. Fix the PHP error of accessing an undefined index.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
By adding `isset()` to the PHP code and fallback to the handle icon in React.

I'm not sure if it's worth it to require the icon to be defined and stored in the serialized output?

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->
1. Create a navigation block
2. Don't select any icon for the block
3. Notice that the icon defaults to "handle"

