### PR TITLE
Block Popover: Fix incorrect positioning of padding and margin visualizers on scroll

### DIFF
--- a/packages/block-editor/CHANGELOG.md
+++ b/packages/block-editor/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 -   `FontSizePicker`: Update fluid utils so that only string, floats and integers are treated as valid font sizes for the purposes of fluid typography ([#44847](https://github.com/WordPress/gutenberg/pull/44847))
 -   `getTypographyClassesAndStyles()`: Ensure that font sizes are transformed into fluid values if fluid typography is activated ([#44852](https://github.com/WordPress/gutenberg/pull/44852))
+-   `BlockPopover`: Ensure that padding and margin visualizers display in correct position even when scrolling past block. ([#44998](https://github.com/WordPress/gutenberg/pull/44998))
 
 ### New features
 

--- a/packages/block-editor/src/components/block-popover/README.md
+++ b/packages/block-editor/src/components/block-popover/README.md
@@ -22,6 +22,14 @@ The client ID of the block representing the bottom position of the popover.
 -   Type: `String`
 -   Required: No
 
+#### shift
+
+This determines whether the block popover always shifts into the viewport or remains at its original position. See FloatingUI for more details on shift.
+
+-	Type: `Boolean`
+-	Required: No
+-	Default: `true`
+
 ## BlockPopoverInbetween
 
 ### Props

--- a/packages/block-editor/src/components/block-popover/index.js
+++ b/packages/block-editor/src/components/block-popover/index.js
@@ -32,6 +32,7 @@ function BlockPopover(
 		__unstableCoverTarget = false,
 		__unstablePopoverSlot,
 		__unstableContentRef,
+		shift = true,
 		...props
 	},
 	ref
@@ -166,7 +167,7 @@ function BlockPopover(
 			placement="top-start"
 			resize={ false }
 			flip={ false }
-			shift
+			shift={ shift }
 			{ ...props }
 			className={ classnames(
 				'block-editor-block-popover',

--- a/packages/block-editor/src/hooks/margin.js
+++ b/packages/block-editor/src/hooks/margin.js
@@ -231,6 +231,7 @@ export function MarginVisualizer( { clientId, attributes } ) {
 			clientId={ clientId }
 			__unstableCoverTarget
 			__unstableRefreshSize={ margin }
+			shift={ false }
 		>
 			<div className="block-editor__padding-visualizer" style={ style } />
 		</BlockPopover>

--- a/packages/block-editor/src/hooks/padding.js
+++ b/packages/block-editor/src/hooks/padding.js
@@ -222,6 +222,7 @@ export function PaddingVisualizer( { clientId, attributes } ) {
 			clientId={ clientId }
 			__unstableCoverTarget
 			__unstableRefreshSize={ padding }
+			shift={ false }
 		>
 			<div className="block-editor__padding-visualizer" style={ style } />
 		</BlockPopover>


### PR DESCRIPTION
Fixes #44977.

<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Adds a shift prop to tell whether the floating UI should shift into view or stay positioned normally.

## Why?
This fixes a visual bug where if you scroll past the top of a group and use padding or margin, the visualizer appears always at the top of the page. This is due to the Floating UI library's shift property.

## How?
Adds a shift prop to BlockPopover that defaults to true, as that was always the value for the component. Padding and Margin Visualizers pass false to the shift property so that Floating UI library does not put the padding and margin visualizers at the top of the screen even when scrolling past element.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
1. Create a group of content that spans a large area.
2. Create content below the group that allows you to scroll past the group.
3. While the top of the screen is partially intersecting the group open the dimensions panel.
4. Adjust the padding and margin.
5. The visualizer should position accurately and not fixed at the top of the screen.

## Screenshots or screencast <!-- if applicable -->
