### PR TITLE
ESLint: Fix `testing-library/prefer-presence-queries` violations

### DIFF
--- a/packages/viewport/src/test/if-viewport-matches.js
+++ b/packages/viewport/src/test/if-viewport-matches.js
@@ -40,6 +40,6 @@ describe( 'ifViewportMatches()', () => {
 
 		expect( useViewportMatch ).toHaveBeenCalledWith( 'wide', '>=' );
 
-		expect( screen.queryByText( 'Hello' ) ).toBeInTheDocument();
+		expect( screen.getByText( 'Hello' ) ).toBeInTheDocument();
 	} );
 } );


### PR DESCRIPTION
## What?
This PR fixes all violations of the [`testing-library/prefer-presence-queries` rule](https://github.com/testing-library/eslint-plugin-testing-library/blob/main/docs/rules/prefer-presence-queries.md), in preparation for enabling `eslint-plugin-testing-library` globally for the project.

See the [plugin README](https://github.com/testing-library/eslint-plugin-testing-library) for more info on the `testing-library` ESLint plugin.

## Why?
We've been improving our tests a lot recently with the migration to `@testing-library`. One way we could improve them is to better standardize them and follow best practices whenever we can, and one of the best ways to get there is to follow the recommended ESLint rules of the libraries and utilities we use under the hood.

## How?
We're essentially fixing up a single instance where we've been using a `query*` screen query when we should really be using `get` queries because it's about an element that exists.

## Testing Instructions
Verify all checks are green.

cc @brookewp as we've been discussing working to address some of those violations together.