### PR TITLE
Update video placeholder style.

### DIFF
--- a/packages/block-library/src/video/edit.js
+++ b/packages/block-library/src/video/edit.js
@@ -13,6 +13,7 @@ import {
 	Disabled,
 	PanelBody,
 	Spinner,
+	Placeholder,
 } from '@wordpress/components';
 import {
 	BlockControls,
@@ -42,6 +43,23 @@ import { createUpgradedEmbedBlock } from '../embed/util';
 import VideoCommonSettings from './edit-common-settings';
 import TracksEditor from './tracks-editor';
 import Tracks from './tracks';
+
+// Much of this description is duplicated from MediaPlaceholder.
+const placeholder = ( content ) => {
+	return (
+		<Placeholder
+			className="block-editor-media-placeholder"
+			withIllustration={ true }
+			icon={ icon }
+			label={ __( 'Video' ) }
+			instructions={ __(
+				'Upload a video file, pick one from your media library, or add one with a URL.'
+			) }
+		>
+			{ content }
+		</Placeholder>
+	);
+};
 
 const ALLOWED_MEDIA_TYPES = [ 'video' ];
 const VIDEO_POSTER_ALLOWED_MEDIA_TYPES = [ 'image' ];
@@ -146,6 +164,7 @@ function VideoEdit( {
 					allowedTypes={ ALLOWED_MEDIA_TYPES }
 					value={ attributes }
 					onError={ onUploadError }
+					placeholder={ placeholder }
 				/>
 			</div>
 		);

--- a/packages/block-library/src/video/editor.scss
+++ b/packages/block-library/src/video/editor.scss
@@ -1,3 +1,32 @@
+// Provide special styling for the placeholder.
+// @todo: this particular minimal style of placeholder could be componentized further.
+.wp-block-video.wp-block-video {
+	// Show Placeholder style on-select.
+	&.is-selected .components-placeholder {
+		// Block UI appearance.
+		color: $gray-900;
+		background-color: $white;
+		box-shadow: inset 0 0 0 $border-width $gray-900;
+		border: none;
+
+		// @todo: this should eventually be overridden by a custom border-radius set in the inspector.
+		border-radius: $radius-block-ui;
+
+		> svg {
+			opacity: 0;
+		}
+	}
+
+	// Remove the transition while we still have a legacy placeholder style.
+	// Otherwise the content jumps between the 1px placeholder border, and any inherited custom
+	// parent border that may get applied when you deselect.
+	.components-placeholder__label,
+	.components-placeholder__instructions,
+	.components-button {
+		transition: none;
+	}
+}
+
 .wp-block[data-align="center"] > .wp-block-video {
 	text-align: center;
 }

--- a/packages/block-library/src/video/editor.scss
+++ b/packages/block-library/src/video/editor.scss
@@ -15,6 +15,10 @@
 		> svg {
 			opacity: 0;
 		}
+
+		&::before {
+			opacity: 0;
+		}
 	}
 
 	// Remove the transition while we still have a legacy placeholder style.


### PR DESCRIPTION
## What?

Followup to #43180. See also #44190. Updates the placeholder of the Video block to start out dashed. Instead of showing the resting state of the video block as the dark-bordered classic placeholder, it now shows a dashed outline until you select it.

Before:

<img width="857" alt="Screenshot 2022-09-16 at 09 26 15" src="https://user-images.githubusercontent.com/1204802/190582447-fed086fb-4ca5-4b86-bf3b-808ec0565838.png">

After:

![video](https://user-images.githubusercontent.com/1204802/190582460-e4ac602a-8970-4eed-bd8e-142855a2a81e.gif)

We'll likely want [an icon](https://github.com/WordPress/gutenberg/pull/44190#issuecomment-1249011941) to denote the difference between placeholders, but perhaps this one is good enough to land as a starting point?

## Why?

For patterns and templates, including a video block can be a good way to suggest a particular use case. But the descriptions quickly become repetitive in patterns where you may have multiple video blocks. By showing these on select, we better enable this use case.

## Testing Instructions

Insert a video block and observe its resting and selected states.