### PR TITLE
Configure Dependabot pull requests for GitHub Actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,10 @@
+# Configure Dependabot scanning.
+version: 2
+
+updates:
+  # Check for updates to GitHub Actions.
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "daily"
+    open-pull-requests-limit: 10


### PR DESCRIPTION
## What?
This adds a `dependabot.yml` file configuring automatic pull requests when there are updates to third-party GitHub Actions released.

## Why?
This helps keep our workflows using the latest versions of third-party actions. These can easily fall out of date.
