### PR TITLE
ESLint: Fix `testing-library/no-render-in-setup` violations

### DIFF
--- a/packages/components/src/base-field/test/index.js
+++ b/packages/components/src/base-field/test/index.js
@@ -14,16 +14,14 @@ const TestField = ( props ) => {
 };
 
 describe( 'base field', () => {
-	let base;
-
 	it( 'should render correctly', () => {
-		base = render( <TestField /> ).container;
+		const base = render( <TestField /> ).container;
 		expect( base.firstChild ).toMatchSnapshot();
 	} );
 
 	describe( 'props', () => {
 		it( 'should render error styles', () => {
-			base = render( <TestField /> ).container;
+			const base = render( <TestField /> ).container;
 			const { container } = render( <TestField hasError /> );
 			expect( container.firstChild ).toMatchStyleDiffSnapshot(
 				base.firstChild
@@ -31,7 +29,7 @@ describe( 'base field', () => {
 		} );
 
 		it( 'should render inline styles', () => {
-			base = render( <TestField /> ).container;
+			const base = render( <TestField /> ).container;
 			const { container } = render( <TestField isInline /> );
 			expect( container.firstChild ).toMatchStyleDiffSnapshot(
 				base.firstChild
@@ -39,7 +37,7 @@ describe( 'base field', () => {
 		} );
 
 		it( 'should render subtle styles', () => {
-			base = render( <TestField /> ).container;
+			const base = render( <TestField /> ).container;
 			const { container } = render( <TestField isSubtle /> );
 			expect( container.firstChild ).toMatchStyleDiffSnapshot(
 				base.firstChild

--- a/packages/components/src/base-field/test/index.js
+++ b/packages/components/src/base-field/test/index.js
@@ -16,16 +16,14 @@ const TestField = ( props ) => {
 describe( 'base field', () => {
 	let base;
 
-	beforeEach( () => {
-		base = render( <TestField /> ).container;
-	} );
-
 	it( 'should render correctly', () => {
+		base = render( <TestField /> ).container;
 		expect( base.firstChild ).toMatchSnapshot();
 	} );
 
 	describe( 'props', () => {
 		it( 'should render error styles', () => {
+			base = render( <TestField /> ).container;
 			const { container } = render( <TestField hasError /> );
 			expect( container.firstChild ).toMatchStyleDiffSnapshot(
 				base.firstChild
@@ -33,6 +31,7 @@ describe( 'base field', () => {
 		} );
 
 		it( 'should render inline styles', () => {
+			base = render( <TestField /> ).container;
 			const { container } = render( <TestField isInline /> );
 			expect( container.firstChild ).toMatchStyleDiffSnapshot(
 				base.firstChild
@@ -40,6 +39,7 @@ describe( 'base field', () => {
 		} );
 
 		it( 'should render subtle styles', () => {
+			base = render( <TestField /> ).container;
 			const { container } = render( <TestField isSubtle /> );
 			expect( container.firstChild ).toMatchStyleDiffSnapshot(
 				base.firstChild

--- a/packages/components/src/ui/spinner/test/index.js
+++ b/packages/components/src/ui/spinner/test/index.js
@@ -11,15 +11,13 @@ import { Spinner } from '..';
 describe( 'props', () => {
 	let base;
 
-	beforeEach( () => {
-		base = render( <Spinner /> );
-	} );
-
 	test( 'should render correctly', () => {
+		base = render( <Spinner /> );
 		expect( base.container.firstChild ).toMatchSnapshot();
 	} );
 
 	test( 'should render color', () => {
+		base = render( <Spinner /> );
 		const { container } = render( <Spinner color="blue" /> );
 		expect( container.firstChild ).toMatchDiffSnapshot(
 			base.container.firstChild
@@ -27,6 +25,7 @@ describe( 'props', () => {
 	} );
 
 	test( 'should render size', () => {
+		base = render( <Spinner /> );
 		const { container } = render( <Spinner size={ 31 } /> );
 		expect( container.firstChild ).toMatchDiffSnapshot(
 			base.container.firstChild

--- a/packages/components/src/ui/spinner/test/index.js
+++ b/packages/components/src/ui/spinner/test/index.js
@@ -9,15 +9,13 @@ import { render } from '@testing-library/react';
 import { Spinner } from '..';
 
 describe( 'props', () => {
-	let base;
-
 	test( 'should render correctly', () => {
-		base = render( <Spinner /> );
+		const base = render( <Spinner /> );
 		expect( base.container.firstChild ).toMatchSnapshot();
 	} );
 
 	test( 'should render color', () => {
-		base = render( <Spinner /> );
+		const base = render( <Spinner /> );
 		const { container } = render( <Spinner color="blue" /> );
 		expect( container.firstChild ).toMatchDiffSnapshot(
 			base.container.firstChild
@@ -25,7 +23,7 @@ describe( 'props', () => {
 	} );
 
 	test( 'should render size', () => {
-		base = render( <Spinner /> );
+		const base = render( <Spinner /> );
 		const { container } = render( <Spinner size={ 31 } /> );
 		expect( container.firstChild ).toMatchDiffSnapshot(
 			base.container.firstChild

--- a/packages/components/src/ui/tooltip/test/index.js
+++ b/packages/components/src/ui/tooltip/test/index.js
@@ -13,20 +13,22 @@ describe( 'props', () => {
 	const baseTooltipId = 'base-tooltip';
 	const baseTooltipTriggerContent = 'WordPress.org - Base trigger content';
 	const byId = ( id ) => ( t ) => t.id === id;
-	beforeEach( () => {
+	const renderVisibleTooltip = () => {
 		render(
 			<Tooltip baseId={ baseTooltipId } content="Code is Poetry" visible>
 				<Text>{ baseTooltipTriggerContent }</Text>
 			</Tooltip>
 		);
-	} );
+	};
 
 	test( 'should render correctly', () => {
+		renderVisibleTooltip();
 		const tooltip = screen.getByRole( /tooltip/i );
 		expect( tooltip ).toMatchSnapshot();
 	} );
 
 	test( 'should render invisible', () => {
+		renderVisibleTooltip();
 		const invisibleTooltipTriggerContent = 'WordPress.org - Invisible';
 		render(
 			<Tooltip
@@ -50,6 +52,7 @@ describe( 'props', () => {
 	} );
 
 	test( 'should render without children', () => {
+		renderVisibleTooltip();
 		const childlessTooltipId = 'tooltip-without-children';
 		render(
 			<Tooltip
@@ -64,6 +67,7 @@ describe( 'props', () => {
 	} );
 
 	test( 'should not render a tooltip without content', () => {
+		renderVisibleTooltip();
 		const contentlessTooltipId = 'contentless-tooltip';
 		render(
 			<Tooltip baseId={ contentlessTooltipId } visible>


### PR DESCRIPTION
## What?
This PR fixes all violations of the [`testing-library/no-render-in-setup` rule](https://github.com/testing-library/eslint-plugin-testing-library/blob/main/docs/rules/no-render-in-setup.md), in preparation for enabling `eslint-plugin-testing-library` globally for the project.

See the [plugin README](https://github.com/testing-library/eslint-plugin-testing-library) for more info on the `testing-library` ESLint plugin.

## Why?
We've been improving our tests a lot recently with the migration to `@testing-library`. One way we could improve them is to better standardize them and follow best practices whenever we can, and one of the best ways to get there is to follow the recommended ESLint rules of the libraries and utilities we use under the hood.

## How?
We're moving the rendering to the actual tests.

## Testing Instructions
Verify all checks are green.

cc @brookewp as we've been discussing working to address some of those violations together.