### PR TITLE
Mobile - Code block - Migrate from React Test Render to React Native Testing Library

### DIFF
--- a/packages/block-library/src/code/test/__snapshots__/edit.native.js.snap
+++ b/packages/block-library/src/code/test/__snapshots__/edit.native.js.snap
@@ -1,0 +1,13 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Code renders given text without crashing 1`] = `
+"<!-- wp:code -->
+<pre class=\\"wp-block-code\\"><code>Sample text</code></pre>
+<!-- /wp:code -->"
+`;
+
+exports[`Code renders without crashing 1`] = `
+"<!-- wp:code -->
+<pre class=\\"wp-block-code\\"><code></code></pre>
+<!-- /wp:code -->"
+`;

--- a/packages/block-library/src/code/test/edit.native.js
+++ b/packages/block-library/src/code/test/edit.native.js
@@ -34,6 +34,10 @@ describe( 'Code', () => {
 		// Add block
 		await addBlock( screen, 'Code' );
 
+		// Get block
+		const codeBlock = await getBlock( screen, 'Code' );
+		expect( codeBlock ).toBeVisible();
+
 		expect( getEditorHtml() ).toMatchSnapshot();
 	} );
 

--- a/packages/block-library/src/code/test/edit.native.js
+++ b/packages/block-library/src/code/test/edit.native.js
@@ -1,51 +1,61 @@
 /**
  * External dependencies
  */
-import renderer from 'react-test-renderer';
-import { TextInput } from 'react-native';
+import {
+	fireEvent,
+	getEditorHtml,
+	initializeEditor,
+	addBlock,
+	getBlock,
+} from 'test/helpers';
 
 /**
  * WordPress dependencies
  */
-import { BlockEdit } from '@wordpress/block-editor';
-import { registerBlockType, unregisterBlockType } from '@wordpress/blocks';
-
-/**
- * Internal dependencies
- */
-import { metadata, settings, name } from '../index';
-
-const Code = ( { clientId, ...props } ) => (
-	<BlockEdit name={ name } clientId={ clientId || 0 } { ...props } />
-);
+import { getBlockTypes, unregisterBlockType } from '@wordpress/blocks';
+import { registerCoreBlocks } from '@wordpress/block-library';
 
 describe( 'Code', () => {
 	beforeAll( () => {
-		registerBlockType( name, {
-			...metadata,
-			...settings,
-		} );
+		// Register all core blocks
+		registerCoreBlocks();
 	} );
 
 	afterAll( () => {
-		unregisterBlockType( name );
+		// Clean up registered blocks
+		getBlockTypes().forEach( ( block ) => {
+			unregisterBlockType( block.name );
+		} );
 	} );
 
-	it( 'renders without crashing', () => {
-		const component = renderer.create(
-			<Code attributes={ { content: '' } } />
-		);
-		const rendered = component.toJSON();
-		expect( rendered ).toBeTruthy();
+	it( 'renders without crashing', async () => {
+		const screen = await initializeEditor();
+
+		// Add block
+		await addBlock( screen, 'Code' );
+
+		expect( getEditorHtml() ).toMatchSnapshot();
 	} );
 
-	it( 'renders given text without crashing', () => {
-		const component = renderer.create(
-			<Code attributes={ { content: 'sample text' } } />
-		);
-		const testInstance = component.root;
-		const textInput = testInstance.findByType( TextInput );
-		expect( textInput ).toBeTruthy();
-		expect( textInput.props.value ).toBe( 'sample text' );
+	it( 'renders given text without crashing', async () => {
+		const initialHtml = `<!-- wp:code -->
+		<pre class="wp-block-code"><code>Sample text</code></pre>
+		<!-- /wp:code -->`;
+
+		const screen = await initializeEditor( {
+			initialHtml,
+		} );
+		const { getByDisplayValue } = screen;
+
+		// Get block
+		const codeBlock = await getBlock( screen, 'Code' );
+		expect( codeBlock ).toBeVisible();
+		fireEvent.press( codeBlock );
+
+		// Get initial text
+		const codeBlockText = getByDisplayValue( 'Sample text' );
+		expect( codeBlockText ).toBeVisible();
+
+		expect( getEditorHtml() ).toMatchSnapshot();
 	} );
 } );


### PR DESCRIPTION
## What?
Part of https://github.com/WordPress/gutenberg/issues/44780

Migrates test from `react-test-render` to `testing-library/react-native`.

## Why?
It is a part of recent efforts to use `@testing-library/react-native` as the project's primary testing library.

## How?
We're just using the render method from React Native Testing Library, and using `fireEvent` to trigger user actions.

## Testing Instructions
``` 
npm run native test --f packages/block-library/src/code/test/edit.native.js
```
