### PR TITLE
ESLint: Fix `testing-library/prefer-find-by` violations

### DIFF
--- a/packages/data/src/components/use-select/test/suspense.js
+++ b/packages/data/src/components/use-select/test/suspense.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { render, waitFor } from '@testing-library/react';
+import { render } from '@testing-library/react';
 
 /**
  * WordPress dependencies
@@ -110,7 +110,7 @@ describe( 'useSuspenseSelect', () => {
 		);
 
 		const rendered = render( <App /> );
-		await waitFor( () => rendered.getByLabelText( 'loaded' ) );
+		await rendered.findByLabelText( 'loaded' );
 
 		// Verify there were 3 attempts to render. Suspended twice because of
 		// `getToken` and `getData` selectors not being resolved, and then finally
@@ -157,7 +157,7 @@ describe( 'useSuspenseSelect', () => {
 		);
 
 		const rendered = render( <App /> );
-		const label = await waitFor( () => rendered.getByLabelText( 'error' ) );
+		const label = await rendered.findByLabelText( 'error' );
 		expect( label ).toHaveTextContent( 'resolution failed' );
 		expect( console ).toHaveErrored();
 	} );


### PR DESCRIPTION
## What?
This PR fixes all violations of the [`testing-library/prefer-find-by` rule](https://github.com/testing-library/eslint-plugin-testing-library/blob/main/docs/rules/prefer-find-by.md), in preparation for enabling `eslint-plugin-testing-library` globally for the project.

See the [plugin README](https://github.com/testing-library/eslint-plugin-testing-library) for more info on the `testing-library` ESLint plugin.

## Why?
We've been improving our tests a lot recently with the migration to `@testing-library`. One way we could improve them is to better standardize them and follow best practices whenever we can, and one of the best ways to get there is to follow the recommended ESLint rules of the libraries and utilities we use under the hood.

## How?
We're essentially fixing up a few instances that were using `waitFor()` in combination with `get*` queries, when we could really use async `find*` queries.

## Testing Instructions
Verify all checks are green.

cc @brookewp as we've been discussing working to address some of those violations together.