### PR TITLE
Try: Fix preview test.

### DIFF
--- a/packages/e2e-test-utils-playwright/src/editor/preview.ts
+++ b/packages/e2e-test-utils-playwright/src/editor/preview.ts
@@ -19,7 +19,9 @@ export async function openPreviewPage( this: Editor ): Promise< Page > {
 	const editorTopBar = this.page.locator(
 		'role=region[name="Editor top bar"i]'
 	);
-	const previewButton = editorTopBar.locator( 'role=button[name="View"i]' );
+	const previewButton = editorTopBar.locator(
+		'role=button[name="Preview"i]'
+	);
 	await previewButton.click();
 
 	const [ previewPage ] = await Promise.all( [

--- a/test/e2e/specs/editor/various/new-post.spec.js
+++ b/test/e2e/specs/editor/various/new-post.spec.js
@@ -32,7 +32,7 @@ test.describe( 'new editor state', () => {
 
 		// Should display the View button.
 		await expect(
-			page.locator( 'role=button[name="View"i]' )
+			page.locator( 'role=button[name="Preview"i]' )
 		).toBeVisible();
 
 		// Should display the Post Formats UI.

--- a/test/e2e/specs/editor/various/preview.spec.js
+++ b/test/e2e/specs/editor/various/preview.spec.js
@@ -24,7 +24,7 @@ test.describe( 'Preview', () => {
 
 		// Disabled until content present.
 		await expect(
-			editorPage.locator( 'role=button[name="View"i]' )
+			editorPage.locator( 'role=button[name="Preview"i]' )
 		).toBeDisabled();
 
 		await editorPage.type(
@@ -282,7 +282,7 @@ test.describe( 'Preview with private custom post type', () => {
 		await admin.createNewPost( { postType: 'not_public', title: 'aaaaa' } );
 
 		// Open the view menu.
-		await page.click( 'role=button[name="View"i]' );
+		await page.click( 'role=button[name="Preview"i]' );
 
 		await expect(
 			page.locator( 'role=menuitem[name="Preview in new tab"i]' )


### PR DESCRIPTION
## What?

Followup to #45074. It wasn't entirely clear to me whether the tests passed or not, but it appears there may have been a hiccup looking at https://github.com/WordPress/gutenberg/pull/45074/files. If the tests pass on this PR, then that's the case.