### PR TITLE
FIX: typo in block.json schema default scope values

### DIFF
--- a/schemas/json/block.json
+++ b/schemas/json/block.json
@@ -576,7 +576,7 @@
 						"items": {
 							"enum": [ "inserter", "block", "transform" ]
 						},
-						"default": [ "inseter", "block" ]
+						"default": [ "inserter", "block" ]
 					},
 					"keywords": {
 						"type": "array",


### PR DESCRIPTION
The accepted scope value is `inserter`, not `inseter`

<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Fixing a typo

## Why?
Use an accepted default value for scope.

## How?
Fixes the typo.

## Testing Instructions
While editing in a text editor that uses $schema context, add a `scope` attribute to a variation.

## Screenshots or screencast <!-- if applicable -->
