### PR TITLE
Tag Processor: Remove the shorthand next_tag( $tag_name ) syntax

### DIFF
--- a/lib/experimental/html/class-wp-html-tag-processor.php
+++ b/lib/experimental/html/class-wp-html-tag-processor.php
@@ -203,7 +203,7 @@ class WP_HTML_Tag_Processor {
 	 * @since 6.2.0
 	 * @var string|null
 	 */
-	private $sought_tag;
+	private $sought_tag_name;
 
 	/**
 	 * The CSS class name this processor currently scans for.
@@ -211,7 +211,7 @@ class WP_HTML_Tag_Processor {
 	 * @since 6.2.0
 	 * @var string|null
 	 */
-	private $sought_class;
+	private $sought_class_name;
 
 	/**
 	 * The match offset this processor currently scans for.
@@ -259,7 +259,7 @@ class WP_HTML_Tag_Processor {
 	 * @since 6.2.0
 	 * @var ?int
 	 */
-	private $tag_starts_at;
+	private $tag_name_starts_at;
 
 	/**
 	 * Byte length of current tag name.
@@ -274,7 +274,7 @@ class WP_HTML_Tag_Processor {
 	 * @since 6.2.0
 	 * @var ?int
 	 */
-	private $tag_length;
+	private $tag_name_length;
 
 	/**
 	 * Lazily-built index of attributes found within an HTML tag, keyed by the attribute name.
@@ -321,8 +321,8 @@ class WP_HTML_Tag_Processor {
 	 *     // Add the `WP-block-group` class, remove the `WP-group` class.
 	 *     $class_changes = [
 	 *         // Indexed by a comparable class name
-	 *         'wp-block-group' => new WP_class_Operation( 'WP-block-group', WP_class_Operation::ADD ),
-	 *         'wp-group'       => new WP_class_Operation( 'WP-group', WP_class_Operation::REMOVE )
+	 *         'wp-block-group' => new WP_Class_Name_Operation( 'WP-block-group', WP_Class_Name_Operation::ADD ),
+	 *         'wp-group'       => new WP_Class_Name_Operation( 'WP-group', WP_Class_Name_Operation::REMOVE )
 	 *     ];
 	 * </code>
 	 *
@@ -384,11 +384,11 @@ class WP_HTML_Tag_Processor {
 	 * @param array|string $query {
 	 *     Which tag name to find, having which class, etc.
 	 *
-	 *     @type string|null $tag     Which tag to find, or `null` for "any tag."
+	 *     @type string|null $tag_name     Which tag to find, or `null` for "any tag."
 	 *     @type int|null    $match_offset Find the Nth tag matching all search criteria.
 	 *                                     0 for "first" tag, 2 for "third," etc.
 	 *                                     Defaults to first tag.
-	 *     @type string|null $class   Tag must contain this whole class name to match.
+	 *     @type string|null $class_name   Tag must contain this whole class name to match.
 	 * }
 	 * @return boolean Whether a tag was matched.
 	 */
@@ -415,14 +415,14 @@ class WP_HTML_Tag_Processor {
 			}
 
 			// Avoid copying the tag name string when possible.
-			$t = $this->html[ $this->tag_starts_at ];
+			$t = $this->html[ $this->tag_name_starts_at ];
 			if ( 's' === $t || 'S' === $t || 't' === $t || 'T' === $t ) {
-				$tag = $this->get_tag();
+				$tag_name = $this->get_tag();
 
-				if ( 'SCRIPT' === $tag ) {
+				if ( 'SCRIPT' === $tag_name ) {
 					$this->skip_script_data();
-				} elseif ( 'TEXTAREA' === $tag || 'TITLE' === $tag ) {
-					$this->skip_rcdata( $tag );
+				} elseif ( 'TEXTAREA' === $tag_name || 'TITLE' === $tag_name ) {
+					$this->skip_rcdata( $tag_name );
 				}
 			}
 		} while ( $already_found < $this->sought_match_offset );
@@ -435,13 +435,13 @@ class WP_HTML_Tag_Processor {
 	 * tag closer is found.
 	 *
 	 * @see https://html.spec.whatwg.org/multipage/parsing.html#rcdata-state
-	 * @param string $tag – the lowercase tag name which will close the RCDATA region.
+	 * @param string $tag_name – the lowercase tag name which will close the RCDATA region.
 	 * @since 6.2.0
 	 */
-	private function skip_rcdata( $tag ) {
+	private function skip_rcdata( $tag_name ) {
 		$html       = $this->html;
 		$doc_length = strlen( $html );
-		$tag_length = strlen( $tag );
+		$tag_length = strlen( $tag_name );
 
 		$at = $this->parsed_bytes;
 
@@ -464,7 +464,7 @@ class WP_HTML_Tag_Processor {
 			 * will never be a match.
 			 */
 			for ( $i = 0; $i < $tag_length; $i++ ) {
-				$tag_char  = $tag[ $i ];
+				$tag_char  = $tag_name[ $i ];
 				$html_char = $html[ $at + $i ];
 
 				if ( $html_char !== $tag_char && strtoupper( $html_char ) !== $tag_char ) {
@@ -842,10 +842,10 @@ class WP_HTML_Tag_Processor {
 	 * @return void
 	 */
 	private function after_tag() {
-		$this->class_updates_to_attributes_updates();
+		$this->class_name_updates_to_attributes_updates();
 		$this->apply_attributes_updates();
-		$this->tag_starts_at = null;
-		$this->tag_length    = null;
+		$this->tag_name_starts_at = null;
+		$this->tag_name_length    = null;
 		$this->attributes         = array();
 	}
 
@@ -862,7 +862,7 @@ class WP_HTML_Tag_Processor {
 	 * @see $classname_updates
 	 * @see $attribute_updates
 	 */
-	private function class_updates_to_attributes_updates() {
+	private function class_name_updates_to_attributes_updates() {
 		if ( count( $this->classname_updates ) === 0 || isset( $this->attribute_updates['class'] ) ) {
 			$this->classname_updates = array();
 			return;
@@ -1044,7 +1044,7 @@ class WP_HTML_Tag_Processor {
 	 *                          Boolean attributes return `true`.
 	 */
 	public function get_attribute( $name ) {
-		if ( null === $this->tag_starts_at ) {
+		if ( null === $this->tag_name_starts_at ) {
 			return null;
 		}
 
@@ -1082,13 +1082,13 @@ class WP_HTML_Tag_Processor {
 	 * @return string|null Name of current tag in input HTML, or `null` if none currently open.
 	 */
 	public function get_tag() {
-		if ( null === $this->tag_starts_at ) {
+		if ( null === $this->tag_name_starts_at ) {
 			return null;
 		}
 
-		$tag = substr( $this->html, $this->tag_starts_at, $this->tag_length );
+		$tag_name = substr( $this->html, $this->tag_name_starts_at, $this->tag_name_length );
 
-		return strtoupper( $tag );
+		return strtoupper( $tag_name );
 	}
 
 	/**
@@ -1107,7 +1107,7 @@ class WP_HTML_Tag_Processor {
 	 * @throws Exception When WP_DEBUG is true and the attribute name is invalid.
 	 */
 	public function set_attribute( $name, $value ) {
-		if ( null === $this->tag_starts_at ) {
+		if ( null === $this->tag_name_starts_at ) {
 			return;
 		}
 
@@ -1203,8 +1203,8 @@ class WP_HTML_Tag_Processor {
 			 *    Result: <div id="new"/>
 			 */
 			$this->attribute_updates[ $name ] = new WP_HTML_Text_Replacement(
-				$this->tag_starts_at + $this->tag_length,
-				$this->tag_starts_at + $this->tag_length,
+				$this->tag_name_starts_at + $this->tag_name_length,
+				$this->tag_name_starts_at + $this->tag_name_length,
 				' ' . $updated_attribute
 			);
 		}
@@ -1245,11 +1245,11 @@ class WP_HTML_Tag_Processor {
 	 *
 	 * @since 6.2.0
 	 *
-	 * @param string $class The class name to add.
+	 * @param string $class_name The class name to add.
 	 */
-	public function add_class( $class ) {
-		if ( null !== $this->tag_starts_at ) {
-			$this->classname_updates[ $class ] = self::ADD_CLASS;
+	public function add_class( $class_name ) {
+		if ( null !== $this->tag_name_starts_at ) {
+			$this->classname_updates[ $class_name ] = self::ADD_CLASS;
 		}
 	}
 
@@ -1258,11 +1258,11 @@ class WP_HTML_Tag_Processor {
 	 *
 	 * @since 6.2.0
 	 *
-	 * @param string $class The class name to remove.
+	 * @param string $class_name The class name to remove.
 	 */
-	public function remove_class( $class ) {
-		if ( null !== $this->tag_starts_at ) {
-			$this->classname_updates[ $class ] = self::REMOVE_CLASS;
+	public function remove_class( $class_name ) {
+		if ( null !== $this->tag_name_starts_at ) {
+			$this->classname_updates[ $class_name ] = self::REMOVE_CLASS;
 		}
 	}
 
@@ -1301,26 +1301,26 @@ class WP_HTML_Tag_Processor {
 		 */
 
 		// Find tag name's end in the updated markup.
-		$markup_updated_up_to_a_tag_end = $this->updated_html . substr( $this->html, $this->updated_bytes, $this->tag_starts_at + $this->tag_length - $this->updated_bytes );
-		$updated_tag_ends_at            = strlen( $markup_updated_up_to_a_tag_end );
-		$updated_tag_starts_at          = $updated_tag_ends_at - $this->tag_length;
+		$markup_updated_up_to_a_tag_name_end = $this->updated_html . substr( $this->html, $this->updated_bytes, $this->tag_name_starts_at + $this->tag_name_length - $this->updated_bytes );
+		$updated_tag_name_ends_at            = strlen( $markup_updated_up_to_a_tag_name_end );
+		$updated_tag_name_starts_at          = $updated_tag_name_ends_at - $this->tag_name_length;
 
 		// Apply attributes updates.
-		$this->updated_html  = $markup_updated_up_to_a_tag_end;
-		$this->updated_bytes = $this->tag_starts_at + $this->tag_length;
-		$this->class_updates_to_attributes_updates();
+		$this->updated_html  = $markup_updated_up_to_a_tag_name_end;
+		$this->updated_bytes = $this->tag_name_starts_at + $this->tag_name_length;
+		$this->class_name_updates_to_attributes_updates();
 		$this->apply_attributes_updates();
 
 		// Replace $this->html with the updated markup.
 		$this->html = $this->updated_html . substr( $this->html, $this->updated_bytes );
 
 		// Rewind this processor to the tag name's end.
-		$this->tag_starts_at = $updated_tag_starts_at;
-		$this->parsed_bytes       = $updated_tag_ends_at;
+		$this->tag_name_starts_at = $updated_tag_name_starts_at;
+		$this->parsed_bytes       = $updated_tag_name_ends_at;
 
 		// Restore the previous version of the updated_html as we are not finished with the current_tag yet.
-		$this->updated_html  = $markup_updated_up_to_a_tag_end;
-		$this->updated_bytes = $updated_tag_ends_at;
+		$this->updated_html  = $markup_updated_up_to_a_tag_name_end;
+		$this->updated_bytes = $updated_tag_name_ends_at;
 
 		// Parse the attributes in the updated markup.
 		$this->attributes = array();
@@ -1337,8 +1337,8 @@ class WP_HTML_Tag_Processor {
 	 * @param array $query {
 	 *     Which tag name to find, having which class.
 	 *
-	 *     @type string|null $tag     Which tag to find, or `null` for "any tag."
-	 *     @type string|null $class   Tag must contain this class name to match.
+	 *     @type string|null $tag_name     Which tag to find, or `null` for "any tag."
+	 *     @type string|null $class_name   Tag must contain this class name to match.
 	 * }
 	 */
 	private function parse_query( $query ) {
@@ -1349,16 +1349,16 @@ class WP_HTML_Tag_Processor {
 		}
 
 		$this->last_query          = $query;
-		$this->sought_tag     = null;
-		$this->sought_class   = null;
+		$this->sought_tag_name     = null;
+		$this->sought_class_name   = null;
 		$this->sought_match_offset = 1;
 
 		if ( isset( $query['tag'] ) && is_string( $query['tag'] ) ) {
-			$this->sought_tag = $query['tag'];
+			$this->sought_tag_name = $query['tag'];
 		}
 
 		if ( isset( $query['class'] ) && is_string( $query['class'] ) ) {
-			$this->sought_class = $query['class'];
+			$this->sought_class_name = $query['class'];
 		}
 
 		if ( isset( $query['match_offset'] ) && is_int( $query['match_offset'] ) && 0 < $query['match_offset'] ) {
@@ -1376,12 +1376,12 @@ class WP_HTML_Tag_Processor {
 	 */
 	private function matches() {
 		// Do we match a case-insensitive HTML tag name?
-		if ( null !== $this->sought_tag ) {
+		if ( null !== $this->sought_tag_name ) {
 			/*
 			 * String (byte) length lookup is fast. If they aren't the
 			 * same length then they can't be the same string values.
 			 */
-			if ( strlen( $this->sought_tag ) !== $this->tag_length ) {
+			if ( strlen( $this->sought_tag_name ) !== $this->tag_name_length ) {
 				return false;
 			}
 
@@ -1393,9 +1393,9 @@ class WP_HTML_Tag_Processor {
 			 * most of the time this runs we shouldn't expect to
 			 * actually run the case-folding comparison.
 			 */
-			for ( $i = 0; $i < $this->tag_length; $i++ ) {
-				$html_char = $this->html[ $this->tag_starts_at + $i ];
-				$tag_char  = $this->sought_tag[ $i ];
+			for ( $i = 0; $i < $this->tag_name_length; $i++ ) {
+				$html_char = $this->html[ $this->tag_name_starts_at + $i ];
+				$tag_char  = $this->sought_tag_name[ $i ];
 
 				if ( $html_char !== $tag_char && strtoupper( $html_char ) !== $tag_char ) {
 					return false;
@@ -1403,14 +1403,14 @@ class WP_HTML_Tag_Processor {
 			}
 		}
 
-		$needs_class = null !== $this->sought_class;
+		$needs_class_name = null !== $this->sought_class_name;
 
-		if ( $needs_class && ! isset( $this->attributes['class'] ) ) {
+		if ( $needs_class_name && ! isset( $this->attributes['class'] ) ) {
 			return false;
 		}
 
 		// Do we match a byte-for-byte (case-sensitive and encoding-form-sensitive) class name?
-		if ( $needs_class ) {
+		if ( $needs_class_name ) {
 			$class_start = $this->attributes['class']->value_starts_at;
 			$class_end   = $class_start + $this->attributes['class']->value_length;
 			$class_at    = $class_start;
@@ -1428,7 +1428,7 @@ class WP_HTML_Tag_Processor {
 			 */
 			while (
 				// phpcs:ignore WordPress.CodeAnalysis.AssignmentInCondition.FoundInWhileCondition
-				false !== ( $class_at = strpos( $this->html, $this->sought_class, $class_at ) ) &&
+				false !== ( $class_at = strpos( $this->html, $this->sought_class_name, $class_at ) ) &&
 				$class_at < $class_end
 			) {
 				/*
@@ -1440,7 +1440,7 @@ class WP_HTML_Tag_Processor {
 					$character = $this->html[ $class_at - 1 ];
 
 					if ( ' ' !== $character && "\t" !== $character && "\f" !== $character && "\r" !== $character && "\n" !== $character ) {
-						$class_at += strlen( $this->sought_class );
+						$class_at += strlen( $this->sought_class_name );
 						continue;
 					}
 				}
@@ -1450,11 +1450,11 @@ class WP_HTML_Tag_Processor {
 				 * can end at the very end of the string value, otherwise we have
 				 * to end at a place where the next character is whitespace.
 				 */
-				if ( $class_at + strlen( $this->sought_class ) < $class_end ) {
-					$character = $this->html[ $class_at + strlen( $this->sought_class ) ];
+				if ( $class_at + strlen( $this->sought_class_name ) < $class_end ) {
+					$character = $this->html[ $class_at + strlen( $this->sought_class_name ) ];
 
 					if ( ' ' !== $character && "\t" !== $character && "\f" !== $character && "\r" !== $character && "\n" !== $character ) {
-						$class_at += strlen( $this->sought_class );
+						$class_at += strlen( $this->sought_class_name );
 						continue;
 					}
 				}

--- a/lib/experimental/html/class-wp-html-tag-processor.php
+++ b/lib/experimental/html/class-wp-html-tag-processor.php
@@ -402,7 +402,7 @@ class WP_HTML_Tag_Processor {
 			 * lead us to skip over other tags and lose track of our place. So we need to search for
 			 * _every_ tag and then check after we find one if it's the one we are looking for.
 			 */
-			if ( false === $this->parse_next() ) {
+			if ( false === $this->parse_next_tag() ) {
 				$this->parsed_bytes = strlen( $this->html );
 
 				return false;
@@ -620,7 +620,7 @@ class WP_HTML_Tag_Processor {
 	 *
 	 * @since 6.2.0
 	 */
-	private function parse_next() {
+	private function parse_next_tag() {
 		$this->after_tag();
 
 		$html = $this->html;

--- a/lib/experimental/html/class-wp-html-tag-processor.php
+++ b/lib/experimental/html/class-wp-html-tag-processor.php
@@ -42,14 +42,14 @@
  * Example:
  * ```php
  *     $tags = new WP_HTML_Tag_Processor( $html );
- *     if ( $tags->next_tag( [ 'tag_name' => 'option' ] ) ) {
+ *     if ( $tags->next( [ 'tag_name' => 'option' ] ) ) {
  *         $tags->set_attribute( 'selected', true );
  *     }
  * ```
  *
  * ### Finding tags
  *
- * The `next_tag()` function moves the internal cursor through
+ * The `next()` function moves the internal cursor through
  * your input HTML document until it finds a tag meeting any of
  * the supplied restrictions in the optional query argument. If
  * no argument is provided then it will find the next HTML tag,
@@ -57,17 +57,17 @@
  *
  * If you want to _find whatever the next tag is_:
  * ```php
- *     $tags->next_tag();
+ *     $tags->next();
  * ```
  *
  * | Goal                                                      | Query                                                                      |
  * |-----------------------------------------------------------|----------------------------------------------------------------------------|
- * | Find any tag.                                             | `$tags->next_tag();`                                                       |
- * | Find next image tag.                                      | `$tags->next_tag( [ 'tag_name' => 'img' ] );`                              |
- * | Find next tag containing the `fullwidth` CSS class.       | `$tags->next_tag( [ 'class_name' => 'fullwidth' ] );`                      |
- * | Find next image tag containing the `fullwidth` CSS class. | `$tags->next_tag( [ 'tag_name' => 'img', 'class_name' => 'fullwidth' ] );` |
+ * | Find any tag.                                             | `$tags->next();`                                                       |
+ * | Find next image tag.                                      | `$tags->next( [ 'tag_name' => 'img' ] );`                              |
+ * | Find next tag containing the `fullwidth` CSS class.       | `$tags->next( [ 'class_name' => 'fullwidth' ] );`                      |
+ * | Find next image tag containing the `fullwidth` CSS class. | `$tags->next( [ 'tag_name' => 'img', 'class_name' => 'fullwidth' ] );` |
  *
- * If a tag was found meeting your criteria then `next_tag()`
+ * If a tag was found meeting your criteria then `next()`
  * will return `true` and you can proceed to modify it. If it
  * returns `false`, however, it failed to find the tag and
  * moved the cursor to the end of the file.
@@ -88,7 +88,7 @@
  * ```php
  *     // Paint up to the first five DIV or SPAN tags marked with the "jazzy" style.
  *     $remaining_count = 5;
- *     while ( $remaining_count > 0 && $tags->next_tag() ) {
+ *     while ( $remaining_count > 0 && $tags->next() ) {
  *         if (
  *              ( 'DIV' === $tags->get_tag() || 'SPAN' === $tags->get_tag() ) &&
  *              'jazzy' === $tags->get_attribute( 'data-style' )
@@ -115,7 +115,7 @@
  *
  * Example:
  * ```php
- *     if ( $tags->next_tag( [ 'class' => 'wp-group-block' ] ) ) {
+ *     if ( $tags->next( [ 'class' => 'wp-group-block' ] ) ) {
  *         $tags->set_attribute( 'title', 'This groups the contained content.' );
  *         $tags->remove_attribute( 'data-test-id' );
  *     }
@@ -190,7 +190,7 @@ class WP_HTML_Tag_Processor {
 	private $html;
 
 	/**
-	 * The last query passed to next_tag().
+	 * The last query passed to next().
 	 *
 	 * @since 6.2.0
 	 * @var array|null
@@ -392,7 +392,7 @@ class WP_HTML_Tag_Processor {
 	 * }
 	 * @return boolean Whether a tag was matched.
 	 */
-	public function next_tag( $query = null ) {
+	public function next( $query = null ) {
 		$this->parse_query( $query );
 		$already_found = 0;
 
@@ -402,7 +402,7 @@ class WP_HTML_Tag_Processor {
 			 * lead us to skip over other tags and lose track of our place. So we need to search for
 			 * _every_ tag and then check after we find one if it's the one we are looking for.
 			 */
-			if ( false === $this->parse_next_tag() ) {
+			if ( false === $this->parse_next() ) {
 				$this->parsed_bytes = strlen( $this->html );
 
 				return false;
@@ -620,7 +620,7 @@ class WP_HTML_Tag_Processor {
 	 *
 	 * @since 6.2.0
 	 */
-	private function parse_next_tag() {
+	private function parse_next() {
 		$this->after_tag();
 
 		$html = $this->html;
@@ -1027,12 +1027,12 @@ class WP_HTML_Tag_Processor {
 	 * Example:
 	 * <code>
 	 *     $p = new WP_HTML_Tag_Processor( '<div enabled class="test" data-test-id="14">Test</div>' );
-	 *     $p->next_tag( [ 'class_name' => 'test' ] ) === true;
+	 *     $p->next( [ 'class_name' => 'test' ] ) === true;
 	 *     $p->get_attribute( 'data-test-id' ) === '14';
 	 *     $p->get_attribute( 'enabled' ) === true;
 	 *     $p->get_attribute( 'aria-label' ) === null;
 	 *
-	 *     $p->next_tag( [] ) === false;
+	 *     $p->next( [] ) === false;
 	 *     $p->get_attribute( 'class' ) === null;
 	 * </code>
 	 *
@@ -1069,10 +1069,10 @@ class WP_HTML_Tag_Processor {
 	 * Example:
 	 * <code>
 	 *     $p = new WP_HTML_Tag_Processor( '<DIV CLASS="test">Test</DIV>' );
-	 *     $p->next_tag( [] ) === true;
+	 *     $p->next( [] ) === true;
 	 *     $p->get_tag() === 'DIV';
 	 *
-	 *     $p->next_tag( [] ) === false;
+	 *     $p->next( [] ) === false;
 	 *     $p->get_tag() === null;
 	 * </code>
 	 *
@@ -1333,7 +1333,7 @@ class WP_HTML_Tag_Processor {
 	 *
 	 * @since 6.2.0
 	 *
-	 * @param array|string $query {
+	 * @param array $query {
 	 *     Which tag name to find, having which class.
 	 *
 	 *     @type string|null $tag_name     Which tag to find, or `null` for "any tag."
@@ -1341,8 +1341,10 @@ class WP_HTML_Tag_Processor {
 	 * }
 	 */
 	private function parse_query( $query ) {
-		if ( null !== $query && $query === $this->last_query ) {
-			return;
+		if ( null !== $query ) {
+			if ( ! is_array( $query ) || $query === $this->last_query ) {
+				return;
+			}
 		}
 
 		$this->last_query          = $query;
@@ -1350,23 +1352,12 @@ class WP_HTML_Tag_Processor {
 		$this->sought_class_name   = null;
 		$this->sought_match_offset = 1;
 
-		// A single string value means "find the tag of this name".
-		if ( is_string( $query ) ) {
-			$this->sought_tag_name = $query;
-			return;
+		if ( isset( $query['tag'] ) && is_string( $query['tag'] ) ) {
+			$this->sought_tag_name = $query['tag'];
 		}
 
-		// If not using the string interface we have to pass an associative array.
-		if ( ! is_array( $query ) ) {
-			return;
-		}
-
-		if ( isset( $query['tag_name'] ) && is_string( $query['tag_name'] ) ) {
-			$this->sought_tag_name = $query['tag_name'];
-		}
-
-		if ( isset( $query['class_name'] ) && is_string( $query['class_name'] ) ) {
-			$this->sought_class_name = $query['class_name'];
+		if ( isset( $query['class'] ) && is_string( $query['class'] ) ) {
+			$this->sought_class_name = $query['class'];
 		}
 
 		if ( isset( $query['match_offset'] ) && is_int( $query['match_offset'] ) && 0 < $query['match_offset'] ) {

--- a/lib/experimental/html/class-wp-html-tag-processor.php
+++ b/lib/experimental/html/class-wp-html-tag-processor.php
@@ -1342,10 +1342,8 @@ class WP_HTML_Tag_Processor {
 	 * }
 	 */
 	private function parse_query( $query ) {
-		if ( null !== $query ) {
-			if ( ! is_array( $query ) || $query === $this->last_query ) {
-				return;
-			}
+		if ( null !== $query && $query === $this->last_query ) {
+			return;
 		}
 
 		$this->last_query          = $query;

--- a/lib/experimental/html/class-wp-html-tag-processor.php
+++ b/lib/experimental/html/class-wp-html-tag-processor.php
@@ -60,11 +60,11 @@
  *     $tags->next();
  * ```
  *
- * | Goal                                                      | Query                                                                      |
- * |-----------------------------------------------------------|----------------------------------------------------------------------------|
- * | Find any tag.                                             | `$tags->next();`                                                       |
- * | Find next image tag.                                      | `$tags->next( [ 'tag' => 'img' ] );`                              |
- * | Find next tag containing the `fullwidth` CSS class.       | `$tags->next( [ 'class' => 'fullwidth' ] );`                      |
+ * | Goal                                                      | Query                                                        |
+ * |-----------------------------------------------------------|--------------------------------------------------------------|
+ * | Find any tag.                                             | `$tags->next();`                                             |
+ * | Find next image tag.                                      | `$tags->next( [ 'tag' => 'img' ] );`                         |
+ * | Find next tag containing the `fullwidth` CSS class.       | `$tags->next( [ 'class' => 'fullwidth' ] );`                 |
  * | Find next image tag containing the `fullwidth` CSS class. | `$tags->next( [ 'tag' => 'img', 'class' => 'fullwidth' ] );` |
  *
  * If a tag was found meeting your criteria then `next()`

--- a/lib/experimental/html/class-wp-html-tag-processor.php
+++ b/lib/experimental/html/class-wp-html-tag-processor.php
@@ -42,7 +42,7 @@
  * Example:
  * ```php
  *     $tags = new WP_HTML_Tag_Processor( $html );
- *     if ( $tags->next( [ 'tag_name' => 'option' ] ) ) {
+ *     if ( $tags->next( [ 'tag' => 'option' ] ) ) {
  *         $tags->set_attribute( 'selected', true );
  *     }
  * ```
@@ -63,9 +63,9 @@
  * | Goal                                                      | Query                                                                      |
  * |-----------------------------------------------------------|----------------------------------------------------------------------------|
  * | Find any tag.                                             | `$tags->next();`                                                       |
- * | Find next image tag.                                      | `$tags->next( [ 'tag_name' => 'img' ] );`                              |
- * | Find next tag containing the `fullwidth` CSS class.       | `$tags->next( [ 'class_name' => 'fullwidth' ] );`                      |
- * | Find next image tag containing the `fullwidth` CSS class. | `$tags->next( [ 'tag_name' => 'img', 'class_name' => 'fullwidth' ] );` |
+ * | Find next image tag.                                      | `$tags->next( [ 'tag' => 'img' ] );`                              |
+ * | Find next tag containing the `fullwidth` CSS class.       | `$tags->next( [ 'class' => 'fullwidth' ] );`                      |
+ * | Find next image tag containing the `fullwidth` CSS class. | `$tags->next( [ 'tag' => 'img', 'class' => 'fullwidth' ] );` |
  *
  * If a tag was found meeting your criteria then `next()`
  * will return `true` and you can proceed to modify it. If it
@@ -203,7 +203,7 @@ class WP_HTML_Tag_Processor {
 	 * @since 6.2.0
 	 * @var string|null
 	 */
-	private $sought_tag_name;
+	private $sought_tag;
 
 	/**
 	 * The CSS class name this processor currently scans for.
@@ -211,7 +211,7 @@ class WP_HTML_Tag_Processor {
 	 * @since 6.2.0
 	 * @var string|null
 	 */
-	private $sought_class_name;
+	private $sought_class;
 
 	/**
 	 * The match offset this processor currently scans for.
@@ -259,7 +259,7 @@ class WP_HTML_Tag_Processor {
 	 * @since 6.2.0
 	 * @var ?int
 	 */
-	private $tag_name_starts_at;
+	private $tag_starts_at;
 
 	/**
 	 * Byte length of current tag name.
@@ -274,7 +274,7 @@ class WP_HTML_Tag_Processor {
 	 * @since 6.2.0
 	 * @var ?int
 	 */
-	private $tag_name_length;
+	private $tag_length;
 
 	/**
 	 * Lazily-built index of attributes found within an HTML tag, keyed by the attribute name.
@@ -321,8 +321,8 @@ class WP_HTML_Tag_Processor {
 	 *     // Add the `WP-block-group` class, remove the `WP-group` class.
 	 *     $class_changes = [
 	 *         // Indexed by a comparable class name
-	 *         'wp-block-group' => new WP_Class_Name_Operation( 'WP-block-group', WP_Class_Name_Operation::ADD ),
-	 *         'wp-group'       => new WP_Class_Name_Operation( 'WP-group', WP_Class_Name_Operation::REMOVE )
+	 *         'wp-block-group' => new WP_class_Operation( 'WP-block-group', WP_class_Operation::ADD ),
+	 *         'wp-group'       => new WP_class_Operation( 'WP-group', WP_class_Operation::REMOVE )
 	 *     ];
 	 * </code>
 	 *
@@ -384,11 +384,11 @@ class WP_HTML_Tag_Processor {
 	 * @param array|string $query {
 	 *     Which tag name to find, having which class, etc.
 	 *
-	 *     @type string|null $tag_name     Which tag to find, or `null` for "any tag."
+	 *     @type string|null $tag     Which tag to find, or `null` for "any tag."
 	 *     @type int|null    $match_offset Find the Nth tag matching all search criteria.
 	 *                                     0 for "first" tag, 2 for "third," etc.
 	 *                                     Defaults to first tag.
-	 *     @type string|null $class_name   Tag must contain this whole class name to match.
+	 *     @type string|null $class   Tag must contain this whole class name to match.
 	 * }
 	 * @return boolean Whether a tag was matched.
 	 */
@@ -415,14 +415,14 @@ class WP_HTML_Tag_Processor {
 			}
 
 			// Avoid copying the tag name string when possible.
-			$t = $this->html[ $this->tag_name_starts_at ];
+			$t = $this->html[ $this->tag_starts_at ];
 			if ( 's' === $t || 'S' === $t || 't' === $t || 'T' === $t ) {
-				$tag_name = $this->get_tag();
+				$tag = $this->get_tag();
 
-				if ( 'SCRIPT' === $tag_name ) {
+				if ( 'SCRIPT' === $tag ) {
 					$this->skip_script_data();
-				} elseif ( 'TEXTAREA' === $tag_name || 'TITLE' === $tag_name ) {
-					$this->skip_rcdata( $tag_name );
+				} elseif ( 'TEXTAREA' === $tag || 'TITLE' === $tag ) {
+					$this->skip_rcdata( $tag );
 				}
 			}
 		} while ( $already_found < $this->sought_match_offset );
@@ -435,13 +435,13 @@ class WP_HTML_Tag_Processor {
 	 * tag closer is found.
 	 *
 	 * @see https://html.spec.whatwg.org/multipage/parsing.html#rcdata-state
-	 * @param string $tag_name – the lowercase tag name which will close the RCDATA region.
+	 * @param string $tag – the lowercase tag name which will close the RCDATA region.
 	 * @since 6.2.0
 	 */
-	private function skip_rcdata( $tag_name ) {
+	private function skip_rcdata( $tag ) {
 		$html       = $this->html;
 		$doc_length = strlen( $html );
-		$tag_length = strlen( $tag_name );
+		$tag_length = strlen( $tag );
 
 		$at = $this->parsed_bytes;
 
@@ -464,7 +464,7 @@ class WP_HTML_Tag_Processor {
 			 * will never be a match.
 			 */
 			for ( $i = 0; $i < $tag_length; $i++ ) {
-				$tag_char  = $tag_name[ $i ];
+				$tag_char  = $tag[ $i ];
 				$html_char = $html[ $at + $i ];
 
 				if ( $html_char !== $tag_char && strtoupper( $html_char ) !== $tag_char ) {
@@ -644,12 +644,13 @@ class WP_HTML_Tag_Processor {
 			 * * https://html.spec.whatwg.org/multipage/parsing.html#data-state
 			 * * https://html.spec.whatwg.org/multipage/parsing.html#tag-open-state
 			 */
-			$tag_name_prefix_length = strspn( $html, 'abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ', $at + 1 );
-			if ( $tag_name_prefix_length > 0 ) {
+			$tag_prefix_length = strspn( $html, 'abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ', $at + 1 );
+			if ( $tag_prefix_length > 0 ) {
 				++$at;
-				$this->tag_name_length    = $tag_name_prefix_length + strcspn( $html, " \t\f\r\n/>", $at + $tag_name_prefix_length );
-				$this->tag_name_starts_at = $at;
-				$this->parsed_bytes       = $at + $this->tag_name_length;
+				$this->tag_length    = $tag_prefix_length + strcspn( $html, " \t\f\r\n/>", $at + $tag_prefix_length );
+				$this->tag_starts_at = $at;
+				$this->parsed_bytes  = $at + $this->tag_length;
+
 				return true;
 			}
 
@@ -841,10 +842,10 @@ class WP_HTML_Tag_Processor {
 	 * @return void
 	 */
 	private function after_tag() {
-		$this->class_name_updates_to_attributes_updates();
+		$this->class_updates_to_attributes_updates();
 		$this->apply_attributes_updates();
-		$this->tag_name_starts_at = null;
-		$this->tag_name_length    = null;
+		$this->tag_starts_at = null;
+		$this->tag_length    = null;
 		$this->attributes         = array();
 	}
 
@@ -861,7 +862,7 @@ class WP_HTML_Tag_Processor {
 	 * @see $classname_updates
 	 * @see $attribute_updates
 	 */
-	private function class_name_updates_to_attributes_updates() {
+	private function class_updates_to_attributes_updates() {
 		if ( count( $this->classname_updates ) === 0 || isset( $this->attribute_updates['class'] ) ) {
 			$this->classname_updates = array();
 			return;
@@ -1027,7 +1028,7 @@ class WP_HTML_Tag_Processor {
 	 * Example:
 	 * <code>
 	 *     $p = new WP_HTML_Tag_Processor( '<div enabled class="test" data-test-id="14">Test</div>' );
-	 *     $p->next( [ 'class_name' => 'test' ] ) === true;
+	 *     $p->next( [ 'class' => 'test' ] ) === true;
 	 *     $p->get_attribute( 'data-test-id' ) === '14';
 	 *     $p->get_attribute( 'enabled' ) === true;
 	 *     $p->get_attribute( 'aria-label' ) === null;
@@ -1043,7 +1044,7 @@ class WP_HTML_Tag_Processor {
 	 *                          Boolean attributes return `true`.
 	 */
 	public function get_attribute( $name ) {
-		if ( null === $this->tag_name_starts_at ) {
+		if ( null === $this->tag_starts_at ) {
 			return null;
 		}
 
@@ -1081,13 +1082,13 @@ class WP_HTML_Tag_Processor {
 	 * @return string|null Name of current tag in input HTML, or `null` if none currently open.
 	 */
 	public function get_tag() {
-		if ( null === $this->tag_name_starts_at ) {
+		if ( null === $this->tag_starts_at ) {
 			return null;
 		}
 
-		$tag_name = substr( $this->html, $this->tag_name_starts_at, $this->tag_name_length );
+		$tag = substr( $this->html, $this->tag_starts_at, $this->tag_length );
 
-		return strtoupper( $tag_name );
+		return strtoupper( $tag );
 	}
 
 	/**
@@ -1106,7 +1107,7 @@ class WP_HTML_Tag_Processor {
 	 * @throws Exception When WP_DEBUG is true and the attribute name is invalid.
 	 */
 	public function set_attribute( $name, $value ) {
-		if ( null === $this->tag_name_starts_at ) {
+		if ( null === $this->tag_starts_at ) {
 			return;
 		}
 
@@ -1202,8 +1203,8 @@ class WP_HTML_Tag_Processor {
 			 *    Result: <div id="new"/>
 			 */
 			$this->attribute_updates[ $name ] = new WP_HTML_Text_Replacement(
-				$this->tag_name_starts_at + $this->tag_name_length,
-				$this->tag_name_starts_at + $this->tag_name_length,
+				$this->tag_starts_at + $this->tag_length,
+				$this->tag_starts_at + $this->tag_length,
 				' ' . $updated_attribute
 			);
 		}
@@ -1244,11 +1245,11 @@ class WP_HTML_Tag_Processor {
 	 *
 	 * @since 6.2.0
 	 *
-	 * @param string $class_name The class name to add.
+	 * @param string $class The class name to add.
 	 */
-	public function add_class( $class_name ) {
-		if ( null !== $this->tag_name_starts_at ) {
-			$this->classname_updates[ $class_name ] = self::ADD_CLASS;
+	public function add_class( $class ) {
+		if ( null !== $this->tag_starts_at ) {
+			$this->classname_updates[ $class ] = self::ADD_CLASS;
 		}
 	}
 
@@ -1257,11 +1258,11 @@ class WP_HTML_Tag_Processor {
 	 *
 	 * @since 6.2.0
 	 *
-	 * @param string $class_name The class name to remove.
+	 * @param string $class The class name to remove.
 	 */
-	public function remove_class( $class_name ) {
-		if ( null !== $this->tag_name_starts_at ) {
-			$this->classname_updates[ $class_name ] = self::REMOVE_CLASS;
+	public function remove_class( $class ) {
+		if ( null !== $this->tag_starts_at ) {
+			$this->classname_updates[ $class ] = self::REMOVE_CLASS;
 		}
 	}
 
@@ -1300,26 +1301,26 @@ class WP_HTML_Tag_Processor {
 		 */
 
 		// Find tag name's end in the updated markup.
-		$markup_updated_up_to_a_tag_name_end = $this->updated_html . substr( $this->html, $this->updated_bytes, $this->tag_name_starts_at + $this->tag_name_length - $this->updated_bytes );
-		$updated_tag_name_ends_at            = strlen( $markup_updated_up_to_a_tag_name_end );
-		$updated_tag_name_starts_at          = $updated_tag_name_ends_at - $this->tag_name_length;
+		$markup_updated_up_to_a_tag_end = $this->updated_html . substr( $this->html, $this->updated_bytes, $this->tag_starts_at + $this->tag_length - $this->updated_bytes );
+		$updated_tag_ends_at            = strlen( $markup_updated_up_to_a_tag_end );
+		$updated_tag_starts_at          = $updated_tag_ends_at - $this->tag_length;
 
 		// Apply attributes updates.
-		$this->updated_html  = $markup_updated_up_to_a_tag_name_end;
-		$this->updated_bytes = $this->tag_name_starts_at + $this->tag_name_length;
-		$this->class_name_updates_to_attributes_updates();
+		$this->updated_html  = $markup_updated_up_to_a_tag_end;
+		$this->updated_bytes = $this->tag_starts_at + $this->tag_length;
+		$this->class_updates_to_attributes_updates();
 		$this->apply_attributes_updates();
 
 		// Replace $this->html with the updated markup.
 		$this->html = $this->updated_html . substr( $this->html, $this->updated_bytes );
 
 		// Rewind this processor to the tag name's end.
-		$this->tag_name_starts_at = $updated_tag_name_starts_at;
-		$this->parsed_bytes       = $updated_tag_name_ends_at;
+		$this->tag_starts_at = $updated_tag_starts_at;
+		$this->parsed_bytes       = $updated_tag_ends_at;
 
 		// Restore the previous version of the updated_html as we are not finished with the current_tag yet.
-		$this->updated_html  = $markup_updated_up_to_a_tag_name_end;
-		$this->updated_bytes = $updated_tag_name_ends_at;
+		$this->updated_html  = $markup_updated_up_to_a_tag_end;
+		$this->updated_bytes = $updated_tag_ends_at;
 
 		// Parse the attributes in the updated markup.
 		$this->attributes = array();
@@ -1336,8 +1337,8 @@ class WP_HTML_Tag_Processor {
 	 * @param array $query {
 	 *     Which tag name to find, having which class.
 	 *
-	 *     @type string|null $tag_name     Which tag to find, or `null` for "any tag."
-	 *     @type string|null $class_name   Tag must contain this class name to match.
+	 *     @type string|null $tag     Which tag to find, or `null` for "any tag."
+	 *     @type string|null $class   Tag must contain this class name to match.
 	 * }
 	 */
 	private function parse_query( $query ) {
@@ -1348,16 +1349,16 @@ class WP_HTML_Tag_Processor {
 		}
 
 		$this->last_query          = $query;
-		$this->sought_tag_name     = null;
-		$this->sought_class_name   = null;
+		$this->sought_tag     = null;
+		$this->sought_class   = null;
 		$this->sought_match_offset = 1;
 
 		if ( isset( $query['tag'] ) && is_string( $query['tag'] ) ) {
-			$this->sought_tag_name = $query['tag'];
+			$this->sought_tag = $query['tag'];
 		}
 
 		if ( isset( $query['class'] ) && is_string( $query['class'] ) ) {
-			$this->sought_class_name = $query['class'];
+			$this->sought_class = $query['class'];
 		}
 
 		if ( isset( $query['match_offset'] ) && is_int( $query['match_offset'] ) && 0 < $query['match_offset'] ) {
@@ -1375,12 +1376,12 @@ class WP_HTML_Tag_Processor {
 	 */
 	private function matches() {
 		// Do we match a case-insensitive HTML tag name?
-		if ( null !== $this->sought_tag_name ) {
+		if ( null !== $this->sought_tag ) {
 			/*
 			 * String (byte) length lookup is fast. If they aren't the
 			 * same length then they can't be the same string values.
 			 */
-			if ( strlen( $this->sought_tag_name ) !== $this->tag_name_length ) {
+			if ( strlen( $this->sought_tag ) !== $this->tag_length ) {
 				return false;
 			}
 
@@ -1392,9 +1393,9 @@ class WP_HTML_Tag_Processor {
 			 * most of the time this runs we shouldn't expect to
 			 * actually run the case-folding comparison.
 			 */
-			for ( $i = 0; $i < $this->tag_name_length; $i++ ) {
-				$html_char = $this->html[ $this->tag_name_starts_at + $i ];
-				$tag_char  = $this->sought_tag_name[ $i ];
+			for ( $i = 0; $i < $this->tag_length; $i++ ) {
+				$html_char = $this->html[ $this->tag_starts_at + $i ];
+				$tag_char  = $this->sought_tag[ $i ];
 
 				if ( $html_char !== $tag_char && strtoupper( $html_char ) !== $tag_char ) {
 					return false;
@@ -1402,14 +1403,14 @@ class WP_HTML_Tag_Processor {
 			}
 		}
 
-		$needs_class_name = null !== $this->sought_class_name;
+		$needs_class = null !== $this->sought_class;
 
-		if ( $needs_class_name && ! isset( $this->attributes['class'] ) ) {
+		if ( $needs_class && ! isset( $this->attributes['class'] ) ) {
 			return false;
 		}
 
 		// Do we match a byte-for-byte (case-sensitive and encoding-form-sensitive) class name?
-		if ( $needs_class_name ) {
+		if ( $needs_class ) {
 			$class_start = $this->attributes['class']->value_starts_at;
 			$class_end   = $class_start + $this->attributes['class']->value_length;
 			$class_at    = $class_start;
@@ -1427,7 +1428,7 @@ class WP_HTML_Tag_Processor {
 			 */
 			while (
 				// phpcs:ignore WordPress.CodeAnalysis.AssignmentInCondition.FoundInWhileCondition
-				false !== ( $class_at = strpos( $this->html, $this->sought_class_name, $class_at ) ) &&
+				false !== ( $class_at = strpos( $this->html, $this->sought_class, $class_at ) ) &&
 				$class_at < $class_end
 			) {
 				/*
@@ -1439,7 +1440,7 @@ class WP_HTML_Tag_Processor {
 					$character = $this->html[ $class_at - 1 ];
 
 					if ( ' ' !== $character && "\t" !== $character && "\f" !== $character && "\r" !== $character && "\n" !== $character ) {
-						$class_at += strlen( $this->sought_class_name );
+						$class_at += strlen( $this->sought_class );
 						continue;
 					}
 				}
@@ -1449,11 +1450,11 @@ class WP_HTML_Tag_Processor {
 				 * can end at the very end of the string value, otherwise we have
 				 * to end at a place where the next character is whitespace.
 				 */
-				if ( $class_at + strlen( $this->sought_class_name ) < $class_end ) {
-					$character = $this->html[ $class_at + strlen( $this->sought_class_name ) ];
+				if ( $class_at + strlen( $this->sought_class ) < $class_end ) {
+					$character = $this->html[ $class_at + strlen( $this->sought_class ) ];
 
 					if ( ' ' !== $character && "\t" !== $character && "\f" !== $character && "\r" !== $character && "\n" !== $character ) {
-						$class_at += strlen( $this->sought_class_name );
+						$class_at += strlen( $this->sought_class );
 						continue;
 					}
 				}

--- a/phpunit/html/wp-html-tag-processor-standalone-test.php
+++ b/phpunit/html/wp-html-tag-processor-standalone-test.php
@@ -460,7 +460,7 @@ class WP_HTML_Tag_Processor_Standalone_Test extends WP_UnitTestCase {
 	 * @covers add_class
 	 * @covers get_updated_html
 	 */
-	public function test_calling_add_class_twice_creates_a_class_attribute_with_both_classs_when_there_is_no_class_attribute() {
+	public function test_calling_add_class_twice_creates_a_class_attribute_with_both_class_names_when_there_is_no_class_attribute() {
 		$p = new WP_HTML_Tag_Processor( self::HTML_SIMPLE );
 		$p->next();
 		$p->add_class( 'foo-class' );
@@ -487,7 +487,7 @@ class WP_HTML_Tag_Processor_Standalone_Test extends WP_UnitTestCase {
 	 * @covers add_class
 	 * @covers get_updated_html
 	 */
-	public function test_add_class_appends_classs_to_the_existing_class_attribute_when_one_already_exists() {
+	public function test_add_class_appends_class_names_to_the_existing_class_attribute_when_one_already_exists() {
 		$p = new WP_HTML_Tag_Processor( self::HTML_WITH_CLASSES );
 		$p->next();
 		$p->add_class( 'foo-class' );
@@ -520,7 +520,7 @@ class WP_HTML_Tag_Processor_Standalone_Test extends WP_UnitTestCase {
 	 * @covers remove_class
 	 * @covers get_updated_html
 	 */
-	public function test_calling_remove_class_with_all_listed_classs_removes_the_existing_class_attribute_from_the_markup() {
+	public function test_calling_remove_class_with_all_listed_class_names_removes_the_existing_class_attribute_from_the_markup() {
 		$p = new WP_HTML_Tag_Processor( self::HTML_WITH_CLASSES );
 		$p->next();
 		$p->remove_class( 'main' );
@@ -537,7 +537,7 @@ class WP_HTML_Tag_Processor_Standalone_Test extends WP_UnitTestCase {
 	 * @covers add_class
 	 * @covers get_updated_html
 	 */
-	public function test_add_class_does_not_add_duplicate_classs() {
+	public function test_add_class_does_not_add_duplicate_class_names() {
 		$p = new WP_HTML_Tag_Processor( self::HTML_WITH_CLASSES );
 		$p->next();
 		$p->add_class( 'with-border' );
@@ -553,7 +553,7 @@ class WP_HTML_Tag_Processor_Standalone_Test extends WP_UnitTestCase {
 	 * @covers add_class
 	 * @covers get_updated_html
 	 */
-	public function test_add_class_preserves_class_order_when_a_duplicate_class_is_added() {
+	public function test_add_class_preserves_class_name_order_when_a_duplicate_class_name_is_added() {
 		$p = new WP_HTML_Tag_Processor( self::HTML_WITH_CLASSES );
 		$p->next();
 		$p->add_class( 'main' );

--- a/phpunit/html/wp-html-tag-processor-standalone-test.php
+++ b/phpunit/html/wp-html-tag-processor-standalone-test.php
@@ -747,7 +747,7 @@ HTML;
 			'Querying an existing tag did not return true'
 		);
 		$p->remove_attribute( 'class' );
-		$this->assertFalse( $p->next( 'non-existent' ), 'Querying a non-existing tag did not return false' );
+		$this->assertFalse( $p->next( array( 'tag' => 'non-existent' ) ), 'Querying a non-existing tag did not return false' );
 		$p->set_attribute( 'class', 'test' );
 		$this->assertSame( $expected_output, $p->get_updated_html(), 'Calling get_updated_html after updating the attributes did not return the expected HTML' );
 	}

--- a/phpunit/html/wp-html-tag-processor-standalone-test.php
+++ b/phpunit/html/wp-html-tag-processor-standalone-test.php
@@ -50,24 +50,24 @@ class WP_HTML_Tag_Processor_Standalone_Test extends WP_UnitTestCase {
 	/**
 	 * @ticket 56299
 	 *
-	 * @covers next_tag
+	 * @covers next
 	 * @covers get_tag
 	 */
 	public function test_get_tag_returns_null_when_not_in_open_tag() {
 		$p = new WP_HTML_Tag_Processor( '<div>Test</div>' );
-		$this->assertFalse( $p->next_tag( 'p' ), 'Querying a non-existing tag did not return false' );
+		$this->assertFalse( $p->next( array( 'tag' => 'p' ) ), 'Querying a non-existing tag did not return false' );
 		$this->assertNull( $p->get_tag(), 'Accessing a non-existing tag did not return null' );
 	}
 
 	/**
 	 * @ticket 56299
 	 *
-	 * @covers next_tag
+	 * @covers next
 	 * @covers get_tag
 	 */
-	public function test_get_tag_returns_open_tag_name() {
+	public function test_get_tag_returns_open_tag() {
 		$p = new WP_HTML_Tag_Processor( '<div>Test</div>' );
-		$this->assertTrue( $p->next_tag( 'div' ), 'Querying an existing tag did not return true' );
+		$this->assertTrue( $p->next( array( 'tag' => 'div' ) ), 'Querying an existing tag did not return true' );
 		$this->assertSame( 'DIV', $p->get_tag(), 'Accessing an existing tag name did not return "div"' );
 	}
 
@@ -84,60 +84,60 @@ class WP_HTML_Tag_Processor_Standalone_Test extends WP_UnitTestCase {
 	/**
 	 * @ticket 56299
 	 *
-	 * @covers next_tag
+	 * @covers next
 	 * @covers get_attribute
 	 */
 	public function test_get_attribute_returns_null_when_not_in_open_tag() {
 		$p = new WP_HTML_Tag_Processor( '<div class="test">Test</div>' );
-		$this->assertFalse( $p->next_tag( 'p' ), 'Querying a non-existing tag did not return false' );
+		$this->assertFalse( $p->next( array( 'tag' => 'p' ) ), 'Querying a non-existing tag did not return false' );
 		$this->assertNull( $p->get_attribute( 'class' ), 'Accessing an attribute of a non-existing tag did not return null' );
 	}
 
 	/**
 	 * @ticket 56299
 	 *
-	 * @covers next_tag
+	 * @covers next
 	 * @covers get_attribute
 	 */
 	public function test_get_attribute_returns_null_when_attribute_missing() {
 		$p = new WP_HTML_Tag_Processor( '<div class="test">Test</div>' );
-		$this->assertTrue( $p->next_tag( 'div' ), 'Querying an existing tag did not return true' );
+		$this->assertTrue( $p->next( array( 'tag' => 'div' ) ), 'Querying an existing tag did not return true' );
 		$this->assertNull( $p->get_attribute( 'test-id' ), 'Accessing a non-existing attribute did not return null' );
 	}
 
 	/**
 	 * @ticket 56299
 	 *
-	 * @covers next_tag
+	 * @covers next
 	 * @covers get_attribute
 	 */
 	public function test_get_attribute_returns_attribute_value() {
 		$p = new WP_HTML_Tag_Processor( '<div class="test">Test</div>' );
-		$this->assertTrue( $p->next_tag( 'div' ), 'Querying an existing tag did not return true' );
+		$this->assertTrue( $p->next( array( 'tag' => 'div' ) ), 'Querying an existing tag did not return true' );
 		$this->assertSame( 'test', $p->get_attribute( 'class' ), 'Accessing a class="test" attribute value did not return "test"' );
 	}
 
 	/**
 	 * @ticket 56299
 	 *
-	 * @covers next_tag
+	 * @covers next
 	 * @covers get_attribute
 	 */
 	public function test_get_attribute_returns_true_for_boolean_attribute() {
 		$p = new WP_HTML_Tag_Processor( '<div enabled class="test">Test</div>' );
-		$this->assertTrue( $p->next_tag( array( 'class_name' => 'test' ) ), 'Querying an existing tag did not return true' );
+		$this->assertTrue( $p->next( array( 'class' => 'test' ) ), 'Querying an existing tag did not return true' );
 		$this->assertTrue( $p->get_attribute( 'enabled' ), 'Accessing a boolean "enabled" attribute value did not return true' );
 	}
 
 	/**
 	 * @ticket 56299
 	 *
-	 * @covers next_tag
+	 * @covers next
 	 * @covers get_attribute
 	 */
 	public function test_get_attribute_returns_string_for_truthy_attributes() {
 		$p = new WP_HTML_Tag_Processor( '<div enabled=enabled checked=1 hidden="true" class="test">Test</div>' );
-		$this->assertTrue( $p->next_tag( array() ), 'Querying an existing tag did not return true' );
+		$this->assertTrue( $p->next( array() ), 'Querying an existing tag did not return true' );
 		$this->assertSame( 'enabled', $p->get_attribute( 'enabled' ), 'Accessing a boolean "enabled" attribute value did not return true' );
 		$this->assertSame( '1', $p->get_attribute( 'checked' ), 'Accessing a checked=1 attribute value did not return "1"' );
 		$this->assertSame( 'true', $p->get_attribute( 'hidden' ), 'Accessing a hidden="true" attribute value did not return "true"' );
@@ -150,19 +150,19 @@ class WP_HTML_Tag_Processor_Standalone_Test extends WP_UnitTestCase {
 	 */
 	public function test_get_attribute_decodes_html_character_references() {
 		$p = new WP_HTML_Tag_Processor( '<div id="the &quot;grande&quot; is &lt; &#x033;&#50;oz&dagger;"></div>' );
-		$p->next_tag();
+		$p->next();
 		$this->assertSame( 'the "grande" is < 32oz†', $p->get_attribute( 'id' ), 'HTML Attribute value was returned without decoding character references' );
 	}
 
 	/**
 	 * @ticket 56299
 	 *
-	 * @covers next_tag
+	 * @covers next
 	 * @covers get_attribute
 	 */
 	public function test_attributes_parser_treats_slash_as_attribute_separator() {
 		$p = new WP_HTML_Tag_Processor( '<div a/b/c/d/e="test">Test</div>' );
-		$this->assertTrue( $p->next_tag( array() ), 'Querying an existing tag did not return true' );
+		$this->assertTrue( $p->next( array() ), 'Querying an existing tag did not return true' );
 		$this->assertTrue( $p->get_attribute( 'a' ), 'Accessing an existing attribute did not return true' );
 		$this->assertTrue( $p->get_attribute( 'b' ), 'Accessing an existing attribute did not return true' );
 		$this->assertTrue( $p->get_attribute( 'c' ), 'Accessing an existing attribute did not return true' );
@@ -197,10 +197,10 @@ class WP_HTML_Tag_Processor_Standalone_Test extends WP_UnitTestCase {
 	 */
 	public function test_get_updated_html_applies_the_updates_so_far_and_keeps_the_processor_on_the_current_tag() {
 		$p = new WP_HTML_Tag_Processor( '<hr id="remove" /><div enabled class="test">Test</div><span id="span-id"></span>' );
-		$p->next_tag();
+		$p->next();
 		$p->remove_attribute( 'id' );
 
-		$p->next_tag();
+		$p->next();
 		$p->set_attribute( 'id', 'div-id-1' );
 		$p->add_class( 'new_class_1' );
 		$this->assertSame(
@@ -217,7 +217,7 @@ class WP_HTML_Tag_Processor_Standalone_Test extends WP_UnitTestCase {
 			'Calling get_updated_html after updating the attributes of the second tag for the second time returned different HTML than expected'
 		);
 
-		$p->next_tag();
+		$p->next();
 		$p->remove_attribute( 'id' );
 		$this->assertSame(
 			'<hr  /><div id="div-id-2" enabled class="test new_class_1 new_class_2">Test</div><span ></span>',
@@ -239,33 +239,33 @@ class WP_HTML_Tag_Processor_Standalone_Test extends WP_UnitTestCase {
 	/**
 	 * @ticket 56299
 	 *
-	 * @covers next_tag
+	 * @covers next
 	 */
-	public function test_next_tag_with_no_arguments_should_find_the_next_existing_tag() {
+	public function test_next_with_no_arguments_should_find_the_next_existing_tag() {
 		$p = new WP_HTML_Tag_Processor( self::HTML_SIMPLE );
-		$this->assertTrue( $p->next_tag(), 'Querying an existing tag did not return true' );
+		$this->assertTrue( $p->next(), 'Querying an existing tag did not return true' );
 	}
 
 	/**
 	 * @ticket 56299
 	 *
-	 * @covers next_tag
+	 * @covers next
 	 */
-	public function test_next_tag_should_return_false_for_a_non_existing_tag() {
+	public function test_next_should_return_false_for_a_non_existing_tag() {
 		$p = new WP_HTML_Tag_Processor( self::HTML_SIMPLE );
-		$this->assertFalse( $p->next_tag( 'p' ), 'Querying a non-existing tag did not return false' );
+		$this->assertFalse( $p->next( array( 'tag' => 'p' ) ), 'Querying a non-existing tag did not return false' );
 	}
 
 	/**
 	 * @ticket 56299
 	 *
-	 * @covers next_tag
+	 * @covers next
 	 * @covers get_updated_html
 	 */
 	public function test_set_attribute_on_a_non_existing_tag_does_not_change_the_markup() {
 		$p = new WP_HTML_Tag_Processor( self::HTML_SIMPLE );
-		$this->assertFalse( $p->next_tag( 'p' ), 'Querying a non-existing tag did not return false' );
-		$this->assertFalse( $p->next_tag( 'div' ), 'Querying a non-existing tag did not return false' );
+		$this->assertFalse( $p->next( array( 'tag' => 'p' ) ), 'Querying a non-existing tag did not return false' );
+		$this->assertFalse( $p->next( array( 'tag' => 'div' ) ), 'Querying a non-existing tag did not return false' );
 		$p->set_attribute( 'id', 'primary' );
 		$this->assertSame(
 			self::HTML_SIMPLE,
@@ -279,7 +279,7 @@ class WP_HTML_Tag_Processor_Standalone_Test extends WP_UnitTestCase {
 	 *
 	 * <code>
 	 *     $p = new WP_HTML_Tag_Processor( '<div class="header"></div>' );
-	 *     $p->next_tag();
+	 *     $p->next();
 	 *     $p->set_attribute('class', '" onclick="alert');
 	 *     echo $p;
 	 *     // <div class="" onclick="alert"></div>
@@ -298,7 +298,7 @@ class WP_HTML_Tag_Processor_Standalone_Test extends WP_UnitTestCase {
 	 */
 	public function test_set_attribute_prevents_xss( $attribute_value ) {
 		$p = new WP_HTML_Tag_Processor( '<div></div>' );
-		$p->next_tag();
+		$p->next();
 		$p->set_attribute( 'test', $attribute_value );
 
 		/*
@@ -344,7 +344,7 @@ class WP_HTML_Tag_Processor_Standalone_Test extends WP_UnitTestCase {
 	 */
 	public function test_set_attribute_with_a_non_existing_attribute_adds_a_new_attribute_to_the_markup() {
 		$p = new WP_HTML_Tag_Processor( self::HTML_SIMPLE );
-		$p->next_tag();
+		$p->next();
 		$p->set_attribute( 'test-attribute', 'test-value' );
 		$this->assertSame( '<div test-attribute="test-value" id="first"><span id="second">Text</span></div>', $p->get_updated_html() );
 	}
@@ -360,7 +360,7 @@ class WP_HTML_Tag_Processor_Standalone_Test extends WP_UnitTestCase {
 	 */
 	public function test_update_first_when_duplicated_attribute() {
 		$p = new WP_HTML_Tag_Processor( '<div id="update-me" id="ignored-id"><span id="second">Text</span></div>' );
-		$p->next_tag();
+		$p->next();
 		$p->set_attribute( 'id', 'updated-id' );
 		$this->assertSame( '<div id="updated-id" id="ignored-id"><span id="second">Text</span></div>', $p->get_updated_html() );
 	}
@@ -373,7 +373,7 @@ class WP_HTML_Tag_Processor_Standalone_Test extends WP_UnitTestCase {
 	 */
 	public function test_set_attribute_with_an_existing_attribute_name_updates_its_value_in_the_markup() {
 		$p = new WP_HTML_Tag_Processor( self::HTML_SIMPLE );
-		$p->next_tag();
+		$p->next();
 		$p->set_attribute( 'id', 'new-id' );
 		$this->assertSame( '<div id="new-id"><span id="second">Text</span></div>', $p->get_updated_html() );
 	}
@@ -384,9 +384,9 @@ class WP_HTML_Tag_Processor_Standalone_Test extends WP_UnitTestCase {
 	 * @covers set_attribute
 	 * @covers get_updated_html
 	 */
-	public function test_next_tag_and_set_attribute_in_a_loop_update_all_tags_in_the_markup() {
+	public function test_next_and_set_attribute_in_a_loop_update_all_tags_in_the_markup() {
 		$p = new WP_HTML_Tag_Processor( self::HTML_SIMPLE );
-		while ( $p->next_tag() ) {
+		while ( $p->next() ) {
 			$p->set_attribute( 'data-foo', 'bar' );
 		}
 
@@ -410,7 +410,7 @@ class WP_HTML_Tag_Processor_Standalone_Test extends WP_UnitTestCase {
 	 */
 	public function test_remove_first_when_duplicated_attribute() {
 		$p = new WP_HTML_Tag_Processor( '<div id="update-me" id="ignored-id"><span id="second">Text</span></div>' );
-		$p->next_tag();
+		$p->next();
 		$p->remove_attribute( 'id' );
 		$this->assertSame( '<div  id="ignored-id"><span id="second">Text</span></div>', $p->get_updated_html() );
 	}
@@ -423,7 +423,7 @@ class WP_HTML_Tag_Processor_Standalone_Test extends WP_UnitTestCase {
 	 */
 	public function test_remove_attribute_with_an_existing_attribute_name_removes_it_from_the_markup() {
 		$p = new WP_HTML_Tag_Processor( self::HTML_SIMPLE );
-		$p->next_tag();
+		$p->next();
 		$p->remove_attribute( 'id' );
 		$this->assertSame( '<div ><span id="second">Text</span></div>', $p->get_updated_html() );
 	}
@@ -436,7 +436,7 @@ class WP_HTML_Tag_Processor_Standalone_Test extends WP_UnitTestCase {
 	 */
 	public function test_remove_attribute_with_a_non_existing_attribute_name_does_not_change_the_markup() {
 		$p = new WP_HTML_Tag_Processor( self::HTML_SIMPLE );
-		$p->next_tag();
+		$p->next();
 		$p->remove_attribute( 'no-such-attribute' );
 		$this->assertSame( self::HTML_SIMPLE, $p->get_updated_html() );
 	}
@@ -449,7 +449,7 @@ class WP_HTML_Tag_Processor_Standalone_Test extends WP_UnitTestCase {
 	 */
 	public function test_add_class_creates_a_class_attribute_when_there_is_none() {
 		$p = new WP_HTML_Tag_Processor( self::HTML_SIMPLE );
-		$p->next_tag();
+		$p->next();
 		$p->add_class( 'foo-class' );
 		$this->assertSame( '<div class="foo-class" id="first"><span id="second">Text</span></div>', $p->get_updated_html() );
 	}
@@ -460,9 +460,9 @@ class WP_HTML_Tag_Processor_Standalone_Test extends WP_UnitTestCase {
 	 * @covers add_class
 	 * @covers get_updated_html
 	 */
-	public function test_calling_add_class_twice_creates_a_class_attribute_with_both_class_names_when_there_is_no_class_attribute() {
+	public function test_calling_add_class_twice_creates_a_class_attribute_with_both_classs_when_there_is_no_class_attribute() {
 		$p = new WP_HTML_Tag_Processor( self::HTML_SIMPLE );
-		$p->next_tag();
+		$p->next();
 		$p->add_class( 'foo-class' );
 		$p->add_class( 'bar-class' );
 		$this->assertSame( '<div class="foo-class bar-class" id="first"><span id="second">Text</span></div>', $p->get_updated_html() );
@@ -476,7 +476,7 @@ class WP_HTML_Tag_Processor_Standalone_Test extends WP_UnitTestCase {
 	 */
 	public function test_remove_class_does_not_change_the_markup_when_there_is_no_class_attribute() {
 		$p = new WP_HTML_Tag_Processor( self::HTML_SIMPLE );
-		$p->next_tag();
+		$p->next();
 		$p->remove_class( 'foo-class' );
 		$this->assertSame( self::HTML_SIMPLE, $p->get_updated_html() );
 	}
@@ -487,9 +487,9 @@ class WP_HTML_Tag_Processor_Standalone_Test extends WP_UnitTestCase {
 	 * @covers add_class
 	 * @covers get_updated_html
 	 */
-	public function test_add_class_appends_class_names_to_the_existing_class_attribute_when_one_already_exists() {
+	public function test_add_class_appends_classs_to_the_existing_class_attribute_when_one_already_exists() {
 		$p = new WP_HTML_Tag_Processor( self::HTML_WITH_CLASSES );
-		$p->next_tag();
+		$p->next();
 		$p->add_class( 'foo-class' );
 		$p->add_class( 'bar-class' );
 		$this->assertSame(
@@ -506,7 +506,7 @@ class WP_HTML_Tag_Processor_Standalone_Test extends WP_UnitTestCase {
 	 */
 	public function test_remove_class_removes_a_single_class_from_the_class_attribute_when_one_exists() {
 		$p = new WP_HTML_Tag_Processor( self::HTML_WITH_CLASSES );
-		$p->next_tag();
+		$p->next();
 		$p->remove_class( 'main' );
 		$this->assertSame(
 			'<div class=" with-border" id="first"><span class="not-main bold with-border" id="second">Text</span></div>',
@@ -520,9 +520,9 @@ class WP_HTML_Tag_Processor_Standalone_Test extends WP_UnitTestCase {
 	 * @covers remove_class
 	 * @covers get_updated_html
 	 */
-	public function test_calling_remove_class_with_all_listed_class_names_removes_the_existing_class_attribute_from_the_markup() {
+	public function test_calling_remove_class_with_all_listed_classs_removes_the_existing_class_attribute_from_the_markup() {
 		$p = new WP_HTML_Tag_Processor( self::HTML_WITH_CLASSES );
-		$p->next_tag();
+		$p->next();
 		$p->remove_class( 'main' );
 		$p->remove_class( 'with-border' );
 		$this->assertSame(
@@ -537,9 +537,9 @@ class WP_HTML_Tag_Processor_Standalone_Test extends WP_UnitTestCase {
 	 * @covers add_class
 	 * @covers get_updated_html
 	 */
-	public function test_add_class_does_not_add_duplicate_class_names() {
+	public function test_add_class_does_not_add_duplicate_classs() {
 		$p = new WP_HTML_Tag_Processor( self::HTML_WITH_CLASSES );
-		$p->next_tag();
+		$p->next();
 		$p->add_class( 'with-border' );
 		$this->assertSame(
 			'<div class="main with-border" id="first"><span class="not-main bold with-border" id="second">Text</span></div>',
@@ -553,9 +553,9 @@ class WP_HTML_Tag_Processor_Standalone_Test extends WP_UnitTestCase {
 	 * @covers add_class
 	 * @covers get_updated_html
 	 */
-	public function test_add_class_preserves_class_name_order_when_a_duplicate_class_name_is_added() {
+	public function test_add_class_preserves_class_order_when_a_duplicate_class_is_added() {
 		$p = new WP_HTML_Tag_Processor( self::HTML_WITH_CLASSES );
-		$p->next_tag();
+		$p->next();
 		$p->add_class( 'main' );
 		$this->assertSame(
 			'<div class="main with-border" id="first"><span class="not-main bold with-border" id="second">Text</span></div>',
@@ -573,7 +573,7 @@ class WP_HTML_Tag_Processor_Standalone_Test extends WP_UnitTestCase {
 		$p = new WP_HTML_Tag_Processor(
 			'<div class="   main   with-border   " id="first"><span class="not-main bold with-border" id="second">Text</span></div>'
 		);
-		$p->next_tag();
+		$p->next();
 		$p->add_class( 'foo-class' );
 		$this->assertSame(
 			'<div class="   main   with-border foo-class" id="first"><span class="not-main bold with-border" id="second">Text</span></div>',
@@ -591,7 +591,7 @@ class WP_HTML_Tag_Processor_Standalone_Test extends WP_UnitTestCase {
 		$p = new WP_HTML_Tag_Processor(
 			'<div class="   main   with-border   " id="first"><span class="not-main bold with-border" id="second">Text</span></div>'
 		);
-		$p->next_tag();
+		$p->next();
 		$p->remove_class( 'with-border' );
 		$this->assertSame(
 			'<div class="   main" id="first"><span class="not-main bold with-border" id="second">Text</span></div>',
@@ -609,7 +609,7 @@ class WP_HTML_Tag_Processor_Standalone_Test extends WP_UnitTestCase {
 		$p = new WP_HTML_Tag_Processor(
 			'<div class="   main   with-border   " id="first"><span class="not-main bold with-border" id="second">Text</span></div>'
 		);
-		$p->next_tag();
+		$p->next();
 		$p->remove_class( 'main' );
 		$p->remove_class( 'with-border' );
 		$this->assertSame(
@@ -632,7 +632,7 @@ class WP_HTML_Tag_Processor_Standalone_Test extends WP_UnitTestCase {
 	 */
 	public function test_set_attribute_takes_priority_over_add_class() {
 		$p = new WP_HTML_Tag_Processor( self::HTML_WITH_CLASSES );
-		$p->next_tag();
+		$p->next();
 		$p->add_class( 'add_class' );
 		$p->set_attribute( 'class', 'set_attribute' );
 		$this->assertSame(
@@ -642,7 +642,7 @@ class WP_HTML_Tag_Processor_Standalone_Test extends WP_UnitTestCase {
 		);
 
 		$p = new WP_HTML_Tag_Processor( self::HTML_WITH_CLASSES );
-		$p->next_tag();
+		$p->next();
 		$p->set_attribute( 'class', 'set_attribute' );
 		$p->add_class( 'add_class' );
 		$this->assertSame(
@@ -709,14 +709,14 @@ HTML;
 HTML;
 
 		$p = new WP_HTML_Tag_Processor( $input );
-		$this->assertTrue( $p->next_tag( 'div' ), 'Querying an existing tag did not return true' );
+		$this->assertTrue( $p->next( array( 'tag' => 'div' ) ), 'Querying an existing tag did not return true' );
 		$p->set_attribute( 'data-details', '{ "key": "value" }' );
 		$p->add_class( 'is-processed' );
 		$this->assertTrue(
-			$p->next_tag(
+			$p->next(
 				array(
-					'tag_name'   => 'div',
-					'class_name' => 'BtnGroup',
+					'tag'   => 'div',
+					'class' => 'BtnGroup',
 				)
 			),
 			'Querying an existing tag did not return true'
@@ -725,10 +725,10 @@ HTML;
 		$p->add_class( 'button-group' );
 		$p->add_class( 'Another-Mixed-Case' );
 		$this->assertTrue(
-			$p->next_tag(
+			$p->next(
 				array(
-					'tag_name'   => 'div',
-					'class_name' => 'BtnGroup',
+					'tag'   => 'div',
+					'class' => 'BtnGroup',
 				)
 			),
 			'Querying an existing tag did not return true'
@@ -737,17 +737,17 @@ HTML;
 		$p->add_class( 'button-group' );
 		$p->add_class( 'Another-Mixed-Case' );
 		$this->assertTrue(
-			$p->next_tag(
+			$p->next(
 				array(
-					'tag_name'     => 'button',
-					'class_name'   => 'btn',
+					'tag'          => 'button',
+					'class'        => 'btn',
 					'match_offset' => 3,
 				)
 			),
 			'Querying an existing tag did not return true'
 		);
 		$p->remove_attribute( 'class' );
-		$this->assertFalse( $p->next_tag( 'non-existent' ), 'Querying a non-existing tag did not return false' );
+		$this->assertFalse( $p->next( 'non-existent' ), 'Querying a non-existing tag did not return false' );
 		$p->set_attribute( 'class', 'test' );
 		$this->assertSame( $expected_output, $p->get_updated_html(), 'Calling get_updated_html after updating the attributes did not return the expected HTML' );
 	}
@@ -763,17 +763,17 @@ HTML;
 		$p = new WP_HTML_Tag_Processor(
 			'<div id=\'first\'><span id=\'second\'>Text</span></div>'
 		);
-		$p->next_tag(
+		$p->next(
 			array(
-				'tag_name' => 'div',
-				'id'       => 'first',
+				'tag' => 'div',
+				'id'  => 'first',
 			)
 		);
 		$p->remove_attribute( 'id' );
-		$p->next_tag(
+		$p->next(
 			array(
-				'tag_name' => 'span',
-				'id'       => 'second',
+				'tag' => 'span',
+				'id'  => 'second',
 			)
 		);
 		$p->set_attribute( 'id', 'single-quote' );
@@ -793,7 +793,7 @@ HTML;
 		$p = new WP_HTML_Tag_Processor(
 			'<form action="/action_page.php"><input type="checkbox" name="vehicle" value="Bike"><label for="vehicle">I have a bike</label></form>'
 		);
-		$p->next_tag( 'input' );
+		$p->next( array( 'tag' => 'input' ) );
 		$p->set_attribute( 'checked', true );
 		$this->assertSame(
 			'<form action="/action_page.php"><input checked type="checkbox" name="vehicle" value="Bike"><label for="vehicle">I have a bike</label></form>',
@@ -811,7 +811,7 @@ HTML;
 		$p = new WP_HTML_Tag_Processor(
 			'<form action="/action_page.php"><input checked type="checkbox" name="vehicle" value="Bike"><label for="vehicle">I have a bike</label></form>'
 		);
-		$p->next_tag( 'input' );
+		$p->next( array( 'tag' => 'input' ) );
 		$p->set_attribute( 'checked', false );
 		$this->assertSame(
 			'<form action="/action_page.php"><input  type="checkbox" name="vehicle" value="Bike"><label for="vehicle">I have a bike</label></form>',
@@ -828,7 +828,7 @@ HTML;
 	public function test_setting_a_missing_attribute_to_false_does_not_change_the_markup() {
 		$html_input = '<form action="/action_page.php"><input type="checkbox" name="vehicle" value="Bike"><label for="vehicle">I have a bike</label></form>';
 		$p          = new WP_HTML_Tag_Processor( $html_input );
-		$p->next_tag( 'input' );
+		$p->next( array( 'tag' => 'input' ) );
 		$p->set_attribute( 'checked', false );
 		$this->assertSame( $html_input, $p->get_updated_html() );
 	}
@@ -843,7 +843,7 @@ HTML;
 		$p = new WP_HTML_Tag_Processor(
 			'<form action="/action_page.php"><input checked type="checkbox" name="vehicle" value="Bike"><label for="vehicle">I have a bike</label></form>'
 		);
-		$p->next_tag( 'input' );
+		$p->next( array( 'tag' => 'input' ) );
 		$p->set_attribute( 'checked', 'checked' );
 		$this->assertSame(
 			'<form action="/action_page.php"><input checked="checked" type="checkbox" name="vehicle" value="Bike"><label for="vehicle">I have a bike</label></form>',
@@ -855,27 +855,27 @@ HTML;
 	 * @ticket 56299
 	 *
 	 * @covers get_tag
-	 * @covers next_tag
+	 * @covers next
 	 */
 	public function test_unclosed_script_tag_should_not_cause_an_infinite_loop() {
 		$p = new WP_HTML_Tag_Processor( '<script>' );
-		$p->next_tag();
+		$p->next();
 		$this->assertSame( 'SCRIPT', $p->get_tag() );
-		$p->next_tag();
+		$p->next();
 	}
 
 	/**
 	 * @ticket 56299
 	 *
-	 * @covers next_tag
+	 * @covers next
 	 *
 	 * @dataProvider data_script_state
 	 */
-	public function test_next_tag_ignores_the_contents_of_a_script_tag( $script_then_div ) {
+	public function test_next_ignores_the_contents_of_a_script_tag( $script_then_div ) {
 		$p = new WP_HTML_Tag_Processor( $script_then_div );
-		$p->next_tag();
+		$p->next();
 		$this->assertSame( 'SCRIPT', $p->get_tag(), 'The first found tag was not "script"' );
-		$p->next_tag();
+		$p->next();
 		$this->assertSame( 'DIV', $p->get_tag(), 'The second found tag was not "div"' );
 	}
 
@@ -944,15 +944,15 @@ HTML;
 	/**
 	 * @ticket 56299
 	 *
-	 * @covers next_tag
+	 * @covers next
 	 *
 	 * @dataProvider data_rcdata_state
 	 */
-	public function test_next_tag_ignores_the_contents_of_a_rcdata_tag( $rcdata_then_div, $rcdata_tag ) {
+	public function test_next_ignores_the_contents_of_a_rcdata_tag( $rcdata_then_div, $rcdata_tag ) {
 		$p = new WP_HTML_Tag_Processor( $rcdata_then_div );
-		$p->next_tag();
+		$p->next();
 		$this->assertSame( $rcdata_tag, $p->get_tag(), "The first found tag was not '$rcdata_tag'" );
-		$p->next_tag();
+		$p->next();
 		$this->assertSame( 'DIV', $p->get_tag(), "The second found tag was not 'div'" );
 	}
 
@@ -1003,7 +1003,7 @@ HTML;
 	/**
 	 * @ticket 56299
 	 *
-	 * @covers next_tag
+	 * @covers next
 	 * @covers set_attribute
 	 * @covers get_updated_html
 	 */
@@ -1011,9 +1011,9 @@ HTML;
 		$p = new WP_HTML_Tag_Processor(
 			'<span>123<p>456</span>789</p>'
 		);
-		$p->next_tag( 'span' );
+		$p->next( array( 'tag' => 'span' ) );
 		$p->set_attribute( 'class', 'span-class' );
-		$p->next_tag( 'p' );
+		$p->next( array( 'tag' => 'p' ) );
 		$p->set_attribute( 'class', 'p-class' );
 		$this->assertSame(
 			'<span class="span-class">123<p class="p-class">456</span>789</p>',
@@ -1024,13 +1024,13 @@ HTML;
 	/**
 	 * @ticket 56299
 	 *
-	 * @covers next_tag
+	 * @covers next
 	 * @covers remove_attribute
 	 * @covers get_updated_html
 	 */
 	public function test_removing_attributes_works_even_in_malformed_html() {
 		$p = new WP_HTML_Tag_Processor( self::HTML_MALFORMED );
-		$p->next_tag( 'span' );
+		$p->next( array( 'tag' => 'span' ) );
 		$p->remove_attribute( 'Notifications<' );
 		$this->assertSame(
 			'<div><span class="d-md-none" /span><span class="d-none d-md-inline">Back to notifications</span></div>',
@@ -1041,15 +1041,15 @@ HTML;
 	/**
 	 * @ticket 56299
 	 *
-	 * @covers next_Tag
+	 * @covers next
 	 * @covers set_attribute
 	 * @covers get_updated_html
 	 */
 	public function test_updating_attributes_works_even_in_malformed_html_1() {
 		$p = new WP_HTML_Tag_Processor( self::HTML_MALFORMED );
-		$p->next_tag( 'span' );
+		$p->next( array( 'tag' => 'span' ) );
 		$p->set_attribute( 'id', 'first' );
-		$p->next_tag( 'span' );
+		$p->next( array( 'tag' => 'span' ) );
 		$p->set_attribute( 'id', 'second' );
 		$this->assertSame(
 			'<div><span id="first" class="d-md-none" Notifications</span><span id="second" class="d-none d-md-inline">Back to notifications</span></div>',
@@ -1060,7 +1060,7 @@ HTML;
 	/**
 	 * @ticket 56299
 	 *
-	 * @covers next_tag
+	 * @covers next
 	 * @covers set_attribute
 	 * @covers add_class
 	 * @covers get_updated_html
@@ -1069,10 +1069,10 @@ HTML;
 	 */
 	public function test_updating_attributes_works_even_in_malformed_html_2( $html_input, $html_expected ) {
 		$p = new WP_HTML_Tag_Processor( $html_input );
-		$p->next_tag();
+		$p->next();
 		$p->set_attribute( 'foo', 'bar' );
 		$p->add_class( 'firstTag' );
-		$p->next_tag();
+		$p->next();
 		$p->add_class( 'secondTag' );
 		$this->assertSame(
 			$html_expected,

--- a/phpunit/html/wp-html-tag-processor-wp-test.php
+++ b/phpunit/html/wp-html-tag-processor-wp-test.php
@@ -28,7 +28,7 @@ class WP_HTML_Tag_Processor_Test_WP extends WP_UnitTestCase {
 	 *
 	 * <code>
 	 *     $p = new WP_HTML_Tag_Processor( '<div class="header"></div>' );
-	 *     $p->next_tag();
+	 *     $p->next();
 	 *     $p->set_attribute('class', '" onclick="alert');
 	 *     echo $p;
 	 *     // <div class="" onclick="alert"></div>
@@ -47,7 +47,7 @@ class WP_HTML_Tag_Processor_Test_WP extends WP_UnitTestCase {
 	 */
 	public function test_set_attribute_prevents_xss( $value_to_set, $expected_result ) {
 		$p = new WP_HTML_Tag_Processor( '<div></div>' );
-		$p->next_tag();
+		$p->next();
 		$p->set_attribute( 'test', $value_to_set );
 
 		/*


### PR DESCRIPTION
A part of https://github.com/WordPress/gutenberg/issues/44410. Supersedes https://github.com/WordPress/gutenberg/pull/44595/ due to a branch naming collision

## What?
[In @dmsnell's words](https://github.com/WordPress/gutenberg/pull/44478):

> My worry is that we say you can search for a given tag name, but then people want a short hand for class name, so we add it, but then if you don't specify a tag you have `->next( null, 'wp-block-group' )` everywhere. Or someone thinks, let's put class name first, and then we have the other problem.
> 
> I'd even be for exposing this shorthand only after we see use in practice to see if people even want it, and if so, which convention is more dominant.
> 
> Alternatively it's always easy to later add new specialized methods. Suppose we only expose `->next()` right now, taking a query object. we can add `->next_tag( 'img' )` and `->next_with_class( 'wp-block-group' )`. performance wise this is a "free" option

It resonates with me, so this PR removes the shorthand syntax and renames the long `tag_name` and `class_name` keys to short `tag` and `class` ones.

**Before:**

```php
$p->next_tag( 'p' );
```

**After:**

```php
$p->next( array( 'tag' => 'p' ) );
```

## Testing Instructions

Confirm the CI passed and that no `next_tag`, `tag_name`, and `class_name` mentions were missed in this refactoring.

cc @dmsnell 
