### PR TITLE
Make `spacingScale` description more accurate in theme.json schema

### DIFF
--- a/schemas/json/theme.json
+++ b/schemas/json/theme.json
@@ -269,7 +269,7 @@
 							}
 						},
 						"spacingScale": {
-							"description": "Space size presets for the space size selector.\nGenerates a custom property (`--wp--preset--space-size--{slug}`) per preset value.",
+							"description": "Settings to auto-generate space size presets for the space size selector.\nGenerates a custom property (`--wp--preset--space-size--{slug}`) per preset value.",
 							"type": "object",
 							"properties": {
 								"operator": {


### PR DESCRIPTION
## What?
This PR updates the description of spacingScale introduced by #41527

## Why?

In the input support by JSON schema, the descriptions of `spacingSizes` and `spacingScale` are exactly the same, so it may be difficult to understand the difference between them.

spacingScale

![spacingScale](https://user-images.githubusercontent.com/54422211/194710750-1f6d111d-9653-4fd8-858d-93b356a11a45.png)

spacingSizes

![spacingSizes](https://user-images.githubusercontent.com/54422211/194710754-54c1a7a6-2785-486d-9da8-00ed806fbbc0.png)

Furthermore, `spacingScale` doesn'ot generate presets by itself, but is a property that defines the logic for generating presets.

## How?
I have updated the description to what I think is appropriate according to what this property originally meant.

## Testing Instructions
Create a JSON file that references the JSON schema for this branch, such as:

```json
{
	"$schema": "https://raw.githubusercontent.com/WordPress/gutenberg/schema/theme-json-spacing-scale/schemas/json/theme.json",
	"version": 2,
	"settings": {
	}
}
```

In `settings.spacingScale`, confirm that the new description is proposed.
