### PR TITLE
fix: Deeply nested blocks support iOS Voice Control

### DIFF
--- a/packages/block-editor/src/components/block-list/block.native.js
+++ b/packages/block-editor/src/components/block-list/block.native.js
@@ -188,7 +188,7 @@ class BlockListBlock extends Component {
 			getStylesFromColorScheme,
 			marginVertical,
 			marginHorizontal,
-			isInnerBlockSelected,
+			isDescendentBlockSelected,
 			name,
 			draggingEnabled,
 			draggingClientId,
@@ -205,7 +205,7 @@ class BlockListBlock extends Component {
 			order + 1
 		);
 		const { isFullWidth, isContainerRelated } = alignmentHelpers;
-		const accessible = ! ( isSelected || isInnerBlockSelected );
+		const accessible = ! ( isSelected || isDescendentBlockSelected );
 		const screenWidth = Math.floor( Dimensions.get( 'window' ).width );
 		const isScreenWidthEqual = blockWidth === screenWidth;
 		const isScreenWidthWider = blockWidth < screenWidth;
@@ -335,7 +335,11 @@ export default compose( [
 
 		const order = getBlockIndex( clientId );
 		const isSelected = isBlockSelected( clientId );
-		const isInnerBlockSelected = hasSelectedInnerBlock( clientId );
+		const checkDeep = true;
+		const isDescendentBlockSelected = hasSelectedInnerBlock(
+			clientId,
+			checkDeep
+		);
 		const block = getBlock( clientId );
 		const { name, attributes, isValid } = block || {};
 
@@ -378,9 +382,7 @@ export default compose( [
 		// blocks if any of them are selected. This way we prevent the long-press
 		// gesture from being disabled for elements within the block UI.
 		const draggingEnabled =
-			! hasInnerBlocks ||
-			isSelected ||
-			! hasSelectedInnerBlock( clientId, true );
+			! hasInnerBlocks || isSelected || ! isDescendentBlockSelected;
 		// Dragging nested blocks is not supported yet. For this reason, the block to be dragged
 		// will be the top in the hierarchy.
 		const draggingClientId = getBlockHierarchyRootClientId( clientId );
@@ -395,7 +397,7 @@ export default compose( [
 			draggingClientId,
 			draggingEnabled,
 			isSelected,
-			isInnerBlockSelected,
+			isDescendentBlockSelected,
 			isValid,
 			isParentSelected,
 			firstToSelectId,


### PR DESCRIPTION
> **Warning** This change creates severe performance issues and **should not be merged**. 

## What?
Update block accessible status to take into consideration all descendent blocks, rather than merely its child blocks. This allows iOS Voice Control to take action upon text inputs within currently selected, deeply nested blocks.

## Why?
Fixes https://github.com/WordPress/gutenberg/issues/45415. The shallow consideration controlling a block's accessibility status resulted in ancestors erroneously marking themselves as accessible when their deeply nested descendant was the block actively focused. This inhibited accessibility features like iOS Voice Over from taking action on focused text inputs. 

## How?

Using a deep check of `hasInnerBlocks` results in a ancestor's block accessibility status to be accurate based upon its descendants status. 

## Testing Instructions

See https://github.com/WordPress/gutenberg/issues/45415. 

<details><summary>Test iOS Voice Control</summary>

1. Activate iOS [Voice Control](https://support.apple.com/en-us/HT210417) on your iOS device.
1. Add a Columns block. 
2. Add a Paragraph block within the first column. 
3. Add text to the Paragraph block. 
1. Dictate "move to beginning."
1. Verify the cursor is at the beginning of the caption. 
1. Dictate "move to end."
1. Verify the cursor is at the end of the caption. 

</details>

<details><summary>Test iOS Voice Over/Android TalkBack</summary>

1. Activate iOS [Voice Over](https://support.apple.com/guide/iphone/turn-on-and-practice-voiceover-iph3e2e415f/ios) or Android [TalkBack](https://support.google.com/accessibility/android/answer/6007100?hl%3Den).
1. Add a Columns block. 
2. Add a Paragraph block within the first column. 
3. Add text to the Paragraph block. 
1. Verify navigating to and editing Paragraph text works as expected.

</details>

## Screenshots or screencast 

TBD