### PR TITLE
Change Group block default variation in inserter.

### DIFF
--- a/docs/reference-guides/core-blocks.md
+++ b/docs/reference-guides/core-blocks.md
@@ -276,7 +276,7 @@ Gather blocks in a layout container. ([Source](https://github.com/WordPress/gute
 -	**Name:** core/group
 -	**Category:** design
 -	**Supports:** align (full, wide), anchor, ariaLabel, color (background, gradients, link, text), spacing (blockGap, margin, padding), typography (fontSize, lineHeight), ~~html~~
--	**Attributes:** layout, tagName, templateLock
+-	**Attributes:** tagName, templateLock
 
 ## Heading
 

--- a/packages/block-editor/src/components/convert-to-group-buttons/toolbar.js
+++ b/packages/block-editor/src/components/convert-to-group-buttons/toolbar.js
@@ -14,7 +14,7 @@ import { useConvertToGroupButtonProps } from '../convert-to-group-buttons';
 import { store as blockEditorStore } from '../../store';
 
 const layouts = {
-	group: undefined,
+	group: { type: 'constrained' },
 	row: { type: 'flex', flexWrap: 'nowrap' },
 	stack: { type: 'flex', orientation: 'vertical' },
 };
@@ -40,11 +40,15 @@ function BlockGroupToolbar() {
 		[ clientIds, groupingBlockName ]
 	);
 
-	const onConvertToGroup = ( layout = 'group' ) => {
+	const onConvertToGroup = ( layout ) => {
 		const newBlocks = switchToBlockType(
 			blocksSelection,
 			groupingBlockName
 		);
+
+		if ( typeof layout !== 'string' ) {
+			layout = 'group';
+		}
 
 		if ( newBlocks && newBlocks.length > 0 ) {
 			// Because the block is not in the store yet we can't use

--- a/packages/block-library/src/group/block.json
+++ b/packages/block-library/src/group/block.json
@@ -15,12 +15,6 @@
 		"templateLock": {
 			"type": [ "string", "boolean" ],
 			"enum": [ "all", "insert", "contentOnly", false ]
-		},
-		"layout": {
-			"type": "object",
-			"default": {
-				"type": "constrained"
-			}
 		}
 	},
 	"supports": {

--- a/packages/block-library/src/group/edit.js
+++ b/packages/block-library/src/group/edit.js
@@ -1,8 +1,8 @@
 /**
  * WordPress dependencies
  */
-import { useSelect, useDispatch } from '@wordpress/data';
-import { useEffect } from '@wordpress/element';
+import { useSelect } from '@wordpress/data';
+
 import {
 	InnerBlocks,
 	useBlockProps,
@@ -69,16 +69,6 @@ function GroupEdit( { attributes, setAttributes, clientId } ) {
 			__experimentalLayout: layoutSupportEnabled ? usedLayout : undefined,
 		}
 	);
-
-	const { __unstableMarkNextChangeAsNotPersistent } =
-		useDispatch( blockEditorStore );
-	const { type: layoutType = null } = layout;
-	useEffect( () => {
-		if ( layoutType ) {
-			__unstableMarkNextChangeAsNotPersistent();
-			setAttributes( { layout: { ...layout, type: layoutType } } );
-		}
-	}, [ layoutType ] );
 
 	return (
 		<>

--- a/packages/block-library/src/group/transforms.js
+++ b/packages/block-library/src/group/transforms.js
@@ -41,6 +41,7 @@ const transforms = {
 					'core/group',
 					{
 						align: widestAlignment,
+						layout: { type: 'constrained' },
 					},
 					groupInnerBlocks
 				);

--- a/packages/block-library/src/group/variations.js
+++ b/packages/block-library/src/group/variations.js
@@ -17,18 +17,6 @@ const variations = [
 		icon: group,
 	},
 	{
-		name: 'group-flow',
-		title: __( 'Group' ),
-		description: __( 'Gather blocks in a container.' ),
-		attributes: { layout: { type: 'default' } },
-		scope: [ 'block' ],
-		isActive: ( blockAttributes ) =>
-			! blockAttributes.layout ||
-			! blockAttributes.layout?.type ||
-			blockAttributes.layout?.type === 'default',
-		icon: group,
-	},
-	{
 		name: 'group-row',
 		title: _x( 'Row', 'single horizontal line' ),
 		description: __( 'Arrange blocks horizontally.' ),

--- a/packages/block-library/src/group/variations.js
+++ b/packages/block-library/src/group/variations.js
@@ -10,12 +10,22 @@ const variations = [
 		title: __( 'Group' ),
 		description: __( 'Gather blocks in a container.' ),
 		attributes: { layout: { type: 'constrained' } },
-		scope: [ 'transform' ],
+		isDefault: true,
+		scope: [ 'inserter', 'transform' ],
+		isActive: ( blockAttributes ) =>
+			blockAttributes.layout?.type === 'constrained',
+		icon: group,
+	},
+	{
+		name: 'group-flow',
+		title: __( 'Group' ),
+		description: __( 'Gather blocks in a container.' ),
+		attributes: { layout: { type: 'default' } },
+		scope: [ 'block' ],
 		isActive: ( blockAttributes ) =>
 			! blockAttributes.layout ||
 			! blockAttributes.layout?.type ||
-			blockAttributes.layout?.type === 'default' ||
-			blockAttributes.layout?.type === 'constrained',
+			blockAttributes.layout?.type === 'default',
 		icon: group,
 	},
 	{

--- a/packages/block-library/src/group/variations.js
+++ b/packages/block-library/src/group/variations.js
@@ -13,6 +13,9 @@ const variations = [
 		isDefault: true,
 		scope: [ 'inserter', 'transform' ],
 		isActive: ( blockAttributes ) =>
+			! blockAttributes.layout ||
+			! blockAttributes.layout?.type ||
+			blockAttributes.layout?.type === 'default' ||
 			blockAttributes.layout?.type === 'constrained',
 		icon: group,
 	},

--- a/packages/e2e-tests/specs/editor/plugins/__snapshots__/cpt-locking.test.js.snap
+++ b/packages/e2e-tests/specs/editor/plugins/__snapshots__/cpt-locking.test.js.snap
@@ -41,7 +41,7 @@ exports[`cpt locking template_lock all should not error when deleting the cotent
 `;
 
 exports[`cpt locking template_lock all unlocked group should allow blocks to be moved 1`] = `
-"<!-- wp:group {\\"templateLock\\":false,\\"layout\\":{\\"type\\":\\"constrained\\"}} -->
+"<!-- wp:group {\\"templateLock\\":false} -->
 <div class=\\"wp-block-group\\"><!-- wp:paragraph {\\"placeholder\\":\\"Add a description\\"} -->
 <p>p1</p>
 <!-- /wp:paragraph -->
@@ -55,7 +55,7 @@ exports[`cpt locking template_lock all unlocked group should allow blocks to be 
 `;
 
 exports[`cpt locking template_lock all unlocked group should allow blocks to be removed 1`] = `
-"<!-- wp:group {\\"templateLock\\":false,\\"layout\\":{\\"type\\":\\"constrained\\"}} -->
+"<!-- wp:group {\\"templateLock\\":false} -->
 <div class=\\"wp-block-group\\"><!-- wp:quote -->
 <blockquote class=\\"wp-block-quote\\"><!-- wp:paragraph -->
 <p></p>

--- a/packages/e2e-tests/specs/editor/various/__snapshots__/block-grouping.test.js.snap
+++ b/packages/e2e-tests/specs/editor/various/__snapshots__/block-grouping.test.js.snap
@@ -79,7 +79,7 @@ exports[`Block Grouping Group creation groups and ungroups multiple blocks of di
 `;
 
 exports[`Block Grouping Preserving selected blocks attributes preserves width alignment settings of selected blocks 1`] = `
-"<!-- wp:group {\\"layout\\":{\\"type\\":\\"constrained\\"},\\"align\\":\\"full\\"} -->
+"<!-- wp:group {\\"align\\":\\"full\\",\\"layout\\":{\\"type\\":\\"constrained\\"}} -->
 <div class=\\"wp-block-group alignfull\\"><!-- wp:heading -->
 <h2>Group Heading</h2>
 <!-- /wp:heading -->

--- a/test/e2e/specs/editor/blocks/__snapshots__/Group-can-have-other-blocks-appended-to-it-using-the-button-appender-1-chromium.txt
+++ b/test/e2e/specs/editor/blocks/__snapshots__/Group-can-have-other-blocks-appended-to-it-using-the-button-appender-1-chromium.txt
@@ -1,4 +1,4 @@
-<!-- wp:group {"layout":{"type":"constrained"}} -->
+<!-- wp:group -->
 <div class="wp-block-group"><!-- wp:paragraph -->
 <p>Group Block with a Paragraph</p>
 <!-- /wp:paragraph --></div>

--- a/test/integration/fixtures/blocks/core__comments.json
+++ b/test/integration/fixtures/blocks/core__comments.json
@@ -74,9 +74,6 @@
 										"isValid": true,
 										"attributes": {
 											"tagName": "div",
-											"layout": {
-												"type": "flex"
-											},
 											"style": {
 												"spacing": {
 													"margin": {
@@ -84,6 +81,9 @@
 														"bottom": "0px"
 													}
 												}
+											},
+											"layout": {
+												"type": "flex"
 											}
 										},
 										"innerBlocks": [

--- a/test/integration/fixtures/blocks/core__comments.serialized.html
+++ b/test/integration/fixtures/blocks/core__comments.serialized.html
@@ -10,7 +10,7 @@
 <!-- wp:column -->
 <div class="wp-block-column"><!-- wp:comment-author-name {"fontSize":"small"} /-->
 
-<!-- wp:group {"layout":{"type":"flex"},"style":{"spacing":{"margin":{"top":"0px","bottom":"0px"}}}} -->
+<!-- wp:group {"style":{"spacing":{"margin":{"top":"0px","bottom":"0px"}}},"layout":{"type":"flex"}} -->
 <div class="wp-block-group" style="margin-top:0px;margin-bottom:0px"><!-- wp:comment-date {"fontSize":"small"} /-->
 
 <!-- wp:comment-edit-link {"fontSize":"small"} /--></div>

--- a/test/integration/fixtures/blocks/core__comments__deprecated-1.json
+++ b/test/integration/fixtures/blocks/core__comments__deprecated-1.json
@@ -74,9 +74,6 @@
 										"isValid": true,
 										"attributes": {
 											"tagName": "div",
-											"layout": {
-												"type": "flex"
-											},
 											"style": {
 												"spacing": {
 													"margin": {
@@ -84,6 +81,9 @@
 														"bottom": "0px"
 													}
 												}
+											},
+											"layout": {
+												"type": "flex"
 											}
 										},
 										"innerBlocks": [

--- a/test/integration/fixtures/blocks/core__comments__deprecated-1.serialized.html
+++ b/test/integration/fixtures/blocks/core__comments__deprecated-1.serialized.html
@@ -10,7 +10,7 @@
 <!-- wp:column -->
 <div class="wp-block-column"><!-- wp:comment-author-name {"fontSize":"small"} /-->
 
-<!-- wp:group {"layout":{"type":"flex"},"style":{"spacing":{"margin":{"top":"0px","bottom":"0px"}}}} -->
+<!-- wp:group {"style":{"spacing":{"margin":{"top":"0px","bottom":"0px"}}},"layout":{"type":"flex"}} -->
 <div class="wp-block-group" style="margin-top:0px;margin-bottom:0px"><!-- wp:comment-date {"fontSize":"small"} /-->
 
 <!-- wp:comment-edit-link {"fontSize":"small"} /--></div>

--- a/test/integration/fixtures/blocks/core__group-layout-content-size.json
+++ b/test/integration/fixtures/blocks/core__group-layout-content-size.json
@@ -4,11 +4,11 @@
 		"isValid": true,
 		"attributes": {
 			"tagName": "div",
+			"align": "full",
+			"backgroundColor": "secondary",
 			"layout": {
 				"type": "constrained"
-			},
-			"align": "full",
-			"backgroundColor": "secondary"
+			}
 		},
 		"innerBlocks": [
 			{

--- a/test/integration/fixtures/blocks/core__group-layout-content-size.serialized.html
+++ b/test/integration/fixtures/blocks/core__group-layout-content-size.serialized.html
@@ -1,4 +1,4 @@
-<!-- wp:group {"layout":{"type":"constrained"},"align":"full","backgroundColor":"secondary"} -->
+<!-- wp:group {"align":"full","backgroundColor":"secondary","layout":{"type":"constrained"}} -->
 <div class="wp-block-group alignfull has-secondary-background-color has-background"><!-- wp:paragraph -->
 <p>This is a group block.</p>
 <!-- /wp:paragraph -->

--- a/test/integration/fixtures/blocks/core__group-layout-content-size__deprecated.serialized.html
+++ b/test/integration/fixtures/blocks/core__group-layout-content-size__deprecated.serialized.html
@@ -1,4 +1,4 @@
-<!-- wp:group {"layout":{"inherit":true,"type":"constrained"},"align":"full","backgroundColor":"secondary"} -->
+<!-- wp:group {"align":"full","backgroundColor":"secondary","layout":{"inherit":true,"type":"constrained"}} -->
 <div class="wp-block-group alignfull has-secondary-background-color has-background"><!-- wp:paragraph -->
 <p>This is a group block.</p>
 <!-- /wp:paragraph -->

--- a/test/integration/fixtures/blocks/core__group.json
+++ b/test/integration/fixtures/blocks/core__group.json
@@ -4,11 +4,11 @@
 		"isValid": true,
 		"attributes": {
 			"tagName": "div",
+			"align": "full",
+			"backgroundColor": "secondary",
 			"layout": {
 				"type": "default"
-			},
-			"align": "full",
-			"backgroundColor": "secondary"
+			}
 		},
 		"innerBlocks": [
 			{

--- a/test/integration/fixtures/blocks/core__group.serialized.html
+++ b/test/integration/fixtures/blocks/core__group.serialized.html
@@ -1,4 +1,4 @@
-<!-- wp:group {"layout":{"type":"default"},"align":"full","backgroundColor":"secondary"} -->
+<!-- wp:group {"align":"full","backgroundColor":"secondary","layout":{"type":"default"}} -->
 <div class="wp-block-group alignfull has-secondary-background-color has-background"><!-- wp:paragraph -->
 <p>This is a group block.</p>
 <!-- /wp:paragraph -->

--- a/test/integration/fixtures/blocks/core__navigation.json
+++ b/test/integration/fixtures/blocks/core__navigation.json
@@ -6,8 +6,8 @@
 			"showSubmenuIcon": true,
 			"openSubmenusOnClick": false,
 			"overlayMenu": "mobile",
-			"hasIcon": true,
 			"icon": "handle",
+			"hasIcon": true,
 			"maxNestingLevel": 5
 		},
 		"innerBlocks": []

--- a/test/integration/fixtures/blocks/core__post-featured-image.json
+++ b/test/integration/fixtures/blocks/core__post-featured-image.json
@@ -3,11 +3,11 @@
 		"name": "core/post-featured-image",
 		"isValid": true,
 		"attributes": {
-			"dimRatio": 0,
 			"isLink": false,
 			"scale": "cover",
 			"rel": "",
-			"linkTarget": "_self"
+			"linkTarget": "_self",
+			"dimRatio": 0
 		},
 		"innerBlocks": []
 	}

--- a/test/integration/fixtures/blocks/core__pullquote__custom-colors__deprecated-4.json
+++ b/test/integration/fixtures/blocks/core__pullquote__custom-colors__deprecated-4.json
@@ -3,13 +3,13 @@
 		"name": "core/pullquote",
 		"isValid": true,
 		"attributes": {
+			"value": "Pullquote custom color",
 			"className": "has-background is-style-default",
 			"style": {
 				"border": {
 					"color": "#2207d0"
 				}
 			},
-			"value": "Pullquote custom color",
 			"citation": "my citation",
 			"textColor": "subtle-background"
 		},

--- a/test/integration/fixtures/blocks/core__pullquote__deprecated-4.json
+++ b/test/integration/fixtures/blocks/core__pullquote__deprecated-4.json
@@ -3,10 +3,10 @@
 		"name": "core/pullquote",
 		"isValid": true,
 		"attributes": {
+			"value": "pullquote",
 			"className": "is-style-solid-color",
 			"backgroundColor": "black",
 			"textAlign": "left",
-			"value": "pullquote",
 			"citation": "before block supports",
 			"textColor": "white"
 		},

--- a/test/integration/fixtures/blocks/core__pullquote__deprecated-main-color.json
+++ b/test/integration/fixtures/blocks/core__pullquote__deprecated-main-color.json
@@ -3,13 +3,13 @@
 		"name": "core/pullquote",
 		"isValid": true,
 		"attributes": {
+			"value": "Pullquote custom color",
 			"className": "is-style-default",
 			"style": {
 				"border": {
 					"color": "#2207d0"
 				}
 			},
-			"value": "Pullquote custom color",
 			"citation": "my citation",
 			"textColor": "subtle-background"
 		},


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->


## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

Fixes #43760.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

Removes the effect updating layout in the block edit, adds a constrained layout variation as default and removes flow layout variation from inserter. 

Fixtures are updated because removing the effect caused a re-positioning of block attribute output.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->

1. Add a Group block in a post;
2. Check that it has constrained layout enabled;
3. Check that legacy Group blocks with different layout types are not affected.
4. In the site editor, add a template part to a template;
5. Add a Group block inside the template part;
6. Duplicate the template part and check site editor isn't frozen,

## Screenshots or screencast <!-- if applicable -->
