### PR TITLE
Post Featured Image Block: Border radius and color not applied on overlay

### DIFF
--- a/packages/block-library/src/post-featured-image/block.json
+++ b/packages/block-library/src/post-featured-image/block.json
@@ -62,7 +62,7 @@
 			"color": true,
 			"radius": true,
 			"width": true,
-			"__experimentalSelector": "img, .block-editor-media-placeholder",
+			"__experimentalSelector": "img, .block-editor-media-placeholder, .wp-block-post-featured-image__overlay",
 			"__experimentalSkipSerialization": true,
 			"__experimentalDefaultControls": {
 				"color": true,

--- a/packages/block-library/src/post-featured-image/index.php
+++ b/packages/block-library/src/post-featured-image/index.php
@@ -92,7 +92,14 @@ function get_block_core_post_featured_image_overlay_element_markup( $attributes 
 		return '';
 	}
 
+	$styles            = '';
+	$border_attributes = get_block_core_post_featured_image_border_attributes( $attributes );
+
 	// Generate required classes for the element.
+	if ( ! empty( $border_attributes['class'] ) ) {
+		$class_names[] = $border_attributes['class'];
+	}
+
 	if ( $has_dim_background ) {
 		$class_names[] = 'has-background-dim';
 		$class_names[] = "has-background-dim-{$attributes['dimRatio']}";
@@ -111,12 +118,8 @@ function get_block_core_post_featured_image_overlay_element_markup( $attributes 
 	}
 
 	// Generate required CSS properties and their values.
-	if ( ! empty( $attributes['style']['border']['radius'] ) ) {
-		$styles_properties['border-radius'] = $attributes['style']['border']['radius'];
-	}
-
-	if ( ! empty( $attributes['style']['border']['width'] ) ) {
-		$styles_properties['border-width'] = $attributes['style']['border']['width'];
+	if ( ! empty( $border_attributes['style'] ) ) {
+		$styles = "{$border_attributes['style']} ";
 	}
 
 	if ( $has_custom_gradient ) {
@@ -126,8 +129,6 @@ function get_block_core_post_featured_image_overlay_element_markup( $attributes 
 	if ( $has_custom_overlay ) {
 		$styles_properties['background-color'] = $attributes['customOverlayColor'];
 	}
-
-	$styles = '';
 
 	foreach ( $styles_properties as $style_attribute => $style_attribute_value ) {
 		$styles .= "{$style_attribute}: $style_attribute_value; ";

--- a/packages/block-library/src/post-featured-image/overlay.js
+++ b/packages/block-library/src/post-featured-image/overlay.js
@@ -47,20 +47,22 @@ const Overlay = ( {
 
 	return (
 		<>
-			<span
-				aria-hidden="true"
-				className={ classnames(
-					'wp-block-post-featured-image__overlay',
-					dimRatioToClass( dimRatio ),
-					{
-						[ overlayColor.class ]: overlayColor.class,
-						'has-background-dim': dimRatio !== undefined,
-						'has-background-gradient': gradientValue,
-						[ gradientClass ]: gradientClass,
-					}
-				) }
-				style={ overlayStyles }
-			/>
+			{ !! dimRatio && (
+				<span
+					aria-hidden="true"
+					className={ classnames(
+						'wp-block-post-featured-image__overlay',
+						dimRatioToClass( dimRatio ),
+						{
+							[ overlayColor.class ]: overlayColor.class,
+							'has-background-dim': dimRatio !== undefined,
+							'has-background-gradient': gradientValue,
+							[ gradientClass ]: gradientClass,
+						}
+					) }
+					style={ overlayStyles }
+				/>
+			) }
 			<InspectorControls __experimentalGroup="color">
 				<ColorGradientSettingsDropdown
 					__experimentalHasMultipleOrigins


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
- Fixes border-radius not being applied to the overlay when added from the `theme.json` file. 
- Fixes border-radius not being applied to the overlay when different values are added for each corner/side.
- Fixes border-color not being applied on the overlay. 
<!-- In a few words, what is the PR actually doing? -->

## Why?
- Partially covers https://github.com/WordPress/gutenberg/issues/44262
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

## How?
- Uses the style engine-generated attributes for the border and passes it on to the Overlay element.
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

## Testing instructions


## Screenshots or screencast
| Before | After |
|--------|------|
|![Screenshot 2022-09-20 at 6 47 09 PM](https://user-images.githubusercontent.com/59014930/191267898-ff57c7ed-58c2-4b52-af8f-1ce1391da71c.png)|![Screenshot 2022-09-20 at 6 44 41 PM](https://user-images.githubusercontent.com/59014930/191267372-755b0fc5-c1f6-419e-b73d-a8de14c2ee8c.png)|

<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->
