### PR TITLE
[WIP] Sidebar: Allow individual blocks to define default tab

### DIFF
--- a/packages/block-editor/src/components/inspector-controls-tabs/index.js
+++ b/packages/block-editor/src/components/inspector-controls-tabs/index.js
@@ -1,7 +1,7 @@
 /**
  * WordPress dependencies
  */
-import { hasBlockSupport } from '@wordpress/blocks';
+import { getBlockType, hasBlockSupport } from '@wordpress/blocks';
 import {
 	PanelBody,
 	TabPanel,
@@ -115,11 +115,15 @@ export default function InspectorControlsTabs( {
 		}
 	}
 
+	const blockType = getBlockType( blockName );
+
 	// We have multiple tabs with contents so render complete TabPanel.
 	return (
 		<TabPanel
 			className="block-editor-block-inspector__tabs"
 			tabs={ availableTabs }
+			initialTabName={ blockType.defaultTab }
+			key={ clientId }
 		>
 			{ ( tab ) => {
 				if ( tab.name === TAB_MENU.name ) {

--- a/packages/block-library/src/navigation/index.js
+++ b/packages/block-library/src/navigation/index.js
@@ -50,6 +50,7 @@ export const settings = {
 	edit,
 	save,
 	deprecated,
+	defaultTab: 'menu',
 };
 
 export const init = () => initBlock( { name, metadata, settings } );

--- a/packages/block-library/src/paragraph/index.js
+++ b/packages/block-library/src/paragraph/index.js
@@ -55,6 +55,7 @@ export const settings = {
 	},
 	edit,
 	save,
+	defaultTab: 'appearance',
 };
 
 export const init = () => initBlock( { name, metadata, settings } );

--- a/packages/block-library/src/query/index.js
+++ b/packages/block-library/src/query/index.js
@@ -24,6 +24,7 @@ export const settings = {
 	save,
 	variations,
 	deprecated,
+	defaultTab: 'settings',
 };
 
 export const init = () => {


### PR DESCRIPTION
Depends on: 
- https://github.com/WordPress/gutenberg/pull/45005

## What?

This PR will explore allowing individual blocks to set their preferred default tab in the sidebar. For example;
- Navigation --> Menu tab
- Query --> Settings tab
- Paragraph --> Appearance tab

## Why?

The most frequently needed or used controls by users will differ by block. Allowing for block-specific default tabs may help streamline access and discovery of tools in the block inspector sidebar.

## How?

- Updates the block inspector's tab panel to use a `defaultTab` property from the current block type.
- Current approach simply allows the new property to be passed through the additional settings that get merged with block.json metadata when blocks are registered on the JS side.

### Possible Issues
To make the TabPanel update/switch to a newly selected block type's default tab, the TabPanel has it's `key` set to the current `clientId`. It will be worth investigating if this might cause any accessibility issues such as focus loss. We might be safe on that front though as the `clientId` change would happen when focus is already being moved due to selecting a different block.A

### Alternative Approaches

- Update core's block registration from block.json metadata to allow a `defaultTab` property. 
- Set up a context provider for the block inspector's sidebar tabs allowing blocks to define their default tab through that.

## Testing Instructions
1. Enable the Block Inspector Tabs experiment via the Gutenberg Experiments admin page
2. Switch to the editor and add navigation, query, and paragraph blocks
3. Select the Navigation block and it should default to the "menu" tab
4. Select the Query block and it should default to the "settings" tab
5. Select the paragraph block and it should default to the "appearance" tab
6. Switch block selections around and ensure the tabs switch to the default tab appropriately

## Screenshots or screencast <!-- if applicable -->

https://user-images.githubusercontent.com/60436221/197987851-ecb04bfd-cf7b-4fd7-afc6-152abfbad205.mp4

**Note: The "Create a new post" link under the Query block tabs is a known issue and will be address separately.**