### PR TITLE
Components: Update ExternalLink to support onClick handler

### DIFF
--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -30,6 +30,7 @@
 -   `TabPanel`: Call `onSelect()` on every tab selection, regardless of whether it was triggered by user interaction ([#44028](https://github.com/WordPress/gutenberg/pull/44028)).
 -   `FontSizePicker`: Fallback to font size `slug` if `name` is undefined  ([#45041](https://github.com/WordPress/gutenberg/pull/45041)).
 -   `AutocompleterUI`: fix issue where autocompleter UI would appear on top of other UI elements ([#44795](https://github.com/WordPress/gutenberg/pull/44795/))
+-   `ExternalLink`: Fix to re-enable support for `onClick` event handler ([#45214](https://github.com/WordPress/gutenberg/pull/45214)).
 
 ### Internal
 

--- a/packages/components/src/external-link/index.tsx
+++ b/packages/components/src/external-link/index.tsx
@@ -43,17 +43,25 @@ function UnforwardedExternalLink(
 	to prevent them from being opened in the editor. */
 	const isInternalAnchor = !! href?.startsWith( '#' );
 
+	const onClickHandler = (
+		event: React.MouseEvent< HTMLAnchorElement, MouseEvent >
+	) => {
+		if ( isInternalAnchor ) {
+			event.preventDefault();
+		}
+
+		if ( props.onClick ) {
+			props.onClick( event );
+		}
+	};
+
 	return (
 		/* eslint-disable react/jsx-no-target-blank */
 		<a
 			{ ...additionalProps }
 			className={ classes }
 			href={ href }
-			onClick={
-				isInternalAnchor
-					? ( event ) => event.preventDefault()
-					: undefined
-			}
+			onClick={ onClickHandler }
 			target="_blank"
 			rel={ optimizedRel }
 			ref={ ref }

--- a/packages/components/src/external-link/test/index.tsx
+++ b/packages/components/src/external-link/test/index.tsx
@@ -45,6 +45,8 @@ describe( 'ExternalLink', () => {
 			name: "I'm an anchor link! (opens in a new tab)",
 		} );
 
+		// We are using this approach so we can test the defaultPrevented
+		// without passing an onClick prop to the component.
 		const onClickMock = jest.fn();
 		link.onclick = onClickMock;
 
@@ -96,6 +98,8 @@ describe( 'ExternalLink', () => {
 			name: "I'm not an anchor link! (opens in a new tab)",
 		} );
 
+		// We are using this approach so we can test the defaultPrevented
+		// without passing an onClick prop to the component.
 		const onClickMock = jest.fn();
 		link.onclick = onClickMock;
 

--- a/packages/components/src/external-link/test/index.tsx
+++ b/packages/components/src/external-link/test/index.tsx
@@ -1,0 +1,84 @@
+/**
+ * External dependencies
+ */
+import { render, screen, fireEvent, createEvent } from '@testing-library/react';
+
+/**
+ * Internal dependencies
+ */
+import { ExternalLink } from '..';
+
+describe( 'ExternalLink', () => {
+	test( 'should call function passed in onClick handler when clicking the link', () => {
+		const doSomething = jest.fn();
+
+		render(
+			<ExternalLink
+				href="https://wordpress.org"
+				onClick={ doSomething }
+				data-testid="external-link"
+			>
+				WordPress.org
+			</ExternalLink>
+		);
+
+		fireEvent.click( screen.getByTestId( 'external-link' ) );
+
+		expect( doSomething ).toHaveBeenCalled();
+	} );
+
+	test( 'should prevent default action when clicking an internal anchor link', () => {
+		render(
+			<ExternalLink href="#test" data-testid="external-link">
+				I&apos;m an anchor link!
+			</ExternalLink>
+		);
+
+		const component = screen.getByTestId( 'external-link' );
+		const clickEvent = createEvent.click( component );
+
+		fireEvent( component, clickEvent );
+
+		expect( clickEvent.defaultPrevented ).toBe( true );
+	} );
+
+	test( 'should call function passed in onClick handler and prevent default action when clicking an internal anchor link', () => {
+		const doSomething = jest.fn();
+
+		render(
+			<ExternalLink
+				href="#test"
+				onClick={ doSomething }
+				data-testid="external-link"
+			>
+				I&apos;m an anchor link!
+			</ExternalLink>
+		);
+
+		const component = screen.getByTestId( 'external-link' );
+		const clickEvent = createEvent.click( component );
+
+		fireEvent( component, clickEvent );
+
+		expect( doSomething ).toHaveBeenCalled();
+		expect( clickEvent.defaultPrevented ).toBe( true );
+	} );
+
+	test( 'should not prevent default action when clicking a non anchor link', () => {
+		render(
+			<ExternalLink
+				href="https://wordpress.org"
+				data-testid="external-link"
+			>
+				I&apos;m not an anchor link!
+			</ExternalLink>
+		);
+
+		const component = screen.getByTestId( 'external-link' );
+		const clickEvent = createEvent.click( component );
+
+		fireEvent( component, clickEvent );
+
+		expect( clickEvent.defaultPrevented ).toBe( false );
+	} );
+} );

--- a/packages/components/src/external-link/test/index.tsx
+++ b/packages/components/src/external-link/test/index.tsx
@@ -62,11 +62,7 @@ describe( 'ExternalLink', () => {
 		const onClickMock = jest.fn();
 
 		render(
-			<ExternalLink
-				href="#test"
-				onClick={ onClickMock }
-				data-testid="external-link"
-			>
+			<ExternalLink href="#test" onClick={ onClickMock }>
 				I&apos;m an anchor link!
 			</ExternalLink>
 		);
@@ -86,10 +82,7 @@ describe( 'ExternalLink', () => {
 		const user = setupUser();
 
 		render(
-			<ExternalLink
-				href="https://wordpress.org"
-				data-testid="external-link"
-			>
+			<ExternalLink href="https://wordpress.org">
 				I&apos;m not an anchor link!
 			</ExternalLink>
 		);


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->
Fixes #45212

The idea is to make `<ExternalLink>` component to handle onClick events again, based on the issue #45212. Also it includes some unit testing for this component.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
`onClick` handler on `<ExternalLink>` component is currently being used in [multiple instances in Jetpack monorepo](https://github.com/Automattic/jetpack/search?q=ExternalLink+onClick) to record tracking events, and we consider it is necessary to include custom logic on that handler.

This stopped working after a change implemented for validating anchor links in https://github.com/WordPress/gutenberg/pull/42259.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
We are creating a new function for the `onClick` handler to:
* Validate and execute `onClick` whether it is passed as a prop.
* Validate if the link is an internal anchor, so we can prevent default action to not impact what was implemented on [#42259](https://github.com/WordPress/gutenberg/pull/42259)

## Testing Instructions
You can run unit tests for this:
```npm run test:unit -- external-link/test/index.tsx```