### PR TITLE
Add title property to theme.json schema

### DIFF
--- a/schemas/json/theme.json
+++ b/schemas/json/theme.json
@@ -1555,6 +1555,10 @@
 			"type": "integer",
 			"enum": [ 2 ]
 		},
+		"title": {
+			"type": "string",
+			"description": "Title of the global styles variation. If not defined, the file name will be used."
+		},
 		"settings": {
 			"description": "Settings for the block editor and individual blocks. These include things like:\n- Which customization options should be available to the user. \n- The default colors, font sizes... available to the user. \n- CSS custom properties and class names used in styles.\n- And the default layout of the editor (widths and available alignments).",
 			"type": "object",


### PR DESCRIPTION
## What?
This PR adds the `title` property to the `theme.json` schema.

## Why?
The `title` property is not currently defined as a schema. However, it is used as a mouse-over label in global style variations.
When the title property is absent, "Default" is displayed for theme.json and the file name for variations.

![default](https://user-images.githubusercontent.com/54422211/194743918-86f7b932-6845-4e34-a27d-1ba37f84a4c5.png)

![title](https://user-images.githubusercontent.com/54422211/194743920-90530522-414b-469b-860d-b67fba2b1e98.png)

## How?
Added title property and description to theme.json schema.
If you have a more appropriate description, please advise.

## Testing Instructions

Confirm that the code editor outputs an error for the title property when referencing the trunk schema.

```json
{
	"$schema": "https://schemas.wp.org/trunk/theme.json",
	"version": 2,
	"title": "Variation Name"
}
```

![trunk](https://user-images.githubusercontent.com/54422211/194743534-b0b8e079-e593-49cd-884c-21d6e2e0d713.png)

Confirm that the code editor displays the title property as a candidate and does not output an error when referencing this PR's schema.

```json
{
	"$schema": "https://raw.githubusercontent.com/WordPress/gutenberg/add/theme-json-schema-title/schemas/json/theme.json",
	"version": 2,
	"title": "Variation Name"
}
```

![pr](https://user-images.githubusercontent.com/54422211/194743541-291fc3ed-ab3d-428c-b068-9e584109642b.png)

cc @mikachan Because we had a talk about the title property in [the Twenty Twenty Three PR](https://github.com/WordPress/twentytwentythree/pull/269).
