### PR TITLE
Fix animation running in loop while dragging an image on a dropzone

### DIFF
--- a/packages/components/src/drop-zone/index.tsx
+++ b/packages/components/src/drop-zone/index.tsx
@@ -119,7 +119,6 @@ export function DropZoneComponent( {
 	const disableMotion = useReducedMotion();
 
 	let children;
-
 	const backdrop = {
 		hidden: { scaleY: 0, opacity: 0 },
 		show: {
@@ -156,6 +155,10 @@ export function DropZoneComponent( {
 				animate="show"
 				exit={ disableMotion ? 'show' : 'exit' }
 				className="components-drop-zone__content"
+				// Without this, when this div is shown,
+				// Safari calls a onDropZoneLeave causing a loop because of this bug
+				// https://bugs.webkit.org/show_bug.cgi?id=66547
+				style={ { pointerEvents: 'none' } }
 			>
 				<motion.div variants={ foreground }>
 					<Icon

--- a/packages/compose/src/hooks/use-drop-zone/index.js
+++ b/packages/compose/src/hooks/use-drop-zone/index.js
@@ -161,6 +161,8 @@ export default function useDropZone( {
 				// leaving the drop zone, which means the `relatedTarget`
 				// (element that has been entered) should be outside the drop
 				// zone.
+				// Note: This is not entirely reliable in Safari due to this bug
+				// https://bugs.webkit.org/show_bug.cgi?id=66547
 				if ( isElementInZone( event.relatedTarget ) ) {
 					return;
 				}


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?

On an empty image block, if you drag a file from your file explorer on top of the image placeholder, you'll notice that the drop zone animation runs in a loop.

## How?

It turns out this is a [Safari bug](https://bugs.webkit.org/show_bug.cgi?id=66547) where `event.relatedTarget` is not reliable. This PR solves it using a small workaround in the DropZone component.

## Testing Instructions

1- Add an image block.
2- Drag a file from your file explored on top of the image placeholder.
3- The animation only triggers once.

