### PR TITLE
Components: Refactor `AlignmentMatrixControl` tests to use `@testing-library/react`

### DIFF
--- a/packages/components/src/alignment-matrix-control/test/index.js
+++ b/packages/components/src/alignment-matrix-control/test/index.js
@@ -8,16 +8,6 @@ import { render, screen, within } from '@testing-library/react';
  */
 import AlignmentMatrixControl from '../';
 
-const __windowFocus = window.focus;
-
-beforeAll( () => {
-	window.focus = jest.fn();
-} );
-
-afterAll( () => {
-	window.focus = __windowFocus;
-} );
-
 const getControl = () => {
 	return screen.getByRole( 'grid' );
 };

--- a/packages/components/src/alignment-matrix-control/test/index.js
+++ b/packages/components/src/alignment-matrix-control/test/index.js
@@ -22,8 +22,8 @@ const getControl = () => {
 	return screen.getByRole( 'grid' );
 };
 
-const getCells = () => {
-	return within( getControl() ).getAllByRole( 'gridcell' );
+const getCell = ( name ) => {
+	return within( getControl() ).getByRole( 'gridcell', { name } );
 };
 
 describe( 'AlignmentMatrixControl', () => {
@@ -31,31 +31,26 @@ describe( 'AlignmentMatrixControl', () => {
 		it( 'should render', () => {
 			render( <AlignmentMatrixControl /> );
 
-			expect( getControl() ).toBeTruthy();
+			expect( getControl() ).toBeInTheDocument();
 		} );
 	} );
 
 	describe( 'Change value', () => {
-		it( 'should change value on cell click', () => {
-			const spy = jest.fn();
+		const alignments = [ 'center left', 'center center', 'bottom center' ];
 
-			render(
-				<AlignmentMatrixControl value={ 'center' } onChange={ spy } />
-			);
+		it.each( alignments )(
+			'should change value on %s cell click',
+			( alignment ) => {
+				const spy = jest.fn();
 
-			const cells = getCells();
+				render(
+					<AlignmentMatrixControl value="center" onChange={ spy } />
+				);
 
-			cells[ 3 ].focus();
+				getCell( alignment ).focus();
 
-			expect( spy.mock.calls[ 0 ][ 0 ] ).toBe( 'center left' );
-
-			cells[ 4 ].focus();
-
-			expect( spy.mock.calls[ 1 ][ 0 ] ).toBe( 'center center' );
-
-			cells[ 7 ].focus();
-
-			expect( spy.mock.calls[ 2 ][ 0 ] ).toBe( 'bottom center' );
-		} );
+				expect( spy ).toHaveBeenCalledWith( alignment );
+			}
+		);
 	} );
 } );

--- a/packages/components/src/alignment-matrix-control/test/index.js
+++ b/packages/components/src/alignment-matrix-control/test/index.js
@@ -1,8 +1,7 @@
 /**
  * External dependencies
  */
-import { render, unmountComponentAtNode } from 'react-dom';
-import { act } from 'react-dom/test-utils';
+import { render, screen, within } from '@testing-library/react';
 
 /**
  * Internal dependencies
@@ -19,37 +18,20 @@ afterAll( () => {
 	window.focus = __windowFocus;
 } );
 
-let container = null;
-
-beforeEach( () => {
-	container = document.createElement( 'div' );
-	document.body.appendChild( container );
-} );
-
-afterEach( () => {
-	unmountComponentAtNode( container );
-	container.remove();
-	container = null;
-} );
-
 const getControl = () => {
-	return container.querySelector( '.component-alignment-matrix-control' );
+	return screen.getByRole( 'grid' );
 };
 
 const getCells = () => {
-	const control = getControl();
-	return control.querySelectorAll( '[role="gridcell"]' );
+	return within( getControl() ).getAllByRole( 'gridcell' );
 };
 
 describe( 'AlignmentMatrixControl', () => {
 	describe( 'Basic rendering', () => {
 		it( 'should render', () => {
-			act( () => {
-				render( <AlignmentMatrixControl />, container );
-			} );
-			const control = getControl();
+			render( <AlignmentMatrixControl /> );
 
-			expect( control ).toBeTruthy();
+			expect( getControl() ).toBeTruthy();
 		} );
 	} );
 
@@ -57,33 +39,21 @@ describe( 'AlignmentMatrixControl', () => {
 		it( 'should change value on cell click', () => {
 			const spy = jest.fn();
 
-			act( () => {
-				render(
-					<AlignmentMatrixControl
-						value={ 'center' }
-						onChange={ spy }
-					/>,
-					container
-				);
-			} );
+			render(
+				<AlignmentMatrixControl value={ 'center' } onChange={ spy } />
+			);
 
 			const cells = getCells();
 
-			act( () => {
-				cells[ 3 ].focus();
-			} );
+			cells[ 3 ].focus();
 
 			expect( spy.mock.calls[ 0 ][ 0 ] ).toBe( 'center left' );
 
-			act( () => {
-				cells[ 4 ].focus();
-			} );
+			cells[ 4 ].focus();
 
 			expect( spy.mock.calls[ 1 ][ 0 ] ).toBe( 'center center' );
 
-			act( () => {
-				cells[ 7 ].focus();
-			} );
+			cells[ 7 ].focus();
 
 			expect( spy.mock.calls[ 2 ][ 0 ] ).toBe( 'bottom center' );
 		} );


### PR DESCRIPTION
## What?
This PR refactors the tests of `AlignmentMatrixControl` to use `@testing-library/react`'s render instead of `react-dom` render. This addresses one of the changes needed to upgrade to React 18, as touched in #32765.

## Why?
This addresses one of the changes needed to upgrade to React 18, as touched in #32765.

## How?
We're just using the `@testing-library/react` render method and updating a few utilities, but another special.

We're also using the opportunities to refactor all queries to use `screen` rather than `querySelector` and `querySelectorAll`.

## Testing Instructions
Verify tests still pass: `npm run test:unit packages/components/src/alignment-matrix-control/test/index.js`