### PR TITLE
CS/QA: various minor fixes

### DIFF
--- a/lib/block-supports/duotone.php
+++ b/lib/block-supports/duotone.php
@@ -83,10 +83,10 @@ function gutenberg_tinycolor_rgb_to_rgb( $rgb_color ) {
  */
 function gutenberg_tinycolor_hue_to_rgb( $p, $q, $t ) {
 	if ( $t < 0 ) {
-		$t += 1;
+		++$t;
 	}
 	if ( $t > 1 ) {
-		$t -= 1;
+		--$t;
 	}
 	if ( $t < 1 / 6 ) {
 		return $p + ( $q - $p ) * 6 * $t;

--- a/lib/compat/wordpress-6.1/persisted-preferences.php
+++ b/lib/compat/wordpress-6.1/persisted-preferences.php
@@ -72,7 +72,6 @@ function gutenberg_configure_persisted_preferences() {
 		),
 		'after'
 	);
-
 }
 
 add_action( 'admin_init', 'gutenberg_configure_persisted_preferences' );

--- a/lib/experimental/editor-settings.php
+++ b/lib/experimental/editor-settings.php
@@ -70,7 +70,6 @@ function gutenberg_initialize_editor( $editor_name, $editor_script_handle, $sett
 		'wp-blocks',
 		'wp.blocks.unstable__bootstrapServerSideBlockDefinitions(' . wp_json_encode( get_block_editor_server_block_settings() ) . ');'
 	);
-
 }
 
 /**

--- a/packages/block-library/src/comment-template/index.php
+++ b/packages/block-library/src/comment-template/index.php
@@ -70,7 +70,6 @@ function block_core_comment_template_render_comments( $comments, $block ) {
 	}
 
 	return $content;
-
 }
 
 /**

--- a/packages/block-library/src/comment-template/index.php
+++ b/packages/block-library/src/comment-template/index.php
@@ -50,13 +50,13 @@ function block_core_comment_template_render_comments( $comments, $block ) {
 		// comments.
 		if ( ! empty( $children ) && ! empty( $thread_comments ) ) {
 			if ( $comment_depth < $thread_comments_depth ) {
-				$comment_depth += 1;
+				++$comment_depth;
 				$inner_content  = block_core_comment_template_render_comments(
 					$children,
 					$block
 				);
 				$block_content .= sprintf( '<ol>%1$s</ol>', $inner_content );
-				$comment_depth -= 1;
+				--$comment_depth;
 			} else {
 				$inner_content  = block_core_comment_template_render_comments(
 					$children,

--- a/packages/block-library/src/cover/index.php
+++ b/packages/block-library/src/cover/index.php
@@ -25,7 +25,7 @@ function render_block_core_cover( $attributes, $content ) {
 		);
 
 		if ( isset( $attributes['focalPoint'] ) ) {
-			$object_position              = round( $attributes['focalPoint']['x'] * 100 ) . '%' . ' ' . round( $attributes['focalPoint']['y'] * 100 ) . '%';
+			$object_position              = round( $attributes['focalPoint']['x'] * 100 ) . '% ' . round( $attributes['focalPoint']['y'] * 100 ) . '%';
 			$attr['data-object-position'] = $object_position;
 			$attr['style']                = 'object-position: ' . $object_position;
 		}

--- a/packages/block-library/src/page-list/index.php
+++ b/packages/block-library/src/page-list/index.php
@@ -189,7 +189,7 @@ function block_core_page_list_render_nested_page_list( $open_submenus_on_click, 
 
 		if ( isset( $page['children'] ) && $is_navigation_child && $open_submenus_on_click ) {
 			$markup .= '<button aria-label="' . esc_attr( $aria_label ) . '" class="' . esc_attr( $navigation_child_content_class ) . ' wp-block-navigation-submenu__toggle" aria-expanded="false">' . esc_html( $title ) .
-			'</button>' . '<span class="wp-block-page-list__submenu-icon wp-block-navigation__submenu-icon"><svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" viewBox="0 0 12 12" fill="none" aria-hidden="true" focusable="false"><path d="M1.50002 4L6.00002 8L10.5 4" stroke-width="1.5"></path></svg></span>';
+			'</button><span class="wp-block-page-list__submenu-icon wp-block-navigation__submenu-icon"><svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" viewBox="0 0 12 12" fill="none" aria-hidden="true" focusable="false"><path d="M1.50002 4L6.00002 8L10.5 4" stroke-width="1.5"></path></svg></span>';
 		} else {
 			$markup .= '<a class="wp-block-pages-list__item__link' . esc_attr( $navigation_child_content_class ) . '" href="' . esc_url( $page['link'] ) . '"' . $aria_current . '>' . $title . '</a>';
 		}

--- a/phpunit/blocks/render-block-cover-test.php
+++ b/phpunit/blocks/render-block-cover-test.php
@@ -42,7 +42,6 @@ class Tests_Blocks_Render_Cover extends WP_UnitTestCase {
 		);
 
 		set_post_thumbnail( self::$post, self::$attachment_id );
-
 	}
 
 	/**
@@ -128,6 +127,5 @@ class Tests_Blocks_Render_Cover extends WP_UnitTestCase {
 		$this->assertStringContainsString( 'object-position', $rendered );
 		$this->assertStringNotContainsString( 'background-image', $rendered );
 		$this->assertStringNotContainsString( 'min-height', $rendered );
-
 	}
 }

--- a/phpunit/blocks/render-comments-test.php
+++ b/phpunit/blocks/render-comments-test.php
@@ -43,4 +43,4 @@ class Tests_Blocks_RenderComments extends WP_UnitTestCase {
 		$rendered = gutenberg_render_block_core_comments( $attributes, '', $block );
 		$this->assertEmpty( $rendered );
 	}
-};
+}

--- a/phpunit/blocks/render-last-posts-test.php
+++ b/phpunit/blocks/render-last-posts-test.php
@@ -40,7 +40,7 @@ class Tests_Blocks_RenderLastPosts extends WP_UnitTestCase {
 
 		$file = DIR_TESTDATA . '/images/canola.jpg';
 
-		for ( $i = 0; $i < 5; $i ++ ) {
+		for ( $i = 0; $i < 5; $i++ ) {
 			self::$posts[ $i ]          = $factory->post->create_and_get();
 			self::$attachment_ids[ $i ] = $factory->attachment->create_upload_object( $file, self::$posts[ $i ]->ID );
 			set_post_thumbnail( self::$posts[ $i ], self::$attachment_ids[ $i ] );

--- a/phpunit/html/wp-html-tag-processor-standalone-test.php
+++ b/phpunit/html/wp-html-tag-processor-standalone-test.php
@@ -204,7 +204,6 @@ class WP_HTML_Tag_Processor_Standalone_Test extends WP_UnitTestCase {
 			(string) $p,
 			'Calling __toString after removing the id attribute of the third tag returned different HTML than expected'
 		);
-
 	}
 
 	/**


### PR DESCRIPTION
## What?
Various small CS/QA fixes.

## Why?
To improve compatibility/mergability with WP Core.

## How?
* Minor whitespace fix.
    Removes a space in a place where there shouldn't be a space.
* Remove redundant blank lines at the end of functions.
* Remove redundant semi-colon.
    The semi-colon effectively created a new, empty PHP statement, where none was needed.
* Use in/decrementors where appropriate.
    Using in/decrementors is more performant than an assignment with a calculation.
* Remove redundant concatenation.
    Every concatenation exponentially increases the memory needed for the string in PHP, so this removes unnecessary concatenations, i.e. two hard-coded strings being concatenated.