### PR TITLE
TabPanel: move focus to panel on key down

### DIFF
--- a/packages/components/src/tab-panel/index.js
+++ b/packages/components/src/tab-panel/index.js
@@ -35,7 +35,7 @@ export default function TabPanel( {
 	children,
 	tabs,
 	initialTabName,
-	orientation = 'vertical',
+	orientation = 'horizontal',
 	activeClass = 'is-active',
 	onSelect = noop,
 } ) {

--- a/packages/components/src/tab-panel/index.js
+++ b/packages/components/src/tab-panel/index.js
@@ -9,7 +9,7 @@ import { partial, noop, find } from 'lodash';
  */
 import { useState, useEffect, useRef } from '@wordpress/element';
 import { useInstanceId } from '@wordpress/compose';
-import { DOWN } from '@wordpress/keycodes';
+import { DOWN, LEFT, RIGHT } from '@wordpress/keycodes';
 
 /**
  * Internal dependencies
@@ -35,12 +35,13 @@ export default function TabPanel( {
 	children,
 	tabs,
 	initialTabName,
-	orientation = 'horizontal',
+	orientation = 'vertical',
 	activeClass = 'is-active',
 	onSelect = noop,
 } ) {
 	const instanceId = useInstanceId( TabPanel, 'tab-panel' );
 	const [ selected, setSelected ] = useState( null );
+	const [ direction, setDirection ] = useState( null );
 
 	const handleClick = ( tabKey ) => {
 		setSelected( tabKey );
@@ -51,15 +52,28 @@ export default function TabPanel( {
 		child.click();
 	};
 	const onKeyDown = ( evt ) => {
-		// TODO: check orientation
-		if ( evt.keyCode === DOWN ) {
+		const hKey = direction === 'rtl' ? LEFT : RIGHT;
+		const key = orientation === 'vertical' ? hKey : DOWN;
+
+		if ( evt.keyCode === key ) {
 			panelRef.current?.focus();
 		}
 	};
 
+	const tabRef = useRef();
 	const panelRef = useRef();
 	const selectedTab = find( tabs, { name: selected } );
 	const selectedId = `${ instanceId }-${ selectedTab?.name ?? 'none' }`;
+
+	useEffect( () => {
+		if ( tabRef.current ) {
+			const dir = window.getComputedStyle( tabRef.current ).direction;
+
+			if ( dir ) {
+				setDirection( dir );
+			}
+		}
+	}, [ tabRef ] );
 
 	useEffect( () => {
 		const newSelectedTab = find( tabs, { name: selected } );
@@ -78,6 +92,7 @@ export default function TabPanel( {
 				onNavigate={ onNavigate }
 				className="components-tab-panel__tabs"
 				onKeyDown={ onKeyDown }
+				ref={ tabRef }
 			>
 				{ tabs.map( ( tab ) => (
 					<TabButton

--- a/packages/components/src/tab-panel/index.js
+++ b/packages/components/src/tab-panel/index.js
@@ -7,8 +7,9 @@ import { partial, noop, find } from 'lodash';
 /**
  * WordPress dependencies
  */
-import { useState, useEffect } from '@wordpress/element';
+import { useState, useEffect, useRef } from '@wordpress/element';
 import { useInstanceId } from '@wordpress/compose';
+import { DOWN } from '@wordpress/keycodes';
 
 /**
  * Internal dependencies
@@ -49,6 +50,14 @@ export default function TabPanel( {
 	const onNavigate = ( childIndex, child ) => {
 		child.click();
 	};
+	const onKeyDown = ( evt ) => {
+		// TODO: check orientation
+		if ( evt.keyCode === DOWN ) {
+			panelRef.current?.focus();
+		}
+	};
+
+	const panelRef = useRef();
 	const selectedTab = find( tabs, { name: selected } );
 	const selectedId = `${ instanceId }-${ selectedTab?.name ?? 'none' }`;
 
@@ -68,6 +77,7 @@ export default function TabPanel( {
 				orientation={ orientation }
 				onNavigate={ onNavigate }
 				className="components-tab-panel__tabs"
+				onKeyDown={ onKeyDown }
 			>
 				{ tabs.map( ( tab ) => (
 					<TabButton
@@ -95,6 +105,8 @@ export default function TabPanel( {
 					role="tabpanel"
 					id={ `${ selectedId }-view` }
 					className="components-tab-panel__tab-content"
+					tabIndex="-1"
+					ref={ panelRef }
 				>
 					{ children( selectedTab ) }
 				</div>

--- a/packages/components/src/tab-panel/style.scss
+++ b/packages/components/src/tab-panel/style.scss
@@ -62,3 +62,9 @@
 		box-shadow: inset 0 0 0 var(--wp-admin-border-width-focus) var(--wp-admin-theme-color), inset 0 0 -$border-width-tab 0 0 var(--wp-admin-theme-color);
 	}
 }
+
+.components-tab-panel__tab-content {
+	&:focus {
+		box-shadow: inset 0 0 0 var(--wp-admin-border-width-focus) var(--wp-admin-theme-color);
+	}
+}


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
This PR enhances the `TabPanel` component so that pressing the down arrow (in horizontal orientation) moves focus from the tab menu to the selected tab panel.

## Why?
Let's consider a blind user that can't see the content of the tab panel, and is using a screen reader. After they select a tab whose associated panel has no interactive element, focusing to the next focusable element will leave them with no clue about the content of that panel. A way to focus on the selected tab panel should be provided to mitigate that.

Heydon Pickering wrote about this in the [Tabbed Interfaces chapter](https://inclusive-components.design/tabbed-interfaces/#aproblemreadingpanels) of his book _Inclusive Components_.

## How?
The implementation is as follow:

- listen to key press on tab menu
- if orientation is horizontal, move focus to selected panel on arrow down
- if orientation is vertical, move focus to selected panel on arrow left or right, in RTL and LTR languages respectively

## Testing Instructions

1. Run `npm run storybook:dev` from this branch
2. Visit `http://localhost:50240/?path=/story/components-tabpanel--default`
3. Check that pressing the down arrow while the tab menu has focus moves the focus to the selected panel (in horizontal orientation)
4. Verify the behaviour in vertical orientation

## Screenshots or screencast <!-- if applicable -->

https://user-images.githubusercontent.com/1620183/203157086-0faa8be6-b8d1-4e69-b46a-c951a2136abe.mov



