### PR TITLE
PostTextEditor test: wrap .blur calls in act()

### DIFF
--- a/packages/editor/src/components/post-text-editor/test/index.js
+++ b/packages/editor/src/components/post-text-editor/test/index.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { render, screen } from '@testing-library/react';
+import { act, render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 
 /**
@@ -117,7 +117,9 @@ describe( 'PostTextEditor', () => {
 		await user.clear( textarea );
 
 		// Stop editing.
-		textarea.blur();
+		act( () => {
+			textarea.blur();
+		} );
 
 		expect( mockResetEditorBlocks ).toHaveBeenCalledWith( [] );
 	} );
@@ -147,7 +149,9 @@ describe( 'PostTextEditor', () => {
 
 		rerender( <PostTextEditor /> );
 
-		textarea.blur();
+		act( () => {
+			textarea.blur();
+		} );
 
 		expect( textarea ).toHaveValue( 'Goodbye World' );
 	} );


### PR DESCRIPTION
Followup to #44923 which wraps `.blur` calls in `act()`. After React 18 upgrade (see #45235) the `PostTextEditor` test starts to fail because of this, complaining that:

> An update to %s inside a test was not wrapped in act(...)

