### PR TITLE
Temporarily remove group useEffect to test performance issue

### DIFF
--- a/packages/block-library/src/group/edit.js
+++ b/packages/block-library/src/group/edit.js
@@ -70,16 +70,6 @@ function GroupEdit( { attributes, setAttributes, clientId } ) {
 		}
 	);
 
-	const { __unstableMarkNextChangeAsNotPersistent } =
-		useDispatch( blockEditorStore );
-	const { type: layoutType = null } = layout;
-	useEffect( () => {
-		if ( layoutType ) {
-			__unstableMarkNextChangeAsNotPersistent();
-			setAttributes( { layout: { ...layout, type: layoutType } } );
-		}
-	}, [ layoutType ] );
-
 	return (
 		<>
 			<InspectorControls __experimentalGroup="advanced">


### PR DESCRIPTION
Just for debugging performance issue

<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->

## Screenshots or screencast <!-- if applicable -->
