### PR TITLE
Add a missing filter documentation

### DIFF
--- a/packages/block-library/src/comments/index.php
+++ b/packages/block-library/src/comments/index.php
@@ -213,6 +213,7 @@ function register_legacy_post_comments_block() {
 	 * like `_wp_multiple_block_styles`, which is required in this case because
 	 * the block has multiple styles.
 	 */
+	/** This filter is documented in wp-includes/blocks.php */
 	$metadata = apply_filters( 'block_type_metadata', $metadata );
 
 	register_block_type( 'core/post-comments', $metadata );


### PR DESCRIPTION
## What?

This is a duplicate filter that's missing its relevant inline doc.

## Why?

Without this, the parser for the developer site sees this filter twice, once with its documentation and once without.
