### PR TITLE
Block editor: useSetting: Minor refactor

### DIFF
--- a/packages/block-editor/src/components/use-setting/index.js
+++ b/packages/block-editor/src/components/use-setting/index.js
@@ -144,18 +144,19 @@ export default function useSetting( path ) {
 						false
 					)
 				) {
-					const candidateAtts =
+					const attributes =
 						select( blockEditorStore ).getBlockAttributes(
 							candidateClientId
 						);
-					const candidateResult =
-						get(
-							candidateAtts,
-							`settings.blocks.${ blockName }.${ normalizedPath }`
-						) ??
-						get( candidateAtts, `settings.${ normalizedPath }` );
-					if ( candidateResult !== undefined ) {
-						result = candidateResult;
+					result =
+						get( attributes, [
+							'settings',
+							'blocks',
+							blockName,
+							normalizedPath,
+						] ) ??
+						get( attributes, [ 'settings', normalizedPath ] );
+					if ( result !== undefined ) {
 						break;
 					}
 				}
@@ -164,10 +165,17 @@ export default function useSetting( path ) {
 			// 2. Fall back to the settings from the block editor store (__experimentalFeatures).
 			const settings = select( blockEditorStore ).getSettings();
 			if ( result === undefined ) {
-				const defaultsPath = `__experimentalFeatures.${ normalizedPath }`;
-				const blockPath = `__experimentalFeatures.blocks.${ blockName }.${ normalizedPath }`;
 				result =
-					get( settings, blockPath ) ?? get( settings, defaultsPath );
+					get( settings, [
+						'__experimentalFeatures',
+						'blocks',
+						blockName,
+						normalizedPath,
+					] ) ??
+					get( settings, [
+						'__experimentalFeatures',
+						normalizedPath,
+					] );
 			}
 
 			// Return if the setting was found in either the block instance or the store.

--- a/packages/block-editor/src/components/use-setting/index.js
+++ b/packages/block-editor/src/components/use-setting/index.js
@@ -142,18 +142,16 @@ export default function useSetting( path ) {
 						false
 					)
 				) {
-					const attributes =
+					const candidateAtts =
 						select( blockEditorStore ).getBlockAttributes(
 							candidateClientId
 						);
 					result =
-						get( attributes, [
-							'settings',
-							'blocks',
-							blockName,
-							normalizedPath,
-						] ) ??
-						get( attributes, [ 'settings', normalizedPath ] );
+						get(
+							candidateAtts,
+							`settings.blocks.${ blockName }.${ normalizedPath }`
+						) ??
+						get( candidateAtts, `settings.${ normalizedPath }` );
 					if ( result !== undefined ) {
 						// Stop the search for more distant ancestors and move on.
 						break;
@@ -164,17 +162,10 @@ export default function useSetting( path ) {
 			// 2. Fall back to the settings from the block editor store (__experimentalFeatures).
 			const settings = select( blockEditorStore ).getSettings();
 			if ( result === undefined ) {
+				const defaultsPath = `__experimentalFeatures.${ normalizedPath }`;
+				const blockPath = `__experimentalFeatures.blocks.${ blockName }.${ normalizedPath }`;
 				result =
-					get( settings, [
-						'__experimentalFeatures',
-						'blocks',
-						blockName,
-						normalizedPath,
-					] ) ??
-					get( settings, [
-						'__experimentalFeatures',
-						normalizedPath,
-					] );
+					get( settings, blockPath ) ?? get( settings, defaultsPath );
 			}
 
 			// Return if the setting was found in either the block instance or the store.

--- a/packages/block-editor/src/components/use-setting/index.js
+++ b/packages/block-editor/src/components/use-setting/index.js
@@ -123,11 +123,16 @@ export default function useSetting( path ) {
 			const normalizedPath = removeCustomPrefixes( path );
 
 			// 1. Take settings from the block instance or its ancestors.
+			// Start from the current block and work our way up the ancestors.
 			const candidates = [
-				...select( blockEditorStore ).getBlockParents( clientId ),
-				clientId, // The current block is added last, so it overwrites any ancestor.
+				clientId,
+				...select( blockEditorStore ).getBlockParents(
+					clientId,
+					/* ascending */ true
+				),
 			];
-			candidates.forEach( ( candidateClientId ) => {
+
+			for ( const candidateClientId of candidates ) {
 				const candidateBlockName =
 					select( blockEditorStore ).getBlockName(
 						candidateClientId
@@ -151,9 +156,10 @@ export default function useSetting( path ) {
 						get( candidateAtts, `settings.${ normalizedPath }` );
 					if ( candidateResult !== undefined ) {
 						result = candidateResult;
+						break;
 					}
 				}
-			} );
+			}
 
 			// 2. Fall back to the settings from the block editor store (__experimentalFeatures).
 			const settings = select( blockEditorStore ).getSettings();

--- a/packages/block-editor/src/components/use-setting/index.js
+++ b/packages/block-editor/src/components/use-setting/index.js
@@ -21,10 +21,8 @@ import { store as blockEditorStore } from '../../store';
 const blockedPaths = [ 'color', 'border', 'typography', 'spacing' ];
 
 const deprecatedFlags = {
-	'color.palette': ( settings ) =>
-		settings.colors === undefined ? undefined : settings.colors,
-	'color.gradients': ( settings ) =>
-		settings.gradients === undefined ? undefined : settings.gradients,
+	'color.palette': ( settings ) => settings.colors,
+	'color.gradients': ( settings ) => settings.gradients,
 	'color.custom': ( settings ) =>
 		settings.disableCustomColors === undefined
 			? undefined
@@ -33,8 +31,7 @@ const deprecatedFlags = {
 		settings.disableCustomGradients === undefined
 			? undefined
 			: ! settings.disableCustomGradients,
-	'typography.fontSizes': ( settings ) =>
-		settings.fontSizes === undefined ? undefined : settings.fontSizes,
+	'typography.fontSizes': ( settings ) => settings.fontSizes,
 	'typography.customFontSize': ( settings ) =>
 		settings.disableCustomFontSizes === undefined
 			? undefined

--- a/packages/block-editor/src/components/use-setting/index.js
+++ b/packages/block-editor/src/components/use-setting/index.js
@@ -109,7 +109,7 @@ const removeCustomPrefixes = ( path ) => {
 export default function useSetting( path ) {
 	const { name: blockName, clientId } = useBlockEditContext();
 
-	const setting = useSelect(
+	return useSelect(
 		( select ) => {
 			if ( blockedPaths.includes( path ) ) {
 				// eslint-disable-next-line no-console
@@ -120,6 +120,7 @@ export default function useSetting( path ) {
 			}
 
 			let result;
+
 			const normalizedPath = removeCustomPrefixes( path );
 
 			// 1. Take settings from the block instance or its ancestors.
@@ -157,6 +158,7 @@ export default function useSetting( path ) {
 						] ) ??
 						get( attributes, [ 'settings', normalizedPath ] );
 					if ( result !== undefined ) {
+						// Stop the search for more distant ancestors and move on.
 						break;
 					}
 				}
@@ -202,6 +204,4 @@ export default function useSetting( path ) {
 		},
 		[ blockName, clientId, path ]
 	);
-
-	return setting;
 }


### PR DESCRIPTION
## What?
Perform minor and local refactors to block-editor's `useSetting` hook.

## Why?
The only compelling change was to traverse a block's list of ancestors in ascending order and immediately stopping at the first block that provides the settings we are looking for, rather than systematically going through the whole list in descending order (8784762af7380661ddffface1473a52123a07916). Following that, dba8c083dbaf3e0673b395eae498b4902ce14f29 lets `lodash#get` do its own concatenation of the `path` argument so that we don't have to perform string interpolation. Everything else is cosmetic.

## Questions
Be sure to look at the inline comments for questions that I have raised.

## Testing Instructions
All behaviours should remain unchanged.