### PR TITLE
Block Popover: use placement instead of position, move to useBlockToolbarPopoverProps hook

### DIFF
--- a/packages/block-editor/src/components/block-popover/index.js
+++ b/packages/block-editor/src/components/block-popover/index.js
@@ -98,7 +98,6 @@ function BlockPopover(
 		<Popover
 			ref={ mergedRefs }
 			animate={ false }
-			position="top right left"
 			focusOnMount={ false }
 			anchor={ popoverAnchor }
 			// Render in the old slot if needed for backward compatibility,

--- a/packages/block-editor/src/components/block-tools/use-block-toolbar-popover-props.js
+++ b/packages/block-editor/src/components/block-tools/use-block-toolbar-popover-props.js
@@ -11,10 +11,15 @@ import { useCallback, useLayoutEffect, useState } from '@wordpress/element';
 import { store as blockEditorStore } from '../../store';
 import { __unstableUseBlockElement as useBlockElement } from '../block-list/use-block-props/use-block-refs';
 
+const COMMON_PROPS = {
+	placement: 'top-start',
+};
+
 // By default the toolbar sets the `shift` prop. If the user scrolls the page
 // down the toolbar will stay on screen by adopting a sticky position at the
 // top of the viewport.
 const DEFAULT_PROPS = {
+	...COMMON_PROPS,
 	flip: false,
 	shift: true,
 };
@@ -25,6 +30,7 @@ const DEFAULT_PROPS = {
 // the block. This only happens if the block is smaller than the viewport, as
 // otherwise the toolbar will be off-screen.
 const RESTRICTED_HEIGHT_PROPS = {
+	...COMMON_PROPS,
 	flip: true,
 	shift: false,
 };


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

This PR:

- uses the (new) `placement` prop instead of the (legacy) `position` prop for the `Popover` component in the Block Toolbar
- moves the `placement` prop from being assigned to the `Popover` component inline, to the `useBlockToolbarPopoverProps` prop

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

- `placement` is the prop that should be used for positioning the `Popover` component. The legacy `position` prop will soon be deprecated
- it makes sense for the prop to be part of the return value of `useBlockToolbarPopoverProps`, because the logic inside that hook really only makes sense with top/bottom placements. And so, having `placement` closer to the `useBlockToolbarPopoverProps` logic made more sense to me (this was also reported in https://github.com/WordPress/gutenberg/pull/42887#issuecomment-1242717534)

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

Since `placement` needs to be always returned (regardless of whether there is enough space above the block or not), I've created a `COMMON_PROPS` object that is spread into both `DEFAULT_PROPS` and `RESTRICTED_HEIGHT_PROPS`

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->

Play around with the block toolbar, make sure that its placement is the same as on `trunk`:

 - both in the post editor and in the site editor
 - both for blocks next to the very top of the page, and for block further down the page