### PR TITLE
[Block Library - Query Loop]: Fix broken preview in specific category template

### DIFF
--- a/packages/block-library/src/post-template/edit.js
+++ b/packages/block-library/src/post-template/edit.js
@@ -17,7 +17,7 @@ import {
 	store as blockEditorStore,
 } from '@wordpress/block-editor';
 import { Spinner } from '@wordpress/components';
-import { store as coreStore, useEntityRecords } from '@wordpress/core-data';
+import { store as coreStore } from '@wordpress/core-data';
 
 const TEMPLATE = [
 	[ 'core/post-title' ],
@@ -101,19 +101,6 @@ export default function PostTemplateEdit( {
 } ) {
 	const [ { page } ] = queryContext;
 	const [ activeBlockContextId, setActiveBlockContextId ] = useState();
-
-	let categorySlug = null;
-	if ( templateSlug?.startsWith( 'category-' ) ) {
-		categorySlug = templateSlug.replace( 'category-', '' );
-	}
-	const { records: categories, hasResolved: hasResolvedCategories } =
-		useEntityRecords( 'taxonomy', 'category', {
-			context: 'view',
-			per_page: -1,
-			_fields: [ 'id' ],
-			slug: categorySlug,
-		} );
-
 	const { posts, blocks } = useSelect(
 		( select ) => {
 			const { getEntityRecords, getTaxonomies } = select( coreStore );
@@ -123,12 +110,22 @@ export default function PostTemplateEdit( {
 				per_page: -1,
 				context: 'view',
 			} );
+			const templateCategory =
+				inherit &&
+				templateSlug?.startsWith( 'category-' ) &&
+				getEntityRecords( 'taxonomy', 'category', {
+					context: 'view',
+					per_page: 1,
+					_fields: [ 'id' ],
+					slug: templateSlug.replace( 'category-', '' ),
+				} );
 			const query = {
 				offset: perPage ? perPage * ( page - 1 ) + offset : 0,
 				order,
 				orderby: orderBy,
 			};
-			if ( taxQuery ) {
+			// There is no need to build the taxQuery if we inherit.
+			if ( taxQuery && ! inherit ) {
 				// We have to build the tax query for the REST API and use as
 				// keys the taxonomies `rest_base` with the `term ids` as values.
 				const builtTaxQuery = Object.entries( taxQuery ).reduce(
@@ -174,11 +171,8 @@ export default function PostTemplateEdit( {
 				if ( templateSlug?.startsWith( 'archive-' ) ) {
 					query.postType = templateSlug.replace( 'archive-', '' );
 					postType = query.postType;
-				} else if ( !! categorySlug && hasResolvedCategories ) {
-					query.taxQuery = {
-						category: categories.map( ( { id } ) => id ),
-					};
-					taxQuery = query.taxQuery;
+				} else if ( templateCategory ) {
+					query.categories = templateCategory[ 0 ]?.id;
 				}
 			}
 			// When we preview Query Loop blocks we should prefer the current
@@ -210,9 +204,6 @@ export default function PostTemplateEdit( {
 			parents,
 			restQueryArgs,
 			previewPostType,
-			categories,
-			categorySlug,
-			hasResolvedCategories,
 		]
 	);
 	const blockContexts = useMemo(


### PR DESCRIPTION


<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Fixes: https://github.com/WordPress/gutenberg/issues/44156

In a specific category template in site editor if we have a Query Loop which inherits the global query (`inherit:true`), we try to show a better preview by extracting the current template's category(introduced [here](https://github.com/WordPress/gutenberg/pull/43699)). Currently this can cause an infinite loop and break the block.

<img width="1249" alt="Screenshot 2022-09-14 at 14 53 51" src="https://user-images.githubusercontent.com/846565/190173995-dd22ca67-bb53-4095-b1f4-871a035676de.png">

<!-- In a few words, what is the PR actually doing? -->

## Testing Instructions
1. Create a specific category template in site editor and add a Query Loop which inherits the global query (`inherit:true`)
5. Observe that the preview is. correct and the blocks doesn't break

