### PR TITLE
Lodash: Remove completely from `@wordpress/block-directory` package

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16471,8 +16471,7 @@
 				"@wordpress/notices": "file:packages/notices",
 				"@wordpress/plugins": "file:packages/plugins",
 				"@wordpress/url": "file:packages/url",
-				"change-case": "^4.1.2",
-				"lodash": "^4.17.21"
+				"change-case": "^4.1.2"
 			}
 		},
 		"@wordpress/block-editor": {

--- a/packages/block-directory/package.json
+++ b/packages/block-directory/package.json
@@ -44,8 +44,7 @@
 		"@wordpress/notices": "file:../notices",
 		"@wordpress/plugins": "file:../plugins",
 		"@wordpress/url": "file:../url",
-		"change-case": "^4.1.2",
-		"lodash": "^4.17.21"
+		"change-case": "^4.1.2"
 	},
 	"peerDependencies": {
 		"react": "^17.0.0",

--- a/packages/block-directory/src/store/actions.js
+++ b/packages/block-directory/src/store/actions.js
@@ -1,9 +1,4 @@
 /**
- * External dependencies
- */
-import { pick } from 'lodash';
-
-/**
  * WordPress dependencies
  */
 import {
@@ -119,7 +114,11 @@ export const installBlockType =
 						return;
 					}
 					unstable__bootstrapServerSideBlockDefinitions( {
-						[ name ]: pick( response, metadataFields ),
+						[ name ]: Object.fromEntries(
+							Object.entries( response ).filter( ( [ key ] ) =>
+								metadataFields.includes( key )
+							)
+						),
 					} );
 				} );
 


### PR DESCRIPTION
## What?
This PR removes all of the Lodash from the `@wordpress/block-directory` package, including the `lodash` dependency altogether. There are just a few usages and conversion is pretty straightforward. 

## Why?

Lodash is known to unnecessarily inflate the bundle size of packages, and in most cases, it can be replaced with native language functionality. See these for more information and rationale:

* https://github.com/WordPress/gutenberg/issues/16938#issuecomment-602837246
* https://github.com/WordPress/gutenberg/issues/17025
* https://github.com/WordPress/gutenberg/issues/39495 

## How?

We're replacing a single remaining `pick()` with a simple native implementation.

## Testing Instructions

* Verify tests instructions from this PR still work: #38697
* Verify all checks are green.