### PR TITLE
Fix list outdents on Enter in quote block   

### DIFF
--- a/packages/block-library/src/list-item/hooks/use-outdent-list-item.js
+++ b/packages/block-library/src/list-item/hooks/use-outdent-list-item.js
@@ -20,12 +20,16 @@ export default function useOutdentListItem( clientId ) {
 	const registry = useRegistry();
 	const { canOutdent } = useSelect(
 		( innerSelect ) => {
-			const { getBlockRootClientId } = innerSelect( blockEditorStore );
+			const { getBlockRootClientId, getBlockName } =
+				innerSelect( blockEditorStore );
 			const grandParentId = getBlockRootClientId(
 				getBlockRootClientId( clientId )
 			);
+			const grandParentName = getBlockName( grandParentId );
+			const isListItem = grandParentName === listItemName;
+
 			return {
-				canOutdent: !! grandParentId,
+				canOutdent: isListItem,
 			};
 		},
 		[ clientId ]

--- a/test/e2e/specs/editor/blocks/list.spec.js
+++ b/test/e2e/specs/editor/blocks/list.spec.js
@@ -600,6 +600,32 @@ test.describe( 'List', () => {
 		);
 	} );
 
+	test( 'should create paragraph on Enter in quote block', async ( {
+		editor,
+		page,
+	} ) => {
+		await editor.insertBlock( { name: 'core/quote' } );
+		await page.keyboard.type( '/list' );
+		await page.keyboard.press( 'Enter' );
+		await page.keyboard.type( 'aaa' );
+		await page.keyboard.press( 'Enter' );
+		await page.keyboard.press( 'Enter' );
+
+		await expect.poll( editor.getEditedPostContent ).toBe(
+			`<!-- wp:quote -->
+<blockquote class="wp-block-quote"><!-- wp:list -->
+<ul><!-- wp:list-item -->
+<li>aaa</li>
+<!-- /wp:list-item --></ul>
+<!-- /wp:list -->
+
+<!-- wp:paragraph -->
+<p></p>
+<!-- /wp:paragraph --></blockquote>
+<!-- /wp:quote -->`
+		);
+	} );
+
 	test( 'should indent and outdent level 1', async ( { editor, page } ) => {
 		await editor.insertBlock( { name: 'core/list' } );
 		await page.keyboard.type( 'a' );


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Fix #44625
Fixed a problem with list out-denting when pressing enter key in a quotation block.


## Why?
When I create a list block within a quotation block and press enter, I cannot get out of the list block. The cause is that the outdenting process is inhibited first.

## How?
The enter process of the list block strictly determines if it is outdentable or not.
The existing outdenting process only checks for the presence of a parent element. Therefore, it does not work within the parent block.

Added e2e test.

## Testing Instructions
1. Create a quote block.
2. Create a list block in the quote block.
3. Type aaa.
4. Type Enter twice.
5. Ensure that a paragraph block is created out of the list block.


## Screenshots or screencast <!-- if applicable -->
After screen shots
![after-enter-action_221010](https://user-images.githubusercontent.com/15902112/194839134-663a3350-4b91-4e6b-b657-7557f2c887ed.png)


