### PR TITLE
Remove extraneous step to edit the theme color palette via Global Styles

### DIFF
--- a/packages/components/src/palette-edit/index.js
+++ b/packages/components/src/palette-edit/index.js
@@ -301,7 +301,7 @@ export default function PaletteEdit( {
 } ) {
 	const isGradient = !! gradients;
 	const elements = isGradient ? gradients : colors;
-	const [ isEditing, setIsEditing ] = useState( false );
+	const [ isEditing, setIsEditing ] = useState( true );
 	const [ editingElement, setEditingElement ] = useState( null );
 	const isAdding =
 		isEditing &&


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Remove extraneous step to edit the theme color palette via Global Styles

## Why?

Currently there's an extraneous step to edit the site color palette.

To get there you:

1. Open Global Styles
2. Click on "Colors"
3. Click on "Palette"
4. Click on the vertical ellipsis menu icon
5. Click "Edit colors"

The Palette view is what is currently redundant. You can't actually do anything other than edit colors (either the theme, default) or add new colors.

## How?
Changing the default state of `isEditing` to `true`

## Testing Instructions
1. Open Global Styles
2. Click on "Colors"
3. Click on "Palette"

## Screenshots or screencast <!-- if applicable -->
