### PR TITLE
Update json2php to v0.0.5

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16929,14 +16929,6 @@
 			"requires": {
 				"json2php": "^0.0.5",
 				"webpack-sources": "^3.2.2"
-			},
-			"dependencies": {
-				"json2php": {
-					"version": "0.0.5",
-					"resolved": "https://registry.npmjs.org/json2php/-/json2php-0.0.5.tgz",
-					"integrity": "sha512-jWpsGAYlQDKOjJcyq3rYaxcZ+5YMhZIKHKTjdIKJPI9zLSX+yRWHSSwtV8hvIg7YMhbKkgPO669Ve2ZgFK5C7w==",
-					"dev": true
-				}
 			}
 		},
 		"@wordpress/deprecated": {
@@ -42183,6 +42175,12 @@
 			"version": "5.0.1",
 			"resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
 			"integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus=",
+			"dev": true
+		},
+		"json2php": {
+			"version": "0.0.5",
+			"resolved": "https://registry.npmjs.org/json2php/-/json2php-0.0.5.tgz",
+			"integrity": "sha512-jWpsGAYlQDKOjJcyq3rYaxcZ+5YMhZIKHKTjdIKJPI9zLSX+yRWHSSwtV8hvIg7YMhbKkgPO669Ve2ZgFK5C7w==",
 			"dev": true
 		},
 		"json5": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -16927,8 +16927,16 @@
 			"version": "file:packages/dependency-extraction-webpack-plugin",
 			"dev": true,
 			"requires": {
-				"json2php": "^0.0.4",
+				"json2php": "^0.0.5",
 				"webpack-sources": "^3.2.2"
+			},
+			"dependencies": {
+				"json2php": {
+					"version": "0.0.5",
+					"resolved": "https://registry.npmjs.org/json2php/-/json2php-0.0.5.tgz",
+					"integrity": "sha512-jWpsGAYlQDKOjJcyq3rYaxcZ+5YMhZIKHKTjdIKJPI9zLSX+yRWHSSwtV8hvIg7YMhbKkgPO669Ve2ZgFK5C7w==",
+					"dev": true
+				}
 			}
 		},
 		"@wordpress/deprecated": {
@@ -42175,12 +42183,6 @@
 			"version": "5.0.1",
 			"resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
 			"integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus=",
-			"dev": true
-		},
-		"json2php": {
-			"version": "0.0.4",
-			"resolved": "https://registry.npmjs.org/json2php/-/json2php-0.0.4.tgz",
-			"integrity": "sha1-a9haHdpqXdfpECK7JEA8wbfC7jQ=",
 			"dev": true
 		},
 		"json5": {

--- a/packages/dependency-extraction-webpack-plugin/package.json
+++ b/packages/dependency-extraction-webpack-plugin/package.json
@@ -29,7 +29,7 @@
 	"main": "lib/index.js",
 	"types": "lib/types.d.ts",
 	"dependencies": {
-		"json2php": "^0.0.4",
+		"json2php": "^0.0.5",
 		"webpack-sources": "^3.2.2"
 	},
 	"peerDependencies": {


### PR DESCRIPTION
## What?
Updates the `json2php` package to [v0.0.5](https://github.com/daniel-zahariev/json2php/releases/tag/0.0.5).
In v0.0.5, the package added support for bool values (they were previously getting converted to `null`, and this update also included some nice code cleanups).

## Why?
This came up while working on https://github.com/WordPress/wordpress-develop/pull/2252 where the missing boolean values were messing up things. It would be prudent to use the same version in Gutenberg as well - and allow booleans in case we need them in the future.

## How?
Updated the version in `package.json` and then ran `npm install && npm run build`
