### PR TITLE
Fluid typography for custom font values: scratch pad

### DIFF
--- a/lib/block-supports/typography.php
+++ b/lib/block-supports/typography.php
@@ -72,6 +72,7 @@ function gutenberg_register_typography_support( $block_type ) {
  * @return array Typography CSS classes and inline styles.
  */
 function gutenberg_apply_typography_support( $block_type, $block_attributes ) {
+
 	if ( ! property_exists( $block_type, 'supports' ) ) {
 		return array();
 	}
@@ -108,7 +109,7 @@ function gutenberg_apply_typography_support( $block_type, $block_attributes ) {
 	if ( $has_font_size_support && ! $should_skip_font_size ) {
 		$preset_font_size                    = array_key_exists( 'fontSize', $block_attributes ) ? "var:preset|font-size|{$block_attributes['fontSize']}" : null;
 		$custom_font_size                    = isset( $block_attributes['style']['typography']['fontSize'] ) ? $block_attributes['style']['typography']['fontSize'] : null;
-		$typography_block_styles['fontSize'] = $preset_font_size ? $preset_font_size : $custom_font_size;
+		$typography_block_styles['fontSize'] = $preset_font_size ? $preset_font_size : gutenberg_get_typography_font_size_value( array( 'size' => $custom_font_size ) );
 	}
 
 	if ( $has_font_family_support && ! $should_skip_font_family ) {
@@ -381,7 +382,7 @@ function gutenberg_get_typography_font_size_value( $preset, $should_use_fluid_ty
 	$typography_settings         = gutenberg_get_global_settings( array( 'typography' ) );
 	$should_use_fluid_typography = isset( $typography_settings['fluid'] ) && true === $typography_settings['fluid'] ? true : $should_use_fluid_typography;
 
-	if ( ! $should_use_fluid_typography ) {
+	if ( ! $should_use_fluid_typography || empty( $preset['size'] ) ) {
 		return $preset['size'];
 	}
 

--- a/packages/edit-site/src/components/global-styles/typography-utils.js
+++ b/packages/edit-site/src/components/global-styles/typography-utils.js
@@ -23,7 +23,7 @@
 export function getTypographyFontSizeValue( preset, typographySettings ) {
 	const { size: defaultSize } = preset;
 
-	if ( true !== typographySettings?.fluid ) {
+	if ( true !== typographySettings?.fluid || ! defaultSize ) {
 		return defaultSize;
 	}
 

--- a/test/emptytheme/theme.json
+++ b/test/emptytheme/theme.json
@@ -2,6 +2,9 @@
 	"version": 2,
 	"settings": {
 		"appearanceTools": true,
+		"typography": {
+			"fluid": true
+		},
 		"layout": {
 			"contentSize": "840px",
 			"wideSize": "1100px"


### PR DESCRIPTION
This is junk and just a PR to share code.

Don't merge. 

Don't even look if you don't have to.

Related to https://github.com/WordPress/gutenberg/issues/44758