### PR TITLE
Add `blocks` to the list of valid origins for `theme.json`

### DIFF
--- a/lib/compat/wordpress-6.1/class-wp-theme-json-6-1.php
+++ b/lib/compat/wordpress-6.1/class-wp-theme-json-6-1.php
@@ -26,6 +26,18 @@ class WP_Theme_JSON_6_1 extends WP_Theme_JSON_6_0 {
 	);
 
 	/**
+	 * The sources of data this object can represent.
+	 *
+	 * @var string[]
+	 */
+	const VALID_ORIGINS = array(
+		'default',
+		'blocks',
+		'theme',
+		'custom',
+	);
+
+	/**
 	 * Metadata for style properties.
 	 *
 	 * Each element is a direct mapping from the CSS property name to the

--- a/lib/compat/wordpress-6.1/get-global-styles-and-settings.php
+++ b/lib/compat/wordpress-6.1/get-global-styles-and-settings.php
@@ -111,6 +111,10 @@ function gutenberg_get_global_stylesheet( $types = array() ) {
 	 */
 	$styles_rest = '';
 	if ( ! empty( $types ) ) {
+		// We don't add `blocks` here because they're rendered in
+		// wp_add_global_styles_for_blocks. We do so because
+		// we want to render only the blocks in use in some cases,
+		// and we don't have that info at this point.
 		$origins = array( 'default', 'theme', 'custom' );
 		if ( ! $supports_theme_json ) {
 			$origins = array( 'default' );

--- a/lib/compat/wordpress-6.1/get-global-styles-and-settings.php
+++ b/lib/compat/wordpress-6.1/get-global-styles-and-settings.php
@@ -92,14 +92,22 @@ function gutenberg_get_global_stylesheet( $types = array() ) {
 
 	/*
 	 * If variables are part of the stylesheet,
-	 * we add them for all origins (default, theme, user).
+	 * we add them.
+	 *
 	 * This is so themes without a theme.json still work as before 5.9:
 	 * they can override the default presets.
 	 * See https://core.trac.wordpress.org/ticket/54782
 	 */
 	$styles_variables = '';
 	if ( in_array( 'variables', $types, true ) ) {
-		$styles_variables = $tree->get_stylesheet( array( 'variables' ) );
+		/*
+		 * We only use the default, theme, and custom origins.
+		 * This is because styles for blocks origin are added
+		 * at a later phase (render cycle) so we only render the ones in use.
+		 * @see wp_add_global_styles_for_blocks
+		 */
+		$origins          = array( 'default', 'theme', 'custom' );
+		$styles_variables = $tree->get_stylesheet( array( 'variables' ), $origins );
 		$types            = array_diff( $types, array( 'variables' ) );
 	}
 
@@ -111,10 +119,12 @@ function gutenberg_get_global_stylesheet( $types = array() ) {
 	 */
 	$styles_rest = '';
 	if ( ! empty( $types ) ) {
-		// We don't add `blocks` here because they're rendered in
-		// wp_add_global_styles_for_blocks. We do so because
-		// we want to render only the blocks in use in some cases,
-		// and we don't have that info at this point.
+		/*
+		 * We only use the default, theme, and custom origins.
+		 * This is because styles for blocks origin are added
+		 * at a later phase (render cycle) so we only render the ones in use.
+		 * @see wp_add_global_styles_for_blocks
+		 */
 		$origins = array( 'default', 'theme', 'custom' );
 		if ( ! $supports_theme_json ) {
 			$origins = array( 'default' );

--- a/lib/experimental/class-wp-theme-json-resolver-gutenberg.php
+++ b/lib/experimental/class-wp-theme-json-resolver-gutenberg.php
@@ -144,8 +144,6 @@ class WP_Theme_JSON_Resolver_Gutenberg extends WP_Theme_JSON_Resolver_6_1 {
 		$theme_json = apply_filters( 'theme_json_blocks', new WP_Theme_JSON_Data_Gutenberg( $config, 'blocks' ) );
 		$config     = $theme_json->get_data();
 
-		// Core here means it's the lower level part of the styles chain.
-		// It can be a core or a third-party block.
 		return new WP_Theme_JSON_Gutenberg( $config, 'blocks' );
 	}
 

--- a/lib/experimental/class-wp-theme-json-resolver-gutenberg.php
+++ b/lib/experimental/class-wp-theme-json-resolver-gutenberg.php
@@ -141,12 +141,12 @@ class WP_Theme_JSON_Resolver_Gutenberg extends WP_Theme_JSON_Resolver_6_1 {
 		 *
 		 * @param WP_Theme_JSON_Data_Gutenberg Class to access and update the underlying data.
 		 */
-		$theme_json = apply_filters( 'theme_json_blocks', new WP_Theme_JSON_Data_Gutenberg( $config, 'core' ) );
+		$theme_json = apply_filters( 'theme_json_blocks', new WP_Theme_JSON_Data_Gutenberg( $config, 'blocks' ) );
 		$config     = $theme_json->get_data();
 
 		// Core here means it's the lower level part of the styles chain.
 		// It can be a core or a third-party block.
-		return new WP_Theme_JSON_Gutenberg( $config, 'core' );
+		return new WP_Theme_JSON_Gutenberg( $config, 'blocks' );
 	}
 
 	/**


### PR DESCRIPTION
## What?

This PR updates the name of the `blocks` origin from `core` to `blocks` and adds it to the list of valid origins for `theme.json`.

## Why?

- We were missing this new origin from the list.
- The `core` name is not reflective of what it does (see existing comment), as this data origin is related to block styles, whether they come with WordPress/Gutenberg or third-party blocks.
- The existing filter for this piece of data is called `theme_json_blocks`, to reflect it filters "block" data.
- We used `core` in the past for `default`, and reverted because it was confusing and want to use names that communicate what part of the pipeline are processing (`default > blocks > theme > custom`).

## How?

- Rename the string, from `core` to `blocks`.
- Add `blocks` to the list of valid origins.
- Verify that the `$theme_json->get_stylesheet` call uses the proper `$origins` at all times.

## Testing

### Classic theme

Using a theme without `theme.json` (for example, Canape):

- Verify that the styles for the pullquote and navigation blocks are still present in the `global-styles-inline-css`. These blocks are the only ones that use the `__experimentalStyle` API in its `block.json`. It should look like this:

```css
.wp-block-pullquote{font-size: 1.5em;line-height: 1.6;}
.wp-block-navigation a:where(:not(.wp-element-button)){color: inherit;}
```

### Block theme

Using a theme with `theme.json` (for example, TwentyTwentyTwo).

Test that the styles are enqueued when the blocks are in use:

- Create a page that uses the pullquote and navigation blocks and publish.
- Go to the front and
  - verify that the styles for the pullquote and navigation blocks are not part of the `global-styles-inline-css`.
  - verify that there's a `wp-block-pullquote-inline-css` stylesheet and contains `.wp-block-pullquote{border-width: 1px 0;font-size: 1.5em;line-height: 1.6;}`.
    - Note that the stylesheet contains a lot more CSS than expected and the rule generated by the `__experimentalStyle` API also content `border-width`, which is also unexpected. This is an issue in `trunk` that needs to be investigated separately. If you want to go the extra mile and verify that this works as expected, edit the values found in `__experimentalStyle` of the `block.json` of pullquote, recompile and reload the front. The values should be the ones you set.
  - verify that there's a `wp-block-navigation-inline-css` embedded stylesheet whose content is `.wp-block-navigation a:where(:not(.wp-element-button)){color: inherit;}`.

Test that the styles are not enqueued when the blocks are not in use:

- Create a page that does not use the pullquote and navigation blocks and publish.
- Go to the front and verify that the styles for the pullquote and navigation blocks are not part of the `global-styles-inline-css` and aren't loaded separately either.

Test that themes can opt-out from loading blocks separately even if the post uses the blocks:

- Add `add_filter( 'should_load_separate_core_block_assets', '__return_false' );` to the `functions.php` of the theme.
- Go to the front (any post/page) and verify that styles for all blocks are part of the `global-styles-inline-css` stylesheet.
