### PR TITLE
List view: Close after selecting block

### DIFF
--- a/packages/block-editor/src/components/list-view/index.js
+++ b/packages/block-editor/src/components/list-view/index.js
@@ -50,15 +50,22 @@ export const BLOCK_LIST_ITEM_HEIGHT = 36;
 /**
  * Show a hierarchical list of blocks.
  *
- * @param {Object}  props                 Components props.
- * @param {string}  props.id              An HTML element id for the root element of ListView.
- * @param {Array}   props.blocks          Custom subset of block client IDs to be used instead of the default hierarchy.
- * @param {boolean} props.showBlockMovers Flag to enable block movers
- * @param {boolean} props.isExpanded      Flag to determine whether nested levels are expanded by default.
- * @param {Object}  ref                   Forwarded ref
+ * @param {Object}   props                    Components props.
+ * @param {string}   props.id                 An HTML element id for the root element of ListView.
+ * @param {Array}    props.blocks             Custom subset of block client IDs to be used instead of the default hierarchy.
+ * @param {boolean}  props.showBlockMovers    Flag to enable block movers
+ * @param {boolean}  props.isExpanded         Flag to determine whether nested levels are expanded by default.
+ * @param {Function} props.closeOnBlockSelect Callback that fires when block is selected.
+ * @param {Object}   ref                      Forwarded ref
  */
 function ListView(
-	{ id, blocks, showBlockMovers = false, isExpanded = false },
+	{
+		id,
+		blocks,
+		showBlockMovers = false,
+		isExpanded = false,
+		closeOnBlockSelect,
+	},
 	ref
 ) {
 	const { clientIdsTree, draggedClientIds, selectedClientIds } =
@@ -100,6 +107,7 @@ function ListView(
 		( event, clientId ) => {
 			updateBlockSelection( event, clientId );
 			setSelectedTreeId( clientId );
+			closeOnBlockSelect();
 		},
 		[ setSelectedTreeId, updateBlockSelection ]
 	);

--- a/packages/edit-post/src/components/secondary-sidebar/list-view-sidebar.js
+++ b/packages/edit-post/src/components/secondary-sidebar/list-view-sidebar.js
@@ -35,6 +35,10 @@ export default function ListViewSidebar() {
 	const instanceId = useInstanceId( ListViewSidebar );
 	const labelId = `edit-post-editor__list-view-panel-label-${ instanceId }`;
 
+	const closeOnBlockSelect = () => {
+		setIsListViewOpened( false );
+	};
+
 	return (
 		// eslint-disable-next-line jsx-a11y/no-static-element-interactions
 		<div
@@ -60,7 +64,7 @@ export default function ListViewSidebar() {
 					focusOnMountRef,
 				] ) }
 			>
-				<ListView />
+				<ListView closeOnBlockSelect={ closeOnBlockSelect } />
 			</div>
 		</div>
 	);

--- a/packages/edit-site/src/components/secondary-sidebar/list-view-sidebar.js
+++ b/packages/edit-site/src/components/secondary-sidebar/list-view-sidebar.js
@@ -34,6 +34,10 @@ export default function ListViewSidebar() {
 	const instanceId = useInstanceId( ListViewSidebar );
 	const labelId = `edit-site-editor__list-view-panel-label-${ instanceId }`;
 
+	const closeOnBlockSelect = () => {
+		setIsListViewOpened( false );
+	};
+
 	return (
 		// eslint-disable-next-line jsx-a11y/no-static-element-interactions
 		<div
@@ -59,7 +63,7 @@ export default function ListViewSidebar() {
 					focusOnMountRef,
 				] ) }
 			>
-				<ListView />
+				<ListView closeOnBlockSelect={ closeOnBlockSelect } />
 			</div>
 		</div>
 	);

--- a/packages/edit-widgets/src/components/secondary-sidebar/list-view-sidebar.js
+++ b/packages/edit-widgets/src/components/secondary-sidebar/list-view-sidebar.js
@@ -35,6 +35,10 @@ export default function ListViewSidebar() {
 	const instanceId = useInstanceId( ListViewSidebar );
 	const labelId = `edit-widgets-editor__list-view-panel-label-${ instanceId }`;
 
+	const closeOnBlockSelect = () => {
+		setIsListViewOpened( false );
+	};
+
 	return (
 		// eslint-disable-next-line jsx-a11y/no-static-element-interactions
 		<div
@@ -60,7 +64,7 @@ export default function ListViewSidebar() {
 					focusOnMountRef,
 				] ) }
 			>
-				<ListView />
+				<ListView closeOnBlockSelect={ closeOnBlockSelect } />
 			</div>
 		</div>
 	);


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Fixes #29466

After selecting a block from the list view, the list view should close that way it can be re-opened with the global keyboard shortcut. When the list view re-opens, focus is placed in the list view for all users, not just screen readers. This greatly improves the UX.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

Once you select a block, there is no easy way to get to the list view sidebar again. This could be for sighted and even screen reader users. Sighted users could always navigate back to the sidebar with their mouse, but from a keyboard navigation perspective, there is not an easy way. See the linked issue for further discussion/details.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

I passed a callback function in to the `ListView` component that will get called after a block is selected.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->

1. Open Gutenberg post or site editor.
2. Open the list view.
3. Select a block.
4. Notice how the list view sidebar closes.
5. Open the list view.
6. Notice how focus is once again placed in the list view.
7. Notice how selecting the options button for a block does not close the list view.

## Screenshots or screencast <!-- if applicable -->
