### PR TITLE
Fix clickable placeholder upload button

### DIFF
--- a/packages/components/src/placeholder/style.scss
+++ b/packages/components/src/placeholder/style.scss
@@ -201,6 +201,7 @@
 	.components-placeholder__instructions,
 	.components-button {
 		opacity: 0;
+		pointer-events: none;
 		transition: opacity 0.1s linear;
 		@include reduce-motion("transition");
 	}
@@ -210,6 +211,7 @@
 		.components-placeholder__instructions,
 		.components-button {
 			opacity: 1;
+			pointer-events: auto;
 		}
 	}
 


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Fixes: https://github.com/WordPress/gutenberg/issues/44815
Related PR about why we can't use `visibility`: https://github.com/WordPress/gutenberg/pull/43323.

When `Site Logo` and `Featured Image` blocks are on a page, the upload button is clickable even when it isn't visible.

## Testing instructions
1. Insert `Site Logo` and `Featured Image` blocks with no images set.
2. If not selected the `upload` buttons should not be clickable
3. Navigation with arrow keys should have no issues
4. Make sure no visual regression has been introduced