### PR TITLE
PHPCS: use PHPCompatibilityWP

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -28,7 +28,7 @@
 	"require-dev": {
 		"dealerdirect/phpcodesniffer-composer-installer": "^0.7",
 		"squizlabs/php_codesniffer": "^3.5",
-		"phpcompatibility/php-compatibility": "^9.3",
+		"phpcompatibility/phpcompatibility-wp": "^2.1.3",
 		"wp-coding-standards/wpcs": "^2.2",
 		"sirbrillig/phpcs-variable-analysis": "^2.8",
 		"spatie/phpunit-watcher": "^1.23",

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -2,8 +2,10 @@
 <ruleset name="WordPress Coding Standards for Gutenberg Plugin">
 	<description>Sniffs for WordPress plugins, with minor modifications for Gutenberg</description>
 
-	<rule ref="PHPCompatibility"/>
 	<config name="testVersion" value="5.6-"/>
+	<rule ref="PHPCompatibilityWP">
+		<include-pattern>*\.php$</include-pattern>
+	</rule>
 
 	<rule ref="WordPress-Core"/>
 	<rule ref="WordPress-Docs"/>


### PR DESCRIPTION
## What & Why ?
The current PHPCS ruleset `phpcs.xml.dist` uses the `PHPCompatibility` ruleset to flag code which could be incompatible with the supported PHP versions.

For code used in the context of WordPress, a dedicated [`PHPCompatibilityWP`](https://github.com/PHPCompatibility/PHPCompatibilityWP) ruleset is available to prevent PHPCompatibility flagging code for which WordPress prevents polyfills.

Fixes #44541

