### PR TITLE
Dot Tip Popover: use placement prop instead of legacy position prop

### DIFF
--- a/packages/nux/src/components/dot-tip/README.md
+++ b/packages/nux/src/components/dot-tip/README.md
@@ -25,13 +25,13 @@ A string that uniquely identifies the tip. Identifiers should be prefixed with t
 -   Type: `string`
 -   Required: Yes
 
-### position
+### placement
 
-The direction in which the popover should open relative to its parent node. Specify y- and x-axis as a space-separated string. Supports `"top"`, `"middle"`, `"bottom"` y axis, and `"left"`, `"center"`, `"right"` x axis.
+The direction in which the popover should open relative to its parent node. See the `wp.components.Popover` docs for more information.
 
 -   Type: `String`
 -   Required: No
--   Default: `"middle right"`
+-   Default: `"right"`
 
 ### children
 

--- a/packages/nux/src/components/dot-tip/index.js
+++ b/packages/nux/src/components/dot-tip/index.js
@@ -20,7 +20,7 @@ function onClick( event ) {
 }
 
 export function DotTip( {
-	position = 'middle right',
+	placement = 'right',
 	children,
 	isVisible,
 	hasNextTip,
@@ -47,7 +47,7 @@ export function DotTip( {
 	return (
 		<Popover
 			className="nux-dot-tip"
-			position={ position }
+			placement={ placement }
 			focusOnMount
 			role="dialog"
 			aria-label={ __( 'Editor tips' ) }


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

TODO: verify if instead we need to make a non-breaking change (introduce placement, deprecate position, convert from position to placement internally)

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->

## Screenshots or screencast <!-- if applicable -->
