### PR TITLE
Components: Refactor `Tooltip` tests to always render inline

### DIFF
--- a/packages/components/src/ui/tooltip/test/index.js
+++ b/packages/components/src/ui/tooltip/test/index.js
@@ -13,22 +13,20 @@ describe( 'props', () => {
 	const baseTooltipId = 'base-tooltip';
 	const baseTooltipTriggerContent = 'WordPress.org - Base trigger content';
 	const byId = ( id ) => ( t ) => t.id === id;
-	const renderVisibleTooltip = () => {
-		render(
-			<Tooltip baseId={ baseTooltipId } content="Code is Poetry" visible>
-				<Text>{ baseTooltipTriggerContent }</Text>
-			</Tooltip>
-		);
-	};
+	const VisibleTooltip = () => (
+		<Tooltip baseId={ baseTooltipId } content="Code is Poetry" visible>
+			<Text>{ baseTooltipTriggerContent }</Text>
+		</Tooltip>
+	);
 
 	test( 'should render correctly', () => {
-		renderVisibleTooltip();
+		render( <VisibleTooltip /> );
 		const tooltip = screen.getByRole( /tooltip/i );
 		expect( tooltip ).toMatchSnapshot();
 	} );
 
 	test( 'should render invisible', () => {
-		renderVisibleTooltip();
+		render( <VisibleTooltip /> );
 		const invisibleTooltipTriggerContent = 'WordPress.org - Invisible';
 		render(
 			<Tooltip
@@ -52,7 +50,7 @@ describe( 'props', () => {
 	} );
 
 	test( 'should render without children', () => {
-		renderVisibleTooltip();
+		render( <VisibleTooltip /> );
 		const childlessTooltipId = 'tooltip-without-children';
 		render(
 			<Tooltip
@@ -67,7 +65,7 @@ describe( 'props', () => {
 	} );
 
 	test( 'should not render a tooltip without content', () => {
-		renderVisibleTooltip();
+		render( <VisibleTooltip /> );
 		const contentlessTooltipId = 'contentless-tooltip';
 		render(
 			<Tooltip baseId={ contentlessTooltipId } visible>


### PR DESCRIPTION
## What?
This PR refactors the `Tooltip` tests to always render inline.

## Why?
This was suggested in [post-merge feedback](https://github.com/WordPress/gutenberg/pull/45097#discussion_r999194033) and is an improvement over what was previously suggested as it makes the tests more readable.

## How?
We're abstracting the function to a component and render it inline in every test.

## Testing Instructions
Verify tests still pass: `npm run test:unit packages/components/src/ui/tooltip/test/index.js`