### PR TITLE
Buttons: Add specificity for the editor

### DIFF
--- a/lib/compat/wordpress-6.1/script-loader.php
+++ b/lib/compat/wordpress-6.1/script-loader.php
@@ -130,6 +130,11 @@ add_action( 'wp_enqueue_scripts', 'gutenberg_enqueue_classic_theme_styles' );
  * Loads classic theme styles on classic themes in the editor.
  *
  * This is needed for backwards compatibility for button blocks specifically.
+ *
+ * @since 6.1
+ *
+ * @param array $editor_settings The array of editor settings.
+ * @return array A filtered array of editor settings.
  */
 function gutenberg_add_editor_classic_theme_styles( $editor_settings ) {
 	if ( wp_is_block_theme() ) {

--- a/lib/compat/wordpress-6.1/script-loader.php
+++ b/lib/compat/wordpress-6.1/script-loader.php
@@ -114,7 +114,7 @@ add_action( 'wp_enqueue_scripts', 'gutenberg_enqueue_global_styles' );
 add_action( 'wp_footer', 'gutenberg_enqueue_global_styles', 1 );
 
 /**
- * Loads classic theme styles on classic themes.
+ * Loads classic theme styles on classic themes in the frontend.
  *
  * This is needed for backwards compatibility for button blocks specifically.
  */
@@ -124,16 +124,19 @@ function gutenberg_enqueue_classic_theme_styles() {
 		wp_enqueue_style( 'classic-theme-styles' );
 	}
 }
-// To load classic theme styles on the frontend.
 add_action( 'wp_enqueue_scripts', 'gutenberg_enqueue_classic_theme_styles' );
 
-// To load classic theme styles in the the editor.
-function block_editor_settings_add_classic_theme_styles( $editor_settings ) {
+/**
+ * Loads classic theme styles on classic themes in the editor.
+ *
+ * This is needed for backwards compatibility for button blocks specifically.
+ */
+function gutenberg_add_editor_classic_theme_styles( $editor_settings ) {
 	if ( wp_is_block_theme() ) {
 		return;
 	}
 
-	$classic_theme_styles = gutenberg_dir_path(). '/build/block-library/classic.css';
+	$classic_theme_styles = gutenberg_dir_path() . '/build/block-library/classic.css';
 
 	// This follows the pattern of get_block_editor_theme_styles,
 	// but we can't use get_block_editor_theme_styles directly as it
@@ -147,4 +150,4 @@ function block_editor_settings_add_classic_theme_styles( $editor_settings ) {
 
 	return $editor_settings;
 }
-add_filter( 'block_editor_settings_all', 'block_editor_settings_add_classic_theme_styles' );
+add_filter( 'block_editor_settings_all', 'gutenberg_add_editor_classic_theme_styles' );

--- a/lib/compat/wordpress-6.1/script-loader.php
+++ b/lib/compat/wordpress-6.1/script-loader.php
@@ -129,6 +129,10 @@ add_action( 'wp_enqueue_scripts', 'gutenberg_enqueue_classic_theme_styles' );
 
 // To load classic theme styles in the the editor.
 function block_editor_settings_add_classic_theme_styles( $editor_settings ) {
+	if ( wp_is_block_theme() ) {
+		return;
+	}
+
 	$classic_theme_styles = gutenberg_dir_path(). '/build/block-library/classic.css';
 
 	// This follows the pattern of get_block_editor_theme_styles,

--- a/lib/compat/wordpress-6.1/script-loader.php
+++ b/lib/compat/wordpress-6.1/script-loader.php
@@ -126,5 +126,21 @@ function gutenberg_enqueue_classic_theme_styles() {
 }
 // To load classic theme styles on the frontend.
 add_action( 'wp_enqueue_scripts', 'gutenberg_enqueue_classic_theme_styles' );
+
 // To load classic theme styles in the the editor.
-add_action( 'admin_enqueue_scripts', 'gutenberg_enqueue_classic_theme_styles' );
+function block_editor_settings_add_classic_theme_styles( $editor_settings ) {
+	$classic_theme_styles = gutenberg_dir_path(). '/build/block-library/classic.css';
+
+	// This follows the pattern of get_block_editor_theme_styles,
+	// but we can't use get_block_editor_theme_styles directly as it
+	// only handles external files or theme files.
+	$editor_settings['styles'][] = array(
+		'css'            => file_get_contents( $classic_theme_styles ),
+		'baseURL'        => get_theme_file_uri( $classic_theme_styles ),
+		'__unstableType' => 'theme',
+		'isGlobalStyles' => false,
+	);
+
+	return $editor_settings;
+}
+add_filter( 'block_editor_settings_all', 'block_editor_settings_add_classic_theme_styles' );

--- a/lib/compat/wordpress-6.1/script-loader.php
+++ b/lib/compat/wordpress-6.1/script-loader.php
@@ -138,7 +138,7 @@ add_action( 'wp_enqueue_scripts', 'gutenberg_enqueue_classic_theme_styles' );
  */
 function gutenberg_add_editor_classic_theme_styles( $editor_settings ) {
 	if ( wp_is_block_theme() ) {
-		return;
+		return $editor_settings;
 	}
 
 	$classic_theme_styles = gutenberg_dir_path() . '/build/block-library/classic.css';


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
In https://github.com/WordPress/gutenberg/pull/44334 we added styles for buttons in classic themes, but the styles were added with a global scope, whereas editor styles are usually added with a `.editor-styles-wrapper` selector, which makes them more specific. This changes the way we add the classic theme styles so that they also get wrapped in an `.editor-styles-wrapper` selector, matching the specificity.

## Why?
This ensures that the button styles for classic themes are maintained so they don't lose their styling.

## Testing Instructions
1. Switch to a classic theme (like Twenty Ten)
2. Add a button in the editor
3. Check that the button looks the same as in the frontend (black background with white text and a pill shape in this case)
4. Switch to a block theme
5. Check that the classic theme styles don't load

## Screenshots or screencast <!-- if applicable -->
<img width="717" alt="Screenshot 2022-10-06 at 11 14 52" src="https://user-images.githubusercontent.com/275961/194287811-added912-59ff-42a8-97ed-cc84baa9b2c7.png">

