### PR TITLE
Navigation block e2e tests: default to a list of pages if there are no menus

### DIFF
--- a/test/e2e/playwright.config.ts
+++ b/test/e2e/playwright.config.ts
@@ -44,6 +44,9 @@ const config: PlaywrightTestConfig = {
 		trace: 'retain-on-failure',
 		screenshot: 'only-on-failure',
 		video: 'on-first-retry',
+		launchOptions: {
+			slowMo: 1000,
+		},
 	},
 	webServer: {
 		command: 'npm run wp-env start',

--- a/test/e2e/playwright.config.ts
+++ b/test/e2e/playwright.config.ts
@@ -44,9 +44,6 @@ const config: PlaywrightTestConfig = {
 		trace: 'retain-on-failure',
 		screenshot: 'only-on-failure',
 		video: 'on-first-retry',
-		launchOptions: {
-			slowMo: 1000,
-		},
 	},
 	webServer: {
 		command: 'npm run wp-env start',

--- a/test/e2e/specs/editor/blocks/navigation.spec.js
+++ b/test/e2e/specs/editor/blocks/navigation.spec.js
@@ -41,9 +41,5 @@ test.describe(
 <!-- /wp:navigation -->`
 			);
 		} );
-
-		test( 'default to my only existing menu', async () => {} );
-		test( 'default to my most recently created menu', async () => {} );
-		test( 'default to the only existing classic menu if there are no block menus', async () => {} );
 	}
 );

--- a/test/e2e/specs/editor/blocks/navigation.spec.js
+++ b/test/e2e/specs/editor/blocks/navigation.spec.js
@@ -1,0 +1,35 @@
+/**
+ * WordPress dependencies
+ */
+const { test, expect } = require( '@wordpress/e2e-test-utils-playwright' );
+
+test.describe(
+	'As a user I want the navigation block to fallback to the best possible default',
+	() => {
+		test.beforeEach( async ( { admin } ) => {
+			await admin.createNewPost();
+		} );
+
+		test( 'default to a list of pages if there are no menus', async ( {
+			editor,
+		} ) => {
+			await editor.insertBlock( { name: 'core/navigation' } );
+			// TODO:
+			// Check the list view.
+
+			await editor.publishPost();
+
+			// Check the content.
+			const content = await editor.getEditedPostContent();
+			expect( content ).toBe(
+				`<!-- wp:navigation -->
+<!-- wp:page-list /-->
+<!-- /wp:navigation -->`
+			);
+		} );
+
+		test( 'default to my only existing menu', async () => {} );
+		test( 'default to my most recently created menu', async () => {} );
+		test( 'default to the only existing classic menu if there are no block menus', async () => {} );
+	}
+);

--- a/test/e2e/specs/editor/blocks/navigation.spec.js
+++ b/test/e2e/specs/editor/blocks/navigation.spec.js
@@ -14,12 +14,26 @@ test.describe(
 			editor,
 		} ) => {
 			await editor.insertBlock( { name: 'core/navigation' } );
-			// TODO:
-			// Check the list view.
 
+			// Check Page List is in the list view.
+
+			// Open the list view.
+			await editor.page.locator( '[aria-label="List View"i]' ).click();
+			// Click the Navigation block expander, we need to use force because it has aria-hidden set to true.
+			await editor.page
+				.locator(
+					`//a[.//span[text()='Navigation']]/span[contains(@class, 'block-editor-list-view__expander')]`
+				)
+				.click( { force: true } );
+			// Find the Page list selector inside the navigation block.
+			const pageListSelector = await editor.page.locator(
+				`//table[contains(@aria-label,'Block navigation structure')]//a[.//span[text()='Page List']]`
+			);
+
+			expect( pageListSelector ).toBeTruthy();
+
+			// Check the markup of the block is correct.
 			await editor.publishPost();
-
-			// Check the content.
 			const content = await editor.getEditedPostContent();
 			expect( content ).toBe(
 				`<!-- wp:navigation -->

--- a/test/e2e/specs/editor/blocks/navigation.spec.js
+++ b/test/e2e/specs/editor/blocks/navigation.spec.js
@@ -30,7 +30,9 @@ test.describe(
 			// Check Page List is in the list view.
 
 			// Open the list view.
-			await editor.page.locator( '[aria-label="List View"i]' ).click();
+			await editor.page
+				.locator( '[aria-label="Document Overview"i]' )
+				.click();
 			// Click the Navigation block expander, we need to use force because it has aria-hidden set to true.
 			await editor.page
 				.locator(

--- a/test/e2e/specs/editor/blocks/navigation.spec.js
+++ b/test/e2e/specs/editor/blocks/navigation.spec.js
@@ -33,18 +33,26 @@ test.describe(
 			// Open the list view.
 			await page.click( '[aria-label="Document Overview"i]' );
 
-			// Click the Navigation block expander, we need to use force because it has aria-hidden set to true.
-			await page.click(
-				`//a[.//span[text()='Navigation']]/span[contains(@class, 'block-editor-list-view__expander')]`,
-				{ force: true }
+			const listView = await page.locator(
+				`//table[contains(@aria-label,'Block navigation structure')]`
 			);
+
+			// Click the Navigation block expander within the List View.
+			await listView
+				.locator( `//a[.//span[text()='Navigation']]` )
+				.locator( '.block-editor-list-view__expander' )
+				.click( {
+					force: true, // required as element has aria-hidden set to true.);
+				} );
 
 			// Find the Page list selector inside the navigation block.
-			const pageListSelector = await page.locator(
-				`//table[contains(@aria-label,'Block navigation structure')]//a[.//span[text()='Page List']]`
+			const pageListSelector = await listView.locator(
+				`//a[.//span[text()='Page List']]`
 			);
 
-			expect( pageListSelector ).toBeTruthy();
+			// Todo: wait on resolution state of the block
+			// in order to proceed with assertion using `toBeVisible()`.
+			await expect( pageListSelector ).toBeTruthy();
 
 			// Check the markup of the block is correct.
 			await editor.publishPost();

--- a/test/e2e/specs/editor/blocks/navigation.spec.js
+++ b/test/e2e/specs/editor/blocks/navigation.spec.js
@@ -31,14 +31,13 @@ test.describe(
 			// Check Page List is in the list view.
 
 			// Open the list view.
-			await page.locator( '[aria-label="Document Overview"i]' ).click();
+			await page.click( '[aria-label="Document Overview"i]' );
 
 			// Click the Navigation block expander, we need to use force because it has aria-hidden set to true.
-			await page
-				.locator(
-					`//a[.//span[text()='Navigation']]/span[contains(@class, 'block-editor-list-view__expander')]`
-				)
-				.click( { force: true } );
+			await page.click(
+				`//a[.//span[text()='Navigation']]/span[contains(@class, 'block-editor-list-view__expander')]`,
+				{ force: true }
+			);
 
 			// Find the Page list selector inside the navigation block.
 			const pageListSelector = await page.locator(

--- a/test/e2e/specs/editor/blocks/navigation.spec.js
+++ b/test/e2e/specs/editor/blocks/navigation.spec.js
@@ -26,35 +26,30 @@ test.describe(
 			editor,
 			page,
 		} ) => {
+			const pagesRequest = page
+				.waitForRequest( ( response ) => {
+					return response.url().includes( 'rest_route=/wp/v2/pages' );
+				} )
+				.catch( () => {} );
+
+			const menusRequest = page
+				.waitForRequest( ( response ) => {
+					return response.url().includes( 'rest_route=/wp/v2/menus' );
+				} )
+				.catch( () => {} );
+
 			await editor.insertBlock( { name: 'core/navigation' } );
 
-			// Necessary to wait for the block to be in loaded state else
-			// initial rendered state will not be resolved.
-			await page.waitForLoadState( 'networkidle' );
+			await pagesRequest;
+			await menusRequest;
 
-			// Check Page List is in the list view.
+			//await page.waitForTimeout( 10000 );
 
-			// Open the list view.
-			await page.click( '[aria-label="Document Overview"i]' );
+			const pageListBlock = await page.getByRole( 'document', {
+				name: 'Block: Page List',
+			} );
 
-			const listView = await page.locator(
-				`//table[contains(@aria-label,'Block navigation structure')]`
-			);
-
-			// Click the Navigation block expander within the List View.
-			await listView
-				.locator( `//a[.//span[text()='Navigation']]` )
-				.locator( '.block-editor-list-view__expander' )
-				.click( {
-					force: true, // required as element has aria-hidden set to true.);
-				} );
-
-			// Find the Page list selector inside the navigation block.
-			const pageListSelector = await listView.locator(
-				`//a[.//span[text()='Page List']]`
-			);
-
-			await expect( pageListSelector ).toBeVisible();
+			await expect( pageListBlock ).toBeVisible();
 
 			// Check the markup of the block is correct.
 			await editor.publishPost();

--- a/test/e2e/specs/editor/blocks/navigation.spec.js
+++ b/test/e2e/specs/editor/blocks/navigation.spec.js
@@ -42,7 +42,10 @@ test.describe(
 			} );
 
 			await expect( pageListBlock ).toBeVisible( {
-				// Wait for the API to be loaded.
+				// Wait for the Nav and Page List block API requests to resolve.
+				// Note: avoid waiting on network requests as these are not perceivable
+				// to the user.
+				// See: https://github.com/WordPress/gutenberg/pull/45070#issuecomment-1373712007.
 				timeout: 10000,
 			} );
 

--- a/test/e2e/specs/editor/blocks/navigation.spec.js
+++ b/test/e2e/specs/editor/blocks/navigation.spec.js
@@ -24,23 +24,24 @@ test.describe(
 
 		test( 'default to a list of pages if there are no menus', async ( {
 			editor,
+			page,
 		} ) => {
 			await editor.insertBlock( { name: 'core/navigation' } );
 
 			// Check Page List is in the list view.
 
 			// Open the list view.
-			await editor.page
-				.locator( '[aria-label="Document Overview"i]' )
-				.click();
+			await page.locator( '[aria-label="Document Overview"i]' ).click();
+
 			// Click the Navigation block expander, we need to use force because it has aria-hidden set to true.
-			await editor.page
+			await page
 				.locator(
 					`//a[.//span[text()='Navigation']]/span[contains(@class, 'block-editor-list-view__expander')]`
 				)
 				.click( { force: true } );
+
 			// Find the Page list selector inside the navigation block.
-			const pageListSelector = await editor.page.locator(
+			const pageListSelector = await page.locator(
 				`//table[contains(@aria-label,'Block navigation structure')]//a[.//span[text()='Page List']]`
 			);
 

--- a/test/e2e/specs/editor/blocks/navigation.spec.js
+++ b/test/e2e/specs/editor/blocks/navigation.spec.js
@@ -6,8 +6,20 @@ const { test, expect } = require( '@wordpress/e2e-test-utils-playwright' );
 test.describe(
 	'As a user I want the navigation block to fallback to the best possible default',
 	() => {
+		test.beforeAll( async ( { requestUtils } ) => {
+			await requestUtils.activateTheme( 'emptytheme' );
+		} );
+
 		test.beforeEach( async ( { admin } ) => {
 			await admin.createNewPost();
+		} );
+
+		test.afterAll( async ( { requestUtils } ) => {
+			await requestUtils.activateTheme( 'twentytwentyone' );
+		} );
+
+		test.afterEach( async ( { requestUtils } ) => {
+			await requestUtils.deleteAllPosts();
 		} );
 
 		test( 'default to a list of pages if there are no menus', async ( {

--- a/test/e2e/specs/editor/blocks/navigation.spec.js
+++ b/test/e2e/specs/editor/blocks/navigation.spec.js
@@ -28,6 +28,10 @@ test.describe(
 		} ) => {
 			await editor.insertBlock( { name: 'core/navigation' } );
 
+			// Necessary to wait for the block to be in loaded state else
+			// initial rendered state will not be resolved.
+			await page.waitForLoadState( 'networkidle' );
+
 			// Check Page List is in the list view.
 
 			// Open the list view.
@@ -50,9 +54,7 @@ test.describe(
 				`//a[.//span[text()='Page List']]`
 			);
 
-			// Todo: wait on resolution state of the block
-			// in order to proceed with assertion using `toBeVisible()`.
-			await expect( pageListSelector ).toBeTruthy();
+			await expect( pageListSelector ).toBeVisible();
 
 			// Check the markup of the block is correct.
 			await editor.publishPost();


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

This is part of the effort to re work all the navigation block e2e tests and migration to playwright. This is one of the user stories described in #45199

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

The navigation e2e tests were really flaky and bottlenecking the github actions. We are rethinking them so they make more sense and are more usable and maintainable.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->

Run `npm run test:e2e:playwright -- editor/blocks/navigation.spec.js`

Co-authored-by: Dave Smith <444434+getdave@users.noreply.github.com>


