### PR TITLE
Format Toolbar Popover: use new placement prop instead of legacy position prop

### DIFF
--- a/packages/block-editor/src/components/rich-text/format-toolbar-container.js
+++ b/packages/block-editor/src/components/rich-text/format-toolbar-container.js
@@ -42,7 +42,7 @@ function InlineSelectionToolbar( {
 function InlineToolbar( { popoverAnchor } ) {
 	return (
 		<Popover
-			position="top center"
+			placement="top"
 			focusOnMount={ false }
 			anchor={ popoverAnchor }
 			className="block-editor-rich-text__inline-format-toolbar"


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Part of #44401

Use the new `placement` prop instead of the legacy `position` prop to define the `Popover`'s placement when opened.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

With the recent refactor of the `Popover` component to `floating-ui`, we're in the process of refactoring all of its usages to the new `placement` prop (native to `floating-ui`). See #44401 for more details

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

Swap `position` with the new corresponding `placement`. 

See this [conversion table](https://github.com/WordPress/gutenberg/blob/0a9402ac623876cc2a29d0f4a72eaefba3310501/packages/components/src/popover/utils.ts#L17-L71) that we're currently using to map `position` values to `placement` values.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->

- Add an image block
- Add a caption by clicking the corresponding button in the inline toolbar
- When typing the caption, make sure that the inline formatting toolbar for the caption text displays as on `trunk`

## Screenshots or screencast <!-- if applicable -->

https://user-images.githubusercontent.com/1083581/198672722-89e63b88-ee60-4dba-b08a-d63dedd94915.mp4

