### PR TITLE
Add theme.json schema tests

### DIFF
--- a/docs/reference-guides/theme-json-reference/theme-json-living.md
+++ b/docs/reference-guides/theme-json-reference/theme-json-living.md
@@ -139,10 +139,10 @@ Border styles.
 | radius | undefined |  |
 | style | string |  |
 | width | string |  |
-| top | undefined |  |
-| right | undefined |  |
-| bottom | undefined |  |
-| left | undefined |  |
+| top | object | color, style, width |
+| right | object | color, style, width |
+| bottom | object | color, style, width |
+| left | object | color, style, width |
 
 ---
 

--- a/schemas/json/theme.json
+++ b/schemas/json/theme.json
@@ -919,60 +919,76 @@
 							"type": "string"
 						},
 						"top": {
-							"color": {
-								"description": "Sets the `border-top-color` CSS property.",
-								"type": "string"
+							"type": "object",
+							"properties": {
+								"color": {
+									"description": "Sets the `border-top-color` CSS property.",
+									"type": "string"
+								},
+								"style": {
+									"description": "Sets the `border-top-style` CSS property.",
+									"type": "string"
+								},
+								"width": {
+									"description": "Sets the `border-top-width` CSS property.",
+									"type": "string"
+								}
 							},
-							"style": {
-								"description": "Sets the `border-top-style` CSS property.",
-								"type": "string"
-							},
-							"width": {
-								"description": "Sets the `border-top-width` CSS property.",
-								"type": "string"
-							}
+							"additionalProperties": false
 						},
 						"right": {
-							"color": {
-								"description": "Sets the `border-right-color` CSS property.",
-								"type": "string"
+							"type": "object",
+							"properties": {
+								"color": {
+									"description": "Sets the `border-right-color` CSS property.",
+									"type": "string"
+								},
+								"style": {
+									"description": "Sets the `border-right-style` CSS property.",
+									"type": "string"
+								},
+								"width": {
+									"description": "Sets the `border-right-width` CSS property.",
+									"type": "string"
+								}
 							},
-							"style": {
-								"description": "Sets the `border-right-style` CSS property.",
-								"type": "string"
-							},
-							"width": {
-								"description": "Sets the `border-right-width` CSS property.",
-								"type": "string"
-							}
+							"additionalProperties": false
 						},
 						"bottom": {
-							"color": {
-								"description": "Sets the `border-bottom-color` CSS property.",
-								"type": "string"
+							"type": "object",
+							"properties": {
+								"color": {
+									"description": "Sets the `border-bottom-color` CSS property.",
+									"type": "string"
+								},
+								"style": {
+									"description": "Sets the `border-bottom-style` CSS property.",
+									"type": "string"
+								},
+								"width": {
+									"description": "Sets the `border-bottom-width` CSS property.",
+									"type": "string"
+								}
 							},
-							"style": {
-								"description": "Sets the `border-bottom-style` CSS property.",
-								"type": "string"
-							},
-							"width": {
-								"description": "Sets the `border-bottom-width` CSS property.",
-								"type": "string"
-							}
+							"additionalProperties": false
 						},
 						"left": {
-							"color": {
-								"description": "Sets the `border-left-color` CSS property.",
-								"type": "string"
+							"type": "object",
+							"properties": {
+								"color": {
+									"description": "Sets the `border-left-color` CSS property.",
+									"type": "string"
+								},
+								"style": {
+									"description": "Sets the `border-left-style` CSS property.",
+									"type": "string"
+								},
+								"width": {
+									"description": "Sets the `border-left-width` CSS property.",
+									"type": "string"
+								}
 							},
-							"style": {
-								"description": "Sets the `border-left-style` CSS property.",
-								"type": "string"
-							},
-							"width": {
-								"description": "Sets the `border-left-width` CSS property.",
-								"type": "string"
-							}
+							"additionalProperties": false
 						}
 					},
 					"additionalProperties": false

--- a/schemas/json/theme.json
+++ b/schemas/json/theme.json
@@ -570,7 +570,9 @@
 			"type": "object",
 			"properties": {
 				"core/archives": {
-					"description": "Archive block. Display a monthly archive of your posts. This block has no block-level settings"
+					"type": "object",
+					"description": "Archive block. Display a monthly archive of your posts. This block has no block-level settings",
+					"additionalProperties": false
 				},
 				"core/audio": {
 					"$ref": "#/definitions/settingsPropertiesComplete"

--- a/schemas/json/theme.json
+++ b/schemas/json/theme.json
@@ -433,7 +433,6 @@
 												},
 												"fontWeight": {
 													"description": "List of available font weights, separated by a space.",
-													"type": "string",
 													"default": "400",
 													"oneOf": [
 														{

--- a/schemas/json/theme.json
+++ b/schemas/json/theme.json
@@ -570,8 +570,7 @@
 			"type": "object",
 			"properties": {
 				"core/archives": {
-					"description": "Archive block. Display a monthly archive of your posts. This block has no block-level settings",
-					"additionalProperties": false
+					"description": "Archive block. Display a monthly archive of your posts. This block has no block-level settings"
 				},
 				"core/audio": {
 					"$ref": "#/definitions/settingsPropertiesComplete"

--- a/schemas/json/theme.json
+++ b/schemas/json/theme.json
@@ -380,18 +380,25 @@
 									},
 									"fluid": {
 										"description": "Specifics the minimum and maximum font size value of a fluid font size. Set to `false` to bypass fluid calculations and use the static `size` value.",
-										"type": [ "object", "boolean" ],
-										"properties": {
-											"min": {
-												"description": "A min font size for fluid font size calculations in px, rem or em.",
-												"type": "string"
+										"oneOf": [
+											{
+												"type": "object",
+												"properties": {
+													"min": {
+														"description": "A min font size for fluid font size calculations in px, rem or em.",
+														"type": "string"
+													},
+													"max": {
+														"description": "A max font size for fluid font size calculations in px, rem or em.",
+														"type": "string"
+													}
+												},
+												"additionalProperties": false
 											},
-											"max": {
-												"description": "A max font size for fluid font size calculations in px, rem or em.",
-												"type": "string"
+											{
+												"type": "boolean"
 											}
-										},
-										"additionalProperties": false
+										]
 									}
 								},
 								"additionalProperties": false

--- a/schemas/json/theme.json
+++ b/schemas/json/theme.json
@@ -871,6 +871,7 @@
 			}
 		},
 		"stylesProperties": {
+			"type": "object",
 			"properties": {
 				"border": {
 					"description": "Border styles.",

--- a/schemas/json/theme.json
+++ b/schemas/json/theme.json
@@ -8,6 +8,7 @@
 			"reference": "https://developer.wordpress.org/block-editor/how-to-guides/themes/theme-json/"
 		},
 		"settingsPropertiesAppearanceTools": {
+			"type": "object",
 			"properties": {
 				"appearanceTools": {
 					"description": "Setting that enables the following UI tools:\n\n- border: color, radius, style, width\n- color: link\n- spacing: blockGap, margin, padding\n- typography: lineHeight",
@@ -26,6 +27,7 @@
 			}
 		},
 		"settingsPropertiesBorder": {
+			"type": "object",
 			"properties": {
 				"border": {
 					"description": "Settings related to borders.",
@@ -57,6 +59,7 @@
 			}
 		},
 		"settingsPropertiesColor": {
+			"type": "object",
 			"properties": {
 				"color": {
 					"description": "Settings related to colors.",
@@ -186,6 +189,7 @@
 			}
 		},
 		"settingsPropertiesLayout": {
+			"type": "object",
 			"properties": {
 				"layout": {
 					"description": "Settings related to layout.",
@@ -205,6 +209,7 @@
 			}
 		},
 		"settingsPropertiesSpacing": {
+			"type": "object",
 			"properties": {
 				"spacing": {
 					"description": "Settings related to spacing.",
@@ -305,6 +310,7 @@
 			}
 		},
 		"settingsPropertiesTypography": {
+			"type": "object",
 			"properties": {
 				"typography": {
 					"description": "Settings related to typography.",
@@ -515,6 +521,7 @@
 			}
 		},
 		"settingsPropertiesCustom": {
+			"type": "object",
 			"properties": {
 				"custom": {
 					"description": "Generate custom CSS custom properties of the form `--wp--custom--{key}--{nested-key}: {value};`. `camelCased` keys are transformed to `kebab-case` as to follow the CSS property naming schema. Keys at different depth levels are separated by `--`, so keys should not include `--` in the name.",
@@ -570,11 +577,13 @@
 					"$ref": "#/definitions/settingsPropertiesComplete"
 				},
 				"core/button": {
+					"type": "object",
 					"allOf": [
 						{
 							"$ref": "#/definitions/settingsPropertiesAppearanceTools"
 						},
 						{
+							"type": "object",
 							"properties": {
 								"border": {
 									"description": "Settings related to borders.\nGutenberg plugin required.",

--- a/test/integration/theme-schema.test.js
+++ b/test/integration/theme-schema.test.js
@@ -1,0 +1,23 @@
+/**
+ * External dependencies
+ */
+import Ajv from 'ajv-draft-04';
+
+/**
+ * Internal dependencies
+ */
+import themeSchema from '../../schemas/json/theme.json';
+
+describe( 'theme.json schema', () => {
+	const ajv = new Ajv( {
+		// Used for matching unknown blocks without repeating core blocks names
+		// with patternProperties in settings.blocks and settings.styles
+		allowMatchingProperties: true,
+	} );
+
+	it( 'compiles in strict mode', async () => {
+		const result = ajv.compile( themeSchema );
+
+		expect( result.errors ).toBe( null );
+	} );
+} );

--- a/test/integration/theme-schema.test.js
+++ b/test/integration/theme-schema.test.js
@@ -15,7 +15,11 @@ describe( 'theme.json schema', () => {
 		allowMatchingProperties: true,
 	} );
 
-	it( 'compiles in strict mode', async () => {
+	it( 'strictly adheres to the draft-04 meta schema', () => {
+		// Use ajv.compile instead of ajv.validateSchema to validate the schema
+		// because validateSchema only checks syntax, whereas, compile checks
+		// if the schema is semantically correct with strict mode.
+		// See https://github.com/ajv-validator/ajv/issues/1434#issuecomment-822982571
 		const result = ajv.compile( themeSchema );
 
 		expect( result.errors ).toBe( null );


### PR DESCRIPTION
## What?

See original PR https://github.com/WordPress/gutenberg/pull/43801. This PR does not include nesting-specific changes, just the `theme.json` test additions and fixes to the current schema. Relevant portions of the original PR discussion have been copied here.

These changes were made:

1. Add schema validation in `theme-schema.test.js` based on existing [block schema tests](https://github.com/WordPress/gutenberg/blob/trunk/test/integration/blocks-schema.test.js). The existing schema failed validation with [Ajv's strict mode](https://ajv.js.org/strict-mode.html) against `draft-04`, mostly due to some missing `type` identifiers and a handful of other small changes.
2. Fix the existing strict mode errors.
3. Update autogenerated docs

## Why?

From [Ajv's strict mode](https://ajv.js.org/strict-mode.html) documentation:

> Strict mode intends to prevent any unexpected behaviours or silently ignored mistakes in user schemas

Strict mode testing fixes a few missing/unknown identifiers in the current schema, and should help prevent accidental mistakes going forward.

## How

Some minor changes were made to the original schema to make it validate correctly against `draft-04`. To view the original errors, check out the `test/integration/theme-schema.test.js` test file [from the fork repository](https://github.com/alecgeatches/gutenberg) branch against `trunk` and use this command to run validation checks:

```bash
git checkout add/theme-schema-updates-and-docs -- test/integration/theme-schema.test.js
npx wp-scripts test-unit-js --config test/unit/jest.config.js --no-cache theme-schema.test.js
```

Running the test gives this validation result:

<details>
  
<summary>Click to expand</summary>
  
```bash
$ npx wp-scripts test-unit-js --config test/unit/jest.config.js --no-cache theme-schema.test.js
 FAIL  test/integration/theme-schema.test.js
  theme.json schema
    ✕ compiles in strict mode (82 ms)

  ● theme.json schema › compiles in strict mode

    strict mode: unknown keyword: "color"

      17 |
      18 |      it( 'compiles in strict mode', async () => {
    > 19 |              const result = ajv.compile( themeSchema );
         |                                 ^
      20 |
      21 |              expect( result.errors ).toBe( null );
      22 |      } );

      at checkStrictMode (node_modules/ajv/lib/compile/util.ts:211:28)
      at checkUnknownRules (node_modules/ajv/lib/compile/util.ts:27:22)
      at alwaysValidSchema (node_modules/ajv/lib/compile/util.ts:17:3)
      at node_modules/ajv/lib/vocabularies/applicator/properties.ts:23:65
          at Array.filter (<anonymous>)
      at Object.code (node_modules/ajv/lib/vocabularies/applicator/properties.ts:23:33)
      at keywordCode (node_modules/ajv/lib/compile/validate/index.ts:523:9)
      at node_modules/ajv/lib/compile/validate/index.ts:265:9
      at CodeGen.code (node_modules/ajv/lib/compile/codegen/index.ts:525:33)
      at CodeGen.block (node_modules/ajv/lib/compile/codegen/index.ts:680:20)
      at iterateKeywords (node_modules/ajv/lib/compile/validate/index.ts:262:7)
      at groupKeywords (node_modules/ajv/lib/compile/validate/index.ts:241:7)
      at node_modules/ajv/lib/compile/validate/index.ts:233:38
      at CodeGen.code (node_modules/ajv/lib/compile/codegen/index.ts:525:33)
      at CodeGen.block (node_modules/ajv/lib/compile/codegen/index.ts:680:20)
      at schemaKeywords (node_modules/ajv/lib/compile/validate/index.ts:232:7)
      at typeAndKeywords (node_modules/ajv/lib/compile/validate/index.ts:161:3)
      at subSchemaObjCode (node_modules/ajv/lib/compile/validate/index.ts:147:3)
      at subschemaCode (node_modules/ajv/lib/compile/validate/index.ts:124:7)
      at KeywordCxt.subschema (node_modules/ajv/lib/compile/validate/index.ts:491:5)
      at applyPropertySchema (node_modules/ajv/lib/vocabularies/applicator/properties.ts:45:11)
      at Object.code (node_modules/ajv/lib/vocabularies/applicator/properties.ts:32:9)
      at keywordCode (node_modules/ajv/lib/compile/validate/index.ts:523:9)
      at node_modules/ajv/lib/compile/validate/index.ts:265:9
      at CodeGen.code (node_modules/ajv/lib/compile/codegen/index.ts:525:33)
      at CodeGen.block (node_modules/ajv/lib/compile/codegen/index.ts:680:20)
      at iterateKeywords (node_modules/ajv/lib/compile/validate/index.ts:262:7)
      at groupKeywords (node_modules/ajv/lib/compile/validate/index.ts:241:7)
      at node_modules/ajv/lib/compile/validate/index.ts:233:38
      at CodeGen.code (node_modules/ajv/lib/compile/codegen/index.ts:525:33)
      at CodeGen.block (node_modules/ajv/lib/compile/codegen/index.ts:680:20)
      at schemaKeywords (node_modules/ajv/lib/compile/validate/index.ts:232:7)
      at typeAndKeywords (node_modules/ajv/lib/compile/validate/index.ts:161:3)
      at subSchemaObjCode (node_modules/ajv/lib/compile/validate/index.ts:147:3)
      at subschemaCode (node_modules/ajv/lib/compile/validate/index.ts:124:7)
      at KeywordCxt.subschema (node_modules/ajv/lib/compile/validate/index.ts:491:5)
      at inlineRefSchema (node_modules/ajv/lib/vocabularies/core/ref.ts:40:26)
      at Object.code (node_modules/ajv/lib/vocabularies/core/ref.ts:21:12)
      at keywordCode (node_modules/ajv/lib/compile/validate/index.ts:523:9)
      at node_modules/ajv/lib/compile/validate/index.ts:228:21
      at CodeGen.code (node_modules/ajv/lib/compile/codegen/index.ts:525:33)
      at CodeGen.block (node_modules/ajv/lib/compile/codegen/index.ts:680:20)
      at schemaKeywords (node_modules/ajv/lib/compile/validate/index.ts:228:9)
      at typeAndKeywords (node_modules/ajv/lib/compile/validate/index.ts:161:3)
      at subSchemaObjCode (node_modules/ajv/lib/compile/validate/index.ts:147:3)
      at subschemaCode (node_modules/ajv/lib/compile/validate/index.ts:124:7)
      at KeywordCxt.subschema (node_modules/ajv/lib/compile/validate/index.ts:491:5)
      at node_modules/ajv/lib/vocabularies/applicator/allOf.ts:15:26
          at Array.forEach (<anonymous>)
      at Object.code (node_modules/ajv/lib/vocabularies/applicator/allOf.ts:13:12)
      at keywordCode (node_modules/ajv/lib/compile/validate/index.ts:523:9)
      at node_modules/ajv/lib/compile/validate/index.ts:265:9
      at CodeGen.code (node_modules/ajv/lib/compile/codegen/index.ts:525:33)
      at CodeGen.block (node_modules/ajv/lib/compile/codegen/index.ts:680:20)
      at iterateKeywords (node_modules/ajv/lib/compile/validate/index.ts:262:7)
      at groupKeywords (node_modules/ajv/lib/compile/validate/index.ts:248:7)
      at node_modules/ajv/lib/compile/validate/index.ts:233:38
      at CodeGen.code (node_modules/ajv/lib/compile/codegen/index.ts:525:33)
      at CodeGen.block (node_modules/ajv/lib/compile/codegen/index.ts:680:20)
      at schemaKeywords (node_modules/ajv/lib/compile/validate/index.ts:232:7)
      at typeAndKeywords (node_modules/ajv/lib/compile/validate/index.ts:161:3)
      at subSchemaObjCode (node_modules/ajv/lib/compile/validate/index.ts:147:3)
      at subschemaCode (node_modules/ajv/lib/compile/validate/index.ts:124:7)
      at KeywordCxt.subschema (node_modules/ajv/lib/compile/validate/index.ts:491:5)
      at applyPropertySchema (node_modules/ajv/lib/vocabularies/applicator/properties.ts:45:11)
      at Object.code (node_modules/ajv/lib/vocabularies/applicator/properties.ts:32:9)
      at keywordCode (node_modules/ajv/lib/compile/validate/index.ts:523:9)
      at node_modules/ajv/lib/compile/validate/index.ts:265:9
      at CodeGen.code (node_modules/ajv/lib/compile/codegen/index.ts:525:33)
      at CodeGen.block (node_modules/ajv/lib/compile/codegen/index.ts:680:20)
      at iterateKeywords (node_modules/ajv/lib/compile/validate/index.ts:262:7)
      at groupKeywords (node_modules/ajv/lib/compile/validate/index.ts:241:7)
      at node_modules/ajv/lib/compile/validate/index.ts:233:38
      at CodeGen.code (node_modules/ajv/lib/compile/codegen/index.ts:525:33)
      at CodeGen.block (node_modules/ajv/lib/compile/codegen/index.ts:680:20)
      at schemaKeywords (node_modules/ajv/lib/compile/validate/index.ts:232:7)
      at typeAndKeywords (node_modules/ajv/lib/compile/validate/index.ts:161:3)
      at node_modules/ajv/lib/compile/validate/index.ts:100:5
      at CodeGen.code (node_modules/ajv/lib/compile/codegen/index.ts:525:33)
      at node_modules/ajv/lib/compile/validate/index.ts:61:45
      at CodeGen.code (node_modules/ajv/lib/compile/codegen/index.ts:525:33)
      at CodeGen.func (node_modules/ajv/lib/compile/codegen/index.ts:699:24)
      at validateFunction (node_modules/ajv/lib/compile/validate/index.ts:60:9)
      at topSchemaObjCode (node_modules/ajv/lib/compile/validate/index.ts:94:3)
      at validateFunctionCode (node_modules/ajv/lib/compile/validate/index.ts:42:7)
      at Ajv.compileSchema (node_modules/ajv/lib/compile/index.ts:163:25)
      at Ajv._compileSchemaEnv (node_modules/ajv/lib/core.ts:718:24)
      at Ajv.compile (node_modules/ajv/lib/core.ts:370:34)
      at Object.<anonymous> (test/integration/theme-schema.test.js:19:22)
          at runMicrotasks (<anonymous>)

  ● theme.json schema › compiles in strict mode

    expect(jest.fn()).not.toHaveWarned(expected)

    Expected mock function not to be called but it was called with:
    ["strict mode: missing type \"object\" for keyword \"properties\" at \"#/definitions/settingsPropertiesAppearanceTools\" (strictTypes)"],
    ["strict mode: missing type \"object\" for keyword \"properties\" at \"#/definitions/settingsPropertiesBorder\" (strictTypes)"],
    ["strict mode: missing type \"object\" for keyword \"properties\" at \"#/definitions/settingsPropertiesColor\" (strictTypes)"],
    ["strict mode: missing type \"object\" for keyword \"properties\" at \"#/definitions/settingsPropertiesLayout\" (strictTypes)"],
    ["strict mode: missing type \"object\" for keyword \"properties\" at \"#/definitions/settingsPropertiesSpacing\" (strictTypes)"],
    ["strict mode: missing type \"object\" for keyword \"properties\" at \"#/definitions/settingsPropertiesTypography\" (strictTypes)"],
    ["strict mode: use allowUnionTypes to allow union type keyword at \"#/definitions/settingsPropertiesTypography/properties/typography/properties/fontSizes/items/properties/fluid\" (strictTypes)"],
    ["strict mode: type \"integer\" not allowed by context \"string\" at \"#/definitions/settingsPropertiesTypography/properties/typography/properties/fontFamilies/items/properties/fontFace/items/properties/fontWeight/oneOf/1\" (strictTypes)"],
    ["strict mode: missing type \"object\" for keyword \"properties\" at \"#\" (strictTypes)"],
    ["strict mode: missing type \"object\" for keyword \"additionalProperties\" at \"#/properties/core~1archives\" (strictTypes)"],
    ["strict mode: missing type \"object\" for keyword \"properties\" at \"#/definitions/settingsPropertiesAppearanceTools\" (strictTypes)"],
    ["strict mode: missing type \"object\" for keyword \"properties\" at \"#/properties/core~1button/allOf/1\" (strictTypes)"],
    ["strict mode: missing type \"object\" for keyword \"properties\" at \"#/definitions/settingsPropertiesColor\" (strictTypes)"],
    ["strict mode: missing type \"object\" for keyword \"properties\" at \"#/definitions/settingsPropertiesLayout\" (strictTypes)"],
    ["strict mode: missing type \"object\" for keyword \"properties\" at \"#/definitions/settingsPropertiesSpacing\" (strictTypes)"],
    ["strict mode: missing type \"object\" for keyword \"properties\" at \"#/definitions/settingsPropertiesTypography\" (strictTypes)"],
    ["strict mode: use allowUnionTypes to allow union type keyword at \"#/definitions/settingsPropertiesTypography/properties/typography/properties/fontSizes/items/properties/fluid\" (strictTypes)"],
    ["strict mode: type \"integer\" not allowed by context \"string\" at \"#/definitions/settingsPropertiesTypography/properties/typography/properties/fontFamilies/items/properties/fontFace/items/properties/fontWeight/oneOf/1\" (strictTypes)"],
    ["strict mode: missing type \"object\" for keyword \"properties\" at \"#/definitions/stylesProperties\" (strictTypes)"]

      30 |      function assertExpectedCalls() {
      31 |              if ( spy.assertionsNumber === 0 && spy.mock.calls.length > 0 ) {
    > 32 |                      expect( console ).not[ matcherName ]();
         |                      ^
      33 |              }
      34 |      }
      35 |

      at Object.assertExpectedCalls (packages/jest-console/src/index.js:32:4)
          at runMicrotasks (<anonymous>)
      at TestScheduler.scheduleTests (node_modules/@jest/core/build/TestScheduler.js:333:13)
      at runJest (node_modules/@jest/core/build/runJest.js:404:19)
      at _run10000 (node_modules/@jest/core/build/cli/index.js:320:7)
      at runCLI (node_modules/@jest/core/build/cli/index.js:173:3)

Test Suites: 1 failed, 1 total
Tests:       1 failed, 1 total
Snapshots:   0 total
Time:        1.998 s
Ran all test suites matching /theme-schema.test.js/i.
```
  
</details>

Those individual fixes are documented in these commits:

1. [Fix missing property object types](https://github.com/alecgeatches/gutenberg/pull/11/commits/ce7e75abba02817a4b1495ea146f275fcbd7b182) for errors like:

    ```
    strict mode: missing type "object" for keyword "properties" at "#/definitions/settingsPropertiesAppearanceTools" (strictTypes)
    ```
2. [Remove type conflict in fontWeight](https://github.com/alecgeatches/gutenberg/pull/11/commits/66bf0b8e6e3afa8ba23f6ddb4d6fe6a3b8deb47c) for this error:

    ```
    strict mode: type "integer" not allowed by context "string" at "#/definitions/settingsPropertiesTypography/properties/typography/properties/fontFamilies/items/properties/fontFace/items/properties/fontWeight/oneOf/1" (strictTypes)
    ```
4. [Refactor fontSizes.fluid into non-union type](https://github.com/alecgeatches/gutenberg/pull/11/commits/5700764827356bfaee1e201c2d3eb7ec151a5716) for this error:

    ```
    strict mode: use allowUnionTypes to allow union type keyword at "#/definitions/settingsPropertiesTypography/properties/typography/properties/fontSizes/items/properties/fluid" (strictTypes)
    ```
5. [Fix core/archives non-property block having additionalProperties: false](https://github.com/alecgeatches/gutenberg/pull/11/commits/6095a7ab7210ae9ebb3f119283c8c0a1d6886d58) for this error:

    ```
    strict mode: missing type "object" for keyword "additionalProperties" at "#/properties/core/archives" (strictTypes)
    ```
6. Some additional fixes in [Fix stylesProperties type](https://github.com/alecgeatches/gutenberg/pull/11/commits/cd3e2b33f501bb11d8c4f99cd32d3f9977b2b4c4) and [Fix styleProperties border direction properties](https://github.com/alecgeatches/gutenberg/pull/11/commits/441f338b6a09d65f9312923662edda49d7757e8c) that cropped up after the previous fixes, mostly addressing additional `properties` object types missing. This also fixes the `border` [autogenerated documentation](https://github.com/alecgeatches/gutenberg/blob/add/theme-schema-updates-and-docs/docs/reference-guides/theme-json-reference/theme-json-living.md#border-1) for `top`/`bottom`/`left`/`right`.

7. Remove sub-properties from `core/archive` in https://github.com/WordPress/gutenberg/commit/3c3291593f7926705e1efd1af5ae6bc232022f33 per [this discussion](https://github.com/WordPress/gutenberg/pull/43801#discussion_r961970166).

## Testing Instructions

To test theme validation, run:

```bash
npx wp-scripts test-unit-js --config test/unit/jest.config.js --no-cache theme-schema.test.js
```