### PR TITLE
Layout: backport code quality changes from core to Gutenberg

### DIFF
--- a/lib/block-supports/layout.php
+++ b/lib/block-supports/layout.php
@@ -373,6 +373,7 @@ function gutenberg_render_layout_support_flag( $block_content, $block ) {
 	if ( ! current_theme_supports( 'disable-layout-styles' ) ) {
 
 		$gap_value = _wp_array_get( $block, array( 'attrs', 'style', 'spacing', 'blockGap' ) );
+
 		/*
 		 * Skip if gap value contains unsupported characters.
 		 * Regex for CSS value borrowed from `safecss_filter_attr`, and used here

--- a/lib/block-supports/layout.php
+++ b/lib/block-supports/layout.php
@@ -28,19 +28,20 @@ function gutenberg_register_layout_support( $block_type ) {
 /**
  * Generates the CSS corresponding to the provided layout.
  *
- * @param string  $selector                      CSS selector.
- * @param array   $layout                        Layout object. The one that is passed has already checked the existence of default block layout.
- * @param boolean $has_block_gap_support         Whether the theme has support for the block gap.
- * @param string  $gap_value                     The block gap value to apply.
- * @param boolean $should_skip_gap_serialization Whether to skip applying the user-defined value set in the editor.
- * @param string  $fallback_gap_value            The block gap value to apply.
- * @param array   $block_spacing                 Custom spacing set on the block.
- *
- * @return string                                CSS style.
+ * @param string               $selector                      CSS selector.
+ * @param array                $layout                        Layout object. The one that is passed has already checked
+ *                                                            the existence of default block layout.
+ * @param bool                 $has_block_gap_support         Optional. Whether the theme has support for the block gap. Default false.
+ * @param string|string[]|null $gap_value                     Optional. The block gap value to apply. Default null.
+ * @param bool                 $should_skip_gap_serialization Optional. Whether to skip applying the user-defined value set in the editor. Default false.
+ * @param string               $fallback_gap_value            Optional. The block gap value to apply. Default '0.5em'.
+ * @param array|null           $block_spacing                 Optional. Custom spacing set on the block. Default null.
+ * @return string CSS styles on success. Else, empty string.
  */
 function gutenberg_get_layout_style( $selector, $layout, $has_block_gap_support = false, $gap_value = null, $should_skip_gap_serialization = false, $fallback_gap_value = '0.5em', $block_spacing = null ) {
 	$layout_type   = isset( $layout['type'] ) ? $layout['type'] : 'default';
 	$layout_styles = array();
+
 	if ( 'default' === $layout_type ) {
 		if ( $has_block_gap_support ) {
 			if ( is_array( $gap_value ) ) {
@@ -117,8 +118,10 @@ function gutenberg_get_layout_style( $selector, $layout, $has_block_gap_support 
 					)
 				);
 
-				// Handle negative margins for alignfull children of blocks with custom padding set.
-				// They're added separately because padding might only be set on one side.
+				/*
+				 * Handle negative margins for alignfull children of blocks with custom padding set.
+				 * They're added separately because padding might only be set on one side.
+				 */
 				if ( isset( $block_spacing_values['declarations']['padding-right'] ) ) {
 					$padding_right   = $block_spacing_values['declarations']['padding-right'];
 					$layout_styles[] = array(
@@ -232,7 +235,7 @@ function gutenberg_get_layout_style( $selector, $layout, $has_block_gap_support 
 		}
 
 		if ( 'horizontal' === $layout_orientation ) {
-			/**
+			/*
 			 * Add this style only if is not empty for backwards compatibility,
 			 * since we intend to convert blocks that had flex layout implemented
 			 * by custom css.
@@ -270,13 +273,17 @@ function gutenberg_get_layout_style( $selector, $layout, $has_block_gap_support 
 	}
 
 	if ( ! empty( $layout_styles ) ) {
-		// Add to the style engine store to enqueue and render layout styles.
-		// Return compiled layout styles to retain backwards compatibility.
-		// Since https://github.com/WordPress/gutenberg/pull/42452 we no longer call wp_enqueue_block_support_styles in this block supports file.
+		/*
+		 * Add to the style engine store to enqueue and render layout styles.
+		 * Return compiled layout styles to retain backwards compatibility.
+		 * Since https://github.com/WordPress/gutenberg/pull/42452,
+		 * wp_enqueue_block_support_styles is no longer called in this block supports file.
+		 */
 		return gutenberg_style_engine_get_stylesheet_from_css_rules(
 			$layout_styles,
 			array(
-				'context' => 'block-supports',
+				'context'  => 'block-supports',
+				'prettify' => false,
 			)
 		);
 	}
@@ -330,10 +337,12 @@ function gutenberg_render_layout_support_flag( $block_content, $block ) {
 		$class_names[] = 'has-global-padding';
 	}
 
-	// The following section was added to reintroduce a small set of layout classnames that were
-	// removed in the 5.9 release (https://github.com/WordPress/gutenberg/issues/38719). It is
-	// not intended to provide an extended set of classes to match all block layout attributes
-	// here.
+	/*
+	 * The following section was added to reintroduce a small set of layout classnames that were
+	 * removed in the 5.9 release (https://github.com/WordPress/gutenberg/issues/38719). It is
+	 * not intended to provide an extended set of classes to match all block layout attributes
+	 * here.
+	 */
 	if ( ! empty( $block['attrs']['layout']['orientation'] ) ) {
 		$class_names[] = 'is-' . sanitize_title( $block['attrs']['layout']['orientation'] );
 	}
@@ -357,14 +366,18 @@ function gutenberg_render_layout_support_flag( $block_content, $block ) {
 		$class_names[] = sanitize_title( $layout_classname );
 	}
 
-	// Only generate Layout styles if the theme has not opted-out.
-	// Attribute-based Layout classnames are output in all cases.
+	/*
+	 * Only generate Layout styles if the theme has not opted-out.
+	 * Attribute-based Layout classnames are output in all cases.
+	 */
 	if ( ! current_theme_supports( 'disable-layout-styles' ) ) {
 
 		$gap_value = _wp_array_get( $block, array( 'attrs', 'style', 'spacing', 'blockGap' ) );
-		// Skip if gap value contains unsupported characters.
-		// Regex for CSS value borrowed from `safecss_filter_attr`, and used here
-		// because we only want to match against the value, not the CSS attribute.
+		/*
+		 * Skip if gap value contains unsupported characters.
+		 * Regex for CSS value borrowed from `safecss_filter_attr`, and used here
+		 * to only match against the value, not the CSS attribute.
+		 */
 		if ( is_array( $gap_value ) ) {
 			foreach ( $gap_value as $key => $value ) {
 				$gap_value[ $key ] = $value && preg_match( '%[\\\(&=}]|/\*%', $value ) ? null : $value;
@@ -376,10 +389,21 @@ function gutenberg_render_layout_support_flag( $block_content, $block ) {
 		$fallback_gap_value = _wp_array_get( $block_type->supports, array( 'spacing', 'blockGap', '__experimentalDefault' ), '0.5em' );
 		$block_spacing      = _wp_array_get( $block, array( 'attrs', 'style', 'spacing' ), null );
 
-		// If a block's block.json skips serialization for spacing or spacing.blockGap,
-		// don't apply the user-defined value to the styles.
+		/*
+		 * If a block's block.json skips serialization for spacing or spacing.blockGap,
+		 * don't apply the user-defined value to the styles.
+		 */
 		$should_skip_gap_serialization = gutenberg_should_skip_block_supports_serialization( $block_type, 'spacing', 'blockGap' );
-		$style                         = gutenberg_get_layout_style( ".$block_classname.$container_class", $used_layout, $has_block_gap_support, $gap_value, $should_skip_gap_serialization, $fallback_gap_value, $block_spacing );
+
+		$style = gutenberg_get_layout_style(
+			".$block_classname.$container_class",
+			$used_layout,
+			$has_block_gap_support,
+			$gap_value,
+			$should_skip_gap_serialization,
+			$fallback_gap_value,
+			$block_spacing
+		);
 
 		// Only add container class and enqueue block support styles if unique styles were generated.
 		if ( ! empty( $style ) ) {
@@ -387,8 +411,10 @@ function gutenberg_render_layout_support_flag( $block_content, $block ) {
 		}
 	}
 
-	// This assumes the hook only applies to blocks with a single wrapper.
-	// I think this is a reasonable limitation for that particular hook.
+	/*
+	 * This assumes the hook only applies to blocks with a single wrapper.
+	 * A limitation of this hook is that nested inner blocks wrappers are not yet supported.
+	 */
 	$content = preg_replace(
 		'/' . preg_quote( 'class="', '/' ) . '/',
 		'class="' . esc_attr( implode( ' ', $class_names ) ) . ' ',

--- a/phpunit/block-supports/layout-test.php
+++ b/phpunit/block-supports/layout-test.php
@@ -103,6 +103,16 @@ class WP_Block_Supports_Layout_Test extends WP_UnitTestCase {
 		$this->assertSame( $expected, gutenberg_restore_image_outer_container( $block_content, $block ) );
 	}
 
+	const ARGS_DEFAULTS = array(
+		'selector'                      => null,
+		'layout'                        => null,
+		'has_block_gap_support'         => false,
+		'gap_value'                     => null,
+		'should_skip_gap_serialization' => false,
+		'fallback_gap_value'            => '0.5em',
+		'block_spacing'                 => null,
+	);
+
 	/**
 	 * Generates the CSS corresponding to the provided layout.
 	 *
@@ -110,21 +120,21 @@ class WP_Block_Supports_Layout_Test extends WP_UnitTestCase {
 	 *
 	 * @covers ::gutenberg_get_layout_style
 	 *
-	 * @param array  $args {
-	 *       Arguments for the test function.
-	 *
-	 *      @type string  $selector                      CSS selector.
-	 *      @type array   $layout                        Layout object. The one that is passed has already checked the existence of default block layout.
-	 *      @type boolean $has_block_gap_support         Whether the theme has support for the block gap.
-	 *      @type string  $gap_value                     The block gap value to apply.
-	 *      @type boolean $should_skip_gap_serialization Whether to skip applying the user-defined value set in the editor.
-	 *      @type string  $fallback_gap_value            The block gap value to apply.
-	 *      @type array   $block_spacing                 Custom spacing set on the block.
-	 * }
+	 * @param array  $args            Dataset to test.
 	 * @param string $expected_output The expected output.
 	 */
 	public function test_gutenberg_get_layout_style( $args, $expected_output ) {
-		$layout_styles = gutenberg_get_layout_style( $args['selector'], $args['layout'], $args['has_block_gap_support'], $args['gap_value'], $args['should_skip_gap_serialization'], $args['fallback_gap_value'], $args['block_spacing'] );
+		$args          = array_merge( static::ARGS_DEFAULTS, $args );
+		$layout_styles = gutenberg_get_layout_style(
+			$args['selector'],
+			$args['layout'],
+			$args['has_block_gap_support'],
+			$args['gap_value'],
+			$args['should_skip_gap_serialization'],
+			$args['fallback_gap_value'],
+			$args['block_spacing']
+		);
+
 		$this->assertSame( $expected_output, $layout_styles );
 	}
 
@@ -135,7 +145,11 @@ class WP_Block_Supports_Layout_Test extends WP_UnitTestCase {
 	 */
 	public function data_gutenberg_get_layout_style() {
 		return array(
-			'should_return_empty_value_with_no_args'       => array(
+			'no args should return empty value'            => array(
+				'args'            => array(),
+				'expected_output' => '',
+			),
+			'nulled args should return empty value'        => array(
 				'args'            => array(
 					'selector'                      => null,
 					'layout'                        => null,
@@ -147,83 +161,57 @@ class WP_Block_Supports_Layout_Test extends WP_UnitTestCase {
 				),
 				'expected_output' => '',
 			),
-			'should_return_empty_value_with_only_selector' => array(
+			'only selector should return empty value'      => array(
 				'args'            => array(
-					'selector'                      => '.wp-layout',
-					'layout'                        => null,
-					'has_block_gap_support'         => null,
-					'gap_value'                     => null,
-					'should_skip_gap_serialization' => null,
-					'fallback_gap_value'            => null,
-					'block_spacing'                 => null,
+					'selector' => '.wp-layout',
 				),
 				'expected_output' => '',
 			),
-			'should_return_default_layout_with_block_gap_support' => array(
+			'default layout and block gap support'         => array(
 				'args'            => array(
-					'selector'                      => '.wp-layout',
-					'layout'                        => null,
-					'has_block_gap_support'         => true,
-					'gap_value'                     => '1em',
-					'should_skip_gap_serialization' => null,
-					'fallback_gap_value'            => null,
-					'block_spacing'                 => null,
+					'selector'              => '.wp-layout',
+					'has_block_gap_support' => true,
+					'gap_value'             => '1em',
 				),
 				'expected_output' => '.wp-layout > *{margin-block-start:0;margin-block-end:0;}.wp-layout.wp-layout > * + *{margin-block-start:1em;margin-block-end:0;}',
 			),
-			'should_return_empty_value_with_block_gap_support_and_skip_serialization' => array(
+			'skip serialization should return empty value' => array(
 				'args'            => array(
 					'selector'                      => '.wp-layout',
-					'layout'                        => null,
 					'has_block_gap_support'         => true,
 					'gap_value'                     => '1em',
 					'should_skip_gap_serialization' => true,
-					'fallback_gap_value'            => null,
-					'block_spacing'                 => null,
 				),
 				'expected_output' => '',
 			),
-			'should_return_default_layout_with_axial_block_gap_support' => array(
+			'default layout and axial block gap support'   => array(
 				'args'            => array(
-					'selector'                      => '.wp-layout',
-					'layout'                        => null,
-					'has_block_gap_support'         => true,
-					'gap_value'                     => array( 'top' => '1em' ),
-					'should_skip_gap_serialization' => null,
-					'fallback_gap_value'            => null,
-					'block_spacing'                 => null,
+					'selector'              => '.wp-layout',
+					'has_block_gap_support' => true,
+					'gap_value'             => array( 'top' => '1em' ),
 				),
 				'expected_output' => '.wp-layout > *{margin-block-start:0;margin-block-end:0;}.wp-layout.wp-layout > * + *{margin-block-start:1em;margin-block-end:0;}',
 			),
-			'should_return_constrained_layout_with_sizes'  => array(
+			'constrained layout with sizes'                => array(
 				'args'            => array(
-					'selector'                      => '.wp-layout',
-					'layout'                        => array(
+					'selector' => '.wp-layout',
+					'layout'   => array(
 						'type'        => 'constrained',
 						'contentSize' => '800px',
 						'wideSize'    => '1200px',
 					),
-					'has_block_gap_support'         => null,
-					'gap_value'                     => null,
-					'should_skip_gap_serialization' => null,
-					'fallback_gap_value'            => null,
-					'block_spacing'                 => null,
 				),
 				'expected_output' => '.wp-layout > :where(:not(.alignleft):not(.alignright):not(.alignfull)){max-width:800px;margin-left:auto !important;margin-right:auto !important;}.wp-layout > .alignwide{max-width:1200px;}.wp-layout .alignfull{max-width:none;}',
 			),
-			'should_return_constrained_layout_with_sizes_and_block_spacing' => array(
+			'constrained layout with sizes and block spacing' => array(
 				'args'            => array(
-					'selector'                      => '.wp-layout',
-					'layout'                        => array(
+					'selector'      => '.wp-layout',
+					'layout'        => array(
 						'type'        => 'constrained',
 						'contentSize' => '800px',
 						'wideSize'    => '1200px',
 					),
-					'has_block_gap_support'         => null,
-					'gap_value'                     => null,
-					'should_skip_gap_serialization' => null,
-					'fallback_gap_value'            => null,
-					'block_spacing'                 => array(
+					'block_spacing' => array(
 						'padding' => array(
 							'left'  => '20px',
 							'right' => '10px',
@@ -232,171 +220,148 @@ class WP_Block_Supports_Layout_Test extends WP_UnitTestCase {
 				),
 				'expected_output' => '.wp-layout > :where(:not(.alignleft):not(.alignright):not(.alignfull)){max-width:800px;margin-left:auto !important;margin-right:auto !important;}.wp-layout > .alignwide{max-width:1200px;}.wp-layout .alignfull{max-width:none;}.wp-layout > .alignfull{margin-right:calc(10px * -1);margin-left:calc(20px * -1);}',
 			),
-			'should_return_constrained_layout_with_block_gap_support' => array(
+			'constrained layout with block gap support'    => array(
 				'args'            => array(
-					'selector'                      => '.wp-layout',
-					'layout'                        => array(
+					'selector'              => '.wp-layout',
+					'layout'                => array(
 						'type' => 'constrained',
 					),
-					'has_block_gap_support'         => true,
-					'gap_value'                     => '2.5rem',
-					'should_skip_gap_serialization' => null,
-					'fallback_gap_value'            => null,
-					'block_spacing'                 => null,
+					'has_block_gap_support' => true,
+					'gap_value'             => '2.5rem',
 				),
 				'expected_output' => '.wp-layout > *{margin-block-start:0;margin-block-end:0;}.wp-layout.wp-layout > * + *{margin-block-start:2.5rem;margin-block-end:0;}',
 			),
-			'should_return_constrained_layout_with_axial_block_gap_support' => array(
+			'constrained layout with axial block gap support' => array(
 				'args'            => array(
-					'selector'                      => '.wp-layout',
-					'layout'                        => array(
+					'selector'              => '.wp-layout',
+					'layout'                => array(
 						'type' => 'constrained',
 					),
-					'has_block_gap_support'         => true,
-					'gap_value'                     => array( 'top' => '2.5rem' ),
-					'should_skip_gap_serialization' => null,
-					'fallback_gap_value'            => null,
-					'block_spacing'                 => null,
+					'has_block_gap_support' => true,
+					'gap_value'             => array( 'top' => '2.5rem' ),
 				),
 				'expected_output' => '.wp-layout > *{margin-block-start:0;margin-block-end:0;}.wp-layout.wp-layout > * + *{margin-block-start:2.5rem;margin-block-end:0;}',
 			),
-			'should_return_constrained_layout_with_block_gap_support_and_spacing' => array(
+			'constrained layout with block gap support and spacing preset' => array(
 				'args'            => array(
-					'selector'                      => '.wp-layout',
-					'layout'                        => array(
+					'selector'              => '.wp-layout',
+					'layout'                => array(
 						'type' => 'constrained',
 					),
-					'has_block_gap_support'         => true,
-					'gap_value'                     => 'var:preset|spacing|50',
-					'should_skip_gap_serialization' => null,
-					'fallback_gap_value'            => null,
-					'block_spacing'                 => null,
+					'has_block_gap_support' => true,
+					'gap_value'             => 'var:preset|spacing|50',
 				),
 				'expected_output' => '.wp-layout > *{margin-block-start:0;margin-block-end:0;}.wp-layout.wp-layout > * + *{margin-block-start:var(--wp--preset--spacing--50);margin-block-end:0;}',
 			),
-			'should_return_empty_value_for_flex_layout_with_no_args' => array(
+			'flex layout with no args should return empty value' => array(
 				'args'            => array(
-					'selector'                      => '.wp-layout',
-					'layout'                        => array(
+					'selector' => '.wp-layout',
+					'layout'   => array(
 						'type' => 'flex',
 					),
-					'has_block_gap_support'         => null,
-					'gap_value'                     => null,
-					'should_skip_gap_serialization' => null,
-					'fallback_gap_value'            => null,
-					'block_spacing'                 => null,
 				),
 				'expected_output' => '',
 			),
-			'should_return_empty_value_for_horizontal_flex_layout_with_orientation_only' => array(
+			'horizontal flex layout should return empty value' => array(
 				'args'            => array(
-					'selector'                      => '.wp-layout',
-					'layout'                        => array(
+					'selector' => '.wp-layout',
+					'layout'   => array(
 						'type'        => 'flex',
 						'orientation' => 'horizontal',
 					),
-					'has_block_gap_support'         => null,
-					'gap_value'                     => null,
-					'should_skip_gap_serialization' => null,
-					'fallback_gap_value'            => null,
-					'block_spacing'                 => null,
 				),
 				'expected_output' => '',
 			),
-			'should_return_rule_horizontal_flex_layout_with_flex_properties' => array(
+			'flex layout with properties'                  => array(
 				'args'            => array(
-					'selector'                      => '.wp-layout',
-					'layout'                        => array(
+					'selector' => '.wp-layout',
+					'layout'   => array(
 						'type'              => 'flex',
 						'orientation'       => 'horizontal',
 						'flexWrap'          => 'nowrap',
 						'justifyContent'    => 'left',
 						'verticalAlignment' => 'bottom',
 					),
-					'has_block_gap_support'         => null,
-					'gap_value'                     => null,
-					'should_skip_gap_serialization' => null,
-					'fallback_gap_value'            => null,
-					'block_spacing'                 => null,
 				),
 				'expected_output' => '.wp-layout{flex-wrap:nowrap;justify-content:flex-start;align-items:flex-end;}',
 			),
-			'should_return_rule_for_horizontal_flex_layout_with_flex_properties_and_gap' => array(
+			'flex layout with properties and block gap'    => array(
 				'args'            => array(
-					'selector'                      => '.wp-layout',
-					'layout'                        => array(
+					'selector'              => '.wp-layout',
+					'layout'                => array(
 						'type'              => 'flex',
 						'orientation'       => 'horizontal',
 						'flexWrap'          => 'nowrap',
 						'justifyContent'    => 'left',
 						'verticalAlignment' => 'bottom',
 					),
-					'has_block_gap_support'         => true,
-					'gap_value'                     => '29px',
-					'should_skip_gap_serialization' => null,
-					'fallback_gap_value'            => null,
-					'block_spacing'                 => null,
+					'has_block_gap_support' => true,
+					'gap_value'             => '29px',
 				),
 				'expected_output' => '.wp-layout{flex-wrap:nowrap;gap:29px;justify-content:flex-start;align-items:flex-end;}',
 			),
-			'should_return_rule_for_horizontal_flex_layout_with_flex_properties_and_axial_gap' => array(
+			'flex layout with properties and axial block gap' => array(
 				'args'            => array(
-					'selector'                      => '.wp-layout',
-					'layout'                        => array(
+					'selector'              => '.wp-layout',
+					'layout'                => array(
 						'type'              => 'flex',
 						'orientation'       => 'horizontal',
 						'flexWrap'          => 'nowrap',
 						'justifyContent'    => 'left',
 						'verticalAlignment' => 'bottom',
 					),
-					'has_block_gap_support'         => true,
-					'gap_value'                     => array(
+					'has_block_gap_support' => true,
+					'gap_value'             => array(
 						'top'  => '1px',
 						'left' => '2px',
 					),
-					'should_skip_gap_serialization' => null,
-					'fallback_gap_value'            => null,
-					'block_spacing'                 => null,
 				),
 				'expected_output' => '.wp-layout{flex-wrap:nowrap;gap:1px 2px;justify-content:flex-start;align-items:flex-end;}',
 			),
-			'should_return_rule_for_horizontal_flex_layout_with_flex_properties_gap_fallback_and_spacing' => array(
+			'flex layout with properties and axial block gap using spacing preset' => array(
 				'args'            => array(
-					'selector'                      => '.wp-layout',
-					'layout'                        => array(
+					'selector'              => '.wp-layout',
+					'layout'                => array(
 						'type'              => 'flex',
 						'orientation'       => 'horizontal',
 						'flexWrap'          => 'nowrap',
 						'justifyContent'    => 'left',
 						'verticalAlignment' => 'bottom',
 					),
-					'has_block_gap_support'         => true,
-					'gap_value'                     => array(
+					'has_block_gap_support' => true,
+					'gap_value'             => array(
 						'left' => 'var:preset|spacing|40',
 					),
-					'should_skip_gap_serialization' => null,
-					'fallback_gap_value'            => '11px',
-					'block_spacing'                 => null,
+					'fallback_gap_value'    => '11px',
 				),
 				'expected_output' => '.wp-layout{flex-wrap:nowrap;gap:11px var(--wp--preset--spacing--40);justify-content:flex-start;align-items:flex-end;}',
 			),
-			'should_return_rule_for_vertical_flex_layout_with_flex_properties' => array(
+			'vertical flex layout with properties'         => array(
 				'args'            => array(
-					'selector'                      => '.wp-layout',
-					'layout'                        => array(
+					'selector' => '.wp-layout',
+					'layout'   => array(
 						'type'              => 'flex',
 						'orientation'       => 'vertical',
 						'flexWrap'          => 'nowrap',
 						'justifyContent'    => 'left',
 						'verticalAlignment' => 'bottom',
 					),
-					'has_block_gap_support'         => null,
-					'gap_value'                     => null,
-					'should_skip_gap_serialization' => null,
-					'fallback_gap_value'            => null,
-					'block_spacing'                 => null,
 				),
 				'expected_output' => '.wp-layout{flex-wrap:nowrap;flex-direction:column;align-items:flex-start;}',
+			),
+			'default layout with blockGap to verify converting gap value into valid CSS' => array(
+				'args'            => array(
+					'selector'              => '.wp-block-group.wp-container-6',
+					'layout'                => array(
+						'type' => 'default',
+					),
+					'has_block_gap_support' => true,
+					'gap_value'             => 'var:preset|spacing|70',
+					'block_spacing'         => array(
+						'blockGap' => 'var(--wp--preset--spacing--70)',
+					),
+				),
+				'expected_output' => '.wp-block-group.wp-container-6 > *{margin-block-start:0;margin-block-end:0;}.wp-block-group.wp-container-6.wp-block-group.wp-container-6 > * + *{margin-block-start:var(--wp--preset--spacing--70);margin-block-end:0;}',
 			),
 		);
 	}


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

When https://github.com/WordPress/wordpress-develop/pull/3254 was merged into core, it involved a couple of tweaks to documenting, readability improvements, and renaming of some tests. This PR ports those changes back to the Gutenberg plugin.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
As the `layout.php` file in Gutenberg is evergreen, it's good to try to ensure as much consistency as possible between core and the Gutenberg file.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
Copy + paste changes from core's `layout.php` and ensure that we keep the `gutenberg_` prefixed versions of changes in the Gutenberg plugin.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->

Check that PHP tests pass.
Smoke test that layout still works correctly (e.g. try out a range of Group, Buttons, and Social Icons blocks in a post, ensure rendering is the same as on trunk)