### PR TITLE
Persisted preferences: Fix context property of  user meta config

### DIFF
--- a/lib/compat/wordpress-6.1/persisted-preferences.php
+++ b/lib/compat/wordpress-6.1/persisted-preferences.php
@@ -21,11 +21,11 @@ function gutenberg_register_persisted_preferences_meta() {
 			'type'         => 'object',
 			'single'       => true,
 			'show_in_rest' => array(
-				'name'    => 'persisted_preferences',
-				'type'    => 'object',
-				'context' => array( 'edit' ),
-				'schema'  => array(
+				'name'   => 'persisted_preferences',
+				'type'   => 'object',
+				'schema' => array(
 					'type'                 => 'object',
+					'context'              => array( 'edit' ),
 					'properties'           => array(
 						'_modified' => array(
 							'description' => __( 'The date and time the preferences were updated.', 'default' ),


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
See https://core.trac.wordpress.org/ticket/56665.

Fixes the registration of persisted preferences user meta - The `context` property should be part of the `schema` array.