### PR TITLE
Lodash: Remove completely from `@wordpress/compose` package

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16374,7 +16374,8 @@
 		"@types/lodash": {
 			"version": "4.14.172",
 			"resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.172.tgz",
-			"integrity": "sha512-/BHF5HAx3em7/KkzVKm3LrsD6HZAXuXO1AJZQ3cRRBZj4oHZDviWPYu0aEplAqDFNHZPW6d3G7KN+ONcCCC7pw=="
+			"integrity": "sha512-/BHF5HAx3em7/KkzVKm3LrsD6HZAXuXO1AJZQ3cRRBZj4oHZDviWPYu0aEplAqDFNHZPW6d3G7KN+ONcCCC7pw==",
+			"dev": true
 		},
 		"@types/mdast": {
 			"version": "3.0.10",
@@ -17513,7 +17514,6 @@
 			"version": "file:packages/compose",
 			"requires": {
 				"@babel/runtime": "^7.16.0",
-				"@types/lodash": "^4.14.172",
 				"@types/mousetrap": "^1.6.8",
 				"@wordpress/deprecated": "file:packages/deprecated",
 				"@wordpress/dom": "file:packages/dom",
@@ -17523,7 +17523,6 @@
 				"@wordpress/priority-queue": "file:packages/priority-queue",
 				"change-case": "^4.1.2",
 				"clipboard": "^2.0.8",
-				"lodash": "^4.17.21",
 				"mousetrap": "^1.6.5",
 				"use-memo-one": "^1.1.1"
 			}

--- a/packages/compose/package.json
+++ b/packages/compose/package.json
@@ -30,7 +30,6 @@
 	"sideEffects": false,
 	"dependencies": {
 		"@babel/runtime": "^7.16.0",
-		"@types/lodash": "^4.14.172",
 		"@types/mousetrap": "^1.6.8",
 		"@wordpress/deprecated": "file:../deprecated",
 		"@wordpress/dom": "file:../dom",
@@ -40,7 +39,6 @@
 		"@wordpress/priority-queue": "file:../priority-queue",
 		"change-case": "^4.1.2",
 		"clipboard": "^2.0.8",
-		"lodash": "^4.17.21",
 		"mousetrap": "^1.6.5",
 		"use-memo-one": "^1.1.1"
 	},

--- a/packages/compose/src/higher-order/with-global-events/listener.js
+++ b/packages/compose/src/higher-order/with-global-events/listener.js
@@ -1,9 +1,4 @@
 /**
- * External dependencies
- */
-import { without } from 'lodash';
-
-/**
  * Class responsible for orchestrating event handling on the global window,
  * binding a single event to be shared across all handling instances, and
  * removing the handler when no instances are listening for the event.
@@ -27,10 +22,10 @@ class Listener {
 	}
 
 	remove( /** @type {any} */ eventType, /** @type {any} */ instance ) {
-		this.listeners[ eventType ] = without(
-			this.listeners[ eventType ],
-			instance
-		);
+		this.listeners[ eventType ] =
+			this.listeners[ eventType ]?.filter(
+				( /** @type {any} */ listener ) => listener !== instance
+			) ?? [];
 
 		if ( ! this.listeners[ eventType ].length ) {
 			// Removing last listener for this type, so unbind event.

--- a/packages/compose/src/higher-order/with-global-events/listener.js
+++ b/packages/compose/src/higher-order/with-global-events/listener.js
@@ -22,10 +22,13 @@ class Listener {
 	}
 
 	remove( /** @type {any} */ eventType, /** @type {any} */ instance ) {
-		this.listeners[ eventType ] =
-			this.listeners[ eventType ]?.filter(
-				( /** @type {any} */ listener ) => listener !== instance
-			) ?? [];
+		if ( ! this.listeners[ eventType ] ) {
+			return;
+		}
+
+		this.listeners[ eventType ] = this.listeners[ eventType ].filter(
+			( /** @type {any} */ listener ) => listener !== instance
+		);
 
 		if ( ! this.listeners[ eventType ].length ) {
 			// Removing last listener for this type, so unbind event.

--- a/packages/compose/src/higher-order/with-safe-timeout/index.tsx
+++ b/packages/compose/src/higher-order/with-safe-timeout/index.tsx
@@ -1,9 +1,4 @@
 /**
- * External dependencies
- */
-import { without } from 'lodash';
-
-/**
  * WordPress dependencies
  */
 import { Component } from '@wordpress/element';
@@ -64,7 +59,7 @@ const withSafeTimeout = createHigherOrderComponent(
 
 			clearTimeout( id: number ) {
 				clearTimeout( id );
-				this.timeouts = without( this.timeouts, id );
+				this.timeouts.filter( ( timeoutId ) => timeoutId !== id );
 			}
 
 			render() {

--- a/packages/compose/src/hooks/use-disabled/index.js
+++ b/packages/compose/src/hooks/use-disabled/index.js
@@ -1,9 +1,4 @@
 /**
- * External dependencies
- */
-import { includes } from 'lodash';
-
-/**
  * WordPress dependencies
  */
 import { focus } from '@wordpress/dom';
@@ -89,8 +84,7 @@ export default function useDisabled( {
 
 				focus.focusable.find( node ).forEach( ( focusable ) => {
 					if (
-						includes(
-							DISABLED_ELIGIBLE_NODE_NAMES,
+						DISABLED_ELIGIBLE_NODE_NAMES.includes(
 							focusable.nodeName
 						) &&
 						// @ts-ignore

--- a/packages/compose/src/hooks/use-focus-outside/index.js
+++ b/packages/compose/src/hooks/use-focus-outside/index.js
@@ -1,9 +1,4 @@
 /**
- * External dependencies
- */
-import { includes } from 'lodash';
-
-/**
  * WordPress dependencies
  */
 import { useCallback, useEffect, useRef } from '@wordpress/element';
@@ -42,8 +37,7 @@ function isFocusNormalizedButton( eventTarget ) {
 			return true;
 
 		case 'INPUT':
-			return includes(
-				INPUT_BUTTON_TYPES,
+			return INPUT_BUTTON_TYPES.includes(
 				/** @type {HTMLInputElement} */ ( eventTarget ).type
 			);
 	}
@@ -136,7 +130,7 @@ export default function useFocusOutside( onFocusOutside ) {
 	 */
 	const normalizeButtonFocus = useCallback( ( event ) => {
 		const { type, target } = event;
-		const isInteractionEnd = includes( [ 'mouseup', 'touchend' ], type );
+		const isInteractionEnd = [ 'mouseup', 'touchend' ].includes( type );
 
 		if ( isInteractionEnd ) {
 			preventBlurCheck.current = false;

--- a/packages/compose/src/hooks/use-focus-outside/index.native.js
+++ b/packages/compose/src/hooks/use-focus-outside/index.native.js
@@ -1,9 +1,4 @@
 /**
- * External dependencies
- */
-import { includes } from 'lodash';
-
-/**
  * WordPress dependencies
  */
 import { useCallback, useEffect, useRef } from '@wordpress/element';
@@ -39,8 +34,7 @@ function isFocusNormalizedButton( eventTarget ) {
 			return true;
 
 		case 'INPUT':
-			return includes(
-				INPUT_BUTTON_TYPES,
+			return INPUT_BUTTON_TYPES.includes(
 				/** @type {HTMLInputElement} */ ( eventTarget ).type
 			);
 	}
@@ -133,7 +127,7 @@ export default function useFocusOutside( onFocusOutside ) {
 	 */
 	const normalizeButtonFocus = useCallback( ( event ) => {
 		const { type, target } = event;
-		const isInteractionEnd = includes( [ 'mouseup', 'touchend' ], type );
+		const isInteractionEnd = [ 'mouseup', 'touchend' ].includes( type );
 
 		if ( isInteractionEnd ) {
 			preventBlurCheck.current = false;

--- a/packages/compose/src/hooks/use-keyboard-shortcut/index.js
+++ b/packages/compose/src/hooks/use-keyboard-shortcut/index.js
@@ -3,7 +3,6 @@
  */
 import Mousetrap from 'mousetrap';
 import 'mousetrap/plugins/global-bind/mousetrap-global-bind';
-import { castArray } from 'lodash';
 
 /**
  * WordPress dependencies
@@ -60,7 +59,10 @@ function useKeyboardShortcut(
 				  // necessary to maintain the existing behavior.
 				  /** @type {Element} */ ( /** @type {unknown} */ ( document ) )
 		);
-		castArray( shortcuts ).forEach( ( shortcut ) => {
+		const shortcutsArray = Array.isArray( shortcuts )
+			? shortcuts
+			: [ shortcuts ];
+		shortcutsArray.forEach( ( shortcut ) => {
 			const keys = shortcut.split( '+' );
 			// Determines whether a key is a modifier by the length of the string.
 			// E.g. if I add a pass a shortcut Shift+Cmd+M, it'll determine that


### PR DESCRIPTION
## What?
This PR removes all of the Lodash from the `@wordpress/compose` package. There are just a few usages and conversion is pretty straightforward. 

## Why?

Lodash is known to unnecessarily inflate the bundle size of packages, and in most cases, it can be replaced with native language functionality. See these for more information and rationale:

* https://github.com/WordPress/gutenberg/issues/16938#issuecomment-602837246
* https://github.com/WordPress/gutenberg/issues/17025
* https://github.com/WordPress/gutenberg/issues/39495 

## How?
We have to deal essentially a couple of methods, and migration away from them is pretty straightforward:

#### `castArray`

Replacing `castArray` is as simple as checking if X is an array, and creating an array with the X element if it's not.

#### `includes`

Straightforward to replace it with `Array.prototype.includes()`, as long as we're sure that we're calling it on an array.

#### `without`

Straightforward to replace it with `Array.prototype.filter()`, with an inverted condition, as long as we're sure that we're calling it on an array.

## Testing Instructions
* Verify tests still pass: `npm run test-unit packages/compose`
* Smoke test the post editor and site editor.