### PR TITLE
Add `ariaLabel` support to block supports reference documentation

### DIFF
--- a/docs/reference-guides/block-api/block-supports.md
+++ b/docs/reference-guides/block-api/block-supports.md
@@ -105,6 +105,20 @@ supports: {
 }
 ```
 
+## ariaLabel
+
+- Type: `boolean`
+- Default value: `false`
+
+ARIA-labels let you define an accessible label for elements. This property allows enabling the definition of an aria-label for the block, without exposing a UI field.
+
+```js
+supports: {
+	// Add the support for aria label.
+	ariaLabel: true
+}
+```
+
 ## className
 
 -   Type: `boolean`


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Adds the `ariaLabel` supports option to the documentation. The option was introduced in #41744 

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

Because all available non experimental support options should be documented

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

_Not applicable_

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->
_Not applicable_

## Screenshots or screencast <!-- if applicable -->
_Not applicable_