### PR TITLE
ESLint: Fix `testing-library/no-wait-for-multiple-assertions` violations

### DIFF
--- a/packages/block-editor/src/components/image-size-control/test/index.js
+++ b/packages/block-editor/src/components/image-size-control/test/index.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { render, screen, fireEvent } from '@testing-library/react';
 
 /**
  * Internal dependencies
@@ -85,7 +85,7 @@ describe( 'ImageSizeControl', () => {
 	} );
 
 	describe( 'updating dimension inputs', () => {
-		it( 'updates height and calls onChange', async () => {
+		it( 'updates height and calls onChange', () => {
 			render( <ImageSizeControl onChange={ mockOnChange } /> );
 
 			const heightInput = getHeightInput();
@@ -96,16 +96,14 @@ describe( 'ImageSizeControl', () => {
 
 			fireEvent.change( heightInput, { target: { value: '500' } } );
 
-			await waitFor( () => {
-				expect( mockOnChange ).toHaveBeenCalledTimes( 1 );
-				expect( mockOnChange ).toHaveBeenCalledWith( { height: 500 } );
-			} );
+			expect( mockOnChange ).toHaveBeenCalledTimes( 1 );
+			expect( mockOnChange ).toHaveBeenCalledWith( { height: 500 } );
 
 			expect( heightInput.value ).toBe( '500' );
 			expect( widthInput.value ).toBe( '' );
 		} );
 
-		it( 'updates width and calls onChange', async () => {
+		it( 'updates width and calls onChange', () => {
 			render( <ImageSizeControl onChange={ mockOnChange } /> );
 
 			const heightInput = getHeightInput();
@@ -115,16 +113,15 @@ describe( 'ImageSizeControl', () => {
 			expect( widthInput.value ).toBe( '' );
 
 			fireEvent.change( widthInput, { target: { value: '500' } } );
-			await waitFor( () => {
-				expect( mockOnChange ).toHaveBeenCalledTimes( 1 );
-				expect( mockOnChange ).toHaveBeenCalledWith( { width: 500 } );
-			} );
+
+			expect( mockOnChange ).toHaveBeenCalledTimes( 1 );
+			expect( mockOnChange ).toHaveBeenCalledWith( { width: 500 } );
 
 			expect( heightInput.value ).toBe( '' );
 			expect( widthInput.value ).toBe( '500' );
 		} );
 
-		it( 'updates height and calls onChange for empty value', async () => {
+		it( 'updates height and calls onChange for empty value', () => {
 			render(
 				<ImageSizeControl
 					imageHeight="100"
@@ -141,20 +138,19 @@ describe( 'ImageSizeControl', () => {
 
 			fireEvent.change( heightInput, { target: { value: '' } } );
 
-			await waitFor( () => {
-				// onChange is called and sets the dimension to undefined rather than
-				// the empty string.
-				expect( mockOnChange ).toHaveBeenCalledTimes( 1 );
-				expect( mockOnChange ).toHaveBeenCalledWith( {
-					height: undefined,
-				} );
+			// onChange is called and sets the dimension to undefined rather than
+			// the empty string.
+			expect( mockOnChange ).toHaveBeenCalledTimes( 1 );
+			expect( mockOnChange ).toHaveBeenCalledWith( {
+				height: undefined,
 			} );
+
 			// Height is updated to empty value and does not reset to default.
 			expect( heightInput.value ).toBe( '' );
 			expect( widthInput.value ).toBe( '100' );
 		} );
 
-		it( 'updates width and calls onChange for empty value', async () => {
+		it( 'updates width and calls onChange for empty value', () => {
 			render(
 				<ImageSizeControl
 					imageHeight="100"
@@ -171,14 +167,13 @@ describe( 'ImageSizeControl', () => {
 
 			fireEvent.change( widthInput, { target: { value: '' } } );
 
-			await waitFor( () => {
-				// onChange is called and sets the dimension to undefined rather than
-				// the empty string.
-				expect( mockOnChange ).toHaveBeenCalledTimes( 1 );
-				expect( mockOnChange ).toHaveBeenCalledWith( {
-					width: undefined,
-				} );
+			// onChange is called and sets the dimension to undefined rather than
+			// the empty string.
+			expect( mockOnChange ).toHaveBeenCalledTimes( 1 );
+			expect( mockOnChange ).toHaveBeenCalledWith( {
+				width: undefined,
 			} );
+
 			// Width is updated to empty value and does not reset to default.
 			expect( heightInput.value ).toBe( '100' );
 			expect( widthInput.value ).toBe( '' );
@@ -186,7 +181,7 @@ describe( 'ImageSizeControl', () => {
 	} );
 
 	describe( 'reset button', () => {
-		it( 'resets both height and width to default values', async () => {
+		it( 'resets both height and width to default values', () => {
 			render(
 				<ImageSizeControl
 					imageHeight="100"
@@ -206,22 +201,20 @@ describe( 'ImageSizeControl', () => {
 
 			fireEvent.click( screen.getByText( 'Reset' ) );
 
-			await waitFor( () => {
-				// Both attributes are set to undefined to clear custom values.
-				expect( mockOnChange ).toHaveBeenCalledWith( {
-					height: undefined,
-					width: undefined,
-				} );
-
-				// The inputs display the default values once more.
-				expect( heightInput.value ).toBe( '100' );
-				expect( widthInput.value ).toBe( '200' );
+			// Both attributes are set to undefined to clear custom values.
+			expect( mockOnChange ).toHaveBeenCalledWith( {
+				height: undefined,
+				width: undefined,
 			} );
+
+			// The inputs display the default values once more.
+			expect( heightInput.value ).toBe( '100' );
+			expect( widthInput.value ).toBe( '200' );
 		} );
 	} );
 
 	describe( 'image size percentage presets', () => {
-		it( 'updates height and width attributes on selection', async () => {
+		it( 'updates height and width attributes on selection', () => {
 			render(
 				<ImageSizeControl
 					imageHeight="100"
@@ -232,18 +225,16 @@ describe( 'ImageSizeControl', () => {
 
 			fireEvent.click( screen.getByText( '50%' ) );
 
-			await waitFor( () => {
-				expect( screen.getByText( '50%' ) ).toHaveClass( 'is-pressed' );
+			expect( screen.getByText( '50%' ) ).toHaveClass( 'is-pressed' );
 
-				// Both attributes are set to the rounded scaled value.
-				expect( mockOnChange ).toHaveBeenCalledWith( {
-					height: 50,
-					width: 101,
-				} );
+			// Both attributes are set to the rounded scaled value.
+			expect( mockOnChange ).toHaveBeenCalledWith( {
+				height: 50,
+				width: 101,
 			} );
 		} );
 
-		it( 'updates height and width inputs on selection', async () => {
+		it( 'updates height and width inputs on selection', () => {
 			render(
 				<ImageSizeControl
 					imageHeight="100"
@@ -254,11 +245,9 @@ describe( 'ImageSizeControl', () => {
 
 			fireEvent.click( screen.getByText( '50%' ) );
 
-			await waitFor( () => {
-				// Both attributes are set to the rounded scaled value.
-				expect( getHeightInput().value ).toBe( '50' );
-				expect( getWidthInput().value ).toBe( '101' );
-			} );
+			// Both attributes are set to the rounded scaled value.
+			expect( getHeightInput().value ).toBe( '50' );
+			expect( getWidthInput().value ).toBe( '101' );
 		} );
 	} );
 
@@ -284,7 +273,7 @@ describe( 'ImageSizeControl', () => {
 			);
 		} );
 
-		it( 'calls onChangeImage with selected slug on selection', async () => {
+		it( 'calls onChangeImage with selected slug on selection', () => {
 			render(
 				<ImageSizeControl
 					imageSizeOptions={ IMAGE_SIZE_OPTIONS }
@@ -298,13 +287,11 @@ describe( 'ImageSizeControl', () => {
 				target: { value: 'thumbnail' },
 			} );
 
-			await waitFor( () => {
-				// onChangeImage is called with the slug and the event.
-				expect( mockOnChangeImage ).toHaveBeenCalledWith(
-					'thumbnail',
-					expect.any( Object )
-				);
-			} );
+			// onChangeImage is called with the slug and the event.
+			expect( mockOnChangeImage ).toHaveBeenCalledWith(
+				'thumbnail',
+				expect.any( Object )
+			);
 		} );
 	} );
 } );

--- a/packages/components/src/number-control/test/index.js
+++ b/packages/components/src/number-control/test/index.js
@@ -90,9 +90,10 @@ describe( 'NumberControl', () => {
 			// After the blur, the `onChange` callback fires asynchronously.
 			await waitFor( () => {
 				expect( spy ).toHaveBeenCalledTimes( 2 );
-				expect( spy ).toHaveBeenNthCalledWith( 1, '1' );
-				expect( spy ).toHaveBeenNthCalledWith( 2, 4 );
 			} );
+
+			expect( spy ).toHaveBeenNthCalledWith( 1, '1' );
+			expect( spy ).toHaveBeenNthCalledWith( 2, 4 );
 		} );
 
 		it( 'should call onChange callback when value is not valid', () => {


### PR DESCRIPTION
## What?
This PR fixes all violations of the [`testing-library/no-wait-for-multiple-assertions` rule](https://github.com/testing-library/eslint-plugin-testing-library/blob/main/docs/rules/no-wait-for-multiple-assertions.md), in preparation for enabling `eslint-plugin-testing-library` globally for the project.

See the [plugin README](https://github.com/testing-library/eslint-plugin-testing-library) for more info on the `testing-library` ESLint plugin.

## Why?
We've been improving our tests a lot recently with the migration to `@testing-library`. One way we could improve them is to better standardize them and follow best practices whenever we can, and one of the best ways to get there is to follow the recommended ESLint rules of the libraries and utilities we use under the hood.

## How?
We're essentially fixing up a few instances where we either unnecessarily used `waitFor()` around assertions, or had multiple assertions when only one is allowed.

## Testing Instructions
Verify all checks are green.

cc @brookewp as we've been discussing working to address some of those violations together.