### PR TITLE
Try running PHP unit tests in multiple PHP versions on github

### DIFF
--- a/.github/workflows/unit-test.yml
+++ b/.github/workflows/unit-test.yml
@@ -56,6 +56,10 @@ jobs:
         runs-on: ubuntu-latest
         if: ${{ github.repository == 'WordPress/gutenberg' || github.event_name == 'pull_request' }}
 
+        strategy:
+            matrix:
+                php-version: ['7.2', '8.1']
+
         steps:
             - uses: actions/checkout@5a4ac9002d0be2fb38bd78e4b4dbde5606d7042f # v2.3.4
 
@@ -72,7 +76,7 @@ jobs:
 
             - name: Install WordPress
               run: |
-                  npm run wp-env start
+                  WP_ENV_PHP_VERSION=${{ matrix.php-version }} npm run wp-env start
 
             - name: Running lint check
               run: npm run lint:php

--- a/.github/workflows/unit-test.yml
+++ b/.github/workflows/unit-test.yml
@@ -75,8 +75,10 @@ jobs:
                   npm run build
 
             - name: Install WordPress
+              env:
+                  WP_ENV_PHP_VERSION: ${{ matrix.php-version }}
               run: |
-                  WP_ENV_PHP_VERSION=${{ matrix.php-version }} npm run wp-env start
+                  npm run wp-env start
 
             - name: Running lint check
               run: npm run lint:php

--- a/.github/workflows/unit-test.yml
+++ b/.github/workflows/unit-test.yml
@@ -60,6 +60,9 @@ jobs:
             matrix:
                 php-version: ['7.2', '8.1']
 
+        env:
+            WP_ENV_PHP_VERSION: ${{ matrix.php-version }}
+
         steps:
             - uses: actions/checkout@5a4ac9002d0be2fb38bd78e4b4dbde5606d7042f # v2.3.4
 
@@ -74,24 +77,14 @@ jobs:
                   npm ci
                   npm run build
 
-            - name: Install WordPress
-              env:
-                  WP_ENV_PHP_VERSION: ${{ matrix.php-version }}
-              run: |
-                  npm run wp-env start
-
             - name: Running lint check
               run: npm run lint:php
 
             - name: Running single site unit tests
-              env:
-                  WP_ENV_PHP_VERSION: ${{ matrix.php-version }}
               run: npm run test:unit:php
               if: ${{ success() || failure() }}
 
             - name: Running multisite unit tests
-              env:
-                  WP_ENV_PHP_VERSION: ${{ matrix.php-version }}
               run: npm run test:unit:php:multisite
               if: ${{ success() || failure() }}
 

--- a/.github/workflows/unit-test.yml
+++ b/.github/workflows/unit-test.yml
@@ -84,10 +84,14 @@ jobs:
               run: npm run lint:php
 
             - name: Running single site unit tests
+              env:
+                  WP_ENV_PHP_VERSION: ${{ matrix.php-version }}
               run: npm run test:unit:php
               if: ${{ success() || failure() }}
 
             - name: Running multisite unit tests
+              env:
+                  WP_ENV_PHP_VERSION: ${{ matrix.php-version }}
               run: npm run test:unit:php:multisite
               if: ${{ success() || failure() }}
 

--- a/package.json
+++ b/package.json
@@ -271,7 +271,7 @@
 		"lint:js:fix": "npm run lint:js -- --fix",
 		"lint:lockfile": "node ./bin/validate-package-lock.js",
 		"lint:md:docs": "wp-scripts lint-md-docs",
-		"prelint:php": "wp-env run composer \"install --no-interaction\"",
+		"prelint:php": "wp-env start && wp-env run composer \"install --no-interaction\"",
 		"lint:php": "wp-env run composer run-script lint",
 		"lint:pkg-json": "wp-scripts lint-pkg-json . 'packages/*/package.json'",
 		"native": "npm run --prefix packages/react-native-editor",


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
See #43333

wp-env supports specifying the PHP version as an environment variable, so I'm hoping this is all that's required to run PHP unit tests against multiple PHP versions.

## Why?
It'll help catch issues like this one - [PHP 8.2 | Gutenberg is introducing deprecated callables into WP Core](https://github.com/WordPress/gutenberg/issues/44536#top).

One problem is that wp-env doesn't seem to support PHP 8.2, when I tried it from the command line it errors:
```
ERROR: for tests-wordpress  manifest for wordpress:php8.2 not found: manifest unknown: manifest unknown

ERROR: for tests-cli  manifest for wordpress:cli-php8.2 not found: manifest unknown: manifest unknown

ERROR: for cli  manifest for wordpress:cli-php8.2 not found: manifest unknown: manifest unknown
Some service image(s) must be built from source by running:
    docker-compose build wordpress
manifest for wordpress:php8.2 not found: manifest unknown: manifest unknown
manifest for wordpress:cli-php8.2 not found: manifest unknown: manifest unknown
manifest for wordpress:cli-php8.2 not found: manifest unknown: manifest unknown
```

## How?
Use a matrix for the 'unit-php' job. At the moment I've started with 7.2 and 8.1 as the PHP versions to test that this works.