### PR TITLE
Tag Processor: throw when supplied unacceptible attribute names.

### DIFF
--- a/lib/experimental/html/class-wp-html-tag-processor.php
+++ b/lib/experimental/html/class-wp-html-tag-processor.php
@@ -970,7 +970,19 @@ class WP_HTML_Tag_Processor {
 		 * @see https://html.spec.whatwg.org/#attributes-2
 		 */
 		if ( preg_match(
-			'~[ "\'>&</=\x{00}-\x{1F}\x{FDD0}-\x{FDEF}\x{FFFE}\x{FFFF}\x{1FFFE}\x{1FFFF}\x{2FFFE}\x{2FFFF}\x{3FFFE}\x{3FFFF}\x{4FFFE}\x{4FFFF}\x{5FFFE}\x{5FFFF}\x{6FFFE}\x{6FFFF}\x{7FFFE}\x{7FFFF}\x{8FFFE}\x{8FFFF}\x{9FFFE}\x{9FFFF}\x{AFFFE}\x{AFFFF}\x{BFFFE}\x{BFFFF}\x{CFFFE}\x{CFFFF}\x{DFFFE}\x{DFFFF}\x{EFFFE}\x{EFFFF}\x{FFFFE}\x{FFFFF}\x{10FFFE}\x{10FFFF}]~Ssu',
+			'~[' .
+				// Syntax-like characters
+				'"\'>&</ =' .
+				// Control characters
+				'\x{00}-\x{1F}' .
+				// HTML noncharacters
+				'\x{FDD0}-\x{FDEF}' .
+				'\x{FFFE}\x{FFFF}\x{1FFFE}\x{1FFFF}\x{2FFFE}\x{2FFFF}\x{3FFFE}\x{3FFFF}' .
+				'\x{4FFFE}\x{4FFFF}\x{5FFFE}\x{5FFFF}\x{6FFFE}\x{6FFFF}\x{7FFFE}\x{7FFFF}' .
+				'\x{8FFFE}\x{8FFFF}\x{9FFFE}\x{9FFFF}\x{AFFFE}\x{AFFFF}\x{BFFFE}\x{BFFFF}' .
+				'\x{CFFFE}\x{CFFFF}\x{DFFFE}\x{DFFFF}\x{EFFFE}\x{EFFFF}\x{FFFFE}\x{FFFFF}' .
+				'\x{10FFFE}\x{10FFFF}' .
+			']~Ssu',
 			$name
 		) ) {
 			if ( defined( 'WP_DEBUG' ) && WP_DEBUG ) {

--- a/lib/experimental/html/class-wp-html-tag-processor.php
+++ b/lib/experimental/html/class-wp-html-tag-processor.php
@@ -950,7 +950,7 @@ class WP_HTML_Tag_Processor {
 
 		/*
 		 * Verify that the attribute name is allowable. In WP_DEBUG
-		 * environments we want to crash to quickly alert developers
+		 * environments we want to crash quickly to alert developers
 		 * of typos and issues; but in production we don't want to
 		 * interrupt a normal page view, so we'll silently avoid
 		 * updating the attribute in those cases.
@@ -958,14 +958,14 @@ class WP_HTML_Tag_Processor {
 		 * Of note, we're disallowing more characters than are strictly
 		 * forbidden in HTML5. This is to prevent additional security
 		 * risks deeper in the WordPress and plugin stack. Specifically
-		 * we reject the less-than (<) and ampersand (&) characters.
+		 * we reject the less-than (<) greater-than (>) and ampersand (&).
 		 *
 		 * The use of a PCRE match allows us to look for specific Unicode
 		 * code points without writing a UTF-8 decoder. Whereas scanning
-		 * for one-byte characters is trivial, scanning for the longer
-		 * byte sequences would be more complicated, and this shouldn't
-		 * be in the hot path for execution so we can compromise on the
-		 * efficiency at this point.
+		 * for one-byte characters is trivial (with `strcspn`), scanning
+		 * for the longer byte sequences would be more complicated, and
+		 * this shouldn't be in the hot path for execution so we can
+		 * compromise on the efficiency at this point.
 		 *
 		 * @see https://html.spec.whatwg.org/#attributes-2
 		 */

--- a/lib/experimental/html/class-wp-html-tag-processor.php
+++ b/lib/experimental/html/class-wp-html-tag-processor.php
@@ -942,6 +942,7 @@ class WP_HTML_Tag_Processor {
 	 *
 	 * @param string         $name  The attribute name to target.
 	 * @param string|boolean $value The new attribute value.
+	 * @throws Exception When WP_DEBUG is true and the attribute name is invalid.
 	 */
 	public function set_attribute( $name, $value ) {
 		if ( null === $this->tag_name_starts_at ) {
@@ -971,11 +972,11 @@ class WP_HTML_Tag_Processor {
 		 */
 		if ( preg_match(
 			'~[' .
-				// Syntax-like characters
+				// Syntax-like characters.
 				'"\'>&</ =' .
-				// Control characters
+				// Control characters.
 				'\x{00}-\x{1F}' .
-				// HTML noncharacters
+				// HTML noncharacters.
 				'\x{FDD0}-\x{FDEF}' .
 				'\x{FFFE}\x{FFFF}\x{1FFFE}\x{1FFFF}\x{2FFFE}\x{2FFFF}\x{3FFFE}\x{3FFFF}' .
 				'\x{4FFFE}\x{4FFFF}\x{5FFFE}\x{5FFFF}\x{6FFFE}\x{6FFFF}\x{7FFFE}\x{7FFFF}' .

--- a/phpunit/html/WP_HTML_Tag_Processor_Isolated_Test.php
+++ b/phpunit/html/WP_HTML_Tag_Processor_Isolated_Test.php
@@ -1,0 +1,98 @@
+<?php
+/**
+ * Unit tests covering WP_HTML_Tag_Processor functionality.
+ *
+ * @package WordPress
+ * @subpackage HTML
+ */
+
+if ( ! function_exists( 'esc_attr' ) ) {
+	function esc_attr( $s ) {
+		return str_replace( '"', '&quot;', $s );
+	}
+}
+
+if ( ! class_exists( 'WP_UnitTestCase' ) ) {
+	abstract class WP_UnitTestCase extends \PHPUnit\Framework\TestCase {}
+}
+
+require_once __DIR__ . '/../../lib/experimental/html/index.php';
+
+/**
+ * Runs tests in isolated PHP process for verifying behaviors
+ * that depend on the `WP_DEBUG` constant value, if set.
+ *
+ * @group html
+ *
+ * @coversDefaultClass WP_HTML_Tag_Processor
+ */
+class WP_HTML_Tag_Processor_Isolated_Test extends WP_UnitTestCase {
+	protected $runTestInSeparateProcess = TRUE;
+
+	/**
+	 * Attribute names with invalid characters should be rejected.
+	 *
+	 * When WP_DEBUG is set we want to throw an error to alert a
+	 * developer that they are sending invalid attribute names.
+	 *
+	 * @dataProvider data_invalid_attribute_names
+	 * @covers set_attribute
+	 */
+	public function test_set_attribute_throw_when_given_invalid_attribute_names_in_debug_mode( $attribute_name ) {
+		define( 'WP_DEBUG', true );
+		$p = new WP_HTML_Tag_Processor( '<span></span>' );
+
+		$this->expectException( Exception::class );
+
+		$p->next_tag();
+		$p->set_attribute( $attribute_name, "test" );
+
+		$this->assertEquals( '<span></span>', (string) $p );
+	}
+
+	/**
+	 * Attribute names with invalid characters should be rejected.
+	 *
+	 * When WP_DEBUG isn't set we want to quietly fail to set the
+	 * invalid attribute to avoid breaking the HTML and to do so
+	 * without breaking the entire page.
+	 *
+	 * @dataProvider data_invalid_attribute_names
+	 * @covers set_attribute
+	 */
+	public function test_set_attribute_silently_fails_when_given_invalid_attribute_names_outside_of_debug_mode( $attribute_name ) {
+		$p = new WP_HTML_Tag_Processor( '<span></span>' );
+
+		$p->next_tag();
+		$p->set_attribute( $attribute_name, "test" );
+
+		$this->assertEquals( '<span></span>', (string) $p );
+	}
+
+	/**
+	 * Data provider with invalid HTML attribute names.
+	 *
+	 * @return array {
+	 *     @type string $attribute_name Text considered invalid for HTML attribute names.
+	 * }
+	 */
+	public function data_invalid_attribute_names() {
+		return array(
+			'controls_null'    => array( "i\x00d" ),
+			'controls_newline' => array( "\nbroken-expectations" ),
+			'space'            => array( "aria label" ),
+			'double-quote'     => array( '"id"' ),
+			'single-quote'     => array( "'id'" ),
+			'greater-than'     => array( 'sneaky>script' ),
+			'solidus'          => array( 'data/test-id' ),
+			'equals'           => array( 'checked=checked' ),
+			'noncharacters_1'  => array( html_entity_decode( 'anything&#xFDD0;' ) ),
+			'noncharacters_2'  => array( html_entity_decode( 'te&#xFFFF;st' ) ),
+			'noncharacters_3'  => array( html_entity_decode( 'te&#x2FFFE;st' ) ),
+			'noncharacters_4'  => array( html_entity_decode( 'te&#xDFFFF;st' ) ),
+			'noncharacters_5'  => array( html_entity_decode( '&#x10FFFE;' ) ),
+			'wp_no_lt'         => array( 'id<script'),
+			'wp_no_amp'        => array( 'class&lt;script'),
+		);
+	}
+}

--- a/phpunit/html/WP_HTML_Tag_Processor_Isolated_Test.php
+++ b/phpunit/html/WP_HTML_Tag_Processor_Isolated_Test.php
@@ -27,7 +27,8 @@ require_once __DIR__ . '/../../lib/experimental/html/index.php';
  * @coversDefaultClass WP_HTML_Tag_Processor
  */
 class WP_HTML_Tag_Processor_Isolated_Test extends WP_UnitTestCase {
-	protected $runTestInSeparateProcess = TRUE;
+	// phpcs:disable WordPress.NamingConventions.ValidVariableName.PropertyNotSnakeCase
+	protected $runTestInSeparateProcess = true;
 
 	/**
 	 * Attribute names with invalid characters should be rejected.
@@ -45,7 +46,7 @@ class WP_HTML_Tag_Processor_Isolated_Test extends WP_UnitTestCase {
 		$this->expectException( Exception::class );
 
 		$p->next_tag();
-		$p->set_attribute( $attribute_name, "test" );
+		$p->set_attribute( $attribute_name, 'test' );
 
 		$this->assertEquals( '<span></span>', (string) $p );
 	}
@@ -64,7 +65,7 @@ class WP_HTML_Tag_Processor_Isolated_Test extends WP_UnitTestCase {
 		$p = new WP_HTML_Tag_Processor( '<span></span>' );
 
 		$p->next_tag();
-		$p->set_attribute( $attribute_name, "test" );
+		$p->set_attribute( $attribute_name, 'test' );
 
 		$this->assertEquals( '<span></span>', (string) $p );
 	}
@@ -80,7 +81,7 @@ class WP_HTML_Tag_Processor_Isolated_Test extends WP_UnitTestCase {
 		return array(
 			'controls_null'    => array( "i\x00d" ),
 			'controls_newline' => array( "\nbroken-expectations" ),
-			'space'            => array( "aria label" ),
+			'space'            => array( 'aria label' ),
 			'double-quote'     => array( '"id"' ),
 			'single-quote'     => array( "'id'" ),
 			'greater-than'     => array( 'sneaky>script' ),
@@ -91,9 +92,8 @@ class WP_HTML_Tag_Processor_Isolated_Test extends WP_UnitTestCase {
 			'noncharacters_3'  => array( html_entity_decode( 'te&#x2FFFE;st' ) ),
 			'noncharacters_4'  => array( html_entity_decode( 'te&#xDFFFF;st' ) ),
 			'noncharacters_5'  => array( html_entity_decode( '&#x10FFFE;' ) ),
-			'noncharacters_6'  => array( "\u{10FFFE}" ),
-			'wp_no_lt'         => array( 'id<script'),
-			'wp_no_amp'        => array( 'class&lt;script'),
+			'wp_no_lt'         => array( 'id<script' ),
+			'wp_no_amp'        => array( 'class&lt;script' ),
 		);
 	}
 
@@ -115,7 +115,7 @@ class WP_HTML_Tag_Processor_Isolated_Test extends WP_UnitTestCase {
 		$p = new WP_HTML_Tag_Processor( '<span></span>' );
 
 		$p->next_tag();
-		$p->set_attribute( $attribute_name, "test" );
+		$p->set_attribute( $attribute_name, 'test' );
 
 		$this->assertEquals( "<span $attribute_name=\"test\"></span>", (string) $p );
 	}
@@ -129,13 +129,16 @@ class WP_HTML_Tag_Processor_Isolated_Test extends WP_UnitTestCase {
 	 */
 	public function data_valid_attribute_names() {
 		return array(
-			'ascii_letters'    => array( "abcdefghijklmnopqrstuwxyzABCDEFGHIJKLMNOPQRSTUWXYZ" ),
-			'ascii_numbers'    => array( "0123456789" ),
-			'symbols'          => array( '!@#$%^*()[]{};:\\||,.?`~£§±' ),
-			'utf8_diacritics'  => array( "ÁÄÂÀÃÅČÇĆĎÉĚËÈÊẼĔȆĞÍÌÎÏİŇÑÓÖÒÔÕØŘŔŠŞŤÚŮÜÙÛÝŸŽáäâàãåčçćďéěëèêẽĕȇğíìîïıňñóöòôõøðřŕšşťúůüùûýÿžþÞĐđßÆa" ),
-			'hebrew_accents'   => array( "\u{059D}a" ),
-			// See https://arxiv.org/abs/2111.00169
-			'rtl_magic'        => array( html_entity_decode("&#x2067;&#x2066;abc&#x2069;&#x2066;def&#x2069;&#x2069;") ),
+			'ascii_letters'         => array( 'abcdefghijklmnopqrstuwxyzABCDEFGHIJKLMNOPQRSTUWXYZ' ),
+			'ascii_numbers'         => array( '0123456789' ),
+			'symbols'               => array( '!@#$%^*()[]{};:\\||,.?`~£§±' ),
+			'emoji'                 => array( '❌' ),
+			'utf8_diacritics'       => array( 'ÁÄÂÀÃÅČÇĆĎÉĚËÈÊẼĔȆĞÍÌÎÏİŇÑÓÖÒÔÕØŘŔŠŞŤÚŮÜÙÛÝŸŽáäâàãåčçćďéěëèêẽĕȇğíìîïıňñóöòôõøðřŕšşťúůüùûýÿžþÞĐđßÆa' ),
+			'hebrew_accents'        => array( html_entity_decode( '&#x059D;a' ) ),
+			// See https://arxiv.org/abs/2111.00169.
+			'rtl_magic'             => array( html_entity_decode( '&#x2067;&#x2066;abc&#x2069;&#x2066;def&#x2069;&#x2069;' ) ),
+			// Only a single unicode "noncharacter" should be rejected. Specific byte segments used in the "noncharacter" sequence are valid.
+			'noncharacter_segments' => array( "\xFF\xFE" ),
 		);
 	}
 

--- a/phpunit/html/WP_HTML_Tag_Processor_Isolated_Test.php
+++ b/phpunit/html/WP_HTML_Tag_Processor_Isolated_Test.php
@@ -121,10 +121,10 @@ class WP_HTML_Tag_Processor_Isolated_Test extends WP_UnitTestCase {
 	}
 
 	/**
-	 * Data provider with invalid HTML attribute names.
+	 * Data provider with valid HTML attribute names.
 	 *
 	 * @return array {
-	 *     @type string $attribute_name Text considered invalid for HTML attribute names.
+	 *     @type string $attribute_name Text considered valid for HTML attribute names.
 	 * }
 	 */
 	public function data_valid_attribute_names() {

--- a/phpunit/html/WP_HTML_Tag_Processor_Isolated_Test.php
+++ b/phpunit/html/WP_HTML_Tag_Processor_Isolated_Test.php
@@ -91,8 +91,52 @@ class WP_HTML_Tag_Processor_Isolated_Test extends WP_UnitTestCase {
 			'noncharacters_3'  => array( html_entity_decode( 'te&#x2FFFE;st' ) ),
 			'noncharacters_4'  => array( html_entity_decode( 'te&#xDFFFF;st' ) ),
 			'noncharacters_5'  => array( html_entity_decode( '&#x10FFFE;' ) ),
+			'noncharacters_6'  => array( "\u{10FFFE}" ),
 			'wp_no_lt'         => array( 'id<script'),
 			'wp_no_amp'        => array( 'class&lt;script'),
 		);
 	}
+
+	/**
+	 * Attribute names with only valid characters should not be rejected.
+	 *
+	 * > Attributes have a name and a value. Attribute names must
+	 * > consist of one or more characters other than controls,
+	 * > U+0020 SPACE, U+0022 ("), U+0027 ('), U+003E (>),
+	 * > U+002F (/), U+003D (=), and noncharacters.
+	 *
+	 * @see https://html.spec.whatwg.org/#attributes-2
+	 *
+	 * @dataProvider data_valid_attribute_names
+	 * @covers set_attribute
+	 */
+	public function test_set_attribute_does_not_reject_valid_attribute_names( $attribute_name ) {
+		define( 'WP_DEBUG', true );
+		$p = new WP_HTML_Tag_Processor( '<span></span>' );
+
+		$p->next_tag();
+		$p->set_attribute( $attribute_name, "test" );
+
+		$this->assertEquals( "<span $attribute_name=\"test\"></span>", (string) $p );
+	}
+
+	/**
+	 * Data provider with invalid HTML attribute names.
+	 *
+	 * @return array {
+	 *     @type string $attribute_name Text considered invalid for HTML attribute names.
+	 * }
+	 */
+	public function data_valid_attribute_names() {
+		return array(
+			'ascii_letters'    => array( "abcdefghijklmnopqrstuwxyzABCDEFGHIJKLMNOPQRSTUWXYZ" ),
+			'ascii_numbers'    => array( "0123456789" ),
+			'symbols'          => array( '!@#$%^*()[]{};:\\||,.?`~£§±' ),
+			'utf8_diacritics'  => array( "ÁÄÂÀÃÅČÇĆĎÉĚËÈÊẼĔȆĞÍÌÎÏİŇÑÓÖÒÔÕØŘŔŠŞŤÚŮÜÙÛÝŸŽáäâàãåčçćďéěëèêẽĕȇğíìîïıňñóöòôõøðřŕšşťúůüùûýÿžþÞĐđßÆa" ),
+			'hebrew_accents'   => array( "\u{059D}a" ),
+			// See https://arxiv.org/abs/2111.00169
+			'rtl_magic'        => array( html_entity_decode("&#x2067;&#x2066;abc&#x2069;&#x2066;def&#x2069;&#x2069;") ),
+		);
+	}
+
 }

--- a/phpunit/html/WP_HTML_Tag_Processor_Test.php
+++ b/phpunit/html/WP_HTML_Tag_Processor_Test.php
@@ -249,57 +249,6 @@ class WP_HTML_Tag_Processor_Test extends WP_UnitTestCase {
 	}
 
 	/**
-	 * Attribute names with invalid characters should be rejected.
-	 *
-	 * > Attributes have a name and a value. Attribute names must
-	 * > consist of one or more characters other than controls,
-	 * > U+0020 SPACE, U+0022 ("), U+0027 ('), U+003E (>),
-	 * > U+002F (/), U+003D (=), and noncharacters.
-	 *
-	 * @see https://html.spec.whatwg.org/#attributes-2
-	 *
-	 * @dataProvider data_invalid_attribute_names
-	 * @covers set_attribute
-	 */
-	public function test_set_attribute_rejects_invalid_attribute_names( $attribute_name ) {
-		$p = new WP_HTML_Tag_Processor( '<span></span>' );
-
-		$this->expectException( Exception::class );
-
-		$p->next_tag();
-		$p->set_attribute( $attribute_name, "test" );
-
-		$this->assertEquals( '<span></span>', (string) $p );
-	}
-
-	/**
-	 * Data provider with invalid HTML attribute names.
-	 *
-	 * @return array {
-	 *     @type string $attribute_name Text considered invalid for HTML attribute names.
-	 * }
-	 */
-	public function data_invalid_attribute_names() {
-		return array(
-			'controls_null'    => array( "i\x00d" ),
-			'controls_newline' => array( "\nbroken-expectations" ),
-			'space'            => array( "aria label" ),
-			'double-quote'     => array( '"id"' ),
-			'single-quote'     => array( "'id'" ),
-			'greater-than'     => array( 'sneaky>script' ),
-			'solidus'          => array( 'data/test-id' ),
-			'equals'           => array( 'checked=checked' ),
-			'noncharacters_1'  => array( html_entity_decode( 'anything&#xFDD0;' ) ),
-			'noncharacters_2'  => array( html_entity_decode( 'te&#xFFFF;st' ) ),
-			'noncharacters_3'  => array( html_entity_decode( 'te&#x2FFFE;st' ) ),
-			'noncharacters_4'  => array( html_entity_decode( 'te&#xDFFFF;st' ) ),
-			'noncharacters_5'  => array( html_entity_decode( '&#x10FFFE;' ) ),
-			'wp_no_lt'         => array( 'id<script'),
-			'wp_no_amp'        => array( 'class&lt;script'),
-		);
-	}
-
-	/**
 	 * According to HTML spec, only the first instance of an attribute counts.
 	 * The other ones are ignored.
 	 *


### PR DESCRIPTION
Part of #44410 

## What

The `WP_HTML_Tag_Processor` allows setting new HTML attributes with a given name and value. Previously this has allowed any string input for the attribute name, but we have to be careful not to print output that might break the HTML we're modifying.

In this patch we're adding a check against the given attribute name and rejecting invalid or unacceptible names. WordPress here is more restrictive than HTML5.

## Why?

We don't want to allow setting attributes whose names could break the HTML syntax or open new vulnerabilities in code that parses post content.

## How?

Validate the given attribute name with a PCRE pattern that looks for unalloyed characters.

## Testing Instructions

Please audit the code and review the new unit tests.
Review with an eye towards security.

cc: @azaozz 