### PR TITLE
Tests: Use `container` instead of `container.firstChild` for snapshots

### DIFF
--- a/packages/block-editor/src/components/block-breadcrumb/test/__snapshots__/index.js.snap
+++ b/packages/block-editor/src/components/block-breadcrumb/test/__snapshots__/index.js.snap
@@ -1,16 +1,18 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`BlockBreadcrumb should render correctly 1`] = `
-<ul
-  aria-label="Block breadcrumb"
-  class="block-editor-block-breadcrumb"
-  role="list"
->
-  <li
-    aria-current="true"
-    class="block-editor-block-breadcrumb__current"
+<div>
+  <ul
+    aria-label="Block breadcrumb"
+    class="block-editor-block-breadcrumb"
+    role="list"
   >
-    Document
-  </li>
-</ul>
+    <li
+      aria-current="true"
+      class="block-editor-block-breadcrumb__current"
+    >
+      Document
+    </li>
+  </ul>
+</div>
 `;

--- a/packages/block-editor/src/components/block-breadcrumb/test/index.js
+++ b/packages/block-editor/src/components/block-breadcrumb/test/index.js
@@ -12,7 +12,7 @@ describe( 'BlockBreadcrumb', () => {
 	it( 'should render correctly', () => {
 		const { container } = render( <BlockBreadcrumb /> );
 
-		expect( container.firstChild ).toMatchSnapshot();
+		expect( container ).toMatchSnapshot();
 	} );
 
 	describe( 'Root label text', () => {

--- a/packages/block-editor/src/components/color-palette/test/__snapshots__/control.js.snap
+++ b/packages/block-editor/src/components/color-palette/test/__snapshots__/control.js.snap
@@ -117,114 +117,116 @@ exports[`ColorPaletteControl matches the snapshot 1`] = `
   min-width: 0;
 }
 
-<div
-  class="components-base-control block-editor-color-gradient-control emotion-0 emotion-1"
->
+<div>
   <div
-    class="components-base-control__field emotion-2 emotion-3"
+    class="components-base-control block-editor-color-gradient-control emotion-0 emotion-1"
   >
-    <fieldset
-      class="block-editor-color-gradient-control__fieldset"
+    <div
+      class="components-base-control__field emotion-2 emotion-3"
     >
-      <div
-        class="components-flex components-h-stack components-v-stack emotion-4 emotion-5"
-        data-wp-c16t="true"
-        data-wp-component="VStack"
+      <fieldset
+        class="block-editor-color-gradient-control__fieldset"
       >
-        <legend>
-          <div
-            class="block-editor-color-gradient-control__color-indicator"
-          >
-            <span
-              class="components-base-control__label emotion-6 emotion-7"
-            >
-              Test Color
-            </span>
-          </div>
-        </legend>
         <div
-          class="block-editor-color-gradient-control__panel"
+          class="components-flex components-h-stack components-v-stack emotion-4 emotion-5"
+          data-wp-c16t="true"
+          data-wp-component="VStack"
         >
+          <legend>
+            <div
+              class="block-editor-color-gradient-control__color-indicator"
+            >
+              <span
+                class="components-base-control__label emotion-6 emotion-7"
+              >
+                Test Color
+              </span>
+            </div>
+          </legend>
           <div
-            class="components-flex components-h-stack components-v-stack emotion-8 emotion-5"
-            data-wp-c16t="true"
-            data-wp-component="VStack"
+            class="block-editor-color-gradient-control__panel"
           >
             <div
-              class="components-dropdown"
-              tabindex="-1"
-            >
-              <button
-                aria-expanded="false"
-                aria-haspopup="true"
-                aria-label="Custom color picker. The currently selected color is called \\"red\\" and has a value of \\"f00\\"."
-                class="components-flex components-color-palette__custom-color emotion-10 emotion-5"
-                data-wp-c16t="true"
-                data-wp-component="Flex"
-                style="background: rgb(255, 0, 0); color: rgb(0, 0, 0);"
-              >
-                <span
-                  class="components-truncate components-flex-item components-color-palette__custom-color-name emotion-5 emotion-13 emotion-5"
-                  data-wp-c16t="true"
-                  data-wp-component="FlexItem"
-                >
-                  red
-                </span>
-                <span
-                  class="components-flex-item components-color-palette__custom-color-value emotion-15 emotion-5"
-                  data-wp-c16t="true"
-                  data-wp-component="FlexItem"
-                >
-                  f00
-                </span>
-              </button>
-            </div>
-            <div
-              class="components-circular-option-picker"
+              class="components-flex components-h-stack components-v-stack emotion-8 emotion-5"
+              data-wp-c16t="true"
+              data-wp-component="VStack"
             >
               <div
-                class="components-circular-option-picker__swatches"
-              >
-                <div
-                  class="components-circular-option-picker__option-wrapper"
-                >
-                  <button
-                    aria-label="Color: red"
-                    aria-pressed="true"
-                    class="components-button components-circular-option-picker__option is-pressed"
-                    style="background-color: rgb(255, 0, 0); color: rgb(255, 0, 0);"
-                    type="button"
-                  />
-                  <svg
-                    aria-hidden="true"
-                    fill="#000"
-                    focusable="false"
-                    height="24"
-                    viewBox="0 0 24 24"
-                    width="24"
-                    xmlns="http://www.w3.org/2000/svg"
-                  >
-                    <path
-                      d="M16.7 7.1l-6.3 8.5-3.3-2.5-.9 1.2 4.5 3.4L17.9 8z"
-                    />
-                  </svg>
-                </div>
-              </div>
-              <div
-                class="components-circular-option-picker__custom-clear-wrapper"
+                class="components-dropdown"
+                tabindex="-1"
               >
                 <button
-                  class="components-button components-circular-option-picker__clear is-tertiary"
-                  type="button"
+                  aria-expanded="false"
+                  aria-haspopup="true"
+                  aria-label="Custom color picker. The currently selected color is called \\"red\\" and has a value of \\"f00\\"."
+                  class="components-flex components-color-palette__custom-color emotion-10 emotion-5"
+                  data-wp-c16t="true"
+                  data-wp-component="Flex"
+                  style="background: rgb(255, 0, 0); color: rgb(0, 0, 0);"
                 >
-                  Clear
+                  <span
+                    class="components-truncate components-flex-item components-color-palette__custom-color-name emotion-5 emotion-13 emotion-5"
+                    data-wp-c16t="true"
+                    data-wp-component="FlexItem"
+                  >
+                    red
+                  </span>
+                  <span
+                    class="components-flex-item components-color-palette__custom-color-value emotion-15 emotion-5"
+                    data-wp-c16t="true"
+                    data-wp-component="FlexItem"
+                  >
+                    f00
+                  </span>
                 </button>
+              </div>
+              <div
+                class="components-circular-option-picker"
+              >
+                <div
+                  class="components-circular-option-picker__swatches"
+                >
+                  <div
+                    class="components-circular-option-picker__option-wrapper"
+                  >
+                    <button
+                      aria-label="Color: red"
+                      aria-pressed="true"
+                      class="components-button components-circular-option-picker__option is-pressed"
+                      style="background-color: rgb(255, 0, 0); color: rgb(255, 0, 0);"
+                      type="button"
+                    />
+                    <svg
+                      aria-hidden="true"
+                      fill="#000"
+                      focusable="false"
+                      height="24"
+                      viewBox="0 0 24 24"
+                      width="24"
+                      xmlns="http://www.w3.org/2000/svg"
+                    >
+                      <path
+                        d="M16.7 7.1l-6.3 8.5-3.3-2.5-.9 1.2 4.5 3.4L17.9 8z"
+                      />
+                    </svg>
+                  </div>
+                </div>
+                <div
+                  class="components-circular-option-picker__custom-clear-wrapper"
+                >
+                  <button
+                    class="components-button components-circular-option-picker__clear is-tertiary"
+                    type="button"
+                  >
+                    Clear
+                  </button>
+                </div>
               </div>
             </div>
           </div>
         </div>
-      </div>
-    </fieldset>
+      </fieldset>
+    </div>
   </div>
 </div>
 `;

--- a/packages/block-editor/src/components/color-palette/test/control.js
+++ b/packages/block-editor/src/components/color-palette/test/control.js
@@ -22,6 +22,6 @@ describe( 'ColorPaletteControl', () => {
 			/>
 		);
 
-		expect( container.firstChild ).toMatchSnapshot();
+		expect( container ).toMatchSnapshot();
 	} );
 } );

--- a/packages/components/src/form-toggle/test/__snapshots__/index.tsx.snap
+++ b/packages/components/src/form-toggle/test/__snapshots__/index.tsx.snap
@@ -1,20 +1,22 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`FormToggle basic rendering should render a span element with an unchecked checkbox 1`] = `
-<span
-  class="components-form-toggle"
->
-  <input
-    class="components-form-toggle__input"
-    type="checkbox"
-  />
+<div>
   <span
-    class="components-form-toggle__track"
-  />
-  <span
-    class="components-form-toggle__thumb"
-  />
-</span>
+    class="components-form-toggle"
+  >
+    <input
+      class="components-form-toggle__input"
+      type="checkbox"
+    />
+    <span
+      class="components-form-toggle__track"
+    />
+    <span
+      class="components-form-toggle__thumb"
+    />
+  </span>
+</div>
 `;
 
 exports[`FormToggle basic rendering should render an id prop for the input checkbox 1`] = `

--- a/packages/components/src/form-toggle/test/index.tsx
+++ b/packages/components/src/form-toggle/test/index.tsx
@@ -36,7 +36,7 @@ describe( 'FormToggle', () => {
 			const { container } = render( <FormToggle onChange={ noop } /> );
 
 			expect( getInput() ).not.toBeChecked();
-			expect( container.firstChild ).toMatchSnapshot();
+			expect( container ).toMatchSnapshot();
 		} );
 
 		it( 'should render a checked checkbox when providing checked prop', () => {

--- a/packages/components/src/h-stack/test/__snapshots__/index.tsx.snap
+++ b/packages/components/src/h-stack/test/__snapshots__/index.tsx.snap
@@ -25,17 +25,19 @@ exports[`props should render alignment 1`] = `
   min-width: 0;
 }
 
-<div
-  class="components-flex components-h-stack emotion-0 emotion-1"
-  data-wp-c16t="true"
-  data-wp-component="HStack"
->
+<div>
   <div
-    class="emotion-2 emotion-1"
-  />
-  <div
-    class="emotion-2 emotion-1"
-  />
+    class="components-flex components-h-stack emotion-0 emotion-1"
+    data-wp-c16t="true"
+    data-wp-component="HStack"
+  >
+    <div
+      class="emotion-2 emotion-1"
+    />
+    <div
+      class="emotion-2 emotion-1"
+    />
+  </div>
 </div>
 `;
 
@@ -63,17 +65,19 @@ exports[`props should render correctly 1`] = `
   min-width: 0;
 }
 
-<div
-  class="components-flex components-h-stack emotion-0 emotion-1"
-  data-wp-c16t="true"
-  data-wp-component="HStack"
->
+<div>
   <div
-    class="emotion-2 emotion-1"
-  />
-  <div
-    class="emotion-2 emotion-1"
-  />
+    class="components-flex components-h-stack emotion-0 emotion-1"
+    data-wp-c16t="true"
+    data-wp-component="HStack"
+  >
+    <div
+      class="emotion-2 emotion-1"
+    />
+    <div
+      class="emotion-2 emotion-1"
+    />
+  </div>
 </div>
 `;
 
@@ -101,16 +105,18 @@ exports[`props should render spacing 1`] = `
   min-width: 0;
 }
 
-<div
-  class="components-flex components-h-stack emotion-0 emotion-1"
-  data-wp-c16t="true"
-  data-wp-component="HStack"
->
+<div>
   <div
-    class="emotion-2 emotion-1"
-  />
-  <div
-    class="emotion-2 emotion-1"
-  />
+    class="components-flex components-h-stack emotion-0 emotion-1"
+    data-wp-c16t="true"
+    data-wp-component="HStack"
+  >
+    <div
+      class="emotion-2 emotion-1"
+    />
+    <div
+      class="emotion-2 emotion-1"
+    />
+  </div>
 </div>
 `;

--- a/packages/components/src/h-stack/test/index.tsx
+++ b/packages/components/src/h-stack/test/index.tsx
@@ -17,7 +17,7 @@ describe( 'props', () => {
 				<View />
 			</HStack>
 		);
-		expect( container.firstChild ).toMatchSnapshot();
+		expect( container ).toMatchSnapshot();
 	} );
 
 	test( 'should render alignment', () => {
@@ -27,7 +27,7 @@ describe( 'props', () => {
 				<View />
 			</HStack>
 		);
-		expect( container.firstChild ).toMatchSnapshot();
+		expect( container ).toMatchSnapshot();
 	} );
 
 	test( 'should render spacing', () => {
@@ -37,6 +37,6 @@ describe( 'props', () => {
 				<View />
 			</HStack>
 		);
-		expect( container.firstChild ).toMatchSnapshot();
+		expect( container ).toMatchSnapshot();
 	} );
 } );

--- a/packages/components/src/item-group/test/__snapshots__/index.js.snap
+++ b/packages/components/src/item-group/test/__snapshots__/index.js.snap
@@ -82,22 +82,24 @@ exports[`ItemGroup ItemGroup component should render correctly 1`] = `
   border-radius: 2px;
 }
 
-<div
-  class="components-item-group emotion-0 emotion-1"
-  data-wp-c16t="true"
-  data-wp-component="ItemGroup"
-  role="list"
->
+<div>
   <div
-    class="emotion-2"
-    role="listitem"
+    class="components-item-group emotion-0 emotion-1"
+    data-wp-c16t="true"
+    data-wp-component="ItemGroup"
+    role="list"
   >
     <div
-      class="components-item emotion-3 emotion-1"
-      data-wp-c16t="true"
-      data-wp-component="Item"
+      class="emotion-2"
+      role="listitem"
     >
-      Code is poetry
+      <div
+        class="components-item emotion-3 emotion-1"
+        data-wp-c16t="true"
+        data-wp-component="Item"
+      >
+        Code is poetry
+      </div>
     </div>
   </div>
 </div>

--- a/packages/components/src/item-group/test/index.js
+++ b/packages/components/src/item-group/test/index.js
@@ -16,7 +16,7 @@ describe( 'ItemGroup', () => {
 					<Item>Code is poetry</Item>
 				</ItemGroup>
 			);
-			expect( container.firstChild ).toMatchSnapshot();
+			expect( container ).toMatchSnapshot();
 		} );
 
 		it( 'should show borders when the isBordered prop is true', () => {

--- a/packages/components/src/text/test/__snapshots__/index.tsx.snap
+++ b/packages/components/src/text/test/__snapshots__/index.tsx.snap
@@ -31,17 +31,19 @@ exports[`Text should render highlighted words with highlightCaseSensitive 1`] = 
   box-shadow: 0 0 0 1px rgba( 0, 0, 0, 0.05 ) inset,0 -1px 0 rgba( 0, 0, 0, 0.1 ) inset;
 }
 
-<span
-  class="components-truncate components-text emotion-0 emotion-1"
-  data-wp-c16t="true"
-  data-wp-component="Text"
->
+<div>
   <span
-    class=""
+    class="components-truncate components-text emotion-0 emotion-1"
+    data-wp-c16t="true"
+    data-wp-component="Text"
   >
-    Lorem ipsum.
+    <span
+      class=""
+    >
+      Lorem ipsum.
+    </span>
   </span>
-</span>
+</div>
 `;
 
 exports[`Text snapshot tests should render correctly 1`] = `
@@ -53,11 +55,13 @@ exports[`Text snapshot tests should render correctly 1`] = `
   font-weight: normal;
 }
 
-<span
-  class="components-truncate components-text emotion-0 emotion-1"
-  data-wp-c16t="true"
-  data-wp-component="Text"
->
-  Lorem ipsum.
-</span>
+<div>
+  <span
+    class="components-truncate components-text emotion-0 emotion-1"
+    data-wp-c16t="true"
+    data-wp-component="Text"
+  >
+    Lorem ipsum.
+  </span>
+</div>
 `;

--- a/packages/components/src/text/test/index.tsx
+++ b/packages/components/src/text/test/index.tsx
@@ -14,7 +14,7 @@ describe( 'Text', () => {
 	describe( 'snapshot tests', () => {
 		test( 'should render correctly', () => {
 			const { container } = render( <Text>Lorem ipsum.</Text> );
-			expect( container.firstChild ).toMatchSnapshot();
+			expect( container ).toMatchSnapshot();
 		} );
 	} );
 
@@ -116,7 +116,7 @@ describe( 'Text', () => {
 			</Text>
 		);
 
-		expect( container.firstChild ).toMatchSnapshot();
+		expect( container ).toMatchSnapshot();
 		// It'll have a length of 1 because there shouldn't be anything but the single span being rendered.
 		expect( container.firstChild?.childNodes ).toHaveLength( 1 );
 	} );

--- a/packages/components/src/toggle-group-control/test/__snapshots__/index.tsx.snap
+++ b/packages/components/src/toggle-group-control/test/__snapshots__/index.tsx.snap
@@ -178,103 +178,105 @@ exports[`ToggleGroupControl should render correctly with icons 1`] = `
   line-height: 1;
 }
 
-<div
-  class="components-base-control emotion-0 emotion-1"
->
+<div>
   <div
-    class="components-base-control__field emotion-2 emotion-3"
+    class="components-base-control emotion-0 emotion-1"
   >
     <div
-      class="emotion-4 emotion-5"
-    >
-      <span
-        class="components-base-control__label emotion-6 emotion-7"
-      >
-        Test Toggle Group Control
-      </span>
-    </div>
-    <div
-      aria-label="Test Toggle Group Control"
-      class="components-toggle-group-control emotion-8 emotion-9"
-      data-wp-c16t="true"
-      data-wp-component="ToggleGroupControl"
-      id="toggle-group-control-1"
-      role="radiogroup"
+      class="components-base-control__field emotion-2 emotion-3"
     >
       <div
-        aria-hidden="true"
-        style="position: absolute; top: 0px; left: 0px; right: 0px; bottom: 0px; pointer-events: none; opacity: 0; overflow: hidden; z-index: -1;"
-      />
-      <div
-        class="emotion-10 emotion-11"
-        role="presentation"
-        style="transform: translateX(0px); transition: none; width: 0px;"
-      />
-      <div
-        class="emotion-12 emotion-13"
-        data-active="true"
+        class="emotion-4 emotion-5"
       >
-        <button
-          aria-checked="true"
-          aria-label="Uppercase"
-          class="emotion-14 emotion-15 components-toggle-group-control-option-base emotion-16"
-          data-value="uppercase"
-          data-wp-c16t="true"
-          data-wp-component="ToggleGroupControlOptionBase"
-          id="toggle-group-control-1-2"
-          role="radio"
-          tabindex="0"
+        <span
+          class="components-base-control__label emotion-6 emotion-7"
         >
-          <div
-            class="emotion-17 emotion-18"
-          >
-            <svg
-              aria-hidden="true"
-              focusable="false"
-              height="24"
-              viewBox="0 0 24 24"
-              width="24"
-              xmlns="http://www.w3.org/2000/svg"
-            >
-              <path
-                d="M6.1 6.8L2.1 18h1.6l1.1-3h4.3l1.1 3h1.6l-4-11.2H6.1zm-.8 6.8L7 8.9l1.7 4.7H5.3zm15.1-.7c-.4-.5-.9-.8-1.6-1 .4-.2.7-.5.8-.9.2-.4.3-.9.3-1.4 0-.9-.3-1.6-.8-2-.6-.5-1.3-.7-2.4-.7h-3.5V18h4.2c1.1 0 2-.3 2.6-.8.6-.6 1-1.4 1-2.4-.1-.8-.3-1.4-.6-1.9zm-5.7-4.7h1.8c.6 0 1.1.1 1.4.4.3.2.5.7.5 1.3 0 .6-.2 1.1-.5 1.3-.3.2-.8.4-1.4.4h-1.8V8.2zm4 8c-.4.3-.9.5-1.5.5h-2.6v-3.8h2.6c1.4 0 2 .6 2 1.9.1.6-.1 1-.5 1.4z"
-              />
-            </svg>
-          </div>
-        </button>
+          Test Toggle Group Control
+        </span>
       </div>
       <div
-        class="emotion-12 emotion-13"
-        data-active="false"
+        aria-label="Test Toggle Group Control"
+        class="components-toggle-group-control emotion-8 emotion-9"
+        data-wp-c16t="true"
+        data-wp-component="ToggleGroupControl"
+        id="toggle-group-control-1"
+        role="radiogroup"
       >
-        <button
-          aria-checked="false"
-          aria-label="Lowercase"
-          class="emotion-14 emotion-15 components-toggle-group-control-option-base"
-          data-value="lowercase"
-          data-wp-c16t="true"
-          data-wp-component="ToggleGroupControlOptionBase"
-          id="toggle-group-control-1-3"
-          role="radio"
-          tabindex="-1"
+        <div
+          aria-hidden="true"
+          style="position: absolute; top: 0px; left: 0px; right: 0px; bottom: 0px; pointer-events: none; opacity: 0; overflow: hidden; z-index: -1;"
+        />
+        <div
+          class="emotion-10 emotion-11"
+          role="presentation"
+          style="transform: translateX(0px); transition: none; width: 0px;"
+        />
+        <div
+          class="emotion-12 emotion-13"
+          data-active="true"
         >
-          <div
-            class="emotion-17 emotion-18"
+          <button
+            aria-checked="true"
+            aria-label="Uppercase"
+            class="emotion-14 emotion-15 components-toggle-group-control-option-base emotion-16"
+            data-value="uppercase"
+            data-wp-c16t="true"
+            data-wp-component="ToggleGroupControlOptionBase"
+            id="toggle-group-control-1-2"
+            role="radio"
+            tabindex="0"
           >
-            <svg
-              aria-hidden="true"
-              focusable="false"
-              height="24"
-              viewBox="0 0 24 24"
-              width="24"
-              xmlns="http://www.w3.org/2000/svg"
+            <div
+              class="emotion-17 emotion-18"
             >
-              <path
-                d="M11 16.8c-.1-.1-.2-.3-.3-.5v-2.6c0-.9-.1-1.7-.3-2.2-.2-.5-.5-.9-.9-1.2-.4-.2-.9-.3-1.6-.3-.5 0-1 .1-1.5.2s-.9.3-1.2.6l.2 1.2c.4-.3.7-.4 1.1-.5.3-.1.7-.2 1-.2.6 0 1 .1 1.3.4.3.2.4.7.4 1.4-1.2 0-2.3.2-3.3.7s-1.4 1.1-1.4 2.1c0 .7.2 1.2.7 1.6.4.4 1 .6 1.8.6.9 0 1.7-.4 2.4-1.2.1.3.2.5.4.7.1.2.3.3.6.4.3.1.6.1 1.1.1h.1l.2-1.2h-.1c-.4.1-.6 0-.7-.1zM9.2 16c-.2.3-.5.6-.9.8-.3.1-.7.2-1.1.2-.4 0-.7-.1-.9-.3-.2-.2-.3-.5-.3-.9 0-.6.2-1 .7-1.3.5-.3 1.3-.4 2.5-.5v2zm10.6-3.9c-.3-.6-.7-1.1-1.2-1.5-.6-.4-1.2-.6-1.9-.6-.5 0-.9.1-1.4.3-.4.2-.8.5-1.1.8V6h-1.4v12h1.3l.2-1c.2.4.6.6 1 .8.4.2.9.3 1.4.3.7 0 1.2-.2 1.8-.5.5-.4 1-.9 1.3-1.5.3-.6.5-1.3.5-2.1-.1-.6-.2-1.3-.5-1.9zm-1.7 4c-.4.5-.9.8-1.6.8s-1.2-.2-1.7-.7c-.4-.5-.7-1.2-.7-2.1 0-.9.2-1.6.7-2.1.4-.5 1-.7 1.7-.7s1.2.3 1.6.8c.4.5.6 1.2.6 2s-.2 1.4-.6 2z"
-              />
-            </svg>
-          </div>
-        </button>
+              <svg
+                aria-hidden="true"
+                focusable="false"
+                height="24"
+                viewBox="0 0 24 24"
+                width="24"
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <path
+                  d="M6.1 6.8L2.1 18h1.6l1.1-3h4.3l1.1 3h1.6l-4-11.2H6.1zm-.8 6.8L7 8.9l1.7 4.7H5.3zm15.1-.7c-.4-.5-.9-.8-1.6-1 .4-.2.7-.5.8-.9.2-.4.3-.9.3-1.4 0-.9-.3-1.6-.8-2-.6-.5-1.3-.7-2.4-.7h-3.5V18h4.2c1.1 0 2-.3 2.6-.8.6-.6 1-1.4 1-2.4-.1-.8-.3-1.4-.6-1.9zm-5.7-4.7h1.8c.6 0 1.1.1 1.4.4.3.2.5.7.5 1.3 0 .6-.2 1.1-.5 1.3-.3.2-.8.4-1.4.4h-1.8V8.2zm4 8c-.4.3-.9.5-1.5.5h-2.6v-3.8h2.6c1.4 0 2 .6 2 1.9.1.6-.1 1-.5 1.4z"
+                />
+              </svg>
+            </div>
+          </button>
+        </div>
+        <div
+          class="emotion-12 emotion-13"
+          data-active="false"
+        >
+          <button
+            aria-checked="false"
+            aria-label="Lowercase"
+            class="emotion-14 emotion-15 components-toggle-group-control-option-base"
+            data-value="lowercase"
+            data-wp-c16t="true"
+            data-wp-component="ToggleGroupControlOptionBase"
+            id="toggle-group-control-1-3"
+            role="radio"
+            tabindex="-1"
+          >
+            <div
+              class="emotion-17 emotion-18"
+            >
+              <svg
+                aria-hidden="true"
+                focusable="false"
+                height="24"
+                viewBox="0 0 24 24"
+                width="24"
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <path
+                  d="M11 16.8c-.1-.1-.2-.3-.3-.5v-2.6c0-.9-.1-1.7-.3-2.2-.2-.5-.5-.9-.9-1.2-.4-.2-.9-.3-1.6-.3-.5 0-1 .1-1.5.2s-.9.3-1.2.6l.2 1.2c.4-.3.7-.4 1.1-.5.3-.1.7-.2 1-.2.6 0 1 .1 1.3.4.3.2.4.7.4 1.4-1.2 0-2.3.2-3.3.7s-1.4 1.1-1.4 2.1c0 .7.2 1.2.7 1.6.4.4 1 .6 1.8.6.9 0 1.7-.4 2.4-1.2.1.3.2.5.4.7.1.2.3.3.6.4.3.1.6.1 1.1.1h.1l.2-1.2h-.1c-.4.1-.6 0-.7-.1zM9.2 16c-.2.3-.5.6-.9.8-.3.1-.7.2-1.1.2-.4 0-.7-.1-.9-.3-.2-.2-.3-.5-.3-.9 0-.6.2-1 .7-1.3.5-.3 1.3-.4 2.5-.5v2zm10.6-3.9c-.3-.6-.7-1.1-1.2-1.5-.6-.4-1.2-.6-1.9-.6-.5 0-.9.1-1.4.3-.4.2-.8.5-1.1.8V6h-1.4v12h1.3l.2-1c.2.4.6.6 1 .8.4.2.9.3 1.4.3.7 0 1.2-.2 1.8-.5.5-.4 1-.9 1.3-1.5.3-.6.5-1.3.5-2.1-.1-.6-.2-1.3-.5-1.9zm-1.7 4c-.4.5-.9.8-1.6.8s-1.2-.2-1.7-.7c-.4-.5-.7-1.2-.7-2.1 0-.9.2-1.6.7-2.1.4-.5 1-.7 1.7-.7s1.2.3 1.6.8c.4.5.6 1.2.6 2s-.2 1.4-.6 2z"
+                />
+              </svg>
+            </div>
+          </button>
+        </div>
       </div>
     </div>
   </div>
@@ -425,76 +427,78 @@ exports[`ToggleGroupControl should render correctly with text options 1`] = `
   line-height: 1;
 }
 
-<div
-  class="components-base-control emotion-0 emotion-1"
->
+<div>
   <div
-    class="components-base-control__field emotion-2 emotion-3"
+    class="components-base-control emotion-0 emotion-1"
   >
     <div
-      class="emotion-4 emotion-5"
-    >
-      <span
-        class="components-base-control__label emotion-6 emotion-7"
-      >
-        Test Toggle Group Control
-      </span>
-    </div>
-    <div
-      aria-label="Test Toggle Group Control"
-      class="components-toggle-group-control emotion-8 emotion-9"
-      data-wp-c16t="true"
-      data-wp-component="ToggleGroupControl"
-      id="toggle-group-control-0"
-      role="radiogroup"
+      class="components-base-control__field emotion-2 emotion-3"
     >
       <div
-        aria-hidden="true"
-        style="position: absolute; top: 0px; left: 0px; right: 0px; bottom: 0px; pointer-events: none; opacity: 0; overflow: hidden; z-index: -1;"
-      />
-      <div
-        class="emotion-10 emotion-11"
-        data-active="false"
+        class="emotion-4 emotion-5"
       >
-        <button
-          aria-checked="false"
-          aria-label="R"
-          class="emotion-12 components-toggle-group-control-option-base"
-          data-value="rigas"
-          data-wp-c16t="true"
-          data-wp-component="ToggleGroupControlOptionBase"
-          id="toggle-group-control-0-0"
-          role="radio"
-          tabindex="0"
+        <span
+          class="components-base-control__label emotion-6 emotion-7"
         >
-          <div
-            class="emotion-13 emotion-14"
-          >
-            R
-          </div>
-        </button>
+          Test Toggle Group Control
+        </span>
       </div>
       <div
-        class="emotion-10 emotion-11"
-        data-active="false"
+        aria-label="Test Toggle Group Control"
+        class="components-toggle-group-control emotion-8 emotion-9"
+        data-wp-c16t="true"
+        data-wp-component="ToggleGroupControl"
+        id="toggle-group-control-0"
+        role="radiogroup"
       >
-        <button
-          aria-checked="false"
-          aria-label="J"
-          class="emotion-12 components-toggle-group-control-option-base"
-          data-value="jack"
-          data-wp-c16t="true"
-          data-wp-component="ToggleGroupControlOptionBase"
-          id="toggle-group-control-0-1"
-          role="radio"
-          tabindex="-1"
+        <div
+          aria-hidden="true"
+          style="position: absolute; top: 0px; left: 0px; right: 0px; bottom: 0px; pointer-events: none; opacity: 0; overflow: hidden; z-index: -1;"
+        />
+        <div
+          class="emotion-10 emotion-11"
+          data-active="false"
         >
-          <div
-            class="emotion-13 emotion-14"
+          <button
+            aria-checked="false"
+            aria-label="R"
+            class="emotion-12 components-toggle-group-control-option-base"
+            data-value="rigas"
+            data-wp-c16t="true"
+            data-wp-component="ToggleGroupControlOptionBase"
+            id="toggle-group-control-0-0"
+            role="radio"
+            tabindex="0"
           >
-            J
-          </div>
-        </button>
+            <div
+              class="emotion-13 emotion-14"
+            >
+              R
+            </div>
+          </button>
+        </div>
+        <div
+          class="emotion-10 emotion-11"
+          data-active="false"
+        >
+          <button
+            aria-checked="false"
+            aria-label="J"
+            class="emotion-12 components-toggle-group-control-option-base"
+            data-value="jack"
+            data-wp-c16t="true"
+            data-wp-component="ToggleGroupControlOptionBase"
+            id="toggle-group-control-0-1"
+            role="radio"
+            tabindex="-1"
+          >
+            <div
+              class="emotion-13 emotion-14"
+            >
+              J
+            </div>
+          </button>
+        </div>
       </div>
     </div>
   </div>

--- a/packages/components/src/toggle-group-control/test/index.tsx
+++ b/packages/components/src/toggle-group-control/test/index.tsx
@@ -48,7 +48,7 @@ describe( 'ToggleGroupControl', () => {
 				</ToggleGroupControl>
 			);
 
-			expect( container.firstChild ).toMatchSnapshot();
+			expect( container ).toMatchSnapshot();
 		} );
 		it( 'with icons', () => {
 			const { container } = render(
@@ -69,7 +69,7 @@ describe( 'ToggleGroupControl', () => {
 				</ToggleGroupControl>
 			);
 
-			expect( container.firstChild ).toMatchSnapshot();
+			expect( container ).toMatchSnapshot();
 		} );
 	} );
 	it( 'should call onChange with proper value', () => {

--- a/packages/components/src/tree-grid/test/__snapshots__/cell.js.snap
+++ b/packages/components/src/tree-grid/test/__snapshots__/cell.js.snap
@@ -1,25 +1,27 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`TreeGridCell uses a child render function to render children 1`] = `
-<div
-  role="application"
->
-  <table
-    role="treegrid"
+<div>
+  <div
+    role="application"
   >
-    <tbody>
-      <tr>
-        <td
-          role="gridcell"
-        >
-          <button
-            class="my-button"
+    <table
+      role="treegrid"
+    >
+      <tbody>
+        <tr>
+          <td
+            role="gridcell"
           >
-            Click Me!
-          </button>
-        </td>
-      </tr>
-    </tbody>
-  </table>
+            <button
+              class="my-button"
+            >
+              Click Me!
+            </button>
+          </td>
+        </tr>
+      </tbody>
+    </table>
+  </div>
 </div>
 `;

--- a/packages/components/src/tree-grid/test/__snapshots__/roving-tab-index.js.snap
+++ b/packages/components/src/tree-grid/test/__snapshots__/roving-tab-index.js.snap
@@ -2,6 +2,8 @@
 
 exports[`RovingTabIndex does not render any elements other than its children 1`] = `
 <div>
-  child element
+  <div>
+    child element
+  </div>
 </div>
 `;

--- a/packages/components/src/tree-grid/test/__snapshots__/row.js.snap
+++ b/packages/components/src/tree-grid/test/__snapshots__/row.js.snap
@@ -1,36 +1,40 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`TreeGridRow forwards other props to the rendered tr element 1`] = `
-<table>
-  <tbody>
-    <tr
-      aria-level="1"
-      aria-posinset="1"
-      aria-setsize="1"
-      class="my-row"
-      role="row"
-    >
-      <td>
-        Test
-      </td>
-    </tr>
-  </tbody>
-</table>
+<div>
+  <table>
+    <tbody>
+      <tr
+        aria-level="1"
+        aria-posinset="1"
+        aria-setsize="1"
+        class="my-row"
+        role="row"
+      >
+        <td>
+          Test
+        </td>
+      </tr>
+    </tbody>
+  </table>
+</div>
 `;
 
 exports[`TreeGridRow renders a tr with support for level, positionInSet and setSize props 1`] = `
-<table>
-  <tbody>
-    <tr
-      aria-level="1"
-      aria-posinset="1"
-      aria-setsize="1"
-      role="row"
-    >
-      <td>
-        Test
-      </td>
-    </tr>
-  </tbody>
-</table>
+<div>
+  <table>
+    <tbody>
+      <tr
+        aria-level="1"
+        aria-posinset="1"
+        aria-setsize="1"
+        role="row"
+      >
+        <td>
+          Test
+        </td>
+      </tr>
+    </tbody>
+  </table>
+</div>
 `;

--- a/packages/components/src/tree-grid/test/cell.js
+++ b/packages/components/src/tree-grid/test/cell.js
@@ -49,6 +49,6 @@ describe( 'TreeGridCell', () => {
 			</TreeGrid>
 		);
 
-		expect( container.firstChild ).toMatchSnapshot();
+		expect( container ).toMatchSnapshot();
 	} );
 } );

--- a/packages/components/src/tree-grid/test/roving-tab-index.js
+++ b/packages/components/src/tree-grid/test/roving-tab-index.js
@@ -16,6 +16,6 @@ describe( 'RovingTabIndex', () => {
 			</RovingTabIndex>
 		);
 
-		expect( container.firstChild ).toMatchSnapshot();
+		expect( container ).toMatchSnapshot();
 	} );
 } );

--- a/packages/components/src/tree-grid/test/row.js
+++ b/packages/components/src/tree-grid/test/row.js
@@ -20,7 +20,7 @@ describe( 'TreeGridRow', () => {
 			</table>
 		);
 
-		expect( container.firstChild ).toMatchSnapshot();
+		expect( container ).toMatchSnapshot();
 	} );
 
 	it( 'forwards other props to the rendered tr element', () => {
@@ -39,6 +39,6 @@ describe( 'TreeGridRow', () => {
 			</table>
 		);
 
-		expect( container.firstChild ).toMatchSnapshot();
+		expect( container ).toMatchSnapshot();
 	} );
 } );

--- a/packages/components/src/ui/context/test/__snapshots__/context-system-provider.js.snap
+++ b/packages/components/src/ui/context/test/__snapshots__/context-system-provider.js.snap
@@ -1,29 +1,35 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`props should render _override props 1`] = `
-<div
-  class="components-component test-component emotion-0 emotion-1"
-  data-wp-c16t="true"
-  data-wp-component="Component"
->
-  Code is Poetry
+<div>
+  <div
+    class="components-component test-component emotion-0 emotion-1"
+    data-wp-c16t="true"
+    data-wp-component="Component"
+  >
+    Code is Poetry
+  </div>
 </div>
 `;
 
 exports[`props should render context props 1`] = `
-<div
-  class="components-component emotion-0 emotion-1"
-  data-wp-c16t="true"
-  data-wp-component="Component"
->
-  Code is Poetry
+<div>
+  <div
+    class="components-component emotion-0 emotion-1"
+    data-wp-c16t="true"
+    data-wp-component="Component"
+  >
+    Code is Poetry
+  </div>
 </div>
 `;
 
 exports[`props should render correctly 1`] = `
-<div
-  class="components-component emotion-0 emotion-1"
-  data-wp-c16t="true"
-  data-wp-component="Component"
-/>
+<div>
+  <div
+    class="components-component emotion-0 emotion-1"
+    data-wp-c16t="true"
+    data-wp-component="Component"
+  />
+</div>
 `;

--- a/packages/components/src/ui/context/test/context-system-provider.js
+++ b/packages/components/src/ui/context/test/context-system-provider.js
@@ -30,7 +30,7 @@ describe( 'props', () => {
 			</ContextSystemProvider>
 		);
 
-		expect( container.firstChild ).toMatchSnapshot();
+		expect( container ).toMatchSnapshot();
 	} );
 
 	test( 'should render context props', () => {
@@ -60,7 +60,7 @@ describe( 'props', () => {
 			</ContextSystemProvider>
 		);
 
-		expect( container.firstChild ).toMatchSnapshot();
+		expect( container ).toMatchSnapshot();
 		expect( container.firstChild.innerHTML ).toContain( 'Code is Poetry' );
 	} );
 
@@ -98,7 +98,7 @@ describe( 'props', () => {
 			</>
 		);
 
-		expect( container.firstChild ).toMatchSnapshot();
+		expect( container ).toMatchSnapshot();
 
 		const el = container.querySelector( '.test-component' );
 

--- a/packages/components/src/ui/control-group/test/__snapshots__/index.js.snap
+++ b/packages/components/src/ui/control-group/test/__snapshots__/index.js.snap
@@ -28,22 +28,24 @@ exports[`props should render correctly 1`] = `
   z-index: 1;
 }
 
-<div
-  class="components-flex components-control-group emotion-0 emotion-1"
-  data-wp-c16t="true"
-  data-wp-component="ControlGroup"
->
-  <button
-    class="components-button"
-    type="button"
+<div>
+  <div
+    class="components-flex components-control-group emotion-0 emotion-1"
+    data-wp-c16t="true"
+    data-wp-component="ControlGroup"
   >
-    Code is Poetry
-  </button>
-  <button
-    class="components-button"
-    type="button"
-  >
-    WordPress.org
-  </button>
+    <button
+      class="components-button"
+      type="button"
+    >
+      Code is Poetry
+    </button>
+    <button
+      class="components-button"
+      type="button"
+    >
+      WordPress.org
+    </button>
+  </div>
 </div>
 `;

--- a/packages/components/src/ui/control-group/test/index.js
+++ b/packages/components/src/ui/control-group/test/index.js
@@ -17,6 +17,6 @@ describe( 'props', () => {
 				<Button>WordPress.org</Button>
 			</ControlGroup>
 		);
-		expect( container.firstChild ).toMatchSnapshot();
+		expect( container ).toMatchSnapshot();
 	} );
 } );

--- a/packages/components/src/ui/control-label/test/__snapshots__/index.js.snap
+++ b/packages/components/src/ui/control-label/test/__snapshots__/index.js.snap
@@ -37,13 +37,15 @@ exports[`props should render correctly 1`] = `
   }
 }
 
-<label
-  class="components-truncate components-text components-control-label emotion-0 emotion-1"
-  data-wp-c16t="true"
-  data-wp-component="ControlLabel"
->
-  Label
-</label>
+<div>
+  <label
+    class="components-truncate components-text components-control-label emotion-0 emotion-1"
+    data-wp-c16t="true"
+    data-wp-component="ControlLabel"
+  >
+    Label
+  </label>
+</div>
 `;
 
 exports[`props should render no truncate 1`] = `
@@ -79,13 +81,15 @@ exports[`props should render no truncate 1`] = `
   }
 }
 
-<label
-  class="components-truncate components-text components-control-label emotion-0 emotion-1"
-  data-wp-c16t="true"
-  data-wp-component="ControlLabel"
->
-  Label
-</label>
+<div>
+  <label
+    class="components-truncate components-text components-control-label emotion-0 emotion-1"
+    data-wp-c16t="true"
+    data-wp-component="ControlLabel"
+  >
+    Label
+  </label>
+</div>
 `;
 
 exports[`props should render size 1`] = `
@@ -125,11 +129,13 @@ exports[`props should render size 1`] = `
   }
 }
 
-<label
-  class="components-truncate components-text components-control-label emotion-0 emotion-1"
-  data-wp-c16t="true"
-  data-wp-component="ControlLabel"
->
-  Label
-</label>
+<div>
+  <label
+    class="components-truncate components-text components-control-label emotion-0 emotion-1"
+    data-wp-c16t="true"
+    data-wp-component="ControlLabel"
+  >
+    Label
+  </label>
+</div>
 `;

--- a/packages/components/src/ui/control-label/test/index.js
+++ b/packages/components/src/ui/control-label/test/index.js
@@ -12,7 +12,7 @@ describe( 'props', () => {
 	test( 'should render correctly', () => {
 		const { container } = render( <ControlLabel>Label</ControlLabel> );
 
-		expect( container.firstChild ).toMatchSnapshot();
+		expect( container ).toMatchSnapshot();
 	} );
 
 	test( 'should render htmlFor', () => {
@@ -28,7 +28,7 @@ describe( 'props', () => {
 			<ControlLabel size="small">Label</ControlLabel>
 		);
 
-		expect( container.firstChild ).toMatchSnapshot();
+		expect( container ).toMatchSnapshot();
 	} );
 
 	test( 'should render no truncate', () => {
@@ -36,6 +36,6 @@ describe( 'props', () => {
 			<ControlLabel truncate={ false }>Label</ControlLabel>
 		);
 
-		expect( container.firstChild ).toMatchSnapshot();
+		expect( container ).toMatchSnapshot();
 	} );
 } );

--- a/packages/components/src/ui/form-group/test/__snapshots__/index.js.snap
+++ b/packages/components/src/ui/form-group/test/__snapshots__/index.js.snap
@@ -38,23 +38,25 @@ exports[`props should render alignLabel 1`] = `
   }
 }
 
-<div
-  class="components-form-group emotion-0 emotion-1"
-  data-wp-c16t="true"
-  data-wp-component="FormGroup"
->
-  <label
-    class="components-truncate components-text components-control-label emotion-2 emotion-1"
+<div>
+  <div
+    class="components-form-group emotion-0 emotion-1"
     data-wp-c16t="true"
-    data-wp-component="ControlLabel"
-    for="fname"
+    data-wp-component="FormGroup"
   >
-    First name
-  </label>
-  <input
-    id="fname"
-    type="text"
-  />
+    <label
+      class="components-truncate components-text components-control-label emotion-2 emotion-1"
+      data-wp-c16t="true"
+      data-wp-component="ControlLabel"
+      for="fname"
+    >
+      First name
+    </label>
+    <input
+      id="fname"
+      type="text"
+    />
+  </div>
 </div>
 `;
 
@@ -96,22 +98,24 @@ exports[`props should render vertically 1`] = `
   }
 }
 
-<div
-  class="components-form-group emotion-0 emotion-1"
-  data-wp-c16t="true"
-  data-wp-component="FormGroup"
->
-  <label
-    class="components-truncate components-text components-control-label emotion-2 emotion-1"
+<div>
+  <div
+    class="components-form-group emotion-0 emotion-1"
     data-wp-c16t="true"
-    data-wp-component="ControlLabel"
-    for="fname"
+    data-wp-component="FormGroup"
   >
-    First name
-  </label>
-  <input
-    id="fname"
-    type="text"
-  />
+    <label
+      class="components-truncate components-text components-control-label emotion-2 emotion-1"
+      data-wp-c16t="true"
+      data-wp-component="ControlLabel"
+      for="fname"
+    >
+      First name
+    </label>
+    <input
+      id="fname"
+      type="text"
+    />
+  </div>
 </div>
 `;

--- a/packages/components/src/ui/form-group/test/index.js
+++ b/packages/components/src/ui/form-group/test/index.js
@@ -67,7 +67,7 @@ describe( 'props', () => {
 			</FormGroup>
 		);
 
-		expect( container.firstChild ).toMatchSnapshot();
+		expect( container ).toMatchSnapshot();
 	} );
 
 	test( 'should render vertically', () => {
@@ -77,7 +77,7 @@ describe( 'props', () => {
 			</FormGroup>
 		);
 
-		expect( container.firstChild ).toMatchSnapshot();
+		expect( container ).toMatchSnapshot();
 	} );
 } );
 /* eslint-enable no-restricted-syntax */

--- a/packages/components/src/ui/shortcut/test/__snapshots__/index.js.snap
+++ b/packages/components/src/ui/shortcut/test/__snapshots__/index.js.snap
@@ -10,4 +10,4 @@ exports[`Shortcut should render a span with the shortcut text 1`] = `
 </span>
 `;
 
-exports[`Shortcut should render null when no shortcut is provided 1`] = `null`;
+exports[`Shortcut should render null when no shortcut is provided 1`] = `<div />`;

--- a/packages/components/src/ui/shortcut/test/index.js
+++ b/packages/components/src/ui/shortcut/test/index.js
@@ -11,7 +11,7 @@ import { Shortcut } from '..';
 describe( 'Shortcut', () => {
 	it( 'should render null when no shortcut is provided', () => {
 		const { container } = render( <Shortcut /> );
-		expect( container.firstChild ).toMatchSnapshot();
+		expect( container ).toMatchSnapshot();
 	} );
 
 	it( 'should render a span with the shortcut text', () => {

--- a/packages/components/src/ui/spinner/test/__snapshots__/index.js.snap
+++ b/packages/components/src/ui/spinner/test/__snapshots__/index.js.snap
@@ -179,58 +179,60 @@ exports[`props should render correctly 1`] = `
   transform: rotate( 330deg ) translate( 0, -130% );
 }
 
-<div
-  aria-busy="true"
-  class="components-spinner emotion-0 emotion-1"
-  data-wp-c16t="true"
-  data-wp-component="Spinner"
-  style="height: 16px; width: 16px;"
->
+<div>
   <div
-    aria-hidden="true"
-    class="emotion-2 emotion-3"
-    style="transform: scale(0.4444444444444444);"
+    aria-busy="true"
+    class="components-spinner emotion-0 emotion-1"
+    data-wp-c16t="true"
+    data-wp-component="Spinner"
+    style="height: 16px; width: 16px;"
   >
     <div
-      class="emotion-4 emotion-5"
-      style="color: rgb(30, 30, 30);"
+      aria-hidden="true"
+      class="emotion-2 emotion-3"
+      style="transform: scale(0.4444444444444444);"
     >
       <div
-        class="InnerBar1"
-      />
-      <div
-        class="InnerBar2"
-      />
-      <div
-        class="InnerBar3"
-      />
-      <div
-        class="InnerBar4"
-      />
-      <div
-        class="InnerBar5"
-      />
-      <div
-        class="InnerBar6"
-      />
-      <div
-        class="InnerBar7"
-      />
-      <div
-        class="InnerBar8"
-      />
-      <div
-        class="InnerBar9"
-      />
-      <div
-        class="InnerBar10"
-      />
-      <div
-        class="InnerBar11"
-      />
-      <div
-        class="InnerBar12"
-      />
+        class="emotion-4 emotion-5"
+        style="color: rgb(30, 30, 30);"
+      >
+        <div
+          class="InnerBar1"
+        />
+        <div
+          class="InnerBar2"
+        />
+        <div
+          class="InnerBar3"
+        />
+        <div
+          class="InnerBar4"
+        />
+        <div
+          class="InnerBar5"
+        />
+        <div
+          class="InnerBar6"
+        />
+        <div
+          class="InnerBar7"
+        />
+        <div
+          class="InnerBar8"
+        />
+        <div
+          class="InnerBar9"
+        />
+        <div
+          class="InnerBar10"
+        />
+        <div
+          class="InnerBar11"
+        />
+        <div
+          class="InnerBar12"
+        />
+      </div>
     </div>
   </div>
 </div>

--- a/packages/components/src/ui/spinner/test/index.js
+++ b/packages/components/src/ui/spinner/test/index.js
@@ -11,7 +11,7 @@ import { Spinner } from '..';
 describe( 'props', () => {
 	test( 'should render correctly', () => {
 		const { container } = render( <Spinner /> );
-		expect( container.firstChild ).toMatchSnapshot();
+		expect( container ).toMatchSnapshot();
 	} );
 
 	test( 'should render color', () => {

--- a/packages/components/src/v-stack/test/__snapshots__/index.tsx.snap
+++ b/packages/components/src/v-stack/test/__snapshots__/index.tsx.snap
@@ -24,17 +24,19 @@ exports[`props should render alignment 1`] = `
   min-height: 0;
 }
 
-<div
-  class="components-flex components-h-stack components-v-stack emotion-0 emotion-1"
-  data-wp-c16t="true"
-  data-wp-component="VStack"
->
+<div>
   <div
-    class="emotion-2 emotion-1"
-  />
-  <div
-    class="emotion-2 emotion-1"
-  />
+    class="components-flex components-h-stack components-v-stack emotion-0 emotion-1"
+    data-wp-c16t="true"
+    data-wp-component="VStack"
+  >
+    <div
+      class="emotion-2 emotion-1"
+    />
+    <div
+      class="emotion-2 emotion-1"
+    />
+  </div>
 </div>
 `;
 
@@ -61,17 +63,19 @@ exports[`props should render correctly 1`] = `
   min-height: 0;
 }
 
-<div
-  class="components-flex components-h-stack components-v-stack emotion-0 emotion-1"
-  data-wp-c16t="true"
-  data-wp-component="VStack"
->
+<div>
   <div
-    class="emotion-2 emotion-1"
-  />
-  <div
-    class="emotion-2 emotion-1"
-  />
+    class="components-flex components-h-stack components-v-stack emotion-0 emotion-1"
+    data-wp-c16t="true"
+    data-wp-component="VStack"
+  >
+    <div
+      class="emotion-2 emotion-1"
+    />
+    <div
+      class="emotion-2 emotion-1"
+    />
+  </div>
 </div>
 `;
 
@@ -98,16 +102,18 @@ exports[`props should render spacing 1`] = `
   min-height: 0;
 }
 
-<div
-  class="components-flex components-h-stack components-v-stack emotion-0 emotion-1"
-  data-wp-c16t="true"
-  data-wp-component="VStack"
->
+<div>
   <div
-    class="emotion-2 emotion-1"
-  />
-  <div
-    class="emotion-2 emotion-1"
-  />
+    class="components-flex components-h-stack components-v-stack emotion-0 emotion-1"
+    data-wp-c16t="true"
+    data-wp-component="VStack"
+  >
+    <div
+      class="emotion-2 emotion-1"
+    />
+    <div
+      class="emotion-2 emotion-1"
+    />
+  </div>
 </div>
 `;

--- a/packages/components/src/v-stack/test/index.tsx
+++ b/packages/components/src/v-stack/test/index.tsx
@@ -17,7 +17,7 @@ describe( 'props', () => {
 				<View />
 			</VStack>
 		);
-		expect( container.firstChild ).toMatchSnapshot();
+		expect( container ).toMatchSnapshot();
 	} );
 
 	test( 'should render alignment', () => {
@@ -27,7 +27,7 @@ describe( 'props', () => {
 				<View />
 			</VStack>
 		);
-		expect( container.firstChild ).toMatchSnapshot();
+		expect( container ).toMatchSnapshot();
 	} );
 
 	test( 'should render spacing', () => {
@@ -37,6 +37,6 @@ describe( 'props', () => {
 				<View />
 			</VStack>
 		);
-		expect( container.firstChild ).toMatchSnapshot();
+		expect( container ).toMatchSnapshot();
 	} );
 } );

--- a/packages/components/src/view/test/__snapshots__/index.js.snap
+++ b/packages/components/src/view/test/__snapshots__/index.js.snap
@@ -1,41 +1,51 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`props should render as another element 1`] = `
-<p
-  class="emotion-0 emotion-1"
->
-  <span />
-</p>
+<div>
+  <p
+    class="emotion-0 emotion-1"
+  >
+    <span />
+  </p>
+</div>
 `;
 
 exports[`props should render correctly 1`] = `
-<div
-  class="emotion-0 emotion-1"
->
-  <span />
+<div>
+  <div
+    class="emotion-0 emotion-1"
+  >
+    <span />
+  </div>
 </div>
 `;
 
 exports[`props should render with custom styles (Array) 1`] = `
-<p
-  class="emotion-0 emotion-1"
->
-  <span />
-</p>
+<div>
+  <p
+    class="emotion-0 emotion-1"
+  >
+    <span />
+  </p>
+</div>
 `;
 
 exports[`props should render with custom styles (object) 1`] = `
-<p
-  class="emotion-0 emotion-1"
->
-  <span />
-</p>
+<div>
+  <p
+    class="emotion-0 emotion-1"
+  >
+    <span />
+  </p>
+</div>
 `;
 
 exports[`props should render with custom styles (string) 1`] = `
-<p
-  class="emotion-0 emotion-1"
->
-  <span />
-</p>
+<div>
+  <p
+    class="emotion-0 emotion-1"
+  >
+    <span />
+  </p>
+</div>
 `;

--- a/packages/components/src/view/test/index.js
+++ b/packages/components/src/view/test/index.js
@@ -15,7 +15,7 @@ describe( 'props', () => {
 				<span />
 			</View>
 		);
-		expect( container.firstChild ).toMatchSnapshot();
+		expect( container ).toMatchSnapshot();
 	} );
 
 	test( 'should render as another element', () => {
@@ -24,7 +24,7 @@ describe( 'props', () => {
 				<span />
 			</View>
 		);
-		expect( container.firstChild ).toMatchSnapshot();
+		expect( container ).toMatchSnapshot();
 	} );
 
 	test( 'should render with custom styles (string)', () => {
@@ -38,7 +38,7 @@ describe( 'props', () => {
 				<span />
 			</View>
 		);
-		expect( container.firstChild ).toMatchSnapshot();
+		expect( container ).toMatchSnapshot();
 	} );
 
 	test( 'should render with custom styles (object)', () => {
@@ -52,7 +52,7 @@ describe( 'props', () => {
 				<span />
 			</View>
 		);
-		expect( container.firstChild ).toMatchSnapshot();
+		expect( container ).toMatchSnapshot();
 	} );
 
 	test( 'should render with custom styles (Array)', () => {
@@ -69,6 +69,6 @@ describe( 'props', () => {
 				<span />
 			</View>
 		);
-		expect( container.firstChild ).toMatchSnapshot();
+		expect( container ).toMatchSnapshot();
 	} );
 } );

--- a/packages/edit-post/src/components/sidebar/plugin-post-status-info/test/__snapshots__/index.js.snap
+++ b/packages/edit-post/src/components/sidebar/plugin-post-status-info/test/__snapshots__/index.js.snap
@@ -1,9 +1,11 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`PluginPostStatusInfo renders fill properly 1`] = `
-<div
-  class="components-panel__row my-plugin-post-status-info"
->
-  My plugin post status info
+<div>
+  <div
+    class="components-panel__row my-plugin-post-status-info"
+  >
+    My plugin post status info
+  </div>
 </div>
 `;

--- a/packages/edit-post/src/components/sidebar/plugin-post-status-info/test/index.js
+++ b/packages/edit-post/src/components/sidebar/plugin-post-status-info/test/index.js
@@ -24,6 +24,6 @@ describe( 'PluginPostStatusInfo', () => {
 			</SlotFillProvider>
 		);
 
-		expect( container.firstChild ).toMatchSnapshot();
+		expect( container ).toMatchSnapshot();
 	} );
 } );


### PR DESCRIPTION
## What?
This PR updates snapshot tests that use RTL's `container.firstChild` to use `container` instead. This changes the snapshots by adding the wrapper as well.

## Why?
Because it allows us to get rid of a bunch of [`no-node-access`](https://github.com/testing-library/eslint-plugin-testing-library/blob/main/docs/rules/no-node-access.md) ESLint violations for a very cheap price.

Also, it's better according to Kent C. Dodds, if we don't compare snapshots before and after, see https://twitter.com/kentcdodds/status/1272186092779761669

## How?
We're just replacing `container.firstChild` with `container` and updating the tests.

## Testing Instructions
Verify all tests still pass.