### PR TITLE
BlockDraggable: Change prop name passed to children when dragging is disabled

### DIFF
--- a/packages/block-editor/src/components/block-draggable/index.js
+++ b/packages/block-editor/src/components/block-draggable/index.js
@@ -52,7 +52,7 @@ const BlockDraggable = ( {
 	}, [] );
 
 	if ( ! isDraggable ) {
-		return children( { isDraggable: false } );
+		return children( { draggable: false } );
 	}
 
 	const transferData = {


### PR DESCRIPTION
## What?
PR tries to make props passed to `BlockDraggable` children more consistent. I think the current prop was leftover from the #27669 reactor.

This also fixes the `React does not recognize the 'isDragable' prop on a DOM element` error that's visible in certain scenarios.

P.S. Noticed this while debugging #44341.

## Why?
To avoid React error when block draggable props are passed directly into children.

Example - https://github.com/WordPress/gutenberg/blob/trunk/packages/block-editor/src/components/block-mover/index.js#L67-L80

## Testing Instructions
1. Copy and activate the CPT locking plugin - `packages/e2e-tests/plugins/cpt-locking.php`.
2. Create a new "Locked All Post."
3. In the Column block, choose any variation. The tests use 50/50.
4. Confirm that `React does not recognize the 'isDraggable' prop on a DOM element` isn't displayed in the console.
