### PR TITLE
Site Title: Avoid 403 errors for users with low permissions

### DIFF
--- a/packages/block-library/src/site-title/edit/index.js
+++ b/packages/block-library/src/site-title/edit/index.js
@@ -6,8 +6,8 @@ import classnames from 'classnames';
 /**
  * WordPress dependencies
  */
-import { useSelect } from '@wordpress/data';
-import { useEntityProp, store as coreStore } from '@wordpress/core-data';
+import { useDispatch, useSelect } from '@wordpress/data';
+import { store as coreStore } from '@wordpress/core-data';
 import { __ } from '@wordpress/i18n';
 import {
 	RichText,
@@ -31,21 +31,31 @@ export default function SiteTitleEdit( {
 	insertBlocksAfter,
 } ) {
 	const { level, textAlign, isLink, linkTarget } = attributes;
-	const [ title, setTitle ] = useEntityProp( 'root', 'site', 'title' );
-	const { canUserEdit, readOnlyTitle } = useSelect( ( select ) => {
-		const { canUser, getEntityRecord } = select( coreStore );
-		const siteData = getEntityRecord( 'root', '__unstableBase' );
+	const { canUserEdit, title } = useSelect( ( select ) => {
+		const { canUser, getEntityRecord, getEditedEntityRecord } =
+			select( coreStore );
+		const canEdit = canUser( 'update', 'settings' );
+		const settings = canEdit ? getEditedEntityRecord( 'root', 'site' ) : {};
+		const readOnlySettings = getEntityRecord( 'root', '__unstableBase' );
+
 		return {
-			canUserEdit: canUser( 'update', 'settings' ),
-			readOnlyTitle: decodeEntities( siteData?.name ),
+			canUserEdit: canEdit,
+			title: canEdit ? settings?.title : readOnlySettings?.name,
 		};
 	}, [] );
+	const { editEntityRecord } = useDispatch( coreStore );
+
+	function setTitle( newTitle ) {
+		editEntityRecord( 'root', 'site', undefined, {
+			title: newTitle,
+		} );
+	}
+
 	const TagName = level === 0 ? 'p' : `h${ level }`;
 	const blockProps = useBlockProps( {
 		className: classnames( {
 			[ `has-text-align-${ textAlign }` ]: textAlign,
-			'wp-block-site-title__placeholder':
-				! canUserEdit && ! readOnlyTitle,
+			'wp-block-site-title__placeholder': ! canUserEdit && ! title,
 		} ),
 	} );
 	const siteTitleContent = canUserEdit ? (
@@ -71,10 +81,11 @@ export default function SiteTitleEdit( {
 					href="#site-title-pseudo-link"
 					onClick={ ( event ) => event.preventDefault() }
 				>
-					{ readOnlyTitle || __( 'Site Title placeholder' ) }
+					{ decodeEntities( title ) ||
+						__( 'Site Title placeholder' ) }
 				</a>
 			) : (
-				<span>{ title || readOnlyTitle }</span>
+				<span>{ decodeEntities( title ) }</span>
 			) }
 		</TagName>
 	);

--- a/packages/block-library/src/site-title/edit/index.js
+++ b/packages/block-library/src/site-title/edit/index.js
@@ -85,7 +85,10 @@ export default function SiteTitleEdit( {
 						__( 'Site Title placeholder' ) }
 				</a>
 			) : (
-				<span>{ decodeEntities( title ) }</span>
+				<span>
+					{ decodeEntities( title ) ||
+						__( 'Site Title placeholder' ) }
+				</span>
 			) }
 		</TagName>
 	);

--- a/packages/e2e-tests/specs/editor/blocks/site-title.test.js
+++ b/packages/e2e-tests/specs/editor/blocks/site-title.test.js
@@ -10,6 +10,7 @@ import {
 	loginUser,
 	pressKeyWithModifier,
 	setOption,
+	openDocumentSettingsSidebar,
 } from '@wordpress/e2e-test-utils';
 
 const saveEntities = async () => {
@@ -66,11 +67,18 @@ describe( 'Site Title block', () => {
 		await createNewPost();
 		await insertBlock( 'Site Title' );
 
-		const editableSiteTitleSelector = '[aria-label="Block: Site Title"] a';
-		await page.waitForSelector( editableSiteTitleSelector );
+		await openDocumentSettingsSidebar();
+
+		const [ disableLink ] = await page.$x(
+			"//label[contains(text(), 'Make title link to home')]"
+		);
+		await disableLink.click();
+
+		const siteTitleSelector = '[aria-label="Block: Site Title"] span';
+		await page.waitForSelector( siteTitleSelector );
 
 		const editable = await page.$eval(
-			editableSiteTitleSelector,
+			siteTitleSelector,
 			( element ) => element.contentEditable
 		);
 		expect( editable ).toBe( 'inherit' );

--- a/packages/e2e-tests/specs/editor/blocks/site-title.test.js
+++ b/packages/e2e-tests/specs/editor/blocks/site-title.test.js
@@ -60,11 +60,7 @@ describe( 'Site Title block', () => {
 		expect( siteTitle ).toEqual( 'New Site Title' );
 	} );
 
-	// FIXME: Fix https://github.com/WordPress/gutenberg/issues/33003 and enable this test.
-	// I tried adding an `expect( console ).toHaveErroredWith()` as a workaround, but
-	// the error occurs only sporadically (e.g. locally in interactive mode, but not in
-	// headless mode).
-	it.skip( 'Cannot edit the site title as editor', async () => {
+	it( 'Cannot edit the site title as editor', async () => {
 		await loginUser( username, password );
 
 		await createNewPost();

--- a/packages/e2e-tests/specs/editor/blocks/site-title.test.js
+++ b/packages/e2e-tests/specs/editor/blocks/site-title.test.js
@@ -61,7 +61,11 @@ describe( 'Site Title block', () => {
 		expect( siteTitle ).toEqual( 'New Site Title' );
 	} );
 
-	it( 'Cannot edit the site title as editor', async () => {
+	// FIXME: Fix https://github.com/WordPress/gutenberg/issues/33003 and enable this test.
+	// I tried adding an `expect( console ).toHaveErroredWith()` as a workaround, but
+	// the error occurs only sporadically (e.g. locally in interactive mode, but not in
+	// headless mode).
+	it.skip( 'Cannot edit the site title as editor', async () => {
 		await loginUser( username, password );
 
 		await createNewPost();


### PR DESCRIPTION
## What?
Fixes #33003.

PR fixes `403` errors generated by the Site Title block for non-admin users.

## Why?
The editor should check permission before making requests when data isn't available for everyone.

## How?
I've updated the selector logic to conditionally use (and fetch) data from the settings endpoint or from the read-only index based on user permissions.

## Testing Instructions

### Admin users

The Site Title block should work as before.

### Non-admin users (e.g. Editor or Author role).

1. Log into WP as a non-admin user
2. Create a new post.
3. Open your browser devtools bar (Network tab), and clear it.
4. Insert a 'Site Title' block
5. No network request to fail with a 403.

### E2E Tests
```
npm run test:e2e -- packages/e2e-tests/specs/editor/blocks/site-title.test.js
```