### PR TITLE
List: allow pasting pre/code

### DIFF
--- a/packages/block-library/src/code/transforms.js
+++ b/packages/block-library/src/code/transforms.js
@@ -43,7 +43,9 @@ const transforms = {
 			type: 'block',
 			blocks: [ 'core/paragraph' ],
 			transform: ( { content } ) => {
-				return createBlock( 'core/paragraph', { content } );
+				return createBlock( 'core/paragraph', {
+					content: content.replace( /\n/g, '<br>' ),
+				} );
 			},
 		},
 	],

--- a/packages/block-library/src/list-item/utils.js
+++ b/packages/block-library/src/list-item/utils.js
@@ -8,6 +8,7 @@ import { createBlock, switchToBlockType } from '@wordpress/blocks';
  */
 import { name as listItemName } from './block.json';
 import { name as listName } from '../list/block.json';
+import { name as paragraphName } from '../paragraph/block.json';
 
 export function createListItem( listItemAttributes, listAttributes, children ) {
 	return createBlock(
@@ -19,6 +20,14 @@ export function createListItem( listItemAttributes, listAttributes, children ) {
 	);
 }
 
+function convertBlockToList( block ) {
+	const list = switchToBlockType( block, listName );
+	if ( list ) return list;
+	const paragraph = switchToBlockType( block, paragraphName );
+	if ( paragraph ) return switchToBlockType( paragraph, listName );
+	return null;
+}
+
 export function convertToListItems( blocks ) {
 	const listItems = [];
 
@@ -27,7 +36,7 @@ export function convertToListItems( blocks ) {
 			listItems.push( block );
 		} else if ( block.name === listName ) {
 			listItems.push( ...block.innerBlocks );
-		} else if ( ( block = switchToBlockType( block, listName ) ) ) {
+		} else if ( ( block = convertBlockToList( block ) ) ) {
 			for ( const { innerBlocks } of block ) {
 				listItems.push( ...innerBlocks );
 			}

--- a/packages/block-library/src/preformatted/transforms.js
+++ b/packages/block-library/src/preformatted/transforms.js
@@ -34,7 +34,10 @@ const transforms = {
 			type: 'block',
 			blocks: [ 'core/paragraph' ],
 			transform: ( attributes ) =>
-				createBlock( 'core/paragraph', attributes ),
+				createBlock( 'core/paragraph', {
+					...attributes,
+					content: attributes.content.replace( /\n/g, '<br>' ),
+				} ),
 		},
 		{
 			type: 'block',

--- a/test/e2e/specs/editor/various/__snapshots__/Copy-cut-paste-should-paste-preformatted-in-list-1-chromium.txt
+++ b/test/e2e/specs/editor/various/__snapshots__/Copy-cut-paste-should-paste-preformatted-in-list-1-chromium.txt
@@ -1,0 +1,5 @@
+<!-- wp:list -->
+<ul><!-- wp:list-item -->
+<li>xy</li>
+<!-- /wp:list-item --></ul>
+<!-- /wp:list -->

--- a/test/e2e/specs/editor/various/copy-cut-paste.spec.js
+++ b/test/e2e/specs/editor/various/copy-cut-paste.spec.js
@@ -433,4 +433,19 @@ test.describe( 'Copy/cut/paste', () => {
 			await page.evaluate( () => document.activeElement.innerHTML )
 		).toBe( 'axyb' );
 	} );
+
+	test( 'should paste preformatted in list', async ( {
+		page,
+		pageUtils,
+		editor,
+	} ) => {
+		await pageUtils.setClipboardData( {
+			html: '<pre>x</pre>',
+		} );
+		await editor.insertBlock( { name: 'core/list' } );
+		await pageUtils.pressKeyWithModifier( 'primary', 'v' );
+		// Ensure the selection is correct.
+		await page.keyboard.type( 'y' );
+		expect( await editor.getEditedPostContent() ).toMatchSnapshot();
+	} );
 } );


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?

Fixes #9476.

This PR does two things:

When transforming the code or preformatted block to a paragraph, make sure line breaks are converted to HTML, otherwise it becomes a single line.

Use these transforms to convert the resulting paragraph to list items when pasted in a list block.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

Currently nothing happens when pasting preformatted text in a list. This is better than nothing.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->

## Screenshots or screencast <!-- if applicable -->
