### PR TITLE
Verse Block: Prevent text overflow off-screen when the previous block has float

### DIFF
--- a/packages/block-library/src/verse/style.scss
+++ b/packages/block-library/src/verse/style.scss
@@ -1,6 +1,10 @@
 pre.wp-block-verse {
 	overflow: auto;
 	white-space: pre-wrap;
+
+	// Prevent text overflow off-screen when the previous block has float.
+	min-width: 1em;
+	word-break: break-word;
 }
 
 :where(pre.wp-block-verse) {


### PR DESCRIPTION
Fix #44924

## What?
This PR fixes a problem with verse text being pushed off the screen at mobile sizes when a block with a float applied is placed before the verse block.

## Why?
My understanding is that wrapping is intentionally prohibited, as was done in #9584.

> Today, we prevent wrapping Verse block lines in the editor because we want to preserve the author's intent, but that intent is not respected consistently on the front end where certain themes wrap Verse lines. This PR simply adds a rule to prevent Verse lines from wrapping on the front end in addition to the editor.

This makes sense, but I believe that wrapping should be allowed if the text overflows the container.

## How?
I have added `word-break:bread-word;` to allow for wrapping if the screen width is such that the text overflows.

## Screenshots or screencast

### On trunk

Confirm that the verse text is pushed out of view when the screen width is small.

<details>
<summary>Screencast: Verse with left-aligned image on trunk</summary>

https://user-images.githubusercontent.com/54422211/197332546-85413dc6-251c-474d-8b1f-16900e61caf2.mp4
</details>

<details>
<summary>Screencast: Verse with right-aligned image on trunk</summary>

https://user-images.githubusercontent.com/54422211/197332573-c3eff480-8215-4008-9159-529fb1fd8a94.mp4

</details>

### On this branch

Confirm that the text wraps just before the verse text becomes invisible.

<details>
<summary>Screencast: Verse with left-aligned image on this branch</summary>

https://user-images.githubusercontent.com/54422211/197332588-168a4a30-efe0-4aa5-9048-b3f944caf089.mp4

</details>

<details>
<summary>Screencast: Verse with right-aligned image on this branch</summary>

https://user-images.githubusercontent.com/54422211/197332596-b7ab4434-5e97-4b2e-9d4e-34bac56963ed.mp4

</details>