### PR TITLE
Try nested patterns previews

### DIFF
--- a/packages/block-editor/src/components/block-preview/index.js
+++ b/packages/block-editor/src/components/block-preview/index.js
@@ -28,15 +28,21 @@ export function BlockPreview( {
 	__experimentalOnClick,
 	__experimentalMinHeight,
 } ) {
-	const originalSettings = useSelect(
-		( select ) => select( blockEditorStore ).getSettings(),
-		[]
+	const { originalSettings, patterns } = useSelect( ( select ) => {
+		const { getSettings, __experimentalGetAllowedPatterns } =
+			select( blockEditorStore );
+		return {
+			originalSettings: getSettings(),
+			patterns: __experimentalGetAllowedPatterns(),
+		};
+	}, [] );
+	const settings = useMemo(
+		() => ( {
+			...originalSettings,
+			__experimentalBlockPatterns: patterns,
+		} ),
+		[ originalSettings, patterns ]
 	);
-	const settings = useMemo( () => {
-		const _settings = { ...originalSettings };
-		_settings.__experimentalBlockPatterns = [];
-		return _settings;
-	}, [ originalSettings ] );
 	const renderedBlocks = useMemo( () => castArray( blocks ), [ blocks ] );
 	if ( ! blocks || blocks.length === 0 ) {
 		return null;
@@ -90,15 +96,22 @@ export function useBlockPreview( {
 	props = {},
 	__experimentalLayout,
 } ) {
-	const originalSettings = useSelect(
-		( select ) => select( blockEditorStore ).getSettings(),
-		[]
-	);
 	const disabledRef = useDisabled();
 	const ref = useMergeRefs( [ props.ref, disabledRef ] );
+	const { originalSettings, patterns } = useSelect( ( select ) => {
+		const { getSettings, __experimentalGetAllowedPatterns } =
+			select( blockEditorStore );
+		return {
+			originalSettings: getSettings(),
+			patterns: __experimentalGetAllowedPatterns(),
+		};
+	}, [] );
 	const settings = useMemo(
-		() => ( { ...originalSettings, __experimentalBlockPatterns: [] } ),
-		[ originalSettings ]
+		() => ( {
+			...originalSettings,
+			__experimentalBlockPatterns: patterns,
+		} ),
+		[ originalSettings, patterns ]
 	);
 	const renderedBlocks = useMemo( () => castArray( blocks ), [ blocks ] );
 

--- a/packages/block-editor/src/store/selectors.js
+++ b/packages/block-editor/src/store/selectors.js
@@ -2249,6 +2249,11 @@ export const __experimentalGetParsedPattern = createSelector(
 		if ( ! pattern ) {
 			return null;
 		}
+		// In previews we pass the already passed patterns
+		// to avoid parsing again.
+		if ( pattern.blocks ) {
+			return { ...pattern };
+		}
 		return {
 			...pattern,
 			blocks: parse( pattern.content, {

--- a/packages/block-library/src/pattern/edit.js
+++ b/packages/block-library/src/pattern/edit.js
@@ -26,10 +26,17 @@ const PatternEdit = ( { attributes, clientId } ) => {
 	// It will continue to pull from the pattern file unless changes are made to its respective template part.
 	useEffect( () => {
 		if ( selectedPattern?.blocks ) {
-			__unstableMarkNextChangeAsNotPersistent();
-			replaceBlocks( clientId, selectedPattern.blocks );
+			// We batch updates to block list settings to avoid triggering cascading renders
+			// for each container block included in a tree and optimize initial render.
+			// Since the above uses microtasks, we need to use a microtask here as well,
+			// because nested pattern blocks cannot be inserted if the parent block supports
+			// inner blocks but doesn't have blockSettings in the state.
+			window.queueMicrotask( () => {
+				__unstableMarkNextChangeAsNotPersistent();
+				replaceBlocks( clientId, selectedPattern.blocks );
+			} );
 		}
-	}, [ selectedPattern?.blocks ] );
+	}, [ clientId, selectedPattern?.blocks ] );
 
 	const props = useBlockProps();
 


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
An attempt to fix: https://github.com/WordPress/gutenberg/issues/39732
Alternative to: https://github.com/WordPress/gutenberg/pull/42832

## Why?
In every block editor instance inside the `BlockList` we use `usePreParsePatterns` for better performance to preparse the available patterns. This means we would need to parse them for every block preview that loads a new editor. Previously we were just setting an empty array to the available block patterns and now I'm passing the already parsed patterns, with an additional check not to parse a patterns if contains the `blocks` property.

<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

## Testing Instructions
1. Make sure pattern blocks work as before in general and no regression have been introduced
2. Register a pattern like this:
```
register_block_pattern( 'demo-pattern', array(
	'title'      => __( 'Nested patterns', 'twentytwentytwo' ),
	'categories' => array( 'text' ),
	'content' => '<!-- wp:group {"layout":{"type":"constrained"}} -->
	<div class="wp-block-group"><!-- wp:heading -->
	<h2>nested pattern</h2>
	<!-- /wp:heading --><!-- wp:pattern {"slug":"twentytwentytwo/header-large-dark"} /-->
	<!-- wp:pattern {"slug":"twentytwentytwo/general-list-events"} /--></div>
	<!-- /wp:group --><!-- wp:heading -->
	<h2>After group</h2>
	<!-- /wp:heading -->'
 ) );
```
3. Open the inserter and see the preview

