### PR TITLE
Navigation Block styles: ".is-menu-open" has been declared 2x

### DIFF
--- a/packages/block-library/src/navigation/style.scss
+++ b/packages/block-library/src/navigation/style.scss
@@ -470,7 +470,7 @@ button.wp-block-navigation-item__content {
 
 	// If the responsive wrapper is present but overlay is not open,
 	// overlay styles shouldn't apply.
-	&:not(.is-menu-open.is-menu-open) {
+	&:not(.is-menu-open) {
 		color: inherit !important;
 		background-color: inherit !important;
 	}


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
The double class declaration in `:not()` doesn't make any sense.

Introduced in: https://github.com/WordPress/gutenberg/pull/36479/files#diff-d66a4ed73d0d50a799547b78db235a4bad3428a0decb8895752032cd849d01f0

This fix should also be backported to WordPress Core: https://github.com/WordPress/WordPress/blob/master/wp-includes/blocks/navigation/style.css#L398

## Why?
Removing the second class still inherits the styles in closed menus.

## Testing Instructions
See: https://github.com/WordPress/gutenberg/pull/36479/files#diff-d66a4ed73d0d50a799547b78db235a4bad3428a0decb8895752032cd849d01f0