### PR TITLE
Rich text: avoid updating partial selection unnecessarily

### DIFF
--- a/packages/block-editor/src/components/rich-text/index.js
+++ b/packages/block-editor/src/components/rich-text/index.js
@@ -159,6 +159,8 @@ function RichTextWrapper(
 	// retreived from the store on merge.
 	// To do: fix this somehow.
 	const { selectionStart, selectionEnd, isSelected } = useSelect( selector );
+	const { getSelectionStart, getSelectionEnd } =
+		useSelect( blockEditorStore );
 	const { selectionChange } = useDispatch( blockEditorStore );
 	const multilineTag = getMultilineTag( multiline );
 	const adjustedAllowedFormats = getAllowedFormats( {
@@ -195,6 +197,17 @@ function RichTextWrapper(
 			const unset = start === undefined && end === undefined;
 
 			if ( typeof start === 'number' || unset ) {
+				// If we are only setting the start (or the end below), which
+				// means a partial selection, and we're not updating a selection
+				// with the same client ID, abort. This means the selected block
+				// is a parent block.
+				if (
+					end === undefined &&
+					clientId !== getSelectionStart().clientId
+				) {
+					return;
+				}
+
 				selection.start = {
 					clientId,
 					attributeKey: identifier,
@@ -203,6 +216,13 @@ function RichTextWrapper(
 			}
 
 			if ( typeof end === 'number' || unset ) {
+				if (
+					start === undefined &&
+					clientId !== getSelectionEnd().clientId
+				) {
+					return;
+				}
+
 				selection.end = {
 					clientId,
 					attributeKey: identifier,

--- a/packages/block-editor/src/components/rich-text/index.js
+++ b/packages/block-editor/src/components/rich-text/index.js
@@ -159,7 +159,7 @@ function RichTextWrapper(
 	// retreived from the store on merge.
 	// To do: fix this somehow.
 	const { selectionStart, selectionEnd, isSelected } = useSelect( selector );
-	const { getSelectionStart, getSelectionEnd } =
+	const { getSelectionStart, getSelectionEnd, getBlockRootClientId } =
 		useSelect( blockEditorStore );
 	const { selectionChange } = useDispatch( blockEditorStore );
 	const multilineTag = getMultilineTag( multiline );
@@ -203,7 +203,8 @@ function RichTextWrapper(
 				// is a parent block.
 				if (
 					end === undefined &&
-					clientId !== getSelectionStart().clientId
+					getBlockRootClientId( clientId ) !==
+						getBlockRootClientId( getSelectionEnd().clientId )
 				) {
 					return;
 				}
@@ -218,7 +219,8 @@ function RichTextWrapper(
 			if ( typeof end === 'number' || unset ) {
 				if (
 					start === undefined &&
-					clientId !== getSelectionEnd().clientId
+					getBlockRootClientId( clientId ) !==
+						getBlockRootClientId( getSelectionStart().clientId )
 				) {
 					return;
 				}


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?

This should fix the flicker in https://github.com/WordPress/gutenberg/pull/44150#issuecomment-1250796566.

## Why?

Who likes flicker?

## How?

The problem is that in the selection observer, we detect that the selection start is e.g. the paragraph block, and the selection end is in e.g. a list item, so it resets the depth of the selection end to the list block instead of the list item so that the list block is fully selected. 

However, rich text will just ignore this, detect some selection end in the list item, and set the selection end offset together with the new client ID of the list item. So the solution is to check if the client ID to update is the same as one we have in the store, otherwise just ignore what rich text is detecting.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->

## Screenshots or screencast <!-- if applicable -->
