### PR TITLE
Navigation: Remove ellipses as menu icon options for now

### DIFF
--- a/packages/block-library/src/navigation/edit/overlay-menu-icon.js
+++ b/packages/block-library/src/navigation/edit/overlay-menu-icon.js
@@ -2,15 +2,11 @@
  * WordPress dependencies
  */
 import { SVG, Rect } from '@wordpress/primitives';
-import { Icon, menu, moreVertical, moreHorizontal } from '@wordpress/icons';
+import { Icon, menu } from '@wordpress/icons';
 
 export default function OverlayMenuIcon( { icon } ) {
 	if ( icon === 'menu' ) {
 		return <Icon icon={ menu } />;
-	} else if ( icon === 'more-vertical' ) {
-		return <Icon icon={ moreVertical } />;
-	} else if ( icon === 'more-horizontal' ) {
-		return <Icon icon={ moreHorizontal } />;
 	}
 
 	return (

--- a/packages/block-library/src/navigation/edit/overlay-menu-preview.js
+++ b/packages/block-library/src/navigation/edit/overlay-menu-preview.js
@@ -41,16 +41,6 @@ export default function OverlayMenuPreview( { setAttributes, hasIcon, icon } ) {
 					aria-label={ __( 'menu' ) }
 					label={ <OverlayMenuIcon icon="menu" /> }
 				/>
-				<ToggleGroupControlOption
-					value="more-vertical"
-					aria-label={ __( 'more vertical' ) }
-					label={ <OverlayMenuIcon icon="more-vertical" /> }
-				/>
-				<ToggleGroupControlOption
-					value="more-horizontal"
-					aria-label={ __( 'more horizontal' ) }
-					label={ <OverlayMenuIcon icon="more-horizontal" /> }
-				/>
 			</ToggleGroupControl>
 		</>
 	);

--- a/packages/block-library/src/navigation/index.php
+++ b/packages/block-library/src/navigation/index.php
@@ -623,10 +623,6 @@ function render_block_core_navigation( $attributes, $content, $block ) {
 	if ( isset( $attributes['icon'] ) ) {
 		if ( 'menu' === $attributes['icon'] ) {
 			$toggle_button_icon = '<svg width="24" height="24" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"><path d="M5 5v1.5h14V5H5zm0 7.8h14v-1.5H5v1.5zM5 19h14v-1.5H5V19z" /></svg>';
-		} elseif ( 'more-vertical' === $attributes['icon'] ) {
-			$toggle_button_icon = '<svg width="24" height="24" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"><path d="M13 19h-2v-2h2v2zm0-6h-2v-2h2v2zm0-6h-2V5h2v2z" /></svg>';
-		} elseif ( 'more-horizontal' === $attributes['icon'] ) {
-			$toggle_button_icon = '<svg width="24" height="24" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"><path d="M11 13h2v-2h-2v2zm-6 0h2v-2H5v2zm12-2v2h2v-2h-2z" /></svg>';
 		}
 	}
 	$toggle_button_content       = $should_display_icon_label ? $toggle_button_icon : __( 'Menu' );


### PR DESCRIPTION
## What?

This PR removes the two ellipsis icons from the navigation overlay menu options. Before:

<img width="304" alt="Screenshot 2022-09-16 at 11 00 05" src="https://user-images.githubusercontent.com/1204802/190600168-c6e2dc88-1279-4317-8cec-26630e9b36f2.png">

After:

<img width="318" alt="Screenshot 2022-09-16 at 11 00 17" src="https://user-images.githubusercontent.com/1204802/190600184-f6b39fcd-55ea-4c1f-8dc7-aff5d655449f.png">

## Why?

Given we can't easily allow uploading custom SVGs, we should heavily curate the defaults, but still not have too many. Perhaps 5 in total. In that light, the two ellipses are not the most compelling options we can offer, so we should remove them before they go out in 6.1 and become something we have to support long term.

That is to say: we should add options back, but we should add them carefully and deliberately and with confidence that they are icons we love. This could be a fun creative exercise as well, what 5 icons should we offer? A big plus? A minimalist dot? We can also add the kebab menu back, but if we do that, it should probably be 3 circles instead of 3 squares which is very much a block editor iconographic flair, more so than a general ellipsis pattern.

## Testing Instructions

Please test the navigation block, click the gray preview area, and observe only two icons.