### PR TITLE
Fix cover block text color heuristic for cross origin media

### DIFF
--- a/packages/block-library/src/cover/edit/index.js
+++ b/packages/block-library/src/cover/edit/index.js
@@ -131,13 +131,7 @@ function CoverEdit( {
 		createErrorNotice( message, { type: 'snackbar' } );
 	};
 
-	const mediaElement = useRef();
-	const isCoverDark = useCoverIsDark(
-		url,
-		dimRatio,
-		overlayColor.color,
-		mediaElement
-	);
+	const isCoverDark = useCoverIsDark( url, dimRatio, overlayColor.color );
 
 	useEffect( () => {
 		// This side-effect should not create an undo level.
@@ -204,7 +198,6 @@ function CoverEdit( {
 	const currentSettings = {
 		isVideoBackground,
 		isImageBackground,
-		mediaElement,
 		hasInnerBlocks,
 		url,
 		isImgElement,
@@ -366,7 +359,6 @@ function CoverEdit( {
 					isImageBackground &&
 					( isImgElement ? (
 						<img
-							ref={ mediaElement }
 							className="wp-block-cover__image-background"
 							alt={ alt }
 							src={ url }
@@ -374,7 +366,6 @@ function CoverEdit( {
 						/>
 					) : (
 						<div
-							ref={ mediaElement }
 							role="img"
 							className={ classnames(
 								classes,
@@ -385,7 +376,6 @@ function CoverEdit( {
 					) ) }
 				{ url && isVideoBackground && (
 					<video
-						ref={ mediaElement }
 						className="wp-block-cover__video-background"
 						autoPlay
 						muted

--- a/packages/block-library/src/cover/edit/use-cover-is-dark.js
+++ b/packages/block-library/src/cover/edit/use-cover-is-dark.js
@@ -62,8 +62,10 @@ export default function useCoverIsDark(
 				} )
 				.then( ( color ) => setIsDark( color.isDark ) );
 			return () => {
-				elementRef.current.crossOrigin = originalCrossOrigin;
-			}
+				if ( elementRef.current ) {
+					elementRef.current.crossOrigin = originalCrossOrigin;
+				}
+			};
 		}
 	}, [ url, url && dimRatio <= 50 && elementRef.current, setIsDark ] );
 	useEffect( () => {

--- a/packages/block-library/src/cover/edit/use-cover-is-dark.js
+++ b/packages/block-library/src/cover/edit/use-cover-is-dark.js
@@ -8,6 +8,7 @@ import { colord } from 'colord';
  * WordPress dependencies
  */
 import { useEffect, useState } from '@wordpress/element';
+import { applyFilters } from '@wordpress/hooks';
 
 function retrieveFastAverageColor() {
 	if ( ! retrieveFastAverageColor.fastAverageColor ) {
@@ -41,6 +42,14 @@ export default function useCoverIsDark(
 		// If opacity is lower than 50 the dominant color is the image or video color,
 		// so use that color for the dark mode computation.
 		if ( url && dimRatio <= 50 && elementRef.current ) {
+			const imgCrossOrigin = applyFilters(
+				'media.crossOrigin',
+				elementRef.current.crossOrigin,
+				url
+			);
+			if ( typeof imgCrossOrigin === 'string' ) {
+				elementRef.current.crossOrigin = imgCrossOrigin;
+			}
 			retrieveFastAverageColor()
 				.getColorAsync( elementRef.current, {
 					// Previously the default color was white, but that changed

--- a/packages/block-library/src/cover/edit/use-cover-is-dark.js
+++ b/packages/block-library/src/cover/edit/use-cover-is-dark.js
@@ -42,6 +42,7 @@ export default function useCoverIsDark(
 		// If opacity is lower than 50 the dominant color is the image or video color,
 		// so use that color for the dark mode computation.
 		if ( url && dimRatio <= 50 && elementRef.current ) {
+			const originalCrossOrigin = elementRef.current.crossOrigin;
 			const imgCrossOrigin = applyFilters(
 				'media.crossOrigin',
 				elementRef.current.crossOrigin,
@@ -60,6 +61,9 @@ export default function useCoverIsDark(
 					silent: process.env.NODE_ENV === 'production',
 				} )
 				.then( ( color ) => setIsDark( color.isDark ) );
+			return () => {
+				elementRef.current.crossOrigin = originalCrossOrigin;
+			}
 		}
 	}, [ url, url && dimRatio <= 50 && elementRef.current, setIsDark ] );
 	useEffect( () => {

--- a/packages/block-library/src/cover/edit/use-cover-is-dark.js
+++ b/packages/block-library/src/cover/edit/use-cover-is-dark.js
@@ -26,48 +26,33 @@ function retrieveFastAverageColor() {
  *                               color are set, dimRatio is used to decide what is used
  *                               for background darkness checking purposes.
  * @param {?string} overlayColor String containing the overlay color value if one exists.
- * @param {?Object} elementRef   If a media background is set, elementRef should contain a reference to a
- *                               dom element that renders that media.
  *
  * @return {boolean} True if the cover background is considered "dark" and false otherwise.
  */
-export default function useCoverIsDark(
-	url,
-	dimRatio = 50,
-	overlayColor,
-	elementRef
-) {
+export default function useCoverIsDark( url, dimRatio = 50, overlayColor ) {
 	const [ isDark, setIsDark ] = useState( false );
 	useEffect( () => {
 		// If opacity is lower than 50 the dominant color is the image or video color,
 		// so use that color for the dark mode computation.
-		if ( url && dimRatio <= 50 && elementRef.current ) {
-			const originalCrossOrigin = elementRef.current.crossOrigin;
+		if ( url && dimRatio <= 50 ) {
 			const imgCrossOrigin = applyFilters(
 				'media.crossOrigin',
-				elementRef.current.crossOrigin,
+				undefined,
 				url
 			);
-			if ( typeof imgCrossOrigin === 'string' ) {
-				elementRef.current.crossOrigin = imgCrossOrigin;
-			}
 			retrieveFastAverageColor()
-				.getColorAsync( elementRef.current, {
+				.getColorAsync( url, {
 					// Previously the default color was white, but that changed
 					// in v6.0.0 so it has to be manually set now.
 					defaultColor: [ 255, 255, 255, 255 ],
 					// Errors that come up don't reject the promise, so error
 					// logging has to be silenced with this option.
 					silent: process.env.NODE_ENV === 'production',
+					crossOrigin: imgCrossOrigin,
 				} )
 				.then( ( color ) => setIsDark( color.isDark ) );
-			return () => {
-				if ( elementRef.current ) {
-					elementRef.current.crossOrigin = originalCrossOrigin;
-				}
-			};
 		}
-	}, [ url, url && dimRatio <= 50 && elementRef.current, setIsDark ] );
+	}, [ url, url && dimRatio <= 50, setIsDark ] );
 	useEffect( () => {
 		// If opacity is greater than 50 the dominant color is the overlay color,
 		// so use that color for the dark mode computation.


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Fixes the cover block text color heuristic for sites using the [`media.crossOrigin`](https://github.com/WordPress/gutenberg/blob/0fbe556e9f35638a4129a0d4ce19fdd20da49bf1/docs/reference-guides/filters/editor-filters.md#mediacrossorigin) filter.

The image used in the Gutenberg demo that spurred this in #44174 is from an external CDN, so this won't fix the issue there, but it should help out sites serving images from a different subdomain with various CORS configurations.

Additionally, the implementation happens to fix text color heuristics for fixed and repeated backgrounds that don't use an `<img>` element.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

In #44174, I discovered that the text color heuristic wasn't working because of CORS issues. I saw in #28255 there was a similar issue with image editing that happens in sites with images served from a different subdomain. I expect those sites also have the text color heuristic broken in the same way as the demo. The solution for image editing in #28255 was to add the `media.crossOrigin` filter so that individual sites can configure it how they wish. The same filter can be used in other places where cross origin images are used in canvases in the browser.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

The text color heuristic uses [fast-average-color](https://www.npmjs.com/package/fast-average-color/v/9.1.1) when the cover block uses an image, so this PR just updates the fast-average-color configuration.

- Uses the image URL instead of image element. This downloads the image again with CORS options enabled so it doesn't trigger a [tainted canvas](https://developer.mozilla.org/en-US/docs/Web/HTML/CORS_enabled_image#security_and_tainted_canvases) when the calculation is done. Not relying on the HTMLImageElement also means fixed/repeated backgrounds that use a div background instead also work now.
- Adds the [`media.crossOrigin`](https://github.com/WordPress/gutenberg/blob/0fbe556e9f35638a4129a0d4ce19fdd20da49bf1/docs/reference-guides/filters/editor-filters.md#mediacrossorigin) filter for sites that don't want to use the default `crossorigin` option (`''` which is the same as `'anonymous'`) used by fast-average-color. 

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->

You can download the following images for testing. In a cover block background, the dark image should have white text and the light image should have black text.

| Dark Image | Light Image |
| ---------- | ----------- |
| ![dark image](https://cldup.com/Fz-ASbo2s3.jpg) | ![light image](https://cldup.com/_rSwtEeDGD.jpg) |

### Fixed/Repeated backgrounds

1. Upload an obviously dark and light colored image.
2. Insert a cover block using the light image.
3. Select "Fixed background" and/or "Repeated background" from the media settings.
4. Replace the image with the dark image.
5. The text color should be white and there should be no CORS errors in the console.

### Subdomain uploads

1. Configure your site to use a different subdomain for uploads with CORS support.<sup>*, **</sup>
2. Upload an obviously dark colored image.
3. Insert a cover block using that image.
4. The text color should be white and there should be no CORS errors in the console.

\* How I configured LocalWP for CORS on uploads:
- Configure a site to use `wp.local` as the site domain.
- Use Apache web server.
- Set the `upload_url_path` to `http://uploads.wp.local` in http://wp.local/wp-admin/options.php.
- Configure Apache to use `Access-Control-Allow-Origin` for uploads in modules.conf.hbs
  ```hbs
  LoadModule headers_module "{{ modules }}/mod_headers.so"
  <IfModule mod_setenvif.c>
  	<IfModule mod_headers.c>
  		SetEnvIf Host "^uploads.wp.local$" IS_UPLOADS
  		Header set Access-Control-Allow-Origin "http://wp.local" env=IS_UPLOADS
  	</IfModule>
  </IfModule>
  ```
- Add `uploads.wp.local` to /etc/hosts. LocalWP should have already configured `wp.local`.
  ```shell
  ## LocalWP uploads - Start ##
  ::1 uploads.wp.local #Local Site
  127.0.0.1 uploads.wp.local #Local Site
  ## LocalWP uploads - End ##
  ```

\** Presumably you can modify the testing instructions from #28255, but I don't use wp-env, so I can't confirm.

### CORS Credentials

1. Configure your site to use a different subdomain for uploads with CORS support. <sup>†, ††</sup>
2. Add this [Media Cross Origin Use Credentials plugin](https://github.com/WordPress/gutenberg/files/9669336/media-cross-origin-use-credentials.zip)<sup>†††</sup> to run the `media.crossOrigin` hook.
3. Upload an obviously dark colored image.
4. Insert a cover block using that image.
5. The text color should be white and there should be no CORS errors in the console.

† How I configured LocalWP for CORS with Credentials on uploads:
- Configure a site to use `wp.local` as the site domain.
- Use Apache web server.
- Set the `upload_url_path` to `http://uploads.wp.local` in http://wp.local/wp-admin/options.php.
- Configure Apache to use `Access-Control-Allow-Origin` for uploads in modules.conf.hbs
  ```hbs
  LoadModule headers_module "{{ modules }}/mod_headers.so"
  <IfModule mod_setenvif.c>
  	<IfModule mod_headers.c>
  		SetEnvIf Host "^uploads.wp.local$" IS_UPLOADS
  		Header set Access-Control-Allow-Origin "http://wp.local" env=IS_UPLOADS
  		Header set Access-Control-Allow-Credentials "true" env=IS_UPLOADS
  		Header set Vary "Origin" env=IS_UPLOADS
  	</IfModule>
  </IfModule>
  ```
- Add `uploads.wp.local` to /etc/hosts. LocalWP should have already configured `wp.local`.
  ```shell
  ## LocalWP uploads - Start ##
  ::1 uploads.wp.local #Local Site
  127.0.0.1 uploads.wp.local #Local Site
  ## LocalWP uploads - End ##

†† Again, I don't use wp-env, so I can't confirm, but you can probably modify the testing instructions from #28255 to test with wp-env.

††† Plugin source for reference

```php
add_action( 'init', function() {
	// Use the upload_url_path for convenience for testing.
	$upload_url_path = rawurlencode( (string) get_option( 'upload_url_path' ) );
	if ( $upload_url_path ) {
		$script_handle = 'a8c-media-cross-origin-use-credentials';
		wp_register_script( $script_handle, '', array('wp-hooks') );
		wp_enqueue_script( $script_handle );
		wp_add_inline_script(
			$script_handle,
		<<<SCRIPT
(function () {
	'use strict';
	wp.hooks.addFilter(
		'media.crossOrigin',
		'$script_handle',
		( crossOrigin, imgSrc ) =>
			imgSrc.startsWith( decodeURIComponent( '$upload_url_path' ) )
				? 'use-credentials'
				: crossOrigin
	);
})();
SCRIPT
		);
	}
} );
```

## Screenshots or screencast <!-- if applicable -->

### Before

![broken-text-color-heuristic](https://user-images.githubusercontent.com/5129775/192904658-cfe810f1-70c7-4d3c-8bfc-33876ebeadaf.gif)

![fast-average-color error](https://user-images.githubusercontent.com/5129775/192664868-2ffe0e72-8b72-4181-bcc4-e536778d1a24.png)

### After

![fixed-text-color-heuristic](https://user-images.githubusercontent.com/5129775/192901982-dd0f3502-f233-42c6-a3d2-b69a3073617f.gif)
