### PR TITLE
Don't display placeholder SVG when Video block selected.

### DIFF
--- a/packages/block-library/src/video/editor.scss
+++ b/packages/block-library/src/video/editor.scss
@@ -16,6 +16,10 @@
 			opacity: 0;
 		}
 
+		.components-placeholder__illustration {
+			display: none;
+		}
+
 		&::before {
 			opacity: 0;
 		}


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

Fixes Video block placeholder buttons not being clickable due to the invisible SVG overlay persisting when block is selected.


## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

I copied over [a block of CSS](https://github.com/WordPress/gutenberg/blob/trunk/packages/block-library/src/image/editor.scss#L22) that's being used for the same purpose in the Image block placeholder.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->

1. Add a Video block to the page;
2. Check that block placeholder buttons are clickable.

## Screenshots or screencast <!-- if applicable -->
