### PR TITLE
[Block Library - Query Loop]: Fix variation with declared`icon` object with `src`

### DIFF
--- a/packages/block-library/src/query/edit/query-placeholder.js
+++ b/packages/block-library/src/query/edit/query-placeholder.js
@@ -48,7 +48,10 @@ export default function QueryPlaceholder( {
 	);
 
 	const matchingVariation = getMatchingVariation( attributes, allVariations );
-	const icon = matchingVariation?.icon || blockType?.icon?.src;
+	const icon =
+		matchingVariation?.icon?.src ||
+		matchingVariation?.icon ||
+		blockType?.icon?.src;
 	const label = matchingVariation?.title || blockType?.title;
 	if ( isStartingBlank ) {
 		return (


### PR DESCRIPTION

<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Currently if we register a Query Loop variation with having an `icon` object with `src` property - which is not a `dashicon` - it will crash the block during the insertion, due to the lack of handling this case. This PR just adds some adhoc handling for this, as this is related to some implementation details to QueryPlaceholder component..

It would be good to consider a better handling of variations validation [similar to block types](https://github.com/WordPress/gutenberg/blob/trunk/packages/blocks/src/store/actions.js#L56), but that should be discussed and handled separately. By playing around a bit, it has nuances in general because handling `registerBlockVariation` isn't enough, as we operate on variations in places directly from the `blockType` object.
<!-- In a few words, what is the PR actually doing? -->

## Testing Instructions
1. Register a  Query Loop variation with an `icon` with `src`. Example:
```
{
	name: 'products-list',
	title: 'Products List',
	description: 'Display a list of your product.',
	attributes: {
		query: {
			perPage: 4,
			pages: 0,
			offset: 0,
			postType: 'product',
			order: 'desc',
			orderBy: 'date',
			author: '',
			search: '',
			sticky: '',
			inherit: false,
		},
		namespace: 'prefix/products-list',
	},
	icon: {
		src: (
			<svg viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
				<path fill="none" d="M0 0h24v24H0V0z" />
				<path d="M19 13H5v-2h14v2z" />
			</svg>
		),
	},
	allowControls: [ 'order', 'taxQuery', 'search' ],
	isActive: [ 'namespace' ],
	scope: [ 'inserter' ],
},
```
2. Observe that in trunk it would crash the block during insertion and with this change it will work fine.



