### PR TITLE
Components: refactor `SlotFill` to pass `exhaustive-deps`

### DIFF
--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -23,6 +23,7 @@
 -   `withFocusReturn`: Refactor tests to `@testing-library/react` ([#45012](https://github.com/WordPress/gutenberg/pull/45012)).
 -   `ToolsPanel`: updated to satisfy `react/exhaustive-deps` eslint rule ([#45028](https://github.com/WordPress/gutenberg/pull/45028))
 -   `Tooltip`: updated to ignore `react/exhaustive-deps` eslint rule ([#45043](https://github.com/WordPress/gutenberg/pull/45043))
+-   `SlotFill`: updated to satisfy `react/exhaustive-deps` eslint rule ([#44403](https://github.com/WordPress/gutenberg/pull/44403))
 
 ## 21.2.0 (2022-10-05)
 

--- a/packages/components/src/slot-fill/bubbles-virtually/fill.js
+++ b/packages/components/src/slot-fill/bubbles-virtually/fill.js
@@ -28,18 +28,18 @@ function useForceUpdate() {
 }
 
 export default function Fill( { name, children } ) {
-	const slot = useSlot( name );
+	const { registerFill, unregisterFill, ...slot } = useSlot( name );
 	const ref = useRef( { rerender: useForceUpdate() } );
 
 	useEffect( () => {
 		// We register fills so we can keep track of their existance.
 		// Some Slot implementations need to know if there're already fills
 		// registered so they can choose to render themselves or not.
-		slot.registerFill( ref );
+		registerFill( ref );
 		return () => {
-			slot.unregisterFill( ref );
+			unregisterFill( ref );
 		};
-	}, [ slot.registerFill, slot.unregisterFill ] );
+	}, [ registerFill, unregisterFill ] );
 
 	if ( ! slot.ref || ! slot.ref.current ) {
 		return null;

--- a/packages/components/src/slot-fill/bubbles-virtually/slot.js
+++ b/packages/components/src/slot-fill/bubbles-virtually/slot.js
@@ -19,19 +19,22 @@ function Slot(
 	{ name, fillProps = {}, as: Component = 'div', ...props },
 	forwardedRef
 ) {
-	const registry = useContext( SlotFillContext );
+	const { registerSlot, unregisterSlot, ...registry } =
+		useContext( SlotFillContext );
 	const ref = useRef();
 
+	// We don't fillProps in the deps of the layout effect below because we don't want to
+	// unregister and register the slot whenever fillProps change. Doing so would
+	// cause the fill to be re-mounted, and we are only considering the initial value
+	// of fillProps. Instead, we store that initial value in a ref, but don't update it.
+	const fillPropsRef = useRef( fillProps );
+
 	useLayoutEffect( () => {
-		registry.registerSlot( name, ref, fillProps );
+		registerSlot( name, ref, fillPropsRef.current );
 		return () => {
-			registry.unregisterSlot( name, ref );
+			unregisterSlot( name, ref );
 		};
-		// We are not including fillProps in the deps because we don't want to
-		// unregister and register the slot whenever fillProps change, which would
-		// cause the fill to be re-mounted. We are only considering the initial value
-		// of fillProps.
-	}, [ registry.registerSlot, registry.unregisterSlot, name ] );
+	}, [ registerSlot, unregisterSlot, name ] );
 	// fillProps may be an update that interacts with the layout, so we
 	// useLayoutEffect.
 	useLayoutEffect( () => {

--- a/packages/components/src/slot-fill/bubbles-virtually/slot.js
+++ b/packages/components/src/slot-fill/bubbles-virtually/slot.js
@@ -23,7 +23,7 @@ function Slot(
 		useContext( SlotFillContext );
 	const ref = useRef();
 
-	// We don't fillProps in the deps of the layout effect below because we don't want to
+	// We want don't fillProps in the deps of the layout effect below because we don't want to
 	// unregister and register the slot whenever fillProps change. Doing so would
 	// cause the fill to be re-mounted, and we are only considering the initial value
 	// of fillProps. Instead, we store that initial value in a ref, but don't update it.

--- a/packages/components/src/slot-fill/bubbles-virtually/slot.js
+++ b/packages/components/src/slot-fill/bubbles-virtually/slot.js
@@ -25,15 +25,15 @@ function Slot(
 
 	// We want don't fillProps in the deps of the layout effect below because we don't want to
 	// unregister and register the slot whenever fillProps change. Doing so would
-	// cause the fill to be re-mounted, and we are only considering the initial value
-	// of fillProps. Instead, we store that initial value in a ref, but don't update it.
-	const fillPropsRef = useRef( fillProps );
-
+	// cause the fill to be re-mounted.
 	useLayoutEffect( () => {
-		registerSlot( name, ref, fillPropsRef.current );
+		registerSlot( name, ref, fillProps );
 		return () => {
 			unregisterSlot( name, ref );
 		};
+		// Ignore reason: see above.
+		// Also, please see: https://github.com/WordPress/gutenberg/pull/44403#discussion_r994415973
+		// eslint-disable-next-line react-hooks/exhaustive-deps
 	}, [ registerSlot, unregisterSlot, name ] );
 	// fillProps may be an update that interacts with the layout, so we
 	// useLayoutEffect.

--- a/packages/components/src/slot-fill/bubbles-virtually/slot.js
+++ b/packages/components/src/slot-fill/bubbles-virtually/slot.js
@@ -23,16 +23,15 @@ function Slot(
 		useContext( SlotFillContext );
 	const ref = useRef();
 
-	// We want don't fillProps in the deps of the layout effect below because we don't want to
-	// unregister and register the slot whenever fillProps change. Doing so would
-	// cause the fill to be re-mounted.
 	useLayoutEffect( () => {
 		registerSlot( name, ref, fillProps );
 		return () => {
 			unregisterSlot( name, ref );
 		};
-		// Ignore reason: see above.
-		// Also, please see: https://github.com/WordPress/gutenberg/pull/44403#discussion_r994415973
+		// Ignore reason: We don't want to unregister and register the slot whenever
+		// `fillProps` change, which would cause the fill to be re-mounted. Instead,
+		// we can just update the slot (see hook below).
+		// For more context, see https://github.com/WordPress/gutenberg/pull/44403#discussion_r994415973
 		// eslint-disable-next-line react-hooks/exhaustive-deps
 	}, [ registerSlot, unregisterSlot, name ] );
 	// fillProps may be an update that interacts with the layout, so we

--- a/packages/components/src/slot-fill/bubbles-virtually/use-slot.js
+++ b/packages/components/src/slot-fill/bubbles-virtually/use-slot.js
@@ -15,7 +15,13 @@ import { useCallback, useContext } from '@wordpress/element';
 import SlotFillContext from './slot-fill-context';
 
 export default function useSlot( name ) {
-	const registry = useContext( SlotFillContext );
+	const {
+		updateSlot: registryUpdateSlot,
+		unregisterSlot: registryUnregisterSlot,
+		registerFill: registryRegisterFill,
+		unregisterFill: registryUnregisterFill,
+		...registry
+	} = useContext( SlotFillContext );
 	const slots = useSnapshot( registry.slots, { sync: true } );
 	// The important bit here is that this call ensures
 	// the hook only causes a re-render if the slot
@@ -24,30 +30,30 @@ export default function useSlot( name ) {
 
 	const updateSlot = useCallback(
 		( fillProps ) => {
-			registry.updateSlot( name, fillProps );
+			registryUpdateSlot( name, fillProps );
 		},
-		[ name, registry.updateSlot ]
+		[ name, registryUpdateSlot ]
 	);
 
 	const unregisterSlot = useCallback(
 		( slotRef ) => {
-			registry.unregisterSlot( name, slotRef );
+			registryUnregisterSlot( name, slotRef );
 		},
-		[ name, registry.unregisterSlot ]
+		[ name, registryUnregisterSlot ]
 	);
 
 	const registerFill = useCallback(
 		( fillRef ) => {
-			registry.registerFill( name, fillRef );
+			registryRegisterFill( name, fillRef );
 		},
-		[ name, registry.registerFill ]
+		[ name, registryRegisterFill ]
 	);
 
 	const unregisterFill = useCallback(
 		( fillRef ) => {
-			registry.unregisterFill( name, fillRef );
+			registryUnregisterFill( name, fillRef );
 		},
-		[ name, registry.unregisterFill ]
+		[ name, registryUnregisterFill ]
 	);
 
 	return {

--- a/packages/components/src/slot-fill/fill.js
+++ b/packages/components/src/slot-fill/fill.js
@@ -21,7 +21,13 @@ function FillComponent( { name, children, registerFill, unregisterFill } ) {
 
 	useLayoutEffect( () => {
 		registerFill( name, ref.current );
+		// Ignore reason: The ref.current value will likely change before the cleanup is run.
+		// This may be intentional, but could be impacted by future refactors of the other useLayoutEffects in this component.
+		// eslint-disable-next-line react-hooks/exhaustive-deps
 		return () => unregisterFill( name, ref.current );
+		// Ignore reason: the useLayoutEffects here are written to fire at specific times, and introducing new dependencies could cause unexpected changes in behavior.
+		// We'll leave them as-is until a more detailed investigation/refactor can be performed.
+		// eslint-disable-next-line react-hooks/exhaustive-deps
 	}, [] );
 
 	useLayoutEffect( () => {
@@ -29,6 +35,9 @@ function FillComponent( { name, children, registerFill, unregisterFill } ) {
 		if ( slot ) {
 			slot.forceUpdate();
 		}
+		// Ignore reason: the useLayoutEffects here are written to fire at specific times, and introducing new dependencies could cause unexpected changes in behavior.
+		// We'll leave them as-is until a more detailed investigation/refactor can be performed.
+		// eslint-disable-next-line react-hooks/exhaustive-deps
 	}, [ children ] );
 
 	useLayoutEffect( () => {
@@ -39,6 +48,9 @@ function FillComponent( { name, children, registerFill, unregisterFill } ) {
 		unregisterFill( ref.current.name, ref.current );
 		ref.current.name = name;
 		registerFill( name, ref.current );
+		// Ignore reason: the useLayoutEffects here are written to fire at specific times, and introducing new dependencies could cause unexpected changes in behavior.
+		// We'll leave them as-is until a more detailed investigation/refactor can be performed.
+		// eslint-disable-next-line react-hooks/exhaustive-deps
 	}, [ name ] );
 
 	if ( ! slot || ! slot.node ) {

--- a/packages/components/src/slot-fill/fill.js
+++ b/packages/components/src/slot-fill/fill.js
@@ -20,11 +20,9 @@ function FillComponent( { name, children, registerFill, unregisterFill } ) {
 	} );
 
 	useLayoutEffect( () => {
-		registerFill( name, ref.current );
-		// Ignore reason: The ref.current value will likely change before the cleanup is run.
-		// This may be intentional, but could be impacted by future refactors of the other useLayoutEffects in this component.
-		// eslint-disable-next-line react-hooks/exhaustive-deps
-		return () => unregisterFill( name, ref.current );
+		const refValue = ref.current;
+		registerFill( name, refValue );
+		return () => unregisterFill( name, refValue );
 		// Ignore reason: the useLayoutEffects here are written to fire at specific times, and introducing new dependencies could cause unexpected changes in behavior.
 		// We'll leave them as-is until a more detailed investigation/refactor can be performed.
 		// eslint-disable-next-line react-hooks/exhaustive-deps

--- a/packages/components/src/slot-fill/use-slot.js
+++ b/packages/components/src/slot-fill/use-slot.js
@@ -26,6 +26,9 @@ const useSlot = ( name ) => {
 		} );
 
 		return unsubscribe;
+		// Ignore reason: Modifying this dep array could introduce unexpected changes in behavior,
+		// so we'll leave it as=is until the hook can be properly refactored for exhaustive-deps.
+		// eslint-disable-next-line react-hooks/exhaustive-deps
 	}, [ name ] );
 
 	return slot;


### PR DESCRIPTION
## What?
Updates the `SlotFill` component to satisfy the `exhaustive-deps` eslint rule

## Why?
Part of the effort in https://github.com/WordPress/gutenberg/pull/41166 to apply `exhuastive-deps` to the Components package

## How?
**.../slot-fill/bubbles-virtually/fill.js**:

Due to [issues with how `this` applies to reading methods from an object](https://github.com/facebook/react/issues/16265#issuecomment-517518539), the lint rule wants to see the full `slot` object as a dependency and not the methods themselves. To resolve this, we can destructure the methods beforehand, so our dependencies reflect the methods themselves.

**.../slot-fill/bubbles-virtually/slot.js:**

`registerSlot` and `unregisterSlot` have been destructured for the same reasons as the dependencies above.

It was noted in the comments that `fillProps` were intentionally left out of the array to avoid un-and-reregistering the fill on every single prop change. We really only want the initial value. That makes sense, but causes our favorite lint rule a lot of anxiety, so I've placed the initial `fillProps` value into a ref that doesn't get updated, and used that in the layout effect.

**.../src/slot-fill/fill.js** & **.../slot-fill/use-slot.js**

The warnings here have been treated with `eslint ignore` comments for now, as they may require a more in-depth refactor. the `useLayoutEffect`s in [slot-fill/fill.js](https://github.com/WordPress/gutenberg/pull/44403/files#diff-ab966e9739116b51ca25555ad05c17ed44083bdb68bc6399c3d6c9a83a01612a) in particular look like they were written to fire at very specific points.

cc'ing @youknowriad in case you're able to assist or offer any advice on updating this component  to pass the`exhaustive-deps` `es-lint` rule.

## Testing Instructions
1. From your local Gutenberg directory, run `npx eslint --rule 'react-hooks/exhaustive-deps: warn' packages/components/src/slot-fill`
2. Confirm that the linter returns no errors
3. Confirm unit tests still pass
4. Run Storybook locally, confirm the components stories and/or docs still work as expected
