### PR TITLE
Global Styles: Re-add styles that were removed, for classic themes

### DIFF
--- a/lib/compat/wordpress-6.1/script-loader.php
+++ b/lib/compat/wordpress-6.1/script-loader.php
@@ -182,13 +182,18 @@ add_action( 'wp_footer', 'gutenberg_enqueue_global_styles', 1 );
 add_action( 'wp_enqueue_scripts', 'gutenberg_enqueue_stored_styles' );
 add_action( 'wp_footer', 'gutenberg_enqueue_stored_styles', 1 );
 
+/**
+ * Loads classic theme styles on classic themes.
+ *
+ * This is needed for backwards compatibility for button blocks specifically.
+ */
 function gutenberg_enqueue_classic_theme_styles() {
 	if ( ! wp_is_block_theme() ) {
 		wp_register_style( 'classic-theme-styles', gutenberg_url( 'build/block-library/classic.css' ), array(), true );
 		wp_enqueue_style( 'classic-theme-styles' );
 	}
 }
-// To load classic theme styles on the frontend:
+// To load classic theme styles on the frontend.
 add_action( 'wp_enqueue_scripts', 'gutenberg_enqueue_classic_theme_styles' );
-// To load classic theme styles in the the editor:
+// To load classic theme styles in the the editor.
 add_action( 'admin_enqueue_scripts', 'gutenberg_enqueue_classic_theme_styles' );

--- a/lib/compat/wordpress-6.1/script-loader.php
+++ b/lib/compat/wordpress-6.1/script-loader.php
@@ -188,5 +188,7 @@ function gutenberg_enqueue_classic_theme_styles() {
 		wp_enqueue_style( 'classic-theme-styles' );
 	}
 }
+// To load classic theme styles on the frontend:
 add_action( 'wp_enqueue_scripts', 'gutenberg_enqueue_classic_theme_styles' );
+// To load classic theme styles in the the editor:
 add_action( 'admin_enqueue_scripts', 'gutenberg_enqueue_classic_theme_styles' );

--- a/lib/compat/wordpress-6.1/script-loader.php
+++ b/lib/compat/wordpress-6.1/script-loader.php
@@ -188,4 +188,5 @@ function gutenberg_enqueue_classic_theme_styles() {
 		wp_enqueue_style( 'classic-theme-styles' );
 	}
 }
-add_action( 'after_setup_theme', 'gutenberg_enqueue_classic_theme_styles' );
+add_action( 'wp_enqueue_scripts', 'gutenberg_enqueue_classic_theme_styles' );
+add_action( 'admin_enqueue_scripts', 'gutenberg_enqueue_classic_theme_styles' );

--- a/lib/compat/wordpress-6.1/script-loader.php
+++ b/lib/compat/wordpress-6.1/script-loader.php
@@ -181,3 +181,11 @@ add_action( 'wp_enqueue_scripts', 'gutenberg_enqueue_global_styles' );
 add_action( 'wp_footer', 'gutenberg_enqueue_global_styles', 1 );
 add_action( 'wp_enqueue_scripts', 'gutenberg_enqueue_stored_styles' );
 add_action( 'wp_footer', 'gutenberg_enqueue_stored_styles', 1 );
+
+function gutenberg_enqueue_classic_theme_styles() {
+	if ( ! wp_is_block_theme() ) {
+		wp_register_style( 'classic-theme-styles', gutenberg_url( 'build/block-library/classic.css' ), array(), true );
+		wp_enqueue_style( 'classic-theme-styles' );
+	}
+}
+add_action( 'after_setup_theme', 'gutenberg_enqueue_classic_theme_styles' );

--- a/packages/block-library/src/classic.scss
+++ b/packages/block-library/src/classic.scss
@@ -1,0 +1,15 @@
+// These rules are needed for backwards compatibility.
+.wp-block-button__link {
+	color: $white;
+	background-color: #32373c;
+	border-radius: 9999px; // 100% causes an oval, but any explicit but really high value retains the pill shape.
+
+	// This needs a low specificity so it won't override the rules from the button element if defined in theme.json.
+	box-shadow: none;
+	text-decoration: none;
+
+	// The extra 2px are added to size solids the same as the outline versions.
+	padding: calc(0.667em + 2px) calc(1.333em + 2px);
+
+	font-size: 1.125em;
+}


### PR DESCRIPTION
## What?
This is another attempt at https://github.com/WordPress/gutenberg/pull/43981.

In classic themes we don't output the styles for elements, which we rely on for button styles. This adds a classic.scss file that will be output in all classic themes to ensure that those styles are preserved.

Fixes https://github.com/Automattic/wp-calypso/issues/64917

We might decide in the future to create one file per block, but I don't anticipate this being a common problem, so for now I think this solution is sufficient.

## Why?
These styles were removed in https://github.com/WordPress/gutenberg/pull/34180. We explored adding them to all themes in https://github.com/WordPress/gutenberg/pull/43981 but this seems impossible because every theme handles buttons differently.

## Testing Instructions
- Check the visual appearance of buttons blocks in both the frontend and the editor, in both classic and block themes.
- It's worth testing various different themes as they all handle buttons differently!

## Screenshots or screencast <!-- if applicable -->
<img width="795" alt="Screenshot 2022-09-21 at 17 20 09" src="https://user-images.githubusercontent.com/275961/191558087-86acd3d2-c742-4108-a1ff-8f6ee0b658b2.png">
<img width="866" alt="Screenshot 2022-09-21 at 17 19 50" src="https://user-images.githubusercontent.com/275961/191558089-d35090da-8439-4a00-b7b2-f3c0ac50b1fc.png">
<img width="705" alt="Screenshot 2022-09-21 at 17 19 16" src="https://user-images.githubusercontent.com/275961/191558092-ed491aa8-3f9a-4d01-b780-761badcbafd3.png">
<img width="752" alt="Screenshot 2022-09-21 at 17 18 47" src="https://user-images.githubusercontent.com/275961/191558094-0b7f96ad-06aa-4c57-b757-660962bcdc88.png">
