### PR TITLE
Hide the done button of the Global Style palette editor when there aren't colors to edit

### DIFF
--- a/packages/components/src/palette-edit/index.js
+++ b/packages/components/src/palette-edit/index.js
@@ -316,7 +316,7 @@ export default function PaletteEdit( {
 			<PaletteHStackHeader>
 				<PaletteHeading>{ paletteLabel }</PaletteHeading>
 				<PaletteActionsContainer>
-					{ isEditing && (
+					{ hasElements && isEditing && (
 						<DoneButton
 							isSmall
 							onClick={ () => {


### PR DESCRIPTION
This PR tries to fix the behavior of the done button in the palette editor. 

Currently, if you remove all the items from the color palette, the done button stays visible, giving the impression that you need to click it to finish the edition (which is not true)

### Before
https://user-images.githubusercontent.com/4933/191758269-90f39608-0fcd-4079-82af-cf0ff8b9d40b.mov

### After

https://user-images.githubusercontent.com/4933/191758275-140583bc-98a7-4a31-b2b3-8783812d35f5.mov

### How to test this PR

1. Add one or more custom colors to the Global Style palette
2. Remove all the colors

The done button should disappear.
