### PR TITLE
ESLint: Add and enable `eslint-plugin-jest-dom`

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -320,6 +320,11 @@ module.exports = {
 			extends: [ 'plugin:@wordpress/eslint-plugin/test-unit' ],
 		},
 		{
+			files: [ '**/test/**/*.js' ],
+			excludedFiles: [ '**/*.@(android|ios|native).js' ],
+			extends: [ 'plugin:jest-dom/recommended' ],
+		},
+		{
 			files: [ 'packages/e2e-test*/**/*.js' ],
 			excludedFiles: [ 'packages/e2e-test-utils-playwright/**/*.js' ],
 			extends: [ 'plugin:@wordpress/eslint-plugin/test-e2e' ],

--- a/package-lock.json
+++ b/package-lock.json
@@ -33453,6 +33453,28 @@
 				"@typescript-eslint/experimental-utils": "^5.0.0"
 			}
 		},
+		"eslint-plugin-jest-dom": {
+			"version": "4.0.2",
+			"resolved": "https://registry.npmjs.org/eslint-plugin-jest-dom/-/eslint-plugin-jest-dom-4.0.2.tgz",
+			"integrity": "sha512-Jo51Atwyo2TdcUncjmU+UQeSTKh3sc2LF/M5i/R3nTU0Djw9V65KGJisdm/RtuKhy2KH/r7eQ1n6kwYFPNdHlA==",
+			"dev": true,
+			"requires": {
+				"@babel/runtime": "^7.16.3",
+				"@testing-library/dom": "^8.11.1",
+				"requireindex": "^1.2.0"
+			},
+			"dependencies": {
+				"@babel/runtime": {
+					"version": "7.19.4",
+					"resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.19.4.tgz",
+					"integrity": "sha512-EXpLCrk55f+cYqmHsSR+yD/0gAIMxxA9QK9lnQWzhMCvt+YmoBN7Zx94s++Kv0+unHk39vxNO8t+CMA2WSS3wA==",
+					"dev": true,
+					"requires": {
+						"regenerator-runtime": "^0.13.4"
+					}
+				}
+			}
+		},
 		"eslint-plugin-jsdoc": {
 			"version": "37.0.3",
 			"resolved": "https://registry.npmjs.org/eslint-plugin-jsdoc/-/eslint-plugin-jsdoc-37.0.3.tgz",

--- a/package.json
+++ b/package.json
@@ -185,6 +185,7 @@
 		"eslint-import-resolver-node": "0.3.4",
 		"eslint-plugin-eslint-comments": "3.1.2",
 		"eslint-plugin-import": "2.25.2",
+		"eslint-plugin-jest-dom": "4.0.2",
 		"eslint-plugin-playwright": "0.8.0",
 		"eslint-plugin-ssr-friendly": "1.0.6",
 		"execa": "4.0.2",

--- a/packages/components/src/ui/tooltip/test/index.js
+++ b/packages/components/src/ui/tooltip/test/index.js
@@ -37,14 +37,14 @@ describe( 'props', () => {
 				<Text>{ invisibleTooltipTriggerContent }</Text>
 			</Tooltip>
 		);
-		const tooltips = screen.getAllByRole( /tooltip/i );
+		const tooltip = screen.getByRole( /tooltip/i );
 		const invisibleTooltipTrigger = screen.getByText(
 			invisibleTooltipTriggerContent
 		);
-		// The invisible tooltip should not render.
-		expect( tooltips ).toHaveLength( 1 );
+		// The base tooltip should render only; invisible tooltip should not render.
+		expect( tooltip ).toBeInTheDocument();
 		// Assert that the rendered tooltip is indeed the base tooltip.
-		expect( tooltips[ 0 ].id ).toBe( baseTooltipId );
+		expect( tooltip.id ).toBe( baseTooltipId );
 		// But the invisible tooltip's trigger still should have rendered.
 		expect( invisibleTooltipTrigger ).not.toBeUndefined();
 	} );
@@ -70,9 +70,9 @@ describe( 'props', () => {
 				<Text>WordPress.org</Text>
 			</Tooltip>
 		);
-		const tooltips = screen.getAllByRole( /tooltip/i );
+		const tooltip = screen.getByRole( /tooltip/i );
 		// Assert only the base tooltip rendered.
-		expect( tooltips ).toHaveLength( 1 );
-		expect( tooltips[ 0 ].id ).toBe( baseTooltipId );
+		expect( tooltip ).toBeInTheDocument();
+		expect( tooltip.id ).toBe( baseTooltipId );
 	} );
 } );


### PR DESCRIPTION
## What?
This PR introduces the [`eslint-plugin-jest-dom`](https://github.com/testing-library/eslint-plugin-jest-dom) ESLint plugin and enables it for all non-native test files. 

## Why?
It aims to help maintain following the best practices when writing tests with `jest-dom`. There's been [a discussion](https://github.com/WordPress/gutenberg/pull/44925#issuecomment-1277433488) around how restrictive those are, and I believe they ensure best practices while being not-so-restrictive, but I'm happy to take feedback.

## How?
We're enabling the plugin and all its recommended rules for all test files, and excluding all native tests because there's a [separate library](https://testing-library.com/docs/ecosystem-jest-native/) for it, and we're not using it just yet.

We're also fixing a false positive in a test - the only remaining one that wasn't following the recommended rules.

## Testing Instructions
* Verify all checks are still green.
* Verify that if you try using `element.textContent` or `element.getAttribute()` in your test, you'll get an error.
