### PR TITLE
Use `get_queried_object_id` when setting `current-menu-item` classes

### DIFF
--- a/packages/block-library/src/navigation-submenu/index.php
+++ b/packages/block-library/src/navigation-submenu/index.php
@@ -148,7 +148,7 @@ function render_block_core_navigation_submenu( $attributes, $content, $block ) {
 
 	$css_classes = trim( implode( ' ', $classes ) );
 	$has_submenu = count( $block->inner_blocks ) > 0;
-	$is_active   = ! empty( $attributes['id'] ) && ( get_the_ID() === (int) $attributes['id'] );
+	$is_active   = ! empty( $attributes['id'] ) && ( get_queried_object_id() === (int) $attributes['id'] );
 
 	$show_submenu_indicators = isset( $block->context['showSubmenuIcon'] ) && $block->context['showSubmenuIcon'];
 	$open_on_click           = isset( $block->context['openSubmenusOnClick'] ) && $block->context['openSubmenusOnClick'];

--- a/packages/block-library/src/page-list/index.php
+++ b/packages/block-library/src/page-list/index.php
@@ -264,7 +264,7 @@ function render_block_core_page_list( $attributes, $content, $block ) {
 	$active_page_ancestor_ids = array();
 
 	foreach ( (array) $all_pages as $page ) {
-		$is_active = ! empty( $page->ID ) && ( get_the_ID() === $page->ID );
+		$is_active = ! empty( $page->ID ) && ( get_queried_object_id() === $page->ID );
 
 		if ( $is_active ) {
 			$active_page_ancestor_ids = get_post_ancestors( $page->ID );


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?

Use `get_queried_object_id` when setting `current-menu-item` classes. Same as https://github.com/WordPress/gutenberg/pull/43800 but for other blocks.


## Why?

Beside navigation-links blocks, page-list and navigation submenu have also `current-menu-item` classes and should share the same logic around it. With the current implementation, navigation submenus linking to pages or post categories have the wrong `current-menu-item` class applied: sometimes it is applied even if the current page is another one, and sometimes it's not applied even if the page is rendered.

## How?

This commit applies the same fix as https://github.com/WordPress/gutenberg/pull/43800 but at other places where we are adding the current-menu-item class.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->

* Use a "Navigation" block with two main entries (ex: the main page and a post category) and make them both submenus.
* When navigating to both pages, the expected entry should have the `current-menu-item` class.

## Screenshots or screencast <!-- if applicable -->
