### PR TITLE
Fix cover preview

### DIFF
--- a/packages/block-library/src/cover/index.js
+++ b/packages/block-library/src/cover/index.js
@@ -30,9 +30,16 @@ export const settings = {
 			{
 				name: 'core/paragraph',
 				attributes: {
-					customFontSize: 48,
 					content: __( '<strong>Snow Patrol</strong>' ),
 					align: 'center',
+					style: {
+						typography: {
+							fontSize: 48,
+						},
+						color: {
+							text: 'white',
+						},
+					},
 				},
 			},
 		],


### PR DESCRIPTION
## What?

The cover block preview in the inserter is using old syntax so it isn't accurate:

<img width="318" alt="Screenshot 2022-09-21 at 11 34 31" src="https://user-images.githubusercontent.com/1204802/191472441-69b9a1bb-0cb1-47ca-b363-5e6c7289da34.png">

This PR updates the syntax to work again:


<img width="439" alt="Screenshot 2022-09-21 at 11 41 59" src="https://user-images.githubusercontent.com/1204802/191472485-2d0dc0d2-2387-4424-8453-2c3f1c5a540c.png">

## Testing Instructions

Hover the cover block in the inserter.

See also unrelated issue discovered in the process: #44320