### PR TITLE
ToolsPanel: Add subheadings and reset text to tools panel menu

### DIFF
--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -10,6 +10,11 @@
 
 -   The `LinkedButton` to unlink sides in `BoxControl`, `BorderBoxControl` and `BorderRadiusControl` have changed from a rectangular primary button to an icon-only button, with a sentence case tooltip, and default-size icon for better legibility. The `Button` component has been fixed so when `isSmall` and `icon` props are set, and no text is present, the button shape is square rather than rectangular.
 
+### New Features
+
+-   `MenuItem`: Add suffix prop for injecting non-icon and non-shortcut content to menu items ([#44260](https://github.com/WordPress/gutenberg/pull/44260)).
+-   `ToolsPanel`: Add subheadings to ellipsis menu and reset text to default control menu items ([#44260](https://github.com/WordPress/gutenberg/pull/44260)).
+
 ### Internal
 
 -   `NavigationMenu` updated to ignore `react/exhaustive-deps` eslint rule ([#44090](https://github.com/WordPress/gutenberg/pull/44090)).

--- a/packages/components/src/menu-item/README.md
+++ b/packages/components/src/menu-item/README.md
@@ -79,3 +79,10 @@ If shortcut is a string, it is expecting the display text. If shortcut is an obj
 -   Default: `'menuitem'`
 
 [Aria Spec](https://www.w3.org/TR/wai-aria-1.1/#aria-checked). If you need to have selectable menu items use menuitemradio for single select, and menuitemcheckbox for multiselect.
+
+### `suffix`
+
+-   Type: `WPElement`
+-   Required: No
+
+Allows for markup other than icons or shortcuts to be added to the menu item.

--- a/packages/components/src/menu-item/index.js
+++ b/packages/components/src/menu-item/index.js
@@ -64,11 +64,15 @@ export function MenuItem( props, ref ) {
 			{ ...buttonProps }
 		>
 			<span className="components-menu-item__item">{ children }</span>
-			<Shortcut
-				className="components-menu-item__shortcut"
-				shortcut={ shortcut }
-			/>
-			{ icon && iconPosition === 'right' && <Icon icon={ icon } /> }
+			{ ! suffix && (
+				<Shortcut
+					className="components-menu-item__shortcut"
+					shortcut={ shortcut }
+				/>
+			) }
+			{ ! suffix && icon && iconPosition === 'right' && (
+				<Icon icon={ icon } />
+			) }
 			{ suffix }
 		</Button>
 	);

--- a/packages/components/src/menu-item/index.js
+++ b/packages/components/src/menu-item/index.js
@@ -26,6 +26,7 @@ export function MenuItem( props, ref ) {
 		shortcut,
 		isSelected,
 		role = 'menuitem',
+		suffix,
 		...buttonProps
 	} = props;
 
@@ -68,6 +69,7 @@ export function MenuItem( props, ref ) {
 				shortcut={ shortcut }
 			/>
 			{ icon && iconPosition === 'right' && <Icon icon={ icon } /> }
+			{ suffix }
 		</Button>
 	);
 }

--- a/packages/components/src/menu-item/style.scss
+++ b/packages/components/src/menu-item/style.scss
@@ -8,6 +8,7 @@
 			// Ensure unchecked items have clearance for consistency
 			// with checked items containing an icon or shortcut.
 			padding-right: $grid-unit-60;
+			box-sizing: initial;
 		}
 	}
 

--- a/packages/components/src/menu-item/test/__snapshots__/index.js.snap
+++ b/packages/components/src/menu-item/test/__snapshots__/index.js.snap
@@ -30,6 +30,9 @@ exports[`MenuItem should match snapshot when all props provided 1`] = `
       d="M4 9v1.5h16V9H4zm12 5.5h4V13h-4v1.5zm-6 0h4V13h-4v1.5zm-6 0h4V13H4v1.5z"
     />
   </svg>
+  <span>
+    Suffix
+  </span>
 </button>
 `;
 

--- a/packages/components/src/menu-item/test/__snapshots__/index.js.snap
+++ b/packages/components/src/menu-item/test/__snapshots__/index.js.snap
@@ -30,9 +30,6 @@ exports[`MenuItem should match snapshot when all props provided 1`] = `
       d="M4 9v1.5h16V9H4zm12 5.5h4V13h-4v1.5zm-6 0h4V13h-4v1.5zm-6 0h4V13H4v1.5z"
     />
   </svg>
-  <span>
-    Suffix
-  </span>
 </button>
 `;
 

--- a/packages/components/src/menu-item/test/index.js
+++ b/packages/components/src/menu-item/test/index.js
@@ -31,7 +31,6 @@ describe( 'MenuItem', () => {
 				role="menuitemcheckbox"
 				onClick={ noop }
 				shortcut="mod+shift+alt+w"
-				suffix={ <span>Suffix</span> }
 			>
 				My item
 			</MenuItem>
@@ -107,5 +106,41 @@ describe( 'MenuItem', () => {
 		const checkboxMenuItem = screen.getByRole( 'menuitemcheckbox' );
 		expect( checkboxMenuItem ).toBeChecked();
 		expect( checkboxMenuItem ).toHaveAttribute( 'aria-checked', 'true' );
+	} );
+
+	it( 'should not render shortcut or right icon if suffix provided', () => {
+		render(
+			<MenuItem
+				icon="Icon"
+				iconPosition="right"
+				role="menuitemcheckbox"
+				shortcut="Shortcut"
+				suffix="Suffix"
+			>
+				My item
+			</MenuItem>
+		);
+
+		expect( screen.getByText( 'Suffix' ) ).toBeInTheDocument();
+		expect( screen.queryByText( 'Shortcut' ) ).not.toBeInTheDocument();
+		expect( screen.queryByText( 'Icon' ) ).not.toBeInTheDocument();
+	} );
+
+	it( 'should render left icon despite suffix being provided', () => {
+		render(
+			<MenuItem
+				icon={ <span>Icon</span> }
+				iconPosition="left"
+				role="menuitemcheckbox"
+				shortcut="Shortcut"
+				suffix="Suffix"
+			>
+				My item
+			</MenuItem>
+		);
+
+		expect( screen.getByText( 'Icon' ) ).toBeInTheDocument();
+		expect( screen.getByText( 'Suffix' ) ).toBeInTheDocument();
+		expect( screen.queryByText( 'Shortcut' ) ).not.toBeInTheDocument();
 	} );
 } );

--- a/packages/components/src/menu-item/test/index.js
+++ b/packages/components/src/menu-item/test/index.js
@@ -31,6 +31,7 @@ describe( 'MenuItem', () => {
 				role="menuitemcheckbox"
 				onClick={ noop }
 				shortcut="mod+shift+alt+w"
+				suffix={ <span>Suffix</span> }
 			>
 				My item
 			</MenuItem>

--- a/packages/components/src/menu-item/test/index.js
+++ b/packages/components/src/menu-item/test/index.js
@@ -111,7 +111,7 @@ describe( 'MenuItem', () => {
 	it( 'should not render shortcut or right icon if suffix provided', () => {
 		render(
 			<MenuItem
-				icon="Icon"
+				icon={ <span>Icon</span> }
 				iconPosition="right"
 				role="menuitemcheckbox"
 				shortcut="Shortcut"

--- a/packages/components/src/tools-panel/stories/index.js
+++ b/packages/components/src/tools-panel/stories/index.js
@@ -29,11 +29,13 @@ export const _default = () => {
 	const [ height, setHeight ] = useState();
 	const [ minHeight, setMinHeight ] = useState();
 	const [ width, setWidth ] = useState();
+	const [ scale, setScale ] = useState();
 
 	const resetAll = () => {
 		setHeight( undefined );
 		setWidth( undefined );
 		setMinHeight( undefined );
+		setScale( undefined );
 	};
 
 	return (
@@ -78,6 +80,31 @@ export const _default = () => {
 							value={ minHeight }
 							onChange={ ( next ) => setMinHeight( next ) }
 						/>
+					</ToolsPanelItem>
+					<ToolsPanelItem
+						hasValue={ () => !! scale }
+						label="Scale"
+						onDeselect={ () => setScale( undefined ) }
+					>
+						<ToggleGroupControl
+							label="Scale"
+							value={ scale }
+							onChange={ ( next ) => setScale( next ) }
+							isBlock
+						>
+							<ToggleGroupControlOption
+								value="cover"
+								label="Cover"
+							/>
+							<ToggleGroupControlOption
+								value="contain"
+								label="Contain"
+							/>
+							<ToggleGroupControlOption
+								value="fill"
+								label="Fill"
+							/>
+						</ToggleGroupControl>
 					</ToolsPanelItem>
 				</ToolsPanel>
 			</Panel>

--- a/packages/components/src/tools-panel/styles.ts
+++ b/packages/components/src/tools-panel/styles.ts
@@ -1,6 +1,7 @@
 /**
  * External dependencies
  */
+import styled from '@emotion/styled';
 import { css } from '@emotion/react';
 
 /**
@@ -146,14 +147,14 @@ export const DropdownMenu = css`
 	min-width: 200px;
 `;
 
+export const ResetLabel = styled.span`
+	color: var( --wp-admin-theme-color-darker-10 );
+	margin-left: ${ space( 3 ) };
+	${ baseLabelTypography }
+`;
+
 export const DefaultControlsItem = css`
 	color: ${ COLORS.gray[ 900 ] };
-
-	span:last-child {
-		color: var( --wp-admin-theme-color-darker-10 );
-		margin-left: ${ space( 3 ) };
-		${ baseLabelTypography }
-	}
 
 	&[aria-disabled='true'] {
 		color: ${ COLORS.gray[ 700 ] };
@@ -163,7 +164,7 @@ export const DefaultControlsItem = css`
 			color: ${ COLORS.gray[ 700 ] };
 		}
 
-		span:last-child {
+		${ ResetLabel } {
 			opacity: 0.3;
 		}
 	}

--- a/packages/components/src/tools-panel/styles.ts
+++ b/packages/components/src/tools-panel/styles.ts
@@ -13,7 +13,7 @@ import {
 	Wrapper as BaseControlWrapper,
 } from '../base-control/styles/base-control-styles';
 import { LabelWrapper } from '../input-control/styles/input-control-styles';
-import { baseLabelTypography, COLORS, CONFIG } from '../utils';
+import { COLORS, CONFIG } from '../utils';
 import { space } from '../ui/utils/space';
 
 const toolsPanelGrid = {
@@ -149,8 +149,11 @@ export const DropdownMenu = css`
 
 export const ResetLabel = styled.span`
 	color: var( --wp-admin-theme-color-darker-10 );
+	font-size: 11px;
+	font-weight: 500;
+	line-height: 1.4;
 	margin-left: ${ space( 3 ) };
-	${ baseLabelTypography }
+	text-transform: uppercase;
 `;
 
 export const DefaultControlsItem = css`

--- a/packages/components/src/tools-panel/styles.ts
+++ b/packages/components/src/tools-panel/styles.ts
@@ -159,7 +159,7 @@ export const ResetLabel = styled.span`
 export const DefaultControlsItem = css`
 	color: ${ COLORS.gray[ 900 ] };
 
-	&[aria-disabled='true'] {
+	&&[aria-disabled='true'] {
 		color: ${ COLORS.gray[ 700 ] };
 		opacity: 1;
 

--- a/packages/components/src/tools-panel/styles.ts
+++ b/packages/components/src/tools-panel/styles.ts
@@ -12,7 +12,7 @@ import {
 	Wrapper as BaseControlWrapper,
 } from '../base-control/styles/base-control-styles';
 import { LabelWrapper } from '../input-control/styles/input-control-styles';
-import { COLORS, CONFIG } from '../utils';
+import { baseLabelTypography, COLORS, CONFIG } from '../utils';
 import { space } from '../ui/utils/space';
 
 const toolsPanelGrid = {
@@ -144,4 +144,20 @@ export const ToolsPanelItemPlaceholder = css`
 
 export const DropdownMenu = css`
 	min-width: 200px;
+`;
+
+export const DefaultControlsItem = css`
+	span:last-child {
+		color: var( --wp-admin-theme-color-darker-10 );
+		margin-left: ${ space( 3 ) };
+		${ baseLabelTypography }
+	}
+
+	&&[aria-disabled='true'] {
+		opacity: 1;
+
+		span:last-child {
+			opacity: 0.3;
+		}
+	}
 `;

--- a/packages/components/src/tools-panel/styles.ts
+++ b/packages/components/src/tools-panel/styles.ts
@@ -147,6 +147,8 @@ export const DropdownMenu = css`
 `;
 
 export const DefaultControlsItem = css`
+	color: ${ COLORS.gray[ 700 ] };
+
 	span:last-child {
 		color: var( --wp-admin-theme-color-darker-10 );
 		margin-left: ${ space( 3 ) };

--- a/packages/components/src/tools-panel/styles.ts
+++ b/packages/components/src/tools-panel/styles.ts
@@ -147,7 +147,7 @@ export const DropdownMenu = css`
 `;
 
 export const DefaultControlsItem = css`
-	color: ${ COLORS.gray[ 700 ] };
+	color: ${ COLORS.gray[ 900 ] };
 
 	span:last-child {
 		color: var( --wp-admin-theme-color-darker-10 );
@@ -155,8 +155,13 @@ export const DefaultControlsItem = css`
 		${ baseLabelTypography }
 	}
 
-	&&[aria-disabled='true'] {
+	&[aria-disabled='true'] {
+		color: ${ COLORS.gray[ 700 ] };
 		opacity: 1;
+
+		&:hover {
+			color: ${ COLORS.gray[ 700 ] };
+		}
 
 		span:last-child {
 			opacity: 0.3;

--- a/packages/components/src/tools-panel/styles.ts
+++ b/packages/components/src/tools-panel/styles.ts
@@ -13,7 +13,7 @@ import {
 	Wrapper as BaseControlWrapper,
 } from '../base-control/styles/base-control-styles';
 import { LabelWrapper } from '../input-control/styles/input-control-styles';
-import { COLORS, CONFIG } from '../utils';
+import { COLORS, CONFIG, rtl } from '../utils';
 import { space } from '../ui/utils/space';
 
 const toolsPanelGrid = {
@@ -152,7 +152,7 @@ export const ResetLabel = styled.span`
 	font-size: 11px;
 	font-weight: 500;
 	line-height: 1.4;
-	margin-left: ${ space( 3 ) };
+	${ rtl( { marginLeft: space( 3 ) } ) }
 	text-transform: uppercase;
 `;
 

--- a/packages/components/src/tools-panel/tools-panel-header/component.tsx
+++ b/packages/components/src/tools-panel/tools-panel-header/component.tsx
@@ -76,7 +76,6 @@ const DefaultControlsGroup = ( {
 						role="menuitemcheckbox"
 						isSelected
 						aria-disabled
-						suffix={ resetSuffix }
 					>
 						{ label }
 					</MenuItem>

--- a/packages/components/src/tools-panel/tools-panel-header/component.tsx
+++ b/packages/components/src/tools-panel/tools-panel-header/component.tsx
@@ -20,6 +20,7 @@ import { HStack } from '../../h-stack';
 import { Heading } from '../../heading';
 import { useToolsPanelHeader } from './hook';
 import { contextConnect, WordPressComponentProps } from '../../ui/context';
+import { ResetLabel } from '../styles';
 import type {
 	ToolsPanelControlsGroupProps,
 	ToolsPanelHeaderProps,
@@ -34,7 +35,7 @@ const DefaultControlsGroup = ( {
 		return null;
 	}
 
-	const resetSuffix = <span aria-hidden>{ __( 'Reset' ) }</span>;
+	const resetSuffix = <ResetLabel aria-hidden>{ __( 'Reset' ) }</ResetLabel>;
 
 	return (
 		<MenuGroup label={ __( 'Defaults' ) }>

--- a/packages/components/src/tools-panel/tools-panel-header/component.tsx
+++ b/packages/components/src/tools-panel/tools-panel-header/component.tsx
@@ -7,7 +7,7 @@ import type { ForwardedRef } from 'react';
  * WordPress dependencies
  */
 import { speak } from '@wordpress/a11y';
-import { check, reset, moreVertical, plus } from '@wordpress/icons';
+import { check, moreVertical, plus } from '@wordpress/icons';
 import { __, _x, sprintf } from '@wordpress/i18n';
 
 /**
@@ -26,6 +26,7 @@ import type {
 } from '../types';
 
 const DefaultControlsGroup = ( {
+	itemClassName,
 	items,
 	toggleItem,
 }: ToolsPanelControlsGroupProps ) => {
@@ -33,15 +34,17 @@ const DefaultControlsGroup = ( {
 		return null;
 	}
 
+	const resetSuffix = <span>{ __( 'Reset' ) }</span>;
+
 	return (
-		<MenuGroup>
+		<MenuGroup label={ __( 'Defaults' ) }>
 			{ items.map( ( [ label, hasValue ] ) => {
 				if ( hasValue ) {
 					return (
 						<MenuItem
 							key={ label }
+							className={ itemClassName }
 							role="menuitem"
-							icon={ reset }
 							label={ sprintf(
 								// translators: %s: The name of the control being reset e.g. "Padding".
 								__( 'Reset %s' ),
@@ -58,6 +61,7 @@ const DefaultControlsGroup = ( {
 									'assertive'
 								);
 							} }
+							suffix={ resetSuffix }
 						>
 							{ label }
 						</MenuItem>
@@ -67,10 +71,11 @@ const DefaultControlsGroup = ( {
 				return (
 					<MenuItem
 						key={ label }
+						className={ itemClassName }
 						role="menuitemcheckbox"
-						icon={ check }
 						isSelected
 						aria-disabled
+						suffix={ resetSuffix }
 					>
 						{ label }
 					</MenuItem>
@@ -89,7 +94,7 @@ const OptionalControlsGroup = ( {
 	}
 
 	return (
-		<MenuGroup>
+		<MenuGroup label={ __( 'Tools' ) }>
 			{ items.map( ( [ label, isSelected ] ) => {
 				const itemLabel = isSelected
 					? sprintf(
@@ -147,6 +152,7 @@ const ToolsPanelHeader = (
 ) => {
 	const {
 		areAllOptionalControlsHidden,
+		defaultControlsItemClassName,
 		dropdownMenuClassName,
 		hasMenuItems,
 		headingClassName,
@@ -197,6 +203,7 @@ const ToolsPanelHeader = (
 							<DefaultControlsGroup
 								items={ defaultItems }
 								toggleItem={ toggleItem }
+								itemClassName={ defaultControlsItemClassName }
 							/>
 							<OptionalControlsGroup
 								items={ optionalItems }

--- a/packages/components/src/tools-panel/tools-panel-header/component.tsx
+++ b/packages/components/src/tools-panel/tools-panel-header/component.tsx
@@ -34,7 +34,7 @@ const DefaultControlsGroup = ( {
 		return null;
 	}
 
-	const resetSuffix = <span>{ __( 'Reset' ) }</span>;
+	const resetSuffix = <span aria-hidden>{ __( 'Reset' ) }</span>;
 
 	return (
 		<MenuGroup label={ __( 'Defaults' ) }>

--- a/packages/components/src/tools-panel/tools-panel-header/hook.ts
+++ b/packages/components/src/tools-panel/tools-panel-header/hook.ts
@@ -33,12 +33,17 @@ export function useToolsPanelHeader(
 		return cx( styles.ToolsPanelHeading );
 	}, [ cx ] );
 
+	const defaultControlsItemClassName = useMemo( () => {
+		return cx( styles.DefaultControlsItem );
+	}, [ cx ] );
+
 	const { menuItems, hasMenuItems, areAllOptionalControlsHidden } =
 		useToolsPanelContext();
 
 	return {
 		...otherProps,
 		areAllOptionalControlsHidden,
+		defaultControlsItemClassName,
 		dropdownMenuClassName,
 		hasMenuItems,
 		headingClassName,

--- a/packages/components/src/tools-panel/types.ts
+++ b/packages/components/src/tools-panel/types.ts
@@ -147,6 +147,7 @@ export type ToolsPanelContext = {
 };
 
 export type ToolsPanelControlsGroupProps = {
+	itemClassName?: string;
 	items: [ string, boolean ][];
 	toggleItem: ( label: string ) => void;
 };


### PR DESCRIPTION
Fixes: https://github.com/WordPress/gutenberg/issues/44096

## What?

- Adds subheadings to the `ToolsPanel` ellipsis menu
- Adds reset text within the default control menu items
- Updates `MenuItem` to allow more than just an icon or shortcut as a suffix

## Why?

Improve the `ToolsPanel` ellipsis menu UX.

## How?

- Updates the `MenuItem` to allow non icon or shortcut content (i.e. "reset" text)
- Leverages new `suffix` prop for a `MenuItem` to set reset text for default control items in the `ToolsPanel`
- Tweaks `ToolsPanel` styles to match the mockups in [#44096](https://github.com/WordPress/gutenberg/issues/44096)
- Updates `ToolsPanel` stories to provide better demonstration of the ellipsis menu for the default story

## Testing Instructions
1. Fire up Storybook and check out the ToolsPanel stories. Ensure the menu looks and behaves as per [#44096](https://github.com/WordPress/gutenberg/issues/44096)
2. Test out the various ToolsPanel uses in the editors e.g. the block support panels for typography, dimensions etc
3. Run `npm run test:unit packages/components/src/menu-item`

## Screenshots or screencast <!-- if applicable -->

| Storybook | Editor |
|---|---|
| <video src="https://user-images.githubusercontent.com/60436221/190987707-4c52ad42-e6b9-4a2b-8f54-471c887aefd3.mp4" /> | <video src="https://user-images.githubusercontent.com/60436221/190987699-fb7cdea9-874c-4b2d-be38-fac384b130ff.mp4" /> |







