### PR TITLE
Updating versions in WP in light of 6.0.3 release

### DIFF
--- a/docs/contributors/versions-in-wordpress.md
+++ b/docs/contributors/versions-in-wordpress.md
@@ -7,6 +7,7 @@ If anything looks incorrect here, please bring it up in #core-editor in [WordPre
 | Gutenberg Versions | WordPress Version |
 | ------------------ | ----------------- |
 | 13.1-14.1          | 6.1               |
+| 12.0-13.0          | 6.0.3             |
 | 12.0-13.0          | 6.0.2             |
 | 12.0-13.0          | 6.0.1             |
 | 12.0-13.0          | 6.0               |


### PR DESCRIPTION
## What?

Quick update to keep the versions in WP doc up to date after today's security release. 

