### PR TITLE
Missing Block: Fix HTML block check

### DIFF
--- a/packages/block-directory/src/plugins/get-install-missing/index.js
+++ b/packages/block-directory/src/plugins/get-install-missing/index.js
@@ -3,7 +3,7 @@
  */
 import { __, sprintf } from '@wordpress/i18n';
 import { Button } from '@wordpress/components';
-import { createBlock, getBlockType } from '@wordpress/blocks';
+import { createBlock } from '@wordpress/blocks';
 import { RawHTML } from '@wordpress/element';
 import { useDispatch, useSelect } from '@wordpress/data';
 import { store as coreStore } from '@wordpress/core-data';
@@ -49,7 +49,8 @@ const getInstallMissing = ( OriginalComponent ) => ( props ) => {
 };
 
 const ModifiedWarning = ( { originalBlock, ...props } ) => {
-	const { originalName, originalUndelimitedContent } = props.attributes;
+	const { originalName, originalUndelimitedContent, clientId } =
+		props.attributes;
 	const { replaceBlock } = useDispatch( blockEditorStore );
 	const convertToHTML = () => {
 		replaceBlock(
@@ -61,7 +62,18 @@ const ModifiedWarning = ( { originalBlock, ...props } ) => {
 	};
 
 	const hasContent = !! originalUndelimitedContent;
-	const hasHTMLBlock = getBlockType( 'core/html' );
+	const hasHTMLBlock = useSelect(
+		( select ) => {
+			const { canInsertBlockType, getBlockRootClientId } =
+				select( blockEditorStore );
+
+			return canInsertBlockType(
+				'core/html',
+				getBlockRootClientId( clientId )
+			);
+		},
+		[ clientId ]
+	);
 
 	let messageHTML = sprintf(
 		/* translators: %s: block name */

--- a/packages/block-library/src/missing/edit.js
+++ b/packages/block-library/src/missing/edit.js
@@ -4,8 +4,8 @@
 import { __, sprintf } from '@wordpress/i18n';
 import { RawHTML } from '@wordpress/element';
 import { Button } from '@wordpress/components';
-import { getBlockType, createBlock } from '@wordpress/blocks';
-import { withDispatch } from '@wordpress/data';
+import { createBlock } from '@wordpress/blocks';
+import { withDispatch, useSelect } from '@wordpress/data';
 import {
 	Warning,
 	useBlockProps,
@@ -13,10 +13,21 @@ import {
 } from '@wordpress/block-editor';
 import { safeHTML } from '@wordpress/dom';
 
-function MissingBlockWarning( { attributes, convertToHTML } ) {
+function MissingBlockWarning( { attributes, convertToHTML, clientId } ) {
 	const { originalName, originalUndelimitedContent } = attributes;
 	const hasContent = !! originalUndelimitedContent;
-	const hasHTMLBlock = getBlockType( 'core/html' );
+	const hasHTMLBlock = useSelect(
+		( select ) => {
+			const { canInsertBlockType, getBlockRootClientId } =
+				select( blockEditorStore );
+
+			return canInsertBlockType(
+				'core/html',
+				getBlockRootClientId( clientId )
+			);
+		},
+		[ clientId ]
+	);
 
 	const actions = [];
 	let messageHTML;


### PR DESCRIPTION
## What?
Update the `hasHTMLBlock` check in the Missing block warning to check if the user can insert a Custom HTML block

## Why?
The current method checked if the block was registered and didn't consider the `allowedBlockTypes` list. 

When the user disabled the block via the Preferences, the "Keep as HTML" action was doing nothing.

## How?
Updates checks to use `canInsertBlockType` selector. The changes had to be made in the block and block directory modifier component.

## Testing Instructions
1. Open a Post or Page.
2. Disabled Custom HTML block using Preferences.
3. Insert a non-registered block using the Code Editor (see example below).
4. Confirm that the "Keep as HTML" action isn't displayed.

```
<!-- wp:mamaduka/test -->
<div class="wp-block-mamaduka-text"><p>This is a <strong>missing block</strong>.</p></div>
<!-- /wp:mamaduka/test -->
```

## Screenshots or screencast <!-- if applicable -->

![CleanShot 2022-09-21 at 16 41 21](https://user-images.githubusercontent.com/240569/191506485-c045e866-3a5b-4399-a922-54d034831c96.png)
