### PR TITLE
Video Block: fix unclickable button on placeholder

### DIFF
--- a/packages/block-library/src/video/editor.scss
+++ b/packages/block-library/src/video/editor.scss
@@ -16,6 +16,10 @@
 			opacity: 0;
 		}
 
+		.components-placeholder__illustration {
+			display: none;
+		}
+
 		&::before {
 			opacity: 0;
 		}


### PR DESCRIPTION
Follow-up on: #44215

## What?
This PR fixes a problem where the media buttons can't be clicked with the mouse in the video block placeholder.

## Why?
This is because the placeholder is covered by the svg element with `opacity:0`.

## How?
After comparing with the editor style for the image block, a style to hide SVG elements when a block is selected was missing, so it was added.

## Testing Instructions
- Add the video block.
- When a block is selected, a placeholder is displayed.
- Confirm that you can click on the three buttons in the placeholder.

## Screenshots or screencast

### Before

https://user-images.githubusercontent.com/54422211/193032533-a646eddd-5771-486f-8403-c353f0299873.mp4

### After

https://user-images.githubusercontent.com/54422211/193032097-3b091dcc-b2c3-40dd-b357-2a8f0a013b35.mp4


