### PR TITLE
Ensure stale github actions workflow only runs for particular issue labels

### DIFF
--- a/.github/workflows/stale-issue-gardening.yml
+++ b/.github/workflows/stale-issue-gardening.yml
@@ -1,52 +1,53 @@
 name: 'Stale Issue Gardening'
 
 on:
-  schedule:
-    - cron: '0 0 * * *'
+    schedule:
+        - cron: '0 0 * * *'
 
 jobs:
-  issue-gardening:
-    name: ${{ matrix.name }}
-    runs-on: ubuntu-latest
-    if: ${{ github.repository == 'WordPress/gutenberg' }}
-    strategy:
-      matrix:
-        include:
-          - name: 'Issues that require more info'
-            message: 'Help us move this issue forward. This issue is being marked stale since it has no activity after 15 days of requesting more information. Please add info requested so we can help move the issue forward. Note: The triage policy is to close stale issues that need more info and no response after 2 weeks.'
-            days-before-stale: 15
-            days-before-close: -1
-            only-labels: '[Status] Needs More Info'
-            remove-stale-when-updated: true
-            stale-issue-label: '[Status] Stale'
-          - name: 'Issues that have needed testing for a period of time'
-            message: "Hi,\nThis issue has gone 30 days without any activity. This means it is time for a check-in to make sure it is still relevant. If you are still experiencing this issue with the latest versions, you can help the project by responding to confirm the problem and by providing any updated reproduction steps.\nThanks for helping out."
-            days-before-stale: 30
-            days-before-close: -1
-            only-labels: 'Needs Testing'
-            remove-stale-when-updated: true
-            stale-issue-label: '[Status] Stale'
-          - name: 'Flaky test issues without activity'
-            message: 'This issue has gone 30 days without any activity.'
-            days-before-stale: 30
-            days-before-close: 1
-            only-labels: '[Type] Flaky Test'
-            remove-stale-when-updated: true
-            stale-issue-label: '[Status] Stale'
-          - name: 'Issues without recent updates that need confirmation'
-            message: "Hi,\nThis issue has gone 180 days without any activity. This means it is time for a check-in to make sure it is still relevant. If you are still experiencing this issue with the latest versions, you can help the project by responding to confirm the problem and by providing any updated reproduction steps.\nThanks for helping out."
-            days-before-stale: 180
-            days-before-close: -1
-            remove-stale-when-updated: false
-            stale-issue-label: 'Needs Testing'
+    issue-gardening:
+        name: ${{ matrix.name }}
+        runs-on: ubuntu-latest
+        if: ${{ github.repository == 'WordPress/gutenberg' }}
+        strategy:
+            matrix:
+                include:
+                    - name: 'Issues that require more info'
+                      message: 'Help us move this issue forward. This issue is being marked stale since it has no activity after 15 days of requesting more information. Please add info requested so we can help move the issue forward. Note: The triage policy is to close stale issues that need more info and no response after 2 weeks.'
+                      days-before-stale: 15
+                      days-before-close: -1
+                      only-labels: '[Status] Needs More Info'
+                      remove-stale-when-updated: true
+                      stale-issue-label: '[Status] Stale'
+                    - name: 'Issues that have needed testing for a period of time'
+                      message: "Hi,\nThis issue has gone 30 days without any activity. This means it is time for a check-in to make sure it is still relevant. If you are still experiencing this issue with the latest versions, you can help the project by responding to confirm the problem and by providing any updated reproduction steps.\nThanks for helping out."
+                      days-before-stale: 30
+                      days-before-close: -1
+                      only-labels: 'Needs Testing'
+                      remove-stale-when-updated: true
+                      stale-issue-label: '[Status] Stale'
+                    - name: 'Flaky test issues without activity'
+                      message: 'This issue has gone 30 days without any activity.'
+                      days-before-stale: 30
+                      days-before-close: 1
+                      only-labels: '[Type] Flaky Test'
+                      remove-stale-when-updated: true
+                      stale-issue-label: '[Status] Stale'
+                    - name: 'Issues without recent updates that need confirmation'
+                      message: "Hi,\nThis issue has gone 180 days without any activity. This means it is time for a check-in to make sure it is still relevant. If you are still experiencing this issue with the latest versions, you can help the project by responding to confirm the problem and by providing any updated reproduction steps.\nThanks for helping out."
+                      days-before-stale: 180
+                      days-before-close: -1
+                      remove-stale-when-updated: false
+                      stale-issue-label: 'Needs Testing'
 
-    steps:
-      - name: Update issues
-        uses: actions/stale@5ebf00ea0e4c1561e9b43a292ed34424fb1d4578 # v6.0.1
-        with:
-          repo-token: ${{ secrets.GITHUB_TOKEN }}
-          stale-issue-message: ${{ matrix.message }}
-          days-before-stale: ${{ matrix.days-before-stale }}
-          days-before-close: ${{ matrix.days-before-close }}
-          remove-stale-when-updated: ${{ matrix.remove-stale-when-updated }}
-          stale-issue-label: ${{ matrix.stale-issue-label }}
+        steps:
+            - name: Update issues
+              uses: actions/stale@5ebf00ea0e4c1561e9b43a292ed34424fb1d4578 # v6.0.1
+              with:
+                  repo-token: ${{ secrets.GITHUB_TOKEN }}
+                  stale-issue-message: ${{ matrix.message }}
+                  days-before-stale: ${{ matrix.days-before-stale }}
+                  days-before-close: ${{ matrix.days-before-close }}
+                  only-labels: ${{ matrix.only-labels }}
+                  remove-stale-when-updated: ${{ matrix.remove-stale-when-updated }}
+                  stale-issue-label: ${{ matrix.stale-issue-label }}


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
A bug was introduced in #44754, whereby stale workflows that are supposed to run for issues with particular labels were run on all issues.

This PR remedies the problem.

I guess we'll have to find a way to go back through all the issues that 'Stale' was accidentally applied to and remove the labels. Maybe a script that removes every stale label added in the last 24 hours?

## How?
Ensures the `only-labels` property is set.

Looks like some automatic formatting was also applied to the yml file 🤔 

## Testing Instructions
There is no way to test it, we'll just have to wait and see 😎 