### PR TITLE
Spacing visualizer: add option to trigger with mousover as well as value change

### DIFF
--- a/packages/block-editor/src/components/spacing-sizes-control/all-input-control.js
+++ b/packages/block-editor/src/components/spacing-sizes-control/all-input-control.js
@@ -16,6 +16,7 @@ export default function AllInputControl( {
 	spacingSizes,
 	type,
 	minimumCustomValue,
+	setMouseOver,
 } ) {
 	const allValue = getAllRawValue( values );
 	const hasValues = isValuesDefined( values );
@@ -35,6 +36,7 @@ export default function AllInputControl( {
 			isMixed={ isMixed }
 			type={ type }
 			minimumCustomValue={ minimumCustomValue }
+			setMouseOver={ setMouseOver }
 		/>
 	);
 }

--- a/packages/block-editor/src/components/spacing-sizes-control/all-input-control.js
+++ b/packages/block-editor/src/components/spacing-sizes-control/all-input-control.js
@@ -16,7 +16,8 @@ export default function AllInputControl( {
 	spacingSizes,
 	type,
 	minimumCustomValue,
-	setMouseOver,
+	onMouseOver,
+	onMouseOut,
 } ) {
 	const allValue = getAllRawValue( values );
 	const hasValues = isValuesDefined( values );
@@ -36,7 +37,8 @@ export default function AllInputControl( {
 			isMixed={ isMixed }
 			type={ type }
 			minimumCustomValue={ minimumCustomValue }
-			setMouseOver={ setMouseOver }
+			onMouseOver={ onMouseOver }
+			onMouseOut={ onMouseOut }
 		/>
 	);
 }

--- a/packages/block-editor/src/components/spacing-sizes-control/axial-input-controls.js
+++ b/packages/block-editor/src/components/spacing-sizes-control/axial-input-controls.js
@@ -13,6 +13,7 @@ export default function AxialInputControls( {
 	spacingSizes,
 	type,
 	minimumCustomValue,
+	setMouseOver,
 } ) {
 	const createHandleOnChange = ( side ) => ( next ) => {
 		if ( ! onChange ) {
@@ -54,6 +55,7 @@ export default function AxialInputControls( {
 						spacingSizes={ spacingSizes }
 						type={ type }
 						minimumCustomValue={ minimumCustomValue }
+						setMouseOver={ setMouseOver }
 					/>
 				);
 			} ) }

--- a/packages/block-editor/src/components/spacing-sizes-control/axial-input-controls.js
+++ b/packages/block-editor/src/components/spacing-sizes-control/axial-input-controls.js
@@ -13,7 +13,8 @@ export default function AxialInputControls( {
 	spacingSizes,
 	type,
 	minimumCustomValue,
-	setMouseOver,
+	onMouseOver,
+	onMouseOut,
 } ) {
 	const createHandleOnChange = ( side ) => ( next ) => {
 		if ( ! onChange ) {
@@ -55,7 +56,8 @@ export default function AxialInputControls( {
 						spacingSizes={ spacingSizes }
 						type={ type }
 						minimumCustomValue={ minimumCustomValue }
-						setMouseOver={ setMouseOver }
+						onMouseOver={ onMouseOver }
+						onMouseOut={ onMouseOut }
 					/>
 				);
 			} ) }

--- a/packages/block-editor/src/components/spacing-sizes-control/index.js
+++ b/packages/block-editor/src/components/spacing-sizes-control/index.js
@@ -20,6 +20,7 @@ import LinkedButton from './linked-button';
 import { DEFAULT_VALUES, isValuesMixed, isValuesDefined } from './utils';
 import useSetting from '../use-setting';
 
+const noop = () => {};
 export default function SpacingSizesControl( {
 	inputProps,
 	onChange,
@@ -29,6 +30,7 @@ export default function SpacingSizesControl( {
 	splitOnAxis = false,
 	useSelect,
 	minimumCustomValue = 0,
+	setMouseOver = noop,
 } ) {
 	const spacingSizes = [
 		{ name: 0, slug: '0', size: 0 },
@@ -70,6 +72,7 @@ export default function SpacingSizesControl( {
 		useSelect,
 		type: label,
 		minimumCustomValue,
+		setMouseOver,
 	};
 
 	return (

--- a/packages/block-editor/src/components/spacing-sizes-control/index.js
+++ b/packages/block-editor/src/components/spacing-sizes-control/index.js
@@ -30,7 +30,8 @@ export default function SpacingSizesControl( {
 	splitOnAxis = false,
 	useSelect,
 	minimumCustomValue = 0,
-	setMouseOver = noop,
+	onMouseOver = noop,
+	onMouseOut = noop,
 } ) {
 	const spacingSizes = [
 		{ name: 0, slug: '0', size: 0 },
@@ -72,7 +73,8 @@ export default function SpacingSizesControl( {
 		useSelect,
 		type: label,
 		minimumCustomValue,
-		setMouseOver,
+		onMouseOver,
+		onMouseOut,
 	};
 
 	return (

--- a/packages/block-editor/src/components/spacing-sizes-control/index.js
+++ b/packages/block-editor/src/components/spacing-sizes-control/index.js
@@ -20,7 +20,6 @@ import LinkedButton from './linked-button';
 import { DEFAULT_VALUES, isValuesMixed, isValuesDefined } from './utils';
 import useSetting from '../use-setting';
 
-const noop = () => {};
 export default function SpacingSizesControl( {
 	inputProps,
 	onChange,
@@ -30,8 +29,8 @@ export default function SpacingSizesControl( {
 	splitOnAxis = false,
 	useSelect,
 	minimumCustomValue = 0,
-	onMouseOver = noop,
-	onMouseOut = noop,
+	onMouseOver,
+	onMouseOut,
 } ) {
 	const spacingSizes = [
 		{ name: 0, slug: '0', size: 0 },

--- a/packages/block-editor/src/components/spacing-sizes-control/input-controls.js
+++ b/packages/block-editor/src/components/spacing-sizes-control/input-controls.js
@@ -11,6 +11,7 @@ export default function BoxInputControls( {
 	spacingSizes,
 	type,
 	minimumCustomValue,
+	setMouseOver,
 } ) {
 	// Filter sides if custom configuration provided, maintaining default order.
 	const filteredSides = sides?.length
@@ -38,6 +39,7 @@ export default function BoxInputControls( {
 						spacingSizes={ spacingSizes }
 						type={ type }
 						minimumCustomValue={ minimumCustomValue }
+						setMouseOver={ setMouseOver }
 					/>
 				);
 			} ) }

--- a/packages/block-editor/src/components/spacing-sizes-control/input-controls.js
+++ b/packages/block-editor/src/components/spacing-sizes-control/input-controls.js
@@ -11,7 +11,8 @@ export default function BoxInputControls( {
 	spacingSizes,
 	type,
 	minimumCustomValue,
-	setMouseOver,
+	onMouseOver,
+	onMouseOut,
 } ) {
 	// Filter sides if custom configuration provided, maintaining default order.
 	const filteredSides = sides?.length
@@ -39,7 +40,8 @@ export default function BoxInputControls( {
 						spacingSizes={ spacingSizes }
 						type={ type }
 						minimumCustomValue={ minimumCustomValue }
-						setMouseOver={ setMouseOver }
+						onMouseOver={ onMouseOver }
+						onMouseOut={ onMouseOut }
 					/>
 				);
 			} ) }

--- a/packages/block-editor/src/components/spacing-sizes-control/spacing-input-control.js
+++ b/packages/block-editor/src/components/spacing-sizes-control/spacing-input-control.js
@@ -51,17 +51,18 @@ export default function SpacingInputControl( {
 	isMixed = false,
 	type,
 	minimumCustomValue,
-	setMouseOver,
+	onMouseOver,
+	onMouseOut,
 } ) {
 	// Treat value as a preset value if the passed in value matches the value of one of the spacingSizes.
 	value = getPresetValueFromCustomValue( value, spacingSizes );
 
-	const handleMouseOver = () => {
-		setMouseOver( true );
-	};
-	const handleMouseOut = () => {
-		setMouseOver( false );
-	};
+	// const handleMouseOver = () => {
+	// 	setMouseOver( true );
+	// };
+	// const handleMouseOut = () => {
+	// 	setMouseOver( false );
+	// };
 	let selectListSizes = spacingSizes;
 	const showRangeControl = spacingSizes.length <= 8;
 
@@ -225,8 +226,8 @@ export default function SpacingInputControl( {
 			{ showCustomValueControl && (
 				<>
 					<UnitControl
-						onMouseOver={ handleMouseOver }
-						onMouseOut={ handleMouseOut }
+						onMouseOver={ onMouseOver }
+						onMouseOut={ onMouseOut }
 						onChange={ ( newSize ) =>
 							onChange( getNewCustomValue( newSize ) )
 						}
@@ -243,8 +244,8 @@ export default function SpacingInputControl( {
 					/>
 
 					<RangeControl
-						onMouseOver={ handleMouseOver }
-						onMouseOut={ handleMouseOut }
+						onMouseOver={ onMouseOver }
+						onMouseOut={ onMouseOut }
 						value={ customRangeValue }
 						min={ 0 }
 						max={ CUSTOM_VALUE_SETTINGS[ selectedUnit ]?.max ?? 10 }
@@ -259,8 +260,8 @@ export default function SpacingInputControl( {
 			) }
 			{ showRangeControl && ! showCustomValueControl && (
 				<RangeControl
-					onMouseOver={ handleMouseOver }
-					onMouseOut={ handleMouseOut }
+					onMouseOver={ onMouseOver }
+					onMouseOut={ onMouseOut }
 					className="components-spacing-sizes-control__range-control"
 					value={ currentValue }
 					onChange={ ( newSize ) =>
@@ -306,8 +307,8 @@ export default function SpacingInputControl( {
 					hideLabelFromVision={ true }
 					__nextUnconstrainedWidth={ true }
 					size={ '__unstable-large' }
-					onMouseOver={ handleMouseOver }
-					onMouseOut={ handleMouseOut }
+					onMouseOver={ onMouseOver }
+					onMouseOut={ onMouseOut }
 				/>
 			) }
 		</>

--- a/packages/block-editor/src/components/spacing-sizes-control/spacing-input-control.js
+++ b/packages/block-editor/src/components/spacing-sizes-control/spacing-input-control.js
@@ -57,12 +57,6 @@ export default function SpacingInputControl( {
 	// Treat value as a preset value if the passed in value matches the value of one of the spacingSizes.
 	value = getPresetValueFromCustomValue( value, spacingSizes );
 
-	// const handleMouseOver = () => {
-	// 	setMouseOver( true );
-	// };
-	// const handleMouseOut = () => {
-	// 	setMouseOver( false );
-	// };
 	let selectListSizes = spacingSizes;
 	const showRangeControl = spacingSizes.length <= 8;
 

--- a/packages/block-editor/src/components/spacing-sizes-control/spacing-input-control.js
+++ b/packages/block-editor/src/components/spacing-sizes-control/spacing-input-control.js
@@ -51,10 +51,17 @@ export default function SpacingInputControl( {
 	isMixed = false,
 	type,
 	minimumCustomValue,
+	setMouseOver,
 } ) {
 	// Treat value as a preset value if the passed in value matches the value of one of the spacingSizes.
 	value = getPresetValueFromCustomValue( value, spacingSizes );
 
+	const handleMouseOver = () => {
+		setMouseOver( true );
+	};
+	const handleMouseOut = () => {
+		setMouseOver( false );
+	};
 	let selectListSizes = spacingSizes;
 	const showRangeControl = spacingSizes.length <= 8;
 
@@ -218,6 +225,8 @@ export default function SpacingInputControl( {
 			{ showCustomValueControl && (
 				<>
 					<UnitControl
+						onMouseOver={ handleMouseOver }
+						onMouseOut={ handleMouseOut }
 						onChange={ ( newSize ) =>
 							onChange( getNewCustomValue( newSize ) )
 						}
@@ -234,6 +243,8 @@ export default function SpacingInputControl( {
 					/>
 
 					<RangeControl
+						onMouseOver={ handleMouseOver }
+						onMouseOut={ handleMouseOut }
 						value={ customRangeValue }
 						min={ 0 }
 						max={ CUSTOM_VALUE_SETTINGS[ selectedUnit ]?.max ?? 10 }
@@ -248,6 +259,8 @@ export default function SpacingInputControl( {
 			) }
 			{ showRangeControl && ! showCustomValueControl && (
 				<RangeControl
+					onMouseOver={ handleMouseOver }
+					onMouseOut={ handleMouseOut }
 					className="components-spacing-sizes-control__range-control"
 					value={ currentValue }
 					onChange={ ( newSize ) =>
@@ -293,6 +306,8 @@ export default function SpacingInputControl( {
 					hideLabelFromVision={ true }
 					__nextUnconstrainedWidth={ true }
 					size={ '__unstable-large' }
+					onMouseOver={ handleMouseOver }
+					onMouseOut={ handleMouseOut }
 				/>
 			) }
 		</>

--- a/packages/block-editor/src/hooks/dimensions.js
+++ b/packages/block-editor/src/hooks/dimensions.js
@@ -44,7 +44,7 @@ export const SPACING_SUPPORT_KEY = 'spacing';
 export const ALL_SIDES = [ 'top', 'right', 'bottom', 'left' ];
 export const AXIAL_SIDES = [ 'vertical', 'horizontal' ];
 
-function useVisualiserMouseOver() {
+function useVisualizerMouseOver() {
 	const [ isMouseOver, setIsMouseOver ] = useState( false );
 	return { isMouseOver, setIsMouseOver };
 }
@@ -63,8 +63,8 @@ export function DimensionsPanel( props ) {
 	const isDisabled = useIsDimensionsDisabled( props );
 	const isSupported = hasDimensionsSupport( props.name );
 	const spacingSizes = useSetting( 'spacing.spacingSizes' );
-	const paddingMouseOver = useVisualiserMouseOver();
-	const marginMouseOver = useVisualiserMouseOver();
+	const paddingMouseOver = useVisualizerMouseOver();
+	const marginMouseOver = useVisualizerMouseOver();
 
 	if ( isDisabled || ! isSupported ) {
 		return null;

--- a/packages/block-editor/src/hooks/dimensions.js
+++ b/packages/block-editor/src/hooks/dimensions.js
@@ -7,7 +7,7 @@ import classnames from 'classnames';
  * WordPress dependencies
  */
 import { __experimentalToolsPanelItem as ToolsPanelItem } from '@wordpress/components';
-import { Platform } from '@wordpress/element';
+import { Platform, useState } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import { getBlockSupport } from '@wordpress/blocks';
 
@@ -44,6 +44,11 @@ export const SPACING_SUPPORT_KEY = 'spacing';
 export const ALL_SIDES = [ 'top', 'right', 'bottom', 'left' ];
 export const AXIAL_SIDES = [ 'vertical', 'horizontal' ];
 
+function useVisualiserMouseOver() {
+	const [ isMouseOver, setIsMouseOver ] = useState( false );
+	return { isMouseOver, setIsMouseOver };
+}
+
 /**
  * Inspector controls for dimensions support.
  *
@@ -58,6 +63,8 @@ export function DimensionsPanel( props ) {
 	const isDisabled = useIsDimensionsDisabled( props );
 	const isSupported = hasDimensionsSupport( props.name );
 	const spacingSizes = useSetting( 'spacing.spacingSizes' );
+	const paddingMouseOver = useVisualiserMouseOver();
+	const marginMouseOver = useVisualiserMouseOver();
 
 	if ( isDisabled || ! isSupported ) {
 		return null;
@@ -96,7 +103,10 @@ export function DimensionsPanel( props ) {
 						isShownByDefault={ defaultSpacingControls?.padding }
 						panelId={ props.clientId }
 					>
-						<PaddingEdit { ...props } />
+						<PaddingEdit
+							setMouseOver={ paddingMouseOver.setIsMouseOver }
+							{ ...props }
+						/>
 					</ToolsPanelItem>
 				) }
 				{ ! isMarginDisabled && (
@@ -109,7 +119,10 @@ export function DimensionsPanel( props ) {
 						isShownByDefault={ defaultSpacingControls?.margin }
 						panelId={ props.clientId }
 					>
-						<MarginEdit { ...props } />
+						<MarginEdit
+							setMouseOver={ marginMouseOver.setIsMouseOver }
+							{ ...props }
+						/>
 					</ToolsPanelItem>
 				) }
 				{ ! isGapDisabled && (
@@ -126,8 +139,18 @@ export function DimensionsPanel( props ) {
 					</ToolsPanelItem>
 				) }
 			</InspectorControls>
-			{ ! isPaddingDisabled && <PaddingVisualizer { ...props } /> }
-			{ ! isMarginDisabled && <MarginVisualizer { ...props } /> }
+			{ ! isPaddingDisabled && (
+				<PaddingVisualizer
+					isMouseOver={ paddingMouseOver.isMouseOver }
+					{ ...props }
+				/>
+			) }
+			{ ! isMarginDisabled && (
+				<MarginVisualizer
+					isMouseOver={ marginMouseOver.isMouseOver }
+					{ ...props }
+				/>
+			) }
 		</>
 	);
 }

--- a/packages/block-editor/src/hooks/dimensions.js
+++ b/packages/block-editor/src/hooks/dimensions.js
@@ -10,7 +10,6 @@ import { __experimentalToolsPanelItem as ToolsPanelItem } from '@wordpress/compo
 import { Platform, useState } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import { getBlockSupport } from '@wordpress/blocks';
-import { useDispatch } from '@wordpress/data';
 
 /**
  * Internal dependencies
@@ -40,22 +39,15 @@ import {
 	useIsPaddingDisabled,
 } from './padding';
 import useSetting from '../components/use-setting';
-import { store as blockEditorStore } from '../store';
+
 export const SPACING_SUPPORT_KEY = 'spacing';
 export const ALL_SIDES = [ 'top', 'right', 'bottom', 'left' ];
 export const AXIAL_SIDES = [ 'vertical', 'horizontal' ];
 
 function useVisualizerMouseOver() {
 	const [ isMouseOver, setIsMouseOver ] = useState( false );
-	const { __unstableSetEditorMode } = useDispatch( blockEditorStore );
-	const onMouseOver = () => {
-		__unstableSetEditorMode( 'visualize' );
-		setIsMouseOver( true );
-	};
-	const onMouseOut = () => {
-		__unstableSetEditorMode( 'edit' );
-		setIsMouseOver( false );
-	};
+	const onMouseOver = () => setIsMouseOver( true );
+	const onMouseOut = () => setIsMouseOver( false );
 	return { isMouseOver, onMouseOver, onMouseOut };
 }
 

--- a/packages/block-editor/src/hooks/dimensions.js
+++ b/packages/block-editor/src/hooks/dimensions.js
@@ -46,7 +46,9 @@ export const AXIAL_SIDES = [ 'vertical', 'horizontal' ];
 
 function useVisualizerMouseOver() {
 	const [ isMouseOver, setIsMouseOver ] = useState( false );
-	return { isMouseOver, setIsMouseOver };
+	const onMouseOver = () => setIsMouseOver( true );
+	const onMouseOut = () => setIsMouseOver( false );
+	return { isMouseOver, onMouseOver, onMouseOut };
 }
 
 /**
@@ -104,7 +106,8 @@ export function DimensionsPanel( props ) {
 						panelId={ props.clientId }
 					>
 						<PaddingEdit
-							setMouseOver={ paddingMouseOver.setIsMouseOver }
+							onMouseOver={ paddingMouseOver.onMouseOver }
+							onMouseOut={ paddingMouseOver.onMouseOut }
 							{ ...props }
 						/>
 					</ToolsPanelItem>
@@ -120,7 +123,8 @@ export function DimensionsPanel( props ) {
 						panelId={ props.clientId }
 					>
 						<MarginEdit
-							setMouseOver={ marginMouseOver.setIsMouseOver }
+							onMouseOver={ marginMouseOver.onMouseOver }
+							onMouseOut={ marginMouseOver.onMouseOut }
 							{ ...props }
 						/>
 					</ToolsPanelItem>

--- a/packages/block-editor/src/hooks/dimensions.js
+++ b/packages/block-editor/src/hooks/dimensions.js
@@ -10,6 +10,7 @@ import { __experimentalToolsPanelItem as ToolsPanelItem } from '@wordpress/compo
 import { Platform, useState } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import { getBlockSupport } from '@wordpress/blocks';
+import { useDispatch } from '@wordpress/data';
 
 /**
  * Internal dependencies
@@ -39,15 +40,22 @@ import {
 	useIsPaddingDisabled,
 } from './padding';
 import useSetting from '../components/use-setting';
-
+import { store as blockEditorStore } from '../store';
 export const SPACING_SUPPORT_KEY = 'spacing';
 export const ALL_SIDES = [ 'top', 'right', 'bottom', 'left' ];
 export const AXIAL_SIDES = [ 'vertical', 'horizontal' ];
 
 function useVisualizerMouseOver() {
 	const [ isMouseOver, setIsMouseOver ] = useState( false );
-	const onMouseOver = () => setIsMouseOver( true );
-	const onMouseOut = () => setIsMouseOver( false );
+	const { __unstableSetEditorMode } = useDispatch( blockEditorStore );
+	const onMouseOver = () => {
+		__unstableSetEditorMode( 'visualize' );
+		setIsMouseOver( true );
+	};
+	const onMouseOut = () => {
+		__unstableSetEditorMode( 'edit' );
+		setIsMouseOver( false );
+	};
 	return { isMouseOver, onMouseOver, onMouseOut };
 }
 

--- a/packages/block-editor/src/hooks/dimensions.js
+++ b/packages/block-editor/src/hooks/dimensions.js
@@ -145,13 +145,13 @@ export function DimensionsPanel( props ) {
 			</InspectorControls>
 			{ ! isPaddingDisabled && (
 				<PaddingVisualizer
-					isMouseOver={ paddingMouseOver.isMouseOver }
+					forceShow={ paddingMouseOver.isMouseOver }
 					{ ...props }
 				/>
 			) }
 			{ ! isMarginDisabled && (
 				<MarginVisualizer
-					isMouseOver={ marginMouseOver.isMouseOver }
+					forceShow={ marginMouseOver.isMouseOver }
 					{ ...props }
 				/>
 			) }

--- a/packages/block-editor/src/hooks/margin.js
+++ b/packages/block-editor/src/hooks/margin.js
@@ -101,6 +101,7 @@ export function MarginEdit( props ) {
 		name: blockName,
 		attributes: { style },
 		setAttributes,
+		setMouseOver,
 	} = props;
 
 	const spacingSizes = useSetting( 'spacing.spacingSizes' );
@@ -159,6 +160,7 @@ export function MarginEdit( props ) {
 						units={ units }
 						allowReset={ false }
 						splitOnAxis={ false }
+						setMouseOver={ setMouseOver }
 					/>
 				) }
 			</>
@@ -167,7 +169,7 @@ export function MarginEdit( props ) {
 	} );
 }
 
-export function MarginVisualizer( { clientId, attributes } ) {
+export function MarginVisualizer( { clientId, attributes, isMouseOver } ) {
 	const margin = attributes?.style?.spacing?.margin;
 	const spacingSizes = useSetting( 'spacing.spacingSizes' );
 
@@ -208,7 +210,7 @@ export function MarginVisualizer( { clientId, attributes } ) {
 	};
 
 	useEffect( () => {
-		if ( ! isShallowEqual( margin, valueRef.current ) ) {
+		if ( ! isShallowEqual( margin, valueRef.current ) && ! isMouseOver ) {
 			setIsActive( true );
 			valueRef.current = margin;
 
@@ -220,9 +222,9 @@ export function MarginVisualizer( { clientId, attributes } ) {
 		}
 
 		return () => clearTimer();
-	}, [ margin ] );
+	}, [ margin, isMouseOver ] );
 
-	if ( ! isActive ) {
+	if ( ! isActive && ! isMouseOver ) {
 		return null;
 	}
 

--- a/packages/block-editor/src/hooks/margin.js
+++ b/packages/block-editor/src/hooks/margin.js
@@ -29,7 +29,7 @@ import {
 import { cleanEmptyObject } from './utils';
 import BlockPopover from '../components/block-popover';
 import SpacingSizesControl from '../components/spacing-sizes-control';
-import { getCustomValueFromPreset } from '../components/spacing-sizes-control/utils';
+import { getSpacingPresetCssVar } from '../components/spacing-sizes-control/utils';
 
 /**
  * Determines if there is margin support.
@@ -175,31 +175,39 @@ export function MarginEdit( props ) {
 
 export function MarginVisualizer( { clientId, attributes, isMouseOver } ) {
 	const margin = attributes?.style?.spacing?.margin;
-	const spacingSizes = useSetting( 'spacing.spacingSizes' );
 
 	const style = useMemo( () => {
 		const marginTop = margin?.top
-			? getCustomValueFromPreset( margin?.top, spacingSizes )
+			? getSpacingPresetCssVar( margin?.top )
 			: 0;
 		const marginRight = margin?.right
-			? getCustomValueFromPreset( margin?.right, spacingSizes )
+			? getSpacingPresetCssVar( margin?.right )
 			: 0;
 		const marginBottom = margin?.bottom
-			? getCustomValueFromPreset( margin?.bottom, spacingSizes )
+			? getSpacingPresetCssVar( margin?.bottom )
 			: 0;
 		const marginLeft = margin?.left
-			? getCustomValueFromPreset( margin?.left, spacingSizes )
+			? getSpacingPresetCssVar( margin?.left )
 			: 0;
 
 		return {
-			borderTopWidth: marginTop,
-			borderRightWidth: marginRight,
-			borderBottomWidth: marginBottom,
-			borderLeftWidth: marginLeft,
-			top: marginTop !== 0 ? `calc(${ marginTop } * -1)` : 0,
-			right: marginRight !== 0 ? `calc(${ marginRight } * -1)` : 0,
-			bottom: marginBottom !== 0 ? `calc(${ marginBottom } * -1)` : 0,
-			left: marginLeft !== 0 ? `calc(${ marginLeft } * -1)` : 0,
+			borderTopWidth: marginTop ? marginTop : 0,
+			borderRightWidth: marginRight ? marginRight : 0,
+			borderBottomWidth: marginBottom ? marginBottom : 0,
+			borderLeftWidth: marginLeft ? marginLeft : 0,
+			top: marginTop && marginTop !== 0 ? `calc(${ marginTop } * -1)` : 0,
+			right:
+				marginRight && marginRight !== 0
+					? `calc(${ marginRight } * -1)`
+					: 0,
+			bottom:
+				marginBottom && marginBottom !== 0
+					? `calc(${ marginBottom } * -1)`
+					: 0,
+			left:
+				marginLeft && marginLeft !== 0
+					? `calc(${ marginLeft } * -1)`
+					: 0,
 		};
 	}, [ margin ] );
 

--- a/packages/block-editor/src/hooks/margin.js
+++ b/packages/block-editor/src/hooks/margin.js
@@ -101,7 +101,8 @@ export function MarginEdit( props ) {
 		name: blockName,
 		attributes: { style },
 		setAttributes,
-		setMouseOver,
+		onMouseOver,
+		onMouseOut,
 	} = props;
 
 	const spacingSizes = useSetting( 'spacing.spacingSizes' );
@@ -149,6 +150,8 @@ export function MarginEdit( props ) {
 						units={ units }
 						allowReset={ false }
 						splitOnAxis={ splitOnAxis }
+						onMouseOver={ onMouseOver }
+						onMouseOut={ onMouseOut }
 					/>
 				) }
 				{ spacingSizes?.length > 0 && (
@@ -160,7 +163,8 @@ export function MarginEdit( props ) {
 						units={ units }
 						allowReset={ false }
 						splitOnAxis={ false }
-						setMouseOver={ setMouseOver }
+						onMouseOver={ onMouseOver }
+						onMouseOut={ onMouseOut }
 					/>
 				) }
 			</>

--- a/packages/block-editor/src/hooks/margin.js
+++ b/packages/block-editor/src/hooks/margin.js
@@ -191,23 +191,14 @@ export function MarginVisualizer( { clientId, attributes, isMouseOver } ) {
 			: 0;
 
 		return {
-			borderTopWidth: marginTop ? marginTop : 0,
-			borderRightWidth: marginRight ? marginRight : 0,
-			borderBottomWidth: marginBottom ? marginBottom : 0,
-			borderLeftWidth: marginLeft ? marginLeft : 0,
-			top: marginTop && marginTop !== 0 ? `calc(${ marginTop } * -1)` : 0,
-			right:
-				marginRight && marginRight !== 0
-					? `calc(${ marginRight } * -1)`
-					: 0,
-			bottom:
-				marginBottom && marginBottom !== 0
-					? `calc(${ marginBottom } * -1)`
-					: 0,
-			left:
-				marginLeft && marginLeft !== 0
-					? `calc(${ marginLeft } * -1)`
-					: 0,
+			borderTopWidth: marginTop,
+			borderRightWidth: marginRight,
+			borderBottomWidth: marginBottom,
+			borderLeftWidth: marginLeft,
+			top: marginTop ? `calc(${ marginTop } * -1)` : 0,
+			right: marginRight ? `calc(${ marginRight } * -1)` : 0,
+			bottom: marginBottom ? `calc(${ marginBottom } * -1)` : 0,
+			left: marginLeft ? `calc(${ marginLeft } * -1)` : 0,
 		};
 	}, [ margin ] );
 

--- a/packages/block-editor/src/hooks/margin.js
+++ b/packages/block-editor/src/hooks/margin.js
@@ -173,7 +173,7 @@ export function MarginEdit( props ) {
 	} );
 }
 
-export function MarginVisualizer( { clientId, attributes, isMouseOver } ) {
+export function MarginVisualizer( { clientId, attributes, forceShow } ) {
 	const margin = attributes?.style?.spacing?.margin;
 
 	const style = useMemo( () => {
@@ -213,7 +213,7 @@ export function MarginVisualizer( { clientId, attributes, isMouseOver } ) {
 	};
 
 	useEffect( () => {
-		if ( ! isShallowEqual( margin, valueRef.current ) && ! isMouseOver ) {
+		if ( ! isShallowEqual( margin, valueRef.current ) && ! forceShow ) {
 			setIsActive( true );
 			valueRef.current = margin;
 
@@ -225,9 +225,9 @@ export function MarginVisualizer( { clientId, attributes, isMouseOver } ) {
 		}
 
 		return () => clearTimer();
-	}, [ margin, isMouseOver ] );
+	}, [ margin, forceShow ] );
 
-	if ( ! isActive && ! isMouseOver ) {
+	if ( ! isActive && ! forceShow ) {
 		return null;
 	}
 

--- a/packages/block-editor/src/hooks/padding.js
+++ b/packages/block-editor/src/hooks/padding.js
@@ -103,6 +103,7 @@ export function PaddingEdit( props ) {
 		name: blockName,
 		attributes: { style },
 		setAttributes,
+		setMouseOver,
 	} = props;
 
 	const spacingSizes = useSetting( 'spacing.spacingSizes' );
@@ -161,6 +162,7 @@ export function PaddingEdit( props ) {
 						units={ units }
 						allowReset={ false }
 						splitOnAxis={ splitOnAxis }
+						setMouseOver={ setMouseOver }
 					/>
 				) }
 			</>
@@ -169,7 +171,7 @@ export function PaddingEdit( props ) {
 	} );
 }
 
-export function PaddingVisualizer( { clientId, attributes } ) {
+export function PaddingVisualizer( { clientId, attributes, isMouseOver } ) {
 	const padding = attributes?.style?.spacing?.padding;
 	const style = useMemo( () => {
 		return {
@@ -199,7 +201,7 @@ export function PaddingVisualizer( { clientId, attributes } ) {
 	};
 
 	useEffect( () => {
-		if ( ! isShallowEqual( padding, valueRef.current ) ) {
+		if ( ! isShallowEqual( padding, valueRef.current ) && ! isMouseOver ) {
 			setIsActive( true );
 			valueRef.current = padding;
 
@@ -211,9 +213,9 @@ export function PaddingVisualizer( { clientId, attributes } ) {
 		}
 
 		return () => clearTimer();
-	}, [ padding ] );
+	}, [ padding, isMouseOver ] );
 
-	if ( ! isActive ) {
+	if ( ! isActive && ! isMouseOver ) {
 		return null;
 	}
 

--- a/packages/block-editor/src/hooks/padding.js
+++ b/packages/block-editor/src/hooks/padding.js
@@ -172,7 +172,7 @@ export function PaddingEdit( props ) {
 	} );
 }
 
-export function PaddingVisualizer( { clientId, attributes, isMouseOver } ) {
+export function PaddingVisualizer( { clientId, attributes, forceShow } ) {
 	const padding = attributes?.style?.spacing?.padding;
 	const style = useMemo( () => {
 		return {
@@ -202,7 +202,7 @@ export function PaddingVisualizer( { clientId, attributes, isMouseOver } ) {
 	};
 
 	useEffect( () => {
-		if ( ! isShallowEqual( padding, valueRef.current ) && ! isMouseOver ) {
+		if ( ! isShallowEqual( padding, valueRef.current ) && ! forceShow ) {
 			setIsActive( true );
 			valueRef.current = padding;
 
@@ -214,9 +214,9 @@ export function PaddingVisualizer( { clientId, attributes, isMouseOver } ) {
 		}
 
 		return () => clearTimer();
-	}, [ padding, isMouseOver ] );
+	}, [ padding, forceShow ] );
 
-	if ( ! isActive && ! isMouseOver ) {
+	if ( ! isActive && ! forceShow ) {
 		return null;
 	}
 

--- a/packages/block-editor/src/hooks/padding.js
+++ b/packages/block-editor/src/hooks/padding.js
@@ -29,10 +29,7 @@ import {
 import { cleanEmptyObject } from './utils';
 import BlockPopover from '../components/block-popover';
 import SpacingSizesControl from '../components/spacing-sizes-control';
-import {
-	getSpacingPresetCssVar,
-	isValueSpacingPreset,
-} from '../components/spacing-sizes-control/utils';
+import { getSpacingPresetCssVar } from '../components/spacing-sizes-control/utils';
 /**
  * Determines if there is padding support.
  *
@@ -179,18 +176,18 @@ export function PaddingVisualizer( { clientId, attributes, isMouseOver } ) {
 	const padding = attributes?.style?.spacing?.padding;
 	const style = useMemo( () => {
 		return {
-			borderTopWidth: isValueSpacingPreset( padding?.top )
+			borderTopWidth: padding?.top
 				? getSpacingPresetCssVar( padding?.top )
-				: padding?.top,
-			borderRightWidth: isValueSpacingPreset( padding?.right )
+				: 0,
+			borderRightWidth: padding?.right
 				? getSpacingPresetCssVar( padding?.right )
-				: padding?.right,
-			borderBottomWidth: isValueSpacingPreset( padding?.bottom )
+				: 0,
+			borderBottomWidth: padding?.bottom
 				? getSpacingPresetCssVar( padding?.bottom )
-				: padding?.bottom,
-			borderLeftWidth: isValueSpacingPreset( padding?.left )
+				: 0,
+			borderLeftWidth: padding?.left
 				? getSpacingPresetCssVar( padding?.left )
-				: padding?.left,
+				: 0,
 		};
 	}, [ padding ] );
 

--- a/packages/block-editor/src/hooks/padding.js
+++ b/packages/block-editor/src/hooks/padding.js
@@ -103,7 +103,8 @@ export function PaddingEdit( props ) {
 		name: blockName,
 		attributes: { style },
 		setAttributes,
-		setMouseOver,
+		onMouseOver,
+		onMouseOut,
 	} = props;
 
 	const spacingSizes = useSetting( 'spacing.spacingSizes' );
@@ -151,6 +152,8 @@ export function PaddingEdit( props ) {
 						units={ units }
 						allowReset={ false }
 						splitOnAxis={ splitOnAxis }
+						onMouseOver={ onMouseOver }
+						onMouseOut={ onMouseOut }
 					/>
 				) }
 				{ spacingSizes?.length > 0 && (
@@ -162,7 +165,8 @@ export function PaddingEdit( props ) {
 						units={ units }
 						allowReset={ false }
 						splitOnAxis={ splitOnAxis }
-						setMouseOver={ setMouseOver }
+						onMouseOver={ onMouseOver }
+						onMouseOut={ onMouseOut }
 					/>
 				) }
 			</>

--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## Unreleased
 
+### New Feature
+
+-   `CustomSelectControl`: Add `onMouseOver` and `onMouseOut` callback props to allow handling of these events by parent coomponents ([#44955](https://github.com/WordPress/gutenberg/pull/44955))
+-   `BoxControl`: Add `onMouseOver` and `onMouseOut` callback props to allow handling of these events by parent coomponents ([#44955](https://github.com/WordPress/gutenberg/pull/44955))
+
 ## 21.3.0 (2022-10-19)
 
 ### Bug Fix

--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -4,8 +4,7 @@
 
 ### New Feature
 
--   `CustomSelectControl`: Add `onMouseOver` and `onMouseOut` callback props to allow handling of these events by parent coomponents ([#44955](https://github.com/WordPress/gutenberg/pull/44955))
--   `BoxControl`: Add `onMouseOver` and `onMouseOut` callback props to allow handling of these events by parent coomponents ([#44955](https://github.com/WordPress/gutenberg/pull/44955))
+-   `BoxControl` & `CustomSelectControl`: Add `onMouseOver` and `onMouseOut` callback props to allow handling of these events by parent components ([#44955](https://github.com/WordPress/gutenberg/pull/44955))
 
 ## 21.3.0 (2022-10-19)
 

--- a/packages/components/src/box-control/README.md
+++ b/packages/components/src/box-control/README.md
@@ -95,3 +95,17 @@ The `top`, `right`, `bottom`, and `left` box dimension values.
 
 -   Type: `Object`
 -   Required: No
+
+### onMouseOver
+
+A handler for onMouseOver events.
+
+-   Type: `Function`
+-   Required: No
+
+### onMouseOut
+
+A handler for onMouseOut events.
+
+-   Type: `Function`
+-   Required: No

--- a/packages/components/src/box-control/index.js
+++ b/packages/components/src/box-control/index.js
@@ -52,8 +52,8 @@ export default function BoxControl( {
 	splitOnAxis = false,
 	allowReset = true,
 	resetValues = DEFAULT_VALUES,
-	onMouseOver = noop,
-	onMouseOut = noop,
+	onMouseOver,
+	onMouseOut,
 } ) {
 	const [ values, setValues ] = useControlledState( valuesProp, {
 		fallback: DEFAULT_VALUES,

--- a/packages/components/src/box-control/index.js
+++ b/packages/components/src/box-control/index.js
@@ -52,6 +52,8 @@ export default function BoxControl( {
 	splitOnAxis = false,
 	allowReset = true,
 	resetValues = DEFAULT_VALUES,
+	onMouseOver = noop,
+	onMouseOut = noop,
 } ) {
 	const [ values, setValues ] = useControlledState( valuesProp, {
 		fallback: DEFAULT_VALUES,
@@ -114,6 +116,8 @@ export default function BoxControl( {
 		setSelectedUnits,
 		sides,
 		values: inputValues,
+		onMouseOver,
+		onMouseOut,
 	};
 
 	return (

--- a/packages/components/src/custom-select-control/README.md
+++ b/packages/components/src/custom-select-control/README.md
@@ -131,6 +131,20 @@ Start opting into the unconstrained width style that will become the default in 
 -   Required: No
 -   Default: `false`
 
+#### onMouseOver
+
+A handler for onMouseOver events.
+
+-   Type: `Function`
+-   Required: No
+
+#### onMouseOut
+
+A handler for onMouseOut events.
+
+-   Type: `Function`
+-   Required: No
+
 ## Related components
 
 -   Like this component, but implemented using a native `<select>` for when custom styling is not necessary, the `SelectControl` component.

--- a/packages/components/src/custom-select-control/index.js
+++ b/packages/components/src/custom-select-control/index.js
@@ -61,6 +61,9 @@ const stateReducer = (
 			return changes;
 	}
 };
+
+const noop = () => {};
+
 export default function CustomSelectControl( {
 	/** Start opting into the larger default height that will become the default size in a future version. */
 	__next36pxDefaultSize = false,
@@ -75,6 +78,8 @@ export default function CustomSelectControl( {
 	/** @type {import('../select-control/types').SelectControlProps.size} */
 	size = 'default',
 	value: _selectedItem,
+	onMouseOver = noop,
+	onMouseOut = noop,
 } ) {
 	const {
 		getLabelProps,
@@ -173,6 +178,8 @@ export default function CustomSelectControl( {
 				suffix={ <SelectControlChevronDown /> }
 			>
 				<SelectControlSelect
+					onMouseOver={ onMouseOver }
+					onMouseOut={ onMouseOut }
 					as="button"
 					onFocus={ () => setIsFocused( true ) }
 					onBlur={ () => setIsFocused( false ) }

--- a/packages/components/src/custom-select-control/index.js
+++ b/packages/components/src/custom-select-control/index.js
@@ -62,25 +62,25 @@ const stateReducer = (
 	}
 };
 
-const noop = () => {};
+export default function CustomSelectControl( props ) {
+	const {
+		/** Start opting into the larger default height that will become the default size in a future version. */
+		__next36pxDefaultSize = false,
+		/** Start opting into the unconstrained width that will become the default in a future version. */
+		__nextUnconstrainedWidth = false,
+		className,
+		hideLabelFromVision,
+		label,
+		describedBy,
+		options: items,
+		onChange: onSelectedItemChange,
+		/** @type {import('../select-control/types').SelectControlProps.size} */
+		size = 'default',
+		value: _selectedItem,
+		onMouseOver,
+		onMouseOut,
+	} = props;
 
-export default function CustomSelectControl( {
-	/** Start opting into the larger default height that will become the default size in a future version. */
-	__next36pxDefaultSize = false,
-	/** Start opting into the unconstrained width that will become the default in a future version. */
-	__nextUnconstrainedWidth = false,
-	className,
-	hideLabelFromVision,
-	label,
-	describedBy,
-	options: items,
-	onChange: onSelectedItemChange,
-	/** @type {import('../select-control/types').SelectControlProps.size} */
-	size = 'default',
-	value: _selectedItem,
-	onMouseOver = noop,
-	onMouseOut = noop,
-} ) {
 	const {
 		getLabelProps,
 		getToggleButtonProps,


### PR DESCRIPTION
## What?
Adds a mouseover trigger to the padding/margin visualiser

## Why?
Part of improvements to visualiser in #44700

## How?
Passes down a mouseover handler to the spacing controls

## Testing Instructions
Add a Group block and try setting margin and padding, and check that visualiser displays while moused over the spacing control

## Screenshots or screencast 
Before:

https://user-images.githubusercontent.com/3629020/195733607-6e01baa1-bde2-4cd8-a945-d5f8bb0ccb32.mp4

After:

https://user-images.githubusercontent.com/3629020/195733373-4c6cd02e-12a8-4f5f-a921-a10f7d260a92.mp4

