### PR TITLE
Post excerpt: Add layout and align / wide support

### DIFF
--- a/docs/reference-guides/core-blocks.md
+++ b/docs/reference-guides/core-blocks.md
@@ -536,7 +536,7 @@ Display a post's excerpt. ([Source](https://github.com/WordPress/gutenberg/tree/
 
 -	**Name:** core/post-excerpt
 -	**Category:** theme
--	**Supports:** color (background, gradients, link, text), spacing (margin, padding), typography (fontSize, lineHeight), ~~html~~
+-	**Supports:** align (full, wide), color (background, gradients, link, text), spacing (margin, padding), typography (fontSize, lineHeight), ~~html~~
 -	**Attributes:** moreText, showMoreOnNewLine, textAlign
 
 ## Post Featured Image

--- a/packages/block-library/src/post-excerpt/block.json
+++ b/packages/block-library/src/post-excerpt/block.json
@@ -20,6 +20,8 @@
 	},
 	"usesContext": [ "postId", "postType", "queryId" ],
 	"supports": {
+		"align": [ "wide", "full" ],
+		"__experimentalLayout": true,
 		"html": false,
 		"color": {
 			"gradients": true,


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->
Adds align wide, full width, and layout support to the post excerpt block.
Closes https://github.com/WordPress/gutenberg/issues/35697

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
The block was missing these layout features, and as an example, a post content block and a post excerpt block would not align with each other (since the post content block default is to enable "Inner blocks use content width").

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
Adds align wide, full, and experimental layout block support.

## Testing Instructions

Please test the post excerpt block in both the block editor and site editor.
Confirm that the wide width, full width and layout settings (including justifications) work correctly, and display correctly on the front.

Note that depending on where you place the block, you may need to place it inside a group with the "inner blocks use content width" setting enabled.

Optionally, in the Site Editor, open or create the template for single posts. Add a post excerpt block and a post content block,
and compare the position of the content inside these blocks, with different settings enabled. It should be possible to align the block so that the text position is the same in both blocks.

## Screenshots or screencast <!-- if applicable -->
Before:
<img width="1490" alt="Post excerpt is missing layout settings and is full width" src="https://user-images.githubusercontent.com/7422055/196117377-6c5691fc-154c-496b-995a-4d3aa4796da2.png">

After:
<img width="1490" alt="post excerpt has layout settings enabled and the text aligns with the post content block that is above it." src="https://user-images.githubusercontent.com/7422055/196118248-56c07518-2f1e-49b3-bce6-051e973b7434.png">

