### PR TITLE
Add missing import statement for useBlockProps

### DIFF
--- a/docs/getting-started/create-block/author-experience.md
+++ b/docs/getting-started/create-block/author-experience.md
@@ -79,6 +79,7 @@ All of this combined together, here's what the edit function looks like:
 ```jsx
 import { Placeholder, TextControl } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
+import { useBlockProps } from "@wordpress/block-editor";
 
 export default function Edit( { attributes, isSelected, setAttributes } ) {
 	return (


### PR DESCRIPTION
Added a missing import statement in `Authoring Experience` Documentation.