### PR TITLE
Template part: prevent adding block in post editor or inside post template or content blocks

### DIFF
--- a/packages/block-library/src/template-part/index.js
+++ b/packages/block-library/src/template-part/index.js
@@ -62,13 +62,13 @@ export const init = () => {
 		'blockEditor.__unstableCanInsertBlockType',
 		'removeTemplatePartsFromPostTemplates',
 		(
-			can,
+			canInsert,
 			blockType,
 			rootClientId,
 			{ getBlock, getBlockParentsByBlockName }
 		) => {
 			if ( blockType.name !== 'core/template-part' ) {
-				return can;
+				return canInsert;
 			}
 
 			for ( const disallowedParentType of DISALLOWED_PARENTS ) {

--- a/packages/edit-post/src/index.js
+++ b/packages/edit-post/src/index.js
@@ -121,8 +121,12 @@ export function initializeEditor(
 		} );
 	}
 
-	// Prevent adding template part in the post editor.
-	// Only add the filter when the post editor is initialized, not imported.
+	/*
+		Prevent adding template part in the post editor.
+		Only add the filter when the post editor is initialized, not imported.
+		Also only add the filter(s) after registerCoreBlocks()
+		so that common filters in the block library are not overwritten.
+	 */
 	addFilter(
 		'blockEditor.__unstableCanInsertBlockType',
 		'removeTemplatePartsFromInserter',

--- a/packages/edit-post/src/index.js
+++ b/packages/edit-post/src/index.js
@@ -80,22 +80,6 @@ export function initializeEditor(
 	settings,
 	initialEdits
 ) {
-	// Prevent adding template part in the post editor.
-	// Only add the filter when the post editor is initialized, not imported.
-	addFilter(
-		'blockEditor.__unstableCanInsertBlockType',
-		'removeTemplatePartsFromInserter',
-		( can, blockType ) => {
-			if (
-				! select( editPostStore ).isEditingTemplate() &&
-				blockType.name === 'core/template-part'
-			) {
-				return false;
-			}
-			return can;
-		}
-	);
-
 	const target = document.getElementById( id );
 	const reboot = reinitializeEditor.bind(
 		null,
@@ -136,6 +120,22 @@ export function initializeEditor(
 			enableFSEBlocks: settings.__unstableEnableFullSiteEditingBlocks,
 		} );
 	}
+
+	// Prevent adding template part in the post editor.
+	// Only add the filter when the post editor is initialized, not imported.
+	addFilter(
+		'blockEditor.__unstableCanInsertBlockType',
+		'removeTemplatePartsFromInserter',
+		( canInsert, blockType ) => {
+			if (
+				! select( editPostStore ).isEditingTemplate() &&
+				blockType.name === 'core/template-part'
+			) {
+				return false;
+			}
+			return canInsert;
+		}
+	);
 
 	// Show a console log warning if the browser is not in Standards rendering mode.
 	const documentMode =

--- a/packages/edit-post/src/index.js
+++ b/packages/edit-post/src/index.js
@@ -122,10 +122,10 @@ export function initializeEditor(
 	}
 
 	/*
-		Prevent adding template part in the post editor.
-		Only add the filter when the post editor is initialized, not imported.
-		Also only add the filter(s) after registerCoreBlocks()
-		so that common filters in the block library are not overwritten.
+	 * Prevent adding template part in the post editor.
+	 * Only add the filter when the post editor is initialized, not imported.
+	 * Also only add the filter(s) after registerCoreBlocks()
+	 * so that common filters in the block library are not overwritten.
 	 */
 	addFilter(
 		'blockEditor.__unstableCanInsertBlockType',


### PR DESCRIPTION
Resolves https://github.com/WordPress/gutenberg/issues/44397

## What? Why?? How???
This PR reinstates the behaviour from original PR: https://github.com/WordPress/gutenberg/pull/37157

It reorders the addition of the `blockEditor.__unstableCanInsertBlockType` hook in `initializeEditor()` so that it appears after `registerCoreBlocks();`.

Why? So that any corresponding filters added in the block library get applied first, and, therefore, are not overridden by the filter in post editor initialization.

Oh yes, also renaming `can` to `canInsert` for clarity.

Props to @gziolo 

## Testing Instructions

1. In the site editor, confirm that you can add a template-part block **anywhere except** inside post-template or post-content blocks.
2. In the post editor, confirm you can't add a template-part block at all.
3. In the template editor, confirm you can add a template-part block **anywhere except** inside post-template or post-content blocks.