### PR TITLE
Writing flow: add Shift+Arrow when selection is 'full'

### DIFF
--- a/packages/block-editor/src/components/rich-text/index.js
+++ b/packages/block-editor/src/components/rich-text/index.js
@@ -156,8 +156,12 @@ function RichTextWrapper(
 	// retreived from the store on merge.
 	// To do: fix this somehow.
 	const { selectionStart, selectionEnd, isSelected } = useSelect( selector );
-	const { getSelectionStart, getSelectionEnd, getBlockRootClientId } =
-		useSelect( blockEditorStore );
+	const {
+		getSelectionStart,
+		getSelectionEnd,
+		getBlockRootClientId,
+		__unstableIsBlockMergeable,
+	} = useSelect( blockEditorStore );
 	const { selectionChange } = useDispatch( blockEditorStore );
 	const multilineTag = getMultilineTag( multiline );
 	const adjustedAllowedFormats = getAllowedFormats( {
@@ -199,8 +203,9 @@ function RichTextWrapper(
 				// is a parent block.
 				if (
 					end === undefined &&
-					getBlockRootClientId( clientId ) !==
-						getBlockRootClientId( getSelectionEnd().clientId )
+					( getBlockRootClientId( clientId ) !==
+						getBlockRootClientId( getSelectionEnd().clientId ) ||
+						! __unstableIsBlockMergeable( clientId ) )
 				) {
 					return;
 				}
@@ -215,8 +220,9 @@ function RichTextWrapper(
 			if ( typeof end === 'number' || unset ) {
 				if (
 					start === undefined &&
-					getBlockRootClientId( clientId ) !==
-						getBlockRootClientId( getSelectionStart().clientId )
+					( getBlockRootClientId( clientId ) !==
+						getBlockRootClientId( getSelectionStart().clientId ) ||
+						! __unstableIsBlockMergeable( clientId ) )
 				) {
 					return;
 				}

--- a/packages/block-editor/src/components/writing-flow/use-arrow-nav.js
+++ b/packages/block-editor/src/components/writing-flow/use-arrow-nav.js
@@ -1,4 +1,9 @@
 /**
+ * External dependencies
+ */
+import scrollIntoView from 'dom-scroll-into-view';
+
+/**
  * WordPress dependencies
  */
 import {
@@ -9,6 +14,7 @@ import {
 	placeCaretAtHorizontalEdge,
 	placeCaretAtVerticalEdge,
 	isRTL,
+	getScrollContainer,
 } from '@wordpress/dom';
 import { UP, DOWN, LEFT, RIGHT } from '@wordpress/keycodes';
 import { useDispatch, useSelect } from '@wordpress/data';
@@ -142,11 +148,13 @@ export default function useArrowNav() {
 	const {
 		getMultiSelectedBlocksStartClientId,
 		getMultiSelectedBlocksEndClientId,
+		getPreviousBlockClientId,
+		getNextBlockClientId,
 		getSettings,
 		hasMultiSelection,
 		__unstableIsFullySelected,
 	} = useSelect( blockEditorStore );
-	const { selectBlock } = useDispatch( blockEditorStore );
+	const { selectBlock, multiSelect } = useDispatch( blockEditorStore );
 	return useRefEffect( ( node ) => {
 		// Here a DOMRect is stored while moving the caret vertically so
 		// vertical position of the start position can be restored. This is to
@@ -195,10 +203,6 @@ export default function useArrowNav() {
 			// If there is a multi-selection, the arrow keys should collapse the
 			// selection to the start or end of the selection.
 			if ( hasMultiSelection() ) {
-				if ( shiftKey ) {
-					return;
-				}
-
 				// Only handle if we have a full selection (not a native partial
 				// selection).
 				if ( ! __unstableIsFullySelected() ) {
@@ -207,7 +211,42 @@ export default function useArrowNav() {
 
 				event.preventDefault();
 
-				if ( isReverse ) {
+				if ( shiftKey ) {
+					const selectionStartClientId =
+						getMultiSelectedBlocksStartClientId();
+					const selectionEndClientId =
+						getMultiSelectedBlocksEndClientId();
+					const selectionBeforeEndClientId =
+						getPreviousBlockClientId( selectionEndClientId );
+					const selectionAfterEndClientId =
+						getNextBlockClientId( selectionEndClientId );
+					const nextSelectionEndClientId = isReverse
+						? selectionBeforeEndClientId
+						: selectionAfterEndClientId;
+
+					if ( nextSelectionEndClientId ) {
+						if (
+							selectionStartClientId === nextSelectionEndClientId
+						) {
+							selectBlock( nextSelectionEndClientId );
+						} else {
+							multiSelect(
+								selectionStartClientId,
+								nextSelectionEndClientId
+							);
+							scrollIntoView(
+								node.ownerDocument.getElementById(
+									`block-${ nextSelectionEndClientId }`
+								),
+								getScrollContainer( node ) ||
+									node.ownerDocument.defaultView,
+								{
+									onlyScrollIfNeeded: true,
+								}
+							);
+						}
+					}
+				} else if ( isReverse ) {
 					selectBlock( getMultiSelectedBlocksStartClientId() );
 				} else {
 					selectBlock( getMultiSelectedBlocksEndClientId(), -1 );

--- a/packages/block-editor/src/store/selectors.js
+++ b/packages/block-editor/src/store/selectors.js
@@ -958,11 +958,15 @@ export function __unstableIsSelectionCollapsed( state ) {
 	);
 }
 
+export function __unstableIsBlockMergeable( state, clientId ) {
+	const blockName = getBlockName( state, clientId );
+	const blockType = getBlockType( blockName );
+	return !! blockType.merge;
+}
+
 export function __unstableSelectionHasUnmergeableBlock( state ) {
 	return getSelectedBlockClientIds( state ).some( ( clientId ) => {
-		const blockName = getBlockName( state, clientId );
-		const blockType = getBlockType( blockName );
-		return ! blockType.merge;
+		return ! __unstableIsBlockMergeable( state, clientId );
 	} );
 }
 

--- a/test/e2e/specs/editor/various/multi-block-selection.spec.js
+++ b/test/e2e/specs/editor/various/multi-block-selection.spec.js
@@ -1258,6 +1258,39 @@ test.describe( 'Multi-block selection', () => {
 			.poll( multiBlockSelectionUtils.getSelectedFlatIndices )
 			.toEqual( [ 1, 2 ] );
 	} );
+
+	test( 'should be able to expand "full" block selection', async ( {
+		page,
+		editor,
+		pageUtils,
+	} ) => {
+		await editor.insertBlock( {
+			name: 'core/paragraph',
+			attributes: { content: '1' },
+		} );
+		await editor.insertBlock( {
+			name: 'core/paragraph',
+			attributes: { content: '2' },
+		} );
+		await editor.insertBlock( {
+			name: 'core/list',
+			innerBlocks: [
+				{
+					name: 'core/list-item',
+					attributes: { content: '3' },
+				},
+				{
+					name: 'core/list-item',
+					attributes: { content: '4' },
+				},
+			],
+		} );
+		await page.keyboard.press( 'ArrowDown' );
+		await page.keyboard.press( 'ArrowDown' );
+		await pageUtils.pressKeys( 'Shift+ArrowLeft', { times: 4 } );
+		await page.keyboard.press( 'Backspace' );
+		await expect.poll( editor.getBlocks ).toMatchObject( [] );
+	} );
 } );
 
 class MultiBlockSelectionUtils {


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?

When selection is "full" (not partial), Shift+Arrow Up/Down should expand selection block by block.

## Why?

Currently Shift+Arrow doesn't work at all.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

## Testing Instructions

Select across two blocks that can't be merged, for example the list block and paragraph block. Try to expand selection with the keyboard (Shift+ArrowUp/Down).

## Screenshots or screencast <!-- if applicable -->
