### PR TITLE
Ensure style card effect doesn't cause scrollbars to appear.

### DIFF
--- a/packages/edit-site/src/components/global-styles/preview.js
+++ b/packages/edit-site/src/components/global-styles/preview.js
@@ -93,7 +93,7 @@ const StylesPreview = ( { label, isFocused, withHoverView } ) => {
 			return [
 				...styles,
 				{
-					css: 'body{min-width: 0;padding: 0;border: none;}',
+					css: 'html{overflow:hidden}body{min-width: 0;padding: 0;border: none;}',
 					isGlobalStyles: true,
 				},
 			];


### PR DESCRIPTION
Fixes #44796.

This happens when the spring animation overshoots above scale(1) during the transition.