### PR TITLE
ESLint: Fix `testing-library/await-async-utils` violations

### DIFF
--- a/packages/data/src/redux-store/test/index.js
+++ b/packages/data/src/redux-store/test/index.js
@@ -47,7 +47,7 @@ describe( 'controls', () => {
 
 	it( 'resolves in expected order', async () => {
 		const actions = {
-			wait: () => ( { type: 'WAIT' } ),
+			standby: () => ( { type: 'STANDBY' } ),
 			receive: ( items ) => ( { type: 'RECEIVE', items } ),
 		};
 
@@ -64,12 +64,12 @@ describe( 'controls', () => {
 			},
 			resolvers: {
 				*getItems() {
-					yield actions.wait();
+					yield actions.standby();
 					yield actions.receive( [ 1, 2, 3 ] );
 				},
 			},
 			controls: {
-				WAIT() {
+				STANDBY() {
 					return new Promise( ( resolve ) =>
 						process.nextTick( resolve )
 					);


### PR DESCRIPTION
## What?
This PR fixes all violations of the [`testing-library/await-async-utils` rule](https://github.com/testing-library/eslint-plugin-testing-library/blob/main/docs/rules/await-async-utils.md), in preparation for enabling `eslint-plugin-testing-library` globally for the project.

See the [plugin README](https://github.com/testing-library/eslint-plugin-testing-library) for more info on the `testing-library` ESLint plugin.

## Why?
We've been improving our tests a lot recently with the migration to `@testing-library`. One way we could improve them is to better standardize them and follow best practices whenever we can, and one of the best ways to get there is to follow the recommended ESLint rules of the libraries and utilities we use under the hood.

## How?
This single instance is actually a false alarm and we're fixing it by just renaming the dummy action creator.

## Testing Instructions
Verify all checks are green.

cc @brookewp as we've been discussing working to address some of those violations together.