### PR TITLE
Navigation: Try fixing link color in some TT2 contexts.

### DIFF
--- a/packages/block-library/src/navigation/style.scss
+++ b/packages/block-library/src/navigation/style.scss
@@ -49,6 +49,8 @@ $navigation-icon-size: 24px;
 
 	// This rule needs extra specificity so that it inherits the correct color from its parent.
 	// Otherwise, a link color set by a parent group can override the value.
+	// This also fixes an issue where a navigation with an explicitly set color is overridden
+	// by link colors defined in Global Styles.
 	.wp-block-navigation-item__content.wp-block-navigation-item__content {
 		color: inherit;
 	}

--- a/packages/block-library/src/navigation/style.scss
+++ b/packages/block-library/src/navigation/style.scss
@@ -47,6 +47,8 @@ $navigation-icon-size: 24px;
 		display: block;
 	}
 
+	// This rule needs extra specificity so that it inherits the correct color from its parent.
+	// Otherwise, a link color set by a parent group can override the value.
 	.wp-block-navigation-item__content.wp-block-navigation-item__content {
 		color: inherit;
 	}

--- a/packages/block-library/src/navigation/style.scss
+++ b/packages/block-library/src/navigation/style.scss
@@ -47,6 +47,10 @@ $navigation-icon-size: 24px;
 		display: block;
 	}
 
+	.wp-block-navigation-item__content.wp-block-navigation-item__content {
+		color: inherit;
+	}
+
 	// The following rules provide class based application of user selected text
 	// decoration via block supports.
 	&.has-text-decoration-underline .wp-block-navigation-item__content {


### PR DESCRIPTION
## What?

Alternative to #44409. Fixes an issue where submenus in TT2 would be white on a white background.

I'm seeing this issue both for custom menus, and for page list menus, and in both the editor and the frontend. Steps to reproduce on #44409. 

It isn't entirely clear to me what sets the color to white in TT2, but it is set with somewhat high specificity, so this PR needs to boost it further. It's important to test this one with all configurations of navigation colors, with and without backgrounds, with and without submenu colors.

Before:

<img width="663" alt="Screenshot 2022-09-29 at 15 43 51" src="https://user-images.githubusercontent.com/1204802/193048186-53021a92-8421-432c-a6ea-df833b6b06fd.png">

After:

<img width="527" alt="Screenshot 2022-09-29 at 15 39 40" src="https://user-images.githubusercontent.com/1204802/193048206-fe5afd42-1831-4993-830c-21fb5e3c4e51.png">


<img width="544" alt="Screenshot 2022-09-29 at 15 39 48" src="https://user-images.githubusercontent.com/1204802/193048129-d9f44f68-ea4b-4d38-8ec0-854439597adb.png">

Also fixes #20017, where a link color defined in global styles can override an explicitly set color on the navigation block. Before:

<img width="1104" alt="before" src="https://user-images.githubusercontent.com/1204802/193559454-d786995b-1153-4c4d-ae56-ca7c3f0633d1.png">

After:

<img width="1108" alt="after" src="https://user-images.githubusercontent.com/1204802/193559460-e6b94220-1e82-4a45-a549-42841c7137ce.png">
