### PR TITLE
Avoid querying block templates during installation

### DIFF
--- a/packages/block-library/src/template-part/index.php
+++ b/packages/block-library/src/template-part/index.php
@@ -189,6 +189,10 @@ function build_template_part_block_area_variations() {
  * @return array Array containing the block variation objects.
  */
 function build_template_part_block_instance_variations() {
+	// Block themes are unavailable during installation.
+	if ( wp_installing() ) {
+		return array();
+	}
 	$variations     = array();
 	$template_parts = get_block_templates(
 		array(


### PR DESCRIPTION
The database tables don't yet exist.

From https://core.trac.wordpress.org/ticket/56617