### PR TITLE
Don't use the custom 'Template Parts' page with WP 6.1 and above

### DIFF
--- a/lib/compat/wordpress-6.1/template-parts-screen.php
+++ b/lib/compat/wordpress-6.1/template-parts-screen.php
@@ -24,6 +24,24 @@ function gutenberg_template_parts_screen_menu() {
 		return;
 	}
 
+	global $submenu;
+	if ( ! isset( $submenu['themes.php'] ) ) {
+		return;
+	}
+
+	$needs_custom_page = true;
+	foreach ( $submenu['themes.php'] as $menu_item ) {
+		if ( str_contains( $menu_item[2], 'site-editor.php?postType=wp_template_part' ) ) {
+			$needs_custom_page = false;
+			break;
+		}
+	}
+
+	// Don't use the custom 'Template Parts' page with WP 6.1 and above.
+	if ( ! $needs_custom_page ) {
+		return;
+	}
+
 	add_theme_page(
 		__( 'Template Parts', 'gutenberg' ),
 		__( 'Template Parts', 'gutenberg' ),


### PR DESCRIPTION
## What?
PR adds a check not to register the custom 'Template Parts' page for WP 6.1 and above. This also prevents displaying two menu items with 'Template Parts'  under the Appearance.

## Why?
The custom page is only needed for older WP versions, where required restrictions are missing from `site-editor.php`.

## Testing Instructions
1. Install and activate a classic theme that enables block template parts - https://github.com/Mamaduka/block-fragments.
2. On WP 6.0, confirm that the "Template Parts" menu uses a custom page.
3. Upgrade to WP 6.1 RC.
4. Confirm that the "Template Parts" page uses the `site-editor.php` path.

## Screenshots or screencast <!-- if applicable -->
| Before | After |
| --- | --- |
|![CleanShot 2022-10-20 at 16 21 44](https://user-images.githubusercontent.com/240569/196947591-5a8628fe-d401-4c32-a163-c0768eee3a6e.png)|![CleanShot 2022-10-20 at 16 21 20](https://user-images.githubusercontent.com/240569/196947606-6a338cb6-c391-4b24-aa84-dc88d5361060.png)|