### PR TITLE
Navigation: Simplify navigation message.

### DIFF
--- a/packages/block-library/src/navigation/edit/index.js
+++ b/packages/block-library/src/navigation/edit/index.js
@@ -773,17 +773,7 @@ function Navigation( {
 						</Button>
 					</PanelBody>
 				</InspectorControls>
-				<Warning>
-					{ __(
-						'Navigation menu has been deleted or is unavailable. '
-					) }
-					<Button
-						onClick={ createUntitledEmptyNavigationMenu }
-						variant="link"
-					>
-						{ __( 'Create a new menu?' ) }
-					</Button>
-				</Warning>
+				<Warning>{ __( 'Menu missing.' ) }</Warning>
 			</TagName>
 		);
 	}


### PR DESCRIPTION
## What?

Simplifies the message showing when a navigation menu has been deleted, to just "Menu missing."

<img width="715" alt="Screenshot 2022-10-07 at 14 50 15" src="https://user-images.githubusercontent.com/1204802/194557899-638e2d03-7866-41be-955c-67836446e456.png">

In trunk, it's a longer message that wraps and rarely fits in the header where the navigation commonly rests:

<img width="796" alt="Screenshot 2022-10-07 at 14 51 55" src="https://user-images.githubusercontent.com/1204802/194558081-86604470-f26a-4cd9-bfbc-01ae2594881f.png">

The canvas itself is not a great place to show error messages. If we need to add more context, the inspector is a great place for it. 

## Testing Instructions

Create a custom menu, then delete it, and observe the message. 