### PR TITLE
Fix insertion point showing up unexpectedly

### DIFF
--- a/docs/reference-guides/data/data-core-block-editor.md
+++ b/docs/reference-guides/data/data-core-block-editor.md
@@ -1191,10 +1191,6 @@ _Parameters_
 
 Action that hides the insertion point.
 
-_Returns_
-
--   `Object`: Action object.
-
 ### insertAfterBlock
 
 Action that inserts an empty block after a given block.
@@ -1515,6 +1511,10 @@ _Parameters_
 -   _rootClientId_ `?string`: Optional root client ID of block list on which to insert.
 -   _index_ `?number`: Index at which block should be inserted.
 -   _\_\_unstableOptions_ `Object`: Whether or not to show an inserter button.
+
+_Returns_
+
+-   `Object`: Action object.
 
 ### startDraggingBlocks
 

--- a/docs/reference-guides/data/data-core-block-editor.md
+++ b/docs/reference-guides/data/data-core-block-editor.md
@@ -1516,10 +1516,6 @@ _Parameters_
 -   _index_ `?number`: Index at which block should be inserted.
 -   _\_\_unstableOptions_ `Object`: Whether or not to show an inserter button.
 
-_Returns_
-
--   `Object`: Action object.
-
 ### startDraggingBlocks
 
 Returns an action object used in signalling that the user has begun to drag blocks.

--- a/packages/block-editor/src/components/block-list/use-in-between-inserter.js
+++ b/packages/block-editor/src/components/block-list/use-in-between-inserter.js
@@ -146,7 +146,6 @@ export function useInBetweenInserter() {
 
 				showInsertionPoint( rootClientId, index, {
 					__unstableWithInserter: true,
-					delay: 500,
 				} );
 			}
 

--- a/packages/block-editor/src/components/block-list/use-in-between-inserter.js
+++ b/packages/block-editor/src/components/block-list/use-in-between-inserter.js
@@ -1,7 +1,7 @@
 /**
  * WordPress dependencies
  */
-import { useRefEffect, useDebounce } from '@wordpress/compose';
+import { useRefEffect } from '@wordpress/compose';
 import { useSelect, useDispatch } from '@wordpress/data';
 import { useContext } from '@wordpress/element';
 
@@ -32,10 +32,6 @@ export function useInBetweenInserter() {
 	const { showInsertionPoint, hideInsertionPoint } =
 		useDispatch( blockEditorStore );
 
-	const delayedShowInsertionPoint = useDebounce( showInsertionPoint, 500, {
-		trailing: true,
-	} );
-
 	return useRefEffect(
 		( node ) => {
 			if ( isInBetweenInserterDisabled ) {
@@ -56,10 +52,7 @@ export function useInBetweenInserter() {
 						'block-editor-block-list__layout'
 					)
 				) {
-					delayedShowInsertionPoint.cancel();
-					if ( isBlockInsertionPointVisible() ) {
-						hideInsertionPoint();
-					}
+					hideInsertionPoint();
 					return;
 				}
 
@@ -138,10 +131,7 @@ export function useInBetweenInserter() {
 						( event.clientX > elementRect.right ||
 							event.clientX < elementRect.left ) )
 				) {
-					delayedShowInsertionPoint.cancel();
-					if ( isBlockInsertionPointVisible() ) {
-						hideInsertionPoint();
-					}
+					hideInsertionPoint();
 					return;
 				}
 
@@ -150,15 +140,13 @@ export function useInBetweenInserter() {
 				// Don't show the in-between inserter before the first block in
 				// the list (preserves the original behaviour).
 				if ( index === 0 ) {
-					delayedShowInsertionPoint.cancel();
-					if ( isBlockInsertionPointVisible() ) {
-						hideInsertionPoint();
-					}
+					hideInsertionPoint();
 					return;
 				}
 
-				delayedShowInsertionPoint( rootClientId, index, {
+				showInsertionPoint( rootClientId, index, {
 					__unstableWithInserter: true,
+					delay: 500,
 				} );
 			}
 

--- a/packages/block-editor/src/components/block-tools/insertion-point.js
+++ b/packages/block-editor/src/components/block-tools/insertion-point.js
@@ -149,13 +149,13 @@ function InsertionPointPopover( {
 			...( ! isVertical ? horizontalLine.rest : verticalLine.rest ),
 			opacity: 1,
 			borderRadius: '2px',
-			transition: { delay: isInserterShown ? 0.1 : 0, type: 'tween' },
+			transition: { delay: isInserterShown ? 0.5 : 0, type: 'tween' },
 		},
 		hover: {
 			...( ! isVertical ? horizontalLine.hover : verticalLine.hover ),
 			opacity: 1,
 			borderRadius: '2px',
-			transition: { delay: 0.1, type: 'tween' },
+			transition: { delay: 0.5, type: 'tween' },
 		},
 	};
 
@@ -165,7 +165,7 @@ function InsertionPointPopover( {
 		},
 		rest: {
 			scale: 1,
-			transition: { type: 'tween' },
+			transition: { delay: 0.4, type: 'tween' },
 		},
 	};
 

--- a/packages/block-editor/src/store/actions.js
+++ b/packages/block-editor/src/store/actions.js
@@ -621,8 +621,6 @@ export const insertBlocks =
 		}
 	};
 
-const delayedInsertionPointCalls = new WeakMap();
-
 /**
  * Action that shows the insertion point.
  *
@@ -630,40 +628,28 @@ const delayedInsertionPointCalls = new WeakMap();
  *                                    which to insert.
  * @param {?number} index             Index at which block should be inserted.
  * @param {Object}  __unstableOptions Whether or not to show an inserter button.
- */
-export const showInsertionPoint =
-	( rootClientId, index, __unstableOptions = {} ) =>
-	( { dispatch, registry } ) => {
-		const previousCall = delayedInsertionPointCalls.get( registry );
-		if ( previousCall ) {
-			clearTimeout( previousCall );
-		}
-		const { __unstableWithInserter, delay } = __unstableOptions;
-		delayedInsertionPointCalls.set(
-			registry,
-			setTimeout( () => {
-				dispatch( {
-					type: 'SHOW_INSERTION_POINT',
-					rootClientId,
-					index,
-					__unstableWithInserter,
-				} );
-			}, delay )
-		);
-	};
-
-/**
- * Action that hides the insertion point.
  *
  * @return {Object} Action object.
  */
+export function showInsertionPoint(
+	rootClientId,
+	index,
+	__unstableOptions = {}
+) {
+	const { __unstableWithInserter } = __unstableOptions;
+	return {
+		type: 'SHOW_INSERTION_POINT',
+		rootClientId,
+		index,
+		__unstableWithInserter,
+	};
+}
+/**
+ * Action that hides the insertion point.
+ */
 export const hideInsertionPoint =
 	() =>
-	( { select, dispatch, registry } ) => {
-		const previousCall = delayedInsertionPointCalls.get( registry );
-		if ( previousCall ) {
-			clearTimeout( previousCall );
-		}
+	( { select, dispatch } ) => {
 		if ( ! select.isBlockInsertionPointVisible() ) {
 			return;
 		}

--- a/packages/block-editor/src/store/actions.js
+++ b/packages/block-editor/src/store/actions.js
@@ -621,6 +621,8 @@ export const insertBlocks =
 		}
 	};
 
+const delayedInsertionPointCalls = new WeakMap();
+
 /**
  * Action that shows the insertion point.
  *
@@ -628,33 +630,47 @@ export const insertBlocks =
  *                                    which to insert.
  * @param {?number} index             Index at which block should be inserted.
  * @param {Object}  __unstableOptions Whether or not to show an inserter button.
- *
- * @return {Object} Action object.
  */
-export function showInsertionPoint(
-	rootClientId,
-	index,
-	__unstableOptions = {}
-) {
-	const { __unstableWithInserter } = __unstableOptions;
-	return {
-		type: 'SHOW_INSERTION_POINT',
-		rootClientId,
-		index,
-		__unstableWithInserter,
+export const showInsertionPoint =
+	( rootClientId, index, __unstableOptions = {} ) =>
+	( { dispatch, registry } ) => {
+		const previousCall = delayedInsertionPointCalls.get( registry );
+		if ( previousCall ) {
+			clearTimeout( previousCall );
+		}
+		const { __unstableWithInserter, delay } = __unstableOptions;
+		delayedInsertionPointCalls.set(
+			registry,
+			setTimeout( () => {
+				dispatch( {
+					type: 'SHOW_INSERTION_POINT',
+					rootClientId,
+					index,
+					__unstableWithInserter,
+				} );
+			}, delay )
+		);
 	};
-}
 
 /**
  * Action that hides the insertion point.
  *
  * @return {Object} Action object.
  */
-export function hideInsertionPoint() {
-	return {
-		type: 'HIDE_INSERTION_POINT',
+export const hideInsertionPoint =
+	() =>
+	( { select, dispatch, registry } ) => {
+		const previousCall = delayedInsertionPointCalls.get( registry );
+		if ( previousCall ) {
+			clearTimeout( previousCall );
+		}
+		if ( ! select.isBlockInsertionPointVisible() ) {
+			return;
+		}
+		dispatch( {
+			type: 'HIDE_INSERTION_POINT',
+		} );
 	};
-}
 
 /**
  * Action that resets the template validity.

--- a/packages/block-editor/src/store/test/actions.js
+++ b/packages/block-editor/src/store/test/actions.js
@@ -27,7 +27,6 @@ const noop = () => {};
 
 const {
 	clearSelectedBlock,
-	hideInsertionPoint,
 	insertBlock,
 	insertBlocks,
 	mergeBlocks,
@@ -606,14 +605,6 @@ describe( 'actions', () => {
 		it( 'should return the SHOW_INSERTION_POINT action', () => {
 			expect( showInsertionPoint() ).toEqual( {
 				type: 'SHOW_INSERTION_POINT',
-			} );
-		} );
-	} );
-
-	describe( 'hideInsertionPoint', () => {
-		it( 'should return the HIDE_INSERTION_POINT action', () => {
-			expect( hideInsertionPoint() ).toEqual( {
-				type: 'HIDE_INSERTION_POINT',
 			} );
 		} );
 	} );


### PR DESCRIPTION
Closes #44694

## What?

Recently, I did a performance optimization to avoid calling too much actions when moving the mouse or scrolling. That introduced a race condition that was causing the insertion point to show up unexpectedly in some situations. Basically a delayed showInsertionPoint function call was not being "canceled" properly as we left the insertion point position. This PR fixes it by making sure that all calls to hideInsertionPoint cancel any scheduled call to showInsertionPoint.

## Testing Instructions

1- Open the site editor
2- Hover the area right after the header template part
3- Move the mouse on the template part
4- The insertion point should not appear again.
