### PR TITLE
PostPreviewButton: rewrite to functional, avoid state transitions in lifecycles

### DIFF
--- a/packages/block-editor/src/components/preview-options/README.md
+++ b/packages/block-editor/src/components/preview-options/README.md
@@ -28,23 +28,25 @@ const MyPreviewOptions = () => (
 		className="edit-post-post-preview-dropdown"
 		deviceType={ deviceType }
 		setDeviceType={ setPreviewDeviceType }
-	>
-		<MenuGroup>
-			<div className="edit-post-header-preview__grouping-external">
-				<PostPreviewButton
-					className={ 'edit-post-header-preview__button-external' }
-					role="menuitem"
-					forceIsAutosaveable={ hasActiveMetaboxes }
-					forcePreviewLink={ isSaving ? null : undefined }
-					textContent={
-						<>
-							{ __( 'Preview in new tab' ) }
-							<Icon icon={ external } />
-						</>
-					}
-				/>
-			</div>
-		</MenuGroup>
+	> { ( { onClose } ) => (
+			<MenuGroup>
+				<div className="edit-post-header-preview__grouping-external">
+					<PostPreviewButton
+						className="edit-post-header-preview__button-external"
+						role="menuitem"
+						forceIsAutosaveable={ hasActiveMetaboxes }
+						forcePreviewLink={ isSaving ? null : undefined }
+						textContent={
+							<>
+								{ __( 'Preview in new tab' ) }
+								<Icon icon={ external } />
+							</>
+						}
+						onPreview={ onClose }
+					/>
+				</div>
+			</MenuGroup>
+		) }
 	</PreviewOptions>
 );
 ```

--- a/packages/block-editor/src/components/preview-options/README.md
+++ b/packages/block-editor/src/components/preview-options/README.md
@@ -35,7 +35,6 @@ const MyPreviewOptions = () => (
 						className="edit-post-header-preview__button-external"
 						role="menuitem"
 						forceIsAutosaveable={ hasActiveMetaboxes }
-						forcePreviewLink={ isSaving ? null : undefined }
 						textContent={
 							<>
 								{ __( 'Preview in new tab' ) }

--- a/packages/block-editor/src/components/preview-options/index.js
+++ b/packages/block-editor/src/components/preview-options/index.js
@@ -54,7 +54,7 @@ export default function PreviewOptions( {
 			icon={ deviceIcons[ deviceType.toLowerCase() ] }
 			label={ label || __( 'Preview' ) }
 		>
-			{ () => (
+			{ ( renderProps ) => (
 				<>
 					<MenuGroup>
 						<MenuItem
@@ -79,7 +79,7 @@ export default function PreviewOptions( {
 							{ __( 'Mobile' ) }
 						</MenuItem>
 					</MenuGroup>
-					{ children }
+					{ children( renderProps ) }
 				</>
 			) }
 		</DropdownMenu>

--- a/packages/e2e-tests/specs/editor/various/publish-button.test.js
+++ b/packages/e2e-tests/specs/editor/various/publish-button.test.js
@@ -43,19 +43,4 @@ describe( 'PostPublishButton', () => {
 			await page.$( '.editor-post-publish-button[aria-disabled="true"]' )
 		).not.toBeNull();
 	} );
-
-	it( 'should be disabled when metabox is being saved', async () => {
-		await canvas().type( '.editor-post-title__input', 'E2E Test Post' ); // Make it saveable.
-		expect(
-			await page.$( '.editor-post-publish-button[aria-disabled="true"]' )
-		).toBeNull();
-
-		await page.evaluate( () => {
-			window.wp.data.dispatch( 'core/edit-post' ).requestMetaBoxUpdates();
-			return true;
-		} );
-		expect(
-			await page.$( '.editor-post-publish-button[aria-disabled="true"]' )
-		).not.toBeNull();
-	} );
 } );

--- a/packages/edit-post/src/components/device-preview/index.js
+++ b/packages/edit-post/src/components/device-preview/index.js
@@ -15,26 +15,22 @@ import { store as coreStore } from '@wordpress/core-data';
 import { store as editPostStore } from '../../store';
 
 export default function DevicePreview() {
-	const {
-		hasActiveMetaboxes,
-		isPostSaveable,
-		isSaving,
-		isViewable,
-		deviceType,
-	} = useSelect( ( select ) => {
-		const { getEditedPostAttribute } = select( editorStore );
-		const { getPostType } = select( coreStore );
-		const postType = getPostType( getEditedPostAttribute( 'type' ) );
+	const { hasActiveMetaboxes, isPostSaveable, isViewable, deviceType } =
+		useSelect( ( select ) => {
+			const { getEditedPostAttribute } = select( editorStore );
+			const { getPostType } = select( coreStore );
+			const postType = getPostType( getEditedPostAttribute( 'type' ) );
 
-		return {
-			hasActiveMetaboxes: select( editPostStore ).hasMetaBoxes(),
-			isSaving: select( editPostStore ).isSavingMetaBoxes(),
-			isPostSaveable: select( editorStore ).isEditedPostSaveable(),
-			isViewable: postType?.viewable ?? false,
-			deviceType:
-				select( editPostStore ).__experimentalGetPreviewDeviceType(),
-		};
-	}, [] );
+			return {
+				hasActiveMetaboxes: select( editPostStore ).hasMetaBoxes(),
+				isPostSaveable: select( editorStore ).isEditedPostSaveable(),
+				isViewable: postType?.viewable ?? false,
+				deviceType:
+					select(
+						editPostStore
+					).__experimentalGetPreviewDeviceType(),
+			};
+		}, [] );
 	const { __experimentalSetPreviewDeviceType: setPreviewDeviceType } =
 		useDispatch( editPostStore );
 
@@ -54,7 +50,6 @@ export default function DevicePreview() {
 								className="edit-post-header-preview__button-external"
 								role="menuitem"
 								forceIsAutosaveable={ hasActiveMetaboxes }
-								forcePreviewLink={ isSaving ? null : undefined }
 								textContent={
 									<>
 										{ __( 'Preview in new tab' ) }

--- a/packages/edit-post/src/components/device-preview/index.js
+++ b/packages/edit-post/src/components/device-preview/index.js
@@ -46,26 +46,27 @@ export default function DevicePreview() {
 			setDeviceType={ setPreviewDeviceType }
 			label={ __( 'Preview' ) }
 		>
-			{ isViewable && (
-				<MenuGroup>
-					<div className="edit-post-header-preview__grouping-external">
-						<PostPreviewButton
-							className={
-								'edit-post-header-preview__button-external'
-							}
-							role="menuitem"
-							forceIsAutosaveable={ hasActiveMetaboxes }
-							forcePreviewLink={ isSaving ? null : undefined }
-							textContent={
-								<>
-									{ __( 'Preview in new tab' ) }
-									<Icon icon={ external } />
-								</>
-							}
-						/>
-					</div>
-				</MenuGroup>
-			) }
+			{ ( { onClose } ) =>
+				isViewable && (
+					<MenuGroup>
+						<div className="edit-post-header-preview__grouping-external">
+							<PostPreviewButton
+								className="edit-post-header-preview__button-external"
+								role="menuitem"
+								forceIsAutosaveable={ hasActiveMetaboxes }
+								forcePreviewLink={ isSaving ? null : undefined }
+								textContent={
+									<>
+										{ __( 'Preview in new tab' ) }
+										<Icon icon={ external } />
+									</>
+								}
+								onPreview={ onClose }
+							/>
+						</div>
+					</MenuGroup>
+				)
+			}
 		</PreviewOptions>
 	);
 }

--- a/packages/edit-post/src/components/header/index.js
+++ b/packages/edit-post/src/components/header/index.js
@@ -32,22 +32,17 @@ const slideX = {
 
 function Header( { setEntitiesSavedStatesCallback } ) {
 	const isLargeViewport = useViewportMatch( 'large' );
-	const {
-		hasActiveMetaboxes,
-		isPublishSidebarOpened,
-		isSaving,
-		showIconLabels,
-	} = useSelect(
-		( select ) => ( {
-			hasActiveMetaboxes: select( editPostStore ).hasMetaBoxes(),
-			isPublishSidebarOpened:
-				select( editPostStore ).isPublishSidebarOpened(),
-			isSaving: select( editPostStore ).isSavingMetaBoxes(),
-			showIconLabels:
-				select( editPostStore ).isFeatureActive( 'showIconLabels' ),
-		} ),
-		[]
-	);
+	const { hasActiveMetaboxes, isPublishSidebarOpened, showIconLabels } =
+		useSelect(
+			( select ) => ( {
+				hasActiveMetaboxes: select( editPostStore ).hasMetaBoxes(),
+				isPublishSidebarOpened:
+					select( editPostStore ).isPublishSidebarOpened(),
+				showIconLabels:
+					select( editPostStore ).isFeatureActive( 'showIconLabels' ),
+			} ),
+			[]
+		);
 
 	return (
 		<div className="edit-post-header">
@@ -82,19 +77,14 @@ function Header( { setEntitiesSavedStatesCallback } ) {
 					// when the publish sidebar has been closed.
 					<PostSavedState
 						forceIsDirty={ hasActiveMetaboxes }
-						forceIsSaving={ isSaving }
 						showIconLabels={ showIconLabels }
 					/>
 				) }
 				<DevicePreview />
-				<PostPreviewButton
-					forceIsAutosaveable={ hasActiveMetaboxes }
-					forcePreviewLink={ isSaving ? null : undefined }
-				/>
+				<PostPreviewButton forceIsAutosaveable={ hasActiveMetaboxes } />
 				<ViewLink />
 				<PostPublishButtonOrToggle
 					forceIsDirty={ hasActiveMetaboxes }
-					forceIsSaving={ isSaving }
 					setEntitiesSavedStatesCallback={
 						setEntitiesSavedStatesCallback
 					}

--- a/packages/edit-post/src/components/header/post-publish-button-or-toggle.js
+++ b/packages/edit-post/src/components/header/post-publish-button-or-toggle.js
@@ -12,7 +12,6 @@ import { store as editPostStore } from '../../store';
 
 export function PostPublishButtonOrToggle( {
 	forceIsDirty,
-	forceIsSaving,
 	hasPublishAction,
 	isBeingScheduled,
 	isPending,
@@ -67,7 +66,6 @@ export function PostPublishButtonOrToggle( {
 	return (
 		<PostPublishButton
 			forceIsDirty={ forceIsDirty }
-			forceIsSaving={ forceIsSaving }
 			isOpen={ isPublishSidebarOpened }
 			isToggle={ component === IS_TOGGLE }
 			onToggle={ togglePublishSidebar }

--- a/packages/edit-post/src/components/layout/actions-panel.js
+++ b/packages/edit-post/src/components/layout/actions-panel.js
@@ -31,18 +31,17 @@ export default function ActionsPanel( {
 	const {
 		publishSidebarOpened,
 		hasActiveMetaboxes,
-		isSavingMetaBoxes,
 		hasNonPostEntityChanges,
-	} = useSelect( ( select ) => {
-		return {
+	} = useSelect(
+		( select ) => ( {
 			publishSidebarOpened:
 				select( editPostStore ).isPublishSidebarOpened(),
 			hasActiveMetaboxes: select( editPostStore ).hasMetaBoxes(),
-			isSavingMetaBoxes: select( editPostStore ).isSavingMetaBoxes(),
 			hasNonPostEntityChanges:
 				select( editorStore ).hasNonPostEntityChanges(),
-		};
-	}, [] );
+		} ),
+		[]
+	);
 
 	const openEntitiesSavedStates = useCallback(
 		() => setEntitiesSavedStatesCallback( true ),
@@ -57,7 +56,6 @@ export default function ActionsPanel( {
 			<PostPublishPanel
 				onClose={ closePublishSidebar }
 				forceIsDirty={ hasActiveMetaboxes }
-				forceIsSaving={ isSavingMetaBoxes }
 				PrePublishExtension={ PluginPrePublishPanel.Slot }
 				PostPublishExtension={ PluginPostPublishPanel.Slot }
 			/>

--- a/packages/edit-post/src/store/actions.js
+++ b/packages/edit-post/src/store/actions.js
@@ -11,6 +11,7 @@ import { store as coreStore } from '@wordpress/core-data';
 import { store as blockEditorStore } from '@wordpress/block-editor';
 import { store as editorStore } from '@wordpress/editor';
 import deprecated from '@wordpress/deprecated';
+import { addFilter } from '@wordpress/hooks';
 
 /**
  * Internal dependencies
@@ -567,33 +568,23 @@ export const initializeMetaBoxes =
 
 		metaBoxesInitialized = true;
 
-		let wasSavingPost = registry.select( editorStore ).isSavingPost();
-		let wasAutosavingPost = registry
-			.select( editorStore )
-			.isAutosavingPost();
+		// Save metaboxes on save completion, except for autosaves.
+		addFilter(
+			'editor.SavePost',
+			'core/edit-post/save-metaboxes',
+			( previous, options ) =>
+				previous.then( () => {
+					if ( options.isAutosave ) {
+						return;
+					}
 
-		// Save metaboxes when performing a full save on the post.
-		registry.subscribe( async () => {
-			const isSavingPost = registry.select( editorStore ).isSavingPost();
-			const isAutosavingPost = registry
-				.select( editorStore )
-				.isAutosavingPost();
+					if ( ! select.hasMetaBoxes() ) {
+						return;
+					}
 
-			// Save metaboxes on save completion, except for autosaves.
-			const shouldTriggerMetaboxesSave =
-				wasSavingPost &&
-				! wasAutosavingPost &&
-				! isSavingPost &&
-				select.hasMetaBoxes();
-
-			// Save current state for next inspection.
-			wasSavingPost = isSavingPost;
-			wasAutosavingPost = isAutosavingPost;
-
-			if ( shouldTriggerMetaboxesSave ) {
-				await dispatch.requestMetaBoxUpdates();
-			}
-		} );
+					return dispatch.requestMetaBoxUpdates();
+				} )
+		);
 
 		dispatch( {
 			type: 'META_BOXES_INITIALIZED',

--- a/packages/edit-post/src/store/actions.js
+++ b/packages/edit-post/src/store/actions.js
@@ -570,7 +570,7 @@ export const initializeMetaBoxes =
 
 		// Save metaboxes on save completion, except for autosaves.
 		addFilter(
-			'editor.SavePost',
+			'editor.__unstableSavePost',
 			'core/edit-post/save-metaboxes',
 			( previous, options ) =>
 				previous.then( () => {

--- a/packages/edit-site/src/components/header-edit-mode/index.js
+++ b/packages/edit-site/src/components/header-edit-mode/index.js
@@ -323,21 +323,24 @@ export default function HeaderEditMode() {
 								setDeviceType={ setPreviewDeviceType }
 								label={ __( 'View' ) }
 							>
-								<MenuGroup>
-									<MenuItem
-										href={ homeUrl }
-										target="_blank"
-										icon={ external }
-									>
-										{ __( 'View site' ) }
-										<VisuallyHidden as="span">
-											{
-												/* translators: accessibility text */
-												__( '(opens in a new tab)' )
-											}
-										</VisuallyHidden>
-									</MenuItem>
-								</MenuGroup>
+								{ ( { onClose } ) => (
+									<MenuGroup>
+										<MenuItem
+											href={ homeUrl }
+											target="_blank"
+											icon={ external }
+											onClick={ onClose }
+										>
+											{ __( 'View site' ) }
+											<VisuallyHidden as="span">
+												{
+													/* translators: accessibility text */
+													__( '(opens in a new tab)' )
+												}
+											</VisuallyHidden>
+										</MenuItem>
+									</MenuGroup>
+								) }
 							</PreviewOptions>
 						</div>
 					) }

--- a/packages/editor/src/components/post-preview-button/index.js
+++ b/packages/editor/src/components/post-preview-button/index.js
@@ -105,6 +105,7 @@ function PostPreviewButton( {
 	forceIsAutosaveable,
 	forcePreviewLink,
 	role,
+	onPreview,
 } ) {
 	const { postId, currentPostLink, previewLink, isSaveable, isViewable } =
 		useSelect(
@@ -162,6 +163,8 @@ function PostPreviewButton( {
 		} );
 
 		previewWindow.location = link;
+
+		onPreview?.();
 	};
 
 	// Link to the `?preview=true` URL if we have it, since this lets us see

--- a/packages/editor/src/components/post-preview-button/index.js
+++ b/packages/editor/src/components/post-preview-button/index.js
@@ -99,7 +99,7 @@ function writeInterstitialMessage( targetDocument ) {
 	targetDocument.close();
 }
 
-function PostPreviewButton( {
+export default function PostPreviewButton( {
 	className,
 	textContent,
 	forceIsAutosaveable,
@@ -112,7 +112,7 @@ function PostPreviewButton( {
 			const core = select( coreStore );
 
 			const postType = core.getPostType(
-				editor.getEditedPostAttribute( 'type' )
+				editor.getCurrentPostType( 'type' )
 			);
 
 			return {
@@ -186,5 +186,3 @@ function PostPreviewButton( {
 		</Button>
 	);
 }
-
-export default PostPreviewButton;

--- a/packages/editor/src/components/post-preview-button/index.js
+++ b/packages/editor/src/components/post-preview-button/index.js
@@ -103,33 +103,26 @@ function PostPreviewButton( {
 	className,
 	textContent,
 	forceIsAutosaveable,
-	forcePreviewLink,
 	role,
 	onPreview,
 } ) {
 	const { postId, currentPostLink, previewLink, isSaveable, isViewable } =
-		useSelect(
-			( select ) => {
-				const editor = select( editorStore );
-				const core = select( coreStore );
+		useSelect( ( select ) => {
+			const editor = select( editorStore );
+			const core = select( coreStore );
 
-				const postType = core.getPostType(
-					editor.getEditedPostAttribute( 'type' )
-				);
+			const postType = core.getPostType(
+				editor.getEditedPostAttribute( 'type' )
+			);
 
-				return {
-					postId: editor.getCurrentPostId(),
-					currentPostLink: editor.getCurrentPostAttribute( 'link' ),
-					previewLink:
-						forcePreviewLink !== undefined
-							? forcePreviewLink
-							: editor.getEditedPostPreviewLink(),
-					isSaveable: editor.isEditedPostSaveable(),
-					isViewable: postType?.viewable ?? false,
-				};
-			},
-			[ forcePreviewLink ]
-		);
+			return {
+				postId: editor.getCurrentPostId(),
+				currentPostLink: editor.getCurrentPostAttribute( 'link' ),
+				previewLink: editor.getEditedPostPreviewLink(),
+				isSaveable: editor.isEditedPostSaveable(),
+				isViewable: postType?.viewable ?? false,
+			};
+		}, [] );
 
 	const { __unstableSaveForPreview } = useDispatch( editorStore );
 
@@ -157,10 +150,7 @@ function PostPreviewButton( {
 
 		writeInterstitialMessage( previewWindow.document );
 
-		const link = await __unstableSaveForPreview( {
-			forcePreviewLink,
-			forceIsAutosaveable,
-		} );
+		const link = await __unstableSaveForPreview( { forceIsAutosaveable } );
 
 		previewWindow.location = link;
 

--- a/packages/editor/src/components/post-preview-button/index.js
+++ b/packages/editor/src/components/post-preview-button/index.js
@@ -1,16 +1,10 @@
 /**
- * External dependencies
- */
-import classnames from 'classnames';
-
-/**
  * WordPress dependencies
  */
-import { Component, createRef, renderToString } from '@wordpress/element';
+import { renderToString } from '@wordpress/element';
 import { Button, Path, SVG, VisuallyHidden } from '@wordpress/components';
 import { __, _x } from '@wordpress/i18n';
-import { withSelect, withDispatch } from '@wordpress/data';
-import { ifCondition, compose } from '@wordpress/compose';
+import { useSelect, useDispatch } from '@wordpress/data';
 import { applyFilters } from '@wordpress/hooks';
 import { store as coreStore } from '@wordpress/core-data';
 
@@ -105,48 +99,46 @@ function writeInterstitialMessage( targetDocument ) {
 	targetDocument.close();
 }
 
-export class PostPreviewButton extends Component {
-	constructor() {
-		super( ...arguments );
+function PostPreviewButton( {
+	className,
+	textContent,
+	forceIsAutosaveable,
+	forcePreviewLink,
+	role,
+} ) {
+	const { postId, currentPostLink, previewLink, isSaveable, isViewable } =
+		useSelect(
+			( select ) => {
+				const editor = select( editorStore );
+				const core = select( coreStore );
 
-		this.buttonRef = createRef();
+				const postType = core.getPostType(
+					editor.getEditedPostAttribute( 'type' )
+				);
 
-		this.openPreviewWindow = this.openPreviewWindow.bind( this );
+				return {
+					postId: editor.getCurrentPostId(),
+					currentPostLink: editor.getCurrentPostAttribute( 'link' ),
+					previewLink:
+						forcePreviewLink !== undefined
+							? forcePreviewLink
+							: editor.getEditedPostPreviewLink(),
+					isSaveable: editor.isEditedPostSaveable(),
+					isViewable: postType?.viewable ?? false,
+				};
+			},
+			[ forcePreviewLink ]
+		);
+
+	const { __unstableSaveForPreview } = useDispatch( editorStore );
+
+	if ( ! isViewable ) {
+		return null;
 	}
 
-	componentDidUpdate( prevProps ) {
-		const { previewLink } = this.props;
-		// This relies on the window being responsible to unset itself when
-		// navigation occurs or a new preview window is opened, to avoid
-		// unintentional forceful redirects.
-		if ( previewLink && ! prevProps.previewLink ) {
-			this.setPreviewWindowLink( previewLink );
-		}
-	}
+	const targetId = `wp-preview-${ postId }`;
 
-	/**
-	 * Sets the preview window's location to the given URL, if a preview window
-	 * exists and is not closed.
-	 *
-	 * @param {string} url URL to assign as preview window location.
-	 */
-	setPreviewWindowLink( url ) {
-		const { previewWindow } = this;
-
-		if ( previewWindow && ! previewWindow.closed ) {
-			previewWindow.location = url;
-			if ( this.buttonRef.current ) {
-				this.buttonRef.current.focus();
-			}
-		}
-	}
-
-	getWindowTarget() {
-		const { postId } = this.props;
-		return `wp-preview-${ postId }`;
-	}
-
-	openPreviewWindow( event ) {
+	const openPreviewWindow = async ( event ) => {
 		// Our Preview button has its 'href' and 'target' set correctly for a11y
 		// purposes. Unfortunately, though, we can't rely on the default 'click'
 		// handler since sometimes it incorrectly opens a new tab instead of reusing
@@ -155,117 +147,51 @@ export class PostPreviewButton extends Component {
 		event.preventDefault();
 
 		// Open up a Preview tab if needed. This is where we'll show the preview.
-		if ( ! this.previewWindow || this.previewWindow.closed ) {
-			this.previewWindow = window.open( '', this.getWindowTarget() );
-		}
+		const previewWindow = window.open( '', targetId );
 
 		// Focus the Preview tab. This might not do anything, depending on the browser's
 		// and user's preferences.
 		// https://html.spec.whatwg.org/multipage/interaction.html#dom-window-focus
-		this.previewWindow.focus();
+		previewWindow.focus();
 
-		if (
-			// If we don't need to autosave the post before previewing, then we simply
-			// load the Preview URL in the Preview tab.
-			! this.props.isAutosaveable ||
-			// Do not save or overwrite the post, if the post is already locked.
-			this.props.isPostLocked
-		) {
-			this.setPreviewWindowLink( event.target.href );
-			return;
-		}
+		writeInterstitialMessage( previewWindow.document );
 
-		// Request an autosave. This happens asynchronously and causes the component
-		// to update when finished.
-		if ( this.props.isDraft ) {
-			this.props.savePost( { isPreview: true } );
-		} else {
-			this.props.autosave( { isPreview: true } );
-		}
+		const link = await __unstableSaveForPreview( {
+			forcePreviewLink,
+			forceIsAutosaveable,
+		} );
 
-		// Display a 'Generating preview' message in the Preview tab while we wait for the
-		// autosave to finish.
-		writeInterstitialMessage( this.previewWindow.document );
-	}
+		previewWindow.location = link;
+	};
 
-	render() {
-		const { previewLink, currentPostLink, isSaveable, role } = this.props;
+	// Link to the `?preview=true` URL if we have it, since this lets us see
+	// changes that were autosaved since the post was last published. Otherwise,
+	// just link to the post's URL.
+	const href = previewLink || currentPostLink;
 
-		// Link to the `?preview=true` URL if we have it, since this lets us see
-		// changes that were autosaved since the post was last published. Otherwise,
-		// just link to the post's URL.
-		const href = previewLink || currentPostLink;
-
-		const classNames = classnames(
-			{
-				'editor-post-preview': ! this.props.className,
-			},
-			this.props.className
-		);
-
-		return (
-			<Button
-				variant={ ! this.props.className ? 'tertiary' : undefined }
-				className={ classNames }
-				href={ href }
-				target={ this.getWindowTarget() }
-				disabled={ ! isSaveable }
-				onClick={ this.openPreviewWindow }
-				ref={ this.buttonRef }
-				role={ role }
-			>
-				{ this.props.textContent ? (
-					this.props.textContent
-				) : (
-					<>
-						{ _x( 'Preview', 'imperative verb' ) }
-						<VisuallyHidden as="span">
-							{
-								/* translators: accessibility text */
-								__( '(opens in a new tab)' )
-							}
-						</VisuallyHidden>
-					</>
-				) }
-			</Button>
-		);
-	}
+	return (
+		<Button
+			variant={ ! className ? 'tertiary' : undefined }
+			className={ className || 'editor-post-preview' }
+			href={ href }
+			target={ targetId }
+			disabled={ ! isSaveable }
+			onClick={ openPreviewWindow }
+			role={ role }
+		>
+			{ textContent || (
+				<>
+					{ _x( 'Preview', 'imperative verb' ) }
+					<VisuallyHidden as="span">
+						{
+							/* translators: accessibility text */
+							__( '(opens in a new tab)' )
+						}
+					</VisuallyHidden>
+				</>
+			) }
+		</Button>
+	);
 }
 
-export default compose( [
-	withSelect( ( select, { forcePreviewLink, forceIsAutosaveable } ) => {
-		const {
-			getCurrentPostId,
-			getCurrentPostAttribute,
-			getEditedPostAttribute,
-			isEditedPostSaveable,
-			isEditedPostAutosaveable,
-			getEditedPostPreviewLink,
-			isPostLocked,
-		} = select( editorStore );
-		const { getPostType } = select( coreStore );
-
-		const previewLink = getEditedPostPreviewLink();
-		const postType = getPostType( getEditedPostAttribute( 'type' ) );
-
-		return {
-			postId: getCurrentPostId(),
-			currentPostLink: getCurrentPostAttribute( 'link' ),
-			previewLink:
-				forcePreviewLink !== undefined ? forcePreviewLink : previewLink,
-			isSaveable: isEditedPostSaveable(),
-			isAutosaveable: forceIsAutosaveable || isEditedPostAutosaveable(),
-			isViewable: postType?.viewable ?? false,
-			isDraft:
-				[ 'draft', 'auto-draft' ].indexOf(
-					getEditedPostAttribute( 'status' )
-				) !== -1,
-			isPostLocked: isPostLocked(),
-		};
-	} ),
-	withDispatch( ( dispatch ) => ( {
-		autosave: dispatch( editorStore ).autosave,
-		savePost: dispatch( editorStore ).savePost,
-	} ) ),
-	ifCondition( ( { isViewable } ) => isViewable ),
-] )( PostPreviewButton );
+export default PostPreviewButton;

--- a/packages/editor/src/components/post-preview-button/test/index.js
+++ b/packages/editor/src/components/post-preview-button/test/index.js
@@ -5,9 +5,38 @@ import { render, screen, within } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 
 /**
+ * WordPress dependencies
+ */
+import { useSelect, useDispatch } from '@wordpress/data';
+
+/**
  * Internal dependencies
  */
-import { PostPreviewButton } from '../';
+import PostPreviewButton from '..';
+
+jest.useRealTimers();
+
+jest.mock( '@wordpress/data/src/components/use-select', () => jest.fn() );
+jest.mock( '@wordpress/data/src/components/use-dispatch/use-dispatch', () =>
+	jest.fn()
+);
+
+function mockUseSelect( overrides ) {
+	useSelect.mockImplementation( ( map ) =>
+		map( () => ( {
+			getPostType: () => ( { viewable: true } ),
+			getCurrentPostId: () => 123,
+			getCurrentPostType: () => 'post',
+			getCurrentPostAttribute: () => undefined,
+			getEditedPostPreviewLink: () => undefined,
+			isEditedPostSaveable: () => false,
+			...overrides,
+		} ) )
+	);
+	useDispatch.mockImplementation( () => ( {
+		__unstableSaveForPreview: () => Promise.resolve(),
+	} ) );
+}
 
 describe( 'PostPreviewButton', () => {
 	const documentWrite = jest.fn();
@@ -42,33 +71,39 @@ describe( 'PostPreviewButton', () => {
 	} );
 
 	it( 'should render with `editor-post-preview` class if no `className` is specified.', () => {
+		mockUseSelect();
+
 		render( <PostPreviewButton /> );
 
-		expect( screen.getByRole( 'button' ) ).toHaveClass(
-			'editor-post-preview'
-		);
+		const button = screen.getByRole( 'button' );
+		expect( button ).toHaveClass( 'editor-post-preview' );
 	} );
 
 	it( 'should render with a custom class and not `editor-post-preview` if `className` is specified.', () => {
+		mockUseSelect();
+
 		render( <PostPreviewButton className="foo-bar" /> );
 
 		const button = screen.getByRole( 'button' );
-
 		expect( button ).toHaveClass( 'foo-bar' );
 		expect( button ).not.toHaveClass( 'editor-post-preview' );
 	} );
 
 	it( 'should render a tertiary button if no classname is specified.', () => {
+		mockUseSelect();
+
 		render( <PostPreviewButton /> );
 
-		expect( screen.getByRole( 'button' ) ).toHaveClass( 'is-tertiary' );
+		const button = screen.getByRole( 'button' );
+		expect( button ).toHaveClass( 'is-tertiary' );
 	} );
 
 	it( 'should render the button in its default variant if a custom classname is specified.', () => {
+		mockUseSelect();
+
 		render( <PostPreviewButton className="foo-bar" /> );
 
 		const button = screen.getByRole( 'button' );
-
 		expect( button ).not.toHaveClass( 'is-primary' );
 		expect( button ).not.toHaveClass( 'is-secondary' );
 		expect( button ).not.toHaveClass( 'is-tertiary' );
@@ -76,12 +111,13 @@ describe( 'PostPreviewButton', () => {
 	} );
 
 	it( 'should render `textContent` if specified.', () => {
+		mockUseSelect();
+
 		const textContent = 'Foo bar';
 
 		render( <PostPreviewButton textContent={ textContent } /> );
 
 		const button = screen.getByRole( 'button' );
-
 		expect( button ).toHaveTextContent( textContent );
 		expect(
 			within( button ).queryByText( 'Preview' )
@@ -92,213 +128,113 @@ describe( 'PostPreviewButton', () => {
 	} );
 
 	it( 'should render `Preview` with accessibility text if `textContent` not specified.', () => {
+		mockUseSelect();
+
 		render( <PostPreviewButton /> );
 
 		const button = screen.getByRole( 'button' );
-
 		expect( within( button ).getByText( 'Preview' ) ).toBeVisible();
 		expect(
 			within( button ).getByText( '(opens in a new tab)' )
 		).toBeInTheDocument();
 	} );
 
-	it( 'should be disabled if post is not saveable.', async () => {
-		render( <PostPreviewButton isSaveable={ false } postId={ 123 } /> );
+	it( 'should be disabled if post is not saveable.', () => {
+		mockUseSelect( { isEditedPostSaveable: () => false } );
+
+		render( <PostPreviewButton /> );
 
 		expect( screen.getByRole( 'button' ) ).toBeDisabled();
 	} );
 
-	it( 'should not be disabled if post is saveable.', async () => {
-		render( <PostPreviewButton isSaveable postId={ 123 } /> );
+	it( 'should not be disabled if post is saveable.', () => {
+		mockUseSelect( { isEditedPostSaveable: () => true } );
+
+		render( <PostPreviewButton /> );
 
 		expect( screen.getByRole( 'button' ) ).toBeEnabled();
 	} );
 
-	it( 'should set `href` to `previewLink` if `previewLink` is specified.', async () => {
+	it( 'should set `href` to edited post preview link if specified.', () => {
 		const url = 'https://wordpress.org';
+		mockUseSelect( {
+			getEditedPostPreviewLink: () => url,
+			isEditedPostSaveable: () => true,
+		} );
 
-		render(
-			<PostPreviewButton isSaveable postId={ 123 } previewLink={ url } />
-		);
+		render( <PostPreviewButton /> );
 
 		expect( screen.getByRole( 'link' ) ).toHaveAttribute( 'href', url );
 	} );
 
-	it( 'should set `href` to `currentPostLink` if `currentPostLink` is specified.', async () => {
+	it( 'should set `href` to current post link if specified.', () => {
 		const url = 'https://wordpress.org';
+		mockUseSelect( {
+			getCurrentPostAttribute: () => url,
+			isEditedPostSaveable: () => true,
+		} );
 
-		render(
-			<PostPreviewButton
-				isSaveable
-				postId={ 123 }
-				currentPostLink={ url }
-			/>
-		);
+		render( <PostPreviewButton /> );
 
 		expect( screen.getByRole( 'link' ) ).toHaveAttribute( 'href', url );
 	} );
 
-	it( 'should prioritize `previewLink` if both `previewLink` and `currentPostLink` are specified.', async () => {
+	it( 'should prioritize preview link if both preview link and link attribute are specified.', () => {
 		const url1 = 'https://wordpress.org';
 		const url2 = 'https://wordpress.com';
+		mockUseSelect( {
+			getEditedPostPreviewLink: () => url1,
+			getCurrentPostAttribute: () => url2,
+			isEditedPostSaveable: () => true,
+		} );
 
-		render(
-			<PostPreviewButton
-				isSaveable
-				postId={ 123 }
-				previewLink={ url1 }
-				currentPostLink={ url2 }
-			/>
-		);
+		render( <PostPreviewButton /> );
 
 		expect( screen.getByRole( 'link' ) ).toHaveAttribute( 'href', url1 );
 	} );
 
-	it( 'should properly set target to `wp-preview-${ postId }`.', async () => {
-		const postId = 123;
-		const url = 'https://wordpress.org';
+	it( 'should properly set link target', () => {
+		mockUseSelect( {
+			getEditedPostPreviewLink: () => 'https://wordpress.org',
+			isEditedPostSaveable: () => true,
+		} );
 
-		render(
-			<PostPreviewButton
-				isSaveable
-				postId={ postId }
-				previewLink={ url }
-			/>
-		);
+		render( <PostPreviewButton /> );
 
 		expect( screen.getByRole( 'link' ) ).toHaveAttribute(
 			'target',
-			`wp-preview-${ postId }`
-		);
-	} );
-
-	it( 'should save post if `isDraft` is `true`', async () => {
-		const user = userEvent.setup();
-		const url = 'https://wordpress.org';
-		const savePost = jest.fn();
-		const autosave = jest.fn();
-
-		render(
-			<PostPreviewButton
-				isAutosaveable
-				isSaveable
-				isDraft
-				postId={ 123 }
-				previewLink={ url }
-				savePost={ savePost }
-				autosave={ autosave }
-			/>
-		);
-
-		await user.click( screen.getByRole( 'link' ) );
-
-		expect( savePost ).toHaveBeenCalledWith(
-			expect.objectContaining( { isPreview: true } )
-		);
-		expect( autosave ).not.toHaveBeenCalled();
-	} );
-
-	it( 'should autosave post if `isDraft` is `false`', async () => {
-		const user = userEvent.setup();
-		const url = 'https://wordpress.org';
-		const savePost = jest.fn();
-		const autosave = jest.fn();
-
-		render(
-			<PostPreviewButton
-				isAutosaveable
-				isSaveable
-				isDraft={ false }
-				postId={ 123 }
-				previewLink={ url }
-				savePost={ savePost }
-				autosave={ autosave }
-			/>
-		);
-
-		await user.click( screen.getByRole( 'link' ) );
-
-		expect( savePost ).not.toHaveBeenCalled();
-		expect( autosave ).toHaveBeenCalledWith(
-			expect.objectContaining( { isPreview: true } )
+			'wp-preview-123'
 		);
 	} );
 
 	it( 'should open a window with the specified target', async () => {
 		const user = userEvent.setup();
-		const postId = 123;
-		const url = 'https://wordpress.org';
 
-		render(
-			<PostPreviewButton
-				isAutosaveable
-				isSaveable
-				postId={ postId }
-				previewLink={ url }
-				savePost={ jest.fn() }
-				autosave={ jest.fn() }
-			/>
-		);
+		mockUseSelect( {
+			getEditedPostPreviewLink: () => 'https://wordpress.org',
+			isEditedPostSaveable: () => true,
+		} );
+
+		render( <PostPreviewButton /> );
 
 		await user.click( screen.getByRole( 'link' ) );
 
-		expect( global.open ).toHaveBeenCalledWith(
-			'',
-			`wp-preview-${ postId }`
-		);
-	} );
-
-	it( 'should set the location in the window properly', async () => {
-		const user = userEvent.setup();
-		const postId = 123;
-		const url = 'https://wordpress.org';
-
-		const { rerender } = render(
-			<PostPreviewButton
-				isSaveable
-				postId={ postId }
-				savePost={ jest.fn() }
-				autosave={ jest.fn() }
-			/>
-		);
-
-		await user.click( screen.getByRole( 'button' ) );
-
-		expect( setLocation ).toHaveBeenCalledWith( undefined );
-
-		rerender(
-			<PostPreviewButton
-				isSaveable
-				postId={ postId }
-				previewLink={ url }
-				savePost={ jest.fn() }
-				autosave={ jest.fn() }
-			/>
-		);
-
-		expect( setLocation ).toHaveBeenCalledWith( url );
+		expect( global.open ).toHaveBeenCalledWith( '', 'wp-preview-123' );
 	} );
 
 	it( 'should display a `Generating preview` message while waiting for autosaving', async () => {
 		const user = userEvent.setup();
-		const previewText = 'Generating preview…';
-		const url = 'https://wordpress.org';
-		const savePost = jest.fn();
-		const autosave = jest.fn();
 
-		render(
-			<PostPreviewButton
-				isAutosaveable
-				isSaveable
-				isDraft={ false }
-				postId={ 123 }
-				previewLink={ url }
-				savePost={ savePost }
-				autosave={ autosave }
-			/>
-		);
+		mockUseSelect( {
+			getEditedPostPreviewLink: () => 'https://wordpress.org',
+			isEditedPostSaveable: () => true,
+		} );
+
+		render( <PostPreviewButton /> );
 
 		await user.click( screen.getByRole( 'link' ) );
+
+		const previewText = 'Generating preview…';
 
 		expect( documentWrite ).toHaveBeenCalledWith(
 			expect.stringContaining( previewText )

--- a/packages/editor/src/components/post-publish-button/index.js
+++ b/packages/editor/src/components/post-publish-button/index.js
@@ -102,7 +102,6 @@ export class PostPublishButton extends Component {
 	render() {
 		const {
 			forceIsDirty,
-			forceIsSaving,
 			hasPublishAction,
 			isBeingScheduled,
 			isOpen,
@@ -124,7 +123,6 @@ export class PostPublishButton extends Component {
 
 		const isButtonDisabled =
 			( isSaving ||
-				forceIsSaving ||
 				! isSaveable ||
 				isPostSavingLocked ||
 				( ! isPublishable && ! forceIsDirty ) ) &&
@@ -133,7 +131,6 @@ export class PostPublishButton extends Component {
 		const isToggleDisabled =
 			( isPublished ||
 				isSaving ||
-				forceIsSaving ||
 				! isSaveable ||
 				( ! isPublishable && ! forceIsDirty ) ) &&
 			( ! hasNonPostEntityChanges || isSavingNonPostEntityChanges );
@@ -187,7 +184,6 @@ export class PostPublishButton extends Component {
 			: __( 'Publish' );
 		const buttonChildren = (
 			<PublishButtonLabel
-				forceIsSaving={ forceIsSaving }
 				hasNonPostEntityChanges={ hasNonPostEntityChanges }
 			/>
 		);
@@ -231,10 +227,9 @@ export default compose( [
 			hasNonPostEntityChanges,
 			isSavingNonPostEntityChanges,
 		} = select( editorStore );
-		const _isAutoSaving = isAutosavingPost();
 		return {
-			isSaving: isSavingPost() || _isAutoSaving,
-			isAutoSaving: _isAutoSaving,
+			isSaving: isSavingPost(),
+			isAutoSaving: isAutosavingPost(),
 			isBeingScheduled: isEditedPostBeingScheduled(),
 			visibility: getEditedPostVisibility(),
 			isSaveable: isEditedPostSaveable(),

--- a/packages/editor/src/components/post-publish-button/label.js
+++ b/packages/editor/src/components/post-publish-button/label.js
@@ -44,7 +44,7 @@ export function PublishButtonLabel( {
 }
 
 export default compose( [
-	withSelect( ( select, { forceIsSaving } ) => {
+	withSelect( ( select ) => {
 		const {
 			isCurrentPostPublished,
 			isEditedPostBeingScheduled,
@@ -57,7 +57,7 @@ export default compose( [
 		return {
 			isPublished: isCurrentPostPublished(),
 			isBeingScheduled: isEditedPostBeingScheduled(),
-			isSaving: forceIsSaving || isSavingPost(),
+			isSaving: isSavingPost(),
 			isPublishing: isPublishingPost(),
 			hasPublishAction:
 				getCurrentPost()._links?.[ 'wp:action-publish' ] ?? false,

--- a/packages/editor/src/components/post-publish-button/test/index.js
+++ b/packages/editor/src/components/post-publish-button/test/index.js
@@ -19,16 +19,6 @@ describe( 'PostPublishButton', () => {
 			).toHaveAttribute( 'aria-disabled', 'true' );
 		} );
 
-		it( 'should be true if forceIsSaving is true', () => {
-			render(
-				<PostPublishButton isPublishable isSaveable forceIsSaving />
-			);
-
-			expect(
-				screen.getByRole( 'button', { name: 'Submit for Review' } )
-			).toHaveAttribute( 'aria-disabled', 'true' );
-		} );
-
 		it( 'should be true if post is not publishable and not forceIsDirty', () => {
 			render(
 				<PostPublishButton

--- a/packages/editor/src/components/post-publish-panel/index.js
+++ b/packages/editor/src/components/post-publish-panel/index.js
@@ -51,7 +51,6 @@ export class PostPublishPanel extends Component {
 	render() {
 		const {
 			forceIsDirty,
-			forceIsSaving,
 			isBeingScheduled,
 			isPublished,
 			isPublishSidebarEnabled,
@@ -87,10 +86,9 @@ export class PostPublishPanel extends Component {
 						<>
 							<div className="editor-post-publish-panel__header-publish-button">
 								<PostPublishButton
-									focusOnMount={ true }
+									focusOnMount
 									onSubmit={ this.onSubmit }
 									forceIsDirty={ forceIsDirty }
-									forceIsSaving={ forceIsSaving }
 								/>
 							</div>
 							<div className="editor-post-publish-panel__header-cancel-button">

--- a/packages/editor/src/components/post-saved-state/index.js
+++ b/packages/editor/src/components/post-saved-state/index.js
@@ -29,14 +29,11 @@ import { store as editorStore } from '../../store';
  * @param {Object}   props                Component props.
  * @param {?boolean} props.forceIsDirty   Whether to force the post to be marked
  *                                        as dirty.
- * @param {?boolean} props.forceIsSaving  Whether to force the post to be marked
- *                                        as being saved.
  * @param {?boolean} props.showIconLabels Whether interface buttons show labels instead of icons
  * @return {import('@wordpress/element').WPComponent} The component.
  */
 export default function PostSavedState( {
 	forceIsDirty,
-	forceIsSaving,
 	showIconLabels = false,
 } ) {
 	const [ forceSavedMessage, setForceSavedMessage ] = useState( false );
@@ -72,14 +69,14 @@ export default function PostSavedState( {
 				isNew: isEditedPostNew(),
 				isPending: 'pending' === getEditedPostAttribute( 'status' ),
 				isPublished: isCurrentPostPublished(),
-				isSaving: forceIsSaving || isSavingPost(),
+				isSaving: isSavingPost(),
 				isSaveable: isEditedPostSaveable(),
 				isScheduled: isCurrentPostScheduled(),
 				hasPublishAction:
 					getCurrentPost()?._links?.[ 'wp:action-publish' ] ?? false,
 			};
 		},
-		[ forceIsDirty, forceIsSaving ]
+		[ forceIsDirty ]
 	);
 
 	const { savePost } = useDispatch( editorStore );

--- a/packages/editor/src/store/actions.js
+++ b/packages/editor/src/store/actions.js
@@ -189,7 +189,7 @@ export const savePost =
 
 		if ( ! error ) {
 			await applyFilters(
-				'editor.SavePost',
+				'editor.__unstableSavePost',
 				Promise.resolve(),
 				options
 			).catch( ( err ) => {

--- a/packages/editor/src/store/actions.js
+++ b/packages/editor/src/store/actions.js
@@ -289,6 +289,26 @@ export const autosave =
 		}
 	};
 
+export const __unstableSaveForPreview =
+	( { forceIsAutosaveable, forcePreviewLink } ) =>
+	async ( { select, dispatch } ) => {
+		if (
+			( forceIsAutosaveable || select.isEditedPostAutosaveable() ) &&
+			! select.isPostLocked()
+		) {
+			const isDraft = [ 'draft', 'auto-draft' ].includes(
+				select.getEditedPostAttribute( 'status' )
+			);
+			if ( isDraft ) {
+				await dispatch.savePost( { isPreview: true } );
+			} else {
+				await dispatch.autosave( { isPreview: true } );
+			}
+		}
+
+		return forcePreviewLink ?? select.getEditedPostPreviewLink();
+	};
+
 /**
  * Action that restores last popped state in undo history.
  */

--- a/packages/editor/src/store/actions.js
+++ b/packages/editor/src/store/actions.js
@@ -302,7 +302,7 @@ export const autosave =
 	};
 
 export const __unstableSaveForPreview =
-	( { forceIsAutosaveable, forcePreviewLink } ) =>
+	( { forceIsAutosaveable } ) =>
 	async ( { select, dispatch } ) => {
 		if (
 			( forceIsAutosaveable || select.isEditedPostAutosaveable() ) &&
@@ -318,7 +318,7 @@ export const __unstableSaveForPreview =
 			}
 		}
 
-		return forcePreviewLink ?? select.getEditedPostPreviewLink();
+		return select.getEditedPostPreviewLink();
 	};
 
 /**

--- a/packages/editor/src/store/selectors.js
+++ b/packages/editor/src/store/selectors.js
@@ -681,15 +681,9 @@ export function isDeletingPost( state ) {
  *
  * @return {boolean} Whether post is being saved.
  */
-export const isSavingPost = createRegistrySelector( ( select ) => ( state ) => {
-	const postType = getCurrentPostType( state );
-	const postId = getCurrentPostId( state );
-	return select( coreStore ).isSavingEntityRecord(
-		'postType',
-		postType,
-		postId
-	);
-} );
+export function isSavingPost( state ) {
+	return !! state.saving.pending;
+}
 
 /**
  * Returns true if non-post entities are currently being saved, or false otherwise.
@@ -760,10 +754,7 @@ export const didPostSaveRequestFail = createRegistrySelector(
  * @return {boolean} Whether the post is autosaving.
  */
 export function isAutosavingPost( state ) {
-	if ( ! isSavingPost( state ) ) {
-		return false;
-	}
-	return Boolean( state.saving.options?.isAutosave );
+	return isSavingPost( state ) && Boolean( state.saving.options?.isAutosave );
 }
 
 /**
@@ -774,10 +765,7 @@ export function isAutosavingPost( state ) {
  * @return {boolean} Whether the post is being previewed.
  */
 export function isPreviewingPost( state ) {
-	if ( ! isSavingPost( state ) ) {
-		return false;
-	}
-	return Boolean( state.saving.options?.isPreview );
+	return isSavingPost( state ) && Boolean( state.saving.options?.isPreview );
 }
 
 /**

--- a/packages/editor/src/store/test/selectors.js
+++ b/packages/editor/src/store/test/selectors.js
@@ -75,10 +75,6 @@ selectorNames.forEach( ( name ) => {
 				};
 			},
 
-			isSavingEntityRecord() {
-				return state.saving && state.saving.requesting;
-			},
-
 			getLastEntitySaveError() {
 				const saving = state.saving;
 				const successful = saving && saving.successful;
@@ -1254,7 +1250,7 @@ describe( 'selectors', () => {
 					title: 'sassel',
 				},
 				saving: {
-					requesting: true,
+					pending: true,
 				},
 			};
 
@@ -1403,9 +1399,8 @@ describe( 'selectors', () => {
 				currentPost: {
 					title: 'sassel',
 				},
-				saving: {
-					requesting: true,
-				},
+				postAutosavingLock: {},
+				saving: {},
 				getCurrentUser() {},
 				hasFetchedAutosaves() {
 					return false;
@@ -1434,9 +1429,8 @@ describe( 'selectors', () => {
 				currentPost: {
 					title: 'sassel',
 				},
-				saving: {
-					requesting: true,
-				},
+				postAutosavingLock: {},
+				saving: {},
 				getCurrentUser() {},
 				hasFetchedAutosaves() {
 					return true;
@@ -2017,7 +2011,7 @@ describe( 'selectors', () => {
 		it( 'should return true if the post is currently being saved', () => {
 			const state = {
 				saving: {
-					requesting: true,
+					pending: true,
 				},
 			};
 
@@ -2027,7 +2021,7 @@ describe( 'selectors', () => {
 		it( 'should return false if the post is not currently being saved', () => {
 			const state = {
 				saving: {
-					requesting: false,
+					pending: false,
 				},
 			};
 


### PR DESCRIPTION
This PR extracts one part of the React 18 migration from #32765, the one where `PostPreviewButton` is rewritten to a functional component and awaits save/autosave instead of setting the `previewWindow.location` in a `componentDidUpdate` lifecycle method.

The second commit ensures that the preview dropdown menu is closed after clicking the "preview in another tab" item. That's done with a new `onPreview` prop for `PostPreviewButton`, and passing the `onClose` render prop from `DropDownMenu` down through `PreviewOptions` to the button component.

In current state, the PR has one major problem that needs to be addressed before it can be merged: if the post has active metaboxes, we need to wait for them to be finished saving before we can show the preview. But that waiting is now broken.

Originally, the `componentDidUpdate` lifecycle waited for the `previewLink` prop to change from `null` to a valid URL, and then set the preview location. With the `forcePreviewLink` prop, which is being set to `null` when `isSavingMetaboxes()` is `true`, we were keeping the `null` value for a while after the post save was finished, but that doesn't work now.

Ideally, the "save metaboxes" action should hook into the `savePost` and `autosave` actions and be awaited there. That would replace the [current listener that tries to catch the "save finished" event](https://github.com/WordPress/gutenberg/blob/35f04fa882b46bbd321fa868935645547a733052/packages/edit-post/src/store/actions.js#L573-L598) by checking `isSavingPost` transitions from `true` to `false`.