### PR TITLE
Lodash: Remove completely from `@wordpress/list-reusable-blocks` package

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -18205,7 +18205,7 @@
 				"@wordpress/compose": "file:packages/compose",
 				"@wordpress/element": "file:packages/element",
 				"@wordpress/i18n": "file:packages/i18n",
-				"lodash": "^4.17.21"
+				"change-case": "^4.1.2"
 			}
 		},
 		"@wordpress/media-utils": {

--- a/packages/list-reusable-blocks/package.json
+++ b/packages/list-reusable-blocks/package.json
@@ -31,7 +31,7 @@
 		"@wordpress/compose": "file:../compose",
 		"@wordpress/element": "file:../element",
 		"@wordpress/i18n": "file:../i18n",
-		"lodash": "^4.17.21"
+		"change-case": "^4.1.2"
 	},
 	"peerDependencies": {
 		"react": "^17.0.0",

--- a/packages/list-reusable-blocks/src/utils/export.js
+++ b/packages/list-reusable-blocks/src/utils/export.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { kebabCase } from 'lodash';
+import { paramCase as kebabCase } from 'change-case';
 
 /**
  * WordPress dependencies


### PR DESCRIPTION
## What?
This PR removes all of the Lodash from the `@wordpress/list-reusable-blocks` package, including the `lodash` dependency altogether. There's just a single usage and it is pretty straightforward. 

## Why?

Lodash is known to unnecessarily inflate the bundle size of packages, and in most cases, it can be replaced with native language functionality. See these for more information and rationale:

* https://github.com/WordPress/gutenberg/issues/16938#issuecomment-602837246
* https://github.com/WordPress/gutenberg/issues/17025
* https://github.com/WordPress/gutenberg/issues/39495 

## How?

We're replacing a `_.kebabCase()` with its counterpart from the `change-case` library that we've been widely using. 

## Testing Instructions

* Make sure you have a few reusable blocks created.
* Head to `/wp-admin/edit.php?post_type=wp_block`
* Export a block and verify the export file name is still properly kebab-cased (`kebab-case`).
* Verify all checks are green.