### PR TITLE
Navigation Link Popover: use placement prop instead of legacy position prop

### DIFF
--- a/packages/block-library/src/navigation-link/edit.js
+++ b/packages/block-library/src/navigation-link/edit.js
@@ -847,7 +847,7 @@ export default function NavigationLinkEdit( {
 					) }
 					{ isLinkOpen && (
 						<Popover
-							position="bottom center"
+							placement="bottom"
 							onClose={ () => setIsLinkOpen( false ) }
 							anchor={ popoverAnchor }
 							shift


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Part of #44401

Use the new `placement` prop instead of the legacy `position` prop to define the `Popover`'s placement when opened.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

With the recent refactor of the `Popover` component to `floating-ui`, we're in the process of refactoring all of its usages to the new `placement` prop (native to `floating-ui`). See #44401 for more details

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

Swap `position` with the new corresponding `placement`. 

See this [conversion table](https://github.com/WordPress/gutenberg/blob/0a9402ac623876cc2a29d0f4a72eaefba3310501/packages/components/src/popover/utils.ts#L17-L71) that we're currently using to map `position` values to `placement` values.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->

- Insert a Navigation block
- Click on a Navigation Link, and edit its link by clicking on the related button in the inline toolbar
- Make sure that the NavigationLink URL popover opens in the same position as on trunk

## Screenshots or screencast <!-- if applicable -->

https://user-images.githubusercontent.com/1083581/198681848-6bd816ef-5367-4f1a-bb85-c9c68b0f0208.mp4

