### PR TITLE
Popover: write better docs regarding the recent API changes

### DIFF
--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -20,6 +20,8 @@
 
 -   `FontSizePicker`: Deprecate bottom margin style. Add a `__nextHasNoMarginBottom` prop to start opting into the margin-free styles that will become the default in a future version, currently scheduled to be WordPress 6.4 ([#43870](https://github.com/WordPress/gutenberg/pull/43870)).
 -   `AnglePickerControl`: Deprecate bottom margin style. Add a `__nextHasNoMarginBottom` prop to start opting into the margin-free styles that will become the default in a future version, currently scheduled to be WordPress 6.4 ([#43867](https://github.com/WordPress/gutenberg/pull/43867)).
+-   `Popover`: deprecate `__unstableShift` prop in favour of new `shift` prop. The `__unstableShift` is currently scheduled for removal in WordPress 6.3 ([#43845](https://github.com/WordPress/gutenberg/pull/43845)).
+-   `Popover`: removed the `__unstableObserveElement` prop, which is not necessary anymore. The functionality is now supported directly by the component without the need of an external prop ([#43617](https://github.com/WordPress/gutenberg/pull/43617)).
 
 ### Bug Fix
 
@@ -46,7 +48,6 @@
 -   `FocalPointPicker`: Tweak media placeholder background color to be consistent with the grays in `@wordpress/base-styles` ([#43994](https://github.com/WordPress/gutenberg/pull/43994)).
 -   `RangeControl`: Tweak rail, track, and mark colors to be consistent with the grays in `@wordpress/base-styles` ([#43994](https://github.com/WordPress/gutenberg/pull/43994)).
 -   `UnitControl`: Tweak unit dropdown hover color to be consistent with the grays in `@wordpress/base-styles` ([#43994](https://github.com/WordPress/gutenberg/pull/43994)).
--   `Popover`: stabilize `__unstableShift` to `shift` ([#43845](https://github.com/WordPress/gutenberg/pull/43845)).
 
 ### Internal
 
@@ -85,6 +86,7 @@
 ### Deprecations
 
 -   `CustomSelectControl`: Deprecate constrained width style. Add a `__nextUnconstrainedWidth` prop to start opting into the unconstrained width that will become the default in a future version, currently scheduled to be WordPress 6.4 ([#43230](https://github.com/WordPress/gutenberg/pull/43230)).
+-   `Popover`: deprecate `__unstableForcePosition` prop in favour of new `flip` and `resize` props. The `__unstableForcePosition` is currently scheduled for removal in WordPress 6.3 ([#43546](https://github.com/WordPress/gutenberg/pull/43546)).
 
 ### Bug Fix
 

--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -2,13 +2,13 @@
 
 ## Unreleased
 
+### Deprecations
+
+-   `Popover`: added new `anchor` prop, supposed to supersede all previous anchor-related props (`anchorRef`, `anchorRect`, `getAnchorRect`). These older anchor-related props are now marked as deprecated and are scheduled to be removed in WordPress 6.3 ([#43691](https://github.com/WordPress/gutenberg/pull/43691)).
+
 ### Bug Fix
 
 -   The `LinkedButton` to unlink sides in `BoxControl`, `BorderBoxControl` and `BorderRadiusControl` have changed from a rectangular primary button to an icon-only button, with a sentence case tooltip, and default-size icon for better legibility. The `Button` component has been fixed so when `isSmall` and `icon` props are set, and no text is present, the button shape is square rather than rectangular.
-
-### New Features
-
--   `Popover`: added new `anchor` prop, supposed to supersede all previous anchor-related props (`anchorRef`, `anchorRect`, `getAnchorRect`). These older anchor-related props are now marked as deprecated and are scheduled to be removed in WordPress 6.3 ([#43691](https://github.com/WordPress/gutenberg/pull/43691)).
 
 ### Internal
 
@@ -16,7 +16,7 @@
 
 ## 21.0.0 (2022-09-13)
 
-### Breaking Changes
+### Deprecations
 
 -   `FontSizePicker`: Deprecate bottom margin style. Add a `__nextHasNoMarginBottom` prop to start opting into the margin-free styles that will become the default in a future version, currently scheduled to be WordPress 6.4 ([#43870](https://github.com/WordPress/gutenberg/pull/43870)).
 -   `AnglePickerControl`: Deprecate bottom margin style. Add a `__nextHasNoMarginBottom` prop to start opting into the margin-free styles that will become the default in a future version, currently scheduled to be WordPress 6.4 ([#43867](https://github.com/WordPress/gutenberg/pull/43867)).
@@ -82,7 +82,7 @@
 
 ## 20.0.0 (2022-08-24)
 
-### Breaking Changes
+### Deprecations
 
 -   `CustomSelectControl`: Deprecate constrained width style. Add a `__nextUnconstrainedWidth` prop to start opting into the unconstrained width that will become the default in a future version, currently scheduled to be WordPress 6.4 ([#43230](https://github.com/WordPress/gutenberg/pull/43230)).
 

--- a/packages/rich-text/CHANGELOG.md
+++ b/packages/rich-text/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Unreleased
 
-### New features
+### Deprecations
 
 -   Introduced new `useAnchor` hook, which works better with the new `Popover` component APIs. The previous `useAnchorRef` hook is now marked as deprecated, and is scheduled to be removed in WordPress 6.3 ([#43691](https://github.com/WordPress/gutenberg/pull/43691)).
 


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Following up from https://github.com/WordPress/gutenberg/pull/43691#discussion_r971012324, this PR:

- adds more detailed notes about recent prop deprecations while working on the `Popover` component
- renames the affected CHANGELOG sections from `Breaking Changes` to `Deprecations`


@mirka I'm not sure what to do with the [deprecations.md](https://github.com/WordPress/gutenberg/blob/trunk/docs/contributors/code/deprecations.md) file — it looks like it hasn't been updated in some time


### Dev note

_Note: this dev note is a collective dev note for the recent changes to the `Popover` component which aimed at addressing a spike of regressions happened recently, mostly tracked in https://github.com/WordPress/gutenberg/issues/42770_

The `Popover` component from the `@wordpress/components` package has been mostly rewritten, in an effort to make it more stable, more reliable and more performant. While doing so, one of the main goals was to avoid introducing breaking changes. Here is the list with the main API changes:

- a new `placement` prop has been introduced. This prop is meant to replace the legacy `position` prop (which will be marked as deprecated in the near future)
- a new `anchor` prop has been introduced. This prop is meant to replace all previous anchor-related props (`anchorRef`, `anchorRect`, `getAnchorRect`). These older anchor-related props are now marked as deprecated and are scheduled to be removed in WordPress 6.3
- the `__unstableForcePosition` prop has been marked as deprecated, in favour of new `flip` and `resize` props. The `__unstableForcePosition` is currently scheduled for removal in WordPress 6.3
- the `__unstableShift` prop has been marked as deprecated, in favour of the `shift` prop. The `__unstableShift` is currently scheduled for removal in WordPress 6.3
- the `__unstableObserveElement` prop has been removed, since it's not necessary anymore after the recent updates to the `Popover`

For more details, see the updated component's [README](https://github.com/WordPress/gutenberg/blob/trunk/packages/components/src/popover/README.md) and the [Storybook examples](https://wordpress.github.io/gutenberg/?path=/story/components-popover--default).

The changes to the `Popover` component also affected the `@wordpress/rich-text`, where a new `useAnchor` hook was introduced. The previous `useAnchorRef` hook has been marked as deprecated, and is scheduled to be removed in WordPress 6.3.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

The recent changes won't cause any breakage (apart from deprecation warnings in dev mode), and therefore should not be flagged as such.

We will flag correctly the breaking changes in future versions of Gutenberg, when we will delete those deprecated props.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

Editing the docs