### PR TITLE
Element: Refactor 'createInterpolateElement' tests to use RTL

### DIFF
--- a/packages/element/src/test/create-interpolate-element.js
+++ b/packages/element/src/test/create-interpolate-element.js
@@ -208,7 +208,7 @@ describe( 'createInterpolateElement', () => {
 			);
 		};
 		const { container, rerender } = render(
-			<TestComponent switchKey={ true } />
+			<TestComponent switchKey />
 		);
 
 		expect( container.firstChild ).toContainHTML( '<em>string!</em>' );

--- a/packages/element/src/test/create-interpolate-element.js
+++ b/packages/element/src/test/create-interpolate-element.js
@@ -207,9 +207,7 @@ describe( 'createInterpolateElement', () => {
 				</div>
 			);
 		};
-		const { container, rerender } = render(
-			<TestComponent switchKey />
-		);
+		const { container, rerender } = render( <TestComponent switchKey /> );
 
 		expect( container.firstChild ).toContainHTML( '<em>string!</em>' );
 		expect( container.firstChild ).not.toContainHTML( '<strong>' );

--- a/packages/element/src/test/create-interpolate-element.js
+++ b/packages/element/src/test/create-interpolate-element.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import TestRenderer, { act } from 'react-test-renderer';
+import { render } from '@testing-library/react';
 
 /**
  * Internal dependencies
@@ -207,19 +207,19 @@ describe( 'createInterpolateElement', () => {
 				</div>
 			);
 		};
-		let renderer;
-		act( () => {
-			renderer = TestRenderer.create(
-				<TestComponent switchKey={ true } />
-			);
-		} );
-		expect( () => renderer.root.findByType( 'em' ) ).not.toThrow();
-		expect( () => renderer.root.findByType( 'strong' ) ).toThrow();
-		act( () => {
-			renderer.update( <TestComponent switchKey={ false } /> );
-		} );
-		expect( () => renderer.root.findByType( 'strong' ) ).not.toThrow();
-		expect( () => renderer.root.findByType( 'em' ) ).toThrow();
+		const { container, rerender } = render(
+			<TestComponent switchKey={ true } />
+		);
+
+		expect( container.firstChild ).toContainHTML( '<em>string!</em>' );
+		expect( container.firstChild ).not.toContainHTML( '<strong>' );
+
+		rerender( <TestComponent switchKey={ false } /> );
+
+		expect( container.firstChild ).toContainHTML(
+			'<strong>string!</strong>'
+		);
+		expect( container.firstChild ).not.toContainHTML( '<em>' );
 	} );
 	it( 'handles parsing emojii correctly', () => {
 		const testString = '👳‍♀️<icon>🚨🤷‍♂️⛈️fully</icon> here';


### PR DESCRIPTION
## What?
PR of #44780.

PR refactors `createInterpolateElement` method tests to use `@testing-library/react` instead of `react-test-renderer`.

## Why?
It is a part of recent efforts to use `@testing-library/react` as the project's primary testing library.

## How?
We're just using the `render` method from RTL.

## Testing Instructions
```
npm run test:unit -- packages/element/src/test/create-interpolate-element.js
```
