### PR TITLE
Adds a modal version of the block inserter only in Distraction Free mode

### DIFF
--- a/packages/block-editor/src/components/inserter/index.js
+++ b/packages/block-editor/src/components/inserter/index.js
@@ -20,6 +20,7 @@ import { plus } from '@wordpress/icons';
  */
 import InserterMenu from './menu';
 import QuickInserter from './quick-inserter';
+import ModalInserter from './modal-inserter';
 import { store as blockEditorStore } from '../../store';
 
 const defaultRenderToggle = ( {
@@ -142,12 +143,27 @@ class Inserter extends Component {
 			// This prop is experimental to give some time for the quick inserter to mature
 			// Feel free to make them stable after a few releases.
 			__experimentalIsQuick: isQuick,
+			__experimentalIsModal: isModal,
 			prioritizePatterns,
 		} = this.props;
 
 		if ( isQuick ) {
 			return (
 				<QuickInserter
+					onSelect={ () => {
+						onClose();
+					} }
+					rootClientId={ rootClientId }
+					clientId={ clientId }
+					isAppender={ isAppender }
+					prioritizePatterns={ prioritizePatterns }
+				/>
+			);
+		}
+
+		if ( isModal ) {
+			return (
+				<ModalInserter
 					onSelect={ () => {
 						onClose();
 					} }
@@ -173,6 +189,21 @@ class Inserter extends Component {
 		);
 	}
 
+	renderModal() {
+		const { rootClientId, clientId, isAppender, prioritizePatterns } =
+			this.props;
+
+		return (
+			<ModalInserter
+				onSelect={ () => null }
+				rootClientId={ rootClientId }
+				clientId={ clientId }
+				isAppender={ isAppender }
+				prioritizePatterns={ prioritizePatterns }
+			/>
+		);
+	}
+
 	render() {
 		const {
 			position,
@@ -180,8 +211,13 @@ class Inserter extends Component {
 			directInsertBlock,
 			insertOnlyAllowedBlock,
 			__experimentalIsQuick: isQuick,
+			__experimentalIsModal: isModal,
 			onSelectOrClose,
 		} = this.props;
+
+		if ( isModal ) {
+			return this.renderModal();
+		}
 
 		if ( hasSingleBlockType || directInsertBlock ) {
 			return this.renderToggle( { onToggle: insertOnlyAllowedBlock } );

--- a/packages/block-editor/src/components/inserter/modal-inserter.js
+++ b/packages/block-editor/src/components/inserter/modal-inserter.js
@@ -1,0 +1,113 @@
+/**
+ * External dependencies
+ */
+import classnames from 'classnames';
+
+/**
+ * WordPress dependencies
+ */
+import { useState } from '@wordpress/element';
+import { __ } from '@wordpress/i18n';
+import { SearchControl } from '@wordpress/components';
+import { useSelect } from '@wordpress/data';
+
+/**
+ * Internal dependencies
+ */
+import InserterSearchResults from './search-results';
+import useInsertionPoint from './hooks/use-insertion-point';
+import usePatternsState from './hooks/use-patterns-state';
+import useBlockTypesState from './hooks/use-block-types-state';
+import { store as blockEditorStore } from '../../store';
+
+const SEARCH_THRESHOLD = 6;
+const SHOWN_BLOCK_TYPES = 6;
+const SHOWN_BLOCK_PATTERNS = 2;
+const SHOWN_BLOCK_PATTERNS_WITH_PRIORITIZATION = 4;
+
+export default function ModalInserter(
+	{ onSelect, rootClientId, clientId, isAppender, prioritizePatterns },
+	ref
+) {
+	const [ filterValue, setFilterValue ] = useState( '' );
+	const [ destinationRootClientId, onInsertBlocks ] = useInsertionPoint( {
+		onSelect,
+		rootClientId,
+		clientId,
+		isAppender,
+	} );
+	const [ blockTypes ] = useBlockTypesState(
+		destinationRootClientId,
+		onInsertBlocks
+	);
+
+	const [ patterns ] = usePatternsState(
+		onInsertBlocks,
+		destinationRootClientId
+	);
+
+	const { setInserterIsOpened } = useSelect(
+		( select ) => {
+			const { getSettings, getBlockIndex, getBlockCount } =
+				select( blockEditorStore );
+			const settings = getSettings();
+			const index = getBlockIndex( clientId );
+			const blockCount = getBlockCount();
+
+			return {
+				setInserterIsOpened: settings.__experimentalSetIsInserterOpened,
+				insertionIndex: index === -1 ? blockCount : index,
+			};
+		},
+		[ clientId ]
+	);
+
+	const showPatterns =
+		patterns.length && ( !! filterValue || prioritizePatterns );
+	const showSearch =
+		( showPatterns && patterns.length > SEARCH_THRESHOLD ) ||
+		blockTypes.length > SEARCH_THRESHOLD;
+
+	let maxBlockPatterns = 0;
+	if ( showPatterns ) {
+		maxBlockPatterns = prioritizePatterns
+			? SHOWN_BLOCK_PATTERNS_WITH_PRIORITIZATION
+			: SHOWN_BLOCK_PATTERNS;
+	}
+
+	return (
+		<div
+			className={ classnames( 'block-editor-inserter__quick-inserter', {
+				'has-search': showSearch,
+				'has-expand': setInserterIsOpened,
+			} ) }
+		>
+			{ showSearch && (
+				<SearchControl
+					ref={ ref }
+					className="block-editor-inserter__search"
+					value={ filterValue }
+					onChange={ ( value ) => {
+						setFilterValue( value );
+					} }
+					label={ __( 'Search for blocks and patterns' ) }
+					placeholder={ __( 'Search' ) }
+				/>
+			) }
+
+			<div className="block-editor-inserter__quick-inserter-results">
+				<InserterSearchResults
+					filterValue={ filterValue }
+					onSelect={ onSelect }
+					rootClientId={ rootClientId }
+					clientId={ clientId }
+					isAppender={ isAppender }
+					maxBlockPatterns={ maxBlockPatterns }
+					maxBlockTypes={ SHOWN_BLOCK_TYPES }
+					isDraggable={ false }
+					prioritizePatterns={ prioritizePatterns }
+				/>
+			</div>
+		</div>
+	);
+}

--- a/packages/block-editor/src/components/inserter/modal-inserter.js
+++ b/packages/block-editor/src/components/inserter/modal-inserter.js
@@ -10,6 +10,7 @@ import { useState } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import { SearchControl } from '@wordpress/components';
 import { useSelect } from '@wordpress/data';
+import { useFocusOnMount } from '@wordpress/compose';
 
 /**
  * Internal dependencies
@@ -25,10 +26,14 @@ const SHOWN_BLOCK_TYPES = 6;
 const SHOWN_BLOCK_PATTERNS = 2;
 const SHOWN_BLOCK_PATTERNS_WITH_PRIORITIZATION = 4;
 
-export default function ModalInserter(
-	{ onSelect, rootClientId, clientId, isAppender, prioritizePatterns },
-	ref
-) {
+export default function ModalInserter( {
+	onSelect,
+	rootClientId,
+	clientId,
+	isAppender,
+	prioritizePatterns,
+} ) {
+	const ref = useFocusOnMount();
 	const [ filterValue, setFilterValue ] = useState( '' );
 	const [ destinationRootClientId, onInsertBlocks ] = useInsertionPoint( {
 		onSelect,

--- a/packages/edit-post/src/components/header/style.scss
+++ b/packages/edit-post/src/components/header/style.scss
@@ -219,7 +219,6 @@
 			visibility: hidden;
 		}
 
-		& > .edit-post-header__toolbar .edit-post-header-toolbar__inserter-toggle,
 		& > .edit-post-header__toolbar .edit-post-header-toolbar__list-view-toggle,
 		& > .edit-post-header__settings > .block-editor-post-preview__dropdown,
 		& > .edit-post-header__settings > .interface-pinned-items {

--- a/packages/edit-post/src/components/keyboard-shortcuts/index.js
+++ b/packages/edit-post/src/components/keyboard-shortcuts/index.js
@@ -24,6 +24,7 @@ function KeyboardShortcuts() {
 		getEditorMode,
 		isEditorSidebarOpened,
 		isListViewOpened,
+		isInserterOpened,
 		isFeatureActive,
 	} = useSelect( editPostStore );
 	const isModeToggleDisabled = useSelect( ( select ) => {
@@ -91,6 +92,16 @@ function KeyboardShortcuts() {
 			keyCombination: {
 				modifier: 'access',
 				character: 'o',
+			},
+		} );
+
+		registerShortcut( {
+			name: 'core/edit-post/toggle-modal-inserter',
+			category: 'global',
+			description: __( 'Open modal inserter.' ),
+			keyCombination: {
+				modifier: 'access',
+				character: 'i',
 			},
 		} );
 
@@ -198,6 +209,10 @@ function KeyboardShortcuts() {
 
 	useShortcut( 'core/edit-post/toggle-list-view', () =>
 		setIsListViewOpened( ! isListViewOpened() )
+	);
+
+	useShortcut( 'core/edit-post/toggle-modal-inserter', () =>
+		setIsInserterOpened( ! isInserterOpened() )
 	);
 
 	return null;

--- a/packages/edit-post/src/components/layout/index.js
+++ b/packages/edit-post/src/components/layout/index.js
@@ -49,6 +49,7 @@ import WelcomeGuide from '../welcome-guide';
 import ActionsPanel from './actions-panel';
 import StartPageOptions from '../start-page-options';
 import { store as editPostStore } from '../../store';
+import { ModalInserter } from './modal-inserter';
 
 const interfaceLabels = {
 	/* translators: accessibility text for the editor top bar landmark region. */
@@ -174,8 +175,11 @@ function Layout( { styles } ) {
 		: __( 'Block Library' );
 
 	const secondarySidebar = () => {
-		if ( mode === 'visual' && isInserterOpened ) {
+		if ( mode === 'visual' && ! isDistractionFree && isInserterOpened ) {
 			return <InserterSidebar />;
+		}
+		if ( mode === 'visual' && isDistractionFree && isInserterOpened ) {
+			return <ModalInserter />;
 		}
 		if ( mode === 'visual' && isListViewOpened ) {
 			return <ListViewSidebar />;

--- a/packages/edit-post/src/components/layout/modal-inserter.js
+++ b/packages/edit-post/src/components/layout/modal-inserter.js
@@ -1,0 +1,24 @@
+/**
+ * WordPress dependencies
+ */
+import { __ } from '@wordpress/i18n';
+import { Modal } from '@wordpress/components';
+import { Inserter } from '@wordpress/block-editor';
+import { useDispatch } from '@wordpress/data';
+
+/**
+ * Internal dependencies
+ */
+import { store as editPostStore } from '../../store';
+
+export function ModalInserter() {
+	const { setIsInserterOpened } = useDispatch( editPostStore );
+	const closeModal = () => {
+		setIsInserterOpened( false );
+	};
+	return (
+		<Modal onRequestClose={ closeModal } title={ __( 'Insert block' ) }>
+			<Inserter __experimentalIsModal />
+		</Modal>
+	);
+}


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->
Continues the work in #41740.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

To have a version of the inserter specific to distraction free mode. It was one of the [remaining items](https://github.com/WordPress/gutenberg/pull/41740#issuecomment-1273570605) in the original PR:

> The inserter should be available via the top toolbar (exploring an Alfred like UI)

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

Adds a modified version of the quick inserter into a modal.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->

- switch to this PR
- click on the top right corner dotted menu
- click Distraction Free Mode
- hover on where the top bar should be
- click the plus
- modal inserter!

## Screenshots or screencast <!-- if applicable -->


https://user-images.githubusercontent.com/107534/195585128-9aaefd1b-7688-4cfb-af42-17342395086d.mp4

## To do

- [ ] Refactor for best composability
- [x] Make sure the focus is on the inserter's search box
- [x] Add a keyboard shortcut for the modal inserter (added `access + I`)
- [ ] Add the keyboard shortcut to the shortcuts help modal
- [ ] Manage focus back to blocks when inserter is closed