### PR TITLE
Block Patterns: Add category for banners

### DIFF
--- a/lib/compat/wordpress-6.1/block-patterns.php
+++ b/lib/compat/wordpress-6.1/block-patterns.php
@@ -188,8 +188,13 @@ function gutenberg_register_core_block_patterns() {
 
 	// Register categories used for block patterns.
 	$pattern_category_registry = WP_Block_Pattern_Categories_Registry::get_instance();
+
 	if ( ! $pattern_category_registry->is_registered( 'footer' ) ) {
 		register_block_pattern_category( 'footer', array( 'label' => __( 'Footers', 'gutenberg' ) ) );
+	}
+
+	if ( ! $pattern_category_registry->is_registered( 'heading' ) ) {
+		register_block_pattern_category( 'heading', array( 'label' => __( 'Headings & Titles', 'gutenberg' ) ) );
 	}
 
 	if ( $should_register_core_patterns ) {

--- a/lib/compat/wordpress-6.1/block-patterns.php
+++ b/lib/compat/wordpress-6.1/block-patterns.php
@@ -193,8 +193,8 @@ function gutenberg_register_core_block_patterns() {
 		register_block_pattern_category( 'footer', array( 'label' => __( 'Footers', 'gutenberg' ) ) );
 	}
 
-	if ( ! $pattern_category_registry->is_registered( 'heading' ) ) {
-		register_block_pattern_category( 'heading', array( 'label' => __( 'Headings & Titles', 'gutenberg' ) ) );
+	if ( ! $pattern_category_registry->is_registered( 'banner' ) ) {
+		register_block_pattern_category( 'banner', array( 'label' => __( 'Banners', 'gutenberg' ) ) );
 	}
 
 	if ( $should_register_core_patterns ) {


### PR DESCRIPTION
Fixes #40116

## What?

Register a new category for block patterns named ~"Headings & Titles"~ "Banners".

## Why?

See the parent issue. With this new category, we can clarify the categorisation of patterns as "Headers". Category "Headers" pertains to global patterns meant to sit at the top of a page ("the header of the site"), while category "Banners" pertains to typically visually distinctive elements that help structure or contrast the contents of a page (including headings and "hero" elements).