### PR TITLE
Add a correct TS signature for useEntityRecords

### DIFF
--- a/packages/core-data/src/hooks/use-entity-records.ts
+++ b/packages/core-data/src/hooks/use-entity-records.ts
@@ -9,15 +9,26 @@ import deprecated from '@wordpress/deprecated';
  */
 import useQuerySelect from './use-query-select';
 import { store as coreStore } from '../';
-import type { Options, EntityRecordResolution } from './use-entity-record';
+import type { Options } from './use-entity-record';
+import type { Status } from './constants';
 
-type EntityRecordsResolution< RecordType > = Omit<
-	EntityRecordResolution< RecordType >,
-	'record'
-> & {
+interface EntityRecordsResolution< RecordType > {
 	/** The requested entity record */
 	records: RecordType[] | null;
-};
+
+	/**
+	 * Is the record still being resolved?
+	 */
+	isResolving: boolean;
+
+	/**
+	 * Is the record resolved by now?
+	 */
+	hasResolved: boolean;
+
+	/** Resolution status */
+	status: Status;
+}
 
 const EMPTY_ARRAY = [];
 


### PR DESCRIPTION
## What?
Fixes the TypeScript signature of `useEntityRecords` that got broken in https://github.com/WordPress/gutenberg/pull/39595.

`EntityRecordsResolution` reuses the `EntityRecordResolution` definition. However, the latter received a few new properties in https://github.com/WordPress/gutenberg/pull/39595 that just aren't returned by `useEntityRecords`. This Pull Requests rewrites the type signature explicitly to only include the properties that are actually returned.

## Testing Instructions
Manually review the diff and confirm the new type makes sense.

cc @gziolo @ockham @michalczaplinski 
