### PR TITLE
Hide the inbetween inserter consistently as you move the mouse

### DIFF
--- a/packages/block-editor/src/components/block-list/use-in-between-inserter.js
+++ b/packages/block-editor/src/components/block-list/use-in-between-inserter.js
@@ -93,6 +93,7 @@ export function useInBetweenInserter() {
 				} );
 
 				if ( ! element ) {
+					hideInsertionPoint();
 					return;
 				}
 
@@ -102,6 +103,7 @@ export function useInBetweenInserter() {
 					element = element.firstElementChild;
 
 					if ( ! element ) {
+						hideInsertionPoint();
 						return;
 					}
 				}

--- a/packages/block-editor/src/components/block-tools/insertion-point.js
+++ b/packages/block-editor/src/components/block-tools/insertion-point.js
@@ -24,7 +24,7 @@ function InsertionPointPopover( {
 	__unstablePopoverSlot,
 	__unstableContentRef,
 } ) {
-	const { selectBlock, hideInsertionPoint } = useDispatch( blockEditorStore );
+	const { selectBlock } = useDispatch( blockEditorStore );
 	const openRef = useContext( InsertionPointOpenRef );
 	const ref = useRef();
 	const {
@@ -85,14 +85,6 @@ function InsertionPointPopover( {
 		// bubbled from the inserter itself.
 		if ( event.target !== ref.current ) {
 			openRef.current = true;
-		}
-	}
-
-	function maybeHideInserterPoint( event ) {
-		// Only hide the inserter if it's triggered on the wrapper,
-		// and the inserter is not open.
-		if ( event.target === ref.current && ! openRef.current ) {
-			hideInsertionPoint();
 		}
 	}
 
@@ -195,7 +187,6 @@ function InsertionPointPopover( {
 				className={ classnames( className, {
 					'is-with-inserter': isInserterShown,
 				} ) }
-				onHoverEnd={ maybeHideInserterPoint }
 			>
 				<motion.div
 					variants={ lineVariants }


### PR DESCRIPTION
## What?

In some situations, the in-between inserter lingers. This PR tries to improves the situation by hiding the inserter when it should.

## How?

Move showing and hiding the inserter to the same event handler.

## Testing Instructions

1- Test the inbetween inserter in all different situations : between nested blocks, template parts, drag and drop, hovering inserter items..
