### PR TITLE
Query Loop block: Add 8 new patterns

### DIFF
--- a/lib/compat/wordpress-6.0/block-patterns-update.php
+++ b/lib/compat/wordpress-6.0/block-patterns-update.php
@@ -435,7 +435,7 @@ function gutenberg_register_gutenberg_patterns() {
 			<!-- /wp:query -->
 
 			<!-- wp:paragraph {"textColor":"white"} -->
-			<p class="has-white-color has-text-color"><strong>More Posts</strong></p>
+			<p class="has-white-color has-text-color"><strong>' . _x( 'More Posts', 'block pattern sample content', 'gutenberg' ) . '</strong></p>
 			<!-- /wp:paragraph -->
 
 			<!-- wp:query {"query":{"perPage":6,"pages":0,"offset":0,"postType":"post","order":"desc","orderBy":"date","author":"","search":"","exclude":[],"sticky":"exclude","inherit":false},"displayLayout":{"type":"flex","columns":3}} -->

--- a/lib/compat/wordpress-6.0/block-patterns-update.php
+++ b/lib/compat/wordpress-6.0/block-patterns-update.php
@@ -442,7 +442,7 @@ function gutenberg_register_gutenberg_patterns() {
 			<div class="wp-block-query"><!-- wp:post-template -->
 			<!-- wp:group {"layout":{"inherit":false},"style":{"spacing":{"padding":{"top":"0px","right":"0px","bottom":"var:preset|spacing|40","left":"0px"}}}} -->
 			<div class="wp-block-group" style="padding-top:0px;padding-right:0px;padding-bottom:var(--wp--preset--spacing--40);padding-left:0px"><!-- wp:separator {"backgroundColor":"white"} -->
-			<hr class="wp-block-separator has-text-color has-white-color has-alpha-channel-opacity has-white-background-color has-background"/>
+			<hr class="wp-block-separator has-text-color has-white-color has-alpha-channel-opacity has-white-background-color has-background is-style-wide"/>
 			<!-- /wp:separator -->
 
 			<!-- wp:post-title {"isLink":true,"style":{"elements":{"link":{"color":{"text":"var:preset|color|white"}}}}} /--></div>
@@ -450,6 +450,34 @@ function gutenberg_register_gutenberg_patterns() {
 			<!-- /wp:post-template --></div>
 			<!-- /wp:query --></div>
 			<!-- /wp:group -->',
+		),
+		'query-post-and-date-list'                   => array(
+			'title'      => _x( 'Post and date list', 'Block pattern title', 'gutenberg' ),
+			'blockTypes' => array( 'core/query' ),
+			'categories' => array( 'query' ),
+			'content'    => '<!-- wp:group {"style":{"spacing":{"margin":{"top":"14vh","bottom":"0px"}}},"layout":{"inherit":true,"type":"constrained"}} -->
+<div class="wp-block-group" style="margin-top:14vh;margin-bottom:0px"><!-- wp:query {"query":{"perPage":"99","pages":0,"offset":0,"postType":"post","order":"desc","orderBy":"date","author":"","search":"","exclude":[],"sticky":"","inherit":false}} -->
+<div class="wp-block-query"><!-- wp:post-template -->
+<!-- wp:group {"style":{"spacing":{"margin":{"top":"0px","bottom":"0px"},"blockGap":"0px","padding":{"top":"0px","right":"0px","bottom":"0px","left":"0px"}}}} -->
+<div class="wp-block-group" style="margin-top:0px;margin-bottom:0px;padding-top:0px;padding-right:0px;padding-bottom:0px;padding-left:0px"><!-- wp:separator {"style":{"color":{"background":"#d6d5d3"}},"className":"is-style-wide"} -->
+<hr class="wp-block-separator has-text-color has-alpha-channel-opacity has-background is-style-wide" style="background-color:#d6d5d3;color:#d6d5d3"/>
+<!-- /wp:separator -->
+
+<!-- wp:group {"style":{"spacing":{"margin":{"top":"0px","bottom":"0px"},"padding":{"top":"26px","bottom":"0px"},"blockGap":"1em"}},"layout":{"type":"flex","flexWrap":"nowrap","justifyContent":"space-between","verticalAlignment":"top"}} -->
+<div class="wp-block-group" style="margin-top:0px;margin-bottom:0px;padding-top:26px;padding-bottom:0px"><!-- wp:post-title {"isLink":true,"style":{"typography":{"fontStyle":"normal","fontWeight":"500"},"elements":{"link":{"color":{"text":"#1d201f"}}}},"fontSize":"medium"} /-->
+
+<!-- wp:post-date {"textAlign":"right","format":"M Y","isLink":true,"style":{"elements":{"link":{"color":{"text":"#707170"}}}},"className":"no-shrink","fontSize":"medium"} /--></div>
+<!-- /wp:group --></div>
+<!-- /wp:group -->
+<!-- /wp:post-template --></div>
+<!-- /wp:query -->
+
+<!-- wp:group {"style":{"spacing":{"blockGap":"0px","margin":{"top":"0px","bottom":"0px"},"padding":{"top":"26px"}}}} -->
+<div class="wp-block-group" style="margin-top:0px;margin-bottom:0px;padding-top:26px"><!-- wp:separator {"style":{"color":{"background":"#d6d5d3"}},"className":"is-style-wide"} -->
+<hr class="wp-block-separator has-text-color has-alpha-channel-opacity has-background is-style-wide" style="background-color:#d6d5d3;color:#d6d5d3"/>
+<!-- /wp:separator --></div>
+<!-- /wp:group --></div>
+<!-- /wp:group -->',
 		),
 		// Initial block pattern to be used with block transformations with patterns.
 		'social-links-shared-background-color' => array(

--- a/lib/compat/wordpress-6.0/block-patterns-update.php
+++ b/lib/compat/wordpress-6.0/block-patterns-update.php
@@ -157,8 +157,8 @@ function gutenberg_register_gutenberg_patterns() {
 			'categories' => array( 'query' ),
 			'content'    => '<!-- wp:query {"query":{"perPage":8,"pages":0,"offset":0,"postType":"post","order":"desc","orderBy":"date","author":"","search":"","exclude":[],"sticky":"","inherit":false},"displayLayout":{"type":"list"}} -->
 			<div class="wp-block-query"><!-- wp:post-template -->
-			<!-- wp:group {"style":{"spacing":{"padding":{"top":"20px","right":"0px","bottom":"20px","left":"0px"}}}} -->
-			<div class="wp-block-group" style="padding-top:20px;padding-right:0px;padding-bottom:20px;padding-left:0px"><!-- wp:columns -->
+			<!-- wp:group {"style":{"spacing":{"padding":{"top":"0px","right":"0px","bottom":"0px","left":"0px"}}}} -->
+			<div class="wp-block-group" style="padding-top:0px;padding-right:0px;padding-bottom:0px;padding-left:0px"><!-- wp:columns -->
 			<div class="wp-block-columns"><!-- wp:column {"width":"10%"} -->
 			<div class="wp-block-column" style="flex-basis:10%"><!-- wp:post-featured-image {"width":"60px","height":"60px"} /--></div>
 			<!-- /wp:column -->
@@ -181,34 +181,6 @@ function gutenberg_register_gutenberg_patterns() {
 			<!-- wp:separator {"opacity":"css","style":{"color":{"background":"#cccdbb"}},"className":"is-style-wide"} -->
 			<hr class="wp-block-separator has-text-color has-css-opacity has-background is-style-wide" style="background-color:#cccdbb;color:#cccdbb"/>
 			<!-- /wp:separator --></div>
-			<!-- /wp:group -->
-			<!-- /wp:post-template --></div>
-			<!-- /wp:query -->',
-		),
-		'query-post-list-cards'                   => array(
-			'title'      => _x( 'Post list cards', 'Block pattern title', 'gutenberg' ),
-			'blockTypes' => array( 'core/query' ),
-			'categories' => array( 'query' ),
-			'content'    => '<!-- wp:query {"query":{"perPage":"6","pages":0,"offset":0,"postType":"post","order":"desc","orderBy":"date","author":"","search":"","exclude":[],"sticky":"","inherit":false},"displayLayout":{"type":"list"},"align":"wide"} -->
-			<div class="wp-block-query alignwide"><!-- wp:post-template {"align":"full"} -->
-			<!-- wp:group {"style":{"border":{"radius":"0px","width":"4px"},"spacing":{"padding":{"top":"4px","right":"4px","bottom":"4px","left":"4px"}}},"borderColor":"contrast"} -->
-			<div class="wp-block-group has-border-color has-contrast-border-color" style="border-width:4px;border-radius:0px;padding-top:4px;padding-right:4px;padding-bottom:4px;padding-left:4px"><!-- wp:columns {"style":{"spacing":{"padding":{"top":"0px","right":"0px","bottom":"0px","left":"0px"}}},"backgroundColor":"base"} -->
-			<div class="wp-block-columns has-base-background-color has-background" style="padding-top:0px;padding-right:0px;padding-bottom:0px;padding-left:0px"><!-- wp:column {"verticalAlignment":"center","width":"25%"} -->
-			<div class="wp-block-column is-vertically-aligned-center" style="flex-basis:25%"><!-- wp:cover {"useFeaturedImage":true,"dimRatio":0,"minHeight":300} -->
-			<div class="wp-block-cover" style="min-height:300px"><span aria-hidden="true" class="wp-block-cover__background has-background-dim-0 has-background-dim"></span><div class="wp-block-cover__inner-container"><!-- wp:paragraph {"align":"center","placeholder":"Write title…","fontSize":"large"} -->
-			<p class="has-text-align-center has-large-font-size"></p>
-			<!-- /wp:paragraph --></div></div>
-			<!-- /wp:cover --></div>
-			<!-- /wp:column -->
-
-			<!-- wp:column {"verticalAlignment":"center","width":"75%","style":{"spacing":{"padding":{"top":"0px","right":"0px","bottom":"0px","left":"0px"}}}} -->
-			<div class="wp-block-column is-vertically-aligned-center" style="padding-top:0px;padding-right:0px;padding-bottom:0px;padding-left:0px;flex-basis:75%"><!-- wp:group {"layout":{"type":"constrained"},"style":{"border":{"radius":"0px"},"spacing":{"blockGap":"12px","padding":{"top":"var:preset|spacing|30","right":"var:preset|spacing|30","bottom":"var:preset|spacing|30","left":"var:preset|spacing|30"}}},"backgroundColor":"base"} -->
-			<div class="wp-block-group has-base-background-color has-background" style="border-radius:0px;padding-top:var(--wp--preset--spacing--30);padding-right:var(--wp--preset--spacing--30);padding-bottom:var(--wp--preset--spacing--30);padding-left:var(--wp--preset--spacing--30)"><!-- wp:post-title {"textAlign":"center","style":{"typography":{"fontStyle":"normal","fontWeight":"700","textTransform":"capitalize"}},"fontSize":"x-large"} /-->
-
-			<!-- wp:post-author {"textAlign":"center","showAvatar":false} /--></div>
-			<!-- /wp:group --></div>
-			<!-- /wp:column --></div>
-			<!-- /wp:columns --></div>
 			<!-- /wp:group -->
 			<!-- /wp:post-template --></div>
 			<!-- /wp:query -->',
@@ -269,29 +241,29 @@ function gutenberg_register_gutenberg_patterns() {
 			'title'      => _x( 'Post list cards', 'Block pattern title', 'gutenberg' ),
 			'blockTypes' => array( 'core/query' ),
 			'categories' => array( 'query' ),
-			'content'    => '<!-- wp:query {"query":{"perPage":"6","pages":0,"offset":0,"postType":"post","order":"desc","orderBy":"date","author":"","search":"","exclude":[],"sticky":"","inherit":false},"displayLayout":{"type":"list"},"align":"wide"} -->
-			<div class="wp-block-query alignwide"><!-- wp:post-template {"align":"full"} -->
-			<!-- wp:group {"style":{"border":{"radius":"0px","width":"4px"},"spacing":{"padding":{"top":"4px","right":"4px","bottom":"4px","left":"4px"}}},"borderColor":"contrast"} -->
-			<div class="wp-block-group has-border-color has-contrast-border-color" style="border-width:4px;border-radius:0px;padding-top:4px;padding-right:4px;padding-bottom:4px;padding-left:4px"><!-- wp:columns {"style":{"spacing":{"padding":{"top":"0px","right":"0px","bottom":"0px","left":"0px"}}},"backgroundColor":"base"} -->
-			<div class="wp-block-columns has-base-background-color has-background" style="padding-top:0px;padding-right:0px;padding-bottom:0px;padding-left:0px"><!-- wp:column {"verticalAlignment":"center","width":"25%"} -->
-			<div class="wp-block-column is-vertically-aligned-center" style="flex-basis:25%"><!-- wp:cover {"useFeaturedImage":true,"dimRatio":0,"minHeight":300} -->
-			<div class="wp-block-cover" style="min-height:300px"><span aria-hidden="true" class="wp-block-cover__background has-background-dim-0 has-background-dim"></span><div class="wp-block-cover__inner-container"><!-- wp:paragraph {"align":"center","placeholder":"Write title…","fontSize":"large"} -->
-			<p class="has-text-align-center has-large-font-size"></p>
-			<!-- /wp:paragraph --></div></div>
-			<!-- /wp:cover --></div>
-			<!-- /wp:column -->
+			'content'    => '<!-- wp:query {query":{"perPage":"6","pages":0,"offset":0,"postType":"post","order":"desc","orderBy":"date","author":"","search":"","exclude":[],"sticky":"","inherit":false},"displayLayout":{"type":"list"},"align":"wide"} -->
+<div class="wp-block-query alignwide"><!-- wp:post-template {"align":"full"} -->
+<!-- wp:group {"style":{"border":{"radius":"0px","width":"4px"},"spacing":{"padding":{"top":"4px","right":"4px","bottom":"4px","left":"4px"}}},"borderColor":"black"} -->
+<div class="wp-block-group has-border-color has-black-border-color" style="border-width:4px;border-radius:0px;padding-top:4px;padding-right:4px;padding-bottom:4px;padding-left:4px"><!-- wp:columns {"style":{"spacing":{"padding":{"top":"0px","right":"0px","bottom":"0px","left":"0px"}}}} -->
+<div class="wp-block-columns" style="padding-top:0px;padding-right:0px;padding-bottom:0px;padding-left:0px"><!-- wp:column {"verticalAlignment":"center","width":"25%"} -->
+<div class="wp-block-column is-vertically-aligned-center" style="flex-basis:25%"><!-- wp:cover {"useFeaturedImage":true,"dimRatio":0,"minHeight":300} -->
+<div class="wp-block-cover" style="min-height:300px"><span aria-hidden="true" class="wp-block-cover__background has-background-dim-0 has-background-dim"></span><div class="wp-block-cover__inner-container"><!-- wp:paragraph {"align":"center","placeholder":"Write title…","fontSize":"large"} -->
+<p class="has-text-align-center has-large-font-size"></p>
+<!-- /wp:paragraph --></div></div>
+<!-- /wp:cover --></div>
+<!-- /wp:column -->
 
-			<!-- wp:column {"verticalAlignment":"center","width":"75%","style":{"spacing":{"padding":{"top":"0px","right":"0px","bottom":"0px","left":"0px"}}}} -->
-			<div class="wp-block-column is-vertically-aligned-center" style="padding-top:0px;padding-right:0px;padding-bottom:0px;padding-left:0px;flex-basis:75%"><!-- wp:group {"layout":{"type":"constrained"},"style":{"border":{"radius":"0px"},"spacing":{"blockGap":"12px","padding":{"top":"var:preset|spacing|30","right":"var:preset|spacing|30","bottom":"var:preset|spacing|30","left":"var:preset|spacing|30"}}},"backgroundColor":"base"} -->
-			<div class="wp-block-group has-base-background-color has-background" style="border-radius:0px;padding-top:var(--wp--preset--spacing--30);padding-right:var(--wp--preset--spacing--30);padding-bottom:var(--wp--preset--spacing--30);padding-left:var(--wp--preset--spacing--30)"><!-- wp:post-title {"textAlign":"center","style":{"typography":{"fontStyle":"normal","fontWeight":"700","textTransform":"capitalize"}},"fontSize":"x-large"} /-->
+<!-- wp:column {"verticalAlignment":"center","width":"75%","style":{"spacing":{"padding":{"top":"0px","right":"0px","bottom":"0px","left":"0px"}}}} -->
+<div class="wp-block-column is-vertically-aligned-center" style="padding-top:0px;padding-right:0px;padding-bottom:0px;padding-left:0px;flex-basis:75%"><!-- wp:group {"layout":{"type":"constrained"},"style":{"border":{"radius":"0px"},"spacing":{"blockGap":"12px","padding":{"top":"var:preset|spacing|30","right":"var:preset|spacing|30","bottom":"var:preset|spacing|30","left":"var:preset|spacing|30"}}}} -->
+<div class="wp-block-group" style="border-radius:0px;padding-top:var(--wp--preset--spacing--30);padding-right:var(--wp--preset--spacing--30);padding-bottom:var(--wp--preset--spacing--30);padding-left:var(--wp--preset--spacing--30)"><!-- wp:post-title {"textAlign":"center","isLink":true,"style":{"typography":{"fontStyle":"normal","fontWeight":"700","textTransform":"capitalize"}},"fontSize":"x-large"} /-->
 
-			<!-- wp:post-author {"textAlign":"center","showAvatar":false} /--></div>
-			<!-- /wp:group --></div>
-			<!-- /wp:column --></div>
-			<!-- /wp:columns --></div>
-			<!-- /wp:group -->
-			<!-- /wp:post-template --></div>
-			<!-- /wp:query -->',
+<!-- wp:post-author {"textAlign":"center","showAvatar":false} /--></div>
+<!-- /wp:group --></div>
+<!-- /wp:column --></div>
+<!-- /wp:columns --></div>
+<!-- /wp:group -->
+<!-- /wp:post-template --></div>
+<!-- /wp:query -->',
 		),
 		'query-two-column-text-list'                   => array(
 			'title'      => _x( 'Two column text list', 'Block pattern title', 'gutenberg' ),
@@ -311,8 +283,8 @@ function gutenberg_register_gutenberg_patterns() {
 			<!-- /wp:column --></div>
 			<!-- /wp:columns -->
 
-			<!-- wp:separator {"opacity":"css","backgroundColor":"primary","className":"alignwide is-style-wide"} -->
-			<hr class="wp-block-separator has-text-color has-primary-color has-css-opacity has-primary-background-color has-background alignwide is-style-wide"/>
+			<!-- wp:separator {"opacity":"css","backgroundColor":"cyan-bluish-gray","className":"alignwide is-style-wide"} -->
+			<hr class="wp-block-separator has-text-color has-cyan-bluish-gray-color has-alpha-channel-opacity has-cyan-bluish-gray-background-color has-background alignwide is-style-wide"/>
 			<!-- /wp:separator -->
 			<!-- /wp:post-template -->
 
@@ -325,34 +297,6 @@ function gutenberg_register_gutenberg_patterns() {
 			<!-- wp:query-pagination-next /-->
 			<!-- /wp:query-pagination --></div>
 			<!-- /wp:group --></div>
-			<!-- /wp:query -->',
-		),
-		'query-post-list-cards'                   => array(
-			'title'      => _x( 'Post list cards', 'Block pattern title', 'gutenberg' ),
-			'blockTypes' => array( 'core/query' ),
-			'categories' => array( 'query' ),
-			'content'    => '<!-- wp:query {"query":{"perPage":"6","pages":0,"offset":0,"postType":"post","order":"desc","orderBy":"date","author":"","search":"","exclude":[],"sticky":"","inherit":false},"displayLayout":{"type":"list"},"align":"wide"} -->
-			<div class="wp-block-query alignwide"><!-- wp:post-template {"align":"full"} -->
-			<!-- wp:group {"style":{"border":{"radius":"0px","width":"4px"},"spacing":{"padding":{"top":"4px","right":"4px","bottom":"4px","left":"4px"}}},"borderColor":"contrast"} -->
-			<div class="wp-block-group has-border-color has-contrast-border-color" style="border-width:4px;border-radius:0px;padding-top:4px;padding-right:4px;padding-bottom:4px;padding-left:4px"><!-- wp:columns {"style":{"spacing":{"padding":{"top":"0px","right":"0px","bottom":"0px","left":"0px"}}},"backgroundColor":"base"} -->
-			<div class="wp-block-columns has-base-background-color has-background" style="padding-top:0px;padding-right:0px;padding-bottom:0px;padding-left:0px"><!-- wp:column {"verticalAlignment":"center","width":"25%"} -->
-			<div class="wp-block-column is-vertically-aligned-center" style="flex-basis:25%"><!-- wp:cover {"useFeaturedImage":true,"dimRatio":0,"minHeight":300} -->
-			<div class="wp-block-cover" style="min-height:300px"><span aria-hidden="true" class="wp-block-cover__background has-background-dim-0 has-background-dim"></span><div class="wp-block-cover__inner-container"><!-- wp:paragraph {"align":"center","placeholder":"Write title…","fontSize":"large"} -->
-			<p class="has-text-align-center has-large-font-size"></p>
-			<!-- /wp:paragraph --></div></div>
-			<!-- /wp:cover --></div>
-			<!-- /wp:column -->
-
-			<!-- wp:column {"verticalAlignment":"center","width":"75%","style":{"spacing":{"padding":{"top":"0px","right":"0px","bottom":"0px","left":"0px"}}}} -->
-			<div class="wp-block-column is-vertically-aligned-center" style="padding-top:0px;padding-right:0px;padding-bottom:0px;padding-left:0px;flex-basis:75%"><!-- wp:group {"layout":{"type":"constrained"},"style":{"border":{"radius":"0px"},"spacing":{"blockGap":"12px","padding":{"top":"var:preset|spacing|30","right":"var:preset|spacing|30","bottom":"var:preset|spacing|30","left":"var:preset|spacing|30"}}},"backgroundColor":"base"} -->
-			<div class="wp-block-group has-base-background-color has-background" style="border-radius:0px;padding-top:var(--wp--preset--spacing--30);padding-right:var(--wp--preset--spacing--30);padding-bottom:var(--wp--preset--spacing--30);padding-left:var(--wp--preset--spacing--30)"><!-- wp:post-title {"textAlign":"center","style":{"typography":{"fontStyle":"normal","fontWeight":"700","textTransform":"capitalize"}},"fontSize":"x-large"} /-->
-
-			<!-- wp:post-author {"textAlign":"center","showAvatar":false} /--></div>
-			<!-- /wp:group --></div>
-			<!-- /wp:column --></div>
-			<!-- /wp:columns --></div>
-			<!-- /wp:group -->
-			<!-- /wp:post-template --></div>
 			<!-- /wp:query -->',
 		),
 		'query-two-column-with-tags'                   => array(
@@ -391,7 +335,7 @@ function gutenberg_register_gutenberg_patterns() {
 			<div class="wp-block-group alignfull"><!-- wp:query {"query":{"perPage":"1","pages":0,"offset":0,"postType":"post","order":"desc","orderBy":"date","author":"","search":"","exclude":[],"sticky":"","inherit":false},"displayLayout":{"type":"list"},"align":"full"} -->
 			<div class="wp-block-query alignfull"><!-- wp:post-template {"align":"full"} -->
 			<!-- wp:cover {"customOverlayColor":"#eef5e9","minHeight":246,"minHeightUnit":"px","contentPosition":"center center","isDark":false,"align":"full"} -->
-			<div class="wp-block-cover alignfull is-light" style="min-height:246px"><span aria-hidden="true" class="wp-block-cover__background has-background-dim-100 has-background-dim" style="background-color:#eef5e9"></span><div class="wp-block-cover__inner-container"><!-- wp:post-title {"textAlign":"center","level":3,"textColor":"black"} /--></div></div>
+			<div class="wp-block-cover alignfull is-light" style="min-height:246px"><span aria-hidden="true" class="wp-block-cover__background has-background-dim-100 has-background-dim" style="background-color:#eef5e9"></span><div class="wp-block-cover__inner-container"><!-- wp:post-title {"textAlign":"center","level":3,"isLink":true,"textColor":"black"} /--></div></div>
 			<!-- /wp:cover -->
 			<!-- /wp:post-template --></div>
 			<!-- /wp:query -->
@@ -399,7 +343,7 @@ function gutenberg_register_gutenberg_patterns() {
 			<!-- wp:query {"query":{"perPage":"1","pages":0,"offset":1,"postType":"post","order":"desc","orderBy":"date","author":"","search":"","exclude":[],"sticky":"","inherit":false},"displayLayout":{"type":"list"},"align":"full"} -->
 			<div class="wp-block-query alignfull"><!-- wp:post-template {"align":"full"} -->
 			<!-- wp:cover {"customOverlayColor":"#ffc4a3","minHeight":246,"minHeightUnit":"px","contentPosition":"center center","isDark":false,"align":"full"} -->
-			<div class="wp-block-cover alignfull is-light" style="min-height:246px"><span aria-hidden="true" class="wp-block-cover__background has-background-dim-100 has-background-dim" style="background-color:#ffc4a3"></span><div class="wp-block-cover__inner-container"><!-- wp:post-title {"textAlign":"center","level":3,"textColor":"black"} /--></div></div>
+			<div class="wp-block-cover alignfull is-light" style="min-height:246px"><span aria-hidden="true" class="wp-block-cover__background has-background-dim-100 has-background-dim" style="background-color:#ffc4a3"></span><div class="wp-block-cover__inner-container"><!-- wp:post-title {"textAlign":"center","level":3,"isLink":true,"textColor":"black"} /--></div></div>
 			<!-- /wp:cover -->
 			<!-- /wp:post-template --></div>
 			<!-- /wp:query -->
@@ -407,7 +351,7 @@ function gutenberg_register_gutenberg_patterns() {
 			<!-- wp:query {"query":{"perPage":"1","pages":0,"offset":2,"postType":"post","order":"desc","orderBy":"date","author":"","search":"","exclude":[],"sticky":"","inherit":false},"displayLayout":{"type":"list"},"align":"full"} -->
 			<div class="wp-block-query alignfull"><!-- wp:post-template {"align":"full"} -->
 			<!-- wp:cover {"customOverlayColor":"#cccdbb","minHeight":246,"minHeightUnit":"px","contentPosition":"center center","isDark":false,"align":"full"} -->
-			<div class="wp-block-cover alignfull is-light" style="min-height:246px"><span aria-hidden="true" class="wp-block-cover__background has-background-dim-100 has-background-dim" style="background-color:#cccdbb"></span><div class="wp-block-cover__inner-container"><!-- wp:post-title {"textAlign":"center","level":3,"textColor":"black"} /--></div></div>
+			<div class="wp-block-cover alignfull is-light" style="min-height:246px"><span aria-hidden="true" class="wp-block-cover__background has-background-dim-100 has-background-dim" style="background-color:#cccdbb"></span><div class="wp-block-cover__inner-container"><!-- wp:post-title {"textAlign":"center","level":3,"isLink":true,"textColor":"black"} /--></div></div>
 			<!-- /wp:cover -->
 			<!-- /wp:post-template --></div>
 			<!-- /wp:query -->
@@ -415,7 +359,7 @@ function gutenberg_register_gutenberg_patterns() {
 			<!-- wp:query {"query":{"perPage":"1","pages":0,"offset":3,"postType":"post","order":"desc","orderBy":"date","author":"","search":"","exclude":[],"sticky":"","inherit":false},"displayLayout":{"type":"list"},"align":"full"} -->
 			<div class="wp-block-query alignfull"><!-- wp:post-template {"align":"full"} -->
 			<!-- wp:cover {"customOverlayColor":"#ffedbf","minHeight":246,"minHeightUnit":"px","contentPosition":"center center","isDark":false,"align":"full"} -->
-			<div class="wp-block-cover alignfull is-light" style="min-height:246px"><span aria-hidden="true" class="wp-block-cover__background has-background-dim-100 has-background-dim" style="background-color:#ffedbf"></span><div class="wp-block-cover__inner-container"><!-- wp:post-title {"textAlign":"center","level":3,"textColor":"black"} /--></div></div>
+			<div class="wp-block-cover alignfull is-light" style="min-height:246px"><span aria-hidden="true" class="wp-block-cover__background has-background-dim-100 has-background-dim" style="background-color:#ffedbf"></span><div class="wp-block-cover__inner-container"><!-- wp:post-title {"textAlign":"center","level":3,"isLink":true,"textColor":"black"} /--></div></div>
 			<!-- /wp:cover -->
 			<!-- /wp:post-template --></div>
 			<!-- /wp:query --></div>
@@ -468,8 +412,8 @@ function gutenberg_register_gutenberg_patterns() {
 			'content'    => '<!-- wp:group {"align":"wide","style":{"spacing":{"padding":{"top":"var:preset|spacing|30","right":"var:preset|spacing|30","bottom":"var:preset|spacing|30","left":"var:preset|spacing|30"}}},"backgroundColor":"black"} -->
 			<div class="wp-block-group alignwide has-black-background-color has-background" style="padding-top:var(--wp--preset--spacing--30);padding-right:var(--wp--preset--spacing--30);padding-bottom:var(--wp--preset--spacing--30);padding-left:var(--wp--preset--spacing--30)"><!-- wp:query {"query":{"perPage":1,"pages":0,"offset":0,"postType":"post","order":"desc","orderBy":"date","author":"","search":"","exclude":[],"sticky":"","inherit":false},"displayLayout":{"type":"list"}} -->
 			<div class="wp-block-query"><!-- wp:post-template -->
-			<!-- wp:columns {"verticalAlignment":"center","textColor":"base"} -->
-			<div class="wp-block-columns are-vertically-aligned-center has-base-color has-text-color"><!-- wp:column {"verticalAlignment":"center","width":"20%"} -->
+			<!-- wp:columns {"verticalAlignment":"center","textColor":"white"} -->
+			<div class="wp-block-columns are-vertically-aligned-center has-white-color has-text-color"><!-- wp:column {"verticalAlignment":"center","width":"20%"} -->
 			<div class="wp-block-column is-vertically-aligned-center" style="flex-basis:20%"><!-- wp:post-author {"showAvatar":false} /--></div>
 			<!-- /wp:column -->
 
@@ -480,9 +424,9 @@ function gutenberg_register_gutenberg_patterns() {
 
 			<!-- wp:post-featured-image {"isLink":true,"align":"wide"} /-->
 
-			<!-- wp:post-title {"isLink":true,"style":{"elements":{"link":{"color":{"text":"var:preset|color|base"}}}},"textColor":"base"} /-->
+			<!-- wp:post-title {"isLink":true,"style":{"elements":{"link":{"color":{"text":"var:preset|color|white"}}}}} /-->
 
-			<!-- wp:post-excerpt {"style":{"elements":{"link":{"color":{"text":"var:preset|color|base"}}}},"textColor":"base"} /-->
+			<!-- wp:post-excerpt {"style":{"elements":{"link":{"color":{"text":"var:preset|color|white"}}}},"textColor":"white"} /-->
 
 			<!-- wp:spacer {"height":"25px"} -->
 			<div style="height:25px" aria-hidden="true" class="wp-block-spacer"></div>
@@ -490,18 +434,18 @@ function gutenberg_register_gutenberg_patterns() {
 			<!-- /wp:post-template --></div>
 			<!-- /wp:query -->
 
-			<!-- wp:paragraph {"style":{"elements":{"link":{"color":{"text":"var:preset|color|base"}}}},"textColor":"base"} -->
-			<p class="has-base-color has-text-color has-link-color"><strong>More Posts</strong></p>
+			<!-- wp:paragraph {"textColor":"white"} -->
+			<p class="has-white-color has-text-color"><strong>More Posts</strong></p>
 			<!-- /wp:paragraph -->
 
 			<!-- wp:query {"query":{"perPage":6,"pages":0,"offset":0,"postType":"post","order":"desc","orderBy":"date","author":"","search":"","exclude":[],"sticky":"exclude","inherit":false},"displayLayout":{"type":"flex","columns":3}} -->
 			<div class="wp-block-query"><!-- wp:post-template -->
 			<!-- wp:group {"layout":{"inherit":false},"style":{"spacing":{"padding":{"top":"0px","right":"0px","bottom":"var:preset|spacing|40","left":"0px"}}}} -->
-			<div class="wp-block-group" style="padding-top:0px;padding-right:0px;padding-bottom:var(--wp--preset--spacing--40);padding-left:0px"><!-- wp:separator {"backgroundColor":"base"} -->
-			<hr class="wp-block-separator has-text-color has-base-color has-alpha-channel-opacity has-base-background-color has-background"/>
+			<div class="wp-block-group" style="padding-top:0px;padding-right:0px;padding-bottom:var(--wp--preset--spacing--40);padding-left:0px"><!-- wp:separator {"backgroundColor":"white"} -->
+			<hr class="wp-block-separator has-text-color has-white-color has-alpha-channel-opacity has-white-background-color has-background"/>
 			<!-- /wp:separator -->
 
-			<!-- wp:post-title {"textColor":"base"} /--></div>
+			<!-- wp:post-title {"isLink":true,"style":{"elements":{"link":{"color":{"text":"var:preset|color|white"}}}}} /--></div>
 			<!-- /wp:group -->
 			<!-- /wp:post-template --></div>
 			<!-- /wp:query --></div>

--- a/lib/compat/wordpress-6.0/block-patterns-update.php
+++ b/lib/compat/wordpress-6.0/block-patterns-update.php
@@ -155,7 +155,7 @@ function gutenberg_register_gutenberg_patterns() {
 			'title'      => _x( 'Post feed', 'Block pattern title', 'gutenberg' ),
 			'blockTypes' => array( 'core/query' ),
 			'categories' => array( 'query' ),
-			'content'    => '<!-- wp:query {"queryId":7,"query":{"perPage":8,"pages":0,"offset":0,"postType":"post","order":"desc","orderBy":"date","author":"","search":"","exclude":[],"sticky":"","inherit":false},"displayLayout":{"type":"list"}} -->
+			'content'    => '<!-- wp:query {"query":{"perPage":8,"pages":0,"offset":0,"postType":"post","order":"desc","orderBy":"date","author":"","search":"","exclude":[],"sticky":"","inherit":false},"displayLayout":{"type":"list"}} -->
 			<div class="wp-block-query"><!-- wp:post-template -->
 			<!-- wp:group {"style":{"spacing":{"padding":{"top":"20px","right":"0px","bottom":"20px","left":"0px"}}}} -->
 			<div class="wp-block-group" style="padding-top:20px;padding-right:0px;padding-bottom:20px;padding-left:0px"><!-- wp:columns -->
@@ -189,7 +189,7 @@ function gutenberg_register_gutenberg_patterns() {
 			'title'      => _x( 'Post list cards', 'Block pattern title', 'gutenberg' ),
 			'blockTypes' => array( 'core/query' ),
 			'categories' => array( 'query' ),
-			'content'    => '<!-- wp:query {"queryId":7,"query":{"perPage":"6","pages":0,"offset":0,"postType":"post","order":"desc","orderBy":"date","author":"","search":"","exclude":[],"sticky":"","inherit":false},"displayLayout":{"type":"list"},"align":"wide"} -->
+			'content'    => '<!-- wp:query {"query":{"perPage":"6","pages":0,"offset":0,"postType":"post","order":"desc","orderBy":"date","author":"","search":"","exclude":[],"sticky":"","inherit":false},"displayLayout":{"type":"list"},"align":"wide"} -->
 			<div class="wp-block-query alignwide"><!-- wp:post-template {"align":"full"} -->
 			<!-- wp:group {"style":{"border":{"radius":"0px","width":"4px"},"spacing":{"padding":{"top":"4px","right":"4px","bottom":"4px","left":"4px"}}},"borderColor":"contrast"} -->
 			<div class="wp-block-group has-border-color has-contrast-border-color" style="border-width:4px;border-radius:0px;padding-top:4px;padding-right:4px;padding-bottom:4px;padding-left:4px"><!-- wp:columns {"style":{"spacing":{"padding":{"top":"0px","right":"0px","bottom":"0px","left":"0px"}}},"backgroundColor":"base"} -->
@@ -222,7 +222,7 @@ function gutenberg_register_gutenberg_patterns() {
 <hr class="wp-block-separator has-css-opacity alignwide is-style-wide"/>
 <!-- /wp:separator -->
 
-<!-- wp:query {"queryId":7,"query":{"perPage":10,"pages":0,"offset":0,"postType":"post","order":"desc","orderBy":"date","author":"","search":"","exclude":[],"sticky":"","inherit":false},"displayLayout":{"type":"list"},"align":"wide"} -->
+<!-- wp:query {"query":{"perPage":10,"pages":0,"offset":0,"postType":"post","order":"desc","orderBy":"date","author":"","search":"","exclude":[],"sticky":"","inherit":false},"displayLayout":{"type":"list"},"align":"wide"} -->
 <div class="wp-block-query alignwide"><!-- wp:post-template {"align":"wide"} -->
 <!-- wp:columns {"align":"wide"} -->
 <div class="wp-block-columns alignwide"><!-- wp:column -->
@@ -269,7 +269,7 @@ function gutenberg_register_gutenberg_patterns() {
 			'title'      => _x( 'Post list cards', 'Block pattern title', 'gutenberg' ),
 			'blockTypes' => array( 'core/query' ),
 			'categories' => array( 'query' ),
-			'content'    => '<!-- wp:query {"queryId":7,"query":{"perPage":"6","pages":0,"offset":0,"postType":"post","order":"desc","orderBy":"date","author":"","search":"","exclude":[],"sticky":"","inherit":false},"displayLayout":{"type":"list"},"align":"wide"} -->
+			'content'    => '<!-- wp:query {"query":{"perPage":"6","pages":0,"offset":0,"postType":"post","order":"desc","orderBy":"date","author":"","search":"","exclude":[],"sticky":"","inherit":false},"displayLayout":{"type":"list"},"align":"wide"} -->
 			<div class="wp-block-query alignwide"><!-- wp:post-template {"align":"full"} -->
 			<!-- wp:group {"style":{"border":{"radius":"0px","width":"4px"},"spacing":{"padding":{"top":"4px","right":"4px","bottom":"4px","left":"4px"}}},"borderColor":"contrast"} -->
 			<div class="wp-block-group has-border-color has-contrast-border-color" style="border-width:4px;border-radius:0px;padding-top:4px;padding-right:4px;padding-bottom:4px;padding-left:4px"><!-- wp:columns {"style":{"spacing":{"padding":{"top":"0px","right":"0px","bottom":"0px","left":"0px"}}},"backgroundColor":"base"} -->
@@ -297,7 +297,7 @@ function gutenberg_register_gutenberg_patterns() {
 			'title'      => _x( 'Two column text list', 'Block pattern title', 'gutenberg' ),
 			'blockTypes' => array( 'core/query' ),
 			'categories' => array( 'query' ),
-			'content'    => '<!-- wp:query {"queryId":0,"query":{"perPage":5,"pages":0,"offset":0,"postType":"post","order":"desc","orderBy":"date","author":"","search":"","exclude":[],"sticky":"","inherit":false},"displayLayout":{"type":"list"},"align":"full"} -->
+			'content'    => '<!-- wp:query {"query":{"perPage":5,"pages":0,"offset":0,"postType":"post","order":"desc","orderBy":"date","author":"","search":"","exclude":[],"sticky":"","inherit":false},"displayLayout":{"type":"list"},"align":"full"} -->
 			<div class="wp-block-query alignfull"><!-- wp:post-template {"align":"full"} -->
 			<!-- wp:columns {"align":"wide"} -->
 			<div class="wp-block-columns alignwide"><!-- wp:column {"width":"50%","style":{"spacing":{"padding":{"top":"2em","bottom":"0em"}}}} -->
@@ -331,7 +331,7 @@ function gutenberg_register_gutenberg_patterns() {
 			'title'      => _x( 'Post list cards', 'Block pattern title', 'gutenberg' ),
 			'blockTypes' => array( 'core/query' ),
 			'categories' => array( 'query' ),
-			'content'    => '<!-- wp:query {"queryId":7,"query":{"perPage":"6","pages":0,"offset":0,"postType":"post","order":"desc","orderBy":"date","author":"","search":"","exclude":[],"sticky":"","inherit":false},"displayLayout":{"type":"list"},"align":"wide"} -->
+			'content'    => '<!-- wp:query {"query":{"perPage":"6","pages":0,"offset":0,"postType":"post","order":"desc","orderBy":"date","author":"","search":"","exclude":[],"sticky":"","inherit":false},"displayLayout":{"type":"list"},"align":"wide"} -->
 			<div class="wp-block-query alignwide"><!-- wp:post-template {"align":"full"} -->
 			<!-- wp:group {"style":{"border":{"radius":"0px","width":"4px"},"spacing":{"padding":{"top":"4px","right":"4px","bottom":"4px","left":"4px"}}},"borderColor":"contrast"} -->
 			<div class="wp-block-group has-border-color has-contrast-border-color" style="border-width:4px;border-radius:0px;padding-top:4px;padding-right:4px;padding-bottom:4px;padding-left:4px"><!-- wp:columns {"style":{"spacing":{"padding":{"top":"0px","right":"0px","bottom":"0px","left":"0px"}}},"backgroundColor":"base"} -->
@@ -359,7 +359,7 @@ function gutenberg_register_gutenberg_patterns() {
 			'title'      => _x( 'Two column with tags', 'Block pattern title', 'gutenberg' ),
 			'blockTypes' => array( 'core/query' ),
 			'categories' => array( 'query' ),
-			'content'    => '<!-- wp:query {"queryId":0,"query":{"perPage":"10","pages":0,"offset":0,"postType":"post","order":"desc","orderBy":"date","author":"","search":"","exclude":[],"sticky":"","inherit":false},"displayLayout":{"type":"list"},"align":"wide"} -->
+			'content'    => '<!-- wp:query {"query":{"perPage":"10","pages":0,"offset":0,"postType":"post","order":"desc","orderBy":"date","author":"","search":"","exclude":[],"sticky":"","inherit":false},"displayLayout":{"type":"list"},"align":"wide"} -->
 			<div class="wp-block-query alignwide"><!-- wp:post-template -->
 			<!-- wp:columns {"verticalAlignment":"center","align":"wide","style":{"spacing":{"padding":{"top":"0px","right":"0px","bottom":"0px","left":"0px"}}}} -->
 			<div class="wp-block-columns alignwide are-vertically-aligned-center" style="padding-top:0px;padding-right:0px;padding-bottom:0px;padding-left:0px"><!-- wp:column {"verticalAlignment":"center","width":"50%","style":{"spacing":{"padding":{"bottom":"0em","top":"0em"}}}} -->
@@ -388,7 +388,7 @@ function gutenberg_register_gutenberg_patterns() {
 			'blockTypes' => array( 'core/query' ),
 			'categories' => array( 'query' ),
 			'content'    => '<!-- wp:group {"layout":{"type":"constrained"},"align":"full","style":{"spacing":{"blockGap":"0px"}}} -->
-			<div class="wp-block-group alignfull"><!-- wp:query {"queryId":7,"query":{"perPage":"1","pages":0,"offset":0,"postType":"post","order":"desc","orderBy":"date","author":"","search":"","exclude":[],"sticky":"","inherit":false},"displayLayout":{"type":"list"},"align":"full"} -->
+			<div class="wp-block-group alignfull"><!-- wp:query {"query":{"perPage":"1","pages":0,"offset":0,"postType":"post","order":"desc","orderBy":"date","author":"","search":"","exclude":[],"sticky":"","inherit":false},"displayLayout":{"type":"list"},"align":"full"} -->
 			<div class="wp-block-query alignfull"><!-- wp:post-template {"align":"full"} -->
 			<!-- wp:cover {"customOverlayColor":"#eef5e9","minHeight":246,"minHeightUnit":"px","contentPosition":"center center","isDark":false,"align":"full"} -->
 			<div class="wp-block-cover alignfull is-light" style="min-height:246px"><span aria-hidden="true" class="wp-block-cover__background has-background-dim-100 has-background-dim" style="background-color:#eef5e9"></span><div class="wp-block-cover__inner-container"><!-- wp:post-title {"textAlign":"center","level":3,"textColor":"black"} /--></div></div>
@@ -396,7 +396,7 @@ function gutenberg_register_gutenberg_patterns() {
 			<!-- /wp:post-template --></div>
 			<!-- /wp:query -->
 
-			<!-- wp:query {"queryId":7,"query":{"perPage":"1","pages":0,"offset":1,"postType":"post","order":"desc","orderBy":"date","author":"","search":"","exclude":[],"sticky":"","inherit":false},"displayLayout":{"type":"list"},"align":"full"} -->
+			<!-- wp:query {"query":{"perPage":"1","pages":0,"offset":1,"postType":"post","order":"desc","orderBy":"date","author":"","search":"","exclude":[],"sticky":"","inherit":false},"displayLayout":{"type":"list"},"align":"full"} -->
 			<div class="wp-block-query alignfull"><!-- wp:post-template {"align":"full"} -->
 			<!-- wp:cover {"customOverlayColor":"#ffc4a3","minHeight":246,"minHeightUnit":"px","contentPosition":"center center","isDark":false,"align":"full"} -->
 			<div class="wp-block-cover alignfull is-light" style="min-height:246px"><span aria-hidden="true" class="wp-block-cover__background has-background-dim-100 has-background-dim" style="background-color:#ffc4a3"></span><div class="wp-block-cover__inner-container"><!-- wp:post-title {"textAlign":"center","level":3,"textColor":"black"} /--></div></div>
@@ -404,7 +404,7 @@ function gutenberg_register_gutenberg_patterns() {
 			<!-- /wp:post-template --></div>
 			<!-- /wp:query -->
 
-			<!-- wp:query {"queryId":7,"query":{"perPage":"1","pages":0,"offset":2,"postType":"post","order":"desc","orderBy":"date","author":"","search":"","exclude":[],"sticky":"","inherit":false},"displayLayout":{"type":"list"},"align":"full"} -->
+			<!-- wp:query {"query":{"perPage":"1","pages":0,"offset":2,"postType":"post","order":"desc","orderBy":"date","author":"","search":"","exclude":[],"sticky":"","inherit":false},"displayLayout":{"type":"list"},"align":"full"} -->
 			<div class="wp-block-query alignfull"><!-- wp:post-template {"align":"full"} -->
 			<!-- wp:cover {"customOverlayColor":"#cccdbb","minHeight":246,"minHeightUnit":"px","contentPosition":"center center","isDark":false,"align":"full"} -->
 			<div class="wp-block-cover alignfull is-light" style="min-height:246px"><span aria-hidden="true" class="wp-block-cover__background has-background-dim-100 has-background-dim" style="background-color:#cccdbb"></span><div class="wp-block-cover__inner-container"><!-- wp:post-title {"textAlign":"center","level":3,"textColor":"black"} /--></div></div>
@@ -412,7 +412,7 @@ function gutenberg_register_gutenberg_patterns() {
 			<!-- /wp:post-template --></div>
 			<!-- /wp:query -->
 
-			<!-- wp:query {"queryId":7,"query":{"perPage":"1","pages":0,"offset":3,"postType":"post","order":"desc","orderBy":"date","author":"","search":"","exclude":[],"sticky":"","inherit":false},"displayLayout":{"type":"list"},"align":"full"} -->
+			<!-- wp:query {"query":{"perPage":"1","pages":0,"offset":3,"postType":"post","order":"desc","orderBy":"date","author":"","search":"","exclude":[],"sticky":"","inherit":false},"displayLayout":{"type":"list"},"align":"full"} -->
 			<div class="wp-block-query alignfull"><!-- wp:post-template {"align":"full"} -->
 			<!-- wp:cover {"customOverlayColor":"#ffedbf","minHeight":246,"minHeightUnit":"px","contentPosition":"center center","isDark":false,"align":"full"} -->
 			<div class="wp-block-cover alignfull is-light" style="min-height:246px"><span aria-hidden="true" class="wp-block-cover__background has-background-dim-100 has-background-dim" style="background-color:#ffedbf"></span><div class="wp-block-cover__inner-container"><!-- wp:post-title {"textAlign":"center","level":3,"textColor":"black"} /--></div></div>
@@ -427,7 +427,7 @@ function gutenberg_register_gutenberg_patterns() {
 			'categories' => array( 'query' ),
 			'content'    => '<!-- wp:columns {"align":"wide"} -->
 			<div class="wp-block-columns alignwide"><!-- wp:column {"width":"66.66%"} -->
-			<div class="wp-block-column" style="flex-basis:66.66%"><!-- wp:query {"queryId":2,"query":{"perPage":1,"pages":0,"offset":0,"postType":"post","order":"desc","orderBy":"date","author":"","search":"","exclude":[],"sticky":"","inherit":false},"displayLayout":{"type":"list"}} -->
+			<div class="wp-block-column" style="flex-basis:66.66%"><!-- wp:query {"query":{"perPage":1,"pages":0,"offset":0,"postType":"post","order":"desc","orderBy":"date","author":"","search":"","exclude":[],"sticky":"","inherit":false},"displayLayout":{"type":"list"}} -->
 			<div class="wp-block-query"><!-- wp:post-template -->
 			<!-- wp:post-featured-image {"isLink":true} /-->
 
@@ -439,7 +439,7 @@ function gutenberg_register_gutenberg_patterns() {
 			<!-- /wp:column -->
 
 			<!-- wp:column -->
-			<div class="wp-block-column"><!-- wp:query {"queryId":1,"query":{"perPage":7,"pages":0,"offset":1,"postType":"post","order":"desc","orderBy":"date","author":"","search":"","exclude":[],"sticky":"","inherit":false},"displayLayout":{"type":"list","columns":2}} -->
+			<div class="wp-block-column"><!-- wp:query {"query":{"perPage":7,"pages":0,"offset":1,"postType":"post","order":"desc","orderBy":"date","author":"","search":"","exclude":[],"sticky":"","inherit":false},"displayLayout":{"type":"list","columns":2}} -->
 			<div class="wp-block-query"><!-- wp:post-template -->
 			<!-- wp:post-title {"isLink":true,"fontSize":"large"} /-->
 
@@ -466,7 +466,7 @@ function gutenberg_register_gutenberg_patterns() {
 			'blockTypes' => array( 'core/query' ),
 			'categories' => array( 'query' ),
 			'content'    => '<!-- wp:group {"align":"wide","style":{"spacing":{"padding":{"top":"var:preset|spacing|30","right":"var:preset|spacing|30","bottom":"var:preset|spacing|30","left":"var:preset|spacing|30"}}},"backgroundColor":"black"} -->
-			<div class="wp-block-group alignwide has-black-background-color has-background" style="padding-top:var(--wp--preset--spacing--30);padding-right:var(--wp--preset--spacing--30);padding-bottom:var(--wp--preset--spacing--30);padding-left:var(--wp--preset--spacing--30)"><!-- wp:query {"queryId":25,"query":{"perPage":1,"pages":0,"offset":0,"postType":"post","order":"desc","orderBy":"date","author":"","search":"","exclude":[],"sticky":"","inherit":false},"displayLayout":{"type":"list"}} -->
+			<div class="wp-block-group alignwide has-black-background-color has-background" style="padding-top:var(--wp--preset--spacing--30);padding-right:var(--wp--preset--spacing--30);padding-bottom:var(--wp--preset--spacing--30);padding-left:var(--wp--preset--spacing--30)"><!-- wp:query {"query":{"perPage":1,"pages":0,"offset":0,"postType":"post","order":"desc","orderBy":"date","author":"","search":"","exclude":[],"sticky":"","inherit":false},"displayLayout":{"type":"list"}} -->
 			<div class="wp-block-query"><!-- wp:post-template -->
 			<!-- wp:columns {"verticalAlignment":"center","textColor":"base"} -->
 			<div class="wp-block-columns are-vertically-aligned-center has-base-color has-text-color"><!-- wp:column {"verticalAlignment":"center","width":"20%"} -->
@@ -494,7 +494,7 @@ function gutenberg_register_gutenberg_patterns() {
 			<p class="has-base-color has-text-color has-link-color"><strong>More Posts</strong></p>
 			<!-- /wp:paragraph -->
 
-			<!-- wp:query {"queryId":14,"query":{"perPage":6,"pages":0,"offset":0,"postType":"post","order":"desc","orderBy":"date","author":"","search":"","exclude":[],"sticky":"exclude","inherit":false},"displayLayout":{"type":"flex","columns":3}} -->
+			<!-- wp:query {"query":{"perPage":6,"pages":0,"offset":0,"postType":"post","order":"desc","orderBy":"date","author":"","search":"","exclude":[],"sticky":"exclude","inherit":false},"displayLayout":{"type":"flex","columns":3}} -->
 			<div class="wp-block-query"><!-- wp:post-template -->
 			<!-- wp:group {"layout":{"inherit":false},"style":{"spacing":{"padding":{"top":"0px","right":"0px","bottom":"var:preset|spacing|40","left":"0px"}}}} -->
 			<div class="wp-block-group" style="padding-top:0px;padding-right:0px;padding-bottom:var(--wp--preset--spacing--40);padding-left:0px"><!-- wp:separator {"backgroundColor":"base"} -->

--- a/lib/compat/wordpress-6.0/block-patterns-update.php
+++ b/lib/compat/wordpress-6.0/block-patterns-update.php
@@ -151,6 +151,362 @@ function gutenberg_register_gutenberg_patterns() {
 							<!-- /wp:columns --></div>
 							<!-- /wp:group -->',
 		),
+		'query-post-feed'                   => array(
+			'title'      => _x( 'Post feed', 'Block pattern title', 'gutenberg' ),
+			'blockTypes' => array( 'core/query' ),
+			'categories' => array( 'query' ),
+			'content'    => '<!-- wp:query {"queryId":7,"query":{"perPage":8,"pages":0,"offset":0,"postType":"post","order":"desc","orderBy":"date","author":"","search":"","exclude":[],"sticky":"","inherit":false},"displayLayout":{"type":"list"}} -->
+			<div class="wp-block-query"><!-- wp:post-template -->
+			<!-- wp:group {"style":{"spacing":{"padding":{"top":"20px","right":"0px","bottom":"20px","left":"0px"}}}} -->
+			<div class="wp-block-group" style="padding-top:20px;padding-right:0px;padding-bottom:20px;padding-left:0px"><!-- wp:columns -->
+			<div class="wp-block-columns"><!-- wp:column {"width":"10%"} -->
+			<div class="wp-block-column" style="flex-basis:10%"><!-- wp:post-featured-image {"width":"60px","height":"60px"} /--></div>
+			<!-- /wp:column -->
+
+			<!-- wp:column {"width":"90%","style":{"spacing":{"padding":{"top":"0px","right":"0px","bottom":"0px","left":"0px"},"blockGap":"0px"}}} -->
+			<div class="wp-block-column" style="padding-top:0px;padding-right:0px;padding-bottom:0px;padding-left:0px;flex-basis:90%"><!-- wp:columns -->
+			<div class="wp-block-columns"><!-- wp:column {"width":"50%"} -->
+			<div class="wp-block-column" style="flex-basis:50%"><!-- wp:post-author {"avatarSize":24,"showAvatar":false} /--></div>
+			<!-- /wp:column -->
+
+			<!-- wp:column {"width":"50%"} -->
+			<div class="wp-block-column" style="flex-basis:50%"><!-- wp:post-date {"textAlign":"right"} /--></div>
+			<!-- /wp:column --></div>
+			<!-- /wp:columns -->
+
+			<!-- wp:post-title {"fontSize":"large"} /--></div>
+			<!-- /wp:column --></div>
+			<!-- /wp:columns -->
+
+			<!-- wp:separator {"opacity":"css","style":{"color":{"background":"#cccdbb"}},"className":"is-style-wide"} -->
+			<hr class="wp-block-separator has-text-color has-css-opacity has-background is-style-wide" style="background-color:#cccdbb;color:#cccdbb"/>
+			<!-- /wp:separator --></div>
+			<!-- /wp:group -->
+			<!-- /wp:post-template --></div>
+			<!-- /wp:query -->',
+		),
+		'query-post-list-cards'                   => array(
+			'title'      => _x( 'Post list cards', 'Block pattern title', 'gutenberg' ),
+			'blockTypes' => array( 'core/query' ),
+			'categories' => array( 'query' ),
+			'content'    => '<!-- wp:query {"queryId":7,"query":{"perPage":"6","pages":0,"offset":0,"postType":"post","order":"desc","orderBy":"date","author":"","search":"","exclude":[],"sticky":"","inherit":false},"displayLayout":{"type":"list"},"align":"wide"} -->
+			<div class="wp-block-query alignwide"><!-- wp:post-template {"align":"full"} -->
+			<!-- wp:group {"style":{"border":{"radius":"0px","width":"4px"},"spacing":{"padding":{"top":"4px","right":"4px","bottom":"4px","left":"4px"}}},"borderColor":"contrast"} -->
+			<div class="wp-block-group has-border-color has-contrast-border-color" style="border-width:4px;border-radius:0px;padding-top:4px;padding-right:4px;padding-bottom:4px;padding-left:4px"><!-- wp:columns {"style":{"spacing":{"padding":{"top":"0px","right":"0px","bottom":"0px","left":"0px"}}},"backgroundColor":"base"} -->
+			<div class="wp-block-columns has-base-background-color has-background" style="padding-top:0px;padding-right:0px;padding-bottom:0px;padding-left:0px"><!-- wp:column {"verticalAlignment":"center","width":"25%"} -->
+			<div class="wp-block-column is-vertically-aligned-center" style="flex-basis:25%"><!-- wp:cover {"useFeaturedImage":true,"dimRatio":0,"minHeight":300} -->
+			<div class="wp-block-cover" style="min-height:300px"><span aria-hidden="true" class="wp-block-cover__background has-background-dim-0 has-background-dim"></span><div class="wp-block-cover__inner-container"><!-- wp:paragraph {"align":"center","placeholder":"Write title…","fontSize":"large"} -->
+			<p class="has-text-align-center has-large-font-size"></p>
+			<!-- /wp:paragraph --></div></div>
+			<!-- /wp:cover --></div>
+			<!-- /wp:column -->
+
+			<!-- wp:column {"verticalAlignment":"center","width":"75%","style":{"spacing":{"padding":{"top":"0px","right":"0px","bottom":"0px","left":"0px"}}}} -->
+			<div class="wp-block-column is-vertically-aligned-center" style="padding-top:0px;padding-right:0px;padding-bottom:0px;padding-left:0px;flex-basis:75%"><!-- wp:group {"layout":{"type":"constrained"},"style":{"border":{"radius":"0px"},"spacing":{"blockGap":"12px","padding":{"top":"var:preset|spacing|30","right":"var:preset|spacing|30","bottom":"var:preset|spacing|30","left":"var:preset|spacing|30"}}},"backgroundColor":"base"} -->
+			<div class="wp-block-group has-base-background-color has-background" style="border-radius:0px;padding-top:var(--wp--preset--spacing--30);padding-right:var(--wp--preset--spacing--30);padding-bottom:var(--wp--preset--spacing--30);padding-left:var(--wp--preset--spacing--30)"><!-- wp:post-title {"textAlign":"center","style":{"typography":{"fontStyle":"normal","fontWeight":"700","textTransform":"capitalize"}},"fontSize":"x-large"} /-->
+
+			<!-- wp:post-author {"textAlign":"center","showAvatar":false} /--></div>
+			<!-- /wp:group --></div>
+			<!-- /wp:column --></div>
+			<!-- /wp:columns --></div>
+			<!-- /wp:group -->
+			<!-- /wp:post-template --></div>
+			<!-- /wp:query -->',
+		),
+		'query-post-table'                   => array(
+			'title'      => _x( 'Post table', 'Block pattern title', 'gutenberg' ),
+			'blockTypes' => array( 'core/query' ),
+			'categories' => array( 'query' ),
+			'content'    => '<!-- wp:group {"align":"wide"} -->
+<div class="wp-block-group alignwide"><!-- wp:separator {"opacity":"css","className":"alignwide is-style-wide"} -->
+<hr class="wp-block-separator has-css-opacity alignwide is-style-wide"/>
+<!-- /wp:separator -->
+
+<!-- wp:query {"queryId":7,"query":{"perPage":10,"pages":0,"offset":0,"postType":"post","order":"desc","orderBy":"date","author":"","search":"","exclude":[],"sticky":"","inherit":false},"displayLayout":{"type":"list"},"align":"wide"} -->
+<div class="wp-block-query alignwide"><!-- wp:post-template {"align":"wide"} -->
+<!-- wp:columns {"align":"wide"} -->
+<div class="wp-block-columns alignwide"><!-- wp:column -->
+<div class="wp-block-column"><!-- wp:post-date {"fontSize":"small"} /--></div>
+<!-- /wp:column -->
+
+<!-- wp:column {"width":"30%"} -->
+<div class="wp-block-column" style="flex-basis:30%"><!-- wp:post-title {"isLink":true,"fontSize":"small"} /--></div>
+<!-- /wp:column -->
+
+<!-- wp:column -->
+<div class="wp-block-column"><!-- wp:post-terms {"term":"category","fontSize":"small"} /--></div>
+<!-- /wp:column -->
+
+<!-- wp:column -->
+<div class="wp-block-column"><!-- wp:post-terms {"term":"post_tag","fontSize":"small"} /--></div>
+<!-- /wp:column --></div>
+<!-- /wp:columns -->
+<!-- /wp:post-template -->
+
+<!-- wp:spacer {"height":"20px"} -->
+<div style="height:20px" aria-hidden="true" class="wp-block-spacer"></div>
+<!-- /wp:spacer -->
+
+<!-- wp:separator {"opacity":"css","className":"alignwide"} -->
+<hr class="wp-block-separator has-css-opacity alignwide"/>
+<!-- /wp:separator -->
+
+<!-- wp:spacer {"height":"40px"} -->
+<div style="height:40px" aria-hidden="true" class="wp-block-spacer"></div>
+<!-- /wp:spacer -->
+
+<!-- wp:query-pagination {"className":"aligncenter"} -->
+<!-- wp:query-pagination-previous /-->
+
+<!-- wp:query-pagination-numbers /-->
+
+<!-- wp:query-pagination-next /-->
+<!-- /wp:query-pagination --></div>
+<!-- /wp:query --></div>
+<!-- /wp:group -->',
+		),
+		'query-post-list-cards'                   => array(
+			'title'      => _x( 'Post list cards', 'Block pattern title', 'gutenberg' ),
+			'blockTypes' => array( 'core/query' ),
+			'categories' => array( 'query' ),
+			'content'    => '<!-- wp:query {"queryId":7,"query":{"perPage":"6","pages":0,"offset":0,"postType":"post","order":"desc","orderBy":"date","author":"","search":"","exclude":[],"sticky":"","inherit":false},"displayLayout":{"type":"list"},"align":"wide"} -->
+			<div class="wp-block-query alignwide"><!-- wp:post-template {"align":"full"} -->
+			<!-- wp:group {"style":{"border":{"radius":"0px","width":"4px"},"spacing":{"padding":{"top":"4px","right":"4px","bottom":"4px","left":"4px"}}},"borderColor":"contrast"} -->
+			<div class="wp-block-group has-border-color has-contrast-border-color" style="border-width:4px;border-radius:0px;padding-top:4px;padding-right:4px;padding-bottom:4px;padding-left:4px"><!-- wp:columns {"style":{"spacing":{"padding":{"top":"0px","right":"0px","bottom":"0px","left":"0px"}}},"backgroundColor":"base"} -->
+			<div class="wp-block-columns has-base-background-color has-background" style="padding-top:0px;padding-right:0px;padding-bottom:0px;padding-left:0px"><!-- wp:column {"verticalAlignment":"center","width":"25%"} -->
+			<div class="wp-block-column is-vertically-aligned-center" style="flex-basis:25%"><!-- wp:cover {"useFeaturedImage":true,"dimRatio":0,"minHeight":300} -->
+			<div class="wp-block-cover" style="min-height:300px"><span aria-hidden="true" class="wp-block-cover__background has-background-dim-0 has-background-dim"></span><div class="wp-block-cover__inner-container"><!-- wp:paragraph {"align":"center","placeholder":"Write title…","fontSize":"large"} -->
+			<p class="has-text-align-center has-large-font-size"></p>
+			<!-- /wp:paragraph --></div></div>
+			<!-- /wp:cover --></div>
+			<!-- /wp:column -->
+
+			<!-- wp:column {"verticalAlignment":"center","width":"75%","style":{"spacing":{"padding":{"top":"0px","right":"0px","bottom":"0px","left":"0px"}}}} -->
+			<div class="wp-block-column is-vertically-aligned-center" style="padding-top:0px;padding-right:0px;padding-bottom:0px;padding-left:0px;flex-basis:75%"><!-- wp:group {"layout":{"type":"constrained"},"style":{"border":{"radius":"0px"},"spacing":{"blockGap":"12px","padding":{"top":"var:preset|spacing|30","right":"var:preset|spacing|30","bottom":"var:preset|spacing|30","left":"var:preset|spacing|30"}}},"backgroundColor":"base"} -->
+			<div class="wp-block-group has-base-background-color has-background" style="border-radius:0px;padding-top:var(--wp--preset--spacing--30);padding-right:var(--wp--preset--spacing--30);padding-bottom:var(--wp--preset--spacing--30);padding-left:var(--wp--preset--spacing--30)"><!-- wp:post-title {"textAlign":"center","style":{"typography":{"fontStyle":"normal","fontWeight":"700","textTransform":"capitalize"}},"fontSize":"x-large"} /-->
+
+			<!-- wp:post-author {"textAlign":"center","showAvatar":false} /--></div>
+			<!-- /wp:group --></div>
+			<!-- /wp:column --></div>
+			<!-- /wp:columns --></div>
+			<!-- /wp:group -->
+			<!-- /wp:post-template --></div>
+			<!-- /wp:query -->',
+		),
+		'query-two-column-text-list'                   => array(
+			'title'      => _x( 'Two column text list', 'Block pattern title', 'gutenberg' ),
+			'blockTypes' => array( 'core/query' ),
+			'categories' => array( 'query' ),
+			'content'    => '<!-- wp:query {"queryId":0,"query":{"perPage":5,"pages":0,"offset":0,"postType":"post","order":"desc","orderBy":"date","author":"","search":"","exclude":[],"sticky":"","inherit":false},"displayLayout":{"type":"list"},"align":"full"} -->
+			<div class="wp-block-query alignfull"><!-- wp:post-template {"align":"full"} -->
+			<!-- wp:columns {"align":"wide"} -->
+			<div class="wp-block-columns alignwide"><!-- wp:column {"width":"50%","style":{"spacing":{"padding":{"top":"2em","bottom":"0em"}}}} -->
+			<div class="wp-block-column" style="padding-top:2em;padding-bottom:0em;flex-basis:50%"><!-- wp:post-title {"isLink":true} /-->
+
+			<!-- wp:post-date {"fontSize":"small"} /--></div>
+			<!-- /wp:column -->
+
+			<!-- wp:column {"width":"50%","style":{"spacing":{"padding":{"top":"2em","right":"0em","bottom":"0em","left":"0em"}}}} -->
+			<div class="wp-block-column" style="padding-top:2em;padding-right:0em;padding-bottom:0em;padding-left:0em;flex-basis:50%"><!-- wp:post-excerpt {"moreText":"","style":{"typography":{"lineHeight":"1.6"}}} /--></div>
+			<!-- /wp:column --></div>
+			<!-- /wp:columns -->
+
+			<!-- wp:separator {"opacity":"css","backgroundColor":"primary","className":"alignwide is-style-wide"} -->
+			<hr class="wp-block-separator has-text-color has-primary-color has-css-opacity has-primary-background-color has-background alignwide is-style-wide"/>
+			<!-- /wp:separator -->
+			<!-- /wp:post-template -->
+
+			<!-- wp:group {"align":"wide","style":{"spacing":{"padding":{"top":"2em"}}}} -->
+			<div class="wp-block-group alignwide" style="padding-top:2em"><!-- wp:query-pagination {"className":"alignwide"} -->
+			<!-- wp:query-pagination-previous /-->
+
+			<!-- wp:query-pagination-numbers /-->
+
+			<!-- wp:query-pagination-next /-->
+			<!-- /wp:query-pagination --></div>
+			<!-- /wp:group --></div>
+			<!-- /wp:query -->',
+		),
+		'query-post-list-cards'                   => array(
+			'title'      => _x( 'Post list cards', 'Block pattern title', 'gutenberg' ),
+			'blockTypes' => array( 'core/query' ),
+			'categories' => array( 'query' ),
+			'content'    => '<!-- wp:query {"queryId":7,"query":{"perPage":"6","pages":0,"offset":0,"postType":"post","order":"desc","orderBy":"date","author":"","search":"","exclude":[],"sticky":"","inherit":false},"displayLayout":{"type":"list"},"align":"wide"} -->
+			<div class="wp-block-query alignwide"><!-- wp:post-template {"align":"full"} -->
+			<!-- wp:group {"style":{"border":{"radius":"0px","width":"4px"},"spacing":{"padding":{"top":"4px","right":"4px","bottom":"4px","left":"4px"}}},"borderColor":"contrast"} -->
+			<div class="wp-block-group has-border-color has-contrast-border-color" style="border-width:4px;border-radius:0px;padding-top:4px;padding-right:4px;padding-bottom:4px;padding-left:4px"><!-- wp:columns {"style":{"spacing":{"padding":{"top":"0px","right":"0px","bottom":"0px","left":"0px"}}},"backgroundColor":"base"} -->
+			<div class="wp-block-columns has-base-background-color has-background" style="padding-top:0px;padding-right:0px;padding-bottom:0px;padding-left:0px"><!-- wp:column {"verticalAlignment":"center","width":"25%"} -->
+			<div class="wp-block-column is-vertically-aligned-center" style="flex-basis:25%"><!-- wp:cover {"useFeaturedImage":true,"dimRatio":0,"minHeight":300} -->
+			<div class="wp-block-cover" style="min-height:300px"><span aria-hidden="true" class="wp-block-cover__background has-background-dim-0 has-background-dim"></span><div class="wp-block-cover__inner-container"><!-- wp:paragraph {"align":"center","placeholder":"Write title…","fontSize":"large"} -->
+			<p class="has-text-align-center has-large-font-size"></p>
+			<!-- /wp:paragraph --></div></div>
+			<!-- /wp:cover --></div>
+			<!-- /wp:column -->
+
+			<!-- wp:column {"verticalAlignment":"center","width":"75%","style":{"spacing":{"padding":{"top":"0px","right":"0px","bottom":"0px","left":"0px"}}}} -->
+			<div class="wp-block-column is-vertically-aligned-center" style="padding-top:0px;padding-right:0px;padding-bottom:0px;padding-left:0px;flex-basis:75%"><!-- wp:group {"layout":{"type":"constrained"},"style":{"border":{"radius":"0px"},"spacing":{"blockGap":"12px","padding":{"top":"var:preset|spacing|30","right":"var:preset|spacing|30","bottom":"var:preset|spacing|30","left":"var:preset|spacing|30"}}},"backgroundColor":"base"} -->
+			<div class="wp-block-group has-base-background-color has-background" style="border-radius:0px;padding-top:var(--wp--preset--spacing--30);padding-right:var(--wp--preset--spacing--30);padding-bottom:var(--wp--preset--spacing--30);padding-left:var(--wp--preset--spacing--30)"><!-- wp:post-title {"textAlign":"center","style":{"typography":{"fontStyle":"normal","fontWeight":"700","textTransform":"capitalize"}},"fontSize":"x-large"} /-->
+
+			<!-- wp:post-author {"textAlign":"center","showAvatar":false} /--></div>
+			<!-- /wp:group --></div>
+			<!-- /wp:column --></div>
+			<!-- /wp:columns --></div>
+			<!-- /wp:group -->
+			<!-- /wp:post-template --></div>
+			<!-- /wp:query -->',
+		),
+		'query-two-column-with-tags'                   => array(
+			'title'      => _x( 'Two column with tags', 'Block pattern title', 'gutenberg' ),
+			'blockTypes' => array( 'core/query' ),
+			'categories' => array( 'query' ),
+			'content'    => '<!-- wp:query {"queryId":0,"query":{"perPage":"10","pages":0,"offset":0,"postType":"post","order":"desc","orderBy":"date","author":"","search":"","exclude":[],"sticky":"","inherit":false},"displayLayout":{"type":"list"},"align":"wide"} -->
+			<div class="wp-block-query alignwide"><!-- wp:post-template -->
+			<!-- wp:columns {"verticalAlignment":"center","align":"wide","style":{"spacing":{"padding":{"top":"0px","right":"0px","bottom":"0px","left":"0px"}}}} -->
+			<div class="wp-block-columns alignwide are-vertically-aligned-center" style="padding-top:0px;padding-right:0px;padding-bottom:0px;padding-left:0px"><!-- wp:column {"verticalAlignment":"center","width":"50%","style":{"spacing":{"padding":{"bottom":"0em","top":"0em"}}}} -->
+			<div class="wp-block-column is-vertically-aligned-center" style="padding-top:0em;padding-bottom:0em;flex-basis:50%"><!-- wp:post-title {"isLink":true,"fontSize":"large"} /--></div>
+			<!-- /wp:column -->
+
+			<!-- wp:column {"verticalAlignment":"center","width":"50%","style":{"spacing":{"padding":{"right":"0em","bottom":"0em","left":"0em","top":"0em"}}}} -->
+			<div class="wp-block-column is-vertically-aligned-center" style="padding-top:0em;padding-right:0em;padding-bottom:0em;padding-left:0em;flex-basis:50%"><!-- wp:post-terms {"term":"post_tag"} /--></div>
+			<!-- /wp:column --></div>
+			<!-- /wp:columns -->
+			<!-- /wp:post-template -->
+
+			<!-- wp:group {"align":"wide","style":{"spacing":{"padding":{"top":"2em"}}}} -->
+			<div class="wp-block-group alignwide" style="padding-top:2em"><!-- wp:query-pagination {"className":"alignwide"} -->
+			<!-- wp:query-pagination-previous /-->
+
+			<!-- wp:query-pagination-numbers /-->
+
+			<!-- wp:query-pagination-next /-->
+			<!-- /wp:query-pagination --></div>
+			<!-- /wp:group --></div>
+			<!-- /wp:query -->',
+		),
+		'query-colorful-full-width-posts'                   => array(
+			'title'      => _x( 'Colorful full width posts', 'Block pattern title', 'gutenberg' ),
+			'blockTypes' => array( 'core/query' ),
+			'categories' => array( 'query' ),
+			'content'    => '<!-- wp:group {"layout":{"type":"constrained"},"align":"full","style":{"spacing":{"blockGap":"0px"}}} -->
+			<div class="wp-block-group alignfull"><!-- wp:query {"queryId":7,"query":{"perPage":"1","pages":0,"offset":0,"postType":"post","order":"desc","orderBy":"date","author":"","search":"","exclude":[],"sticky":"","inherit":false},"displayLayout":{"type":"list"},"align":"full"} -->
+			<div class="wp-block-query alignfull"><!-- wp:post-template {"align":"full"} -->
+			<!-- wp:cover {"customOverlayColor":"#eef5e9","minHeight":246,"minHeightUnit":"px","contentPosition":"center center","isDark":false,"align":"full"} -->
+			<div class="wp-block-cover alignfull is-light" style="min-height:246px"><span aria-hidden="true" class="wp-block-cover__background has-background-dim-100 has-background-dim" style="background-color:#eef5e9"></span><div class="wp-block-cover__inner-container"><!-- wp:post-title {"textAlign":"center","level":3,"textColor":"black"} /--></div></div>
+			<!-- /wp:cover -->
+			<!-- /wp:post-template --></div>
+			<!-- /wp:query -->
+
+			<!-- wp:query {"queryId":7,"query":{"perPage":"1","pages":0,"offset":1,"postType":"post","order":"desc","orderBy":"date","author":"","search":"","exclude":[],"sticky":"","inherit":false},"displayLayout":{"type":"list"},"align":"full"} -->
+			<div class="wp-block-query alignfull"><!-- wp:post-template {"align":"full"} -->
+			<!-- wp:cover {"customOverlayColor":"#ffc4a3","minHeight":246,"minHeightUnit":"px","contentPosition":"center center","isDark":false,"align":"full"} -->
+			<div class="wp-block-cover alignfull is-light" style="min-height:246px"><span aria-hidden="true" class="wp-block-cover__background has-background-dim-100 has-background-dim" style="background-color:#ffc4a3"></span><div class="wp-block-cover__inner-container"><!-- wp:post-title {"textAlign":"center","level":3,"textColor":"black"} /--></div></div>
+			<!-- /wp:cover -->
+			<!-- /wp:post-template --></div>
+			<!-- /wp:query -->
+
+			<!-- wp:query {"queryId":7,"query":{"perPage":"1","pages":0,"offset":2,"postType":"post","order":"desc","orderBy":"date","author":"","search":"","exclude":[],"sticky":"","inherit":false},"displayLayout":{"type":"list"},"align":"full"} -->
+			<div class="wp-block-query alignfull"><!-- wp:post-template {"align":"full"} -->
+			<!-- wp:cover {"customOverlayColor":"#cccdbb","minHeight":246,"minHeightUnit":"px","contentPosition":"center center","isDark":false,"align":"full"} -->
+			<div class="wp-block-cover alignfull is-light" style="min-height:246px"><span aria-hidden="true" class="wp-block-cover__background has-background-dim-100 has-background-dim" style="background-color:#cccdbb"></span><div class="wp-block-cover__inner-container"><!-- wp:post-title {"textAlign":"center","level":3,"textColor":"black"} /--></div></div>
+			<!-- /wp:cover -->
+			<!-- /wp:post-template --></div>
+			<!-- /wp:query -->
+
+			<!-- wp:query {"queryId":7,"query":{"perPage":"1","pages":0,"offset":3,"postType":"post","order":"desc","orderBy":"date","author":"","search":"","exclude":[],"sticky":"","inherit":false},"displayLayout":{"type":"list"},"align":"full"} -->
+			<div class="wp-block-query alignfull"><!-- wp:post-template {"align":"full"} -->
+			<!-- wp:cover {"customOverlayColor":"#ffedbf","minHeight":246,"minHeightUnit":"px","contentPosition":"center center","isDark":false,"align":"full"} -->
+			<div class="wp-block-cover alignfull is-light" style="min-height:246px"><span aria-hidden="true" class="wp-block-cover__background has-background-dim-100 has-background-dim" style="background-color:#ffedbf"></span><div class="wp-block-cover__inner-container"><!-- wp:post-title {"textAlign":"center","level":3,"textColor":"black"} /--></div></div>
+			<!-- /wp:cover -->
+			<!-- /wp:post-template --></div>
+			<!-- /wp:query --></div>
+			<!-- /wp:group -->',
+		),
+		'query-featured-post-with-post-list'                   => array(
+			'title'      => _x( 'Featured post with post list', 'Block pattern title', 'gutenberg' ),
+			'blockTypes' => array( 'core/query' ),
+			'categories' => array( 'query' ),
+			'content'    => '<!-- wp:columns {"align":"wide"} -->
+			<div class="wp-block-columns alignwide"><!-- wp:column {"width":"66.66%"} -->
+			<div class="wp-block-column" style="flex-basis:66.66%"><!-- wp:query {"queryId":2,"query":{"perPage":1,"pages":0,"offset":0,"postType":"post","order":"desc","orderBy":"date","author":"","search":"","exclude":[],"sticky":"","inherit":false},"displayLayout":{"type":"list"}} -->
+			<div class="wp-block-query"><!-- wp:post-template -->
+			<!-- wp:post-featured-image {"isLink":true} /-->
+
+			<!-- wp:post-title {"isLink":true} /-->
+
+			<!-- wp:post-date {"fontSize":"tiny"} /-->
+			<!-- /wp:post-template --></div>
+			<!-- /wp:query --></div>
+			<!-- /wp:column -->
+
+			<!-- wp:column -->
+			<div class="wp-block-column"><!-- wp:query {"queryId":1,"query":{"perPage":7,"pages":0,"offset":1,"postType":"post","order":"desc","orderBy":"date","author":"","search":"","exclude":[],"sticky":"","inherit":false},"displayLayout":{"type":"list","columns":2}} -->
+			<div class="wp-block-query"><!-- wp:post-template -->
+			<!-- wp:post-title {"isLink":true,"fontSize":"large"} /-->
+
+			<!-- wp:post-date {"fontSize":"extra-small"} /-->
+
+			<!-- wp:spacer {"height":"20px"} -->
+			<div style="height:20px" aria-hidden="true" class="wp-block-spacer"></div>
+			<!-- /wp:spacer -->
+
+			<!-- wp:separator {"opacity":"css","className":"is-style-wide"} -->
+			<hr class="wp-block-separator has-css-opacity is-style-wide"/>
+			<!-- /wp:separator -->
+
+			<!-- wp:spacer {"height":"20px"} -->
+			<div style="height:20px" aria-hidden="true" class="wp-block-spacer"></div>
+			<!-- /wp:spacer -->
+			<!-- /wp:post-template --></div>
+			<!-- /wp:query --></div>
+			<!-- /wp:column --></div>
+			<!-- /wp:columns -->',
+		),
+		'query-more-posts'                   => array(
+			'title'      => _x( 'Featured post with more posts', 'Block pattern title', 'gutenberg' ),
+			'blockTypes' => array( 'core/query' ),
+			'categories' => array( 'query' ),
+			'content'    => '<!-- wp:group {"align":"wide","style":{"spacing":{"padding":{"top":"var:preset|spacing|30","right":"var:preset|spacing|30","bottom":"var:preset|spacing|30","left":"var:preset|spacing|30"}}},"backgroundColor":"black"} -->
+			<div class="wp-block-group alignwide has-black-background-color has-background" style="padding-top:var(--wp--preset--spacing--30);padding-right:var(--wp--preset--spacing--30);padding-bottom:var(--wp--preset--spacing--30);padding-left:var(--wp--preset--spacing--30)"><!-- wp:query {"queryId":25,"query":{"perPage":1,"pages":0,"offset":0,"postType":"post","order":"desc","orderBy":"date","author":"","search":"","exclude":[],"sticky":"","inherit":false},"displayLayout":{"type":"list"}} -->
+			<div class="wp-block-query"><!-- wp:post-template -->
+			<!-- wp:columns {"verticalAlignment":"center","textColor":"base"} -->
+			<div class="wp-block-columns are-vertically-aligned-center has-base-color has-text-color"><!-- wp:column {"verticalAlignment":"center","width":"20%"} -->
+			<div class="wp-block-column is-vertically-aligned-center" style="flex-basis:20%"><!-- wp:post-author {"showAvatar":false} /--></div>
+			<!-- /wp:column -->
+
+			<!-- wp:column {"verticalAlignment":"center","width":"66.66%"} -->
+			<div class="wp-block-column is-vertically-aligned-center" style="flex-basis:66.66%"><!-- wp:post-date /--></div>
+			<!-- /wp:column --></div>
+			<!-- /wp:columns -->
+
+			<!-- wp:post-featured-image {"isLink":true,"align":"wide"} /-->
+
+			<!-- wp:post-title {"isLink":true,"style":{"elements":{"link":{"color":{"text":"var:preset|color|base"}}}},"textColor":"base"} /-->
+
+			<!-- wp:post-excerpt {"style":{"elements":{"link":{"color":{"text":"var:preset|color|base"}}}},"textColor":"base"} /-->
+
+			<!-- wp:spacer {"height":"25px"} -->
+			<div style="height:25px" aria-hidden="true" class="wp-block-spacer"></div>
+			<!-- /wp:spacer -->
+			<!-- /wp:post-template --></div>
+			<!-- /wp:query -->
+
+			<!-- wp:paragraph {"style":{"elements":{"link":{"color":{"text":"var:preset|color|base"}}}},"textColor":"base"} -->
+			<p class="has-base-color has-text-color has-link-color"><strong>More Posts</strong></p>
+			<!-- /wp:paragraph -->
+
+			<!-- wp:query {"queryId":14,"query":{"perPage":6,"pages":0,"offset":0,"postType":"post","order":"desc","orderBy":"date","author":"","search":"","exclude":[],"sticky":"exclude","inherit":false},"displayLayout":{"type":"flex","columns":3}} -->
+			<div class="wp-block-query"><!-- wp:post-template -->
+			<!-- wp:group {"layout":{"inherit":false},"style":{"spacing":{"padding":{"top":"0px","right":"0px","bottom":"var:preset|spacing|40","left":"0px"}}}} -->
+			<div class="wp-block-group" style="padding-top:0px;padding-right:0px;padding-bottom:var(--wp--preset--spacing--40);padding-left:0px"><!-- wp:separator {"backgroundColor":"base"} -->
+			<hr class="wp-block-separator has-text-color has-base-color has-alpha-channel-opacity has-base-background-color has-background"/>
+			<!-- /wp:separator -->
+
+			<!-- wp:post-title {"textColor":"base"} /--></div>
+			<!-- /wp:group -->
+			<!-- /wp:post-template --></div>
+			<!-- /wp:query --></div>
+			<!-- /wp:group -->',
+		),
 		// Initial block pattern to be used with block transformations with patterns.
 		'social-links-shared-background-color' => array(
 			'title'         => _x( 'Social links with a shared background color', 'Block pattern title', 'gutenberg' ),


### PR DESCRIPTION
Follow up to https://github.com/WordPress/gutenberg/pull/30763, closes https://github.com/WordPress/gutenberg/issues/44140

It's been a while since we've updated the bundled patterns for the Query Loop block. I wanted to share a few new options, especially some more text-based options as discussed in https://github.com/WordPress/gutenberg/issues/44140

This PR adds 8 new patterns for the Query Loop block. If we move forward with adding some of these new patterns, we may also want to go through and remove some of the existing image-based ones. Here are names and screenshots of the patterns added:

**Post feed**

<img src="https://user-images.githubusercontent.com/77359364/191310565-35d64e36-d0fb-4ff8-b339-6f135b643396.png">

**Post list cards**

<img src="https://user-images.githubusercontent.com/77359364/190220409-f3ca86f4-fd04-41f1-85e8-9d1f9e844482.png">

**Post table**

<img src="https://user-images.githubusercontent.com/77359364/190220454-e319b106-aa00-40bf-9532-548fe1d30e6e.png">

**Two column text list**

<img src="https://user-images.githubusercontent.com/77359364/190220501-ef28843e-d85f-4566-833e-1d61b3155e91.png">

**Two column with tags**

<img src="https://user-images.githubusercontent.com/77359364/190220551-18f0d5f9-61a0-4737-aaa3-7c5c6cbcb587.png">

**Colorful full width posts**

<img src="https://user-images.githubusercontent.com/77359364/190220584-2fe4b5ec-14b7-4be9-974e-dd35f674cbc0.png">

**Featured post with post list**

<img src="https://user-images.githubusercontent.com/77359364/190220620-1070de29-5d21-4f1b-96ce-786e1fd7eaca.png">

**More posts**

<img src="https://user-images.githubusercontent.com/77359364/190220666-9fd8c314-6d5b-42f0-8351-1b92f697c283.png">

**Post and date list**
(Adapted from [Beaumont theme](https://wordpress.org/themes/beaumont/))

<img src="https://user-images.githubusercontent.com/77359364/193334788-234ddfaf-ad7a-488f-a437-aa711fb0719d.png">

Note: the last three patterns are combinations of blocks that contain a Query Loop block within.

## Testing Instructions
1. Open the site editor
2. Select the Query Loop block and select "Replace" from the toolbar to open the pattern explore modal
3. Check to see whether the new patterns appear in the modal
4. Insert the patterns and make sure they look ok in the template

## Requested feedback
Let's figure out which of these patterns we'd like to add and which of the existing Query Loop patterns should be removed. cc [@WordPress/gutenberg-design](https://github.com/orgs/WordPress/teams/gutenberg-design)
