### PR TITLE
ESLint: Fix `jest-dom/prefer-checked` rule violations

### DIFF
--- a/packages/components/src/menu-item/test/index.js
+++ b/packages/components/src/menu-item/test/index.js
@@ -83,7 +83,6 @@ describe( 'MenuItem', () => {
 
 		const menuItem = screen.getByRole( 'menuitem' );
 		expect( menuItem ).not.toBeChecked();
-		expect( menuItem ).not.toHaveAttribute( 'aria-checked' );
 	} );
 
 	it( 'should use aria-checked if menuitemradio or menuitemcheckbox is set as aria-role', () => {
@@ -95,7 +94,6 @@ describe( 'MenuItem', () => {
 
 		const radioMenuItem = screen.getByRole( 'menuitemradio' );
 		expect( radioMenuItem ).toBeChecked();
-		expect( radioMenuItem ).toHaveAttribute( 'aria-checked', 'true' );
 
 		rerender(
 			<MenuItem role="menuitemcheckbox" isSelected>
@@ -105,7 +103,6 @@ describe( 'MenuItem', () => {
 
 		const checkboxMenuItem = screen.getByRole( 'menuitemcheckbox' );
 		expect( checkboxMenuItem ).toBeChecked();
-		expect( checkboxMenuItem ).toHaveAttribute( 'aria-checked', 'true' );
 	} );
 
 	it( 'should not render shortcut or right icon if suffix provided', () => {


### PR DESCRIPTION
## What?
This PR fixes all violations of the [`jest-dom/prefer-checked` rule](https://github.com/testing-library/eslint-plugin-jest-dom/blob/main/docs/rules/prefer-checked.md), in preparation for enabling `eslint-plugin-jest-dom` globally for the project.

See the [plugin README](https://github.com/testing-library/eslint-plugin-jest-dom) for more info on the jest-dom ESLint plugin.

## Why?
We've been improving our tests a lot recently with the migration to `@testing-library`. One way we could improve them is to better standardize them and follow best practices whenever we can, and one of the best ways to get there is to follow the recommended ESLint rules of the libraries and utilities we use under the hood.

## How?
We're essentially removing a few redundant `aria-checked` assertions, because those are included in `toBeChecked()` that is used there already - see [docs](https://github.com/testing-library/jest-dom#tobechecked).

## Testing Instructions
Verify all checks are green.
