### PR TITLE
[Block Library - Query Loop]: Rename Query Loop variations `allowControls` to `allowedControls`

### DIFF
--- a/packages/block-library/src/query/utils.js
+++ b/packages/block-library/src/query/utils.js
@@ -162,7 +162,7 @@ export function useAllowedControls( attributes ) {
 			select( blocksStore ).getActiveBlockVariation(
 				queryLoopName,
 				attributes
-			)?.allowControls,
+			)?.allowedControls,
 
 		[ attributes ]
 	);


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
This is a follow up of https://github.com/WordPress/gutenberg/pull/43632

It seems I've made a mistake to the intended name of the API which should be `allowedControls` and instead `allowControls` slipped in.. There is no much difference, but I think the originally intended name is better for this API and since it was just introduced in 6.1,  we can safely update it and also change the [docs PR](https://github.com/WordPress/gutenberg/pull/44137) about it.

<!-- In a few words, what is the PR actually doing? -->


## Testing Instructions
The testing instructions are the same from the original PR but the variation should look like this:
Example `Products List` variation
```
{
	name: 'products-list',
	title: __( 'Products List' ),
	description: __( 'Display a list of your products.' ),
	attributes: {
		query: {
			perPage: 4,
			pages: 1,
			offset: 0,
			postType: 'product',
			order: 'desc',
			orderBy: 'date',
			author: '',
			search: '',
			sticky: 'exclude',
			inherit: false,
		},
		namespace: 'wp/query/products',
	},
	allowedControls: [ 'order', 'taxQuery', 'search' ],
	isActive: ( blockAttributes, variationAttributes ) =>
		blockAttributes?.namespace === variationAttributes.namespace,
	scope: [ 'inserter' ],
},
```

The only change is the rename of `allowControls` to `allowedControls`

## Screenshots or screencast <!-- if applicable -->
