### PR TITLE
ESLint: Fix `jest-dom/prefer-in-document` rule violations

### DIFF
--- a/packages/block-directory/src/components/downloadable-block-list-item/test/index.js
+++ b/packages/block-directory/src/components/downloadable-block-list-item/test/index.js
@@ -33,8 +33,8 @@ describe( 'DownloadableBlockListItem', () => {
 		);
 		const author = screen.queryByText( `by ${ plugin.author }` );
 		const description = screen.queryByText( plugin.description );
-		expect( author ).not.toBeNull();
-		expect( description ).not.toBeNull();
+		expect( author ).toBeInTheDocument();
+		expect( description ).toBeInTheDocument();
 	} );
 
 	it( 'should show installing status when installing the block', () => {
@@ -47,7 +47,7 @@ describe( 'DownloadableBlockListItem', () => {
 			<DownloadableBlockListItem onClick={ jest.fn() } item={ plugin } />
 		);
 		const statusLabel = screen.queryByText( 'Installing…' );
-		expect( statusLabel ).not.toBeNull();
+		expect( statusLabel ).toBeInTheDocument();
 	} );
 
 	it( "should be disabled when a plugin can't be installed", () => {

--- a/packages/block-editor/src/components/block-breadcrumb/test/index.js
+++ b/packages/block-editor/src/components/block-breadcrumb/test/index.js
@@ -30,7 +30,7 @@ describe( 'BlockBreadcrumb', () => {
 			const rootLabelText = screen.getByText( 'Tuhinga' );
 			const rootLabelTextDefault = screen.queryByText( 'Document' );
 
-			expect( rootLabelTextDefault ).toBeNull();
+			expect( rootLabelTextDefault ).not.toBeInTheDocument();
 			expect( rootLabelText ).toBeInTheDocument();
 		} );
 	} );

--- a/packages/block-editor/src/components/block-switcher/test/index.js
+++ b/packages/block-editor/src/components/block-switcher/test/index.js
@@ -288,8 +288,8 @@ describe( 'BlockSwitcherDropdownMenu', () => {
 					screen.getByRole( 'menu', {
 						name: 'Block Name',
 					} )
-				).getAllByRole( 'menuitem' )
-			).toHaveLength( 1 );
+				).getByRole( 'menuitem' )
+			).toBeInTheDocument();
 		} );
 	} );
 } );

--- a/packages/components/src/combobox-control/test/index.js
+++ b/packages/components/src/combobox-control/test/index.js
@@ -271,7 +271,7 @@ describe.each( [
 
 		// No options are rendered if no match is found
 		await user.keyboard( unmatchedString );
-		expect( screen.queryByRole( 'option' ) ).toBeNull();
+		expect( screen.queryByRole( 'option' ) ).not.toBeInTheDocument();
 
 		// Clearing the input renders all options again
 		await user.clear( input );

--- a/packages/components/src/higher-order/with-notices/test/index.js
+++ b/packages/components/src/higher-order/with-notices/test/index.js
@@ -91,7 +91,7 @@ describe( 'withNotices operations', () => {
 		act( () => {
 			handle.current.createNotice( { content: message } );
 		} );
-		expect( getByText( message ) ).not.toBeNull();
+		expect( getByText( message ) ).toBeInTheDocument();
 	} );
 
 	it( 'should create notices of error status with createErrorNotice', () => {

--- a/packages/components/src/input-control/test/index.js
+++ b/packages/components/src/input-control/test/index.js
@@ -48,7 +48,7 @@ describe( 'InputControl', () => {
 
 			const input = screen.getByText( 'Hello' );
 
-			expect( input ).toBeTruthy();
+			expect( input ).toBeInTheDocument();
 		} );
 	} );
 

--- a/packages/components/src/toolbar/test/index.js
+++ b/packages/components/src/toolbar/test/index.js
@@ -21,10 +21,10 @@ describe( 'Toolbar', () => {
 
 			expect(
 				screen.getByLabelText( 'control1', { selector: 'button' } )
-			).toBeTruthy();
+			).toBeInTheDocument();
 			expect(
 				screen.getByLabelText( 'control2', { selector: 'button' } )
-			).toBeTruthy();
+			).toBeInTheDocument();
 		} );
 	} );
 } );

--- a/packages/components/src/ui/tooltip/test/index.js
+++ b/packages/components/src/ui/tooltip/test/index.js
@@ -70,7 +70,7 @@ describe( 'props', () => {
 				<Text>WordPress.org</Text>
 			</Tooltip>
 		);
-		const tooltips = screen.getAllByRole( /tooltip/ );
+		const tooltips = screen.getAllByRole( /tooltip/i );
 		// Assert only the base tooltip rendered.
 		expect( tooltips ).toHaveLength( 1 );
 		expect( tooltips[ 0 ].id ).toBe( baseTooltipId );

--- a/packages/core-data/src/hooks/test/use-query-select.js
+++ b/packages/core-data/src/hooks/test/use-query-select.js
@@ -64,7 +64,7 @@ describe( 'useQuerySelect', () => {
 		expect( TestComponent ).toHaveBeenCalledTimes( 2 );
 
 		// ensure expected state was rendered
-		expect( testInstance.findByText( 'bar' ) ).toBeTruthy();
+		expect( testInstance.getByText( 'bar' ) ).toBeInTheDocument();
 	} );
 
 	it( 'uses memoized selectors', () => {

--- a/packages/editor/src/components/document-outline/test/index.js
+++ b/packages/editor/src/components/document-outline/test/index.js
@@ -108,11 +108,11 @@ describe( 'DocumentOutline', () => {
 			const blocks = [ headingH2 ];
 			render( <DocumentOutline blocks={ blocks } /> );
 
-			const tableOfContentItems = within(
+			const tableOfContentItem = within(
 				screen.getByRole( 'list' )
-			).getAllByRole( 'listitem' );
-			expect( tableOfContentItems ).toHaveLength( 1 );
-			expect( tableOfContentItems[ 0 ] ).toHaveTextContent( 'Heading 2' );
+			).getByRole( 'listitem' );
+			expect( tableOfContentItem ).toBeInTheDocument();
+			expect( tableOfContentItem ).toHaveTextContent( 'Heading 2' );
 		} );
 
 		it( 'should render two items when two headings and some paragraphs provided', () => {


### PR DESCRIPTION
## What?
This PR fixes all violations of the [`jest-dom/prefer-in-document` rule](https://github.com/testing-library/eslint-plugin-jest-dom/blob/main/docs/rules/prefer-in-document.md), in preparation for enabling `eslint-plugin-jest-dom` globally for the project.

See the [plugin README](https://github.com/testing-library/eslint-plugin-jest-dom) for more info on the jest-dom ESLint plugin.

## Why?
We've been improving our tests a lot recently with the migration to `@testing-library`. One way we could improve them is to better standardize them and follow best practices whenever we can, and one of the best ways to get there is to follow the recommended ESLint rules of the libraries and utilities we use under the hood.

## How?
We're essentially fixing up a few instances that either assert positively or negatively that the element exists in the document.

## Testing Instructions
Verify all checks are green.
