### PR TITLE
ToggleGroupControl: fix unselected icon color

### DIFF
--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 -   `Popover`: fix limitShift logic by adding iframe offset correctly [#42950](https://github.com/WordPress/gutenberg/pull/42950)).
 -   `Popover`: refine position-to-placement conversion logic, add tests ([#44377](https://github.com/WordPress/gutenberg/pull/44377)).
+-   `ToggleGroupControl`: adjust icon color when inactive, from `gray-700` to `gray-900` ([#44575](https://github.com/WordPress/gutenberg/pull/44575)).
 -   `TokenInput`: improve logic around the `aria-activedescendant` attribute, which was causing unintended focus behavior for some screen readers ([#44526](https://github.com/WordPress/gutenberg/pull/44526)).
 
 ### Internal

--- a/packages/components/src/toggle-group-control/test/__snapshots__/index.tsx.snap
+++ b/packages/components/src/toggle-group-control/test/__snapshots__/index.tsx.snap
@@ -159,6 +159,7 @@ exports[`ToggleGroupControl should render correctly with icons 1`] = `
 }
 
 .emotion-15 {
+  color: #1e1e1e;
   width: 30px;
   padding-left: 0;
   padding-right: 0;

--- a/packages/components/src/toggle-group-control/toggle-group-control-option-base/styles.ts
+++ b/packages/components/src/toggle-group-control/toggle-group-control-option-base/styles.ts
@@ -55,13 +55,6 @@ export const buttonView = css`
 	}
 `;
 
-export const buttonActive = css`
-	color: ${ COLORS.white };
-	&:active {
-		background: transparent;
-	}
-`;
-
 export const ButtonContentView = styled.div`
 	font-size: ${ CONFIG.fontSize };
 	line-height: 1;
@@ -82,8 +75,17 @@ export const isIcon = ( {
 	};
 
 	return css`
+		color: ${ COLORS.gray[ 900 ] };
 		width: ${ iconButtonSizes[ size ] };
 		padding-left: 0;
 		padding-right: 0;
 	`;
 };
+
+export const buttonActive = css`
+	color: ${ COLORS.white };
+
+	&:active {
+		background: transparent;
+	}
+`;


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Fix the unselected icon color in `ToggleGroupControl`, as flagged by @jasmussen in https://github.com/WordPress/gutenberg/issues/44560#issuecomment-1261898150, 

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

Unselected icons in `ToggleGroupControl` should be using the darkest gray (`gray-900`) as their color, but they currently use a lighter shade (`gray-700`), since that is the text color used for unselected options in the component.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

Change the unselected icon color in `ToggleGroupControl` to be `gray-900`.

Note: when text is used instead of icons, the text color for unselected options will remain `gray-700` 

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->

- Visit the Storybook examples for the `ToggleGroupControl` component, check that:
  - [ ] Unselected options in the default example look the same as on `trunk`
  - [ ] Unselected icon options (in the "With Icons" example) use `gray-900`, unlike `trunk`
- Check that the icons in the layout panel in the editor also use the new `gray-900`

## Screenshots or screencast <!-- if applicable -->

| | `trunk` | This PR |
|---|---|---|
| Text options | <img width="263" alt="Screenshot 2022-09-29 at 13 26 19" src="https://user-images.githubusercontent.com/1083581/193020751-ba40bc59-9dcd-4c80-92be-1c6f53c62b60.png"> | <img width="262" alt="Screenshot 2022-09-29 at 13 34 07" src="https://user-images.githubusercontent.com/1083581/193023616-d4838dd8-ea84-4330-8234-b362ef714432.png"> |
| Icons | <img width="90" alt="Screenshot 2022-09-29 at 13 26 29" src="https://user-images.githubusercontent.com/1083581/193020826-c9dcf9f5-462e-4f1c-8602-1ee5fc94cc9b.png"> | <img width="89" alt="Screenshot 2022-09-29 at 13 48 46" src="https://user-images.githubusercontent.com/1083581/193023635-0849f160-66b4-48be-b47c-65c0e293d0b4.png"> |


_(ignore the focus ring around the component, that will remained unchanged)_
