### PR TITLE
PHP 8.2 | Fix for partially supported callback

### DIFF
--- a/lib/experimental/html/class-wp-html-tag-processor.php
+++ b/lib/experimental/html/class-wp-html-tag-processor.php
@@ -847,7 +847,7 @@ class WP_HTML_Tag_Processor {
 		 * out of order, which could otherwise lead to mangled output,
 		 * partially-duplicate attributes, and overwritten attributes.
 		 */
-		usort( $this->attribute_updates, array( 'self', 'sort_start_ascending' ) );
+		usort( $this->attribute_updates, array( self::class, 'sort_start_ascending' ) );
 
 		foreach ( $this->attribute_updates as $diff ) {
 			$this->updated_html .= substr( $this->html, $this->updated_bytes, $diff->start - $this->updated_bytes );


### PR DESCRIPTION
## What?
`array( 'self', 'method_name' )`-like callbacks are only partially supported by PHP. With this mind, they will be deprecated in PHP 8.2, with support being completely removed in PHP 9.0.

Fixed by changing it to a fully supported syntax.

Refs:
* https://wiki.php.net/rfc/deprecate_partially_supported_callables


## Why?
Because code should be cross-version compatible with all supported PHP versions, including the upcoming PHP 8.2.
