### PR TITLE
Block Editor: Fix block search for non-Latin characters

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -164,7 +164,6 @@ module.exports = {
 							'uniqWith',
 							'upperFirst',
 							'values',
-							'words',
 							'xor',
 							'zip',
 						],

--- a/package-lock.json
+++ b/package-lock.json
@@ -17355,7 +17355,6 @@
 				"@wordpress/url": "file:packages/url",
 				"@wordpress/warning": "file:packages/warning",
 				"@wordpress/wordcount": "file:packages/wordcount",
-				"change-case": "^4.1.2",
 				"classnames": "^2.3.1",
 				"colord": "^2.7.0",
 				"diff": "^4.0.2",

--- a/packages/block-editor/package.json
+++ b/packages/block-editor/package.json
@@ -59,7 +59,6 @@
 		"@wordpress/url": "file:../url",
 		"@wordpress/warning": "file:../warning",
 		"@wordpress/wordcount": "file:../wordcount",
-		"change-case": "^4.1.2",
 		"classnames": "^2.3.1",
 		"colord": "^2.7.0",
 		"diff": "^4.0.2",

--- a/packages/block-editor/src/components/inserter/search-items.js
+++ b/packages/block-editor/src/components/inserter/search-items.js
@@ -1,9 +1,8 @@
 /**
  * External dependencies
  */
-import { noCase } from 'change-case';
 import removeAccents from 'remove-accents';
-import { find } from 'lodash';
+import { find, words } from 'lodash';
 
 // Default search helpers.
 const defaultGetName = ( item ) => item.name || '';
@@ -37,17 +36,6 @@ function normalizeSearchInput( input = '' ) {
 }
 
 /**
- * Extracts words from an input string.
- *
- * @param {string} input The input string.
- *
- * @return {Array} Words, extracted from the input string.
- */
-function extractWords( input = '' ) {
-	return noCase( input ).split( ' ' ).filter( Boolean );
-}
-
-/**
  * Converts the search term into a list of normalized terms.
  *
  * @param {string} input The search term to normalize.
@@ -55,7 +43,7 @@ function extractWords( input = '' ) {
  * @return {string[]} The normalized list of search terms.
  */
 export const getNormalizedSearchTerms = ( input = '' ) => {
-	return extractWords( normalizeSearchInput( input ) );
+	return words( normalizeSearchInput( input ) );
 };
 
 const removeMatchingTerms = ( unmatchedTerms, unprocessedTerms ) => {
@@ -162,7 +150,7 @@ export function getItemSearchRank( item, searchTerm, config = {} ) {
 			category,
 			collection,
 		].join( ' ' );
-		const normalizedSearchTerms = extractWords( normalizedSearchInput );
+		const normalizedSearchTerms = words( normalizedSearchInput );
 		const unmatchedTerms = removeMatchingTerms(
 			normalizedSearchTerms,
 			terms

--- a/packages/block-editor/src/components/inserter/test/search-items.js
+++ b/packages/block-editor/src/components/inserter/test/search-items.js
@@ -42,6 +42,10 @@ describe( 'getNormalizedSearchTerms', () => {
 			getNormalizedSearchTerms( '  Média  &   Text Tag-Cloud > 123' )
 		).toEqual( [ 'media', 'text', 'tag', 'cloud', '123' ] );
 	} );
+
+	it( 'should support non-latin letters', () => {
+		expect( getNormalizedSearchTerms( 'მედია' ) ).toEqual( [ 'მედია' ] );
+	} );
 } );
 
 describe( 'getItemSearchRank', () => {


### PR DESCRIPTION
## What?
Fixes #44644.

I've restored the usage of `lodash.words` instead of `noCase`; the latter [only supports Latin characters](https://github.com/blakeembrey/change-case/issues/289).

We'll need to find a better alternative for `_.words`.

P.S. I've also added a test case for `getNormalizedSearchTerms` to avoid regressions.

## Testing Instructions
1. Switch the site language to one that uses non-Latin characters - Chinese, Cyrillic, Greek, Georgian, etc.
2. Open a Post or Page.
3. Open the block inserter.
4. Type the block name in that language.
5. Confirm that block search works.

_I tested with Georgian (`ქართული`). The testing terms were Media (`მედია`) and List (`სია`)._


## Screencast

https://user-images.githubusercontent.com/240569/193654453-b6a0e85b-a8e7-48ef-8bd7-2460a7704792.mp4


