### PR TITLE
Adds types for data package controls

### DIFF
--- a/packages/data/src/index.js
+++ b/packages/data/src/index.js
@@ -27,6 +27,10 @@ export { useDispatch } from './components/use-dispatch';
 export { AsyncModeProvider } from './components/async-mode-provider';
 export { createRegistry } from './registry';
 export { createRegistrySelector, createRegistryControl } from './factory';
+
+/**
+ * @type {import('./types').Controls}
+ */
 export { controls } from './controls';
 export { default as createReduxStore } from './redux-store';
 

--- a/packages/data/src/types.ts
+++ b/packages/data/src/types.ts
@@ -4,6 +4,11 @@
 // eslint-disable-next-line no-restricted-imports
 import type { combineReducers as reduxCombineReducers } from 'redux';
 
+/**
+ * Internal dependencies
+ */
+import type { controls } from './controls';
+
 type MapOf< T > = { [ name: string ]: T };
 
 export type ActionCreator = Function | Generator;
@@ -123,3 +128,9 @@ type SelectorsOf< Config extends AnyConfig > = Config extends ReduxStoreConfig<
 	: never;
 
 export type combineReducers = typeof reduxCombineReducers;
+
+export type Controls = {
+	select: typeof controls.select;
+	resolveSelect: typeof controls.resolveSelect;
+	dispatch: typeof controls.dispatch;
+};


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Adds types for data package controls.

## Why?
Found these missing types in [woocommerce/woocommerce](https://github.com/woocommerce/woocommerce/blob/f9a27d380f66debf4b3b9541b996037cbebe18ba/packages/js/data/typings/index.d.ts) data package.
