### PR TITLE
Spacing presets: fix bug with unlinked not applying if non int slugs used

### DIFF
--- a/packages/block-editor/src/components/spacing-sizes-control/utils.js
+++ b/packages/block-editor/src/components/spacing-sizes-control/utils.js
@@ -211,12 +211,5 @@ export function isValuesDefined( values ) {
 	if ( values === undefined || values === null ) {
 		return false;
 	}
-	return ! isEmpty(
-		Object.values( values ).filter(
-			// Switching units when input is empty causes values only
-			// containing units. This gives false positive on mixed values
-			// unless filtered.
-			( value ) => !! value && /\d/.test( value )
-		)
-	);
+	return ! isEmpty( Object.values( values ).filter( ( value ) => !! value ) );
 }


### PR DESCRIPTION
## What?
Removes the check for digits from the check to see it spacing values are set and just checks for a defined value

## Why?
Fixes: #44133 - if a theme uses string only slugs for spacing sizes the link/unlink option doesn't work as expected - control shows linked when returning to block even if unlinked values are set

## How?
Removes the regex check for `\d`

## Testing Instructions
 - In a theme add the following to the theme.json `settings.spacing` section:

```json
"spacing": {
	"spacingScale": {
		"steps": 0
	},
	"spacingSizes": [
		{
			"name": "XS",
			"size": "0.5rem",
			"slug": "x-small"
		},
		{
			"name": "Small",
			"size": "1rem",
			"slug": "small"
		},
		{
			"name": "Medium",
			"size": "1.5rem",
			"slug": "medium"
		},
		{
			"name": "Large",
			"size": "clamp(1.5rem, 1.364vw + 1.159rem, 2.25rem)",
			"slug": "large"
		},
		{
			"name": "XL",
			"size": "clamp(2.25rem, 1.364vw + 1.909rem, 3rem)",
			"slug": "x-large"
		},
		{
			"name": "2XL",
			"size": "clamp(3rem, 3.603vw + 2.091rem, 5rem)",
			"slug": "xx-large"
		},
		{
			"name": "3XL",
			"size": "clamp(5rem, 3.636vw + 4.091rem, 7rem)",
			"slug": "xxx-large"
		}
	]
}
```
 - Add a paragraph block and set different spacing for each side
 - Unfocus and refocus the block and check that the padding control shows unlinked

## Screenshots or screencast 

Before:

https://user-images.githubusercontent.com/3629020/190017600-e9dda0e9-9e6d-4205-8445-bdc1b6274a91.mp4

After:

https://user-images.githubusercontent.com/3629020/190017672-35b50fda-d569-40d9-87f7-a0cc0d069ca5.mp4




