### PR TITLE
Tag Processor: Add get_updated_html as a non-toString method of stringifying the markup

### DIFF
--- a/lib/experimental/html/class-wp-html-tag-processor.php
+++ b/lib/experimental/html/class-wp-html-tag-processor.php
@@ -1221,13 +1221,24 @@ class WP_HTML_Tag_Processor {
 
 	/**
 	 * Returns the string representation of the HTML Tag Processor.
-	 * It closes the HTML Tag Processor and prevents further lookups and modifications.
+	 *
+	 * @since 6.2.0
+	 * @see getUpdatedHTML
+	 *
+	 * @return string The processed HTML.
+	 */
+	public function __toString() {
+		return $this->get_updated_html();
+	}
+
+	/**
+	 * Returns the string representation of the HTML Tag Processor.
 	 *
 	 * @since 6.2.0
 	 *
 	 * @return string The processed HTML.
 	 */
-	public function __toString() {
+	public function get_updated_html() {
 		// Short-circuit if there are no updates to apply.
 		if ( ! count( $this->classname_updates ) && ! count( $this->attribute_updates ) ) {
 			return $this->updated_html . substr( $this->html, $this->updated_bytes );

--- a/lib/experimental/html/class-wp-html-tag-processor.php
+++ b/lib/experimental/html/class-wp-html-tag-processor.php
@@ -1223,7 +1223,7 @@ class WP_HTML_Tag_Processor {
 	 * Returns the string representation of the HTML Tag Processor.
 	 *
 	 * @since 6.2.0
-	 * @see getUpdatedHTML
+	 * @see get_updated_html
 	 *
 	 * @return string The processed HTML.
 	 */

--- a/phpunit/html/wp-html-tag-processor-wp-test.php
+++ b/phpunit/html/wp-html-tag-processor-wp-test.php
@@ -62,7 +62,7 @@ class WP_HTML_Tag_Processor_Test_WP extends WP_UnitTestCase {
 		 * over the content and because we want to look at the raw values.
 		 */
 		$match = null;
-		preg_match( '~^<div test=(.*)></div>$~', (string) $p, $match );
+		preg_match( '~^<div test=(.*)></div>$~', $p->get_updated_html(), $match );
 		list( , $actual_value ) = $match;
 
 		$this->assertEquals( $actual_value, '"' . $expected_result . '"' );


### PR DESCRIPTION
A part of https://github.com/WordPress/gutenberg/issues/44410

## What?
Adds a `get_updated_html` as a more WordPress-style way of retrieving the updated markup than `(string) $p`.

## Why?
The point about `(string) $p` feeling weird came up multiple times in the original WP_HTML_Walker PR https://github.com/WordPress/gutenberg/pull/42485

## Testing Instructions
Confirm the CI checks are green

cc @dmsnell @azaozz @getdave 
