### PR TITLE
Remove border from Global Styles previews

### DIFF
--- a/packages/edit-site/src/components/global-styles/preview.js
+++ b/packages/edit-site/src/components/global-styles/preview.js
@@ -85,7 +85,7 @@ const StylesPreview = ( { label, isFocused } ) => {
 			return [
 				...styles,
 				{
-					css: 'body{min-width: 0;padding: 0;border: none}',
+					css: 'body{min-width: 0;padding: 0;border: none;}',
 					isGlobalStyles: true,
 				},
 			];

--- a/packages/edit-site/src/components/global-styles/preview.js
+++ b/packages/edit-site/src/components/global-styles/preview.js
@@ -85,7 +85,7 @@ const StylesPreview = ( { label, isFocused } ) => {
 			return [
 				...styles,
 				{
-					css: 'body{min-width: 0;padding: 0;border:none}',
+					css: 'body{min-width: 0;padding: 0;border: none}',
 					isGlobalStyles: true,
 				},
 			];

--- a/packages/edit-site/src/components/global-styles/preview.js
+++ b/packages/edit-site/src/components/global-styles/preview.js
@@ -79,13 +79,13 @@ const StylesPreview = ( { label, isFocused } ) => {
 		)
 		.slice( 0, 2 );
 
-	// Reset leaked styles from WP common.css and remove main content layout padding.
+	// Reset leaked styles from WP common.css and remove main content layout padding and border.
 	const editorStyles = useMemo( () => {
 		if ( styles ) {
 			return [
 				...styles,
 				{
-					css: 'body{min-width: 0;padding: 0;}',
+					css: 'body{min-width: 0;padding: 0;border:none}',
 					isGlobalStyles: true,
 				},
 			];


### PR DESCRIPTION
Fixes #44515

## What?
This PR removes any potential site border from Global Styles preview by resetting it to `none`.

## Why?
The Whisper style variation in the Twenty Twenty-Three (TT3) theme includes site border. In testing TT3, it was discovered that this border was also showing up in the Global Styles previews resulting in a scrollbar (#44515). Site border is a common style choice, but the presence of the border breaks the layout of the Global Styles previews. As noted [here](https://github.com/WordPress/gutenberg/issues/44515#issuecomment-1260345152), simply removing the border from the previews is the most direct solution.

## How?
Following a similar approach used in https://github.com/WordPress/gutenberg/pull/43601, the border is set to `none` in the Global Style preview panels.

## Testing Instructions
1. Use the TT3 theme
2. Navigate to the Site Editor
3. Open the Global Styles panel
4. Click on Browse Styles and notice that the Whisper variation no longer has a border

## Screenshots or screencast <!-- if applicable -->

**Before**
![image](https://user-images.githubusercontent.com/4832319/192921881-166fcebd-07eb-4c9f-a7a7-3feb6d92353b.png)

**After**
![image](https://user-images.githubusercontent.com/4832319/192921828-e2a2542a-f969-422a-858c-1fb937cb377b.png)
