### PR TITLE
Fix overflowing patterns

### DIFF
--- a/packages/block-editor/src/components/block-patterns-list/style.scss
+++ b/packages/block-editor/src/components/block-patterns-list/style.scss
@@ -2,6 +2,11 @@
 	cursor: pointer;
 	margin-bottom: $grid-unit-30;
 
+	// The list item contains absolutely positioned visually hidden text,
+	// so make this container relative. This prevents the bug experienced in
+	// https://github.com/WordPress/gutenberg/issues/44842.
+	position: relative;
+
 	&.is-placeholder {
 		min-height: 100px;
 	}

--- a/packages/block-editor/src/components/inserter/style.scss
+++ b/packages/block-editor/src/components/inserter/style.scss
@@ -87,7 +87,7 @@ $block-inserter-tabs-height: 44px;
 .block-editor-inserter__menu {
 	height: 100%;
 	position: relative;
-	overflow: visible;
+	overflow: hidden;
 }
 
 .block-editor-inserter__inline-elements {

--- a/packages/block-editor/src/components/inserter/style.scss
+++ b/packages/block-editor/src/components/inserter/style.scss
@@ -87,7 +87,7 @@ $block-inserter-tabs-height: 44px;
 .block-editor-inserter__menu {
 	height: 100%;
 	position: relative;
-	overflow: hidden;
+	overflow: visible;
 }
 
 .block-editor-inserter__inline-elements {


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Fixes #44842

## Why?
Resolves the issue of patterns overflowing and causing the editor to have an extra scrollbar.

## How?
The problem was caused by the `VisuallyHidden` text in each pattern list item. This visually hidden text is absolutely positioned and is technically overflowing the sidebar because the ancestor of this element that provides a stacking context has the `overflow: visible` style.

To fix this, this PR makes each pattern list item a stacking context by adding the `position: relative` style.

## Testing Instructions
To more easily test this on Mac OS, Go to System Preferences > General and change 'Show scroll bars' to 'Always'.

1. In the site editor open the block library sidebar.
2. Switch between patterns categories, none should cause an extra scrollbar in the editor.

## Screenshots or screencast <!-- if applicable -->

### Before
![Screen Shot 2022-10-11 at 12 28 28 pm](https://user-images.githubusercontent.com/677833/195001709-3ac28960-efe9-4e4c-9fb6-9471de9c33b1.png)


### After
![Screen Shot 2022-10-11 at 1 07 27 pm](https://user-images.githubusercontent.com/677833/195001786-df020a3c-046d-4cc2-b5ae-be1565ab34d7.png)
