### PR TITLE
Block Editor: Align Warning component actions

### DIFF
--- a/packages/block-editor/src/components/warning/style.scss
+++ b/packages/block-editor/src/components/warning/style.scss
@@ -33,6 +33,7 @@
 	}
 
 	.block-editor-warning__actions {
+		align-items: center;
 		display: flex;
 		margin-top: 1em;
 	}


### PR DESCRIPTION
## What?

PR fixes action alignmed in the Block Editor `Warning` component. A minor issue I noticed while working on #44327.

## Testing Instructions
1. Install block from the directory, activate, and add to a post.
2. Disabled this block.
3. Refresh the post so that the warning is displayed.
4. Confirm actions are correctly aligned


## Screenshots or screencast <!-- if applicable -->
| Before | After |
|---|---|
|![CleanShot 2022-09-21 at 15 27 06](https://user-images.githubusercontent.com/240569/191512051-339a52d2-a2eb-4554-8ec3-bb20c2ed89bb.png)|![CleanShot 2022-09-21 at 15 26 51](https://user-images.githubusercontent.com/240569/191512063-307739e5-91f5-43f2-a3ad-f6e77f9df947.png)|

![CleanShot 2022-09-21 at 17 00 03](https://user-images.githubusercontent.com/240569/191512164-866e3b02-15e1-4de6-9fd3-90fa73aff7e6.png)

