### PR TITLE
[Experiment - Inserter]: Try search input inside each tab

### DIFF
--- a/packages/block-editor/src/components/inserter/library.js
+++ b/packages/block-editor/src/components/inserter/library.js
@@ -19,6 +19,7 @@ function InserterLibrary( {
 	showMostUsedBlocks = false,
 	__experimentalInsertionIndex,
 	__experimentalFilterValue,
+	initialTabName,
 	onSelect = noop,
 	shouldFocusBlock = false,
 } ) {
@@ -48,6 +49,7 @@ function InserterLibrary( {
 			showMostUsedBlocks={ showMostUsedBlocks }
 			__experimentalInsertionIndex={ __experimentalInsertionIndex }
 			__experimentalFilterValue={ __experimentalFilterValue }
+			initialTabName={ initialTabName }
 			shouldFocusBlock={ shouldFocusBlock }
 			prioritizePatterns={ prioritizePatterns }
 		/>

--- a/packages/block-editor/src/components/inserter/library.js
+++ b/packages/block-editor/src/components/inserter/library.js
@@ -2,7 +2,6 @@
  * WordPress dependencies
  */
 import { useSelect } from '@wordpress/data';
-import { forwardRef } from '@wordpress/element';
 
 /**
  * Internal dependencies
@@ -12,20 +11,17 @@ import { store as blockEditorStore } from '../../store';
 
 const noop = () => {};
 
-function InserterLibrary(
-	{
-		rootClientId,
-		clientId,
-		isAppender,
-		showInserterHelpPanel,
-		showMostUsedBlocks = false,
-		__experimentalInsertionIndex,
-		__experimentalFilterValue,
-		onSelect = noop,
-		shouldFocusBlock = false,
-	},
-	ref
-) {
+function InserterLibrary( {
+	rootClientId,
+	clientId,
+	isAppender,
+	showInserterHelpPanel,
+	showMostUsedBlocks = false,
+	__experimentalInsertionIndex,
+	__experimentalFilterValue,
+	onSelect = noop,
+	shouldFocusBlock = false,
+} ) {
 	const { destinationRootClientId, prioritizePatterns } = useSelect(
 		( select ) => {
 			const { getBlockRootClientId, getSettings } =
@@ -54,9 +50,8 @@ function InserterLibrary(
 			__experimentalFilterValue={ __experimentalFilterValue }
 			shouldFocusBlock={ shouldFocusBlock }
 			prioritizePatterns={ prioritizePatterns }
-			ref={ ref }
 		/>
 	);
 }
 
-export default forwardRef( InserterLibrary );
+export default InserterLibrary;

--- a/packages/block-editor/src/components/inserter/menu.js
+++ b/packages/block-editor/src/components/inserter/menu.js
@@ -7,12 +7,11 @@ import classnames from 'classnames';
  * WordPress dependencies
  */
 import {
-	forwardRef,
 	useState,
 	useCallback,
 	useMemo,
-	useImperativeHandle,
 	useRef,
+	useEffect,
 } from '@wordpress/element';
 import { VisuallyHidden, SearchControl } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
@@ -33,21 +32,18 @@ import useInsertionPoint from './hooks/use-insertion-point';
 import InserterTabs from './tabs';
 import { store as blockEditorStore } from '../../store';
 
-function InserterMenu(
-	{
-		rootClientId,
-		clientId,
-		isAppender,
-		__experimentalInsertionIndex,
-		onSelect,
-		showInserterHelpPanel,
-		showMostUsedBlocks,
-		__experimentalFilterValue = '',
-		shouldFocusBlock = true,
-		prioritizePatterns,
-	},
-	ref
-) {
+function InserterMenu( {
+	rootClientId,
+	clientId,
+	isAppender,
+	__experimentalInsertionIndex,
+	onSelect,
+	showInserterHelpPanel,
+	showMostUsedBlocks,
+	__experimentalFilterValue = '',
+	shouldFocusBlock = true,
+	prioritizePatterns,
+} ) {
 	const [ filterValue, setFilterValue ] = useState(
 		__experimentalFilterValue
 	);
@@ -171,12 +167,9 @@ function InserterMenu(
 	);
 
 	const searchRef = useRef();
-	// TODO: this doesn't work now..
-	useImperativeHandle( ref, () => ( {
-		focusSearch: () => {
-			searchRef.current?.focus();
-		},
-	} ) );
+	useEffect( () => {
+		searchRef.current?.focus();
+	}, [ selectedTab ] );
 
 	const getCurrentTab = useCallback(
 		( tab ) => {
@@ -239,6 +232,7 @@ function InserterMenu(
 				</>
 			);
 		},
+		// TODO: check/add deps..
 		[ blocksTab, patternsTab, reusableBlocksTab, filterValue ]
 	);
 
@@ -263,9 +257,9 @@ function InserterMenu(
 						{ getCurrentTab }
 					</InserterTabs>
 				) }
-				{ ! filterValue && ! showAsTabs && (
+				{ ! showAsTabs && (
 					<div className="block-editor-inserter__no-tab-container">
-						{ blocksTab }
+						{ getCurrentTab( { name: 'blocks' } ) }
 					</div>
 				) }
 			</div>
@@ -283,4 +277,4 @@ function InserterMenu(
 	);
 }
 
-export default forwardRef( InserterMenu );
+export default InserterMenu;

--- a/packages/block-editor/src/components/inserter/menu.js
+++ b/packages/block-editor/src/components/inserter/menu.js
@@ -48,7 +48,7 @@ function InserterMenu( {
 	const [ filterValue, setFilterValue ] = useState(
 		__experimentalFilterValue
 	);
-	const [ hoveredItem, setHoveredItem ] = useState( initialTabName );
+	const [ hoveredItem, setHoveredItem ] = useState();
 	const [ selectedPatternCategory, setSelectedPatternCategory ] =
 		useState( null );
 	const [ selectedTab, setSelectedTab ] = useState( null );

--- a/packages/block-editor/src/components/inserter/menu.js
+++ b/packages/block-editor/src/components/inserter/menu.js
@@ -170,28 +170,81 @@ function InserterMenu(
 		[ destinationRootClientId, onInsert, onHover ]
 	);
 
-	const getCurrentTab = useCallback(
-		( tab ) => {
-			if ( tab.name === 'blocks' ) {
-				return blocksTab;
-			} else if ( tab.name === 'patterns' ) {
-				return patternsTab;
-			}
-			return reusableBlocksTab;
-		},
-		[ blocksTab, patternsTab, reusableBlocksTab ]
-	);
-
 	const searchRef = useRef();
+	// TODO: this doesn't work now..
 	useImperativeHandle( ref, () => ( {
 		focusSearch: () => {
-			searchRef.current.focus();
+			searchRef.current?.focus();
 		},
 	} ) );
 
+	const getCurrentTab = useCallback(
+		( tab ) => {
+			const searchControlProps = {};
+			let searchResultsProps;
+			let tabContent;
+			if ( tab.name === 'blocks' ) {
+				searchControlProps.label = __( 'Search for blocks' );
+				searchResultsProps = {
+					showBlockDirectory: true,
+					maxBlockPatterns: 0,
+				};
+				tabContent = blocksTab;
+			} else if ( tab.name === 'patterns' ) {
+				searchControlProps.label = __( 'Search for patterns' );
+				searchResultsProps = {
+					maxBlockTypes: 0,
+				};
+				tabContent = patternsTab;
+			} else if ( tab.name === 'reusable' ) {
+				searchControlProps.label = __( 'Search for blocks' );
+				searchResultsProps = {
+					showBlockDirectory: true,
+					maxBlockPatterns: 0,
+				};
+				tabContent = reusableBlocksTab;
+			}
+
+			return (
+				<>
+					<SearchControl
+						className="block-editor-inserter__search"
+						onChange={ ( value ) => {
+							if ( hoveredItem ) setHoveredItem( null );
+							setFilterValue( value );
+						} }
+						value={ filterValue }
+						placeholder={ __( 'Search' ) }
+						ref={ searchRef }
+						{ ...searchControlProps }
+					/>
+					{ ! filterValue && tabContent }
+					{ !! filterValue && (
+						<div className="block-editor-inserter__no-tab-container">
+							<InserterSearchResults
+								filterValue={ filterValue }
+								onSelect={ onSelect }
+								onHover={ onHover }
+								rootClientId={ rootClientId }
+								clientId={ clientId }
+								isAppender={ isAppender }
+								__experimentalInsertionIndex={
+									__experimentalInsertionIndex
+								}
+								shouldFocusBlock={ shouldFocusBlock }
+								{ ...searchResultsProps }
+							/>
+						</div>
+					) }
+				</>
+			);
+		},
+		[ blocksTab, patternsTab, reusableBlocksTab, filterValue ]
+	);
+
 	const showPatternPanel =
 		selectedTab === 'patterns' && ! filterValue && selectedPatternCategory;
-	const showAsTabs = ! filterValue && ( showPatterns || hasReusableBlocks );
+	const showAsTabs = showPatterns || hasReusableBlocks;
 
 	return (
 		<div className="block-editor-inserter__menu">
@@ -200,34 +253,6 @@ function InserterMenu(
 					'show-as-tabs': showAsTabs,
 				} ) }
 			>
-				<SearchControl
-					className="block-editor-inserter__search"
-					onChange={ ( value ) => {
-						if ( hoveredItem ) setHoveredItem( null );
-						setFilterValue( value );
-					} }
-					value={ filterValue }
-					label={ __( 'Search for blocks and patterns' ) }
-					placeholder={ __( 'Search' ) }
-					ref={ searchRef }
-				/>
-				{ !! filterValue && (
-					<div className="block-editor-inserter__no-tab-container">
-						<InserterSearchResults
-							filterValue={ filterValue }
-							onSelect={ onSelect }
-							onHover={ onHover }
-							rootClientId={ rootClientId }
-							clientId={ clientId }
-							isAppender={ isAppender }
-							__experimentalInsertionIndex={
-								__experimentalInsertionIndex
-							}
-							showBlockDirectory
-							shouldFocusBlock={ shouldFocusBlock }
-						/>
-					</div>
-				) }
 				{ showAsTabs && (
 					<InserterTabs
 						showPatterns={ showPatterns }

--- a/packages/block-editor/src/components/inserter/menu.js
+++ b/packages/block-editor/src/components/inserter/menu.js
@@ -41,13 +41,14 @@ function InserterMenu( {
 	showInserterHelpPanel,
 	showMostUsedBlocks,
 	__experimentalFilterValue = '',
+	initialTabName,
 	shouldFocusBlock = true,
 	prioritizePatterns,
 } ) {
 	const [ filterValue, setFilterValue ] = useState(
 		__experimentalFilterValue
 	);
-	const [ hoveredItem, setHoveredItem ] = useState( null );
+	const [ hoveredItem, setHoveredItem ] = useState( initialTabName );
 	const [ selectedPatternCategory, setSelectedPatternCategory ] =
 		useState( null );
 	const [ selectedTab, setSelectedTab ] = useState( null );
@@ -252,6 +253,7 @@ function InserterMenu( {
 						showPatterns={ showPatterns }
 						showReusableBlocks={ hasReusableBlocks }
 						prioritizePatterns={ prioritizePatterns }
+						initialTabName={ initialTabName }
 						onSelect={ setSelectedTab }
 					>
 						{ getCurrentTab }

--- a/packages/block-editor/src/components/inserter/quick-inserter.js
+++ b/packages/block-editor/src/components/inserter/quick-inserter.js
@@ -14,7 +14,10 @@ import { useSelect } from '@wordpress/data';
 /**
  * Internal dependencies
  */
-import InserterSearchResults from './search-results';
+import {
+	default as InserterSearchResults,
+	useFilteredBlockPatterns,
+} from './search-results';
 import useInsertionPoint from './hooks/use-insertion-point';
 import usePatternsState from './hooks/use-patterns-state';
 import useBlockTypesState from './hooks/use-block-types-state';
@@ -80,7 +83,14 @@ export default function QuickInserter( {
 	// When clicking Browse All select the appropriate block so as
 	// the insertion point can work as expected.
 	const onBrowseAll = () => {
-		setInserterIsOpened( { rootClientId, insertionIndex, filterValue } );
+		setInserterIsOpened( {
+			rootClientId,
+			insertionIndex,
+			filterValue,
+			initialTabName: !! filteredBlockPatterns.length
+				? 'patterns'
+				: 'blocks',
+		} );
 	};
 
 	let maxBlockPatterns = 0;
@@ -89,6 +99,15 @@ export default function QuickInserter( {
 			? SHOWN_BLOCK_PATTERNS_WITH_PRIORITIZATION
 			: SHOWN_BLOCK_PATTERNS;
 	}
+
+	// We need to know if the search results will contain at least
+	// one pattern. If they do, select the `patterns` tab when
+	// `Browse All` button is clicked.
+	const filteredBlockPatterns = useFilteredBlockPatterns(
+		filterValue,
+		patterns,
+		maxBlockPatterns
+	);
 
 	return (
 		<div

--- a/packages/block-editor/src/components/inserter/search-results.js
+++ b/packages/block-editor/src/components/inserter/search-results.js
@@ -35,6 +35,22 @@ const INITIAL_INSERTER_RESULTS = 9;
  */
 const EMPTY_ARRAY = [];
 
+export function useFilteredBlockPatterns(
+	filterValue,
+	patterns,
+	maxBlockPatterns
+) {
+	return useMemo( () => {
+		if ( maxBlockPatterns === 0 ) {
+			return [];
+		}
+		const results = searchItems( patterns, filterValue );
+		return maxBlockPatterns !== undefined
+			? results.slice( 0, maxBlockPatterns )
+			: results;
+	}, [ filterValue, patterns, maxBlockPatterns ] );
+}
+
 function InserterSearchResults( {
 	filterValue,
 	onSelect,
@@ -71,15 +87,11 @@ function InserterSearchResults( {
 		destinationRootClientId
 	);
 
-	const filteredBlockPatterns = useMemo( () => {
-		if ( maxBlockPatterns === 0 ) {
-			return [];
-		}
-		const results = searchItems( patterns, filterValue );
-		return maxBlockPatterns !== undefined
-			? results.slice( 0, maxBlockPatterns )
-			: results;
-	}, [ filterValue, patterns, maxBlockPatterns ] );
+	const filteredBlockPatterns = useFilteredBlockPatterns(
+		filterValue,
+		patterns,
+		maxBlockPatterns
+	);
 
 	let maxBlockTypesToShow = maxBlockTypes;
 	if ( prioritizePatterns && filteredBlockPatterns.length > 2 ) {

--- a/packages/block-editor/src/components/inserter/style.scss
+++ b/packages/block-editor/src/components/inserter/style.scss
@@ -355,6 +355,12 @@ $block-inserter-tabs-height: 44px;
 	@include break-medium {
 		width: $block-inserter-width;
 	}
+
+	.block-editor-inserter__quick-inserter-patterns {
+		.block-editor-block-patterns-list {
+			grid-template-columns: 1fr 1fr;
+		}
+	}
 }
 
 .block-editor-inserter__quick-inserter-results .block-editor-inserter__panel-header {

--- a/packages/block-editor/src/components/inserter/style.scss
+++ b/packages/block-editor/src/components/inserter/style.scss
@@ -371,7 +371,6 @@ $block-inserter-tabs-height: 44px;
 .block-editor-inserter__quick-inserter-patterns {
 	.block-editor-block-patterns-list {
 		display: grid;
-		grid-template-columns: 1fr 1fr;
 		grid-gap: $grid-unit-10;
 		.block-editor-block-patterns-list__list-item {
 			margin-bottom: 0;

--- a/packages/block-editor/src/components/inserter/tabs.js
+++ b/packages/block-editor/src/components/inserter/tabs.js
@@ -27,6 +27,7 @@ function InserterTabs( {
 	showReusableBlocks = false,
 	onSelect,
 	prioritizePatterns,
+	initialTabName,
 } ) {
 	const tabs = useMemo( () => {
 		const tempTabs = [];
@@ -56,6 +57,7 @@ function InserterTabs( {
 			className="block-editor-inserter__tabs"
 			tabs={ tabs }
 			onSelect={ onSelect }
+			initialTabName={ initialTabName }
 		>
 			{ children }
 		</TabPanel>

--- a/packages/components/src/tab-panel/index.tsx
+++ b/packages/components/src/tab-panel/index.tsx
@@ -136,6 +136,7 @@ export function TabPanel( {
 					role="tabpanel"
 					id={ `${ selectedId }-view` }
 					className="components-tab-panel__tab-content"
+					tabIndex={ -1 }
 				>
 					{ children( selectedTab ) }
 				</div>

--- a/packages/components/src/tab-panel/index.tsx
+++ b/packages/components/src/tab-panel/index.tsx
@@ -136,7 +136,6 @@ export function TabPanel( {
 					role="tabpanel"
 					id={ `${ selectedId }-view` }
 					className="components-tab-panel__tab-content"
-					tabIndex={ -1 }
 				>
 					{ children( selectedTab ) }
 				</div>

--- a/packages/e2e-test-utils/CHANGELOG.md
+++ b/packages/e2e-test-utils/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+-   Add an optional `options` param to `insertBlock` and `searchForBlocks` which can contain the `checkSelectedTab` property that defaults to `false`. If we set this to `true` there will be a check if the block types tab is selected, and if not it will select it. This is useful in cases where the block types tab is not the first tab in the global inserter ([#45203](https://github.com/WordPress/gutenberg/pull/45203)).
+
 ## 8.4.0 (2022-10-19)
 
 ## 8.3.0 (2022-10-05)

--- a/packages/e2e-test-utils/README.md
+++ b/packages/e2e-test-utils/README.md
@@ -481,6 +481,8 @@ result that appears. It then waits briefly for the block list to update.
 _Parameters_
 
 -   _searchTerm_ `string`: The text to search the inserter for.
+-   _options_ `[Object]`: Options for the searchForBlock function.
+-   _options.checkSelectedTab_ `[boolean]`: Whether to check and/or select the blocks tab in the inserter.
 
 ### insertBlockDirectoryBlock
 
@@ -715,6 +717,8 @@ Search for block in the global inserter
 _Parameters_
 
 -   _searchTerm_ `string`: The text to search the inserter for.
+-   _options_ `[Object]`: Options for the searchForBlock function.
+-   _options.checkSelectedTab_ `[boolean]`: Whether to check and/or select the blocks tab in the inserter.
 
 ### searchForPattern
 

--- a/packages/e2e-test-utils/src/inserter.js
+++ b/packages/e2e-test-utils/src/inserter.js
@@ -100,12 +100,20 @@ async function waitForInserterCloseAndContentFocus() {
 }
 
 async function selectInserterTab( tabName ) {
-	const tab = await page.waitForXPath(
-		`//div[contains(@class, "block-editor-inserter__tabs")]//button[.="${ tabName }"]`
-	);
-	if ( ! tab.ariaSelected ) {
-		return tab.click();
-	}
+	try {
+		// There are cases that the inserter has no tabs, but we always show the block types tab.
+		// In these cases, we can skip the tab selection.
+		const tab = await page.waitForXPath(
+			`//div[contains(@class, "block-editor-inserter__tabs")]//button[.="${ tabName }"]`,
+			{ timeout: 3000 }
+		);
+		const ariaSelected = await (
+			await tab.getProperty( 'ariaSelected' )
+		 ).jsonValue();
+		if ( ariaSelected !== 'true' ) {
+			return tab.click();
+		}
+	} catch ( e ) {}
 }
 
 /**

--- a/packages/e2e-test-utils/src/inserter.js
+++ b/packages/e2e-test-utils/src/inserter.js
@@ -101,8 +101,8 @@ async function waitForInserterCloseAndContentFocus() {
 
 async function selectInserterTab( tabName ) {
 	try {
-		// There are cases that the inserter has no tabs, but we always show the block types tab.
-		// In these cases, we can skip the tab selection.
+		// There are cases that the inserter has no tabs, where
+		// usually the block types tab is the main content.
 		const tab = await page.waitForXPath(
 			`//div[contains(@class, "block-editor-inserter__tabs")]//button[.="${ tabName }"]`,
 			{ timeout: 3000 }
@@ -119,11 +119,18 @@ async function selectInserterTab( tabName ) {
 /**
  * Search for block in the global inserter
  *
- * @param {string} searchTerm The text to search the inserter for.
+ * @param {string}  searchTerm                       The text to search the inserter for.
+ * @param {Object}  [options={}]                     Options for the searchForBlock function.
+ * @param {boolean} [options.checkSelectedTab=false] Whether to check and/or select the blocks tab in the inserter.
  */
-export async function searchForBlock( searchTerm ) {
+export async function searchForBlock(
+	searchTerm,
+	{ checkSelectedTab = false } = {}
+) {
 	await openGlobalBlockInserter();
-	await selectInserterTab( 'Blocks' );
+	if ( checkSelectedTab ) {
+		await selectInserterTab( 'Blocks' );
+	}
 	await page.waitForSelector( INSERTER_SEARCH_SELECTOR );
 	await page.focus( INSERTER_SEARCH_SELECTOR );
 	await pressKeyWithModifier( 'primary', 'a' );
@@ -162,10 +169,15 @@ export async function searchForReusableBlock( searchTerm ) {
  * Opens the inserter, searches for the given term, then selects the first
  * result that appears. It then waits briefly for the block list to update.
  *
- * @param {string} searchTerm The text to search the inserter for.
+ * @param {string}  searchTerm                       The text to search the inserter for.
+ * @param {Object}  [options={}]                     Options for the searchForBlock function.
+ * @param {boolean} [options.checkSelectedTab=false] Whether to check and/or select the blocks tab in the inserter.
  */
-export async function insertBlock( searchTerm ) {
-	await searchForBlock( searchTerm );
+export async function insertBlock(
+	searchTerm,
+	{ checkSelectedTab = false } = {}
+) {
+	await searchForBlock( searchTerm, { checkSelectedTab } );
 	const insertButton = await page.waitForXPath(
 		`//button//span[contains(text(), '${ searchTerm }')]`
 	);

--- a/packages/e2e-test-utils/src/inserter.js
+++ b/packages/e2e-test-utils/src/inserter.js
@@ -99,6 +99,15 @@ async function waitForInserterCloseAndContentFocus() {
 	);
 }
 
+async function selectInserterTab( tabName ) {
+	const tab = await page.waitForXPath(
+		`//div[contains(@class, "block-editor-inserter__tabs")]//button[.="${ tabName }"]`
+	);
+	if ( ! tab.ariaSelected ) {
+		return tab.click();
+	}
+}
+
 /**
  * Search for block in the global inserter
  *
@@ -106,6 +115,7 @@ async function waitForInserterCloseAndContentFocus() {
  */
 export async function searchForBlock( searchTerm ) {
 	await openGlobalBlockInserter();
+	await selectInserterTab( 'Blocks' );
 	await page.waitForSelector( INSERTER_SEARCH_SELECTOR );
 	await page.focus( INSERTER_SEARCH_SELECTOR );
 	await pressKeyWithModifier( 'primary', 'a' );
@@ -119,11 +129,7 @@ export async function searchForBlock( searchTerm ) {
  */
 export async function searchForPattern( searchTerm ) {
 	await openGlobalBlockInserter();
-	// Select the patterns tab.
-	const tab = await page.waitForXPath(
-		'//div[contains(@class, "block-editor-inserter__tabs")]//button[.="Patterns"]'
-	);
-	await tab.click();
+	await selectInserterTab( 'Patterns' );
 	await page.waitForSelector( INSERTER_SEARCH_SELECTOR );
 	await page.focus( INSERTER_SEARCH_SELECTOR );
 	await pressKeyWithModifier( 'primary', 'a' );
@@ -137,19 +143,7 @@ export async function searchForPattern( searchTerm ) {
  */
 export async function searchForReusableBlock( searchTerm ) {
 	await openGlobalBlockInserter();
-
-	// The reusable blocks tab won't appear until the reusable blocks have been
-	// fetched. They aren't fetched until an inserter is used or the post
-	// already contains reusable blocks, so wait for the tab to appear.
-	await page.waitForXPath(
-		'//div[contains(@class, "block-editor-inserter__tabs")]//button[text()="Reusable"]'
-	);
-
-	// Select the reusable blocks tab.
-	const tab = await page.waitForXPath(
-		'//div[contains(@class, "block-editor-inserter__tabs")]//button[text()="Reusable"]'
-	);
-	await tab.click();
+	await selectInserterTab( 'Reusable' );
 	await page.waitForSelector( INSERTER_SEARCH_SELECTOR );
 	await page.focus( INSERTER_SEARCH_SELECTOR );
 	await pressKeyWithModifier( 'primary', 'a' );

--- a/packages/e2e-tests/specs/experiments/blocks/post-comments-form.test.js
+++ b/packages/e2e-tests/specs/experiments/blocks/post-comments-form.test.js
@@ -35,7 +35,9 @@ describe( 'Post Comments Form', () => {
 			} );
 
 			// Insert post comments form
-			await insertBlock( 'Post Comments Form' );
+			await insertBlock( 'Post Comments Form', {
+				checkSelectedTab: true,
+			} );
 
 			// Ensure the placeholder is there
 			await expect( canvas() ).toMatchElement(

--- a/packages/e2e-tests/specs/performance/site-editor.test.js
+++ b/packages/e2e-tests/specs/performance/site-editor.test.js
@@ -117,7 +117,7 @@ describe( 'Site Editor Performance', () => {
 		await canvas().click(
 			'[data-type="core/post-content"] [data-type="core/paragraph"]'
 		);
-		await insertBlock( 'Paragraph' );
+		await insertBlock( 'Paragraph', { checkSelectedTab: true } );
 		i = 200;
 		const traceFile = __dirname + '/trace.json';
 		await page.tracing.start( {

--- a/packages/e2e-tests/specs/site-editor/multi-entity-saving.test.js
+++ b/packages/e2e-tests/specs/site-editor/multi-entity-saving.test.js
@@ -274,7 +274,7 @@ describe( 'Multi-entity save flow', () => {
 			await page.click( 'button[aria-label="Close List View Sidebar"]' );
 
 			// Insert something to dirty the editor.
-			await insertBlock( 'Paragraph' );
+			await insertBlock( 'Paragraph', { checkSelectedTab: true } );
 
 			const enabledButton = await page.waitForSelector(
 				activeSaveSiteSelector
@@ -303,7 +303,7 @@ describe( 'Multi-entity save flow', () => {
 			} );
 
 			// Insert a paragraph at the bottom.
-			await insertBlock( 'Paragraph' );
+			await insertBlock( 'Paragraph', { checkSelectedTab: true } );
 
 			// Open the block settings.
 			await page.click( 'button[aria-label="Settings"]' );

--- a/packages/e2e-tests/specs/site-editor/settings-sidebar.test.js
+++ b/packages/e2e-tests/specs/site-editor/settings-sidebar.test.js
@@ -99,11 +99,11 @@ describe( 'Settings sidebar', () => {
 				'Template (selected)'
 			);
 			// By inserting the block is also selected.
-			await insertBlock( 'Heading' );
+			await insertBlock( 'Heading', { checkSelectedTab: true } );
 			expect( await getActiveTabLabel() ).toEqual( 'Block (selected)' );
 		} );
 		it( 'should switch to Template tab when a block was selected and we select the Template', async () => {
-			await insertBlock( 'Heading' );
+			await insertBlock( 'Heading', { checkSelectedTab: true } );
 			await toggleSidebar();
 			expect( await getActiveTabLabel() ).toEqual( 'Block (selected)' );
 			await page.evaluate( () => {

--- a/packages/e2e-tests/specs/widgets/editing-widgets.test.js
+++ b/packages/e2e-tests/specs/widgets/editing-widgets.test.js
@@ -88,7 +88,7 @@ describe( 'Widgets screen', () => {
 
 		const searchBox = await find( {
 			role: 'searchbox',
-			name: 'Search for blocks and patterns',
+			name: 'Search for blocks',
 		} );
 		await searchBox.type( blockName );
 

--- a/packages/edit-post/src/components/secondary-sidebar/inserter-sidebar.js
+++ b/packages/edit-post/src/components/secondary-sidebar/inserter-sidebar.js
@@ -10,7 +10,6 @@ import {
 	__experimentalUseDialog as useDialog,
 } from '@wordpress/compose';
 import { __ } from '@wordpress/i18n';
-import { useEffect, useRef } from '@wordpress/element';
 
 /**
  * Internal dependencies
@@ -35,11 +34,6 @@ export default function InserterSidebar() {
 		focusOnMount: null,
 	} );
 
-	const libraryRef = useRef();
-	useEffect( () => {
-		libraryRef.current.focusSearch();
-	}, [] );
-
 	return (
 		<div
 			ref={ inserterDialogRef }
@@ -63,7 +57,6 @@ export default function InserterSidebar() {
 						insertionPoint.insertionIndex
 					}
 					__experimentalFilterValue={ insertionPoint.filterValue }
-					ref={ libraryRef }
 				/>
 			</div>
 		</div>

--- a/packages/edit-post/src/components/secondary-sidebar/inserter-sidebar.js
+++ b/packages/edit-post/src/components/secondary-sidebar/inserter-sidebar.js
@@ -57,6 +57,7 @@ export default function InserterSidebar() {
 						insertionPoint.insertionIndex
 					}
 					__experimentalFilterValue={ insertionPoint.filterValue }
+					initialTabName={ insertionPoint.initialTabName }
 				/>
 			</div>
 		</div>

--- a/packages/edit-post/src/store/selectors.js
+++ b/packages/edit-post/src/store/selectors.js
@@ -464,9 +464,9 @@ export function isInserterOpened( state ) {
  * @return {Object} The root client ID, index to insert at and starting filter value.
  */
 export function __experimentalGetInsertionPoint( state ) {
-	const { rootClientId, insertionIndex, filterValue } =
+	const { rootClientId, insertionIndex, filterValue, initialTabName } =
 		state.blockInserterPanel;
-	return { rootClientId, insertionIndex, filterValue };
+	return { rootClientId, insertionIndex, filterValue, initialTabName };
 }
 
 /**

--- a/packages/edit-site/src/components/secondary-sidebar/inserter-sidebar.js
+++ b/packages/edit-site/src/components/secondary-sidebar/inserter-sidebar.js
@@ -10,7 +10,6 @@ import {
 	__experimentalUseDialog as useDialog,
 } from '@wordpress/compose';
 import { __ } from '@wordpress/i18n';
-import { useEffect, useRef } from '@wordpress/element';
 
 /**
  * Internal dependencies
@@ -30,11 +29,6 @@ export default function InserterSidebar() {
 		onClose: () => setIsInserterOpened( false ),
 		focusOnMount: null,
 	} );
-
-	const libraryRef = useRef();
-	useEffect( () => {
-		libraryRef.current.focusSearch();
-	}, [] );
 
 	return (
 		<div
@@ -58,7 +52,6 @@ export default function InserterSidebar() {
 						insertionPoint.insertionIndex
 					}
 					__experimentalFilterValue={ insertionPoint.filterValue }
-					ref={ libraryRef }
 				/>
 			</div>
 		</div>

--- a/packages/edit-site/src/components/secondary-sidebar/inserter-sidebar.js
+++ b/packages/edit-site/src/components/secondary-sidebar/inserter-sidebar.js
@@ -52,6 +52,7 @@ export default function InserterSidebar() {
 						insertionPoint.insertionIndex
 					}
 					__experimentalFilterValue={ insertionPoint.filterValue }
+					initialTabName={ insertionPoint.initialTabName }
 				/>
 			</div>
 		</div>

--- a/packages/edit-site/src/store/selectors.js
+++ b/packages/edit-site/src/store/selectors.js
@@ -304,9 +304,9 @@ export function isInserterOpened( state ) {
  * @return {Object} The root client ID, index to insert at and starting filter value.
  */
 export function __experimentalGetInsertionPoint( state ) {
-	const { rootClientId, insertionIndex, filterValue } =
+	const { rootClientId, insertionIndex, filterValue, initialTabName } =
 		state.blockInserterPanel;
-	return { rootClientId, insertionIndex, filterValue };
+	return { rootClientId, insertionIndex, filterValue, initialTabName };
 }
 
 /**

--- a/packages/edit-widgets/src/components/secondary-sidebar/inserter-sidebar.js
+++ b/packages/edit-widgets/src/components/secondary-sidebar/inserter-sidebar.js
@@ -8,7 +8,7 @@ import {
 	useViewportMatch,
 	__experimentalUseDialog as useDialog,
 } from '@wordpress/compose';
-import { useCallback, useEffect, useRef } from '@wordpress/element';
+import { useCallback } from '@wordpress/element';
 import { useDispatch } from '@wordpress/data';
 import { __ } from '@wordpress/i18n';
 
@@ -34,11 +34,6 @@ export default function InserterSidebar() {
 		focusOnMount: null,
 	} );
 
-	const libraryRef = useRef();
-	useEffect( () => {
-		libraryRef.current.focusSearch();
-	}, [] );
-
 	return (
 		<div
 			ref={ inserterDialogRef }
@@ -58,7 +53,6 @@ export default function InserterSidebar() {
 					shouldFocusBlock={ isMobileViewport }
 					rootClientId={ rootClientId }
 					__experimentalInsertionIndex={ insertionIndex }
-					ref={ libraryRef }
 				/>
 			</div>
 		</div>

--- a/test/e2e/specs/editor/blocks/group.spec.js
+++ b/test/e2e/specs/editor/blocks/group.spec.js
@@ -19,10 +19,7 @@ test.describe( 'Group', () => {
 
 		await inserterButton.click();
 
-		await page.type(
-			'role=searchbox[name="Search for blocks and patterns"i]',
-			'Group'
-		);
+		await page.type( 'role=searchbox[name="Search for blocks"i]', 'Group' );
 
 		await page.click(
 			'role=listbox[name="Blocks"i] >> role=option[name="Group"i]'

--- a/test/e2e/specs/editor/various/inserting-blocks.spec.js
+++ b/test/e2e/specs/editor/various/inserting-blocks.spec.js
@@ -42,7 +42,6 @@ test.describe( 'Inserting blocks (@firefox, @webkit)', () => {
 			'role=region[name="Editor top bar"i] >> role=button[name="Toggle block inserter"i]'
 		);
 
-		// TODO: need to await for the search input when the tabs are loaded.
 		await page.fill(
 			'role=region[name="Block Library"i] >> role=searchbox[name="Search for blocks"i]',
 			'Heading'
@@ -120,7 +119,6 @@ test.describe( 'Inserting blocks (@firefox, @webkit)', () => {
 			'role=region[name="Editor top bar"i] >> role=button[name="Toggle block inserter"i]'
 		);
 
-		// TODO: need to await for the search input when the tabs are loaded.
 		await page.fill(
 			'role=region[name="Block Library"i] >> role=searchbox[name="Search for blocks"i]',
 			'Heading'

--- a/test/e2e/specs/editor/various/inserting-blocks.spec.js
+++ b/test/e2e/specs/editor/various/inserting-blocks.spec.js
@@ -42,8 +42,9 @@ test.describe( 'Inserting blocks (@firefox, @webkit)', () => {
 			'role=region[name="Editor top bar"i] >> role=button[name="Toggle block inserter"i]'
 		);
 
+		// TODO: need to await for the search input when the tabs are loaded.
 		await page.fill(
-			'role=region[name="Block Library"i] >> role=searchbox[name="Search for blocks and patterns"i]',
+			'role=region[name="Block Library"i] >> role=searchbox[name="Search for blocks"i]',
 			'Heading'
 		);
 
@@ -119,8 +120,9 @@ test.describe( 'Inserting blocks (@firefox, @webkit)', () => {
 			'role=region[name="Editor top bar"i] >> role=button[name="Toggle block inserter"i]'
 		);
 
+		// TODO: need to await for the search input when the tabs are loaded.
 		await page.fill(
-			'role=region[name="Block Library"i] >> role=searchbox[name="Search for blocks and patterns"i]',
+			'role=region[name="Block Library"i] >> role=searchbox[name="Search for blocks"i]',
 			'Heading'
 		);
 
@@ -179,10 +181,14 @@ test.describe( 'Inserting blocks (@firefox, @webkit)', () => {
 			'role=region[name="Editor top bar"i] >> role=button[name="Toggle block inserter"i]'
 		);
 
+		await page.click(
+			'role=region[name="Block Library"i] >> role=tab[name="Patterns"i]'
+		);
+
 		const PATTERN_NAME = 'Social links with a shared background color';
 
 		await page.fill(
-			'role=region[name="Block Library"i] >> role=searchbox[name="Search for blocks and patterns"i]',
+			'role=region[name="Block Library"i] >> role=searchbox[name="Search for patterns"i]',
 			PATTERN_NAME
 		);
 
@@ -247,10 +253,14 @@ test.describe( 'Inserting blocks (@firefox, @webkit)', () => {
 			'role=region[name="Editor top bar"i] >> role=button[name="Toggle block inserter"i]'
 		);
 
+		await page.click(
+			'role=region[name="Block Library"i] >> role=tab[name="Patterns"i]'
+		);
+
 		const PATTERN_NAME = 'Social links with a shared background color';
 
 		await page.fill(
-			'role=region[name="Block Library"i] >> role=searchbox[name="Search for blocks and patterns"i]',
+			'role=region[name="Block Library"i] >> role=searchbox[name="Search for patterns"i]',
 			PATTERN_NAME
 		);
 

--- a/test/e2e/specs/site-editor/site-editor-inserter.spec.js
+++ b/test/e2e/specs/site-editor/site-editor-inserter.spec.js
@@ -27,16 +27,12 @@ test.describe( 'Site Editor Inserter', () => {
 
 		// Visibility check
 		await expect(
-			page.locator(
-				'role=searchbox[name="Search for blocks and patterns"i]'
-			)
+			page.locator( 'role=searchbox[name="Search for patterns"i]' )
 		).toBeVisible();
 		await page.click( 'role=button[name="Toggle block inserter"i]' );
 		//Hidden State check
 		await expect(
-			page.locator(
-				'role=searchbox[name="Search for blocks and patterns"i]'
-			)
+			page.locator( 'role=searchbox[name="Search for patterns"i]' )
 		).toBeHidden();
 	} );
 } );

--- a/test/e2e/specs/widgets/customizing-widgets.spec.js
+++ b/test/e2e/specs/widgets/customizing-widgets.spec.js
@@ -654,7 +654,7 @@ class WidgetsCustomizerPage {
 		);
 
 		const searchBox = this.page.locator(
-			'role=searchbox[name="Search for blocks and patterns"i]'
+			'role=searchbox[name="Search for blocks"i]'
 		);
 
 		// Clear the input.


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
This PR explores how we should handle the search in the inserter. It's still just an early start to discuss design and UX, as it's not clear yet from the existing suggestions.

Some designs about this can be found: https://github.com/WordPress/gutenberg/issues/44496#issuecomment-1278857887, https://github.com/WordPress/gutenberg/pull/44918#issuecomment-1285462961.

It's also related to the `Media` tab in the inserter([PR](https://github.com/WordPress/gutenberg/pull/44918)).

## Notes
1. We should decide if we'll show both patterns and blocks results when searching from the respective tabs. The current PR shows only of the type of the selected tab.
2. The above affects how to handle the `browse all` button in quick inserter.

## Testing Instructions
1. Interact with inserter and the search results

## Screenshots or screencast <!-- if applicable -->

https://user-images.githubusercontent.com/16275880/197173262-c6d0ae4e-6e96-4279-b144-9f980802571e.mov

