### PR TITLE
Style engine: kebab case preset slugs in the editor

### DIFF
--- a/packages/style-engine/phpunit/style-engine-test.php
+++ b/packages/style-engine/phpunit/style-engine-test.php
@@ -363,13 +363,13 @@ class WP_Style_Engine_Test extends WP_UnitTestCase {
 					'spacing' => array(
 						'margin'  => array(
 							'left'   => 'var:preset|spacing|10',
-							'right'  => 'var:preset|spacing|20',
+							'right'  => 'var:preset|spacing|3XL',
 							'top'    => '1rem',
 							'bottom' => '1rem',
 						),
 						'padding' => array(
 							'left'   => 'var:preset|spacing|30',
-							'right'  => 'var:preset|spacing|40',
+							'right'  => 'var:preset|spacing|3XL',
 							'top'    => '14px',
 							'bottom' => '14px',
 						),
@@ -377,14 +377,14 @@ class WP_Style_Engine_Test extends WP_UnitTestCase {
 				),
 				'options'         => array(),
 				'expected_output' => array(
-					'css'          => 'padding-left:var(--wp--preset--spacing--30);padding-right:var(--wp--preset--spacing--40);padding-top:14px;padding-bottom:14px;margin-left:var(--wp--preset--spacing--10);margin-right:var(--wp--preset--spacing--20);margin-top:1rem;margin-bottom:1rem;',
+					'css'          => 'padding-left:var(--wp--preset--spacing--30);padding-right:var(--wp--preset--spacing--3-xl);padding-top:14px;padding-bottom:14px;margin-left:var(--wp--preset--spacing--10);margin-right:var(--wp--preset--spacing--3-xl);margin-top:1rem;margin-bottom:1rem;',
 					'declarations' => array(
 						'padding-left'   => 'var(--wp--preset--spacing--30)',
-						'padding-right'  => 'var(--wp--preset--spacing--40)',
+						'padding-right'  => 'var(--wp--preset--spacing--3-xl)',
 						'padding-top'    => '14px',
 						'padding-bottom' => '14px',
 						'margin-left'    => 'var(--wp--preset--spacing--10)',
-						'margin-right'   => 'var(--wp--preset--spacing--20)',
+						'margin-right'   => 'var(--wp--preset--spacing--3-xl)',
 						'margin-top'     => '1rem',
 						'margin-bottom'  => '1rem',
 					),

--- a/packages/style-engine/src/styles/utils.ts
+++ b/packages/style-engine/src/styles/utils.ts
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { get } from 'lodash';
+import { get, kebabCase } from 'lodash';
 
 /**
  * Internal dependencies
@@ -119,6 +119,7 @@ export function getCSSVarFromStyleValue( styleValue: string ): string {
 		const variable = styleValue
 			.slice( VARIABLE_REFERENCE_PREFIX.length )
 			.split( VARIABLE_PATH_SEPARATOR_TOKEN_ATTRIBUTE )
+			.map( ( presetVariable ) => kebabCase( presetVariable ) )
 			.join( VARIABLE_PATH_SEPARATOR_TOKEN_STYLE );
 		return `var(--wp--${ variable })`;
 	}

--- a/packages/style-engine/src/test/index.js
+++ b/packages/style-engine/src/test/index.js
@@ -96,6 +96,19 @@ describe( 'generate', () => {
 		);
 	} );
 
+	it( 'should parse preset values and kebab-case the slug', () => {
+		expect(
+			compileCSS( {
+				color: {
+					text: 'var:preset|font-size|h1',
+				},
+				spacing: { margin: { top: 'var:preset|spacing|3XL' } },
+			} )
+		).toEqual(
+			'color: var(--wp--preset--font-size--h-1); margin-top: var(--wp--preset--spacing--3-xl);'
+		);
+	} );
+
 	it( 'should parse border rules', () => {
 		expect(
 			compileCSS( {

--- a/packages/style-engine/src/test/utils.js
+++ b/packages/style-engine/src/test/utils.js
@@ -1,7 +1,11 @@
 /**
  * Internal dependencies
  */
-import { camelCaseJoin, upperFirst } from '../styles/utils';
+import {
+	camelCaseJoin,
+	getCSSVarFromStyleValue,
+	upperFirst,
+} from '../styles/utils';
 
 describe( 'utils', () => {
 	describe( 'upperFirst()', () => {
@@ -9,9 +13,30 @@ describe( 'utils', () => {
 			expect( upperFirst( 'toontown' ) ).toEqual( 'Toontown' );
 		} );
 	} );
+
 	describe( 'camelCaseJoin()', () => {
 		it( 'should return a camelCase string', () => {
 			expect( camelCaseJoin( [ 'toon', 'town' ] ) ).toEqual( 'toonTown' );
+		} );
+	} );
+
+	describe( 'getCSSVarFromStyleValue()', () => {
+		it( 'should return a compiled CSS var', () => {
+			expect(
+				getCSSVarFromStyleValue( 'var:preset|color|yellow-bun' )
+			).toEqual( 'var(--wp--preset--color--yellow-bun)' );
+		} );
+
+		it( 'should kebab case numbers', () => {
+			expect(
+				getCSSVarFromStyleValue( 'var:preset|font-size|h1' )
+			).toEqual( 'var(--wp--preset--font-size--h-1)' );
+		} );
+
+		it( 'should kebab case camel case', () => {
+			expect(
+				getCSSVarFromStyleValue( 'var:preset|color|heavenlyBlue' )
+			).toEqual( 'var(--wp--preset--color--heavenly-blue)' );
 		} );
 	} );
 } );


### PR DESCRIPTION
Resolves https://github.com/WordPress/gutenberg/issues/44349

## What?
Making sure to kebab case CSS variables generated from presets, so `var:preset|spacing|3XL` will become `var(--wp--preset--font-size--3-xl)`

Adding test coverage

## Why?
The JS package was not converting preset slugs to kebab case. 

The consequence was that applying preset styles in the editor did not match the CSS vars generated by global styles.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

## Testing Instructions

Add the following to your theme.json file

```json
"spacing": {
			"spacingSizes": [
				{
					"slug": "s",
					"size": "5px",
					"name": "S"
				},
				{
					"slug": "m",
					"size": "10px",
					"name": "M"
				},
				{
					"slug": "l",
					"size": "15px",
					"name": "L"
				},
				{
					"slug": "xl",
					"size": "30px",
					"name": "XL"
				},
				{
					"slug": "2xl",
					"size": "50px",
					"name": "2XL"
				},
				{
					"slug": "3xl",
					"size": "85px",
					"name": "3XL"
				}
			]
		}
```

In the editor, set the padding/margin/blockGap of a block to the "2XL" setting

Check that the applied inline styles contain the kebab-cased slug, e.g., `var(--wp--preset--spacing--2-xl)` and NOT `var(--wp--preset--spacing-2xl)`



## Before

<img width="937" alt="Screen Shot 2022-09-23 at 12 08 42 pm" src="https://user-images.githubusercontent.com/6458278/191880710-497c5cc6-2e52-4ab1-baea-7841b2d6e046.png">

## After
<img width="1280" alt="Screen Shot 2022-09-23 at 12 05 46 pm" src="https://user-images.githubusercontent.com/6458278/191880718-bcc87d10-8795-4b2b-b3c7-b59ff387a5fa.png">

