### PR TITLE
Clean BlockMover component focus style

### DIFF
--- a/packages/block-editor/src/components/block-mover/style.scss
+++ b/packages/block-editor/src/components/block-mover/style.scss
@@ -15,7 +15,7 @@
 
 				// Focus style.
 				&::before {
-					height: 100%;
+					height: calc(100% - 4px);
 					width: calc(100% - 4px);
 				}
 			}
@@ -40,11 +40,6 @@
 				padding-left: 0 !important;
 				padding-right: 0 !important;
 				overflow: hidden;
-
-				// Focus style.
-				&::before {
-					height: 100%;
-				}
 			}
 
 			.block-editor-block-mover-button.is-up-button svg {

--- a/packages/block-editor/src/components/block-mover/style.scss
+++ b/packages/block-editor/src/components/block-mover/style.scss
@@ -16,7 +16,7 @@
 				// Focus style.
 				&::before {
 					height: 100%;
-					width: 100%;
+					width: calc(100% - 4px);
 				}
 			}
 


### PR DESCRIPTION
Follow-up on: #40379

## What?
This PR adjusts the position and size of the BlockMover component focus outline.

## Why?
In the vertical control, the focus outline is off-center.

![trunk_vertical](https://user-images.githubusercontent.com/54422211/190898644-7a5765bc-f2ab-427b-b96f-1fcb680ed2b5.png)

In the horizontal control, only this focus style extends the full vertical width.

![trunk_horizontal](https://user-images.githubusercontent.com/54422211/190898670-6f7dffa4-e991-4569-b2ef-e96aa4083fb4.png)

## How?
Adjusted position and size to match the focus style of the other buttons.
This will unify the focus outline of the block mover to 32 x 20px. This is the same size as the drag button focus outline.

## Screenshots or screencast
| | On trunk | On this branch |
| --- | --- | --- |
| Vertical | ![trunk_vertical](https://user-images.githubusercontent.com/54422211/190897422-14c2cfc3-11c8-4bd1-a463-10bf30d0cc3f.png) | ![pr_vertical](https://user-images.githubusercontent.com/54422211/190897421-4510a7f1-f706-4956-80aa-46609d3be89d.png) |
| Horizontal | ![trunk_horizontal](https://user-images.githubusercontent.com/54422211/190897423-f9b2c66a-04c9-43ec-b314-c32a591e5bac.png) | ![pr_horizontal](https://user-images.githubusercontent.com/54422211/190897424-b01563bf-c3a1-4994-a845-db7746a0ca28.png) |








