### PR TITLE
Perf Tests: Stop building project types during test build phase

### DIFF
--- a/bin/plugin/commands/performance.js
+++ b/bin/plugin/commands/performance.js
@@ -241,7 +241,7 @@ async function runPerformanceTests( branches, options ) {
 
 	log( '    >> Installing dependencies and building packages' );
 	await runShellScript(
-		'npm ci && npm run build:packages',
+		'npm ci && node ./bin/packages/build.js',
 		performanceTestDirectory
 	);
 	log( '    >> Creating the environment folders' );
@@ -275,7 +275,10 @@ async function runPerformanceTests( branches, options ) {
 			await SimpleGit( buildPath ).reset( 'hard' ).checkout( branch );
 
 			log( `        >> Building the ${ fancyBranch } branch` );
-			await runShellScript( 'npm ci && npm run build', buildPath );
+			await runShellScript(
+				'npm ci && node ./bin/packages/build.js',
+				buildPath
+			);
 		}
 
 		await runShellScript(


### PR DESCRIPTION
## What?

Skips TypeScript types generation during performance test runs.

## Why?

We don't use the types we build during the performance test runs, but generating them slows down the tests by doing more things.

## How?

By not doing more things we should take less time to finish running the test workflow.

![branch-compare-45284-44907](https://user-images.githubusercontent.com/5431237/202496989-1b95e454-0124-4ed4-9bc9-600890aa1c2a.png)

## Testing Instructions

Given that this change only affects the types generated during the performance test workflow things ought to be sound as long as the performance test suite passes.

Please audit the code to review the change and comment on it if you find any concerns.

The tradeoff in this PR is that we're using `node ./bin/packages/build.js` directly instead of calling `npm run build`. We _could_ create a separate `npm` script to build without running `npm run build:package-types` but I suspect that this is one of the few cases we want this change. We could get out of date with `package.json`, but also I think if something important were to impact the tests they would start failing and we could investigate.
