### PR TITLE
Add layout styles from Post Content block to post editor

### DIFF
--- a/packages/block-editor/README.md
+++ b/packages/block-editor/README.md
@@ -766,6 +766,28 @@ _Parameters_
 -   _props_ `Object`: Optional. Props to pass to the element. Must contain the ref if one is defined.
 -   _options_ `Object`: Optional. Inner blocks options.
 
+### useLayoutClasses
+
+Generates the utility classnames for the given blocks layout attributes.
+This method was primarily added to reintroduce classnames that were removed
+in the 5.9 release (<https://github.com/WordPress/gutenberg/issues/38719>), rather
+than providing an extensive list of all possible layout classes. The plan is to
+have the style engine generate a more extensive list of utility classnames which
+will then replace this method.
+
+_Parameters_
+
+-   _layout_ `Object`: Layout object.
+-   _layoutDefinitions_ `Object`: An object containing layout definitions, stored in theme.json.
+
+_Returns_
+
+-   `Array`: Array of CSS classname strings.
+
+### useLayoutStyles
+
+Undocumented declaration.
+
 ### useSetting
 
 Hook that retrieves the given setting for the block instance in use.

--- a/packages/block-editor/README.md
+++ b/packages/block-editor/README.md
@@ -766,28 +766,6 @@ _Parameters_
 -   _props_ `Object`: Optional. Props to pass to the element. Must contain the ref if one is defined.
 -   _options_ `Object`: Optional. Inner blocks options.
 
-### useLayoutClasses
-
-Generates the utility classnames for the given blocks layout attributes.
-This method was primarily added to reintroduce classnames that were removed
-in the 5.9 release (<https://github.com/WordPress/gutenberg/issues/38719>), rather
-than providing an extensive list of all possible layout classes. The plan is to
-have the style engine generate a more extensive list of utility classnames which
-will then replace this method.
-
-_Parameters_
-
--   _layout_ `Object`: Layout object.
--   _layoutDefinitions_ `Object`: An object containing layout definitions, stored in theme.json.
-
-_Returns_
-
--   `Array`: Array of CSS classname strings.
-
-### useLayoutStyles
-
-Undocumented declaration.
-
 ### useSetting
 
 Hook that retrieves the given setting for the block instance in use.

--- a/packages/block-editor/src/hooks/index.js
+++ b/packages/block-editor/src/hooks/index.js
@@ -20,6 +20,7 @@ import './metadata';
 import './metadata-name';
 
 export { useCustomSides } from './dimensions';
+export { useLayoutClasses, useLayoutStyles } from './layout';
 export { getBorderClassesAndStyles, useBorderProps } from './use-border-props';
 export { getColorClassesAndStyles, useColorProps } from './use-color-props';
 export { getSpacingClassesAndStyles } from './use-spacing-props';

--- a/packages/block-editor/src/hooks/layout.js
+++ b/packages/block-editor/src/hooks/layout.js
@@ -49,7 +49,7 @@ const layoutBlockSupportKey = '__experimentalLayout';
  *
  * @return { Array } Array of CSS classname strings.
  */
-function useLayoutClasses( layout, layoutDefinitions ) {
+export function useLayoutClasses( layout, layoutDefinitions ) {
 	const rootPaddingAlignment = useSelect( ( select ) => {
 		const { getSettings } = select( blockEditorStore );
 		return getSettings().__experimentalFeatures
@@ -87,6 +87,24 @@ function useLayoutClasses( layout, layoutDefinitions ) {
 	}
 
 	return layoutClassnames;
+}
+
+export function useLayoutStyles( block = {}, selector ) {
+	const { attributes = {}, name } = block;
+	const { layout = {}, style = {} } = attributes;
+	const fullLayoutType = getLayoutType( layout?.type || 'default' );
+	const defaultThemeLayout = useSetting( 'layout' ) || {};
+	const blockGapSupport = useSetting( 'spacing.blockGap' );
+	const hasBlockGapSupport = blockGapSupport !== null;
+	const css = fullLayoutType?.getLayoutStyle?.( {
+		blockName: name,
+		selector,
+		layout,
+		layoutDefinitions: defaultThemeLayout?.definitions,
+		style,
+		hasBlockGapSupport,
+	} );
+	return css;
 }
 
 function LayoutPanel( { setAttributes, attributes, name: blockName } ) {

--- a/packages/block-editor/src/hooks/layout.js
+++ b/packages/block-editor/src/hooks/layout.js
@@ -37,70 +37,90 @@ import { getLayoutType, getLayoutTypes } from '../layouts';
 const layoutBlockSupportKey = '__experimentalLayout';
 
 /**
- * Generates the utility classnames for the given blocks layout attributes.
- * This method was primarily added to reintroduce classnames that were removed
- * in the 5.9 release (https://github.com/WordPress/gutenberg/issues/38719), rather
- * than providing an extensive list of all possible layout classes. The plan is to
- * have the style engine generate a more extensive list of utility classnames which
- * will then replace this method.
+ * Generates the utility classnames for the given block's layout attributes.
  *
- * @param { Object } layout            Layout object.
- * @param { Object } layoutDefinitions An object containing layout definitions, stored in theme.json.
+ * @param { Object } block Block object.
  *
  * @return { Array } Array of CSS classname strings.
  */
-export function useLayoutClasses( layout, layoutDefinitions ) {
+export function useLayoutClasses( block = {} ) {
 	const rootPaddingAlignment = useSelect( ( select ) => {
 		const { getSettings } = select( blockEditorStore );
 		return getSettings().__experimentalFeatures
 			?.useRootPaddingAwareAlignments;
 	}, [] );
+	const globalLayoutSettings = useSetting( 'layout' ) || {};
+
+	const { attributes = {}, name } = block;
+	const { layout } = attributes;
+
+	const { default: defaultBlockLayout } =
+		getBlockSupport( name, layoutBlockSupportKey ) || {};
+	const usedLayout =
+		layout?.inherit || layout?.contentSize || layout?.wideSize
+			? { ...layout, type: 'constrained' }
+			: layout || defaultBlockLayout || {};
+
 	const layoutClassnames = [];
 
-	if ( layoutDefinitions?.[ layout?.type || 'default' ]?.className ) {
+	if (
+		globalLayoutSettings?.definitions?.[ usedLayout?.type || 'default' ]
+			?.className
+	) {
 		layoutClassnames.push(
-			layoutDefinitions?.[ layout?.type || 'default' ]?.className
+			globalLayoutSettings?.definitions?.[ usedLayout?.type || 'default' ]
+				?.className
 		);
 	}
 
 	if (
-		( layout?.inherit ||
-			layout?.contentSize ||
-			layout?.type === 'constrained' ) &&
+		( usedLayout?.inherit ||
+			usedLayout?.contentSize ||
+			usedLayout?.type === 'constrained' ) &&
 		rootPaddingAlignment
 	) {
 		layoutClassnames.push( 'has-global-padding' );
 	}
 
-	if ( layout?.orientation ) {
-		layoutClassnames.push( `is-${ kebabCase( layout.orientation ) }` );
+	if ( usedLayout?.orientation ) {
+		layoutClassnames.push( `is-${ kebabCase( usedLayout.orientation ) }` );
 	}
 
-	if ( layout?.justifyContent ) {
+	if ( usedLayout?.justifyContent ) {
 		layoutClassnames.push(
-			`is-content-justification-${ kebabCase( layout.justifyContent ) }`
+			`is-content-justification-${ kebabCase(
+				usedLayout.justifyContent
+			) }`
 		);
 	}
 
-	if ( layout?.flexWrap && layout.flexWrap === 'nowrap' ) {
+	if ( usedLayout?.flexWrap && usedLayout.flexWrap === 'nowrap' ) {
 		layoutClassnames.push( 'is-nowrap' );
 	}
 
 	return layoutClassnames;
 }
 
+/**
+ * Generates a CSS rule with the given block's layout styles.
+ *
+ * @param { Object } block    Block object.
+ * @param { string } selector A selector to use in generating the CSS rule.
+ *
+ * @return { string } CSS rule.
+ */
 export function useLayoutStyles( block = {}, selector ) {
 	const { attributes = {}, name } = block;
 	const { layout = {}, style = {} } = attributes;
 	const fullLayoutType = getLayoutType( layout?.type || 'default' );
-	const defaultThemeLayout = useSetting( 'layout' ) || {};
+	const globalLayoutSettings = useSetting( 'layout' ) || {};
 	const blockGapSupport = useSetting( 'spacing.blockGap' );
 	const hasBlockGapSupport = blockGapSupport !== null;
 	const css = fullLayoutType?.getLayoutStyle?.( {
 		blockName: name,
 		selector,
 		layout,
-		layoutDefinitions: defaultThemeLayout?.definitions,
+		layoutDefinitions: globalLayoutSettings?.definitions,
 		style,
 		hasBlockGapSupport,
 	} );
@@ -317,7 +337,7 @@ export const withInspectorControls = createHigherOrderComponent(
  */
 export const withLayoutStyles = createHigherOrderComponent(
 	( BlockListBlock ) => ( props ) => {
-		const { name, attributes } = props;
+		const { name, attributes, block } = props;
 		const hasLayoutBlockSupport = hasBlockSupport(
 			name,
 			layoutBlockSupportKey
@@ -339,7 +359,7 @@ export const withLayoutStyles = createHigherOrderComponent(
 				? { ...layout, type: 'constrained' }
 				: layout || defaultBlockLayout || {};
 		const layoutClasses = hasLayoutBlockSupport
-			? useLayoutClasses( usedLayout, defaultThemeLayout?.definitions )
+			? useLayoutClasses( block )
 			: null;
 		const selector = `.${ getBlockDefaultClassName(
 			name

--- a/packages/block-editor/src/hooks/layout.js
+++ b/packages/block-editor/src/hooks/layout.js
@@ -114,13 +114,9 @@ export function useLayoutStyles( block = {}, selector ) {
 	const { layout = {}, style = {} } = attributes;
 	// Update type for blocks using legacy layouts.
 	const usedLayout =
-		layout &&
-		( layout?.type === 'constrained' ||
-			layout?.inherit ||
-			layout?.contentSize ||
-			layout?.wideSize )
+		layout?.inherit || layout?.contentSize || layout?.wideSize
 			? { ...layout, type: 'constrained' }
-			: { ...layout, type: 'default' };
+			: layout || {};
 	const fullLayoutType = getLayoutType( usedLayout?.type || 'default' );
 	const globalLayoutSettings = useSetting( 'layout' ) || {};
 	const blockGapSupport = useSetting( 'spacing.blockGap' );

--- a/packages/block-editor/src/hooks/layout.js
+++ b/packages/block-editor/src/hooks/layout.js
@@ -112,7 +112,16 @@ export function useLayoutClasses( block = {} ) {
 export function useLayoutStyles( block = {}, selector ) {
 	const { attributes = {}, name } = block;
 	const { layout = {}, style = {} } = attributes;
-	const fullLayoutType = getLayoutType( layout?.type || 'default' );
+	// Update type for blocks using legacy layouts.
+	const usedLayout =
+		layout &&
+		( layout?.type === 'constrained' ||
+			layout?.inherit ||
+			layout?.contentSize ||
+			layout?.wideSize )
+			? { ...layout, type: 'constrained' }
+			: { ...layout, type: 'default' };
+	const fullLayoutType = getLayoutType( usedLayout?.type || 'default' );
 	const globalLayoutSettings = useSetting( 'layout' ) || {};
 	const blockGapSupport = useSetting( 'spacing.blockGap' );
 	const hasBlockGapSupport = blockGapSupport !== null;

--- a/packages/block-editor/src/index.js
+++ b/packages/block-editor/src/index.js
@@ -12,6 +12,8 @@ export {
 	getSpacingClassesAndStyles as __experimentalGetSpacingClassesAndStyles,
 	getGapCSSValue as __experimentalGetGapCSSValue,
 	useCachedTruthy,
+	useLayoutClasses,
+	useLayoutStyles,
 } from './hooks';
 export * from './components';
 export * from './elements';

--- a/packages/block-editor/src/index.js
+++ b/packages/block-editor/src/index.js
@@ -12,8 +12,8 @@ export {
 	getSpacingClassesAndStyles as __experimentalGetSpacingClassesAndStyles,
 	getGapCSSValue as __experimentalGetGapCSSValue,
 	useCachedTruthy,
-	useLayoutClasses,
-	useLayoutStyles,
+	useLayoutClasses as __experimentaluseLayoutClasses,
+	useLayoutStyles as __experimentaluseLayoutStyles,
 } from './hooks';
 export * from './components';
 export * from './elements';

--- a/packages/block-library/src/post-content/edit.js
+++ b/packages/block-library/src/post-content/edit.js
@@ -46,7 +46,9 @@ function EditableContent( { layout, context = {} } ) {
 		return getSettings()?.supportsLayout;
 	}, [] );
 	const defaultLayout = useSetting( 'layout' ) || {};
-	const usedLayout = !! layout && layout.inherit ? defaultLayout : layout;
+	const usedLayout = ! layout?.type
+		? { ...defaultLayout, ...layout, type: 'default' }
+		: { ...defaultLayout, ...layout };
 	const [ blocks, onInput, onChange ] = useEntityBlockEditor(
 		'postType',
 		postType,

--- a/packages/edit-post/src/components/visual-editor/index.js
+++ b/packages/edit-post/src/components/visual-editor/index.js
@@ -91,7 +91,13 @@ function findPostContent( blocks ) {
 			return blocks[ i ];
 		}
 		if ( blocks[ i ].innerBlocks.length ) {
-			return findPostContent( blocks[ i ].innerBlocks );
+			const nestedPostContent = findPostContent(
+				blocks[ i ].innerBlocks
+			);
+
+			if ( nestedPostContent ) {
+				return nestedPostContent;
+			}
 		}
 	}
 }

--- a/packages/edit-post/src/components/visual-editor/index.js
+++ b/packages/edit-post/src/components/visual-editor/index.js
@@ -131,7 +131,9 @@ export default function VisualEditor( { styles } ) {
 			deviceType: __experimentalGetPreviewDeviceType(),
 			isWelcomeGuideVisible: isFeatureActive( 'welcomeGuide' ),
 			isTemplateMode: _isTemplateMode,
-			templateContent: getEditedPostTemplate()?.content,
+			templateContent: _isTemplateMode
+				? ''
+				: getEditedPostTemplate()?.content,
 			wrapperBlockName: _wrapperBlockName,
 			wrapperUniqueId: getCurrentPostId(),
 		};

--- a/packages/edit-post/src/components/visual-editor/index.js
+++ b/packages/edit-post/src/components/visual-editor/index.js
@@ -28,8 +28,8 @@ import {
 	__unstableUseMouseMoveTypingReset as useMouseMoveTypingReset,
 	__unstableIframe as Iframe,
 	__experimentalRecursionProvider as RecursionProvider,
-	useLayoutClasses,
-	useLayoutStyles,
+	__experimentaluseLayoutClasses as useLayoutClasses,
+	__experimentaluseLayoutStyles as useLayoutStyles,
 } from '@wordpress/block-editor';
 import { useEffect, useRef, useMemo } from '@wordpress/element';
 import { Button, __unstableMotion as motion } from '@wordpress/components';
@@ -225,10 +225,7 @@ export default function VisualEditor( { styles } ) {
 		return findPostContent( parse( templateContent ) );
 	}, [ templateContent ] );
 
-	const postContentLayoutClasses = useLayoutClasses(
-		postContentBlock?.attributes?.layout,
-		globalLayoutSettings?.definitions
-	);
+	const postContentLayoutClasses = useLayoutClasses( postContentBlock );
 
 	const blockListLayoutClass = classnames(
 		{

--- a/packages/edit-post/src/components/visual-editor/index.js
+++ b/packages/edit-post/src/components/visual-editor/index.js
@@ -231,14 +231,13 @@ export default function VisualEditor( { styles } ) {
 	const blockListLayoutClass = classnames(
 		{
 			'is-layout-flow': ! themeSupportsLayout,
-			'wp-container-visual-editor': themeSupportsLayout,
 		},
 		postContentLayoutClasses
 	);
 
 	const postContentLayoutStyles = useLayoutStyles(
 		postContentBlock,
-		'.wp-container-visual-editor'
+		'.block-editor-block-list__layout.is-root-container'
 	);
 
 	const { attributes = {} } = postContentBlock;

--- a/packages/edit-post/src/components/visual-editor/index.js
+++ b/packages/edit-post/src/components/visual-editor/index.js
@@ -255,8 +255,7 @@ export default function VisualEditor( { styles } ) {
 		'.block-editor-block-list__layout.is-root-container'
 	);
 
-	const { attributes = {} } = postContentBlock;
-	const { layout = {} } = attributes;
+	const layout = postContentBlock?.attributes?.layout || {};
 
 	// Update type for blocks using legacy layouts.
 	const postContentLayout =

--- a/packages/edit-post/src/components/visual-editor/index.js
+++ b/packages/edit-post/src/components/visual-editor/index.js
@@ -337,7 +337,7 @@ export default function VisualEditor( { styles } ) {
 							! isTemplateMode && (
 								<>
 									<LayoutStyle
-										selector=".edit-post-visual-editor__post-title-wrapper"
+										selector=".edit-post-visual-editor__post-title-wrapper, .block-editor-block-list__layout.is-root-container"
 										layout={ fallbackLayout }
 										layoutDefinitions={
 											globalLayoutSettings?.definitions

--- a/packages/edit-post/src/components/visual-editor/index.js
+++ b/packages/edit-post/src/components/visual-editor/index.js
@@ -85,6 +85,14 @@ function MaybeIframe( {
 	);
 }
 
+/**
+ * Given an array of nested blocks, find the first Post Content
+ * block inside it, recursing through any nesting levels.
+ *
+ * @param {Array} blocks A list of blocks.
+ *
+ * @return {Object} The Post Content block.
+ */
 function findPostContent( blocks ) {
 	for ( let i = 0; i < blocks.length; i++ ) {
 		if ( blocks[ i ].name === 'core/post-content' ) {

--- a/packages/edit-post/src/components/visual-editor/index.js
+++ b/packages/edit-post/src/components/visual-editor/index.js
@@ -352,18 +352,6 @@ export default function VisualEditor( { styles } ) {
 											}
 										/>
 									) }
-									{
-										// For classic themes using theme.json we want a default content width in the editor.
-										! postContentBlock && (
-											<LayoutStyle
-												selector=".block-editor-block-list__layout.is-root-container"
-												layout={ fallbackLayout }
-												layoutDefinitions={
-													globalLayoutSettings?.definitions
-												}
-											/>
-										)
-									}
 								</>
 							) }
 						{ ! isTemplateMode && (

--- a/packages/edit-post/src/components/visual-editor/index.js
+++ b/packages/edit-post/src/components/visual-editor/index.js
@@ -131,9 +131,10 @@ export default function VisualEditor( { styles } ) {
 			deviceType: __experimentalGetPreviewDeviceType(),
 			isWelcomeGuideVisible: isFeatureActive( 'welcomeGuide' ),
 			isTemplateMode: _isTemplateMode,
-			templateContent: _isTemplateMode
-				? ''
-				: getEditedPostTemplate()?.content,
+			templateContent:
+				typeof getEditedPostTemplate()?.content === 'string'
+					? getEditedPostTemplate()?.content
+					: '',
 			wrapperBlockName: _wrapperBlockName,
 			wrapperUniqueId: getCurrentPostId(),
 		};

--- a/packages/edit-post/src/components/visual-editor/index.js
+++ b/packages/edit-post/src/components/visual-editor/index.js
@@ -221,8 +221,10 @@ export default function VisualEditor( { styles } ) {
 		return { type: 'default' };
 	}, [ isTemplateMode, themeSupportsLayout, globalLayoutSettings ] );
 
-	const templateBlocks = parse( templateContent );
-	const postContentBlock = findPostContent( templateBlocks );
+	const postContentBlock = useMemo( () => {
+		return findPostContent( parse( templateContent ) );
+	}, [ templateContent ] );
+
 	const postContentLayoutClasses = useLayoutClasses(
 		postContentBlock?.attributes?.layout,
 		globalLayoutSettings?.definitions


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->


## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

Fixes #42911, #44110, #44208.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

Gets layout classnames and styles from Post Content block so post editor layout can match the front end in all respects.

WIP

Todo:

* remove hardcoded layout styles from post editor (custom content widths aren't working yet because they're being overridden by those)
* make sure child block alignments are correct per Post Content layout type
* `useLayoutClasses`, `useLayoutStyles` should probably be experimental or unstable?
* add tests

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->

1. In site editor, change layout settings of Post Content block
2. Check that new layout is reflected in the front end

## Screenshots or screencast <!-- if applicable -->
