### PR TITLE
Quote block: stop slash inserter popup showing in citation

### DIFF
--- a/packages/block-library/src/quote/block.json
+++ b/packages/block-library/src/quote/block.json
@@ -29,7 +29,6 @@
 	},
 	"supports": {
 		"anchor": true,
-		"__experimentalSlashInserter": true,
 		"__experimentalOnEnter": true,
 		"typography": {
 			"fontSize": true,


### PR DESCRIPTION
## What?
Stop slash inserter popup showing in the citation of the Quote block

## Why?
It is not possible to nest blocks in the citation, and attempting to do so causes an exception.
Fixes: #44617

## How?
Removes `__experimentalSlashInserter` support. It looks like `__experimentalSlashInserter` support was added before the v2 of the block so shouldn't be needed now.

## Testing Instructions

- Add a Quote block
- In the citation enter a `/` and make sure the slash inserter popup does not appear
- Check that you still get the slash inserter in the main quote body

## Screenshots or screencast 

Before:

https://user-images.githubusercontent.com/3629020/193489687-51a39923-153f-4faa-aaa9-c2166a2be959.mp4

After:

https://user-images.githubusercontent.com/3629020/193489703-3fda86b7-6b7c-43f7-a6ca-881196ab0fbf.mp4



