### PR TITLE
Scripts: Builds should include source maps by default

### DIFF
--- a/bin/test-create-block.sh
+++ b/bin/test-create-block.sh
@@ -69,7 +69,7 @@ status "Building block..."
 ../node_modules/.bin/wp-scripts build
 
 status "Verifying build..."
-expected=5
+expected=6
 actual=$( find build -maxdepth 1 -type f | wc -l )
 if [ "$expected" -ne "$actual" ]; then
 	error "Expected $expected files in the \`build\` directory, but found $actual."

--- a/packages/scripts/config/webpack.config.js
+++ b/packages/scripts/config/webpack.config.js
@@ -296,16 +296,18 @@ const config = {
 	},
 };
 
+// WP_DEVTOOL global variable controls how source maps are generated.
+// By default, production (!) and development builds should include sourcemaps.
+// See: https://webpack.js.org/configuration/devtool/#devtool.
+config.devtool = process.env.WP_DEVTOOL || 'source-map';
+config.module.rules.unshift( {
+	test: /\.(j|t)sx?$/,
+	exclude: [ /node_modules/ ],
+	use: require.resolve( 'source-map-loader' ),
+	enforce: 'pre',
+} );
+
 if ( ! isProduction ) {
-	// WP_DEVTOOL global variable controls how source maps are generated.
-	// See: https://webpack.js.org/configuration/devtool/#devtool.
-	config.devtool = process.env.WP_DEVTOOL || 'source-map';
-	config.module.rules.unshift( {
-		test: /\.(j|t)sx?$/,
-		exclude: [ /node_modules/ ],
-		use: require.resolve( 'source-map-loader' ),
-		enforce: 'pre',
-	} );
 	config.devServer = {
 		devMiddleware: {
 			writeToDisk: true,


### PR DESCRIPTION
## What?
gutenberg builds should include source maps by default

## Why?
There is no reason production builds should not include sourcemaps - without sourcemaps, debugging the error or - for users - reporting errors is not possible, making the website and the web in general less accessible

* analogous to https://github.com/WordPress/gutenberg/pull/33718
* Fix: https://github.com/WordPress/gutenberg/issues/44278
* Fix: https://github.com/WordPress/gutenberg/discussions/41551

## How?
Making the WP_DEVTOOL not conditional on `isProduction`
Sourcemaps can still be disabled, by explicitly setting `WP_DEVTOOL` to `none`

## Testing Instructions
`npm run build` to create the bundled js, which will now include a .map file

