### PR TITLE
QA: no control structures with empty body

### DIFF
--- a/lib/experimental/html/class-wp-html-tag-processor.php
+++ b/lib/experimental/html/class-wp-html-tag-processor.php
@@ -582,7 +582,7 @@ class WP_HTML_Tag_Processor {
 	 */
 	private function parse_tag_opener_attributes() {
 		while ( $this->parse_next_attribute() ) {
-			// Twiddle our thumbs...
+			continue;
 		}
 	}
 
@@ -593,7 +593,7 @@ class WP_HTML_Tag_Processor {
 	 */
 	private function skip_tag_closer_attributes() {
 		while ( $this->parse_next_attribute( 'tag-closer' ) ) {
-			// Twiddle our thumbs...
+			continue;
 		}
 	}
 

--- a/packages/block-serialization-default-parser/parser.php
+++ b/packages/block-serialization-default-parser/parser.php
@@ -231,9 +231,9 @@ class WP_Block_Parser {
 		$this->stack       = array();
 		$this->empty_attrs = json_decode( '{}', true );
 
-		do {
-			// twiddle our thumbs.
-		} while ( $this->proceed() );
+		while ( $this->proceed() ) {
+			continue;
+		}
 
 		return $this->output;
 	}


### PR DESCRIPTION
## Why?
A control structure with an empty body is often indicative of "missing code", i.e. code which should have been added, but was forgotten.

For this reason, empty bodies for a control structure are flagged when using `WordPress-Extra`.

## How?
For the control structures in this PR, the "body" part is not needed and PHP allows for that without issue (for select control structures). See: https://3v4l.org/ADFk5

