### PR TITLE
Group, Row, Stack, Columns. Fix missing border regression

### DIFF
--- a/packages/block-editor/src/components/button-block-appender/style.scss
+++ b/packages/block-editor/src/components/button-block-appender/style.scss
@@ -48,6 +48,7 @@
 			bottom: 0;
 			left: 0;
 			pointer-events: none;
+			border: $border-width dashed currentColor;
 			@include placeholder-style();
 		}
 

--- a/packages/block-library/src/group/editor.scss
+++ b/packages/block-library/src/group/editor.scss
@@ -42,6 +42,7 @@
 		flex: 1 0 $grid-unit-60;
 		pointer-events: none;
 		min-height: $grid-unit-60 - $border-width - $border-width;
+		border: $border-width dashed currentColor;
 		@include placeholder-style();
 	}
 

--- a/packages/block-library/src/navigation/editor.scss
+++ b/packages/block-library/src/navigation/editor.scss
@@ -291,6 +291,7 @@ $color-control-label-height: 20px;
 		bottom: 0;
 		left: 0;
 		pointer-events: none;
+		border: $border-width dashed currentColor;
 		@include placeholder-style();
 
 		// Inherit border radius from style variations.


### PR DESCRIPTION
## What?

Followup to https://github.com/WordPress/gutenberg/pull/43512#issuecomment-1268046025. Fixes a regression where an updated placeholder style made empty groups, rows, stacks, columns, invisible:

<img width="863" alt="before" src="https://user-images.githubusercontent.com/1204802/194017193-e0eb94d9-92b3-44a3-8328-3feecce72a1b.png">

This PR fixes it by adding the border locally rather than in the mixin, making the states visible again:

<img width="745" alt="after" src="https://user-images.githubusercontent.com/1204802/194017340-b585536b-4ddf-45a6-9f46-f8dfcd883602.png">

## Testing Instructions

Test empty blocks: group, stack, row, navigation, columns. A dashed border should be visible around the setup state.

<details>
<summary>Test content</summary>
```
<!-- wp:paragraph -->
<p>Group</p>
<!-- /wp:paragraph -->

<!-- wp:group {"layout":{"type":"constrained"}} -->
<div class="wp-block-group"></div>
<!-- /wp:group -->

<!-- wp:paragraph -->
<p>Row</p>
<!-- /wp:paragraph -->

<!-- wp:group {"layout":{"type":"flex","flexWrap":"nowrap"}} -->
<div class="wp-block-group"></div>
<!-- /wp:group -->

<!-- wp:paragraph -->
<p>Stack</p>
<!-- /wp:paragraph -->

<!-- wp:group {"layout":{"type":"flex","orientation":"vertical"}} -->
<div class="wp-block-group"></div>
<!-- /wp:group -->

<!-- wp:paragraph -->
<p>Cols</p>
<!-- /wp:paragraph -->

<!-- wp:columns -->
<div class="wp-block-columns"><!-- wp:column -->
<div class="wp-block-column"></div>
<!-- /wp:column -->

<!-- wp:column -->
<div class="wp-block-column"></div>
<!-- /wp:column --></div>
<!-- /wp:columns -->

<!-- wp:paragraph -->
<p>Nav</p>
<!-- /wp:paragraph -->

<!-- wp:navigation {"ref":33637} /-->
```
</details>