### PR TITLE
Multi-select: Fix 1px indent.

### DIFF
--- a/packages/block-editor/src/components/block-list/style.scss
+++ b/packages/block-editor/src/components/block-list/style.scss
@@ -48,10 +48,10 @@
 			position: absolute;
 			z-index: 1;
 			pointer-events: none;
-			top: $border-width;
-			right: $border-width;
-			bottom: $border-width;
-			left: $border-width;
+			top: 0;
+			right: 0;
+			bottom: 0;
+			left: 0;
 			background: var(--wp-admin-theme-color);
 			opacity: 0.4;
 


### PR DESCRIPTION
## What?

Followup to #44150, and might pair well with #44708. 

Inline text selection aligns with the block toolbar:

<img width="442" alt="Screenshot 2022-10-05 at 14 06 53" src="https://user-images.githubusercontent.com/1204802/194057220-3b1a81a0-db52-4e64-9b68-2d1dbfac34c7.png">

But the new multi-select, which was designed to share DNA with inline selection but still be distinct for block level selection, did not. If you zoom in you can see it's indented on all 4 sides by 1px:

<img width="321" alt="before" src="https://user-images.githubusercontent.com/1204802/194057367-5541f617-c13e-465c-92c1-8c6da7582db5.png">

This PR fixes it so things line up:

<img width="252" alt="after" src="https://user-images.githubusercontent.com/1204802/194057502-dfb7b51a-e7d6-448d-9c12-90000a51235e.png">

## Testing Instructions

Observe the multi select style, and that it aligns with block toolbar and inline text.