### PR TITLE
Try adding layout classnames to inner block wrapper

### DIFF
--- a/lib/block-supports/layout.php
+++ b/lib/block-supports/layout.php
@@ -428,6 +428,10 @@ function gutenberg_render_layout_support_flag( $block_content, $block ) {
 		}
 	}
 
+	/**
+	* The first chunk of innerContent contains the block markup up until the inner blocks start.
+	* We want to target the opening tag of the inner blocks wrapper, which is the last tag in that chunk.
+	*/
 	$inner_content_classnames = isset( $block['innerContent'][0] ) && 'string' === gettype( $block['innerContent'][0] ) ? gutenberg_get_classnames_from_last_tag( $block['innerContent'][0] ) : '';
 
 	$content = new WP_HTML_Tag_Processor( $block_content );

--- a/lib/block-supports/layout.php
+++ b/lib/block-supports/layout.php
@@ -305,9 +305,9 @@ function gutenberg_identify_inner_block_wrapper_classnames( $inner_content ) {
 
 	$matches = array();
 
-	preg_match_all( '/class="[a-z\-\_\s]*/', $inner_content[0], $matches );
+	preg_match_all( '/class="([a-z0-9\-\_\s]*)/', $inner_content[0], $matches );
 
-	return end( $matches[0] );
+	return end( $matches[1] );
 
 }
 
@@ -340,7 +340,6 @@ function gutenberg_render_layout_support_flag( $block_content, $block ) {
 
 	$class_names        = array();
 	$layout_definitions = _wp_array_get( $global_layout_settings, array( 'definitions' ), array() );
-	$block_classname    = wp_get_block_default_classname( $block['blockName'] );
 	$container_class    = wp_unique_id( 'wp-container-' );
 	$layout_classname   = '';
 
@@ -417,7 +416,7 @@ function gutenberg_render_layout_support_flag( $block_content, $block ) {
 		$should_skip_gap_serialization = gutenberg_should_skip_block_supports_serialization( $block_type, 'spacing', 'blockGap' );
 
 		$style = gutenberg_get_layout_style(
-			".$block_classname.$container_class",
+			".$container_class.$container_class",
 			$used_layout,
 			$has_block_gap_support,
 			$gap_value,

--- a/lib/block-supports/layout.php
+++ b/lib/block-supports/layout.php
@@ -437,7 +437,9 @@ function gutenberg_render_layout_support_flag( $block_content, $block ) {
 	$content = new WP_HTML_Tag_Processor( $block_content );
 	if ( $inner_content_classnames ) {
 		$content->next_tag( array( 'class_name' => $inner_content_classnames ) );
-		$content->add_class( implode( ' ', $class_names ) );
+		foreach ( $class_names as $class_name ) {
+			$content->add_class( $class_name );
+		}
 	} else {
 		$content->next_tag();
 		$content->add_class( implode( ' ', $class_names ) );

--- a/lib/block-supports/layout.php
+++ b/lib/block-supports/layout.php
@@ -303,12 +303,14 @@ function gutenberg_identify_inner_block_wrapper_classnames( $inner_content ) {
 		return false;
 	}
 
-	$matches = array();
+	$inner_content_chunk      = new WP_HTML_Tag_Processor( $inner_content[0] );
+	$inner_wrapper_classnames = '';
 
-	preg_match_all( '/class="([a-z0-9\-\_\s]*)/', $inner_content[0], $matches );
+	while ( true === $inner_content_chunk->next_tag() ) {
+		$inner_wrapper_classnames = $inner_content_chunk->get_attribute( 'class' );
+	}
 
-	return end( $matches[1] );
-
+	return $inner_wrapper_classnames;
 }
 
 /**

--- a/lib/block-supports/layout.php
+++ b/lib/block-supports/layout.php
@@ -433,20 +433,13 @@ function gutenberg_render_layout_support_flag( $block_content, $block ) {
 
 	$inner_content_classnames = gutenberg_identify_inner_block_wrapper_classnames( $block['innerContent'] );
 
+	$content = new WP_HTML_Tag_Processor( $block_content );
 	if ( $inner_content_classnames ) {
-		$content = preg_replace(
-			'/' . $inner_content_classnames . '/',
-			$inner_content_classnames . ' ' . esc_attr( implode( ' ', $class_names ) ),
-			$block_content,
-			1
-		);
+		$content->next_tag( array( 'class_name' => $inner_content_classnames ) );
+		$content->add_class( esc_attr( implode( ' ', $class_names ) ) );
 	} else {
-		$content = preg_replace(
-			'/' . preg_quote( 'class="', '/' ) . '/',
-			'class="' . esc_attr( implode( ' ', $class_names ) ) . ' ',
-			$block_content,
-			1
-		);
+		$content->next_tag();
+		$content->add_class( esc_attr( implode( ' ', $class_names ) ) );
 	}
 
 	return $content;

--- a/lib/block-supports/layout.php
+++ b/lib/block-supports/layout.php
@@ -292,25 +292,20 @@ function gutenberg_get_layout_style( $selector, $layout, $has_block_gap_support 
 }
 
 /**
- * Indentifies inner block wrapper classnames.
+ * Gets classname from last tag in a string of HTML.
  *
- * @param array $inner_content An array of strings.
+ * @param string $html markup to be processed.
  * @return string String of inner wrapper classnames.
  */
-function gutenberg_identify_inner_block_wrapper_classnames( $inner_content ) {
+function gutenberg_get_classnames_from_last_tag( $html ) {
+	$tags            = new WP_HTML_Tag_Processor( $html );
+	$last_classnames = '';
 
-	if ( ! isset( $inner_content[0] ) ) {
-		return false;
+	while ( $tags->next_tag() ) {
+		$last_classnames = $tags->get_attribute( 'class' );
 	}
 
-	$inner_content_chunk      = new WP_HTML_Tag_Processor( $inner_content[0] );
-	$inner_wrapper_classnames = '';
-
-	while ( true === $inner_content_chunk->next_tag() ) {
-		$inner_wrapper_classnames = $inner_content_chunk->get_attribute( 'class' );
-	}
-
-	return $inner_wrapper_classnames;
+	return $last_classnames;
 }
 
 /**
@@ -433,15 +428,15 @@ function gutenberg_render_layout_support_flag( $block_content, $block ) {
 		}
 	}
 
-	$inner_content_classnames = gutenberg_identify_inner_block_wrapper_classnames( $block['innerContent'] );
+	$inner_content_classnames = isset( $block['innerContent'][0] ) && 'string' === gettype( $block['innerContent'][0] ) ? gutenberg_get_classnames_from_last_tag( $block['innerContent'][0] ) : '';
 
 	$content = new WP_HTML_Tag_Processor( $block_content );
 	if ( $inner_content_classnames ) {
 		$content->next_tag( array( 'class_name' => $inner_content_classnames ) );
-		$content->add_class( esc_attr( implode( ' ', $class_names ) ) );
+		$content->add_class( implode( ' ', $class_names ) );
 	} else {
 		$content->next_tag();
-		$content->add_class( esc_attr( implode( ' ', $class_names ) ) );
+		$content->add_class( implode( ' ', $class_names ) );
 	}
 
 	return $content;

--- a/packages/block-editor/src/components/block-edit/index.js
+++ b/packages/block-editor/src/components/block-edit/index.js
@@ -20,11 +20,12 @@ import { BlockEditContextProvider, useBlockEditContext } from './context';
 export { useBlockEditContext };
 
 export default function BlockEdit( props ) {
-	const { name, isSelected, clientId } = props;
+	const { name, isSelected, clientId, layoutClassNames } = props;
 	const context = {
 		name,
 		isSelected,
 		clientId,
+		layoutClassNames,
 	};
 	return (
 		<BlockEditContextProvider

--- a/packages/block-editor/src/components/block-edit/index.js
+++ b/packages/block-editor/src/components/block-edit/index.js
@@ -20,12 +20,12 @@ import { BlockEditContextProvider, useBlockEditContext } from './context';
 export { useBlockEditContext };
 
 export default function BlockEdit( props ) {
-	const { name, isSelected, clientId, layoutClassNames } = props;
+	const { name, isSelected, clientId, __unstableLayoutClassNames } = props;
 	const context = {
 		name,
 		isSelected,
 		clientId,
-		layoutClassNames,
+		__unstableLayoutClassNames,
 	};
 	return (
 		<BlockEditContextProvider

--- a/packages/block-editor/src/components/block-list/block.js
+++ b/packages/block-editor/src/components/block-list/block.js
@@ -84,6 +84,7 @@ function BlockListBlock( {
 	isSelected,
 	isSelectionEnabled,
 	className,
+	layoutClassNames,
 	name,
 	isValid,
 	attributes,
@@ -146,6 +147,7 @@ function BlockListBlock( {
 			clientId={ clientId }
 			isSelectionEnabled={ isSelectionEnabled }
 			toggleSelection={ toggleSelection }
+			layoutClassNames={ layoutClassNames }
 		/>
 	);
 
@@ -231,7 +233,8 @@ function BlockListBlock( {
 				'is-content-block': hasContentLockedParent && isContentBlock,
 			},
 			dataAlign && themeSupportsLayout && `align${ dataAlign }`,
-			className
+			className,
+			layoutClassNames
 		),
 		wrapperProps: restWrapperProps,
 		isAligned,

--- a/packages/block-editor/src/components/block-list/block.js
+++ b/packages/block-editor/src/components/block-list/block.js
@@ -84,7 +84,7 @@ function BlockListBlock( {
 	isSelected,
 	isSelectionEnabled,
 	className,
-	layoutClassNames,
+	__unstableLayoutClassNames: layoutClassNames,
 	name,
 	isValid,
 	attributes,
@@ -147,7 +147,7 @@ function BlockListBlock( {
 			clientId={ clientId }
 			isSelectionEnabled={ isSelectionEnabled }
 			toggleSelection={ toggleSelection }
-			layoutClassNames={ layoutClassNames }
+			__unstableLayoutClassNames={ layoutClassNames }
 		/>
 	);
 

--- a/packages/block-editor/src/components/block-list/block.js
+++ b/packages/block-editor/src/components/block-list/block.js
@@ -233,8 +233,7 @@ function BlockListBlock( {
 				'is-content-block': hasContentLockedParent && isContentBlock,
 			},
 			dataAlign && themeSupportsLayout && `align${ dataAlign }`,
-			className,
-			layoutClassNames
+			className
 		),
 		wrapperProps: restWrapperProps,
 		isAligned,

--- a/packages/block-editor/src/components/inner-blocks/index.js
+++ b/packages/block-editor/src/components/inner-blocks/index.js
@@ -150,7 +150,7 @@ const ForwardedInnerBlocks = forwardRef( ( props, ref ) => {
  * @see https://github.com/WordPress/gutenberg/blob/HEAD/packages/block-editor/src/components/inner-blocks/README.md
  */
 export function useInnerBlocksProps( props = {}, options = {} ) {
-	const { clientId } = useBlockEditContext();
+	const { clientId, layoutClassNames = '' } = useBlockEditContext();
 	const isSmallScreen = useViewportMatch( 'medium', '<' );
 	const { __experimentalCaptureToolbars, hasOverlay } = useSelect(
 		( select ) => {
@@ -200,11 +200,15 @@ export function useInnerBlocksProps( props = {}, options = {} ) {
 		innerBlocksProps.value && innerBlocksProps.onChange
 			? ControlledInnerBlocks
 			: UncontrolledInnerBlocks;
+	//Dedupe layout classes
+	const allTheClassNames = `${ props.className } ${ layoutClassNames }`;
+	const classNameSet = new Set( allTheClassNames.split( ' ' ) );
+	const dedupedClassNames = Array.from( classNameSet ).join( ' ' );
 	return {
 		...props,
 		ref,
 		className: classnames(
-			props.className,
+			dedupedClassNames,
 			'block-editor-block-list__layout',
 			{
 				'has-overlay': hasOverlay,

--- a/packages/block-editor/src/components/inner-blocks/index.js
+++ b/packages/block-editor/src/components/inner-blocks/index.js
@@ -150,6 +150,7 @@ const ForwardedInnerBlocks = forwardRef( ( props, ref ) => {
  * @see https://github.com/WordPress/gutenberg/blob/HEAD/packages/block-editor/src/components/inner-blocks/README.md
  */
 export function useInnerBlocksProps( props = {}, options = {} ) {
+	const { __experimentalLayout } = options;
 	const { clientId, __unstableLayoutClassNames: layoutClassNames = '' } =
 		useBlockEditContext();
 	const isSmallScreen = useViewportMatch( 'medium', '<' );
@@ -207,10 +208,10 @@ export function useInnerBlocksProps( props = {}, options = {} ) {
 		ref,
 		className: classnames(
 			props.className,
-			layoutClassNames,
 			'block-editor-block-list__layout',
 			{
 				'has-overlay': hasOverlay,
+				[ layoutClassNames ]: __experimentalLayout,
 			}
 		),
 		children: clientId ? (

--- a/packages/block-editor/src/components/inner-blocks/index.js
+++ b/packages/block-editor/src/components/inner-blocks/index.js
@@ -200,15 +200,13 @@ export function useInnerBlocksProps( props = {}, options = {} ) {
 		innerBlocksProps.value && innerBlocksProps.onChange
 			? ControlledInnerBlocks
 			: UncontrolledInnerBlocks;
-	//Dedupe layout classes
-	const allTheClassNames = `${ props.className } ${ layoutClassNames }`;
-	const classNameSet = new Set( allTheClassNames.split( ' ' ) );
-	const dedupedClassNames = Array.from( classNameSet ).join( ' ' );
+
 	return {
 		...props,
 		ref,
 		className: classnames(
-			dedupedClassNames,
+			props.className,
+			layoutClassNames,
 			'block-editor-block-list__layout',
 			{
 				'has-overlay': hasOverlay,

--- a/packages/block-editor/src/components/inner-blocks/index.js
+++ b/packages/block-editor/src/components/inner-blocks/index.js
@@ -150,7 +150,7 @@ const ForwardedInnerBlocks = forwardRef( ( props, ref ) => {
  * @see https://github.com/WordPress/gutenberg/blob/HEAD/packages/block-editor/src/components/inner-blocks/README.md
  */
 export function useInnerBlocksProps( props = {}, options = {} ) {
-	const { __experimentalLayout } = options;
+	const { __unstableNoLayoutClassNames } = options;
 	const { clientId, __unstableLayoutClassNames: layoutClassNames = '' } =
 		useBlockEditContext();
 	const isSmallScreen = useViewportMatch( 'medium', '<' );
@@ -209,9 +209,9 @@ export function useInnerBlocksProps( props = {}, options = {} ) {
 		className: classnames(
 			props.className,
 			'block-editor-block-list__layout',
+			__unstableNoLayoutClassNames ? '' : layoutClassNames,
 			{
 				'has-overlay': hasOverlay,
-				[ layoutClassNames ]: __experimentalLayout,
 			}
 		),
 		children: clientId ? (

--- a/packages/block-editor/src/components/inner-blocks/index.js
+++ b/packages/block-editor/src/components/inner-blocks/index.js
@@ -150,7 +150,7 @@ const ForwardedInnerBlocks = forwardRef( ( props, ref ) => {
  * @see https://github.com/WordPress/gutenberg/blob/HEAD/packages/block-editor/src/components/inner-blocks/README.md
  */
 export function useInnerBlocksProps( props = {}, options = {} ) {
-	const { __unstableNoLayoutClassNames } = options;
+	const { __unstableDisableLayoutClassNames } = options;
 	const { clientId, __unstableLayoutClassNames: layoutClassNames = '' } =
 		useBlockEditContext();
 	const isSmallScreen = useViewportMatch( 'medium', '<' );
@@ -209,7 +209,7 @@ export function useInnerBlocksProps( props = {}, options = {} ) {
 		className: classnames(
 			props.className,
 			'block-editor-block-list__layout',
-			__unstableNoLayoutClassNames ? '' : layoutClassNames,
+			__unstableDisableLayoutClassNames ? '' : layoutClassNames,
 			{
 				'has-overlay': hasOverlay,
 			}

--- a/packages/block-editor/src/components/inner-blocks/index.js
+++ b/packages/block-editor/src/components/inner-blocks/index.js
@@ -150,7 +150,8 @@ const ForwardedInnerBlocks = forwardRef( ( props, ref ) => {
  * @see https://github.com/WordPress/gutenberg/blob/HEAD/packages/block-editor/src/components/inner-blocks/README.md
  */
 export function useInnerBlocksProps( props = {}, options = {} ) {
-	const { clientId, layoutClassNames = '' } = useBlockEditContext();
+	const { clientId, __unstableLayoutClassNames: layoutClassNames = '' } =
+		useBlockEditContext();
 	const isSmallScreen = useViewportMatch( 'medium', '<' );
 	const { __experimentalCaptureToolbars, hasOverlay } = useSelect(
 		( select ) => {

--- a/packages/block-editor/src/hooks/layout.js
+++ b/packages/block-editor/src/hooks/layout.js
@@ -9,11 +9,7 @@ import { kebabCase } from 'lodash';
  */
 import { createHigherOrderComponent, useInstanceId } from '@wordpress/compose';
 import { addFilter } from '@wordpress/hooks';
-import {
-	getBlockDefaultClassName,
-	getBlockSupport,
-	hasBlockSupport,
-} from '@wordpress/blocks';
+import { getBlockSupport, hasBlockSupport } from '@wordpress/blocks';
 import { useSelect } from '@wordpress/data';
 import {
 	Button,
@@ -366,9 +362,8 @@ export const withLayoutStyles = createHigherOrderComponent(
 		const layoutClasses = hasLayoutBlockSupport
 			? useLayoutClasses( block )
 			: null;
-		const selector = `.${ getBlockDefaultClassName(
-			name
-		) }.wp-container-${ id }`;
+		// Higher specificity to override defaults from theme.json.
+		const selector = `.wp-container-${ id }.wp-container-${ id }`;
 		const blockGapSupport = useSetting( 'spacing.blockGap' );
 		const hasBlockGapSupport = blockGapSupport !== null;
 
@@ -413,7 +408,7 @@ export const withLayoutStyles = createHigherOrderComponent(
 						/>,
 						element
 					) }
-				<BlockListBlock { ...props } className={ className } />
+				<BlockListBlock { ...props } layoutClassNames={ className } />
 			</>
 		);
 	}

--- a/packages/block-editor/src/hooks/layout.js
+++ b/packages/block-editor/src/hooks/layout.js
@@ -408,7 +408,10 @@ export const withLayoutStyles = createHigherOrderComponent(
 						/>,
 						element
 					) }
-				<BlockListBlock { ...props } layoutClassNames={ className } />
+				<BlockListBlock
+					{ ...props }
+					__unstableLayoutClassNames={ className }
+				/>
 			</>
 		);
 	}

--- a/packages/block-library/src/cover/block.json
+++ b/packages/block-library/src/cover/block.json
@@ -105,13 +105,6 @@
 			"__experimentalDefaultControls": {
 				"fontSize": true
 			}
-		},
-		"__experimentalLayout": {
-			"allowSwitching": true,
-			"allowInheriting": false,
-			"default": {
-				"type": "flow"
-			}
 		}
 	},
 	"editorStyle": "wp-block-cover-editor",

--- a/packages/block-library/src/cover/block.json
+++ b/packages/block-library/src/cover/block.json
@@ -105,6 +105,13 @@
 			"__experimentalDefaultControls": {
 				"fontSize": true
 			}
+		},
+		"__experimentalLayout": {
+			"allowSwitching": true,
+			"allowInheriting": false,
+			"default": {
+				"type": "flow"
+			}
 		}
 	},
 	"editorStyle": "wp-block-cover-editor",

--- a/packages/block-library/src/cover/block.json
+++ b/packages/block-library/src/cover/block.json
@@ -105,12 +105,6 @@
 			"__experimentalDefaultControls": {
 				"fontSize": true
 			}
-		},
-		"__experimentalLayout": {
-			"allowSwitching": true,
-			"default": {
-				"type": "constrained"
-			}
 		}
 	},
 	"editorStyle": "wp-block-cover-editor",

--- a/packages/block-library/src/cover/block.json
+++ b/packages/block-library/src/cover/block.json
@@ -105,6 +105,12 @@
 			"__experimentalDefaultControls": {
 				"fontSize": true
 			}
+		},
+		"__experimentalLayout": {
+			"allowSwitching": true,
+			"default": {
+				"type": "constrained"
+			}
 		}
 	},
 	"editorStyle": "wp-block-cover-editor",

--- a/packages/block-library/src/gallery/gallery.js
+++ b/packages/block-library/src/gallery/gallery.js
@@ -26,6 +26,7 @@ export const Gallery = ( props ) => {
 		mediaPlaceholder,
 		insertBlocksAfter,
 		blockProps,
+		layoutClassNames,
 	} = props;
 
 	const { align, columns, caption, imageCrop } = attributes;
@@ -42,6 +43,7 @@ export const Gallery = ( props ) => {
 			{ ...innerBlocksProps }
 			className={ classnames(
 				blockProps.className,
+				layoutClassNames,
 				'blocks-gallery-grid',
 				{
 					[ `align${ align }` ]: align,

--- a/packages/block-library/src/gallery/gallery.js
+++ b/packages/block-library/src/gallery/gallery.js
@@ -26,7 +26,7 @@ export const Gallery = ( props ) => {
 		mediaPlaceholder,
 		insertBlocksAfter,
 		blockProps,
-		layoutClassNames,
+		__unstableLayoutClassNames: layoutClassNames,
 	} = props;
 
 	const { align, columns, caption, imageCrop } = attributes;

--- a/packages/block-library/src/group/edit.js
+++ b/packages/block-library/src/group/edit.js
@@ -74,6 +74,7 @@ function GroupEdit( {
 				? undefined
 				: InnerBlocks.ButtonBlockAppender,
 			__experimentalLayout: layoutSupportEnabled ? usedLayout : undefined,
+			__unstableNoLayoutClassNames: ! layoutSupportEnabled,
 		}
 	);
 

--- a/packages/block-library/src/group/edit.js
+++ b/packages/block-library/src/group/edit.js
@@ -74,7 +74,7 @@ function GroupEdit( {
 				? undefined
 				: InnerBlocks.ButtonBlockAppender,
 			__experimentalLayout: layoutSupportEnabled ? usedLayout : undefined,
-			__unstableNoLayoutClassNames: ! layoutSupportEnabled,
+			__unstableDisableLayoutClassNames: ! layoutSupportEnabled,
 		}
 	);
 

--- a/packages/block-library/src/group/edit.js
+++ b/packages/block-library/src/group/edit.js
@@ -35,7 +35,12 @@ const htmlElementMessages = {
 	),
 };
 
-function GroupEdit( { attributes, setAttributes, clientId } ) {
+function GroupEdit( {
+	attributes,
+	setAttributes,
+	clientId,
+	__unstableLayoutClassNames: layoutClassNames,
+} ) {
 	const { hasInnerBlocks, themeSupportsLayout } = useSelect(
 		( select ) => {
 			const { getBlock, getSettings } = select( blockEditorStore );
@@ -55,7 +60,9 @@ function GroupEdit( { attributes, setAttributes, clientId } ) {
 	const { type = 'default' } = usedLayout;
 	const layoutSupportEnabled = themeSupportsLayout || type === 'flex';
 
-	const blockProps = useBlockProps();
+	const blockProps = useBlockProps( {
+		className: ! layoutSupportEnabled ? layoutClassNames : null,
+	} );
 
 	const innerBlocksProps = useInnerBlocksProps(
 		layoutSupportEnabled

--- a/packages/block-library/src/post-content/edit.js
+++ b/packages/block-library/src/post-content/edit.js
@@ -84,8 +84,8 @@ function Content( props ) {
 	);
 }
 
-function Placeholder() {
-	const blockProps = useBlockProps();
+function Placeholder( { layoutClassNames } ) {
+	const blockProps = useBlockProps( { className: layoutClassNames } );
 	return (
 		<div { ...blockProps }>
 			<p>
@@ -118,7 +118,11 @@ function RecursionError() {
 	);
 }
 
-export default function PostContentEdit( { context, attributes } ) {
+export default function PostContentEdit( {
+	context,
+	attributes,
+	layoutClassNames,
+} ) {
 	const { postId: contextPostId, postType: contextPostType } = context;
 	const { layout = {} } = attributes;
 	const hasAlreadyRendered = useHasRecursion( contextPostId );
@@ -132,7 +136,7 @@ export default function PostContentEdit( { context, attributes } ) {
 			{ contextPostId && contextPostType ? (
 				<Content context={ context } layout={ layout } />
 			) : (
-				<Placeholder />
+				<Placeholder layoutClassNames={ layoutClassNames } />
 			) }
 		</RecursionProvider>
 	);

--- a/packages/block-library/src/post-content/edit.js
+++ b/packages/block-library/src/post-content/edit.js
@@ -121,7 +121,7 @@ function RecursionError() {
 export default function PostContentEdit( {
 	context,
 	attributes,
-	layoutClassNames,
+	__unstableLayoutClassNames: layoutClassNames,
 } ) {
 	const { postId: contextPostId, postType: contextPostType } = context;
 	const { layout = {} } = attributes;


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

As a prequel to #43140 we need a way to attach layout-related classnames to the inner block wrapper, instead of the outer (they are not always the same).

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

Does some searching and matching to work out where the inner wrapper classnames are, and attach layout classes to those.


## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->

I added layout to the Cover block so we can test this is working. It doesn't have to stay as part of this PR; we can just focus on the mechanism for adding classes and then deal with block-specific stuff later. But for now this can be tested by adding a Cover block with some content and testing its layout controls. 

1. Add Cover block with a couple blocks inside;
2. Change controls in "Layout" section of block sidebar;
3. Check that layout classnames are attached to inner block wrapper on both editor and front end;
4. Check that other blocks with layout (e.g. Group, Buttons, Columns...) are still working correctly.

## Screenshots or screencast <!-- if applicable -->
