### PR TITLE
Cover: Fix erroneous focus style in editor.

### DIFF
--- a/packages/block-library/src/cover/editor.scss
+++ b/packages/block-library/src/cover/editor.scss
@@ -107,3 +107,10 @@
 .color-block-support-panel__inner-wrapper > :not(.block-editor-tools-panel-color-gradient-settings__item) {
 	margin-top: $grid-unit-30;
 }
+
+
+// The frontend style.scss includes a min-height as an IE11 fix.
+// This fix causes extra spacing for the focus style in the editor, so we omit it here.
+.wp-block-cover::after {
+	min-height: auto;
+}


### PR DESCRIPTION
## What?

In the editor, the focus style for the cover block is wrong, showing a gap at the bottom:

<img width="758" alt="before" src="https://user-images.githubusercontent.com/1204802/194053336-61bbf95a-2850-47b8-a4a3-83812552f7c3.png">

This PR fixes that gap, by unsetting a min-height applied to the focus style in the editor:

<img width="823" alt="after" src="https://user-images.githubusercontent.com/1204802/194053387-d2b7da51-4642-440b-873c-66301201d3d6.png">

As best I can tell from context in style.scss, that min-height exists solely for the frontend, and to fix an older IE issue at that. This PR keeps that hack intact, but adds a comment explaining the context.

## Testing Instructions

Test the cover block in the editor, and observe no gap between image and focus style bottom border.