### PR TITLE
PostFeaturedImage: Fix application of default border style in editor

### DIFF
--- a/packages/block-library/src/post-featured-image/editor.scss
+++ b/packages/block-library/src/post-featured-image/editor.scss
@@ -40,10 +40,19 @@
 
 		// Show default placeholder height when not resized.
 		min-height: 200px;
+	}
 
-		// The following override the default placeholder styles that remove
-		// its border so that a user selection for border color or width displays
-		// a visual border.
+	// The following override the default placeholder styles that remove
+	// its border so that a user selection for border color or width displays
+	// a visual border. They also override the `img { border: none; }` applied
+	// by core.
+	.wp-block-post-featured-image__placeholder,
+	.components-placeholder,
+	img {
+		// The following is required to overcome WP Core applying styles that clear
+		// img borders with a higher specificity than those added by the border
+		// block support to provide a default border-style of solid when a border
+		// color or width has been set.
 		&:where(.has-border-color) {
 			border-style: solid;
 		}


### PR DESCRIPTION
Related:
- https://github.com/WordPress/gutenberg/pull/44286

## What?
Fixes issue where core styles remove `img` borders preventing user-selected borders from showing on the PostFeaturedImage block in the editor.

## Why?
- Fixes unexpected behaviour
- Maintains consistency between the frontend and backend.

## How?
- Applied the same fallback styles as are being applied to the placeholder.

## Testing Instructions
1. Add a Post Featured Image block to a post without a featured image set.
2. Select the block, add an overlay, and ensure that when setting a border, the block shows it accurately
3. Select a featured image
4. Ensure that the border remains as expected on the block
5. Save and confirm the correct display of the border on the frontend

## Screenshots or screencast <!-- if applicable -->

| Before | After |
|---|---|
| <img width="688" alt="Screen Shot 2022-09-28 at 1 39 08 pm" src="https://user-images.githubusercontent.com/60436221/192682314-6c44d05e-4d53-4008-a7e1-b9d58cf29e76.png"> | <img width="684" alt="Screen Shot 2022-09-28 at 1 39 53 pm" src="https://user-images.githubusercontent.com/60436221/192682281-dccf5f10-be8e-4f02-bad6-267884e87ce9.png"> |
