### PR TITLE
Rich Text: use fallback icon for highlight format

### DIFF
--- a/packages/format-library/src/text-color/index.js
+++ b/packages/format-library/src/text-color/index.js
@@ -4,7 +4,11 @@
 import { __ } from '@wordpress/i18n';
 import { useCallback, useMemo, useState } from '@wordpress/element';
 import { RichTextToolbarButton, useSetting } from '@wordpress/block-editor';
-import { Icon, textColor as textColorIcon } from '@wordpress/icons';
+import {
+	Icon,
+	color as colorIcon,
+	textColor as textColorIcon,
+} from '@wordpress/icons';
 import { removeFormat } from '@wordpress/rich-text';
 
 /**
@@ -89,7 +93,11 @@ function TextColorEdit( {
 				isActive={ isActive }
 				icon={
 					<Icon
-						icon={ textColorIcon }
+						icon={
+							Object.keys( activeAttributes ).length
+								? textColorIcon
+								: colorIcon
+						}
 						style={ colorIndicatorStyle }
 					/>
 				}


### PR DESCRIPTION
This is small detail that has been bothering me for some time. When no highlight color is set for a rich text selection, let's use the color drop icon instead of the lonely A.

**Before:**
<img width="805" alt="image" src="https://user-images.githubusercontent.com/548849/194050358-56cdabef-9218-42b5-8b12-b58600bf7ab4.png">

**After:**
<img width="826" alt="image" src="https://user-images.githubusercontent.com/548849/194050109-cf09bbcc-1590-44f2-a49f-b32e9a8c886c.png">

And switch to the colored A icon when there are actually modifications:
<img width="828" alt="image" src="https://user-images.githubusercontent.com/548849/194050185-e7da5f14-b396-46be-a046-050f7c84e8cb.png">
