### PR TITLE
ESLint: Fix a few jsdoc/check-line-alignment warnings

### DIFF
--- a/packages/edit-site/src/components/global-styles/typography-utils.js
+++ b/packages/edit-site/src/components/global-styles/typography-utils.js
@@ -11,7 +11,7 @@ import { getComputedFluidTypographyValue } from '@wordpress/block-editor';
 
 /**
  * @typedef {Object} FluidPreset
- * @property {string|undefined} max A maximum font size value.
+ * @property {string|undefined}  max A maximum font size value.
  * @property {?string|undefined} min A minimum font size value.
  */
 

--- a/packages/style-engine/src/styles/border/index.ts
+++ b/packages/style-engine/src/styles/border/index.ts
@@ -7,7 +7,7 @@ import { generateRule, generateBoxRules, camelCaseJoin } from '../utils';
 /**
  * Creates a function for generating CSS rules when the style path is the same as the camelCase CSS property used in React.
  *
- * @param path An array of strings representing the path to the style value in the style object.
+ * @param  path An array of strings representing the path to the style value in the style object.
  *
  * @return A function that generates CSS rules.
  */
@@ -19,7 +19,7 @@ function createBorderGenerateFunction( path: string[] ): GenerateFunction {
 /**
  * Creates a function for generating border-{top,bottom,left,right}-{color,style,width} CSS rules.
  *
- * @param edge The edge to create CSS rules for.
+ * @param  edge The edge to create CSS rules for.
  *
  * @return A function that generates CSS rules.
  */

--- a/packages/style-engine/src/styles/utils.ts
+++ b/packages/style-engine/src/styles/utils.ts
@@ -129,7 +129,7 @@ export function getCSSVarFromStyleValue( styleValue: string ): string {
 /**
  * Capitalizes the first letter in a string.
  *
- * @param string The string whose first letter the function will capitalize.
+ * @param  string The string whose first letter the function will capitalize.
  *
  * @return String with the first letter capitalized.
  */
@@ -141,7 +141,7 @@ export function upperFirst( string: string ): string {
 /**
  * Converts an array of strings into a camelCase string.
  *
- * @param strings The strings to join into a camelCase string.
+ * @param  strings The strings to join into a camelCase string.
  *
  * @return camelCase string.
  */


### PR DESCRIPTION
## What?
While working on #44983 I discovered that there are a few `jsdoc/check-line-alignment` warnings in the codebase. I'm fixing them in this PR.

## Why?
Ideally, we should have no ESLint warnings or errors at all. This PR reduces the number of warnings.

## How?
We're just running `npm run lint:js:fix`

## Testing Instructions
Run `npm run lint:js` and verify there are no more `jsdoc/check-line-alignment` warnings.
