### PR TITLE
Try: allow replacing a template part from patterns & parts shown in the inspector

### DIFF
--- a/packages/block-library/src/template-part/edit/index.js
+++ b/packages/block-library/src/template-part/edit/index.js
@@ -15,8 +15,9 @@ import {
 	store as blockEditorStore,
 	__experimentalRecursionProvider as RecursionProvider,
 	__experimentalUseHasRecursion as useHasRecursion,
+	InspectorControls,
 } from '@wordpress/block-editor';
-import { Spinner, Modal, MenuItem } from '@wordpress/components';
+import { Spinner, Modal, MenuItem, PanelBody } from '@wordpress/components';
 import { __, sprintf } from '@wordpress/i18n';
 import { store as coreStore } from '@wordpress/core-data';
 import { useState, createInterpolateElement } from '@wordpress/element';
@@ -217,6 +218,17 @@ export default function TemplatePartEdit( {
 					/>
 				</Modal>
 			) }
+			<InspectorControls>
+				<PanelBody title={ __( 'Replacements' ) }>
+					<TemplatePartSelectionModal
+						templatePartId={ templatePartId }
+						clientId={ clientId }
+						area={ area }
+						setAttributes={ setAttributes }
+						onClose={ () => {} } //no operation
+					/>
+				</PanelBody>
+			</InspectorControls>
 		</>
 	);
 }


### PR DESCRIPTION
## What?

Closes https://github.com/WordPress/gutenberg/issues/44582

![template](https://user-images.githubusercontent.com/846565/193064234-81da73ae-3d60-4746-a7d2-343f938f055e.gif)

## How?

Reuses the existing `TemplatePartSelectionModal` with all its components: search, list of template parts, list of patterns. This is a bit different from the mockup, and brings up a few questions / TODO items:

- Is it the "Advanced panel" to be removed? I don't see it in the mockup. 
- Whether we have the advance panel or not may influence our thinking about an issue with the potential long scrolling. In the current state, I used a panel to bind the list of suggestions, so users could toggle it off and access the "advanced" section easily.
- Do we only show patterns in the inspector? Or both parts and patterns? I'm inclined to show the same things a user can access via the modal ("block settings > replace").
- Is it search useful in this context?
- The list of potential replacements needs some sort of visual mechanism to tell them apart. Something similar to what we have for style variations could work.

## Testing Instructions

- Open the side editor and select a template part. For example, the header.
- Open the block inspector and verify that there is a new panel called "Replacements" that contains alternate parts and patterns.
- Click on any and verify that the template part is replaced.

[Gravação de ecrã a partir de 25-10-2022 17:46:40.webm](https://user-images.githubusercontent.com/583546/197820876-022da7af-c2fc-4989-8439-db2723dd9e67.webm)
