### PR TITLE
Navigator: restore focus only once per location

### DIFF
--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Bug Fix
 
 -   `FontSizePicker`: Ensure that fluid font size presets appear correctly in the UI controls ([#44791](https://github.com/WordPress/gutenberg/pull/44791)).
+-   `Navigator`: restore focus only once per location  ([#44972](https://github.com/WordPress/gutenberg/pull/44972)).
 
 ### Documentation
 

--- a/packages/components/src/navigator/navigator-provider/component.tsx
+++ b/packages/components/src/navigator/navigator-provider/component.tsx
@@ -49,6 +49,7 @@ function NavigatorProvider(
 					...options,
 					path,
 					isBack: false,
+					hasRestoredFocus: false,
 				},
 			] );
 		},
@@ -62,6 +63,7 @@ function NavigatorProvider(
 				{
 					...locationHistory[ locationHistory.length - 2 ],
 					isBack: true,
+					hasRestoredFocus: false,
 				},
 			] );
 		}

--- a/packages/components/src/navigator/navigator-screen/component.tsx
+++ b/packages/components/src/navigator/navigator-screen/component.tsx
@@ -75,7 +75,7 @@ function NavigatorScreen( props: Props, forwardedRef: ForwardedRef< any > ) {
 		const activeElement = wrapperRef.current.ownerDocument.activeElement;
 
 		// If an element is already focused within the wrapper do not focus the
-		// element. This prevents inputs or buttons from losing focus unecessarily.
+		// element. This prevents inputs or buttons from losing focus unnecessarily.
 		if ( wrapperRef.current.contains( activeElement ) ) {
 			return;
 		}

--- a/packages/components/src/navigator/navigator-screen/component.tsx
+++ b/packages/components/src/navigator/navigator-screen/component.tsx
@@ -62,7 +62,13 @@ function NavigatorScreen( props: Props, forwardedRef: ForwardedRef< any > ) {
 		// - if the current location is not the initial one (to avoid moving focus on page load)
 		// - when the screen becomes visible
 		// - if the wrapper ref has been assigned
-		if ( isInitialLocation || ! isMatch || ! wrapperRef.current ) {
+		// - if focus hasn't already been restored for the current location
+		if (
+			isInitialLocation ||
+			! isMatch ||
+			! wrapperRef.current ||
+			location.hasRestoredFocus
+		) {
 			return;
 		}
 
@@ -93,10 +99,12 @@ function NavigatorScreen( props: Props, forwardedRef: ForwardedRef< any > ) {
 			elementToFocus = firstTabbable ?? wrapperRef.current;
 		}
 
+		location.hasRestoredFocus = true;
 		elementToFocus.focus();
 	}, [
 		isInitialLocation,
 		isMatch,
+		location.hasRestoredFocus,
 		location.isBack,
 		previousLocation?.focusTargetSelector,
 	] );

--- a/packages/components/src/navigator/test/index.tsx
+++ b/packages/components/src/navigator/test/index.tsx
@@ -379,38 +379,6 @@ describe( 'Navigator', () => {
 		} );
 	} );
 
-	it( 'should restore focus correctly', async () => {
-		const user = userEvent.setup( {
-			advanceTimers: jest.advanceTimersByTime,
-		} );
-
-		render( <MyNavigation /> );
-
-		expect( getScreen( 'home' ) ).toBeInTheDocument();
-
-		// Navigate to child screen.
-		await user.click( getNavigationButton( 'toChildScreen' ) );
-
-		expect( getScreen( 'child' ) ).toBeInTheDocument();
-
-		// Navigate to nested screen.
-		await user.click( getNavigationButton( 'toNestedScreen' ) );
-
-		expect( getScreen( 'nested' ) ).toBeInTheDocument();
-
-		// Navigate back to child screen, check that focus was correctly restored.
-		await user.click( getNavigationButton( 'back' ) );
-
-		expect( getScreen( 'child' ) ).toBeInTheDocument();
-		expect( getNavigationButton( 'toNestedScreen' ) ).toHaveFocus();
-
-		// Navigate back to home screen, check that focus was correctly restored.
-		await user.click( getNavigationButton( 'back' ) );
-
-		expect( getScreen( 'home' ) ).toBeInTheDocument();
-		expect( getNavigationButton( 'toChildScreen' ) ).toHaveFocus();
-	} );
-
 	it( 'should escape the value of the `path` prop', async () => {
 		const user = userEvent.setup( {
 			advanceTimers: jest.advanceTimersByTime,
@@ -445,26 +413,62 @@ describe( 'Navigator', () => {
 		).toHaveFocus();
 	} );
 
-	it( 'should keep focus on the element that is being interacted with, while re-rendering', async () => {
-		const user = userEvent.setup( {
-			advanceTimers: jest.advanceTimersByTime,
+	describe( 'focus management', () => {
+		it( 'should restore focus correctly', async () => {
+			const user = userEvent.setup( {
+				advanceTimers: jest.advanceTimersByTime,
+			} );
+
+			render( <MyNavigation /> );
+
+			expect( getScreen( 'home' ) ).toBeInTheDocument();
+
+			// Navigate to child screen.
+			await user.click( getNavigationButton( 'toChildScreen' ) );
+
+			expect( getScreen( 'child' ) ).toBeInTheDocument();
+
+			// Navigate to nested screen.
+			await user.click( getNavigationButton( 'toNestedScreen' ) );
+
+			expect( getScreen( 'nested' ) ).toBeInTheDocument();
+
+			// Navigate back to child screen, check that focus was correctly restored.
+			await user.click( getNavigationButton( 'back' ) );
+
+			expect( getScreen( 'child' ) ).toBeInTheDocument();
+			expect( getNavigationButton( 'toNestedScreen' ) ).toHaveFocus();
+
+			// Navigate back to home screen, check that focus was correctly restored.
+			await user.click( getNavigationButton( 'back' ) );
+
+			expect( getScreen( 'home' ) ).toBeInTheDocument();
+			expect( getNavigationButton( 'toChildScreen' ) ).toHaveFocus();
 		} );
 
-		render( <MyNavigation /> );
+		it( 'should keep focus on the element that is being interacted with, while re-rendering', async () => {
+			const user = userEvent.setup( {
+				advanceTimers: jest.advanceTimersByTime,
+			} );
 
-		expect( getScreen( 'home' ) ).toBeInTheDocument();
-		expect( getNavigationButton( 'toChildScreen' ) ).toBeInTheDocument();
+			render( <MyNavigation /> );
 
-		// Navigate to child screen.
-		await user.click( getNavigationButton( 'toChildScreen' ) );
+			expect( getScreen( 'home' ) ).toBeInTheDocument();
+			expect(
+				getNavigationButton( 'toChildScreen' )
+			).toBeInTheDocument();
 
-		expect( getScreen( 'child' ) ).toBeInTheDocument();
-		expect( getNavigationButton( 'back' ) ).toBeInTheDocument();
-		expect( getNavigationButton( 'toNestedScreen' ) ).toHaveFocus();
+			// Navigate to child screen.
+			await user.click( getNavigationButton( 'toChildScreen' ) );
 
-		// Interact with the input, the focus should stay on the input element.
-		const input = screen.getByLabelText( 'This is a test input' );
-		await user.type( input, 'd' );
-		expect( input ).toHaveFocus();
+			expect( getScreen( 'child' ) ).toBeInTheDocument();
+			expect( getNavigationButton( 'back' ) ).toBeInTheDocument();
+			expect( getNavigationButton( 'toNestedScreen' ) ).toHaveFocus();
+
+			// Interact with the input, the focus should stay on the input element.
+			const input = screen.getByLabelText( 'This is a test input' );
+			await user.type( input, 'd' );
+			expect( input ).toHaveFocus();
+		} );
 	} );
 } );

--- a/packages/components/src/navigator/test/index.tsx
+++ b/packages/components/src/navigator/test/index.tsx
@@ -441,54 +441,49 @@ describe( 'Navigator', () => {
 
 			render( <MyNavigation /> );
 
-			expect( getScreen( 'home' ) ).toBeInTheDocument();
-
 			// Navigate to child screen.
 			await user.click( getNavigationButton( 'toChildScreen' ) );
 
-			expect( getScreen( 'child' ) ).toBeInTheDocument();
+			// The first tabbable element receives focus.
+			expect( getNavigationButton( 'toNestedScreen' ) ).toHaveFocus();
 
 			// Navigate to nested screen.
 			await user.click( getNavigationButton( 'toNestedScreen' ) );
 
-			expect( getScreen( 'nested' ) ).toBeInTheDocument();
+			// The first tabbable element receives focus.
+			expect( getNavigationButton( 'back' ) ).toHaveFocus();
 
-			// Navigate back to child screen, check that focus was correctly restored.
+			// Navigate back to child screen.
 			await user.click( getNavigationButton( 'back' ) );
 
-			expect( getScreen( 'child' ) ).toBeInTheDocument();
+			// The first tabbable element receives focus.
 			expect( getNavigationButton( 'toNestedScreen' ) ).toHaveFocus();
 
 			// Navigate back to home screen, check that focus was correctly restored.
 			await user.click( getNavigationButton( 'back' ) );
 
-			expect( getScreen( 'home' ) ).toBeInTheDocument();
+			// The first tabbable element receives focus.
 			expect( getNavigationButton( 'toChildScreen' ) ).toHaveFocus();
 		} );
 
-		it( 'should keep focus on the element that is being interacted with, while re-rendering', async () => {
+		it( 'should keep on an active element inside navigator, while re-rendering', async () => {
 			const user = userEvent.setup( {
 				advanceTimers: jest.advanceTimersByTime,
 			} );
 
 			render( <MyNavigation /> );
 
-			expect( getScreen( 'home' ) ).toBeInTheDocument();
-			expect(
-				getNavigationButton( 'toChildScreen' )
-			).toBeInTheDocument();
-
 			// Navigate to child screen.
 			await user.click( getNavigationButton( 'toChildScreen' ) );
 
-			expect( getScreen( 'child' ) ).toBeInTheDocument();
-			expect( getNavigationButton( 'back' ) ).toBeInTheDocument();
+			// The first tabbable element receives focus.
 			expect( getNavigationButton( 'toNestedScreen' ) ).toHaveFocus();
 
-			// Interact with the input, the focus should stay on the input element.
-			const input = screen.getByLabelText( 'Inner input' );
-			await user.type( input, 'd' );
-			expect( input ).toHaveFocus();
+			// Interact with the inner input.
+			// The focus should stay on the input element.
+			const innerInput = screen.getByLabelText( 'Inner input' );
+			await user.type( innerInput, 'd' );
+			expect( innerInput ).toHaveFocus();
 		} );
 	} );
 } );

--- a/packages/components/src/navigator/test/index.tsx
+++ b/packages/components/src/navigator/test/index.tsx
@@ -141,71 +141,91 @@ const MyNavigation = ( {
 	initialPath?: string;
 	onNavigatorButtonClick?: CustomTestOnClickHandler;
 } ) => {
-	const [ inputValue, setInputValue ] = useState( '' );
+	const [ innerInputValue, setInnerInputValue ] = useState( '' );
+	const [ outerInputValue, setOuterInputValue ] = useState( '' );
 	return (
-		<NavigatorProvider initialPath={ initialPath }>
-			<NavigatorScreen path={ PATHS.HOME }>
-				<p>{ SCREEN_TEXT.home }</p>
-				<CustomNavigatorButton
-					path={ PATHS.NOT_FOUND }
-					onClick={ onNavigatorButtonClick }
-				>
-					{ BUTTON_TEXT.toNonExistingScreen }
-				</CustomNavigatorButton>
-				<CustomNavigatorButton
-					path={ PATHS.CHILD }
-					onClick={ onNavigatorButtonClick }
-				>
-					{ BUTTON_TEXT.toChildScreen }
-				</CustomNavigatorButton>
-				<CustomNavigatorButton
-					path={ PATHS.INVALID_HTML_ATTRIBUTE }
-					onClick={ onNavigatorButtonClick }
-				>
-					{ BUTTON_TEXT.toInvalidHtmlPathScreen }
-				</CustomNavigatorButton>
-			</NavigatorScreen>
+		<>
+			<NavigatorProvider initialPath={ initialPath }>
+				<NavigatorScreen path={ PATHS.HOME }>
+					<p>{ SCREEN_TEXT.home }</p>
+					<CustomNavigatorButton
+						path={ PATHS.NOT_FOUND }
+						onClick={ onNavigatorButtonClick }
+					>
+						{ BUTTON_TEXT.toNonExistingScreen }
+					</CustomNavigatorButton>
+					<CustomNavigatorButton
+						path={ PATHS.CHILD }
+						onClick={ onNavigatorButtonClick }
+					>
+						{ BUTTON_TEXT.toChildScreen }
+					</CustomNavigatorButton>
+					<CustomNavigatorButton
+						path={ PATHS.INVALID_HTML_ATTRIBUTE }
+						onClick={ onNavigatorButtonClick }
+					>
+						{ BUTTON_TEXT.toInvalidHtmlPathScreen }
+					</CustomNavigatorButton>
+				</NavigatorScreen>
 
-			<NavigatorScreen path={ PATHS.CHILD }>
-				<p>{ SCREEN_TEXT.child }</p>
-				<CustomNavigatorButtonWithFocusRestoration
-					path={ PATHS.NESTED }
-					onClick={ onNavigatorButtonClick }
-				>
-					{ BUTTON_TEXT.toNestedScreen }
-				</CustomNavigatorButtonWithFocusRestoration>
-				<CustomNavigatorBackButton onClick={ onNavigatorButtonClick }>
-					{ BUTTON_TEXT.back }
-				</CustomNavigatorBackButton>
+				<NavigatorScreen path={ PATHS.CHILD }>
+					<p>{ SCREEN_TEXT.child }</p>
+					<CustomNavigatorButtonWithFocusRestoration
+						path={ PATHS.NESTED }
+						onClick={ onNavigatorButtonClick }
+					>
+						{ BUTTON_TEXT.toNestedScreen }
+					</CustomNavigatorButtonWithFocusRestoration>
+					<CustomNavigatorBackButton
+						onClick={ onNavigatorButtonClick }
+					>
+						{ BUTTON_TEXT.back }
+					</CustomNavigatorBackButton>
 
-				<label htmlFor="test-input">This is a test input</label>
-				<input
-					name="test-input"
-					// eslint-disable-next-line no-restricted-syntax
-					id="test-input"
-					onChange={ ( e ) => {
-						setInputValue( e.target.value );
-					} }
-					value={ inputValue }
-				/>
-			</NavigatorScreen>
+					<label htmlFor="test-input-inner">Inner input</label>
+					<input
+						name="test-input-inner"
+						// eslint-disable-next-line no-restricted-syntax
+						id="test-input-inner"
+						onChange={ ( e ) => {
+							setInnerInputValue( e.target.value );
+						} }
+						value={ innerInputValue }
+					/>
+				</NavigatorScreen>
 
-			<NavigatorScreen path={ PATHS.NESTED }>
-				<p>{ SCREEN_TEXT.nested }</p>
-				<CustomNavigatorBackButton onClick={ onNavigatorButtonClick }>
-					{ BUTTON_TEXT.back }
-				</CustomNavigatorBackButton>
-			</NavigatorScreen>
+				<NavigatorScreen path={ PATHS.NESTED }>
+					<p>{ SCREEN_TEXT.nested }</p>
+					<CustomNavigatorBackButton
+						onClick={ onNavigatorButtonClick }
+					>
+						{ BUTTON_TEXT.back }
+					</CustomNavigatorBackButton>
+				</NavigatorScreen>
 
-			<NavigatorScreen path={ PATHS.INVALID_HTML_ATTRIBUTE }>
-				<p>{ SCREEN_TEXT.invalidHtmlPath }</p>
-				<CustomNavigatorBackButton onClick={ onNavigatorButtonClick }>
-					{ BUTTON_TEXT.back }
-				</CustomNavigatorBackButton>
-			</NavigatorScreen>
+				<NavigatorScreen path={ PATHS.INVALID_HTML_ATTRIBUTE }>
+					<p>{ SCREEN_TEXT.invalidHtmlPath }</p>
+					<CustomNavigatorBackButton
+						onClick={ onNavigatorButtonClick }
+					>
+						{ BUTTON_TEXT.back }
+					</CustomNavigatorBackButton>
+				</NavigatorScreen>
 
-			{ /* A `NavigatorScreen` with `path={ PATHS.NOT_FOUND }` is purposefully not included. */ }
-		</NavigatorProvider>
+				{ /* A `NavigatorScreen` with `path={ PATHS.NOT_FOUND }` is purposefully not included. */ }
+			</NavigatorProvider>
+
+			<label htmlFor="test-input-outer">Outer input</label>
+			<input
+				name="test-input-outer"
+				// eslint-disable-next-line no-restricted-syntax
+				id="test-input-outer"
+				onChange={ ( e ) => {
+					setOuterInputValue( e.target.value );
+				} }
+				value={ outerInputValue }
+			/>
+		</>
 	);
 };
 
@@ -466,7 +486,7 @@ describe( 'Navigator', () => {
 			expect( getNavigationButton( 'toNestedScreen' ) ).toHaveFocus();
 
 			// Interact with the input, the focus should stay on the input element.
-			const input = screen.getByLabelText( 'This is a test input' );
+			const input = screen.getByLabelText( 'Inner input' );
 			await user.type( input, 'd' );
 			expect( input ).toHaveFocus();
 		} );

--- a/packages/components/src/navigator/test/index.tsx
+++ b/packages/components/src/navigator/test/index.tsx
@@ -466,7 +466,7 @@ describe( 'Navigator', () => {
 			expect( getNavigationButton( 'toChildScreen' ) ).toHaveFocus();
 		} );
 
-		it( 'should keep on an active element inside navigator, while re-rendering', async () => {
+		it( 'should keep focus on an active element inside navigator, while re-rendering', async () => {
 			const user = userEvent.setup( {
 				advanceTimers: jest.advanceTimersByTime,
 			} );

--- a/packages/components/src/navigator/test/index.tsx
+++ b/packages/components/src/navigator/test/index.tsx
@@ -485,5 +485,25 @@ describe( 'Navigator', () => {
 			await user.type( innerInput, 'd' );
 			expect( innerInput ).toHaveFocus();
 		} );
+
+		it( 'should keep focus on an active element outside navigator, while re-rendering', async () => {
+			const user = userEvent.setup( {
+				advanceTimers: jest.advanceTimersByTime,
+			} );
+
+			render( <MyNavigation /> );
+
+			// Navigate to child screen.
+			await user.click( getNavigationButton( 'toChildScreen' ) );
+
+			// The first tabbable element receives focus.
+			expect( getNavigationButton( 'toNestedScreen' ) ).toHaveFocus();
+
+			// Interact with the outer input.
+			// The focus should stay on the input element.
+			const outerInput = screen.getByLabelText( 'Outer input' );
+			await user.type( outerInput, 'd' );
+			expect( outerInput ).toHaveFocus();
+		} );
 	} );
 } );

--- a/packages/components/src/navigator/types.ts
+++ b/packages/components/src/navigator/types.ts
@@ -11,6 +11,7 @@ export type NavigatorLocation = NavigateOptions & {
 	isInitial?: boolean;
 	isBack?: boolean;
 	path?: string;
+	hasRestoredFocus?: boolean;
 };
 
 export type NavigatorContext = {


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Requires changes from #44970

Fixes #44834

Fix a bug which caused `Navigator` to attempt to move focus in a screen more than once while the same screen is being re-rendered.

This focus shifting can impact the user experience, especially in cases there the user is interacting with an input, and changes to the input cause the screen to re-render.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

These changes fix an unintended behaviour of the component.

We were already trying to solve this issue with the changes from #44239, but #44834 highlights an edge case that wasn't covered yet: the input that the user is interacting with is not rendered inside of `Navigator`.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

A new `hasRestoredFocus` flag has been added to `location` objects, and is used to avoid that a screen tries to move focus more than once for the same location.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->

Follow instructions from https://github.com/WordPress/gutenberg/issues/44834 , the bug should be fixed

I've also added a new unit test to cover this edge case.

## Screenshots or screencast <!-- if applicable -->

Before:


https://user-images.githubusercontent.com/1083581/194912939-04cdfa92-c685-4d9e-b1ac-f604b71dfc59.mp4


After:


https://user-images.githubusercontent.com/1083581/195831503-e0a7877f-f92b-4a64-b925-59914eb3d6a7.mp4

