### PR TITLE
Fluid typography: ensure fontsizes are strings or integers

### DIFF
--- a/lib/block-supports/typography.php
+++ b/lib/block-supports/typography.php
@@ -282,6 +282,7 @@ function gutenberg_get_typography_value_and_unit( $raw_value, $options = array()
 		return null;
 	}
 
+	// Converts numeric values to pixel values by default.
 	if ( empty( $raw_value ) ) {
 		return null;
 	}

--- a/lib/block-supports/typography.php
+++ b/lib/block-supports/typography.php
@@ -276,7 +276,7 @@ function gutenberg_get_typography_value_and_unit( $raw_value, $options = array()
 	if ( ! is_string( $raw_value ) && ! is_int( $raw_value ) ) {
 		_doing_it_wrong(
 			__FUNCTION__,
-			__( 'Raw size value must be a string or integer.' ),
+			__( 'Raw size value must be a string or integer.', 'gutenberg' ),
 			'6.1.0'
 		);
 		return null;

--- a/lib/block-supports/typography.php
+++ b/lib/block-supports/typography.php
@@ -262,8 +262,8 @@ function gutenberg_render_typography_support( $block_content, $block ) {
  *
  * @access private
  *
- * @param string|int $raw_value Raw size value from theme.json.
- * @param array      $options   {
+ * @param string|int|float $raw_value Raw size value from theme.json.
+ * @param array            $options   {
  *     Optional. An associative array of options. Default is empty array.
  *
  *     @type string        $coerce_to        Coerce the value to rem or px. Default `'rem'`.
@@ -273,10 +273,10 @@ function gutenberg_render_typography_support( $block_content, $block ) {
  * @return array An array consisting of `'value'` and `'unit'` properties.
  */
 function gutenberg_get_typography_value_and_unit( $raw_value, $options = array() ) {
-	if ( ! is_string( $raw_value ) && ! is_int( $raw_value ) ) {
+	if ( ! is_string( $raw_value ) && ! is_int( $raw_value ) && ! is_float( $raw_value ) ) {
 		_doing_it_wrong(
 			__FUNCTION__,
-			__( 'Raw size value must be a string or integer.', 'gutenberg' ),
+			__( 'Raw size value must be a string, integer or a float.', 'gutenberg' ),
 			'6.1.0'
 		);
 		return null;
@@ -411,9 +411,9 @@ function gutenberg_get_computed_fluid_typography_value( $args = array() ) {
  * @param array $preset                     {
  *     Required. fontSizes preset value as seen in theme.json.
  *
- *     @type string     $name Name of the font size preset.
- *     @type string     $slug Kebab-case unique identifier for the font size preset.
- *     @type string|int $size CSS font-size value, including units where applicable.
+ *     @type string           $name Name of the font size preset.
+ *     @type string           $slug Kebab-case unique identifier for the font size preset.
+ *     @type string|int|float $size CSS font-size value, including units where applicable.
  * }
  * @param bool  $should_use_fluid_typography An override to switch fluid typography "on". Can be used for unit testing. Default is `false`.
  *

--- a/lib/block-supports/typography.php
+++ b/lib/block-supports/typography.php
@@ -262,8 +262,8 @@ function gutenberg_render_typography_support( $block_content, $block ) {
  *
  * @access private
  *
- * @param string|number $raw_value Raw size value from theme.json.
- * @param array         $options   {
+ * @param string|int $raw_value Raw size value from theme.json.
+ * @param array      $options   {
  *     Optional. An associative array of options. Default is empty array.
  *
  *     @type string        $coerce_to        Coerce the value to rem or px. Default `'rem'`.
@@ -273,6 +273,15 @@ function gutenberg_render_typography_support( $block_content, $block ) {
  * @return array An array consisting of `'value'` and `'unit'` properties.
  */
 function gutenberg_get_typography_value_and_unit( $raw_value, $options = array() ) {
+	if ( ! is_string( $raw_value ) && ! is_int( $raw_value ) ) {
+		_doing_it_wrong(
+			__FUNCTION__,
+			__( 'Raw size value must be a string or integer.' ),
+			'6.1.0'
+		);
+		return null;
+	}
+
 	if ( empty( $raw_value ) ) {
 		return null;
 	}
@@ -402,17 +411,25 @@ function gutenberg_get_computed_fluid_typography_value( $args = array() ) {
  * @param array $preset                     {
  *     Required. fontSizes preset value as seen in theme.json.
  *
- *     @type string $name Name of the font size preset.
- *     @type string $slug Kebab-case unique identifier for the font size preset.
- *     @type string $size CSS font-size value, including units where applicable.
+ *     @type string     $name Name of the font size preset.
+ *     @type string     $slug Kebab-case unique identifier for the font size preset.
+ *     @type string|int $size CSS font-size value, including units where applicable.
  * }
  * @param bool  $should_use_fluid_typography An override to switch fluid typography "on". Can be used for unit testing. Default is `false`.
  *
  * @return string|null Font-size value or `null` if a size is not passed in $preset.
  */
 function gutenberg_get_typography_font_size_value( $preset, $should_use_fluid_typography = false ) {
-	if ( ! isset( $preset['size'] ) || empty( $preset['size'] ) ) {
+	if ( ! isset( $preset['size'] ) ) {
 		return null;
+	}
+
+	/*
+	 * Catches empty values and 0/'0'.
+	 * Fluid calculations cannot be performed on 0.
+	 */
+	if ( empty( $preset['size'] ) ) {
+		return $preset['size'];
 	}
 
 	// Check if fluid font sizes are activated.

--- a/packages/block-editor/CHANGELOG.md
+++ b/packages/block-editor/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Bug Fix
 
--   `FontSizePicker`: Update fluid utils so that only string and integers are treated as valid font sizes for the purposes of fluid typography.([#44847](https://github.com/WordPress/gutenberg/pull/44847))
+-   `FontSizePicker`: Update fluid utils so that only string, floats integers are treated as valid font sizes for the purposes of fluid typography.([#44847](https://github.com/WordPress/gutenberg/pull/44847))
 
 ## 10.2.0 (2022-10-05)
 

--- a/packages/block-editor/CHANGELOG.md
+++ b/packages/block-editor/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Bug Fix
 
--   `FontSizePicker`: Update fluid utils so that only string and integers are treated as valid font sizes for the purposes of fluid typography.
+-   `FontSizePicker`: Update fluid utils so that only string and integers are treated as valid font sizes for the purposes of fluid typography.([#44847](https://github.com/WordPress/gutenberg/pull/44847))
 
 ## 10.2.0 (2022-10-05)
 

--- a/packages/block-editor/CHANGELOG.md
+++ b/packages/block-editor/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Bug Fix
+
+-   `FontSizePicker`: Update fluid utils so that only string and integers are treated as valid font sizes for the purposes of fluid typography.
+
 ## 10.2.0 (2022-10-05)
 
 ## 10.1.0 (2022-09-21)

--- a/packages/block-editor/CHANGELOG.md
+++ b/packages/block-editor/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Bug Fix
 
--   `FontSizePicker`: Update fluid utils so that only string, floats integers are treated as valid font sizes for the purposes of fluid typography.([#44847](https://github.com/WordPress/gutenberg/pull/44847))
+-   `FontSizePicker`: Update fluid utils so that only string, floats and integers are treated as valid font sizes for the purposes of fluid typography.([#44847](https://github.com/WordPress/gutenberg/pull/44847))
 
 ## 10.2.0 (2022-10-05)
 

--- a/packages/block-editor/README.md
+++ b/packages/block-editor/README.md
@@ -423,7 +423,7 @@ _Parameters_
 -   _args_ `Object`:
 -   _args.minimumViewPortWidth_ `?string`: Minimum viewport size from which type will have fluidity. Optional if fontSize is specified.
 -   _args.maximumViewPortWidth_ `?string`: Maximum size up to which type will have fluidity. Optional if fontSize is specified.
--   _args.fontSize_ `?string|?number`: Size to derive maximumFontSize and minimumFontSize from, if necessary. Optional if minimumFontSize and maximumFontSize are specified.
+-   _args.fontSize_ `[string|number]`: Size to derive maximumFontSize and minimumFontSize from, if necessary. Optional if minimumFontSize and maximumFontSize are specified.
 -   _args.maximumFontSize_ `?string`: Maximum font size for any clamp() calculation. Optional.
 -   _args.minimumFontSize_ `?string`: Minimum font size for any clamp() calculation. Optional.
 -   _args.scaleFactor_ `?number`: A scale factor to determine how fast a font scales within boundaries. Optional.

--- a/packages/block-editor/README.md
+++ b/packages/block-editor/README.md
@@ -423,7 +423,7 @@ _Parameters_
 -   _args_ `Object`:
 -   _args.minimumViewPortWidth_ `?string`: Minimum viewport size from which type will have fluidity. Optional if fontSize is specified.
 -   _args.maximumViewPortWidth_ `?string`: Maximum size up to which type will have fluidity. Optional if fontSize is specified.
--   _args.fontSize_ `?string`: Size to derive maximumFontSize and minimumFontSize from, if necessary. Optional if minimumFontSize and maximumFontSize are specified.
+-   _args.fontSize_ `?string|?number`: Size to derive maximumFontSize and minimumFontSize from, if necessary. Optional if minimumFontSize and maximumFontSize are specified.
 -   _args.maximumFontSize_ `?string`: Maximum font size for any clamp() calculation. Optional.
 -   _args.minimumFontSize_ `?string`: Minimum font size for any clamp() calculation. Optional.
 -   _args.scaleFactor_ `?number`: A scale factor to determine how fast a font scales within boundaries. Optional.

--- a/packages/block-editor/src/components/font-sizes/fluid-utils.js
+++ b/packages/block-editor/src/components/font-sizes/fluid-utils.js
@@ -32,15 +32,15 @@ const DEFAULT_MAXIMUM_FONT_SIZE_FACTOR = 1.5;
  * } );
  * ```
  *
- * @param {Object}  args
- * @param {?string} args.minimumViewPortWidth  Minimum viewport size from which type will have fluidity. Optional if fontSize is specified.
- * @param {?string} args.maximumViewPortWidth  Maximum size up to which type will have fluidity. Optional if fontSize is specified.
- * @param {?string} args.fontSize              Size to derive maximumFontSize and minimumFontSize from, if necessary. Optional if minimumFontSize and maximumFontSize are specified.
- * @param {?string} args.maximumFontSize       Maximum font size for any clamp() calculation. Optional.
- * @param {?string} args.minimumFontSize       Minimum font size for any clamp() calculation. Optional.
- * @param {?number} args.scaleFactor           A scale factor to determine how fast a font scales within boundaries. Optional.
- * @param {?number} args.minimumFontSizeFactor How much to scale defaultFontSize by to derive minimumFontSize. Optional.
- * @param {?number} args.maximumFontSizeFactor How much to scale defaultFontSize by to derive maximumFontSize. Optional.
+ * @param {Object}          args
+ * @param {?string}         args.minimumViewPortWidth  Minimum viewport size from which type will have fluidity. Optional if fontSize is specified.
+ * @param {?string}         args.maximumViewPortWidth  Maximum size up to which type will have fluidity. Optional if fontSize is specified.
+ * @param {?string|?number} args.fontSize              Size to derive maximumFontSize and minimumFontSize from, if necessary. Optional if minimumFontSize and maximumFontSize are specified.
+ * @param {?string}         args.maximumFontSize       Maximum font size for any clamp() calculation. Optional.
+ * @param {?string}         args.minimumFontSize       Minimum font size for any clamp() calculation. Optional.
+ * @param {?number}         args.scaleFactor           A scale factor to determine how fast a font scales within boundaries. Optional.
+ * @param {?number}         args.minimumFontSizeFactor How much to scale defaultFontSize by to derive minimumFontSize. Optional.
+ * @param {?number}         args.maximumFontSizeFactor How much to scale defaultFontSize by to derive maximumFontSize. Optional.
  *
  * @return {string|null} A font-size value using clamp().
  */
@@ -148,7 +148,7 @@ export function getComputedFluidTypographyValue( {
 
 /**
  * Internal method that checks a string for a unit and value and returns an array consisting of `'value'` and `'unit'`, e.g., [ '42', 'rem' ].
- * A raw font size of `value + unit` is expected. If the value is a number, it will convert to `value + 'px'`.
+ * A raw font size of `value + unit` is expected. If the value is an integer, it will convert to `value + 'px'`.
  *
  * @param {string|number}    rawValue Raw size value from theme.json.
  * @param {Object|undefined} options  Calculation options.
@@ -156,7 +156,11 @@ export function getComputedFluidTypographyValue( {
  * @return {{ unit: string, value: number }|null} An object consisting of `'value'` and `'unit'` properties.
  */
 export function getTypographyValueAndUnit( rawValue, options = {} ) {
-	if ( ! rawValue ) {
+	if ( typeof rawValue === 'number' && ! Number.isInteger( rawValue ) ) {
+		return null;
+	}
+
+	if ( typeof rawValue !== 'string' && typeof rawValue !== 'number' ) {
 		return null;
 	}
 

--- a/packages/block-editor/src/components/font-sizes/fluid-utils.js
+++ b/packages/block-editor/src/components/font-sizes/fluid-utils.js
@@ -160,8 +160,8 @@ export function getTypographyValueAndUnit( rawValue, options = {} ) {
 		return null;
 	}
 
-	// Converts numbers to pixel values by default.
-	if ( typeof rawValue === 'number' ) {
+	// Converts numeric values to pixel values by default.
+	if ( isFinite( rawValue ) ) {
 		rawValue = `${ rawValue }px`;
 	}
 

--- a/packages/block-editor/src/components/font-sizes/fluid-utils.js
+++ b/packages/block-editor/src/components/font-sizes/fluid-utils.js
@@ -32,15 +32,15 @@ const DEFAULT_MAXIMUM_FONT_SIZE_FACTOR = 1.5;
  * } );
  * ```
  *
- * @param {Object}          args
- * @param {?string}         args.minimumViewPortWidth  Minimum viewport size from which type will have fluidity. Optional if fontSize is specified.
- * @param {?string}         args.maximumViewPortWidth  Maximum size up to which type will have fluidity. Optional if fontSize is specified.
- * @param {?string|?number} args.fontSize              Size to derive maximumFontSize and minimumFontSize from, if necessary. Optional if minimumFontSize and maximumFontSize are specified.
- * @param {?string}         args.maximumFontSize       Maximum font size for any clamp() calculation. Optional.
- * @param {?string}         args.minimumFontSize       Minimum font size for any clamp() calculation. Optional.
- * @param {?number}         args.scaleFactor           A scale factor to determine how fast a font scales within boundaries. Optional.
- * @param {?number}         args.minimumFontSizeFactor How much to scale defaultFontSize by to derive minimumFontSize. Optional.
- * @param {?number}         args.maximumFontSizeFactor How much to scale defaultFontSize by to derive maximumFontSize. Optional.
+ * @param {Object}        args
+ * @param {?string}       args.minimumViewPortWidth  Minimum viewport size from which type will have fluidity. Optional if fontSize is specified.
+ * @param {?string}       args.maximumViewPortWidth  Maximum size up to which type will have fluidity. Optional if fontSize is specified.
+ * @param {string|number} [args.fontSize]            Size to derive maximumFontSize and minimumFontSize from, if necessary. Optional if minimumFontSize and maximumFontSize are specified.
+ * @param {?string}       args.maximumFontSize       Maximum font size for any clamp() calculation. Optional.
+ * @param {?string}       args.minimumFontSize       Minimum font size for any clamp() calculation. Optional.
+ * @param {?number}       args.scaleFactor           A scale factor to determine how fast a font scales within boundaries. Optional.
+ * @param {?number}       args.minimumFontSizeFactor How much to scale defaultFontSize by to derive minimumFontSize. Optional.
+ * @param {?number}       args.maximumFontSizeFactor How much to scale defaultFontSize by to derive maximumFontSize. Optional.
  *
  * @return {string|null} A font-size value using clamp().
  */
@@ -156,10 +156,6 @@ export function getComputedFluidTypographyValue( {
  * @return {{ unit: string, value: number }|null} An object consisting of `'value'` and `'unit'` properties.
  */
 export function getTypographyValueAndUnit( rawValue, options = {} ) {
-	if ( typeof rawValue === 'number' && ! Number.isInteger( rawValue ) ) {
-		return null;
-	}
-
 	if ( typeof rawValue !== 'string' && typeof rawValue !== 'number' ) {
 		return null;
 	}

--- a/packages/block-editor/src/components/font-sizes/test/fluid-utils.js
+++ b/packages/block-editor/src/components/font-sizes/test/fluid-utils.js
@@ -97,8 +97,71 @@ describe( 'getComputedFluidTypographyValue()', () => {
 					value: [ '10' ],
 					expected: null,
 				},
+				{
+					value: '10vh',
+					expected: null,
+				},
+				{
+					value: 'calc(2 * 10px)',
+					expected: null,
+				},
+				{
+					value: 'clamp(15px, 0.9375rem + ((1vw - 7.68px) * 5.409), 60px)',
+					expected: null,
+				},
+				{
+					value: '10',
+					expected: {
+						value: 10,
+						unit: 'px',
+					},
+				},
+				{
+					value: 11,
+					expected: {
+						value: 11,
+						unit: 'px',
+					},
+				},
+				{
+					value: 11.234,
+					expected: {
+						value: 11.234,
+						unit: 'px',
+					},
+				},
+				{
+					value: '12rem',
+					expected: {
+						value: 12,
+						unit: 'rem',
+					},
+				},
+				{
+					value: '12px',
+					expected: {
+						value: 12,
+						unit: 'px',
+					},
+				},
+				{
+					value: '12em',
+					expected: {
+						value: 12,
+						unit: 'em',
+					},
+				},
+				{
+					value: '12.74em',
+					expected: {
+						value: 12.74,
+						unit: 'em',
+					},
+				},
 			].forEach( ( { value, expected } ) => {
-				expect( getTypographyValueAndUnit( value ) ).toBe( expected );
+				expect( getTypographyValueAndUnit( value ) ).toEqual(
+					expected
+				);
 			} );
 		} );
 	} );

--- a/packages/block-editor/src/components/font-sizes/test/fluid-utils.js
+++ b/packages/block-editor/src/components/font-sizes/test/fluid-utils.js
@@ -94,10 +94,6 @@ describe( 'getComputedFluidTypographyValue()', () => {
 					expected: null,
 				},
 				{
-					value: 10.1234,
-					expected: null,
-				},
-				{
 					value: [ '10' ],
 					expected: null,
 				},

--- a/packages/block-editor/src/components/font-sizes/test/fluid-utils.js
+++ b/packages/block-editor/src/components/font-sizes/test/fluid-utils.js
@@ -6,7 +6,10 @@ import { logged } from '@wordpress/deprecated';
 /**
  * Internal dependencies
  */
-import { getComputedFluidTypographyValue } from '../fluid-utils';
+import {
+	getComputedFluidTypographyValue,
+	getTypographyValueAndUnit,
+} from '../fluid-utils';
 
 describe( 'getComputedFluidTypographyValue()', () => {
 	afterEach( () => {
@@ -73,5 +76,34 @@ describe( 'getComputedFluidTypographyValue()', () => {
 		expect( fluidTypographyValues ).toBe(
 			'clamp(15px, 0.9375rem + ((1vw - 7.68px) * 5.409), 60px)'
 		);
+	} );
+
+	describe( 'getTypographyValueAndUnit', () => {
+		it( 'should return the expected return values', () => {
+			[
+				{
+					value: null,
+					expected: null,
+				},
+				{
+					value: false,
+					expected: null,
+				},
+				{
+					value: true,
+					expected: null,
+				},
+				{
+					value: 10.1234,
+					expected: null,
+				},
+				{
+					value: [ '10' ],
+					expected: null,
+				},
+			].forEach( ( { value, expected } ) => {
+				expect( getTypographyValueAndUnit( value ) ).toBe( expected );
+			} );
+		} );
 	} );
 } );

--- a/packages/edit-site/src/components/global-styles/test/typography-utils.js
+++ b/packages/edit-site/src/components/global-styles/test/typography-utils.js
@@ -15,6 +15,23 @@ describe( 'typography utils', () => {
 					typographySettings: undefined,
 					expected: '28px',
 				},
+				// Default return value where font size is 0.
+				{
+					preset: {
+						size: 0,
+					},
+					typographySettings: undefined,
+					expected: 0,
+				},
+				// Default return value where font size is '0'.
+				{
+					preset: {
+						size: '0',
+					},
+					typographySettings: undefined,
+					expected: '0',
+				},
+
 				// Default return non-fluid value where `size` is undefined.
 				{
 					preset: {

--- a/packages/edit-site/src/components/global-styles/test/typography-utils.js
+++ b/packages/edit-site/src/components/global-styles/test/typography-utils.js
@@ -51,7 +51,7 @@ describe( 'typography utils', () => {
 					},
 					expected: '28px',
 				},
-				// Should coerce number to `px` and return fluid value.
+				// Should coerce integer to `px` and return fluid value.
 				{
 					preset: {
 						size: 33,
@@ -62,6 +62,19 @@ describe( 'typography utils', () => {
 					},
 					expected:
 						'clamp(24.75px, 1.546875rem + ((1vw - 7.68px) * 2.975), 49.5px)',
+				},
+
+				// Should coerce float to `px` and return fluid value.
+				{
+					preset: {
+						size: 100.23,
+						fluid: true,
+					},
+					typographySettings: {
+						fluid: true,
+					},
+					expected:
+						'clamp(75.1725px, 4.69828125rem + ((1vw - 7.68px) * 9.035), 150.345px)',
 				},
 				// Should return incoming value when already clamped.
 				{

--- a/packages/edit-site/src/components/global-styles/test/typography-utils.js
+++ b/packages/edit-site/src/components/global-styles/test/typography-utils.js
@@ -97,6 +97,17 @@ describe( 'typography utils', () => {
 					expected:
 						'clamp(1.3125rem, 1.3125rem + ((1vw - 0.48rem) * 2.524), 2.625rem)',
 				},
+				// Should return fluid value for floats with units.
+				{
+					preset: {
+						size: '100.175px',
+					},
+					typographySettings: {
+						fluid: true,
+					},
+					expected:
+						'clamp(75.13125px, 4.695703125rem + ((1vw - 7.68px) * 9.03), 150.2625px)',
+				},
 				// Should return default fluid values with empty fluid array.
 				{
 					preset: {

--- a/packages/edit-site/src/components/global-styles/typography-utils.js
+++ b/packages/edit-site/src/components/global-styles/typography-utils.js
@@ -12,12 +12,12 @@ import { getComputedFluidTypographyValue } from '@wordpress/block-editor';
 /**
  * @typedef {Object} FluidPreset
  * @property {string|undefined} max A maximum font size value.
- * @property {string|undefined} min A minimum font size value.
+ * @property {?string|undefined} min A minimum font size value.
  */
 
 /**
  * @typedef {Object} Preset
- * @property {string}                        size  A default font size.
+ * @property {?string|?number}               size  A default font size.
  * @property {string}                        name  A font size name, displayed in the UI.
  * @property {string}                        slug  A font size slug
  * @property {boolean|FluidPreset|undefined} fluid A font size slug
@@ -31,10 +31,18 @@ import { getComputedFluidTypographyValue } from '@wordpress/block-editor';
  * @param {Object}  typographySettings
  * @param {boolean} typographySettings.fluid Whether fluid typography is enabled.
  *
- * @return {string} An font-size value
+ * @return {string|*} A font-size value or the value of preset.size.
  */
 export function getTypographyFontSizeValue( preset, typographySettings ) {
 	const { size: defaultSize } = preset;
+
+	/*
+	 * Catches falsy values and 0/'0'.
+	 * Fluid calculations cannot be performed on 0.
+	 */
+	if ( ! defaultSize || '0' === defaultSize ) {
+		return defaultSize;
+	}
 
 	if ( true !== typographySettings?.fluid ) {
 		return defaultSize;

--- a/phpunit/block-supports/typography-test.php
+++ b/phpunit/block-supports/typography-test.php
@@ -323,6 +323,22 @@ class WP_Block_Supports_Typography_Test extends WP_UnitTestCase {
 				'expected_output'             => '28px',
 			),
 
+			'size: int 0'                                  => array(
+				'font_size_preset'            => array(
+					'size' => 0,
+				),
+				'should_use_fluid_typography' => true,
+				'expected_output'             => 0,
+			),
+
+			'size: string 0'                               => array(
+				'font_size_preset'            => array(
+					'size' => '0',
+				),
+				'should_use_fluid_typography' => true,
+				'expected_output'             => '0',
+			),
+
 			'default_return_value_when_size_is_undefined'  => array(
 				'font_size_preset'            => array(
 					'size' => null,
@@ -519,6 +535,37 @@ class WP_Block_Supports_Typography_Test extends WP_UnitTestCase {
 				'should_use_fluid_typography' => true,
 				'expected_output'             => "<div class=\"wp-block-group\" style=\"font-size:clamp(0.75em, 0.75em + ((1vw - 0.48em) * 1.442), 1.5em);\"> \n \n<p style=\"font-size:1em\">A paragraph inside a group</p></div>",
 			),
+		);
+	}
+
+	/**
+	 * Tests generating font size values, including fluid formulae, from fontSizes preset.
+	 *
+	 * @ticket 56467
+	 *
+	 * @covers ::gutenberg_get_typography_value_and_unit
+	 *
+	 * @dataProvider data_invalid_size_wp_get_typography_value_and_unit
+	 * @expectedIncorrectUsage gutenberg_get_typography_value_and_unit
+	 *
+	 * @param mixed $raw_value Raw size value to test.
+	 */
+	public function test_invalid_size_wp_get_typography_value_and_unit( $raw_value ) {
+		$this->assertNull( gutenberg_get_typography_value_and_unit( $raw_value ) );
+	}
+
+	/**
+	 * Data provider.
+	 *
+	 * @return array
+	 */
+	public function data_invalid_size_wp_get_typography_value_and_unit() {
+		return array(
+			'size: null'  => array( null ),
+			'size: false' => array( false ),
+			'size: true'  => array( true ),
+			'size: float' => array( 10.1234 ),
+			'size: array' => array( array( '10' ) ),
 		);
 	}
 }

--- a/phpunit/block-supports/typography-test.php
+++ b/phpunit/block-supports/typography-test.php
@@ -315,7 +315,7 @@ class WP_Block_Supports_Typography_Test extends WP_UnitTestCase {
 	 */
 	public function data_generate_font_size_preset_fixtures() {
 		return array(
-			'default_return_value'                         => array(
+			'default_return_value'                        => array(
 				'font_size_preset'            => array(
 					'size' => '28px',
 				),
@@ -323,7 +323,7 @@ class WP_Block_Supports_Typography_Test extends WP_UnitTestCase {
 				'expected_output'             => '28px',
 			),
 
-			'size: int 0'                                  => array(
+			'size: int 0'                                 => array(
 				'font_size_preset'            => array(
 					'size' => 0,
 				),
@@ -331,7 +331,7 @@ class WP_Block_Supports_Typography_Test extends WP_UnitTestCase {
 				'expected_output'             => 0,
 			),
 
-			'size: string 0'                               => array(
+			'size: string 0'                              => array(
 				'font_size_preset'            => array(
 					'size' => '0',
 				),
@@ -339,7 +339,7 @@ class WP_Block_Supports_Typography_Test extends WP_UnitTestCase {
 				'expected_output'             => '0',
 			),
 
-			'default_return_value_when_size_is_undefined'  => array(
+			'default_return_value_when_size_is_undefined' => array(
 				'font_size_preset'            => array(
 					'size' => null,
 				),
@@ -347,7 +347,7 @@ class WP_Block_Supports_Typography_Test extends WP_UnitTestCase {
 				'expected_output'             => null,
 			),
 
-			'default_return_value_when_fluid_is_false'     => array(
+			'default_return_value_when_fluid_is_false'    => array(
 				'font_size_preset'            => array(
 					'size'  => '28px',
 					'fluid' => false,
@@ -365,7 +365,7 @@ class WP_Block_Supports_Typography_Test extends WP_UnitTestCase {
 				'expected_output'             => 'clamp(21px, 1.3125rem + ((1vw - 7.68px) * 2.524), 42px)',
 			),
 
-			'default_return_value_with_unsupported_unit'   => array(
+			'default_return_value_with_unsupported_unit'  => array(
 				'font_size_preset'            => array(
 					'size'  => '1000%',
 					'fluid' => false,
@@ -374,7 +374,7 @@ class WP_Block_Supports_Typography_Test extends WP_UnitTestCase {
 				'expected_output'             => '1000%',
 			),
 
-			'return_fluid_value'                           => array(
+			'return_fluid_value'                          => array(
 				'font_size_preset'            => array(
 					'size' => '1.75rem',
 				),
@@ -382,7 +382,7 @@ class WP_Block_Supports_Typography_Test extends WP_UnitTestCase {
 				'expected_output'             => 'clamp(1.3125rem, 1.3125rem + ((1vw - 0.48rem) * 2.524), 2.625rem)',
 			),
 
-			'return_fluid_value_with_floats_with_units'    => array(
+			'return_fluid_value_with_floats_with_units'   => array(
 				'font_size_preset'            => array(
 					'size' => '100.175px',
 				),
@@ -390,12 +390,20 @@ class WP_Block_Supports_Typography_Test extends WP_UnitTestCase {
 				'expected_output'             => 'clamp(75.13125px, 4.695703125rem + ((1vw - 7.68px) * 9.03), 150.2625px)',
 			),
 
-			'return_fluid_value_with_number_coerced_to_px' => array(
+			'return_fluid_value_with_integer_coerced_to_px' => array(
 				'font_size_preset'            => array(
 					'size' => 33,
 				),
 				'should_use_fluid_typography' => true,
 				'expected_output'             => 'clamp(24.75px, 1.546875rem + ((1vw - 7.68px) * 2.975), 49.5px)',
+			),
+
+			'return_fluid_value_with_float_coerced_to_px' => array(
+				'font_size_preset'            => array(
+					'size' => 100.23,
+				),
+				'should_use_fluid_typography' => true,
+				'expected_output'             => 'clamp(75.1725px, 4.69828125rem + ((1vw - 7.68px) * 9.035), 150.345px)',
 			),
 
 			'return_default_fluid_values_with_empty_fluid_array' => array(
@@ -407,7 +415,7 @@ class WP_Block_Supports_Typography_Test extends WP_UnitTestCase {
 				'expected_output'             => 'clamp(21px, 1.3125rem + ((1vw - 7.68px) * 2.524), 42px)',
 			),
 
-			'return_default_fluid_values_with_null_value'  => array(
+			'return_default_fluid_values_with_null_value' => array(
 				'font_size_preset'            => array(
 					'size'  => '28px',
 					'fluid' => null,
@@ -416,7 +424,7 @@ class WP_Block_Supports_Typography_Test extends WP_UnitTestCase {
 				'expected_output'             => 'clamp(21px, 1.3125rem + ((1vw - 7.68px) * 2.524), 42px)',
 			),
 
-			'return_size_with_invalid_fluid_units'         => array(
+			'return_size_with_invalid_fluid_units'        => array(
 				'font_size_preset'            => array(
 					'size'  => '10em',
 					'fluid' => array(
@@ -428,7 +436,7 @@ class WP_Block_Supports_Typography_Test extends WP_UnitTestCase {
 				'expected_output'             => '10em',
 			),
 
-			'return_fluid_clamp_value'                     => array(
+			'return_fluid_clamp_value'                    => array(
 				'font_size_preset'            => array(
 					'size'  => '28px',
 					'fluid' => array(
@@ -547,7 +555,7 @@ class WP_Block_Supports_Typography_Test extends WP_UnitTestCase {
 	}
 
 	/**
-	 * Tests generating font size values, including fluid formulae, from fontSizes preset.
+	 * Tests that invalid font size values are not parsed.
 	 *
 	 * @ticket 56467
 	 *
@@ -572,7 +580,6 @@ class WP_Block_Supports_Typography_Test extends WP_UnitTestCase {
 			'size: null'  => array( null ),
 			'size: false' => array( false ),
 			'size: true'  => array( true ),
-			'size: float' => array( 10.1234 ),
 			'size: array' => array( array( '10' ) ),
 		);
 	}

--- a/phpunit/block-supports/typography-test.php
+++ b/phpunit/block-supports/typography-test.php
@@ -382,6 +382,14 @@ class WP_Block_Supports_Typography_Test extends WP_UnitTestCase {
 				'expected_output'             => 'clamp(1.3125rem, 1.3125rem + ((1vw - 0.48rem) * 2.524), 2.625rem)',
 			),
 
+			'return_fluid_value_with_floats_with_units'    => array(
+				'font_size_preset'            => array(
+					'size' => '100.175px',
+				),
+				'should_use_fluid_typography' => true,
+				'expected_output'             => 'clamp(75.13125px, 4.695703125rem + ((1vw - 7.68px) * 9.03), 150.2625px)',
+			),
+
 			'return_fluid_value_with_number_coerced_to_px' => array(
 				'font_size_preset'            => array(
 					'size' => 33,

--- a/phpunit/block-supports/typography-test.php
+++ b/phpunit/block-supports/typography-test.php
@@ -555,7 +555,94 @@ class WP_Block_Supports_Typography_Test extends WP_UnitTestCase {
 	}
 
 	/**
-	 * Tests that invalid font size values are not parsed.
+	 * Tests that valid font size values are parsed.
+	 *
+	 * @ticket 56467
+	 *
+	 * @covers ::gutenberg_get_typography_value_and_unit
+	 *
+	 * @dataProvider data_valid_size_wp_get_typography_value_and_unit
+	 *
+	 * @param mixed $raw_value Raw size value to test.
+	 * @param mixed $expected  An expected return value.
+	 */
+	public function test_valid_size_wp_get_typography_value_and_unit( $raw_value, $expected ) {
+		$this->assertEquals( $expected, gutenberg_get_typography_value_and_unit( $raw_value ) );
+	}
+
+	/**
+	 * Data provider.
+	 *
+	 * @return array
+	 */
+	public function data_valid_size_wp_get_typography_value_and_unit() {
+		return array(
+			'size: 10vh with default units do not match' => array(
+				'raw_value' => '10vh',
+				'expected'  => null,
+			),
+			'size: calc() values do not match'           => array(
+				'raw_value' => 'calc(2 * 10px)',
+				'expected'  => null,
+			),
+			'size: clamp() values do not match'          => array(
+				'raw_value' => 'clamp(15px, 0.9375rem + ((1vw - 7.68px) * 5.409), 60px)',
+				'expected'  => null,
+			),
+			'size: `"10"`'                               => array(
+				'raw_value' => '10',
+				'expected'  => array(
+					'value' => 10,
+					'unit'  => 'px',
+				),
+			),
+			'size: `11`'                                 => array(
+				'raw_value' => 11,
+				'expected'  => array(
+					'value' => 11,
+					'unit'  => 'px',
+				),
+			),
+			'size: `11.234`'                             => array(
+				'raw_value' => '11.234',
+				'expected'  => array(
+					'value' => 11.234,
+					'unit'  => 'px',
+				),
+			),
+			'size: `"12rem"`'                            => array(
+				'raw_value' => '12rem',
+				'expected'  => array(
+					'value' => 12,
+					'unit'  => 'rem',
+				),
+			),
+			'size: `"12px"`'                             => array(
+				'raw_value' => '12px',
+				'expected'  => array(
+					'value' => 12,
+					'unit'  => 'px',
+				),
+			),
+			'size: `"12em"`'                             => array(
+				'raw_value' => '12em',
+				'expected'  => array(
+					'value' => 12,
+					'unit'  => 'em',
+				),
+			),
+			'size: `"12.74em"`'                          => array(
+				'raw_value' => '12.74em',
+				'expected'  => array(
+					'value' => 12.74,
+					'unit'  => 'em',
+				),
+			),
+		);
+	}
+
+	/**
+	 * Tests that invalid font size values are not parsed and trigger incorrect usage.
 	 *
 	 * @ticket 56467
 	 *


### PR DESCRIPTION
Parent issue: https://github.com/WordPress/gutenberg/issues/44758

## What?
This PR  addresses the review comments from https://github.com/WordPress/gutenberg/pull/44807#pullrequestreview-1136360189 and backports changes have already been backported to Core in https://github.com/WordPress/wordpress-develop/pull/3428 😄 

This PR also harmonizes the JS methods and tests to ensure both versions are compatible and consistent.

## Why?
By the time the [Core patch](https://github.com/WordPress/wordpress-develop/pull/3428) was merged, we hadn't merged into Gutenberg a null check on `gutenberg_get_typography_font_size_value`

This broke the tests after subsequent WP backport PRs were merged into Gutenberg. See: https://github.com/WordPress/gutenberg/issues/44758

Also, to ensure editor and frontend parity, the same rules should be present in the JS and PHP.


## Testing Instructions

Ensure the tests pass.

Manually testing by ensuring fluid font size presets and custom sizes work everywhere (site editor, global styles, post editor, block supports, frontend)



<details>

<summary>Here's some test theme.json!</summary>

```html
{
	"version": 2,
	"settings": {
		"appearanceTools": true,
		"typography": {
			"fluid": true,
			"fontSizes": [
				{
					"size": "12",
					"slug": "small"
				},
				{
					"fluid": {
						"min": "1rem",
						"max": "1.125rem"
					},
					"size": "1.125rem",
					"slug": "medium"
				},
				{
					"size": "3.5rem",
					"slug": "large",
					"fluid": {
						"min": "3rem",
						"max": "5rem"
					}
				},
				{
					"size": "10rem",
					"slug": "xx-large",
					"fluid": {
						"min": "4rem",
						"max": "20rem"
					}
				},
				{
					"size": "14rem",
					"slug": "Colossal",
					"fluid": {
						"min": "8rem",
						"max": "30rem"
					}
				}
			]
		}
	},
	"styles": {
		"typography": {
			"fontSize": "12px"
		},
		"elements": {
			"link": {
				"typography": {
					"fontSize": "15px"
				}
			}
		},
		"blocks": {
			"core/table": {
				"typography": {
					"fontSize": "2.5rem"
				}
			},
			"core/list": {
				"typography": {
					"fontSize": {
						"ref": "styles.elements.link.typography.fontSize"
					}
				}
			}
		}
	}
}
```

</details>