### PR TITLE
Fixing padding on the post editor when RootPaddingAwareAlignments setting is enabled

### DIFF
--- a/packages/edit-post/src/components/visual-editor/index.js
+++ b/packages/edit-post/src/components/visual-editor/index.js
@@ -118,15 +118,21 @@ export default function VisualEditor( { styles } ) {
 		( select ) => select( editPostStore ).hasMetaBoxes(),
 		[]
 	);
-	const { themeHasDisabledLayoutStyles, themeSupportsLayout, assets } =
-		useSelect( ( select ) => {
-			const _settings = select( blockEditorStore ).getSettings();
-			return {
-				themeHasDisabledLayoutStyles: _settings.disableLayoutStyles,
-				themeSupportsLayout: _settings.supportsLayout,
-				assets: _settings.__unstableResolvedAssets,
-			};
-		}, [] );
+	const {
+		themeHasDisabledLayoutStyles,
+		themeSupportsLayout,
+		assets,
+		useRootPaddingAwareAlignments,
+	} = useSelect( ( select ) => {
+		const _settings = select( blockEditorStore ).getSettings();
+		return {
+			themeHasDisabledLayoutStyles: _settings.disableLayoutStyles,
+			themeSupportsLayout: _settings.supportsLayout,
+			assets: _settings.__unstableResolvedAssets,
+			useRootPaddingAwareAlignments:
+				_settings.__experimentalFeatures?.useRootPaddingAwareAlignments,
+		};
+	}, [] );
 	const { clearSelectedBlock } = useDispatch( blockEditorStore );
 	const { setIsEditingTemplate } = useDispatch( editPostStore );
 	const desktopCanvasStyles = {
@@ -189,9 +195,11 @@ export default function VisualEditor( { styles } ) {
 		return { type: 'default' };
 	}, [ isTemplateMode, themeSupportsLayout, defaultLayout ] );
 
-	const blockListLayoutClass = themeSupportsLayout
-		? 'is-layout-constrained'
-		: 'is-layout-flow';
+	const blockListLayoutClass = classnames( {
+		'is-layout-constrained': themeSupportsLayout,
+		'is-layout-flow': ! themeSupportsLayout,
+		'has-global-padding': useRootPaddingAwareAlignments,
+	} );
 
 	const titleRef = useRef();
 	useEffect( () => {


### PR DESCRIPTION
## What?
Fixing padding on the post editor when RootPaddingAwareAlignments setting is enabled

## Why?
Because padding on the post editor and doesn't match the frontend because the post-content block lacks the right CSS  class name when `setting.useRootPaddingAwareAlignments` is enabled in theme.json.

## How?
Setting `has-global-padding` class on the post content block on the editor if `useRootPaddingAwareAlignments` is enabled.
## Testing Instructions
Follow the instructions from the issue: https://github.com/WordPress/gutenberg/issues/44208

## Screenshots or screencast <!-- if applicable -->
Before: (left ->  editor, right -> frontend).
![image](https://user-images.githubusercontent.com/1310626/190497424-c2399a8d-5072-40ba-adf0-df5e7c6e98db.png)





After: (left ->  editor, right -> frontend).
![image](https://user-images.githubusercontent.com/1310626/190497439-eefa50fe-eaf0-4a5a-84c9-3b3b22d6cb8e.png)



Fixes: https://github.com/WordPress/gutenberg/issues/44208