### PR TITLE
Fix Site Title: link color not applied in editor #37071

### DIFF
--- a/packages/block-library/src/site-title/block.json
+++ b/packages/block-library/src/site-title/block.json
@@ -60,5 +60,6 @@
 			}
 		}
 	},
-	"editorStyle": "wp-block-site-title-editor"
+	"editorStyle": "wp-block-site-title-editor",
+	"style": "wp-block-site-title"
 }

--- a/packages/block-library/src/site-title/editor.scss
+++ b/packages/block-library/src/site-title/editor.scss
@@ -2,3 +2,9 @@
 	padding: 1em 0;
 	border: 1px dashed;
 }
+
+.editor-styles-wrapper .wp-block-site-title {
+	a {
+		color: inherit;
+	}
+}

--- a/packages/block-library/src/site-title/style.scss
+++ b/packages/block-library/src/site-title/style.scss
@@ -1,0 +1,5 @@
+.wp-block-site-title {
+	a {
+		color: inherit;
+	}
+}

--- a/packages/block-library/src/style.scss
+++ b/packages/block-library/src/style.scss
@@ -44,6 +44,7 @@
 @import "./search/style.scss";
 @import "./separator/style.scss";
 @import "./site-logo/style.scss";
+@import "./site-title/style.scss";
 @import "./social-links/style.scss";
 @import "./spacer/style.scss";
 @import "./tag-cloud/style.scss";


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
The color of the link in the site title has been changed to inherit.

## Why?
Fix  #37071.

## Testing Instructions
1. Add site title block.
2. Change text color.
