### PR TITLE
Allow customising the Navigation block breakpoint

### DIFF
--- a/docs/reference-guides/core-blocks/README.md
+++ b/docs/reference-guides/core-blocks/README.md
@@ -549,7 +549,7 @@ A collection of blocks that allow visitors to get around your site.
 -	**Category:** [theme](https://developer.wordpress.org/block-editor/reference-guides/core-blocks/core-blocks-theme/)
 -	**Allowed Blocks:** core/navigation-link, core/search, core/social-links, core/page-list, core/spacer, core/home-link, core/icon, core/site-title, core/site-logo, core/navigation-submenu, core/loginout, core/buttons
 -	**Supports:** align (full, wide), anchor, ariaLabel, contentRole, inserter, interactivity, layout (allowSizingOnChildren, default, ~~allowInheriting~~, ~~allowSwitching~~, ~~allowVerticalAlignment~~), spacing (blockGap, units), typography (fontSize, lineHeight), ~~html~~, ~~renaming~~
--	**Attributes:** __unstableLocation, backgroundColor, collapsedMenuBreakpoint, customBackgroundColor, customOverlayBackgroundColor, customOverlayTextColor, customTextColor, hasIcon, icon, maxNestingLevel, overlay, overlayBackgroundColor, overlayMenu, overlayTextColor, ref, rgbBackgroundColor, rgbTextColor, showSubmenuIcon, submenuVisibility, templateLock, textColor
+-	**Attributes:** __unstableLocation, backgroundColor, customBackgroundColor, customOverlayBackgroundColor, customOverlayTextColor, customTextColor, hasIcon, icon, maxNestingLevel, overlay, overlayBackgroundColor, overlayBreakpoint, overlayMenu, overlayTextColor, ref, rgbBackgroundColor, rgbTextColor, showSubmenuIcon, submenuVisibility, templateLock, textColor
 
 ## Custom Link
 

--- a/docs/reference-guides/core-blocks/README.md
+++ b/docs/reference-guides/core-blocks/README.md
@@ -549,7 +549,7 @@ A collection of blocks that allow visitors to get around your site.
 -	**Category:** [theme](https://developer.wordpress.org/block-editor/reference-guides/core-blocks/core-blocks-theme/)
 -	**Allowed Blocks:** core/navigation-link, core/search, core/social-links, core/page-list, core/spacer, core/home-link, core/icon, core/site-title, core/site-logo, core/navigation-submenu, core/loginout, core/buttons
 -	**Supports:** align (full, wide), anchor, ariaLabel, contentRole, inserter, interactivity, layout (allowSizingOnChildren, default, ~~allowInheriting~~, ~~allowSwitching~~, ~~allowVerticalAlignment~~), spacing (blockGap, units), typography (fontSize, lineHeight), ~~html~~, ~~renaming~~
--	**Attributes:** __unstableLocation, backgroundColor, customBackgroundColor, customOverlayBackgroundColor, customOverlayTextColor, customTextColor, hasIcon, icon, maxNestingLevel, overlay, overlayBackgroundColor, overlayMenu, overlayTextColor, ref, rgbBackgroundColor, rgbTextColor, showSubmenuIcon, submenuVisibility, templateLock, textColor
+-	**Attributes:** __unstableLocation, backgroundColor, collapsedMenuBreakpoint, customBackgroundColor, customOverlayBackgroundColor, customOverlayTextColor, customTextColor, hasIcon, icon, maxNestingLevel, overlay, overlayBackgroundColor, overlayMenu, overlayTextColor, ref, rgbBackgroundColor, rgbTextColor, showSubmenuIcon, submenuVisibility, templateLock, textColor
 
 ## Custom Link
 

--- a/packages/block-library/src/navigation/README.md
+++ b/packages/block-library/src/navigation/README.md
@@ -64,7 +64,7 @@ _Defined via the [`attributes`](https://developer.wordpress.org/block-editor/ref
 | `customOverlayTextColor` | `string` | — | — |
 | `maxNestingLevel` | `number` | `5` | — |
 | `templateLock` | `string \| boolean` | — | [Enum](https://developer.wordpress.org/block-editor/reference-guides/block-api/block-attributes/#enum-validation): `all`, `insert`, `contentOnly`, `false` |
-| `collapsedMenuBreakpoint` | `string` | `"600px"` | — |
+| `overlayBreakpoint` | `string` | `"600px"` | — |
 
 ## Supports
 

--- a/packages/block-library/src/navigation/README.md
+++ b/packages/block-library/src/navigation/README.md
@@ -64,6 +64,7 @@ _Defined via the [`attributes`](https://developer.wordpress.org/block-editor/ref
 | `customOverlayTextColor` | `string` | — | — |
 | `maxNestingLevel` | `number` | `5` | — |
 | `templateLock` | `string \| boolean` | — | [Enum](https://developer.wordpress.org/block-editor/reference-guides/block-api/block-attributes/#enum-validation): `all`, `insert`, `contentOnly`, `false` |
+| `collapsedMenuBreakpoint` | `string` | `"600px"` | — |
 
 ## Supports
 

--- a/packages/block-library/src/navigation/block.json
+++ b/packages/block-library/src/navigation/block.json
@@ -71,6 +71,10 @@
 		"templateLock": {
 			"type": [ "string", "boolean" ],
 			"enum": [ "all", "insert", "contentOnly", false ]
+		},
+		"mobileBreakpoint": {
+			"type": "string",
+			"default": "782px"
 		}
 	},
 	"providesContext": {

--- a/packages/block-library/src/navigation/block.json
+++ b/packages/block-library/src/navigation/block.json
@@ -90,7 +90,7 @@
 			"type": [ "string", "boolean" ],
 			"enum": [ "all", "insert", "contentOnly", false ]
 		},
-		"mobileBreakpoint": {
+		"collapsedMenuBreakpoint": {
 			"type": "string",
 			"default": "600px"
 		}

--- a/packages/block-library/src/navigation/block.json
+++ b/packages/block-library/src/navigation/block.json
@@ -89,6 +89,10 @@
 		"templateLock": {
 			"type": [ "string", "boolean" ],
 			"enum": [ "all", "insert", "contentOnly", false ]
+		},
+		"mobileBreakpoint": {
+			"type": "string",
+			"default": "600px"
 		}
 	},
 	"providesContext": {

--- a/packages/block-library/src/navigation/block.json
+++ b/packages/block-library/src/navigation/block.json
@@ -90,7 +90,7 @@
 			"type": [ "string", "boolean" ],
 			"enum": [ "all", "insert", "contentOnly", false ]
 		},
-		"collapsedMenuBreakpoint": {
+		"overlayBreakpoint": {
 			"type": "string",
 			"default": "600px"
 		}

--- a/packages/block-library/src/navigation/constants.js
+++ b/packages/block-library/src/navigation/constants.js
@@ -28,6 +28,14 @@ export const SELECT_NAVIGATION_MENUS_ARGS = [
 	PRELOADED_NAVIGATION_MENUS_QUERY,
 ];
 
+export const DEFAULT_MOBILE_BREAKPOINT = '600px';
+
+export const MOBILE_BREAKPOINT_UNITS = [
+	{ value: 'px', label: 'px', default: 600 },
+	{ value: 'em', label: 'em', default: 37.5 },
+	{ value: 'rem', label: 'rem', default: 37.5 },
+];
+
 /**
  * Template part area identifier for navigation overlays.
  * This constant defines the area name used when registering and filtering

--- a/packages/block-library/src/navigation/constants.js
+++ b/packages/block-library/src/navigation/constants.js
@@ -28,9 +28,9 @@ export const SELECT_NAVIGATION_MENUS_ARGS = [
 	PRELOADED_NAVIGATION_MENUS_QUERY,
 ];
 
-export const DEFAULT_COLLAPSED_MENU_BREAKPOINT = '600px';
+export const DEFAULT_OVERLAY_BREAKPOINT = '600px';
 
-export const COLLAPSED_MENU_BREAKPOINT_UNITS = [
+export const OVERLAY_BREAKPOINT_UNITS = [
 	{ value: 'px', label: 'px', default: 600 },
 	{ value: 'em', label: 'em', default: 37.5 },
 	{ value: 'rem', label: 'rem', default: 37.5 },

--- a/packages/block-library/src/navigation/constants.js
+++ b/packages/block-library/src/navigation/constants.js
@@ -28,9 +28,9 @@ export const SELECT_NAVIGATION_MENUS_ARGS = [
 	PRELOADED_NAVIGATION_MENUS_QUERY,
 ];
 
-export const DEFAULT_MOBILE_BREAKPOINT = '600px';
+export const DEFAULT_COLLAPSED_MENU_BREAKPOINT = '600px';
 
-export const MOBILE_BREAKPOINT_UNITS = [
+export const COLLAPSED_MENU_BREAKPOINT_UNITS = [
 	{ value: 'px', label: 'px', default: 600 },
 	{ value: 'em', label: 'em', default: 37.5 },
 	{ value: 'rem', label: 'rem', default: 37.5 },

--- a/packages/block-library/src/navigation/edit/index.js
+++ b/packages/block-library/src/navigation/edit/index.js
@@ -29,6 +29,7 @@ import {
 	ToggleControl,
 	__experimentalToggleGroupControl as ToggleGroupControl,
 	__experimentalToggleGroupControlOption as ToggleGroupControlOption,
+	__experimentalInputControl as InputControl,
 	Button,
 	Spinner,
 } from '@wordpress/components';
@@ -94,6 +95,7 @@ function Navigation( {
 		} = {},
 		hasIcon,
 		icon = 'handle',
+		mobileBreakpoint,
 	} = attributes;
 
 	const ref = attributes.ref;
@@ -561,6 +563,15 @@ function Navigation( {
 							label={ __( 'Always' ) }
 						/>
 					</ToggleGroupControl>
+
+					<InputControl
+						value={ mobileBreakpoint }
+						onChange={ ( nextValue ) =>
+							setAttributes( {
+								mobileBreakpoint: nextValue,
+							} )
+						}
+					/>
 					{ hasSubmenus && (
 						<>
 							<h3>{ __( 'Submenus' ) }</h3>
@@ -701,6 +712,7 @@ function Navigation( {
 					isHiddenByDefault={ 'always' === overlayMenu }
 					overlayBackgroundColor={ overlayBackgroundColor }
 					overlayTextColor={ overlayTextColor }
+					mobileBreakpoint={ mobileBreakpoint }
 				>
 					<UnsavedInnerBlocks
 						blocks={ uncontrolledInnerBlocks }
@@ -937,6 +949,7 @@ function Navigation( {
 							isHiddenByDefault={ 'always' === overlayMenu }
 							overlayBackgroundColor={ overlayBackgroundColor }
 							overlayTextColor={ overlayTextColor }
+							mobileBreakpoint={ mobileBreakpoint }
 						>
 							{ isEntityAvailable && (
 								<NavigationInnerBlocks

--- a/packages/block-library/src/navigation/edit/index.js
+++ b/packages/block-library/src/navigation/edit/index.js
@@ -68,8 +68,8 @@ import useCreateNavigationMenu from './use-create-navigation-menu';
 import { useInnerBlocks } from './use-inner-blocks';
 import {
 	detectColors,
-	hasCustomCollapsedMenuBreakpoint,
-	normalizeCollapsedMenuBreakpoint,
+	hasCustomOverlayBreakpoint,
+	normalizeOverlayBreakpoint,
 } from './utils';
 import ManageMenusButton from './manage-menus-button';
 import MenuInspectorControls from './menu-inspector-controls';
@@ -282,14 +282,14 @@ function Navigation( {
 		} = {},
 		hasIcon,
 		icon = 'handle',
-		collapsedMenuBreakpoint,
+		overlayBreakpoint,
 	} = attributes;
 
-	const normalizedCollapsedMenuBreakpoint = normalizeCollapsedMenuBreakpoint(
-		collapsedMenuBreakpoint
-	);
-	const hasCustomCollapsedMenuBreakpointValue =
-		hasCustomCollapsedMenuBreakpoint( collapsedMenuBreakpoint );
+	const normalizedOverlayBreakpoint =
+		normalizeOverlayBreakpoint( overlayBreakpoint );
+	const hasCustomOverlayBreakpointValue =
+		overlayMenu === 'mobile' &&
+		hasCustomOverlayBreakpoint( overlayBreakpoint );
 	const ref = attributes.ref;
 	useLayoutCustomProperties( {
 		clientId,
@@ -652,8 +652,8 @@ function Navigation( {
 					backgroundColor?.slug
 				) ]: !! backgroundColor?.slug,
 				[ `has-text-decoration-${ textDecoration }` ]: textDecoration,
-				'has-custom-collapsed-menu-breakpoint':
-					isResponsive && hasCustomCollapsedMenuBreakpointValue,
+				'has-custom-overlay-breakpoint':
+					isResponsive && hasCustomOverlayBreakpointValue,
 				'block-editor-block-content-overlay': hasBlockOverlay,
 			},
 			layoutClassNames
@@ -947,9 +947,7 @@ function Navigation( {
 						isResponsive={ isResponsive }
 						currentTheme={ currentTheme }
 						hasOverlays={ hasOverlays }
-						collapsedMenuBreakpoint={
-							normalizedCollapsedMenuBreakpoint
-						}
+						overlayBreakpoint={ normalizedOverlayBreakpoint }
 					/>
 				</InspectorControls>
 			) }
@@ -1023,11 +1021,9 @@ function Navigation( {
 						overlayTextColor={ overlayTextColor }
 						overlay={ overlay }
 						onNavigateToEntityRecord={ onNavigateToEntityRecord }
-						collapsedMenuBreakpoint={
-							normalizedCollapsedMenuBreakpoint
-						}
-						hasCustomCollapsedMenuBreakpoint={
-							hasCustomCollapsedMenuBreakpointValue
+						overlayBreakpoint={ normalizedOverlayBreakpoint }
+						hasCustomOverlayBreakpoint={
+							hasCustomOverlayBreakpointValue
 						}
 					>
 						<UnsavedInnerBlocks
@@ -1198,11 +1194,11 @@ function Navigation( {
 									onNavigateToEntityRecord={
 										onNavigateToEntityRecord
 									}
-									collapsedMenuBreakpoint={
-										normalizedCollapsedMenuBreakpoint
+									overlayBreakpoint={
+										normalizedOverlayBreakpoint
 									}
-									hasCustomCollapsedMenuBreakpoint={
-										hasCustomCollapsedMenuBreakpointValue
+									hasCustomOverlayBreakpoint={
+										hasCustomOverlayBreakpointValue
 									}
 								>
 									{ isEntityAvailable && (

--- a/packages/block-library/src/navigation/edit/index.js
+++ b/packages/block-library/src/navigation/edit/index.js
@@ -68,8 +68,8 @@ import useCreateNavigationMenu from './use-create-navigation-menu';
 import { useInnerBlocks } from './use-inner-blocks';
 import {
 	detectColors,
-	hasCustomMobileBreakpoint,
-	normalizeMobileBreakpoint,
+	hasCustomCollapsedMenuBreakpoint,
+	normalizeCollapsedMenuBreakpoint,
 } from './utils';
 import ManageMenusButton from './manage-menus-button';
 import MenuInspectorControls from './menu-inspector-controls';
@@ -282,13 +282,14 @@ function Navigation( {
 		} = {},
 		hasIcon,
 		icon = 'handle',
-		mobileBreakpoint,
+		collapsedMenuBreakpoint,
 	} = attributes;
 
-	const normalizedMobileBreakpoint =
-		normalizeMobileBreakpoint( mobileBreakpoint );
-	const hasCustomMobileBreakpointValue =
-		hasCustomMobileBreakpoint( mobileBreakpoint );
+	const normalizedCollapsedMenuBreakpoint = normalizeCollapsedMenuBreakpoint(
+		collapsedMenuBreakpoint
+	);
+	const hasCustomCollapsedMenuBreakpointValue =
+		hasCustomCollapsedMenuBreakpoint( collapsedMenuBreakpoint );
 	const ref = attributes.ref;
 	useLayoutCustomProperties( {
 		clientId,
@@ -651,8 +652,8 @@ function Navigation( {
 					backgroundColor?.slug
 				) ]: !! backgroundColor?.slug,
 				[ `has-text-decoration-${ textDecoration }` ]: textDecoration,
-				'has-custom-mobile-breakpoint':
-					isResponsive && hasCustomMobileBreakpointValue,
+				'has-custom-collapsed-menu-breakpoint':
+					isResponsive && hasCustomCollapsedMenuBreakpointValue,
 				'block-editor-block-content-overlay': hasBlockOverlay,
 			},
 			layoutClassNames
@@ -946,7 +947,9 @@ function Navigation( {
 						isResponsive={ isResponsive }
 						currentTheme={ currentTheme }
 						hasOverlays={ hasOverlays }
-						mobileBreakpoint={ normalizedMobileBreakpoint }
+						collapsedMenuBreakpoint={
+							normalizedCollapsedMenuBreakpoint
+						}
 					/>
 				</InspectorControls>
 			) }
@@ -1020,9 +1023,11 @@ function Navigation( {
 						overlayTextColor={ overlayTextColor }
 						overlay={ overlay }
 						onNavigateToEntityRecord={ onNavigateToEntityRecord }
-						mobileBreakpoint={ normalizedMobileBreakpoint }
-						hasCustomMobileBreakpoint={
-							hasCustomMobileBreakpointValue
+						collapsedMenuBreakpoint={
+							normalizedCollapsedMenuBreakpoint
+						}
+						hasCustomCollapsedMenuBreakpoint={
+							hasCustomCollapsedMenuBreakpointValue
 						}
 					>
 						<UnsavedInnerBlocks
@@ -1193,11 +1198,11 @@ function Navigation( {
 									onNavigateToEntityRecord={
 										onNavigateToEntityRecord
 									}
-									mobileBreakpoint={
-										normalizedMobileBreakpoint
+									collapsedMenuBreakpoint={
+										normalizedCollapsedMenuBreakpoint
 									}
-									hasCustomMobileBreakpoint={
-										hasCustomMobileBreakpointValue
+									hasCustomCollapsedMenuBreakpoint={
+										hasCustomCollapsedMenuBreakpointValue
 									}
 								>
 									{ isEntityAvailable && (

--- a/packages/block-library/src/navigation/edit/index.js
+++ b/packages/block-library/src/navigation/edit/index.js
@@ -66,7 +66,11 @@ import useConvertClassicToBlockMenu, {
 } from './use-convert-classic-menu-to-block-menu';
 import useCreateNavigationMenu from './use-create-navigation-menu';
 import { useInnerBlocks } from './use-inner-blocks';
-import { detectColors } from './utils';
+import {
+	detectColors,
+	hasCustomMobileBreakpoint,
+	normalizeMobileBreakpoint,
+} from './utils';
 import ManageMenusButton from './manage-menus-button';
 import MenuInspectorControls from './menu-inspector-controls';
 import DeletedNavigationWarning from './deleted-navigation-warning';
@@ -278,8 +282,13 @@ function Navigation( {
 		} = {},
 		hasIcon,
 		icon = 'handle',
+		mobileBreakpoint,
 	} = attributes;
 
+	const normalizedMobileBreakpoint =
+		normalizeMobileBreakpoint( mobileBreakpoint );
+	const hasCustomMobileBreakpointValue =
+		hasCustomMobileBreakpoint( mobileBreakpoint );
 	const ref = attributes.ref;
 	useLayoutCustomProperties( {
 		clientId,
@@ -642,6 +651,8 @@ function Navigation( {
 					backgroundColor?.slug
 				) ]: !! backgroundColor?.slug,
 				[ `has-text-decoration-${ textDecoration }` ]: textDecoration,
+				'has-custom-mobile-breakpoint':
+					isResponsive && hasCustomMobileBreakpointValue,
 				'block-editor-block-content-overlay': hasBlockOverlay,
 			},
 			layoutClassNames
@@ -935,6 +946,7 @@ function Navigation( {
 						isResponsive={ isResponsive }
 						currentTheme={ currentTheme }
 						hasOverlays={ hasOverlays }
+						mobileBreakpoint={ normalizedMobileBreakpoint }
 					/>
 				</InspectorControls>
 			) }
@@ -1008,6 +1020,10 @@ function Navigation( {
 						overlayTextColor={ overlayTextColor }
 						overlay={ overlay }
 						onNavigateToEntityRecord={ onNavigateToEntityRecord }
+						mobileBreakpoint={ normalizedMobileBreakpoint }
+						hasCustomMobileBreakpoint={
+							hasCustomMobileBreakpointValue
+						}
 					>
 						<UnsavedInnerBlocks
 							createNavigationMenu={ createNavigationMenu }
@@ -1176,6 +1192,12 @@ function Navigation( {
 									overlay={ overlay }
 									onNavigateToEntityRecord={
 										onNavigateToEntityRecord
+									}
+									mobileBreakpoint={
+										normalizedMobileBreakpoint
+									}
+									hasCustomMobileBreakpoint={
+										hasCustomMobileBreakpointValue
 									}
 								>
 									{ isEntityAvailable && (

--- a/packages/block-library/src/navigation/edit/overlay-panel.js
+++ b/packages/block-library/src/navigation/edit/overlay-panel.js
@@ -7,7 +7,7 @@ import {
 	__experimentalUnitControl as UnitControl,
 } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
-import { useState } from '@wordpress/element';
+import { useEffect, useState } from '@wordpress/element';
 import { reset as resetIcon } from '@wordpress/icons';
 import { Stack } from '@wordpress/ui';
 
@@ -20,6 +20,7 @@ import OverlayMenuPreviewButton from './overlay-menu-preview-button';
 import OverlayPreview from './overlay-preview';
 import {
 	hasCustomOverlayBreakpoint,
+	isValidOverlayBreakpoint,
 	normalizeOverlayBreakpoint,
 } from './utils';
 import {
@@ -66,16 +67,47 @@ export default function OverlayPanel( {
 	const [ isCreatingOverlay, setIsCreatingOverlay ] = useState( false );
 	const normalizedOverlayBreakpoint =
 		normalizeOverlayBreakpoint( overlayBreakpoint );
+	const [ overlayBreakpointInputValue, setOverlayBreakpointInputValue ] =
+		useState( normalizedOverlayBreakpoint );
 	const hasCustomOverlayBreakpointValue =
 		hasCustomOverlayBreakpoint( overlayBreakpoint );
 
+	useEffect( () => {
+		setOverlayBreakpointInputValue( normalizedOverlayBreakpoint );
+	}, [ normalizedOverlayBreakpoint ] );
+
 	const handleOverlayBreakpointChange = ( nextValue ) => {
-		setAttributes( {
-			overlayBreakpoint: normalizeOverlayBreakpoint( nextValue ),
-		} );
+		setOverlayBreakpointInputValue( nextValue );
+
+		if ( isValidOverlayBreakpoint( nextValue ) ) {
+			setAttributes( {
+				overlayBreakpoint: normalizeOverlayBreakpoint( nextValue ),
+			} );
+		}
+	};
+
+	const commitOverlayBreakpoint = () => {
+		const nextOverlayBreakpoint = normalizeOverlayBreakpoint(
+			overlayBreakpointInputValue
+		);
+
+		setOverlayBreakpointInputValue( nextOverlayBreakpoint );
+
+		if ( nextOverlayBreakpoint !== normalizedOverlayBreakpoint ) {
+			setAttributes( {
+				overlayBreakpoint: nextOverlayBreakpoint,
+			} );
+		}
+	};
+
+	const handleOverlayBreakpointKeyDown = ( event ) => {
+		if ( event.key === 'Enter' ) {
+			commitOverlayBreakpoint();
+		}
 	};
 
 	const handleOverlayBreakpointReset = () => {
+		setOverlayBreakpointInputValue( DEFAULT_OVERLAY_BREAKPOINT );
 		setAttributes( {
 			overlayBreakpoint: DEFAULT_OVERLAY_BREAKPOINT,
 		} );
@@ -98,10 +130,12 @@ export default function OverlayPanel( {
 							isResetValueOnUnitChange
 							label={ __( 'Overlay breakpoint' ) }
 							min={ 0 }
+							onBlur={ commitOverlayBreakpoint }
 							onChange={ handleOverlayBreakpointChange }
+							onKeyDown={ handleOverlayBreakpointKeyDown }
 							step="any"
 							units={ OVERLAY_BREAKPOINT_UNITS }
-							value={ normalizedOverlayBreakpoint }
+							value={ overlayBreakpointInputValue }
 						/>
 						{ hasCustomOverlayBreakpointValue && (
 							<Button

--- a/packages/block-library/src/navigation/edit/overlay-panel.js
+++ b/packages/block-library/src/navigation/edit/overlay-panel.js
@@ -72,6 +72,8 @@ export default function OverlayPanel( {
 	const hasCustomOverlayBreakpointValue =
 		hasCustomOverlayBreakpoint( overlayBreakpoint );
 
+	// Keep the editable field in sync when the attribute changes outside direct
+	// input, while still allowing partial/invalid draft values before commit.
 	useEffect( () => {
 		setOverlayBreakpointInputValue( normalizedOverlayBreakpoint );
 	}, [ normalizedOverlayBreakpoint ] );

--- a/packages/block-library/src/navigation/edit/overlay-panel.js
+++ b/packages/block-library/src/navigation/edit/overlay-panel.js
@@ -4,6 +4,7 @@
 import {
 	PanelBody,
 	__experimentalVStack as VStack,
+	__experimentalUnitControl as UnitControl,
 } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 import { useState } from '@wordpress/element';
@@ -15,6 +16,11 @@ import OverlayTemplatePartSelector from './overlay-template-part-selector';
 import OverlayVisibilityControl from './overlay-visibility-control';
 import OverlayMenuPreviewButton from './overlay-menu-preview-button';
 import OverlayPreview from './overlay-preview';
+import { normalizeMobileBreakpoint } from './utils';
+import {
+	DEFAULT_MOBILE_BREAKPOINT,
+	MOBILE_BREAKPOINT_UNITS,
+} from '../constants';
 
 /**
  * Overlay Panel component for Navigation block.
@@ -33,6 +39,7 @@ import OverlayPreview from './overlay-preview';
  * @param {boolean}  props.isResponsive              Whether overlay menu is responsive.
  * @param {string}   props.currentTheme              Current theme stylesheet name.
  * @param {boolean}  props.hasOverlays               Whether any overlay template parts exist.
+ * @param {string}   props.mobileBreakpoint          Breakpoint at which the overlay switches to desktop layout.
  * @return {React.JSX.Element}                       The overlay panel component or null if overlay is disabled.
  */
 export default function OverlayPanel( {
@@ -49,8 +56,15 @@ export default function OverlayPanel( {
 	isResponsive,
 	currentTheme,
 	hasOverlays,
+	mobileBreakpoint = DEFAULT_MOBILE_BREAKPOINT,
 } ) {
 	const [ isCreatingOverlay, setIsCreatingOverlay ] = useState( false );
+
+	const handleMobileBreakpointChange = ( nextValue ) => {
+		setAttributes( {
+			mobileBreakpoint: normalizeMobileBreakpoint( nextValue ),
+		} );
+	};
 
 	return (
 		<PanelBody title={ __( 'Overlay' ) } initialOpen>
@@ -59,6 +73,19 @@ export default function OverlayPanel( {
 					overlayMenu={ overlayMenu }
 					setAttributes={ setAttributes }
 				/>
+
+				{ overlayMenu !== 'never' && (
+					<UnitControl
+						isResetValueOnUnitChange
+						label={ __( 'Breakpoint' ) }
+						min={ 0.01 }
+						onChange={ handleMobileBreakpointChange }
+						units={ MOBILE_BREAKPOINT_UNITS }
+						value={ normalizeMobileBreakpoint(
+							mobileBreakpoint
+						) }
+					/>
+				) }
 
 				{ overlayMenu !== 'never' && (
 					<OverlayMenuPreviewButton

--- a/packages/block-library/src/navigation/edit/overlay-panel.js
+++ b/packages/block-library/src/navigation/edit/overlay-panel.js
@@ -2,12 +2,14 @@
  * WordPress dependencies
  */
 import {
+	Button,
 	PanelBody,
-	__experimentalVStack as VStack,
 	__experimentalUnitControl as UnitControl,
 } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 import { useState } from '@wordpress/element';
+import { reset as resetIcon } from '@wordpress/icons';
+import { Stack } from '@wordpress/ui';
 
 /**
  * Internal dependencies
@@ -16,10 +18,13 @@ import OverlayTemplatePartSelector from './overlay-template-part-selector';
 import OverlayVisibilityControl from './overlay-visibility-control';
 import OverlayMenuPreviewButton from './overlay-menu-preview-button';
 import OverlayPreview from './overlay-preview';
-import { normalizeCollapsedMenuBreakpoint } from './utils';
 import {
-	DEFAULT_COLLAPSED_MENU_BREAKPOINT,
-	COLLAPSED_MENU_BREAKPOINT_UNITS,
+	hasCustomOverlayBreakpoint,
+	normalizeOverlayBreakpoint,
+} from './utils';
+import {
+	DEFAULT_OVERLAY_BREAKPOINT,
+	OVERLAY_BREAKPOINT_UNITS,
 } from '../constants';
 
 /**
@@ -39,7 +44,7 @@ import {
  * @param {boolean}  props.isResponsive              Whether overlay menu is responsive.
  * @param {string}   props.currentTheme              Current theme stylesheet name.
  * @param {boolean}  props.hasOverlays               Whether any overlay template parts exist.
- * @param {string}   props.collapsedMenuBreakpoint   Breakpoint at which the overlay switches to inline layout.
+ * @param {string}   props.overlayBreakpoint         Breakpoint at which the overlay switches to inline layout.
  * @return {React.JSX.Element}                       The overlay panel component or null if overlay is disabled.
  */
 export default function OverlayPanel( {
@@ -56,40 +61,58 @@ export default function OverlayPanel( {
 	isResponsive,
 	currentTheme,
 	hasOverlays,
-	collapsedMenuBreakpoint = DEFAULT_COLLAPSED_MENU_BREAKPOINT,
+	overlayBreakpoint = DEFAULT_OVERLAY_BREAKPOINT,
 } ) {
 	const [ isCreatingOverlay, setIsCreatingOverlay ] = useState( false );
+	const normalizedOverlayBreakpoint =
+		normalizeOverlayBreakpoint( overlayBreakpoint );
+	const hasCustomOverlayBreakpointValue =
+		hasCustomOverlayBreakpoint( overlayBreakpoint );
 
-	const handleCollapsedMenuBreakpointChange = ( nextValue ) => {
+	const handleOverlayBreakpointChange = ( nextValue ) => {
 		setAttributes( {
-			collapsedMenuBreakpoint:
-				normalizeCollapsedMenuBreakpoint( nextValue ),
+			overlayBreakpoint: normalizeOverlayBreakpoint( nextValue ),
+		} );
+	};
+
+	const handleOverlayBreakpointReset = () => {
+		setAttributes( {
+			overlayBreakpoint: DEFAULT_OVERLAY_BREAKPOINT,
 		} );
 	};
 
 	return (
 		<PanelBody title={ __( 'Overlay' ) } initialOpen>
-			<VStack spacing={ 4 }>
+			<Stack direction="column" gap="lg">
 				<OverlayVisibilityControl
 					overlayMenu={ overlayMenu }
 					setAttributes={ setAttributes }
 				/>
 
-				{ overlayMenu !== 'never' && (
-					<UnitControl
-						help={ __(
-							'Below this width, the navigation is collapsed behind a menu button. At this width and wider, links are shown inline.'
+				{ overlayMenu === 'mobile' && (
+					<Stack direction="row" gap="sm" align="flex-start">
+						<UnitControl
+							help={ __(
+								'Sets the width where navigation items switch from collapsed to inline.'
+							) }
+							isResetValueOnUnitChange
+							label={ __( 'Overlay breakpoint' ) }
+							min={ 0 }
+							onChange={ handleOverlayBreakpointChange }
+							step="any"
+							units={ OVERLAY_BREAKPOINT_UNITS }
+							value={ normalizedOverlayBreakpoint }
+						/>
+						{ hasCustomOverlayBreakpointValue && (
+							<Button
+								__next40pxDefaultSize
+								icon={ resetIcon }
+								label={ __( 'Reset overlay breakpoint' ) }
+								onClick={ handleOverlayBreakpointReset }
+								size="small"
+							/>
 						) }
-						isResetValueOnUnitChange
-						label={ __( 'Breakpoint' ) }
-						min={ 0 }
-						onChange={ handleCollapsedMenuBreakpointChange }
-						step="any"
-						units={ COLLAPSED_MENU_BREAKPOINT_UNITS }
-						value={ normalizeCollapsedMenuBreakpoint(
-							collapsedMenuBreakpoint
-						) }
-					/>
+					</Stack>
 				) }
 
 				{ overlayMenu !== 'never' && (
@@ -125,7 +148,7 @@ export default function OverlayPanel( {
 							currentTheme={ currentTheme }
 						/>
 					) }
-			</VStack>
+			</Stack>
 		</PanelBody>
 	);
 }

--- a/packages/block-library/src/navigation/edit/overlay-panel.js
+++ b/packages/block-library/src/navigation/edit/overlay-panel.js
@@ -16,10 +16,10 @@ import OverlayTemplatePartSelector from './overlay-template-part-selector';
 import OverlayVisibilityControl from './overlay-visibility-control';
 import OverlayMenuPreviewButton from './overlay-menu-preview-button';
 import OverlayPreview from './overlay-preview';
-import { normalizeMobileBreakpoint } from './utils';
+import { normalizeCollapsedMenuBreakpoint } from './utils';
 import {
-	DEFAULT_MOBILE_BREAKPOINT,
-	MOBILE_BREAKPOINT_UNITS,
+	DEFAULT_COLLAPSED_MENU_BREAKPOINT,
+	COLLAPSED_MENU_BREAKPOINT_UNITS,
 } from '../constants';
 
 /**
@@ -39,7 +39,7 @@ import {
  * @param {boolean}  props.isResponsive              Whether overlay menu is responsive.
  * @param {string}   props.currentTheme              Current theme stylesheet name.
  * @param {boolean}  props.hasOverlays               Whether any overlay template parts exist.
- * @param {string}   props.mobileBreakpoint          Breakpoint at which the overlay switches to desktop layout.
+ * @param {string}   props.collapsedMenuBreakpoint   Breakpoint at which the overlay switches to inline layout.
  * @return {React.JSX.Element}                       The overlay panel component or null if overlay is disabled.
  */
 export default function OverlayPanel( {
@@ -56,13 +56,14 @@ export default function OverlayPanel( {
 	isResponsive,
 	currentTheme,
 	hasOverlays,
-	mobileBreakpoint = DEFAULT_MOBILE_BREAKPOINT,
+	collapsedMenuBreakpoint = DEFAULT_COLLAPSED_MENU_BREAKPOINT,
 } ) {
 	const [ isCreatingOverlay, setIsCreatingOverlay ] = useState( false );
 
-	const handleMobileBreakpointChange = ( nextValue ) => {
+	const handleCollapsedMenuBreakpointChange = ( nextValue ) => {
 		setAttributes( {
-			mobileBreakpoint: normalizeMobileBreakpoint( nextValue ),
+			collapsedMenuBreakpoint:
+				normalizeCollapsedMenuBreakpoint( nextValue ),
 		} );
 	};
 
@@ -76,13 +77,17 @@ export default function OverlayPanel( {
 
 				{ overlayMenu !== 'never' && (
 					<UnitControl
+						help={ __(
+							'Below this width, the navigation is collapsed behind a menu button. At this width and wider, links are shown inline.'
+						) }
 						isResetValueOnUnitChange
 						label={ __( 'Breakpoint' ) }
-						min={ 0.01 }
-						onChange={ handleMobileBreakpointChange }
-						units={ MOBILE_BREAKPOINT_UNITS }
-						value={ normalizeMobileBreakpoint(
-							mobileBreakpoint
+						min={ 0 }
+						onChange={ handleCollapsedMenuBreakpointChange }
+						step="any"
+						units={ COLLAPSED_MENU_BREAKPOINT_UNITS }
+						value={ normalizeCollapsedMenuBreakpoint(
+							collapsedMenuBreakpoint
 						) }
 					/>
 				) }

--- a/packages/block-library/src/navigation/edit/overlay-visibility-control.js
+++ b/packages/block-library/src/navigation/edit/overlay-visibility-control.js
@@ -25,7 +25,7 @@ export default function OverlayVisibilityControl( {
 			aria-label={ __( 'Configure overlay visibility' ) }
 			value={ overlayMenu }
 			help={ __(
-				'Collapses the navigation options in a menu icon opening an overlay.'
+				'Collapses the navigation items behind a menu button that opens an overlay.'
 			) }
 			onChange={ ( value ) => setAttributes( { overlayMenu: value } ) }
 			isBlock

--- a/packages/block-library/src/navigation/edit/responsive-wrapper.js
+++ b/packages/block-library/src/navigation/edit/responsive-wrapper.js
@@ -10,6 +10,7 @@ import { close, Icon } from '@wordpress/icons';
 import { Button } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 import { getColorClassName } from '@wordpress/block-editor';
+import { useMediaQuery } from '@wordpress/compose';
 
 /**
  * Internal dependencies
@@ -27,7 +28,14 @@ export default function ResponsiveWrapper( {
 	overlayTextColor,
 	hasIcon,
 	icon,
+	mobileBreakpoint,
 } ) {
+	const isMobileBreakPoint = useMediaQuery(
+		`(max-width: ${ mobileBreakpoint })`
+	);
+
+	console.log( { mobileBreakpoint, isMobileBreakPoint } );
+
 	if ( ! isResponsive ) {
 		return children;
 	}
@@ -48,6 +56,7 @@ export default function ResponsiveWrapper( {
 			) ]: !! overlayBackgroundColor?.slug,
 			'is-menu-open': isOpen,
 			'hidden-by-default': isHiddenByDefault,
+			'is-mobile-breakpoint': isMobileBreakPoint,
 		}
 	);
 
@@ -61,7 +70,10 @@ export default function ResponsiveWrapper( {
 
 	const openButtonClasses = classnames(
 		'wp-block-navigation__responsive-container-open',
-		{ 'always-shown': isHiddenByDefault }
+		{
+			'always-shown': isHiddenByDefault,
+			'is-mobile-breakpoint': isMobileBreakPoint,
+		}
 	);
 
 	const modalId = `${ id }-modal`;

--- a/packages/block-library/src/navigation/edit/responsive-wrapper.js
+++ b/packages/block-library/src/navigation/edit/responsive-wrapper.js
@@ -19,7 +19,7 @@ import { useMediaQuery } from '@wordpress/compose';
  */
 import OverlayMenuIcon from './overlay-menu-icon';
 import { createTemplatePartId } from '../../template-part/edit/utils/create-template-part-id';
-import { DEFAULT_MOBILE_BREAKPOINT } from '../constants';
+import { DEFAULT_COLLAPSED_MENU_BREAKPOINT } from '../constants';
 
 export default function ResponsiveWrapper( {
 	children,
@@ -34,15 +34,15 @@ export default function ResponsiveWrapper( {
 	icon,
 	overlay,
 	onNavigateToEntityRecord,
-	mobileBreakpoint = DEFAULT_MOBILE_BREAKPOINT,
-	hasCustomMobileBreakpoint = false,
+	collapsedMenuBreakpoint = DEFAULT_COLLAPSED_MENU_BREAKPOINT,
+	hasCustomCollapsedMenuBreakpoint = false,
 } ) {
 	const currentTheme = useSelect(
 		( select ) => select( coreStore ).getCurrentTheme()?.stylesheet,
 		[]
 	);
-	const isCustomMobileBreakpointDesktop = useMediaQuery(
-		`(min-width: ${ mobileBreakpoint })`
+	const isCustomCollapsedMenuBreakpointInline = useMediaQuery(
+		`(min-width: ${ collapsedMenuBreakpoint })`
 	);
 
 	if ( ! isResponsive ) {
@@ -51,8 +51,9 @@ export default function ResponsiveWrapper( {
 
 	// Only apply overlay colors if there's no custom overlay template part.
 	const hasCustomOverlay = !! overlay;
-	const shouldUseDesktopLayout =
-		hasCustomMobileBreakpoint && isCustomMobileBreakpointDesktop;
+	const shouldUseInlineLayout =
+		hasCustomCollapsedMenuBreakpoint &&
+		isCustomCollapsedMenuBreakpointInline;
 
 	const responsiveContainerClasses = clsx(
 		'wp-block-navigation__responsive-container',
@@ -72,7 +73,7 @@ export default function ResponsiveWrapper( {
 		{
 			'is-menu-open': isOpen,
 			'hidden-by-default': isHiddenByDefault,
-			'is-custom-mobile-breakpoint-desktop': shouldUseDesktopLayout,
+			'is-custom-collapsed-menu-breakpoint-inline': shouldUseInlineLayout,
 		}
 	);
 
@@ -90,7 +91,7 @@ export default function ResponsiveWrapper( {
 		'wp-block-navigation__responsive-container-open',
 		{
 			'always-shown': isHiddenByDefault,
-			'is-custom-mobile-breakpoint-desktop': shouldUseDesktopLayout,
+			'is-custom-collapsed-menu-breakpoint-inline': shouldUseInlineLayout,
 		}
 	);
 

--- a/packages/block-library/src/navigation/edit/responsive-wrapper.js
+++ b/packages/block-library/src/navigation/edit/responsive-wrapper.js
@@ -19,7 +19,7 @@ import { useMediaQuery } from '@wordpress/compose';
  */
 import OverlayMenuIcon from './overlay-menu-icon';
 import { createTemplatePartId } from '../../template-part/edit/utils/create-template-part-id';
-import { DEFAULT_COLLAPSED_MENU_BREAKPOINT } from '../constants';
+import { DEFAULT_OVERLAY_BREAKPOINT } from '../constants';
 
 export default function ResponsiveWrapper( {
 	children,
@@ -34,15 +34,15 @@ export default function ResponsiveWrapper( {
 	icon,
 	overlay,
 	onNavigateToEntityRecord,
-	collapsedMenuBreakpoint = DEFAULT_COLLAPSED_MENU_BREAKPOINT,
-	hasCustomCollapsedMenuBreakpoint = false,
+	overlayBreakpoint = DEFAULT_OVERLAY_BREAKPOINT,
+	hasCustomOverlayBreakpoint = false,
 } ) {
 	const currentTheme = useSelect(
 		( select ) => select( coreStore ).getCurrentTheme()?.stylesheet,
 		[]
 	);
-	const isCustomCollapsedMenuBreakpointInline = useMediaQuery(
-		`(min-width: ${ collapsedMenuBreakpoint })`
+	const isCustomOverlayBreakpointInline = useMediaQuery(
+		`(min-width: ${ overlayBreakpoint })`
 	);
 
 	if ( ! isResponsive ) {
@@ -52,8 +52,7 @@ export default function ResponsiveWrapper( {
 	// Only apply overlay colors if there's no custom overlay template part.
 	const hasCustomOverlay = !! overlay;
 	const shouldUseInlineLayout =
-		hasCustomCollapsedMenuBreakpoint &&
-		isCustomCollapsedMenuBreakpointInline;
+		hasCustomOverlayBreakpoint && isCustomOverlayBreakpointInline;
 
 	const responsiveContainerClasses = clsx(
 		'wp-block-navigation__responsive-container',
@@ -73,7 +72,7 @@ export default function ResponsiveWrapper( {
 		{
 			'is-menu-open': isOpen,
 			'hidden-by-default': isHiddenByDefault,
-			'is-custom-collapsed-menu-breakpoint-inline': shouldUseInlineLayout,
+			'is-custom-overlay-breakpoint-inline': shouldUseInlineLayout,
 		}
 	);
 
@@ -91,7 +90,7 @@ export default function ResponsiveWrapper( {
 		'wp-block-navigation__responsive-container-open',
 		{
 			'always-shown': isHiddenByDefault,
-			'is-custom-collapsed-menu-breakpoint-inline': shouldUseInlineLayout,
+			'is-custom-overlay-breakpoint-inline': shouldUseInlineLayout,
 		}
 	);
 

--- a/packages/block-library/src/navigation/edit/responsive-wrapper.js
+++ b/packages/block-library/src/navigation/edit/responsive-wrapper.js
@@ -12,12 +12,14 @@ import { __ } from '@wordpress/i18n';
 import { getColorClassName } from '@wordpress/block-editor';
 import { useSelect } from '@wordpress/data';
 import { store as coreStore } from '@wordpress/core-data';
+import { useMediaQuery } from '@wordpress/compose';
 
 /**
  * Internal dependencies
  */
 import OverlayMenuIcon from './overlay-menu-icon';
 import { createTemplatePartId } from '../../template-part/edit/utils/create-template-part-id';
+import { DEFAULT_MOBILE_BREAKPOINT } from '../constants';
 
 export default function ResponsiveWrapper( {
 	children,
@@ -32,10 +34,15 @@ export default function ResponsiveWrapper( {
 	icon,
 	overlay,
 	onNavigateToEntityRecord,
+	mobileBreakpoint = DEFAULT_MOBILE_BREAKPOINT,
+	hasCustomMobileBreakpoint = false,
 } ) {
 	const currentTheme = useSelect(
 		( select ) => select( coreStore ).getCurrentTheme()?.stylesheet,
 		[]
+	);
+	const isCustomMobileBreakpointDesktop = useMediaQuery(
+		`(min-width: ${ mobileBreakpoint })`
 	);
 
 	if ( ! isResponsive ) {
@@ -44,6 +51,8 @@ export default function ResponsiveWrapper( {
 
 	// Only apply overlay colors if there's no custom overlay template part.
 	const hasCustomOverlay = !! overlay;
+	const shouldUseDesktopLayout =
+		hasCustomMobileBreakpoint && isCustomMobileBreakpointDesktop;
 
 	const responsiveContainerClasses = clsx(
 		'wp-block-navigation__responsive-container',
@@ -63,6 +72,7 @@ export default function ResponsiveWrapper( {
 		{
 			'is-menu-open': isOpen,
 			'hidden-by-default': isHiddenByDefault,
+			'is-custom-mobile-breakpoint-desktop': shouldUseDesktopLayout,
 		}
 	);
 
@@ -78,7 +88,10 @@ export default function ResponsiveWrapper( {
 
 	const openButtonClasses = clsx(
 		'wp-block-navigation__responsive-container-open',
-		{ 'always-shown': isHiddenByDefault }
+		{
+			'always-shown': isHiddenByDefault,
+			'is-custom-mobile-breakpoint-desktop': shouldUseDesktopLayout,
+		}
 	);
 
 	const modalId = `${ id }-modal`;

--- a/packages/block-library/src/navigation/edit/test/overlay-panel.js
+++ b/packages/block-library/src/navigation/edit/test/overlay-panel.js
@@ -14,10 +14,14 @@ import { __experimentalUnitControl as UnitControl } from '@wordpress/components'
 import OverlayPanel from '../overlay-panel';
 
 jest.mock( '@wordpress/components', () => ( {
+	Button: jest.fn( ( { label, onClick } ) => (
+		<button aria-label={ label } onClick={ onClick } type="button">
+			{ label }
+		</button>
+	) ),
 	PanelBody: ( { children, title } ) => (
 		<section aria-label={ title }>{ children }</section>
 	),
-	__experimentalVStack: ( { children } ) => <div>{ children }</div>,
 	__experimentalUnitControl: jest.fn(
 		( { help, label, onChange, value } ) => (
 			<div>
@@ -30,6 +34,10 @@ jest.mock( '@wordpress/components', () => ( {
 			</div>
 		)
 	),
+} ) );
+
+jest.mock( '@wordpress/ui', () => ( {
+	Stack: ( { children } ) => <div>{ children }</div>,
 } ) );
 
 jest.mock( '../overlay-template-part-selector', () => () => null );
@@ -52,7 +60,7 @@ describe( 'OverlayPanel', () => {
 		isResponsive: true,
 		currentTheme: 'twentytwentyfive',
 		hasOverlays: false,
-		collapsedMenuBreakpoint: '10px',
+		overlayBreakpoint: '10px',
 	};
 
 	beforeEach( () => {
@@ -64,31 +72,72 @@ describe( 'OverlayPanel', () => {
 
 		expect( UnitControl.mock.calls[ 0 ][ 0 ] ).toEqual(
 			expect.objectContaining( {
-				help: 'Below this width, the navigation is collapsed behind a menu button. At this width and wider, links are shown inline.',
+				help: 'Sets the width where navigation items switch from collapsed to inline.',
+				label: 'Overlay breakpoint',
 				min: 0,
 				step: 'any',
 				value: '10px',
 			} )
 		);
 
-		fireEvent.change( screen.getByLabelText( 'Breakpoint' ), {
+		fireEvent.change( screen.getByLabelText( 'Overlay breakpoint' ), {
 			target: { value: '37.5rem' },
 		} );
 
 		expect( defaultProps.setAttributes ).toHaveBeenLastCalledWith( {
-			collapsedMenuBreakpoint: '37.5rem',
+			overlayBreakpoint: '37.5rem',
 		} );
 	} );
 
 	it( 'falls back to the default breakpoint for invalid values', () => {
 		render( <OverlayPanel { ...defaultProps } /> );
 
-		fireEvent.change( screen.getByLabelText( 'Breakpoint' ), {
+		fireEvent.change( screen.getByLabelText( 'Overlay breakpoint' ), {
 			target: { value: '0px' },
 		} );
 
 		expect( defaultProps.setAttributes ).toHaveBeenLastCalledWith( {
-			collapsedMenuBreakpoint: '600px',
+			overlayBreakpoint: '600px',
 		} );
+	} );
+
+	it.each( [ 'never', 'always' ] )(
+		'hides the overlay breakpoint control when overlay visibility is %s',
+		( overlayMenu ) => {
+			render(
+				<OverlayPanel { ...defaultProps } overlayMenu={ overlayMenu } />
+			);
+
+			expect(
+				screen.queryByLabelText( 'Overlay breakpoint' )
+			).not.toBeInTheDocument();
+			expect( UnitControl ).not.toHaveBeenCalled();
+		}
+	);
+
+	it( 'resets the breakpoint to the default value and unit', () => {
+		render( <OverlayPanel { ...defaultProps } /> );
+
+		fireEvent.click(
+			screen.getByRole( 'button', {
+				name: 'Reset overlay breakpoint',
+			} )
+		);
+
+		expect( defaultProps.setAttributes ).toHaveBeenLastCalledWith( {
+			overlayBreakpoint: '600px',
+		} );
+	} );
+
+	it( 'does not show the reset button for the default breakpoint', () => {
+		render(
+			<OverlayPanel { ...defaultProps } overlayBreakpoint="600px" />
+		);
+
+		expect(
+			screen.queryByRole( 'button', {
+				name: 'Reset overlay breakpoint',
+			} )
+		).not.toBeInTheDocument();
 	} );
 } );

--- a/packages/block-library/src/navigation/edit/test/overlay-panel.js
+++ b/packages/block-library/src/navigation/edit/test/overlay-panel.js
@@ -1,0 +1,94 @@
+/**
+ * External dependencies
+ */
+import { fireEvent, render, screen } from '@testing-library/react';
+
+/**
+ * WordPress dependencies
+ */
+import { __experimentalUnitControl as UnitControl } from '@wordpress/components';
+
+/**
+ * Internal dependencies
+ */
+import OverlayPanel from '../overlay-panel';
+
+jest.mock( '@wordpress/components', () => ( {
+	PanelBody: ( { children, title } ) => (
+		<section aria-label={ title }>{ children }</section>
+	),
+	__experimentalVStack: ( { children } ) => <div>{ children }</div>,
+	__experimentalUnitControl: jest.fn(
+		( { help, label, onChange, value } ) => (
+			<div>
+				<input
+					aria-label={ label }
+					onChange={ ( event ) => onChange( event.target.value ) }
+					value={ value }
+				/>
+				<span>{ help }</span>
+			</div>
+		)
+	),
+} ) );
+
+jest.mock( '../overlay-template-part-selector', () => () => null );
+jest.mock( '../overlay-visibility-control', () => () => null );
+jest.mock( '../overlay-menu-preview-button', () => () => null );
+jest.mock( '../overlay-preview', () => () => null );
+
+describe( 'OverlayPanel', () => {
+	const defaultProps = {
+		overlayMenu: 'mobile',
+		overlay: undefined,
+		setAttributes: jest.fn(),
+		onNavigateToEntityRecord: jest.fn(),
+		overlayMenuPreview: false,
+		setOverlayMenuPreview: jest.fn(),
+		hasIcon: true,
+		icon: 'menu',
+		overlayMenuPreviewClasses: '',
+		overlayMenuPreviewId: 'test-preview',
+		isResponsive: true,
+		currentTheme: 'twentytwentyfive',
+		hasOverlays: false,
+		collapsedMenuBreakpoint: '10px',
+	};
+
+	beforeEach( () => {
+		jest.clearAllMocks();
+	} );
+
+	it( 'explains the breakpoint and allows decimal values for all supported units', () => {
+		render( <OverlayPanel { ...defaultProps } /> );
+
+		expect( UnitControl.mock.calls[ 0 ][ 0 ] ).toEqual(
+			expect.objectContaining( {
+				help: 'Below this width, the navigation is collapsed behind a menu button. At this width and wider, links are shown inline.',
+				min: 0,
+				step: 'any',
+				value: '10px',
+			} )
+		);
+
+		fireEvent.change( screen.getByLabelText( 'Breakpoint' ), {
+			target: { value: '37.5rem' },
+		} );
+
+		expect( defaultProps.setAttributes ).toHaveBeenLastCalledWith( {
+			collapsedMenuBreakpoint: '37.5rem',
+		} );
+	} );
+
+	it( 'falls back to the default breakpoint for invalid values', () => {
+		render( <OverlayPanel { ...defaultProps } /> );
+
+		fireEvent.change( screen.getByLabelText( 'Breakpoint' ), {
+			target: { value: '0px' },
+		} );
+
+		expect( defaultProps.setAttributes ).toHaveBeenLastCalledWith( {
+			collapsedMenuBreakpoint: '600px',
+		} );
+	} );
+} );

--- a/packages/block-library/src/navigation/edit/test/overlay-panel.js
+++ b/packages/block-library/src/navigation/edit/test/overlay-panel.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { fireEvent, render, screen } from '@testing-library/react';
+import { createEvent, fireEvent, render, screen } from '@testing-library/react';
 
 /**
  * WordPress dependencies
@@ -23,11 +23,13 @@ jest.mock( '@wordpress/components', () => ( {
 		<section aria-label={ title }>{ children }</section>
 	),
 	__experimentalUnitControl: jest.fn(
-		( { help, label, onChange, value } ) => (
+		( { help, label, onBlur, onChange, onKeyDown, value } ) => (
 			<div>
 				<input
 					aria-label={ label }
+					onBlur={ onBlur }
 					onChange={ ( event ) => onChange( event.target.value ) }
+					onKeyDown={ onKeyDown }
 					value={ value }
 				/>
 				<span>{ help }</span>
@@ -89,11 +91,101 @@ describe( 'OverlayPanel', () => {
 		} );
 	} );
 
-	it( 'falls back to the default breakpoint for invalid values', () => {
+	it( 'does not commit empty or partial values while editing', () => {
+		render( <OverlayPanel { ...defaultProps } /> );
+
+		fireEvent.change( screen.getByLabelText( 'Overlay breakpoint' ), {
+			target: { value: '' },
+		} );
+
+		fireEvent.change( screen.getByLabelText( 'Overlay breakpoint' ), {
+			target: { value: '37.' },
+		} );
+
+		expect( defaultProps.setAttributes ).not.toHaveBeenCalled();
+		expect( screen.getByLabelText( 'Overlay breakpoint' ) ).toHaveValue(
+			'37.'
+		);
+	} );
+
+	// Follow-up: validation UI is intentionally out of scope for this PR.
+	// This skipped test documents the desired hardening without expanding the
+	// current review beyond the Copilot snap-back fix.
+	// eslint-disable-next-line jest/no-disabled-tests
+	it.skip( 'marks invalid typed values as invalid without saving or normalizing them', () => {
 		render( <OverlayPanel { ...defaultProps } /> );
 
 		fireEvent.change( screen.getByLabelText( 'Overlay breakpoint' ), {
 			target: { value: '0px' },
+		} );
+		fireEvent.blur( screen.getByLabelText( 'Overlay breakpoint' ) );
+
+		expect( defaultProps.setAttributes ).not.toHaveBeenCalled();
+		expect( screen.getByLabelText( 'Overlay breakpoint' ) ).toHaveValue(
+			'0px'
+		);
+		expect(
+			screen.getByText(
+				'Enter a positive breakpoint using px, em, or rem.'
+			)
+		).toBeVisible();
+	} );
+
+	// Follow-up: paste handling needs a dedicated validation implementation.
+	// Invalid pasted values should leave the field value untouched, show an
+	// error, and avoid applying the value to block attributes.
+	// eslint-disable-next-line jest/no-disabled-tests
+	it.skip( 'marks invalid pasted values as invalid without changing the field value', () => {
+		render( <OverlayPanel { ...defaultProps } /> );
+
+		const input = screen.getByLabelText( 'Overlay breakpoint' );
+		const pasteEvent = createEvent.paste( input, {
+			clipboardData: {
+				getData: () => 'not a number',
+			},
+		} );
+
+		fireEvent( input, pasteEvent );
+
+		expect( pasteEvent.defaultPrevented ).toBe( true );
+		expect( input ).toHaveValue( '10px' );
+		expect( defaultProps.setAttributes ).not.toHaveBeenCalled();
+		expect(
+			screen.getByText(
+				'Enter a positive breakpoint using px, em, or rem.'
+			)
+		).toBeVisible();
+	} );
+
+	// Follow-up: keyboard filtering should be considered alongside the final
+	// validation UI so unsupported characters are handled consistently.
+	// eslint-disable-next-line jest/no-disabled-tests
+	it.skip( 'marks negative breakpoint input as invalid', () => {
+		render( <OverlayPanel { ...defaultProps } /> );
+
+		const input = screen.getByLabelText( 'Overlay breakpoint' );
+		const keyDownEvent = createEvent.keyDown( input, {
+			key: '-',
+		} );
+
+		fireEvent( input, keyDownEvent );
+
+		expect( keyDownEvent.defaultPrevented ).toBe( true );
+		expect(
+			screen.getByText(
+				'Enter a positive breakpoint using px, em, or rem.'
+			)
+		).toBeVisible();
+	} );
+
+	it( 'falls back to the default breakpoint for empty values on Enter', () => {
+		render( <OverlayPanel { ...defaultProps } /> );
+
+		fireEvent.change( screen.getByLabelText( 'Overlay breakpoint' ), {
+			target: { value: '' },
+		} );
+		fireEvent.keyDown( screen.getByLabelText( 'Overlay breakpoint' ), {
+			key: 'Enter',
 		} );
 
 		expect( defaultProps.setAttributes ).toHaveBeenLastCalledWith( {

--- a/packages/block-library/src/navigation/edit/test/responsive-wrapper.js
+++ b/packages/block-library/src/navigation/edit/test/responsive-wrapper.js
@@ -20,6 +20,27 @@ jest.mock( '@wordpress/block-editor', () => ( {
 	getColorClassName: jest.fn( () => '' ),
 } ) );
 
+jest.mock( '@wordpress/components', () => ( {
+	Button: ( { children, className, onClick, ...props } ) => {
+		const buttonProps = Object.fromEntries(
+			Object.entries( props ).filter(
+				( [ key, value ] ) =>
+					key !== '__next40pxDefaultSize' && value !== false
+			)
+		);
+
+		return (
+			<button
+				className={ className }
+				onClick={ onClick }
+				{ ...buttonProps }
+			>
+				{ children }
+			</button>
+		);
+	},
+} ) );
+
 jest.mock( '@wordpress/compose', () => ( {
 	useMediaQuery: jest.fn(),
 } ) );
@@ -48,6 +69,12 @@ jest.mock( '@wordpress/data', () => ( {
 describe( 'ResponsiveWrapper', () => {
 	const mockOnToggle = jest.fn();
 	const mockOnNavigateToEntityRecord = jest.fn();
+	const getResponsiveContainer = () => {
+		// eslint-disable-next-line testing-library/no-node-access
+		return document.querySelector(
+			'.wp-block-navigation__responsive-container'
+		);
+	};
 
 	const defaultProps = {
 		id: 'test-navigation',
@@ -81,14 +108,14 @@ describe( 'ResponsiveWrapper', () => {
 		} );
 	} );
 
-	describe( 'Custom mobile breakpoints', () => {
-		it( 'preserves the default breakpoint behavior without desktop state classes', () => {
+	describe( 'Custom collapsed menu breakpoints', () => {
+		it( 'preserves the default breakpoint behavior without inline state classes', () => {
 			useMediaQuery.mockReturnValue( true );
 
 			render(
 				<ResponsiveWrapper
 					{ ...defaultProps }
-					mobileBreakpoint="600px"
+					collapsedMenuBreakpoint="600px"
 				/>
 			);
 
@@ -97,57 +124,54 @@ describe( 'ResponsiveWrapper', () => {
 			);
 			expect(
 				screen.getByRole( 'button', { name: 'Menu' } )
-			).not.toHaveClass( 'is-custom-mobile-breakpoint-desktop' );
-			expect(
-				document.querySelector(
-					'.wp-block-navigation__responsive-container'
-				)
-			).not.toHaveClass( 'is-custom-mobile-breakpoint-desktop' );
+			).not.toHaveClass( 'is-custom-collapsed-menu-breakpoint-inline' );
+			expect( getResponsiveContainer() ).not.toHaveClass(
+				'is-custom-collapsed-menu-breakpoint-inline'
+			);
 		} );
 
-		it( 'adds desktop state classes when the custom breakpoint matches', () => {
-			useMediaQuery.mockReturnValue( true );
+		it.each( [ '10px', '37.5em', '48rem' ] )(
+			'adds inline state classes when the custom %s breakpoint matches',
+			( collapsedMenuBreakpoint ) => {
+				useMediaQuery.mockReturnValue( true );
 
-			render(
-				<ResponsiveWrapper
-					{ ...defaultProps }
-					mobileBreakpoint="48rem"
-					hasCustomMobileBreakpoint
-				/>
-			);
+				render(
+					<ResponsiveWrapper
+						{ ...defaultProps }
+						collapsedMenuBreakpoint={ collapsedMenuBreakpoint }
+						hasCustomCollapsedMenuBreakpoint
+					/>
+				);
 
-			expect( useMediaQuery ).toHaveBeenCalledWith(
-				'(min-width: 48rem)'
-			);
-			expect(
-				screen.getByRole( 'button', { name: 'Menu' } )
-			).toHaveClass( 'is-custom-mobile-breakpoint-desktop' );
-			expect(
-				document.querySelector(
-					'.wp-block-navigation__responsive-container'
-				)
-			).toHaveClass( 'is-custom-mobile-breakpoint-desktop' );
-		} );
+				expect( useMediaQuery ).toHaveBeenCalledWith(
+					`(min-width: ${ collapsedMenuBreakpoint })`
+				);
+				expect(
+					screen.getByRole( 'button', { name: 'Menu' } )
+				).toHaveClass( 'is-custom-collapsed-menu-breakpoint-inline' );
+				expect( getResponsiveContainer() ).toHaveClass(
+					'is-custom-collapsed-menu-breakpoint-inline'
+				);
+			}
+		);
 
-		it( 'keeps mobile state classes when the custom breakpoint does not match', () => {
+		it( 'keeps collapsed state classes when the custom breakpoint does not match', () => {
 			useMediaQuery.mockReturnValue( false );
 
 			render(
 				<ResponsiveWrapper
 					{ ...defaultProps }
-					mobileBreakpoint="48rem"
-					hasCustomMobileBreakpoint
+					collapsedMenuBreakpoint="48rem"
+					hasCustomCollapsedMenuBreakpoint
 				/>
 			);
 
 			expect(
 				screen.getByRole( 'button', { name: 'Menu' } )
-			).not.toHaveClass( 'is-custom-mobile-breakpoint-desktop' );
-			expect(
-				document.querySelector(
-					'.wp-block-navigation__responsive-container'
-				)
-			).not.toHaveClass( 'is-custom-mobile-breakpoint-desktop' );
+			).not.toHaveClass( 'is-custom-collapsed-menu-breakpoint-inline' );
+			expect( getResponsiveContainer() ).not.toHaveClass(
+				'is-custom-collapsed-menu-breakpoint-inline'
+			);
 		} );
 	} );
 

--- a/packages/block-library/src/navigation/edit/test/responsive-wrapper.js
+++ b/packages/block-library/src/navigation/edit/test/responsive-wrapper.js
@@ -108,14 +108,14 @@ describe( 'ResponsiveWrapper', () => {
 		} );
 	} );
 
-	describe( 'Custom collapsed menu breakpoints', () => {
+	describe( 'Custom overlay breakpoints', () => {
 		it( 'preserves the default breakpoint behavior without inline state classes', () => {
 			useMediaQuery.mockReturnValue( true );
 
 			render(
 				<ResponsiveWrapper
 					{ ...defaultProps }
-					collapsedMenuBreakpoint="600px"
+					overlayBreakpoint="600px"
 				/>
 			);
 
@@ -124,33 +124,33 @@ describe( 'ResponsiveWrapper', () => {
 			);
 			expect(
 				screen.getByRole( 'button', { name: 'Menu' } )
-			).not.toHaveClass( 'is-custom-collapsed-menu-breakpoint-inline' );
+			).not.toHaveClass( 'is-custom-overlay-breakpoint-inline' );
 			expect( getResponsiveContainer() ).not.toHaveClass(
-				'is-custom-collapsed-menu-breakpoint-inline'
+				'is-custom-overlay-breakpoint-inline'
 			);
 		} );
 
 		it.each( [ '10px', '37.5em', '48rem' ] )(
 			'adds inline state classes when the custom %s breakpoint matches',
-			( collapsedMenuBreakpoint ) => {
+			( overlayBreakpoint ) => {
 				useMediaQuery.mockReturnValue( true );
 
 				render(
 					<ResponsiveWrapper
 						{ ...defaultProps }
-						collapsedMenuBreakpoint={ collapsedMenuBreakpoint }
-						hasCustomCollapsedMenuBreakpoint
+						overlayBreakpoint={ overlayBreakpoint }
+						hasCustomOverlayBreakpoint
 					/>
 				);
 
 				expect( useMediaQuery ).toHaveBeenCalledWith(
-					`(min-width: ${ collapsedMenuBreakpoint })`
+					`(min-width: ${ overlayBreakpoint })`
 				);
 				expect(
 					screen.getByRole( 'button', { name: 'Menu' } )
-				).toHaveClass( 'is-custom-collapsed-menu-breakpoint-inline' );
+				).toHaveClass( 'is-custom-overlay-breakpoint-inline' );
 				expect( getResponsiveContainer() ).toHaveClass(
-					'is-custom-collapsed-menu-breakpoint-inline'
+					'is-custom-overlay-breakpoint-inline'
 				);
 			}
 		);
@@ -161,16 +161,16 @@ describe( 'ResponsiveWrapper', () => {
 			render(
 				<ResponsiveWrapper
 					{ ...defaultProps }
-					collapsedMenuBreakpoint="48rem"
-					hasCustomCollapsedMenuBreakpoint
+					overlayBreakpoint="48rem"
+					hasCustomOverlayBreakpoint
 				/>
 			);
 
 			expect(
 				screen.getByRole( 'button', { name: 'Menu' } )
-			).not.toHaveClass( 'is-custom-collapsed-menu-breakpoint-inline' );
+			).not.toHaveClass( 'is-custom-overlay-breakpoint-inline' );
 			expect( getResponsiveContainer() ).not.toHaveClass(
-				'is-custom-collapsed-menu-breakpoint-inline'
+				'is-custom-overlay-breakpoint-inline'
 			);
 		} );
 	} );

--- a/packages/block-library/src/navigation/edit/test/responsive-wrapper.js
+++ b/packages/block-library/src/navigation/edit/test/responsive-wrapper.js
@@ -7,6 +7,7 @@ import userEvent from '@testing-library/user-event';
 /**
  * WordPress dependencies
  */
+import { useMediaQuery } from '@wordpress/compose';
 import { useSelect } from '@wordpress/data';
 
 /**
@@ -17,6 +18,10 @@ import ResponsiveWrapper from '../responsive-wrapper';
 // Mock block-editor to avoid private API issues
 jest.mock( '@wordpress/block-editor', () => ( {
 	getColorClassName: jest.fn( () => '' ),
+} ) );
+
+jest.mock( '@wordpress/compose', () => ( {
+	useMediaQuery: jest.fn(),
 } ) );
 
 // Mock core-data store
@@ -61,6 +66,7 @@ describe( 'ResponsiveWrapper', () => {
 
 	beforeEach( () => {
 		jest.clearAllMocks();
+		useMediaQuery.mockReturnValue( false );
 		// Mock useSelect - component calls: select( coreStore ).getCurrentTheme()?.stylesheet
 		useSelect.mockImplementation( ( selector ) => {
 			if ( typeof selector === 'function' ) {
@@ -72,6 +78,76 @@ describe( 'ResponsiveWrapper', () => {
 				return selector( mockSelect );
 			}
 			return 'twentytwentyfive';
+		} );
+	} );
+
+	describe( 'Custom mobile breakpoints', () => {
+		it( 'preserves the default breakpoint behavior without desktop state classes', () => {
+			useMediaQuery.mockReturnValue( true );
+
+			render(
+				<ResponsiveWrapper
+					{ ...defaultProps }
+					mobileBreakpoint="600px"
+				/>
+			);
+
+			expect( useMediaQuery ).toHaveBeenCalledWith(
+				'(min-width: 600px)'
+			);
+			expect(
+				screen.getByRole( 'button', { name: 'Menu' } )
+			).not.toHaveClass( 'is-custom-mobile-breakpoint-desktop' );
+			expect(
+				document.querySelector(
+					'.wp-block-navigation__responsive-container'
+				)
+			).not.toHaveClass( 'is-custom-mobile-breakpoint-desktop' );
+		} );
+
+		it( 'adds desktop state classes when the custom breakpoint matches', () => {
+			useMediaQuery.mockReturnValue( true );
+
+			render(
+				<ResponsiveWrapper
+					{ ...defaultProps }
+					mobileBreakpoint="48rem"
+					hasCustomMobileBreakpoint
+				/>
+			);
+
+			expect( useMediaQuery ).toHaveBeenCalledWith(
+				'(min-width: 48rem)'
+			);
+			expect(
+				screen.getByRole( 'button', { name: 'Menu' } )
+			).toHaveClass( 'is-custom-mobile-breakpoint-desktop' );
+			expect(
+				document.querySelector(
+					'.wp-block-navigation__responsive-container'
+				)
+			).toHaveClass( 'is-custom-mobile-breakpoint-desktop' );
+		} );
+
+		it( 'keeps mobile state classes when the custom breakpoint does not match', () => {
+			useMediaQuery.mockReturnValue( false );
+
+			render(
+				<ResponsiveWrapper
+					{ ...defaultProps }
+					mobileBreakpoint="48rem"
+					hasCustomMobileBreakpoint
+				/>
+			);
+
+			expect(
+				screen.getByRole( 'button', { name: 'Menu' } )
+			).not.toHaveClass( 'is-custom-mobile-breakpoint-desktop' );
+			expect(
+				document.querySelector(
+					'.wp-block-navigation__responsive-container'
+				)
+			).not.toHaveClass( 'is-custom-mobile-breakpoint-desktop' );
 		} );
 	} );
 

--- a/packages/block-library/src/navigation/edit/test/utils.js
+++ b/packages/block-library/src/navigation/edit/test/utils.js
@@ -1,7 +1,36 @@
 /**
  * Internal dependencies
  */
-import { getUniqueTemplatePartTitle, getCleanTemplatePartSlug } from '../utils';
+import {
+	getUniqueTemplatePartTitle,
+	getCleanTemplatePartSlug,
+	hasCustomMobileBreakpoint,
+	normalizeMobileBreakpoint,
+} from '../utils';
+
+describe( 'normalizeMobileBreakpoint', () => {
+	it( 'normalizes valid breakpoint values', () => {
+		expect( normalizeMobileBreakpoint( '48rem' ) ).toBe( '48rem' );
+		expect( normalizeMobileBreakpoint( '37.5EM' ) ).toBe( '37.5em' );
+		expect( normalizeMobileBreakpoint( ' 720px ' ) ).toBe( '720px' );
+	} );
+
+	it( 'falls back to the default for empty, invalid, or non-positive values', () => {
+		expect( normalizeMobileBreakpoint() ).toBe( '600px' );
+		expect( normalizeMobileBreakpoint( '' ) ).toBe( '600px' );
+		expect( normalizeMobileBreakpoint( '0px' ) ).toBe( '600px' );
+		expect( normalizeMobileBreakpoint( '-1px' ) ).toBe( '600px' );
+		expect( normalizeMobileBreakpoint( '40vw' ) ).toBe( '600px' );
+	} );
+} );
+
+describe( 'hasCustomMobileBreakpoint', () => {
+	it( 'returns true only for valid non-default breakpoints', () => {
+		expect( hasCustomMobileBreakpoint( '600px' ) ).toBe( false );
+		expect( hasCustomMobileBreakpoint( '0px' ) ).toBe( false );
+		expect( hasCustomMobileBreakpoint( '48rem' ) ).toBe( true );
+	} );
+} );
 
 describe( 'getUniqueTemplatePartTitle', () => {
 	it( 'should return the title if it is unique', () => {

--- a/packages/block-library/src/navigation/edit/test/utils.js
+++ b/packages/block-library/src/navigation/edit/test/utils.js
@@ -4,31 +4,43 @@
 import {
 	getUniqueTemplatePartTitle,
 	getCleanTemplatePartSlug,
-	hasCustomMobileBreakpoint,
-	normalizeMobileBreakpoint,
+	hasCustomCollapsedMenuBreakpoint,
+	normalizeCollapsedMenuBreakpoint,
 } from '../utils';
 
-describe( 'normalizeMobileBreakpoint', () => {
+describe( 'normalizeCollapsedMenuBreakpoint', () => {
 	it( 'normalizes valid breakpoint values', () => {
-		expect( normalizeMobileBreakpoint( '48rem' ) ).toBe( '48rem' );
-		expect( normalizeMobileBreakpoint( '37.5EM' ) ).toBe( '37.5em' );
-		expect( normalizeMobileBreakpoint( ' 720px ' ) ).toBe( '720px' );
+		expect( normalizeCollapsedMenuBreakpoint( '48rem' ) ).toBe( '48rem' );
+		expect( normalizeCollapsedMenuBreakpoint( '37.5EM' ) ).toBe( '37.5em' );
+		expect( normalizeCollapsedMenuBreakpoint( ' 720px ' ) ).toBe( '720px' );
 	} );
 
 	it( 'falls back to the default for empty, invalid, or non-positive values', () => {
-		expect( normalizeMobileBreakpoint() ).toBe( '600px' );
-		expect( normalizeMobileBreakpoint( '' ) ).toBe( '600px' );
-		expect( normalizeMobileBreakpoint( '0px' ) ).toBe( '600px' );
-		expect( normalizeMobileBreakpoint( '-1px' ) ).toBe( '600px' );
-		expect( normalizeMobileBreakpoint( '40vw' ) ).toBe( '600px' );
+		expect( normalizeCollapsedMenuBreakpoint() ).toBe( '600px' );
+		expect( normalizeCollapsedMenuBreakpoint( '' ) ).toBe( '600px' );
+		expect( normalizeCollapsedMenuBreakpoint( '0px' ) ).toBe( '600px' );
+		expect( normalizeCollapsedMenuBreakpoint( '-1px' ) ).toBe( '600px' );
+		expect( normalizeCollapsedMenuBreakpoint( '40vw' ) ).toBe( '600px' );
+	} );
+
+	it.each( [
+		'10px);body{background:red}',
+		'10px;background:url(javascript:alert(1))',
+		'10px/*comment*/',
+		'<style>10px</style>',
+		'expression(alert(1))',
+		'url(javascript:alert(1))',
+		'calc(100vw - 1rem)',
+	] )( 'rejects unsafe CSS breakpoint value %p', ( value ) => {
+		expect( normalizeCollapsedMenuBreakpoint( value ) ).toBe( '600px' );
 	} );
 } );
 
-describe( 'hasCustomMobileBreakpoint', () => {
+describe( 'hasCustomCollapsedMenuBreakpoint', () => {
 	it( 'returns true only for valid non-default breakpoints', () => {
-		expect( hasCustomMobileBreakpoint( '600px' ) ).toBe( false );
-		expect( hasCustomMobileBreakpoint( '0px' ) ).toBe( false );
-		expect( hasCustomMobileBreakpoint( '48rem' ) ).toBe( true );
+		expect( hasCustomCollapsedMenuBreakpoint( '600px' ) ).toBe( false );
+		expect( hasCustomCollapsedMenuBreakpoint( '0px' ) ).toBe( false );
+		expect( hasCustomCollapsedMenuBreakpoint( '48rem' ) ).toBe( true );
 	} );
 } );
 

--- a/packages/block-library/src/navigation/edit/test/utils.js
+++ b/packages/block-library/src/navigation/edit/test/utils.js
@@ -5,6 +5,7 @@ import {
 	getUniqueTemplatePartTitle,
 	getCleanTemplatePartSlug,
 	hasCustomOverlayBreakpoint,
+	isValidOverlayBreakpoint,
 	normalizeOverlayBreakpoint,
 } from '../utils';
 
@@ -41,6 +42,17 @@ describe( 'hasCustomOverlayBreakpoint', () => {
 		expect( hasCustomOverlayBreakpoint( '600px' ) ).toBe( false );
 		expect( hasCustomOverlayBreakpoint( '0px' ) ).toBe( false );
 		expect( hasCustomOverlayBreakpoint( '48rem' ) ).toBe( true );
+	} );
+} );
+
+describe( 'isValidOverlayBreakpoint', () => {
+	it( 'returns true only for valid positive breakpoints with supported units', () => {
+		expect( isValidOverlayBreakpoint( '600px' ) ).toBe( true );
+		expect( isValidOverlayBreakpoint( '37.5rem' ) ).toBe( true );
+		expect( isValidOverlayBreakpoint( '0px' ) ).toBe( false );
+		expect( isValidOverlayBreakpoint( '' ) ).toBe( false );
+		expect( isValidOverlayBreakpoint( '37.' ) ).toBe( false );
+		expect( isValidOverlayBreakpoint( '40vw' ) ).toBe( false );
 	} );
 } );
 

--- a/packages/block-library/src/navigation/edit/test/utils.js
+++ b/packages/block-library/src/navigation/edit/test/utils.js
@@ -4,23 +4,23 @@
 import {
 	getUniqueTemplatePartTitle,
 	getCleanTemplatePartSlug,
-	hasCustomCollapsedMenuBreakpoint,
-	normalizeCollapsedMenuBreakpoint,
+	hasCustomOverlayBreakpoint,
+	normalizeOverlayBreakpoint,
 } from '../utils';
 
-describe( 'normalizeCollapsedMenuBreakpoint', () => {
+describe( 'normalizeOverlayBreakpoint', () => {
 	it( 'normalizes valid breakpoint values', () => {
-		expect( normalizeCollapsedMenuBreakpoint( '48rem' ) ).toBe( '48rem' );
-		expect( normalizeCollapsedMenuBreakpoint( '37.5EM' ) ).toBe( '37.5em' );
-		expect( normalizeCollapsedMenuBreakpoint( ' 720px ' ) ).toBe( '720px' );
+		expect( normalizeOverlayBreakpoint( '48rem' ) ).toBe( '48rem' );
+		expect( normalizeOverlayBreakpoint( '37.5EM' ) ).toBe( '37.5em' );
+		expect( normalizeOverlayBreakpoint( ' 720px ' ) ).toBe( '720px' );
 	} );
 
 	it( 'falls back to the default for empty, invalid, or non-positive values', () => {
-		expect( normalizeCollapsedMenuBreakpoint() ).toBe( '600px' );
-		expect( normalizeCollapsedMenuBreakpoint( '' ) ).toBe( '600px' );
-		expect( normalizeCollapsedMenuBreakpoint( '0px' ) ).toBe( '600px' );
-		expect( normalizeCollapsedMenuBreakpoint( '-1px' ) ).toBe( '600px' );
-		expect( normalizeCollapsedMenuBreakpoint( '40vw' ) ).toBe( '600px' );
+		expect( normalizeOverlayBreakpoint() ).toBe( '600px' );
+		expect( normalizeOverlayBreakpoint( '' ) ).toBe( '600px' );
+		expect( normalizeOverlayBreakpoint( '0px' ) ).toBe( '600px' );
+		expect( normalizeOverlayBreakpoint( '-1px' ) ).toBe( '600px' );
+		expect( normalizeOverlayBreakpoint( '40vw' ) ).toBe( '600px' );
 	} );
 
 	it.each( [
@@ -32,15 +32,15 @@ describe( 'normalizeCollapsedMenuBreakpoint', () => {
 		'url(javascript:alert(1))',
 		'calc(100vw - 1rem)',
 	] )( 'rejects unsafe CSS breakpoint value %p', ( value ) => {
-		expect( normalizeCollapsedMenuBreakpoint( value ) ).toBe( '600px' );
+		expect( normalizeOverlayBreakpoint( value ) ).toBe( '600px' );
 	} );
 } );
 
-describe( 'hasCustomCollapsedMenuBreakpoint', () => {
+describe( 'hasCustomOverlayBreakpoint', () => {
 	it( 'returns true only for valid non-default breakpoints', () => {
-		expect( hasCustomCollapsedMenuBreakpoint( '600px' ) ).toBe( false );
-		expect( hasCustomCollapsedMenuBreakpoint( '0px' ) ).toBe( false );
-		expect( hasCustomCollapsedMenuBreakpoint( '48rem' ) ).toBe( true );
+		expect( hasCustomOverlayBreakpoint( '600px' ) ).toBe( false );
+		expect( hasCustomOverlayBreakpoint( '0px' ) ).toBe( false );
+		expect( hasCustomOverlayBreakpoint( '48rem' ) ).toBe( true );
 	} );
 } );
 

--- a/packages/block-library/src/navigation/edit/utils.js
+++ b/packages/block-library/src/navigation/edit/utils.js
@@ -7,30 +7,38 @@ import { paramCase as kebabCase } from 'change-case';
 /**
  * Internal dependencies
  */
-import { DEFAULT_MOBILE_BREAKPOINT } from '../constants';
+import { DEFAULT_COLLAPSED_MENU_BREAKPOINT } from '../constants';
 
-const VALID_MOBILE_BREAKPOINT = /^([0-9]*\.?[0-9]+)(px|em|rem)$/i;
+const VALID_COLLAPSED_MENU_BREAKPOINT = /^([0-9]*\.?[0-9]+)(px|em|rem)$/i;
+const UNSAFE_CSS_VALUE = /[\\{}();&=<>`]|\/\*/;
 
 function getComputedStyle( node ) {
 	return node.ownerDocument.defaultView.getComputedStyle( node );
 }
 
-export function normalizeMobileBreakpoint( value ) {
+export function normalizeCollapsedMenuBreakpoint( value ) {
 	if ( typeof value !== 'string' ) {
-		return DEFAULT_MOBILE_BREAKPOINT;
+		return DEFAULT_COLLAPSED_MENU_BREAKPOINT;
 	}
 
 	const trimmedValue = value.trim();
-	const match = trimmedValue.match( VALID_MOBILE_BREAKPOINT );
+	if ( UNSAFE_CSS_VALUE.test( trimmedValue ) ) {
+		return DEFAULT_COLLAPSED_MENU_BREAKPOINT;
+	}
+
+	const match = trimmedValue.match( VALID_COLLAPSED_MENU_BREAKPOINT );
 	if ( ! match || parseFloat( match[ 1 ] ) <= 0 ) {
-		return DEFAULT_MOBILE_BREAKPOINT;
+		return DEFAULT_COLLAPSED_MENU_BREAKPOINT;
 	}
 
 	return `${ match[ 1 ] }${ match[ 2 ].toLowerCase() }`;
 }
 
-export function hasCustomMobileBreakpoint( value ) {
-	return normalizeMobileBreakpoint( value ) !== DEFAULT_MOBILE_BREAKPOINT;
+export function hasCustomCollapsedMenuBreakpoint( value ) {
+	return (
+		normalizeCollapsedMenuBreakpoint( value ) !==
+		DEFAULT_COLLAPSED_MENU_BREAKPOINT
+	);
 }
 
 export function detectColors(

--- a/packages/block-library/src/navigation/edit/utils.js
+++ b/packages/block-library/src/navigation/edit/utils.js
@@ -7,38 +7,35 @@ import { paramCase as kebabCase } from 'change-case';
 /**
  * Internal dependencies
  */
-import { DEFAULT_COLLAPSED_MENU_BREAKPOINT } from '../constants';
+import { DEFAULT_OVERLAY_BREAKPOINT } from '../constants';
 
-const VALID_COLLAPSED_MENU_BREAKPOINT = /^([0-9]*\.?[0-9]+)(px|em|rem)$/i;
+const VALID_OVERLAY_BREAKPOINT = /^([0-9]*\.?[0-9]+)(px|em|rem)$/i;
 const UNSAFE_CSS_VALUE = /[\\{}();&=<>`]|\/\*/;
 
 function getComputedStyle( node ) {
 	return node.ownerDocument.defaultView.getComputedStyle( node );
 }
 
-export function normalizeCollapsedMenuBreakpoint( value ) {
+export function normalizeOverlayBreakpoint( value ) {
 	if ( typeof value !== 'string' ) {
-		return DEFAULT_COLLAPSED_MENU_BREAKPOINT;
+		return DEFAULT_OVERLAY_BREAKPOINT;
 	}
 
 	const trimmedValue = value.trim();
 	if ( UNSAFE_CSS_VALUE.test( trimmedValue ) ) {
-		return DEFAULT_COLLAPSED_MENU_BREAKPOINT;
+		return DEFAULT_OVERLAY_BREAKPOINT;
 	}
 
-	const match = trimmedValue.match( VALID_COLLAPSED_MENU_BREAKPOINT );
+	const match = trimmedValue.match( VALID_OVERLAY_BREAKPOINT );
 	if ( ! match || parseFloat( match[ 1 ] ) <= 0 ) {
-		return DEFAULT_COLLAPSED_MENU_BREAKPOINT;
+		return DEFAULT_OVERLAY_BREAKPOINT;
 	}
 
 	return `${ match[ 1 ] }${ match[ 2 ].toLowerCase() }`;
 }
 
-export function hasCustomCollapsedMenuBreakpoint( value ) {
-	return (
-		normalizeCollapsedMenuBreakpoint( value ) !==
-		DEFAULT_COLLAPSED_MENU_BREAKPOINT
-	);
+export function hasCustomOverlayBreakpoint( value ) {
+	return normalizeOverlayBreakpoint( value ) !== DEFAULT_OVERLAY_BREAKPOINT;
 }
 
 export function detectColors(

--- a/packages/block-library/src/navigation/edit/utils.js
+++ b/packages/block-library/src/navigation/edit/utils.js
@@ -12,22 +12,35 @@ import { DEFAULT_OVERLAY_BREAKPOINT } from '../constants';
 const VALID_OVERLAY_BREAKPOINT = /^([0-9]*\.?[0-9]+)(px|em|rem)$/i;
 const UNSAFE_CSS_VALUE = /[\\{}();&=<>`]|\/\*/;
 
-function getComputedStyle( node ) {
-	return node.ownerDocument.defaultView.getComputedStyle( node );
-}
-
-export function normalizeOverlayBreakpoint( value ) {
+function getOverlayBreakpointMatch( value ) {
 	if ( typeof value !== 'string' ) {
-		return DEFAULT_OVERLAY_BREAKPOINT;
+		return null;
 	}
 
 	const trimmedValue = value.trim();
 	if ( UNSAFE_CSS_VALUE.test( trimmedValue ) ) {
-		return DEFAULT_OVERLAY_BREAKPOINT;
+		return null;
 	}
 
 	const match = trimmedValue.match( VALID_OVERLAY_BREAKPOINT );
 	if ( ! match || parseFloat( match[ 1 ] ) <= 0 ) {
+		return null;
+	}
+
+	return match;
+}
+
+function getComputedStyle( node ) {
+	return node.ownerDocument.defaultView.getComputedStyle( node );
+}
+
+export function isValidOverlayBreakpoint( value ) {
+	return !! getOverlayBreakpointMatch( value );
+}
+
+export function normalizeOverlayBreakpoint( value ) {
+	const match = getOverlayBreakpointMatch( value );
+	if ( ! match ) {
 		return DEFAULT_OVERLAY_BREAKPOINT;
 	}
 

--- a/packages/block-library/src/navigation/edit/utils.js
+++ b/packages/block-library/src/navigation/edit/utils.js
@@ -4,8 +4,33 @@
 import clsx from 'clsx';
 import { paramCase as kebabCase } from 'change-case';
 
+/**
+ * Internal dependencies
+ */
+import { DEFAULT_MOBILE_BREAKPOINT } from '../constants';
+
+const VALID_MOBILE_BREAKPOINT = /^([0-9]*\.?[0-9]+)(px|em|rem)$/i;
+
 function getComputedStyle( node ) {
 	return node.ownerDocument.defaultView.getComputedStyle( node );
+}
+
+export function normalizeMobileBreakpoint( value ) {
+	if ( typeof value !== 'string' ) {
+		return DEFAULT_MOBILE_BREAKPOINT;
+	}
+
+	const trimmedValue = value.trim();
+	const match = trimmedValue.match( VALID_MOBILE_BREAKPOINT );
+	if ( ! match || parseFloat( match[ 1 ] ) <= 0 ) {
+		return DEFAULT_MOBILE_BREAKPOINT;
+	}
+
+	return `${ match[ 1 ] }${ match[ 2 ].toLowerCase() }`;
+}
+
+export function hasCustomMobileBreakpoint( value ) {
+	return normalizeMobileBreakpoint( value ) !== DEFAULT_MOBILE_BREAKPOINT;
 }
 
 export function detectColors(

--- a/packages/block-library/src/navigation/editor.scss
+++ b/packages/block-library/src/navigation/editor.scss
@@ -433,7 +433,8 @@ $color-control-label-height: 20px;
 // These needs extra specificity in the editor.
 .wp-block-navigation__responsive-container:not(.is-menu-open) {
 	.components-button.wp-block-navigation__responsive-container-close {
-		@include break-small {
+		// @include break-small {
+		&.is-mobile-breakpoint {
 			display: none;
 		}
 	}
@@ -448,21 +449,26 @@ $color-control-label-height: 20px;
 		$admin-bar-height-big + $header-height + $block-toolbar-height +
 		$border-width;
 
-	@include break-medium() {
+	// @include break-medium() {
+	&.is-mobile-breakpoint {
 		top: $admin-bar-height + $header-height + $border-width;
 	}
 
+
 	// Navigation sidebar rules.
-	@include break-medium() {
+	// @include break-medium() {
+	&.is-mobile-breakpoint {
 		left: $admin-sidebar-width-collapsed;
 	}
+
 	@include break-large() {
 		left: $admin-sidebar-width;
 	}
 }
 
 .has-fixed-toolbar .wp-block-navigation__responsive-container.is-menu-open {
-	@include break-medium() {
+	// @include break-medium() {
+	&.is-mobile-breakpoint {
 		top:
 			$admin-bar-height + $header-height + $block-toolbar-height +
 			$border-width;
@@ -488,13 +494,15 @@ $color-control-label-height: 20px;
 			$admin-bar-height-big + $header-height + $block-toolbar-height +
 			$border-width;
 
-		@include break-medium() {
+		// @include break-medium() {
+		&.is-mobile-breakpoint {
 			top: $header-height + $border-width;
 		}
 	}
 
 	.has-fixed-toolbar .wp-block-navigation__responsive-container.is-menu-open {
-		@include break-medium() {
+		// @include break-medium() {
+		&.is-mobile-breakpoint {
 			top: $header-height + $block-toolbar-height + $border-width;
 		}
 	}

--- a/packages/block-library/src/navigation/index.php
+++ b/packages/block-library/src/navigation/index.php
@@ -40,8 +40,8 @@ function block_core_navigation_get_submenu_visibility( $attributes ) {
 	return $submenu_visibility ?? 'hover';
 }
 
-const BLOCK_CORE_NAVIGATION_COLLAPSED_MENU_BREAKPOINT_DEFAULT = '600px';
-const BLOCK_CORE_NAVIGATION_UNSAFE_COLLAPSED_MENU_BREAKPOINT_PATTERN = '%[\\\\{}();&=<>`]|/\*%';
+const BLOCK_CORE_NAVIGATION_OVERLAY_BREAKPOINT_DEFAULT = '600px';
+const BLOCK_CORE_NAVIGATION_UNSAFE_OVERLAY_BREAKPOINT_PATTERN = '%[\\\\{}();&=<>`]|/\*%';
 
 /**
  * Returns whether or not this is responsive navigation.
@@ -60,55 +60,56 @@ function block_core_navigation_is_responsive( $attributes ) {
 }
 
 /**
- * Returns a valid Navigation collapsed menu breakpoint.
+ * Returns a valid Navigation overlay breakpoint.
  *
  * @since 7.1.0
  *
  * @param array $attributes The block attributes.
- * @return string Collapsed menu breakpoint with a supported CSS length unit.
+ * @return string Overlay breakpoint with a supported CSS length unit.
  */
-function block_core_navigation_get_collapsed_menu_breakpoint( $attributes ) {
-	if ( ! isset( $attributes['collapsedMenuBreakpoint'] ) || ! is_string( $attributes['collapsedMenuBreakpoint'] ) ) {
-		return BLOCK_CORE_NAVIGATION_COLLAPSED_MENU_BREAKPOINT_DEFAULT;
+function block_core_navigation_get_overlay_breakpoint( $attributes ) {
+	if ( ! isset( $attributes['overlayBreakpoint'] ) || ! is_string( $attributes['overlayBreakpoint'] ) ) {
+		return BLOCK_CORE_NAVIGATION_OVERLAY_BREAKPOINT_DEFAULT;
 	}
 
-	$collapsed_menu_breakpoint = trim( $attributes['collapsedMenuBreakpoint'] );
+	$overlay_breakpoint = trim( $attributes['overlayBreakpoint'] );
 	if (
-		'' === $collapsed_menu_breakpoint ||
-		$collapsed_menu_breakpoint !== wp_strip_all_tags( $collapsed_menu_breakpoint, true ) ||
-		preg_match( BLOCK_CORE_NAVIGATION_UNSAFE_COLLAPSED_MENU_BREAKPOINT_PATTERN, $collapsed_menu_breakpoint )
+		'' === $overlay_breakpoint ||
+		$overlay_breakpoint !== wp_strip_all_tags( $overlay_breakpoint, true ) ||
+		preg_match( BLOCK_CORE_NAVIGATION_UNSAFE_OVERLAY_BREAKPOINT_PATTERN, $overlay_breakpoint )
 	) {
-		return BLOCK_CORE_NAVIGATION_COLLAPSED_MENU_BREAKPOINT_DEFAULT;
+		return BLOCK_CORE_NAVIGATION_OVERLAY_BREAKPOINT_DEFAULT;
 	}
 
-	if ( ! preg_match( '/^([0-9]*\.?[0-9]+)(px|em|rem)$/i', $collapsed_menu_breakpoint, $matches ) ) {
-		return BLOCK_CORE_NAVIGATION_COLLAPSED_MENU_BREAKPOINT_DEFAULT;
+	if ( ! preg_match( '/^([0-9]*\.?[0-9]+)(px|em|rem)$/i', $overlay_breakpoint, $matches ) ) {
+		return BLOCK_CORE_NAVIGATION_OVERLAY_BREAKPOINT_DEFAULT;
 	}
 
 	if ( (float) $matches[1] <= 0 || ! is_finite( (float) $matches[1] ) ) {
-		return BLOCK_CORE_NAVIGATION_COLLAPSED_MENU_BREAKPOINT_DEFAULT;
+		return BLOCK_CORE_NAVIGATION_OVERLAY_BREAKPOINT_DEFAULT;
 	}
 
-	$normalized_collapsed_menu_breakpoint = $matches[1] . strtolower( $matches[2] );
-	if ( "width:{$normalized_collapsed_menu_breakpoint}" !== safecss_filter_attr( "width:{$normalized_collapsed_menu_breakpoint}" ) ) {
-		return BLOCK_CORE_NAVIGATION_COLLAPSED_MENU_BREAKPOINT_DEFAULT;
+	$normalized_overlay_breakpoint = $matches[1] . strtolower( $matches[2] );
+	if ( "width:{$normalized_overlay_breakpoint}" !== safecss_filter_attr( "width:{$normalized_overlay_breakpoint}" ) ) {
+		return BLOCK_CORE_NAVIGATION_OVERLAY_BREAKPOINT_DEFAULT;
 	}
 
-	return $normalized_collapsed_menu_breakpoint;
+	return $normalized_overlay_breakpoint;
 }
 
 /**
- * Returns whether a Navigation block uses a custom collapsed menu breakpoint.
+ * Returns whether a Navigation block uses a custom overlay breakpoint.
  *
  * @since 7.1.0
  *
  * @param array $attributes The block attributes.
- * @return bool Whether the block has a non-default collapsed menu breakpoint.
+ * @return bool Whether the block uses a non-default overlay breakpoint.
  */
-function block_core_navigation_has_custom_collapsed_menu_breakpoint( $attributes ) {
+function block_core_navigation_has_custom_overlay_breakpoint( $attributes ) {
 	return (
-		block_core_navigation_get_collapsed_menu_breakpoint( $attributes ) !==
-		BLOCK_CORE_NAVIGATION_COLLAPSED_MENU_BREAKPOINT_DEFAULT
+		'mobile' === ( $attributes['overlayMenu'] ?? null ) &&
+		block_core_navigation_get_overlay_breakpoint( $attributes ) !==
+		BLOCK_CORE_NAVIGATION_OVERLAY_BREAKPOINT_DEFAULT
 	);
 }
 
@@ -713,11 +714,11 @@ class WP_Navigation_Block_Renderer {
 	 */
 	private static function get_classes( $attributes ) {
 		// Restore legacy classnames for submenu positioning.
-		$layout_class                 = static::get_layout_class( $attributes );
-		$colors                       = block_core_navigation_build_css_colors( $attributes );
-		$font_sizes                   = block_core_navigation_build_css_font_sizes( $attributes );
-		$is_responsive_menu           = static::is_responsive( $attributes );
-		$has_custom_collapsed_menu_breakpoint = $is_responsive_menu && block_core_navigation_has_custom_collapsed_menu_breakpoint( $attributes );
+		$layout_class                  = static::get_layout_class( $attributes );
+		$colors                        = block_core_navigation_build_css_colors( $attributes );
+		$font_sizes                    = block_core_navigation_build_css_font_sizes( $attributes );
+		$is_responsive_menu            = static::is_responsive( $attributes );
+		$has_custom_overlay_breakpoint = block_core_navigation_has_custom_overlay_breakpoint( $attributes );
 
 		// Manually add block support text decoration as CSS class.
 		$text_decoration       = $attributes['style']['typography']['textDecoration'] ?? null;
@@ -727,8 +728,8 @@ class WP_Navigation_Block_Renderer {
 			$colors['css_classes'],
 			$font_sizes['css_classes'],
 			$is_responsive_menu ? array( 'is-responsive' ) : array(),
-			$has_custom_collapsed_menu_breakpoint
-				? array( 'has-custom-collapsed-menu-breakpoint' )
+			$has_custom_overlay_breakpoint
+				? array( 'has-custom-overlay-breakpoint' )
 				: array(),
 			$layout_class ? array( $layout_class ) : array(),
 			$text_decoration ? array( $text_decoration_class ) : array()
@@ -1684,7 +1685,7 @@ add_action( 'init', 'register_block_core_navigation' );
  * change those classes, so equivalent custom properties and a scoping class
  * are generated for each configured viewport layout.
  *
- * Navigation blocks with custom collapsed menu breakpoints also need scoped rules so
+ * Navigation blocks with custom overlay breakpoints also need scoped rules so
  * they can opt out of the default static breakpoint without affecting other
  * Navigation blocks on the page.
  *
@@ -1749,10 +1750,10 @@ function block_core_navigation_add_support_classes_to_container( $block_content,
 	if ( is_string( $class_attribute ) && preg_match( '/\bwp-states-[a-f0-9]{8}\b/', $class_attribute, $matches ) ) {
 		$state_class = $matches[0];
 	}
-	$has_custom_collapsed_menu_breakpoint =
+	$has_custom_overlay_breakpoint =
 		is_string( $class_attribute ) &&
-		preg_match( '/\bhas-custom-collapsed-menu-breakpoint\b/', $class_attribute ) &&
-		block_core_navigation_has_custom_collapsed_menu_breakpoint( $attributes );
+		preg_match( '/\bhas-custom-overlay-breakpoint\b/', $class_attribute ) &&
+		block_core_navigation_has_custom_overlay_breakpoint( $attributes );
 
 	$layout_class = null;
 	if ( ! empty( $styles ) ) {
@@ -1772,17 +1773,17 @@ function block_core_navigation_add_support_classes_to_container( $block_content,
 		);
 	}
 
-	$custom_collapsed_menu_breakpoint_class = null;
-	if ( $has_custom_collapsed_menu_breakpoint ) {
-		$custom_collapsed_menu_breakpoint_class = wp_unique_id( 'wp-block-navigation-custom-breakpoint-' );
-		$processor->add_class( $custom_collapsed_menu_breakpoint_class );
+	$custom_overlay_breakpoint_class = null;
+	if ( $has_custom_overlay_breakpoint ) {
+		$custom_overlay_breakpoint_class = wp_unique_id( 'wp-block-navigation-custom-overlay-breakpoint-' );
+		$processor->add_class( $custom_overlay_breakpoint_class );
 
-			$collapsed_menu_breakpoint    = block_core_navigation_get_collapsed_menu_breakpoint( $attributes );
-			$selector_base                = ".wp-block-navigation.{$custom_collapsed_menu_breakpoint_class}.has-custom-collapsed-menu-breakpoint";
-			$container_selector           = $selector_base . ' .wp-block-navigation__responsive-container';
-			$container_inline_selector    = $container_selector . ':not(.hidden-by-default):not(.is-menu-open)';
-			$submenu_container_selectors  = '.wp-block-navigation__submenu-container.wp-block-navigation__submenu-container.wp-block-navigation__submenu-container.wp-block-navigation__submenu-container';
-			$rules_group                  = "@media (min-width: {$collapsed_menu_breakpoint})";
+		$overlay_breakpoint           = block_core_navigation_get_overlay_breakpoint( $attributes );
+		$selector_base                = ".wp-block-navigation.{$custom_overlay_breakpoint_class}.has-custom-overlay-breakpoint";
+		$container_selector           = $selector_base . ' .wp-block-navigation__responsive-container';
+		$container_inline_selector    = $container_selector . ':not(.hidden-by-default):not(.is-menu-open)';
+		$submenu_container_selectors  = '.wp-block-navigation__submenu-container.wp-block-navigation__submenu-container.wp-block-navigation__submenu-container.wp-block-navigation__submenu-container';
+		$rules_group                  = "@media (min-width: {$overlay_breakpoint})";
 
 		wp_style_engine_get_stylesheet_from_css_rules(
 			array(
@@ -1823,7 +1824,7 @@ function block_core_navigation_add_support_classes_to_container( $block_content,
 		);
 	}
 
-	if ( null === $state_class && null === $layout_class && null === $custom_collapsed_menu_breakpoint_class ) {
+	if ( null === $state_class && null === $layout_class && null === $custom_overlay_breakpoint_class ) {
 		return $block_content;
 	}
 

--- a/packages/block-library/src/navigation/index.php
+++ b/packages/block-library/src/navigation/index.php
@@ -40,6 +40,64 @@ function block_core_navigation_get_submenu_visibility( $attributes ) {
 	return $submenu_visibility ?? 'hover';
 }
 
+const BLOCK_CORE_NAVIGATION_MOBILE_BREAKPOINT_DEFAULT = '600px';
+
+/**
+ * Returns whether or not this is responsive navigation.
+ *
+ * @since 7.1.0
+ *
+ * @param array $attributes The block attributes.
+ * @return bool Returns whether or not this is responsive navigation.
+ */
+function block_core_navigation_is_responsive( $attributes ) {
+	$has_old_responsive_attribute = ! empty( $attributes['isResponsive'] ) && $attributes['isResponsive'];
+	return (
+		isset( $attributes['overlayMenu'] ) &&
+		'never' !== $attributes['overlayMenu']
+	) || $has_old_responsive_attribute;
+}
+
+/**
+ * Returns a valid Navigation mobile breakpoint.
+ *
+ * @since 7.1.0
+ *
+ * @param array $attributes The block attributes.
+ * @return string Mobile breakpoint with a supported CSS length unit.
+ */
+function block_core_navigation_get_mobile_breakpoint( $attributes ) {
+	if ( ! isset( $attributes['mobileBreakpoint'] ) || ! is_string( $attributes['mobileBreakpoint'] ) ) {
+		return BLOCK_CORE_NAVIGATION_MOBILE_BREAKPOINT_DEFAULT;
+	}
+
+	$mobile_breakpoint = trim( $attributes['mobileBreakpoint'] );
+	if ( ! preg_match( '/^([0-9]*\.?[0-9]+)(px|em|rem)$/i', $mobile_breakpoint, $matches ) ) {
+		return BLOCK_CORE_NAVIGATION_MOBILE_BREAKPOINT_DEFAULT;
+	}
+
+	if ( (float) $matches[1] <= 0 ) {
+		return BLOCK_CORE_NAVIGATION_MOBILE_BREAKPOINT_DEFAULT;
+	}
+
+	return $matches[1] . strtolower( $matches[2] );
+}
+
+/**
+ * Returns whether a Navigation block uses a custom mobile breakpoint.
+ *
+ * @since 7.1.0
+ *
+ * @param array $attributes The block attributes.
+ * @return bool Whether the block has a non-default mobile breakpoint.
+ */
+function block_core_navigation_has_custom_mobile_breakpoint( $attributes ) {
+	return (
+		block_core_navigation_get_mobile_breakpoint( $attributes ) !==
+		BLOCK_CORE_NAVIGATION_MOBILE_BREAKPOINT_DEFAULT
+	);
+}
+
 /**
  * Returns the custom properties used by the Navigation block for a layout.
  *
@@ -129,8 +187,7 @@ class WP_Navigation_Block_Renderer {
 		 * This is for backwards compatibility after the `isResponsive` attribute was been removed.
 		 */
 
-		$has_old_responsive_attribute = ! empty( $attributes['isResponsive'] ) && $attributes['isResponsive'];
-		return isset( $attributes['overlayMenu'] ) && 'never' !== $attributes['overlayMenu'] || $has_old_responsive_attribute;
+		return block_core_navigation_is_responsive( $attributes );
 	}
 
 	/**
@@ -642,10 +699,11 @@ class WP_Navigation_Block_Renderer {
 	 */
 	private static function get_classes( $attributes ) {
 		// Restore legacy classnames for submenu positioning.
-		$layout_class       = static::get_layout_class( $attributes );
-		$colors             = block_core_navigation_build_css_colors( $attributes );
-		$font_sizes         = block_core_navigation_build_css_font_sizes( $attributes );
-		$is_responsive_menu = static::is_responsive( $attributes );
+		$layout_class                 = static::get_layout_class( $attributes );
+		$colors                       = block_core_navigation_build_css_colors( $attributes );
+		$font_sizes                   = block_core_navigation_build_css_font_sizes( $attributes );
+		$is_responsive_menu           = static::is_responsive( $attributes );
+		$has_custom_mobile_breakpoint = $is_responsive_menu && block_core_navigation_has_custom_mobile_breakpoint( $attributes );
 
 		// Manually add block support text decoration as CSS class.
 		$text_decoration       = $attributes['style']['typography']['textDecoration'] ?? null;
@@ -655,6 +713,9 @@ class WP_Navigation_Block_Renderer {
 			$colors['css_classes'],
 			$font_sizes['css_classes'],
 			$is_responsive_menu ? array( 'is-responsive' ) : array(),
+			$has_custom_mobile_breakpoint
+				? array( 'has-custom-mobile-breakpoint' )
+				: array(),
 			$layout_class ? array( $layout_class ) : array(),
 			$text_decoration ? array( $text_decoration_class ) : array()
 		);
@@ -1609,6 +1670,10 @@ add_action( 'init', 'register_block_core_navigation' );
  * change those classes, so equivalent custom properties and a scoping class
  * are generated for each configured viewport layout.
  *
+ * Navigation blocks with custom mobile breakpoints also need scoped rules so
+ * they can opt out of the default static breakpoint without affecting other
+ * Navigation blocks on the page.
+ *
  * Currently this is required as a workaround because of how difficult it is for nav
  * child blocks to inherit styles through the complex responsive nav block html. The
  * bug in https://github.com/WordPress/gutenberg/issues/62690 also prevents inheritance.
@@ -1670,6 +1735,10 @@ function block_core_navigation_add_support_classes_to_container( $block_content,
 	if ( is_string( $class_attribute ) && preg_match( '/\bwp-states-[a-f0-9]{8}\b/', $class_attribute, $matches ) ) {
 		$state_class = $matches[0];
 	}
+	$has_custom_mobile_breakpoint =
+		is_string( $class_attribute ) &&
+		preg_match( '/\bhas-custom-mobile-breakpoint\b/', $class_attribute ) &&
+		block_core_navigation_has_custom_mobile_breakpoint( $attributes );
 
 	$layout_class = null;
 	if ( ! empty( $styles ) ) {
@@ -1689,7 +1758,58 @@ function block_core_navigation_add_support_classes_to_container( $block_content,
 		);
 	}
 
-	if ( null === $state_class && null === $layout_class ) {
+	$custom_mobile_breakpoint_class = null;
+	if ( $has_custom_mobile_breakpoint ) {
+		$custom_mobile_breakpoint_class = wp_unique_id( 'wp-block-navigation-custom-breakpoint-' );
+		$processor->add_class( $custom_mobile_breakpoint_class );
+
+		$mobile_breakpoint           = block_core_navigation_get_mobile_breakpoint( $attributes );
+		$selector_base               = ".wp-block-navigation.{$custom_mobile_breakpoint_class}.has-custom-mobile-breakpoint";
+		$container_selector          = $selector_base . ' .wp-block-navigation__responsive-container';
+		$container_desktop_selector  = $container_selector . ':not(.hidden-by-default):not(.is-menu-open)';
+		$submenu_container_selectors = '.wp-block-navigation__submenu-container.wp-block-navigation__submenu-container.wp-block-navigation__submenu-container.wp-block-navigation__submenu-container';
+		$rules_group                 = "@media (min-width: {$mobile_breakpoint})";
+
+		wp_style_engine_get_stylesheet_from_css_rules(
+			array(
+				array(
+					'selector'     => $container_desktop_selector,
+					'declarations' => array(
+						'display'          => 'block',
+						'width'            => '100%',
+						'position'         => 'relative',
+						'z-index'          => 'auto',
+						'background-color' => 'inherit',
+					),
+					'rules_group'  => $rules_group,
+				),
+				array(
+					'selector'     => $container_desktop_selector . ' .wp-block-navigation__responsive-container-close',
+					'declarations' => array(
+						'display' => 'none',
+					),
+					'rules_group'  => $rules_group,
+				),
+				array(
+					'selector'     => $container_selector . '.is-menu-open ' . $submenu_container_selectors,
+					'declarations' => array(
+						'left' => '0',
+					),
+					'rules_group'  => $rules_group,
+				),
+				array(
+					'selector'     => $selector_base . ' .wp-block-navigation__responsive-container-open:not(.always-shown)',
+					'declarations' => array(
+						'display' => 'none',
+					),
+					'rules_group'  => $rules_group,
+				),
+			),
+			array( 'context' => 'block-supports' )
+		);
+	}
+
+	if ( null === $state_class && null === $layout_class && null === $custom_mobile_breakpoint_class ) {
 		return $block_content;
 	}
 

--- a/packages/block-library/src/navigation/index.php
+++ b/packages/block-library/src/navigation/index.php
@@ -40,7 +40,8 @@ function block_core_navigation_get_submenu_visibility( $attributes ) {
 	return $submenu_visibility ?? 'hover';
 }
 
-const BLOCK_CORE_NAVIGATION_MOBILE_BREAKPOINT_DEFAULT = '600px';
+const BLOCK_CORE_NAVIGATION_COLLAPSED_MENU_BREAKPOINT_DEFAULT = '600px';
+const BLOCK_CORE_NAVIGATION_UNSAFE_COLLAPSED_MENU_BREAKPOINT_PATTERN = '%[\\\\{}();&=<>`]|/\*%';
 
 /**
  * Returns whether or not this is responsive navigation.
@@ -59,42 +60,55 @@ function block_core_navigation_is_responsive( $attributes ) {
 }
 
 /**
- * Returns a valid Navigation mobile breakpoint.
+ * Returns a valid Navigation collapsed menu breakpoint.
  *
  * @since 7.1.0
  *
  * @param array $attributes The block attributes.
- * @return string Mobile breakpoint with a supported CSS length unit.
+ * @return string Collapsed menu breakpoint with a supported CSS length unit.
  */
-function block_core_navigation_get_mobile_breakpoint( $attributes ) {
-	if ( ! isset( $attributes['mobileBreakpoint'] ) || ! is_string( $attributes['mobileBreakpoint'] ) ) {
-		return BLOCK_CORE_NAVIGATION_MOBILE_BREAKPOINT_DEFAULT;
+function block_core_navigation_get_collapsed_menu_breakpoint( $attributes ) {
+	if ( ! isset( $attributes['collapsedMenuBreakpoint'] ) || ! is_string( $attributes['collapsedMenuBreakpoint'] ) ) {
+		return BLOCK_CORE_NAVIGATION_COLLAPSED_MENU_BREAKPOINT_DEFAULT;
 	}
 
-	$mobile_breakpoint = trim( $attributes['mobileBreakpoint'] );
-	if ( ! preg_match( '/^([0-9]*\.?[0-9]+)(px|em|rem)$/i', $mobile_breakpoint, $matches ) ) {
-		return BLOCK_CORE_NAVIGATION_MOBILE_BREAKPOINT_DEFAULT;
+	$collapsed_menu_breakpoint = trim( $attributes['collapsedMenuBreakpoint'] );
+	if (
+		'' === $collapsed_menu_breakpoint ||
+		$collapsed_menu_breakpoint !== wp_strip_all_tags( $collapsed_menu_breakpoint, true ) ||
+		preg_match( BLOCK_CORE_NAVIGATION_UNSAFE_COLLAPSED_MENU_BREAKPOINT_PATTERN, $collapsed_menu_breakpoint )
+	) {
+		return BLOCK_CORE_NAVIGATION_COLLAPSED_MENU_BREAKPOINT_DEFAULT;
 	}
 
-	if ( (float) $matches[1] <= 0 ) {
-		return BLOCK_CORE_NAVIGATION_MOBILE_BREAKPOINT_DEFAULT;
+	if ( ! preg_match( '/^([0-9]*\.?[0-9]+)(px|em|rem)$/i', $collapsed_menu_breakpoint, $matches ) ) {
+		return BLOCK_CORE_NAVIGATION_COLLAPSED_MENU_BREAKPOINT_DEFAULT;
 	}
 
-	return $matches[1] . strtolower( $matches[2] );
+	if ( (float) $matches[1] <= 0 || ! is_finite( (float) $matches[1] ) ) {
+		return BLOCK_CORE_NAVIGATION_COLLAPSED_MENU_BREAKPOINT_DEFAULT;
+	}
+
+	$normalized_collapsed_menu_breakpoint = $matches[1] . strtolower( $matches[2] );
+	if ( "width:{$normalized_collapsed_menu_breakpoint}" !== safecss_filter_attr( "width:{$normalized_collapsed_menu_breakpoint}" ) ) {
+		return BLOCK_CORE_NAVIGATION_COLLAPSED_MENU_BREAKPOINT_DEFAULT;
+	}
+
+	return $normalized_collapsed_menu_breakpoint;
 }
 
 /**
- * Returns whether a Navigation block uses a custom mobile breakpoint.
+ * Returns whether a Navigation block uses a custom collapsed menu breakpoint.
  *
  * @since 7.1.0
  *
  * @param array $attributes The block attributes.
- * @return bool Whether the block has a non-default mobile breakpoint.
+ * @return bool Whether the block has a non-default collapsed menu breakpoint.
  */
-function block_core_navigation_has_custom_mobile_breakpoint( $attributes ) {
+function block_core_navigation_has_custom_collapsed_menu_breakpoint( $attributes ) {
 	return (
-		block_core_navigation_get_mobile_breakpoint( $attributes ) !==
-		BLOCK_CORE_NAVIGATION_MOBILE_BREAKPOINT_DEFAULT
+		block_core_navigation_get_collapsed_menu_breakpoint( $attributes ) !==
+		BLOCK_CORE_NAVIGATION_COLLAPSED_MENU_BREAKPOINT_DEFAULT
 	);
 }
 
@@ -703,7 +717,7 @@ class WP_Navigation_Block_Renderer {
 		$colors                       = block_core_navigation_build_css_colors( $attributes );
 		$font_sizes                   = block_core_navigation_build_css_font_sizes( $attributes );
 		$is_responsive_menu           = static::is_responsive( $attributes );
-		$has_custom_mobile_breakpoint = $is_responsive_menu && block_core_navigation_has_custom_mobile_breakpoint( $attributes );
+		$has_custom_collapsed_menu_breakpoint = $is_responsive_menu && block_core_navigation_has_custom_collapsed_menu_breakpoint( $attributes );
 
 		// Manually add block support text decoration as CSS class.
 		$text_decoration       = $attributes['style']['typography']['textDecoration'] ?? null;
@@ -713,8 +727,8 @@ class WP_Navigation_Block_Renderer {
 			$colors['css_classes'],
 			$font_sizes['css_classes'],
 			$is_responsive_menu ? array( 'is-responsive' ) : array(),
-			$has_custom_mobile_breakpoint
-				? array( 'has-custom-mobile-breakpoint' )
+			$has_custom_collapsed_menu_breakpoint
+				? array( 'has-custom-collapsed-menu-breakpoint' )
 				: array(),
 			$layout_class ? array( $layout_class ) : array(),
 			$text_decoration ? array( $text_decoration_class ) : array()
@@ -1670,7 +1684,7 @@ add_action( 'init', 'register_block_core_navigation' );
  * change those classes, so equivalent custom properties and a scoping class
  * are generated for each configured viewport layout.
  *
- * Navigation blocks with custom mobile breakpoints also need scoped rules so
+ * Navigation blocks with custom collapsed menu breakpoints also need scoped rules so
  * they can opt out of the default static breakpoint without affecting other
  * Navigation blocks on the page.
  *
@@ -1735,10 +1749,10 @@ function block_core_navigation_add_support_classes_to_container( $block_content,
 	if ( is_string( $class_attribute ) && preg_match( '/\bwp-states-[a-f0-9]{8}\b/', $class_attribute, $matches ) ) {
 		$state_class = $matches[0];
 	}
-	$has_custom_mobile_breakpoint =
+	$has_custom_collapsed_menu_breakpoint =
 		is_string( $class_attribute ) &&
-		preg_match( '/\bhas-custom-mobile-breakpoint\b/', $class_attribute ) &&
-		block_core_navigation_has_custom_mobile_breakpoint( $attributes );
+		preg_match( '/\bhas-custom-collapsed-menu-breakpoint\b/', $class_attribute ) &&
+		block_core_navigation_has_custom_collapsed_menu_breakpoint( $attributes );
 
 	$layout_class = null;
 	if ( ! empty( $styles ) ) {
@@ -1758,22 +1772,22 @@ function block_core_navigation_add_support_classes_to_container( $block_content,
 		);
 	}
 
-	$custom_mobile_breakpoint_class = null;
-	if ( $has_custom_mobile_breakpoint ) {
-		$custom_mobile_breakpoint_class = wp_unique_id( 'wp-block-navigation-custom-breakpoint-' );
-		$processor->add_class( $custom_mobile_breakpoint_class );
+	$custom_collapsed_menu_breakpoint_class = null;
+	if ( $has_custom_collapsed_menu_breakpoint ) {
+		$custom_collapsed_menu_breakpoint_class = wp_unique_id( 'wp-block-navigation-custom-breakpoint-' );
+		$processor->add_class( $custom_collapsed_menu_breakpoint_class );
 
-		$mobile_breakpoint           = block_core_navigation_get_mobile_breakpoint( $attributes );
-		$selector_base               = ".wp-block-navigation.{$custom_mobile_breakpoint_class}.has-custom-mobile-breakpoint";
-		$container_selector          = $selector_base . ' .wp-block-navigation__responsive-container';
-		$container_desktop_selector  = $container_selector . ':not(.hidden-by-default):not(.is-menu-open)';
-		$submenu_container_selectors = '.wp-block-navigation__submenu-container.wp-block-navigation__submenu-container.wp-block-navigation__submenu-container.wp-block-navigation__submenu-container';
-		$rules_group                 = "@media (min-width: {$mobile_breakpoint})";
+			$collapsed_menu_breakpoint    = block_core_navigation_get_collapsed_menu_breakpoint( $attributes );
+			$selector_base                = ".wp-block-navigation.{$custom_collapsed_menu_breakpoint_class}.has-custom-collapsed-menu-breakpoint";
+			$container_selector           = $selector_base . ' .wp-block-navigation__responsive-container';
+			$container_inline_selector    = $container_selector . ':not(.hidden-by-default):not(.is-menu-open)';
+			$submenu_container_selectors  = '.wp-block-navigation__submenu-container.wp-block-navigation__submenu-container.wp-block-navigation__submenu-container.wp-block-navigation__submenu-container';
+			$rules_group                  = "@media (min-width: {$collapsed_menu_breakpoint})";
 
 		wp_style_engine_get_stylesheet_from_css_rules(
 			array(
 				array(
-					'selector'     => $container_desktop_selector,
+					'selector'     => $container_inline_selector,
 					'declarations' => array(
 						'display'          => 'block',
 						'width'            => '100%',
@@ -1784,7 +1798,7 @@ function block_core_navigation_add_support_classes_to_container( $block_content,
 					'rules_group'  => $rules_group,
 				),
 				array(
-					'selector'     => $container_desktop_selector . ' .wp-block-navigation__responsive-container-close',
+					'selector'     => $container_inline_selector . ' .wp-block-navigation__responsive-container-close',
 					'declarations' => array(
 						'display' => 'none',
 					),
@@ -1809,7 +1823,7 @@ function block_core_navigation_add_support_classes_to_container( $block_content,
 		);
 	}
 
-	if ( null === $state_class && null === $layout_class && null === $custom_mobile_breakpoint_class ) {
+	if ( null === $state_class && null === $layout_class && null === $custom_collapsed_menu_breakpoint_class ) {
 		return $block_content;
 	}
 

--- a/packages/block-library/src/navigation/index.php
+++ b/packages/block-library/src/navigation/index.php
@@ -40,7 +40,7 @@ function block_core_navigation_get_submenu_visibility( $attributes ) {
 	return $submenu_visibility ?? 'hover';
 }
 
-const BLOCK_CORE_NAVIGATION_OVERLAY_BREAKPOINT_DEFAULT = '600px';
+const BLOCK_CORE_NAVIGATION_OVERLAY_BREAKPOINT_DEFAULT        = '600px';
 const BLOCK_CORE_NAVIGATION_UNSAFE_OVERLAY_BREAKPOINT_PATTERN = '%[\\\\{}();&=<>`]|/\*%';
 
 /**
@@ -75,7 +75,7 @@ function block_core_navigation_get_overlay_breakpoint( $attributes ) {
 	$overlay_breakpoint = trim( $attributes['overlayBreakpoint'] );
 	if (
 		'' === $overlay_breakpoint ||
-		$overlay_breakpoint !== wp_strip_all_tags( $overlay_breakpoint, true ) ||
+		wp_strip_all_tags( $overlay_breakpoint, true ) !== $overlay_breakpoint ||
 		preg_match( BLOCK_CORE_NAVIGATION_UNSAFE_OVERLAY_BREAKPOINT_PATTERN, $overlay_breakpoint )
 	) {
 		return BLOCK_CORE_NAVIGATION_OVERLAY_BREAKPOINT_DEFAULT;
@@ -1778,12 +1778,12 @@ function block_core_navigation_add_support_classes_to_container( $block_content,
 		$custom_overlay_breakpoint_class = wp_unique_id( 'wp-block-navigation-custom-overlay-breakpoint-' );
 		$processor->add_class( $custom_overlay_breakpoint_class );
 
-		$overlay_breakpoint           = block_core_navigation_get_overlay_breakpoint( $attributes );
-		$selector_base                = ".wp-block-navigation.{$custom_overlay_breakpoint_class}.has-custom-overlay-breakpoint";
-		$container_selector           = $selector_base . ' .wp-block-navigation__responsive-container';
-		$container_inline_selector    = $container_selector . ':not(.hidden-by-default):not(.is-menu-open)';
-		$submenu_container_selectors  = '.wp-block-navigation__submenu-container.wp-block-navigation__submenu-container.wp-block-navigation__submenu-container.wp-block-navigation__submenu-container';
-		$rules_group                  = "@media (min-width: {$overlay_breakpoint})";
+		$overlay_breakpoint          = block_core_navigation_get_overlay_breakpoint( $attributes );
+		$selector_base               = ".wp-block-navigation.{$custom_overlay_breakpoint_class}.has-custom-overlay-breakpoint";
+		$container_selector          = $selector_base . ' .wp-block-navigation__responsive-container';
+		$container_inline_selector   = $container_selector . ':not(.hidden-by-default):not(.is-menu-open)';
+		$submenu_container_selectors = '.wp-block-navigation__submenu-container.wp-block-navigation__submenu-container.wp-block-navigation__submenu-container.wp-block-navigation__submenu-container';
+		$rules_group                 = "@media (min-width: {$overlay_breakpoint})";
 
 		wp_style_engine_get_stylesheet_from_css_rules(
 			array(

--- a/packages/block-library/src/navigation/style.scss
+++ b/packages/block-library/src/navigation/style.scss
@@ -10,6 +10,8 @@
 // Size of burger and close icons.
 $navigation-icon-size: 24px;
 
+
+
 .wp-block-navigation {
 	position: relative;
 
@@ -591,7 +593,8 @@ button.wp-block-navigation-item__content {
 		}
 	}
 
-	@include break-small() {
+	// @include break-small() {
+	&:not(.is-mobile-breakpoint) {
 		&:not(.hidden-by-default) {
 			&:not(.is-menu-open) {
 				display: block;
@@ -654,7 +657,8 @@ button.wp-block-navigation-item__content {
 	display: flex;
 
 	&:not(.always-shown) {
-		@include break-small {
+		// @include break-small {
+		&:not(.is-mobile-breakpoint) {
 			display: none;
 		}
 	}

--- a/packages/block-library/src/navigation/style.scss
+++ b/packages/block-library/src/navigation/style.scss
@@ -13,8 +13,6 @@
 // Size of burger and close icons.
 $navigation-icon-size: 24px;
 
-
-
 .wp-block-navigation {
 	position: relative;
 
@@ -721,8 +719,11 @@ button.wp-block-navigation-item__content {
 		}
 	}
 
+	// Keep the static default breakpoint for Navigation blocks without a
+	// custom breakpoint. Custom breakpoint blocks opt out here and receive
+	// instance-scoped rules from server rendering.
 	@include break-small() {
-		.wp-block-navigation:not(.has-custom-mobile-breakpoint) & {
+		.wp-block-navigation:not(.has-custom-collapsed-menu-breakpoint) & {
 			&:not(.hidden-by-default) {
 				&:not(.is-menu-open) {
 					display: block;
@@ -746,7 +747,7 @@ button.wp-block-navigation-item__content {
 		}
 	}
 
-	&.is-custom-mobile-breakpoint-desktop {
+	&.is-custom-collapsed-menu-breakpoint-inline {
 		&:not(.hidden-by-default) {
 			&:not(.is-menu-open) {
 				display: block;
@@ -823,13 +824,16 @@ button.wp-block-navigation-item__content {
 	}
 
 	&:not(.always-shown) {
+		// Keep the static default breakpoint for Navigation blocks without a
+		// custom breakpoint. Custom breakpoint blocks opt out here and receive
+		// instance-scoped rules from server rendering.
 		@include break-small {
-			.wp-block-navigation:not(.has-custom-mobile-breakpoint) & {
+			.wp-block-navigation:not(.has-custom-collapsed-menu-breakpoint) & {
 				display: none;
 			}
 		}
 
-		&.is-custom-mobile-breakpoint-desktop {
+		&.is-custom-collapsed-menu-breakpoint-inline {
 			display: none;
 		}
 	}

--- a/packages/block-library/src/navigation/style.scss
+++ b/packages/block-library/src/navigation/style.scss
@@ -720,10 +720,10 @@ button.wp-block-navigation-item__content {
 	}
 
 	// Keep the static default breakpoint for Navigation blocks without a
-	// custom breakpoint. Custom breakpoint blocks opt out here and receive
-	// instance-scoped rules from server rendering.
+	// custom overlay breakpoint. Custom overlay breakpoint blocks opt out here
+	// and receive instance-scoped rules from server rendering.
 	@include break-small() {
-		.wp-block-navigation:not(.has-custom-collapsed-menu-breakpoint) & {
+		.wp-block-navigation:not(.has-custom-overlay-breakpoint) & {
 			&:not(.hidden-by-default) {
 				&:not(.is-menu-open) {
 					display: block;
@@ -747,7 +747,7 @@ button.wp-block-navigation-item__content {
 		}
 	}
 
-	&.is-custom-collapsed-menu-breakpoint-inline {
+	&.is-custom-overlay-breakpoint-inline {
 		&:not(.hidden-by-default) {
 			&:not(.is-menu-open) {
 				display: block;
@@ -825,15 +825,15 @@ button.wp-block-navigation-item__content {
 
 	&:not(.always-shown) {
 		// Keep the static default breakpoint for Navigation blocks without a
-		// custom breakpoint. Custom breakpoint blocks opt out here and receive
-		// instance-scoped rules from server rendering.
+		// custom overlay breakpoint. Custom overlay breakpoint blocks opt out here
+		// and receive instance-scoped rules from server rendering.
 		@include break-small {
-			.wp-block-navigation:not(.has-custom-collapsed-menu-breakpoint) & {
+			.wp-block-navigation:not(.has-custom-overlay-breakpoint) & {
 				display: none;
 			}
 		}
 
-		&.is-custom-collapsed-menu-breakpoint-inline {
+		&.is-custom-overlay-breakpoint-inline {
 			display: none;
 		}
 	}

--- a/packages/block-library/src/navigation/style.scss
+++ b/packages/block-library/src/navigation/style.scss
@@ -739,7 +739,8 @@ button.wp-block-navigation-item__content {
 			}
 
 			&.is-menu-open {
-				// Override breakpoint-inherited submenu rules.
+				// Preserve open-overlay submenu positioning after the default
+				// breakpoint styles are scoped away from custom breakpoints.
 				.wp-block-navigation__submenu-container.wp-block-navigation__submenu-container.wp-block-navigation__submenu-container.wp-block-navigation__submenu-container {
 					left: 0;
 				}
@@ -763,7 +764,8 @@ button.wp-block-navigation-item__content {
 		}
 
 		&.is-menu-open {
-			// Override breakpoint-inherited submenu rules.
+			// Match the default breakpoint path so custom breakpoints keep
+			// open-overlay submenus positioned as overlay content.
 			.wp-block-navigation__submenu-container.wp-block-navigation__submenu-container.wp-block-navigation__submenu-container.wp-block-navigation__submenu-container {
 				left: 0;
 			}

--- a/packages/block-library/src/navigation/style.scss
+++ b/packages/block-library/src/navigation/style.scss
@@ -13,6 +13,8 @@
 // Size of burger and close icons.
 $navigation-icon-size: 24px;
 
+
+
 .wp-block-navigation {
 	position: relative;
 
@@ -720,6 +722,31 @@ button.wp-block-navigation-item__content {
 	}
 
 	@include break-small() {
+		.wp-block-navigation:not(.has-custom-mobile-breakpoint) & {
+			&:not(.hidden-by-default) {
+				&:not(.is-menu-open) {
+					display: block;
+					width: 100%;
+					position: relative;
+					z-index: auto;
+					background-color: inherit;
+
+					.wp-block-navigation__responsive-container-close {
+						display: none;
+					}
+				}
+			}
+
+			&.is-menu-open {
+				// Override breakpoint-inherited submenu rules.
+				.wp-block-navigation__submenu-container.wp-block-navigation__submenu-container.wp-block-navigation__submenu-container.wp-block-navigation__submenu-container {
+					left: 0;
+				}
+			}
+		}
+	}
+
+	&.is-custom-mobile-breakpoint-desktop {
 		&:not(.hidden-by-default) {
 			&:not(.is-menu-open) {
 				display: block;
@@ -797,6 +824,12 @@ button.wp-block-navigation-item__content {
 
 	&:not(.always-shown) {
 		@include break-small {
+			.wp-block-navigation:not(.has-custom-mobile-breakpoint) & {
+				display: none;
+			}
+		}
+
+		&.is-custom-mobile-breakpoint-desktop {
 			display: none;
 		}
 	}

--- a/phpunit/blocks/render-block-navigation-test.php
+++ b/phpunit/blocks/render-block-navigation-test.php
@@ -157,13 +157,13 @@ class Render_Block_Navigation_Test extends WP_UnitTestCase {
 	}
 
 	/**
-	 * Test that the default mobile breakpoint preserves the original markup.
+	 * Test that the default collapsed menu breakpoint preserves the original markup.
 	 *
-	 * @covers ::block_core_navigation_get_mobile_breakpoint
-	 * @covers ::block_core_navigation_has_custom_mobile_breakpoint
+	 * @covers ::gutenberg_block_core_navigation_get_collapsed_menu_breakpoint
+	 * @covers ::gutenberg_block_core_navigation_has_custom_collapsed_menu_breakpoint
 	 * @covers ::gutenberg_block_core_navigation_add_support_classes_to_container
 	 */
-	public function test_default_mobile_breakpoint_preserves_block_markup() {
+	public function test_default_collapsed_menu_breakpoint_preserves_block_markup() {
 		$block_content = '<nav class="wp-block-navigation is-responsive"><button class="wp-block-navigation__responsive-container-open">Menu</button><div class="wp-block-navigation__responsive-container"><div class="wp-block-navigation__responsive-close"><div class="wp-block-navigation__responsive-dialog"><button class="wp-block-navigation__responsive-container-close">Close</button><div class="wp-block-navigation__responsive-container-content"><ul class="wp-block-navigation__container wp-block-navigation"><li>Item</li></ul></div></div></div></div></nav>';
 		$block         = array(
 			'blockName' => 'core/navigation',
@@ -175,24 +175,27 @@ class Render_Block_Navigation_Test extends WP_UnitTestCase {
 		$actual = gutenberg_block_core_navigation_add_support_classes_to_container( $block_content, $block );
 
 		$this->assertSame( $block_content, $actual );
-		$this->assertSame( '600px', block_core_navigation_get_mobile_breakpoint( $block['attrs'] ) );
-		$this->assertFalse( block_core_navigation_has_custom_mobile_breakpoint( $block['attrs'] ) );
+		$this->assertSame( '600px', gutenberg_block_core_navigation_get_collapsed_menu_breakpoint( $block['attrs'] ) );
+		$this->assertFalse( gutenberg_block_core_navigation_has_custom_collapsed_menu_breakpoint( $block['attrs'] ) );
 	}
 
 	/**
-	 * Test that custom mobile breakpoints add a scoping class and CSS.
+	 * Test that custom collapsed menu breakpoints add a scoping class and CSS.
 	 *
-	 * @covers ::block_core_navigation_get_mobile_breakpoint
-	 * @covers ::block_core_navigation_has_custom_mobile_breakpoint
+	 * @covers ::gutenberg_block_core_navigation_get_collapsed_menu_breakpoint
+	 * @covers ::gutenberg_block_core_navigation_has_custom_collapsed_menu_breakpoint
 	 * @covers ::gutenberg_block_core_navigation_add_support_classes_to_container
+	 * @dataProvider data_custom_collapsed_menu_breakpoints
+	 *
+	 * @param string $collapsed_menu_breakpoint The breakpoint value to test.
 	 */
-	public function test_custom_mobile_breakpoint_adds_scoped_styles() {
-		$block_content = '<nav class="wp-block-navigation is-responsive has-custom-mobile-breakpoint"><button class="wp-block-navigation__responsive-container-open">Menu</button><div class="wp-block-navigation__responsive-container"><div class="wp-block-navigation__responsive-close"><div class="wp-block-navigation__responsive-dialog"><button class="wp-block-navigation__responsive-container-close">Close</button><div class="wp-block-navigation__responsive-container-content"><ul class="wp-block-navigation__container wp-block-navigation"><li>Item</li></ul></div></div></div></div></nav>';
+	public function test_custom_collapsed_menu_breakpoint_adds_scoped_styles( $collapsed_menu_breakpoint ) {
+		$block_content = '<nav class="wp-block-navigation is-responsive has-custom-collapsed-menu-breakpoint"><button class="wp-block-navigation__responsive-container-open">Menu</button><div class="wp-block-navigation__responsive-container"><div class="wp-block-navigation__responsive-close"><div class="wp-block-navigation__responsive-dialog"><button class="wp-block-navigation__responsive-container-close">Close</button><div class="wp-block-navigation__responsive-container-content"><ul class="wp-block-navigation__container wp-block-navigation"><li>Item</li></ul></div></div></div></div></nav>';
 		$block         = array(
 			'blockName' => 'core/navigation',
 			'attrs'     => array(
 				'overlayMenu'       => 'mobile',
-				'mobileBreakpoint'  => '48rem',
+				'collapsedMenuBreakpoint'  => $collapsed_menu_breakpoint,
 			),
 		);
 
@@ -202,26 +205,43 @@ class Render_Block_Navigation_Test extends WP_UnitTestCase {
 		$breakpoint_class = $matches[0];
 		$stylesheet       = gutenberg_style_engine_get_stylesheet_from_context( 'block-supports', array( 'prettify' => false ) );
 
-		$this->assertSame( '48rem', block_core_navigation_get_mobile_breakpoint( $block['attrs'] ) );
-		$this->assertTrue( block_core_navigation_has_custom_mobile_breakpoint( $block['attrs'] ) );
-		$this->assertStringContainsString( "@media (min-width: 48rem){.wp-block-navigation.$breakpoint_class.has-custom-mobile-breakpoint .wp-block-navigation__responsive-container:not(.hidden-by-default):not(.is-menu-open){display:block;width:100%;position:relative;z-index:auto;background-color:inherit;}", $stylesheet );
-		$this->assertStringContainsString( ".wp-block-navigation.$breakpoint_class.has-custom-mobile-breakpoint .wp-block-navigation__responsive-container-open:not(.always-shown){display:none;}", $stylesheet );
+		$this->assertSame( $collapsed_menu_breakpoint, gutenberg_block_core_navigation_get_collapsed_menu_breakpoint( $block['attrs'] ) );
+		$this->assertTrue( gutenberg_block_core_navigation_has_custom_collapsed_menu_breakpoint( $block['attrs'] ) );
+		$this->assertStringContainsString( "@media (min-width: $collapsed_menu_breakpoint){.wp-block-navigation.$breakpoint_class.has-custom-collapsed-menu-breakpoint .wp-block-navigation__responsive-container:not(.hidden-by-default):not(.is-menu-open){display:block;width:100%;position:relative;z-index:auto;background-color:inherit;}", $stylesheet );
+		$this->assertStringContainsString( ".wp-block-navigation.$breakpoint_class.has-custom-collapsed-menu-breakpoint .wp-block-navigation__responsive-container-open:not(.always-shown){display:none;}", $stylesheet );
 	}
 
 	/**
-	 * Test that invalid mobile breakpoints fall back to the default.
+	 * Data provider for valid custom collapsed menu breakpoints.
 	 *
-	 * @covers ::block_core_navigation_get_mobile_breakpoint
-	 * @covers ::block_core_navigation_has_custom_mobile_breakpoint
-	 * @covers ::gutenberg_block_core_navigation_add_support_classes_to_container
+	 * @return array[]
 	 */
-	public function test_invalid_mobile_breakpoint_falls_back_to_default() {
+	public function data_custom_collapsed_menu_breakpoints() {
+		return array(
+			'px'  => array( '10px' ),
+			'em'  => array( '37.5em' ),
+			'rem' => array( '48rem' ),
+		);
+	}
+
+	/**
+	 * Test that invalid collapsed menu breakpoints fall back to the default.
+	 *
+	 * @covers ::gutenberg_block_core_navigation_get_collapsed_menu_breakpoint
+	 * @covers ::gutenberg_block_core_navigation_has_custom_collapsed_menu_breakpoint
+	 * @covers ::gutenberg_block_core_navigation_add_support_classes_to_container
+	 * @dataProvider data_invalid_collapsed_menu_breakpoints
+	 *
+	 * @param string $collapsed_menu_breakpoint Invalid breakpoint value to test.
+	 * @param string $unsafe_fragment   Unsafe fragment that must not be emitted.
+	 */
+	public function test_invalid_collapsed_menu_breakpoint_falls_back_to_default( $collapsed_menu_breakpoint, $unsafe_fragment ) {
 		$block_content = '<nav class="wp-block-navigation is-responsive"><button class="wp-block-navigation__responsive-container-open">Menu</button><div class="wp-block-navigation__responsive-container"><div class="wp-block-navigation__responsive-close"><div class="wp-block-navigation__responsive-dialog"><button class="wp-block-navigation__responsive-container-close">Close</button><div class="wp-block-navigation__responsive-container-content"><ul class="wp-block-navigation__container wp-block-navigation"><li>Item</li></ul></div></div></div></div></nav>';
 		$block         = array(
 			'blockName' => 'core/navigation',
 			'attrs'     => array(
 				'overlayMenu'       => 'mobile',
-				'mobileBreakpoint'  => 'calc(100vw - 1rem)',
+				'collapsedMenuBreakpoint'  => $collapsed_menu_breakpoint,
 			),
 		);
 
@@ -229,10 +249,28 @@ class Render_Block_Navigation_Test extends WP_UnitTestCase {
 		$stylesheet = gutenberg_style_engine_get_stylesheet_from_context( 'block-supports', array( 'prettify' => false ) );
 
 		$this->assertSame( $block_content, $actual );
-		$this->assertSame( '600px', block_core_navigation_get_mobile_breakpoint( $block['attrs'] ) );
-		$this->assertFalse( block_core_navigation_has_custom_mobile_breakpoint( $block['attrs'] ) );
+		$this->assertSame( '600px', gutenberg_block_core_navigation_get_collapsed_menu_breakpoint( $block['attrs'] ) );
+		$this->assertFalse( gutenberg_block_core_navigation_has_custom_collapsed_menu_breakpoint( $block['attrs'] ) );
 		$this->assertStringNotContainsString( 'wp-block-navigation-custom-breakpoint-', $stylesheet );
-		$this->assertStringNotContainsString( 'calc(100vw - 1rem)', $stylesheet );
+		$this->assertStringNotContainsString( $unsafe_fragment, $stylesheet );
+	}
+
+	/**
+	 * Data provider for invalid and malicious custom collapsed menu breakpoints.
+	 *
+	 * @return array[]
+	 */
+	public function data_invalid_collapsed_menu_breakpoints() {
+		return array(
+			'calc expression'       => array( 'calc(100vw - 1rem)', 'calc(100vw - 1rem)' ),
+			'css rule injection'   => array( '10px);body{background:red}', 'body{background:red}' ),
+			'javascript URL'       => array( '10px;background:url(javascript:alert(1))', 'javascript:alert(1)' ),
+			'css comment'          => array( '10px/*comment*/', '/*comment*/' ),
+			'html style tag'       => array( '<style>10px</style>', '<style>' ),
+			'css expression'       => array( 'expression(alert(1))', 'expression(alert(1))' ),
+			'unsupported unit'     => array( '40vw', '40vw' ),
+			'non-positive length'  => array( '0px', '0px' ),
+		);
 	}
 
 	/**

--- a/phpunit/blocks/render-block-navigation-test.php
+++ b/phpunit/blocks/render-block-navigation-test.php
@@ -262,14 +262,14 @@ class Render_Block_Navigation_Test extends WP_UnitTestCase {
 	 */
 	public function data_invalid_overlay_breakpoints() {
 		return array(
-			'calc expression'       => array( 'calc(100vw - 1rem)', 'calc(100vw - 1rem)' ),
-			'css rule injection'   => array( '10px);body{background:red}', 'body{background:red}' ),
-			'javascript URL'       => array( '10px;background:url(javascript:alert(1))', 'javascript:alert(1)' ),
-			'css comment'          => array( '10px/*comment*/', '/*comment*/' ),
-			'html style tag'       => array( '<style>10px</style>', '<style>' ),
-			'css expression'       => array( 'expression(alert(1))', 'expression(alert(1))' ),
-			'unsupported unit'     => array( '40vw', '40vw' ),
-			'non-positive length'  => array( '0px', '0px' ),
+			'calc expression'     => array( 'calc(100vw - 1rem)', 'calc(100vw - 1rem)' ),
+			'css rule injection'  => array( '10px);body{background:red}', 'body{background:red}' ),
+			'javascript URL'      => array( '10px;background:url(javascript:alert(1))', 'javascript:alert(1)' ),
+			'css comment'         => array( '10px/*comment*/', '/*comment*/' ),
+			'html style tag'      => array( '<style>10px</style>', '<style>' ),
+			'css expression'      => array( 'expression(alert(1))', 'expression(alert(1))' ),
+			'unsupported unit'    => array( '40vw', '40vw' ),
+			'non-positive length' => array( '0px', '0px' ),
 		);
 	}
 

--- a/phpunit/blocks/render-block-navigation-test.php
+++ b/phpunit/blocks/render-block-navigation-test.php
@@ -12,6 +12,11 @@
  * @group blocks
  */
 class Render_Block_Navigation_Test extends WP_UnitTestCase {
+	public function tear_down() {
+		WP_Style_Engine_CSS_Rules_Store_Gutenberg::remove_all_stores();
+		parent::tear_down();
+	}
+
 	/**
 	 * @covers gutenberg_block_core_navigation_from_block_get_post_ids
 	 */
@@ -149,6 +154,85 @@ class Render_Block_Navigation_Test extends WP_UnitTestCase {
 		$actual = gutenberg_block_core_navigation_add_support_classes_to_container( $block_content, $block );
 
 		$this->assertSame( $block_content, $actual );
+	}
+
+	/**
+	 * Test that the default mobile breakpoint preserves the original markup.
+	 *
+	 * @covers ::block_core_navigation_get_mobile_breakpoint
+	 * @covers ::block_core_navigation_has_custom_mobile_breakpoint
+	 * @covers ::gutenberg_block_core_navigation_add_support_classes_to_container
+	 */
+	public function test_default_mobile_breakpoint_preserves_block_markup() {
+		$block_content = '<nav class="wp-block-navigation is-responsive"><button class="wp-block-navigation__responsive-container-open">Menu</button><div class="wp-block-navigation__responsive-container"><div class="wp-block-navigation__responsive-close"><div class="wp-block-navigation__responsive-dialog"><button class="wp-block-navigation__responsive-container-close">Close</button><div class="wp-block-navigation__responsive-container-content"><ul class="wp-block-navigation__container wp-block-navigation"><li>Item</li></ul></div></div></div></div></nav>';
+		$block         = array(
+			'blockName' => 'core/navigation',
+			'attrs'     => array(
+				'overlayMenu' => 'mobile',
+			),
+		);
+
+		$actual = gutenberg_block_core_navigation_add_support_classes_to_container( $block_content, $block );
+
+		$this->assertSame( $block_content, $actual );
+		$this->assertSame( '600px', block_core_navigation_get_mobile_breakpoint( $block['attrs'] ) );
+		$this->assertFalse( block_core_navigation_has_custom_mobile_breakpoint( $block['attrs'] ) );
+	}
+
+	/**
+	 * Test that custom mobile breakpoints add a scoping class and CSS.
+	 *
+	 * @covers ::block_core_navigation_get_mobile_breakpoint
+	 * @covers ::block_core_navigation_has_custom_mobile_breakpoint
+	 * @covers ::gutenberg_block_core_navigation_add_support_classes_to_container
+	 */
+	public function test_custom_mobile_breakpoint_adds_scoped_styles() {
+		$block_content = '<nav class="wp-block-navigation is-responsive has-custom-mobile-breakpoint"><button class="wp-block-navigation__responsive-container-open">Menu</button><div class="wp-block-navigation__responsive-container"><div class="wp-block-navigation__responsive-close"><div class="wp-block-navigation__responsive-dialog"><button class="wp-block-navigation__responsive-container-close">Close</button><div class="wp-block-navigation__responsive-container-content"><ul class="wp-block-navigation__container wp-block-navigation"><li>Item</li></ul></div></div></div></div></nav>';
+		$block         = array(
+			'blockName' => 'core/navigation',
+			'attrs'     => array(
+				'overlayMenu'       => 'mobile',
+				'mobileBreakpoint'  => '48rem',
+			),
+		);
+
+		$actual = gutenberg_block_core_navigation_add_support_classes_to_container( $block_content, $block );
+		$this->assertMatchesRegularExpression( '/\bwp-block-navigation-custom-breakpoint-(\d+)\b/', $actual );
+		preg_match( '/\bwp-block-navigation-custom-breakpoint-(\d+)\b/', $actual, $matches );
+		$breakpoint_class = $matches[0];
+		$stylesheet       = gutenberg_style_engine_get_stylesheet_from_context( 'block-supports', array( 'prettify' => false ) );
+
+		$this->assertSame( '48rem', block_core_navigation_get_mobile_breakpoint( $block['attrs'] ) );
+		$this->assertTrue( block_core_navigation_has_custom_mobile_breakpoint( $block['attrs'] ) );
+		$this->assertStringContainsString( "@media (min-width: 48rem){.wp-block-navigation.$breakpoint_class.has-custom-mobile-breakpoint .wp-block-navigation__responsive-container:not(.hidden-by-default):not(.is-menu-open){display:block;width:100%;position:relative;z-index:auto;background-color:inherit;}", $stylesheet );
+		$this->assertStringContainsString( ".wp-block-navigation.$breakpoint_class.has-custom-mobile-breakpoint .wp-block-navigation__responsive-container-open:not(.always-shown){display:none;}", $stylesheet );
+	}
+
+	/**
+	 * Test that invalid mobile breakpoints fall back to the default.
+	 *
+	 * @covers ::block_core_navigation_get_mobile_breakpoint
+	 * @covers ::block_core_navigation_has_custom_mobile_breakpoint
+	 * @covers ::gutenberg_block_core_navigation_add_support_classes_to_container
+	 */
+	public function test_invalid_mobile_breakpoint_falls_back_to_default() {
+		$block_content = '<nav class="wp-block-navigation is-responsive"><button class="wp-block-navigation__responsive-container-open">Menu</button><div class="wp-block-navigation__responsive-container"><div class="wp-block-navigation__responsive-close"><div class="wp-block-navigation__responsive-dialog"><button class="wp-block-navigation__responsive-container-close">Close</button><div class="wp-block-navigation__responsive-container-content"><ul class="wp-block-navigation__container wp-block-navigation"><li>Item</li></ul></div></div></div></div></nav>';
+		$block         = array(
+			'blockName' => 'core/navigation',
+			'attrs'     => array(
+				'overlayMenu'       => 'mobile',
+				'mobileBreakpoint'  => 'calc(100vw - 1rem)',
+			),
+		);
+
+		$actual     = gutenberg_block_core_navigation_add_support_classes_to_container( $block_content, $block );
+		$stylesheet = gutenberg_style_engine_get_stylesheet_from_context( 'block-supports', array( 'prettify' => false ) );
+
+		$this->assertSame( $block_content, $actual );
+		$this->assertSame( '600px', block_core_navigation_get_mobile_breakpoint( $block['attrs'] ) );
+		$this->assertFalse( block_core_navigation_has_custom_mobile_breakpoint( $block['attrs'] ) );
+		$this->assertStringNotContainsString( 'wp-block-navigation-custom-breakpoint-', $stylesheet );
+		$this->assertStringNotContainsString( 'calc(100vw - 1rem)', $stylesheet );
 	}
 
 	/**

--- a/phpunit/blocks/render-block-navigation-test.php
+++ b/phpunit/blocks/render-block-navigation-test.php
@@ -157,13 +157,13 @@ class Render_Block_Navigation_Test extends WP_UnitTestCase {
 	}
 
 	/**
-	 * Test that the default collapsed menu breakpoint preserves the original markup.
+	 * Test that the default overlay breakpoint preserves the original markup.
 	 *
-	 * @covers ::gutenberg_block_core_navigation_get_collapsed_menu_breakpoint
-	 * @covers ::gutenberg_block_core_navigation_has_custom_collapsed_menu_breakpoint
+	 * @covers ::gutenberg_block_core_navigation_get_overlay_breakpoint
+	 * @covers ::gutenberg_block_core_navigation_has_custom_overlay_breakpoint
 	 * @covers ::gutenberg_block_core_navigation_add_support_classes_to_container
 	 */
-	public function test_default_collapsed_menu_breakpoint_preserves_block_markup() {
+	public function test_default_overlay_breakpoint_preserves_block_markup() {
 		$block_content = '<nav class="wp-block-navigation is-responsive"><button class="wp-block-navigation__responsive-container-open">Menu</button><div class="wp-block-navigation__responsive-container"><div class="wp-block-navigation__responsive-close"><div class="wp-block-navigation__responsive-dialog"><button class="wp-block-navigation__responsive-container-close">Close</button><div class="wp-block-navigation__responsive-container-content"><ul class="wp-block-navigation__container wp-block-navigation"><li>Item</li></ul></div></div></div></div></nav>';
 		$block         = array(
 			'blockName' => 'core/navigation',
@@ -175,48 +175,48 @@ class Render_Block_Navigation_Test extends WP_UnitTestCase {
 		$actual = gutenberg_block_core_navigation_add_support_classes_to_container( $block_content, $block );
 
 		$this->assertSame( $block_content, $actual );
-		$this->assertSame( '600px', gutenberg_block_core_navigation_get_collapsed_menu_breakpoint( $block['attrs'] ) );
-		$this->assertFalse( gutenberg_block_core_navigation_has_custom_collapsed_menu_breakpoint( $block['attrs'] ) );
+		$this->assertSame( '600px', gutenberg_block_core_navigation_get_overlay_breakpoint( $block['attrs'] ) );
+		$this->assertFalse( gutenberg_block_core_navigation_has_custom_overlay_breakpoint( $block['attrs'] ) );
 	}
 
 	/**
-	 * Test that custom collapsed menu breakpoints add a scoping class and CSS.
+	 * Test that custom overlay breakpoints add a scoping class and CSS.
 	 *
-	 * @covers ::gutenberg_block_core_navigation_get_collapsed_menu_breakpoint
-	 * @covers ::gutenberg_block_core_navigation_has_custom_collapsed_menu_breakpoint
+	 * @covers ::gutenberg_block_core_navigation_get_overlay_breakpoint
+	 * @covers ::gutenberg_block_core_navigation_has_custom_overlay_breakpoint
 	 * @covers ::gutenberg_block_core_navigation_add_support_classes_to_container
-	 * @dataProvider data_custom_collapsed_menu_breakpoints
+	 * @dataProvider data_custom_overlay_breakpoints
 	 *
-	 * @param string $collapsed_menu_breakpoint The breakpoint value to test.
+	 * @param string $overlay_breakpoint The breakpoint value to test.
 	 */
-	public function test_custom_collapsed_menu_breakpoint_adds_scoped_styles( $collapsed_menu_breakpoint ) {
-		$block_content = '<nav class="wp-block-navigation is-responsive has-custom-collapsed-menu-breakpoint"><button class="wp-block-navigation__responsive-container-open">Menu</button><div class="wp-block-navigation__responsive-container"><div class="wp-block-navigation__responsive-close"><div class="wp-block-navigation__responsive-dialog"><button class="wp-block-navigation__responsive-container-close">Close</button><div class="wp-block-navigation__responsive-container-content"><ul class="wp-block-navigation__container wp-block-navigation"><li>Item</li></ul></div></div></div></div></nav>';
+	public function test_custom_overlay_breakpoint_adds_scoped_styles( $overlay_breakpoint ) {
+		$block_content = '<nav class="wp-block-navigation is-responsive has-custom-overlay-breakpoint"><button class="wp-block-navigation__responsive-container-open">Menu</button><div class="wp-block-navigation__responsive-container"><div class="wp-block-navigation__responsive-close"><div class="wp-block-navigation__responsive-dialog"><button class="wp-block-navigation__responsive-container-close">Close</button><div class="wp-block-navigation__responsive-container-content"><ul class="wp-block-navigation__container wp-block-navigation"><li>Item</li></ul></div></div></div></div></nav>';
 		$block         = array(
 			'blockName' => 'core/navigation',
 			'attrs'     => array(
 				'overlayMenu'       => 'mobile',
-				'collapsedMenuBreakpoint'  => $collapsed_menu_breakpoint,
+				'overlayBreakpoint' => $overlay_breakpoint,
 			),
 		);
 
 		$actual = gutenberg_block_core_navigation_add_support_classes_to_container( $block_content, $block );
-		$this->assertMatchesRegularExpression( '/\bwp-block-navigation-custom-breakpoint-(\d+)\b/', $actual );
-		preg_match( '/\bwp-block-navigation-custom-breakpoint-(\d+)\b/', $actual, $matches );
+		$this->assertMatchesRegularExpression( '/\bwp-block-navigation-custom-overlay-breakpoint-(\d+)\b/', $actual );
+		preg_match( '/\bwp-block-navigation-custom-overlay-breakpoint-(\d+)\b/', $actual, $matches );
 		$breakpoint_class = $matches[0];
 		$stylesheet       = gutenberg_style_engine_get_stylesheet_from_context( 'block-supports', array( 'prettify' => false ) );
 
-		$this->assertSame( $collapsed_menu_breakpoint, gutenberg_block_core_navigation_get_collapsed_menu_breakpoint( $block['attrs'] ) );
-		$this->assertTrue( gutenberg_block_core_navigation_has_custom_collapsed_menu_breakpoint( $block['attrs'] ) );
-		$this->assertStringContainsString( "@media (min-width: $collapsed_menu_breakpoint){.wp-block-navigation.$breakpoint_class.has-custom-collapsed-menu-breakpoint .wp-block-navigation__responsive-container:not(.hidden-by-default):not(.is-menu-open){display:block;width:100%;position:relative;z-index:auto;background-color:inherit;}", $stylesheet );
-		$this->assertStringContainsString( ".wp-block-navigation.$breakpoint_class.has-custom-collapsed-menu-breakpoint .wp-block-navigation__responsive-container-open:not(.always-shown){display:none;}", $stylesheet );
+		$this->assertSame( $overlay_breakpoint, gutenberg_block_core_navigation_get_overlay_breakpoint( $block['attrs'] ) );
+		$this->assertTrue( gutenberg_block_core_navigation_has_custom_overlay_breakpoint( $block['attrs'] ) );
+		$this->assertStringContainsString( "@media (min-width: $overlay_breakpoint){.wp-block-navigation.$breakpoint_class.has-custom-overlay-breakpoint .wp-block-navigation__responsive-container:not(.hidden-by-default):not(.is-menu-open){display:block;width:100%;position:relative;z-index:auto;background-color:inherit;}", $stylesheet );
+		$this->assertStringContainsString( ".wp-block-navigation.$breakpoint_class.has-custom-overlay-breakpoint .wp-block-navigation__responsive-container-open:not(.always-shown){display:none;}", $stylesheet );
 	}
 
 	/**
-	 * Data provider for valid custom collapsed menu breakpoints.
+	 * Data provider for valid custom overlay breakpoints.
 	 *
 	 * @return array[]
 	 */
-	public function data_custom_collapsed_menu_breakpoints() {
+	public function data_custom_overlay_breakpoints() {
 		return array(
 			'px'  => array( '10px' ),
 			'em'  => array( '37.5em' ),
@@ -225,23 +225,23 @@ class Render_Block_Navigation_Test extends WP_UnitTestCase {
 	}
 
 	/**
-	 * Test that invalid collapsed menu breakpoints fall back to the default.
+	 * Test that invalid overlay breakpoints fall back to the default.
 	 *
-	 * @covers ::gutenberg_block_core_navigation_get_collapsed_menu_breakpoint
-	 * @covers ::gutenberg_block_core_navigation_has_custom_collapsed_menu_breakpoint
+	 * @covers ::gutenberg_block_core_navigation_get_overlay_breakpoint
+	 * @covers ::gutenberg_block_core_navigation_has_custom_overlay_breakpoint
 	 * @covers ::gutenberg_block_core_navigation_add_support_classes_to_container
-	 * @dataProvider data_invalid_collapsed_menu_breakpoints
+	 * @dataProvider data_invalid_overlay_breakpoints
 	 *
-	 * @param string $collapsed_menu_breakpoint Invalid breakpoint value to test.
+	 * @param string $overlay_breakpoint Invalid breakpoint value to test.
 	 * @param string $unsafe_fragment   Unsafe fragment that must not be emitted.
 	 */
-	public function test_invalid_collapsed_menu_breakpoint_falls_back_to_default( $collapsed_menu_breakpoint, $unsafe_fragment ) {
+	public function test_invalid_overlay_breakpoint_falls_back_to_default( $overlay_breakpoint, $unsafe_fragment ) {
 		$block_content = '<nav class="wp-block-navigation is-responsive"><button class="wp-block-navigation__responsive-container-open">Menu</button><div class="wp-block-navigation__responsive-container"><div class="wp-block-navigation__responsive-close"><div class="wp-block-navigation__responsive-dialog"><button class="wp-block-navigation__responsive-container-close">Close</button><div class="wp-block-navigation__responsive-container-content"><ul class="wp-block-navigation__container wp-block-navigation"><li>Item</li></ul></div></div></div></div></nav>';
 		$block         = array(
 			'blockName' => 'core/navigation',
 			'attrs'     => array(
 				'overlayMenu'       => 'mobile',
-				'collapsedMenuBreakpoint'  => $collapsed_menu_breakpoint,
+				'overlayBreakpoint' => $overlay_breakpoint,
 			),
 		);
 
@@ -249,18 +249,18 @@ class Render_Block_Navigation_Test extends WP_UnitTestCase {
 		$stylesheet = gutenberg_style_engine_get_stylesheet_from_context( 'block-supports', array( 'prettify' => false ) );
 
 		$this->assertSame( $block_content, $actual );
-		$this->assertSame( '600px', gutenberg_block_core_navigation_get_collapsed_menu_breakpoint( $block['attrs'] ) );
-		$this->assertFalse( gutenberg_block_core_navigation_has_custom_collapsed_menu_breakpoint( $block['attrs'] ) );
-		$this->assertStringNotContainsString( 'wp-block-navigation-custom-breakpoint-', $stylesheet );
+		$this->assertSame( '600px', gutenberg_block_core_navigation_get_overlay_breakpoint( $block['attrs'] ) );
+		$this->assertFalse( gutenberg_block_core_navigation_has_custom_overlay_breakpoint( $block['attrs'] ) );
+		$this->assertStringNotContainsString( 'wp-block-navigation-custom-overlay-breakpoint-', $stylesheet );
 		$this->assertStringNotContainsString( $unsafe_fragment, $stylesheet );
 	}
 
 	/**
-	 * Data provider for invalid and malicious custom collapsed menu breakpoints.
+	 * Data provider for invalid and malicious custom overlay breakpoints.
 	 *
 	 * @return array[]
 	 */
-	public function data_invalid_collapsed_menu_breakpoints() {
+	public function data_invalid_overlay_breakpoints() {
 		return array(
 			'calc expression'       => array( 'calc(100vw - 1rem)', 'calc(100vw - 1rem)' ),
 			'css rule injection'   => array( '10px);body{background:red}', 'body{background:red}' ),
@@ -270,6 +270,48 @@ class Render_Block_Navigation_Test extends WP_UnitTestCase {
 			'css expression'       => array( 'expression(alert(1))', 'expression(alert(1))' ),
 			'unsupported unit'     => array( '40vw', '40vw' ),
 			'non-positive length'  => array( '0px', '0px' ),
+		);
+	}
+
+	/**
+	 * Test that custom overlay breakpoints are ignored outside the responsive overlay setting.
+	 *
+	 * @covers ::gutenberg_block_core_navigation_get_overlay_breakpoint
+	 * @covers ::gutenberg_block_core_navigation_has_custom_overlay_breakpoint
+	 * @covers ::gutenberg_block_core_navigation_add_support_classes_to_container
+	 * @dataProvider data_non_responsive_overlay_menu_settings
+	 *
+	 * @param string $overlay_menu Overlay menu setting to test.
+	 */
+	public function test_custom_overlay_breakpoint_is_ignored_when_overlay_visibility_is_not_responsive( $overlay_menu ) {
+		$block_content = '<nav class="wp-block-navigation is-responsive has-custom-overlay-breakpoint"><button class="wp-block-navigation__responsive-container-open">Menu</button><div class="wp-block-navigation__responsive-container"><div class="wp-block-navigation__responsive-close"><div class="wp-block-navigation__responsive-dialog"><button class="wp-block-navigation__responsive-container-close">Close</button><div class="wp-block-navigation__responsive-container-content"><ul class="wp-block-navigation__container wp-block-navigation"><li>Item</li></ul></div></div></div></div></nav>';
+		$block         = array(
+			'blockName' => 'core/navigation',
+			'attrs'     => array(
+				'overlayMenu'       => $overlay_menu,
+				'overlayBreakpoint' => '10px',
+			),
+		);
+
+		$actual     = gutenberg_block_core_navigation_add_support_classes_to_container( $block_content, $block );
+		$stylesheet = gutenberg_style_engine_get_stylesheet_from_context( 'block-supports', array( 'prettify' => false ) );
+
+		$this->assertSame( $block_content, $actual );
+		$this->assertSame( '10px', gutenberg_block_core_navigation_get_overlay_breakpoint( $block['attrs'] ) );
+		$this->assertFalse( gutenberg_block_core_navigation_has_custom_overlay_breakpoint( $block['attrs'] ) );
+		$this->assertStringNotContainsString( 'wp-block-navigation-custom-overlay-breakpoint-', $actual );
+		$this->assertStringNotContainsString( 'wp-block-navigation-custom-overlay-breakpoint-', $stylesheet );
+	}
+
+	/**
+	 * Data provider for overlay visibility settings that do not use breakpoints.
+	 *
+	 * @return array[]
+	 */
+	public function data_non_responsive_overlay_menu_settings() {
+		return array(
+			'never'  => array( 'never' ),
+			'always' => array( 'always' ),
 		);
 	}
 

--- a/test/integration/fixtures/blocks/core__navigation.json
+++ b/test/integration/fixtures/blocks/core__navigation.json
@@ -6,6 +6,7 @@
 			"showSubmenuIcon": true,
 			"submenuVisibility": "hover",
 			"overlayMenu": "mobile",
+			"overlayBreakpoint": "600px",
 			"icon": "handle",
 			"hasIcon": true,
 			"maxNestingLevel": 5

--- a/tools/eslint/suppressions.json
+++ b/tools/eslint/suppressions.json
@@ -399,11 +399,6 @@
 			"count": 1
 		}
 	},
-	"packages/block-library/src/navigation/edit/overlay-panel.js": {
-		"@wordpress/use-recommended-components": {
-			"count": 1
-		}
-	},
 	"packages/block-library/src/navigation/edit/overlay-template-part-selector.js": {
 		"@wordpress/use-recommended-components": {
 			"count": 2


### PR DESCRIPTION
## What

Adds an `overlayBreakpoint` attribute to the Navigation block so the responsive overlay can switch between the collapsed menu button and inline navigation items at a user-configured viewport width.

This is a major refresh of the earlier PR direction. The PR had gone stale, so the implementation has been updated to fit the current Navigation block overlay architecture and the newer patterns now present in `trunk`.

## Why

The Navigation block currently uses a fixed breakpoint for its mobile overlay behavior. That can be too limiting for themes and layouts where navigation needs to collapse earlier or later depending on available space, typography, item count, or design requirements.

## How

- Adds an `overlayBreakpoint` block attribute with a default of `600px`.
- Adds an Overlay breakpoint control to the Navigation block Overlay settings when Overlay Visibility is set to Mobile.
- Supports `px`, `em`, and `rem` values, including decimal values.
- Normalizes invalid or unsafe values back to the default breakpoint.
- Preserves the existing default breakpoint behavior for Navigation blocks without a custom value.
- Emits instance-scoped frontend CSS only when a valid custom mobile overlay breakpoint is used.
- Mirrors the custom breakpoint behavior in the editor preview.
- Ignores custom breakpoint styling for Overlay Visibility values that do not use a responsive breakpoint, such as Off and Always.
- Updates Navigation block docs and adds JS/PHP coverage for validation, editor behavior, rendered CSS, and default compatibility.

## FAQs

### Why 600px?

- `600px` is the breakpoint Navigation already uses today through WordPress's small breakpoint, not a new design decision introduced by this PR.
- `packages/base-styles/_breakpoints.scss:12` defines `$break-small: 600px`.
- `packages/base-styles/_mixins.scss:118` exposes that value as `break-small()`.
- Keeping that value as the default preserves the current behavior for existing Navigation blocks.
- Custom values only apply when a block has a valid non-default Mobile overlay breakpoint, and those styles are scoped to the individual Navigation block instance.

### Why not automate this?

Two automation routes were explored before returning to an explicit breakpoint control:

- CSS/intrinsic layout, including container queries.
- JavaScript measurement, where the block detects at runtime whether the navigation still fits.

Those routes did not give us a robust enough solution for this PR:

- Container queries were suggested in [#45274](https://github.com/WordPress/gutenberg/pull/45274#issuecomment-1292037460) and explored further in [#53475](https://github.com/WordPress/gutenberg/discussions/53475).
- The blocker is that container queries still require an explicit threshold, for example "when this container is narrower than `X`, switch layout." They do not automatically know when the Navigation block's inline items no longer fit.
- The correct `X` is content-dependent. It changes with the number of menu items, label length, font size, spacing, submenu indicators, and translations. A threshold that works for one Navigation instance can be wrong for another instance in the same theme.
- Querying the Navigation block's own container is not enough because many real headers break due to surrounding layout, not only the menu itself. Site Logo, Site Title, social links, Groups, Columns, spacing, and future layout containers can all reduce the available space.
- Querying a parent container does not solve that either. It just moves the hardcoded threshold to a different container, and the right parent can vary across header layouts.
- [#57587](https://github.com/WordPress/gutenberg/pull/57587) explored a JavaScript `auto` mode because CSS/container queries could not answer the actual question: "do these navigation items still fit in this layout right now?" That route required measurement heuristics across both Navigation items and parent containers.
- Those heuristics surfaced unresolved concerns around layout assumptions, nested containers, zooming, multiple collapsible menus, resize handling, editor-visible wrapped states, measurement performance, and future Grid layout changes.
- This PR therefore takes the narrower route: preserve the default behavior, expose a custom value only for the Mobile overlay case, and scope generated CSS to the individual Navigation block instance.

### How does this relate to the WordPress 7.1 responsive styling system?

- The new responsive styling system and this PR solve different problems.
- The WordPress 7.1 responsive styling system lets block styles vary across named viewport states such as `@mobile` and `@tablet`. Those states are driven by `settings.viewport.mobile` and `settings.viewport.tablet`.
- `overlayBreakpoint` is not a responsive style state. It is a Navigation-block behavior setting that controls when one Navigation block switches between inline items and the overlay menu button.
- Changing `settings.viewport` does not automatically change a Navigation block's `overlayBreakpoint`, and changing `overlayBreakpoint` does not redefine the site's `@mobile` or `@tablet` style breakpoints.
- The two systems can still work together. Responsive style controls can adjust how the Navigation block looks at mobile/tablet viewports, while `overlayBreakpoint` controls when the overlay behavior starts.
- In practice, a theme or user can choose matching values if they want the Navigation overlay transition to align with a site viewport breakpoint, but this PR does not force that coupling.
- Keeping the values separate avoids making a content-dependent Navigation behavior part of the global responsive styling API, while still preserving compatibility with the new responsive styling system.

## Testing Instructions

1. Add a Navigation block.
2. Open the block settings sidebar and expand the Overlay panel.
3. Set Overlay Visibility to Mobile.
4. Change the Overlay breakpoint value, for example `720px`, `37.5em`, or `48rem`.
5. Resize the editor and frontend viewport and confirm the Navigation block switches between the menu button and inline navigation items at the configured breakpoint.
6. Confirm a Navigation block using the default `600px` breakpoint still behaves as before.
7. Confirm the Overlay breakpoint control is hidden when Overlay Visibility is Off or Always.
8. Run `npm run test:unit packages/block-library/src/navigation/edit/test`.
9. With the test environment running, run `vendor/bin/phpunit phpunit/blocks/render-block-navigation-test.php`.
