### PR TITLE
CS: use pre-increment instead of post-increment

### DIFF
--- a/lib/compat/wordpress-6.1/class-wp-theme-json-6-1.php
+++ b/lib/compat/wordpress-6.1/class-wp-theme-json-6-1.php
@@ -1323,7 +1323,7 @@ class WP_Theme_JSON_6_1 extends WP_Theme_JSON_6_0 {
 			}
 
 			if ( $below_midpoint_count < $steps_mid_point - 2 ) {
-				$x_small_count++;
+				++$x_small_count;
 			}
 
 			$slug -= 10;
@@ -1360,7 +1360,7 @@ class WP_Theme_JSON_6_1 extends WP_Theme_JSON_6_0 {
 			}
 
 			if ( $above_midpoint_count > 1 ) {
-				$x_large_count++;
+				++$x_large_count;
 			}
 
 			$slug += 10;

--- a/lib/experimental/html/class-wp-html-tag-processor.php
+++ b/lib/experimental/html/class-wp-html-tag-processor.php
@@ -262,7 +262,7 @@ class WP_HTML_Tag_Processor {
 			$this->parse_tag_opener_attributes();
 
 			if ( $this->matches() ) {
-				$already_found++;
+				++$already_found;
 			}
 
 			// Avoid copying the tag name string when possible.
@@ -341,7 +341,7 @@ class WP_HTML_Tag_Processor {
 			$at = $this->parsed_bytes;
 
 			if ( '>' === $html[ $at ] || '/' === $html[ $at ] ) {
-				$this->parsed_bytes++;
+				++$this->parsed_bytes;
 				return;
 			}
 		}
@@ -407,7 +407,7 @@ class WP_HTML_Tag_Processor {
 
 			if ( '/' === $html[ $at ] ) {
 				$is_closing = true;
-				$at++;
+				++$at;
 			} else {
 				$is_closing = false;
 			}
@@ -427,7 +427,7 @@ class WP_HTML_Tag_Processor {
 				( 'p' === $html[ $at + 4 ] || 'P' === $html[ $at + 4 ] ) &&
 				( 't' === $html[ $at + 5 ] || 'T' === $html[ $at + 5 ] )
 			) ) {
-				$at++;
+				++$at;
 				continue;
 			}
 
@@ -438,7 +438,7 @@ class WP_HTML_Tag_Processor {
 			$at += 6;
 			$c   = $html[ $at ];
 			if ( ' ' !== $c && "\t" !== $c && "\r" !== $c && "\n" !== $c && '/' !== $c && '>' !== $c ) {
-				$at++;
+				++$at;
 				continue;
 			}
 
@@ -457,12 +457,12 @@ class WP_HTML_Tag_Processor {
 				$this->skip_tag_closer_attributes();
 
 				if ( '>' === $html[ $this->parsed_bytes ] ) {
-					$this->parsed_bytes++;
+					++$this->parsed_bytes;
 					return;
 				}
 			}
 
-			$at++;
+			++$at;
 		}
 	}
 
@@ -497,7 +497,7 @@ class WP_HTML_Tag_Processor {
 			 */
 			$tag_name_prefix_length = strspn( $html, 'abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ', $at + 1 );
 			if ( $tag_name_prefix_length > 0 ) {
-				$at++;
+				++$at;
 				$this->tag_name_length    = $tag_name_prefix_length + strcspn( $html, " \t\f\r\n/>", $at + $tag_name_prefix_length );
 				$this->tag_name_starts_at = $at;
 				$this->parsed_bytes       = $at + $this->tag_name_length;
@@ -571,7 +571,7 @@ class WP_HTML_Tag_Processor {
 				continue;
 			}
 
-			$at++;
+			++$at;
 		}
 	}
 
@@ -629,7 +629,7 @@ class WP_HTML_Tag_Processor {
 
 		$has_value = '=' === $this->html[ $this->parsed_bytes ];
 		if ( $has_value ) {
-			$this->parsed_bytes++;
+			++$this->parsed_bytes;
 			$this->skip_whitespace();
 
 			switch ( $this->html[ $this->parsed_bytes ] ) {

--- a/packages/block-library/src/categories/index.php
+++ b/packages/block-library/src/categories/index.php
@@ -14,7 +14,7 @@
  */
 function render_block_core_categories( $attributes ) {
 	static $block_id = 0;
-	$block_id++;
+	++$block_id;
 
 	$args = array(
 		'echo'         => false,

--- a/packages/block-library/src/comment-reply-link/index.php
+++ b/packages/block-library/src/comment-reply-link/index.php
@@ -34,7 +34,7 @@ function render_block_core_comment_reply_link( $attributes, $content, $block ) {
 
 	// Compute comment's depth iterating over its ancestors.
 	while ( ! empty( $parent_id ) ) {
-		$depth++;
+		++$depth;
 		$parent_id = get_comment( $parent_id )->comment_parent;
 	}
 

--- a/packages/block-library/src/page-list/index.php
+++ b/packages/block-library/src/page-list/index.php
@@ -243,7 +243,7 @@ function block_core_page_list_nest_pages( $current_level, $children ) {
  */
 function render_block_core_page_list( $attributes, $content, $block ) {
 	static $block_id = 0;
-	$block_id++;
+	++$block_id;
 
 	$all_pages = get_pages(
 		array(


### PR DESCRIPTION
## What?
Use pre-increment instead of post-increment for stand-alone statements.

## Why?
“Pre” will in/decrement and then return, “post” will return and then in/decrement.

Using the “pre” version is slightly more performant and can prevent future bugs when code gets moved around.

