### PR TITLE
Archive: No need to escape class variable

### DIFF
--- a/packages/block-library/src/archives/index.php
+++ b/packages/block-library/src/archives/index.php
@@ -41,9 +41,7 @@ function render_block_core_archives( $attributes ) {
 
 		$archives = wp_get_archives( $dropdown_args );
 
-		$classnames = esc_attr( $class );
-
-		$wrapper_attributes = get_block_wrapper_attributes( array( 'class' => $classnames ) );
+		$wrapper_attributes = get_block_wrapper_attributes( array( 'class' => $class ) );
 
 		switch ( $dropdown_args['type'] ) {
 			case 'yearly':


### PR DESCRIPTION
## What?
PR removes unnecessary attribute escape from the Archive block.

## Why?
The variable is basically an enum - `wp-block-archives-(list|dropdown)`. It doesn't directly depend on user input, and there's no need to escape it.

## Testing Instructions
The archive block should work as before.
