### PR TITLE
npm publish: Add --force-publish flag to lerna

### DIFF
--- a/bin/plugin/commands/packages.js
+++ b/bin/plugin/commands/packages.js
@@ -380,7 +380,7 @@ async function publishPackagesToNpm( {
 	} else if ( [ 'bugfix', 'wp' ].includes( releaseType ) ) {
 		log( '>> Publishing modified packages to npm.' );
 		await command(
-			`npx lerna publish ${ minimumVersionBump } --dist-tag ${ distTag } --no-private ${ yesFlag } ${ noVerifyAccessFlag }`,
+			`npx lerna publish ${ minimumVersionBump } --dist-tag ${ distTag } --no-private ${ yesFlag } ${ noVerifyAccessFlag } --force-publish`,
 			{
 				cwd: gitWorkingDirectoryPath,
 				stdio: 'inherit',


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Add the `--force-publish` flag to lerna when invoked for releasing npm packages.

## Why?
There's been a [problem](https://github.com/WordPress/wordpress-develop/pull/3154#issuecomment-1252155850) when publishing npm packages for WP 6.1. It appears that some npm packages didn't get the required `wp-6.1` dist-tag.

## How?
We'll attempt to fix that by re-publishing; however, since there haven't been any changes to some of them, we'll need to force publishing.

Once that's done, we'll revert this PR.

## Testing Instructions

N/A
