### PR TITLE
Polyfill requestIdleCallback in safari for better performance

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17650,7 +17650,8 @@
 		"@wordpress/priority-queue": {
 			"version": "file:packages/priority-queue",
 			"requires": {
-				"@babel/runtime": "^7.16.0"
+				"@babel/runtime": "^7.16.0",
+				"requestidlecallback": "^0.3.0"
 			}
 		},
 		"@wordpress/project-management-automation": {
@@ -51998,6 +51999,11 @@
 					"dev": true
 				}
 			}
+		},
+		"requestidlecallback": {
+			"version": "0.3.0",
+			"resolved": "https://registry.npmjs.org/requestidlecallback/-/requestidlecallback-0.3.0.tgz",
+			"integrity": "sha512-TWHFkT7S9p7IxLC5A1hYmAYQx2Eb9w1skrXmQ+dS1URyvR8tenMLl4lHbqEOUnpEYxNKpkVMXUgknVpBZWXXfQ=="
 		},
 		"require-directory": {
 			"version": "2.1.1",

--- a/packages/priority-queue/package.json
+++ b/packages/priority-queue/package.json
@@ -28,7 +28,8 @@
 	"types": "build-types",
 	"sideEffects": false,
 	"dependencies": {
-		"@babel/runtime": "^7.16.0"
+		"@babel/runtime": "^7.16.0",
+		"requestidlecallback": "^0.3.0"
 	},
 	"publishConfig": {
 		"access": "public"

--- a/packages/priority-queue/src/request-idle-callback.js
+++ b/packages/priority-queue/src/request-idle-callback.js
@@ -1,4 +1,9 @@
 /**
+ * External dependencies
+ */
+import 'requestidlecallback';
+
+/**
  * @typedef {( timeOrDeadline: IdleDeadline | number ) => void} Callback
  */
 
@@ -12,7 +17,7 @@ export function createRequestIdleCallback() {
 		};
 	}
 
-	return window.requestIdleCallback || window.requestAnimationFrame;
+	return window.requestIdleCallback;
 }
 
 export default createRequestIdleCallback();


### PR DESCRIPTION
## What and Why?

the goal of this PR is to improve the perceived performance in Safari (Inserter, patterns, previews). 

In a lot of places in Gutenberg we use `requestIdleCallback` in order to delay some computations to the moment the browser is idle (no user input, no higher priority tasks being run). The problem in Safari is that `requestIdleCallback` is not available, so we were using `requestAnimationFrame` as a fallback.

So between two low-priority tasks, we run `requestAnimationFrame` which basically waits 40ms because of the task is executed if the browser is not doing any rendering. This means that if we have a long list of low-priority tasks waiting, we're going to wait a long time before the actual tasks run. This is visible in the inserter, where the patterns freeze the inserter and we want a long time when switching categories...

Note, that it's impossible to polyfill requestIdleCallback properly to solve this but the PR uses a community-developed polyfill that is doing a better job than our naive fallback to `requestAnimationFrame`.

**Testing instructions**

I've tested this by using this benchmark on the console:

```
export function runBenchmark( total = 1000 ) {
	const testQueue = wp.priorityQueue.createQueue();
	const start = Date.now();
	for ( let i = 1; i <= total; i++ ) {
		testQueue.add( {}, () => {
			if ( i === total ) {
				console.log( 'Duration: ' + ( Date.now() - start ) );
			}
		} );
	}

	return testQueue;
}

runBenchmark( 1000 ); // you can change the number of tasks to run.
```

The function above prints the duration it takes to run X low-priority tasks. You can try running it on your own in the console and comparing the results with trunk. You can also try navigating the inserter in this branch and trunk and see if you notice any difference.

The downside of this polyfill is that high-priority tasks might be delayed a bit more than with using `requestAnimationFrame`. The best solution is to find a compromise between doing nothing (which means leaving the browser handle the higher priority tasks) and running the list of pending low-priority tasks. I think we went a bit too far in the "high priority" tasks with `requestAnimationFrame` initially and this polyfill restores the balance a bit.