### PR TITLE
Button block Popover: use placement prop instead of legacy position prop

### DIFF
--- a/packages/block-library/src/button/edit.js
+++ b/packages/block-library/src/button/edit.js
@@ -221,7 +221,7 @@ function ButtonEdit( props ) {
 			</BlockControls>
 			{ isSelected && ( isEditingURL || isURLSet ) && (
 				<Popover
-					position="bottom center"
+					placement="bottom"
 					onClose={ () => {
 						setIsEditingURL( false );
 						richTextRef.current?.focus();


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Part of #44401

Use the new `placement` prop instead of the legacy `position` prop to define the `Popover`'s placement when opened.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

With the recent refactor of the `Popover` component to `floating-ui`, we're in the process of refactoring all of its usages to the new `placement` prop (native to `floating-ui`). See #44401 for more details

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

Swap `position` with the new corresponding `placement`. 

See this [conversion table](https://github.com/WordPress/gutenberg/blob/0a9402ac623876cc2a29d0f4a72eaefba3310501/packages/components/src/popover/utils.ts#L17-L71) that we're currently using to map `position` values to `placement` values.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->

- Add a "Buttons" block
- Edit the button's Link by pressing the related button in the block inline toolbar
- Make sure that the URL popover that appears is positioned the same way as on trunk

## Screenshots or screencast <!-- if applicable -->


https://user-images.githubusercontent.com/1083581/198677383-280434a6-2eda-4ceb-9bb5-268bacf6eedb.mp4

