### PR TITLE
Feature/Respect Image Proportions for the Image Size Control Manual Inputs

### DIFF
--- a/packages/block-editor/src/components/image-size-control/index.js
+++ b/packages/block-editor/src/components/image-size-control/index.js
@@ -11,10 +11,10 @@ import {
 	ButtonGroup,
 	SelectControl,
 	TextControl,
-	ToggleControl,
 } from '@wordpress/components';
-import { __ } from '@wordpress/i18n';
+import { __, sprintf } from '@wordpress/i18n';
 import { useState } from '@wordpress/element';
+import { unlock, lock } from '@wordpress/icons';
 
 /**
  * Internal dependencies
@@ -39,7 +39,7 @@ export default function ImageSizeControl( {
 	// Set currently-updating dimension to state.
 	const [ dimension, setDimension ] = useState( 'height' );
 	// Set whether or not we should be locking image aspect ratio. True by default.
-	const [ lockAspectRatio, setLockAspectRatio ] = useState( true );
+	const [ lockAspectRatio, setToggleAspectRatio ] = useState( true );
 	// Get and set height and width.
 	const { currentHeight, currentWidth, updateDimension, updateDimensions } =
 		useDimensionHandler(
@@ -79,24 +79,21 @@ export default function ImageSizeControl( {
 								updateDimension( 'width', value );
 							} }
 						/>
-						<TextControl
-							type="number"
-							className="block-editor-image-size-control__height"
-							label={ __( 'Height' ) }
-							value={ currentHeight }
-							min={ 1 }
-							onChange={ ( value ) => {
-								setDimension( 'height' );
-								updateDimension( 'height', value );
-							} }
-						/>
-						<ToggleControl
-							checked={ lockAspectRatio }
+						<Button
 							className="block-editor-image-size-control__proportions_toggle"
-							label={ __( 'Retain Image Proportions' ) }
-							onChange={ () => {
+							icon={ lockAspectRatio ? lock : unlock }
+							isSmall
+							label={ sprintf(
+								/* translators: image proportions */
+								__( '%s Image Proportions' ),
+								lockAspectRatio ? __( 'Unlock' ) : __( 'Lock' )
+							) }
+							onClick={ () => {
 								const next = ! lockAspectRatio;
-								setLockAspectRatio( next );
+								setToggleAspectRatio( next );
+
+								// If setting to true.
+								// Update height/width with proper ratio.
 								if ( next ) {
 									updateDimension(
 										dimension,
@@ -106,6 +103,18 @@ export default function ImageSizeControl( {
 										true
 									);
 								}
+							} }
+							variant="tertiary"
+						/>
+						<TextControl
+							type="number"
+							className="block-editor-image-size-control__height"
+							label={ __( 'Height' ) }
+							value={ currentHeight }
+							min={ 1 }
+							onChange={ ( value ) => {
+								setDimension( 'height' );
+								updateDimension( 'height', value );
 							} }
 						/>
 					</div>

--- a/packages/block-editor/src/components/image-size-control/index.js
+++ b/packages/block-editor/src/components/image-size-control/index.js
@@ -64,7 +64,7 @@ export default function ImageSizeControl( {
 		if ( ratio !== defaultRatio ) {
 			setToggleAspectRatio( false );
 		}
-	}, [ currentHeight, currentWidth, imageHeight, imageWidth ] );
+	}, [] );
 
 	return (
 		<>
@@ -155,19 +155,26 @@ export default function ImageSizeControl( {
 											isCurrent ? 'primary' : undefined
 										}
 										isPressed={ isCurrent }
-										onClick={ () =>
+										onClick={ () => {
 											updateDimensions(
 												scaledHeight,
 												scaledWidth
-											)
-										}
+											);
+											setToggleAspectRatio( true );
+										} }
 									>
 										{ scale }%
 									</Button>
 								);
 							} ) }
 						</ButtonGroup>
-						<Button isSmall onClick={ () => updateDimensions() }>
+						<Button
+							isSmall
+							onClick={ () => {
+								updateDimensions();
+								setToggleAspectRatio( true );
+							} }
+						>
 							{ __( 'Reset' ) }
 						</Button>
 					</div>

--- a/packages/block-editor/src/components/image-size-control/index.js
+++ b/packages/block-editor/src/components/image-size-control/index.js
@@ -14,6 +14,7 @@ import {
 	ToggleControl,
 } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
+import { useState } from '@wordpress/element';
 
 /**
  * Internal dependencies
@@ -35,8 +36,17 @@ export default function ImageSizeControl( {
 	onChange,
 	onChangeImage = noop,
 } ) {
+	const [ dimension, setDimension ] = useState( 'height' );
+	const [ lockAspectRatio, setLockAspectRatio ] = useState( true );
 	const { currentHeight, currentWidth, updateDimension, updateDimensions } =
-		useDimensionHandler( height, width, imageHeight, imageWidth, onChange );
+		useDimensionHandler(
+			height,
+			width,
+			imageHeight,
+			imageWidth,
+			onChange,
+			lockAspectRatio
+		);
 
 	return (
 		<>
@@ -61,9 +71,10 @@ export default function ImageSizeControl( {
 							label={ __( 'Width' ) }
 							value={ currentWidth }
 							min={ 1 }
-							onChange={ ( value ) =>
-								updateDimension( 'width', value )
-							}
+							onChange={ ( value ) => {
+								setDimension( 'width' );
+								updateDimension( 'width', value );
+							} }
 						/>
 						<TextControl
 							type="number"
@@ -71,13 +82,28 @@ export default function ImageSizeControl( {
 							label={ __( 'Height' ) }
 							value={ currentHeight }
 							min={ 1 }
-							onChange={ ( value ) =>
-								updateDimension( 'height', value )
-							}
+							onChange={ ( value ) => {
+								setDimension( 'height' );
+								updateDimension( 'height', value );
+							} }
 						/>
 						<ToggleControl
+							checked={ lockAspectRatio }
 							className="block-editor-image-size-control__proportions_toggle"
-							label={ __( 'Constrain Proportions' ) }
+							label={ __( 'Retain Image Proportions' ) }
+							onChange={ () => {
+								const next = ! lockAspectRatio;
+								setLockAspectRatio( next );
+								if ( next ) {
+									updateDimension(
+										dimension,
+										'height' === dimension
+											? currentHeight
+											: currentWidth,
+										true
+									);
+								}
+							} }
 						/>
 					</div>
 					<div className="block-editor-image-size-control__row">

--- a/packages/block-editor/src/components/image-size-control/index.js
+++ b/packages/block-editor/src/components/image-size-control/index.js
@@ -36,8 +36,11 @@ export default function ImageSizeControl( {
 	onChange,
 	onChangeImage = noop,
 } ) {
+	// Set currently-updating dimension to state.
 	const [ dimension, setDimension ] = useState( 'height' );
+	// Set whether or not we should be locking image aspect ratio. True by default.
 	const [ lockAspectRatio, setLockAspectRatio ] = useState( true );
+	// Get and set height and width.
 	const { currentHeight, currentWidth, updateDimension, updateDimensions } =
 		useDimensionHandler(
 			height,

--- a/packages/block-editor/src/components/image-size-control/index.js
+++ b/packages/block-editor/src/components/image-size-control/index.js
@@ -13,13 +13,14 @@ import {
 	TextControl,
 } from '@wordpress/components';
 import { __, sprintf } from '@wordpress/i18n';
-import { useState } from '@wordpress/element';
+import { useEffect, useState } from '@wordpress/element';
 import { unlock, lock } from '@wordpress/icons';
 
 /**
  * Internal dependencies
  */
 import useDimensionHandler from './use-dimension-handler';
+import { getImageRatio } from './utils';
 
 const IMAGE_SIZE_PRESETS = [ 25, 50, 75, 100 ];
 const noop = () => {};
@@ -50,6 +51,20 @@ export default function ImageSizeControl( {
 			onChange,
 			lockAspectRatio
 		);
+
+	/**
+	 * Handle updating the aspect lock state on load.
+	 */
+	useEffect( () => {
+		const ratio = getImageRatio( currentHeight, currentWidth );
+		const defaultRatio = getImageRatio( imageHeight, imageWidth );
+
+		// If our incoming ratio doesn't match the saved ratio.
+		// Set assume unlock force-aspect ratio.
+		if ( ratio !== defaultRatio ) {
+			setToggleAspectRatio( false );
+		}
+	}, [ currentHeight, currentWidth, imageHeight, imageWidth ] );
 
 	return (
 		<>

--- a/packages/block-editor/src/components/image-size-control/index.js
+++ b/packages/block-editor/src/components/image-size-control/index.js
@@ -11,6 +11,7 @@ import {
 	ButtonGroup,
 	SelectControl,
 	TextControl,
+	ToggleControl,
 } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 
@@ -73,6 +74,10 @@ export default function ImageSizeControl( {
 							onChange={ ( value ) =>
 								updateDimension( 'height', value )
 							}
+						/>
+						<ToggleControl
+							className="block-editor-image-size-control__proportions_toggle"
+							label={ __( 'Constrain Proportions' ) }
 						/>
 					</div>
 					<div className="block-editor-image-size-control__row">

--- a/packages/block-editor/src/components/image-size-control/style.scss
+++ b/packages/block-editor/src/components/image-size-control/style.scss
@@ -3,12 +3,11 @@
 
 	.block-editor-image-size-control__row {
 		display: flex;
-		flex-flow: row wrap;
 		justify-content: space-between;
+		align-items: center;
 
 		.block-editor-image-size-control__width,
 		.block-editor-image-size-control__height {
-			flex: 0 0 calc(50% - 5px);
 			margin-bottom: 0.5em;
 
 			// Fix the text and placeholder text being misaligned in Safari
@@ -26,8 +25,7 @@
 		}
 
 		.block-editor-image-size-control__proportions_toggle {
-			flex: 0 0 100%;
-			margin-bottom: 13px;
+			margin-top: 8px;
 		}
 	}
 }

--- a/packages/block-editor/src/components/image-size-control/style.scss
+++ b/packages/block-editor/src/components/image-size-control/style.scss
@@ -3,10 +3,12 @@
 
 	.block-editor-image-size-control__row {
 		display: flex;
+		flex-flow: row wrap;
 		justify-content: space-between;
 
 		.block-editor-image-size-control__width,
 		.block-editor-image-size-control__height {
+			flex: 0 0 calc(50% - 5px);
 			margin-bottom: 0.5em;
 
 			// Fix the text and placeholder text being misaligned in Safari
@@ -21,6 +23,11 @@
 
 		.block-editor-image-size-control__height {
 			margin-left: 5px;
+		}
+
+		.block-editor-image-size-control__proportions_toggle {
+			flex: 0 0 100%;
+			margin-bottom: 13px;
 		}
 	}
 }

--- a/packages/block-editor/src/components/image-size-control/style.scss
+++ b/packages/block-editor/src/components/image-size-control/style.scss
@@ -10,7 +10,7 @@
 		.block-editor-image-size-control__height {
 			margin-bottom: 0.5em;
 
-			// Fix the text and placeholder text being misaligned in Safari
+			// Fix the text and placeholder text being misaligned in Safari.
 			input {
 				line-height: 1.25;
 			}
@@ -24,6 +24,7 @@
 			margin-left: 5px;
 		}
 
+		// Vertical alignment help for lock button.
 		.block-editor-image-size-control__proportions_toggle {
 			margin-top: 8px;
 		}

--- a/packages/block-editor/src/components/image-size-control/test/utils.js
+++ b/packages/block-editor/src/components/image-size-control/test/utils.js
@@ -1,0 +1,22 @@
+/**
+ * Internal dependencies
+ */
+import { isPortrait, getImageRatio, getDimensionsByRatio } from '../utils';
+
+test( 'isPortrait should return a boolean based on image orientation.', () => {
+	expect( isPortrait( 1024, 768 ) ).toBeTruthy();
+	expect( isPortrait( 768, 1024 ) ).toBeFalsy();
+	expect( isPortrait( 500, 500 ) ).toBeFalsy();
+} );
+
+test( 'getImageRatio should return an aspect ratio based on the image orientation.', () => {
+	expect( getImageRatio( 1024, 768 ) ).toEqual( 1.333 );
+	expect( getImageRatio( 768, 1024 ) ).toEqual( 1.333 );
+	expect( getImageRatio( 500, 500 ) ).toEqual( 1 );
+} );
+
+test( 'getRatioByOrientation should return the respective height or width based on the saved value by ratio.', () => {
+	expect( getDimensionsByRatio( 1024, 0.75 ) ).toEqual( 768 );
+	expect( getDimensionsByRatio( 768, 0.75, false ) ).toEqual( 1024 );
+	expect( getDimensionsByRatio( 500, 1, false ) ).toEqual( 500 );
+} );

--- a/packages/block-editor/src/components/image-size-control/use-dimension-handler.js
+++ b/packages/block-editor/src/components/image-size-control/use-dimension-handler.js
@@ -23,7 +23,7 @@ export default function useDimensionHandler(
 	onChange,
 	lockAspectRatio = false
 ) {
-	// Define the image's aspect ratio.
+	// Define the image's aspect ratio by orientation.
 	const isVertical = defaultHeight > defaultWidth;
 	const ratio = isVertical
 		? defaultHeight / defaultWidth

--- a/packages/block-editor/src/components/image-size-control/use-dimension-handler.js
+++ b/packages/block-editor/src/components/image-size-control/use-dimension-handler.js
@@ -4,6 +4,11 @@
 import { useEffect, useState } from '@wordpress/element';
 
 /**
+ * Internal dependencies
+ */
+import { getImageRatio, getDimensionsByRatio, isPortrait } from './utils';
+
+/**
  * Hook to return dimensions of an element.
  *
  * @param {number}   customHeight    new height.
@@ -24,10 +29,8 @@ export default function useDimensionHandler(
 	lockAspectRatio = false
 ) {
 	// Define the image's aspect ratio by orientation.
-	const isVertical = defaultHeight > defaultWidth;
-	const ratio = isVertical
-		? defaultHeight / defaultWidth
-		: defaultWidth / defaultHeight;
+	const ratio = getImageRatio( defaultHeight, defaultWidth );
+	const isVertical = isPortrait( defaultHeight, defaultWidth );
 
 	const [ currentWidth, setCurrentWidth ] = useState(
 		customWidth ?? defaultWidth ?? ''
@@ -66,16 +69,6 @@ export default function useDimensionHandler(
 	}, [ customWidth, customHeight ] );
 
 	/**
-	 * Get ratio dimension based on image orientation.
-	 *
-	 * @param {number}  value    new height or width value.
-	 * @param {boolean} vertical whether or not the image aspect is vertical.
-	 * @return {number} multiplied or divided value by ratio.
-	 */
-	const getRatioByOrientation = ( value, vertical = true ) =>
-		Math.round( vertical ? value * ratio : value / ratio );
-
-	/**
 	 * Update single value dimension on change.
 	 * If lockAspectRatio is true, set height and width simultaneously.
 	 *
@@ -89,11 +82,11 @@ export default function useDimensionHandler(
 			const lockedHeight =
 				dimension === 'height'
 					? value
-					: getRatioByOrientation( value, isVertical );
+					: getDimensionsByRatio( value, ratio, isVertical );
 			const lockedWidth =
 				dimension === 'width'
 					? value
-					: getRatioByOrientation( value, ! isVertical );
+					: getDimensionsByRatio( value, ratio, ! isVertical );
 			updateDimensions( lockedHeight, lockedWidth );
 		} else if ( dimension === 'width' ) {
 			setCurrentWidth( value );
@@ -106,7 +99,7 @@ export default function useDimensionHandler(
 	};
 
 	/**
-	 * Update the height and width simultanously on change.
+	 * Update the height and width simultaneously on change.
 	 *
 	 * @param {number} nextHeight next height.
 	 * @param {number} nextWidth  next width.

--- a/packages/block-editor/src/components/image-size-control/use-dimension-handler.js
+++ b/packages/block-editor/src/components/image-size-control/use-dimension-handler.js
@@ -65,8 +65,15 @@ export default function useDimensionHandler(
 		}
 	}, [ customWidth, customHeight ] );
 
-	const getValueTest = ( value, multiply = true ) =>
-		multiply ? value * ratio : value / ratio;
+	/**
+	 * Get ratio dimension based on image orientation.
+	 *
+	 * @param {number}  value    new height or width value.
+	 * @param {boolean} vertical whether or not the image aspect is vertical.
+	 * @return {number} multiplied or divided value by ratio.
+	 */
+	const getRatioByOrientation = ( value, vertical = true ) =>
+		vertical ? value * ratio : value / ratio;
 
 	/**
 	 * Update single value dimension on change.
@@ -78,16 +85,16 @@ export default function useDimensionHandler(
 	 */
 	const updateDimension = ( dimension, value, lock = false ) => {
 		// If we're supporting aspect ratio locking, update the height and width simultaneously.
-		if ( lockAspectRatio || lock ) {
-			const nextHeight =
+		if ( ( lockAspectRatio || lock ) && value ) {
+			const lockedHeight =
 				dimension === 'height'
 					? value
-					: getValueTest( value, isVertical );
-			const nextWidth =
+					: getRatioByOrientation( value, isVertical );
+			const lockedWidth =
 				dimension === 'width'
 					? value
-					: getValueTest( value, ! isVertical );
-			updateDimensions( nextHeight, nextWidth );
+					: getRatioByOrientation( value, ! isVertical );
+			updateDimensions( lockedHeight, lockedWidth );
 		} else if ( dimension === 'width' ) {
 			setCurrentWidth( value );
 		} else if ( dimension === 'height' ) {
@@ -98,6 +105,12 @@ export default function useDimensionHandler(
 		} );
 	};
 
+	/**
+	 * Update the height and width simultanously on change.
+	 *
+	 * @param {number} nextHeight next height.
+	 * @param {number} nextWidth  next width.
+	 */
 	const updateDimensions = ( nextHeight, nextWidth ) => {
 		setCurrentHeight( nextHeight ?? defaultHeight );
 		setCurrentWidth( nextWidth ?? defaultWidth );

--- a/packages/block-editor/src/components/image-size-control/use-dimension-handler.js
+++ b/packages/block-editor/src/components/image-size-control/use-dimension-handler.js
@@ -73,7 +73,7 @@ export default function useDimensionHandler(
 	 * @return {number} multiplied or divided value by ratio.
 	 */
 	const getRatioByOrientation = ( value, vertical = true ) =>
-		vertical ? value * ratio : value / ratio;
+		Math.round( vertical ? value * ratio : value / ratio );
 
 	/**
 	 * Update single value dimension on change.

--- a/packages/block-editor/src/components/image-size-control/utils.js
+++ b/packages/block-editor/src/components/image-size-control/utils.js
@@ -1,0 +1,34 @@
+/**
+ * Determine if an image is portrait by height/width.
+ *
+ * @param {number} height image height.
+ * @param {number} width  image width.
+ * @return {boolean} is portrait image.
+ */
+export const isPortrait = ( height, width ) => height > width;
+
+/**
+ * Determine the image aspect ratio based on orientation.
+ *
+ * @param {number} height image height.
+ * @param {number} width  image width.
+ * @return {number} image aspect ratio as decimal.
+ */
+export const getImageRatio = ( height, width ) =>
+	Number(
+		( isPortrait( height, width )
+			? height / width
+			: width / height
+		).toFixed( 3 )
+	);
+
+/**
+ * Get calculated height or respective width dimension based on image orientation.
+ *
+ * @param {number}  value    new height or width value.
+ * @param {number}  ratio    ratio of the height.
+ * @param {boolean} vertical whether or not the image aspect is vertical.
+ * @return {number} multiplied or divided value by ratio.
+ */
+export const getDimensionsByRatio = ( value, ratio, vertical = true ) =>
+	Math.round( vertical ? value * ratio : value / ratio );


### PR DESCRIPTION
## What?
Adds a Toggle to optionally constrain the proportions of the ImageSizeControl feature, default false (mimics current WP behaviors).

## Why?
Closes: https://github.com/WordPress/gutenberg/issues/21918

The classic editor, when inserting images had the option of resizing in the media selector which retrained the image ratio by default (and was actually forced). Inserting an image and changing the aspect ratio (and not cropping the image) is bad practice, and while the Handles on the image retain the aspect ratio, there have been some reports of difficulty on mobile and is generally confusing to have different behaviors between the two interfaces.

This PR adds an image ratio lock and brings the two resize features in line with one another, though provides the ability to opt-out if necessary.

## How?
- Added a toggle lock icon that locks the proportions of the image when the image width or height are modified independently of one another.
- Defaults to true, opt-out behavior.

## Testing Instructions
1. Create a new post or page.
2. Add an image block from any source (upload, URL, media library, etc).
3. Confirm that the locking icon is present between the width and height icons (screenshots below).
4. Confirm that the locking icon is closed (lock) and the tooltip reads, "Unlock image proportions".
5. Modify the width or height in either direction and confirm that the other value is updated automatically and that the image proportions are retained.
6. Click the locking icon and confirm that the tooltip reads, "Lock image proportions".
7. Confirm that when unlocked the height and width of the images are set independently from one another.
8. Confirm that if the locking icon is clicked (to locked state) the respective height or width (the value note being edited last) is updated and the image aspect ratio is reset.
9. Confirm that the image size presets, reset, and handlebars on the image are functional as expected.
10. Confirm that the behavior is consistent for portrait, landscape, and square images.

## Screenshots or screencast
![CleanShot 2022-09-23 at 17 22 00](https://user-images.githubusercontent.com/5230729/192068773-a720f92b-2063-4864-8861-e962f3ef156c.png)

https://user-images.githubusercontent.com/5230729/192069892-a0cb4fcc-1258-43d8-a6c0-6d66c593e0ee.mp4

