### PR TITLE
Lodash: Refactor away from `_.every()`

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -97,6 +97,7 @@ module.exports = {
 							'dropRight',
 							'each',
 							'escapeRegExp',
+							'every',
 							'extend',
 							'findIndex',
 							'findKey',

--- a/packages/blocks/src/api/utils.js
+++ b/packages/blocks/src/api/utils.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { every, reduce } from 'lodash';
+import { reduce } from 'lodash';
 import { colord, extend } from 'colord';
 import namesPlugin from 'colord/plugins/names';
 import a11yPlugin from 'colord/plugins/a11y';
@@ -57,9 +57,8 @@ export function isUnmodifiedDefaultBlock( block ) {
 	const newDefaultBlock = isUnmodifiedDefaultBlock.block;
 	const blockType = getBlockType( defaultBlockName );
 
-	return every(
-		blockType?.attributes,
-		( value, key ) =>
+	return Object.entries( blockType?.attributes ?? {} ).every(
+		( [ key ] ) =>
 			newDefaultBlock.attributes[ key ] === block.attributes[ key ]
 	);
 }

--- a/packages/blocks/src/api/utils.js
+++ b/packages/blocks/src/api/utils.js
@@ -57,9 +57,8 @@ export function isUnmodifiedDefaultBlock( block ) {
 	const newDefaultBlock = isUnmodifiedDefaultBlock.block;
 	const blockType = getBlockType( defaultBlockName );
 
-	return Object.entries( blockType?.attributes ?? {} ).every(
-		( [ key ] ) =>
-			newDefaultBlock.attributes[ key ] === block.attributes[ key ]
+	return Object.keys( blockType?.attributes ?? {} ).every(
+		( key ) => newDefaultBlock.attributes[ key ] === block.attributes[ key ]
 	);
 }
 

--- a/packages/components/src/higher-order/with-fallback-styles/index.js
+++ b/packages/components/src/higher-order/with-fallback-styles/index.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { every, isEqual } from 'lodash';
+import { isEqual } from 'lodash';
 
 /**
  * WordPress dependencies
@@ -45,10 +45,14 @@ export default ( mapNodeToProps ) =>
 						this.nodeRef,
 						this.props
 					);
+
 					if ( ! isEqual( newFallbackStyles, fallbackStyles ) ) {
 						this.setState( {
 							fallbackStyles: newFallbackStyles,
-							grabStylesCompleted: !! every( newFallbackStyles ),
+							grabStylesCompleted:
+								Object.values( newFallbackStyles ).every(
+									Boolean
+								),
 						} );
 					}
 				}


### PR DESCRIPTION
## What?
This PR removes Lodash's `_.every()` completely and deprecates the method. There are just a few usages and conversion is pretty straightforward. 

## Why?

Lodash is known to unnecessarily inflate the bundle size of packages, and in most cases, it can be replaced with native language functionality. See these for more information and rationale:

* https://github.com/WordPress/gutenberg/issues/16938#issuecomment-602837246
* https://github.com/WordPress/gutenberg/issues/17025
* https://github.com/WordPress/gutenberg/issues/39495 

## How?

We're replacing a few usages with a simple native `Array.prototype.every()`. 

## Testing Instructions

* In the post editor, start typing into a paragraph block and verify it doesn't crash.
* cc @jorgefilipecosta for the `withFallbackStyles` change - also https://github.com/WordPress/gutenberg/pull/3483/files#r151347395 for context. It's not used anywhere so it's not testable at this time. 
* Verify all checks are green.