### PR TITLE
Cherry-pick: Making sure to kebab case CSS variables generated from presets

### DIFF
--- a/packages/style-engine/phpunit/style-engine-test.php
+++ b/packages/style-engine/phpunit/style-engine-test.php
@@ -363,13 +363,13 @@ class WP_Style_Engine_Test extends WP_UnitTestCase {
 					'spacing' => array(
 						'margin'  => array(
 							'left'   => 'var:preset|spacing|10',
-							'right'  => 'var:preset|spacing|20',
+							'right'  => 'var:preset|spacing|3XL',
 							'top'    => '1rem',
 							'bottom' => '1rem',
 						),
 						'padding' => array(
 							'left'   => 'var:preset|spacing|30',
-							'right'  => 'var:preset|spacing|40',
+							'right'  => 'var:preset|spacing|3XL',
 							'top'    => '14px',
 							'bottom' => '14px',
 						),
@@ -377,14 +377,14 @@ class WP_Style_Engine_Test extends WP_UnitTestCase {
 				),
 				'options'         => array(),
 				'expected_output' => array(
-					'css'          => 'padding-left:var(--wp--preset--spacing--30);padding-right:var(--wp--preset--spacing--40);padding-top:14px;padding-bottom:14px;margin-left:var(--wp--preset--spacing--10);margin-right:var(--wp--preset--spacing--20);margin-top:1rem;margin-bottom:1rem;',
+					'css'          => 'padding-left:var(--wp--preset--spacing--30);padding-right:var(--wp--preset--spacing--3-xl);padding-top:14px;padding-bottom:14px;margin-left:var(--wp--preset--spacing--10);margin-right:var(--wp--preset--spacing--3-xl);margin-top:1rem;margin-bottom:1rem;',
 					'declarations' => array(
 						'padding-left'   => 'var(--wp--preset--spacing--30)',
-						'padding-right'  => 'var(--wp--preset--spacing--40)',
+						'padding-right'  => 'var(--wp--preset--spacing--3-xl)',
 						'padding-top'    => '14px',
 						'padding-bottom' => '14px',
 						'margin-left'    => 'var(--wp--preset--spacing--10)',
-						'margin-right'   => 'var(--wp--preset--spacing--20)',
+						'margin-right'   => 'var(--wp--preset--spacing--3-xl)',
 						'margin-top'     => '1rem',
 						'margin-bottom'  => '1rem',
 					),

--- a/packages/style-engine/src/styles/utils.ts
+++ b/packages/style-engine/src/styles/utils.ts
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { get } from 'lodash';
+import { get, kebabCase } from 'lodash';
 
 /**
  * Internal dependencies
@@ -119,6 +119,7 @@ export function getCSSVarFromStyleValue( styleValue: string ): string {
 		const variable = styleValue
 			.slice( VARIABLE_REFERENCE_PREFIX.length )
 			.split( VARIABLE_PATH_SEPARATOR_TOKEN_ATTRIBUTE )
+			.map( ( presetVariable ) => kebabCase( presetVariable ) )
 			.join( VARIABLE_PATH_SEPARATOR_TOKEN_STYLE );
 		return `var(--wp--${ variable })`;
 	}

--- a/packages/style-engine/src/test/index.js
+++ b/packages/style-engine/src/test/index.js
@@ -96,6 +96,19 @@ describe( 'generate', () => {
 		);
 	} );
 
+	it( 'should parse preset values and kebab-case the slug', () => {
+		expect(
+			compileCSS( {
+				color: {
+					text: 'var:preset|font-size|h1',
+				},
+				spacing: { margin: { top: 'var:preset|spacing|3XL' } },
+			} )
+		).toEqual(
+			'color: var(--wp--preset--font-size--h-1); margin-top: var(--wp--preset--spacing--3-xl);'
+		);
+	} );
+
 	it( 'should parse border rules', () => {
 		expect(
 			compileCSS( {

--- a/packages/style-engine/src/test/utils.js
+++ b/packages/style-engine/src/test/utils.js
@@ -1,12 +1,42 @@
 /**
  * Internal dependencies
  */
-import { upperFirst } from '../styles/utils';
+import {
+	camelCaseJoin,
+	getCSSVarFromStyleValue,
+	upperFirst,
+} from '../styles/utils';
 
 describe( 'utils', () => {
 	describe( 'upperFirst()', () => {
 		it( 'should return an string with a capitalized first letter', () => {
 			expect( upperFirst( 'toontown' ) ).toEqual( 'Toontown' );
+		} );
+	} );
+
+	describe( 'camelCaseJoin()', () => {
+		it( 'should return a camelCase string', () => {
+			expect( camelCaseJoin( [ 'toon', 'town' ] ) ).toEqual( 'toonTown' );
+		} );
+	} );
+
+	describe( 'getCSSVarFromStyleValue()', () => {
+		it( 'should return a compiled CSS var', () => {
+			expect(
+				getCSSVarFromStyleValue( 'var:preset|color|yellow-bun' )
+			).toEqual( 'var(--wp--preset--color--yellow-bun)' );
+		} );
+
+		it( 'should kebab case numbers', () => {
+			expect(
+				getCSSVarFromStyleValue( 'var:preset|font-size|h1' )
+			).toEqual( 'var(--wp--preset--font-size--h-1)' );
+		} );
+
+		it( 'should kebab case camel case', () => {
+			expect(
+				getCSSVarFromStyleValue( 'var:preset|color|heavenlyBlue' )
+			).toEqual( 'var(--wp--preset--color--heavenly-blue)' );
 		} );
 	} );
 } );


### PR DESCRIPTION
Cherry picking [Style engine: kebab case preset slugs in the editor](https://github.com/WordPress/gutenberg/pull/44406#top) into `wp/6.1` (note the PR base).

This is necessary as the original PR is slated for being backported into the 6.1 Beta 2 release. Normally, this is nowadays done automatically through a [cherry-pick script](https://developer.wordpress.org/block-editor/contributors/code/release/auto-cherry-picking/) but the #44406 PR had some merge conflicts so had to be cherry-picked manually.