### PR TITLE
Theme export: Fix broken spacingScale export

### DIFF
--- a/lib/compat/wordpress-6.1/class-wp-theme-json-6-1.php
+++ b/lib/compat/wordpress-6.1/class-wp-theme-json-6-1.php
@@ -1194,15 +1194,6 @@ class WP_Theme_JSON_6_1 extends WP_Theme_JSON_6_0 {
 			'classes'           => array(),
 			'properties'        => array( 'padding', 'margin' ),
 		),
-		array(
-			'path'              => array( 'spacing', 'spacingScale' ),
-			'prevent_override'  => false,
-			'use_default_names' => true,
-			'value_key'         => 'size',
-			'css_vars'          => '--wp--preset--spacing--$slug',
-			'classes'           => array(),
-			'properties'        => array( 'padding', 'margin' ),
-		),
 	);
 
 	/**


### PR DESCRIPTION
## What?
Removes a spacing presets config that was added in error.

## Why?
Fixes: #44546

## How?
Removes the spacing presets config for `spacingScale` as only `spacingSizes` should be defined.

## Testing Instructions

- Under theme.json `settings.spacing` define a `"spacingScale": { "steps": 0}` array in a theme.json
- Export the theme from the site editor
- Make sure the exported theme.json includes the `spacingScale`
- Check that the spacing presets still work as expected in post editor, site editor and frontend

## Screenshots or screencast 

Before:
![space-after](https://user-images.githubusercontent.com/3629020/192927865-4d833da0-9dbb-41bf-b91b-7eacaf9eeb01.png)

After:
![space-before](https://user-images.githubusercontent.com/3629020/192927891-5d3ab1d2-1efc-49ef-813e-ef847858e9af.png)

