### PR TITLE
Update margin & padding overlay design

### DIFF
--- a/packages/block-editor/src/components/spacing-sizes-control/utils.js
+++ b/packages/block-editor/src/components/spacing-sizes-control/utils.js
@@ -208,3 +208,16 @@ export function isValuesDefined( values ) {
 	}
 	return Object.values( values ).filter( ( value ) => !! value ).length > 0;
 }
+
+/**
+ * Finds the name label for a given preset var value.
+ *
+ * @param {string} presetVar The preset var string to find the name of.
+ * @param {Array}  spacingSizes The array of spacing sizes for current theme.
+ *
+ * @return {boolean} Whether values are defined.
+ */
+export function getNameFromPresetVar( presetVar, spacingSizes ) {
+	const slug = getSpacingPresetSlug( presetVar );
+	return spacingSizes.find( ( size ) => size.slug === slug )?.name;
+}

--- a/packages/block-editor/src/hooks/margin.js
+++ b/packages/block-editor/src/hooks/margin.js
@@ -9,7 +9,8 @@ import isShallowEqual from '@wordpress/is-shallow-equal';
  */
 import BlockPopover from '../components/block-popover';
 import { __unstableUseBlockElement as useBlockElement } from '../components/block-list/use-block-props/use-block-refs';
-import { getSpacingPresetSlug } from '../components/spacing-sizes-control/utils';
+import { getNameFromPresetVar } from '../components/spacing-sizes-control/utils';
+import useSetting from '../components/use-setting';
 
 function getComputedCSS( element, property ) {
 	return element.ownerDocument.defaultView
@@ -20,6 +21,7 @@ function getComputedCSS( element, property ) {
 export function MarginVisualizer( { clientId, attributes, forceShow } ) {
 	const blockElement = useBlockElement( clientId );
 	const [ style, setStyle ] = useState();
+	const spacingSizes = useSetting( 'spacing.spacingSizes' );
 
 	const margin = attributes?.style?.spacing?.margin;
 
@@ -95,18 +97,24 @@ export function MarginVisualizer( { clientId, attributes, forceShow } ) {
 			shift={ false }
 		>
 			<div className="block-editor__margin-visualizer" style={ style } />
-			<span
-				className="block-editor__margin-visualizer-label-top"
-				style={ { top: style.top, right: '0' } }
-			>
-				{ getSpacingPresetSlug( margin?.top ) || margin?.top }
-			</span>
-			<span
-				className="block-editor__margin-visualizer-label-bottom"
-				style={ { bottom: style.bottom, right: '0' } }
-			>
-				{ getSpacingPresetSlug( margin?.bottom ) || margin?.bottom }
-			</span>
+			{ margin?.top && (
+				<span
+					className="block-editor__margin-visualizer-label-top"
+					style={ { top: style.top, right: '0' } }
+				>
+					{ getNameFromPresetVar( margin?.top, spacingSizes ) ||
+						margin?.top }
+				</span>
+			) }
+			{ margin?.bottom && (
+				<span
+					className="block-editor__margin-visualizer-label-bottom"
+					style={ { bottom: style.bottom, right: '0' } }
+				>
+					{ getNameFromPresetVar( margin?.bottom, spacingSizes ) ||
+						margin?.bottom }
+				</span>
+			) }
 		</BlockPopover>
 	);
 }

--- a/packages/block-editor/src/hooks/margin.js
+++ b/packages/block-editor/src/hooks/margin.js
@@ -9,6 +9,7 @@ import isShallowEqual from '@wordpress/is-shallow-equal';
  */
 import BlockPopover from '../components/block-popover';
 import { __unstableUseBlockElement as useBlockElement } from '../components/block-list/use-block-props/use-block-refs';
+import { getSpacingPresetSlug } from '../components/spacing-sizes-control/utils';
 
 function getComputedCSS( element, property ) {
 	return element.ownerDocument.defaultView
@@ -27,6 +28,15 @@ export function MarginVisualizer( { clientId, attributes, forceShow } ) {
 			return;
 		}
 
+		// Render diagonal stripes to represent spacing.
+		// Leverage blend modes to ensure visibility
+		// over different sets of backgrounds.
+		const stripes = {
+			opacity: '0.5',
+			mixBlendMode: 'multiply',
+		};
+		const stripesColor = 'var(--wp-admin-theme-color)';
+
 		const top = getComputedCSS( blockElement, 'margin-top' );
 		const right = getComputedCSS( blockElement, 'margin-right' );
 		const bottom = getComputedCSS( blockElement, 'margin-bottom' );
@@ -41,6 +51,8 @@ export function MarginVisualizer( { clientId, attributes, forceShow } ) {
 			right: right ? `-${ right }` : 0,
 			bottom: bottom ? `-${ bottom }` : 0,
 			left: left ? `-${ left }` : 0,
+			backgroundImage: `linear-gradient(135deg, ${ stripesColor } 7.14%, transparent 7.14%, transparent 50%, ${ stripesColor } 50%, ${ stripesColor } 57.14%, transparent 57.14%, transparent 100%)`,
+			...stripes,
 		} );
 	}, [ blockElement, margin ] );
 
@@ -82,24 +94,18 @@ export function MarginVisualizer( { clientId, attributes, forceShow } ) {
 			__unstablePopoverSlot="block-toolbar"
 			shift={ false }
 		>
-			<div className="block-editor__padding-visualizer" style={ style } />
+			<div className="block-editor__margin-visualizer" style={ style } />
 			<span
-				className="block-editor__padding-visualizer-label-top"
-				style={ { top: `-${ margin?.top }`, right: '0' } }
+				className="block-editor__margin-visualizer-label-top"
+				style={ { top: style.top, right: '0' } }
 			>
-				{ margin?.top }
+				{ getSpacingPresetSlug( margin?.top ) || margin?.top }
 			</span>
 			<span
-				className="block-editor__padding-visualizer-label-bottom"
-				style={ { bottom: `-${ margin?.bottom }`, right: '0' } }
+				className="block-editor__margin-visualizer-label-bottom"
+				style={ { bottom: style.bottom, right: '0' } }
 			>
-				{ margin?.bottom }
-			</span>
-			<span className="block-editor__padding-visualizer-label-left">
-				{ margin?.left }
-			</span>
-			<span className="block-editor__padding-visualizer-label-right">
-				{ margin?.right }
+				{ getSpacingPresetSlug( margin?.bottom ) || margin?.bottom }
 			</span>
 		</BlockPopover>
 	);

--- a/packages/block-editor/src/hooks/margin.js
+++ b/packages/block-editor/src/hooks/margin.js
@@ -83,6 +83,24 @@ export function MarginVisualizer( { clientId, attributes, forceShow } ) {
 			shift={ false }
 		>
 			<div className="block-editor__padding-visualizer" style={ style } />
+			<span
+				className="block-editor__padding-visualizer-label-top"
+				style={ { top: `-${ margin?.top }`, right: '0' } }
+			>
+				{ margin?.top }
+			</span>
+			<span
+				className="block-editor__padding-visualizer-label-bottom"
+				style={ { bottom: `-${ margin?.bottom }`, right: '0' } }
+			>
+				{ margin?.bottom }
+			</span>
+			<span className="block-editor__padding-visualizer-label-left">
+				{ margin?.left }
+			</span>
+			<span className="block-editor__padding-visualizer-label-right">
+				{ margin?.right }
+			</span>
 		</BlockPopover>
 	);
 }

--- a/packages/block-editor/src/hooks/padding.js
+++ b/packages/block-editor/src/hooks/padding.js
@@ -21,10 +21,35 @@ export function PaddingVisualizer( { clientId, attributes, forceShow } ) {
 	const [ style, setStyle ] = useState();
 
 	const padding = attributes?.style?.spacing?.padding;
+	const isDark = attributes?.isDark;
+	const url = attributes?.url;
+	const dimRatio = attributes?.dimRatio;
 
 	useEffect( () => {
 		if ( ! blockElement ) {
 			return;
+		}
+
+		// Render diagonal stripes to represent spacing.
+		// Leverage blend modes to ensure visibility
+		// over different sets of backgrounds.
+		const stripes = {
+			opacity: '0.8',
+			mixBlendMode: 'color-dodge',
+		};
+		let stripesColor = 'var(--wp-admin-theme-color)';
+
+		// Handle dark contrast.
+		if ( isDark ) {
+			stripes.mixBlendMode = 'plus-lighter';
+			stripesColor = 'rgb(255,255,255)';
+		}
+
+		// When the image has preponderance over the
+		// colored overlay.
+		if ( url && dimRatio <= 50 ) {
+			stripes.mixBlendMode = 'plus-lighter';
+			stripesColor = 'var(--wp-admin-theme-color)';
 		}
 
 		setStyle( {
@@ -32,8 +57,10 @@ export function PaddingVisualizer( { clientId, attributes, forceShow } ) {
 			borderRightWidth: getComputedCSS( blockElement, 'padding-right' ),
 			borderBottomWidth: getComputedCSS( blockElement, 'padding-bottom' ),
 			borderLeftWidth: getComputedCSS( blockElement, 'padding-left' ),
+			backgroundImage: `linear-gradient(135deg, ${ stripesColor } 7.14%, transparent 7.14%, transparent 50%, ${ stripesColor } 50%, ${ stripesColor } 57.14%, transparent 57.14%, transparent 100%)`,
+			...stripes,
 		} );
-	}, [ blockElement, padding ] );
+	}, [ blockElement, padding, isDark, url, dimRatio ] );
 
 	const [ isActive, setIsActive ] = useState( false );
 	const valueRef = useRef( padding );

--- a/packages/block-editor/src/hooks/padding.js
+++ b/packages/block-editor/src/hooks/padding.js
@@ -34,8 +34,8 @@ export function PaddingVisualizer( { clientId, attributes, forceShow } ) {
 		// Leverage blend modes to ensure visibility
 		// over different sets of backgrounds.
 		const stripes = {
-			opacity: '0.8',
-			mixBlendMode: 'color-dodge',
+			opacity: '0.6',
+			mixBlendMode: 'difference',
 		};
 		let stripesColor = 'var(--wp-admin-theme-color)';
 

--- a/packages/block-editor/src/hooks/padding.scss
+++ b/packages/block-editor/src/hooks/padding.scss
@@ -1,12 +1,32 @@
 .block-editor__padding-visualizer {
+	z-index: -1;
 	position: absolute;
 	top: 0;
 	bottom: 0;
 	left: 0;
 	right: 0;
 	opacity: 0.5;
-	border-color: var(--wp-admin-theme-color);
+	border-color: transparent;
 	border-style: solid;
 	pointer-events: none;
 	box-sizing: border-box;
+	background-size: 11px 11px;
+	background-image: linear-gradient(135deg, rgba(var(--wp-admin-theme-color--rgb), 0.8) 9.09%, transparent 9.09%, transparent 50%, rgba(var(--wp-admin-theme-color--rgb), 0.8) 50%, rgba(var(--wp-admin-theme-color--rgb), 0.8) 59.09%, transparent 59.09%, transparent 100%);
+	background-position: left top;
+	background-origin: border-box;
+	background-clip: border-box, content-box;
+	-webkit-mask: linear-gradient(#fff 0 0) padding-box, linear-gradient(#fff 0 0) border-box;
+	-webkit-mask-composite: xor;
+	mask-composite: exclude;
+}
+
+.block-editor__padding-visualizer-label-top,
+.block-editor__padding-visualizer-label-bottom {
+	background-color: rgba(var(--wp-admin-theme-color--rgb), 1);
+	color: #fff;
+	padding: 3px 10px;
+	border-radius: 2px;
+	font-size: 13px;
+	position: absolute;
+	margin: 8px;
 }

--- a/packages/block-editor/src/hooks/padding.scss
+++ b/packages/block-editor/src/hooks/padding.scss
@@ -1,17 +1,16 @@
-.block-editor__padding-visualizer {
+.block-editor__padding-visualizer,
+.block-editor__margin-visualizer {
 	z-index: -1;
 	position: absolute;
 	top: 0;
 	bottom: 0;
 	left: 0;
 	right: 0;
-	opacity: 0.5;
 	border-color: transparent;
 	border-style: solid;
 	pointer-events: none;
 	box-sizing: border-box;
-	background-size: 11px 11px;
-	background-image: linear-gradient(135deg, rgba(var(--wp-admin-theme-color--rgb), 0.8) 9.09%, transparent 9.09%, transparent 50%, rgba(var(--wp-admin-theme-color--rgb), 0.8) 50%, rgba(var(--wp-admin-theme-color--rgb), 0.8) 59.09%, transparent 59.09%, transparent 100%);
+	background-size: 7px 7px;
 	background-position: left top;
 	background-origin: border-box;
 	background-clip: border-box, content-box;
@@ -20,8 +19,8 @@
 	mask-composite: exclude;
 }
 
-.block-editor__padding-visualizer-label-top,
-.block-editor__padding-visualizer-label-bottom {
+.block-editor__margin-visualizer-label-top,
+.block-editor__margin-visualizer-label-bottom {
 	background-color: rgba(var(--wp-admin-theme-color--rgb), 1);
 	color: #fff;
 	padding: 3px 10px;
@@ -29,4 +28,5 @@
 	font-size: 13px;
 	position: absolute;
 	margin: 8px;
+	border: 1px solid #fff;
 }

--- a/packages/block-editor/src/hooks/padding.scss
+++ b/packages/block-editor/src/hooks/padding.scss
@@ -25,8 +25,8 @@
 	color: #fff;
 	padding: 3px 10px;
 	border-radius: 2px;
-	font-size: 13px;
+	font-family: $default-font;
+	font-size: $helptext-font-size;
 	position: absolute;
 	margin: 8px;
-	border: 1px solid #fff;
 }


### PR DESCRIPTION
This updates the design of the overlay when manipulating margin and padding. It uses a striped background and blend modes to try to keep a visible representation over multiple background situations. It also introduces tooltip feedback representing both discrete values and space presets.

https://user-images.githubusercontent.com/548849/196324087-6866d819-c057-476f-b1af-76a7e6292e5f.mov

**Notes:**
- When spacing presets are used we append a "Space" prefix. This is something we are still exploring for the label itself in the tools panel.
- We have z-index issues that would be addressed by other improvements to hiding UI when overlays are active.
- Blend modes are a progressive enhancement (they don't seem to work in chrome at the moment either).