### PR TITLE
Post Featured Image: Fix height/scale overwriting img inline styles

### DIFF
--- a/packages/block-library/src/post-featured-image/index.php
+++ b/packages/block-library/src/post-featured-image/index.php
@@ -29,11 +29,18 @@ function render_block_core_post_featured_image( $attributes, $content, $block ) 
 		$attr['alt'] = $post_title;
 	}
 
+	if ( ! empty( $attributes['height'] ) ) {
+		$extra_styles = "height:{$attributes['height']};";
+		if ( ! empty( $attributes['scale'] ) ) {
+			$extra_styles .= "object-fit:{$attributes['scale']};";
+		}
+		$attr['style'] = empty( $attr['style'] ) ? $extra_styles : $attr['style'] . $extra_styles;
+	}
+
 	$featured_image = get_the_post_thumbnail( $post_ID, $size_slug, $attr );
 	if ( ! $featured_image ) {
 		return '';
 	}
-	$wrapper_attributes = get_block_wrapper_attributes();
 	if ( $is_link ) {
 		$link_target    = $attributes['linkTarget'];
 		$rel            = ! empty( $attributes['rel'] ) ? 'rel="' . esc_attr( $attributes['rel'] ) . '"' : '';
@@ -49,23 +56,9 @@ function render_block_core_post_featured_image( $attributes, $content, $block ) 
 		$featured_image = $featured_image . $overlay_markup;
 	}
 
-	$has_width  = ! empty( $attributes['width'] );
-	$has_height = ! empty( $attributes['height'] );
-	if ( ! $has_height && ! $has_width ) {
-		return "<figure {$wrapper_attributes}>{$featured_image}</figure>";
-	}
-
-	if ( $has_width ) {
-		$wrapper_attributes = get_block_wrapper_attributes( array( 'style' => "width:{$attributes['width']};" ) );
-	}
-
-	if ( $has_height ) {
-		$image_styles = "height:{$attributes['height']};";
-		if ( ! empty( $attributes['scale'] ) ) {
-			$image_styles .= "object-fit:{$attributes['scale']};";
-		}
-		$featured_image = str_replace( 'src=', 'style="' . esc_attr( $image_styles ) . '" src=', $featured_image );
-	}
+	$wrapper_attributes = empty( $attributes['width'] )
+		? get_block_wrapper_attributes()
+		: get_block_wrapper_attributes( array( 'style' => "width:{$attributes['width']};" ) );
 
 	return "<figure {$wrapper_attributes}>{$featured_image}</figure>";
 }


### PR DESCRIPTION
Fixes https://github.com/WordPress/gutenberg/issues/44194

## What?

Refactors application of inline styles to the featured image to avoid multiple `style` attributes causing loss of inline styles.

## Why?

Without this fix, you cannot set post featured image heights as well as borders.

## How?

Refactors the block's render callback to conditionally generate the height/scale related styles earlier and pass them through to the function generating the img element.

## Testing Instructions

1. Replicate the original issue following the instructions in [#44194](https://github.com/WordPress/gutenberg/issues/44194). Not that along with border radius, custom border colors, width, and style are also lost.
2. Checkout this PR and repeat the process ensuring that the border styles are maintained when viewed on the front end.
3. Continue to put the Post Featured Image block through its paces and confirm everything else still functions and displays correctly.


## Screenshots or screencast <!-- if applicable -->

| Before | After |
|---|---|
| <video src="https://user-images.githubusercontent.com/60436221/190544030-265695b3-d01a-4db8-94f7-9d846f31af08.mp4" /> | <video src="https://user-images.githubusercontent.com/60436221/190544134-64f8c8e0-2889-4a31-a0da-bca160004f8c.mp4" /> | 


