### PR TITLE
Fix: Hide list items from content area of content locked blocks

### DIFF
--- a/packages/block-editor/src/components/block-inspector/index.js
+++ b/packages/block-editor/src/components/block-inspector/index.js
@@ -40,6 +40,7 @@ function useContentBlocks( blockTypes, block ) {
 	const contenBlocksObjectAux = useMemo( () => {
 		return blockTypes.reduce( ( result, blockType ) => {
 			if (
+				blockType.name !== 'core/list-item' &&
 				Object.entries( blockType.attributes ).some(
 					( [ , { __experimentalRole } ] ) =>
 						__experimentalRole === 'content'


### PR DESCRIPTION
On the content area of a locked block, we were showing each list item, we should just show the list otherwise, the section becomes noisy.

### Sample
```
<!-- wp:group {"templateLock":"contentOnly","backgroundColor":"pale-cyan-blue","layout":{"type":"default"}} -->
<div class="wp-block-group has-pale-cyan-blue-background-color has-background"><!-- wp:heading {"style":{"typography":{"fontStyle":"normal","fontWeight":"700"}},"backgroundColor":"pale-pink","fontSize":"x-large"} -->
<h2 class="has-pale-pink-background-color has-background has-x-large-font-size" style="font-style:normal;font-weight:700">Heading</h2>
<!-- /wp:heading -->

<!-- wp:list -->
<ul><!-- wp:list-item -->
<li>1</li>
<!-- /wp:list-item -->

<!-- wp:list-item -->
<li>2</li>
<!-- /wp:list-item -->

<!-- wp:list-item -->
<li>3</li>
<!-- /wp:list-item -->

<!-- wp:list-item -->
<li>4</li>
<!-- /wp:list-item --></ul>
<!-- /wp:list -->

<!-- wp:paragraph {"backgroundColor":"vivid-red","textColor":"secondary"} -->
<p class="has-secondary-color has-vivid-red-background-color has-text-color has-background">Paragraph</p>
<!-- /wp:paragraph -->

<!-- wp:quote -->
<blockquote class="wp-block-quote"><!-- wp:paragraph -->
<p>sdsds</p>
<!-- /wp:paragraph --><cite>sd</cite></blockquote>
<!-- /wp:quote -->

<!-- wp:image {"align":"center","width":239,"height":239,"sizeSlug":"large","style":{"border":{"width":"18px"}}} -->
<figure class="wp-block-image aligncenter size-large is-resized has-custom-border"><img src="https://s.w.org/style/images/about/WordPress-logotype-wmark.png" alt="" style="border-width:18px" width="239" height="239"/><figcaption class="wp-element-caption">f</figcaption></figure>
<!-- /wp:image -->

<!-- wp:spacer {"height":"28px"} -->
<div style="height:28px" aria-hidden="true" class="wp-block-spacer"></div>
<!-- /wp:spacer -->

<!-- wp:group {"backgroundColor":"secondary"} -->
<div class="wp-block-group has-secondary-background-color has-background"><!-- wp:separator -->
<hr class="wp-block-separator has-alpha-channel-opacity"/>
<!-- /wp:separator -->

<!-- wp:spacer {"height":"55px"} -->
<div style="height:55px" aria-hidden="true" class="wp-block-spacer"></div>
<!-- /wp:spacer -->

<!-- wp:pullquote {"gradient":"blush-bordeaux"} -->
<figure class="wp-block-pullquote has-blush-bordeaux-gradient-background has-background"><blockquote><p>End quote inside another group</p></blockquote></figure>
<!-- /wp:pullquote --></div>
<!-- /wp:group --></div>
<!-- /wp:group -->
```

![image](https://user-images.githubusercontent.com/11271197/193889447-e099642c-118b-44af-a8ca-cba25ae7adc2.png)


### Testing
Pasted the previous code sample and verified that the content area was the one shown on the screenshot.