### PR TITLE
Enforce coding guideline regarding the usage of quotation marks.

### DIFF
--- a/docs/reference-guides/core-blocks.md
+++ b/docs/reference-guides/core-blocks.md
@@ -28,7 +28,7 @@ Embed a simple audio player. ([Source](https://github.com/WordPress/gutenberg/tr
 
 ## Avatar
 
-Add a user's avatar. ([Source](https://github.com/WordPress/gutenberg/tree/trunk/packages/block-library/src/avatar))
+Add a user’s avatar. ([Source](https://github.com/WordPress/gutenberg/tree/trunk/packages/block-library/src/avatar))
 
 -	**Name:** core/avatar
 -	**Category:** theme
@@ -730,7 +730,7 @@ Display a graphic to represent this site. Update the block, and the changes appl
 
 ## Site Tagline
 
-Describe in a few words what the site is about. The tagline can be used in search results or when sharing on social networks even if it's not displayed in the theme design. ([Source](https://github.com/WordPress/gutenberg/tree/trunk/packages/block-library/src/site-tagline))
+Describe in a few words what the site is about. The tagline can be used in search results or when sharing on social networks even if it’s not displayed in the theme design. ([Source](https://github.com/WordPress/gutenberg/tree/trunk/packages/block-library/src/site-tagline))
 
 -	**Name:** core/site-tagline
 -	**Category:** theme

--- a/packages/block-library/src/avatar/block.json
+++ b/packages/block-library/src/avatar/block.json
@@ -4,7 +4,7 @@
 	"name": "core/avatar",
 	"title": "Avatar",
 	"category": "theme",
-	"description": "Add a user's avatar.",
+	"description": "Add a user’s avatar.",
 	"textdomain": "default",
 	"attributes": {
 		"userId": {

--- a/packages/block-library/src/block/edit.native.js
+++ b/packages/block-library/src/block/edit.native.js
@@ -163,7 +163,7 @@ export default function ReusableBlockEdit( {
 					</Text>
 					<Text style={ [ infoTextStyle, infoDescriptionStyle ] }>
 						{ __(
-							'Alternatively, you can detach and edit these blocks separately by tapping "Convert to regular blocks".'
+							'Alternatively, you can detach and edit these blocks separately by tapping “Convert to regular blocks”.'
 						) }
 					</Text>
 					<TextControl

--- a/packages/block-library/src/code/index.js
+++ b/packages/block-library/src/code/index.js
@@ -24,7 +24,7 @@ export const settings = {
 			/* eslint-disable @wordpress/i18n-no-collapsible-whitespace */
 			// translators: Preserve \n markers for line breaks
 			content: __(
-				'// A "block" is the abstract term used\n// to describe units of markup that\n// when composed together, form the\n// content or layout of a page.\nregisterBlockType( name, settings );'
+				'// A “block” is the abstract term used\n// to describe units of markup that\n// when composed together, form the\n// content or layout of a page.\nregisterBlockType( name, settings );'
 			),
 			/* eslint-enable @wordpress/i18n-no-collapsible-whitespace */
 		},

--- a/packages/block-library/src/comments-title/edit.js
+++ b/packages/block-library/src/comments-title/edit.js
@@ -104,7 +104,7 @@ export default function Edit( {
 		</InspectorControls>
 	);
 
-	const postTitle = isSiteEditor ? __( '"Post Title"' ) : `"${ rawTitle }"`;
+	const postTitle = isSiteEditor ? __( '“Post Title”' ) : `"${ rawTitle }"`;
 
 	let placeholder;
 	if ( showCommentsCount && commentsCount !== undefined ) {

--- a/packages/block-library/src/comments/edit/comments-legacy.js
+++ b/packages/block-library/src/comments/edit/comments-legacy.js
@@ -57,7 +57,7 @@ export default function CommentsLegacy( {
 			<div { ...blockProps }>
 				<Warning actions={ actions }>
 					{ __(
-						"Comments block: You’re currently using the legacy version of the block. " +
+						'Comments block: You’re currently using the legacy version of the block. ' +
 							'The following is just a placeholder - the final styling will likely look different. ' +
 							'For a better representation and more customization options, ' +
 							'switch the block to its editable mode.'

--- a/packages/block-library/src/comments/edit/comments-legacy.js
+++ b/packages/block-library/src/comments/edit/comments-legacy.js
@@ -57,7 +57,7 @@ export default function CommentsLegacy( {
 			<div { ...blockProps }>
 				<Warning actions={ actions }>
 					{ __(
-						"Comments block: You're currently using the legacy version of the block. " +
+						"Comments block: You’re currently using the legacy version of the block. " +
 							'The following is just a placeholder - the final styling will likely look different. ' +
 							'For a better representation and more customization options, ' +
 							'switch the block to its editable mode.'

--- a/packages/block-library/src/more/edit.js
+++ b/packages/block-library/src/more/edit.js
@@ -54,7 +54,7 @@ export default function MoreEdit( {
 			</InspectorControls>
 			<div { ...useBlockProps() }>
 				<input
-					aria-label={ __( 'Read more link text' ) }
+					aria-label={ __( '“Read more” link text' ) }
 					type="text"
 					value={ customText }
 					placeholder={ DEFAULT_TEXT }

--- a/packages/block-library/src/post-excerpt/edit.js
+++ b/packages/block-library/src/post-excerpt/edit.js
@@ -87,7 +87,7 @@ export default function PostExcerptEditor( {
 		<RichText
 			className="wp-block-post-excerpt__more-link"
 			tagName="a"
-			aria-label={ __( '"Read more" link text' ) }
+			aria-label={ __( '“Read more” link text' ) }
 			placeholder={ __( 'Add "read more" link text' ) }
 			value={ moreText }
 			onChange={ ( newMoreText ) =>

--- a/packages/block-library/src/query-title/edit.js
+++ b/packages/block-library/src/query-title/edit.js
@@ -85,7 +85,7 @@ export default function QueryTitleEdit( {
 
 				<TagName { ...blockProps }>
 					{ showSearchTerm
-						? __( 'Search results for: "search term"' )
+						? __( 'Search results for: “search term”' )
 						: __( 'Search results' ) }
 				</TagName>
 			</>

--- a/packages/block-library/src/query/edit/inspector-controls/index.js
+++ b/packages/block-library/src/query/edit/inspector-controls/index.js
@@ -133,7 +133,7 @@ export default function QueryInspectorControls( {
 								label={ __( 'Post type' ) }
 								onChange={ onPostTypeChange }
 								help={ __(
-									'WordPress contains different types of content and they are divided into collections called "Post types". By default there are a few different ones such as blog posts and pages, but plugins could add more.'
+									'WordPress contains different types of content and they are divided into collections called “Post types”. By default there are a few different ones such as blog posts and pages, but plugins could add more.'
 								) }
 							/>
 						) }

--- a/packages/block-library/src/query/edit/inspector-controls/sticky-control.js
+++ b/packages/block-library/src/query/edit/inspector-controls/sticky-control.js
@@ -18,7 +18,7 @@ export default function StickyControl( { value, onChange } ) {
 			value={ value }
 			onChange={ onChange }
 			help={ __(
-				'Blog posts can be "stickied", a feature that places them at the top of the front page of posts, keeping it there until new sticky posts are published.'
+				'Blog posts can be “stickied”, a feature that places them at the top of the front page of posts, keeping it there until new sticky posts are published.'
 			) }
 		/>
 	);

--- a/packages/block-library/src/quote/block.json
+++ b/packages/block-library/src/quote/block.json
@@ -4,7 +4,7 @@
 	"name": "core/quote",
 	"title": "Quote",
 	"category": "text",
-	"description": "Give quoted text visual emphasis. “In quoting others, we cite ourselves.” — Julio Cortázar",
+	"description": "Give quoted text visual emphasis. \"In quoting others, we cite ourselves.\" — Julio Cortázar",
 	"keywords": [ "blockquote", "cite" ],
 	"textdomain": "default",
 	"attributes": {

--- a/packages/block-library/src/quote/block.json
+++ b/packages/block-library/src/quote/block.json
@@ -4,7 +4,7 @@
 	"name": "core/quote",
 	"title": "Quote",
 	"category": "text",
-	"description": "Give quoted text visual emphasis. \"In quoting others, we cite ourselves.\" — Julio Cortázar",
+	"description": "Give quoted text visual emphasis. “In quoting others, we cite ourselves.” — Julio Cortázar",
 	"keywords": [ "blockquote", "cite" ],
 	"textdomain": "default",
 	"attributes": {

--- a/packages/block-library/src/read-more/edit.js
+++ b/packages/block-library/src/read-more/edit.js
@@ -33,7 +33,7 @@ export default function ReadMore( {
 			</InspectorControls>
 			<RichText
 				tagName="a"
-				aria-label={ __( '"Read more" link text' ) }
+				aria-label={ __( '“Read more” link text' ) }
 				placeholder={ __( 'Read more' ) }
 				value={ content }
 				onChange={ ( newValue ) =>

--- a/packages/block-library/src/site-tagline/block.json
+++ b/packages/block-library/src/site-tagline/block.json
@@ -4,7 +4,7 @@
 	"name": "core/site-tagline",
 	"title": "Site Tagline",
 	"category": "theme",
-	"description": "Describe in a few words what the site is about. The tagline can be used in search results or when sharing on social networks even if it's not displayed in the theme design.",
+	"description": "Describe in a few words what the site is about. The tagline can be used in search results or when sharing on social networks even if it’s not displayed in the theme design.",
 	"keywords": [ "description" ],
 	"textdomain": "default",
 	"attributes": {


### PR DESCRIPTION
## What
Updates text strings that don’t follow the [coding guideline](https://github.com/WordPress/gutenberg/blob/939cb7cdc16ce4cbb0d0f430f2b710371705bc3e/docs/contributors/code/coding-guidelines.md#strings) regarding the usage of the apostrophe instead of single-quote characters.

It also looks for double-quote characters (aka “straight quotes”) and replace then with appropriate “curly quotes”. 

## Why
Besides enforcing a coding guideline, this is a good opportunity to push for better typographic handling of text strings, as WordPress now focus more on design. 

## How
I just manually searched for instances of text strings that include single or double-quote characters and changed them accordingly where appropriate.

Several blocks already followed the guideline regarging the usage of the apostrophe, but there were many more that did not. Apostrophes or curly quotes are already used in user-facing messages in the following blocks:

- Site title
- Calendar
- Unsupported
- Reusable
- Site logo

The following blocks include user-facing messages that include straight quotation marks:

- Avatar
- Block
- Code
- Comments
- Comments title
- More
- Post excerpt
- Query
- Query Title
- Quote
- Read more
- Site tagline

## Testing Instructions
Add any of the above blocks in the site editor or post editor, and check user-facing messages for the use of the apostrophe or curly quotes.

![2022-09-20 16 45 18](https://user-images.githubusercontent.com/1451087/191373679-2ca5e407-62cd-4e99-a968-3ce3942bcff5.gif)


