### PR TITLE
button-width-with-alignment issue solve

### DIFF
--- a/packages/block-library/src/button/style.scss
+++ b/packages/block-library/src/button/style.scss
@@ -42,7 +42,7 @@ $blocks-block__margin: 0.5em;
 }
 
 // Increased specificity needed to override margins.
-.wp-block-buttons > .wp-block-button {
+.wp-block-buttons .wp-block-button {
 	&.has-custom-width {
 		max-width: none;
 		.wp-block-button__link {


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->
#44385 
## What?
<!-- In a few words, what is the PR actually doing? -->

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
This will solve the issue of button block when alignment is given and width is choosen.
## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->

## Screenshots or screencast <!-- if applicable -->
