### PR TITLE
Reset background-image property for outline button style

### DIFF
--- a/packages/block-library/src/button/style.scss
+++ b/packages/block-library/src/button/style.scss
@@ -113,4 +113,6 @@ $blocks-block__margin: 0.5em;
 .wp-block-button.is-style-outline > .wp-block-button__link:not(.has-background),
 .wp-block-button .wp-block-button__link.is-style-outline:not(.has-background) {
 	background-color: transparent;
+	// background-image is required to overwrite a gradient background
+	background-image: none;
 }


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->
This resets the `background-image` property for the 'outline' button style (.is-style-outline), in a similar way to how we set the `backgorund-color` to `transparent` for this style.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
This stops a default button gradient from being applied to the outline buttons (e.g. if a gradient is set in theme.json at `button.color.gradient`), so they still look like 'outline' buttons.

Fixes https://github.com/WordPress/gutenberg/issues/45233.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
Sets `background-image` to `none`.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->
1. Enable TT3 and pick the Pilgrimage style variation
2. Insert a button with the outline style
3. It shouldn't inherit the gradient that is applied to all buttons

## Screenshots or screencast <!-- if applicable -->

| Before | After |
| ------ | ----- |
| <img width="677" alt="image" src="https://user-images.githubusercontent.com/1645628/197396805-524a1029-8603-491e-bbac-c98d7638718f.png"> | <img width="677" alt="image" src="https://user-images.githubusercontent.com/1645628/197396780-0f74ad9a-c4d2-491e-8dcf-1d24d00401cf.png"> |


