### PR TITLE
Edit-post: Remove right border when sidebars are closed.

### DIFF
--- a/packages/edit-post/src/style.scss
+++ b/packages/edit-post/src/style.scss
@@ -98,3 +98,17 @@ body.block-editor-page {
 }
 
 @include wordpress-admin-schemes();
+
+// The edit-site package adds or removes the sidebar when it's opened or closed.
+// The edit-post package, however, always has the sidebar in the canvas.
+// These edit-post specific rules ensures there isn't a border on the right of
+// the canvas when a sidebar is visually closed.
+.interface-interface-skeleton__sidebar {
+	border-left: none;
+
+	.is-sidebar-opened & {
+		@include break-medium() {
+			border-left: $border-width solid $gray-200;
+		}
+	}
+}


### PR DESCRIPTION
## What?

The edit-site package adds or removes the sidebar when it's opened or closed. The edit-post package, however, always has the sidebar in the canvas. This PR adds edit-post specific rules ensures there isn't a border on the right of the canvas when a sidebar is visually closed.

Before, zoom in, notice there's a light gray border to the right of the dark canvas:

<img width="1392" alt="border on the right, before" src="https://user-images.githubusercontent.com/1204802/193256230-27ca88c2-8be3-4ed6-b67f-603d26c1eb9b.png">

After, this border is gone:

<img width="1392" alt="no border on the right, after" src="https://user-images.githubusercontent.com/1204802/193256272-f9e3f7ca-3ffc-4a86-a181-8e64029a746d.png">

## Testing Instructions

Please test both edit-post and edit-site, with and without sidebars open. Including plugin sidebars, ideally. When a sidebar is closed, no border should be present. When a sidebar is open, it should be.