### PR TITLE
Fixes the placeholder for the navigation link label, to be about the label.

### DIFF
--- a/packages/block-library/src/navigation-link/edit.js
+++ b/packages/block-library/src/navigation-link/edit.js
@@ -467,7 +467,7 @@ export default function NavigationLinkEdit( {
 	const [ popoverAnchor, setPopoverAnchor ] = useState( null );
 	const listItemRef = useRef( null );
 	const isDraggingWithin = useIsDraggingWithin( listItemRef );
-	const itemLabelPlaceholder = __( 'Add link…' );
+	const itemLabelPlaceholder = __( 'Add label…' );
 	const ref = useRef();
 
 	const pagesPermissions = useResourcePermissions( 'pages' );


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Closes #30163

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

Because the current placeholder is misleading.


## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

Fix the label


## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->

1. Create a post
2. Insert a navigation block
3. Add a link in the navigation block
4. From the suggestions pick one or write your URL
5. Delete the label of the created navigation link
6. Notice the proper label

## Screenshots or screencast <!-- if applicable -->

<img width="596" alt="Screenshot 2022-10-06 at 14 05 57" src="https://user-images.githubusercontent.com/107534/194299091-d39a29e2-9822-4a73-ae1e-08837b0c9bb1.png">


