### PR TITLE
Fix demo content cover block text color

### DIFF
--- a/post-content.php
+++ b/post-content.php
@@ -7,8 +7,8 @@
 
 ?>
 <!-- wp:cover {"url":"https://cldup.com/Fz-ASbo2s3.jpg","className":"alignwide"} -->
-<div class="wp-block-cover has-background-dim alignwide" style="background-image:url(https://cldup.com/Fz-ASbo2s3.jpg)"><div class="wp-block-cover__inner-container"><!-- wp:paragraph {"align":"center","placeholder":"Write title…","fontSize":"large"} -->
-<p class="has-text-align-center has-large-font-size"><?php _e( 'Of Mountains &amp; Printing Presses', 'gutenberg' ); ?></p>
+<div class="wp-block-cover has-background-dim alignwide" style="background-image:url(https://cldup.com/Fz-ASbo2s3.jpg)"><div class="wp-block-cover__inner-container"><!-- wp:paragraph {"align":"center","placeholder":"Write title…","textColor":"white","fontSize":"large"} -->
+<p class="has-text-align-center has-white-color has-text-color has-large-font-size"><?php _e( 'Of Mountains &amp; Printing Presses', 'gutenberg' ); ?></p>
 <!-- /wp:paragraph --></div></div>
 <!-- /wp:cover -->
 


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Fix the demo content cover block text color.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

We want the content on our demo to look nice and be color accessible.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

The external URL that the demo cover block uses causes FastAverageColor used in the is-dark/is-light heuristic to fail because of a tainted canvas due to a CORS error. Manually setting the text color for the demo is the most straightforward way to fix it right now.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->

1. From wp-admin select Gutenberg > Demo
2. See that the cover block has white text

## Screenshots or screencast <!-- if applicable -->

### Before
![before](https://user-images.githubusercontent.com/5129775/190272942-ac941b30-e1c9-4962-b3ae-682bce142bb0.png)

### After
![after](https://user-images.githubusercontent.com/5129775/190272268-25f42cf6-e906-41ca-936d-0e50efda6127.png)