### PR TITLE
ESLint: Fix `jest-dom/prefer-focus` rule violations

### DIFF
--- a/packages/components/src/higher-order/with-focus-return/test/index.js
+++ b/packages/components/src/higher-order/with-focus-return/test/index.js
@@ -78,11 +78,11 @@ describe( 'withFocusReturn()', () => {
 
 			// Change activeElement.
 			switchFocusTo.focus();
-			expect( document.activeElement ).toBe( switchFocusTo );
+			expect( switchFocusTo ).toHaveFocus();
 
 			// Should keep focus on switchFocusTo, because it is not within HOC.
 			unmount();
-			expect( document.activeElement ).toBe( switchFocusTo );
+			expect( switchFocusTo ).toHaveFocus();
 		} );
 
 		it( 'should switch focus back when unmounted while having focus', () => {
@@ -95,14 +95,14 @@ describe( 'withFocusReturn()', () => {
 			const textarea = container.querySelector( 'textarea' );
 			fireEvent.focusIn( textarea, { target: textarea } );
 			textarea.focus();
-			expect( document.activeElement ).toBe( textarea );
+			expect( textarea ).toHaveFocus();
 
 			// Should return to the activeElement saved with this component.
 			unmount();
 			render( <div></div>, {
 				container,
 			} );
-			expect( document.activeElement ).toBe( activeElement );
+			expect( activeElement ).toHaveFocus();
 		} );
 	} );
 } );


### PR DESCRIPTION
## What?
This PR fixes all violations of the [`jest-dom/prefer-focus` rule](https://github.com/testing-library/eslint-plugin-jest-dom/blob/main/docs/rules/prefer-focus.md), in preparation for enabling `eslint-plugin-jest-dom` globally for the project.

See the [plugin README](https://github.com/testing-library/eslint-plugin-jest-dom) for more info on the jest-dom ESLint plugin.

## Why?
We've been improving our tests a lot recently with the migration to `@testing-library`. One way we could improve them is to better standardize them and follow best practices whenever we can, and one of the best ways to get there is to follow the recommended ESLint rules of the libraries and utilities we use under the hood.

## How?
We're essentially fixing up a few instances that either assert positively or negatively that the element is focused.

## Testing Instructions
Verify all checks are green.
