### PR TITLE
CS: all methods must declare visibility

### DIFF
--- a/packages/block-serialization-default-parser/parser.php
+++ b/packages/block-serialization-default-parser/parser.php
@@ -80,7 +80,7 @@ class WP_Block_Parser_Block {
 	 * @param string $innerHTML    Resultant HTML from inside block comment delimiters after removing inner blocks.
 	 * @param array  $innerContent List of string fragments and null markers where inner blocks were found.
 	 */
-	function __construct( $name, $attrs, $innerBlocks, $innerHTML, $innerContent ) {
+	public function __construct( $name, $attrs, $innerBlocks, $innerHTML, $innerContent ) {
 		$this->blockName    = $name;
 		$this->attrs        = $attrs;
 		$this->innerBlocks  = $innerBlocks;
@@ -152,7 +152,7 @@ class WP_Block_Parser_Frame {
 	 * @param int                   $prev_offset        Byte offset into document for after parse token ends.
 	 * @param int                   $leading_html_start Byte offset into document where leading HTML before token starts.
 	 */
-	function __construct( $block, $token_start, $token_length, $prev_offset = null, $leading_html_start = null ) {
+	public function __construct( $block, $token_start, $token_length, $prev_offset = null, $leading_html_start = null ) {
 		$this->block              = $block;
 		$this->token_start        = $token_start;
 		$this->token_length       = $token_length;
@@ -224,7 +224,7 @@ class WP_Block_Parser {
 	 * @param string $document Input document being parsed.
 	 * @return array[]
 	 */
-	function parse( $document ) {
+	public function parse( $document ) {
 		$this->document    = $document;
 		$this->offset      = 0;
 		$this->output      = array();
@@ -252,7 +252,7 @@ class WP_Block_Parser {
 	 * @since 5.0.0
 	 * @return bool
 	 */
-	function proceed() {
+	public function proceed() {
 		$next_token = $this->next_token();
 		list( $token_type, $block_name, $attrs, $start_offset, $token_length ) = $next_token;
 		$stack_depth = count( $this->stack );
@@ -398,7 +398,7 @@ class WP_Block_Parser {
 	 * @since 4.6.1 fixed a bug in attribute parsing which caused catastrophic backtracking on invalid block comments
 	 * @return array
 	 */
-	function next_token() {
+	public function next_token() {
 		$matches = null;
 
 		/*
@@ -473,7 +473,7 @@ class WP_Block_Parser {
 	 * @param string $innerHTML HTML content of block.
 	 * @return WP_Block_Parser_Block freeform block object.
 	 */
-	function freeform( $innerHTML ) {
+	public function freeform( $innerHTML ) {
 		return new WP_Block_Parser_Block( null, $this->empty_attrs, array(), $innerHTML, array( $innerHTML ) );
 	}
 
@@ -485,7 +485,7 @@ class WP_Block_Parser {
 	 * @since 5.0.0
 	 * @param null $length how many bytes of document text to output.
 	 */
-	function add_freeform( $length = null ) {
+	public function add_freeform( $length = null ) {
 		$length = $length ? $length : strlen( $this->document ) - $this->offset;
 
 		if ( 0 === $length ) {
@@ -506,7 +506,7 @@ class WP_Block_Parser {
 	 * @param int                   $token_length Byte length of entire block from start of opening token to end of closing token.
 	 * @param int|null              $last_offset  Last byte offset into document if continuing form earlier output.
 	 */
-	function add_inner_block( WP_Block_Parser_Block $block, $token_start, $token_length, $last_offset = null ) {
+	public function add_inner_block( WP_Block_Parser_Block $block, $token_start, $token_length, $last_offset = null ) {
 		$parent                       = $this->stack[ count( $this->stack ) - 1 ];
 		$parent->block->innerBlocks[] = (array) $block;
 		$html                         = substr( $this->document, $parent->prev_offset, $token_start - $parent->prev_offset );
@@ -527,7 +527,7 @@ class WP_Block_Parser {
 	 * @since 5.0.0
 	 * @param int|null $end_offset byte offset into document for where we should stop sending text output as HTML.
 	 */
-	function add_block_from_stack( $end_offset = null ) {
+	public function add_block_from_stack( $end_offset = null ) {
 		$stack_top   = array_pop( $this->stack );
 		$prev_offset = $stack_top->prev_offset;
 

--- a/packages/e2e-tests/plugins/class-test-widget.php
+++ b/packages/e2e-tests/plugins/class-test-widget.php
@@ -14,7 +14,7 @@ class Test_Widget extends WP_Widget {
 	/**
 	 * Sets up a new test widget instance.
 	 */
-	function __construct() {
+	public function __construct() {
 		parent::__construct(
 			'test_widget',
 			'Test Widget',

--- a/phpunit/block-supports/border-test.php
+++ b/phpunit/block-supports/border-test.php
@@ -12,12 +12,12 @@ class WP_Block_Supports_Border_Test extends WP_UnitTestCase {
 	 */
 	private $test_block_name;
 
-	function set_up() {
+	public function set_up() {
 		parent::set_up();
 		$this->test_block_name = null;
 	}
 
-	function tear_down() {
+	public function tear_down() {
 		unregister_block_type( $this->test_block_name );
 		$this->test_block_name = null;
 		parent::tear_down();
@@ -53,7 +53,7 @@ class WP_Block_Supports_Border_Test extends WP_UnitTestCase {
 		return $registry->get_registered( $this->test_block_name );
 	}
 
-	function test_border_object_with_no_styles() {
+	public function test_border_object_with_no_styles() {
 		$block_type  = self::register_bordered_block_with_support(
 			'test/border-object-with-no-styles',
 			array(
@@ -72,7 +72,7 @@ class WP_Block_Supports_Border_Test extends WP_UnitTestCase {
 		$this->assertSame( $expected, $actual );
 	}
 
-	function test_border_object_with_invalid_style_prop() {
+	public function test_border_object_with_invalid_style_prop() {
 		$block_type  = self::register_bordered_block_with_support(
 			'test/border-object-with-invalid-style-prop',
 			array(
@@ -91,7 +91,7 @@ class WP_Block_Supports_Border_Test extends WP_UnitTestCase {
 		$this->assertSame( $expected, $actual );
 	}
 
-	function test_border_color_slug_with_numbers_is_kebab_cased_properly() {
+	public function test_border_color_slug_with_numbers_is_kebab_cased_properly() {
 		$block_type = self::register_bordered_block_with_support(
 			'test/border-color-slug-with-numbers-is-kebab-cased-properly',
 			array(
@@ -123,7 +123,7 @@ class WP_Block_Supports_Border_Test extends WP_UnitTestCase {
 		$this->assertSame( $expected, $actual );
 	}
 
-	function test_flat_border_with_skipped_serialization() {
+	public function test_flat_border_with_skipped_serialization() {
 		$block_type = self::register_bordered_block_with_support(
 			'test/flat-border-with-skipped-serialization',
 			array(
@@ -153,7 +153,7 @@ class WP_Block_Supports_Border_Test extends WP_UnitTestCase {
 		$this->assertSame( $expected, $actual );
 	}
 
-	function test_flat_border_with_individual_skipped_serialization() {
+	public function test_flat_border_with_individual_skipped_serialization() {
 		$block_type = self::register_bordered_block_with_support(
 			'test/flat-border-with-individual-skipped-serialization',
 			array(
@@ -185,7 +185,7 @@ class WP_Block_Supports_Border_Test extends WP_UnitTestCase {
 		$this->assertSame( $expected, $actual );
 	}
 
-	function test_split_border_radius() {
+	public function test_split_border_radius() {
 		$block_type  = self::register_bordered_block_with_support(
 			'test/split-border-radius',
 			array(
@@ -214,7 +214,7 @@ class WP_Block_Supports_Border_Test extends WP_UnitTestCase {
 		$this->assertSame( $expected, $actual );
 	}
 
-	function test_flat_border_with_custom_color() {
+	public function test_flat_border_with_custom_color() {
 		$block_type  = self::register_bordered_block_with_support(
 			'test/flat-border-with-custom-color',
 			array(
@@ -243,7 +243,7 @@ class WP_Block_Supports_Border_Test extends WP_UnitTestCase {
 		$this->assertSame( $expected, $actual );
 	}
 
-	function test_split_borders_with_custom_colors() {
+	public function test_split_borders_with_custom_colors() {
 		$block_type  = self::register_bordered_block_with_support(
 			'test/split-borders-with-custom-colors',
 			array(
@@ -288,7 +288,7 @@ class WP_Block_Supports_Border_Test extends WP_UnitTestCase {
 		$this->assertSame( $expected, $actual );
 	}
 
-	function test_split_borders_with_skipped_serialization() {
+	public function test_split_borders_with_skipped_serialization() {
 		$block_type  = self::register_bordered_block_with_support(
 			'test/split-borders-with-skipped-serialization',
 			array(
@@ -332,7 +332,7 @@ class WP_Block_Supports_Border_Test extends WP_UnitTestCase {
 		$this->assertSame( $expected, $actual );
 	}
 
-	function test_split_borders_with_skipped_individual_feature_serialization() {
+	public function test_split_borders_with_skipped_individual_feature_serialization() {
 		$block_type  = self::register_bordered_block_with_support(
 			'test/split-borders-with-skipped-individual-feature-serialization',
 			array(
@@ -378,7 +378,7 @@ class WP_Block_Supports_Border_Test extends WP_UnitTestCase {
 		$this->assertSame( $expected, $actual );
 	}
 
-	function test_partial_split_borders() {
+	public function test_partial_split_borders() {
 		$block_type  = self::register_bordered_block_with_support(
 			'test/partial-split-borders',
 			array(
@@ -415,7 +415,7 @@ class WP_Block_Supports_Border_Test extends WP_UnitTestCase {
 		$this->assertSame( $expected, $actual );
 	}
 
-	function test_split_borders_with_named_colors() {
+	public function test_split_borders_with_named_colors() {
 		$block_type  = self::register_bordered_block_with_support(
 			'test/split-borders-with-named-colors',
 			array(

--- a/phpunit/block-supports/colors-test.php
+++ b/phpunit/block-supports/colors-test.php
@@ -12,18 +12,18 @@ class WP_Block_Supports_Colors_Test extends WP_UnitTestCase {
 	 */
 	private $test_block_name;
 
-	function set_up() {
+	public function set_up() {
 		parent::set_up();
 		$this->test_block_name = null;
 	}
 
-	function tear_down() {
+	public function tear_down() {
 		unregister_block_type( $this->test_block_name );
 		$this->test_block_name = null;
 		parent::tear_down();
 	}
 
-	function test_color_slugs_with_numbers_are_kebab_cased_properly() {
+	public function test_color_slugs_with_numbers_are_kebab_cased_properly() {
 		$this->test_block_name = 'test/color-slug-with-numbers';
 		register_block_type(
 			$this->test_block_name,
@@ -64,7 +64,7 @@ class WP_Block_Supports_Colors_Test extends WP_UnitTestCase {
 		$this->assertSame( $expected, $actual );
 	}
 
-	function test_color_with_skipped_serialization_block_supports() {
+	public function test_color_with_skipped_serialization_block_supports() {
 		$this->test_block_name = 'test/color-with-skipped-serialization-block-supports';
 		register_block_type(
 			$this->test_block_name,
@@ -102,7 +102,7 @@ class WP_Block_Supports_Colors_Test extends WP_UnitTestCase {
 		$this->assertSame( $expected, $actual );
 	}
 
-	function test_gradient_with_individual_skipped_serialization_block_supports() {
+	public function test_gradient_with_individual_skipped_serialization_block_supports() {
 		$this->test_block_name = 'test/gradient-with-individual-skipped-serialization-block-support';
 		register_block_type(
 			$this->test_block_name,

--- a/phpunit/block-supports/layout-test.php
+++ b/phpunit/block-supports/layout-test.php
@@ -7,7 +7,7 @@
  */
 
 class WP_Block_Supports_Layout_Test extends WP_UnitTestCase {
-	function set_up() {
+	public function set_up() {
 		parent::set_up();
 		$this->theme_root     = realpath( __DIR__ . '/../data/themedir1' );
 		$this->orig_theme_dir = $GLOBALS['wp_theme_directories'];
@@ -24,7 +24,7 @@ class WP_Block_Supports_Layout_Test extends WP_UnitTestCase {
 		unset( $GLOBALS['wp_themes'] );
 	}
 
-	function tear_down() {
+	public function tear_down() {
 		$GLOBALS['wp_theme_directories'] = $this->orig_theme_dir;
 		wp_clean_themes_cache();
 		unset( $GLOBALS['wp_themes'] );
@@ -32,11 +32,11 @@ class WP_Block_Supports_Layout_Test extends WP_UnitTestCase {
 		parent::tear_down();
 	}
 
-	function filter_set_theme_root() {
+	public function filter_set_theme_root() {
 		return $this->theme_root;
 	}
 
-	function test_outer_container_not_restored_for_non_aligned_image_block_with_non_themejson_theme() {
+	public function test_outer_container_not_restored_for_non_aligned_image_block_with_non_themejson_theme() {
 		// The "default" theme doesn't have theme.json support.
 		switch_theme( 'default' );
 		$block         = array(
@@ -49,7 +49,7 @@ class WP_Block_Supports_Layout_Test extends WP_UnitTestCase {
 		$this->assertSame( $expected, gutenberg_restore_image_outer_container( $block_content, $block ) );
 	}
 
-	function test_outer_container_restored_for_aligned_image_block_with_non_themejson_theme() {
+	public function test_outer_container_restored_for_aligned_image_block_with_non_themejson_theme() {
 		// The "default" theme doesn't have theme.json support.
 		switch_theme( 'default' );
 		$block         = array(
@@ -62,7 +62,7 @@ class WP_Block_Supports_Layout_Test extends WP_UnitTestCase {
 		$this->assertSame( $expected, gutenberg_restore_image_outer_container( $block_content, $block ) );
 	}
 
-	function test_additional_styles_moved_to_restored_outer_container_for_aligned_image_block_with_non_themejson_theme() {
+	public function test_additional_styles_moved_to_restored_outer_container_for_aligned_image_block_with_non_themejson_theme() {
 		// The "default" theme doesn't have theme.json support.
 		switch_theme( 'default' );
 		$block = array(
@@ -89,7 +89,7 @@ class WP_Block_Supports_Layout_Test extends WP_UnitTestCase {
 		$this->assertSame( $expected_other_attributes, gutenberg_restore_image_outer_container( $block_classes_other_attributes, $block ) );
 	}
 
-	function test_outer_container_not_restored_for_aligned_image_block_with_themejson_theme() {
+	public function test_outer_container_not_restored_for_aligned_image_block_with_themejson_theme() {
 		switch_theme( 'block-theme' );
 		$block         = array(
 			'blockName' => 'core/image',
@@ -123,7 +123,7 @@ class WP_Block_Supports_Layout_Test extends WP_UnitTestCase {
 	 * }
 	 * @param string $expected_output The expected output.
 	 */
-	function test_gutenberg_get_layout_style( $args, $expected_output ) {
+	public function test_gutenberg_get_layout_style( $args, $expected_output ) {
 		$layout_styles = gutenberg_get_layout_style( $args['selector'], $args['layout'], $args['has_block_gap_support'], $args['gap_value'], $args['should_skip_gap_serialization'], $args['fallback_gap_value'], $args['block_spacing'] );
 		$this->assertSame( $expected_output, $layout_styles );
 	}

--- a/phpunit/block-supports/spacing-test.php
+++ b/phpunit/block-supports/spacing-test.php
@@ -12,18 +12,18 @@ class WP_Block_Supports_Spacing_Test extends WP_UnitTestCase {
 	 */
 	private $test_block_name;
 
-	function set_up() {
+	public function set_up() {
 		parent::set_up();
 		$this->test_block_name = null;
 	}
 
-	function tear_down() {
+	public function tear_down() {
 		unregister_block_type( $this->test_block_name );
 		$this->test_block_name = null;
 		parent::tear_down();
 	}
 
-	function test_spacing_style_is_applied() {
+	public function test_spacing_style_is_applied() {
 		$this->test_block_name = 'test/spacing-style-is-applied';
 		register_block_type(
 			$this->test_block_name,
@@ -68,7 +68,7 @@ class WP_Block_Supports_Spacing_Test extends WP_UnitTestCase {
 		$this->assertSame( $expected, $actual );
 	}
 
-	function test_spacing_with_skipped_serialization_block_supports() {
+	public function test_spacing_with_skipped_serialization_block_supports() {
 		$this->test_block_name = 'test/spacing-with-skipped-serialization-block-supports';
 		register_block_type(
 			$this->test_block_name,
@@ -112,7 +112,7 @@ class WP_Block_Supports_Spacing_Test extends WP_UnitTestCase {
 		$this->assertSame( $expected, $actual );
 	}
 
-	function test_margin_with_individual_skipped_serialization_block_supports() {
+	public function test_margin_with_individual_skipped_serialization_block_supports() {
 		$this->test_block_name = 'test/margin-with-individual-skipped-serialization-block-supports';
 		register_block_type(
 			$this->test_block_name,

--- a/phpunit/block-supports/typography-test.php
+++ b/phpunit/block-supports/typography-test.php
@@ -15,7 +15,7 @@ class WP_Block_Supports_Typography_Test extends WP_UnitTestCase {
 	/**
 	 * Sets up tests.
 	 */
-	function set_up() {
+	public function set_up() {
 		parent::set_up();
 		$this->test_block_name = null;
 	}
@@ -23,7 +23,7 @@ class WP_Block_Supports_Typography_Test extends WP_UnitTestCase {
 	/**
 	 * Tears down tests.
 	 */
-	function tear_down() {
+	public function tear_down() {
 		unregister_block_type( $this->test_block_name );
 		$this->test_block_name = null;
 		parent::tear_down();
@@ -34,7 +34,7 @@ class WP_Block_Supports_Typography_Test extends WP_UnitTestCase {
 	 *
 	 * @covers ::wp_apply_typography_support
 	 */
-	function test_should_kebab_case_font_size_slug_with_numbers() {
+	public function test_should_kebab_case_font_size_slug_with_numbers() {
 		$this->test_block_name = 'test/font-size-slug-with-numbers';
 		register_block_type(
 			$this->test_block_name,
@@ -68,7 +68,7 @@ class WP_Block_Supports_Typography_Test extends WP_UnitTestCase {
 	 *
 	 * @covers ::wp_apply_typography_support
 	 */
-	function test_should_generate_font_family_with_legacy_inline_styles_using_a_value() {
+	public function test_should_generate_font_family_with_legacy_inline_styles_using_a_value() {
 		$this->test_block_name = 'test/font-family-with-inline-styles-using-value';
 		register_block_type(
 			$this->test_block_name,
@@ -101,7 +101,7 @@ class WP_Block_Supports_Typography_Test extends WP_UnitTestCase {
 	 *
 	 * @covers ::wp_apply_typography_support
 	 */
-	function test_should_skip_serialization_for_typography_block_supports() {
+	public function test_should_skip_serialization_for_typography_block_supports() {
 		$this->test_block_name = 'test/typography-with-skipped-serialization-block-supports';
 		register_block_type(
 			$this->test_block_name,
@@ -147,7 +147,7 @@ class WP_Block_Supports_Typography_Test extends WP_UnitTestCase {
 	 *
 	 * @covers ::wp_apply_typography_support
 	 */
-	function test_should_skip_serialization_for_letter_spacing_block_supports() {
+	public function test_should_skip_serialization_for_letter_spacing_block_supports() {
 		$this->test_block_name = 'test/letter-spacing-with-individual-skipped-serialization-block-supports';
 		register_block_type(
 			$this->test_block_name,
@@ -183,7 +183,7 @@ class WP_Block_Supports_Typography_Test extends WP_UnitTestCase {
 	 *
 	 * @covers ::wp_apply_typography_support
 	 */
-	function test_should_generate_css_var_for_font_family_with_legacy_inline_styles() {
+	public function test_should_generate_css_var_for_font_family_with_legacy_inline_styles() {
 		$this->test_block_name = 'test/font-family-with-inline-styles-using-css-var';
 		register_block_type(
 			$this->test_block_name,
@@ -216,7 +216,7 @@ class WP_Block_Supports_Typography_Test extends WP_UnitTestCase {
 	 *
 	 * @covers ::wp_apply_typography_support
 	 */
-	function test_should_generate_classname_for_font_family() {
+	public function test_should_generate_classname_for_font_family() {
 		$this->test_block_name = 'test/font-family-with-class';
 		register_block_type(
 			$this->test_block_name,
@@ -263,7 +263,7 @@ class WP_Block_Supports_Typography_Test extends WP_UnitTestCase {
 	 * @param bool   $should_use_fluid_typography An override to switch fluid typography "on". Can be used for unit testing.
 	 * @param string $expected_output Expected output of gutenberg_get_typography_font_size_value().
 	 */
-	function test_gutenberg_get_typography_font_size_value( $font_size_preset, $should_use_fluid_typography, $expected_output ) {
+	public function test_gutenberg_get_typography_font_size_value( $font_size_preset, $should_use_fluid_typography, $expected_output ) {
 		$actual = gutenberg_get_typography_font_size_value( $font_size_preset, $should_use_fluid_typography );
 
 		$this->assertSame( $expected_output, $actual );

--- a/phpunit/class-block-context-test.php
+++ b/phpunit/class-block-context-test.php
@@ -66,7 +66,7 @@ class Block_Context_Test extends WP_UnitTestCase {
 	 * Tests that a block which provides context makes that context available to
 	 * its inner blocks.
 	 */
-	function test_provides_block_context() {
+	public function test_provides_block_context() {
 		$provided_context = array();
 
 		$this->register_block_type(
@@ -133,7 +133,7 @@ class Block_Context_Test extends WP_UnitTestCase {
 	 * Tests that a block can receive default-provided context through
 	 * render_block.
 	 */
-	function test_provides_default_context() {
+	public function test_provides_default_context() {
 		global $post;
 
 		$provided_context = array();
@@ -166,7 +166,7 @@ class Block_Context_Test extends WP_UnitTestCase {
 	/**
 	 * Tests that default block context can be filtered.
 	 */
-	function test_default_context_is_filterable() {
+	public function test_default_context_is_filterable() {
 		$provided_context = array();
 
 		$this->register_block_type(

--- a/phpunit/class-block-fixture-test.php
+++ b/phpunit/class-block-fixture-test.php
@@ -13,7 +13,7 @@ class Block_Fixture_Test extends WP_UnitTestCase {
 	 *
 	 * @dataProvider data_block_fixtures
 	 */
-	function test_kses_doesnt_change_fixtures( $block, $filename ) {
+	public function test_kses_doesnt_change_fixtures( $block, $filename ) {
 
 		// KSES doesn't allow data: URLs, so we need to replace any of them in fixtures.
 		$block = preg_replace( "/src=['\"]data:[^'\"]+['\"]/", 'src="https://wordpress.org/foo.jpg"', $block );
@@ -31,7 +31,7 @@ class Block_Fixture_Test extends WP_UnitTestCase {
 		$this->assertSame( $block, $kses_block, "Failed to match $filename" );
 	}
 
-	function data_block_fixtures() {
+	public function data_block_fixtures() {
 		$data = array();
 
 		foreach ( glob( gutenberg_dir_path() . 'test/integration/fixtures/blocks/*.serialized.html' ) as $path ) {

--- a/phpunit/class-block-library-navigation-link-test.php
+++ b/phpunit/class-block-library-navigation-link-test.php
@@ -109,7 +109,7 @@ class Block_Library_Navigation_Link_Test extends WP_UnitTestCase {
 		parent::tear_down();
 	}
 
-	function test_returns_link_when_post_is_published() {
+	public function test_returns_link_when_post_is_published() {
 		$page_id = self::$page->ID;
 
 		$parsed_blocks = parse_blocks(
@@ -131,7 +131,7 @@ class Block_Library_Navigation_Link_Test extends WP_UnitTestCase {
 		);
 	}
 
-	function test_returns_empty_when_label_is_missing() {
+	public function test_returns_empty_when_label_is_missing() {
 		$page_id = self::$page->ID;
 
 		$parsed_blocks = parse_blocks(
@@ -150,7 +150,7 @@ class Block_Library_Navigation_Link_Test extends WP_UnitTestCase {
 		);
 	}
 
-	function test_returns_empty_when_draft() {
+	public function test_returns_empty_when_draft() {
 		$page_id = self::$draft->ID;
 
 		$parsed_blocks = parse_blocks(
@@ -170,7 +170,7 @@ class Block_Library_Navigation_Link_Test extends WP_UnitTestCase {
 		);
 	}
 
-	function test_returns_link_for_category() {
+	public function test_returns_link_for_category() {
 		$category_id = self::$category->term_id;
 
 		$parsed_blocks = parse_blocks(
@@ -192,7 +192,7 @@ class Block_Library_Navigation_Link_Test extends WP_UnitTestCase {
 		);
 	}
 
-	function test_returns_link_for_plain_link() {
+	public function test_returns_link_for_plain_link() {
 		$parsed_blocks = parse_blocks(
 			'<!-- wp:navigation-link {"label":"My Website","url":"https://example.com"} /-->'
 		);
@@ -212,7 +212,7 @@ class Block_Library_Navigation_Link_Test extends WP_UnitTestCase {
 		);
 	}
 
-	function test_returns_empty_when_custom_post_type_draft() {
+	public function test_returns_empty_when_custom_post_type_draft() {
 		$page_id = self::$custom_draft->ID;
 
 		$parsed_blocks = parse_blocks(
@@ -232,7 +232,7 @@ class Block_Library_Navigation_Link_Test extends WP_UnitTestCase {
 		);
 	}
 
-	function test_returns_link_when_custom_post_is_published() {
+	public function test_returns_link_when_custom_post_is_published() {
 		$page_id = self::$custom_post->ID;
 
 		$parsed_blocks = parse_blocks(

--- a/phpunit/class-override-script-test.php
+++ b/phpunit/class-override-script-test.php
@@ -6,7 +6,7 @@
  */
 
 class Override_Script_Test extends WP_UnitTestCase {
-	function set_up() {
+	public function set_up() {
 		parent::set_up();
 
 		wp_register_script(
@@ -18,7 +18,7 @@ class Override_Script_Test extends WP_UnitTestCase {
 		);
 	}
 
-	function tear_down() {
+	public function tear_down() {
 		parent::tear_down();
 
 		wp_deregister_script( 'gutenberg-dummy-script' );
@@ -27,7 +27,7 @@ class Override_Script_Test extends WP_UnitTestCase {
 	/**
 	 * Tests that script is localized.
 	 */
-	function test_localizes_script() {
+	public function test_localizes_script() {
 		global $wp_scripts;
 
 		gutenberg_override_script(
@@ -46,7 +46,7 @@ class Override_Script_Test extends WP_UnitTestCase {
 	/**
 	 * Tests that script properties are overridden.
 	 */
-	function test_replaces_registered_properties() {
+	public function test_replaces_registered_properties() {
 		global $wp_scripts;
 
 		gutenberg_override_script(
@@ -68,7 +68,7 @@ class Override_Script_Test extends WP_UnitTestCase {
 	/**
 	 * Tests that new script registers normally if no handle by the name.
 	 */
-	function test_registers_new_script() {
+	public function test_registers_new_script() {
 		global $wp_scripts;
 
 		gutenberg_override_script(

--- a/phpunit/class-phpunit-environment-setup-test.php
+++ b/phpunit/class-phpunit-environment-setup-test.php
@@ -12,7 +12,7 @@ class Phpunit_Environment_Setup_Test extends WP_UnitTestCase {
 	 * added to wp-config by the setup code. We need to know when tests are not
 	 * actually running in a multisite environment when they should be.
 	 */
-	function test_is_multisite_if_defined() {
+	public function test_is_multisite_if_defined() {
 		$is_multisite_in_env = ( '1' === getenv( 'WP_MULTISITE' ) );
 
 		$this->assertEquals( $is_multisite_in_env, is_multisite(), 'Despite WP_MULTISITE being set in the environment, the tests were not run in multisite mode. There is likely an issue with the phpunit setup.' );

--- a/phpunit/class-wp-theme-json-resolver-test.php
+++ b/phpunit/class-wp-theme-json-resolver-test.php
@@ -8,7 +8,7 @@
 
 class WP_Theme_JSON_Resolver_Gutenberg_Test extends WP_UnitTestCase {
 
-	function set_up() {
+	public function set_up() {
 		parent::set_up();
 		$this->theme_root = realpath( __DIR__ . '/data/themedir1' );
 
@@ -26,29 +26,29 @@ class WP_Theme_JSON_Resolver_Gutenberg_Test extends WP_UnitTestCase {
 		unset( $GLOBALS['wp_themes'] );
 	}
 
-	function tear_down() {
+	public function tear_down() {
 		$GLOBALS['wp_theme_directories'] = $this->orig_theme_dir;
 		wp_clean_themes_cache();
 		unset( $GLOBALS['wp_themes'] );
 		parent::tear_down();
 	}
 
-	function filter_set_theme_root() {
+	public function filter_set_theme_root() {
 		return $this->theme_root;
 	}
 
-	function filter_set_locale_to_polish() {
+	public function filter_set_locale_to_polish() {
 		return 'pl_PL';
 	}
 
-	function filter_db_query( $query ) {
+	public function filter_db_query( $query ) {
 		if ( preg_match( '#post_type = \'wp_global_styles\'#', $query ) ) {
 			$this->queries[] = $query;
 		}
 		return $query;
 	}
 
-	function test_translations_are_applied() {
+	public function test_translations_are_applied() {
 		add_filter( 'locale', array( $this, 'filter_set_locale_to_polish' ) );
 		load_textdomain( 'block-theme', realpath( __DIR__ . '/data/languages/themes/block-theme-pl_PL.mo' ) );
 
@@ -125,7 +125,7 @@ class WP_Theme_JSON_Resolver_Gutenberg_Test extends WP_UnitTestCase {
 		);
 	}
 
-	function test_switching_themes_recalculates_data() {
+	public function test_switching_themes_recalculates_data() {
 		// The "default" theme doesn't have theme.json support.
 		switch_theme( 'default' );
 		$default = WP_Theme_JSON_Resolver_Gutenberg::theme_has_support();
@@ -138,7 +138,7 @@ class WP_Theme_JSON_Resolver_Gutenberg_Test extends WP_UnitTestCase {
 		$this->assertTrue( $has_theme_json_support );
 	}
 
-	function test_add_theme_supports_are_loaded_for_themes_without_theme_json() {
+	public function test_add_theme_supports_are_loaded_for_themes_without_theme_json() {
 		switch_theme( 'default' );
 		$color_palette = array(
 			array(
@@ -182,7 +182,7 @@ class WP_Theme_JSON_Resolver_Gutenberg_Test extends WP_UnitTestCase {
 		ksort( $array );
 	}
 
-	function test_merges_child_theme_json_into_parent_theme_json() {
+	public function test_merges_child_theme_json_into_parent_theme_json() {
 		switch_theme( 'block-theme-child' );
 
 		$actual_settings   = WP_Theme_JSON_Resolver_Gutenberg::get_theme_data()->get_settings();
@@ -268,7 +268,7 @@ class WP_Theme_JSON_Resolver_Gutenberg_Test extends WP_UnitTestCase {
 		);
 	}
 
-	function test_get_user_data_from_wp_global_styles_does_not_use_uncached_queries() {
+	public function test_get_user_data_from_wp_global_styles_does_not_use_uncached_queries() {
 		add_filter( 'query', array( $this, 'filter_db_query' ) );
 		$query_count = count( $this->queries );
 		for ( $i = 0; $i < 3; $i++ ) {

--- a/phpunit/class-wp-theme-json-test.php
+++ b/phpunit/class-wp-theme-json-test.php
@@ -432,7 +432,7 @@ class WP_Theme_JSON_Gutenberg_Test extends WP_UnitTestCase {
 		$this->assertEquals( $variables, $theme_json->get_stylesheet( array( 'variables' ) ) );
 	}
 
-	function test_get_stylesheet_handles_whitelisted_element_pseudo_selectors() {
+	public function test_get_stylesheet_handles_whitelisted_element_pseudo_selectors() {
 		$theme_json = new WP_Theme_JSON_Gutenberg(
 			array(
 				'version' => WP_Theme_JSON_Gutenberg::LATEST_SCHEMA,
@@ -475,7 +475,7 @@ class WP_Theme_JSON_Gutenberg_Test extends WP_UnitTestCase {
 		$this->assertEquals( $expected, $theme_json->get_stylesheet( array( 'styles' ) ) );
 	}
 
-	function test_get_stylesheet_handles_only_pseudo_selector_rules_for_given_property() {
+	public function test_get_stylesheet_handles_only_pseudo_selector_rules_for_given_property() {
 		$theme_json = new WP_Theme_JSON_Gutenberg(
 			array(
 				'version' => WP_Theme_JSON_Gutenberg::LATEST_SCHEMA,
@@ -514,7 +514,7 @@ class WP_Theme_JSON_Gutenberg_Test extends WP_UnitTestCase {
 		$this->assertEquals( $expected, $theme_json->get_stylesheet( array( 'styles' ) ) );
 	}
 
-	function test_get_stylesheet_ignores_pseudo_selectors_on_non_whitelisted_elements() {
+	public function test_get_stylesheet_ignores_pseudo_selectors_on_non_whitelisted_elements() {
 		$theme_json = new WP_Theme_JSON_Gutenberg(
 			array(
 				'version' => WP_Theme_JSON_Gutenberg::LATEST_SCHEMA,
@@ -553,7 +553,7 @@ class WP_Theme_JSON_Gutenberg_Test extends WP_UnitTestCase {
 		$this->assertEquals( $expected, $theme_json->get_stylesheet( array( 'styles' ) ) );
 	}
 
-	function test_get_stylesheet_ignores_non_whitelisted_pseudo_selectors() {
+	public function test_get_stylesheet_ignores_non_whitelisted_pseudo_selectors() {
 		$theme_json = new WP_Theme_JSON_Gutenberg(
 			array(
 				'version' => WP_Theme_JSON_Gutenberg::LATEST_SCHEMA,
@@ -593,7 +593,7 @@ class WP_Theme_JSON_Gutenberg_Test extends WP_UnitTestCase {
 		$this->assertStringNotContainsString( 'a:levitate{', $theme_json->get_stylesheet( array( 'styles' ) ) );
 	}
 
-	function test_get_stylesheet_handles_priority_of_elements_vs_block_elements_pseudo_selectors() {
+	public function test_get_stylesheet_handles_priority_of_elements_vs_block_elements_pseudo_selectors() {
 		$theme_json = new WP_Theme_JSON_Gutenberg(
 			array(
 				'version' => WP_Theme_JSON_Gutenberg::LATEST_SCHEMA,
@@ -640,7 +640,7 @@ class WP_Theme_JSON_Gutenberg_Test extends WP_UnitTestCase {
 		$this->assertEquals( $expected, $theme_json->get_stylesheet( array( 'styles' ) ) );
 	}
 
-	function test_get_stylesheet_handles_whitelisted_block_level_element_pseudo_selectors() {
+	public function test_get_stylesheet_handles_whitelisted_block_level_element_pseudo_selectors() {
 		$theme_json = new WP_Theme_JSON_Gutenberg(
 			array(
 				'version' => WP_Theme_JSON_Gutenberg::LATEST_SCHEMA,
@@ -695,7 +695,7 @@ class WP_Theme_JSON_Gutenberg_Test extends WP_UnitTestCase {
 	 * bootstrap. After a core block adopts feature level selectors we could
 	 * remove that filter and instead use the core block for the following test.
 	 */
-	function test_get_stylesheet_with_block_support_feature_level_selectors() {
+	public function test_get_stylesheet_with_block_support_feature_level_selectors() {
 		$theme_json = new WP_Theme_JSON_Gutenberg(
 			array(
 				'version'  => WP_Theme_JSON_Gutenberg::LATEST_SCHEMA,
@@ -748,7 +748,7 @@ class WP_Theme_JSON_Gutenberg_Test extends WP_UnitTestCase {
 		$this->assertEquals( $expected, $theme_json->get_stylesheet() );
 	}
 
-	function test_remove_invalid_element_pseudo_selectors() {
+	public function test_remove_invalid_element_pseudo_selectors() {
 		$actual = WP_Theme_JSON_Gutenberg::remove_insecure_properties(
 			array(
 				'version' => WP_Theme_JSON_Gutenberg::LATEST_SCHEMA,
@@ -795,14 +795,14 @@ class WP_Theme_JSON_Gutenberg_Test extends WP_UnitTestCase {
 		$this->assertEqualSetsWithIndex( $expected, $actual );
 	}
 
-	function test_get_element_class_name_button() {
+	public function test_get_element_class_name_button() {
 		$expected = 'wp-element-button';
 		$actual   = WP_Theme_JSON_Gutenberg::get_element_class_name( 'button' );
 
 		$this->assertEquals( $expected, $actual );
 	}
 
-	function test_get_element_class_name_invalid() {
+	public function test_get_element_class_name_invalid() {
 		$expected = '';
 		$actual   = WP_Theme_JSON_Gutenberg::get_element_class_name( 'unknown-element' );
 
@@ -813,7 +813,7 @@ class WP_Theme_JSON_Gutenberg_Test extends WP_UnitTestCase {
 	 * Testing that dynamic properties in theme.json return the value they reference, e.g.
 	 * array( 'ref' => 'styles.color.background' ) => "#ffffff".
 	 */
-	function test_get_property_value_valid() {
+	public function test_get_property_value_valid() {
 		$theme_json = new WP_Theme_JSON_Gutenberg(
 			array(
 				'version' => 2,
@@ -845,7 +845,7 @@ class WP_Theme_JSON_Gutenberg_Test extends WP_UnitTestCase {
 	 *
 	 * @expectedIncorrectUsage get_property_value
 	 */
-	function test_get_property_value_loop() {
+	public function test_get_property_value_loop() {
 		$theme_json = new WP_Theme_JSON_Gutenberg(
 			array(
 				'version' => 2,
@@ -876,7 +876,7 @@ class WP_Theme_JSON_Gutenberg_Test extends WP_UnitTestCase {
 	 *
 	 * @expectedIncorrectUsage get_property_value
 	 */
-	function test_get_property_value_recursion() {
+	public function test_get_property_value_recursion() {
 		$theme_json = new WP_Theme_JSON_Gutenberg(
 			array(
 				'version' => 2,
@@ -907,7 +907,7 @@ class WP_Theme_JSON_Gutenberg_Test extends WP_UnitTestCase {
 	 *
 	 * @expectedIncorrectUsage get_property_value
 	 */
-	function test_get_property_value_self() {
+	public function test_get_property_value_self() {
 		$theme_json = new WP_Theme_JSON_Gutenberg(
 			array(
 				'version' => 2,
@@ -929,7 +929,7 @@ class WP_Theme_JSON_Gutenberg_Test extends WP_UnitTestCase {
 	 *
 	 * @dataProvider data_generate_spacing_scale_fixtures
 	 */
-	function test_set_spacing_sizes( $spacing_scale, $expected_output ) {
+	public function test_set_spacing_sizes( $spacing_scale, $expected_output ) {
 		$theme_json = new WP_Theme_JSON_Gutenberg(
 			array(
 				'version'  => 2,
@@ -950,7 +950,7 @@ class WP_Theme_JSON_Gutenberg_Test extends WP_UnitTestCase {
 	 *
 	 * @return array
 	 */
-	function data_generate_spacing_scale_fixtures() {
+	public function data_generate_spacing_scale_fixtures() {
 		return array(
 			'one_step_spacing_scale' => array(
 				'spacingScale'    => array(
@@ -1192,7 +1192,7 @@ class WP_Theme_JSON_Gutenberg_Test extends WP_UnitTestCase {
 	 *
 	 * @return array
 	 */
-	function data_set_spacing_sizes_when_invalid() {
+	public function data_set_spacing_sizes_when_invalid() {
 		return array(
 
 			'invalid_spacing_scale_values_missing_operator' => array(
@@ -1251,7 +1251,7 @@ class WP_Theme_JSON_Gutenberg_Test extends WP_UnitTestCase {
 		);
 	}
 
-	function test_get_styles_for_block_with_padding_aware_alignments() {
+	public function test_get_styles_for_block_with_padding_aware_alignments() {
 		$theme_json = new WP_Theme_JSON_Gutenberg(
 			array(
 				'version'  => 2,
@@ -1284,7 +1284,7 @@ class WP_Theme_JSON_Gutenberg_Test extends WP_UnitTestCase {
 		$this->assertEquals( $expected, $root_rules . $style_rules );
 	}
 
-	function test_get_styles_for_block_without_padding_aware_alignments() {
+	public function test_get_styles_for_block_without_padding_aware_alignments() {
 		$theme_json = new WP_Theme_JSON_Gutenberg(
 			array(
 				'version' => 2,
@@ -1314,7 +1314,7 @@ class WP_Theme_JSON_Gutenberg_Test extends WP_UnitTestCase {
 		$this->assertEquals( $expected, $root_rules . $style_rules );
 	}
 
-	function test_get_styles_for_block_with_content_width() {
+	public function test_get_styles_for_block_with_content_width() {
 		$theme_json = new WP_Theme_JSON_Gutenberg(
 			array(
 				'version'  => 2,

--- a/phpunit/class-wp-webfonts-local-provider-test.php
+++ b/phpunit/class-wp-webfonts-local-provider-test.php
@@ -38,7 +38,7 @@ class WP_Webfonts_Provider_Local_Test extends WP_UnitTestCase {
 		unset( $GLOBALS['wp_themes'] );
 	}
 
-	function tear_down() {
+	public function tear_down() {
 		// Restore the original theme directory setup.
 		$GLOBALS['wp_theme_directories'] = $this->orig_theme_dir;
 		wp_clean_themes_cache();


### PR DESCRIPTION
## What?
Adds missing visibility modifiers to class methods.

## Why?
Visibility expresses whether a method is allowed to be used from outside of the class/from within child classes. It should always be expressly set to clarify intend of how the code should be used.


## How?
To not break BC, these have now all been set to `public`, but a careful review of the visibility for the (non-test) methods is recommended.