### PR TITLE
List/quote: unwrap inner block when pressing Backspace at start

### DIFF
--- a/packages/block-editor/src/components/block-list/block.js
+++ b/packages/block-editor/src/components/block-list/block.js
@@ -354,6 +354,15 @@ const applyWithDispatch = withDispatch( ( dispatch, ownProps, registry ) => {
 				canInsertBlockType,
 			} = registry.select( blockEditorStore );
 
+			/**
+			 * Moves the block with clientId up one level. If the block type
+			 * cannot be inserted at the new location, it will be attempted to
+			 * convert to the default block type.
+			 *
+			 * @param {string}  _clientId       The block to move.
+			 * @param {boolean} changeSelection Whether to change the selection
+			 *                                  to the moved block.
+			 */
 			function moveFirstItemUp( _clientId, changeSelection = true ) {
 				const targetRootClientId = getBlockRootClientId( _clientId );
 				const blockOrder = getBlockOrder( _clientId );

--- a/packages/block-editor/src/components/block-list/block.native.js
+++ b/packages/block-editor/src/components/block-list/block.native.js
@@ -20,6 +20,8 @@ import {
 	getBlockType,
 	__experimentalGetAccessibleBlockLabel as getAccessibleBlockLabel,
 	switchToBlockType,
+	getDefaultBlockName,
+	isUnmodifiedBlock,
 } from '@wordpress/blocks';
 import { useSetting } from '@wordpress/block-editor';
 
@@ -436,7 +438,71 @@ export default compose( [
 					getBlockAttributes,
 					getBlockName,
 					getBlockOrder,
+					getBlockIndex,
+					getBlockRootClientId,
+					canInsertBlockType,
 				} = registry.select( blockEditorStore );
+
+				/**
+				 * Moves the block with clientId up one level. If the block type
+				 * cannot be inserted at the new location, it will be attempted to
+				 * convert to the default block type.
+				 *
+				 * @param {string}  _clientId       The block to move.
+				 * @param {boolean} changeSelection Whether to change the selection
+				 *                                  to the moved block.
+				 */
+				function moveFirstItemUp( _clientId, changeSelection = true ) {
+					const targetRootClientId =
+						getBlockRootClientId( _clientId );
+					const blockOrder = getBlockOrder( _clientId );
+					const [ firstClientId ] = blockOrder;
+
+					if (
+						blockOrder.length === 1 &&
+						isUnmodifiedBlock( getBlock( firstClientId ) )
+					) {
+						removeBlock( _clientId );
+					} else {
+						if (
+							canInsertBlockType(
+								getBlockName( firstClientId ),
+								targetRootClientId
+							)
+						) {
+							moveBlocksToPosition(
+								[ firstClientId ],
+								_clientId,
+								targetRootClientId,
+								getBlockIndex( _clientId )
+							);
+						} else {
+							const replacement = switchToBlockType(
+								getBlock( firstClientId ),
+								getDefaultBlockName()
+							);
+
+							if ( replacement && replacement.length ) {
+								registry.batch( () => {
+									insertBlocks(
+										replacement,
+										getBlockIndex( _clientId ),
+										targetRootClientId,
+										changeSelection
+									);
+									removeBlock( firstClientId, false );
+								} );
+							}
+						}
+
+						if (
+							! getBlockOrder( _clientId ).length &&
+							isUnmodifiedBlock( getBlock( _clientId ) )
+						) {
+							removeBlock( _clientId, false );
+						}
+					}
+				}
 
 				// For `Delete` or forward merge, we should do the exact same thing
 				// as `Backspace`, but from the other block.
@@ -488,15 +554,8 @@ export default compose( [
 						return;
 					}
 
-					// Check if it's possibile to "unwrap" the following block
-					// before trying to merge.
-					const replacement = switchToBlockType(
-						getBlock( nextBlockClientId ),
-						'*'
-					);
-
-					if ( replacement && replacement.length ) {
-						replaceBlocks( nextBlockClientId, replacement );
+					if ( getBlockOrder( nextBlockClientId ).length ) {
+						moveFirstItemUp( nextBlockClientId, false );
 					} else {
 						mergeBlocks( clientId, nextBlockClientId );
 					}
@@ -541,18 +600,7 @@ export default compose( [
 							}
 						}
 
-						// Attempt to "unwrap" the block contents when there's no
-						// preceding block to merge with.
-						const replacement = switchToBlockType(
-							getBlock( rootClientId ),
-							'*'
-						);
-						if ( replacement && replacement.length ) {
-							registry.batch( () => {
-								replaceBlocks( rootClientId, replacement );
-								selectBlock( replacement[ 0 ].clientId, 0 );
-							} );
-						}
+						moveFirstItemUp( rootClientId );
 					}
 				}
 			},

--- a/packages/block-library/src/list-item/index.js
+++ b/packages/block-library/src/list-item/index.js
@@ -10,6 +10,7 @@ import initBlock from '../utils/init-block';
 import metadata from './block.json';
 import edit from './edit';
 import save from './save';
+import transforms from './transforms';
 
 const { name } = metadata;
 
@@ -25,6 +26,7 @@ export const settings = {
 			content: attributes.content + attributesToMerge.content,
 		};
 	},
+	transforms,
 };
 
 export const init = () => initBlock( { name, metadata, settings } );

--- a/packages/block-library/src/list-item/transforms.js
+++ b/packages/block-library/src/list-item/transforms.js
@@ -1,0 +1,17 @@
+/**
+ * WordPress dependencies
+ */
+import { createBlock } from '@wordpress/blocks';
+
+const transforms = {
+	to: [
+		{
+			type: 'block',
+			blocks: [ 'core/paragraph' ],
+			transform: ( attributes ) =>
+				createBlock( 'core/paragraph', attributes ),
+		},
+	],
+};
+
+export default transforms;

--- a/packages/block-library/src/list/test/edit.native.js
+++ b/packages/block-library/src/list/test/edit.native.js
@@ -361,7 +361,7 @@ describe( 'List block', () => {
 		` );
 	} );
 
-	it( 'unwraps list items when attempting to merge with non-list block', async () => {
+	it( 'unwraps first item when attempting to merge with non-list block', async () => {
 		const initialHtml = `<!-- wp:paragraph -->
 		<p>A quick brown fox.</p>
 		<!-- /wp:paragraph -->
@@ -400,14 +400,16 @@ describe( 'List block', () => {
 		"<!-- wp:paragraph -->
 		<p>A quick brown fox.</p>
 		<!-- /wp:paragraph -->
-
+		
 		<!-- wp:paragraph -->
 		<p>One</p>
 		<!-- /wp:paragraph -->
-
-		<!-- wp:paragraph -->
-		<p>Two</p>
-		<!-- /wp:paragraph -->"
+		
+		<!-- wp:list -->
+		<ul><!-- wp:list-item -->
+		<li>Two</li>
+		<!-- /wp:list-item --></ul>
+		<!-- /wp:list -->"
 	` );
 	} );
 } );

--- a/packages/block-library/src/list/transforms.js
+++ b/packages/block-library/src/list/transforms.js
@@ -114,17 +114,6 @@ const transforms = {
 				);
 			},
 		} ) ),
-		{
-			type: 'block',
-			blocks: [ '*' ],
-			transform: ( _attributes, childBlocks ) => {
-				return getListContentFlat( childBlocks ).map( ( content ) =>
-					createBlock( 'core/paragraph', {
-						content,
-					} )
-				);
-			},
-		},
 	],
 };
 

--- a/packages/block-library/src/utils/transformation-categories.native.js
+++ b/packages/block-library/src/utils/transformation-categories.native.js
@@ -3,6 +3,7 @@ const transformationCategories = {
 		'core/paragraph',
 		'core/heading',
 		'core/list',
+		'core/list-item',
 		'core/quote',
 		'core/pullquote',
 		'core/preformatted',

--- a/packages/blocks/README.md
+++ b/packages/blocks/README.md
@@ -529,10 +529,9 @@ _Returns_
 
 -   `boolean`: Whether the given block is a template part.
 
-### isUnmodifiedDefaultBlock
+### isUnmodifiedBlock
 
-Determines whether the block is a default block
-and its attributes are equal to the default attributes
+Determines whether the block's attributes are equal to the default attributes
 which means the block is unmodified.
 
 _Parameters_
@@ -541,7 +540,20 @@ _Parameters_
 
 _Returns_
 
--   `boolean`: Whether the block is an unmodified default block
+-   `boolean`: Whether the block is an unmodified block.
+
+### isUnmodifiedDefaultBlock
+
+Determines whether the block is a default block and its attributes are equal
+to the default attributes which means the block is unmodified.
+
+_Parameters_
+
+-   _block_ `WPBlock`: Block Object
+
+_Returns_
+
+-   `boolean`: Whether the block is an unmodified default block.
 
 ### isValidBlockContent
 

--- a/packages/blocks/src/api/index.js
+++ b/packages/blocks/src/api/index.js
@@ -137,6 +137,7 @@ export {
 	unregisterBlockVariation,
 } from './registration';
 export {
+	isUnmodifiedBlock,
 	isUnmodifiedDefaultBlock,
 	normalizeIconObject,
 	isValidIcon,

--- a/packages/blocks/src/api/utils.js
+++ b/packages/blocks/src/api/utils.js
@@ -30,35 +30,38 @@ extend( [ namesPlugin, a11yPlugin ] );
 const ICON_COLORS = [ '#191e23', '#f8f9f9' ];
 
 /**
- * Determines whether the block is a default block
- * and its attributes are equal to the default attributes
+ * Determines whether the block's attributes are equal to the default attributes
  * which means the block is unmodified.
  *
  * @param {WPBlock} block Block Object
  *
- * @return {boolean} Whether the block is an unmodified default block
+ * @return {boolean} Whether the block is an unmodified block.
  */
-export function isUnmodifiedDefaultBlock( block ) {
-	const defaultBlockName = getDefaultBlockName();
-	if ( block.name !== defaultBlockName ) {
-		return false;
-	}
-
+export function isUnmodifiedBlock( block ) {
 	// Cache a created default block if no cache exists or the default block
 	// name changed.
-	if (
-		! isUnmodifiedDefaultBlock.block ||
-		isUnmodifiedDefaultBlock.block.name !== defaultBlockName
-	) {
-		isUnmodifiedDefaultBlock.block = createBlock( defaultBlockName );
+	if ( ! isUnmodifiedBlock[ block.name ] ) {
+		isUnmodifiedBlock[ block.name ] = createBlock( block.name );
 	}
 
-	const newDefaultBlock = isUnmodifiedDefaultBlock.block;
-	const blockType = getBlockType( defaultBlockName );
+	const newBlock = isUnmodifiedBlock[ block.name ];
+	const blockType = getBlockType( block.name );
 
 	return Object.keys( blockType?.attributes ?? {} ).every(
-		( key ) => newDefaultBlock.attributes[ key ] === block.attributes[ key ]
+		( key ) => newBlock.attributes[ key ] === block.attributes[ key ]
 	);
+}
+
+/**
+ * Determines whether the block is a default block and its attributes are equal
+ * to the default attributes which means the block is unmodified.
+ *
+ * @param {WPBlock} block Block Object
+ *
+ * @return {boolean} Whether the block is an unmodified default block.
+ */
+export function isUnmodifiedDefaultBlock( block ) {
+	return block.name === getDefaultBlockName() && isUnmodifiedBlock( block );
 }
 
 /**

--- a/packages/e2e-tests/specs/editor/blocks/quote.test.js
+++ b/packages/e2e-tests/specs/editor/blocks/quote.test.js
@@ -191,9 +191,9 @@ describe( 'Quote', () => {
 		<p>1</p>
 		<!-- /wp:paragraph -->
 
-		<!-- wp:paragraph -->
-		<p>2</p>
-		<!-- /wp:paragraph -->"
+		<!-- wp:quote -->
+		<blockquote class=\\"wp-block-quote\\"><cite>2</cite></blockquote>
+		<!-- /wp:quote -->"
 	` );
 	} );
 } );

--- a/packages/e2e-tests/specs/editor/various/block-switcher.test.js
+++ b/packages/e2e-tests/specs/editor/various/block-switcher.test.js
@@ -82,9 +82,9 @@ describe( 'Block Switcher', () => {
 		await pressKeyWithModifier( 'alt', 'F10' );
 
 		// Verify the block switcher exists.
-		expect( await hasBlockSwitcher() ).toBeTruthy();
+		expect( await hasBlockSwitcher() ).toBeFalsy();
 		// Verify the correct block transforms appear.
-		expect( await getAvailableBlockTransforms() ).toHaveLength( 1 );
+		expect( await getAvailableBlockTransforms() ).toHaveLength( 0 );
 	} );
 
 	describe( 'Conditional tranformation options', () => {

--- a/test/e2e/specs/editor/blocks/list.spec.js
+++ b/test/e2e/specs/editor/blocks/list.spec.js
@@ -1090,9 +1090,11 @@ test.describe( 'List', () => {
 <p></p>
 <!-- /wp:paragraph -->
 
-<!-- wp:paragraph -->
-<p>2</p>
-<!-- /wp:paragraph -->`
+<!-- wp:list -->
+<ul><!-- wp:list-item -->
+<li>2</li>
+<!-- /wp:list-item --></ul>
+<!-- /wp:list -->`
 		);
 	} );
 

--- a/test/e2e/specs/editor/various/__snapshots__/splitting-and-merging-blocks-test-restore-sele-18edb-roduces-more-than-one-block-on-forward-delete-2-chromium.txt
+++ b/test/e2e/specs/editor/various/__snapshots__/splitting-and-merging-blocks-test-restore-sele-18edb-roduces-more-than-one-block-on-forward-delete-2-chromium.txt
@@ -1,9 +1,5 @@
 <!-- wp:paragraph -->
-<p>hi</p>
-<!-- /wp:paragraph -->
-
-<!-- wp:paragraph -->
-<p>item 1</p>
+<p>hi-item 1</p>
 <!-- /wp:paragraph -->
 
 <!-- wp:list -->

--- a/test/e2e/specs/editor/various/__snapshots__/splitting-and-merging-blocks-test-restore-sele-46dfa-rge-produces-more-than-one-block-on-backspace-2-chromium.txt
+++ b/test/e2e/specs/editor/various/__snapshots__/splitting-and-merging-blocks-test-restore-sele-46dfa-rge-produces-more-than-one-block-on-backspace-2-chromium.txt
@@ -1,9 +1,5 @@
 <!-- wp:paragraph -->
-<p>hi</p>
-<!-- /wp:paragraph -->
-
-<!-- wp:paragraph -->
-<p>item 1</p>
+<p>hi-item 1</p>
 <!-- /wp:paragraph -->
 
 <!-- wp:list -->

--- a/test/e2e/specs/editor/various/__snapshots__/splitting-and-merging-blocks-test-restore-sele-92273-rge-produces-more-than-one-block-on-backspace-1-chromium.txt
+++ b/test/e2e/specs/editor/various/__snapshots__/splitting-and-merging-blocks-test-restore-sele-92273-rge-produces-more-than-one-block-on-backspace-1-chromium.txt
@@ -3,9 +3,11 @@
 <!-- /wp:paragraph -->
 
 <!-- wp:paragraph -->
-<p>-item 1</p>
+<p>item 1</p>
 <!-- /wp:paragraph -->
 
-<!-- wp:paragraph -->
-<p>item 2</p>
-<!-- /wp:paragraph -->
+<!-- wp:list -->
+<ul><!-- wp:list-item -->
+<li>item 2</li>
+<!-- /wp:list-item --></ul>
+<!-- /wp:list -->

--- a/test/e2e/specs/editor/various/splitting-merging.spec.js
+++ b/test/e2e/specs/editor/various/splitting-merging.spec.js
@@ -377,7 +377,11 @@ test.describe( 'splitting and merging blocks', () => {
 				await page.keyboard.type( 'item 1' );
 				await page.keyboard.press( 'Enter' );
 				await page.keyboard.type( 'item 2' );
-				await pageUtils.pressKeyTimes( 'ArrowUp', 2 );
+				await pageUtils.pressKeyTimes( 'ArrowUp', 3 );
+				await page.keyboard.press( 'Delete' );
+
+				expect( await editor.getEditedPostContent() ).toMatchSnapshot();
+
 				await page.keyboard.press( 'Delete' );
 				// Carret should be in the first block and at the proper position.
 				await page.keyboard.type( '-' );
@@ -395,6 +399,10 @@ test.describe( 'splitting and merging blocks', () => {
 				await page.keyboard.type( 'item 2' );
 				await page.keyboard.press( 'ArrowUp' );
 				await pageUtils.pressKeyTimes( 'ArrowLeft', 6 );
+				await page.keyboard.press( 'Backspace' );
+
+				expect( await editor.getEditedPostContent() ).toMatchSnapshot();
+
 				await page.keyboard.press( 'Backspace' );
 				// Carret should be in the first block and at the proper position.
 				await page.keyboard.type( '-' );


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?

Fixes #34100.
Follow up to #43181.

## Why?

It's less jarring than the current experience: unwrapping all list items at once.

## How?

Modifies the onMerge function.

## Testing Instructions

Create a list, press Backspace at the start of the first list item.

Do the same for Quote and Group.

## Screenshots or screencast <!-- if applicable -->

![list-backspace-at-start](https://user-images.githubusercontent.com/4710635/196452885-e2c808f0-5aae-4f09-b5f0-4104dd391bba.gif)

