### PR TITLE
Lodash: Remove completely from `@wordpress/rich-text` package

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -18097,7 +18097,6 @@
 				"@wordpress/escape-html": "file:packages/escape-html",
 				"@wordpress/i18n": "file:packages/i18n",
 				"@wordpress/keycodes": "file:packages/keycodes",
-				"lodash": "^4.17.21",
 				"memize": "^1.1.0",
 				"rememo": "^4.0.0"
 			}

--- a/packages/rich-text/package.json
+++ b/packages/rich-text/package.json
@@ -38,7 +38,6 @@
 		"@wordpress/escape-html": "file:../escape-html",
 		"@wordpress/i18n": "file:../i18n",
 		"@wordpress/keycodes": "file:../keycodes",
-		"lodash": "^4.17.21",
 		"memize": "^1.1.0",
 		"rememo": "^4.0.0"
 	},

--- a/packages/rich-text/src/component/index.native.js
+++ b/packages/rich-text/src/component/index.native.js
@@ -4,7 +4,6 @@
  * External dependencies
  */
 import { View, Platform, Dimensions } from 'react-native';
-import { get, pickBy } from 'lodash';
 import memize from 'memize';
 import { colord } from 'colord';
 
@@ -228,8 +227,10 @@ export class RichText extends Component {
 
 	onFormatChange( record ) {
 		const { start = 0, end = 0, activeFormats = [] } = record;
-		const changeHandlers = pickBy( this.props, ( v, key ) =>
-			key.startsWith( 'format_on_change_functions_' )
+		const changeHandlers = Object.fromEntries(
+			Object.entries( this.props ).filter( ( [ key ] ) =>
+				key.startsWith( 'format_on_change_functions_' )
+			)
 		);
 
 		Object.values( changeHandlers ).forEach( ( changeHandler ) => {
@@ -1282,10 +1283,7 @@ export default compose( [
 			select( 'core/block-editor' );
 		const parents = getBlockParents( clientId, true );
 		const parentBlock = parents ? getBlock( parents[ 0 ] ) : undefined;
-		const parentBlockStyles = get( parentBlock, [
-			'attributes',
-			'childrenStyles',
-		] );
+		const parentBlockStyles = parentBlock?.attributes?.childrenStyles;
 
 		const settings = getSettings();
 		const baseGlobalStyles = settings?.__experimentalGlobalStylesBaseStyles;

--- a/packages/rich-text/src/get-active-format.js
+++ b/packages/rich-text/src/get-active-format.js
@@ -1,13 +1,6 @@
 /**
- * External dependencies
- */
-
-import { find } from 'lodash';
-
-/**
  * Internal dependencies
  */
-
 import { getActiveFormats } from './get-active-formats';
 
 /** @typedef {import('./create').RichTextValue} RichTextValue */
@@ -26,5 +19,7 @@ import { getActiveFormats } from './get-active-formats';
  *                                    type, or undefined.
  */
 export function getActiveFormat( value, formatType ) {
-	return find( getActiveFormats( value ), { type: formatType } );
+	return getActiveFormats( value )?.find(
+		( { type } ) => type === formatType
+	);
 }

--- a/packages/rich-text/src/store/actions.js
+++ b/packages/rich-text/src/store/actions.js
@@ -1,9 +1,4 @@
 /**
- * External dependencies
- */
-import { castArray } from 'lodash';
-
-/**
  * Returns an action object used in signalling that format types have been
  * added.
  *
@@ -14,7 +9,9 @@ import { castArray } from 'lodash';
 export function addFormatTypes( formatTypes ) {
 	return {
 		type: 'ADD_FORMAT_TYPES',
-		formatTypes: castArray( formatTypes ),
+		formatTypes: Array.isArray( formatTypes )
+			? formatTypes
+			: [ formatTypes ],
 	};
 }
 
@@ -28,6 +25,6 @@ export function addFormatTypes( formatTypes ) {
 export function removeFormatTypes( names ) {
 	return {
 		type: 'REMOVE_FORMAT_TYPES',
-		names: castArray( names ),
+		names: Array.isArray( names ) ? names : [ names ],
 	};
 }

--- a/packages/rich-text/src/store/reducer.js
+++ b/packages/rich-text/src/store/reducer.js
@@ -1,9 +1,4 @@
 /**
- * External dependencies
- */
-import { omit } from 'lodash';
-
-/**
  * WordPress dependencies
  */
 import { combineReducers } from '@wordpress/data';
@@ -31,7 +26,11 @@ export function formatTypes( state = {}, action ) {
 				),
 			};
 		case 'REMOVE_FORMAT_TYPES':
-			return omit( state, action.names );
+			return Object.fromEntries(
+				Object.entries( state ).filter(
+					( [ key ] ) => ! action.names.includes( key )
+				)
+			);
 	}
 
 	return state;

--- a/packages/rich-text/src/store/selectors.js
+++ b/packages/rich-text/src/store/selectors.js
@@ -2,7 +2,6 @@
  * External dependencies
  */
 import createSelector from 'rememo';
-import { find } from 'lodash';
 
 /**
  * Returns all the available format types.
@@ -38,7 +37,7 @@ export function getFormatType( state, name ) {
  * @return {?Object} Format type.
  */
 export function getFormatTypeForBareElement( state, bareElementTagName ) {
-	return find( getFormatTypes( state ), ( { className, tagName } ) => {
+	return getFormatTypes( state ).find( ( { className, tagName } ) => {
 		return className === null && bareElementTagName === tagName;
 	} );
 }
@@ -52,7 +51,7 @@ export function getFormatTypeForBareElement( state, bareElementTagName ) {
  * @return {?Object} Format type.
  */
 export function getFormatTypeForClassName( state, elementClassName ) {
-	return find( getFormatTypes( state ), ( { className } ) => {
+	return getFormatTypes( state ).find( ( { className } ) => {
 		if ( className === null ) {
 			return false;
 		}


### PR DESCRIPTION
## What?
This PR removes all of the Lodash from the `@wordpress/rich-text` package, including the `lodash` dependency altogether. There are just a few usages and conversion is pretty straightforward. 

## Why?

Lodash is known to unnecessarily inflate the bundle size of packages, and in most cases, it can be replaced with native language functionality. See these for more information and rationale:

* https://github.com/WordPress/gutenberg/issues/16938#issuecomment-602837246
* https://github.com/WordPress/gutenberg/issues/17025
* https://github.com/WordPress/gutenberg/issues/39495 

## How?

We're replacing a few usages with their native counterparts. 

## Testing Instructions

* The affected functionality is well covered by tests. Verify all checks are green.