### PR TITLE
Fix: PHP 8.1 Deprecation - strncmp(): Passing null to parameter

### DIFF
--- a/lib/compat/wordpress-6.1/class-wp-theme-json-6-1.php
+++ b/lib/compat/wordpress-6.1/class-wp-theme-json-6-1.php
@@ -1078,7 +1078,7 @@ class WP_Theme_JSON_6_1 extends WP_Theme_JSON_6_0 {
 	 * @param array $styles Styles subtree.
 	 * @param array $path   Which property to process.
 	 * @param array $theme_json Theme JSON array.
-	 * @return string Style property value.
+	 * @return string|array|null Style property value.
 	 */
 	protected static function get_property_value( $styles, $path, $theme_json = null ) {
 		$value = _wp_array_get( $styles, $path );

--- a/lib/compat/wordpress-6.1/class-wp-theme-json-6-1.php
+++ b/lib/compat/wordpress-6.1/class-wp-theme-json-6-1.php
@@ -1101,7 +1101,7 @@ class WP_Theme_JSON_6_1 extends WP_Theme_JSON_6_0 {
 			}
 		}
 
-		if ( is_array( $value ) ) {
+		if ( ! $value || is_array( $value ) ) {
 			return $value;
 		}
 


### PR DESCRIPTION
## What?
If the `$value` is `null`, we don't need to do some string checks, because they throw PHP 8.1 deprecation messages: `strncmp(): Passing null to parameter #1 ($string1) of type string is deprecated`.


Fixes: #44792 


