### PR TITLE
Update css for calendar block center alignment issue

### DIFF
--- a/packages/block-library/src/calendar/style.scss
+++ b/packages/block-library/src/calendar/style.scss
@@ -1,3 +1,6 @@
+.aligncenter.wp-block-calendar caption {
+    text-align: center;
+}
 .wp-block-calendar {
 	text-align: center;
 


### PR DESCRIPTION
In this PR i have solved the designing issue which is mentioned in #44216 

1)Activate Twenty Eleven Theme
2)Add Calendar Block
3)Change the alignment center of calendar block and also default position of calendar caption in editor side is center but not align in center in front end side.

