### PR TITLE
Fix: Follow discussion settings in the comments block edit

### DIFF
--- a/packages/block-library/src/comment-template/edit.js
+++ b/packages/block-library/src/comment-template/edit.js
@@ -129,7 +129,6 @@ function CommentTemplateInnerBlocks( {
 			 is ALWAYS rendered and the preview for the active block is hidden.
 			 This ensures that when switching the active block, the component is not
 			 mounted again but rather it only toggles the `isHidden` prop.
- 
 			 The same strategy is used for preventing the flicker in the Post Template
 			 block. */ }
 			<MemoizedCommentTemplatePreview

--- a/packages/block-library/src/comment-template/edit.js
+++ b/packages/block-library/src/comment-template/edit.js
@@ -37,7 +37,7 @@ const TEMPLATE = [
  *
  * @param {Object}  settings                       Discussion Settings.
  * @param {number}  [settings.perPage]             - Comments per page setting or block attribute.
- * @param {boolean}  [settings.pageComments]       - Enable break comments into pages setting.
+ * @param {boolean} [settings.pageComments]        - Enable break comments into pages setting.
  * @param {boolean} [settings.threadComments]      - Enable threaded (nested) comments setting.
  * @param {number}  [settings.threadCommentsDepth] - Level deep of threaded comments.
  *

--- a/packages/block-library/src/comment-template/edit.js
+++ b/packages/block-library/src/comment-template/edit.js
@@ -50,7 +50,9 @@ const getCommentsPlaceholder = ( {
 	threadComments,
 	threadCommentsDepth,
 } ) => {
-	const commentsDepth = ! threadComments ? 1 : threadCommentsDepth;
+	const commentsDepth = ! threadComments
+		? 1
+		: Math.min( threadCommentsDepth, 3 );
 
 	const buildChildrenComment = ( commentsLevel ) => {
 		// Render children comments until commentsDepth is reached

--- a/packages/block-library/src/comment-template/edit.js
+++ b/packages/block-library/src/comment-template/edit.js
@@ -37,6 +37,7 @@ const TEMPLATE = [
  *
  * @param {Object}  settings                       Discussion Settings.
  * @param {number}  [settings.perPage]             - Comments per page setting or block attribute.
+ * @param {boolean}  [settings.pageComments]       - Enable break comments into pages setting.
  * @param {boolean} [settings.threadComments]      - Enable threaded (nested) comments setting.
  * @param {number}  [settings.threadCommentsDepth] - Level deep of threaded comments.
  *
@@ -45,42 +46,50 @@ const TEMPLATE = [
  */
 const getCommentsPlaceholder = ( {
 	perPage,
+	pageComments,
 	threadComments,
 	threadCommentsDepth,
 } ) => {
-	// In case that `threadCommentsDepth` is falsy, we default to a somewhat
-	// arbitrary value of 3.
-	// In case that the value is set but larger than 3 we truncate it to 3.
-	const commentsDepth = Math.min( threadCommentsDepth || 3, 3 );
+	const commentsDepth = ! threadComments ? 1 : threadCommentsDepth;
 
-	// We set a limit in order not to overload the editor of empty comments.
-	const defaultCommentsToShow =
-		perPage <= commentsDepth ? perPage : commentsDepth;
-	if ( ! threadComments || defaultCommentsToShow === 1 ) {
-		// If displaying threaded comments is disabled, we only show one comment
-		// A commentId is negative in order to avoid conflicts with the actual comments.
-		return [ { commentId: -1, children: [] } ];
-	} else if ( defaultCommentsToShow === 2 ) {
-		return [
-			{
-				commentId: -1,
-				children: [ { commentId: -2, children: [] } ],
-			},
-		];
+	const buildChildrenComment = ( commentsLevel ) => {
+		// Render children comments until commentsDepth is reached
+		if ( commentsLevel < commentsDepth ) {
+			const nextLevel = commentsLevel + 1;
+
+			return [
+				{
+					commentId: -( commentsLevel + 3 ),
+					children: buildChildrenComment( nextLevel ),
+				},
+			];
+		}
+		return [];
+	};
+
+	// Add the first comment and its children
+	const placeholderComments = [
+		{ commentId: -1, children: buildChildrenComment( 1 ) },
+	];
+
+	// Add a second comment unless the break comments setting is active and set to less than 2
+	if ( ! pageComments || perPage >= 2 ) {
+		placeholderComments.push( {
+			commentId: -2,
+			children: [],
+		} );
+	}
+
+	// Add a third comment unless the break comments setting is active and set to less than 3
+	if ( ! pageComments || perPage >= 3 ) {
+		placeholderComments.push( {
+			commentId: -3,
+			children: [],
+		} );
 	}
 
 	// In case that the value is set but larger than 3 we truncate it to 3.
-	return [
-		{
-			commentId: -1,
-			children: [
-				{
-					commentId: -2,
-					children: [ { commentId: -3, children: [] } ],
-				},
-			],
-		},
-	];
+	return placeholderComments;
 };
 
 /**
@@ -114,12 +123,12 @@ function CommentTemplateInnerBlocks( {
 				: null }
 
 			{ /* To avoid flicker when switching active block contexts, a preview
-			is ALWAYS rendered and the preview for the active block is hidden.
-			This ensures that when switching the active block, the component is not
-			mounted again but rather it only toggles the `isHidden` prop.
-
-			The same strategy is used for preventing the flicker in the Post Template
-			block. */ }
+			 is ALWAYS rendered and the preview for the active block is hidden.
+			 This ensures that when switching the active block, the component is not
+			 mounted again but rather it only toggles the `isHidden` prop.
+ 
+			 The same strategy is used for preventing the flicker in the Post Template
+			 block. */ }
 			<MemoizedCommentTemplatePreview
 				blocks={ blocks }
 				commentId={ comment.commentId }
@@ -239,6 +248,7 @@ export default function CommentTemplateEdit( {
 		threadCommentsDepth,
 		threadComments,
 		commentsPerPage,
+		pageComments,
 	} = useSelect( ( select ) => {
 		const { getSettings } = select( blockEditorStore );
 		return getSettings().__experimentalDiscussionSettings;
@@ -282,6 +292,7 @@ export default function CommentTemplateEdit( {
 	if ( ! postId ) {
 		commentTree = getCommentsPlaceholder( {
 			perPage: commentsPerPage,
+			pageComments,
 			threadComments,
 			threadCommentsDepth,
 		} );

--- a/packages/block-library/src/comment-template/edit.js
+++ b/packages/block-library/src/comment-template/edit.js
@@ -50,6 +50,7 @@ const getCommentsPlaceholder = ( {
 	threadComments,
 	threadCommentsDepth,
 } ) => {
+	// Limit commentsDepth to 3
 	const commentsDepth = ! threadComments
 		? 1
 		: Math.min( threadCommentsDepth, 3 );
@@ -74,16 +75,16 @@ const getCommentsPlaceholder = ( {
 		{ commentId: -1, children: buildChildrenComment( 1 ) },
 	];
 
-	// Add a second comment unless the break comments setting is active and set to less than 2
-	if ( ! pageComments || perPage >= 2 ) {
+	// Add a second comment unless the break comments setting is active and set to less than 2, and there is one nested comment max
+	if ( ( ! pageComments || perPage >= 2 ) && commentsDepth < 3 ) {
 		placeholderComments.push( {
 			commentId: -2,
 			children: [],
 		} );
 	}
 
-	// Add a third comment unless the break comments setting is active and set to less than 3
-	if ( ! pageComments || perPage >= 3 ) {
+	// Add a third comment unless the break comments setting is active and set to less than 3, and there aren't nested comments
+	if ( ( ! pageComments || perPage >= 3 ) && commentsDepth < 2 ) {
 		placeholderComments.push( {
 			commentId: -3,
 			children: [],

--- a/packages/block-library/src/comments-title/edit.js
+++ b/packages/block-library/src/comments-title/edit.js
@@ -55,24 +55,16 @@ export default function Edit( {
 		if ( isSiteEditor ) {
 			// Match the number of comments that will be shown in the comment-template/edit.js placeholder
 
-			const commentsDepth = ! threadComments
-				? 1
-				: Math.min( threadCommentsDepth, 3 );
+			const nestedCommentsNumber = threadComments
+				? Math.min( threadCommentsDepth, 3 ) - 1
+				: 0;
+			const topLevelCommentsNumber = pageComments ? commentsPerPage : 3;
 
-			// Number of nested comments
-			let commentsNumber = commentsDepth;
+			const commentsNumber =
+				parseInt( nestedCommentsNumber ) +
+				parseInt( topLevelCommentsNumber );
 
-			// Sum one comment unless the break comments setting is active and set to less than 2
-			if ( ! pageComments || commentsPerPage >= 2 ) {
-				commentsNumber++;
-			}
-
-			// Sum one comment unless the break comments setting is active and set to less than 3
-			if ( ! pageComments || commentsPerPage >= 3 ) {
-				commentsNumber++;
-			}
-
-			setCommentsCount( commentsNumber );
+			setCommentsCount( Math.min( commentsNumber, 3 ) );
 			return;
 		}
 		const currentPostId = postId;


### PR DESCRIPTION
## What?
This Pull Request aims to respect all the discussion settings in the new Comments block while working in the Site Editor. We are loading some placeholders, and they should follow the discussion settings as much as possible. We decided to show 3 comments (to not overload it with too many comments), but in some cases it wasn't working properly. 

>Bear in mind that, while using the Comments block in the Post Editor, the use case is different. Inside the Site Editor we are using placeholders, but in the Post Editor it gets real data from the REST API, which is a bit trickier. Right now, we are only fetching the top-level comments (due to [this argument](https://github.com/WordPress/gutenberg/blob/trunk/packages/block-library/src/comment-template/hooks.js#L29)) and the _embedded children property only includes the next-level children. So we aren’t fetching more than 2 levels at this moment. If we remove the parent: 0  argument, we would get all the comments on the post, but it gets tricky as well. We would have to add some logic to nest the comments and there could be a case where the children are fetched and not the parent, which could cause weird UX issues. Imagine a case where the per_page is set to 10 and we have a parent comment with 15 replies. Only the latest 10 replies would be fetched and the parent would be excluded.
>
> This part is not covered in this Pull Request anyway. 

## Why?
Depending on the discussion settings, the UX right now is a bit weird, so I suggest a new way of handling it to prevent this. For example, at this moment, if the _"Enable threaded (nested) comments X levels deep"_ setting is disabled, just one comment is shown ([this code](https://github.com/WordPress/gutenberg/blob/trunk/packages/block-library/src/comment-template/edit.js#L59-L63)).

<img width="385" alt="Screenshot 2022-09-26 at 12 58 40" src="https://user-images.githubusercontent.com/34552881/192273899-e1352c14-1d9c-4e53-9aeb-fe6fcc24d673.png">


## How?
I refactored the code a bit and changed slightly the UX. With this I aimed to provide the following workflows:
1. Don't show only two comments if the break comments into pages is disabled (even if it is set to 2):
<img width="801" alt="Screenshot 2022-09-26 at 14 18 06" src="https://user-images.githubusercontent.com/34552881/192274292-9db10eff-3352-44bb-b35e-6317a88f1d37.png">

For this, we have to read the `pageComments` setting.

2. Show at least three top-level comments unless `per_page` is less than three and it is enabled.
<img width="818" alt="Screenshot 2022-09-26 at 14 19 52" src="https://user-images.githubusercontent.com/34552881/192274476-82998c59-a34b-4851-ae8e-02dbe1d94e41.png">

3. Show all the nested levels in the first comment if the setting is enabled.
<img width="418" alt="Screenshot 2022-09-26 at 14 20 48" src="https://user-images.githubusercontent.com/34552881/192274660-b84a6c88-2d1c-4a0b-940f-2e4f09b681af.png">

In this case, I wasn't sure if we should limit it to three levels. The max for this option is 10, and I thought it could make sense to show the user how it would look like if the levels is too high.

## Testing Instructions

1. Open the Site Editor with a block-based theme using the new Comments block (the Twenty Twenty-Three theme for example).
2. Navigate to the Single template, where the Comments should be placed.
3. Check the placeholders with the different Discussion Settings.