### PR TITLE
Update 6.1 CSS filter to match core

### DIFF
--- a/lib/compat/wordpress-6.1/blocks.php
+++ b/lib/compat/wordpress-6.1/blocks.php
@@ -38,11 +38,15 @@ add_filter( 'safe_style_css', 'gutenberg_safe_style_attrs_6_1' );
  */
 function gutenberg_safecss_filter_attr_allow_css_6_1( $allow_css, $css_test_string ) {
 	if ( false === $allow_css ) {
-		// Allow some CSS functions.
-		$css_test_string = preg_replace( '/\b(?:calc|min|max|minmax|clamp)\(((?:\([^()]*\)?|[^()])*)\)/', '', $css_test_string );
-
-		// Allow CSS var.
-		$css_test_string = preg_replace( '/\(?var\(--[\w\-\()[\]\,\s]*\)/', '', $css_test_string );
+		/*
+		 * Allow CSS functions like var(), calc(), etc. by removing them from the test string.
+		 * Nested functions and parentheses are also removed, so long as the parentheses are balanced.
+		 */
+		$css_test_string = preg_replace(
+			'/\b(?:var|calc|min|max|minmax|clamp)(\((?:[^()]|(?1))*\))/',
+			'',
+			$css_test_string
+		);
 
 		// Check for any CSS containing \ ( & } = or comments,
 		// except for url(), calc(), or var() usage checked above.


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Follow up to https://github.com/WordPress/gutenberg/pull/43004 to backport a backport of the CSS filter from 6.1. This copies over the logic from https://github.com/WordPress/wordpress-develop/blob/2b4d385298504d412e9f0dea2e7019d53463c705/src/wp-includes/kses.php#L2504-L2512 in core, to make sure that Gutenberg + WP 6.0 has the same support for CSS functions as 6.1.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

The previous version of this code wasn't current with core, and had edge cases that weren't allowed, as discussed in https://github.com/WordPress/gutenberg/pull/43070#discussion_r995313817.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

Copy + paste the lines from https://github.com/WordPress/wordpress-develop/blob/2b4d385298504d412e9f0dea2e7019d53463c705/src/wp-includes/kses.php#L2504-L2512 in core.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->

* Ensure that style engine tests still pass, e.g. https://github.com/WordPress/gutenberg/blob/388e5d23e327e13b7e88f60268b99d89e761bf79/phpunit/style-engine/class-wp-style-engine-css-declarations-test.php#L157
* Smoke test that layout styles on the site frontend are still working as expected 
* Check that the copy+pasted lines are copy+pasted correctly 😀