### PR TITLE
AutocompleteUI: Close popup when click happens outside of the popover.

### DIFF
--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -16,6 +16,7 @@
 -   `Button`: Fix RTL alignment for buttons containing an icon and text ([#44787](https://github.com/WordPress/gutenberg/pull/44787)).
 -   `TabPanel`: Call `onSelect()` on every tab selection, regardless of whether it was triggered by user interaction ([#44028](https://github.com/WordPress/gutenberg/pull/44028)).
 -   `FontSizePicker`: Fallback to font size `slug` if `name` is undefined  ([#45041](https://github.com/WordPress/gutenberg/pull/45041)).
+-   `AutocompleterUI`: fix issue where autocompleter UI would appear on top of other UI elements ([#44795](https://github.com/WordPress/gutenberg/pull/44795/))
 
 ### Internal
 

--- a/packages/components/src/autocomplete/autocompleter-ui.js
+++ b/packages/components/src/autocomplete/autocompleter-ui.js
@@ -63,12 +63,12 @@ export function getAutoCompleterUI( autocompleter ) {
 				position="top right"
 				className="components-autocomplete__popover"
 				anchor={ popoverAnchor }
+				ref={ popoverRef }
 			>
 				<div
 					id={ listBoxId }
 					role="listbox"
 					className="components-autocomplete__results"
-					ref={ popoverRef }
 				>
 					{ map( items, ( option, index ) => (
 						<Button

--- a/packages/components/src/autocomplete/autocompleter-ui.js
+++ b/packages/components/src/autocomplete/autocompleter-ui.js
@@ -102,7 +102,7 @@ export function getAutoCompleterUI( autocompleter ) {
 function useOnClickOutside( ref, handler ) {
 	useEffect( () => {
 		const listener = ( event ) => {
-			// Do nothing if clicking ref's element or descendent elements
+			// Do nothing if clicking ref's element or descendent elements, or if the ref is not referencing an element
 			if ( ! ref.current || ref.current.contains( event.target ) ) {
 				return;
 			}

--- a/packages/components/src/autocomplete/autocompleter-ui.js
+++ b/packages/components/src/autocomplete/autocompleter-ui.js
@@ -7,7 +7,7 @@ import { map } from 'lodash';
 /**
  * WordPress dependencies
  */
-import { useLayoutEffect } from '@wordpress/element';
+import { useLayoutEffect, useRef, useEffect } from '@wordpress/element';
 import { useAnchor } from '@wordpress/rich-text';
 
 /**
@@ -31,6 +31,7 @@ export function getAutoCompleterUI( autocompleter ) {
 		onChangeOptions,
 		onSelect,
 		onReset,
+		reset,
 		value,
 		contentRef,
 	} ) {
@@ -38,6 +39,12 @@ export function getAutoCompleterUI( autocompleter ) {
 		const popoverAnchor = useAnchor( {
 			editableContentElement: contentRef.current,
 			value,
+		} );
+
+		const popoverRef = useRef();
+
+		useOnClickOutside( popoverRef, () => {
+			reset();
 		} );
 
 		useLayoutEffect( () => {
@@ -63,6 +70,7 @@ export function getAutoCompleterUI( autocompleter ) {
 					id={ listBoxId }
 					role="listbox"
 					className="components-autocomplete__results"
+					ref={ popoverRef }
 				>
 					{ map( items, ( option, index ) => (
 						<Button
@@ -89,4 +97,25 @@ export function getAutoCompleterUI( autocompleter ) {
 	}
 
 	return AutocompleterUI;
+}
+
+function useOnClickOutside( ref, handler ) {
+	useEffect(
+		() => {
+			const listener = ( event ) => {
+				// Do nothing if clicking ref's element or descendent elements
+				if ( ! ref.current || ref.current.contains( event.target ) ) {
+					return;
+				}
+				handler( event );
+			};
+			document.addEventListener( 'mousedown', listener );
+			document.addEventListener( 'touchstart', listener );
+			return () => {
+				document.removeEventListener( 'mousedown', listener );
+				document.removeEventListener( 'touchstart', listener );
+			};
+		},
+		[ ref, handler ]
+	);
 }

--- a/packages/components/src/autocomplete/autocompleter-ui.js
+++ b/packages/components/src/autocomplete/autocompleter-ui.js
@@ -100,22 +100,19 @@ export function getAutoCompleterUI( autocompleter ) {
 }
 
 function useOnClickOutside( ref, handler ) {
-	useEffect(
-		() => {
-			const listener = ( event ) => {
-				// Do nothing if clicking ref's element or descendent elements
-				if ( ! ref.current || ref.current.contains( event.target ) ) {
-					return;
-				}
-				handler( event );
-			};
-			document.addEventListener( 'mousedown', listener );
-			document.addEventListener( 'touchstart', listener );
-			return () => {
-				document.removeEventListener( 'mousedown', listener );
-				document.removeEventListener( 'touchstart', listener );
-			};
-		},
-		[ ref, handler ]
-	);
+	useEffect( () => {
+		const listener = ( event ) => {
+			// Do nothing if clicking ref's element or descendent elements
+			if ( ! ref.current || ref.current.contains( event.target ) ) {
+				return;
+			}
+			handler( event );
+		};
+		document.addEventListener( 'mousedown', listener );
+		document.addEventListener( 'touchstart', listener );
+		return () => {
+			document.removeEventListener( 'mousedown', listener );
+			document.removeEventListener( 'touchstart', listener );
+		};
+	}, [ ref, handler ] );
 }

--- a/packages/components/src/autocomplete/autocompleter-ui.js
+++ b/packages/components/src/autocomplete/autocompleter-ui.js
@@ -43,9 +43,7 @@ export function getAutoCompleterUI( autocompleter ) {
 
 		const popoverRef = useRef();
 
-		useOnClickOutside( popoverRef, () => {
-			reset();
-		} );
+		useOnClickOutside( popoverRef, reset );
 
 		useLayoutEffect( () => {
 			onChangeOptions( items );

--- a/packages/components/src/autocomplete/autocompleter-ui.js
+++ b/packages/components/src/autocomplete/autocompleter-ui.js
@@ -114,5 +114,8 @@ function useOnClickOutside( ref, handler ) {
 			document.removeEventListener( 'mousedown', listener );
 			document.removeEventListener( 'touchstart', listener );
 		};
-	}, [ ref, handler ] );
+		// Disable reason: `ref` is a ref object and should not be included in a
+		// hook's dependency list.
+		// eslint-disable-next-line react-hooks/exhaustive-deps
+	}, [ handler ] );
 }

--- a/packages/components/src/autocomplete/test/index.js
+++ b/packages/components/src/autocomplete/test/index.js
@@ -1,0 +1,89 @@
+/**
+ * External dependencies
+ */
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+
+/**
+ * WordPress dependencies
+ */
+import { useRef } from '@wordpress/element';
+
+/**
+ * Internal dependencies
+ */
+import { getAutoCompleterUI } from '../autocompleter-ui';
+
+describe( 'AutocompleterUI', () => {
+	describe( 'click outside behavior', () => {
+		it( 'should call reset function when a click on another element occurs', async () => {
+			const user = userEvent.setup( {
+				advanceTimers: jest.advanceTimersByTime,
+			} );
+
+			const resetSpy = jest.fn();
+
+			const autocompleter = {
+				name: 'fruit',
+				// The prefix that triggers this completer
+				triggerPrefix: '~',
+				// Mock useItems function to return a autocomplete item.
+				useItems: () => {
+					return [
+						[
+							{
+								isDisabled: false,
+								key: 'Apple',
+								value: 'Apple',
+								label: (
+									<span>
+										<span className="icon">🍎</span>
+										{ 'Apple' }
+									</span>
+								),
+							},
+						],
+					];
+				},
+			};
+
+			const AutocompleterUI = getAutoCompleterUI( autocompleter );
+
+			const OtherElement = <div>Other Element</div>;
+
+			const Container = () => {
+				const contentRef = useRef();
+
+				return (
+					<div>
+						<AutocompleterUI
+							className={ 'test' }
+							filterValue={ '~' }
+							instanceId={ '1' }
+							listBoxId={ '1' }
+							selectedIndex={ 0 }
+							onChangeOptions={ () => {} }
+							onSelect={ () => {} }
+							value={ { visual: '🍎', name: 'Apple', id: 1 } }
+							contentRef={ contentRef }
+							reset={ resetSpy }
+						/>
+						{ OtherElement }
+					</div>
+				);
+			};
+
+			render( <Container /> );
+
+			// Click on autocompleter.
+			await user.click( screen.getByText( 'Apple' ) );
+
+			expect( resetSpy ).toHaveBeenCalledTimes( 0 );
+
+			// Click on other element out side of the tree.
+			await user.click( screen.getByText( 'Other Element' ) );
+
+			expect( resetSpy ).toHaveBeenCalledTimes( 1 );
+		} );
+	} );
+} );


### PR DESCRIPTION
Fixes #44767.

<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
This prevents the popover from appearing above UI elements like the Patterns Explore Modal window.

## Why?
 When the AutocompleteUI component renders, you can open the explorer for patterns modal window while the AutocompleteUI is still rendered. I don't believe the z-index for CSS should be changed as the modal windows need to appear below WordPress admin elements, where as the popover will be ontop of those.

## How?
Adds a handler that looks for when the user clicks outside of the popover and closes the popover. 

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
1. Open the Gutenberg Editor. Go to a new block and type `/` to open the autocomplete popover for inserting a block.
2. Without inserting a block, go to the top left and click on the Inserter button. At this point the autocomplete should close.
3. Click the patterns tab in the sidebar.
4. Click Explore.
5. You should no longer see the autocomplete popover on top of the modal window.
