### PR TITLE
Sidebar: Split block tools into menu, settings, and appearance tabs

### DIFF
--- a/lib/experimental/editor-settings.php
+++ b/lib/experimental/editor-settings.php
@@ -86,6 +86,9 @@ function gutenberg_enable_experiments() {
 	if ( $gutenberg_experiments && array_key_exists( 'gutenberg-off-canvas-navigation-editor', $gutenberg_experiments ) ) {
 		wp_add_inline_script( 'wp-block-editor', 'window.__experimentalEnableOffCanvasNavigationEditor = true', 'before' );
 	}
+	if ( $gutenberg_experiments && array_key_exists( 'gutenberg-block-inspector-tabs', $gutenberg_experiments ) ) {
+		wp_add_inline_script( 'wp-block-editor', 'window.__experimentalEnableBlockInspectorTabs = true', 'before' );
+	}
 }
 
 add_action( 'admin_init', 'gutenberg_enable_experiments' );

--- a/lib/experiments-page.php
+++ b/lib/experiments-page.php
@@ -52,6 +52,7 @@ function gutenberg_initialize_experiments_settings() {
 			'id'    => 'gutenberg-zoomed-out-view',
 		)
 	);
+
 	add_settings_field(
 		'gutenberg-off-canvas-navigation-editor',
 		__( 'Off canvas navigation editor ', 'gutenberg' ),
@@ -63,6 +64,7 @@ function gutenberg_initialize_experiments_settings() {
 			'id'    => 'gutenberg-off-canvas-navigation-editor',
 		)
 	);
+
 	add_settings_field(
 		'gutenberg-color-randomizer',
 		__( 'Color randomizer ', 'gutenberg' ),
@@ -72,6 +74,18 @@ function gutenberg_initialize_experiments_settings() {
 		array(
 			'label' => __( 'Test the Global Styles color randomizer; a utility that lets you mix the current color palette pseudo-randomly.', 'gutenberg' ),
 			'id'    => 'gutenberg-color-randomizer',
+		)
+	);
+
+	add_settings_field(
+		'gutenberg-block-inspector-tabs',
+		__( 'Block inspector tabs ', 'gutenberg' ),
+		'gutenberg_display_experiment_field',
+		'gutenberg-experiments',
+		'gutenberg_experiments_section',
+		array(
+			'label' => __( 'Test a new block inspector view splitting settings and appearance controls into tabs', 'gutenberg' ),
+			'id'    => 'gutenberg-block-inspector-tabs',
 		)
 	);
 

--- a/packages/block-editor/src/components/block-inspector/index.js
+++ b/packages/block-editor/src/components/block-inspector/index.js
@@ -9,9 +9,8 @@ import {
 	store as blocksStore,
 } from '@wordpress/blocks';
 import {
-	PanelBody,
-	__experimentalUseSlotFills as useSlotFills,
 	FlexItem,
+	PanelBody,
 	__experimentalHStack as HStack,
 	__experimentalVStack as VStack,
 	Button,
@@ -24,20 +23,19 @@ import { useMemo, useCallback } from '@wordpress/element';
  */
 import SkipToSelectedBlock from '../skip-to-selected-block';
 import BlockCard from '../block-card';
-import {
-	default as InspectorControls,
-	InspectorAdvancedControls,
-} from '../inspector-controls';
-import BlockStyles from '../block-styles';
 import MultiSelectionInspector from '../multi-selection-inspector';
-import DefaultStylePicker from '../default-style-picker';
 import BlockVariationTransforms from '../block-variation-transforms';
 import useBlockDisplayInformation from '../use-block-display-information';
 import { store as blockEditorStore } from '../../store';
 import BlockIcon from '../block-icon';
+import BlockStyles from '../block-styles';
+import DefaultStylePicker from '../default-style-picker';
+import { default as InspectorControls } from '../inspector-controls';
+import { default as InspectorControlsTabs } from '../inspector-controls-tabs';
+import AdvancedControls from '../inspector-controls-tabs/advanced-controls-panel';
 
 function useContentBlocks( blockTypes, block ) {
-	const contenBlocksObjectAux = useMemo( () => {
+	const contentBlocksObjectAux = useMemo( () => {
 		return blockTypes.reduce( ( result, blockType ) => {
 			if (
 				blockType.name !== 'core/list-item' &&
@@ -53,7 +51,7 @@ function useContentBlocks( blockTypes, block ) {
 	}, [ blockTypes ] );
 	const isContentBlock = useCallback(
 		( blockName ) => {
-			return !! contenBlocksObjectAux[ blockName ];
+			return !! contentBlocksObjectAux[ blockName ];
 		},
 		[ blockTypes ]
 	);
@@ -166,28 +164,36 @@ const BlockInspector = ( { showNoBlockSelectedMessage = true } ) => {
 		};
 	}, [] );
 
+	const showTabs = window?.__experimentalEnableBlockInspectorTabs;
+
 	if ( count > 1 ) {
 		return (
 			<div className="block-editor-block-inspector">
 				<MultiSelectionInspector />
-				<InspectorControls.Slot />
-				<InspectorControls.Slot
-					__experimentalGroup="color"
-					label={ __( 'Color' ) }
-					className="color-block-support-panel__inner-wrapper"
-				/>
-				<InspectorControls.Slot
-					__experimentalGroup="typography"
-					label={ __( 'Typography' ) }
-				/>
-				<InspectorControls.Slot
-					__experimentalGroup="dimensions"
-					label={ __( 'Dimensions' ) }
-				/>
-				<InspectorControls.Slot
-					__experimentalGroup="border"
-					label={ __( 'Border' ) }
-				/>
+				{ showTabs ? (
+					<InspectorControlsTabs />
+				) : (
+					<>
+						<InspectorControls.Slot />
+						<InspectorControls.Slot
+							__experimentalGroup="color"
+							label={ __( 'Color' ) }
+							className="color-block-support-panel__inner-wrapper"
+						/>
+						<InspectorControls.Slot
+							__experimentalGroup="typography"
+							label={ __( 'Typography' ) }
+						/>
+						<InspectorControls.Slot
+							__experimentalGroup="dimensions"
+							label={ __( 'Dimensions' ) }
+						/>
+						<InspectorControls.Slot
+							__experimentalGroup="border"
+							label={ __( 'Border' ) }
+						/>
+					</>
+				) }
 			</div>
 		);
 	}
@@ -229,6 +235,8 @@ const BlockInspector = ( { showNoBlockSelectedMessage = true } ) => {
 };
 
 const BlockInspectorSingleBlock = ( { clientId, blockName } ) => {
+	const showTabs = window?.__experimentalEnableBlockInspectorTabs;
+
 	const hasBlockStyles = useSelect(
 		( select ) => {
 			const { getBlockStyles } = select( blocksStore );
@@ -238,64 +246,61 @@ const BlockInspectorSingleBlock = ( { clientId, blockName } ) => {
 		[ blockName ]
 	);
 	const blockInformation = useBlockDisplayInformation( clientId );
+
 	return (
 		<div className="block-editor-block-inspector">
 			<BlockCard { ...blockInformation } />
 			<BlockVariationTransforms blockClientId={ clientId } />
-			{ hasBlockStyles && (
-				<div>
-					<PanelBody title={ __( 'Styles' ) }>
-						<BlockStyles clientId={ clientId } />
-						{ hasBlockSupport(
-							blockName,
-							'defaultStylePicker',
-							true
-						) && <DefaultStylePicker blockName={ blockName } /> }
-					</PanelBody>
-				</div>
+			{ showTabs && (
+				<InspectorControlsTabs
+					hasBlockStyles={ hasBlockStyles }
+					clientId={ clientId }
+					blockName={ blockName }
+				/>
 			) }
-			<InspectorControls.Slot />
-			<InspectorControls.Slot
-				__experimentalGroup="color"
-				label={ __( 'Color' ) }
-				className="color-block-support-panel__inner-wrapper"
-			/>
-			<InspectorControls.Slot
-				__experimentalGroup="typography"
-				label={ __( 'Typography' ) }
-			/>
-			<InspectorControls.Slot
-				__experimentalGroup="dimensions"
-				label={ __( 'Dimensions' ) }
-			/>
-			<InspectorControls.Slot
-				__experimentalGroup="border"
-				label={ __( 'Border' ) }
-			/>
-			<div>
-				<AdvancedControls />
-			</div>
+			{ ! showTabs && (
+				<>
+					{ hasBlockStyles && (
+						<div>
+							<PanelBody title={ __( 'Styles' ) }>
+								<BlockStyles clientId={ clientId } />
+								{ hasBlockSupport(
+									blockName,
+									'defaultStylePicker',
+									true
+								) && (
+									<DefaultStylePicker
+										blockName={ blockName }
+									/>
+								) }
+							</PanelBody>
+						</div>
+					) }
+					<InspectorControls.Slot />
+					<InspectorControls.Slot
+						__experimentalGroup="color"
+						label={ __( 'Color' ) }
+						className="color-block-support-panel__inner-wrapper"
+					/>
+					<InspectorControls.Slot
+						__experimentalGroup="typography"
+						label={ __( 'Typography' ) }
+					/>
+					<InspectorControls.Slot
+						__experimentalGroup="dimensions"
+						label={ __( 'Dimensions' ) }
+					/>
+					<InspectorControls.Slot
+						__experimentalGroup="border"
+						label={ __( 'Border' ) }
+					/>
+					<div>
+						<AdvancedControls />
+					</div>
+				</>
+			) }
 			<SkipToSelectedBlock key="back" />
 		</div>
-	);
-};
-
-const AdvancedControls = () => {
-	const fills = useSlotFills( InspectorAdvancedControls.slotName );
-	const hasFills = Boolean( fills && fills.length );
-
-	if ( ! hasFills ) {
-		return null;
-	}
-
-	return (
-		<PanelBody
-			className="block-editor-block-inspector__advanced"
-			title={ __( 'Advanced' ) }
-			initialOpen={ false }
-		>
-			<InspectorControls.Slot __experimentalGroup="advanced" />
-		</PanelBody>
 	);
 };
 

--- a/packages/block-editor/src/components/block-inspector/style.scss
+++ b/packages/block-editor/src/components/block-inspector/style.scss
@@ -27,7 +27,8 @@
 	}
 }
 
-.block-editor-block-inspector__no-blocks {
+.block-editor-block-inspector__no-blocks,
+.block-editor-block-inspector__no-block-tools {
 	display: block;
 	font-size: $default-font-size;
 	background: $white;
@@ -35,6 +36,13 @@
 	text-align: center;
 }
 
+.block-editor-block-inspector__no-block-tools {
+	border-top: $border-width solid $gray-300;
+}
+
+.block-editor-block-inspector__tab-item {
+	flex: 1 1 0px;
+}
 
 .block-editor-block-inspector__block-buttons-container {
 	border-top: $border-width solid $gray-200;

--- a/packages/block-editor/src/components/inspector-controls-tabs/advanced-controls-panel.js
+++ b/packages/block-editor/src/components/inspector-controls-tabs/advanced-controls-panel.js
@@ -1,0 +1,37 @@
+/**
+ * WordPress dependencies
+ */
+import {
+	PanelBody,
+	__experimentalUseSlotFills as useSlotFills,
+} from '@wordpress/components';
+import { __ } from '@wordpress/i18n';
+
+/**
+ * Internal dependencies
+ */
+import {
+	default as InspectorControls,
+	InspectorAdvancedControls,
+} from '../inspector-controls';
+
+const AdvancedControls = () => {
+	const fills = useSlotFills( InspectorAdvancedControls.slotName );
+	const hasFills = Boolean( fills && fills.length );
+
+	if ( ! hasFills ) {
+		return null;
+	}
+
+	return (
+		<PanelBody
+			className="block-editor-block-inspector__advanced"
+			title={ __( 'Advanced' ) }
+			initialOpen={ false }
+		>
+			<InspectorControls.Slot __experimentalGroup="advanced" />
+		</PanelBody>
+	);
+};
+
+export default AdvancedControls;

--- a/packages/block-editor/src/components/inspector-controls-tabs/appearance-tab.js
+++ b/packages/block-editor/src/components/inspector-controls-tabs/appearance-tab.js
@@ -1,0 +1,75 @@
+/**
+ * WordPress dependencies
+ */
+import { hasBlockSupport } from '@wordpress/blocks';
+import {
+	PanelBody,
+	__experimentalUseSlotFills as useSlotFills,
+} from '@wordpress/components';
+import { __ } from '@wordpress/i18n';
+
+/**
+ * Internal dependencies
+ */
+import BlockStyles from '../block-styles';
+import DefaultStylePicker from '../default-style-picker';
+import InspectorControls from '../inspector-controls';
+import InspectorControlsGroups from '../inspector-controls/groups';
+
+const AppearanceTab = ( {
+	blockName,
+	clientId,
+	hasBlockStyles,
+	hasSingleBlockSelection = false,
+} ) => {
+	const { border, color, dimensions, typography } = InspectorControlsGroups;
+	const appearanceFills = [
+		...( useSlotFills( border.Slot.__unstableName ) || [] ),
+		...( useSlotFills( color.Slot.__unstableName ) || [] ),
+		...( useSlotFills( dimensions.Slot.__unstableName ) || [] ),
+		...( useSlotFills( typography.Slot.__unstableName ) || [] ),
+	];
+
+	return (
+		<>
+			{ ! appearanceFills.length && (
+				<span className="block-editor-block-inspector__no-block-tools">
+					{ hasSingleBlockSelection
+						? __( 'This block has no style options.' )
+						: __( 'The selected blocks have no style options.' ) }
+				</span>
+			) }
+			{ hasBlockStyles && (
+				<div>
+					<PanelBody title={ __( 'Styles' ) }>
+						<BlockStyles clientId={ clientId } />
+						{ hasBlockSupport(
+							blockName,
+							'defaultStylePicker',
+							true
+						) && <DefaultStylePicker blockName={ blockName } /> }
+					</PanelBody>
+				</div>
+			) }
+			<InspectorControls.Slot
+				__experimentalGroup="color"
+				label={ __( 'Color' ) }
+				className="color-block-support-panel__inner-wrapper"
+			/>
+			<InspectorControls.Slot
+				__experimentalGroup="typography"
+				label={ __( 'Typography' ) }
+			/>
+			<InspectorControls.Slot
+				__experimentalGroup="dimensions"
+				label={ __( 'Dimensions' ) }
+			/>
+			<InspectorControls.Slot
+				__experimentalGroup="border"
+				label={ __( 'Border' ) }
+			/>
+		</>
+	);
+};
+
+export default AppearanceTab;

--- a/packages/block-editor/src/components/inspector-controls-tabs/index.js
+++ b/packages/block-editor/src/components/inspector-controls-tabs/index.js
@@ -1,0 +1,42 @@
+/**
+ * WordPress dependencies
+ */
+import { TabPanel } from '@wordpress/components';
+
+/**
+ * Internal dependencies
+ */
+import { TAB_SETTINGS, TAB_APPEARANCE } from './utils';
+import AppearanceTab from './appearance-tab';
+import SettingsTab from './settings-tab';
+
+const tabs = [ TAB_APPEARANCE, TAB_SETTINGS ];
+
+export default function InspectorControlsTabs( {
+	blockName,
+	clientId,
+	hasBlockStyles,
+} ) {
+	return (
+		<TabPanel className="block-editor-block-inspector__tabs" tabs={ tabs }>
+			{ ( tab ) => {
+				if ( tab.name === TAB_SETTINGS.name ) {
+					return (
+						<SettingsTab hasSingleBlockSelection={ !! blockName } />
+					);
+				}
+
+				if ( tab.name === TAB_APPEARANCE.name ) {
+					return (
+						<AppearanceTab
+							blockName={ blockName }
+							clientId={ clientId }
+							hasBlockStyles={ hasBlockStyles }
+							hasSingleBlockSelection={ !! blockName }
+						/>
+					);
+				}
+			} }
+		</TabPanel>
+	);
+}

--- a/packages/block-editor/src/components/inspector-controls-tabs/settings-tab.js
+++ b/packages/block-editor/src/components/inspector-controls-tabs/settings-tab.js
@@ -1,0 +1,43 @@
+/**
+ * WordPress dependencies
+ */
+import { __experimentalUseSlotFills as useSlotFills } from '@wordpress/components';
+import { __ } from '@wordpress/i18n';
+
+/**
+ * Internal dependencies
+ */
+import AdvancedControls from './advanced-controls-panel';
+import InspectorControlsGroups from '../inspector-controls/groups';
+import {
+	default as InspectorControls,
+	InspectorAdvancedControls,
+} from '../inspector-controls';
+
+const SettingsTab = ( { hasSingleBlockSelection = false } ) => {
+	const { default: defaultGroup } = InspectorControlsGroups;
+	const settingsFills = [
+		...( useSlotFills( defaultGroup.Slot.__unstableName ) || [] ),
+		...( useSlotFills( InspectorAdvancedControls.slotName ) || [] ),
+	];
+
+	return (
+		<>
+			<InspectorControls.Slot />
+			{ hasSingleBlockSelection && (
+				<div>
+					<AdvancedControls />
+				</div>
+			) }
+			{ ! settingsFills.length && (
+				<span className="block-editor-block-inspector__no-block-tools">
+					{ hasSingleBlockSelection
+						? __( 'This block has no settings.' )
+						: __( 'The selected blocks have no settings.' ) }
+				</span>
+			) }
+		</>
+	);
+};
+
+export default SettingsTab;

--- a/packages/block-editor/src/components/inspector-controls-tabs/utils.js
+++ b/packages/block-editor/src/components/inspector-controls-tabs/utils.js
@@ -1,0 +1,20 @@
+/**
+ * WordPress dependencies
+ */
+import { cog, styles } from '@wordpress/icons';
+
+export const TAB_SETTINGS = {
+	name: 'settings',
+	title: 'Settings',
+	value: 'settings',
+	icon: cog,
+	className: 'block-editor-block-inspector__tab-item',
+};
+
+export const TAB_APPEARANCE = {
+	name: 'appearance',
+	title: 'Appearance',
+	value: 'appearance',
+	icon: styles,
+	className: 'block-editor-block-inspector__tab-item',
+};

--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -2,12 +2,15 @@
 
 ## Unreleased
 
+### Enhancements
+
+-   `TabPanel`: Add ability to set icon only tab buttons ([#45005](https://github.com/WordPress/gutenberg/pull/45005)).
+
 ## 22.1.0 (2022-11-16)
 
 ### Enhancements
 
 -   `ColorPalette`, `BorderBox`, `BorderBoxControl`: polish and DRY prop types, add default values ([#45463](https://github.com/WordPress/gutenberg/pull/45463)).
--   `TabPanel`: Add ability to set icon only tab buttons ([#45005](https://github.com/WordPress/gutenberg/pull/45005)).
 
 ### Bug Fix
 

--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -7,6 +7,7 @@
 ### Enhancements
 
 -   `ColorPalette`, `BorderBox`, `BorderBoxControl`: polish and DRY prop types, add default values ([#45463](https://github.com/WordPress/gutenberg/pull/45463)).
+-   `TabPanel`: Add ability to set icon only tab buttons ([#45005](https://github.com/WordPress/gutenberg/pull/45005)).
 
 ### Bug Fix
 

--- a/packages/components/src/tab-panel/README.md
+++ b/packages/components/src/tab-panel/README.md
@@ -120,6 +120,7 @@ An array of objects containing the following properties:
 -   `name`: `(string)` Defines the key for the tab.
 -   `title`:`(string)` Defines the translated text for the tab.
 -   `className`:`(string)` Optional. Defines the class to put on the tab.
+-   `icon`:`(ReactNode)` Optional. When set, displays the icon in place of the tab title. The title is then rendered as an aria-label and tooltip.
 
 > > **Note:** Other fields may be added to the object and accessed from the child function if desired.
 

--- a/packages/components/src/tab-panel/index.tsx
+++ b/packages/components/src/tab-panel/index.tsx
@@ -127,8 +127,11 @@ export function TabPanel( {
 						selected={ tab.name === selected }
 						key={ tab.name }
 						onClick={ () => handleTabSelection( tab.name ) }
+						label={ tab.icon && tab.title }
+						icon={ tab.icon }
+						showTooltip={ !! tab.icon }
 					>
-						{ tab.title }
+						{ ! tab.icon && tab.title }
 					</TabButton>
 				) ) }
 			</NavigableMenu>

--- a/packages/components/src/tab-panel/types.ts
+++ b/packages/components/src/tab-panel/types.ts
@@ -3,6 +3,11 @@
  */
 import type { ReactNode } from 'react';
 
+/**
+ * Internal dependencies
+ */
+import type { IconType } from '../icon';
+
 type Tab = {
 	/**
 	 * The key of the tab.
@@ -18,11 +23,14 @@ type Tab = {
 	className?: string;
 } & Record< any, any >;
 
-export type TabButtonProps = {
+export type TabButtonProps< IconProps = unknown > = {
 	children: ReactNode;
 	className?: string;
+	icon?: IconType< IconProps >;
+	label?: string;
 	onClick: ( event: MouseEvent ) => void;
 	selected: boolean;
+	showTooltip?: boolean;
 	tabId: string;
 };
 

--- a/packages/edit-post/src/components/sidebar/settings-sidebar/index.js
+++ b/packages/edit-post/src/components/sidebar/settings-sidebar/index.js
@@ -5,10 +5,12 @@ import {
 	BlockInspector,
 	store as blockEditorStore,
 } from '@wordpress/block-editor';
-import { cog } from '@wordpress/icons';
+import { useSelect } from '@wordpress/data';
 import { Platform } from '@wordpress/element';
-import { store as keyboardShortcutsStore } from '@wordpress/keyboard-shortcuts';
+import { isRTL, __ } from '@wordpress/i18n';
+import { drawerLeft, drawerRight } from '@wordpress/icons';
 import { store as interfaceStore } from '@wordpress/interface';
+import { store as keyboardShortcutsStore } from '@wordpress/keyboard-shortcuts';
 
 /**
  * Internal dependencies
@@ -25,8 +27,6 @@ import MetaBoxes from '../../meta-boxes';
 import PluginDocumentSettingPanel from '../plugin-document-setting-panel';
 import PluginSidebarEditPost from '../plugin-sidebar';
 import TemplateSummary from '../template-summary';
-import { __ } from '@wordpress/i18n';
-import { useSelect } from '@wordpress/data';
 import { store as editPostStore } from '../../../store';
 
 const SIDEBAR_ACTIVE_BY_DEFAULT = Platform.select( {
@@ -78,7 +78,7 @@ const SettingsSidebar = () => {
 			/* translators: button label text should, if possible, be under 16 characters. */
 			title={ __( 'Settings' ) }
 			toggleShortcut={ keyboardShortcut }
-			icon={ cog }
+			icon={ isRTL() ? drawerLeft : drawerRight }
 			isActiveByDefault={ SIDEBAR_ACTIVE_BY_DEFAULT }
 		>
 			{ ! isTemplateMode && sidebarName === 'edit-post/document' && (

--- a/packages/edit-site/src/components/sidebar-edit-mode/index.js
+++ b/packages/edit-site/src/components/sidebar-edit-mode/index.js
@@ -2,8 +2,8 @@
  * WordPress dependencies
  */
 import { createSlotFill, PanelBody } from '@wordpress/components';
-import { __ } from '@wordpress/i18n';
-import { cog } from '@wordpress/icons';
+import { isRTL, __ } from '@wordpress/i18n';
+import { drawerLeft, drawerRight } from '@wordpress/icons';
 import { useEffect, Fragment } from '@wordpress/element';
 import { useSelect, useDispatch } from '@wordpress/data';
 import { store as interfaceStore } from '@wordpress/interface';
@@ -78,7 +78,7 @@ export function SidebarComplementaryAreaFills() {
 			<DefaultSidebar
 				identifier={ sidebarName }
 				title={ __( 'Settings' ) }
-				icon={ cog }
+				icon={ isRTL() ? drawerLeft : drawerRight }
 				closeLabel={ __( 'Close settings sidebar' ) }
 				header={ <SettingsHeader sidebarName={ sidebarName } /> }
 				headerClassName="edit-site-sidebar-edit-mode__panel-tabs"

--- a/packages/icons/src/index.js
+++ b/packages/icons/src/index.js
@@ -66,6 +66,8 @@ export { default as currencyPound } from './library/currency-pound';
 export { default as customPostType } from './library/custom-post-type';
 export { default as desktop } from './library/desktop';
 export { default as dragHandle } from './library/drag-handle';
+export { default as drawerLeft } from './library/drawer-left';
+export { default as drawerRight } from './library/drawer-right';
 export { default as download } from './library/download';
 export { default as edit } from './library/edit';
 export { default as external } from './library/external';

--- a/packages/icons/src/library/drawer-left.js
+++ b/packages/icons/src/library/drawer-left.js
@@ -1,0 +1,21 @@
+/**
+ * WordPress dependencies
+ */
+import { SVG, Path } from '@wordpress/primitives';
+
+const drawerLeft = (
+	<SVG
+		width="24"
+		height="24"
+		xmlns="http://www.w3.org/2000/svg"
+		viewBox="0 0 24 24"
+	>
+		<Path
+			fillRule="evenodd"
+			clipRule="evenodd"
+			d="M18 4H6c-1.1 0-2 .9-2 2v12c0 1.1.9 2 2 2h12c1.1 0 2-.9 2-2V6c0-1.1-.9-2-2-2zM8.5 18.5H6c-.3 0-.5-.2-.5-.5V6c0-.3.2-.5.5-.5h2.5v13zm10-.5c0 .3-.2.5-.5.5h-8v-13h8c.3 0 .5.2.5.5v12z"
+		/>
+	</SVG>
+);
+
+export default drawerLeft;

--- a/packages/icons/src/library/drawer-right.js
+++ b/packages/icons/src/library/drawer-right.js
@@ -1,0 +1,21 @@
+/**
+ * WordPress dependencies
+ */
+import { SVG, Path } from '@wordpress/primitives';
+
+const drawerRight = (
+	<SVG
+		width="24"
+		height="24"
+		xmlns="http://www.w3.org/2000/svg"
+		viewBox="0 0 24 24"
+	>
+		<Path
+			fillRule="evenodd"
+			clipRule="evenodd"
+			d="M18 4H6c-1.1 0-2 .9-2 2v12c0 1.1.9 2 2 2h12c1.1 0 2-.9 2-2V6c0-1.1-.9-2-2-2zm-4 14.5H6c-.3 0-.5-.2-.5-.5V6c0-.3.2-.5.5-.5h8v13zm4.5-.5c0 .3-.2.5-.5.5h-2.5v-13H18c.3 0 .5.2.5.5v12z"
+		/>
+	</SVG>
+);
+
+export default drawerRight;


### PR DESCRIPTION
Fixes: https://github.com/WordPress/gutenberg/issues/40204

## What?

- Adds new Gutenberg Experiment to put the new tabs feature behind
- Splits the block inspector primarily between settings and appearance-related tools.
- The appearance tab contains tools provided via block supports.
- The settings tab contains block-specific tools rendered into the default `InspectorControls` slot.
- Updates the sidebar icon to use two new "drawer" icons taking into account RTL.

## Why?

It's another step towards decluttering the sidebar and making it more intuitive to locate and discover block tools.

## How?

- Adds new drawer icons to the icons package
- Updates sidebar icons
- Updates the `TabPanel` component to allow icon-only buttons
- Adds Gutenberg Experiment, making the new tabs opt-in
- Updates the block inspector to render the various `InspectorControls` slots into their respective tabs when the new experiment is enabled
- The same tabs have been introduced into the block inspector for both single and multi-block selections

Note: Tabs are no longer omitted should they not have any fills in their respective slots. Instead, they'd display a message illustrating the fact there are no settings/appearance tools. This helps maintain a more consistent UI for a11y purposes.

## Testing Instructions

1. Check that the sidebar icons have been updated in both the post and site editors, and confirm they get flipped when switching between LTR and RTL.
2. In the post editor, add a navigation block, several paragraphs, a group block etc., to a post, save and select one.
3. Confirm the block inspector displays as normal.
4. Navigate to the Gutenberg Experiments admin page and enabled the Block Inspector Tabs experiment
    <img width="1232" alt="Screen Shot 2022-10-26 at 6 05 27 pm" src="https://user-images.githubusercontent.com/60436221/197973951-fb05f4e2-9e1e-4738-944e-c0f37a3a2cc2.png">
5. Switch back to the editor, reload the page, and select each block.
6. Check that both tabs (settings & appearance) are in the sidebar and controls continue to function.
7. Select multiple blocks of different types and confirm no controls within either tab.
8. Select multiple blocks of the same type, e.g. two paragraph blocks. The appearance tab should still contain items.

## Screenshots or screencast <!-- if applicable -->


https://user-images.githubusercontent.com/60436221/198951252-9e88ea2d-290c-4307-a1b6-09d4ef9ed9bd.mp4

