### PR TITLE
Hide the Classic block in the Site Editor

### DIFF
--- a/packages/edit-site/src/index.js
+++ b/packages/edit-site/src/index.js
@@ -18,6 +18,7 @@ import { store as preferencesStore } from '@wordpress/preferences';
 import { __ } from '@wordpress/i18n';
 import { store as viewportStore } from '@wordpress/viewport';
 import { getQueryArgs } from '@wordpress/url';
+import { addFilter } from '@wordpress/hooks';
 
 /**
  * Internal dependencies
@@ -50,6 +51,23 @@ export function reinitializeEditor( target, settings ) {
 		);
 		return;
 	}
+
+	/*
+	 * Prevent adding template part in the post editor.
+	 * Only add the filter when the post editor is initialized, not imported.
+	 * Also only add the filter(s) after registerCoreBlocks()
+	 * so that common filters in the block library are not overwritten.
+	 */
+	addFilter(
+		'blockEditor.__unstableCanInsertBlockType',
+		'removeClassicBlockFromInserter',
+		( canInsert, blockType ) => {
+			if ( blockType.name === 'core/freeform' ) {
+				return false;
+			}
+			return canInsert;
+		}
+	);
 
 	// This will be a no-op if the target doesn't have any React nodes.
 	unmountComponentAtNode( target );

--- a/packages/edit-site/src/index.js
+++ b/packages/edit-site/src/index.js
@@ -53,10 +53,13 @@ export function reinitializeEditor( target, settings ) {
 	}
 
 	/*
-	 * Prevent adding template part in the post editor.
-	 * Only add the filter when the post editor is initialized, not imported.
+	 * Prevent adding the Clasic block in the site editor.
+	 * Only add the filter when the site editor is initialized, not imported.
 	 * Also only add the filter(s) after registerCoreBlocks()
 	 * so that common filters in the block library are not overwritten.
+	 *
+	 * This usage here is inspired by previous usage of the filter in the post editor:
+	 * https://github.com/WordPress/gutenberg/pull/37157
 	 */
 	addFilter(
 		'blockEditor.__unstableCanInsertBlockType',


### PR DESCRIPTION
## What?
An attempt to fix #23086.

## Why?
As described in the issue, the Classic block (`core/freeform`) fails to load in the site editor.

## How?
Disabling the block in the Site Editor by using a filter first introduced in https://github.com/WordPress/gutenberg/pull/37157

## Testing instructions
1. Open the site editor. Try to insert the Classic block. Verify that the block does not show up in the inserter.
2. Open the post editor. Make sure that the Classic block is available.