### PR TITLE
Fix rotated image crop area aspect ratio

### DIFF
--- a/packages/block-editor/src/components/image-editor/use-transform-image.js
+++ b/packages/block-editor/src/components/image-editor/use-transform-image.js
@@ -41,7 +41,7 @@ function useTransformState( { url, naturalWidth, naturalHeight } ) {
 		if ( angle === 0 ) {
 			setEditedUrl();
 			setRotation( angle );
-			setAspect( 1 / aspect );
+			setAspect( naturalWidth / naturalHeight );
 			setPosition( {
 				x: -( position.y * naturalAspectRatio ),
 				y: position.x * naturalAspectRatio,
@@ -80,7 +80,7 @@ function useTransformState( { url, naturalWidth, naturalHeight } ) {
 			canvas.toBlob( ( blob ) => {
 				setEditedUrl( URL.createObjectURL( blob ) );
 				setRotation( angle );
-				setAspect( 1 / aspect );
+				setAspect( canvas.width / canvas.height );
 				setPosition( {
 					x: -( position.y * naturalAspectRatio ),
 					y: position.x * naturalAspectRatio,


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Fixes #44422 

> When using the inline image editor, rotating the image has the wrong aspect ratio for the cropping area. With a landscape image at a 180º rotation, the aspect ratio should be landscape again, but it is still portrait. And at a 270º rotation it should be portrait, but is landscape.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

🐛 

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

Sets the aspect ratio to the actual aspect ratio rather than assuming it should be the inverse of the previous one.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->

1. Insert image
2. Open image cropper tool
3. Rotate image
4. Check that the aspect ratio for the cropping area matches the rotation

## Screenshots or screencast <!-- if applicable -->

### Before
![image-rotation-bug](https://user-images.githubusercontent.com/5129775/192002711-cd7416e3-619c-4b1a-9095-0977e5878a6a.gif)

### After
![image-rotation-fix](https://user-images.githubusercontent.com/5129775/192036242-a1598906-3668-46e2-80c1-7bdf09318d40.gif)
