### PR TITLE
Lodash: Remove completely from `@wordpress/library-export-default-webpack-plugin` package

### DIFF
--- a/packages/library-export-default-webpack-plugin/index.js
+++ b/packages/library-export-default-webpack-plugin/index.js
@@ -1,7 +1,6 @@
 /**
  * External dependencies
  */
-const { includes } = require( 'lodash' );
 const { ConcatSource } = require( 'webpack-sources' );
 
 module.exports = class LibraryExportDefaultPlugin {
@@ -16,7 +15,7 @@ module.exports = class LibraryExportDefaultPlugin {
 				const { mainTemplate, chunkTemplate } = compilation;
 
 				const onRenderWithEntry = ( source, chunk ) => {
-					if ( ! includes( this.entryPointNames, chunk.name ) ) {
+					if ( ! this.entryPointNames.includes( chunk.name ) ) {
 						return source;
 					}
 					return new ConcatSource( source, '["default"]' );

--- a/packages/library-export-default-webpack-plugin/index.js
+++ b/packages/library-export-default-webpack-plugin/index.js
@@ -4,7 +4,7 @@
 const { ConcatSource } = require( 'webpack-sources' );
 
 module.exports = class LibraryExportDefaultPlugin {
-	constructor( entryPointNames ) {
+	constructor( entryPointNames = [] ) {
 		this.entryPointNames = entryPointNames;
 	}
 

--- a/packages/library-export-default-webpack-plugin/package.json
+++ b/packages/library-export-default-webpack-plugin/package.json
@@ -29,7 +29,6 @@
 	],
 	"main": "index.js",
 	"dependencies": {
-		"lodash": "^4.17.21",
 		"webpack-sources": "^3.2.2"
 	},
 	"peerDependencies": {


### PR DESCRIPTION
## What?
This PR removes all of the Lodash from the `@wordpress/library-export-default-webpack-plugin` package, including the `lodash` dependency altogether. There's just a single use and it is pretty straightforward. 

## Why?

Lodash is known to unnecessarily inflate the bundle size of packages, and in most cases, it can be replaced with native language functionality. See these for more information and rationale:

* https://github.com/WordPress/gutenberg/issues/16938#issuecomment-602837246
* https://github.com/WordPress/gutenberg/issues/17025
* https://github.com/WordPress/gutenberg/issues/39495 

## How?

We're replacing a `_.includes()` with `Array.prototype.includes()`, which is fine, because the entry points should be provided as an array (as confirmed by the package docs).

## Testing Instructions

* This isn't used anymore as it's deprecated since we use Webpack 5, so testing it requires using it somewhere in a project with an older version of Webpack. 