### PR TITLE
Fix typo in WP_Navigation_Page_Test

### DIFF
--- a/phpunit/navigation-page-test.php
+++ b/phpunit/navigation-page-test.php
@@ -83,7 +83,7 @@ class WP_Navigation_Page_Test extends WP_UnitTestCase {
 		$this->callback
 			->expects( $this->once() )
 			->method( 'preload_menus_rest_pre_dispatch_callback' )
-			->willReturn( new $response() );
+			->willReturn( $response );
 
 		gutenberg_navigation_editor_preload_menus();
 


### PR DESCRIPTION
## What?
This PR removes the `new` operator from the `WP_Navigation_Page_Test::test_gutenberg_navigation_editor_preload_menus_initializes_createMenuPreloadingMiddleware` test method.

## Why?
The `new` operator is not needed there. It's a typo and it must be removed.

## How?
There are not many implementation details to share. It's a simple fix and this PR just removes the `new` operator.

## Testing Instructions
1. Make sure that the unit tests pass.

