### PR TITLE
Add extra guarding against legacy widget preview errors

### DIFF
--- a/packages/widgets/src/blocks/legacy-widget/edit/preview.js
+++ b/packages/widgets/src/blocks/legacy-widget/edit/preview.js
@@ -64,7 +64,12 @@ export default function Preview( { idBase, instance, isVisible } ) {
 					iframe.contentDocument.documentElement?.offsetHeight ?? 0,
 					iframe.contentDocument.body?.offsetHeight ?? 0
 				);
-				iframe.style.height = `${ height }px`;
+
+				// Fallback to a height of 100px if the height cannot be determined.
+				// This ensures the block is still selectable. 100px should hopefully
+				// be not so big that it's annoying, and not so small that nothing
+				// can be seen.
+				iframe.style.height = `${ height !== 0 ? height : 100 }px`;
 			}
 
 			const { IntersectionObserver } = iframe.ownerDocument.defaultView;

--- a/packages/widgets/src/blocks/legacy-widget/edit/preview.js
+++ b/packages/widgets/src/blocks/legacy-widget/edit/preview.js
@@ -61,8 +61,8 @@ export default function Preview( { idBase, instance, isVisible } ) {
 			function setHeight() {
 				// Pick the maximum of these two values to account for margin collapsing.
 				const height = Math.max(
-					iframe.contentDocument.documentElement.offsetHeight,
-					iframe.contentDocument.body.offsetHeight
+					iframe.contentDocument.documentElement?.offsetHeight ?? 0,
+					iframe.contentDocument.body?.offsetHeight ?? 0
 				);
 				iframe.style.height = `${ height }px`;
 			}


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Closes #43661

Adds some extra guarding around the code that determines the height of the legacy widget preview height.

## Why?
According to the issue, this code can throw errors under some circumstances.

I wasn't personally able to reproduce an error — likely it requires a specific plugin.

One possibility of why this may happen is invalid HTML causing an iframe to enter quirks mode. This can change how an iframe works. What might be happening is that a plugin is adding a widget that has invalid HTML. If there are reports of specific plugins where the preview isn't working this can be explored further.

## How?
This adds a fallback of `0` if either the body or document is `null` so that the `Math.max` comparison still works. If `Math.max` returns `0`, the code now falls back to a default height of `100px`.

## Testing Instructions
Prerequsites:
- Use a non-block theme
- Ensure you have Legacy Widgets available. Consider using a plugin like 'SiteOrigin Widgets Bundle'

Steps:
1. Open the widgets editor
2. Add a legacy widget and configure it
3. Deselect the block

Expected: The preview should show correctly