### PR TITLE
Fix failing quote to reusable block conversion e2e test

### DIFF
--- a/packages/e2e-tests/specs/editor/various/reusable-blocks.test.js
+++ b/packages/e2e-tests/specs/editor/various/reusable-blocks.test.js
@@ -363,9 +363,8 @@ describe( 'Reusable blocks', () => {
 		const quoteBlock = await page.waitForSelector(
 			'.block-editor-block-list__block[aria-label="Block: Quote"]'
 		);
-		await quoteBlock.click();
 		// Select the quote block.
-		await page.keyboard.press( 'ArrowDown' );
+		await quoteBlock.focus();
 		await openDocumentSettingsSidebar();
 		await page.waitForXPath(
 			'//*[@role="region"][@aria-label="Editor settings"]//button[.="Styles"]'


### PR DESCRIPTION
## What?
Fixes #44332.

PR tries to fix the failing Reusable block e2e test.

## Why?
The tests often fail on the current trunk after the inner block refactor.

## How?
I updated the test to use `focus` for selecting the block instead of relying on keyboard navigation to land on the citation field.

## Testing Instructions
Tests should be pass on CI.

Locally:

```
npm run test:e2e -- specs/editor/various/reusable-blocks.test.js
```
