### PR TITLE
Lodash: Remove dependency from `@wordpress/widgets` package

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -18248,8 +18248,7 @@
 				"@wordpress/i18n": "file:packages/i18n",
 				"@wordpress/icons": "file:packages/icons",
 				"@wordpress/notices": "file:packages/notices",
-				"classnames": "^2.3.1",
-				"lodash": "^4.17.21"
+				"classnames": "^2.3.1"
 			}
 		},
 		"@wordpress/wordcount": {

--- a/packages/widgets/package.json
+++ b/packages/widgets/package.json
@@ -32,8 +32,7 @@
 		"@wordpress/i18n": "file:../i18n",
 		"@wordpress/icons": "file:../icons",
 		"@wordpress/notices": "file:../notices",
-		"classnames": "^2.3.1",
-		"lodash": "^4.17.21"
+		"classnames": "^2.3.1"
 	},
 	"peerDependencies": {
 		"react": "^17.0.0",


### PR DESCRIPTION
## What?
This PR removes the Lodash dependency from the `@wordpress/widgets` package.

## Why?

Lodash is no longer needed since #43943 landed.

## How?

We're just removing the dependency.

## Testing Instructions
Verify all checks are green.