### PR TITLE
Fix: Focus animation collapse in global style

### DIFF
--- a/packages/edit-site/src/components/global-styles/preview.js
+++ b/packages/edit-site/src/components/global-styles/preview.js
@@ -121,6 +121,7 @@ const StylesPreview = ( { label, isFocused, withHoverView } ) => {
 					width: '100%',
 					background: gradientValue ?? backgroundColor,
 					cursor: 'pointer',
+					overflow: 'hidden',
 				} }
 				initial="start"
 				animate={
@@ -220,8 +221,7 @@ const StylesPreview = ( { label, isFocused, withHoverView } ) => {
 							) ) }
 					</HStack>
 				</motion.div>
-				<motion.div
-					variants={ secondFrame }
+				<div
 					style={ {
 						height: '100%',
 						width: '100%',
@@ -230,32 +230,39 @@ const StylesPreview = ( { label, isFocused, withHoverView } ) => {
 						top: 0,
 					} }
 				>
-					<VStack
-						spacing={ 3 * ratio }
-						justify="center"
+					<motion.div
+						variants={ secondFrame }
 						style={ {
 							height: '100%',
-							overflow: 'hidden',
-							padding: 10 * ratio,
-							boxSizing: 'border-box',
 						} }
 					>
-						{ label && (
-							<div
-								style={ {
-									fontSize: 40 * ratio,
-									fontFamily: headingFontFamily,
-									color: headingColor,
-									fontWeight: headingFontWeight,
-									lineHeight: '1em',
-									textAlign: 'center',
-								} }
-							>
-								{ label }
-							</div>
-						) }
-					</VStack>
-				</motion.div>
+						<VStack
+							spacing={ 3 * ratio }
+							justify="center"
+							style={ {
+								height: '100%',
+								overflow: 'hidden',
+								padding: 10 * ratio,
+								boxSizing: 'border-box',
+							} }
+						>
+							{ label && (
+								<div
+									style={ {
+										fontSize: 40 * ratio,
+										fontFamily: headingFontFamily,
+										color: headingColor,
+										fontWeight: headingFontWeight,
+										lineHeight: '1em',
+										textAlign: 'center',
+									} }
+								>
+									{ label }
+								</div>
+							) }
+						</VStack>
+					</motion.div>
+				</div>
 			</motion.div>
 		</Iframe>
 	);


### PR DESCRIPTION
Fix #44796
Related to #39717

## What?
This PR solves a problem where a scrollbar temporarily appears and does not animate smoothly when the preview area of a global style is focused.

https://user-images.githubusercontent.com/54422211/194746661-3f304394-aa15-412c-855b-03157e010434.mp4

## Why?
This problem probably depends on the scrollbar settings in the operating system. With Windows, this problem could be reproduced at any time.

If you are using a Mac, you may be able to reproduce this by changing the scrollbar setting to "Always" after proceeding in the following order: 

the Apple menu > System Preferences > General > Show scroll bars

## How?
I tried applying `overflow: hidden;` style to many elements, but it did not solve the problem completely. Finally, I found a solution by wrapping one of the motion elements placed in absolute with a div tag.

This may not be the best way to do it, so I would appreciate your advice.

## Testing Instructions
In this PR, confirm that the animation is smooth and without scrollbars when the mouse hovers over the style variation. At least in my Windows OS, both Google Chrome and Firefox animate correctly.
