### PR TITLE
Fix: Inspector is usable on the top level block even if it is content locked

### DIFF
--- a/packages/block-editor/src/components/block-inspector/index.js
+++ b/packages/block-editor/src/components/block-inspector/index.js
@@ -144,6 +144,7 @@ const BlockInspector = ( { showNoBlockSelectedMessage = true } ) => {
 			getSelectedBlockCount,
 			getBlockName,
 			__unstableGetContentLockingParent,
+			getTemplateLock,
 		} = select( blockEditorStore );
 
 		const _selectedBlockClientId = getSelectedBlockClientId();
@@ -157,9 +158,11 @@ const BlockInspector = ( { showNoBlockSelectedMessage = true } ) => {
 			selectedBlockClientId: _selectedBlockClientId,
 			selectedBlockName: _selectedBlockName,
 			blockType: _blockType,
-			topLevelLockedBlock: __unstableGetContentLockingParent(
-				_selectedBlockClientId
-			),
+			topLevelLockedBlock:
+				__unstableGetContentLockingParent( _selectedBlockClientId ) ||
+				( getTemplateLock( _selectedBlockClientId ) === 'contentOnly'
+					? _selectedBlockClientId
+					: undefined ),
 		};
 	}, [] );
 


### PR DESCRIPTION
We had a regression where we could still use the inspector in the top-level block with content locking. This PR fixes the issue.

## Testing
I pasted the following blocks on the code editor:

```
<!-- wp:group {"templateLock":"contentOnly","style":{"color":{"background":"#ff0000"}},"layout":{"type":"constrained"}} -->
<div class="wp-block-group has-background" style="background-color:#ff0000"><!-- wp:paragraph -->
<p>Paragraph 1</p>
<!-- /wp:paragraph -->

<!-- wp:spacer {"height":"124px"} -->
<div style="height:124px" aria-hidden="true" class="wp-block-spacer"></div>
<!-- /wp:spacer -->

<!-- wp:paragraph -->
<p>Paragraph 2</p>
<!-- /wp:paragraph --></div>
<!-- /wp:group -->
```

Using the list view, I selected the group block.

I verified the block inspector shows the following:

![image](https://user-images.githubusercontent.com/11271197/195152871-ba96a964-1fb3-4b45-aaed-1b6624f3333f.png)


On the trunk, it shows the normal group block inspector (bug):