### PR TITLE
[Site Editor]: Fix React warning on template creation

### DIFF
--- a/packages/edit-site/src/components/add-new-template/new-template.js
+++ b/packages/edit-site/src/components/add-new-template/new-template.js
@@ -9,7 +9,7 @@ import {
 	MenuItem,
 	NavigableMenu,
 } from '@wordpress/components';
-import { useState } from '@wordpress/element';
+import { useState, useRef, useEffect } from '@wordpress/element';
 import { useDispatch } from '@wordpress/data';
 import { store as coreStore } from '@wordpress/core-data';
 import {
@@ -88,12 +88,16 @@ export default function NewTemplate( { postType } ) {
 	] = useState( false );
 	const [ entityForSuggestions, setEntityForSuggestions ] = useState( {} );
 	const [ isCreatingTemplate, setIsCreatingTemplate ] = useState( false );
-
 	const history = useHistory();
 	const { saveEntityRecord } = useDispatch( coreStore );
 	const { createErrorNotice, createSuccessNotice } =
 		useDispatch( noticesStore );
 	const { setTemplate } = useDispatch( editSiteStore );
+	const isMounted = useRef( false );
+	useEffect( () => {
+		isMounted.current = true;
+		return () => ( isMounted.current = false );
+	}, [] );
 
 	async function createTemplate( template, isWPSuggestion = true ) {
 		if ( isCreatingTemplate ) {
@@ -158,7 +162,9 @@ export default function NewTemplate( { postType } ) {
 				type: 'snackbar',
 			} );
 		} finally {
-			setIsCreatingTemplate( false );
+			if ( isMounted.current ) {
+				setIsCreatingTemplate( false );
+			}
 		}
 	}
 


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
A small fix for a React warning as a follow up of: https://github.com/WordPress/gutenberg/pull/44146


## Testing Instructions
1. In site editor create a new template 
2. Open browser console and observe that no React warning is thrown(`Can't perform a React state update on an unmounted component`)