### PR TITLE
Components: refactor `TabPanel` to pass `exhaustive-deps`

### DIFF
--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -24,6 +24,7 @@
 -   `SlotFill`: updated to satisfy `react/exhaustive-deps` eslint rule ([#44403](https://github.com/WordPress/gutenberg/pull/44403))
 -   `Context`: updated to ignore `react/exhaustive-deps` eslint rule ([#45044](https://github.com/WordPress/gutenberg/pull/45044))
 -   `Button`: Refactor Storybook to controls and align docs ([#44105](https://github.com/WordPress/gutenberg/pull/44105)).
+-   `TabPanel`: updated to satisfy `react/exhaustive-deps` eslint rule ([#44935](https://github.com/WordPress/gutenberg/pull/44935))
 
 ## 21.3.0 (2022-10-19)
 

--- a/packages/components/src/tab-panel/index.tsx
+++ b/packages/components/src/tab-panel/index.tsx
@@ -101,7 +101,7 @@ export function TabPanel( {
 		if ( ! newSelectedTab && tabs.length > 0 ) {
 			handleTabSelection( initialTabName || tabs[ 0 ].name );
 		}
-	}, [ tabs ] );
+	}, [ tabs, selected, initialTabName ] );
 
 	return (
 		<div className={ className }>

--- a/packages/components/src/tab-panel/index.tsx
+++ b/packages/components/src/tab-panel/index.tsx
@@ -97,7 +97,8 @@ export function TabPanel( {
 	const selectedId = `${ instanceId }-${ selectedTab?.name ?? 'none' }`;
 
 	useEffect( () => {
-		if ( ! selectedTab?.name ) {
+		if ( ! selectedTab?.name && tabs.length > 0 ) {
+			handleTabSelection( initialTabName || tabs[ 0 ].name );
 			setSelected(
 				initialTabName ||
 					( tabs.length > 0 ? tabs[ 0 ].name : undefined )

--- a/packages/components/src/tab-panel/index.tsx
+++ b/packages/components/src/tab-panel/index.tsx
@@ -99,10 +99,6 @@ export function TabPanel( {
 	useEffect( () => {
 		if ( ! selectedTab?.name && tabs.length > 0 ) {
 			handleTabSelection( initialTabName || tabs[ 0 ].name );
-			setSelected(
-				initialTabName ||
-					( tabs.length > 0 ? tabs[ 0 ].name : undefined )
-			);
 		}
 	}, [ tabs, selectedTab?.name, initialTabName ] );
 

--- a/packages/components/src/tab-panel/index.tsx
+++ b/packages/components/src/tab-panel/index.tsx
@@ -7,7 +7,7 @@ import { find } from 'lodash';
 /**
  * WordPress dependencies
  */
-import { useState, useEffect } from '@wordpress/element';
+import { useState, useEffect, useMemo } from '@wordpress/element';
 import { useInstanceId } from '@wordpress/compose';
 
 /**
@@ -93,15 +93,20 @@ export function TabPanel( {
 	const onNavigate = ( _childIndex: number, child: HTMLButtonElement ) => {
 		child.click();
 	};
-	const selectedTab = find( tabs, { name: selected } );
+	const selectedTab = useMemo(
+		() => find( tabs, { name: selected } ),
+		[ tabs, selected ]
+	);
 	const selectedId = `${ instanceId }-${ selectedTab?.name ?? 'none' }`;
 
 	useEffect( () => {
-		const newSelectedTab = find( tabs, { name: selected } );
-		if ( ! newSelectedTab && tabs.length > 0 ) {
-			handleTabSelection( initialTabName || tabs[ 0 ].name );
+		if ( ! selectedTab ) {
+			setSelected(
+				initialTabName ||
+					( tabs.length > 0 ? tabs[ 0 ].name : undefined )
+			);
 		}
-	}, [ tabs, selected, initialTabName ] );
+	}, [ tabs, selectedTab, initialTabName ] );
 
 	return (
 		<div className={ className }>

--- a/packages/components/src/tab-panel/index.tsx
+++ b/packages/components/src/tab-panel/index.tsx
@@ -7,7 +7,7 @@ import { find } from 'lodash';
 /**
  * WordPress dependencies
  */
-import { useState, useEffect, useMemo } from '@wordpress/element';
+import { useState, useEffect } from '@wordpress/element';
 import { useInstanceId } from '@wordpress/compose';
 
 /**
@@ -93,20 +93,17 @@ export function TabPanel( {
 	const onNavigate = ( _childIndex: number, child: HTMLButtonElement ) => {
 		child.click();
 	};
-	const selectedTab = useMemo(
-		() => find( tabs, { name: selected } ),
-		[ tabs, selected ]
-	);
+	const selectedTab = find( tabs, { name: selected } );
 	const selectedId = `${ instanceId }-${ selectedTab?.name ?? 'none' }`;
 
 	useEffect( () => {
-		if ( ! selectedTab ) {
+		if ( ! selectedTab?.name ) {
 			setSelected(
 				initialTabName ||
 					( tabs.length > 0 ? tabs[ 0 ].name : undefined )
 			);
 		}
-	}, [ tabs, selectedTab, initialTabName ] );
+	}, [ tabs, selectedTab?.name, initialTabName ] );
 
 	return (
 		<div className={ className }>


### PR DESCRIPTION
## What?
Updates the `TabPanel` component to satisfy the `exhaustive-deps` eslint rule

## Why?
Part of the effort in https://github.com/WordPress/gutenberg/pull/41166 to apply `exhuastive-deps` to the Components package

## How?
Adds two missing dependencies (`selected` and `initialTabName`) to the component's `useEffect` dep array.

Adding `initialTabName` doesn't appear to cause any noticeable changes. Adding `selected`, on the other hand, does mean this effect now fires on every render, though it doesn't appear to cause any additional re-renders.

Previously, the effect only fired when the `tabs` props changed, and it was used to unsure the currently selected tab still existed. If not, it selects a fallback tab instead. With this change, the effect will also fire when a tab is selected and check that the selected tab exist (and it should, the user just clicked on it).

This isn't an expensive check, so I don't think we need to worry about it. If we want to prevent the effect from firing more than it used to, we could use the [Latest Ref pattern](https://epicreact.dev/the-latest-ref-pattern-in-react/) to track the currently selected tab and use that ref's value in the effect. That would eliminate the dependency on `selected` and restore the effect's behavior to what it was before, but I don't honestly think it's worth the readability cost.

## Testing Instructions
1. From your local Gutenberg directory, run `npx eslint --rule 'react-hooks/exhaustive-deps: warn' packages/components/src/tab-panel`
2. Confirm that the linter returns no errors
3. Confirm unit tests still pass
4. Run Storybook locally, confirm the components stories and/or docs still work as expected
