### PR TITLE
Update design of FontSizePicker when withSlider is set

### DIFF
--- a/packages/block-editor/src/hooks/font-size.js
+++ b/packages/block-editor/src/hooks/font-size.js
@@ -150,6 +150,7 @@ export function FontSizeEdit( props ) {
 			onChange={ onChange }
 			value={ fontSizeValue }
 			withReset={ false }
+			withSlider
 			size="__unstable-large"
 			__nextHasNoMarginBottom
 		/>

--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -6,6 +6,10 @@
 
 -   `BoxControl` & `CustomSelectControl`: Add `onMouseOver` and `onMouseOut` callback props to allow handling of these events by parent components ([#44955](https://github.com/WordPress/gutenberg/pull/44955))
 
+## Enhancements
+
+-   `FontSizePicker`: Improved slider design when `withSlider` is set ([#44598](https://github.com/WordPress/gutenberg/pull/44598)).
+
 ### Bug Fix
 
 -   `Button`: Fix RTL alignment for buttons containing an icon and text ([#44787](https://github.com/WordPress/gutenberg/pull/44787)).

--- a/packages/components/src/font-size-picker/README.md
+++ b/packages/components/src/font-size-picker/README.md
@@ -93,7 +93,7 @@ The current font size value.
 
 ### withSlider
 
-If `true`, the UI will contain a slider, instead of a numeric text input field. If `false`, no slider will be present.
+If `true`, a slider will be displayed alongside the input field when a custom font size is active. Has no effect when `disableCustomFontSizes` is `true`.
 
 -   Type: `Boolean`
 -   Required: no
@@ -101,7 +101,7 @@ If `true`, the UI will contain a slider, instead of a numeric text input field. 
 
 ### withReset
 
-If `true`, a reset button will be displayed alongside the input field when a custom font size is active. Has no effect when `disableCustomFontSizes` or `withSlider` is `true`.
+If `true`, a reset button will be displayed alongside the input field when a custom font size is active. Has no effect when `disableCustomFontSizes` is `true`.
 
 -   Type: `Boolean`
 -   Required: no

--- a/packages/components/src/font-size-picker/index.tsx
+++ b/packages/components/src/font-size-picker/index.tsx
@@ -156,7 +156,7 @@ const UnforwardedFontSizePicker = (
 	// operates in a legacy "unitless" mode where UnitControl can only be used
 	// to select px values and onChange() is always called with number values.
 	const hasUnits =
-		typeof value === 'string' || typeof fontSizes[ 0 ].size === 'string';
+		typeof value === 'string' || typeof fontSizes[ 0 ]?.size === 'string';
 
 	const [ valueNumber, valueUnit ] = parseNumberAndUnitFromSize( value );
 	const isValueUnitRelative =

--- a/packages/components/src/font-size-picker/index.tsx
+++ b/packages/components/src/font-size-picker/index.tsx
@@ -17,7 +17,11 @@ import { useState, useMemo, forwardRef } from '@wordpress/element';
 import Button from '../button';
 import RangeControl from '../range-control';
 import { Flex, FlexItem } from '../flex';
-import { default as UnitControl, useCustomUnits } from '../unit-control';
+import {
+	default as UnitControl,
+	parseQuantityAndUnitFromRawValue,
+	useCustomUnits,
+} from '../unit-control';
 import CustomSelectControl from '../custom-select-control';
 import { VisuallyHidden } from '../visually-hidden';
 import {
@@ -27,7 +31,6 @@ import {
 import {
 	getFontSizeOptions,
 	getSelectedOption,
-	parseNumberAndUnitFromSize,
 	isSimpleCssValue,
 	CUSTOM_FONT_SIZE,
 } from './utils';
@@ -124,8 +127,9 @@ const UnforwardedFontSizePicker = (
 			! fontSizesContainComplexValues &&
 			typeof selectedOption.size === 'string'
 		) {
-			const [ , unit ] = parseNumberAndUnitFromSize(
-				selectedOption.size
+			const [ , unit ] = parseQuantityAndUnitFromRawValue(
+				selectedOption.size,
+				units
 			);
 			hint += `(${ unit })`;
 		}
@@ -158,7 +162,10 @@ const UnforwardedFontSizePicker = (
 	const hasUnits =
 		typeof value === 'string' || typeof fontSizes[ 0 ]?.size === 'string';
 
-	const [ valueNumber, valueUnit ] = parseNumberAndUnitFromSize( value );
+	const [ valueQuantity, valueUnit ] = parseQuantityAndUnitFromRawValue(
+		value,
+		units
+	);
 	const isValueUnitRelative =
 		!! valueUnit && [ 'em', 'rem' ].includes( valueUnit );
 
@@ -299,7 +306,7 @@ const UnforwardedFontSizePicker = (
 										className="components-font-size-picker__custom-input"
 										label={ __( 'Custom Size' ) }
 										hideLabelFromVision
-										value={ valueNumber }
+										value={ valueQuantity }
 										initialPosition={ fallbackFontSize }
 										withInputField={ false }
 										onChange={ ( newValue ) => {

--- a/packages/components/src/font-size-picker/index.tsx
+++ b/packages/components/src/font-size-picker/index.tsx
@@ -321,9 +321,9 @@ const UnforwardedFontSizePicker = (
 												onChange?.( newValue );
 											}
 										} }
-										min={ isValueUnitRelative ? 0.75 : 12 }
-										max={ isValueUnitRelative ? 6.25 : 100 }
-										step={ isValueUnitRelative ? 0.05 : 1 }
+										min={ 0 }
+										max={ isValueUnitRelative ? 10 : 100 }
+										step={ isValueUnitRelative ? 0.1 : 1 }
 									/>
 								</Spacer>
 							</FlexItem>

--- a/packages/components/src/font-size-picker/index.tsx
+++ b/packages/components/src/font-size-picker/index.tsx
@@ -152,13 +152,15 @@ const UnforwardedFontSizePicker = (
 		selectedOption.name
 	);
 
+	// If neither the value or first font size is a string, then FontSizePicker
+	// operates in a legacy "unitless" mode where UnitControl can only be used
+	// to select px values and onChange() is always called with number values.
+	const hasUnits =
+		typeof value === 'string' || typeof fontSizes[ 0 ].size === 'string';
+
 	const [ valueNumber, valueUnit ] = parseNumberAndUnitFromSize( value );
 	const isValueUnitRelative =
 		!! valueUnit && [ 'em', 'rem' ].includes( valueUnit );
-	const [ , firstFontSizeUnit ] = parseNumberAndUnitFromSize(
-		fontSizes[ 0 ]?.size
-	);
-	const hasUnits = !! valueUnit || !! firstFontSizeUnit;
 
 	return (
 		<Container ref={ ref } className="components-font-size-picker">

--- a/packages/components/src/font-size-picker/index.tsx
+++ b/packages/components/src/font-size-picker/index.tsx
@@ -288,31 +288,34 @@ const UnforwardedFontSizePicker = (
 						</FlexItem>
 						{ withSlider && (
 							<FlexItem isBlock>
-								<RangeControl
-									__nextHasNoMarginBottom={
-										__nextHasNoMarginBottom
-									}
-									className="components-font-size-picker__custom-input"
-									label={ __( 'Custom Size' ) }
-									hideLabelFromVision
-									value={ valueNumber }
-									initialPosition={ fallbackFontSize }
-									withInputField={ false }
-									onChange={ ( newValue ) => {
-										if ( newValue === undefined ) {
-											onChange?.( undefined );
-										} else if ( hasUnits ) {
-											onChange?.(
-												newValue + ( valueUnit ?? 'px' )
-											);
-										} else {
-											onChange?.( newValue );
+								<Spacer marginX={ 2 } marginBottom={ 0 }>
+									<RangeControl
+										__nextHasNoMarginBottom={
+											__nextHasNoMarginBottom
 										}
-									} }
-									min={ isValueUnitRelative ? 0.75 : 12 }
-									max={ isValueUnitRelative ? 6.25 : 100 }
-									step={ isValueUnitRelative ? 0.05 : 1 }
-								/>
+										className="components-font-size-picker__custom-input"
+										label={ __( 'Custom Size' ) }
+										hideLabelFromVision
+										value={ valueNumber }
+										initialPosition={ fallbackFontSize }
+										withInputField={ false }
+										onChange={ ( newValue ) => {
+											if ( newValue === undefined ) {
+												onChange?.( undefined );
+											} else if ( hasUnits ) {
+												onChange?.(
+													newValue +
+														( valueUnit ?? 'px' )
+												);
+											} else {
+												onChange?.( newValue );
+											}
+										} }
+										min={ isValueUnitRelative ? 0.75 : 12 }
+										max={ isValueUnitRelative ? 6.25 : 100 }
+										step={ isValueUnitRelative ? 0.05 : 1 }
+									/>
+								</Spacer>
 							</FlexItem>
 						) }
 						{ withReset && (

--- a/packages/components/src/font-size-picker/index.tsx
+++ b/packages/components/src/font-size-picker/index.tsx
@@ -284,6 +284,7 @@ const UnforwardedFontSizePicker = (
 								} }
 								size={ size }
 								units={ hasUnits ? units : [] }
+								min={ 0 }
 							/>
 						</FlexItem>
 						{ withSlider && (

--- a/packages/components/src/font-size-picker/index.tsx
+++ b/packages/components/src/font-size-picker/index.tsx
@@ -278,7 +278,7 @@ const UnforwardedFontSizePicker = (
 										onChange?.(
 											hasUnits
 												? newValue
-												: parseFloat( newValue )
+												: parseInt( newValue, 10 )
 										);
 									}
 								} }

--- a/packages/components/src/font-size-picker/index.tsx
+++ b/packages/components/src/font-size-picker/index.tsx
@@ -27,7 +27,7 @@ import {
 import {
 	getFontSizeOptions,
 	getSelectedOption,
-	splitNumberAndUnitFromSize,
+	parseNumberAndUnitFromSize,
 	isSimpleCssValue,
 	CUSTOM_FONT_SIZE,
 } from './utils';
@@ -124,7 +124,7 @@ const UnforwardedFontSizePicker = (
 			! fontSizesContainComplexValues &&
 			typeof selectedOption.size === 'string'
 		) {
-			const [ , unit ] = splitNumberAndUnitFromSize(
+			const [ , unit ] = parseNumberAndUnitFromSize(
 				selectedOption.size
 			);
 			hint += `(${ unit })`;
@@ -152,10 +152,10 @@ const UnforwardedFontSizePicker = (
 		selectedOption.name
 	);
 
-	const [ valueNumber, valueUnit ] = splitNumberAndUnitFromSize( value );
+	const [ valueNumber, valueUnit ] = parseNumberAndUnitFromSize( value );
 	const isValueUnitRelative =
 		!! valueUnit && [ 'em', 'rem' ].includes( valueUnit );
-	const [ , firstFontSizeUnit ] = splitNumberAndUnitFromSize(
+	const [ , firstFontSizeUnit ] = parseNumberAndUnitFromSize(
 		fontSizes[ 0 ]?.size
 	);
 	const hasUnits = !! valueUnit || !! firstFontSizeUnit;

--- a/packages/components/src/font-size-picker/test/utils.ts
+++ b/packages/components/src/font-size-picker/test/utils.ts
@@ -3,7 +3,7 @@
  */
 import {
 	isSimpleCssValue,
-	splitNumberAndUnitFromSize,
+	parseNumberAndUnitFromSize,
 	getToggleGroupOptions,
 } from '../utils';
 
@@ -76,7 +76,7 @@ describe( 'splitValueAndUnitFromSize', () => {
 	test.each( splitValuesCases )(
 		'given %p as argument, returns value = %p and unit = %p',
 		( cssValue, expectedValue, expectedUnit ) => {
-			const [ value, unit ] = splitNumberAndUnitFromSize( cssValue );
+			const [ value, unit ] = parseNumberAndUnitFromSize( cssValue );
 			expect( value ).toBe( expectedValue );
 			expect( unit ).toBe( expectedUnit );
 		}

--- a/packages/components/src/font-size-picker/test/utils.ts
+++ b/packages/components/src/font-size-picker/test/utils.ts
@@ -3,7 +3,7 @@
  */
 import {
 	isSimpleCssValue,
-	splitValueAndUnitFromSize,
+	splitNumberAndUnitFromSize,
 	getToggleGroupOptions,
 } from '../utils';
 
@@ -42,22 +42,24 @@ describe( 'isSimpleCssValue', () => {
 } );
 
 const splitValuesCases: [
-	number | string,
-	string | undefined,
+	number | string | undefined,
+	number | undefined,
 	string | undefined
 ][] = [
+	// Test undefined.
+	[ undefined, undefined, undefined ],
 	// Test integers and non-integers.
-	[ 1, '1', undefined ],
-	[ 1.25, '1.25', undefined ],
-	[ '123', '123', undefined ],
-	[ '1.5', '1.5', undefined ],
-	[ '0.75', '0.75', undefined ],
+	[ 1, 1, undefined ],
+	[ 1.25, 1.25, undefined ],
+	[ '123', 123, undefined ],
+	[ '1.5', 1.5, undefined ],
+	[ '0.75', 0.75, undefined ],
 	// Valid simple CSS values.
-	[ '20px', '20', 'px' ],
-	[ '0.8em', '0.8', 'em' ],
-	[ '2rem', '2', 'rem' ],
-	[ '1.4vw', '1.4', 'vw' ],
-	[ '0.4vh', '0.4', 'vh' ],
+	[ '20px', 20, 'px' ],
+	[ '0.8em', 0.8, 'em' ],
+	[ '2rem', 2, 'rem' ],
+	[ '1.4vw', 1.4, 'vw' ],
+	[ '0.4vh', 0.4, 'vh' ],
 	// Invalid negative values,
 	[ '-5px', undefined, undefined ],
 	// Complex CSS values that shouldn't parse.
@@ -74,7 +76,7 @@ describe( 'splitValueAndUnitFromSize', () => {
 	test.each( splitValuesCases )(
 		'given %p as argument, returns value = %p and unit = %p',
 		( cssValue, expectedValue, expectedUnit ) => {
-			const [ value, unit ] = splitValueAndUnitFromSize( cssValue );
+			const [ value, unit ] = splitNumberAndUnitFromSize( cssValue );
 			expect( value ).toBe( expectedValue );
 			expect( unit ).toBe( expectedUnit );
 		}

--- a/packages/components/src/font-size-picker/test/utils.ts
+++ b/packages/components/src/font-size-picker/test/utils.ts
@@ -1,11 +1,7 @@
 /**
  * Internal dependencies
  */
-import {
-	isSimpleCssValue,
-	parseNumberAndUnitFromSize,
-	getToggleGroupOptions,
-} from '../utils';
+import { isSimpleCssValue, getToggleGroupOptions } from '../utils';
 
 const simpleCSSCases: [ number | string, boolean ][] = [
 	// Test integers and non-integers.
@@ -37,48 +33,6 @@ describe( 'isSimpleCssValue', () => {
 		'given %p as argument, returns %p',
 		( cssValue, result ) => {
 			expect( isSimpleCssValue( cssValue ) ).toBe( result );
-		}
-	);
-} );
-
-const splitValuesCases: [
-	number | string | undefined,
-	number | undefined,
-	string | undefined
-][] = [
-	// Test undefined.
-	[ undefined, undefined, undefined ],
-	// Test integers and non-integers.
-	[ 1, 1, undefined ],
-	[ 1.25, 1.25, undefined ],
-	[ '123', 123, undefined ],
-	[ '1.5', 1.5, undefined ],
-	[ '0.75', 0.75, undefined ],
-	// Valid simple CSS values.
-	[ '20px', 20, 'px' ],
-	[ '0.8em', 0.8, 'em' ],
-	[ '2rem', 2, 'rem' ],
-	[ '1.4vw', 1.4, 'vw' ],
-	[ '0.4vh', 0.4, 'vh' ],
-	// Invalid negative values,
-	[ '-5px', undefined, undefined ],
-	// Complex CSS values that shouldn't parse.
-	[ 'abs(-15px)', undefined, undefined ],
-	[ 'calc(10px + 1)', undefined, undefined ],
-	[ 'clamp(2.5rem, 4vw, 3rem)', undefined, undefined ],
-	[ 'max(4.5em, 3vh)', undefined, undefined ],
-	[ 'min(10px, 1rem)', undefined, undefined ],
-	[ 'minmax(30px, auto)', undefined, undefined ],
-	[ 'var(--wp--font-size)', undefined, undefined ],
-];
-
-describe( 'splitValueAndUnitFromSize', () => {
-	test.each( splitValuesCases )(
-		'given %p as argument, returns value = %p and unit = %p',
-		( cssValue, expectedValue, expectedUnit ) => {
-			const [ value, unit ] = parseNumberAndUnitFromSize( cssValue );
-			expect( value ).toBe( expectedValue );
-			expect( unit ).toBe( expectedUnit );
 		}
 	);
 } );

--- a/packages/components/src/font-size-picker/utils.ts
+++ b/packages/components/src/font-size-picker/utils.ts
@@ -44,24 +44,20 @@ const FONT_SIZES_ALIASES = [
 ];
 
 /**
- * Helper util to split a font size to its numeric value
- * and its `unit`, if exists.
+ * Splits a font size into its numeric part and unit part. For example, '30px'
+ * would be split into 30 and 'px'.
  *
  * @param  size Font size.
- * @return An array with the numeric value and the unit if exists.
+ * @return An array with the number and the unit if it exists.
  */
-export function splitValueAndUnitFromSize(
-	size: NonNullable< FontSizePickerProps[ 'value' ] >
-) {
-	const [ numericValue, unit ] = `${ size }`.match( /[\d\.]+|\D+/g ) ?? [];
-
-	if (
-		! isNaN( parseFloat( numericValue ) ) &&
-		isFinite( Number( numericValue ) )
-	) {
-		return [ numericValue, unit ];
+export function splitNumberAndUnitFromSize(
+	size: FontSizePickerProps[ 'value' ]
+): [ number, string ] | [ number ] | [] {
+	const [ , rawNumber, unit ] = `${ size }`.match( /^([\d\.]+)(\D*)/ ) ?? [];
+	const number = Number( rawNumber );
+	if ( ! isNaN( number ) && isFinite( number ) ) {
+		return unit ? [ number, unit ] : [ number ];
 	}
-
 	return [];
 }
 

--- a/packages/components/src/font-size-picker/utils.ts
+++ b/packages/components/src/font-size-picker/utils.ts
@@ -44,24 +44,6 @@ const FONT_SIZES_ALIASES = [
 ];
 
 /**
- * Given a font size, returns the numeric part and unit part. For example, given
- * '30px', 30 and 'px' would be returned.
- *
- * @param  size Font size.
- * @return An array with the number and the unit if it exists.
- */
-export function parseNumberAndUnitFromSize(
-	size: FontSizePickerProps[ 'value' ]
-): [ number, string ] | [ number ] | [] {
-	const [ , rawNumber, unit ] = `${ size }`.match( /^([\d\.]+)(\D*)/ ) ?? [];
-	const number = Number( rawNumber );
-	if ( ! isNaN( number ) && isFinite( number ) ) {
-		return unit ? [ number, unit ] : [ number ];
-	}
-	return [];
-}
-
-/**
  * Some themes use css vars for their font sizes, so until we
  * have the way of calculating them don't display them.
  *

--- a/packages/components/src/font-size-picker/utils.ts
+++ b/packages/components/src/font-size-picker/utils.ts
@@ -44,13 +44,13 @@ const FONT_SIZES_ALIASES = [
 ];
 
 /**
- * Splits a font size into its numeric part and unit part. For example, '30px'
- * would be split into 30 and 'px'.
+ * Given a font size, returns the numeric part and unit part. For example, given
+ * '30px', 30 and 'px' would be returned.
  *
  * @param  size Font size.
  * @return An array with the number and the unit if it exists.
  */
-export function splitNumberAndUnitFromSize(
+export function parseNumberAndUnitFromSize(
 	size: FontSizePickerProps[ 'value' ]
 ): [ number, string ] | [ number ] | [] {
 	const [ , rawNumber, unit ] = `${ size }`.match( /^([\d\.]+)(\D*)/ ) ?? [];

--- a/packages/edit-site/src/components/global-styles/style.scss
+++ b/packages/edit-site/src/components/global-styles/style.scss
@@ -19,6 +19,7 @@
 	margin-bottom: $grid-unit-20;
 	background: $gray-100;
 	border-radius: $radius-block-ui;
+	overflow: hidden;
 }
 
 .edit-site-typography-panel__full-width-control {

--- a/packages/edit-site/src/components/global-styles/typography-panel.js
+++ b/packages/edit-site/src/components/global-styles/typography-panel.js
@@ -256,6 +256,7 @@ export default function TypographyPanel( { name, element, headingLevel } ) {
 						fontSizes={ fontSizesWithFluidValues }
 						disableCustomFontSizes={ disableCustomFontSizes }
 						withReset={ false }
+						withSlider
 						size="__unstable-large"
 						__nextHasNoMarginBottom
 					/>


### PR DESCRIPTION
## What?
Updates the design and behaviour of `FontSizePicker` when `withSlider` is set to match [the design](https://github.com/WordPress/gutenberg/issues/34345#issue-981044454).

- The slider will now only appear when setting a custom font size value.
- The slider will appear inline with the custom font size field.
- Users can now edit `em` and `rem` values using the slider.

## Why?
Part of an effort to make the Typography panel match the design. See https://github.com/WordPress/gutenberg/issues/34345#issuecomment-1217390408.

## How?


## Testing Instructions
1. Open the site editor.
2. Go to Global Styles → Typography → Text.
3. Select _Set custom size_.
4. Play with setting different custom font sizes using the text field and slider.

## Screenshots or screencast <!-- if applicable -->
**Global styles:**

| Before | After |
| - | - | 
| <img width="298" alt="Screen Shot 2022-09-30 at 15 34 57" src="https://user-images.githubusercontent.com/612155/193198337-73d65cbb-3c88-4a13-b225-fdb9e4e92055.png"> | <img width="295" alt="Screen Shot 2022-09-30 at 15 35 25" src="https://user-images.githubusercontent.com/612155/193198375-dbf65910-b464-4866-8606-3d01d2d70b92.png"> |

**Storybook:**

| Before | After |
| - | - | 
| <img width="340" alt="Screen Shot 2022-09-30 at 15 41 24" src="https://user-images.githubusercontent.com/612155/193198452-23d1bd7a-97c0-40a8-b52c-1f910e20b966.png"> | <img width="330" alt="Screen Shot 2022-09-30 at 15 40 52" src="https://user-images.githubusercontent.com/612155/193198444-e3691948-884d-465a-8a5f-c7ceac2000ea.png"> |

**Storybook with _Reset_ button:**

This isn't used anywhere in Gutenberg (we could probably deprecate `withReset`) but I ensured it looks reasonable as this is the default.

| Before | After |
| - | - | 
| <img width="340" alt="Screen Shot 2022-09-30 at 15 41 24" src="https://user-images.githubusercontent.com/612155/193198649-3f105029-e84d-4986-8185-56dec66779c1.png"> | <img width="341" alt="Screen Shot 2022-09-30 at 15 43 28" src="https://user-images.githubusercontent.com/612155/193198662-2e436dd3-bd09-4cfd-bb38-eced4784a4cd.png"> |

**Video:**

https://user-images.githubusercontent.com/612155/193198882-05f6f042-5b7c-4166-823b-727db01ca602.mp4