### PR TITLE
Popover: deprecate the position prop

### DIFF
--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -7,6 +7,7 @@
 ### Deprecations
 
 -   `Popover`: added new `anchor` prop, supposed to supersede all previous anchor-related props (`anchorRef`, `anchorRect`, `getAnchorRect`). These older anchor-related props are now marked as deprecated and are scheduled to be removed in WordPress 6.3 ([#43691](https://github.com/WordPress/gutenberg/pull/43691)).
+-   `Popover`: deprecate the legacy `position` prop, in favor of the newer `placement` prop. The `position` prop is scheduled to be removed in WordPress 6.4 ([#44386](https://github.com/WordPress/gutenberg/pull/44386)).
 
 ### Bug Fix
 

--- a/packages/components/src/popover/README.md
+++ b/packages/components/src/popover/README.md
@@ -203,7 +203,7 @@ Used to specify the popover's position with respect to its anchor.
 
 ### `position`: `[yAxis] [xAxis] [optionalCorner]`
 
-_Note: use the `placement` prop instead when possible._
+_Note: this prop is deprecated and will be removed in WordPress 6.4. Please use the `placement` prop instead._
 
 Legacy way to specify the popover's position with respect to its anchor.
 
@@ -212,7 +212,6 @@ Possible values:
 - `yAxis`: `'top' | 'middle' | 'bottom'`
 - `xAxis`: `'left' | 'center' | 'right'`
 - `corner`: `'top' | 'right' | 'bottom' | 'left'`
-
 
 -   Required: No
 

--- a/packages/components/src/popover/index.tsx
+++ b/packages/components/src/popover/index.tsx
@@ -170,7 +170,6 @@ const UnforwardedPopover = (
 		className,
 		noArrow = true,
 		isAlternate,
-		position,
 		placement: placementProp = 'bottom-start',
 		offset: offsetProp = 0,
 		focusOnMount = 'firstElement',
@@ -188,6 +187,7 @@ const UnforwardedPopover = (
 		anchorRef,
 		anchorRect,
 		getAnchorRect,
+		position,
 		range,
 
 		// Rest
@@ -249,6 +249,14 @@ const UnforwardedPopover = (
 			since: '6.1',
 			version: '6.3',
 			alternative: '`anchor` prop',
+		} );
+	}
+
+	if ( position !== undefined ) {
+		deprecated( '`position` prop in wp.components.Popover', {
+			since: '6.2',
+			version: '6.4',
+			alternative: '`placement` prop',
 		} );
 	}
 

--- a/packages/components/src/popover/types.ts
+++ b/packages/components/src/popover/types.ts
@@ -117,13 +117,6 @@ export type PopoverProps = {
 	 */
 	placement?: Placement;
 	/**
-	 * Legacy way to specify the popover's position with respect to its anchor.
-	 * _Note: this prop is deprecated. Use the `placement` prop instead._
-	 */
-	position?:
-		| `${ PositionYAxis } ${ PositionXAxis }`
-		| `${ PositionYAxis } ${ PositionXAxis } ${ PositionCorner }`;
-	/**
 	 * Adjusts the size of the popover to prevent its contents from going out of
 	 * view when meeting the viewport edges.
 	 *
@@ -189,4 +182,13 @@ export type PopoverProps = {
 	 * @deprecated
 	 */
 	range?: unknown;
+	/**
+	 * Legacy way to specify the popover's position with respect to its anchor.
+	 * _Note: this prop is deprecated. Use the `placement` prop instead._
+	 *
+	 * @deprecated
+	 */
+	position?:
+		| `${ PositionYAxis } ${ PositionXAxis }`
+		| `${ PositionYAxis } ${ PositionXAxis } ${ PositionCorner }`;
 };


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## Dev Note:

Following the recent refactors on the `Popover` component, the legacy `position` prop has been marked as deprecated. The newer `placement` prop should be used instead. The `position` prop is scheduled to be removed in WordPress 6.4.

## What?
<!-- In a few words, what is the PR actually doing? -->

Add a deprecation warning for the `position` prop for the `Popover` component.

_Note: this PR should only be merged once all instance of `Popover` in the repository have been migrated from using the `position` prop to the `placement` prop_

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

With the refactor to `floating-ui` (#40740), a new `placement` prop was introduced to position the Popover. We should therefore remove the legacy `position` prop to avoid having two props achieving the same goal.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

Add a warning notice.

Preparatory work has been carried out in other PRs (see #42770 for more details)

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->

Do a general smoke test across Gutenberg and:

- make sure that there are no deprecation warnings about the `position` prop written in the console
- make sure that all Popover instances keep behaving like on `trunk`