### PR TITLE
Icons: Fix arrow icons being misaligned.

### DIFF
--- a/packages/icons/src/library/arrow-down.js
+++ b/packages/icons/src/library/arrow-down.js
@@ -5,7 +5,7 @@ import { SVG, Path } from '@wordpress/primitives';
 
 const arrowDown = (
 	<SVG xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24">
-		<Path d="M16.2 13.2l-4 4V4h-1.5v13.3l-4.5-4.1-1 1.1 6.2 5.8 5.8-5.8-1-1.1z" />
+		<Path d="m16.5 13.5-3.7 3.7V4h-1.5v13.2l-3.8-3.7-1 1 5.5 5.6 5.5-5.6z" />
 	</SVG>
 );
 

--- a/packages/icons/src/library/arrow-left.js
+++ b/packages/icons/src/library/arrow-left.js
@@ -5,7 +5,7 @@ import { SVG, Path } from '@wordpress/primitives';
 
 const arrowLeft = (
 	<SVG xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24">
-		<Path d="M20 10.8H6.7l4.1-4.5-1.1-1.1-5.8 6.3 5.8 5.8 1.1-1.1-4-3.9H20z" />
+		<Path d="M20 11.2H6.8l3.7-3.7-1-1L3.9 12l5.6 5.5 1-1-3.7-3.7H20z" />
 	</SVG>
 );
 

--- a/packages/icons/src/library/arrow-right.js
+++ b/packages/icons/src/library/arrow-right.js
@@ -5,7 +5,7 @@ import { SVG, Path } from '@wordpress/primitives';
 
 const arrowRight = (
 	<SVG xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24">
-		<Path d="M14.3 6.7l-1.1 1.1 4 4H4v1.5h13.3l-4.1 4.4 1.1 1.1 5.8-6.3z" />
+		<Path d="m14.5 6.5-1 1 3.7 3.7H4v1.6h13.2l-3.7 3.7 1 1 5.6-5.5z" />
 	</SVG>
 );
 

--- a/packages/icons/src/library/arrow-up.js
+++ b/packages/icons/src/library/arrow-up.js
@@ -5,7 +5,7 @@ import { SVG, Path } from '@wordpress/primitives';
 
 const arrowUp = (
 	<SVG xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24">
-		<Path d="M12.5 3.9L6.7 9.7l1.1 1.1 4-4V20h1.4V6.7l4.5 4.1 1.1-1.1z" />
+		<Path d="M12 3.9 6.5 9.5l1 1 3.8-3.7V20h1.5V6.8l3.7 3.7 1-1z" />
 	</SVG>
 );
 


### PR DESCRIPTION
## What?

Arrow icons are misaligned:

<img width="764" alt="image" src="https://user-images.githubusercontent.com/1204802/193794988-f205c64e-3c8e-4fd9-9534-5772d66b8858.png">

This PR fixes it:

<img width="601" alt="Screenshot 2022-10-04 at 12 13 37" src="https://user-images.githubusercontent.com/1204802/193795128-300fcdc6-0ced-433d-aad3-a44bdcf5b54a.png">

## Testing Instructions

Compile the branch, then run storybook: `npm run storybook:dev` and test the icon library, verify the arrow-left|right|up|down icons look right.