### PR TITLE
Lodash: Refactor away from `_.includes()`

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -114,6 +114,7 @@ module.exports = {
 							'fromPairs',
 							'has',
 							'identity',
+							'includes',
 							'invoke',
 							'isArray',
 							'isBoolean',

--- a/packages/editor/src/components/post-format/index.js
+++ b/packages/editor/src/components/post-format/index.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { find, includes } from 'lodash';
+import { find } from 'lodash';
 
 /**
  * WordPress dependencies
@@ -66,7 +66,7 @@ export default function PostFormat() {
 		// Ensure current format is always in the set.
 		// The current format may not be a format supported by the theme.
 		return (
-			includes( supportedFormats, format.id ) || postFormat === format.id
+			supportedFormats?.includes( format.id ) || postFormat === format.id
 		);
 	} );
 	const suggestion = find(

--- a/packages/editor/src/components/post-publish-panel/maybe-post-format-panel.js
+++ b/packages/editor/src/components/post-publish-panel/maybe-post-format-panel.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { find, get, includes } from 'lodash';
+import { find, get } from 'lodash';
 
 /**
  * WordPress dependencies
@@ -19,7 +19,7 @@ import { store as editorStore } from '../../store';
 
 const getSuggestion = ( supportedFormats, suggestedPostFormat ) => {
 	const formats = POST_FORMATS.filter( ( format ) =>
-		includes( supportedFormats, format.id )
+		supportedFormats?.includes( format.id )
 	);
 	return find( formats, ( format ) => format.id === suggestedPostFormat );
 };

--- a/packages/editor/src/components/post-taxonomies/check.js
+++ b/packages/editor/src/components/post-taxonomies/check.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { some, includes } from 'lodash';
+import { some } from 'lodash';
 
 /**
  * WordPress dependencies
@@ -17,7 +17,7 @@ import { store as editorStore } from '../../store';
 
 export function PostTaxonomiesCheck( { postType, taxonomies, children } ) {
 	const hasTaxonomies = some( taxonomies, ( taxonomy ) =>
-		includes( taxonomy.types, postType )
+		taxonomy.types.includes( postType )
 	);
 	if ( ! hasTaxonomies ) {
 		return null;

--- a/packages/editor/src/components/post-taxonomies/index.js
+++ b/packages/editor/src/components/post-taxonomies/index.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { filter, includes } from 'lodash';
+import { filter } from 'lodash';
 
 /**
  * WordPress dependencies
@@ -26,7 +26,7 @@ export function PostTaxonomies( {
 	taxonomyWrapper = identity,
 } ) {
 	const availableTaxonomies = filter( taxonomies, ( taxonomy ) =>
-		includes( taxonomy.types, postType )
+		taxonomy.types.includes( postType )
 	);
 	const visibleTaxonomies = filter(
 		availableTaxonomies,

--- a/packages/editor/src/components/theme-support-check/index.js
+++ b/packages/editor/src/components/theme-support-check/index.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { includes, get, some } from 'lodash';
+import { get, some } from 'lodash';
 
 /**
  * WordPress dependencies
@@ -29,7 +29,7 @@ export function ThemeSupportCheck( {
 			// within `supported`. If `postType` isn't passed, then the check
 			// should fail.
 			if ( 'post-thumbnails' === key && Array.isArray( supported ) ) {
-				return includes( supported, postType );
+				return supported.includes( postType );
 			}
 			return supported;
 		}

--- a/packages/editor/src/store/utils/notice-builder.js
+++ b/packages/editor/src/store/utils/notice-builder.js
@@ -11,7 +11,7 @@ import { SAVE_POST_NOTICE_ID, TRASH_POST_NOTICE_ID } from '../constants';
 /**
  * External dependencies
  */
-import { get, includes } from 'lodash';
+import { get } from 'lodash';
 
 /**
  * Builds the arguments for a success notification dispatch.
@@ -34,8 +34,8 @@ export function getNotificationArgumentsForSaveSuccess( data ) {
 	}
 
 	const publishStatus = [ 'publish', 'private', 'future' ];
-	const isPublished = includes( publishStatus, previousPost.status );
-	const willPublish = includes( publishStatus, post.status );
+	const isPublished = publishStatus.includes( previousPost.status );
+	const willPublish = publishStatus.includes( post.status );
 
 	let noticeMessage;
 	let shouldShowLink = get( postType, [ 'viewable' ], false );


### PR DESCRIPTION
## What?
This PR removes Lodash's `_.includes()` completely and deprecates the package. There are just a few usages and conversion is pretty straightforward. 

## Why?

Lodash is known to unnecessarily inflate the bundle size of packages, and in most cases, it can be replaced with native language functionality. See these for more information and rationale:

* https://github.com/WordPress/gutenberg/issues/16938#issuecomment-602837246
* https://github.com/WordPress/gutenberg/issues/17025
* https://github.com/WordPress/gutenberg/issues/39495 

## How?

We're replacing a few usages with a simple native `Array.prototype.includes()` or `String.prototype.includes()`. 

## Testing Instructions

* Test with a theme that has post formats (`twentyseventeen` for example) and verify you can still set one properly for your post. 
* Test with a theme that does not support post formats and verify it doesn't crash when you save/open a post in the admin.
* Test both with a theme that supports and doesn't support featured images, and verify you can open a post and save it correctly.
* Verify you're still properly able to retrieve and set terms of a taxonomy (post tags, categories) for a post.
* Verify all checks are green and tests still pass.