### PR TITLE
Add style-engine to gutenberg tsconfig references

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -33,6 +33,7 @@
 		{ "path": "packages/project-management-automation" },
 		{ "path": "packages/react-i18n" },
 		{ "path": "packages/report-flaky-tests" },
+		{ "path": "packages/style-engine" },
 		{ "path": "packages/token-list" },
 		{ "path": "packages/url" },
 		{ "path": "packages/warning" },


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Makes the style engine types be built when building gutenberg `npm run build:package-types` which is called by `npm run build` and `npm run dev`.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

The style engine types should be built when gutenberg is built.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

Adds style-engine to gutenberg tsconfig references.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->

1. `npm run build:package-types`
2. See `packages/style-engine/build-types` exists

## Screenshots or screencast <!-- if applicable -->
