### PR TITLE
Upgrade react-easy-crop to bring in fix for site editor iframe

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16519,7 +16519,7 @@
 				"inherits": "^2.0.3",
 				"lodash": "^4.17.21",
 				"react-autosize-textarea": "^7.1.0",
-				"react-easy-crop": "^3.0.0",
+				"react-easy-crop": "^4.5.1",
 				"rememo": "^4.0.0",
 				"remove-accents": "^0.4.2",
 				"traverse": "^0.6.6"
@@ -16579,6 +16579,20 @@
 					"version": "2.7.0",
 					"resolved": "https://registry.npmjs.org/colord/-/colord-2.7.0.tgz",
 					"integrity": "sha512-pZJBqsHz+pYyw3zpX6ZRXWoCHM1/cvFikY9TV8G3zcejCaKE0lhankoj8iScyrrePA8C7yJ5FStfA9zbcOnw7Q=="
+				},
+				"react-easy-crop": {
+					"version": "4.5.1",
+					"resolved": "https://registry.npmjs.org/react-easy-crop/-/react-easy-crop-4.5.1.tgz",
+					"integrity": "sha512-MVzCWmKXTwZTK0iYqlF/gPLdLqvUGrLGX7SQ4g+DO3b/lCiVAwxZKLeZ1wjDfG+r/yEWUoL7At5a0kkDJeU+rQ==",
+					"requires": {
+						"normalize-wheel": "^1.0.1",
+						"tslib": "2.0.1"
+					}
+				},
+				"tslib": {
+					"version": "2.0.1",
+					"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.0.1.tgz",
+					"integrity": "sha512-SgIkNheinmEBgx1IUNirK0TUD4X9yjjBRTqqjggWCU3pUEqIk3/Uwl3yRixYKT6WjQuGiwDv4NomL3wqRCj+CQ=="
 				}
 			}
 		},
@@ -46070,6 +46084,11 @@
 			"integrity": "sha512-U+JJi7duF1o+u2pynbp2zXDW2/PADgC30f0GsHZtRh+HOcXHnw137TrNlyxxRvWW5fjKd3bcLHPxofWuCjaeZg==",
 			"dev": true
 		},
+		"normalize-wheel": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/normalize-wheel/-/normalize-wheel-1.0.1.tgz",
+			"integrity": "sha512-1OnlAPZ3zgrk8B91HyRj+eVv+kS5u+Z0SCsak6Xil/kmgEia50ga7zfkumayonZrImffAxPU/5WcyGhzetHNPA=="
+		},
 		"npm-bundled": {
 			"version": "1.1.2",
 			"resolved": "https://registry.npmjs.org/npm-bundled/-/npm-bundled-1.1.2.tgz",
@@ -50318,21 +50337,6 @@
 				"loose-envify": "^1.1.0",
 				"object-assign": "^4.1.1",
 				"scheduler": "^0.20.2"
-			}
-		},
-		"react-easy-crop": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/react-easy-crop/-/react-easy-crop-3.0.0.tgz",
-			"integrity": "sha512-aP+G2W4WNE4IPRX/YPXna4gsoR+usLilGX/hepzzntZkD+rD1XaziPNOQH6z26NZKdQRDT4Avh37R5cnGmyRHQ==",
-			"requires": {
-				"tslib": "1.11.2"
-			},
-			"dependencies": {
-				"tslib": {
-					"version": "1.11.2",
-					"resolved": "https://registry.npmjs.org/tslib/-/tslib-1.11.2.tgz",
-					"integrity": "sha512-tTSkux6IGPnUGUd1XAZHcpu85MOkIl5zX49pO+jfsie3eP0B6pyhOlLXm3cAC6T7s+euSDDUUV+Acop5WmtkVg=="
-				}
 			}
 		},
 		"react-element-to-jsx-string": {

--- a/packages/block-editor/package.json
+++ b/packages/block-editor/package.json
@@ -67,7 +67,7 @@
 		"inherits": "^2.0.3",
 		"lodash": "^4.17.21",
 		"react-autosize-textarea": "^7.1.0",
-		"react-easy-crop": "^3.0.0",
+		"react-easy-crop": "^4.5.1",
 		"rememo": "^4.0.0",
 		"remove-accents": "^0.4.2",
 		"traverse": "^0.6.6"


### PR DESCRIPTION
## What?
Upgrades react-easy-crop to version `4.5.1`

## Why?
The current version bundled with Gutenberg does not work correctly when run in the site editor iframe as the styles and events are attached to the global window and document instead of the iframe. This issue was fixed in [this commit](https://github.com/ValentinH/react-easy-crop/commit/6cc485acce5286f6a2978bd04aa6988e78c5411f).

## How?
Updates the package.json in the block editor package to reference the latest version.

## Testing Instructions

- Check out this PR and run `npm install`
- Insert an Image block in the post editor and make sure the crop tools work as expected
- Insert an Image block in the site editor and make sure the crop tools work the same as in the post editor

## Screenshots or screencast 

Before in site editor:

https://user-images.githubusercontent.com/3629020/191895986-262c488e-43d5-41ed-a938-a2c04080ab93.mp4

After in site editor:

https://user-images.githubusercontent.com/3629020/191896000-3eb777ab-f01a-4e6f-98c6-bf0c2afeadd0.mp4



