### PR TITLE
Raw handling: Markdown: also convert bulleted list with bullet characters

### DIFF
--- a/packages/blocks/src/api/raw-handling/markdown-converter.js
+++ b/packages/blocks/src/api/raw-handling/markdown-converter.js
@@ -30,6 +30,10 @@ function slackMarkdownVariantCorrector( text ) {
 	);
 }
 
+function bulletsToAsterisks( text ) {
+	return text.replace( /(^|\n)•( +)/g, '$1*$2' );
+}
+
 /**
  * Converts a piece of text into HTML based on any Markdown present.
  * Also decodes any encoded HTML.
@@ -39,5 +43,7 @@ function slackMarkdownVariantCorrector( text ) {
  * @return {string} HTML.
  */
 export default function markdownConverter( text ) {
-	return converter.makeHtml( slackMarkdownVariantCorrector( text ) );
+	return converter.makeHtml(
+		slackMarkdownVariantCorrector( bulletsToAsterisks( text ) )
+	);
 }

--- a/test/integration/blocks-raw-handling.test.js
+++ b/test/integration/blocks-raw-handling.test.js
@@ -192,6 +192,31 @@ describe( 'Blocks raw handling', () => {
 		expect( console ).toHaveLogged();
 	} );
 
+	it( 'should parse bulleted list', () => {
+		const filtered = pasteHandler( {
+			HTML: '• one<br>• two<br>• three',
+			plainText: '• one\n• two\n• three',
+			mode: 'AUTO',
+		} )
+			.map( getBlockContent )
+			.join( '' );
+
+		expect( filtered ).toMatchInlineSnapshot( `
+		"<ul><!-- wp:list-item -->
+		<li>one</li>
+		<!-- /wp:list-item -->
+
+		<!-- wp:list-item -->
+		<li>two</li>
+		<!-- /wp:list-item -->
+
+		<!-- wp:list-item -->
+		<li>three</li>
+		<!-- /wp:list-item --></ul>"
+	` );
+		expect( console ).toHaveLogged();
+	} );
+
 	it( 'should parse inline Markdown', () => {
 		const filtered = pasteHandler( {
 			HTML: 'Some **bold** text.',


### PR DESCRIPTION

<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?

Fixes #20770.

When pasting a list with actual bullet characters, convert them to asterisks so the markdown converter creates a list instead of a paragraph.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->

## Screenshots or screencast <!-- if applicable -->
