### PR TITLE
[Block Library - Image]: Add toolbar button to add a caption

### DIFF
--- a/packages/block-library/src/image/editor.scss
+++ b/packages/block-library/src/image/editor.scss
@@ -66,7 +66,7 @@ figure.wp-block-image:not(.wp-block) {
 
 // This is necessary for the editor resize handles to accurately work on a non-floated, non-resized, small image.
 .wp-block-image .components-resizable-box__container {
-	display: inline-block;
+	display: table;
 	img {
 		display: block;
 		width: inherit;

--- a/packages/block-library/src/image/editor.scss
+++ b/packages/block-library/src/image/editor.scss
@@ -66,6 +66,9 @@ figure.wp-block-image:not(.wp-block) {
 
 // This is necessary for the editor resize handles to accurately work on a non-floated, non-resized, small image.
 .wp-block-image .components-resizable-box__container {
+	// Using "display: table" because:
+	// - it visually hides empty white space in between elements
+	// - it allows the element to be as wide as its contents (instead of 100% width, as it would be with `display: block`)
 	display: table;
 	img {
 		display: block;

--- a/packages/block-library/src/image/image.js
+++ b/packages/block-library/src/image/image.js
@@ -333,14 +333,23 @@ export default function Image( {
 						onChange={ updateAlignment }
 					/>
 				) }
-				{ ! isContentLocked && ! caption && (
+				{ ! isContentLocked && (
 					<ToolbarButton
 						onClick={ () => {
 							setShowCaption( ! showCaption );
+							if (
+								showCaption &&
+								! RichText.isEmpty( caption )
+							) {
+								setAttributes( { caption: undefined } );
+							}
 						} }
 						icon={ captionIcon }
-						disabled={ showCaption }
-						label={ __( 'Add caption' ) }
+						label={
+							showCaption
+								? __( 'Remove caption' )
+								: __( 'Add caption' )
+						}
 					/>
 				) }
 				{ ! multiImageSelection && ! isEditingImage && (

--- a/packages/block-library/src/image/image.js
+++ b/packages/block-library/src/image/image.js
@@ -337,7 +337,7 @@ export default function Image( {
 					<ToolbarButton
 						onClick={ () => {
 							setShowCaption( ! showCaption );
-							if ( showCaption && ! caption ) {
+							if ( showCaption && caption ) {
 								setAttributes( { caption: undefined } );
 							}
 						} }

--- a/packages/block-library/src/image/image.js
+++ b/packages/block-library/src/image/image.js
@@ -343,11 +343,7 @@ export default function Image( {
 						} }
 						icon={ captionIcon }
 						isPressed={ showCaption }
-						label={
-							showCaption
-								? __( 'Remove caption' )
-								: __( 'Add caption' )
-						}
+						label={ __( 'Caption' ) }
 					/>
 				) }
 				{ ! multiImageSelection && ! isEditingImage && (

--- a/packages/block-library/src/image/image.js
+++ b/packages/block-library/src/image/image.js
@@ -337,14 +337,12 @@ export default function Image( {
 					<ToolbarButton
 						onClick={ () => {
 							setShowCaption( ! showCaption );
-							if (
-								showCaption &&
-								! RichText.isEmpty( caption )
-							) {
+							if ( showCaption && ! caption ) {
 								setAttributes( { caption: undefined } );
 							}
 						} }
 						icon={ captionIcon }
+						isPressed={ showCaption }
 						label={
 							showCaption
 								? __( 'Remove caption' )

--- a/packages/e2e-tests/specs/editor/blocks/gallery.test.js
+++ b/packages/e2e-tests/specs/editor/blocks/gallery.test.js
@@ -16,6 +16,7 @@ import {
 	clickButton,
 	openListView,
 	getListViewBlocks,
+	clickBlockToolbarButton,
 } from '@wordpress/e2e-test-utils';
 
 async function upload( selector ) {
@@ -110,7 +111,7 @@ describe( 'Gallery', () => {
 
 		const imageListLink = ( await getListViewBlocks( 'Image' ) )[ 0 ];
 		await imageListLink.click();
-
+		await clickBlockToolbarButton( 'Add caption' );
 		const captionElement = await figureElement.$(
 			'.block-editor-rich-text__editable'
 		);

--- a/packages/e2e-tests/specs/editor/blocks/gallery.test.js
+++ b/packages/e2e-tests/specs/editor/blocks/gallery.test.js
@@ -111,7 +111,7 @@ describe( 'Gallery', () => {
 
 		const imageListLink = ( await getListViewBlocks( 'Image' ) )[ 0 ];
 		await imageListLink.click();
-		await clickBlockToolbarButton( 'Add caption' );
+		await clickBlockToolbarButton( 'Caption' );
 		const captionElement = await figureElement.$(
 			'.block-editor-rich-text__editable'
 		);

--- a/packages/icons/src/index.js
+++ b/packages/icons/src/index.js
@@ -27,6 +27,7 @@ export { default as button } from './library/button';
 export { default as buttons } from './library/buttons';
 export { default as calendar } from './library/calendar';
 export { default as cancelCircleFilled } from './library/cancel-circle-filled';
+export { default as caption } from './library/caption';
 export { default as capturePhoto } from './library/capture-photo';
 export { default as captureVideo } from './library/capture-video';
 export { default as category } from './library/category';

--- a/packages/icons/src/library/caption.js
+++ b/packages/icons/src/library/caption.js
@@ -1,0 +1,16 @@
+/**
+ * WordPress dependencies
+ */
+import { Path, SVG } from '@wordpress/primitives';
+
+const caption = (
+	<SVG viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
+		<Path
+			fillRule="evenodd"
+			clipRule="evenodd"
+			d="M6 5.5h12a.5.5 0 0 1 .5.5v12a.5.5 0 0 1-.5.5H6a.5.5 0 0 1-.5-.5V6a.5.5 0 0 1 .5-.5ZM4 6a2 2 0 0 1 2-2h12a2 2 0 0 1 2 2v12a2 2 0 0 1-2 2H6a2 2 0 0 1-2-2V6Zm4 10h2v-1.5H8V16Zm5 0h-2v-1.5h2V16Zm1 0h2v-1.5h-2V16Z"
+		/>
+	</SVG>
+);
+
+export default caption;

--- a/test/e2e/specs/editor/blocks/image.spec.js
+++ b/test/e2e/specs/editor/blocks/image.spec.js
@@ -141,7 +141,7 @@ test.describe( 'Image', () => {
 		}
 	} );
 
-	test( 'should place caret at end of caption after merging empty paragraph', async ( {
+	test( 'should place caret on caption when clicking to add one', async ( {
 		editor,
 		page,
 		imageBlockUtils,
@@ -157,7 +157,7 @@ test.describe( 'Image', () => {
 			imageBlock.locator( 'data-testid=form-file-upload-input' )
 		);
 		await expect( image ).toHaveAttribute( 'src', new RegExp( filename ) );
-
+		await editor.clickBlockToolbarButton( 'Add caption' );
 		await page.keyboard.type( '1' );
 		await page.keyboard.press( 'Enter' );
 		await page.keyboard.press( 'Backspace' );
@@ -186,7 +186,7 @@ test.describe( 'Image', () => {
 
 		await expect( image ).toBeVisible();
 		await expect( image ).toHaveAttribute( 'src', new RegExp( fileName ) );
-
+		await editor.clickBlockToolbarButton( 'Add caption' );
 		await page.keyboard.type( '12' );
 		await page.keyboard.press( 'ArrowLeft' );
 		await page.keyboard.press( 'Enter' );
@@ -216,7 +216,8 @@ test.describe( 'Image', () => {
 		await expect( image ).toBeVisible();
 		await expect( image ).toHaveAttribute( 'src', new RegExp( fileName ) );
 
-		// Navigate to inline toolbar,
+		// Add caption and navigate to inline toolbar.
+		await editor.clickBlockToolbarButton( 'Add caption' );
 		await pageUtils.pressKeyWithModifier( 'shift', 'Tab' );
 		await expect(
 			await page.evaluate( () =>
@@ -516,7 +517,7 @@ test.describe( 'Image', () => {
 		);
 
 		await expect( image ).toHaveAttribute( 'src', new RegExp( filename ) );
-
+		await page.focus( '.wp-block-image' );
 		await pageUtils.pressKeyWithModifier( 'primary', 'z' );
 
 		// Expect an empty image block (placeholder) rather than one with a

--- a/test/e2e/specs/editor/blocks/image.spec.js
+++ b/test/e2e/specs/editor/blocks/image.spec.js
@@ -157,7 +157,7 @@ test.describe( 'Image', () => {
 			imageBlock.locator( 'data-testid=form-file-upload-input' )
 		);
 		await expect( image ).toHaveAttribute( 'src', new RegExp( filename ) );
-		await editor.clickBlockToolbarButton( 'Add caption' );
+		await editor.clickBlockToolbarButton( 'Caption' );
 		await page.keyboard.type( '1' );
 		await page.keyboard.press( 'Enter' );
 		await page.keyboard.press( 'Backspace' );
@@ -186,7 +186,7 @@ test.describe( 'Image', () => {
 
 		await expect( image ).toBeVisible();
 		await expect( image ).toHaveAttribute( 'src', new RegExp( fileName ) );
-		await editor.clickBlockToolbarButton( 'Add caption' );
+		await editor.clickBlockToolbarButton( 'Caption' );
 		await page.keyboard.type( '12' );
 		await page.keyboard.press( 'ArrowLeft' );
 		await page.keyboard.press( 'Enter' );
@@ -217,7 +217,7 @@ test.describe( 'Image', () => {
 		await expect( image ).toHaveAttribute( 'src', new RegExp( fileName ) );
 
 		// Add caption and navigate to inline toolbar.
-		await editor.clickBlockToolbarButton( 'Add caption' );
+		await editor.clickBlockToolbarButton( 'Caption' );
 		await pageUtils.pressKeyWithModifier( 'shift', 'Tab' );
 		await expect(
 			await page.evaluate( () =>


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Resolves: https://github.com/WordPress/gutenberg/issues/44359

This PR adds a toggle toolbar item on Image's Block Toolbar to add/remove a caption. Another change here is that the when we insert an image, the caption is not focused, even if the inserted image has one - this is important for https://github.com/WordPress/gutenberg/pull/44918 to add Images from the Inserter and keep the focus there.

When we land an acceptable solution for this, we should probably do the same for Video and Audio blocks.

## Testing Instructions
1. Insert image blocks(with or without captions)
2. Edit captions, navigate around history after changes(undo/redo) and select various blocks.

## Screenshots or screencast <!-- if applicable -->

https://user-images.githubusercontent.com/16275880/195773507-36431c40-61c4-471d-86af-a899433f1311.mov

