### PR TITLE
Components: Refactor Notice tests to use RTL

### DIFF
--- a/packages/components/src/notice/test/__snapshots__/index.js.snap
+++ b/packages/components/src/notice/test/__snapshots__/index.js.snap
@@ -1,54 +1,55 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`Notice should match snapshot 1`] = `
-<div
-  className="components-notice is-success is-dismissible"
->
+<div>
   <div
-    className="components-notice__content"
+    class="components-notice is-success is-dismissible"
   >
-    Example
     <div
-      className="components-notice__actions"
+      class="components-notice__content"
     >
-      <ForwardRef(Button)
-        className="components-notice__action"
-        href="https://example.com"
-        variant="link"
+      Example
+      <div
+        class="components-notice__actions"
       >
-        More information
-      </ForwardRef(Button)>
-      <ForwardRef(Button)
-        className="components-notice__action"
-        onClick={[Function]}
-        variant="secondary"
-      >
-        Cancel
-      </ForwardRef(Button)>
-      <ForwardRef(Button)
-        className="components-notice__action"
-        onClick={[Function]}
-        variant="primary"
-      >
-        Submit
-      </ForwardRef(Button)>
+        <a
+          class="components-button components-notice__action is-link"
+          href="https://example.com"
+        >
+          More information
+        </a>
+        <button
+          class="components-button components-notice__action is-secondary"
+          type="button"
+        >
+          Cancel
+        </button>
+        <button
+          class="components-button components-notice__action is-primary"
+          type="button"
+        >
+          Submit
+        </button>
+      </div>
     </div>
-  </div>
-  <ForwardRef(Button)
-    className="components-notice__dismiss"
-    icon={
-      <SVG
+    <button
+      aria-label="Dismiss this notice"
+      class="components-button components-notice__dismiss has-icon"
+      type="button"
+    >
+      <svg
+        aria-hidden="true"
+        focusable="false"
+        height="24"
         viewBox="0 0 24 24"
+        width="24"
         xmlns="http://www.w3.org/2000/svg"
       >
-        <Path
+        <path
           d="M13 11.8l6.1-6.3-1-1-6.1 6.2-6.1-6.2-1 1 6.1 6.3-6.5 6.7 1 1 6.5-6.6 6.5 6.6 1-1z"
         />
-      </SVG>
-    }
-    label="Dismiss this notice"
-    onClick={[Function]}
-    showTooltip={false}
-  />
+      </svg>
+    </button>
+  </div>
 </div>
 `;

--- a/packages/components/src/notice/test/index.js
+++ b/packages/components/src/notice/test/index.js
@@ -1,13 +1,11 @@
 /**
  * External dependencies
  */
-import ShallowRenderer from 'react-test-renderer/shallow';
-import { create } from 'react-test-renderer';
+import { render } from '@testing-library/react';
 
 /**
  * WordPress dependencies
  */
-import TokenList from '@wordpress/token-list';
 import { speak } from '@wordpress/a11y';
 
 /**
@@ -23,9 +21,7 @@ describe( 'Notice', () => {
 	} );
 
 	it( 'should match snapshot', () => {
-		const renderer = new ShallowRenderer();
-
-		renderer.render(
+		const { container } = render(
 			<Notice
 				status="success"
 				actions={ [
@@ -38,63 +34,47 @@ describe( 'Notice', () => {
 			</Notice>
 		);
 
-		expect( renderer.getRenderOutput() ).toMatchSnapshot();
+		expect( container ).toMatchSnapshot();
 	} );
 
 	it( 'should not have is-dismissible class when isDismissible prop is false', () => {
-		const renderer = new ShallowRenderer();
+		const { container } = render( <Notice isDismissible={ false } /> );
 
-		renderer.render( <Notice isDismissible={ false } /> );
-
-		const classes = new TokenList(
-			renderer.getRenderOutput().props.className
-		);
-		expect( classes.contains( 'components-notice' ) ).toBe( true );
-		expect( classes.contains( 'is-dismissible' ) ).toBe( false );
+		expect( container.firstChild ).toHaveClass( 'components-notice' );
+		expect( container.firstChild ).not.toHaveClass( 'is-dismissible' );
 	} );
 
 	it( 'should default to info status', () => {
-		const renderer = new ShallowRenderer();
+		const { container } = render( <Notice /> );
 
-		renderer.render( <Notice /> );
-
-		const classes = new TokenList(
-			renderer.getRenderOutput().props.className
-		);
-		expect( classes.contains( 'is-info' ) ).toBe( true );
+		expect( container.firstChild ).toHaveClass( 'is-info' );
 	} );
 
 	describe( 'useSpokenMessage', () => {
 		it( 'should speak the given message', () => {
-			const tree = create( <Notice>FYI</Notice> );
-			tree.update();
+			render( <Notice>FYI</Notice> );
 
 			expect( speak ).toHaveBeenCalledWith( 'FYI', 'polite' );
 		} );
 
 		it( 'should speak the given message by explicit politeness', () => {
-			const tree = create(
-				<Notice politeness="assertive">Uh oh!</Notice>
-			);
-			tree.update();
+			render( <Notice politeness="assertive">Uh oh!</Notice> );
 
 			expect( speak ).toHaveBeenCalledWith( 'Uh oh!', 'assertive' );
 		} );
 
 		it( 'should speak the given message by implicit politeness by status', () => {
-			const tree = create( <Notice status="error">Uh oh!</Notice> );
-			tree.update();
+			render( <Notice status="error">Uh oh!</Notice> );
 
 			expect( speak ).toHaveBeenCalledWith( 'Uh oh!', 'assertive' );
 		} );
 
 		it( 'should speak the given message, preferring explicit to implicit politeness', () => {
-			const tree = create(
+			render(
 				<Notice politeness="polite" status="error">
 					No need to panic
 				</Notice>
 			);
-			tree.update();
 
 			expect( speak ).toHaveBeenCalledWith(
 				'No need to panic',
@@ -105,12 +85,11 @@ describe( 'Notice', () => {
 		it( 'should coerce a message to a string', () => {
 			// This test assumes that `@wordpress/a11y` is capable of handling
 			// markup strings appropriately.
-			const tree = create(
+			render(
 				<Notice>
 					With <em>emphasis</em> this time.
 				</Notice>
 			);
-			tree.update();
 
 			expect( speak ).toHaveBeenCalledWith(
 				'With <em>emphasis</em> this time.',
@@ -119,12 +98,12 @@ describe( 'Notice', () => {
 		} );
 
 		it( 'should not re-speak an effectively equivalent element message', () => {
-			const tree = create(
+			const { rerender } = render(
 				<Notice>
 					With <em>emphasis</em> this time.
 				</Notice>
 			);
-			tree.update(
+			rerender(
 				<Notice>
 					With <em>emphasis</em> this time.
 				</Notice>


### PR DESCRIPTION
## What?
PR of #44780.

PR refactors `Notice` component tests to use `@testing-library/react` instead of `react-test-renderer.`

## Why?
It is a part of recent efforts to use `@testing-library/react` as the project's primary testing library.

## How?
We're just using the render method from RTL, improving how assertions are made and updating the snapshot.

## Testing Instructions
```
npm run test:unit -- packages/components/src/notice/test/index.js
```