### PR TITLE
Block Directory: Use 'tertiary' in missing block warning

### DIFF
--- a/packages/block-directory/src/plugins/get-install-missing/index.js
+++ b/packages/block-directory/src/plugins/get-install-missing/index.js
@@ -100,7 +100,7 @@ const ModifiedWarning = ( { originalBlock, ...props } ) => {
 			originalBlock.title || originalName
 		);
 		actions.push(
-			<Button key="convert" onClick={ convertToHTML } variant="link">
+			<Button key="convert" onClick={ convertToHTML } variant="tertiary">
 				{ __( 'Keep as HTML' ) }
 			</Button>
 		);


### PR DESCRIPTION
## What?
A follow-up to https://github.com/WordPress/gutenberg/pull/44328#issuecomment-1253724387.

PR updates the non-primary action button in the missing block warning to use a tertiary variant.

## Testing Instructions

1. Install block from the directory, activate, and add to a post.
2. Disabled this block.
3. Refresh the post so that the warning is displayed.
4. Confirm "Keep as HTML" uses a tertiary variant.

## Screenshots or screencast <!-- if applicable -->

**Before**
![CleanShot 2022-09-22 at 15 28 44](https://user-images.githubusercontent.com/240569/191735976-cb9e1900-4e11-48ee-9659-abf4acce4c8a.png)

**After**
![CleanShot 2022-09-22 at 15 28 14](https://user-images.githubusercontent.com/240569/191735964-ff0d7ced-7f88-48a6-9f72-8c83f3868a4d.png)
