### PR TITLE
fix: Image caption supports Voice Control

### DIFF
--- a/packages/block-library/src/image/edit.native.js
+++ b/packages/block-library/src/image/edit.native.js
@@ -878,7 +878,7 @@ export class ImageEdit extends Component {
 				<BlockCaption
 					clientId={ this.props.clientId }
 					isSelected={ this.state.isCaptionSelected }
-					accessible
+					accessible={ ! this.state.isCaptionSelected }
 					accessibilityLabelCreator={ this.accessibilityLabelCreator }
 					onFocus={ this.onFocusCaption }
 					onBlur={ this.props.onBlur } // Always assign onBlur as props.

--- a/packages/react-native-editor/CHANGELOG.md
+++ b/packages/react-native-editor/CHANGELOG.md
@@ -11,6 +11,7 @@ For each user feature we should also add a importance categorization label  to i
 
 ## Unreleased
 -   [*] Upgrade compile and target sdk version to Android API 31 [#44610]
+-   [*] [iOS] Fixed iOS Voice Control support within Image block captions. [#44850]
 
 ## 1.83.0
 * No User facing changes *


### PR DESCRIPTION
## What?
Fix iOS Voice Control support allowing moving the cursor within the caption
rich text input.

## Why?
Partially addresses wordpress-mobile/WordPress-iOS#19175. This broke user expectations for how
Voice Control should interact with the text input, e.g. the ability to move the
cursor to the beginning of the input.

## How?
The static `accessible` prop of the wrapping element prevented Voice Control
from taking action on the underlying text input. This disables the `accessible`
status of the element wrapping the caption Rich Text whenever the caption text
input is focused. This allows iOS Voice Control to take action upon the text
input itself.

## Testing Instructions

<details><summary>Test iOS Voice Control</summary>

1. Activate iOS [Voice Control](https://support.apple.com/en-us/HT210417) on your iOS device.
1. Open a post and create an _Image_ block with a caption. 
1. Place your cursor within the caption input. 
1. Dictate "move to beginning."
1. Verify the cursor is at the beginning of the caption. 
1. Dictate "move to end."
1. Verify the cursor is at the end of the caption. 

</details>

<details><summary>Test iOS Voice Over/Android TalkBack</summary>

1. Activate iOS [Voice Over](https://support.apple.com/guide/iphone/turn-on-and-practice-voiceover-iph3e2e415f/ios) or Android [TalkBack](https://support.google.com/accessibility/android/answer/6007100?hl%3Den).
1. Open a post and create an _Image_ block with a caption. 
1. Place your cursor within the caption input. 
1. Verify navigating to and editing captions work as expected.[^1]

</details>

## Screenshots or screencast

<details><summary>Voice Control Before</summary>

https://user-images.githubusercontent.com/438664/194995600-8f0c20d5-5062-4991-b8c6-b3139032af40.MP4

</details>
<details><summary>Voice Control After</summary>

https://user-images.githubusercontent.com/438664/194995612-18a4cd96-26cc-4817-ad6c-12b6a81391e3.MP4

</details>
<details><summary>Voice Over Before</summary>

https://user-images.githubusercontent.com/438664/194995622-9bf3ca52-5e79-4082-89f7-90748101a176.MP4

</details>
<details><summary>Voice Over After</summary>

https://user-images.githubusercontent.com/438664/194995658-049e9061-8133-423e-afd9-431034f9b0ba.MP4

</details>

<details><summary>TalkBack Before</summary>

Note[^2]

https://user-images.githubusercontent.com/438664/195127272-5d68f9ff-ad04-4133-92f8-1d041d9b9991.mp4

</details>
<details><summary>TalkBack After</summary>

Note[^2]

https://user-images.githubusercontent.com/438664/195127345-8f39173a-d94c-4918-a2d3-dd970c4f0e44.mp4

</details>

[^1]: The changes in this PR cause an additional element to be focusable via iOS Voice Over: the caption button (original) and the caption text input (new). This is less than ideal, as it is unnecessary and confusing. However, this issue preexists with Android TalkBack and preexists for Paragraphs with a placeholder value with both Android TalkBack and iOS Voice Over. Therefore, I consider it unrelated and should be addressed in a different PR, likely requiring a larger refactor of how accessibility labels are applied to rich text inputs. 
[^2]: I was unable to determine a way to record TalkBack's audio, so the screencast only includes visual examples of the focusable elements. 