### PR TITLE
Add block pattern categories' descriptions to the REST API and update the descriptions

### DIFF
--- a/lib/compat/wordpress-6.0/rest-api.php
+++ b/lib/compat/wordpress-6.0/rest-api.php
@@ -35,14 +35,6 @@ function gutenberg_register_edit_site_export_endpoint() {
 }
 add_action( 'rest_api_init', 'gutenberg_register_edit_site_export_endpoint' );
 
-/**
- * Registers the block pattern categories REST API routes.
- */
-function gutenberg_register_rest_block_pattern_categories() {
-	$block_patterns = new WP_REST_Block_Pattern_Categories_Controller();
-	$block_patterns->register_routes();
-}
-add_action( 'rest_api_init', 'gutenberg_register_rest_block_pattern_categories' );
 
 /**
  * Register a core site settings.

--- a/lib/compat/wordpress-6.2/block-patterns.php
+++ b/lib/compat/wordpress-6.2/block-patterns.php
@@ -48,8 +48,8 @@ function gutenberg_register_core_block_patterns_and_categories() {
 	register_block_pattern_category(
 		'query',
 		array(
-			'label'       => _x( 'Query', 'Block pattern category', 'gutenberg' ),
-			'description' => __( 'Display post summaries in lists, grids, and other layouts', 'gutenberg' ),
+			'label'       => _x( 'Posts', 'Block pattern category', 'gutenberg' ),
+			'description' => __( 'Display post summaries in lists, grids, and other layouts.', 'gutenberg' ),
 		)
 	);
 	register_block_pattern_category(

--- a/lib/compat/wordpress-6.2/block-patterns.php
+++ b/lib/compat/wordpress-6.2/block-patterns.php
@@ -12,57 +12,50 @@ function gutenberg_register_core_block_patterns_and_categories() {
 	register_block_pattern_category(
 		'buttons',
 		array(
-			'label'       => _x( 'Buttons', 'Block pattern category', 'gutenberg' ),
-			'description' => __( 'Buttons description', 'gutenberg' ),
+			'label' => _x( 'Buttons', 'Block pattern category', 'gutenberg' ),
 		)
 	);
 	register_block_pattern_category(
 		'columns',
 		array(
-			'label'       => _x( 'Columns', 'Block pattern category', 'gutenberg' ),
-			'description' => __( 'Columns description', 'gutenberg' ),
+			'label' => _x( 'Columns', 'Block pattern category', 'gutenberg' ),
 		)
 	);
 	register_block_pattern_category(
 		'footer',
 		array(
-			'label'       => _x( 'Footers', 'Block pattern category', 'gutenberg' ),
-			'description' => __( 'Footers description', 'gutenberg' ),
+			'label' => _x( 'Footers', 'Block pattern category', 'gutenberg' ),
 		)
 	);
 	register_block_pattern_category(
 		'gallery',
 		array(
-			'label'       => _x( 'Gallery', 'Block pattern category', 'gutenberg' ),
-			'description' => __( 'Gallery description', 'gutenberg' ),
+			'label' => _x( 'Gallery', 'Block pattern category', 'gutenberg' ),
 		)
 	);
 	register_block_pattern_category(
 		'header',
 		array(
-			'label'       => _x( 'Headers', 'Block pattern category', 'gutenberg' ),
-			'description' => __( 'Headers description', 'gutenberg' ),
+			'label' => _x( 'Headers', 'Block pattern category', 'gutenberg' ),
 		)
 	);
 	register_block_pattern_category(
 		'text',
 		array(
-			'label'       => _x( 'Text', 'Block pattern category', 'gutenberg' ),
-			'description' => __( 'Text description', 'gutenberg' ),
+			'label' => _x( 'Text', 'Block pattern category', 'gutenberg' ),
 		)
 	);
 	register_block_pattern_category(
 		'query',
 		array(
 			'label'       => _x( 'Query', 'Block pattern category', 'gutenberg' ),
-			'description' => __( 'Query description', 'gutenberg' ),
+			'description' => __( 'Display post summaries in lists, grids, and other layouts', 'gutenberg' ),
 		)
 	);
 	register_block_pattern_category(
 		'featured',
 		array(
-			'label'       => _x( 'Featured', 'Block pattern category', 'gutenberg' ),
-			'description' => __( 'Featured description', 'gutenberg' ),
+			'label' => _x( 'Featured', 'Block pattern category', 'gutenberg' ),
 		)
 	);
 }

--- a/lib/compat/wordpress-6.2/block-patterns.php
+++ b/lib/compat/wordpress-6.2/block-patterns.php
@@ -1,0 +1,69 @@
+<?php
+/**
+ * Overrides Core's wp-includes/block-patterns.php to add category descriptions for WP 6.2.
+ *
+ * @package gutenberg
+ */
+
+/**
+ * Registers the block pattern categories REST API routes.
+ */
+function gutenberg_register_core_block_patterns_and_categories() {
+	register_block_pattern_category(
+		'buttons',
+		array(
+			'label'       => _x( 'Buttons', 'Block pattern category', 'gutenberg' ),
+			'description' => __( 'Buttons description', 'gutenberg' ),
+		)
+	);
+	register_block_pattern_category(
+		'columns',
+		array(
+			'label'       => _x( 'Columns', 'Block pattern category', 'gutenberg' ),
+			'description' => __( 'Columns description', 'gutenberg' ),
+		)
+	);
+	register_block_pattern_category(
+		'footer',
+		array(
+			'label'       => _x( 'Footers', 'Block pattern category', 'gutenberg' ),
+			'description' => __( 'Footers description', 'gutenberg' ),
+		)
+	);
+	register_block_pattern_category(
+		'gallery',
+		array(
+			'label'       => _x( 'Gallery', 'Block pattern category', 'gutenberg' ),
+			'description' => __( 'Gallery description', 'gutenberg' ),
+		)
+	);
+	register_block_pattern_category(
+		'header',
+		array(
+			'label'       => _x( 'Headers', 'Block pattern category', 'gutenberg' ),
+			'description' => __( 'Headers description', 'gutenberg' ),
+		)
+	);
+	register_block_pattern_category(
+		'text',
+		array(
+			'label'       => _x( 'Text', 'Block pattern category', 'gutenberg' ),
+			'description' => __( 'Text description', 'gutenberg' ),
+		)
+	);
+	register_block_pattern_category(
+		'query',
+		array(
+			'label'       => _x( 'Query', 'Block pattern category', 'gutenberg' ),
+			'description' => __( 'Query description', 'gutenberg' ),
+		)
+	);
+	register_block_pattern_category(
+		'featured',
+		array(
+			'label'       => _x( 'Featured', 'Block pattern category', 'gutenberg' ),
+			'description' => __( 'Featured description', 'gutenberg' ),
+		)
+	);
+}
+add_action( 'init', 'gutenberg_register_core_block_patterns_and_categories' );

--- a/lib/compat/wordpress-6.2/class-gutenberg-rest-block-pattern-categories-controller.php
+++ b/lib/compat/wordpress-6.2/class-gutenberg-rest-block-pattern-categories-controller.php
@@ -1,0 +1,78 @@
+<?php
+/**
+ * REST API: Gutenberg_REST_Block_Pattern_Categories_Controller class
+ *
+ * Adds descriptions to the block pattern categories.
+ *
+ * @package    WordPress
+ * @subpackage REST_API
+ */
+
+/**
+ * Core class used to access block pattern categories via the REST API.
+ *
+ * @see   WP_REST_Controller
+ */
+class Gutenberg_REST_Block_Pattern_Categories_Controller extends WP_REST_Block_Pattern_Categories_Controller {
+	/**
+	 * Prepare a raw block pattern category before it gets output in a REST API response.
+	 *
+	 * @since 6.0.0
+	 *
+	 * @param object          $item    Raw category as registered, before any changes.
+	 * @param WP_REST_Request $request Request object.
+	 * @return WP_REST_Response
+	 */
+	public function prepare_item_for_response( $item, $request ) {
+		$fields = $this->get_fields_for_response( $request );
+		$keys   = array( 'name', 'label', 'description' );
+		$data   = array();
+		foreach ( $keys as $key ) {
+			if ( rest_is_field_included( $key, $fields ) ) {
+				$data[ $key ] = $item[ $key ];
+			}
+		}
+
+		$context = ! empty( $request['context'] ) ? $request['context'] : 'view';
+		$data    = $this->add_additional_fields_to_object( $data, $request );
+		$data    = $this->filter_response_by_context( $data, $context );
+		return rest_ensure_response( $data );
+	}
+
+	/**
+	 * Retrieves the block pattern category schema, conforming to JSON Schema.
+	 *
+	 * @since 6.0.0
+	 *
+	 * @return array Item schema data.
+	 */
+	public function get_item_schema() {
+		$schema = array(
+			'$schema'    => 'http://json-schema.org/draft-04/schema#',
+			'title'      => 'block-pattern-category',
+			'type'       => 'object',
+			'properties' => array(
+				'name'        => array(
+					'description' => __( 'The category name.', 'gutenberg' ),
+					'type'        => 'string',
+					'readonly'    => true,
+					'context'     => array( 'view', 'edit', 'embed' ),
+				),
+				'label'       => array(
+					'description' => __( 'The category label, in human readable format.', 'gutenberg' ),
+					'type'        => 'string',
+					'readonly'    => true,
+					'context'     => array( 'view', 'edit', 'embed' ),
+				),
+				'description' => array(
+					'description' => __( 'The category description, in human readable format.', 'gutenberg' ),
+					'type'        => 'string',
+					'readonly'    => true,
+					'context'     => array( 'view', 'edit', 'embed' ),
+				),
+			),
+		);
+
+		return $this->add_additional_fields_schema( $schema );
+	}
+}

--- a/lib/compat/wordpress-6.2/rest-api.php
+++ b/lib/compat/wordpress-6.2/rest-api.php
@@ -1,0 +1,15 @@
+<?php
+/**
+ * Overrides Core's wp-includes/rest-api.php and registers the new endpoint for WP 6.2.
+ *
+ * @package gutenberg
+ */
+
+/**
+ * Registers the block pattern categories REST API routes.
+ */
+function gutenberg_register_rest_block_pattern_categories() {
+	$block_patterns = new Gutenberg_REST_Block_Pattern_Categories_Controller();
+	$block_patterns->register_routes();
+}
+add_action( 'rest_api_init', 'gutenberg_register_rest_block_pattern_categories' );

--- a/lib/load.php
+++ b/lib/load.php
@@ -49,6 +49,11 @@ if ( class_exists( 'WP_REST_Controller' ) ) {
 	require_once __DIR__ . '/compat/wordpress-6.1/class-gutenberg-rest-templates-controller.php';
 	require_once __DIR__ . '/compat/wordpress-6.1/rest-api.php';
 
+	// WordPress 6.2 compat.
+	require_once __DIR__ . '/compat/wordpress-6.2/class-gutenberg-rest-block-pattern-categories-controller.php';
+	require_once __DIR__ . '/compat/wordpress-6.2/rest-api.php';
+	require_once __DIR__ . '/compat/wordpress-6.2/block-patterns.php';
+
 	// Experimental.
 	if ( ! class_exists( 'WP_Rest_Customizer_Nonces' ) ) {
 		require_once __DIR__ . '/experimental/class-wp-rest-customizer-nonces.php';


### PR DESCRIPTION
Related #41379

## What?

In #41379 we implemented the new patterns inserter but we left out of the addition of the descriptions to the block pattern categories as a follow-up.

This PR adds these descriptions.

**Note** I've just added placeholder descriptions for now. Please can you help provide the right descriptions for each category.

**Note 2** I know that we want to change the categories, can we leave that out of the current PR and just focus on addition the descriptions for now.

## Testing Instructions

1- Open the patterns inserter
2- Notice that you can see "descriptions" under the category title when you open the panel.
