### PR TITLE
BorderBoxControl: Omit unit select when values are mixed

### DIFF
--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -5,7 +5,7 @@
 ### Enhancements
 
 -   `FontSizePicker`: Updated to take up full width of its parent and have a 40px Reset button when `size` is `__unstable-large` ((44559)[https://github.com/WordPress/gutenberg/pull/44559]).
--   `BorderBoxControl`: Omit unit select when values are mixed ([#44592](https://github.com/WordPress/gutenberg/pull/44592))
+-   `BorderBoxControl`: Omit unit select when width values are mixed ([#44592](https://github.com/WordPress/gutenberg/pull/44592))
 -   `BorderControl`: Add ability to disable unit selection ([#44592](https://github.com/WordPress/gutenberg/pull/44592))
 
 ### Bug Fix

--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -5,10 +5,12 @@
 ### Enhancements
 
 -   `FontSizePicker`: Updated to take up full width of its parent and have a 40px Reset button when `size` is `__unstable-large` ((44559)[https://github.com/WordPress/gutenberg/pull/44559]).
+-   `BorderBoxControl`: Omit unit select when values are mixed ([#44592](https://github.com/WordPress/gutenberg/pull/44592))
+-   `BorderControl`: Add ability to disable unit selection ([#44592](https://github.com/WordPress/gutenberg/pull/44592))
 
 ### Bug Fix
 
--   `Popover`: fix limitShift logic by adding iframe offset correctly [#42950](https://github.com/WordPress/gutenberg/pull/42950)).
+-   `Popover`: fix limitShift logic by adding iframe offset correctly ([#42950](https://github.com/WordPress/gutenberg/pull/42950)).
 -   `Popover`: refine position-to-placement conversion logic, add tests ([#44377](https://github.com/WordPress/gutenberg/pull/44377)).
 -   `ToggleGroupControl`: adjust icon color when inactive, from `gray-700` to `gray-900` ([#44575](https://github.com/WordPress/gutenberg/pull/44575)).
 -   `TokenInput`: improve logic around the `aria-activedescendant` attribute, which was causing unintended focus behavior for some screen readers ([#44526](https://github.com/WordPress/gutenberg/pull/44526)).

--- a/packages/components/src/border-box-control/border-box-control/component.tsx
+++ b/packages/components/src/border-box-control/border-box-control/component.tsx
@@ -46,6 +46,7 @@ const BorderBoxControl = (
 		className,
 		colors,
 		disableCustomColors,
+		disableUnits,
 		enableAlpha,
 		enableStyle,
 		hasMixedBorders,
@@ -100,7 +101,7 @@ const BorderBoxControl = (
 					<BorderControl
 						className={ linkedControlClassName }
 						colors={ colors }
-						disableUnits={ hasMixedBorders }
+						disableUnits={ disableUnits }
 						disableCustomColors={ disableCustomColors }
 						enableAlpha={ enableAlpha }
 						enableStyle={ enableStyle }

--- a/packages/components/src/border-box-control/border-box-control/component.tsx
+++ b/packages/components/src/border-box-control/border-box-control/component.tsx
@@ -100,6 +100,7 @@ const BorderBoxControl = (
 					<BorderControl
 						className={ linkedControlClassName }
 						colors={ colors }
+						disableUnits={ hasMixedBorders }
 						disableCustomColors={ disableCustomColors }
 						enableAlpha={ enableAlpha }
 						enableStyle={ enableStyle }

--- a/packages/components/src/border-box-control/border-box-control/hook.ts
+++ b/packages/components/src/border-box-control/border-box-control/hook.ts
@@ -41,6 +41,9 @@ export function useBorderBoxControl(
 		? ( value as Borders )
 		: getSplitBorders( value as Border | undefined );
 
+	// If no numeric width value is set, the unit select will be disabled.
+	const hasWidthValue = ! isNaN( parseFloat( `${ linkedValue?.width }` ) );
+
 	const [ isLinked, setIsLinked ] = useState( ! mixedBorders );
 	const toggleLinked = () => setIsLinked( ! isLinked );
 
@@ -107,6 +110,7 @@ export function useBorderBoxControl(
 	return {
 		...otherProps,
 		className: classes,
+		disableUnits: mixedBorders && ! hasWidthValue,
 		hasMixedBorders: mixedBorders,
 		isLinked,
 		linkedControlClassName,

--- a/packages/components/src/border-box-control/test/index.js
+++ b/packages/components/src/border-box-control/test/index.js
@@ -120,17 +120,20 @@ describe( 'BorderBoxControl', () => {
 			expect( widthInput.value ).toBe( '1' );
 		} );
 
-		it( 'should render placeholder when border values are mixed', () => {
+		it( 'should render placeholder and omit unit select when border values are mixed', () => {
 			renderBorderBoxControl( { value: mixedBorders } );
 
 			// First render of control with mixed values should show split view.
 			clickButton( 'Link sides' );
 
 			const widthInput = screen.getByRole( 'spinbutton' );
+			const unitSelect = screen.queryByRole( 'combobox' );
+
 			expect( widthInput ).toHaveAttribute( 'placeholder', 'Mixed' );
+			expect( unitSelect ).not.toBeInTheDocument();
 		} );
 
-		it( 'should render shared border width when switching to linked view', async () => {
+		it( 'should render shared border width and unit select when switching to linked view', async () => {
 			// Render control with mixed border values but consistent widths.
 			renderBorderBoxControl( {
 				value: {
@@ -144,8 +147,10 @@ describe( 'BorderBoxControl', () => {
 			// First render of control with mixed values should show split view.
 			clickButton( 'Link sides' );
 			const linkedInput = screen.getByRole( 'spinbutton' );
+			const unitSelect = screen.getByRole( 'combobox' );
 
 			expect( linkedInput.value ).toBe( '5' );
+			expect( unitSelect ).toBeInTheDocument();
 		} );
 
 		it( 'should omit style options when requested', () => {

--- a/packages/components/src/border-control/border-control/README.md
+++ b/packages/components/src/border-control/border-control/README.md
@@ -66,6 +66,12 @@ This toggles the ability to choose custom colors.
 
 - Required: No
 
+### `disableUnits`: `boolean`
+
+This controls whether unit selection should be disabled.
+
+- Required: No
+
 ### `enableAlpha`: `boolean`
 
 This controls whether the alpha channel will be offered when selecting

--- a/packages/components/src/border-control/border-control/component.tsx
+++ b/packages/components/src/border-control/border-control/component.tsx
@@ -39,6 +39,7 @@ const UnconnectedBorderControl = (
 	const {
 		colors,
 		disableCustomColors,
+		disableUnits,
 		enableAlpha,
 		enableStyle = true,
 		hideLabelFromVision,
@@ -97,6 +98,7 @@ const UnconnectedBorderControl = (
 					onChange={ onWidthChange }
 					value={ border?.width || '' }
 					placeholder={ placeholder }
+					disableUnits={ disableUnits }
 					__unstableInputWidth={ inputWidth }
 				/>
 				{ withSlider && (

--- a/packages/components/src/border-control/types.ts
+++ b/packages/components/src/border-control/types.ts
@@ -68,6 +68,10 @@ export type LabelProps = {
 export type BorderControlProps = ColorProps &
 	LabelProps & {
 		/**
+		 * This controls whether unit selection should be disabled.
+		 */
+		disableUnits?: boolean;
+		/**
 		 * This controls whether to include border style options within the
 		 * `BorderDropdown` sub-component.
 		 *


### PR DESCRIPTION
Related: 
- https://github.com/WordPress/gutenberg/pull/41860
- https://github.com/WordPress/gutenberg/pull/44565

## What?

Hides the unit select from the `BorderBoxControl` when it has mixed values. 

Behind the scenes the control still maintains the most common unit selection from the mixed values. This way when the user adjusts the "linked" control then that previous unit selection is honoured.

## Why?

- This provides extra real estate when values are mixed for a meaningful placeholder to be displayed. This is more important as we switch to 40px tall controls that have increased internal padding by default.
- When mixed values are set, the color and width value are shown in an unset state. This also effectively makes the unit appear "unset" as well.

## How?

Adds a new `disableUnits` prop to the `BorderControl`, which is passed through to the `UnitControl`. When the `BorderBoxControl` has mixed values it will use the new prop to disable the unit select.

#### Alternative approach.

One alternative might be to simply check for the existence of a placeholder in the `BorderControl`. At preset the only time this placeholder is set is when the `BorderBoxControl` passes 'Mixed' to represent that state. This seemed a bit fragile and I can see in the near future if we gain access to Global Styles data in the post editor, that value might actually be used as a placeholder.

## Testing Instructions
1. Fire up storybook and confirm the control behaves as normal except when the values are mixed, the unit select is hidden.
2. Confirm there are no surprises in the block editor.

## Screenshots or screencast <!-- if applicable -->

| Before | After |
|---|---|
| <img width="280" alt="Screen Shot 2022-09-30 at 12 07 53 pm" src="https://user-images.githubusercontent.com/60436221/193183441-d368e687-9cf7-4928-b08a-d0ed311a7fcc.png"> | <img width="278" alt="Screen Shot 2022-09-30 at 1 23 10 pm" src="https://user-images.githubusercontent.com/60436221/193183438-ec7014f7-3bf6-4eec-bfce-9dbbfa9698eb.png"> |


https://user-images.githubusercontent.com/60436221/193183421-76af73e3-b396-4ecf-b152-d9c81ae68ed1.mp4


