### PR TITLE
Styling blocks and elements inside template parts with theme.json

### DIFF
--- a/lib/compat/wordpress-6.1/class-wp-theme-json-6-1.php
+++ b/lib/compat/wordpress-6.1/class-wp-theme-json-6-1.php
@@ -187,7 +187,7 @@ class WP_Theme_JSON_6_1 extends WP_Theme_JSON_6_0 {
 			}
 		}
 
-		$templateParts                = $input['templateParts'];
+		$templateParts                = isset( $input['templateParts'] ) ? $input['templateParts'] : array();
 		$schema_styles_blocks         = array();
 		$schema_settings_blocks       = array();
 		$schema_styles_template_parts = array();
@@ -776,7 +776,7 @@ class WP_Theme_JSON_6_1 extends WP_Theme_JSON_6_0 {
 		// processed as normal.
 		$feature_declarations = array();
 
-		if ( ! empty( $block_metadata['features'] ) ) {
+		if ( ! empty( $block_metadata['features'] ) && is_array( $block_metadata['features'] ) ) {
 			foreach ( $block_metadata['features'] as $feature_name => $feature_selector ) {
 				if ( ! empty( $node[ $feature_name ] ) ) {
 					// Create temporary node containing only the feature data

--- a/lib/compat/wordpress-6.1/get-global-styles-and-settings.php
+++ b/lib/compat/wordpress-6.1/get-global-styles-and-settings.php
@@ -48,6 +48,28 @@ function wp_add_global_styles_for_blocks() {
 	}
 }
 
+function wp_add_global_styles_for_template_parts() {
+	$tree                 = WP_Theme_JSON_Resolver_Gutenberg::get_merged_data();
+	$template_parts_nodes = $tree->get_styles_template_part_nodes();
+
+	foreach ( $template_parts_nodes as $metadata ) {
+		$block_css = $tree->get_styles_for_block( $metadata );
+
+		if ( isset( $metadata['name'] ) ) {
+			$block_name = str_replace( 'core/', '', $metadata['name'] );
+			// These block styles are added on block_render.
+			// This hooks inline CSS to them so that they are loaded conditionally
+			// based on whether or not the block is used on the page.
+			wp_add_inline_style( 'wp-block-' . $block_name, $block_css );
+		}
+
+		// The element styles are added to the global styles
+		if ( ! isset( $metadata['name'] ) && ! empty( $metadata['path'] ) ) {
+			wp_add_inline_style( 'global-styles', $block_css );
+		}
+	}
+}
+
 /**
  * Returns the stylesheet resulting of merging core, theme, and user data.
  *

--- a/lib/compat/wordpress-6.1/script-loader.php
+++ b/lib/compat/wordpress-6.1/script-loader.php
@@ -157,6 +157,8 @@ function gutenberg_enqueue_global_styles() {
 
 	// add each block as an inline css.
 	wp_add_global_styles_for_blocks();
+	// add each template part block style as inline css.
+	wp_add_global_styles_for_template_parts();
 }
 
 remove_action( 'wp_enqueue_scripts', 'wp_enqueue_global_styles' );

--- a/packages/block-library/src/template-part/index.php
+++ b/packages/block-library/src/template-part/index.php
@@ -153,7 +153,8 @@ function render_block_core_template_part( $attributes ) {
 	} else {
 		$html_tag = esc_attr( $attributes['tagName'] );
 	}
-	$wrapper_attributes = get_block_wrapper_attributes();
+	$template_part_class = 'wp-block-template-part-' . $attributes['slug'];
+	$wrapper_attributes  = get_block_wrapper_attributes( array( 'class' => $template_part_class ) );
 
 	return "<$html_tag $wrapper_attributes>" . str_replace( ']]>', ']]&gt;', $content ) . "</$html_tag>";
 }


### PR DESCRIPTION
## What?
Theme.json: adding capabilities to style blocks and elements at the scope level of a template part

:warning: This is a draft, working, up to this moment, only server side. So the rendered styles are rendered correctly on the frontend (public version of the posts) but not on the editor.

## Why?
To be able to style blocks or elements just for a particular template part and not for the entire site.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

## Testing Instructions
Add some settings in order to style elements or block inside a template part.

Let's say you have 2 template parts defined in your theme.json file:
```
	"templateParts": [
        {
            "area": "header",
            "name": "header"
        },
        {
            "area": "footer",
            "name": "footer"
        }
    ]
```
Then you are able to define styles for the blocks or elements inside each of those template parts previously defined.

Examples:
You can add `styles.templateParts.header.elements.link` to style link elements inside the header template part.
You can add `styles.templateParts.footer.blocks.core/site-title` to style site-title block inside the footer template part.

```
"styles": {
    "templateParts": {
        "header": {
            "blocks": {
                "core/site-title": {
                    "color": {
                        "text": "lemonchiffon"
                    }
                },
                "core/site-tagline": {
                    "color": {
                        "text": "cyan"
                    }
                }
            },
            "elements": {
                "link": {
                    "color": {
                        "text": "yellow"
                    }
                }
            }
        },
        "footer": {
            "blocks": {
                "core/site-title": {
                    "color": {
                        "text": "red"
                    }
                }
            }
        }
    },
}
```


Fixes: https://github.com/WordPress/gutenberg/issues/43347
