### PR TITLE
ESLint: Fix `jest-dom/prefer-to-have-text-content` rule violations

### DIFF
--- a/packages/a11y/src/test/clear.test.js
+++ b/packages/a11y/src/test/clear.test.js
@@ -16,7 +16,7 @@ describe( 'clear', () => {
 		document.body.appendChild( container2 );
 
 		clear();
-		expect( container1.textContent ).toBe( '' );
-		expect( container2.textContent ).toBe( '' );
+		expect( container1 ).toHaveTextContent( '' );
+		expect( container2 ).toHaveTextContent( '' );
 	} );
 } );

--- a/packages/a11y/src/test/index.test.js
+++ b/packages/a11y/src/test/index.test.js
@@ -42,8 +42,8 @@ describe( 'speak', () => {
 	describe( 'in default mode', () => {
 		it( 'should set the textcontent of the polite aria-live region', () => {
 			speak( 'default message' );
-			expect( containerPolite.textContent ).toBe( 'default message' );
-			expect( containerAssertive.textContent ).toBe( '' );
+			expect( containerPolite ).toHaveTextContent( 'default message' );
+			expect( containerAssertive ).toHaveTextContent( '' );
 			expect( clear ).toHaveBeenCalled();
 			expect( filterMessage ).toHaveBeenCalledWith( 'default message' );
 		} );
@@ -52,8 +52,8 @@ describe( 'speak', () => {
 	describe( 'in assertive mode', () => {
 		it( 'should set the textcontent of the assertive aria-live region', () => {
 			speak( 'assertive message', 'assertive' );
-			expect( containerPolite.textContent ).toBe( '' );
-			expect( containerAssertive.textContent ).toBe(
+			expect( containerPolite ).toHaveTextContent( '' );
+			expect( containerAssertive ).toHaveTextContent(
 				'assertive message'
 			);
 		} );
@@ -62,8 +62,8 @@ describe( 'speak', () => {
 	describe( 'in explicit polite mode', () => {
 		it( 'should set the textcontent of the polite aria-live region', () => {
 			speak( 'polite message', 'polite' );
-			expect( containerPolite.textContent ).toBe( 'polite message' );
-			expect( containerAssertive.textContent ).toBe( '' );
+			expect( containerPolite ).toHaveTextContent( 'polite message' );
+			expect( containerAssertive ).toHaveTextContent( '' );
 		} );
 	} );
 
@@ -81,7 +81,7 @@ describe( 'speak', () => {
 
 		it( 'should set the textcontent of the polite aria-live region', () => {
 			speak( 'message', 'assertive' );
-			expect( containerPolite.textContent ).toBe( 'message' );
+			expect( containerPolite ).toHaveTextContent( 'message' );
 			expect(
 				document.getElementById( 'a11y-speak-assertive' )
 			).toBeNull();

--- a/packages/block-editor/src/components/inserter/test/reusable-blocks-tab.js
+++ b/packages/block-editor/src/components/inserter/test/reusable-blocks-tab.js
@@ -98,7 +98,7 @@ describe( 'InserterMenu', () => {
 		);
 
 		expect( blocks ).toHaveLength( 1 );
-		expect( blocks[ 0 ].textContent ).toBe( 'My reusable block' );
+		expect( blocks[ 0 ] ).toHaveTextContent( 'My reusable block' );
 	} );
 
 	it( 'should trim whitespace of search terms', () => {
@@ -111,6 +111,6 @@ describe( 'InserterMenu', () => {
 		);
 
 		expect( blocks ).toHaveLength( 1 );
-		expect( blocks[ 0 ].textContent ).toBe( 'My reusable block' );
+		expect( blocks[ 0 ] ).toHaveTextContent( 'My reusable block' );
 	} );
 } );

--- a/packages/components/src/font-size-picker/test/index.tsx
+++ b/packages/components/src/font-size-picker/test/index.tsx
@@ -215,7 +215,7 @@ describe( 'FontSizePicker', () => {
 				);
 				const element = screen.getByLabelText( 'Large' );
 				expect( element ).toBeInTheDocument();
-				expect( element.children[ 0 ].textContent ).toBe( 'L' );
+				expect( element.children[ 0 ] ).toHaveTextContent( 'L' );
 			} );
 			it( 'should use incremental sequence of t-shirt sizes as labels if we have complex css', () => {
 				const fontSizes = [
@@ -240,7 +240,7 @@ describe( 'FontSizePicker', () => {
 				const extraLargeElement =
 					screen.getByLabelText( 'Extra Large' );
 				expect( extraLargeElement ).toBeInTheDocument();
-				expect( extraLargeElement.children[ 0 ].textContent ).toBe(
+				expect( extraLargeElement.children[ 0 ] ).toHaveTextContent(
 					'XL'
 				);
 			} );

--- a/packages/components/src/navigation/test/index.js
+++ b/packages/components/src/navigation/test/index.js
@@ -220,7 +220,7 @@ describe( 'Navigation', () => {
 		render( <TestNavigation showBadge /> );
 
 		const menuItem = screen.getAllByRole( 'listitem' );
-		expect( menuItem[ 0 ].textContent ).toBe( 'Item 1' + '21' );
+		expect( menuItem[ 0 ] ).toHaveTextContent( 'Item 1' + '21' );
 	} );
 
 	it( 'should render menu titles when items exist', () => {

--- a/packages/components/src/text-highlight/test/index.tsx
+++ b/packages/components/src/text-highlight/test/index.tsx
@@ -50,9 +50,7 @@ describe( 'TextHighlight', () => {
 			expect( highlightedEls ).toHaveLength( 2 );
 
 			highlightedEls.forEach( ( el ) => {
-				expect( el.textContent ).toEqual(
-					expect.stringContaining( highlight )
-				);
+				expect( el ).toHaveTextContent( highlight );
 			} );
 		} );
 

--- a/packages/components/src/truncate/test/index.tsx
+++ b/packages/components/src/truncate/test/index.tsx
@@ -11,7 +11,7 @@ import { Truncate } from '..';
 describe( 'props', () => {
 	test( 'should render correctly', () => {
 		const { container } = render( <Truncate>Lorem ipsum.</Truncate> );
-		expect( container.firstChild?.textContent ).toEqual( 'Lorem ipsum.' );
+		expect( container.firstChild ).toHaveTextContent( 'Lorem ipsum.' );
 	} );
 
 	test( 'should render limit', () => {
@@ -20,7 +20,7 @@ describe( 'props', () => {
 				Lorem ipsum.
 			</Truncate>
 		);
-		expect( container.firstChild?.textContent ).toEqual( 'L…' );
+		expect( container.firstChild ).toHaveTextContent( 'L…' );
 	} );
 
 	test( 'should render custom ellipsis', () => {
@@ -29,7 +29,7 @@ describe( 'props', () => {
 				Lorem ipsum.
 			</Truncate>
 		);
-		expect( container.firstChild?.textContent ).toEqual( 'Lorem!!!' );
+		expect( container.firstChild ).toHaveTextContent( 'Lorem!!!' );
 	} );
 
 	test( 'should render custom ellipsizeMode', () => {
@@ -38,6 +38,6 @@ describe( 'props', () => {
 				Lorem ipsum.
 			</Truncate>
 		);
-		expect( container.firstChild?.textContent ).toEqual( 'Lo!!!m.' );
+		expect( container.firstChild ).toHaveTextContent( 'Lo!!!m.' );
 	} );
 } );

--- a/packages/data/src/components/use-select/test/suspense.js
+++ b/packages/data/src/components/use-select/test/suspense.js
@@ -158,7 +158,7 @@ describe( 'useSuspenseSelect', () => {
 
 		const rendered = render( <App /> );
 		const label = await waitFor( () => rendered.getByLabelText( 'error' ) );
-		expect( label.textContent ).toBe( 'resolution failed' );
+		expect( label ).toHaveTextContent( 'resolution failed' );
 		expect( console ).toHaveErrored();
 	} );
 } );


### PR DESCRIPTION
## What?
This PR fixes all violations of the [`jest-dom/prefer-to-have-text-content` rule](https://github.com/testing-library/eslint-plugin-jest-dom/blob/main/docs/rules/prefer-to-have-text-content.md), in preparation for enabling `eslint-plugin-jest-dom` globally for the project.

See the [plugin README](https://github.com/testing-library/eslint-plugin-jest-dom) for more info on the jest-dom ESLint plugin.

## Why?
We've been improving our tests a lot recently with the migration to `@testing-library`. One way we could improve them is to better standardize them and follow best practices whenever we can, and one of the best ways to get there is to follow the recommended ESLint rules of the libraries and utilities we use under the hood.

## How?
We're essentially fixing up a few instances that either assert positively or negatively that the element has a certain text content.

## Testing Instructions
Verify all checks are green.
