### PR TITLE
Mobile - useResizeObserver - Migrate from React Test Render to React Native Testing Library

### DIFF
--- a/packages/compose/src/hooks/use-resize-observer/index.native.js
+++ b/packages/compose/src/hooks/use-resize-observer/index.native.js
@@ -47,7 +47,11 @@ const useResizeObserver = () => {
 	}, [] );
 
 	const observer = (
-		<View style={ StyleSheet.absoluteFill } onLayout={ onLayout } />
+		<View
+			testID="resize-observer"
+			style={ StyleSheet.absoluteFill }
+			onLayout={ onLayout }
+		/>
 	);
 
 	return [ observer, measurements ];

--- a/packages/compose/src/hooks/use-resize-observer/test/index.native.js
+++ b/packages/compose/src/hooks/use-resize-observer/test/index.native.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { create, act } from 'react-test-renderer';
+import { render, fireEvent } from 'test/helpers';
 import { View } from 'react-native';
 
 /**
@@ -13,36 +13,32 @@ const TestComponent = ( { onLayout } ) => {
 	const [ resizeObserver, sizes ] = useResizeObserver();
 
 	return (
-		<View sizes={ sizes } onLayout={ onLayout }>
+		<View testID="test-component" sizes={ sizes } onLayout={ onLayout }>
 			{ resizeObserver }
 		</View>
 	);
 };
 
-const renderWithOnLayout = ( component ) => {
-	const testComponent = create( component );
-
-	const mockNativeEvent = {
-		nativeEvent: {
-			layout: {
-				width: 300,
-				height: 500,
-			},
-		},
-	};
-
-	act( () => {
-		testComponent.toJSON().children[ 0 ].props.onLayout( mockNativeEvent );
-	} );
-
-	return testComponent.toJSON();
-};
-
 describe( 'useResizeObserver()', () => {
 	it( 'should return "{ width: 300, height: 500 }"', () => {
-		const component = renderWithOnLayout( <TestComponent /> );
+		const mockNativeEvent = {
+			nativeEvent: {
+				layout: {
+					width: 300,
+					height: 500,
+				},
+			},
+		};
 
-		expect( component.props.sizes ).toMatchObject( {
+		const { getByTestId } = render(
+			<TestComponent onLayout={ mockNativeEvent } />
+		);
+
+		const resizeObserver = getByTestId( 'resize-observer' );
+		fireEvent( resizeObserver, 'layout', mockNativeEvent );
+
+		const testComponent = getByTestId( 'test-component' );
+		expect( testComponent.props.sizes ).toMatchObject( {
 			width: 300,
 			height: 500,
 		} );


### PR DESCRIPTION
## What?
Part of https://github.com/WordPress/gutenberg/issues/44780

Migrates test from `react-test-render` to `testing-library/react-native`.

## Why?
It is a part of recent efforts to use `@testing-library/react-native` as the project's primary testing library.

## How?
We're just using the render method from React Native Testing Library, and using `fireEvent` to trigger user actions.

## Testing Instructions
``` 
npm run native test --f packages/compose/src/hooks/use-resize-observer/test/index.native.js
```
