### PR TITLE
useAnchorRef: update deprecation message

### DIFF
--- a/packages/rich-text/CHANGELOG.md
+++ b/packages/rich-text/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Deprecations
+
+-   Update deprecation message for the `useAnchorRef` hook ([#45195](https://github.com/WordPress/gutenberg/pull/45195)).
+
 ## 5.18.0 (2022-10-19)
 
 ## 5.17.0 (2022-10-05)

--- a/packages/rich-text/src/component/use-anchor-ref.js
+++ b/packages/rich-text/src/component/use-anchor-ref.js
@@ -30,7 +30,6 @@ import { getActiveFormat } from '../get-active-format';
 export function useAnchorRef( { ref, value, settings = {} } ) {
 	deprecated( '`useAnchorRef` hook', {
 		since: '6.1',
-		version: '6.3',
 		alternative: '`useAnchor` hook',
 	} );
 


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Following the conversation in #45195, update the deprecation message for the `useAnchorRef` — the hook _will not_ be deleted as of WordPress 6.3.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

To better adhere to the deprecation policies of the WordPress project. See the conversation in #45195 for more details.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

Update changelog and remove 6.3 version from the deprecation warning.

## ✍️ Dev Note 

As also written in an update to the previous ["Editor Components updates in WordPress 6.1" post](https://make.wordpress.org/core/2022/10/10/editor-components-updates-for-wordpress-6-1/), the deprecated `useAnchorRef` hook from the `@wordpress/rich-text` package will not be deleted in WordPress 6.3, as initially planned.