### PR TITLE
Update fast-average-color

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15581,6 +15581,11 @@
 			"integrity": "sha512-WKG4gTr8przEZBiJ5r3s8ZIAoMXNbOgQ+j/d5O4X3x6kZJRLNvyUJuUK/KoG3+8BaOHPhp2m7WC6JKKeovDSzQ==",
 			"dev": true
 		},
+		"@types/offscreencanvas": {
+			"version": "2019.7.0",
+			"resolved": "https://registry.npmjs.org/@types/offscreencanvas/-/offscreencanvas-2019.7.0.tgz",
+			"integrity": "sha512-PGcyveRIpL1XIqK8eBsmRBt76eFgtzuPiSTyKHZxnGemp2yzGzWpjYKAfK3wIMiU7eH+851yEpiuP8JZerTmWg=="
+		},
 		"@types/overlayscrollbars": {
 			"version": "1.12.0",
 			"resolved": "https://registry.npmjs.org/@types/overlayscrollbars/-/overlayscrollbars-1.12.0.tgz",
@@ -16610,7 +16615,7 @@
 				"change-case": "^4.1.2",
 				"classnames": "^2.3.1",
 				"colord": "^2.7.0",
-				"fast-average-color": "^4.3.0",
+				"fast-average-color": "^9.1.1",
 				"lodash": "^4.17.21",
 				"memize": "^1.1.0",
 				"micromodal": "^0.4.10",
@@ -17711,7 +17716,7 @@
 				"@wordpress/react-native-aztec": "file:packages/react-native-aztec",
 				"@wordpress/react-native-bridge": "file:packages/react-native-bridge",
 				"core-js": "^3.19.1",
-				"fast-average-color": "^4.3.0",
+				"fast-average-color": "^9.1.1",
 				"gettext-parser": "^1.3.1",
 				"jed": "^1.1.1",
 				"jsdom-jscore-rn": "git+https://github.com/iamcco/jsdom-jscore-rn.git#a562f3d57c27c13e5bfc8cf82d496e69a3ba2800",
@@ -34580,9 +34585,12 @@
 			"dev": true
 		},
 		"fast-average-color": {
-			"version": "4.3.0",
-			"resolved": "https://registry.npmjs.org/fast-average-color/-/fast-average-color-4.3.0.tgz",
-			"integrity": "sha512-k8FXd6+JeXoItmdNqB3hMwFgArryjdYBLuzEM8fRY/oztd/051yhSHU6GUrMOfIQU9dDHyFDcIAkGrQKlYtpDA=="
+			"version": "9.1.1",
+			"resolved": "https://registry.npmjs.org/fast-average-color/-/fast-average-color-9.1.1.tgz",
+			"integrity": "sha512-PJizLBcGb/jqUzrH66385te4+GcOK7wcUiCDvBUszdpzc/pvV1kwifvvsFygV3mS+7qwnWmK9/BrZniaOOC9ag==",
+			"requires": {
+				"@types/offscreencanvas": "^2019.7.0"
+			}
 		},
 		"fast-base64-decode": {
 			"version": "1.0.0",

--- a/packages/block-library/package.json
+++ b/packages/block-library/package.json
@@ -60,7 +60,7 @@
 		"change-case": "^4.1.2",
 		"classnames": "^2.3.1",
 		"colord": "^2.7.0",
-		"fast-average-color": "^4.3.0",
+		"fast-average-color": "^9.1.1",
 		"lodash": "^4.17.21",
 		"memize": "^1.1.0",
 		"micromodal": "^0.4.10",

--- a/packages/block-library/src/cover/edit/use-cover-is-dark.js
+++ b/packages/block-library/src/cover/edit/use-cover-is-dark.js
@@ -46,6 +46,9 @@ export default function useCoverIsDark(
 					// Previously the default color was white, but that changed
 					// in v6.0.0 so it has to be manually set now.
 					defaultColor: [ 255, 255, 255, 255 ],
+					// Errors that come up don't reject the promise, so error
+					// logging has to be silenced with this option.
+					silent: true,
 				} )
 				.then( ( color ) => setIsDark( color.isDark ) );
 		}

--- a/packages/block-library/src/cover/edit/use-cover-is-dark.js
+++ b/packages/block-library/src/cover/edit/use-cover-is-dark.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import FastAverageColor from 'fast-average-color';
+import { FastAverageColor } from 'fast-average-color';
 import { colord } from 'colord';
 
 /**
@@ -41,12 +41,13 @@ export default function useCoverIsDark(
 		// If opacity is lower than 50 the dominant color is the image or video color,
 		// so use that color for the dark mode computation.
 		if ( url && dimRatio <= 50 && elementRef.current ) {
-			retrieveFastAverageColor().getColorAsync(
-				elementRef.current,
-				( color ) => {
-					setIsDark( color.isDark );
-				}
-			);
+			retrieveFastAverageColor()
+				.getColorAsync( elementRef.current, {
+					// Previously the default color was white, but that changed
+					// in v6.0.0 so it has to be manually set now.
+					defaultColor: [ 255, 255, 255, 255 ],
+				} )
+				.then( ( color ) => setIsDark( color.isDark ) );
 		}
 	}, [ url, url && dimRatio <= 50 && elementRef.current, setIsDark ] );
 	useEffect( () => {

--- a/packages/block-library/src/cover/edit/use-cover-is-dark.js
+++ b/packages/block-library/src/cover/edit/use-cover-is-dark.js
@@ -48,7 +48,7 @@ export default function useCoverIsDark(
 					defaultColor: [ 255, 255, 255, 255 ],
 					// Errors that come up don't reject the promise, so error
 					// logging has to be silenced with this option.
-					silent: true,
+					silent: process.env.NODE_ENV === 'production',
 				} )
 				.then( ( color ) => setIsDark( color.isDark ) );
 		}

--- a/packages/react-native-editor/package.json
+++ b/packages/react-native-editor/package.json
@@ -51,7 +51,7 @@
 		"@wordpress/react-native-aztec": "file:../react-native-aztec",
 		"@wordpress/react-native-bridge": "file:../react-native-bridge",
 		"core-js": "^3.19.1",
-		"fast-average-color": "^4.3.0",
+		"fast-average-color": "^9.1.1",
 		"gettext-parser": "^1.3.1",
 		"jed": "^1.1.1",
 		"jsdom-jscore-rn": "git+https://github.com/iamcco/jsdom-jscore-rn.git#a562f3d57c27c13e5bfc8cf82d496e69a3ba2800",


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Update fast-average-color to the latest version.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

The new version reports errors instead of hiding them as a property in the callback (the Promise will reject). Updating to this version helped me figure out why `FastAverageColor` wasn't working in #44174.

![fast-average-color error: FastAverageColor: security error (CORS) for resource https://cldup.com/Fz-ASbo2s3.jpg. Details: https://developer.mozilla.org/en/docs/Web/HTML/CORS_enabled_image. DOMException: The operation is insecure.](https://user-images.githubusercontent.com/5129775/190276363-babb1281-d91d-41c4-b9f8-659a280a3c6d.png)

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

Updating fast-average-color from 4.0.3 to 9.1.1 had some breaking changes:
- It now uses named exports instead of default exports.
- It returns a Promise instead of using a callback.
- The default return color changed from white to black.
- Error logging was added.

Fortunately, the updated version can be configured to behave like the old version:
- I've configured it so error logging is only silenced in production (`process.env.NODE_ENV === 'production'`).
- And I've manually set the `defaultColor` back to white so existing blocks don't change.

Unfortunately, the library doesn't actually reject the promise when there is a CORS error—it resolves with the `defaultColor` and logs errors unless the `silent` option is set, so those configuration options are the only way to maintain backwards compatibility.

There may be an opportunity to address the CORS issue directly, but I've left that for another PR for another day.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->

Make sure the cover block is-dark/is-light heuristics are working by using different images with the overlay color opacity set to anything less than or equal to 50.

If running in a development environment the errors shown above should be logged.

