### PR TITLE
Simplify BlockStyles preview by removing the slot

### DIFF
--- a/packages/block-editor/src/components/block-inspector/index.js
+++ b/packages/block-editor/src/components/block-inspector/index.js
@@ -242,10 +242,7 @@ const BlockInspectorSingleBlock = ( { clientId, blockName } ) => {
 			{ hasBlockStyles && (
 				<div>
 					<PanelBody title={ __( 'Styles' ) }>
-						<BlockStyles
-							scope="core/block-inspector"
-							clientId={ clientId }
-						/>
+						<BlockStyles clientId={ clientId } />
 						{ hasBlockSupport(
 							blockName,
 							'defaultStylePicker',

--- a/packages/block-editor/src/components/block-styles/index.js
+++ b/packages/block-editor/src/components/block-styles/index.js
@@ -6,14 +6,14 @@ import classnames from 'classnames';
 /**
  * WordPress dependencies
  */
-import { useState, useLayoutEffect } from '@wordpress/element';
+import { useState } from '@wordpress/element';
 import { debounce, useViewportMatch } from '@wordpress/compose';
 import {
 	Button,
 	__experimentalTruncate as Truncate,
-	Slot,
-	Fill,
+	Popover,
 } from '@wordpress/components';
+import deprecated from '@wordpress/deprecated';
 
 /**
  * Internal dependencies
@@ -21,32 +21,10 @@ import {
 import BlockStylesPreviewPanel from './preview-panel';
 import useStylesForBlocks from './use-styles-for-block';
 
-function BlockStylesPreviewPanelSlot( { scope } ) {
-	return <Slot name={ `BlockStylesPreviewPanel/${ scope }` } />;
-}
-
-function BlockStylesPreviewPanelFill( { children, scope, ...props } ) {
-	return (
-		<Fill name={ `BlockStylesPreviewPanel/${ scope }` }>
-			<div { ...props }>{ children }</div>
-		</Fill>
-	);
-}
-
-// Top position (in px) of the Block Styles container
-// relative to the editor pane.
-// The value is the equivalent of the container's right position.
-const DEFAULT_POSITION_TOP = 16;
-
 const noop = () => {};
 
 // Block Styles component for the Settings Sidebar.
-function BlockStyles( {
-	clientId,
-	onSwitch = noop,
-	onHoverClassName = noop,
-	scope,
-} ) {
+function BlockStyles( { clientId, onSwitch = noop, onHoverClassName = noop } ) {
 	const {
 		onSelect,
 		stylesToRender,
@@ -58,16 +36,7 @@ function BlockStyles( {
 		onSwitch,
 	} );
 	const [ hoveredStyle, setHoveredStyle ] = useState( null );
-	const [ containerScrollTop, setContainerScrollTop ] = useState( 0 );
 	const isMobileViewport = useViewportMatch( 'medium', '<' );
-
-	useLayoutEffect( () => {
-		const scrollContainer = document.querySelector(
-			'.interface-interface-skeleton__content'
-		);
-		const scrollTop = scrollContainer?.scrollTop || 0;
-		setContainerScrollTop( scrollTop + DEFAULT_POSITION_TOP );
-	}, [ hoveredStyle ] );
 
 	if ( ! stylesToRender || stylesToRender.length === 0 ) {
 		return null;
@@ -127,23 +96,31 @@ function BlockStyles( {
 				} ) }
 			</div>
 			{ hoveredStyle && ! isMobileViewport && (
-				<BlockStylesPreviewPanelFill
-					scope={ scope }
-					className="block-editor-block-styles__preview-panel"
-					style={ { top: containerScrollTop } }
-					onMouseLeave={ () => styleItemHandler( null ) }
-				>
-					<BlockStylesPreviewPanel
-						activeStyle={ activeStyle }
-						className={ previewClassName }
-						genericPreviewBlock={ genericPreviewBlock }
-						style={ hoveredStyle }
-					/>
-				</BlockStylesPreviewPanelFill>
+				<Popover placement="left-start" offset={ 20 }>
+					<div
+						className="block-editor-block-styles__preview-panel"
+						onMouseLeave={ () => styleItemHandler( null ) }
+					>
+						<BlockStylesPreviewPanel
+							activeStyle={ activeStyle }
+							className={ previewClassName }
+							genericPreviewBlock={ genericPreviewBlock }
+							style={ hoveredStyle }
+						/>
+					</div>
+				</Popover>
 			) }
 		</div>
 	);
 }
 
-BlockStyles.Slot = BlockStylesPreviewPanelSlot;
 export default BlockStyles;
+
+BlockStyles.Slot = () => {
+	deprecated( 'BlockStyles.Slot', {
+		version: '6.4',
+		since: '6.2',
+	} );
+
+	return null;
+};

--- a/packages/edit-post/src/components/layout/index.js
+++ b/packages/edit-post/src/components/layout/index.js
@@ -16,7 +16,7 @@ import {
 	store as editorStore,
 } from '@wordpress/editor';
 import { useSelect, useDispatch } from '@wordpress/data';
-import { BlockBreadcrumb, BlockStyles } from '@wordpress/block-editor';
+import { BlockBreadcrumb } from '@wordpress/block-editor';
 import { Button, ScrollLock, Popover } from '@wordpress/components';
 import { useViewportMatch } from '@wordpress/compose';
 import { PluginArea } from '@wordpress/plugins';
@@ -252,7 +252,6 @@ function Layout( { styles } ) {
 						{ isMobileViewport && sidebarIsOpened && (
 							<ScrollLock />
 						) }
-						<BlockStyles.Slot scope="core/block-inspector" />
 					</>
 				}
 				footer={

--- a/packages/edit-site/src/components/editor/index.js
+++ b/packages/edit-site/src/components/editor/index.js
@@ -8,7 +8,6 @@ import { EntityProvider, store as coreStore } from '@wordpress/core-data';
 import {
 	BlockContextProvider,
 	BlockBreadcrumb,
-	BlockStyles,
 	store as blockEditorStore,
 } from '@wordpress/block-editor';
 import {
@@ -260,7 +259,6 @@ function Editor( { onError } ) {
 											content={
 												<>
 													<EditorNotices />
-													<BlockStyles.Slot scope="core/block-inspector" />
 													{ editorMode === 'visual' &&
 														template && (
 															<BlockEditor

--- a/packages/edit-widgets/src/components/layout/interface.js
+++ b/packages/edit-widgets/src/components/layout/interface.js
@@ -2,7 +2,7 @@
  * WordPress dependencies
  */
 import { useViewportMatch } from '@wordpress/compose';
-import { BlockBreadcrumb, BlockStyles } from '@wordpress/block-editor';
+import { BlockBreadcrumb } from '@wordpress/block-editor';
 import { useEffect } from '@wordpress/element';
 import { useDispatch, useSelect } from '@wordpress/data';
 import {
@@ -106,7 +106,6 @@ function Interface( { blockEditorSettings } ) {
 					<WidgetAreasBlockEditorContent
 						blockEditorSettings={ blockEditorSettings }
 					/>
-					<BlockStyles.Slot scope="core/block-inspector" />
 				</>
 			}
 			footer={


### PR DESCRIPTION
Follow-up to the discussion here https://github.com/WordPress/gutenberg/pull/34522#issuecomment-1273016139

## What?

This is a small refactoring to the block styles preview to avoid relying on Slot/Fill

## Why?

We have too many slots and boilerplate code we need to write every time we want to build a new block editor instance. This PR just removes one of these Slots and make the preview contextual to the BlockStyles element instead.

The difference with trunk is that instead of the styles preview showing up at the top of the canvas, they will be aligned with the "Styles panel" instead.

## Testing Instructions

1- Select a block with styles variations like "Button"
2- Hover the style variations in the sidebar
3- The preview should show up at the left of the buttons.

## Screenshots or screencast

<img width="1440" alt="Screen Shot 2022-10-10 at 2 17 30 PM" src="https://user-images.githubusercontent.com/272444/194875384-996624c5-0ee9-4ed9-aed7-6dfe5409c4d4.png">
