### PR TITLE
Fix comment typo in document generation tools

### DIFF
--- a/bin/api-docs/gen-block-lib-list.js
+++ b/bin/api-docs/gen-block-lib-list.js
@@ -1,7 +1,7 @@
 /**
  * Generates core block documentation using block.json files.
  * Reads from  : packages/block-library/src
- * Publishes to: docs/reference-guides/core-blocks.ms
+ * Publishes to: docs/reference-guides/core-blocks.md
  */
 
 /**

--- a/bin/api-docs/gen-theme-reference.js
+++ b/bin/api-docs/gen-theme-reference.js
@@ -1,7 +1,7 @@
 /**
- * Generates core block documentation using block.json files.
- * Reads from  : packages/block-library/src
- * Publishes to: docs/reference-guides/core-blocks.ms
+ * Generates theme.json documentation using theme.json schema.
+ * Reads from  : schemas/json/theme.json
+ * Publishes to: docs/reference-guides/theme-json-reference/theme-json-living.md
  */
 
 /**


### PR DESCRIPTION
## What?
This PR Fixes comment typo in document generation tools.

## How?

### bin/api-docs/gen-block-lib-list.js

Fix typo in extension.

### bin/api-docs/gen-theme-reference.js

I have updated this comment appropriately as it appeared to be copied from the above file.

## Testing Instructions
No impact on code.
