### PR TITLE
Fix empty color indicator with a custom style

### DIFF
--- a/packages/components/src/color-indicator/index.tsx
+++ b/packages/components/src/color-indicator/index.tsx
@@ -23,7 +23,7 @@ function UnforwardedColorIndicator(
 
 	return (
 		<span
-			className={ classnames( 'component-color-indicator', className ) }
+			className={ classnames( 'component-color-indicator', className, !colorValue ? 'is-empty' : undefined ) }
 			style={ { background: colorValue } }
 			ref={ forwardedRef }
 			{ ...additionalProps }

--- a/packages/components/src/color-indicator/index.tsx
+++ b/packages/components/src/color-indicator/index.tsx
@@ -23,7 +23,7 @@ function UnforwardedColorIndicator(
 
 	return (
 		<span
-			className={ classnames( 'component-color-indicator', className, !colorValue ? 'is-empty' : undefined ) }
+			className={ classnames( 'component-color-indicator', className ) }
 			style={ { background: colorValue } }
 			ref={ forwardedRef }
 			{ ...additionalProps }

--- a/packages/edit-site/src/components/global-styles/style.scss
+++ b/packages/edit-site/src/components/global-styles/style.scss
@@ -45,9 +45,22 @@
 	margin: $grid-unit-20;
 
 	.component-color-indicator {
-		// Show a diagonal line (crossed out) for empty swatches.
-		background: linear-gradient(-45deg, transparent 48%, $gray-300 48%, $gray-300 52%, transparent 52%);
+		position: relative;
 		flex-shrink: 0;
+	}
+
+	.component-color-indicator.is-empty {
+	  background: $white;
+	}
+
+	.component-color-indicator.is-empty:before {
+		content: '';
+    position: absolute;
+    top: 50%;
+    border-top: 1px solid $gray-300;
+    width: 100%;
+    height: 1px;
+    transform: rotate(-45deg);
 	}
 }
 

--- a/packages/edit-site/src/components/global-styles/style.scss
+++ b/packages/edit-site/src/components/global-styles/style.scss
@@ -50,17 +50,17 @@
 	}
 
 	.component-color-indicator.is-empty {
-	  background: $white;
+		background: $white;
 	}
 
-	.component-color-indicator.is-empty:before {
-		content: '';
-    position: absolute;
-    top: 50%;
-    border-top: 1px solid $gray-300;
-    width: 100%;
-    height: 1px;
-    transform: rotate(-45deg);
+	.component-color-indicator.is-empty::before {
+		content: "";
+		position: absolute;
+		top: 50%;
+		border-top: 1px solid $gray-300;
+		width: 100%;
+		height: 1px;
+		transform: rotate(-45deg);
 	}
 }
 

--- a/packages/edit-site/src/components/global-styles/style.scss
+++ b/packages/edit-site/src/components/global-styles/style.scss
@@ -45,22 +45,9 @@
 	margin: $grid-unit-20;
 
 	.component-color-indicator {
-		position: relative;
+		// Show a diagonal line (crossed out) for empty swatches.
+		background: $white linear-gradient(-45deg, transparent 48%, $gray-300 48%, $gray-300 52%, transparent 52%);
 		flex-shrink: 0;
-	}
-
-	.component-color-indicator.is-empty {
-		background: $white;
-	}
-
-	.component-color-indicator.is-empty::before {
-		content: "";
-		position: absolute;
-		top: 50%;
-		border-top: 1px solid $gray-300;
-		width: 100%;
-		height: 1px;
-		transform: rotate(-45deg);
 	}
 }
 


### PR DESCRIPTION
This PR tries to fix the empty color indicator style so it looks OK on top of other color indicators:

| Before | After |
| ------------- | ------------- |
|![october local_wp-admin_site-editor php_postType=wp_template postId=twentytwentytwo%2F%2Fhome](https://user-images.githubusercontent.com/4933/191723422-df88f477-c9af-417b-a384-21370c7a5877.png)| ![october local_wp-admin_site-editor php_postType=wp_template postId=twentytwentytwo%2F%2Fhome (1)](https://user-images.githubusercontent.com/4933/191723416-313fea64-33bd-4696-bc3a-74a3f5f3a61d.png)  | 

### Testing instructions

1. Open Global Styles
2. Select Colors
3. Check that the empty indicators are rendered correctly on top of other indicators 