### PR TITLE
Components: Refactor `NoticeList` tests to RTL

### DIFF
--- a/packages/components/src/notice/test/list.js
+++ b/packages/components/src/notice/test/list.js
@@ -1,12 +1,7 @@
 /**
  * External dependencies
  */
-import ShallowRenderer from 'react-test-renderer/shallow';
-
-/**
- * WordPress dependencies
- */
-import TokenList from '@wordpress/token-list';
+import { render } from '@testing-library/react';
 
 /**
  * Internal dependencies
@@ -15,14 +10,11 @@ import NoticeList from '../list';
 
 describe( 'NoticeList', () => {
 	it( 'should merge className', () => {
-		const renderer = new ShallowRenderer();
-
-		renderer.render( <NoticeList notices={ [] } className="is-ok" /> );
-
-		const classes = new TokenList(
-			renderer.getRenderOutput().props.className
+		const { container } = render(
+			<NoticeList notices={ [] } className="is-ok" />
 		);
-		expect( classes.contains( 'is-ok' ) ).toBe( true );
-		expect( classes.contains( 'components-notice-list' ) ).toBe( true );
+
+		expect( container.firstChild ).toHaveClass( 'is-ok' );
+		expect( container.firstChild ).toHaveClass( 'components-notice-list' );
 	} );
 } );


### PR DESCRIPTION
## What?
This PR refactors the `NoticeList` tests to fully use `@testing-library/react` instead of `react-test-renderer`.

Part of #44780.

## Why?
It is a part of the recent effort to use `@testing-library/react` as the primary testing library.

## How?
We're updating rendering to now be with RTL. They're not the most useful tests, but it's not the time to make the decision I guess.

## Testing Instructions
Verify tests still pass: `npm run test:unit:watch packages/components/src/notice/test/list.js`
