### PR TITLE
Editor: Refactor `AutosaveMonitor` tests to `@testing-library/react`

### DIFF
--- a/packages/editor/src/components/autosave-monitor/test/index.js
+++ b/packages/editor/src/components/autosave-monitor/test/index.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { shallow } from 'enzyme';
+import { render } from '@testing-library/react';
 
 /**
  * Internal dependencies
@@ -9,7 +9,6 @@ import { shallow } from 'enzyme';
 import { AutosaveMonitor } from '../';
 
 describe( 'AutosaveMonitor', () => {
-	let wrapper;
 	let setAutosaveTimerSpy;
 	beforeEach( () => {
 		jest.useFakeTimers( 'legacy' );
@@ -17,9 +16,6 @@ describe( 'AutosaveMonitor', () => {
 			AutosaveMonitor.prototype,
 			'setAutosaveTimer'
 		);
-		wrapper = shallow( <AutosaveMonitor isDirty />, {
-			lifecycleExperimental: true,
-		} );
 	} );
 
 	afterEach( () => {
@@ -29,128 +25,167 @@ describe( 'AutosaveMonitor', () => {
 		setAutosaveTimerSpy.mockClear();
 	} );
 
+	it( 'should render nothing', () => {
+		const { container } = render( <AutosaveMonitor isDirty /> );
+
+		expect( container ).toBeEmptyDOMElement();
+	} );
+
 	it( 'should start autosave timer after being mounted', () => {
+		render( <AutosaveMonitor isDirty /> );
+
 		expect( setAutosaveTimerSpy ).toHaveBeenCalled();
 	} );
 
 	it( 'should clear the autosave timer after being unmounted', () => {
-		wrapper.unmount();
+		const { rerender } = render( <AutosaveMonitor isDirty /> );
+
+		rerender( <div /> );
+
 		expect( clearTimeout ).toHaveBeenCalled();
 	} );
 
-	describe( '#componentDidUpdate()', () => {
-		it( 'should clear and restart autosave timer when the interval changes', () => {
-			wrapper.setProps( { interval: 999 } );
-			expect( clearTimeout ).toHaveBeenCalled();
-			expect( setAutosaveTimerSpy ).toHaveBeenCalledTimes( 2 );
-		} );
+	it( 'should clear and restart autosave timer when the interval changes', () => {
+		const { rerender } = render( <AutosaveMonitor isDirty /> );
 
-		it( 'should set needsAutosave=true when editReference changes', () => {
-			expect( wrapper.instance().needsAutosave ).toBe( false );
-			wrapper.setProps( {
-				editsReference: [],
-			} );
-			expect( wrapper.instance().needsAutosave ).toBe( true );
-		} );
+		rerender( <AutosaveMonitor isDirty interval={ 999 } /> );
 
-		it( 'should set needsAutosave=true when editReference changes and the post becomes dirty', () => {
-			expect( wrapper.instance().needsAutosave ).toBe( false );
-			wrapper.setProps( {
-				isDirty: true,
-				editsReference: [],
-			} );
-			expect( wrapper.instance().needsAutosave ).toBe( true );
-		} );
-
-		it( 'should not set needsAutosave=true when editReference changes and the post is not dirty anymore', () => {
-			expect( wrapper.instance().needsAutosave ).toBe( false );
-			wrapper.setProps( {
-				isDirty: true,
-				editsReference: [],
-			} );
-			wrapper.setProps( {
-				isDirty: false,
-				editsReference: [],
-			} );
-			expect( wrapper.instance().needsAutosave ).toBe( false );
-		} );
-
-		it( 'should set needsAutosave=true when editReference changes and the post is not autosaving', () => {
-			expect( wrapper.instance().needsAutosave ).toBe( false );
-			wrapper.setProps( {
-				isAutosaving: false,
-				editsReference: [],
-			} );
-			expect( wrapper.instance().needsAutosave ).toBe( true );
-		} );
-
-		it( 'should not set needsAutosave=true when editReference changes and the post started autosaving', () => {
-			expect( wrapper.instance().needsAutosave ).toBe( false );
-			wrapper.setProps( {
-				isAutosaving: false,
-				editsReference: [],
-			} );
-			wrapper.setProps( {
-				isAutosaving: true,
-				editsReference: [],
-			} );
-			expect( wrapper.instance().needsAutosave ).toBe( false );
-		} );
+		expect( clearTimeout ).toHaveBeenCalled();
+		expect( setAutosaveTimerSpy ).toHaveBeenCalledTimes( 2 );
 	} );
 
-	describe( '#autosaveTimerHandler()', () => {
-		it( 'should schedule itself in another {interval} ms', () => {
-			wrapper.setProps( {
-				isAutosaveable: true,
-				interval: 5,
-			} );
-			expect( setAutosaveTimerSpy ).toHaveBeenCalledTimes( 2 );
-			wrapper.instance().autosaveTimerHandler();
-			expect( setAutosaveTimerSpy ).toHaveBeenCalledTimes( 3 );
-			expect( setTimeout ).lastCalledWith( expect.any( Function ), 5000 );
-		} );
+	it( 'should autosave when `editReference` changes', () => {
+		const autosave = jest.fn();
+		const { rerender } = render(
+			<AutosaveMonitor isDirty isAutosaveable autosave={ autosave } />
+		);
 
-		it( 'should schedule itself in 1000 ms if the post is not autosaveable at a time', () => {
-			wrapper.setProps( {
-				isAutosaveable: false,
-				interval: 5,
-			} );
-			expect( setAutosaveTimerSpy ).toHaveBeenCalledTimes( 2 );
-			wrapper.instance().autosaveTimerHandler();
-			expect( setAutosaveTimerSpy ).toHaveBeenCalledTimes( 3 );
-			expect( setTimeout ).lastCalledWith( expect.any( Function ), 1000 );
-		} );
+		expect( autosave ).toHaveBeenCalledTimes( 0 );
 
-		it( 'should call autosave if needsAutosave=true', () => {
-			const autosave = jest.fn();
-			wrapper.setProps( {
-				isAutosaveable: true,
-				interval: 5,
-				autosave,
-			} );
-			wrapper.instance().needsAutosave = true;
-			expect( autosave ).toHaveBeenCalledTimes( 0 );
-			wrapper.instance().autosaveTimerHandler();
-			expect( autosave ).toHaveBeenCalledTimes( 1 );
-		} );
+		rerender(
+			<AutosaveMonitor
+				isDirty
+				isAutosaveable
+				autosave={ autosave }
+				editsReference={ [] }
+			/>
+		);
 
-		it( 'should not call autosave if needsAutosave is not true', () => {
-			const autosave = jest.fn();
-			wrapper.setProps( {
-				isAutosaveable: true,
-				interval: 5,
-				autosave,
-			} );
-			wrapper.instance().needsAutosave = false;
-			expect( autosave ).toHaveBeenCalledTimes( 0 );
-			wrapper.instance().autosaveTimerHandler();
-			expect( autosave ).toHaveBeenCalledTimes( 0 );
-		} );
+		jest.runOnlyPendingTimers();
+
+		expect( autosave ).toHaveBeenCalledTimes( 1 );
 	} );
 
-	describe( '#render()', () => {
-		it( 'should render nothing', () => {
-			expect( wrapper.type() ).toBe( null );
-		} );
+	it( 'should autosave when `editReference` changes and the post becomes dirty', () => {
+		const autosave = jest.fn();
+		const { rerender } = render(
+			<AutosaveMonitor isAutosaveable autosave={ autosave } />
+		);
+
+		expect( autosave ).toHaveBeenCalledTimes( 0 );
+
+		rerender(
+			<AutosaveMonitor
+				isDirty
+				isAutosaveable
+				autosave={ autosave }
+				editsReference={ [] }
+			/>
+		);
+
+		jest.runOnlyPendingTimers();
+
+		expect( autosave ).toHaveBeenCalledTimes( 1 );
+	} );
+
+	it( 'should not autosave when `editReference` changes and the post is not dirty anymore', () => {
+		const autosave = jest.fn();
+		const { rerender } = render(
+			<AutosaveMonitor isDirty isAutosaveable autosave={ autosave } />
+		);
+
+		expect( autosave ).toHaveBeenCalledTimes( 0 );
+
+		rerender(
+			<AutosaveMonitor
+				isAutosaveable
+				autosave={ autosave }
+				editsReference={ [] }
+			/>
+		);
+
+		jest.runOnlyPendingTimers();
+
+		expect( autosave ).toHaveBeenCalledTimes( 0 );
+	} );
+
+	it( 'should not autosave when `editReference` changes and the post is not autosaving', () => {
+		const autosave = jest.fn();
+		const { rerender } = render(
+			<AutosaveMonitor isAutosaveable autosave={ autosave } />
+		);
+
+		expect( autosave ).toHaveBeenCalledTimes( 0 );
+
+		rerender(
+			<AutosaveMonitor
+				isAutosaveable
+				autosave={ autosave }
+				isAutosaving={ false }
+				editsReference={ [] }
+			/>
+		);
+
+		jest.runOnlyPendingTimers();
+
+		expect( autosave ).toHaveBeenCalledTimes( 0 );
+	} );
+
+	it( 'should not autosave when `editReference` changes and the post started autosaving', () => {
+		const autosave = jest.fn();
+		const { rerender } = render(
+			<AutosaveMonitor
+				isAutosaveable
+				autosave={ autosave }
+				isAutosaving={ false }
+			/>
+		);
+
+		expect( autosave ).toHaveBeenCalledTimes( 0 );
+
+		rerender(
+			<AutosaveMonitor
+				isAutosaveable
+				autosave={ autosave }
+				isAutosaving
+				editsReference={ [] }
+			/>
+		);
+
+		jest.runOnlyPendingTimers();
+
+		expect( autosave ).toHaveBeenCalledTimes( 0 );
+	} );
+
+	it( 'should schedule itself in another {interval} ms', () => {
+		const { rerender } = render( <AutosaveMonitor isDirty /> );
+
+		rerender( <AutosaveMonitor isDirty isAutosaveable interval={ 5 } /> );
+
+		jest.runOnlyPendingTimers();
+
+		expect( setTimeout ).lastCalledWith( expect.any( Function ), 5000 );
+	} );
+
+	it( 'should schedule itself in 1000 ms if the post is not autosaveable at a time', () => {
+		const { rerender } = render( <AutosaveMonitor isDirty /> );
+
+		rerender(
+			<AutosaveMonitor isDirty isAutosaveable={ false } interval={ 5 } />
+		);
+
+		jest.runOnlyPendingTimers();
+
+		expect( setTimeout ).lastCalledWith( expect.any( Function ), 1000 );
 	} );
 } );

--- a/packages/editor/src/components/autosave-monitor/test/index.js
+++ b/packages/editor/src/components/autosave-monitor/test/index.js
@@ -60,7 +60,7 @@ describe( 'AutosaveMonitor', () => {
 			<AutosaveMonitor isDirty isAutosaveable autosave={ autosave } />
 		);
 
-		expect( autosave ).toHaveBeenCalledTimes( 0 );
+		expect( autosave ).not.toHaveBeenCalled();
 
 		rerender(
 			<AutosaveMonitor
@@ -82,7 +82,7 @@ describe( 'AutosaveMonitor', () => {
 			<AutosaveMonitor isAutosaveable autosave={ autosave } />
 		);
 
-		expect( autosave ).toHaveBeenCalledTimes( 0 );
+		expect( autosave ).not.toHaveBeenCalled();
 
 		rerender(
 			<AutosaveMonitor
@@ -104,7 +104,7 @@ describe( 'AutosaveMonitor', () => {
 			<AutosaveMonitor isDirty isAutosaveable autosave={ autosave } />
 		);
 
-		expect( autosave ).toHaveBeenCalledTimes( 0 );
+		expect( autosave ).not.toHaveBeenCalled();
 
 		rerender(
 			<AutosaveMonitor
@@ -116,7 +116,7 @@ describe( 'AutosaveMonitor', () => {
 
 		jest.runOnlyPendingTimers();
 
-		expect( autosave ).toHaveBeenCalledTimes( 0 );
+		expect( autosave ).not.toHaveBeenCalled();
 	} );
 
 	it( 'should not autosave when `editReference` changes and the post is not autosaving', () => {
@@ -125,7 +125,7 @@ describe( 'AutosaveMonitor', () => {
 			<AutosaveMonitor isAutosaveable autosave={ autosave } />
 		);
 
-		expect( autosave ).toHaveBeenCalledTimes( 0 );
+		expect( autosave ).not.toHaveBeenCalled();
 
 		rerender(
 			<AutosaveMonitor
@@ -138,7 +138,7 @@ describe( 'AutosaveMonitor', () => {
 
 		jest.runOnlyPendingTimers();
 
-		expect( autosave ).toHaveBeenCalledTimes( 0 );
+		expect( autosave ).not.toHaveBeenCalled();
 	} );
 
 	it( 'should not autosave when `editReference` changes and the post started autosaving', () => {
@@ -151,7 +151,7 @@ describe( 'AutosaveMonitor', () => {
 			/>
 		);
 
-		expect( autosave ).toHaveBeenCalledTimes( 0 );
+		expect( autosave ).not.toHaveBeenCalled();
 
 		rerender(
 			<AutosaveMonitor
@@ -164,7 +164,7 @@ describe( 'AutosaveMonitor', () => {
 
 		jest.runOnlyPendingTimers();
 
-		expect( autosave ).toHaveBeenCalledTimes( 0 );
+		expect( autosave ).not.toHaveBeenCalled();
 	} );
 
 	it( 'should schedule itself in another {interval} ms', () => {


### PR DESCRIPTION
## What?
We've recently started refactoring `enzyme` tests to `@testing-library/react`.

This PR refactors the `AutosaveMonitor` tests from `enzyme` to `@testing-library/react`.

One of the last remaining bits of https://github.com/WordPress/gutenberg/issues/17249.

## Why?
`@testing-library/react` provides a better way to write tests for accessible components that is closer to the way the user experiences them.

## How?
We're straightforwardly replacing `enzyme` tests with `@testing-library/react` ones, using `jest-dom` matchers and mocks to avoid testing unrelated implementation details.

## Testing Instructions
Verify tests pass: `npm run test:unit packages/editor/src/components/autosave-monitor/test/index.js`
