### PR TITLE
Update the names of filters for global styles data

### DIFF
--- a/docs/reference-guides/filters/global-styles-filters.md
+++ b/docs/reference-guides/filters/global-styles-filters.md
@@ -2,10 +2,10 @@
 
 WordPress 6.1 has introduced some server-side filters to hook into the `theme.json` data provided at the different data layers:
 
-- `theme_json_default`: hooks into the default data provided by WordPress
-- `theme_json_blocks`: hooks into the data provided by the blocks
-- `theme_json_theme`: hooks into the data provided by the theme
-- `theme_json_user`: hooks into the data provided by the user
+- `wp_theme_json_data_default`: hooks into the default data provided by WordPress
+- `wp_theme_json_data_blocks`: hooks into the data provided by the blocks
+- `wp_theme_json_data_theme`: hooks into the data provided by the theme
+- `wp_theme_json_data_user`: hooks into the data provided by the user
 
 Each filter receives an instance of the `WP_Theme_JSON_Data` class with the data for the respective layer. To provide new data, the filter callback needs to use the `update_with( $new_data )` method, where `$new_data` is a valid `theme.json`-like structure. As with any `theme.json`, the new data needs to declare which `version` of the `theme.json` is using, so it can correctly be migrated to the runtime one, should it be different.
 
@@ -38,5 +38,5 @@ function filter_theme_json_theme( $theme_json ){
 
 	return $theme_json->update_with( $new_data );
 }
-add_filter( 'theme_json_theme', 'filter_theme_json_theme' );
+add_filter( 'wp_theme_json_data_theme', 'filter_theme_json_theme' );
 ```

--- a/lib/compat/wordpress-6.1/class-wp-theme-json-resolver-6-1.php
+++ b/lib/compat/wordpress-6.1/class-wp-theme-json-resolver-6-1.php
@@ -61,7 +61,7 @@ class WP_Theme_JSON_Resolver_6_1 extends WP_Theme_JSON_Resolver_6_0 {
 		 *
 		 * @param WP_Theme_JSON_Data_Gutenberg Class to access and update the underlying data.
 		 */
-		$theme_json   = apply_filters( 'theme_json_default', new WP_Theme_JSON_Data_Gutenberg( $config, 'default' ) );
+		$theme_json   = apply_filters( 'wp_theme_json_data_default', new WP_Theme_JSON_Data_Gutenberg( $config, 'default' ) );
 		$config       = $theme_json->get_data();
 		static::$core = new WP_Theme_JSON_Gutenberg( $config, 'default' );
 
@@ -92,7 +92,7 @@ class WP_Theme_JSON_Resolver_6_1 extends WP_Theme_JSON_Resolver_6_0 {
 				 *
 				 * @param WP_Theme_JSON_Data_Gutenberg Class to access and update the underlying data.
 				 */
-				$theme_json = apply_filters( 'theme_json_user', new WP_Theme_JSON_Data_Gutenberg( $config, 'custom' ) );
+				$theme_json = apply_filters( 'wp_theme_json_data_user', new WP_Theme_JSON_Data_Gutenberg( $config, 'custom' ) );
 				$config     = $theme_json->get_data();
 				return new WP_Theme_JSON_Gutenberg( $config, 'custom' );
 			}
@@ -114,7 +114,7 @@ class WP_Theme_JSON_Resolver_6_1 extends WP_Theme_JSON_Resolver_6_0 {
 		 *
 		 * @param WP_Theme_JSON_Data_Gutenberg Class to access and update the underlying data.
 		 */
-		$theme_json   = apply_filters( 'theme_json_user', new WP_Theme_JSON_Data_Gutenberg( $config, 'custom' ) );
+		$theme_json   = apply_filters( 'wp_theme_json_data_user', new WP_Theme_JSON_Data_Gutenberg( $config, 'custom' ) );
 		$config       = $theme_json->get_data();
 		static::$user = new WP_Theme_JSON_Gutenberg( $config, 'custom' );
 

--- a/lib/experimental/class-wp-theme-json-resolver-gutenberg.php
+++ b/lib/experimental/class-wp-theme-json-resolver-gutenberg.php
@@ -44,7 +44,7 @@ class WP_Theme_JSON_Resolver_Gutenberg extends WP_Theme_JSON_Resolver_6_1 {
 			 *
 			 * @param WP_Theme_JSON_Data_Gutenberg Class to access and update the underlying data.
 			 */
-			$theme_json      = apply_filters( 'theme_json_theme', new WP_Theme_JSON_Data_Gutenberg( $theme_json_data, 'theme' ) );
+			$theme_json      = apply_filters( 'wp_theme_json_data_theme', new WP_Theme_JSON_Data_Gutenberg( $theme_json_data, 'theme' ) );
 			$theme_json_data = $theme_json->get_data();
 			static::$theme   = new WP_Theme_JSON_Gutenberg( $theme_json_data );
 
@@ -141,7 +141,7 @@ class WP_Theme_JSON_Resolver_Gutenberg extends WP_Theme_JSON_Resolver_6_1 {
 		 *
 		 * @param WP_Theme_JSON_Data_Gutenberg Class to access and update the underlying data.
 		 */
-		$theme_json = apply_filters( 'theme_json_blocks', new WP_Theme_JSON_Data_Gutenberg( $config, 'blocks' ) );
+		$theme_json = apply_filters( 'wp_theme_json_data_blocks', new WP_Theme_JSON_Data_Gutenberg( $config, 'blocks' ) );
 		$config     = $theme_json->get_data();
 
 		return new WP_Theme_JSON_Gutenberg( $config, 'blocks' );


### PR DESCRIPTION
Backports changes made in wordpress-develop at https://github.com/WordPress/wordpress-develop/pull/3443 related to filters for global styles data.

It does not backport the changes done to the `theme_json_get_style_nodes` filter. This needs to be considered separately ([see](https://github.com/WordPress/wordpress-develop/pull/3443/files#r994721974)).

Changes:

- updates block editor handbook docs
- names of filters
