### PR TITLE
Global Styles: add a hint so the user knows Site Title and Post Title have their own styling menus

### DIFF
--- a/packages/edit-site/src/components/global-styles/header.js
+++ b/packages/edit-site/src/components/global-styles/header.js
@@ -12,7 +12,7 @@ import {
 import { isRTL, __ } from '@wordpress/i18n';
 import { chevronRight, chevronLeft } from '@wordpress/icons';
 
-function ScreenHeader( { title, description } ) {
+function ScreenHeader( { title, description, hint = undefined } ) {
 	return (
 		<VStack spacing={ 0 }>
 			<View>
@@ -38,6 +38,9 @@ function ScreenHeader( { title, description } ) {
 				<p className="edit-site-global-styles-header__description">
 					{ description }
 				</p>
+			) }
+			{ hint && (
+				<p className="edit-site-global-styles-header__hint">{ hint }</p>
 			) }
 		</VStack>
 	);

--- a/packages/edit-site/src/components/global-styles/screen-typography-element.js
+++ b/packages/edit-site/src/components/global-styles/screen-typography-element.js
@@ -2,12 +2,23 @@
  * WordPress dependencies
  */
 import { __ } from '@wordpress/i18n';
+import { __experimentalNavigatorButton as NavigatorButton } from '@wordpress/components';
+import { createInterpolateElement } from '@wordpress/element';
 
 /**
  * Internal dependencies
  */
 import TypographyPanel from './typography-panel';
 import ScreenHeader from './header';
+
+function BlockStylesLink( { children } ) {
+	return (
+		<NavigatorButton path={ '/blocks' } isLink>
+			{ ' ' }
+			{ children }{ ' ' }
+		</NavigatorButton>
+	);
+}
 
 const elements = {
 	text: {
@@ -21,6 +32,12 @@ const elements = {
 	heading: {
 		description: __( 'Manage the fonts and typography used on headings.' ),
 		title: __( 'Headings' ),
+		hint: createInterpolateElement(
+			__(
+				'Some special headings like your Site Title and Post Title are managed separately via dedicated settings under the <link>Styles > Blocks</link> menu.'
+			),
+			{ link: <BlockStylesLink /> }
+		),
 	},
 	button: {
 		description: __( 'Manage the fonts and typography used on buttons.' ),
@@ -34,6 +51,7 @@ function ScreenTypographyElement( { name, element } ) {
 			<ScreenHeader
 				title={ elements[ element ].title }
 				description={ elements[ element ].description }
+				hint={ elements[ element ].hint }
 			/>
 			<TypographyPanel name={ name } element={ element } />
 		</>

--- a/packages/edit-site/src/components/global-styles/style.scss
+++ b/packages/edit-site/src/components/global-styles/style.scss
@@ -51,6 +51,7 @@
 	}
 }
 
+.edit-site-global-styles-header__hint,
 .edit-site-global-styles-header__description,
 .edit-site-block-types-search {
 	padding: 0 $grid-unit-20;


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Add a hint to the Heading Typography menu 
![image](https://user-images.githubusercontent.com/6851384/191884729-484e44c8-472b-47d5-9561-5bb7c0787bec.png)

## Why?
When you focus a Site Title or Post Title in the Editor, it will be shown as an H1 or whatever heading it is based on:
![image](https://user-images.githubusercontent.com/6851384/191884544-cfffcb2a-8272-4a05-9f59-2f2307d0be61.png)
If you go to Global Styles > Typography > Headings and update the H1 style, it might not update because Site Title has its own styling menu under Global Styles > Blocks > Site Title. This small PR adds a hint and link to the Block styling menu.

## How?
Uses existing `<NavigatorButton isLink/>` component.

## Testing Instructions
1. Open the Editor for a theme with Global Styles and to Global Styles > Typography > Headings and confirm the text is present with a link to the parent Block Styles menu. 
2. Confirm back navigation works. 

## Screenshots or screencast <!-- if applicable -->
