### PR TITLE
Style cards: Fix focus style.

### DIFF
--- a/packages/edit-site/src/components/global-styles/style.scss
+++ b/packages/edit-site/src/components/global-styles/style.scss
@@ -97,7 +97,7 @@
 	}
 
 	&:focus .edit-site-global-styles-variations_item-preview {
-		border: var(--wp-admin-theme-color) $border-width solid;
+		border: var(--wp-admin-theme-color) var(--wp-admin-border-width-focus) solid;
 	}
 }
 


### PR DESCRIPTION
## What?

The focus style for style cards (Global Styles > Browse styles) was wrong being just 1px:

<img width="273" alt="before" src="https://user-images.githubusercontent.com/1204802/193252858-942c4536-d238-42fa-850d-83930c66e3c7.png">

This PR fixes it to be thicker:

<img width="269" alt="after" src="https://user-images.githubusercontent.com/1204802/193252908-db0506c0-84d1-490d-b780-9cda466a9532.png">

## Testing Instructions

Activate a theme that has style variations, then browse styles in the site editor, and focus a style card. It should have a thicker focus style.