### PR TITLE
Performance Tests: --runInBand to avoid performance issues in CI environment

### DIFF
--- a/.github/workflows/performance.yml
+++ b/.github/workflows/performance.yml
@@ -42,7 +42,7 @@ jobs:
 
             - name: Compare performance with trunk
               if: github.event_name == 'pull_request'
-              run: ./bin/plugin/cli.js perf $GITHUB_SHA trunk --tests-branch $GITHUB_SHA
+              run: ./bin/plugin/cli.js perf $GITHUB_SHA trunk --tests-branch $GITHUB_SHA --rounds 15
 
             - name: Store performance measurements
               if: github.event_name == 'pull_request'

--- a/bin/plugin/commands/performance.js
+++ b/bin/plugin/commands/performance.js
@@ -201,7 +201,7 @@ function curateResults( testSuite, results ) {
  */
 async function runTestSuite( testSuite, performanceTestDirectory, runKey ) {
 	await runShellScript(
-		`npm run test:performance -- packages/e2e-tests/specs/performance/${ testSuite }.test.js`,
+		`npm run test:performance -- --runInBand packages/e2e-tests/specs/performance/${ testSuite }.test.js`,
 		performanceTestDirectory
 	);
 	const resultsFile = path.join(


### PR DESCRIPTION
Please ignore for now, this is for testing.

Does limiting test runs to `--runInBand` reduce variation in measured metrics?