### PR TITLE
Lodash: Refactor away from `_.castArray()`

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -81,6 +81,7 @@ module.exports = {
 						importNames: [
 							'camelCase',
 							'capitalize',
+							'castArray',
 							'chunk',
 							'clamp',
 							'cloneDeep',

--- a/packages/block-editor/src/components/block-compare/index.js
+++ b/packages/block-editor/src/components/block-compare/index.js
@@ -2,7 +2,6 @@
  * External dependencies
  */
 import classnames from 'classnames';
-import { castArray } from 'lodash';
 // diff doesn't tree-shake correctly, so we import from the individual
 // module here, to avoid including too much of the library
 import { diffChars } from 'diff/lib/diff/character';
@@ -44,7 +43,9 @@ function BlockCompare( {
 
 	function getConvertedContent( convertedBlock ) {
 		// The convertor may return an array of items or a single item.
-		const newBlocks = castArray( convertedBlock );
+		const newBlocks = Array.isArray( convertedBlock )
+			? convertedBlock
+			: [ convertedBlock ];
 
 		// Get converted block details.
 		const newContent = newBlocks.map( ( item ) =>

--- a/packages/block-editor/src/components/block-preview/index.js
+++ b/packages/block-editor/src/components/block-preview/index.js
@@ -1,7 +1,6 @@
 /**
  * External dependencies
  */
-import { castArray } from 'lodash';
 import classnames from 'classnames';
 
 /**
@@ -36,7 +35,10 @@ export function BlockPreview( {
 		() => ( { ...originalSettings, __unstableIsPreviewMode: true } ),
 		[ originalSettings ]
 	);
-	const renderedBlocks = useMemo( () => castArray( blocks ), [ blocks ] );
+	const renderedBlocks = useMemo(
+		() => ( Array.isArray( blocks ) ? blocks : [ blocks ] ),
+		[ blocks ]
+	);
 	if ( ! blocks || blocks.length === 0 ) {
 		return null;
 	}
@@ -99,7 +101,10 @@ export function useBlockPreview( {
 	);
 	const disabledRef = useDisabled();
 	const ref = useMergeRefs( [ props.ref, disabledRef ] );
-	const renderedBlocks = useMemo( () => castArray( blocks ), [ blocks ] );
+	const renderedBlocks = useMemo(
+		() => ( Array.isArray( blocks ) ? blocks : [ blocks ] ),
+		[ blocks ]
+	);
 
 	const children = (
 		<BlockEditorProvider value={ renderedBlocks } settings={ settings }>

--- a/packages/block-editor/src/components/block-settings-menu/block-settings-dropdown.js
+++ b/packages/block-editor/src/components/block-settings-menu/block-settings-dropdown.js
@@ -1,9 +1,4 @@
 /**
- * External dependencies
- */
-import { castArray } from 'lodash';
-
-/**
  * WordPress dependencies
  */
 import {
@@ -58,7 +53,9 @@ export function BlockSettingsDropdown( {
 	__unstableDisplayLocation,
 	...props
 } ) {
-	const blockClientIds = castArray( clientIds );
+	const blockClientIds = Array.isArray( clientIds )
+		? clientIds
+		: [ clientIds ];
 	const count = blockClientIds.length;
 	const firstBlockClientId = blockClientIds[ 0 ];
 	const {

--- a/packages/block-editor/src/components/block-switcher/index.js
+++ b/packages/block-editor/src/components/block-switcher/index.js
@@ -1,9 +1,4 @@
 /**
- * External dependencies
- */
-import { castArray } from 'lodash';
-
-/**
  * WordPress dependencies
  */
 import { __, _n, sprintf } from '@wordpress/i18n';
@@ -52,7 +47,7 @@ export const BlockSwitcherDropdownMenu = ( { clientIds, blocks } ) => {
 			const { getBlockStyles, getBlockType } = select( blocksStore );
 			const { canRemoveBlocks } = select( blockEditorStore );
 			const rootClientId = getBlockRootClientId(
-				castArray( clientIds )[ 0 ]
+				Array.isArray( clientIds ) ? clientIds[ 0 ] : clientIds
 			);
 			const [ { name: firstBlockName } ] = blocks;
 			const _isSingleBlockSelected = blocks.length === 1;

--- a/packages/block-editor/src/components/inserter/hooks/use-insertion-point.js
+++ b/packages/block-editor/src/components/inserter/hooks/use-insertion-point.js
@@ -1,9 +1,4 @@
 /**
- * External dependencies
- */
-import { castArray } from 'lodash';
-
-/**
  * WordPress dependencies
  */
 import { useDispatch, useSelect } from '@wordpress/data';
@@ -118,14 +113,11 @@ function useInsertionPoint( {
 					meta
 				);
 			}
+			const blockLength = Array.isArray( blocks ) ? blocks.length : 1;
 			const message = sprintf(
 				// translators: %d: the name of the block that has been added
-				_n(
-					'%d block added.',
-					'%d blocks added.',
-					castArray( blocks ).length
-				),
-				castArray( blocks ).length
+				_n( '%d block added.', '%d blocks added.', blockLength ),
+				blockLength
 			);
 			speak( message );
 

--- a/packages/block-editor/src/store/array.js
+++ b/packages/block-editor/src/store/array.js
@@ -1,9 +1,4 @@
 /**
- * External dependencies
- */
-import { castArray } from 'lodash';
-
-/**
  * Insert one or multiple elements into a given position of an array.
  *
  * @param {Array}  array    Source array.
@@ -15,7 +10,7 @@ import { castArray } from 'lodash';
 export function insertAt( array, elements, index ) {
 	return [
 		...array.slice( 0, index ),
-		...castArray( elements ),
+		...( Array.isArray( elements ) ? elements : [ elements ] ),
 		...array.slice( index ),
 	];
 }

--- a/packages/block-editor/src/store/selectors.js
+++ b/packages/block-editor/src/store/selectors.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { castArray, map, reduce, some, find, filter, orderBy } from 'lodash';
+import { map, reduce, some, find, filter, orderBy } from 'lodash';
 import createSelector from 'rememo';
 
 /**
@@ -319,12 +319,13 @@ export const __experimentalGetGlobalBlocksByName = createSelector(
  */
 export const getBlocksByClientId = createSelector(
 	( state, clientIds ) =>
-		map( castArray( clientIds ), ( clientId ) =>
-			getBlock( state, clientId )
+		map(
+			Array.isArray( clientIds ) ? clientIds : [ clientIds ],
+			( clientId ) => getBlock( state, clientId )
 		),
 	( state, clientIds ) =>
 		map(
-			castArray( clientIds ),
+			Array.isArray( clientIds ) ? clientIds : [ clientIds ],
 			( clientId ) => state.blocks.tree[ clientId ]
 		)
 );
@@ -2065,7 +2066,7 @@ export const getInserterItems = createSelector(
  */
 export const getBlockTransformItems = createSelector(
 	( state, blocks, rootClientId = null ) => {
-		const normalizedBlocks = castArray( blocks );
+		const normalizedBlocks = Array.isArray( blocks ) ? blocks : [ blocks ];
 		const [ sourceBlock ] = normalizedBlocks;
 		const buildBlockTypeTransformItem = buildBlockTypeItem( state, {
 			buildScope: 'transform',

--- a/packages/block-library/src/list-item/hooks/use-outdent-list-item.js
+++ b/packages/block-library/src/list-item/hooks/use-outdent-list-item.js
@@ -1,9 +1,4 @@
 /**
- * External dependencies
- */
-import { castArray } from 'lodash';
-
-/**
  * WordPress dependencies
  */
 import { useCallback } from '@wordpress/element';
@@ -61,7 +56,9 @@ export default function useOutdentListItem( clientId ) {
 	return [
 		canOutdent,
 		useCallback( ( clientIds = getSelectedBlockClientIds() ) => {
-			clientIds = castArray( clientIds );
+			if ( ! Array.isArray( clientIds ) ) {
+				clientIds = [ clientIds ];
+			}
 
 			if ( ! clientIds.length ) return;
 

--- a/packages/blocks/src/api/children.js
+++ b/packages/blocks/src/api/children.js
@@ -1,9 +1,4 @@
 /**
- * External dependencies
- */
-import { castArray } from 'lodash';
-
-/**
  * WordPress dependencies
  */
 import { renderToString } from '@wordpress/element';
@@ -75,7 +70,9 @@ export function concat( ...blockNodes ) {
 
 	const result = [];
 	for ( let i = 0; i < blockNodes.length; i++ ) {
-		const blockNode = castArray( blockNodes[ i ] );
+		const blockNode = Array.isArray( blockNodes[ i ] )
+			? blockNodes[ i ]
+			: [ blockNodes[ i ] ];
 		for ( let j = 0; j < blockNode.length; j++ ) {
 			const child = blockNode[ j ];
 			const canConcatToPreviousString =

--- a/packages/blocks/src/api/parser/apply-block-deprecated-versions.js
+++ b/packages/blocks/src/api/parser/apply-block-deprecated-versions.js
@@ -1,9 +1,4 @@
 /**
- * External dependencies
- */
-import { castArray } from 'lodash';
-
-/**
  * Internal dependencies
  */
 import { DEPRECATED_ENTRY_KEYS } from '../constants';
@@ -102,10 +97,15 @@ export function applyBlockDeprecatedVersions( block, rawBlock, blockType ) {
 		// inner blocks.
 		const { migrate } = deprecatedBlockType;
 		if ( migrate ) {
+			let migrated = migrate( migratedAttributes, block.innerBlocks );
+			if ( ! Array.isArray( migrated ) ) {
+				migrated = [ migrated ];
+			}
+
 			[
 				migratedAttributes = parsedAttributes,
 				migratedInnerBlocks = block.innerBlocks,
-			] = castArray( migrate( migratedAttributes, block.innerBlocks ) );
+			] = migrated;
 		}
 
 		block = {

--- a/packages/blocks/src/api/parser/get-block-attributes.js
+++ b/packages/blocks/src/api/parser/get-block-attributes.js
@@ -2,7 +2,7 @@
  * External dependencies
  */
 import { parse as hpqParse } from 'hpq';
-import { mapValues, castArray } from 'lodash';
+import { mapValues } from 'lodash';
 import memoize from 'memize';
 
 /**
@@ -165,7 +165,10 @@ export function getBlockAttribute(
  * @return {boolean} Whether value is valid.
  */
 export function isValidByType( value, type ) {
-	return type === undefined || isOfTypes( value, castArray( type ) );
+	return (
+		type === undefined ||
+		isOfTypes( value, Array.isArray( type ) ? type : [ type ] )
+	);
 }
 
 /**

--- a/packages/blocks/src/store/actions.js
+++ b/packages/blocks/src/store/actions.js
@@ -2,7 +2,7 @@
  * External dependencies
  */
 import { isPlainObject } from 'is-plain-object';
-import { castArray, pick, some } from 'lodash';
+import { pick, some } from 'lodash';
 
 /**
  * WordPress dependencies
@@ -163,7 +163,7 @@ const processBlockType = ( blockType, { select } ) => {
 export function addBlockTypes( blockTypes ) {
 	return {
 		type: 'ADD_BLOCK_TYPES',
-		blockTypes: castArray( blockTypes ),
+		blockTypes: Array.isArray( blockTypes ) ? blockTypes : [ blockTypes ],
 	};
 }
 
@@ -242,7 +242,7 @@ export const __experimentalReapplyBlockTypeFilters =
 export function removeBlockTypes( names ) {
 	return {
 		type: 'REMOVE_BLOCK_TYPES',
-		names: castArray( names ),
+		names: Array.isArray( names ) ? names : [ names ],
 	};
 }
 
@@ -260,7 +260,7 @@ export function removeBlockTypes( names ) {
 export function addBlockStyles( blockName, styles ) {
 	return {
 		type: 'ADD_BLOCK_STYLES',
-		styles: castArray( styles ),
+		styles: Array.isArray( styles ) ? styles : [ styles ],
 		blockName,
 	};
 }
@@ -279,7 +279,7 @@ export function addBlockStyles( blockName, styles ) {
 export function removeBlockStyles( blockName, styleNames ) {
 	return {
 		type: 'REMOVE_BLOCK_STYLES',
-		styleNames: castArray( styleNames ),
+		styleNames: Array.isArray( styleNames ) ? styleNames : [ styleNames ],
 		blockName,
 	};
 }
@@ -298,7 +298,7 @@ export function removeBlockStyles( blockName, styleNames ) {
 export function addBlockVariations( blockName, variations ) {
 	return {
 		type: 'ADD_BLOCK_VARIATIONS',
-		variations: castArray( variations ),
+		variations: Array.isArray( variations ) ? variations : [ variations ],
 		blockName,
 	};
 }
@@ -317,7 +317,9 @@ export function addBlockVariations( blockName, variations ) {
 export function removeBlockVariations( blockName, variationNames ) {
 	return {
 		type: 'REMOVE_BLOCK_VARIATIONS',
-		variationNames: castArray( variationNames ),
+		variationNames: Array.isArray( variationNames )
+			? variationNames
+			: [ variationNames ],
 		blockName,
 	};
 }

--- a/packages/core-data/src/actions.js
+++ b/packages/core-data/src/actions.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { castArray, isEqual, find } from 'lodash';
+import { isEqual, find } from 'lodash';
 import { v4 as uuid } from 'uuid';
 
 /**
@@ -33,7 +33,7 @@ import { STORE_NAME } from './name';
 export function receiveUserQuery( queryID, users ) {
 	return {
 		type: 'RECEIVE_USER_QUERY',
-		users: castArray( users ),
+		users: Array.isArray( users ) ? users : [ users ],
 		queryID,
 	};
 }
@@ -91,8 +91,11 @@ export function receiveEntityRecords(
 	// Auto drafts should not have titles, but some plugins rely on them so we can't filter this
 	// on the server.
 	if ( kind === 'postType' ) {
-		records = castArray( records ).map( ( record ) =>
-			record.status === 'auto-draft' ? { ...record, title: '' } : record
+		records = ( Array.isArray( records ) ? records : [ records ] ).map(
+			( record ) =>
+				record.status === 'auto-draft'
+					? { ...record, title: '' }
+					: record
 		);
 	}
 	let action;
@@ -820,6 +823,6 @@ export function receiveAutosaves( postId, autosaves ) {
 	return {
 		type: 'RECEIVE_AUTOSAVES',
 		postId,
-		autosaves: castArray( autosaves ),
+		autosaves: Array.isArray( autosaves ) ? autosaves : [ autosaves ],
 	};
 }

--- a/packages/core-data/src/queried-data/actions.js
+++ b/packages/core-data/src/queried-data/actions.js
@@ -1,9 +1,4 @@
 /**
- * External dependencies
- */
-import { castArray } from 'lodash';
-
-/**
  * Returns an action object used in signalling that items have been received.
  *
  * @param {Array}   items Items received.
@@ -14,7 +9,7 @@ import { castArray } from 'lodash';
 export function receiveItems( items, edits ) {
 	return {
 		type: 'RECEIVE_ITEMS',
-		items: castArray( items ),
+		items: Array.isArray( items ) ? items : [ items ],
 		persistedEdits: edits,
 	};
 }
@@ -32,7 +27,7 @@ export function receiveItems( items, edits ) {
 export function removeItems( kind, name, records, invalidateCache = false ) {
 	return {
 		type: 'REMOVE_ITEMS',
-		itemIds: castArray( records ),
+		itemIds: Array.isArray( records ) ? records : [ records ],
 		kind,
 		name,
 		invalidateCache,

--- a/packages/customize-widgets/src/components/keyboard-shortcut-help-modal/shortcut.js
+++ b/packages/customize-widgets/src/components/keyboard-shortcut-help-modal/shortcut.js
@@ -1,9 +1,4 @@
 /**
- * External dependencies
- */
-import { castArray } from 'lodash';
-
-/**
  * WordPress dependencies
  */
 import { Fragment } from '@wordpress/element';
@@ -26,20 +21,22 @@ function KeyCombination( { keyCombination, forceAriaLabel } ) {
 			className="customize-widgets-keyboard-shortcut-help-modal__shortcut-key-combination"
 			aria-label={ forceAriaLabel || ariaLabel }
 		>
-			{ castArray( shortcut ).map( ( character, index ) => {
-				if ( character === '+' ) {
-					return <Fragment key={ index }>{ character }</Fragment>;
-				}
+			{ ( Array.isArray( shortcut ) ? shortcut : [ shortcut ] ).map(
+				( character, index ) => {
+					if ( character === '+' ) {
+						return <Fragment key={ index }>{ character }</Fragment>;
+					}
 
-				return (
-					<kbd
-						key={ index }
-						className="customize-widgets-keyboard-shortcut-help-modal__shortcut-key"
-					>
-						{ character }
-					</kbd>
-				);
-			} ) }
+					return (
+						<kbd
+							key={ index }
+							className="customize-widgets-keyboard-shortcut-help-modal__shortcut-key"
+						>
+							{ character }
+						</kbd>
+					);
+				}
+			) }
 		</kbd>
 	);
 }

--- a/packages/edit-post/src/components/keyboard-shortcut-help-modal/shortcut.js
+++ b/packages/edit-post/src/components/keyboard-shortcut-help-modal/shortcut.js
@@ -1,9 +1,4 @@
 /**
- * External dependencies
- */
-import { castArray } from 'lodash';
-
-/**
  * WordPress dependencies
  */
 import { Fragment } from '@wordpress/element';
@@ -26,20 +21,22 @@ function KeyCombination( { keyCombination, forceAriaLabel } ) {
 			className="edit-post-keyboard-shortcut-help-modal__shortcut-key-combination"
 			aria-label={ forceAriaLabel || ariaLabel }
 		>
-			{ castArray( shortcut ).map( ( character, index ) => {
-				if ( character === '+' ) {
-					return <Fragment key={ index }>{ character }</Fragment>;
-				}
+			{ ( Array.isArray( shortcut ) ? shortcut : [ shortcut ] ).map(
+				( character, index ) => {
+					if ( character === '+' ) {
+						return <Fragment key={ index }>{ character }</Fragment>;
+					}
 
-				return (
-					<kbd
-						key={ index }
-						className="edit-post-keyboard-shortcut-help-modal__shortcut-key"
-					>
-						{ character }
-					</kbd>
-				);
-			} ) }
+					return (
+						<kbd
+							key={ index }
+							className="edit-post-keyboard-shortcut-help-modal__shortcut-key"
+						>
+							{ character }
+						</kbd>
+					);
+				}
+			) }
 		</kbd>
 	);
 }

--- a/packages/edit-post/src/store/actions.js
+++ b/packages/edit-post/src/store/actions.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { castArray, reduce } from 'lodash';
+import { reduce } from 'lodash';
 
 /**
  * WordPress dependencies
@@ -296,7 +296,10 @@ export const showBlockTypes =
 				.get( 'core/edit-post', 'hiddenBlockTypes' ) ?? [];
 
 		const newBlockNames = existingBlockNames.filter(
-			( type ) => ! castArray( blockNames ).includes( type )
+			( type ) =>
+				! (
+					Array.isArray( blockNames ) ? blockNames : [ blockNames ]
+				 ).includes( type )
 		);
 
 		registry
@@ -319,7 +322,7 @@ export const hideBlockTypes =
 
 		const mergedBlockNames = new Set( [
 			...existingBlockNames,
-			...castArray( blockNames ),
+			...( Array.isArray( blockNames ) ? blockNames : [ blockNames ] ),
 		] );
 
 		registry

--- a/packages/edit-site/src/components/keyboard-shortcut-help-modal/shortcut.js
+++ b/packages/edit-site/src/components/keyboard-shortcut-help-modal/shortcut.js
@@ -1,9 +1,4 @@
 /**
- * External dependencies
- */
-import { castArray } from 'lodash';
-
-/**
  * WordPress dependencies
  */
 import { Fragment } from '@wordpress/element';
@@ -26,20 +21,22 @@ function KeyCombination( { keyCombination, forceAriaLabel } ) {
 			className="edit-site-keyboard-shortcut-help-modal__shortcut-key-combination"
 			aria-label={ forceAriaLabel || ariaLabel }
 		>
-			{ castArray( shortcut ).map( ( character, index ) => {
-				if ( character === '+' ) {
-					return <Fragment key={ index }>{ character }</Fragment>;
-				}
+			{ ( Array.isArray( shortcut ) ? shortcut : [ shortcut ] ).map(
+				( character, index ) => {
+					if ( character === '+' ) {
+						return <Fragment key={ index }>{ character }</Fragment>;
+					}
 
-				return (
-					<kbd
-						key={ index }
-						className="edit-site-keyboard-shortcut-help-modal__shortcut-key"
-					>
-						{ character }
-					</kbd>
-				);
-			} ) }
+					return (
+						<kbd
+							key={ index }
+							className="edit-site-keyboard-shortcut-help-modal__shortcut-key"
+						>
+							{ character }
+						</kbd>
+					);
+				}
+			) }
 		</kbd>
 	);
 }

--- a/packages/editor/src/components/post-type-support-check/index.js
+++ b/packages/editor/src/components/post-type-support-check/index.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { some, castArray } from 'lodash';
+import { some } from 'lodash';
 
 /**
  * WordPress dependencies
@@ -31,7 +31,7 @@ export function PostTypeSupportCheck( { postType, children, supportKeys } ) {
 	let isSupported = true;
 	if ( postType ) {
 		isSupported = some(
-			castArray( supportKeys ),
+			Array.isArray( supportKeys ) ? supportKeys : [ supportKeys ],
 			( key ) => !! postType.supports[ key ]
 		);
 	}

--- a/packages/editor/src/components/theme-support-check/index.js
+++ b/packages/editor/src/components/theme-support-check/index.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { castArray, includes, get, some } from 'lodash';
+import { includes, get, some } from 'lodash';
 
 /**
  * WordPress dependencies
@@ -20,17 +20,20 @@ export function ThemeSupportCheck( {
 	postType,
 	supportKeys,
 } ) {
-	const isSupported = some( castArray( supportKeys ), ( key ) => {
-		const supported = get( themeSupports, [ key ], false );
-		// 'post-thumbnails' can be boolean or an array of post types.
-		// In the latter case, we need to verify `postType` exists
-		// within `supported`. If `postType` isn't passed, then the check
-		// should fail.
-		if ( 'post-thumbnails' === key && Array.isArray( supported ) ) {
-			return includes( supported, postType );
+	const isSupported = some(
+		Array.isArray( supportKeys ) ? supportKeys : [ supportKeys ],
+		( key ) => {
+			const supported = get( themeSupports, [ key ], false );
+			// 'post-thumbnails' can be boolean or an array of post types.
+			// In the latter case, we need to verify `postType` exists
+			// within `supported`. If `postType` isn't passed, then the check
+			// should fail.
+			if ( 'post-thumbnails' === key && Array.isArray( supported ) ) {
+				return includes( supported, postType );
+			}
+			return supported;
 		}
-		return supported;
-	} );
+	);
 
 	if ( ! isSupported ) {
 		return null;


### PR DESCRIPTION
## What?
This PR removes Lodash's `_.castArray()` completely and deprecates the method. There are just a few usages and conversion is pretty straightforward. 

## Why?

Lodash is known to unnecessarily inflate the bundle size of packages, and in most cases, it can be replaced with native language functionality. See these for more information and rationale:

* https://github.com/WordPress/gutenberg/issues/16938#issuecomment-602837246
* https://github.com/WordPress/gutenberg/issues/17025
* https://github.com/WordPress/gutenberg/issues/39495 

## How?

We're safely replacing a few usages with a simple native `Array.isArray()` check that manually casts to an array if necessary. 

## Testing Instructions
* Smoke test the post editor and site editor.
* Verify all checks are green.