### PR TITLE
Components: use new theming accent color in all components

### DIFF
--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -54,6 +54,10 @@
 -   `Autocomplete`: use Popover's new `placement` prop instead of legacy `position` prop ([#44396](https://github.com/WordPress/gutenberg/pull/44396/)).
 -   `FontSizePicker`: Add more comprehensive tests ([#45298](https://github.com/WordPress/gutenberg/pull/45298)).
 
+### Experimental
+-   Theming: updated Components package to utilize the new `accent` prop of the experimental `Theme` component.
+
+
 ## 21.3.0 (2022-10-19)
 
 ### Bug Fix

--- a/packages/components/src/angle-picker-control/index.js
+++ b/packages/components/src/angle-picker-control/index.js
@@ -21,8 +21,6 @@ import { Text } from '../text';
 import { Spacer } from '../spacer';
 import { COLORS } from '../utils/colors-values';
 
-const accentColor = COLORS.ui.theme;
-
 export default function AnglePickerControl( {
 	/** Start opting into the new margin-free styles that will become the default in a future version. */
 	__nextHasNoMarginBottom = false,
@@ -73,7 +71,7 @@ export default function AnglePickerControl( {
 							marginBottom={ 0 }
 							marginRight={ space( 3 ) }
 							style={ {
-								color: accentColor,
+								color: COLORS.ui.theme,
 							} }
 						>
 							°

--- a/packages/components/src/angle-picker-control/index.js
+++ b/packages/components/src/angle-picker-control/index.js
@@ -19,6 +19,9 @@ import { Root } from './styles/angle-picker-control-styles';
 import { space } from '../ui/utils/space';
 import { Text } from '../text';
 import { Spacer } from '../spacer';
+import { COLORS } from '../utils/colors-values';
+
+const accentColor = COLORS.ui.theme;
 
 export default function AnglePickerControl( {
 	/** Start opting into the new margin-free styles that will become the default in a future version. */
@@ -70,7 +73,7 @@ export default function AnglePickerControl( {
 							marginBottom={ 0 }
 							marginRight={ space( 3 ) }
 							style={ {
-								color: 'var( --wp-admin-theme-color )',
+								color: accentColor,
 							} }
 						>
 							°

--- a/packages/components/src/autocomplete/style.scss
+++ b/packages/components/src/autocomplete/style.scss
@@ -11,6 +11,6 @@
 	width: 100%;
 
 	&.is-selected {
-		box-shadow: 0 0 0 var(--wp-admin-border-width-focus) var(--wp-admin-theme-color);
+		box-shadow: 0 0 0 var(--wp-admin-border-width-focus) $components-color-accent;
 	}
 }

--- a/packages/components/src/base-field/test/__snapshots__/index.js.snap
+++ b/packages/components/src/base-field/test/__snapshots__/index.js.snap
@@ -127,8 +127,8 @@ exports[`base field should render correctly 1`] = `
 
 .emotion-0:focus,
 .emotion-0[data-focused='true'] {
-  border-color: var( --wp-admin-theme-color, #007cba);
-  box-shadow: 0 0 0 0.5px var( --wp-admin-theme-color, #007cba);
+  border-color: var(--wp-components-color-accent, var(--wp-admin-theme-color, #007cba));
+  box-shadow: 0 0 0 0.5px var(--wp-components-color-accent, var(--wp-admin-theme-color, #007cba));
 }
 
 <div

--- a/packages/components/src/button/style.scss
+++ b/packages/components/src/button/style.scss
@@ -324,6 +324,11 @@
 	.components-visually-hidden {
 		height: auto;
 	}
+
+	// Override for theming on the block mover handle. `.block-editor-block-mover__drag-handle` was needed for specificity to override declaration order.
+	.components-accessible-toolbar &.block-editor-block-mover__drag-handle:focus::before {
+		box-shadow: inset 0 0 0 var(--wp-admin-border-width-focus) $components-color-accent, inset 0 0 0 4px $white;
+	}
 }
 
 @keyframes components-button__busy-animation {

--- a/packages/components/src/button/style.scss
+++ b/packages/components/src/button/style.scss
@@ -324,11 +324,6 @@
 	.components-visually-hidden {
 		height: auto;
 	}
-
-	// Override for theming on the block mover handle. `.block-editor-block-mover__drag-handle` was needed for specificity to override declaration order.
-	.components-accessible-toolbar &.block-editor-block-mover__drag-handle:focus::before {
-		box-shadow: inset 0 0 0 var(--wp-admin-border-width-focus) $components-color-accent, inset 0 0 0 4px $white;
-	}
 }
 
 @keyframes components-button__busy-animation {

--- a/packages/components/src/checkbox-control/style.scss
+++ b/packages/components/src/checkbox-control/style.scss
@@ -27,7 +27,7 @@ $checkbox-input-size-sm: 24px; // Width & height for small viewports.
 	@include reduce-motion("transition");
 
 	&:focus {
-		box-shadow: 0 0 0 ($border-width * 2) $white, 0 0 0 ($border-width * 2 + $border-width-focus) var(--wp-admin-theme-color);
+		box-shadow: 0 0 0 ($border-width * 2) $white, 0 0 0 ($border-width * 2 + $border-width-focus) $components-color-accent;
 
 		// Only visible in Windows High Contrast mode.
 		outline: 2px solid transparent;
@@ -35,8 +35,8 @@ $checkbox-input-size-sm: 24px; // Width & height for small viewports.
 
 	&:checked,
 	&:indeterminate {
-		background: var(--wp-admin-theme-color);
-		border-color: var(--wp-admin-theme-color);
+		background: $components-color-accent;
+		border-color: $components-color-accent;
 
 		// Hide default checkbox styles in IE.
 		&::-ms-check {

--- a/packages/components/src/checkbox-control/style.scss
+++ b/packages/components/src/checkbox-control/style.scss
@@ -28,15 +28,13 @@ $checkbox-input-size-sm: 24px; // Width & height for small viewports.
 
 	&:focus {
 		box-shadow: 0 0 0 ($border-width * 2) $white, 0 0 0 ($border-width * 2 + $border-width-focus) $components-color-accent;
-		border-color: $components-color-accent;
 
 		// Only visible in Windows High Contrast mode.
 		outline: 2px solid transparent;
 	}
 
 	&:checked,
-	&:indeterminate,
-	&[aria-checked="mixed"] {
+	&:indeterminate {
 		background: $components-color-accent;
 		border-color: $components-color-accent;
 

--- a/packages/components/src/checkbox-control/style.scss
+++ b/packages/components/src/checkbox-control/style.scss
@@ -35,7 +35,8 @@ $checkbox-input-size-sm: 24px; // Width & height for small viewports.
 	}
 
 	&:checked,
-	&:indeterminate {
+	&:indeterminate,
+	&[aria-checked="mixed"] {
 		background: $components-color-accent;
 		border-color: $components-color-accent;
 

--- a/packages/components/src/checkbox-control/style.scss
+++ b/packages/components/src/checkbox-control/style.scss
@@ -28,6 +28,7 @@ $checkbox-input-size-sm: 24px; // Width & height for small viewports.
 
 	&:focus {
 		box-shadow: 0 0 0 ($border-width * 2) $white, 0 0 0 ($border-width * 2 + $border-width-focus) $components-color-accent;
+		border-color: $components-color-accent;
 
 		// Only visible in Windows High Contrast mode.
 		outline: 2px solid transparent;

--- a/packages/components/src/color-palette/style.scss
+++ b/packages/components/src/color-palette/style.scss
@@ -25,7 +25,7 @@
 	outline: 1px solid transparent;
 
 	&:focus {
-		box-shadow: inset 0 0 0 var(--wp-admin-border-width-focus) var(--wp-admin-theme-color);
+		box-shadow: inset 0 0 0 var(--wp-admin-border-width-focus) $components-color-accent;
 		// Show a outline in Windows high contrast mode.
 		outline-width: 2px;
 	}

--- a/packages/components/src/drop-zone/style.scss
+++ b/packages/components/src/drop-zone/style.scss
@@ -24,7 +24,7 @@
 	height: 100%;
 	width: 100%;
 	display: flex;
-	background-color: var(--wp-admin-theme-color);
+	background-color: $components-color-accent;
 	align-items: center;
 	justify-content: center;
 	z-index: z-index(".components-drop-zone__content");

--- a/packages/components/src/form-toggle/style.scss
+++ b/packages/components/src/form-toggle/style.scss
@@ -38,13 +38,13 @@ $toggle-border-width: 1px;
 
 	// Checked state.
 	&.is-checked .components-form-toggle__track {
-		background-color: var(--wp-admin-theme-color);
-		border: $toggle-border-width solid var(--wp-admin-theme-color);
+		background-color: $components-color-accent;
+		border: $toggle-border-width solid $components-color-accent;
 		border: #{ $toggle-height * 0.5 } solid transparent; // Expand the border to fake a solid in Windows High Contrast Mode.
 	}
 
 	.components-form-toggle__input:focus + .components-form-toggle__track {
-		box-shadow: 0 0 0 2px $white, 0 0 0 (2px + $border-width-focus) var(--wp-admin-theme-color);
+		box-shadow: 0 0 0 2px $white, 0 0 0 (2px + $border-width-focus) $components-color-accent;
 
 		// Windows High Contrast mode will show this outline, but not the box-shadow.
 		outline: 2px solid transparent;

--- a/packages/components/src/form-token-field/style.scss
+++ b/packages/components/src/form-token-field/style.scss
@@ -12,13 +12,6 @@
 
 	&.is-active {
 		@include input-style__focus();
-		border-color: $components-color-accent;
-		box-shadow: 0 0 0 ($border-width-focus - $border-width) $components-color-accent;
-	}
-
-	&:focus {
-		border-color: $components-color-accent;
-		box-shadow: 0 0 0 ($border-width-focus - $border-width) $components-color-accent;
 	}
 
 	// Token input

--- a/packages/components/src/form-token-field/style.scss
+++ b/packages/components/src/form-token-field/style.scss
@@ -88,7 +88,7 @@
 
 		.components-form-token-field__token-text {
 			background: transparent;
-			color: var(--wp-admin-theme-color);
+			color: $components-color-accent;
 		}
 
 		.components-form-token-field__remove-token {
@@ -183,7 +183,7 @@
 	cursor: pointer;
 
 	&.is-selected {
-		background: var(--wp-admin-theme-color);
+		background: $components-color-accent;
 		color: $white;
 	}
 }

--- a/packages/components/src/form-token-field/style.scss
+++ b/packages/components/src/form-token-field/style.scss
@@ -12,6 +12,13 @@
 
 	&.is-active {
 		@include input-style__focus();
+		border-color: $components-color-accent;
+		box-shadow: 0 0 0 ($border-width-focus - $border-width) $components-color-accent;
+	}
+
+	&:focus {
+		border-color: $components-color-accent;
+		box-shadow: 0 0 0 ($border-width-focus - $border-width) $components-color-accent;
 	}
 
 	// Token input

--- a/packages/components/src/higher-order/navigate-regions/style.scss
+++ b/packages/components/src/higher-order/navigate-regions/style.scss
@@ -14,7 +14,7 @@
 		right: 0;
 		pointer-events: none;
 		outline: 4px solid transparent; // Shown in Windows High Contrast mode.
-		box-shadow: inset 0 0 0 4px var(--wp-admin-theme-color);
+		box-shadow: inset 0 0 0 4px $components-color-accent;
 	}
 
 	@supports ( outline-offset: 1px ) {
@@ -24,7 +24,7 @@
 
 		&:focus {
 			outline-style: solid;
-			outline-color: var(--wp-admin-theme-color);
+			outline-color: $components-color-accent;
 			outline-width: 4px;
 			outline-offset: -4px;
 		}

--- a/packages/components/src/menu-item/style.scss
+++ b/packages/components/src/menu-item/style.scss
@@ -45,7 +45,7 @@
 		// Override the button component's tertiary background and color.
 		&.is-tertiary {
 			background: none;
-			color: var(--wp-admin-theme-color-darker-10);
+			color: $components-color-accent-darker-10;
 			opacity: 0.3;
 		}
 	}

--- a/packages/components/src/notice/README.md
+++ b/packages/components/src/notice/README.md
@@ -34,7 +34,8 @@ Notices display at the top of the screen, below any toolbars anchored to the top
 Notices are color-coded to indicate the type of message being communicated:
 
 -   **Default** notices have **no background**.
--   **Informational** notices are **blue.**
+-   **Informational** notices are **blue** by default.
+    - If there is a parent `Theme` component with an `accent` color prop, informational notices will take on that color instead.
 -   **Success** notices are **green.**
 -   **Warning** notices are **yellow\*\***.\*\*
 -   **Error** notices are **red.**

--- a/packages/components/src/notice/style.scss
+++ b/packages/components/src/notice/style.scss
@@ -3,7 +3,7 @@
 	font-family: $default-font;
 	font-size: $default-font-size;
 	background-color: $white;
-	border-left: 4px solid var(--wp-admin-theme-color);
+	border-left: 4px solid $components-color-accent;
 	margin: 5px 15px 2px;
 	padding: 8px 12px;
 	align-items: center;

--- a/packages/components/src/panel/style.scss
+++ b/packages/components/src/panel/style.scss
@@ -91,7 +91,7 @@
 	height: auto;
 
 	&:focus {
-		box-shadow: inset 0 0 0 var(--wp-admin-border-width-focus) var(--wp-admin-theme-color);
+		box-shadow: inset 0 0 0 var(--wp-admin-border-width-focus) $components-color-accent;
 		border-radius: 0;
 	}
 

--- a/packages/components/src/range-control/styles/range-control-styles.ts
+++ b/packages/components/src/range-control/styles/range-control-styles.ts
@@ -174,7 +174,7 @@ const thumbColor = ( { disabled }: ThumbProps ) =>
 				background-color: ${ COLORS.gray[ 400 ] };
 		  `
 		: css`
-				background-color: var( --wp-admin-theme-color );
+				background-color: ${ COLORS.ui.theme };
 		  `;
 
 export const ThumbWrapper = styled.span`
@@ -205,7 +205,7 @@ const thumbFocus = ( { isFocused }: ThumbProps ) => {
 				&::before {
 					content: ' ';
 					position: absolute;
-					background-color: var( --wp-admin-theme-color );
+					background-color: ${ COLORS.ui.theme };
 					opacity: 0.4;
 					border-radius: 50%;
 					height: ${ thumbSize + 8 }px;

--- a/packages/components/src/resizable-box/style.scss
+++ b/packages/components/src/resizable-box/style.scss
@@ -35,7 +35,7 @@ $resize-handler-container-size: $resize-handler-size + ($grid-unit-05 * 2); // M
 	top: calc(50% - #{ceil($resize-handler-size * 0.5)});
 	right: calc(50% - #{ceil($resize-handler-size * 0.5)});
 
-	box-shadow: inset 0 0 0 var(--wp-admin-border-width-focus) var(--wp-admin-theme-color);
+	box-shadow: inset 0 0 0 var(--wp-admin-border-width-focus) $components-color-accent;
 	// Only visible in Windows High Contrast mode.
 	outline: 2px solid transparent;
 }
@@ -47,7 +47,7 @@ $resize-handler-container-size: $resize-handler-size + ($grid-unit-05 * 2); // M
 	content: "";
 	width: 3px;
 	height: 3px;
-	background: var(--wp-admin-theme-color);
+	background: $components-color-accent;
 	cursor: inherit;
 	position: absolute;
 	top: calc(50% - 1px);

--- a/packages/components/src/search-control/style.scss
+++ b/packages/components/src/search-control/style.scss
@@ -19,6 +19,7 @@
 		&:focus {
 			background: $white;
 			box-shadow: inset 0 0 0 var(--wp-admin-border-width-focus) $components-color-accent;
+			border-color: $components-color-accent;
 		}
 
 		&::placeholder {

--- a/packages/components/src/search-control/style.scss
+++ b/packages/components/src/search-control/style.scss
@@ -18,7 +18,7 @@
 
 		&:focus {
 			background: $white;
-			box-shadow: inset 0 0 0 var(--wp-admin-border-width-focus) var(--wp-admin-theme-color);
+			box-shadow: inset 0 0 0 var(--wp-admin-border-width-focus) $components-color-accent;
 		}
 
 		&::placeholder {

--- a/packages/components/src/search-control/style.scss
+++ b/packages/components/src/search-control/style.scss
@@ -19,7 +19,6 @@
 		&:focus {
 			background: $white;
 			box-shadow: inset 0 0 0 var(--wp-admin-border-width-focus) $components-color-accent;
-			border-color: $components-color-accent;
 		}
 
 		&::placeholder {

--- a/packages/components/src/snackbar/style.scss
+++ b/packages/components/src/snackbar/style.scss
@@ -22,7 +22,7 @@
 	&:focus {
 		box-shadow:
 			0 0 0 1px $white,
-			0 0 0 3px var(--wp-admin-theme-color);
+			0 0 0 3px $components-color-accent;
 	}
 
 	&.components-snackbar-explicit-dismiss {
@@ -64,7 +64,7 @@
 		}
 
 		&:hover {
-			color: var(--wp-admin-theme-color);
+			color: $components-color-accent;
 		}
 	}
 }

--- a/packages/components/src/spinner/styles.ts
+++ b/packages/components/src/spinner/styles.ts
@@ -24,7 +24,7 @@ export const StyledSpinner = styled.svg`
 	display: inline-block;
 	margin: 5px 11px 0;
 	position: relative;
-	color: var( --wp-admin-theme-color );
+	color: ${ COLORS.ui.theme };
 	overflow: visible;
 `;
 

--- a/packages/components/src/tab-panel/style.scss
+++ b/packages/components/src/tab-panel/style.scss
@@ -33,13 +33,12 @@
 	}
 
 	&:focus:not(:disabled) {
-		box-shadow: inset 0 var(--wp-admin-border-width-focus) var(--wp-admin-theme-color);
+		box-shadow: inset 0 var(--wp-admin-border-width-focus) $components-color-accent;
 	}
-
 
 	&.is-active {
 		// The transparent shadow ensures no jumpiness when focus animates on an active tab.
-		box-shadow: inset 0 0 0 var(--wp-admin-border-width-focus) transparent, inset 0 0 -$border-width-tab 0 0 var(--wp-admin-theme-color);
+		box-shadow: inset 0 0 0 var(--wp-admin-border-width-focus) transparent, inset 0 0 -$border-width-tab 0 0 $components-color-accent;
 		position: relative;
 
 		// This border appears in Windows High Contrast mode instead of the box-shadow.
@@ -55,10 +54,10 @@
 	}
 
 	&:focus {
-		box-shadow: inset 0 0 0 var(--wp-admin-border-width-focus) var(--wp-admin-theme-color);
+		box-shadow: inset 0 0 0 var(--wp-admin-border-width-focus) $components-color-accent;
 	}
 
 	&.is-active:focus {
-		box-shadow: inset 0 0 0 var(--wp-admin-border-width-focus) var(--wp-admin-theme-color), inset 0 -#{$border-width-tab * 2} 0 0 var(--wp-admin-theme-color);
+		box-shadow: inset 0 0 0 var(--wp-admin-border-width-focus) $components-color-accent, inset 0 -#{$border-width-tab * 2} 0 0 $components-color-accent;
 	}
 }

--- a/packages/components/src/toggle-group-control/test/__snapshots__/index.tsx.snap
+++ b/packages/components/src/toggle-group-control/test/__snapshots__/index.tsx.snap
@@ -66,8 +66,8 @@ exports[`ToggleGroupControl should render correctly with icons 1`] = `
 }
 
 .emotion-8:focus-within {
-  border-color: var( --wp-admin-theme-color-darker-10, #006ba1);
-  box-shadow: 0 0 0 0.5px var( --wp-admin-theme-color, #007cba);
+  border-color: var(--wp-components-color-accent-darker-10, var(--wp-admin-theme-color-darker-10, #006ba1));
+  box-shadow: 0 0 0 0.5px var(--wp-components-color-accent, var(--wp-admin-theme-color, #007cba));
   outline: none;
   z-index: 1;
 }
@@ -402,8 +402,8 @@ exports[`ToggleGroupControl should render correctly with text options 1`] = `
 }
 
 .emotion-8:focus-within {
-  border-color: var( --wp-admin-theme-color-darker-10, #006ba1);
-  box-shadow: 0 0 0 0.5px var( --wp-admin-theme-color, #007cba);
+  border-color: var(--wp-components-color-accent-darker-10, var(--wp-admin-theme-color-darker-10, #006ba1));
+  box-shadow: 0 0 0 0.5px var(--wp-components-color-accent, var(--wp-admin-theme-color, #007cba));
   outline: none;
   z-index: 1;
 }

--- a/packages/components/src/tools-panel/styles.ts
+++ b/packages/components/src/tools-panel/styles.ts
@@ -148,7 +148,7 @@ export const DropdownMenu = css`
 `;
 
 export const ResetLabel = styled.span`
-	color: ${ COLORS.ui.borderFocus };
+	color: ${ COLORS.ui.themeDark10 };
 	font-size: 11px;
 	font-weight: 500;
 	line-height: 1.4;

--- a/packages/components/src/tools-panel/styles.ts
+++ b/packages/components/src/tools-panel/styles.ts
@@ -148,7 +148,7 @@ export const DropdownMenu = css`
 `;
 
 export const ResetLabel = styled.span`
-	color: var( --wp-admin-theme-color-darker-10 );
+	color: ${ COLORS.ui.borderFocus };
 	font-size: 11px;
 	font-weight: 500;
 	line-height: 1.4;

--- a/packages/components/src/utils/colors-values.js
+++ b/packages/components/src/utils/colors-values.js
@@ -38,6 +38,7 @@ const ADMIN = {
 
 const UI = {
 	theme: ADMIN.theme,
+	themeDark10: ADMIN.themeDark10,
 	background: white,
 	backgroundDisabled: GRAY[ 100 ],
 	border: GRAY[ 700 ],

--- a/packages/components/src/utils/colors-values.js
+++ b/packages/components/src/utils/colors-values.js
@@ -31,8 +31,9 @@ const ALERT = {
 
 // Matches @wordpress/base-styles
 const ADMIN = {
-	theme: 'var( --wp-admin-theme-color, #007cba)',
-	themeDark10: 'var( --wp-admin-theme-color-darker-10, #006ba1)',
+	theme: 'var(--wp-components-color-accent, var(--wp-admin-theme-color, #007cba))',
+	themeDark10:
+		'var(--wp-components-color-accent-darker-10, var(--wp-admin-theme-color-darker-10, #006ba1))',
 };
 
 const UI = {

--- a/packages/components/src/utils/input/base.js
+++ b/packages/components/src/utils/input/base.js
@@ -19,10 +19,10 @@ export const inputStyleNeutral = css`
 `;
 
 export const inputStyleFocus = css`
-	border-color: var( --wp-admin-theme-color );
+	border-color: ${ COLORS.ui.theme };
 	box-shadow: 0 0 0
 		calc( ${ CONFIG.borderWidthFocus } - ${ CONFIG.borderWidth } )
-		var( --wp-admin-theme-color );
+		${ COLORS.ui.theme };
 
 	// Windows High Contrast mode will show this outline, but not the box-shadow.
 	outline: 2px solid transparent;

--- a/packages/edit-post/src/components/preferences-modal/test/__snapshots__/index.js.snap
+++ b/packages/edit-post/src/components/preferences-modal/test/__snapshots__/index.js.snap
@@ -580,13 +580,13 @@ exports[`EditPostPreferencesModal should match snapshot when the modal is active
 }
 
 .emotion-13:hover {
-  color: var( --wp-admin-theme-color, #007cba);
+  color: var(--wp-components-color-accent, var(--wp-admin-theme-color, #007cba));
 }
 
 .emotion-13:focus {
   background-color: transparent;
-  color: var( --wp-admin-theme-color, #007cba);
-  border-color: var( --wp-admin-theme-color, #007cba);
+  color: var(--wp-components-color-accent, var(--wp-admin-theme-color, #007cba));
+  border-color: var(--wp-components-color-accent, var(--wp-admin-theme-color, #007cba));
   outline: 3px solid transparent;
 }
 

--- a/packages/editor/src/components/post-publish-panel/test/__snapshots__/index.js.snap
+++ b/packages/editor/src/components/post-publish-panel/test/__snapshots__/index.js.snap
@@ -609,7 +609,7 @@ exports[`PostPublishPanel should render the spinner if the post is being saved 1
   display: inline-block;
   margin: 5px 11px 0;
   position: relative;
-  color: var( --wp-admin-theme-color );
+  color: var(--wp-components-color-accent, var(--wp-admin-theme-color, #007cba))
   overflow: visible;
 }
 

--- a/packages/editor/src/components/post-publish-panel/test/__snapshots__/index.js.snap
+++ b/packages/editor/src/components/post-publish-panel/test/__snapshots__/index.js.snap
@@ -609,7 +609,7 @@ exports[`PostPublishPanel should render the spinner if the post is being saved 1
   display: inline-block;
   margin: 5px 11px 0;
   position: relative;
-  color: var(--wp-components-color-accent, var(--wp-admin-theme-color, #007cba))
+  color: var(--wp-components-color-accent, var(--wp-admin-theme-color, #007cba));
   overflow: visible;
 }
 


### PR DESCRIPTION
closes #45249
part of #44116

## What?
Updates the Components package to use the new accent color variables in all relevant components.

## Why
Because colors look nice.

## How? 
First updating the emotion variables to use the new component theme var, with the proper fallbacks.

Then updating any references to the existing WP theme variables to instead point to the new [component theme variables](https://github.com/WordPress/gutenberg/blob/trunk/packages/components/src/utils/theme-variables.scss) in individual component styles.

**TODO List**
- [x] Update emotion variables
- [x] AnglePickerControl
- [x] Autocomplete
- [x] useBaseField hook
- [x] CheckBoxControl
- [x] ColorPalette
- [x] DropZone
- [x] FormToggle
- [x] FormTokenField
- [x] useNavigateRegions
- [x] MenuItem
- [x] Notice
- [x] Panel
- [x] RangeControl
- [x] ResizableBox
- [x] SearchControl
- [x] Snackbox
- [x] Spinner
- [x] TabPanel
- [x] ToggleGroupControl
- [x] ToolsPanel
- [x] Input (variable is in `utils/input/base.js`)

For each of the above, we'll need to:
- update the variables
- test the default and theme colors in Storybook
- test the default an theme colors in the editor:
  - run GB locally and load the editor to a state that will render the desired component
  - modify the desired component by wrapping its render value in a `<Theme>` component
  - pass the `Theme` component different `accent` props to test the color change

## Testing Instructions
- Launch Storybook locally
- Play with as many components as you can/want
- If applicable, confirm that the default color displays as expected.
- If applicable, test interactions (like hovering) to ensure the darker color variants are working
- If applicable, use the paintbrush decorator icon in the top toolbar to test different themes. Confirm the accent color changes when a new theme is selected. 

## Additional Notes

Some things that came up, but don't necessarily fit in this PR. Some of these are mentioned in comments below, but I wanted to gather them in a single location:

- [Outline visible](https://github.com/WordPress/gutenberg/pull/45289#issuecomment-1291819631) while rotating the `AngleCircle` of `AnglePickerControl`. This outline is immune to theming, but we should be able to fix that easily. Question is do we want that outline showing? Or do we want to hide it?
- Certain colors [could potentially cause some confusion with `Notice` styling](https://github.com/WordPress/gutenberg/pull/45289#pullrequestreview-1157189100). We may need to update `Notice's` Readme.
- There are several places where [styles from the `base-styles` package need to be overridden for theming to take effect](https://github.com/WordPress/gutenberg/pull/45289#discussion_r1005976003). On this PR, all such overrides are commented and separated into their own commits in case we decide not to override them.
- `COLORS.ui.borderFocused` is mapped to the `darker-10` color variant and as of this PR, our new `$components-color-accent-darker-10` variable. That `borderFocused` property [isn't used exclusively for borders though](https://github.com/WordPress/gutenberg/pull/45289/files/6f0d8ee3715bb1ce68ace024252ef0c6e6f77204#diff-b9d2f04e5531eddd009a262929fd75fa8cf52cd4a1b98a42a29fa9a863ac8ba5). Should it be renamed?
- the `Inserter` (a `block-library` component) has SVGs icons for the various blocks that do not respect our theming. I don't think a simple CSS override will do here? 🤔 
- `block-editor`'s `URLPopover`, `TextDecorationControl`, and `TextTransformControl` don't currently respect theming. We can probably override those styles without too much trouble, but I didn't want to hold this PR up while I dove down that rabbit hole. If desired, I can happily work to add those changes here 🙂 