### PR TITLE
Show Letter Spacing in Global Styles -> Typography -> Headings

### DIFF
--- a/packages/edit-site/src/components/global-styles/typography-panel.js
+++ b/packages/edit-site/src/components/global-styles/typography-panel.js
@@ -53,12 +53,16 @@ function useHasAppearanceControl( name ) {
 	return hasFontStyles || hasFontWeights;
 }
 
-function useHasLetterSpacingControl( name ) {
+function useHasLetterSpacingControl( name, element ) {
+	const setting = useSetting( 'typography.letterSpacing', name )[ 0 ];
+	if ( ! setting ) {
+		return false;
+	}
+	if ( ! name && element === 'heading' ) {
+		return true;
+	}
 	const supports = getSupportedGlobalStylesPanels( name );
-	return (
-		useSetting( 'typography.letterSpacing', name )[ 0 ] &&
-		supports.includes( 'letterSpacing' )
-	);
+	return supports.includes( 'letterSpacing' );
 }
 
 export default function TypographyPanel( { name, element } ) {
@@ -84,7 +88,7 @@ export default function TypographyPanel( { name, element } ) {
 		supports.includes( 'fontWeight' );
 	const hasLineHeightEnabled = useHasLineHeightControl( name );
 	const hasAppearanceControl = useHasAppearanceControl( name );
-	const hasLetterSpacingControl = useHasLetterSpacingControl( name );
+	const hasLetterSpacingControl = useHasLetterSpacingControl( name, element );
 
 	/* Disable font size controls when the option to style all headings is selected. */
 	let hasFontSizeEnabled = supports.includes( 'fontSize' );


### PR DESCRIPTION
## What?
Makes _Letter spacing_ (`LetterSpacingControl`) appear in Global Styles → Typography → Headings.

I split this out from https://github.com/WordPress/gutenberg/pull/43356.

## Why?
So that the Typography panel in Global Styles looks closer to what was designed in Figma. See https://github.com/WordPress/gutenberg/issues/34345#issuecomment-1217390408.

## How?
_Letter spacing_ was already set up in Global Styles, just not enabled for headings at the global level. To fix this I added a special condition to `useHasLetterSpacingControl`.

## Testing Instructions
1. Go to Editor → Global Styles → Typography.
2. Check that _Letter spacing_ appears in the Heading section but no other sections, and that modifying them works.
2. Go to Global Styles → Blocks.
3. Check that _Letter spacing_ appears in the Typography panel for blocks that support these controls, and that modifying them works.

## Screenshots 
| Before | After |
| - | - |
| <img width="293" alt="Screen Shot 2022-09-14 at 14 57 58" src="https://user-images.githubusercontent.com/612155/190063221-ed75e910-28e5-49e5-b9e6-984fa813883e.png"> | <img width="294" alt="Screen Shot 2022-09-14 at 14 57 40" src="https://user-images.githubusercontent.com/612155/190063224-7be4de0c-6ae6-4028-a190-54470bb894c6.png"> |