### PR TITLE
Text Selection in Safari: Try new fix for recent version

### DIFF
--- a/packages/block-editor/src/components/block-list/style.scss
+++ b/packages/block-editor/src/components/block-list/style.scss
@@ -51,6 +51,11 @@
 		}
 	}
 
+	// Hide the selection indicator on .block-editor-block-list__layout, else Safari will show it stacked.
+	.has-multi-selection &::selection {
+		background: transparent;
+	}
+
 	.block-editor-block-list__block.is-highlighted::after {
 		box-shadow: 0 0 0 var(--wp-admin-border-width-focus) var(--wp-admin-theme-color);
 		outline: $border-width solid transparent;
@@ -129,7 +134,7 @@
 	// `unset` only when selected, it has to start out unset.
 	&.is-selected,
 	&.has-block-overlay,
-	&.is-multi-selected,
+	&.is-multi-selected:not(.is-partially-selected),
 	&.is-highlighted {
 		position: relative;
 	}

--- a/packages/block-editor/src/components/block-list/style.scss
+++ b/packages/block-editor/src/components/block-list/style.scss
@@ -123,7 +123,16 @@
 }
 
 .block-editor-block-list__layout .block-editor-block-list__block {
-	position: relative;
+	// Due to changes in how Safari 16 renders text selection, it has
+	// become sensitive to `position: relative;`. If it is set initially
+	// it will cause the selection to render incorrectly. It cannot be
+	// `unset` only when selected, it has to start out unset.
+	&.is-selected,
+	&.has-block-overlay,
+	&.is-multi-selected,
+	&.is-highlighted {
+		position: relative;
+	}
 
 	// Re-enable text-selection on editable blocks.
 	user-select: text;

--- a/packages/block-editor/src/components/block-list/style.scss
+++ b/packages/block-editor/src/components/block-list/style.scss
@@ -13,6 +13,12 @@
 .block-editor-block-list__layout {
 	position: relative;
 
+	// Hide selections on this element, otherwise Safari will include it stacked
+	// under your actual selection.
+	&::selection {
+		background: transparent;
+	}
+
 	// The primary indicator of selection in text is the native selection marker.
 	// When selecting multiple blocks, we provide an additional selection indicator.
 	.block-editor-block-list__block.is-multi-selected:not(.is-partially-selected),
@@ -128,28 +134,27 @@
 }
 
 .block-editor-block-list__layout .block-editor-block-list__block {
-	// Due to changes in how Safari 16 renders text selection, it has
-	// become sensitive to `position: relative;`. If it is set initially
-	// it will cause the selection to render incorrectly. It cannot be
-	// `unset` only when selected, it has to start out unset.
-	&.is-selected,
-	&.has-block-overlay,
-	&.is-multi-selected:not(.is-partially-selected),
-	&.is-highlighted {
-		position: relative;
-	}
+	position: relative;
 
 	// Re-enable text-selection on editable blocks.
 	user-select: text;
 
-	// Hide the select style pseudo element as it interferes with the style.
+	// Hide the select style pseudo element as otherwise it gets shwon as "selected" in Safari.
 	&.is-partially-selected::after {
-		height: 0;
+		// By positioning this pseudo element outside the boundaries of the parent block,
+		// when partially selected it hides the pseudo element selection in Safari.
+		top: -0.5px;
+		right: -0.5px;
+		bottom: -0.5px;
+		left: -0.5px;
 	}
 
 	&.is-highlighted::after,
 	&.is-highlighted ~ .is-multi-selected::after {
-		height: auto;
+		top: 0;
+		right: 0;
+		bottom: 0;
+		left: 0;
 	}
 
 	// Break long strings of text without spaces so they don't overflow the block.


### PR DESCRIPTION
## What?

Followup to #43313. A very recent update to the Safari browser has reintroduced the original issue of full-width selection indicators appearing between blocks. This PR dives in and applies a new fix. 

In trunk, selecting text looks like this:
![safari in trunk](https://user-images.githubusercontent.com/1204802/190126231-d92709bc-5d2e-4f31-9beb-65f0e376fae6.gif)

With this PR applied, the selection looks better and more correct in terms of what you've actually selected:

![safari after](https://user-images.githubusercontent.com/1204802/190126316-2b00cd3f-7ec7-4fbf-a48d-351ec90689c1.gif)

## How?

It seems the Safari selection indicator has become sensitive to the presence of `position: relative;` for the purposes of drawing the indicator. For context, that property is set so that we can draw the blue focus rectangle around the selected block in a pseudo element. 

But if set initially, Safari will draw an incorrect selection indicator. It is unfortunately not enough to apply `position: static;` or `unset` or anything like that, the property must simply not be set at all. This is a little curious, and if you have any insights as to why this might be, I'd appreciate it.

Nevertheless, setting the value contextually as this PR does, appears to still allow us to paint the pseudo elements as we need to, without breaking the selection.

## Testing Instructions

* Use a theme with a centered main column, such as TT2 or TT3
* Use Safari, ideally the latest version (17614.1.25.9.10 or newer)
* Select across paragraphs and headings in the editor

The selection marker should look correct.