### PR TITLE
Global Styles: Invoke zoomed-out view when selecting a style variation

### DIFF
--- a/packages/edit-site/src/components/global-styles/screen-style-variations.js
+++ b/packages/edit-site/src/components/global-styles/screen-style-variations.js
@@ -8,8 +8,14 @@ import classnames from 'classnames';
  * WordPress dependencies
  */
 import { store as coreStore } from '@wordpress/core-data';
-import { useSelect } from '@wordpress/data';
-import { useMemo, useContext, useState } from '@wordpress/element';
+import { useSelect, useDispatch } from '@wordpress/data';
+import {
+	useMemo,
+	useContext,
+	useState,
+	useEffect,
+	useRef,
+} from '@wordpress/element';
 import { ENTER } from '@wordpress/keycodes';
 import {
 	__experimentalGrid as Grid,
@@ -17,6 +23,7 @@ import {
 	CardBody,
 } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
+import { store as blockEditorStore } from '@wordpress/block-editor';
 
 /**
  * Internal dependencies
@@ -96,12 +103,14 @@ function Variation( { variation } ) {
 }
 
 function ScreenStyleVariations() {
-	const { variations } = useSelect( ( select ) => {
+	const { variations, mode } = useSelect( ( select ) => {
 		return {
 			variations:
 				select(
 					coreStore
 				).__experimentalGetCurrentThemeGlobalStylesVariations(),
+
+			mode: select( blockEditorStore ).__unstableGetEditorMode(),
 		};
 	}, [] );
 
@@ -119,6 +128,31 @@ function ScreenStyleVariations() {
 			} ) ),
 		];
 	}, [ variations ] );
+
+	const { __unstableSetEditorMode } = useDispatch( blockEditorStore );
+	const shouldRevertInitialMode = useRef( null );
+	useEffect( () => {
+		// ignore changes to zoom-out mode as we explictily change to it on mount.
+		if ( mode !== 'zoom-out' ) {
+			shouldRevertInitialMode.current = false;
+		}
+	}, [ mode ] );
+
+	// Intentionality left without any dependency.
+	// This effect should only run the first time the component is rendered.
+	// The effect opens the zoom-out view if it is not open before when applying a style variation.
+	useEffect( () => {
+		if ( mode !== 'zoom-out' ) {
+			__unstableSetEditorMode( 'zoom-out' );
+			shouldRevertInitialMode.current = true;
+			return () => {
+				// if there were not mode changes revert to the initial mode when unmounting.
+				if ( shouldRevertInitialMode.current ) {
+					__unstableSetEditorMode( mode );
+				}
+			};
+		}
+	}, [] );
 
 	return (
 		<>


### PR DESCRIPTION
Fixes: https://github.com/WordPress/gutenberg/issues/44419

This PR opens the zoom-out when the user selects a style variation.


## Testing
- Open the style variations UI and verify that when the panel opens, the editor automatically goes into zoom-out mode.
- Close the global styles sidebar when picking a style variation and verify the editor automatically goes out of zoom-out mode.
- Open the style variations UI, then go to the code editor mode.
- Close the global styles sidebar when picking a style variation and verify the editor continue on the code editor mode.