### PR TITLE
CS: always use parentheses when instantiating objects

### DIFF
--- a/packages/block-library/src/latest-posts/index.php
+++ b/packages/block-library/src/latest-posts/index.php
@@ -55,7 +55,7 @@ function render_block_core_latest_posts( $attributes ) {
 		$args['author'] = $attributes['selectedAuthor'];
 	}
 
-	$query        = new WP_Query;
+	$query        = new WP_Query();
 	$recent_posts = $query->query( $args );
 
 	if ( isset( $attributes['displayFeaturedImage'] ) && $attributes['displayFeaturedImage'] ) {

--- a/phpunit/navigation-page-test.php
+++ b/phpunit/navigation-page-test.php
@@ -83,7 +83,7 @@ class WP_Navigation_Page_Test extends WP_UnitTestCase {
 		$this->callback
 			->expects( $this->once() )
 			->method( 'preload_menus_rest_pre_dispatch_callback' )
-			->willReturn( new $response );
+			->willReturn( new $response() );
 
 		gutenberg_navigation_editor_preload_menus();
 


### PR DESCRIPTION
While not (yet) enforced, this is a rule for WordPress Core.
