### PR TITLE
Try to improve the performance of rendering many empty paragraphs

### DIFF
--- a/packages/block-library/src/paragraph/drop-zone.js
+++ b/packages/block-library/src/paragraph/drop-zone.js
@@ -1,7 +1,6 @@
 /**
  * WordPress dependencies
  */
-import { useState } from '@wordpress/element';
 import { useSelect } from '@wordpress/data';
 import {
 	__experimentalUseOnBlockDrop as useOnBlockDrop,
@@ -11,11 +10,7 @@ import {
 	__experimentalUseDropZone as useDropZone,
 	useReducedMotion,
 } from '@wordpress/compose';
-import {
-	Popover,
-	__unstableMotion as motion,
-	__unstableAnimatePresence as AnimatePresence,
-} from '@wordpress/components';
+import { Popover, __unstableMotion as motion } from '@wordpress/components';
 
 const animateVariants = {
 	hide: { opacity: 0, scaleY: 0.75 },
@@ -23,7 +18,11 @@ const animateVariants = {
 	exit: { opacity: 0, scaleY: 0.9 },
 };
 
-export default function DropZone( { paragraphElement, clientId } ) {
+export default function DropZone( {
+	paragraphElement,
+	clientId,
+	setIsDropZoneVisible,
+} ) {
 	const { rootClientId, blockIndex } = useSelect(
 		( select ) => {
 			const selectors = select( blockEditorStore );
@@ -37,23 +36,10 @@ export default function DropZone( { paragraphElement, clientId } ) {
 	const onBlockDrop = useOnBlockDrop( rootClientId, blockIndex, {
 		action: 'replace',
 	} );
-	const [ isDragging, setIsDragging ] = useState( false );
-	const [ isVisible, setIsVisible ] = useState( false );
-	const popoverRef = useDropZone( {
-		onDragStart: () => {
-			setIsDragging( true );
-		},
-		onDragEnd: () => {
-			setIsDragging( false );
-		},
-	} );
 	const dropZoneRef = useDropZone( {
 		onDrop: onBlockDrop,
-		onDragEnter: () => {
-			setIsVisible( true );
-		},
 		onDragLeave: () => {
-			setIsVisible( false );
+			setIsDropZoneVisible( false );
 		},
 	} );
 	const reducedMotion = useReducedMotion();
@@ -67,39 +53,23 @@ export default function DropZone( { paragraphElement, clientId } ) {
 			flip={ false }
 			resize={ false }
 			className="wp-block-paragraph__drop-zone"
-			ref={ popoverRef }
 		>
-			{ isDragging ? (
-				<div
-					className="wp-block-paragraph__drop-zone-backdrop"
-					ref={ dropZoneRef }
-					style={ {
-						width: paragraphElement?.offsetWidth,
-						height: paragraphElement?.offsetHeight,
-					} }
-				>
-					<AnimatePresence>
-						{ isVisible ? (
-							<motion.div
-								key="drop-zone-foreground"
-								data-testid="empty-paragraph-drop-zone"
-								initial={
-									reducedMotion
-										? animateVariants.show
-										: animateVariants.hide
-								}
-								animate={ animateVariants.show }
-								exit={
-									reducedMotion
-										? animateVariants.show
-										: animateVariants.exit
-								}
-								className="wp-block-paragraph__drop-zone-foreground"
-							/>
-						) : null }
-					</AnimatePresence>
-				</div>
-			) : null }
+			<motion.div
+				ref={ dropZoneRef }
+				style={ {
+					width: paragraphElement?.offsetWidth,
+					height: paragraphElement?.offsetHeight,
+				} }
+				data-testid="empty-paragraph-drop-zone"
+				initial={
+					reducedMotion ? animateVariants.show : animateVariants.hide
+				}
+				animate={ animateVariants.show }
+				exit={
+					reducedMotion ? animateVariants.show : animateVariants.exit
+				}
+				className="wp-block-paragraph__drop-zone-foreground"
+			/>
 		</Popover>
 	);
 }

--- a/packages/block-library/src/paragraph/drop-zone.js
+++ b/packages/block-library/src/paragraph/drop-zone.js
@@ -1,15 +1,7 @@
 /**
  * WordPress dependencies
  */
-import { useSelect } from '@wordpress/data';
-import {
-	__experimentalUseOnBlockDrop as useOnBlockDrop,
-	store as blockEditorStore,
-} from '@wordpress/block-editor';
-import {
-	__experimentalUseDropZone as useDropZone,
-	useReducedMotion,
-} from '@wordpress/compose';
+import { useReducedMotion } from '@wordpress/compose';
 import { Popover, __unstableMotion as motion } from '@wordpress/components';
 
 const animateVariants = {
@@ -18,30 +10,7 @@ const animateVariants = {
 	exit: { opacity: 0, scaleY: 0.9 },
 };
 
-export default function DropZone( {
-	paragraphElement,
-	clientId,
-	setIsDropZoneVisible,
-} ) {
-	const { rootClientId, blockIndex } = useSelect(
-		( select ) => {
-			const selectors = select( blockEditorStore );
-			return {
-				rootClientId: selectors.getBlockRootClientId( clientId ),
-				blockIndex: selectors.getBlockIndex( clientId ),
-			};
-		},
-		[ clientId ]
-	);
-	const onBlockDrop = useOnBlockDrop( rootClientId, blockIndex, {
-		action: 'replace',
-	} );
-	const dropZoneRef = useDropZone( {
-		onDrop: onBlockDrop,
-		onDragLeave: () => {
-			setIsDropZoneVisible( false );
-		},
-	} );
+export default function DropZone( { paragraphElement } ) {
 	const reducedMotion = useReducedMotion();
 
 	return (
@@ -55,7 +24,6 @@ export default function DropZone( {
 			className="wp-block-paragraph__drop-zone"
 		>
 			<motion.div
-				ref={ dropZoneRef }
 				style={ {
 					width: paragraphElement?.offsetWidth,
 					height: paragraphElement?.offsetHeight,

--- a/packages/block-library/src/paragraph/editor.scss
+++ b/packages/block-library/src/paragraph/editor.scss
@@ -25,14 +25,8 @@
 		box-shadow: none;
 	}
 
-	.wp-block-paragraph__drop-zone-backdrop {
-		position: absolute;
-	}
-
 	.wp-block-paragraph__drop-zone-foreground {
 		position: absolute;
-		inset: 0;
-		pointer-events: none;
 		background-color: var(--wp-admin-theme-color);
 		border-radius: 2px;
 	}

--- a/packages/block-library/src/paragraph/editor.scss
+++ b/packages/block-library/src/paragraph/editor.scss
@@ -28,6 +28,7 @@
 	.wp-block-paragraph__drop-zone-foreground {
 		position: absolute;
 		background-color: var(--wp-admin-theme-color);
+		pointer-events: none;
 		border-radius: 2px;
 	}
 }


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->
A follow-up to #42722 to improve the select performance when rendering a large number of empty paragraphs at the same time.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->

## Screenshots or screencast <!-- if applicable -->
