### PR TITLE
Fix scrolling when editing a template part

### DIFF
--- a/packages/edit-site/src/components/block-editor/style.scss
+++ b/packages/edit-site/src/components/block-editor/style.scss
@@ -21,6 +21,10 @@
 	&.is-focus-mode {
 		padding: $grid-unit-60;
 
+		// In focus mode, we have to show the scrollbars if the edited template
+		// part overlows the container.
+		overflow: auto;
+
 		.edit-site-visual-editor__editor-canvas {
 			border-radius: $radius-block-ui;
 		}


### PR DESCRIPTION
## What?
Fixing #45084 

## Why?
When in focus mode, it was not possible to scroll when editing a Template Part.

## How?
Adding a `overflow: auto` on the `is-focus-mode` CSS class.

This should override the `overflow: hidden` that is set in: https://github.com/WordPress/gutenberg/blob/26b91a67f22daa442db1ea41c5d4f8401d201e38/packages/edit-site/src/components/editor/style.scss#L35

## Testing Instructions
1. Use 6.1 RC 2.
2. Head to Appearance > Editor.
3. Edit any Template Part
4. Add enough content to it so that it overflows the viewport
5. You should be able to scroll up and down

## Screenshots or screencast <!-- if applicable -->


https://user-images.githubusercontent.com/5417266/197021374-e57f289c-cabc-4681-8a40-7c2a363b607d.mp4



