### PR TITLE
Add a readme to the letter spacing component

### DIFF
--- a/packages/block-editor/src/components/letter-spacing-control/README.md
+++ b/packages/block-editor/src/components/letter-spacing-control/README.md
@@ -20,11 +20,11 @@ Renders a letter spacing control.
 import { LetterSpacingControl } from '@wordpress/block-editor';
 
 const MyLetterSpacingControl = () => (
-		<LetterSpacingControl
-			value={ value }
-			onChange={ onChange }
-			__unstableInputWidth="auto"
-		/>
+	<LetterSpacingControl
+		value={ value }
+		onChange={ onChange }
+		__unstableInputWidth="auto"
+	/>
 );
 ```
 

--- a/packages/block-editor/src/components/letter-spacing-control/README.md
+++ b/packages/block-editor/src/components/letter-spacing-control/README.md
@@ -1,0 +1,55 @@
+# Letter spacing control
+
+The `LetterSpacingControl` component renders a [`UnitControl`](https://github.com/WordPress/gutenberg/blob/trunk/packages/block-editor/src/components/unit-control/README.md) that lets the user enter a numeric value and select a unit, for example px or rem.
+
+This component is used for blocks that display text, commonly inside a 
+[`ToolsPanelItem`](https://github.com/WordPress/gutenberg/blob/trunk/packages/components/src/tools-panel/tools-panel-item/README.md).
+
+## Table of contents
+
+1. [Development guidelines](#development-guidelines)
+2. [Related components](#related-components)
+
+## Development guidelines
+
+### Usage
+
+Renders a letter spacing control.
+
+```jsx
+import { LetterSpacingControl } from '@wordpress/block-editor';
+
+const MyLetterSpacingControl = () => (
+		<LetterSpacingControl
+			value={ value }
+			onChange={ onChange }
+			__unstableInputWidth="auto"
+		/>
+);
+```
+
+### Props
+
+### `value`
+
+-   **Type:** `String`
+-   **Default:** `undefined`
+
+The current value of the letter spacing setting.
+
+### `onChange`
+
+-   **Type:** `Function`
+
+A callback function invoked when the value is changed.
+
+### `_unstableInputWidth`
+
+-   **Type:** `string|number|undefined`
+-   **Default:** `undefined`
+
+Input width to pass through to inner UnitControl. Should be a valid CSS value.
+
+## Related components
+
+Block Editor components are components that can be used to compose the UI of your block editor. Thus, they can only be used under a [`BlockEditorProvider`](https://github.com/WordPress/gutenberg/blob/HEAD/packages/block-editor/src/components/provider/README.md) in the components tree.


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->
Adds a README.md with a description and list of props to the letter spacing component.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
Documentation was missing.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->

## Screenshots or screencast <!-- if applicable -->
