### PR TITLE
E2E Tests: Make attributes and innerblocks optional in insertBlock

### DIFF
--- a/packages/e2e-test-utils-playwright/src/editor/insert-block.ts
+++ b/packages/e2e-test-utils-playwright/src/editor/insert-block.ts
@@ -5,8 +5,8 @@ import type { Editor } from './index';
 
 interface BlockRepresentation {
 	name: string;
-	attributes: Object;
-	innerBlocks: BlockRepresentation[];
+	attributes?: Object;
+	innerBlocks?: BlockRepresentation[];
 }
 
 /**


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Update the types for `insertBlock` to make `attributes` and `innerBlocks` optional.

## Why?
`attributes` and `innerBlocks` has a default value and the users don't need to set these. This makes the types align with the code.

## Testing Instructions
Create a simple E2E test using `@wordpress/e2e-test-utils-playwright`, TypeScript and `insertBlock`.

Ex:
```ts
import { test, expect } from '@wordpress/e2e-test-utils-playwright';

test.describe( 'Paragraph', () => {
	test.beforeEach( async ( { admin } ) => {
		await admin.createNewPost();
	} );

	test( 'can insert block', async ( { editor } ) => {
		await editor.insertBlock( {
			name: 'core/paragraph',
		} );
		expect( await editor.getEditedPostContent() ).toMatchSnapshot();
	} );
} );
```

TypeScript validation should pass.

## Screenshots or screencast <!-- if applicable -->
![image](https://user-images.githubusercontent.com/1415747/195587566-1f0c2920-9fee-4dc7-9e3d-f84b7ef97e53.png)
