### PR TITLE
[WP6.1] Site editor clips body background style

### DIFF
--- a/packages/block-editor/src/components/iframe/index.js
+++ b/packages/block-editor/src/components/iframe/index.js
@@ -282,11 +282,7 @@ function Iframe(
 
 	head = (
 		<>
-			<style>
-				{
-					'html{height:auto!important;}body{height:auto;important!;margin:0}'
-				}
-			</style>
+			<style>{ 'html{height:auto!important;}body{margin:0}' }</style>
 			{ styles.map(
 				( { tagName, href, id, rel, media, textContent } ) => {
 					const TagName = tagName.toLowerCase();

--- a/packages/block-editor/src/components/iframe/index.js
+++ b/packages/block-editor/src/components/iframe/index.js
@@ -282,7 +282,11 @@ function Iframe(
 
 	head = (
 		<>
-			<style>{ 'body{margin:0}' }</style>
+			<style>
+				{
+					'html{height:auto!important;}body{height:auto;important!;margin:0}'
+				}
+			</style>
 			{ styles.map(
 				( { tagName, href, id, rel, media, textContent } ) => {
 					const TagName = tagName.toLowerCase();


### PR DESCRIPTION
Fix: #44374

## What?
This PR fixes a problem with the site editor that is also occurring in WordPress RC2.

In a theme or theme variation, if a background color is set, it is not applied up to the actual height of the content and is looped vertically. As a result, if the background is a gradient, the background appears to be clipped in the middle.

Note: I will submit the same changes to the latest Gutenberg after this PR is merged.

## Why?
Background on this issue is discussed in detail in [this comment](https://github.com/WordPress/gutenberg/issues/44374#issuecomment-1260784743). The complication is that this problem cannot be reproduced in the usual way as long as Gutenberg plugin is enabled.

## How?
Applied `height:auto` to the `html` and `body` of the iframe, with `important` to override the styles in `common.css`.

## Testing Instructions
To test this PR (i.e., to simulate the status of WordPress core without Gutenberg), the following steps are required:

- Build the wp/6.1 branch.
- To simulate that WordPress core loading `common.css` into an iframe editor instance, add a dummy selector, `.wp-block{}`, to `wp-admin/css/common.css` in WordPress with wp-env running.
- Confirm that issue #44374 occurs in the site editor. Additionally, confirm that the issue is with the `html` and `body` `height:100%` that common.css is applying:

![capture_1](https://user-images.githubusercontent.com/54422211/196730726-97f28ca4-f48a-432b-876d-20468fcb4ded.png)

- Checkout this PR.
- Confirm that this issue is resolved:

![capture_2](https://user-images.githubusercontent.com/54422211/196732858-a4cabfe5-5b10-4172-bff5-ead41de8164b.png)

