### PR TITLE
Update Playwright to v1.27

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7970,19 +7970,19 @@
 			}
 		},
 		"@playwright/test": {
-			"version": "1.25.1",
-			"resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.25.1.tgz",
-			"integrity": "sha512-IJ4X0yOakXtwkhbnNzKkaIgXe6df7u3H3FnuhI9Jqh+CdO0e/lYQlDLYiyI9cnXK8E7UAppAWP+VqAv6VX7HQg==",
+			"version": "1.27.1",
+			"resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.27.1.tgz",
+			"integrity": "sha512-mrL2q0an/7tVqniQQF6RBL2saskjljXzqNcCOVMUjRIgE6Y38nCNaP+Dc2FBW06bcpD3tqIws/HT9qiMHbNU0A==",
 			"dev": true,
 			"requires": {
 				"@types/node": "*",
-				"playwright-core": "1.25.1"
+				"playwright-core": "1.27.1"
 			},
 			"dependencies": {
 				"playwright-core": {
-					"version": "1.25.1",
-					"resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.25.1.tgz",
-					"integrity": "sha512-lSvPCmA2n7LawD2Hw7gSCLScZ+vYRkhU8xH0AapMyzwN+ojoDqhkH/KIEUxwNu2PjPoE/fcE0wLAksdOhJ2O5g==",
+					"version": "1.27.1",
+					"resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.27.1.tgz",
+					"integrity": "sha512-9EmeXDncC2Pmp/z+teoVYlvmPWUC6ejSSYZUln7YaP89Z6lpAaiaAnqroUt/BoLo8tn7WYShcfaCh+xofZa44Q==",
 					"dev": true
 				}
 			}

--- a/package.json
+++ b/package.json
@@ -100,7 +100,7 @@
 		"@octokit/rest": "16.26.0",
 		"@octokit/types": "6.34.0",
 		"@octokit/webhooks-types": "5.6.0",
-		"@playwright/test": "1.25.1",
+		"@playwright/test": "1.27.1",
 		"@pmmmwh/react-refresh-webpack-plugin": "0.5.2",
 		"@storybook/addon-a11y": "6.5.7",
 		"@storybook/addon-actions": "6.5.7",

--- a/test/e2e/README.md
+++ b/test/e2e/README.md
@@ -19,6 +19,7 @@ Use the selector engine [role-selector](https://playwright.dev/docs/selectors#ro
 ```js
 // Select a button with the accessible name "Hello World" (case-insensitive).
 page.locator( 'role=button[name="Hello World"i]' );
+page.getByRole( 'button', { name: 'Hello World' } ); // short-form
 ```
 
 It's recommended to append `i` to the name attribute to match it case-insensitively wherever it makes sense. It can also be chained with built-in selector engines to perform complex queries:

--- a/test/e2e/README.md
+++ b/test/e2e/README.md
@@ -19,7 +19,9 @@ Use the selector engine [role-selector](https://playwright.dev/docs/selectors#ro
 ```js
 // Select a button with the accessible name "Hello World" (case-insensitive).
 page.locator( 'role=button[name="Hello World"i]' );
-page.getByRole( 'button', { name: 'Hello World' } ); // short-form
+
+// Using short-form API, the `name` is case-insensitive by default.
+page.getByRole( 'button', { name: 'Hello World' } );
 ```
 
 It's recommended to append `i` to the name attribute to match it case-insensitively wherever it makes sense. It can also be chained with built-in selector engines to perform complex queries:


### PR DESCRIPTION
## What?
Upgrade `@playwright/test` to v1.27.1.

## Why?
v1.27 introduced a new locator APIs inspired by Testing Library. This would make it easier for folks to use locators, especially now that unit tests are fully migrated to RTL.

New APIs:

- [page.getByText(text, options)](https://playwright.dev/docs/api/class-page#page-get-by-text) to locate by text content.
- [page.getByRole(role, options)](https://playwright.dev/docs/api/class-page#page-get-by-role) to locate by [ARIA role](https://www.w3.org/TR/wai-aria-1.2/#roles), [ARIA attributes](https://www.w3.org/TR/wai-aria-1.2/#aria-attributes) and [accessible name](https://w3c.github.io/accname/#dfn-accessible-name).
- [page.getByLabel(label, options)](https://playwright.dev/docs/api/class-page#page-get-by-label) to locate a form control by associated label's text.
- [page.getByPlaceholder(placeholder, options)](https://playwright.dev/docs/api/class-page#page-get-by-placeholder) to locate an input by placeholder.
- [page.getByAltText(altText, options)](https://playwright.dev/docs/api/class-page#page-get-by-alt-text) to locate an element, usually image, by its text alternative.
- [page.getByTitle(title, options)](https://playwright.dev/docs/api/class-page#page-get-by-title) to locate an element by its title.

For more details, see the release page: https://github.com/microsoft/playwright/releases/tag/v1.27.0

## Testing Instructions
CI should pass.
