### PR TITLE
Web Font: Fix ascent/descent-override property typo

### DIFF
--- a/lib/experimental/class-wp-webfonts.php
+++ b/lib/experimental/class-wp-webfonts.php
@@ -249,8 +249,8 @@ class WP_Webfonts {
 		}
 
 		$valid_props = array(
-			'ascend-override',
-			'descend-override',
+			'ascent-override',
+			'descent-override',
 			'font-display',
 			'font-family',
 			'font-stretch',

--- a/schemas/json/theme.json
+++ b/schemas/json/theme.json
@@ -486,12 +486,12 @@
 													"description": "CSS font-stretch value.",
 													"type": "string"
 												},
-												"ascendOverride": {
-													"description": "CSS ascend-override value.",
+												"ascentOverride": {
+													"description": "CSS ascent-override value.",
 													"type": "string"
 												},
-												"descendOverride": {
-													"description": "CSS descend-override value.",
+												"descentOverride": {
+													"description": "CSS descent-override value.",
 													"type": "string"
 												},
 												"fontVariant": {


### PR DESCRIPTION
Fix: #44919

## What?
This PR fixes a typo in the ascender/descender definition of the font.

- [ ascent-override - CSS: Cascading Style Sheets | MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/@font-face/ascent-override)
- [descent-override - CSS: Cascading Style Sheets | MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/@font-face/descent-override)

## How?
I searched the repository and corrected all areas that were typos.

## Testing Instructions
In TT3's theme.json, change the fontFace property as follows:

```
			"fontFamilies": [
				{
					"fontFace": [
						{
							"fontFamily": "DM Sans",
							"fontStretch": "normal",
							"fontStyle": "normal",
							"fontWeight": "400",
							"src": [
								"file:./assets/fonts/dm-sans/DMSans-Regular.woff2"
							],
							"ascentOverride": "300%"
						},
						{
							"fontFamily": "DM Sans",
							"fontStretch": "normal",
							"fontStyle": "italic",
							"fontWeight": "400",
							"src": [
								"file:./assets/fonts/dm-sans/DMSans-Regular-Italic.woff2"
							],
							"descentOverride": "300%"
						},
						...
					]
				}
				...
			]
```

In `webfonts-inline-css`, check that the `font-face` property is output correctly.

## Screenshots or screencast <!-- if applicable -->

![override](https://user-images.githubusercontent.com/54422211/196747331-954ea678-8c1b-47ad-aa99-83dc1d07d811.png)
