### PR TITLE
Editor: Refactor PostTypeSupportCheck test to use RTL

### DIFF
--- a/packages/editor/src/components/post-type-support-check/test/index.js
+++ b/packages/editor/src/components/post-type-support-check/test/index.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { create } from 'react-test-renderer';
+import { render } from '@testing-library/react';
 
 /**
  * Internal dependencies
@@ -10,27 +10,26 @@ import { PostTypeSupportCheck } from '../';
 
 describe( 'PostTypeSupportCheck', () => {
 	it( 'renders its children when post type is not known', () => {
-		let postType;
-		const tree = create(
-			<PostTypeSupportCheck postType={ postType } supportKeys="title">
+		const { container } = render(
+			<PostTypeSupportCheck postType={ undefined } supportKeys="title">
 				Supported
 			</PostTypeSupportCheck>
 		);
 
-		expect( tree.toJSON() ).toBe( 'Supported' );
+		expect( container ).toHaveTextContent( 'Supported' );
 	} );
 
 	it( 'does not render its children when post type is known and not supports', () => {
 		const postType = {
 			supports: {},
 		};
-		const tree = create(
+		const { container } = render(
 			<PostTypeSupportCheck postType={ postType } supportKeys="title">
 				Supported
 			</PostTypeSupportCheck>
 		);
 
-		expect( tree.toJSON() ).toBe( null );
+		expect( container ).not.toHaveTextContent( 'Supported' );
 	} );
 
 	it( 'renders its children when post type is known and supports', () => {
@@ -39,13 +38,13 @@ describe( 'PostTypeSupportCheck', () => {
 				title: true,
 			},
 		};
-		const tree = create(
+		const { container } = render(
 			<PostTypeSupportCheck postType={ postType } supportKeys="title">
 				Supported
 			</PostTypeSupportCheck>
 		);
 
-		expect( tree.toJSON() ).toBe( 'Supported' );
+		expect( container ).toHaveTextContent( 'Supported' );
 	} );
 
 	it( 'renders its children if some of keys supported', () => {
@@ -54,7 +53,7 @@ describe( 'PostTypeSupportCheck', () => {
 				title: true,
 			},
 		};
-		const tree = create(
+		const { container } = render(
 			<PostTypeSupportCheck
 				postType={ postType }
 				supportKeys={ [ 'title', 'thumbnail' ] }
@@ -63,14 +62,14 @@ describe( 'PostTypeSupportCheck', () => {
 			</PostTypeSupportCheck>
 		);
 
-		expect( tree.toJSON() ).toBe( 'Supported' );
+		expect( container ).toHaveTextContent( 'Supported' );
 	} );
 
 	it( 'does not render its children if none of keys supported', () => {
 		const postType = {
 			supports: {},
 		};
-		const tree = create(
+		const { container } = render(
 			<PostTypeSupportCheck
 				postType={ postType }
 				supportKeys={ [ 'title', 'thumbnail' ] }
@@ -79,6 +78,6 @@ describe( 'PostTypeSupportCheck', () => {
 			</PostTypeSupportCheck>
 		);
 
-		expect( tree.toJSON() ).toBe( null );
+		expect( container ).not.toHaveTextContent( 'Supported' );
 	} );
 } );


### PR DESCRIPTION
## What?
Part of #44780.

This PR refactors the `PostTypeSupportCheck` tests to use @testing-library/react instead of `react-test-renderer`.

## Why?
It is a part of the recent effort to use `@testing-library/react` as the primary testing library.

## How?
Updates render method to use RTL.

## Testing Instructions
```
npm run test:unit -- packages/editor/src/components/post-type-support-check/test/index.js
```
