### PR TITLE
Fix: PHP 8.1 Deprecation messages

### DIFF
--- a/lib/compat/plugin/edit-site-routes-backwards-compat.php
+++ b/lib/compat/plugin/edit-site-routes-backwards-compat.php
@@ -28,7 +28,7 @@
  */
 function gutenberg_site_editor_menu() {
 	if ( wp_is_block_theme() ) {
-		add_submenu_page( null, null, null, 'edit_theme_options', 'gutenberg-edit-site', '__return_empty_string' );
+		add_submenu_page( '', '', '', 'edit_theme_options', 'gutenberg-edit-site', '__return_empty_string' );
 	}
 }
 add_action( 'admin_menu', 'gutenberg_site_editor_menu', 9 );


### PR DESCRIPTION
## What?
Fixes two PHP 8.1 Deprecation messages.

- `Deprecated: strpos(): Passing null to parameter #1 ($haystack) of type string is deprecated`
- `Deprecated: str_replace(): Passing null to parameter #3 ($subject) of type array|string is deprecated`

The first three parameter of [add_submenu_page](https://developer.wordpress.org/reference/functions/add_submenu_page/) need to be strings.

