### PR TITLE
URLPopover: use new placement prop instead of legacy position prop

### DIFF
--- a/packages/block-editor/src/components/url-popover/README.md
+++ b/packages/block-editor/src/components/url-popover/README.md
@@ -194,3 +194,13 @@ Reference passed to the auto complete element of the ([URLInput component](/pack
 
 -   Type: `Object`
 -   Required: no
+
+### position
+
+_Note: this prop is deprecated. Please use the `placement` prop instead._
+
+Where the Popover should be positioned relative to its parent. Defaults to "bottom center".
+
+-   Type: `String`
+-   Required: No
+-   Default: "bottom center"

--- a/packages/block-editor/src/components/url-popover/README.md
+++ b/packages/block-editor/src/components/url-popover/README.md
@@ -199,8 +199,7 @@ Reference passed to the auto complete element of the ([URLInput component](/pack
 
 _Note: this prop is deprecated. Please use the `placement` prop instead._
 
-Where the Popover should be positioned relative to its parent. Defaults to "bottom center".
+Where the Popover should be positioned relative to its parent.
 
 -   Type: `String`
 -   Required: No
--   Default: "bottom center"

--- a/packages/block-editor/src/components/url-popover/README.md
+++ b/packages/block-editor/src/components/url-popover/README.md
@@ -94,13 +94,13 @@ class MyURLPopover extends Component {
 
 The component accepts the following props. Any other props are passed through to the underlying `Popover` component ([refer to props documentation](/packages/components/src/popover/README.md)).
 
-### position
+### placement
 
-Where the Popover should be positioned relative to its parent. Defaults to "bottom center".
+Where the Popover should be positioned relative to its parent. Defaults to "bottom".
 
 -   Type: `String`
 -   Required: No
--   Default: "bottom center"
+-   Default: "bottom"
 
 ### focusOnMount
 

--- a/packages/block-editor/src/components/url-popover/index.js
+++ b/packages/block-editor/src/components/url-popover/index.js
@@ -16,7 +16,7 @@ function URLPopover( {
 	additionalControls,
 	children,
 	renderSettings,
-	position = 'bottom center',
+	placement = 'bottom',
 	focusOnMount = 'firstElement',
 	...popoverProps
 } ) {
@@ -32,7 +32,7 @@ function URLPopover( {
 		<Popover
 			className="block-editor-url-popover"
 			focusOnMount={ focusOnMount }
-			position={ position }
+			placement={ placement }
 			shift
 			{ ...popoverProps }
 		>

--- a/packages/block-editor/src/components/url-popover/index.js
+++ b/packages/block-editor/src/components/url-popover/index.js
@@ -17,26 +17,38 @@ import deprecated from '@wordpress/deprecated';
 import LinkViewer from './link-viewer';
 import LinkEditor from './link-editor';
 
+const DEFAULT_PLACEMENT = 'bottom';
+
 function URLPopover( {
 	additionalControls,
 	children,
 	renderSettings,
-	placement = 'bottom',
+	// The DEFAULT_PLACEMENT value is assigned inside the function's body
+	placement,
 	focusOnMount = 'firstElement',
 	// Deprecated
 	position,
 	// Rest
 	...popoverProps
 } ) {
-	let computedPlacement = placement;
 	if ( position !== undefined ) {
 		deprecated( '`position` prop in wp.blockEditor.URLPopover', {
 			since: '6.2',
 			alternative: '`placement` prop',
 		} );
+	}
 
+	// Compute popover's placement:
+	// - give priority to `placement` prop, if defined
+	// - otherwise, compute it from the legacy `position` prop (if defined)
+	// - finally, fallback to the DEFAULT_PLACEMENT.
+	let computedPlacement;
+	if ( placement !== undefined ) {
+		computedPlacement = placement;
+	} else if ( position !== undefined ) {
 		computedPlacement = positionToPlacement( position );
 	}
+	computedPlacement = computedPlacement || DEFAULT_PLACEMENT;
 
 	const [ isSettingsExpanded, setIsSettingsExpanded ] = useState( false );
 

--- a/packages/block-editor/src/components/url-popover/index.js
+++ b/packages/block-editor/src/components/url-popover/index.js
@@ -3,8 +3,13 @@
  */
 import { __ } from '@wordpress/i18n';
 import { useState } from '@wordpress/element';
-import { Button, Popover } from '@wordpress/components';
+import {
+	Button,
+	Popover,
+	__experimentalPopoverPositionToPlacement as positionToPlacement,
+} from '@wordpress/components';
 import { chevronDown } from '@wordpress/icons';
+import deprecated from '@wordpress/deprecated';
 
 /**
  * Internal dependencies
@@ -18,8 +23,21 @@ function URLPopover( {
 	renderSettings,
 	placement = 'bottom',
 	focusOnMount = 'firstElement',
+	// Deprecated
+	position,
+	// Rest
 	...popoverProps
 } ) {
+	let computedPlacement = placement;
+	if ( position !== undefined ) {
+		deprecated( '`position` prop in wp.blockEditor.URLPopover', {
+			since: '6.2',
+			alternative: '`placement` prop',
+		} );
+
+		computedPlacement = positionToPlacement( position );
+	}
+
 	const [ isSettingsExpanded, setIsSettingsExpanded ] = useState( false );
 
 	const showSettings = !! renderSettings && isSettingsExpanded;
@@ -32,7 +50,7 @@ function URLPopover( {
 		<Popover
 			className="block-editor-url-popover"
 			focusOnMount={ focusOnMount }
-			placement={ placement }
+			placement={ computedPlacement }
 			shift
 			{ ...popoverProps }
 		>

--- a/packages/components/src/index.js
+++ b/packages/components/src/index.js
@@ -126,6 +126,7 @@ export { default as PanelHeader } from './panel/header';
 export { default as PanelRow } from './panel/row';
 export { default as Placeholder } from './placeholder';
 export { default as Popover } from './popover';
+export { positionToPlacement as __experimentalPopoverPositionToPlacement } from './popover/utils';
 export { default as QueryControls } from './query-controls';
 export { default as __experimentalRadio } from './radio-group/radio';
 export { default as __experimentalRadioGroup } from './radio-group';


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Part of #44401

Use the new `placement` prop instead of the legacy `position` prop to define the `Popover`'s placement in the `URLPopover` component.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

With the recent refactor of the `Popover` component to `floating-ui`, we're in the process of refactoring all of its usages to the new `placement` prop (native to `floating-ui`). See #44401 for more details

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

- Introduced new `placement` prop for the `URLPopover` component
- marked the `position` prop as deprecated — the prop, however, is still supported by the component
- internally, the `URLPopover` component uses the new `placement` prop for the `Popover` component, also thanks to the `positionToPlacement` prop that is being exported from the `Popover` component

See this [conversion table](https://github.com/WordPress/gutenberg/blob/0a9402ac623876cc2a29d0f4a72eaefba3310501/packages/components/src/popover/utils.ts#L17-L71) that we're currently using to map `position` values to `placement` values.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->

- Add an image block, click on the "Insert from URL" button. Make sure that the URL popover shows up in the same position as on `trunk`
- Add a Social Link block, then add a generic social link. Click on the link icon button in the editor, and make sure that the URL Popover shows up in the same position as on trunk

## Screenshots or screencast <!-- if applicable -->


https://user-images.githubusercontent.com/1083581/198674577-d29ae53a-e8b0-45a9-b739-c50f4e1e94bc.mp4


## ✍️ Dev Note 

With the recent refactor of the `Popover` component to use the `floating-ui` library, the `placement` prop has become the recommended way to determine how the component positions with respect to its anchor. While the older `position` prop is still supported, we're making changes towards removing all of its usages in the Gutenberg repository and deprecating it.

As part of these efforts, the `position` prop has been marked as deprecated on the following components:
- `Dropdown` from the `@wordpress/components` package
- `URLPopover` component from the `@wordpress/block-editor` package

Consumers of these components should be using the new `placement` prop instead.