### PR TITLE
Add storybook intro 

### DIFF
--- a/storybook/stories/docs/introduction.story.mdx
+++ b/storybook/stories/docs/introduction.story.mdx
@@ -3,7 +3,6 @@ import { Meta } from '@storybook/addon-docs';
 <Meta title="Docs/Introduction" />
 
 # Introduction
-
 ## Welcome! 
 The WordPress Gutenberg project uses Storybook to view and work with the UI components 
 developed in the WordPress package [@wordpress/components](https://github.com/WordPress/gutenberg/tree/trunk/packages/components). 
@@ -11,7 +10,8 @@ developed in the WordPress package [@wordpress/components](https://github.com/Wo
 On this interactive site you can browse individual components, 
 their controls, options, and settings in isolation. You can also modify controls and arguments and see the changes right away. 
 
-The components displayed on this site can be used in your custom blocks by importing them from the components root directory:
+The components displayed on this site can be used in your code to build the editor's UI for your custom blocks or other pages. 
+Import them from the components root directory:
 
 ```
 import { Button } from '@wordpress/components';

--- a/storybook/stories/docs/introduction.story.mdx
+++ b/storybook/stories/docs/introduction.story.mdx
@@ -4,4 +4,21 @@ import { Meta } from '@storybook/addon-docs';
 
 # Introduction
 
-Hello World
+## Welcome! 
+The WordPress Gutenberg project uses Storybook to view and work with the UI components 
+developed in the WordPress package [@wordpress/components](https://github.com/WordPress/gutenberg/tree/trunk/packages/components). 
+On this interactive site you can browse single components, 
+their controls, options, and settings in isolation, modify controls and arguments and see the changes right away. 
+
+The site shows the Components in the sidebar and the Canvas on the right. 
+Select the component you’d like to explore, and you’ll see the display on the Canvas tab. 
+If the component also has controls/arguments, you can modify them on the Controls tab on the lower half of the screen. 
+
+To view the documentation for each component use the Docs menu item in the top toolbar. 
+
+For local use in your development environment `npm run storybook:dev` from the top-level Gutenberg directory
+
+## Resources to learn more: 
+- [Storybook.js.org](https://storybook.js.org/) - Storybook is a frontend workshop for building UI components and pages in isolation. 
+- [[Package] Components](https://github.com/WordPress/gutenberg/issues?q=is%3Aopen+is%3Aissue+label%3A%22%5BPackage%5D+Components%22) - Open Issue Gutenberg Repo
+

--- a/storybook/stories/docs/introduction.story.mdx
+++ b/storybook/stories/docs/introduction.story.mdx
@@ -11,7 +11,7 @@ On this interactive site you can browse individual components,
 their controls, options, and settings in isolation. You can also modify controls and arguments and see the changes right away. 
 
 The components displayed on this site can be used in your code to build the editor's UI for your custom blocks or other pages. 
-Import them from the components root directory:
+Import them from the components root directory like in below example: 
 
 ```
 import { Button } from '@wordpress/components';

--- a/storybook/stories/docs/introduction.story.mdx
+++ b/storybook/stories/docs/introduction.story.mdx
@@ -7,18 +7,34 @@ import { Meta } from '@storybook/addon-docs';
 ## Welcome! 
 The WordPress Gutenberg project uses Storybook to view and work with the UI components 
 developed in the WordPress package [@wordpress/components](https://github.com/WordPress/gutenberg/tree/trunk/packages/components). 
-On this interactive site you can browse single components, 
-their controls, options, and settings in isolation, modify controls and arguments and see the changes right away. 
 
-The site shows the Components in the sidebar and the Canvas on the right. 
+On this interactive site you can browse individual components, 
+their controls, options, and settings in isolation. You can also modify controls and arguments and see the changes right away. 
+
+The components displayed on this site can be used in your custom blocks by importing them from the components root directory:
+
+```
+import { Button } from '@wordpress/components';
+
+export default function MyButton() { 
+    return <Button>Click Me!</Button>; 
+}
+````
+
+## How this site works
+The site shows the individual components in the sidebar and the Canvas on the right. 
 Select the component you’d like to explore, and you’ll see the display on the Canvas tab. 
 If the component also has controls/arguments, you can modify them on the Controls tab on the lower half of the screen. 
 
-To view the documentation for each component use the Docs menu item in the top toolbar. 
+To view the documentation for each component use the **Docs** menu item in the top toolbar. 
 
-For local use in your development environment `npm run storybook:dev` from the top-level Gutenberg directory
+To use it in your local development environment run the following command in the top level Gutenberg directory:
+ 
+ ```
+ npm run storybook:dev
+ ```
 
 ## Resources to learn more: 
 - [Storybook.js.org](https://storybook.js.org/) - Storybook is a frontend workshop for building UI components and pages in isolation. 
 - [[Package] Components](https://github.com/WordPress/gutenberg/issues?q=is%3Aopen+is%3Aissue+label%3A%22%5BPackage%5D+Components%22) - Open Issue Gutenberg Repo
-
+- [On the known "loading source..." issue](https://github.com/WordPress/gutenberg/issues/45095) at the 'Story' tab for some components 

--- a/storybook/stories/docs/introduction.story.mdx
+++ b/storybook/stories/docs/introduction.story.mdx
@@ -13,7 +13,7 @@ On this interactive site you can browse individual components, their controls, o
 The components displayed on this site can be used in your code to build the editor's UI for your custom blocks or other pages.
 Import them from the components root directory like in below example:
 
-```
+```jsx
 import { Button } from '@wordpress/components';
 
 export default function MyButton() {
@@ -29,7 +29,7 @@ To view the documentation for each component use the **Docs** menu item in the t
 
 To use it in your local development environment run the following command in the top level Gutenberg directory:
 
- ```
+ ```bash
  npm run storybook:dev
  ```
 

--- a/storybook/stories/docs/introduction.story.mdx
+++ b/storybook/stories/docs/introduction.story.mdx
@@ -3,38 +3,38 @@ import { Meta } from '@storybook/addon-docs';
 <Meta title="Docs/Introduction" />
 
 # Introduction
-## Welcome! 
-The WordPress Gutenberg project uses Storybook to view and work with the UI components 
-developed in the WordPress package [@wordpress/components](https://github.com/WordPress/gutenberg/tree/trunk/packages/components). 
 
-On this interactive site you can browse individual components, 
-their controls, options, and settings in isolation. You can also modify controls and arguments and see the changes right away. 
+## Welcome!
 
-The components displayed on this site can be used in your code to build the editor's UI for your custom blocks or other pages. 
-Import them from the components root directory like in below example: 
+The WordPress Gutenberg project uses Storybook to view and work with the UI components developed in the WordPress package [@wordpress/components](https://github.com/WordPress/gutenberg/tree/trunk/packages/components).
+
+On this interactive site you can browse individual components, their controls, options, and settings in isolation. You can also modify controls and arguments and see the changes right away.
+
+The components displayed on this site can be used in your code to build the editor's UI for your custom blocks or other pages.
+Import them from the components root directory like in below example:
 
 ```
 import { Button } from '@wordpress/components';
 
-export default function MyButton() { 
-    return <Button>Click Me!</Button>; 
+export default function MyButton() {
+    return <Button>Click Me!</Button>;
 }
 ````
 
 ## How this site works
-The site shows the individual components in the sidebar and the Canvas on the right. 
-Select the component you’d like to explore, and you’ll see the display on the Canvas tab. 
-If the component also has controls/arguments, you can modify them on the Controls tab on the lower half of the screen. 
 
-To view the documentation for each component use the **Docs** menu item in the top toolbar. 
+The site shows the individual components in the sidebar and the Canvas on the right. Select the component you’d like to explore, and you’ll see the display on the Canvas tab. If the component also has controls/arguments, you can modify them on the Controls tab on the lower half of the screen.
+
+To view the documentation for each component use the **Docs** menu item in the top toolbar.
 
 To use it in your local development environment run the following command in the top level Gutenberg directory:
- 
+
  ```
  npm run storybook:dev
  ```
 
-## Resources to learn more: 
-- [Storybook.js.org](https://storybook.js.org/) - Storybook is a frontend workshop for building UI components and pages in isolation. 
+## Resources to learn more:
+
+- [Storybook.js.org](https://storybook.js.org/) - Storybook is a frontend workshop for building UI components and pages in isolation.
 - [[Package] Components](https://github.com/WordPress/gutenberg/issues?q=is%3Aopen+is%3Aissue+label%3A%22%5BPackage%5D+Components%22) - Open Issue Gutenberg Repo
-- [On the known "loading source..." issue](https://github.com/WordPress/gutenberg/issues/45095) at the 'Story' tab for some components 
+- [On the known "loading source..." issue](https://github.com/WordPress/gutenberg/issues/45095) at the 'Story' tab for some components


### PR DESCRIPTION
fixes #45080 

## What?
Updates the [Introduction on the Storybook site](https://wordpress.github.io/gutenberg/?path=/docs/docs-introduction--page)

## Why?
It needs more information than Hello World

## How?
Create the page in markdown >

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->

## Screenshots or screencast <!-- if applicable -->
![Screen Shot 2022-10-19 at 09 31 52](https://user-images.githubusercontent.com/39980/196705568-db7e4473-c0ca-4a58-9f02-9691c040e0cb.png)

Props @juanmaguitar @mburridge @mirka for review of the content.