### PR TITLE
BorderBoxControl: Ensure most common unit selection is maintained

### DIFF
--- a/packages/components/src/border-box-control/test/utils.js
+++ b/packages/components/src/border-box-control/test/utils.js
@@ -244,6 +244,54 @@ describe( 'BorderBoxControl Utils', () => {
 
 			expect( getCommonBorder( sideBorders ) ).toEqual( commonBorder );
 		} );
+
+		it( 'should return most common unit selection if border widths are mixed', () => {
+			const sideBorders = {
+				top: { color: '#fff', style: 'solid', width: '10px' },
+				right: { color: '#000', style: 'solid', width: '1rem' },
+				bottom: { color: '#000', style: 'solid', width: '2em' },
+				left: { color: '#000', style: undefined, width: '2em' },
+			};
+			const commonBorder = {
+				color: undefined,
+				style: undefined,
+				width: 'em',
+			};
+
+			expect( getCommonBorder( sideBorders ) ).toEqual( commonBorder );
+		} );
+
+		it( 'should return first unit when multiple units are equal most common', () => {
+			const sideBorders = {
+				top: { color: '#fff', style: 'solid', width: '1rem' },
+				right: { color: '#000', style: 'solid', width: '0.75em' },
+				bottom: { color: '#000', style: 'solid', width: '1vw' },
+				left: { color: '#000', style: undefined, width: '2vh' },
+			};
+			const commonBorder = {
+				color: undefined,
+				style: undefined,
+				width: 'rem',
+			};
+
+			expect( getCommonBorder( sideBorders ) ).toEqual( commonBorder );
+		} );
+
+		it( 'should ignore undefined values in determining most common unit', () => {
+			const sideBorders = {
+				top: { color: '#fff', style: 'solid', width: undefined },
+				right: { color: '#000', style: 'solid', width: '5vw' },
+				bottom: { color: '#000', style: 'solid', width: undefined },
+				left: { color: '#000', style: undefined, width: '2vh' },
+			};
+			const commonBorder = {
+				color: undefined,
+				style: undefined,
+				width: 'vw',
+			};
+
+			expect( getCommonBorder( sideBorders ) ).toEqual( commonBorder );
+		} );
 	} );
 
 	describe( 'getShorthandBorderStyle', () => {


### PR DESCRIPTION
Related:
- https://github.com/WordPress/gutenberg/pull/41860

## What?

Updates the `BorderBoxControl` such that when it contains "mixed" border values, it maintains the most common unit selection when switching back to the "linked" view.


## Why?

Having the "linked" control display 'px' as the selected unit when split borders might all be using different CSS units is confusing. This PR brings it more in line with the box control while still maintaining the border control specific behaviour.

## How?

- Updates the `getCommonBorder` util to return a "CSS unit-only" value for mixed widths so the `UnitControl` maintains an appropriate unit selection.
- Adds additional unit tests for related unit selection

## Testing Instructions
1. Run `BorderBoxcontrol` unit tests: `npm run test:unit packages/components/src/border-box-control/test`
2. Fire up Storybook and visit the [BorderBoxControl page](http://localhost:50240/?path=/story/components-experimental-borderboxcontrol--default).
3. Unlink the control and set two or more fields to the same unit and the remaining fields to a different unit.
4. Re-link the control, and the unit selected should be the one set multiple times in the previous step.
5. Unlink the control again and make each field have a different unit. Re-link again, and the selected unit should be the first unit, i.e. the top border's unit. (the first defined unit is used in the case of multiple mode values)

## Screenshots or screencast <!-- if applicable -->

| Before | After |
|---|---|
| <video src="https://user-images.githubusercontent.com/60436221/192954198-7213d8a1-1ad4-4dca-9426-e6ce1eea8d91.mp4"/> | <video src="https://user-images.githubusercontent.com/60436221/192954193-726d9ae3-07b6-409c-90f6-067d686a1aed.mp4"/> |

