### PR TITLE
Site editor outlines: Try no outlines on block hover

### DIFF
--- a/packages/block-editor/src/components/block-content-overlay/style.scss
+++ b/packages/block-editor/src/components/block-content-overlay/style.scss
@@ -1,3 +1,12 @@
+@keyframes click-overlay__fade-in-animation {
+	from {
+		opacity: 0;
+	}
+	to {
+		opacity: 1;
+	}
+}
+
 .block-editor-block-list__block.has-block-overlay {
 	cursor: default;
 
@@ -21,6 +30,11 @@
 	&:hover:not(.is-dragging-blocks)::before {
 		background: rgba(var(--wp-admin-theme-color--rgb), 0.3);
 		box-shadow: 0 0 0 $border-width var(--wp-admin-theme-color) inset;
+
+		// Animate.
+		animation: click-overlay__fade-in-animation 0.1s ease-out;
+		animation-fill-mode: forwards;
+		@include reduce-motion("animation");
 	}
 
 	&.is-selected:not(.is-dragging-blocks)::before {

--- a/packages/block-editor/src/components/block-list/style.scss
+++ b/packages/block-editor/src/components/block-list/style.scss
@@ -266,7 +266,8 @@
 	}
 }
 
-.is-outline-mode .block-editor-block-list__block:not(.remove-outline) {
+// Show hover borders (née "outline-mode") in navigate-mode.
+.is-navigate-mode .block-editor-block-list__block:not(.remove-outline) {
 	&.is-hovered {
 		cursor: default;
 


### PR DESCRIPTION
## What?

This PR does two things:

1. It adds a small animation to the "click overlay" present when selecting a template part.
2. It removes hover outlines entirely from the site editor keeping them only in select mode.

Before, hovering anything showed boundaries with a 1px border:

![before](https://user-images.githubusercontent.com/1204802/194537795-a390ab5f-9711-4c1e-9fe1-8571f6ba1098.gif)

After, these are only present in select mode:

![after](https://user-images.githubusercontent.com/1204802/194537569-d13ad0ca-748d-44fd-8e9f-d36cb1038c7c.gif)

## Why?

This is a draft PR to find out whether the experience is better without the hover outlines or not. A separate PR will explore a different treatment for these outlines.

## Testing Instructions

Open the site editor, hover various blocks. There should be no outline unless you enter select mode.