### PR TITLE
Fixes code typo that causes content to be off center in some themes.

### DIFF
--- a/packages/block-editor/src/layouts/constrained.js
+++ b/packages/block-editor/src/layouts/constrained.js
@@ -175,7 +175,7 @@ export default {
 					) } {
 						max-width: ${ contentSize ?? wideSize };
 						margin-left: ${ marginLeft };
-						margin-right: ${ marginRight }t;
+						margin-right: ${ marginRight };
 					}
 					${ appendSelectors( selector, '> .alignwide' ) }  {
 						max-width: ${ wideSize ?? contentSize };


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Fixes a code typo 
[here](https://github.com/WordPress/gutenberg/blob/a3c753d28ddb0972311e2da0136277626bdf832e/packages/block-editor/src/layouts/constrained.js#L178) 
which caused content to not be centered when it had a fixed width.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

Because it's a bug.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

Find typo. Fix typo.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->

1. Use a theme like Wabi
2. Write a post
3. In the editor the content should be nicely centered.
4. Inspect a paragraph block:
This rule:
`.editor-styles-wrapper .block-editor-block-list__layout.is-root-container > 
:where(:not(.alignleft):not(.alignright):not(.alignfull))`
should not contain `margin-right: auto !importantt;` (notice the extra t).

## Screenshots or screencast <!-- if applicable -->

N/A
