### PR TITLE
Site Logo: Fix user permission HTTP errors

### DIFF
--- a/packages/block-library/src/site-logo/edit.js
+++ b/packages/block-library/src/site-logo/edit.js
@@ -81,12 +81,12 @@ const SiteLogo = ( {
 	} );
 	const { imageEditing, maxWidth, title } = useSelect( ( select ) => {
 		const { getSettings } = select( blockEditorStore );
-		const siteEntities = select( coreStore ).getEditedEntityRecord(
+		const siteEntities = select( coreStore ).getEntityRecord(
 			'root',
-			'site'
+			'__unstableBase'
 		);
 		return {
-			title: siteEntities.title,
+			title: siteEntities?.name,
 			...pick( getSettings(), [ 'imageEditing', 'maxWidth' ] ),
 		};
 	}, [] );

--- a/packages/block-library/src/site-logo/edit.js
+++ b/packages/block-library/src/site-logo/edit.js
@@ -370,12 +370,14 @@ export default function LogoEdit( {
 	} = useSelect( ( select ) => {
 		const { canUser, getEntityRecord, getEditedEntityRecord } =
 			select( coreStore );
-		const siteSettings = getEditedEntityRecord( 'root', 'site' );
-		const siteData = getEntityRecord( 'root', '__unstableBase' );
-		const _siteLogo = siteSettings?.site_logo;
-		const _readOnlyLogo = siteData?.site_logo;
 		const _canUserEdit = canUser( 'update', 'settings' );
-		const _siteLogoId = _canUserEdit ? _siteLogo : _readOnlyLogo;
+		const siteSettings = _canUserEdit
+			? getEditedEntityRecord( 'root', 'site' )
+			: undefined;
+		const siteData = getEntityRecord( 'root', '__unstableBase' );
+		const _siteLogoId = _canUserEdit
+			? siteSettings?.site_logo
+			: siteData?.site_logo;
 		const _siteIconId = siteSettings?.site_icon;
 		const mediaItem =
 			_siteLogoId &&


### PR DESCRIPTION
## What?
Similar to #45093.

PR fixes user permission HTTP errors generated by the Site Logo block for non-admin users.

## Why?
The editor should check permission before making requests when data isn't available for everyone.

## How?
* I've updated the selector logic to conditionally fetch data from the settings endpoint or the read-only index based on user permissions.
* Used read-only endpoint for fetching the site title.

## Testing Instructions

### Admin users

The Site Logo block should work as before.

### Non-admin users (e.g. Editor or Author role).

1. Log into WP as a non-admin user
2. Create a new post.
3. Open your browser DevTools (Network tab), and clear it.
4. Insert a Site Logo block
5. No network request to fail with a 403.
