### PR TITLE
Edit Post: Optimize legacy post content layout

### DIFF
--- a/packages/edit-post/src/components/visual-editor/index.js
+++ b/packages/edit-post/src/components/visual-editor/index.js
@@ -266,14 +266,21 @@ export default function VisualEditor( { styles } ) {
 	const layout = postContentBlock?.attributes?.layout || {};
 
 	// Update type for blocks using legacy layouts.
-	const postContentLayout =
-		layout &&
-		( layout?.type === 'constrained' ||
-			layout?.inherit ||
-			layout?.contentSize ||
-			layout?.wideSize )
+	const postContentLayout = useMemo( () => {
+		return layout &&
+			( layout?.type === 'constrained' ||
+				layout?.inherit ||
+				layout?.contentSize ||
+				layout?.wideSize )
 			? { ...globalLayoutSettings, ...layout, type: 'constrained' }
 			: { ...globalLayoutSettings, ...layout, type: 'default' };
+	}, [
+		layout?.type,
+		layout?.inherit,
+		layout?.contentSize,
+		layout?.wideSize,
+		globalLayoutSettings,
+	] );
 
 	// If there is a Post Content block we use its layout for the block list;
 	// if not, this must be a classic theme, in which case we use the fallback layout.


### PR DESCRIPTION
## What?
This PR optimizes the legacy post content layout calculation that was introduced in #44258.

## Why?
I noticed that opening the inserter became a few times slower after #44258 landed.

## How?
We're wrapping a computed object that results in expensive rerenders in a `useMemo()` in order to take advantage of memoization when working with the same layout data. This appears to have an immediate effect on the performance, as displayed by the performance test results.

## Testing Instructions
* Run `npm run test:performance -- packages/e2e-tests/specs/performance/post-editor.test.js` locally.
* Observe the numbers.
* Checkout this branch locally.
* Apply this diff to enable only the test we're interested in:

```
diff --git a/packages/e2e-tests/specs/performance/post-editor.test.js b/packages/e2e-tests/specs/performance/post-editor.test.js
index 933b4973fb..3b4d9b3118 100644
--- a/packages/e2e-tests/specs/performance/post-editor.test.js
+++ b/packages/e2e-tests/specs/performance/post-editor.test.js
@@ -201,7 +201,7 @@ describe( 'Post Editor Performance', () => {
                }
        } );

-       it( 'Opening the inserter', async () => {
+       it.only( 'Opening the inserter', async () => {
                // Measure time to open inserter.
                await page.waitForSelector( '.edit-post-layout' );
                for ( let j = 0; j < 10; j++ ) {
```
* Run `npm run test:performance -- packages/e2e-tests/specs/performance/post-editor.test.js`
* Verify it's a few times faster!
* Verify #44258 test instructions still work.

## Screenshots or screencast <!-- if applicable -->

Before this PR:

![Screenshot 2022-09-27 at 17 39 13](https://user-images.githubusercontent.com/8436925/192557206-077ba73e-2915-44ca-a4b6-14fb4bd3f36f.png)
![Screenshot 2022-09-27 at 17 39 22](https://user-images.githubusercontent.com/8436925/192557210-276720e1-4d1f-49a4-90b0-d9ab7a1d4e84.png)

After this PR:

![Screenshot 2022-09-27 at 17 39 01](https://user-images.githubusercontent.com/8436925/192557198-6cf66fe8-b876-4102-accf-62d54d2e6f18.png)
![Screenshot 2022-09-27 at 17 39 08](https://user-images.githubusercontent.com/8436925/192557204-4c9c715b-826e-4589-8827-62762e142a50.png)
