### PR TITLE
Update REST API to handle slug refs

### DIFF
--- a/lib/compat/wordpress-6.2/class-gutenberg-rest-navigation-controller.php
+++ b/lib/compat/wordpress-6.2/class-gutenberg-rest-navigation-controller.php
@@ -1,0 +1,117 @@
+<?php
+/**
+ * REST API: Gutenberg_REST_Templates_Controller class
+ *
+ * @package    Gutenberg
+ * @subpackage REST_API
+ */
+
+/**
+ * Base Templates REST API Controller.
+ */
+class Gutenberg_REST_Navigation_Controller extends WP_REST_Posts_Controller {
+
+	/**
+	 * Registers the controllers routes.
+	 *
+	 * @return void
+	 */
+	public function register_routes() {
+
+		parent::register_routes();
+
+		// Lists a single nav item based on the given id or slug.
+		register_rest_route(
+			$this->namespace,
+			'/' . $this->rest_base . '/((?P<id>[\d]+)|(?P<slug>[\w\-]+))',
+			array(
+				'args'        => array(
+					'slug' => array(
+						'description' => __( 'The slug identifier for a Navigation', 'gutenberg' ),
+						'type'        => 'string',
+					),
+				),
+				array(
+					'methods'             => WP_REST_Server::READABLE,
+					'callback'            => array( $this, 'get_item' ),
+					'permission_callback' => array( $this, 'get_item_permissions_check' ),
+					'args'                => $this->get_endpoint_args_for_item_schema( WP_REST_Server::READABLE ),
+				),
+				array(
+					'methods'             => WP_REST_Server::EDITABLE,
+					'callback'            => array( $this, 'update_item' ),
+					'permission_callback' => array( $this, 'update_item_permissions_check' ),
+					'args'                => $this->get_endpoint_args_for_item_schema( WP_REST_Server::EDITABLE ),
+				),
+				array(
+					'methods'             => WP_REST_Server::DELETABLE,
+					'callback'            => array( $this, 'delete_item' ),
+					'permission_callback' => array( $this, 'delete_item_permissions_check' ),
+					'args'                => array(
+						'force' => array(
+							'type'        => 'boolean',
+							'default'     => false,
+							'description' => __( 'Whether to bypass Trash and force deletion.' ),
+						),
+					),
+				),
+				'allow_batch' => $this->allow_batch,
+				'schema'      => array( $this, 'get_public_item_schema' ),
+			)
+		);
+	}
+
+	/**
+	 * Overide WP_REST_Posts_Controller parent function to query for
+	 * `wp_navigation` posts by slug (post_name) instead of ID.
+	 *
+	 * This is required to successfully process OPTIONS requests as with
+	 * these the `rest_request_before_callbacks` method which is used to
+	 * map slug to postId does not run which means `get_post` will not
+	 * behave as expected.
+	 *
+	 * The function will continue to delegate to the parent implementation
+	 * if the $id argument is ID-based, thereby ensuring backwards
+	 * compatbility.
+	 *
+	 * It may be possible to remove this implemenation in future releases.
+	 *
+	 * See: https://github.com/WordPress/gutenberg/pull/43703.
+	 *
+	 * @param string $id the slug of the Navigation post.
+	 * @return WP_Post|null
+	 */
+	protected function get_post( $id ) {
+
+		// Handle ID based $id param.
+		if ( is_numeric( $id ) ) {
+			return parent::get_post( $id );
+		}
+
+		// For string based $id the argument is a "slug".
+		// Lookup Post using `post_name` query.
+		$slug = $id;
+
+		$args = array(
+			'name'                   => $slug,
+			'post_type'              => 'wp_navigation',
+			'nopaging'               => true,
+			'posts_per_page'         => '1',
+			'update_post_term_cache' => false,
+			'no_found_rows'          => true,
+		);
+
+		// Query for the Navigation Post by slug (post_name).
+		$query = new WP_Query( $args );
+
+		if ( empty( $query->posts ) ) {
+			return new WP_Error(
+				'rest_post_not_found',
+				__( 'No navigation found.' ),
+				array( 'status' => 404 )
+			);
+		}
+
+		return $query->posts[0];
+	}
+}

--- a/lib/compat/wordpress-6.2/rest-api.php
+++ b/lib/compat/wordpress-6.2/rest-api.php
@@ -23,10 +23,11 @@ function gutenberg_update_navigation_rest_controller( $args, $post_type ) {
 add_filter( 'register_post_type_args', 'gutenberg_update_navigation_rest_controller', 10, 2 );
 
 /**
- * Transform slug as recordId to postID.
+ * Sets the 'ID' field of the WP_REST_Request to be the Post retrieved by `slug` if
+ * one is present in the request URL.
  *
- * This allows Navigation Posts to be requested by slug. It then looks up the Post
- * by slug and uses the result postID of the record to set the 'ID' field of the
+ * Allows Navigation Posts to be requested by slug by looking up the Post
+ * by slug and using the resulting postID of the record to set the 'ID' field of the
  * request before it is handled.
  *
  * This ensures that the same handler logic can be reused whether the endpoint

--- a/lib/compat/wordpress-6.2/rest-api.php
+++ b/lib/compat/wordpress-6.2/rest-api.php
@@ -1,0 +1,89 @@
+<?php
+/**
+ * Overrides Core's wp-includes/rest-api.php and registers the new endpoint for WP 6.2.
+ *
+ * @package gutenberg
+ */
+
+/**
+ * Use custom REST API Controller for Navigation Posts
+ *
+ * @param array $args the post type arguments.
+ * @return array the filtered post type arguments with the new REST Controller set.
+ */
+function gutenberg_update_navigation_rest_controller( $args, $post_type ) {
+	if ( in_array( $post_type, array( 'wp_navigation' ), true ) ) {
+		// Original set in
+		// https://github.com/WordPress/wordpress-develop/blob/6cbed78c94b9d8c6a9b4c8b472b88ee0cd56528c/src/wp-includes/post.php#L528.
+		$args['rest_controller_class'] = 'Gutenberg_REST_Navigation_Controller';
+	}
+	return $args;
+}
+add_filter( 'register_post_type_args', 'gutenberg_update_navigation_rest_controller', 10, 2 );
+
+function gutenberg_transform_slug_to_post_id( $response, $handler, WP_REST_Request $request ) {
+
+	$route = rest_get_route_for_post_type_items( 'wp_navigation' );
+
+	// Ignore non-Navigation REST API requests.
+	if ( ! str_starts_with( $request->get_route(), $route ) ) {
+		return $response;
+	}
+
+	// Get the slug from the request **URL** (not the request body).
+	// PUT requests will have a param of `slug` in both the URL and (potentially)
+	// in the body. In all cases only the slug in the URL should be mapped to a
+	// postId in order that the correct post to be updated can be retrived.
+	// The `slug` within the body should be preserved "as is".
+	$slug = isset( $request->get_url_params()['slug'] ) ? $request->get_url_params()['slug'] : null;
+
+	// If no slug provided assume ID and continue as normal.
+	if ( empty( $slug ) ) {
+		return $response;
+	}
+
+	$args = array(
+		'name'                   => $slug, // query by slug
+		'post_type'              => 'wp_navigation',
+		'nopaging'               => true,
+		'posts_per_page'         => '1',
+		'update_post_term_cache' => false,
+		'no_found_rows'          => true,
+	);
+
+	// Query for the Navigation Post by slug (post_name).
+	$query = new WP_Query( $args );
+
+	if ( empty( $query->posts ) ) {
+		return new WP_Error(
+			'rest_post_not_found',
+			__( 'No navigation found.' ),
+			array( 'status' => 404 )
+		);
+	}
+
+	// Set the post ID based on the slug.
+	$request['id'] = $query->posts[0]->ID;
+
+	return $response;
+}
+add_filter( 'rest_request_before_callbacks', 'gutenberg_transform_slug_to_post_id', 10, 3 );
+
+function gutenberg_update_navigation_rest_route_for_post( $route, WP_Post $post ) {
+
+	if ( $post->post_type !== 'wp_navigation' ) {
+		return $route;
+	}
+
+	$post_type_route = rest_get_route_for_post_type_items( $post->post_type );
+
+	if ( ! $post_type_route ) {
+		return '';
+	}
+
+	// Replace Post ID in route with Post "Slug" (post_name).
+	return sprintf( '%s/%s', $post_type_route, $post->post_name );
+}
+
+
+add_filter( 'rest_route_for_post', 'gutenberg_update_navigation_rest_route_for_post', 10, 2 );

--- a/lib/load.php
+++ b/lib/load.php
@@ -49,6 +49,10 @@ if ( class_exists( 'WP_REST_Controller' ) ) {
 	require_once __DIR__ . '/compat/wordpress-6.1/class-gutenberg-rest-templates-controller.php';
 	require_once __DIR__ . '/compat/wordpress-6.1/rest-api.php';
 
+	// WordPress 6.2 compat.
+	require_once __DIR__ . '/compat/wordpress-6.2/class-gutenberg-rest-navigation-controller.php';
+	require_once __DIR__ . '/compat/wordpress-6.2/rest-api.php';
+
 	// Experimental.
 	if ( ! class_exists( 'WP_Rest_Customizer_Nonces' ) ) {
 		require_once __DIR__ . '/experimental/class-wp-rest-customizer-nonces.php';

--- a/phpunit/class-gutenberg-rest-navigation-controller-test.php
+++ b/phpunit/class-gutenberg-rest-navigation-controller-test.php
@@ -1,0 +1,253 @@
+<?php
+
+class Gutenberg_REST_Navigation_Controller_Test extends WP_Test_REST_Controller_Testcase {
+	/**
+	 * @var int
+	 */
+	protected static $admin_id;
+
+	/**
+	 * @var int
+	 */
+	protected static $test_navigation_post_id;
+
+	protected static $test_navigation_post_slug = 'test-navigation-post-slug';
+
+	public function set_up() {
+		parent::set_up();
+		switch_theme( 'emptytheme' );
+	}
+
+	/**
+	 * Create fake data before our tests run.
+	 *
+	 * @param WP_UnitTest_Factory $factory Helper that lets us create fake data.
+	 */
+	public static function wpSetupBeforeClass( $factory ) {
+		self::$admin_id = $factory->user->create(
+			array(
+				'role' => 'administrator',
+			)
+		);
+		// This creates the global styles for the current theme.
+		self::$test_navigation_post_id = wp_insert_post(
+			array(
+				'post_content' => '',
+				'post_status'  => 'publish',
+				'post_title'   => __( 'Test Navigation Menu', 'default' ),
+				'post_type'    => 'wp_navigation',
+				'post_name'    => self::$test_navigation_post_slug,
+			),
+			true
+		);
+	}
+
+	public function test_register_routes() {
+		$routes = rest_get_server()->get_routes();
+
+		$this->assertArrayHasKey(
+			'/wp/v2/navigation/((?P<id>[\d]+)|(?P<slug>[\w\-]+))',
+			$routes,
+			'Navigation based on (post) ID or slug route does not exist'
+		);
+	}
+
+	public function test_rest_route_for_post() {
+		$route = \rest_get_route_for_post( self::$test_navigation_post_id );
+
+		$this->assertEquals( '/wp/v2/navigation/' . self::$test_navigation_post_slug, $route );
+	}
+
+	public function test_context_param() {
+		$this->markTestIncomplete();
+	}
+
+	public function test_get_items() {
+		$this->markTestIncomplete();
+	}
+
+	public function test_get_item_by_slug() {
+		wp_set_current_user( self::$admin_id );
+		$request  = new WP_REST_Request( 'GET', '/wp/v2/navigation/' . self::$test_navigation_post_slug );
+		$response = rest_get_server()->dispatch( $request );
+
+		$this->assertSame( 200, $response->get_status() );
+
+		$data = $response->get_data();
+
+		$this->assertEquals(
+			self::$test_navigation_post_id,
+			$data['id']
+		);
+
+		$this->assertEquals(
+			'Test Navigation Menu',
+			$data['title']['rendered']
+		);
+
+		$this->assertEquals(
+			'test-navigation-post-slug',
+			$data['slug']
+		);
+
+		$this->assertEquals(
+			'wp_navigation',
+			$data['type']
+		);
+	}
+
+	public function test_get_item_by_id() {
+		wp_set_current_user( self::$admin_id );
+		$request  = new WP_REST_Request( 'GET', '/wp/v2/navigation/' . self::$test_navigation_post_id );
+		$response = rest_get_server()->dispatch( $request );
+
+		$this->assertSame( 200, $response->get_status() );
+
+		$data = $response->get_data();
+
+		$this->assertEquals(
+			self::$test_navigation_post_id,
+			$data['id']
+		);
+
+		$this->assertEquals(
+			'Test Navigation Menu',
+			$data['title']['rendered']
+		);
+
+		$this->assertEquals(
+			'test-navigation-post-slug',
+			$data['slug']
+		);
+
+		$this->assertEquals(
+			'wp_navigation',
+			$data['type']
+		);
+	}
+
+	public function test_get_item() {
+		$this->markTestIncomplete();
+	}
+
+	public function test_create_item() {
+		wp_set_current_user( self::$admin_id );
+
+		$request = new WP_REST_Request( 'POST', '/wp/v2/navigation' );
+		$request->set_body_params(
+			array(
+				'title'   => 'Freshly created Navigation',
+				'slug'    => 'freshly-created-navigation',
+				'status'  => 'publish',
+				'content' => '',
+			)
+		);
+		$response = rest_get_server()->dispatch( $request );
+		$this->assertSame( 201, $response->get_status() );
+
+		$data = $response->get_data();
+
+		$this->assertEquals(
+			'Freshly created Navigation',
+			$data['title']['rendered']
+		);
+
+		$this->assertEquals(
+			'freshly-created-navigation',
+			$data['slug']
+		);
+
+		$this->assertEquals(
+			'wp_navigation',
+			$data['type']
+		);
+	}
+
+	public function test_update_item() {
+		wp_set_current_user( self::$admin_id );
+
+		$request = new WP_REST_Request( 'PUT', '/wp/v2/navigation/' . self::$test_navigation_post_slug );
+		$request->set_body_params(
+			array(
+				'title' => 'New Nav title',
+				'slug'  => 'the-new-navigation-slug',
+			)
+		);
+		$response = rest_get_server()->dispatch( $request );
+		$data     = $response->get_data();
+
+		$this->assertEquals(
+			self::$test_navigation_post_id,
+			$data['id']
+		);
+
+		$this->assertEquals(
+			'New Nav title',
+			$data['title']['rendered']
+		);
+
+		$this->assertEquals(
+			'the-new-navigation-slug',
+			$data['slug']
+		);
+
+		$this->assertEquals(
+			'wp_navigation',
+			$data['type']
+		);
+	}
+
+	public function test_delete_item() {
+		wp_set_current_user( self::$admin_id );
+		$request  = new WP_REST_Request( 'DELETE', '/wp/v2/navigation/' . self::$test_navigation_post_id );
+		$response = rest_get_server()->dispatch( $request );
+
+		$this->assertSame( 200, $response->get_status() );
+
+		$data = $response->get_data();
+
+		$this->assertEquals(
+			self::$test_navigation_post_id,
+			$data['id']
+		);
+
+		$this->assertEquals(
+			'trash',
+			$data['status']
+		);
+
+		$this->assertEquals(
+			'Test Navigation Menu',
+			$data['title']['rendered']
+		);
+
+		$this->assertEquals(
+			'test-navigation-post-slug__trashed',
+			$data['slug']
+		);
+	}
+
+	public function test_permissions_requests_for_item() {
+		$this->markTestSkipped( 'Skipped as OPTIONS requests do not contain headers when running phpunit' );
+		wp_set_current_user( self::$admin_id );
+		$request  = new WP_REST_Request( 'OPTIONS', '/wp/v2/navigation/' . self::$test_navigation_post_slug );
+		$response = rest_get_server()->dispatch( $request );
+
+		$this->assertSame( 200, $response->get_status() );
+
+		$headers = $response->get_headers();
+
+		$this->assertEquals(
+			'GET, POST, PUT, PATCH, DELETE',
+			$headers['Allow']
+		);
+	}
+
+	public function test_prepare_item() {
+		$this->markTestIncomplete();
+	}
+
+	public function test_get_item_schema() {
+		$this->markTestIncomplete();
+	}
+}


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Sub PR of https://github.com/WordPress/gutenberg/pull/42809 containing changes to REST API needed to handle slugs as references for Navigation posts.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

Foundational work for [using slugs as references instead of IDs in the Nav block](https://github.com/WordPress/gutenberg/pull/42809).

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

Updates the REST API with a new endpoint which handles string-based slugs specifically and then routes that along the same handlers established for int based IDs.

Also adds test coverage for the endpoint.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->

- Check backwards compat - Nav block should still find menus by ID. Just create a Nav block with a menu and save then ensure that you can reload the page and the menu is found.
- Run the tests:
```
npm run test:unit:php /var/www/html/wp-content/plugins/gutenberg/phpunit/class-gutenberg-rest-navigation-controller-test.php
```


## Screenshots or screencast <!-- if applicable -->
