### PR TITLE
Fix popover stacking in the customize widgets editor

### DIFF
--- a/packages/customize-widgets/src/components/sidebar-block-editor/style.scss
+++ b/packages/customize-widgets/src/components/sidebar-block-editor/style.scss
@@ -19,7 +19,8 @@
 	z-index: z-index(".customize-widgets__block-toolbar");
 }
 
-.customize-widgets-popover .components-popover {
+.customize-widgets-popover .components-popover,
+.customize-control-sidebar_block_editor .components-popover {
 	// FloatingUI library used in Popover component forces us to have an "absolute" inline style.
 	// We need to override this in the customizer.
 	position: fixed !important;


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Fixes #41739

## Why?
Some popovers in the widgets editor became absolutely positioned after the recent popover refactor. They were previously fixed position, and that was important because it ensured they were in a different stacking context and render outside of their container.

## How?
#41312 added some CSS to fix some popovers, and this expands on that to cover more popovers.

Adding CSS in this way isn't the ideal solution, but I think it's worth fixing the user facing problem first and then revisiting to come up with the best developer solution second. I've added a task to #42770 to consider a better way to fix this.

## Testing Instructions
1. Open the customize widgets editor
2. Add a link to some text
3. Observe that the link popover isn't clipped and is still positioned correctly.

## Screenshots or screencast <!-- if applicable -->

### Before
![Screen Shot 2022-09-20 at 11 38 24 am](https://user-images.githubusercontent.com/677833/191162137-a3c2968d-c7a1-42b1-8f4c-6fd95760b9e1.png)

### After
![Screen Shot 2022-09-20 at 11 37 01 am](https://user-images.githubusercontent.com/677833/191161989-4ca8c456-69f2-4e21-80e8-cbf16c1bcd57.png)
