### PR TITLE
Navigator: refactor Storybook code to TypeScript and controls

### DIFF
--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -14,6 +14,7 @@
 
 -   `Modal`: Convert to TypeScript ([#42949](https://github.com/WordPress/gutenberg/pull/42949)).
 -   `Navigator`: refactor unit tests to TypeScript and to `user-event` ([#44970](https://github.com/WordPress/gutenberg/pull/44970)).
+-   `Navigator`: Refactor Storybook code to TypeScript and controls ([#44979](https://github.com/WordPress/gutenberg/pull/44979)).
 
 ## 21.2.0 (2022-10-05)
 

--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Bug Fix
 
 -   `FontSizePicker`: Ensure that fluid font size presets appear correctly in the UI controls ([#44791](https://github.com/WordPress/gutenberg/pull/44791)).
+-   `Navigator`: prevent partially hiding focus ring styles, by removing unnecessary overflow rules on `NavigatorScreen` ([#44973](https://github.com/WordPress/gutenberg/pull/44973)).
 
 ### Documentation
 

--- a/packages/components/src/navigator/index.ts
+++ b/packages/components/src/navigator/index.ts
@@ -1,5 +1,5 @@
-export { default as NavigatorProvider } from './navigator-provider';
-export { default as NavigatorScreen } from './navigator-screen';
-export { default as NavigatorButton } from './navigator-button';
-export { default as NavigatorBackButton } from './navigator-back-button';
+export { NavigatorProvider } from './navigator-provider';
+export { NavigatorScreen } from './navigator-screen';
+export { NavigatorButton } from './navigator-button';
+export { NavigatorBackButton } from './navigator-back-button';
 export { default as useNavigator } from './use-navigator';

--- a/packages/components/src/navigator/navigator-back-button/component.tsx
+++ b/packages/components/src/navigator/navigator-back-button/component.tsx
@@ -11,7 +11,7 @@ import { View } from '../../view';
 import { useNavigatorBackButton } from './hook';
 import type { NavigatorBackButtonProps } from '../types';
 
-function NavigatorBackButton(
+function UnconnectedNavigatorBackButton(
 	props: WordPressComponentProps< NavigatorBackButtonProps, 'button' >,
 	forwardedRef: ForwardedRef< any >
 ) {
@@ -54,9 +54,9 @@ function NavigatorBackButton(
  * );
  * ```
  */
-const ConnectedNavigatorBackButton = contextConnect(
-	NavigatorBackButton,
+export const NavigatorBackButton = contextConnect(
+	UnconnectedNavigatorBackButton,
 	'NavigatorBackButton'
 );
 
-export default ConnectedNavigatorBackButton;
+export default NavigatorBackButton;

--- a/packages/components/src/navigator/navigator-back-button/index.ts
+++ b/packages/components/src/navigator/navigator-back-button/index.ts
@@ -1,1 +1,1 @@
-export { default } from './component';
+export { default as NavigatorBackButton } from './component';

--- a/packages/components/src/navigator/navigator-button/component.tsx
+++ b/packages/components/src/navigator/navigator-button/component.tsx
@@ -11,7 +11,7 @@ import { View } from '../../view';
 import { useNavigatorButton } from './hook';
 import type { NavigatorButtonProps } from '../types';
 
-function NavigatorButton(
+function UnconnectedNavigatorButton(
 	props: WordPressComponentProps< NavigatorButtonProps, 'button' >,
 	forwardedRef: ForwardedRef< any >
 ) {
@@ -53,9 +53,9 @@ function NavigatorButton(
  * );
  * ```
  */
-const ConnectedNavigatorButton = contextConnect(
-	NavigatorButton,
+export const NavigatorButton = contextConnect(
+	UnconnectedNavigatorButton,
 	'NavigatorButton'
 );
 
-export default ConnectedNavigatorButton;
+export default NavigatorButton;

--- a/packages/components/src/navigator/navigator-button/index.ts
+++ b/packages/components/src/navigator/navigator-button/index.ts
@@ -1,1 +1,1 @@
-export { default } from './component';
+export { default as NavigatorButton } from './component';

--- a/packages/components/src/navigator/navigator-provider/component.tsx
+++ b/packages/components/src/navigator/navigator-provider/component.tsx
@@ -26,7 +26,7 @@ import type {
 	NavigatorContext as NavigatorContextType,
 } from '../types';
 
-function NavigatorProvider(
+function UnconnectedNavigatorProvider(
 	props: WordPressComponentProps< NavigatorProviderProps, 'div' >,
 	forwardedRef: ForwardedRef< any >
 ) {
@@ -129,9 +129,9 @@ function NavigatorProvider(
  * );
  * ```
  */
-const ConnectedNavigatorProvider = contextConnect(
-	NavigatorProvider,
+export const NavigatorProvider = contextConnect(
+	UnconnectedNavigatorProvider,
 	'NavigatorProvider'
 );
 
-export default ConnectedNavigatorProvider;
+export default NavigatorProvider;

--- a/packages/components/src/navigator/navigator-provider/index.ts
+++ b/packages/components/src/navigator/navigator-provider/index.ts
@@ -1,1 +1,1 @@
-export { default } from './component';
+export { default as NavigatorProvider } from './component';

--- a/packages/components/src/navigator/navigator-screen/component.tsx
+++ b/packages/components/src/navigator/navigator-screen/component.tsx
@@ -42,7 +42,10 @@ type Props = Omit<
 	keyof MotionProps
 >;
 
-function NavigatorScreen( props: Props, forwardedRef: ForwardedRef< any > ) {
+function UnconnectedNavigatorScreen(
+	props: Props,
+	forwardedRef: ForwardedRef< any >
+) {
 	const { children, className, path, ...otherProps } = useContextSystem(
 		props,
 		'NavigatorScreen'
@@ -200,9 +203,9 @@ function NavigatorScreen( props: Props, forwardedRef: ForwardedRef< any > ) {
  * );
  * ```
  */
-const ConnectedNavigatorScreen = contextConnect(
-	NavigatorScreen,
+export const NavigatorScreen = contextConnect(
+	UnconnectedNavigatorScreen,
 	'NavigatorScreen'
 );
 
-export default ConnectedNavigatorScreen;
+export default NavigatorScreen;

--- a/packages/components/src/navigator/navigator-screen/index.ts
+++ b/packages/components/src/navigator/navigator-screen/index.ts
@@ -1,1 +1,1 @@
-export { default } from './component';
+export { default as NavigatorScreen } from './component';

--- a/packages/components/src/navigator/stories/index.tsx
+++ b/packages/components/src/navigator/stories/index.tsx
@@ -3,6 +3,7 @@
  */
 import type { ReactNode } from 'react';
 import { css } from '@emotion/react';
+import type { ComponentMeta, ComponentStory } from '@storybook/react';
 
 /**
  * Internal dependencies
@@ -19,17 +20,33 @@ import {
 	NavigatorBackButton,
 } from '..';
 
-export default {
-	title: 'Components (Experimental)/Navigator',
+const meta: ComponentMeta< typeof NavigatorProvider > = {
 	component: NavigatorProvider,
+	title: 'Components (Experimental)/Navigator',
+	subcomponents: { NavigatorScreen, NavigatorButton, NavigatorBackButton },
+	argTypes: {
+		as: { control: { type: null } },
+		children: { control: { type: null } },
+	},
+	parameters: {
+		controls: { expanded: true },
+		docs: { source: { state: 'open' } },
+	},
 };
+export default meta;
 
-const MyNavigation = () => {
+const Template: ComponentStory< typeof NavigatorProvider > = ( {
+	className,
+	...props
+} ) => {
 	const cx = useCx();
 	return (
 		<NavigatorProvider
-			initialPath="/"
-			className={ cx( css( `height: 100vh; max-height: 450px;` ) ) }
+			className={ cx(
+				css( `height: 100vh; max-height: 450px;` ),
+				className
+			) }
+			{ ...props }
 		>
 			<NavigatorScreen path="/">
 				<Card>
@@ -153,8 +170,10 @@ const MyNavigation = () => {
 	);
 };
 
-export const _default = () => {
-	return <MyNavigation />;
+export const Default: ComponentStory< typeof NavigatorProvider > =
+	Template.bind( {} );
+Default.args = {
+	initialPath: '/',
 };
 
 type StickyProps = {

--- a/packages/components/src/navigator/stories/index.tsx
+++ b/packages/components/src/navigator/stories/index.tsx
@@ -16,7 +16,7 @@ import {
 	NavigatorScreen,
 	NavigatorButton,
 	NavigatorBackButton,
-} from '../';
+} from '..';
 
 export default {
 	title: 'Components (Experimental)/Navigator',

--- a/packages/components/src/navigator/stories/index.tsx
+++ b/packages/components/src/navigator/stories/index.tsx
@@ -1,6 +1,7 @@
 /**
  * External dependencies
  */
+import type { ReactNode } from 'react';
 import { css } from '@emotion/react';
 
 /**
@@ -55,7 +56,14 @@ const MyNavigation = () => {
 							</NavigatorButton>
 
 							<Dropdown
-								renderToggle={ ( { isOpen, onToggle } ) => (
+								renderToggle={ ( {
+									isOpen,
+									onToggle,
+								}: {
+									// TODO: remove once `Dropdown` is refactored to TypeScript
+									isOpen: boolean;
+									onToggle: () => void;
+								} ) => (
 									<Button
 										onClick={ onToggle }
 										aria-expanded={ isOpen }
@@ -119,19 +127,19 @@ const MyNavigation = () => {
 
 			<NavigatorScreen path="/stickies">
 				<Card>
-					<Sticky as={ CardHeader } z="2">
+					<Sticky as={ CardHeader } z={ 2 }>
 						<NavigatorBackButton variant="secondary">
 							Go back
 						</NavigatorBackButton>
 					</Sticky>
 					<CardBody>
-						<Sticky top="69px" colors="papayawhip/peachpuff">
+						<Sticky top={ 69 } colors="papayawhip/peachpuff">
 							<h2>A wild sticky element appears</h2>
 						</Sticky>
 						<MetaphorIpsum quantity={ 3 } />
 					</CardBody>
 					<CardBody>
-						<Sticky top="69px" colors="azure/paleturquoise">
+						<Sticky top={ 69 } colors="azure/paleturquoise">
 							<h2>Another wild sticky element appears</h2>
 						</Sticky>
 						<MetaphorIpsum quantity={ 3 } />
@@ -149,17 +157,27 @@ export const _default = () => {
 	return <MyNavigation />;
 };
 
+type StickyProps = {
+	as?: React.ElementType;
+	bottom?: number;
+	children: ReactNode;
+	className?: string;
+	colors?: string;
+	top?: number;
+	z?: number;
+};
 function Sticky( {
 	as: Tag = 'div',
 	bottom = 0,
+	children,
+	className,
 	colors = 'whitesmoke/lightgrey',
 	top = 0,
 	z: zIndex = 1,
-	...props
-} ) {
+}: StickyProps ) {
 	const cx = useCx();
 	const [ bgColor, dotColor ] = colors.split( '/' );
-	const className = cx(
+	const classes = cx(
 		css( {
 			top,
 			bottom,
@@ -168,13 +186,12 @@ function Sticky( {
 			position: 'sticky',
 			background: `radial-gradient(${ dotColor } 1px, ${ bgColor } 2px) 50%/1em 1em`,
 		} ),
-		props.className
+		className
 	);
-	const propsOut = { ...props, className };
-	return <Tag { ...propsOut } />;
+	return <Tag className={ classes }>{ children }</Tag>;
 }
 
-function MetaphorIpsum( { quantity } ) {
+function MetaphorIpsum( { quantity }: { quantity: number } ) {
 	const cx = useCx();
 	const list = [
 		'A loopy clarinet’s year comes with it the thought that the fenny step-son is an ophthalmologist. The literature would have us believe that a glabrate country is not but a rhythm. A beech is a rub from the right perspective. In ancient times few can name an unglossed walrus that isn’t an unspilt trial.',

--- a/packages/components/src/navigator/stories/index.tsx
+++ b/packages/components/src/navigator/stories/index.tsx
@@ -1,8 +1,6 @@
 /**
  * External dependencies
  */
-import type { ReactNode } from 'react';
-import { css } from '@emotion/react';
 import type { ComponentMeta, ComponentStory } from '@storybook/react';
 
 /**
@@ -12,7 +10,6 @@ import Button from '../../button';
 import { Card, CardBody, CardFooter, CardHeader } from '../../card';
 import { HStack } from '../../h-stack';
 import Dropdown from '../../dropdown';
-import { useCx } from '../../utils/hooks/use-cx';
 import {
 	NavigatorProvider,
 	NavigatorScreen,
@@ -27,6 +24,7 @@ const meta: ComponentMeta< typeof NavigatorProvider > = {
 	argTypes: {
 		as: { control: { type: null } },
 		children: { control: { type: null } },
+		initialPath: { control: { type: null } },
 	},
 	parameters: {
 		controls: { expanded: true },
@@ -36,139 +34,140 @@ const meta: ComponentMeta< typeof NavigatorProvider > = {
 export default meta;
 
 const Template: ComponentStory< typeof NavigatorProvider > = ( {
-	className,
+	style,
 	...props
-} ) => {
-	const cx = useCx();
-	return (
-		<NavigatorProvider
-			className={ cx(
-				css( `height: 100vh; max-height: 450px;` ),
-				className
-			) }
-			{ ...props }
-		>
-			<NavigatorScreen path="/">
-				<Card>
-					<CardBody>
-						<p>This is the home screen.</p>
+} ) => (
+	<NavigatorProvider
+		style={ { ...style, height: '100vh', maxHeight: '450px' } }
+		{ ...props }
+	>
+		<NavigatorScreen path="/">
+			<Card>
+				<CardBody>
+					<p>This is the home screen.</p>
 
-						<HStack justify="flex-start" wrap>
-							<NavigatorButton variant="secondary" path="/child">
-								Navigate to child screen.
-							</NavigatorButton>
+					<HStack justify="flex-start" wrap>
+						<NavigatorButton variant="secondary" path="/child">
+							Navigate to child screen.
+						</NavigatorButton>
 
-							<NavigatorButton
-								variant="secondary"
-								path="/overflow-child"
-							>
-								Navigate to screen with horizontal overflow.
-							</NavigatorButton>
-
-							<NavigatorButton
-								variant="secondary"
-								path="/stickies"
-							>
-								Navigate to screen with sticky content.
-							</NavigatorButton>
-
-							<Dropdown
-								renderToggle={ ( {
-									isOpen,
-									onToggle,
-								}: {
-									// TODO: remove once `Dropdown` is refactored to TypeScript
-									isOpen: boolean;
-									onToggle: () => void;
-								} ) => (
-									<Button
-										onClick={ onToggle }
-										aria-expanded={ isOpen }
-										variant="primary"
-									>
-										Open test dialog
-									</Button>
-								) }
-								renderContent={ () => (
-									<Card>
-										<CardHeader>Go</CardHeader>
-										<CardBody>Stuff</CardBody>
-									</Card>
-								) }
-							/>
-						</HStack>
-					</CardBody>
-				</Card>
-			</NavigatorScreen>
-
-			<NavigatorScreen path="/child">
-				<Card>
-					<CardBody>
-						<p>This is the child screen.</p>
-						<NavigatorBackButton variant="secondary">
-							Go back
-						</NavigatorBackButton>
-					</CardBody>
-				</Card>
-			</NavigatorScreen>
-
-			<NavigatorScreen path="/overflow-child">
-				<Card>
-					<CardBody>
-						<NavigatorBackButton variant="secondary">
-							Go back
-						</NavigatorBackButton>
-						<div
-							className={ cx(
-								css( `
-									display: inline-block;
-									background: papayawhip;
-								` )
-							) }
+						<NavigatorButton
+							variant="secondary"
+							path="/overflow-child"
 						>
-							<span
-								className={ cx(
-									css( `
-										color: palevioletred;
-										white-space: nowrap;
-										font-size: 42vw;
-									` )
-								) }
-							>
-								¯\_(ツ)_/¯
-							</span>
-						</div>
-					</CardBody>
-				</Card>
-			</NavigatorScreen>
+							Navigate to screen with horizontal overflow.
+						</NavigatorButton>
 
-			<NavigatorScreen path="/stickies">
-				<Card>
-					<Sticky as={ CardHeader } z={ 2 }>
-						<NavigatorBackButton variant="secondary">
-							Go back
-						</NavigatorBackButton>
-					</Sticky>
-					<CardBody>
-						<Sticky top={ 69 } colors="papayawhip/peachpuff">
-							<h2>A wild sticky element appears</h2>
-						</Sticky>
-						<MetaphorIpsum quantity={ 3 } />
-					</CardBody>
-					<CardBody>
-						<Sticky top={ 69 } colors="azure/paleturquoise">
-							<h2>Another wild sticky element appears</h2>
-						</Sticky>
-						<MetaphorIpsum quantity={ 3 } />
-					</CardBody>
-					<Sticky as={ CardFooter } colors="mistyrose/pink">
-						<Button variant="primary">Primary noop</Button>
-					</Sticky>
-				</Card>
-			</NavigatorScreen>
-		</NavigatorProvider>
-	);
-};
+						<NavigatorButton variant="secondary" path="/stickies">
+							Navigate to screen with sticky content.
+						</NavigatorButton>
+
+						<Dropdown
+							renderToggle={ ( {
+								isOpen,
+								onToggle,
+							}: {
+								// TODO: remove once `Dropdown` is refactored to TypeScript
+								isOpen: boolean;
+								onToggle: () => void;
+							} ) => (
+								<Button
+									onClick={ onToggle }
+									aria-expanded={ isOpen }
+									variant="primary"
+								>
+									Open test dialog
+								</Button>
+							) }
+							renderContent={ () => (
+								<Card>
+									<CardHeader>Go</CardHeader>
+									<CardBody>Stuff</CardBody>
+								</Card>
+							) }
+						/>
+					</HStack>
+				</CardBody>
+			</Card>
+		</NavigatorScreen>
+
+		<NavigatorScreen path="/child">
+			<Card>
+				<CardBody>
+					<p>This is the child screen.</p>
+					<NavigatorBackButton variant="secondary">
+						Go back
+					</NavigatorBackButton>
+				</CardBody>
+			</Card>
+		</NavigatorScreen>
+
+		<NavigatorScreen path="/overflow-child">
+			<Card>
+				<CardBody>
+					<NavigatorBackButton variant="secondary">
+						Go back
+					</NavigatorBackButton>
+					<div
+						style={ {
+							display: 'inline-block',
+							background: 'papayawhip',
+						} }
+					>
+						<span
+							style={ {
+								color: 'palevioletred',
+								whiteSpace: 'nowrap',
+								fontSize: '42vw',
+							} }
+						>
+							¯\_(ツ)_/¯
+						</span>
+					</div>
+				</CardBody>
+			</Card>
+		</NavigatorScreen>
+
+		<NavigatorScreen path="/stickies">
+			<Card>
+				<CardHeader style={ getStickyStyles( { zIndex: 2 } ) }>
+					<NavigatorBackButton variant="secondary">
+						Go back
+					</NavigatorBackButton>
+				</CardHeader>
+				<CardBody>
+					<div
+						style={ getStickyStyles( {
+							top: 69,
+							bgColor: 'peachpuff',
+						} ) }
+					>
+						<h2>A wild sticky element appears</h2>
+					</div>
+					<MetaphorIpsum quantity={ 3 } />
+				</CardBody>
+				<CardBody>
+					<div
+						style={ getStickyStyles( {
+							top: 69,
+							bgColor: 'paleturquoise',
+						} ) }
+					>
+						<h2>Another wild sticky element appears</h2>
+					</div>
+					<MetaphorIpsum quantity={ 3 } />
+				</CardBody>
+				<CardFooter
+					style={ getStickyStyles( {
+						bgColor: 'mistyrose',
+					} ) }
+				>
+					<Button variant="primary">Primary noop</Button>
+				</CardFooter>
+			</Card>
+		</NavigatorScreen>
+	</NavigatorProvider>
+);
 
 export const Default: ComponentStory< typeof NavigatorProvider > =
 	Template.bind( {} );
@@ -176,42 +175,23 @@ Default.args = {
 	initialPath: '/',
 };
 
-type StickyProps = {
-	as?: React.ElementType;
-	bottom?: number;
-	children: ReactNode;
-	className?: string;
-	colors?: string;
-	top?: number;
-	z?: number;
-};
-function Sticky( {
-	as: Tag = 'div',
+function getStickyStyles( {
 	bottom = 0,
-	children,
-	className,
-	colors = 'whitesmoke/lightgrey',
+	bgColor = 'whitesmoke',
 	top = 0,
-	z: zIndex = 1,
-}: StickyProps ) {
-	const cx = useCx();
-	const [ bgColor, dotColor ] = colors.split( '/' );
-	const classes = cx(
-		css( {
-			top,
-			bottom,
-			zIndex,
-			display: 'flex',
-			position: 'sticky',
-			background: `radial-gradient(${ dotColor } 1px, ${ bgColor } 2px) 50%/1em 1em`,
-		} ),
-		className
-	);
-	return <Tag className={ classes }>{ children }</Tag>;
+	zIndex = 1,
+} ): React.CSSProperties {
+	return {
+		display: 'flex',
+		position: 'sticky',
+		top,
+		bottom,
+		zIndex,
+		backgroundColor: bgColor,
+	};
 }
 
 function MetaphorIpsum( { quantity }: { quantity: number } ) {
-	const cx = useCx();
 	const list = [
 		'A loopy clarinet’s year comes with it the thought that the fenny step-son is an ophthalmologist. The literature would have us believe that a glabrate country is not but a rhythm. A beech is a rub from the right perspective. In ancient times few can name an unglossed walrus that isn’t an unspilt trial.',
 		'Authors often misinterpret the afterthought as a roseless mother-in-law, when in actuality it feels more like an uncapped thunderstorm. In recent years, some posit the tarry bottle to be less than acerb. They were lost without the unkissed timbale that composed their customer. A donna is a springtime breath.',
@@ -221,7 +201,7 @@ function MetaphorIpsum( { quantity }: { quantity: number } ) {
 	return (
 		<>
 			{ list.slice( 0, quantity ).map( ( text, key ) => (
-				<p className={ cx( css( `max-width: 20em;` ) ) } key={ key }>
+				<p style={ { maxWidth: '20em' } } key={ key }>
 					{ text }
 				</p>
 			) ) }

--- a/packages/components/src/navigator/types.ts
+++ b/packages/components/src/navigator/types.ts
@@ -47,6 +47,7 @@ export type NavigatorScreenProps = {
 type ButtonProps = {
 	// TODO: should also extend `Button` prop types once the `Button` component
 	// is refactored to TypeScript.
+	variant?: 'primary' | 'secondary' | 'tertiary' | 'link';
 };
 export type NavigatorBackButtonProps = Omit< ButtonProps, 'href' > & {
 	/**


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Part of https://github.com/WordPress/gutenberg/issues/35744

Refactor `Navigator`'s Storybook code to TypeScript and controls, thus enabling auto-generated documentation.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

Improving the code quality and the documentation of `@wordpress/components`.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

 - Refactored Storybook code to remove TypeScript errors, use controls and allow doc generation from types
 - This required a refactor in the way the `Navigator` sub-components are named/exported internally (as suggested in the [migration guide](https://github.com/WordPress/gutenberg/blob/trunk/packages/components/CONTRIBUTING.md#refactoring-a-component-to-typescript))
 - In the process, I made some simplification to the Storybook stories code:
   - Removed usage of Emotion's `cx` and `css` functions, in favour or simpler inline styles (this is to show that Emotion is not necessary to consume and style our components)
   - Simplified code around the Sticky component — instead of a polymorphic component (which was creating some TypeScript hiccups due to its polymorphic nature), I've replace it with a simpler style getter. I also decided to drop the (pretty but useless) dotted backgrounds, in favour of a solid background.

_Reviewing this PR commit-by-commit may ease the reviewing process._

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->

Interact with `Navigator`'s Storybook examples, make sure they look and work as on `trunk`.
