### PR TITLE
build: Native demo editor supports Xcode 14

### DIFF
--- a/packages/react-native-editor/ios/Podfile
+++ b/packages/react-native-editor/ios/Podfile
@@ -58,6 +58,16 @@ target 'GutenbergDemo' do
         end
       end
     end
+		### End workaround for https://github.com/facebook/react-native/issues/31034
+
+		### Begin workaround: https://github.com/CocoaPods/CocoaPods/issues/8891#issuecomment-1201465446
+		installer.pods_project.targets.each do |target|
+			if target.respond_to?(:product_type) and target.product_type == "com.apple.product-type.bundle"
+				target.build_configurations.each do |config|
+						config.build_settings['CODE_SIGNING_ALLOWED'] = 'NO'
+				end
+			end
+		end
+		### End workaround: https://github.com/CocoaPods/CocoaPods/issues/8891#issuecomment-1201465446
   end
-  ### End workaround for https://github.com/facebook/react-native/issues/31034
 end

--- a/packages/react-native-editor/ios/Podfile.lock
+++ b/packages/react-native-editor/ios/Podfile.lock
@@ -544,12 +544,12 @@ SPEC CHECKSUMS:
   React-logger: faee236598b0f7e1a5e3b68577016ac451f1f993
   react-native-blur: ef741a08d020010ba65e411be0ab82d1d325e7ad
   react-native-get-random-values: b6fb85e7169b9822976793e467458c151c3e8b69
-  react-native-keyboard-aware-scroll-view: 0bc6c2dfe9056935a40dc1a70e764b7a1bbf6568
+  react-native-keyboard-aware-scroll-view: 374b637c8684d7de50bd930df1a2d2b8fd49daa5
   react-native-safe-area: c9cf765aa2dd96159476a99633e7d462ce5bb94f
-  react-native-safe-area-context: f0906bf8bc9835ac9a9d3f97e8bde2a997d8da79
+  react-native-safe-area-context: e471852c5ed67eea4b10c5d9d43c1cebae3b231d
   react-native-slider: a433f1c13c5da3c17a587351bff7371f65cc9a07
-  react-native-video: bbc5d6759a481da913f1d917dd119c3366f4c36d
-  react-native-webview: 193d233c29eacce1f42ca2637dab7ba79c25a6de
+  react-native-video: 628148a219f300d4d9f8127563aea2fe0120b718
+  react-native-webview: 1f56115845c98f0a59dfbbac685797c014a821be
   React-perflogger: 5ab487cacfe6ec19bfe3d3f8072bf71eb07d63da
   React-RCTActionSheet: 03f25695e095fb5aa003828620943c74cc281fec
   React-RCTAnimation: eaf82da39f0c36fb0ef2a28df797c5f73a2a98ea
@@ -562,8 +562,8 @@ SPEC CHECKSUMS:
   React-RCTVibration: 3e815c3d2dd2e0e931b68595b5b92d23ba38b3fb
   React-runtimeexecutor: 393e26602c1b248683372051e34db63e359e3b01
   ReactCommon: c0263c1a41509aeb94be3214fa7bc3b71eae5ef6
-  RNCClipboard: 99fc8ad669a376b756fbc8098ae2fd05c0ed0668
-  RNCMaskedView: c298b644a10c0c142055b3ae24d83879ecb13ccd
+  RNCClipboard: f49f3de56b40d0f4104680dabadc7a1f063f4fd4
+  RNCMaskedView: d367b2a8df3992114e31b32b091a0c00dc800827
   RNFastImage: 1f2cab428712a4baaf78d6169eaec7f622556dd7
   RNGestureHandler: 3e0ea0c115175e66680032904339696bab928ca3
   RNReanimated: 2366094144f5bfc2179b401237ef49034ecbee3e
@@ -575,6 +575,6 @@ SPEC CHECKSUMS:
   WordPress-Aztec-iOS: 7d11d598f14c82c727c08b56bd35fbeb7dafb504
   Yoga: 9a08effa851c1d8cc1647691895540bc168ea65f
 
-PODFILE CHECKSUM: d0a2d4714ee19a1821eb2a30029333be8d6a729f
+PODFILE CHECKSUM: efade6f93821f386d9f463cf4d0ab66f76f971ec
 
 COCOAPODS: 1.10.1


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->
Address a native Demo editor build error when using Xcode 14 to build to a physical device.

```
[...]/packages/react-native-editor/ios/Pods/Pods.xcodeproj: error: Signing for "WordPress-Aztec-iOS-WordPress-Aztec-iOS" requires a development team. Select a development team in the Signing & Capabilities editor. (in target 'WordPress-Aztec-iOS-WordPress-Aztec-iOS' from project 'Pods')
[...]/packages/react-native-editor/ios/Pods/Pods.xcodeproj: error: Signing for "React-Core-AccessibilityResources" requires a development team. Select a development team in the Signing & Capabilities editor. (in target 'React-Core-AccessibilityResources' from project 'Pods')
```

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
The native Demo editor fails to build using Xcode 14.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
Apply a [suggested workaround](https://github.com/CocoaPods/CocoaPods/issues/8891#issuecomment-1201465446) for the Xcode 14 build error.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->
1. Check out `trunk` branch.
1. `cd packages/react-native-editor/ios/`
1. `rm -rf Pods/`
1. `bundle exec pod install`
1. Build the native Demo editor to a physical device with Xcode 14.
1. Note the build error occurs.
1. Check out this PR branch.
1. `cd packages/react-native-editor/ios/`
1. `rm -rf Pods/`
1. `bundle exec pod install`
1. Build the native Demo editor to a physical device with Xcode 14.
1. Verify the error does not occur.

## Screenshots or screencast <!-- if applicable -->
n/a
