### PR TITLE
Chore: renaming functions to fit 6.1

### DIFF
--- a/lib/compat/wordpress-6.1/theme.php
+++ b/lib/compat/wordpress-6.1/theme.php
@@ -30,7 +30,7 @@ function gutenberg_create_initial_theme_features() {
 }
 add_action( 'setup_theme', 'gutenberg_create_initial_theme_features', 0 );
 
-if ( ! function_exists( 'wp_theme_element_class_name' ) ) {
+if ( ! function_exists( 'wp_theme_get_element_class_name' ) ) {
 	/**
 	 * Given an element name, returns a class name.
 	 * Alias from WP_Theme_JSON_Gutenberg::get_element_class_name.
@@ -41,7 +41,7 @@ if ( ! function_exists( 'wp_theme_element_class_name' ) ) {
 	 *
 	 * @since 6.1.0
 	 */
-	function wp_theme_element_class_name( $element ) {
+	function wp_theme_get_element_class_name( $element ) {
 		return WP_Theme_JSON_Gutenberg::get_element_class_name( $element );
 	}
 }

--- a/packages/block-library/src/comments/index.php
+++ b/packages/block-library/src/comments/index.php
@@ -109,7 +109,7 @@ add_action( 'init', 'register_block_core_comments' );
  */
 function comments_block_form_defaults( $fields ) {
 	if ( wp_is_block_theme() ) {
-		$fields['submit_button'] = '<input name="%1$s" type="submit" id="%2$s" class="%3$s wp-block-button__link ' . wp_theme_element_class_name( 'button' ) . '" value="%4$s" />';
+		$fields['submit_button'] = '<input name="%1$s" type="submit" id="%2$s" class="%3$s wp-block-button__link ' . wp_theme_get_element_class_name( 'button' ) . '" value="%4$s" />';
 		$fields['submit_field']  = '<p class="form-submit wp-block-button">%1$s %2$s</p>';
 	}
 

--- a/packages/block-library/src/post-comments-form/index.php
+++ b/packages/block-library/src/post-comments-form/index.php
@@ -72,7 +72,7 @@ add_action( 'init', 'register_block_core_post_comments_form' );
  */
 function post_comments_form_block_form_defaults( $fields ) {
 	if ( wp_is_block_theme() ) {
-		$fields['submit_button'] = '<input name="%1$s" type="submit" id="%2$s" class="wp-block-button__link ' . wp_theme_element_class_name( 'button' ) . '" value="%4$s" />';
+		$fields['submit_button'] = '<input name="%1$s" type="submit" id="%2$s" class="wp-block-button__link ' . wp_theme_get_element_class_name( 'button' ) . '" value="%4$s" />';
 		$fields['submit_field']  = '<p class="form-submit wp-block-button">%1$s %2$s</p>';
 	}
 

--- a/packages/block-library/src/post-featured-image/index.php
+++ b/packages/block-library/src/post-featured-image/index.php
@@ -175,7 +175,7 @@ function get_block_core_post_featured_image_border_attributes( $attributes ) {
 		);
 	}
 
-	$styles     = gutenberg_style_engine_get_styles( array( 'border' => $border_styles ) );
+	$styles     = wp_style_engine_get_styles( array( 'border' => $border_styles ) );
 	$attributes = array();
 	if ( ! empty( $styles['classnames'] ) ) {
 		$attributes['class'] = $styles['classnames'];

--- a/packages/block-library/src/search/index.php
+++ b/packages/block-library/src/search/index.php
@@ -121,7 +121,7 @@ function render_block_core_search( $attributes ) {
 		}
 
 		// Include the button element class.
-		$button_classes[] = wp_theme_element_class_name( 'button' );
+		$button_classes[] = wp_theme_get_element_class_name( 'button' );
 		$button_markup    = sprintf(
 			'<button type="submit" class="%s" %s %s>%s</button>',
 			esc_attr( implode( ' ', $button_classes ) ),

--- a/phpunit/class-wp-theme-json-test.php
+++ b/phpunit/class-wp-theme-json-test.php
@@ -797,14 +797,14 @@ class WP_Theme_JSON_Gutenberg_Test extends WP_UnitTestCase {
 
 	function test_get_element_class_name_button() {
 		$expected = 'wp-element-button';
-		$actual   = wp_theme_element_class_name( 'button' );
+		$actual   = wp_theme_get_element_class_name( 'button' );
 
 		$this->assertEquals( $expected, $actual );
 	}
 
 	function test_get_element_class_name_invalid() {
 		$expected = '';
-		$actual   = wp_theme_element_class_name( 'unknown-element' );
+		$actual   = wp_theme_get_element_class_name( 'unknown-element' );
 
 		$this->assertEquals( $expected, $actual );
 	}

--- a/phpunit/class-wp-theme-json-test.php
+++ b/phpunit/class-wp-theme-json-test.php
@@ -797,14 +797,14 @@ class WP_Theme_JSON_Gutenberg_Test extends WP_UnitTestCase {
 
 	function test_get_element_class_name_button() {
 		$expected = 'wp-element-button';
-		$actual   = wp_theme_get_element_class_name( 'button' );
+		$actual   = WP_Theme_JSON_Gutenberg::get_element_class_name( 'button' );
 
 		$this->assertEquals( $expected, $actual );
 	}
 
 	function test_get_element_class_name_invalid() {
 		$expected = '';
-		$actual   = wp_theme_get_element_class_name( 'unknown-element' );
+		$actual   = WP_Theme_JSON_Gutenberg::get_element_class_name( 'unknown-element' );
 
 		$this->assertEquals( $expected, $actual );
 	}

--- a/tools/webpack/blocks.js
+++ b/tools/webpack/blocks.js
@@ -30,6 +30,7 @@ const blockViewRegex = new RegExp(
 const prefixFunctions = [
 	'build_query_vars_from_query_block',
 	'wp_enqueue_block_support_styles',
+	'wp_style_engine_get_styles',
 ];
 
 /**


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->
As mentioned [on Sync Gutenberg packages PR](https://github.com/WordPress/wordpress-develop/pull/3154#discussion_r972550490), I need to update a styles engine function to have the same name as Core.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->
Check no fatal errors appears.
Play with border support and check it's working on Comments, Featured Images, Search or Post Comments form.
## Screenshots or screencast <!-- if applicable -->
