### PR TITLE
Margin visualiser: Apply negative value to margins with calc()

### DIFF
--- a/packages/block-editor/src/hooks/margin.js
+++ b/packages/block-editor/src/hooks/margin.js
@@ -190,10 +190,10 @@ export function MarginVisualizer( { clientId, attributes } ) {
 			borderRightWidth: marginRight,
 			borderBottomWidth: marginBottom,
 			borderLeftWidth: marginLeft,
-			top: marginTop !== 0 ? `-${ marginTop }` : 0,
-			right: marginRight !== 0 ? `-${ marginRight }` : 0,
-			bottom: marginBottom !== 0 ? `-${ marginBottom }` : 0,
-			left: marginLeft !== 0 ? `-${ marginLeft }` : 0,
+			top: marginTop !== 0 ? `calc(${ marginTop } * -1)` : 0,
+			right: marginRight !== 0 ? `calc(${ marginRight } * -1)` : 0,
+			bottom: marginBottom !== 0 ? `calc(${ marginBottom } * -1)` : 0,
+			left: marginLeft !== 0 ? `calc(${ marginLeft } * -1)` : 0,
 		};
 	}, [ margin ] );
 


### PR DESCRIPTION
## What?
Updates the way the margin values are converted to negative values for the correct display of the margin visualiser

## Why?
Fixes: #44693 Currently the visualiser only works with simple custom values, and breaks if complex `clamp` values are used via the spacing presets.

## How?
Convert margins to negative value using `calc` rather than appending a `-` to margin string.

## Testing Instructions

- In a site running TT3 add a Group block and add margins to it
- Make sure the visualiser displays correctly as you adjust the margins with the presets slider

## Screenshots or screencast 

Before:

https://user-images.githubusercontent.com/3629020/194176523-b173c910-c64a-45bc-8130-eaeac63b3314.mp4

After:

https://user-images.githubusercontent.com/3629020/194176561-4782bb8c-701c-4d8b-8c56-251c1e9d5c96.mp4


