### PR TITLE
Fix empty links being created for the author's name comment

### DIFF
--- a/packages/block-library/src/comment-author-name/index.php
+++ b/packages/block-library/src/comment-author-name/index.php
@@ -34,7 +34,7 @@ function render_block_core_comment_author_name( $attributes, $content, $block ) 
 	$comment_author     = get_comment_author( $comment );
 	$link               = get_comment_author_url( $comment );
 
-	if ( ! empty( $attributes['isLink'] ) && ! empty( $attributes['linkTarget'] ) ) {
+	if ( ! empty( $link ) && ! empty( $attributes['isLink'] ) && ! empty( $attributes['linkTarget'] ) ) {
 		$comment_author = sprintf( '<a rel="external nofollow ugc" href="%1s" target="%2s" >%3s</a>', esc_url( $link ), esc_attr( $attributes['linkTarget'] ), $comment_author );
 	}
 	if ( '0' === $comment->comment_approved && ! $show_pending_links ) {


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
It fixes issue #44648, which creates a link for the author's name, even if there's no URL provided in the comment posting form.

## Why?
Now the author's name is not displayed as a link.

## How?
Just by adding an empty check.

## Testing Instructions

1. Using Twenty Twenty-Three, add a comment to a post.
2. Enter a comment, a name, and an email but don't enter any website URL.
3. In your dashboard, approve the comment.
4. Visit the post on the frond-end to see your new comment.
