### PR TITLE
[Block Settings]: Show `move to` on nested blocks when only one root block

### DIFF
--- a/packages/block-editor/src/components/block-settings-menu/block-settings-dropdown.js
+++ b/packages/block-editor/src/components/block-settings-menu/block-settings-dropdown.js
@@ -91,7 +91,7 @@ export function BlockSettingsDropdown( {
 			return {
 				firstParentClientId: _firstParentClientId,
 				isDistractionFree: getSettings().isDistractionFree,
-				onlyBlock: 1 === getBlockCount(),
+				onlyBlock: 1 === getBlockCount( _firstParentClientId ),
 				parentBlockType:
 					getActiveBlockVariation(
 						parentBlockName,

--- a/packages/block-editor/src/components/block-settings-menu/block-settings-dropdown.js
+++ b/packages/block-editor/src/components/block-settings-menu/block-settings-dropdown.js
@@ -74,7 +74,7 @@ export function BlockSettingsDropdown( {
 			const {
 				getBlockCount,
 				getBlockName,
-				getBlockParents,
+				getBlockRootClientId,
 				getPreviousBlockClientId,
 				getNextBlockClientId,
 				getSelectedBlockClientIds,
@@ -84,19 +84,22 @@ export function BlockSettingsDropdown( {
 
 			const { getActiveBlockVariation } = select( blocksStore );
 
-			const parents = getBlockParents( firstBlockClientId );
-			const _firstParentClientId = parents[ parents.length - 1 ];
-			const parentBlockName = getBlockName( _firstParentClientId );
+			const _firstParentClientId =
+				getBlockRootClientId( firstBlockClientId );
+			const parentBlockName =
+				_firstParentClientId && getBlockName( _firstParentClientId );
 
 			return {
 				firstParentClientId: _firstParentClientId,
 				isDistractionFree: getSettings().isDistractionFree,
 				onlyBlock: 1 === getBlockCount( _firstParentClientId ),
 				parentBlockType:
-					getActiveBlockVariation(
+					_firstParentClientId &&
+					( getActiveBlockVariation(
 						parentBlockName,
 						getBlockAttributes( _firstParentClientId )
-					) || getBlockType( parentBlockName ),
+					) ||
+						getBlockType( parentBlockName ) ),
 				previousBlockClientId:
 					getPreviousBlockClientId( firstBlockClientId ),
 				nextBlockClientId: getNextBlockClientId( firstBlockClientId ),
@@ -221,7 +224,7 @@ export function BlockSettingsDropdown( {
 								<__unstableBlockSettingsMenuFirstItem.Slot
 									fillProps={ { onClose } }
 								/>
-								{ firstParentClientId !== undefined && (
+								{ !! firstParentClientId && (
 									<MenuItem
 										{ ...showParentOutlineGestures }
 										ref={ selectParentButtonRef }


### PR DESCRIPTION


<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Fixes: https://github.com/WordPress/gutenberg/issues/41889

"Move to" in the block settings dropdown only shows if there is more than one top-level block. For example, if all the post content is contained inside a Columns block, it is not possible to use the "Move to" feature on any of its inner blocks.

This PR fixes that by checking the parents block count

## Testing Instructions
1. In a post, add a `Group` block, and add only `one` block inside it.
2. Observe that `Move to` is not shown for both blocks.
3. Then add more blocks inside the top level `Group` block
4. Verify that `Move to` is shown in the block settings dropdown for any of those blocks inside the Group block.
5. Verify that `Move to` is not shown on the parent `Group` block.
6. Add more top level blocks and verify that `Move to` is shown to every root block

<!-- In a few words, what is the PR actually doing? -->
