### PR TITLE
Image Block: Don't render if there is no URL set

### DIFF
--- a/packages/block-library/src/image/index.php
+++ b/packages/block-library/src/image/index.php
@@ -14,13 +14,18 @@
  * @return string Returns the block content with the data-id attribute added.
  */
 function render_block_core_image( $attributes, $content ) {
+	$processor = new WP_HTML_Tag_Processor( $content );
+	$processor->next_tag( 'img' );
+
+	if ( $processor->get_attribute( 'src' ) === null ) {
+		return '';
+	}
+
 	if ( isset( $attributes['data-id'] ) ) {
 		// Add the data-id="$id" attribute to the img element
 		// to provide backwards compatibility for the Gallery Block,
 		// which now wraps Image Blocks within innerBlocks.
 		// The data-id attribute is added in a core/gallery `render_block_data` hook.
-		$processor = new WP_HTML_Tag_Processor( $content );
-		$processor->next_tag( 'img' );
 		$processor->set_attribute( 'data-id', $attributes['data-id'] );
 		$content = $processor->get_updated_html();
 	}


### PR DESCRIPTION
Fix #44639

> **Note**
> This PR probably depends on #43178

## What?
This PR disables rendering on the front end when no URL is set in the image block.

## Why?
When the image block doesn't have a URL, the front end outputs HTML like this:

```html
<figure class="wp-block-image"><img decoding="async" alt=""></figure>
```

According to [MDN](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/img), the img element must have `src` attribute, so I believe this is incorrect markup.

> The src attribute is required, and contains the path to the image you want to embed.

## How?
This PR uses the new  HTML Tag Processor API introduced in #42485 and changed to output nothing if the src attribute is empty. This rule is similar to the one that outputs nothing if the image is empty in the following block:

- [Post Featured Image](https://github.com/WordPress/gutenberg/blob/430fb9faadb00a5be74e414a7975bec672a3bba4/packages/block-library/src/post-featured-image/index.php#L41-L43)
- [Site Logo](https://github.com/WordPress/gutenberg/blob/430fb9faadb00a5be74e414a7975bec672a3bba4/packages/block-library/src/site-logo/index.php#L30-L32)
- [Social Link](https://github.com/WordPress/gutenberg/blob/430fb9faadb00a5be74e414a7975bec672a3bba4/packages/block-library/src/social-link/index.php#L25-L28)

Also, a refactoring using this API in the core block in general is proposed by #43178. So this PR may need to be updated after #43178 is merged to prevent conflicts.

## Testing Instructions

1. After inserting the image block, save the article without specifying an image.
2. Confirm that nothing is output to the front end.
