### PR TITLE
Add prop to disable block selection clearer in BlockList

### DIFF
--- a/packages/block-editor/README.md
+++ b/packages/block-editor/README.md
@@ -616,6 +616,7 @@ _Properties_
 -   _codeEditingEnabled_ `boolean`: Whether or not the user can switch to the code editor
 -   _generateAnchors_ `boolean`: Enable/Disable auto anchor generation for Heading blocks
 -   _\_\_experimentalCanUserUseUnfilteredHTML_ `boolean`: Whether the user should be able to use unfiltered HTML or the HTML should be filtered e.g., to remove elements considered insecure like iframes.
+-   _\_\_experimentalClearBlockSelection_ `boolean`: Whether the block editor should clear selection on mousedown when a block is not clicked.
 -   _\_\_experimentalBlockDirectory_ `boolean`: Whether the user has enabled the Block Directory
 -   _\_\_experimentalBlockPatterns_ `Array`: Array of objects representing the block patterns
 -   _\_\_experimentalBlockPatternCategories_ `Array`: Array of objects representing the block pattern categories

--- a/packages/block-editor/src/components/block-list/index.js
+++ b/packages/block-editor/src/components/block-list/index.js
@@ -46,7 +46,7 @@ const elementContext = createContext();
 export const IntersectionObserver = createContext();
 const pendingBlockVisibilityUpdatesPerRegistry = new WeakMap();
 
-function Root( { className, ...settings } ) {
+function Root( { className, disableBlockSelectionClearer, ...settings } ) {
 	const [ element, setElement ] = useState();
 	const isLargeViewport = useViewportMatch( 'medium' );
 	const { isOutlineMode, isFocusMode, editorMode } = useSelect(
@@ -103,7 +103,9 @@ function Root( { className, ...settings } ) {
 	const innerBlocksProps = useInnerBlocksProps(
 		{
 			ref: useMergeRefs( [
-				useBlockSelectionClearer(),
+				useBlockSelectionClearer( {
+					disabled: disableBlockSelectionClearer,
+				} ),
 				useInBetweenInserter(),
 				setElement,
 			] ),

--- a/packages/block-editor/src/components/block-list/index.js
+++ b/packages/block-editor/src/components/block-list/index.js
@@ -46,7 +46,7 @@ const elementContext = createContext();
 export const IntersectionObserver = createContext();
 const pendingBlockVisibilityUpdatesPerRegistry = new WeakMap();
 
-function Root( { className, disableBlockSelectionClearer, ...settings } ) {
+function Root( { className, ...settings } ) {
 	const [ element, setElement ] = useState();
 	const isLargeViewport = useViewportMatch( 'medium' );
 	const { isOutlineMode, isFocusMode, editorMode } = useSelect(
@@ -103,9 +103,7 @@ function Root( { className, disableBlockSelectionClearer, ...settings } ) {
 	const innerBlocksProps = useInnerBlocksProps(
 		{
 			ref: useMergeRefs( [
-				useBlockSelectionClearer( {
-					disabled: disableBlockSelectionClearer,
-				} ),
+				useBlockSelectionClearer(),
 				useInBetweenInserter(),
 				setElement,
 			] ),

--- a/packages/block-editor/src/components/block-selection-clearer/index.js
+++ b/packages/block-editor/src/components/block-selection-clearer/index.js
@@ -14,17 +14,17 @@ import { store as blockEditorStore } from '../../store';
  * selection. Selection will only be cleared if the element is clicked directly,
  * not if a child element is clicked.
  *
- * @param {boolean} isDisabled Disable the block selection clearer.
  * @return {import('react').RefCallback} Ref callback.
  */
-export function useBlockSelectionClearer( isDisabled = false ) {
-	const { hasSelectedBlock, hasMultiSelection } =
+export function useBlockSelectionClearer() {
+	const { getSettings, hasSelectedBlock, hasMultiSelection } =
 		useSelect( blockEditorStore );
 	const { clearSelectedBlock } = useDispatch( blockEditorStore );
+	const { __experimentalClearBlockSelection: isEnabled } = getSettings();
 
 	return useRefEffect(
 		( node ) => {
-			if ( isDisabled ) {
+			if ( ! isEnabled ) {
 				return;
 			}
 
@@ -47,7 +47,7 @@ export function useBlockSelectionClearer( isDisabled = false ) {
 				node.removeEventListener( 'mousedown', onMouseDown );
 			};
 		},
-		[ hasSelectedBlock, hasMultiSelection, clearSelectedBlock, isDisabled ]
+		[ hasSelectedBlock, hasMultiSelection, clearSelectedBlock, isEnabled ]
 	);
 }
 

--- a/packages/block-editor/src/components/block-selection-clearer/index.js
+++ b/packages/block-editor/src/components/block-selection-clearer/index.js
@@ -17,7 +17,7 @@ import { store as blockEditorStore } from '../../store';
  * @param {boolean} isDisabled Disable the block selection clearer.
  * @return {import('react').RefCallback} Ref callback.
  */
-export function useBlockSelectionClearer( isDisabled ) {
+export function useBlockSelectionClearer( isDisabled = false ) {
 	const { hasSelectedBlock, hasMultiSelection } =
 		useSelect( blockEditorStore );
 	const { clearSelectedBlock } = useDispatch( blockEditorStore );

--- a/packages/block-editor/src/components/block-selection-clearer/index.js
+++ b/packages/block-editor/src/components/block-selection-clearer/index.js
@@ -14,15 +14,20 @@ import { store as blockEditorStore } from '../../store';
  * selection. Selection will only be cleared if the element is clicked directly,
  * not if a child element is clicked.
  *
+ * @param {boolean} isDisabled Disable the block selection clearer.
  * @return {import('react').RefCallback} Ref callback.
  */
-export function useBlockSelectionClearer() {
+export function useBlockSelectionClearer( isDisabled ) {
 	const { hasSelectedBlock, hasMultiSelection } =
 		useSelect( blockEditorStore );
 	const { clearSelectedBlock } = useDispatch( blockEditorStore );
 
 	return useRefEffect(
 		( node ) => {
+			if ( isDisabled ) {
+				return;
+			}
+
 			function onMouseDown( event ) {
 				if ( ! hasSelectedBlock() && ! hasMultiSelection() ) {
 					return;
@@ -42,7 +47,7 @@ export function useBlockSelectionClearer() {
 				node.removeEventListener( 'mousedown', onMouseDown );
 			};
 		},
-		[ hasSelectedBlock, hasMultiSelection, clearSelectedBlock ]
+		[ hasSelectedBlock, hasMultiSelection, clearSelectedBlock, isDisabled ]
 	);
 }
 

--- a/packages/block-editor/src/components/block-selection-clearer/test/index.js
+++ b/packages/block-editor/src/components/block-selection-clearer/test/index.js
@@ -1,0 +1,118 @@
+/**
+ * External dependencies
+ */
+import { fireEvent, render } from '@testing-library/react';
+
+/**
+ * WordPress dependencies
+ */
+import { useDispatch, useSelect } from '@wordpress/data';
+
+/**
+ * Internal dependencies
+ */
+import BlockSelectionClearer from '../';
+
+const defaultUseSelectValues = {
+	hasSelectedBlock: jest.fn().mockReturnValue( false ),
+	hasMultiSelection: jest.fn().mockReturnValue( false ),
+	getSettings: jest.fn().mockReturnValue( {
+		__experimentalClearBlockSelection: true,
+	} ),
+};
+
+jest.mock( '@wordpress/data/src/components/use-dispatch', () => ( {
+	useDispatch: jest.fn(),
+} ) );
+
+jest.mock( '@wordpress/data/src/components/use-select', () => {
+	// This allows us to tweak the returned value on each test.
+	const mock = jest.fn();
+	return mock;
+} );
+
+describe( 'BlockSelectionClearer component', () => {
+	it( 'should clear the selected block when a selected block exists', () => {
+		const mockClearSelectedBlock = jest.fn();
+		useSelect.mockImplementation( () => ( {
+			...defaultUseSelectValues,
+			hasSelectedBlock: jest.fn().mockReturnValue( true ),
+		} ) );
+		useDispatch.mockImplementation( () => ( {
+			clearSelectedBlock: mockClearSelectedBlock,
+		} ) );
+
+		const { queryByRole } = render(
+			<BlockSelectionClearer>
+				<button>Not a block</button>
+			</BlockSelectionClearer>
+		);
+		const button = queryByRole( 'button' );
+		fireEvent.mouseDown( button.parentElement );
+
+		expect( mockClearSelectedBlock ).toBeCalled();
+	} );
+
+	it( 'should clear the selected block when multiple blocks are selected', () => {
+		const mockClearSelectedBlock = jest.fn();
+		useSelect.mockImplementation( () => ( {
+			...defaultUseSelectValues,
+			hasMultiSelection: jest.fn().mockReturnValue( true ),
+		} ) );
+		useDispatch.mockImplementation( () => ( {
+			clearSelectedBlock: mockClearSelectedBlock,
+		} ) );
+
+		const { queryByRole } = render(
+			<BlockSelectionClearer>
+				<button>Not a block</button>
+			</BlockSelectionClearer>
+		);
+		const button = queryByRole( 'button' );
+		fireEvent.mouseDown( button.parentElement );
+
+		expect( mockClearSelectedBlock ).toBeCalled();
+	} );
+
+	it( 'should not clear the block selection when no blocks are selected', () => {
+		const mockClearSelectedBlock = jest.fn();
+		useSelect.mockImplementation( () => defaultUseSelectValues );
+		useDispatch.mockImplementation( () => ( {
+			clearSelectedBlock: mockClearSelectedBlock,
+		} ) );
+
+		const { queryByRole } = render(
+			<BlockSelectionClearer>
+				<button>Not a block</button>
+			</BlockSelectionClearer>
+		);
+		const button = queryByRole( 'button' );
+		fireEvent.mouseDown( button.parentElement );
+
+		expect( mockClearSelectedBlock ).not.toBeCalled();
+	} );
+
+	it( 'should not clear the block selection when the feature is disabled', () => {
+		const mockClearSelectedBlock = jest.fn();
+		useSelect.mockImplementation( () => ( {
+			...defaultUseSelectValues,
+			hasSelectedBlock: jest.fn().mockReturnValue( true ),
+			getSettings: jest.fn().mockReturnValue( {
+				__experimentalClearBlockSelection: false,
+			} ),
+		} ) );
+		useDispatch.mockImplementation( () => ( {
+			clearSelectedBlock: mockClearSelectedBlock,
+		} ) );
+
+		const { queryByRole } = render(
+			<BlockSelectionClearer>
+				<button>Not a block</button>
+			</BlockSelectionClearer>
+		);
+		const button = queryByRole( 'button' );
+		fireEvent.mouseDown( button.parentElement );
+
+		expect( mockClearSelectedBlock ).not.toBeCalled();
+	} );
+} );

--- a/packages/block-editor/src/store/defaults.js
+++ b/packages/block-editor/src/store/defaults.js
@@ -27,6 +27,7 @@ export const PREFERENCES_DEFAULTS = {
  * @property {boolean}       codeEditingEnabled                     Whether or not the user can switch to the code editor
  * @property {boolean}       generateAnchors                        Enable/Disable auto anchor generation for Heading blocks
  * @property {boolean}       __experimentalCanUserUseUnfilteredHTML Whether the user should be able to use unfiltered HTML or the HTML should be filtered e.g., to remove elements considered insecure like iframes.
+ * @property {boolean}       __experimentalClearBlockSelection      Whether the block editor should clear selection on mousedown when a block is not clicked.
  * @property {boolean}       __experimentalBlockDirectory           Whether the user has enabled the Block Directory
  * @property {Array}         __experimentalBlockPatterns            Array of objects representing the block patterns
  * @property {Array}         __experimentalBlockPatternCategories   Array of objects representing the block pattern categories
@@ -156,6 +157,7 @@ export const SETTINGS_DEFAULTS = {
 	canLockBlocks: true,
 
 	__experimentalCanUserUseUnfilteredHTML: false,
+	__experimentalClearBlockSelection: true,
 	__experimentalBlockDirectory: false,
 	__mobileEnablePageTemplates: false,
 	__experimentalBlockPatterns: [],


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
This PR adds a prop to allow disabling of the block selection clearing.

I'm open to other ways of handling this, but this seems like the most minimal and non-invasive way to handle this without affecting existing editors.

Fixes #44508

## Why?
This can be useful for consumers wanting to use the block editor who don't necessarily want to deselect block elements and lose the contextual toolbar when editing.

In WooCommerce, we're working on a [rich text editor](https://github.com/woocommerce/woocommerce/pull/34629) which should always show a toolbar.  Currently this isn't always possible due to deselection:

<img width="327" alt="Screen Shot 2022-09-26 at 12 57 46 PM" src="https://user-images.githubusercontent.com/10561050/192630945-68d4fc4d-05c1-40c1-a97c-41ae76ecac87.png">


## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

## Testing Instructions

1. Compose a block editor with the `disableBlockSelectionClearer` prop:
```
import {
    BlockEditorProvider,
    BlockList,
    BlockTools,
    WritingFlow,
    ObserveTyping,
} from '@wordpress/block-editor';
import { SlotFillProvider, Popover } from '@wordpress/components';
import { useState } from '@wordpress/element';

function MyEditorComponent() {
    const [ blocks, updateBlocks ] = useState( [] );

    return (
        <BlockEditorProvider
            value={ blocks }
            onInput={ ( blocks ) => updateBlocks( blocks ) }
            onChange={ ( blocks ) => updateBlocks( blocks ) }
        >
            <SlotFillProvider>
                <BlockTools>
                    <WritingFlow>
                        <ObserveTyping>
                            <BlockList disableBlockSelectionClearer />
                        </ObserveTyping>
                    </WritingFlow>
                </BlockTools>
                <Popover.Slot />
            </SlotFillProvider>
        </BlockEditorProvider>
    );
}
```
2. Add some blocks
3. Attempt to click the margin between blocks
4. Note that the toolbar is still visible and block selection has not been cleared
5. Verify that other editors around the site are not affected by this change


## Screenshots or screencast <!-- if applicable -->
<img width="289" alt="Screen Shot 2022-09-26 at 12 57 40 PM" src="https://user-images.githubusercontent.com/10561050/192631200-454c33fc-fb88-4ebf-b43d-9db254646fab.png">
