### PR TITLE
Block supports: prioritize prettify options over SCRIPT_DEBUG

### DIFF
--- a/lib/compat/wordpress-6.1/script-loader.php
+++ b/lib/compat/wordpress-6.1/script-loader.php
@@ -70,8 +70,9 @@ function gutenberg_enqueue_stored_styles( $options = array() ) {
 	$compiled_core_stylesheet = '';
 	$style_tag_id             = 'core';
 	foreach ( $core_styles_keys as $style_key ) {
-		// Adds comment to identify core styles sections in debugging.
-		if ( ( isset( $options['prettify'] ) && true === $options['prettify'] ) || ( defined( 'SCRIPT_DEBUG' ) && SCRIPT_DEBUG ) ) {
+		// Adds comment if code is prettified to identify core styles sections in debugging.
+		$should_prettify = isset( $options['prettify'] ) ? true === $options['prettify'] : defined( 'SCRIPT_DEBUG' ) && SCRIPT_DEBUG;
+		if ( $should_prettify ) {
 			$compiled_core_stylesheet .= "/**\n * Core styles: $style_key\n */\n";
 		}
 		// Chains core store ids to signify what the styles contain.


### PR DESCRIPTION
## What?
Update to https://github.com/WordPress/gutenberg/pull/44248

Let's make sure we prioritize the incoming prettify option over the SCRIPT_DEBUG setting.

Context: https://github.com/WordPress/wordpress-develop/pull/3273

## Why?
If `$options['prettify']` is set we want to use it, even if `false`. The `||` operand did not permit this.

## How?
Check for the option using `isset` and use it if found.

## Testing Instructions
Run `npm run test:unit:php /var/www/html/wp-content/plugins/gutenberg/phpunit/script-loader.php`

