### PR TITLE
ESLint: Fix `testing-library/render-result-naming-convention` violations

### DIFF
--- a/packages/block-editor/src/components/inserter/test/reusable-blocks-tab.js
+++ b/packages/block-editor/src/components/inserter/test/reusable-blocks-tab.js
@@ -41,14 +41,14 @@ function InserterBlockList( props ) {
 }
 
 const initializeAllClosedMenuState = ( propOverrides ) => {
-	const result = render( <InserterBlockList { ...propOverrides } /> );
-	const activeTabs = result.container.querySelectorAll(
+	const { container } = render( <InserterBlockList { ...propOverrides } /> );
+	const activeTabs = container.querySelectorAll(
 		'.components-panel__body.is-opened button.components-panel__body-toggle'
 	);
 	activeTabs.forEach( ( tab ) => {
 		fireEvent.click( tab );
 	} );
-	return result;
+	return container;
 };
 
 describe( 'InserterMenu', () => {
@@ -92,7 +92,7 @@ describe( 'InserterMenu', () => {
 	} );
 
 	it( 'should list reusable blocks', () => {
-		const { container } = initializeAllClosedMenuState();
+		const container = initializeAllClosedMenuState();
 		const blocks = container.querySelectorAll(
 			'.block-editor-block-types-list__item-title'
 		);

--- a/packages/components/src/item-group/test/index.js
+++ b/packages/components/src/item-group/test/index.js
@@ -11,12 +11,12 @@ import { Item, ItemGroup } from '..';
 describe( 'ItemGroup', () => {
 	describe( 'ItemGroup component', () => {
 		it( 'should render correctly', () => {
-			const wrapper = render(
+			const { container } = render(
 				<ItemGroup>
 					<Item>Code is poetry</Item>
 				</ItemGroup>
 			);
-			expect( wrapper.container.firstChild ).toMatchSnapshot();
+			expect( container.firstChild ).toMatchSnapshot();
 		} );
 
 		it( 'should show borders when the isBordered prop is true', () => {

--- a/packages/components/src/sandbox/test/index.js
+++ b/packages/components/src/sandbox/test/index.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { act, fireEvent, render, screen } from '@testing-library/react';
+import { fireEvent, render, screen } from '@testing-library/react';
 
 /**
  * WordPress dependencies
@@ -39,10 +39,7 @@ describe( 'Sandbox', () => {
 	};
 
 	it( 'should rerender with new emdeded content if html prop changes', () => {
-		let result;
-		act( () => {
-			result = render( <TestWrapper /> );
-		} );
+		const result = render( <TestWrapper /> );
 
 		const iframe = result.container.querySelector( '.components-sandbox' );
 
@@ -54,9 +51,7 @@ describe( 'Sandbox', () => {
 			'https://super.embed'
 		);
 
-		act( () => {
-			fireEvent.click( screen.getByRole( 'button' ) );
-		} );
+		fireEvent.click( screen.getByRole( 'button' ) );
 
 		sandboxedIframe =
 			iframe.contentWindow.document.body.querySelector( '.mock-iframe' );

--- a/packages/components/src/ui/spinner/test/index.js
+++ b/packages/components/src/ui/spinner/test/index.js
@@ -10,23 +10,27 @@ import { Spinner } from '..';
 
 describe( 'props', () => {
 	test( 'should render correctly', () => {
-		const base = render( <Spinner /> );
-		expect( base.container.firstChild ).toMatchSnapshot();
+		const { container } = render( <Spinner /> );
+		expect( container.firstChild ).toMatchSnapshot();
 	} );
 
 	test( 'should render color', () => {
-		const base = render( <Spinner /> );
-		const { container } = render( <Spinner color="blue" /> );
-		expect( container.firstChild ).toMatchDiffSnapshot(
-			base.container.firstChild
+		const { container } = render( <Spinner /> );
+		const { container: secondRenderContainer } = render(
+			<Spinner color="blue" />
+		);
+		expect( secondRenderContainer.firstChild ).toMatchDiffSnapshot(
+			container.firstChild
 		);
 	} );
 
 	test( 'should render size', () => {
-		const base = render( <Spinner /> );
-		const { container } = render( <Spinner size={ 31 } /> );
-		expect( container.firstChild ).toMatchDiffSnapshot(
-			base.container.firstChild
+		const { container } = render( <Spinner /> );
+		const { container: secondRenderContainer } = render(
+			<Spinner size={ 31 } />
+		);
+		expect( secondRenderContainer.firstChild ).toMatchDiffSnapshot(
+			container.firstChild
 		);
 	} );
 } );

--- a/packages/data/src/components/with-select/test/index.js
+++ b/packages/data/src/components/with-select/test/index.js
@@ -584,7 +584,7 @@ describe( 'withSelect', () => {
 		expect( ChildOriginalComponent ).toHaveBeenCalledTimes( 1 );
 		expect( ParentOriginalComponent ).toHaveBeenCalledTimes( 1 );
 
-		await ( async () => {
+		await act( async () => {
 			registry.dispatch( 'childRender' ).toggleRender();
 		} );
 

--- a/packages/data/src/components/with-select/test/index.js
+++ b/packages/data/src/components/with-select/test/index.js
@@ -584,7 +584,7 @@ describe( 'withSelect', () => {
 		expect( ChildOriginalComponent ).toHaveBeenCalledTimes( 1 );
 		expect( ParentOriginalComponent ).toHaveBeenCalledTimes( 1 );
 
-		await act( async () => {
+		await ( async () => {
 			registry.dispatch( 'childRender' ).toggleRender();
 		} );
 


### PR DESCRIPTION
## What?
This PR fixes all violations of the [`testing-library/render-result-naming-convention` rule](https://github.com/testing-library/eslint-plugin-testing-library/blob/main/docs/rules/render-result-naming-convention.md), in preparation for enabling `eslint-plugin-testing-library` globally for the project. We're also using the opportunity to address the few ` testing-library/no-unnecessary-act` violations.

See the [plugin README](https://github.com/testing-library/eslint-plugin-testing-library) for more info on the `testing-library` ESLint plugin.

See #45103 for enabling the `testing-library/eslint-plugin-testing-library` eslint plugin.

## Why?
We've been improving our tests a lot recently with the migration to `@testing-library`. One way we could improve them is to better standardize them and follow best practices whenever we can, and one of the best ways to get there is to follow the recommended ESLint rules of the libraries and utilities we use under the hood.

## How?
We're essentially using the recommended ways to destructure the `render()` result and removing unnecessary `act()` calls. 

There are a few remaining `render-result-naming-convention` violations, but those are false alarms and we'll fix them with some explicit `eslint-disable` rules.

## Testing Instructions
Verify all checks are green.

cc @brookewp as we've been discussing working to address some of those violations together.