### PR TITLE
Navigation: Fix semitransparent burger icon.

### DIFF
--- a/packages/block-library/src/navigation/editor.scss
+++ b/packages/block-library/src/navigation/editor.scss
@@ -629,3 +629,9 @@ body.editor-styles-wrapper
 	margin-bottom: $grid-unit-20;
 	width: 100%;
 }
+
+// Buttons inside a disabled component get semitransparent when there's a clickthrough overlay.
+// Since this navigation button is content rather than UI, however, override that.
+.wp-block-navigation__responsive-container-open.components-button {
+	opacity: 1;
+}


### PR DESCRIPTION
## What?

Buttons inside a `Disabled` component are semitransparent. That means a navigation burger menu inside a header template part with clickthrough overlay looks disabled:

<img width="882" alt="disabled" src="https://user-images.githubusercontent.com/1204802/192741664-c0f7d01a-743f-4cf0-814a-abc6ddd1c4f5.png">

The rule is meant for block UI, not for content. This PR adds full opacity to the burger menu as a result:

<img width="898" alt="after" src="https://user-images.githubusercontent.com/1204802/192741855-62da7dcc-aabb-4d01-bb2c-385e65eabdf2.png">

## Testing Instructions

Test a block theme with a header template part that features navigation. Ensure the navigation collapses to a menu always. Observe full opacity for the burger icon, whether selected or not.