### PR TITLE
Fix navigation block console error

### DIFF
--- a/packages/block-library/src/navigation/edit/index.js
+++ b/packages/block-library/src/navigation/edit/index.js
@@ -282,16 +282,18 @@ function Navigation( {
 		hasResolvedNavigationMenus &&
 		! hasUncontrolledInnerBlocks;
 
-	if ( isPlaceholder && ! ref ) {
-		/**
-		 *  this fallback only displays (both in editor and on front)
-		 *  the list of pages block if no menu is available as a fallback.
-		 *  We don't want the fallback to request a save,
-		 *  nor to be undoable, hence we mark it non persistent.
-		 */
-		__unstableMarkNextChangeAsNotPersistent();
-		replaceInnerBlocks( clientId, [ createBlock( 'core/page-list' ) ] );
-	}
+	useEffect( () => {
+		if ( isPlaceholder && ! ref ) {
+			/**
+			 *  this fallback only displays (both in editor and on front)
+			 *  the list of pages block if no menu is available as a fallback.
+			 *  We don't want the fallback to request a save,
+			 *  nor to be undoable, hence we mark it non persistent.
+			 */
+			__unstableMarkNextChangeAsNotPersistent();
+			replaceInnerBlocks( clientId, [ createBlock( 'core/page-list' ) ] );
+		}
+	}, [ clientId, isPlaceholder, ref ] );
 
 	const isEntityAvailable =
 		! isNavigationMenuMissing && isNavigationMenuResolved;


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
After resetting my dev environment recently, I noticed an error in the console when entering the site editor:
```
Warning: Cannot update a component (`TemplateAreas`) while rendering a different component (`Navigation`). To locate the bad setState() call inside `Navigation`, follow the stack trace as described in https://reactjs.org/link/setstate-in-render
    at Navigation (http://localhost:8888/wp-content/plugins/gutenberg/build/block-library/index.min.js?ver=e2c4a47915e520227f20:34672:5)
```

It looks like this happens when there are no navigation menus.

## Why?
It seems to be happening because `replaceInnerBlocks` is called during render:
https://github.com/WordPress/gutenberg/blob/469e2886a3bfbd89eba7cb55c982b6111d9bcee7/packages/block-library/src/navigation/edit/index.js#L285-L294

Side-effecty code should be in an effect.

## How?
Move the code into an effect.

I still think it'd be good to export using an inner blocks `template` in place of this call to `replaceInnerBlocks` (edit: I've done that now in https://github.com/WordPress/gutenberg/pull/44596). But this is a small PR that can be backported to 6.1. Using a template is a bit too dramatic to backport.

## Testing Instructions
1. Delete all menus
2. Open the site editor
3. There should be no console error.

## Screenshots or screencast <!-- if applicable -->
### Before
![Screen Shot 2022-09-30 at 11 58 24 am](https://user-images.githubusercontent.com/677833/193187180-897f30ea-4bf2-40bb-b142-7126bea10ef0.png)

### After
![Screen Shot 2022-09-30 at 12 15 29 pm](https://user-images.githubusercontent.com/677833/193189133-ad1653e9-8faf-4423-9d72-739304248cee.png)

