### PR TITLE
Data: Refactor 'useDispatch' tests to use RTL

### DIFF
--- a/packages/data/src/components/use-dispatch/test/use-dispatch.js
+++ b/packages/data/src/components/use-dispatch/test/use-dispatch.js
@@ -20,6 +20,8 @@ import { RegistryProvider } from '../../registry-provider';
 const noop = () => ( { type: '__INERT__' } );
 const reducer = ( state ) => state;
 
+jest.useRealTimers();
+
 describe( 'useDispatch', () => {
 	let registry;
 	beforeEach( () => {
@@ -55,9 +57,7 @@ describe( 'useDispatch', () => {
 	} );
 
 	it( 'returns expected action creators from store for given storeName', async () => {
-		const user = userEvent.setup( {
-			advanceTimers: jest.advanceTimersByTime,
-		} );
+		const user = userEvent.setup();
 		const testAction = jest.fn().mockImplementation( noop );
 		const store = createReduxStore( 'demoStore', {
 			reducer,
@@ -84,9 +84,7 @@ describe( 'useDispatch', () => {
 	} );
 
 	it( 'returns expected action creators from store for given store descriptor', async () => {
-		const user = userEvent.setup( {
-			advanceTimers: jest.advanceTimersByTime,
-		} );
+		const user = userEvent.setup();
 		const testAction = jest.fn().mockImplementation( noop );
 		registry.registerStore( 'demoStore', {
 			reducer,
@@ -111,9 +109,7 @@ describe( 'useDispatch', () => {
 	} );
 
 	it( 'returns dispatch from correct registry if registries change', async () => {
-		const user = userEvent.setup( {
-			advanceTimers: jest.advanceTimersByTime,
-		} );
+		const user = userEvent.setup();
 		const firstRegistryAction = jest.fn().mockImplementation( noop );
 		const secondRegistryAction = jest.fn().mockImplementation( noop );
 

--- a/packages/data/src/components/use-dispatch/test/use-dispatch.js
+++ b/packages/data/src/components/use-dispatch/test/use-dispatch.js
@@ -131,4 +131,52 @@ describe( 'useDispatch', () => {
 		expect( firstRegistry.select( 'demo' ).get() ).toBe( 1 );
 		expect( secondRegistry.select( 'demo' ).get() ).toBe( 1 );
 	} );
+
+	it( 'dispatches returned actions correctly', async () => {
+		const user = userEvent.setup();
+		const fooAction = jest.fn( () => ( { type: '__INERT__' } ) );
+		const barAction = jest.fn( () => ( { type: '__INERT__' } ) );
+		const store = createReduxStore( 'demo', {
+			reducer: ( state ) => state,
+			actions: {
+				foo: fooAction,
+				bar: barAction,
+			},
+		} );
+		registry.register( store );
+
+		const TestComponent = () => {
+			const { foo, bar } = useDispatch( store );
+			return (
+				<>
+					<button onClick={ foo }>foo</button>
+					<button onClick={ bar }>bar</button>
+				</>
+			);
+		};
+
+		render(
+			<RegistryProvider value={ registry }>
+				<TestComponent />
+			</RegistryProvider>
+		);
+
+		await user.click(
+			screen.getByRole( 'button', {
+				name: 'foo',
+			} )
+		);
+
+		expect( fooAction ).toBeCalledTimes( 1 );
+		expect( barAction ).toBeCalledTimes( 0 );
+
+		await user.click(
+			screen.getByRole( 'button', {
+				name: 'bar',
+			} )
+		);
+
+		expect( fooAction ).toBeCalledTimes( 1 );
+		expect( barAction ).toBeCalledTimes( 1 );
+	} );
 } );

--- a/packages/data/src/components/use-dispatch/test/use-dispatch.js
+++ b/packages/data/src/components/use-dispatch/test/use-dispatch.js
@@ -138,7 +138,9 @@ describe( 'useDispatch', () => {
 
 		await user.click( screen.getByRole( 'button' ) );
 		expect( firstRegistryAction ).toHaveBeenCalledTimes( 1 );
-		expect( secondRegistryAction ).toHaveBeenCalledTimes( 0 );
+		expect( secondRegistryAction ).not.toHaveBeenCalled();
+
+		firstRegistryAction.mockClear();
 
 		const secondRegistry = createRegistry();
 		secondRegistry.registerStore( 'demo', {
@@ -155,7 +157,7 @@ describe( 'useDispatch', () => {
 		);
 
 		await user.click( screen.getByRole( 'button' ) );
-		expect( firstRegistryAction ).toHaveBeenCalledTimes( 1 );
+		expect( firstRegistryAction ).not.toHaveBeenCalled();
 		expect( secondRegistryAction ).toHaveBeenCalledTimes( 1 );
 	} );
 } );

--- a/packages/data/src/components/use-dispatch/test/use-dispatch.js
+++ b/packages/data/src/components/use-dispatch/test/use-dispatch.js
@@ -7,7 +7,6 @@ import userEvent from '@testing-library/user-event';
 /**
  * WordPress dependencies
  */
-import { createRef, useEffect } from '@wordpress/element';
 
 /**
  * Internal dependencies
@@ -17,34 +16,37 @@ import createReduxStore from '../../../redux-store';
 import { createRegistry } from '../../../registry';
 import { RegistryProvider } from '../../registry-provider';
 
-const noop = () => ( { type: '__INERT__' } );
-const reducer = ( state ) => state;
-
 jest.useRealTimers();
 
 describe( 'useDispatch', () => {
+	const counterStore = {
+		reducer: ( state = 0, action ) => {
+			if ( action.type === 'INC' ) {
+				return state + 1;
+			}
+
+			return state;
+		},
+		actions: {
+			inc: () => ( { type: 'INC' } ),
+		},
+		selectors: {
+			get: ( state ) => state,
+		},
+	};
+
 	let registry;
 	beforeEach( () => {
 		registry = createRegistry();
 	} );
 
-	it( 'returns dispatch function from store with no store name provided', () => {
-		registry.registerStore( 'demoStore', {
-			reducer,
-			actions: {
-				foo: () => 'bar',
-			},
-		} );
+	it( 'returns dispatch function from store with no store name provided', async () => {
+		const user = userEvent.setup();
+		registry.registerStore( 'demo', counterStore );
 
-		const result = createRef();
 		const TestComponent = () => {
 			const dispatch = useDispatch();
-
-			useEffect( () => {
-				result.current = dispatch;
-			} );
-
-			return null;
+			return <button onClick={ () => dispatch( 'demo' ).inc() } />;
 		};
 
 		render(
@@ -53,23 +55,19 @@ describe( 'useDispatch', () => {
 			</RegistryProvider>
 		);
 
-		expect( result.current ).toBe( registry.dispatch );
+		await user.click( screen.getByRole( 'button' ) );
+
+		expect( registry.select( 'demo' ).get() ).toBe( 1 );
 	} );
 
 	it( 'returns expected action creators from store for given storeName', async () => {
 		const user = userEvent.setup();
-		const testAction = jest.fn().mockImplementation( noop );
-		const store = createReduxStore( 'demoStore', {
-			reducer,
-			actions: {
-				foo: testAction,
-			},
-		} );
+		const store = createReduxStore( 'demoStore', counterStore );
 		registry.register( store );
 
 		const TestComponent = () => {
-			const { foo } = useDispatch( store );
-			return <button onClick={ foo } />;
+			const { inc } = useDispatch( store );
+			return <button onClick={ inc } />;
 		};
 
 		render(
@@ -80,21 +78,15 @@ describe( 'useDispatch', () => {
 
 		await user.click( screen.getByRole( 'button' ) );
 
-		expect( testAction ).toHaveBeenCalledTimes( 1 );
+		expect( registry.select( store ).get() ).toBe( 1 );
 	} );
 
 	it( 'returns expected action creators from store for given store descriptor', async () => {
 		const user = userEvent.setup();
-		const testAction = jest.fn().mockImplementation( noop );
-		registry.registerStore( 'demoStore', {
-			reducer,
-			actions: {
-				foo: testAction,
-			},
-		} );
+		registry.registerStore( 'demoStore', counterStore );
 		const TestComponent = () => {
-			const { foo } = useDispatch( 'demoStore' );
-			return <button onClick={ foo } />;
+			const { inc } = useDispatch( 'demoStore' );
+			return <button onClick={ inc } />;
 		};
 
 		render(
@@ -105,25 +97,21 @@ describe( 'useDispatch', () => {
 
 		await user.click( screen.getByRole( 'button' ) );
 
-		expect( testAction ).toHaveBeenCalledTimes( 1 );
+		expect( registry.select( 'demoStore' ).get() ).toBe( 1 );
 	} );
 
 	it( 'returns dispatch from correct registry if registries change', async () => {
 		const user = userEvent.setup();
-		const firstRegistryAction = jest.fn().mockImplementation( noop );
-		const secondRegistryAction = jest.fn().mockImplementation( noop );
 
 		const firstRegistry = createRegistry();
-		firstRegistry.registerStore( 'demo', {
-			reducer,
-			actions: {
-				noop: firstRegistryAction,
-			},
-		} );
+		firstRegistry.registerStore( 'demo', counterStore );
+
+		const secondRegistry = createRegistry();
+		secondRegistry.registerStore( 'demo', counterStore );
 
 		const TestComponent = () => {
 			const dispatch = useDispatch();
-			return <button onClick={ () => dispatch( 'demo' ).noop() } />;
+			return <button onClick={ () => dispatch( 'demo' ).inc() } />;
 		};
 
 		const { rerender } = render(
@@ -133,18 +121,9 @@ describe( 'useDispatch', () => {
 		);
 
 		await user.click( screen.getByRole( 'button' ) );
-		expect( firstRegistryAction ).toHaveBeenCalledTimes( 1 );
-		expect( secondRegistryAction ).not.toHaveBeenCalled();
 
-		firstRegistryAction.mockClear();
-
-		const secondRegistry = createRegistry();
-		secondRegistry.registerStore( 'demo', {
-			reducer,
-			actions: {
-				noop: secondRegistryAction,
-			},
-		} );
+		expect( firstRegistry.select( 'demo' ).get() ).toBe( 1 );
+		expect( secondRegistry.select( 'demo' ).get() ).toBe( 0 );
 
 		rerender(
 			<RegistryProvider value={ secondRegistry }>
@@ -153,7 +132,7 @@ describe( 'useDispatch', () => {
 		);
 
 		await user.click( screen.getByRole( 'button' ) );
-		expect( firstRegistryAction ).not.toHaveBeenCalled();
-		expect( secondRegistryAction ).toHaveBeenCalledTimes( 1 );
+		expect( firstRegistry.select( 'demo' ).get() ).toBe( 1 );
+		expect( secondRegistry.select( 'demo' ).get() ).toBe( 1 );
 	} );
 } );

--- a/packages/data/src/components/use-dispatch/test/use-dispatch.js
+++ b/packages/data/src/components/use-dispatch/test/use-dispatch.js
@@ -5,10 +5,6 @@ import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 
 /**
- * WordPress dependencies
- */
-
-/**
  * Internal dependencies
  */
 import useDispatch from '../use-dispatch';


### PR DESCRIPTION
## What?
PR of #44780.

PR refactors `useDispatch` hook tests to use `@testing-library/react` instead of `react-test-renderer`.

## Why?
It is a part of recent efforts to use `@testing-library/react` as the project's primary testing library.

## How?
We're just using the render method from RTL, improving how assertions, and using `userEvent` for user actions.

## Testing Instructions
```
npm run test:unit -- packages/data/src/components/use-dispatch/test/use-dispatch.js
```