### PR TITLE
Comments: Add spacing support

### DIFF
--- a/docs/reference-guides/core-blocks.md
+++ b/docs/reference-guides/core-blocks.md
@@ -176,7 +176,7 @@ An advanced block that allows displaying post comments using different visual co
 
 -	**Name:** core/comments
 -	**Category:** theme
--	**Supports:** align (full, wide), color (background, gradients, link, text), typography (fontSize, lineHeight), ~~html~~
+-	**Supports:** align (full, wide), color (background, gradients, link, text), spacing (margin, padding), typography (fontSize, lineHeight), ~~html~~
 -	**Attributes:** legacy, tagName
 
 ## Comments Pagination

--- a/packages/block-library/src/comments/block.json
+++ b/packages/block-library/src/comments/block.json
@@ -18,7 +18,6 @@
 	},
 	"supports": {
 		"align": [ "wide", "full" ],
-		"html": false,
 		"color": {
 			"gradients": true,
 			"link": true,
@@ -27,6 +26,11 @@
 				"text": true,
 				"link": true
 			}
+		},
+		"html": false,
+		"spacing": {
+			"margin": true,
+			"padding": true
 		},
 		"typography": {
 			"fontSize": true,

--- a/packages/block-library/src/comments/style.scss
+++ b/packages/block-library/src/comments/style.scss
@@ -1,5 +1,7 @@
 /* Styles for backwards compatibility with the legacy `post-comments` block */
 .wp-block-post-comments {
+	// This block has customizable padding, border-box makes that more predictable.
+	box-sizing: border-box;
 
 	/* utility classes */
 	.alignleft {


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->
Add padding and margin support to the comments block.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
For consistency.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

## Testing Instructions
Create a new post or page and add a comments block.
Confirm that there is a dimension panel and that padding and margin are available but not enabled by default.
Test the padding and margin settings and confirm if the settings work, both in the editor and the front (optionally, add a background color for better visibility).

## Screenshots or screencast <!-- if applicable -->
