### PR TITLE
[docs] Remove the package name from the sub-menu item for clarity.

### DIFF
--- a/docs/manifest.json
+++ b/docs/manifest.json
@@ -1482,7 +1482,7 @@
 		"parent": "packages"
 	},
 	{
-		"title": "@wordpress/create-block External Template",
+		"title": "External Project Templates",
 		"slug": "packages-create-block-external-template",
 		"markdown_source": "../packages/create-block/docs/external-template.md",
 		"parent": "packages-create-block"

--- a/packages/create-block/docs/toc.json
+++ b/packages/create-block/docs/toc.json
@@ -1,6 +1,6 @@
 [
 	{
-		"title": "@wordpress/create-block External Template",
+		"title": "External Project Templates",
 		"slug": "packages-create-block-external-template",
 		"markdown_source": "../packages/create-block/docs/external-template.md",
 		"parent": "packages-create-block"


### PR DESCRIPTION
## What?
The PR removes the package name from the sub-menu item for documentation for External Template creation in the `@wordpress/create-block` package. 

## Why?
The `@wordpress/create-block` prefix is unnecessary and removing it improves readabiility.
