### PR TITLE
Removes __unstableMaxPages attribute from Page List block (and Nav block)

### DIFF
--- a/docs/reference-guides/core-blocks.md
+++ b/docs/reference-guides/core-blocks.md
@@ -429,7 +429,7 @@ Display a list of all pages. ([Source](https://github.com/WordPress/gutenberg/tr
 -	**Name:** core/page-list
 -	**Category:** widgets
 -	**Supports:** ~~html~~, ~~reusable~~
--	**Attributes:** __unstableMaxPages
+-	**Attributes:** 
 
 ## Paragraph
 

--- a/packages/block-library/src/navigation/index.php
+++ b/packages/block-library/src/navigation/index.php
@@ -307,9 +307,6 @@ function block_core_navigation_get_fallback_blocks() {
 	$page_list_fallback = array(
 		array(
 			'blockName' => 'core/page-list',
-			'attrs'     => array(
-				'__unstableMaxPages' => 4,
-			),
 		),
 	);
 

--- a/packages/block-library/src/page-list/block.json
+++ b/packages/block-library/src/page-list/block.json
@@ -7,11 +7,7 @@
 	"description": "Display a list of all pages.",
 	"keywords": [ "menu", "navigation" ],
 	"textdomain": "default",
-	"attributes": {
-		"__unstableMaxPages": {
-			"type": "number"
-		}
-	},
+	"attributes": {},
 	"usesContext": [
 		"textColor",
 		"customTextColor",

--- a/packages/block-library/src/page-list/index.php
+++ b/packages/block-library/src/page-list/index.php
@@ -299,11 +299,6 @@ function render_block_core_page_list( $attributes, $content, $block ) {
 
 	$nested_pages = block_core_page_list_nest_pages( $top_level_pages, $pages_with_children );
 
-	// Limit the number of items to be visually displayed.
-	if ( ! empty( $attributes['__unstableMaxPages'] ) ) {
-		$nested_pages = array_slice( $nested_pages, 0, $attributes['__unstableMaxPages'] );
-	}
-
 	$is_navigation_child = array_key_exists( 'showSubmenuIcon', $block->context );
 
 	$open_submenus_on_click = array_key_exists( 'openSubmenusOnClick', $block->context ) ? $block->context['openSubmenusOnClick'] : false;


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Removes the unstable attribute which was being tested to allow limiting of number of Page List pages being shown.

This PR also removes the attribute from the Nav block and will cause the Navigation block fallback page list to display _**unlimited numbers of pages**_ (cc @jameskoster @jasmussen).

Closes https://github.com/WordPress/gutenberg/issues/44360

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

See discussion here https://github.com/WordPress/gutenberg/issues/44360.

Essentially most contributors felt this prop is unnecessary and should be omitted.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

Remove attribute and any related implementation.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->

- Add 10 or so Pages
- New Post
- Switch to code view and add `<!-- wp:page-list {"__unstableMaxPages":4} /-->`
- You should see _all_ your 10 Pages. Should not be limited.
- Switch to front of site and confirm the same thing happens.

## Screenshots or screencast <!-- if applicable -->
