### PR TITLE
RangeControl: Remove unused UseDebouncedHoverInteractionArgs type

### DIFF
--- a/packages/components/src/range-control/types.ts
+++ b/packages/components/src/range-control/types.ts
@@ -290,39 +290,6 @@ export type UseControlledRangeValueArgs = {
 	value: number | null;
 };
 
-export type UseDebouncedHoverInteractionArgs = {
-	/**
-	 *  A callback function invoked when the element is hidden.
-	 *
-	 * @default () => {}
-	 */
-	onHide?: () => void;
-	/**
-	 * A callback function invoked when the mouse is moved out of the element.
-	 *
-	 * @default () => {}
-	 */
-	onMouseLeave?: MouseEventHandler< HTMLInputElement >;
-	/**
-	 * A callback function invoked when the mouse is moved.
-	 *
-	 * @default () => {}
-	 */
-	onMouseMove?: MouseEventHandler< HTMLInputElement >;
-	/**
-	 * A callback function invoked when the element is shown.
-	 *
-	 * @default () => {}
-	 */
-	onShow?: () => void;
-	/**
-	 * Timeout before the element is shown or hidden.
-	 *
-	 * @default 300
-	 */
-	timeout?: number;
-};
-
 export type UseMarksArgs = NumericProps & {
 	marks: RangeMarks;
 	step: number;


### PR DESCRIPTION
Related: https://github.com/WordPress/gutenberg/pull/44271

## What?

In https://github.com/WordPress/gutenberg/pull/44271, `useDebouncedHoverInteraction` was removed but its related type `UseDebouncedHoverInteractionArgs` wasn't. As this isn't used anymore, this PR simply removes it.

## Why?

🧹 Keeping things clean is good.

## How?

- Deleted unused type.

## Testing Instructions

1. Check there are no type errors.
2. Ensure there are no other references to `UseDebouncedHoverInteractionArgs` in the code base.
3. Run `RangeControl` unit tests if you feel like it

