### PR TITLE
Scripts: Use start without watcher using --no-watch

### DIFF
--- a/packages/scripts/scripts/start.js
+++ b/packages/scripts/scripts/start.js
@@ -30,11 +30,14 @@ process.env.WP_SRC_DIRECTORY = hasArgInCLI( '--webpack-src-dir' )
 	? getArgFromCLI( '--webpack-src-dir' )
 	: 'src';
 
-const { status } = spawn(
-	resolveBin( 'webpack' ),
-	[ hasArgInCLI( '--hot' ) ? 'serve' : 'watch', ...getWebpackArgs() ],
-	{
-		stdio: 'inherit',
-	}
-);
+const webpackArgs = getWebpackArgs();
+if ( hasArgInCLI( '--hot' ) ) {
+	webpackArgs.unshift( 'serve' );
+} else if ( ! hasArgInCLI( '--no-watch' ) ) {
+	webpackArgs.unshift( 'watch' );
+}
+
+const { status } = spawn( resolveBin( 'webpack' ), webpackArgs, {
+	stdio: 'inherit',
+} );
 process.exit( status === null ? EXIT_ERROR_CODE : status );


### PR DESCRIPTION
## What?
Sometimes there's a use case, where we don't want to use "npm start" with the watcher.

## Why?
"npm start" directly followed by Ctrl+C, or certain CI environments that want to create unminified JS for analysis without changing the config,...

## How?
- change package.json "start" to "wp-scripts start --no-watch"
- run "npm start -- --no-watch"

## Testing Instructions
any gutenberg, isntead of "npm start" run "npm start -- --no-watch", which will create the unminified/dev JS without starting the watcher.
