### PR TITLE
Compose: Introduce an in-house `throttle()` utility, deprecate Lodash version

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -151,6 +151,7 @@ module.exports = {
 							'sum',
 							'sumBy',
 							'take',
+							'throttle',
 							'times',
 							'toString',
 							'trim',

--- a/packages/block-editor/src/components/block-draggable/test/index.native.js
+++ b/packages/block-editor/src/components/block-draggable/test/index.native.js
@@ -29,15 +29,6 @@ import {
 	getDraggableChip,
 } from './helpers';
 
-// Mock throttle to allow updating the dragging position on every "onDragOver" event.
-jest.mock( 'lodash', () => ( {
-	...jest.requireActual( 'lodash' ),
-	throttle: ( fn ) => {
-		fn.cancel = jest.fn();
-		return fn;
-	},
-} ) );
-
 beforeAll( () => {
 	// Register all core blocks
 	registerCoreBlocks();

--- a/packages/components/src/draggable/index.js
+++ b/packages/components/src/draggable/index.js
@@ -1,12 +1,8 @@
 /**
  * WordPress dependencies
  */
+import { throttle } from '@wordpress/compose';
 import { useEffect, useRef } from '@wordpress/element';
-
-/**
- * External dependencies
- */
-import { throttle } from 'lodash';
 
 const dragImageClass = 'components-draggable__invisible-drag-image';
 const cloneWrapperClass = 'components-draggable__clone';
@@ -180,6 +176,7 @@ export default function Draggable( {
 
 		// Aim for 60fps (16 ms per frame) for now. We can potentially use requestAnimationFrame (raf) instead,
 		// note that browsers may throttle raf below 60fps in certain conditions.
+		// @ts-ignore
 		const throttledDragOver = throttle( over, 16 );
 
 		ownerDocument.addEventListener( 'dragover', throttledDragOver );

--- a/packages/compose/README.md
+++ b/packages/compose/README.md
@@ -161,6 +161,39 @@ _Related_
 Given a component returns the enhanced component augmented with a component
 only re-rendering when its props/state change
 
+### throttle
+
+A simplified and properly typed version of lodash's `throttle`, that
+always uses timers instead of sometimes using rAF.
+
+Creates a throttled function that only invokes `func` at most once per
+every `wait` milliseconds (or once per browser frame). The throttled function
+comes with a `cancel` method to cancel delayed `func` invocations and a
+`flush` method to immediately invoke them. Provide `options` to indicate
+whether `func` should be invoked on the leading and/or trailing edge of the
+`wait` timeout. The `func` is invoked with the last arguments provided to the
+throttled function. Subsequent calls to the throttled function return the
+result of the last `func` invocation.
+
+**Note:** If `leading` and `trailing` options are `true`, `func` is
+invoked on the trailing edge of the timeout only if the throttled function
+is invoked more than once during the `wait` timeout.
+
+If `wait` is `0` and `leading` is `false`, `func` invocation is deferred
+until the next tick, similar to `setTimeout` with a timeout of `0`.
+
+_Parameters_
+
+-   _func_ `Function`: The function to throttle.
+-   _wait_ `number`: The number of milliseconds to throttle invocations to.
+-   _options_ `Partial< ThrottleOptions >`: The options object.
+-   _options.leading_ `boolean`: Specify invoking on the leading edge of the timeout.
+-   _options.trailing_ `boolean`: Specify invoking on the trailing edge of the timeout.
+
+_Returns_
+
+-   Returns the new throttled function.
+
 ### useAsyncList
 
 React hook returns an array which items get asynchronously appended from a source array.
@@ -511,7 +544,7 @@ const App = () => {
 
 ### useThrottle
 
-Throttles a function with Lodash's `throttle`. A new throttled function will
+Throttles a function similar to Lodash's `throttle`. A new throttled function will
 be returned and any scheduled calls cancelled if any of the arguments change,
 including the function to throttle, so please wrap functions created on
 render in components in `useCallback`.
@@ -524,11 +557,11 @@ _Parameters_
 
 -   _fn_ `TFunc`: The function to throttle.
 -   _wait_ `[number]`: The number of milliseconds to throttle invocations to.
--   _options_ `[import('lodash').ThrottleSettings]`: The options object. See linked documentation for details.
+-   _options_ `[import('../../utils/throttle').ThrottleOptions]`: The options object. See linked documentation for details.
 
 _Returns_
 
--   `import('lodash').DebouncedFunc<TFunc>`: Throttled function.
+-   `import('../../utils/debounce').DebouncedFunc<TFunc>`: Throttled function.
 
 ### useViewportMatch
 

--- a/packages/compose/README.md
+++ b/packages/compose/README.md
@@ -167,13 +167,13 @@ A simplified and properly typed version of lodash's `throttle`, that
 always uses timers instead of sometimes using rAF.
 
 Creates a throttled function that only invokes `func` at most once per
-every `wait` milliseconds (or once per browser frame). The throttled function
-comes with a `cancel` method to cancel delayed `func` invocations and a
-`flush` method to immediately invoke them. Provide `options` to indicate
-whether `func` should be invoked on the leading and/or trailing edge of the
-`wait` timeout. The `func` is invoked with the last arguments provided to the
-throttled function. Subsequent calls to the throttled function return the
-result of the last `func` invocation.
+every `wait` milliseconds. The throttled function comes with a `cancel`
+method to cancel delayed `func` invocations and a `flush` method to
+immediately invoke them. Provide `options` to indicate whether `func`
+should be invoked on the leading and/or trailing edge of the `wait`
+timeout. The `func` is invoked with the last arguments provided to the
+throttled function. Subsequent calls to the throttled function return
+the result of the last `func` invocation.
 
 **Note:** If `leading` and `trailing` options are `true`, `func` is
 invoked on the trailing edge of the timeout only if the throttled function

--- a/packages/compose/src/hooks/use-throttle/index.js
+++ b/packages/compose/src/hooks/use-throttle/index.js
@@ -1,7 +1,6 @@
 /**
  * External dependencies
  */
-import { throttle } from 'lodash';
 import { useMemoOne } from 'use-memo-one';
 
 /**
@@ -10,7 +9,12 @@ import { useMemoOne } from 'use-memo-one';
 import { useEffect } from '@wordpress/element';
 
 /**
- * Throttles a function with Lodash's `throttle`. A new throttled function will
+ * Internal dependencies
+ */
+import { throttle } from '../../utils/throttle';
+
+/**
+ * Throttles a function similar to Lodash's `throttle`. A new throttled function will
  * be returned and any scheduled calls cancelled if any of the arguments change,
  * including the function to throttle, so please wrap functions created on
  * render in components in `useCallback`.
@@ -19,14 +23,14 @@ import { useEffect } from '@wordpress/element';
  *
  * @template {(...args: any[]) => void} TFunc
  *
- * @param {TFunc}                             fn        The function to throttle.
- * @param {number}                            [wait]    The number of milliseconds to throttle invocations to.
- * @param {import('lodash').ThrottleSettings} [options] The options object. See linked documentation for details.
- * @return {import('lodash').DebouncedFunc<TFunc>} Throttled function.
+ * @param {TFunc}                                          fn        The function to throttle.
+ * @param {number}                                         [wait]    The number of milliseconds to throttle invocations to.
+ * @param {import('../../utils/throttle').ThrottleOptions} [options] The options object. See linked documentation for details.
+ * @return {import('../../utils/debounce').DebouncedFunc<TFunc>} Throttled function.
  */
 export default function useThrottle( fn, wait, options ) {
 	const throttled = useMemoOne(
-		() => throttle( fn, wait, options ),
+		() => throttle( fn, wait ?? 0, options ),
 		[ fn, wait, options ]
 	);
 	useEffect( () => () => throttled.cancel(), [ throttled ] );

--- a/packages/compose/src/index.js
+++ b/packages/compose/src/index.js
@@ -2,6 +2,8 @@
 export * from './utils/create-higher-order-component';
 // The `debounce` helper and its types.
 export * from './utils/debounce';
+// The `throttle` helper and its types.
+export * from './utils/throttle';
 
 // The `compose` and `pipe` helpers (inspired by `flowRight` and `flow` from Lodash).
 export { default as compose } from './higher-order/compose';

--- a/packages/compose/src/index.native.js
+++ b/packages/compose/src/index.native.js
@@ -2,6 +2,8 @@
 export * from './utils/create-higher-order-component';
 // The `debounce` helper and its types.
 export * from './utils/debounce';
+// The `throttle` helper and its types.
+export * from './utils/throttle';
 
 // The `compose` and `pipe` helpers (inspired by `flowRight` and `flow` from Lodash).
 export { default as compose } from './higher-order/compose';

--- a/packages/compose/src/utils/throttle/index.ts
+++ b/packages/compose/src/utils/throttle/index.ts
@@ -1,0 +1,95 @@
+/**
+ * Parts of this source were derived and modified from lodash,
+ * released under the MIT license.
+ *
+ * https://github.com/lodash/lodash
+ *
+ * Copyright JS Foundation and other contributors <https://js.foundation/>
+ *
+ * Based on Underscore.js, copyright Jeremy Ashkenas,
+ * DocumentCloud and Investigative Reporters & Editors <http://underscorejs.org/>
+ *
+ * This software consists of voluntary contributions made by many
+ * individuals. For exact contribution history, see the revision history
+ * available at https://github.com/lodash/lodash
+ *
+ * The following license applies to all parts of this software except as
+ * documented below:
+ *
+ * ====
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining
+ * a copy of this software and associated documentation files (the
+ * "Software"), to deal in the Software without restriction, including
+ * without limitation the rights to use, copy, modify, merge, publish,
+ * distribute, sublicense, and/or sell copies of the Software, and to
+ * permit persons to whom the Software is furnished to do so, subject to
+ * the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+ * LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+ * OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+ * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+/**
+ * Internal dependencies
+ */
+import { debounce } from '../debounce';
+
+export interface ThrottleOptions {
+	leading?: boolean;
+	trailing?: boolean;
+}
+
+/**
+ * A simplified and properly typed version of lodash's `throttle`, that
+ * always uses timers instead of sometimes using rAF.
+ *
+ * Creates a throttled function that only invokes `func` at most once per
+ * every `wait` milliseconds (or once per browser frame). The throttled function
+ * comes with a `cancel` method to cancel delayed `func` invocations and a
+ * `flush` method to immediately invoke them. Provide `options` to indicate
+ * whether `func` should be invoked on the leading and/or trailing edge of the
+ * `wait` timeout. The `func` is invoked with the last arguments provided to the
+ * throttled function. Subsequent calls to the throttled function return the
+ * result of the last `func` invocation.
+ *
+ * **Note:** If `leading` and `trailing` options are `true`, `func` is
+ * invoked on the trailing edge of the timeout only if the throttled function
+ * is invoked more than once during the `wait` timeout.
+ *
+ * If `wait` is `0` and `leading` is `false`, `func` invocation is deferred
+ * until the next tick, similar to `setTimeout` with a timeout of `0`.
+ *
+ * @param {Function}                   func             The function to throttle.
+ * @param {number}                     wait             The number of milliseconds to throttle invocations to.
+ * @param {Partial< ThrottleOptions >} options          The options object.
+ * @param {boolean}                    options.leading  Specify invoking on the leading edge of the timeout.
+ * @param {boolean}                    options.trailing Specify invoking on the trailing edge of the timeout.
+ * @return Returns the new throttled function.
+ */
+export const throttle = < FunctionT extends ( ...args: unknown[] ) => unknown >(
+	func: FunctionT,
+	wait: number,
+	options?: ThrottleOptions
+) => {
+	let leading = true;
+	let trailing = true;
+
+	if ( options ) {
+		leading = 'leading' in options ? !! options.leading : leading;
+		trailing = 'trailing' in options ? !! options.trailing : trailing;
+	}
+	return debounce( func, wait, {
+		leading,
+		trailing,
+		maxWait: wait,
+	} );
+};

--- a/packages/compose/src/utils/throttle/index.ts
+++ b/packages/compose/src/utils/throttle/index.ts
@@ -53,13 +53,13 @@ export interface ThrottleOptions {
  * always uses timers instead of sometimes using rAF.
  *
  * Creates a throttled function that only invokes `func` at most once per
- * every `wait` milliseconds (or once per browser frame). The throttled function
- * comes with a `cancel` method to cancel delayed `func` invocations and a
- * `flush` method to immediately invoke them. Provide `options` to indicate
- * whether `func` should be invoked on the leading and/or trailing edge of the
- * `wait` timeout. The `func` is invoked with the last arguments provided to the
- * throttled function. Subsequent calls to the throttled function return the
- * result of the last `func` invocation.
+ * every `wait` milliseconds. The throttled function comes with a `cancel`
+ * method to cancel delayed `func` invocations and a `flush` method to
+ * immediately invoke them. Provide `options` to indicate whether `func`
+ * should be invoked on the leading and/or trailing edge of the `wait`
+ * timeout. The `func` is invoked with the last arguments provided to the
+ * throttled function. Subsequent calls to the throttled function return
+ * the result of the last `func` invocation.
  *
  * **Note:** If `leading` and `trailing` options are `true`, `func` is
  * invoked on the trailing edge of the timeout only if the throttled function

--- a/packages/compose/src/utils/throttle/test/index.ts
+++ b/packages/compose/src/utils/throttle/test/index.ts
@@ -1,0 +1,256 @@
+/**
+ * Internal dependencies
+ */
+import { throttle } from '../index';
+
+const identity = ( value ) => value;
+
+describe( 'throttle', () => {
+	beforeEach( () => {
+		jest.useFakeTimers();
+	} );
+
+	afterEach( () => {
+		jest.useRealTimers();
+	} );
+
+	it( 'should throttle a function', () => {
+		let callCount = 0;
+		const throttled = throttle( function () {
+			callCount++;
+		}, 32 );
+
+		throttled();
+		throttled();
+		throttled();
+
+		const lastCount = callCount;
+		expect( callCount ).toBeGreaterThan( 0 );
+
+		jest.advanceTimersByTime( 64 );
+
+		expect( callCount ).toBeGreaterThan( lastCount );
+	} );
+
+	it( 'should return the result of the first call on subsequent calls', () => {
+		const throttled = throttle( identity, 32 );
+		let results = [ throttled( 'a' ), throttled( 'b' ) ];
+
+		expect( results ).toStrictEqual( [ 'a', 'a' ] );
+
+		jest.advanceTimersByTime( 64 );
+
+		results = [ throttled( 'c' ), throttled( 'd' ) ];
+		expect( results[ 0 ] ).not.toBe( 'a' );
+		expect( results[ 0 ] ).not.toBe( undefined );
+
+		expect( results[ 1 ] ).not.toBe( 'd' );
+		expect( results[ 1 ] ).not.toBe( undefined );
+	} );
+
+	it( 'should clear timeout when `func` is called', () => {
+		let callCount = 0;
+		let dateCount = 0;
+
+		const globalDateNow = global.Date.now;
+		global.Date.now = function () {
+			return ++dateCount === 5 ? Infinity : +new Date();
+		};
+
+		const throttled = throttle( () => {
+			callCount++;
+		}, 32 );
+
+		throttled();
+		throttled();
+
+		jest.advanceTimersByTime( 64 );
+
+		expect( callCount ).toBe( 2 );
+		global.Date.now = globalDateNow;
+	} );
+
+	it( 'should not trigger a trailing call when invoked once', () => {
+		let callCount = 0;
+		const throttled = throttle( () => {
+			callCount++;
+		}, 32 );
+
+		throttled();
+		expect( callCount ).toBe( 1 );
+
+		jest.advanceTimersByTime( 64 );
+
+		expect( callCount ).toBe( 1 );
+	} );
+
+	[ true, false ].forEach( ( leading ) => {
+		it(
+			'should trigger a call when invoked repeatedly' +
+				( ! leading ? ' and `leading` is `false`' : '' ),
+			() => {
+				let callCount = 0;
+				const limit = 320;
+				const options = leading ? {} : { leading: false };
+				const throttled = throttle(
+					() => {
+						callCount++;
+					},
+					32,
+					options
+				);
+
+				const start = Date.now();
+				while ( Date.now() - start < limit ) {
+					throttled();
+					jest.advanceTimersByTime( 1 );
+				}
+				const actual = callCount;
+
+				jest.advanceTimersByTime( 1 );
+
+				expect( actual ).toBeGreaterThan( 1 );
+			}
+		);
+	} );
+
+	it( 'should trigger a second throttled call as soon as possible', () => {
+		let callCount = 0;
+
+		const throttled = throttle(
+			() => {
+				callCount++;
+			},
+			128,
+			{ leading: false }
+		);
+
+		throttled();
+
+		jest.advanceTimersByTime( 192 );
+
+		expect( callCount ).toBe( 1 );
+		throttled();
+
+		jest.advanceTimersByTime( 64 );
+
+		expect( callCount ).toBe( 1 );
+
+		jest.advanceTimersByTime( 130 );
+
+		expect( callCount ).toBe( 2 );
+	} );
+
+	it( 'should apply default options', () => {
+		let callCount = 0;
+		const throttled = throttle(
+			() => {
+				callCount++;
+			},
+			32,
+			{}
+		);
+
+		throttled();
+		throttled();
+		expect( callCount ).toBe( 1 );
+
+		jest.advanceTimersByTime( 128 );
+
+		expect( callCount ).toBe( 2 );
+	} );
+
+	it( 'should support a `leading` option', () => {
+		const withLeading = throttle( identity, 32, { leading: true } );
+		expect( withLeading( 'a' ) ).toBe( 'a' );
+
+		const withoutLeading = throttle( identity, 32, { leading: false } );
+		expect( withoutLeading( 'a' ) ).toBeUndefined();
+	} );
+
+	it( 'should support a `trailing` option', () => {
+		let withCount = 0;
+		let withoutCount = 0;
+
+		const withTrailing = throttle(
+			( value ) => {
+				withCount++;
+				return value;
+			},
+			64,
+			{ trailing: true }
+		);
+
+		const withoutTrailing = throttle(
+			( value ) => {
+				withoutCount++;
+				return value;
+			},
+			64,
+			{ trailing: false }
+		);
+
+		expect( withTrailing( 'a' ) ).toBe( 'a' );
+		expect( withTrailing( 'b' ) ).toBe( 'a' );
+
+		expect( withoutTrailing( 'a' ) ).toBe( 'a' );
+		expect( withoutTrailing( 'b' ) ).toBe( 'a' );
+
+		jest.advanceTimersByTime( 256 );
+
+		expect( withCount ).toBe( 2 );
+		expect( withoutCount ).toBe( 1 );
+	} );
+
+	it( 'should not update `lastCalled`, at the end of the timeout, when `trailing` is `false`', () => {
+		let callCount = 0;
+
+		const throttled = throttle(
+			function () {
+				callCount++;
+			},
+			64,
+			{ trailing: false }
+		);
+
+		throttled();
+		throttled();
+
+		jest.advanceTimersByTime( 96 );
+
+		throttled();
+		throttled();
+
+		jest.advanceTimersByTime( 96 );
+
+		expect( callCount ).toBeGreaterThan( 1 );
+	} );
+
+	it( 'should work with a system time of `0`', () => {
+		let callCount = 0;
+		let dateCount = 0;
+
+		const globalDateNow = global.Date.now;
+		global.Date.now = function () {
+			return ++dateCount < 4 ? 0 : +new Date();
+		};
+
+		const throttled = throttle( ( value ) => {
+			callCount++;
+			return value;
+		}, 32 );
+
+		const results = [
+			throttled( 'a' ),
+			throttled( 'b' ),
+			throttled( 'c' ),
+		];
+		expect( results ).toStrictEqual( [ 'a', 'a', 'a' ] );
+		expect( callCount ).toBe( 1 );
+
+		jest.advanceTimersByTime( 64 );
+
+		expect( callCount ).toBe( 2 );
+		global.Date.now = globalDateNow;
+	} );
+} );


### PR DESCRIPTION
## What?
This PR introduces an in-house version of the `_.throttle()` function, along with some tests. I've borrowed most of the prior art by @sgomes (kudos for that), as indicated by his co-authorship of the first commit. We also update all `throttle` usages in Gutenberg to use the new version. Finally, we deprecate the original `_.throttle()` function so it will never be seen again in the repo.

## Why?

Lodash is known to unnecessarily inflate the bundle size of packages, and in most cases, it can be replaced with native language functionality. See these for more information and rationale:

* https://github.com/WordPress/gutenberg/issues/16938#issuecomment-602837246
* https://github.com/WordPress/gutenberg/issues/17025
* https://github.com/WordPress/gutenberg/issues/39495 

## How?

Similar to how. we introduced `debounce` in #43943, we're introducing `throttle` as another utility function in the `@wordpress/compose` package. That nicely gives us the opportunity to type it, which we're essentially doing. It comes with a few tests as well. We're exposing it externally since it will be used by other packages.

Furthermore, we update all `_.throttle()` calls to use the new utility function, including the `useThrottle()` hook. IMHO, that closes the loop of having an in-house hook for `useThrottle()` but using an external function for the actual throttling, giving us control on the types and functionality. 

You might ask why we're adding all the custom features (the `options` third argument) when they're not used internally. Well, because `useThrottle()` is exposed externally, and it was supporting all those options, so we have to continue supporting them for backwards compatibility. 

## Testing Instructions
* Verify all checks are green. 
* Smoke test all the editors.
* RN: Do some thorough smoke testing.
* Verify the places that use the new `throttle()` continue to work:
  * Drag and drop of blocks inside block areas
  * Drag and drop of images and videos inside block areas
  * Testing instructions from #33395