### PR TITLE
package(prettier-config): update docs

### DIFF
--- a/packages/prettier-config/CHANGELOG.md
+++ b/packages/prettier-config/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## Unreleased
 
+### Internal
+
+-   Fix doc for extending the prettier config in `.prettierrc` config file.
+-   Add step to extend the prettier config in `.prettierrc.js` config file.
+
 ## 2.1.0 (2022-09-21)
 
 ## 2.0.0 (2022-08-24)

--- a/packages/prettier-config/README.md
+++ b/packages/prettier-config/README.md
@@ -26,6 +26,12 @@ Alternatively, add this to `.prettierrc` file:
 "@wordpress/prettier-config"
 ```
 
+Or add this to `.prettierrc.js` file:
+
+```js
+module.exports = require( '@wordpress/prettier-config' );
+```
+
 ## Contributing to this package
 
 This is an individual package that's part of the Gutenberg project. The project is organized as a monorepo. It's made up of multiple self-contained software packages, each with a specific purpose. The packages in this monorepo are published to [npm](https://www.npmjs.com/) and used by [WordPress](https://make.wordpress.org/core/) as well as other software projects.

--- a/packages/prettier-config/README.md
+++ b/packages/prettier-config/README.md
@@ -23,7 +23,7 @@ Add this to your `package.json` file:
 Alternatively, add this to `.prettierrc` file:
 
 ```
-extends: ['@wordpress/prettier-config']
+"@wordpress/prettier-config"
 ```
 
 ## Contributing to this package


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
- Fix doc for extending `prettier-config` in `.prettierrc` file.
- Add step for extending `prettier-config` in `.prettierrc.js` file.

## Why?
Adding `extends: ['@wordpress/prettier-config']` in `prettierrc` file doesn't really extends the config.

Also, see: https://stackoverflow.com/questions/63963613/configuring-prettier-format-tool-for-wordpress-in-prettierrc

## How?

```diff
- extends: ['@wordpress/prettier-config']
+ "@wordpress/prettier-config"
```

## Testing Instructions
Try extending the config with both ways inside the code editor and open the extension terminal by:
- Open the terminal
- Select the output tab 
- Choose prettier from the dropdown on the right side.
- Now see the output in both cases.
