### PR TITLE
Improve cover block heuristics for is-light/is-dark-theme

### DIFF
--- a/packages/block-library/src/cover/edit/use-cover-is-dark.js
+++ b/packages/block-library/src/cover/edit/use-cover-is-dark.js
@@ -73,8 +73,8 @@ export default function useCoverIsDark(
 					silent: process.env.NODE_ENV === 'production',
 					crossOrigin: imgCrossOrigin,
 				} )
-				.then( ( color ) => {
-					const media = colord( color.hex ).toRgb();
+				.then( ( { value: [ r, g, b, a ] } ) => {
+					const media = { r, g, b, a: a / 255 };
 					const composite = compositeOver( overlay, media );
 					setIsDark( colord( composite ).isDark() );
 				} );

--- a/packages/block-library/src/cover/edit/use-cover-is-dark.js
+++ b/packages/block-library/src/cover/edit/use-cover-is-dark.js
@@ -19,7 +19,7 @@ import { applyFilters } from '@wordpress/hooks';
  * @param {import('colord').RgbaColor} dest Destination color.
  * @return {import('colord').RgbaColor} Composite color.
  */
-function compositeOver( source, dest ) {
+function compositeSourceOver( source, dest ) {
 	return {
 		r: source.r * source.a + dest.r * dest.a * ( 1 - source.a ),
 		g: source.g * source.a + dest.g * dest.a * ( 1 - source.a ),
@@ -75,14 +75,14 @@ export default function useCoverIsDark(
 				} )
 				.then( ( { value: [ r, g, b, a ] } ) => {
 					const media = { r, g, b, a: a / 255 };
-					const composite = compositeOver( overlay, media );
+					const composite = compositeSourceOver( overlay, media );
 					setIsDark( colord( composite ).isDark() );
 				} );
 		} else {
 			// Assume a white background because it isn't easy to get the actual
 			// parent background color.
 			const background = { r: 255, g: 255, b: 255, a: 1 };
-			const composite = compositeOver( overlay, background );
+			const composite = compositeSourceOver( overlay, background );
 			setIsDark( colord( composite ).isDark() );
 		}
 	}, [ overlayColor, dimRatio, url, setIsDark ] );

--- a/packages/block-library/src/cover/edit/use-cover-is-dark.js
+++ b/packages/block-library/src/cover/edit/use-cover-is-dark.js
@@ -10,6 +10,15 @@ import { colord } from 'colord';
 import { useEffect, useState } from '@wordpress/element';
 import { applyFilters } from '@wordpress/hooks';
 
+/**
+ * Performs a Porter Duff composite source over operation on two rgba colors.
+ *
+ * @see https://www.w3.org/TR/compositing-1/#porterduffcompositingoperators_srcover
+ *
+ * @param {import('colord').RgbaColor} source Source color.
+ * @param {import('colord').RgbaColor} dest Destination color.
+ * @returns {import('colord').RgbaColor} Composite color.
+ */
 function compositeOver( source, dest ) {
 	return {
 		r: source.r * source.a + dest.r * dest.a * ( 1 - source.a ),

--- a/packages/block-library/src/cover/edit/use-cover-is-dark.js
+++ b/packages/block-library/src/cover/edit/use-cover-is-dark.js
@@ -31,10 +31,8 @@ function retrieveFastAverageColor() {
  */
 export default function useCoverIsDark( url, dimRatio = 50, overlayColor ) {
 	const [ isDark, setIsDark ] = useState( false );
-	const isDimmedEnough = dimRatio > 50;
-	const hasMedia = !! url;
 	useEffect( () => {
-		if ( isDimmedEnough || ! hasMedia || ! elementRef.current ) {
+		if ( dimRatio > 50 || ! url || ! elementRef.current ) {
 			// If opacity is greater than 50 the dominant color is the overlay
 			// color, so use the overlay color for the dark mode computation.
 			// Additionally, fall back to using the overlay color if a
@@ -63,12 +61,6 @@ export default function useCoverIsDark( url, dimRatio = 50, overlayColor ) {
 				} )
 				.then( ( color ) => setIsDark( color.isDark ) );
 		}
-	}, [
-		hasMedia,
-		isDimmedEnough,
-		overlayColor,
-		elementRef.current,
-		setIsDark,
-	] );
+	}, [ dimRatio > 50, ! url, overlayColor, elementRef.current, setIsDark ] );
 	return isDark;
 }

--- a/packages/block-library/src/cover/edit/use-cover-is-dark.js
+++ b/packages/block-library/src/cover/edit/use-cover-is-dark.js
@@ -74,6 +74,6 @@ export default function useCoverIsDark(
 		} else {
 			setIsDark( colord( overlayColor ).isDark() );
 		}
-	}, [ overlayColor, url, setIsDark ] );
+	}, [ overlayColor, dimRatio, url, setIsDark ] );
 	return isDark;
 }

--- a/packages/block-library/src/cover/edit/use-cover-is-dark.js
+++ b/packages/block-library/src/cover/edit/use-cover-is-dark.js
@@ -75,14 +75,15 @@ export default function useCoverIsDark(
 				} )
 				.then( ( color ) => {
 					const media = colord( color.hex ).toRgb();
-					const composite = colord( compositeOver( overlay, media ) );
-					setIsDark( composite.isDark() );
+					const composite = compositeOver( overlay, media );
+					setIsDark( colord( composite ).isDark() );
 				} );
 		} else {
-			// Assume a white background because it isn't easy to get the actual site background color.
+			// Assume a white background because it isn't easy to get the actual
+			// parent background color.
 			const background = { r: 255, g: 255, b: 255, a: 1 };
-			const composite = colord( compositeOver( overlay, background ) );
-			setIsDark( composite.isDark() );
+			const composite = compositeOver( overlay, background );
+			setIsDark( colord( composite ).isDark() );
 		}
 	}, [ overlayColor, dimRatio, url, setIsDark ] );
 	return isDark;

--- a/packages/block-library/src/cover/edit/use-cover-is-dark.js
+++ b/packages/block-library/src/cover/edit/use-cover-is-dark.js
@@ -74,6 +74,7 @@ export default function useCoverIsDark(
 					crossOrigin: imgCrossOrigin,
 				} )
 				.then( ( { value: [ r, g, b, a ] } ) => {
+					// FAC uses 0-255 for alpha, but colord expects 0-1.
 					const media = { r, g, b, a: a / 255 };
 					const composite = compositeSourceOver( overlay, media );
 					setIsDark( colord( composite ).isDark() );

--- a/packages/block-library/src/cover/edit/use-cover-is-dark.js
+++ b/packages/block-library/src/cover/edit/use-cover-is-dark.js
@@ -16,7 +16,7 @@ import { applyFilters } from '@wordpress/hooks';
  * @see https://www.w3.org/TR/compositing-1/#porterduffcompositingoperators_srcover
  *
  * @param {import('colord').RgbaColor} source Source color.
- * @param {import('colord').RgbaColor} dest Destination color.
+ * @param {import('colord').RgbaColor} dest   Destination color.
  * @return {import('colord').RgbaColor} Composite color.
  */
 function compositeSourceOver( source, dest ) {

--- a/packages/block-library/src/cover/edit/use-cover-is-dark.js
+++ b/packages/block-library/src/cover/edit/use-cover-is-dark.js
@@ -17,7 +17,7 @@ import { applyFilters } from '@wordpress/hooks';
  *
  * @param {import('colord').RgbaColor} source Source color.
  * @param {import('colord').RgbaColor} dest Destination color.
- * @returns {import('colord').RgbaColor} Composite color.
+ * @return {import('colord').RgbaColor} Composite color.
  */
 function compositeOver( source, dest ) {
 	return {

--- a/packages/block-library/src/cover/edit/use-cover-is-dark.js
+++ b/packages/block-library/src/cover/edit/use-cover-is-dark.js
@@ -65,11 +65,10 @@ export default function useCoverIsDark(
 						dimRatio / 100
 					);
 					const media = colord( color.hex );
-					const c = colord(
+					const composite = colord(
 						compositeOver( overlay.toRgb(), media.toRgb() )
 					);
-					console.log( c );
-					setIsDark( c.isDark() );
+					setIsDark( composite.isDark() );
 				} );
 		} else {
 			setIsDark( colord( overlayColor ).isDark() );

--- a/packages/block-library/src/cover/edit/use-cover-is-dark.js
+++ b/packages/block-library/src/cover/edit/use-cover-is-dark.js
@@ -11,11 +11,12 @@ import { useEffect, useState } from '@wordpress/element';
 import { applyFilters } from '@wordpress/hooks';
 
 function compositeOver( source, dest ) {
-	const a = source.a + dest.a * ( 1 - source.a );
-	const r = source.r * source.a + dest.r * dest.a * ( 1 - source.a );
-	const g = source.g * source.a + dest.g * dest.a * ( 1 - source.a );
-	const b = source.b * source.a + dest.b * dest.a * ( 1 - source.a );
-	return { r, g, b, a };
+	return {
+		r: source.r * source.a + dest.r * dest.a * ( 1 - source.a ),
+		g: source.g * source.a + dest.g * dest.a * ( 1 - source.a ),
+		b: source.b * source.a + dest.b * dest.a * ( 1 - source.a ),
+		a: source.a + dest.a * ( 1 - source.a ),
+	};
 }
 
 function retrieveFastAverageColor() {

--- a/packages/block-library/src/cover/edit/use-cover-is-dark.js
+++ b/packages/block-library/src/cover/edit/use-cover-is-dark.js
@@ -54,6 +54,9 @@ export default function useCoverIsDark(
 ) {
 	const [ isDark, setIsDark ] = useState( false );
 	useEffect( () => {
+		const overlay = colord( overlayColor )
+			.alpha( dimRatio / 100 )
+			.toRgb();
 		if ( url ) {
 			const imgCrossOrigin = applyFilters(
 				'media.crossOrigin',
@@ -71,17 +74,15 @@ export default function useCoverIsDark(
 					crossOrigin: imgCrossOrigin,
 				} )
 				.then( ( color ) => {
-					const overlay = colord( overlayColor ).alpha(
-						dimRatio / 100
-					);
-					const media = colord( color.hex );
-					const composite = colord(
-						compositeOver( overlay.toRgb(), media.toRgb() )
-					);
+					const media = colord( color.hex ).toRgb();
+					const composite = colord( compositeOver( overlay, media ) );
 					setIsDark( composite.isDark() );
 				} );
 		} else {
-			setIsDark( colord( overlayColor ).isDark() );
+			// Assume a white background because it isn't easy to get the actual site background color.
+			const background = { r: 255, g: 255, b: 255, a: 1 };
+			const composite = colord( compositeOver( overlay, background ) );
+			setIsDark( composite.isDark() );
 		}
 	}, [ overlayColor, dimRatio, url, setIsDark ] );
 	return isDark;

--- a/packages/block-library/src/cover/edit/use-cover-is-dark.js
+++ b/packages/block-library/src/cover/edit/use-cover-is-dark.js
@@ -54,6 +54,9 @@ export default function useCoverIsDark(
 ) {
 	const [ isDark, setIsDark ] = useState( false );
 	useEffect( () => {
+		const overlay = colord( overlayColor )
+			.alpha( dimRatio / 100 )
+			.toRgb();
 		if ( url ) {
 			const imgCrossOrigin = applyFilters(
 				'media.crossOrigin',
@@ -72,16 +75,16 @@ export default function useCoverIsDark(
 				} )
 				.then( ( { value: [ r, g, b, a ] } ) => {
 					// FAC uses 0-255 for alpha, but colord expects 0-1.
-					const overlay = colord( overlayColor )
-						.alpha( dimRatio / 100 )
-						.toRgb();
 					const media = { r, g, b, a: a / 255 };
 					const composite = compositeSourceOver( overlay, media );
 					setIsDark( colord( composite ).isDark() );
 				} );
 		} else {
-			// Use the color directly since it's hard to determine the background color.
-			setIsDark( colord( overlayColor ).isDark() );
+			// Assume a white background because it isn't easy to get the actual
+			// parent background color.
+			const background = { r: 255, g: 255, b: 255, a: 1 };
+			const composite = compositeSourceOver( overlay, background );
+			setIsDark( colord( composite ).isDark() );
 		}
 	}, [ overlayColor, dimRatio, url, setIsDark ] );
 	return isDark;

--- a/packages/block-library/src/cover/edit/use-cover-is-dark.js
+++ b/packages/block-library/src/cover/edit/use-cover-is-dark.js
@@ -54,9 +54,6 @@ export default function useCoverIsDark(
 ) {
 	const [ isDark, setIsDark ] = useState( false );
 	useEffect( () => {
-		const overlay = colord( overlayColor )
-			.alpha( dimRatio / 100 )
-			.toRgb();
 		if ( url ) {
 			const imgCrossOrigin = applyFilters(
 				'media.crossOrigin',
@@ -75,16 +72,16 @@ export default function useCoverIsDark(
 				} )
 				.then( ( { value: [ r, g, b, a ] } ) => {
 					// FAC uses 0-255 for alpha, but colord expects 0-1.
+					const overlay = colord( overlayColor )
+						.alpha( dimRatio / 100 )
+						.toRgb();
 					const media = { r, g, b, a: a / 255 };
 					const composite = compositeSourceOver( overlay, media );
 					setIsDark( colord( composite ).isDark() );
 				} );
 		} else {
-			// Assume a white background because it isn't easy to get the actual
-			// parent background color.
-			const background = { r: 255, g: 255, b: 255, a: 1 };
-			const composite = compositeSourceOver( overlay, background );
-			setIsDark( colord( composite ).isDark() );
+			// Use the color directly since it's hard to determine the background color.
+			setIsDark( colord( overlayColor ).isDark() );
 		}
 	}, [ overlayColor, dimRatio, url, setIsDark ] );
 	return isDark;

--- a/packages/block-library/src/cover/test/edit.js
+++ b/packages/block-library/src/cover/test/edit.js
@@ -422,7 +422,7 @@ describe( 'Cover block', () => {
 				name: 'Color: Black',
 			} );
 			await userEvent.click( popupColorPicker );
-			expect( coverBlock ).toHaveClass( 'is-dark' );
+			expect( coverBlock ).not.toHaveClass( 'is-light' );
 		} );
 	} );
 } );

--- a/packages/block-library/src/cover/test/edit.js
+++ b/packages/block-library/src/cover/test/edit.js
@@ -404,7 +404,7 @@ describe( 'Cover block', () => {
 			await userEvent.click( popupColorPicker );
 			expect( coverBlock ).not.toHaveClass( 'is-light' );
 		} );
-		test( 'should apply is-light class if overlay color is removed', async () => {
+		test( 'should keep is-dark class if overlay color is removed as the CSS default is black', async () => {
 			await setup();
 			await createAndSelectBlock();
 			const coverBlock = screen.getByLabelText( 'Block: Cover' );
@@ -416,13 +416,13 @@ describe( 'Cover block', () => {
 				} )
 			);
 			await userEvent.click( screen.getByText( 'Overlay' ) );
-			// The default color is black, so clicking the black color option will remove the background color,
-			// which should remove the isDark setting and assign the is-light class.
+			// The default color is black, so clicking the black color option will remove the background color.
+			// The fallback CSS is still black, so the is-dark class should remain.
 			const popupColorPicker = screen.getByRole( 'button', {
 				name: 'Color: Black',
 			} );
 			await userEvent.click( popupColorPicker );
-			expect( coverBlock ).toHaveClass( 'is-light' );
+			expect( coverBlock ).toHaveClass( 'is-dark' );
 		} );
 	} );
 } );

--- a/packages/e2e-tests/specs/editor/various/__snapshots__/inserting-blocks.test.js.snap
+++ b/packages/e2e-tests/specs/editor/various/__snapshots__/inserting-blocks.test.js.snap
@@ -88,8 +88,8 @@ exports[`Inserting blocks inserts a block in proper place after having clicked \
 <p>First paragraph</p>
 <!-- /wp:paragraph -->
 
-<!-- wp:cover {"isDark":false,"layout":{"type":"constrained"}} -->
-<div class="wp-block-cover is-light"><span aria-hidden="true" class="wp-block-cover__background has-background-dim-100 has-background-dim"></span><div class="wp-block-cover__inner-container"></div></div>
+<!-- wp:cover {"layout":{"type":"constrained"}} -->
+<div class="wp-block-cover"><span aria-hidden="true" class="wp-block-cover__background has-background-dim-100 has-background-dim"></span><div class="wp-block-cover__inner-container"></div></div>
 <!-- /wp:cover -->
 
 <!-- wp:heading -->


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

- Improves the text color heuristics for the cover block for better accessibility.
- Fixes default (no overlayColor) to be dark as it defaults to black in the CSS.
- Also may fix flickering dark/light in the scenario described in #53253.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

Fixes #53253.

Previously the heuristic was to use the image average brightness at 50% overlay opacity or lower and the overlay color at greater than 50% overlay opacity.

No heuristic will be perfect, but I think this one produces better results than the previous one.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

Simplifies `useCoverIsDark` into a single `useEffect` that prevents the oscillation seen in #53211.

Defaults to black background in calculations like the block CSS.

Calculates `isDark` based on the average image color _with_ overlay.

Simple alpha compositing is done in the browser with the [Porter Duff source over operation](https://www.w3.org/TR/compositing-1/#porterduffcompositingoperators_srcover). Colord, which we're using for color operations, doesn't include the source over operation, so it has been implemented in this PR. The `mix` operation is close, but does it's calculations in the Lab color space instead of sRGB like the browser.

Example numbers for the image below and the default overlay.

| | Color | Brightness |
|-|-|-|
|Image Average Color| `rgb(152, 141, 133)`|56%|
|Overlay Color| `rgba(0, 0, 0, 0.5)`|50% on white|
|Composite| `rgb(76, 71, 67)`|28%|

![color-heuristic](https://user-images.githubusercontent.com/5129775/196301740-8a195fcb-3202-4dbf-9287-8db0a59a46ba.jpg)

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->

Try different combinations of images and overlay colors to see if the text color matches your expectations. Below is an example image with an average color brightness of 56%.

![demo image with average brightness of 56%](https://cldup.com/L-cC3qX2DN.jpg)

## Screenshots or screencast <!-- if applicable -->

#### Before

Overlay opacity was ≤50%, so text color was based solely on image's average color brightness of 56%, so black text is used.

![before cover block uses black text](https://user-images.githubusercontent.com/5129775/196294070-5a024f6a-2ce4-4f23-b914-44e118122deb.png)

#### After

Image average color overlaid with the 50% opacity black has a brightness of 28%, so white text is used.

![after cover block uses white text](https://user-images.githubusercontent.com/5129775/196293741-da4f7ef8-dba4-48cc-8706-9f3121df6695.png)