### PR TITLE
Block supports: allow overriding prettify options for enqueued CSS

### DIFF
--- a/lib/compat/wordpress-6.1/script-loader.php
+++ b/lib/compat/wordpress-6.1/script-loader.php
@@ -38,9 +38,20 @@ function gutenberg_enqueue_block_support_styles( $style, $priority = 10 ) {
 
 /**
  * Fetches, processes and compiles stored core styles, then combines and renders them to the page.
- * Styles are stored via the style engine API. See: packages/style-engine/README.md
+ * Styles are stored via the style engine API.
+ *
+ * See: https://developer.wordpress.org/block-editor/reference-guides/packages/packages-style-engine/
+ *
+ * @param array $options {
+ *     Optional. An array of options to pass to gutenberg_style_engine_get_stylesheet_from_context(). Default empty array.
+ *
+ *     @type bool $optimize Whether to optimize the CSS output, e.g., combine rules. Default is `false`.
+ *     @type bool $prettify Whether to add new lines and indents to output. Default is the test of whether the global constant `SCRIPT_DEBUG` is defined.
+ * }
+ *
+ * @return void
  */
-function gutenberg_enqueue_stored_styles() {
+function gutenberg_enqueue_stored_styles( $options = array() ) {
 	$is_block_theme   = wp_is_block_theme();
 	$is_classic_theme = ! $is_block_theme;
 
@@ -59,16 +70,16 @@ function gutenberg_enqueue_stored_styles() {
 	$compiled_core_stylesheet = '';
 	$style_tag_id             = 'core';
 	foreach ( $core_styles_keys as $style_key ) {
-		// Add comment to identify core styles sections in debugging.
-		if ( defined( 'SCRIPT_DEBUG' ) && SCRIPT_DEBUG ) {
+		// Adds comment to identify core styles sections in debugging.
+		if ( ( isset( $options['prettify'] ) && true === $options['prettify'] ) || ( defined( 'SCRIPT_DEBUG' ) && SCRIPT_DEBUG ) ) {
 			$compiled_core_stylesheet .= "/**\n * Core styles: $style_key\n */\n";
 		}
-		// Chain core store ids to signify what the styles contain.
+		// Chains core store ids to signify what the styles contain.
 		$style_tag_id             .= '-' . $style_key;
-		$compiled_core_stylesheet .= gutenberg_style_engine_get_stylesheet_from_context( $style_key );
+		$compiled_core_stylesheet .= gutenberg_style_engine_get_stylesheet_from_context( $style_key, $options );
 	}
 
-	// Combine Core styles.
+	// Combines Core styles.
 	if ( ! empty( $compiled_core_stylesheet ) ) {
 		wp_register_style( $style_tag_id, false, array(), true, true );
 		wp_add_inline_style( $style_tag_id, $compiled_core_stylesheet );
@@ -81,7 +92,7 @@ function gutenberg_enqueue_stored_styles() {
 		if ( in_array( $store_name, $core_styles_keys, true ) ) {
 			continue;
 		}
-		$styles = gutenberg_style_engine_get_stylesheet_from_context( $store_name );
+		$styles = gutenberg_style_engine_get_stylesheet_from_context( $store_name, $options );
 		if ( ! empty( $styles ) ) {
 			$key = "wp-style-engine-$store_name";
 			wp_register_style( $key, false, array(), true, true );

--- a/phpunit/script-loader.php
+++ b/phpunit/script-loader.php
@@ -7,9 +7,8 @@
 
 class WP_Script_Loader_Test extends WP_UnitTestCase {
 	/**
-	 * Clean up global scope.
+	 * Cleans up global scope.
 	 *
-	 * @global WP_Scripts $wp_scripts
 	 * @global WP_Styles $wp_styles
 	 */
 	public function clean_up_global_scope() {
@@ -19,8 +18,10 @@ class WP_Script_Loader_Test extends WP_UnitTestCase {
 	}
 	/**
 	 * Tests that stored CSS is enqueued.
+	 *
+	 * @covers ::wp_enqueue_stored_styles
 	 */
-	public function test_enqueue_stored_styles() {
+	public function test_should_enqueue_stored_styles() {
 		$core_styles_to_enqueue = array(
 			array(
 				'selector'     => '.saruman',
@@ -32,7 +33,7 @@ class WP_Script_Loader_Test extends WP_UnitTestCase {
 			),
 		);
 
-		// Enqueue a block supports (core styles).
+		// Enqueues a block supports (core styles).
 		gutenberg_style_engine_get_stylesheet_from_css_rules(
 			$core_styles_to_enqueue,
 			array(
@@ -51,7 +52,7 @@ class WP_Script_Loader_Test extends WP_UnitTestCase {
 			),
 		);
 
-		// Enqueue some other styles.
+		// Enqueues some other styles.
 		gutenberg_style_engine_get_stylesheet_from_css_rules(
 			$my_styles_to_enqueue,
 			array(
@@ -59,15 +60,17 @@ class WP_Script_Loader_Test extends WP_UnitTestCase {
 			)
 		);
 
-		gutenberg_enqueue_stored_styles();
+		gutenberg_enqueue_stored_styles(
+			array( 'prettify' => false )
+		);
 
-		$this->assertEquals(
+		$this->assertSame(
 			array( '.saruman{color:white;height:100px;border-style:solid;}' ),
 			wp_styles()->registered['core-block-supports']->extra['after'],
 			'Registered styles with handle of "core-block-supports" do not match expected value from Style Engine store.'
 		);
 
-		$this->assertEquals(
+		$this->assertSame(
 			array( '.gandalf{color:grey;height:90px;border-style:dotted;}' ),
 			wp_styles()->registered['wp-style-engine-my-styles']->extra['after'],
 			'Registered styles with handle of "wp-style-engine-my-styles" do not match expected value from the Style Engine store.'


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?

Allowing `gutenberg_enqueue_stored_styles()` to pass down formatting options to `gutenberg_style_engine_get_stylesheet_from_context()`.

Context: https://github.com/WordPress/wordpress-develop/pull/3259#issuecomment-1250403735

## Why?
So tests and other usages of `gutenberg_enqueue_stored_styles()` can bypass, or at least don't have to rely on, the global constant `SCRIPT_DEBUG` to determine whether the output is prettified.

## How?
See **"What?"**


## Testing Instructions
Run the tests!

`npm run test:unit:php /var/www/html/wp-content/plugins/gutenberg/phpunit/script-loader.php`

Smoke test a development site by creating a post with some block support styles, and checking the resulting styles in the frontend. 

For example, 

<details>

<summary>This example block code</summary>

```html

<!-- wp:group {"style":{"spacing":{"padding":{"top":"var:preset|spacing|50","right":"var:preset|spacing|50","bottom":"var:preset|spacing|50","left":"var:preset|spacing|50"},"blockGap":"var:preset|spacing|60"}},"layout":{"type":"constrained"}} -->
<div class="wp-block-group" style="padding-top:var(--wp--preset--spacing--50);padding-right:var(--wp--preset--spacing--50);padding-bottom:var(--wp--preset--spacing--50);padding-left:var(--wp--preset--spacing--50)"><!-- wp:columns -->
<div class="wp-block-columns"><!-- wp:column -->
<div class="wp-block-column"><!-- wp:paragraph -->
<p>test</p>
<!-- /wp:paragraph --></div>
<!-- /wp:column -->

<!-- wp:column -->
<div class="wp-block-column"></div>
<!-- /wp:column -->

<!-- wp:column -->
<div class="wp-block-column"></div>
<!-- /wp:column --></div>
<!-- /wp:columns -->

<!-- wp:columns {"style":{"spacing":{"padding":{"top":"var:preset|spacing|40","right":"var:preset|spacing|40","bottom":"var:preset|spacing|40","left":"var:preset|spacing|40"},"blockGap":{"top":"var:preset|spacing|60","left":"var:preset|spacing|60"}}}} -->
<div class="wp-block-columns" style="padding-top:var(--wp--preset--spacing--40);padding-right:var(--wp--preset--spacing--40);padding-bottom:var(--wp--preset--spacing--40);padding-left:var(--wp--preset--spacing--40)"><!-- wp:column {"style":{"spacing":{"padding":{"top":"var:preset|spacing|30","right":"var:preset|spacing|30","bottom":"var:preset|spacing|30","left":"var:preset|spacing|30"},"blockGap":"var:preset|spacing|60"}}} -->
<div class="wp-block-column" style="padding-top:var(--wp--preset--spacing--30);padding-right:var(--wp--preset--spacing--30);padding-bottom:var(--wp--preset--spacing--30);padding-left:var(--wp--preset--spacing--30)"><!-- wp:paragraph -->
<p>test</p>
<!-- /wp:paragraph --></div>
<!-- /wp:column -->

<!-- wp:column -->
<div class="wp-block-column"></div>
<!-- /wp:column -->

<!-- wp:column -->
<div class="wp-block-column"></div>
<!-- /wp:column --></div>
<!-- /wp:columns --></div>
<!-- /wp:group -->
```

</details>

Should generate the following CSS in development mode:

```html
<style id='core-block-supports-inline-css'>
/**
 * Core styles: block-supports
 */
.wp-block-columns.wp-container-4 {
	flex-wrap: nowrap;
}
.wp-block-column.wp-container-5.wp-block-column.wp-container-5 > * + * {
	margin-block-start: var:preset|spacing|60;
	margin-block-end: 0;
}
.wp-block-columns.wp-container-8 {
	flex-wrap: nowrap;
	gap: var(--wp--preset--spacing--60) var(--wp--preset--spacing--60);
}
.wp-block-group.wp-container-9.wp-block-group.wp-container-9 > * + * {
	margin-block-start: var(--wp--preset--spacing--60);
	margin-block-end: 0;
}
.wp-block-column.wp-container-5 > *,
.wp-block-group.wp-container-9 > * {
	margin-block-start: 0;
	margin-block-end: 0;
}

</style>
```

