### PR TITLE
Try: Improve partial selections.

### DIFF
--- a/packages/block-editor/src/components/block-list/use-block-props/use-block-class-names.js
+++ b/packages/block-editor/src/components/block-list/use-block-props/use-block-class-names.js
@@ -33,7 +33,6 @@ export function useBlockClassNames( clientId ) {
 				getSettings,
 				hasSelectedInnerBlock,
 				isTyping,
-				__unstableIsFullySelected,
 				__unstableSelectionHasUnmergeableBlock,
 			} = select( blockEditorStore );
 			const { outlineMode } = getSettings();
@@ -53,7 +52,6 @@ export function useBlockClassNames( clientId ) {
 				'is-multi-selected': isMultiSelected,
 				'is-partially-selected':
 					isMultiSelected &&
-					! __unstableIsFullySelected() &&
 					! __unstableSelectionHasUnmergeableBlock(),
 				'is-reusable': isReusableBlock( getBlockType( name ) ),
 				'is-dragging': isDragging,


### PR DESCRIPTION
## What?

Fixes #44153. 

**This PR needs a double check, as I'm touching code I don't fully understand. You can consider it a proof of concept.**

By removing `__unstableIsFullySelected` from the criteria of when `is-partially-selected` is applied, the text selection behavior appears to be less flickery and stable when moving from paragraph to paragraph, and into an image:

![fix partial selections](https://user-images.githubusercontent.com/1204802/190156021-bc269fb3-c6e5-4005-97c8-f7025fc29eda.gif)

It isn't entirely clear what `__unstableIsFullySelected` does to me, so this needs a look.