### PR TITLE
CSS: backport the 6.1 Core kses regex changes to Gutenberg for safecss_filter_attr_allow_css

### DIFF
--- a/lib/compat/wordpress-6.1/blocks.php
+++ b/lib/compat/wordpress-6.1/blocks.php
@@ -38,11 +38,12 @@ add_filter( 'safe_style_css', 'gutenberg_safe_style_attrs_6_1' );
  */
 function gutenberg_safecss_filter_attr_allow_css_6_1( $allow_css, $css_test_string ) {
 	if ( false === $allow_css ) {
-		// Allow some CSS functions.
-		$css_test_string = preg_replace( '/\b(?:calc|min|max|minmax|clamp)\(((?:\([^()]*\)?|[^()])*)\)/', '', $css_test_string );
-
-		// Allow CSS var.
-		$css_test_string = preg_replace( '/\(?var\(--[\w\-\()[\]\,\s]*\)/', '', $css_test_string );
+		// Allows some CSS functions and CSS vars.
+		$css_test_string = preg_replace(
+			'/\b(?:var|calc|min|max|minmax|clamp)(\((?:[^()]|(?1))*\))/',
+			'',
+			$css_test_string
+		);
 
 		// Check for any CSS containing \ ( & } = or comments,
 		// except for url(), calc(), or var() usage checked above.


### PR DESCRIPTION
## What?
Updates the `gutenberg_safecss_filter_attr_allow_css_6_1` filter added in https://github.com/WordPress/gutenberg/pull/43004 with the latest Core changes committed in https://github.com/WordPress/wordpress-develop/commit/cb6f447d52e59a74c229c82ea8d3ca7efb81884d

Props to @andrewserong for noticing that we [hadn't backported the backport](https://github.com/WordPress/gutenberg/pull/43070#discussion_r995313817) 🙇 

## Why?
So that Gutenberg's 6.1 compat matches the code that is in WordPress 6.1 Core.

## How?
Copying over the new CSS filter regex from Core in order to allow min(), max(), minmax(), clamp() and var() values to be used in inline CSS.

## Testing Instructions

The existing tests should pass, specifically those added in https://github.com/WordPress/gutenberg/pull/43004
 
```
npm run test:unit:php -- --filter WP_Style_Engine_CSS_Declarations_Test
npm run test:unit:php -- --filter WP_Style_Engine_CSS_Rule_Test  
```



