### PR TITLE
Block Editor: Refactor `ColorPalette` tests to RTL

### DIFF
--- a/packages/block-editor/src/components/color-palette/test/__snapshots__/control.js.snap
+++ b/packages/block-editor/src/components/color-palette/test/__snapshots__/control.js.snap
@@ -118,67 +118,61 @@ exports[`ColorPaletteControl matches the snapshot 1`] = `
 }
 
 <div
-  className="components-base-control block-editor-color-gradient-control emotion-0 emotion-1"
+  class="components-base-control block-editor-color-gradient-control emotion-0 emotion-1"
 >
   <div
-    className="components-base-control__field emotion-2 emotion-3"
+    class="components-base-control__field emotion-2 emotion-3"
   >
     <fieldset
-      className="block-editor-color-gradient-control__fieldset"
+      class="block-editor-color-gradient-control__fieldset"
     >
       <div
-        className="components-flex components-h-stack components-v-stack emotion-4 emotion-5"
-        data-wp-c16t={true}
+        class="components-flex components-h-stack components-v-stack emotion-4 emotion-5"
+        data-wp-c16t="true"
         data-wp-component="VStack"
       >
         <legend>
           <div
-            className="block-editor-color-gradient-control__color-indicator"
+            class="block-editor-color-gradient-control__color-indicator"
           >
             <span
-              className="components-base-control__label emotion-6 emotion-7"
+              class="components-base-control__label emotion-6 emotion-7"
             >
               Test Color
             </span>
           </div>
         </legend>
         <div
-          className="block-editor-color-gradient-control__panel"
+          class="block-editor-color-gradient-control__panel"
         >
           <div
-            className="components-flex components-h-stack components-v-stack emotion-8 emotion-5"
-            data-wp-c16t={true}
+            class="components-flex components-h-stack components-v-stack emotion-8 emotion-5"
+            data-wp-c16t="true"
             data-wp-component="VStack"
           >
             <div
-              className="components-dropdown"
-              tabIndex="-1"
+              class="components-dropdown"
+              tabindex="-1"
             >
               <button
-                aria-expanded={false}
+                aria-expanded="false"
                 aria-haspopup="true"
                 aria-label="Custom color picker. The currently selected color is called \\"red\\" and has a value of \\"f00\\"."
-                className="components-flex components-color-palette__custom-color emotion-10 emotion-5"
-                data-wp-c16t={true}
+                class="components-flex components-color-palette__custom-color emotion-10 emotion-5"
+                data-wp-c16t="true"
                 data-wp-component="Flex"
-                onClick={[Function]}
-                style={
-                  Object {
-                    "background": "#f00",
-                    "color": "#000",
-                  }
-                }
+                style="background: rgb(255, 0, 0); color: rgb(0, 0, 0);"
               >
                 <span
-                  className="components-truncate components-flex-item components-color-palette__custom-color-name emotion-5 emotion-13 emotion-5"
-                  data-wp-c16t={true}
+                  class="components-truncate components-flex-item components-color-palette__custom-color-name emotion-5 emotion-13 emotion-5"
+                  data-wp-c16t="true"
                   data-wp-component="FlexItem"
                 >
                   red
                 </span>
                 <span
-                  className="components-flex-item components-color-palette__custom-color-value emotion-15 emotion-5"
-                  data-wp-c16t={true}
+                  class="components-flex-item components-color-palette__custom-color-value emotion-15 emotion-5"
+                  data-wp-c16t="true"
                   data-wp-component="FlexItem"
                 >
                   f00
@@ -186,40 +180,28 @@ exports[`ColorPaletteControl matches the snapshot 1`] = `
               </button>
             </div>
             <div
-              className="components-circular-option-picker"
+              class="components-circular-option-picker"
             >
               <div
-                className="components-circular-option-picker__swatches"
+                class="components-circular-option-picker__swatches"
               >
                 <div
-                  className="components-circular-option-picker__option-wrapper"
+                  class="components-circular-option-picker__option-wrapper"
                 >
                   <button
-                    aria-describedby={null}
                     aria-label="Color: red"
-                    aria-pressed={true}
-                    className="components-button components-circular-option-picker__option is-pressed"
-                    onBlur={[Function]}
-                    onClick={[Function]}
-                    onFocus={[Function]}
-                    onMouseDown={[Function]}
-                    onMouseEnter={[Function]}
-                    onMouseLeave={[Function]}
-                    style={
-                      Object {
-                        "backgroundColor": "#f00",
-                        "color": "#f00",
-                      }
-                    }
+                    aria-pressed="true"
+                    class="components-button components-circular-option-picker__option is-pressed"
+                    style="background-color: rgb(255, 0, 0); color: rgb(255, 0, 0);"
                     type="button"
                   />
                   <svg
-                    aria-hidden={true}
+                    aria-hidden="true"
                     fill="#000"
-                    focusable={false}
-                    height={24}
+                    focusable="false"
+                    height="24"
                     viewBox="0 0 24 24"
-                    width={24}
+                    width="24"
                     xmlns="http://www.w3.org/2000/svg"
                   >
                     <path
@@ -229,12 +211,10 @@ exports[`ColorPaletteControl matches the snapshot 1`] = `
                 </div>
               </div>
               <div
-                className="components-circular-option-picker__custom-clear-wrapper"
+                class="components-circular-option-picker__custom-clear-wrapper"
               >
                 <button
-                  aria-describedby={null}
-                  className="components-button components-circular-option-picker__clear is-tertiary"
-                  onClick={[Function]}
+                  class="components-button components-circular-option-picker__clear is-tertiary"
                   type="button"
                 >
                   Clear

--- a/packages/block-editor/src/components/color-palette/test/control.js
+++ b/packages/block-editor/src/components/color-palette/test/control.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { create, act } from 'react-test-renderer';
+import { render } from '@testing-library/react';
 
 /**
  * Internal dependencies
@@ -12,20 +12,16 @@ const noop = () => {};
 
 describe( 'ColorPaletteControl', () => {
 	it( 'matches the snapshot', async () => {
-		let root;
+		const { container } = render(
+			<ColorPaletteControl
+				label="Test Color"
+				value="#f00"
+				colors={ [ { color: '#f00', name: 'red' } ] }
+				disableCustomColors={ false }
+				onChange={ noop }
+			/>
+		);
 
-		await act( async () => {
-			root = create(
-				<ColorPaletteControl
-					label="Test Color"
-					value="#f00"
-					colors={ [ { color: '#f00', name: 'red' } ] }
-					disableCustomColors={ false }
-					onChange={ noop }
-				/>
-			);
-		} );
-
-		expect( root.toJSON() ).toMatchSnapshot();
+		expect( container.firstChild ).toMatchSnapshot();
 	} );
 } );


### PR DESCRIPTION
## What?
This PR refactors the `ColorPalette` tests to use `@testing-library/react` instead of `react-test-renderer`.

Part of #44780.

## Why?
It is a part of the recent effort to use `@testing-library/react` as the primary testing library.

## How?
We're updating rendering to now be with RTL.

## Testing Instructions
Verify tests still pass: `npm run test:unit packages/block-editor/src/components/color-palette/test/control.js`
