### PR TITLE
Scripts: Use default value for process.env.WP_SRC_DIRECTORY

### DIFF
--- a/packages/scripts/config/webpack.config.js
+++ b/packages/scripts/config/webpack.config.js
@@ -25,6 +25,7 @@ const {
 	hasArgInCLI,
 	hasCssnanoConfig,
 	hasPostCSSConfig,
+	getWordPressSrcDirectory,
 	getWebpackEntryPoints,
 	getRenderPropPaths,
 } = require( '../utils' );
@@ -233,7 +234,7 @@ const config = {
 			patterns: [
 				{
 					from: '**/block.json',
-					context: process.env.WP_SRC_DIRECTORY,
+					context: getWordPressSrcDirectory(),
 					noErrorOnMissing: true,
 					transform( content, absoluteFrom ) {
 						const convertExtension = ( path ) => {
@@ -267,7 +268,7 @@ const config = {
 				},
 				{
 					from: '**/*.php',
-					context: process.env.WP_SRC_DIRECTORY,
+					context: getWordPressSrcDirectory(),
 					noErrorOnMissing: true,
 					filter: ( filepath ) => {
 						return (

--- a/packages/scripts/utils/config.js
+++ b/packages/scripts/utils/config.js
@@ -169,6 +169,16 @@ const getWebpackArgs = () => {
 };
 
 /**
+ * Returns the WordPress source directory. It defaults to 'src' if the
+ * `process.env.WP_SRC_DIRECTORY` variable is not set.
+ *
+ * @return {string} The WordPress source directory.
+ */
+function getWordPressSrcDirectory() {
+	return process.env.WP_SRC_DIRECTORY || 'src';
+}
+
+/**
  * Detects the list of entry points to use with webpack. There are three ways to do this:
  *  1. Use the legacy webpack 4 format passed as CLI arguments.
  *  2. Scan `block.json` files for scripts.
@@ -185,10 +195,10 @@ function getWebpackEntryPoints() {
 	}
 
 	// Continue only if the source directory exists.
-	if ( ! hasProjectFile( process.env.WP_SRC_DIRECTORY ) ) {
+	if ( ! hasProjectFile( getWordPressSrcDirectory() ) ) {
 		log(
 			chalk.yellow(
-				`Source directory "${ process.env.WP_SRC_DIRECTORY }" was not found. Please confirm there is a "src" directory in the root or the value passed to --webpack-src-dir is correct.`
+				`Source directory "${ getWordPressSrcDirectory() }" was not found. Please confirm there is a "src" directory in the root or the value passed to --webpack-src-dir is correct.`
 			)
 		);
 		return {};
@@ -197,7 +207,7 @@ function getWebpackEntryPoints() {
 	// 2. Checks whether any block metadata files can be detected in the defined source directory.
 	//    It scans all discovered files looking for JavaScript assets and converts them to entry points.
 	const blockMetadataFiles = glob(
-		`${ process.env.WP_SRC_DIRECTORY }/**/block.json`,
+		`${ getWordPressSrcDirectory() }/**/block.json`,
 		{
 			absolute: true,
 		}
@@ -205,7 +215,7 @@ function getWebpackEntryPoints() {
 
 	if ( blockMetadataFiles.length > 0 ) {
 		const srcDirectory = fromProjectRoot(
-			process.env.WP_SRC_DIRECTORY + sep
+			getWordPressSrcDirectory() + sep
 		);
 		const entryPoints = blockMetadataFiles.reduce(
 			( accumulator, blockMetadataFile ) => {
@@ -232,9 +242,7 @@ function getWebpackEntryPoints() {
 									) }" listed in "${ blockMetadataFile.replace(
 										fromProjectRoot( sep ),
 										''
-									) }". File is located outside of the "${
-										process.env.WP_SRC_DIRECTORY
-									}" directory.`
+									) }". File is located outside of the "${ getWordPressSrcDirectory() }" directory.`
 								)
 							);
 							return;
@@ -246,7 +254,7 @@ function getWebpackEntryPoints() {
 
 						// Detects the proper file extension used in the defined source directory.
 						const [ entryFilepath ] = glob(
-							`${ process.env.WP_SRC_DIRECTORY }/${ entryName }.[jt]s?(x)`,
+							`${ getWordPressSrcDirectory() }/${ entryName }.[jt]s?(x)`,
 							{
 								absolute: true,
 							}
@@ -261,9 +269,7 @@ function getWebpackEntryPoints() {
 									) }" listed in "${ blockMetadataFile.replace(
 										fromProjectRoot( sep ),
 										''
-									) }". File does not exist in the "${
-										process.env.WP_SRC_DIRECTORY
-									}" directory.`
+									) }". File does not exist in the "${ getWordPressSrcDirectory() }" directory.`
 								)
 							);
 							return;
@@ -283,7 +289,7 @@ function getWebpackEntryPoints() {
 	// 3. Checks whether a standard file name can be detected in the defined source directory,
 	//    and converts the discovered file to entry point.
 	const [ entryFile ] = glob(
-		`${ process.env.WP_SRC_DIRECTORY }/index.[jt]s?(x)`,
+		`${ getWordPressSrcDirectory() }/index.[jt]s?(x)`,
 		{
 			absolute: true,
 		}
@@ -291,7 +297,7 @@ function getWebpackEntryPoints() {
 	if ( ! entryFile ) {
 		log(
 			chalk.yellow(
-				`No entry file discovered in the "${ process.env.WP_SRC_DIRECTORY }" directory.`
+				`No entry file discovered in the "${ getWordPressSrcDirectory() }" directory.`
 			)
 		);
 		return {};
@@ -309,19 +315,19 @@ function getWebpackEntryPoints() {
  */
 function getRenderPropPaths() {
 	// Continue only if the source directory exists.
-	if ( ! hasProjectFile( process.env.WP_SRC_DIRECTORY ) ) {
+	if ( ! hasProjectFile( getWordPressSrcDirectory() ) ) {
 		return [];
 	}
 
 	// Checks whether any block metadata files can be detected in the defined source directory.
 	const blockMetadataFiles = glob(
-		`${ process.env.WP_SRC_DIRECTORY }/**/block.json`,
+		`${ getWordPressSrcDirectory() }/**/block.json`,
 		{
 			absolute: true,
 		}
 	);
 
-	const srcDirectory = fromProjectRoot( process.env.WP_SRC_DIRECTORY + sep );
+	const srcDirectory = fromProjectRoot( getWordPressSrcDirectory() + sep );
 
 	const renderPaths = blockMetadataFiles.map( ( blockMetadataFile ) => {
 		const { render } = JSON.parse( readFileSync( blockMetadataFile ) );
@@ -342,9 +348,7 @@ function getRenderPropPaths() {
 						) }" listed in "${ blockMetadataFile.replace(
 							fromProjectRoot( sep ),
 							''
-						) }". File is located outside of the "${
-							process.env.WP_SRC_DIRECTORY
-						}" directory.`
+						) }". File is located outside of the "${ getWordPressSrcDirectory() }" directory.`
 					)
 				);
 				return false;
@@ -360,6 +364,7 @@ function getRenderPropPaths() {
 module.exports = {
 	getJestOverrideConfigFile,
 	getWebpackArgs,
+	getWordPressSrcDirectory,
 	getWebpackEntryPoints,
 	getRenderPropPaths,
 	hasBabelConfig,

--- a/packages/scripts/utils/index.js
+++ b/packages/scripts/utils/index.js
@@ -13,6 +13,7 @@ const {
 const {
 	getJestOverrideConfigFile,
 	getWebpackArgs,
+	getWordPressSrcDirectory,
 	getWebpackEntryPoints,
 	getRenderPropPaths,
 	hasBabelConfig,
@@ -34,6 +35,7 @@ module.exports = {
 	getNodeArgsFromCLI,
 	getPackageProp,
 	getWebpackArgs,
+	getWordPressSrcDirectory,
 	getWebpackEntryPoints,
 	getRenderPropPaths,
 	hasArgInCLI,


### PR DESCRIPTION
## What?
Fixes this regression: WordPress/gutenberg#44309

## Why?
See discussion here: https://github.com/WordPress/gutenberg/pull/43917#pullrequestreview-1113911446

## How?
Using wp-scripts command, if is not specified, `process.env.WP_SRC_DIRECTORY` defaults to string 'src'. When extending the webpack.config.js directly, it should behave the same.