### PR TITLE
Site logo: Fix centered state, for upload button

### DIFF
--- a/packages/block-library/src/site-logo/editor.scss
+++ b/packages/block-library/src/site-logo/editor.scss
@@ -47,6 +47,7 @@
 
 	// Style the placeholder.
 	.components-placeholder {
+		display: flex;
 		justify-content: center;
 		align-items: center;
 		padding: 0;


### PR DESCRIPTION
## What?

Fixes #44816. 

Before:

<img width="800" alt="Screenshot 2022-10-11 at 10 07 50" src="https://user-images.githubusercontent.com/1204802/195034969-d2f8ac2e-cc19-4dd9-b108-3db4102c47a0.png">

After:

<img width="694" alt="Screenshot 2022-10-11 at 10 09 47" src="https://user-images.githubusercontent.com/1204802/195034986-d78df9c4-23ef-44d5-8917-8f5326dbf5e1.png">

Essentially, display: table was inherited, causing flex alignment to break. This PR re-adds display: flex, fixing it.

## Testing Instructions

Insert a site logo, center it, observe that the upload button is correctly centered inside.