### PR TITLE
Fix the cover block focal point picker

### DIFF
--- a/packages/block-library/src/cover/edit/index.js
+++ b/packages/block-library/src/cover/edit/index.js
@@ -195,9 +195,11 @@ function CoverEdit( {
 		}
 	);
 
+	const mediaElement = useRef();
 	const currentSettings = {
 		isVideoBackground,
 		isImageBackground,
+		mediaElement,
 		hasInnerBlocks,
 		url,
 		isImgElement,
@@ -359,6 +361,7 @@ function CoverEdit( {
 					isImageBackground &&
 					( isImgElement ? (
 						<img
+							ref={ mediaElement }
 							className="wp-block-cover__image-background"
 							alt={ alt }
 							src={ url }
@@ -366,6 +369,7 @@ function CoverEdit( {
 						/>
 					) : (
 						<div
+							ref={ mediaElement }
 							role="img"
 							className={ classnames(
 								classes,
@@ -376,6 +380,7 @@ function CoverEdit( {
 					) ) }
 				{ url && isVideoBackground && (
 					<video
+						ref={ mediaElement }
 						className="wp-block-cover__video-background"
 						autoPlay
 						muted


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Fixes an issue with the cover block focal point picker introduced by #44552 where the focal point could no longer be selected.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

🐛🔧 bug fix

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

Re-adds the `mediaElement` ref to the cover block which is needed for the focal point picker.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->

1. Insert a cover block.
2. Select an image/video background.
3. Use the focal point picker to change the focal point of the image.

## Screenshots or screencast <!-- if applicable -->
