### PR TITLE
[wp-env] Allow DB connection from any host

### DIFF
--- a/packages/env/lib/build-docker-compose-config.js
+++ b/packages/env/lib/build-docker-compose-config.js
@@ -206,6 +206,7 @@ module.exports = function buildDockerComposeConfig( config ) {
 				image: 'mariadb',
 				ports: [ '3306' ],
 				environment: {
+					MYSQL_ROOT_HOST: '%',
 					MYSQL_ROOT_PASSWORD:
 						dbEnv.credentials.WORDPRESS_DB_PASSWORD,
 					MYSQL_DATABASE: dbEnv.development.WORDPRESS_DB_NAME,
@@ -216,6 +217,7 @@ module.exports = function buildDockerComposeConfig( config ) {
 				image: 'mariadb',
 				ports: [ '3306' ],
 				environment: {
+					MYSQL_ROOT_HOST: '%',
 					MYSQL_ROOT_PASSWORD:
 						dbEnv.credentials.WORDPRESS_DB_PASSWORD,
 					MYSQL_DATABASE: dbEnv.tests.WORDPRESS_DB_NAME,


### PR DESCRIPTION
## What?
Fix `wp-env` utility so that it can work with newer version of MariaDB docker image. Related issue: #25717

## Why?

As explained in [MySQL docs](https://dev.mysql.com/doc/en/docker-mysql-more-topics.html#docker_var_mysql-root-host), by default the root user can be accessed only from inside the container and any other access is denied.

Given that we are only interested in development, what we really want is to allow connection from any host.

## How?
Set the `MYSQL_ROOT_HOST` env variable for MariaDB containers to allow access from any host.