### PR TITLE
Code Block: Add box-sizing to fix inconsistent layout

### DIFF
--- a/packages/block-library/src/code/style.scss
+++ b/packages/block-library/src/code/style.scss
@@ -1,8 +1,13 @@
-// Provide a minimum of overflow handling and ensure the code markup inherits
-// the font-family set on pre.
-.wp-block-code code {
-	display: block;
-	font-family: inherit;
-	overflow-wrap: break-word;
-	white-space: pre-wrap;
+.wp-block-code {
+	// This block has customizable padding, border-box makes that more predictable.
+	box-sizing: border-box;
+
+	// Provide a minimum of overflow handling and ensure the code markup inherits
+	// the font-family set on pre.
+	code {
+		display: block;
+		font-family: inherit;
+		overflow-wrap: break-word;
+		white-space: pre-wrap;
+	}
 }


### PR DESCRIPTION
Related to: https://github.com/WordPress/gutenberg/issues/43465

## What?
This PR adds `box-sizing: border-box;` to the Code block `style.css` file.

## Why?
When padding is applied to the Code block, the block extends beyond the defined content width due to no `box-sizing: border-box;`. This PR fixes that to ensure consistency across core blocks. See screenshots for details.

 Since standardizing design tools was a big part of 6.1, I think it makes sense to backport this minor bug fix. 

## How?
Add `box-sizing: border-box;` to the Code block `style.css` file. 

## Testing Instructions
1. Using the TT2 theme, add a code block (note there is another COde block issue in TT3, so use TT2 for this)
2. Add some ample padding. 
3. Notice that the Code block remains contained within the content width, unlike before. 

## Screenshots or screencast

**Before:**

![image](https://user-images.githubusercontent.com/4832319/193050914-89d9086d-ca5e-4c72-97eb-238bf402fd20.png)

**After:**

![image](https://user-images.githubusercontent.com/4832319/193051035-96f5ed68-b6ca-4726-8701-e69330ddf27f.png)


