### PR TITLE
Data: Refactor 'withSelect' tests to use RTL

### DIFF
--- a/packages/data/src/components/with-select/test/index.js
+++ b/packages/data/src/components/with-select/test/index.js
@@ -42,13 +42,13 @@ describe( 'withSelect', () => {
 		} ) );
 
 		const OriginalComponent = jest.fn( ( props ) => (
-			<div>{ props.data }</div>
+			<div role="status">{ props.data }</div>
 		) );
 
 		const DataBoundComponent =
 			withSelect( mapSelectToProps )( OriginalComponent );
 
-		const { container } = render(
+		render(
 			<RegistryProvider value={ registry }>
 				<DataBoundComponent keyName="reactKey" />
 			</RegistryProvider>
@@ -61,7 +61,9 @@ describe( 'withSelect', () => {
 		expect( OriginalComponent ).toHaveBeenCalledTimes( 1 );
 
 		// Wrapper is the enhanced component.
-		expect( container ).toHaveTextContent( 'reactState' );
+		expect( screen.getByRole( 'status' ) ).toHaveTextContent(
+			'reactState'
+		);
 	} );
 
 	it( 'should rerun selection on state changes', async () => {
@@ -167,7 +169,7 @@ describe( 'withSelect', () => {
 			}
 
 			render() {
-				return <div>{ this.props.count }</div>;
+				return <div role="status">{ this.props.count }</div>;
 			}
 		}
 
@@ -187,13 +189,13 @@ describe( 'withSelect', () => {
 		] )( OriginalComponent );
 
 		it( 'should rerun if had dispatched action during mount', () => {
-			const { container, unmount } = render(
+			const { unmount } = render(
 				<RegistryProvider value={ testRegistry }>
 					<DataBoundComponent />
 				</RegistryProvider>
 			);
 
-			expect( container ).toHaveTextContent( '2' );
+			expect( screen.getByRole( 'status' ) ).toHaveTextContent( '2' );
 			// Expected 3 times because:
 			// - 1 on initial render
 			// - 1 on effect before subscription set.
@@ -205,13 +207,13 @@ describe( 'withSelect', () => {
 		} );
 
 		it( 'should rerun on unmount and mount', () => {
-			const { container } = render(
+			render(
 				<RegistryProvider value={ testRegistry }>
 					<DataBoundComponent />
 				</RegistryProvider>
 			);
 
-			expect( container ).toHaveTextContent( '4' );
+			expect( screen.getByRole( 'status' ) ).toHaveTextContent( '4' );
 			// Expected an additional 3 times because of the unmount and remount:
 			// - 1 on initial render
 			// - 1 on effect before subscription set.
@@ -241,13 +243,13 @@ describe( 'withSelect', () => {
 		} ) );
 
 		const OriginalComponent = jest.fn( ( props ) => (
-			<div>{ props.count }</div>
+			<div role="status">{ props.count }</div>
 		) );
 
 		const DataBoundComponent =
 			withSelect( mapSelectToProps )( OriginalComponent );
 
-		const { container, rerender } = render(
+		const { rerender } = render(
 			<RegistryProvider value={ registry }>
 				<DataBoundComponent offset={ 0 } />
 			</RegistryProvider>
@@ -265,7 +267,7 @@ describe( 'withSelect', () => {
 			</RegistryProvider>
 		);
 
-		expect( container ).toHaveTextContent( '10' );
+		expect( screen.getByRole( 'status' ) ).toHaveTextContent( '10' );
 		expect( mapSelectToProps ).toHaveBeenCalledTimes( 3 );
 		expect( OriginalComponent ).toHaveBeenCalledTimes( 2 );
 	} );
@@ -439,13 +441,13 @@ describe( 'withSelect', () => {
 		} );
 
 		const OriginalComponent = jest.fn( ( props ) => (
-			<div>{ JSON.stringify( props ) }</div>
+			<div role="status">{ JSON.stringify( props ) }</div>
 		) );
 
 		const DataBoundComponent =
 			withSelect( mapSelectToProps )( OriginalComponent );
 
-		const { container, rerender } = render(
+		const { rerender } = render(
 			<RegistryProvider value={ registry }>
 				<DataBoundComponent propName="foo" />
 			</RegistryProvider>
@@ -457,7 +459,7 @@ describe( 'withSelect', () => {
 		expect( mapSelectToProps ).toHaveBeenCalledTimes( 2 );
 		expect( OriginalComponent ).toHaveBeenCalledTimes( 1 );
 
-		expect( container ).toHaveTextContent(
+		expect( screen.getByRole( 'status' ) ).toHaveTextContent(
 			JSON.stringify( {
 				propName: 'foo',
 				foo: 'OK',
@@ -472,7 +474,7 @@ describe( 'withSelect', () => {
 
 		expect( mapSelectToProps ).toHaveBeenCalledTimes( 3 );
 		expect( OriginalComponent ).toHaveBeenCalledTimes( 2 );
-		expect( container ).toHaveTextContent(
+		expect( screen.getByRole( 'status' ) ).toHaveTextContent(
 			JSON.stringify( {
 				propName: 'bar',
 				bar: 'OK',
@@ -498,13 +500,13 @@ describe( 'withSelect', () => {
 		} );
 
 		const OriginalComponent = jest.fn( ( props ) => (
-			<div>{ props.count || 'Unknown' }</div>
+			<div role="status">{ props.count || 'Unknown' }</div>
 		) );
 
 		const DataBoundComponent =
 			withSelect( mapSelectToProps )( OriginalComponent );
 
-		const { container, rerender } = render(
+		const { rerender } = render(
 			<RegistryProvider value={ registry }>
 				<DataBoundComponent pass={ false } />
 			</RegistryProvider>
@@ -515,7 +517,7 @@ describe( 'withSelect', () => {
 		// - 1 on effect before subscription set.
 		expect( mapSelectToProps ).toHaveBeenCalledTimes( 2 );
 		expect( OriginalComponent ).toHaveBeenCalledTimes( 1 );
-		expect( container ).toHaveTextContent( 'Unknown' );
+		expect( screen.getByRole( 'status' ) ).toHaveTextContent( 'Unknown' );
 
 		rerender(
 			<RegistryProvider value={ registry }>
@@ -525,7 +527,7 @@ describe( 'withSelect', () => {
 
 		expect( mapSelectToProps ).toHaveBeenCalledTimes( 3 );
 		expect( OriginalComponent ).toHaveBeenCalledTimes( 2 );
-		expect( container ).toHaveTextContent( 'OK' );
+		expect( screen.getByRole( 'status' ) ).toHaveTextContent( 'OK' );
 
 		rerender(
 			<RegistryProvider value={ registry }>
@@ -535,7 +537,7 @@ describe( 'withSelect', () => {
 
 		expect( mapSelectToProps ).toHaveBeenCalledTimes( 4 );
 		expect( OriginalComponent ).toHaveBeenCalledTimes( 3 );
-		expect( container ).toHaveTextContent( 'Unknown' );
+		expect( screen.getByRole( 'status' ) ).toHaveTextContent( 'Unknown' );
 	} );
 
 	it( 'should limit unnecessary selections run on children', async () => {
@@ -606,13 +608,13 @@ describe( 'withSelect', () => {
 		} ) );
 
 		const OriginalComponent = jest.fn( ( props ) => (
-			<div>{ props.value }</div>
+			<div role="status">{ props.value }</div>
 		) );
 
 		const DataBoundComponent =
 			withSelect( mapSelectToProps )( OriginalComponent );
 
-		const { container, rerender } = render(
+		const { rerender } = render(
 			<RegistryProvider value={ firstRegistry }>
 				<DataBoundComponent />
 			</RegistryProvider>
@@ -624,7 +626,7 @@ describe( 'withSelect', () => {
 		expect( mapSelectToProps ).toHaveBeenCalledTimes( 2 );
 		expect( OriginalComponent ).toHaveBeenCalledTimes( 1 );
 
-		expect( container ).toHaveTextContent( 'first' );
+		expect( screen.getByRole( 'status' ) ).toHaveTextContent( 'first' );
 
 		const secondRegistry = createRegistry();
 		secondRegistry.registerStore( 'demo', {
@@ -647,6 +649,6 @@ describe( 'withSelect', () => {
 		// - 1 on effect before new subscription set (because registry has changed)
 		expect( mapSelectToProps ).toHaveBeenCalledTimes( 4 );
 		expect( OriginalComponent ).toHaveBeenCalledTimes( 2 );
-		expect( container ).toHaveTextContent( 'second' );
+		expect( screen.getByRole( 'status' ) ).toHaveTextContent( 'second' );
 	} );
 } );

--- a/packages/data/src/components/with-select/test/index.js
+++ b/packages/data/src/components/with-select/test/index.js
@@ -312,7 +312,7 @@ describe( 'withSelect', () => {
 		expect( OriginalComponent ).toHaveBeenCalledTimes( 1 );
 	} );
 
-	it( 'should not rerender if state has changed but merge props the same', () => {
+	it( 'should not rerender if state has changed but merge props the same', async () => {
 		const registry = createRegistry();
 		registry.registerStore( 'demo', {
 			reducer: () => ( {} ),
@@ -345,7 +345,7 @@ describe( 'withSelect', () => {
 		expect( mapSelectToProps ).toHaveBeenCalledTimes( 2 );
 		expect( OriginalComponent ).toHaveBeenCalledTimes( 1 );
 
-		registry.dispatch( 'demo' ).update();
+		await act( async () => registry.dispatch( 'demo' ).update() );
 
 		expect( mapSelectToProps ).toHaveBeenCalledTimes( 3 );
 		expect( OriginalComponent ).toHaveBeenCalledTimes( 1 );
@@ -389,7 +389,7 @@ describe( 'withSelect', () => {
 		expect( OriginalComponent ).toHaveBeenCalledTimes( 2 );
 	} );
 
-	it( 'should not rerun selection on unchanging state', () => {
+	it( 'should not rerun selection on unchanging state', async () => {
 		const registry = createRegistry();
 		const store = registry.registerStore( 'unchanging', {
 			reducer: ( state = {} ) => state,
@@ -417,7 +417,7 @@ describe( 'withSelect', () => {
 		expect( mapSelectToProps ).toHaveBeenCalledTimes( 2 );
 		expect( OriginalComponent ).toHaveBeenCalledTimes( 1 );
 
-		store.dispatch( { type: 'dummy' } );
+		await act( async () => store.dispatch( { type: 'dummy' } ) );
 
 		expect( mapSelectToProps ).toHaveBeenCalledTimes( 2 );
 		expect( OriginalComponent ).toHaveBeenCalledTimes( 1 );
@@ -538,7 +538,7 @@ describe( 'withSelect', () => {
 		expect( container ).toHaveTextContent( 'Unknown' );
 	} );
 
-	it( 'should limit unnecessary selections run on children', () => {
+	it( 'should limit unnecessary selections run on children', async () => {
 		const registry = createRegistry();
 		registry.registerStore( 'childRender', {
 			reducer: ( state = true, action ) =>
@@ -582,7 +582,7 @@ describe( 'withSelect', () => {
 		expect( ChildOriginalComponent ).toHaveBeenCalledTimes( 1 );
 		expect( ParentOriginalComponent ).toHaveBeenCalledTimes( 1 );
 
-		act( () => {
+		await act( async () => {
 			registry.dispatch( 'childRender' ).toggleRender();
 		} );
 

--- a/packages/data/src/components/with-select/test/index.js
+++ b/packages/data/src/components/with-select/test/index.js
@@ -21,12 +21,8 @@ import { RegistryProvider } from '../../registry-provider';
 jest.useRealTimers();
 
 describe( 'withSelect', () => {
-	let registry;
-	beforeEach( () => {
-		registry = createRegistry();
-	} );
-
 	it( 'passes the relevant data to the component', () => {
+		const registry = createRegistry();
 		registry.registerStore( 'reactReducer', {
 			reducer: () => ( { reactKey: 'reactState' } ),
 			selectors: {
@@ -70,6 +66,7 @@ describe( 'withSelect', () => {
 
 	it( 'should rerun selection on state changes', async () => {
 		const user = userEvent.setup();
+		const registry = createRegistry();
 		registry.registerStore( 'counter', {
 			reducer: ( state = 0, action ) => {
 				if ( action.type === 'increment' ) {
@@ -225,6 +222,7 @@ describe( 'withSelect', () => {
 	} );
 
 	it( 'should rerun selection on props changes', () => {
+		const registry = createRegistry();
 		registry.registerStore( 'counter', {
 			reducer: ( state = 0, action ) => {
 				if ( action.type === 'increment' ) {
@@ -273,6 +271,7 @@ describe( 'withSelect', () => {
 	} );
 
 	it( 'should not run selection if props have not changed', () => {
+		const registry = createRegistry();
 		registry.registerStore( 'unchanging', {
 			reducer: ( state = {} ) => state,
 			selectors: {
@@ -314,6 +313,7 @@ describe( 'withSelect', () => {
 	} );
 
 	it( 'should not rerender if state has changed but merge props the same', () => {
+		const registry = createRegistry();
 		registry.registerStore( 'demo', {
 			reducer: () => ( {} ),
 			selectors: {
@@ -352,6 +352,7 @@ describe( 'withSelect', () => {
 	} );
 
 	it( 'should render if props have changed but not state', () => {
+		const registry = createRegistry();
 		registry.registerStore( 'unchanging', {
 			reducer: ( state = {} ) => state,
 			selectors: {
@@ -389,6 +390,7 @@ describe( 'withSelect', () => {
 	} );
 
 	it( 'should not rerun selection on unchanging state', () => {
+		const registry = createRegistry();
 		const store = registry.registerStore( 'unchanging', {
 			reducer: ( state = {} ) => state,
 			selectors: {
@@ -422,6 +424,7 @@ describe( 'withSelect', () => {
 	} );
 
 	it( 'omits props which are not returned on subsequent mappings', () => {
+		const registry = createRegistry();
 		registry.registerStore( 'demo', {
 			reducer: ( state = 'OK' ) => state,
 			selectors: {
@@ -478,6 +481,7 @@ describe( 'withSelect', () => {
 	} );
 
 	it( 'allows undefined return from mapSelectToProps', () => {
+		const registry = createRegistry();
 		registry.registerStore( 'demo', {
 			reducer: ( state = 'OK' ) => state,
 			selectors: {
@@ -535,6 +539,7 @@ describe( 'withSelect', () => {
 	} );
 
 	it( 'should limit unnecessary selections run on children', () => {
+		const registry = createRegistry();
 		registry.registerStore( 'childRender', {
 			reducer: ( state = true, action ) =>
 				action.type === 'TOGGLE_RENDER' ? ! state : state,


### PR DESCRIPTION
## What?
PR of #44780.

PR refactors `withSelect` hook tests to use `@testing-library/react` instead of `react-test-renderer`.

## Why?
It is a part of recent efforts to use `@testing-library/react` as the project's primary testing library.

## How?
Updates the `render` method to use RTL, improves assertions and uses `userEvent` for user actions.

**Additional changes:**
* [Use self-container registry creation for each test](https://github.com/WordPress/gutenberg/commit/2a7dbb675fb2658055c2c3a5f8bdd1b1533c60f8)
* [Wrap all action dispatchers in 'act' for consistency](https://github.com/WordPress/gutenberg/commit/2639bf4613c411f1e33d81e283bcfd865c0412a2)

## Testing Instructions
```
npm run test:unit packages/data/src/components/with-select/test/index.js
```
