### PR TITLE
Add type check user cpt array

### DIFF
--- a/lib/compat/wordpress-6.1/class-wp-theme-json-resolver-6-1.php
+++ b/lib/compat/wordpress-6.1/class-wp-theme-json-resolver-6-1.php
@@ -80,8 +80,7 @@ class WP_Theme_JSON_Resolver_6_1 extends WP_Theme_JSON_Resolver_6_0 {
 
 		$config   = array();
 		$user_cpt = static::get_user_data_from_wp_global_styles( wp_get_theme() );
-
-		if ( array_key_exists( 'post_content', $user_cpt ) ) {
+		if ( is_array( $user_cpt ) && array_key_exists( 'post_content', $user_cpt ) ) {
 			$decoded_data = json_decode( $user_cpt['post_content'], true );
 
 			$json_decoding_error = json_last_error();


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->
Fixes #45240 

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
If `$user_cpt` is not an array. `array_key_exists( 'post_content', $user_cpt )` function can throw a Fatal error or a warning.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
Add the `is_array()` check to the conditional.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->

## Screenshots or screencast <!-- if applicable -->
