### PR TITLE
Mobile - Tooltip - Migrate from React Test Render to React Native Testing Library

### DIFF
--- a/packages/components/src/tooltip/test/index.native.js
+++ b/packages/components/src/tooltip/test/index.native.js
@@ -1,8 +1,7 @@
 /**
  * External dependencies
  */
-import { act } from 'react-test-renderer';
-import { fireEvent, render } from 'test/helpers';
+import { fireEvent, render, act } from 'test/helpers';
 import { Keyboard, Text } from 'react-native';
 
 /**


### PR DESCRIPTION
## What?
Part of https://github.com/WordPress/gutenberg/issues/44780

Migrates test from `react-test-render` to `testing-library/react-native`.

## Why?
It is a part of recent efforts to use `@testing-library/react-native` as the project's primary testing library.

## How?
We're just using the helpers from React Native Testing Library instead of the React Test Renderer.

## Testing Instructions
``` 
npm run native test --f packages/components/src/tooltip/test/index.native.js
```