### PR TITLE
Try: Fix navigation block link color when the block is nested

### DIFF
--- a/packages/block-library/src/navigation/style.scss
+++ b/packages/block-library/src/navigation/style.scss
@@ -47,7 +47,10 @@ $navigation-icon-size: 24px;
 		display: block;
 	}
 
-	.wp-block-navigation-item.has-text-color a {
+	// Increases the specificity of custom text colors so that they are not overriden
+	// by custom link colors set on a parent container block.
+	.wp-block-navigation-item.has-text-color a,
+	.wp-block-page-list.has-text-color .wp-block-navigation-item a {
 		color: inherit;
 	}
 
@@ -391,7 +394,7 @@ button.wp-block-navigation-item__content {
 	}
 }
 
-// Default background and font color.
+// Submenu default background and text color.
 .wp-block-navigation:not(.has-background) {
 	.wp-block-navigation__submenu-container {
 		// Set a background color for submenus so that they're not transparent.
@@ -399,8 +402,16 @@ button.wp-block-navigation-item__content {
 		// submenus have a default background color, this feature has regressed
 		// several times, so care needs to be taken.
 		background-color: #fff;
-		color: #000;
 		border: 1px solid rgba(0, 0, 0, 0.15);
+	}
+}
+// Set a default background color to match the white background,
+// but only if there are no custom colors.
+.wp-block-navigation:not(.has-background):not(.has-text-color) {
+	.wp-block-navigation__submenu-container {
+		.wp-block-navigation-item a {
+			color: #000;
+		}
 	}
 }
 

--- a/packages/block-library/src/navigation/style.scss
+++ b/packages/block-library/src/navigation/style.scss
@@ -47,7 +47,7 @@ $navigation-icon-size: 24px;
 		display: block;
 	}
 
-	// Increases the specificity of custom text colors so that they are not overriden
+	// Increases the specificity of user-set text colors so that they are not overriden
 	// by custom link colors set on a parent container block.
 	.wp-block-navigation-item.has-text-color a,
 	.wp-block-page-list.has-text-color .wp-block-navigation-item a {
@@ -405,7 +405,7 @@ button.wp-block-navigation-item__content {
 		border: 1px solid rgba(0, 0, 0, 0.15);
 	}
 }
-// Set a default background color to match the white background,
+// Set a default text color to match the white background,
 // but only if there are no custom colors.
 .wp-block-navigation:not(.has-background):not(.has-text-color) {
 	.wp-block-navigation__submenu-container {

--- a/packages/block-library/src/navigation/style.scss
+++ b/packages/block-library/src/navigation/style.scss
@@ -396,7 +396,7 @@ button.wp-block-navigation-item__content {
 
 // Submenu default background and text color.
 .wp-block-navigation:not(.has-background) {
-	.wp-block-navigation__submenu-container {
+	.wp-block-navigation__submenu-container .wp-block-navigation-item:not(.has-background) {
 		// Set a background color for submenus so that they're not transparent.
 		// NOTE TO DEVS - if refactoring this code, please double-check that
 		// submenus have a default background color, this feature has regressed
@@ -404,15 +404,20 @@ button.wp-block-navigation-item__content {
 		background-color: #fff;
 		border: 1px solid rgba(0, 0, 0, 0.15);
 	}
-}
-// Set a default text color to match the white background,
-// but only if there are no custom colors.
-.wp-block-navigation:not(.has-background):not(.has-text-color) {
-	.wp-block-navigation__submenu-container {
-		.wp-block-navigation-item a {
-			color: #000;
-		}
+	// Set the text and link color to #000 if there is no custom text color.
+	.wp-block-navigation__submenu-container .wp-block-navigation-item:not(.has-text-color),
+	.wp-block-navigation__submenu-container .wp-block-navigation-item:not(.has-text-color) a {
+		color: #000;
 	}
+}
+
+// Increase the specificity of user-set colors on page-list submenus.
+.wp-block-navigation__submenu-container .wp-block-navigation-item.has-background * .wp-block-navigation-item:not(.has-background) {
+	background: inherit;
+	color: inherit;
+}
+.wp-block-navigation__submenu-container .wp-block-navigation-item.has-background * .wp-block-navigation-item:not(.has-text-color) a {
+	color: inherit;
 }
 
 // Navigation block inner container.

--- a/packages/block-library/src/navigation/style.scss
+++ b/packages/block-library/src/navigation/style.scss
@@ -47,6 +47,10 @@ $navigation-icon-size: 24px;
 		display: block;
 	}
 
+	.wp-block-navigation-item.has-text-color a {
+		color: inherit;
+	}
+
 	// The following rules provide class based application of user selected text
 	// decoration via block supports.
 	&.has-text-decoration-underline .wp-block-navigation-item__content {

--- a/packages/block-library/src/page-list/edit.js
+++ b/packages/block-library/src/page-list/edit.js
@@ -167,6 +167,14 @@ const PageItems = memo( function PageItems( {
 	const isNavigationChild = 'showSubmenuIcon' in context;
 	const isSubmenuItem = depth > 0;
 
+	// User-set custom colors for the submmenu needs to be added inline.
+	const blockProps = useBlockProps();
+	const customSumbmenuStyles = {
+		...blockProps.style,
+		color: context.customOverlayTextColor,
+		background: context.customOverlayBackgroundColor,
+	};
+
 	if ( ! pages?.length ) {
 		return [];
 	}
@@ -185,16 +193,24 @@ const PageItems = memo( function PageItems( {
 						context.showSubmenuIcon,
 					'menu-item-home': page.id === frontPageId,
 					'has-text-color':
-						!! context.overlayTextColor && isSubmenuItem,
+						( !! context.overlayTextColor && isSubmenuItem ) ||
+						( !! context.customOverlayTextColor && isSubmenuItem ),
 					[ getColorClassName( 'color', context.overlayTextColor ) ]:
 						!! context.overlayTextColor && isSubmenuItem,
 					'has-background':
-						!! context.overlayBackgroundColor && isSubmenuItem,
+						!! (
+							context.overlayBackgroundColor && isSubmenuItem
+						) ||
+						!! (
+							context.customOverlayBackgroundColor &&
+							isSubmenuItem
+						),
 					[ getColorClassName(
 						'background-color',
 						context.overlayBackgroundColor
 					) ]: !! context.overlayBackgroundColor && isSubmenuItem,
 				} ) }
+				style={ !! isSubmenuItem ? customSumbmenuStyles : undefined }
 			>
 				{ hasChildren && context.openSubmenusOnClick ? (
 					<>

--- a/packages/block-library/src/page-list/edit.js
+++ b/packages/block-library/src/page-list/edit.js
@@ -164,6 +164,8 @@ const PageItems = memo( function PageItems( {
 } ) {
 	const pages = pagesByParentId.get( parentId );
 	const frontPageId = useFrontPageId();
+	const isNavigationChild = 'showSubmenuIcon' in context;
+	const isSubmenuItem = depth > 0;
 
 	if ( ! pages?.length ) {
 		return [];
@@ -171,7 +173,6 @@ const PageItems = memo( function PageItems( {
 
 	return pages.map( ( page ) => {
 		const hasChildren = pagesByParentId.has( page.id );
-		const isNavigationChild = 'showSubmenuIcon' in context;
 		return (
 			<li
 				key={ page.id }
@@ -183,6 +184,16 @@ const PageItems = memo( function PageItems( {
 						! context.openSubmenusOnClick &&
 						context.showSubmenuIcon,
 					'menu-item-home': page.id === frontPageId,
+					'has-text-color':
+						!! context.overlayTextColor && isSubmenuItem,
+					[ getColorClassName( 'color', context.overlayTextColor ) ]:
+						!! context.overlayTextColor && isSubmenuItem,
+					'has-background':
+						!! context.overlayBackgroundColor && isSubmenuItem,
+					[ getColorClassName(
+						'background-color',
+						context.overlayBackgroundColor
+					) ]: !! context.overlayBackgroundColor && isSubmenuItem,
 				} ) }
 			>
 				{ hasChildren && context.openSubmenusOnClick ? (

--- a/packages/block-library/src/page-list/edit.js
+++ b/packages/block-library/src/page-list/edit.js
@@ -167,9 +167,9 @@ const PageItems = memo( function PageItems( {
 	const isNavigationChild = 'showSubmenuIcon' in context;
 	const isSubmenuItem = depth > 0;
 
-	// User-set custom colors for the submmenu needs to be added inline.
+	// User-set custom colors for the submenu needs to be added inline.
 	const blockProps = useBlockProps();
-	const customSumbmenuStyles = {
+	const customSubmenuStyles = {
 		...blockProps.style,
 		color: context.customOverlayTextColor,
 		background: context.customOverlayBackgroundColor,
@@ -210,7 +210,7 @@ const PageItems = memo( function PageItems( {
 						context.overlayBackgroundColor
 					) ]: !! context.overlayBackgroundColor && isSubmenuItem,
 				} ) }
-				style={ !! isSubmenuItem ? customSumbmenuStyles : undefined }
+				style={ !! isSubmenuItem ? customSubmenuStyles : undefined }
 			>
 				{ hasChildren && context.openSubmenusOnClick ? (
 					<>


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Adds `color:inherit` to a navigation item link:
- When the link is in a submenu.
- When the link is in a page list, page list submenu, page list nested submenus (submenus of submenus)
- When the navigation item has the class `has-text-color`.

Updates the specificity of the `#000` default text color on submenus.
Adds the overlay and submenu color context to the page list.

Closes https://github.com/WordPress/gutenberg/issues/40908

**WIP.** I am parking this here while I continue testing.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

When a navigation block was placed inside a container block (like a group) that had a _link_ color set,
the parent container link color would override the navigation block text color and submenu text color in the editor.

On the front, the parent container text color would also override the color for the submenu block. Regular link items would display in the correct color.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
Updates the style.scss file.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->

## Screenshots or screencast <!-- if applicable -->
