### PR TITLE
Navigation block: Fix submenu colors for imported classic menus

### DIFF
--- a/packages/block-library/src/navigation/test/menu-items-to-blocks.js
+++ b/packages/block-library/src/navigation/test/menu-items-to-blocks.js
@@ -189,12 +189,14 @@ describe( 'converting menu items to blocks', () => {
 				name: 'core/navigation-submenu',
 				attributes: expect.objectContaining( {
 					label: 'Top Level',
+					isTopLevelItem: true,
 				} ),
 				innerBlocks: [
 					expect.objectContaining( {
 						name: 'core/navigation-link',
 						attributes: expect.objectContaining( {
 							label: 'Child 1',
+							isTopLevelLink: false,
 						} ),
 						innerBlocks: [],
 					} ),
@@ -202,18 +204,21 @@ describe( 'converting menu items to blocks', () => {
 						name: 'core/navigation-submenu',
 						attributes: expect.objectContaining( {
 							label: 'Child 2',
+							isTopLevelItem: false,
 						} ),
 						innerBlocks: [
 							expect.objectContaining( {
 								name: 'core/navigation-submenu',
 								attributes: expect.objectContaining( {
 									label: 'Sub Child',
+									isTopLevelItem: false,
 								} ),
 								innerBlocks: [
 									expect.objectContaining( {
 										name: 'core/navigation-link',
 										attributes: expect.objectContaining( {
 											label: 'Sub Sub Child',
+											isTopLevelLink: false,
 										} ),
 										innerBlocks: [],
 									} ),
@@ -227,6 +232,7 @@ describe( 'converting menu items to blocks', () => {
 				name: 'core/navigation-link',
 				attributes: expect.objectContaining( {
 					label: 'Top Level 2',
+					isTopLevelLink: true,
 				} ),
 				innerBlocks: [],
 			} ),


### PR DESCRIPTION
## What?
Fixes #44235

## Why?
The `isTopLevelLink` / `isTopLevelItem` attribute is important for rendering colors correctly in the navigation block.

The values weren't being set correctly when importing classic menus which resulted in the colors being wrong.

## How?
Ensure those values are set correctly when importing classic menus

## Testing Instructions
Prerequsites: 
- At least one classic menu that has nested items
- A block theme currently active

1. Open the site editor and select the navigation block 
2. Set some background and text colors for the submenu
3. Import a classic menu
4. Save
5. View the frontend

Expected: The submenu colors should be shown correctly.

## Screenshots or screencast <!-- if applicable -->

### Before

![Screen Shot 2022-09-20 at 1 02 23 pm](https://user-images.githubusercontent.com/677833/191171634-2c381c21-81d3-4b68-a393-ea38c4b8d8a4.png)

### After

![Screen Shot 2022-09-20 at 1 01 46 pm](https://user-images.githubusercontent.com/677833/191171648-b1071fe0-d430-4794-bcb5-99594e4587ae.png)