### PR TITLE
Performance tests: Install locked dependencies without resolution

### DIFF
--- a/bin/plugin/commands/performance.js
+++ b/bin/plugin/commands/performance.js
@@ -161,10 +161,7 @@ async function setUpGitBranch( branch, environmentDirectory ) {
 	await git.checkoutRemoteBranch( environmentDirectory, branch );
 
 	log( '        >> Building the ' + formats.success( branch ) + ' branch' );
-	await runShellScript(
-		'npm install && npm run build',
-		environmentDirectory
-	);
+	await runShellScript( 'npm ci && npm run build', environmentDirectory );
 }
 
 /**
@@ -235,7 +232,7 @@ async function runPerformanceTests( branches, options ) {
 	}
 	log( '    >> Installing dependencies and building packages' );
 	await runShellScript(
-		'npm install && npm run build:packages',
+		'npm ci && npm run build:packages',
 		performanceTestDirectory
 	);
 	log( '    >> Creating the environment folders' );


### PR DESCRIPTION
## What

Installs `npm` dependencies during performance tests with `npm ci` instead of `npm install`

## Why

When running the performance tests we're installing our `npm` dependencies using `npm install`. This not only takes longer to run than `npm ci`, but also results in non‑deterministic builds which could flavor the results of our tests.

In this patch we're using `npm ci` instead which should result in more consistent test runs with less setup overhead.

## Testing Instructions

As this only impacts the test runner it should not have any impact on the generated build or bundles. Confirm that the tests pass and pass within reasonable believability. Audit the code and evaluate the appropriateness of `ci` vs. `install` options.
