### PR TITLE
Global styles: Remove the beta label from global styles header

### DIFF
--- a/packages/edit-site/src/components/sidebar/global-styles-sidebar.js
+++ b/packages/edit-site/src/components/sidebar/global-styles-sidebar.js
@@ -29,9 +29,6 @@ export default function GlobalStylesSidebar() {
 				<Flex>
 					<FlexBlock>
 						<strong>{ __( 'Styles' ) }</strong>
-						<span className="edit-site-global-styles-sidebar__beta">
-							{ __( 'Beta' ) }
-						</span>
 					</FlexBlock>
 					<FlexItem>
 						<DropdownMenu

--- a/packages/edit-site/src/components/sidebar/style.scss
+++ b/packages/edit-site/src/components/sidebar/style.scss
@@ -78,8 +78,7 @@
 	padding: $grid-unit-20;
 }
 
-.edit-site-navigation-sidebar__beta,
-.edit-site-global-styles-sidebar__beta {
+.edit-site-navigation-sidebar__beta {
 	display: inline-flex;
 	margin-left: $grid-unit-10;
 	padding: 0 $grid-unit-10;


### PR DESCRIPTION
## What?
Removes the Beta label from global styles.

## Why?
Fixes: #44135

## How?
Deletes relevant code

## Testing Instructions
Open global styles in the site editor and make sure the Beta label no longer displays

## Screenshots or screencast 

Before:
<img width="278" alt="styles-beta-before" src="https://user-images.githubusercontent.com/3629020/190951164-33864f91-b6a1-44df-ab45-04bb7a49cff7.png">

After:
<img width="281" alt="styles-beta-after" src="https://user-images.githubusercontent.com/3629020/190951177-79fca402-238d-4aed-9a58-d44a7589bec3.png">
