### PR TITLE
Global Styles: use color hex + index as key in the Palette component color indicator

### DIFF
--- a/packages/edit-site/src/components/global-styles/palette.js
+++ b/packages/edit-site/src/components/global-styles/palette.js
@@ -68,11 +68,15 @@ function Palette( { name } ) {
 						}
 					>
 						<ZStack isLayered={ false } offset={ -8 }>
-							{ colors.slice( 0, 5 ).map( ( { color, slug } ) => (
-								<ColorIndicatorWrapper key={ slug }>
-									<ColorIndicator colorValue={ color } />
-								</ColorIndicatorWrapper>
-							) ) }
+							{ colors
+								.slice( 0, 5 )
+								.map( ( { color }, index ) => (
+									<ColorIndicatorWrapper
+										key={ `${ color }-${ index }` }
+									>
+										<ColorIndicator colorValue={ color } />
+									</ColorIndicatorWrapper>
+								) ) }
 						</ZStack>
 						<FlexItem>{ paletteButtonText }</FlexItem>
 					</HStack>

--- a/packages/edit-site/src/components/global-styles/palette.js
+++ b/packages/edit-site/src/components/global-styles/palette.js
@@ -68,8 +68,8 @@ function Palette( { name } ) {
 						}
 					>
 						<ZStack isLayered={ false } offset={ -8 }>
-							{ colors.slice( 0, 5 ).map( ( { color } ) => (
-								<ColorIndicatorWrapper key={ color }>
+							{ colors.slice( 0, 5 ).map( ( { color, slug } ) => (
+								<ColorIndicatorWrapper key={ slug }>
 									<ColorIndicator colorValue={ color } />
 								</ColorIndicatorWrapper>
 							) ) }


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->
Use the color's `slug` attribute from theme.json color palette configuration as `key` for `ColorWrapperIndicator` component.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
In the global styles panel's palette component, the color's hex code is used as a `key` for the ColorIndicatorWrapper, but the hex is not necessarily a unique identifier, unlike the `slug` attribute, which is expected to be unique. Using slug as key prevents errors such as this:

> Warning: Encountered two children with the same key, `.$#040DE1`. Keys should be unique so that components maintain their identity across updates. Non-unique keys may cause children to be duplicated and/or omitted — the behavior is unsupported and could change in a future version.

with a palette that looks lilke this:

```json
[
	{
			"color": "#040DE1",
			"name": "Primary",
			"slug": "primary"
	},
	{
			"color": "#040DE1",
			"name": "Foreground",
			"slug": "foreground"
	},
]

```

Regardless of whether or not it's practical to have the same hex under two different color configurations, slug is the value expected to be unique, not the color itself.

## Testing Instructions
Make sure that using the same color on two different palette color slots does't throw an error in the console. 
