### PR TITLE
Update versions in WordPress documentation for 6.1

### DIFF
--- a/docs/contributors/versions-in-wordpress.md
+++ b/docs/contributors/versions-in-wordpress.md
@@ -6,6 +6,7 @@ If anything looks incorrect here, please bring it up in #core-editor in [WordPre
 
 | Gutenberg Versions | WordPress Version |
 | ------------------ | ----------------- |
+| 13.1-14.1          | 6.1               |
 | 12.0-13.0          | 6.0.2             |
 | 12.0-13.0          | 6.0.1             |
 | 12.0-13.0          | 6.0               |


### PR DESCRIPTION
## What?

This updates versions in WordPress for 6.1 ahead of RC1 when folks are likely to turn their attention to what's in this release.

## Why?

To give folks information about what's planned for 6.1 from the Gutenberg plugin.
