### PR TITLE
ESLint: Fix `jest-dom/prefer-to-have-style` rule violations

### DIFF
--- a/packages/components/src/form-file-upload/test/index.tsx
+++ b/packages/components/src/form-file-upload/test/index.tsx
@@ -41,7 +41,7 @@ describe( 'FormFileUpload', () => {
 		const button = screen.getByText( 'My Upload Button' );
 		const input = screen.getByTestId( 'form-file-upload-input' );
 		expect( button ).toBeInTheDocument();
-		expect( input.style.display ).toBe( 'none' );
+		expect( input ).toHaveStyle( 'display: none' );
 	} );
 
 	it( 'should not fire a change event after selecting the same file', async () => {


### PR DESCRIPTION
## What?
This PR fixes all violations of the [`jest-dom/prefer-to-have-style` rule](https://github.com/testing-library/eslint-plugin-jest-dom/blob/main/docs/rules/prefer-to-have-style.md), in preparation for enabling `eslint-plugin-jest-dom` globally for the project.

See the [plugin README](https://github.com/testing-library/eslint-plugin-jest-dom) for more info on the jest-dom ESLint plugin.

## Why?
We've been improving our tests a lot recently with the migration to `@testing-library`. One way we could improve them is to better standardize them and follow best practices whenever we can, and one of the best ways to get there is to follow the recommended ESLint rules of the libraries and utilities we use under the hood.

## How?
We're essentially fixing a single instance that was accessing `element.style` directly.

## Testing Instructions
Verify all checks are green.
