### PR TITLE
Placeholder: Fix hover style.

### DIFF
--- a/packages/block-editor/src/components/block-list/style.scss
+++ b/packages/block-editor/src/components/block-list/style.scss
@@ -268,6 +268,7 @@
 		&::after {
 			content: "";
 			position: absolute;
+			pointer-events: none;
 			top: $border-width;
 			left: $border-width;
 			right: $border-width;

--- a/packages/block-editor/src/components/block-list/style.scss
+++ b/packages/block-editor/src/components/block-list/style.scss
@@ -264,8 +264,17 @@
 .is-outline-mode .block-editor-block-list__block:not(.remove-outline) {
 	&.is-hovered {
 		cursor: default;
-		box-shadow: inset 0 0 0 $border-width var(--wp-admin-theme-color);
-		border-radius: $radius-block-ui;
+
+		&::after {
+			content: "";
+			position: absolute;
+			top: $border-width;
+			left: $border-width;
+			right: $border-width;
+			bottom: $border-width;
+			box-shadow: 0 0 0 $border-width var(--wp-admin-theme-color);
+			border-radius: $radius-block-ui - $border-width;
+		}
 	}
 
 	&.is-selected {

--- a/packages/components/src/placeholder/style.scss
+++ b/packages/components/src/placeholder/style.scss
@@ -182,6 +182,9 @@
 	backdrop-filter: blur(100px);
 	background-color: transparent;
 
+	// This appears to fix an occasional Chrome bug where the blurred background would have an incorrect color.
+	backface-visibility: hidden;
+
 	// Invert the colors in themes deemed dark.
 	.is-dark-theme & {
 		background-color: rgba($black, 0.1);


### PR DESCRIPTION
## What?

Followup to #44150 which moved a hover style from a pseudo element onto the block itself. This caused an issue where the backdrop-filter applied to placeholders got blurred:

<img width="978" alt="Screenshot 2022-10-05 at 10 37 24" src="https://user-images.githubusercontent.com/1204802/194026279-be2a1c72-ae53-4efb-ba71-fc4dbfd82935.png">

This PR moves it back to a pseudo element, fixing the issue:

<img width="958" alt="Screenshot 2022-10-05 at 11 17 16" src="https://user-images.githubusercontent.com/1204802/194026316-4da79c04-7a11-4e37-9311-119cc6b407f1.png">

The PR also includes a fix for an occasional Chrome/Mac glitch where the backdrop filter placeholder would lose its color on resizing.

## Testing Instructions

Test image placeholders in various contexts, including inside a Cover block that has a background. The new placeholder style should work well in all contexts. 