### PR TITLE
Fix: Block label and title don't consider variations

### DIFF
--- a/packages/block-editor/src/components/block-list/use-block-props/index.js
+++ b/packages/block-editor/src/components/block-list/use-block-props/index.js
@@ -11,6 +11,7 @@ import { __, sprintf } from '@wordpress/i18n';
 import {
 	__unstableGetBlockProps as getBlockProps,
 	getBlockType,
+	store as blocksStore,
 } from '@wordpress/blocks';
 import { useMergeRefs, useDisabled } from '@wordpress/compose';
 import { useSelect } from '@wordpress/data';
@@ -77,6 +78,7 @@ export function useBlockProps( props = {}, { __unstableIsHtml } = {} ) {
 	} = useSelect(
 		( select ) => {
 			const {
+				getBlockAttributes,
 				getBlockIndex,
 				getBlockMode,
 				getBlockName,
@@ -87,19 +89,22 @@ export function useBlockProps( props = {}, { __unstableIsHtml } = {} ) {
 				isAncestorMultiSelected,
 				isFirstMultiSelectedBlock,
 			} = select( blockEditorStore );
+			const { getActiveBlockVariation } = select( blocksStore );
 			const isSelected = isBlockSelected( clientId );
 			const isPartOfMultiSelection =
 				isBlockMultiSelected( clientId ) ||
 				isAncestorMultiSelected( clientId );
 			const blockName = getBlockName( clientId );
 			const blockType = getBlockType( blockName );
+			const attributes = getBlockAttributes( clientId );
+			const match = getActiveBlockVariation( blockName, attributes );
 
 			return {
 				index: getBlockIndex( clientId ),
 				mode: getBlockMode( clientId ),
 				name: blockName,
 				blockApiVersion: blockType?.apiVersion || 1,
-				blockTitle: blockType?.title,
+				blockTitle: match?.title || blockType?.title,
 				isPartOfSelection: isSelected || isPartOfMultiSelection,
 				adjustScrolling:
 					isSelected || isFirstMultiSelectedBlock( clientId ),


### PR DESCRIPTION
Fix #44249

## What?
This PR fixes a problem where the `data-title` and `aria-label` attributes show information about the original block when a variation block is inserted.

## Why?
As shown in the following screenshot, I believe that the block names should be displayed with variations given priority.
The following is a Categories block, which is a variation of `core/post-terms`, and I think the block name should be unified as "Categories" instead of "Post Terms".

![variation](https://user-images.githubusercontent.com/54422211/190947709-249579bd-81a7-4c6a-8199-df7469265233.png)

## How?
I found that [useBlockDisplayInformation](https://github.com/WordPress/gutenberg/blob/33d84b036592a5bf31af05b7710f3b2b14163dc4/packages/block-editor/src/components/use-block-display-information/index.js#L52-L66) takes into account the title of the variation, so we used the same logic.

## Testing Instructions
- Insert variation blocks such as `core/post-terms`, `core/embed`, `core/social-link`, etc.
- Confirm that the `data-title` and `aria-label` attributes are set to the title of the variation, like the block names shown elsewhere.

## Screenshots or screencast

### On trunk

![trunk_youtube](https://user-images.githubusercontent.com/54422211/190949133-ad265697-85e7-4c5e-9944-dd92e2dcbb6b.png)

![trunk_social_link](https://user-images.githubusercontent.com/54422211/190949139-6417cd3c-8252-41cb-848c-6904bfce3c0a.png)

### On this branch

![pr_youtube](https://user-images.githubusercontent.com/54422211/190949147-3f5e761a-e349-4139-ae87-a3701abd6d24.png)

![pr_social_link](https://user-images.githubusercontent.com/54422211/190949155-9ec05912-5b6c-40f7-be16-85fa2c8d5a78.png)
