### PR TITLE
Performance Tests Optimization: Measure impact of changes

### DIFF
--- a/.github/workflows/performance.yml
+++ b/.github/workflows/performance.yml
@@ -61,7 +61,7 @@ jobs:
                   WP_VERSION=$(awk -F ': ' '/^Tested up to/{print $2}' readme.txt)
                   IFS=. read -ra WP_VERSION_ARRAY <<< "$WP_VERSION"
                   WP_MAJOR="${WP_VERSION_ARRAY[0]}.${WP_VERSION_ARRAY[1]}"
-                  ./bin/plugin/cli.js perf $GITHUB_SHA debd225d007f4e441ceec80fbd6fa96653f94737 --tests-branch $GITHUB_SHA --wp-version "$WP_MAJOR"
+                  ./bin/plugin/cli.js perf $GITHUB_SHA debd225d007f4e441ceec80fbd6fa96653f94737 --tests-branch $GITHUB_SHA  --wp-version "$WP_MAJOR"
 
             - uses: actions/github-script@d556feaca394842dc55e4734bf3bb9f685482fa0 # v6.3.3
               if: github.event_name == 'push'

--- a/bin/plugin/cli.js
+++ b/bin/plugin/cli.js
@@ -95,10 +95,6 @@ program
 	.alias( 'perf' )
 	.option( ...ciOption )
 	.option(
-		'--rounds <count>',
-		'Run each test suite this many times for each branch; results are summarized, default = 1'
-	)
-	.option(
 		'--tests-branch <branch>',
 		"Use this branch's performance test files"
 	)

--- a/bin/plugin/commands/common.js
+++ b/bin/plugin/commands/common.js
@@ -1,26 +1,72 @@
 /**
  * External dependencies
  */
+const fs = require( 'fs' );
+const rimraf = require( 'rimraf' );
 const semver = require( 'semver' );
-const SimpleGit = require( 'simple-git' );
 
 /**
  * Internal dependencies
  */
-const { readJSONFile } = require( '../lib/utils' );
+const { log, formats } = require( '../lib/logger' );
+const { runStep, readJSONFile } = require( '../lib/utils' );
+const git = require( '../lib/git' );
+const config = require( '../config' );
+
+/**
+ * Clone the repository and returns the working directory.
+ *
+ * @param {string} abortMessage Abort message.
+ *
+ * @return {Promise<string>} Repository local path.
+ */
+async function runGitRepositoryCloneStep( abortMessage ) {
+	// Cloning the repository.
+	let gitWorkingDirectoryPath;
+	await runStep( 'Cloning the Git repository', abortMessage, async () => {
+		log( '>> Cloning the Git repository' );
+		gitWorkingDirectoryPath = await git.clone( config.gitRepositoryURL );
+		log(
+			'>> The Git repository has been successfully cloned in the following temporary folder: ' +
+				formats.success( gitWorkingDirectoryPath )
+		);
+	} );
+
+	return gitWorkingDirectoryPath;
+}
+
+/**
+ * Clean the working directories.
+ *
+ * @param {string[]} folders      Folders to clean.
+ * @param {string}   abortMessage Abort message.
+ */
+async function runCleanLocalFoldersStep( folders, abortMessage ) {
+	await runStep( 'Cleaning the temporary folders', abortMessage, async () => {
+		await Promise.all(
+			folders.map( async ( directoryPath ) => {
+				if ( fs.existsSync( directoryPath ) ) {
+					await rimraf( directoryPath, ( err ) => {
+						if ( err ) {
+							throw err;
+						}
+					} );
+				}
+			} )
+		);
+	} );
+}
 
 /**
  * Finds the name of the current plugin release branch based on the version in
- * the package.json file and the latest `trunk` branch in `git`.
+ * the package.json file.
  *
  * @param {string} gitWorkingDirectoryPath Path to the project's working directory.
  *
  * @return {string} Name of the plugin release branch.
  */
 async function findPluginReleaseBranchName( gitWorkingDirectoryPath ) {
-	await SimpleGit( gitWorkingDirectoryPath )
-		.fetch( 'origin', 'trunk' )
-		.checkout( 'trunk' );
+	await git.checkoutRemoteBranch( gitWorkingDirectoryPath, 'trunk' );
 
 	const packageJsonPath = gitWorkingDirectoryPath + '/package.json';
 	const mainPackageJson = readJSONFile( packageJsonPath );
@@ -95,4 +141,6 @@ function calculateVersionBumpFromChangelog(
 module.exports = {
 	calculateVersionBumpFromChangelog,
 	findPluginReleaseBranchName,
+	runGitRepositoryCloneStep,
+	runCleanLocalFoldersStep,
 };

--- a/bin/plugin/commands/packages.js
+++ b/bin/plugin/commands/packages.js
@@ -6,24 +6,20 @@ const path = require( 'path' );
 const glob = require( 'fast-glob' );
 const fs = require( 'fs' );
 const { inc: semverInc } = require( 'semver' );
-const rimraf = require( 'rimraf' );
 const readline = require( 'readline' );
-const SimpleGit = require( 'simple-git' );
 
 /**
  * Internal dependencies
  */
 const { log, formats } = require( '../lib/logger' );
-const {
-	askForConfirmation,
-	runStep,
-	readJSONFile,
-	getRandomTemporaryPath,
-} = require( '../lib/utils' );
+const { askForConfirmation, runStep, readJSONFile } = require( '../lib/utils' );
 const {
 	calculateVersionBumpFromChangelog,
 	findPluginReleaseBranchName,
+	runGitRepositoryCloneStep,
+	runCleanLocalFoldersStep,
 } = require( './common' );
+const git = require( '../lib/git' );
 const { join } = require( 'path' );
 
 /**
@@ -60,17 +56,6 @@ const { join } = require( 'path' );
  */
 
 /**
- * Throws if given an error in the node.js callback style.
- *
- * @param {any|null} error If callback failed, this will hold a value.
- */
-const rethrow = ( error ) => {
-	if ( error ) {
-		throw error;
-	}
-};
-
-/**
  * Checks out the npm release branch.
  *
  * @param {WPPackagesConfig} options The config object.
@@ -79,28 +64,9 @@ async function checkoutNpmReleaseBranch( {
 	gitWorkingDirectoryPath,
 	npmReleaseBranch,
 } ) {
-	/*
-	 * Create the release branch.
-	 *
-	 * Note that we are grabbing an arbitrary depth of commits
-	 * during the fetch. When `lerna` attempts to determine if
-	 * a package needs an update, it looks at `git` history,
-	 * and if we have pruned that history it will pre-emptively
-	 * publish when it doesn't need to.
-	 *
-	 * We could set a different arbitrary depth if this isn't
-	 * long enough or if it's excessive. We could also try and
-	 * find a way to more specifically fetch what we expect to
-	 * change. For example, if we knew we'll be performing
-	 * updates every two weeks, we might be conservative and
-	 * use `--shallow-since=4.weeks.ago`.
-	 *
-	 * At the time of writing, a depth of 100 pulls in all
-	 * `trunk` commits from within the past week.
-	 */
-	await SimpleGit( gitWorkingDirectoryPath )
-		.fetch( npmReleaseBranch, [ '--depth=100' ] )
-		.checkout( npmReleaseBranch );
+	// Creating the release branch.
+	await git.checkoutRemoteBranch( gitWorkingDirectoryPath, npmReleaseBranch );
+	await git.fetch( gitWorkingDirectoryPath, [ '--depth=100' ] );
 	log(
 		'>> The local npm release branch ' +
 			formats.success( npmReleaseBranch ) +
@@ -139,19 +105,13 @@ async function runNpmReleaseBranchSyncStep( pluginReleaseBranch, config ) {
 			`>> Syncing the latest plugin release to "${ pluginReleaseBranch }".`
 		);
 
-		const repo = SimpleGit( gitWorkingDirectoryPath );
+		await git.replaceContentFromRemoteBranch(
+			gitWorkingDirectoryPath,
+			pluginReleaseBranch
+		);
 
-		/*
-		 * Replace content from remote branch.
-		 *
-		 * @TODO: What is our goal here? Could `git reset --hard origin/${pluginReleaseBranch}` work?
-		 *        Why are we manually removing and then adding files back in?
-		 */
-		await repo
-			.raw( 'rm', '-r', '.' )
-			.raw( 'checkout', `origin/${ pluginReleaseBranch }`, '--', '.' );
-
-		const { commit: commitHash } = await repo.commit(
+		const commitHash = await git.commit(
+			gitWorkingDirectoryPath,
 			`Merge changes published in the Gutenberg plugin "${ pluginReleaseBranch }" branch`
 		);
 
@@ -263,7 +223,6 @@ async function updatePackages( config ) {
 		'>> Recommended version bumps based on the changes detected in CHANGELOG files:'
 	);
 
-	// e.g. "2022-11-01T00:13:26.102Z" -> "2022-11-01"
 	const publishDate = new Date().toISOString().split( 'T' )[ 0 ];
 	await Promise.all(
 		packagesToUpdate.map(
@@ -275,8 +234,11 @@ async function updatePackages( config ) {
 				version,
 			} ) => {
 				// Update changelog.
-				const content = fs.readFileSync( changelogPath, 'utf8' );
-				fs.writeFileSync(
+				const content = await fs.promises.readFile(
+					changelogPath,
+					'utf8'
+				);
+				await fs.promises.writeFile(
 					changelogPath,
 					content.replace(
 						'## Unreleased',
@@ -318,10 +280,11 @@ async function updatePackages( config ) {
 		);
 	}
 
-	const { commit: commitHash } = await SimpleGit( gitWorkingDirectoryPath )
-		.add( [ './*' ] )
-		.commit( 'Update changelog files' );
-
+	const commitHash = await git.commit(
+		gitWorkingDirectoryPath,
+		'Update changelog files',
+		[ './*' ]
+	);
 	if ( commitHash ) {
 		await runPushGitChangesStep( config );
 	}
@@ -350,8 +313,8 @@ async function runPushGitChangesStep( {
 				abortMessage
 			);
 		}
-		await SimpleGit( gitWorkingDirectoryPath ).push(
-			'origin',
+		await git.pushBranchToOrigin(
+			gitWorkingDirectoryPath,
 			npmReleaseBranch
 		);
 	} );
@@ -382,9 +345,9 @@ async function publishPackagesToNpm( {
 		stdio: 'inherit',
 	} );
 
-	const beforeCommitHash = await SimpleGit(
+	const beforeCommitHash = await git.getLastCommitHash(
 		gitWorkingDirectoryPath
-	).revparse( [ '--short', 'HEAD' ] );
+	);
 
 	const yesFlag = interactive ? '' : '--yes';
 	const noVerifyAccessFlag = interactive ? '' : '--no-verify-access';
@@ -440,8 +403,8 @@ async function publishPackagesToNpm( {
 		);
 	}
 
-	const afterCommitHash = await SimpleGit( gitWorkingDirectoryPath ).revparse(
-		[ '--short', 'HEAD' ]
+	const afterCommitHash = await git.getLastCommitHash(
+		gitWorkingDirectoryPath
 	);
 	if ( afterCommitHash === beforeCommitHash ) {
 		return;
@@ -476,23 +439,18 @@ async function backportCommitsToBranch(
 
 	log( `>> Backporting commits to "${ branchName }".` );
 
-	const repo = SimpleGit( gitWorkingDirectoryPath );
-
-	/*
-	 * Reset any local changes and replace them with the origin branch's copy.
-	 *
-	 * Perform an additional fetch to ensure that when we push our changes that
-	 * it's very unlikely that new commits could have appeared at the origin
-	 * HEAD between when we started running this script and now when we're
-	 * pushing our changes back upstream.
-	 */
-	await repo.fetch().checkout( branchName ).pull( 'origin', branchName );
-
+	await git.resetLocalBranchAgainstOrigin(
+		gitWorkingDirectoryPath,
+		branchName
+	);
 	for ( const commitHash of commits ) {
-		await repo.raw( 'cherry-pick', commitHash );
+		await git.cherrypickCommitIntoBranch(
+			gitWorkingDirectoryPath,
+			branchName,
+			commitHash
+		);
 	}
-
-	await repo.push( 'origin', branchName );
+	await git.pushBranchToOrigin( gitWorkingDirectoryPath, branchName );
 
 	log( `>> Backporting successfully finished.` );
 }
@@ -520,20 +478,11 @@ async function runPackagesRelease( config, customMessages ) {
 
 	const temporaryFolders = [];
 	if ( ! config.gitWorkingDirectoryPath ) {
-		const gitPath = getRandomTemporaryPath();
-		config.gitWorkingDirectoryPath = gitPath;
-		fs.mkdirSync( gitPath, { recursive: true } );
-		temporaryFolders.push( gitPath );
-
-		await runStep(
-			'Cloning the Git repository',
-			config.abortMessage,
-			async () => {
-				log( '>> Cloning the Git repository' );
-				await SimpleGit( gitPath ).clone( config.gitRepositoryURL );
-				log( `   >> successfully clone into: ${ gitPath }` );
-			}
+		// Cloning the Git repository.
+		config.gitWorkingDirectoryPath = await runGitRepositoryCloneStep(
+			config.abortMessage
 		);
+		temporaryFolders.push( config.gitWorkingDirectoryPath );
 	}
 
 	let pluginReleaseBranch;
@@ -569,16 +518,7 @@ async function runPackagesRelease( config, customMessages ) {
 		}
 	}
 
-	await runStep(
-		'Cleaning the temporary folders',
-		'Cleaning failed',
-		async () =>
-			await Promise.all(
-				temporaryFolders
-					.filter( ( tempDir ) => fs.existsSync( tempDir ) )
-					.map( ( tempDir ) => rimraf( tempDir, rethrow ) )
-			)
-	);
+	await runCleanLocalFoldersStep( temporaryFolders, 'Cleaning failed.' );
 
 	log(
 		'\n>> 🎉 WordPress packages are now published!\n\n',

--- a/bin/plugin/commands/performance.js
+++ b/bin/plugin/commands/performance.js
@@ -161,7 +161,10 @@ async function setUpGitBranch( branch, environmentDirectory ) {
 	await git.checkoutRemoteBranch( environmentDirectory, branch );
 
 	log( '        >> Building the ' + formats.success( branch ) + ' branch' );
-	await runShellScript( 'npm ci && npm run build', environmentDirectory );
+	await runShellScript(
+		'npm install && npm run build',
+		environmentDirectory
+	);
 }
 
 /**
@@ -234,7 +237,7 @@ async function runPerformanceTests( branches, options ) {
 	}
 	log( '    >> Installing dependencies and building packages' );
 	await runShellScript(
-		'npm ci && npm run build:packages',
+		'npm install && npm run build:packages',
 		performanceTestDirectory
 	);
 	log( '    >> Creating the environment folders' );

--- a/bin/plugin/commands/performance.js
+++ b/bin/plugin/commands/performance.js
@@ -260,23 +260,12 @@ async function runPerformanceTests( branches, options ) {
 		await runShellScript( 'mkdir ' + environmentDirectory );
 		await runShellScript( `cp -R ${ baseDirectory } ${ buildPath }` );
 
-		const fancyBranch = formats.success( branch );
+		log( `        >> Fetching the ${ formats.success( branch ) } branch` );
+		// @ts-ignore
+		await SimpleGit( buildPath ).reset( 'hard' ).checkout( branch );
 
-		if ( branch === options.testsBranch ) {
-			log(
-				`        >> Re-using the testing branch for ${ fancyBranch }`
-			);
-			await runShellScript(
-				`cp -R ${ performanceTestDirectory } ${ buildPath }`
-			);
-		} else {
-			log( `        >> Fetching the ${ fancyBranch } branch` );
-			// @ts-ignore
-			await SimpleGit( buildPath ).reset( 'hard' ).checkout( branch );
-
-			log( `        >> Building the ${ fancyBranch } branch` );
-			await runShellScript( 'npm ci && npm run build', buildPath );
-		}
+		log( `        >> Building the ${ formats.success( branch ) } branch` );
+		await runShellScript( 'npm ci && npm run build', buildPath );
 
 		await runShellScript(
 			'cp ' +

--- a/bin/plugin/commands/performance.js
+++ b/bin/plugin/commands/performance.js
@@ -4,7 +4,6 @@
 const fs = require( 'fs' );
 const path = require( 'path' );
 const { mapValues, kebabCase } = require( 'lodash' );
-const SimpleGit = require( 'simple-git' );
 
 /**
  * Internal dependencies
@@ -16,6 +15,7 @@ const {
 	askForConfirmation,
 	getRandomTemporaryPath,
 } = require( '../lib/utils' );
+const git = require( '../lib/git' );
 const config = require( '../config' );
 
 /**
@@ -147,6 +147,24 @@ function curateResults( results ) {
 }
 
 /**
+ * Set up the given branch for testing.
+ *
+ * @param {string} branch               Branch name.
+ * @param {string} environmentDirectory Path to the plugin environment's clone.
+ */
+async function setUpGitBranch( branch, environmentDirectory ) {
+	// Restore clean working directory (e.g. if `package-lock.json` has local
+	// changes after install).
+	await git.discardLocalChanges( environmentDirectory );
+
+	log( '        >> Fetching the ' + formats.success( branch ) + ' branch' );
+	await git.checkoutRemoteBranch( environmentDirectory, branch );
+
+	log( '        >> Building the ' + formats.success( branch ) + ' branch' );
+	await runShellScript( 'npm ci && npm run build', environmentDirectory );
+}
+
+/**
  * Runs the performance tests on the current branch.
  *
  * @param {string} testSuite                Name of the tests set.
@@ -196,47 +214,24 @@ async function runPerformanceTests( branches, options ) {
 	// 1- Preparing the tests directory.
 	log( '\n>> Preparing the tests directories' );
 	log( '    >> Cloning the repository' );
-
-	/**
-	 * @type {string[]} git refs against which to run tests;
-	 *                  could be commit SHA, branch name, tag, etc...
-	 */
-	if ( branches.length < 2 ) {
-		throw new Error( `Need at least two git refs to run` );
-	}
-
-	const baseDirectory = getRandomTemporaryPath();
-	fs.mkdirSync( baseDirectory, { recursive: true } );
-
-	// @ts-ignore
-	const git = SimpleGit( baseDirectory );
-	await git
-		.raw( 'init' )
-		.raw( 'remote', 'add', 'origin', config.gitRepositoryURL );
-
-	for ( const branch of branches ) {
-		await git.raw( 'fetch', '--depth=1', 'origin', branch );
-	}
-
-	await git.raw( 'checkout', branches[ 0 ] );
-
+	const baseDirectory = await git.clone( config.gitRepositoryURL );
 	const rootDirectory = getRandomTemporaryPath();
 	const performanceTestDirectory = rootDirectory + '/tests';
 	await runShellScript( 'mkdir -p ' + rootDirectory );
 	await runShellScript(
 		'cp -R ' + baseDirectory + ' ' + performanceTestDirectory
 	);
-
 	if ( !! options.testsBranch ) {
-		const branchName = formats.success( options.testsBranch );
-		log( `    >> Fetching the test-runner branch: ${ branchName }` );
-
-		// @ts-ignore
-		await SimpleGit( performanceTestDirectory )
-			.raw( 'fetch', '--depth=1', 'origin', options.testsBranch )
-			.raw( 'checkout', options.testsBranch );
+		log(
+			'    >> Fetching the test branch: ' +
+				formats.success( options.testsBranch ) +
+				' branch'
+		);
+		await git.checkoutRemoteBranch(
+			performanceTestDirectory,
+			options.testsBranch
+		);
 	}
-
 	log( '    >> Installing dependencies and building packages' );
 	await runShellScript(
 		'npm ci && npm run build:packages',
@@ -249,22 +244,16 @@ async function runPerformanceTests( branches, options ) {
 	log( '\n>> Preparing an environment directory per branch' );
 	const branchDirectories = {};
 	for ( const branch of branches ) {
-		log( `    >> Branch: ${ branch }` );
+		log( '    >> Branch: ' + branch );
 		const environmentDirectory =
 			rootDirectory + '/envs/' + kebabCase( branch );
 		// @ts-ignore
 		branchDirectories[ branch ] = environmentDirectory;
-		const buildPath = `${ environmentDirectory }/plugin`;
 		await runShellScript( 'mkdir ' + environmentDirectory );
-		await runShellScript( `cp -R ${ baseDirectory } ${ buildPath }` );
-
-		log( `        >> Fetching the ${ formats.success( branch ) } branch` );
-		// @ts-ignore
-		await SimpleGit( buildPath ).reset( 'hard' ).checkout( branch );
-
-		log( `        >> Building the ${ formats.success( branch ) } branch` );
-		await runShellScript( 'npm ci && npm run build', buildPath );
-
+		await runShellScript(
+			'cp -R ' + baseDirectory + ' ' + environmentDirectory + '/plugin'
+		);
+		await setUpGitBranch( branch, environmentDirectory + '/plugin' );
 		await runShellScript(
 			'cp ' +
 				path.resolve(
@@ -313,9 +302,13 @@ async function runPerformanceTests( branches, options ) {
 			formats.success( performanceTestDirectory )
 	);
 	for ( const branch of branches ) {
-		// @ts-ignore
-		const envPath = formats.success( branchDirectories[ branch ] );
-		log( `>> Environment Directory (${ branch }) : ${ envPath }` );
+		log(
+			'>> Environment Directory (' +
+				branch +
+				') : ' +
+				// @ts-ignore
+				formats.success( branchDirectories[ branch ] )
+		);
 	}
 
 	// 4- Running the tests.
@@ -335,7 +328,7 @@ async function runPerformanceTests( branches, options ) {
 			for ( const branch of branches ) {
 				// @ts-ignore
 				const environmentDirectory = branchDirectories[ branch ];
-				log( `    >> Branch: ${ branch }, Suite: ${ testSuite }` );
+				log( '    >> Branch: ' + branch + ', Suite: ' + testSuite );
 				log( '        >> Starting the environment.' );
 				await runShellScript(
 					'../../tests/node_modules/.bin/wp-env start',

--- a/bin/plugin/commands/performance.js
+++ b/bin/plugin/commands/performance.js
@@ -241,7 +241,7 @@ async function runPerformanceTests( branches, options ) {
 
 	log( '    >> Installing dependencies and building packages' );
 	await runShellScript(
-		'npm ci && node ./bin/packages/build.js',
+		'npm ci && npm run build:packages',
 		performanceTestDirectory
 	);
 	log( '    >> Creating the environment folders' );
@@ -275,10 +275,7 @@ async function runPerformanceTests( branches, options ) {
 			await SimpleGit( buildPath ).reset( 'hard' ).checkout( branch );
 
 			log( `        >> Building the ${ fancyBranch } branch` );
-			await runShellScript(
-				'npm ci && node ./bin/packages/build.js',
-				buildPath
-			);
+			await runShellScript( 'npm ci && npm run build', buildPath );
 		}
 
 		await runShellScript(

--- a/bin/plugin/commands/performance.js
+++ b/bin/plugin/commands/performance.js
@@ -22,7 +22,6 @@ const config = require( '../config' );
  * @typedef WPPerformanceCommandOptions
  *
  * @property {boolean=} ci          Run on CI.
- * @property {number=}  rounds      Run each test suite this many times for each branch.
  * @property {string=}  testsBranch The branch whose performance test files will be used for testing.
  * @property {string=}  wpVersion   The WordPress version to be used as the base install for testing.
  */
@@ -177,7 +176,6 @@ async function runTestSuite( testSuite, performanceTestDirectory ) {
  */
 async function runPerformanceTests( branches, options ) {
 	const runningInCI = !! process.env.CI || !! options.ci;
-	const TEST_ROUNDS = options.rounds || 1;
 
 	// The default value doesn't work because commander provides an array.
 	if ( branches.length === 0 ) {
@@ -332,7 +330,7 @@ async function runPerformanceTests( branches, options ) {
 		/** @type {Array<Record<string, WPPerformanceResults>>} */
 		const rawResults = [];
 		// Alternate three times between branches.
-		for ( let i = 0; i < TEST_ROUNDS; i++ ) {
+		for ( let i = 0; i < 3; i++ ) {
 			rawResults[ i ] = {};
 			for ( const branch of branches ) {
 				// @ts-ignore

--- a/bin/plugin/lib/git.js
+++ b/bin/plugin/lib/git.js
@@ -1,0 +1,202 @@
+// @ts-nocheck
+/**
+ * External dependencies
+ */
+const SimpleGit = require( 'simple-git' );
+
+/**
+ * Internal dependencies
+ */
+const { getRandomTemporaryPath } = require( './utils' );
+
+/**
+ * Clones a GitHub repository.
+ *
+ * @param {string} repositoryUrl
+ *
+ * @return {Promise<string>} Repository local Path
+ */
+async function clone( repositoryUrl ) {
+	const gitWorkingDirectoryPath = getRandomTemporaryPath();
+	const simpleGit = SimpleGit();
+	await simpleGit.clone( repositoryUrl, gitWorkingDirectoryPath, [
+		'--depth=1',
+		'--no-single-branch',
+	] );
+	return gitWorkingDirectoryPath;
+}
+
+/**
+ * Fetches changes from the repository.
+ *
+ * @param {string}          gitWorkingDirectoryPath Local repository path.
+ * @param {string[]|Object} options                 Git options to apply.
+ */
+async function fetch( gitWorkingDirectoryPath, options = [] ) {
+	const simpleGit = SimpleGit( gitWorkingDirectoryPath );
+	await simpleGit.fetch( options );
+}
+
+/**
+ * Commits changes to the repository.
+ *
+ * @param {string}   gitWorkingDirectoryPath Local repository path.
+ * @param {string}   message                 Commit message.
+ * @param {string[]} filesToAdd              Files to add.
+ *
+ * @return {Promise<string>} Commit Hash
+ */
+async function commit( gitWorkingDirectoryPath, message, filesToAdd = [] ) {
+	const simpleGit = SimpleGit( gitWorkingDirectoryPath );
+	await simpleGit.add( filesToAdd );
+	const commitData = await simpleGit.commit( message );
+	const commitHash = commitData.commit;
+
+	return commitHash;
+}
+
+/**
+ * Creates a local branch.
+ *
+ * @param {string} gitWorkingDirectoryPath Local repository path.
+ * @param {string} branchName              Branch Name
+ */
+async function createLocalBranch( gitWorkingDirectoryPath, branchName ) {
+	const simpleGit = SimpleGit( gitWorkingDirectoryPath );
+	await simpleGit.checkoutLocalBranch( branchName );
+}
+
+/**
+ * Checkout a local branch.
+ *
+ * @param {string} gitWorkingDirectoryPath Local repository path.
+ * @param {string} branchName              Branch Name
+ */
+async function checkoutRemoteBranch( gitWorkingDirectoryPath, branchName ) {
+	const simpleGit = SimpleGit( gitWorkingDirectoryPath );
+	await simpleGit.fetch( 'origin', branchName );
+	await simpleGit.checkout( branchName );
+}
+
+/**
+ * Creates a local tag.
+ *
+ * @param {string} gitWorkingDirectoryPath Local repository path.
+ * @param {string} tagName                 Tag Name
+ */
+async function createLocalTag( gitWorkingDirectoryPath, tagName ) {
+	const simpleGit = SimpleGit( gitWorkingDirectoryPath );
+	await simpleGit.addTag( tagName );
+}
+
+/**
+ * Pushes a local branch to the origin.
+ *
+ * @param {string} gitWorkingDirectoryPath Local repository path.
+ * @param {string} branchName              Branch Name
+ */
+async function pushBranchToOrigin( gitWorkingDirectoryPath, branchName ) {
+	const simpleGit = SimpleGit( gitWorkingDirectoryPath );
+	await simpleGit.push( 'origin', branchName );
+}
+
+/**
+ * Pushes tags to the origin.
+ *
+ * @param {string} gitWorkingDirectoryPath Local repository path.
+ */
+async function pushTagsToOrigin( gitWorkingDirectoryPath ) {
+	const simpleGit = SimpleGit( gitWorkingDirectoryPath );
+	await simpleGit.pushTags( 'origin' );
+}
+
+/**
+ * Discard local changes.
+ *
+ * @param {string} gitWorkingDirectoryPath Local repository path.
+ */
+async function discardLocalChanges( gitWorkingDirectoryPath ) {
+	const simpleGit = SimpleGit( gitWorkingDirectoryPath );
+	await simpleGit.reset( 'hard' );
+}
+
+/**
+ * Reset local branch against the origin.
+ *
+ * @param {string} gitWorkingDirectoryPath Local repository path.
+ * @param {string} branchName              Branch Name
+ */
+async function resetLocalBranchAgainstOrigin(
+	gitWorkingDirectoryPath,
+	branchName
+) {
+	const simpleGit = SimpleGit( gitWorkingDirectoryPath );
+	await simpleGit.fetch();
+	await simpleGit.checkout( branchName );
+	await simpleGit.pull( 'origin', branchName );
+}
+
+/**
+ * Gets the commit hash for the last commit in the current branch.
+ *
+ * @param {string} gitWorkingDirectoryPath Local repository path.
+ *
+ * @return {string} Commit hash.
+ */
+async function getLastCommitHash( gitWorkingDirectoryPath ) {
+	const simpleGit = SimpleGit( gitWorkingDirectoryPath );
+	return await simpleGit.revparse( [ '--short', 'HEAD' ] );
+}
+
+/**
+ * Cherry-picks a commit into trunk
+ *
+ * @param {string} gitWorkingDirectoryPath Local repository path.
+ * @param {string} branchName              Branch name.
+ * @param {string} commitHash              Commit hash.
+ */
+async function cherrypickCommitIntoBranch(
+	gitWorkingDirectoryPath,
+	branchName,
+	commitHash
+) {
+	const simpleGit = SimpleGit( gitWorkingDirectoryPath );
+	await simpleGit.checkout( branchName );
+	await simpleGit.raw( [ 'cherry-pick', commitHash ] );
+}
+
+/**
+ * Replaces the local branch's content with the content from another branch.
+ *
+ * @param {string} gitWorkingDirectoryPath Local repository path.
+ * @param {string} sourceBranchName        Branch Name
+ */
+async function replaceContentFromRemoteBranch(
+	gitWorkingDirectoryPath,
+	sourceBranchName
+) {
+	const simpleGit = SimpleGit( gitWorkingDirectoryPath );
+	await simpleGit.raw( [ 'rm', '-r', '.' ] );
+	await simpleGit.raw( [
+		'checkout',
+		`origin/${ sourceBranchName }`,
+		'--',
+		'.',
+	] );
+}
+
+module.exports = {
+	clone,
+	commit,
+	checkoutRemoteBranch,
+	createLocalBranch,
+	createLocalTag,
+	fetch,
+	pushBranchToOrigin,
+	pushTagsToOrigin,
+	discardLocalChanges,
+	resetLocalBranchAgainstOrigin,
+	getLastCommitHash,
+	cherrypickCommitIntoBranch,
+	replaceContentFromRemoteBranch,
+};

--- a/bin/tsconfig.json
+++ b/bin/tsconfig.json
@@ -25,6 +25,7 @@
 		"./plugin/lib/version.js",
 		"./plugin/lib/logger.js",
 		"./plugin/lib/utils.js",
+		"./plugin/lib/git.js",
 		"./validate-package-lock.js"
 	]
 }


### PR DESCRIPTION
> **Note**: **DO NOT MERGE** this is a long-running branch that needs to remain an open PR (and not a draft) so that it runs the normal CI test suite. It's purpose is for data-gathering to measure the impact of a sequence of changes to the performance test suite.

## What

This branch is intended to follow `trunk` without the set of changes meant improve the runtime performance of the Performance Test CI workflow.

![branch-compare-44907-45175](https://user-images.githubusercontent.com/5431237/203651787-1cb56bce-5837-4744-82a5-ea44194a21d8.png)

 - average time to run performance test workflow in `trunk` as of this test is **20.6min**
 - average time to run performance test workflow without the changes is **53.3min**
 - measured reduction in average runtime is therefore **-32.7min ✅**
 - measured against 181 test runs in `trunk` and 76 test runs in this branch (there are more in `trunk` because the tests finish faster and I'm able to get more data in the same amount of time)
 - standard deviation in `trunk` is **2.6min** vs. without the changes at **7.5min**, so not only has the average test time reduced but also the extrema for the test runs has also reduced and the runtimes are now more consistent.
 - there is overwhelming statistical reason to believe that the reduction is real. the chance that random sampling variation could account for these changes is almost zero (P-value is on the order of 2·10<sup>-16</sup>)

### Results

| Variant | N | Mean / Median | Minimum | StdDev | Δ w/o changes | Δ trunk |
|---|---|---|---|---|---|---|
| Without changes #45175 | 30 | 50m 43s / 49m 3s | 42m 22s | 6m 56s | 0m 0s 100% | 5m 33s 112% |
| Empty change #44907 | 30 | 45m 10s / 43m 24s | 32m 19s | 7m 33s | -5m 33s 89.0% | 0m 0s 100% |
| 🚫 --runInBand #44905 | 30 | 48m 33s / 43m 52s | 38m 16s | 10m 14s | -2m 10s 95.7% | 3m 22s 107% |
| ✅ --depth=2 at merge branch #45057 | 30 | 42m 47s / 42m 27s | 31m 7s | 5m 3s | -7m 56s 84.3% | -2m 22s 94.7% |
| ✅ No-generate-types #45284 | 30 | 45m 54s / 45m 4s | 37m 49s | 5m 40s | -4m 49s 90.5% | 0m 44s 102% |
| 🚫 Clone local checkout #45188 | 29 | 46m 50s / 45m 6s | 38m 7s | 6m 29s | -3m 53s 92.3% | 1m 40s 104% |
| Refactor use of ENV #45255 | 30 | 49m 56s / 50m 2s | 38m 47s | 7m 27s | -0m 47s 98.4% | 4m 45s 111% |
| ✅ Reuse tests-branch build #45737 | | | | | |
| 🚫 Single fetch with `refspecs` #45780 | | | | | |

In order to eliminate some bias introduced by variations in test run durations over time these numbers reflect only the 30 most recent test runs.

**Nov. 1**

I'm rebasing all branches and am going to let them re-gather data to see if any clearer patterns emerge. Will be ignoring all test run data before Nov. 1 to see if there were effects due to getting too far behind `trunk`.


## Why

By comparing the runtimes in this branch against those in `trunk` we can measure the impact of the overall optimization project while deploying improvements incrementally. Running this over time will not only eliminate sampling bias and noise, but it will more importantly help us to eliminate the impact of other changes on the performance test suite which might be conflated with changes we're making to the suite itself (e.g. if someone adds a new set of performance tests to the suite which would slow them down).