### PR TITLE
ESLint: Fix empty `toHaveTextContent`

### DIFF
--- a/packages/a11y/src/test/clear.test.js
+++ b/packages/a11y/src/test/clear.test.js
@@ -16,7 +16,7 @@ describe( 'clear', () => {
 		document.body.appendChild( container2 );
 
 		clear();
-		expect( container1 ).toHaveTextContent( '' );
-		expect( container2 ).toHaveTextContent( '' );
+		expect( container1 ).toBeEmptyDOMElement();
+		expect( container2 ).toBeEmptyDOMElement();
 	} );
 } );

--- a/packages/a11y/src/test/index.test.js
+++ b/packages/a11y/src/test/index.test.js
@@ -43,7 +43,7 @@ describe( 'speak', () => {
 		it( 'should set the textcontent of the polite aria-live region', () => {
 			speak( 'default message' );
 			expect( containerPolite ).toHaveTextContent( 'default message' );
-			expect( containerAssertive ).toHaveTextContent( '' );
+			expect( containerAssertive ).toBeEmptyDOMElement();
 			expect( clear ).toHaveBeenCalled();
 			expect( filterMessage ).toHaveBeenCalledWith( 'default message' );
 		} );
@@ -52,7 +52,7 @@ describe( 'speak', () => {
 	describe( 'in assertive mode', () => {
 		it( 'should set the textcontent of the assertive aria-live region', () => {
 			speak( 'assertive message', 'assertive' );
-			expect( containerPolite ).toHaveTextContent( '' );
+			expect( containerPolite ).toBeEmptyDOMElement();
 			expect( containerAssertive ).toHaveTextContent(
 				'assertive message'
 			);
@@ -63,7 +63,7 @@ describe( 'speak', () => {
 		it( 'should set the textcontent of the polite aria-live region', () => {
 			speak( 'polite message', 'polite' );
 			expect( containerPolite ).toHaveTextContent( 'polite message' );
-			expect( containerAssertive ).toHaveTextContent( '' );
+			expect( containerAssertive ).toBeEmptyDOMElement();
 		} );
 	} );
 


### PR DESCRIPTION
## What?
This improves the `.toHaveTextContent( '' )` instances to actually use `.toBeEmptyDOMElement()`.

## Why?
Because `.toHaveTextContent()` with an empty string will always be truthy. See https://github.com/WordPress/gutenberg/pull/44925#discussion_r996711228 for context.

## How?
We're doing a straightforward replacement with `.toBeEmptyDOMElement()`.

## Testing Instructions
Verify tests still pass and linting is green as well.