### PR TITLE
Use prefix `theme_json_` in hooks related to `theme.json`

### DIFF
--- a/lib/compat/wordpress-6.1/class-wp-theme-json-6-1.php
+++ b/lib/compat/wordpress-6.1/class-wp-theme-json-6-1.php
@@ -534,7 +534,7 @@ class WP_Theme_JSON_6_1 extends WP_Theme_JSON_6_0 {
 		$nodes = array_merge( $nodes, static::get_block_nodes( $theme_json, $selectors ) );
 
 		// This filter allows us to modify the output of WP_Theme_JSON so that we can do things like loading block CSS independently.
-		return apply_filters( 'gutenberg_get_style_nodes', $nodes );
+		return apply_filters( 'gutenberg_theme_json_get_style_nodes', $nodes );
 	}
 
 	/**

--- a/lib/compat/wordpress-6.1/script-loader.php
+++ b/lib/compat/wordpress-6.1/script-loader.php
@@ -144,7 +144,7 @@ function gutenberg_enqueue_global_styles() {
 	 * This removes the CSS from the global-styles stylesheet and adds it to the inline CSS for each block.
 	 * This filter has to be registered before we call gutenberg_get_global_stylesheet();
 	 */
-	add_filter( 'gutenberg_get_style_nodes', 'gutenberg_filter_out_block_nodes', 10, 1 );
+	add_filter( 'gutenberg_theme_json_get_style_nodes', 'gutenberg_filter_out_block_nodes', 10, 1 );
 
 	$stylesheet = gutenberg_get_global_stylesheet();
 	if ( empty( $stylesheet ) ) {


### PR DESCRIPTION
## What?

Renames the filter `get_style_nodes` to `theme_json_get_style_nodes`.

## Why?

We've introduced a number of filters for `theme.json` in this cycle:

- a few to hook into the data: `theme_json_default`, `theme_json_blocks`, `theme_json_theme`, `theme_json_user`. [44015](https://github.com/WordPress/gutenberg/pull/44015) and [44159](https://github.com/WordPress/gutenberg/pull/44159)
- another to hook into the low-level algorithm: `get_style_nodes` [41160](https://github.com/WordPress/gutenberg/pull/41160)

With so many hooks in core, it helps discoverability and devexp that we use a coherent names for things that are related.

## How?

Renames the calls to the filter.

## Testing Instructions

See https://github.com/WordPress/gutenberg/pull/41160
