### PR TITLE
Freeform: Hide 'Convert to blocks' when locked

### DIFF
--- a/packages/block-library/src/freeform/edit.js
+++ b/packages/block-library/src/freeform/edit.js
@@ -43,6 +43,10 @@ export default function ClassicEdit( {
 	onReplace,
 } ) {
 	const { getMultiSelectedBlockClientIds } = useSelect( blockEditorStore );
+	const canRemove = useSelect(
+		( select ) => select( blockEditorStore ).canRemoveBlock( clientId ),
+		[ clientId ]
+	);
 	const didMount = useRef( false );
 
 	useEffect( () => {
@@ -221,11 +225,13 @@ export default function ClassicEdit( {
 	/* eslint-disable jsx-a11y/no-static-element-interactions */
 	return (
 		<>
-			<BlockControls>
-				<ToolbarGroup>
-					<ConvertToBlocksButton clientId={ clientId } />
-				</ToolbarGroup>
-			</BlockControls>
+			{ canRemove && (
+				<BlockControls>
+					<ToolbarGroup>
+						<ConvertToBlocksButton clientId={ clientId } />
+					</ToolbarGroup>
+				</BlockControls>
+			) }
 			<div { ...useBlockProps() }>
 				<div
 					key="toolbar"


### PR DESCRIPTION
## What?
Closes #29743.
Similar to #39939.

PR adds a check to hide 'Convert to blocks' when the block is locked.

## Why?
The action removes the block; this should not be allowed when block removal or template is locked.

## Testing Instructions
1. Open a Post or Page.
2. Insert a Freeform block.
3. Lock block removal.
4. Confirm that the "Convert to blocks" toolbar action isn't displayed.

## Screenshots or screencast <!-- if applicable -->

https://user-images.githubusercontent.com/240569/191207771-d69547c0-7dca-4f98-92e3-780c7311abb9.mp4

