### PR TITLE
Featured Image Block: Add missing output escaping

### DIFF
--- a/packages/block-library/src/post-featured-image/index.php
+++ b/packages/block-library/src/post-featured-image/index.php
@@ -64,7 +64,7 @@ function render_block_core_post_featured_image( $attributes, $content, $block ) 
 		if ( ! empty( $attributes['scale'] ) ) {
 			$image_styles .= "object-fit:{$attributes['scale']};";
 		}
-		$featured_image = str_replace( 'src=', 'style="' . esc_attr( $image_styles ) . '" src=', $featured_image );
+		$featured_image = str_replace( '<img ', '<img style="' . esc_attr( safecss_filter_attr( $image_styles ) ) . '" ', $featured_image );
 	}
 
 	return "<figure {$wrapper_attributes}>{$featured_image}</figure>";


### PR DESCRIPTION
_Note that this is for the `wp/6.1` branch._

We recently added output escaping to a few blocks, across various WordPress versions (see e.g. #45035 for WP 6.0, #45020 for WP 5.9, etc), prior to releasing WP 6.0.3 (and friends). We did the same for Gutenberg's `trunk` in #45045. The latter was then [cherry-picked](https://github.com/WordPress/gutenberg/pull/45045#issuecomment-1281656961) to the `wp/6.1` branch, and [included](https://github.com/WordPress/gutenberg/pull/45051) in WP 6.1 RC2.

However, if you compare #45045 (GB `trunk`) to #45035 (WP 6.0), you'll notice that the PR for GB `trunk` doesn't have the changes for the Post Featured Image block. (This probably happened since the relevant code changed quite significantly.)

This PR aims to solve this issue by carrying over the relevant changes to WP 6.1.

Note that this will temporarily cause a [known issue](https://core.trac.wordpress.org/ticket/56855) with that block that has meanwhile been found in WP 6.0.3. That's okay; we're going to need to fix that issue anyway for WP 6.1, and it already has a promising patch.
