### PR TITLE
Use default value for process.env.WP_SRC_DIRECTORY. 

### DIFF
--- a/packages/scripts/utils/config.js
+++ b/packages/scripts/utils/config.js
@@ -309,7 +309,7 @@ function getWebpackEntryPoints() {
  */
 function getRenderPropPaths() {
 	// Continue only if the source directory exists.
-	if ( ! hasProjectFile( process.env.WP_SRC_DIRECTORY ) ) {
+	if ( ! hasProjectFile( process.env.WP_SRC_DIRECTORY || 'src' ) ) {
 		return [];
 	}
 


### PR DESCRIPTION
## What?
Fixes WordPress/gutenberg#44309

## Why?
See discussion here: https://github.com/WordPress/gutenberg/pull/43917#pullrequestreview-1113911446

## How?
Using wp-scripts command, if is not specified, `process.env.WP_SRC_DIRECTORY` defaults to string 'src'. When extending the webpack.config.js directly, it should behave the same.