### PR TITLE
Fluid Typography: Use wp_ prefixed function

### DIFF
--- a/packages/block-library/src/navigation-link/index.php
+++ b/packages/block-library/src/navigation-link/index.php
@@ -100,7 +100,7 @@ function block_core_navigation_link_build_css_font_sizes( $context ) {
 		// Add the custom font size inline style.
 		$font_sizes['inline_styles'] = sprintf(
 			'font-size: %s;',
-			gutenberg_get_typography_font_size_value(
+			wp_get_typography_font_size_value(
 				array(
 					'size' => $context['style']['typography']['fontSize'],
 				)

--- a/packages/block-library/src/navigation-submenu/index.php
+++ b/packages/block-library/src/navigation-submenu/index.php
@@ -100,7 +100,7 @@ function block_core_navigation_submenu_build_css_font_sizes( $context ) {
 		// Add the custom font size inline style.
 		$font_sizes['inline_styles'] = sprintf(
 			'font-size: %s;',
-			gutenberg_get_typography_font_size_value(
+			wp_get_typography_font_size_value(
 				array(
 					'size' => $context['style']['typography']['fontSize'],
 				)

--- a/packages/block-library/src/page-list/index.php
+++ b/packages/block-library/src/page-list/index.php
@@ -121,7 +121,7 @@ function block_core_page_list_build_css_font_sizes( $context ) {
 		// Add the custom font size inline style.
 		$font_sizes['inline_styles'] = sprintf(
 			'font-size: %s;',
-			gutenberg_get_typography_font_size_value(
+			wp_get_typography_font_size_value(
 				array(
 					'size' => $context['style']['typography']['fontSize'],
 				)

--- a/packages/block-library/src/search/index.php
+++ b/packages/block-library/src/search/index.php
@@ -444,7 +444,7 @@ function get_typography_styles_for_block_core_search( $attributes ) {
 	if ( ! empty( $attributes['style']['typography']['fontSize'] ) ) {
 		$typography_styles[] = sprintf(
 			'font-size: %s;',
-			gutenberg_get_typography_font_size_value(
+			wp_get_typography_font_size_value(
 				array(
 					'size' => $attributes['style']['typography']['fontSize'],
 				)

--- a/tools/webpack/blocks.js
+++ b/tools/webpack/blocks.js
@@ -30,6 +30,7 @@ const blockViewRegex = new RegExp(
 const prefixFunctions = [
 	'build_query_vars_from_query_block',
 	'wp_enqueue_block_support_styles',
+	'wp_get_typography_font_size_value',
 	'wp_style_engine_get_styles',
 ];
 


### PR DESCRIPTION
## What?
In dynamic blocks, use a `wp_` prefixed `wp_get_typography_font_size_value` rather than its `gutenberg_` counterpart, `gutenberg_get_typography_font_size_value`.

## Why?
See https://github.com/WordPress/wordpress-develop/pull/3437#issuecomment-1274846664.

## How?
Adding webpack logic to replace the prefix if needed.

## Testing Instructions
Insert one of the affected blocks (Navigation Link, Navigation Submenu, Page List, Search) and set its font size. Save and view on the frontend. Confirm that it works, and no fatals are thrown.

