### PR TITLE
Fix the block toolbar styling when the 'Show button text labels' preference is enabled

### DIFF
--- a/packages/block-editor/src/components/block-mover/style.scss
+++ b/packages/block-editor/src/components/block-mover/style.scss
@@ -6,7 +6,6 @@
 	@include break-small() {
 		.block-editor-block-mover:not(.is-horizontal) & {
 			flex-direction: column;
-			width: $block-toolbar-height - $grid-unit-15;
 
 			> * {
 				height: $block-toolbar-height * 0.5;

--- a/packages/block-editor/src/components/block-toolbar/style.scss
+++ b/packages/block-editor/src/components/block-toolbar/style.scss
@@ -137,20 +137,6 @@
 		padding-right: 6px;
 	}
 
-	// Switcher overrides.
-	.block-editor-block-switcher {
-		border-right: 1px solid $gray-900;
-		padding-right: 6px;
-
-		.components-dropdown-menu__toggle {
-			margin-left: 0;
-		}
-	}
-
-	.block-editor-block-contextual-toolbar.is-fixed .block-editor-block-switcher {
-		border-right-color: $gray-200;
-	}
-
 	.block-editor-block-switcher .components-dropdown-menu__toggle,
 	.block-editor-block-switcher__no-switcher-icon {
 		.block-editor-block-icon {
@@ -173,8 +159,14 @@
 
 	// Mover overrides.
 	.block-editor-block-toolbar__block-controls .block-editor-block-mover {
-		margin-left: 0;
+		border-left: 1px solid $gray-900;
+		margin-left: 6px;
+		margin-right: -6px;
 		white-space: nowrap;
+	}
+
+	.block-editor-block-contextual-toolbar.is-fixed .block-editor-block-toolbar__block-controls .block-editor-block-mover {
+		border-left-color: $gray-200;
 	}
 
 	.block-editor-block-mover-button {
@@ -186,10 +178,6 @@
 	.block-editor-block-mover__drag-handle.has-icon {
 		padding-left: 12px !important;
 		padding-right: 12px !important;
-	}
-
-	.block-editor-block-mover__move-button-container {
-		padding-left: 6px;
 	}
 
 	.block-editor-block-contextual-toolbar.is-fixed .block-editor-block-mover__move-button-container {
@@ -212,8 +200,6 @@
 				display: block;
 				height: 1px;
 				background: $gray-900;
-				width: calc(100% + 12px);
-				margin: 0 -6px;
 				order: 2;
 			}
 		}

--- a/packages/block-editor/src/components/block-toolbar/style.scss
+++ b/packages/block-editor/src/components/block-toolbar/style.scss
@@ -148,7 +148,7 @@
 	}
 
 	.block-editor-block-contextual-toolbar.is-fixed .block-editor-block-switcher {
-		border-right-color: $gray-300;
+		border-right-color: $gray-200;
 	}
 
 	.block-editor-block-switcher .components-dropdown-menu__toggle,

--- a/packages/block-editor/src/components/block-toolbar/style.scss
+++ b/packages/block-editor/src/components/block-toolbar/style.scss
@@ -140,10 +140,15 @@
 	// Switcher overrides.
 	.block-editor-block-switcher {
 		border-right: 1px solid $gray-900;
+		padding-right: 6px;
 
 		.components-dropdown-menu__toggle {
 			margin-left: 0;
 		}
+	}
+
+	.block-editor-block-contextual-toolbar.is-fixed .block-editor-block-switcher {
+		border-right-color: $gray-300;
 	}
 
 	.block-editor-block-switcher .components-dropdown-menu__toggle,
@@ -162,6 +167,10 @@
 		}
 	}
 
+	.block-editor-block-mover:not(.is-horizontal) .block-editor-block-mover__move-button-container {
+		width: auto;
+	}
+
 	// Mover overrides.
 	.block-editor-block-toolbar__block-controls .block-editor-block-mover {
 		margin-left: 0;
@@ -175,17 +184,46 @@
 	}
 
 	.block-editor-block-mover__drag-handle.has-icon {
-		padding-left: 6px !important;
-		padding-right: 6px !important;
-		border-right: 1px solid $gray-900;
+		padding-left: 12px !important;
+		padding-right: 12px !important;
+	}
+
+	.block-editor-block-mover__move-button-container {
+		padding-left: 6px;
+	}
+
+	.block-editor-block-contextual-toolbar.is-fixed .block-editor-block-mover__move-button-container {
+		border-width: 0;
 	}
 
 	@include break-small() {
 		// Specificity override for https://github.com/WordPress/gutenberg/blob/try/block-toolbar-labels/packages/block-editor/src/components/block-mover/style.scss#L69
 		.is-up-button.is-up-button.is-up-button {
-			border-bottom: 1px solid $gray-900;
 			margin-right: 0;
 			border-radius: 0;
+			order: 1;
+		}
+
+		.block-editor-block-mover__move-button-container {
+			border-left: 1px solid $gray-900;
+
+			&::before {
+				content: "";
+				display: block;
+				height: 1px;
+				background: $gray-900;
+				width: calc(100% + 12px);
+				margin: 0 -6px;
+				order: 2;
+			}
+		}
+
+		.is-down-button.is-down-button.is-down-button {
+			order: 3;
+		}
+
+		.block-editor-block-contextual-toolbar.is-fixed .block-editor-block-mover__move-button-container::before {
+			background: $gray-300;
 		}
 	}
 


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->
When the 'Show button text labels' preference is enabled, the block toolbar styling is broken:
- The mover buttons have a fixed width and their text is too long to be container within the button.
- Padding on some buttons / groups is uneven.
- When the toolbar becomes 'fixed', either via the dedicated preference or in the responsive view, soem borders have a wrong color.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
- The mover buttons text is hard to read because it overlaps the gray borders. his is also an accessibility issue.
- Buttons should have a consistent visual spacing.
- Styling should be consistent, see the wrong border colors when thee toolbar is fixed.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
- Most of the CSS changes apply only when the 'Show button text labels' preference is enabled, as they use the CSS selector `.show-icon-labels`.
- Note: I used the CSS property `order` which is generally not recommended for accessibility. However, in this case it only changes the position of the CSS pseudo element used as border below the 'Move up' button so it doesn't affect the order of the content. The buttons order is unchanged.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->
- Edit a post.
- Go to Options > Preferences, and enable 'Show button text labels'.
- Select a block to make its toolbar appear.
- Check the mover buttons have now sufficient space for their text.
- Check the spacing between buttons and groups is improved.
- Check with various viewport widths.
- When the toolbar is fixed, check all the color of all borders is a lighter gray.
- Disable the 'Show button text labels' preference.
- Check the toolbar buttons styling is unchanged. Check at various viewport widths.
- Go to the site editor and repeat the steps above.

## Screenshots or screencast <!-- if applicable -->

**Before:**
- Mover buttons don't contain their text.
- Horizontal spacing is uneven.

<img width="698" alt="before" src="https://user-images.githubusercontent.com/1682452/194558172-c860a566-e2af-48a5-83f4-b051098354ca.png">

- when the toolbar is fixed, a couple borders have a wrong color:

<img width="852" alt="wrong borders color when fixed" src="https://user-images.githubusercontent.com/1682452/194558318-90adae52-4fa6-4f3e-bd66-47d70358ee95.png">

**After:**

<img width="707" alt="after" src="https://user-images.githubusercontent.com/1682452/194558376-f30270e1-cff1-41a2-99f8-40dcfc67c8a9.png">
