### PR TITLE
Allow direct selection of nested Page List block by avoiding dual rendering within block

### DIFF
--- a/packages/block-library/src/page-list/edit.js
+++ b/packages/block-library/src/page-list/edit.js
@@ -67,6 +67,7 @@ export default function PageListEdit( { context, clientId } ) {
 					clientId={ clientId }
 				/>
 			) }
+
 			{ ! hasResolvedPages && (
 				<div { ...blockProps }>
 					<Spinner />
@@ -81,14 +82,14 @@ export default function PageListEdit( { context, clientId } ) {
 				</div>
 			) }
 
-			{ totalPages === 0 && (
+			{ hasResolvedPages && totalPages === 0 && (
 				<div { ...blockProps }>
 					<Notice status={ 'info' } isDismissible={ false }>
 						{ __( 'Page List: Cannot retrieve Pages.' ) }
 					</Notice>
 				</div>
 			) }
-			{ totalPages > 0 && (
+			{ hasResolvedPages && totalPages > 0 && (
 				<ul { ...blockProps }>
 					<PageItems
 						context={ context }

--- a/packages/block-library/src/page-list/edit.js
+++ b/packages/block-library/src/page-list/edit.js
@@ -52,6 +52,47 @@ export default function PageListEdit( { context, clientId } ) {
 		style: { ...context.style?.color },
 	} );
 
+	const getBlockContent = () => {
+		if ( ! hasResolvedPages ) {
+			return (
+				<div { ...blockProps }>
+					<Spinner />
+				</div>
+			);
+		}
+
+		if ( totalPages === null ) {
+			return (
+				<div { ...blockProps }>
+					<Notice status={ 'warning' } isDismissible={ false }>
+						{ __( 'Page List: Cannot retrieve Pages.' ) }
+					</Notice>
+				</div>
+			);
+		}
+
+		if ( totalPages === 0 ) {
+			return (
+				<div { ...blockProps }>
+					<Notice status={ 'info' } isDismissible={ false }>
+						{ __( 'Page List: Cannot retrieve Pages.' ) }
+					</Notice>
+				</div>
+			);
+		}
+
+		if ( totalPages > 0 ) {
+			return (
+				<ul { ...blockProps }>
+					<PageItems
+						context={ context }
+						pagesByParentId={ pagesByParentId }
+					/>
+				</ul>
+			);
+		}
+	};
+
 	return (
 		<>
 			{ allowConvertToLinks && (
@@ -68,35 +109,7 @@ export default function PageListEdit( { context, clientId } ) {
 				/>
 			) }
 
-			{ ! hasResolvedPages && (
-				<div { ...blockProps }>
-					<Spinner />
-				</div>
-			) }
-
-			{ hasResolvedPages && totalPages === null && (
-				<div { ...blockProps }>
-					<Notice status={ 'warning' } isDismissible={ false }>
-						{ __( 'Page List: Cannot retrieve Pages.' ) }
-					</Notice>
-				</div>
-			) }
-
-			{ hasResolvedPages && totalPages === 0 && (
-				<div { ...blockProps }>
-					<Notice status={ 'info' } isDismissible={ false }>
-						{ __( 'Page List: Cannot retrieve Pages.' ) }
-					</Notice>
-				</div>
-			) }
-			{ hasResolvedPages && totalPages > 0 && (
-				<ul { ...blockProps }>
-					<PageItems
-						context={ context }
-						pagesByParentId={ pagesByParentId }
-					/>
-				</ul>
-			) }
+			{ getBlockContent() }
 		</>
 	);
 }


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->
![Screen Capture on 2022-10-20 at 09-34-30](https://user-images.githubusercontent.com/444434/196898821-cd86cb73-eb40-4020-99c5-6b4ce200f56e.gif)

## What?
<!-- In a few words, what is the PR actually doing? -->

Fixes the Page List to make it selectable in the canvas when it is a child of a container block such as the Navigation block. 

Closes https://github.com/WordPress/gutenberg/issues/45083

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

In https://github.com/WordPress/gutenberg/issues/45083 it was reported that it was impossible to _directly_ select the Page List block when it was within a Navigation block. This was also reproducable when the Page List was nested inside other containers such as Group thus confirming that this was not a Nav block specific Issue.


## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

After a lot of deep diving (see Issue) I determine this was due to a `focusin` handler responsible for dispatching [the `selectBlock` action](https://github.com/WordPress/gutenberg/blob/1b73e8b3603e747744e73b189fa1cd91072263a9/packages/block-editor/src/components/block-list/use-block-props/use-focus-handler.js#L57) being [_de-_registered on the Page List block node](https://github.com/WordPress/gutenberg/blob/1b73e8b3603e747744e73b189fa1cd91072263a9/packages/block-editor/src/components/block-list/use-block-props/use-focus-handler.js#L62-L64). This meant that despite being able to focus the block it was not being "selected" in the editor.

The cleanup function that removes the `focusin` event listener is here

https://github.com/WordPress/gutenberg/blob/dc107885fec50ab7417afcb545d97cd63cbc9577/packages/block-editor/src/components/block-list/use-block-props/use-focus-handler.js#L62-L64

This hook uses `useRefEffect` which is an effect which will run when the `ref` changes:

https://github.com/WordPress/gutenberg/blob/1b73e8b3603e747744e73b189fa1cd91072263a9/packages/block-editor/src/components/block-list/use-block-props/use-focus-handler.js#L22

The callback that removes the `focusin` with be called by `useRefEffect` when there is no `node`

https://github.com/WordPress/gutenberg/blob/1b73e8b3603e747744e73b189fa1cd91072263a9/packages/compose/src/hooks/use-ref-effect/index.ts#L38-L40

Therefore the registering of the `focusin` listener on the Page List node is due to the node being added/remove from the DOM.

This made me immediately suspicious of the `render` method of Page List. After some debugging in the browser I was able to observe the Page List block node being **rendered _twice_**. I tracked this down to the following lines 

https://github.com/WordPress/gutenberg/blob/1b73e8b3603e747744e73b189fa1cd91072263a9/packages/block-library/src/page-list/edit.js#L70-L74

https://github.com/WordPress/gutenberg/blob/1b73e8b3603e747744e73b189fa1cd91072263a9/packages/block-library/src/page-list/edit.js#L91-L98

These are not mutually exclusive due to the later not being predicated on `hasResolvedPages` being truthy. Therefore it was possible for both the loading and the "resolved" rendering state of the block to be rendered at the same time. As both use `blockProps` it was causing problems with the registeration of hanlders described above.

The fix in this PR ensures that only one representation of the block can be rendered at any one time.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->

### Before
- Delete all existing Navigation Menus (`http://localhost:8888/wp-admin/edit.php?post_type=wp_navigation`).
- Insert Nav block.
- Toggle List view and see that there is a Page List nested inside the Nav block.
- On the canvas try to directly select the Page List block.
- Notice this is _not_ possible. The block may be "focused" but it will not be "selected" by the editor.



### After

- Delete all existing Navigation Menus (`http://localhost:8888/wp-admin/edit.php?post_type=wp_navigation`).
- Insert Nav block.
- Toggle List view and see that there is a Page List nested inside the Nav block.
- On the canvas try to directly select the Page List block.
- Notice that this is now possible 🥳 
- Open dev tools and select the Page List `<ul>` element. 

For bonus points also do the following (watch the screencast below to see how to do this):

- Toggle the event listeners panel in the dev tools right hand panel.
- Look for the `focusin` listener.
- Notice that there is a listener attached _directly_ to the `<ul>` node.
- Notice that this listener is the `onFocus` callback of the `useFocusHandler` hook.

## Screenshots or screencast <!-- if applicable -->

https://user-images.githubusercontent.com/444434/196898188-a005f8a8-4e69-470e-b1bb-8c2edd4d5174.mp4

