### PR TITLE
Lodash: Remove completely from `@wordpress/viewport` package

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -18866,8 +18866,7 @@
 			"requires": {
 				"@babel/runtime": "^7.16.0",
 				"@wordpress/compose": "file:packages/compose",
-				"@wordpress/data": "file:packages/data",
-				"lodash": "^4.17.21"
+				"@wordpress/data": "file:packages/data"
 			}
 		},
 		"@wordpress/warning": {

--- a/packages/jest-preset-default/scripts/setup-globals.js
+++ b/packages/jest-preset-default/scripts/setup-globals.js
@@ -44,7 +44,9 @@ global.window.cancelIdleCallback = function cancelIdleCallback( handle ) {
 global.window.matchMedia = () => ( {
 	matches: false,
 	addListener: () => {},
+	addEventListener: () => {},
 	removeListener: () => {},
+	removeEventListener: () => {},
 } );
 
 // Setup fake localStorage.

--- a/packages/react-native-editor/src/globals.js
+++ b/packages/react-native-editor/src/globals.js
@@ -55,7 +55,9 @@ if ( ! global.window.matchMedia ) {
 	global.window.matchMedia = () => ( {
 		matches: false,
 		addListener: () => {},
+		addEventListener: () => {},
 		removeListener: () => {},
+		removeEventListener: () => {},
 	} );
 }
 

--- a/packages/viewport/package.json
+++ b/packages/viewport/package.json
@@ -27,8 +27,7 @@
 	"dependencies": {
 		"@babel/runtime": "^7.16.0",
 		"@wordpress/compose": "file:../compose",
-		"@wordpress/data": "file:../data",
-		"lodash": "^4.17.21"
+		"@wordpress/data": "file:../data"
 	},
 	"peerDependencies": {
 		"react": "^17.0.0"

--- a/packages/viewport/src/listener.js
+++ b/packages/viewport/src/listener.js
@@ -33,7 +33,7 @@ const addDimensionsEventListener = ( breakpoints, operators ) => {
 					const list = window.matchMedia(
 						`(${ condition }: ${ width }px)`
 					);
-					list.addEventListener( 'change', setIsMatching );
+					list.addListener( setIsMatching );
 					return [ `${ operator } ${ name }`, list ];
 				} );
 			} );

--- a/packages/viewport/src/listener.js
+++ b/packages/viewport/src/listener.js
@@ -17,10 +17,7 @@ const addDimensionsEventListener = ( breakpoints, operators ) => {
 	const setIsMatching = debounce(
 		() => {
 			const values = Object.fromEntries(
-				Object.entries( queries ).map( ( [ key, query ] ) => [
-					key,
-					query.matches,
-				] )
+				queries.map( ( [ key, query ] ) => [ key, query.matches ] )
 			);
 			dispatch( store ).setIsMatching( values );
 		},
@@ -37,23 +34,17 @@ const addDimensionsEventListener = ( breakpoints, operators ) => {
 	 *
 	 * @type {Object<string,MediaQueryList>}
 	 */
-	const queries = Object.entries( breakpoints ).reduce(
-		( result, [ name, width ] ) => {
-			Object.entries( operators ).forEach(
-				( [ operator, condition ] ) => {
-					const list = window.matchMedia(
-						`(${ condition }: ${ width }px)`
-					);
-					list.addListener( setIsMatching );
-
-					const key = [ operator, name ].join( ' ' );
-					result[ key ] = list;
-				}
-			);
-
-			return result;
-		},
-		{}
+	const operatorEntries = Object.entries( operators );
+	const queries = Object.entries( breakpoints ).flatMap(
+		( [ name, width ] ) => {
+			return operatorEntries.map( ( [ operator, condition ] ) => {
+				const list = window.matchMedia(
+					`(${ condition }: ${ width }px)`
+				);
+				list.addEventListener( 'change', setIsMatching );
+				return [ `${ operator } ${ name }`, list ];
+			} );
+		}
 	);
 
 	window.addEventListener( 'orientationchange', setIsMatching );

--- a/packages/viewport/src/listener.js
+++ b/packages/viewport/src/listener.js
@@ -33,7 +33,7 @@ const addDimensionsEventListener = ( breakpoints, operators ) => {
 					const list = window.matchMedia(
 						`(${ condition }: ${ width }px)`
 					);
-					list.addListener( setIsMatching );
+					list.addEventListener( 'change', setIsMatching );
 					return [ `${ operator } ${ name }`, list ];
 				} );
 			} );

--- a/packages/viewport/src/listener.js
+++ b/packages/viewport/src/listener.js
@@ -1,9 +1,4 @@
 /**
- * External dependencies
- */
-import { reduce, mapValues } from 'lodash';
-
-/**
  * WordPress dependencies
  */
 import { debounce } from '@wordpress/compose';
@@ -21,7 +16,12 @@ const addDimensionsEventListener = ( breakpoints, operators ) => {
 	 */
 	const setIsMatching = debounce(
 		() => {
-			const values = mapValues( queries, ( query ) => query.matches );
+			const values = Object.fromEntries(
+				Object.entries( queries ).map( ( [ key, query ] ) => [
+					key,
+					query.matches,
+				] )
+			);
 			dispatch( store ).setIsMatching( values );
 		},
 		0,
@@ -37,9 +37,8 @@ const addDimensionsEventListener = ( breakpoints, operators ) => {
 	 *
 	 * @type {Object<string,MediaQueryList>}
 	 */
-	const queries = reduce(
-		breakpoints,
-		( result, width, name ) => {
+	const queries = Object.entries( breakpoints ).reduce(
+		( result, [ name, width ] ) => {
 			Object.entries( operators ).forEach(
 				( [ operator, condition ] ) => {
 					const list = window.matchMedia(

--- a/packages/viewport/src/listener.js
+++ b/packages/viewport/src/listener.js
@@ -10,50 +10,41 @@ import { dispatch } from '@wordpress/data';
 import { store } from './store';
 
 const addDimensionsEventListener = ( breakpoints, operators ) => {
+	const operatorEntries = Object.entries( operators );
+	const breakpointEntries = Object.entries( breakpoints );
+
 	/**
 	 * Callback invoked when media query state should be updated. Is invoked a
 	 * maximum of one time per call stack.
 	 */
 	const setIsMatching = debounce(
 		() => {
+			/**
+			 * Hash of breakpoint names with generated MediaQueryList for corresponding
+			 * media query.
+			 *
+			 * @see https://developer.mozilla.org/en-US/docs/Web/API/Window/matchMedia
+			 * @see https://developer.mozilla.org/en-US/docs/Web/API/MediaQueryList
+			 *
+			 * @type {Object<string,MediaQueryList>}
+			 */
+			const queries = breakpointEntries.flatMap( ( [ name, width ] ) => {
+				return operatorEntries.map( ( [ operator, condition ] ) => {
+					const list = window.matchMedia(
+						`(${ condition }: ${ width }px)`
+					);
+					list.addListener( setIsMatching );
+					return [ `${ operator } ${ name }`, list ];
+				} );
+			} );
+
 			const values = Object.fromEntries(
-				Object.entries( queries ).map( ( [ key, query ] ) => [
-					key,
-					query.matches,
-				] )
+				queries.map( ( [ key, query ] ) => [ key, query.matches ] )
 			);
 			dispatch( store ).setIsMatching( values );
 		},
 		0,
 		{ leading: true }
-	);
-
-	/**
-	 * Hash of breakpoint names with generated MediaQueryList for corresponding
-	 * media query.
-	 *
-	 * @see https://developer.mozilla.org/en-US/docs/Web/API/Window/matchMedia
-	 * @see https://developer.mozilla.org/en-US/docs/Web/API/MediaQueryList
-	 *
-	 * @type {Object<string,MediaQueryList>}
-	 */
-	const queries = Object.entries( breakpoints ).reduce(
-		( result, [ name, width ] ) => {
-			Object.entries( operators ).forEach(
-				( [ operator, condition ] ) => {
-					const list = window.matchMedia(
-						`(${ condition }: ${ width }px)`
-					);
-					list.addListener( setIsMatching );
-
-					const key = [ operator, name ].join( ' ' );
-					result[ key ] = list;
-				}
-			);
-
-			return result;
-		},
-		{}
 	);
 
 	window.addEventListener( 'orientationchange', setIsMatching );

--- a/packages/viewport/src/listener.js
+++ b/packages/viewport/src/listener.js
@@ -10,41 +10,50 @@ import { dispatch } from '@wordpress/data';
 import { store } from './store';
 
 const addDimensionsEventListener = ( breakpoints, operators ) => {
-	const operatorEntries = Object.entries( operators );
-	const breakpointEntries = Object.entries( breakpoints );
-
 	/**
 	 * Callback invoked when media query state should be updated. Is invoked a
 	 * maximum of one time per call stack.
 	 */
 	const setIsMatching = debounce(
 		() => {
-			/**
-			 * Hash of breakpoint names with generated MediaQueryList for corresponding
-			 * media query.
-			 *
-			 * @see https://developer.mozilla.org/en-US/docs/Web/API/Window/matchMedia
-			 * @see https://developer.mozilla.org/en-US/docs/Web/API/MediaQueryList
-			 *
-			 * @type {Object<string,MediaQueryList>}
-			 */
-			const queries = breakpointEntries.flatMap( ( [ name, width ] ) => {
-				return operatorEntries.map( ( [ operator, condition ] ) => {
-					const list = window.matchMedia(
-						`(${ condition }: ${ width }px)`
-					);
-					list.addListener( setIsMatching );
-					return [ `${ operator } ${ name }`, list ];
-				} );
-			} );
-
 			const values = Object.fromEntries(
-				queries.map( ( [ key, query ] ) => [ key, query.matches ] )
+				Object.entries( queries ).map( ( [ key, query ] ) => [
+					key,
+					query.matches,
+				] )
 			);
 			dispatch( store ).setIsMatching( values );
 		},
 		0,
 		{ leading: true }
+	);
+
+	/**
+	 * Hash of breakpoint names with generated MediaQueryList for corresponding
+	 * media query.
+	 *
+	 * @see https://developer.mozilla.org/en-US/docs/Web/API/Window/matchMedia
+	 * @see https://developer.mozilla.org/en-US/docs/Web/API/MediaQueryList
+	 *
+	 * @type {Object<string,MediaQueryList>}
+	 */
+	const queries = Object.entries( breakpoints ).reduce(
+		( result, [ name, width ] ) => {
+			Object.entries( operators ).forEach(
+				( [ operator, condition ] ) => {
+					const list = window.matchMedia(
+						`(${ condition }: ${ width }px)`
+					);
+					list.addListener( setIsMatching );
+
+					const key = [ operator, name ].join( ' ' );
+					result[ key ] = list;
+				}
+			);
+
+			return result;
+		},
+		{}
 	);
 
 	window.addEventListener( 'orientationchange', setIsMatching );

--- a/packages/viewport/src/listener.native.js
+++ b/packages/viewport/src/listener.native.js
@@ -24,20 +24,16 @@ const matchWidth = ( operator, breakpoint ) => {
 };
 
 const addDimensionsEventListener = ( breakpoints, operators ) => {
-	const setIsMatching = () => {
-		const matches = Object.entries( breakpoints ).reduce(
-			( result, [ name, width ] ) => {
-				Object.entries( operators ).forEach(
-					( [ operator, condition ] ) => {
-						const key = [ operator, name ].join( ' ' );
-						result[ key ] = matchWidth( condition, width );
-					}
-				);
+	const operatorEntries = Object.entries( operators );
+	const breakpointEntries = Object.entries( breakpoints );
 
-				return result;
-			},
-			{}
-		);
+	const setIsMatching = () => {
+		const matches = breakpointEntries.flatMap( ( [ name, width ] ) => {
+			return operatorEntries.map( ( [ operator, condition ] ) => [
+				`${ operator } ${ name }`,
+				matchWidth( condition, width ),
+			] );
+		} );
 
 		dispatch( store ).setIsMatching( matches );
 	};

--- a/packages/viewport/src/listener.native.js
+++ b/packages/viewport/src/listener.native.js
@@ -24,22 +24,20 @@ const matchWidth = ( operator, breakpoint ) => {
 };
 
 const addDimensionsEventListener = ( breakpoints, operators ) => {
-	const operatorEntries = Object.entries( operators );
-	const breakpointEntries = Object.entries( breakpoints );
-
 	const setIsMatching = () => {
-		const matches = breakpointEntries.flatMap( ( [ name, width ] ) => {
-			return operatorEntries.map( ( [ operator, condition ] ) => {
-				const list = window.matchMedia(
-					`(${ condition }: ${ width }px)`
+		const matches = Object.entries( breakpoints ).reduce(
+			( result, [ name, width ] ) => {
+				Object.entries( operators ).forEach(
+					( [ operator, condition ] ) => {
+						const key = [ operator, name ].join( ' ' );
+						result[ key ] = matchWidth( condition, width );
+					}
 				);
-				list.addListener( setIsMatching );
-				return [
-					`${ operator } ${ name }`,
-					matchWidth( condition, width ),
-				];
-			} );
-		} );
+
+				return result;
+			},
+			{}
+		);
 
 		dispatch( store ).setIsMatching( matches );
 	};

--- a/packages/viewport/src/listener.native.js
+++ b/packages/viewport/src/listener.native.js
@@ -1,7 +1,6 @@
 /**
  * External dependencies
  */
-import { reduce } from 'lodash';
 import { Dimensions } from 'react-native';
 
 /**
@@ -26,9 +25,8 @@ const matchWidth = ( operator, breakpoint ) => {
 
 const addDimensionsEventListener = ( breakpoints, operators ) => {
 	const setIsMatching = () => {
-		const matches = reduce(
-			breakpoints,
-			( result, width, name ) => {
+		const matches = Object.entries( breakpoints ).reduce(
+			( result, [ name, width ] ) => {
 				Object.entries( operators ).forEach(
 					( [ operator, condition ] ) => {
 						const key = [ operator, name ].join( ' ' );

--- a/packages/viewport/src/listener.native.js
+++ b/packages/viewport/src/listener.native.js
@@ -28,12 +28,14 @@ const addDimensionsEventListener = ( breakpoints, operators ) => {
 	const breakpointEntries = Object.entries( breakpoints );
 
 	const setIsMatching = () => {
-		const matches = breakpointEntries.flatMap( ( [ name, width ] ) => {
-			return operatorEntries.map( ( [ operator, condition ] ) => [
-				`${ operator } ${ name }`,
-				matchWidth( condition, width ),
-			] );
-		} );
+		const matches = Object.fromEntries(
+			breakpointEntries.flatMap( ( [ name, width ] ) => {
+				return operatorEntries.map( ( [ operator, condition ] ) => [
+					`${ operator } ${ name }`,
+					matchWidth( condition, width ),
+				] );
+			} )
+		);
 
 		dispatch( store ).setIsMatching( matches );
 	};

--- a/packages/viewport/src/listener.native.js
+++ b/packages/viewport/src/listener.native.js
@@ -24,20 +24,22 @@ const matchWidth = ( operator, breakpoint ) => {
 };
 
 const addDimensionsEventListener = ( breakpoints, operators ) => {
-	const setIsMatching = () => {
-		const matches = Object.entries( breakpoints ).reduce(
-			( result, [ name, width ] ) => {
-				Object.entries( operators ).forEach(
-					( [ operator, condition ] ) => {
-						const key = [ operator, name ].join( ' ' );
-						result[ key ] = matchWidth( condition, width );
-					}
-				);
+	const operatorEntries = Object.entries( operators );
+	const breakpointEntries = Object.entries( breakpoints );
 
-				return result;
-			},
-			{}
-		);
+	const setIsMatching = () => {
+		const matches = breakpointEntries.flatMap( ( [ name, width ] ) => {
+			return operatorEntries.map( ( [ operator, condition ] ) => {
+				const list = window.matchMedia(
+					`(${ condition }: ${ width }px)`
+				);
+				list.addListener( setIsMatching );
+				return [
+					`${ operator } ${ name }`,
+					matchWidth( condition, width ),
+				];
+			} );
+		} );
 
 		dispatch( store ).setIsMatching( matches );
 	};

--- a/packages/viewport/src/listener.native.js
+++ b/packages/viewport/src/listener.native.js
@@ -33,7 +33,7 @@ const addDimensionsEventListener = ( breakpoints, operators ) => {
 				const list = window.matchMedia(
 					`(${ condition }: ${ width }px)`
 				);
-				list.addEventListener( 'change', setIsMatching );
+				list.addListener( setIsMatching );
 				return [
 					`${ operator } ${ name }`,
 					matchWidth( condition, width ),

--- a/packages/viewport/src/listener.native.js
+++ b/packages/viewport/src/listener.native.js
@@ -33,7 +33,7 @@ const addDimensionsEventListener = ( breakpoints, operators ) => {
 				const list = window.matchMedia(
 					`(${ condition }: ${ width }px)`
 				);
-				list.addListener( setIsMatching );
+				list.addEventListener( 'change', setIsMatching );
 				return [
 					`${ operator } ${ name }`,
 					matchWidth( condition, width ),

--- a/packages/viewport/src/with-viewport-match.js
+++ b/packages/viewport/src/with-viewport-match.js
@@ -1,9 +1,4 @@
 /**
- * External dependencies
- */
-import { mapValues } from 'lodash';
-
-/**
  * WordPress dependencies
  */
 import {
@@ -37,18 +32,20 @@ import {
  */
 const withViewportMatch = ( queries ) => {
 	const useViewPortQueriesResult = () =>
-		mapValues( queries, ( query ) => {
-			let [ operator, breakpointName ] = query.split( ' ' );
-			if ( breakpointName === undefined ) {
-				breakpointName = operator;
-				operator = '>=';
-			}
-			// Hooks should unconditionally execute in the same order,
-			// we are respecting that as from the static query of the HOC we generate
-			// a hook that calls other hooks always in the same order (because the query never changes).
-			// eslint-disable-next-line react-hooks/rules-of-hooks
-			return useViewportMatch( breakpointName, operator );
-		} );
+		Object.fromEntries(
+			Object.entries( queries ).map( ( [ key, query ] ) => {
+				let [ operator, breakpointName ] = query.split( ' ' );
+				if ( breakpointName === undefined ) {
+					breakpointName = operator;
+					operator = '>=';
+				}
+				// Hooks should unconditionally execute in the same order,
+				// we are respecting that as from the static query of the HOC we generate
+				// a hook that calls other hooks always in the same order (because the query never changes).
+				// eslint-disable-next-line react-hooks/rules-of-hooks
+				return [ key, useViewportMatch( breakpointName, operator ) ];
+			} )
+		);
 	return createHigherOrderComponent( ( WrappedComponent ) => {
 		return pure( ( props ) => {
 			const queriesResult = useViewPortQueriesResult();

--- a/packages/viewport/src/with-viewport-match.js
+++ b/packages/viewport/src/with-viewport-match.js
@@ -31,10 +31,9 @@ import {
  * @return {Function} Higher-order component.
  */
 const withViewportMatch = ( queries ) => {
-	const queryEntries = Object.entries( queries );
 	const useViewPortQueriesResult = () =>
 		Object.fromEntries(
-			queryEntries.map( ( [ key, query ] ) => {
+			Object.entries( queries ).map( ( [ key, query ] ) => {
 				let [ operator, breakpointName ] = query.split( ' ' );
 				if ( breakpointName === undefined ) {
 					breakpointName = operator;

--- a/packages/viewport/src/with-viewport-match.js
+++ b/packages/viewport/src/with-viewport-match.js
@@ -31,9 +31,10 @@ import {
  * @return {Function} Higher-order component.
  */
 const withViewportMatch = ( queries ) => {
+	const queryEntries = Object.entries( queries );
 	const useViewPortQueriesResult = () =>
 		Object.fromEntries(
-			Object.entries( queries ).map( ( [ key, query ] ) => {
+			queryEntries.map( ( [ key, query ] ) => {
 				let [ operator, breakpointName ] = query.split( ' ' );
 				if ( breakpointName === undefined ) {
 					breakpointName = operator;

--- a/packages/viewport/src/with-viewport-match.native.js
+++ b/packages/viewport/src/with-viewport-match.native.js
@@ -32,16 +32,18 @@ import { store } from './store';
  *
  * @return {Function} Higher-order component.
  */
-const withViewportMatch = ( queries ) =>
-	createHigherOrderComponent(
+const withViewportMatch = ( queries ) => {
+	const queryEntries = Object.entries( queries );
+	return createHigherOrderComponent(
 		withSelect( ( select ) => {
 			return Object.fromEntries(
-				Object.entries( queries ).map( ( [ key, query ] ) => {
+				queryEntries.map( ( [ key, query ] ) => {
 					return [ key, select( store ).isViewportMatch( query ) ];
 				} )
 			);
 		} ),
 		'withViewportMatch'
 	);
+};
 
 export default withViewportMatch;

--- a/packages/viewport/src/with-viewport-match.native.js
+++ b/packages/viewport/src/with-viewport-match.native.js
@@ -32,16 +32,19 @@ import { store } from './store';
  *
  * @return {Function} Higher-order component.
  */
-const withViewportMatch = ( queries ) =>
-	createHigherOrderComponent(
+const withViewportMatch = ( queries ) => {
+	const queryEntries = Object.entries( queries );
+
+	return createHigherOrderComponent(
 		withSelect( ( select ) => {
 			return Object.fromEntries(
-				Object.entries( queries ).map( ( [ key, query ] ) => {
+				queryEntries.map( ( [ key, query ] ) => {
 					return [ key, select( store ).isViewportMatch( query ) ];
 				} )
 			);
 		} ),
 		'withViewportMatch'
 	);
+};
 
 export default withViewportMatch;

--- a/packages/viewport/src/with-viewport-match.native.js
+++ b/packages/viewport/src/with-viewport-match.native.js
@@ -1,9 +1,4 @@
 /**
- * External dependencies
- */
-import { mapValues } from 'lodash';
-
-/**
  * WordPress dependencies
  */
 import { createHigherOrderComponent } from '@wordpress/compose';
@@ -27,9 +22,9 @@ import { store } from './store';
  *
  * ```jsx
  * function MyComponent( { isMobile } ) {
- * 	return (
- * 		<div>Currently: { isMobile ? 'Mobile' : 'Not Mobile' }</div>
- * 	);
+ *     return (
+ *         <div>Currently: { isMobile ? 'Mobile' : 'Not Mobile' }</div>
+ *     );
  * }
  *
  * MyComponent = withViewportMatch( { isMobile: '< small' } )( MyComponent );
@@ -40,9 +35,11 @@ import { store } from './store';
 const withViewportMatch = ( queries ) =>
 	createHigherOrderComponent(
 		withSelect( ( select ) => {
-			return mapValues( queries, ( query ) => {
-				return select( store ).isViewportMatch( query );
-			} );
+			return Object.fromEntries(
+				Object.entries( queries ).map( ( [ key, query ] ) => {
+					return [ key, select( store ).isViewportMatch( query ) ];
+				} )
+			);
 		} ),
 		'withViewportMatch'
 	);

--- a/packages/viewport/src/with-viewport-match.native.js
+++ b/packages/viewport/src/with-viewport-match.native.js
@@ -32,19 +32,16 @@ import { store } from './store';
  *
  * @return {Function} Higher-order component.
  */
-const withViewportMatch = ( queries ) => {
-	const queryEntries = Object.entries( queries );
-
-	return createHigherOrderComponent(
+const withViewportMatch = ( queries ) =>
+	createHigherOrderComponent(
 		withSelect( ( select ) => {
 			return Object.fromEntries(
-				queryEntries.map( ( [ key, query ] ) => {
+				Object.entries( queries ).map( ( [ key, query ] ) => {
 					return [ key, select( store ).isViewportMatch( query ) ];
 				} )
 			);
 		} ),
 		'withViewportMatch'
 	);
-};
 
 export default withViewportMatch;


### PR DESCRIPTION
## What?
This PR removes all of the Lodash from the `@wordpress/viewport` package, including the `lodash` dependency altogether. There are just a few usages and they're straightforward to replace.

## Why?

Lodash is known to unnecessarily inflate the bundle size of packages, and in most cases, it can be replaced with native language functionality. See these for more information and rationale:

* https://github.com/WordPress/gutenberg/issues/16938#issuecomment-602837246
* https://github.com/WordPress/gutenberg/issues/17025
* https://github.com/WordPress/gutenberg/issues/39495 

## How?

We have to deal essentially with 2 methods (`mapValues`, and `reduce` ), and migration away from them is pretty straightforward, especially because the functionality is covered by unit tests. 

## Testing Instructions
* Insert a gallery block with 3 images, and as you resize down to < 600px, observe that 2 images are displayed per row, and not 3.
* Verify all checks are green and all tests pass.