### PR TITLE
Embed Block: Add support for Tumblr Dashboard URLs.

### DIFF
--- a/packages/block-library/src/embed/variations.js
+++ b/packages/block-library/src/embed/variations.js
@@ -309,7 +309,10 @@ const variations = [
 		icon: embedTumblrIcon,
 		keywords: [ __( 'social' ) ],
 		description: __( 'Embed a Tumblr post.' ),
-		patterns: [ /^https?:\/\/(www\.)?tumblr\.com\/.+/i ],
+		patterns: [
+			/^https?:\/\/(www\.)?tumblr\.com\/.+/i,
+			/^https?:\/\/(www\.)?tumblr\.com\/blog\/view\/[^\/]+\/.*/i,
+		],
 		attributes: { providerNameSlug: 'tumblr', responsive: true },
 	},
 	{

--- a/packages/block-library/src/embed/variations.js
+++ b/packages/block-library/src/embed/variations.js
@@ -309,10 +309,7 @@ const variations = [
 		icon: embedTumblrIcon,
 		keywords: [ __( 'social' ) ],
 		description: __( 'Embed a Tumblr post.' ),
-		patterns: [
-			/^https?:\/\/(www\.)?tumblr\.com\/.+/i,
-			/^https?:\/\/(www\.)?tumblr\.com\/blog\/view\/[^\/]+\/.*/i,
-		],
+		patterns: [ /^https?:\/\/(.+)\.tumblr\.com\/.+/i ],
 		attributes: { providerNameSlug: 'tumblr', responsive: true },
 	},
 	{


### PR DESCRIPTION
## What?

Following up on [WP56733](https://core.trac.wordpress.org/ticket/56733), this adds the corresponding regex for Tumblr Dashboard URLs to the Embed block.

## Testing Instructions

- Create a new post.
- Check that pasting this URL shows the correct Tumblr embed: https://photomatt.tumblr.com/post/696629352701493248/why-go-nuts-show-nuts-doesnt-work-in-2022
- Check that pasting this URL shows the correct Tumblr embed: https://www.tumblr.com/photomatt/696629352701493248/why-go-nuts-show-nuts-doesnt-work-in-2022
