### PR TITLE
Fix: use active variation as the parent block if available

### DIFF
--- a/packages/block-editor/src/components/block-settings-menu/block-settings-dropdown.js
+++ b/packages/block-editor/src/components/block-settings-menu/block-settings-dropdown.js
@@ -6,7 +6,11 @@ import { castArray } from 'lodash';
 /**
  * WordPress dependencies
  */
-import { getBlockType, serialize } from '@wordpress/blocks';
+import {
+	getBlockType,
+	serialize,
+	store as blocksStore,
+} from '@wordpress/blocks';
 import { DropdownMenu, MenuGroup, MenuItem } from '@wordpress/components';
 import { useDispatch, useSelect } from '@wordpress/data';
 import { moreVertical } from '@wordpress/icons';
@@ -75,7 +79,10 @@ export function BlockSettingsDropdown( {
 				getNextBlockClientId,
 				getSelectedBlockClientIds,
 				getSettings,
+				getBlockAttributes,
 			} = select( blockEditorStore );
+
+			const { getActiveBlockVariation } = select( blocksStore );
 
 			const parents = getBlockParents( firstBlockClientId );
 			const _firstParentClientId = parents[ parents.length - 1 ];
@@ -85,7 +92,11 @@ export function BlockSettingsDropdown( {
 				firstParentClientId: _firstParentClientId,
 				hasReducedUI: getSettings().hasReducedUI,
 				onlyBlock: 1 === getBlockCount(),
-				parentBlockType: getBlockType( parentBlockName ),
+				parentBlockType:
+					getActiveBlockVariation(
+						parentBlockName,
+						getBlockAttributes( _firstParentClientId )
+					) || getBlockType( parentBlockName ),
 				previousBlockClientId:
 					getPreviousBlockClientId( firstBlockClientId ),
 				nextBlockClientId: getNextBlockClientId( firstBlockClientId ),


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->
This PR shows the active variation info in the inner block's menu if the parent block is a variation.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
Fixes #44608

If the current parent block is a variation, it's better to display the variation title and icon in the block menu. Otherwise, it can make users confused.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
This PR checks if the first parent block is a variation and then uses the active variation as the parent block, so the correct metadata is displayed in the block menu: `Select parent block (...)` item.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
1. Add a Row block to the page. 
2. Add a Heading block to the Row block.
3. Open the menu of the Heading block.
4. See `Select parent block (Row)`.

Or check out this PR, add a filter block to the page and check the block menu of inner block as screenshots show: https://github.com/woocommerce/woocommerce-blocks/pull/6978

## Screenshots or screencast <!-- if applicable -->

### Before this PR
<img width="628" alt="Screen Shot 2022-09-30 at 16 20 21" src="https://user-images.githubusercontent.com/5423135/193240223-b20881f9-0bb7-4423-8c7a-d5302cc7b133.png">

### With this PR
<img width="653" alt="Screen Shot 2022-09-30 at 16 18 10" src="https://user-images.githubusercontent.com/5423135/193240265-adae23ec-dcd4-47e5-ba87-d6c7705264f7.png">