### PR TITLE
Avoid PHP warning when getting dynamic template data

### DIFF
--- a/lib/compat/wordpress-6.1/block-template-utils.php
+++ b/lib/compat/wordpress-6.1/block-template-utils.php
@@ -290,7 +290,7 @@ function _gutenberg_build_title_and_description_for_single_post_type_block_templ
 	);
 	$template->description = sprintf(
 		// translators: Represents the description of a user's custom template in the Site Editor, e.g. "Template for Page: Hello".
-		__( 'Template for %$s', 'gutenberg' ),
+		__( 'Template for %s', 'gutenberg' ),
 		$post_title
 	);
 


### PR DESCRIPTION
## What?
PR fixes the following warning generated by `_gutenberg_build_title_and_description_for_single_post_type_block_template`.

```
PHP Warning:  sprintf(): Argument number must be greater than zero
```
## Why?
The `sprintf` argument number specifier must have a number - https://3v4l.org/EHGss

## How?
Remove the number specifier; the string has only one placeholder.

## Testing Instructions
1. Open a Site Editor
2. Confirm the warning isn't logged or displayed.
