### PR TITLE
Fix visibility of nested Group block appender

### DIFF
--- a/packages/block-editor/src/components/button-block-appender/style.scss
+++ b/packages/block-editor/src/components/button-block-appender/style.scss
@@ -36,8 +36,9 @@
 .block-list-appender:only-child {
 	.is-layout-constrained.block-editor-block-list__block:not(.is-selected) > &,
 	.is-layout-flow.block-editor-block-list__block:not(.is-selected) > &,
-	.is-layout-constrained.block-editor-block-list__block:not(.is-selected) > .block-editor-block-list__layout > &,
-	.is-layout-flow.block-editor-block-list__block:not(.is-selected) > .block-editor-block-list__layout > & {
+	// Legacy groups have an inner container so need to be targeted separately
+	.is-layout-constrained.block-editor-block-list__block:not(.is-selected) > .wp-block-group__inner-container > &,
+	.is-layout-flow.block-editor-block-list__block:not(.is-selected) > .wp-block-group__inner-container > & {
 		pointer-events: none;
 
 		&::after {


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

Fixes #44989.

Styles were added in #44660 to allow empty, unselected Group blocks to display in classic themes as dashed outlines with no visible appender, like so:

<img width="640" alt="Screen Shot 2022-10-18 at 10 22 23 am" src="https://user-images.githubusercontent.com/8096000/196301530-f6d82152-fe8b-40ac-b007-17a1e76f68ea.png">

These styles were generic enough that they accidentally made the appender invisible for nested Groups in block themes, too.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

This PR changes the abovementioned styles to specifically target legacy Group blocks.


## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->

1. Enable a block theme;
2. In the post editor, add a Group and then another Group inside it;
3. Make sure the appender displays correctly in the nested Group when it is selected;
4. Check that unselecting the Group hides the appender.
5. Enable a classic theme;
6. Navigate to the previous post and check that visibility of appenders works the same as with the block theme.

## Screenshots or screencast <!-- if applicable -->

Selected Group with TT3:
<img width="880" alt="Screen Shot 2022-10-18 at 10 26 52 am" src="https://user-images.githubusercontent.com/8096000/196302031-3ce471f0-b826-421d-ac4d-ebf02f2e31d8.png">

Unselected Group with TT3:
<img width="875" alt="Screen Shot 2022-10-18 at 10 27 07 am" src="https://user-images.githubusercontent.com/8096000/196302043-e9334198-407a-4fc1-b49f-06fbdac657f2.png">

Selected Group with TT1:
<img width="1133" alt="Screen Shot 2022-10-18 at 10 28 15 am" src="https://user-images.githubusercontent.com/8096000/196302138-0a14d20e-08ea-49e2-b529-408e7771afd1.png">

Unselected Group with TT1:
<img width="1136" alt="Screen Shot 2022-10-18 at 10 28 07 am" src="https://user-images.githubusercontent.com/8096000/196302157-447dff61-d3a6-4fcc-a19b-21e435a2c6f1.png">

