### PR TITLE
Layout Docs: Fix broken link in table of contents

### DIFF
--- a/docs/explanations/architecture/styles.md
+++ b/docs/explanations/architecture/styles.md
@@ -12,7 +12,7 @@ This document introduces the main concepts related to styles that affect the use
   - [Consolidate data](#consolidate-data)
   - [From data to styles](#from-data-to-styles)
   - [Current limitations of the Global Styles API](#current-limitations-of-the-global-styles-api)
-4. [Structural layout styles](#structural-layout-styles)
+4. [Layout styles](#layout-styles)
   - [Base layout styles](#base-layout-styles)
   - [Individual layout styles](#individual-layout-styles)
   - [Available layout types](#available-layout-types)
@@ -565,4 +565,4 @@ The current semantic class names that can be output by the Layout block support 
 
 #### Opting out of generated layout styles
 
-Layout styles output is switched on by default because the styles are required by core structural blocks. However, themes can opt out of generated block layout styles while retaining semantic class name output by using the `disable-layout-styles` block support. Such themes will be responsible for providing all their own structural layout styles. See [the entry under Theme Support](https://developer.wordpress.org/block-editor/how-to-guides/themes/theme-support/#disabling-base-layout-styles).
+Layout styles output is switched on by default because the styles are required by core structural blocks. However, themes can opt out of generated block layout styles while retaining semantic class name output by using the `disable-layout-styles` block support. Such themes will be responsible for providing all their own layout styles. See [the entry under Theme Support](https://developer.wordpress.org/block-editor/how-to-guides/themes/theme-support/#disabling-base-layout-styles).


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Follow up to #42619 — fix a broken link in the table of contents and remove the word "structural".

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

Non-broken links make navigating a table of contents section significantly more pleasing for the reader! 😅

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

Manually update the link in the table of contents to reference the correct id, and ensure the label matches the appropriate heading.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->

1. Go to the file view via this link: https://github.com/WordPress/gutenberg/blob/9374d6567fc1d3428fc581161b67c6fb1f56ddb8/docs/explanations/architecture/styles.md
2. Click on `4. Layout styles` and the link should take you down to the layout styles section
