### PR TITLE
Lodash: Refactor `@wordpress/keycodes` away from `_.includes()`

### DIFF
--- a/packages/keycodes/src/index.js
+++ b/packages/keycodes/src/index.js
@@ -13,7 +13,7 @@
  * External dependencies
  */
 import { capitalCase } from 'change-case';
-import { get, mapValues, includes } from 'lodash';
+import { get, mapValues } from 'lodash';
 
 /**
  * WordPress dependencies
@@ -365,7 +365,7 @@ export const isKeyboardEvent = mapValues( modifiers, ( getModifiers ) => {
 		let key = event.key.toLowerCase();
 
 		if ( ! character ) {
-			return includes( mods, key );
+			return mods.includes( /** @type {WPModifierPart} */ ( key ) );
 		}
 
 		if ( event.altKey && character.length === 1 ) {

--- a/packages/keycodes/src/platform.js
+++ b/packages/keycodes/src/platform.js
@@ -1,9 +1,4 @@
 /**
- * External dependencies
- */
-import { includes } from 'lodash';
-
-/**
  * Return true if platform is MacOS.
  *
  * @param {Window?} _window window object by default; used for DI testing.
@@ -23,6 +18,6 @@ export function isAppleOS( _window = null ) {
 
 	return (
 		platform.indexOf( 'Mac' ) !== -1 ||
-		includes( [ 'iPad', 'iPhone' ], platform )
+		[ 'iPad', 'iPhone' ].includes( platform )
 	);
 }


### PR DESCRIPTION
## What?
This PR removes Lodash's `_.includes()` from the keycodes package. There are just a few usages and conversion is pretty straightforward. 

## Why?

Lodash is known to unnecessarily inflate the bundle size of packages, and in most cases, it can be replaced with native language functionality. See these for more information and rationale:

* https://github.com/WordPress/gutenberg/issues/16938#issuecomment-602837246
* https://github.com/WordPress/gutenberg/issues/17025
* https://github.com/WordPress/gutenberg/issues/39495 

## How?

We're replacing a few usages with a simple native `Array.prototype.includes()`. 

## Testing Instructions

* Verify that undoing in a classic editor block works like before.
* Verify all checks are green and tests pass.