### PR TITLE
Use inert attribute instead of useDisabled

### DIFF
--- a/lib/compat/wordpress-6.2/script-loader.php
+++ b/lib/compat/wordpress-6.2/script-loader.php
@@ -1,0 +1,31 @@
+<?php
+/**
+ * Updates the script-loader.php file
+ *
+ * @package gutenberg
+ */
+
+/**
+ * Registers vendor JavaScript files to be used as dependencies of the editor
+ * and plugins.
+ *
+ * This function is called from a script during the plugin build process, so it
+ * should not call any WordPress PHP functions.
+ *
+ * @since 13.0
+ *
+ * @param WP_Scripts $scripts WP_Scripts instance.
+ */
+function gutenberg_register_vendor_scripts_62( $scripts ) {
+	$extension = SCRIPT_DEBUG ? '.js' : '.min.js';
+
+	$script = $scripts->query( 'wp-inert-polyfill', 'registered' );
+	if ( ! $script ) {
+		$scripts->add( 'wp-inert-polyfill', gutenberg_url( 'build/vendors/inert-polyfill' . $extension ), array() );
+	}
+
+
+	$script = $scripts->query( 'wp-polyfill', 'registered' );
+	$script->deps = array_merge( $script->deps, array( 'wp-inert-polyfill' ) );
+}
+add_action( 'wp_default_scripts', 'gutenberg_register_vendor_scripts_62' );

--- a/lib/compat/wordpress-6.2/script-loader.php
+++ b/lib/compat/wordpress-6.2/script-loader.php
@@ -24,8 +24,7 @@ function gutenberg_register_vendor_scripts_62( $scripts ) {
 		$scripts->add( 'wp-inert-polyfill', gutenberg_url( 'build/vendors/inert-polyfill' . $extension ), array() );
 	}
 
-
-	$script = $scripts->query( 'wp-polyfill', 'registered' );
+	$script       = $scripts->query( 'wp-polyfill', 'registered' );
 	$script->deps = array_merge( $script->deps, array( 'wp-inert-polyfill' ) );
 }
 add_action( 'wp_default_scripts', 'gutenberg_register_vendor_scripts_62' );

--- a/lib/load.php
+++ b/lib/load.php
@@ -95,6 +95,9 @@ require __DIR__ . '/compat/wordpress-6.1/edit-form-blocks.php';
 require __DIR__ . '/compat/wordpress-6.1/template-parts-screen.php';
 require __DIR__ . '/compat/wordpress-6.1/theme.php';
 
+// WordPress 6.2 compat.
+require __DIR__ . '/compat/wordpress-6.2/script-loader.php';
+
 // Experimental features.
 remove_action( 'plugins_loaded', '_wp_theme_json_webfonts_handler' ); // Turns off WP 6.0's stopgap handler for Webfonts API.
 require __DIR__ . '/experimental/block-editor-settings-mobile.php';

--- a/package-lock.json
+++ b/package-lock.json
@@ -37838,11 +37838,6 @@
 			"integrity": "sha1-8w9xbI4r00bHtn0985FVZqfAVgc=",
 			"dev": true
 		},
-		"inert-polyfill": {
-			"version": "0.2.5",
-			"resolved": "https://registry.npmjs.org/inert-polyfill/-/inert-polyfill-0.2.5.tgz",
-			"integrity": "sha512-on1Nri2CciTI8hc+BaIGCe1pDO3Qzniivt9HALcse/NGvUvu/4t2uh6REwOU5fx/Nsb5c3dCRPJdvinYH0mlkg=="
-		},
 		"infer-owner": {
 			"version": "1.0.4",
 			"resolved": "https://registry.npmjs.org/infer-owner/-/infer-owner-1.0.4.tgz",
@@ -60052,6 +60047,11 @@
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/which-module/-/which-module-2.0.0.tgz",
 			"integrity": "sha1-2e8H3Od7mQK4o6j6SzHD4/fm6Ho="
+		},
+		"wicg-inert": {
+			"version": "3.1.2",
+			"resolved": "https://registry.npmjs.org/wicg-inert/-/wicg-inert-3.1.2.tgz",
+			"integrity": "sha512-Ba9tGNYxXwaqKEi9sJJvPMKuo063umUPsHN0JJsjrs2j8KDSzkWLMZGZ+MH1Jf1Fq4OWZ5HsESJID6nRza2ang=="
 		},
 		"wide-align": {
 			"version": "1.1.3",

--- a/package-lock.json
+++ b/package-lock.json
@@ -37838,6 +37838,11 @@
 			"integrity": "sha1-8w9xbI4r00bHtn0985FVZqfAVgc=",
 			"dev": true
 		},
+		"inert-polyfill": {
+			"version": "0.2.5",
+			"resolved": "https://registry.npmjs.org/inert-polyfill/-/inert-polyfill-0.2.5.tgz",
+			"integrity": "sha512-on1Nri2CciTI8hc+BaIGCe1pDO3Qzniivt9HALcse/NGvUvu/4t2uh6REwOU5fx/Nsb5c3dCRPJdvinYH0mlkg=="
+		},
 		"infer-owner": {
 			"version": "1.0.4",
 			"resolved": "https://registry.npmjs.org/infer-owner/-/infer-owner-1.0.4.tgz",

--- a/package.json
+++ b/package.json
@@ -85,7 +85,7 @@
 		"@wordpress/warning": "file:packages/warning",
 		"@wordpress/widgets": "file:packages/widgets",
 		"@wordpress/wordcount": "file:packages/wordcount",
-		"inert-polyfill": "0.2.5"
+		"wicg-inert": "3.1.2"
 	},
 	"devDependencies": {
 		"@actions/core": "1.8.0",

--- a/package.json
+++ b/package.json
@@ -84,7 +84,8 @@
 		"@wordpress/viewport": "file:packages/viewport",
 		"@wordpress/warning": "file:packages/warning",
 		"@wordpress/widgets": "file:packages/widgets",
-		"@wordpress/wordcount": "file:packages/wordcount"
+		"@wordpress/wordcount": "file:packages/wordcount",
+		"inert-polyfill": "0.2.5"
 	},
 	"devDependencies": {
 		"@actions/core": "1.8.0",

--- a/packages/block-editor/src/components/block-preview/auto.js
+++ b/packages/block-editor/src/components/block-preview/auto.js
@@ -1,7 +1,6 @@
 /**
  * WordPress dependencies
  */
-import { Disabled } from '@wordpress/components';
 import { useResizeObserver, pure, useRefEffect } from '@wordpress/compose';
 import { useSelect } from '@wordpress/data';
 import { useMemo } from '@wordpress/element';
@@ -61,7 +60,8 @@ function ScaledBlockPreview( {
 
 	const scale = containerWidth / viewportWidth;
 	return (
-		<Disabled
+		<div
+			inert="true"
 			className="block-editor-block-preview__content"
 			style={ {
 				transform: `scale(${ scale })`,
@@ -118,7 +118,7 @@ function ScaledBlockPreview( {
 				}
 				<MemoizedBlockList renderAppender={ false } />
 			</Iframe>
-		</Disabled>
+		</div>
 	);
 }
 

--- a/packages/block-editor/src/components/block-preview/auto.js
+++ b/packages/block-editor/src/components/block-preview/auto.js
@@ -4,6 +4,7 @@
 import { useResizeObserver, pure, useRefEffect } from '@wordpress/compose';
 import { useSelect } from '@wordpress/data';
 import { useMemo } from '@wordpress/element';
+import { Disabled } from '@wordpress/components';
 
 /**
  * Internal dependencies
@@ -60,8 +61,7 @@ function ScaledBlockPreview( {
 
 	const scale = containerWidth / viewportWidth;
 	return (
-		<div
-			inert="true"
+		<Disabled
 			className="block-editor-block-preview__content"
 			style={ {
 				transform: `scale(${ scale })`,
@@ -118,7 +118,7 @@ function ScaledBlockPreview( {
 				}
 				<MemoizedBlockList renderAppender={ false } />
 			</Iframe>
-		</div>
+		</Disabled>
 	);
 }
 

--- a/packages/block-editor/src/components/block-preview/live.js
+++ b/packages/block-editor/src/components/block-preview/live.js
@@ -1,9 +1,4 @@
 /**
- * WordPress dependencies
- */
-import { Disabled } from '@wordpress/components';
-
-/**
  * Internal dependencies
  */
 import BlockList from '../block-list';
@@ -16,9 +11,9 @@ export default function LiveBlockPreview( { onClick } ) {
 			onClick={ onClick }
 			onKeyPress={ onClick }
 		>
-			<Disabled>
+			<div inert="true">
 				<BlockList />
-			</Disabled>
+			</div>
 		</div>
 	);
 }

--- a/packages/block-editor/src/components/block-preview/test/index.js
+++ b/packages/block-editor/src/components/block-preview/test/index.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { render, screen, waitFor } from '@testing-library/react';
+import { render, screen } from '@testing-library/react';
 
 /**
  * WordPress dependencies
@@ -98,12 +98,6 @@ describe( 'useBlockPreview', () => {
 			'Test block edit view'
 		);
 		expect( previewedBlockContents ).toBeInTheDocument();
-
-		// Test elements within block contents are disabled.
-		await waitFor( () => {
-			const button = screen.getByText( 'Button' );
-			expect( button.hasAttribute( 'disabled' ) ).toBe( true );
-		} );
 
 		// Ensure the block preview class names are merged with the component's class name.
 		expect( container.firstChild.className ).toBe(

--- a/packages/block-editor/src/components/block-tools/back-compat.js
+++ b/packages/block-editor/src/components/block-tools/back-compat.js
@@ -2,7 +2,6 @@
  * WordPress dependencies
  */
 import { useContext } from '@wordpress/element';
-import { Disabled } from '@wordpress/components';
 import deprecated from '@wordpress/deprecated';
 
 /**
@@ -13,16 +12,16 @@ import BlockPopover from './selected-block-popover';
 
 export default function BlockToolsBackCompat( { children } ) {
 	const openRef = useContext( InsertionPointOpenRef );
-	const isDisabled = useContext( Disabled.Context );
 
 	// If context is set, `BlockTools` is a parent component.
-	if ( openRef || isDisabled ) {
+	if ( openRef ) {
 		return children;
 	}
 
 	deprecated( 'wp.components.Popover.Slot name="block-toolbar"', {
 		alternative: 'wp.blockEditor.BlockTools',
 		since: '5.8',
+		version: '6.3',
 	} );
 
 	return (

--- a/packages/block-editor/src/components/block-tools/back-compat.js
+++ b/packages/block-editor/src/components/block-tools/back-compat.js
@@ -2,6 +2,7 @@
  * WordPress dependencies
  */
 import { useContext } from '@wordpress/element';
+import { Disabled } from '@wordpress/components';
 import deprecated from '@wordpress/deprecated';
 
 /**
@@ -12,9 +13,10 @@ import BlockPopover from './selected-block-popover';
 
 export default function BlockToolsBackCompat( { children } ) {
 	const openRef = useContext( InsertionPointOpenRef );
+	const isDisabled = useContext( Disabled.Context );
 
 	// If context is set, `BlockTools` is a parent component.
-	if ( openRef ) {
+	if ( openRef || isDisabled ) {
 		return children;
 	}
 

--- a/packages/block-library/src/comments/edit/placeholder.js
+++ b/packages/block-library/src/comments/edit/placeholder.js
@@ -5,7 +5,6 @@ import { store as blockEditorStore } from '@wordpress/block-editor';
 import { __, sprintf } from '@wordpress/i18n';
 import { useSelect } from '@wordpress/data';
 import { useEntityProp } from '@wordpress/core-data';
-import { useDisabled } from '@wordpress/compose';
 
 /**
  * Internal dependencies
@@ -22,13 +21,8 @@ export default function PostCommentsPlaceholder( { postType, postId } ) {
 				.__experimentalDiscussionSettings
 	);
 
-	const disabledRef = useDisabled();
-
 	return (
-		<div
-			className="wp-block-comments__legacy-placeholder"
-			ref={ disabledRef }
-		>
+		<div className="wp-block-comments__legacy-placeholder" inert="true">
 			<h3>
 				{
 					/* translators: %s: Post title. */

--- a/packages/block-library/src/post-comments-form/form.js
+++ b/packages/block-library/src/post-comments-form/form.js
@@ -13,18 +13,17 @@ import {
 	__experimentalGetElementClassName,
 } from '@wordpress/block-editor';
 import { Button } from '@wordpress/components';
-import { useDisabled, useInstanceId } from '@wordpress/compose';
+import { useInstanceId } from '@wordpress/compose';
 import { useEntityProp, store as coreStore } from '@wordpress/core-data';
 import { useSelect } from '@wordpress/data';
 
 const CommentsFormPlaceholder = () => {
-	const disabledFormRef = useDisabled();
 	const instanceId = useInstanceId( CommentsFormPlaceholder );
 
 	return (
 		<div className="comment-respond">
 			<h3 className="comment-reply-title">{ __( 'Leave a Reply' ) }</h3>
-			<form noValidate className="comment-form" ref={ disabledFormRef }>
+			<form noValidate className="comment-form" inert="true">
 				<p>
 					<label htmlFor={ `comment-${ instanceId }` }>
 						{ __( 'Comment' ) }

--- a/packages/block-library/src/table-of-contents/edit.js
+++ b/packages/block-library/src/table-of-contents/edit.js
@@ -21,7 +21,6 @@ import {
 	ToolbarButton,
 	ToolbarGroup,
 } from '@wordpress/components';
-import { useDisabled } from '@wordpress/compose';
 import { useDispatch, useSelect } from '@wordpress/data';
 import { __unstableStripHTML as stripHTML } from '@wordpress/dom';
 import { renderToString, useEffect } from '@wordpress/element';
@@ -55,7 +54,6 @@ export default function TableOfContentsEdit( {
 	setAttributes,
 } ) {
 	const blockProps = useBlockProps();
-	const disabledRef = useDisabled();
 
 	const canInsertList = useSelect(
 		( select ) => {
@@ -295,7 +293,7 @@ export default function TableOfContentsEdit( {
 	return (
 		<>
 			<nav { ...blockProps }>
-				<ol ref={ disabledRef }>
+				<ol inert="true">
 					<TableOfContentsList nestedHeadingList={ headingTree } />
 				</ol>
 			</nav>

--- a/packages/components/src/disabled/index.tsx
+++ b/packages/components/src/disabled/index.tsx
@@ -1,13 +1,7 @@
 /**
- * External dependencies
- */
-import type { HTMLProps } from 'react';
-
-/**
  * WordPress dependencies
  */
-import { useDisabled } from '@wordpress/compose';
-import { createContext, forwardRef } from '@wordpress/element';
+import { createContext } from '@wordpress/element';
 
 /**
  * Internal dependencies
@@ -19,15 +13,6 @@ import { useCx } from '../utils';
 
 const Context = createContext< boolean >( false );
 const { Consumer, Provider } = Context;
-
-// Extracting this ContentWrapper component in order to make it more explicit
-// the same 'ContentWrapper' component is needed so that React can reconcile
-// the dom correctly when switching between disabled/non-disabled (instead
-// of thrashing the previous DOM and therefore losing the form fields values).
-const ContentWrapper = forwardRef<
-	HTMLDivElement,
-	HTMLProps< HTMLDivElement >
->( ( props, ref ) => <div { ...props } ref={ ref } /> );
 
 /**
  * `Disabled` is a component which disables descendant tabbable elements and prevents pointer interaction.
@@ -65,29 +50,22 @@ function Disabled( {
 	isDisabled = true,
 	...props
 }: WordPressComponentProps< DisabledProps, 'div' > ) {
-	const ref = useDisabled();
 	const cx = useCx();
-	if ( ! isDisabled ) {
-		return (
-			<Provider value={ false }>
-				<ContentWrapper>{ children }</ContentWrapper>
-			</Provider>
-		);
-	}
 
 	return (
-		<Provider value={ true }>
-			<ContentWrapper
-				ref={ ref }
-				className={ cx(
-					disabledStyles,
-					className,
-					'components-disabled'
-				) }
+		<Provider value={ isDisabled }>
+			<div
+				// @ts-ignore Reason: inert is a recent HTML attribute
+				inert={ isDisabled ? 'true' : undefined }
+				className={
+					isDisabled
+						? cx( disabledStyles, className, 'components-disabled' )
+						: undefined
+				}
 				{ ...props }
 			>
 				{ children }
-			</ContentWrapper>
+			</div>
 		</Provider>
 	);
 }

--- a/packages/components/src/disabled/test/index.tsx
+++ b/packages/components/src/disabled/test/index.tsx
@@ -1,42 +1,13 @@
 /**
  * External dependencies
  */
-import { render, screen, waitFor } from '@testing-library/react';
+import { render, screen } from '@testing-library/react';
 
 /**
  * Internal dependencies
  */
 import Disabled from '../';
 import userEvent from '@testing-library/user-event';
-
-jest.mock( '@wordpress/dom', () => {
-	const focus = jest.requireActual( '../../../../dom/src' ).focus;
-	return {
-		focus: {
-			...focus,
-			focusable: {
-				...focus.focusable,
-				find( context: Element, options = { sequential: false } ) {
-					// In JSDOM, all elements have zero'd widths and height.
-					// This is a metric for focusable's `isVisible`, so find
-					// and apply an arbitrary non-zero width.
-					Array.from( context.querySelectorAll( '*' ) ).forEach(
-						( element ) => {
-							Object.defineProperties( element, {
-								offsetWidth: {
-									get: () => 1,
-									configurable: true,
-								},
-							} );
-						}
-					);
-
-					return focus.focusable.find( context, options );
-				},
-			},
-		},
-	};
-} );
 
 describe( 'Disabled', () => {
 	const Form = () => (
@@ -47,18 +18,14 @@ describe( 'Disabled', () => {
 	);
 
 	it( 'will disable all fields', () => {
-		render(
+		const { container } = render(
 			<Disabled>
 				<Form />
 			</Disabled>
 		);
 
-		const input = screen.getByRole( 'textbox' );
-		const contentEditable = screen.getByTitle( 'edit my content' );
-		expect( input ).toBeDisabled();
-		expect( contentEditable ).toHaveAttribute( 'contenteditable', 'false' );
-		expect( contentEditable ).not.toHaveAttribute( 'tabindex' );
-		expect( contentEditable ).not.toHaveAttribute( 'disabled' );
+		// @ts-ignore
+		expect( container.firstChild.hasAttribute( 'inert' ) ).toBe( true );
 	} );
 
 	it( 'should cleanly un-disable via reconciliation', () => {
@@ -71,19 +38,15 @@ describe( 'Disabled', () => {
 				<Form />
 			);
 
-		const { rerender } = render( <MaybeDisable /> );
+		const { container, rerender } = render( <MaybeDisable /> );
 
-		const input = screen.getByRole( 'textbox' );
-		const contentEditable = screen.getByTitle( 'edit my content' );
-
-		expect( input ).toBeDisabled();
-		expect( contentEditable ).toHaveAttribute( 'contenteditable', 'false' );
+		// @ts-ignore
+		expect( container.firstChild.hasAttribute( 'inert' ) ).toBe( true );
 
 		rerender( <MaybeDisable isDisabled={ false } /> );
 
-		expect( input ).not.toBeDisabled();
-		expect( contentEditable ).toHaveAttribute( 'contenteditable', 'true' );
-		expect( contentEditable ).toHaveAttribute( 'tabindex' );
+		// @ts-ignore
+		expect( container.firstChild.hasAttribute( 'inert' ) ).toBe( false );
 	} );
 
 	it( 'will disable or enable descendant fields based on the isDisabled prop value', () => {
@@ -93,46 +56,15 @@ describe( 'Disabled', () => {
 			</Disabled>
 		);
 
-		const { rerender } = render( <MaybeDisable /> );
+		const { rerender, container } = render( <MaybeDisable /> );
 
-		const input = screen.getByRole( 'textbox' );
-		const contentEditable = screen.getByTitle( 'edit my content' );
-
-		expect( input ).toBeDisabled();
-		expect( contentEditable ).toHaveAttribute( 'contenteditable', 'false' );
+		// @ts-ignore
+		expect( container.firstChild.hasAttribute( 'inert' ) ).toBe( true );
 
 		rerender( <MaybeDisable isDisabled={ false } /> );
 
-		expect( input ).not.toBeDisabled();
-		expect( contentEditable ).toHaveAttribute( 'contenteditable', 'true' );
-	} );
-
-	it( 'will disable all fields on sneaky DOM manipulation', async () => {
-		render(
-			<Disabled>
-				<Form />
-			</Disabled>
-		);
-
-		const form = screen.getByTitle( 'form' );
-		form.insertAdjacentHTML(
-			'beforeend',
-			'<input title="sneaky input" />'
-		);
-		form.insertAdjacentHTML(
-			'beforeend',
-			'<div title="sneaky editable content" contentEditable tabIndex={ 0 } />'
-		);
-		const sneakyInput = screen.getByTitle( 'sneaky input' );
-		const sneakyEditable = screen.getByTitle( 'sneaky editable content' );
-
-		await waitFor( () => expect( sneakyInput ).toBeDisabled() );
-		await waitFor( () =>
-			expect( sneakyEditable ).toHaveAttribute(
-				'contenteditable',
-				'false'
-			)
-		);
+		// @ts-ignore
+		expect( container.firstChild.hasAttribute( 'inert' ) ).toBe( false );
 	} );
 
 	it( 'should preserve input values when toggling the isDisabled prop', async () => {

--- a/packages/compose/README.md
+++ b/packages/compose/README.md
@@ -288,6 +288,7 @@ _Returns_
 In some circumstances, such as block previews, all focusable DOM elements
 (input fields, links, buttons, etc.) need to be disabled. This hook adds the
 behavior to disable nested DOM elements to the returned ref.
+
 If you can, prefer the use of the inert HTML attribute.
 
 _Usage_

--- a/packages/compose/README.md
+++ b/packages/compose/README.md
@@ -288,11 +288,13 @@ _Returns_
 In some circumstances, such as block previews, all focusable DOM elements
 (input fields, links, buttons, etc.) need to be disabled. This hook adds the
 behavior to disable nested DOM elements to the returned ref.
+If you can, prefer the use of the inert HTML attribute.
 
 _Usage_
 
 ```js
 import { useDisabled } from '@wordpress/compose';
+
 const DisabledExample = () => {
 	const disabledRef = useDisabled();
 	return (

--- a/packages/compose/src/hooks/use-disabled/index.js
+++ b/packages/compose/src/hooks/use-disabled/index.js
@@ -1,37 +1,13 @@
 /**
- * WordPress dependencies
- */
-import { focus } from '@wordpress/dom';
-
-/**
  * Internal dependencies
  */
-import { debounce } from '../../utils/debounce';
 import useRefEffect from '../use-ref-effect';
-
-/**
- * Names of control nodes which qualify for disabled behavior.
- *
- * See WHATWG HTML Standard: 4.10.18.5: "Enabling and disabling form controls: the disabled attribute".
- *
- * @see https://html.spec.whatwg.org/multipage/form-control-infrastructure.html#enabling-and-disabling-form-controls:-the-disabled-attribute
- *
- * @type {string[]}
- */
-const DISABLED_ELIGIBLE_NODE_NAMES = [
-	'BUTTON',
-	'FIELDSET',
-	'INPUT',
-	'OPTGROUP',
-	'OPTION',
-	'SELECT',
-	'TEXTAREA',
-];
 
 /**
  * In some circumstances, such as block previews, all focusable DOM elements
  * (input fields, links, buttons, etc.) need to be disabled. This hook adds the
  * behavior to disable nested DOM elements to the returned ref.
+ * If you can, prefer the use of the inert HTML attribute.
  *
  * @param {Object}   config            Configuration object.
  * @param {boolean=} config.isDisabled Whether the element should be disabled.
@@ -40,6 +16,7 @@ const DISABLED_ELIGIBLE_NODE_NAMES = [
  * @example
  * ```js
  * import { useDisabled } from '@wordpress/compose';
+ *
  * const DisabledExample = () => {
  * 	const disabledRef = useDisabled();
  *	return (
@@ -60,136 +37,9 @@ export default function useDisabled( {
 				return;
 			}
 
-			/** A variable keeping track of the previous updates in order to restore them. */
-			/** @type {Function[]} */
-			const updates = [];
-
-			const disable = () => {
-				if ( node.style.getPropertyValue( 'user-select' ) !== 'none' ) {
-					const previousValue =
-						node.style.getPropertyValue( 'user-select' );
-					node.style.setProperty( 'user-select', 'none' );
-					node.style.setProperty( '-webkit-user-select', 'none' );
-					updates.push( () => {
-						if ( ! node.isConnected ) {
-							return;
-						}
-						node.style.setProperty( 'user-select', previousValue );
-						node.style.setProperty(
-							'-webkit-user-select',
-							previousValue
-						);
-					} );
-				}
-
-				focus.focusable.find( node ).forEach( ( focusable ) => {
-					if (
-						DISABLED_ELIGIBLE_NODE_NAMES.includes(
-							focusable.nodeName
-						) &&
-						// @ts-ignore
-						! focusable.disabled
-					) {
-						focusable.setAttribute( 'disabled', '' );
-						updates.push( () => {
-							if ( ! focusable.isConnected ) {
-								return;
-							}
-							// @ts-ignore
-							focusable.disabled = false;
-						} );
-					}
-
-					if (
-						focusable.nodeName === 'A' &&
-						focusable.getAttribute( 'tabindex' ) !== '-1'
-					) {
-						const previousValue =
-							focusable.getAttribute( 'tabindex' );
-						focusable.setAttribute( 'tabindex', '-1' );
-						updates.push( () => {
-							if ( ! focusable.isConnected ) {
-								return;
-							}
-							if ( ! previousValue ) {
-								focusable.removeAttribute( 'tabindex' );
-							} else {
-								focusable.setAttribute(
-									'tabindex',
-									previousValue
-								);
-							}
-						} );
-					}
-
-					const tabIndex = focusable.getAttribute( 'tabindex' );
-					if ( tabIndex !== null && tabIndex !== '-1' ) {
-						focusable.removeAttribute( 'tabindex' );
-						updates.push( () => {
-							if ( ! focusable.isConnected ) {
-								return;
-							}
-							focusable.setAttribute( 'tabindex', tabIndex );
-						} );
-					}
-
-					if (
-						focusable.hasAttribute( 'contenteditable' ) &&
-						focusable.getAttribute( 'contenteditable' ) !== 'false'
-					) {
-						focusable.setAttribute( 'contenteditable', 'false' );
-						updates.push( () => {
-							if ( ! focusable.isConnected ) {
-								return;
-							}
-							focusable.setAttribute( 'contenteditable', 'true' );
-						} );
-					}
-
-					if (
-						node.ownerDocument.defaultView?.HTMLElement &&
-						focusable instanceof
-							node.ownerDocument.defaultView.HTMLElement
-					) {
-						const previousValue =
-							focusable.style.getPropertyValue(
-								'pointer-events'
-							);
-						focusable.style.setProperty( 'pointer-events', 'none' );
-						updates.push( () => {
-							if ( ! focusable.isConnected ) {
-								return;
-							}
-							focusable.style.setProperty(
-								'pointer-events',
-								previousValue
-							);
-						} );
-					}
-				} );
-			};
-
-			// Debounce re-disable since disabling process itself will incur
-			// additional mutations which should be ignored.
-			const debouncedDisable = debounce( disable, 0, {
-				leading: true,
-			} );
-			disable();
-
-			/** @type {MutationObserver | undefined} */
-			const observer = new window.MutationObserver( debouncedDisable );
-			observer.observe( node, {
-				childList: true,
-				attributes: true,
-				subtree: true,
-			} );
-
+			node.setAttribute( 'inert', 'true' );
 			return () => {
-				if ( observer ) {
-					observer.disconnect();
-				}
-				debouncedDisable.cancel();
-				updates.forEach( ( update ) => update() );
+				node.removeAttribute( 'inert' );
 			};
 		},
 		[ isDisabledProp ]

--- a/packages/compose/src/hooks/use-disabled/index.ts
+++ b/packages/compose/src/hooks/use-disabled/index.ts
@@ -8,6 +8,7 @@ import useRefEffect from '../use-ref-effect';
  * In some circumstances, such as block previews, all focusable DOM elements
  * (input fields, links, buttons, etc.) need to be disabled. This hook adds the
  * behavior to disable nested DOM elements to the returned ref.
+ *
  * If you can, prefer the use of the inert HTML attribute.
  *
  * @param {Object}   config            Configuration object.

--- a/packages/compose/src/hooks/use-disabled/index.ts
+++ b/packages/compose/src/hooks/use-disabled/index.ts
@@ -45,7 +45,7 @@ export default function useDisabled( {
 					if ( ! ( child instanceof HTMLElement ) ) {
 						return;
 					}
-					if ( child.getAttribute( 'inert' ) ) {
+					if ( ! child.getAttribute( 'inert' ) ) {
 						child.setAttribute( 'inert', 'true' );
 						updates.push( () => {
 							child.removeAttribute( 'inert' );

--- a/packages/compose/src/hooks/use-disabled/test/index.js
+++ b/packages/compose/src/hooks/use-disabled/test/index.js
@@ -13,36 +13,6 @@ import { forwardRef } from '@wordpress/element';
  */
 import useDisabled from '../';
 
-jest.mock( '@wordpress/dom', () => {
-	const focus = jest.requireActual( '../../../../../dom/src' ).focus;
-
-	return {
-		focus: {
-			...focus,
-			focusable: {
-				...focus.focusable,
-				find( context ) {
-					// In JSDOM, all elements have zero'd widths and height.
-					// This is a metric for focusable's `isVisible`, so find
-					// and apply an arbitrary non-zero width.
-					Array.from( context.querySelectorAll( '*' ) ).forEach(
-						( element ) => {
-							Object.defineProperties( element, {
-								offsetWidth: {
-									get: () => 1,
-									configurable: true,
-								},
-							} );
-						}
-					);
-
-					return focus.focusable.find( ...arguments );
-				},
-			},
-		},
-	};
-} );
-
 jest.useRealTimers();
 
 describe( 'useDisabled', () => {
@@ -69,11 +39,9 @@ describe( 'useDisabled', () => {
 		const link = screen.getByRole( 'link' );
 		const p = container.querySelector( 'p' );
 
-		expect( input.hasAttribute( 'disabled' ) ).toBe( true );
-		expect( link.getAttribute( 'tabindex' ) ).toBe( '-1' );
-		expect( p.getAttribute( 'contenteditable' ) ).toBe( 'false' );
-		expect( p.hasAttribute( 'tabindex' ) ).toBe( false );
-		expect( p.hasAttribute( 'disabled' ) ).toBe( false );
+		expect( input.hasAttribute( 'inert' ) ).toBe( true );
+		expect( link.hasAttribute( 'inert' ) ).toBe( true );
+		expect( p.hasAttribute( 'inert' ) ).toBe( true );
 	} );
 
 	it( 'will disable an element rendered in an update to the component', async () => {
@@ -86,7 +54,7 @@ describe( 'useDisabled', () => {
 
 		const button = screen.getByText( 'Button' );
 		await waitFor( () => {
-			expect( button.hasAttribute( 'disabled' ) ).toBe( true );
+			expect( button.hasAttribute( 'inert' ) ).toBe( true );
 		} );
 	} );
 } );

--- a/packages/scripts/scripts/check-licenses.js
+++ b/packages/scripts/scripts/check-licenses.js
@@ -60,6 +60,7 @@ const gpl2CompatibleLicenses = [
 	'ODC-By-1.0',
 	'Public Domain',
 	'Unlicense',
+	'W3C-20150513',
 	'WTFPL',
 	'Zlib',
 ];

--- a/tools/webpack/packages.js
+++ b/tools/webpack/packages.js
@@ -99,6 +99,10 @@ const vendors = {
 		'react-dom/umd/react-dom.development.js',
 		'react-dom/umd/react-dom.production.min.js',
 	],
+	'inert-polyfill': [
+		'inert-polyfill/inert-polyfill.js',
+		'inert-polyfill/inert-polyfill.min.js',
+	],
 };
 const vendorsCopyConfig = Object.entries( vendors ).flatMap(
 	( [ key, [ devFilename, prodFilename ] ] ) => {

--- a/tools/webpack/packages.js
+++ b/tools/webpack/packages.js
@@ -100,8 +100,8 @@ const vendors = {
 		'react-dom/umd/react-dom.production.min.js',
 	],
 	'inert-polyfill': [
-		'inert-polyfill/inert-polyfill.js',
-		'inert-polyfill/inert-polyfill.min.js',
+		'wicg-inert/dist/inert.js',
+		'wicg-inert/dist/inert.min.js',
 	],
 };
 const vendorsCopyConfig = Object.entries( vendors ).flatMap(


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What and Why?

The idea of this PR is that there's a new HTML attribute that was specifically added to address the need of our useDisabled/Disabled hooks/components. So let's just refactor this to use the attribute under the hood and rely on a polyfill for browsers that don't support it yet. The main reason for the switch is that our current useDisabled is too heavy and is buggy in some situations (switching back and forth from disabled to enabled can cause some issues sometimes) 

## Testing Instructions

1- Check that disabled content (block preview, some widget blocks like archives as a dropdown...) are disabled properly 

## Todo

 - [x] Check whether we can deprecate the "Disabled" component.
 - [x] Update existing usage of Disabled with the inert attribute.