### PR TITLE
Updating missing shortcut in FAQ section

### DIFF
--- a/docs/explanations/faq.md
+++ b/docs/explanations/faq.md
@@ -270,7 +270,7 @@ This is the canonical list of keyboard shortcuts:
 		</tr>
 		<tr>
 			<td>Remove multiple selected blocks.</td>
-			<td></td>
+			<td><kbd>del</kbd><kbd>backspace</kbd></td>
 			<td><kbd>del</kbd><kbd>backspace</kbd></td>
 		</tr>
 	</tbody>


### PR DESCRIPTION


<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->
Win/linux keyboard shortcut key for 'deleting multiple selected blocks' was missing.
included `del` and `backspace`
## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

This is the same as that of my previous PR #43831 , which got deleted when I deleted my repo
