### PR TITLE
Navigation block: Add padding to buttons when Submenus Open on click is enabled

### DIFF
--- a/packages/block-library/src/navigation/style.scss
+++ b/packages/block-library/src/navigation/style.scss
@@ -351,7 +351,9 @@ button.wp-block-navigation-item__content {
 
 // Provide a default padding for submenus who should always have some, regardless of the top level menu items.
 :where(.wp-block-navigation .wp-block-navigation__submenu-container .wp-block-navigation-item a:not(.wp-element-button)),
-:where(.wp-block-navigation .wp-block-navigation__submenu-container .wp-block-navigation-submenu a:not(.wp-element-button)) {
+:where(.wp-block-navigation .wp-block-navigation__submenu-container .wp-block-navigation-submenu a:not(.wp-element-button)),
+:where(.wp-block-navigation .wp-block-navigation__submenu-container .wp-block-navigation-submenu button.wp-block-navigation-item__content),
+:where(.wp-block-navigation .wp-block-navigation__submenu-container .wp-block-pages-list__item button.wp-block-navigation-item__content) {
 	padding: 0.5em 1em;
 }
 


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->
Adds padding to the submenu block and page list submenus when buttons are used instead of links.
-Buttons are used when the option "Submenus Open on click" is enabled.

Partial for https://github.com/WordPress/gutenberg/issues/44591
This PR does not address the part where the page list submenus can not be opened.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
The padding was only applied to links, so when the buttons were in use the spacing was incorrect.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
Updates the stylesheet to apply padding to the buttons in the submenu block and in the page list submenu.

## Testing Instructions

1. On your WordPress install, create a few posts and page with a child page and a "grandchild page".
2. In the editor, add a navigation block with a page list. The page list should have (at least) a sub menu with two submenu levels.
3. Add a navigation link with a sub menu ( a submenu block) to the navigation block.
4. Hover over the navigation block and take note of the spacing.
5. Next, enable the option "Submenus Open on click".'
6. Click to open all nested items in the submenu block, confirm if the spacing is correct.
7. Click to open all nested items in the page list block, confirm if the spacing is correct.
8. Save and view the front. Confirm if the spacing is correct on the front.

## Screenshots or screencast <!-- if applicable -->
Before:
<img width="703" alt="padding -before" src="https://user-images.githubusercontent.com/7422055/193217867-6ee6c2f9-fddd-4859-a24e-cd8c9f6e3efa.png">

After:
<img width="1006" alt="padding -after" src="https://user-images.githubusercontent.com/7422055/193218312-1dbbcc6c-639c-4712-98a1-ade1f53d9a78.png">
