### PR TITLE
Theme export: Stop slugs being cast to ints when theme is exported

### DIFF
--- a/lib/compat/wordpress-6.0/class-wp-theme-json-6-0.php
+++ b/lib/compat/wordpress-6.0/class-wp-theme-json-6-0.php
@@ -592,7 +592,7 @@ class WP_Theme_JSON_6_0 extends WP_Theme_JSON {
 				}
 				$flattened_preset = array();
 				foreach ( $items as $slug => $value ) {
-					$flattened_preset[] = array_merge( array( 'slug' => $slug ), $value );
+					$flattened_preset[] = array_merge( array( 'slug' => (string) $slug ), $value );
 				}
 				_wp_array_set( $output, $path, $flattened_preset );
 			}


### PR DESCRIPTION
## What?
Prevent slugs containing only digits from being cast to ints by PHP when used as keys in theme.json processing

## Why?

Fixes one of the issues noted in #44546 that spacing preset slugs are cast to ints when a theme is exported via the site editor

## How?
Cast the array key to a string when converting back to the preset sizing array

## Testing Instructions

- In a site with the 2023 theme set export the theme from the site editor
- Make sure the exported theme.json has the settings.spacingScale slugs as strings
- Check that the spacing presets still work as expected in post editor, site editor and frontend

## Screenshots or screencast 

before:
<img width="603" alt="Screen Shot 2022-09-30 at 10 49 43 AM" src="https://user-images.githubusercontent.com/3629020/193148488-169b53e8-4844-47d8-b756-4bd1165a5da8.png">

after:
<img width="594" alt="Screen Shot 2022-09-30 at 10 49 50 AM" src="https://user-images.githubusercontent.com/3629020/193148513-1f46e0bf-601b-4c04-b3f5-aad8dfe98fb1.png">

