### PR TITLE
Lodash: Refactor away from `_.words()` - take 2

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -168,6 +168,7 @@ module.exports = {
 							'upperFirst',
 							'values',
 							'without',
+							'words',
 							'xor',
 							'zip',
 						],

--- a/package-lock.json
+++ b/package-lock.json
@@ -17593,6 +17593,7 @@
 				"@wordpress/url": "file:packages/url",
 				"@wordpress/warning": "file:packages/warning",
 				"@wordpress/wordcount": "file:packages/wordcount",
+				"change-case": "^4.1.2",
 				"classnames": "^2.3.1",
 				"colord": "^2.7.0",
 				"diff": "^4.0.2",

--- a/packages/block-editor/package.json
+++ b/packages/block-editor/package.json
@@ -59,6 +59,7 @@
 		"@wordpress/url": "file:../url",
 		"@wordpress/warning": "file:../warning",
 		"@wordpress/wordcount": "file:../wordcount",
+		"change-case": "^4.1.2",
 		"classnames": "^2.3.1",
 		"colord": "^2.7.0",
 		"diff": "^4.0.2",

--- a/packages/block-editor/src/components/inserter/search-items.js
+++ b/packages/block-editor/src/components/inserter/search-items.js
@@ -2,7 +2,8 @@
  * External dependencies
  */
 import removeAccents from 'remove-accents';
-import { find, words } from 'lodash';
+import { find } from 'lodash';
+import { noCase } from 'change-case';
 
 // Default search helpers.
 const defaultGetName = ( item ) => item.name || '';
@@ -11,6 +12,25 @@ const defaultGetDescription = ( item ) => item.description || '';
 const defaultGetKeywords = ( item ) => item.keywords || [];
 const defaultGetCategory = ( item ) => item.category;
 const defaultGetCollection = () => null;
+
+/**
+ * Extracts words from an input string.
+ *
+ * @param {string} input The input string.
+ *
+ * @return {Array} Words, extracted from the input string.
+ */
+function extractWords( input = '' ) {
+	return noCase( input, {
+		splitRegexp: [
+			/([\p{Ll}\p{Lo}\p{N}])([\p{Lu}\p{Lt}])/gu, // One lowercase or digit, followed by one uppercase.
+			/([\p{Lu}\p{Lt}])([\p{Lu}\p{Lt}][\p{Ll}\p{Lo}])/gu, // One uppercase followed by one uppercase and one lowercase.
+		],
+		stripRegexp: /(\p{C}|\p{P}|\p{S})+/giu, // Anything that's not a punctuation, symbol or control/format character.
+	} )
+		.split( ' ' )
+		.filter( Boolean );
+}
 
 /**
  * Sanitizes the search input string.
@@ -43,7 +63,7 @@ function normalizeSearchInput( input = '' ) {
  * @return {string[]} The normalized list of search terms.
  */
 export const getNormalizedSearchTerms = ( input = '' ) => {
-	return words( normalizeSearchInput( input ) );
+	return extractWords( normalizeSearchInput( input ) );
 };
 
 const removeMatchingTerms = ( unmatchedTerms, unprocessedTerms ) => {
@@ -150,7 +170,7 @@ export function getItemSearchRank( item, searchTerm, config = {} ) {
 			category,
 			collection,
 		].join( ' ' );
-		const normalizedSearchTerms = words( normalizedSearchInput );
+		const normalizedSearchTerms = extractWords( normalizedSearchInput );
 		const unmatchedTerms = removeMatchingTerms(
 			normalizedSearchTerms,
 			terms

--- a/packages/block-editor/src/components/inserter/test/search-items.js
+++ b/packages/block-editor/src/components/inserter/test/search-items.js
@@ -45,6 +45,12 @@ describe( 'getNormalizedSearchTerms', () => {
 
 	it( 'should support non-latin letters', () => {
 		expect( getNormalizedSearchTerms( 'მედია' ) ).toEqual( [ 'მედია' ] );
+		expect(
+			getNormalizedSearchTerms( '师父领进门，修行在个人。' )
+		).toEqual( [ '师父领进门', '修行在个人' ] );
+		expect(
+			getNormalizedSearchTerms( 'Бързата работа – срам за майстора.' )
+		).toEqual( [ 'бързата', 'работа', 'срам', 'за', 'майстора' ] );
 	} );
 } );
 


### PR DESCRIPTION
## What?
This PR removes the `_.words()` usage completely and deprecates the function again.

This is the second attempt to remove `_.words()`, after #42467 broke inserter searching for non-latin characters (see #44644) and it was reverted in #44652.

## Why?

Lodash is known to unnecessarily inflate the bundle size of packages, and in most cases, it can be replaced with native language functionality. See these for more information and rationale:

* https://github.com/WordPress/gutenberg/issues/16938#issuecomment-602837246
* https://github.com/WordPress/gutenberg/issues/17025
* https://github.com/WordPress/gutenberg/issues/39495 

## How?

Similar to #42427, we're suggesting to use the `change-case` library, which offers modular functions for all the casing functions we use from Lodash (like `snakeCase`, `capitalize`, `startCase`, `camelCase`, `kebabCase` ), at a small price (the methods are small themselves), and has TS support. The benefit of using that external library for all those case conversion functions is that we won't have to maintain our own versions of them, and those are already broadly used and tested.

In particular, we replace the single instance of `words()` with a custom implementation that uses `noCase()` to generate a normalized string of words, then splits it into an array and filters out the empty values.

We're altering the default regexes that `noCase()` uses, in order to properly provide unicode support and therefore support proper splitting to words for all languages.

We're also adding another 2 assertions to the non-latin tests - one in Chinese Simplified and one in Bulgarian, to better cover non-latin support.

## Testing Instructions
* Verify all tests still pass, particularly:
  * `npm run test-unit packages/block-editor/src/components/inserter/test/search-items.js`
* Verify searching in all inserters (inline slash inserter, header toolbar, inline block editor inserter) still works well:
  * Searching for blocks using their name, description or keywords still works the same way as before.
  * Searching for a string with diacritics still works the same way: `média`
 * Verify these test instructions still work well: 
   * #44644
   * #44652
