### PR TITLE
Add constrained/flow layout to Cover block.

### DIFF
--- a/packages/block-editor/src/layouts/constrained.js
+++ b/packages/block-editor/src/layouts/constrained.js
@@ -32,8 +32,10 @@ export default {
 	inspectorControls: function DefaultLayoutInspectorControls( {
 		layout,
 		onChange,
+		layoutBlockSupport = {},
 	} ) {
 		const { wideSize, contentSize, justifyContent = 'center' } = layout;
+		const { allowJustification = true } = layoutBlockSupport;
 		const onJustificationChange = ( value ) => {
 			onChange( {
 				...layout,
@@ -117,23 +119,27 @@ export default {
 						'Customize the width for all elements that are assigned to the center or wide columns.'
 					) }
 				</p>
-				<ToggleGroupControl
-					__nextHasNoMarginBottom
-					label={ __( 'Justification' ) }
-					value={ justifyContent }
-					onChange={ onJustificationChange }
-				>
-					{ justificationOptions.map( ( { value, icon, label } ) => {
-						return (
-							<ToggleGroupControlOptionIcon
-								key={ value }
-								value={ value }
-								icon={ icon }
-								label={ label }
-							/>
-						);
-					} ) }
-				</ToggleGroupControl>
+				{ allowJustification && (
+					<ToggleGroupControl
+						__nextHasNoMarginBottom
+						label={ __( 'Justification' ) }
+						value={ justifyContent }
+						onChange={ onJustificationChange }
+					>
+						{ justificationOptions.map(
+							( { value, icon, label } ) => {
+								return (
+									<ToggleGroupControlOptionIcon
+										key={ value }
+										value={ value }
+										icon={ icon }
+										label={ label }
+									/>
+								);
+							}
+						) }
+					</ToggleGroupControl>
+				) }
 			</>
 		);
 	},

--- a/packages/block-library/src/cover/block.json
+++ b/packages/block-library/src/cover/block.json
@@ -111,9 +111,7 @@
 			}
 		},
 		"__experimentalLayout": {
-			"default": {
-				"type": "constrained"
-			}
+			"allowJustification": false
 		}
 	},
 	"editorStyle": "wp-block-cover-editor",

--- a/packages/block-library/src/cover/block.json
+++ b/packages/block-library/src/cover/block.json
@@ -109,6 +109,11 @@
 			"__experimentalDefaultControls": {
 				"fontSize": true
 			}
+		},
+		"__experimentalLayout": {
+			"default": {
+				"type": "constrained"
+			}
 		}
 	},
 	"editorStyle": "wp-block-cover-editor",

--- a/packages/block-library/src/cover/edit/index.js
+++ b/packages/block-library/src/cover/edit/index.js
@@ -89,7 +89,6 @@ function CoverEdit( {
 		hasParallax,
 		isDark,
 		isRepeated,
-		layout = {},
 		minHeight,
 		minHeightUnit,
 		alt,
@@ -188,11 +187,6 @@ function CoverEdit( {
 		fontSize: hasFontSizes ? 'large' : undefined,
 	} );
 
-	const defaultLayout = useSetting( 'layout' ) || {};
-	const usedLayout = ! layout?.type
-		? { ...defaultLayout, ...layout, type: 'constrained' }
-		: { ...defaultLayout, ...layout };
-
 	const innerBlocksProps = useInnerBlocksProps(
 		{
 			className: 'wp-block-cover__inner-container',
@@ -204,7 +198,6 @@ function CoverEdit( {
 			templateInsertUpdatesSelection: true,
 			allowedBlocks,
 			templateLock,
-			__experimentalLayout: usedLayout,
 		}
 	);
 

--- a/packages/block-library/src/cover/edit/index.js
+++ b/packages/block-library/src/cover/edit/index.js
@@ -89,6 +89,7 @@ function CoverEdit( {
 		hasParallax,
 		isDark,
 		isRepeated,
+		layout = {},
 		minHeight,
 		minHeightUnit,
 		alt,
@@ -187,6 +188,11 @@ function CoverEdit( {
 		fontSize: hasFontSizes ? 'large' : undefined,
 	} );
 
+	const defaultLayout = useSetting( 'layout' ) || {};
+	const usedLayout = ! layout?.type
+		? { ...defaultLayout, ...layout, type: 'constrained' }
+		: { ...defaultLayout, ...layout };
+
 	const innerBlocksProps = useInnerBlocksProps(
 		{
 			className: 'wp-block-cover__inner-container',
@@ -198,6 +204,7 @@ function CoverEdit( {
 			templateInsertUpdatesSelection: true,
 			allowedBlocks,
 			templateLock,
+			__experimentalLayout: usedLayout,
 		}
 	);
 

--- a/packages/block-library/src/cover/index.js
+++ b/packages/block-library/src/cover/index.js
@@ -13,6 +13,7 @@ import edit from './edit';
 import metadata from './block.json';
 import save from './save';
 import transforms from './transforms';
+import variations from './variations';
 
 const { name } = metadata;
 
@@ -48,6 +49,7 @@ export const settings = {
 	save,
 	edit,
 	deprecated,
+	variations,
 };
 
 export const init = () => initBlock( { name, metadata, settings } );

--- a/packages/block-library/src/cover/variations.js
+++ b/packages/block-library/src/cover/variations.js
@@ -13,11 +13,6 @@ const variations = [
 		),
 		attributes: { layout: { type: 'constrained' } },
 		isDefault: true,
-		scope: [ 'block', 'inserter', 'transform' ],
-		isActive: ( blockAttributes ) =>
-			! blockAttributes.layout ||
-			! blockAttributes.layout?.type ||
-			blockAttributes.layout?.type === 'constrained',
 		icon: cover,
 	},
 ];

--- a/packages/block-library/src/cover/variations.js
+++ b/packages/block-library/src/cover/variations.js
@@ -1,0 +1,25 @@
+/**
+ * WordPress dependencies
+ */
+import { __ } from '@wordpress/i18n';
+import { cover } from '@wordpress/icons';
+
+const variations = [
+	{
+		name: 'cover',
+		title: __( 'Cover' ),
+		description: __(
+			'Add an image or video with a text overlay — great for headers.'
+		),
+		attributes: { layout: { type: 'constrained' } },
+		isDefault: true,
+		scope: [ 'block', 'inserter', 'transform' ],
+		isActive: ( blockAttributes ) =>
+			! blockAttributes.layout ||
+			! blockAttributes.layout?.type ||
+			blockAttributes.layout?.type === 'constrained',
+		icon: cover,
+	},
+];
+
+export default variations;

--- a/packages/e2e-tests/specs/editor/various/__snapshots__/inserting-blocks.test.js.snap
+++ b/packages/e2e-tests/specs/editor/various/__snapshots__/inserting-blocks.test.js.snap
@@ -88,7 +88,7 @@ exports[`Inserting blocks inserts a block in proper place after having clicked \
 <p>First paragraph</p>
 <!-- /wp:paragraph -->
 
-<!-- wp:cover {"isDark":false} -->
+<!-- wp:cover {"isDark":false,"layout":{"type":"constrained"}} -->
 <div class="wp-block-cover is-light"><span aria-hidden="true" class="wp-block-cover__background has-background-dim-100 has-background-dim"></span><div class="wp-block-cover__inner-container"></div></div>
 <!-- /wp:cover -->
 


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

Closes #43140.

Adds support for constrained (as default) and flow layout to Cover block.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

Now that #44600 is merged, layout classnames are applied to the block inner wrapper by default. This means that layout support will work in Cover block in the same way as it does in e.g. Group (but without the flex variations for now).

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->

1. Add a Cover block to a post;
2. Check that the Layout section now displays in the sidebar;
3. Check that constrained layout applies by default to Cover children;
4. Check that Cover children now have wide/full alignment controls where applicable.

TODO:

Existing Cover blocks should not change their layouts. I haven't done any testing for this yet, but anticipate some tweaks may be needed. I don't think a deprecation should be required because we're only adding functionality, not changing anything existing.

## Screenshots or screencast <!-- if applicable -->
<img width="880" alt="Screen Shot 2022-10-27 at 11 14 12 am" src="https://user-images.githubusercontent.com/8096000/198162006-895e5c50-65bb-4d3b-8168-4c2a019f23ae.png">
