### PR TITLE
Lodash: Refactor away from `_.flowRight()`

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -104,6 +104,7 @@ module.exports = {
 							'flatMap',
 							'flatten',
 							'flattenDeep',
+							'flowRight',
 							'forEach',
 							'fromPairs',
 							'has',

--- a/package-lock.json
+++ b/package-lock.json
@@ -16815,6 +16815,7 @@
 				"@babel/runtime": "^7.16.0",
 				"@wordpress/api-fetch": "file:packages/api-fetch",
 				"@wordpress/blocks": "file:packages/blocks",
+				"@wordpress/compose": "file:packages/compose",
 				"@wordpress/data": "file:packages/data",
 				"@wordpress/deprecated": "file:packages/deprecated",
 				"@wordpress/element": "file:packages/element",

--- a/packages/core-data/package.json
+++ b/packages/core-data/package.json
@@ -33,6 +33,7 @@
 		"@babel/runtime": "^7.16.0",
 		"@wordpress/api-fetch": "file:../api-fetch",
 		"@wordpress/blocks": "file:../blocks",
+		"@wordpress/compose": "file:../compose",
 		"@wordpress/data": "file:../data",
 		"@wordpress/deprecated": "file:../deprecated",
 		"@wordpress/element": "file:../element",

--- a/packages/core-data/src/queried-data/reducer.js
+++ b/packages/core-data/src/queried-data/reducer.js
@@ -1,12 +1,13 @@
 /**
  * External dependencies
  */
-import { map, flowRight, omit, filter, mapValues } from 'lodash';
+import { map, omit, filter, mapValues } from 'lodash';
 
 /**
  * WordPress dependencies
  */
 import { combineReducers } from '@wordpress/data';
+import { compose } from '@wordpress/compose';
 
 /**
  * Internal dependencies
@@ -172,7 +173,7 @@ export function itemIsComplete( state = {}, action ) {
  *
  * @return {Object} Next state.
  */
-const receiveQueries = flowRight( [
+const receiveQueries = compose( [
 	// Limit to matching action type so we don't attempt to replace action on
 	// an unhandled action.
 	ifMatchingAction( ( action ) => 'query' in action ),

--- a/packages/core-data/src/reducer.js
+++ b/packages/core-data/src/reducer.js
@@ -1,11 +1,12 @@
 /**
  * External dependencies
  */
-import { map, groupBy, flowRight, isEqual, get } from 'lodash';
+import { map, groupBy, isEqual, get } from 'lodash';
 
 /**
  * WordPress dependencies
  */
+import { compose } from '@wordpress/compose';
 import { combineReducers } from '@wordpress/data';
 import isShallowEqual from '@wordpress/is-shallow-equal';
 
@@ -197,7 +198,7 @@ export function themeGlobalStyleVariations( state = {}, action ) {
  * @return {AnyFunction} Reducer.
  */
 function entity( entityConfig ) {
-	return flowRight( [
+	return compose( [
 		// Limit to matching action type so we don't attempt to replace action on
 		// an unhandled action.
 		ifMatchingAction(

--- a/packages/data/src/redux-store/index.js
+++ b/packages/data/src/redux-store/index.js
@@ -2,7 +2,7 @@
  * External dependencies
  */
 import { createStore, applyMiddleware } from 'redux';
-import { flowRight, get, mapValues } from 'lodash';
+import { get, mapValues } from 'lodash';
 import combineReducers from 'turbo-combine-reducers';
 import EquivalentKeyMap from 'equivalent-key-map';
 
@@ -10,6 +10,7 @@ import EquivalentKeyMap from 'equivalent-key-map';
  * WordPress dependencies
  */
 import createReduxRoutineMiddleware from '@wordpress/redux-routine';
+import { compose } from '@wordpress/compose';
 
 /**
  * Internal dependencies
@@ -268,7 +269,7 @@ function instantiateReduxStore( key, options, registry, thunkArgs ) {
 	return createStore(
 		enhancedReducer,
 		{ root: initialState },
-		flowRight( enhancers )
+		compose( enhancers )
 	);
 }
 


### PR DESCRIPTION
## What?
This PR removes Lodash's `_.flowRight()` completely and deprecates it. There are just a few usages and conversion is pretty straightforward. 

## Why?

Lodash is known to unnecessarily inflate the bundle size of packages, and in most cases, it can be replaced with native language functionality. See these for more information and rationale:

* https://github.com/WordPress/gutenberg/issues/16938#issuecomment-602837246
* https://github.com/WordPress/gutenberg/issues/17025
* https://github.com/WordPress/gutenberg/issues/39495 

## How?

We're replacing a few usages with the in-house `compose()` that we recently introduced in #44112. 

## Testing Instructions
* Smoke test both the post and site editor.
* Verify all tests still pass.