### PR TITLE
ToggleGroupControl: Add de-selectable variant

### DIFF
--- a/packages/block-editor/src/layouts/constrained.js
+++ b/packages/block-editor/src/layouts/constrained.js
@@ -116,7 +116,6 @@ export default {
 					) }
 				</p>
 				<ToggleGroupControl
-					__experimentalIsBorderless
 					label={ __( 'Justification' ) }
 					value={ justifyContent }
 					onChange={ onJustificationChange }

--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -21,6 +21,7 @@
 -   `BorderControl` & `BorderBoxControl`: Replace `__next36pxDefaultSize` with "default" and "large" size variants ([#41860](https://github.com/WordPress/gutenberg/pull/41860)).
 -   `UnitControl`: Remove outer wrapper to normalize className placement ([#41860](https://github.com/WordPress/gutenberg/pull/41860)).
 -   `ColorPalette`: Fix transparent checkered background pattern ([#45295](https://github.com/WordPress/gutenberg/pull/45295)).
+-   `ToggleGroupControl`: Add `isDeselectable` prop to allow deselecting the selected option ([#45123](https://github.com/WordPress/gutenberg/pull/45123)).
 
 ### Bug Fix
 
@@ -53,10 +54,6 @@
 -   `ToggleGroupControl`: Remove unsupported `disabled` prop from types, and correctly mark `label` prop as required ([#45114](https://github.com/WordPress/gutenberg/pull/45114)).
 -   `Navigator`: prevent partially hiding focus ring styles, by removing unnecessary overflow rules on `NavigatorScreen` ([#44973](https://github.com/WordPress/gutenberg/pull/44973)).
 -   `Navigator`: restore focus only once per location  ([#44972](https://github.com/WordPress/gutenberg/pull/44972)).
-
-### Enhancements
-
--   `ToggleGroupControl`: Add `isDeselectable` prop to allow deselecting the selected option ([#45123](https://github.com/WordPress/gutenberg/pull/45123)).
 
 ### Documentation
 

--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -54,6 +54,10 @@
 -   `Navigator`: prevent partially hiding focus ring styles, by removing unnecessary overflow rules on `NavigatorScreen` ([#44973](https://github.com/WordPress/gutenberg/pull/44973)).
 -   `Navigator`: restore focus only once per location  ([#44972](https://github.com/WordPress/gutenberg/pull/44972)).
 
+### Enhancements
+
+-   `ToggleGroupControl`: Add `isDeselectable` prop to allow deselecting the selected option ([#45123](https://github.com/WordPress/gutenberg/pull/45123)).
+
 ### Documentation
 
 -   `VisuallyHidden`: Add some notes on best practices around stacking contexts when using this component ([#44867](https://github.com/WordPress/gutenberg/pull/44867)).

--- a/packages/components/src/toggle-group-control/stories/index.tsx
+++ b/packages/components/src/toggle-group-control/stories/index.tsx
@@ -122,3 +122,13 @@ WithIcons.args = {
 		{ value: 'lowercase', label: 'Lowercase', icon: formatLowercase },
 	].map( mapPropsToOptionIconComponent ),
 };
+
+/**
+ * When the `isDeselectable` prop is true, the option can be deselected by clicking on it again.
+ */
+export const Deselectable: ComponentStory< typeof ToggleGroupControl > =
+	Template.bind( {} );
+Deselectable.args = {
+	...WithIcons.args,
+	isDeselectable: true,
+};

--- a/packages/components/src/toggle-group-control/stories/index.tsx
+++ b/packages/components/src/toggle-group-control/stories/index.tsx
@@ -122,13 +122,3 @@ WithIcons.args = {
 		{ value: 'lowercase', label: 'Lowercase', icon: formatLowercase },
 	].map( mapPropsToOptionIconComponent ),
 };
-
-/**
- * A borderless style may be preferred in some contexts.
- */
-export const Borderless: ComponentStory< typeof ToggleGroupControl > =
-	Template.bind( {} );
-Borderless.args = {
-	...WithIcons.args,
-	__experimentalIsBorderless: true,
-};

--- a/packages/components/src/toggle-group-control/test/__snapshots__/index.tsx.snap
+++ b/packages/components/src/toggle-group-control/test/__snapshots__/index.tsx.snap
@@ -41,7 +41,6 @@ exports[`ToggleGroupControl should render correctly with icons 1`] = `
 .emotion-8 {
   background: #fff;
   border: 1px solid transparent;
-  border-radius: 2px;
   display: -webkit-inline-box;
   display: -webkit-inline-flex;
   display: -ms-inline-flexbox;
@@ -53,12 +52,17 @@ exports[`ToggleGroupControl should render correctly with icons 1`] = `
   transition: transform 100ms linear;
   min-height: 36px;
   border-color: #757575;
+  border-radius: 2px;
 }
 
 @media ( prefers-reduced-motion: reduce ) {
   .emotion-8 {
     transition-duration: 0ms;
   }
+}
+
+.emotion-8:hover {
+  border-color: #757575;
 }
 
 .emotion-8:focus-within {
@@ -68,14 +72,9 @@ exports[`ToggleGroupControl should render correctly with icons 1`] = `
   z-index: 1;
 }
 
-.emotion-8:hover {
-  border-color: #757575;
-}
-
 .emotion-10 {
   background: #1e1e1e;
   border-radius: 2px;
-  box-shadow: transparent;
   left: 0;
   position: absolute;
   top: 2px;
@@ -142,6 +141,11 @@ exports[`ToggleGroupControl should render correctly with icons 1`] = `
   user-select: none;
   width: 100%;
   z-index: 2;
+  color: #1e1e1e;
+  width: 30px;
+  padding-left: 0;
+  padding-right: 0;
+  color: #fff;
 }
 
 @media ( prefers-reduced-motion: reduce ) {
@@ -158,24 +162,71 @@ exports[`ToggleGroupControl should render correctly with icons 1`] = `
   background: #fff;
 }
 
+.emotion-14:active {
+  background: transparent;
+}
+
 .emotion-15 {
+  font-size: 13px;
+  line-height: 1;
+}
+
+.emotion-19 {
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  -ms-appearance: none;
+  appearance: none;
+  background: transparent;
+  border: none;
+  border-radius: 2px;
+  color: #757575;
+  fill: currentColor;
+  cursor: pointer;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  font-family: inherit;
+  height: 100%;
+  -webkit-box-pack: center;
+  -ms-flex-pack: center;
+  -webkit-justify-content: center;
+  justify-content: center;
+  line-height: 100%;
+  outline: none;
+  padding: 0 12px;
+  position: relative;
+  text-align: center;
+  -webkit-transition: background 160ms linear,color 160ms linear,font-weight 60ms linear;
+  transition: background 160ms linear,color 160ms linear,font-weight 60ms linear;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
+  width: 100%;
+  z-index: 2;
   color: #1e1e1e;
   width: 30px;
   padding-left: 0;
   padding-right: 0;
 }
 
-.emotion-16 {
-  color: #fff;
+@media ( prefers-reduced-motion: reduce ) {
+  .emotion-19 {
+    transition-duration: 0ms;
+  }
 }
 
-.emotion-16:active {
-  background: transparent;
+.emotion-19::-moz-focus-inner {
+  border: 0;
 }
 
-.emotion-17 {
-  font-size: 13px;
-  line-height: 1;
+.emotion-19:active {
+  background: #fff;
 }
 
 <div>
@@ -217,7 +268,7 @@ exports[`ToggleGroupControl should render correctly with icons 1`] = `
           <button
             aria-checked="true"
             aria-label="Uppercase"
-            class="emotion-14 emotion-15 components-toggle-group-control-option-base emotion-16"
+            class="emotion-14 components-toggle-group-control-option-base"
             data-value="uppercase"
             data-wp-c16t="true"
             data-wp-component="ToggleGroupControlOptionBase"
@@ -226,7 +277,7 @@ exports[`ToggleGroupControl should render correctly with icons 1`] = `
             tabindex="0"
           >
             <div
-              class="emotion-17 emotion-18"
+              class="emotion-15 emotion-16"
             >
               <svg
                 aria-hidden="true"
@@ -249,7 +300,7 @@ exports[`ToggleGroupControl should render correctly with icons 1`] = `
           <button
             aria-checked="false"
             aria-label="Lowercase"
-            class="emotion-14 emotion-15 components-toggle-group-control-option-base"
+            class="emotion-19 components-toggle-group-control-option-base"
             data-value="lowercase"
             data-wp-c16t="true"
             data-wp-component="ToggleGroupControlOptionBase"
@@ -258,7 +309,7 @@ exports[`ToggleGroupControl should render correctly with icons 1`] = `
             tabindex="-1"
           >
             <div
-              class="emotion-17 emotion-18"
+              class="emotion-15 emotion-16"
             >
               <svg
                 aria-hidden="true"
@@ -322,7 +373,6 @@ exports[`ToggleGroupControl should render correctly with text options 1`] = `
 .emotion-8 {
   background: #fff;
   border: 1px solid transparent;
-  border-radius: 2px;
   display: -webkit-inline-box;
   display: -webkit-inline-flex;
   display: -ms-inline-flexbox;
@@ -334,6 +384,7 @@ exports[`ToggleGroupControl should render correctly with text options 1`] = `
   transition: transform 100ms linear;
   min-height: 36px;
   border-color: #757575;
+  border-radius: 2px;
 }
 
 @media ( prefers-reduced-motion: reduce ) {
@@ -342,15 +393,15 @@ exports[`ToggleGroupControl should render correctly with text options 1`] = `
   }
 }
 
+.emotion-8:hover {
+  border-color: #757575;
+}
+
 .emotion-8:focus-within {
   border-color: var( --wp-admin-theme-color-darker-10, #006ba1);
   box-shadow: 0 0 0 0.5px var( --wp-admin-theme-color, #007cba);
   outline: none;
   z-index: 1;
-}
-
-.emotion-8:hover {
-  border-color: #757575;
 }
 
 .emotion-10 {

--- a/packages/components/src/toggle-group-control/test/__snapshots__/index.tsx.snap
+++ b/packages/components/src/toggle-group-control/test/__snapshots__/index.tsx.snap
@@ -199,7 +199,7 @@ exports[`ToggleGroupControl should render correctly with icons 1`] = `
         class="components-toggle-group-control emotion-8 emotion-9"
         data-wp-c16t="true"
         data-wp-component="ToggleGroupControl"
-        id="toggle-group-control-1"
+        id="toggle-group-control-as-radio-1"
         role="radiogroup"
       >
         <div
@@ -213,7 +213,6 @@ exports[`ToggleGroupControl should render correctly with icons 1`] = `
         />
         <div
           class="emotion-12 emotion-13"
-          data-active="true"
         >
           <button
             aria-checked="true"
@@ -222,7 +221,7 @@ exports[`ToggleGroupControl should render correctly with icons 1`] = `
             data-value="uppercase"
             data-wp-c16t="true"
             data-wp-component="ToggleGroupControlOptionBase"
-            id="toggle-group-control-1-2"
+            id="toggle-group-control-as-radio-1-2"
             role="radio"
             tabindex="0"
           >
@@ -246,7 +245,6 @@ exports[`ToggleGroupControl should render correctly with icons 1`] = `
         </div>
         <div
           class="emotion-12 emotion-13"
-          data-active="false"
         >
           <button
             aria-checked="false"
@@ -255,7 +253,7 @@ exports[`ToggleGroupControl should render correctly with icons 1`] = `
             data-value="lowercase"
             data-wp-c16t="true"
             data-wp-component="ToggleGroupControlOptionBase"
-            id="toggle-group-control-1-3"
+            id="toggle-group-control-as-radio-1-3"
             role="radio"
             tabindex="-1"
           >
@@ -448,7 +446,7 @@ exports[`ToggleGroupControl should render correctly with text options 1`] = `
         class="components-toggle-group-control emotion-8 emotion-9"
         data-wp-c16t="true"
         data-wp-component="ToggleGroupControl"
-        id="toggle-group-control-0"
+        id="toggle-group-control-as-radio-0"
         role="radiogroup"
       >
         <div
@@ -457,7 +455,6 @@ exports[`ToggleGroupControl should render correctly with text options 1`] = `
         />
         <div
           class="emotion-10 emotion-11"
-          data-active="false"
         >
           <button
             aria-checked="false"
@@ -466,7 +463,7 @@ exports[`ToggleGroupControl should render correctly with text options 1`] = `
             data-value="rigas"
             data-wp-c16t="true"
             data-wp-component="ToggleGroupControlOptionBase"
-            id="toggle-group-control-0-0"
+            id="toggle-group-control-as-radio-0-0"
             role="radio"
             tabindex="0"
           >
@@ -479,7 +476,6 @@ exports[`ToggleGroupControl should render correctly with text options 1`] = `
         </div>
         <div
           class="emotion-10 emotion-11"
-          data-active="false"
         >
           <button
             aria-checked="false"
@@ -488,7 +484,7 @@ exports[`ToggleGroupControl should render correctly with text options 1`] = `
             data-value="jack"
             data-wp-c16t="true"
             data-wp-component="ToggleGroupControlOptionBase"
-            id="toggle-group-control-0-1"
+            id="toggle-group-control-as-radio-0-1"
             role="radio"
             tabindex="-1"
           >

--- a/packages/components/src/toggle-group-control/test/__snapshots__/index.tsx.snap
+++ b/packages/components/src/toggle-group-control/test/__snapshots__/index.tsx.snap
@@ -167,6 +167,10 @@ exports[`ToggleGroupControl should render correctly with icons 1`] = `
 }
 
 .emotion-15 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
   font-size: 13px;
   line-height: 1;
 }
@@ -250,7 +254,7 @@ exports[`ToggleGroupControl should render correctly with icons 1`] = `
         class="components-toggle-group-control emotion-8 emotion-9"
         data-wp-c16t="true"
         data-wp-component="ToggleGroupControl"
-        id="toggle-group-control-as-radio-1"
+        id="toggle-group-control-as-radio-group-1"
         role="radiogroup"
       >
         <div
@@ -272,7 +276,7 @@ exports[`ToggleGroupControl should render correctly with icons 1`] = `
             data-value="uppercase"
             data-wp-c16t="true"
             data-wp-component="ToggleGroupControlOptionBase"
-            id="toggle-group-control-as-radio-1-2"
+            id="toggle-group-control-as-radio-group-1-2"
             role="radio"
             tabindex="0"
           >
@@ -304,7 +308,7 @@ exports[`ToggleGroupControl should render correctly with icons 1`] = `
             data-value="lowercase"
             data-wp-c16t="true"
             data-wp-component="ToggleGroupControlOptionBase"
-            id="toggle-group-control-as-radio-1-3"
+            id="toggle-group-control-as-radio-group-1-3"
             role="radio"
             tabindex="-1"
           >
@@ -472,6 +476,10 @@ exports[`ToggleGroupControl should render correctly with text options 1`] = `
 }
 
 .emotion-13 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
   font-size: 13px;
   line-height: 1;
 }
@@ -497,7 +505,7 @@ exports[`ToggleGroupControl should render correctly with text options 1`] = `
         class="components-toggle-group-control emotion-8 emotion-9"
         data-wp-c16t="true"
         data-wp-component="ToggleGroupControl"
-        id="toggle-group-control-as-radio-0"
+        id="toggle-group-control-as-radio-group-0"
         role="radiogroup"
       >
         <div
@@ -514,7 +522,7 @@ exports[`ToggleGroupControl should render correctly with text options 1`] = `
             data-value="rigas"
             data-wp-c16t="true"
             data-wp-component="ToggleGroupControlOptionBase"
-            id="toggle-group-control-as-radio-0-0"
+            id="toggle-group-control-as-radio-group-0-0"
             role="radio"
             tabindex="0"
           >
@@ -535,7 +543,7 @@ exports[`ToggleGroupControl should render correctly with text options 1`] = `
             data-value="jack"
             data-wp-c16t="true"
             data-wp-component="ToggleGroupControlOptionBase"
-            id="toggle-group-control-as-radio-0-1"
+            id="toggle-group-control-as-radio-group-0-1"
             role="radio"
             tabindex="-1"
           >

--- a/packages/components/src/toggle-group-control/test/index.tsx
+++ b/packages/components/src/toggle-group-control/test/index.tsx
@@ -178,7 +178,7 @@ describe( 'ToggleGroupControl', () => {
 		} );
 
 		describe( 'isDeselectable = true', () => {
-			it( 'should  be deselectable', async () => {
+			it( 'should be deselectable', async () => {
 				const mockOnChange = jest.fn();
 				const user = userEvent.setup( {
 					advanceTimers: jest.advanceTimersByTime,
@@ -196,7 +196,7 @@ describe( 'ToggleGroupControl', () => {
 				);
 
 				await user.click(
-					await screen.findByRole( 'button', {
+					await screen.getByRole( 'button', {
 						name: 'R',
 						pressed: true,
 					} )

--- a/packages/components/src/toggle-group-control/toggle-group-control-option-base/component.tsx
+++ b/packages/components/src/toggle-group-control/toggle-group-control-option-base/component.tsx
@@ -76,10 +76,8 @@ function ToggleGroupControlOptionBase(
 	const cx = useCx();
 	const labelViewClasses = cx( isBlock && styles.labelBlock );
 	const classes = cx(
-		styles.buttonView,
-		isIcon && styles.isIcon( { size } ),
-		className,
-		isPressed && styles.buttonPressed
+		styles.buttonView( { isDeselectable, isIcon, isPressed, size } ),
+		className
 	);
 
 	const buttonOnClick = () => {

--- a/packages/components/src/toggle-group-control/toggle-group-control-option-base/component.tsx
+++ b/packages/components/src/toggle-group-control/toggle-group-control-option-base/component.tsx
@@ -58,20 +58,21 @@ function ToggleGroupControlOptionBase(
 		'ToggleGroupControlOptionBase'
 	);
 	const {
-		className,
 		isBlock = false,
+		isDeselectable = false,
+		size = 'default',
+		...otherContextProps
+	} = toggleGroupControlContext;
+	const {
+		className,
 		isIcon = false,
 		value,
 		children,
-		size = 'default',
 		showTooltip = false,
-		...radioProps
-	} = {
-		...toggleGroupControlContext,
-		...buttonProps,
-	};
+		...otherButtonProps
+	} = buttonProps;
 
-	const isActive = radioProps.state === value;
+	const isActive = otherContextProps.state === value;
 	const cx = useCx();
 	const labelViewClasses = cx( isBlock && styles.labelBlock );
 	const classes = cx(
@@ -81,23 +82,44 @@ function ToggleGroupControlOptionBase(
 		isActive && styles.buttonActive
 	);
 
+	const buttonOnClick = () => {
+		if ( isDeselectable && isActive ) {
+			otherContextProps.setState( undefined );
+		} else {
+			otherContextProps.setState( value );
+		}
+	};
+
 	return (
-		<LabelView className={ labelViewClasses } data-active={ isActive }>
+		<LabelView className={ labelViewClasses }>
 			<WithToolTip
 				showTooltip={ showTooltip }
-				text={ radioProps[ 'aria-label' ] }
+				text={ otherButtonProps[ 'aria-label' ] }
 			>
-				<Radio
-					{ ...radioProps }
-					as="button"
-					aria-label={ radioProps[ 'aria-label' ] }
-					className={ classes }
-					data-value={ value }
-					ref={ forwardedRef }
-					value={ value }
-				>
-					<ButtonContentView>{ children }</ButtonContentView>
-				</Radio>
+				{ isDeselectable ? (
+					<button
+						{ ...otherButtonProps }
+						type="button"
+						className={ classes }
+						data-value={ value }
+						onClick={ buttonOnClick }
+						ref={ forwardedRef }
+					>
+						<ButtonContentView>{ children }</ButtonContentView>
+					</button>
+				) : (
+					<Radio
+						as="button"
+						{ ...otherButtonProps }
+						{ ...otherContextProps }
+						className={ classes }
+						data-value={ value }
+						ref={ forwardedRef }
+						value={ value }
+					>
+						<ButtonContentView>{ children }</ButtonContentView>
+					</Radio>
+				) }
 			</WithToolTip>
 		</LabelView>
 	);

--- a/packages/components/src/toggle-group-control/toggle-group-control-option-base/component.tsx
+++ b/packages/components/src/toggle-group-control/toggle-group-control-option-base/component.tsx
@@ -72,18 +72,18 @@ function ToggleGroupControlOptionBase(
 		...otherButtonProps
 	} = buttonProps;
 
-	const isActive = otherContextProps.state === value;
+	const isPressed = otherContextProps.state === value;
 	const cx = useCx();
 	const labelViewClasses = cx( isBlock && styles.labelBlock );
 	const classes = cx(
 		styles.buttonView,
 		isIcon && styles.isIcon( { size } ),
 		className,
-		isActive && styles.buttonActive
+		isPressed && styles.buttonPressed
 	);
 
 	const buttonOnClick = () => {
-		if ( isDeselectable && isActive ) {
+		if ( isDeselectable && isPressed ) {
 			otherContextProps.setState( undefined );
 		} else {
 			otherContextProps.setState( value );

--- a/packages/components/src/toggle-group-control/toggle-group-control-option-base/component.tsx
+++ b/packages/components/src/toggle-group-control/toggle-group-control-option-base/component.tsx
@@ -97,6 +97,7 @@ function ToggleGroupControlOptionBase(
 				{ isDeselectable ? (
 					<button
 						{ ...otherButtonProps }
+						aria-pressed={ isPressed }
 						type="button"
 						className={ classes }
 						data-value={ value }

--- a/packages/components/src/toggle-group-control/toggle-group-control-option-base/component.tsx
+++ b/packages/components/src/toggle-group-control/toggle-group-control-option-base/component.tsx
@@ -88,6 +88,13 @@ function ToggleGroupControlOptionBase(
 		}
 	};
 
+	const commonProps = {
+		...otherButtonProps,
+		className: classes,
+		'data-value': value,
+		ref: forwardedRef,
+	};
+
 	return (
 		<LabelView className={ labelViewClasses }>
 			<WithToolTip
@@ -96,26 +103,20 @@ function ToggleGroupControlOptionBase(
 			>
 				{ isDeselectable ? (
 					<button
-						{ ...otherButtonProps }
+						{ ...commonProps }
 						aria-pressed={ isPressed }
 						type="button"
-						className={ classes }
-						data-value={ value }
 						onClick={ buttonOnClick }
-						ref={ forwardedRef }
 					>
 						<ButtonContentView>{ children }</ButtonContentView>
 					</button>
 				) : (
 					<Radio
-						{ ...otherButtonProps }
+						{ ...commonProps }
 						{
 							...otherContextProps /* these are only for Ariakit Radio */
 						}
 						as="button"
-						className={ classes }
-						data-value={ value }
-						ref={ forwardedRef }
 						value={ value }
 					>
 						<ButtonContentView>{ children }</ButtonContentView>

--- a/packages/components/src/toggle-group-control/toggle-group-control-option-base/component.tsx
+++ b/packages/components/src/toggle-group-control/toggle-group-control-option-base/component.tsx
@@ -108,9 +108,9 @@ function ToggleGroupControlOptionBase(
 					</button>
 				) : (
 					<Radio
-						as="button"
 						{ ...otherButtonProps }
 						{ ...otherContextProps }
+						as="button"
 						className={ classes }
 						data-value={ value }
 						ref={ forwardedRef }

--- a/packages/components/src/toggle-group-control/toggle-group-control-option-base/component.tsx
+++ b/packages/components/src/toggle-group-control/toggle-group-control-option-base/component.tsx
@@ -61,7 +61,7 @@ function ToggleGroupControlOptionBase(
 		isBlock = false,
 		isDeselectable = false,
 		size = 'default',
-		...otherContextProps
+		...otherContextProps /* context props for Ariakit Radio */
 	} = toggleGroupControlContext;
 	const {
 		className,
@@ -109,7 +109,9 @@ function ToggleGroupControlOptionBase(
 				) : (
 					<Radio
 						{ ...otherButtonProps }
-						{ ...otherContextProps }
+						{
+							...otherContextProps /* these are only for Ariakit Radio */
+						}
 						as="button"
 						className={ classes }
 						data-value={ value }

--- a/packages/components/src/toggle-group-control/toggle-group-control-option-base/styles.ts
+++ b/packages/components/src/toggle-group-control/toggle-group-control-option-base/styles.ts
@@ -21,7 +21,17 @@ export const labelBlock = css`
 	flex: 1;
 `;
 
-export const buttonView = css`
+export const buttonView = ( {
+	isDeselectable,
+	isIcon,
+	isPressed,
+	size,
+}: {
+	isDeselectable?: boolean;
+	isIcon?: boolean;
+	isPressed?: boolean;
+	size: NonNullable< ToggleGroupControlProps[ 'size' ] >;
+} ) => css`
 	align-items: center;
 	appearance: none;
 	background: transparent;
@@ -53,6 +63,22 @@ export const buttonView = css`
 	&:active {
 		background: ${ CONFIG.toggleGroupControlBackgroundColor };
 	}
+
+	${ isDeselectable && deselectable }
+	${ isIcon && isIconStyles( { size } ) }
+	${ isPressed && pressed }
+`;
+
+const pressed = css`
+	color: ${ COLORS.white };
+
+	&:active {
+		background: transparent;
+	}
+`;
+
+const deselectable = css`
+	color: ${ COLORS.gray[ 900 ] };
 `;
 
 export const ButtonContentView = styled.div`
@@ -60,11 +86,7 @@ export const ButtonContentView = styled.div`
 	line-height: 1;
 `;
 
-export const separatorActive = css`
-	background: transparent;
-`;
-
-export const isIcon = ( {
+const isIconStyles = ( {
 	size,
 }: {
 	size: NonNullable< ToggleGroupControlProps[ 'size' ] >;
@@ -81,11 +103,3 @@ export const isIcon = ( {
 		padding-right: 0;
 	`;
 };
-
-export const buttonPressed = css`
-	color: ${ COLORS.white };
-
-	&:active {
-		background: transparent;
-	}
-`;

--- a/packages/components/src/toggle-group-control/toggle-group-control-option-base/styles.ts
+++ b/packages/components/src/toggle-group-control/toggle-group-control-option-base/styles.ts
@@ -88,6 +88,7 @@ const deselectable = css`
 `;
 
 export const ButtonContentView = styled.div`
+	display: flex;
 	font-size: ${ CONFIG.fontSize };
 	line-height: 1;
 `;

--- a/packages/components/src/toggle-group-control/toggle-group-control-option-base/styles.ts
+++ b/packages/components/src/toggle-group-control/toggle-group-control-option-base/styles.ts
@@ -82,7 +82,7 @@ export const isIcon = ( {
 	`;
 };
 
-export const buttonActive = css`
+export const buttonPressed = css`
 	color: ${ COLORS.white };
 
 	&:active {

--- a/packages/components/src/toggle-group-control/toggle-group-control-option-base/styles.ts
+++ b/packages/components/src/toggle-group-control/toggle-group-control-option-base/styles.ts
@@ -8,7 +8,10 @@ import styled from '@emotion/styled';
  * Internal dependencies
  */
 import { CONFIG, COLORS, reduceMotion } from '../../utils';
-import type { ToggleGroupControlProps } from '../types';
+import type {
+	ToggleGroupControlProps,
+	ToggleGroupControlOptionBaseProps,
+} from '../types';
 
 export const LabelView = styled.div`
 	display: inline-flex;
@@ -26,12 +29,10 @@ export const buttonView = ( {
 	isIcon,
 	isPressed,
 	size,
-}: {
-	isDeselectable?: boolean;
-	isIcon?: boolean;
-	isPressed?: boolean;
-	size: NonNullable< ToggleGroupControlProps[ 'size' ] >;
-} ) => css`
+}: Pick< ToggleGroupControlProps, 'isDeselectable' | 'size' > &
+	Pick< ToggleGroupControlOptionBaseProps, 'isIcon' > & {
+		isPressed?: boolean;
+	} ) => css`
 	align-items: center;
 	appearance: none;
 	background: transparent;
@@ -94,10 +95,8 @@ export const ButtonContentView = styled.div`
 `;
 
 const isIconStyles = ( {
-	size,
-}: {
-	size: NonNullable< ToggleGroupControlProps[ 'size' ] >;
-} ) => {
+	size = 'default',
+}: Pick< ToggleGroupControlProps, 'size' > ) => {
 	const iconButtonSizes = {
 		default: '30px',
 		'__unstable-large': '34px',

--- a/packages/components/src/toggle-group-control/toggle-group-control-option-base/styles.ts
+++ b/packages/components/src/toggle-group-control/toggle-group-control-option-base/styles.ts
@@ -79,6 +79,12 @@ const pressed = css`
 
 const deselectable = css`
 	color: ${ COLORS.gray[ 900 ] };
+
+	&:focus {
+		box-shadow: inset 0 0 0 1px ${ COLORS.white },
+			0 0 0 ${ CONFIG.borderWidthFocus } ${ COLORS.ui.theme };
+		outline: 2px solid transparent;
+	}
 `;
 
 export const ButtonContentView = styled.div`

--- a/packages/components/src/toggle-group-control/toggle-group-control/as-button-group.tsx
+++ b/packages/components/src/toggle-group-control/toggle-group-control/as-button-group.tsx
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import type { ForwardedRef, ReactText } from 'react';
+import type { ForwardedRef } from 'react';
 
 /**
  * WordPress dependencies
@@ -34,7 +34,7 @@ function UnforwardedToggleGroupControlAsButtonGroup(
 		value,
 		...otherProps
 	}: WordPressComponentProps< ToggleGroupControlAsRadioProps, 'div', false >,
-	forwardedRef: ForwardedRef< any >
+	forwardedRef: ForwardedRef< HTMLDivElement >
 ) {
 	const containerRef = useRef();
 	const [ resizeListener, sizes ] = useResizeObserver();
@@ -42,39 +42,40 @@ function UnforwardedToggleGroupControlAsButtonGroup(
 		ToggleGroupControlAsButtonGroup,
 		'toggle-group-control-as-button-group'
 	).toString();
-	const [ selectedValue, setSelectedValue ] = useState<
-		ReactText | undefined
-	>( value );
-	const radio = { baseId, state: selectedValue, setState: setSelectedValue };
+	const [ selectedValue, setSelectedValue ] = useState( value );
+	const groupContext = {
+		baseId,
+		state: selectedValue,
+		setState: setSelectedValue,
+	};
 	const previousValue = usePrevious( value );
 
-	// Propagate radio.state change.
+	// Propagate groupContext.state change.
 	useUpdateEffect( () => {
-		// Avoid calling onChange if radio state changed
+		// Avoid calling onChange if groupContext state changed
 		// from incoming value.
-		if ( previousValue !== radio.state ) {
-			onChange( radio.state );
+		if ( previousValue !== groupContext.state ) {
+			onChange( groupContext.state );
 		}
-	}, [ radio.state ] );
+	}, [ groupContext.state ] );
 
-	// Sync incoming value with radio.state.
+	// Sync incoming value with groupContext.state.
 	useUpdateEffect( () => {
-		if ( value !== radio.state ) {
-			radio.setState( value );
+		if ( value !== groupContext.state ) {
+			groupContext.setState( value );
 		}
 	}, [ value ] );
 
 	return (
 		<ToggleGroupControlContext.Provider
 			value={ {
-				...radio,
+				...groupContext,
 				isBlock: ! isAdaptiveWidth,
 				isDeselectable: true,
 				size,
 			} }
 		>
 			<View
-				{ ...radio }
 				aria-label={ label }
 				{ ...otherProps }
 				ref={ useMergeRefs( [ containerRef, forwardedRef ] ) }
@@ -82,7 +83,7 @@ function UnforwardedToggleGroupControlAsButtonGroup(
 			>
 				{ resizeListener }
 				<ToggleGroupControlBackdrop
-					{ ...radio }
+					state={ groupContext.state }
 					containerRef={ containerRef }
 					containerWidth={ sizes.width }
 					isAdaptiveWidth={ isAdaptiveWidth }

--- a/packages/components/src/toggle-group-control/toggle-group-control/as-button-group.tsx
+++ b/packages/components/src/toggle-group-control/toggle-group-control/as-button-group.tsx
@@ -1,0 +1,98 @@
+/**
+ * External dependencies
+ */
+import type { ForwardedRef, ReactText } from 'react';
+
+/**
+ * WordPress dependencies
+ */
+import {
+	useMergeRefs,
+	useInstanceId,
+	usePrevious,
+	useResizeObserver,
+} from '@wordpress/compose';
+import { forwardRef, useRef, useState } from '@wordpress/element';
+
+/**
+ * Internal dependencies
+ */
+import { View } from '../../view';
+import ToggleGroupControlBackdrop from './toggle-group-control-backdrop';
+import ToggleGroupControlContext from '../context';
+import { useUpdateEffect } from '../../utils/hooks';
+import type { WordPressComponentProps } from '../../ui/context';
+import type { ToggleGroupControlAsRadioProps } from '../types';
+
+function UnforwardedToggleGroupControlAsButtonGroup(
+	{
+		children,
+		isAdaptiveWidth,
+		label,
+		onChange,
+		size,
+		value,
+		...otherProps
+	}: WordPressComponentProps< ToggleGroupControlAsRadioProps, 'div', false >,
+	forwardedRef: ForwardedRef< any >
+) {
+	const containerRef = useRef();
+	const [ resizeListener, sizes ] = useResizeObserver();
+	const baseId = useInstanceId(
+		ToggleGroupControlAsButtonGroup,
+		'toggle-group-control-as-button-group'
+	).toString();
+	const [ selectedValue, setSelectedValue ] = useState<
+		ReactText | undefined
+	>( value );
+	const radio = { baseId, state: selectedValue, setState: setSelectedValue };
+	const previousValue = usePrevious( value );
+
+	// Propagate radio.state change.
+	useUpdateEffect( () => {
+		// Avoid calling onChange if radio state changed
+		// from incoming value.
+		if ( previousValue !== radio.state ) {
+			onChange( radio.state );
+		}
+	}, [ radio.state ] );
+
+	// Sync incoming value with radio.state.
+	useUpdateEffect( () => {
+		if ( value !== radio.state ) {
+			radio.setState( value );
+		}
+	}, [ value ] );
+
+	return (
+		<ToggleGroupControlContext.Provider
+			value={ {
+				...radio,
+				isBlock: ! isAdaptiveWidth,
+				isDeselectable: true,
+				size,
+			} }
+		>
+			<View
+				{ ...radio }
+				aria-label={ label }
+				{ ...otherProps }
+				ref={ useMergeRefs( [ containerRef, forwardedRef ] ) }
+				role="group"
+			>
+				{ resizeListener }
+				<ToggleGroupControlBackdrop
+					{ ...radio }
+					containerRef={ containerRef }
+					containerWidth={ sizes.width }
+					isAdaptiveWidth={ isAdaptiveWidth }
+				/>
+				{ children }
+			</View>
+		</ToggleGroupControlContext.Provider>
+	);
+}
+
+export const ToggleGroupControlAsButtonGroup = forwardRef(
+	UnforwardedToggleGroupControlAsButtonGroup
+);

--- a/packages/components/src/toggle-group-control/toggle-group-control/as-button-group.tsx
+++ b/packages/components/src/toggle-group-control/toggle-group-control/as-button-group.tsx
@@ -22,7 +22,7 @@ import ToggleGroupControlBackdrop from './toggle-group-control-backdrop';
 import ToggleGroupControlContext from '../context';
 import { useUpdateEffect } from '../../utils/hooks';
 import type { WordPressComponentProps } from '../../ui/context';
-import type { ToggleGroupControlAsRadioGroupProps } from '../types';
+import type { ToggleGroupControlMainControlProps } from '../types';
 
 function UnforwardedToggleGroupControlAsButtonGroup(
 	{
@@ -34,7 +34,7 @@ function UnforwardedToggleGroupControlAsButtonGroup(
 		value,
 		...otherProps
 	}: WordPressComponentProps<
-		ToggleGroupControlAsRadioGroupProps,
+		ToggleGroupControlMainControlProps,
 		'div',
 		false
 	>,

--- a/packages/components/src/toggle-group-control/toggle-group-control/as-button-group.tsx
+++ b/packages/components/src/toggle-group-control/toggle-group-control/as-button-group.tsx
@@ -22,7 +22,7 @@ import ToggleGroupControlBackdrop from './toggle-group-control-backdrop';
 import ToggleGroupControlContext from '../context';
 import { useUpdateEffect } from '../../utils/hooks';
 import type { WordPressComponentProps } from '../../ui/context';
-import type { ToggleGroupControlAsRadioProps } from '../types';
+import type { ToggleGroupControlAsRadioGroupProps } from '../types';
 
 function UnforwardedToggleGroupControlAsButtonGroup(
 	{
@@ -33,7 +33,11 @@ function UnforwardedToggleGroupControlAsButtonGroup(
 		size,
 		value,
 		...otherProps
-	}: WordPressComponentProps< ToggleGroupControlAsRadioProps, 'div', false >,
+	}: WordPressComponentProps<
+		ToggleGroupControlAsRadioGroupProps,
+		'div',
+		false
+	>,
 	forwardedRef: ForwardedRef< HTMLDivElement >
 ) {
 	const containerRef = useRef();

--- a/packages/components/src/toggle-group-control/toggle-group-control/as-radio-group.tsx
+++ b/packages/components/src/toggle-group-control/toggle-group-control/as-radio-group.tsx
@@ -36,7 +36,7 @@ function UnforwardedToggleGroupControlAsRadio(
 		value,
 		...otherProps
 	}: WordPressComponentProps< ToggleGroupControlAsRadioProps, 'div', false >,
-	forwardedRef: ForwardedRef< any >
+	forwardedRef: ForwardedRef< HTMLDivElement >
 ) {
 	const containerRef = useRef();
 	const [ resizeListener, sizes ] = useResizeObserver();
@@ -79,7 +79,7 @@ function UnforwardedToggleGroupControlAsRadio(
 			>
 				{ resizeListener }
 				<ToggleGroupControlBackdrop
-					{ ...radio }
+					state={ radio.state }
 					containerRef={ containerRef }
 					containerWidth={ sizes.width }
 					isAdaptiveWidth={ isAdaptiveWidth }

--- a/packages/components/src/toggle-group-control/toggle-group-control/as-radio-group.tsx
+++ b/packages/components/src/toggle-group-control/toggle-group-control/as-radio-group.tsx
@@ -24,9 +24,9 @@ import ToggleGroupControlBackdrop from './toggle-group-control-backdrop';
 import ToggleGroupControlContext from '../context';
 import { useUpdateEffect } from '../../utils/hooks';
 import type { WordPressComponentProps } from '../../ui/context';
-import type { ToggleGroupControlAsRadioProps } from '../types';
+import type { ToggleGroupControlAsRadioGroupProps } from '../types';
 
-function UnforwardedToggleGroupControlAsRadio(
+function UnforwardedToggleGroupControlAsRadioGroup(
 	{
 		children,
 		isAdaptiveWidth,
@@ -35,14 +35,18 @@ function UnforwardedToggleGroupControlAsRadio(
 		size,
 		value,
 		...otherProps
-	}: WordPressComponentProps< ToggleGroupControlAsRadioProps, 'div', false >,
+	}: WordPressComponentProps<
+		ToggleGroupControlAsRadioGroupProps,
+		'div',
+		false
+	>,
 	forwardedRef: ForwardedRef< HTMLDivElement >
 ) {
 	const containerRef = useRef();
 	const [ resizeListener, sizes ] = useResizeObserver();
 	const baseId = useInstanceId(
-		ToggleGroupControlAsRadio,
-		'toggle-group-control-as-radio'
+		ToggleGroupControlAsRadioGroup,
+		'toggle-group-control-as-radio-group'
 	).toString();
 	const radio = useRadioState( {
 		baseId,
@@ -90,6 +94,6 @@ function UnforwardedToggleGroupControlAsRadio(
 	);
 }
 
-export const ToggleGroupControlAsRadio = forwardRef(
-	UnforwardedToggleGroupControlAsRadio
+export const ToggleGroupControlAsRadioGroup = forwardRef(
+	UnforwardedToggleGroupControlAsRadioGroup
 );

--- a/packages/components/src/toggle-group-control/toggle-group-control/as-radio-group.tsx
+++ b/packages/components/src/toggle-group-control/toggle-group-control/as-radio-group.tsx
@@ -24,7 +24,7 @@ import ToggleGroupControlBackdrop from './toggle-group-control-backdrop';
 import ToggleGroupControlContext from '../context';
 import { useUpdateEffect } from '../../utils/hooks';
 import type { WordPressComponentProps } from '../../ui/context';
-import type { ToggleGroupControlAsRadioGroupProps } from '../types';
+import type { ToggleGroupControlMainControlProps } from '../types';
 
 function UnforwardedToggleGroupControlAsRadioGroup(
 	{
@@ -36,7 +36,7 @@ function UnforwardedToggleGroupControlAsRadioGroup(
 		value,
 		...otherProps
 	}: WordPressComponentProps<
-		ToggleGroupControlAsRadioGroupProps,
+		ToggleGroupControlMainControlProps,
 		'div',
 		false
 	>,

--- a/packages/components/src/toggle-group-control/toggle-group-control/as-radio.tsx
+++ b/packages/components/src/toggle-group-control/toggle-group-control/as-radio.tsx
@@ -1,0 +1,95 @@
+/**
+ * External dependencies
+ */
+import type { ForwardedRef } from 'react';
+// eslint-disable-next-line no-restricted-imports
+import { RadioGroup, useRadioState } from 'reakit';
+
+/**
+ * WordPress dependencies
+ */
+import {
+	useMergeRefs,
+	useInstanceId,
+	usePrevious,
+	useResizeObserver,
+} from '@wordpress/compose';
+import { forwardRef, useRef } from '@wordpress/element';
+
+/**
+ * Internal dependencies
+ */
+import { View } from '../../view';
+import ToggleGroupControlBackdrop from './toggle-group-control-backdrop';
+import ToggleGroupControlContext from '../context';
+import { useUpdateEffect } from '../../utils/hooks';
+import type { WordPressComponentProps } from '../../ui/context';
+import type { ToggleGroupControlAsRadioProps } from '../types';
+
+function UnforwardedToggleGroupControlAsRadio(
+	{
+		children,
+		isAdaptiveWidth,
+		label,
+		onChange,
+		size,
+		value,
+		...otherProps
+	}: WordPressComponentProps< ToggleGroupControlAsRadioProps, 'div', false >,
+	forwardedRef: ForwardedRef< any >
+) {
+	const containerRef = useRef();
+	const [ resizeListener, sizes ] = useResizeObserver();
+	const baseId = useInstanceId(
+		ToggleGroupControlAsRadio,
+		'toggle-group-control-as-radio'
+	).toString();
+	const radio = useRadioState( {
+		baseId,
+		state: value,
+	} );
+	const previousValue = usePrevious( value );
+
+	// Propagate radio.state change.
+	useUpdateEffect( () => {
+		// Avoid calling onChange if radio state changed
+		// from incoming value.
+		if ( previousValue !== radio.state ) {
+			onChange( radio.state );
+		}
+	}, [ radio.state ] );
+
+	// Sync incoming value with radio.state.
+	useUpdateEffect( () => {
+		if ( value !== radio.state ) {
+			radio.setState( value );
+		}
+	}, [ value ] );
+
+	return (
+		<ToggleGroupControlContext.Provider
+			value={ { ...radio, isBlock: ! isAdaptiveWidth, size } }
+		>
+			<RadioGroup
+				{ ...radio }
+				aria-label={ label }
+				as={ View }
+				{ ...otherProps }
+				ref={ useMergeRefs( [ containerRef, forwardedRef ] ) }
+			>
+				{ resizeListener }
+				<ToggleGroupControlBackdrop
+					{ ...radio }
+					containerRef={ containerRef }
+					containerWidth={ sizes.width }
+					isAdaptiveWidth={ isAdaptiveWidth }
+				/>
+				{ children }
+			</RadioGroup>
+		</ToggleGroupControlContext.Provider>
+	);
+}
+
+export const ToggleGroupControlAsRadio = forwardRef(
+	UnforwardedToggleGroupControlAsRadio
+);

--- a/packages/components/src/toggle-group-control/toggle-group-control/component.tsx
+++ b/packages/components/src/toggle-group-control/toggle-group-control/component.tsx
@@ -26,7 +26,7 @@ import { ToggleGroupControlAsRadio } from './as-radio';
 const noop = () => {};
 
 function UnconnectedToggleGroupControl(
-	props: WordPressComponentProps< ToggleGroupControlProps, 'input', false >,
+	props: WordPressComponentProps< ToggleGroupControlProps, 'div', false >,
 	forwardedRef: ForwardedRef< any >
 ) {
 	const {

--- a/packages/components/src/toggle-group-control/toggle-group-control/component.tsx
+++ b/packages/components/src/toggle-group-control/toggle-group-control/component.tsx
@@ -36,7 +36,6 @@ function UnconnectedToggleGroupControl(
 		isBlock = false,
 		isDeselectable = false,
 		label,
-		multiple = false,
 		hideLabelFromVision = false,
 		help,
 		onChange = noop,
@@ -67,7 +66,7 @@ function UnconnectedToggleGroupControl(
 					<BaseControl.VisualLabel>{ label }</BaseControl.VisualLabel>
 				</VisualLabelWrapper>
 			) }
-			{ ! multiple && ! isDeselectable && (
+			{ ! isDeselectable && (
 				<ToggleGroupControlAsRadio
 					{ ...otherProps }
 					children={ children }

--- a/packages/components/src/toggle-group-control/toggle-group-control/component.tsx
+++ b/packages/components/src/toggle-group-control/toggle-group-control/component.tsx
@@ -22,6 +22,7 @@ import type { ToggleGroupControlProps } from '../types';
 import { VisualLabelWrapper } from './styles';
 import * as styles from './styles';
 import { ToggleGroupControlAsRadio } from './as-radio';
+import { ToggleGroupControlAsButtonGroup } from './as-button-group';
 
 const noop = () => {};
 
@@ -66,7 +67,19 @@ function UnconnectedToggleGroupControl(
 					<BaseControl.VisualLabel>{ label }</BaseControl.VisualLabel>
 				</VisualLabelWrapper>
 			) }
-			{ ! isDeselectable && (
+			{ isDeselectable ? (
+				<ToggleGroupControlAsButtonGroup
+					{ ...otherProps }
+					children={ children }
+					className={ classes }
+					isAdaptiveWidth={ isAdaptiveWidth }
+					label={ label }
+					onChange={ onChange }
+					ref={ forwardedRef }
+					size={ size }
+					value={ value }
+				/>
+			) : (
 				<ToggleGroupControlAsRadio
 					{ ...otherProps }
 					children={ children }
@@ -76,7 +89,7 @@ function UnconnectedToggleGroupControl(
 					onChange={ onChange }
 					ref={ forwardedRef }
 					size={ size }
-					value={ Array.isArray( value ) ? value[ 0 ] : value }
+					value={ value }
 				/>
 			) }
 		</BaseControl>

--- a/packages/components/src/toggle-group-control/toggle-group-control/component.tsx
+++ b/packages/components/src/toggle-group-control/toggle-group-control/component.tsx
@@ -50,8 +50,7 @@ function UnconnectedToggleGroupControl(
 	const classes = useMemo(
 		() =>
 			cx(
-				styles.ToggleGroupControl( { size } ),
-				! isDeselectable && styles.border,
+				styles.ToggleGroupControl( { isDeselectable, size } ),
 				isBlock && styles.block,
 				className
 			),

--- a/packages/components/src/toggle-group-control/toggle-group-control/component.tsx
+++ b/packages/components/src/toggle-group-control/toggle-group-control/component.tsx
@@ -35,7 +35,6 @@ function UnconnectedToggleGroupControl(
 		isAdaptiveWidth = false,
 		isBlock = false,
 		isDeselectable = false,
-		__experimentalIsBorderless = false,
 		label,
 		multiple = false,
 		hideLabelFromVision = false,
@@ -52,11 +51,11 @@ function UnconnectedToggleGroupControl(
 		() =>
 			cx(
 				styles.ToggleGroupControl( { size } ),
-				! __experimentalIsBorderless && styles.border,
+				! isDeselectable && styles.border,
 				isBlock && styles.block,
 				className
 			),
-		[ className, cx, isBlock, __experimentalIsBorderless, size ]
+		[ className, cx, isBlock, isDeselectable, size ]
 	);
 	return (
 		<BaseControl

--- a/packages/components/src/toggle-group-control/toggle-group-control/component.tsx
+++ b/packages/components/src/toggle-group-control/toggle-group-control/component.tsx
@@ -21,7 +21,7 @@ import BaseControl from '../../base-control';
 import type { ToggleGroupControlProps } from '../types';
 import { VisualLabelWrapper } from './styles';
 import * as styles from './styles';
-import { ToggleGroupControlAsRadio } from './as-radio';
+import { ToggleGroupControlAsRadio } from './as-radio-group';
 import { ToggleGroupControlAsButtonGroup } from './as-button-group';
 
 const noop = () => {};

--- a/packages/components/src/toggle-group-control/toggle-group-control/component.tsx
+++ b/packages/components/src/toggle-group-control/toggle-group-control/component.tsx
@@ -21,7 +21,7 @@ import BaseControl from '../../base-control';
 import type { ToggleGroupControlProps } from '../types';
 import { VisualLabelWrapper } from './styles';
 import * as styles from './styles';
-import { ToggleGroupControlAsRadio } from './as-radio-group';
+import { ToggleGroupControlAsRadioGroup } from './as-radio-group';
 import { ToggleGroupControlAsButtonGroup } from './as-button-group';
 
 const noop = () => {};
@@ -79,7 +79,7 @@ function UnconnectedToggleGroupControl(
 					value={ value }
 				/>
 			) : (
-				<ToggleGroupControlAsRadio
+				<ToggleGroupControlAsRadioGroup
 					{ ...otherProps }
 					children={ children }
 					className={ classes }

--- a/packages/components/src/toggle-group-control/toggle-group-control/component.tsx
+++ b/packages/components/src/toggle-group-control/toggle-group-control/component.tsx
@@ -56,6 +56,11 @@ function UnconnectedToggleGroupControl(
 			),
 		[ className, cx, isBlock, isDeselectable, size ]
 	);
+
+	const MainControl = isDeselectable
+		? ToggleGroupControlAsButtonGroup
+		: ToggleGroupControlAsRadioGroup;
+
 	return (
 		<BaseControl
 			help={ help }
@@ -66,31 +71,17 @@ function UnconnectedToggleGroupControl(
 					<BaseControl.VisualLabel>{ label }</BaseControl.VisualLabel>
 				</VisualLabelWrapper>
 			) }
-			{ isDeselectable ? (
-				<ToggleGroupControlAsButtonGroup
-					{ ...otherProps }
-					children={ children }
-					className={ classes }
-					isAdaptiveWidth={ isAdaptiveWidth }
-					label={ label }
-					onChange={ onChange }
-					ref={ forwardedRef }
-					size={ size }
-					value={ value }
-				/>
-			) : (
-				<ToggleGroupControlAsRadioGroup
-					{ ...otherProps }
-					children={ children }
-					className={ classes }
-					isAdaptiveWidth={ isAdaptiveWidth }
-					label={ label }
-					onChange={ onChange }
-					ref={ forwardedRef }
-					size={ size }
-					value={ value }
-				/>
-			) }
+			<MainControl
+				{ ...otherProps }
+				children={ children }
+				className={ classes }
+				isAdaptiveWidth={ isAdaptiveWidth }
+				label={ label }
+				onChange={ onChange }
+				ref={ forwardedRef }
+				size={ size }
+				value={ value }
+			/>
 		</BaseControl>
 	);
 }

--- a/packages/components/src/toggle-group-control/toggle-group-control/styles.ts
+++ b/packages/components/src/toggle-group-control/toggle-group-control/styles.ts
@@ -67,7 +67,6 @@ export const block = css`
 export const BackdropView = styled.div`
 	background: ${ COLORS.gray[ 900 ] };
 	border-radius: ${ CONFIG.controlBorderRadius };
-	box-shadow: ${ CONFIG.toggleGroupControlBackdropBoxShadow };
 	left: 0;
 	position: absolute;
 	top: 2px;

--- a/packages/components/src/toggle-group-control/toggle-group-control/styles.ts
+++ b/packages/components/src/toggle-group-control/toggle-group-control/styles.ts
@@ -11,13 +11,14 @@ import { CONFIG, COLORS, reduceMotion } from '../../utils';
 import type { ToggleGroupControlProps } from '../types';
 
 export const ToggleGroupControl = ( {
+	isDeselectable,
 	size,
 }: {
+	isDeselectable?: boolean;
 	size: NonNullable< ToggleGroupControlProps[ 'size' ] >;
 } ) => css`
 	background: ${ COLORS.ui.background };
 	border: 1px solid transparent;
-	border-radius: ${ CONFIG.controlBorderRadius };
 	display: inline-flex;
 	min-width: 0;
 	padding: 2px;
@@ -26,20 +27,22 @@ export const ToggleGroupControl = ( {
 	${ reduceMotion( 'transition' ) }
 
 	${ toggleGroupControlSize( size ) }
+	${ ! isDeselectable && enclosingBorder }
+`;
+
+const enclosingBorder = css`
+	border-color: ${ COLORS.ui.border };
+	border-radius: ${ CONFIG.controlBorderRadius };
+
+	&:hover {
+		border-color: ${ COLORS.ui.borderHover };
+	}
 
 	&:focus-within {
 		border-color: ${ COLORS.ui.borderFocus };
 		box-shadow: ${ CONFIG.controlBoxShadowFocus };
 		outline: none;
 		z-index: 1;
-	}
-`;
-
-export const border = css`
-	border-color: ${ COLORS.ui.border };
-
-	&:hover {
-		border-color: ${ COLORS.ui.borderHover };
 	}
 `;
 

--- a/packages/components/src/toggle-group-control/types.ts
+++ b/packages/components/src/toggle-group-control/types.ts
@@ -124,14 +124,10 @@ export type ToggleGroupControlProps = Pick<
 	size?: 'default' | '__unstable-large';
 };
 
-export type ToggleGroupControlContextProps = RadioStateReturn &
-	Pick< ToggleGroupControlProps, 'size' > & {
-		/**
-		 * Renders `ToggleGroupControl` as a (CSS) block element.
-		 *
-		 * @default false
-		 */
-		isBlock?: boolean;
+export type ToggleGroupControlContextProps = Partial< RadioStateReturn > &
+	Pick< RadioStateReturn, 'state' | 'setState' > &
+	Pick< ToggleGroupControlProps, 'isBlock' | 'isDeselectable' | 'size' > & {
+		baseId: string;
 	};
 
 export type ToggleGroupControlBackdropProps = {

--- a/packages/components/src/toggle-group-control/types.ts
+++ b/packages/components/src/toggle-group-control/types.ts
@@ -110,12 +110,6 @@ export type ToggleGroupControlProps = Pick<
 	 */
 	isDeselectable?: boolean;
 	/**
-	 * Borderless style that may be preferred in some contexts.
-	 *
-	 * @default false
-	 */
-	__experimentalIsBorderless?: boolean;
-	/**
 	 * Callback when a segment is selected.
 	 */
 	onChange?: ( value: ReactText | undefined ) => void;

--- a/packages/components/src/toggle-group-control/types.ts
+++ b/packages/components/src/toggle-group-control/types.ts
@@ -80,12 +80,6 @@ export type ToggleGroupControlProps = Pick<
 	 */
 	label: string;
 	/**
-	 * Whether multiple options can be selected at once.
-	 *
-	 * @default false
-	 */
-	multiple?: boolean;
-	/**
 	 * If true, the label will only be visible to screen readers.
 	 *
 	 * @default false
@@ -116,7 +110,7 @@ export type ToggleGroupControlProps = Pick<
 	/**
 	 * The selected value(s).
 	 */
-	value?: ReactText | ReactText[];
+	value?: ReactText;
 	/**
 	 * The options to render in the `ToggleGroupControl`, using either the `ToggleGroupControlOption` or
 	 * `ToggleGroupControlOptionIcon` components.

--- a/packages/components/src/toggle-group-control/types.ts
+++ b/packages/components/src/toggle-group-control/types.ts
@@ -137,7 +137,7 @@ export type ToggleGroupControlBackdropProps = {
 	state?: any;
 };
 
-export type ToggleGroupControlAsRadioGroupProps = Pick<
+export type ToggleGroupControlMainControlProps = Pick<
 	ToggleGroupControlProps,
 	'children' | 'isAdaptiveWidth' | 'label' | 'size'
 > & {

--- a/packages/components/src/toggle-group-control/types.ts
+++ b/packages/components/src/toggle-group-control/types.ts
@@ -108,7 +108,7 @@ export type ToggleGroupControlProps = Pick<
 	 */
 	onChange?: ( value: ReactText | undefined ) => void;
 	/**
-	 * The selected value(s).
+	 * The selected value.
 	 */
 	value?: ReactText;
 	/**

--- a/packages/components/src/toggle-group-control/types.ts
+++ b/packages/components/src/toggle-group-control/types.ts
@@ -80,6 +80,12 @@ export type ToggleGroupControlProps = Pick<
 	 */
 	label: string;
 	/**
+	 * Whether multiple options can be selected at once.
+	 *
+	 * @default false
+	 */
+	multiple?: boolean;
+	/**
 	 * If true, the label will only be visible to screen readers.
 	 *
 	 * @default false
@@ -98,6 +104,12 @@ export type ToggleGroupControlProps = Pick<
 	 */
 	isBlock?: boolean;
 	/**
+	 * Whether an option can be deselected by clicking it again.
+	 *
+	 * @default false
+	 */
+	isDeselectable?: boolean;
+	/**
 	 * Borderless style that may be preferred in some contexts.
 	 *
 	 * @default false
@@ -108,9 +120,9 @@ export type ToggleGroupControlProps = Pick<
 	 */
 	onChange?: ( value: ReactText | undefined ) => void;
 	/**
-	 * The value of `ToggleGroupControl`
+	 * The selected value(s).
 	 */
-	value?: ReactText;
+	value?: ReactText | ReactText[];
 	/**
 	 * The options to render in the `ToggleGroupControl`, using either the `ToggleGroupControlOption` or
 	 * `ToggleGroupControlOptionIcon` components.
@@ -139,4 +151,12 @@ export type ToggleGroupControlBackdropProps = {
 	containerWidth?: number | null;
 	isAdaptiveWidth?: boolean;
 	state?: any;
+};
+
+export type ToggleGroupControlAsRadioProps = Pick<
+	ToggleGroupControlProps,
+	'children' | 'isAdaptiveWidth' | 'label' | 'size'
+> & {
+	onChange: ( value: ReactText | undefined ) => void;
+	value?: ReactText;
 };

--- a/packages/components/src/toggle-group-control/types.ts
+++ b/packages/components/src/toggle-group-control/types.ts
@@ -124,11 +124,21 @@ export type ToggleGroupControlProps = Pick<
 	size?: 'default' | '__unstable-large';
 };
 
-export type ToggleGroupControlContextProps = Partial< RadioStateReturn > &
-	Pick< RadioStateReturn, 'state' | 'setState' > &
-	Pick< ToggleGroupControlProps, 'isBlock' | 'isDeselectable' | 'size' > & {
-		baseId: string;
-	};
+type ToggleGroupControlAsRadioContext = {
+	isDeselectable?: false;
+} & RadioStateReturn;
+
+type ToggleGroupControlAsButtonContext = { isDeselectable: true } & Pick<
+	RadioStateReturn,
+	'state' | 'setState'
+>;
+
+export type ToggleGroupControlContextProps = Pick<
+	ToggleGroupControlProps,
+	'isBlock' | 'size'
+> & {
+	baseId: string;
+} & ( ToggleGroupControlAsRadioContext | ToggleGroupControlAsButtonContext );
 
 export type ToggleGroupControlBackdropProps = {
 	containerRef: MutableRefObject< HTMLElement | undefined >;

--- a/packages/components/src/toggle-group-control/types.ts
+++ b/packages/components/src/toggle-group-control/types.ts
@@ -137,7 +137,7 @@ export type ToggleGroupControlBackdropProps = {
 	state?: any;
 };
 
-export type ToggleGroupControlAsRadioProps = Pick<
+export type ToggleGroupControlAsRadioGroupProps = Pick<
 	ToggleGroupControlProps,
 	'children' | 'isAdaptiveWidth' | 'label' | 'size'
 > & {

--- a/packages/components/src/utils/config-values.js
+++ b/packages/components/src/utils/config-values.js
@@ -33,7 +33,6 @@ const TOGGLE_GROUP_CONTROL_PROPS = {
 	toggleGroupControlBackdropBackgroundColor:
 		CONTROL_PROPS.controlSurfaceColor,
 	toggleGroupControlBackdropBorderColor: COLORS.ui.border,
-	toggleGroupControlBackdropBoxShadow: 'transparent',
 	toggleGroupControlButtonColorActive: CONTROL_PROPS.controlBackgroundColor,
 };
 

--- a/packages/e2e-tests/specs/editor/various/font-size-picker.test.js
+++ b/packages/e2e-tests/specs/editor/various/font-size-picker.test.js
@@ -233,7 +233,7 @@ describe( 'Font Size Picker', () => {
 			await page.keyboard.type( 'Paragraph to be made "large"' );
 
 			await clickFontSizeButtonByLabel( 'Large' );
-			const buttonSelector = `${ FONT_SIZE_TOGGLE_GROUP_SELECTOR }//div[@data-active='true']//button`;
+			const buttonSelector = `${ FONT_SIZE_TOGGLE_GROUP_SELECTOR }//button[@aria-checked='true']`;
 			const [ activeButton ] = await page.$x( buttonSelector );
 			const activeLabel = await page.evaluate(
 				( element ) => element?.getAttribute( 'aria-label' ),


### PR DESCRIPTION
Extracted from #44168 (where a high-level review was completed first)

## What?

Add an `isDeselectable` prop to allow ToggleGroupControl to be deselectable.

## Why?

See #44168

## How?

1. Split the main part of the ToggleGroupControl component into an "as radio group" component and an "as button group" component. The radio group version is basically the same implementation as we had before.
2. When the `isDeselectable` prop is enabled, we use the button group implementation.
3. The `__experimentalIsBorderless` prop is removed, since the border will be dictated by whether or not the control is deselectable.

## Testing Instructions

`npm run storybook:dev` and see the ToggleGroupControl stories.

## Screenshots or screencast <!-- if applicable -->

<img width="104" alt="A deselectable ToggleGroupControl" src="https://user-images.githubusercontent.com/555336/196774955-4fc453d5-e373-4511-a847-a300ee3e56c1.png">

