### PR TITLE
Spacing presets: Modify the styling of the input controls when in unlinked mode in order to better differentiate sides

### DIFF
--- a/packages/block-editor/src/components/spacing-sizes-control/index.js
+++ b/packages/block-editor/src/components/spacing-sizes-control/index.js
@@ -1,4 +1,9 @@
 /**
+ * External dependencies
+ */
+import classnames from 'classnames';
+
+/**
  * WordPress dependencies
  */
 import { useState } from '@wordpress/element';
@@ -68,7 +73,12 @@ export default function SpacingSizesControl( {
 	};
 
 	return (
-		<fieldset role="region" className="component-spacing-sizes-control">
+		<fieldset
+			role="region"
+			className={ classnames( 'component-spacing-sizes-control', {
+				'is-unlinked': ! isLinked,
+			} ) }
+		>
 			<Text as="legend">{ label }</Text>
 			{ ! hasOneSide && (
 				<LinkedButton onClick={ toggleLinked } isLinked={ isLinked } />

--- a/packages/block-editor/src/components/spacing-sizes-control/index.js
+++ b/packages/block-editor/src/components/spacing-sizes-control/index.js
@@ -8,7 +8,7 @@ import classnames from 'classnames';
  */
 import { useState } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
-import { __experimentalText as Text } from '@wordpress/components';
+import { BaseControl } from '@wordpress/components';
 
 /**
  * Internal dependencies
@@ -79,7 +79,9 @@ export default function SpacingSizesControl( {
 				'is-unlinked': ! isLinked,
 			} ) }
 		>
-			<Text as="legend">{ label }</Text>
+			<BaseControl.VisualLabel as="legend">
+				{ label }
+			</BaseControl.VisualLabel>
 			{ ! hasOneSide && (
 				<LinkedButton onClick={ toggleLinked } isLinked={ isLinked } />
 			) }

--- a/packages/block-editor/src/components/spacing-sizes-control/spacing-input-control.js
+++ b/packages/block-editor/src/components/spacing-sizes-control/spacing-input-control.js
@@ -9,12 +9,12 @@ import classnames from 'classnames';
 import { useState, useMemo } from '@wordpress/element';
 import { useSelect } from '@wordpress/data';
 import {
+	BaseControl,
 	Button,
 	RangeControl,
 	CustomSelectControl,
 	__experimentalUnitControl as UnitControl,
 	__experimentalHStack as HStack,
-	__experimentalText as Text,
 	__experimentalUseCustomUnits as useCustomUnits,
 	__experimentalParseQuantityAndUnitFromRawValue as parseQuantityAndUnitFromRawValue,
 } from '@wordpress/components';
@@ -167,21 +167,21 @@ export default function SpacingInputControl( {
 		<>
 			{ side !== 'all' && (
 				<HStack className="components-spacing-sizes-control__side-labels">
-					<Text className="components-spacing-sizes-control__side-label">
+					<BaseControl.VisualLabel className="components-spacing-sizes-control__side-label">
 						{ LABELS[ side ] }
-					</Text>
+					</BaseControl.VisualLabel>
 
 					{ showHint && (
-						<Text className="components-spacing-sizes-control__hint-single">
+						<BaseControl.VisualLabel className="components-spacing-sizes-control__hint-single">
 							{ currentValueHint }
-						</Text>
+						</BaseControl.VisualLabel>
 					) }
 				</HStack>
 			) }
 			{ side === 'all' && showHint && (
-				<Text className="components-spacing-sizes-control__hint-all">
+				<BaseControl.VisualLabel className="components-spacing-sizes-control__hint-all">
 					{ currentValueHint }
-				</Text>
+				</BaseControl.VisualLabel>
 			) }
 
 			{ ! disableCustomSpacingSizes && (

--- a/packages/block-editor/src/components/spacing-sizes-control/spacing-input-control.js
+++ b/packages/block-editor/src/components/spacing-sizes-control/spacing-input-control.js
@@ -256,6 +256,7 @@ export default function SpacingInputControl( {
 					marks={ marks }
 					label={ ariaLabel }
 					hideLabelFromVision={ true }
+					__nextHasNoMarginBottom={ true }
 				/>
 			) }
 			{ ! showRangeControl && ! showCustomValueControl && (

--- a/packages/block-editor/src/components/spacing-sizes-control/style.scss
+++ b/packages/block-editor/src/components/spacing-sizes-control/style.scss
@@ -2,6 +2,7 @@
 	display: grid;
 	grid-template-columns: auto 1fr auto;
 	align-items: center;
+	grid-template-rows: 25px auto;
 }
 
 .component-spacing-sizes-control {
@@ -101,11 +102,6 @@
 	.components-spacing-sizes-control__range-control {
 		grid-column: span 3;
 		height: 40px;
-		margin-bottom: $grid-unit-20;
-	}
-
-	.components-range-control__wrapper {
-		margin-bottom: 0;
 	}
 
 	.components-range-control__mark {

--- a/packages/block-editor/src/components/spacing-sizes-control/style.scss
+++ b/packages/block-editor/src/components/spacing-sizes-control/style.scss
@@ -24,11 +24,8 @@
 	}
 
 	&.is-unlinked {
-		.components-spacing-sizes-control__side-label {
-			margin-left: $grid-unit-10;
-		}
 		.components-range-control.components-spacing-sizes-control__range-control {
-			margin: -$grid-unit-10 0 0 $grid-unit-10;
+			margin: -$grid-unit-10 0 0 0;
 		}
 		.components-unit-control-wrapper {
 			margin: 0 0 $grid-unit-10 $grid-unit-10;
@@ -36,14 +33,12 @@
 	}
 
 	.components-spacing-sizes-control__hint-single {
-		margin-top: 0;
-		margin-left: 0;
+		margin: 0;
 	}
 
 	.components-spacing-sizes-control__hint-single,
 	.components-spacing-sizes-control__hint-all {
 		color: $gray-700;
-		font-size: 12px;
 	}
 
 	.components-spacing-sizes-control__hint-all {
@@ -127,7 +122,7 @@
 	.components-spacing-sizes-control__side-label {
 		grid-column: 1 / 1;
 		justify-self: left;
-		font-size: 12px;
+		margin-bottom: 0;
 	}
 
 	.components-spacing-sizes-control__custom-select-control {

--- a/packages/block-editor/src/components/spacing-sizes-control/style.scss
+++ b/packages/block-editor/src/components/spacing-sizes-control/style.scss
@@ -19,21 +19,19 @@
 
 	.components-spacing-sizes-control__side-labels {
 		grid-column: 1 / 1;
-		min-height: 30px;
+		margin-bottom: $grid-unit-10;
 		justify-content: left;
+	}
+
+	.components-spacing-sizes-control__side-label {
+		grid-column: 1 / 1;
+		justify-self: left;
 	}
 
 	&.is-unlinked {
 		.components-range-control.components-spacing-sizes-control__range-control {
-			margin: -$grid-unit-10 0 0 0;
+			margin: -$grid-unit-10 0 $grid-unit-20 0;
 		}
-		.components-unit-control-wrapper {
-			margin: 0 0 $grid-unit-10 $grid-unit-10;
-		}
-	}
-
-	.components-spacing-sizes-control__hint-single {
-		margin: 0;
 	}
 
 	.components-spacing-sizes-control__hint-single,
@@ -82,7 +80,6 @@
 	.components-spacing-sizes-control__custom-value-range {
 		grid-column: span 2;
 		margin-left: $grid-unit-10;
-		padding-right: $grid-unit-10;
 		height: 30px;
 	}
 
@@ -92,8 +89,8 @@
 
 	.components-spacing-sizes-control__range-control {
 		grid-column: span 3;
-		padding-right: $grid-unit-10;
-		height: 36px;
+		height: 40px;
+		margin-bottom: $grid-unit-20;
 	}
 
 	.components-range-control__wrapper {
@@ -117,12 +114,6 @@
 
 	[class*="ThumbWrapper-thumbColor"] {
 		z-index: 3;
-	}
-
-	.components-spacing-sizes-control__side-label {
-		grid-column: 1 / 1;
-		justify-self: left;
-		margin-bottom: 0;
 	}
 
 	.components-spacing-sizes-control__custom-select-control {

--- a/packages/block-editor/src/components/spacing-sizes-control/style.scss
+++ b/packages/block-editor/src/components/spacing-sizes-control/style.scss
@@ -19,14 +19,14 @@
 
 	.components-base-control__label {
 		margin-bottom: 0;
-		height: 16px;
+		height: $grid-unit-20;
 	}
 
 	.components-spacing-sizes-control__side-labels {
 		grid-column: 1 / 1;
 		justify-content: left;
-		height: 16px;
-		margin-top: 12px;
+		height: $grid-unit-20;
+		margin-top: $grid-unit-15;
 	}
 
 	.components-spacing-sizes-control__side-label {
@@ -37,7 +37,7 @@
 
 	&.is-unlinked {
 		.components-range-control.components-spacing-sizes-control__range-control {
-			margin-top: 12px;
+			margin-top: $grid-unit-15;
 		}
 	}
 
@@ -60,6 +60,11 @@
 		grid-row: 1 / 1;
 		justify-self: end;
 		padding: 0;
+		&.is-small.has-icon {
+			padding: 0;
+			min-width: $icon-size;
+			height: $grid-unit-20;
+		}
 	}
 
 	.component-spacing-sizes-control__linked-button ~ .components-spacing-sizes-control__custom-toggle-all {
@@ -69,15 +74,11 @@
 	.components-spacing-sizes-control__custom-toggle-single {
 		grid-column: 3 / 3;
 		justify-self: end;
-	}
-
-	.components-spacing-sizes-control__custom-toggle-all,
-	.components-spacing-sizes-control__custom-toggle-single {
 		&.is-small.has-icon {
 			padding: 0;
 			min-width: $icon-size;
-			height: 16px;
-			margin-top: 12px;
+			height: $grid-unit-20;
+			margin-top: $grid-unit-15;
 		}
 	}
 

--- a/packages/block-editor/src/components/spacing-sizes-control/style.scss
+++ b/packages/block-editor/src/components/spacing-sizes-control/style.scss
@@ -1,7 +1,6 @@
 .tools-panel-item-spacing {
 	display: grid;
 	grid-template-columns: auto 1fr auto;
-	grid-row-gap: $grid-unit-05;
 	align-items: center;
 }
 
@@ -27,6 +26,7 @@
 		grid-column: 1 / 1;
 		justify-content: left;
 		height: 16px;
+		margin-top: 12px;
 	}
 
 	.components-spacing-sizes-control__side-label {
@@ -37,7 +37,7 @@
 
 	&.is-unlinked {
 		.components-range-control.components-spacing-sizes-control__range-control {
-			margin: 0 0 $grid-unit-10 0;
+			margin-top: 12px;
 		}
 	}
 
@@ -76,6 +76,8 @@
 		&.is-small.has-icon {
 			padding: 0;
 			min-width: $icon-size;
+			height: 16px;
+			margin-top: 12px;
 		}
 	}
 

--- a/packages/block-editor/src/components/spacing-sizes-control/style.scss
+++ b/packages/block-editor/src/components/spacing-sizes-control/style.scss
@@ -17,26 +17,35 @@
 		align-self: center;
 	}
 
+	.components-base-control__label {
+		margin-bottom: 0;
+		height: 16px;
+	}
+
 	.components-spacing-sizes-control__side-labels {
 		grid-column: 1 / 1;
-		margin-bottom: $grid-unit-10;
 		justify-content: left;
+		height: 16px;
+		margin-top: $grid-unit-05;
+		margin-bottom: $grid-unit-10;
 	}
 
 	.components-spacing-sizes-control__side-label {
 		grid-column: 1 / 1;
 		justify-self: left;
+		margin-bottom: 0;
 	}
 
 	&.is-unlinked {
 		.components-range-control.components-spacing-sizes-control__range-control {
-			margin: -$grid-unit-10 0 $grid-unit-20 0;
+			margin: -$grid-unit-10 0 $grid-unit-10 0;
 		}
 	}
 
 	.components-spacing-sizes-control__hint-single,
 	.components-spacing-sizes-control__hint-all {
 		color: $gray-700;
+		margin-bottom: 0;
 	}
 
 	.components-spacing-sizes-control__hint-all {

--- a/packages/block-editor/src/components/spacing-sizes-control/style.scss
+++ b/packages/block-editor/src/components/spacing-sizes-control/style.scss
@@ -2,6 +2,7 @@
 	display: grid;
 	grid-template-columns: auto 1fr auto;
 	grid-row-gap: $grid-unit-05;
+	align-items: center;
 }
 
 .component-spacing-sizes-control {
@@ -26,8 +27,6 @@
 		grid-column: 1 / 1;
 		justify-content: left;
 		height: 16px;
-		margin-top: $grid-unit-05;
-		margin-bottom: $grid-unit-10;
 	}
 
 	.components-spacing-sizes-control__side-label {
@@ -38,7 +37,7 @@
 
 	&.is-unlinked {
 		.components-range-control.components-spacing-sizes-control__range-control {
-			margin: -$grid-unit-10 0 $grid-unit-10 0;
+			margin: 0 0 $grid-unit-10 0;
 		}
 	}
 

--- a/packages/block-editor/src/components/spacing-sizes-control/style.scss
+++ b/packages/block-editor/src/components/spacing-sizes-control/style.scss
@@ -23,6 +23,18 @@
 		justify-content: left;
 	}
 
+	&.is-unlinked {
+		.components-spacing-sizes-control__side-label {
+			margin-left: $grid-unit-10;
+		}
+		.components-range-control.components-spacing-sizes-control__range-control {
+			margin: -$grid-unit-10 0 0 $grid-unit-10;
+		}
+		.components-unit-control-wrapper {
+			margin: 0 0 $grid-unit-10 $grid-unit-10;
+		}
+	}
+
 	.components-spacing-sizes-control__hint-single {
 		margin-top: 0;
 		margin-left: 0;
@@ -86,7 +98,7 @@
 	.components-spacing-sizes-control__range-control {
 		grid-column: span 3;
 		padding-right: $grid-unit-10;
-		height: 30px;
+		height: 36px;
 	}
 
 	.components-range-control__wrapper {
@@ -113,7 +125,6 @@
 	}
 
 	.components-spacing-sizes-control__side-label {
-		margin-right: $grid-unit-05;
 		grid-column: 1 / 1;
 		justify-self: left;
 		font-size: 12px;


### PR DESCRIPTION
## What?
Modifies CSS on spacing presets control to better differentiate which side a control relates to. Also adds a slight indent to better indicate which dimension setting they relate to

## Why?
Currently the control is equidistant from the above and below labels so hard to tell which one it relates to.
Fixes: #44121

## How?
Adds some additional margins and padding

## Testing Instructions
 - Add a Group and set unlinked Padding and Margins and check that controls display as expected for both preset and custom values

## Screenshots or screencast 

Before:

<img width="276" alt="before" src="https://user-images.githubusercontent.com/3629020/190057767-d85dd1ac-ee79-4699-a3e2-33d412ffdd53.png">

After:

<img width="273" alt="Screen Shot 2022-09-29 at 4 01 15 PM" src="https://user-images.githubusercontent.com/3629020/192929284-6aaab035-55d1-4539-9180-4827e1e1c71d.png">




