### PR TITLE
Ensure replacing a template part using a pattern doesn't update the existing entity

### DIFF
--- a/packages/block-library/src/template-part/edit/selection-modal.js
+++ b/packages/block-library/src/template-part/edit/selection-modal.js
@@ -7,10 +7,7 @@ import { store as noticesStore } from '@wordpress/notices';
 import { useDispatch } from '@wordpress/data';
 import { parse } from '@wordpress/blocks';
 import { useAsyncList } from '@wordpress/compose';
-import {
-	__experimentalBlockPatternsList as BlockPatternsList,
-	store as blockEditorStore,
-} from '@wordpress/block-editor';
+import { __experimentalBlockPatternsList as BlockPatternsList } from '@wordpress/block-editor';
 import {
 	SearchControl,
 	__experimentalHStack as HStack,
@@ -36,9 +33,6 @@ export default function TemplatePartSelectionModal( {
 } ) {
 	const [ searchValue, setSearchValue ] = useState( '' );
 
-	// When the templatePartId is undefined,
-	// it means the user is creating a new one from the placeholder.
-	const isReplacingTemplatePartContent = !! templatePartId;
 	const { templateParts } = useAlternativeTemplateParts(
 		area,
 		templatePartId
@@ -62,7 +56,6 @@ export default function TemplatePartSelectionModal( {
 	const shownBlockPatterns = useAsyncList( filteredBlockPatterns );
 
 	const { createSuccessNotice } = useDispatch( noticesStore );
-	const { replaceInnerBlocks } = useDispatch( blockEditorStore );
 
 	const onTemplatePartSelect = useCallback( ( templatePart ) => {
 		setAttributes( {
@@ -121,12 +114,7 @@ export default function TemplatePartSelectionModal( {
 						blockPatterns={ filteredBlockPatterns }
 						shownPatterns={ shownBlockPatterns }
 						onClickPattern={ ( pattern, blocks ) => {
-							if ( isReplacingTemplatePartContent ) {
-								replaceInnerBlocks( clientId, blocks );
-							} else {
-								createFromBlocks( blocks, pattern.title );
-							}
-
+							createFromBlocks( blocks, pattern.title );
 							onClose();
 						} }
 					/>


### PR DESCRIPTION
## What?
Fixes the comment here - https://github.com/WordPress/gutenberg/issues/41397#issuecomment-1185543233, see also #44147

## Why?
As mentioned in the above issue comment, it can be confusing that selecting a template part creates a new entity, while selecting a pattern replaces the blocks in the existing entity.

This can also be destructive if the user didn't intend to update the entity. A template part can be used across multiple templates, so it would result in unexpectedly widespread changes.

## How?
Remarkably the fix is to delete some code. There was a specific code path added to replace the template part's blocks, but I removed this in favour of the same behavior the template part's placeholder has - creating a new entity and setting that entity as active.

## Testing Instructions
1. Open a template in the site editor
2. Select a template part (preferably a header or footer) and make a note of the name of the template part.
3. Select 'Replace' from the block settings drop down
4. Select a pattern (that has a different name to the current template part).
5. Observe that a new template part is created that has the same name as the pattern
6. Click the editor 'Save' button.
7. Observe that the only 'edits' are to the Template.

## Screenshots or screencast <!-- if applicable -->

### Before

https://user-images.githubusercontent.com/677833/190592493-da21d934-afca-44aa-887a-875968c32223.mp4


### After

https://user-images.githubusercontent.com/677833/190592066-2980ca77-a057-421e-b3a2-e506539a1a22.mp4
