### PR TITLE
Update hook's names from `global_styles_*` to `theme_json_*`

### DIFF
--- a/docs/reference-guides/filters/global-styles-filters.md
+++ b/docs/reference-guides/filters/global-styles-filters.md
@@ -1,11 +1,11 @@
 # Global Styles Filters
 
-WordPress 6.1 has introduced some server-side filters to hook into the data provided to Global Styles & Settings:
+WordPress 6.1 has introduced some server-side filters to hook into the `theme.json` data provided at the different data layers:
 
-- `global_styles_default`: hooks into the default data provided by WordPress
-- `global_styles_blocks`: hooks into the data provided by the blocks
-- `global_styles_theme`: hooks into the data provided by the theme
-- `global_styles_user`: hooks into the data provided by the user
+- `theme_json_default`: hooks into the default data provided by WordPress
+- `theme_json_blocks`: hooks into the data provided by the blocks
+- `theme_json_theme`: hooks into the data provided by the theme
+- `theme_json_user`: hooks into the data provided by the user
 
 Each filter receives an instance of the `WP_Theme_JSON_Data` class with the data for the respective layer. To provide new data, the filter callback needs to use the `update_with( $new_data )` method, where `$new_data` is a valid `theme.json`-like structure. As with any `theme.json`, the new data needs to declare which `version` of the `theme.json` is using, so it can correctly be migrated to the runtime one, should it be different.
 
@@ -14,7 +14,7 @@ _Example:_
 This is how to pass a new color palette for the theme and disable the text color UI:
 
 ```php
-function filter_global_styles_theme( $theme_json ){
+function filter_theme_json_theme( $theme_json ){
 	$new_data = array(
 		'version'  => 2,
 		'settings' => array(
@@ -38,5 +38,5 @@ function filter_global_styles_theme( $theme_json ){
 
 	return $theme_json->update_with( $new_data );
 }
-add_filter( 'global_styles_theme', 'filter_global_styles_theme' );
+add_filter( 'theme_json_theme', 'filter_theme_json_theme' );
 ```

--- a/lib/compat/wordpress-6.1/class-wp-theme-json-resolver-6-1.php
+++ b/lib/compat/wordpress-6.1/class-wp-theme-json-resolver-6-1.php
@@ -61,7 +61,7 @@ class WP_Theme_JSON_Resolver_6_1 extends WP_Theme_JSON_Resolver_6_0 {
 		 *
 		 * @param WP_Theme_JSON_Data_Gutenberg Class to access and update the underlying data.
 		 */
-		$theme_json   = apply_filters( 'global_styles_default', new WP_Theme_JSON_Data_Gutenberg( $config, 'default' ) );
+		$theme_json   = apply_filters( 'theme_json_default', new WP_Theme_JSON_Data_Gutenberg( $config, 'default' ) );
 		$config       = $theme_json->get_data();
 		static::$core = new WP_Theme_JSON_Gutenberg( $config, 'default' );
 
@@ -92,7 +92,7 @@ class WP_Theme_JSON_Resolver_6_1 extends WP_Theme_JSON_Resolver_6_0 {
 				 *
 				 * @param WP_Theme_JSON_Data_Gutenberg Class to access and update the underlying data.
 				 */
-				$theme_json = apply_filters( 'global_styles_user', new WP_Theme_JSON_Data_Gutenberg( $config, 'custom' ) );
+				$theme_json = apply_filters( 'theme_json_user', new WP_Theme_JSON_Data_Gutenberg( $config, 'custom' ) );
 				$config     = $theme_json->get_data();
 				return new WP_Theme_JSON_Gutenberg( $config, 'custom' );
 			}
@@ -114,7 +114,7 @@ class WP_Theme_JSON_Resolver_6_1 extends WP_Theme_JSON_Resolver_6_0 {
 		 *
 		 * @param WP_Theme_JSON_Data_Gutenberg Class to access and update the underlying data.
 		 */
-		$theme_json   = apply_filters( 'global_styles_user', new WP_Theme_JSON_Data_Gutenberg( $config, 'custom' ) );
+		$theme_json   = apply_filters( 'theme_json_user', new WP_Theme_JSON_Data_Gutenberg( $config, 'custom' ) );
 		$config       = $theme_json->get_data();
 		static::$user = new WP_Theme_JSON_Gutenberg( $config, 'custom' );
 

--- a/lib/experimental/class-wp-theme-json-resolver-gutenberg.php
+++ b/lib/experimental/class-wp-theme-json-resolver-gutenberg.php
@@ -44,7 +44,7 @@ class WP_Theme_JSON_Resolver_Gutenberg extends WP_Theme_JSON_Resolver_6_1 {
 			 *
 			 * @param WP_Theme_JSON_Data_Gutenberg Class to access and update the underlying data.
 			 */
-			$theme_json      = apply_filters( 'global_styles_theme', new WP_Theme_JSON_Data_Gutenberg( $theme_json_data, 'theme' ) );
+			$theme_json      = apply_filters( 'theme_json_theme', new WP_Theme_JSON_Data_Gutenberg( $theme_json_data, 'theme' ) );
 			$theme_json_data = $theme_json->get_data();
 			static::$theme   = new WP_Theme_JSON_Gutenberg( $theme_json_data );
 
@@ -141,7 +141,7 @@ class WP_Theme_JSON_Resolver_Gutenberg extends WP_Theme_JSON_Resolver_6_1 {
 		 *
 		 * @param WP_Theme_JSON_Data_Gutenberg Class to access and update the underlying data.
 		 */
-		$theme_json = apply_filters( 'global_styles_blocks', new WP_Theme_JSON_Data_Gutenberg( $config, 'core' ) );
+		$theme_json = apply_filters( 'theme_json_blocks', new WP_Theme_JSON_Data_Gutenberg( $config, 'core' ) );
 		$config     = $theme_json->get_data();
 
 		// Core here means it's the lower level part of the styles chain.


### PR DESCRIPTION
## What?

In https://github.com/WordPress/gutenberg/pull/44015 we've added a few hooks to filter the theme.json data at the different layer levels. This PR proposes that we rename them:

- `global_styles_default` => `theme_json_default`
- `global_styles_blocks` => `theme_json_blocks`
- `global_styles_theme` => `theme_json_theme`
- `global_styles_user` => `theme_json_user`

## Why?

Because we're not filtering "global styles" but a specific part of it: the `theme.json` data it takes as input. The new names make this clearer. We also leave the `global_styles_` prefix free for the future, in case we want to offer other kind of filters.

## How?

- Renames the filters.
- Updates the docs.

## Testing Instructions

Use the filters to modify some of the data. For example, this is how the theme data can be modified:

```php
<?php

function filter_theme_json_theme( $theme_json ){
        $new_data = array(
                'version'  => 2,
                'settings' => array(
                        'color' => array(
                                'text'  => false, /* disable text color UI */
                                'palette'    => array( /* New palette */
                                        array(
                                                'slug'  => 'foreground',
                                                'color' => 'red',
                                                'name'  => 'Foreground',
                                        ),
                                ),
                        ),
                ),
        );
        return $theme_json->update_with( $new_data );
}
add_filter( 'theme_json_theme', 'filter_theme_json_theme' );
```
