### PR TITLE
Fix spacing property generation in flow layout type.

### DIFF
--- a/lib/block-supports/layout.php
+++ b/lib/block-supports/layout.php
@@ -47,6 +47,13 @@ function gutenberg_get_layout_style( $selector, $layout, $has_block_gap_support 
 				$gap_value = isset( $gap_value['top'] ) ? $gap_value['top'] : null;
 			}
 			if ( null !== $gap_value && ! $should_skip_gap_serialization ) {
+				// Get spacing CSS variable from preset value if provided.
+				if ( is_string( $gap_value ) && str_contains( $gap_value, 'var:preset|spacing|' ) ) {
+					$index_to_splice = strrpos( $gap_value, '|' ) + 1;
+					$slug            = _wp_to_kebab_case( substr( $gap_value, $index_to_splice ) );
+					$gap_value       = "var(--wp--preset--spacing--$slug)";
+				}
+
 				array_push(
 					$layout_styles,
 					array(


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

Fixes #44435.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

Adds logic to convert preset values into CSS custom properties to flow ('default') layout type.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->

1. Add a Columns block with one Column to a post.
2. Inside the Column, add 2 or more Paragraphs.
3. In the Column block sidebar, under "Dimensions", add the "Block spacing" controls from the options menu and change the block spacing to a non-default value.
4. Save the post and in the front end check that spacing styles render correctly.

## Screenshots or screencast <!-- if applicable -->

Before:

<img width="679" alt="Screen Shot 2022-09-26 at 12 37 13 pm" src="https://user-images.githubusercontent.com/8096000/192183019-db7c5061-13f6-42a8-bc46-7d892f3db5b7.png">


After:

<img width="677" alt="Screen Shot 2022-09-26 at 12 33 19 pm" src="https://user-images.githubusercontent.com/8096000/192182636-c93bd5b6-dda7-4cb5-98aa-1925837a1a71.png">
