### PR TITLE
ItemGroup: fix RTL text alignment when item is clickable

### DIFF
--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -13,6 +13,7 @@
 ### Bug Fix
 
 -   `UnitControl`: Fix `disabled` style is overridden by core `form.css` style ([#45250](https://github.com/WordPress/gutenberg/pull/45250)).
+-   `ItemGroup`: fix RTL `Item` styles when rendered as a button ([#45280](https://github.com/WordPress/gutenberg/pull/45280)).
 -   `Button`: Fix RTL alignment for buttons containing an icon and text ([#44787](https://github.com/WordPress/gutenberg/pull/44787)).
 -   `TabPanel`: Call `onSelect()` on every tab selection, regardless of whether it was triggered by user interaction ([#44028](https://github.com/WordPress/gutenberg/pull/44028)).
 -   `FontSizePicker`: Fallback to font size `slug` if `name` is undefined  ([#45041](https://github.com/WordPress/gutenberg/pull/45041)).

--- a/packages/components/src/item-group/styles.ts
+++ b/packages/components/src/item-group/styles.ts
@@ -13,7 +13,7 @@ export const unstyledButton = css`
 	border: 1px solid transparent;
 	cursor: pointer;
 	background: none;
-	text-align: left;
+	text-align: start;
 
 	&:hover {
 		color: ${ COLORS.ui.theme };

--- a/packages/edit-post/src/components/preferences-modal/test/__snapshots__/index.js.snap
+++ b/packages/edit-post/src/components/preferences-modal/test/__snapshots__/index.js.snap
@@ -565,7 +565,7 @@ exports[`EditPostPreferencesModal should match snapshot when the modal is active
   border: 1px solid transparent;
   cursor: pointer;
   background: none;
-  text-align: left;
+  text-align: start;
   padding: calc((36px - calc(13px * 1.2) - 2px) / 2) 12px;
   width: 100%;
   display: block;


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Quick fix for an issue that I noticed while reviewing https://github.com/WordPress/gutenberg/pull/43208

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

Making the component look as expected for RTL writing directions

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

This PR uses [logical properties](https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_Logical_Properties/Floating_and_positioning) for the value of `text-align` in the `Item` component, specifically when the `Item` is clickable (and therefore rendered as a `button`)

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->

- Open the `ItemGroup`'s default story on Storybook
- Set the writing direction to RTL via the toolbar buttons
- Notice how the text in the clickable elements is correctly aligned to the right, and compare it to the (incorrectly) left-aligned text for the same buttons on `trunk`

## Screenshots or screencast <!-- if applicable -->

| Before | After |
|---|---|
|  <img width="436" alt="Screenshot 2022-10-25 at 15 42 48" src="https://user-images.githubusercontent.com/1083581/197793369-b4cd8240-fa83-4607-907e-e6269b17d84f.png"> |  <img width="324" alt="Screenshot 2022-10-25 at 15 57 53" src="https://user-images.githubusercontent.com/1083581/197793445-669cf1f3-a620-47ea-bd10-8d0d55973ea6.png"> |