### PR TITLE
QA: add missing early return statement

### DIFF
--- a/packages/block-serialization-default-parser/class-wp-block-parser.php
+++ b/packages/block-serialization-default-parser/class-wp-block-parser.php
@@ -286,6 +286,7 @@ class WP_Block_Parser {
 		 */
 		if ( $is_closer && ( $is_void || $has_attrs ) ) {
 			// we can ignore them since they don't hurt anything.
+			return array();
 		}
 
 		if ( $is_void ) {


### PR DESCRIPTION
## Why?
In contrast to the intention expressed in the comment in the code, the state was not being ignored as the function did not `return` within the `if` statement.

## How?
As the docblock indicates that the function should return an array, I've chosen to return an empty array for this event, but I can imagine that throwing a `RuntimeException` or returning with a more specific error state in the array may be more appropriate.

Consider this PR as flagging up the code error, but the final implementation needs to be decided by people more familiar with the code than me.
