### PR TITLE
Only include theme.css if the theme declares support for wp-block-styles

### DIFF
--- a/lib/client-assets.php
+++ b/lib/client-assets.php
@@ -323,8 +323,8 @@ function gutenberg_register_packages_styles( $styles ) {
 	}
 
 	global $editor_styles;
-	if ( ! is_array( $editor_styles ) || count( $editor_styles ) === 0 ) {
-		// Include opinionated block styles if no $editor_styles are declared, so the editor never appears broken.
+	if ( current_theme_supports('wp-block-styles') && ( ! is_array( $editor_styles ) || count( $editor_styles ) === 0 )) {
+		// Include opinionated block styles if the theme supports block styles and no $editor_styless are declared, so the editor never appears broken.
 		$wp_edit_blocks_dependencies[] = 'wp-block-library-theme';
 	}
 

--- a/lib/client-assets.php
+++ b/lib/client-assets.php
@@ -323,7 +323,7 @@ function gutenberg_register_packages_styles( $styles ) {
 	}
 
 	global $editor_styles;
-	if ( current_theme_supports('wp-block-styles') && ( ! is_array( $editor_styles ) || count( $editor_styles ) === 0 )) {
+	if ( current_theme_supports( 'wp-block-styles' ) && ( ! is_array( $editor_styles ) || count( $editor_styles ) === 0 )) {
 		// Include opinionated block styles if the theme supports block styles and no $editor_styless are declared, so the editor never appears broken.
 		$wp_edit_blocks_dependencies[] = 'wp-block-library-theme';
 	}

--- a/lib/client-assets.php
+++ b/lib/client-assets.php
@@ -324,7 +324,7 @@ function gutenberg_register_packages_styles( $styles ) {
 
 	global $editor_styles;
 	if ( current_theme_supports( 'wp-block-styles' ) && ( ! is_array( $editor_styles ) || count( $editor_styles ) === 0 ) ) {
-		// Include opinionated block styles if the theme supports block styles and no $editor_styless are declared, so the editor never appears broken.
+		// Include opinionated block styles if the theme supports block styles and no $editor_styles are declared, so the editor never appears broken.
 		$wp_edit_blocks_dependencies[] = 'wp-block-library-theme';
 	}
 

--- a/lib/client-assets.php
+++ b/lib/client-assets.php
@@ -323,7 +323,7 @@ function gutenberg_register_packages_styles( $styles ) {
 	}
 
 	global $editor_styles;
-	if ( current_theme_supports( 'wp-block-styles' ) && ( ! is_array( $editor_styles ) || count( $editor_styles ) === 0 )) {
+	if ( current_theme_supports( 'wp-block-styles' ) && ( ! is_array( $editor_styles ) || count( $editor_styles ) === 0 ) ) {
 		// Include opinionated block styles if the theme supports block styles and no $editor_styless are declared, so the editor never appears broken.
 		$wp_edit_blocks_dependencies[] = 'wp-block-library-theme';
 	}


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->
Adds an additional condition to the check that loads the `wp-block-library-theme` as a dependency of the **editor** styles.
The dependency should only be added if the theme includes the wp-block-styles theme support.

_(This file is already loading correctly on the front, this is only related to the editor styles)_

Closes https://github.com/WordPress/gutenberg/issues/44510

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
The theme.css was loaded in the editor even though themes did not declare support for it, which lead to the editor and front not matching.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
Adds an additional condition to the check that loads the `wp-block-library-theme` as a dependency of the editor styles.

## Testing Instructions

1. Activate Twenty Twenty-Three.
2. In the block editor, add a quote block. Confirm that the quote block does not have a border.
3. Create a functions.php  in the theme's root directory, that includes the theme support:
```
<?php
add_theme_support( 'wp-block-styles' );
?>
```

4. Next please reload the editor where you added the quote block, and confirm that the block has a left border.

## Screenshots or screencast <!-- if applicable -->
