### PR TITLE
[Mobile] - Update Group block test snapshot

### DIFF
--- a/packages/block-library/src/group/test/__snapshots__/edit.native.js.snap
+++ b/packages/block-library/src/group/test/__snapshots__/edit.native.js.snap
@@ -1,7 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`Group block inserts block and adds a Heading block as an inner block 1`] = `
-"<!-- wp:group -->
+"<!-- wp:group {\\"layout\\":{\\"type\\":\\"constrained\\"}} -->
 <div class=\\"wp-block-group\\"><!-- wp:heading -->
 <h2></h2>
 <!-- /wp:heading --></div>


### PR DESCRIPTION
Follow up https://github.com/WordPress/gutenberg/pull/44192

## What?
Updates the test snapshot for the Group block.

## Why?
We recently updated the tests in https://github.com/WordPress/gutenberg/pull/44192 so we need to update the snapshot.

## How?
By updating the test snapshot.

## Testing Instructions
CI checks should pass

## Screenshots or screencast <!-- if applicable -->
N/A