### PR TITLE
Backport template creation changes from core

### DIFF
--- a/lib/compat/wordpress-6.1/class-gutenberg-rest-templates-controller.php
+++ b/lib/compat/wordpress-6.1/class-gutenberg-rest-templates-controller.php
@@ -25,11 +25,12 @@ class Gutenberg_REST_Templates_Controller extends WP_REST_Templates_Controller {
 				array(
 					'methods'             => WP_REST_Server::READABLE,
 					'callback'            => array( $this, 'get_template_fallback' ),
-					'permission_callback' => array( $this, 'get_items_permissions_check' ),
+					'permission_callback' => array( $this, 'get_item_permissions_check' ),
 					'args'                => array(
 						'slug'            => array(
 							'description' => __( 'The slug of the template to get the fallback for', 'gutenberg' ),
 							'type'        => 'string',
+							'required'    => true,
 						),
 						'is_custom'       => array(
 							'description' => __( ' Indicates if a template is custom or part of the template hierarchy', 'gutenberg' ),
@@ -54,16 +55,10 @@ class Gutenberg_REST_Templates_Controller extends WP_REST_Templates_Controller {
 	 * @return WP_REST_Response|WP_Error
 	 */
 	public function get_template_fallback( $request ) {
-		if ( empty( $request['slug'] ) ) {
-			return new WP_Error(
-				'rest_invalid_param',
-				__( 'Invalid slug.', 'gutenberg' ),
-				array( 'status' => 400 )
-			);
-		}
 		$hierarchy         = get_template_hierarchy( $request['slug'], $request['is_custom'], $request['template_prefix'] );
 		$fallback_template = resolve_block_template( $request['slug'], $hierarchy, '' );
-		return rest_ensure_response( $fallback_template );
+		$response          = $this->prepare_item_for_response( $fallback_template, $request );
+		return rest_ensure_response( $response );
 	}
 
 	/**

--- a/packages/edit-site/src/components/add-new-template/new-template.js
+++ b/packages/edit-site/src/components/add-new-template/new-template.js
@@ -112,7 +112,7 @@ export default function NewTemplate( { postType } ) {
 						template_prefix: templatePrefix,
 					} ),
 				} );
-				templateContent = fallbackTemplate.content;
+				templateContent = fallbackTemplate.content.raw;
 			}
 			const newTemplate = await saveEntityRecord(
 				'postType',

--- a/phpunit/class-gutenberg-rest-templates-controller-test.php
+++ b/phpunit/class-gutenberg-rest-templates-controller-test.php
@@ -34,33 +34,26 @@ class Gutenberg_REST_Templates_Controller_Test extends WP_Test_REST_Controller_T
 	}
 
 	public function test_get_template_fallback() {
-		$base_path = gutenberg_dir_path() . 'test/emptytheme/block-templates/';
 		wp_set_current_user( self::$admin_id );
 		$request = new WP_REST_Request( 'GET', '/wp/v2/templates/lookup' );
-		// Should match `category.html`.
+		// Should fallback to `category.html`.
 		$request->set_param( 'slug', 'category-fruits' );
 		$request->set_param( 'is_custom', false );
 		$request->set_param( 'template_prefix', 'category' );
 		$response = rest_get_server()->dispatch( $request );
-		$data     = $response->get_data()->content;
-		$expected = file_get_contents( $base_path . 'category.html' );
-		$this->assertEquals( $expected, $data );
-		// Should fallback to `index.html` .
-		$request->set_param( 'slug', 'tag-status' );
-		$request->set_param( 'is_custom', false );
-		$request->set_param( 'template_prefix', 'tag' );
-		$response = rest_get_server()->dispatch( $request );
-		$data     = $response->get_data()->content;
-		$expected = file_get_contents( $base_path . 'index.html' );
-		$this->assertEquals( $expected, $data );
-		// Should fallback to `singular.html` .
+		$this->assertSame( 'category', $response->get_data()['slug'], 'Should fallback to `category.html`.' );
+		// Should fallback to `singular.html`.
 		$request->set_param( 'slug', 'page-hello' );
 		$request->set_param( 'is_custom', false );
 		$request->set_param( 'template_prefix', 'page' );
 		$response = rest_get_server()->dispatch( $request );
-		$data     = $response->get_data()->content;
-		$expected = file_get_contents( $base_path . 'singular.html' );
-		$this->assertEquals( $expected, $data );
+		$this->assertSame( 'singular', $response->get_data()['slug'], 'Should fallback to `singular.html`.' );
+		// Should fallback to `index.html`.
+		$request->set_param( 'slug', 'tag-rigas' );
+		$request->set_param( 'is_custom', false );
+		$request->set_param( 'template_prefix', 'tag' );
+		$response = rest_get_server()->dispatch( $request );
+		$this->assertSame( 'index', $response->get_data()['slug'], 'Should fallback to `index.html`.' );
 	}
 
 	public function test_context_param() {


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
This PR backports from core some changes that were made here: https://github.com/WordPress/wordpress-develop/pull/3221

Here I include the php changes that were made, but this PR will also need to be backported to core to get the `JS` change for the template content retrieval.

## Testing Instructions
1. Template creation in site editor should work as before with no problems.

