### PR TITLE
Fix distraction free shortcut typo

### DIFF
--- a/packages/edit-post/src/components/keyboard-shortcuts/index.js
+++ b/packages/edit-post/src/components/keyboard-shortcuts/index.js
@@ -67,7 +67,7 @@ function KeyboardShortcuts() {
 		registerShortcut( {
 			name: 'core/edit-post/toggle-distraction-free',
 			category: 'global',
-			description: __( 'Toggle disrtaction free mode.' ),
+			description: __( 'Toggle distraction free mode.' ),
 			keyCombination: {
 				modifier: 'primaryShift',
 				character: '\\',


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Fixes a typo in some user facing copy

## Testing Instructions
1. Open the post editor
2. Open the keyboard shortcut modal
3. The distraction free description should have no typos

## Screenshots or screencast <!-- if applicable -->
#### Before
![Screen Shot 2022-10-21 at 11 28 07 am](https://user-images.githubusercontent.com/677833/197104964-96b9c00c-debf-4e50-9fa7-31d5c489fa2b.png)

#### After
![Screen Shot 2022-10-21 at 11 28 25 am](https://user-images.githubusercontent.com/677833/197104989-cf631aa7-443f-47f6-9438-f14992547aac.png)
