### PR TITLE
Edit Post: Refactor listener hook tests to RTL

### DIFF
--- a/packages/edit-post/src/components/editor-initialization/test/listener-hooks.js
+++ b/packages/edit-post/src/components/editor-initialization/test/listener-hooks.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import TestRenderer, { act } from 'react-test-renderer';
+import { render, act } from '@testing-library/react';
 
 /**
  * WordPress dependencies
@@ -62,11 +62,6 @@ describe( 'listener hook tests', () => {
 		},
 	};
 
-	let registry;
-	beforeEach( () => {
-		registry = createRegistry( mockStores );
-	} );
-
 	const setMockReturnValue = ( store, functionName, value ) => {
 		mockStores[ store ].selectors[ functionName ].mockReturnValue( value );
 	};
@@ -74,20 +69,7 @@ describe( 'listener hook tests', () => {
 		mockStores[ store ].selectors[ functionName ];
 	const getSpyedAction = ( store, actionName ) =>
 		mockStores[ store ].actions[ actionName ];
-	const renderComponent = ( testedHook, id, renderer = null ) => {
-		const TestComponent = ( { postId } ) => {
-			testedHook( postId );
-			return null;
-		};
-		const TestedOutput = (
-			<RegistryProvider value={ registry }>
-				<TestComponent postId={ id } />
-			</RegistryProvider>
-		);
-		return renderer === null
-			? TestRenderer.create( TestedOutput )
-			: renderer.update( TestedOutput );
-	};
+
 	afterEach( () => {
 		Object.values( mockStores ).forEach( ( storeMocks ) => {
 			Object.values( storeMocks.selectors ).forEach( ( mock ) => {
@@ -99,17 +81,29 @@ describe( 'listener hook tests', () => {
 		} );
 	} );
 	describe( 'useBlockSelectionListener', () => {
+		const registry = createRegistry( mockStores );
+		const TestComponent = ( { postId } ) => {
+			useBlockSelectionListener( postId );
+			return null;
+		};
+		const TestedOutput = () => {
+			return (
+				<RegistryProvider value={ registry }>
+					<TestComponent postId={ 10 } />
+				</RegistryProvider>
+			);
+		};
+
 		it( 'does nothing when editor sidebar is not open', () => {
 			setMockReturnValue( STORE_NAME, 'isEditorSidebarOpened', false );
-			act( () => {
-				renderComponent( useBlockSelectionListener, 10 );
-			} );
+			render( <TestedOutput /> );
+
 			expect(
 				getSpyedFunction( STORE_NAME, 'isEditorSidebarOpened' )
 			).toHaveBeenCalled();
 			expect(
 				getSpyedAction( STORE_NAME, 'openGeneralSidebar' )
-			).toHaveBeenCalledTimes( 0 );
+			).not.toHaveBeenCalled();
 		} );
 		it( 'opens block sidebar if block is selected', () => {
 			setMockReturnValue( STORE_NAME, 'isEditorSidebarOpened', true );
@@ -118,9 +112,9 @@ describe( 'listener hook tests', () => {
 				'getBlockSelectionStart',
 				true
 			);
-			act( () => {
-				renderComponent( useBlockSelectionListener, 10 );
-			} );
+
+			render( <TestedOutput /> );
+
 			expect(
 				getSpyedAction( STORE_NAME, 'openGeneralSidebar' )
 			).toHaveBeenCalledWith( 'edit-post/block' );
@@ -132,9 +126,9 @@ describe( 'listener hook tests', () => {
 				'getBlockSelectionStart',
 				false
 			);
-			act( () => {
-				renderComponent( useBlockSelectionListener, 10 );
-			} );
+
+			render( <TestedOutput /> );
+
 			expect(
 				getSpyedAction( STORE_NAME, 'openGeneralSidebar' )
 			).toHaveBeenCalledWith( 'edit-post/document' );
@@ -142,6 +136,19 @@ describe( 'listener hook tests', () => {
 	} );
 
 	describe( 'useUpdatePostLinkListener', () => {
+		const registry = createRegistry( mockStores );
+		const TestComponent = ( { postId } ) => {
+			useUpdatePostLinkListener( postId );
+			return null;
+		};
+		const TestedOutput = ( { postId = 10 } ) => {
+			return (
+				<RegistryProvider value={ registry }>
+					<TestComponent postId={ postId } />
+				</RegistryProvider>
+			);
+		};
+
 		const setAttribute = jest.fn();
 		const mockSelector = jest.fn();
 		beforeEach( () => {
@@ -158,29 +165,24 @@ describe( 'listener hook tests', () => {
 			setMockReturnValue( 'core/editor', 'getCurrentPost', {
 				link: 'foo',
 			} );
-			act( () => {
-				renderComponent( useUpdatePostLinkListener, 10 );
-			} );
+			render( <TestedOutput /> );
+
 			expect( setAttribute ).not.toHaveBeenCalled();
 		} );
 		it( 'updates nothing if there is no permalink', () => {
 			setMockReturnValue( 'core/editor', 'getCurrentPost', { link: '' } );
-			act( () => {
-				renderComponent( useUpdatePostLinkListener, 10 );
-			} );
+			render( <TestedOutput /> );
+
 			expect( setAttribute ).not.toHaveBeenCalled();
 		} );
 		it( 'only calls document query selector once across renders', () => {
 			setMockReturnValue( 'core/editor', 'getCurrentPost', {
 				link: 'foo',
 			} );
-			act( () => {
-				const renderer = renderComponent(
-					useUpdatePostLinkListener,
-					10
-				);
-				renderComponent( useUpdatePostLinkListener, 20, renderer );
-			} );
+			const { rerender } = render( <TestedOutput /> );
+
+			rerender( <TestedOutput id={ 20 } /> );
+
 			expect( mockSelector ).toHaveBeenCalledTimes( 1 );
 			act( () => {
 				registry.dispatch( 'core/editor' ).forceUpdate();
@@ -191,9 +193,7 @@ describe( 'listener hook tests', () => {
 			setMockReturnValue( 'core/editor', 'getCurrentPost', {
 				link: 'foo',
 			} );
-			act( () => {
-				renderComponent( useUpdatePostLinkListener, 10 );
-			} );
+			render( <TestedOutput /> );
 			expect( setAttribute ).toHaveBeenCalledTimes( 1 );
 			act( () => {
 				registry.dispatch( 'core/editor' ).forceUpdate();
@@ -204,9 +204,7 @@ describe( 'listener hook tests', () => {
 			setMockReturnValue( 'core/editor', 'getCurrentPost', {
 				link: 'foo',
 			} );
-			act( () => {
-				renderComponent( useUpdatePostLinkListener, 10 );
-			} );
+			render( <TestedOutput /> );
 			expect( setAttribute ).toHaveBeenCalledTimes( 1 );
 			expect( setAttribute ).toHaveBeenCalledWith( 'href', 'foo' );
 


### PR DESCRIPTION
## What?
Part of #44780.

This PR refactors the listener hook tests to use `@testing-library/react` instead of `react-test-renderer`

## Why?
It is a part of the recent effort to use `@testing-library/react` as the primary testing library.

## How?
We're simply rendering with RTL and updating the assertions to be better.

## Testing Instructions
```
npm run test:unit packages/edit-post/src/components/editor-initialization/test/listener-hooks.js
```