### PR TITLE
Reduce number of action triggers when dragging blocks and fix calculation of index around dragged block

### DIFF
--- a/packages/block-editor/src/components/use-block-drop-zone/index.js
+++ b/packages/block-editor/src/components/use-block-drop-zone/index.js
@@ -53,7 +53,12 @@ export function getNearestBlockIndex( elements, position, orientation ) {
 			allowedEdges
 		);
 
-		if ( candidateDistance === undefined || distance < candidateDistance ) {
+		const isDraggedBlock = element.classList.contains( 'is-dragging' );
+
+		if (
+			! isDraggedBlock &&
+			( candidateDistance === undefined || distance < candidateDistance )
+		) {
 			// If the user is dropping to the trailing edge of the block
 			// add 1 to the index to represent dragging after.
 			// Take RTL languages into account where the left edge is
@@ -111,7 +116,8 @@ export default function useBlockDropZone( {
 		[ targetRootClientId ]
 	);
 
-	const { getBlockListSettings } = useSelect( blockEditorStore );
+	const { getBlockListSettings, getBlockInsertionPoint } =
+		useSelect( blockEditorStore );
 	const { showInsertionPoint, hideInsertionPoint } =
 		useDispatch( blockEditorStore );
 
@@ -129,8 +135,14 @@ export default function useBlockDropZone( {
 			);
 
 			setTargetBlockIndex( targetIndex === undefined ? 0 : targetIndex );
+			const { rootClientId: currentRootClientId, index: currentIndex } =
+				getBlockInsertionPoint();
 
-			if ( targetIndex !== null ) {
+			if (
+				targetIndex !== null &&
+				( currentRootClientId !== targetRootClientId ||
+					currentIndex !== targetIndex )
+			) {
 				showInsertionPoint( targetRootClientId, targetIndex );
 			}
 		}, [] ),


### PR DESCRIPTION
## What?
When dragging blocks, the `SHOW_INSERTION_POINT` action is repeatedly triggered, even if the user doesn't move the mouse. This PR resolves that issue so the action is only triggered when the insertion point changes.

Also fixes a flicker of the drop indicator that happens when dragging past the greyed-out dragged block.

## How?
- Checks if the insertion point is the same as already set and avoids triggering `SHOW_INSERTION_POINT` when it is.
- Also ignores the dragged block when determining a candidate block index for the drop target.

## Testing Instructions
1. Add three blocks
2. Start dragging the last block
3. Check that the `SHOW_INSERTION_POINT` action is only triggered once (use redux dev tools or add logging)
4. Drag up and down within the grey area left by the dragged block. The drop indicator should not flicker.

## Screenshots or screencast <!-- if applicable -->

### Before

https://user-images.githubusercontent.com/677833/191190313-690865ff-43b8-4456-a3a5-2fac7a096242.mp4


### After

https://user-images.githubusercontent.com/677833/191190698-be9093ac-bf84-4a67-b3e9-3c9aab481724.mp4




