### PR TITLE
Archive Block: remove unnecessary spaces from class attributes

### DIFF
--- a/packages/block-library/src/archives/index.php
+++ b/packages/block-library/src/archives/index.php
@@ -18,6 +18,8 @@ function render_block_core_archives( $attributes ) {
 	$show_post_count = ! empty( $attributes['showPostCounts'] );
 	$type            = isset( $attributes['type'] ) ? $attributes['type'] : 'monthly';
 
+	$class = 'wp-block-archives-list';
+
 	if ( ! empty( $attributes['displayAsDropdown'] ) ) {
 
 		$class = 'wp-block-archives-dropdown';
@@ -73,8 +75,6 @@ function render_block_core_archives( $attributes ) {
 			$block_content
 		);
 	}
-
-	$class = 'wp-block-archives-list';
 
 	/** This filter is documented in wp-includes/widgets/class-wp-widget-archives.php */
 	$archives_args = apply_filters(

--- a/packages/block-library/src/archives/index.php
+++ b/packages/block-library/src/archives/index.php
@@ -17,11 +17,10 @@
 function render_block_core_archives( $attributes ) {
 	$show_post_count = ! empty( $attributes['showPostCounts'] );
 	$type            = isset( $attributes['type'] ) ? $attributes['type'] : 'monthly';
-	$class           = '';
 
 	if ( ! empty( $attributes['displayAsDropdown'] ) ) {
 
-		$class .= ' wp-block-archives-dropdown';
+		$class = 'wp-block-archives-dropdown';
 
 		$dropdown_id = wp_unique_id( 'wp-block-archives-' );
 		$title       = __( 'Archives' );
@@ -75,7 +74,7 @@ function render_block_core_archives( $attributes ) {
 		);
 	}
 
-	$class .= ' wp-block-archives-list';
+	$class = 'wp-block-archives-list';
 
 	/** This filter is documented in wp-includes/widgets/class-wp-widget-archives.php */
 	$archives_args = apply_filters(


### PR DESCRIPTION
## What?
This PR removes unnecessary spaces from class attributes on the archive block.

## Why?
To improve code quality.

## How?
Just removed spaces.

## Testing Instructions
- Add two archive block.
- In one block, turn on "Show post counts".
- On the front end (or server-side rendered elements on the editor side), confirm that the space at the beginning of class attributes are removed.

## Screenshots or screencast

### Before

![before](https://user-images.githubusercontent.com/54422211/192128416-d424bbf2-b9b6-4f8d-9e2a-08e39fb44357.png)

### After

![after](https://user-images.githubusercontent.com/54422211/192128421-22b22d78-bab4-4da1-b90c-824a71a8bfdd.png)