### PR TITLE
Performance: remove unnecessary repeated function call

### DIFF
--- a/lib/experimental/html/class-wp-html-tag-processor.php
+++ b/lib/experimental/html/class-wp-html-tag-processor.php
@@ -761,7 +761,8 @@ class WP_HTML_Tag_Processor {
 		$modified = false;
 
 		// Remove unwanted classes by only copying the new ones.
-		while ( $at < strlen( $existing_class ) ) {
+		$existing_class_length = strlen( $existing_class );
+		while ( $at < $existing_class_length ) {
 			// Skip to the first non-whitespace character.
 			$ws_at     = $at;
 			$ws_length = strspn( $existing_class, " \t\f\r\n", $ws_at );


### PR DESCRIPTION
## Why?
The length of the `$existing_class` does not change within the loop, so it is completely redundant and inefficient to recalculate the length for every loop.

Along the same lines, the count of `$this->stack` will not change within the loop.

## How?
By making the function call once and saving the return value to a variable, we can avoid the unnecessary repeated function calls.
