### PR TITLE
Most used tags: Try fixing label

### DIFF
--- a/packages/editor/src/components/post-taxonomies/most-used-terms.js
+++ b/packages/editor/src/components/post-taxonomies/most-used-terms.js
@@ -6,7 +6,7 @@ import { get } from 'lodash';
 /**
  * WordPress dependencies
  */
-import { Button } from '@wordpress/components';
+import { BaseControl, Button } from '@wordpress/components';
 import { useSelect } from '@wordpress/data';
 import { store as coreStore } from '@wordpress/core-data';
 
@@ -47,9 +47,12 @@ export default function MostUsedTerms( { onSelect, taxonomy } ) {
 
 	return (
 		<div className="editor-post-taxonomies__flat-term-most-used">
-			<h3 className="editor-post-taxonomies__flat-term-most-used-label">
+			<BaseControl.VisualLabel
+				as="h3"
+				className="editor-post-taxonomies__flat-term-most-used-label"
+			>
 				{ label }
-			</h3>
+			</BaseControl.VisualLabel>
 			{ /*
 			 * Disable reason: The `list` ARIA role is redundant but
 			 * Safari+VoiceOver won't announce the list otherwise.

--- a/packages/editor/src/components/post-taxonomies/style.scss
+++ b/packages/editor/src/components/post-taxonomies/style.scss
@@ -38,8 +38,7 @@
 
 .editor-post-taxonomies__flat-term-most-used {
 	.editor-post-taxonomies__flat-term-most-used-label {
-		font-weight: 400;
-		margin-bottom: $grid-unit-15;
+		margin-bottom: $grid-unit-05;
 	}
 }
 

--- a/packages/interface/src/components/complementary-area/style.scss
+++ b/packages/interface/src/components/complementary-area/style.scss
@@ -1,4 +1,3 @@
-.interface-interface-skeleton__actions,
 .interface-complementary-area {
 	background: $white;
 	color: $gray-900;

--- a/packages/interface/src/components/complementary-area/style.scss
+++ b/packages/interface/src/components/complementary-area/style.scss
@@ -1,3 +1,4 @@
+.interface-interface-skeleton__actions,
 .interface-complementary-area {
 	background: $white;
 	color: $gray-900;


### PR DESCRIPTION
## What?

Most used tags is a thin weight:

<img width="385" alt="Screenshot 2022-10-11 at 09 20 18" src="https://user-images.githubusercontent.com/1204802/195022145-24a5212c-4f69-4bb9-b8a6-8ae31873ac13.png">

I think it was designed for a previous style of labels that weren't small and uppercase. This PR just removes the font weight:

<img width="312" alt="Screenshot 2022-10-11 at 09 21 08" src="https://user-images.githubusercontent.com/1204802/195022211-1dfe7957-711f-4e0d-a148-c5b4837b1c59.png">

The prepublish interface was also missing the style entirely:

<img width="341" alt="Screenshot 2022-10-11 at 09 23 12" src="https://user-images.githubusercontent.com/1204802/195023797-e3205e4e-bf0b-4352-ac08-dd5880f73021.png">

I made a biggish change to the code that styles the default inspector, to also encompass the pre-publish sidebar. I'll comment in the code and ask for an extra look:

<img width="368" alt="Screenshot 2022-10-11 at 09 29 02" src="https://user-images.githubusercontent.com/1204802/195023956-33a06074-05d7-4eb7-ba4a-7f771f2135d6.png">


## Testing Instructions

Have at least 4 different labels, and 3 of them used on a bunch of posts. Then observe the Tags sidebar, and the pre publish tag suggestion dialog.