### PR TITLE
[Block Library - Video]: Add toolbar button to add/remove caption

### DIFF
--- a/packages/block-library/src/video/edit.js
+++ b/packages/block-library/src/video/edit.js
@@ -29,7 +29,7 @@ import {
 	store as blockEditorStore,
 	__experimentalGetElementClassName,
 } from '@wordpress/block-editor';
-import { useRef, useEffect, useState } from '@wordpress/element';
+import { useRef, useEffect, useState, useCallback } from '@wordpress/element';
 import { __, sprintf } from '@wordpress/i18n';
 import { useInstanceId, usePrevious } from '@wordpress/compose';
 import { useDispatch, useSelect } from '@wordpress/data';
@@ -79,7 +79,6 @@ function VideoEdit( {
 	const { id, caption, controls, poster, src, tracks } = attributes;
 	const prevCaption = usePrevious( caption );
 	const [ showCaption, setShowCaption ] = useState( !! caption );
-	const captionRef = useRef();
 	const isTemporaryVideo = ! id && isBlobURL( src );
 	const mediaUpload = useSelect(
 		( select ) => select( blockEditorStore ).getSettings().mediaUpload,
@@ -116,11 +115,14 @@ function VideoEdit( {
 	}, [ caption, prevCaption ] );
 
 	// Focus the caption when we click to add one.
-	useEffect( () => {
-		if ( showCaption && ! caption ) {
-			captionRef.current?.focus();
-		}
-	}, [ caption, showCaption ] );
+	const captionRef = useCallback(
+		( node ) => {
+			if ( node && ! caption ) {
+				node.focus();
+			}
+		},
+		[ caption ]
+	);
 
 	useEffect( () => {
 		if ( ! isSelected && ! caption ) {


### PR DESCRIPTION
## What?

This PR adds a toggle toolbar item on Video's Block Toolbar to add/remove a caption. It follows suit with what we did in [Image block](https://github.com/WordPress/gutenberg/pull/44965) with the a11y concerns addressed.


## Testing Instructions
1. Insert video blocks(with or without captions)
2. Edit captions, navigate around history after changes(undo/redo) and select various blocks.

## Screenshots or screencast <!-- if applicable -->


https://user-images.githubusercontent.com/16275880/196697064-0fe78cee-11d4-4316-84a5-c9dd06949eeb.mov

