### PR TITLE
Cherry Pick Script: Restore retrieval of merge_commit_sha

### DIFF
--- a/bin/cherry-pick.mjs
+++ b/bin/cherry-pick.mjs
@@ -127,7 +127,7 @@ async function fetchPRs() {
 
 	const PRsWithMergeCommit = [];
 	for ( const PR of PRs ) {
-		const { mergeCommitHash } = await GitHubFetch(
+		const { merge_commit_sha: mergeCommitHash } = await GitHubFetch(
 			'/repos/WordPress/Gutenberg/pulls/' + PR.number
 		);
 		PRsWithMergeCommit.push( {


### PR DESCRIPTION
## What?

Fixes regression introduced by https://github.com/WordPress/gutenberg/pull/44662

## Why?
Without the fix, it fails when attempting to retrieve commit hashes.

## How?
Destructures the `merge_commit_sha` property from the fetched GitHub PR data in a way that still keeps the linter happy honouring the intent of #44662

## Testing Instructions
1. Run this updated cherry picking script locally and ensure it doesn't error before cherry picking PRs
2. Make sure this hasn't introduced a linting error.

## Screenshots or screencast <!-- if applicable -->

| Before | After |
|---|---|
| <img width="1527" alt="Screen Shot 2022-10-12 at 3 04 58 pm" src="https://user-images.githubusercontent.com/60436221/195261975-fd37eb4b-cea8-4687-9de5-fd1444639a9e.png"> | <img width="993" alt="Screen Shot 2022-10-12 at 3 52 04 pm" src="https://user-images.githubusercontent.com/60436221/195262000-69e50192-3406-41fd-b8b4-d3b297ce47fb.png"> |
