### PR TITLE
Prevent empty block toolbars from showing empty slots

### DIFF
--- a/packages/components/src/slot-fill/bubbles-virtually/slot-fill-provider.js
+++ b/packages/components/src/slot-fill/bubbles-virtually/slot-fill-provider.js
@@ -67,9 +67,11 @@ function useSlotRegistry() {
 		if ( fills.current.get( name ) ) {
 			fills.current.set(
 				name,
-				fills.current
-					.get( name )
-					.filter( ( fillRef ) => fillRef !== ref )
+				valRef(
+					fills.current
+						.get( name )
+						.filter( ( fillRef ) => fillRef !== ref )
+				)
 			);
 		}
 	}, [] );


### PR DESCRIPTION
Addresses https://github.com/WordPress/gutenberg/pull/44642?notification_referrer_id=NT_kwDOAAQoPLE0NTI2NDE3NzE4OjI3MjQ0NA#issuecomment-1268129030

## What?

In #44642 we improved the performance of slot/fills but a small regression was introduced where sometimes empty toolbars show an empty slot like the following screenshot 
![Screen Shot 2022-10-05 at 4 30 16 pm](https://user-images.githubusercontent.com/677833/194016546-0b9b5823-34b9-497a-8be1-26b2d3187967.png)

This was a small mistake due to `valtio` usage. This library tracks any object in its state by using a "proxy" to the object itself. So `useSlotFills` was actually returning a proxy to an array instead of the array directly, so it was not considered as "empty".


## Testing Instructions

1. Open the TT3 Home template in the site editor
2. Select the Heading block with the 'Mindblown' text.
3. Select its container - notice there's no empty toolbar section. 

