### PR TITLE
Navigator: refactor tests to TypeScript and user-event

### DIFF
--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -4,11 +4,11 @@
 
 ### Bug Fix
 
--   `FontSizePicker`: Ensure that fluid font size presets appear correctly in the UI controls ([#44791](https://github.com/WordPress/gutenberg/pull/44791))
+-   `FontSizePicker`: Ensure that fluid font size presets appear correctly in the UI controls ([#44791](https://github.com/WordPress/gutenberg/pull/44791)).
 
 ### Documentation
 
--   `VisuallyHidden`: Add some notes on best practices around stacking contexts when using this component ([#44867](https://github.com/WordPress/gutenberg/pull/44867))
+-   `VisuallyHidden`: Add some notes on best practices around stacking contexts when using this component ([#44867](https://github.com/WordPress/gutenberg/pull/44867)).
 
 ### Internal
 

--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -13,6 +13,7 @@
 ### Internal
 
 -   `Modal`: Convert to TypeScript ([#42949](https://github.com/WordPress/gutenberg/pull/42949)).
+-   `Navigator`: refactor unit tests to TypeScript and to `user-event` ([#44970](https://github.com/WordPress/gutenberg/pull/44970)).
 
 ## 21.2.0 (2022-10-05)
 

--- a/packages/components/src/navigator/test/index.tsx
+++ b/packages/components/src/navigator/test/index.tsx
@@ -54,6 +54,22 @@ const PATHS = {
 	NOT_FOUND: '/not-found',
 };
 
+const SCREEN_TEXT = {
+	home: 'This is the home screen.',
+	child: 'This is the child screen.',
+	nested: 'This is the nested screen.',
+	invalidHtmlPath: 'This is the screen with an invalid HTML value as a path.',
+};
+
+const BUTTON_TEXT = {
+	toNonExistingScreen: 'Navigate to non-existing screen.',
+	toChildScreen: 'Navigate to child screen.',
+	toNestedScreen: 'Navigate to nested screen.',
+	toInvalidHtmlPathScreen:
+		'Navigate to screen with an invalid HTML value as a path.',
+	back: 'Go back',
+};
+
 type CustomTestOnClickHandler = (
 	args:
 		| {
@@ -129,37 +145,37 @@ const MyNavigation = ( {
 	return (
 		<NavigatorProvider initialPath={ initialPath }>
 			<NavigatorScreen path={ PATHS.HOME }>
-				<p>This is the home screen.</p>
+				<p>{ SCREEN_TEXT.home }</p>
 				<CustomNavigatorButton
 					path={ PATHS.NOT_FOUND }
 					onClick={ onNavigatorButtonClick }
 				>
-					Navigate to non-existing screen.
+					{ BUTTON_TEXT.toNonExistingScreen }
 				</CustomNavigatorButton>
 				<CustomNavigatorButton
 					path={ PATHS.CHILD }
 					onClick={ onNavigatorButtonClick }
 				>
-					Navigate to child screen.
+					{ BUTTON_TEXT.toChildScreen }
 				</CustomNavigatorButton>
 				<CustomNavigatorButton
 					path={ PATHS.INVALID_HTML_ATTRIBUTE }
 					onClick={ onNavigatorButtonClick }
 				>
-					Navigate to screen with an invalid HTML value as a path.
+					{ BUTTON_TEXT.toInvalidHtmlPathScreen }
 				</CustomNavigatorButton>
 			</NavigatorScreen>
 
 			<NavigatorScreen path={ PATHS.CHILD }>
-				<p>This is the child screen.</p>
+				<p>{ SCREEN_TEXT.child }</p>
 				<CustomNavigatorButtonWithFocusRestoration
 					path={ PATHS.NESTED }
 					onClick={ onNavigatorButtonClick }
 				>
-					Navigate to nested screen.
+					{ BUTTON_TEXT.toNestedScreen }
 				</CustomNavigatorButtonWithFocusRestoration>
 				<CustomNavigatorBackButton onClick={ onNavigatorButtonClick }>
-					Go back
+					{ BUTTON_TEXT.back }
 				</CustomNavigatorBackButton>
 
 				<label htmlFor="test-input">This is a test input</label>
@@ -175,16 +191,16 @@ const MyNavigation = ( {
 			</NavigatorScreen>
 
 			<NavigatorScreen path={ PATHS.NESTED }>
-				<p>This is the nested screen.</p>
+				<p>{ SCREEN_TEXT.nested }</p>
 				<CustomNavigatorBackButton onClick={ onNavigatorButtonClick }>
-					Go back
+					{ BUTTON_TEXT.back }
 				</CustomNavigatorBackButton>
 			</NavigatorScreen>
 
 			<NavigatorScreen path={ PATHS.INVALID_HTML_ATTRIBUTE }>
-				<p>This is the screen with an invalid HTML value as a path.</p>
+				<p>{ SCREEN_TEXT.invalidHtmlPath }</p>
 				<CustomNavigatorBackButton onClick={ onNavigatorButtonClick }>
-					Go back
+					{ BUTTON_TEXT.back }
 				</CustomNavigatorBackButton>
 			</NavigatorScreen>
 

--- a/packages/components/src/navigator/test/index.tsx
+++ b/packages/components/src/navigator/test/index.tsx
@@ -193,23 +193,31 @@ const MyNavigation = ( {
 	);
 };
 
-const getNavigationScreenByText = ( text, { throwIfNotFound = true } = {} ) => {
+type HelperGetterOptions = {
+	throwIfNotFound?: boolean;
+};
+const getNavigationScreenByText = (
+	text: string,
+	{ throwIfNotFound = true }: HelperGetterOptions = {}
+) => {
 	const fnName = throwIfNotFound ? 'getByText' : 'queryByText';
 	return screen[ fnName ]( text );
 };
-const getHomeScreen = ( { throwIfNotFound } = {} ) =>
+const getHomeScreen = ( { throwIfNotFound }: HelperGetterOptions = {} ) =>
 	getNavigationScreenByText( 'This is the home screen.', {
 		throwIfNotFound,
 	} );
-const getChildScreen = ( { throwIfNotFound } = {} ) =>
+const getChildScreen = ( { throwIfNotFound }: HelperGetterOptions = {} ) =>
 	getNavigationScreenByText( 'This is the child screen.', {
 		throwIfNotFound,
 	} );
-const getNestedScreen = ( { throwIfNotFound } = {} ) =>
+const getNestedScreen = ( { throwIfNotFound }: HelperGetterOptions = {} ) =>
 	getNavigationScreenByText( 'This is the nested screen.', {
 		throwIfNotFound,
 	} );
-const getInvalidHTMLPathScreen = ( { throwIfNotFound } = {} ) =>
+const getInvalidHTMLPathScreen = ( {
+	throwIfNotFound,
+}: HelperGetterOptions = {} ) =>
 	getNavigationScreenByText(
 		'This is the screen with an invalid HTML value as a path.',
 		{
@@ -217,30 +225,41 @@ const getInvalidHTMLPathScreen = ( { throwIfNotFound } = {} ) =>
 		}
 	);
 
-const getNavigationButtonByText = ( text, { throwIfNotFound = true } = {} ) => {
+const getNavigationButtonByText = (
+	text: string,
+	{ throwIfNotFound = true }: HelperGetterOptions = {}
+) => {
 	const fnName = throwIfNotFound ? 'getByRole' : 'queryByRole';
 	return screen[ fnName ]( 'button', { name: text } );
 };
-const getToNonExistingScreenButton = ( { throwIfNotFound } = {} ) =>
+const getToNonExistingScreenButton = ( {
+	throwIfNotFound,
+}: HelperGetterOptions = {} ) =>
 	getNavigationButtonByText( 'Navigate to non-existing screen.', {
 		throwIfNotFound,
 	} );
-const getToChildScreenButton = ( { throwIfNotFound } = {} ) =>
+const getToChildScreenButton = ( {
+	throwIfNotFound,
+}: HelperGetterOptions = {} ) =>
 	getNavigationButtonByText( 'Navigate to child screen.', {
 		throwIfNotFound,
 	} );
-const getToNestedScreenButton = ( { throwIfNotFound } = {} ) =>
+const getToNestedScreenButton = ( {
+	throwIfNotFound,
+}: HelperGetterOptions = {} ) =>
 	getNavigationButtonByText( 'Navigate to nested screen.', {
 		throwIfNotFound,
 	} );
-const getToInvalidHTMLPathScreenButton = ( { throwIfNotFound } = {} ) =>
+const getToInvalidHTMLPathScreenButton = ( {
+	throwIfNotFound,
+}: HelperGetterOptions = {} ) =>
 	getNavigationButtonByText(
 		'Navigate to screen with an invalid HTML value as a path.',
 		{
 			throwIfNotFound,
 		}
 	);
-const getBackButton = ( { throwIfNotFound } = {} ) =>
+const getBackButton = ( { throwIfNotFound }: HelperGetterOptions = {} ) =>
 	getNavigationButtonByText( 'Go back', {
 		throwIfNotFound,
 	} );

--- a/packages/components/src/navigator/test/index.tsx
+++ b/packages/components/src/navigator/test/index.tsx
@@ -2,7 +2,7 @@
  * External dependencies
  */
 import type { ReactNode, ForwardedRef, ComponentPropsWithoutRef } from 'react';
-import { render, screen, fireEvent } from '@testing-library/react';
+import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 
 /**
@@ -349,8 +349,12 @@ describe( 'Navigator', () => {
 		).not.toBeInTheDocument();
 	} );
 
-	it( 'should navigate across screens', () => {
+	it( 'should navigate across screens', async () => {
 		const spy = jest.fn();
+
+		const user = userEvent.setup( {
+			advanceTimers: jest.advanceTimersByTime,
+		} );
 
 		render( <MyNavigation onNavigatorButtonClick={ spy } /> );
 
@@ -358,36 +362,36 @@ describe( 'Navigator', () => {
 		expect( getToChildScreenButton() ).toBeInTheDocument();
 
 		// Navigate to child screen.
-		fireEvent.click( getToChildScreenButton() );
+		await user.click( getToChildScreenButton() );
 
 		expect( getChildScreen() ).toBeInTheDocument();
 		expect( getBackButton() ).toBeInTheDocument();
 
 		// Navigate back to home screen.
-		fireEvent.click( getBackButton() );
+		await user.click( getBackButton() );
 		expect( getHomeScreen() ).toBeInTheDocument();
 		expect( getToChildScreenButton() ).toBeInTheDocument();
 
 		// Navigate again to child screen.
-		fireEvent.click( getToChildScreenButton() );
+		await user.click( getToChildScreenButton() );
 
 		expect( getChildScreen() ).toBeInTheDocument();
 		expect( getToNestedScreenButton() ).toBeInTheDocument();
 
 		// Navigate to nested screen.
-		fireEvent.click( getToNestedScreenButton() );
+		await user.click( getToNestedScreenButton() );
 
 		expect( getNestedScreen() ).toBeInTheDocument();
 		expect( getBackButton() ).toBeInTheDocument();
 
 		// Navigate back to child screen.
-		fireEvent.click( getBackButton() );
+		await user.click( getBackButton() );
 
 		expect( getChildScreen() ).toBeInTheDocument();
 		expect( getToNestedScreenButton() ).toBeInTheDocument();
 
 		// Navigate back to home screen.
-		fireEvent.click( getBackButton() );
+		await user.click( getBackButton() );
 
 		expect( getHomeScreen() ).toBeInTheDocument();
 		expect( getToChildScreenButton() ).toBeInTheDocument();
@@ -417,15 +421,19 @@ describe( 'Navigator', () => {
 		} );
 	} );
 
-	it( 'should not rended anything if the path does not match any available screen', () => {
+	it( 'should not rended anything if the path does not match any available screen', async () => {
 		const spy = jest.fn();
+
+		const user = userEvent.setup( {
+			advanceTimers: jest.advanceTimersByTime,
+		} );
 
 		render( <MyNavigation onNavigatorButtonClick={ spy } /> );
 
 		expect( getToNonExistingScreenButton() ).toBeInTheDocument();
 
 		// Attempt to navigate to non-existing screen. No screens get rendered.
-		fireEvent.click( getToNonExistingScreenButton() );
+		await user.click( getToNonExistingScreenButton() );
 
 		expect(
 			getHomeScreen( { throwIfNotFound: false } )
@@ -445,35 +453,43 @@ describe( 'Navigator', () => {
 		} );
 	} );
 
-	it( 'should restore focus correctly', () => {
+	it( 'should restore focus correctly', async () => {
+		const user = userEvent.setup( {
+			advanceTimers: jest.advanceTimersByTime,
+		} );
+
 		render( <MyNavigation /> );
 
 		expect( getHomeScreen() ).toBeInTheDocument();
 
 		// Navigate to child screen.
-		fireEvent.click( getToChildScreenButton() );
+		await user.click( getToChildScreenButton() );
 
 		expect( getChildScreen() ).toBeInTheDocument();
 
 		// Navigate to nested screen.
-		fireEvent.click( getToNestedScreenButton() );
+		await user.click( getToNestedScreenButton() );
 
 		expect( getNestedScreen() ).toBeInTheDocument();
 
 		// Navigate back to child screen, check that focus was correctly restored.
-		fireEvent.click( getBackButton() );
+		await user.click( getBackButton() );
 
 		expect( getChildScreen() ).toBeInTheDocument();
 		expect( getToNestedScreenButton() ).toHaveFocus();
 
 		// Navigate back to home screen, check that focus was correctly restored.
-		fireEvent.click( getBackButton() );
+		await user.click( getBackButton() );
 
 		expect( getHomeScreen() ).toBeInTheDocument();
 		expect( getToChildScreenButton() ).toHaveFocus();
 	} );
 
-	it( 'should escape the value of the `path` prop', () => {
+	it( 'should escape the value of the `path` prop', async () => {
+		const user = userEvent.setup( {
+			advanceTimers: jest.advanceTimersByTime,
+		} );
+
 		render( <MyNavigation /> );
 
 		expect( getHomeScreen() ).toBeInTheDocument();
@@ -487,14 +503,14 @@ describe( 'Navigator', () => {
 		);
 
 		// Navigate to screen with an invalid HTML value for its `path`.
-		fireEvent.click( getToInvalidHTMLPathScreenButton() );
+		await user.click( getToInvalidHTMLPathScreenButton() );
 
 		expect( getInvalidHTMLPathScreen() ).toBeInTheDocument();
 		expect( getBackButton() ).toBeInTheDocument();
 
 		// Navigate back to home screen, check that the focus restoration selector
 		// worked correctly despite the escaping.
-		fireEvent.click( getBackButton() );
+		await user.click( getBackButton() );
 
 		expect( getHomeScreen() ).toBeInTheDocument();
 		expect( getToInvalidHTMLPathScreenButton() ).toHaveFocus();

--- a/packages/components/src/navigator/test/index.tsx
+++ b/packages/components/src/navigator/test/index.tsx
@@ -279,6 +279,8 @@ describe( 'Navigator', () => {
 	] );
 
 	beforeAll( () => {
+		// @ts-expect-error There's no need for an exact mock, this is just needed
+		// for the tests to pass (see `mockedGetClientRects` inline comments).
 		window.Element.prototype.getClientRects =
 			jest.fn( mockedGetClientRects );
 	} );

--- a/packages/components/src/navigator/test/index.tsx
+++ b/packages/components/src/navigator/test/index.tsx
@@ -1,6 +1,7 @@
 /**
  * External dependencies
  */
+import type { ReactNode, ForwardedRef } from 'react';
 import { render, screen, fireEvent } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 
@@ -24,12 +25,18 @@ jest.mock( 'framer-motion', () => {
 	return {
 		__esModule: true,
 		...actual,
-		AnimatePresence: ( { children } ) => <div>{ children }</div>,
+		AnimatePresence:
+			( { children }: { children?: ReactNode } ) =>
+			() =>
+				<div>{ children }</div>,
 		motion: {
 			...actual.motion,
-			div: require( 'react' ).forwardRef( ( { children }, ref ) => (
-				<div ref={ ref }>{ children }</div>
-			) ),
+			div: require( 'react' ).forwardRef(
+				(
+					{ children }: { children?: ReactNode },
+					ref: ForwardedRef< HTMLDivElement >
+				) => <div ref={ ref }>{ children }</div>
+			),
 		},
 	};
 } );

--- a/packages/components/src/navigator/test/index.tsx
+++ b/packages/components/src/navigator/test/index.tsx
@@ -17,7 +17,7 @@ import {
 	NavigatorScreen,
 	NavigatorButton,
 	NavigatorBackButton,
-} from '../';
+} from '..';
 
 jest.mock( 'framer-motion', () => {
 	const actual = jest.requireActual( 'framer-motion' );

--- a/packages/components/src/navigator/test/index.tsx
+++ b/packages/components/src/navigator/test/index.tsx
@@ -209,76 +209,12 @@ const MyNavigation = ( {
 	);
 };
 
-type HelperGetterOptions = {
-	throwIfNotFound?: boolean;
-};
-const getNavigationScreenByText = (
-	text: string,
-	{ throwIfNotFound = true }: HelperGetterOptions = {}
-) => {
-	const fnName = throwIfNotFound ? 'getByText' : 'queryByText';
-	return screen[ fnName ]( text );
-};
-const getHomeScreen = ( { throwIfNotFound }: HelperGetterOptions = {} ) =>
-	getNavigationScreenByText( 'This is the home screen.', {
-		throwIfNotFound,
-	} );
-const getChildScreen = ( { throwIfNotFound }: HelperGetterOptions = {} ) =>
-	getNavigationScreenByText( 'This is the child screen.', {
-		throwIfNotFound,
-	} );
-const getNestedScreen = ( { throwIfNotFound }: HelperGetterOptions = {} ) =>
-	getNavigationScreenByText( 'This is the nested screen.', {
-		throwIfNotFound,
-	} );
-const getInvalidHTMLPathScreen = ( {
-	throwIfNotFound,
-}: HelperGetterOptions = {} ) =>
-	getNavigationScreenByText(
-		'This is the screen with an invalid HTML value as a path.',
-		{
-			throwIfNotFound,
-		}
-	);
-
-const getNavigationButtonByText = (
-	text: string,
-	{ throwIfNotFound = true }: HelperGetterOptions = {}
-) => {
-	const fnName = throwIfNotFound ? 'getByRole' : 'queryByRole';
-	return screen[ fnName ]( 'button', { name: text } );
-};
-const getToNonExistingScreenButton = ( {
-	throwIfNotFound,
-}: HelperGetterOptions = {} ) =>
-	getNavigationButtonByText( 'Navigate to non-existing screen.', {
-		throwIfNotFound,
-	} );
-const getToChildScreenButton = ( {
-	throwIfNotFound,
-}: HelperGetterOptions = {} ) =>
-	getNavigationButtonByText( 'Navigate to child screen.', {
-		throwIfNotFound,
-	} );
-const getToNestedScreenButton = ( {
-	throwIfNotFound,
-}: HelperGetterOptions = {} ) =>
-	getNavigationButtonByText( 'Navigate to nested screen.', {
-		throwIfNotFound,
-	} );
-const getToInvalidHTMLPathScreenButton = ( {
-	throwIfNotFound,
-}: HelperGetterOptions = {} ) =>
-	getNavigationButtonByText(
-		'Navigate to screen with an invalid HTML value as a path.',
-		{
-			throwIfNotFound,
-		}
-	);
-const getBackButton = ( { throwIfNotFound }: HelperGetterOptions = {} ) =>
-	getNavigationButtonByText( 'Go back', {
-		throwIfNotFound,
-	} );
+const getScreen = ( screenKey: keyof typeof SCREEN_TEXT ) =>
+	screen.getByText( SCREEN_TEXT[ screenKey ] );
+const queryScreen = ( screenKey: keyof typeof SCREEN_TEXT ) =>
+	screen.queryByText( SCREEN_TEXT[ screenKey ] );
+const getNavigationButton = ( buttonKey: keyof typeof BUTTON_TEXT ) =>
+	screen.getByRole( 'button', { name: BUTTON_TEXT[ buttonKey ] } );
 
 describe( 'Navigator', () => {
 	const originalGetClientRects = window.Element.prototype.getClientRects;
@@ -308,61 +244,39 @@ describe( 'Navigator', () => {
 	it( 'should render', () => {
 		render( <MyNavigation /> );
 
-		expect( getHomeScreen() ).toBeInTheDocument();
-		expect(
-			getChildScreen( { throwIfNotFound: false } )
-		).not.toBeInTheDocument();
-		expect(
-			getNestedScreen( { throwIfNotFound: false } )
-		).not.toBeInTheDocument();
+		expect( getScreen( 'home' ) ).toBeInTheDocument();
+		expect( queryScreen( 'child' ) ).not.toBeInTheDocument();
+		expect( queryScreen( 'nested' ) ).not.toBeInTheDocument();
 	} );
 
 	it( 'should show a different screen on the first render depending on the value of `initialPath`', () => {
 		render( <MyNavigation initialPath={ PATHS.CHILD } /> );
 
-		expect(
-			getHomeScreen( { throwIfNotFound: false } )
-		).not.toBeInTheDocument();
-		expect( getChildScreen() ).toBeInTheDocument();
-		expect(
-			getNestedScreen( { throwIfNotFound: false } )
-		).not.toBeInTheDocument();
+		expect( queryScreen( 'home' ) ).not.toBeInTheDocument();
+		expect( getScreen( 'child' ) ).toBeInTheDocument();
+		expect( queryScreen( 'nested' ) ).not.toBeInTheDocument();
 	} );
 
 	it( 'should ignore changes to `initialPath` after the first render', () => {
 		const { rerender } = render( <MyNavigation /> );
 
-		expect( getHomeScreen() ).toBeInTheDocument();
-		expect(
-			getChildScreen( { throwIfNotFound: false } )
-		).not.toBeInTheDocument();
-		expect(
-			getNestedScreen( { throwIfNotFound: false } )
-		).not.toBeInTheDocument();
+		expect( getScreen( 'home' ) ).toBeInTheDocument();
+		expect( queryScreen( 'child' ) ).not.toBeInTheDocument();
+		expect( queryScreen( 'nested' ) ).not.toBeInTheDocument();
 
 		rerender( <MyNavigation initialPath={ PATHS.CHILD } /> );
 
-		expect( getHomeScreen() ).toBeInTheDocument();
-		expect(
-			getChildScreen( { throwIfNotFound: false } )
-		).not.toBeInTheDocument();
-		expect(
-			getNestedScreen( { throwIfNotFound: false } )
-		).not.toBeInTheDocument();
+		expect( getScreen( 'home' ) ).toBeInTheDocument();
+		expect( queryScreen( 'child' ) ).not.toBeInTheDocument();
+		expect( queryScreen( 'nested' ) ).not.toBeInTheDocument();
 	} );
 
 	it( 'should not rended anything if the `initialPath` does not match any available screen', () => {
 		render( <MyNavigation initialPath={ PATHS.NOT_FOUND } /> );
 
-		expect(
-			getHomeScreen( { throwIfNotFound: false } )
-		).not.toBeInTheDocument();
-		expect(
-			getChildScreen( { throwIfNotFound: false } )
-		).not.toBeInTheDocument();
-		expect(
-			getNestedScreen( { throwIfNotFound: false } )
-		).not.toBeInTheDocument();
+		expect( queryScreen( 'home' ) ).not.toBeInTheDocument();
+		expect( queryScreen( 'child' ) ).not.toBeInTheDocument();
+		expect( queryScreen( 'nested' ) ).not.toBeInTheDocument();
 	} );
 
 	it( 'should navigate across screens', async () => {
@@ -374,43 +288,43 @@ describe( 'Navigator', () => {
 
 		render( <MyNavigation onNavigatorButtonClick={ spy } /> );
 
-		expect( getHomeScreen() ).toBeInTheDocument();
-		expect( getToChildScreenButton() ).toBeInTheDocument();
+		expect( getScreen( 'home' ) ).toBeInTheDocument();
+		expect( getNavigationButton( 'toChildScreen' ) ).toBeInTheDocument();
 
 		// Navigate to child screen.
-		await user.click( getToChildScreenButton() );
+		await user.click( getNavigationButton( 'toChildScreen' ) );
 
-		expect( getChildScreen() ).toBeInTheDocument();
-		expect( getBackButton() ).toBeInTheDocument();
+		expect( getScreen( 'child' ) ).toBeInTheDocument();
+		expect( getNavigationButton( 'back' ) ).toBeInTheDocument();
 
 		// Navigate back to home screen.
-		await user.click( getBackButton() );
-		expect( getHomeScreen() ).toBeInTheDocument();
-		expect( getToChildScreenButton() ).toBeInTheDocument();
+		await user.click( getNavigationButton( 'back' ) );
+		expect( getScreen( 'home' ) ).toBeInTheDocument();
+		expect( getNavigationButton( 'toChildScreen' ) ).toBeInTheDocument();
 
 		// Navigate again to child screen.
-		await user.click( getToChildScreenButton() );
+		await user.click( getNavigationButton( 'toChildScreen' ) );
 
-		expect( getChildScreen() ).toBeInTheDocument();
-		expect( getToNestedScreenButton() ).toBeInTheDocument();
+		expect( getScreen( 'child' ) ).toBeInTheDocument();
+		expect( getNavigationButton( 'toNestedScreen' ) ).toBeInTheDocument();
 
 		// Navigate to nested screen.
-		await user.click( getToNestedScreenButton() );
+		await user.click( getNavigationButton( 'toNestedScreen' ) );
 
-		expect( getNestedScreen() ).toBeInTheDocument();
-		expect( getBackButton() ).toBeInTheDocument();
+		expect( getScreen( 'nested' ) ).toBeInTheDocument();
+		expect( getNavigationButton( 'back' ) ).toBeInTheDocument();
 
 		// Navigate back to child screen.
-		await user.click( getBackButton() );
+		await user.click( getNavigationButton( 'back' ) );
 
-		expect( getChildScreen() ).toBeInTheDocument();
-		expect( getToNestedScreenButton() ).toBeInTheDocument();
+		expect( getScreen( 'child' ) ).toBeInTheDocument();
+		expect( getNavigationButton( 'toNestedScreen' ) ).toBeInTheDocument();
 
 		// Navigate back to home screen.
-		await user.click( getBackButton() );
+		await user.click( getNavigationButton( 'back' ) );
 
-		expect( getHomeScreen() ).toBeInTheDocument();
-		expect( getToChildScreenButton() ).toBeInTheDocument();
+		expect( getScreen( 'home' ) ).toBeInTheDocument();
+		expect( getNavigationButton( 'toChildScreen' ) ).toBeInTheDocument();
 
 		// Check the values passed to `navigator.goTo()`.
 		expect( spy ).toHaveBeenCalledTimes( 6 );
@@ -446,20 +360,16 @@ describe( 'Navigator', () => {
 
 		render( <MyNavigation onNavigatorButtonClick={ spy } /> );
 
-		expect( getToNonExistingScreenButton() ).toBeInTheDocument();
+		expect(
+			getNavigationButton( 'toNonExistingScreen' )
+		).toBeInTheDocument();
 
 		// Attempt to navigate to non-existing screen. No screens get rendered.
-		await user.click( getToNonExistingScreenButton() );
+		await user.click( getNavigationButton( 'toNonExistingScreen' ) );
 
-		expect(
-			getHomeScreen( { throwIfNotFound: false } )
-		).not.toBeInTheDocument();
-		expect(
-			getChildScreen( { throwIfNotFound: false } )
-		).not.toBeInTheDocument();
-		expect(
-			getNestedScreen( { throwIfNotFound: false } )
-		).not.toBeInTheDocument();
+		expect( queryScreen( 'home' ) ).not.toBeInTheDocument();
+		expect( queryScreen( 'child' ) ).not.toBeInTheDocument();
+		expect( queryScreen( 'nested' ) ).not.toBeInTheDocument();
 
 		// Check the values passed to `navigator.goTo()`.
 		expect( spy ).toHaveBeenCalledTimes( 1 );
@@ -476,29 +386,29 @@ describe( 'Navigator', () => {
 
 		render( <MyNavigation /> );
 
-		expect( getHomeScreen() ).toBeInTheDocument();
+		expect( getScreen( 'home' ) ).toBeInTheDocument();
 
 		// Navigate to child screen.
-		await user.click( getToChildScreenButton() );
+		await user.click( getNavigationButton( 'toChildScreen' ) );
 
-		expect( getChildScreen() ).toBeInTheDocument();
+		expect( getScreen( 'child' ) ).toBeInTheDocument();
 
 		// Navigate to nested screen.
-		await user.click( getToNestedScreenButton() );
+		await user.click( getNavigationButton( 'toNestedScreen' ) );
 
-		expect( getNestedScreen() ).toBeInTheDocument();
+		expect( getScreen( 'nested' ) ).toBeInTheDocument();
 
 		// Navigate back to child screen, check that focus was correctly restored.
-		await user.click( getBackButton() );
+		await user.click( getNavigationButton( 'back' ) );
 
-		expect( getChildScreen() ).toBeInTheDocument();
-		expect( getToNestedScreenButton() ).toHaveFocus();
+		expect( getScreen( 'child' ) ).toBeInTheDocument();
+		expect( getNavigationButton( 'toNestedScreen' ) ).toHaveFocus();
 
 		// Navigate back to home screen, check that focus was correctly restored.
-		await user.click( getBackButton() );
+		await user.click( getNavigationButton( 'back' ) );
 
-		expect( getHomeScreen() ).toBeInTheDocument();
-		expect( getToChildScreenButton() ).toHaveFocus();
+		expect( getScreen( 'home' ) ).toBeInTheDocument();
+		expect( getNavigationButton( 'toChildScreen' ) ).toHaveFocus();
 	} );
 
 	it( 'should escape the value of the `path` prop', async () => {
@@ -508,28 +418,31 @@ describe( 'Navigator', () => {
 
 		render( <MyNavigation /> );
 
-		expect( getHomeScreen() ).toBeInTheDocument();
-		expect( getToInvalidHTMLPathScreenButton() ).toBeInTheDocument();
+		expect( getScreen( 'home' ) ).toBeInTheDocument();
+		expect(
+			getNavigationButton( 'toInvalidHtmlPathScreen' )
+		).toBeInTheDocument();
 
 		// The following line tests the implementation details, but it's necessary
 		// as this would be otherwise transparent to the user.
-		expect( getToInvalidHTMLPathScreenButton() ).toHaveAttribute(
-			'id',
-			INVALID_HTML_ATTRIBUTE.escaped
-		);
+		expect(
+			getNavigationButton( 'toInvalidHtmlPathScreen' )
+		).toHaveAttribute( 'id', INVALID_HTML_ATTRIBUTE.escaped );
 
 		// Navigate to screen with an invalid HTML value for its `path`.
-		await user.click( getToInvalidHTMLPathScreenButton() );
+		await user.click( getNavigationButton( 'toInvalidHtmlPathScreen' ) );
 
-		expect( getInvalidHTMLPathScreen() ).toBeInTheDocument();
-		expect( getBackButton() ).toBeInTheDocument();
+		expect( getScreen( 'invalidHtmlPath' ) ).toBeInTheDocument();
+		expect( getNavigationButton( 'back' ) ).toBeInTheDocument();
 
 		// Navigate back to home screen, check that the focus restoration selector
 		// worked correctly despite the escaping.
-		await user.click( getBackButton() );
+		await user.click( getNavigationButton( 'back' ) );
 
-		expect( getHomeScreen() ).toBeInTheDocument();
-		expect( getToInvalidHTMLPathScreenButton() ).toHaveFocus();
+		expect( getScreen( 'home' ) ).toBeInTheDocument();
+		expect(
+			getNavigationButton( 'toInvalidHtmlPathScreen' )
+		).toHaveFocus();
 	} );
 
 	it( 'should keep focus on the element that is being interacted with, while re-rendering', async () => {
@@ -539,15 +452,15 @@ describe( 'Navigator', () => {
 
 		render( <MyNavigation /> );
 
-		expect( getHomeScreen() ).toBeInTheDocument();
-		expect( getToChildScreenButton() ).toBeInTheDocument();
+		expect( getScreen( 'home' ) ).toBeInTheDocument();
+		expect( getNavigationButton( 'toChildScreen' ) ).toBeInTheDocument();
 
 		// Navigate to child screen.
-		await user.click( getToChildScreenButton() );
+		await user.click( getNavigationButton( 'toChildScreen' ) );
 
-		expect( getChildScreen() ).toBeInTheDocument();
-		expect( getBackButton() ).toBeInTheDocument();
-		expect( getToNestedScreenButton() ).toHaveFocus();
+		expect( getScreen( 'child' ) ).toBeInTheDocument();
+		expect( getNavigationButton( 'back' ) ).toBeInTheDocument();
+		expect( getNavigationButton( 'toNestedScreen' ) ).toHaveFocus();
 
 		// Interact with the input, the focus should stay on the input element.
 		const input = screen.getByLabelText( 'This is a test input' );

--- a/packages/components/src/navigator/test/index.tsx
+++ b/packages/components/src/navigator/test/index.tsx
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import type { ReactNode, ForwardedRef } from 'react';
+import type { ReactNode, ForwardedRef, ComponentPropsWithoutRef } from 'react';
 import { render, screen, fireEvent } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 
@@ -54,7 +54,22 @@ const PATHS = {
 	NOT_FOUND: '/not-found',
 };
 
-function CustomNavigatorButton( { path, onClick, ...props } ) {
+type CustomTestOnClickHandler = (
+	args:
+		| {
+				type: 'goTo';
+				path: string;
+		  }
+		| { type: 'goBack' }
+) => void;
+
+function CustomNavigatorButton( {
+	path,
+	onClick,
+	...props
+}: Omit< ComponentPropsWithoutRef< typeof NavigatorButton >, 'onClick' > & {
+	onClick?: CustomTestOnClickHandler;
+} ) {
 	return (
 		<NavigatorButton
 			onClick={ () => {
@@ -71,6 +86,8 @@ function CustomNavigatorButtonWithFocusRestoration( {
 	path,
 	onClick,
 	...props
+}: Omit< ComponentPropsWithoutRef< typeof NavigatorButton >, 'onClick' > & {
+	onClick?: CustomTestOnClickHandler;
 } ) {
 	return (
 		<NavigatorButton
@@ -84,7 +101,12 @@ function CustomNavigatorButtonWithFocusRestoration( {
 	);
 }
 
-function CustomNavigatorBackButton( { onClick, ...props } ) {
+function CustomNavigatorBackButton( {
+	onClick,
+	...props
+}: Omit< ComponentPropsWithoutRef< typeof NavigatorBackButton >, 'onClick' > & {
+	onClick?: CustomTestOnClickHandler;
+} ) {
 	return (
 		<NavigatorBackButton
 			onClick={ () => {
@@ -99,6 +121,9 @@ function CustomNavigatorBackButton( { onClick, ...props } ) {
 const MyNavigation = ( {
 	initialPath = PATHS.HOME,
 	onNavigatorButtonClick,
+}: {
+	initialPath?: string;
+	onNavigatorButtonClick?: CustomTestOnClickHandler;
 } ) => {
 	const [ inputValue, setInputValue ] = useState( '' );
 	return (


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Converts `Navigator`'s unit tests to TypeScript, and refactors `fireEvent` usages to `user-event`

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

See #35744

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

The main change (apart from adding types) is a refactor of the getter helper function — I removed a layer of abstraction (which didn't let TypeScript infer certain types correctly) and thus simplified the code, while still keeping the tests very readable.

Reviewing the PR commit-by-commit may speed up the review process.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->

- Review code changes
- Make sure that unit tests still pass