### PR TITLE
Global styles: convert preset font size values to CSS vars 

### DIFF
--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -40,6 +40,7 @@
 
 ### Enhancements
 
+-   `FontSizePicker`: Pass the preset object to the onChange callback to allow conversion from preset slugs to CSS vars ([#44967](https://github.com/WordPress/gutenberg/pull/44967)).
 -   `FontSizePicker`: Improved slider design when `withSlider` is set ([#44598](https://github.com/WordPress/gutenberg/pull/44598)).
 -   `ToggleControl`: Improved types for the `help` prop, covering the dynamic render function option, and enabled the dynamic `help` behavior only for a controlled component ([#45279](https://github.com/WordPress/gutenberg/pull/45279)).
 -   `BorderControl` & `BorderBoxControl`: Replace `__next36pxDefaultSize` with "default" and "large" size variants ([#41860](https://github.com/WordPress/gutenberg/pull/41860)).

--- a/packages/components/src/font-size-picker/index.tsx
+++ b/packages/components/src/font-size-picker/index.tsx
@@ -173,7 +173,8 @@ const UnforwardedFontSizePicker = (
 									onChange?.( undefined );
 								} else {
 									onChange?.(
-										hasUnits ? newValue : Number( newValue )
+										hasUnits ? newValue : Number( newValue ),
+										selectedFontSize
 									);
 								}
 							} }
@@ -193,7 +194,8 @@ const UnforwardedFontSizePicker = (
 								onChange?.( undefined );
 							} else {
 								onChange?.(
-									hasUnits ? newValue : Number( newValue )
+									hasUnits ? newValue : Number( newValue ),
+									selectedFontSize
 								);
 							}
 						} }

--- a/packages/components/src/font-size-picker/index.tsx
+++ b/packages/components/src/font-size-picker/index.tsx
@@ -173,8 +173,13 @@ const UnforwardedFontSizePicker = (
 									onChange?.( undefined );
 								} else {
 									onChange?.(
-										hasUnits ? newValue : Number( newValue ),
-										selectedFontSize
+										hasUnits
+											? newValue
+											: Number( newValue ),
+										fontSizes.find(
+											( fontSize ) =>
+												fontSize.size === newValue
+										)
 									);
 								}
 							} }
@@ -195,7 +200,10 @@ const UnforwardedFontSizePicker = (
 							} else {
 								onChange?.(
 									hasUnits ? newValue : Number( newValue ),
-									selectedFontSize
+									fontSizes.find(
+										( fontSize ) =>
+											fontSize.size === newValue
+									)
 								);
 							}
 						} }

--- a/packages/components/src/font-size-picker/test/index.tsx
+++ b/packages/components/src/font-size-picker/test/index.tsx
@@ -147,11 +147,19 @@ describe( 'FontSizePicker', () => {
 		);
 
 		test.each( [
-			{ option: 'Default', value: '8px', expectedValue: undefined },
-			{ option: 'Tiny 8', value: undefined, expectedValue: '8px' },
+			{
+				option: 'Default',
+				value: '8px',
+				expectedArguments: [ undefined ],
+			},
+			{
+				option: 'Tiny 8',
+				value: undefined,
+				expectedArguments: [ '8px', fontSizes[ 0 ] ],
+			},
 		] )(
-			'calls onChange( $expectedValue ) when $option is selected',
-			async ( { option, value, expectedValue } ) => {
+			'calls onChange( $expectedArguments ) when $option is selected',
+			async ( { option, value, expectedArguments } ) => {
 				const user = userEvent.setup( {
 					advanceTimers: jest.advanceTimersByTime,
 				} );
@@ -171,7 +179,7 @@ describe( 'FontSizePicker', () => {
 					screen.getByRole( 'option', { name: option } )
 				);
 				expect( onChange ).toHaveBeenCalledTimes( 1 );
-				expect( onChange ).toHaveBeenCalledWith( expectedValue );
+				expect( onChange ).toHaveBeenCalledWith( ...expectedArguments );
 			}
 		);
 
@@ -405,7 +413,7 @@ describe( 'FontSizePicker', () => {
 			);
 			await user.click( screen.getByRole( 'radio', { name: 'Medium' } ) );
 			expect( onChange ).toHaveBeenCalledTimes( 1 );
-			expect( onChange ).toHaveBeenCalledWith( '16px' );
+			expect( onChange ).toHaveBeenCalledWith( '16px', fontSizes[ 1 ] );
 		} );
 
 		commonToggleGroupTests( fontSizes );
@@ -481,16 +489,16 @@ describe( 'FontSizePicker', () => {
 		);
 
 		test.each( [
-			{ radio: 'Small', expectedValue: '12px' },
-			{ radio: 'Medium', expectedValue: '1em' },
-			{ radio: 'Large', expectedValue: '2rem' },
+			{ radio: 'Small', expectedArguments: [ '12px', fontSizes[ 0 ] ] },
+			{ radio: 'Medium', expectedArguments: [ '1em', fontSizes[ 1 ] ] },
+			{ radio: 'Large', expectedArguments: [ '2em', fontSizes[ 2 ] ] },
 			{
 				radio: 'Extra Large',
 				expectedValue: 'clamp(1.75rem, 3vw, 2.25rem)',
 			},
 		] )(
-			'calls onChange( $expectedValue ) when $radio is selected',
-			async ( { radio, expectedValue } ) => {
+			'calls onChange( $expectedArguments ) when $radio is selected',
+			async ( { radio, expectedArguments } ) => {
 				const user = userEvent.setup( {
 					advanceTimers: jest.advanceTimersByTime,
 				} );
@@ -506,7 +514,7 @@ describe( 'FontSizePicker', () => {
 					screen.getByRole( 'radio', { name: radio } )
 				);
 				expect( onChange ).toHaveBeenCalledTimes( 1 );
-				expect( onChange ).toHaveBeenCalledWith( expectedValue );
+				expect( onChange ).toHaveBeenCalledWith( ...expectedArguments );
 			}
 		);
 

--- a/packages/components/src/font-size-picker/test/index.tsx
+++ b/packages/components/src/font-size-picker/test/index.tsx
@@ -494,7 +494,10 @@ describe( 'FontSizePicker', () => {
 			{ radio: 'Large', expectedArguments: [ '2em', fontSizes[ 2 ] ] },
 			{
 				radio: 'Extra Large',
-				expectedValue: 'clamp(1.75rem, 3vw, 2.25rem)',
+				expectedArguments: [
+					'clamp(1.75rem, 3vw, 2.25rem)',
+					fontSizes[ 3 ],
+				],
 			},
 		] )(
 			'calls onChange( $expectedArguments ) when $radio is selected',

--- a/packages/components/src/font-size-picker/test/index.tsx
+++ b/packages/components/src/font-size-picker/test/index.tsx
@@ -290,18 +290,37 @@ describe( 'FontSizePicker', () => {
 		);
 
 		test.each( [
-			{ option: 'Default', value: '8px', expectedValue: undefined },
-			{ option: 'Tiny 8px', value: undefined, expectedValue: '8px' },
-			{ option: 'Small 1em', value: '8px', expectedValue: '1em' },
-			{ option: 'Medium 2rem', value: '8px', expectedValue: '2rem' },
+			{
+				option: 'Default',
+				value: '8px',
+				expectedArguments: [ undefined ],
+			},
+			{
+				option: 'Tiny 8px',
+				value: undefined,
+				expectedArguments: [ '8px', fontSizes[ 0 ] ],
+			},
+			{
+				option: 'Small 1em',
+				value: '8px',
+				expectedArguments: [ '1em', fontSizes[ 1 ] ],
+			},
+			{
+				option: 'Medium 2rem',
+				value: '8px',
+				expectedArguments: [ '2rem', fontSizes[ 2 ] ],
+			},
 			{
 				option: 'Large',
 				value: '8px',
-				expectedValue: 'clamp(1.75rem, 3vw, 2.25rem)',
+				expectedArguments: [
+					'clamp(1.75rem, 3vw, 2.25rem)',
+					fontSizes[ 3 ],
+				],
 			},
 		] )(
 			'calls onChange( $expectedValue ) when $option is selected',
-			async ( { option, value, expectedValue } ) => {
+			async ( { option, value, expectedArguments } ) => {
 				const user = userEvent.setup( {
 					advanceTimers: jest.advanceTimersByTime,
 				} );
@@ -321,7 +340,7 @@ describe( 'FontSizePicker', () => {
 					screen.getByRole( 'option', { name: option } )
 				);
 				expect( onChange ).toHaveBeenCalledTimes( 1 );
-				expect( onChange ).toHaveBeenCalledWith( expectedValue );
+				expect( onChange ).toHaveBeenCalledWith( ...expectedArguments );
 			}
 		);
 
@@ -491,7 +510,7 @@ describe( 'FontSizePicker', () => {
 		test.each( [
 			{ radio: 'Small', expectedArguments: [ '12px', fontSizes[ 0 ] ] },
 			{ radio: 'Medium', expectedArguments: [ '1em', fontSizes[ 1 ] ] },
-			{ radio: 'Large', expectedArguments: [ '2em', fontSizes[ 2 ] ] },
+			{ radio: 'Large', expectedArguments: [ '2rem', fontSizes[ 2 ] ] },
 			{
 				radio: 'Extra Large',
 				expectedArguments: [

--- a/packages/components/src/font-size-picker/types.ts
+++ b/packages/components/src/font-size-picker/types.ts
@@ -24,7 +24,7 @@ export type FontSizePickerProps = {
 	 */
 	onChange?: (
 		value: number | string | undefined,
-		selectedItem?: FontSizeOption
+		selectedItem?: FontSize
 	) => void;
 	/**
 	 * The current font size value.

--- a/packages/components/src/font-size-picker/types.ts
+++ b/packages/components/src/font-size-picker/types.ts
@@ -22,7 +22,10 @@ export type FontSizePickerProps = {
 	 * attending to what reset means in that context, e.g., set the font size to
 	 * undefined or set the font size a starting value.
 	 */
-	onChange?: ( value: number | string | undefined ) => void;
+	onChange?: (
+		value: number | string | undefined,
+		selectedItem?: FontSizeOption
+	) => void;
 	/**
 	 * The current font size value.
 	 */

--- a/packages/edit-site/src/components/global-styles/hooks.js
+++ b/packages/edit-site/src/components/global-styles/hooks.js
@@ -108,19 +108,27 @@ export function useStyle( path, blockName, source = 'all' ) {
 		? `styles.${ path }`
 		: `styles.blocks.${ blockName }.${ path }`;
 
-	const setStyle = ( newValue ) => {
+	const setStyle = ( newValue, metadata ) => {
 		setUserConfig( ( currentConfig ) => {
 			// Deep clone `currentConfig` to avoid mutating it later.
 			const newUserConfig = JSON.parse( JSON.stringify( currentConfig ) );
-			set(
-				newUserConfig,
-				finalPath,
-				getPresetVariableFromValue(
+			let styleValue = getPresetVariableFromValue(
 					mergedConfig.settings,
 					blockName,
 					path,
 					newValue
-				)
+				);
+			// Convert font size styles to fluid if fluid is activated.
+			if ( finalPath.indexOf( 'typography.fontSize' ) !== -1 && !! metadata?.slug ) {
+				styleValue = `var:preset|font-size|${ metadata?.slug })`;
+			}
+
+
+
+			set(
+				newUserConfig,
+				finalPath,
+				styleValue
 			);
 			return newUserConfig;
 		} );

--- a/packages/edit-site/src/components/global-styles/hooks.js
+++ b/packages/edit-site/src/components/global-styles/hooks.js
@@ -108,25 +108,20 @@ export function useStyle( path, blockName, source = 'all' ) {
 		? `styles.${ path }`
 		: `styles.blocks.${ blockName }.${ path }`;
 
-	const setStyle = ( newValue, metadata ) => {
+	const setStyle = ( newValue ) => {
 		setUserConfig( ( currentConfig ) => {
 			// Deep clone `currentConfig` to avoid mutating it later.
 			const newUserConfig = JSON.parse( JSON.stringify( currentConfig ) );
-			let styleValue = getPresetVariableFromValue(
-				mergedConfig.settings,
-				blockName,
-				path,
-				newValue
+			set(
+				newUserConfig,
+				finalPath,
+				getPresetVariableFromValue(
+					mergedConfig.settings,
+					blockName,
+					path,
+					newValue
+				)
 			);
-			// Convert font size styles to fluid if fluid is activated.
-			if (
-				finalPath.indexOf( 'typography.fontSize' ) !== -1 &&
-				!! metadata?.slug
-			) {
-				styleValue = `var:preset|font-size|${ metadata?.slug })`;
-			}
-
-			set( newUserConfig, finalPath, styleValue );
 			return newUserConfig;
 		} );
 	};

--- a/packages/edit-site/src/components/global-styles/hooks.js
+++ b/packages/edit-site/src/components/global-styles/hooks.js
@@ -113,23 +113,20 @@ export function useStyle( path, blockName, source = 'all' ) {
 			// Deep clone `currentConfig` to avoid mutating it later.
 			const newUserConfig = JSON.parse( JSON.stringify( currentConfig ) );
 			let styleValue = getPresetVariableFromValue(
-					mergedConfig.settings,
-					blockName,
-					path,
-					newValue
-				);
+				mergedConfig.settings,
+				blockName,
+				path,
+				newValue
+			);
 			// Convert font size styles to fluid if fluid is activated.
-			if ( finalPath.indexOf( 'typography.fontSize' ) !== -1 && !! metadata?.slug ) {
+			if (
+				finalPath.indexOf( 'typography.fontSize' ) !== -1 &&
+				!! metadata?.slug
+			) {
 				styleValue = `var:preset|font-size|${ metadata?.slug })`;
 			}
 
-
-
-			set(
-				newUserConfig,
-				finalPath,
-				styleValue
-			);
+			set( newUserConfig, finalPath, styleValue );
 			return newUserConfig;
 		} );
 	};

--- a/packages/edit-site/src/components/global-styles/typography-panel.js
+++ b/packages/edit-site/src/components/global-styles/typography-panel.js
@@ -110,6 +110,25 @@ function useStyleWithReset( path, blockName ) {
 	return [ style, setStyle, hasStyle, resetStyle ];
 }
 
+function useFontSizeStyleWithReset(
+	path,
+	blockName,
+	isFluidTypographyEnabled
+) {
+	const [ style, setStyleCallback ] = useStyle( path, blockName );
+	const [ userStyle ] = useStyle( path, blockName, 'user' );
+	const hasStyle = () => !! userStyle;
+	const resetStyle = () => setStyleCallback( undefined );
+	const setStyle = ( newValue, metadata ) => {
+		// Convert font size styles to fluid if fluid is activated.
+		if ( isFluidTypographyEnabled && !! metadata?.slug ) {
+			newValue = `var:preset|font-size|${ metadata?.slug }`;
+		}
+		setStyleCallback( newValue );
+	};
+	return [ style, setStyle, hasStyle, resetStyle ];
+}
+
 function useFontAppearance( prefix, name ) {
 	const [ fontStyle, setFontStyle ] = useStyle(
 		prefix + 'typography.fontStyle',
@@ -192,7 +211,11 @@ export default function TypographyPanel( { name, element, headingLevel } ) {
 	const [ fontFamily, setFontFamily, hasFontFamily, resetFontFamily ] =
 		useStyleWithReset( prefix + 'typography.fontFamily', name );
 	const [ fontSize, setFontSize, hasFontSize, resetFontSize ] =
-		useStyleWithReset( prefix + 'typography.fontSize', name );
+		useFontSizeStyleWithReset(
+			prefix + 'typography.fontSize',
+			name,
+			fluidTypography
+		);
 	const {
 		fontStyle,
 		setFontStyle,

--- a/packages/edit-site/src/components/global-styles/typography-panel.js
+++ b/packages/edit-site/src/components/global-styles/typography-panel.js
@@ -110,23 +110,25 @@ function useStyleWithReset( path, blockName ) {
 	return [ style, setStyle, hasStyle, resetStyle ];
 }
 
-function useFontSizeStyleWithReset(
-	path,
-	blockName,
-	isFluidTypographyEnabled
-) {
-	const [ style, setStyleCallback ] = useStyle( path, blockName );
+function useFontSizeStyleWithReset( path, blockName ) {
+	const [ fontSize, setStyleCallback ] = useStyle( path, blockName );
 	const [ userStyle ] = useStyle( path, blockName, 'user' );
-	const hasStyle = () => !! userStyle;
-	const resetStyle = () => setStyleCallback( undefined );
-	const setStyle = ( newValue, metadata ) => {
+	const hasFontSize = () => !! userStyle;
+	const resetFontSize = () => setStyleCallback( undefined );
+	const setFontSize = ( newValue, metadata ) => {
 		// Convert font size styles to fluid if fluid is activated.
-		if ( isFluidTypographyEnabled && !! metadata?.slug ) {
+		if ( !! metadata?.slug ) {
 			newValue = `var:preset|font-size|${ metadata?.slug }`;
 		}
 		setStyleCallback( newValue );
 	};
-	return [ style, setStyle, hasStyle, resetStyle ];
+
+	return {
+		fontSize,
+		setFontSize,
+		hasFontSize,
+		resetFontSize,
+	};
 }
 
 function useFontAppearance( prefix, name ) {
@@ -210,12 +212,8 @@ export default function TypographyPanel( { name, element, headingLevel } ) {
 
 	const [ fontFamily, setFontFamily, hasFontFamily, resetFontFamily ] =
 		useStyleWithReset( prefix + 'typography.fontFamily', name );
-	const [ fontSize, setFontSize, hasFontSize, resetFontSize ] =
-		useFontSizeStyleWithReset(
-			prefix + 'typography.fontSize',
-			name,
-			fluidTypography
-		);
+	const { fontSize, setFontSize, hasFontSize, resetFontSize } =
+		useFontSizeStyleWithReset( prefix + 'typography.fontSize', name );
 	const {
 		fontStyle,
 		setFontStyle,

--- a/packages/edit-site/src/components/global-styles/typography-panel.js
+++ b/packages/edit-site/src/components/global-styles/typography-panel.js
@@ -19,7 +19,6 @@ import { __ } from '@wordpress/i18n';
  * Internal dependencies
  */
 import { getSupportedGlobalStylesPanels, useSetting, useStyle } from './hooks';
-import { getTypographyFontSizeValue } from './typography-utils';
 
 export function useHasTypographyPanel( name ) {
 	const hasFontFamily = useHasFontFamilyControl( name );
@@ -173,18 +172,7 @@ export default function TypographyPanel( { name, element, headingLevel } ) {
 	} else if ( element && element !== 'text' ) {
 		prefix = `elements.${ element }.`;
 	}
-	const [ fluidTypography ] = useSetting( 'typography.fluid', name );
 	const [ fontSizes ] = useSetting( 'typography.fontSizes', name );
-
-	// Convert static font size values to fluid font sizes if fluidTypography is activated.
-	const fontSizesWithFluidValues = fontSizes.map( ( font ) => {
-		if ( !! fluidTypography ) {
-			font.size = getTypographyFontSizeValue( font, {
-				fluid: fluidTypography,
-			} );
-		}
-		return font;
-	} );
 
 	const disableCustomFontSizes = ! useSetting(
 		'typography.customFontSize',
@@ -274,7 +262,7 @@ export default function TypographyPanel( { name, element, headingLevel } ) {
 					<FontSizePicker
 						value={ fontSize }
 						onChange={ setFontSize }
-						fontSizes={ fontSizesWithFluidValues }
+						fontSizes={ fontSizes }
 						disableCustomFontSizes={ disableCustomFontSizes }
 						withReset={ false }
 						withSlider

--- a/packages/edit-site/src/components/global-styles/typography-panel.js
+++ b/packages/edit-site/src/components/global-styles/typography-panel.js
@@ -109,7 +109,7 @@ function useStyleWithReset( path, blockName ) {
 	return [ style, setStyle, hasStyle, resetStyle ];
 }
 
-function useFontSizeStyleWithReset( path, blockName ) {
+function useFontSizeWithReset( path, blockName ) {
 	const [ fontSize, setStyleCallback ] = useStyle( path, blockName );
 	const [ userStyle ] = useStyle( path, blockName, 'user' );
 	const hasFontSize = () => !! userStyle;
@@ -200,7 +200,7 @@ export default function TypographyPanel( { name, element, headingLevel } ) {
 	const [ fontFamily, setFontFamily, hasFontFamily, resetFontFamily ] =
 		useStyleWithReset( prefix + 'typography.fontFamily', name );
 	const { fontSize, setFontSize, hasFontSize, resetFontSize } =
-		useFontSizeStyleWithReset( prefix + 'typography.fontSize', name );
+		useFontSizeWithReset( prefix + 'typography.fontSize', name );
 	const {
 		fontStyle,
 		setFontStyle,

--- a/packages/edit-site/src/components/global-styles/typography-panel.js
+++ b/packages/edit-site/src/components/global-styles/typography-panel.js
@@ -115,7 +115,6 @@ function useFontSizeStyleWithReset( path, blockName ) {
 	const hasFontSize = () => !! userStyle;
 	const resetFontSize = () => setStyleCallback( undefined );
 	const setFontSize = ( newValue, metadata ) => {
-		// Convert font size styles to fluid if fluid is activated.
 		if ( !! metadata?.slug ) {
 			newValue = `var:preset|font-size|${ metadata?.slug }`;
 		}


### PR DESCRIPTION
Parent issue: https://github.com/WordPress/gutenberg/issues/44888

Context: https://github.com/WordPress/gutenberg/issues/44752#issuecomment-1276907842

## What?
This PR converts font size presets to `var:preset|font-size|${slug}` values so that they can be parsed by `getValueFromVariable` and converted to `var(--wp--preset--font-size--${slug}`) values.

## Why?

Why not?

At the moment we're saving the raw value. When fluid is turned on this means we're saving the `clamp()` value.

CSS vars are there. Why not use them?

## Testing

In the site editor, apply a font size preset to an element/block in global styles (not block styles)

<img width="1007" alt="Screen Shot 2022-10-14 at 6 03 08 pm" src="https://user-images.githubusercontent.com/6458278/195783498-430a4f0b-7bac-4c2b-8cac-0d20e72b7a86.png">

Check that we're using the preset CSS variable, and not the raw font size value.
