### PR TITLE
Remove gutenberg_ prefix for theme_json_get_style_nodes filter

### DIFF
--- a/lib/compat/wordpress-6.1/class-wp-theme-json-6-1.php
+++ b/lib/compat/wordpress-6.1/class-wp-theme-json-6-1.php
@@ -583,7 +583,7 @@ class WP_Theme_JSON_6_1 extends WP_Theme_JSON_6_0 {
 		$nodes = array_merge( $nodes, static::get_block_nodes( $theme_json, $selectors ) );
 
 		// This filter allows us to modify the output of WP_Theme_JSON so that we can do things like loading block CSS independently.
-		return apply_filters( 'gutenberg_theme_json_get_style_nodes', $nodes );
+		return apply_filters( 'wp_theme_json_get_style_nodes', $nodes );
 	}
 
 	/**

--- a/lib/compat/wordpress-6.1/script-loader.php
+++ b/lib/compat/wordpress-6.1/script-loader.php
@@ -89,7 +89,7 @@ function gutenberg_enqueue_global_styles() {
 	 * This removes the CSS from the global-styles stylesheet and adds it to the inline CSS for each block.
 	 * This filter has to be registered before we call gutenberg_get_global_stylesheet();
 	 */
-	add_filter( 'gutenberg_theme_json_get_style_nodes', 'gutenberg_filter_out_block_nodes', 10, 1 );
+	add_filter( 'wp_theme_json_get_style_nodes', 'gutenberg_filter_out_block_nodes', 10, 1 );
 
 	$stylesheet = gutenberg_get_global_stylesheet();
 	if ( empty( $stylesheet ) ) {


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Updates the filter to match the name used in core.

See https://github.com/WordPress/wordpress-develop/pull/3443.

Related to https://github.com/WordPress/gutenberg/pull/44940.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

We shouldn't be using different prefixes per environment—it's problematic for any consumer that want to use the filter.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

Renamed `gutenberg_theme_json_get_style_nodes` to `wp_theme_json_get_style_nodes` to match core.

<!-- ## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->


<!-- ## Screenshots or screencast if applicable -->
