### PR TITLE
Block Editor: Refactor `ResponsiveBlockControl` tests to use `@testing-library/react`

### DIFF
--- a/packages/block-editor/src/components/responsive-block-control/test/index.js
+++ b/packages/block-editor/src/components/responsive-block-control/test/index.js
@@ -1,34 +1,19 @@
 /**
  * External dependencies
  */
-import { render, unmountComponentAtNode } from 'react-dom';
-import { act, Simulate } from 'react-dom/test-utils';
+import { render } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 
 /**
  * WordPress dependencies
  */
 import { Fragment, useState } from '@wordpress/element';
-
 import { SelectControl } from '@wordpress/components';
 
 /**
  * Internal dependencies
  */
 import ResponsiveBlockControl from '../index';
-
-let container = null;
-beforeEach( () => {
-	// Setup a DOM element as a render target.
-	container = document.createElement( 'div' );
-	document.body.appendChild( container );
-} );
-
-afterEach( () => {
-	// Cleanup on exiting.
-	unmountComponentAtNode( container );
-	container.remove();
-	container = null;
-} );
 
 const inputId = 'input-12345678';
 
@@ -65,16 +50,13 @@ const renderTestDefaultControlComponent = ( labelComponent, device ) => {
 
 describe( 'Basic rendering', () => {
 	it( 'should render with required props', () => {
-		act( () => {
-			render(
-				<ResponsiveBlockControl
-					title="Padding"
-					property="padding"
-					renderDefaultControl={ renderTestDefaultControlComponent }
-				/>,
-				container
-			);
-		} );
+		const { container } = render(
+			<ResponsiveBlockControl
+				title="Padding"
+				property="padding"
+				renderDefaultControl={ renderTestDefaultControlComponent }
+			/>
+		);
 
 		const activePropertyLabel = Array.from(
 			container.querySelectorAll( 'legend' )
@@ -121,40 +103,31 @@ describe( 'Basic rendering', () => {
 	} );
 
 	it( 'should not render without valid legend', () => {
-		act( () => {
-			render(
-				<ResponsiveBlockControl
-					property="padding"
-					renderDefaultControl={ renderTestDefaultControlComponent }
-				/>,
-				container
-			);
-		} );
+		const { container } = render(
+			<ResponsiveBlockControl
+				property="padding"
+				renderDefaultControl={ renderTestDefaultControlComponent }
+			/>
+		);
 
 		expect( container.innerHTML ).toBe( '' );
 	} );
 
 	it( 'should not render without valid property', () => {
-		act( () => {
-			render(
-				<ResponsiveBlockControl
-					title="Padding"
-					renderDefaultControl={ renderTestDefaultControlComponent }
-				/>,
-				container
-			);
-		} );
+		const { container } = render(
+			<ResponsiveBlockControl
+				title="Padding"
+				renderDefaultControl={ renderTestDefaultControlComponent }
+			/>
+		);
 
 		expect( container.innerHTML ).toBe( '' );
 	} );
 
 	it( 'should not render without valid default control render prop', () => {
-		act( () => {
-			render(
-				<ResponsiveBlockControl title="Padding" property="padding" />,
-				container
-			);
-		} );
+		const { container } = render(
+			<ResponsiveBlockControl title="Padding" property="padding" />
+		);
 
 		expect( container.innerHTML ).toBe( '' );
 	} );
@@ -162,17 +135,14 @@ describe( 'Basic rendering', () => {
 	it( 'should render with custom label for toggle control when provided', () => {
 		const customToggleLabel =
 			'Utilise a matching padding value on all viewports';
-		act( () => {
-			render(
-				<ResponsiveBlockControl
-					title="Padding"
-					property="padding"
-					renderDefaultControl={ renderTestDefaultControlComponent }
-					toggleLabel={ customToggleLabel }
-				/>,
-				container
-			);
-		} );
+		const { container } = render(
+			<ResponsiveBlockControl
+				title="Padding"
+				property="padding"
+				renderDefaultControl={ renderTestDefaultControlComponent }
+				toggleLabel={ customToggleLabel }
+			/>
+		);
 
 		const actualToggleLabel = container.querySelector(
 			'label.components-toggle-control__label'
@@ -184,17 +154,14 @@ describe( 'Basic rendering', () => {
 	it( 'should pass custom label for default control group to the renderDefaultControl function when provided', () => {
 		const customDefaultControlGroupLabel = 'Everything';
 
-		act( () => {
-			render(
-				<ResponsiveBlockControl
-					title="Padding"
-					property="padding"
-					renderDefaultControl={ renderTestDefaultControlComponent }
-					defaultLabel={ customDefaultControlGroupLabel }
-				/>,
-				container
-			);
-		} );
+		const { container } = render(
+			<ResponsiveBlockControl
+				title="Padding"
+				property="padding"
+				renderDefaultControl={ renderTestDefaultControlComponent }
+				defaultLabel={ customDefaultControlGroupLabel }
+			/>
+		);
 
 		const defaultControlLabel = Array.from(
 			container.querySelectorAll( 'label' )
@@ -206,17 +173,14 @@ describe( 'Basic rendering', () => {
 
 describe( 'Default and Responsive modes', () => {
 	it( 'should render in responsive mode when isResponsive prop is set to true', () => {
-		act( () => {
-			render(
-				<ResponsiveBlockControl
-					title="Padding"
-					property="padding"
-					isResponsive={ true }
-					renderDefaultControl={ renderTestDefaultControlComponent }
-				/>,
-				container
-			);
-		} );
+		const { container } = render(
+			<ResponsiveBlockControl
+				title="Padding"
+				property="padding"
+				isResponsive={ true }
+				renderDefaultControl={ renderTestDefaultControlComponent }
+			/>
+		);
 
 		const defaultControlGroup = container.querySelector(
 			'.block-editor-responsive-block-control__group:not(.is-responsive)'
@@ -253,18 +217,15 @@ describe( 'Default and Responsive modes', () => {
 			renderTestDefaultControlComponent
 		);
 
-		act( () => {
-			render(
-				<ResponsiveBlockControl
-					title="Padding"
-					property="padding"
-					isResponsive={ true }
-					renderDefaultControl={ mockRenderDefaultControl }
-					viewports={ customViewportSet }
-				/>,
-				container
-			);
-		} );
+		const { container } = render(
+			<ResponsiveBlockControl
+				title="Padding"
+				property="padding"
+				isResponsive={ true }
+				renderDefaultControl={ mockRenderDefaultControl }
+				viewports={ customViewportSet }
+			/>
+		);
 
 		const defaultRenderControlCall = 1;
 
@@ -287,7 +248,10 @@ describe( 'Default and Responsive modes', () => {
 		);
 	} );
 
-	it( 'should switch between default and responsive modes when interacting with toggle control', () => {
+	it( 'should switch between default and responsive modes when interacting with toggle control', async () => {
+		const user = userEvent.setup( {
+			advanceTimers: jest.advanceTimersByTime,
+		} );
 		const ResponsiveBlockControlConsumer = () => {
 			const [ isResponsive, setIsResponsive ] = useState( false );
 
@@ -304,9 +268,7 @@ describe( 'Default and Responsive modes', () => {
 			);
 		};
 
-		act( () => {
-			render( <ResponsiveBlockControlConsumer />, container );
-		} );
+		const { container } = render( <ResponsiveBlockControlConsumer /> );
 
 		let defaultControlGroup = container.querySelector(
 			'.block-editor-responsive-block-control__group:not(.is-responsive)'
@@ -332,9 +294,7 @@ describe( 'Default and Responsive modes', () => {
 		expect( responsiveControlGroup ).toBeNull();
 
 		// Toggle to "responsive" mode.
-		act( () => {
-			Simulate.change( toggleInput, { target: { checked: false } } );
-		} );
+		await user.click( toggleInput );
 
 		defaultControlGroup = container.querySelector(
 			'.block-editor-responsive-block-control__group:not(.is-responsive)'
@@ -347,9 +307,7 @@ describe( 'Default and Responsive modes', () => {
 		expect( responsiveControlGroup ).not.toBeNull();
 
 		// Toggle back to "default" mode.
-		act( () => {
-			Simulate.change( toggleInput, { target: { checked: true } } );
-		} );
+		await user.click( toggleInput );
 
 		defaultControlGroup = container.querySelector(
 			'.block-editor-responsive-block-control__group:not(.is-responsive)'
@@ -382,18 +340,15 @@ describe( 'Default and Responsive modes', () => {
 			} );
 		} );
 
-		act( () => {
-			render(
-				<ResponsiveBlockControl
-					title="Padding"
-					property="padding"
-					isResponsive={ true }
-					renderDefaultControl={ spyRenderDefaultControl }
-					renderResponsiveControls={ mockRenderResponsiveControls }
-				/>,
-				container
-			);
-		} );
+		const { container } = render(
+			<ResponsiveBlockControl
+				title="Padding"
+				property="padding"
+				isResponsive={ true }
+				renderDefaultControl={ spyRenderDefaultControl }
+				renderResponsiveControls={ mockRenderResponsiveControls }
+			/>
+		);
 
 		// The user should see "range" controls so we can legitimately query for them here.
 		const customControls = Array.from(


### PR DESCRIPTION
## What?
This PR refactors the tests of `ResponsiveBlockControl` to use `@testing-library/react`'s render instead of `react-dom` render. This addresses one of the changes needed to upgrade to React 18, as touched in #32765.

## Why?
This addresses one of the changes needed to upgrade to React 18, as touched in #32765.

## How?
We're just using the `@testing-library/react` render method and updating a few utilities, but another special.

A good follow-up for this component's tests would be to refactor all queries to use `screen` rather than `querySelector` and `querySelectorAll`.

## Testing Instructions
Verify tests still pass: `npm run test:unit packages/block-editor/src/components/responsive-block-control/test/index.js`