### PR TITLE
Add support for React 18 and later to jest-preset-default

### DIFF
--- a/packages/jest-preset-default/package.json
+++ b/packages/jest-preset-default/package.json
@@ -36,8 +36,8 @@
 	"peerDependencies": {
 		"@babel/core": ">=7",
 		"jest": ">=27",
-		"react": "^17.0.0",
-		"react-dom": "^17.0.0"
+		"react": ">=17",
+		"react-dom": ">=17"
 	},
 	"publishConfig": {
 		"access": "public"


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
jest-preset-default only allowed for react to be of version 17.x its peer dependencies. I made it so it allows React 17 and all versions after

## Why?
I don't see a reason for jest-preset-default to only allow react 17. React 18 has been out for long and is very stable. This way, developers using react 18 won't get warnings/errors about mismatching versions. 

## How?
I changed the peerDependencies for `react` and `react-dom` to `">=17"`. I don't see what else is needed to be changed really, since I think all code still applies to react 18. 

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->

## Screenshots or screencast <!-- if applicable -->
