### PR TITLE
Removes whitespace from l18n-strings

### DIFF
--- a/lib/compat/wordpress-6.1/class-gutenberg-rest-block-patterns-controller.php
+++ b/lib/compat/wordpress-6.1/class-gutenberg-rest-block-patterns-controller.php
@@ -187,7 +187,7 @@ class Gutenberg_REST_Block_Patterns_Controller extends WP_REST_Controller {
 					'context'     => array( 'view', 'edit', 'embed' ),
 				),
 				'post_types'     => array(
-					'description' => __( ' An array of post types that the pattern is restricted to be used with.', 'gutenberg' ),
+					'description' => __(' An array of post types that the pattern is restricted to be used with.', 'gutenberg' ),
 					'type'        => 'array',
 					'readonly'    => true,
 					'context'     => array( 'view', 'edit', 'embed' ),

--- a/lib/compat/wordpress-6.1/class-gutenberg-rest-block-patterns-controller.php
+++ b/lib/compat/wordpress-6.1/class-gutenberg-rest-block-patterns-controller.php
@@ -187,7 +187,7 @@ class Gutenberg_REST_Block_Patterns_Controller extends WP_REST_Controller {
 					'context'     => array( 'view', 'edit', 'embed' ),
 				),
 				'post_types'     => array(
-					'description' => __(' An array of post types that the pattern is restricted to be used with.', 'gutenberg' ),
+					'description' => __( 'An array of post types that the pattern is restricted to be used with.', 'gutenberg' ),
 					'type'        => 'array',
 					'readonly'    => true,
 					'context'     => array( 'view', 'edit', 'embed' ),

--- a/lib/compat/wordpress-6.1/class-gutenberg-rest-templates-controller.php
+++ b/lib/compat/wordpress-6.1/class-gutenberg-rest-templates-controller.php
@@ -33,7 +33,7 @@ class Gutenberg_REST_Templates_Controller extends WP_REST_Templates_Controller {
 							'required'    => true,
 						),
 						'is_custom'       => array(
-							'description' => __( ' Indicates if a template is custom or part of the template hierarchy', 'gutenberg' ),
+							'description' => __( 'Indicates if a template is custom or part of the template hierarchy', 'gutenberg' ),
 							'type'        => 'boolean',
 						),
 						'template_prefix' => array(


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->
This PR removes whitespaces from l18n-strings and closes #44312  

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
Whitespaces should not be included before the actual string.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->

## Screenshots or screencast <!-- if applicable -->
