### PR TITLE
Add :visited to theme.json schema

### DIFF
--- a/schemas/json/theme.json
+++ b/schemas/json/theme.json
@@ -1202,6 +1202,9 @@
 								},
 								":active": {
 									"$ref": "#/definitions/stylesPropertiesComplete"
+								},
+								":visited": {
+									"$ref": "#/definitions/stylesPropertiesComplete"
 								}
 							},
 							"additionalProperties": false
@@ -1227,6 +1230,9 @@
 									"$ref": "#/definitions/stylesPropertiesComplete"
 								},
 								":active": {
+									"$ref": "#/definitions/stylesPropertiesComplete"
+								},
+								":visited": {
 									"$ref": "#/definitions/stylesPropertiesComplete"
 								}
 							},


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->
`:visited` pseudo selector was added to WP_Theme_JSON in https://github.com/WordPress/gutenberg/pull/42096
This PR adds :`visited` to the theme.json schema.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
Using visited in theme.json produces a warning `Property :visited is not allowed.` in VSCode when the schema is used.
