### PR TITLE
Update `templateLock` value from `noContent` to `contentOnly`

### DIFF
--- a/docs/reference-guides/block-api/block-templates.md
+++ b/docs/reference-guides/block-api/block-templates.md
@@ -115,7 +115,7 @@ add_action( 'init', 'myplugin_register_template' );
 
 _Options:_
 
--   `noContent` — prevents all operations. Additionally, the block types that don't have content are hidden from the list view and can't gain focus within the block list. Unlike the other lock types, this is not overrideable by children.
+-   `contentOnly` — prevents all operations. Additionally, the block types that don't have content are hidden from the list view and can't gain focus within the block list. Unlike the other lock types, this is not overrideable by children.
 -   `all` — prevents all operations. It is not possible to insert new blocks, move existing blocks, or delete blocks.
 -   `insert` — prevents inserting or removing blocks, but allows moving existing blocks.
 

--- a/packages/block-editor/src/components/block-inspector/index.js
+++ b/packages/block-editor/src/components/block-inspector/index.js
@@ -158,7 +158,7 @@ const BlockInspector = ( { showNoBlockSelectedMessage = true } ) => {
 			selectedBlockName: _selectedBlockName,
 			blockType: _blockType,
 			topLevelLockedBlock:
-				getTemplateLock( _selectedBlockClientId ) === 'noContent'
+				getTemplateLock( _selectedBlockClientId ) === 'contentOnly'
 					? _selectedBlockClientId
 					: __unstableGetContentLockingParent(
 							_selectedBlockClientId

--- a/packages/block-editor/src/components/block-list/block.js
+++ b/packages/block-editor/src/components/block-list/block.js
@@ -118,7 +118,7 @@ function BlockListBlock( {
 					),
 				hasContentLockedParent: _hasContentLockedParent,
 				isContentLocking:
-					getTemplateLock( clientId ) === 'noContent' &&
+					getTemplateLock( clientId ) === 'contentOnly' &&
 					! _hasContentLockedParent,
 				isTemporarilyEditingAsBlocks:
 					__unstableGetTemporarilyEditingAsBlocks() === clientId,

--- a/packages/block-editor/src/components/block-lock/use-block-lock.js
+++ b/packages/block-editor/src/components/block-lock/use-block-lock.js
@@ -38,7 +38,7 @@ export default function useBlockLock( clientId ) {
 				canMove,
 				canRemove,
 				canLock: canLockBlockType( getBlockName( clientId ) ),
-				isContentLocked: getTemplateLock( clientId ) === 'noContent',
+				isContentLocked: getTemplateLock( clientId ) === 'contentOnly',
 				isLocked: ! canEdit || ! canMove || ! canRemove,
 			};
 		},

--- a/packages/block-editor/src/components/inner-blocks/README.md
+++ b/packages/block-editor/src/components/inner-blocks/README.md
@@ -125,12 +125,12 @@ Template locking of `InnerBlocks` is similar to [Custom Post Type templates lock
 Template locking allows locking the `InnerBlocks` area for the current template.
 _Options:_
 
--   `noContent` — prevents all operations. Additionally, the block types that don't have content are hidden from the list view and can't gain focus within the block list. Unlike the other lock types, this is not overrideable by children.
+-   `contentOnly` — prevents all operations. Additionally, the block types that don't have content are hidden from the list view and can't gain focus within the block list. Unlike the other lock types, this is not overrideable by children.
 -   `'all'` — prevents all operations. It is not possible to insert new blocks. Move existing blocks or delete them.
 -   `'insert'` — prevents inserting or removing blocks, but allows moving existing ones.
 -   `false` — prevents locking from being applied to an `InnerBlocks` area even if a parent block contains locking. ( Boolean )
 
-If locking is not set in an `InnerBlocks` area: the locking of the parent `InnerBlocks` area is used. Note that `noContent` can't be overriden: it's present, the `templateLock` value of any children is ignored.
+If locking is not set in an `InnerBlocks` area: the locking of the parent `InnerBlocks` area is used. Note that `contentOnly` can't be overriden: it's present, the `templateLock` value of any children is ignored.
 
 If the block is a top level block: the locking of the Custom Post Type is used.
 

--- a/packages/block-editor/src/components/inner-blocks/use-inner-block-template-sync.js
+++ b/packages/block-editor/src/components/inner-blocks/use-inner-block-template-sync.js
@@ -19,7 +19,7 @@ import { store as blockEditorStore } from '../../store';
  * This hook makes sure that a block's inner blocks stay in sync with the given
  * block "template". The template is a block hierarchy to which inner blocks must
  * conform. If the blocks get "out of sync" with the template and the template
- * is meant to be locked (e.g. templateLock = "all" or templateLock = "noContent"),
+ * is meant to be locked (e.g. templateLock = "all" or templateLock = "contentOnly"),
  * then we replace the inner blocks with the correct value after synchronizing it with the template.
  *
  * @param {string}  clientId                       The block client ID.
@@ -52,11 +52,11 @@ export default function useInnerBlockTemplateSync(
 	const existingTemplate = useRef( null );
 	useLayoutEffect( () => {
 		// Only synchronize innerBlocks with template if innerBlocks are empty
-		// or a locking "all" or "noContent" exists directly on the block.
+		// or a locking "all" or "contentOnly" exists directly on the block.
 		if (
 			innerBlocks.length === 0 ||
 			templateLock === 'all' ||
-			templateLock === 'noContent'
+			templateLock === 'contentOnly'
 		) {
 			const hasTemplateChanged = ! isEqual(
 				template,

--- a/packages/block-editor/src/components/inner-blocks/use-nested-settings-update.js
+++ b/packages/block-editor/src/components/inner-blocks/use-nested-settings-update.js
@@ -69,7 +69,7 @@ export default function useNestedSettingsUpdate(
 		const newSettings = {
 			allowedBlocks: _allowedBlocks,
 			templateLock:
-				templateLock === undefined || parentLock === 'noContent'
+				templateLock === undefined || parentLock === 'contentOnly'
 					? parentLock
 					: templateLock,
 		};

--- a/packages/block-editor/src/components/list-view/branch.js
+++ b/packages/block-editor/src/components/list-view/branch.js
@@ -99,7 +99,7 @@ function ListViewBranch( props ) {
 			return !! (
 				parentId &&
 				select( blockEditorStore ).getTemplateLock( parentId ) ===
-					'noContent'
+					'contentOnly'
 			);
 		},
 		[ parentId ]

--- a/packages/block-editor/src/components/use-block-drop-zone/index.js
+++ b/packages/block-editor/src/components/use-block-drop-zone/index.js
@@ -101,7 +101,7 @@ export default function useBlockDropZone( {
 			} = select( blockEditorStore );
 			const templateLock = getTemplateLock( targetRootClientId );
 			return (
-				[ 'all', 'noContent' ].some(
+				[ 'all', 'contentOnly' ].some(
 					( lock ) => lock === templateLock
 				) ||
 				__unstableHasActiveBlockOverlayActive( targetRootClientId ) ||

--- a/packages/block-editor/src/hooks/content-lock-ui.js
+++ b/packages/block-editor/src/hooks/content-lock-ui.js
@@ -72,7 +72,7 @@ export const withBlockControls = createHigherOrderComponent(
 			__unstableSetTemporarilyEditingAsBlocks,
 		} = useDispatch( blockEditorStore );
 		const isContentLocked =
-			! isLockedByParent && templateLock === 'noContent';
+			! isLockedByParent && templateLock === 'contentOnly';
 		const {
 			__unstableMarkNextChangeAsNotPersistent,
 			updateBlockAttributes,
@@ -81,11 +81,11 @@ export const withBlockControls = createHigherOrderComponent(
 		const stopEditingAsBlock = useCallback( () => {
 			__unstableMarkNextChangeAsNotPersistent();
 			updateBlockAttributes( props.clientId, {
-				templateLock: 'noContent',
+				templateLock: 'contentOnly',
 			} );
 			updateBlockListSettings( props.clientId, {
 				...getBlockListSettings( props.clientId ),
-				templateLock: 'noContent',
+				templateLock: 'contentOnly',
 			} );
 			updateSettings( { focusMode: focusModeToRevert.current } );
 			__unstableSetTemporarilyEditingAsBlocks();

--- a/packages/block-editor/src/store/selectors.js
+++ b/packages/block-editor/src/store/selectors.js
@@ -2696,7 +2696,7 @@ export const __unstableGetContentLockingParent = createSelector(
 		let result;
 		while ( !! state.blocks.parents[ current ] ) {
 			current = state.blocks.parents[ current ];
-			if ( getTemplateLock( state, current ) === 'noContent' ) {
+			if ( getTemplateLock( state, current ) === 'contentOnly' ) {
 				result = current;
 			}
 		}

--- a/packages/block-library/src/column/block.json
+++ b/packages/block-library/src/column/block.json
@@ -19,7 +19,7 @@
 		},
 		"templateLock": {
 			"type": [ "string", "boolean" ],
-			"enum": [ "all", "insert", "noContent", false ]
+			"enum": [ "all", "insert", "contentOnly", false ]
 		}
 	},
 	"supports": {

--- a/packages/block-library/src/cover/block.json
+++ b/packages/block-library/src/cover/block.json
@@ -73,7 +73,7 @@
 		},
 		"templateLock": {
 			"type": [ "string", "boolean" ],
-			"enum": [ "all", "insert", "noContent", false ]
+			"enum": [ "all", "insert", "contentOnly", false ]
 		}
 	},
 	"usesContext": [ "postId", "postType" ],

--- a/packages/block-library/src/group/block.json
+++ b/packages/block-library/src/group/block.json
@@ -14,7 +14,7 @@
 		},
 		"templateLock": {
 			"type": [ "string", "boolean" ],
-			"enum": [ "all", "insert", "noContent", false ]
+			"enum": [ "all", "insert", "contentOnly", false ]
 		},
 		"layout": {
 			"type": "object",


### PR DESCRIPTION
## What?

This PR updates the `templateLock`s value called `noContent` by `contentOnly`.

## Why?

It aims to create more clarity about what it really does. See [comment](https://github.com/WordPress/gutenberg/pull/43037#issuecomment-1245544763) and [original thread](https://github.com/WordPress/gutenberg/pull/43037#discussion_r950131396).

## How?

By updating all the places in which `noContent` is used.

## Testing Instructions

Verify that it works as before.

- Paste the following content in the post editor (use the code editor):

```html
<!-- wp:group {"templateLock":"contentOnly","backgroundColor":"pale-cyan-blue","layout":{"type":"default"}} -->
<div class="wp-block-group has-pale-cyan-blue-background-color has-background"><!-- wp:heading {"style":{"typography":{"fontStyle":"normal","fontWeight":"700"}},"backgroundColor":"pale-pink","fontSize":"x-large"} -->
<h2 class="has-pale-pink-background-color has-background has-x-large-font-size" style="font-style:normal;font-weight:700">Heading</h2>
<!-- /wp:heading -->

<!-- wp:paragraph {"backgroundColor":"vivid-red","textColor":"secondary"} -->
<p class="has-secondary-color has-vivid-red-background-color has-text-color has-background">Paragraph</p>
<!-- /wp:paragraph -->

<!-- wp:image {"align":"center","width":239,"height":239,"sizeSlug":"large","style":{"border":{"width":"18px"}}} -->
<figure class="wp-block-image aligncenter size-large is-resized has-custom-border"><img src="https://s.w.org/style/images/about/WordPress-logotype-wmark.png" alt="" style="border-width:18px" width="239" height="239"/></figure>
<!-- /wp:image -->

<!-- wp:spacer {"height":"28px"} -->
<div style="height:28px" aria-hidden="true" class="wp-block-spacer"></div>
<!-- /wp:spacer -->

<!-- wp:group {"backgroundColor":"secondary"} -->
<div class="wp-block-group has-secondary-background-color has-background"><!-- wp:separator -->
<hr class="wp-block-separator has-alpha-channel-opacity"/>
<!-- /wp:separator -->

<!-- wp:spacer {"height":"55px"} -->
<div style="height:55px" aria-hidden="true" class="wp-block-spacer"></div>
<!-- /wp:spacer -->

<!-- wp:pullquote {"gradient":"blush-bordeaux"} -->
<figure class="wp-block-pullquote has-blush-bordeaux-gradient-background has-background"><blockquote><p>End quote inside another group</p></blockquote></figure>
<!-- /wp:pullquote --></div>
<!-- /wp:group --></div>
<!-- /wp:group -->
```

- In the editor, verify that
  - no blocks can't be added
  - existing content can be modified
  - contents without content aren't reachable (keyboard, mouse)
- In the list view, verify that only the root group block is rendered
- In the block inspector, verify that shows a list of the blocks with content within the root group block.
- Verify that clicking the "Modify" button in the root group block allows to edit all the blocks (list view shows them all, blocks without content are reachable via keyboard and mouse, etc).
