### PR TITLE
URL Input Popover: use new placement prop instead of legacy position prop

### DIFF
--- a/packages/block-editor/src/components/url-input/index.js
+++ b/packages/block-editor/src/components/url-input/index.js
@@ -543,7 +543,7 @@ class URLInput extends Component {
 			!! suggestions.length
 		) {
 			return (
-				<Popover position="bottom" focusOnMount={ false }>
+				<Popover placement="bottom" focusOnMount={ false }>
 					<div
 						{ ...suggestionsListProps }
 						className={ classnames(


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Part of #44401

Use the new `placement` prop instead of the legacy `position` prop to define the `Popover`'s placement when opened.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

With the recent refactor of the `Popover` component to `floating-ui`, we're in the process of refactoring all of its usages to the new `placement` prop (native to `floating-ui`). See #44401 for more details

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

Swap `position` with the new corresponding `placement`. 

See this [conversion table](https://github.com/WordPress/gutenberg/blob/0a9402ac623876cc2a29d0f4a72eaefba3310501/packages/components/src/popover/utils.ts#L17-L71) that we're currently using to map `position` values to `placement` values.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->

I'm not quite sure how to test this _organically_ — all URL Input popovers don't seem to hit [this path](https://github.com/WordPress/gutenberg/blob/7dbe09344bc25d567fe36df19398707bbd05ecb7/packages/block-editor/src/components/url-input/index.js#L540-L546)

Anyway, it should be a pretty easy change to review.