### PR TITLE
Packages: Ensure all packages get minor/major version bump when requested

### DIFF
--- a/bin/plugin/commands/packages.js
+++ b/bin/plugin/commands/packages.js
@@ -164,10 +164,6 @@ async function updatePackages( config ) {
 		}
 	);
 
-	const productionPackageNames = Object.keys(
-		require( '../../../package.json' ).dependencies
-	);
-
 	const processedPackages = await Promise.all(
 		changelogFilesPublicPackages.map( async ( changelogPath ) => {
 			const fileStream = fs.createReadStream( changelogPath );
@@ -187,13 +183,12 @@ async function updatePackages( config ) {
 			const packageName = `@wordpress/${
 				changelogPath.split( '/' ).reverse()[ 1 ]
 			}`;
-			// Enforce version bump for production packages when
+			// Enforce version bump for all packages when
 			// the stable minor or major version bump requested.
 			if (
 				! versionBump &&
 				releaseType !== 'next' &&
-				minimumVersionBump !== 'patch' &&
-				productionPackageNames.includes( packageName )
+				minimumVersionBump !== 'patch'
 			) {
 				versionBump = minimumVersionBump;
 			}


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Whenever we publish production packages to npm with the Gutenberg plugin RC1 release, we enforce that at minimum `minor` version bump is applied to leave space for bug fixes releases. It's mostly necessary when handling security/bug fixes for WordPress core. 

This patch proposes we update versions for all existing non-private packages.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

We didn't do that for development packages, but it turned out to be problematic with preparations for WordPress 6.1 release where one of the packages had lower version in the `trunk` than on npm - it was published from `wp/6.0` branch.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

Remove the check that enforces minor/major version bump only for production packages.