### PR TITLE
Remap gradient colors from "background" to "background-image"

### DIFF
--- a/lib/compat/wordpress-6.1/class-wp-theme-json-6-1.php
+++ b/lib/compat/wordpress-6.1/class-wp-theme-json-6-1.php
@@ -44,7 +44,7 @@ class WP_Theme_JSON_6_1 extends WP_Theme_JSON_6_0 {
 	 * path to the value in theme.json & block attributes.
 	 */
 	const PROPERTIES_METADATA = array(
-		'background'                        => array( 'color', 'gradient' ),
+		'background-image'                  => array( 'color', 'gradient' ),
 		'background-color'                  => array( 'color', 'background' ),
 		'border-radius'                     => array( 'border', 'radius' ),
 		'border-top-left-radius'            => array( 'border', 'radius', 'topLeft' ),


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Changes gradient color to use `background-image` instead of `background`.
Closes https://github.com/WordPress/gutenberg/issues/32787
Partial for https://github.com/WordPress/gutenberg/issues/42105

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
-To enable using background effects like background-clip, for detailed example please see #32787
-To differentiate the solid background color from the gradient background color

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->
Activate a theme that has a default gradient for the body set in theme.json.
In the browser console, view the Styles source; confirm that the body tag has 
`background-image: (the selected gradient)`. and not `background: (the selected gradient)`

## Screenshots or screencast <!-- if applicable -->
