### PR TITLE
Storybook: Add theme switcher tool

### DIFF
--- a/storybook/decorators/with-theme.js
+++ b/storybook/decorators/with-theme.js
@@ -14,6 +14,8 @@ export const WithTheme = ( Story, context ) => {
 			accent: '#3858e9',
 		},
 		sunrise: {
+			// This color was chosen intentionally, because for sufficient contrast,
+			// the foreground text should be black when this orange is used as a background color.
 			accent: '#dd823b',
 		},
 	};

--- a/storybook/decorators/with-theme.js
+++ b/storybook/decorators/with-theme.js
@@ -1,0 +1,26 @@
+/**
+ * Internal dependencies
+ */
+import Theme from '../../packages/components/src/theme';
+
+/**
+ *  A Storybook decorator to show a div before and after the story to check for unwanted margins.
+ */
+
+export const WithTheme = ( Story, context ) => {
+	const themes = {
+		default: {},
+		modern: {
+			accent: '#3858e9',
+		},
+		sunrise: {
+			accent: '#dd823b',
+		},
+	};
+
+	return (
+		<Theme { ...themes[ context.globals.componentsTheme ] }>
+			<Story { ...context } />
+		</Theme>
+	);
+};

--- a/storybook/preview.js
+++ b/storybook/preview.js
@@ -4,6 +4,7 @@
 import { WithGlobalCSS } from './decorators/with-global-css';
 import { WithMarginChecker } from './decorators/with-margin-checker';
 import { WithRTL } from './decorators/with-rtl';
+import { WithTheme } from './decorators/with-theme';
 import './style.scss';
 
 export const globalTypes = {
@@ -16,6 +17,19 @@ export const globalTypes = {
 			items: [
 				{ value: 'ltr', title: 'LTR' },
 				{ value: 'rtl', title: 'RTL' },
+			],
+		},
+	},
+	componentsTheme: {
+		name: 'Theme',
+		description: 'Change the components theme.',
+		defaultValue: 'default',
+		toolbar: {
+			icon: 'paintbrush',
+			items: [
+				{ value: 'default', title: 'Default' },
+				{ value: 'modern', title: 'Modern' },
+				{ value: 'sunrise', title: 'Sunrise' },
 			],
 		},
 	},
@@ -51,7 +65,12 @@ export const globalTypes = {
 	},
 };
 
-export const decorators = [ WithGlobalCSS, WithMarginChecker, WithRTL ];
+export const decorators = [
+	WithTheme,
+	WithGlobalCSS,
+	WithMarginChecker,
+	WithRTL,
+];
 
 export const parameters = {
 	controls: {

--- a/storybook/preview.js
+++ b/storybook/preview.js
@@ -22,7 +22,7 @@ export const globalTypes = {
 	},
 	componentsTheme: {
 		name: 'Theme',
-		description: 'Change the components theme.',
+		description: 'Change the components theme. (Work in progress)',
 		defaultValue: 'default',
 		toolbar: {
 			icon: 'paintbrush',


### PR DESCRIPTION
Part of #44116
Based on #44668

## What?

Adds a theme switcher tool to the Storybook toolbar to test component support of the new experimental `Theme` component.

## Why?

We need to test whether the new configurable colors we introduce are supported correctly by all components.

## How?

Adds a new toolbar add-on with some preset accent colors.

The orange accent color ("Sunrise") was chosen intentionally, because for sufficient contrast, the foreground text should be black when this orange is used as a background color. As can be seen with the primary variant of the Button component in the video, we don't support automatic text color switching yet. This is one of our next steps to work on.

## Testing Instructions

1. `npm run storybook:dev`
2. Go to the Primary story for the Button component and try switching the theme. (The theme switching component only works for Button at the moment.)

## Screenshots or screencast <!-- if applicable -->

https://user-images.githubusercontent.com/555336/194099916-ceed2f05-8974-4726-a824-42eccce7fe53.mp4


