### PR TITLE
Gallery: Add a deprecation for captions in the gallery block

### DIFF
--- a/packages/block-library/src/gallery/deprecated.js
+++ b/packages/block-library/src/gallery/deprecated.js
@@ -7,7 +7,11 @@ import { map, some } from 'lodash';
 /**
  * WordPress dependencies
  */
-import { RichText, useBlockProps } from '@wordpress/block-editor';
+import {
+	RichText,
+	useBlockProps,
+	useInnerBlocksProps,
+} from '@wordpress/block-editor';
 
 import { createBlock } from '@wordpress/blocks';
 
@@ -221,68 +225,19 @@ const v7 = {
 		},
 	},
 	save( { attributes } ) {
-		const {
-			images,
-			columns = defaultColumnsNumberV1( attributes ),
-			imageCrop,
-			caption,
-			linkTo,
-		} = attributes;
-		const className = `columns-${ columns } ${
-			imageCrop ? 'is-cropped' : ''
-		}`;
+		const { caption, columns, imageCrop } = attributes;
+
+		const className = classnames( 'has-nested-images', {
+			[ `columns-${ columns }` ]: columns !== undefined,
+			[ `columns-default` ]: columns === undefined,
+			'is-cropped': imageCrop,
+		} );
+		const blockProps = useBlockProps.save( { className } );
+		const innerBlocksProps = useInnerBlocksProps.save( blockProps );
 
 		return (
-			<figure { ...useBlockProps.save( { className } ) }>
-				<ul className="blocks-gallery-grid">
-					{ images.map( ( image ) => {
-						let href;
-
-						switch ( linkTo ) {
-							case LINK_DESTINATION_MEDIA:
-								href = image.fullUrl || image.url;
-								break;
-							case LINK_DESTINATION_ATTACHMENT:
-								href = image.link;
-								break;
-						}
-
-						const img = (
-							<img
-								src={ image.url }
-								alt={ image.alt }
-								data-id={ image.id }
-								data-full-url={ image.fullUrl }
-								data-link={ image.link }
-								className={
-									image.id ? `wp-image-${ image.id }` : null
-								}
-							/>
-						);
-
-						return (
-							<li
-								key={ image.id || image.url }
-								className="blocks-gallery-item"
-							>
-								<figure>
-									{ href ? (
-										<a href={ href }>{ img }</a>
-									) : (
-										img
-									) }
-									{ ! RichText.isEmpty( image.caption ) && (
-										<RichText.Content
-											tagName="figcaption"
-											className="blocks-gallery-item"
-											value={ image.caption }
-										/>
-									) }
-								</figure>
-							</li>
-						);
-					} ) }
-				</ul>
+			<figure { ...innerBlocksProps }>
+				{ innerBlocksProps.children }
 				{ ! RichText.isEmpty( caption ) && (
 					<RichText.Content
 						tagName="figcaption"

--- a/packages/block-library/src/gallery/deprecated.js
+++ b/packages/block-library/src/gallery/deprecated.js
@@ -127,6 +127,174 @@ export function getImageBlock( image, sizeSlug, linkTo ) {
 	} );
 }
 
+const v7 = {
+	attributes: {
+		images: {
+			type: 'array',
+			default: [],
+			source: 'query',
+			selector: '.blocks-gallery-item',
+			query: {
+				url: {
+					type: 'string',
+					source: 'attribute',
+					selector: 'img',
+					attribute: 'src',
+				},
+				fullUrl: {
+					type: 'string',
+					source: 'attribute',
+					selector: 'img',
+					attribute: 'data-full-url',
+				},
+				link: {
+					type: 'string',
+					source: 'attribute',
+					selector: 'img',
+					attribute: 'data-link',
+				},
+				alt: {
+					type: 'string',
+					source: 'attribute',
+					selector: 'img',
+					attribute: 'alt',
+					default: '',
+				},
+				id: {
+					type: 'string',
+					source: 'attribute',
+					selector: 'img',
+					attribute: 'data-id',
+				},
+				caption: {
+					type: 'string',
+					source: 'html',
+					selector: '.blocks-gallery-item__caption',
+				},
+			},
+		},
+		ids: {
+			type: 'array',
+			items: {
+				type: 'number',
+			},
+			default: [],
+		},
+		shortCodeTransforms: {
+			type: 'array',
+			default: [],
+			items: {
+				type: 'object',
+			},
+		},
+		columns: {
+			type: 'number',
+			minimum: 1,
+			maximum: 8,
+		},
+		caption: {
+			type: 'string',
+			source: 'html',
+			selector: '.blocks-gallery-caption',
+		},
+		imageCrop: {
+			type: 'boolean',
+			default: true,
+		},
+		fixedHeight: {
+			type: 'boolean',
+			default: true,
+		},
+		linkTarget: {
+			type: 'string',
+		},
+		linkTo: {
+			type: 'string',
+		},
+		sizeSlug: {
+			type: 'string',
+			default: 'large',
+		},
+		allowResize: {
+			type: 'boolean',
+			default: false,
+		},
+	},
+	save( { attributes } ) {
+		const {
+			images,
+			columns = defaultColumnsNumberV1( attributes ),
+			imageCrop,
+			caption,
+			linkTo,
+		} = attributes;
+		const className = `columns-${ columns } ${
+			imageCrop ? 'is-cropped' : ''
+		}`;
+
+		return (
+			<figure { ...useBlockProps.save( { className } ) }>
+				<ul className="blocks-gallery-grid">
+					{ images.map( ( image ) => {
+						let href;
+
+						switch ( linkTo ) {
+							case LINK_DESTINATION_MEDIA:
+								href = image.fullUrl || image.url;
+								break;
+							case LINK_DESTINATION_ATTACHMENT:
+								href = image.link;
+								break;
+						}
+
+						const img = (
+							<img
+								src={ image.url }
+								alt={ image.alt }
+								data-id={ image.id }
+								data-full-url={ image.fullUrl }
+								data-link={ image.link }
+								className={
+									image.id ? `wp-image-${ image.id }` : null
+								}
+							/>
+						);
+
+						return (
+							<li
+								key={ image.id || image.url }
+								className="blocks-gallery-item"
+							>
+								<figure>
+									{ href ? (
+										<a href={ href }>{ img }</a>
+									) : (
+										img
+									) }
+									{ ! RichText.isEmpty( image.caption ) && (
+										<RichText.Content
+											tagName="figcaption"
+											className="blocks-gallery-item"
+											value={ image.caption }
+										/>
+									) }
+								</figure>
+							</li>
+						);
+					} ) }
+				</ul>
+				{ ! RichText.isEmpty( caption ) && (
+					<RichText.Content
+						tagName="figcaption"
+						className="blocks-gallery-caption"
+						value={ caption }
+					/>
+				) }
+			</figure>
+		);
+	},
+};
+
 const v6 = {
 	attributes: {
 		images: {
@@ -984,4 +1152,4 @@ const v1 = {
 	},
 };
 
-export default [ v6, v5, v4, v3, v2, v1 ];
+export default [ v7, v6, v5, v4, v3, v2, v1 ];

--- a/packages/block-library/src/gallery/deprecated.js
+++ b/packages/block-library/src/gallery/deprecated.js
@@ -131,6 +131,8 @@ export function getImageBlock( image, sizeSlug, linkTo ) {
 	} );
 }
 
+// In #41140 support was added to global styles for caption elements which added a `wp-element-caption` classname
+// to the gallery figcaption element.
 const v7 = {
 	attributes: {
 		images: {

--- a/test/integration/fixtures/blocks/core__gallery__deprecated-7.html
+++ b/test/integration/fixtures/blocks/core__gallery__deprecated-7.html
@@ -1,0 +1,31 @@
+<!-- wp:gallery {"linkTo":"media"} -->
+<figure class="wp-block-gallery has-nested-images columns-default is-cropped">
+	<!-- wp:image {"id":705,"sizeSlug":"large","linkDestination":"media"} -->
+		<figure class="wp-block-image size-large"><a href="http://wptest.local/wp-content/uploads/2020/09/test-image-edited-1-682x1024.jpg"><img src="http://wptest.local/wp-content/uploads/2020/09/test-image-edited-1-682x1024.jpg" alt="" class="wp-image-705"/></a></figure>
+	<!-- /wp:image -->
+	
+	<!-- wp:image {"id":704,"sizeSlug":"large","linkDestination":"media"} -->
+		<figure class="wp-block-image size-large"><a href="http://wptest.local/wp-content/uploads/2020/09/test-image-edited-1024x682.jpg"><img src="http://wptest.local/wp-content/uploads/2020/09/test-image-edited-1024x682.jpg" alt="" class="wp-image-704"/></a></figure>
+	<!-- /wp:image -->
+	
+	<!-- wp:image {"id":703,"sizeSlug":"large","linkDestination":"media"} -->
+		<figure class="wp-block-image size-large"><a href="http://wptest.local/wp-content/uploads/2020/04/test-image-1024x683.jpg"><img src="http://wptest.local/wp-content/uploads/2020/04/test-image-1024x683.jpg" alt="" class="wp-image-703"/></a></figure>
+	<!-- /wp:image -->
+</figure>
+<!-- /wp:gallery -->
+<!-- wp:gallery {"linkTo":"media"} -->
+<figure class="wp-block-gallery has-nested-images columns-default is-cropped">
+	<!-- wp:image {"id":705,"sizeSlug":"large","linkDestination":"media"} -->
+	<figure class="wp-block-image size-large"><a href="http://wptest.local/wp-content/uploads/2020/09/test-image-edited-1-682x1024.jpg"><img src="http://wptest.local/wp-content/uploads/2020/09/test-image-edited-1-682x1024.jpg" alt="" class="wp-image-705"/></a></figure>
+	<!-- /wp:image -->
+	
+	<!-- wp:image {"id":704,"sizeSlug":"large","linkDestination":"media"} -->
+	<figure class="wp-block-image size-large"><a href="http://wptest.local/wp-content/uploads/2020/09/test-image-edited-1024x682.jpg"><img src="http://wptest.local/wp-content/uploads/2020/09/test-image-edited-1024x682.jpg" alt="" class="wp-image-704"/></a></figure>
+	<!-- /wp:image -->
+	
+	<!-- wp:image {"id":703,"sizeSlug":"large","linkDestination":"media"} -->
+	<figure class="wp-block-image size-large"><a href="http://wptest.local/wp-content/uploads/2020/04/test-image-1024x683.jpg"><img src="http://wptest.local/wp-content/uploads/2020/04/test-image-1024x683.jpg" alt="" class="wp-image-703"/></a></figure>
+	<!-- /wp:image -->
+	<figcaption class="blocks-gallery-caption">This gallery has a caption</figcaption>
+</figure>
+<!-- /wp:gallery -->

--- a/test/integration/fixtures/blocks/core__gallery__deprecated-7.json
+++ b/test/integration/fixtures/blocks/core__gallery__deprecated-7.json
@@ -1,0 +1,120 @@
+[
+	{
+		"name": "core/gallery",
+		"isValid": true,
+		"attributes": {
+			"images": [],
+			"ids": [],
+			"shortCodeTransforms": [],
+			"caption": "",
+			"imageCrop": true,
+			"fixedHeight": true,
+			"linkTo": "media",
+			"sizeSlug": "large",
+			"allowResize": false
+		},
+		"innerBlocks": [
+			{
+				"name": "core/image",
+				"isValid": true,
+				"attributes": {
+					"url": "http://wptest.local/wp-content/uploads/2020/09/test-image-edited-1-682x1024.jpg",
+					"alt": "",
+					"caption": "",
+					"href": "http://wptest.local/wp-content/uploads/2020/09/test-image-edited-1-682x1024.jpg",
+					"id": 705,
+					"sizeSlug": "large",
+					"linkDestination": "media"
+				},
+				"innerBlocks": []
+			},
+			{
+				"name": "core/image",
+				"isValid": true,
+				"attributes": {
+					"url": "http://wptest.local/wp-content/uploads/2020/09/test-image-edited-1024x682.jpg",
+					"alt": "",
+					"caption": "",
+					"href": "http://wptest.local/wp-content/uploads/2020/09/test-image-edited-1024x682.jpg",
+					"id": 704,
+					"sizeSlug": "large",
+					"linkDestination": "media"
+				},
+				"innerBlocks": []
+			},
+			{
+				"name": "core/image",
+				"isValid": true,
+				"attributes": {
+					"url": "http://wptest.local/wp-content/uploads/2020/04/test-image-1024x683.jpg",
+					"alt": "",
+					"caption": "",
+					"href": "http://wptest.local/wp-content/uploads/2020/04/test-image-1024x683.jpg",
+					"id": 703,
+					"sizeSlug": "large",
+					"linkDestination": "media"
+				},
+				"innerBlocks": []
+			}
+		]
+	},
+	{
+		"name": "core/gallery",
+		"isValid": true,
+		"attributes": {
+			"images": [],
+			"ids": [],
+			"shortCodeTransforms": [],
+			"caption": "This gallery has a caption",
+			"imageCrop": true,
+			"fixedHeight": true,
+			"linkTo": "media",
+			"sizeSlug": "large",
+			"allowResize": false
+		},
+		"innerBlocks": [
+			{
+				"name": "core/image",
+				"isValid": true,
+				"attributes": {
+					"url": "http://wptest.local/wp-content/uploads/2020/09/test-image-edited-1-682x1024.jpg",
+					"alt": "",
+					"caption": "",
+					"href": "http://wptest.local/wp-content/uploads/2020/09/test-image-edited-1-682x1024.jpg",
+					"id": 705,
+					"sizeSlug": "large",
+					"linkDestination": "media"
+				},
+				"innerBlocks": []
+			},
+			{
+				"name": "core/image",
+				"isValid": true,
+				"attributes": {
+					"url": "http://wptest.local/wp-content/uploads/2020/09/test-image-edited-1024x682.jpg",
+					"alt": "",
+					"caption": "",
+					"href": "http://wptest.local/wp-content/uploads/2020/09/test-image-edited-1024x682.jpg",
+					"id": 704,
+					"sizeSlug": "large",
+					"linkDestination": "media"
+				},
+				"innerBlocks": []
+			},
+			{
+				"name": "core/image",
+				"isValid": true,
+				"attributes": {
+					"url": "http://wptest.local/wp-content/uploads/2020/04/test-image-1024x683.jpg",
+					"alt": "",
+					"caption": "",
+					"href": "http://wptest.local/wp-content/uploads/2020/04/test-image-1024x683.jpg",
+					"id": 703,
+					"sizeSlug": "large",
+					"linkDestination": "media"
+				},
+				"innerBlocks": []
+			}
+		]
+	}
+]

--- a/test/integration/fixtures/blocks/core__gallery__deprecated-7.parsed.json
+++ b/test/integration/fixtures/blocks/core__gallery__deprecated-7.parsed.json
@@ -1,0 +1,123 @@
+[
+	{
+		"blockName": "core/gallery",
+		"attrs": {
+			"linkTo": "media"
+		},
+		"innerBlocks": [
+			{
+				"blockName": "core/image",
+				"attrs": {
+					"id": 705,
+					"sizeSlug": "large",
+					"linkDestination": "media"
+				},
+				"innerBlocks": [],
+				"innerHTML": "\n\t\t<figure class=\"wp-block-image size-large\"><a href=\"http://wptest.local/wp-content/uploads/2020/09/test-image-edited-1-682x1024.jpg\"><img src=\"http://wptest.local/wp-content/uploads/2020/09/test-image-edited-1-682x1024.jpg\" alt=\"\" class=\"wp-image-705\"/></a></figure>\n\t",
+				"innerContent": [
+					"\n\t\t<figure class=\"wp-block-image size-large\"><a href=\"http://wptest.local/wp-content/uploads/2020/09/test-image-edited-1-682x1024.jpg\"><img src=\"http://wptest.local/wp-content/uploads/2020/09/test-image-edited-1-682x1024.jpg\" alt=\"\" class=\"wp-image-705\"/></a></figure>\n\t"
+				]
+			},
+			{
+				"blockName": "core/image",
+				"attrs": {
+					"id": 704,
+					"sizeSlug": "large",
+					"linkDestination": "media"
+				},
+				"innerBlocks": [],
+				"innerHTML": "\n\t\t<figure class=\"wp-block-image size-large\"><a href=\"http://wptest.local/wp-content/uploads/2020/09/test-image-edited-1024x682.jpg\"><img src=\"http://wptest.local/wp-content/uploads/2020/09/test-image-edited-1024x682.jpg\" alt=\"\" class=\"wp-image-704\"/></a></figure>\n\t",
+				"innerContent": [
+					"\n\t\t<figure class=\"wp-block-image size-large\"><a href=\"http://wptest.local/wp-content/uploads/2020/09/test-image-edited-1024x682.jpg\"><img src=\"http://wptest.local/wp-content/uploads/2020/09/test-image-edited-1024x682.jpg\" alt=\"\" class=\"wp-image-704\"/></a></figure>\n\t"
+				]
+			},
+			{
+				"blockName": "core/image",
+				"attrs": {
+					"id": 703,
+					"sizeSlug": "large",
+					"linkDestination": "media"
+				},
+				"innerBlocks": [],
+				"innerHTML": "\n\t\t<figure class=\"wp-block-image size-large\"><a href=\"http://wptest.local/wp-content/uploads/2020/04/test-image-1024x683.jpg\"><img src=\"http://wptest.local/wp-content/uploads/2020/04/test-image-1024x683.jpg\" alt=\"\" class=\"wp-image-703\"/></a></figure>\n\t",
+				"innerContent": [
+					"\n\t\t<figure class=\"wp-block-image size-large\"><a href=\"http://wptest.local/wp-content/uploads/2020/04/test-image-1024x683.jpg\"><img src=\"http://wptest.local/wp-content/uploads/2020/04/test-image-1024x683.jpg\" alt=\"\" class=\"wp-image-703\"/></a></figure>\n\t"
+				]
+			}
+		],
+		"innerHTML": "\n<figure class=\"wp-block-gallery has-nested-images columns-default is-cropped\">\n\t\n\t\n\t\n\t\n\t\n</figure>\n",
+		"innerContent": [
+			"\n<figure class=\"wp-block-gallery has-nested-images columns-default is-cropped\">\n\t",
+			null,
+			"\n\t\n\t",
+			null,
+			"\n\t\n\t",
+			null,
+			"\n</figure>\n"
+		]
+	},
+	{
+		"blockName": null,
+		"attrs": {},
+		"innerBlocks": [],
+		"innerHTML": "\n",
+		"innerContent": [ "\n" ]
+	},
+	{
+		"blockName": "core/gallery",
+		"attrs": {
+			"linkTo": "media"
+		},
+		"innerBlocks": [
+			{
+				"blockName": "core/image",
+				"attrs": {
+					"id": 705,
+					"sizeSlug": "large",
+					"linkDestination": "media"
+				},
+				"innerBlocks": [],
+				"innerHTML": "\n\t<figure class=\"wp-block-image size-large\"><a href=\"http://wptest.local/wp-content/uploads/2020/09/test-image-edited-1-682x1024.jpg\"><img src=\"http://wptest.local/wp-content/uploads/2020/09/test-image-edited-1-682x1024.jpg\" alt=\"\" class=\"wp-image-705\"/></a></figure>\n\t",
+				"innerContent": [
+					"\n\t<figure class=\"wp-block-image size-large\"><a href=\"http://wptest.local/wp-content/uploads/2020/09/test-image-edited-1-682x1024.jpg\"><img src=\"http://wptest.local/wp-content/uploads/2020/09/test-image-edited-1-682x1024.jpg\" alt=\"\" class=\"wp-image-705\"/></a></figure>\n\t"
+				]
+			},
+			{
+				"blockName": "core/image",
+				"attrs": {
+					"id": 704,
+					"sizeSlug": "large",
+					"linkDestination": "media"
+				},
+				"innerBlocks": [],
+				"innerHTML": "\n\t<figure class=\"wp-block-image size-large\"><a href=\"http://wptest.local/wp-content/uploads/2020/09/test-image-edited-1024x682.jpg\"><img src=\"http://wptest.local/wp-content/uploads/2020/09/test-image-edited-1024x682.jpg\" alt=\"\" class=\"wp-image-704\"/></a></figure>\n\t",
+				"innerContent": [
+					"\n\t<figure class=\"wp-block-image size-large\"><a href=\"http://wptest.local/wp-content/uploads/2020/09/test-image-edited-1024x682.jpg\"><img src=\"http://wptest.local/wp-content/uploads/2020/09/test-image-edited-1024x682.jpg\" alt=\"\" class=\"wp-image-704\"/></a></figure>\n\t"
+				]
+			},
+			{
+				"blockName": "core/image",
+				"attrs": {
+					"id": 703,
+					"sizeSlug": "large",
+					"linkDestination": "media"
+				},
+				"innerBlocks": [],
+				"innerHTML": "\n\t<figure class=\"wp-block-image size-large\"><a href=\"http://wptest.local/wp-content/uploads/2020/04/test-image-1024x683.jpg\"><img src=\"http://wptest.local/wp-content/uploads/2020/04/test-image-1024x683.jpg\" alt=\"\" class=\"wp-image-703\"/></a></figure>\n\t",
+				"innerContent": [
+					"\n\t<figure class=\"wp-block-image size-large\"><a href=\"http://wptest.local/wp-content/uploads/2020/04/test-image-1024x683.jpg\"><img src=\"http://wptest.local/wp-content/uploads/2020/04/test-image-1024x683.jpg\" alt=\"\" class=\"wp-image-703\"/></a></figure>\n\t"
+				]
+			}
+		],
+		"innerHTML": "\n<figure class=\"wp-block-gallery has-nested-images columns-default is-cropped\">\n\t\n\t\n\t\n\t\n\t\n\t<figcaption class=\"blocks-gallery-caption\">This gallery has a caption</figcaption>\n</figure>\n",
+		"innerContent": [
+			"\n<figure class=\"wp-block-gallery has-nested-images columns-default is-cropped\">\n\t",
+			null,
+			"\n\t\n\t",
+			null,
+			"\n\t\n\t",
+			null,
+			"\n\t<figcaption class=\"blocks-gallery-caption\">This gallery has a caption</figcaption>\n</figure>\n"
+		]
+	}
+]

--- a/test/integration/fixtures/blocks/core__gallery__deprecated-7.serialized.html
+++ b/test/integration/fixtures/blocks/core__gallery__deprecated-7.serialized.html
@@ -1,0 +1,27 @@
+<!-- wp:gallery {"linkTo":"media"} -->
+<figure class="wp-block-gallery has-nested-images columns-default is-cropped"><!-- wp:image {"id":705,"sizeSlug":"large","linkDestination":"media"} -->
+<figure class="wp-block-image size-large"><a href="http://wptest.local/wp-content/uploads/2020/09/test-image-edited-1-682x1024.jpg"><img src="http://wptest.local/wp-content/uploads/2020/09/test-image-edited-1-682x1024.jpg" alt="" class="wp-image-705"/></a></figure>
+<!-- /wp:image -->
+
+<!-- wp:image {"id":704,"sizeSlug":"large","linkDestination":"media"} -->
+<figure class="wp-block-image size-large"><a href="http://wptest.local/wp-content/uploads/2020/09/test-image-edited-1024x682.jpg"><img src="http://wptest.local/wp-content/uploads/2020/09/test-image-edited-1024x682.jpg" alt="" class="wp-image-704"/></a></figure>
+<!-- /wp:image -->
+
+<!-- wp:image {"id":703,"sizeSlug":"large","linkDestination":"media"} -->
+<figure class="wp-block-image size-large"><a href="http://wptest.local/wp-content/uploads/2020/04/test-image-1024x683.jpg"><img src="http://wptest.local/wp-content/uploads/2020/04/test-image-1024x683.jpg" alt="" class="wp-image-703"/></a></figure>
+<!-- /wp:image --></figure>
+<!-- /wp:gallery -->
+
+<!-- wp:gallery {"ids":[],"shortCodeTransforms":[],"linkTo":"media"} -->
+<figure class="wp-block-gallery has-nested-images columns-default is-cropped"><!-- wp:image {"id":705,"sizeSlug":"large","linkDestination":"media"} -->
+<figure class="wp-block-image size-large"><a href="http://wptest.local/wp-content/uploads/2020/09/test-image-edited-1-682x1024.jpg"><img src="http://wptest.local/wp-content/uploads/2020/09/test-image-edited-1-682x1024.jpg" alt="" class="wp-image-705"/></a></figure>
+<!-- /wp:image -->
+
+<!-- wp:image {"id":704,"sizeSlug":"large","linkDestination":"media"} -->
+<figure class="wp-block-image size-large"><a href="http://wptest.local/wp-content/uploads/2020/09/test-image-edited-1024x682.jpg"><img src="http://wptest.local/wp-content/uploads/2020/09/test-image-edited-1024x682.jpg" alt="" class="wp-image-704"/></a></figure>
+<!-- /wp:image -->
+
+<!-- wp:image {"id":703,"sizeSlug":"large","linkDestination":"media"} -->
+<figure class="wp-block-image size-large"><a href="http://wptest.local/wp-content/uploads/2020/04/test-image-1024x683.jpg"><img src="http://wptest.local/wp-content/uploads/2020/04/test-image-1024x683.jpg" alt="" class="wp-image-703"/></a></figure>
+<!-- /wp:image --><figcaption class="blocks-gallery-caption wp-element-caption">This gallery has a caption</figcaption></figure>
+<!-- /wp:gallery -->


### PR DESCRIPTION
## What?
Adds a deprecation for the gallery block caption element class name. I should have done this in https://github.com/WordPress/gutenberg/pull/41140.

## Why?
When we change the save function of a block we need to add a deprecation so that the new code knows how to interpret the old markup.

## How?
This just adds a copy of the save function and attributes of the block in the state they were in before https://github.com/WordPress/gutenberg/pull/41140.

## Testing Instructions
- Using WordPress 6.0, add a gallery block to a post
- Activate Gutenberg
- Reload the post editor
- Confirm that you see a block validation error:
<img width="776" alt="Screenshot 2022-10-20 at 17 47 00" src="https://user-images.githubusercontent.com/275961/197009570-5a790bb3-0a3c-43be-9835-eb82339d4d19.png">

- Checkout this branch
- Confirm that the error is gone: 
TBD

