### PR TITLE
Fluid typography: add font size constraints

### DIFF
--- a/lib/block-supports/typography.php
+++ b/lib/block-supports/typography.php
@@ -414,8 +414,9 @@ function gutenberg_get_computed_fluid_typography_value( $args = array() ) {
 	// Borrowed from https://websemantics.uk/tools/responsive-font-calculator/.
 	$view_port_width_offset = round( $minimum_viewport_width['value'] / 100, 3 ) . $font_size_unit;
 	$linear_factor          = 100 * ( ( $maximum_font_size['value'] - $minimum_font_size['value'] ) / ( $maximum_viewport_width['value'] - $minimum_viewport_width['value'] ) );
-	$linear_factor          = round( $linear_factor, 3 ) * $scale_factor;
-	$fluid_target_font_size = implode( '', $minimum_font_size_rem ) . " + ((1vw - $view_port_width_offset) * $linear_factor)";
+	$linear_factor_scaled   = round( $linear_factor * $scale_factor, 3 );
+	$linear_factor_scaled   = empty( $linear_factor_scaled ) ? 1 : $linear_factor_scaled;
+	$fluid_target_font_size = implode( '', $minimum_font_size_rem ) . " + ((1vw - $view_port_width_offset) * $linear_factor_scaled)";
 
 	return "clamp($minimum_font_size_raw, $fluid_target_font_size, $maximum_font_size_raw)";
 }

--- a/lib/block-supports/typography.php
+++ b/lib/block-supports/typography.php
@@ -453,7 +453,7 @@ function gutenberg_get_typography_font_size_value( $preset, $should_use_fluid_ty
 		return $preset['size'];
 	}
 
-	// Check if fluid font sizes are activated.
+	// Checks if fluid font sizes are activated.
 	$typography_settings         = gutenberg_get_global_settings( array( 'typography' ) );
 	$should_use_fluid_typography = isset( $typography_settings['fluid'] ) && true === $typography_settings['fluid'] ? true : $should_use_fluid_typography;
 
@@ -506,10 +506,10 @@ function gutenberg_get_typography_font_size_value( $preset, $should_use_fluid_ty
 		/*
 		 * If a minimum size was not passed to this function
 		 * and the user-defined font size is lower than $minimum_font_size_limit,
-		 * then do not fluidify.
+		 * then uses the user-defined font size as the minimum font-size.
 		 */
 		if ( ! isset( $fluid_font_size_settings['min'] ) && $preferred_size['value'] < $minimum_font_size_limit['value'] ) {
-			return $preset['size'];
+			$minimum_font_size_raw = implode( '', $preferred_size );
 		} else {
 			$minimum_font_size_parsed = gutenberg_get_typography_value_and_unit(
 				$minimum_font_size_raw,

--- a/lib/block-supports/typography.php
+++ b/lib/block-supports/typography.php
@@ -375,7 +375,7 @@ function gutenberg_get_computed_fluid_typography_value( $args = array() ) {
 	 */
 	$font_size_unit = isset( $minimum_font_size['unit'] ) ? $minimum_font_size['unit'] : 'rem';
 
-	// Grab the maximum font size and normalize it in order to use the value for calculations.
+	// Grabs the maximum font size and normalize it in order to use the value for calculations.
 	$maximum_font_size = gutenberg_get_typography_value_and_unit(
 		$maximum_font_size_raw,
 		array(
@@ -385,11 +385,6 @@ function gutenberg_get_computed_fluid_typography_value( $args = array() ) {
 
 	// Checks for mandatory min and max sizes, and protects against unsupported units.
 	if ( ! $maximum_font_size || ! $minimum_font_size ) {
-		return null;
-	}
-
-	// Min font size should not be greater than max font size.
-	if ( $minimum_font_size['value'] > $maximum_font_size['value'] ) {
 		return null;
 	}
 
@@ -489,6 +484,11 @@ function gutenberg_get_typography_font_size_value( $preset, $should_use_fluid_ty
 		return $preset['size'];
 	}
 
+	// If no fluid max font size is available, create one using max font size factor.
+	if ( ! $maximum_font_size_raw ) {
+		$maximum_font_size_raw = round( $preferred_size['value'] * $default_maximum_font_size_factor, 3 ) . $preferred_size['unit'];
+	}
+
 	// If no fluid min font size is available, create one using min font size factor.
 	if ( ! $minimum_font_size_raw ) {
 		$minimum_font_size_raw = round( $preferred_size['value'] * $default_minimum_font_size_factor, 3 ) . $preferred_size['unit'];
@@ -519,18 +519,13 @@ function gutenberg_get_typography_font_size_value( $preset, $should_use_fluid_ty
 			);
 
 			/*
-			 * Otherwise, if the passed or calculated minimum font size is lower than $minimum_font_size_limit
+			 * If the passed or calculated minimum font size is lower than $minimum_font_size_limit
 			 * use $minimum_font_size_limit instead.
 			 */
 			if ( ! empty( $minimum_font_size_parsed ) && $minimum_font_size_parsed['value'] < $minimum_font_size_limit['value'] ) {
 				$minimum_font_size_raw = implode( '', $minimum_font_size_limit );
 			}
 		}
-	}
-
-	// If no fluid max font size is available, create one using max font size factor.
-	if ( ! $maximum_font_size_raw ) {
-		$maximum_font_size_raw = round( $preferred_size['value'] * $default_maximum_font_size_factor, 3 ) . $preferred_size['unit'];
 	}
 
 	$fluid_font_size_value = gutenberg_get_computed_fluid_typography_value(

--- a/lib/block-supports/typography.php
+++ b/lib/block-supports/typography.php
@@ -329,7 +329,7 @@ function gutenberg_get_typography_value_and_unit( $raw_value, $options = array()
 	}
 
 	return array(
-		'value' => $value,
+		'value' => round( $value, 3 ),
 		'unit'  => $unit,
 	);
 }

--- a/lib/block-supports/typography.php
+++ b/lib/block-supports/typography.php
@@ -535,11 +535,11 @@ function gutenberg_get_typography_font_size_value( $preset, $should_use_fluid_ty
 
 	$fluid_font_size_value = gutenberg_get_computed_fluid_typography_value(
 		array(
-			'minimum_viewport_width'  => $default_minimum_viewport_width,
-			'maximum_viewport_width'  => $default_maximum_viewport_width,
-			'minimum_font_size'       => $minimum_font_size_raw,
-			'maximum_font_size'       => $maximum_font_size_raw,
-			'scale_factor'            => $default_scale_factor,
+			'minimum_viewport_width' => $default_minimum_viewport_width,
+			'maximum_viewport_width' => $default_maximum_viewport_width,
+			'minimum_font_size'      => $minimum_font_size_raw,
+			'maximum_font_size'      => $maximum_font_size_raw,
+			'scale_factor'           => $default_scale_factor,
 		)
 	);
 

--- a/packages/block-editor/src/components/font-sizes/fluid-utils.js
+++ b/packages/block-editor/src/components/font-sizes/fluid-utils.js
@@ -264,7 +264,8 @@ export function getTypographyValueAndUnit( rawValue, options = {} ) {
  * @return {number|undefined} Value rounded to standard precision.
  */
 export function roundToPrecision( value, digits = 3 ) {
+	const base = Math.pow( 10, Number( digits ) + 1 );
 	return Number.isFinite( value )
-		? parseFloat( value.toFixed( digits ) )
+		? parseFloat( ( Number( value ) + 1 / base ).toFixed( digits ) )
 		: undefined;
 }

--- a/packages/block-editor/src/components/font-sizes/fluid-utils.js
+++ b/packages/block-editor/src/components/font-sizes/fluid-utils.js
@@ -95,7 +95,7 @@ export function getComputedFluidTypographyValue( {
 		if ( !! minimumFontSizeLimitParsed?.value ) {
 			/*
 			 * If a minimum size was not passed to this function
-			 * and the user-defined font size is lower than $minimum_font_size_limit,
+			 * and the user-defined font size is lower than `minimumFontSizeLimit`,
 			 * then uses the user-defined font size as the minimum font-size.
 			 */
 			if (
@@ -112,8 +112,8 @@ export function getComputedFluidTypographyValue( {
 				);
 
 				/*
-				 * Otherwise, if the passed or calculated minimum font size is lower than $minimum_font_size_limit
-				 * use $minimum_font_size_limit instead.
+				 * Otherwise, if the passed or calculated minimum font size is lower than `minimumFontSizeLimit`
+				 * use `minimumFontSizeLimit` instead.
 				 */
 				if (
 					!! minimumFontSizeParsed?.value &&

--- a/packages/block-editor/src/components/font-sizes/fluid-utils.js
+++ b/packages/block-editor/src/components/font-sizes/fluid-utils.js
@@ -93,27 +93,35 @@ export function getComputedFluidTypographyValue( {
 		);
 
 		if ( !! minimumFontSizeLimitParsed?.value ) {
+			/*
+			 * If a minimum size was not passed to this function
+			 * and the user-defined font size is lower than $minimum_font_size_limit,
+			 * then uses the user-defined font size as the minimum font-size.
+			 */
 			if (
 				! minimumFontSize &&
 				fontSizeParsed?.value < minimumFontSizeLimitParsed?.value
 			) {
-				return null;
-			}
-			const minimumFontSizeParsed = getTypographyValueAndUnit(
-				minimumFontSizeValue,
-				{
-					coerceTo: fontSizeParsed.unit,
+				minimumFontSizeValue = `${ fontSizeParsed.value }${ fontSizeParsed.unit }`;
+			} else {
+				const minimumFontSizeParsed = getTypographyValueAndUnit(
+					minimumFontSizeValue,
+					{
+						coerceTo: fontSizeParsed.unit,
+					}
+				);
+
+				/*
+				 * Otherwise, if the passed or calculated minimum font size is lower than $minimum_font_size_limit
+				 * use $minimum_font_size_limit instead.
+				 */
+				if (
+					!! minimumFontSizeParsed?.value &&
+					minimumFontSizeParsed.value <
+						minimumFontSizeLimitParsed.value
+				) {
+					minimumFontSizeValue = `${ minimumFontSizeLimitParsed.value }${ minimumFontSizeLimitParsed.unit }`;
 				}
-			);
-			/*
-			 * Otherwise, if the passed or calculated minimum font size is lower than $minimum_font_size_limit
-			 * use $minimum_font_size_limit instead.
-			 */
-			if (
-				!! minimumFontSizeParsed?.value &&
-				minimumFontSizeParsed.value < minimumFontSizeLimitParsed.value
-			) {
-				minimumFontSizeValue = `${ minimumFontSizeLimitParsed.value }${ minimumFontSizeLimitParsed.unit }`;
 			}
 		}
 

--- a/packages/block-editor/src/components/font-sizes/fluid-utils.js
+++ b/packages/block-editor/src/components/font-sizes/fluid-utils.js
@@ -200,7 +200,7 @@ export function getComputedFluidTypographyValue( {
 			( maximumViewPortWidthParsed.value -
 				minumumViewPortWidthParsed.value ) );
 	const linearFactorScaled = roundToPrecision(
-		linearFactor * scaleFactor,
+		( linearFactor || 1 ) * scaleFactor,
 		3
 	);
 	const fluidTargetFontSize = `${ minimumFontSizeRem.value }${ minimumFontSizeRem.unit } + ((1vw - ${ viewPortWidthOffset }) * ${ linearFactorScaled })`;
@@ -289,8 +289,8 @@ export function getTypographyValueAndUnit( rawValue, options = {} ) {
  * @return {number|undefined} Value rounded to standard precision.
  */
 export function roundToPrecision( value, digits = 3 ) {
-	const base = Math.pow( 10, digits + 1 );
+	const base = Math.pow( 10, digits );
 	return Number.isFinite( value )
-		? parseFloat( ( value + 1 / base ).toFixed( digits ) )
+		? parseFloat( Math.round( value * base ) / base )
 		: undefined;
 }

--- a/packages/block-editor/src/components/font-sizes/fluid-utils.js
+++ b/packages/block-editor/src/components/font-sizes/fluid-utils.js
@@ -148,7 +148,7 @@ export function getComputedFluidTypographyValue( {
 	// otherwise the result will not be accurate.
 	const fontSizeUnit = minimumFontSizeParsed?.unit || 'rem';
 
-	// Grab the maximum font size and normalize it in order to use the value for calculations.
+	// Grabs the maximum font size and normalize it in order to use the value for calculations.
 	const maximumFontSizeParsed = getTypographyValueAndUnit( maximumFontSize, {
 		coerceTo: fontSizeUnit,
 	} );
@@ -158,12 +158,7 @@ export function getComputedFluidTypographyValue( {
 		return null;
 	}
 
-	// Max font size should not be greater than min font size.
-	if ( minimumFontSizeParsed.value > maximumFontSizeParsed.value ) {
-		return null;
-	}
-
-	// Use rem for accessible fluid target font scaling.
+	// Uses rem for accessible fluid target font scaling.
 	const minimumFontSizeRem = getTypographyValueAndUnit(
 		minimumFontSizeValue,
 		{

--- a/packages/block-editor/src/components/font-sizes/fluid-utils.js
+++ b/packages/block-editor/src/components/font-sizes/fluid-utils.js
@@ -264,8 +264,8 @@ export function getTypographyValueAndUnit( rawValue, options = {} ) {
  * @return {number|undefined} Value rounded to standard precision.
  */
 export function roundToPrecision( value, digits = 3 ) {
-	const base = Math.pow( 10, Number( digits ) + 1 );
+	const base = Math.pow( 10, digits + 1 );
 	return Number.isFinite( value )
-		? parseFloat( ( Number( value ) + 1 / base ).toFixed( digits ) )
+		? parseFloat( ( value + 1 / base ).toFixed( digits ) )
 		: undefined;
 }

--- a/packages/block-editor/src/components/font-sizes/test/fluid-utils.js
+++ b/packages/block-editor/src/components/font-sizes/test/fluid-utils.js
@@ -33,7 +33,7 @@ describe( 'getComputedFluidTypographyValue()', () => {
 			fontSize: '30px',
 		} );
 		expect( fluidTypographyValues ).toBe(
-			'clamp(22.5px, 1.40625rem + ((1vw - 7.68px) * 2.704), 45px)'
+			'clamp(22.5px, 1.406rem + ((1vw - 7.68px) * 2.704), 45px)'
 		);
 	} );
 
@@ -42,7 +42,7 @@ describe( 'getComputedFluidTypographyValue()', () => {
 			fontSize: '30px',
 		} );
 		expect( fluidTypographyValues ).toBe(
-			'clamp(22.5px, 1.40625rem + ((1vw - 7.68px) * 2.704), 45px)'
+			'clamp(22.5px, 1.406rem + ((1vw - 7.68px) * 2.704), 45px)'
 		);
 	} );
 
@@ -53,7 +53,7 @@ describe( 'getComputedFluidTypographyValue()', () => {
 			maximumViewPortWidth: '1000px',
 		} );
 		expect( fluidTypographyValues ).toBe(
-			'clamp(22.5px, 1.40625rem + ((1vw - 5px) * 4.5), 45px)'
+			'clamp(22.5px, 1.406rem + ((1vw - 5px) * 4.5), 45px)'
 		);
 	} );
 
@@ -63,7 +63,7 @@ describe( 'getComputedFluidTypographyValue()', () => {
 			scaleFactor: '2',
 		} );
 		expect( fluidTypographyValues ).toBe(
-			'clamp(22.5px, 1.40625rem + ((1vw - 7.68px) * 5.408), 45px)'
+			'clamp(22.5px, 1.406rem + ((1vw - 7.68px) * 5.409), 45px)'
 		);
 	} );
 
@@ -74,7 +74,7 @@ describe( 'getComputedFluidTypographyValue()', () => {
 			maximumFontSizeFactor: '2',
 		} );
 		expect( fluidTypographyValues ).toBe(
-			'clamp(15px, 0.9375rem + ((1vw - 7.68px) * 5.409), 60px)'
+			'clamp(15px, 0.938rem + ((1vw - 7.68px) * 5.409), 60px)'
 		);
 	} );
 

--- a/packages/edit-site/src/components/global-styles/test/typography-utils.js
+++ b/packages/edit-site/src/components/global-styles/test/typography-utils.js
@@ -79,7 +79,7 @@ describe( 'typography utils', () => {
 					fluid: true,
 				},
 				expected:
-					'clamp(75.172px, 4.698rem + ((1vw - 7.68px) * 9.035), 150.345px)',
+					'clamp(75.173px, 4.698rem + ((1vw - 7.68px) * 9.035), 150.345px)',
 			},
 
 			{
@@ -128,8 +128,7 @@ describe( 'typography utils', () => {
 					fluid: true,
 				},
 				expected:
-					// @TODO this is not the same as the PHP output: 150.263px
-					'clamp(75.131px, 4.696rem + ((1vw - 7.68px) * 9.03), 150.262px)',
+					'clamp(75.131px, 4.696rem + ((1vw - 7.68px) * 9.03), 150.263px)',
 			},
 
 			{

--- a/packages/edit-site/src/components/global-styles/test/typography-utils.js
+++ b/packages/edit-site/src/components/global-styles/test/typography-utils.js
@@ -128,6 +128,7 @@ describe( 'typography utils', () => {
 					fluid: true,
 				},
 				expected:
+					// @TODO this is not the same as the PHP output: 150.263px
 					'clamp(75.131px, 4.696rem + ((1vw - 7.68px) * 9.03), 150.262px)',
 			},
 

--- a/packages/edit-site/src/components/global-styles/test/typography-utils.js
+++ b/packages/edit-site/src/components/global-styles/test/typography-utils.js
@@ -190,7 +190,20 @@ describe( 'typography utils', () => {
 			},
 
 			{
-				message: 'return fluid clamp value.',
+				message:
+					'return size where no min is give and size is less than default min size.',
+				preset: {
+					size: '3px',
+				},
+				typographySettings: {
+					fluid: true,
+				},
+				expected: '3px',
+			},
+
+			{
+				message:
+					'return fluid clamp value with different min max units.',
 				preset: {
 					size: '28px',
 					fluid: {
@@ -259,6 +272,18 @@ describe( 'typography utils', () => {
 				},
 				expected:
 					'clamp(0.875rem, 0.875rem + ((1vw - 0.48rem) * 1.49), 1.65rem)',
+			},
+
+			{
+				message: 'adjust computed min in em to min limit.',
+				preset: {
+					size: '1.1em',
+				},
+				typographySettings: {
+					fluid: true,
+				},
+				expected:
+					'clamp(0.875em, 0.875rem + ((1vw - 0.48em) * 1.49), 1.65em)',
 			},
 
 			{

--- a/packages/edit-site/src/components/global-styles/test/typography-utils.js
+++ b/packages/edit-site/src/components/global-styles/test/typography-utils.js
@@ -191,14 +191,15 @@ describe( 'typography utils', () => {
 
 			{
 				message:
-					'return size where no min is give and size is less than default min size.',
+					'return clamped using font size where no min is given and size is less than default min size.',
 				preset: {
 					size: '3px',
 				},
 				typographySettings: {
 					fluid: true,
 				},
-				expected: '3px',
+				expected:
+					'clamp(3px, 0.188rem + ((1vw - 7.68px) * 0.18), 4.5px)',
 			},
 
 			{

--- a/packages/edit-site/src/components/global-styles/test/typography-utils.js
+++ b/packages/edit-site/src/components/global-styles/test/typography-utils.js
@@ -5,206 +5,309 @@ import { getTypographyFontSizeValue } from '../typography-utils';
 
 describe( 'typography utils', () => {
 	describe( 'getTypographyFontSizeValue', () => {
-		it( 'should return the expected values', () => {
-			[
-				// Default return non-fluid value.
-				{
-					preset: {
-						size: '28px',
-					},
-					typographySettings: undefined,
-					expected: '28px',
+		[
+			{
+				message: 'Default return non-fluid value.',
+				preset: {
+					size: '28px',
 				},
-				// Default return value where font size is 0.
-				{
-					preset: {
-						size: 0,
-					},
-					typographySettings: undefined,
-					expected: 0,
-				},
-				// Default return value where font size is '0'.
-				{
-					preset: {
-						size: '0',
-					},
-					typographySettings: undefined,
-					expected: '0',
-				},
+				typographySettings: undefined,
+				expected: '28px',
+			},
 
-				// Default return non-fluid value where `size` is undefined.
-				{
-					preset: {
-						size: undefined,
-					},
-					typographySettings: undefined,
-					expected: undefined,
+			{
+				message: 'Default return value where font size is 0.',
+				preset: {
+					size: 0,
 				},
-				// Should return non-fluid value when fluid is `false`.
-				{
-					preset: {
-						size: '28px',
-						fluid: false,
-					},
-					typographySettings: {
-						fluid: true,
-					},
-					expected: '28px',
-				},
-				// Should coerce integer to `px` and return fluid value.
-				{
-					preset: {
-						size: 33,
-						fluid: true,
-					},
-					typographySettings: {
-						fluid: true,
-					},
-					expected:
-						'clamp(24.75px, 1.546875rem + ((1vw - 7.68px) * 2.975), 49.5px)',
-				},
+				typographySettings: undefined,
+				expected: 0,
+			},
 
-				// Should coerce float to `px` and return fluid value.
-				{
-					preset: {
-						size: 100.23,
-						fluid: true,
-					},
-					typographySettings: {
-						fluid: true,
-					},
-					expected:
-						'clamp(75.1725px, 4.69828125rem + ((1vw - 7.68px) * 9.035), 150.345px)',
+			{
+				message: "Default return value where font size is '0'.",
+				preset: {
+					size: '0',
 				},
-				// Should return incoming value when already clamped.
-				{
-					preset: {
-						size: 'clamp(21px, 1.3125rem + ((1vw - 7.68px) * 2.524), 42px)',
-						fluid: false,
-					},
-					typographySettings: {
-						fluid: true,
-					},
-					expected:
-						'clamp(21px, 1.3125rem + ((1vw - 7.68px) * 2.524), 42px)',
-				},
-				// Should return incoming value with unsupported unit.
-				{
-					preset: {
-						size: '1000%',
-						fluid: false,
-					},
-					typographySettings: {
-						fluid: true,
-					},
-					expected: '1000%',
-				},
-				// Should return fluid value.
-				{
-					preset: {
-						size: '1.75rem',
-					},
-					typographySettings: {
-						fluid: true,
-					},
-					expected:
-						'clamp(1.3125rem, 1.3125rem + ((1vw - 0.48rem) * 2.524), 2.625rem)',
-				},
-				// Should return fluid value for floats with units.
-				{
-					preset: {
-						size: '100.175px',
-					},
-					typographySettings: {
-						fluid: true,
-					},
-					expected:
-						'clamp(75.13125px, 4.695703125rem + ((1vw - 7.68px) * 9.03), 150.2625px)',
-				},
-				// Should return default fluid values with empty fluid array.
-				{
-					preset: {
-						size: '28px',
-						fluid: [],
-					},
-					typographySettings: {
-						fluid: true,
-					},
-					expected:
-						'clamp(21px, 1.3125rem + ((1vw - 7.68px) * 2.524), 42px)',
-				},
+				typographySettings: undefined,
+				expected: '0',
+			},
 
-				// Should return default fluid values with null values.
-				{
-					preset: {
-						size: '28px',
-						fluid: null,
-					},
-					typographySettings: {
-						fluid: true,
-					},
-					expected:
-						'clamp(21px, 1.3125rem + ((1vw - 7.68px) * 2.524), 42px)',
+			{
+				message:
+					'Default return non-fluid value where `size` is undefined.',
+				preset: {
+					size: undefined,
 				},
+				typographySettings: undefined,
+				expected: undefined,
+			},
 
-				// Should return size with invalid fluid units.
-				{
-					preset: {
-						size: '10em',
-						fluid: {
-							min: '20vw',
-							max: '50%',
-						},
-					},
-					typographySettings: {
-						fluid: true,
-					},
-					expected: '10em',
+			{
+				message: 'return non-fluid value when fluid is `false`.',
+				preset: {
+					size: '28px',
+					fluid: false,
 				},
-				// Should return fluid clamp value.
-				{
-					preset: {
-						size: '28px',
-						fluid: {
-							min: '20px',
-							max: '50rem',
-						},
-					},
-					typographySettings: {
-						fluid: true,
-					},
-					expected:
-						'clamp(20px, 1.25rem + ((1vw - 7.68px) * 93.75), 50rem)',
+				typographySettings: {
+					fluid: true,
 				},
-				// Should return clamp value with default fluid max value.
-				{
-					preset: {
-						size: '28px',
-						fluid: {
-							min: '2.6rem',
-						},
-					},
-					typographySettings: {
-						fluid: true,
-					},
-					expected:
-						'clamp(2.6rem, 2.6rem + ((1vw - 0.48rem) * 0.048), 42px)',
+				expected: '28px',
+			},
+
+			{
+				message:
+					'Should coerce integer to `px` and return fluid value.',
+				preset: {
+					size: 33,
+					fluid: true,
 				},
-				// Should return clamp value with default fluid min value.
-				{
-					preset: {
-						size: '28px',
-						fluid: {
-							max: '80px',
-						},
-					},
-					typographySettings: {
-						fluid: true,
-					},
-					expected:
-						'clamp(21px, 1.3125rem + ((1vw - 7.68px) * 7.091), 80px)',
+				typographySettings: {
+					fluid: true,
 				},
-			].forEach( ( { preset, typographySettings, expected } ) => {
+				expected:
+					'clamp(24.75px, 1.547rem + ((1vw - 7.68px) * 2.975), 49.5px)',
+			},
+
+			{
+				message: 'coerce float to `px` and return fluid value.',
+				preset: {
+					size: 100.23,
+					fluid: true,
+				},
+				typographySettings: {
+					fluid: true,
+				},
+				expected:
+					'clamp(75.172px, 4.698rem + ((1vw - 7.68px) * 9.035), 150.345px)',
+			},
+
+			{
+				message: 'return incoming value when already clamped.',
+				preset: {
+					size: 'clamp(21px, 1.313rem + ((1vw - 7.68px) * 2.524), 42px)',
+					fluid: false,
+				},
+				typographySettings: {
+					fluid: true,
+				},
+				expected:
+					'clamp(21px, 1.313rem + ((1vw - 7.68px) * 2.524), 42px)',
+			},
+
+			{
+				message: 'return incoming value with unsupported unit.',
+				preset: {
+					size: '1000%',
+					fluid: false,
+				},
+				typographySettings: {
+					fluid: true,
+				},
+				expected: '1000%',
+			},
+
+			{
+				message: 'return fluid value.',
+				preset: {
+					size: '1.75rem',
+				},
+				typographySettings: {
+					fluid: true,
+				},
+				expected:
+					'clamp(1.313rem, 1.313rem + ((1vw - 0.48rem) * 2.523), 2.625rem)',
+			},
+
+			{
+				message: 'return fluid value for floats with units.',
+				preset: {
+					size: '100.175px',
+				},
+				typographySettings: {
+					fluid: true,
+				},
+				expected:
+					'clamp(75.131px, 4.696rem + ((1vw - 7.68px) * 9.03), 150.262px)',
+			},
+
+			{
+				message:
+					'Should return default fluid values with empty fluid array.',
+				preset: {
+					size: '28px',
+					fluid: [],
+				},
+				typographySettings: {
+					fluid: true,
+				},
+				expected:
+					'clamp(21px, 1.313rem + ((1vw - 7.68px) * 2.524), 42px)',
+			},
+
+			{
+				message: 'return default fluid values with null value.',
+				preset: {
+					size: '28px',
+					fluid: null,
+				},
+				typographySettings: {
+					fluid: true,
+				},
+				expected:
+					'clamp(21px, 1.313rem + ((1vw - 7.68px) * 2.524), 42px)',
+			},
+
+			{
+				message:
+					'Should return default value if min font size is greater than max.',
+				preset: {
+					size: '3rem',
+					fluid: {
+						min: '5rem',
+						max: '32px',
+					},
+				},
+				typographySettings: {
+					fluid: true,
+				},
+				expected: '3rem',
+			},
+
+			{
+				message: 'return size with invalid fluid units.',
+				preset: {
+					size: '10em',
+					fluid: {
+						min: '20vw',
+						max: '50%',
+					},
+				},
+				typographySettings: {
+					fluid: true,
+				},
+				expected: '10em',
+			},
+
+			{
+				message: 'return fluid clamp value.',
+				preset: {
+					size: '28px',
+					fluid: {
+						min: '20px',
+						max: '50rem',
+					},
+				},
+				typographySettings: {
+					fluid: true,
+				},
+				expected:
+					'clamp(20px, 1.25rem + ((1vw - 7.68px) * 93.75), 50rem)',
+			},
+			//
+			{
+				message:
+					' Should return clamp value with default fluid max value.',
+				preset: {
+					size: '28px',
+					fluid: {
+						min: '2.6rem',
+					},
+				},
+				typographySettings: {
+					fluid: true,
+				},
+				expected:
+					'clamp(2.6rem, 2.6rem + ((1vw - 0.48rem) * 0.048), 42px)',
+			},
+
+			{
+				message:
+					'Should return clamp value with default fluid min value.',
+				preset: {
+					size: '28px',
+					fluid: {
+						max: '80px',
+					},
+				},
+				typographySettings: {
+					fluid: true,
+				},
+				expected:
+					'clamp(21px, 1.313rem + ((1vw - 7.68px) * 7.091), 80px)',
+			},
+
+			{
+				message: 'adjust computed min in px to min limit.',
+				preset: {
+					size: '14px',
+				},
+				typographySettings: {
+					fluid: true,
+				},
+				expected:
+					'clamp(14px, 0.875rem + ((1vw - 7.68px) * 0.841), 21px)',
+			},
+
+			{
+				message: 'adjust computed min in rem to min limit.',
+				preset: {
+					size: '1.1rem',
+				},
+				typographySettings: {
+					fluid: true,
+				},
+				expected:
+					'clamp(0.875rem, 0.875rem + ((1vw - 0.48rem) * 1.49), 1.65rem)',
+			},
+
+			{
+				message: 'adjust fluid min value in px to min limit',
+				preset: {
+					size: '20px',
+					fluid: {
+						min: '12px',
+					},
+				},
+				typographySettings: {
+					fluid: true,
+				},
+				expected:
+					'clamp(14px, 0.875rem + ((1vw - 7.68px) * 1.923), 30px)',
+			},
+
+			{
+				message: 'adjust fluid min value in rem to min limit.',
+				preset: {
+					size: '1.5rem',
+					fluid: {
+						min: '0.5rem',
+					},
+				},
+				typographySettings: {
+					fluid: true,
+				},
+				expected:
+					'clamp(0.875rem, 0.875rem + ((1vw - 0.48rem) * 2.644), 2.25rem)',
+			},
+
+			{
+				message: 'adjust fluid min value but honor max value.',
+				preset: {
+					size: '1.5rem',
+					fluid: {
+						min: '0.5rem',
+						max: '5rem',
+					},
+				},
+				typographySettings: {
+					fluid: true,
+				},
+				expected:
+					'clamp(0.875rem, 0.875rem + ((1vw - 0.48rem) * 7.933), 5rem)',
+			},
+		].forEach( ( { message, preset, typographySettings, expected } ) => {
+			it( `should ${ message }`, () => {
 				expect(
 					getTypographyFontSizeValue( preset, typographySettings )
 				).toBe( expected );

--- a/packages/edit-site/src/components/global-styles/test/typography-utils.js
+++ b/packages/edit-site/src/components/global-styles/test/typography-utils.js
@@ -333,6 +333,22 @@ describe( 'typography utils', () => {
 				expected:
 					'clamp(0.875rem, 0.875rem + ((1vw - 0.48rem) * 7.933), 5rem)',
 			},
+
+			{
+				message:
+					'return a fluid font size a min and max font sizes are equal.',
+				preset: {
+					size: '4rem',
+					fluid: {
+						min: '30px',
+						max: '30px',
+					},
+				},
+				typographySettings: {
+					fluid: true,
+				},
+				expected: 'clamp(30px, 1.875rem + ((1vw - 7.68px) * 1), 30px)',
+			},
 		].forEach( ( { message, preset, typographySettings, expected } ) => {
 			it( `should ${ message }`, () => {
 				expect(

--- a/packages/edit-site/src/components/global-styles/test/typography-utils.js
+++ b/packages/edit-site/src/components/global-styles/test/typography-utils.js
@@ -160,7 +160,7 @@ describe( 'typography utils', () => {
 
 			{
 				message:
-					'Should return default value if min font size is greater than max.',
+					'return clamped value if min font size is greater than max.',
 				preset: {
 					size: '3rem',
 					fluid: {
@@ -171,7 +171,8 @@ describe( 'typography utils', () => {
 				typographySettings: {
 					fluid: true,
 				},
-				expected: '3rem',
+				expected:
+					'clamp(5rem, 5rem + ((1vw - 0.48rem) * -5.769), 32px)',
 			},
 
 			{

--- a/packages/edit-site/src/components/global-styles/test/use-global-styles-output.js
+++ b/packages/edit-site/src/components/global-styles/test/use-global-styles-output.js
@@ -782,7 +782,7 @@ describe( 'global styles renderer', () => {
 				'padding-bottom: 33px',
 				'padding-left: 33px',
 				'font-family: sans-serif',
-				'font-size: clamp(10.5px, 0.65625rem + ((1vw - 7.68px) * 1.262), 21px)',
+				'font-size: clamp(14px, 0.875rem + ((1vw - 7.68px) * 0.841), 21px)',
 			] );
 		} );
 

--- a/packages/edit-site/src/components/global-styles/typography-utils.js
+++ b/packages/edit-site/src/components/global-styles/typography-utils.js
@@ -10,32 +10,31 @@
 import { getComputedFluidTypographyValue } from '@wordpress/block-editor';
 
 /**
- * @typedef {Object} FluidValues
+ * @typedef {Object} FluidPreset
  * @property {string|undefined} max A maximum font size value.
  * @property {?string|undefined} min A minimum font size value.
  */
 
 /**
- * @typedef {Object} FontSize
+ * @typedef {Object} Preset
  * @property {?string|?number}               size  A default font size.
  * @property {string}                        name  A font size name, displayed in the UI.
  * @property {string}                        slug  A font size slug
- * @property {boolean|FluidValues|undefined} fluid A font size slug
+ * @property {boolean|FluidPreset|undefined} fluid A font size slug
  */
 
 /**
- * Returns a font-size value based on a given fontSize.
- * The fontSize is represented in the preset format as seen in theme.json.
+ * Returns a font-size value based on a given font-size preset.
  * Takes into account fluid typography parameters and attempts to return a css formula depending on available, valid values.
  *
- * @param {FontSize} fontSize
- * @param {Object}   typographySettings
- * @param {boolean}  typographySettings.fluid Whether fluid typography is enabled.
+ * @param {Preset}  preset
+ * @param {Object}  typographySettings
+ * @param {boolean} typographySettings.fluid Whether fluid typography is enabled.
  *
- * @return {string|*} A font-size value or the value of fontSize.size.
+ * @return {string|*} A font-size value or the value of preset.size.
  */
-export function getTypographyFontSizeValue( fontSize, typographySettings ) {
-	const { size: defaultSize } = fontSize;
+export function getTypographyFontSizeValue( preset, typographySettings ) {
+	const { size: defaultSize } = preset;
 
 	/*
 	 * Catches falsy values and 0/'0'.
@@ -50,13 +49,13 @@ export function getTypographyFontSizeValue( fontSize, typographySettings ) {
 	}
 
 	// A font size has explicitly bypassed fluid calculations.
-	if ( false === fontSize?.fluid ) {
+	if ( false === preset?.fluid ) {
 		return defaultSize;
 	}
 
 	const fluidFontSizeValue = getComputedFluidTypographyValue( {
-		minimumFontSize: fontSize?.fluid?.min,
-		maximumFontSize: fontSize?.fluid?.max,
+		minimumFontSize: preset?.fluid?.min,
+		maximumFontSize: preset?.fluid?.max,
 		fontSize: defaultSize,
 	} );
 

--- a/packages/edit-site/src/components/global-styles/typography-utils.js
+++ b/packages/edit-site/src/components/global-styles/typography-utils.js
@@ -10,31 +10,32 @@
 import { getComputedFluidTypographyValue } from '@wordpress/block-editor';
 
 /**
- * @typedef {Object} FluidPreset
+ * @typedef {Object} FluidValues
  * @property {string|undefined} max A maximum font size value.
  * @property {?string|undefined} min A minimum font size value.
  */
 
 /**
- * @typedef {Object} Preset
+ * @typedef {Object} FontSize
  * @property {?string|?number}               size  A default font size.
  * @property {string}                        name  A font size name, displayed in the UI.
  * @property {string}                        slug  A font size slug
- * @property {boolean|FluidPreset|undefined} fluid A font size slug
+ * @property {boolean|FluidValues|undefined} fluid A font size slug
  */
 
 /**
- * Returns a font-size value based on a given font-size preset.
+ * Returns a font-size value based on a given fontSize.
+ * The fontSize is represented in the preset format as seen in theme.json.
  * Takes into account fluid typography parameters and attempts to return a css formula depending on available, valid values.
  *
- * @param {Preset}  preset
- * @param {Object}  typographySettings
- * @param {boolean} typographySettings.fluid Whether fluid typography is enabled.
+ * @param {FontSize} fontSize
+ * @param {Object}   typographySettings
+ * @param {boolean}  typographySettings.fluid Whether fluid typography is enabled.
  *
- * @return {string|*} A font-size value or the value of preset.size.
+ * @return {string|*} A font-size value or the value of fontSize.size.
  */
-export function getTypographyFontSizeValue( preset, typographySettings ) {
-	const { size: defaultSize } = preset;
+export function getTypographyFontSizeValue( fontSize, typographySettings ) {
+	const { size: defaultSize } = fontSize;
 
 	/*
 	 * Catches falsy values and 0/'0'.
@@ -49,13 +50,13 @@ export function getTypographyFontSizeValue( preset, typographySettings ) {
 	}
 
 	// A font size has explicitly bypassed fluid calculations.
-	if ( false === preset?.fluid ) {
+	if ( false === fontSize?.fluid ) {
 		return defaultSize;
 	}
 
 	const fluidFontSizeValue = getComputedFluidTypographyValue( {
-		minimumFontSize: preset?.fluid?.min,
-		maximumFontSize: preset?.fluid?.max,
+		minimumFontSize: fontSize?.fluid?.min,
+		maximumFontSize: fontSize?.fluid?.max,
 		fontSize: defaultSize,
 	} );
 

--- a/phpunit/block-supports/typography-test.php
+++ b/phpunit/block-supports/typography-test.php
@@ -292,8 +292,8 @@ class WP_Block_Supports_Typography_Test extends WP_UnitTestCase {
 	 *
 	 * @dataProvider data_generate_font_size_preset_fixtures
 	 *
-	 * @param array  $font_size_preset                     {
-	 *      Required. fontSizes preset value as seen in theme.json.
+	 * @param array  $font_size                     {
+	 *     Required. fontSizes represented in the preset format as seen in theme.json.
 	 *
 	 *     @type string $name Name of the font size preset.
 	 *     @type string $slug Kebab-case unique identifier for the font size preset.
@@ -302,8 +302,8 @@ class WP_Block_Supports_Typography_Test extends WP_UnitTestCase {
 	 * @param bool   $should_use_fluid_typography An override to switch fluid typography "on". Can be used for unit testing.
 	 * @param string $expected_output Expected output of gutenberg_get_typography_font_size_value().
 	 */
-	public function test_gutenberg_get_typography_font_size_value( $font_size_preset, $should_use_fluid_typography, $expected_output ) {
-		$actual = gutenberg_get_typography_font_size_value( $font_size_preset, $should_use_fluid_typography );
+	public function test_gutenberg_get_typography_font_size_value( $font_size, $should_use_fluid_typography, $expected_output ) {
+		$actual = gutenberg_get_typography_font_size_value( $font_size, $should_use_fluid_typography );
 
 		$this->assertSame( $expected_output, $actual );
 	}
@@ -316,7 +316,7 @@ class WP_Block_Supports_Typography_Test extends WP_UnitTestCase {
 	public function data_generate_font_size_preset_fixtures() {
 		return array(
 			'default_return_value'                        => array(
-				'font_size_preset'            => array(
+				'font_size'                   => array(
 					'size' => '28px',
 				),
 				'should_use_fluid_typography' => false,
@@ -324,7 +324,7 @@ class WP_Block_Supports_Typography_Test extends WP_UnitTestCase {
 			),
 
 			'size: int 0'                                 => array(
-				'font_size_preset'            => array(
+				'font_size'                   => array(
 					'size' => 0,
 				),
 				'should_use_fluid_typography' => true,
@@ -332,7 +332,7 @@ class WP_Block_Supports_Typography_Test extends WP_UnitTestCase {
 			),
 
 			'size: string 0'                              => array(
-				'font_size_preset'            => array(
+				'font_size'                   => array(
 					'size' => '0',
 				),
 				'should_use_fluid_typography' => true,
@@ -340,7 +340,7 @@ class WP_Block_Supports_Typography_Test extends WP_UnitTestCase {
 			),
 
 			'default_return_value_when_size_is_undefined' => array(
-				'font_size_preset'            => array(
+				'font_size'                   => array(
 					'size' => null,
 				),
 				'should_use_fluid_typography' => false,
@@ -348,7 +348,7 @@ class WP_Block_Supports_Typography_Test extends WP_UnitTestCase {
 			),
 
 			'default_return_value_when_fluid_is_false'    => array(
-				'font_size_preset'            => array(
+				'font_size'                   => array(
 					'size'  => '28px',
 					'fluid' => false,
 				),
@@ -357,16 +357,16 @@ class WP_Block_Supports_Typography_Test extends WP_UnitTestCase {
 			),
 
 			'default_return_value_when_value_is_already_clamped' => array(
-				'font_size_preset'            => array(
-					'size'  => 'clamp(21px, 1.3125rem + ((1vw - 7.68px) * 2.524), 42px)',
+				'font_size'                   => array(
+					'size'  => 'clamp(21px, 1.313rem + ((1vw - 7.68px) * 2.524), 42px)',
 					'fluid' => false,
 				),
 				'should_use_fluid_typography' => true,
-				'expected_output'             => 'clamp(21px, 1.3125rem + ((1vw - 7.68px) * 2.524), 42px)',
+				'expected_output'             => 'clamp(21px, 1.313rem + ((1vw - 7.68px) * 2.524), 42px)',
 			),
 
 			'default_return_value_with_unsupported_unit'  => array(
-				'font_size_preset'            => array(
+				'font_size'                   => array(
 					'size'  => '1000%',
 					'fluid' => false,
 				),
@@ -375,15 +375,15 @@ class WP_Block_Supports_Typography_Test extends WP_UnitTestCase {
 			),
 
 			'return_fluid_value'                          => array(
-				'font_size_preset'            => array(
+				'font_size'                   => array(
 					'size' => '1.75rem',
 				),
 				'should_use_fluid_typography' => true,
-				'expected_output'             => 'clamp(1.3125rem, 1.3125rem + ((1vw - 0.48rem) * 2.524), 2.625rem)',
+				'expected_output'             => 'clamp(1.313rem, 1.313rem + ((1vw - 0.48rem) * 2.524), 2.625rem)',
 			),
 
 			'return_fluid_value_with_floats_with_units'   => array(
-				'font_size_preset'            => array(
+				'font_size'                   => array(
 					'size' => '100.175px',
 				),
 				'should_use_fluid_typography' => true,
@@ -391,41 +391,53 @@ class WP_Block_Supports_Typography_Test extends WP_UnitTestCase {
 			),
 
 			'return_fluid_value_with_integer_coerced_to_px' => array(
-				'font_size_preset'            => array(
+				'font_size'                   => array(
 					'size' => 33,
 				),
 				'should_use_fluid_typography' => true,
-				'expected_output'             => 'clamp(24.75px, 1.546875rem + ((1vw - 7.68px) * 2.975), 49.5px)',
+				'expected_output'             => 'clamp(24.75px, 1.547rem + ((1vw - 7.68px) * 2.975), 49.5px)',
 			),
 
 			'return_fluid_value_with_float_coerced_to_px' => array(
-				'font_size_preset'            => array(
+				'font_size'                   => array(
 					'size' => 100.23,
 				),
 				'should_use_fluid_typography' => true,
-				'expected_output'             => 'clamp(75.1725px, 4.69828125rem + ((1vw - 7.68px) * 9.035), 150.345px)',
+				'expected_output'             => 'clamp(75.1725px, 4.698rem + ((1vw - 7.68px) * 9.035), 150.345px)',
 			),
 
 			'return_default_fluid_values_with_empty_fluid_array' => array(
-				'font_size_preset'            => array(
+				'font_size'                   => array(
 					'size'  => '28px',
 					'fluid' => array(),
 				),
 				'should_use_fluid_typography' => true,
-				'expected_output'             => 'clamp(21px, 1.3125rem + ((1vw - 7.68px) * 2.524), 42px)',
+				'expected_output'             => 'clamp(21px, 1.313rem + ((1vw - 7.68px) * 2.524), 42px)',
 			),
 
 			'return_default_fluid_values_with_null_value' => array(
-				'font_size_preset'            => array(
+				'font_size'                   => array(
 					'size'  => '28px',
 					'fluid' => null,
 				),
 				'should_use_fluid_typography' => true,
-				'expected_output'             => 'clamp(21px, 1.3125rem + ((1vw - 7.68px) * 2.524), 42px)',
+				'expected_output'             => 'clamp(21px, 1.313rem + ((1vw - 7.68px) * 2.524), 42px)',
+			),
+
+			'return_default_value_if_min_font_size_is_greater_than_max' => array(
+				'font_size'                   => array(
+					'size'  => '3rem',
+					'fluid' => array(
+						'min' => '5rem',
+						'max' => '32px',
+					),
+				),
+				'should_use_fluid_typography' => true,
+				'expected_output'             => '3rem',
 			),
 
 			'return_size_with_invalid_fluid_units'        => array(
-				'font_size_preset'            => array(
+				'font_size'                   => array(
 					'size'  => '10em',
 					'fluid' => array(
 						'min' => '20vw',
@@ -437,7 +449,7 @@ class WP_Block_Supports_Typography_Test extends WP_UnitTestCase {
 			),
 
 			'return_fluid_clamp_value'                    => array(
-				'font_size_preset'            => array(
+				'font_size'                   => array(
 					'size'  => '28px',
 					'fluid' => array(
 						'min' => '20px',
@@ -449,7 +461,7 @@ class WP_Block_Supports_Typography_Test extends WP_UnitTestCase {
 			),
 
 			'return_clamp_value_with_default_fluid_max_value' => array(
-				'font_size_preset'            => array(
+				'font_size'                   => array(
 					'size'  => '28px',
 					'fluid' => array(
 						'min' => '2.6rem',
@@ -460,14 +472,72 @@ class WP_Block_Supports_Typography_Test extends WP_UnitTestCase {
 			),
 
 			'default_return_clamp_value_with_default_fluid_min_value' => array(
-				'font_size_preset'            => array(
+				'font_size'                   => array(
 					'size'  => '28px',
 					'fluid' => array(
 						'max' => '80px',
 					),
 				),
 				'should_use_fluid_typography' => true,
-				'expected_output'             => 'clamp(21px, 1.3125rem + ((1vw - 7.68px) * 7.091), 80px)',
+				'expected_output'             => 'clamp(21px, 1.313rem + ((1vw - 7.68px) * 7.091), 80px)',
+			),
+
+			'should_adjust_computed_min_in_px_to_min_limit' => array(
+				'font_size'                   => array(
+					'size' => '14px',
+				),
+				'should_use_fluid_typography' => true,
+				'expected_output'             => 'clamp(14px, 0.875rem + ((1vw - 7.68px) * 0.841), 21px)',
+			),
+
+			'should_adjust_computed_min_in_rem_to_min_limit' => array(
+				'font_size'                   => array(
+					'size' => '1.1rem',
+				),
+				'should_use_fluid_typography' => true,
+				'expected_output'             => 'clamp(0.875rem, 0.875rem + ((1vw - 0.48rem) * 1.49), 1.65rem)',
+			),
+// @TODO check that $fluid_target_font_size should use `rem` when `em` font size value is passed.
+//			'default_return_clamp_value_with_replaced_fluid_min_value_in_em' => array(
+//				'font_size'                   => array(
+//					'size' => '1.1em',
+//				),
+//				'should_use_fluid_typography' => true,
+//				'expected_output'             => 'clamp(0.875em, 0.875em + ((1vw - 0.48em) * 1.49), 1.65em)',
+//			),
+
+			'should_adjust_fluid_min_value_in_px_to_min_limit' => array(
+				'font_size'                   => array(
+					'size'  => '20px',
+					'fluid' => array(
+						'min' => '12px',
+					),
+				),
+				'should_use_fluid_typography' => true,
+				'expected_output'             => 'clamp(14px, 0.875rem + ((1vw - 7.68px) * 1.923), 30px)',
+			),
+
+			'should_adjust_fluid_min_value_in_rem_to_min_limit' => array(
+				'font_size'                   => array(
+					'size'  => '1.5rem',
+					'fluid' => array(
+						'min' => '0.5rem',
+					),
+				),
+				'should_use_fluid_typography' => true,
+				'expected_output'             => 'clamp(0.875rem, 0.875rem + ((1vw - 0.48rem) * 2.644), 2.25rem)',
+			),
+
+			'should_adjust_fluid_min_value_but_honor_max_value' => array(
+				'font_size'                   => array(
+					'size'  => '1.5rem',
+					'fluid' => array(
+						'min' => '0.5rem',
+						'max' => '5rem',
+					),
+				),
+				'should_use_fluid_typography' => true,
+				'expected_output'             => 'clamp(0.875rem, 0.875rem + ((1vw - 0.48rem) * 7.933), 5rem)',
 			),
 		);
 	}
@@ -619,10 +689,10 @@ class WP_Block_Supports_Typography_Test extends WP_UnitTestCase {
 				'expected_output'             => '<p class="has-medium-font-size" style="    font-size:clamp(15px, 0.9375rem + ((1vw - 7.68px) * 1.803), 30px);    ">A paragraph inside a group</p>',
 			),
 			'return_content_with_first_match_replace_only' => array(
-				'block_content'               => "<div class=\"wp-block-group\" style=\"font-size:1em\"> \n \n<p style=\"font-size:1em\">A paragraph inside a group</p></div>",
-				'font_size_value'             => '1em',
+				'block_content'               => "<div class=\"wp-block-group\" style=\"font-size:1.5em\"> \n \n<p style=\"font-size:1.5em\">A paragraph inside a group</p></div>",
+				'font_size_value'             => '1.5em',
 				'should_use_fluid_typography' => true,
-				'expected_output'             => "<div class=\"wp-block-group\" style=\"font-size:clamp(0.75em, 0.75em + ((1vw - 0.48em) * 1.442), 1.5em);\"> \n \n<p style=\"font-size:1em\">A paragraph inside a group</p></div>",
+				'expected_output'             => "<div class=\"wp-block-group\" style=\"font-size:clamp(1.125em, 1.125em + ((1vw - 0.48em) * 2.163), 2.25em);\"> \n \n<p style=\"font-size:1.5em\">A paragraph inside a group</p></div>",
 			),
 		);
 	}

--- a/phpunit/block-supports/typography-test.php
+++ b/phpunit/block-supports/typography-test.php
@@ -547,6 +547,18 @@ class WP_Block_Supports_Typography_Test extends WP_UnitTestCase {
 				'should_use_fluid_typography' => true,
 				'expected_output'             => 'clamp(0.875rem, 0.875rem + ((1vw - 0.48rem) * 7.933), 5rem)',
 			),
+
+			'should_return_fluid_value_when_min_and_max_font_sizes_are_equal' => array(
+				'font_size'                   => array(
+					'size'  => '4rem',
+					'fluid' => array(
+						'min' => '30px',
+						'max' => '30px',
+					),
+				),
+				'should_use_fluid_typography' => true,
+				'expected_output'             => 'clamp(30px, 1.875rem + ((1vw - 7.68px) * 1), 30px)',
+			),
 		);
 	}
 

--- a/phpunit/block-supports/typography-test.php
+++ b/phpunit/block-supports/typography-test.php
@@ -424,7 +424,7 @@ class WP_Block_Supports_Typography_Test extends WP_UnitTestCase {
 				'expected_output'             => 'clamp(21px, 1.313rem + ((1vw - 7.68px) * 2.524), 42px)',
 			),
 
-			'return_default_value_if_min_font_size_is_greater_than_max' => array(
+			'return_clamped_value_if_min_font_size_is_greater_than_max' => array(
 				'font_size'                   => array(
 					'size'  => '3rem',
 					'fluid' => array(
@@ -433,7 +433,7 @@ class WP_Block_Supports_Typography_Test extends WP_UnitTestCase {
 					),
 				),
 				'should_use_fluid_typography' => true,
-				'expected_output'             => '3rem',
+				'expected_output'             => 'clamp(5rem, 5rem + ((1vw - 0.48rem) * -5.769), 32px)',
 			),
 
 			'return_size_with_invalid_fluid_units'        => array(

--- a/phpunit/block-supports/typography-test.php
+++ b/phpunit/block-supports/typography-test.php
@@ -448,12 +448,12 @@ class WP_Block_Supports_Typography_Test extends WP_UnitTestCase {
 				'expected_output'             => '10em',
 			),
 
-			'return_size_where_no_min_is_given_and_less_than_default_min_size' => array(
+			'return_clamped_size_where_no_min_is_given_and_less_than_default_min_size' => array(
 				'font_size'                   => array(
 					'size' => '3px',
 				),
 				'should_use_fluid_typography' => true,
-				'expected_output'             => '3px',
+				'expected_output'             => 'clamp(3px, 0.188rem + ((1vw - 7.68px) * 0.18), 4.5px)',
 			),
 
 			'return_fluid_clamp_value_with_different_min_max_units' => array(

--- a/phpunit/block-supports/typography-test.php
+++ b/phpunit/block-supports/typography-test.php
@@ -293,7 +293,7 @@ class WP_Block_Supports_Typography_Test extends WP_UnitTestCase {
 	 * @dataProvider data_generate_font_size_preset_fixtures
 	 *
 	 * @param array  $font_size                     {
-	 *     Required. fontSizes represented in the preset format as seen in theme.json.
+	 *     Required. A font size as represented in the fontSizes preset format as seen in theme.json.
 	 *
 	 *     @type string $name Name of the font size preset.
 	 *     @type string $slug Kebab-case unique identifier for the font size preset.
@@ -448,7 +448,15 @@ class WP_Block_Supports_Typography_Test extends WP_UnitTestCase {
 				'expected_output'             => '10em',
 			),
 
-			'return_fluid_clamp_value'                    => array(
+			'return_size_where_no_min_is_given_and_less_than_default_min_size' => array(
+				'font_size'                   => array(
+					'size' => '3px',
+				),
+				'should_use_fluid_typography' => true,
+				'expected_output'             => '3px',
+			),
+
+			'return_fluid_clamp_value_with_different_min_max_units' => array(
 				'font_size'                   => array(
 					'size'  => '28px',
 					'fluid' => array(
@@ -497,14 +505,14 @@ class WP_Block_Supports_Typography_Test extends WP_UnitTestCase {
 				'should_use_fluid_typography' => true,
 				'expected_output'             => 'clamp(0.875rem, 0.875rem + ((1vw - 0.48rem) * 1.49), 1.65rem)',
 			),
-// @TODO check that $fluid_target_font_size should use `rem` when `em` font size value is passed.
-//			'default_return_clamp_value_with_replaced_fluid_min_value_in_em' => array(
-//				'font_size'                   => array(
-//					'size' => '1.1em',
-//				),
-//				'should_use_fluid_typography' => true,
-//				'expected_output'             => 'clamp(0.875em, 0.875em + ((1vw - 0.48em) * 1.49), 1.65em)',
-//			),
+
+			'default_return_clamp_value_with_replaced_fluid_min_value_in_em' => array(
+				'font_size'                   => array(
+					'size' => '1.1em',
+				),
+				'should_use_fluid_typography' => true,
+				'expected_output'             => 'clamp(0.875em, 0.875rem + ((1vw - 0.48em) * 1.49), 1.65em)',
+			),
 
 			'should_adjust_fluid_min_value_in_px_to_min_limit' => array(
 				'font_size'                   => array(
@@ -692,7 +700,7 @@ class WP_Block_Supports_Typography_Test extends WP_UnitTestCase {
 				'block_content'               => "<div class=\"wp-block-group\" style=\"font-size:1.5em\"> \n \n<p style=\"font-size:1.5em\">A paragraph inside a group</p></div>",
 				'font_size_value'             => '1.5em',
 				'should_use_fluid_typography' => true,
-				'expected_output'             => "<div class=\"wp-block-group\" style=\"font-size:clamp(1.125em, 1.125em + ((1vw - 0.48em) * 2.163), 2.25em);\"> \n \n<p style=\"font-size:1.5em\">A paragraph inside a group</p></div>",
+				'expected_output'             => "<div class=\"wp-block-group\" style=\"font-size:clamp(1.125em, 1.125rem + ((1vw - 0.48em) * 2.163), 2.25em);\"> \n \n<p style=\"font-size:1.5em\">A paragraph inside a group</p></div>",
 			),
 		);
 	}

--- a/phpunit/block-supports/typography-test.php
+++ b/phpunit/block-supports/typography-test.php
@@ -379,7 +379,7 @@ class WP_Block_Supports_Typography_Test extends WP_UnitTestCase {
 					'size' => '1.75rem',
 				),
 				'should_use_fluid_typography' => true,
-				'expected_output'             => 'clamp(1.313rem, 1.313rem + ((1vw - 0.48rem) * 2.524), 2.625rem)',
+				'expected_output'             => 'clamp(1.313rem, 1.313rem + ((1vw - 0.48rem) * 2.523), 2.625rem)',
 			),
 
 			'return_fluid_value_with_floats_with_units'   => array(
@@ -387,7 +387,7 @@ class WP_Block_Supports_Typography_Test extends WP_UnitTestCase {
 					'size' => '100.175px',
 				),
 				'should_use_fluid_typography' => true,
-				'expected_output'             => 'clamp(75.13125px, 4.695703125rem + ((1vw - 7.68px) * 9.03), 150.2625px)',
+				'expected_output'             => 'clamp(75.131px, 4.696rem + ((1vw - 7.68px) * 9.03), 150.263px)',
 			),
 
 			'return_fluid_value_with_integer_coerced_to_px' => array(
@@ -403,7 +403,7 @@ class WP_Block_Supports_Typography_Test extends WP_UnitTestCase {
 					'size' => 100.23,
 				),
 				'should_use_fluid_typography' => true,
-				'expected_output'             => 'clamp(75.1725px, 4.698rem + ((1vw - 7.68px) * 9.035), 150.345px)',
+				'expected_output'             => 'clamp(75.173px, 4.698rem + ((1vw - 7.68px) * 9.035), 150.345px)',
 			),
 
 			'return_default_fluid_values_with_empty_fluid_array' => array(
@@ -610,7 +610,7 @@ class WP_Block_Supports_Typography_Test extends WP_UnitTestCase {
 			'return_value_with_fluid_typography' => array(
 				'font_size_value'             => '50px',
 				'should_use_fluid_typography' => true,
-				'expected_output'             => 'font-size:clamp(37.5px, 2.34375rem + ((1vw - 7.68px) * 4.507), 75px);',
+				'expected_output'             => 'font-size:clamp(37.5px, 2.344rem + ((1vw - 7.68px) * 4.507), 75px);',
 			),
 		);
 	}
@@ -686,7 +686,7 @@ class WP_Block_Supports_Typography_Test extends WP_UnitTestCase {
 				'block_content'               => '<p class="has-medium-font-size" style="    font-size:   20px   ;    ">A paragraph inside a group</p>',
 				'font_size_value'             => '20px',
 				'should_use_fluid_typography' => true,
-				'expected_output'             => '<p class="has-medium-font-size" style="    font-size:clamp(15px, 0.9375rem + ((1vw - 7.68px) * 1.803), 30px);    ">A paragraph inside a group</p>',
+				'expected_output'             => '<p class="has-medium-font-size" style="    font-size:clamp(15px, 0.938rem + ((1vw - 7.68px) * 1.803), 30px);    ">A paragraph inside a group</p>',
 			),
 			'return_content_with_first_match_replace_only' => array(
 				'block_content'               => "<div class=\"wp-block-group\" style=\"font-size:1.5em\"> \n \n<p style=\"font-size:1.5em\">A paragraph inside a group</p></div>",


### PR DESCRIPTION
Resolves https://github.com/WordPress/gutenberg/issues/44957

WordPress/wordpress-develop patch:

- https://github.com/WordPress/wordpress-develop/pull/3489

Cherry picked into wp/6.1 branch in this PR:

- https://github.com/WordPress/gutenberg/pull/45133

## What?

This PR adds default minimum font size constraint of 14px/0.875rem/0.875em so that a fluid font's minimum font size does not become smaller than the constraint.

❗ For user-defined font sizes that are < 14px we will use the font-size itself as the minimum value. This is so that changes to these custom values are reflected in the editor and frontend. We trust the user here to insert a sensible value

## Why and how?
To ensure that minimum font sizes, whether user-defined or calculated by `gutenberg_get_typography_font_size_value` are not less than 14px/0.875rem/0.875em.

This is to protect readability and accessibility.

## Testing Instructions
In theme.json, add some very small font sizes (<14px or .875rem) to the presets' `fluid.min`.

Example:

```json
				{
					"size": "2.8rem",
					"fluid": {
						"min": "0.3rem",
						"max": "30px"
					},
					"slug": "neutrale",
					"name": "Neutrale"
				},
```

Add a post and apply the preset.

Check that these font sizes are never less than 14px or .875rem in the editor and frontend.

Next add a custom font size to an element, either in theme.json or via the editor.

If your custom font size is <14px or .875rem, the value of the custom font size will be static.

Otherwise the clamped value's minimum font size should be never be less than 14px or .875rem.

<details>

<summary>Example theme.json</summary>

```json
{
	"version": 2,
	"settings": {
		"typography": {
			"fluid": true,
			"fontSizes": [
				{
					"size": ".9rem",
					"slug": "piccolino",
					"name": "Piccolino"
				},
				{
					"size": "2rem",
					"fluid": {
						"min": "1.8rem",
						"max": "40px"
					},
					"slug": "in-mezzo",
					"name": "In Mezzo"
				},
				{
					"size": "2.8rem",
					"fluid": {
						"min": "0.3rem",
						"max": "30px"
					},
					"slug": "neutrale",
					"name": "Neutrale"
				},
				{
					"size": "4.75rem",
					"slug": "grandone",
					"name": "Grandone"
				}
			]
		}
	},
	"styles": {
		"typography": {
			"fontSize": "12px"
		},
		"elements": {
			"h1": {
				"typography": {
					"fontSize": "4rem"
				}
			}
		},
		"blocks": {
			"core/post-date": {
				"typography": {
					"fontSize": "16px"
				}
			}
		}
	}
}

```

</details>

<details>

<summary>Example HTML</summary>

```html
<!-- wp:heading -->
<h2>Default font size in theme.json style (not clamped because &lt; 14px):</h2>
<!-- /wp:heading -->

<!-- wp:paragraph -->
<p>Lorem ipsum dolor sit amet. A eaque harum in aspernatur vero qui sapiente asperiores quo harum exercitationem qui quasi neque et laborum veritatis. Et sint inventore rem aliquam tempora nam ratione quaerat.</p>
<!-- /wp:paragraph -->

<!-- wp:heading -->
<h2>Corrected font size in preset (won't be smaller than 14px):</h2>
<!-- /wp:heading -->

<!-- wp:paragraph {"fontSize":"piccolino"} -->
<p class="has-piccolino-font-size">Lorem ipsum dolor sit amet. A eaque harum in aspernatur vero qui sapiente asperiores quo harum exercitationem qui quasi neque et laborum veritatis. Et sint inventore rem aliquam tempora nam ratione quaerat.</p>
<!-- /wp:paragraph -->

<!-- wp:heading -->
<h2>Corrected fluid.min font size in preset (won't be smaller than 14px):</h2>
<!-- /wp:heading -->

<!-- wp:paragraph {"fontSize":"neutrale"} -->
<p class="has-neutrale-font-size">Lorem ipsum dolor sit amet. A eaque harum in aspernatur vero qui sapiente asperiores quo harum exercitationem qui quasi neque et laborum veritatis. Et sint inventore rem aliquam tempora nam ratione quaerat.</p>
<!-- /wp:paragraph -->

<!-- wp:heading -->
<h2>Small custom font size (not clamped because &lt; 14px):</h2>
<!-- /wp:heading -->

<!-- wp:paragraph {"style":{"typography":{"fontSize":"12px"}}} -->
<p style="font-size:12px">Lorem ipsum dolor sit amet. A eaque harum in aspernatur vero qui sapiente asperiores quo harum exercitationem qui quasi neque et laborum veritatis. Et sint inventore rem aliquam tempora nam ratione quaerat.</p>
<!-- /wp:paragraph -->
```

</details>
## Screenshots or screencast <!-- if applicable -->

https://user-images.githubusercontent.com/6458278/196073775-1459f362-cbc1-4e36-81aa-e46660730ad1.mp4



