### PR TITLE
Data: Refactor 'withDispatch' tests to use RTL

### DIFF
--- a/packages/data/src/components/with-dispatch/test/index.js
+++ b/packages/data/src/components/with-dispatch/test/index.js
@@ -1,7 +1,8 @@
 /**
  * External dependencies
  */
-import TestRenderer, { act } from 'react-test-renderer';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 
 /**
  * Internal dependencies
@@ -10,224 +11,138 @@ import withDispatch from '../';
 import { createRegistry } from '../../../registry';
 import { RegistryProvider } from '../../registry-provider';
 
+jest.useRealTimers();
+
 describe( 'withDispatch', () => {
-	let registry;
-	beforeEach( () => {
-		registry = createRegistry();
-	} );
+	const storeOptions = {
+		reducer: ( state = 0, action ) => {
+			if ( action.type === 'inc' ) {
+				return state + action.count;
+			}
+			return state;
+		},
+		actions: {
+			increment: ( count = 1 ) => ( { type: 'inc', count } ),
+		},
+		selectors: {
+			getCount: ( state ) => state,
+		},
+	};
 
-	it( 'passes the relevant data to the component', () => {
-		const store = registry.registerStore( 'counter', {
-			reducer: ( state = 0, action ) => {
-				if ( action.type === 'increment' ) {
-					return state + action.count;
-				}
-				return state;
-			},
-			actions: {
-				increment: ( count = 1 ) => ( { type: 'increment', count } ),
-			},
-		} );
+	it( 'passes the relevant data to the component', async () => {
+		const user = userEvent.setup();
+		const registry = createRegistry();
+		registry.registerStore( 'counter', storeOptions );
 
-		const Component = withDispatch( ( _dispatch, ownProps ) => {
+		const Component = withDispatch( ( dispatch, ownProps ) => {
 			const { count } = ownProps;
 
 			return {
 				increment: () => {
-					const actionReturnedFromDispatch = Promise.resolve(
-						_dispatch( 'counter' ).increment( count )
-					);
-					return expect(
-						actionReturnedFromDispatch
-					).resolves.toEqual( {
-						type: 'increment',
-						count,
-					} );
+					dispatch( 'counter' ).increment( count );
 				},
 			};
 		} )( ( props ) => <button onClick={ props.increment } /> );
 
-		let testRenderer;
-		act( () => {
-			testRenderer = TestRenderer.create(
-				<RegistryProvider value={ registry }>
-					<Component count={ 0 } />
-				</RegistryProvider>
-			);
-		} );
-		const testInstance = testRenderer.root;
-
-		const incrementBeforeSetProps =
-			testInstance.findByType( 'button' ).props.onClick;
+		const { rerender } = render(
+			<RegistryProvider value={ registry }>
+				<Component count={ 0 } />
+			</RegistryProvider>
+		);
 
 		// Verify that dispatch respects props at the time of being invoked by
 		// changing props after the initial mount.
-		act( () => {
-			testRenderer.update(
-				<RegistryProvider value={ registry }>
-					<Component count={ 2 } />
-				</RegistryProvider>
-			);
-		} );
-
-		// Function value reference should not have changed in props update.
-		expect( testInstance.findByType( 'button' ).props.onClick ).toBe(
-			incrementBeforeSetProps
+		rerender(
+			<RegistryProvider value={ registry }>
+				<Component count={ 2 } />
+			</RegistryProvider>
 		);
 
-		act( () => {
-			incrementBeforeSetProps();
-		} );
-
-		expect( store.getState() ).toBe( 2 );
+		await user.click( screen.getByRole( 'button' ) );
+		expect( registry.select( 'counter' ).getCount() ).toBe( 2 );
 	} );
 
-	it( 'calls dispatch on the correct registry if updated', () => {
-		const reducer = ( state = null ) => state;
-		const noop = () => ( { type: '__INERT__' } );
-		const firstRegistryAction = jest.fn().mockImplementation( noop );
-		const secondRegistryAction = jest.fn().mockImplementation( noop );
+	it( 'calls dispatch on the correct registry if updated', async () => {
+		const user = userEvent.setup();
 
-		const firstRegistry = registry;
-		firstRegistry.registerStore( 'demo', {
-			reducer,
-			actions: {
-				noop: firstRegistryAction,
-			},
-		} );
-
-		const Component = withDispatch( ( _dispatch ) => {
-			const noopByReference = _dispatch( 'demo' ).noop;
-
-			return {
-				noop() {
-					_dispatch( 'demo' ).noop();
-					noopByReference();
-				},
-			};
-		} )( ( props ) => <button onClick={ props.noop } /> );
-
-		let testRenderer;
-		act( () => {
-			testRenderer = TestRenderer.create(
-				<RegistryProvider value={ firstRegistry }>
-					<Component />
-				</RegistryProvider>
-			);
-		} );
-		const testInstance = testRenderer.root;
-
-		act( () => {
-			testInstance.findByType( 'button' ).props.onClick();
-		} );
-		expect( firstRegistryAction ).toHaveBeenCalledTimes( 2 );
-		expect( secondRegistryAction ).toHaveBeenCalledTimes( 0 );
+		const firstRegistry = createRegistry();
+		firstRegistry.registerStore( 'demo', storeOptions );
 
 		const secondRegistry = createRegistry();
-		secondRegistry.registerStore( 'demo', {
-			reducer,
-			actions: {
-				noop: secondRegistryAction,
-			},
-		} );
+		secondRegistry.registerStore( 'demo', storeOptions );
 
-		act( () => {
-			testRenderer.update(
-				<RegistryProvider value={ secondRegistry }>
-					<Component />
-				</RegistryProvider>
-			);
-		} );
-		act( () => {
-			testInstance.findByType( 'button' ).props.onClick();
-		} );
-		expect( firstRegistryAction ).toHaveBeenCalledTimes( 2 );
-		expect( secondRegistryAction ).toHaveBeenCalledTimes( 2 );
+		const Component = withDispatch( ( dispatch ) => {
+			return {
+				increment() {
+					dispatch( 'demo' ).increment();
+				},
+			};
+		} )( ( props ) => <button onClick={ props.increment } /> );
+
+		const { rerender } = render(
+			<RegistryProvider value={ firstRegistry }>
+				<Component />
+			</RegistryProvider>
+		);
+
+		await user.click( screen.getByRole( 'button' ) );
+		expect( firstRegistry.select( 'demo' ).getCount() ).toBe( 1 );
+		expect( secondRegistry.select( 'demo' ).getCount() ).toBe( 0 );
+
+		rerender(
+			<RegistryProvider value={ secondRegistry }>
+				<Component />
+			</RegistryProvider>
+		);
+		await user.click( screen.getByRole( 'button' ) );
+		expect( firstRegistry.select( 'demo' ).getCount() ).toBe( 1 );
+		expect( secondRegistry.select( 'demo' ).getCount() ).toBe( 1 );
 	} );
 
-	it(
-		'always calls select with the latest state in the handler passed to ' +
-			'the component',
-		() => {
-			const store = registry.registerStore( 'counter', {
-				reducer: ( state = 0, action ) => {
-					if ( action.type === 'update' ) {
-						return action.count;
-					}
-					return state;
+	it( 'always calls select with the latest state in the handler passed to the component', async () => {
+		const user = userEvent.setup();
+		const registry = createRegistry();
+		registry.registerStore( 'counter', storeOptions );
+
+		const Component = withDispatch( ( dispatch, ownProps, { select } ) => {
+			return {
+				update: () => {
+					const currentCount = select( 'counter' ).getCount();
+					dispatch( 'counter' ).increment( currentCount + 1 );
 				},
-				actions: {
-					update: ( count ) => ( { type: 'update', count } ),
-				},
-				selectors: {
-					getCount: ( state ) => state,
-				},
-			} );
+			};
+		} )( ( props ) => <button onClick={ props.update } /> );
 
-			const Component = withDispatch(
-				( _dispatch, ownProps, { select: _select } ) => {
-					const outerCount = _select( 'counter' ).getCount();
-					return {
-						update: () => {
-							const innerCount = _select( 'counter' ).getCount();
-							expect( innerCount ).toBe( outerCount );
-							const actionReturnedFromDispatch = Promise.resolve(
-								_dispatch( 'counter' ).update( innerCount + 1 )
-							);
-							return expect(
-								actionReturnedFromDispatch
-							).resolves.toEqual( {
-								type: 'update',
-								count: innerCount + 1,
-							} );
-						},
-					};
-				}
-			)( ( props ) => <button onClick={ props.update } /> );
+		render(
+			<RegistryProvider value={ registry }>
+				<Component />
+			</RegistryProvider>
+		);
 
-			let testRenderer;
-			act( () => {
-				testRenderer = TestRenderer.create(
-					<RegistryProvider value={ registry }>
-						<Component />
-					</RegistryProvider>
-				);
-			} );
+		await user.click( screen.getByRole( 'button' ) );
+		expect( registry.select( 'counter' ).getCount() ).toBe( 1 );
 
-			const counterUpdateHandler =
-				testRenderer.root.findByType( 'button' ).props.onClick;
+		await user.click( screen.getByRole( 'button' ) );
+		expect( registry.select( 'counter' ).getCount() ).toBe( 3 );
 
-			act( () => {
-				counterUpdateHandler();
-			} );
-			expect( store.getState() ).toBe( 1 );
-
-			act( () => {
-				counterUpdateHandler();
-			} );
-			expect( store.getState() ).toBe( 2 );
-
-			act( () => {
-				counterUpdateHandler();
-			} );
-			expect( store.getState() ).toBe( 3 );
-		}
-	);
+		await user.click( screen.getByRole( 'button' ) );
+		expect( registry.select( 'counter' ).getCount() ).toBe( 7 );
+	} );
 
 	it( 'warns when mapDispatchToProps returns non-function property', () => {
+		const registry = createRegistry();
 		const Component = withDispatch( () => {
 			return {
 				count: 3,
 			};
 		} )( () => null );
 
-		act( () => {
-			TestRenderer.create(
-				<RegistryProvider value={ registry }>
-					<Component />
-				</RegistryProvider>
-			);
-		} );
+		render(
+			<RegistryProvider value={ registry }>
+				<Component />
+			</RegistryProvider>
+		);
+
 		expect( console ).toHaveWarnedWith(
 			'Property count returned from dispatchMap in useDispatchWithMap must be a function.'
 		);

--- a/packages/data/src/components/with-dispatch/test/index.js
+++ b/packages/data/src/components/with-dispatch/test/index.js
@@ -50,7 +50,15 @@ describe( 'withDispatch', () => {
 
 			return {
 				increment: () => {
-					dispatch( 'counter' ).increment( count );
+					const actionReturnedFromDispatch = Promise.resolve(
+						dispatch( 'counter' ).increment( count )
+					);
+					return expect(
+						actionReturnedFromDispatch
+					).resolves.toEqual( {
+						type: 'inc',
+						count,
+					} );
 				},
 			};
 		} )( ( props ) => <Button onClick={ props.increment } /> );

--- a/packages/data/src/components/with-dispatch/test/index.js
+++ b/packages/data/src/components/with-dispatch/test/index.js
@@ -120,6 +120,7 @@ describe( 'withDispatch', () => {
 		);
 
 		await user.click( screen.getByRole( 'button' ) );
+		// expectedValue = 2 * currentValue + 1.
 		expect( registry.select( 'counter' ).getCount() ).toBe( 1 );
 
 		await user.click( screen.getByRole( 'button' ) );

--- a/packages/data/src/components/with-dispatch/test/index.js
+++ b/packages/data/src/components/with-dispatch/test/index.js
@@ -36,14 +36,13 @@ describe( 'withDispatch', () => {
 
 	it( 'passes the relevant data to the component', async () => {
 		const user = userEvent.setup();
-		const buttonSpy = jest.fn();
 		const registry = createRegistry();
 		registry.registerStore( 'counter', storeOptions );
 
-		const Button = memo( ( { onClick } ) => {
-			buttonSpy();
-			return <button onClick={ onClick } />;
-		} );
+		const ButtonSpy = jest.fn( ( { onClick } ) => (
+			<button onClick={ onClick } />
+		) );
+		const Button = memo( ButtonSpy );
 
 		const Component = withDispatch( ( dispatch, ownProps ) => {
 			const { count } = ownProps;
@@ -79,7 +78,7 @@ describe( 'withDispatch', () => {
 
 		// Function value reference should not have changed in props update.
 		// The spy method is only called during inital render.
-		expect( buttonSpy ).toBeCalledTimes( 1 );
+		expect( ButtonSpy ).toBeCalledTimes( 1 );
 
 		await user.click( screen.getByRole( 'button' ) );
 		expect( registry.select( 'counter' ).getCount() ).toBe( 2 );


### PR DESCRIPTION
## What?
PR of #44780.

PR refactors `withDispatch` HOC tests to use `@testing-library/react` instead of `react-test-renderer`.

## Why?
It is a part of recent efforts to use `@testing-library/react` as the project's primary testing library.

## How?
Updates the `render` method to use RTL, improves assertions and uses `userEvent` for user actions.

## Testing Instructions
```
npm run test:unit -- packages/data/src/components/with-dispatch/test/index.js
```