### PR TITLE
wp-env: Use case insensitive regex when checking WP version string

### DIFF
--- a/packages/env/lib/download-wp-phpunit.js
+++ b/packages/env/lib/download-wp-phpunit.js
@@ -122,7 +122,7 @@ async function downloadTestSuite(
 	// Alpha, Beta, and RC versions are bleeding edge and should pull from trunk.
 	let ref;
 	const fetchRaw = [];
-	if ( ! wpVersion || wpVersion.match( /-(?:alpha|beta|rc)/ ) ) {
+	if ( ! wpVersion || wpVersion.match( /-(?:alpha|beta|rc)/i ) ) {
 		ref = 'trunk';
 		fetchRaw.push( 'fetch', 'origin', ref, '--depth', '1' );
 	} else {


### PR DESCRIPTION
## What?
All CI jobs are currently failing due to this error:

```
✖ fatal: couldn't find remote ref refs/tags/6.1-RC1-54503
```

## Why?
Related to https://github.com/WordPress/gutenberg/pull/41780. 

WordPress version strings use `-RC1`, not `-rc1`. This causes `wp-env` to look for a tag in `wordpress-develop` that does not exist, which in turn causes a fatal error.

## How?
Using a case insensitive regex fixes the problem.

## Testing Instructions
CI should pass.