### PR TITLE
ToggleGroupControl: Refactor to handle de-selection and multiple selections

### DIFF
--- a/packages/components/src/toggle-group-control/stories/index.tsx
+++ b/packages/components/src/toggle-group-control/stories/index.tsx
@@ -122,3 +122,13 @@ WithIcons.args = {
 		{ value: 'lowercase', label: 'Lowercase', icon: formatLowercase },
 	].map( mapPropsToOptionIconComponent ),
 };
+
+/**
+ * When the `isDeselectable` prop is true, the option can be deselected by clicking on it again.
+ */
+export const Deselectable: ComponentStory< typeof ToggleGroupControl > =
+	Template.bind( {} );
+Deselectable.args = {
+	...WithIcons.args,
+	isDeselectable: true,
+};

--- a/packages/components/src/toggle-group-control/stories/index.tsx
+++ b/packages/components/src/toggle-group-control/stories/index.tsx
@@ -122,13 +122,3 @@ WithIcons.args = {
 		{ value: 'lowercase', label: 'Lowercase', icon: formatLowercase },
 	].map( mapPropsToOptionIconComponent ),
 };
-
-/**
- * A borderless style may be preferred in some contexts.
- */
-export const Borderless: ComponentStory< typeof ToggleGroupControl > =
-	Template.bind( {} );
-Borderless.args = {
-	...WithIcons.args,
-	__experimentalIsBorderless: true,
-};

--- a/packages/components/src/toggle-group-control/test/__snapshots__/index.tsx.snap
+++ b/packages/components/src/toggle-group-control/test/__snapshots__/index.tsx.snap
@@ -198,7 +198,7 @@ exports[`ToggleGroupControl should render correctly with icons 1`] = `
       class="components-toggle-group-control emotion-8 emotion-9"
       data-wp-c16t="true"
       data-wp-component="ToggleGroupControl"
-      id="toggle-group-control-1"
+      id="toggle-group-control-as-radio-1"
       role="radiogroup"
     >
       <div
@@ -212,7 +212,6 @@ exports[`ToggleGroupControl should render correctly with icons 1`] = `
       />
       <div
         class="emotion-12 emotion-13"
-        data-active="true"
       >
         <button
           aria-checked="true"
@@ -221,7 +220,7 @@ exports[`ToggleGroupControl should render correctly with icons 1`] = `
           data-value="uppercase"
           data-wp-c16t="true"
           data-wp-component="ToggleGroupControlOptionBase"
-          id="toggle-group-control-1-2"
+          id="toggle-group-control-as-radio-1-2"
           role="radio"
           tabindex="0"
         >
@@ -245,7 +244,6 @@ exports[`ToggleGroupControl should render correctly with icons 1`] = `
       </div>
       <div
         class="emotion-12 emotion-13"
-        data-active="false"
       >
         <button
           aria-checked="false"
@@ -254,7 +252,7 @@ exports[`ToggleGroupControl should render correctly with icons 1`] = `
           data-value="lowercase"
           data-wp-c16t="true"
           data-wp-component="ToggleGroupControlOptionBase"
-          id="toggle-group-control-1-3"
+          id="toggle-group-control-as-radio-1-3"
           role="radio"
           tabindex="-1"
         >
@@ -445,7 +443,7 @@ exports[`ToggleGroupControl should render correctly with text options 1`] = `
       class="components-toggle-group-control emotion-8 emotion-9"
       data-wp-c16t="true"
       data-wp-component="ToggleGroupControl"
-      id="toggle-group-control-0"
+      id="toggle-group-control-as-radio-0"
       role="radiogroup"
     >
       <div
@@ -454,7 +452,6 @@ exports[`ToggleGroupControl should render correctly with text options 1`] = `
       />
       <div
         class="emotion-10 emotion-11"
-        data-active="false"
       >
         <button
           aria-checked="false"
@@ -463,7 +460,7 @@ exports[`ToggleGroupControl should render correctly with text options 1`] = `
           data-value="rigas"
           data-wp-c16t="true"
           data-wp-component="ToggleGroupControlOptionBase"
-          id="toggle-group-control-0-0"
+          id="toggle-group-control-as-radio-0-0"
           role="radio"
           tabindex="0"
         >
@@ -476,7 +473,6 @@ exports[`ToggleGroupControl should render correctly with text options 1`] = `
       </div>
       <div
         class="emotion-10 emotion-11"
-        data-active="false"
       >
         <button
           aria-checked="false"
@@ -485,7 +481,7 @@ exports[`ToggleGroupControl should render correctly with text options 1`] = `
           data-value="jack"
           data-wp-c16t="true"
           data-wp-component="ToggleGroupControlOptionBase"
-          id="toggle-group-control-0-1"
+          id="toggle-group-control-as-radio-0-1"
           role="radio"
           tabindex="-1"
         >

--- a/packages/components/src/toggle-group-control/test/__snapshots__/index.tsx.snap
+++ b/packages/components/src/toggle-group-control/test/__snapshots__/index.tsx.snap
@@ -41,7 +41,6 @@ exports[`ToggleGroupControl should render correctly with icons 1`] = `
 .emotion-8 {
   background: #fff;
   border: 1px solid transparent;
-  border-radius: 2px;
   display: -webkit-inline-box;
   display: -webkit-inline-flex;
   display: -ms-inline-flexbox;
@@ -53,12 +52,17 @@ exports[`ToggleGroupControl should render correctly with icons 1`] = `
   transition: transform 100ms linear;
   min-height: 36px;
   border-color: #757575;
+  border-radius: 2px;
 }
 
 @media ( prefers-reduced-motion: reduce ) {
   .emotion-8 {
     transition-duration: 0ms;
   }
+}
+
+.emotion-8:hover {
+  border-color: #757575;
 }
 
 .emotion-8:focus-within {
@@ -68,14 +72,9 @@ exports[`ToggleGroupControl should render correctly with icons 1`] = `
   z-index: 1;
 }
 
-.emotion-8:hover {
-  border-color: #757575;
-}
-
 .emotion-10 {
   background: #1e1e1e;
   border-radius: 2px;
-  box-shadow: transparent;
   left: 0;
   position: absolute;
   top: 2px;
@@ -142,6 +141,11 @@ exports[`ToggleGroupControl should render correctly with icons 1`] = `
   user-select: none;
   width: 100%;
   z-index: 2;
+  color: #1e1e1e;
+  width: 30px;
+  padding-left: 0;
+  padding-right: 0;
+  color: #fff;
 }
 
 @media ( prefers-reduced-motion: reduce ) {
@@ -158,24 +162,71 @@ exports[`ToggleGroupControl should render correctly with icons 1`] = `
   background: #fff;
 }
 
+.emotion-14:active {
+  background: transparent;
+}
+
 .emotion-15 {
+  font-size: 13px;
+  line-height: 1;
+}
+
+.emotion-19 {
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  -ms-appearance: none;
+  appearance: none;
+  background: transparent;
+  border: none;
+  border-radius: 2px;
+  color: #757575;
+  fill: currentColor;
+  cursor: pointer;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  font-family: inherit;
+  height: 100%;
+  -webkit-box-pack: center;
+  -ms-flex-pack: center;
+  -webkit-justify-content: center;
+  justify-content: center;
+  line-height: 100%;
+  outline: none;
+  padding: 0 12px;
+  position: relative;
+  text-align: center;
+  -webkit-transition: background 160ms linear,color 160ms linear,font-weight 60ms linear;
+  transition: background 160ms linear,color 160ms linear,font-weight 60ms linear;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
+  width: 100%;
+  z-index: 2;
   color: #1e1e1e;
   width: 30px;
   padding-left: 0;
   padding-right: 0;
 }
 
-.emotion-16 {
-  color: #fff;
+@media ( prefers-reduced-motion: reduce ) {
+  .emotion-19 {
+    transition-duration: 0ms;
+  }
 }
 
-.emotion-16:active {
-  background: transparent;
+.emotion-19::-moz-focus-inner {
+  border: 0;
 }
 
-.emotion-17 {
-  font-size: 13px;
-  line-height: 1;
+.emotion-19:active {
+  background: #fff;
 }
 
 <div
@@ -216,7 +267,7 @@ exports[`ToggleGroupControl should render correctly with icons 1`] = `
         <button
           aria-checked="true"
           aria-label="Uppercase"
-          class="emotion-14 emotion-15 components-toggle-group-control-option-base emotion-16"
+          class="emotion-14 components-toggle-group-control-option-base"
           data-value="uppercase"
           data-wp-c16t="true"
           data-wp-component="ToggleGroupControlOptionBase"
@@ -225,7 +276,7 @@ exports[`ToggleGroupControl should render correctly with icons 1`] = `
           tabindex="0"
         >
           <div
-            class="emotion-17 emotion-18"
+            class="emotion-15 emotion-16"
           >
             <svg
               aria-hidden="true"
@@ -248,7 +299,7 @@ exports[`ToggleGroupControl should render correctly with icons 1`] = `
         <button
           aria-checked="false"
           aria-label="Lowercase"
-          class="emotion-14 emotion-15 components-toggle-group-control-option-base"
+          class="emotion-19 components-toggle-group-control-option-base"
           data-value="lowercase"
           data-wp-c16t="true"
           data-wp-component="ToggleGroupControlOptionBase"
@@ -257,7 +308,7 @@ exports[`ToggleGroupControl should render correctly with icons 1`] = `
           tabindex="-1"
         >
           <div
-            class="emotion-17 emotion-18"
+            class="emotion-15 emotion-16"
           >
             <svg
               aria-hidden="true"
@@ -320,7 +371,6 @@ exports[`ToggleGroupControl should render correctly with text options 1`] = `
 .emotion-8 {
   background: #fff;
   border: 1px solid transparent;
-  border-radius: 2px;
   display: -webkit-inline-box;
   display: -webkit-inline-flex;
   display: -ms-inline-flexbox;
@@ -332,6 +382,7 @@ exports[`ToggleGroupControl should render correctly with text options 1`] = `
   transition: transform 100ms linear;
   min-height: 36px;
   border-color: #757575;
+  border-radius: 2px;
 }
 
 @media ( prefers-reduced-motion: reduce ) {
@@ -340,15 +391,15 @@ exports[`ToggleGroupControl should render correctly with text options 1`] = `
   }
 }
 
+.emotion-8:hover {
+  border-color: #757575;
+}
+
 .emotion-8:focus-within {
   border-color: var( --wp-admin-theme-color-darker-10, #006ba1);
   box-shadow: 0 0 0 0.5px var( --wp-admin-theme-color, #007cba);
   outline: none;
   z-index: 1;
-}
-
-.emotion-8:hover {
-  border-color: #757575;
 }
 
 .emotion-10 {

--- a/packages/components/src/toggle-group-control/test/__snapshots__/index.tsx.snap
+++ b/packages/components/src/toggle-group-control/test/__snapshots__/index.tsx.snap
@@ -143,6 +143,7 @@ exports[`ToggleGroupControl should render correctly with icons 1`] = `
   z-index: 2;
   color: #1e1e1e;
   width: 30px;
+  height: 30px;
   padding-left: 0;
   padding-right: 0;
   color: #fff;
@@ -211,6 +212,7 @@ exports[`ToggleGroupControl should render correctly with icons 1`] = `
   z-index: 2;
   color: #1e1e1e;
   width: 30px;
+  height: 30px;
   padding-left: 0;
   padding-right: 0;
 }

--- a/packages/components/src/toggle-group-control/toggle-group-control-option-base/component.tsx
+++ b/packages/components/src/toggle-group-control/toggle-group-control-option-base/component.tsx
@@ -76,10 +76,8 @@ function ToggleGroupControlOptionBase(
 	const cx = useCx();
 	const labelViewClasses = cx( isBlock && styles.labelBlock );
 	const classes = cx(
-		styles.buttonView,
-		isIcon && styles.isIcon( { size } ),
-		className,
-		isPressed && styles.buttonPressed
+		styles.buttonView( { isDeselectable, isIcon, isPressed, size } ),
+		className
 	);
 
 	const buttonOnClick = () => {

--- a/packages/components/src/toggle-group-control/toggle-group-control-option-base/component.tsx
+++ b/packages/components/src/toggle-group-control/toggle-group-control-option-base/component.tsx
@@ -66,26 +66,33 @@ function ToggleGroupControlOptionBase(
 	const {
 		className,
 		isIcon = false,
+		isMultiple = false,
 		value,
 		children,
 		showTooltip = false,
 		...otherButtonProps
 	} = buttonProps;
 
-	const isPressed = otherContextProps.state === value;
+	const isPressed =
+		otherContextProps.state === value ||
+		otherButtonProps[ 'aria-pressed' ] === true;
 	const cx = useCx();
 	const labelViewClasses = cx( isBlock && styles.labelBlock );
 	const classes = cx(
-		styles.buttonView( { isDeselectable, isIcon, isPressed, size } ),
+		styles.buttonView( {
+			isDeselectable,
+			isIcon,
+			isMultiple,
+			isPressed,
+			size,
+		} ),
 		className
 	);
 
-	const buttonOnClick = () => {
-		if ( isDeselectable && isPressed ) {
-			otherContextProps.setState( undefined );
-		} else {
-			otherContextProps.setState( value );
-		}
+	const singleSelectButtonProps = {
+		'aria-pressed': isPressed,
+		onClick: () =>
+			otherContextProps.setState( isPressed ? undefined : value ),
 	};
 
 	return (
@@ -97,11 +104,10 @@ function ToggleGroupControlOptionBase(
 				{ isDeselectable ? (
 					<button
 						{ ...otherButtonProps }
-						aria-pressed={ isPressed }
+						{ ...( isMultiple ? {} : singleSelectButtonProps ) }
 						type="button"
 						className={ classes }
 						data-value={ value }
-						onClick={ buttonOnClick }
 						ref={ forwardedRef }
 					>
 						<ButtonContentView>{ children }</ButtonContentView>

--- a/packages/components/src/toggle-group-control/toggle-group-control-option-base/component.tsx
+++ b/packages/components/src/toggle-group-control/toggle-group-control-option-base/component.tsx
@@ -58,20 +58,21 @@ function ToggleGroupControlOptionBase(
 		'ToggleGroupControlOptionBase'
 	);
 	const {
-		className,
 		isBlock = false,
+		isDeselectable = false,
+		size = 'default',
+		...otherContextProps
+	} = toggleGroupControlContext;
+	const {
+		className,
 		isIcon = false,
 		value,
 		children,
-		size = 'default',
 		showTooltip = false,
-		...radioProps
-	} = {
-		...toggleGroupControlContext,
-		...buttonProps,
-	};
+		...otherButtonProps
+	} = buttonProps;
 
-	const isActive = radioProps.state === value;
+	const isActive = otherContextProps.state === value;
 	const cx = useCx();
 	const labelViewClasses = cx( isBlock && styles.labelBlock );
 	const classes = cx(
@@ -81,23 +82,44 @@ function ToggleGroupControlOptionBase(
 		isActive && styles.buttonActive
 	);
 
+	const buttonOnClick = () => {
+		if ( isDeselectable && isActive ) {
+			otherContextProps.setState( undefined );
+		} else {
+			otherContextProps.setState( value );
+		}
+	};
+
 	return (
-		<LabelView className={ labelViewClasses } data-active={ isActive }>
+		<LabelView className={ labelViewClasses }>
 			<WithToolTip
 				showTooltip={ showTooltip }
-				text={ radioProps[ 'aria-label' ] }
+				text={ otherButtonProps[ 'aria-label' ] }
 			>
-				<Radio
-					{ ...radioProps }
-					as="button"
-					aria-label={ radioProps[ 'aria-label' ] }
-					className={ classes }
-					data-value={ value }
-					ref={ forwardedRef }
-					value={ value }
-				>
-					<ButtonContentView>{ children }</ButtonContentView>
-				</Radio>
+				{ isDeselectable ? (
+					<button
+						{ ...otherButtonProps }
+						type="button"
+						className={ classes }
+						data-value={ value }
+						onClick={ buttonOnClick }
+						ref={ forwardedRef }
+					>
+						<ButtonContentView>{ children }</ButtonContentView>
+					</button>
+				) : (
+					<Radio
+						as="button"
+						{ ...otherButtonProps }
+						{ ...otherContextProps }
+						className={ classes }
+						data-value={ value }
+						ref={ forwardedRef }
+						value={ value }
+					>
+						<ButtonContentView>{ children }</ButtonContentView>
+					</Radio>
+				) }
 			</WithToolTip>
 		</LabelView>
 	);

--- a/packages/components/src/toggle-group-control/toggle-group-control-option-base/component.tsx
+++ b/packages/components/src/toggle-group-control/toggle-group-control-option-base/component.tsx
@@ -72,18 +72,18 @@ function ToggleGroupControlOptionBase(
 		...otherButtonProps
 	} = buttonProps;
 
-	const isActive = otherContextProps.state === value;
+	const isPressed = otherContextProps.state === value;
 	const cx = useCx();
 	const labelViewClasses = cx( isBlock && styles.labelBlock );
 	const classes = cx(
 		styles.buttonView,
 		isIcon && styles.isIcon( { size } ),
 		className,
-		isActive && styles.buttonActive
+		isPressed && styles.buttonPressed
 	);
 
 	const buttonOnClick = () => {
-		if ( isDeselectable && isActive ) {
+		if ( isDeselectable && isPressed ) {
 			otherContextProps.setState( undefined );
 		} else {
 			otherContextProps.setState( value );

--- a/packages/components/src/toggle-group-control/toggle-group-control-option-base/component.tsx
+++ b/packages/components/src/toggle-group-control/toggle-group-control-option-base/component.tsx
@@ -97,6 +97,7 @@ function ToggleGroupControlOptionBase(
 				{ isDeselectable ? (
 					<button
 						{ ...otherButtonProps }
+						aria-pressed={ isPressed }
 						type="button"
 						className={ classes }
 						data-value={ value }

--- a/packages/components/src/toggle-group-control/toggle-group-control-option-base/styles.ts
+++ b/packages/components/src/toggle-group-control/toggle-group-control-option-base/styles.ts
@@ -21,7 +21,17 @@ export const labelBlock = css`
 	flex: 1;
 `;
 
-export const buttonView = css`
+export const buttonView = ( {
+	isDeselectable,
+	isIcon,
+	isPressed,
+	size,
+}: {
+	isDeselectable?: boolean;
+	isIcon?: boolean;
+	isPressed?: boolean;
+	size: NonNullable< ToggleGroupControlProps[ 'size' ] >;
+} ) => css`
 	align-items: center;
 	appearance: none;
 	background: transparent;
@@ -53,6 +63,22 @@ export const buttonView = css`
 	&:active {
 		background: ${ CONFIG.toggleGroupControlBackgroundColor };
 	}
+
+	${ isDeselectable && deselectable }
+	${ isIcon && isIconStyles( { size } ) }
+	${ isPressed && pressed }
+`;
+
+const pressed = css`
+	color: ${ COLORS.white };
+
+	&:active {
+		background: transparent;
+	}
+`;
+
+const deselectable = css`
+	color: ${ COLORS.gray[ 900 ] };
 `;
 
 export const ButtonContentView = styled.div`
@@ -60,11 +86,7 @@ export const ButtonContentView = styled.div`
 	line-height: 1;
 `;
 
-export const separatorActive = css`
-	background: transparent;
-`;
-
-export const isIcon = ( {
+const isIconStyles = ( {
 	size,
 }: {
 	size: NonNullable< ToggleGroupControlProps[ 'size' ] >;
@@ -81,11 +103,3 @@ export const isIcon = ( {
 		padding-right: 0;
 	`;
 };
-
-export const buttonPressed = css`
-	color: ${ COLORS.white };
-
-	&:active {
-		background: transparent;
-	}
-`;

--- a/packages/components/src/toggle-group-control/toggle-group-control-option-base/styles.ts
+++ b/packages/components/src/toggle-group-control/toggle-group-control-option-base/styles.ts
@@ -8,6 +8,7 @@ import styled from '@emotion/styled';
  * Internal dependencies
  */
 import { CONFIG, COLORS, reduceMotion } from '../../utils';
+import { BACKDROP_BG_COLOR } from '../toggle-group-control/styles';
 import type { ToggleGroupControlProps } from '../types';
 
 export const LabelView = styled.div`
@@ -24,11 +25,13 @@ export const labelBlock = css`
 export const buttonView = ( {
 	isDeselectable,
 	isIcon,
+	isMultiple,
 	isPressed,
 	size,
 }: {
 	isDeselectable?: boolean;
 	isIcon?: boolean;
+	isMultiple?: boolean;
 	isPressed?: boolean;
 	size: NonNullable< ToggleGroupControlProps[ 'size' ] >;
 } ) => css`
@@ -66,7 +69,12 @@ export const buttonView = ( {
 
 	${ isDeselectable && deselectable }
 	${ isIcon && isIconStyles( { size } ) }
+	${ isMultiple && isPressed && staticBackground }
 	${ isPressed && pressed }
+`;
+
+const staticBackground = css`
+	background: ${ BACKDROP_BG_COLOR };
 `;
 
 const pressed = css`
@@ -105,6 +113,7 @@ const isIconStyles = ( {
 	return css`
 		color: ${ COLORS.gray[ 900 ] };
 		width: ${ iconButtonSizes[ size ] };
+		height: ${ iconButtonSizes[ size ] };
 		padding-left: 0;
 		padding-right: 0;
 	`;

--- a/packages/components/src/toggle-group-control/toggle-group-control-option-base/styles.ts
+++ b/packages/components/src/toggle-group-control/toggle-group-control-option-base/styles.ts
@@ -82,7 +82,7 @@ export const isIcon = ( {
 	`;
 };
 
-export const buttonActive = css`
+export const buttonPressed = css`
 	color: ${ COLORS.white };
 
 	&:active {

--- a/packages/components/src/toggle-group-control/toggle-group-control-option-base/styles.ts
+++ b/packages/components/src/toggle-group-control/toggle-group-control-option-base/styles.ts
@@ -79,6 +79,12 @@ const pressed = css`
 
 const deselectable = css`
 	color: ${ COLORS.gray[ 900 ] };
+
+	&:focus {
+		box-shadow: inset 0 0 0 1px ${ COLORS.white },
+			0 0 0 ${ CONFIG.borderWidthFocus } ${ COLORS.ui.theme };
+		outline: 2px solid transparent;
+	}
 `;
 
 export const ButtonContentView = styled.div`

--- a/packages/components/src/toggle-group-control/toggle-group-control/as-button-group.tsx
+++ b/packages/components/src/toggle-group-control/toggle-group-control/as-button-group.tsx
@@ -22,7 +22,8 @@ import ToggleGroupControlBackdrop from './toggle-group-control-backdrop';
 import ToggleGroupControlContext from '../context';
 import { useUpdateEffect } from '../../utils/hooks';
 import type { WordPressComponentProps } from '../../ui/context';
-import type { ToggleGroupControlAsRadioProps } from '../types';
+import type { ToggleGroupControlInnerGroupProps } from '../types';
+import { HStack } from '../../h-stack';
 
 function UnforwardedToggleGroupControlAsButtonGroup(
 	{
@@ -33,7 +34,11 @@ function UnforwardedToggleGroupControlAsButtonGroup(
 		size,
 		value,
 		...otherProps
-	}: WordPressComponentProps< ToggleGroupControlAsRadioProps, 'div', false >,
+	}: WordPressComponentProps<
+		ToggleGroupControlInnerGroupProps,
+		'div',
+		false
+	>,
 	forwardedRef: ForwardedRef< HTMLDivElement >
 ) {
 	const containerRef = useRef();
@@ -88,7 +93,7 @@ function UnforwardedToggleGroupControlAsButtonGroup(
 					containerWidth={ sizes.width }
 					isAdaptiveWidth={ isAdaptiveWidth }
 				/>
-				{ children }
+				<HStack spacing={ 1 }>{ children }</HStack>
 			</View>
 		</ToggleGroupControlContext.Provider>
 	);

--- a/packages/components/src/toggle-group-control/toggle-group-control/as-button-group.tsx
+++ b/packages/components/src/toggle-group-control/toggle-group-control/as-button-group.tsx
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import type { ForwardedRef, ReactText } from 'react';
+import type { ForwardedRef } from 'react';
 
 /**
  * WordPress dependencies
@@ -34,7 +34,7 @@ function UnforwardedToggleGroupControlAsButtonGroup(
 		value,
 		...otherProps
 	}: WordPressComponentProps< ToggleGroupControlAsRadioProps, 'div', false >,
-	forwardedRef: ForwardedRef< any >
+	forwardedRef: ForwardedRef< HTMLDivElement >
 ) {
 	const containerRef = useRef();
 	const [ resizeListener, sizes ] = useResizeObserver();
@@ -42,39 +42,40 @@ function UnforwardedToggleGroupControlAsButtonGroup(
 		ToggleGroupControlAsButtonGroup,
 		'toggle-group-control-as-button-group'
 	).toString();
-	const [ selectedValue, setSelectedValue ] = useState<
-		ReactText | undefined
-	>( value );
-	const radio = { baseId, state: selectedValue, setState: setSelectedValue };
+	const [ selectedValue, setSelectedValue ] = useState( value );
+	const groupContext = {
+		baseId,
+		state: selectedValue,
+		setState: setSelectedValue,
+	};
 	const previousValue = usePrevious( value );
 
-	// Propagate radio.state change.
+	// Propagate groupContext.state change.
 	useUpdateEffect( () => {
-		// Avoid calling onChange if radio state changed
+		// Avoid calling onChange if groupContext state changed
 		// from incoming value.
-		if ( previousValue !== radio.state ) {
-			onChange( radio.state );
+		if ( previousValue !== groupContext.state ) {
+			onChange( groupContext.state );
 		}
-	}, [ radio.state ] );
+	}, [ groupContext.state ] );
 
-	// Sync incoming value with radio.state.
+	// Sync incoming value with groupContext.state.
 	useUpdateEffect( () => {
-		if ( value !== radio.state ) {
-			radio.setState( value );
+		if ( value !== groupContext.state ) {
+			groupContext.setState( value );
 		}
 	}, [ value ] );
 
 	return (
 		<ToggleGroupControlContext.Provider
 			value={ {
-				...radio,
+				...groupContext,
 				isBlock: ! isAdaptiveWidth,
 				isDeselectable: true,
 				size,
 			} }
 		>
 			<View
-				{ ...radio }
 				aria-label={ label }
 				{ ...otherProps }
 				ref={ useMergeRefs( [ containerRef, forwardedRef ] ) }
@@ -82,7 +83,7 @@ function UnforwardedToggleGroupControlAsButtonGroup(
 			>
 				{ resizeListener }
 				<ToggleGroupControlBackdrop
-					{ ...radio }
+					state={ groupContext.state }
 					containerRef={ containerRef }
 					containerWidth={ sizes.width }
 					isAdaptiveWidth={ isAdaptiveWidth }

--- a/packages/components/src/toggle-group-control/toggle-group-control/as-button-group.tsx
+++ b/packages/components/src/toggle-group-control/toggle-group-control/as-button-group.tsx
@@ -1,0 +1,98 @@
+/**
+ * External dependencies
+ */
+import type { ForwardedRef, ReactText } from 'react';
+
+/**
+ * WordPress dependencies
+ */
+import {
+	useMergeRefs,
+	useInstanceId,
+	usePrevious,
+	useResizeObserver,
+} from '@wordpress/compose';
+import { forwardRef, useRef, useState } from '@wordpress/element';
+
+/**
+ * Internal dependencies
+ */
+import { View } from '../../view';
+import ToggleGroupControlBackdrop from './toggle-group-control-backdrop';
+import ToggleGroupControlContext from '../context';
+import { useUpdateEffect } from '../../utils/hooks';
+import type { WordPressComponentProps } from '../../ui/context';
+import type { ToggleGroupControlAsRadioProps } from '../types';
+
+function UnforwardedToggleGroupControlAsButtonGroup(
+	{
+		children,
+		isAdaptiveWidth,
+		label,
+		onChange,
+		size,
+		value,
+		...otherProps
+	}: WordPressComponentProps< ToggleGroupControlAsRadioProps, 'div', false >,
+	forwardedRef: ForwardedRef< any >
+) {
+	const containerRef = useRef();
+	const [ resizeListener, sizes ] = useResizeObserver();
+	const baseId = useInstanceId(
+		ToggleGroupControlAsButtonGroup,
+		'toggle-group-control-as-button-group'
+	).toString();
+	const [ selectedValue, setSelectedValue ] = useState<
+		ReactText | undefined
+	>( value );
+	const radio = { baseId, state: selectedValue, setState: setSelectedValue };
+	const previousValue = usePrevious( value );
+
+	// Propagate radio.state change.
+	useUpdateEffect( () => {
+		// Avoid calling onChange if radio state changed
+		// from incoming value.
+		if ( previousValue !== radio.state ) {
+			onChange( radio.state );
+		}
+	}, [ radio.state ] );
+
+	// Sync incoming value with radio.state.
+	useUpdateEffect( () => {
+		if ( value !== radio.state ) {
+			radio.setState( value );
+		}
+	}, [ value ] );
+
+	return (
+		<ToggleGroupControlContext.Provider
+			value={ {
+				...radio,
+				isBlock: ! isAdaptiveWidth,
+				isDeselectable: true,
+				size,
+			} }
+		>
+			<View
+				{ ...radio }
+				aria-label={ label }
+				{ ...otherProps }
+				ref={ useMergeRefs( [ containerRef, forwardedRef ] ) }
+				role="group"
+			>
+				{ resizeListener }
+				<ToggleGroupControlBackdrop
+					{ ...radio }
+					containerRef={ containerRef }
+					containerWidth={ sizes.width }
+					isAdaptiveWidth={ isAdaptiveWidth }
+				/>
+				{ children }
+			</View>
+		</ToggleGroupControlContext.Provider>
+	);
+}
+
+export const ToggleGroupControlAsButtonGroup = forwardRef(
+	UnforwardedToggleGroupControlAsButtonGroup
+);

--- a/packages/components/src/toggle-group-control/toggle-group-control/as-radio-group.tsx
+++ b/packages/components/src/toggle-group-control/toggle-group-control/as-radio-group.tsx
@@ -24,7 +24,7 @@ import ToggleGroupControlBackdrop from './toggle-group-control-backdrop';
 import ToggleGroupControlContext from '../context';
 import { useUpdateEffect } from '../../utils/hooks';
 import type { WordPressComponentProps } from '../../ui/context';
-import type { ToggleGroupControlAsRadioProps } from '../types';
+import type { ToggleGroupControlInnerGroupProps } from '../types';
 
 function UnforwardedToggleGroupControlAsRadio(
 	{
@@ -35,7 +35,11 @@ function UnforwardedToggleGroupControlAsRadio(
 		size,
 		value,
 		...otherProps
-	}: WordPressComponentProps< ToggleGroupControlAsRadioProps, 'div', false >,
+	}: WordPressComponentProps<
+		ToggleGroupControlInnerGroupProps,
+		'div',
+		false
+	>,
 	forwardedRef: ForwardedRef< HTMLDivElement >
 ) {
 	const containerRef = useRef();

--- a/packages/components/src/toggle-group-control/toggle-group-control/as-radio-group.tsx
+++ b/packages/components/src/toggle-group-control/toggle-group-control/as-radio-group.tsx
@@ -36,7 +36,7 @@ function UnforwardedToggleGroupControlAsRadio(
 		value,
 		...otherProps
 	}: WordPressComponentProps< ToggleGroupControlAsRadioProps, 'div', false >,
-	forwardedRef: ForwardedRef< any >
+	forwardedRef: ForwardedRef< HTMLDivElement >
 ) {
 	const containerRef = useRef();
 	const [ resizeListener, sizes ] = useResizeObserver();
@@ -79,7 +79,7 @@ function UnforwardedToggleGroupControlAsRadio(
 			>
 				{ resizeListener }
 				<ToggleGroupControlBackdrop
-					{ ...radio }
+					state={ radio.state }
 					containerRef={ containerRef }
 					containerWidth={ sizes.width }
 					isAdaptiveWidth={ isAdaptiveWidth }

--- a/packages/components/src/toggle-group-control/toggle-group-control/as-radio.tsx
+++ b/packages/components/src/toggle-group-control/toggle-group-control/as-radio.tsx
@@ -1,0 +1,95 @@
+/**
+ * External dependencies
+ */
+import type { ForwardedRef } from 'react';
+// eslint-disable-next-line no-restricted-imports
+import { RadioGroup, useRadioState } from 'reakit';
+
+/**
+ * WordPress dependencies
+ */
+import {
+	useMergeRefs,
+	useInstanceId,
+	usePrevious,
+	useResizeObserver,
+} from '@wordpress/compose';
+import { forwardRef, useRef } from '@wordpress/element';
+
+/**
+ * Internal dependencies
+ */
+import { View } from '../../view';
+import ToggleGroupControlBackdrop from './toggle-group-control-backdrop';
+import ToggleGroupControlContext from '../context';
+import { useUpdateEffect } from '../../utils/hooks';
+import type { WordPressComponentProps } from '../../ui/context';
+import type { ToggleGroupControlAsRadioProps } from '../types';
+
+function UnforwardedToggleGroupControlAsRadio(
+	{
+		children,
+		isAdaptiveWidth,
+		label,
+		onChange,
+		size,
+		value,
+		...otherProps
+	}: WordPressComponentProps< ToggleGroupControlAsRadioProps, 'div', false >,
+	forwardedRef: ForwardedRef< any >
+) {
+	const containerRef = useRef();
+	const [ resizeListener, sizes ] = useResizeObserver();
+	const baseId = useInstanceId(
+		ToggleGroupControlAsRadio,
+		'toggle-group-control-as-radio'
+	).toString();
+	const radio = useRadioState( {
+		baseId,
+		state: value,
+	} );
+	const previousValue = usePrevious( value );
+
+	// Propagate radio.state change.
+	useUpdateEffect( () => {
+		// Avoid calling onChange if radio state changed
+		// from incoming value.
+		if ( previousValue !== radio.state ) {
+			onChange( radio.state );
+		}
+	}, [ radio.state ] );
+
+	// Sync incoming value with radio.state.
+	useUpdateEffect( () => {
+		if ( value !== radio.state ) {
+			radio.setState( value );
+		}
+	}, [ value ] );
+
+	return (
+		<ToggleGroupControlContext.Provider
+			value={ { ...radio, isBlock: ! isAdaptiveWidth, size } }
+		>
+			<RadioGroup
+				{ ...radio }
+				aria-label={ label }
+				as={ View }
+				{ ...otherProps }
+				ref={ useMergeRefs( [ containerRef, forwardedRef ] ) }
+			>
+				{ resizeListener }
+				<ToggleGroupControlBackdrop
+					{ ...radio }
+					containerRef={ containerRef }
+					containerWidth={ sizes.width }
+					isAdaptiveWidth={ isAdaptiveWidth }
+				/>
+				{ children }
+			</RadioGroup>
+		</ToggleGroupControlContext.Provider>
+	);
+}
+
+export const ToggleGroupControlAsRadio = forwardRef(
+	UnforwardedToggleGroupControlAsRadio
+);

--- a/packages/components/src/toggle-group-control/toggle-group-control/component.tsx
+++ b/packages/components/src/toggle-group-control/toggle-group-control/component.tsx
@@ -26,7 +26,7 @@ import { ToggleGroupControlAsRadio } from './as-radio';
 const noop = () => {};
 
 function UnconnectedToggleGroupControl(
-	props: WordPressComponentProps< ToggleGroupControlProps, 'input', false >,
+	props: WordPressComponentProps< ToggleGroupControlProps, 'div', false >,
 	forwardedRef: ForwardedRef< any >
 ) {
 	const {

--- a/packages/components/src/toggle-group-control/toggle-group-control/component.tsx
+++ b/packages/components/src/toggle-group-control/toggle-group-control/component.tsx
@@ -36,7 +36,6 @@ function UnconnectedToggleGroupControl(
 		isBlock = false,
 		isDeselectable = false,
 		label,
-		multiple = false,
 		hideLabelFromVision = false,
 		help,
 		onChange = noop,
@@ -67,7 +66,7 @@ function UnconnectedToggleGroupControl(
 					<BaseControl.VisualLabel>{ label }</BaseControl.VisualLabel>
 				</VisualLabelWrapper>
 			) }
-			{ ! multiple && ! isDeselectable && (
+			{ ! isDeselectable && (
 				<ToggleGroupControlAsRadio
 					{ ...otherProps }
 					children={ children }

--- a/packages/components/src/toggle-group-control/toggle-group-control/component.tsx
+++ b/packages/components/src/toggle-group-control/toggle-group-control/component.tsx
@@ -22,6 +22,7 @@ import type { ToggleGroupControlProps } from '../types';
 import { VisualLabelWrapper } from './styles';
 import * as styles from './styles';
 import { ToggleGroupControlAsRadio } from './as-radio';
+import { ToggleGroupControlAsButtonGroup } from './as-button-group';
 
 const noop = () => {};
 
@@ -66,7 +67,19 @@ function UnconnectedToggleGroupControl(
 					<BaseControl.VisualLabel>{ label }</BaseControl.VisualLabel>
 				</VisualLabelWrapper>
 			) }
-			{ ! isDeselectable && (
+			{ isDeselectable ? (
+				<ToggleGroupControlAsButtonGroup
+					{ ...otherProps }
+					children={ children }
+					className={ classes }
+					isAdaptiveWidth={ isAdaptiveWidth }
+					label={ label }
+					onChange={ onChange }
+					ref={ forwardedRef }
+					size={ size }
+					value={ value }
+				/>
+			) : (
 				<ToggleGroupControlAsRadio
 					{ ...otherProps }
 					children={ children }
@@ -76,7 +89,7 @@ function UnconnectedToggleGroupControl(
 					onChange={ onChange }
 					ref={ forwardedRef }
 					size={ size }
-					value={ Array.isArray( value ) ? value[ 0 ] : value }
+					value={ value }
 				/>
 			) }
 		</BaseControl>

--- a/packages/components/src/toggle-group-control/toggle-group-control/component.tsx
+++ b/packages/components/src/toggle-group-control/toggle-group-control/component.tsx
@@ -50,8 +50,7 @@ function UnconnectedToggleGroupControl(
 	const classes = useMemo(
 		() =>
 			cx(
-				styles.ToggleGroupControl( { size } ),
-				! isDeselectable && styles.border,
+				styles.ToggleGroupControl( { isDeselectable, size } ),
 				isBlock && styles.block,
 				className
 			),

--- a/packages/components/src/toggle-group-control/toggle-group-control/component.tsx
+++ b/packages/components/src/toggle-group-control/toggle-group-control/component.tsx
@@ -35,7 +35,6 @@ function UnconnectedToggleGroupControl(
 		isAdaptiveWidth = false,
 		isBlock = false,
 		isDeselectable = false,
-		__experimentalIsBorderless = false,
 		label,
 		multiple = false,
 		hideLabelFromVision = false,
@@ -52,11 +51,11 @@ function UnconnectedToggleGroupControl(
 		() =>
 			cx(
 				styles.ToggleGroupControl( { size } ),
-				! __experimentalIsBorderless && styles.border,
+				! isDeselectable && styles.border,
 				isBlock && styles.block,
 				className
 			),
-		[ className, cx, isBlock, __experimentalIsBorderless, size ]
+		[ className, cx, isBlock, isDeselectable, size ]
 	);
 	return (
 		<BaseControl

--- a/packages/components/src/toggle-group-control/toggle-group-control/component.tsx
+++ b/packages/components/src/toggle-group-control/toggle-group-control/component.tsx
@@ -21,7 +21,7 @@ import BaseControl from '../../base-control';
 import type { ToggleGroupControlProps } from '../types';
 import { VisualLabelWrapper } from './styles';
 import * as styles from './styles';
-import { ToggleGroupControlAsRadio } from './as-radio';
+import { ToggleGroupControlAsRadio } from './as-radio-group';
 import { ToggleGroupControlAsButtonGroup } from './as-button-group';
 
 const noop = () => {};

--- a/packages/components/src/toggle-group-control/toggle-group-control/styles.ts
+++ b/packages/components/src/toggle-group-control/toggle-group-control/styles.ts
@@ -67,7 +67,6 @@ export const block = css`
 export const BackdropView = styled.div`
 	background: ${ COLORS.gray[ 900 ] };
 	border-radius: ${ CONFIG.controlBorderRadius };
-	box-shadow: ${ CONFIG.toggleGroupControlBackdropBoxShadow };
 	left: 0;
 	position: absolute;
 	top: 2px;

--- a/packages/components/src/toggle-group-control/toggle-group-control/styles.ts
+++ b/packages/components/src/toggle-group-control/toggle-group-control/styles.ts
@@ -10,6 +10,8 @@ import styled from '@emotion/styled';
 import { CONFIG, COLORS, reduceMotion } from '../../utils';
 import type { ToggleGroupControlProps } from '../types';
 
+export const BACKDROP_BG_COLOR = COLORS.gray[ 900 ];
+
 export const ToggleGroupControl = ( {
 	isDeselectable,
 	size,
@@ -65,7 +67,7 @@ export const block = css`
 `;
 
 export const BackdropView = styled.div`
-	background: ${ COLORS.gray[ 900 ] };
+	background: ${ BACKDROP_BG_COLOR };
 	border-radius: ${ CONFIG.controlBorderRadius };
 	left: 0;
 	position: absolute;

--- a/packages/components/src/toggle-group-control/toggle-group-control/styles.ts
+++ b/packages/components/src/toggle-group-control/toggle-group-control/styles.ts
@@ -11,13 +11,14 @@ import { CONFIG, COLORS, reduceMotion } from '../../utils';
 import type { ToggleGroupControlProps } from '../types';
 
 export const ToggleGroupControl = ( {
+	isDeselectable,
 	size,
 }: {
+	isDeselectable?: boolean;
 	size: NonNullable< ToggleGroupControlProps[ 'size' ] >;
 } ) => css`
 	background: ${ COLORS.ui.background };
 	border: 1px solid transparent;
-	border-radius: ${ CONFIG.controlBorderRadius };
 	display: inline-flex;
 	min-width: 0;
 	padding: 2px;
@@ -26,20 +27,22 @@ export const ToggleGroupControl = ( {
 	${ reduceMotion( 'transition' ) }
 
 	${ toggleGroupControlSize( size ) }
+	${ ! isDeselectable && enclosingBorder }
+`;
+
+const enclosingBorder = css`
+	border-color: ${ COLORS.ui.border };
+	border-radius: ${ CONFIG.controlBorderRadius };
+
+	&:hover {
+		border-color: ${ COLORS.ui.borderHover };
+	}
 
 	&:focus-within {
 		border-color: ${ COLORS.ui.borderFocus };
 		box-shadow: ${ CONFIG.controlBoxShadowFocus };
 		outline: none;
 		z-index: 1;
-	}
-`;
-
-export const border = css`
-	border-color: ${ COLORS.ui.border };
-
-	&:hover {
-		border-color: ${ COLORS.ui.borderHover };
 	}
 `;
 

--- a/packages/components/src/toggle-group-control/types.ts
+++ b/packages/components/src/toggle-group-control/types.ts
@@ -18,6 +18,15 @@ export type ToggleGroupControlOptionBaseProps = {
 	 * @default false
 	 */
 	isIcon?: boolean;
+	/**
+	 * Whether the group supports multiple selection.
+	 *
+	 * @default false
+	 */
+	isMultiple?: boolean;
+	/**
+	 * The unique key of the option.
+	 */
 	value: ReactText;
 	/**
 	 * Whether to display a Tooltip for the control option. If set to `true`, the tooltip will
@@ -137,7 +146,7 @@ export type ToggleGroupControlBackdropProps = {
 	state?: any;
 };
 
-export type ToggleGroupControlAsRadioProps = Pick<
+export type ToggleGroupControlInnerGroupProps = Pick<
 	ToggleGroupControlProps,
 	'children' | 'isAdaptiveWidth' | 'label' | 'size'
 > & {

--- a/packages/components/src/toggle-group-control/types.ts
+++ b/packages/components/src/toggle-group-control/types.ts
@@ -124,14 +124,10 @@ export type ToggleGroupControlProps = Pick<
 	size?: 'default' | '__unstable-large';
 };
 
-export type ToggleGroupControlContextProps = RadioStateReturn &
-	Pick< ToggleGroupControlProps, 'size' > & {
-		/**
-		 * Renders `ToggleGroupControl` as a (CSS) block element.
-		 *
-		 * @default false
-		 */
-		isBlock?: boolean;
+export type ToggleGroupControlContextProps = Partial< RadioStateReturn > &
+	Pick< RadioStateReturn, 'state' | 'setState' > &
+	Pick< ToggleGroupControlProps, 'isBlock' | 'isDeselectable' | 'size' > & {
+		baseId: string;
 	};
 
 export type ToggleGroupControlBackdropProps = {

--- a/packages/components/src/toggle-group-control/types.ts
+++ b/packages/components/src/toggle-group-control/types.ts
@@ -82,6 +82,12 @@ export type ToggleGroupControlProps = Omit<
 		 */
 		label: string;
 		/**
+		 * Whether multiple options can be selected at once.
+		 *
+		 * @default false
+		 */
+		multiple?: boolean;
+		/**
 		 * If true, the label will only be visible to screen readers.
 		 *
 		 * @default false
@@ -100,6 +106,12 @@ export type ToggleGroupControlProps = Omit<
 		 */
 		isBlock?: boolean;
 		/**
+		 * Whether an option can be deselected by clicking it again.
+		 *
+		 * @default false
+		 */
+		isDeselectable?: boolean;
+		/**
 		 * Borderless style that may be preferred in some contexts.
 		 *
 		 * @default false
@@ -110,9 +122,9 @@ export type ToggleGroupControlProps = Omit<
 		 */
 		onChange?: ( value: ReactText | undefined ) => void;
 		/**
-		 * The value of `ToggleGroupControl`
+		 * The selected value(s).
 		 */
-		value?: ReactText;
+		value?: ReactText | ReactText[];
 		/**
 		 * The options to render in the `ToggleGroupControl`, using either the `ToggleGroupControlOption` or
 		 * `ToggleGroupControlOptionIcon` components.
@@ -141,4 +153,12 @@ export type ToggleGroupControlBackdropProps = {
 	containerWidth?: number | null;
 	isAdaptiveWidth?: boolean;
 	state?: any;
+};
+
+export type ToggleGroupControlAsRadioProps = Pick<
+	ToggleGroupControlProps,
+	'children' | 'isAdaptiveWidth' | 'label' | 'size'
+> & {
+	onChange: ( value: ReactText | undefined ) => void;
+	value?: ReactText;
 };

--- a/packages/components/src/toggle-group-control/types.ts
+++ b/packages/components/src/toggle-group-control/types.ts
@@ -110,12 +110,6 @@ export type ToggleGroupControlProps = Pick<
 	 */
 	isDeselectable?: boolean;
 	/**
-	 * Borderless style that may be preferred in some contexts.
-	 *
-	 * @default false
-	 */
-	__experimentalIsBorderless?: boolean;
-	/**
 	 * Callback when a segment is selected.
 	 */
 	onChange?: ( value: ReactText | undefined ) => void;

--- a/packages/components/src/toggle-group-control/types.ts
+++ b/packages/components/src/toggle-group-control/types.ts
@@ -9,7 +9,6 @@ import type { RadioStateReturn } from 'reakit';
  * Internal dependencies
  */
 import type { BaseControlProps } from '../base-control/types';
-import type { FormElementProps } from '../utils/types';
 
 export type ToggleGroupControlOptionBaseProps = {
 	children: ReactNode;
@@ -72,71 +71,70 @@ export type WithToolTipProps = {
 	showTooltip?: boolean;
 };
 
-export type ToggleGroupControlProps = Omit<
-	FormElementProps< any >,
-	'defaultValue'
-> &
-	Pick< BaseControlProps, 'help' | '__nextHasNoMarginBottom' > & {
-		/**
-		 * Label for the form element.
-		 */
-		label: string;
-		/**
-		 * Whether multiple options can be selected at once.
-		 *
-		 * @default false
-		 */
-		multiple?: boolean;
-		/**
-		 * If true, the label will only be visible to screen readers.
-		 *
-		 * @default false
-		 */
-		hideLabelFromVision?: boolean;
-		/**
-		 * Determines if segments should be rendered with equal widths.
-		 *
-		 * @default false
-		 */
-		isAdaptiveWidth?: boolean;
-		/**
-		 * Renders `ToggleGroupControl` as a (CSS) block element.
-		 *
-		 * @default false
-		 */
-		isBlock?: boolean;
-		/**
-		 * Whether an option can be deselected by clicking it again.
-		 *
-		 * @default false
-		 */
-		isDeselectable?: boolean;
-		/**
-		 * Borderless style that may be preferred in some contexts.
-		 *
-		 * @default false
-		 */
-		__experimentalIsBorderless?: boolean;
-		/**
-		 * Callback when a segment is selected.
-		 */
-		onChange?: ( value: ReactText | undefined ) => void;
-		/**
-		 * The selected value(s).
-		 */
-		value?: ReactText | ReactText[];
-		/**
-		 * The options to render in the `ToggleGroupControl`, using either the `ToggleGroupControlOption` or
-		 * `ToggleGroupControlOptionIcon` components.
-		 */
-		children: ReactNode;
-		/**
-		 * The size variant of the control.
-		 *
-		 * @default 'default'
-		 */
-		size?: 'default' | '__unstable-large';
-	};
+export type ToggleGroupControlProps = Pick<
+	BaseControlProps,
+	'help' | '__nextHasNoMarginBottom'
+> & {
+	/**
+	 * Label for the control.
+	 */
+	label: string;
+	/**
+	 * Whether multiple options can be selected at once.
+	 *
+	 * @default false
+	 */
+	multiple?: boolean;
+	/**
+	 * If true, the label will only be visible to screen readers.
+	 *
+	 * @default false
+	 */
+	hideLabelFromVision?: boolean;
+	/**
+	 * Determines if segments should be rendered with equal widths.
+	 *
+	 * @default false
+	 */
+	isAdaptiveWidth?: boolean;
+	/**
+	 * Renders `ToggleGroupControl` as a (CSS) block element.
+	 *
+	 * @default false
+	 */
+	isBlock?: boolean;
+	/**
+	 * Whether an option can be deselected by clicking it again.
+	 *
+	 * @default false
+	 */
+	isDeselectable?: boolean;
+	/**
+	 * Borderless style that may be preferred in some contexts.
+	 *
+	 * @default false
+	 */
+	__experimentalIsBorderless?: boolean;
+	/**
+	 * Callback when a segment is selected.
+	 */
+	onChange?: ( value: ReactText | undefined ) => void;
+	/**
+	 * The selected value(s).
+	 */
+	value?: ReactText | ReactText[];
+	/**
+	 * The options to render in the `ToggleGroupControl`, using either the `ToggleGroupControlOption` or
+	 * `ToggleGroupControlOptionIcon` components.
+	 */
+	children: ReactNode;
+	/**
+	 * The size variant of the control.
+	 *
+	 * @default 'default'
+	 */
+	size?: 'default' | '__unstable-large';
+};
 
 export type ToggleGroupControlContextProps = RadioStateReturn &
 	Pick< ToggleGroupControlProps, 'size' > & {

--- a/packages/components/src/toggle-group-control/types.ts
+++ b/packages/components/src/toggle-group-control/types.ts
@@ -80,12 +80,6 @@ export type ToggleGroupControlProps = Pick<
 	 */
 	label: string;
 	/**
-	 * Whether multiple options can be selected at once.
-	 *
-	 * @default false
-	 */
-	multiple?: boolean;
-	/**
 	 * If true, the label will only be visible to screen readers.
 	 *
 	 * @default false
@@ -116,7 +110,7 @@ export type ToggleGroupControlProps = Pick<
 	/**
 	 * The selected value(s).
 	 */
-	value?: ReactText | ReactText[];
+	value?: ReactText;
 	/**
 	 * The options to render in the `ToggleGroupControl`, using either the `ToggleGroupControlOption` or
 	 * `ToggleGroupControlOptionIcon` components.

--- a/packages/components/src/toggle-multiple-group-control/component.tsx
+++ b/packages/components/src/toggle-multiple-group-control/component.tsx
@@ -1,0 +1,54 @@
+/**
+ * External dependencies
+ */
+import type { ForwardedRef } from 'react';
+
+/**
+ * Internal dependencies
+ */
+import {
+	contextConnect,
+	ContextSystemProvider,
+	WordPressComponentProps,
+} from '../ui/context';
+import type { ToggleMultipleGroupControlProps } from './types';
+import { ToggleGroupControl } from '../toggle-group-control';
+import { useContextSystem } from '../ui/context/use-context-system';
+
+const contextProviderValue = {
+	ToggleGroupControlOptionBase: {
+		isMultiple: true,
+	},
+};
+
+function UnconnectedToggleMultipleGroupControl(
+	props: WordPressComponentProps<
+		ToggleMultipleGroupControlProps,
+		'div',
+		false
+	>,
+	forwardedRef: ForwardedRef< any >
+) {
+	const {
+		onChange, // omit
+		...otherProps
+	} = useContextSystem( props, 'UnconnectedToggleMultipleGroupControl' );
+
+	return (
+		<ContextSystemProvider value={ contextProviderValue }>
+			<ToggleGroupControl
+				{ ...otherProps }
+				isDeselectable
+				__nextHasNoMarginBottom
+				ref={ forwardedRef }
+			/>
+		</ContextSystemProvider>
+	);
+}
+
+export const ToggleMultipleGroupControl = contextConnect(
+	UnconnectedToggleMultipleGroupControl,
+	'ToggleMultipleGroupControl'
+);
+
+export default ToggleMultipleGroupControl;

--- a/packages/components/src/toggle-multiple-group-control/index.ts
+++ b/packages/components/src/toggle-multiple-group-control/index.ts
@@ -1,0 +1,1 @@
+export { ToggleMultipleGroupControl } from './component';

--- a/packages/components/src/toggle-multiple-group-control/option-icon.tsx
+++ b/packages/components/src/toggle-multiple-group-control/option-icon.tsx
@@ -1,0 +1,40 @@
+/**
+ * External dependencies
+ */
+import type { ForwardedRef } from 'react';
+
+/**
+ * WordPress dependencies
+ */
+import { forwardRef } from '@wordpress/element';
+
+/**
+ * Internal dependencies
+ */
+import { ToggleGroupControlOptionIcon } from '../toggle-group-control';
+import type { ToggleMultipleGroupControlOptionIconProps } from './types';
+import type { WordPressComponentProps } from '../ui/context';
+
+function UnforwardedToggleMultipleGroupControlOptionIcon(
+	{
+		isPressed,
+		...otherProps
+	}: WordPressComponentProps<
+		ToggleMultipleGroupControlOptionIconProps,
+		'button',
+		false
+	>,
+	ref: ForwardedRef< any >
+) {
+	return (
+		<ToggleGroupControlOptionIcon
+			{ ...otherProps }
+			ref={ ref }
+			aria-pressed={ isPressed }
+		/>
+	);
+}
+
+export const ToggleMultipleGroupControlOptionIcon = forwardRef(
+	UnforwardedToggleMultipleGroupControlOptionIcon
+);

--- a/packages/components/src/toggle-multiple-group-control/stories/index.tsx
+++ b/packages/components/src/toggle-multiple-group-control/stories/index.tsx
@@ -1,0 +1,70 @@
+/**
+ * External dependencies
+ */
+import type { ComponentMeta, ComponentStory } from '@storybook/react';
+
+/**
+ * WordPress dependencies
+ */
+import { useState } from '@wordpress/element';
+import { formatBold, formatItalic, formatUnderline } from '@wordpress/icons';
+
+/**
+ * Internal dependencies
+ */
+import { ToggleMultipleGroupControl } from '../';
+import { ToggleMultipleGroupControlOptionIcon } from '../option-icon';
+
+const meta: ComponentMeta< typeof ToggleMultipleGroupControl > = {
+	component: ToggleMultipleGroupControl,
+	title: 'Components (Experimental)/ToggleMultipleGroupControl',
+	subcomponents: { ToggleMultipleGroupControlOptionIcon },
+	argTypes: {
+		help: { control: { type: 'text' } },
+	},
+	parameters: {
+		controls: { expanded: true },
+		docs: { source: { state: 'open' } },
+	},
+};
+export default meta;
+
+const Template: ComponentStory< typeof ToggleMultipleGroupControl > = (
+	props
+) => {
+	const [ bold, setBold ] = useState( false );
+	const [ italic, setItalic ] = useState( false );
+	const [ underline, setUndeline ] = useState( false );
+
+	return (
+		<ToggleMultipleGroupControl { ...props }>
+			<ToggleMultipleGroupControlOptionIcon
+				value="bold"
+				label="Bold"
+				icon={ formatBold }
+				isPressed={ bold }
+				onClick={ () => setBold( ! bold ) }
+			/>
+			<ToggleMultipleGroupControlOptionIcon
+				value="italic"
+				label="Italic"
+				icon={ formatItalic }
+				isPressed={ italic }
+				onClick={ () => setItalic( ! italic ) }
+			/>
+			<ToggleMultipleGroupControlOptionIcon
+				value="underline"
+				label="Underline"
+				icon={ formatUnderline }
+				isPressed={ underline }
+				onClick={ () => setUndeline( ! underline ) }
+			/>
+		</ToggleMultipleGroupControl>
+	);
+};
+
+export const Default: ComponentStory< typeof ToggleMultipleGroupControl > =
+	Template.bind( {} );
+Default.args = {
+	label: 'Label',
+};

--- a/packages/components/src/toggle-multiple-group-control/types.ts
+++ b/packages/components/src/toggle-multiple-group-control/types.ts
@@ -1,0 +1,26 @@
+/**
+ * Internal dependencies
+ */
+import type {
+	ToggleGroupControlOptionIconProps,
+	ToggleGroupControlProps,
+} from '../toggle-group-control/types';
+
+export type ToggleMultipleGroupControlProps = Pick<
+	ToggleGroupControlProps,
+	'children' | 'label' | 'help' | 'hideLabelFromVision' | 'size'
+>;
+
+export type ToggleMultipleGroupControlOptionIconProps =
+	ToggleGroupControlOptionIconProps & {
+		/**
+		 * Whether the button is pressed.
+		 *
+		 * @default false
+		 */
+		isPressed: boolean;
+		/**
+		 * Listen to click events to manage the `isPressed` state.
+		 */
+		onClick: () => void;
+	};


### PR DESCRIPTION
Follow-up to #44067
Fixes icon color issue noted in https://github.com/WordPress/gutenberg/pull/44065#issuecomment-1245068026

I'll probably split this for code review.

🚩 In this PR, let's first discuss the visual/interaction design concerns.

## What?

The goal of this refactor is to add de-selection and multi-selection support to ToggleGroupControl, in a way that is:

- Sufficiently accessible through assistive technologies
- Visually clear and consistent
- Has non-confusing API for developers

## Why?

Discussions started in #36735 and many possible approaches were thought through. Eventually, we arrived at the point where product requirements pretty much necessitated a "de-selectable radio control", which initially seemed kind of impossible to implement accessibly. Our impasse was broken when @noisysocks found [some recent information](https://lea.verou.me/2022/07/button-group/) from two accessibility experts regarding almost our exact problem. According to the article, it's not only ok but *preferable* that segmented controls are implemented with `button` and `aria-pressed`.

So with the semantics issue unblocked, all we have to do is work out the visual design and API.

## How?

To recap, our component needs to support three combinations of behaviors:

1. mutually exclusive, not de-selectable
1. mutually exclusive, de-selectable
1. not mutually exclusive (de-selectable by nature)

### Mutually exclusive, not de-selectable

First, this is our basic "radio-like" behavior. This is how ToggleGroupControl works today. The entire control is one tab stop, and options are toggled immediately when navigating with the arrow keys.

https://user-images.githubusercontent.com/555336/190493709-0a43e402-6c1f-442a-a087-3467967d6e6e.mp4

### Mutually exclusive, de-selectable

Next, we have a mutually exclusive, but de-selectable behavior. The button options are now distinct, and separate tab stops.

https://user-images.githubusercontent.com/555336/190493101-ef38239e-59c6-474a-89de-73b53bbe48f8.mp4

There are actually already a good number of ad hoc components in Gutenberg that pretty much look like ☝️, sans backdrop animation. However, some initial feedback from the Components Squad noted that it was visually unclear that this was a group of buttons, and was suggested that maybe we should keep the border. After trying it, I think I prefer the borderless version, but here's a bordered one for reference:

https://user-images.githubusercontent.com/555336/190493108-7e8074db-b345-4f93-a51e-4cdfdb13ded0.mp4

### Not mutually exclusive (always de-selectable)

Finally, this is the multi-select version. As far as I know, the only similar UI that currently exists in Gutenberg is the formatting buttons in the Rich Text toolbar:

<img width="159" alt="Bold and Italic buttons in the inline block toolbar" src="https://user-images.githubusercontent.com/555336/190496500-fc995131-957f-450a-9533-796409c5a234.png">

https://user-images.githubusercontent.com/555336/190493099-72a1ce2f-a887-4a7d-a3f4-3a06440b1556.mp4

(☝️ Sorry the icons are a smidge off-center. I'll fix that)

Here there was also some initial feedback from the Components Squad that the "group"-ness was visually unclear. A version with some kind of separator was suggested, so here's a rough prototype for reference:

https://user-images.githubusercontent.com/555336/190493080-c9ca0282-2dfb-4656-8410-eb59ed25d585.mp4


## Testing Instructions

The docs are incomplete, but you can do `npm run storybook:dev` and see the stories for ToggleGroupControl and ToggleMultipleGroupControl if you want to try it out yourself.