### PR TITLE
Table Block: Apply borders and padding on both front end and editor

### DIFF
--- a/packages/block-library/src/table/editor.scss
+++ b/packages/block-library/src/table/editor.scss
@@ -31,6 +31,7 @@
 	td,
 	th {
 		border: $border-width solid;
+		padding: 0.5em;
 	}
 
 	td.is-selected,

--- a/packages/block-library/src/table/style.scss
+++ b/packages/block-library/src/table/style.scss
@@ -15,6 +15,7 @@
 	td,
 	th {
 		border: $border-width solid;
+		padding: 0.5em;
 	}
 
 	// Fixed layout toggle

--- a/packages/block-library/src/table/style.scss
+++ b/packages/block-library/src/table/style.scss
@@ -11,6 +11,12 @@
 		width: 100%;
 	}
 
+	// Match default border style to default style in editor
+	td,
+	th {
+		border: $border-width solid;
+	}
+
 	// Fixed layout toggle
 	.has-fixed-layout {
 		table-layout: fixed;

--- a/packages/block-library/src/table/theme.scss
+++ b/packages/block-library/src/table/theme.scss
@@ -11,8 +11,6 @@
 
 	td,
 	th {
-		padding: 0.5em;
-		border: 1px solid;
 		word-break: normal;
 	}
 


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->
This PR applies a default border to the front end of the Table Block, the same as the border style used in the editor. It also applies a default padding of `0.5em` to the table cells, on both the front end and the editor.

Before:

| Editor | Front end |
| ----- | ---------- |
| <img width="1024" alt="image" src="https://user-images.githubusercontent.com/1645628/196415474-ba609e91-98b7-4df3-b62d-4679c1c1142b.png"> | <img width="1226" alt="image" src="https://user-images.githubusercontent.com/1645628/196415411-403f58db-7b29-4859-a598-8a02a0a327dd.png"> |

After:

| Editor | Front end |
| ----- | ---------- |
| <img width="1040" alt="image" src="https://user-images.githubusercontent.com/1645628/196479854-b45e0794-6bc5-41d1-ab59-a38e5dac0d60.png"> | <img width="1232" alt="image" src="https://user-images.githubusercontent.com/1645628/196479958-2b186469-5c79-4cec-a01e-97dd1fdc19fc.png"> |


## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
Fixes https://github.com/WordPress/gutenberg/issues/45065.

This makes the styles for the Table block consistent between the front end and the editor. The border styles can still be overwritten using the block settings in the editor.

I personally like showing the table border by default, as it makes it clear where the table cells are, and the user can choose to change or remove the border using the block settings. However, I'm not sure what the original reasoning was behind styling the table block this way, and if there perhaps needs to be more thought put into the default styles themselves.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
Uses the same line of CSS from the `editor.scss` file in the `style.scss` file for the table block.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->

1. Go to a post/page
2. Insert a Table block
3. With this PR applied, see that there are borders applied to the table on both the front end and the editor
4. Change the table block border styles using the post editor
5. Ensure the custom border styles are applied both in the editor and on the front end
