### PR TITLE
ESLint: Fix `jest-dom/prefer-enabled-disabled` rule violations

### DIFF
--- a/packages/components/src/button/test/index.js
+++ b/packages/components/src/button/test/index.js
@@ -27,7 +27,7 @@ describe( 'Button', () => {
 			expect( button ).not.toHaveClass( 'is-large' );
 			expect( button ).not.toHaveClass( 'is-primary' );
 			expect( button ).not.toHaveClass( 'is-pressed' );
-			expect( button ).not.toHaveAttribute( 'disabled' );
+			expect( button ).toBeEnabled();
 			expect( button ).not.toHaveAttribute( 'aria-disabled' );
 			expect( button ).toHaveAttribute( 'type', 'button' );
 		} );
@@ -114,16 +114,14 @@ describe( 'Button', () => {
 		it( 'should add a disabled prop to the button', () => {
 			render( <Button disabled /> );
 
-			expect( screen.getByRole( 'button' ) ).toHaveAttribute(
-				'disabled'
-			);
+			expect( screen.getByRole( 'button' ) ).toBeDisabled();
 		} );
 
 		it( 'should add only aria-disabled attribute when disabled and isFocusable are true', () => {
 			render( <Button disabled __experimentalIsFocusable /> );
 			const button = screen.getByRole( 'button' );
 
-			expect( button ).not.toHaveAttribute( 'disabled' );
+			expect( button ).toBeEnabled();
 			expect( button ).toHaveAttribute( 'aria-disabled' );
 		} );
 

--- a/packages/editor/src/components/post-preview-button/test/index.js
+++ b/packages/editor/src/components/post-preview-button/test/index.js
@@ -111,7 +111,7 @@ describe( 'PostPreviewButton', () => {
 	it( 'should not be disabled if post is saveable.', async () => {
 		render( <PostPreviewButton isSaveable postId={ 123 } /> );
 
-		expect( screen.getByRole( 'button' ) ).not.toBeDisabled();
+		expect( screen.getByRole( 'button' ) ).toBeEnabled();
 	} );
 
 	it( 'should set `href` to `previewLink` if `previewLink` is specified.', async () => {

--- a/test/e2e/specs/widgets/customizing-widgets.spec.js
+++ b/test/e2e/specs/widgets/customizing-widgets.spec.js
@@ -564,7 +564,7 @@ test.describe( 'Widgets Customizer', () => {
 		// (2) We should still be in the "Block Settings" area
 		await expect(
 			page.locator( 'role=button[name="Publish"i]' )
-		).not.toBeDisabled();
+		).toBeEnabled();
 
 		// This fails on 539cea09 and earlier; we get kicked back to the widgets area.
 		// We expect to stay in block settings.


### PR DESCRIPTION
## What?
This PR fixes all violations of the [`jest-dom/prefer-enabled-disabled` rule](https://github.com/testing-library/eslint-plugin-jest-dom/blob/main/docs/rules/prefer-enabled-disabled.md), in preparation for enabling `eslint-plugin-jest-dom` globally for the project.

See the [plugin README](https://github.com/testing-library/eslint-plugin-jest-dom) for more info on the jest-dom ESLint plugin.

## Why?
We've been improving our tests a lot recently with the migration to `@testing-library`. One way we could improve them is to better standardize them and follow best practices whenever we can, and one of the best ways to get there is to follow the recommended ESLint rules of the libraries and utilities we use under the hood.

## How?
We're essentially fixing up a few instances:
* Using `toBeDisabled()` instead of `.toHaveAttribute( 'disabled' )`.
* Using `toBeEnabled()` instead of `.not.toHaveAttribute( 'disabled' )`.
* Using `toBeDisabled()` instead of `.not.toBeEnabled()`.
* Using `toBeEnabled()` instead of `.not.toBeDisabled()`.

## Testing Instructions
Verify all checks are green.
