### PR TITLE
Font Size Picker Hint: Fallback to font size `slug` if `name` is undefined

### DIFF
--- a/packages/components/src/font-size-picker/index.tsx
+++ b/packages/components/src/font-size-picker/index.tsx
@@ -139,7 +139,7 @@ const UnforwardedFontSizePicker = (
 		}
 
 		// Calculate the `hint` for toggle group control.
-		let hint = selectedOption.name;
+		let hint = selectedOption?.name || selectedOption.slug;
 		if (
 			! fontSizesContainComplexValues &&
 			typeof selectedOption.size === 'string'


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->
This PR tweaks the `headerHint` function so that the font size preset `slug` is used when `name` is missing/undefined. I believe `name` is optional, so this may be a common occurrence.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
When a theme sets custom font sizes but does not include a `name` for a preset, the font picker displays 'undefined' as the size label:

<img width="282" alt="image" src="https://user-images.githubusercontent.com/1645628/196222757-603ee775-dd41-4128-8960-5fc8147f71fb.png">

Addresses this comment: https://github.com/WordPress/gutenberg/pull/44791#issuecomment-1280502247.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
This changes the logic so that instead of always trying to use the `name` from the font size preset, it will attempt to use `name` if it exists, and if it doesn't, it will use `slug` instead. I believe the font size `slug` is required, so this should be a safe fallback.

Here's an example from the Canary variation in TT3, which defines the font sizes with no `name` keys. I've added a `name` to the first size to show how this is currently used.

<details><summary>theme.json</summary>

```
"typography": {
	"fontSizes": [
		{
			"name": "Smallish",
			"size": "0.75rem",
			"slug": "small"
		},
		{
			"size": "1.125rem",
			"slug": "medium"
		},
		{
			"size": "1.75rem",
			"slug": "large"
		},
		{
			"size": "2.25rem",
			"slug": "x-large"
		},
		{
			"size": "10rem",
			"slug": "xx-large"
		}
	]
}
```

</details>

Before:

https://user-images.githubusercontent.com/1645628/196224210-b51cd5be-3a2f-44ef-99a5-b33b82983102.mov

After:

https://user-images.githubusercontent.com/1645628/196224986-5ed5cb8e-6534-4c1e-a2ca-70a8a6a5fd8b.mov


## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->
1. Add the above theme.json `fontSizes` array to a theme
2. Go to the Site Editor and use the editor to change the font size of a text element/block
3. Toggle between the available sizes and notice the label/hint value next to the 'Size' label

(I've not worked in this area before, so I'm not sure if this is correct/the best solution!)
