### PR TITLE
Remove anchor support from the navigation block

### DIFF
--- a/docs/reference-guides/core-blocks.md
+++ b/docs/reference-guides/core-blocks.md
@@ -392,7 +392,7 @@ A collection of blocks that allow visitors to get around your site. ([Source](ht
 
 -	**Name:** core/navigation
 -	**Category:** theme
--	**Supports:** align (full, wide), anchor, inserter, spacing (blockGap, units), typography (fontSize, lineHeight), ~~html~~
+-	**Supports:** align (full, wide), inserter, spacing (blockGap, units), typography (fontSize, lineHeight), ~~html~~
 -	**Attributes:** __unstableLocation, backgroundColor, customBackgroundColor, customOverlayBackgroundColor, customOverlayTextColor, customTextColor, hasIcon, icon, maxNestingLevel, openSubmenusOnClick, overlayBackgroundColor, overlayMenu, overlayTextColor, ref, rgbBackgroundColor, rgbTextColor, showSubmenuIcon, textColor
 
 ## Custom Link

--- a/packages/block-library/src/navigation/block.json
+++ b/packages/block-library/src/navigation/block.json
@@ -88,7 +88,6 @@
 	},
 	"supports": {
 		"align": [ "wide", "full" ],
-		"anchor": true,
 		"html": false,
 		"inserter": true,
 		"typography": {


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
See https://github.com/WordPress/gutenberg/issues/29401#issuecomment-1269272153

Removes anchor support from the navigation block, as the feature doesn't work in the navigation block or for any fully dynamic block.

## Why?
At the very least removing something that's not supported makes the experience less confusing for users.

This change is also something that I hope can be backported to WordPress 6.1. 

The alternative, adding anchor support for dynamic blocks is more of a feature and would likely not be allowed during the feature freeze.

## How?
Removes the anchor support declaration in the block.json. Updates associated docs.

## Testing Instructions
1. Add and select a navigation block
2. In the block inspector expand the Advanced section
3. Confirm that the Anchor input field is no longer present

## Screenshots or screencast <!-- if applicable -->

### Before

![Screen Shot 2022-10-06 at 12 13 53 pm](https://user-images.githubusercontent.com/677833/194212515-ff03e1f3-e95d-4066-a1cc-45043ddfb585.png)


### After

![Screen Shot 2022-10-06 at 12 13 22 pm](https://user-images.githubusercontent.com/677833/194212503-6bf0c46c-3792-4e88-a795-26e0ec019d93.png)
