### PR TITLE
PHP 8.2 | Fix deprecated embedded variables in text strings

### DIFF
--- a/lib/compat/wordpress-6.1/class-wp-theme-json-6-1.php
+++ b/lib/compat/wordpress-6.1/class-wp-theme-json-6-1.php
@@ -1060,7 +1060,7 @@ class WP_Theme_JSON_6_1 extends WP_Theme_JSON_6_0 {
 			if ( is_array( $ref_value ) && array_key_exists( 'ref', $ref_value ) ) {
 				$path_string      = json_encode( $path );
 				$ref_value_string = json_encode( $ref_value );
-				_doing_it_wrong( 'get_property_value', "Your theme.json file uses a dynamic value (${ref_value_string}) for the path at ${path_string}. However, the value at ${path_string} is also a dynamic value (pointing to ${ref_value['ref']}) and pointing to another dynamic value is not supported. Please update ${path_string} to point directly to ${ref_value['ref']}.", '6.1.0' );
+				_doing_it_wrong( 'get_property_value', "Your theme.json file uses a dynamic value ({$ref_value_string}) for the path at {$path_string}. However, the value at {$path_string} is also a dynamic value (pointing to {$ref_value['ref']}) and pointing to another dynamic value is not supported. Please update {$path_string} to point directly to {$ref_value['ref']}.", '6.1.0' );
 			}
 		}
 


### PR DESCRIPTION
## What?
PHP 8.2 will deprecate two of the four currently supported syntaxes for embedding variables in double quoted text string/heredocs.

This library contains six uses of embedded variables using braces after the dollar sign (`"${foo}"`), which is one of the deprecated forms.

This commit fixes all six.

Refs:
* https://wiki.php.net/rfc/deprecate_dollar_brace_string_interpolation


## Why?
Because code should be cross-version compatible with all supported PHP versions, including the upcoming PHP 8.2.
