### PR TITLE
cleanForSlug: Replace multiple hyphens with a single one

### DIFF
--- a/packages/url/src/clean-for-slug.js
+++ b/packages/url/src/clean-for-slug.js
@@ -31,6 +31,8 @@ export function cleanForSlug( string ) {
 			.replace( /[^\p{L}\p{N}_-]+/gu, '' )
 			// Convert to lowercase
 			.toLowerCase()
+			// Replace multiple hyphens with a single one.
+			.replace( /-+/g, '-' )
 			// Remove any remaining leading or trailing hyphens.
 			.replace( /(^-+)|(-+$)/g, '' )
 	);

--- a/packages/url/src/test/index.js
+++ b/packages/url/src/test/index.js
@@ -1004,6 +1004,11 @@ describe( 'cleanForSlug', () => {
 			'is-tht-deja_vu'
 		);
 	} );
+
+	it( 'Should replace multiple hyphens with a single one', () => {
+		expect( cleanForSlug( 'the long - cat' ) ).toBe( 'the-long-cat' );
+		expect( cleanForSlug( 'the----long---cat' ) ).toBe( 'the-long-cat' );
+	} );
 } );
 
 describe( 'normalizePath', () => {


### PR DESCRIPTION
## What?
See https://github.com/WordPress/gutenberg/issues/12907#issuecomment-1179594582.

PR updates the `cleanForSlug` function to replace multiple hyphens with a single one and match the `sanitize_title` function behavior.

## Testing Instructions
1. Create a Post or Page.
2. Enter the following as post title - `Title - Hypens`
3. Save as a draft.
4. Open the URL popover in the sidebar.
5. Confirm slug doesn't contain multiple hypes.

## Screenshots or screencast <!-- if applicable -->
| Before | After |
| --- | --- |
|![CleanShot 2022-10-11 at 17 20 04](https://user-images.githubusercontent.com/240569/195103216-cc509f28-6598-4d80-8cd3-228f0765d5e2.png)|![CleanShot 2022-10-11 at 17 18 54](https://user-images.githubusercontent.com/240569/195103204-92e951f6-fa03-461c-9996-f8512f38fcd6.png)|

