### PR TITLE
Docs: instruct people to keep using `wp-scripts` even when extending webpack

### DIFF
--- a/packages/scripts/README.md
+++ b/packages/scripts/README.md
@@ -676,7 +676,10 @@ module.exports = {
 };
 ```
 
-If you follow this approach, please, be aware that future versions of this package may change what webpack and Babel plugins we bundle, default configs, etc. Should those changes be necessary, they will be registered in the [package’s CHANGELOG](https://github.com/WordPress/gutenberg/blob/HEAD/packages/scripts/CHANGELOG.md), so make sure to read it before upgrading.
+If you follow this approach, please, be aware that:
+
+- You should keep using the `wp-scripts` commands (`start` and `build`). Do not use `webpack` directly.
+- Future versions of this package may change what webpack and Babel plugins we bundle, default configs, etc. Should those changes be necessary, they will be registered in the [package’s CHANGELOG](https://github.com/WordPress/gutenberg/blob/HEAD/packages/scripts/CHANGELOG.md), so make sure to read it before upgrading.
 
 ## Contributing to this package
 


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

I've added a note in the `wp-scripts` docs to ensure people keep using the `wp-scripts` commands when they extend webpack.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

Because `wp-scripts` initializes some values (like `process.env.WP_SRC_DIRECTORY`) that the webpack configuration expects, so it doesn't work when using webpack's CLI directly.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

I've added a note in the "Extending the webpack config" section.
