### PR TITLE
SuggestionList: use requestAnimationFrame instead of setTimeout when scrolling selected item into view

### DIFF
--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -26,6 +26,10 @@
 -   `NavigatorScreen`: fix focus issue where back button received focus unexpectedly ([#44239](https://github.com/WordPress/gutenberg/pull/44239))
 -   `FontSizePicker`: Fix header order in RTL languages ([#44590](https://github.com/WordPress/gutenberg/pull/44590)).
 
+### Enhancements
+
+-   `SuggestionList`: use `requestAnimationFrame` instead of `setTimeout` when scrolling selected item into view. This change improves the responsiveness of the `ComboboxControl` and `FormTokenField` components when rapidly hovering over the suggestion items in the list ([#44573](https://github.com/WordPress/gutenberg/pull/44573)).
+
 ### Internal
 
 -   `Mobile` updated to ignore `react/exhaustive-deps` eslint rule ([#44207](https://github.com/WordPress/gutenberg/pull/44207)).

--- a/packages/components/src/form-token-field/suggestions-list.tsx
+++ b/packages/components/src/form-token-field/suggestions-list.tsx
@@ -38,6 +38,7 @@ export function SuggestionsList< T extends string | { value: string } >( {
 		( listNode ) => {
 			// only have to worry about scrolling selected suggestion into view
 			// when already expanded.
+			let rafId: number | undefined;
 			if (
 				selectedIndex > -1 &&
 				scrollIntoView &&
@@ -51,10 +52,16 @@ export function SuggestionsList< T extends string | { value: string } >( {
 						onlyScrollIfNeeded: true,
 					}
 				);
-				requestAnimationFrame( () => {
+				rafId = requestAnimationFrame( () => {
 					setScrollingIntoView( false );
 				} );
 			}
+
+			return () => {
+				if ( rafId !== undefined ) {
+					cancelAnimationFrame( rafId );
+				}
+			};
 		},
 		[ selectedIndex, scrollIntoView ]
 	);

--- a/packages/components/src/form-token-field/suggestions-list.tsx
+++ b/packages/components/src/form-token-field/suggestions-list.tsx
@@ -38,7 +38,6 @@ export function SuggestionsList< T extends string | { value: string } >( {
 		( listNode ) => {
 			// only have to worry about scrolling selected suggestion into view
 			// when already expanded.
-			let id: number;
 			if (
 				selectedIndex > -1 &&
 				scrollIntoView &&
@@ -52,16 +51,10 @@ export function SuggestionsList< T extends string | { value: string } >( {
 						onlyScrollIfNeeded: true,
 					}
 				);
-				id = window.setTimeout( () => {
+				requestAnimationFrame( () => {
 					setScrollingIntoView( false );
-				}, 100 );
+				} );
 			}
-
-			return () => {
-				if ( id !== undefined ) {
-					window.clearTimeout( id );
-				}
-			};
 		},
 		[ selectedIndex, scrollIntoView ]
 	);


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

As originally flagged by @andrewserong in https://github.com/WordPress/gutenberg/pull/44526#pullrequestreview-1124715152, currently `SuggestionList` (used in the `ComboboxControl` and `FormTokenField` components) uses a 100ms timeout when scrolling selected list items into view. This timeout causes the UI to be very unresponsive when hovering over the list of suggestions.

This PR swaps the `setTimeout` call with a `requestAnimationFrame` call, in order to minimize the delay while keeping the "scroll into view" logic unchanged.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

Make out UI smoother and more pleasant to interact with

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

Swap the `setTimeout` call with a `requestAnimationFrame` call, in order to minimize the delay while keeping the "scroll into view" logic unchanged.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->

On `ComboboxControl`:

- Click on the input, scroll down and pick an item that would normally render "below the fold" in the list of suggestions
  - [ ] Make sure that the suggestions are highlighted in a responsive manner when hovering (contrarily to what happens on `trunk`)
- Click outside the combobox to blur the input
- Click on the combobox's input again:
  - [ ] the suggestion list should open and the list of suggestions should be scrolled to the previously selected item
- As a bonus: while the list of suggestions is opened, move the cursor to the edges of the list
  - [ ] Make sure that when hovering on an item that is only partially visible, the list automatically scrolls that item fully into view
- [ ] Make sure that the same behaviors described above can be observed [on `trunk`](https://wordpress.github.io/gutenberg) as well

## Screenshots or screencast <!-- if applicable -->

`trunk`:

https://user-images.githubusercontent.com/1083581/193004840-b0be93bd-b362-45c5-aa61-5205d6f8c4ae.mp4

This PR:

https://user-images.githubusercontent.com/1083581/193004527-ce6441fa-fe44-4ce9-8b43-0b5f31bea5fa.mp4