### PR TITLE
Spacing presets:  Update with core review changes

### DIFF
--- a/lib/compat/wordpress-6.1/class-wp-theme-json-6-1.php
+++ b/lib/compat/wordpress-6.1/class-wp-theme-json-6-1.php
@@ -1248,38 +1248,42 @@ class WP_Theme_JSON_6_1 extends WP_Theme_JSON_6_0 {
 
 		$unit            = '%' === $spacing_scale['unit'] ? '%' : sanitize_title( $spacing_scale['unit'] );
 		$current_step    = $spacing_scale['mediumStep'];
-		$steps_mid_point = round( ( ( $spacing_scale['steps'] ) / 2 ), 0 );
+		$steps_mid_point = round( $spacing_scale['steps'] / 2, 0 );
 		$x_small_count   = null;
 		$below_sizes     = array();
 		$slug            = 40;
 		$remainder       = 0;
 
-		for ( $x = $steps_mid_point - 1; $spacing_scale['steps'] > 1 && $slug > 0 && $x > 0; $x-- ) {
-			$current_step = '+' === $spacing_scale['operator']
-				? $current_step - $spacing_scale['increment']
-				: ( $spacing_scale['increment'] > 1 ? $current_step / $spacing_scale['increment'] : $current_step * $spacing_scale['increment'] );
+		for ( $below_midpoint_count = $steps_mid_point - 1; $spacing_scale['steps'] > 1 && $slug > 0 && $below_midpoint_count > 0; $below_midpoint_count-- ) {
+			if ( '+' === $spacing_scale['operator'] ) {
+				$current_step -= $spacing_scale['increment'];
+			} elseif ( $spacing_scale['increment'] > 1 ) {
+				$current_step /= $spacing_scale['increment'];
+			} else {
+				$current_step *= $spacing_scale['increment'];
+			}
 
 			if ( $current_step <= 0 ) {
-				$remainder = $x;
+				$remainder = $below_midpoint_count;
 				break;
 			}
 
 			$below_sizes[] = array(
-				/* translators: %s: Multiple of t-shirt sizing, eg. 2X-Small */
-				'name' => $x === $steps_mid_point - 1 ? __( 'Small', 'gutenberg' ) : sprintf( __( '%sX-Small', 'gutenberg' ), strval( $x_small_count ) ),
+				/* translators: %s: Digit to indicate multiple of sizing, eg. 2X-Small. */
+				'name' => $below_midpoint_count === $steps_mid_point - 1 ? __( 'Small' ) : sprintf( __( '%sX-Small', 'gutenberg' ), strval( $x_small_count ) ),
 				'slug' => (string) $slug,
 				'size' => round( $current_step, 2 ) . $unit,
 			);
 
-			if ( $x === $steps_mid_point - 2 ) {
+			if ( $below_midpoint_count === $steps_mid_point - 2 ) {
 				$x_small_count = 2;
 			}
 
-			if ( $x < $steps_mid_point - 2 ) {
+			if ( $below_midpoint_count < $steps_mid_point - 2 ) {
 				$x_small_count++;
 			}
 
-			$slug = $slug - 10;
+			$slug -= 10;
 		}
 
 		$below_sizes = array_reverse( $below_sizes );
@@ -1296,27 +1300,27 @@ class WP_Theme_JSON_6_1 extends WP_Theme_JSON_6_0 {
 		$slug          = 60;
 		$steps_above   = ( $spacing_scale['steps'] - $steps_mid_point ) + $remainder;
 
-		for ( $x = 0; $x < $steps_above; $x++ ) {
+		for ( $above_midpoint_count = 0; $above_midpoint_count < $steps_above; $above_midpoint_count++ ) {
 			$current_step = '+' === $spacing_scale['operator']
 				? $current_step + $spacing_scale['increment']
 				: ( $spacing_scale['increment'] >= 1 ? $current_step * $spacing_scale['increment'] : $current_step / $spacing_scale['increment'] );
 
 			$above_sizes[] = array(
-				/* translators: %s: Multiple of t-shirt sizing, eg. 2X-Large */
-				'name' => 0 === $x ? __( 'Large', 'gutenberg' ) : sprintf( __( '%sX-Large', 'gutenberg' ), strval( $x_large_count ) ),
+				/* translators: %s: Digit to indicate multiple of sizing, eg. 2X-Large. */
+				'name' => 0 === $above_midpoint_count ? __( 'Large' ) : sprintf( __( '%sX-Large', 'gutenberg' ), strval( $x_large_count ) ),
 				'slug' => (string) $slug,
 				'size' => round( $current_step, 2 ) . $unit,
 			);
 
-			if ( 1 === $x ) {
+			if ( 1 === $above_midpoint_count ) {
 				$x_large_count = 2;
 			}
 
-			if ( $x > 1 ) {
+			if ( $above_midpoint_count > 1 ) {
 				$x_large_count++;
 			}
 
-			$slug = $slug + 10;
+			$slug += 10;
 		}
 
 		_wp_array_set( $this->theme_json, array( 'settings', 'spacing', 'spacingSizes', 'default' ), array_merge( $below_sizes, $above_sizes ) );

--- a/lib/compat/wordpress-6.1/class-wp-theme-json-6-1.php
+++ b/lib/compat/wordpress-6.1/class-wp-theme-json-6-1.php
@@ -1270,7 +1270,7 @@ class WP_Theme_JSON_6_1 extends WP_Theme_JSON_6_0 {
 
 			$below_sizes[] = array(
 				/* translators: %s: Digit to indicate multiple of sizing, eg. 2X-Small. */
-				'name' => $below_midpoint_count === $steps_mid_point - 1 ? __( 'Small' ) : sprintf( __( '%sX-Small', 'gutenberg' ), strval( $x_small_count ) ),
+				'name' => $below_midpoint_count === $steps_mid_point - 1 ? __( 'Small', 'gutenberg' ) : sprintf( __( '%sX-Small', 'gutenberg' ), strval( $x_small_count ) ),
 				'slug' => (string) $slug,
 				'size' => round( $current_step, 2 ) . $unit,
 			);
@@ -1307,7 +1307,7 @@ class WP_Theme_JSON_6_1 extends WP_Theme_JSON_6_0 {
 
 			$above_sizes[] = array(
 				/* translators: %s: Digit to indicate multiple of sizing, eg. 2X-Large. */
-				'name' => 0 === $above_midpoint_count ? __( 'Large' ) : sprintf( __( '%sX-Large', 'gutenberg' ), strval( $x_large_count ) ),
+				'name' => 0 === $above_midpoint_count ? __( 'Large', 'gutenberg' ) : sprintf( __( '%sX-Large', 'gutenberg' ), strval( $x_large_count ) ),
 				'slug' => (string) $slug,
 				'size' => round( $current_step, 2 ) . $unit,
 			);

--- a/phpunit/class-wp-theme-json-test.php
+++ b/phpunit/class-wp-theme-json-test.php
@@ -928,9 +928,12 @@ class WP_Theme_JSON_Gutenberg_Test extends WP_UnitTestCase {
 	 * Tests generating the spacing presets array based on the spacing scale provided.
 	 *
 	 * @dataProvider data_generate_spacing_scale_fixtures
+	 *
+	 * @param array $spacing_scale   Example spacing scale definitions from the data provider.
+	 * @param array $expected_output Expected output from data provider.
 	 */
-	function test_set_spacing_sizes( $spacing_scale, $expected_output ) {
-		$theme_json = new WP_Theme_JSON_Gutenberg(
+	function test_should_set_spacing_sizes( $spacing_scale, $expected_output ) {
+		$theme_json = new WP_Theme_JSON(
 			array(
 				'version'  => 2,
 				'settings' => array(
@@ -952,7 +955,7 @@ class WP_Theme_JSON_Gutenberg_Test extends WP_UnitTestCase {
 	 */
 	function data_generate_spacing_scale_fixtures() {
 		return array(
-			'one_step_spacing_scale' => array(
+			'only one value when single step in spacing scale' => array(
 				'spacingScale'    => array(
 					'operator'   => '+',
 					'increment'  => 1.5,
@@ -968,8 +971,7 @@ class WP_Theme_JSON_Gutenberg_Test extends WP_UnitTestCase {
 					),
 				),
 			),
-
-			'two_step_spacing_scale_should_add_step_above_medium' => array(
+			'one step above medium when two steps in spacing scale' => array(
 				'spacingScale'    => array(
 					'operator'   => '+',
 					'increment'  => 1.5,
@@ -990,8 +992,7 @@ class WP_Theme_JSON_Gutenberg_Test extends WP_UnitTestCase {
 					),
 				),
 			),
-
-			'three_step_spacing_scale_should_add_step_above_and_below_medium' => array(
+			'one step above medium and one below when three steps in spacing scale' => array(
 				'spacingScale'    => array(
 					'operator'   => '+',
 					'increment'  => 1.5,
@@ -1017,8 +1018,7 @@ class WP_Theme_JSON_Gutenberg_Test extends WP_UnitTestCase {
 					),
 				),
 			),
-
-			'even_step_spacing_scale_steps_should_add_extra_step_above_medium' => array(
+			'extra step added above medium when an even number of steps > 2 specified' => array(
 				'spacingScale'    => array(
 					'operator'   => '+',
 					'increment'  => 1.5,
@@ -1049,8 +1049,7 @@ class WP_Theme_JSON_Gutenberg_Test extends WP_UnitTestCase {
 					),
 				),
 			),
-
-			'if_bottom_end_will_go_below_zero_should_add_extra_steps_above_medium_instead' => array(
+			'extra steps above medium if bottom end will go below zero' => array(
 				'spacingScale'    => array(
 					'operator'   => '+',
 					'increment'  => 2.5,
@@ -1086,8 +1085,7 @@ class WP_Theme_JSON_Gutenberg_Test extends WP_UnitTestCase {
 					),
 				),
 			),
-
-			'multiplier_should_correctly_calculate_above_and_below_medium' => array(
+			'multiplier correctly calculated above and below medium' => array(
 				'spacingScale'    => array(
 					'operator'   => '*',
 					'increment'  => 1.5,
@@ -1123,8 +1121,7 @@ class WP_Theme_JSON_Gutenberg_Test extends WP_UnitTestCase {
 					),
 				),
 			),
-
-			'increment_<_1_combined_with_*_operator_should_act_as_divisor_to_calculate_above_and_below_medium' => array(
+			'increment < 1 combined showing * operator acting as divisor above and below medium' => array(
 				'spacingScale'    => array(
 					'operator'   => '*',
 					'increment'  => 0.25,
@@ -1167,12 +1164,15 @@ class WP_Theme_JSON_Gutenberg_Test extends WP_UnitTestCase {
 	 * Tests generating the spacing presets array based on the spacing scale provided.
 	 *
 	 * @dataProvider data_set_spacing_sizes_when_invalid
+	 *
+	 * @param array $spacing_scale   Example spacing scale definitions from the data provider.
+	 * @param array $expected_output Expected output from data provider.
 	 */
-	public function test_set_spacing_sizes_when_invalid( $spacing_scale, $expected_output ) {
+	public function test_set_spacing_sizes_validation( $spacing_scale, $expected_output ) {
 		$this->expectNotice();
 		$this->expectNoticeMessage( 'Some of the theme.json settings.spacing.spacingScale values are invalid' );
 
-		$theme_json = new WP_Theme_JSON_Gutenberg(
+		$theme_json = new WP_Theme_JSON(
 			array(
 				'version'  => 2,
 				'settings' => array(
@@ -1194,8 +1194,7 @@ class WP_Theme_JSON_Gutenberg_Test extends WP_UnitTestCase {
 	 */
 	function data_set_spacing_sizes_when_invalid() {
 		return array(
-
-			'invalid_spacing_scale_values_missing_operator' => array(
+			'spacing scale is missing operator value'   => array(
 				'spacingScale'    => array(
 					'operator'   => '',
 					'increment'  => 1.5,
@@ -1205,8 +1204,7 @@ class WP_Theme_JSON_Gutenberg_Test extends WP_UnitTestCase {
 				),
 				'expected_output' => null,
 			),
-
-			'invalid_spacing_scale_values_non_numeric_increment' => array(
+			'spacing scale has non numeric increment'   => array(
 				'spacingScale'    => array(
 					'operator'   => '+',
 					'increment'  => 'add two to previous value',
@@ -1216,8 +1214,7 @@ class WP_Theme_JSON_Gutenberg_Test extends WP_UnitTestCase {
 				),
 				'expected_output' => null,
 			),
-
-			'invalid_spacing_scale_values_non_numeric_steps' => array(
+			'spacing scale has non numeric steps'       => array(
 				'spacingScale'    => array(
 					'operator'   => '+',
 					'increment'  => 1.5,
@@ -1227,8 +1224,7 @@ class WP_Theme_JSON_Gutenberg_Test extends WP_UnitTestCase {
 				),
 				'expected_output' => null,
 			),
-
-			'invalid_spacing_scale_values_non_numeric_medium_step' => array(
+			'spacing scale has non numeric medium step' => array(
 				'spacingScale'    => array(
 					'operator'   => '+',
 					'increment'  => 1.5,
@@ -1238,8 +1234,7 @@ class WP_Theme_JSON_Gutenberg_Test extends WP_UnitTestCase {
 				),
 				'expected_output' => null,
 			),
-
-			'invalid_spacing_scale_values_missing_unit' => array(
+			'spacing scale is missing unit value'       => array(
 				'spacingScale'    => array(
 					'operator'   => '+',
 					'increment'  => 1.5,

--- a/phpunit/class-wp-theme-json-test.php
+++ b/phpunit/class-wp-theme-json-test.php
@@ -933,7 +933,7 @@ class WP_Theme_JSON_Gutenberg_Test extends WP_UnitTestCase {
 	 * @param array $expected_output Expected output from data provider.
 	 */
 	function test_should_set_spacing_sizes( $spacing_scale, $expected_output ) {
-		$theme_json = new WP_Theme_JSON(
+		$theme_json = new WP_Theme_JSON_Gutenberg(
 			array(
 				'version'  => 2,
 				'settings' => array(
@@ -1172,7 +1172,7 @@ class WP_Theme_JSON_Gutenberg_Test extends WP_UnitTestCase {
 		$this->expectNotice();
 		$this->expectNoticeMessage( 'Some of the theme.json settings.spacing.spacingScale values are invalid' );
 
-		$theme_json = new WP_Theme_JSON(
+		$theme_json = new WP_Theme_JSON_Gutenberg(
 			array(
 				'version'  => 2,
 				'settings' => array(


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Copies back some of the code review changes from the 6.1 backport 

## Why?
Will make it easier if any further changes are made that also need to be backported

## How?
Copy pasta

## Testing Instructions

- Make sure all the tests pass
- Make sure spacing presets works as expected, eg. add a group and set padding and margin and make sure presets from 0 -> 2X-Large are available

