### PR TITLE
UnitControl: Normalize wrapper classnames by removing outer wrapper

### DIFF
--- a/packages/block-editor/src/components/border-radius-control/index.js
+++ b/packages/block-editor/src/components/border-radius-control/index.js
@@ -94,7 +94,7 @@ export default function BorderRadiusControl( { onChange, values } ) {
 				{ isLinked ? (
 					<>
 						<AllInputControl
-							__unstableWrapperClassName="components-border-radius-control__unit-control"
+							className="components-border-radius-control__unit-control"
 							values={ values }
 							min={ MIN_BORDER_RADIUS_VALUE }
 							onChange={ onChange }

--- a/packages/components/src/border-control/styles.ts
+++ b/packages/components/src/border-control/styles.ts
@@ -13,7 +13,7 @@ import {
 	StyledLabel,
 } from '../base-control/styles/base-control-styles';
 import {
-	Root as UnitControlWrapper,
+	ValueInput as UnitControlWrapper,
 	UnitSelect,
 } from '../unit-control/styles/unit-control-styles';
 

--- a/packages/components/src/dimension-control/test/__snapshots__/index.test.js.snap
+++ b/packages/components/src/dimension-control/test/__snapshots__/index.test.js.snap
@@ -38,6 +38,7 @@ exports[`DimensionControl rendering renders with custom sizes 1`] = `
   -webkit-justify-content: space-between;
   justify-content: space-between;
   height: 100%;
+  box-sizing: border-box;
   position: relative;
   border-radius: 2px;
   padding-top: 0;
@@ -309,6 +310,7 @@ exports[`DimensionControl rendering renders with defaults 1`] = `
   -webkit-justify-content: space-between;
   justify-content: space-between;
   height: 100%;
+  box-sizing: border-box;
   position: relative;
   border-radius: 2px;
   padding-top: 0;
@@ -590,6 +592,7 @@ exports[`DimensionControl rendering renders with icon and custom icon label 1`] 
   -webkit-justify-content: space-between;
   justify-content: space-between;
   height: 100%;
+  box-sizing: border-box;
   position: relative;
   border-radius: 2px;
   padding-top: 0;
@@ -883,6 +886,7 @@ exports[`DimensionControl rendering renders with icon and default icon label 1`]
   -webkit-justify-content: space-between;
   justify-content: space-between;
   height: 100%;
+  box-sizing: border-box;
   position: relative;
   border-radius: 2px;
   padding-top: 0;

--- a/packages/components/src/input-control/styles/input-control-styles.tsx
+++ b/packages/components/src/input-control/styles/input-control-styles.tsx
@@ -34,6 +34,7 @@ const rootFocusedStyles = ( { isFocused }: RootProps ) => {
 };
 
 export const Root = styled( Flex )< RootProps >`
+	box-sizing: border-box;
 	position: relative;
 	border-radius: 2px;
 	padding-top: 0;

--- a/packages/components/src/unit-control/index.tsx
+++ b/packages/components/src/unit-control/index.tsx
@@ -104,7 +104,13 @@ function UnforwardedUnitControl(
 	// Stores parsed value for hand-off in state reducer.
 	const refParsedQuantity = useRef< number | undefined >( undefined );
 
-	const classes = classnames( 'components-unit-control', className );
+	const classes = classnames(
+		'components-unit-control',
+		// This class is added for legacy purposes to maintain it on the outer
+		// wrapper. See: https://github.com/WordPress/gutenberg/pull/45139
+		'components-unit-control-wrapper',
+		className
+	);
 
 	const handleOnQuantityChange = (
 		nextQuantityValue: number | string | undefined,

--- a/packages/components/src/unit-control/index.tsx
+++ b/packages/components/src/unit-control/index.tsx
@@ -23,7 +23,7 @@ import { __ } from '@wordpress/i18n';
  */
 import type { WordPressComponentProps } from '../ui/context';
 import * as inputControlActionTypes from '../input-control/reducer/actions';
-import { Root, ValueInput } from './styles/unit-control-styles';
+import { ValueInput } from './styles/unit-control-styles';
 import UnitSelectControl from './unit-select-control';
 import {
 	CSS_UNITS,
@@ -58,12 +58,10 @@ function UnforwardedUnitControl(
 		onChange: onChangeProp,
 		onUnitChange,
 		size = 'default',
-		style,
 		unit: unitProp,
 		units: unitsProp = CSS_UNITS,
 		value: valueProp,
 		onBlur: onBlurProp,
-		__unstableWrapperClassName,
 		...props
 	} = unitControlProps;
 
@@ -107,10 +105,6 @@ function UnforwardedUnitControl(
 	const refParsedQuantity = useRef< number | undefined >( undefined );
 
 	const classes = classnames( 'components-unit-control', className );
-	const wrapperClasses = classnames(
-		'components-unit-control-wrapper',
-		__unstableWrapperClassName
-	);
 
 	const handleOnQuantityChange = (
 		nextQuantityValue: number | string | undefined,
@@ -182,7 +176,7 @@ function UnforwardedUnitControl(
 				: undefined;
 			const changeProps = { event, data };
 
-			// The `onChange` callback already gets called, no need to call it explicitely.
+			// The `onChange` callback already gets called, no need to call it explicitly.
 			onUnitChange?.( validParsedUnit, changeProps );
 
 			setUnit( validParsedUnit );
@@ -263,27 +257,25 @@ function UnforwardedUnitControl(
 	}
 
 	return (
-		<Root className={ wrapperClasses } style={ style }>
-			<ValueInput
-				type={ isPressEnterToChange ? 'text' : 'number' }
-				{ ...props }
-				autoComplete={ autoComplete }
-				className={ classes }
-				disabled={ disabled }
-				hideHTMLArrows
-				isPressEnterToChange={ isPressEnterToChange }
-				label={ label }
-				onBlur={ handleOnBlur }
-				onKeyDown={ handleOnKeyDown }
-				onChange={ handleOnQuantityChange }
-				ref={ forwardedRef }
-				size={ size }
-				suffix={ inputSuffix }
-				value={ parsedQuantity ?? '' }
-				step={ step }
-				__unstableStateReducer={ stateReducer }
-			/>
-		</Root>
+		<ValueInput
+			type={ isPressEnterToChange ? 'text' : 'number' }
+			{ ...props }
+			autoComplete={ autoComplete }
+			className={ classes }
+			disabled={ disabled }
+			hideHTMLArrows
+			isPressEnterToChange={ isPressEnterToChange }
+			label={ label }
+			onBlur={ handleOnBlur }
+			onKeyDown={ handleOnKeyDown }
+			onChange={ handleOnQuantityChange }
+			ref={ forwardedRef }
+			size={ size }
+			suffix={ inputSuffix }
+			value={ parsedQuantity ?? '' }
+			step={ step }
+			__unstableStateReducer={ stateReducer }
+		/>
 	);
 }
 

--- a/packages/components/src/unit-control/styles/unit-control-styles.ts
+++ b/packages/components/src/unit-control/styles/unit-control-styles.ts
@@ -18,16 +18,6 @@ type SelectProps = {
 	selectSize: SelectSize;
 };
 
-export const Root = styled.div`
-	box-sizing: border-box;
-	position: relative;
-
-	/* Target the InputControl's backdrop and make focus styles smoother. */
-	&&& ${ BackdropUI } {
-		transition: box-shadow 0.1s linear;
-	}
-`;
-
 // TODO: Resolve need to use &&& to increase specificity
 // https://github.com/WordPress/gutenberg/issues/18483
 
@@ -36,6 +26,10 @@ export const ValueInput = styled( NumberControl )`
 		input {
 			display: block;
 			width: 100%;
+		}
+
+		${ BackdropUI } {
+			transition: box-shadow 0.1s linear;
 		}
 	}
 `;

--- a/packages/components/src/unit-control/types.ts
+++ b/packages/components/src/unit-control/types.ts
@@ -100,8 +100,4 @@ export type UnitControlProps = Omit< UnitSelectControlProps, 'unit' > &
 		 * Callback when either the quantity or the unit inputs lose focus.
 		 */
 		onBlur?: FocusEventHandler< HTMLInputElement | HTMLSelectElement >;
-		/**
-		 * Custom CSS class to apply to the unit control's outer wrapper.
-		 */
-		__unstableWrapperClassName?: string;
 	};


### PR DESCRIPTION
Fixes: https://github.com/WordPress/gutenberg/issues/45094

Related:
- https://github.com/WordPress/gutenberg/pull/41860

## What?

Normalizes the application of class names for the UnitControl, so it is applied to the outermost wrapper.

## Why?

- Makes UnitControl consistent with our other components and their `className` props being applied to the outermost element.

## How?

This PR removes the outer wrapper for the UnitControl. It appears unnecessary, and with only a few other minor tweaks, we maintain the status quo in terms of layout for other components e.g. BorderRadiusControl, while also bringing UnitControl in line with our other components.

## Testing Instructions
1. Ensure there are no styling differences for the UnitControl or components leveraging it in Storybook
    - UnitControl
    - RangeControl
    - BoxControl
    - BorderControl
    - BorderBoxControl
2. Confirm the BorderRadiusControl in our editors appears the same as https://github.com/WordPress/gutenberg/pull/41860
3. Ensure there are no occurrences of components or consumers using the `components-unit-control-wrapper` class that was formerly on the outer wrapper.
4. Check that any other uses of UnitControl that may add inline styles via props still display as before.
5. Check component unit tests still pass, in particular, those for UnitControl


## ✍️ Dev Note 

In order to improve consistency across the `@wordpress/components` package, any class names to the `UnitControl` component through its `className` prop will be applied to its outer wrapper element, instead of an inner input wrapper element.

As a consequence of this change, the `components-unit-control-wrapper` class name and the `__unstableWrapperClassName` prop have been removed from the component.
