### PR TITLE
ESLint: Fix `testing-library/no-wait-for-side-effects` violations

### DIFF
--- a/packages/components/src/tools-panel/test/index.js
+++ b/packages/components/src/tools-panel/test/index.js
@@ -295,7 +295,7 @@ describe( 'ToolsPanel', () => {
 			expect( control ).toBeInTheDocument();
 
 			// Test the aria live announcement.
-			const announcement = await screen.getByText( 'Alt is now visible' );
+			const announcement = screen.getByText( 'Alt is now visible' );
 			expect( announcement ).toHaveAttribute( 'aria-live', 'assertive' );
 		} );
 
@@ -308,7 +308,7 @@ describe( 'ToolsPanel', () => {
 			expect( control ).not.toBeInTheDocument();
 
 			// Test the aria live announcement.
-			const announcement = await screen.getByText(
+			const announcement = screen.getByText(
 				'Example hidden and reset to default'
 			);
 			expect( announcement ).toHaveAttribute( 'aria-live', 'assertive' );
@@ -337,9 +337,7 @@ describe( 'ToolsPanel', () => {
 			expect( resetControl ).toBeInTheDocument();
 
 			// Test the aria live announcement.
-			const announcement = await screen.getByText(
-				'Example reset to default'
-			);
+			const announcement = screen.getByText( 'Example reset to default' );
 			expect( announcement ).toHaveAttribute( 'aria-live', 'assertive' );
 		} );
 
@@ -1057,7 +1055,7 @@ describe( 'ToolsPanel', () => {
 			await selectMenuItem( 'Reset all' );
 
 			// Test the aria live announcement.
-			const announcement = await screen.getByText( 'All options reset' );
+			const announcement = screen.getByText( 'All options reset' );
 			expect( announcement ).toHaveAttribute( 'aria-live', 'assertive' );
 
 			const disabledResetAllItem = await screen.findByRole( 'menuitem', {


### PR DESCRIPTION
## What?
This PR fixes all violations of the [`testing-library/no-wait-for-side-effects` rule](https://github.com/testing-library/eslint-plugin-testing-library/blob/main/docs/rules/no-wait-for-side-effects.md), in preparation for enabling `eslint-plugin-testing-library` globally for the project.

See the [plugin README](https://github.com/testing-library/eslint-plugin-testing-library) for more info on the `testing-library` ESLint plugin.

## Why?
We've been improving our tests a lot recently with the migration to `@testing-library`. One way we could improve them is to better standardize them and follow best practices whenever we can, and one of the best ways to get there is to follow the recommended ESLint rules of the libraries and utilities we use under the hood.

## How?
We're essentially fixing up a few instances where we've been `await`-ing for synchronous calls.

## Testing Instructions
Verify all checks are green.

cc @brookewp as we've been discussing working to address some of those violations together.