### PR TITLE
Submenu block href only if url is not empty

### DIFF
--- a/packages/block-library/src/navigation-submenu/index.php
+++ b/packages/block-library/src/navigation-submenu/index.php
@@ -183,7 +183,16 @@ function render_block_core_navigation_submenu( $attributes, $content, $block ) {
 	if ( ! $open_on_click ) {
 		$item_url = isset( $attributes['url'] ) ? $attributes['url'] : '';
 		// Start appending HTML attributes to anchor tag.
-		$html .= '<a class="wp-block-navigation-item__content" href="' . esc_url( $item_url ) . '"';
+		$html .= '<a class="wp-block-navigation-item__content"';
+
+		// The href attribute on a and area elements is not required;
+		// when those elements do not have href attributes they do not create hyperlinks.
+		// But also The href attribute must have a value that is a valid URL potentially
+		// surrounded by spaces.
+		// see: https://html.spec.whatwg.org/multipage/links.html#links-created-by-a-and-area-elements.
+		if ( ! empty( $item_url ) ) {
+			$html .= ' href="' . esc_url( $item_url ) . '"';
+		}
 
 		if ( $is_active ) {
 			$html .= ' aria-current="page"';


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Conditionally adds the `href` attribute to submenus on the front of the site to ensure valid HTML.

Closes https://github.com/WordPress/gutenberg/issues/43897

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

[The spec](https://html.spec.whatwg.org/multipage/links.html#links-created-by-a-and-area-elements) says that

> The href [a](https://html.spec.whatwg.org/multipage/text-level-semantics.html#the-a-element)ttribute on a and [area](https://html.spec.whatwg.org/multipage/image-maps.html#the-area-element) elements must have a value that is a [valid URL potentially surrounded by spaces](https://html.spec.whatwg.org/multipage/urls-and-fetching.html#valid-url-potentially-surrounded-by-spaces).

Therefore it cannot be empty (e.g. `href="'`).

However the spec also says...

> The [href](https://html.spec.whatwg.org/multipage/links.html#attr-hyperlink-href) [a](https://html.spec.whatwg.org/multipage/text-level-semantics.html#the-a-element)ttribute on a and [area](https://html.spec.whatwg.org/multipage/image-maps.html#the-area-element) elements is not required; when those elements do not have [href](https://html.spec.whatwg.org/multipage/links.html#attr-hyperlink-href) attributes they do not create hyperlinks.

Therefore it's valid to have a `<a>` without a `href` but not a `<a>` with a `href` that is empty.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

Conditionally adds the `href` to the front end markup. Editor remains "as is" and that's ok.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->

- Add Nav block.
- Add Submenu with a link and add one item inside the submenu.
- Click on Submenu block and click the link icon.
- Remove the link from the block using the "Unlink" icon in the Link UI.
- Publish post.
- Switch to front of site and see no `href` on the submenu item in the Nav.
- Back in editor, re-add the link to the Submenu and Update the Post.
- Switch to front of site and see the `href` is now shown on the submenu item in the Nav.

## Screenshots or screencast <!-- if applicable -->
