### PR TITLE
Fix padding/margin visualizer placement

### DIFF
--- a/packages/block-editor/src/components/block-popover/index.js
+++ b/packages/block-editor/src/components/block-popover/index.js
@@ -148,6 +148,7 @@ function BlockPopover(
 			// Render in the old slot if needed for backward compatibility,
 			// otherwise render in place (not in the default popover slot).
 			__unstableSlotName={ __unstablePopoverSlot || null }
+			placement="top-start"
 			resize={ false }
 			flip={ false }
 			shift


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Fixes the issue noted here - https://github.com/WordPress/gutenberg/pull/44323#issuecomment-1258992914, and here - https://github.com/WordPress/gutenberg/issues/44335#issuecomment-1258979758

After a recent refactor of the `BlockPopover` component, the padding/marging visualizers were incorrectly positioned below the block.

## Why?
The `position`/`placement` prop for those components was accidentally removed.

## How?
Adds the `placement` prop to `BlockPopover` so that all components that render it default to a 'top-start' placement.

## Testing Instructions
1. Edit padding or margin on a block
2. The padding/margin visualizers should overlay the block

## Screenshots or screencast <!-- if applicable -->

### Before

![Screen Shot 2022-09-27 at 2 04 09 pm](https://user-images.githubusercontent.com/677833/192445669-44de57ef-87ef-4422-9f2b-6cfb56f6c911.png)


### After

![Screen Shot 2022-09-27 at 2 02 06 pm](https://user-images.githubusercontent.com/677833/192445689-37ee7e78-1197-4c87-b9b9-7cc3e015e52f.png)
