### PR TITLE
Lodash: Refactor away from `_.flow()`

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -105,6 +105,7 @@ module.exports = {
 							'flatMap',
 							'flatten',
 							'flattenDeep',
+							'flow',
 							'flowRight',
 							'forEach',
 							'fromPairs',

--- a/bin/plugin/commands/changelog.js
+++ b/bin/plugin/commands/changelog.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-const { groupBy, flow } = require( 'lodash' );
+const { groupBy } = require( 'lodash' );
 const Octokit = require( '@octokit/rest' );
 const { sprintf } = require( 'sprintf-js' );
 const semver = require( 'semver' );
@@ -184,6 +184,21 @@ const REWORD_TERMS = {
 	config: 'configuration',
 	docs: 'documentation',
 };
+
+/**
+ * Creates a pipe function. Performs left-to-right function composition, where
+ * each successive invocation is supplied the return value of the previous.
+ *
+ * @param {Function[]} functions Functions to pipe.
+ */
+function pipe( functions ) {
+	return ( /** @type {unknown[]} */ ...args ) => {
+		return functions.reduce(
+			( prev, func ) => [ func( ...prev ) ],
+			args
+		)[ 0 ];
+	};
+}
 
 /**
  * Escapes the RegExp special characters.
@@ -880,7 +895,7 @@ function skipCreatedByBots( pullRequests ) {
  * @return {string} The formatted props section.
  */
 function getContributorProps( pullRequests ) {
-	const contributorsList = flow( [
+	const contributorsList = pipe( [
 		skipCreatedByBots,
 		getFirstTimeContributorPRs,
 		getUniqueByUsername,
@@ -920,7 +935,7 @@ function getContributorsMarkdownList( pullRequests ) {
  * @return {string} The formatted contributors section.
  */
 function getContributorsList( pullRequests ) {
-	const contributorsList = flow( [
+	const contributorsList = pipe( [
 		skipCreatedByBots,
 		getUniqueByUsername,
 		sortByUsername,

--- a/package-lock.json
+++ b/package-lock.json
@@ -17475,6 +17475,7 @@
 				"@wordpress/autop": "file:packages/autop",
 				"@wordpress/blob": "file:packages/blob",
 				"@wordpress/block-serialization-default-parser": "file:packages/block-serialization-default-parser",
+				"@wordpress/compose": "file:packages/compose",
 				"@wordpress/data": "file:packages/data",
 				"@wordpress/deprecated": "file:packages/deprecated",
 				"@wordpress/dom": "file:packages/dom",

--- a/packages/block-editor/src/components/block-settings-menu/block-settings-dropdown.js
+++ b/packages/block-editor/src/components/block-settings-menu/block-settings-dropdown.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { castArray, flow } from 'lodash';
+import { castArray } from 'lodash';
 
 /**
  * WordPress dependencies
@@ -18,7 +18,7 @@ import {
 } from '@wordpress/element';
 import { __, sprintf } from '@wordpress/i18n';
 import { store as keyboardShortcutsStore } from '@wordpress/keyboard-shortcuts';
-import { useCopyToClipboard } from '@wordpress/compose';
+import { pipe, useCopyToClipboard } from '@wordpress/compose';
 
 /**
  * Internal dependencies
@@ -241,7 +241,7 @@ export function BlockSettingsDropdown( {
 								/>
 								{ canDuplicate && (
 									<MenuItem
-										onClick={ flow(
+										onClick={ pipe(
 											onClose,
 											onDuplicate,
 											updateSelectionAfterDuplicate
@@ -254,7 +254,7 @@ export function BlockSettingsDropdown( {
 								{ canInsertDefaultBlock && (
 									<>
 										<MenuItem
-											onClick={ flow(
+											onClick={ pipe(
 												onClose,
 												onInsertBefore
 											) }
@@ -263,7 +263,7 @@ export function BlockSettingsDropdown( {
 											{ __( 'Insert before' ) }
 										</MenuItem>
 										<MenuItem
-											onClick={ flow(
+											onClick={ pipe(
 												onClose,
 												onInsertAfter
 											) }
@@ -275,7 +275,7 @@ export function BlockSettingsDropdown( {
 								) }
 								{ canMove && ! onlyBlock && (
 									<MenuItem
-										onClick={ flow( onClose, onMoveTo ) }
+										onClick={ pipe( onClose, onMoveTo ) }
 									>
 										{ __( 'Move to' ) }
 									</MenuItem>
@@ -302,7 +302,7 @@ export function BlockSettingsDropdown( {
 							{ canRemove && (
 								<MenuGroup>
 									<MenuItem
-										onClick={ flow(
+										onClick={ pipe(
 											onClose,
 											onRemove,
 											updateSelectionAfterRemove

--- a/packages/block-editor/src/components/inserter/block-types-tab.js
+++ b/packages/block-editor/src/components/inserter/block-types-tab.js
@@ -1,14 +1,14 @@
 /**
  * External dependencies
  */
-import { map, flow, groupBy, orderBy } from 'lodash';
+import { map, groupBy, orderBy } from 'lodash';
 
 /**
  * WordPress dependencies
  */
 import { __, _x } from '@wordpress/i18n';
 import { useMemo, useEffect } from '@wordpress/element';
-import { useAsyncList } from '@wordpress/compose';
+import { pipe, useAsyncList } from '@wordpress/compose';
 
 /**
  * Internal dependencies
@@ -53,7 +53,7 @@ export function BlockTypesTab( {
 	}, [ items ] );
 
 	const itemsPerCategory = useMemo( () => {
-		return flow(
+		return pipe(
 			( itemList ) =>
 				itemList.filter(
 					( item ) => item.category && item.category !== 'reusable'

--- a/packages/block-editor/src/store/reducer.js
+++ b/packages/block-editor/src/store/reducer.js
@@ -2,7 +2,6 @@
  * External dependencies
  */
 import {
-	flow,
 	reduce,
 	omit,
 	without,
@@ -15,6 +14,7 @@ import {
 /**
  * WordPress dependencies
  */
+import { pipe } from '@wordpress/compose';
 import { combineReducers, select } from '@wordpress/data';
 import { store as blocksStore } from '@wordpress/blocks';
 /**
@@ -789,7 +789,7 @@ const withResetControlledBlocks = ( reducer ) => ( state, action ) => {
  *
  * @return {Object} Updated state.
  */
-export const blocks = flow(
+export const blocks = pipe(
 	combineReducers,
 	withSaveReusableBlock, // Needs to be before withBlockCache.
 	withBlockTree, // Needs to be before withInnerBlocksRemoveCascade.
@@ -1055,7 +1055,7 @@ export const blocks = flow(
 
 				const mappedBlocks = mapBlockOrder( action.blocks );
 
-				return flow( [
+				return pipe( [
 					( nextState ) =>
 						omit( nextState, action.replacedClientIds ),
 					( nextState ) => ( {
@@ -1089,7 +1089,7 @@ export const blocks = flow(
 			}
 
 			case 'REMOVE_BLOCKS_AUGMENTED_WITH_CHILDREN':
-				return flow( [
+				return pipe( [
 					// Remove inner block ordering for removed blocks.
 					( nextState ) => omit( nextState, action.removedClientIds ),
 

--- a/packages/block-library/src/code/utils.js
+++ b/packages/block-library/src/code/utils.js
@@ -1,7 +1,7 @@
 /**
- * External dependencies
+ * WordPress dependencies
  */
-import { flow } from 'lodash';
+import { pipe } from '@wordpress/compose';
 
 /**
  * Escapes ampersands, shortcodes, and links.
@@ -10,7 +10,7 @@ import { flow } from 'lodash';
  * @return {string} The given content with some characters escaped.
  */
 export function escape( content ) {
-	return flow(
+	return pipe(
 		escapeOpeningSquareBrackets,
 		escapeProtocolInIsolatedUrls
 	)( content || '' );

--- a/packages/blocks/package.json
+++ b/packages/blocks/package.json
@@ -32,6 +32,7 @@
 		"@wordpress/autop": "file:../autop",
 		"@wordpress/blob": "file:../blob",
 		"@wordpress/block-serialization-default-parser": "file:../block-serialization-default-parser",
+		"@wordpress/compose": "file:../compose",
 		"@wordpress/data": "file:../data",
 		"@wordpress/deprecated": "file:../deprecated",
 		"@wordpress/dom": "file:../dom",

--- a/packages/blocks/src/api/parser/get-block-attributes.js
+++ b/packages/blocks/src/api/parser/get-block-attributes.js
@@ -2,12 +2,13 @@
  * External dependencies
  */
 import { parse as hpqParse } from 'hpq';
-import { flow, mapValues, castArray } from 'lodash';
+import { mapValues, castArray } from 'lodash';
 import memoize from 'memize';
 
 /**
  * WordPress dependencies
  */
+import { pipe } from '@wordpress/compose';
 import { applyFilters } from '@wordpress/hooks';
 
 /**
@@ -28,7 +29,7 @@ import { normalizeBlockType } from '../utils';
  * @return {Function} Enhanced hpq matcher.
  */
 export const toBooleanAttributeMatcher = ( matcher ) =>
-	flow( [
+	pipe( [
 		matcher,
 		// Expected values from `attr( 'disabled' )`:
 		//
@@ -213,7 +214,7 @@ export const matcherFromSource = memoize( ( sourceConfig ) => {
 			);
 			return query( sourceConfig.selector, subMatchers );
 		case 'tag':
-			return flow( [
+			return pipe( [
 				prop( sourceConfig.selector, 'nodeName' ),
 				( nodeName ) =>
 					nodeName ? nodeName.toLowerCase() : undefined,

--- a/packages/blocks/src/store/selectors.js
+++ b/packages/blocks/src/store/selectors.js
@@ -3,7 +3,12 @@
  */
 import createSelector from 'rememo';
 import removeAccents from 'remove-accents';
-import { filter, flow, get, includes, map, some } from 'lodash';
+import { filter, get, includes, map, some } from 'lodash';
+
+/**
+ * WordPress dependencies
+ */
+import { pipe } from '@wordpress/compose';
 
 /** @typedef {import('../api/registration').WPBlockVariation} WPBlockVariation */
 /** @typedef {import('../api/registration').WPBlockVariationScope} WPBlockVariationScope */
@@ -686,7 +691,7 @@ export function hasBlockSupport( state, nameOrType, feature, defaultSupports ) {
 export function isMatchingSearchTerm( state, nameOrType, searchTerm ) {
 	const blockType = getNormalizedBlockType( state, nameOrType );
 
-	const getNormalizedSearchTerm = flow( [
+	const getNormalizedSearchTerm = pipe( [
 		// Disregard diacritics.
 		//  Input: "média"
 		( term ) => removeAccents( term ?? '' ),
@@ -702,7 +707,7 @@ export function isMatchingSearchTerm( state, nameOrType, searchTerm ) {
 
 	const normalizedSearchTerm = getNormalizedSearchTerm( searchTerm );
 
-	const isSearchMatch = flow( [
+	const isSearchMatch = pipe( [
 		getNormalizedSearchTerm,
 		( normalizedCandidate ) =>
 			includes( normalizedCandidate, normalizedSearchTerm ),

--- a/packages/list-reusable-blocks/src/components/import-dropdown/index.js
+++ b/packages/list-reusable-blocks/src/components/import-dropdown/index.js
@@ -1,11 +1,7 @@
 /**
- * External dependencies
- */
-import { flow } from 'lodash';
-
-/**
  * WordPress dependencies
  */
+import { pipe } from '@wordpress/compose';
 import { __ } from '@wordpress/i18n';
 import { Dropdown, Button } from '@wordpress/components';
 
@@ -29,7 +25,7 @@ function ImportDropdown( { onUpload } ) {
 				</Button>
 			) }
 			renderContent={ ( { onClose } ) => (
-				<ImportForm onUpload={ flow( onClose, onUpload ) } />
+				<ImportForm onUpload={ pipe( onClose, onUpload ) } />
 			) }
 		/>
 	);


### PR DESCRIPTION
## What?
This PR removes Lodash's `_.flow()` completely and deprecates that method. 

## Why?

Lodash is known to unnecessarily inflate the bundle size of packages, and in most cases, it can be replaced with native language functionality. See these for more information and rationale:

* https://github.com/WordPress/gutenberg/issues/16938#issuecomment-602837246
* https://github.com/WordPress/gutenberg/issues/17025
* https://github.com/WordPress/gutenberg/issues/39495 

## How?

We're replacing a few usages with the `pipe()` function that we already introduced in #44112 as a reverse counterpart for the existing `compose()`. 

## Testing Instructions

* Smoke test the block editor and site editor.
* Verify all checks are green - the affected code is well covered by tests.