### PR TITLE
Fix missing TS types for a11y in packages/components

### DIFF
--- a/packages/components/tsconfig.json
+++ b/packages/components/tsconfig.json
@@ -18,6 +18,7 @@
 		"strictNullChecks": true
 	},
 	"references": [
+		{ "path": "../a11y" },
 		{ "path": "../compose" },
 		{ "path": "../date" },
 		{ "path": "../deprecated" },


### PR DESCRIPTION
Adding a reference to the TS types for `a11y` as suggested by @ciampo in https://github.com/WordPress/wordpress-develop/pull/3154#issuecomment-1251533545

This is an attempt to fix a bug that is [preventing publishing](https://github.com/WordPress/gutenberg/actions/runs/3084760362/jobs/4987280231) the npm packages for 6.1. 