### PR TITLE
Try generating styles for classic themes by filtering `theme.json` data

### DIFF
--- a/lib/compat/wordpress-6.1/class-wp-theme-json-data-gutenberg.php
+++ b/lib/compat/wordpress-6.1/class-wp-theme-json-data-gutenberg.php
@@ -47,6 +47,10 @@ class WP_Theme_JSON_Data_Gutenberg {
 		return $this;
 	}
 
+	public function create_with( $new_data ) {
+		$this->theme_json = new WP_Theme_JSON_Gutenberg( $new_data, $this->origin );
+	}
+
 	/**
 	 * Returns the underlying data.
 	 *

--- a/lib/compat/wordpress-6.1/get-global-styles-and-settings.php
+++ b/lib/compat/wordpress-6.1/get-global-styles-and-settings.php
@@ -82,42 +82,9 @@ function gutenberg_get_global_stylesheet( $types = array() ) {
 			return $cached;
 		}
 	}
-	$tree                = WP_Theme_JSON_Resolver_Gutenberg::get_merged_data();
-	$supports_theme_json = WP_Theme_JSON_Resolver_Gutenberg::theme_has_support();
-	if ( empty( $types ) && ! $supports_theme_json ) {
-		$types = array( 'variables', 'presets', 'base-layout-styles' );
-	} elseif ( empty( $types ) ) {
-		$types = array( 'variables', 'styles', 'presets' );
-	}
+	$tree       = WP_Theme_JSON_Resolver_Gutenberg::get_merged_data();
+	$stylesheet = $tree->get_stylesheet( $types );
 
-	/*
-	 * If variables are part of the stylesheet,
-	 * we add them for all origins (default, theme, user).
-	 * This is so themes without a theme.json still work as before 5.9:
-	 * they can override the default presets.
-	 * See https://core.trac.wordpress.org/ticket/54782
-	 */
-	$styles_variables = '';
-	if ( in_array( 'variables', $types, true ) ) {
-		$styles_variables = $tree->get_stylesheet( array( 'variables' ) );
-		$types            = array_diff( $types, array( 'variables' ) );
-	}
-
-	/*
-	 * For the remaining types (presets, styles), we do consider origins:
-	 *
-	 * - themes without theme.json: only the classes for the presets defined by core
-	 * - themes with theme.json: the presets and styles classes, both from core and the theme
-	 */
-	$styles_rest = '';
-	if ( ! empty( $types ) ) {
-		$origins = array( 'default', 'theme', 'custom' );
-		if ( ! $supports_theme_json ) {
-			$origins = array( 'default' );
-		}
-		$styles_rest = $tree->get_stylesheet( $types, $origins );
-	}
-	$stylesheet = $styles_variables . $styles_rest;
 	if ( $can_use_cached ) {
 		// Cache for a minute.
 		// This cache doesn't need to be any longer, we only want to avoid spikes on high-traffic sites.

--- a/lib/compat/wordpress-6.1/hook-theme-json-for-classic-themes.php
+++ b/lib/compat/wordpress-6.1/hook-theme-json-for-classic-themes.php
@@ -5,43 +5,50 @@ function theme_json_current_theme_has_support( ){
 }
 
 function theme_json_default_filter_for_classic_themes( $theme_json_data ) {
-	if ( theme_json_current_theme_has_support() ) {
+	if ( ! theme_json_current_theme_has_support() ) {
 		$new_data = array(
 			'version'  => 2,
-			'settings' => array( /* we should maintain the presets by core */ ),
-			'styles'   => array( /* clear this? add only the base-layout-styles? */ ),
+			'settings' => array(
+				/*
+				 * We should be able to remove this.
+				 * Without it, it breaks.
+				 */
+				"spacing" => array(
+					"spacingScale" => array(
+						"operator" => "*",
+						"increment" => 1.5,
+						"steps" => 7,
+						"mediumStep" => 1.5,
+						"unit" => "rem"
+					),
+				),
+			),
+			'styles'   => array(
+				'elements' => array(
+					'button' => array(
+						'color' => array(
+							'text'       => '#fff',
+							'background' => '#32373c',
+						),
+						'spacing' => array(
+							'padding' =>'calc(0.667em + 2px) calc(1.333em + 2px)',
+						),
+						'typography' => array(
+							'fontSize'       => 'inherit',
+							'fontFamily'     => 'inherit',
+							'lineHeight'     => 'inherit',
+							'textDecoration' => 'none',
+						),
+						'border' => array(
+							'width' => '0',
+						),
+					),
+				),
+			),
 		);
-		$theme_json_data->update_with( $new_data );
+		$theme_json_data->create_with( $new_data );
 	}
+
 	return $theme_json_data;
 }
 add_filter( 'theme_json_default', 'theme_json_default_filter_for_classic_themes');
-
-function theme_json_blocks_filter_for_classic_themes( $theme_json_data ) {
-	if ( theme_json_current_theme_has_support() ) {
-		$new_data = array(
-			'version'  => 2,
-			'settings' => array(),
-			'styles'   => array( /* add button styles for classic here */ ),
-		);
-		$theme_json_data->update_with( $new_data );
-	}
-	return $theme_json_data;
-}
-add_filter( 'theme_json_blocks', 'theme_json_blocks_filter_for_classic_themes' );
-
-function theme_json_reset_for_classic_themes( $theme_json_data ) {
-	if ( theme_json_current_theme_has_support() ) {
-		$new_data = array(
-			'version'  => 2,
-			'settings' => array(),
-			'styles'   => array(),
-		);
-		$theme_json_data->update_with( $new_data );
-	}
-
-	error_log( 'theme_json_data ' . print_r( $theme_json_data, true ) );
-	return $theme_json_data;
-}
-add_filter( 'theme_json_theme', 'theme_json_reset_for_classic_themes' );
-add_filter( 'theme_json_user', 'theme_json_reset_for_classic_themes' );

--- a/lib/compat/wordpress-6.1/hook-theme-json-for-classic-themes.php
+++ b/lib/compat/wordpress-6.1/hook-theme-json-for-classic-themes.php
@@ -1,0 +1,47 @@
+<?php
+
+function theme_json_current_theme_has_support( ){
+	return WP_Theme_JSON_Resolver_Gutenberg::theme_has_support();
+}
+
+function theme_json_default_filter_for_classic_themes( $theme_json_data ) {
+	if ( theme_json_current_theme_has_support() ) {
+		$new_data = array(
+			'version'  => 2,
+			'settings' => array( /* we should maintain the presets by core */ ),
+			'styles'   => array( /* clear this? add only the base-layout-styles? */ ),
+		);
+		$theme_json_data->update_with( $new_data );
+	}
+	return $theme_json_data;
+}
+add_filter( 'theme_json_default', 'theme_json_default_filter_for_classic_themes');
+
+function theme_json_blocks_filter_for_classic_themes( $theme_json_data ) {
+	if ( theme_json_current_theme_has_support() ) {
+		$new_data = array(
+			'version'  => 2,
+			'settings' => array(),
+			'styles'   => array( /* add button styles for classic here */ ),
+		);
+		$theme_json_data->update_with( $new_data );
+	}
+	return $theme_json_data;
+}
+add_filter( 'theme_json_blocks', 'theme_json_blocks_filter_for_classic_themes' );
+
+function theme_json_reset_for_classic_themes( $theme_json_data ) {
+	if ( theme_json_current_theme_has_support() ) {
+		$new_data = array(
+			'version'  => 2,
+			'settings' => array(),
+			'styles'   => array(),
+		);
+		$theme_json_data->update_with( $new_data );
+	}
+
+	error_log( 'theme_json_data ' . print_r( $theme_json_data, true ) );
+	return $theme_json_data;
+}
+add_filter( 'theme_json_theme', 'theme_json_reset_for_classic_themes' );
+add_filter( 'theme_json_user', 'theme_json_reset_for_classic_themes' );

--- a/lib/load.php
+++ b/lib/load.php
@@ -83,6 +83,7 @@ require __DIR__ . '/compat/wordpress-6.1/blocks.php';
 require __DIR__ . '/compat/wordpress-6.1/block-editor-settings.php';
 require __DIR__ . '/compat/wordpress-6.1/persisted-preferences.php';
 require __DIR__ . '/compat/wordpress-6.1/get-global-styles-and-settings.php';
+require __DIR__ . '/compat/wordpress-6.1/hook-theme-json-for-classic-themes.php';
 require __DIR__ . '/compat/wordpress-6.1/class-wp-theme-json-data-gutenberg.php';
 require __DIR__ . '/compat/wordpress-6.1/class-wp-theme-json-6-1.php';
 require __DIR__ . '/compat/wordpress-6.1/class-wp-theme-json-resolver-6-1.php';


### PR DESCRIPTION
## What?

Potential alternative to https://github.com/WordPress/gutenberg/pull/43981

This PR experiments with extracting the logic we have for classic themes to a different place, making use of the new `theme_json_(origin)` filters.

## Why?

It's increasingly difficult to reason about and follow which styles would classic themes get.

## How?

By making use of the `theme_json_(origin)` filters we can modify the `theme.json` if, and only if, the current theme in use is a classic theme.

## Testing Instructions

Not ready for testing. It's just a skeleton so far.
