### PR TITLE
Spacing visualizer: reduce rerenders on mouse events

### DIFF
--- a/packages/block-editor/src/hooks/dimensions.js
+++ b/packages/block-editor/src/hooks/dimensions.js
@@ -7,7 +7,7 @@ import classnames from 'classnames';
  * WordPress dependencies
  */
 import { __experimentalToolsPanelItem as ToolsPanelItem } from '@wordpress/components';
-import { Platform, useState } from '@wordpress/element';
+import { Platform, useState, useCallback } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import { getBlockSupport } from '@wordpress/blocks';
 
@@ -46,8 +46,8 @@ export const AXIAL_SIDES = [ 'vertical', 'horizontal' ];
 
 function useVisualizerMouseOver() {
 	const [ isMouseOver, setIsMouseOver ] = useState( false );
-	const onMouseOver = () => setIsMouseOver( true );
-	const onMouseOut = () => setIsMouseOver( false );
+	const onMouseOver = useCallback( () => setIsMouseOver( true ), [] );
+	const onMouseOut = useCallback( () => setIsMouseOver( false ), [] );
 	return { isMouseOver, onMouseOver, onMouseOut };
 }
 

--- a/packages/block-editor/src/hooks/dimensions.js
+++ b/packages/block-editor/src/hooks/dimensions.js
@@ -7,7 +7,7 @@ import classnames from 'classnames';
  * WordPress dependencies
  */
 import { __experimentalToolsPanelItem as ToolsPanelItem } from '@wordpress/components';
-import { Platform, useState, useCallback } from '@wordpress/element';
+import { Platform, useState, useCallback, memo } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import { getBlockSupport } from '@wordpress/blocks';
 
@@ -51,6 +51,8 @@ function useVisualizerMouseOver() {
 	return { isMouseOver, onMouseOver, onMouseOut };
 }
 
+const MemoizedPaddingEdit = memo( PaddingEdit );
+const MemoizedMarginEdit = memo( MarginEdit );
 /**
  * Inspector controls for dimensions support.
  *
@@ -105,7 +107,7 @@ export function DimensionsPanel( props ) {
 						isShownByDefault={ defaultSpacingControls?.padding }
 						panelId={ props.clientId }
 					>
-						<PaddingEdit
+						<MemoizedPaddingEdit
 							onMouseOver={ paddingMouseOver.onMouseOver }
 							onMouseOut={ paddingMouseOver.onMouseOut }
 							{ ...props }
@@ -122,7 +124,7 @@ export function DimensionsPanel( props ) {
 						isShownByDefault={ defaultSpacingControls?.margin }
 						panelId={ props.clientId }
 					>
-						<MarginEdit
+						<MemoizedMarginEdit
 							onMouseOver={ marginMouseOver.onMouseOver }
 							onMouseOut={ marginMouseOver.onMouseOut }
 							{ ...props }


### PR DESCRIPTION
## What?
Caches the spacing visualizer mouse events

## Why?
While debugging [an issue with the spacing presets slider](https://github.com/WordPress/gutenberg/issues/45297) I noticed that the mouseover callbacks where causing rerenders as they were being redefined on every render.

## How?
Wraps the mouseover callbacks in a useCallback with no dependencies so they only get defined on the initial render

## Testing Instructions

- Add a Group block and set margin and padding and check the visualizer still displays for both when mousing over the range control

