### PR TITLE
GH-39602 | Change label for adding inner-block button.

### DIFF
--- a/packages/block-editor/src/components/button-block-appender/index.js
+++ b/packages/block-editor/src/components/button-block-appender/index.js
@@ -42,7 +42,7 @@ function ButtonBlockAppender(
 					);
 				} else {
 					label = _x(
-						'Add block',
+						'Add new item',
 						'Generic label for block inserter button'
 					);
 				}


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Inner blocks have their own label for button. The name is generic.

## Why?
To differ adding blocks (like navigation, columns, etc.) and inner blocks (items inside this blocks) according to [this issue](https://github.com/WordPress/gutenberg/issues/39602).

## How?
Now inner blocks have generic label"Add new item" instead of "Add block".

## Testing Instructions
1. Add some blocks with inner block (columns, navigation, etc.)
2. Label for it should be "Add new item".
3. Label for regular block should still be "Add block".

## Screenshots or screencast <!-- if applicable -->
![obraz](https://user-images.githubusercontent.com/68051717/197477915-9accc9a5-22a5-4268-9acb-1235539f990a.png)

