### PR TITLE
Lodash: Refactor `@wordpress/blocks` away from `_.includes()`

### DIFF
--- a/packages/blocks/src/api/validation/index.js
+++ b/packages/blocks/src/api/validation/index.js
@@ -2,7 +2,7 @@
  * External dependencies
  */
 import { Tokenizer } from 'simple-html-tokenizer';
-import { isEqual, includes } from 'lodash';
+import { isEqual } from 'lodash';
 
 /**
  * WordPress dependencies
@@ -289,7 +289,7 @@ export function getMeaningfulAttributePairs( token ) {
 		return (
 			value ||
 			key.indexOf( 'data-' ) === 0 ||
-			includes( MEANINGFUL_ATTRIBUTES, key )
+			MEANINGFUL_ATTRIBUTES.includes( key )
 		);
 	} );
 }

--- a/packages/blocks/src/store/selectors.js
+++ b/packages/blocks/src/store/selectors.js
@@ -3,7 +3,7 @@
  */
 import createSelector from 'rememo';
 import removeAccents from 'remove-accents';
-import { filter, get, includes, map, some } from 'lodash';
+import { filter, get, map, some } from 'lodash';
 
 /**
  * WordPress dependencies
@@ -555,7 +555,7 @@ export const getChildBlockNames = createSelector(
 	( state, blockName ) => {
 		return map(
 			filter( state.blockTypes, ( blockType ) => {
-				return includes( blockType.parent, blockName );
+				return blockType.parent?.includes( blockName );
 			} ),
 			( { name } ) => name
 		);
@@ -710,7 +710,7 @@ export function isMatchingSearchTerm( state, nameOrType, searchTerm ) {
 	const isSearchMatch = pipe( [
 		getNormalizedSearchTerm,
 		( normalizedCandidate ) =>
-			includes( normalizedCandidate, normalizedSearchTerm ),
+			normalizedCandidate.includes( normalizedSearchTerm ),
 	] );
 
 	return (


### PR DESCRIPTION
## What?
This PR removes Lodash's `_.includes()` from the blocks package. There are just a few usages and conversion is pretty straightforward. 

## Why?

Lodash is known to unnecessarily inflate the bundle size of packages, and in most cases, it can be replaced with native language functionality. See these for more information and rationale:

* https://github.com/WordPress/gutenberg/issues/16938#issuecomment-602837246
* https://github.com/WordPress/gutenberg/issues/17025
* https://github.com/WordPress/gutenberg/issues/39495 

## How?

We're replacing a few usages with a simple native `Array.prototype.includes()` / `String.prototype.includes()`. 

## Testing Instructions

* Smoke test the post editor and site editor.
* Verify all checks are green and tests pass - the changes are well covered by tests.