### PR TITLE
Zoomed out view: keep list view open when entering mode

### DIFF
--- a/packages/edit-site/src/components/header/index.js
+++ b/packages/edit-site/src/components/header/index.js
@@ -205,7 +205,6 @@ export default function Header( {
 									label={ __( 'Zoom-out View' ) }
 									onClick={ () => {
 										setPreviewDeviceType( 'desktop' );
-										setIsListViewOpened( false );
 										__unstableSetEditorMode(
 											isZoomedOutView
 												? 'edit'


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Fixes: https://github.com/WordPress/gutenberg/issues/44655
<!-- In a few words, what is the PR actually doing? -->


## Testing Instructions
1. Turn on the zoomed out view experiment in Gutenberg > Experiment.
2. Go to Appearance > Site Editor.
3. Open List view.
4. Click the zoomed out view mode.
5. Observe that the list view remains open
