### PR TITLE
hasChangedContent: remove obsolete blocks check

### DIFF
--- a/packages/editor/src/store/selectors.js
+++ b/packages/editor/src/store/selectors.js
@@ -95,16 +95,7 @@ export function isEditedPostNew( state ) {
  */
 export function hasChangedContent( state ) {
 	const edits = getPostEdits( state );
-
-	return (
-		'blocks' in edits ||
-		// `edits` is intended to contain only values which are different from
-		// the saved post, so the mere presence of a property is an indicator
-		// that the value is different than what is known to be saved. While
-		// content in Visual mode is represented by the blocks state, in Text
-		// mode it is tracked by `edits.content`.
-		'content' in edits
-	);
+	return 'content' in edits;
 }
 
 /**

--- a/packages/editor/src/store/test/selectors.js
+++ b/packages/editor/src/store/test/selectors.js
@@ -1514,11 +1514,9 @@ describe( 'selectors', () => {
 			const state = {
 				editor: {
 					present: {
-						blocks: {
-							value: [],
-							isDirty: true,
+						edits: {
+							content: () => 'new-content',
 						},
-						edits: {},
 					},
 				},
 				currentPost: {

--- a/packages/editor/src/store/test/selectors.js
+++ b/packages/editor/src/store/test/selectors.js
@@ -148,7 +148,6 @@ const {
 	hasEditorUndo,
 	hasEditorRedo,
 	isEditedPostNew,
-	hasChangedContent,
 	isEditedPostDirty,
 	hasNonPostEntityChanges,
 	isCleanNewPost,
@@ -389,57 +388,6 @@ describe( 'selectors', () => {
 			};
 
 			expect( isEditedPostNew( state ) ).toBe( false );
-		} );
-	} );
-
-	describe( 'hasChangedContent', () => {
-		it( 'should return false if no dirty blocks nor content property edit', () => {
-			const state = {
-				editor: {
-					present: {
-						blocks: {
-							isDirty: false,
-						},
-						edits: {},
-					},
-				},
-			};
-
-			expect( hasChangedContent( state ) ).toBe( false );
-		} );
-
-		it( 'should return true if dirty blocks', () => {
-			const state = {
-				editor: {
-					present: {
-						blocks: {
-							isDirty: true,
-							value: [],
-						},
-						edits: {},
-					},
-				},
-			};
-
-			expect( hasChangedContent( state ) ).toBe( true );
-		} );
-
-		it( 'should return true if content property edit', () => {
-			const state = {
-				editor: {
-					present: {
-						blocks: {
-							isDirty: false,
-							value: [],
-						},
-						edits: {
-							content: 'text mode edited',
-						},
-					},
-				},
-			};
-
-			expect( hasChangedContent( state ) ).toBe( true );
 		} );
 	} );
 


### PR DESCRIPTION
Fixes a bug where the `hasChangedContent` selector would return `true` even when the post doesn't have any non-transient edits, only the transient `blocks` edit. This `blocks` edit is added on editor initialization, namely on [`EntityProvider` mount](https://github.com/WordPress/gutenberg/blob/trunk/packages/core-data/src/entity-provider.js#L175-L183), and merely calculates the parsed blocks from the post's original `content`.

We only need to check `'content' in edits` because every relevant `blocks` edit will add a `content` edit, too, setting it to a function that serializes the blocks when called.

The `'blocks' in edits` check was originally added in #10844 at a time when blocks state was in the `editor` store, and it was checking the blocks' dirty flag: `state.editor.present.blocks.isDirty`. Then this `editor` blocks state was refactored to `core` entities in #16932, and changed this condition to just `'blocks' in edits`. But this condition is not needed nowadays.

The PR also removes obsolete unit tests for `hasChangedContent` which were working with the old state shape (like `state.editor.present.blocks`) and mocking `getEntityRecordEdits`. Such tests are very far from real-world usage.

**How to test:**
Look at the original report (https://github.com/WordPress/gutenberg/pull/27950#discussion_r994661445) and verify this workflow:
- load the editor with a post, don't perform any edits yet
- put a breakpoint on the `isEditedPostAutosaveable` selector and watch what it returns
- clicking the "View" button to show a preview of the post
- the preview code will check it it should autosave and calls `isEditedPostAutosaveable`. Verify that it returns `false` now.

The selector used to return `true` even on unchanged post.