### PR TITLE
[Block Library - Query Loop]: Suggest active variation patterns

### DIFF
--- a/packages/block-library/src/query/utils.js
+++ b/packages/block-library/src/query/utils.js
@@ -219,10 +219,12 @@ export const getTransformedBlocksFromPattern = (
 /**
  * Helper hook that determines if there is an active variation of the block
  * and if there are available specific patterns for this variation.
- * If there are, they are going to be suggested to the user in setup and
- * replace flow.
+ * If there are, these patterns are going to be the only ones suggested to
+ * the user in setup and replace flow, without including the default ones
+ * for Query Loop.
  *
- * If there are no patterns, the default ones for Query Loop are going to be suggested.
+ * If there are no such patterns, the default ones for Query Loop are going
+ * to be suggested.
  *
  * @param {string} clientId   The block's client ID.
  * @param {Object} attributes The block's attributes.

--- a/packages/block-library/src/query/utils.js
+++ b/packages/block-library/src/query/utils.js
@@ -9,6 +9,7 @@ import { get } from 'lodash';
 import { useSelect } from '@wordpress/data';
 import { useMemo } from '@wordpress/element';
 import { store as coreStore } from '@wordpress/core-data';
+import { store as blockEditorStore } from '@wordpress/block-editor';
 import { decodeEntities } from '@wordpress/html-entities';
 import { cloneBlock, store as blocksStore } from '@wordpress/blocks';
 
@@ -214,3 +215,43 @@ export const getTransformedBlocksFromPattern = (
 	}
 	return { newBlocks: clonedBlocks, queryClientIds };
 };
+
+/**
+ * Helper hook that determines if there is an active variation of the block
+ * and if there are available specific patterns for this variation.
+ * If there are, they are going to be suggested to the user in setup and
+ * replace flow.
+ *
+ * If there are no patterns, the default ones for Query Loop are going to be suggested.
+ *
+ * @param {string} clientId   The block's client ID.
+ * @param {Object} attributes The block's attributes.
+ * @return {string} The block name to be used in the patterns suggestions.
+ */
+export function useBlockNameForPatterns( clientId, attributes ) {
+	const activeVariationName = useSelect(
+		( select ) =>
+			select( blocksStore ).getActiveBlockVariation(
+				queryLoopName,
+				attributes
+			)?.name,
+
+		[ attributes ]
+	);
+	const blockName = `${ queryLoopName }/${ activeVariationName }`;
+	const activeVariationPatterns = useSelect(
+		( select ) => {
+			const {
+				getBlockRootClientId,
+				__experimentalGetPatternsByBlockTypes,
+			} = select( blockEditorStore );
+			const rootClientId = getBlockRootClientId( clientId );
+			return __experimentalGetPatternsByBlockTypes(
+				blockName,
+				rootClientId
+			);
+		},
+		[ clientId, blockName ]
+	);
+	return activeVariationPatterns?.length ? blockName : queryLoopName;
+}

--- a/packages/block-library/src/query/utils.js
+++ b/packages/block-library/src/query/utils.js
@@ -18,6 +18,8 @@ import { cloneBlock, store as blocksStore } from '@wordpress/blocks';
  */
 import { name as queryLoopName } from './block.json';
 
+const EMPTY_ARRAY = [];
+
 /**
  * @typedef IHasNameAndId
  * @property {string|number} id   The entity's id.
@@ -241,6 +243,9 @@ export function useBlockNameForPatterns( clientId, attributes ) {
 	const blockName = `${ queryLoopName }/${ activeVariationName }`;
 	const activeVariationPatterns = useSelect(
 		( select ) => {
+			if ( ! activeVariationName ) {
+				return EMPTY_ARRAY;
+			}
 			const {
 				getBlockRootClientId,
 				__experimentalGetPatternsByBlockTypes,
@@ -251,7 +256,7 @@ export function useBlockNameForPatterns( clientId, attributes ) {
 				rootClientId
 			);
 		},
-		[ clientId, blockName ]
+		[ clientId, activeVariationName ]
 	);
 	return activeVariationPatterns?.length ? blockName : queryLoopName;
 }

--- a/packages/block-library/src/query/utils.js
+++ b/packages/block-library/src/query/utils.js
@@ -18,8 +18,6 @@ import { cloneBlock, store as blocksStore } from '@wordpress/blocks';
  */
 import { name as queryLoopName } from './block.json';
 
-const EMPTY_ARRAY = [];
-
 /**
  * @typedef IHasNameAndId
  * @property {string|number} id   The entity's id.
@@ -244,7 +242,7 @@ export function useBlockNameForPatterns( clientId, attributes ) {
 	const activeVariationPatterns = useSelect(
 		( select ) => {
 			if ( ! activeVariationName ) {
-				return EMPTY_ARRAY;
+				return;
 			}
 			const {
 				getBlockRootClientId,


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
With this PR it's possible to create Query Loop patterns for a specific block variation in the set up and replace flows.
The block determines if there is an active variation of the block and if there are available specific patterns for this variation. If there are, these patterns are going to be the only ones suggested to the user in setup and replace flow, without including the default ones for Query Loop. If there are no such patterns, the default ones for Query Loop are going to be suggested.

 In order for a pattern to be 'connected' with a Query Loop variation, you should add to the pattern's `blockTypes` property the name of your variation prefixed with the Query Loop name(ex `core/query/$variation_name`). This is the same convention we are also following for Template Parts, which also have similar flows for setup/replace.


## Testing Instructions
1. I used WooCommerce for my convenience, but feel free to test by registering your custom post type. 
1. Register a block variation
```
{
	name: 'products-list',
	title: 'Products List',
	description: 'Display a list of your products.',
	attributes: {
		query: {
			perPage: 4,
			pages: 0,
			offset: 0,
			postType: 'product',
			order: 'desc',
			orderBy: 'date',
			author: '',
			search: '',
			sticky: '',
			inherit: false,
		},
		namespace: 'prefix/products-list',
	},
	allowControls: [ 'order', 'taxQuery', 'search' ],
	isActive: [ 'namespace' ],
	scope: [ 'inserter' ],
},
```
3. register a pattern for this variation - example:
```
register_block_pattern(
	'demo/my-example',
	array(
		'title'         => __( 'Demo pattern', 'textdomain' ),
		'description'   => _x( 'This is my first block pattern', 'Block pattern description', 'textdomain' ),
		'content'       => '
		<!-- wp:query {"query":{"perPage":3,"pages":0,"offset":0,"postType":"product","order":"desc","orderBy":"date","author":"","search":"","exclude":[],"sticky":"","inherit":false},"namespace":"prefix/products-list","backgroundColor":"black","textColor":"luminous-vivid-amber"} -->
<div class="wp-block-query has-luminous-vivid-amber-color has-black-background-color has-text-color has-background"><!-- wp:post-template -->
<!-- wp:post-title /-->

<!-- wp:paragraph -->
<p>My Query Loop variation pattern!!!!</p>
<!-- /wp:paragraph -->

<!-- wp:post-date /-->
<!-- /wp:post-template -->

<!-- wp:query-pagination -->
<!-- wp:query-pagination-previous /-->

<!-- wp:query-pagination-numbers /-->

<!-- wp:query-pagination-next /-->
<!-- /wp:query-pagination -->

<!-- wp:query-no-results -->
<!-- wp:paragraph {"placeholder":"Add text or blocks that will display when a query returns no results."} -->
<p></p>
<!-- /wp:paragraph -->
<!-- /wp:query-no-results --></div>
<!-- /wp:query -->',
		'categories'    => array( 'text' ),
		'viewportWidth' => 800,
		'blockTypes'    => array( 'core/query/products-list' ),
	)
);

```
5. insert a Query Loop block and one `Products List` block
6. Observe that the suggested patterns are different
7. If you don't register the above variation, in `Products List` block the suggested patterns should be the default for Query Loop


## Screenshots or screencast <!-- if applicable -->

https://user-images.githubusercontent.com/16275880/190431393-4933ab22-6573-4f20-8eb2-e768624ecc95.mov

