### PR TITLE
Fix: Site editor clips body background style

### DIFF
--- a/packages/block-editor/src/components/iframe/index.js
+++ b/packages/block-editor/src/components/iframe/index.js
@@ -282,7 +282,7 @@ function Iframe(
 
 	head = (
 		<>
-			<style>{ 'body{margin:0}' }</style>
+			<style>{ 'html{height:auto!important;}body{margin:0}' }</style>
 			{ styles.map(
 				( { tagName, href, id, rel, media, textContent } ) => {
 					const TagName = tagName.toLowerCase();


### PR DESCRIPTION
## What?
This PR applies the fix backported to WordPress 6.1 by #45118 to the latest Gutenberg.

## Why?
Background on this issue is discussed in detail in https://github.com/WordPress/gutenberg/issues/44374#issuecomment-1260784743. The complication is that this problem cannot be reproduced in the usual way as long as Gutenberg plugin is enabled.

## How?
Same changes as #45118.

## Testing Instructions

To test this PR, follow the "Testing Instructions" in #45118.
