### PR TITLE
Revert "Lodash: Refactor away from `_.kebabCase()` in site editor"

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -18053,7 +18053,6 @@
 				"@wordpress/style-engine": "file:packages/style-engine",
 				"@wordpress/url": "file:packages/url",
 				"@wordpress/viewport": "file:packages/viewport",
-				"change-case": "^4.1.2",
 				"classnames": "^2.3.1",
 				"downloadjs": "^1.4.7",
 				"history": "^5.1.0",

--- a/packages/edit-site/package.json
+++ b/packages/edit-site/package.json
@@ -54,7 +54,6 @@
 		"@wordpress/style-engine": "file:../style-engine",
 		"@wordpress/url": "file:../url",
 		"@wordpress/viewport": "file:../viewport",
-		"change-case": "^4.1.2",
 		"classnames": "^2.3.1",
 		"downloadjs": "^1.4.7",
 		"history": "^5.1.0",

--- a/packages/edit-site/src/components/add-new-template/add-custom-generic-template-modal.js
+++ b/packages/edit-site/src/components/add-new-template/add-custom-generic-template-modal.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { paramCase as kebabCase } from 'change-case';
+import { kebabCase } from 'lodash';
 
 /**
  * WordPress dependencies

--- a/packages/edit-site/src/components/add-new-template/new-template-part.js
+++ b/packages/edit-site/src/components/add-new-template/new-template-part.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { paramCase as kebabCase } from 'change-case';
+import { kebabCase } from 'lodash';
 
 /**
  * WordPress dependencies

--- a/packages/edit-site/src/components/global-styles/test/use-global-styles-output.js
+++ b/packages/edit-site/src/components/global-styles/test/use-global-styles-output.js
@@ -340,7 +340,7 @@ describe( 'global styles renderer', () => {
 			};
 
 			expect( toCustomProperties( tree, blockSelectors ) ).toEqual(
-				'body{--wp--preset--color--white: white;--wp--preset--color--black: black;--wp--preset--color--white2black: value;--wp--custom--white2black: value;--wp--custom--font-primary: value;--wp--custom--line-height--body: 1.7;--wp--custom--line-height--heading: 1.3;}h1,h2,h3,h4,h5,h6{--wp--preset--font-size--small: 12px;--wp--preset--font-size--medium: 23px;}'
+				'body{--wp--preset--color--white: white;--wp--preset--color--black: black;--wp--preset--color--white-2-black: value;--wp--custom--white-2-black: value;--wp--custom--font-primary: value;--wp--custom--line-height--body: 1.7;--wp--custom--line-height--heading: 1.3;}h1,h2,h3,h4,h5,h6{--wp--preset--font-size--small: 12px;--wp--preset--font-size--medium: 23px;}'
 			);
 		} );
 	} );

--- a/packages/edit-site/src/components/global-styles/use-global-styles-output.js
+++ b/packages/edit-site/src/components/global-styles/use-global-styles-output.js
@@ -1,8 +1,7 @@
 /**
  * External dependencies
  */
-import { paramCase as kebabCase } from 'change-case';
-import { get, isEmpty, pickBy, reduce, set } from 'lodash';
+import { get, isEmpty, kebabCase, pickBy, reduce, set } from 'lodash';
 
 /**
  * WordPress dependencies

--- a/packages/edit-site/src/components/template-part-converter/convert-to-template-part.js
+++ b/packages/edit-site/src/components/template-part-converter/convert-to-template-part.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { paramCase as kebabCase } from 'change-case';
+import { kebabCase } from 'lodash';
 
 /**
  * WordPress dependencies


### PR DESCRIPTION
Reverts WordPress/gutenberg#45192

See https://github.com/WordPress/gutenberg/pull/45192#issuecomment-1286958596