### PR TITLE
Edit Post: Refactor 'PluginPostStatusInfo' tests to use RTL

### DIFF
--- a/packages/edit-post/src/components/sidebar/plugin-post-status-info/test/__snapshots__/index.js.snap
+++ b/packages/edit-post/src/components/sidebar/plugin-post-status-info/test/__snapshots__/index.js.snap
@@ -2,7 +2,7 @@
 
 exports[`PluginPostStatusInfo renders fill properly 1`] = `
 <div
-  className="components-panel__row my-plugin-post-status-info"
+  class="components-panel__row my-plugin-post-status-info"
 >
   My plugin post status info
 </div>

--- a/packages/edit-post/src/components/sidebar/plugin-post-status-info/test/index.js
+++ b/packages/edit-post/src/components/sidebar/plugin-post-status-info/test/index.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import ReactTestRenderer from 'react-test-renderer';
+import { render } from '@testing-library/react';
 
 /**
  * WordPress dependencies
@@ -15,15 +15,15 @@ import PluginPostStatusInfo from '../';
 
 describe( 'PluginPostStatusInfo', () => {
 	test( 'renders fill properly', () => {
-		const tree = ReactTestRenderer.create(
+		const { container } = render(
 			<SlotFillProvider>
 				<PluginPostStatusInfo className="my-plugin-post-status-info">
 					My plugin post status info
 				</PluginPostStatusInfo>
 				<PluginPostStatusInfo.Slot />
 			</SlotFillProvider>
-		).toJSON();
+		);
 
-		expect( tree ).toMatchSnapshot();
+		expect( container.firstChild ).toMatchSnapshot();
 	} );
 } );


### PR DESCRIPTION
## What?
Part of #44780.

This PR refactors the `PluginPostStatusInfo` tests to use @testing-library/react instead of `react-test-renderer`.

## Why?
It is a part of the recent effort to use `@testing-library/react` as the primary testing library.

## How?
Updates render method to use RTL

## Testing Instructions
```
npm run test:unit -- packages/edit-post/src/components/sidebar/plugin-post-status-info/test/index.js
```
