### PR TITLE
Prevent flipping the border style when creating RTL stylesheets

### DIFF
--- a/packages/block-library/src/common.scss
+++ b/packages/block-library/src/common.scss
@@ -128,12 +128,14 @@ html :where([style*="border-top-color"]) {
 	border-top-style: solid;
 }
 html :where([style*="border-right-color"]) {
+	/*rtl:ignore*/
 	border-right-style: solid;
 }
 html :where([style*="border-bottom-color"]) {
 	border-bottom-style: solid;
 }
 html :where([style*="border-left-color"]) {
+	/*rtl:ignore*/
 	border-left-style: solid;
 }
 
@@ -144,12 +146,14 @@ html :where([style*="border-top-width"]) {
 	border-top-style: solid;
 }
 html :where([style*="border-right-width"]) {
+	/*rtl:ignore*/
 	border-right-style: solid;
 }
 html :where([style*="border-bottom-width"]) {
 	border-bottom-style: solid;
 }
 html :where([style*="border-left-width"]) {
+	/*rtl:ignore*/
 	border-left-style: solid;
 }
 


### PR DESCRIPTION
Fixes #44169 by not flipping the border style when creating the RTL stylesheets. On trunk, adding a border to a block on an RTL site will apply the border style to the wrong side, causing a black border on the wrong side, and no border on the correct side. #44169 has some screenshots.

The issue seems to be that the `rtlcss` process flips the properties, so that 

```css
html :where([style*="border-right-width"]) {
	border-right-style: solid;
}
```

becomes

```css
html :where([style*="border-right-width"]) {
	border-left-style: solid;
}
```

The right border no longer has a default style, so it doesn't show up, and the left border now _has_ a style so it also inherits a default width and color.

## Testing Instructions

1. Using a site in an RTL language
2. Open the editor and add a block that can have a border
3. Apply only a left or right border
4. That border, and only that border should appear, with the correct color/width
