### PR TITLE
SpacingSizesControl: Increase slider's max value to 300

### DIFF
--- a/packages/block-editor/src/components/spacing-sizes-control/spacing-input-control.js
+++ b/packages/block-editor/src/components/spacing-sizes-control/spacing-input-control.js
@@ -227,7 +227,7 @@ export default function SpacingInputControl( {
 					<RangeControl
 						value={ customRangeValue }
 						min={ 0 }
-						max={ 100 }
+						max={ 300 }
 						withInputField={ false }
 						onChange={ handleCustomValueSliderChange }
 						className="components-spacing-sizes-control__custom-value-range"


### PR DESCRIPTION
## What and why?
The slider next to a padding or margin control currently maxes out at 100px. This feels a little too restrictive—let's try bumping it up to 300px.

Note that you can enter any value you want into the text field.

## Testing Instructions
1. Go to Global Styles → Layout. The padding and margin sliders should go up to 300px.
2. Inspect a block with padding or margin support. The padding and margin sliders should go up to 300px.

## Screenshots or screencast 
https://user-images.githubusercontent.com/612155/195733884-397d11f3-b68f-4fbf-b2c9-08b638693f6a.mp4