### PR TITLE
Lodash: Refactor away from `_.orderBy()`

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -108,6 +108,7 @@ const restrictedImports = [
 			'nth',
 			'omitBy',
 			'once',
+			'orderby',
 			'overEvery',
 			'partial',
 			'partialRight',

--- a/packages/block-editor/src/autocompleters/block.js
+++ b/packages/block-editor/src/autocompleters/block.js
@@ -1,9 +1,4 @@
 /**
- * External dependencies
- */
-import { orderBy } from 'lodash';
-
-/**
  * WordPress dependencies
  */
 import { useSelect } from '@wordpress/data';
@@ -20,6 +15,7 @@ import { searchBlockItems } from '../components/inserter/search-items';
 import useBlockTypesState from '../components/inserter/hooks/use-block-types-state';
 import BlockIcon from '../components/block-icon';
 import { store as blockEditorStore } from '../store';
+import { orderBy } from '../utils/sorting';
 
 const noop = () => {};
 const SHOWN_BLOCK_TYPES = 9;
@@ -68,7 +64,7 @@ function createBlockCompleter() {
 							collections,
 							filterValue
 					  )
-					: orderBy( items, [ 'frecency' ], [ 'desc' ] );
+					: orderBy( items, 'frecency', 'desc' );
 
 				return initialFilteredItems
 					.filter( ( item ) => item.name !== selectedBlockName )

--- a/packages/block-editor/src/components/block-list/block-list-context.native.js
+++ b/packages/block-editor/src/components/block-list/block-list-context.native.js
@@ -103,7 +103,7 @@ export function deleteBlockLayoutByClientId( data, clientId ) {
  */
 function getBlockLayoutsOrderedByYCoord( data ) {
 	// Only enabled for root level blocks.
-	return orderBy( data, 'y' );
+	return orderBy( Object.values( data ), 'y' );
 }
 
 /**

--- a/packages/block-editor/src/components/block-list/block-list-context.native.js
+++ b/packages/block-editor/src/components/block-list/block-list-context.native.js
@@ -1,12 +1,12 @@
 /**
- * External dependencies
- */
-import { orderBy } from 'lodash';
-
-/**
  * WordPress dependencies
  */
 import { createContext, useContext } from '@wordpress/element';
+
+/**
+ * Internal dependencies
+ */
+import { orderBy } from '../../utils/sorting';
 
 export const DEFAULT_BLOCK_LIST_CONTEXT = {
 	scrollRef: null,
@@ -103,10 +103,7 @@ export function deleteBlockLayoutByClientId( data, clientId ) {
  */
 function getBlockLayoutsOrderedByYCoord( data ) {
 	// Only enabled for root level blocks.
-	// Using lodash orderBy due to hermes not having
-	// stable support for native .sort(). It will be
-	// supported in the React Native version 0.68.0.
-	return orderBy( data, [ 'y', 'asc' ] );
+	return orderBy( data, 'y' );
 }
 
 /**

--- a/packages/block-editor/src/components/inserter/block-types-tab.js
+++ b/packages/block-editor/src/components/inserter/block-types-tab.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { map, groupBy, orderBy } from 'lodash';
+import { map, groupBy } from 'lodash';
 
 /**
  * WordPress dependencies
@@ -17,6 +17,7 @@ import BlockTypesList from '../block-types-list';
 import InserterPanel from './panel';
 import useBlockTypesState from './hooks/use-block-types-state';
 import InserterListbox from '../inserter-listbox';
+import { orderBy } from '../../utils/sorting';
 
 const getBlockNamespace = ( item ) => item.name.split( '/' )[ 0 ];
 
@@ -42,7 +43,7 @@ export function BlockTypesTab( {
 	);
 
 	const suggestedItems = useMemo( () => {
-		return orderBy( items, [ 'frecency' ], [ 'desc' ] ).slice(
+		return orderBy( items, 'frecency', 'desc' ).slice(
 			0,
 			MAX_SUGGESTED_ITEMS
 		);

--- a/packages/block-editor/src/components/inserter/search-results.js
+++ b/packages/block-editor/src/components/inserter/search-results.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { orderBy, isEmpty } from 'lodash';
+import { isEmpty } from 'lodash';
 
 /**
  * WordPress dependencies
@@ -25,6 +25,7 @@ import usePatternsState from './hooks/use-patterns-state';
 import useBlockTypesState from './hooks/use-block-types-state';
 import { searchBlockItems, searchItems } from './search-items';
 import InserterListbox from '../inserter-listbox';
+import { orderBy } from '../../utils/sorting';
 
 const INITIAL_INSERTER_RESULTS = 9;
 /**
@@ -91,7 +92,7 @@ function InserterSearchResults( {
 			return [];
 		}
 		const results = searchBlockItems(
-			orderBy( blockTypes, [ 'frecency' ], [ 'desc' ] ),
+			orderBy( blockTypes, 'frecency', 'desc' ),
 			blockTypeCategories,
 			blockTypeCollections,
 			filterValue

--- a/packages/block-editor/src/components/rich-text/format-toolbar/index.js
+++ b/packages/block-editor/src/components/rich-text/format-toolbar/index.js
@@ -1,17 +1,19 @@
 /**
  * External dependencies
  */
-
-import { orderBy } from 'lodash';
 import classnames from 'classnames';
 
 /**
  * WordPress dependencies
  */
-
 import { __ } from '@wordpress/i18n';
 import { ToolbarItem, DropdownMenu, Slot } from '@wordpress/components';
 import { chevronDown } from '@wordpress/icons';
+
+/**
+ * Internal dependencies
+ */
+import { orderBy } from '../../../utils/sorting';
 
 const POPOVER_PROPS = {
 	position: 'bottom right',

--- a/packages/block-editor/src/store/selectors.js
+++ b/packages/block-editor/src/store/selectors.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { map, find, orderBy } from 'lodash';
+import { map, find } from 'lodash';
 import createSelector from 'rememo';
 
 /**
@@ -27,6 +27,7 @@ import deprecated from '@wordpress/deprecated';
  * Internal dependencies
  */
 import { mapRichTextSettings } from './utils';
+import { orderBy } from '../utils/sorting';
 
 /**
  * A block selection object.

--- a/packages/block-editor/src/utils/sorting.js
+++ b/packages/block-editor/src/utils/sorting.js
@@ -1,0 +1,46 @@
+/**
+ * Recursive sorting criteria function.
+ *
+ * @param {string|Function|Array} criteria Field(s) to sort by.
+ * @return {Function} Comparison function to be used in a `.sort()`.
+ */
+const sortBy = ( criteria ) => {
+	return ( a, b ) => {
+		let cmpA, cmpB;
+
+		if ( typeof criteria === 'function' ) {
+			cmpA = criteria( a );
+			cmpB = criteria( b );
+		} else {
+			cmpA = a[ criteria ];
+			cmpB = b[ criteria ];
+		}
+
+		if ( cmpA > cmpB ) {
+			return 1;
+		} else if ( cmpB > cmpA ) {
+			return -1;
+		}
+
+		return 0;
+	};
+};
+
+/**
+ * Order items by a certain key.
+ * Supports decorator functions that allow complex picking of a comparison field.
+ * Sorts in ascending order by default, but supports descending as well.
+ *
+ * @param {Array}           items    Items to order.
+ * @param {string|Function} criteria Field to order by.
+ * @param {string}          order    Sorting order, `asc` or `desc`.
+ * @return {Array} Sorted items.
+ */
+export function orderBy( items, criteria, order = 'asc' ) {
+	const result = items.concat().sort( sortBy( criteria ) );
+
+	if ( order === 'desc' ) {
+		return result.reverse();
+	}
+	return result;
+}

--- a/packages/block-editor/src/utils/sorting.js
+++ b/packages/block-editor/src/utils/sorting.js
@@ -1,10 +1,12 @@
 /**
- * Recursive sorting criteria function.
+ * Recursive stable sorting criteria function.
  *
  * @param {string|Function|Array} criteria Field(s) to sort by.
+ * @param {Array}                 items    Items to sort.
+ * @param {string}                order    Order, 'asc' or 'desc'.
  * @return {Function} Comparison function to be used in a `.sort()`.
  */
-const sortBy = ( criteria ) => {
+const sortBy = ( criteria, items, order ) => {
 	return ( a, b ) => {
 		let cmpA, cmpB;
 
@@ -17,8 +19,18 @@ const sortBy = ( criteria ) => {
 		}
 
 		if ( cmpA > cmpB ) {
-			return 1;
+			return order === 'asc' ? 1 : -1;
 		} else if ( cmpB > cmpA ) {
+			return order === 'asc' ? -1 : 1;
+		}
+
+		const orderA = items.findIndex( ( item ) => item === a );
+		const orderB = items.findIndex( ( item ) => item === b );
+
+		// Stable sort: maintaining original array order
+		if ( orderA > orderB ) {
+			return 1;
+		} else if ( orderB > orderA ) {
 			return -1;
 		}
 
@@ -30,6 +42,7 @@ const sortBy = ( criteria ) => {
  * Order items by a certain key.
  * Supports decorator functions that allow complex picking of a comparison field.
  * Sorts in ascending order by default, but supports descending as well.
+ * Stable sort - maintains original order of equal items.
  *
  * @param {Array}           items    Items to order.
  * @param {string|Function} criteria Field to order by.
@@ -37,10 +50,5 @@ const sortBy = ( criteria ) => {
  * @return {Array} Sorted items.
  */
 export function orderBy( items, criteria, order = 'asc' ) {
-	const result = items.concat().sort( sortBy( criteria ) );
-
-	if ( order === 'desc' ) {
-		return result.reverse();
-	}
-	return result;
+	return items.concat().sort( sortBy( criteria, items, order ) );
 }

--- a/packages/block-editor/src/utils/sorting.js
+++ b/packages/block-editor/src/utils/sorting.js
@@ -1,9 +1,9 @@
 /**
  * Recursive stable sorting comparator function.
  *
- * @param {string|Function|Array} field Field(s) to sort by.
- * @param {Array}                 items Items to sort.
- * @param {string}                order Order, 'asc' or 'desc'.
+ * @param {string|Function} field Field to sort by.
+ * @param {Array}           items Items to sort.
+ * @param {string}          order Order, 'asc' or 'desc'.
  * @return {Function} Comparison function to be used in a `.sort()`.
  */
 const comparator = ( field, items, order ) => {

--- a/packages/block-editor/src/utils/sorting.js
+++ b/packages/block-editor/src/utils/sorting.js
@@ -1,21 +1,21 @@
 /**
- * Recursive stable sorting criteria function.
+ * Recursive stable sorting comparator function.
  *
- * @param {string|Function|Array} criteria Field(s) to sort by.
- * @param {Array}                 items    Items to sort.
- * @param {string}                order    Order, 'asc' or 'desc'.
+ * @param {string|Function|Array} field Field(s) to sort by.
+ * @param {Array}                 items Items to sort.
+ * @param {string}                order Order, 'asc' or 'desc'.
  * @return {Function} Comparison function to be used in a `.sort()`.
  */
-const sortBy = ( criteria, items, order ) => {
+const comparator = ( field, items, order ) => {
 	return ( a, b ) => {
 		let cmpA, cmpB;
 
-		if ( typeof criteria === 'function' ) {
-			cmpA = criteria( a );
-			cmpB = criteria( b );
+		if ( typeof field === 'function' ) {
+			cmpA = field( a );
+			cmpB = field( b );
 		} else {
-			cmpA = a[ criteria ];
-			cmpB = b[ criteria ];
+			cmpA = a[ field ];
+			cmpB = b[ field ];
 		}
 
 		if ( cmpA > cmpB ) {
@@ -44,11 +44,11 @@ const sortBy = ( criteria, items, order ) => {
  * Sorts in ascending order by default, but supports descending as well.
  * Stable sort - maintains original order of equal items.
  *
- * @param {Array}           items    Items to order.
- * @param {string|Function} criteria Field to order by.
- * @param {string}          order    Sorting order, `asc` or `desc`.
+ * @param {Array}           items Items to order.
+ * @param {string|Function} field Field to order by.
+ * @param {string}          order Sorting order, `asc` or `desc`.
  * @return {Array} Sorted items.
  */
-export function orderBy( items, criteria, order = 'asc' ) {
-	return items.concat().sort( sortBy( criteria, items, order ) );
+export function orderBy( items, field, order = 'asc' ) {
+	return items.concat().sort( comparator( field, items, order ) );
 }

--- a/packages/block-editor/src/utils/test/sorting.js
+++ b/packages/block-editor/src/utils/test/sorting.js
@@ -1,0 +1,29 @@
+/**
+ * Internal dependencies
+ */
+import { orderBy } from '../sorting';
+
+describe( 'orderBy', () => {
+	it( 'should not mutate original input', () => {
+		const input = [];
+		expect( orderBy( input, 'x' ) ).not.toBe( input );
+	} );
+
+	it( 'should sort items by a field when it is specified as a string', () => {
+		const input = [ { x: 2 }, { x: 1 }, { x: 3 } ];
+		const expected = [ { x: 1 }, { x: 2 }, { x: 3 } ];
+		expect( orderBy( input, 'x' ) ).toEqual( expected );
+	} );
+
+	it( 'should support functions for picking the field', () => {
+		const input = [ { x: 2 }, { x: 1 }, { x: 3 } ];
+		const expected = [ { x: 1 }, { x: 2 }, { x: 3 } ];
+		expect( orderBy( input, ( item ) => item.x ) ).toEqual( expected );
+	} );
+
+	it( 'should support sorting in a descending order', () => {
+		const input = [ { x: 2 }, { x: 1 }, { x: 3 } ];
+		const expected = [ { x: 3 }, { x: 2 }, { x: 1 } ];
+		expect( orderBy( input, 'x', 'desc' ) ).toEqual( expected );
+	} );
+} );

--- a/packages/block-editor/src/utils/test/sorting.js
+++ b/packages/block-editor/src/utils/test/sorting.js
@@ -26,4 +26,24 @@ describe( 'orderBy', () => {
 		const expected = [ { x: 3 }, { x: 2 }, { x: 1 } ];
 		expect( orderBy( input, 'x', 'desc' ) ).toEqual( expected );
 	} );
+
+	it( 'should maintain original order of equal items', () => {
+		const a = { x: 1, a: 1 };
+		const b = { x: 1, b: 2 };
+		const c = { x: 0 };
+		const d = { x: 1, b: 4 };
+		const input = [ a, b, c, d ];
+		const expected = [ c, a, b, d ];
+		expect( orderBy( input, 'x' ) ).toEqual( expected );
+	} );
+
+	it( 'should maintain original order of equal items in descencing order', () => {
+		const a = { x: 1, a: 1 };
+		const b = { x: 1, b: 2 };
+		const c = { x: 0 };
+		const d = { x: 1, b: 4 };
+		const input = [ a, b, c, d ];
+		const expected = [ a, b, d, c ];
+		expect( orderBy( input, 'x', 'desc' ) ).toEqual( expected );
+	} );
 } );


### PR DESCRIPTION
## What?
This PR removes Lodash's `_.orderBy()` completely and deprecates the method. We're introducing a custom sorting function to preserve the same behavior as the Lodash function. There are just a few usages and conversion is pretty straightforward. 

## Why?

Lodash is known to unnecessarily inflate the bundle size of packages, and in most cases, it can be replaced with native language functionality. See these for more information and rationale:

* https://github.com/WordPress/gutenberg/issues/16938#issuecomment-602837246
* https://github.com/WordPress/gutenberg/issues/17025
* https://github.com/WordPress/gutenberg/issues/39495 

## How?

We're introducing a simple custom sorting function and using it to replace the complex Lodash implementation.

## Testing Instructions
* Verify the list of blocks when you type `/` in the editor is sorted the same way.
* RN: Verify testing instructions of #40424 still work well.
* Verify the list of blocks in each inserter is sorted the same way as in `trunk`. 
* Verify the inserter search results are sorted the same way as in `trunk`.
* Verify that the rich text formatting controls are still sorted ascending by title.
* Verify the list of available blocks to transform to is still sorted the same way.
* Verify all tests pass and all checks are green.