### PR TITLE
Pullquote: fix transform to quote crash

### DIFF
--- a/packages/block-library/src/quote/transforms.js
+++ b/packages/block-library/src/quote/transforms.js
@@ -17,7 +17,7 @@ const transforms = {
 						fontSize,
 						style,
 					},
-					createBlock( 'core/paragraph', { content: value } )
+					[ createBlock( 'core/paragraph', { content: value } ) ]
 				);
 			},
 		},

--- a/packages/e2e-tests/specs/editor/blocks/pullquote.test.js
+++ b/packages/e2e-tests/specs/editor/blocks/pullquote.test.js
@@ -1,0 +1,47 @@
+/**
+ * WordPress dependencies
+ */
+import {
+	clickBlockAppender,
+	getEditedPostContent,
+	createNewPost,
+	transformBlockTo,
+} from '@wordpress/e2e-test-utils';
+
+describe( 'Quote', () => {
+	beforeEach( async () => {
+		await createNewPost();
+	} );
+
+	it( 'can be created by converting a quote and converted back to quote', async () => {
+		await clickBlockAppender();
+		await page.keyboard.type( 'test' );
+		await transformBlockTo( 'Quote' );
+
+		expect( await getEditedPostContent() ).toMatchInlineSnapshot( `
+		"<!-- wp:quote -->
+		<blockquote class=\\"wp-block-quote\\"><!-- wp:paragraph -->
+		<p>test</p>
+		<!-- /wp:paragraph --></blockquote>
+		<!-- /wp:quote -->"
+	` );
+
+		await transformBlockTo( 'Pullquote' );
+
+		expect( await getEditedPostContent() ).toMatchInlineSnapshot( `
+		"<!-- wp:pullquote -->
+		<figure class=\\"wp-block-pullquote\\"><blockquote><p>test</p></blockquote></figure>
+		<!-- /wp:pullquote -->"
+	` );
+
+		await transformBlockTo( 'Quote' );
+
+		expect( await getEditedPostContent() ).toMatchInlineSnapshot( `
+		"<!-- wp:quote -->
+		<blockquote class=\\"wp-block-quote\\"><!-- wp:paragraph -->
+		<p>test</p>
+		<!-- /wp:paragraph --></blockquote>
+		<!-- /wp:quote -->"
+	` );
+	} );
+} );


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Fixes #44307. Inner blocks is not an array. It was caused by me in #43210. 

Also adds an e2e test.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->

## Screenshots or screencast <!-- if applicable -->
