### PR TITLE
Fix/theme json schema validation

### DIFF
--- a/docs/reference-guides/theme-json-reference/theme-json-living.md
+++ b/docs/reference-guides/theme-json-reference/theme-json-living.md
@@ -158,19 +158,6 @@ Color styles.
 
 ---
 
-### outline
-
-Outline styles.
-
-| Property  | Type   |  Props  |
-| ---       | ---    |---   |
-| color | string |  |
-| offset | string |  |
-| style | string |  |
-| width | string |  |
-
----
-
 ### spacing
 
 Spacing styles.
@@ -214,6 +201,19 @@ CSS and SVG filter styles.
 
 Box shadow styles.
 
+
+---
+
+### outline
+
+Outline styles.
+
+| Property  | Type   |  Props  |
+| ---       | ---    |---   |
+| color | string |  |
+| offset | string |  |
+| style | string |  |
+| width | string |  |
 
 ---
 

--- a/schemas/json/theme.json
+++ b/schemas/json/theme.json
@@ -1020,29 +1020,6 @@
 					},
 					"additionalProperties": false
 				},
-				"outline": {
-					"description": "Outline styles.",
-					"type": "object",
-					"properties": {
-						"color": {
-							"description": "Sets the `outline-color` CSS property.",
-							"type": "string"
-						},
-						"offset": {
-							"description": "Sets the `outline-offset` CSS property.",
-							"type": "string"
-						},
-						"style": {
-							"description": "Sets the `outline-style` CSS property.",
-							"type": "string"
-						},
-						"width": {
-							"description": "Sets the `outline-width` CSS property.",
-							"type": "string"
-						}
-					},
-					"additionalProperties": false
-				},
 				"spacing": {
 					"description": "Spacing styles.",
 					"type": "object",
@@ -1153,6 +1130,29 @@
 				"shadow": {
 					"description": "Box shadow styles.",
 					"type": "string"
+				},
+				"outline": {
+					"description": "Outline styles.",
+					"type": "object",
+					"properties": {
+						"color": {
+							"description": "Sets the `outline-color` CSS property.",
+							"type": "string"
+						},
+						"offset": {
+							"description": "Sets the `outline-offset` CSS property.",
+							"type": "string"
+						},
+						"style": {
+							"description": "Sets the `outline-style` CSS property.",
+							"type": "string"
+						},
+						"width": {
+							"description": "Sets the `outline-width` CSS property.",
+							"type": "string"
+						}
+					},
+					"additionalProperties": false
 				}
 			}
 		},
@@ -1169,7 +1169,8 @@
 						"spacing": {},
 						"typography": {},
 						"filter": {},
-						"shadow": {}
+						"shadow": {},
+						"outline": {}
 					},
 					"additionalProperties": false
 				}
@@ -1189,8 +1190,8 @@
 								"border": {},
 								"color": {},
 								"filter": {},
-								"outline": {},
 								"shadow": {},
+								"outline": {},
 								"spacing": {},
 								"typography": {},
 								":hover": {
@@ -1535,6 +1536,9 @@
 						"color": {},
 						"spacing": {},
 						"typography": {},
+						"filter": {},
+						"shadow": {},
+						"outline": {},
 						"elements": {
 							"$ref": "#/definitions/stylesElementsPropertiesComplete"
 						}
@@ -1597,6 +1601,8 @@
 						"spacing": {},
 						"typography": {},
 						"filter": {},
+						"shadow": {},
+						"outline": {},
 						"elements": {
 							"description": "Styles defined on a per-element basis using the element's selector.",
 							"$ref": "#/definitions/stylesElementsPropertiesComplete"


### PR DESCRIPTION
Fix: #44442

## What?
This PR solves the problem that the three properties `filter`, `shadow`, and `outline` are not defined correctly in the theme.json schema.

## Why?
This is because these three are not correctly defined in the `properties` section that is the source of the validation.

## How?
I updated `filter`, `shadow`, and `outline` in a consistent order, besides adding the definitions.

## Testing Instructions

- Create the following JSON file with all three properties defined in all locations.

<details>
<summary>theme.json</summary>

```json
{
	"$schema": "https://schemas.wp.org/trunk/theme.json",
	"version": 2,
	"styles": {
		"filter": {},
		"shadow": "",
		"outline": {},
		"elements": {
			"button": {
				"filter": {},
				"shadow": "",
				"outline": {},
				":active": {
					"filter": {},
					"shadow": "",
					"outline": {}
				},
				":focus": {
					"filter": {},
					"shadow": "",
					"outline": {}
				},
				":hover": {
					"filter": {},
					"shadow": "",
					"outline": {}
				}
			}
		},
		"blocks": {
			"core/button": {
				"filter": {},
				"shadow": "",
				"outline": {}
			},
			"core/heading": {
				"filter": {},
				"shadow": "",
				"outline": {}
			}
		}
	}
}
```
</details>

- Confirm that the code editor shows errors in some properties.

![schema](https://user-images.githubusercontent.com/54422211/194745111-07501f12-1981-44a2-af0a-41467d609370.png)

- Change the schema reference to this PR.
```
{
	"$schema": "https://raw.githubusercontent.com/WordPress/gutenberg/fix/theme-json-schema-validation/schemas/json/theme.json"
}
```
- Confirm that all error messages disappear. At the same time, verify that these three properties don't appear as automatic candidates outside of the allowed locations.
