### PR TITLE
Fluid typography: convert font size inline style attributes to fluid values

### DIFF
--- a/lib/block-supports/typography.php
+++ b/lib/block-supports/typography.php
@@ -236,7 +236,11 @@ function gutenberg_typography_get_css_variable_inline_style( $attributes, $featu
  * @return string                Filtered block content.
  */
 function gutenberg_render_typography_support( $block_content, $block ) {
-	$custom_font_size = isset( $block['attrs']['style']['typography']['fontSize'] ) ? $block['attrs']['style']['typography']['fontSize'] : null;
+	if ( ! isset( $block['attrs']['style']['typography']['fontSize'] ) ) {
+		return $block_content;
+	}
+
+	$custom_font_size = $block['attrs']['style']['typography']['fontSize'];
 	$fluid_font_size  = gutenberg_get_typography_font_size_value( array( 'size' => $custom_font_size ) );
 
 	/*

--- a/lib/block-supports/typography.php
+++ b/lib/block-supports/typography.php
@@ -262,8 +262,8 @@ function gutenberg_render_typography_support( $block_content, $block ) {
  *
  * @access private
  *
- * @param string $raw_value Raw size value from theme.json.
- * @param array  $options   {
+ * @param string|number $raw_value Raw size value from theme.json.
+ * @param array         $options   {
  *     Optional. An associative array of options. Default is empty array.
  *
  *     @type string        $coerce_to        Coerce the value to rem or px. Default `'rem'`.

--- a/lib/block-supports/typography.php
+++ b/lib/block-supports/typography.php
@@ -239,7 +239,12 @@ function gutenberg_render_typography_support( $block_content, $block ) {
 	$custom_font_size = isset( $block['attrs']['style']['typography']['fontSize'] ) ? $block['attrs']['style']['typography']['fontSize'] : null;
 	$fluid_font_size  = gutenberg_get_typography_font_size_value( array( 'size' => $custom_font_size ) );
 
+	/*
+	 * Checks that $fluid_font_size does not match $custom_font_size,
+	 * which means it's been mutated by the fluid font size functions.
+	 */
 	if ( ! empty( $fluid_font_size ) && $fluid_font_size !== $custom_font_size ) {
+		// Replaces the first instance of `font-size:$custom_font_size` with `font-size:$fluid_font_size`.
 		return preg_replace( '/font-size\s*:\s*' . preg_quote( $custom_font_size, '/' ) . '\s*;?/', 'font-size:' . esc_attr( $fluid_font_size ) . ';', $block_content, 1 );
 	}
 

--- a/phpunit/block-supports/typography-test.php
+++ b/phpunit/block-supports/typography-test.php
@@ -340,6 +340,24 @@ class WP_Block_Supports_Typography_Test extends WP_UnitTestCase {
 				'expected_output'             => '28px',
 			),
 
+			'default_return_value_when_value_is_already_clamped' => array(
+				'font_size_preset'            => array(
+					'size'  => 'clamp(21px, 1.3125rem + ((1vw - 7.68px) * 2.524), 42px)',
+					'fluid' => false,
+				),
+				'should_use_fluid_typography' => true,
+				'expected_output'             => 'clamp(21px, 1.3125rem + ((1vw - 7.68px) * 2.524), 42px)',
+			),
+
+			'default_return_value_with_unsupported_unit'   => array(
+				'font_size_preset'            => array(
+					'size'  => '1000%',
+					'fluid' => false,
+				),
+				'should_use_fluid_typography' => true,
+				'expected_output'             => '1000%',
+			),
+
 			'return_fluid_value'                           => array(
 				'font_size_preset'            => array(
 					'size' => '1.75rem',

--- a/phpunit/data/themedir1/block-theme-child-with-fluid-typography/theme.json
+++ b/phpunit/data/themedir1/block-theme-child-with-fluid-typography/theme.json
@@ -1,0 +1,9 @@
+{
+	"version": 2,
+	"settings": {
+		"appearanceTools": true,
+		"typography": {
+			"fluid": true
+		}
+	}
+}


### PR DESCRIPTION
Parent issue:

- https://github.com/WordPress/gutenberg/issues/44758

## What?
This commit ensures that custom font size values that appear in the style attribute of block content are converted to fluid typography (if activated)

## Why?
Fluid typography for font size presets was added in https://github.com/WordPress/gutenberg/pull/39529

However, custom font sizes should also be automatically converted to fluid values. This is a bug

## How?
By adding a filter to the `render_block` hook, then replacing the custom font size via a regex.

## Testing Instructions

Enable fluid typography via theme.json
<details>

<summary>Example theme.json</summary>

```json
{
	"version": 2,
	"settings": {
		"appearanceTools": true,
		"typography": {
			"fluid": true
		}
	}
}


```

</details>

Testing in the post and site editors, add a few blocks that have typography support, e.g., text blocks, Group, Columns... there are many 😄 

<details>

<summary>Example block HTML</summary>

```html
<!-- wp:paragraph {"style":{"typography":{"fontSize":"2em"}}} -->
<p style="font-size:2em">This is a paragraph</p>
<!-- /wp:paragraph -->

<!-- wp:heading {"style":{"typography":{"fontSize":"4rem","fontStyle":"normal","fontWeight":"600","textTransform":"capitalize","letterSpacing":"29px","textDecoration":"underline"},"spacing":{"padding":{"top":"var:preset|spacing|50","right":"var:preset|spacing|50","bottom":"var:preset|spacing|50","left":"var:preset|spacing|50"},"margin":{"top":"var:preset|spacing|60","right":"var:preset|spacing|60","bottom":"var:preset|spacing|60","left":"var:preset|spacing|60"}},"elements":{"link":{"color":{"text":"var:preset|color|vivid-purple"}}}},"backgroundColor":"vivid-red"} -->
<h2 class="has-vivid-red-background-color has-background has-link-color" style="margin-top:var(--wp--preset--spacing--60);margin-right:var(--wp--preset--spacing--60);margin-bottom:var(--wp--preset--spacing--60);margin-left:var(--wp--preset--spacing--60);padding-top:var(--wp--preset--spacing--50);padding-right:var(--wp--preset--spacing--50);padding-bottom:var(--wp--preset--spacing--50);padding-left:var(--wp--preset--spacing--50);font-size:4rem;font-style:normal;font-weight:600;letter-spacing:29px;text-decoration:underline;text-transform:capitalize">This is a heading</h2>
<!-- /wp:heading -->

<!-- wp:group {"style":{"typography":{"fontSize":"1em"}},"layout":{"type":"constrained"}} -->
<div class="wp-block-group" style="font-size:1em"><!-- wp:paragraph {"style":{"typography":{"fontSize":"1em"}}} -->
<p style="font-size:1em">A paragraph inside a group</p>
<!-- /wp:paragraph -->

<!-- wp:search {"label":"Search","buttonText":"Search","style":{"typography":{"fontSize":"52px"}}} /--></div>
<!-- /wp:group -->

<!-- wp:paragraph -->
<p></p>
<!-- /wp:paragraph -->

<!-- wp:buttons {"style":{"typography":{"fontSize":"47px"}}} -->
<div class="wp-block-buttons has-custom-font-size" style="font-size:47px"><!-- wp:button -->
<div class="wp-block-button"><a class="wp-block-button__link wp-element-button">Test button</a></div>
<!-- /wp:button --></div>
<!-- /wp:buttons -->

```

</details>

For these blocks, add a custom value via the UI control  and publish the page

<img width="271" alt="Screen Shot 2022-10-07 at 4 07 33 pm" src="https://user-images.githubusercontent.com/6458278/194472011-5e757786-ec40-4736-a265-114de4849eea.png">

In the frontend, check that the inline font size style values for these blocks have been converted to fluid

### Before
<img width="784" alt="Screen Shot 2022-10-07 at 4 09 18 pm" src="https://user-images.githubusercontent.com/6458278/194472281-2185f454-9251-438c-81d0-d3ffd4ccd278.png">

### After
<img width="1198" alt="Screen Shot 2022-10-07 at 4 08 59 pm" src="https://user-images.githubusercontent.com/6458278/194472277-3f4d9c97-7e3e-4f48-b49f-60813737d96a.png">



