### PR TITLE
Classic themes: Only load classic theme button styles for themes that don't use theme.json

### DIFF
--- a/lib/compat/wordpress-6.1/script-loader.php
+++ b/lib/compat/wordpress-6.1/script-loader.php
@@ -86,7 +86,7 @@ add_action( 'wp_footer', 'gutenberg_enqueue_global_styles', 1 );
  * This is needed for backwards compatibility for button blocks specifically.
  */
 function gutenberg_enqueue_classic_theme_styles() {
-	if ( ! wp_is_block_theme() ) {
+	if ( ! WP_Theme_JSON_Resolver::theme_has_support() ) {
 		wp_register_style( 'classic-theme-styles', gutenberg_url( 'build/block-library/classic.css' ), array(), true );
 		wp_enqueue_style( 'classic-theme-styles' );
 	}
@@ -104,7 +104,7 @@ add_action( 'wp_enqueue_scripts', 'gutenberg_enqueue_classic_theme_styles' );
  * @return array A filtered array of editor settings.
  */
 function gutenberg_add_editor_classic_theme_styles( $editor_settings ) {
-	if ( wp_is_block_theme() ) {
+	if ( WP_Theme_JSON_Resolver::theme_has_support() ) {
 		return $editor_settings;
 	}
 

--- a/lib/compat/wordpress-6.1/script-loader.php
+++ b/lib/compat/wordpress-6.1/script-loader.php
@@ -113,12 +113,14 @@ function gutenberg_add_editor_classic_theme_styles( $editor_settings ) {
 	// This follows the pattern of get_block_editor_theme_styles,
 	// but we can't use get_block_editor_theme_styles directly as it
 	// only handles external files or theme files.
-	$editor_settings['styles'][] = array(
+	$classic_theme_styles_settings = array(
 		'css'            => file_get_contents( $classic_theme_styles ),
-		'baseURL'        => get_theme_file_uri( $classic_theme_styles ),
-		'__unstableType' => 'theme',
+		'__unstableType' => 'core',
 		'isGlobalStyles' => false,
 	);
+
+	// Add these settings to the start of the array so that themes can override them.
+	array_unshift( $editor_settings['styles'], $classic_theme_styles_settings );
 
 	return $editor_settings;
 }


### PR DESCRIPTION
In https://github.com/WordPress/gutenberg/pull/44334 we added fallback styles for buttons to classic themes. This approach won't work for classic themes that use theme.json - the fallback styles should not be for _all_ classic themes, only for those that don't opt in to theme.json.

This changes the conditions when we load this classic theme fallback - now it only loads on themes that don't have theme.json support.

Testing instructions:
- Switch to Twenty Ten
- Add some button blocks
- Add a theme.json file that looks like this:
```
{
	"version": 2,
    "settings": {
        "layout": {
           "contentSize": "720px",
           "wideSize": "960px"
       }
   },
	"styles": {
		"elements": {
			"button": {
				"color": {
					"background": "yellow",
					"text": "white"
				},
				"border": {
					"color": "white",
					"radius": "70px",
					"style": "solid",
					"width": "4px"
				},
				"typography": {
					"fontWeight": "700"
				}
			}
		},
		"color": {
			"background": "yellow",
			"text": "white"
		}
	}
}
```
- Confirm that the button background is still black on trunk in the editor:
<img width="815" alt="Screenshot 2022-10-18 at 10 35 21" src="https://user-images.githubusercontent.com/275961/196394312-fd66db7e-907b-410e-9d73-bd2e637d6cf4.png">
- Now switch to this branch and confirm that in the editor the buttons have a yellow background:
<img width="801" alt="Screenshot 2022-10-18 at 10 33 02" src="https://user-images.githubusercontent.com/275961/196394417-e5284863-a25f-466a-bb30-ddf23949b747.png">

cc @WordPress/block-themers 