### PR TITLE
Fluid typography: convert server-side block support values

### DIFF
--- a/lib/block-supports/typography.php
+++ b/lib/block-supports/typography.php
@@ -110,8 +110,7 @@ function gutenberg_apply_typography_support( $block_type, $block_attributes ) {
 		$custom_font_size                    = isset( $block_attributes['style']['typography']['fontSize'] ) ? $block_attributes['style']['typography']['fontSize'] : null;
 		$typography_block_styles['fontSize'] = $preset_font_size ? $preset_font_size : gutenberg_get_typography_font_size_value(
 			array(
-				'size'  => $custom_font_size,
-				'fluid' => true,
+				'size' => $custom_font_size,
 			)
 		);
 	}

--- a/lib/block-supports/typography.php
+++ b/lib/block-supports/typography.php
@@ -108,7 +108,12 @@ function gutenberg_apply_typography_support( $block_type, $block_attributes ) {
 	if ( $has_font_size_support && ! $should_skip_font_size ) {
 		$preset_font_size                    = array_key_exists( 'fontSize', $block_attributes ) ? "var:preset|font-size|{$block_attributes['fontSize']}" : null;
 		$custom_font_size                    = isset( $block_attributes['style']['typography']['fontSize'] ) ? $block_attributes['style']['typography']['fontSize'] : null;
-		$typography_block_styles['fontSize'] = $preset_font_size ? $preset_font_size : $custom_font_size;
+		$typography_block_styles['fontSize'] = $preset_font_size ? $preset_font_size : gutenberg_get_typography_font_size_value(
+			array(
+				'size'  => $custom_font_size,
+				'fluid' => true,
+			)
+		);
 	}
 
 	if ( $has_font_family_support && ! $should_skip_font_family ) {

--- a/packages/block-library/src/navigation-link/index.php
+++ b/packages/block-library/src/navigation-link/index.php
@@ -102,8 +102,7 @@ function block_core_navigation_link_build_css_font_sizes( $context ) {
 			'font-size: %s;',
 			gutenberg_get_typography_font_size_value(
 				array(
-					'size'  => $context['style']['typography']['fontSize'],
-					'fluid' => true,
+					'size' => $context['style']['typography']['fontSize'],
 				)
 			)
 		);

--- a/packages/block-library/src/navigation-link/index.php
+++ b/packages/block-library/src/navigation-link/index.php
@@ -98,7 +98,15 @@ function block_core_navigation_link_build_css_font_sizes( $context ) {
 		$font_sizes['css_classes'][] = sprintf( 'has-%s-font-size', $context['fontSize'] );
 	} elseif ( $has_custom_font_size ) {
 		// Add the custom font size inline style.
-		$font_sizes['inline_styles'] = sprintf( 'font-size: %s;', $context['style']['typography']['fontSize'] );
+		$font_sizes['inline_styles'] = sprintf(
+			'font-size: %s;',
+			gutenberg_get_typography_font_size_value(
+				array(
+					'size'  => $context['style']['typography']['fontSize'],
+					'fluid' => true,
+				)
+			)
+		);
 	}
 
 	return $font_sizes;

--- a/packages/block-library/src/navigation-submenu/index.php
+++ b/packages/block-library/src/navigation-submenu/index.php
@@ -98,7 +98,15 @@ function block_core_navigation_submenu_build_css_font_sizes( $context ) {
 		$font_sizes['css_classes'][] = sprintf( 'has-%s-font-size', $context['fontSize'] );
 	} elseif ( $has_custom_font_size ) {
 		// Add the custom font size inline style.
-		$font_sizes['inline_styles'] = sprintf( 'font-size: %s;', $context['style']['typography']['fontSize'] );
+		$font_sizes['inline_styles'] = sprintf(
+			'font-size: %s;',
+			gutenberg_get_typography_font_size_value(
+				array(
+					'size'  => $context['style']['typography']['fontSize'],
+					'fluid' => true,
+				)
+			)
+		);
 	}
 
 	return $font_sizes;

--- a/packages/block-library/src/navigation-submenu/index.php
+++ b/packages/block-library/src/navigation-submenu/index.php
@@ -102,8 +102,7 @@ function block_core_navigation_submenu_build_css_font_sizes( $context ) {
 			'font-size: %s;',
 			gutenberg_get_typography_font_size_value(
 				array(
-					'size'  => $context['style']['typography']['fontSize'],
-					'fluid' => true,
+					'size' => $context['style']['typography']['fontSize'],
 				)
 			)
 		);

--- a/packages/block-library/src/page-list/index.php
+++ b/packages/block-library/src/page-list/index.php
@@ -123,8 +123,7 @@ function block_core_page_list_build_css_font_sizes( $context ) {
 			'font-size: %s;',
 			gutenberg_get_typography_font_size_value(
 				array(
-					'size'  => $context['style']['typography']['fontSize'],
-					'fluid' => true,
+					'size' => $context['style']['typography']['fontSize'],
 				)
 			)
 		);

--- a/packages/block-library/src/page-list/index.php
+++ b/packages/block-library/src/page-list/index.php
@@ -119,7 +119,15 @@ function block_core_page_list_build_css_font_sizes( $context ) {
 		$font_sizes['css_classes'][] = sprintf( 'has-%s-font-size', $context['fontSize'] );
 	} elseif ( $has_custom_font_size ) {
 		// Add the custom font size inline style.
-		$font_sizes['inline_styles'] = sprintf( 'font-size: %s;', $context['style']['typography']['fontSize'] );
+		$font_sizes['inline_styles'] = sprintf(
+			'font-size: %s;',
+			gutenberg_get_typography_font_size_value(
+				array(
+					'size'  => $context['style']['typography']['fontSize'],
+					'fluid' => true,
+				)
+			)
+		);
 	}
 
 	return $font_sizes;

--- a/packages/block-library/src/search/index.php
+++ b/packages/block-library/src/search/index.php
@@ -381,7 +381,7 @@ function styles_for_block_core_search( $attributes ) {
 	}
 
 	// Get typography styles to be shared across inner elements.
-	$typography_styles = get_typography_styles_for_block_core_search( $attributes );
+	$typography_styles = esc_attr( get_typography_styles_for_block_core_search( $attributes ) );
 	if ( ! empty( $typography_styles ) ) {
 		$label_styles [] = $typography_styles;
 		$button_styles[] = $typography_styles;
@@ -446,7 +446,7 @@ function get_typography_styles_for_block_core_search( $attributes ) {
 			'font-size: %s;',
 			gutenberg_get_typography_font_size_value(
 				array(
-					'size' => esc_attr( $attributes['style']['typography']['fontSize'] ),
+					'size' => $attributes['style']['typography']['fontSize'],
 				)
 			)
 		);
@@ -454,27 +454,27 @@ function get_typography_styles_for_block_core_search( $attributes ) {
 	}
 
 	if ( ! empty( $attributes['style']['typography']['fontFamily'] ) ) {
-		$typography_styles[] = sprintf( 'font-family: %s;', esc_attr( $attributes['style']['typography']['fontFamily'] ) );
+		$typography_styles[] = sprintf( 'font-family: %s;', $attributes['style']['typography']['fontFamily'] );
 	}
 
 	if ( ! empty( $attributes['style']['typography']['letterSpacing'] ) ) {
-		$typography_styles[] = sprintf( 'letter-spacing: %s;', esc_attr( $attributes['style']['typography']['letterSpacing'] ) );
+		$typography_styles[] = sprintf( 'letter-spacing: %s;', $attributes['style']['typography']['letterSpacing'] );
 	}
 
 	if ( ! empty( $attributes['style']['typography']['fontWeight'] ) ) {
-		$typography_styles[] = sprintf( 'font-weight: %s;', esc_attr( $attributes['style']['typography']['fontWeight'] ) );
+		$typography_styles[] = sprintf( 'font-weight: %s;', $attributes['style']['typography']['fontWeight'] );
 	}
 
 	if ( ! empty( $attributes['style']['typography']['fontStyle'] ) ) {
-		$typography_styles[] = sprintf( 'font-style: %s;', esc_attr( $attributes['style']['typography']['fontStyle'] ) );
+		$typography_styles[] = sprintf( 'font-style: %s;', $attributes['style']['typography']['fontStyle'] );
 	}
 
 	if ( ! empty( $attributes['style']['typography']['lineHeight'] ) ) {
-		$typography_styles[] = sprintf( 'line-height: %s;', esc_attr( $attributes['style']['typography']['lineHeight'] ) );
+		$typography_styles[] = sprintf( 'line-height: %s;', $attributes['style']['typography']['lineHeight'] );
 	}
 
 	if ( ! empty( $attributes['style']['typography']['textTransform'] ) ) {
-		$typography_styles[] = sprintf( 'text-transform: %s;', esc_attr( $attributes['style']['typography']['textTransform'] ) );
+		$typography_styles[] = sprintf( 'text-transform: %s;', $attributes['style']['typography']['textTransform'] );
 	}
 
 	return implode( '', $typography_styles );

--- a/packages/block-library/src/search/index.php
+++ b/packages/block-library/src/search/index.php
@@ -442,7 +442,16 @@ function get_typography_styles_for_block_core_search( $attributes ) {
 
 	// Add typography styles.
 	if ( ! empty( $attributes['style']['typography']['fontSize'] ) ) {
-		$typography_styles[] = sprintf( 'font-size: %s;', esc_attr( $attributes['style']['typography']['fontSize'] ) );
+		$typography_styles[] = sprintf(
+			'font-size: %s;',
+			gutenberg_get_typography_font_size_value(
+				array(
+					'size'  => esc_attr( $attributes['style']['typography']['fontSize'] ),
+					'fluid' => true,
+				)
+			)
+		);
+
 	}
 
 	if ( ! empty( $attributes['style']['typography']['fontFamily'] ) ) {

--- a/packages/block-library/src/search/index.php
+++ b/packages/block-library/src/search/index.php
@@ -446,8 +446,7 @@ function get_typography_styles_for_block_core_search( $attributes ) {
 			'font-size: %s;',
 			gutenberg_get_typography_font_size_value(
 				array(
-					'size'  => esc_attr( $attributes['style']['typography']['fontSize'] ),
-					'fluid' => true,
+					'size' => esc_attr( $attributes['style']['typography']['fontSize'] ),
 				)
 			)
 		);


### PR DESCRIPTION
Parent issue:

- https://github.com/WordPress/gutenberg/issues/44758

## What?

Let's do this! 🕺 

For server  rendered typography block support styles, covert font size values to fluid values in the inline styles if fluid typography is activated.

❗ This has effect on the frontend only and not the editor.

## Why?

Fluid typography for **font size presets** was added in https://github.com/WordPress/gutenberg/pull/39529

However, custom font sizes should also be automatically converted to fluid values. This is a bug.

## How?
Using the existing `gutenberg_get_typography_font_size_value()` function.

## Testing Instructions

Run `npm run test:unit:php -- --filter WP_Block_Supports_Typography_Test`

Enable fluid typography via theme.json
<details>

<summary>Here is some test theme.json</summary>

```json

{
	"version": 2,
	"settings": {
		"appearanceTools": true,
		"typography": {
			"fluid": true
		}
	}
}

```

</details>


Testing in the post and site editors, add a Site Title block

<details>

<summary>Here is some example HTML</summary>

```html
<!-- wp:site-title {"style":{"typography":{"fontSize":"62px"}}} /-->

```

</details>


Apply a custom font size to the block and publish the page

<img width="270" alt="Screen Shot 2022-10-07 at 12 33 05 pm" src="https://user-images.githubusercontent.com/6458278/194447581-f639497d-821d-4288-b5cd-84e335e5cec4.png">

In the frontend, check that the inline font size style value has been converted to fluid

<img width="860" alt="Screen Shot 2022-10-07 at 11 44 15 am" src="https://user-images.githubusercontent.com/6458278/194447599-d2aac4d0-293e-487c-96b0-4f617d572441.png">

https://user-images.githubusercontent.com/6458278/194447642-01caf387-22ac-4acd-92a0-69fe09fca59f.mp4

