### PR TITLE
Visual Editor: Fix permission error

### DIFF
--- a/packages/edit-post/src/components/visual-editor/index.js
+++ b/packages/edit-post/src/components/visual-editor/index.js
@@ -38,6 +38,7 @@ import { useMergeRefs } from '@wordpress/compose';
 import { arrowLeft } from '@wordpress/icons';
 import { __ } from '@wordpress/i18n';
 import { parse } from '@wordpress/blocks';
+import { store as coreStore } from '@wordpress/core-data';
 
 /**
  * Internal dependencies
@@ -137,6 +138,10 @@ export default function VisualEditor( { styles } ) {
 		}
 
 		const supportsTemplateMode = getEditorSettings().supportsTemplateMode;
+		const canEditTemplate = select( coreStore ).canUser(
+			'create',
+			'templates'
+		);
 
 		return {
 			deviceType: __experimentalGetPreviewDeviceType(),
@@ -144,9 +149,10 @@ export default function VisualEditor( { styles } ) {
 			isTemplateMode: _isTemplateMode,
 			// Post template fetch returns a 404 on classic themes, which
 			// messes with e2e tests, so we check it's a block theme first.
-			editedPostTemplate: supportsTemplateMode
-				? getEditedPostTemplate()
-				: {},
+			editedPostTemplate:
+				supportsTemplateMode && canEditTemplate
+					? getEditedPostTemplate()
+					: {},
 			wrapperBlockName: _wrapperBlockName,
 			wrapperUniqueId: getCurrentPostId(),
 		};

--- a/packages/edit-post/src/components/visual-editor/index.js
+++ b/packages/edit-post/src/components/visual-editor/index.js
@@ -152,7 +152,7 @@ export default function VisualEditor( { styles } ) {
 			editedPostTemplate:
 				supportsTemplateMode && canEditTemplate
 					? getEditedPostTemplate()
-					: {},
+					: undefined,
 			wrapperBlockName: _wrapperBlockName,
 			wrapperUniqueId: getCurrentPostId(),
 		};


### PR DESCRIPTION
## What?
This is a follow-up for #44258.

PR fixes permission errors triggered by `getEditedPostTemplate` for users with lower capabilities.

## Why?
The editor should check permission before making requests when data isn't available for everyone.

## How?
Add check for user permissions before requesting `getEditedPostTemplate`.

## Testing Instructions
1. Login to the test site with an Author role.
2. Open a Post or Page.
3. Close the "Summary" panel and reload the page. I'm going to fix a similar issue for this component separately.
4. Open the DevTools network tab and confirm there're no 403 requests.
