### PR TITLE
Script loader: remove 6.1 wp actions

### DIFF
--- a/lib/client-assets.php
+++ b/lib/client-assets.php
@@ -445,3 +445,96 @@ function gutenberg_register_packages_styles( $styles ) {
 	$styles->add_data( 'wp-widgets', 'rtl', 'replace' );
 }
 add_action( 'wp_default_styles', 'gutenberg_register_packages_styles' );
+
+/**
+ * Fetches, processes and compiles stored core styles, then combines and renders them to the page.
+ * Styles are stored via the Style Engine API.
+ *
+ * This hook also exists, and should be backported to Core in future versions.
+ * However, it is envisaged that Gutenberg will continue to use the Style Engine's `gutenberg_*` functions and `_Gutenberg` classes to aid continuous development.
+ *
+ * See: https://developer.wordpress.org/block-editor/reference-guides/packages/packages-style-engine/
+ *
+ * @param array $options {
+ *     Optional. An array of options to pass to gutenberg_style_engine_get_stylesheet_from_context(). Default empty array.
+ *
+ *     @type bool $optimize Whether to optimize the CSS output, e.g., combine rules. Default is `false`.
+ *     @type bool $prettify Whether to add new lines and indents to output. Default is the test of whether the global constant `SCRIPT_DEBUG` is defined.
+ * }
+ *
+ * @since 6.1
+ *
+ * @return void
+ */
+function gutenberg_enqueue_stored_styles( $options = array() ) {
+	$is_block_theme   = wp_is_block_theme();
+	$is_classic_theme = ! $is_block_theme;
+
+	/*
+	 * For block themes, print stored styles in the header.
+	 * For classic themes, in the footer.
+	 */
+	if (
+		( $is_block_theme && doing_action( 'wp_footer' ) ) ||
+		( $is_classic_theme && doing_action( 'wp_enqueue_scripts' ) )
+	) {
+		return;
+	}
+
+	$core_styles_keys         = array( 'block-supports' );
+	$compiled_core_stylesheet = '';
+	$style_tag_id             = 'core';
+	foreach ( $core_styles_keys as $style_key ) {
+		// Adds comment if code is prettified to identify core styles sections in debugging.
+		$should_prettify = isset( $options['prettify'] ) ? true === $options['prettify'] : defined( 'SCRIPT_DEBUG' ) && SCRIPT_DEBUG;
+		if ( $should_prettify ) {
+			$compiled_core_stylesheet .= "/**\n * Core styles: $style_key\n */\n";
+		}
+		// Chains core store ids to signify what the styles contain.
+		$style_tag_id             .= '-' . $style_key;
+		$compiled_core_stylesheet .= gutenberg_style_engine_get_stylesheet_from_context( $style_key, $options );
+	}
+
+	// Combines Core styles.
+	if ( ! empty( $compiled_core_stylesheet ) ) {
+		wp_register_style( $style_tag_id, false, array(), true, true );
+		wp_add_inline_style( $style_tag_id, $compiled_core_stylesheet );
+		wp_enqueue_style( $style_tag_id );
+	}
+
+	// If there are any other stores registered by themes etc., print them out.
+	$additional_stores = WP_Style_Engine_CSS_Rules_Store_Gutenberg::get_stores();
+
+	/*
+	 * Since the corresponding action hook in Core is removed below,
+	 * this function should still honour any styles stored using the Core Style Engine store.
+	 */
+	if ( class_exists( 'WP_Style_Engine_CSS_Rules_Store' ) ) {
+		$additional_stores = array_merge( $additional_stores, WP_Style_Engine_CSS_Rules_Store_Gutenberg::get_stores() );
+	}
+
+	foreach ( array_keys( $additional_stores ) as $store_name ) {
+		if ( in_array( $store_name, $core_styles_keys, true ) ) {
+			continue;
+		}
+		$styles = gutenberg_style_engine_get_stylesheet_from_context( $store_name, $options );
+		if ( ! empty( $styles ) ) {
+			$key = "wp-style-engine-$store_name";
+			wp_register_style( $key, false, array(), true, true );
+			wp_add_inline_style( $key, $styles );
+			wp_enqueue_style( $key );
+		}
+	}
+}
+
+/*
+ * Always remove the Core action hook while gutenberg_enqueue_stored_styles() exists to avoid styles being printed twice.
+ * This is also because gutenberg_enqueue_stored_styles uses the Style Engine's `gutenberg_*` functions and `_Gutenberg` classes,
+ * which are in continuous development and generally ahead of Core.
+ */
+remove_action( 'wp_enqueue_scripts', 'wp_enqueue_stored_styles' );
+remove_action( 'wp_footer', 'wp_enqueue_stored_styles', 1 );
+
+// Enqueue stored styles.
+add_action( 'wp_enqueue_scripts', 'gutenberg_enqueue_stored_styles' );
+add_action( 'wp_footer', 'gutenberg_enqueue_stored_styles', 1 );

--- a/lib/client-assets.php
+++ b/lib/client-assets.php
@@ -510,7 +510,7 @@ function gutenberg_enqueue_stored_styles( $options = array() ) {
 	 * this function should still honour any styles stored using the Core Style Engine store.
 	 */
 	if ( class_exists( 'WP_Style_Engine_CSS_Rules_Store' ) ) {
-		$additional_stores = array_merge( $additional_stores, WP_Style_Engine_CSS_Rules_Store_Gutenberg::get_stores() );
+		$additional_stores = array_merge( $additional_stores, WP_Style_Engine_CSS_Rules_Store::get_stores() );
 	}
 
 	foreach ( array_keys( $additional_stores ) as $store_name ) {

--- a/lib/compat/wordpress-6.1/script-loader.php
+++ b/lib/compat/wordpress-6.1/script-loader.php
@@ -175,6 +175,8 @@ remove_action( 'wp_enqueue_scripts', 'wp_enqueue_global_styles' );
 remove_action( 'wp_footer', 'wp_enqueue_global_styles', 1 );
 remove_action( 'wp_enqueue_scripts', 'gutenberg_enqueue_global_styles_assets' );
 remove_action( 'wp_footer', 'gutenberg_enqueue_global_styles_assets' );
+remove_action( 'wp_enqueue_scripts', 'wp_enqueue_stored_styles' );
+remove_action( 'wp_footer', 'wp_enqueue_stored_styles', 1 );
 
 // Enqueue global styles, and then block supports styles.
 add_action( 'wp_enqueue_scripts', 'gutenberg_enqueue_global_styles' );

--- a/lib/compat/wordpress-6.1/script-loader.php
+++ b/lib/compat/wordpress-6.1/script-loader.php
@@ -37,73 +37,6 @@ function gutenberg_enqueue_block_support_styles( $style, $priority = 10 ) {
 }
 
 /**
- * Fetches, processes and compiles stored core styles, then combines and renders them to the page.
- * Styles are stored via the style engine API.
- *
- * See: https://developer.wordpress.org/block-editor/reference-guides/packages/packages-style-engine/
- *
- * @param array $options {
- *     Optional. An array of options to pass to gutenberg_style_engine_get_stylesheet_from_context(). Default empty array.
- *
- *     @type bool $optimize Whether to optimize the CSS output, e.g., combine rules. Default is `false`.
- *     @type bool $prettify Whether to add new lines and indents to output. Default is the test of whether the global constant `SCRIPT_DEBUG` is defined.
- * }
- *
- * @return void
- */
-function gutenberg_enqueue_stored_styles( $options = array() ) {
-	$is_block_theme   = wp_is_block_theme();
-	$is_classic_theme = ! $is_block_theme;
-
-	/*
-	 * For block themes, print stored styles in the header.
-	 * For classic themes, in the footer.
-	 */
-	if (
-		( $is_block_theme && doing_action( 'wp_footer' ) ) ||
-		( $is_classic_theme && doing_action( 'wp_enqueue_scripts' ) )
-	) {
-		return;
-	}
-
-	$core_styles_keys         = array( 'block-supports' );
-	$compiled_core_stylesheet = '';
-	$style_tag_id             = 'core';
-	foreach ( $core_styles_keys as $style_key ) {
-		// Adds comment if code is prettified to identify core styles sections in debugging.
-		$should_prettify = isset( $options['prettify'] ) ? true === $options['prettify'] : defined( 'SCRIPT_DEBUG' ) && SCRIPT_DEBUG;
-		if ( $should_prettify ) {
-			$compiled_core_stylesheet .= "/**\n * Core styles: $style_key\n */\n";
-		}
-		// Chains core store ids to signify what the styles contain.
-		$style_tag_id             .= '-' . $style_key;
-		$compiled_core_stylesheet .= gutenberg_style_engine_get_stylesheet_from_context( $style_key, $options );
-	}
-
-	// Combines Core styles.
-	if ( ! empty( $compiled_core_stylesheet ) ) {
-		wp_register_style( $style_tag_id, false, array(), true, true );
-		wp_add_inline_style( $style_tag_id, $compiled_core_stylesheet );
-		wp_enqueue_style( $style_tag_id );
-	}
-
-	// If there are any other stores registered by themes etc, print them out.
-	$additional_stores = WP_Style_Engine_CSS_Rules_Store_Gutenberg::get_stores();
-	foreach ( array_keys( $additional_stores ) as $store_name ) {
-		if ( in_array( $store_name, $core_styles_keys, true ) ) {
-			continue;
-		}
-		$styles = gutenberg_style_engine_get_stylesheet_from_context( $store_name, $options );
-		if ( ! empty( $styles ) ) {
-			$key = "wp-style-engine-$store_name";
-			wp_register_style( $key, false, array(), true, true );
-			wp_add_inline_style( $key, $styles );
-			wp_enqueue_style( $key );
-		}
-	}
-}
-
-/**
  * This applies a filter to the list of style nodes that comes from `get_style_nodes` in WP_Theme_JSON.
  * This particular filter removes all of the blocks from the array.
  *
@@ -175,14 +108,10 @@ remove_action( 'wp_enqueue_scripts', 'wp_enqueue_global_styles' );
 remove_action( 'wp_footer', 'wp_enqueue_global_styles', 1 );
 remove_action( 'wp_enqueue_scripts', 'gutenberg_enqueue_global_styles_assets' );
 remove_action( 'wp_footer', 'gutenberg_enqueue_global_styles_assets' );
-remove_action( 'wp_enqueue_scripts', 'wp_enqueue_stored_styles' );
-remove_action( 'wp_footer', 'wp_enqueue_stored_styles', 1 );
 
 // Enqueue global styles, and then block supports styles.
 add_action( 'wp_enqueue_scripts', 'gutenberg_enqueue_global_styles' );
 add_action( 'wp_footer', 'gutenberg_enqueue_global_styles', 1 );
-add_action( 'wp_enqueue_scripts', 'gutenberg_enqueue_stored_styles' );
-add_action( 'wp_footer', 'gutenberg_enqueue_stored_styles', 1 );
 
 /**
  * Loads classic theme styles on classic themes.


### PR DESCRIPTION

## What?
Now that 6.1-beta is running in development, we should remove the backported hook callbacks for `wp_enqueue_stored_styles`.


## Why?
This prevents the callback running twice.

## How?
`remove_action` YO!

## Testing Instructions
In trunk, you can test the before state by creating a post with some layout blocks. 

Here, kind reviewer, is some test HTML

<details>

<summary>Example</summary>

```html
<!-- wp:group {"style":{"spacing":{"blockGap":"var:preset|spacing|50"}},"layout":{"type":"constrained","justifyContent":"left","contentSize":"577px"}} -->
<div class="wp-block-group"><!-- wp:site-title {"style":{"color":{"background":"#b92c2c"},"typography":{"lineHeight":5.7,"letterSpacing":"41px"}},"fontSize":"large"} /-->

<!-- wp:site-title {"style":{"color":{"background":"#88c7b4"},"typography":{"lineHeight":5.7,"letterSpacing":"41px"}},"fontSize":"large"} /--></div>
<!-- /wp:group -->

```

</details>

In the published post's frontend HTML source, you'll see that the block supports inline CSS has two comments `Core styles: block-supports`:

```html
<style id='core-block-supports-inline-css'>
/**
 * Core styles: block-supports
 */

/**
 * Core styles: block-supports
 */
```
This means that the callback has been called twice.

Apply this PR and see that the duplicate comment is GONE BABY