### PR TITLE
CS: remove redundant parentheses for include/require statements

### DIFF
--- a/lib/client-assets.php
+++ b/lib/client-assets.php
@@ -203,7 +203,7 @@ function gutenberg_register_packages_scripts( $scripts ) {
 		// Replace extension with `.asset.php` to find the generated dependencies file.
 		$asset_file   = substr( $path, 0, -( strlen( '.js' ) ) ) . '.asset.php';
 		$asset        = file_exists( $asset_file )
-			? require( $asset_file )
+			? require $asset_file
 			: null;
 		$dependencies = isset( $asset['dependencies'] ) ? $asset['dependencies'] : array();
 		$version      = isset( $asset['version'] ) ? $asset['version'] : $default_version;

--- a/lib/compat/wordpress-6.1/blocks.php
+++ b/lib/compat/wordpress-6.1/blocks.php
@@ -81,7 +81,7 @@ function gutenberg_block_type_metadata_view_script( $settings, $metadata ) {
 
 		// Replace suffix and extension with `.asset.php` to find the generated dependencies file.
 		$view_asset_file          = substr( $view_script_path, 0, -( strlen( '.js' ) ) ) . '.asset.php';
-		$view_asset               = file_exists( $view_asset_file ) ? require( $view_asset_file ) : null;
+		$view_asset               = file_exists( $view_asset_file ) ? require $view_asset_file : null;
 		$view_script_dependencies = isset( $view_asset['dependencies'] ) ? $view_asset['dependencies'] : array();
 		$view_script_version      = isset( $view_asset['version'] ) ? $view_asset['version'] : false;
 		$result                   = wp_register_script(


### PR DESCRIPTION
## What?
Remove redundant parentheses.

## Why?
`include[_once]` and `require[_once]` are language constructs, not function calls. The parentheses are not needed and not using them yields a micro-optimizaton of the code.

