### PR TITLE
Prevent resize observer loops in BlockPreview

### DIFF
--- a/packages/block-editor/src/components/block-preview/auto.js
+++ b/packages/block-editor/src/components/block-preview/auto.js
@@ -20,13 +20,12 @@ let MemoizedBlockList;
 
 const MAX_HEIGHT = 2000;
 
-function AutoBlockPreview( {
+function ScaledBlockPreview( {
 	viewportWidth,
+	containerWidth,
 	__experimentalPadding,
 	__experimentalMinHeight,
 } ) {
-	const [ containerResizeListener, { width: containerWidth } ] =
-		useResizeObserver();
 	const [ contentResizeListener, { height: contentHeight } ] =
 		useResizeObserver();
 	const { styles, assets, duotone } = useSelect( ( select ) => {
@@ -62,71 +61,84 @@ function AutoBlockPreview( {
 
 	const scale = containerWidth / viewportWidth;
 	return (
-		<div className="block-editor-block-preview__container">
-			{ containerResizeListener }
-			<Disabled
-				className="block-editor-block-preview__content"
+		<Disabled
+			className="block-editor-block-preview__content"
+			style={ {
+				transform: `scale(${ scale })`,
+				height: contentHeight * scale,
+				maxHeight:
+					contentHeight > MAX_HEIGHT ? MAX_HEIGHT * scale : undefined,
+				minHeight: __experimentalMinHeight,
+			} }
+		>
+			<Iframe
+				head={ <EditorStyles styles={ editorStyles } /> }
+				assets={ assets }
+				contentRef={ useRefEffect( ( bodyElement ) => {
+					const {
+						ownerDocument: { documentElement },
+					} = bodyElement;
+					documentElement.classList.add(
+						'block-editor-block-preview__content-iframe'
+					);
+					documentElement.style.position = 'absolute';
+					documentElement.style.width = '100%';
+					bodyElement.style.padding = __experimentalPadding + 'px';
+
+					// Necessary for contentResizeListener to work.
+					bodyElement.style.boxSizing = 'border-box';
+					bodyElement.style.position = 'absolute';
+					bodyElement.style.width = '100%';
+				}, [] ) }
+				aria-hidden
+				tabIndex={ -1 }
 				style={ {
-					transform: `scale(${ scale })`,
-					height: contentHeight * scale,
-					maxHeight:
-						contentHeight > MAX_HEIGHT
-							? MAX_HEIGHT * scale
-							: undefined,
-					minHeight: __experimentalMinHeight,
+					position: 'absolute',
+					width: viewportWidth,
+					height: contentHeight,
+					pointerEvents: 'none',
+					// This is a catch-all max-height for patterns.
+					// See: https://github.com/WordPress/gutenberg/pull/38175.
+					maxHeight: MAX_HEIGHT,
+					minHeight:
+						scale !== 0 && scale < 1 && __experimentalMinHeight
+							? __experimentalMinHeight / scale
+							: __experimentalMinHeight,
 				} }
 			>
-				<Iframe
-					head={ <EditorStyles styles={ editorStyles } /> }
-					assets={ assets }
-					contentRef={ useRefEffect( ( bodyElement ) => {
-						const {
-							ownerDocument: { documentElement },
-						} = bodyElement;
-						documentElement.classList.add(
-							'block-editor-block-preview__content-iframe'
-						);
-						documentElement.style.position = 'absolute';
-						documentElement.style.width = '100%';
-						bodyElement.style.padding =
-							__experimentalPadding + 'px';
-
-						// Necessary for contentResizeListener to work.
-						bodyElement.style.boxSizing = 'border-box';
-						bodyElement.style.position = 'absolute';
-						bodyElement.style.width = '100%';
-					}, [] ) }
-					aria-hidden
-					tabIndex={ -1 }
-					style={ {
-						position: 'absolute',
-						width: viewportWidth,
-						height: contentHeight,
-						pointerEvents: 'none',
-						// This is a catch-all max-height for patterns.
-						// See: https://github.com/WordPress/gutenberg/pull/38175.
-						maxHeight: MAX_HEIGHT,
-						minHeight:
-							scale !== 0 && scale < 1 && __experimentalMinHeight
-								? __experimentalMinHeight / scale
-								: __experimentalMinHeight,
-					} }
-				>
-					{ contentResizeListener }
-					{
-						/* Filters need to be rendered before children to avoid Safari rendering issues. */
-						svgFilters.map( ( preset ) => (
-							<PresetDuotoneFilter
-								preset={ preset }
-								key={ preset.slug }
-							/>
-						) )
-					}
-					<MemoizedBlockList renderAppender={ false } />
-				</Iframe>
-			</Disabled>
-		</div>
+				{ contentResizeListener }
+				{
+					/* Filters need to be rendered before children to avoid Safari rendering issues. */
+					svgFilters.map( ( preset ) => (
+						<PresetDuotoneFilter
+							preset={ preset }
+							key={ preset.slug }
+						/>
+					) )
+				}
+				<MemoizedBlockList renderAppender={ false } />
+			</Iframe>
+		</Disabled>
 	);
 }
 
-export default AutoBlockPreview;
+export default function AutoBlockPreview( props ) {
+	const [ containerResizeListener, { width: containerWidth } ] =
+		useResizeObserver();
+
+	return (
+		<>
+			<div style={ { position: 'relative', width: '100%', height: 0 } }>
+				{ containerResizeListener }
+			</div>
+			<div className="block-editor-block-preview__container">
+				{ !! containerWidth && (
+					<ScaledBlockPreview
+						{ ...props }
+						containerWidth={ containerWidth }
+					/>
+				) }
+			</div>
+		</>
+	);
+}


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?

In Safari, if the callback of a `ResizeObserver` triggers a change in height/width of the observed elements, a warning is triggered on the console. In trunk, this happens for all block preview, this PR solves that in a lot of situations.

## Why?

A small performance improvement.

## How?

I've moved the "width" resize observer to a separate "div", this means whenever the "height" of the preview changes, the height of that top level "width" observer doesn't change, so there's no loop there. The height is now fixed to 0 for that hidden div.

## Testing Instructions

1- In Safari, open the inserter
2- Hover a block 
3- No warning is triggered on the console when the block preview shows up.
