### PR TITLE
Avoid showing the recursion warning in previews when replacing template parts

### DIFF
--- a/packages/block-library/src/template-part/edit/index.js
+++ b/packages/block-library/src/template-part/edit/index.js
@@ -133,64 +133,66 @@ export default function TemplatePartEdit( {
 	}
 
 	return (
-		<RecursionProvider uniqueId={ templatePartId }>
-			<TemplatePartAdvancedControls
-				tagName={ tagName }
-				setAttributes={ setAttributes }
-				isEntityAvailable={ isEntityAvailable }
-				templatePartId={ templatePartId }
-				defaultWrapper={ areaObject.tagName }
-			/>
-			{ isPlaceholder && (
-				<TagName { ...blockProps }>
-					<TemplatePartPlaceholder
-						area={ attributes.area }
-						templatePartId={ templatePartId }
-						clientId={ clientId }
-						setAttributes={ setAttributes }
-						onOpenSelectionModal={ () =>
-							setIsTemplatePartSelectionOpen( true )
-						}
-					/>
-				</TagName>
-			) }
-			{ canReplace && (
-				<BlockSettingsMenuControls>
-					{ () => (
-						<MenuItem
-							onClick={ () => {
-								setIsTemplatePartSelectionOpen( true );
-							} }
-						>
-							{ createInterpolateElement(
-								__( 'Replace <BlockTitle />' ),
-								{
-									BlockTitle: (
-										<BlockTitle
-											clientId={ clientId }
-											maximumLength={ 25 }
-										/>
-									),
-								}
-							) }
-						</MenuItem>
-					) }
-				</BlockSettingsMenuControls>
-			) }
-			{ isEntityAvailable && (
-				<TemplatePartInnerBlocks
-					tagName={ TagName }
-					blockProps={ blockProps }
-					postId={ templatePartId }
-					hasInnerBlocks={ innerBlocks.length > 0 }
-					layout={ layout }
+		<>
+			<RecursionProvider uniqueId={ templatePartId }>
+				<TemplatePartAdvancedControls
+					tagName={ tagName }
+					setAttributes={ setAttributes }
+					isEntityAvailable={ isEntityAvailable }
+					templatePartId={ templatePartId }
+					defaultWrapper={ areaObject.tagName }
 				/>
-			) }
-			{ ! isPlaceholder && ! isResolved && (
-				<TagName { ...blockProps }>
-					<Spinner />
-				</TagName>
-			) }
+				{ isPlaceholder && (
+					<TagName { ...blockProps }>
+						<TemplatePartPlaceholder
+							area={ attributes.area }
+							templatePartId={ templatePartId }
+							clientId={ clientId }
+							setAttributes={ setAttributes }
+							onOpenSelectionModal={ () =>
+								setIsTemplatePartSelectionOpen( true )
+							}
+						/>
+					</TagName>
+				) }
+				{ canReplace && (
+					<BlockSettingsMenuControls>
+						{ () => (
+							<MenuItem
+								onClick={ () => {
+									setIsTemplatePartSelectionOpen( true );
+								} }
+							>
+								{ createInterpolateElement(
+									__( 'Replace <BlockTitle />' ),
+									{
+										BlockTitle: (
+											<BlockTitle
+												clientId={ clientId }
+												maximumLength={ 25 }
+											/>
+										),
+									}
+								) }
+							</MenuItem>
+						) }
+					</BlockSettingsMenuControls>
+				) }
+				{ isEntityAvailable && (
+					<TemplatePartInnerBlocks
+						tagName={ TagName }
+						blockProps={ blockProps }
+						postId={ templatePartId }
+						hasInnerBlocks={ innerBlocks.length > 0 }
+						layout={ layout }
+					/>
+				) }
+				{ ! isPlaceholder && ! isResolved && (
+					<TagName { ...blockProps }>
+						<Spinner />
+					</TagName>
+				) }
+			</RecursionProvider>
 			{ isTemplatePartSelectionOpen && (
 				<Modal
 					overlayClassName="block-editor-template-part__selection-modal"
@@ -215,6 +217,6 @@ export default function TemplatePartEdit( {
 					/>
 				</Modal>
 			) }
-		</RecursionProvider>
+		</>
 	);
 }


### PR DESCRIPTION
## What?
Fixes #44210

Best reviewed with white space turned off, as it's just a move and indentation of some code.

## Why?
This is tricky to explain! First thing to note is that this is noticeable in Twenty Twenty Two because it nests template parts (the 'Header (Dark, small)' template part contains a 'Header' template part).

If you try the 'replace' option for 'Header', any of the other template parts that contain 'Header' show a recursion warning. It happens because the template part selection modal is rendered inside the `RecursionProvider` (the component that tracks whether a recursion has happened). The resulting component hierarchy is like this:

- 'Header' template part
    - Recursion Provider
        - Template part selection modal
            - 'Header (Dark, small)' template part preview
                - 'Header' template part within the preview <---- This is a recursion

## How?
The fix is to not render the template part selection modal within the `RecursionProvider`. Because the 'Replace' option actually swaps the template part this is hierarchically correct. The render tree becomes:

- 'Header' template part
    - Recursion Provider
- Template part selection modal
    - 'Header (Dark, small)' template part preview
       - 'Header' template part within the preview <---- No longer a recursion

## Testing Instructions
1. Use Twenty Twenty Two
2. Open the 404 tempalte
3. Select the 'Header' Template part
4. From the Block settings dropdown select 'Replace'

Expected: None of the previews should show a recursion error

## Screenshots or screencast <!-- if applicable -->

### Before
![Screen Shot 2022-09-19 at 2 15 26 pm](https://user-images.githubusercontent.com/677833/190959113-ea1c2501-b4b9-4c64-9987-4f82fc4ebb3b.png)

### After
![Screen Shot 2022-09-19 at 2 15 01 pm](https://user-images.githubusercontent.com/677833/190959125-c3568a53-ed1b-4b78-b98a-4168bbe9750a.png)
