### PR TITLE
Add missing value to CSS font-display descriptor in theme.json

### DIFF
--- a/lib/experimental/class-wp-webfonts.php
+++ b/lib/experimental/class-wp-webfonts.php
@@ -244,7 +244,7 @@ class WP_Webfonts {
 		}
 
 		// Check the font-display.
-		if ( ! in_array( $webfont['font-display'], array( 'auto', 'block', 'fallback', 'swap' ), true ) ) {
+		if ( ! in_array( $webfont['font-display'], array( 'auto', 'block', 'fallback', 'swap', 'optional' ), true ) ) {
 			$webfont['font-display'] = 'fallback';
 		}
 

--- a/schemas/json/theme.json
+++ b/schemas/json/theme.json
@@ -463,7 +463,8 @@
 														"auto",
 														"block",
 														"fallback",
-														"swap"
+														"swap",
+														"optional"
 													]
 												},
 												"src": {


### PR DESCRIPTION
## What?
The “optional” value for the CSS `font-display` descriptor is missing from `theme.json` (see below). This PR simply adds it.

<img width="1132" alt="Screen-Shot-2022-09-30-13-56-12" src="https://user-images.githubusercontent.com/1451087/193337967-0ac5c703-8fcf-4b94-bd09-bcdab68f1f85.png">


## Why?
The value is part of the [CSS fonts spec](https://w3c.github.io/csswg-drafts/css-fonts-4/#font-display-desc), and it's recommended for body text, where a custom font is not absolutely required to load on the first visit and can be safely seen only on subsequent page loads.

## How?
The `theme.json` schema was manually updated with the missing value. 

## Testing Instructions
1. Open any `theme.json` file, from any block theme, on VS Code.
2. Go to the `fontFamilies` section and add a `fontDisplay` definition.
3. Add a new value and see that “optional” appears.
4. Check the front-end code to see if the value was correctly applied to the `font-face` property.

![2022-09-30 15 54 26](https://user-images.githubusercontent.com/1451087/193337948-af711642-ddee-48b0-accd-835b02369e29.gif)

