### PR TITLE
Add `.eslintcache` to `.gitignore`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,6 +17,7 @@ yarn.lock
 /composer.lock
 
 .cache
+.eslintcache
 *.tsbuildinfo
 
 # Operating system specific files


### PR DESCRIPTION
## What?
This PR adds `.eslintcache` to `.gitignore`.

## Why?
Necessary when using `eslint-nibble` locally with the `--cache` option.

## How?
We're straightforwardly git-ignoring that file.

## Testing Instructions
Not necessary, but you can run `npx eslint-nibble ./ --cache --fixable-only` and you'll see such a file be created locally.
