### PR TITLE
Update placeholder style

### DIFF
--- a/packages/base-styles/_mixins.scss
+++ b/packages/base-styles/_mixins.scss
@@ -203,8 +203,19 @@
 }
 
 @mixin placeholder-style() {
-	border: $border-width dashed currentColor;
 	border-radius: $radius-block-ui;
+
+	&::before {
+		content: "";
+		position: absolute;
+		top: 0;
+		right: 0;
+		bottom: 0;
+		left: 0;
+		pointer-events: none;
+		background: currentColor;
+		opacity: 0.1;
+	}
 }
 
 /**

--- a/packages/block-library/src/image/editor.scss
+++ b/packages/block-library/src/image/editor.scss
@@ -22,6 +22,10 @@
 		.components-placeholder__illustration {
 			display: none;
 		}
+
+		&::before {
+			opacity: 0;
+		}
 	}
 
 	// Remove the transition while we still have a legacy placeholder style.

--- a/packages/components/src/placeholder/style.scss
+++ b/packages/components/src/placeholder/style.scss
@@ -234,5 +234,12 @@
 	width: 100%;
 	height: 100%;
 	stroke: currentColor;
-	stroke-dasharray: 3;
+	opacity: 0.25;
+}
+
+// Hide the semi-opaque background on selection
+.is-selected {
+	.components-placeholder.has-illustration::before {
+		opacity: 0;
+	}
 }

--- a/packages/components/src/placeholder/style.scss
+++ b/packages/components/src/placeholder/style.scss
@@ -236,10 +236,3 @@
 	stroke: currentColor;
 	opacity: 0.25;
 }
-
-// Hide the semi-opaque background on selection
-.is-selected {
-	.components-placeholder.has-illustration::before {
-		opacity: 0;
-	}
-}


### PR DESCRIPTION
## What?
Updates the block placeholder style

## Why?
The current implementation with the dashed border(s) is a little noisy. This iteration replaced the outline with a semi-opaque scrim, and updated the diagonal stroke to be solid rather than dashed.

## How?
To create the scrim, a pseudo element is added to the placeholder mixin. It uses `currentColor` for the background and has `opacity: 1`.

## Testing Instructions
Insert blocks that exhibit the placeholder state (Site Logo, Image, Featured Image) and observe the new style.

## Screenshots or screencast

| Before | After |
| --- | --- |
| <img width="754" alt="Screenshot 2022-09-15 at 13 38 54" src="https://user-images.githubusercontent.com/846565/190405776-8edf49fe-a83d-4607-80ef-99d49a95639c.png"> | <img width="845" alt="Screenshot 2022-09-15 at 13 21 17" src="https://user-images.githubusercontent.com/846565/190405874-67e14f4e-0638-4df2-92b6-ecbb81344856.png"> |

More examples

<img width="748" alt="Screenshot 2022-09-15 at 13 20 17" src="https://user-images.githubusercontent.com/846565/190406135-557bcbd6-38fb-4838-a8ff-4455a58d55be.png">
<img width="1522" alt="Screenshot 2022-09-15 at 13 41 09" src="https://user-images.githubusercontent.com/846565/190406271-70c767e0-ecbe-433c-b07b-aa80e37b0627.png">



