### PR TITLE
Mark "post author name" as stable / no longer experimental

### DIFF
--- a/packages/block-library/src/post-author-name/block.json
+++ b/packages/block-library/src/post-author-name/block.json
@@ -1,7 +1,6 @@
 {
 	"$schema": "https://schemas.wp.org/trunk/block.json",
 	"apiVersion": 2,
-	"__experimental": true,
 	"name": "core/post-author-name",
 	"title": "Post Author Name",
 	"category": "theme",


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->
Removes the `"__experimental": true,` from block.json.

Closes https://github.com/WordPress/gutenberg/issues/44618

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
From WP 6.2, the block should be included in WP core and not be experimental.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
Removes the `"__experimental": true,` from block.json.

