### PR TITLE
Lodash: Refactor away from `_.without()` in post editor

### DIFF
--- a/packages/edit-post/src/components/block-manager/category.js
+++ b/packages/edit-post/src/components/block-manager/category.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { includes, map, without } from 'lodash';
+import { includes, map } from 'lodash';
 
 /**
  * WordPress dependencies
@@ -64,9 +64,8 @@ function BlockManagerCategory( { title, blockTypes } ) {
 		return null;
 	}
 
-	const checkedBlockNames = without(
-		map( filteredBlockTypes, 'name' ),
-		...hiddenBlockTypes
+	const checkedBlockNames = map( filteredBlockTypes, 'name' ).filter(
+		( type ) => ! hiddenBlockTypes.includes( type )
 	);
 
 	const titleId = 'edit-post-block-manager__category-title-' + instanceId;

--- a/packages/edit-post/src/editor.js
+++ b/packages/edit-post/src/editor.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { map, without } from 'lodash';
+import { map } from 'lodash';
 
 /**
  * WordPress dependencies
@@ -139,9 +139,8 @@ function Editor( {
 					? map( blockTypes, 'name' )
 					: settings.allowedBlockTypes || [];
 
-			result.allowedBlockTypes = without(
-				defaultAllowedBlockTypes,
-				...hiddenBlockTypes
+			result.allowedBlockTypes = defaultAllowedBlockTypes.filter(
+				( type ) => ! hiddenBlockTypes.includes( type )
 			);
 		}
 

--- a/packages/edit-post/src/editor.native.js
+++ b/packages/edit-post/src/editor.native.js
@@ -2,7 +2,7 @@
  * External dependencies
  */
 import memize from 'memize';
-import { map, without } from 'lodash';
+import { map } from 'lodash';
 import { I18nManager } from 'react-native';
 
 /**
@@ -76,9 +76,8 @@ class Editor extends Component {
 					? map( blockTypes, 'name' )
 					: settings.allowedBlockTypes || [];
 
-			settings.allowedBlockTypes = without(
-				defaultAllowedBlockTypes,
-				...hiddenBlockTypes
+			settings.allowedBlockTypes = defaultAllowedBlockTypes.filter(
+				( type ) => ! hiddenBlockTypes.includes( type )
 			);
 		}
 

--- a/packages/edit-post/src/store/actions.js
+++ b/packages/edit-post/src/store/actions.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { castArray, reduce, without } from 'lodash';
+import { castArray, reduce } from 'lodash';
 
 /**
  * WordPress dependencies
@@ -295,9 +295,8 @@ export const showBlockTypes =
 				.select( preferencesStore )
 				.get( 'core/edit-post', 'hiddenBlockTypes' ) ?? [];
 
-		const newBlockNames = without(
-			existingBlockNames,
-			...castArray( blockNames )
+		const newBlockNames = existingBlockNames.filter(
+			( type ) => ! castArray( blockNames ).includes( type )
 		);
 
 		registry


### PR DESCRIPTION
## What?
This PR removes Lodash's `_.without()` from the post editor. There are just a few usages and conversion is pretty straightforward. 

## Why?

Lodash is known to unnecessarily inflate the bundle size of packages, and in most cases, it can be replaced with native language functionality. See these for more information and rationale:

* https://github.com/WordPress/gutenberg/issues/16938#issuecomment-602837246
* https://github.com/WordPress/gutenberg/issues/17025
* https://github.com/WordPress/gutenberg/issues/39495 

## How?

We're replacing a few usages with a simple native filter. 

## Testing Instructions

* Verify managing (enabling/disabling/saving/retrieving) blocks still works well from Preferences -> Blocks
* Smoke test the post editor.
* Verify all checks are green - some of the affected code is well covered by tests.