### PR TITLE
ColorPalette: Fix transparent checkered background pattern 

### DIFF
--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -20,6 +20,7 @@
 -   `ToggleControl`: Improved types for the `help` prop, covering the dynamic render function option, and enabled the dynamic `help` behavior only for a controlled component ([#45279](https://github.com/WordPress/gutenberg/pull/45279)).
 -   `BorderControl` & `BorderBoxControl`: Replace `__next36pxDefaultSize` with "default" and "large" size variants ([#41860](https://github.com/WordPress/gutenberg/pull/41860)).
 -   `UnitControl`: Remove outer wrapper to normalize className placement ([#41860](https://github.com/WordPress/gutenberg/pull/41860)).
+-   `ColorPalette`: Fix transparent checkered background pattern ([#45295](https://github.com/WordPress/gutenberg/pull/45295)).
 
 ### Bug Fix
 

--- a/packages/components/src/color-palette/style.scss
+++ b/packages/components/src/color-palette/style.scss
@@ -14,9 +14,9 @@
 	background-image:
 		repeating-linear-gradient(45deg, $gray-200 25%, transparent 25%, transparent 75%, $gray-200 75%, $gray-200),
 		repeating-linear-gradient(45deg, $gray-200 25%, transparent 25%, transparent 75%, $gray-200 75%, $gray-200);
-	background-position: 0 0, 25px 25px;
+	background-position: 0 0, 24px 24px;
 	/*rtl:end:ignore*/
-	background-size: calc(2 * 25px) calc(2 * 25px);
+	background-size: calc(2 * 24px) calc(2 * 24px);
 	box-sizing: border-box;
 	color: $white;
 	cursor: pointer;


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Update the `ColorPalette` component's transparent checkered background pattern, so it doesn't become slightly cut off on the right side as outlined in this issue: #42687 

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

For a more visually appealing look. 

One thing to note is in Storybook, the background is `248px` wide when set to the WP Sidebar max-width. In the editor, it's `228px` wide, so the look is slightly different the checkered pattern is still cut off but in a less awkward way. 

If we don't want anything cut off, we could change the pattern to `19px` and set the height from `64px` to `57px`. For one example, so visually, it doesn't change too much. 

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

By changing the background size and positioning to `24px` instead of `25px`, as suggested by @mirka in the issue mentioned above (#42687).

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->

1. Add a block that has color options (i.e. button block, paragraph block) to the editor in a page or post 
2. Click on 'Background', 'Text', 'Link', or whichever color options are available in the block sidebar
3. See the transparent background with the checkered pattern that isn't as cut off on the right side as the 'before' screenshot below  

## Screenshots or screencast <!-- if applicable -->

**Before:**
<img width="277" alt="Screen Shot 2022-10-25 at 6 12 47 PM" src="https://user-images.githubusercontent.com/35543432/197911512-ca9aae59-cee6-4dbb-851a-310dfb16639a.png">

**After:** 
<img width="276" alt="Screen Shot 2022-10-25 at 6 36 19 PM" src="https://user-images.githubusercontent.com/35543432/197914022-80756839-20f5-4fe4-85df-80ad777806d7.png">

