### PR TITLE
Button component: Fix RTL alignment when containing icon and text

### DIFF
--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -6,6 +6,10 @@
 
 -   `BoxControl` & `CustomSelectControl`: Add `onMouseOver` and `onMouseOut` callback props to allow handling of these events by parent components ([#44955](https://github.com/WordPress/gutenberg/pull/44955))
 
+### Bug Fix
+
+-   `Button`: Fix RTL alignment for buttons containing an icon and text ([#44787](https://github.com/WordPress/gutenberg/pull/44787)).
+
 ## 21.3.0 (2022-10-19)
 
 ### Bug Fix

--- a/packages/components/src/button/style.scss
+++ b/packages/components/src/button/style.scss
@@ -315,7 +315,7 @@
 		}
 
 		&.has-text {
-			justify-content: left;
+			justify-content: start;
 		}
 
 		&.has-text svg {


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->
This fixes the RTL alignment inside the Button component for buttons with both an icon and text.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
The `.components-button.has-icon.has-text` style had a `justify-content: left`, because of which the button contents were always left-aligned, even in RTL languages. 

This effect normally isn't visible because the buttons aren't wide enough. But it became apparent in Calypso: when opening the block editor's sidebar, the "View Posts" button is actually a wider one: 

![image](https://user-images.githubusercontent.com/75777864/194639358-6421582f-918b-4981-8435-c735db486cd1.png)

For this button, the problem with the alignment for RTL languages is visible: 

![image](https://user-images.githubusercontent.com/75777864/194639403-b826d649-f810-4bad-b3cb-312ea46c518e.png)

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
This PR changes the `justify-content` from `left` to `start`, which works for both LTR and RTL languages.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->
1. Replace the content of any block's `edit.js` with the following — some extra width has been added to the button to be able to see the effect of the alignment:
```js
/**
 * WordPress dependencies
 */
import { useBlockProps } from '@wordpress/block-editor';
import { Button } from '@wordpress/components';
import { plusCircle } from '@wordpress/icons';

export default function CodeEdit( { attributes, setAttributes, onRemove } ) {
	const blockProps = useBlockProps();
	return (
		<div { ...blockProps }>
			<Button variant="primary" icon={ plusCircle } style={{ width: 200 }}>
				Hello
			</Button>
		</div>
	);
}
```

2. Switch to an RTL language, edit a post, add the block you replaced, and confirm that the button contents are now right-aligned.
3. Switch to an LTR language, edit a post, add the block you replaced, and confirm that the button contents are still left-aligned.

## Screenshots <!-- if applicable -->
RTL before & after:
![image](https://user-images.githubusercontent.com/75777864/194640175-4259d5ee-2c45-4eb2-acca-11205073e3c6.png)
![image](https://user-images.githubusercontent.com/75777864/194640200-2a42a3db-ed73-4c50-a7a8-5e1f92e0045c.png)

LTR before & after (should be unchanged):
![image](https://user-images.githubusercontent.com/75777864/194640108-eede7e4a-2748-44b0-b4f0-d73b51e974b7.png)
![image](https://user-images.githubusercontent.com/75777864/194640116-e85d2399-c7c5-425c-a15b-d9066a1db4d1.png)

