### PR TITLE
[experiments] Add README.md and CHANGELOG.md

### DIFF
--- a/packages/experiments/CHANGELOG.md
+++ b/packages/experiments/CHANGELOG.md
@@ -1,0 +1,5 @@
+<!-- Learn how to maintain this file at https://github.com/WordPress/gutenberg/tree/HEAD/packages#maintaining-changelogs. -->
+
+## Unreleased
+
+– Package created.

--- a/packages/experiments/README.md
+++ b/packages/experiments/README.md
@@ -9,7 +9,7 @@ Each package needs to start by registering itself:
 ```js
 const { register } =
 	__dangerousOptInToUnstableAPIsOnlyForCoreModules(
-		'<CONSENT STRING>',  // See index.js
+		'<CONSENT STRING>',  // See index.js, this may change without notice.
 		'@wordpress/blocks'
 	);
 ```

--- a/packages/experiments/README.md
+++ b/packages/experiments/README.md
@@ -1,0 +1,49 @@
+# Experiments
+
+Private `__experimental` APIs that are not [exposed publicly plugin authors](https://make.wordpress.org/core/2022/08/10/proposal-stop-merging-experimental-apis-from-gutenberg-to-wordpress-core/#respond).
+
+This package acts as a "dealer" that only allows WordPress packages to use the experimental APIs.
+
+Each package needs to start by registering itself:
+
+```js
+const { register } =
+	__dangerousOptInToUnstableAPIsOnlyForCoreModules(
+		'I know using unstable features means my plugin or theme will inevitably break on the next WordPress release.',
+		'@wordpress/blocks'
+	);
+```
+
+The function name communicates that plugins are not supposed to use it. To make double and triple sure, the first argument must be that exact consent string, and the second argument must be a known `@wordpress` package that hasn't opted in yet – otherwise an error is thrown.
+
+Expose a new `__experimental` API as follows:
+
+```js
+export const __experiments = register( { __unstableGetInnerBlocksProps } )
+```
+
+Consume the registered `__experimental` APIs as follows:
+
+```js
+// In the @wordpress/block-editor package:
+import { __experiments as blocksExperiments } from '@wordpress/blocks';
+const { unlock } =
+	__dangerousOptInToUnstableAPIsOnlyForCoreModules(
+		'I know using unstable features means my plugin or theme will inevitably break on the next WordPress release.',
+		'@wordpress/block-editor'
+	);
+
+const { __unstableGetInnerBlocksProps } = unlock( blocksExperiments );
+```
+
+All new experimental APIs should be shipped as **private** using this method.
+
+The **public** experimental APIs that have already been shipped in a stable WordPress version should
+remain accessible via `window.wp`. Please do not create new ones.
+
+A determined developer who would want to use the private experimental APIs at all costs would have to:
+
+* Realize a private importing system exists
+* Read the code where the risks would be spelled out in capital letters
+* Explicitly type out he or she is aware of the consequences
+* Pretend to register a `@wordpress` package (and trigger an error as soon as the real package is loaded)

--- a/packages/experiments/README.md
+++ b/packages/experiments/README.md
@@ -9,7 +9,7 @@ Each package needs to start by registering itself:
 ```js
 const { register } =
 	__dangerousOptInToUnstableAPIsOnlyForCoreModules(
-		'I know using unstable features means my plugin or theme will inevitably break on the next WordPress release.',
+		'<CONSENT STRING>',  // See index.js
 		'@wordpress/blocks'
 	);
 ```
@@ -29,7 +29,7 @@ Consume the registered `__experimental` APIs as follows:
 import { __experiments as blocksExperiments } from '@wordpress/blocks';
 const { unlock } =
 	__dangerousOptInToUnstableAPIsOnlyForCoreModules(
-		'I know using unstable features means my plugin or theme will inevitably break on the next WordPress release.',
+		'<CONSENT STRING>',  // See index.js
 		'@wordpress/block-editor'
 	);
 

--- a/packages/experiments/README.md
+++ b/packages/experiments/README.md
@@ -38,8 +38,7 @@ const { __unstableGetInnerBlocksProps } = unlock( blocksExperiments );
 
 All new experimental APIs should be shipped as **private** using this method.
 
-The **public** experimental APIs that have already been shipped in a stable WordPress version should
-remain accessible via `window.wp`. Please do not create new ones.
+The **public** experimental APIs that have already been shipped in a stable WordPress version should remain accessible via `window.wp`. Please do not create new ones.
 
 A determined developer who would want to use the private experimental APIs at all costs would have to:
 

--- a/packages/experiments/README.md
+++ b/packages/experiments/README.md
@@ -47,6 +47,10 @@ A determined developer who would want to use the private experimental APIs at al
 * Explicitly type out he or she is aware of the consequences
 * Pretend to register a `@wordpress` package (and trigger an error as soon as the real package is loaded)
 
+Dangerously opting in to using these APIs by theme and plugin developers is not recommended. Furthermore, the WordPress Core philosophy to strive to maintain backward compatibility for third-party developers **does not apply** to experimental APIs registered via this package.
+
+The consent string for opting in to these APIs may change at any time and without notice. This change will break existing third-party code. Such a change may occur in either a major or minor release.
+
 ## Contributing to this package
 
 This is an individual package that's part of the Gutenberg project. The project is organized as a monorepo. It's made up of multiple self-contained software packages, each with a specific purpose. The packages in this monorepo are published to [npm](https://www.npmjs.com/) and used by [WordPress](https://make.wordpress.org/core/) as well as other software projects.

--- a/packages/experiments/README.md
+++ b/packages/experiments/README.md
@@ -46,3 +46,11 @@ A determined developer who would want to use the private experimental APIs at al
 * Read the code where the risks would be spelled out in capital letters
 * Explicitly type out he or she is aware of the consequences
 * Pretend to register a `@wordpress` package (and trigger an error as soon as the real package is loaded)
+
+## Contributing to this package
+
+This is an individual package that's part of the Gutenberg project. The project is organized as a monorepo. It's made up of multiple self-contained software packages, each with a specific purpose. The packages in this monorepo are published to [npm](https://www.npmjs.com/) and used by [WordPress](https://make.wordpress.org/core/) as well as other software projects.
+
+To find out more about contributing to this package or Gutenberg as a whole, please read the project's main [contributor guide](https://github.com/WordPress/gutenberg/tree/HEAD/CONTRIBUTING.md).
+
+<br /><br /><p align="center"><img src="https://s.w.org/style/images/codeispoetry.png?1" alt="Code is Poetry." /></p>

--- a/packages/experiments/package.json
+++ b/packages/experiments/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "@wordpress/experiments",
 	"version": "0.0.1",
-	"description": "Dependency Injection container for WordPress.",
+	"description": "Internal experimental APIs for WordPress core.",
 	"author": "The WordPress Contributors",
 	"license": "GPL-2.0-or-later",
 	"keywords": [

--- a/packages/experiments/package.json
+++ b/packages/experiments/package.json
@@ -10,11 +10,11 @@
 		"dom",
 		"utils"
 	],
-	"homepage": "https://github.com/WordPress/gutenberg/tree/HEAD/packages/dependency-injection/README.md",
+	"homepage": "https://github.com/WordPress/gutenberg/tree/HEAD/packages/experiments/README.md",
 	"repository": {
 		"type": "git",
 		"url": "https://github.com/WordPress/gutenberg.git",
-		"directory": "packages/injection"
+		"directory": "packages/experiments"
 	},
 	"bugs": {
 		"url": "https://github.com/WordPress/gutenberg/issues"

--- a/packages/experiments/package.json
+++ b/packages/experiments/package.json
@@ -1,5 +1,5 @@
 {
-	"name": "@wordpress/dependency-injection",
+	"name": "@wordpress/experiments",
 	"version": "0.0.1",
 	"description": "Dependency Injection container for WordPress.",
 	"author": "The WordPress Contributors",


### PR DESCRIPTION
## What?
Follow up to https://github.com/WordPress/gutenberg/pull/43386 that introduced a new `@wordpress` package called `experiments`.

As @gziolo mentioned:

> we need to add README.md and CHANGELOG.md files. We also should either rename the folder with the package to dependency-injection or update this name with experiments in package.json file.

This PR does just that. My one concern is that it explains an intentionally opaque system, even if most non-core developers are not aware of the README.md file. I removed the consent string from the README file to avoid producing code snippets that can be copied and pasted.

## Testing Instructions
Read the PR and confirm it looks good and makes sense.

CC @gziolo @jsnajdr @peterwilsoncc 
