### PR TITLE
Typo in id in URL

### DIFF
--- a/docs/explanations/faq.md
+++ b/docs/explanations/faq.md
@@ -28,7 +28,7 @@ What follows is a set of questions that have come up from the last few years of 
 
 ### The Development Experience
 - [How do I make my own block?](#how-do-i-make-my-own-block)
-- [Does Gutenberg involve editing posts/pages in the front-end?](#does-gutenberg-involve-editing-postspages-in-the-front-end)
+- [Does Gutenberg involve editing posts/pages in the front-end?](#does-gutenberg-involve-editing-posts-pages-in-the-front-end)
 - [Given Gutenberg is built in JavaScript, how do old meta boxes (PHP) work?](#given-gutenberg-is-built-in-javascript-how-do-old-meta-boxes-php-work)
 - [How can plugins extend the Gutenberg UI?](#how-can-plugins-extend-the-gutenberg-ui)
 - [Are Custom Post Types still supported?](#are-custom-post-types-still-supported)


### PR DESCRIPTION
In this page: https://developer.wordpress.org/block-editor/explanations/faq/

Under the title: 'The Development Experience', the link to the section titled: 'Does Gutenberg involve editing posts/pages in the front-end?' misses the hyphen and therefore doesn't link to the url.

This means when a user clicks on the link, they are not sent to the section id.

The correct url should be:

https://developer.wordpress.org/block-editor/explanations/faq/#does-gutenberg-involve-editing-posts-pages-in-the-front-end

The id in the url misses the hyphen, and doesn't link to the id correctly.

<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->

## Screenshots or screencast <!-- if applicable -->
