### PR TITLE
ESLint: Fix `testing-library/prefer-screen-queries` violations

### DIFF
--- a/packages/block-editor/src/components/block-selection-clearer/test/index.js
+++ b/packages/block-editor/src/components/block-selection-clearer/test/index.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { fireEvent, render } from '@testing-library/react';
+import { fireEvent, render, screen } from '@testing-library/react';
 
 /**
  * WordPress dependencies
@@ -42,12 +42,12 @@ describe( 'BlockSelectionClearer component', () => {
 			clearSelectedBlock: mockClearSelectedBlock,
 		} ) );
 
-		const { queryByRole } = render(
+		render(
 			<BlockSelectionClearer>
 				<button>Not a block</button>
 			</BlockSelectionClearer>
 		);
-		const button = queryByRole( 'button' );
+		const button = screen.getByRole( 'button' );
 		fireEvent.mouseDown( button.parentElement );
 
 		expect( mockClearSelectedBlock ).toBeCalled();
@@ -63,12 +63,12 @@ describe( 'BlockSelectionClearer component', () => {
 			clearSelectedBlock: mockClearSelectedBlock,
 		} ) );
 
-		const { queryByRole } = render(
+		render(
 			<BlockSelectionClearer>
 				<button>Not a block</button>
 			</BlockSelectionClearer>
 		);
-		const button = queryByRole( 'button' );
+		const button = screen.getByRole( 'button' );
 		fireEvent.mouseDown( button.parentElement );
 
 		expect( mockClearSelectedBlock ).toBeCalled();
@@ -81,12 +81,12 @@ describe( 'BlockSelectionClearer component', () => {
 			clearSelectedBlock: mockClearSelectedBlock,
 		} ) );
 
-		const { queryByRole } = render(
+		render(
 			<BlockSelectionClearer>
 				<button>Not a block</button>
 			</BlockSelectionClearer>
 		);
-		const button = queryByRole( 'button' );
+		const button = screen.getByRole( 'button' );
 		fireEvent.mouseDown( button.parentElement );
 
 		expect( mockClearSelectedBlock ).not.toBeCalled();
@@ -105,12 +105,12 @@ describe( 'BlockSelectionClearer component', () => {
 			clearSelectedBlock: mockClearSelectedBlock,
 		} ) );
 
-		const { queryByRole } = render(
+		render(
 			<BlockSelectionClearer>
 				<button>Not a block</button>
 			</BlockSelectionClearer>
 		);
-		const button = queryByRole( 'button' );
+		const button = screen.getByRole( 'button' );
 		fireEvent.mouseDown( button.parentElement );
 
 		expect( mockClearSelectedBlock ).not.toBeCalled();

--- a/packages/components/src/sandbox/test/index.js
+++ b/packages/components/src/sandbox/test/index.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { act, fireEvent, render } from '@testing-library/react';
+import { act, fireEvent, render, screen } from '@testing-library/react';
 
 /**
  * WordPress dependencies
@@ -55,7 +55,7 @@ describe( 'Sandbox', () => {
 		);
 
 		act( () => {
-			fireEvent.click( result.getByRole( 'button' ) );
+			fireEvent.click( screen.getByRole( 'button' ) );
 		} );
 
 		sandboxedIframe =

--- a/packages/core-data/src/hooks/test/use-query-select.js
+++ b/packages/core-data/src/hooks/test/use-query-select.js
@@ -10,7 +10,7 @@ import {
 /**
  * External dependencies
  */
-import { act, render } from '@testing-library/react';
+import { act, render, screen } from '@testing-library/react';
 
 /**
  * Internal dependencies
@@ -52,7 +52,7 @@ describe( 'useQuerySelect', () => {
 		const TestComponent = jest
 			.fn()
 			.mockImplementation( getTestComponent( selectSpy, 'keyName' ) );
-		const testInstance = render(
+		render(
 			<RegistryProvider value={ registry }>
 				<TestComponent keyName="foo" />
 			</RegistryProvider>
@@ -64,7 +64,7 @@ describe( 'useQuerySelect', () => {
 		expect( TestComponent ).toHaveBeenCalledTimes( 2 );
 
 		// ensure expected state was rendered
-		expect( testInstance.getByText( 'bar' ) ).toBeInTheDocument();
+		expect( screen.getByText( 'bar' ) ).toBeInTheDocument();
 	} );
 
 	it( 'uses memoized selectors', () => {

--- a/packages/data/src/components/use-select/test/suspense.js
+++ b/packages/data/src/components/use-select/test/suspense.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { render } from '@testing-library/react';
+import { render, screen } from '@testing-library/react';
 
 /**
  * WordPress dependencies
@@ -109,8 +109,8 @@ describe( 'useSuspenseSelect', () => {
 			</RegistryProvider>
 		);
 
-		const rendered = render( <App /> );
-		await rendered.findByLabelText( 'loaded' );
+		render( <App /> );
+		await screen.findByLabelText( 'loaded' );
 
 		// Verify there were 3 attempts to render. Suspended twice because of
 		// `getToken` and `getData` selectors not being resolved, and then finally
@@ -156,8 +156,8 @@ describe( 'useSuspenseSelect', () => {
 			</RegistryProvider>
 		);
 
-		const rendered = render( <App /> );
-		const label = await rendered.findByLabelText( 'error' );
+		render( <App /> );
+		const label = await screen.findByLabelText( 'error' );
 		expect( label ).toHaveTextContent( 'resolution failed' );
 		expect( console ).toHaveErrored();
 	} );


### PR DESCRIPTION
## What?
This PR fixes all violations of the [`testing-library/prefer-screen-queries` rule](https://github.com/testing-library/eslint-plugin-testing-library/blob/main/docs/rules/prefer-screen-queries.md), in preparation for enabling `eslint-plugin-testing-library` globally for the project.

See the [plugin README](https://github.com/testing-library/eslint-plugin-testing-library) for more info on the `testing-library` ESLint plugin.

## Why?
We've been improving our tests a lot recently with the migration to `@testing-library`. One way we could improve them is to better standardize them and follow best practices whenever we can, and one of the best ways to get there is to follow the recommended ESLint rules of the libraries and utilities we use under the hood.

## How?
This fixes a few instances where we've been using the query functions returned by `render` when the recommended way is to use the ones coming from `screen`.

## Testing Instructions
Verify all checks are green.

cc @brookewp as we've been discussing working to address some of those violations together.