### PR TITLE
Site editor outlines: try subtle outlines on block hover

### DIFF
--- a/packages/block-editor/src/components/block-content-overlay/style.scss
+++ b/packages/block-editor/src/components/block-content-overlay/style.scss
@@ -1,3 +1,12 @@
+@keyframes click-overlay__fade-in-animation {
+	from {
+		opacity: 0;
+	}
+	to {
+		opacity: 1;
+	}
+}
+
 .block-editor-block-list__block.has-block-overlay {
 	cursor: default;
 
@@ -21,6 +30,11 @@
 	&:hover:not(.is-dragging-blocks)::before {
 		background: rgba(var(--wp-admin-theme-color--rgb), 0.3);
 		box-shadow: 0 0 0 $border-width var(--wp-admin-theme-color) inset;
+
+		// Animate.
+		animation: click-overlay__fade-in-animation 0.1s ease-out;
+		animation-fill-mode: forwards;
+		@include reduce-motion("animation");
 	}
 
 	&.is-selected:not(.is-dragging-blocks)::before {

--- a/packages/block-editor/src/components/block-list/style.scss
+++ b/packages/block-editor/src/components/block-list/style.scss
@@ -278,7 +278,7 @@
 			left: $border-width;
 			right: $border-width;
 			bottom: $border-width;
-			box-shadow: 0 0 0 $border-width var(--wp-admin-theme-color);
+			box-shadow: 0 0 0 0.5px var(--wp-admin-theme-color);
 			border-radius: $radius-block-ui - $border-width;
 		}
 	}


### PR DESCRIPTION
## What?

Alternative to #44774. This PR does two things:

1. It adds a small animation to the "click overlay" present when selecting a template part.
2. It changes the appearance of hover outlines to be thin `currentColor` versions. In being the same color as the text, and being thin, they are more subtle and less noisy.

Before, hovering anything showed boundaries with a 1px border:

![before](https://user-images.githubusercontent.com/1204802/194537795-a390ab5f-9711-4c1e-9fe1-8571f6ba1098.gif)

After, subtler hover styles:

![after](https://user-images.githubusercontent.com/1204802/194538973-03ecc424-ac68-46cb-b454-8796fb2c2be3.gif)

## Why?

This is a draft PR to find out whether the experience is better with keeping the hover outlines, but making them less noisy. See also #44774.

## Testing Instructions

Open the site editor, hover various blocks. There should be text-color thin outlines when hovering blocks.