### PR TITLE
Re-enable skipped Gallery block e2e test

### DIFF
--- a/test/e2e/specs/editor/blocks/gallery.spec.js
+++ b/test/e2e/specs/editor/blocks/gallery.spec.js
@@ -205,13 +205,14 @@ test.describe( 'Gallery', () => {
 		await editor.insertBlock( { name: 'core/gallery' } );
 		await page.click( 'role=button[name="Media Library"i]' );
 
-		await expect( page.locator( '.media-frame' ) ).toBeVisible();
-		await expect( page.locator( '.media-frame-title h1' ) ).toContainText(
-			'Create gallery'
+		const mediaLibrary = page.locator(
+			'role=dialog[name="Create gallery"i]'
 		);
+
+		await expect( mediaLibrary ).toBeVisible();
 		await expect(
-			page.locator( '.media-toolbar-primary button' )
-		).toContainText( 'Create a new gallery' );
+			mediaLibrary.locator( 'role=button[name="Create a new gallery"i]' )
+		).toBeVisible();
 	} );
 } );
 

--- a/test/e2e/specs/editor/blocks/gallery.spec.js
+++ b/test/e2e/specs/editor/blocks/gallery.spec.js
@@ -196,29 +196,23 @@ test.describe( 'Gallery', () => {
 			);
 	} );
 
-	// Disable reason:
-	// This test would be good to enable, but the media modal contains an
-	// invalid role, which is causing Axe tests to fail:
-	// https://core.trac.wordpress.org/ticket/50273
-	//
-	// Attempts to add an Axe exception for the media modal haven't proved
-	// successful:
-	// https://github.com/WordPress/gutenberg/pull/22719
-	test.fixme(
-		'when initially added the media library shows the Create Gallery view',
-		async ( { admin, editor, page } ) => {
-			await admin.createNewPost();
-			await editor.insertBlock( { name: 'core/gallery' } );
-			await page.click( 'role=button[name="Media Library"i]' );
-			await page.waitForSelector( '.media-frame' );
-			expect( await page.innerText( '.media-frame-title h1' ) ).toBe(
-				'Create gallery'
-			);
-			expect(
-				await page.innerText( '.media-toolbar-primary button' )
-			).toBe( 'Create a new gallery' );
-		}
-	);
+	test( 'when initially added the media library shows the Create Gallery view', async ( {
+		admin,
+		editor,
+		page,
+	} ) => {
+		await admin.createNewPost();
+		await editor.insertBlock( { name: 'core/gallery' } );
+		await page.click( 'role=button[name="Media Library"i]' );
+
+		await expect( page.locator( '.media-frame' ) ).toBeVisible();
+		await expect( page.locator( '.media-frame-title h1' ) ).toContainText(
+			'Create gallery'
+		);
+		await expect(
+			page.locator( '.media-toolbar-primary button' )
+		).toContainText( 'Create a new gallery' );
+	} );
 } );
 
 class GalleryBlockUtils {


### PR DESCRIPTION
## What?
This is a follow-up to https://github.com/WordPress/gutenberg/pull/45202#discussion_r1004058862.

PR re-enables skipped Gallery block e2e tests. I've also updated the test to use locators.

## Testing Instructions
```
npm run test:e2e:playwright -- test/e2e/specs/editor/blocks/gallery.spec.js
```