### PR TITLE
Fix resizeable editor scrolling

### DIFF
--- a/packages/edit-site/src/components/block-editor/resizable-editor.js
+++ b/packages/edit-site/src/components/block-editor/resizable-editor.js
@@ -141,7 +141,7 @@ function ResizableEditor( { enableResizing, settings, children, ...props } ) {
 		>
 			<Iframe
 				isZoomedOut={ isZoomOutMode }
-				style={ enableResizing ? { height } : deviceStyles }
+				style={ enableResizing ? undefined : deviceStyles }
 				head={
 					<>
 						<EditorStyles styles={ settings.styles } />

--- a/packages/edit-site/src/components/block-editor/resizable-editor.js
+++ b/packages/edit-site/src/components/block-editor/resizable-editor.js
@@ -141,7 +141,7 @@ function ResizableEditor( { enableResizing, settings, children, ...props } ) {
 		>
 			<Iframe
 				isZoomedOut={ isZoomOutMode }
-				style={ enableResizing ? undefined : deviceStyles }
+				style={ enableResizing ? { height } : deviceStyles }
 				head={
 					<>
 						<EditorStyles styles={ settings.styles } />

--- a/packages/edit-site/src/components/block-editor/style.scss
+++ b/packages/edit-site/src/components/block-editor/style.scss
@@ -23,6 +23,7 @@
 
 		.edit-site-visual-editor__editor-canvas {
 			border-radius: $radius-block-ui;
+			max-height: 100%;
 		}
 
 		// To hide the horizontal scrollbar and show the drag handle on the


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Fixes #45084

Looking back at the git history, I noticed that I managed to introduce this bug in #43408, so I guess it's only fair that I fix it.

## How?
The `iframe` element is supposed to show a scroll bar. The regression was that #43408 made the `iframe` height always match the content height, meaning a scrollbar couldn't be shown. That change fixed another issue though (adding blocks to a smaller template part should make it expand), so it can't be reverted.

This PR sets a max-height of `100%` to the iframe to stop it from overflowing when it reaches full height, but still allows the iframe to expand when blocks are added to a shorter template part.

## Testing Instructions
1. Open up a template part (TT3's comments template part is a good one to use)
2.  A scrollbar should be visible if the content overflows.

## Screenshots or screencast <!-- if applicable -->
#### Before
![Screen Shot 2022-10-21 at 12 42 14 pm](https://user-images.githubusercontent.com/677833/197113755-fe8bca43-fd8c-4169-b2a3-61129f850fa3.png)

#### After
![Screen Shot 2022-10-21 at 12 41 50 pm](https://user-images.githubusercontent.com/677833/197113771-12851cc6-249d-4cbd-8dce-f419c8220200.png)

