### PR TITLE
E2E Test Utils: Don't use hardcoded login credentials

### DIFF
--- a/packages/e2e-test-utils/CHANGELOG.md
+++ b/packages/e2e-test-utils/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Bug Fixes
+
+-   Don't use hardcoded login credentials when requesting nonce ([#44331](https://github.com/WordPress/gutenberg/pull/44331)).
+
 ## 8.2.0 (2022-09-21)
 
 ## 8.0.0 (2022-08-24)

--- a/packages/e2e-test-utils/src/rest-api.js
+++ b/packages/e2e-test-utils/src/rest-api.js
@@ -12,7 +12,7 @@ import apiFetch from '@wordpress/api-fetch';
 /**
  * Internal dependencies
  */
-import { WP_BASE_URL } from './shared/config';
+import { WP_BASE_URL, WP_USERNAME, WP_PASSWORD } from './shared/config';
 import { createURL } from './create-url';
 
 // `apiFetch` expects `window.fetch` to be available in its default handler.
@@ -37,8 +37,8 @@ Link header: ${ links }` );
 
 async function login( retries = 3 ) {
 	const formData = new FormData();
-	formData.append( 'log', 'admin' );
-	formData.append( 'pwd', 'password' );
+	formData.append( 'log', WP_USERNAME );
+	formData.append( 'pwd', WP_PASSWORD );
 
 	// Login to admin using fetch.
 	const loginResponse = await fetch( createURL( 'wp-login.php' ), {


### PR DESCRIPTION
## What?
Fixes #42761.

PR updates the `login` method for the REST API utils to use username and password from config.

## Testing Instructions
E2E tests are passing on CI

Locally tested by using widget tests, the helper method in this test uses the `rest` util function.

```
npm run test:e2e -- packages/e2e-tests/specs/widgets/editing-widgets.test.js
```
