### PR TITLE
Fix indent and quote in dependbot.yml

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -2,9 +2,9 @@
 version: 2
 
 updates:
-  # Check for updates to GitHub Actions.
-  - package-ecosystem: "github-actions"
-    directory: "/"
-    schedule:
-      interval: "daily"
-    open-pull-requests-limit: 10
+    # Check for updates to GitHub Actions.
+    - package-ecosystem: 'github-actions'
+      directory: '/'
+      schedule:
+          interval: 'daily'
+      open-pull-requests-limit: 10


### PR DESCRIPTION
## What?
This PR changes the indentation in the `dependabot.yml` file from 2 spaces to 4 spaces and from double quotes to single quotes.

## Why?
In the yml file that defines the GitHub Action, everything is in single quotes, indented by 4 spaces, except for this file.

## How?
 Changes the indentation from 2 spaces to 4 spaces and from double quotes to single quotes.

Note: In `.editorconfig`, two spaces are defined in the yml file.

https://github.com/WordPress/gutenberg/blob/fa22a9005294f21f0851633d157750e640180f8d/.editorconfig#L16-L18

However, the actual indentation of the yml file is not limited to multiples of 4. Therefore, I think it is better to leave editorconfig with 2 spaces.


```yml
updates:
    # 4 spaces
    - package-ecosystem: 'github-actions'
      # 6 spaces
      directory: '/'
      schedule:
```
