### PR TITLE
FontSizePicker: Make control take up full width

### DIFF
--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Enhancements
+
+-   `FontSizePicker`: Updated to take up full width of its parent and have a 40px Reset button when `size` is `__unstable-large` ((44559)[https://github.com/WordPress/gutenberg/pull/44559]).
+
 ### Bug Fix
 
 -   `Popover`: fix limitShift logic by adding iframe offset correctly [#42950](https://github.com/WordPress/gutenberg/pull/42950)).

--- a/packages/components/src/font-size-picker/index.tsx
+++ b/packages/components/src/font-size-picker/index.tsx
@@ -271,10 +271,7 @@ const UnforwardedFontSizePicker = (
 					{ ! withSlider &&
 						! disableCustomFontSizes &&
 						showCustomValueControl && (
-							<Flex
-								justify="space-between"
-								className="components-font-size-picker__custom-size-control"
-							>
+							<Flex className="components-font-size-picker__custom-size-control">
 								<FlexItem isBlock>
 									<UnitControl
 										label={ __( 'Custom' ) }
@@ -303,7 +300,7 @@ const UnforwardedFontSizePicker = (
 									/>
 								</FlexItem>
 								{ withReset && (
-									<FlexItem isBlock>
+									<FlexItem>
 										<ResetButton
 											disabled={ value === undefined }
 											onClick={ () => {
@@ -311,6 +308,7 @@ const UnforwardedFontSizePicker = (
 											} }
 											isSmall
 											variant="secondary"
+											size={ size }
 										>
 											{ __( 'Reset' ) }
 										</ResetButton>

--- a/packages/components/src/font-size-picker/styles.ts
+++ b/packages/components/src/font-size-picker/styles.ts
@@ -10,6 +10,7 @@ import BaseControl from '../base-control';
 import Button from '../button';
 import { space } from '../ui/utils/space';
 import { COLORS } from '../utils';
+import type { FontSizePickerProps } from './types';
 
 export const Container = styled.fieldset`
 	border: 0;
@@ -26,19 +27,18 @@ export const HeaderHint = styled.span`
 	margin-left: ${ space( 1 ) };
 `;
 
-// 280px is the sidebar width.
-// TODO: Remove this, @wordpress/components shouldn't care what a "sidebar" is.
 export const Controls = styled.div< {
 	__nextHasNoMarginBottom: boolean;
 } >`
-	max-width: calc( 280px - ${ space( 4 ) } * 2 );
-
 	${ ( props ) =>
 		! props.__nextHasNoMarginBottom && `margin-bottom: ${ space( 6 ) };` }
 `;
 
-export const ResetButton = styled( Button )`
+export const ResetButton = styled( Button )< {
+	size: FontSizePickerProps[ 'size' ];
+} >`
 	&&& {
-		height: 30px;
+		height: ${ ( props ) =>
+			props.size === '__unstable-large' ? '40px' : '30px' };
 	}
 `;


### PR DESCRIPTION
## What?
Removes the 280px `max-width` from `FontSizePicker` so that it takes up the full width of its parent container.

The Reset button will now also be 40px high when `__size` is set to `__unstable-large`.

Neither of these changes make any practical difference to Gutenberg which only uses `FontSizePicker` in the (narrow) sidebar and always hides the _Reset_ button.

## Why?
- More consistent with most other components in `@wordpress/components` which take up the full width.
- Styling such as this is the responsibility of the caller. `@wordpress/components` shouldn't know what a sidebar is or how wide it is.
- 30px tall Reset button looks weird.

## How?

## Testing Instructions
Storybook:
1. `npm run storybook:dev` 
2. Go to `FontSizePicker`
3. Toggle on _Set custom size_

Gutenberg:
1. `npm run dev`
2. Global Styles → Typography → Text
3. Check that the _Size_ control looks the same as it does in `trunk`