### PR TITLE
Better regions and shortcut

### DIFF
--- a/packages/block-editor/src/components/block-list/use-block-props/use-focus-first-element.js
+++ b/packages/block-editor/src/components/block-list/use-block-props/use-focus-first-element.js
@@ -29,17 +29,10 @@ import { store as blockEditorStore } from '../../../store';
 function useInitialPosition( clientId ) {
 	return useSelect(
 		( select ) => {
-			const {
-				getSelectedBlocksInitialCaretPosition,
-				__unstableGetEditorMode,
-				isBlockSelected,
-			} = select( blockEditorStore );
+			const { getSelectedBlocksInitialCaretPosition, isBlockSelected } =
+				select( blockEditorStore );
 
 			if ( ! isBlockSelected( clientId ) ) {
-				return;
-			}
-
-			if ( __unstableGetEditorMode() !== 'edit' ) {
 				return;
 			}
 
@@ -61,11 +54,16 @@ function useInitialPosition( clientId ) {
 export function useFocusFirstElement( clientId ) {
 	const ref = useRef();
 	const initialPosition = useInitialPosition( clientId );
-	const { isBlockSelected, isMultiSelecting } = useSelect( blockEditorStore );
+	const { isBlockSelected, isMultiSelecting, __unstableGetEditorMode } =
+		useSelect( blockEditorStore );
 
 	useEffect( () => {
 		// Check if the block is still selected at the time this effect runs.
 		if ( ! isBlockSelected( clientId ) || isMultiSelecting() ) {
+			return;
+		}
+
+		if ( __unstableGetEditorMode() !== 'edit' ) {
 			return;
 		}
 

--- a/packages/block-editor/src/components/block-tools/block-selection-button.js
+++ b/packages/block-editor/src/components/block-tools/block-selection-button.js
@@ -169,9 +169,12 @@ function BlockSelectionButton( { clientId, rootClientId } ) {
 				selectedBlockClientId;
 		}
 		const startingBlockClientId = hasBlockMovingClientId();
-		if ( isEscape && startingBlockClientId && ! event.defaultPrevented ) {
-			setBlockMovingClientId( null );
-			event.preventDefault();
+		if ( isEscape && ! event.defaultPrevented ) {
+			if ( startingBlockClientId && ! event.shiftKey ) {
+				setBlockMovingClientId( null );
+				event.preventDefault();
+			}
+			return;
 		}
 		if ( ( isEnter || isSpace ) && startingBlockClientId ) {
 			const sourceRoot = getBlockRootClientId( startingBlockClientId );
@@ -275,6 +278,9 @@ function BlockSelectionButton( { clientId, rootClientId } ) {
 								: undefined
 						}
 						onKeyDown={ onKeyDown }
+						onBlur={ () => {
+							setNavigationMode( false );
+						} }
 						label={ label }
 						showTooltip={ false }
 						className="block-selection-button_select-button"

--- a/packages/block-editor/src/components/block-tools/index.js
+++ b/packages/block-editor/src/components/block-tools/index.js
@@ -15,6 +15,7 @@ import {
 	default as InsertionPoint,
 } from './insertion-point';
 import SelectedBlockPopover from './selected-block-popover';
+import NavBlockPopover from './nav-block-popover';
 import { store as blockEditorStore } from '../../store';
 import BlockContextualToolbar from './block-contextual-toolbar';
 import usePopoverScroll from '../block-popover/use-popover-scroll';
@@ -58,7 +59,6 @@ export default function BlockTools( {
 		removeBlocks,
 		insertAfterBlock,
 		insertBeforeBlock,
-		clearSelectedBlock,
 		moveBlocksUp,
 		moveBlocksDown,
 	} = useDispatch( blockEditorStore );
@@ -104,16 +104,6 @@ export default function BlockTools( {
 				event.preventDefault();
 				insertBeforeBlock( clientIds[ 0 ] );
 			}
-		} else if ( isMatch( 'core/block-editor/unselect', event ) ) {
-			const clientIds = getSelectedBlockClientIds();
-			if ( clientIds.length ) {
-				event.preventDefault();
-				clearSelectedBlock();
-				event.target.ownerDocument.defaultView
-					.getSelection()
-					.removeAllRanges();
-				__unstableContentRef?.current.focus();
-			}
 		}
 	}
 
@@ -145,6 +135,9 @@ export default function BlockTools( {
 				<Popover.Slot
 					name="__unstable-block-tools-after"
 					ref={ blockToolbarAfterRef }
+				/>
+				<NavBlockPopover
+					__unstableContentRef={ __unstableContentRef }
 				/>
 				{ isZoomOutMode && (
 					<ZoomOutModeInserters

--- a/packages/block-editor/src/components/block-tools/index.js
+++ b/packages/block-editor/src/components/block-tools/index.js
@@ -59,6 +59,7 @@ export default function BlockTools( {
 		removeBlocks,
 		insertAfterBlock,
 		insertBeforeBlock,
+		clearSelectedBlock,
 		moveBlocksUp,
 		moveBlocksDown,
 	} = useDispatch( blockEditorStore );
@@ -103,6 +104,16 @@ export default function BlockTools( {
 			if ( clientIds.length ) {
 				event.preventDefault();
 				insertBeforeBlock( clientIds[ 0 ] );
+			}
+		} else if ( isMatch( 'core/block-editor/unselect', event ) ) {
+			const clientIds = getSelectedBlockClientIds();
+			if ( clientIds.length ) {
+				event.preventDefault();
+				clearSelectedBlock();
+				event.target.ownerDocument.defaultView
+					.getSelection()
+					.removeAllRanges();
+				__unstableContentRef?.current.focus();
 			}
 		}
 	}

--- a/packages/block-editor/src/components/keyboard-shortcuts/index.js
+++ b/packages/block-editor/src/components/keyboard-shortcuts/index.js
@@ -85,15 +85,6 @@ function KeyboardShortcutsRegister() {
 		} );
 
 		registerShortcut( {
-			name: 'core/block-editor/unselect',
-			category: 'selection',
-			description: __( 'Clear selection.' ),
-			keyCombination: {
-				character: 'escape',
-			},
-		} );
-
-		registerShortcut( {
 			name: 'core/block-editor/focus-toolbar',
 			category: 'global',
 			description: __( 'Navigate to the nearest toolbar.' ),

--- a/packages/block-editor/src/components/keyboard-shortcuts/index.js
+++ b/packages/block-editor/src/components/keyboard-shortcuts/index.js
@@ -85,6 +85,15 @@ function KeyboardShortcutsRegister() {
 		} );
 
 		registerShortcut( {
+			name: 'core/block-editor/unselect',
+			category: 'selection',
+			description: __( 'Clear selection.' ),
+			keyCombination: {
+				character: 'escape',
+			},
+		} );
+
+		registerShortcut( {
 			name: 'core/block-editor/focus-toolbar',
 			category: 'global',
 			description: __( 'Navigate to the nearest toolbar.' ),

--- a/packages/block-editor/src/components/writing-flow/index.js
+++ b/packages/block-editor/src/components/writing-flow/index.js
@@ -46,6 +46,7 @@ export function useWritingFlow() {
 				( node ) => {
 					node.tabIndex = -1;
 					node.contentEditable = hasMultiSelection;
+					node.role = 'region';
 
 					if ( ! hasMultiSelection ) {
 						return;

--- a/packages/block-editor/src/components/writing-flow/use-tab-nav.js
+++ b/packages/block-editor/src/components/writing-flow/use-tab-nav.js
@@ -2,7 +2,7 @@
  * WordPress dependencies
  */
 import { focus, isFormElement } from '@wordpress/dom';
-import { TAB, ESCAPE } from '@wordpress/keycodes';
+import { TAB } from '@wordpress/keycodes';
 import { useSelect, useDispatch } from '@wordpress/data';
 import { useRefEffect, useMergeRefs } from '@wordpress/compose';
 import { useRef } from '@wordpress/element';
@@ -72,12 +72,6 @@ export default function useTabNav() {
 	const ref = useRefEffect( ( node ) => {
 		function onKeyDown( event ) {
 			if ( event.defaultPrevented ) {
-				return;
-			}
-
-			if ( event.keyCode === ESCAPE ) {
-				event.preventDefault();
-				setNavigationMode( true );
 				return;
 			}
 
@@ -183,15 +177,26 @@ export default function useTabNav() {
 			}
 		}
 
+		function onFocus() {
+			setNavigationMode( false );
+
+			const clientId = getSelectedBlockClientId();
+
+			if ( clientId ) {
+				node.querySelector( `[data-block="${ clientId }"]` ).focus();
+			}
+		}
+
 		const { ownerDocument } = node;
 		const { defaultView } = ownerDocument;
 		defaultView.addEventListener( 'keydown', preventScrollOnTab );
 		node.addEventListener( 'keydown', onKeyDown );
 		node.addEventListener( 'focusout', onFocusOut );
+		node.addEventListener( 'focus', onFocus );
 		return () => {
 			defaultView.removeEventListener( 'keydown', preventScrollOnTab );
 			node.removeEventListener( 'keydown', onKeyDown );
-			node.removeEventListener( 'focusout', onFocusOut );
+			node.removeEventListener( 'focus', onFocus );
 		};
 	}, [] );
 

--- a/packages/block-editor/src/components/writing-flow/use-tab-nav.js
+++ b/packages/block-editor/src/components/writing-flow/use-tab-nav.js
@@ -2,7 +2,7 @@
  * WordPress dependencies
  */
 import { focus, isFormElement } from '@wordpress/dom';
-import { TAB } from '@wordpress/keycodes';
+import { TAB, ESCAPE } from '@wordpress/keycodes';
 import { useSelect, useDispatch } from '@wordpress/data';
 import { useRefEffect, useMergeRefs } from '@wordpress/compose';
 import { useRef } from '@wordpress/element';
@@ -72,6 +72,12 @@ export default function useTabNav() {
 	const ref = useRefEffect( ( node ) => {
 		function onKeyDown( event ) {
 			if ( event.defaultPrevented ) {
+				return;
+			}
+
+			if ( event.keyCode === ESCAPE ) {
+				event.preventDefault();
+				setNavigationMode( true );
 				return;
 			}
 

--- a/packages/components/src/higher-order/navigate-regions/index.js
+++ b/packages/components/src/higher-order/navigate-regions/index.js
@@ -12,8 +12,8 @@ import { isKeyboardEvent } from '@wordpress/keycodes';
 const defaultShortcuts = {
 	previous: [
 		{
-			modifier: 'shift',
-			character: 'escape',
+			modifier: 'primary',
+			character: 'F6',
 		},
 		{
 			modifier: 'ctrlShift',
@@ -26,7 +26,8 @@ const defaultShortcuts = {
 	],
 	next: [
 		{
-			character: 'escape',
+			modifier: 'primaryShift',
+			character: 'F6',
 		},
 		{
 			modifier: 'ctrl',

--- a/packages/components/src/higher-order/navigate-regions/index.js
+++ b/packages/components/src/higher-order/navigate-regions/index.js
@@ -12,6 +12,10 @@ import { isKeyboardEvent } from '@wordpress/keycodes';
 const defaultShortcuts = {
 	previous: [
 		{
+			modifier: 'shift',
+			character: 'escape',
+		},
+		{
 			modifier: 'ctrlShift',
 			character: '`',
 		},
@@ -21,6 +25,9 @@ const defaultShortcuts = {
 		},
 	],
 	next: [
+		{
+			character: 'escape',
+		},
 		{
 			modifier: 'ctrl',
 			character: '`',
@@ -39,13 +46,16 @@ export function useNavigateRegions( shortcuts = defaultShortcuts ) {
 	function focusRegion( offset ) {
 		const regions = Array.from(
 			ref.current.querySelectorAll( '[role="region"]' )
-		);
+		).filter( ( node ) => {
+			// Ignore if there's (dynamic) child regions.
+			return ! node.querySelector( '[role="region"]' );
+		} );
 		if ( ! regions.length ) {
 			return;
 		}
 		let nextRegion = regions[ 0 ];
 		const selectedIndex = regions.indexOf(
-			ref.current.ownerDocument.activeElement
+			ref.current.ownerDocument.activeElement.closest( '[role="region"]' )
 		);
 		if ( selectedIndex !== -1 ) {
 			let nextIndex = selectedIndex + offset;
@@ -77,6 +87,10 @@ export function useNavigateRegions( shortcuts = defaultShortcuts ) {
 		ref: useMergeRefs( [ ref, clickRef ] ),
 		className: isFocusingRegions ? 'is-focusing-regions' : '',
 		onKeyDown( event ) {
+			if ( event.defaultPrevented ) {
+				return;
+			}
+
 			if (
 				shortcuts.previous.some( ( { modifier, character } ) => {
 					return isKeyboardEvent[ modifier ]( event, character );

--- a/packages/edit-post/src/components/keyboard-shortcuts/index.js
+++ b/packages/edit-post/src/components/keyboard-shortcuts/index.js
@@ -117,6 +117,9 @@ function KeyboardShortcuts() {
 					modifier: 'access',
 					character: 'n',
 				},
+				{
+					character: 'escape',
+				},
 			],
 		} );
 
@@ -132,6 +135,10 @@ function KeyboardShortcuts() {
 				{
 					modifier: 'access',
 					character: 'p',
+				},
+				{
+					modifier: 'shift',
+					character: 'escape',
 				},
 			],
 		} );

--- a/packages/edit-post/src/components/keyboard-shortcuts/index.js
+++ b/packages/edit-post/src/components/keyboard-shortcuts/index.js
@@ -118,7 +118,8 @@ function KeyboardShortcuts() {
 					character: 'n',
 				},
 				{
-					character: 'escape',
+					modifier: 'primary',
+					character: 'F6',
 				},
 			],
 		} );
@@ -137,8 +138,8 @@ function KeyboardShortcuts() {
 					character: 'p',
 				},
 				{
-					modifier: 'shift',
-					character: 'escape',
+					modifier: 'primaryShift',
+					character: 'F6',
 				},
 			],
 		} );

--- a/packages/edit-site/src/components/keyboard-shortcuts/index.js
+++ b/packages/edit-site/src/components/keyboard-shortcuts/index.js
@@ -163,6 +163,9 @@ function KeyboardShortcutsRegister() {
 					modifier: 'access',
 					character: 'n',
 				},
+				{
+					character: 'escape',
+				},
 			],
 		} );
 
@@ -178,6 +181,10 @@ function KeyboardShortcutsRegister() {
 				{
 					modifier: 'access',
 					character: 'p',
+				},
+				{
+					modifier: 'shift',
+					character: 'escape',
 				},
 			],
 		} );

--- a/packages/edit-site/src/components/keyboard-shortcuts/index.js
+++ b/packages/edit-site/src/components/keyboard-shortcuts/index.js
@@ -164,7 +164,8 @@ function KeyboardShortcutsRegister() {
 					character: 'n',
 				},
 				{
-					character: 'escape',
+					modifier: 'primary',
+					character: 'F6',
 				},
 			],
 		} );
@@ -183,8 +184,8 @@ function KeyboardShortcutsRegister() {
 					character: 'p',
 				},
 				{
-					modifier: 'shift',
-					character: 'escape',
+					modifier: 'primaryShift',
+					character: 'F6',
 				},
 			],
 		} );

--- a/packages/edit-site/src/components/list/use-register-shortcuts.js
+++ b/packages/edit-site/src/components/list/use-register-shortcuts.js
@@ -23,6 +23,9 @@ export default function useRegisterShortcuts() {
 					modifier: 'access',
 					character: 'n',
 				},
+				{
+					character: 'escape',
+				},
 			],
 		} );
 
@@ -38,6 +41,10 @@ export default function useRegisterShortcuts() {
 				{
 					modifier: 'access',
 					character: 'p',
+				},
+				{
+					modifier: 'shift',
+					character: 'escape',
 				},
 			],
 		} );

--- a/packages/edit-site/src/components/list/use-register-shortcuts.js
+++ b/packages/edit-site/src/components/list/use-register-shortcuts.js
@@ -24,7 +24,8 @@ export default function useRegisterShortcuts() {
 					character: 'n',
 				},
 				{
-					character: 'escape',
+					modifier: 'primary',
+					character: 'F6',
 				},
 			],
 		} );
@@ -43,8 +44,8 @@ export default function useRegisterShortcuts() {
 					character: 'p',
 				},
 				{
-					modifier: 'shift',
-					character: 'escape',
+					modifier: 'primaryShift',
+					character: 'F6',
 				},
 			],
 		} );

--- a/packages/edit-widgets/src/components/keyboard-shortcuts/index.js
+++ b/packages/edit-widgets/src/components/keyboard-shortcuts/index.js
@@ -95,7 +95,8 @@ function KeyboardShortcutsRegister() {
 					character: 'n',
 				},
 				{
-					character: 'escape',
+					modifier: 'primary',
+					character: 'F6',
 				},
 			],
 		} );
@@ -114,8 +115,8 @@ function KeyboardShortcutsRegister() {
 					character: 'p',
 				},
 				{
-					modifier: 'shift',
-					character: 'escape',
+					modifier: 'primaryShift',
+					character: 'F6',
 				},
 			],
 		} );

--- a/packages/edit-widgets/src/components/keyboard-shortcuts/index.js
+++ b/packages/edit-widgets/src/components/keyboard-shortcuts/index.js
@@ -94,6 +94,9 @@ function KeyboardShortcutsRegister() {
 					modifier: 'access',
 					character: 'n',
 				},
+				{
+					character: 'escape',
+				},
 			],
 		} );
 
@@ -109,6 +112,10 @@ function KeyboardShortcutsRegister() {
 				{
 					modifier: 'access',
 					character: 'p',
+				},
+				{
+					modifier: 'shift',
+					character: 'escape',
 				},
 			],
 		} );


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?

[Please note that the code is still a WIP, but it works for testing.]

As we are looking at changing tab behaviour in the editor (for list and code blocks), we need to strengthen other types of  navigation.

There's two existing mechanisms:

* Block navigation mode: press Escape.
* Regions: press (Shift+)Ctrl+` or Ctrl+Alt+N/P, both of which I find hard to remember.

Proposal: additional regions with easier to remember shortcuts.

The additional regions would be:

* The block toolbar
* Navigation mode
* Potentially before/after inserter for the selected block

In addition to that, offer easier to remember shortcuts:

* Escape already enters Navigation mode, but does nothing further. Let it be used to enter the next region.
* Shift+Escape should reverse cycle through the regions, so from the selected block, it enters the block toolbar, from there the interface header, and so on.

The (Shift+)Escape combination is a good indicator that it can be used to cycle through the regions, just like (Shift+)Tab can be used to cycle through tabbable elements.

**But Ella, won't Escape clash with existing behaviour?**

When a block is selected and focussed, we already use it for Navigation mode, which is now baked in the regions.

In other places, it can be used for closing popovers and modals, but that's fine. First the popover or modal must be closed before you can continue cycling through the regions. It makes perfect sense to me.

The main regions can be seen as the roundabout on which (Shift+)Escape can be used to navigate. (Shift+)Tab (default) or Arrow keys (navigation mode, toolbars) can be used to navigate more granularly.

## Why?

We need a solid method to navigate the editor because (Shift+)Tab may no longer work when a block is focussed. A single unified way that is easy to remember will benefit all users greatly.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

## Testing Instructions

Select a block. Test Escape and Shift+Escape shortcuts.

## Screenshots or screencast <!-- if applicable -->

![better-regions](https://user-images.githubusercontent.com/4710635/196947276-ba75f775-21a9-4917-9282-ba4810fcd509.gif)
