### PR TITLE
Lodash: Refactor away from `_.every()` in block library

### DIFF
--- a/packages/block-library/src/gallery/transforms.js
+++ b/packages/block-library/src/gallery/transforms.js
@@ -133,11 +133,13 @@ const transforms = {
 				// Init the align and size from the first item which may be either the placeholder or an image.
 				let { align, sizeSlug } = attributes[ 0 ];
 				// Loop through all the images and check if they have the same align and size.
-				align = attributes.every( ( att ) => att.align === align )
+				align = attributes.every(
+					( attribute ) => attribute.align === align
+				)
 					? align
 					: undefined;
 				sizeSlug = attributes.every(
-					( att ) => att.sizeSlug === sizeSlug
+					( attribute ) => attribute.sizeSlug === sizeSlug
 				)
 					? sizeSlug
 					: undefined;

--- a/packages/block-library/src/gallery/transforms.js
+++ b/packages/block-library/src/gallery/transforms.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { filter, every } from 'lodash';
+import { filter } from 'lodash';
 
 /**
  * WordPress dependencies
@@ -133,10 +133,12 @@ const transforms = {
 				// Init the align and size from the first item which may be either the placeholder or an image.
 				let { align, sizeSlug } = attributes[ 0 ];
 				// Loop through all the images and check if they have the same align and size.
-				align = every( attributes, [ 'align', align ] )
+				align = attributes.every( ( att ) => att.align === align )
 					? align
 					: undefined;
-				sizeSlug = every( attributes, [ 'sizeSlug', sizeSlug ] )
+				sizeSlug = attributes.every(
+					( att ) => att.sizeSlug === sizeSlug
+				)
 					? sizeSlug
 					: undefined;
 
@@ -268,8 +270,7 @@ const transforms = {
 			isMatch( files ) {
 				return (
 					files.length !== 1 &&
-					every(
-						files,
+					files.every(
 						( file ) => file.type.indexOf( 'image/' ) === 0
 					)
 				);

--- a/packages/block-library/src/gallery/v1/edit.js
+++ b/packages/block-library/src/gallery/v1/edit.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { every, filter, find, get, isEmpty, map, reduce, some } from 'lodash';
+import { filter, find, get, isEmpty, map, reduce, some } from 'lodash';
 
 /**
  * WordPress dependencies
@@ -333,7 +333,7 @@ function GalleryEdit( props ) {
 			Platform.OS === 'web' &&
 			images &&
 			images.length > 0 &&
-			every( images, ( { url } ) => isBlobURL( url ) )
+			images.every( ( { url } ) => isBlobURL( url ) )
 		) {
 			const filesList = map( images, ( { url } ) => getBlobByURL( url ) );
 			images.forEach( ( { url } ) => revokeBlobURL( url ) );

--- a/packages/block-library/src/image/transforms.js
+++ b/packages/block-library/src/image/transforms.js
@@ -1,9 +1,4 @@
 /**
- * External dependencies
- */
-import { every } from 'lodash';
-
-/**
  * WordPress dependencies
  */
 import { createBlobURL } from '@wordpress/blob';
@@ -157,8 +152,7 @@ const transforms = {
 						}
 					);
 				}
-				return every(
-					files,
+				return files.every(
 					( file ) => file.type.indexOf( 'image/' ) === 0
 				);
 			},

--- a/packages/block-library/src/table/state.js
+++ b/packages/block-library/src/table/state.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { get, mapValues, every, pick } from 'lodash';
+import { get, mapValues, pick } from 'lodash';
 
 const INHERITED_COLUMN_ATTRIBUTES = [ 'align' ];
 
@@ -309,7 +309,7 @@ export function toggleSection( state, sectionName ) {
  * @return {boolean} True if the table section is empty, false otherwise.
  */
 export function isEmptyTableSection( section ) {
-	return ! section || ! section.length || every( section, isEmptyRow );
+	return ! section || ! section.length || section.every( isEmptyRow );
 }
 
 /**


### PR DESCRIPTION
## What?
This PR removes Lodash's `_.every()` from the block library. There are just a few usages and conversion is pretty straightforward. 

## Why?

Lodash is known to unnecessarily inflate the bundle size of packages, and in most cases, it can be replaced with native language functionality. See these for more information and rationale:

* https://github.com/WordPress/gutenberg/issues/16938#issuecomment-602837246
* https://github.com/WordPress/gutenberg/issues/17025
* https://github.com/WordPress/gutenberg/issues/39495 

## How?

We're replacing a few usages with a simple native `.every()`. 

## Testing Instructions
Verify that:
* Transformation from an Image to a Gallery block still works well.
* Adding, removing, uploading and reordering images in a Gallery block still works well.
* Dragging and dropping multiple images into an existing gallery block still works well.
* Table with and without an empty head, body, or foot section still works well and looks the same way.
* Verify all checks are green.