### PR TITLE
Components: Refactor `TreeGridRow` tests to RTL

### DIFF
--- a/packages/components/src/tree-grid/test/__snapshots__/row.js.snap
+++ b/packages/components/src/tree-grid/test/__snapshots__/row.js.snap
@@ -2,31 +2,35 @@
 
 exports[`TreeGridRow forwards other props to the rendered tr element 1`] = `
 <table>
-  <tr
-    aria-level="1"
-    aria-posinset="1"
-    aria-setsize="1"
-    className="my-row"
-    role="row"
-  >
-    <td>
-      Test
-    </td>
-  </tr>
+  <tbody>
+    <tr
+      aria-level="1"
+      aria-posinset="1"
+      aria-setsize="1"
+      class="my-row"
+      role="row"
+    >
+      <td>
+        Test
+      </td>
+    </tr>
+  </tbody>
 </table>
 `;
 
 exports[`TreeGridRow renders a tr with support for level, positionInSet and setSize props 1`] = `
 <table>
-  <tr
-    aria-level="1"
-    aria-posinset="1"
-    aria-setsize="1"
-    role="row"
-  >
-    <td>
-      Test
-    </td>
-  </tr>
+  <tbody>
+    <tr
+      aria-level="1"
+      aria-posinset="1"
+      aria-setsize="1"
+      role="row"
+    >
+      <td>
+        Test
+      </td>
+    </tr>
+  </tbody>
 </table>
 `;

--- a/packages/components/src/tree-grid/test/row.js
+++ b/packages/components/src/tree-grid/test/row.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import TestRenderer from 'react-test-renderer';
+import { render } from '@testing-library/react';
 
 /**
  * Internal dependencies
@@ -10,31 +10,35 @@ import TreeGridRow from '../row';
 
 describe( 'TreeGridRow', () => {
 	it( 'renders a tr with support for level, positionInSet and setSize props', () => {
-		const renderer = TestRenderer.create(
+		const { container } = render(
 			<table>
-				<TreeGridRow level="1" positionInSet="1" setSize="1">
-					<td>Test</td>
-				</TreeGridRow>
+				<tbody>
+					<TreeGridRow level="1" positionInSet="1" setSize="1">
+						<td>Test</td>
+					</TreeGridRow>
+				</tbody>
 			</table>
 		);
 
-		expect( renderer.toJSON() ).toMatchSnapshot();
+		expect( container.firstChild ).toMatchSnapshot();
 	} );
 
 	it( 'forwards other props to the rendered tr element', () => {
-		const renderer = TestRenderer.create(
+		const { container } = render(
 			<table>
-				<TreeGridRow
-					className="my-row"
-					level="1"
-					positionInSet="1"
-					setSize="1"
-				>
-					<td>Test</td>
-				</TreeGridRow>
+				<tbody>
+					<TreeGridRow
+						className="my-row"
+						level="1"
+						positionInSet="1"
+						setSize="1"
+					>
+						<td>Test</td>
+					</TreeGridRow>
+				</tbody>
 			</table>
 		);
 
-		expect( renderer.toJSON() ).toMatchSnapshot();
+		expect( container.firstChild ).toMatchSnapshot();
 	} );
 } );


### PR DESCRIPTION
## What?
This PR refactors the `TreeGridRow` tests to use `@testing-library/react` instead of `react-test-renderer`.

Part of #44780.

## Why?
It is a part of the recent effort to use `@testing-library/react` as the primary testing library.

## How?
We're updating rendering to now be with RTL.

## Testing Instructions
Verify tests still pass: `npm run test:unit packages/components/src/tree-grid/test/row.js`
