### PR TITLE
Fix submenu link color when the block is nested

### DIFF
--- a/packages/block-library/src/navigation/editor.scss
+++ b/packages/block-library/src/navigation/editor.scss
@@ -46,12 +46,12 @@
 }
 
 // Make sure that the default text color is not overwritten by the parent container colors.
-.editor-styles-wrapper .wp-block-navigation__submenu-container:not(.has-text-color) .wp-block-navigation-item {
+.editor-styles-wrapper .wp-block-navigation__submenu-container:not(.has-text-color) .wp-block-navigation-item__content {
 	color: #000;
 }
 
 // Make sure that the user-set text color is not overwritten by the parent container colors.
-.editor-styles-wrapper .wp-block-navigation__submenu-container.has-text-color .wp-block-navigation-item {
+.editor-styles-wrapper .wp-block-navigation__submenu-container.has-text-color .wp-block-navigation-item__content {
 	color: inherit;
 }
 

--- a/packages/block-library/src/navigation/editor.scss
+++ b/packages/block-library/src/navigation/editor.scss
@@ -45,6 +45,16 @@
 	background-color: inherit;
 }
 
+// Make sure that the default text color is not overwritten by the parent container colors.
+.editor-styles-wrapper .wp-block-navigation__submenu-container:not(.has-text-color) .wp-block-navigation-item {
+	color: #000;
+}
+
+// Make sure that the user-set text color is not overwritten by the parent container colors.
+.editor-styles-wrapper .wp-block-navigation__submenu-container.has-text-color .wp-block-navigation-item {
+	color: inherit;
+}
+
 // Only show the flyout on hover if the parent menu item is selected.
 .wp-block-navigation:not(.is-selected):not(.has-child-selected)
 .has-child:hover {


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->
Adds a default black text color to submenus in the editor, and adds `color:inherit` to submenus in the editor if there is a user-set color.

Closes https://github.com/WordPress/gutenberg/issues/40908

-For page list submenus see https://github.com/WordPress/gutenberg/pull/44310

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
If the navigation block was placed inside a container with a text color, submenus used that text color in the editor.
-Because the default submenu background color is white, there was a risk that the text could be white on white background. This could be seen in the header menu of Twenty Twenty-Two.
-The submenu text color option did not work in the editor.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
Updates the editor stylesheet for the navigation block.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->

Activate Twenty Twenty-Two.
Open the Site Editor and select the navigation block in the header template part.
Add a submenu to the navigation.
Confirm that the submenu background color is white, and the text color is black.
Open the color settings for the navigation block and select a submenu text color. Please test both palette colors and custom colors.
Confirm that your selected text color is working in the submenu in the editor and front.

## Screenshots or screencast <!-- if applicable -->
Before:
<img width="437" alt="The text in the submenu is invisible because it is white text on white background" src="https://user-images.githubusercontent.com/7422055/191900639-20b4c89e-f7d8-4f73-9ac4-b8ff622735da.png">

After:
<img width="437" alt="The text is visible in the submenu as the color is black on white background." src="https://user-images.githubusercontent.com/7422055/191899034-903e72b7-a37e-4f74-8753-b1ddaa165540.png">

