### PR TITLE
Transform: select all blocks if the result has more than one block

### DIFF
--- a/packages/block-editor/src/components/block-switcher/index.js
+++ b/packages/block-editor/src/components/block-switcher/index.js
@@ -89,22 +89,26 @@ export const BlockSwitcherDropdownMenu = ( { clientIds, blocks } ) => {
 	const isReusable = blocks.length === 1 && isReusableBlock( blocks[ 0 ] );
 	const isTemplate = blocks.length === 1 && isTemplatePart( blocks[ 0 ] );
 
+	function selectForMultipleBlocks( insertedBlocks ) {
+		if ( insertedBlocks.length > 1 ) {
+			multiSelect(
+				insertedBlocks[ 0 ].clientId,
+				insertedBlocks[ insertedBlocks.length - 1 ].clientId
+			);
+		}
+	}
+
 	// Simple block tranformation based on the `Block Transforms` API.
 	function onBlockTransform( name ) {
 		const newBlocks = switchToBlockType( blocks, name );
 		replaceBlocks( clientIds, newBlocks );
-		multiSelect(
-			newBlocks[ 0 ].clientId,
-			newBlocks[ newBlocks.length - 1 ].clientId
-		);
+		selectForMultipleBlocks( newBlocks );
 	}
+
 	// Pattern transformation through the `Patterns` API.
 	function onPatternTransform( transformedBlocks ) {
 		replaceBlocks( clientIds, transformedBlocks );
-		multiSelect(
-			transformedBlocks[ 0 ].clientId,
-			transformedBlocks[ transformedBlocks.length - 1 ].clientId
-		);
+		selectForMultipleBlocks( transformedBlocks );
 	}
 
 	/**

--- a/packages/block-editor/src/components/block-switcher/index.js
+++ b/packages/block-editor/src/components/block-switcher/index.js
@@ -29,7 +29,7 @@ import PatternTransformationsMenu from './pattern-transformations-menu';
 import useBlockDisplayTitle from '../block-title/use-block-display-title';
 
 export const BlockSwitcherDropdownMenu = ( { clientIds, blocks } ) => {
-	const { replaceBlocks } = useDispatch( blockEditorStore );
+	const { replaceBlocks, multiSelect } = useDispatch( blockEditorStore );
 	const blockInformation = useBlockDisplayInformation( blocks[ 0 ].clientId );
 	const {
 		possibleBlockTransformations,
@@ -90,11 +90,22 @@ export const BlockSwitcherDropdownMenu = ( { clientIds, blocks } ) => {
 	const isTemplate = blocks.length === 1 && isTemplatePart( blocks[ 0 ] );
 
 	// Simple block tranformation based on the `Block Transforms` API.
-	const onBlockTransform = ( name ) =>
-		replaceBlocks( clientIds, switchToBlockType( blocks, name ) );
+	function onBlockTransform( name ) {
+		const newBlocks = switchToBlockType( blocks, name );
+		replaceBlocks( clientIds, newBlocks );
+		multiSelect(
+			newBlocks[ 0 ].clientId,
+			newBlocks[ newBlocks.length - 1 ].clientId
+		);
+	}
 	// Pattern transformation through the `Patterns` API.
-	const onPatternTransform = ( transformedBlocks ) =>
+	function onPatternTransform( transformedBlocks ) {
 		replaceBlocks( clientIds, transformedBlocks );
+		multiSelect(
+			transformedBlocks[ 0 ].clientId,
+			transformedBlocks[ transformedBlocks.length - 1 ].clientId
+		);
+	}
 
 	/**
 	 * The `isTemplate` check is a stopgap solution here.

--- a/packages/e2e-test-utils-playwright/src/editor/transform-block-to.ts
+++ b/packages/e2e-test-utils-playwright/src/editor/transform-block-to.ts
@@ -7,26 +7,38 @@ import type { Editor } from './index';
  * Clicks the default block appender.
  *
  * @param {Editor} this
- * @param {string} name Block name.
+ * @param {string} name Block name or title.
  */
 export async function transformBlockTo( this: Editor, name: string ) {
+	await this.showBlockToolbar();
+
+	if ( name.includes( '/' ) ) {
+		name = await this.page.evaluate( () => {
+			// @ts-ignore (Reason: wp isn't typed).
+			return window.wp.blocks.getBlockType( name ).title;
+		} );
+	}
+
+	const switcherToggle = await this.page.waitForSelector(
+		'.block-editor-block-switcher__toggle'
+	);
+	await switcherToggle.evaluate( ( element ) => element.scrollIntoView() );
+	await this.page.waitForSelector( '.block-editor-block-switcher__toggle' );
+	await switcherToggle.click();
+	await this.page.waitForSelector(
+		'.block-editor-block-switcher__container'
+	);
+
+	// Find the block button option within the switcher popover.
+	const xpath = `//*[contains(@class, "block-editor-block-switcher__popover")]//button[.='${ name }']`;
+	const insertButton = await this.page.waitForSelector( xpath );
+	// Clicks may fail if the button is out of view. Assure it is before click.
+	await insertButton.evaluate( ( element ) => element.scrollIntoView() );
+	await insertButton.click();
+
 	await this.page.evaluate(
-		( [ blockName ] ) => {
-			// @ts-ignore (Reason: wp isn't typed)
-			const clientIds = window.wp.data
-				.select( 'core/block-editor' )
-				.getSelectedBlockClientIds();
-			// @ts-ignore (Reason: wp isn't typed)
-			const blocks = window.wp.data
-				.select( 'core/block-editor' )
-				.getBlocksByClientId( clientIds );
-			// @ts-ignore (Reason: wp isn't typed)
-			window.wp.data.dispatch( 'core/block-editor' ).replaceBlocks(
-				clientIds,
-				// @ts-ignore (Reason: wp isn't typed)
-				window.wp.blocks.switchToBlockType( blocks, blockName )
-			);
-		},
-		[ name ]
+		() =>
+			// @ts-ignore (Reason: window global).
+			new Promise( requestIdleCallback )
 	);
 }

--- a/packages/e2e-test-utils-playwright/src/editor/transform-block-to.ts
+++ b/packages/e2e-test-utils-playwright/src/editor/transform-block-to.ts
@@ -7,38 +7,26 @@ import type { Editor } from './index';
  * Clicks the default block appender.
  *
  * @param {Editor} this
- * @param {string} name Block name or title.
+ * @param {string} name Block name.
  */
 export async function transformBlockTo( this: Editor, name: string ) {
-	await this.showBlockToolbar();
-
-	if ( name.includes( '/' ) ) {
-		name = await this.page.evaluate( ( _name ) => {
-			// @ts-ignore (Reason: wp isn't typed).
-			return window.wp.blocks.getBlockType( _name ).title;
-		}, name );
-	}
-
-	const switcherToggle = await this.page.waitForSelector(
-		'.block-editor-block-switcher__toggle'
-	);
-	await switcherToggle.evaluate( ( element ) => element.scrollIntoView() );
-	await this.page.waitForSelector( '.block-editor-block-switcher__toggle' );
-	await switcherToggle.click();
-	await this.page.waitForSelector(
-		'.block-editor-block-switcher__container'
-	);
-
-	// Find the block button option within the switcher popover.
-	const xpath = `//*[contains(@class, "block-editor-block-switcher__popover")]//button[.='${ name }']`;
-	const insertButton = await this.page.waitForSelector( xpath );
-	// Clicks may fail if the button is out of view. Assure it is before click.
-	await insertButton.evaluate( ( element ) => element.scrollIntoView() );
-	await insertButton.click();
-
 	await this.page.evaluate(
-		() =>
-			// @ts-ignore (Reason: window global).
-			new Promise( requestIdleCallback )
+		( [ blockName ] ) => {
+			// @ts-ignore (Reason: wp isn't typed)
+			const clientIds = window.wp.data
+				.select( 'core/block-editor' )
+				.getSelectedBlockClientIds();
+			// @ts-ignore (Reason: wp isn't typed)
+			const blocks = window.wp.data
+				.select( 'core/block-editor' )
+				.getBlocksByClientId( clientIds );
+			// @ts-ignore (Reason: wp isn't typed)
+			window.wp.data.dispatch( 'core/block-editor' ).replaceBlocks(
+				clientIds,
+				// @ts-ignore (Reason: wp isn't typed)
+				window.wp.blocks.switchToBlockType( blocks, blockName )
+			);
+		},
+		[ name ]
 	);
 }

--- a/packages/e2e-test-utils-playwright/src/editor/transform-block-to.ts
+++ b/packages/e2e-test-utils-playwright/src/editor/transform-block-to.ts
@@ -13,10 +13,10 @@ export async function transformBlockTo( this: Editor, name: string ) {
 	await this.showBlockToolbar();
 
 	if ( name.includes( '/' ) ) {
-		name = await this.page.evaluate( () => {
+		name = await this.page.evaluate( ( _name ) => {
 			// @ts-ignore (Reason: wp isn't typed).
-			return window.wp.blocks.getBlockType( name ).title;
-		} );
+			return window.wp.blocks.getBlockType( _name ).title;
+		}, name );
 	}
 
 	const switcherToggle = await this.page.waitForSelector(

--- a/test/e2e/specs/editor/blocks/__snapshots__/List-selects-all-transformed-output-1-chromium.txt
+++ b/test/e2e/specs/editor/blocks/__snapshots__/List-selects-all-transformed-output-1-chromium.txt
@@ -1,0 +1,9 @@
+<!-- wp:list -->
+<ul><!-- wp:list-item -->
+<li>1</li>
+<!-- /wp:list-item -->
+
+<!-- wp:list-item -->
+<li>2</li>
+<!-- /wp:list-item --></ul>
+<!-- /wp:list -->

--- a/test/e2e/specs/editor/blocks/__snapshots__/List-selects-all-transformed-output-1-chromium.txt
+++ b/test/e2e/specs/editor/blocks/__snapshots__/List-selects-all-transformed-output-1-chromium.txt
@@ -1,9 +1,7 @@
-<!-- wp:list -->
-<ul><!-- wp:list-item -->
-<li>1</li>
-<!-- /wp:list-item -->
+<!-- wp:paragraph -->
+<p>1</p>
+<!-- /wp:paragraph -->
 
-<!-- wp:list-item -->
-<li>2</li>
-<!-- /wp:list-item --></ul>
-<!-- /wp:list -->
+<!-- wp:paragraph -->
+<p>2</p>
+<!-- /wp:paragraph -->

--- a/test/e2e/specs/editor/blocks/__snapshots__/List-selects-all-transformed-output-2-chromium.txt
+++ b/test/e2e/specs/editor/blocks/__snapshots__/List-selects-all-transformed-output-2-chromium.txt
@@ -1,0 +1,7 @@
+<!-- wp:paragraph -->
+<p>1</p>
+<!-- /wp:paragraph -->
+
+<!-- wp:paragraph -->
+<p>2</p>
+<!-- /wp:paragraph -->

--- a/test/e2e/specs/editor/blocks/__snapshots__/List-selects-all-transformed-output-2-chromium.txt
+++ b/test/e2e/specs/editor/blocks/__snapshots__/List-selects-all-transformed-output-2-chromium.txt
@@ -1,7 +1,9 @@
-<!-- wp:paragraph -->
-<p>1</p>
-<!-- /wp:paragraph -->
+<!-- wp:list -->
+<ul><!-- wp:list-item -->
+<li>1</li>
+<!-- /wp:list-item -->
 
-<!-- wp:paragraph -->
-<p>2</p>
-<!-- /wp:paragraph -->
+<!-- wp:list-item -->
+<li>2</li>
+<!-- /wp:list-item --></ul>
+<!-- /wp:list -->

--- a/test/e2e/specs/editor/blocks/__snapshots__/List-selects-all-transformed-output-3-chromium.txt
+++ b/test/e2e/specs/editor/blocks/__snapshots__/List-selects-all-transformed-output-3-chromium.txt
@@ -1,0 +1,9 @@
+<!-- wp:list -->
+<ul><!-- wp:list-item -->
+<li>1</li>
+<!-- /wp:list-item -->
+
+<!-- wp:list-item -->
+<li>2</li>
+<!-- /wp:list-item --></ul>
+<!-- /wp:list -->

--- a/test/e2e/specs/editor/blocks/list.spec.js
+++ b/test/e2e/specs/editor/blocks/list.spec.js
@@ -1233,18 +1233,18 @@ test.describe( 'List', () => {
 	} );
 
 	test( 'selects all transformed output', async ( { editor, page } ) => {
-		await page.click( 'role=button[name="Add default block"i]' );
-		await page.keyboard.type( '* 1' );
-		await page.keyboard.press( 'Enter' );
-		await page.keyboard.type( '2' );
+		await editor.insertBlock( {
+			name: 'core/list',
+			innerBlocks: [
+				{ name: 'core/list-item', attributes: { content: '1' } },
+				{ name: 'core/list-item', attributes: { content: '2' } },
+			],
+		} );
 
-		// Select the whole list.
-		await page.keyboard.press( 'ArrowUp' );
-		await page.keyboard.press( 'ArrowUp' );
+		await editor.selectBlocks(
+			page.locator( 'role=document[name="Block: List"i]' )
+		);
 
-		expect( await editor.getEditedPostContent() ).toMatchSnapshot();
-
-		await editor.showBlockToolbar();
 		await page
 			.getByRole( 'button', {
 				name: 'List',
@@ -1255,7 +1255,6 @@ test.describe( 'List', () => {
 
 		expect( await editor.getEditedPostContent() ).toMatchSnapshot();
 
-		await editor.showBlockToolbar();
 		await page
 			.getByRole( 'button', {
 				name: 'Paragraph',

--- a/test/e2e/specs/editor/blocks/list.spec.js
+++ b/test/e2e/specs/editor/blocks/list.spec.js
@@ -1245,22 +1245,12 @@ test.describe( 'List', () => {
 			page.locator( 'role=document[name="Block: List"i]' )
 		);
 
-		await page
-			.getByRole( 'button', {
-				name: 'List',
-				description: 'List: Change block type or style',
-			} )
-			.click();
+		await page.getByRole( 'button', { name: 'List' } ).click();
 		await page.getByRole( 'menuitem', { name: 'Paragraph' } ).click();
 
 		expect( await editor.getEditedPostContent() ).toMatchSnapshot();
 
-		await page
-			.getByRole( 'button', {
-				name: 'Paragraph',
-				description: 'Change type of 2 blocks',
-			} )
-			.click();
+		await page.getByRole( 'button', { name: 'Paragraph' } ).click();
 		await page.getByRole( 'menuitem', { name: 'List' } ).click();
 
 		expect( await editor.getEditedPostContent() ).toMatchSnapshot();

--- a/test/e2e/specs/editor/blocks/list.spec.js
+++ b/test/e2e/specs/editor/blocks/list.spec.js
@@ -1231,4 +1231,25 @@ test.describe( 'List', () => {
 
 		expect( await editor.getEditedPostContent() ).toMatchSnapshot();
 	} );
+
+	test( 'selects all transformed output', async ( { editor, page } ) => {
+		await page.click( 'role=button[name="Add default block"i]' );
+		await page.keyboard.type( '* 1' );
+		await page.keyboard.press( 'Enter' );
+		await page.keyboard.type( '2' );
+
+		// Select the whole list.
+		await page.keyboard.press( 'ArrowUp' );
+		await page.keyboard.press( 'ArrowUp' );
+
+		expect( await editor.getEditedPostContent() ).toMatchSnapshot();
+
+		await editor.transformBlockTo( 'Paragraph' );
+
+		expect( await editor.getEditedPostContent() ).toMatchSnapshot();
+
+		await editor.transformBlockTo( 'List' );
+
+		expect( await editor.getEditedPostContent() ).toMatchSnapshot();
+	} );
 } );

--- a/test/e2e/specs/editor/blocks/list.spec.js
+++ b/test/e2e/specs/editor/blocks/list.spec.js
@@ -1244,11 +1244,25 @@ test.describe( 'List', () => {
 
 		expect( await editor.getEditedPostContent() ).toMatchSnapshot();
 
-		await editor.transformBlockTo( 'Paragraph' );
+		await editor.showBlockToolbar();
+		await page
+			.getByRole( 'button', {
+				name: 'List',
+				description: 'List: Change block type or style',
+			} )
+			.click();
+		await page.getByRole( 'menuitem', { name: 'Paragraph' } ).click();
 
 		expect( await editor.getEditedPostContent() ).toMatchSnapshot();
 
-		await editor.transformBlockTo( 'List' );
+		await editor.showBlockToolbar();
+		await page
+			.getByRole( 'button', {
+				name: 'Paragraph',
+				description: 'Change type of 2 blocks',
+			} )
+			.click();
+		await page.getByRole( 'menuitem', { name: 'List' } ).click();
 
 		expect( await editor.getEditedPostContent() ).toMatchSnapshot();
 	} );


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?

Fixes #13600. When a transform results in more than one block, select all those blocks so the result is clear and it can easily be transformed back.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->

## Screenshots or screencast <!-- if applicable -->
