### PR TITLE
Metaboxes save: perform hasMetaBoxes check on every save

### DIFF
--- a/packages/edit-post/src/store/actions.js
+++ b/packages/edit-post/src/store/actions.js
@@ -576,13 +576,16 @@ export const initializeMetaBoxes =
 
 			// Save metaboxes on save completion, except for autosaves.
 			const shouldTriggerMetaboxesSave =
-				wasSavingPost && ! wasAutosavingPost && ! isSavingPost;
+				wasSavingPost &&
+				! wasAutosavingPost &&
+				! isSavingPost &&
+				select.hasMetaBoxes();
 
 			// Save current state for next inspection.
 			wasSavingPost = isSavingPost;
 			wasAutosavingPost = isAutosavingPost;
 
-			if ( shouldTriggerMetaboxesSave && select.hasMetaBoxes() ) {
+			if ( shouldTriggerMetaboxesSave ) {
 				await dispatch.requestMetaBoxUpdates();
 			}
 		} );

--- a/packages/edit-post/src/store/actions.js
+++ b/packages/edit-post/src/store/actions.js
@@ -566,7 +566,6 @@ export const initializeMetaBoxes =
 		let wasAutosavingPost = registry
 			.select( editorStore )
 			.isAutosavingPost();
-		const hasMetaBoxes = select.hasMetaBoxes();
 
 		// Save metaboxes when performing a full save on the post.
 		registry.subscribe( async () => {
@@ -575,23 +574,15 @@ export const initializeMetaBoxes =
 				.select( editorStore )
 				.isAutosavingPost();
 
-			// Save metaboxes on save completion, except for autosaves that are not a post preview.
-			//
-			// Meta boxes are initialized once at page load. It is not necessary to
-			// account for updates on each state change.
-			//
-			// See: https://github.com/WordPress/WordPress/blob/5.1.1/wp-admin/includes/post.php#L2307-L2309.
+			// Save metaboxes on save completion, except for autosaves.
 			const shouldTriggerMetaboxesSave =
-				hasMetaBoxes &&
-				wasSavingPost &&
-				! isSavingPost &&
-				! wasAutosavingPost;
+				wasSavingPost && ! wasAutosavingPost && ! isSavingPost;
 
 			// Save current state for next inspection.
 			wasSavingPost = isSavingPost;
 			wasAutosavingPost = isAutosavingPost;
 
-			if ( shouldTriggerMetaboxesSave ) {
+			if ( shouldTriggerMetaboxesSave && select.hasMetaBoxes() ) {
 				await dispatch.requestMetaBoxUpdates();
 			}
 		} );


### PR DESCRIPTION
Fixes #44716 by kind of reverting the optimization in #15041. The assumption about metaboxes being initialized only on rendering was wrong: folks add new metaboxes dynamically.

The patched code is still optimized because we call `select.hasMetaBoxes()` only after detecting there is a "save finished" event, which is quite rate, the selector is not called on every registry state update like it was before #15041.
