### PR TITLE
List Item: Allow Gutenberg to override core block type

### DIFF
--- a/lib/blocks.php
+++ b/lib/blocks.php
@@ -26,6 +26,7 @@ function gutenberg_reregister_core_block_types() {
 				'heading',
 				'html',
 				'list',
+				'list-item',
 				'media-text',
 				'missing',
 				'more',


### PR DESCRIPTION
Related:
- https://github.com/WordPress/gutenberg/pull/42711
- https://github.com/WordPress/gutenberg/pull/43312

## What?
Allows Gutenberg to reregister the `core/list-item` block on the PHP side.

## Why?
Fixes some issues with the List Item block. 
- Without this we can't extend the List Item block fully in Gutenberg
- Global Styles for the List Item block will not save

## How?
- Adds `list-item` to the list of block directories for the Gutenberg core block reregistration action

## Testing Instructions
1. Add font size block support to the List Item block.json (see below for snippet)
2. On trunk (with WP 6.0), in the Site Editor, select a page that has a list containing the List Item block e.g. Navigation
3. Navigate to Global Styles > Blocks > List Item > Typography
4. Set the XL font size, this should be reflected in the preview.
5. Save your Global Styles changes, the large font size will disappear
6. Checkout this PR branch and reload the Site Editor
7. Re-apply the XL font size and save again
8. This time the styles will remain.

##### Alternate Testing Approach

1. On a site running WP 6.1-RC1, checkout https://github.com/WordPress/gutenberg/pull/43312
2. In the Site Editor, navigate to Global Styles > Blocks and notice that List Item isn't in the list
    - This is because without the fix in this PR, Gutenberg doesn't override core's List Item block
    - Without that override, the List Item block never gets the block supports from [#43312](https://github.com/WordPress/gutenberg/pull/43312) and so doesn't show.
3. Apply the fix in this PR, reload the Site Editor, and confirm you can now see List Item under Global Styles > Blocks and adjust typography settings.
