### PR TITLE
Embed: Add deprecation for the caption element

### DIFF
--- a/packages/block-library/src/embed/deprecated.js
+++ b/packages/block-library/src/embed/deprecated.js
@@ -11,36 +11,61 @@ import metadata from './block.json';
 /**
  * WordPress dependencies
  */
-import { RichText } from '@wordpress/block-editor';
+import { RichText, useBlockProps } from '@wordpress/block-editor';
 
 const { attributes: blockAttributes } = metadata;
 
-const deprecated = [
-	{
-		attributes: blockAttributes,
-		save( { attributes: { url, caption, type, providerNameSlug } } ) {
-			if ( ! url ) {
-				return null;
-			}
+const v2 = {
+	attributes: blockAttributes,
+	save( { attributes } ) {
+		const { url, caption, type, providerNameSlug } = attributes;
 
-			const embedClassName = classnames( 'wp-block-embed', {
-				[ `is-type-${ type }` ]: type,
-				[ `is-provider-${ providerNameSlug }` ]: providerNameSlug,
-			} );
+		if ( ! url ) {
+			return null;
+		}
 
-			return (
-				<figure className={ embedClassName }>
+		const className = classnames( 'wp-block-embed', {
+			[ `is-type-${ type }` ]: type,
+			[ `is-provider-${ providerNameSlug }` ]: providerNameSlug,
+			[ `wp-block-embed-${ providerNameSlug }` ]: providerNameSlug,
+		} );
+
+		return (
+			<figure { ...useBlockProps.save( { className } ) }>
+				<div className="wp-block-embed__wrapper">
 					{ `\n${ url }\n` /* URL needs to be on its own line. */ }
-					{ ! RichText.isEmpty( caption ) && (
-						<RichText.Content
-							tagName="figcaption"
-							value={ caption }
-						/>
-					) }
-				</figure>
-			);
-		},
+				</div>
+				{ ! RichText.isEmpty( caption ) && (
+					<RichText.Content tagName="figcaption" value={ caption } />
+				) }
+			</figure>
+		);
 	},
-];
+};
+
+const v1 = {
+	attributes: blockAttributes,
+	save( { attributes: { url, caption, type, providerNameSlug } } ) {
+		if ( ! url ) {
+			return null;
+		}
+
+		const embedClassName = classnames( 'wp-block-embed', {
+			[ `is-type-${ type }` ]: type,
+			[ `is-provider-${ providerNameSlug }` ]: providerNameSlug,
+		} );
+
+		return (
+			<figure className={ embedClassName }>
+				{ `\n${ url }\n` /* URL needs to be on its own line. */ }
+				{ ! RichText.isEmpty( caption ) && (
+					<RichText.Content tagName="figcaption" value={ caption } />
+				) }
+			</figure>
+		);
+	},
+};
+
+const deprecated = [ v2, v1 ];
 
 export default deprecated;

--- a/packages/block-library/src/embed/deprecated.js
+++ b/packages/block-library/src/embed/deprecated.js
@@ -15,6 +15,8 @@ import { RichText, useBlockProps } from '@wordpress/block-editor';
 
 const { attributes: blockAttributes } = metadata;
 
+// In #41140 support was added to global styles for caption elements which added a `wp-element-caption` classname
+// to the embed figcaption element.
 const v2 = {
 	attributes: blockAttributes,
 	save( { attributes } ) {

--- a/test/integration/fixtures/blocks/core__embed__deprecated-1.html
+++ b/test/integration/fixtures/blocks/core__embed__deprecated-1.html
@@ -1,0 +1,6 @@
+<!-- wp:embed {"url":"https://example.com/"} -->
+<figure class="wp-block-embed">
+    https://example.com/
+    <figcaption>Embedded content from an example URL</figcaption>
+</figure>
+<!-- /wp:embed -->

--- a/test/integration/fixtures/blocks/core__embed__deprecated-1.json
+++ b/test/integration/fixtures/blocks/core__embed__deprecated-1.json
@@ -1,0 +1,14 @@
+[
+	{
+		"name": "core/embed",
+		"isValid": true,
+		"attributes": {
+			"url": "https://example.com/",
+			"caption": "Embedded content from an example URL",
+			"allowResponsive": true,
+			"responsive": false,
+			"previewable": true
+		},
+		"innerBlocks": []
+	}
+]

--- a/test/integration/fixtures/blocks/core__embed__deprecated-1.parsed.json
+++ b/test/integration/fixtures/blocks/core__embed__deprecated-1.parsed.json
@@ -1,0 +1,13 @@
+[
+	{
+		"blockName": "core/embed",
+		"attrs": {
+			"url": "https://example.com/"
+		},
+		"innerBlocks": [],
+		"innerHTML": "\n<figure class=\"wp-block-embed\">\n    https://example.com/\n    <figcaption>Embedded content from an example URL</figcaption>\n</figure>\n",
+		"innerContent": [
+			"\n<figure class=\"wp-block-embed\">\n    https://example.com/\n    <figcaption>Embedded content from an example URL</figcaption>\n</figure>\n"
+		]
+	}
+]

--- a/test/integration/fixtures/blocks/core__embed__deprecated-1.serialized.html
+++ b/test/integration/fixtures/blocks/core__embed__deprecated-1.serialized.html
@@ -1,0 +1,5 @@
+<!-- wp:embed {"url":"https://example.com/"} -->
+<figure class="wp-block-embed"><div class="wp-block-embed__wrapper">
+https://example.com/
+</div><figcaption class="wp-element-caption">Embedded content from an example URL</figcaption></figure>
+<!-- /wp:embed -->

--- a/test/integration/fixtures/blocks/core__embed__deprecated-2.html
+++ b/test/integration/fixtures/blocks/core__embed__deprecated-2.html
@@ -1,0 +1,8 @@
+<!-- wp:embed {"url":"https://example.com/"} -->
+<figure class="wp-block-embed">
+    <div class="wp-block-embed__wrapper">
+        https://example.com/
+    </div>
+    <figcaption>Embedded content from an example URL</figcaption>
+</figure>
+<!-- /wp:embed -->

--- a/test/integration/fixtures/blocks/core__embed__deprecated-2.json
+++ b/test/integration/fixtures/blocks/core__embed__deprecated-2.json
@@ -1,0 +1,14 @@
+[
+	{
+		"name": "core/embed",
+		"isValid": true,
+		"attributes": {
+			"url": "https://example.com/",
+			"caption": "Embedded content from an example URL",
+			"allowResponsive": true,
+			"responsive": false,
+			"previewable": true
+		},
+		"innerBlocks": []
+	}
+]

--- a/test/integration/fixtures/blocks/core__embed__deprecated-2.parsed.json
+++ b/test/integration/fixtures/blocks/core__embed__deprecated-2.parsed.json
@@ -1,0 +1,13 @@
+[
+	{
+		"blockName": "core/embed",
+		"attrs": {
+			"url": "https://example.com/"
+		},
+		"innerBlocks": [],
+		"innerHTML": "\n<figure class=\"wp-block-embed\">\n    <div class=\"wp-block-embed__wrapper\">\n        https://example.com/\n    </div>\n    <figcaption>Embedded content from an example URL</figcaption>\n</figure>\n",
+		"innerContent": [
+			"\n<figure class=\"wp-block-embed\">\n    <div class=\"wp-block-embed__wrapper\">\n        https://example.com/\n    </div>\n    <figcaption>Embedded content from an example URL</figcaption>\n</figure>\n"
+		]
+	}
+]

--- a/test/integration/fixtures/blocks/core__embed__deprecated-2.serialized.html
+++ b/test/integration/fixtures/blocks/core__embed__deprecated-2.serialized.html
@@ -1,0 +1,5 @@
+<!-- wp:embed {"url":"https://example.com/"} -->
+<figure class="wp-block-embed"><div class="wp-block-embed__wrapper">
+https://example.com/
+</div><figcaption class="wp-element-caption">Embedded content from an example URL</figcaption></figure>
+<!-- /wp:embed -->


### PR DESCRIPTION
## What?
Adds a deprecation for the embed block caption element class name. I should have done this in https://github.com/WordPress/gutenberg/pull/41140.

## Why?
When we change the save function of a block we need to add a deprecation so that the new code knows how to interpret the old markup.

## How?
This just adds a copy of the save function and attributes of the block in the state they were in before https://github.com/WordPress/gutenberg/pull/41140.

## Testing Instructions
- Using WordPress 6.0, add an embed block to a post
- Activate Gutenberg
- Reload the post editor
- Confirm that you see a block validation error:
<img width="782" alt="Screenshot 2022-10-20 at 16 22 35" src="https://user-images.githubusercontent.com/275961/196990777-bef219d4-ebd0-4a11-bf75-b31c8f80ad0b.png">
- Checkout this branch
- Confirm that the error is gone: 
<img width="566" alt="Screenshot 2022-10-20 at 16 20 27" src="https://user-images.githubusercontent.com/275961/196990939-dceb8743-b8bb-4b35-8a70-20f0fc2e82ad.png">
