### PR TITLE
Try: add a small radius to the multi selection style

### DIFF
--- a/packages/block-editor/src/components/block-list/style.scss
+++ b/packages/block-editor/src/components/block-list/style.scss
@@ -54,6 +54,7 @@
 			left: $border-width;
 			background: var(--wp-admin-theme-color);
 			opacity: 0.4;
+			border-radius: $radius-block-ui;
 
 			// Animate.
 			animation: selection-overlay__fade-in-animation 0.1s ease-out;

--- a/packages/block-editor/src/components/block-list/style.scss
+++ b/packages/block-editor/src/components/block-list/style.scss
@@ -36,6 +36,10 @@
 
 	// Block multi selection
 	.block-editor-block-list__block.is-multi-selected:not(.is-partially-selected) {
+		// Apply a rounded radius to the entire block.
+		border-radius: $radius-block-ui;
+		overflow: hidden;
+
 		// Hide the native selection indicator, for the selection, and children.
 		&::selection,
 		& ::selection {


### PR DESCRIPTION
## What?

The multi selection style is rectangular:

<img width="718" alt="before" src="https://user-images.githubusercontent.com/1204802/194055326-8e92698e-5801-4bbc-b88f-f1f0dfd42cd9.png">

The first commit in this branch adds a small block radius to the multi-selection overlay indicator, but notably leaves out the radius on blocks themselves:

<img width="718" alt="first commit" src="https://user-images.githubusercontent.com/1204802/194055396-aa6fd996-c684-4a39-86a7-8fa2f90a012a.png">

The second commit, and what you'll see at the moment if you check out this branch, adds the radius also to blocks:

<img width="759" alt="cover" src="https://user-images.githubusercontent.com/1204802/194055460-f9afe3f6-492b-49ef-92d9-124c158610d7.png">

The reason this is a separate commit is that it adds an `overflow: hidden;` to the selected block, whether one was there before or not. This feels appropriate given that it literally bounds the selection, however this would be good to test. For example, it appears to work fine with blocks that already have a stylistic radius applied:

<img width="724" alt="image" src="https://user-images.githubusercontent.com/1204802/194055627-09b1de8e-df93-45b2-9039-219be1ec25cc.png">

## Testing Instructions

Please test selecting multiple blocks, including image, cover, and others, and observe the 2px radius.