### PR TITLE
Query Loop: Fix condition for displaying 'parents' control

### DIFF
--- a/packages/block-library/src/query/edit/inspector-controls/index.js
+++ b/packages/block-library/src/query/edit/inspector-controls/index.js
@@ -237,10 +237,7 @@ export default function QueryInspectorControls( {
 							</ToolsPanelItem>
 						) }
 						{ isPostTypeHierarchical &&
-							! isControlAllowed(
-								allowedControls,
-								'parents'
-							) && (
+							isControlAllowed( allowedControls, 'parents' ) && (
 								<ToolsPanelItem
 									hasValue={ () => !! parents?.length }
 									label={ __( 'Parents' ) }


### PR DESCRIPTION
## What?
Fixes #44621.

PR fixes regression introduced in #43632, which prevented "Parents" control filter to be displayed for hierarchical post types.

## Why?
The logical NOT here is a typo. The Query Loop block should display the filter for hierarchical post types; unless the `allowedControls` list omits the control filter.

## Testing Instructions
1. Open a Post or Page.
2. Insert a Query Loop block.
3. Confirm that the "Parents" filter isn't available for the "Post" post type.
4. Switch post type to the "Page."
5. Confirm that the filter is now visible and is working.

## Screenshots or screencast <!-- if applicable -->

https://user-images.githubusercontent.com/240569/193455459-de68e144-04a9-40c8-8c29-4c9a5cf62a78.mp4


