### PR TITLE
Navigation block: Try using a templated page list when there are no menus or inner blocks

### DIFF
--- a/packages/block-library/src/navigation/edit/index.js
+++ b/packages/block-library/src/navigation/edit/index.js
@@ -34,7 +34,6 @@ import {
 } from '@wordpress/components';
 import { __, sprintf } from '@wordpress/i18n';
 import { speak } from '@wordpress/a11y';
-import { createBlock } from '@wordpress/blocks';
 import { close, Icon } from '@wordpress/icons';
 
 /**
@@ -281,19 +280,6 @@ function Navigation( {
 		! isConvertingClassicMenu &&
 		hasResolvedNavigationMenus &&
 		! hasUncontrolledInnerBlocks;
-
-	useEffect( () => {
-		if ( isPlaceholder && ! ref ) {
-			/**
-			 *  this fallback only displays (both in editor and on front)
-			 *  the list of pages block if no menu is available as a fallback.
-			 *  We don't want the fallback to request a save,
-			 *  nor to be undoable, hence we mark it non persistent.
-			 */
-			__unstableMarkNextChangeAsNotPersistent();
-			replaceInnerBlocks( clientId, [ createBlock( 'core/page-list' ) ] );
-		}
-	}, [ clientId, isPlaceholder, ref ] );
 
 	const isEntityAvailable =
 		! isNavigationMenuMissing && isNavigationMenuResolved;
@@ -621,14 +607,14 @@ function Navigation( {
 		</InspectorControls>
 	);
 
-	// If the block has inner blocks, but no menu id, then these blocks are either:
+	// If no navigation menu entity is available, then these blocks are either:
+	// - showing the default Page List inner block when there are no menus or inner blocks of any kind.
 	// - inserted via a pattern.
 	// - inserted directly via Code View (or otherwise).
 	// - from an older version of navigation block added before the block used a wp_navigation entity.
 	// Consider this state as 'unsaved' and offer an uncontrolled version of inner blocks,
 	// that automatically saves the menu as an entity when changes are made to the inner blocks.
-	const hasUnsavedBlocks = hasUncontrolledInnerBlocks && ! isEntityAvailable;
-	if ( hasUnsavedBlocks ) {
+	if ( ! isEntityAvailable ) {
 		return (
 			<TagName { ...blockProps }>
 				<InspectorControls>

--- a/packages/block-library/src/navigation/edit/unsaved-inner-blocks.js
+++ b/packages/block-library/src/navigation/edit/unsaved-inner-blocks.js
@@ -36,6 +36,8 @@ const ALLOWED_BLOCKS = [
 	'core/navigation-submenu',
 ];
 
+const TEMPLATE = [ [ 'core/page-list' ] ];
+
 export default function UnsavedInnerBlocks( {
 	blocks,
 	clientId,
@@ -82,7 +84,7 @@ export default function UnsavedInnerBlocks( {
 			className: 'wp-block-navigation__container',
 		},
 		{
-			template: [ [ 'core/page-list' ] ],
+			template: TEMPLATE,
 			renderAppender: hasSelection ? undefined : false,
 			allowedBlocks: ALLOWED_BLOCKS,
 			__experimentalDefaultBlock: DEFAULT_BLOCK,

--- a/packages/block-library/src/navigation/edit/unsaved-inner-blocks.js
+++ b/packages/block-library/src/navigation/edit/unsaved-inner-blocks.js
@@ -82,6 +82,7 @@ export default function UnsavedInnerBlocks( {
 			className: 'wp-block-navigation__container',
 		},
 		{
+			template: [ [ 'core/page-list' ] ],
 			renderAppender: hasSelection ? undefined : false,
 			allowedBlocks: ALLOWED_BLOCKS,
 			__experimentalDefaultBlock: DEFAULT_BLOCK,


### PR DESCRIPTION
## What?
See #44594.

Replaces the code that runs `replaceInnerBlocks` to create a default page list with an inner blocks `template` prop.

## Why?
The result should hopefully be exactly the same, but this makes the code more declarative. Effects that run on mount are considered a code quality issue, and it's very easy to cause bugs (see the recent issue with the group block - https://github.com/WordPress/gutenberg/pull/44176). If there's an option to replace them, it's good to do that.

## How?
The code in `trunk` results in the following:
1. Checks if there are no menus or inner blocks and if so calls `replaceInnerBlocks( clientId, [ createBlock( 'core/page-list' ) ] );`
2. `UncontrolledInnerBlocks` is conditionally rendered because `hasUncontrolledInnerBlocks` is now `true` and `isEntityAvailable` is still `false`. It shows the new Page List block.

In this PR that switches to:
1. The `UncontrolledInnerBlocks` conditionally renders whenever `isEntityAvailable` is false.
2. The Page List template is used (templates are shown when there are no inner blocks).

## Testing Instructions
1. Delete all menus
2. Add a navigation block
3. It should show a page list

I also tested a couple of other things:
- Inserting a pattern that contains a navigation block (and especially those that don't have Page List as an inner block. TT3 has one called 'Centered logo in navigation'.
- Checking that navigation menus work as before.