### PR TITLE
Fix patterns drag and drop in Safari

### DIFF
--- a/packages/block-editor/src/components/block-preview/style.scss
+++ b/packages/block-editor/src/components/block-preview/style.scss
@@ -64,3 +64,16 @@
 		display: none;
 	}
 }
+
+// The goal of this pseudo-element is to cover the iframe
+// otherwise it won't be able to drag elements containing
+// the preview iframe in Safari.
+.block-editor-block-preview__container::after {
+	content: "";
+	position: absolute;
+	top: 0;
+	left: 0;
+	right: 0;
+	bottom: 0;
+	z-index: 1;
+}


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?

In Safari, it's not possible to drag and drop patterns from the inserter into the canvas. I found that it's due to the "iframe" in the block preview. 

## How?

While we already apply "pointer-events: none" to the iframe, it seems that it's not enough here so I'm adding a pseudo element to the block preview to cover everything.

## Testing Instructions

1- Open the inserter in Safari
2- Try drag and dropping patterns into the canvas.
