### PR TITLE
[List v2]: Fix enter key action when the list is empty

### DIFF
--- a/packages/block-library/src/list-item/hooks/use-enter.js
+++ b/packages/block-library/src/list-item/hooks/use-enter.js
@@ -69,9 +69,14 @@ export default function useEnter( props ) {
 							} ),
 					  ]
 					: [];
+
+				// Replace the list block itself with a paragraph block if it's completely empty.
+				const isEmpty =
+					topParentListBlock.innerBlocks.length === 1 && ! content;
+
 				replaceBlocks(
 					topParentListBlock.clientId,
-					[ head, middle, ...tail ],
+					isEmpty ? [ middle ] : [ head, middle, ...tail ],
 					1
 				);
 				// We manually change the selection here because we are replacing

--- a/test/e2e/specs/editor/blocks/list.spec.js
+++ b/test/e2e/specs/editor/blocks/list.spec.js
@@ -514,6 +514,16 @@ test.describe( 'List', () => {
 		);
 	} );
 
+	test( 'Should be converted from an empty list to an empty paragraph block', async ( {
+		editor,
+		page,
+	} ) => {
+		await editor.insertBlock( { name: 'core/list' } );
+		await page.keyboard.press( 'Enter' );
+
+		await expect.poll( editor.getEditedPostContent ).toBe( `` );
+	} );
+
 	test( 'should split indented list item', async ( { editor, page } ) => {
 		await editor.insertBlock( { name: 'core/list' } );
 		await page.keyboard.type( 'one' );


### PR DESCRIPTION
Fix #44627

This issue was found in [WordPress Mega Meetup Japan 2022 Fall](https://japanmeetup.wordpress.com/) contribute event 🎉

## What?
This PR fixes a problem where an unexpected paragraph block was generated when pressing the Enter key in an empty list.

## Why?
If there are multiple list items and the Enter key is pressed in the middle of a list, the list is split and a paragraph block is generated between them. But in a list with one empty list item, the list itself should be converted into a paragraph block when the Enter key is pressed.

## How?
When the Enter key is pressed, the list is now checked to see if it is "completely empty". If empty, it is converted to a paragraph block.

At the same time, I've added the E2e test.

## Testing Instructions
- Enter a list block.
- While  the contents of the list item empty, press Enter.
- Confirm that the list itself is converted to a paragraph block.

## Screenshots or screencast 

### Before 

https://user-images.githubusercontent.com/54422211/193398264-be75c425-790d-42fa-9ee6-8eb5b645c913.mp4

### After

https://user-images.githubusercontent.com/54422211/193398259-f3bde3bc-acc3-4d8d-87a3-904726fda8c2.mp4