### PR TITLE
List: disable nested list drop zone so dropping list items works

### DIFF
--- a/packages/block-editor/src/components/inner-blocks/index.js
+++ b/packages/block-editor/src/components/inner-blocks/index.js
@@ -150,7 +150,8 @@ const ForwardedInnerBlocks = forwardRef( ( props, ref ) => {
  * @see https://github.com/WordPress/gutenberg/blob/HEAD/packages/block-editor/src/components/inner-blocks/README.md
  */
 export function useInnerBlocksProps( props = {}, options = {} ) {
-	const { __unstableDisableLayoutClassNames } = options;
+	const { __unstableDisableLayoutClassNames, __unstableDisableDropZone } =
+		options;
 	const { clientId, __unstableLayoutClassNames: layoutClassNames = '' } =
 		useBlockEditContext();
 	const isSmallScreen = useViewportMatch( 'medium', '<' );
@@ -187,11 +188,13 @@ export function useInnerBlocksProps( props = {}, options = {} ) {
 		[ clientId, isSmallScreen ]
 	);
 
+	const blockDropZoneRef = useBlockDropZone( {
+		rootClientId: clientId,
+	} );
+
 	const ref = useMergeRefs( [
 		props.ref,
-		useBlockDropZone( {
-			rootClientId: clientId,
-		} ),
+		__unstableDisableDropZone ? null : blockDropZoneRef,
 	] );
 
 	const innerBlocksProps = {

--- a/packages/block-library/src/list-item/edit.js
+++ b/packages/block-library/src/list-item/edit.js
@@ -67,6 +67,7 @@ export default function ListItemEdit( {
 	const innerBlocksProps = useInnerBlocksProps( blockProps, {
 		allowedBlocks: [ 'core/list' ],
 		renderAppender: false,
+		__unstableDisableDropZone: true,
 	} );
 	const useEnterRef = useEnter( { content, clientId } );
 	const useSpaceRef = useSpace( clientId );


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What and why?

Currently it's not possible to rearrange list items by drag and drop.

* Part of the issue is that there's no margin in between list items.
* And when dragging it **over** another list item, that list item is also a block list container with a drop zone for a nested list.

## How?

The simplest solution (this late in the release cycle) is to disable the drop zone for the nested **list**. Not that nested list **items** can still be dropped, we're only disabling dropping into the block list for list items, which anyway can only contain **one** list at most.

## Testing Instructions
Create a list and rearrange items with drag and drop. Also try nested list items.

## Screenshots or screencast <!-- if applicable -->
