### PR TITLE
useMergeRefs: don't call/mutate refs passed if unused

### DIFF
--- a/packages/compose/src/hooks/use-merge-refs/index.js
+++ b/packages/compose/src/hooks/use-merge-refs/index.js
@@ -71,6 +71,7 @@ function assignRef( ref, value ) {
  */
 export default function useMergeRefs( refs ) {
 	const element = useRef();
+	const isAttached = useRef( false );
 	const didElementChange = useRef( false );
 	/* eslint-disable jsdoc/no-undefined-types */
 	/** @type {import('react').MutableRefObject<TRef[]>} */
@@ -86,7 +87,10 @@ export default function useMergeRefs( refs ) {
 	// ref with the node, except when the element changes in the same cycle, in
 	// which case the ref callbacks will already have been called.
 	useLayoutEffect( () => {
-		if ( didElementChange.current === false ) {
+		if (
+			didElementChange.current === false &&
+			isAttached.current === true
+		) {
 			refs.forEach( ( ref, index ) => {
 				const previousRef = previousRefs.current[ index ];
 				if ( ref !== previousRef ) {
@@ -113,6 +117,7 @@ export default function useMergeRefs( refs ) {
 		assignRef( element, value );
 
 		didElementChange.current = true;
+		isAttached.current = value !== null;
 
 		// When an element changes, the current ref callback should be called
 		// with the new element and the previous one with `null`.

--- a/packages/compose/src/hooks/use-merge-refs/test/index.js
+++ b/packages/compose/src/hooks/use-merge-refs/test/index.js
@@ -41,6 +41,7 @@ describe( 'useMergeRefs', () => {
 		tagName: TagName = 'div',
 		disable1,
 		disable2,
+		unused,
 	} ) {
 		function refCallback1( value ) {
 			refCallback1.history.push( value );
@@ -62,6 +63,10 @@ describe( 'useMergeRefs', () => {
 			! disable1 && ref1,
 			! disable2 && ref2,
 		] );
+
+		if ( unused ) {
+			return <TagName ref={ ref1 } />;
+		}
 
 		return <TagName ref={ mergedRefs } />;
 	}
@@ -325,6 +330,45 @@ describe( 'useMergeRefs', () => {
 			],
 			[ [], [] ],
 			[ [], [ originalElement, null ] ],
+		] );
+	} );
+
+	it( 'should allow the hook being unused', () => {
+		const rootElement = document.getElementById( 'root' );
+
+		ReactDOM.render( <MergedRefs unused />, rootElement );
+
+		const originalElement = rootElement.firstElementChild;
+
+		// Render 1: ref 1 should updated, ref 2 should not.
+		expect( renderCallback.history ).toEqual( [
+			[ [ originalElement ], [] ],
+		] );
+
+		ReactDOM.render( <MergedRefs />, rootElement );
+
+		// Render 2: ref 2 should be updated as well.
+		expect( renderCallback.history ).toEqual( [
+			[ [ originalElement, null, originalElement ], [ originalElement ] ],
+			[ [], [] ],
+		] );
+
+		ReactDOM.render( <MergedRefs unused />, rootElement );
+
+		// Render 3: ref 2 should be updated with null
+		expect( renderCallback.history ).toEqual( [
+			[
+				[
+					originalElement,
+					null,
+					originalElement,
+					null,
+					originalElement,
+				],
+				[ originalElement, null ],
+			],
+			[ [], [] ],
+			[ [], [] ],
 		] );
 	} );
 } );


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?

Fixes an issue with useMergeRefs if the hook is called but the returned ref is not passed to a component (the ref is "unused" or not "attached"). The problem is that even though it's unused, we're still calling or mutating the ref object with `null`, which overrides the value set by React.

## Why?

See above.

Required for #32091 because the intersection observer requires a working ref.

## How?

We know if a ref is "used" or "attached" if React calls the returned ref callback with an element (not `null`).

## Testing Instructions

This came to my attention when playing with the reusable block. If the request is not resolved, the block can be selected but the block toolbar doesn't appear.

1. Create a reusable block.
2. Change the following condition to always true: https://github.com/WordPress/gutenberg/blob/b21766438d9bb0de9c04bc2494d7093fb12b9f25/packages/block-library/src/block/edit.js#L95
3. Reload the page with the reusable block, and the spinner UI should appear.
4. Click on the block. You won't see the block toolbar in trunk, but you will with this PR.

## Screenshots or screencast <!-- if applicable -->
