### PR TITLE
Post editor: Rename view to Preview

### DIFF
--- a/packages/block-editor/src/components/preview-options/index.js
+++ b/packages/block-editor/src/components/preview-options/index.js
@@ -13,6 +13,7 @@ import { check } from '@wordpress/icons';
 
 export default function PreviewOptions( {
 	children,
+	viewLabel,
 	className,
 	isEnabled = true,
 	deviceType,
@@ -32,8 +33,7 @@ export default function PreviewOptions( {
 		variant: 'tertiary',
 		className: 'block-editor-post-preview__button-toggle',
 		disabled: ! isEnabled,
-		/* translators: button label text should, if possible, be under 16 characters. */
-		children: __( 'View' ),
+		children: viewLabel,
 	};
 	const menuProps = {
 		'aria-label': __( 'View options' ),

--- a/packages/edit-post/src/components/device-preview/index.js
+++ b/packages/edit-post/src/components/device-preview/index.js
@@ -49,6 +49,8 @@ export default function DevicePreview() {
 			className="edit-post-post-preview-dropdown"
 			deviceType={ deviceType }
 			setDeviceType={ setPreviewDeviceType }
+			/* translators: button label text should, if possible, be under 16 characters. */
+			viewLabel={ __( 'Preview' ) }
 		>
 			{ isViewable && (
 				<MenuGroup>

--- a/packages/edit-site/src/components/header-edit-mode/index.js
+++ b/packages/edit-site/src/components/header-edit-mode/index.js
@@ -217,6 +217,8 @@ export default function Header( {
 							<PreviewOptions
 								deviceType={ deviceType }
 								setDeviceType={ setPreviewDeviceType }
+								/* translators: button label text should, if possible, be under 16 characters. */
+								viewLabel={ __( 'View' ) }
 							>
 								<MenuGroup>
 									<MenuItem


### PR DESCRIPTION
## What?

Changes the "View" button to say "Preview" in the post editor.

Before:
<img width="373" alt="Screenshot 2022-10-18 at 15 33 04" src="https://user-images.githubusercontent.com/1204802/196449379-824f1768-537e-47e2-a60b-6f5728f1ccf8.png">

After:

<img width="390" alt="Screenshot 2022-10-18 at 15 33 59" src="https://user-images.githubusercontent.com/1204802/196449403-13fc6a17-fa6f-47f6-91c7-fc9d493289c7.png">

