### PR TITLE
Blocks: Fix searching of blocks when description is non-string

### DIFF
--- a/packages/blocks/src/store/selectors.js
+++ b/packages/blocks/src/store/selectors.js
@@ -712,7 +712,8 @@ export function isMatchingSearchTerm( state, nameOrType, searchTerm ) {
 		isSearchMatch( blockType.title ) ||
 		some( blockType.keywords, isSearchMatch ) ||
 		isSearchMatch( blockType.category ) ||
-		isSearchMatch( blockType.description )
+		( typeof blockType.description === 'string' &&
+			isSearchMatch( blockType.description ) )
 	);
 }
 

--- a/packages/blocks/src/store/test/selectors.js
+++ b/packages/blocks/src/store/test/selectors.js
@@ -605,6 +605,10 @@ describe( 'selectors', () => {
 			...blockTypeBase,
 			category,
 		};
+		const blockTypeWithNonStringDescription = {
+			...blockTypeBase,
+			description: <div>writing flow</div>,
+		};
 
 		const state = {
 			blockTypes: {
@@ -617,6 +621,10 @@ describe( 'selectors', () => {
 			[ 'block type', blockType ],
 			[ 'block type without category', blockTypeWithoutCategory ],
 			[ 'block type without description', blockTypeWithoutDescription ],
+			[
+				'block type with non-string description',
+				blockTypeWithNonStringDescription,
+			],
 		] )( 'by %s', ( label, nameOrType ) => {
 			it( 'should return false if not match', () => {
 				const result = isMatchingSearchTerm(
@@ -690,7 +698,10 @@ describe( 'selectors', () => {
 				} );
 			}
 
-			if ( nameOrType.description ) {
+			if (
+				nameOrType.description &&
+				typeof nameOrType.description === 'string'
+			) {
 				it( 'should return true if match using the description', () => {
 					const result = isMatchingSearchTerm(
 						state,


### PR DESCRIPTION
## What?
This PR updates the block search by term (the `isMatchingSearchTerm` selector) to ignore non-string descriptions.

## Why?
Some plugins (see [here](https://github.com/Automattic/wp-calypso/blob/161c1e482376d34cfd65845e6e723cf558e2d8f1/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-description-links/src/index.tsx#L26)) tend to override the block descriptions and make them on-strings - in the example case, a React node. 

## How?
To make sure this doesn't break, we're ensuring that we run the comparison with block descriptions only when descriptions are strings. That's how it worked before when we used Lodash for removing accents (before https://github.com/WordPress/gutenberg/pull/43118). We're adding a test case for that as well.

## Testing Instructions
* Open global styles in the site editor.
* Click on "Blocks".
* Search for something.
* Verify it doesn't crash and search results work as they did before.
* Verify tests still pass: ` npm run test:unit packages/blocks/src/store/test/selectors.js`
