### PR TITLE
Resizable editor: fix height setting bug

### DIFF
--- a/packages/edit-site/src/components/block-editor/resizable-editor.js
+++ b/packages/edit-site/src/components/block-editor/resizable-editor.js
@@ -67,8 +67,6 @@ function ResizableEditor( { enableResizing, settings, children, ...props } ) {
 				setHeight( iframe.contentDocument.body.scrollHeight );
 			}
 
-			iframe.addEventListener( 'load', setFrameHeight );
-
 			let resizeObserver;
 
 			function registerObserver() {
@@ -93,7 +91,6 @@ function ResizableEditor( { enableResizing, settings, children, ...props } ) {
 			return () => {
 				resizeObserver?.disconnect();
 				iframe.removeEventListener( 'load', registerObserver );
-				iframe.removeEventListener( 'load', setFrameHeight );
 			};
 		},
 		[ enableResizing, iframeRef.current ]

--- a/packages/edit-site/src/components/block-editor/resizable-editor.js
+++ b/packages/edit-site/src/components/block-editor/resizable-editor.js
@@ -79,14 +79,10 @@ function ResizableEditor( { enableResizing, settings, children, ...props } ) {
 				// Observe the body, since the `html` element seems to always
 				// have a height of `100%`.
 				resizeObserver.observe( iframe.contentDocument.body );
-
 				setFrameHeight();
 			}
 
-			// This is only required in Firefox for some unknown reasons.
 			iframe.addEventListener( 'load', registerObserver );
-			// This is required in Chrome and Safari.
-			registerObserver();
 
 			return () => {
 				resizeObserver?.disconnect();

--- a/packages/edit-site/src/components/block-editor/resizable-editor.js
+++ b/packages/edit-site/src/components/block-editor/resizable-editor.js
@@ -57,39 +57,17 @@ function ResizableEditor( { enableResizing, settings, children, ...props } ) {
 
 	useEffect(
 		function autoResizeIframeHeight() {
-			const iframe = iframeRef.current;
-
-			if ( ! iframe || ! enableResizing ) {
+			if ( ! iframeRef.current || ! enableResizing ) {
 				return;
 			}
 
-			let timeoutId = null;
+			const iframe = iframeRef.current;
 
-			function resizeHeight() {
-				if ( ! timeoutId ) {
-					// Throttle the updates on timeout. This code previously
-					// used `requestAnimationFrame`, but that seems to not
-					// always work before an iframe is ready.
-					timeoutId = iframe.contentWindow.setTimeout( () => {
-						const { readyState } = iframe.contentDocument;
-
-						// Continue deferring the timeout until the document is ready.
-						// Only then will it have a height.
-						if (
-							readyState !== 'interactive' &&
-							readyState !== 'complete'
-						) {
-							resizeHeight();
-							return;
-						}
-
-						setHeight( iframe.contentDocument.body.scrollHeight );
-						timeoutId = null;
-
-						// 30 frames per second.
-					}, 1000 / 30 );
-				}
+			function setFrameHeight() {
+				setHeight( iframe.contentDocument.body.scrollHeight );
 			}
+
+			iframe.addEventListener( 'load', setFrameHeight );
 
 			let resizeObserver;
 
@@ -97,14 +75,14 @@ function ResizableEditor( { enableResizing, settings, children, ...props } ) {
 				resizeObserver?.disconnect();
 
 				resizeObserver = new iframe.contentWindow.ResizeObserver(
-					resizeHeight
+					setFrameHeight
 				);
 
 				// Observe the body, since the `html` element seems to always
 				// have a height of `100%`.
 				resizeObserver.observe( iframe.contentDocument.body );
 
-				resizeHeight();
+				setFrameHeight();
 			}
 
 			// This is only required in Firefox for some unknown reasons.
@@ -113,12 +91,12 @@ function ResizableEditor( { enableResizing, settings, children, ...props } ) {
 			registerObserver();
 
 			return () => {
-				iframe.contentWindow?.clearTimeout( timeoutId );
 				resizeObserver?.disconnect();
 				iframe.removeEventListener( 'load', registerObserver );
+				iframe.removeEventListener( 'load', setFrameHeight );
 			};
 		},
-		[ enableResizing ]
+		[ enableResizing, iframeRef.current ]
 	);
 
 	const resizeWidthBy = useCallback( ( deltaPixels ) => {


### PR DESCRIPTION
## What?
Simplifies the code which sets the initial height of the resizable iframed editor

## Why?
Fixes: #42226

## How?
Removes additional timeouts that wait for iframe page load and rely on the iframe load event listener

## Testing Instructions

- Load the site editor and select to edit a template part, eg. header
- Check that the isolated header iframe loads the correct size
- Try multiple page loads and make sure it loads the same size each time

## Screenshots or screencast 

Before:

https://user-images.githubusercontent.com/677833/191464237-dcea53df-fda6-428b-bff3-209fc60abcf4.mp4

After:

https://user-images.githubusercontent.com/3629020/193698904-d3f7465a-df89-4a85-a33d-20d05664c499.mp4



