### PR TITLE
[Block Library - Quote]: Restrict single block transforms to specific blocks

### DIFF
--- a/packages/block-library/src/quote/transforms.js
+++ b/packages/block-library/src/quote/transforms.js
@@ -64,6 +64,16 @@ const transforms = {
 			isMultiBlock: true,
 			blocks: [ '*' ],
 			isMatch: ( {}, blocks ) => {
+				// When a single block is selected make the tranformation
+				// available only to specific blocks that make sense.
+				if ( blocks.length === 1 ) {
+					return [
+						'core/paragraph',
+						'core/heading',
+						'core/list',
+						'core/pullquote',
+					].includes( blocks[ 0 ].name );
+				}
 				return ! blocks.some( ( { name } ) => name === 'core/quote' );
 			},
 			__experimentalConvert: ( blocks ) =>


### PR DESCRIPTION

<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Follow up of: https://github.com/WordPress/gutenberg/pull/44072

When the [Quote block updated to support inner blocks](https://github.com/WordPress/gutenberg/pull/25892/) it enabled a wildcard transformation for every block, similar to the `Group` block. For most single blocks though doesn't make sense to be offered as an option.

This PR makes the option available to only a handful blocks(`core/paragraph, core/heading, core/list, core/pullquote`, when a single block is selected. If any multiple blocks are selected the option is preserved.
<!-- In a few words, what is the PR actually doing? -->



## Testing Instructions
1. In block editor add the supported blocks(core/paragraph, core/heading, core/list, core/pullquote) and others
2. Observe that in single block selection the transform option for Quote is enabled only for the above list and not for the others
3. Observe that when you multi select blocks, including blocks from the above list, the option is available.
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->


### Before

https://user-images.githubusercontent.com/16275880/189841977-45b0fc08-ae3e-4082-a47b-d40486b2d8ef.mov




### After

https://user-images.githubusercontent.com/16275880/189841685-b27f7140-934f-4dec-b577-59579a969102.mov


