### PR TITLE
Pattern explorer: Try a single tab style.

### DIFF
--- a/packages/block-editor/src/components/inserter/style.scss
+++ b/packages/block-editor/src/components/inserter/style.scss
@@ -349,6 +349,20 @@ $block-inserter-tabs-height: 44px;
 			width: 100%;
 			height: 48px;
 			text-align: left;
+
+			// Mimic the Preferences TabItem style. @todo: componentize this.
+			&.is-pressed:hover:not(:disabled),
+			&:hover,
+			&:active,
+			&.is-pressed {
+				background: $gray-100;
+				color: $gray-900;
+				font-weight: 500;
+			}
+
+			&:hover {
+				color: var(--wp-admin-theme-color);
+			}
 		}
 	}
 


### PR DESCRIPTION
## What?

The preferences modal uses gray tabs:

<img width="500" alt="Screenshot 2022-09-21 at 15 22 37" src="https://user-images.githubusercontent.com/1204802/191515784-a188a97c-b3ed-4ecf-b269-23852a960f7a.png">

The pattern explorer uses dark tabs:

<img width="563" alt="Screenshot 2022-09-21 at 15 24 08" src="https://user-images.githubusercontent.com/1204802/191515825-c413032b-b651-420e-95d1-8a52e917cfcf.png">

In this PR I try to change the style of the pattern explorer tabs to be gray:

<img width="416" alt="Screenshot 2022-09-21 at 15 22 29" src="https://user-images.githubusercontent.com/1204802/191515902-3b129d4b-afe9-445b-a468-49cb36fac57d.png">

## Why?

Ideally we could componentize the `TabItem` to be used in both Preferences and pattern explorer. If you are available to help with that, I would appreciate it, you can push directly to this branch. 

Outside of a refactor, these color changes at least reduces the prominence of the active tab. 