### PR TITLE
Fix alignments for children of Query block.

### DIFF
--- a/packages/block-library/src/query/edit/index.js
+++ b/packages/block-library/src/query/edit/index.js
@@ -56,7 +56,9 @@ export function QueryContent( {
 		return { themeSupportsLayout: getSettings()?.supportsLayout };
 	}, [] );
 	const defaultLayout = useSetting( 'layout' ) || {};
-	const usedLayout = !! layout && layout.inherit ? defaultLayout : layout;
+	const usedLayout = ! layout?.type
+		? { ...defaultLayout, ...layout, type: 'default' }
+		: { ...defaultLayout, ...layout };
 	const blockProps = useBlockProps();
 	const innerBlocksProps = useInnerBlocksProps( blockProps, {
 		template: TEMPLATE,


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Children of the Query block weren't being passed all the data on their parent's layout, so they weren't getting the full set of alignment controls when Query had "Inner blocks use content width" set.

Fixes an [issue reported on TT3](https://github.com/WordPress/twentytwentythree/issues/164#issuecomment-1246126615).

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->

1. Add a Query block to a template;
2. Check that the child Post Template block has "full" and "wide" alignment options;
3. Check that setting Post Template to "wide" alignment works correctly in the editor and front end.

## Screenshots or screencast <!-- if applicable -->
<img width="1068" alt="Screen Shot 2022-09-14 at 3 39 37 pm" src="https://user-images.githubusercontent.com/8096000/190068639-27f6db4c-aca3-461c-a70e-3e6b82832c0c.png">
