### PR TITLE
Edit Post: Refactor `PluginPostPublishPanel` tests to use RTL render

### DIFF
--- a/packages/edit-post/src/components/sidebar/plugin-post-publish-panel/test/__snapshots__/index.js.snap
+++ b/packages/edit-post/src/components/sidebar/plugin-post-publish-panel/test/__snapshots__/index.js.snap
@@ -1,3 +1,39 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`PluginPostPublishPanel renders fill properly 1`] = `"<div class=\\"components-panel__body my-plugin-post-publish-panel is-opened\\"><h2 class=\\"components-panel__body-title\\"><button type=\\"button\\" aria-expanded=\\"true\\" class=\\"components-button components-panel__body-toggle\\"><span aria-hidden=\\"true\\"><svg viewBox=\\"0 0 24 24\\" xmlns=\\"http://www.w3.org/2000/svg\\" width=\\"24\\" height=\\"24\\" class=\\"components-panel__arrow\\" aria-hidden=\\"true\\" focusable=\\"false\\"><path d=\\"M6.5 12.4L12 8l5.5 4.4-.9 1.2L12 10l-4.5 3.6-1-1.2z\\"></path></svg></span>My panel title</button></h2>My panel content</div>"`;
+exports[`PluginPostPublishPanel renders fill properly 1`] = `
+<div>
+  <div
+    class="components-panel__body my-plugin-post-publish-panel is-opened"
+  >
+    <h2
+      class="components-panel__body-title"
+    >
+      <button
+        aria-expanded="true"
+        class="components-button components-panel__body-toggle"
+        type="button"
+      >
+        <span
+          aria-hidden="true"
+        >
+          <svg
+            aria-hidden="true"
+            class="components-panel__arrow"
+            focusable="false"
+            height="24"
+            viewBox="0 0 24 24"
+            width="24"
+            xmlns="http://www.w3.org/2000/svg"
+          >
+            <path
+              d="M6.5 12.4L12 8l5.5 4.4-.9 1.2L12 10l-4.5 3.6-1-1.2z"
+            />
+          </svg>
+        </span>
+        My panel title
+      </button>
+    </h2>
+    My panel content
+  </div>
+</div>
+`;

--- a/packages/edit-post/src/components/sidebar/plugin-post-publish-panel/test/index.js
+++ b/packages/edit-post/src/components/sidebar/plugin-post-publish-panel/test/index.js
@@ -1,8 +1,12 @@
 /**
+ * External dependencies
+ */
+import { render } from '@testing-library/react';
+
+/**
  * WordPress dependencies
  */
 import { SlotFillProvider } from '@wordpress/components';
-import { render } from '@wordpress/element';
 
 /**
  * Internal dependencies
@@ -11,8 +15,7 @@ import PluginPostPublishPanel from '../';
 
 describe( 'PluginPostPublishPanel', () => {
 	test( 'renders fill properly', () => {
-		const div = document.createElement( 'div' );
-		render(
+		const { container } = render(
 			<SlotFillProvider>
 				<PluginPostPublishPanel
 					className="my-plugin-post-publish-panel"
@@ -22,10 +25,9 @@ describe( 'PluginPostPublishPanel', () => {
 					My panel content
 				</PluginPostPublishPanel>
 				<PluginPostPublishPanel.Slot />
-			</SlotFillProvider>,
-			div
+			</SlotFillProvider>
 		);
 
-		expect( div.innerHTML ).toMatchSnapshot();
+		expect( container ).toMatchSnapshot();
 	} );
 } );


### PR DESCRIPTION
## What?
This PR refactors the tests of `PluginPostPublishPanel` to use `@testing-library/react`'s render instead of `react-dom` render. This addresses one of the changes needed to upgrade to React 18, as touched in #32765.

## Why?
This addresses one of the changes needed to upgrade to React 18, as touched in #32765.

## How?
We're just using the `@testing-library/react` render method and updating the snapshot, which mostly contains whitespace changes.

## Testing Instructions
Verify tests still pass: `npm run test:unit packages/edit-post/src/components/sidebar/plugin-post-publish-panel/test/index.js`