### PR TITLE
Button: Adopt support for border color, style, and width

### DIFF
--- a/packages/block-library/src/button/block.json
+++ b/packages/block-library/src/button/block.json
@@ -92,10 +92,16 @@
 			}
 		},
 		"__experimentalBorder": {
+			"color": true,
 			"radius": true,
+			"style": true,
+			"width": true,
 			"__experimentalSkipSerialization": true,
 			"__experimentalDefaultControls": {
-				"radius": true
+				"color": true,
+				"radius": true,
+				"style": true,
+				"width": true
 			}
 		},
 		"__experimentalSelector": ".wp-block-button .wp-block-button__link"

--- a/packages/block-library/src/button/editor.scss
+++ b/packages/block-library/src/button/editor.scss
@@ -82,7 +82,7 @@ div[data-type="core/button"] {
 
 .editor-styles-wrapper .wp-block-button .wp-block-button__link {
 	// The following styles smooth out the experience editing borders for individual
-	// buttons. They override the `button-width: 0;` applied by core's theme.json
+	// buttons. They override the `border-width: 0;` applied by core's theme.json
 	// via the Elements API button.
 	&:where(.has-border-color) {
 		border-width: initial;

--- a/packages/block-library/src/button/editor.scss
+++ b/packages/block-library/src/button/editor.scss
@@ -79,3 +79,40 @@ div[data-type="core/button"] {
 .editor-styles-wrapper .wp-block-button[style*="text-decoration"] .wp-block-button__link {
 	text-decoration: inherit;
 }
+
+.editor-styles-wrapper .wp-block-button .wp-block-button__link {
+	// The following styles smooth out the experience editing borders for individual
+	// buttons. They override the `button-width: 0;` applied by core's theme.json
+	// via the Elements API button.
+	&:where(.has-border-color) {
+		border-width: initial;
+	}
+	&:where([style*="border-top-color"]) {
+		border-top-width: initial;
+	}
+	&:where([style*="border-right-color"]) {
+		border-right-width: initial;
+	}
+	&:where([style*="border-bottom-color"]) {
+		border-bottom-width: initial;
+	}
+	&:where([style*="border-left-color"]) {
+		border-left-width: initial;
+	}
+
+	&:where([style*="border-style"]) {
+		border-width: initial;
+	}
+	&:where([style*="border-top-style"]) {
+		border-top-width: initial;
+	}
+	&:where([style*="border-right-style"]) {
+		border-right-width: initial;
+	}
+	&:where([style*="border-bottom-style"]) {
+		border-bottom-width: initial;
+	}
+	&:where([style*="border-left-style"]) {
+		border-left-width: initial;
+	}
+}

--- a/packages/block-library/src/button/editor.scss
+++ b/packages/block-library/src/button/editor.scss
@@ -83,7 +83,8 @@ div[data-type="core/button"] {
 .editor-styles-wrapper .wp-block-button .wp-block-button__link {
 	// The following styles smooth out the experience editing borders for individual
 	// buttons. They override the `border-width: 0;` applied by core's theme.json
-	// via the Elements API button.
+	// via the Elements API button. Without these overrides if a user selects a border
+	// color it won't show in the editor unless they also select a border width.
 	&:where(.has-border-color) {
 		border-width: initial;
 	}

--- a/packages/block-library/src/button/editor.scss
+++ b/packages/block-library/src/button/editor.scss
@@ -81,10 +81,8 @@ div[data-type="core/button"] {
 }
 
 .editor-styles-wrapper .wp-block-button .wp-block-button__link {
-	// The following styles smooth out the experience editing borders for individual
-	// buttons. They override the `border-width: 0;` applied by core's theme.json
-	// via the Elements API button. Without these overrides if a user selects a border
-	// color it won't show in the editor unless they also select a border width.
+	// The following styles ensure a default border is applied when the user selects only a border color or style in the editor,
+	// but no width. They override the `border-width: 0;` applied by core's theme.json via the Elements API button.
 	&:where(.has-border-color) {
 		border-width: initial;
 	}

--- a/packages/block-library/src/button/style.scss
+++ b/packages/block-library/src/button/style.scss
@@ -92,7 +92,6 @@ $blocks-block__margin: 0.5em;
 	border-radius: 0;
 }
 
-
 // the first selector is required for old buttons markup
 .wp-block-button.no-border-radius,
 .wp-block-button__link.no-border-radius {
@@ -115,4 +114,41 @@ $blocks-block__margin: 0.5em;
 	background-color: transparent;
 	// background-image is required to overwrite a gradient background
 	background-image: none;
+}
+
+.wp-block-button .wp-block-button__link {
+	// The following styles ensure a default border is applied when the user
+	// selects only a border color or style. This overcomes the zero border
+	// width applied by core's theme.json via the elements API.
+	&:where(.has-border-color) {
+		border-width: initial;
+	}
+	&:where([style*="border-top-color"]) {
+		border-top-width: initial;
+	}
+	&:where([style*="border-right-color"]) {
+		border-right-width: initial;
+	}
+	&:where([style*="border-bottom-color"]) {
+		border-bottom-width: initial;
+	}
+	&:where([style*="border-left-color"]) {
+		border-left-width: initial;
+	}
+
+	&:where([style*="border-style"]) {
+		border-width: initial;
+	}
+	&:where([style*="border-top-style"]) {
+		border-top-width: initial;
+	}
+	&:where([style*="border-right-style"]) {
+		border-right-width: initial;
+	}
+	&:where([style*="border-bottom-style"]) {
+		border-bottom-width: initial;
+	}
+	&:where([style*="border-left-style"]) {
+		border-left-width: initial;
+	}
 }


### PR DESCRIPTION
## What?

Adopts border color, style, and width, supports for the Button block.

## Why?
- Provides greater control over button borders
- Allows any borders configured via theme.json to be tweaked via Global Styles.

## How?
- Opts into color, style, and width, support via the Button `block.json`

## Testing Instructions
1. Add some button styles via your theme.json `blocks` section. (See snippet below)
2. Load the editor add a `Buttons` block and a few buttons within it. They should reflect the styles in your theme.json
3. Save the post and switch to the site editor
4. Navigate to Global Styles > Blocks > Button > Layout and adjust the border there.
5. Switch back to your post, the buttons should now reflect the Global Styles values.
6. Select a button block and configure that individually via the inspector controls sidebar.
7. Ensure all the styles are applied correctly on the frontend.

Example theme.json snippet:
```json
	"styles": {
		"blocks": {
			"core/button": {
				"border": {
					"radius": "0",
					"color": "fuchsia",
					"style": "solid",
					"width": "10px"
				},
			}
		}
	}
```


## Screenshots or screencast <!-- if applicable -->



https://user-images.githubusercontent.com/60436221/193013631-97c2d7bc-4b80-471c-8531-aaf3874f8e03.mp4



