### PR TITLE
Fix typo for word occurred

### DIFF
--- a/packages/block-library/src/navigation/edit/index.js
+++ b/packages/block-library/src/navigation/edit/index.js
@@ -495,7 +495,7 @@ function Navigation( {
 			);
 		} catch {
 			showMenuAutoPublishDraftNotice(
-				__( 'Error ocurred while publishing the navigation menu.' )
+				__( 'Error occurred while publishing the navigation menu.' )
 			);
 		}
 	}, [ isDraftNavigationMenu, navigationMenu ] );

--- a/packages/edit-navigation/src/store/actions.js
+++ b/packages/edit-navigation/src/store/actions.js
@@ -81,7 +81,7 @@ export const saveNavigationPost =
 						__( "Unable to save: '%s'" ),
 						saveError.message
 				  )
-				: __( 'Unable to save: An error ocurred.' );
+				: __( 'Unable to save: An error occurred.' );
 			registry.dispatch( noticesStore ).createErrorNotice( errorMessage, {
 				type: 'snackbar',
 			} );


### PR DESCRIPTION
replaced the word `ocurred` with `occurred`

trac ticket : https://core.trac.wordpress.org/ticket/56814

<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->



## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
Typo



