### PR TITLE
Try fixing Site Title flaky e2e tests

### DIFF
--- a/packages/e2e-tests/specs/editor/blocks/site-title.test.js
+++ b/packages/e2e-tests/specs/editor/blocks/site-title.test.js
@@ -3,8 +3,6 @@
  */
 import {
 	createNewPost,
-	createUser,
-	deleteUser,
 	getOption,
 	insertBlock,
 	loginUser,
@@ -36,11 +34,9 @@ describe( 'Site Title block', () => {
 	const username = 'testuser';
 	beforeAll( async () => {
 		originalSiteTitle = await getOption( 'blogname' );
-		password = await createUser( username, { role: 'editor' } );
 	} );
 
 	afterAll( async () => {
-		await deleteUser( username );
 		await setOption( 'blogname', originalSiteTitle );
 	} );
 


### PR DESCRIPTION
## What?
PR tries to fix flaky e2e tests for the Site Title block.

## Why?
Tests started failing more often.

## How?
I removed setup steps only required for the currently skipped test case. Based on logs, I think this was causing the issue.

## Testing Instructions
Let's see if the tests pass on CI.

```
npm run test:e2e -- packages/e2e-tests/specs/editor/blocks/site-title.test.js
```

## Screenshots or screencast <!-- if applicable -->

![CleanShot 2022-10-20 at 18 02 29](https://user-images.githubusercontent.com/240569/196970838-4b967c9a-c8b7-427a-98d1-6ad5747bc901.png)
