### PR TITLE
Navigation block: return undefined from useEffect

### DIFF
--- a/packages/block-library/src/navigation/edit/index.js
+++ b/packages/block-library/src/navigation/edit/index.js
@@ -272,7 +272,7 @@ function Navigation( {
 			fallbackNavigationMenus?.length > 0 ||
 			classicMenus?.length !== 1
 		) {
-			return false;
+			return;
 		}
 
 		// If there's non fallback navigation menus and
@@ -481,24 +481,22 @@ function Navigation( {
 
 	// Prompt the user to publish the menu they have set as a draft
 	const isDraftNavigationMenu = navigationMenu?.status === 'draft';
-	useEffect( async () => {
+	useEffect( () => {
 		hideMenuAutoPublishDraftNotice();
-		if ( ! isDraftNavigationMenu ) return;
-		try {
-			await editEntityRecord(
-				'postType',
-				'wp_navigation',
-				navigationMenu?.id,
-				{
-					status: 'publish',
-				},
-				{ throwOnError: true }
-			);
-		} catch {
+		if ( ! isDraftNavigationMenu ) {
+			return;
+		}
+		editEntityRecord(
+			'postType',
+			'wp_navigation',
+			navigationMenu?.id,
+			{ status: 'publish' },
+			{ throwOnError: true }
+		).catch( () => {
 			showMenuAutoPublishDraftNotice(
 				__( 'Error occurred while publishing the navigation menu.' )
 			);
-		}
+		} );
 	}, [ isDraftNavigationMenu, navigationMenu ] );
 
 	const stylingInspectorControls = (


### PR DESCRIPTION
The `Navigation` block has two `useEffect` calls that return either `false` or a `Promise`. React 18 doesn't like that and reports a warning:

<img width="937" alt="Screenshot 2022-10-24 at 10 01 14" src="https://user-images.githubusercontent.com/664258/197479785-7d2d37c0-2990-4e0d-8d51-503e2cb7782c.png">

and then proceeds to call the non-function anyway as a cleanup function, leading to crash. Seems that React 18 is more sensitive to the `useEffect` return values than previous versions.

This PR fixes the `useEffect` calls. I found the issue when debugging e2e test failures in #45235. The `Navigation` block is displayed in the global block inserter and leads to crash when running the
```
Inserting blocks › inserts blocks at root level when using the root appender while selection is in an inner block
```
e2e test.