### PR TITLE
Navigation: Add warning test

### DIFF
--- a/test/e2e/specs/editor/blocks/navigation.spec.js
+++ b/test/e2e/specs/editor/blocks/navigation.spec.js
@@ -168,10 +168,12 @@ test.describe( 'Navigation block', () => {
 				// Check the markup of the block is correct.
 				await editor.publishPost();
 
-				await expect.poll( editor.getBlocks ).toMatchObject( [ {
-					name: 'core/navigation',
-					attributes: { ref: 1 },
-				} ] );
+				await expect.poll( editor.getBlocks ).toMatchObject( [
+					{
+						name: 'core/navigation',
+						attributes: { ref: 1 },
+					},
+				] );
 
 				// Find the warning message
 				const warningMessage = editor.canvas

--- a/test/e2e/specs/editor/blocks/navigation.spec.js
+++ b/test/e2e/specs/editor/blocks/navigation.spec.js
@@ -166,19 +166,18 @@ test.describe( 'Navigation block', () => {
 
 				// Check the markup of the block is correct.
 				await editor.publishPost();
+
 				const content = await editor.getEditedPostContent();
 				expect( content ).toBe( `<!-- wp:navigation {"ref":1} /-->` );
 
 				// Find the warning message
-				const warningMessage = await editor.page.locator(
-					'class=wp-navigation-block',
-					{
-						hasText:
-							'Navigation menu has been deleted or is unavailable.',
-					}
-				);
-				expect( warningMessage ).toBeTruthy();
+				const warningMessage = editor.canvas
+					.getByRole( 'document', { name: 'Block: Navigation' } )
+					.getByText(
+						'Navigation menu has been deleted or is unavailable.'
+					);
+				await expect( warningMessage ).toBeVisible();
 			} );
 		}
 	);
-} );
+) };

--- a/test/e2e/specs/editor/blocks/navigation.spec.js
+++ b/test/e2e/specs/editor/blocks/navigation.spec.js
@@ -168,8 +168,10 @@ test.describe( 'Navigation block', () => {
 				// Check the markup of the block is correct.
 				await editor.publishPost();
 
-				const content = await editor.getEditedPostContent();
-				expect( content ).toBe( `<!-- wp:navigation {"ref":1} /-->` );
+				await expect.poll( editor.getBlocks ).toMatchObject( [ {
+					name: 'core/navigation',
+					attributes: { ref: 1 },
+				} ] );
 
 				// Find the warning message
 				const warningMessage = editor.canvas

--- a/test/e2e/specs/editor/blocks/navigation.spec.js
+++ b/test/e2e/specs/editor/blocks/navigation.spec.js
@@ -2,49 +2,6 @@
  * WordPress dependencies
  */
 const { test, expect } = require( '@wordpress/e2e-test-utils-playwright' );
-class NavigationBlockUtils {
-	constructor( { editor, page, requestUtils } ) {
-		this.editor = editor;
-		this.page = page;
-		this.requestUtils = requestUtils;
-	}
-
-	/**
-	 * Create a navigation menu
-	 *
-	 * @param {Object} menuData navigation menu post data.
-	 * @return {string} Menu content.
-	 */
-	async createNavigationMenu( menuData ) {
-		return this.requestUtils.rest( {
-			method: 'POST',
-			path: `/wp/v2/navigation/`,
-			data: {
-				status: 'publish',
-				...menuData,
-			},
-		} );
-	}
-
-	/**
-	 * Delete all navigation menus
-	 *
-	 */
-	async deleteAllNavigationMenus() {
-		const menus = await this.requestUtils.rest( {
-			path: `/wp/v2/navigation/`,
-		} );
-
-		if ( ! menus?.length ) return;
-
-		await this.requestUtils.batchRest(
-			menus.map( ( menu ) => ( {
-				method: 'DELETE',
-				path: `/wp/v2/navigation/${ menu.id }?force=true`,
-			} ) )
-		);
-	}
-}
 
 test.use( {
 	navBlockUtils: async ( { page, requestUtils }, use ) => {
@@ -146,6 +103,50 @@ test.describe(
 	}
 );
 
+class NavigationBlockUtils {
+	constructor( { editor, page, requestUtils } ) {
+		this.editor = editor;
+		this.page = page;
+		this.requestUtils = requestUtils;
+	}
+
+	/**
+	 * Create a navigation menu
+	 *
+	 * @param {Object} menuData navigation menu post data.
+	 * @return {string} Menu content.
+	 */
+	async createNavigationMenu( menuData ) {
+		return this.requestUtils.rest( {
+			method: 'POST',
+			path: `/wp/v2/navigation/`,
+			data: {
+				status: 'publish',
+				...menuData,
+			},
+		} );
+	}
+
+	/**
+	 * Delete all navigation menus
+	 *
+	 */
+	async deleteAllNavigationMenus() {
+		const menus = await this.requestUtils.rest( {
+			path: `/wp/v2/navigation/`,
+		} );
+
+		if ( ! menus?.length ) return;
+
+		await this.requestUtils.batchRest(
+			menus.map( ( menu ) => ( {
+				method: 'DELETE',
+				path: `/wp/v2/navigation/${ menu.id }?force=true`,
+			} ) )
+		);
+	}
+}
+
 test.describe( 'Navigation block', () => {
 	test.describe(
 		'As a user I want to see a warning if the menu referenced by a navigation block is not available',
@@ -180,4 +181,4 @@ test.describe( 'Navigation block', () => {
 			} );
 		}
 	);
-) };
+} );


### PR DESCRIPTION
This adds a test to ensure that the user gets a warning message when the ref of their block points to an unknown wp_navigation menu.

Fixes https://github.com/WordPress/gutenberg/issues/45204

## Testing instructions:
Run npm run test:e2e:playwright -- editor/blocks/navigation.spec.js