### PR TITLE
Fix: Embed: Block transformed to a paragraph keeps classes

### DIFF
--- a/packages/block-library/src/embed/transforms.js
+++ b/packages/block-library/src/embed/transforms.js
@@ -1,12 +1,14 @@
 /**
  * WordPress dependencies
  */
-import { createBlock } from '@wordpress/blocks';
+import { createBlock, hasBlockSupport } from '@wordpress/blocks';
+import { addFilter } from '@wordpress/hooks';
 
 /**
  * Internal dependencies
  */
 import metadata from './block.json';
+import { removeAspectRatioClasses } from './util';
 
 const { name: EMBED_BLOCK } = metadata;
 
@@ -47,3 +49,64 @@ const transforms = {
 };
 
 export default transforms;
+
+/**
+ * Remove aspect ratio classes when transforming an embed to other block type.
+ *
+ * @param {Object}   result  The transformed block.
+ * @param {Object[]} source  Original blocks transformed.
+ * @param {number}   index   Index of the transformed block on the array of results.
+ * @param {Object[]} results An array all the blocks that resulted from the transformation.
+ * @return {Object} Filtered block transform.
+ */
+function removeAspectRatioClassesDuringTransform(
+	result,
+	source,
+	index,
+	results
+) {
+	if ( ! hasBlockSupport( result.name, 'customClassName', true ) ) {
+		return result;
+	}
+
+	// If the condition verifies we are probably in the presence of a wrapping transform
+	// e.g: nesting paragraphs in a group or columns and in that case the class should not be kept.
+	if ( results.length === 1 && result.innerBlocks.length === source.length ) {
+		return result;
+	}
+
+	// If we are transforming one block to multiple blocks or multiple blocks to one block,
+	// we ignore the class during the transform.
+	if (
+		( results.length === 1 && source.length > 1 ) ||
+		( results.length > 1 && source.length === 1 )
+	) {
+		return result;
+	}
+
+	// If we are in presence of transform between one or more block in the source
+	// that have one or more blocks in the result
+	// we apply the class on source N to the result N,
+	// if source N does not exists we do nothing.
+	if ( source[ index ] && 'core/embed' === source[ index ].name ) {
+		const originClassName = source[ index ]?.attributes.className;
+		if ( originClassName ) {
+			return {
+				...result,
+				attributes: {
+					...result.attributes,
+					className: removeAspectRatioClasses( originClassName ),
+				},
+			};
+		}
+	}
+	return result;
+}
+
+// run after `core/color/addTransforms` filter from custom-class-name support.
+addFilter(
+	'blocks.switchToBlockType.transformedBlock',
+	'core/embed/removeAspectRatioClassesDuringTransform',
+	removeAspectRatioClassesDuringTransform,
+	15
+);


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Fix #39616. Remove internal css classes, added by the embed block when using some variations like youtube, when transforming the block to another type.

## Why?
Related to #38964, the feature allow user-added custom CSS classes to be carried over when transforming blocks. Unfortunately, the Embed block stores its aspect ratio classes as custom CSS classes and they are also kept during transform.

## How?
Reusing the same filter as the custom classname support `blocks.switchToBlockType.transformedBlock`, we apply the `removeAspectRatioClasses` to the list of classname when transforming an embed block to another type. This allow only remove the aspect ration classes and the keep user-added ones.

## Testing Instructions (Base on the instructions from the original issue)
1. Embed a youtube embed block into any block editor post.
2. Check the block "Additional CSS classes" field. It should contain the values `wp-embed-aspect-16-9` and `wp-has-aspect-ratio`
3. Transform the youtube block to a paragraph (ie, paragraph with a linked text)
4. Check again the block "Additional CSS classes" field. It shouldn't contain the classes `wp-embed-aspect-16-9` and `wp-has-aspect-ratio` anymore
