### PR TITLE
E2E tests: update button selector

### DIFF
--- a/packages/e2e-test-utils-playwright/src/editor/preview.ts
+++ b/packages/e2e-test-utils-playwright/src/editor/preview.ts
@@ -19,7 +19,10 @@ export async function openPreviewPage( this: Editor ): Promise< Page > {
 	const editorTopBar = this.page.locator(
 		'role=region[name="Editor top bar"i]'
 	);
-	const previewButton = editorTopBar.locator( 'role=button[name="Preview"i]' );
+	const previewButton = editorTopBar.locator(
+		'role=button[name="Preview"i]'
+	);
+
 	await previewButton.click();
 
 	const [ previewPage ] = await Promise.all( [

--- a/packages/e2e-test-utils-playwright/src/editor/preview.ts
+++ b/packages/e2e-test-utils-playwright/src/editor/preview.ts
@@ -19,7 +19,7 @@ export async function openPreviewPage( this: Editor ): Promise< Page > {
 	const editorTopBar = this.page.locator(
 		'role=region[name="Editor top bar"i]'
 	);
-	const previewButton = editorTopBar.locator( 'role=button[name="View"i]' );
+	const previewButton = editorTopBar.locator( 'role=button[name="Preview"i]' );
 	await previewButton.click();
 
 	const [ previewPage ] = await Promise.all( [

--- a/test/e2e/specs/editor/various/new-post.spec.js
+++ b/test/e2e/specs/editor/various/new-post.spec.js
@@ -30,9 +30,9 @@ test.describe( 'new editor state', () => {
 		await expect( title ).toBeEditable();
 		await expect( title ).toHaveText( '' );
 
-		// Should display the View button.
+		// Should display the Preview button.
 		await expect(
-			page.locator( 'role=button[name="View"i]' )
+			page.locator( 'role=button[name="Preview"i]' )
 		).toBeVisible();
 
 		// Should display the Post Formats UI.

--- a/test/e2e/specs/editor/various/preview.spec.js
+++ b/test/e2e/specs/editor/various/preview.spec.js
@@ -24,7 +24,7 @@ test.describe( 'Preview', () => {
 
 		// Disabled until content present.
 		await expect(
-			editorPage.locator( 'role=button[name="View"i]' )
+			editorPage.locator( 'role=button[name="Preview"i]' )
 		).toBeDisabled();
 
 		await editorPage.type(
@@ -282,7 +282,7 @@ test.describe( 'Preview with private custom post type', () => {
 		await admin.createNewPost( { postType: 'not_public', title: 'aaaaa' } );
 
 		// Open the view menu.
-		await page.click( 'role=button[name="View"i]' );
+		await page.click( 'role=button[name="Preview"i]' );
 
 		await expect(
 			page.locator( 'role=menuitem[name="Preview in new tab"i]' )
@@ -297,7 +297,7 @@ class PreviewUtils {
 
 	async waitForPreviewNavigation( previewPage ) {
 		const previewToggle = this.page.locator(
-			'role=button[name="View"i][expanded=false]'
+			'role=button[name="Preview"i][expanded=false]'
 		);
 		const isDropdownClosed = await previewToggle.isVisible();
 		if ( isDropdownClosed ) {


### PR DESCRIPTION


## What?
Update E2E selector after the change in https://github.com/WordPress/gutenberg/pull/45074

## Why?
A button label "View" was changed to "Preview"

## How?
By typing.

## Testing Instructions
E2E tests should 🟢 
