### PR TITLE
Font Family Picker: allow selecting "Default" font for heading elements and blocks (doesn't work on some themes)

### DIFF
--- a/packages/block-editor/src/components/font-family/index.js
+++ b/packages/block-editor/src/components/font-family/index.js
@@ -16,6 +16,7 @@ import useSetting from '../use-setting';
 
 export default function FontFamilyControl( {
 	value = '',
+	defaultValue = '',
 	onChange,
 	fontFamilies,
 	...props
@@ -30,7 +31,7 @@ export default function FontFamilyControl( {
 	}
 
 	const options = [
-		{ value: '', label: __( 'Default' ) },
+		{ value: defaultValue, label: __( 'Default' ) },
 		...fontFamilies.map( ( { fontFamily, name } ) => {
 			return {
 				value: fontFamily,

--- a/packages/edit-site/src/components/global-styles/constants.js
+++ b/packages/edit-site/src/components/global-styles/constants.js
@@ -1,0 +1,7 @@
+/**
+ * The default font-family. Used to indicate that no font-family style rule should
+ * be output for an element or block which will use a higher-level style instead
+ *
+ * @type {string}
+ */
+export const DEFAULT_FONT_FAMILY = 'default_font_family';

--- a/packages/edit-site/src/components/global-styles/global-styles-provider.js
+++ b/packages/edit-site/src/components/global-styles/global-styles-provider.js
@@ -14,15 +14,25 @@ import { store as coreStore } from '@wordpress/core-data';
  * Internal dependencies
  */
 import { GlobalStylesContext } from './context';
+import { DEFAULT_FONT_FAMILY } from './constants';
 
 const identity = ( x ) => x;
 
-function mergeTreesCustomizer( _, srcValue ) {
+function mergeTreesCustomizer( _, srcValue, key ) {
 	// We only pass as arrays the presets,
 	// in which case we want the new array of values
 	// to override the old array (no merging).
 	if ( Array.isArray( srcValue ) ) {
 		return srcValue;
+	}
+
+	if ( srcValue === DEFAULT_FONT_FAMILY && key === 'fontFamily' ) {
+		// a null value signals no CSS rule should be output. For heading
+		// styles, e.g. H1, this will mean they use the "All" headings style.
+		// For block styles, e.g. Site Title, this will mean they inherit the default
+		// style for the heading element they are based on e.g. if the Site Title
+		// is an H2 element then the current H2 font-family will be used
+		return null;
 	}
 }
 

--- a/packages/edit-site/src/components/global-styles/test/global-styles-provider.js
+++ b/packages/edit-site/src/components/global-styles/test/global-styles-provider.js
@@ -1,0 +1,44 @@
+/**
+ * Internal dependencies
+ */
+import { mergeBaseAndUserConfigs } from '../global-styles-provider';
+import { DEFAULT_FONT_FAMILY } from '../constants';
+
+describe( 'global styles provider', () => {
+	describe( 'mergeBaseAndUserConfigs', () => {
+		it( 'should output value if non-default fontFamily is used', () => {
+			const { base, user } = makeConfigs( 'serif' );
+			const result = mergeBaseAndUserConfigs( base, user );
+			expect( result.styles.elements.h1.fontFamily ).toBe( 'serif' );
+		} );
+
+		it( 'should output null if default fontFamily is used', () => {
+			const { base, user } = makeConfigs( DEFAULT_FONT_FAMILY );
+			const result = mergeBaseAndUserConfigs( base, user );
+			expect( result.styles.elements.h1.fontFamily ).toBe( null );
+		} );
+	} );
+} );
+
+const makeConfigs = ( fontFamily ) => {
+	return {
+		base: {
+			styles: {
+				elements: {
+					h1: {
+						fontFamily: 'base',
+					},
+				},
+			},
+		},
+		user: {
+			styles: {
+				elements: {
+					h1: {
+						fontFamily,
+					},
+				},
+			},
+		},
+	};
+};

--- a/packages/edit-site/src/components/global-styles/typography-panel.js
+++ b/packages/edit-site/src/components/global-styles/typography-panel.js
@@ -21,6 +21,7 @@ import { useState } from '@wordpress/element';
  * Internal dependencies
  */
 import { getSupportedGlobalStylesPanels, useSetting, useStyle } from './hooks';
+import { DEFAULT_FONT_FAMILY } from './constants';
 
 export function useHasTypographyPanel( name ) {
 	const hasLineHeight = useHasLineHeightControl( name );
@@ -180,7 +181,7 @@ export default function TypographyPanel( { name, element } ) {
 						>
 							<ToggleGroupControlOption
 								value="heading"
-								/* translators: 'All' refers to selecting all heading levels 
+								/* translators: 'All' refers to selecting all heading levels
 							and applying the same style to h1-h6. */
 								label={ __( 'All' ) }
 							/>
@@ -215,6 +216,7 @@ export default function TypographyPanel( { name, element } ) {
 					<div className="edit-site-typography-panel__full-width-control">
 						<FontFamilyControl
 							fontFamilies={ fontFamilies }
+							defaultValue={ DEFAULT_FONT_FAMILY }
 							value={ fontFamily }
 							onChange={ setFontFamily }
 							size="__unstable-large"


### PR DESCRIPTION
**Incomplete - full details to follow**. 

<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Allow users to select the "Default" Heading Font on themes that specify `fontFamily` at element/block-level e.g. Pendant. 

## Why?
If you wanted to set your All Heading Font to "X" and then set, say, your H2 to "Default" then you would expect the H2 `font-family` to use "X" font but this didn't work on some themes like Pendant. 

## How?
The "Default" Font value was `''` which didn't survive the [config merge logic](https://github.com/WordPress/gutenberg/blob/58c78ec5200a38401281c14186095bced2f6f12a/packages/edit-site/src/components/global-styles/global-styles-provider.js#L29) and meant the [base value](https://github.com/Automattic/themes/blob/trunk/pendant/theme.json#L309) was always used if was present. This PR uses a non-empty value which is later set to null to indicate that no additional `font-family` style should be output for the element or block. Instead, the element/block will inherit the `font-family` style set at a higher level. 

Another benefit is that this PR also provides a link between heading elements and heading blocks. Now, if you set your Site Title font to "Default", it will update whenever you change the element, e.g. H1, that it is based on. 

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->

## Screenshots or screencast <!-- if applicable -->
