### PR TITLE
DateTimePicker: Add `__next*` props in Storybook

### DIFF
--- a/packages/components/src/date-time/date-time/index.tsx
+++ b/packages/components/src/date-time/date-time/index.tsx
@@ -207,6 +207,8 @@ function UnforwardedDateTimePicker(
  *       currentDate={ date }
  *       onChange={ ( newDate ) => setDate( newDate ) }
  *       is12Hour
+ *       __nextRemoveHelpButton
+ *       __nextRemoveResetButton
  *     />
  *   );
  * };

--- a/packages/components/src/date-time/stories/date-time.tsx
+++ b/packages/components/src/date-time/stories/date-time.tsx
@@ -52,6 +52,10 @@ const Template: ComponentStory< typeof DateTimePicker > = ( {
 export const Default: ComponentStory< typeof DateTimePicker > = Template.bind(
 	{}
 );
+Default.args = {
+	__nextRemoveHelpButton: true,
+	__nextRemoveResetButton: true,
+};
 
 export const WithEvents: ComponentStory< typeof DateTimePicker > =
 	Template.bind( {} );


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?

Updates the code snippet in the JSDoc, as well as the default Storybook props, so they show the `__next*` props enabled.

## Why?

So devs are [encouraged](https://github.com/WordPress/gutenberg/blob/trunk/packages/components/CONTRIBUTING.md#deprecating-styles) to adopt the `__next*` props from the start.

## Testing Instructions

`npm run storybook:dev` and see the DateTimePicker story. The code snippets should have the `__next*` props enabled. There should be no deprecation warning in the console.