### PR TITLE
Theme.json: fix some shadow properties doesn't work properly on the site editor

### DIFF
--- a/packages/edit-site/src/components/global-styles/use-global-styles-output.js
+++ b/packages/edit-site/src/components/global-styles/use-global-styles-output.js
@@ -441,6 +441,7 @@ export const getNodesWithStyles = ( tree, blockSelectors ) => {
 				'typography',
 				'filter',
 				'outline',
+				'shadow',
 			].includes( key )
 		);
 

--- a/packages/style-engine/src/test/index.js
+++ b/packages/style-engine/src/test/index.js
@@ -246,6 +246,7 @@ describe( 'getCSSRules', () => {
 						style: 'dashed',
 						color: 'red',
 					},
+					shadow: '10px 10px red',
 				},
 				{
 					selector: '.some-selector',
@@ -308,44 +309,49 @@ describe( 'getCSSRules', () => {
 				value: '5px',
 			},
 			{
-				key: 'fontFamily',
 				selector: '.some-selector',
+				key: 'fontFamily',
 				value: "'Helvetica Neue',sans-serif",
 			},
 			{
-				key: 'fontSize',
 				selector: '.some-selector',
+				key: 'fontSize',
 				value: '2.2rem',
 			},
 			{
-				key: 'fontStyle',
 				selector: '.some-selector',
+				key: 'fontStyle',
 				value: 'italic',
 			},
 			{
-				key: 'fontWeight',
 				selector: '.some-selector',
+				key: 'fontWeight',
 				value: '800',
 			},
 			{
-				key: 'letterSpacing',
 				selector: '.some-selector',
+				key: 'letterSpacing',
 				value: '12px',
 			},
 			{
-				key: 'lineHeight',
 				selector: '.some-selector',
+				key: 'lineHeight',
 				value: '3.3',
 			},
 			{
-				key: 'textDecoration',
 				selector: '.some-selector',
+				key: 'textDecoration',
 				value: 'line-through',
 			},
 			{
-				key: 'textTransform',
 				selector: '.some-selector',
+				key: 'textTransform',
 				value: 'uppercase',
+			},
+			{
+				selector: '.some-selector',
+				key: 'boxShadow',
+				value: '10px 10px red',
 			},
 		] );
 	} );


### PR DESCRIPTION
Follow-up on: #41972
Related to: #44504

## What?
This PR fixes some `shadow` properties doesn't work properly on the **site** editor.

## Why?
I suspect this is due to the fact that the key to the global style has not been added.

## How?
I have updated the unit tests as well as fixed this issue.

## Testing Instructions

In `theme.json`, define `shadow` properties at several levels.

<details>
<summary>Test data for theme.json</summary>

```json
{
	"$schema": "https://schemas.wp.org/trunk/theme.json",
	"version": 2,
	"settings": {
		"appearanceTools": true,
		"layout": {
			"contentSize": "840px"
		}
	},
	"styles": {
		"shadow": "10px 10px 10px #f00",
		"elements": {
			"button": {
				"shadow": "10px 10px 10px #f00",
				":active": {
					"shadow": "10px 10px 10px #0f0"
				},
				":focus": {
					"shadow": "10px 10px 10px #00f"
				},
				":hover": {
					"shadow": "10px 10px 10px #ff0"
				}
			}
		},
		"blocks": {
			"core/heading": {
				"shadow": "10px 10px 10px #f00"
			}
		}
	}
}
```
</details>

In the site editor, insert a block with a shadow defined or containing that element.

<details>
<summary>Test HTML code</summary>

```html
<!-- wp:heading -->
<h2>Heading</h2>
<!-- /wp:heading -->

<!-- wp:buttons -->
<div class="wp-block-buttons"><!-- wp:button -->
<div class="wp-block-button"><a class="wp-block-button__link wp-element-button">Button</a></div>
<!-- /wp:button --></div>
<!-- /wp:buttons -->
```
</details>

Make sure that `box-shadow` is applied to all elements (If you used the test code described in this instruction, a red shadow should be applied to the heading, button, and body).

## Screenshots or screencast

### Before

![before](https://user-images.githubusercontent.com/54422211/192990613-1d1cab93-05b6-415c-ae9e-9d6fb812c0eb.png)

### After
![after](https://user-images.githubusercontent.com/54422211/192990089-5338bc1f-4e02-44c9-abbe-3e5fc26f80b4.png)

### Unit Test

Run the following command to confirm that the test passes correctly.

```bash
npm run test:unit packages/style-engine/src/test/index.js
```