### PR TITLE
Template editor: fix crashes due to undefined vars

### DIFF
--- a/packages/block-editor/src/components/block-parent-selector/index.js
+++ b/packages/block-editor/src/components/block-parent-selector/index.js
@@ -83,10 +83,10 @@ export default function BlockParentSelector() {
 				label={ sprintf(
 					/* translators: %s: Name of the block's parent. */
 					__( 'Select %s' ),
-					blockInformation.title
+					blockInformation?.title
 				) }
 				showTooltip
-				icon={ <BlockIcon icon={ blockInformation.icon } /> }
+				icon={ <BlockIcon icon={ blockInformation?.icon } /> }
 			/>
 		</div>
 	);

--- a/packages/block-editor/src/components/block-popover/inbetween.js
+++ b/packages/block-editor/src/components/block-popover/inbetween.js
@@ -218,7 +218,7 @@ function BlockPopoverInbetween( {
 	}, [ nextElement ] );
 
 	useLayoutEffect( () => {
-		if ( ! previousElement?.ownerDocument?.defaultView ) {
+		if ( ! previousElement ) {
 			return;
 		}
 		previousElement.ownerDocument.defaultView.addEventListener(
@@ -226,7 +226,7 @@ function BlockPopoverInbetween( {
 			forcePopoverRecompute
 		);
 		return () => {
-			previousElement.ownerDocument.defaultView.removeEventListener(
+			previousElement.ownerDocument.defaultView?.removeEventListener(
 				'resize',
 				forcePopoverRecompute
 			);

--- a/packages/block-editor/src/components/block-popover/inbetween.js
+++ b/packages/block-editor/src/components/block-popover/inbetween.js
@@ -218,7 +218,7 @@ function BlockPopoverInbetween( {
 	}, [ nextElement ] );
 
 	useLayoutEffect( () => {
-		if ( ! previousElement ) {
+		if ( ! previousElement?.ownerDocument?.defaultView ) {
 			return;
 		}
 		previousElement.ownerDocument.defaultView.addEventListener(


### PR DESCRIPTION
## What?
Adds some guards to BlockParentSelector and Inbetween popover to prevent editor crashing if vars undefined

## Why?
Fixes: #44481

## How?
Add checks to make sure vars defined before trying to access them.

## Testing Instructions
 - In a post right settings panel chose the option to change the template
 - Then edit the assigned template and save it and return back to the post editor
 - Make sure the editor does not crash

## Screenshots or screencast 

After (Once I fixed it on this branch I couldn't replicate the issue again to do a before shot 🤔 ): 

https://user-images.githubusercontent.com/3629020/192430666-29a7e46b-d0b9-4b93-8989-969f197e588d.mp4


