### PR TITLE
Navigation: Fallback to a classic menu if one is available

### DIFF
--- a/lib/experimental/navigation-theme-opt-in.php
+++ b/lib/experimental/navigation-theme-opt-in.php
@@ -197,12 +197,13 @@ function gutenberg_convert_menu_items_to_blocks(
 
 		if ( $has_children ) {
 			$submenu_items = $menu_items_by_parent_id[ $menu_item_id ];
-			$block_name = 'core/navigation-submenu';
+			$block_name    = 'core/navigation-submenu';
 		} else {
 			$submenu_items = array();
-			$block_name = 'core/navigation-link';
+			$block_name    = 'core/navigation-link';
 		}
 
+		// Create a child block.
 		$block = array(
 			'blockName' => $block_name,
 			'attrs'     => array(
@@ -210,14 +211,18 @@ function gutenberg_convert_menu_items_to_blocks(
 				'url'   => $menu_item->url,
 			),
 		);
+
+		// Create the content of the block.
 		$block_content = gutenberg_convert_menu_items_to_blocks(
 			$submenu_items,
-			$menu_items_by_parent_id,
+			$menu_items_by_parent_id
 		);
+
 		if ( ! empty( $block_content ) ) {
 			$block['innerContent'] = $block_content;
-			$block['innerBlocks'] = $block_content;
+			$block['innerBlocks']  = $block_content;
 		}
+
 		$blocks[] = $block;
 	}
 

--- a/lib/experimental/navigation-theme-opt-in.php
+++ b/lib/experimental/navigation-theme-opt-in.php
@@ -214,12 +214,16 @@ function gutenberg_convert_menu_items_to_blocks(
 			);
 		}
 
-		$block['innerBlocks'] = gutenberg_convert_menu_items_to_blocks(
-			isset( $menu_items_by_parent_id[ $menu_item->ID ] )
-					? $menu_items_by_parent_id[ $menu_item->ID ]
+		$menu_item_id = (int) $menu_item->ID;
+
+		$block['innerContent'] = gutenberg_convert_menu_items_to_blocks(
+			isset( $menu_items_by_parent_id[ $menu_item_id ] )
+					? $menu_items_by_parent_id[ $menu_item_id ]
 					: array(),
 			$menu_items_by_parent_id
 		);
+
+		$block['innerBlocks'] = $block['innerContent'] ;
 
 		$blocks[] = $block;
 	}

--- a/lib/experimental/navigation-theme-opt-in.php
+++ b/lib/experimental/navigation-theme-opt-in.php
@@ -191,40 +191,33 @@ function gutenberg_convert_menu_items_to_blocks(
 	$blocks = array();
 
 	foreach ( $menu_items as $menu_item ) {
-		if ( 'block' === $menu_item->type ) {
-			$parsed_blocks = parse_blocks( $menu_item->content );
-
-			if ( count( $parsed_blocks ) ) {
-				$block = $parsed_blocks[0];
-			} else {
-				$block = array(
-					'blockName' => 'core/freeform',
-					'attrs'     => array(
-						'originalContent' => $menu_item->content,
-					),
-				);
-			}
-		} else {
-			$block = array(
-				'blockName' => 'core/navigation-link',
-				'attrs'     => array(
-					'label' => $menu_item->title,
-					'url'   => $menu_item->url,
-				),
-			);
-		}
-
 		$menu_item_id = (int) $menu_item->ID;
 
-		$block['innerContent'] = gutenberg_convert_menu_items_to_blocks(
-			isset( $menu_items_by_parent_id[ $menu_item_id ] )
-					? $menu_items_by_parent_id[ $menu_item_id ]
-					: array(),
-			$menu_items_by_parent_id
+		$has_children = isset( $menu_items_by_parent_id[ $menu_item_id ] );
+
+		if ( $has_children ) {
+			$submenu_items = $menu_items_by_parent_id[ $menu_item_id ];
+			$block_name = 'core/navigation-submenu';
+		} else {
+			$submenu_items = array();
+			$block_name = 'core/navigation-link';
+		}
+
+		$block = array(
+			'blockName' => $block_name,
+			'attrs'     => array(
+				'label' => $menu_item->title,
+				'url'   => $menu_item->url,
+			),
 		);
-
-		$block['innerBlocks'] = $block['innerContent'] ;
-
+		$block_content = gutenberg_convert_menu_items_to_blocks(
+			$submenu_items,
+			$menu_items_by_parent_id,
+		);
+		if ( ! empty( $block_content ) ) {
+			$block['innerContent'] = $block_content;
+			$block['innerBlocks'] = $block_content;
+		}
 		$blocks[] = $block;
 	}
 

--- a/lib/experimental/navigation-theme-opt-in.php
+++ b/lib/experimental/navigation-theme-opt-in.php
@@ -191,37 +191,35 @@ function gutenberg_convert_menu_items_to_blocks(
 	$blocks = array();
 
 	foreach ( $menu_items as $menu_item ) {
-		$menu_item_id = (int) $menu_item->ID;
+		if ( 'block' === $menu_item->type ) {
+			$parsed_blocks = parse_blocks( $menu_item->content );
 
-		$has_children = isset( $menu_items_by_parent_id[ $menu_item_id ] );
-
-		if ( $has_children ) {
-			$submenu_items = $menu_items_by_parent_id[ $menu_item_id ];
-			$block_name    = 'core/navigation-submenu';
+			if ( count( $parsed_blocks ) ) {
+				$block = $parsed_blocks[0];
+			} else {
+				$block = array(
+					'blockName' => 'core/freeform',
+					'attrs'     => array(
+						'originalContent' => $menu_item->content,
+					),
+				);
+			}
 		} else {
-			$submenu_items = array();
-			$block_name    = 'core/navigation-link';
+			$block = array(
+				'blockName' => 'core/navigation-link',
+				'attrs'     => array(
+					'label' => $menu_item->title,
+					'url'   => $menu_item->url,
+				),
+			);
 		}
 
-		// Create a child block.
-		$block = array(
-			'blockName' => $block_name,
-			'attrs'     => array(
-				'label' => $menu_item->title,
-				'url'   => $menu_item->url,
-			),
-		);
-
-		// Create the content of the block.
-		$block_content = gutenberg_convert_menu_items_to_blocks(
-			$submenu_items,
+		$block['innerBlocks'] = gutenberg_convert_menu_items_to_blocks(
+			isset( $menu_items_by_parent_id[ $menu_item->ID ] )
+					? $menu_items_by_parent_id[ $menu_item->ID ]
+					: array(),
 			$menu_items_by_parent_id
 		);
-
-		if ( ! empty( $block_content ) ) {
-			$block['innerContent'] = $block_content;
-			$block['innerBlocks']  = $block_content;
-		}
 
 		$blocks[] = $block;
 	}

--- a/packages/block-library/src/navigation/edit/index.js
+++ b/packages/block-library/src/navigation/edit/index.js
@@ -241,16 +241,11 @@ function Navigation( {
 				// This is duplicated several times.
 				const onSelectClassicMenu = async ( classicMenu ) => {
 					setConvertingClassicMenu( true );
-					const navMenu = await convertClassicMenu(
+					await convertClassicMenu(
 						classicMenu.id,
 						classicMenu.name,
 						'publish'
 					);
-					if ( navMenu ) {
-						handleUpdateMenu( navMenu.id, {
-							focusNavigationBlock: true,
-						} );
-					}
 				};
 
 				onSelectClassicMenu( classicMenus[ 0 ] );

--- a/packages/block-library/src/navigation/edit/index.js
+++ b/packages/block-library/src/navigation/edit/index.js
@@ -216,6 +216,15 @@ function Navigation( {
 	const navMenuResolvedButMissing =
 		hasResolvedNavigationMenus && isNavigationMenuMissing;
 
+	const {
+		convert: convertClassicMenu,
+		status: classicMenuConversionStatus,
+		error: classicMenuConversionError,
+	} = useConvertClassicToBlockMenu( clientId );
+
+	const isConvertingClassicMenu =
+		classicMenuConversionStatus === CLASSIC_MENU_CONVERSION_PENDING;
+
 	// Attempt to retrieve and prioritize any existing navigation menu unless:
 	// - the are uncontrolled inner blocks already present in the block.
 	// - the user is creating a new menu.
@@ -237,10 +246,9 @@ function Navigation( {
 		// only one classic menu then create a new navigation menu based on it.
 		if ( ! fallbackNavigationMenus?.length && classicMenus?.length === 1 ) {
 			// Only create classic menus once.
-			if ( ! convertingClassicMenu ) {
+			if ( ! isConvertingClassicMenu ) {
 				// This is duplicated several times.
 				const onSelectClassicMenu = async ( classicMenu ) => {
-					setConvertingClassicMenu( true );
 					await convertClassicMenu(
 						classicMenu.id,
 						classicMenu.name,
@@ -275,15 +283,6 @@ function Navigation( {
 	}, [ navigationMenus ] );
 
 	const navRef = useRef();
-
-	const {
-		convert: convertClassicMenu,
-		status: classicMenuConversionStatus,
-		error: classicMenuConversionError,
-	} = useConvertClassicToBlockMenu( clientId );
-
-	const isConvertingClassicMenu =
-		classicMenuConversionStatus === CLASSIC_MENU_CONVERSION_PENDING;
 
 	// The standard HTML5 tag for the block wrapper.
 	const TagName = 'nav';
@@ -359,7 +358,6 @@ function Navigation( {
 	// Turn on contrast checker for web only since it's not supported on mobile yet.
 	const enableContrastChecking = Platform.OS === 'web';
 
-	const [ convertingClassicMenu, setConvertingClassicMenu ] = useState();
 	const [ detectedBackgroundColor, setDetectedBackgroundColor ] = useState();
 	const [ detectedColor, setDetectedColor ] = useState();
 	const [

--- a/packages/block-library/src/navigation/edit/index.js
+++ b/packages/block-library/src/navigation/edit/index.js
@@ -233,14 +233,14 @@ function Navigation( {
 	// than 1 exists then use the most recent.
 	// The aim is for the block to "just work" from a user perspective using existing data.
 	useEffect( () => {
+		if ( hasUncontrolledInnerBlocks || isCreatingNavigationMenu || ref ) {
+			return;
+		}
+		
 		// Only autofallback to published menus.
 		const fallbackNavigationMenus = navigationMenus?.filter(
 			( menu ) => menu.status === 'publish'
 		);
-
-		if ( hasUncontrolledInnerBlocks || isCreatingNavigationMenu || ref ) {
-			return;
-		}
 
 		// If there's non fallback navigation menus and
 		// only one classic menu then create a new navigation menu based on it.

--- a/packages/block-library/src/navigation/edit/index.js
+++ b/packages/block-library/src/navigation/edit/index.js
@@ -233,25 +233,30 @@ function Navigation( {
 			return;
 		}
 
+		// If there's non fallback navigation menus and
+		// only one classic menu then create a new navigation menu based on it.
 		if ( ! fallbackNavigationMenus?.length && classicMenus?.length === 1 ) {
-			// If there's only one classic menu
-			// then create a new navigation menu based on it.
+			// Only create classic menus once.
+			if ( ! convertingClassicMenu ) {
+				// This is duplicated several times.
+				const onSelectClassicMenu = async ( classicMenu ) => {
+					setConvertingClassicMenu( true );
+					const navMenu = await convertClassicMenu(
+						classicMenu.id,
+						classicMenu.name,
+						'publish'
+					);
+					if ( navMenu ) {
+						handleUpdateMenu( navMenu.id, {
+							focusNavigationBlock: true,
+						} );
+					}
+				};
 
-			// This is duplicated several times.
-			const onSelectClassicMenu = async ( classicMenu ) => {
-				const navMenu = await convertClassicMenu(
-					classicMenu.id,
-					classicMenu.name,
-					'publish'
-				);
-				if ( navMenu ) {
-					handleUpdateMenu( navMenu.id, {
-						focusNavigationBlock: true,
-					} );
-				}
-			};
+				onSelectClassicMenu( classicMenus[ 0 ] );
+			}
 
-			onSelectClassicMenu( classicMenus[ 0 ] );
+			return;
 		}
 
 		// See if we have any navigation menus
@@ -359,6 +364,7 @@ function Navigation( {
 	// Turn on contrast checker for web only since it's not supported on mobile yet.
 	const enableContrastChecking = Platform.OS === 'web';
 
+	const [ convertingClassicMenu, setConvertingClassicMenu ] = useState();
 	const [ detectedBackgroundColor, setDetectedBackgroundColor ] = useState();
 	const [ detectedColor, setDetectedColor ] = useState();
 	const [
@@ -742,7 +748,8 @@ function Navigation( {
 							onSelectClassicMenu={ async ( classicMenu ) => {
 								const navMenu = await convertClassicMenu(
 									classicMenu.id,
-									classicMenu.name
+									classicMenu.name,
+									'draft'
 								);
 								if ( navMenu ) {
 									handleUpdateMenu( navMenu.id, {
@@ -827,7 +834,8 @@ function Navigation( {
 					onSelectClassicMenu={ async ( classicMenu ) => {
 						const navMenu = await convertClassicMenu(
 							classicMenu.id,
-							classicMenu.name
+							classicMenu.name,
+							'draft'
 						);
 						if ( navMenu ) {
 							handleUpdateMenu( navMenu.id, {
@@ -855,7 +863,8 @@ function Navigation( {
 							onSelectClassicMenu={ async ( classicMenu ) => {
 								const navMenu = await convertClassicMenu(
 									classicMenu.id,
-									classicMenu.name
+									classicMenu.name,
+									'draft'
 								);
 								if ( navMenu ) {
 									handleUpdateMenu( navMenu.id, {

--- a/packages/block-library/src/navigation/edit/index.js
+++ b/packages/block-library/src/navigation/edit/index.js
@@ -264,23 +264,25 @@ function Navigation( {
 		setRef( fallbackNavigationMenus[ 0 ].id );
 	}, [ navigationMenus ] );
 
-	useEffect( async () => {
-		if (
-			! hasResolvedNavigationMenus ||
-			isConvertingClassicMenu ||
-			fallbackNavigationMenus?.length > 0 ||
-			classicMenus?.length !== 1
-		) {
-			return false;
-		}
+	useEffect( () => {
+		( async () => {
+			if (
+				! hasResolvedNavigationMenus ||
+				isConvertingClassicMenu ||
+				fallbackNavigationMenus?.length > 0 ||
+				classicMenus?.length !== 1
+			) {
+				return false;
+			}
 
-		// If there's non fallback navigation menus and
-		// only one classic menu then create a new navigation menu based on it.
-		await convertClassicMenu(
-			classicMenus[ 0 ].id,
-			classicMenus[ 0 ].name,
-			'publish'
-		);
+			// If there's non fallback navigation menus and
+			// only one classic menu then create a new navigation menu based on it.
+			await convertClassicMenu(
+				classicMenus[ 0 ].id,
+				classicMenus[ 0 ].name,
+				'publish'
+			);
+		} )();
 	}, [ hasResolvedNavigationMenus ] );
 
 	const navRef = useRef();

--- a/packages/block-library/src/navigation/edit/index.js
+++ b/packages/block-library/src/navigation/edit/index.js
@@ -233,6 +233,27 @@ function Navigation( {
 			return;
 		}
 
+		if ( ! fallbackNavigationMenus?.length && classicMenus?.length === 1 ) {
+			// If there's only one classic menu
+			// then create a new navigation menu based on it.
+
+			// This is duplicated several times.
+			const onSelectClassicMenu = async ( classicMenu ) => {
+				const navMenu = await convertClassicMenu(
+					classicMenu.id,
+					classicMenu.name,
+					'publish'
+				);
+				if ( navMenu ) {
+					handleUpdateMenu( navMenu.id, {
+						focusNavigationBlock: true,
+					} );
+				}
+			};
+
+			onSelectClassicMenu( classicMenus[ 0 ] );
+		}
+
 		// See if we have any navigation menus
 		if ( fallbackNavigationMenus?.length ) {
 			navigationMenus.sort( ( menuA, menuB ) => {
@@ -250,27 +271,6 @@ function Navigation( {
 			 */
 			__unstableMarkNextChangeAsNotPersistent();
 			setRef( fallbackNavigationMenus[ 0 ].id );
-		} else if ( classicMenus?.length ) {
-			// Use a classic menu fallback
-
-			// We should get the primary one.
-
-			// We should probably create this not as a draft...
-
-			// This is duplicated several times.
-			const onSelectClassicMenu = async ( classicMenu ) => {
-				const navMenu = await convertClassicMenu(
-					classicMenu.id,
-					classicMenu.name
-				);
-				if ( navMenu ) {
-					handleUpdateMenu( navMenu.id, {
-						focusNavigationBlock: true,
-					} );
-				}
-			};
-
-			onSelectClassicMenu( classicMenus[ 0 ] );
 		}
 	}, [ navigationMenus ] );
 
@@ -660,7 +660,8 @@ function Navigation( {
 							onSelectClassicMenu={ async ( classicMenu ) => {
 								const navMenu = await convertClassicMenu(
 									classicMenu.id,
-									classicMenu.name
+									classicMenu.name,
+									'draft'
 								);
 								if ( navMenu ) {
 									handleUpdateMenu( navMenu.id, {

--- a/packages/block-library/src/navigation/edit/index.js
+++ b/packages/block-library/src/navigation/edit/index.js
@@ -236,7 +236,7 @@ function Navigation( {
 		if ( hasUncontrolledInnerBlocks || isCreatingNavigationMenu || ref ) {
 			return;
 		}
-		
+
 		// Only autofallback to published menus.
 		const fallbackNavigationMenus = navigationMenus?.filter(
 			( menu ) => menu.status === 'publish'
@@ -247,8 +247,7 @@ function Navigation( {
 		if ( ! fallbackNavigationMenus?.length && classicMenus?.length === 1 ) {
 			// Only create classic menus once.
 			if ( ! isConvertingClassicMenu ) {
-				// This is duplicated several times.
-				const onSelectClassicMenu = async ( classicMenu ) => {
+				const onConvertClassicMenu = async ( classicMenu ) => {
 					await convertClassicMenu(
 						classicMenu.id,
 						classicMenu.name,
@@ -256,7 +255,7 @@ function Navigation( {
 					);
 				};
 
-				onSelectClassicMenu( classicMenus[ 0 ] );
+				onConvertClassicMenu( classicMenus[ 0 ] );
 			}
 
 			return;

--- a/packages/block-library/src/navigation/edit/index.js
+++ b/packages/block-library/src/navigation/edit/index.js
@@ -265,24 +265,22 @@ function Navigation( {
 	}, [ navigationMenus ] );
 
 	useEffect( () => {
-		( async () => {
-			if (
-				! hasResolvedNavigationMenus ||
-				isConvertingClassicMenu ||
-				fallbackNavigationMenus?.length > 0 ||
-				classicMenus?.length !== 1
-			) {
-				return false;
-			}
+		if (
+			! hasResolvedNavigationMenus ||
+			isConvertingClassicMenu ||
+			fallbackNavigationMenus?.length > 0 ||
+			classicMenus?.length !== 1
+		) {
+			return false;
+		}
 
-			// If there's non fallback navigation menus and
-			// only one classic menu then create a new navigation menu based on it.
-			await convertClassicMenu(
-				classicMenus[ 0 ].id,
-				classicMenus[ 0 ].name,
-				'publish'
-			);
-		} )();
+		// If there's non fallback navigation menus and
+		// only one classic menu then create a new navigation menu based on it.
+		convertClassicMenu(
+			classicMenus[ 0 ].id,
+			classicMenus[ 0 ].name,
+			'publish'
+		);
 	}, [ hasResolvedNavigationMenus ] );
 
 	const navRef = useRef();

--- a/packages/block-library/src/navigation/edit/use-convert-classic-menu-to-block-menu.js
+++ b/packages/block-library/src/navigation/edit/use-convert-classic-menu-to-block-menu.js
@@ -80,7 +80,8 @@ function useConvertClassicToBlockMenu( clientId ) {
 		try {
 			navigationMenu = await createNavigationMenu(
 				menuName,
-				innerBlocks
+				innerBlocks,
+				postStatus
 			);
 
 			/**

--- a/packages/block-library/src/navigation/edit/use-convert-classic-menu-to-block-menu.js
+++ b/packages/block-library/src/navigation/edit/use-convert-classic-menu-to-block-menu.js
@@ -32,7 +32,11 @@ function useConvertClassicToBlockMenu( clientId ) {
 	const [ status, setStatus ] = useState( CLASSIC_MENU_CONVERSION_IDLE );
 	const [ error, setError ] = useState( null );
 
-	async function convertClassicMenuToBlockMenu( menuId, menuName ) {
+	async function convertClassicMenuToBlockMenu(
+		menuId,
+		menuName,
+		postStatus = 'publish'
+	) {
 		let navigationMenu;
 		let classicMenuItems;
 
@@ -91,7 +95,7 @@ function useConvertClassicToBlockMenu( clientId ) {
 				'wp_navigation',
 				navigationMenu.id,
 				{
-					status: 'publish',
+					status: postStatus,
 				},
 				{ throwOnError: true }
 			);
@@ -111,7 +115,7 @@ function useConvertClassicToBlockMenu( clientId ) {
 		return navigationMenu;
 	}
 
-	const convert = useCallback( async ( menuId, menuName ) => {
+	const convert = useCallback( async ( menuId, menuName, postStatus ) => {
 		if ( ! menuId || ! menuName ) {
 			setError( 'Unable to convert menu. Missing menu details.' );
 			setStatus( CLASSIC_MENU_CONVERSION_ERROR );
@@ -121,7 +125,11 @@ function useConvertClassicToBlockMenu( clientId ) {
 		setStatus( CLASSIC_MENU_CONVERSION_PENDING );
 		setError( null );
 
-		return await convertClassicMenuToBlockMenu( menuId, menuName )
+		return await convertClassicMenuToBlockMenu(
+			menuId,
+			menuName,
+			postStatus
+		)
 			.then( ( navigationMenu ) => {
 				setStatus( CLASSIC_MENU_CONVERSION_SUCCESS );
 				return navigationMenu;

--- a/packages/block-library/src/navigation/edit/use-convert-classic-menu-to-block-menu.js
+++ b/packages/block-library/src/navigation/edit/use-convert-classic-menu-to-block-menu.js
@@ -19,7 +19,7 @@ export const CLASSIC_MENU_CONVERSION_IDLE = 'idle';
 
 // This is needed to ensure that multiple components using this hook
 // do not import the same classic menu twice.
-let isConvertingClassicMenu = null;
+let classicMenuBeingConvertedId = null;
 
 function useConvertClassicToBlockMenu( clientId ) {
 	/*
@@ -122,7 +122,7 @@ function useConvertClassicToBlockMenu( clientId ) {
 
 	const convert = useCallback( async ( menuId, menuName, postStatus ) => {
 		// Check whether this classic menu is being imported already.
-		if ( isConvertingClassicMenu === menuId ) {
+		if ( classicMenuBeingConvertedId === menuId ) {
 			return;
 		}
 

--- a/packages/block-library/src/navigation/edit/use-convert-classic-menu-to-block-menu.js
+++ b/packages/block-library/src/navigation/edit/use-convert-classic-menu-to-block-menu.js
@@ -66,6 +66,8 @@ function useConvertClassicToBlockMenu( clientId ) {
 			);
 		}
 
+		classicMenuItems = null;
+
 		// Handle offline response which resolves to `null`.
 		if ( classicMenuItems === null ) {
 			throw new Error(
@@ -153,6 +155,9 @@ function useConvertClassicToBlockMenu( clientId ) {
 				setError( err?.message );
 				// Reset the ID for the currently importing classic menu.
 				setStatus( CLASSIC_MENU_CONVERSION_ERROR );
+
+				// Reset the ID for the currently importing classic menu.
+				classicMenuBeingConvertedId = null;
 
 				// Rethrow error for debugging.
 				throw new Error(

--- a/packages/block-library/src/navigation/edit/use-convert-classic-menu-to-block-menu.js
+++ b/packages/block-library/src/navigation/edit/use-convert-classic-menu-to-block-menu.js
@@ -127,7 +127,7 @@ function useConvertClassicToBlockMenu( clientId ) {
 		}
 
 		// Set the ID for the currently importing classic menu.
-		isConvertingClassicMenu = menuId;
+		classicMenuBeingConvertedId = menuId;
 
 		if ( ! menuId || ! menuName ) {
 			setError( 'Unable to convert menu. Missing menu details.' );
@@ -146,7 +146,7 @@ function useConvertClassicToBlockMenu( clientId ) {
 			.then( ( navigationMenu ) => {
 				setStatus( CLASSIC_MENU_CONVERSION_SUCCESS );
 				// Reset the ID for the currently importing classic menu.
-				isConvertingClassicMenu = null;
+				classicMenuBeingConvertedId = null;
 				return navigationMenu;
 			} )
 			.catch( ( err ) => {

--- a/packages/block-library/src/navigation/edit/use-convert-classic-menu-to-block-menu.js
+++ b/packages/block-library/src/navigation/edit/use-convert-classic-menu-to-block-menu.js
@@ -66,8 +66,6 @@ function useConvertClassicToBlockMenu( clientId ) {
 			);
 		}
 
-		classicMenuItems = null;
-
 		// Handle offline response which resolves to `null`.
 		if ( classicMenuItems === null ) {
 			throw new Error(

--- a/packages/block-library/src/navigation/edit/use-convert-classic-menu-to-block-menu.js
+++ b/packages/block-library/src/navigation/edit/use-convert-classic-menu-to-block-menu.js
@@ -17,6 +17,10 @@ export const CLASSIC_MENU_CONVERSION_ERROR = 'error';
 export const CLASSIC_MENU_CONVERSION_PENDING = 'pending';
 export const CLASSIC_MENU_CONVERSION_IDLE = 'idle';
 
+// This is needed to ensure that multiple components using this hook
+// do not import the same classic menu twice.
+let isConvertingClassicMenu = null;
+
 function useConvertClassicToBlockMenu( clientId ) {
 	/*
 	 * The wp_navigation post is created as a draft so the changes on the frontend and
@@ -117,6 +121,14 @@ function useConvertClassicToBlockMenu( clientId ) {
 	}
 
 	const convert = useCallback( async ( menuId, menuName, postStatus ) => {
+		// Check whether this classic menu is being imported already.
+		if ( isConvertingClassicMenu === menuId ) {
+			return;
+		}
+
+		// Set the ID for the currently importing classic menu.
+		isConvertingClassicMenu = menuId;
+
 		if ( ! menuId || ! menuName ) {
 			setError( 'Unable to convert menu. Missing menu details.' );
 			setStatus( CLASSIC_MENU_CONVERSION_ERROR );
@@ -133,10 +145,13 @@ function useConvertClassicToBlockMenu( clientId ) {
 		)
 			.then( ( navigationMenu ) => {
 				setStatus( CLASSIC_MENU_CONVERSION_SUCCESS );
+				// Reset the ID for the currently importing classic menu.
+				isConvertingClassicMenu = null;
 				return navigationMenu;
 			} )
 			.catch( ( err ) => {
 				setError( err?.message );
+				// Reset the ID for the currently importing classic menu.
 				setStatus( CLASSIC_MENU_CONVERSION_ERROR );
 
 				// Rethrow error for debugging.

--- a/packages/block-library/src/navigation/edit/use-create-navigation-menu.js
+++ b/packages/block-library/src/navigation/edit/use-create-navigation-menu.js
@@ -16,10 +16,7 @@ export const CREATE_NAVIGATION_MENU_ERROR = 'error';
 export const CREATE_NAVIGATION_MENU_PENDING = 'pending';
 export const CREATE_NAVIGATION_MENU_IDLE = 'idle';
 
-export default function useCreateNavigationMenu(
-	clientId,
-	postStatus = 'publish'
-) {
+export default function useCreateNavigationMenu( clientId ) {
 	const [ status, setStatus ] = useState( CREATE_NAVIGATION_MENU_IDLE );
 	const [ value, setValue ] = useState( null );
 	const [ error, setError ] = useState( null );
@@ -30,7 +27,7 @@ export default function useCreateNavigationMenu(
 	// This callback uses data from the two placeholder steps and only creates
 	// a new navigation menu when the user completes the final step.
 	const create = useCallback(
-		async ( title = null, blocks = [] ) => {
+		async ( title = null, blocks = [], postStatus ) => {
 			// Guard against creating Navigations without a title.
 			// Note you can pass no title, but if one is passed it must be
 			// a string otherwise the title may end up being empty.

--- a/packages/block-library/src/navigation/index.php
+++ b/packages/block-library/src/navigation/index.php
@@ -259,13 +259,14 @@ function block_core_navigation_get_classic_menu_fallback() {
 	// If menus exist.
 	if ( $classic_nav_menus && ! is_wp_error( $classic_nav_menus ) && count( $classic_nav_menus ) === 1 ) {
 		// If there's only one classic menu then use it.
-		return $classic_nav_menus[ 0 ];
+		return $classic_nav_menus[0];
 	}
 }
 
 /**
- * Finds the classic navigation fallback to use.
+ * Converts a classic navigation to blocks.
  *
+ * @param  object WP_Term The classic navigation object to convert.
  * @return array the normalized parsed blocks.
  */
 function block_core_navigation_get_classic_menu_fallback_blocks( $classic_nav_menu ) {
@@ -304,21 +305,23 @@ function block_core_navigation_get_classic_menu_fallback_blocks( $classic_nav_me
  * @return array the normalized parsed blocks.
  */
 function block_core_navigation_maybe_use_classic_menu_fallback() {
-	// See if we have a classic menu
+	// See if we have a classic menu.
 	$classic_nav_menu = block_core_navigation_get_classic_menu_fallback();
 
 	// If we have a classic menu then convert it to blocks.
 	if ( $classic_nav_menu ) {
-		$classic_nav_menu_blocks = block_core_navigation_get_classic_menu_fallback_blocks( $classic_nav_menu );
+		$classic_nav_menu_blocks            = block_core_navigation_get_classic_menu_fallback_blocks( $classic_nav_menu );
 		$classic_nav_menu_blocks_serialized = serialize_blocks( $classic_nav_menu_blocks );
 
 		// Create a new navigation menu from the classic menu.
-		wp_insert_post( array(
-			'post_content' => $classic_nav_menu_blocks_serialized,
-			'post_title' => $classic_nav_menu->slug,
-			'post_status' => 'publish',
-			'post_type' => 'wp_navigation'
-		) );
+		wp_insert_post(
+			array(
+				'post_content' => $classic_nav_menu_blocks_serialized,
+				'post_title'   => $classic_nav_menu->slug,
+				'post_status'  => 'publish',
+				'post_type'    => 'wp_navigation'
+			)
+		);
 
 		// Fetch the most recently published navigation which will be the classic one created above.
 		return block_core_navigation_get_most_recently_published_navigation();

--- a/packages/block-library/src/navigation/index.php
+++ b/packages/block-library/src/navigation/index.php
@@ -248,34 +248,27 @@ function block_core_navigation_render_submenu_icon() {
 	return '<svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" viewBox="0 0 12 12" fill="none" aria-hidden="true" focusable="false"><path d="M1.50002 4L6.00002 8L10.5 4" stroke-width="1.5"></path></svg>';
 }
 
+/**
+ * Get the classic navigation menu to use as a fallback.
+ *
+ * @return object WP_Term The classic navigation.
+ */
 function block_core_navigation_get_classic_menu_fallback() {
 	$classic_nav_menus = wp_get_nav_menus();
 
 	// If menus exist.
-	if ( $classic_nav_menus && ! is_wp_error( $classic_nav_menus ) ) {
-		// Get the primary one
-		// Should this be the one at the primary location?
-		$primary_nav_menu = array_filter( $classic_nav_menus, function( $classic_menu ) {
-			return $classic_menu->slug === 'primary';
-		} );
-
-		if ( isset( $primary_nav_menu ) && count( $primary_nav_menu ) > 0 ) {
-			return current( $primary_nav_menu );
-		}
-
-		// If there's no primary one then just use the newest.
+	if ( $classic_nav_menus && ! is_wp_error( $classic_nav_menus ) && count( $classic_nav_menus ) === 1 ) {
+		// If there's only one classic menu then use it.
 		return $classic_nav_menus[ 0 ];
 	}
 }
 
 /**
- * Finds the most classic navigation fallback to use.
+ * Finds the classic navigation fallback to use.
  *
- * @return WP_Post|null the classic navigation post.
+ * @return array the normalized parsed blocks.
  */
-function block_core_navigation_get_classic_menu_fallback_blocks() {
-	$classic_nav_menu = block_core_navigation_get_classic_menu_fallback();
-
+function block_core_navigation_get_classic_menu_fallback_blocks( $classic_nav_menu ) {
 	$menu_items = wp_get_nav_menu_items( $classic_nav_menu->term_id, array( 'update_post_term_cache' => false ) );
 
 	// Set up the $menu_item variables.
@@ -388,7 +381,10 @@ function block_core_navigation_get_fallback_blocks() {
 		$fallback_blocks = ! empty( $maybe_fallback ) ? $maybe_fallback : $fallback_blocks;
 	} else {
 		// See if we have any classic menus
-		$fallback_blocks = block_core_navigation_get_classic_menu_fallback_blocks();
+		$classic_nav_menu = block_core_navigation_get_classic_menu_fallback();
+		if ( $classic_nav_menu ) {
+			$fallback_blocks = block_core_navigation_get_classic_menu_fallback_blocks( $classic_nav_menu );
+		}
 	}
 
 	/**

--- a/packages/block-library/src/navigation/index.php
+++ b/packages/block-library/src/navigation/index.php
@@ -258,7 +258,9 @@ function block_core_navigation_get_classic_menu_fallback() {
 
 	// If menus exist.
 	if ( $classic_nav_menus && ! is_wp_error( $classic_nav_menus ) && count( $classic_nav_menus ) === 1 ) {
-		// If there's only one classic menu then use it.
+		// Use the first classic menu only. Handles simple use case where user has a single
+		// classic menu and switches to a block theme. In future this maybe expanded to
+		// determine the most appropriate classic menu to be used based on location.
 		return $classic_nav_menus[0];
 	}
 }

--- a/packages/block-library/src/navigation/index.php
+++ b/packages/block-library/src/navigation/index.php
@@ -320,6 +320,7 @@ function block_core_navigation_maybe_use_classic_menu_fallback() {
 			array(
 				'post_content' => $classic_nav_menu_blocks_serialized,
 				'post_title'   => $classic_nav_menu->slug,
+				'post_name'   => $classic_nav_menu->slug,
 				'post_status'  => 'publish',
 				'post_type'    => 'wp_navigation'
 			)

--- a/packages/block-library/src/navigation/index.php
+++ b/packages/block-library/src/navigation/index.php
@@ -299,7 +299,7 @@ function block_core_navigation_get_classic_menu_fallback_blocks( $classic_nav_me
 		$menu_items_by_parent_id
 	);
 
-	return $inner_blocks;
+	return serialize_blocks( $inner_blocks );
 }
 
 /**
@@ -316,17 +316,16 @@ function block_core_navigation_maybe_use_classic_menu_fallback() {
 	}
 
 	// If we have a classic menu then convert it to blocks.
-	$classic_nav_menu_blocks            = block_core_navigation_get_classic_menu_fallback_blocks( $classic_nav_menu );
-	$classic_nav_menu_blocks_serialized = serialize_blocks( $classic_nav_menu_blocks );
+	$classic_nav_menu_blocks = block_core_navigation_get_classic_menu_fallback_blocks( $classic_nav_menu );
 
-	if ( empty( $classic_nav_menu_blocks_serialized ) ) {
+	if ( empty( $classic_nav_menu_blocks ) ) {
 		return;
 	}
 
 	// Create a new navigation menu from the classic menu.
 	$wp_insert_post_result = wp_insert_post(
 		array(
-			'post_content' => $classic_nav_menu_blocks_serialized,
+			'post_content' => $classic_nav_menu_blocks,
 			'post_title'   => $classic_nav_menu->slug,
 			'post_name'    => $classic_nav_menu->slug,
 			'post_status'  => 'publish',

--- a/packages/block-library/src/navigation/index.php
+++ b/packages/block-library/src/navigation/index.php
@@ -289,7 +289,7 @@ function block_core_navigation_get_classic_menu_fallback_blocks( $classic_nav_me
 		$menu_items_by_parent_id[ $menu_item->menu_item_parent ][] = $menu_item;
 	}
 
-	$inner_blocks = gutenberg_convert_menu_items_to_blocks(
+	$inner_blocks = block_core_navigation_parse_blocks_from_menu_items(
 		isset( $menu_items_by_parent_id[0] )
 			? $menu_items_by_parent_id[0]
 			: array(),

--- a/packages/block-library/src/navigation/index.php
+++ b/packages/block-library/src/navigation/index.php
@@ -310,30 +310,36 @@ function block_core_navigation_maybe_use_classic_menu_fallback() {
 	// See if we have a classic menu.
 	$classic_nav_menu = block_core_navigation_get_classic_menu_fallback();
 
-	// If we have a classic menu then convert it to blocks.
-	if ( $classic_nav_menu ) {
-		$classic_nav_menu_blocks            = block_core_navigation_get_classic_menu_fallback_blocks( $classic_nav_menu );
-		$classic_nav_menu_blocks_serialized = serialize_blocks( $classic_nav_menu_blocks );
-
-		// Create a new navigation menu from the classic menu.
-		$wp_insert_post_result = wp_insert_post(
-			array(
-				'post_content' => $classic_nav_menu_blocks_serialized,
-				'post_title'   => $classic_nav_menu->slug,
-				'post_name'   => $classic_nav_menu->slug,
-				'post_status'  => 'publish',
-				'post_type'    => 'wp_navigation'
-			),
-			true // So that we can check whether the result is an error.
-		);
-
-		if ( is_wp_error( $wp_insert_post_result ) ) {
-			return;
-		}
-
-		// Fetch the most recently published navigation which will be the classic one created above.
-		return block_core_navigation_get_most_recently_published_navigation();
+	if ( ! $classic_nav_menu ) {
+		return;
 	}
+
+	// If we have a classic menu then convert it to blocks.
+	$classic_nav_menu_blocks            = block_core_navigation_get_classic_menu_fallback_blocks( $classic_nav_menu );
+	$classic_nav_menu_blocks_serialized = serialize_blocks( $classic_nav_menu_blocks );
+
+	if ( empty( $classic_nav_menu_blocks_serialized ) ) {
+		return;
+	}
+
+	// Create a new navigation menu from the classic menu.
+	$wp_insert_post_result = wp_insert_post(
+		array(
+			'post_content' => $classic_nav_menu_blocks_serialized,
+			'post_title'   => $classic_nav_menu->slug,
+			'post_name'   => $classic_nav_menu->slug,
+			'post_status'  => 'publish',
+			'post_type'    => 'wp_navigation'
+		),
+		true // So that we can check whether the result is an error.
+	);
+
+	if ( is_wp_error( $wp_insert_post_result ) ) {
+		return;
+	}
+
+	// Fetch the most recently published navigation which will be the classic one created above.
+	return block_core_navigation_get_most_recently_published_navigation();
 }
 
 /**

--- a/packages/block-library/src/navigation/index.php
+++ b/packages/block-library/src/navigation/index.php
@@ -314,7 +314,7 @@ function block_core_navigation_maybe_use_classic_menu_fallback() {
 		$classic_nav_menu_blocks_serialized = serialize_blocks( $classic_nav_menu_blocks );
 
 		// Create a new navigation menu from the classic menu.
-		wp_insert_post(
+		$wp_insert_post_result = wp_insert_post(
 			array(
 				'post_content' => $classic_nav_menu_blocks_serialized,
 				'post_title'   => $classic_nav_menu->slug,
@@ -322,6 +322,10 @@ function block_core_navigation_maybe_use_classic_menu_fallback() {
 				'post_type'    => 'wp_navigation'
 			)
 		);
+
+		if ( is_wp_error( $wp_insert_post_result ) ) {
+			return;
+		}
 
 		// Fetch the most recently published navigation which will be the classic one created above.
 		return block_core_navigation_get_most_recently_published_navigation();

--- a/packages/block-library/src/navigation/index.php
+++ b/packages/block-library/src/navigation/index.php
@@ -323,7 +323,8 @@ function block_core_navigation_maybe_use_classic_menu_fallback() {
 				'post_name'   => $classic_nav_menu->slug,
 				'post_status'  => 'publish',
 				'post_type'    => 'wp_navigation'
-			)
+			),
+			true // So that we can check whether the result is an error.
 		);
 
 		if ( is_wp_error( $wp_insert_post_result ) ) {

--- a/packages/block-library/src/navigation/index.php
+++ b/packages/block-library/src/navigation/index.php
@@ -422,7 +422,7 @@ function block_core_navigation_get_fallback_blocks() {
 		$navigation_post = block_core_navigation_maybe_use_classic_menu_fallback();
 	}
 
-	// Prefer using the first non-empty Navigation as fallback if available.
+	// Use the first non-empty Navigation as fallback if available.
 	if ( $navigation_post ) {
 		$maybe_fallback = block_core_navigation_filter_out_empty_blocks( parse_blocks( $navigation_post->post_content ) );
 

--- a/packages/block-library/src/navigation/index.php
+++ b/packages/block-library/src/navigation/index.php
@@ -417,7 +417,8 @@ function block_core_navigation_get_fallback_blocks() {
 
 	$navigation_post = block_core_navigation_get_most_recently_published_navigation();
 
-	// If there are no navigation posts then try to find a classic menu.
+	// If there are no navigation posts then try to find a classic menu
+	// and convert it into a block based navigation menu.
 	if ( ! $navigation_post ) {
 		$navigation_post = block_core_navigation_maybe_use_classic_menu_fallback();
 	}

--- a/packages/block-library/src/navigation/index.php
+++ b/packages/block-library/src/navigation/index.php
@@ -341,7 +341,7 @@ function block_core_navigation_maybe_use_classic_menu_fallback() {
  */
 function block_core_navigation_get_most_recently_published_navigation() {
 
-	// We default to the most recently created menu.
+	// Default to the most recently created menu.
 	$parsed_args = array(
 		'post_type'      => 'wp_navigation',
 		'no_found_rows'  => true,

--- a/packages/block-library/src/navigation/index.php
+++ b/packages/block-library/src/navigation/index.php
@@ -272,6 +272,7 @@ function block_core_navigation_get_classic_menu_fallback() {
  * @return array the normalized parsed blocks.
  */
 function block_core_navigation_get_classic_menu_fallback_blocks( $classic_nav_menu ) {
+	// BEGIN: Code that already exists in wp_nav_menu().
 	$menu_items = wp_get_nav_menu_items( $classic_nav_menu->term_id, array( 'update_post_term_cache' => false ) );
 
 	// Set up the $menu_item variables.

--- a/packages/block-library/src/navigation/index.php
+++ b/packages/block-library/src/navigation/index.php
@@ -268,7 +268,7 @@ function block_core_navigation_get_classic_menu_fallback() {
 /**
  * Converts a classic navigation to blocks.
  *
- * @param  object WP_Term The classic navigation object to convert.
+ * @param  object $classic_nav_menu WP_Term The classic navigation object to convert.
  * @return array the normalized parsed blocks.
  */
 function block_core_navigation_get_classic_menu_fallback_blocks( $classic_nav_menu ) {
@@ -328,9 +328,9 @@ function block_core_navigation_maybe_use_classic_menu_fallback() {
 		array(
 			'post_content' => $classic_nav_menu_blocks_serialized,
 			'post_title'   => $classic_nav_menu->slug,
-			'post_name'   => $classic_nav_menu->slug,
+			'post_name'    => $classic_nav_menu->slug,
 			'post_status'  => 'publish',
-			'post_type'    => 'wp_navigation'
+			'post_type'    => 'wp_navigation',
 		),
 		true // So that we can check whether the result is an error.
 	);


### PR DESCRIPTION
## What?
If a site has a classic navigation menu, but no wp_navigation CPTs then we should fallback to the classic navigation block. If there's a primary location then we should use the navigation assigned to it, if not then we could use the latest one.

## Why?
For users who have set up classic menus this will be better than just showing them a list of pages.

## How?
In the frontend we just fetch the correct navigation menu and convert it to blocks

In the editor we actually convert the navigation menu to a wp_navigation CPT. This creates some issues - at the moment it's created as a draft. Also it gets created multiple times. Perhaps the best way round this is to create it as a published menu, so that the fallbacks will continue to work as they do right now.

## Testing Instructions
- You need to have a classic menu called primary and no wp_navigation CPTs
- In that scenario you should see the classic menu in both the editor and the frontend
