### PR TITLE
ESLint: Fix `jest-dom/prefer-empty` rule violations

### DIFF
--- a/packages/block-directory/src/components/downloadable-blocks-list/test/index.js
+++ b/packages/block-directory/src/components/downloadable-blocks-list/test/index.js
@@ -31,7 +31,7 @@ describe( 'DownloadableBlocksList', () => {
 			isInstallable: true,
 		} ) );
 
-		it( 'should render and empty list', () => {
+		it( 'should render an empty list', () => {
 			const { container } = render(
 				<DownloadableBlocksList
 					items={ [] }
@@ -40,7 +40,7 @@ describe( 'DownloadableBlocksList', () => {
 				/>
 			);
 
-			expect( container.firstChild ).toBe( null );
+			expect( container ).toBeEmptyDOMElement();
 		} );
 
 		it( 'should render plugins items into the list', () => {

--- a/packages/block-editor/src/components/panel-color-settings/test/index.js
+++ b/packages/block-editor/src/components/panel-color-settings/test/index.js
@@ -31,7 +31,7 @@ describe( 'PanelColorSettings', () => {
 				] }
 			/>
 		);
-		expect( container.innerHTML ).toBe( '' );
+		expect( container ).toBeEmptyDOMElement();
 	} );
 
 	it( 'should render a color panel if at least one setting supports custom colors', async () => {
@@ -55,7 +55,7 @@ describe( 'PanelColorSettings', () => {
 				] }
 			/>
 		);
-		expect( container.innerHTML ).not.toBe( '' );
+		expect( container ).not.toBeEmptyDOMElement();
 	} );
 
 	it( 'should render a color panel if at least one setting specifies some colors to choose', async () => {
@@ -85,7 +85,7 @@ describe( 'PanelColorSettings', () => {
 				] }
 			/>
 		);
-		expect( container.innerHTML ).not.toBe( '' );
+		expect( container ).not.toBeEmptyDOMElement();
 	} );
 
 	it( 'should not render anything if none of the setting panels has colors to choose', async () => {
@@ -112,6 +112,6 @@ describe( 'PanelColorSettings', () => {
 				] }
 			/>
 		);
-		expect( container.innerHTML ).not.toBe( '' );
+		expect( container ).not.toBeEmptyDOMElement();
 	} );
 } );

--- a/packages/block-editor/src/components/responsive-block-control/test/index.js
+++ b/packages/block-editor/src/components/responsive-block-control/test/index.js
@@ -90,7 +90,7 @@ describe( 'Basic rendering', () => {
 			'.block-editor-responsive-block-control__group.is-responsive'
 		);
 
-		expect( container.innerHTML ).not.toBe( '' );
+		expect( container ).not.toBeEmptyDOMElement();
 
 		expect( defaultControlGroup ).not.toBeNull();
 		expect( responsiveControlGroup ).toBeNull();
@@ -110,7 +110,7 @@ describe( 'Basic rendering', () => {
 			/>
 		);
 
-		expect( container.innerHTML ).toBe( '' );
+		expect( container ).toBeEmptyDOMElement();
 	} );
 
 	it( 'should not render without valid property', () => {
@@ -121,7 +121,7 @@ describe( 'Basic rendering', () => {
 			/>
 		);
 
-		expect( container.innerHTML ).toBe( '' );
+		expect( container ).toBeEmptyDOMElement();
 	} );
 
 	it( 'should not render without valid default control render prop', () => {
@@ -129,7 +129,7 @@ describe( 'Basic rendering', () => {
 			<ResponsiveBlockControl title="Padding" property="padding" />
 		);
 
-		expect( container.innerHTML ).toBe( '' );
+		expect( container ).toBeEmptyDOMElement();
 	} );
 
 	it( 'should render with custom label for toggle control when provided', () => {

--- a/packages/components/src/shortcut/test/index.tsx
+++ b/packages/components/src/shortcut/test/index.tsx
@@ -11,7 +11,7 @@ import Shortcut from '..';
 describe( 'Shortcut', () => {
 	it( 'does not render anything if no shortcut prop is provided', () => {
 		const { container } = render( <Shortcut /> );
-		expect( container.firstChild ).toBe( null );
+		expect( container ).toBeEmptyDOMElement();
 	} );
 
 	it( 'renders the shortcut display text when a string is passed as the shortcut', () => {

--- a/packages/components/src/toolbar-group/test/index.js
+++ b/packages/components/src/toolbar-group/test/index.js
@@ -13,13 +13,13 @@ describe( 'ToolbarGroup', () => {
 		it( 'should render an empty node, when controls are not passed', () => {
 			const { container } = render( <ToolbarGroup /> );
 
-			expect( container.innerHTML ).toBe( '' );
+			expect( container ).toBeEmptyDOMElement();
 		} );
 
 		it( 'should render an empty node, when controls are empty', () => {
 			const { container } = render( <ToolbarGroup controls={ [] } /> );
 
-			expect( container.innerHTML ).toBe( '' );
+			expect( container ).toBeEmptyDOMElement();
 		} );
 
 		it( 'should render a list of controls with buttons', () => {


### PR DESCRIPTION
## What?
This PR fixes all violations of the [`jest-dom/prefer-empty` rule](https://github.com/testing-library/eslint-plugin-jest-dom/blob/main/docs/rules/prefer-empty.md), in preparation for enabling `eslint-plugin-jest-dom` globally for the project.

See the [plugin README](https://github.com/testing-library/eslint-plugin-jest-dom) for more info on the jest-dom ESLint plugin.

## Why?
We've been improving our tests a lot recently with the migration to `@testing-library`. One way we could improve them is to better standardize them and follow best practices whenever we can, and one of the best ways to get there is to follow the recommended ESLint rules of the libraries and utilities we use under the hood.

## How?
We're essentially fixing up a few instances that either assert positively or negatively that the element is empty.

## Testing Instructions
Verify all checks are green.
