### PR TITLE
Components: Try color theming

### DIFF
--- a/docs/manifest.json
+++ b/docs/manifest.json
@@ -1230,6 +1230,12 @@
 		"parent": "components"
 	},
 	{
+		"title": "Theme",
+		"slug": "theme",
+		"markdown_source": "../packages/components/src/theme/README.md",
+		"parent": "components"
+	},
+	{
 		"title": "ToggleControl",
 		"slug": "toggle-control",
 		"markdown_source": "../packages/components/src/toggle-control/README.md",

--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -31,6 +31,10 @@
 -   `FontSizePicker`: Convert to TypeScript ([#44449](https://github.com/WordPress/gutenberg/pull/44449)).
 -   `FontSizePicker`: Replace SCSS with Emotion + components ([#44483](https://github.com/WordPress/gutenberg/pull/44483)).
 
+### Experimental
+
+-   Add experimental `Theme` component ([#44668](https://github.com/WordPress/gutenberg/pull/44668)).
+
 ## 21.1.0 (2022-09-21)
 
 ### Deprecations

--- a/packages/components/CONTRIBUTING.md
+++ b/packages/components/CONTRIBUTING.md
@@ -185,6 +185,26 @@ All new component should be styled using [Emotion](https://emotion.sh/docs/intro
 
 Note: Instead of using Emotion's standard `cx` function, the custom [`useCx` hook](/packages/components/src/utils/hooks/use-cx.ts) should be used instead.
 
+### Themeing
+
+_Note: Themeing is an experimental feature and still being actively developed. Its APIs are an early implementation subject to drastic and breaking changes_
+
+The [`Theme` component](/packages/components/src/theme/README.md) can be used to tweak the visual appearance of the components from the `@wordpress/components` package.
+
+```jsx
+import { __experimentalTheme as Theme } from '@wordpress/components';
+
+const Example = () => {
+	return (
+		<Theme accent="red">
+			<Button variant="primary">I'm red</Button>
+			<Theme accent="blue">
+				<Button variant="primary">I'm blue</Button>
+			</Theme>
+		</Theme>
+	);
+};
+```
 
 ### Deprecating styles
 

--- a/packages/components/src/button/style.scss
+++ b/packages/components/src/button/style.scss
@@ -52,13 +52,13 @@
 		outline: 1px solid transparent;
 
 		&:hover:not(:disabled) {
-			background: var(--wp-admin-theme-color-darker-10);
+			background: $components-color-accent-darker-10;
 			color: $white;
 		}
 
 		&:active:not(:disabled) {
-			background: var(--wp-admin-theme-color-darker-20);
-			border-color: var(--wp-admin-theme-color-darker-20);
+			background: $components-color-accent-darker-20;
+			border-color: $components-color-accent-darker-20;
 			color: $white;
 		}
 
@@ -94,8 +94,8 @@
 			background-image: linear-gradient(
 				-45deg,
 				$components-color-accent 33%,
-				var(--wp-admin-theme-color-darker-20) 33%,
-				var(--wp-admin-theme-color-darker-20) 70%,
+				$components-color-accent-darker-20 33%,
+				$components-color-accent-darker-20 70%,
 				$components-color-accent 70%
 			);
 			/* stylelint-enable */
@@ -114,13 +114,13 @@
 
 		&:active:not(:disabled) {
 			background: $gray-300;
-			color: var(--wp-admin-theme-color-darker-10);
+			color: $components-color-accent-darker-10;
 			box-shadow: none;
 		}
 
 		&:hover:not(:disabled) {
-			color: var(--wp-admin-theme-color-darker-10);
-			box-shadow: inset 0 0 0 $border-width var(--wp-admin-theme-color-darker-10);
+			color: $components-color-accent-darker-10;
+			box-shadow: inset 0 0 0 $border-width $components-color-accent-darker-10;
 		}
 
 		&:disabled,

--- a/packages/components/src/button/style.scss
+++ b/packages/components/src/button/style.scss
@@ -20,7 +20,7 @@
 
 	&[aria-expanded="true"],
 	&:hover {
-		color: var(--wp-admin-theme-color);
+		color: $components-color-accent;
 	}
 
 	// Unset some hovers, instead of adding :not specificity.
@@ -31,7 +31,7 @@
 	// Focus.
 	// See https://github.com/WordPress/gutenberg/issues/13267 for more context on these selectors.
 	&:focus:not(:disabled) {
-		box-shadow: 0 0 0 var(--wp-admin-border-width-focus) var(--wp-admin-theme-color);
+		box-shadow: 0 0 0 var(--wp-admin-border-width-focus) $components-color-accent;
 
 		// Windows High Contrast mode will show this outline, but not the box-shadow.
 		outline: 3px solid transparent;
@@ -43,7 +43,7 @@
 
 	&.is-primary {
 		white-space: nowrap;
-		background: var(--wp-admin-theme-color);
+		background: $components-color-accent;
 		color: $white;
 		text-decoration: none;
 		text-shadow: none;
@@ -63,7 +63,7 @@
 		}
 
 		&:focus:not(:disabled) {
-			box-shadow: inset 0 0 0 1px $white, 0 0 0 var(--wp-admin-border-width-focus) var(--wp-admin-theme-color);
+			box-shadow: inset 0 0 0 1px $white, 0 0 0 var(--wp-admin-border-width-focus) $components-color-accent;
 		}
 
 		&:disabled,
@@ -72,15 +72,15 @@
 		&[aria-disabled="true"]:enabled, // This catches a situation where a Button is aria-disabled, but not disabled.
 		&[aria-disabled="true"]:active:enabled {
 			color: rgba($white, 0.4);
-			background: var(--wp-admin-theme-color);
-			border-color: var(--wp-admin-theme-color);
+			background: $components-color-accent;
+			border-color: $components-color-accent;
 			opacity: 1;
 			outline: none;
 
 			&:focus:enabled {
 				box-shadow:
 					0 0 0 $border-width $white,
-					0 0 0 3px var(--wp-admin-theme-color);
+					0 0 0 3px $components-color-accent;
 			}
 		}
 
@@ -93,13 +93,13 @@
 			/* stylelint-disable */
 			background-image: linear-gradient(
 				-45deg,
-				var(--wp-admin-theme-color) 33%,
+				$components-color-accent 33%,
 				var(--wp-admin-theme-color-darker-20) 33%,
 				var(--wp-admin-theme-color-darker-20) 70%,
-				var(--wp-admin-theme-color) 70%
+				$components-color-accent 70%
 			);
 			/* stylelint-enable */
-			border-color: var(--wp-admin-theme-color);
+			border-color: $components-color-accent;
 		}
 	}
 
@@ -140,10 +140,10 @@
 	 */
 
 	&.is-secondary {
-		box-shadow: inset 0 0 0 $border-width var(--wp-admin-theme-color);
+		box-shadow: inset 0 0 0 $border-width $components-color-accent;
 		outline: 1px solid transparent; // Shown in high contrast mode.
 		white-space: nowrap;
-		color: var(--wp-admin-theme-color);
+		color: $components-color-accent;
 		background: transparent;
 	}
 
@@ -153,7 +153,7 @@
 
 	&.is-tertiary {
 		white-space: nowrap;
-		color: var(--wp-admin-theme-color);
+		color: $components-color-accent;
 		background: transparent;
 		padding: $grid-unit-15 * 0.5; // This reduces the horizontal padding on tertiary/text buttons, so as to space them optically.
 
@@ -182,7 +182,7 @@
 		}
 
 		&:focus:not(:disabled) {
-			color: var(--wp-admin-theme-color);
+			color: $components-color-accent;
 		}
 
 		&:active:not(:disabled) {
@@ -230,7 +230,7 @@
 		background: none;
 		outline: none;
 		text-align: left;
-		color: var(--wp-admin-theme-color);
+		color: $components-color-accent;
 		text-decoration: underline;
 		transition-property: border, background, color;
 		transition-duration: 0.05s;
@@ -253,7 +253,7 @@
 			}
 
 			&:focus:not(:disabled) {
-				color: var(--wp-admin-theme-color);
+				color: $components-color-accent;
 			}
 		}
 	}
@@ -333,7 +333,7 @@
 		background: $gray-900;
 
 		&:focus:not(:disabled) {
-			box-shadow: inset 0 0 0 1px $white, 0 0 0 var(--wp-admin-border-width-focus) var(--wp-admin-theme-color);
+			box-shadow: inset 0 0 0 1px $white, 0 0 0 var(--wp-admin-border-width-focus) $components-color-accent;
 
 			// Windows High Contrast mode will show this outline, but not the box-shadow.
 			outline: 2px solid transparent;

--- a/packages/components/src/index.js
+++ b/packages/components/src/index.js
@@ -146,6 +146,7 @@ export { Text as __experimentalText } from './text';
 export { default as TextControl } from './text-control';
 export { default as TextareaControl } from './textarea-control';
 export { default as TextHighlight } from './text-highlight';
+export { default as __experimentalTheme } from './theme';
 export { default as Tip } from './tip';
 export { default as ToggleControl } from './toggle-control';
 export {

--- a/packages/components/src/style.scss
+++ b/packages/components/src/style.scss
@@ -1,4 +1,6 @@
-$components-color-accent: var(--wp-components-color-accent, --wp-admin-theme-color);
+$components-color-accent: var(--wp-components-color-accent, var(--wp-admin-theme-color, #007cba));
+$components-color-accent-darker-10: var(--wp-components-color-accent-darker-10, var(--wp-admin-theme-color-darker-10, #006ba1));
+$components-color-accent-darker-20: var(--wp-components-color-accent-darker-20, var(--wp-admin-theme-color-darker-20, #005a87));
 @import "./animate/style.scss";
 @import "./autocomplete/style.scss";
 @import "./button-group/style.scss";

--- a/packages/components/src/style.scss
+++ b/packages/components/src/style.scss
@@ -1,3 +1,4 @@
+$components-color-accent: var(--wp-components-color-accent, --wp-admin-theme-color);
 @import "./animate/style.scss";
 @import "./autocomplete/style.scss";
 @import "./button-group/style.scss";

--- a/packages/components/src/style.scss
+++ b/packages/components/src/style.scss
@@ -1,6 +1,7 @@
-$components-color-accent: var(--wp-components-color-accent, var(--wp-admin-theme-color, #007cba));
-$components-color-accent-darker-10: var(--wp-components-color-accent-darker-10, var(--wp-admin-theme-color-darker-10, #006ba1));
-$components-color-accent-darker-20: var(--wp-components-color-accent-darker-20, var(--wp-admin-theme-color-darker-20, #005a87));
+// Variables
+@import "./utils/theme-variables.scss";
+
+// Components
 @import "./animate/style.scss";
 @import "./autocomplete/style.scss";
 @import "./button-group/style.scss";

--- a/packages/components/src/theme/README.md
+++ b/packages/components/src/theme/README.md
@@ -6,7 +6,7 @@ This feature is still experimental. “Experimental” means this is an early im
 
 `Theme` allows defining theme variables for components in the `@wordpress/components` package.
 
-Multiple `Theme` components can be use and nested, in order to override specific theme variables.
+Multiple `Theme` components can be nested in order to override specific theme variables.
 
 ## Usage
 
@@ -29,6 +29,6 @@ const Example = () => {
 
 ### `accent`: `CSSProperties[ 'color' ]`
 
-The accent color, used as the primary color _(wording TBD)_. If an accent color is not defined, the default fallback value is the original WP Admin main theme color.
+Used to set the accent color (used by components as the primary color). If an accent color is not defined, the default fallback value is the original WP Admin main theme color.
 
 -   Required: No

--- a/packages/components/src/theme/README.md
+++ b/packages/components/src/theme/README.md
@@ -29,14 +29,6 @@ const Example = () => {
 
 ### `accent`: `string`
 
-Used to set the accent color (used by components as the primary color). If an accent color is not defined, the default fallback value is the original WP Admin main theme color.
-
-Note: this property only supports some of the multiple syntaxes used to specify a CSS color. In particular, these are the known _unsupported_ values:
-
-- the `'currentcolor'` keyword;
-- global keyworks (like `'-moz-initial'`, `'inherit'`, `'initial'`, `'revert'` and `'unset'`;
-- CSS custom properties (e.g. `var(--my-custom-property)`)
-
-
+Used to set the accent color (used by components as the primary color). If an accent color is not defined, the default fallback value is the original WP Admin main theme color. No all valid CSS color syntaxes are supported — in particular, keywords (like `'currentcolor'`, `'inherit'`, `'initial'`, `'revert'`, `'unset'`...) and CSS custom properties (e.g. `var(--my-custom-property)`) are _not_ supported values for this property.
 
 -   Required: No

--- a/packages/components/src/theme/README.md
+++ b/packages/components/src/theme/README.md
@@ -1,0 +1,34 @@
+# Theme
+
+<div class="callout callout-alert">
+This feature is still experimental. “Experimental” means this is an early implementation subject to drastic and breaking changes.
+</div>
+
+`Theme` allows defining theme variables for components in the `@wordpress/components` package.
+
+Multiple `Theme` components can be use and nested, in order to override specific theme variables.
+
+## Usage
+
+```jsx
+import { __experimentalTheme as Theme } from '@wordpress/components';
+
+const Example = () => {
+	return (
+		<Theme accent="red">
+			<Button variant="primary">I'm red</Button>
+			<Theme accent="blue">
+				<Button variant="primary">I'm blue</Button>
+			</Theme>
+		</Theme>
+	);
+};
+```
+
+## Props
+
+### `accent`: `CSSProperties[ 'color' ]`
+
+The accent color, used as the primary color _(wording TBD)_. If an accent color is not defined, the default fallback value is the original WP Admin main theme color.
+
+-   Required: No

--- a/packages/components/src/theme/README.md
+++ b/packages/components/src/theme/README.md
@@ -27,8 +27,16 @@ const Example = () => {
 
 ## Props
 
-### `accent`: `CSSProperties[ 'color' ]`
+### `accent`: `string`
 
 Used to set the accent color (used by components as the primary color). If an accent color is not defined, the default fallback value is the original WP Admin main theme color.
+
+Note: this property only supports some of the multiple syntaxes used to specify a CSS color. In particular, these are the known _unsupported_ values:
+
+- the `'currentcolor'` keyword;
+- global keyworks (like `'-moz-initial'`, `'inherit'`, `'initial'`, `'revert'` and `'unset'`;
+- CSS custom properties (e.g. `var(--my-custom-property)`)
+
+
 
 -   Required: No

--- a/packages/components/src/theme/index.tsx
+++ b/packages/components/src/theme/index.tsx
@@ -4,6 +4,7 @@
 import { css } from '@emotion/react';
 import styled from '@emotion/styled';
 import type { ReactNode } from 'react';
+import { colord } from 'colord';
 
 /**
  * Internal dependencies
@@ -19,6 +20,12 @@ const colors = ( { accent }: ThemeProps ) => {
 	const accentColor = accent
 		? css`
 				--wp-components-color-accent: ${ accent };
+				--wp-components-color-accent-darker-10: ${ colord( accent )
+					.darken( 0.1 )
+					.toHex() };
+				--wp-components-color-accent-darker-20: ${ colord( accent )
+					.darken( 0.2 )
+					.toHex() };
 		  `
 		: undefined;
 

--- a/packages/components/src/theme/index.tsx
+++ b/packages/components/src/theme/index.tsx
@@ -18,7 +18,7 @@ type ThemeProps = {
 const colors = ( { accent }: ThemeProps ) => {
 	const accentColor = accent
 		? css`
-				--wp-admin-theme-color: ${ accent };
+				--wp-components-color-accent: ${ accent };
 		  `
 		: undefined;
 

--- a/packages/components/src/theme/index.tsx
+++ b/packages/components/src/theme/index.tsx
@@ -1,0 +1,36 @@
+/**
+ * External dependencies
+ */
+import { css } from '@emotion/react';
+import styled from '@emotion/styled';
+import type { ReactNode } from 'react';
+
+/**
+ * Internal dependencies
+ */
+import type { WordPressComponentProps } from '../ui/context';
+
+type ThemeProps = {
+	accent?: string;
+	children?: ReactNode;
+};
+
+const colors = ( { accent }: ThemeProps ) => {
+	const accentColor = accent
+		? css`
+				--wp-admin-theme-color: ${ accent };
+		  `
+		: undefined;
+
+	return accentColor;
+};
+
+const Wrapper = styled.div`
+	${ colors }
+`;
+
+function Theme( props: WordPressComponentProps< ThemeProps, 'div', true > ) {
+	return <Wrapper { ...props } />;
+}
+
+export default Theme;

--- a/packages/components/src/theme/index.tsx
+++ b/packages/components/src/theme/index.tsx
@@ -1,11 +1,27 @@
 /**
+ * External dependencies
+ */
+import { colord, extend } from 'colord';
+import a11yPlugin from 'colord/plugins/a11y';
+import namesPlugin from 'colord/plugins/names';
+
+/**
  * Internal dependencies
  */
 import type { ThemeProps } from './types';
 import type { WordPressComponentProps } from '../ui/context';
 import { Wrapper } from './styles';
 
+extend( [ namesPlugin, a11yPlugin ] );
+
 function Theme( props: WordPressComponentProps< ThemeProps, 'div', true > ) {
+	const { accent } = props;
+	if ( accent && ! colord( accent ).isValid() ) {
+		console.warn(
+			`wp.components.Theme: "${ accent }" is not a valid color value for the 'accent' prop.`
+		);
+	}
+
 	return <Wrapper { ...props } />;
 }
 

--- a/packages/components/src/theme/index.tsx
+++ b/packages/components/src/theme/index.tsx
@@ -1,36 +1,9 @@
 /**
- * External dependencies
- */
-import { css } from '@emotion/react';
-import styled from '@emotion/styled';
-
-import { colord } from 'colord';
-
-/**
  * Internal dependencies
  */
 import type { ThemeProps } from './types';
 import type { WordPressComponentProps } from '../ui/context';
-
-const colors = ( { accent }: ThemeProps ) => {
-	const accentColor = accent
-		? css`
-				--wp-components-color-accent: ${ accent };
-				--wp-components-color-accent-darker-10: ${ colord( accent )
-					.darken( 0.1 )
-					.toHex() };
-				--wp-components-color-accent-darker-20: ${ colord( accent )
-					.darken( 0.2 )
-					.toHex() };
-		  `
-		: undefined;
-
-	return accentColor;
-};
-
-const Wrapper = styled.div`
-	${ colors }
-`;
+import { Wrapper } from './styles';
 
 function Theme( props: WordPressComponentProps< ThemeProps, 'div', true > ) {
 	return <Wrapper { ...props } />;

--- a/packages/components/src/theme/index.tsx
+++ b/packages/components/src/theme/index.tsx
@@ -17,6 +17,7 @@ extend( [ namesPlugin, a11yPlugin ] );
 function Theme( props: WordPressComponentProps< ThemeProps, 'div', true > ) {
 	const { accent } = props;
 	if ( accent && ! colord( accent ).isValid() ) {
+		// eslint-disable-next-line no-console
 		console.warn(
 			`wp.components.Theme: "${ accent }" is not a valid color value for the 'accent' prop.`
 		);

--- a/packages/components/src/theme/index.tsx
+++ b/packages/components/src/theme/index.tsx
@@ -14,6 +14,28 @@ import { Wrapper } from './styles';
 
 extend( [ namesPlugin, a11yPlugin ] );
 
+/**
+ * `Theme` allows defining theme variables for components in the `@wordpress/components` package.
+ *
+ * Multiple `Theme` components can be nested in order to override specific theme variables.
+ *
+ *
+ * @example
+ * ```jsx
+ * import { __experimentalTheme as Theme } from '@wordpress/components';
+ *
+ * const Example = () => {
+ *   return (
+ *     <Theme accent="red">
+ *       <Button variant="primary">I'm red</Button>
+ *       <Theme accent="blue">
+ *         <Button variant="primary">I'm blue</Button>
+ *       </Theme>
+ *     </Theme>
+ *   );
+ * };
+ * ```
+ */
 function Theme( props: WordPressComponentProps< ThemeProps, 'div', true > ) {
 	const { accent } = props;
 	if ( accent && ! colord( accent ).isValid() ) {

--- a/packages/components/src/theme/index.tsx
+++ b/packages/components/src/theme/index.tsx
@@ -3,18 +3,14 @@
  */
 import { css } from '@emotion/react';
 import styled from '@emotion/styled';
-import type { ReactNode } from 'react';
+
 import { colord } from 'colord';
 
 /**
  * Internal dependencies
  */
+import type { ThemeProps } from './types';
 import type { WordPressComponentProps } from '../ui/context';
-
-type ThemeProps = {
-	accent?: string;
-	children?: ReactNode;
-};
 
 const colors = ( { accent }: ThemeProps ) => {
 	const accentColor = accent

--- a/packages/components/src/theme/stories/index.tsx
+++ b/packages/components/src/theme/stories/index.tsx
@@ -30,7 +30,7 @@ const Template: ComponentStory< typeof Theme > = ( args ) => (
 
 export const Default = Template.bind( {} );
 Default.args = {
-	accent: '#00006b',
+	// accent: '#00006b',
 };
 
 export const Nested: ComponentStory< typeof Theme > = ( args ) => (

--- a/packages/components/src/theme/stories/index.tsx
+++ b/packages/components/src/theme/stories/index.tsx
@@ -1,0 +1,47 @@
+/**
+ * External dependencies
+ */
+import type { ComponentMeta, ComponentStory } from '@storybook/react';
+
+/**
+ * Internal dependencies
+ */
+import Theme from '../index';
+import Button from '../../button';
+
+const meta: ComponentMeta< typeof Theme > = {
+	component: Theme,
+	title: 'Components (Experimental)/Theme',
+	argTypes: {
+		accent: { control: { type: 'color' } },
+	},
+	parameters: {
+		controls: { expanded: true },
+		docs: { source: { state: 'open' } },
+	},
+};
+export default meta;
+
+const Template: ComponentStory< typeof Theme > = ( args ) => (
+	<Theme { ...args }>
+		<Button variant="primary">Hello</Button>
+	</Theme>
+);
+
+export const Default = Template.bind( {} );
+Default.args = {
+	accent: '#00006b',
+};
+
+export const Nested: ComponentStory< typeof Theme > = ( args ) => (
+	<Theme accent="tomato">
+		<Button variant="primary">Outer theme</Button>
+
+		<Theme { ...args }>
+			<Button variant="primary">Inner theme</Button>
+		</Theme>
+	</Theme>
+);
+Nested.args = {
+	accent: 'blue',
+};

--- a/packages/components/src/theme/stories/index.tsx
+++ b/packages/components/src/theme/stories/index.tsx
@@ -29,16 +29,16 @@ const Template: ComponentStory< typeof Theme > = ( args ) => (
 );
 
 export const Default = Template.bind( {} );
-Default.args = {
-	// accent: '#00006b',
-};
+Default.args = {};
 
 export const Nested: ComponentStory< typeof Theme > = ( args ) => (
 	<Theme accent="tomato">
-		<Button variant="primary">Outer theme</Button>
+		<Button variant="primary">Outer theme (hardcoded)</Button>
 
 		<Theme { ...args }>
-			<Button variant="primary">Inner theme</Button>
+			<Button variant="primary">
+				Inner theme (set via Storybook controls)
+			</Button>
 		</Theme>
 	</Theme>
 );

--- a/packages/components/src/theme/styles.ts
+++ b/packages/components/src/theme/styles.ts
@@ -1,0 +1,28 @@
+/**
+ * External dependencies
+ */
+import { colord } from 'colord';
+import styled from '@emotion/styled';
+import { css } from '@emotion/react';
+
+/**
+ * Internal dependencies
+ */
+import type { ThemeProps } from './types';
+
+const accentColor = ( { accent }: ThemeProps ) =>
+	accent
+		? css`
+				--wp-components-color-accent: ${ accent };
+				--wp-components-color-accent-darker-10: ${ colord( accent )
+					.darken( 0.1 )
+					.toHex() };
+				--wp-components-color-accent-darker-20: ${ colord( accent )
+					.darken( 0.2 )
+					.toHex() };
+		  `
+		: undefined;
+
+export const Wrapper = styled.div< ThemeProps >`
+	${ accentColor }
+`;

--- a/packages/components/src/theme/test/index.tsx
+++ b/packages/components/src/theme/test/index.tsx
@@ -79,5 +79,23 @@ describe( 'Theme', () => {
 				'--wp-components-color-accent-darker-20': '#091d5f',
 			} );
 		} );
+
+		describe( 'unsupported values', () => {
+			it.each( [
+				// Keywords
+				'currentcolor',
+				'initial',
+				'reset',
+				'inherit',
+				'revert',
+				'unset',
+				// CSS Custom properties
+				'var( --my-variable )',
+			] )( 'should warn when the value is "%s"', ( accentValue ) => {
+				render( <Theme accent={ accentValue } /> );
+
+				expect( console ).toHaveWarned();
+			} );
+		} );
 	} );
 } );

--- a/packages/components/src/theme/test/index.tsx
+++ b/packages/components/src/theme/test/index.tsx
@@ -1,0 +1,83 @@
+/**
+ * External dependencies
+ */
+import { render, screen } from '@testing-library/react';
+import type { ReactNode } from 'react';
+
+/**
+ * Internal dependencies
+ */
+import Theme from '../';
+
+type MyThemableComponentProps = {
+	children: ReactNode;
+};
+
+const MyThemableComponent = ( props: MyThemableComponentProps ) => {
+	return (
+		<div
+			{ ...props }
+			style={ {
+				color: 'var(--wp-components-color-accent)',
+			} }
+		/>
+	);
+};
+
+describe( 'Theme', () => {
+	describe( 'accent color', () => {
+		it( 'it does not define the accent color (and its variations) as a CSS variable when the `accent` prop is undefined', () => {
+			render(
+				<Theme>
+					<MyThemableComponent>Inner</MyThemableComponent>
+				</Theme>
+			);
+
+			const inner = screen.getByText( 'Inner' );
+
+			if ( inner?.parentElement === null ) {
+				throw new Error(
+					'Somehow the `Theme` component does not render a DOM element?'
+				);
+			}
+
+			const innerElementStyles = window.getComputedStyle(
+				inner?.parentElement
+			);
+
+			expect(
+				innerElementStyles.getPropertyValue(
+					'--wp-components-color-accent'
+				)
+			).toBe( '' );
+
+			expect(
+				innerElementStyles.getPropertyValue(
+					'--wp-components-color-accent-darker-10'
+				)
+			).toBe( '' );
+
+			expect(
+				innerElementStyles.getPropertyValue(
+					'--wp-components-color-accent-darker-20'
+				)
+			).toBe( '' );
+		} );
+
+		it( 'it defines the accent color (and its variations) as a CSS variable', () => {
+			render(
+				<Theme accent="#123abc">
+					<MyThemableComponent>Inner</MyThemableComponent>
+				</Theme>
+			);
+
+			const inner = screen.getByText( 'Inner' );
+
+			expect( inner?.parentElement ).toHaveStyle( {
+				'--wp-components-color-accent': '#123abc',
+				'--wp-components-color-accent-darker-10': '#0e2c8d',
+				'--wp-components-color-accent-darker-20': '#091d5f',
+			} );
+		} );
+	} );
+} );

--- a/packages/components/src/theme/types.ts
+++ b/packages/components/src/theme/types.ts
@@ -1,0 +1,9 @@
+/**
+ * External dependencies
+ */
+import type { ReactNode, CSSProperties } from 'react';
+
+export type ThemeProps = {
+	accent?: CSSProperties[ 'color' ];
+	children?: ReactNode;
+};

--- a/packages/components/src/theme/types.ts
+++ b/packages/components/src/theme/types.ts
@@ -1,9 +1,9 @@
 /**
  * External dependencies
  */
-import type { ReactNode, CSSProperties } from 'react';
+import type { ReactNode } from 'react';
 
 export type ThemeProps = {
-	accent?: CSSProperties[ 'color' ];
+	accent?: string;
 	children?: ReactNode;
 };

--- a/packages/components/src/theme/types.ts
+++ b/packages/components/src/theme/types.ts
@@ -4,6 +4,18 @@
 import type { ReactNode } from 'react';
 
 export type ThemeProps = {
+	/**
+	 * Used to set the accent color (used by components as the primary color).
+	 *
+	 * If an accent color is not defined, the default fallback value is the original
+	 * WP Admin main theme color. No all valid CSS color syntaxes are supported —
+	 * in particular, keywords (like `'currentcolor'`, `'inherit'`, `'initial'`,
+	 * `'revert'`, `'unset'`...) and CSS custom properties (e.g.
+	 * `var(--my-custom-property)`) are _not_ supported values for this property.
+	 */
 	accent?: string;
+	/**
+	 * The children elements.
+	 */
 	children?: ReactNode;
 };

--- a/packages/components/src/utils/theme-variables.scss
+++ b/packages/components/src/utils/theme-variables.scss
@@ -1,0 +1,8 @@
+// Accent color
+//
+// If the `--wp-components-color-accent` variable is not defined, fallback to
+// `--wp-admin-theme-color`. If the `--wp-admin-theme-color` variable is not
+// defined, fallback to the default theme color (WP blue).
+$components-color-accent: var(--wp-components-color-accent, var(--wp-admin-theme-color, #007cba));
+$components-color-accent-darker-10: var(--wp-components-color-accent-darker-10, var(--wp-admin-theme-color-darker-10, #006ba1));
+$components-color-accent-darker-20: var(--wp-components-color-accent-darker-20, var(--wp-admin-theme-color-darker-20, #005a87));


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

 - Add a new experimental `Theme` component
 - Experiment with having an `accent` color exposed as a theme variable
 - Experiment with generating darker variables automatically with the `colord` library
 - Use the newly added accent variable in the `Button` component
 - Added initial docs, Storybook examples and unit tests

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

This part of the initial exploration for allowing the `@wordpress/components` to be themeable (see #44116)

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->

- Play around with the new `Theme` component in Storybook:
  - The `Button` in the "Default" example still has the same color as the `Button` in the `Button` story
  - The `Button`s in the "Nested" example should be blue (outer) and orange (inner)
- Most importantly, make sure that the `Button` element renders like on `trunk` in the editor and in its dedicated Storybook examples

## Screenshots or screencast <!-- if applicable -->

<img width="181" alt="Screenshot 2022-10-05 at 17 42 42" src="https://user-images.githubusercontent.com/1083581/194103253-ff7c5954-371a-4402-b91c-4f47581b7c2a.png">
