### PR TITLE
[Mobile] - Columns block - Add Unit tests

### DIFF
--- a/packages/block-editor/src/components/block-variation-picker/index.native.js
+++ b/packages/block-editor/src/components/block-variation-picker/index.native.js
@@ -85,6 +85,7 @@ function BlockVariationPicker( { isVisible, onClose, clientId, variations } ) {
 				title={ __( 'Select a layout' ) }
 				contentStyle={ styles.contentStyle }
 				leftButton={ leftButton }
+				testID="block-variation-modal"
 			>
 				<ScrollView
 					horizontal

--- a/packages/block-editor/src/components/button-block-appender/index.native.js
+++ b/packages/block-editor/src/components/button-block-appender/index.native.js
@@ -43,6 +43,7 @@ function ButtonBlockAppender( {
 				rootClientId={ rootClientId }
 				renderToggle={ ( { onToggle, disabled, isOpen } ) => (
 					<Button
+						testID="appender-button"
 						onClick={ onAddBlock || onToggle }
 						aria-expanded={ isOpen }
 						disabled={ disabled }

--- a/packages/block-library/src/columns/test/__snapshots__/edit.native.js.snap
+++ b/packages/block-library/src/columns/test/__snapshots__/edit.native.js.snap
@@ -202,7 +202,7 @@ exports[`Columns block when using the number of columns setting adds a column bl
 <!-- /wp:columns -->"
 `;
 
-exports[`Columns block when using the number of columns setting reaches the minimun limit of number of column blocks 1`] = `
+exports[`Columns block when using the number of columns setting reaches the minimum limit of number of column blocks 1`] = `
 "<!-- wp:columns -->
 <div class=\\"wp-block-columns\\"><!-- wp:column -->
 <div class=\\"wp-block-column\\"></div>

--- a/packages/block-library/src/columns/test/__snapshots__/edit.native.js.snap
+++ b/packages/block-library/src/columns/test/__snapshots__/edit.native.js.snap
@@ -1,0 +1,219 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Columns block adds a column block using the appender 1`] = `
+"<!-- wp:columns -->
+<div class=\\"wp-block-columns\\"><!-- wp:column -->
+<div class=\\"wp-block-column\\"></div>
+<!-- /wp:column -->
+
+<!-- wp:column -->
+<div class=\\"wp-block-column\\"></div>
+<!-- /wp:column -->
+
+<!-- wp:column -->
+<div class=\\"wp-block-column\\"></div>
+<!-- /wp:column --></div>
+<!-- /wp:columns -->"
+`;
+
+exports[`Columns block changes the vertical alignment on individual Column 1`] = `
+"<!-- wp:columns {\\"verticalAlignment\\":\\"top\\"} -->
+<div class=\\"wp-block-columns are-vertically-aligned-top\\"><!-- wp:column {\\"verticalAlignment\\":\\"bottom\\"} -->
+<div class=\\"wp-block-column is-vertically-aligned-bottom\\"></div>
+<!-- /wp:column -->
+
+<!-- wp:column {\\"verticalAlignment\\":\\"top\\"} -->
+<div class=\\"wp-block-column is-vertically-aligned-top\\"></div>
+<!-- /wp:column --></div>
+<!-- /wp:columns -->"
+`;
+
+exports[`Columns block changes vertical alignment on Columns 1`] = `
+"<!-- wp:columns {\\"verticalAlignment\\":\\"top\\"} -->
+<div class=\\"wp-block-columns are-vertically-aligned-top\\"><!-- wp:column {\\"verticalAlignment\\":\\"top\\"} -->
+<div class=\\"wp-block-column is-vertically-aligned-top\\"></div>
+<!-- /wp:column -->
+
+<!-- wp:column {\\"verticalAlignment\\":\\"top\\"} -->
+<div class=\\"wp-block-column is-vertically-aligned-top\\"></div>
+<!-- /wp:column --></div>
+<!-- /wp:columns -->"
+`;
+
+exports[`Columns block inserts block 1`] = `
+"<!-- wp:columns -->
+<div class=\\"wp-block-columns\\"><!-- wp:column {\\"width\\":\\"50%\\"} -->
+<div class=\\"wp-block-column\\" style=\\"flex-basis:50%\\"></div>
+<!-- /wp:column -->
+
+<!-- wp:column {\\"width\\":\\"50%\\"} -->
+<div class=\\"wp-block-column\\" style=\\"flex-basis:50%\\"></div>
+<!-- /wp:column --></div>
+<!-- /wp:columns -->"
+`;
+
+exports[`Columns block removes column with the remove button 1`] = `
+"<!-- wp:columns -->
+<div class=\\"wp-block-columns\\"><!-- wp:column -->
+<div class=\\"wp-block-column\\"></div>
+<!-- /wp:column --></div>
+<!-- /wp:columns -->"
+`;
+
+exports[`Columns block removes the only one left Column with the remove button 1`] = `
+"<!-- wp:paragraph -->
+<p></p>
+<!-- /wp:paragraph -->"
+`;
+
+exports[`Columns block sets current vertical alignment on new Columns 1`] = `
+"<!-- wp:columns {\\"verticalAlignment\\":\\"top\\"} -->
+<div class=\\"wp-block-columns are-vertically-aligned-top\\"><!-- wp:column {\\"verticalAlignment\\":\\"top\\"} -->
+<div class=\\"wp-block-column is-vertically-aligned-top\\"></div>
+<!-- /wp:column -->
+
+<!-- wp:column {\\"verticalAlignment\\":\\"top\\"} -->
+<div class=\\"wp-block-column is-vertically-aligned-top\\"></div>
+<!-- /wp:column -->
+
+<!-- wp:column {\\"verticalAlignment\\":\\"top\\"} -->
+<div class=\\"wp-block-column is-vertically-aligned-top\\"></div>
+<!-- /wp:column --></div>
+<!-- /wp:columns -->"
+`;
+
+exports[`Columns block when using columns percentage mechanism sets custom values correctly 1`] = `
+"<!-- wp:columns -->
+<div class=\\"wp-block-columns\\"><!-- wp:column {\\"width\\":\\"90%\\"} -->
+<div class=\\"wp-block-column\\" style=\\"flex-basis:90%\\"></div>
+<!-- /wp:column -->
+
+<!-- wp:column {\\"width\\":\\"55.5%\\"} -->
+<div class=\\"wp-block-column\\" style=\\"flex-basis:55.5%\\"></div>
+<!-- /wp:column --></div>
+<!-- /wp:columns -->"
+`;
+
+exports[`Columns block when using columns percentage mechanism updates the slider's input value 1`] = `
+"<!-- wp:columns -->
+<div class=\\"wp-block-columns\\"><!-- wp:column {\\"width\\":\\"55.6%\\"} -->
+<div class=\\"wp-block-column\\" style=\\"flex-basis:55.6%\\"></div>
+<!-- /wp:column -->
+
+<!-- wp:column -->
+<div class=\\"wp-block-column\\"></div>
+<!-- /wp:column -->
+
+<!-- wp:column -->
+<div class=\\"wp-block-column\\"></div>
+<!-- /wp:column --></div>
+<!-- /wp:columns -->"
+`;
+
+exports[`Columns block when using the columns layout picker sets the predefined percentages for 25 / 50 / 25 block 1`] = `
+"<!-- wp:columns -->
+<div class=\\"wp-block-columns\\"><!-- wp:column {\\"width\\":\\"25%\\"} -->
+<div class=\\"wp-block-column\\" style=\\"flex-basis:25%\\"></div>
+<!-- /wp:column -->
+
+<!-- wp:column {\\"width\\":\\"50%\\"} -->
+<div class=\\"wp-block-column\\" style=\\"flex-basis:50%\\"></div>
+<!-- /wp:column -->
+
+<!-- wp:column {\\"width\\":\\"25%\\"} -->
+<div class=\\"wp-block-column\\" style=\\"flex-basis:25%\\"></div>
+<!-- /wp:column --></div>
+<!-- /wp:columns -->"
+`;
+
+exports[`Columns block when using the columns layout picker sets the predefined percentages for 33 / 33 / 33 block 1`] = `
+"<!-- wp:columns -->
+<div class=\\"wp-block-columns\\"><!-- wp:column -->
+<div class=\\"wp-block-column\\"></div>
+<!-- /wp:column -->
+
+<!-- wp:column -->
+<div class=\\"wp-block-column\\"></div>
+<!-- /wp:column -->
+
+<!-- wp:column -->
+<div class=\\"wp-block-column\\"></div>
+<!-- /wp:column --></div>
+<!-- /wp:columns -->"
+`;
+
+exports[`Columns block when using the columns layout picker sets the predefined percentages for 33 / 66 block 1`] = `
+"<!-- wp:columns -->
+<div class=\\"wp-block-columns\\"><!-- wp:column {\\"width\\":\\"33.33%\\"} -->
+<div class=\\"wp-block-column\\" style=\\"flex-basis:33.33%\\"></div>
+<!-- /wp:column -->
+
+<!-- wp:column {\\"width\\":\\"66.66%\\"} -->
+<div class=\\"wp-block-column\\" style=\\"flex-basis:66.66%\\"></div>
+<!-- /wp:column --></div>
+<!-- /wp:columns -->"
+`;
+
+exports[`Columns block when using the columns layout picker sets the predefined percentages for 50 / 50 block 1`] = `
+"<!-- wp:columns -->
+<div class=\\"wp-block-columns\\"><!-- wp:column -->
+<div class=\\"wp-block-column\\"></div>
+<!-- /wp:column -->
+
+<!-- wp:column -->
+<div class=\\"wp-block-column\\"></div>
+<!-- /wp:column --></div>
+<!-- /wp:columns -->"
+`;
+
+exports[`Columns block when using the columns layout picker sets the predefined percentages for 66 / 33 block 1`] = `
+"<!-- wp:columns -->
+<div class=\\"wp-block-columns\\"><!-- wp:column {\\"width\\":\\"66.66%\\"} -->
+<div class=\\"wp-block-column\\" style=\\"flex-basis:66.66%\\"></div>
+<!-- /wp:column -->
+
+<!-- wp:column {\\"width\\":\\"33.33%\\"} -->
+<div class=\\"wp-block-column\\" style=\\"flex-basis:33.33%\\"></div>
+<!-- /wp:column --></div>
+<!-- /wp:columns -->"
+`;
+
+exports[`Columns block when using the columns layout picker sets the predefined percentages for 100 block 1`] = `
+"<!-- wp:columns -->
+<div class=\\"wp-block-columns\\"><!-- wp:column -->
+<div class=\\"wp-block-column\\"></div>
+<!-- /wp:column --></div>
+<!-- /wp:columns -->"
+`;
+
+exports[`Columns block when using the number of columns setting adds a column block when incrementing the value 1`] = `
+"<!-- wp:columns -->
+<div class=\\"wp-block-columns\\"><!-- wp:column -->
+<div class=\\"wp-block-column\\"></div>
+<!-- /wp:column -->
+
+<!-- wp:column -->
+<div class=\\"wp-block-column\\"></div>
+<!-- /wp:column -->
+
+<!-- wp:column -->
+<div class=\\"wp-block-column\\"></div>
+<!-- /wp:column --></div>
+<!-- /wp:columns -->"
+`;
+
+exports[`Columns block when using the number of columns setting reaches the minimun limit of number of column blocks 1`] = `
+"<!-- wp:columns -->
+<div class=\\"wp-block-columns\\"><!-- wp:column -->
+<div class=\\"wp-block-column\\"></div>
+<!-- /wp:column --></div>
+<!-- /wp:columns -->"
+`;
+
+exports[`Columns block when using the number of columns setting removes a column block when incrementing the value 1`] = `
+"<!-- wp:columns -->
+<div class=\\"wp-block-columns\\"><!-- wp:column -->
+<div class=\\"wp-block-column\\"></div>
+<!-- /wp:column --></div>
+<!-- /wp:columns -->"
+`;

--- a/packages/block-library/src/columns/test/__snapshots__/edit.native.js.snap
+++ b/packages/block-library/src/columns/test/__snapshots__/edit.native.js.snap
@@ -210,7 +210,7 @@ exports[`Columns block when using the number of columns setting reaches the mini
 <!-- /wp:columns -->"
 `;
 
-exports[`Columns block when using the number of columns setting removes a column block when incrementing the value 1`] = `
+exports[`Columns block when using the number of columns setting removes a column block when decrementing the value 1`] = `
 "<!-- wp:columns -->
 <div class=\\"wp-block-columns\\"><!-- wp:column -->
 <div class=\\"wp-block-column\\"></div>

--- a/packages/block-library/src/columns/test/edit.native.js
+++ b/packages/block-library/src/columns/test/edit.native.js
@@ -115,7 +115,7 @@ describe( 'Columns block', () => {
 			expect( getEditorHtml() ).toMatchSnapshot();
 		} );
 
-		it( 'reaches the minimun limit of number of column blocks', async () => {
+		it( 'reaches the minimum limit of number of column blocks', async () => {
 			const screen = await initializeEditor();
 			const { getByA11yLabel, getByTestId } = screen;
 

--- a/packages/block-library/src/columns/test/edit.native.js
+++ b/packages/block-library/src/columns/test/edit.native.js
@@ -93,7 +93,7 @@ describe( 'Columns block', () => {
 			expect( getEditorHtml() ).toMatchSnapshot();
 		} );
 
-		it( 'removes a column block when incrementing the value', async () => {
+		it( 'removes a column block when decrementing the value', async () => {
 			const screen = await initializeEditor( {
 				initialHtml: TWO_COLUMNS_BLOCK_HTML,
 			} );

--- a/packages/block-library/src/columns/test/edit.native.js
+++ b/packages/block-library/src/columns/test/edit.native.js
@@ -1,0 +1,432 @@
+/**
+ * External dependencies
+ */
+import {
+	addBlock,
+	fireEvent,
+	getEditorHtml,
+	initializeEditor,
+	openBlockSettings,
+	within,
+	getBlock,
+	waitFor,
+	dismissModal,
+} from 'test/helpers';
+
+/**
+ * WordPress dependencies
+ */
+import { getBlockTypes, unregisterBlockType } from '@wordpress/blocks';
+import { registerCoreBlocks } from '@wordpress/block-library';
+
+const TWO_COLUMNS_BLOCK_HTML = `<!-- wp:columns -->
+<div class="wp-block-columns"><!-- wp:column -->
+<div class="wp-block-column"></div>
+<!-- /wp:column -->
+<!-- wp:column -->
+<div class="wp-block-column"></div>
+<!-- /wp:column --></div>
+<!-- /wp:columns -->`;
+
+beforeAll( () => {
+	// Register all core blocks
+	registerCoreBlocks();
+} );
+
+afterAll( () => {
+	// Clean up registered blocks
+	getBlockTypes().forEach( ( block ) => {
+		unregisterBlockType( block.name );
+	} );
+} );
+
+describe( 'Columns block', () => {
+	it( 'inserts block', async () => {
+		const screen = await initializeEditor();
+
+		// Add block
+		await addBlock( screen, 'Columns' );
+
+		// Get block
+		const columnsBlock = await getBlock( screen, 'Columns' );
+		expect( columnsBlock ).toBeVisible();
+		expect( getEditorHtml() ).toMatchSnapshot();
+	} );
+
+	it( 'adds a column block using the appender', async () => {
+		const screen = await initializeEditor( {
+			initialHtml: TWO_COLUMNS_BLOCK_HTML,
+		} );
+
+		// Get block
+		const columnsBlock = await getBlock( screen, 'Columns' );
+		fireEvent.press( columnsBlock );
+
+		// Add a new column
+		const appenderButton =
+			within( columnsBlock ).getByTestId( 'appender-button' );
+		fireEvent.press( appenderButton );
+
+		expect( getEditorHtml() ).toMatchSnapshot();
+	} );
+
+	describe( 'when using the number of columns setting', () => {
+		it( 'adds a column block when incrementing the value', async () => {
+			const screen = await initializeEditor( {
+				initialHtml: TWO_COLUMNS_BLOCK_HTML,
+			} );
+			const { getByA11yLabel } = screen;
+
+			// Get block
+			const columnsBlock = await getBlock( screen, 'Columns' );
+			fireEvent.press( columnsBlock );
+
+			// Open block settings
+			await openBlockSettings( screen );
+
+			// Update the number of columns by adding one
+			const columnsControl = getByA11yLabel( /Number of columns/ );
+			fireEvent( columnsControl, 'accessibilityAction', {
+				nativeEvent: { actionName: 'increment' },
+			} );
+
+			expect( getEditorHtml() ).toMatchSnapshot();
+		} );
+
+		it( 'removes a column block when incrementing the value', async () => {
+			const screen = await initializeEditor( {
+				initialHtml: TWO_COLUMNS_BLOCK_HTML,
+			} );
+			const { getByA11yLabel } = screen;
+
+			// Wait for the block to be created.
+			const columnsBlock = await getBlock( screen, 'Columns' );
+			fireEvent.press( columnsBlock );
+
+			// Open block settings
+			await openBlockSettings( screen );
+
+			// Update the number of columns by removing one
+			const columnsControl = getByA11yLabel( /Number of columns/ );
+			fireEvent( columnsControl, 'accessibilityAction', {
+				nativeEvent: { actionName: 'decrement' },
+			} );
+
+			expect( getEditorHtml() ).toMatchSnapshot();
+		} );
+
+		it( 'reaches the minimun limit of number of column blocks', async () => {
+			const screen = await initializeEditor();
+			const { getByA11yLabel, getByTestId } = screen;
+
+			// Add block
+			await addBlock( screen, 'Columns' );
+
+			// Wait for the variations modal to be visible
+			await waitFor(
+				() => getByTestId( 'block-variation-modal' ).props.isVisible
+			);
+
+			// Select a column variation
+			const blockVariationModal = getByTestId( 'block-variation-modal' );
+			await waitFor( () => blockVariationModal.props.isVisible );
+			const threeColumnLayout =
+				within( blockVariationModal ).getByA11yLabel(
+					/33 \/ 33 \/ 33 block/
+				);
+			fireEvent.press( threeColumnLayout );
+
+			// Get block
+			const columnsBlock = await getBlock( screen, 'Columns' );
+			fireEvent.press( columnsBlock );
+
+			// Open block settings
+			await openBlockSettings( screen );
+
+			// Update the number of columns by adding one
+			const columnsControl = getByA11yLabel( /Number of columns/ );
+			fireEvent( columnsControl, 'accessibilityAction', {
+				nativeEvent: { actionName: 'increment' },
+			} );
+
+			// Press the decrement button 5 times to remove all columns but one
+			for ( let index = 0; index < 5; index++ ) {
+				fireEvent( columnsControl, 'accessibilityAction', {
+					nativeEvent: { actionName: 'decrement' },
+				} );
+			}
+
+			expect( getEditorHtml() ).toMatchSnapshot();
+		} );
+	} );
+
+	it( 'removes column with the remove button', async () => {
+		const screen = await initializeEditor( {
+			initialHtml: TWO_COLUMNS_BLOCK_HTML,
+		} );
+		const { getByA11yLabel } = screen;
+
+		// Get block
+		const columnsBlock = await getBlock( screen, 'Columns' );
+		fireEvent.press( columnsBlock );
+
+		// Get the first column
+		const firstColumnBlock = await getBlock( screen, 'Column' );
+		fireEvent.press( firstColumnBlock );
+
+		// Open block actions menu
+		const blockActionsButton = getByA11yLabel( /Open Block Actions Menu/ );
+		fireEvent.press( blockActionsButton );
+
+		// Delete block
+		const deleteButton = getByA11yLabel( /Remove block/ );
+		fireEvent.press( deleteButton );
+
+		expect( getEditorHtml() ).toMatchSnapshot();
+	} );
+
+	it( 'removes the only one left Column with the remove button', async () => {
+		const screen = await initializeEditor( {
+			initialHtml: TWO_COLUMNS_BLOCK_HTML,
+		} );
+		const { getByA11yLabel } = screen;
+
+		// Get block
+		const columnsBlock = await getBlock( screen, 'Columns' );
+		fireEvent.press( columnsBlock );
+
+		// Get the first column
+		const firstColumnBlock = await getBlock( screen, 'Column' );
+		fireEvent.press( firstColumnBlock );
+
+		// Open block actions menu
+		let blockActionsButton = getByA11yLabel( /Open Block Actions Menu/ );
+		fireEvent.press( blockActionsButton );
+
+		// Delete block
+		let deleteButton = getByA11yLabel( /Remove block/ );
+		fireEvent.press( deleteButton );
+
+		// Get the only left column
+		const lastColumnBlock = await getBlock( screen, 'Column' );
+		fireEvent.press( lastColumnBlock );
+
+		// Open block actions menu
+		blockActionsButton = getByA11yLabel( /Open Block Actions Menu/ );
+		fireEvent.press( blockActionsButton );
+
+		// Delete block
+		deleteButton = getByA11yLabel( /Remove block/ );
+		fireEvent.press( deleteButton );
+
+		expect( getEditorHtml() ).toMatchSnapshot();
+	} );
+
+	it( 'changes vertical alignment on Columns', async () => {
+		const screen = await initializeEditor( {
+			initialHtml: TWO_COLUMNS_BLOCK_HTML,
+		} );
+		const { getByA11yLabel } = screen;
+
+		// Get block
+		const columnsBlock = await getBlock( screen, 'Columns' );
+		fireEvent.press( columnsBlock );
+
+		// Open vertical alignment menu
+		const verticalAlignmentButton = getByA11yLabel(
+			/Change vertical alignment/
+		);
+		fireEvent.press( verticalAlignmentButton );
+
+		// Get Align top button
+		const verticalTopAlignmentButton = getByA11yLabel( /Align top/ );
+		fireEvent.press( verticalTopAlignmentButton );
+
+		expect( getEditorHtml() ).toMatchSnapshot();
+	} );
+
+	it( 'changes the vertical alignment on individual Column', async () => {
+		const screen = await initializeEditor( {
+			initialHtml: TWO_COLUMNS_BLOCK_HTML,
+		} );
+		const { getByA11yLabel } = screen;
+
+		// Get block
+		const columnsBlock = await getBlock( screen, 'Columns' );
+		fireEvent.press( columnsBlock );
+
+		// Open vertical alignment menu
+		const verticalAlignmentButton = getByA11yLabel(
+			/Change vertical alignment/
+		);
+		fireEvent.press( verticalAlignmentButton );
+
+		// Get Align top button
+		const verticalTopAlignmentButton = getByA11yLabel( /Align top/ );
+		fireEvent.press( verticalTopAlignmentButton );
+
+		// Get the first column
+		const firstColumnBlock = await getBlock( screen, 'Column' );
+		fireEvent.press( firstColumnBlock );
+
+		// Open vertical alignment menu
+		fireEvent.press( verticalAlignmentButton );
+
+		// Get Align bottom button
+		const verticalBottomAlignmentButton = getByA11yLabel( /Align bottom/ );
+		fireEvent.press( verticalBottomAlignmentButton );
+
+		expect( getEditorHtml() ).toMatchSnapshot();
+	} );
+
+	it( 'sets current vertical alignment on new Columns', async () => {
+		const screen = await initializeEditor( {
+			initialHtml: TWO_COLUMNS_BLOCK_HTML,
+		} );
+		const { getByA11yLabel } = screen;
+
+		// Get block
+		const columnsBlock = await getBlock( screen, 'Columns' );
+		fireEvent.press( columnsBlock );
+
+		// Open vertical alignment menu
+		const verticalAlignmentButton = getByA11yLabel(
+			/Change vertical alignment/
+		);
+		fireEvent.press( verticalAlignmentButton );
+
+		// Get Align top button
+		const verticalTopAlignmentButton = getByA11yLabel( /Align top/ );
+		fireEvent.press( verticalTopAlignmentButton );
+
+		// Add a new column
+		const appenderButton =
+			within( columnsBlock ).getByTestId( 'appender-button' );
+		fireEvent.press( appenderButton );
+
+		expect( getEditorHtml() ).toMatchSnapshot();
+	} );
+
+	describe( 'when using columns percentage mechanism', () => {
+		it( "updates the slider's input value", async () => {
+			const screen = await initializeEditor();
+			const { getByA11yLabel, getByTestId } = screen;
+
+			// Add block
+			await addBlock( screen, 'Columns' );
+
+			// Wait for the variations modal to be visible
+			await waitFor(
+				() => getByTestId( 'block-variation-modal' ).props.isVisible
+			);
+
+			// Select a column variation
+			const blockVariationModal = getByTestId( 'block-variation-modal' );
+			await waitFor( () => blockVariationModal.props.isVisible );
+			const threeColumnLayout =
+				within( blockVariationModal ).getByA11yLabel(
+					/33 \/ 33 \/ 33 block/
+				);
+			fireEvent.press( threeColumnLayout );
+
+			// Get the first column
+			const firstColumnBlock = await getBlock( screen, 'Column' );
+			fireEvent.press( firstColumnBlock );
+
+			// Open block settings
+			await openBlockSettings( screen );
+
+			// Get width control
+			const widthControl = getByA11yLabel( /Width. Value is/ );
+			fireEvent.press( within( widthControl ).getByText( '33.3' ) );
+			const widthTextInput =
+				within( widthControl ).getByDisplayValue( '33.3' );
+			fireEvent.changeText( widthTextInput, '55.55555' );
+
+			expect( getEditorHtml() ).toMatchSnapshot();
+		} );
+
+		it( 'sets custom values correctly', async () => {
+			const screen = await initializeEditor( {
+				initialHtml: TWO_COLUMNS_BLOCK_HTML,
+			} );
+			const { getByA11yLabel, getByTestId } = screen;
+
+			// Get block
+			const columnsBlock = await getBlock( screen, 'Columns' );
+			fireEvent.press( columnsBlock );
+
+			// Get the first column
+			const firstColumnBlock = await getBlock( screen, 'Column' );
+			fireEvent.press( firstColumnBlock );
+
+			// Open block settings
+			await openBlockSettings( screen );
+
+			// Set custom width value for the first column
+			let widthControl = getByA11yLabel( /Width. Value is/ );
+			fireEvent.press( within( widthControl ).getByText( '50' ) );
+			let widthTextInput =
+				within( widthControl ).getByDisplayValue( '50' );
+			fireEvent.changeText( widthTextInput, '90' );
+
+			// Dismiss settings
+			await dismissModal( getByTestId( 'block-settings-modal' ) );
+
+			// Get the Second column
+			const secondColumnBlock = await getBlock( screen, 'Column', {
+				rowIndex: 2,
+			} );
+			fireEvent.press( secondColumnBlock );
+
+			// Open block settings
+			await openBlockSettings( screen );
+
+			// Set custom width value for the second column
+			widthControl = getByA11yLabel( /Width. Value is/ );
+			fireEvent.press( within( widthControl ).getByText( '50' ) );
+			widthTextInput = within( widthControl ).getByDisplayValue( '50' );
+			fireEvent.changeText( widthTextInput, '55.5' );
+
+			expect( getEditorHtml() ).toMatchSnapshot();
+		} );
+	} );
+
+	describe( 'when using the columns layout picker', () => {
+		const testData = [
+			[ '100 block' ],
+			[ '50 / 50 block' ],
+			[ '33 / 66 block' ],
+			[ '66 / 33 block' ],
+			[ '33 / 33 / 33 block' ],
+			[ '25 / 50 / 25 block' ],
+		];
+
+		test.each( testData )(
+			'sets the predefined percentages for %s',
+			async ( layout ) => {
+				const screen = await initializeEditor();
+				const { getByTestId } = screen;
+
+				// Add block
+				await addBlock( screen, 'Columns' );
+
+				// Wait for the variations modal to be visible
+				await waitFor(
+					() => getByTestId( 'block-variation-modal' ).props.isVisible
+				);
+
+				// Select a column variation
+				const blockVariationModal = getByTestId(
+					'block-variation-modal'
+				);
+				await waitFor( () => blockVariationModal.props.isVisible );
+				const columnLayout =
+					within( blockVariationModal ).getByA11yLabel( layout );
+				fireEvent.press( columnLayout );
+
+				expect( getEditorHtml() ).toMatchSnapshot();
+			}
+		);
+	} );
+} );

--- a/test/native/__mocks__/styleMock.js
+++ b/test/native/__mocks__/styleMock.js
@@ -171,4 +171,7 @@ module.exports = {
 	'wp-block-list-item__list-item-placeholder': {
 		color: '#87a6bc',
 	},
+	innerAppender: {
+		marginLeft: 8,
+	},
 };


### PR DESCRIPTION
**Related PRs**: https://github.com/wordpress-mobile/test-cases/pull/121

## What?
We are adding some unit tests for the Columns block.

## Why?
These tests were done manually in each release so now we are moving some of them into unit tests.

## How?
By adding the following tests:

```
  Columns block
    inserts block
    adds a column block using the appender
    removes column with the remove button
    removes the only one left Column with the remove button
    changes vertical alignment on Columns
    changes the vertical alignment on individual Column
    sets current vertical alignment on new Columns
    
    when using the number of columns setting
        adds a column block when incrementing the value
        removes a column block when decrementing the value
        reaches the minimum limit of number of column blocks
    when using columns percentage mechanism
        updates the slider's input value
        sets custom values correctly
    when using the columns layout picker
        sets the predefined percentages for 100 block
        sets the predefined percentages for 50 / 50 block
        sets the predefined percentages for 33 / 66 block
        sets the predefined percentages for 66 / 33 block
        sets the predefined percentages for 33 / 33 / 33 block
        sets the predefined percentages for 25 / 50 / 25 block
```

## Testing Instructions
CI checks should pass

## Screenshots or screencast <!-- if applicable -->
N/A