### PR TITLE
Add strict meta schema validation test for block.json

### DIFF
--- a/test/integration/blocks-schema.test.js
+++ b/test/integration/blocks-schema.test.js
@@ -21,6 +21,16 @@ describe( 'block.json schema', () => {
 	] );
 	const ajv = new Ajv();
 
+	test( 'strictly adheres to the draft-04 meta schema', () => {
+		// Use ajv.compile instead of ajv.validateSchema to validate the schema
+		// because validateSchema only checks syntax, whereas, compile checks
+		// if the schema is semantically correct with strict mode.
+		// See https://github.com/ajv-validator/ajv/issues/1434#issuecomment-822982571
+		const result = ajv.compile( blockSchema );
+
+		expect( result.errors ).toBe( null );
+	} );
+
 	test( 'found block folders', () => {
 		expect( blockFolders.length ).toBeGreaterThan( 0 );
 	} );


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Adds a test to validate the block.json schema.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

In #44252 we discovered that `validate` doesn't strictly check the semantics of the schema; whereas, `compile` does.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

Adding a test with `compile` will make sure changes to the block.json schema strictly adhere to the draft-04 spec.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->

`npm run test:unit ./test/integration/blocks-schema.test.js`

## Screenshots or screencast <!-- if applicable -->
