### PR TITLE
Perf tests: Clone repos from local copy already checked out

### DIFF
--- a/.github/workflows/performance.yml
+++ b/.github/workflows/performance.yml
@@ -42,7 +42,7 @@ jobs:
               # PR head branch tip. This means that with a depth=2 shallow fetch we
               # get both commits we want to compare: generally `trunk` by itself at
               # `$GITHUB_SHA~1` and then `trunk` with the PR merged in at `$GITHUB_SHA`.
-              run: ./bin/plugin/cli.js perf $GITHUB_SHA $GITHUB_SHA~1 --tests-branch $GITHUB_SHA
+              run: ./bin/plugin/cli.js perf --test-merge $GITHUB_SHA --tests-branch $GITHUB_SHA
 
             - name: Compare performance with current WordPress Core and previous Gutenberg versions
               if: github.event_name == 'release'

--- a/.github/workflows/performance.yml
+++ b/.github/workflows/performance.yml
@@ -22,6 +22,8 @@ jobs:
 
         steps:
             - uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8 # v3.1.0
+              with:
+                  fetch-depth: 2
 
             - name: Use desired version of NodeJS
               uses: actions/setup-node@8c91899e586c5b171469028077307d293428b516 # v3.5.1
@@ -35,7 +37,12 @@ jobs:
 
             - name: Compare performance with trunk
               if: github.event_name == 'pull_request'
-              run: ./bin/plugin/cli.js perf $GITHUB_SHA trunk --tests-branch $GITHUB_SHA
+              # $GITHUB_SHA refers to the merge branch of a PR; it's a merge commit
+              # whose two parents are first the target branch tip, and second the
+              # PR head branch tip. This means that with a depth=2 shallow fetch we
+              # get both commits we want to compare: generally `trunk` by itself at
+              # `$GITHUB_SHA~1` and then `trunk` with the PR merged in at `$GITHUB_SHA`.
+              run: ./bin/plugin/cli.js perf $GITHUB_SHA $GITHUB_SHA~1 --tests-branch $GITHUB_SHA
 
             - name: Compare performance with current WordPress Core and previous Gutenberg versions
               if: github.event_name == 'release'

--- a/bin/plugin/cli.js
+++ b/bin/plugin/cli.js
@@ -95,6 +95,10 @@ program
 	.alias( 'perf' )
 	.option( ...ciOption )
 	.option(
+		'--test-merge <ref>',
+		'Compare the performance of this commit against its first parent.'
+	)
+	.option(
 		'--rounds <count>',
 		'Run each test suite this many times for each branch; results are summarized, default = 1'
 	)

--- a/bin/plugin/commands/performance.js
+++ b/bin/plugin/commands/performance.js
@@ -211,8 +211,13 @@ async function runPerformanceTests( branches, options ) {
 	const baseDirectory = getRandomTemporaryPath();
 	fs.mkdirSync( baseDirectory, { recursive: true } );
 
-	if ( localCloneAt ) {
+	if ( localCloneAt && fs.existsSync( path.join( localCloneAt, '.git' ) ) ) {
+		log( '\n>> Cloning local repo' );
 		runShellScript( `cp -R ${ localCloneAt } ${ baseDirectory }` );
+	} else if ( localCloneAt ) {
+		log( '\n>> [No `git` repo found at local clone path]' );
+	} else {
+		log( '\n>> [No local clone path set]' );
 	}
 
 	// @ts-ignore


### PR DESCRIPTION
> **Note**: DO NOT MERGE 😄 this is meant to collect data and cannot be a draft-PR, but it's not meant to merge either.

As of yet this PR has failed to shown any significant reduction in overall performance test workflow runtime. It seems to _increase_ the runtime instead of decrease it, which is surprising since it has the potential to avoid a network call.


![branch-compare-45188-44907](https://user-images.githubusercontent.com/5431237/203462146-de55f11f-0510-45a1-9f9e-f0e60b1014f3.png)

