### PR TITLE
Remove unnecessary background color on placeholders

### DIFF
--- a/packages/components/src/placeholder/style.scss
+++ b/packages/components/src/placeholder/style.scss
@@ -178,9 +178,9 @@
 	min-width: 100px;
 
 	// Blur the background so layered dashed placeholders are still visually separate.
-	// We also provide a semitransparent background so as to allow duotones to sheen through.
+	// Make the background transparent to not interfere with the background overlay in placeholder-style() pseudo element
 	backdrop-filter: blur(100px);
-	background-color: rgba($white, 0.1);
+	background-color: transparent;
 
 	// Invert the colors in themes deemed dark.
 	.is-dark-theme & {


### PR DESCRIPTION
This is a subtle one, addressing a detail I missed in https://github.com/WordPress/gutenberg/pull/44190. 

Placeholders effectively have two backgrounds applied at the moment, a semi-transparent white one, and a semi-transparent `currentColor` one. We don't need both. This PR removes the white one.

### Before
<img width="693" alt="Screenshot 2022-09-27 at 12 06 03" src="https://user-images.githubusercontent.com/846565/192509619-23c729cc-298f-4898-b29c-10555e1775de.png">


### After
<img width="685" alt="Screenshot 2022-09-27 at 12 00 48" src="https://user-images.githubusercontent.com/846565/192509524-4bade3d4-813e-4ae4-a24f-79917c5b31ed.png">

