### PR TITLE
Adjust the custom range steps to match the units chosen

### DIFF
--- a/packages/block-editor/src/components/spacing-sizes-control/spacing-input-control.js
+++ b/packages/block-editor/src/components/spacing-sizes-control/spacing-input-control.js
@@ -107,7 +107,7 @@ export default function SpacingInputControl( {
 	const customTooltipContent = ( newValue ) =>
 		value === undefined ? undefined : spacingSizes[ newValue ]?.name;
 
-	const customRangeValue = parseInt( currentValue, 10 );
+	const customRangeValue = parseFloat( currentValue, 10 );
 
 	const getNewCustomValue = ( newSize ) => {
 		const isNumeric = ! isNaN( parseFloat( newSize ) );
@@ -228,6 +228,9 @@ export default function SpacingInputControl( {
 						value={ customRangeValue }
 						min={ 0 }
 						max={ 300 }
+						step={
+							[ 'px', '%' ].includes( selectedUnit ) ? 1 : 0.1
+						}
 						withInputField={ false }
 						onChange={ handleCustomValueSliderChange }
 						className="components-spacing-sizes-control__custom-value-range"

--- a/packages/block-editor/src/components/spacing-sizes-control/spacing-input-control.js
+++ b/packages/block-editor/src/components/spacing-sizes-control/spacing-input-control.js
@@ -163,6 +163,8 @@ export default function SpacingInputControl( {
 		! showCustomValueControl &&
 		currentValueHint !== undefined;
 
+	const maxCustomValues = { px: 300, '%': 100, vw: 100, vh: 100 };
+
 	return (
 		<>
 			{ side !== 'all' && (
@@ -227,9 +229,15 @@ export default function SpacingInputControl( {
 					<RangeControl
 						value={ customRangeValue }
 						min={ 0 }
-						max={ 300 }
+						max={
+							maxCustomValues[ selectedUnit ]
+								? maxCustomValues[ selectedUnit ]
+								: 10
+						}
 						step={
-							[ 'px', '%' ].includes( selectedUnit ) ? 1 : 0.1
+							[ 'px', '%', 'vh', 'vw' ].includes( selectedUnit )
+								? 1
+								: 0.1
 						}
 						withInputField={ false }
 						onChange={ handleCustomValueSliderChange }

--- a/packages/block-editor/src/components/spacing-sizes-control/spacing-input-control.js
+++ b/packages/block-editor/src/components/spacing-sizes-control/spacing-input-control.js
@@ -34,6 +34,15 @@ import {
 	isValueSpacingPreset,
 } from './utils';
 
+const CUSTOM_VALUE_SETTINGS = {
+	px: { max: 300, steps: 1 },
+	'%': { max: 100, steps: 1 },
+	vw: { max: 100, steps: 1 },
+	vh: { max: 100, steps: 1 },
+	em: { max: 10, steps: 0.1 },
+	rm: { max: 10, steps: 0.1 },
+};
+
 export default function SpacingInputControl( {
 	spacingSizes,
 	value,
@@ -163,8 +172,6 @@ export default function SpacingInputControl( {
 		! showCustomValueControl &&
 		currentValueHint !== undefined;
 
-	const maxCustomValues = { px: 300, '%': 100, vw: 100, vh: 100 };
-
 	return (
 		<>
 			{ side !== 'all' && (
@@ -229,15 +236,9 @@ export default function SpacingInputControl( {
 					<RangeControl
 						value={ customRangeValue }
 						min={ 0 }
-						max={
-							maxCustomValues[ selectedUnit ]
-								? maxCustomValues[ selectedUnit ]
-								: 10
-						}
+						max={ CUSTOM_VALUE_SETTINGS[ selectedUnit ]?.max ?? 10 }
 						step={
-							[ 'px', '%', 'vh', 'vw' ].includes( selectedUnit )
-								? 1
-								: 0.1
+							CUSTOM_VALUE_SETTINGS[ selectedUnit ]?.steps ?? 0.1
 						}
 						withInputField={ false }
 						onChange={ handleCustomValueSliderChange }


### PR DESCRIPTION
## What?
Aligns the spacing custom range control steps with the units chosen

## Why?
Other custom ranges, like Border, use a `1` step for `px, %` and `0.1` for others, so Spacing sizing should work the same.

## How?
Checks selected unit and sets step accordingly.

## Testing Instructions

- Add a group block and under the Padding control select a custom value
- Check that when `%` or `px` is set that range control has steps of `1`, and `0.1` for other units

## Screenshots or screencast <!-- if applicable -->

Before:

https://user-images.githubusercontent.com/3629020/195751972-0fd1fa50-4fcc-482f-a71d-f36301aeafad.mp4

After:

https://user-images.githubusercontent.com/3629020/195752002-0c8750bb-a6b0-41f5-9741-73419cfb74b9.mp4



