### PR TITLE
Try getting Post Content layout on server before editor loads

### DIFF
--- a/lib/compat/wordpress-6.1/block-editor-settings.php
+++ b/lib/compat/wordpress-6.1/block-editor-settings.php
@@ -14,21 +14,69 @@
  */
 function gutenberg_get_block_editor_settings( $settings ) {
 	global $post_id;
-	$template_slug    = get_page_template_slug( $post_id );
+
+	$template_slug = get_page_template_slug( $post_id );
+
+	if ( ! $template_slug ) {
+		$post_slug      = 'singular';
+		$page_slug      = 'singular';
+		$template_types = get_block_templates();
+
+		foreach ( $template_types as $template_type ) {
+			if ( 'page' === $template_type->slug ) {
+				$page_slug = 'page';
+			}
+			if ( 'single' === $template_type->slug ) {
+				$post_slug = 'single';
+			}
+		}
+
+		$what_post_type = get_post_type( $post_id );
+		switch ( $what_post_type ) {
+			case 'post':
+				$template_slug = $post_slug;
+				break;
+			case 'page':
+				$template_slug = $page_slug;
+				break;
+		}
+	}
+
 	$current_template = gutenberg_get_block_templates( array( 'slug__in' => array( $template_slug ) ) );
+
+	/**
+	 * Finds Post Content in an array of blocks
+	 *
+	 * @param array $blocks Array of blocks.
+	 *
+	 * @return array Post Content block.
+	 */
+	function get_post_content_block( $blocks ) {
+		foreach ( $blocks as $block ) {
+			if ( 'core/post-content' === $block['blockName'] ) {
+				return $block;
+			}
+			if ( ! empty( $block['innerBlocks'] ) ) {
+				$post_content = get_post_content_block( $block['innerBlocks'] );
+
+				if ( ! empty( $post_content ) ) {
+					return $post_content;
+				}
+			}
+		}
+	}
 
 	if ( ! empty( $current_template ) ) {
 		$template_blocks    = parse_blocks( $current_template[0]->content );
-		$post_content_block = array();
+		$post_content_block = get_post_content_block( $template_blocks );
 
-		foreach ( $template_blocks as $template_block ) {
-			if ( 'core/post-content' === $template_block['blockName'] ) {
-				$post_content_block = $template_block;
+		if ( ! empty( $post_content_block ) ) {
+			// mismatched naming x(.
+			if ( empty( $post_content_block['attributes'] ) && ! empty( $post_content_block['attrs'] ) ) {
+				$post_content_block['attributes'] = $post_content_block['attrs'];
 			}
+			$settings['postContentBlock'] = $post_content_block;
 		}
-		// mismatched naming x(.
-		$post_content_block['attributes'] = $post_content_block['attrs'];
-		$settings['postContentBlock']     = $post_content_block;
 	}
 	// Set what is the context for this data request.
 	$context = 'other';
@@ -43,21 +91,21 @@ function gutenberg_get_block_editor_settings( $settings ) {
 
 	if ( 'other' === $context ) {
 		global $wp_version;
-		$is_wp_5_9 = version_compare( $wp_version, '5.9', '>=' ) && version_compare( $wp_version, '6.0-beta1', '<' );
-		$is_wp_6_0 = version_compare( $wp_version, '6.0-beta1', '>=' );
+		$is_wp_5_9 = version_compare( $wp_version, '5.9', ' >= ' ) && version_compare( $wp_version, '6.0 - beta1', ' < ' );
+		$is_wp_6_0 = version_compare( $wp_version, '6.0 - beta1', ' >= ' );
 
 		// Make sure the styles array exists.
-		// In some contexts, like the navigation editor, it doesn't.
+		// In some contexts, like the navigation editor, it doesn't .
 		if ( ! isset( $settings['styles'] ) ) {
 			$settings['styles'] = array();
 		}
 
-		// Remove existing global styles provided by core.
-		$styles_without_existing_global_styles = array();
+			// Remove existing global styles provided by core.
+			$styles_without_existing_global_styles = array();
 		foreach ( $settings['styles'] as $style ) {
 			if (
-				( $is_wp_5_9 && ! gutenberg_is_global_styles_in_5_9( $style ) ) || // Can be removed when plugin minimum version is 6.0.
-				( $is_wp_6_0 && ( ! isset( $style['isGlobalStyles'] ) || ! $style['isGlobalStyles'] ) )
+			( $is_wp_5_9 && ! gutenberg_is_global_styles_in_5_9( $style ) ) || // Can be removed when plugin minimum version is 6.0.
+			( $is_wp_6_0 && ( ! isset( $style['isGlobalStyles'] ) || ! $style['isGlobalStyles'] ) )
 			) {
 				$styles_without_existing_global_styles[] = $style;
 			}
@@ -91,26 +139,40 @@ function gutenberg_get_block_editor_settings( $settings ) {
 				'__unstableType' => 'theme',
 				'isGlobalStyles' => true,
 			);
-			$actual_css    = gutenberg_get_global_stylesheet( array( $block_classes['css'] ) );
-			if ( '' !== $actual_css ) {
-				$block_classes['css'] = $actual_css;
-				$new_global_styles[]  = $block_classes;
+			foreach ( $presets as $preset_style ) {
+				$actual_css = gutenberg_get_global_stylesheet( array( $preset_style['css'] ) );
+				if ( '' !== $actual_css ) {
+					$preset_style['css'] = $actual_css;
+					$new_global_styles[] = $preset_style;
+				}
 			}
-		} else {
-			// If there is no `theme.json` file, ensure base layout styles are still available.
-			$block_classes = array(
-				'css'            => 'base-layout-styles',
-				'__unstableType' => 'base-layout',
-				'isGlobalStyles' => true,
-			);
-			$actual_css    = gutenberg_get_global_stylesheet( array( $block_classes['css'] ) );
-			if ( '' !== $actual_css ) {
-				$block_classes['css'] = $actual_css;
-				$new_global_styles[]  = $block_classes;
-			}
-		}
 
-		$settings['styles'] = array_merge( $new_global_styles, $styles_without_existing_global_styles );
+			if ( WP_Theme_JSON_Resolver::theme_has_support() ) {
+				$block_classes = array(
+					'css'            => 'styles',
+					'__unstableType' => 'theme',
+					'isGlobalStyles' => true,
+				);
+				$actual_css    = gutenberg_get_global_stylesheet( array( $block_classes['css'] ) );
+				if ( '' !== $actual_css ) {
+					$block_classes['css'] = $actual_css;
+					$new_global_styles[]  = $block_classes;
+				}
+			} else {
+				// If there is no `theme.json` file, ensure base layout styles are still available.
+				$block_classes = array(
+					'css'            => 'base-layout-styles',
+					'__unstableType' => 'base-layout',
+					'isGlobalStyles' => true,
+				);
+				$actual_css    = gutenberg_get_global_stylesheet( array( $block_classes['css'] ) );
+				if ( '' !== $actual_css ) {
+					$block_classes['css'] = $actual_css;
+					$new_global_styles[]  = $block_classes;
+				}
+			}
+
+			$settings['styles'] = array_merge( $new_global_styles, $styles_without_existing_global_styles );
 	}
 
 	// Copied from get_block_editor_settings() at wordpress-develop/block-editor.php.

--- a/lib/compat/wordpress-6.1/block-editor-settings.php
+++ b/lib/compat/wordpress-6.1/block-editor-settings.php
@@ -13,6 +13,23 @@
  * @return array New block editor settings.
  */
 function gutenberg_get_block_editor_settings( $settings ) {
+	global $post_id;
+	$template_slug    = get_page_template_slug( $post_id );
+	$current_template = gutenberg_get_block_templates( array( 'slug__in' => array( $template_slug ) ) );
+
+	if ( ! empty( $current_template ) ) {
+		$template_blocks    = parse_blocks( $current_template[0]->content );
+		$post_content_block = array();
+
+		foreach ( $template_blocks as $template_block ) {
+			if ( 'core/post-content' === $template_block['blockName'] ) {
+				$post_content_block = $template_block;
+			}
+		}
+		// mismatched naming x(.
+		$post_content_block['attributes'] = $post_content_block['attrs'];
+		$settings['postContentBlock']     = $post_content_block;
+	}
 	// Set what is the context for this data request.
 	$context = 'other';
 	if (

--- a/lib/experimental/block-editor-settings.php
+++ b/lib/experimental/block-editor-settings.php
@@ -73,15 +73,12 @@ function gutenberg_get_block_editor_settings_experimental( $settings ) {
 	}
 
 	if ( ! empty( $current_template ) ) {
-		$template_blocks    = parse_blocks( $current_template[0]->content );
-		$post_content_block = get_post_content_block( $template_blocks );
+		$template_blocks         = parse_blocks( $current_template[0]->content );
+		$post_content_block      = get_post_content_block( $template_blocks );
+		$post_content_attributes = $post_content_block['attrs'];
 
-		if ( ! empty( $post_content_block ) ) {
-			// mismatched naming x(.
-			if ( empty( $post_content_block['attributes'] ) && ! empty( $post_content_block['attrs'] ) ) {
-				$post_content_block['attributes'] = $post_content_block['attrs'];
-			}
-			$settings['postContentBlock'] = $post_content_block;
+		if ( ! empty( $post_content_attributes ) ) {
+			$settings['postContentAttributes'] = $post_content_attributes;
 		}
 	}
 

--- a/lib/experimental/block-editor-settings.php
+++ b/lib/experimental/block-editor-settings.php
@@ -13,13 +13,13 @@
  * @return array New block editor settings.
  */
 function gutenberg_get_block_editor_settings_experimental( $settings ) {
-    $is_block_theme = wp_is_block_theme();
+	$is_block_theme = wp_is_block_theme();
 
-    if ( ! $is_block_theme ) {
-        return $settings;
-    }
+	if ( ! $is_block_theme ) {
+		return $settings;
+	}
 
-    global $post_id;
+	global $post_id;
 
 	$template_slug = get_page_template_slug( $post_id );
 
@@ -50,7 +50,7 @@ function gutenberg_get_block_editor_settings_experimental( $settings ) {
 
 	$current_template = gutenberg_get_block_templates( array( 'slug__in' => array( $template_slug ) ) );
 
-    /**
+	/**
 	 * Finds Post Content in an array of blocks
 	 *
 	 * @param array $blocks Array of blocks.
@@ -72,7 +72,7 @@ function gutenberg_get_block_editor_settings_experimental( $settings ) {
 		}
 	}
 
-    if ( ! empty( $current_template ) ) {
+	if ( ! empty( $current_template ) ) {
 		$template_blocks    = parse_blocks( $current_template[0]->content );
 		$post_content_block = get_post_content_block( $template_blocks );
 
@@ -84,8 +84,8 @@ function gutenberg_get_block_editor_settings_experimental( $settings ) {
 			$settings['postContentBlock'] = $post_content_block;
 		}
 	}
-    
-    return $settings;
+
+	return $settings;
 }
 
 add_filter( 'block_editor_settings_all', 'gutenberg_get_block_editor_settings_experimental', PHP_INT_MAX );

--- a/lib/experimental/block-editor-settings.php
+++ b/lib/experimental/block-editor-settings.php
@@ -15,11 +15,11 @@
 function gutenberg_get_block_editor_settings_experimental( $settings ) {
 	$is_block_theme = wp_is_block_theme();
 
-	if ( ! $is_block_theme ) {
+	global $post_id;
+
+	if ( ! $is_block_theme || ! $post_id ) {
 		return $settings;
 	}
-
-	global $post_id;
 
 	$template_slug = get_page_template_slug( $post_id );
 

--- a/lib/experimental/block-editor-settings.php
+++ b/lib/experimental/block-editor-settings.php
@@ -15,13 +15,13 @@
 function gutenberg_get_block_editor_settings_experimental( $settings ) {
 	$is_block_theme = wp_is_block_theme();
 
-	global $post_id;
+	global $post_ID;
 
-	if ( ! $is_block_theme || ! $post_id ) {
+	if ( ! $is_block_theme || ! $post_ID ) {
 		return $settings;
 	}
 
-	$template_slug = get_page_template_slug( $post_id );
+	$template_slug = get_page_template_slug( $post_ID );
 
 	if ( ! $template_slug ) {
 		$post_slug      = 'singular';
@@ -37,7 +37,7 @@ function gutenberg_get_block_editor_settings_experimental( $settings ) {
 			}
 		}
 
-		$what_post_type = get_post_type( $post_id );
+		$what_post_type = get_post_type( $post_ID );
 		switch ( $what_post_type ) {
 			case 'page':
 				$template_slug = $page_slug;

--- a/lib/experimental/block-editor-settings.php
+++ b/lib/experimental/block-editor-settings.php
@@ -73,12 +73,11 @@ function gutenberg_get_block_editor_settings_experimental( $settings ) {
 	}
 
 	if ( ! empty( $current_template ) ) {
-		$template_blocks         = parse_blocks( $current_template[0]->content );
-		$post_content_block      = get_post_content_block( $template_blocks );
-		$post_content_attributes = $post_content_block['attrs'];
+		$template_blocks    = parse_blocks( $current_template[0]->content );
+		$post_content_block = get_post_content_block( $template_blocks );
 
-		if ( ! empty( $post_content_attributes ) ) {
-			$settings['postContentAttributes'] = $post_content_attributes;
+		if ( ! empty( $post_content_block['attrs'] ) ) {
+			$settings['postContentAttributes'] = $post_content_block['attrs'];
 		}
 	}
 

--- a/lib/experimental/block-editor-settings.php
+++ b/lib/experimental/block-editor-settings.php
@@ -1,0 +1,91 @@
+<?php
+/**
+ * Adds settings to the block editor.
+ *
+ * @package gutenberg
+ */
+
+/**
+ * Adds styles and __experimentalFeatures to the block editor settings.
+ *
+ * @param array $settings Existing block editor settings.
+ *
+ * @return array New block editor settings.
+ */
+function gutenberg_get_block_editor_settings_experimental( $settings ) {
+    $is_block_theme = wp_is_block_theme();
+
+    if ( ! $is_block_theme ) {
+        return $settings;
+    }
+
+    global $post_id;
+
+	$template_slug = get_page_template_slug( $post_id );
+
+	if ( ! $template_slug ) {
+		$post_slug      = 'singular';
+		$page_slug      = 'singular';
+		$template_types = get_block_templates();
+
+		foreach ( $template_types as $template_type ) {
+			if ( 'page' === $template_type->slug ) {
+				$page_slug = 'page';
+			}
+			if ( 'single' === $template_type->slug ) {
+				$post_slug = 'single';
+			}
+		}
+
+		$what_post_type = get_post_type( $post_id );
+		switch ( $what_post_type ) {
+			case 'post':
+				$template_slug = $post_slug;
+				break;
+			case 'page':
+				$template_slug = $page_slug;
+				break;
+		}
+	}
+
+	$current_template = gutenberg_get_block_templates( array( 'slug__in' => array( $template_slug ) ) );
+
+    /**
+	 * Finds Post Content in an array of blocks
+	 *
+	 * @param array $blocks Array of blocks.
+	 *
+	 * @return array Post Content block.
+	 */
+	function get_post_content_block( $blocks ) {
+		foreach ( $blocks as $block ) {
+			if ( 'core/post-content' === $block['blockName'] ) {
+				return $block;
+			}
+			if ( ! empty( $block['innerBlocks'] ) ) {
+				$post_content = get_post_content_block( $block['innerBlocks'] );
+
+				if ( ! empty( $post_content ) ) {
+					return $post_content;
+				}
+			}
+		}
+	}
+
+    if ( ! empty( $current_template ) ) {
+		$template_blocks    = parse_blocks( $current_template[0]->content );
+		$post_content_block = get_post_content_block( $template_blocks );
+
+		if ( ! empty( $post_content_block ) ) {
+			// mismatched naming x(.
+			if ( empty( $post_content_block['attributes'] ) && ! empty( $post_content_block['attrs'] ) ) {
+				$post_content_block['attributes'] = $post_content_block['attrs'];
+			}
+			$settings['postContentBlock'] = $post_content_block;
+		}
+	}
+    
+    return $settings;
+}
+
+add_filter( 'block_editor_settings_all', 'gutenberg_get_block_editor_settings_experimental', PHP_INT_MAX );

--- a/lib/experimental/block-editor-settings.php
+++ b/lib/experimental/block-editor-settings.php
@@ -39,11 +39,11 @@ function gutenberg_get_block_editor_settings_experimental( $settings ) {
 
 		$what_post_type = get_post_type( $post_id );
 		switch ( $what_post_type ) {
-			case 'post':
-				$template_slug = $post_slug;
-				break;
 			case 'page':
 				$template_slug = $page_slug;
+				break;
+			default:
+				$template_slug = $post_slug;
 				break;
 		}
 	}

--- a/lib/load.php
+++ b/lib/load.php
@@ -106,6 +106,7 @@ require __DIR__ . '/compat/wordpress-6.3/html-api/class-gutenberg-html-tag-proce
 // Experimental features.
 remove_action( 'plugins_loaded', '_wp_theme_json_webfonts_handler' ); // Turns off WP 6.0's stopgap handler for Webfonts API.
 require __DIR__ . '/experimental/block-editor-settings-mobile.php';
+require __DIR__ . '/experimental/block-editor-settings.php';
 require __DIR__ . '/experimental/blocks.php';
 require __DIR__ . '/experimental/navigation-theme-opt-in.php';
 require __DIR__ . '/experimental/kses.php';

--- a/packages/block-editor/src/hooks/layout.js
+++ b/packages/block-editor/src/hooks/layout.js
@@ -35,18 +35,20 @@ const layoutBlockSupportKey = '__experimentalLayout';
 /**
  * Generates the utility classnames for the given block's layout attributes.
  *
- * @param { Object } layout    Layout object.
- * @param { string } blockName Block name.
+ * @param { Object } blockAttributes Block attributes.
+ * @param { string } blockName       Block name.
  *
  * @return { Array } Array of CSS classname strings.
  */
-export function useLayoutClasses( layout, blockName ) {
+export function useLayoutClasses( blockAttributes = {}, blockName ) {
 	const rootPaddingAlignment = useSelect( ( select ) => {
 		const { getSettings } = select( blockEditorStore );
 		return getSettings().__experimentalFeatures
 			?.useRootPaddingAwareAlignments;
 	}, [] );
 	const globalLayoutSettings = useSetting( 'layout' ) || {};
+
+	const { layout = {} } = blockAttributes;
 
 	const { default: defaultBlockLayout } =
 		getBlockSupport( blockName, layoutBlockSupportKey ) || {};
@@ -370,7 +372,7 @@ export const withLayoutStyles = createHigherOrderComponent(
 				? { ...layout, type: 'constrained' }
 				: layout || defaultBlockLayout || {};
 		const layoutClasses = hasLayoutBlockSupport
-			? useLayoutClasses( layout, name )
+			? useLayoutClasses( attributes, name )
 			: null;
 		// Higher specificity to override defaults from theme.json.
 		const selector = `.wp-container-${ id }.wp-container-${ id }`;

--- a/packages/block-editor/src/hooks/layout.js
+++ b/packages/block-editor/src/hooks/layout.js
@@ -35,11 +35,12 @@ const layoutBlockSupportKey = '__experimentalLayout';
 /**
  * Generates the utility classnames for the given block's layout attributes.
  *
- * @param { Object } block Block object.
+ * @param { Object } layout    Layout object.
+ * @param { string } blockName Block name.
  *
  * @return { Array } Array of CSS classname strings.
  */
-export function useLayoutClasses( block = {} ) {
+export function useLayoutClasses( layout, blockName ) {
 	const rootPaddingAlignment = useSelect( ( select ) => {
 		const { getSettings } = select( blockEditorStore );
 		return getSettings().__experimentalFeatures
@@ -47,11 +48,8 @@ export function useLayoutClasses( block = {} ) {
 	}, [] );
 	const globalLayoutSettings = useSetting( 'layout' ) || {};
 
-	const { attributes = {}, name } = block;
-	const { layout } = attributes;
-
 	const { default: defaultBlockLayout } =
-		getBlockSupport( name, layoutBlockSupportKey ) || {};
+		getBlockSupport( blockName, layoutBlockSupportKey ) || {};
 	const usedLayout =
 		layout?.inherit || layout?.contentSize || layout?.wideSize
 			? { ...layout, type: 'constrained' }
@@ -100,14 +98,14 @@ export function useLayoutClasses( block = {} ) {
 /**
  * Generates a CSS rule with the given block's layout styles.
  *
- * @param { Object } block    Block object.
- * @param { string } selector A selector to use in generating the CSS rule.
+ * @param { Object } blockAttributes Block attributes.
+ * @param { string } blockName       Block name.
+ * @param { string } selector        A selector to use in generating the CSS rule.
  *
  * @return { string } CSS rule.
  */
-export function useLayoutStyles( block = {}, selector ) {
-	const { attributes = {}, name } = block;
-	const { layout = {}, style = {} } = attributes;
+export function useLayoutStyles( blockAttributes, blockName, selector ) {
+	const { layout = {}, style = {} } = blockAttributes;
 	// Update type for blocks using legacy layouts.
 	const usedLayout =
 		layout?.inherit || layout?.contentSize || layout?.wideSize
@@ -118,7 +116,7 @@ export function useLayoutStyles( block = {}, selector ) {
 	const blockGapSupport = useSetting( 'spacing.blockGap' );
 	const hasBlockGapSupport = blockGapSupport !== null;
 	const css = fullLayoutType?.getLayoutStyle?.( {
-		blockName: name,
+		blockName,
 		selector,
 		layout,
 		layoutDefinitions: globalLayoutSettings?.definitions,
@@ -350,7 +348,7 @@ export const withInspectorControls = createHigherOrderComponent(
  */
 export const withLayoutStyles = createHigherOrderComponent(
 	( BlockListBlock ) => ( props ) => {
-		const { name, attributes, block } = props;
+		const { name, attributes } = props;
 		const hasLayoutBlockSupport = hasBlockSupport(
 			name,
 			layoutBlockSupportKey
@@ -372,7 +370,7 @@ export const withLayoutStyles = createHigherOrderComponent(
 				? { ...layout, type: 'constrained' }
 				: layout || defaultBlockLayout || {};
 		const layoutClasses = hasLayoutBlockSupport
-			? useLayoutClasses( block )
+			? useLayoutClasses( layout, name )
 			: null;
 		// Higher specificity to override defaults from theme.json.
 		const selector = `.wp-container-${ id }.wp-container-${ id }`;

--- a/packages/block-editor/src/hooks/layout.js
+++ b/packages/block-editor/src/hooks/layout.js
@@ -48,7 +48,7 @@ export function useLayoutClasses( blockAttributes = {}, blockName ) {
 	}, [] );
 	const globalLayoutSettings = useSetting( 'layout' ) || {};
 
-	const { layout = {} } = blockAttributes;
+	const { layout } = blockAttributes;
 
 	const { default: defaultBlockLayout } =
 		getBlockSupport( blockName, layoutBlockSupportKey ) || {};

--- a/packages/block-editor/src/hooks/layout.js
+++ b/packages/block-editor/src/hooks/layout.js
@@ -104,7 +104,7 @@ export function useLayoutClasses( layout, blockName ) {
  *
  * @return { string } CSS rule.
  */
-export function useLayoutStyles( blockAttributes, blockName, selector ) {
+export function useLayoutStyles( blockAttributes = {}, blockName, selector ) {
 	const { layout = {}, style = {} } = blockAttributes;
 	// Update type for blocks using legacy layouts.
 	const usedLayout =

--- a/packages/edit-post/src/components/visual-editor/index.js
+++ b/packages/edit-post/src/components/visual-editor/index.js
@@ -81,7 +81,7 @@ export default function VisualEditor( { styles } ) {
 		deviceType,
 		isWelcomeGuideVisible,
 		isTemplateMode,
-		postContentBlock,
+		postContentAttributes,
 		wrapperBlockName,
 		wrapperUniqueId,
 		isBlockBasedTheme,
@@ -108,7 +108,7 @@ export default function VisualEditor( { styles } ) {
 			deviceType: __experimentalGetPreviewDeviceType(),
 			isWelcomeGuideVisible: isFeatureActive( 'welcomeGuide' ),
 			isTemplateMode: _isTemplateMode,
-			postContentBlock: getEditorSettings().postContentBlock,
+			postContentAttributes: getEditorSettings().postContentAttributes,
 			wrapperBlockName: _wrapperBlockName,
 			wrapperUniqueId: getCurrentPostId(),
 			isBlockBasedTheme: editorSettings.__unstableIsBlockBasedTheme,
@@ -192,7 +192,12 @@ export default function VisualEditor( { styles } ) {
 		return { type: 'default' };
 	}, [ isTemplateMode, themeSupportsLayout, globalLayoutSettings ] );
 
-	const postContentLayoutClasses = useLayoutClasses( postContentBlock );
+	const layout = postContentAttributes?.layout || {};
+
+	const postContentLayoutClasses = useLayoutClasses(
+		layout,
+		'core/post-content'
+	);
 
 	const blockListLayoutClass = classnames(
 		{
@@ -202,11 +207,10 @@ export default function VisualEditor( { styles } ) {
 	);
 
 	const postContentLayoutStyles = useLayoutStyles(
-		postContentBlock,
+		postContentAttributes,
+		'core/post-content',
 		'.block-editor-block-list__layout.is-root-container'
 	);
-
-	const layout = postContentBlock?.attributes?.layout || {};
 
 	// Update type for blocks using legacy layouts.
 	const postContentLayout = useMemo( () => {
@@ -227,7 +231,7 @@ export default function VisualEditor( { styles } ) {
 
 	// If there is a Post Content block we use its layout for the block list;
 	// if not, this must be a classic theme, in which case we use the fallback layout.
-	const blockListLayout = postContentBlock?.isValid
+	const blockListLayout = postContentAttributes
 		? postContentLayout
 		: fallbackLayout;
 

--- a/packages/edit-post/src/components/visual-editor/index.js
+++ b/packages/edit-post/src/components/visual-editor/index.js
@@ -144,6 +144,8 @@ export default function VisualEditor( { styles } ) {
 			isWelcomeGuideVisible: isFeatureActive( 'welcomeGuide' ),
 			isTemplateMode: _isTemplateMode,
 			postContentAttributes: getEditorSettings().postContentAttributes,
+			// Post template fetch returns a 404 on classic themes, which
+			// messes with e2e tests, so check it's a block theme first.
 			editedPostTemplate:
 				supportsTemplateMode && canEditTemplate
 					? getEditedPostTemplate()

--- a/packages/edit-post/src/components/visual-editor/index.js
+++ b/packages/edit-post/src/components/visual-editor/index.js
@@ -256,7 +256,7 @@ export default function VisualEditor( { styles } ) {
 	const layout = newestPostContentAttributes?.layout || {};
 
 	const postContentLayoutClasses = useLayoutClasses(
-		layout,
+		newestPostContentAttributes,
 		'core/post-content'
 	);
 

--- a/packages/edit-post/src/components/visual-editor/index.js
+++ b/packages/edit-post/src/components/visual-editor/index.js
@@ -285,7 +285,6 @@ export default function VisualEditor( { styles } ) {
 			? { ...globalLayoutSettings, ...layout, type: 'constrained' }
 			: { ...globalLayoutSettings, ...layout, type: 'default' };
 	}, [
-		layout,
 		layout?.type,
 		layout?.inherit,
 		layout?.contentSize,

--- a/packages/editor/src/components/provider/use-block-editor-settings.js
+++ b/packages/editor/src/components/provider/use-block-editor-settings.js
@@ -62,6 +62,7 @@ const BLOCK_EDITOR_SETTINGS = [
 	'locale',
 	'maxWidth',
 	'onUpdateDefaultBlockStyles',
+	'postContentAttributes',
 	'postsPerPage',
 	'readOnly',
 	'styles',


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

Following up from [this conversation](https://github.com/WordPress/gutenberg/pull/44258#discussion_r1003820366) as well as issue raised in #45262.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

Adds the Post Content block from the template used in the post to the block editor settings, where it can be accessed by the visual editor on first render; this eliminates the flash of unstyled layout on editor load.

TODO:

When Post Content is changed in the template editor, changes should be reflected immediately on returning to the post editor. We might need to keep some of the logic from the current iteration around in order to do that 🤔 


## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->

1. Configure some custom layout settings for the Post Content block used in the post template;
2. Load the post editor with a post that uses that template;
3. Observe that layout styles are immediately applied to content.

## Screenshots or screencast <!-- if applicable -->
