### PR TITLE
Components: Refactor `ColorPalette` tests to `@testing-library/react`

### DIFF
--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -63,6 +63,7 @@
 -   `IsolatedEventContainer`: Refactor tests to `@testing-library/react` ([#44073](https://github.com/WordPress/gutenberg/pull/44073)).
 -   `KeyboardShortcuts`: Refactor tests to `@testing-library/react` ([#44075](https://github.com/WordPress/gutenberg/pull/44075)).
 -   `Slot`/`Fill`: Refactor tests to `@testing-library/react` ([#44084](https://github.com/WordPress/gutenberg/pull/44084)).
+-   `ColorPalette`: Refactor tests to `@testing-library/react` ([#44108](https://github.com/WordPress/gutenberg/pull/44108)).
 
 ## 20.0.0 (2022-08-24)
 

--- a/packages/components/src/color-palette/test/__snapshots__/index.js.snap
+++ b/packages/components/src/color-palette/test/__snapshots__/index.js.snap
@@ -1,533 +1,100 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`ColorPalette Dropdown .renderContent should render dropdown content 1`] = `
-<DropdownContentWrapperDiv
-  className="components-dropdown-content-wrapper"
-  data-wp-c16t={true}
-  data-wp-component="DropdownContentWrapper"
-  paddingSize="none"
->
-  <LegacyAdapter
-    color="#f00"
-    onChange={[Function]}
-  />
-</DropdownContentWrapperDiv>
-`;
-
-exports[`ColorPalette Dropdown .renderToggle should render dropdown content 1`] = `
-.emotion-0 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-}
-
-.emotion-1 {
-  -webkit-align-items: flex-start;
-  -webkit-box-align: flex-start;
-  -ms-flex-align: flex-start;
-  align-items: flex-start;
-  -webkit-flex-direction: row;
-  -ms-flex-direction: row;
-  flex-direction: row;
-  gap: calc(4px * 2);
-  -webkit-box-pack: justify;
-  -webkit-justify-content: space-between;
-  justify-content: space-between;
-  width: 100%;
-}
-
-.emotion-2>* {
-  min-width: 0;
-}
-
-.emotion-3 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-align-items: flex-start;
-  -webkit-box-align: flex-start;
-  -ms-flex-align: flex-start;
-  align-items: flex-start;
-  -webkit-flex-direction: row;
-  -ms-flex-direction: row;
-  flex-direction: row;
-  gap: calc(4px * 2);
-  -webkit-box-pack: justify;
-  -webkit-justify-content: space-between;
-  justify-content: space-between;
-  width: 100%;
-}
-
-.emotion-3>* {
-  min-width: 0;
-}
-
-.emotion-5 {
-  display: block;
-  max-height: 100%;
-  max-width: 100%;
-  min-height: 0;
-  min-width: 0;
-}
-
-.emotion-7 {
-  -webkit-flex: 1;
-  -ms-flex: 1;
-  flex: 1;
-}
-
-.emotion-8 {
-  display: block;
-  max-height: 100%;
-  max-width: 100%;
-  min-height: 0;
-  min-width: 0;
-  -webkit-flex: 1;
-  -ms-flex: 1;
-  flex: 1;
-}
-
-.emotion-10 {
-  display: block;
-  overflow: hidden;
-  text-overflow: ellipsis;
-  white-space: nowrap;
-}
-
-.emotion-14 {
-  display: block;
-  overflow: hidden;
-  text-overflow: ellipsis;
-  white-space: nowrap;
-  display: block;
-  max-height: 100%;
-  max-width: 100%;
-  min-height: 0;
-  min-width: 0;
-  -webkit-flex: 1;
-  -ms-flex: 1;
-  flex: 1;
-}
-
-.emotion-18 {
-  display: block;
-  max-height: 100%;
-  max-width: 100%;
-  min-height: 0;
-  min-width: 0;
-}
-
-<Flex
-  align="flex-start"
-  aria-expanded={true}
-  aria-haspopup="true"
-  aria-label="Custom color picker. The currently selected color is called \\"red\\" and has a value of \\"f00\\"."
-  as="button"
-  className="components-color-palette__custom-color"
-  justify="space-between"
-  onClick={[MockFunction]}
-  style={
-    Object {
-      "background": "#f00",
-      "color": "#000",
-    }
-  }
->
-  <View
-    aria-expanded={true}
-    aria-haspopup="true"
-    aria-label="Custom color picker. The currently selected color is called \\"red\\" and has a value of \\"f00\\"."
-    as="button"
-    className="emotion-0 emotion-1 emotion-2 components-flex components-color-palette__custom-color"
-    data-wp-c16t={true}
-    data-wp-component="Flex"
-    onClick={[MockFunction]}
-    style={
-      Object {
-        "background": "#f00",
-        "color": "#000",
-      }
-    }
-  >
-    <Noop />
-    <button
-      aria-expanded={true}
-      aria-haspopup="true"
-      aria-label="Custom color picker. The currently selected color is called \\"red\\" and has a value of \\"f00\\"."
-      className="components-flex components-color-palette__custom-color emotion-3 emotion-4"
-      data-wp-c16t={true}
-      data-wp-component="Flex"
-      onClick={[MockFunction]}
-      style={
-        Object {
-          "background": "#f00",
-          "color": "#000",
-        }
-      }
-    >
-      <FlexItem
-        as={
-          Object {
-            "$$typeof": Symbol(react.forward_ref),
-            "__contextSystemKey__": Array [
-              "Truncate",
-            ],
-            "render": [Function],
-            "selector": ".components-truncate",
-          }
-        }
-        className="components-color-palette__custom-color-name"
-        isBlock={true}
-      >
-        <View
-          as={
-            Object {
-              "$$typeof": Symbol(react.forward_ref),
-              "__contextSystemKey__": Array [
-                "Truncate",
-              ],
-              "render": [Function],
-              "selector": ".components-truncate",
-            }
-          }
-          className="emotion-5 emotion-6 emotion-7 components-flex-item components-color-palette__custom-color-name"
-          data-wp-c16t={true}
-          data-wp-component="FlexItem"
-        >
-          <Noop />
-          <Truncate
-            className="components-flex-item components-color-palette__custom-color-name emotion-8 emotion-4"
-            data-wp-c16t={true}
-            data-wp-component="FlexItem"
-          >
-            <View
-              as="span"
-              className="emotion-10 components-truncate components-flex-item components-color-palette__custom-color-name emotion-8 emotion-4"
-              data-wp-c16t={true}
-              data-wp-component="FlexItem"
-            >
-              <Noop />
-              <span
-                className="components-truncate components-flex-item components-color-palette__custom-color-name emotion-4 emotion-14 emotion-4"
-                data-wp-c16t={true}
-                data-wp-component="FlexItem"
-              >
-                red
-              </span>
-            </View>
-          </Truncate>
-        </View>
-      </FlexItem>
-      <FlexItem
-        as="span"
-        className="components-color-palette__custom-color-value"
-      >
-        <View
-          as="span"
-          className="emotion-5 emotion-6 components-flex-item components-color-palette__custom-color-value"
-          data-wp-c16t={true}
-          data-wp-component="FlexItem"
-        >
-          <Noop />
-          <span
-            className="components-flex-item components-color-palette__custom-color-value emotion-18 emotion-4"
-            data-wp-c16t={true}
-            data-wp-component="FlexItem"
-          >
-            f00
-          </span>
-        </View>
-      </FlexItem>
-    </button>
-  </View>
-</Flex>
-`;
-
-exports[`ColorPalette Dropdown should render it correctly 1`] = `
-.emotion-0 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-}
-
-.emotion-1 {
-  -webkit-align-items: flex-start;
-  -webkit-box-align: flex-start;
-  -ms-flex-align: flex-start;
-  align-items: flex-start;
-  -webkit-flex-direction: row;
-  -ms-flex-direction: row;
-  flex-direction: row;
-  gap: calc(4px * 2);
-  -webkit-box-pack: justify;
-  -webkit-justify-content: space-between;
-  justify-content: space-between;
-  width: 100%;
-}
-
-.emotion-2>* {
-  min-width: 0;
-}
-
-.emotion-3 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-align-items: flex-start;
-  -webkit-box-align: flex-start;
-  -ms-flex-align: flex-start;
-  align-items: flex-start;
-  -webkit-flex-direction: row;
-  -ms-flex-direction: row;
-  flex-direction: row;
-  gap: calc(4px * 2);
-  -webkit-box-pack: justify;
-  -webkit-justify-content: space-between;
-  justify-content: space-between;
-  width: 100%;
-}
-
-.emotion-3>* {
-  min-width: 0;
-}
-
-.emotion-5 {
-  display: block;
-  max-height: 100%;
-  max-width: 100%;
-  min-height: 0;
-  min-width: 0;
-}
-
-.emotion-7 {
-  -webkit-flex: 1;
-  -ms-flex: 1;
-  flex: 1;
-}
-
-.emotion-8 {
-  display: block;
-  max-height: 100%;
-  max-width: 100%;
-  min-height: 0;
-  min-width: 0;
-  -webkit-flex: 1;
-  -ms-flex: 1;
-  flex: 1;
-}
-
-.emotion-10 {
-  display: block;
-  overflow: hidden;
-  text-overflow: ellipsis;
-  white-space: nowrap;
-}
-
-.emotion-14 {
-  display: block;
-  overflow: hidden;
-  text-overflow: ellipsis;
-  white-space: nowrap;
-  display: block;
-  max-height: 100%;
-  max-width: 100%;
-  min-height: 0;
-  min-width: 0;
-  -webkit-flex: 1;
-  -ms-flex: 1;
-  flex: 1;
-}
-
-.emotion-18 {
-  display: block;
-  max-height: 100%;
-  max-width: 100%;
-  min-height: 0;
-  min-width: 0;
-}
-
-<Dropdown
-  contentClassName="components-color-palette__custom-color-dropdown-content"
-  popoverProps={
-    Object {
-      "offset": 8,
-      "placement": "bottom",
-      "shift": true,
-    }
-  }
-  renderContent={[Function]}
-  renderToggle={[Function]}
->
-  <div
-    className="components-dropdown"
-    tabIndex="-1"
-  >
-    <Flex
-      align="flex-start"
-      aria-expanded={false}
-      aria-haspopup="true"
-      aria-label="Custom color picker. The currently selected color is called \\"red\\" and has a value of \\"f00\\"."
-      as="button"
-      className="components-color-palette__custom-color"
-      justify="space-between"
-      onClick={[Function]}
-      style={
-        Object {
-          "background": "#f00",
-          "color": "#000",
-        }
-      }
-    >
-      <View
-        aria-expanded={false}
-        aria-haspopup="true"
-        aria-label="Custom color picker. The currently selected color is called \\"red\\" and has a value of \\"f00\\"."
-        as="button"
-        className="emotion-0 emotion-1 emotion-2 components-flex components-color-palette__custom-color"
-        data-wp-c16t={true}
-        data-wp-component="Flex"
-        onClick={[Function]}
-        style={
-          Object {
-            "background": "#f00",
-            "color": "#000",
-          }
-        }
-      >
-        <Noop />
-        <button
-          aria-expanded={false}
-          aria-haspopup="true"
-          aria-label="Custom color picker. The currently selected color is called \\"red\\" and has a value of \\"f00\\"."
-          className="components-flex components-color-palette__custom-color emotion-3 emotion-4"
-          data-wp-c16t={true}
-          data-wp-component="Flex"
-          onClick={[Function]}
-          style={
-            Object {
-              "background": "#f00",
-              "color": "#000",
-            }
-          }
-        >
-          <FlexItem
-            as={
-              Object {
-                "$$typeof": Symbol(react.forward_ref),
-                "__contextSystemKey__": Array [
-                  "Truncate",
-                ],
-                "render": [Function],
-                "selector": ".components-truncate",
-              }
-            }
-            className="components-color-palette__custom-color-name"
-            isBlock={true}
-          >
-            <View
-              as={
-                Object {
-                  "$$typeof": Symbol(react.forward_ref),
-                  "__contextSystemKey__": Array [
-                    "Truncate",
-                  ],
-                  "render": [Function],
-                  "selector": ".components-truncate",
-                }
-              }
-              className="emotion-5 emotion-6 emotion-7 components-flex-item components-color-palette__custom-color-name"
-              data-wp-c16t={true}
-              data-wp-component="FlexItem"
-            >
-              <Noop />
-              <Truncate
-                className="components-flex-item components-color-palette__custom-color-name emotion-8 emotion-4"
-                data-wp-c16t={true}
-                data-wp-component="FlexItem"
-              >
-                <View
-                  as="span"
-                  className="emotion-10 components-truncate components-flex-item components-color-palette__custom-color-name emotion-8 emotion-4"
-                  data-wp-c16t={true}
-                  data-wp-component="FlexItem"
-                >
-                  <Noop />
-                  <span
-                    className="components-truncate components-flex-item components-color-palette__custom-color-name emotion-4 emotion-14 emotion-4"
-                    data-wp-c16t={true}
-                    data-wp-component="FlexItem"
-                  >
-                    red
-                  </span>
-                </View>
-              </Truncate>
-            </View>
-          </FlexItem>
-          <FlexItem
-            as="span"
-            className="components-color-palette__custom-color-value"
-          >
-            <View
-              as="span"
-              className="emotion-5 emotion-6 components-flex-item components-color-palette__custom-color-value"
-              data-wp-c16t={true}
-              data-wp-component="FlexItem"
-            >
-              <Noop />
-              <span
-                className="components-flex-item components-color-palette__custom-color-value emotion-18 emotion-4"
-                data-wp-c16t={true}
-                data-wp-component="FlexItem"
-              >
-                f00
-              </span>
-            </View>
-          </FlexItem>
-        </button>
-      </View>
-    </Flex>
-  </div>
-</Dropdown>
-`;
-
 exports[`ColorPalette should allow disabling custom color picker 1`] = `
-<VStack
-  spacing={3}
->
-  <SinglePalette
-    actions={
-      <ButtonAction
-        onClick={[Function]}
+.emotion-0 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-align-items: normal;
+  -webkit-box-align: normal;
+  -ms-flex-align: normal;
+  align-items: normal;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  gap: calc(4px * 3);
+  -webkit-box-pack: justify;
+  -webkit-justify-content: space-between;
+  justify-content: space-between;
+}
+
+.emotion-0>* {
+  min-height: 0;
+}
+
+<div>
+  <div
+    class="components-flex components-h-stack components-v-stack emotion-0 emotion-1"
+    data-wp-c16t="true"
+    data-wp-component="VStack"
+  >
+    <div
+      class="components-circular-option-picker"
+    >
+      <div
+        class="components-circular-option-picker__swatches"
       >
-        Clear
-      </ButtonAction>
-    }
-    clearColor={[Function]}
-    clearable={true}
-    colors={
-      Array [
-        Object {
-          "color": "#f00",
-          "name": "red",
-        },
-        Object {
-          "color": "#fff",
-          "name": "white",
-        },
-        Object {
-          "color": "#00f",
-          "name": "blue",
-        },
-      ]
-    }
-    onChange={[MockFunction]}
-    value="#f00"
-  />
-</VStack>
+        <div
+          class="components-circular-option-picker__option-wrapper"
+        >
+          <button
+            aria-label="Color: red"
+            aria-pressed="true"
+            class="components-button components-circular-option-picker__option is-pressed"
+            style="background-color: rgb(255, 0, 0); color: rgb(255, 0, 0);"
+            type="button"
+          />
+          <svg
+            aria-hidden="true"
+            fill="#000"
+            focusable="false"
+            height="24"
+            viewBox="0 0 24 24"
+            width="24"
+            xmlns="http://www.w3.org/2000/svg"
+          >
+            <path
+              d="M16.7 7.1l-6.3 8.5-3.3-2.5-.9 1.2 4.5 3.4L17.9 8z"
+            />
+          </svg>
+        </div>
+        <div
+          class="components-circular-option-picker__option-wrapper"
+        >
+          <button
+            aria-label="Color: white"
+            aria-pressed="false"
+            class="components-button components-circular-option-picker__option"
+            style="background-color: rgb(255, 255, 255); color: rgb(255, 255, 255);"
+            type="button"
+          />
+        </div>
+        <div
+          class="components-circular-option-picker__option-wrapper"
+        >
+          <button
+            aria-label="Color: blue"
+            aria-pressed="false"
+            class="components-button components-circular-option-picker__option"
+            style="background-color: rgb(0, 0, 255); color: rgb(0, 0, 255);"
+            type="button"
+          />
+        </div>
+      </div>
+      <div
+        class="components-circular-option-picker__custom-clear-wrapper"
+      >
+        <button
+          class="components-button components-circular-option-picker__clear is-tertiary"
+          type="button"
+        >
+          Clear
+        </button>
+      </div>
+    </div>
+  </div>
+</div>
 `;
 
 exports[`ColorPalette should render a dynamic toolbar of colors 1`] = `
@@ -536,9 +103,6 @@ exports[`ColorPalette should render a dynamic toolbar of colors 1`] = `
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
-}
-
-.emotion-1 {
   -webkit-align-items: normal;
   -webkit-box-align: normal;
   -ms-flex-align: normal;
@@ -550,109 +114,36 @@ exports[`ColorPalette should render a dynamic toolbar of colors 1`] = `
   -webkit-box-pack: justify;
   -webkit-justify-content: space-between;
   justify-content: space-between;
+}
+
+.emotion-0>* {
+  min-height: 0;
+}
+
+.emotion-2 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-align-items: flex-start;
+  -webkit-box-align: flex-start;
+  -ms-flex-align: flex-start;
+  align-items: flex-start;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
+  gap: calc(4px * 2);
+  -webkit-box-pack: justify;
+  -webkit-justify-content: space-between;
+  justify-content: space-between;
+  width: 100%;
 }
 
 .emotion-2>* {
-  min-height: 0;
-}
-
-.emotion-3 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-align-items: normal;
-  -webkit-box-align: normal;
-  -ms-flex-align: normal;
-  align-items: normal;
-  -webkit-flex-direction: column;
-  -ms-flex-direction: column;
-  flex-direction: column;
-  gap: calc(4px * 3);
-  -webkit-box-pack: justify;
-  -webkit-justify-content: space-between;
-  justify-content: space-between;
-}
-
-.emotion-3>* {
-  min-height: 0;
-}
-
-.emotion-6 {
-  -webkit-align-items: flex-start;
-  -webkit-box-align: flex-start;
-  -ms-flex-align: flex-start;
-  align-items: flex-start;
-  -webkit-flex-direction: row;
-  -ms-flex-direction: row;
-  flex-direction: row;
-  gap: calc(4px * 2);
-  -webkit-box-pack: justify;
-  -webkit-justify-content: space-between;
-  justify-content: space-between;
-  width: 100%;
-}
-
-.emotion-7>* {
   min-width: 0;
 }
 
-.emotion-8 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-align-items: flex-start;
-  -webkit-box-align: flex-start;
-  -ms-flex-align: flex-start;
-  align-items: flex-start;
-  -webkit-flex-direction: row;
-  -ms-flex-direction: row;
-  flex-direction: row;
-  gap: calc(4px * 2);
-  -webkit-box-pack: justify;
-  -webkit-justify-content: space-between;
-  justify-content: space-between;
-  width: 100%;
-}
-
-.emotion-8>* {
-  min-width: 0;
-}
-
-.emotion-10 {
-  display: block;
-  max-height: 100%;
-  max-width: 100%;
-  min-height: 0;
-  min-width: 0;
-}
-
-.emotion-12 {
-  -webkit-flex: 1;
-  -ms-flex: 1;
-  flex: 1;
-}
-
-.emotion-13 {
-  display: block;
-  max-height: 100%;
-  max-width: 100%;
-  min-height: 0;
-  min-width: 0;
-  -webkit-flex: 1;
-  -ms-flex: 1;
-  flex: 1;
-}
-
-.emotion-15 {
-  display: block;
-  overflow: hidden;
-  text-overflow: ellipsis;
-  white-space: nowrap;
-}
-
-.emotion-19 {
+.emotion-5 {
   display: block;
   overflow: hidden;
   text-overflow: ellipsis;
@@ -667,7 +158,7 @@ exports[`ColorPalette should render a dynamic toolbar of colors 1`] = `
   flex: 1;
 }
 
-.emotion-23 {
+.emotion-7 {
   display: block;
   max-height: 100%;
   max-width: 100%;
@@ -675,533 +166,105 @@ exports[`ColorPalette should render a dynamic toolbar of colors 1`] = `
   min-width: 0;
 }
 
-<ColorPalette
-  colors={
-    Array [
-      Object {
-        "color": "#f00",
-        "name": "red",
-      },
-      Object {
-        "color": "#fff",
-        "name": "white",
-      },
-      Object {
-        "color": "#00f",
-        "name": "blue",
-      },
-    ]
-  }
-  onChange={[MockFunction]}
-  value="#f00"
->
-  <VStack
-    spacing={3}
+<div>
+  <div
+    class="components-flex components-h-stack components-v-stack emotion-0 emotion-1"
+    data-wp-c16t="true"
+    data-wp-component="VStack"
   >
-    <View
-      className="emotion-0 emotion-1 emotion-2 components-flex components-h-stack components-v-stack"
-      data-wp-c16t={true}
-      data-wp-component="VStack"
-      isColumn={true}
+    <div
+      class="components-dropdown"
+      tabindex="-1"
     >
-      <Noop />
-      <div
-        className="components-flex components-h-stack components-v-stack emotion-3 emotion-4"
-        data-wp-c16t={true}
-        data-wp-component="VStack"
+      <button
+        aria-expanded="false"
+        aria-haspopup="true"
+        aria-label="Custom color picker. The currently selected color is called \\"red\\" and has a value of \\"f00\\"."
+        class="components-flex components-color-palette__custom-color emotion-2 emotion-1"
+        data-wp-c16t="true"
+        data-wp-component="Flex"
+        style="background: rgb(255, 0, 0); color: rgb(0, 0, 0);"
       >
-        <CustomColorPickerDropdown
-          isRenderedInSidebar={false}
-          key=".0"
-          renderContent={[Function]}
-          renderToggle={[Function]}
+        <span
+          class="components-truncate components-flex-item components-color-palette__custom-color-name emotion-1 emotion-5 emotion-1"
+          data-wp-c16t="true"
+          data-wp-component="FlexItem"
         >
-          <Dropdown
-            contentClassName="components-color-palette__custom-color-dropdown-content"
-            popoverProps={
-              Object {
-                "offset": 8,
-                "placement": "bottom",
-                "shift": true,
-              }
-            }
-            renderContent={[Function]}
-            renderToggle={[Function]}
-          >
-            <div
-              className="components-dropdown"
-              tabIndex="-1"
-            >
-              <Flex
-                align="flex-start"
-                aria-expanded={false}
-                aria-haspopup="true"
-                aria-label="Custom color picker. The currently selected color is called \\"red\\" and has a value of \\"f00\\"."
-                as="button"
-                className="components-color-palette__custom-color"
-                justify="space-between"
-                onClick={[Function]}
-                style={
-                  Object {
-                    "background": "#f00",
-                    "color": "#000",
-                  }
-                }
-              >
-                <View
-                  aria-expanded={false}
-                  aria-haspopup="true"
-                  aria-label="Custom color picker. The currently selected color is called \\"red\\" and has a value of \\"f00\\"."
-                  as="button"
-                  className="emotion-0 emotion-6 emotion-7 components-flex components-color-palette__custom-color"
-                  data-wp-c16t={true}
-                  data-wp-component="Flex"
-                  onClick={[Function]}
-                  style={
-                    Object {
-                      "background": "#f00",
-                      "color": "#000",
-                    }
-                  }
-                >
-                  <Noop />
-                  <button
-                    aria-expanded={false}
-                    aria-haspopup="true"
-                    aria-label="Custom color picker. The currently selected color is called \\"red\\" and has a value of \\"f00\\"."
-                    className="components-flex components-color-palette__custom-color emotion-8 emotion-4"
-                    data-wp-c16t={true}
-                    data-wp-component="Flex"
-                    onClick={[Function]}
-                    style={
-                      Object {
-                        "background": "#f00",
-                        "color": "#000",
-                      }
-                    }
-                  >
-                    <FlexItem
-                      as={
-                        Object {
-                          "$$typeof": Symbol(react.forward_ref),
-                          "__contextSystemKey__": Array [
-                            "Truncate",
-                          ],
-                          "render": [Function],
-                          "selector": ".components-truncate",
-                        }
-                      }
-                      className="components-color-palette__custom-color-name"
-                      isBlock={true}
-                    >
-                      <View
-                        as={
-                          Object {
-                            "$$typeof": Symbol(react.forward_ref),
-                            "__contextSystemKey__": Array [
-                              "Truncate",
-                            ],
-                            "render": [Function],
-                            "selector": ".components-truncate",
-                          }
-                        }
-                        className="emotion-10 emotion-11 emotion-12 components-flex-item components-color-palette__custom-color-name"
-                        data-wp-c16t={true}
-                        data-wp-component="FlexItem"
-                      >
-                        <Noop />
-                        <Truncate
-                          className="components-flex-item components-color-palette__custom-color-name emotion-13 emotion-4"
-                          data-wp-c16t={true}
-                          data-wp-component="FlexItem"
-                        >
-                          <View
-                            as="span"
-                            className="emotion-15 components-truncate components-flex-item components-color-palette__custom-color-name emotion-13 emotion-4"
-                            data-wp-c16t={true}
-                            data-wp-component="FlexItem"
-                          >
-                            <Noop />
-                            <span
-                              className="components-truncate components-flex-item components-color-palette__custom-color-name emotion-4 emotion-19 emotion-4"
-                              data-wp-c16t={true}
-                              data-wp-component="FlexItem"
-                            >
-                              red
-                            </span>
-                          </View>
-                        </Truncate>
-                      </View>
-                    </FlexItem>
-                    <FlexItem
-                      as="span"
-                      className="components-color-palette__custom-color-value"
-                    >
-                      <View
-                        as="span"
-                        className="emotion-10 emotion-11 components-flex-item components-color-palette__custom-color-value"
-                        data-wp-c16t={true}
-                        data-wp-component="FlexItem"
-                      >
-                        <Noop />
-                        <span
-                          className="components-flex-item components-color-palette__custom-color-value emotion-23 emotion-4"
-                          data-wp-c16t={true}
-                          data-wp-component="FlexItem"
-                        >
-                          f00
-                        </span>
-                      </View>
-                    </FlexItem>
-                  </button>
-                </View>
-              </Flex>
-            </div>
-          </Dropdown>
-        </CustomColorPickerDropdown>
-        <SinglePalette
-          actions={
-            <ButtonAction
-              onClick={[Function]}
-            >
-              Clear
-            </ButtonAction>
-          }
-          clearColor={[Function]}
-          clearable={true}
-          colors={
-            Array [
-              Object {
-                "color": "#f00",
-                "name": "red",
-              },
-              Object {
-                "color": "#fff",
-                "name": "white",
-              },
-              Object {
-                "color": "#00f",
-                "name": "blue",
-              },
-            ]
-          }
-          key=".1"
-          onChange={[MockFunction]}
-          value="#f00"
+          red
+        </span>
+        <span
+          class="components-flex-item components-color-palette__custom-color-value emotion-7 emotion-1"
+          data-wp-c16t="true"
+          data-wp-component="FlexItem"
         >
-          <CircularOptionPicker
-            actions={
-              <ButtonAction
-                onClick={[Function]}
-              >
-                Clear
-              </ButtonAction>
-            }
-            options={
-              Array [
-                <Option
-                  aria-label="Color: red"
-                  isSelected={true}
-                  onClick={[Function]}
-                  selectedIconProps={
-                    Object {
-                      "fill": "#000",
-                    }
-                  }
-                  style={
-                    Object {
-                      "backgroundColor": "#f00",
-                      "color": "#f00",
-                    }
-                  }
-                  tooltipText="red"
-                />,
-                <Option
-                  aria-label="Color: white"
-                  isSelected={false}
-                  onClick={[Function]}
-                  selectedIconProps={Object {}}
-                  style={
-                    Object {
-                      "backgroundColor": "#fff",
-                      "color": "#fff",
-                    }
-                  }
-                  tooltipText="white"
-                />,
-                <Option
-                  aria-label="Color: blue"
-                  isSelected={false}
-                  onClick={[Function]}
-                  selectedIconProps={Object {}}
-                  style={
-                    Object {
-                      "backgroundColor": "#00f",
-                      "color": "#00f",
-                    }
-                  }
-                  tooltipText="blue"
-                />,
-              ]
-            }
+          f00
+        </span>
+      </button>
+    </div>
+    <div
+      class="components-circular-option-picker"
+    >
+      <div
+        class="components-circular-option-picker__swatches"
+      >
+        <div
+          class="components-circular-option-picker__option-wrapper"
+        >
+          <button
+            aria-label="Color: red"
+            aria-pressed="true"
+            class="components-button components-circular-option-picker__option is-pressed"
+            style="background-color: rgb(255, 0, 0); color: rgb(255, 0, 0);"
+            type="button"
+          />
+          <svg
+            aria-hidden="true"
+            fill="#000"
+            focusable="false"
+            height="24"
+            viewBox="0 0 24 24"
+            width="24"
+            xmlns="http://www.w3.org/2000/svg"
           >
-            <div
-              className="components-circular-option-picker"
-            >
-              <div
-                className="components-circular-option-picker__swatches"
-              >
-                <Option
-                  aria-label="Color: red"
-                  isSelected={true}
-                  key="#f00-0"
-                  onClick={[Function]}
-                  selectedIconProps={
-                    Object {
-                      "fill": "#000",
-                    }
-                  }
-                  style={
-                    Object {
-                      "backgroundColor": "#f00",
-                      "color": "#f00",
-                    }
-                  }
-                  tooltipText="red"
-                >
-                  <div
-                    className="components-circular-option-picker__option-wrapper"
-                  >
-                    <Tooltip
-                      text="red"
-                    >
-                      <ForwardRef(Button)
-                        aria-label="Color: red"
-                        className="components-circular-option-picker__option"
-                        isPressed={true}
-                        onBlur={[Function]}
-                        onClick={[Function]}
-                        onFocus={[Function]}
-                        onMouseDown={[Function]}
-                        onMouseEnter={[Function]}
-                        onMouseLeave={[Function]}
-                        style={
-                          Object {
-                            "backgroundColor": "#f00",
-                            "color": "#f00",
-                          }
-                        }
-                      >
-                        <button
-                          aria-describedby={null}
-                          aria-label="Color: red"
-                          aria-pressed={true}
-                          className="components-button components-circular-option-picker__option is-pressed"
-                          onBlur={[Function]}
-                          onClick={[Function]}
-                          onFocus={[Function]}
-                          onMouseDown={[Function]}
-                          onMouseEnter={[Function]}
-                          onMouseLeave={[Function]}
-                          style={
-                            Object {
-                              "backgroundColor": "#f00",
-                              "color": "#f00",
-                            }
-                          }
-                          type="button"
-                        />
-                      </ForwardRef(Button)>
-                    </Tooltip>
-                    <Icon
-                      fill="#000"
-                      icon={
-                        <SVG
-                          viewBox="0 0 24 24"
-                          xmlns="http://www.w3.org/2000/svg"
-                        >
-                          <Path
-                            d="M16.7 7.1l-6.3 8.5-3.3-2.5-.9 1.2 4.5 3.4L17.9 8z"
-                          />
-                        </SVG>
-                      }
-                    >
-                      <SVG
-                        fill="#000"
-                        height={24}
-                        viewBox="0 0 24 24"
-                        width={24}
-                        xmlns="http://www.w3.org/2000/svg"
-                      >
-                        <svg
-                          aria-hidden={true}
-                          fill="#000"
-                          focusable={false}
-                          height={24}
-                          viewBox="0 0 24 24"
-                          width={24}
-                          xmlns="http://www.w3.org/2000/svg"
-                        >
-                          <Path
-                            d="M16.7 7.1l-6.3 8.5-3.3-2.5-.9 1.2 4.5 3.4L17.9 8z"
-                          >
-                            <path
-                              d="M16.7 7.1l-6.3 8.5-3.3-2.5-.9 1.2 4.5 3.4L17.9 8z"
-                            />
-                          </Path>
-                        </svg>
-                      </SVG>
-                    </Icon>
-                  </div>
-                </Option>
-                <Option
-                  aria-label="Color: white"
-                  isSelected={false}
-                  key="#fff-1"
-                  onClick={[Function]}
-                  selectedIconProps={Object {}}
-                  style={
-                    Object {
-                      "backgroundColor": "#fff",
-                      "color": "#fff",
-                    }
-                  }
-                  tooltipText="white"
-                >
-                  <div
-                    className="components-circular-option-picker__option-wrapper"
-                  >
-                    <Tooltip
-                      text="white"
-                    >
-                      <ForwardRef(Button)
-                        aria-label="Color: white"
-                        className="components-circular-option-picker__option"
-                        isPressed={false}
-                        onBlur={[Function]}
-                        onClick={[Function]}
-                        onFocus={[Function]}
-                        onMouseDown={[Function]}
-                        onMouseEnter={[Function]}
-                        onMouseLeave={[Function]}
-                        style={
-                          Object {
-                            "backgroundColor": "#fff",
-                            "color": "#fff",
-                          }
-                        }
-                      >
-                        <button
-                          aria-describedby={null}
-                          aria-label="Color: white"
-                          aria-pressed={false}
-                          className="components-button components-circular-option-picker__option"
-                          onBlur={[Function]}
-                          onClick={[Function]}
-                          onFocus={[Function]}
-                          onMouseDown={[Function]}
-                          onMouseEnter={[Function]}
-                          onMouseLeave={[Function]}
-                          style={
-                            Object {
-                              "backgroundColor": "#fff",
-                              "color": "#fff",
-                            }
-                          }
-                          type="button"
-                        />
-                      </ForwardRef(Button)>
-                    </Tooltip>
-                  </div>
-                </Option>
-                <Option
-                  aria-label="Color: blue"
-                  isSelected={false}
-                  key="#00f-2"
-                  onClick={[Function]}
-                  selectedIconProps={Object {}}
-                  style={
-                    Object {
-                      "backgroundColor": "#00f",
-                      "color": "#00f",
-                    }
-                  }
-                  tooltipText="blue"
-                >
-                  <div
-                    className="components-circular-option-picker__option-wrapper"
-                  >
-                    <Tooltip
-                      text="blue"
-                    >
-                      <ForwardRef(Button)
-                        aria-label="Color: blue"
-                        className="components-circular-option-picker__option"
-                        isPressed={false}
-                        onBlur={[Function]}
-                        onClick={[Function]}
-                        onFocus={[Function]}
-                        onMouseDown={[Function]}
-                        onMouseEnter={[Function]}
-                        onMouseLeave={[Function]}
-                        style={
-                          Object {
-                            "backgroundColor": "#00f",
-                            "color": "#00f",
-                          }
-                        }
-                      >
-                        <button
-                          aria-describedby={null}
-                          aria-label="Color: blue"
-                          aria-pressed={false}
-                          className="components-button components-circular-option-picker__option"
-                          onBlur={[Function]}
-                          onClick={[Function]}
-                          onFocus={[Function]}
-                          onMouseDown={[Function]}
-                          onMouseEnter={[Function]}
-                          onMouseLeave={[Function]}
-                          style={
-                            Object {
-                              "backgroundColor": "#00f",
-                              "color": "#00f",
-                            }
-                          }
-                          type="button"
-                        />
-                      </ForwardRef(Button)>
-                    </Tooltip>
-                  </div>
-                </Option>
-              </div>
-              <div
-                className="components-circular-option-picker__custom-clear-wrapper"
-              >
-                <ButtonAction
-                  onClick={[Function]}
-                >
-                  <ForwardRef(Button)
-                    className="components-circular-option-picker__clear"
-                    onClick={[Function]}
-                    variant="tertiary"
-                  >
-                    <button
-                      aria-describedby={null}
-                      className="components-button components-circular-option-picker__clear is-tertiary"
-                      onClick={[Function]}
-                      type="button"
-                    >
-                      Clear
-                    </button>
-                  </ForwardRef(Button)>
-                </ButtonAction>
-              </div>
-            </div>
-          </CircularOptionPicker>
-        </SinglePalette>
+            <path
+              d="M16.7 7.1l-6.3 8.5-3.3-2.5-.9 1.2 4.5 3.4L17.9 8z"
+            />
+          </svg>
+        </div>
+        <div
+          class="components-circular-option-picker__option-wrapper"
+        >
+          <button
+            aria-label="Color: white"
+            aria-pressed="false"
+            class="components-button components-circular-option-picker__option"
+            style="background-color: rgb(255, 255, 255); color: rgb(255, 255, 255);"
+            type="button"
+          />
+        </div>
+        <div
+          class="components-circular-option-picker__option-wrapper"
+        >
+          <button
+            aria-label="Color: blue"
+            aria-pressed="false"
+            class="components-button components-circular-option-picker__option"
+            style="background-color: rgb(0, 0, 255); color: rgb(0, 0, 255);"
+            type="button"
+          />
+        </div>
       </div>
-    </View>
-  </VStack>
-</ColorPalette>
+      <div
+        class="components-circular-option-picker__custom-clear-wrapper"
+      >
+        <button
+          class="components-button components-circular-option-picker__clear is-tertiary"
+          type="button"
+        >
+          Clear
+        </button>
+      </div>
+    </div>
+  </div>
+</div>
 `;

--- a/packages/components/src/color-palette/test/index.js
+++ b/packages/components/src/color-palette/test/index.js
@@ -1,7 +1,8 @@
 /**
  * External dependencies
  */
-import { mount, shallow } from 'enzyme';
+import { render, screen, within } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 
 /**
  * Internal dependencies
@@ -17,102 +18,146 @@ describe( 'ColorPalette', () => {
 	const currentColor = '#f00';
 	const onChange = jest.fn();
 
-	const wrapper = mount(
-		<ColorPalette
-			colors={ colors }
-			value={ currentColor }
-			onChange={ onChange }
-		/>
-	);
-	const buttons = wrapper.find( 'Option button' );
-
 	beforeEach( () => {
 		onChange.mockClear();
 	} );
 
 	test( 'should render a dynamic toolbar of colors', () => {
-		expect( wrapper ).toMatchSnapshot();
+		const { container } = render(
+			<ColorPalette
+				colors={ colors }
+				value={ currentColor }
+				onChange={ onChange }
+			/>
+		);
+
+		expect( container ).toMatchSnapshot();
 	} );
 
 	test( 'should render three color button options', () => {
-		expect( buttons ).toHaveLength( 3 );
+		render(
+			<ColorPalette
+				colors={ colors }
+				value={ currentColor }
+				onChange={ onChange }
+			/>
+		);
+
+		expect(
+			screen.getAllByRole( 'button', { name: /^Color:/ } )
+		).toHaveLength( 3 );
 	} );
 
-	test( 'should call onClick on an active button with undefined', () => {
-		const activeButton = buttons.findWhere( ( button ) =>
-			button.hasClass( 'is-pressed' )
+	test( 'should call onClick on an active button with undefined', async () => {
+		const user = userEvent.setup( {
+			advanceTimers: jest.advanceTimersByTime,
+		} );
+
+		render(
+			<ColorPalette
+				colors={ colors }
+				value={ currentColor }
+				onChange={ onChange }
+			/>
 		);
-		activeButton.simulate( 'click' );
+
+		await user.click(
+			screen.getByRole( 'button', { name: /^Color:/, pressed: true } )
+		);
 
 		expect( onChange ).toHaveBeenCalledTimes( 1 );
 		expect( onChange ).toHaveBeenCalledWith( undefined );
 	} );
 
-	test( 'should call onClick on an inactive button', () => {
-		const inactiveButton = buttons
-			.findWhere( ( button ) => ! button.hasClass( 'is-pressed' ) )
-			.first();
-		inactiveButton.simulate( 'click' );
+	test( 'should call onClick on an inactive button', async () => {
+		const user = userEvent.setup( {
+			advanceTimers: jest.advanceTimersByTime,
+		} );
+
+		render(
+			<ColorPalette
+				colors={ colors }
+				value={ currentColor }
+				onChange={ onChange }
+			/>
+		);
+
+		await user.click(
+			screen.getAllByRole( 'button', {
+				name: /^Color:/,
+				pressed: false,
+			} )[ 0 ]
+		);
 
 		expect( onChange ).toHaveBeenCalledTimes( 1 );
 	} );
 
-	test( 'should call onClick with undefined, when the clearButton onClick is triggered', () => {
-		const clearButton = wrapper.find( 'ButtonAction button' );
+	test( 'should call onClick with undefined, when the clearButton onClick is triggered', async () => {
+		const user = userEvent.setup( {
+			advanceTimers: jest.advanceTimersByTime,
+		} );
 
-		expect( clearButton ).toHaveLength( 1 );
+		render(
+			<ColorPalette
+				colors={ colors }
+				value={ currentColor }
+				onChange={ onChange }
+			/>
+		);
 
-		clearButton.simulate( 'click' );
+		await user.click( screen.getByRole( 'button', { name: 'Clear' } ) );
 
 		expect( onChange ).toHaveBeenCalledTimes( 1 );
 		expect( onChange ).toHaveBeenCalledWith( undefined );
 	} );
 
 	test( 'should allow disabling custom color picker', () => {
-		expect(
-			shallow(
-				<ColorPalette
-					colors={ colors }
-					disableCustomColors={ true }
-					value={ currentColor }
-					onChange={ onChange }
-				/>
-			)
-		).toMatchSnapshot();
+		const { container } = render(
+			<ColorPalette
+				colors={ colors }
+				disableCustomColors
+				value={ currentColor }
+				onChange={ onChange }
+			/>
+		);
+
+		expect( container ).toMatchSnapshot();
 	} );
 
-	describe( 'Dropdown', () => {
-		const dropdown = wrapper.find( 'Dropdown' );
-
-		test( 'should render it correctly', () => {
-			expect( dropdown ).toMatchSnapshot();
+	test( 'should render dropdown and its content', async () => {
+		const user = userEvent.setup( {
+			advanceTimers: jest.advanceTimersByTime,
 		} );
 
-		describe( '.renderToggle', () => {
-			const isOpen = true;
-			const onToggle = jest.fn();
+		render(
+			<ColorPalette
+				colors={ colors }
+				value={ currentColor }
+				onChange={ onChange }
+			/>
+		);
 
-			const renderedToggleButton = mount(
-				dropdown.props().renderToggle( { isOpen, onToggle } )
-			);
+		await user.click(
+			screen.getByRole( 'button', {
+				name: /^Custom color picker/,
+				expanded: false,
+			} )
+		);
 
-			test( 'should render dropdown content', () => {
-				expect( renderedToggleButton ).toMatchSnapshot();
-			} );
-
-			test( 'should call onToggle on click.', () => {
-				renderedToggleButton.find( 'button' ).simulate( 'click' );
-
-				expect( onToggle ).toHaveBeenCalledTimes( 1 );
-			} );
+		const dropdownButton = screen.getByRole( 'button', {
+			name: /^Custom color picker/,
+			expanded: true,
 		} );
 
-		describe( '.renderContent', () => {
-			const renderedContent = shallow( dropdown.props().renderContent() );
+		expect( dropdownButton ).toBeVisible();
 
-			test( 'should render dropdown content', () => {
-				expect( renderedContent ).toMatchSnapshot();
-			} );
-		} );
+		expect(
+			within( dropdownButton ).getByText( colors[ 0 ].name )
+		).toBeVisible();
+		expect(
+			within( dropdownButton ).getByText(
+				colors[ 0 ].color.replace( '#', '' )
+			)
+		).toBeVisible();
 	} );
 } );

--- a/packages/components/src/color-palette/test/index.js
+++ b/packages/components/src/color-palette/test/index.js
@@ -90,6 +90,7 @@ describe( 'ColorPalette', () => {
 		);
 
 		expect( onChange ).toHaveBeenCalledTimes( 1 );
+		expect( onChange ).toHaveBeenCalledWith( '#fff' );
 	} );
 
 	test( 'should call onClick with undefined, when the clearButton onClick is triggered', async () => {


### PR DESCRIPTION
## What?
We've recently started refactoring `enzyme` tests to `@testing-library/react`.

This PR refactors the `ColorPalette` tests from `enzyme` to `@testing-library/react`.

## Why?
`@testing-library/react` provides a better way to write tests for accessible components that is closer to the way the user experiences them.

## How?
We're straightforwardly replacing `enzyme` tests with `@testing-library/react` ones, using `jest-dom` matchers and mocks to avoid testing unrelated implementation details.

Ideally, we should not be using snapshot tests here, however, the purpose of this PR is not to improve or enrich the tests themselves, but rather to migrate them `@testing-library/react`. Our primary motivation is unblocking the upgrade to React 18. 

In any case, it would be a good future step to improve the tests and test actual experience and interaction in order to improve the overall value of the tests.

## Testing Instructions
Verify tests pass: `npm run test:unit packages/components/src/color-palette/test/index.js`
