### PR TITLE
Details block: add a toggleable container block

### DIFF
--- a/lib/blocks.php
+++ b/lib/blocks.php
@@ -22,6 +22,7 @@ function gutenberg_reregister_core_block_types() {
 				'column',
 				'columns',
 				'comments',
+				'details',
 				'group',
 				'heading',
 				'html',

--- a/packages/block-library/src/details/block.json
+++ b/packages/block-library/src/details/block.json
@@ -1,0 +1,49 @@
+{
+	"$schema": "https://schemas.wp.org/trunk/block.json",
+	"apiVersion": 2,
+	"name": "core/details",
+	"title": "Details",
+	"category": "design",
+	"description": "A content area that can be toggled between open and closed.",
+	"keywords": [ "container", "toggle", "details", "collapse", "expand" ],
+	"textdomain": "default",
+	"attributes": {
+		"summary": {
+			"type": "string",
+			"default": ""
+		}
+	},
+	"supports": {
+		"html": false,
+		"align": [ "wide", "full" ],
+		"anchor": true,
+		"ariaLabel": true,
+		"spacing": {
+			"margin": true,
+			"padding": true,
+			"blockGap": true
+		},
+		"__experimentalBorder": true,
+		"color": {
+			"gradients": true,
+			"link": true,
+			"__experimentalDefaultControls": {
+				"background": true,
+				"text": true
+			}
+		},
+		"typography": {
+			"fontSize": true,
+			"lineHeight": true,
+			"__experimentalFontStyle": true,
+			"__experimentalFontWeight": true,
+			"__experimentalLetterSpacing": true,
+			"__experimentalTextTransform": true,
+			"__experimentalDefaultControls": {
+				"fontSize": true
+			}
+		}
+	},
+	"editorStyle": "wp-block-details-editor",
+	"style": "wp-block-details"
+}

--- a/packages/block-library/src/details/edit.js
+++ b/packages/block-library/src/details/edit.js
@@ -1,0 +1,32 @@
+/**
+ * WordPress dependencies
+ */
+import {
+	useBlockProps,
+	useInnerBlocksProps,
+	RichText,
+	BlockIcon,
+} from '@wordpress/block-editor';
+import { __ } from '@wordpress/i18n';
+
+export default function DetailsEdit( { attributes, setAttributes } ) {
+	const blockProps = useBlockProps( { className: 'is-disabled' } );
+	const innerBlocksProps = useInnerBlocksProps( { className: 'wp-block-details__inner-container' } )
+	return (
+		<details { ...blockProps } open>
+			<summary onClick={ ( event ) => event.preventDefault() }>
+				<RichText
+					identifier="content"
+					tagName="span"
+					className="wp-block-details__summary-text"
+					value={ attributes.summary }
+					onChange={ ( value ) => setAttributes( { summary: value } ) }
+					placeholder={ __( 'Click the arrow to expand' ) }
+					deleteEnter={ false }
+					inlineToolbar
+				/>
+			</summary>
+			<div { ...innerBlocksProps } />
+		</details>
+	);
+}

--- a/packages/block-library/src/details/index.js
+++ b/packages/block-library/src/details/index.js
@@ -1,0 +1,38 @@
+/**
+ * WordPress dependencies
+ */
+import { __ } from '@wordpress/i18n';
+import { plus as icon } from '@wordpress/icons';
+
+/**
+ * Internal dependencies
+ */
+import initBlock from '../utils/init-block';
+import edit from './edit';
+import metadata from './block.json';
+import save from './save';
+
+const { name } = metadata;
+
+export { metadata, name };
+
+export const settings = {
+	icon,
+	example: {
+		attributes: {
+			summary: __( 'Click the arrow to expand' ),
+		},
+		innerBlocks: [
+			{
+				name: 'core/paragraph',
+				attributes: {
+					content: __( 'Details text that can be toggled to an opened or closed state.' ),
+				},
+			},
+		],
+	},
+	edit,
+	save,
+};
+
+export const init = () => initBlock( { name, metadata, settings } );

--- a/packages/block-library/src/details/init.js
+++ b/packages/block-library/src/details/init.js
@@ -1,0 +1,6 @@
+/**
+ * Internal dependencies
+ */
+import { init } from './';
+
+export default init();

--- a/packages/block-library/src/details/save.js
+++ b/packages/block-library/src/details/save.js
@@ -1,0 +1,21 @@
+/**
+ * WordPress dependencies
+ */
+import { BlockIcon, RichText, useInnerBlocksProps, useBlockProps } from '@wordpress/block-editor';
+
+export default function save( { attributes: { summary } } ) {
+	return (
+		<details { ...useBlockProps.save() }>
+			<summary>
+				<span className="wp-block-details__summary-text">
+					<RichText.Content value={ summary } />
+				</span>
+			</summary>
+			<div
+				{ ...useInnerBlocksProps.save( {
+					className: 'wp-block-details__inner-container',
+				} ) }
+			/>
+		</details>
+	);
+}

--- a/packages/block-library/src/details/style.scss
+++ b/packages/block-library/src/details/style.scss
@@ -1,0 +1,21 @@
+.wp-block-details {
+	box-sizing: inherit;
+
+	> summary {
+		padding: 10px;
+		cursor: default;
+	}
+
+	> summary:hover {
+		cursor: pointer;
+	}
+
+	.wp-block-details__summary-text {
+		margin-left: 0.5em;
+	}
+
+	> .wp-block-details__inner-container {
+		cursor: default;
+		padding: 0 1em;
+	}
+}

--- a/packages/block-library/src/index.js
+++ b/packages/block-library/src/index.js
@@ -46,6 +46,7 @@ import * as commentsPaginationNumbers from './comments-pagination-numbers';
 import * as commentsTitle from './comments-title';
 import * as cover from './cover';
 import * as embed from './embed';
+import * as details from './details';
 import * as file from './file';
 import * as gallery from './gallery';
 import * as group from './group';
@@ -144,6 +145,7 @@ const getAllBlocks = () =>
 		columns,
 		commentAuthorAvatar,
 		cover,
+		details,
 		embed,
 		file,
 		group,

--- a/packages/block-library/src/style.scss
+++ b/packages/block-library/src/style.scss
@@ -11,6 +11,7 @@
 @import "./comments-pagination/style.scss";
 @import "./comment-template/style.scss";
 @import "./cover/style.scss";
+@import "./details/style.scss";
 @import "./embed/style.scss";
 @import "./file/style.scss";
 @import "./gallery/style.scss";


### PR DESCRIPTION
## What?
Testing whether a "details" core block works.

## Why?

https://user-images.githubusercontent.com/6458278/197647440-e1b0b0ef-ccbc-4acc-9aa9-6be842b944e1.mp4


## Testing Instructions

1. Insert a details block
2. Check that you can edit the summary label
3. Check that you can insert child blocks in the container
4. Ponder whether this is necessary at all
