### PR TITLE
Update Theme JSON `$schema` to allow pseudo selectors on `button` property

### DIFF
--- a/schemas/json/theme.json
+++ b/schemas/json/theme.json
@@ -1154,6 +1154,9 @@
 							"properties": {
 								"border": {},
 								"color": {},
+								"filter": {},
+								"outline": {},
+								"shadow": {},
 								"spacing": {},
 								"typography": {},
 								":hover": {

--- a/schemas/json/theme.json
+++ b/schemas/json/theme.json
@@ -1145,7 +1145,30 @@
 			"type": "object",
 			"properties": {
 				"button": {
-					"$ref": "#/definitions/stylesPropertiesComplete"
+					"type": "object",
+					"allOf": [
+						{
+							"$ref": "#/definitions/stylesProperties"
+						},
+						{
+							"properties": {
+								"border": {},
+								"color": {},
+								"spacing": {},
+								"typography": {},
+								":hover": {
+									"$ref": "#/definitions/stylesPropertiesComplete"
+								},
+								":focus": {
+									"$ref": "#/definitions/stylesPropertiesComplete"
+								},
+								":active": {
+									"$ref": "#/definitions/stylesPropertiesComplete"
+								}
+							},
+							"additionalProperties": false
+						}
+					]
 				},
 				"link": {
 					"type": "object",


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Provide better IDE feedback to show that the pseudo selectors `:hover`, `:focus`, and `:active` are allowed on the `button` property

See also:

- #41786: Pseudo selector support enabled
- #41936: Pseudo selectors allowed on `link` properties

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

Improving the developer experience – anecdotally, I was trying to implement a button hover style in a full-site theme but wasn't certain that I was doing so the right way since the schema was disallowing my solution

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

Update the schema for top-level and interior blocks to allow the valid pseudo selectors `:hover`, `:focus`, and `:active` on the `button` property

As mentioned in #41936, this adds some code duplication and is not the DRYest solution. If this were implemented for all of the other properties in the same manner, we'd be extremely redundant. However, links and buttons are both very standard properties to support pseudo selector states; I feel that it's fair to add a small bit of duplication to support such a common use.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->

1. Activate a Theme which you can modify locally.
2. Open the Theme's `theme.json` file and update the `$schema` to point to your local Gutenberg version do the schema file (e.g. `"$schema": "file:///Users/{{YOUR_USER}}/Sites/gutenberg/schemas/json/theme.json"`).
3. Add allowed pseudo selector rules (`:hover`, `:focus`, and/or `:active`) under `elements.button` and `{{BLOCK_NAME}}.elements.button` and make sure your editor does not show any warnings or errors.
4. Add disallowed pseudo selector rules (such as any applied to `:empty`) and make sure your editor flags them as disallowed.
5. Add allowed pseudo selector rules under an unsupported element (such as `h2`) and make sure your editor flags them as disallowed.

_Shamelessly adapted from #41936_

## Screenshots or screencast <!-- if applicable -->

### Before

Common `button` pseudo selectors are disallowed even though they are functional and follow the same format/pattern as `link`:

<img width="450" alt="image" src="https://user-images.githubusercontent.com/6765732/191314331-be1f7651-f4bb-4394-9352-982bad2df77b.png">

### After

Allowed pseudo selectors no longer show up as errors, but disallowed ones still do:

<img width="450" alt="image" src="https://user-images.githubusercontent.com/6765732/191315141-24806a45-09ed-46df-a38a-6e5a51ad0d5b.png">
