### PR TITLE
Blocks: Deprecate non-string descriptions

### DIFF
--- a/packages/blocks/CHANGELOG.md
+++ b/packages/blocks/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Deprecations
+
+-   Deprecate non-string descriptions ([#44455](https://github.com/WordPress/gutenberg/pull/44455)).
+
 ## 11.17.0 (2022-09-21)
 
 - The block attribute sources `children` and `node` have been deprecated. Please use the `html` source instead. See https://developer.wordpress.org/block-editor/how-to-guides/block-tutorial/introducing-attributes-and-editable-fields/ and the core blocks for examples.

--- a/packages/blocks/src/api/test/registration.js
+++ b/packages/blocks/src/api/test/registration.js
@@ -4,6 +4,7 @@
  * WordPress dependencies
  */
 import { addFilter, removeAllFilters, removeFilter } from '@wordpress/hooks';
+import { logged } from '@wordpress/deprecated';
 import { select } from '@wordpress/data';
 
 /**
@@ -61,6 +62,11 @@ describe( 'blocks', () => {
 		setUnregisteredTypeHandlerName( undefined );
 		setDefaultBlockName( undefined );
 		unstable__bootstrapServerSideBlockDefinitions( {} );
+
+		// Reset deprecation logging to ensure we properly track warnings.
+		for ( const key in logged ) {
+			delete logged[ key ];
+		}
 	} );
 
 	describe( 'registerBlockType()', () => {
@@ -831,6 +837,41 @@ describe( 'blocks', () => {
 				);
 				// Only attributes of block1 are supposed to be edited by the filter thus it must differ from block2.
 				expect( block1.attributes ).not.toEqual( block2.attributes );
+			} );
+
+			it( 'should allow non-string descriptions at registration but warn for undesired usage.', () => {
+				const newDescription = <p>foo bar</p>;
+
+				const block = registerBlockType( 'my-plugin/test-block-1', {
+					...defaultBlockSettings,
+					description: newDescription,
+				} );
+
+				expect( block.description ).toBe( newDescription );
+				expect( console ).toHaveWarnedWith(
+					'Declaring non-string block descriptions is deprecated since version 6.2.'
+				);
+			} );
+
+			it( 'should allow non-string descriptions through `blocks.registerBlockType` filter but warn for undesired usage.', () => {
+				const newDescription = <p>foo bar</p>;
+				addFilter(
+					'blocks.registerBlockType',
+					'core/blocks/non-string-description',
+					( settings ) => {
+						settings.description = newDescription;
+						return settings;
+					}
+				);
+				const block = registerBlockType(
+					'my-plugin/test-block-2',
+					defaultBlockSettings
+				);
+
+				expect( block.description ).toBe( newDescription );
+				expect( console ).toHaveWarnedWith(
+					'Declaring non-string block descriptions is deprecated since version 6.2.'
+				);
 			} );
 		} );
 

--- a/packages/blocks/src/store/actions.js
+++ b/packages/blocks/src/store/actions.js
@@ -7,6 +7,7 @@ import { castArray, pick, some } from 'lodash';
 /**
  * WordPress dependencies
  */
+import deprecated from '@wordpress/deprecated';
 import { applyFilters } from '@wordpress/hooks';
 
 /**
@@ -62,6 +63,12 @@ const processBlockType = ( blockType, { select } ) => {
 		name,
 		null
 	);
+
+	if ( settings.description && typeof settings.description !== 'string' ) {
+		deprecated( 'Declaring non-string block descriptions', {
+			since: '6.2',
+		} );
+	}
 
 	if ( settings.deprecated ) {
 		settings.deprecated = settings.deprecated.map( ( deprecation ) =>


### PR DESCRIPTION
## What?
This PR deprecates non-string descriptions for blocks.

## Why?
Non-strings (for example, React nodes) have been implicitly allowed forever. However, using non-strings for block description can cause subtle bugs, and it would be ideal if we explicitly deprecate it. We're still maintaining support for it, though, in order to avoid breaking anything that relies on that behavior.

See #44233 and discussion there for context.

## How?
We're simply adding a `deprecated()` for the case where a block is registered with, or later filtered to, a non-string description. We're also adding a few tests to cover this behavior, and ensure that we still support non-strings, but warn developers for undesired usage.

## Testing Instructions
* Smoke test the editor and ensure you don't see new errors or deprecation warnings.
* Verify all tests pass.
