### PR TITLE
Components: refactor `ToolsPanel` to pass `exhaustive-deps`

### DIFF
--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -19,6 +19,8 @@
 -   `Navigator`: refactor unit tests to TypeScript and to `user-event` ([#44970](https://github.com/WordPress/gutenberg/pull/44970)).
 -   `Navigator`: Refactor Storybook code to TypeScript and controls ([#44979](https://github.com/WordPress/gutenberg/pull/44979)).
 -   `withFocusReturn`: Refactor tests to `@testing-library/react` ([#45012](https://github.com/WordPress/gutenberg/pull/45012)).
+-   `ToolsPanel`: updated to satisfy `react/exhaustive-deps` eslint rule ([#45028](https://github.com/WordPress/gutenberg/pull/45028))
+-   `Tooltip`: updated to ignore `react/exhaustive-deps` eslint rule ([#45043](https://github.com/WordPress/gutenberg/pull/45043))
 
 ## 21.2.0 (2022-10-05)
 
@@ -50,7 +52,6 @@
 -   `Sandbox`: updated to satisfy `react/exhaustive-deps` eslint rule ([#44378](https://github.com/WordPress/gutenberg/pull/44378))
 -   `FontSizePicker`: Convert to TypeScript ([#44449](https://github.com/WordPress/gutenberg/pull/44449)).
 -   `FontSizePicker`: Replace SCSS with Emotion + components ([#44483](https://github.com/WordPress/gutenberg/pull/44483)).
--   `Tooltip`: updated to ignore `react/exhaustive-deps` eslint rule ([#45043](https://github.com/WordPress/gutenberg/pull/45043))
 
 ### Experimental
 

--- a/packages/components/src/tools-panel/tools-panel-item/hook.ts
+++ b/packages/components/src/tools-panel/tools-panel-item/hook.ts
@@ -42,8 +42,11 @@ export function useToolsPanelItem(
 		__experimentalLastVisibleItemClass,
 	} = useToolsPanelContext();
 
-	const hasValueCallback = useCallback( hasValue, [ panelId ] );
-	const resetAllFilterCallback = useCallback( resetAllFilter, [ panelId ] );
+	const hasValueCallback = useCallback( hasValue, [ panelId, hasValue ] );
+	const resetAllFilterCallback = useCallback( resetAllFilter, [
+		panelId,
+		resetAllFilter,
+	] );
 	const previousPanelId = usePrevious( currentPanelId );
 
 	const hasMatchingPanel =
@@ -79,6 +82,8 @@ export function useToolsPanelItem(
 		panelId,
 		previousPanelId,
 		resetAllFilterCallback,
+		registerPanelItem,
+		deregisterPanelItem,
 	] );
 
 	const isValueSet = hasValue();
@@ -90,7 +95,13 @@ export function useToolsPanelItem(
 		if ( isShownByDefault && isValueSet && ! wasValueSet ) {
 			flagItemCustomization( label );
 		}
-	}, [ isValueSet, wasValueSet, isShownByDefault, label ] );
+	}, [
+		isValueSet,
+		wasValueSet,
+		isShownByDefault,
+		label,
+		flagItemCustomization,
+	] );
 
 	// Note: `label` is used as a key when building menu item state in
 	// `ToolsPanel`.
@@ -118,6 +129,8 @@ export function useToolsPanelItem(
 		isResetting,
 		isValueSet,
 		wasMenuItemChecked,
+		onSelect,
+		onDeselect,
 	] );
 
 	// The item is shown if it is a default control regardless of whether it
@@ -153,6 +166,7 @@ export function useToolsPanelItem(
 		lastDisplayedItem,
 		__experimentalFirstVisibleItemClass,
 		__experimentalLastVisibleItemClass,
+		label,
 	] );
 
 	return {

--- a/packages/components/src/tools-panel/tools-panel/hook.ts
+++ b/packages/components/src/tools-panel/tools-panel/hook.ts
@@ -139,7 +139,7 @@ export function useToolsPanel(
 			} );
 			return items;
 		} );
-	}, [ generateMenuItems, panelItems, setMenuItems ] );
+	}, [ panelItems, setMenuItems ] );
 
 	// Force a menu item to be checked.
 	// This is intended for use with default panel items. They are displayed
@@ -255,13 +255,7 @@ export function useToolsPanel(
 			shouldReset: true,
 		} );
 		setMenuItems( resetMenuItems );
-	}, [
-		generateMenuItems,
-		isResetting.current,
-		panelItems,
-		resetAll,
-		setMenuItems,
-	] );
+	}, [ panelItems, resetAll, setMenuItems ] );
 
 	// Assist ItemGroup styling when there are potentially hidden placeholder
 	// items by identifying first & last items that are toggled on for display.
@@ -300,7 +294,6 @@ export function useToolsPanel(
 			deregisterPanelItem,
 			firstDisplayedItem,
 			flagItemCustomization,
-			isResetting.current,
 			lastDisplayedItem,
 			menuItems,
 			panelId,


### PR DESCRIPTION
## What?
Updates the `ToolsPanel` component to satisfy the `exhaustive-deps` eslint rule

## Why?
Part of the effort in https://github.com/WordPress/gutenberg/pull/41166 to apply `exhuastive-deps` to the Components package

## How?
In `tools-panel/hook.ts`, we can safely remove `generateMenuItems` from dep arrays. React can't tell if an outer scope value like this changes, so it would never trigger a re-render, nor would it cause the effect to actually fire.

We can also safely remove `isResetting.current` from the dependency arrays. Including a `ref.current` value in a dependency array [isn't recommended in general](https://epicreact.dev/why-you-shouldnt-put-refs-in-a-dependency-array/).

In the relevant `useCallback`,  the value is updated, but never actually read... so even if it _had_ changed, that wouldn't impact the callback's behavior.

In the relevant `useMemo`, the value is read, so changes matter, but including the dependency in the array gives a false sense of security. If that were the only dep to change on a given render, React wouldn't notice, and the memoized value wouldn't update. If we really want the `isResetting` value to trigger a re-render to update this memo it should go into state, or a reducer. Because the component has functioned properly as it is now thus far, I think we should hold off on introducing new state (which will be sure to trigger additional renders and potentially other behavior changes) and simply remove the dependency. cc @aaronrobertshaw in case you have any insights, as you did some work with the `isResetting` value here most recently.

Finally, in `tools-panel-item/hook.ts`, a number of missing dependencies were added. In each case the added dep(s) are values being destructured from one of two contexts, so they'd cause their hooks to fire on every render. However, all of these hooks already have dependencies that are being destructured in this way, or derived from similar variables... so these new dependencies shouldn't change the existing behavior of anything. (Please feel free to correct me if my logic doesn't sound right here!)

## Testing Instructions
1. From your local Gutenberg directory, run `npx eslint --rule 'react-hooks/exhaustive-deps: warn' packages/components/src/tools-panel`
2. Confirm that the linter returns no errors
3. Confirm unit tests still pass
4. Run Storybook locally, confirm the components stories and/or docs still work as expected
