### PR TITLE
Preferences-persistence: Remove `@wordpress/compose` dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17632,8 +17632,7 @@
 			"version": "file:packages/preferences-persistence",
 			"requires": {
 				"@babel/runtime": "^7.16.0",
-				"@wordpress/api-fetch": "file:packages/api-fetch",
-				"@wordpress/compose": "file:packages/compose"
+				"@wordpress/api-fetch": "file:packages/api-fetch"
 			}
 		},
 		"@wordpress/prettier-config": {

--- a/packages/preferences-persistence/package.json
+++ b/packages/preferences-persistence/package.json
@@ -28,8 +28,7 @@
 	"sideEffects": false,
 	"dependencies": {
 		"@babel/runtime": "^7.16.0",
-		"@wordpress/api-fetch": "file:../api-fetch",
-		"@wordpress/compose": "file:../compose"
+		"@wordpress/api-fetch": "file:../api-fetch"
 	},
 	"publishConfig": {
 		"access": "public"


### PR DESCRIPTION
## What?
This PR removes the `@wordpress/compose` dependency from `@wordpress/preferences-persistence`.

## Why?
It was unnecessarily added in #43943.

## How?
We're just removing the unnecessary dependency.

## Testing Instructions
Verify all checks are still green.