### PR TITLE
Query Loop: Hide instructions for FormTokenField

### DIFF
--- a/packages/block-library/src/query/edit/inspector-controls/author-control.js
+++ b/packages/block-library/src/query/edit/inspector-controls/author-control.js
@@ -71,6 +71,7 @@ function AuthorControl( { value, onChange } ) {
 			value={ sanitizedValue }
 			suggestions={ authorsInfo.names }
 			onChange={ onAuthorChange }
+			__experimentalShowHowTo={ false }
 		/>
 	);
 }

--- a/packages/block-library/src/query/edit/inspector-controls/parent-control.js
+++ b/packages/block-library/src/query/edit/inspector-controls/parent-control.js
@@ -125,6 +125,7 @@ function ParentControl( { parents, postType, onChange } ) {
 			onInputChange={ debouncedSearch }
 			suggestions={ suggestions }
 			onChange={ onParentChange }
+			__experimentalShowHowTo={ false }
 		/>
 	);
 }

--- a/packages/block-library/src/query/edit/inspector-controls/taxonomy-controls.js
+++ b/packages/block-library/src/query/edit/inspector-controls/taxonomy-controls.js
@@ -116,6 +116,7 @@ export function TaxonomyControls( { onChange, query } ) {
 								value={ getExistingTaxQueryValue( slug ) }
 								suggestions={ terms.names }
 								onChange={ onTermsChange( slug ) }
+								__experimentalShowHowTo={ false }
 							/>
 						</div>
 					);


### PR DESCRIPTION
## What?
PR updates Query loop controls that use `FormTokenField` to hide "How To" instruction.

## Why?
These instructions are helpful when the component allows the creation of new tokens. But in the case of the Query Loop block controls, following the instruction does nothing.

## Testing Instructions
1. Open a Post or Page.
2. Insert Query Loop block.
3. Enable Taxonomies and Author filters.
4. Confirm that the instruction isn't displayed.

## Screenshots or screencast <!-- if applicable -->
| Before | After |
| --- | --- |
|![CleanShot 2022-10-03 at 14 53 33](https://user-images.githubusercontent.com/240569/193561174-2b481b0b-2da0-4e3d-94ac-4e3a515fa6ac.png)|![CleanShot 2022-10-03 at 14 49 14](https://user-images.githubusercontent.com/240569/193561194-b65f7bf3-9648-47d9-96ce-d3aac3b529d8.png)|
