### PR TITLE
Comments block: Support nested comments settings in the comments blocks

### DIFF
--- a/packages/block-library/src/comment-template/index.php
+++ b/packages/block-library/src/comment-template/index.php
@@ -16,8 +16,8 @@
  */
 function block_core_comment_template_render_comments( $comments, $block ) {
 	global $comment_depth;
-	$thread_comments = get_option('thread_comments');
-	$thread_comments_depth = get_option('thread_comments_depth');
+	$thread_comments       = get_option( 'thread_comments' );
+	$thread_comments_depth = get_option( 'thread_comments_depth' );
 
 	if ( empty( $comment_depth ) ) {
 		$comment_depth = 1;
@@ -48,7 +48,7 @@ function block_core_comment_template_render_comments( $comments, $block ) {
 
 		// If the comment has children, recurse to create the HTML for the nested
 		// comments.
-		if ( ! empty( $children ) && !empty( $thread_comments ) ) {
+		if ( ! empty( $children ) && ! empty( $thread_comments ) ) {
 			if ( $comment_depth < $thread_comments_depth ) {
 				$comment_depth += 1;
 				$inner_content  = block_core_comment_template_render_comments(

--- a/packages/block-library/src/comment-template/index.php
+++ b/packages/block-library/src/comment-template/index.php
@@ -16,6 +16,8 @@
  */
 function block_core_comment_template_render_comments( $comments, $block ) {
 	global $comment_depth;
+	$thread_comments = get_option('thread_comments');
+	$thread_comments_depth = get_option('thread_comments_depth');
 
 	if ( empty( $comment_depth ) ) {
 		$comment_depth = 1;
@@ -46,14 +48,22 @@ function block_core_comment_template_render_comments( $comments, $block ) {
 
 		// If the comment has children, recurse to create the HTML for the nested
 		// comments.
-		if ( ! empty( $children ) ) {
-			$comment_depth += 1;
-			$inner_content  = block_core_comment_template_render_comments(
-				$children,
-				$block
-			);
-			$block_content .= sprintf( '<ol>%1$s</ol>', $inner_content );
-			$comment_depth -= 1;
+		if ( ! empty( $children ) && !empty( $thread_comments ) ) {
+			if ( $comment_depth < $thread_comments_depth ) {
+				$comment_depth += 1;
+				$inner_content  = block_core_comment_template_render_comments(
+					$children,
+					$block
+				);
+				$block_content .= sprintf( '<ol>%1$s</ol>', $inner_content );
+				$comment_depth -= 1;
+			} else {
+				$inner_content  = block_core_comment_template_render_comments(
+					$children,
+					$block
+				);
+				$block_content .= sprintf( $inner_content );
+			}
 		}
 
 		$content .= sprintf( '<li id="comment-%1$s" %2$s>%3$s</li>', $comment->comment_ID, $comment_classes, $block_content );


### PR DESCRIPTION
Fixes #44257

## What?
Add support for the setting to "Enable threaded (nested) comments" and define the deep level in the recently create Comments block.

## Why?
As described in [the issue](https://github.com/WordPress/gutenberg/issues/44257), they aren't respected right now in the new Comments block, while in the legacy one it does. As we can see there are mainly two problems:
* When the "Enable threaded (nested) comments" setting is disabled but there are nested comments, they still appear as different levels and they are repeated.
* When the levels deep is surpassed, it should respect the setting, and right now it is not happening. 

## How?
I added some variables to read the global settings and change the conditionals to respect them.

## Testing Instructions
1. Open a Post with many levels of nested comments.
2. Change the "Enable threaded (nested) comments X levels deep" with different possibilities and ensure everything works fine. Some options to review: Enable/Disable the option and change the levels deep to a lower number.
3. You can compare the legacy block and the new Comments block switching between Twenty Twenty Two theme (using legacy block) and Twenty Twenty Three theme (using the new Comments block).

More detailed instructions can be seen in [the issue](https://github.com/WordPress/gutenberg/issues/44257).