### PR TITLE
Prevent nested tags when using backticks in code block

### DIFF
--- a/packages/block-editor/src/components/rich-text/use-input-rules.js
+++ b/packages/block-editor/src/components/rich-text/use-input-rules.js
@@ -108,10 +108,12 @@ export function useInputRules( props ) {
 
 			const transformed = formatTypes.reduce(
 				( accumlator, { __unstableInputRule } ) => {
-					if ( __unstableInputRule ) {
+					if (
+						__unstableInputRule &&
+						event.target.tagName !== 'CODE'
+					) {
 						accumlator = __unstableInputRule( accumlator );
 					}
-
 					return accumlator;
 				},
 				preventEventDiscovery( value )


### PR DESCRIPTION
## What?
Fixes https://github.com/WordPress/gutenberg/issues/28926

If you try to add open and closing backticks inside of a "Code" block, then it produces a nested `<code>` block inside of it.

## Why?
Allows you to use backticks in code block without being auto transformed into a nested code block.

## How?
Doesn't run transformations for the code block.

## Testing Instructions
1. Add a code block to a page.
2. Add some text and wrap one or more words in backticks.
3. The text displays unformatted, and remains wrapped in backticks.

## Screenshots or screencast

![image](https://user-images.githubusercontent.com/1482075/197231758-a62e42bc-d422-4a53-887a-78b96f2cf9e9.png)
