### PR TITLE
Fix typo in block.json schema

### DIFF
--- a/schemas/json/block.json
+++ b/schemas/json/block.json
@@ -27,7 +27,7 @@
 			"description": "The name for a block is a unique string that identifies a block. Names have to be structured as `namespace/block-name`, where namespace is the name of your plugin or theme."
 		},
 		"__experimental": {
-			"description": "The name of the experiment this block is a part of, or boolean true if there there is no specific experiment name.",
+			"description": "The name of the experiment this block is a part of, or boolean true if there is no specific experiment name.",
 			"anyOf": [
 				{
 					"type": "string"


### PR DESCRIPTION
## What?
Fix typo in block.json schema. There is no impact on the code.