### PR TITLE
Fix popover deprecations

### DIFF
--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 ## Unreleased
 
+### Breaking Changes
+
+-   `Popover`: The deprecated `range` and `__unstableShift` props have been removed ([#45195](https://github.com/WordPress/gutenberg/pull/45195)).
+
+### Deprecations
+
+-   `Popover`: the deprecation messages for anchor-related props (`anchorRef`, `anchorRect`, `getAnchorRect`) has been updated. ([#45195](https://github.com/WordPress/gutenberg/pull/45195)).
+
 ### New Feature
 
 -   `BoxControl` & `CustomSelectControl`: Add `onMouseOver` and `onMouseOut` callback props to allow handling of these events by parent components ([#44955](https://github.com/WordPress/gutenberg/pull/44955))

--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -8,7 +8,7 @@
 
 ### Deprecations
 
--   `Popover`: the deprecation messages for anchor-related props (`anchorRef`, `anchorRect`, `getAnchorRect`) has been updated. ([#45195](https://github.com/WordPress/gutenberg/pull/45195)).
+-   `Popover`: the deprecation messages for anchor-related props (`anchorRef`, `anchorRect`, `getAnchorRect`) have been updated. ([#45195](https://github.com/WordPress/gutenberg/pull/45195)).
 
 ### New Feature
 

--- a/packages/components/src/popover/README.md
+++ b/packages/components/src/popover/README.md
@@ -92,7 +92,7 @@ The element should be stored in state rather than a plain ref to ensure reactive
 
 ### `anchorRect`: `DomRectWithOwnerDocument`
 
-_Note: this prop is deprecated and will be removed in WordPress 6.3. Please use the `anchor` prop instead._
+_Note: this prop is deprecated. Please use the `anchor` prop instead._
 
 An object extending a `DOMRect` with an additional optional `ownerDocument` property, used to specify a fixed popover position.
 
@@ -100,7 +100,7 @@ An object extending a `DOMRect` with an additional optional `ownerDocument` prop
 
 ### `anchorRef`: `Element | PopoverAnchorRefReference | PopoverAnchorRefTopBottom | Range`
 
-_Note: this prop is deprecated and will be removed in WordPress 6.3. Please use the `anchor` prop instead._
+_Note: this prop is deprecated. Please use the `anchor` prop instead._
 
 Used to specify a fixed popover position. It can be an `Element`, a React reference to an `element`, an object with a `top` and a `bottom` properties (both pointing to elements), or a `range`.
 
@@ -157,7 +157,7 @@ When not provided, the `onClose` callback will be called instead.
 
 ### `getAnchorRect`: `( fallbackReferenceElement: Element | null ) => DomRectWithOwnerDocument`
 
-_Note: this prop is deprecated and will be removed in WordPress 6.3. Please use the `anchor` prop instead._
+_Note: this prop is deprecated. Please use the `anchor` prop instead._
 
 A function returning the same value as the one expected by the `anchorRect` prop, used to specify a dynamic popover position.
 
@@ -222,9 +222,3 @@ Adjusts the size of the popover to prevent its contents from going out of view w
 
 -   Required: No
 -   Default: `true`
-
-### `range`: `unknown`
-
-_Note: this prop is deprecated and will be removed in WordPress 6.3. It has no effect on the component._
-
--   Required: No

--- a/packages/components/src/popover/index.tsx
+++ b/packages/components/src/popover/index.tsx
@@ -184,22 +184,13 @@ const UnforwardedPopover = (
 
 		// Deprecated props
 		__unstableForcePosition,
-		__unstableShift,
 		anchorRef,
 		anchorRect,
 		getAnchorRect,
-		range,
 
 		// Rest
 		...contentProps
 	} = props;
-
-	if ( range ) {
-		deprecated( '`range` prop in wp.components.Popover', {
-			since: '6.1',
-			version: '6.3',
-		} );
-	}
 
 	let computedFlipProp = flip;
 	let computedResizeProp = resize;
@@ -216,22 +207,9 @@ const UnforwardedPopover = (
 		computedResizeProp = ! __unstableForcePosition;
 	}
 
-	let shouldShift = shift;
-	if ( __unstableShift !== undefined ) {
-		deprecated( '`__unstableShift` prop in wp.components.Popover', {
-			since: '6.1',
-			version: '6.3',
-			alternative: '`shift` prop`',
-		} );
-
-		// Back-compat.
-		shouldShift = __unstableShift;
-	}
-
 	if ( anchorRef !== undefined ) {
 		deprecated( '`anchorRef` prop in wp.components.Popover', {
 			since: '6.1',
-			version: '6.3',
 			alternative: '`anchor` prop',
 		} );
 	}
@@ -239,7 +217,6 @@ const UnforwardedPopover = (
 	if ( anchorRect !== undefined ) {
 		deprecated( '`anchorRect` prop in wp.components.Popover', {
 			since: '6.1',
-			version: '6.3',
 			alternative: '`anchor` prop',
 		} );
 	}
@@ -247,7 +224,6 @@ const UnforwardedPopover = (
 	if ( getAnchorRect !== undefined ) {
 		deprecated( '`getAnchorRect` prop in wp.components.Popover', {
 			since: '6.1',
-			version: '6.3',
 			alternative: '`anchor` prop',
 		} );
 	}
@@ -325,7 +301,7 @@ const UnforwardedPopover = (
 					},
 			  } )
 			: undefined,
-		shouldShift
+		shift
 			? shiftMiddleware( {
 					crossAxis: true,
 					limiter: customLimitShift(),

--- a/packages/components/src/popover/types.ts
+++ b/packages/components/src/popover/types.ts
@@ -149,14 +149,6 @@ export type PopoverProps = {
 	 */
 	__unstableForcePosition?: boolean;
 	/**
-	 * Enables the `Popover` to shift in order to stay in view when meeting the
-	 * viewport edges.
-	 * _Note: this prop is deprecated. Use the `shift` prop instead._
-	 *
-	 * @deprecated
-	 */
-	__unstableShift?: boolean;
-	/**
 	 * An object extending a `DOMRect` with an additional optional `ownerDocument`
 	 * property, used to specify a fixed popover position.
 	 *
@@ -184,10 +176,4 @@ export type PopoverProps = {
 	getAnchorRect?: (
 		fallbackReferenceElement: Element | null
 	) => DomRectWithOwnerDocument;
-	/**
-	 * _Note: this prop is deprecated and has no effect on the component._
-	 *
-	 * @deprecated
-	 */
-	range?: unknown;
 };


### PR DESCRIPTION
## What?
Some popover deprecations were incorrect. This PR should fix them. I've added the backport label as the deprecation messages may be confusing for developers.

The changes are:
- `range` - this prop seems to have no effect, and has been that way for quite some time. It looks like it was removed in https://github.com/WordPress/gutenberg/commit/b9871c6df97fd408c611ed1c60c8d0d8efa32f3f, before Gutenberg landed in core, it seems like no functionality would ever have existed in WP core, so I've decided to remove it. It's amazing it has persisted in the codebase!
- `__unstableShift` - this prop has never existed in WordPress core. It has been deprecated in the plugin for several releases (albeit with a confusing version number), but I think it's fine to now remove this.
- `anchorRef`, `anchorRect`, `getAnchorRect`. These are stable props in WP core, so technically they cannot be removed. The deprecation message was stating they'd be removed in 6.3, so I've changed the deprecation message.

## Testing Instructions
- Popovers should continue to work.
