### PR TITLE
PHP 8.2: remove deprecated callable in Style Engine value functions

### DIFF
--- a/packages/style-engine/class-wp-style-engine.php
+++ b/packages/style-engine/class-wp-style-engine.php
@@ -17,12 +17,12 @@ if ( class_exists( 'WP_Style_Engine' ) ) {
  * The Style Engine aims to provide a consistent API for rendering styling for blocks across both client-side and server-side applications.
  *
  * This class is for internal Core usage and is not supposed to be used by extenders (plugins and/or themes).
- * This class should not be extended.
+ * This class is final and should not be extended.
  * This is a low-level API that may need to do breaking changes. Please, use wp_style_engine_get_styles instead.
  *
  * @access private
  */
-class WP_Style_Engine {
+final class WP_Style_Engine {
 	/**
 	 * Style definitions that contain the instructions to
 	 * parse/output valid Gutenberg styles from a block's attributes.

--- a/packages/style-engine/class-wp-style-engine.php
+++ b/packages/style-engine/class-wp-style-engine.php
@@ -17,6 +17,7 @@ if ( class_exists( 'WP_Style_Engine' ) ) {
  * The Style Engine aims to provide a consistent API for rendering styling for blocks across both client-side and server-side applications.
  *
  * This class is for internal Core usage and is not supposed to be used by extenders (plugins and/or themes).
+ * This class should not be extended.
  * This is a low-level API that may need to do breaking changes. Please, use wp_style_engine_get_styles instead.
  *
  * @access private
@@ -107,28 +108,28 @@ class WP_Style_Engine {
 				'path'          => array( 'border', 'width' ),
 			),
 			'top'    => array(
-				'value_func' => 'static::get_individual_property_css_declarations',
+				'value_func' => array( self::class, 'get_individual_property_css_declarations' ),
 				'path'       => array( 'border', 'top' ),
 				'css_vars'   => array(
 					'color' => '--wp--preset--color--$slug',
 				),
 			),
 			'right'  => array(
-				'value_func' => 'static::get_individual_property_css_declarations',
+				'value_func' => array( self::class, 'get_individual_property_css_declarations' ),
 				'path'       => array( 'border', 'right' ),
 				'css_vars'   => array(
 					'color' => '--wp--preset--color--$slug',
 				),
 			),
 			'bottom' => array(
-				'value_func' => 'static::get_individual_property_css_declarations',
+				'value_func' => array( self::class, 'get_individual_property_css_declarations' ),
 				'path'       => array( 'border', 'bottom' ),
 				'css_vars'   => array(
 					'color' => '--wp--preset--color--$slug',
 				),
 			),
 			'left'   => array(
-				'value_func' => 'static::get_individual_property_css_declarations',
+				'value_func' => array( self::class, 'get_individual_property_css_declarations' ),
 				'path'       => array( 'border', 'left' ),
 				'css_vars'   => array(
 					'color' => '--wp--preset--color--$slug',


### PR DESCRIPTION
Fixes: https://github.com/WordPress/gutenberg/issues/44536

Props to @jrfnl for raising the issue and explaining the options.

## What?
A sync of the 6.1 Core patch: https://github.com/WordPress/wordpress-develop/pull/3363

## Why?
The string syntax for callables will be deprecated in PHP version 9.

8.2 shows a deprecation notice.

See: https://wiki.php.net/rfc/deprecate_partially_supported_callables

See comment: https://core.trac.wordpress.org/ticket/56467#comment:242 for a description of the deprecation notice and explanation.

## How?
This PR switches to use to array( self::class, '*' ) and makes the WP_Style_Engine class final with the understanding that we won't need to, nor should we, extend it.

## Testing Instructions
Things should work as expected, PHP unit tests should pass.

As for the compat check, PHP Gutenberg doesn't run unit tests against 8.2 so for now, check the 8.2 unit tests logs as described over in https://github.com/WordPress/wordpress-develop/pull/3363


