### PR TITLE
Components: Refactor `TreeGrid`'s `RovingTabIndex` tests to RTL

### DIFF
--- a/packages/components/src/tree-grid/test/roving-tab-index.js
+++ b/packages/components/src/tree-grid/test/roving-tab-index.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import TestRenderer from 'react-test-renderer';
+import { render } from '@testing-library/react';
 
 /**
  * Internal dependencies
@@ -10,12 +10,12 @@ import RovingTabIndex from '../roving-tab-index';
 
 describe( 'RovingTabIndex', () => {
 	it( 'does not render any elements other than its children', () => {
-		const renderer = TestRenderer.create(
+		const { container } = render(
 			<RovingTabIndex>
 				<div>child element</div>
 			</RovingTabIndex>
 		);
 
-		expect( renderer.toJSON() ).toMatchSnapshot();
+		expect( container.firstChild ).toMatchSnapshot();
 	} );
 } );


### PR DESCRIPTION
## What?
This PR refactors the `TreeGrid`'s `RovingTabIndex` tests to use `@testing-library/react` instead of `react-test-renderer`

Part of #44780.

## Why?
It is a part of the recent effort to use `@testing-library/react` as the primary testing library.

## How?
We're updating rendering to now be with RTL.

## Testing Instructions
Verify tests still pass: `npm run test:unit packages/components/src/tree-grid/test/roving-tab-index.js`
