### PR TITLE
Fix control widths for Cover, Search, and Spacer blocks

### DIFF
--- a/packages/block-library/src/cover/edit/inspector-controls.js
+++ b/packages/block-library/src/cover/edit/inspector-controls.js
@@ -3,7 +3,6 @@
  */
 import { Fragment, useMemo } from '@wordpress/element';
 import {
-	BaseControl,
 	Button,
 	ExternalLink,
 	FocalPointPicker,
@@ -73,18 +72,17 @@ function CoverHeightInput( {
 	const min = isPx ? COVER_MIN_HEIGHT : 0;
 
 	return (
-		<BaseControl label={ __( 'Minimum height of cover' ) } id={ inputId }>
-			<UnitControl
-				id={ inputId }
-				isResetValueOnUnitChange
-				min={ min }
-				onChange={ handleOnChange }
-				onUnitChange={ onUnitChange }
-				style={ { maxWidth: 80 } }
-				units={ units }
-				value={ computedValue }
-			/>
-		</BaseControl>
+		<UnitControl
+			label={ __( 'Minimum height of cover' ) }
+			id={ inputId }
+			isResetValueOnUnitChange
+			min={ min }
+			onChange={ handleOnChange }
+			onUnitChange={ onUnitChange }
+			__unstableInputWidth={ '80px' }
+			units={ units }
+			value={ computedValue }
+		/>
 	);
 }
 export default function CoverInspectorControls( {

--- a/packages/block-library/src/search/edit.js
+++ b/packages/block-library/src/search/edit.js
@@ -363,7 +363,7 @@ export default function SearchEdit( {
 									widthUnit: newUnit,
 								} );
 							} }
-							style={ { maxWidth: 80 } }
+							__unstableInputWidth={ '80px' }
 							value={ `${ width }${ widthUnit }` }
 							units={ units }
 						/>

--- a/packages/block-library/src/spacer/controls.js
+++ b/packages/block-library/src/spacer/controls.js
@@ -4,7 +4,6 @@
 import { __ } from '@wordpress/i18n';
 import { InspectorControls, useSetting } from '@wordpress/block-editor';
 import {
-	BaseControl,
 	PanelBody,
 	__experimentalUseCustomUnits as useCustomUnits,
 	__experimentalUnitControl as UnitControl,
@@ -51,17 +50,16 @@ function DimensionInput( { label, onChange, isResizing, value = '' } ) {
 	].join( '' );
 
 	return (
-		<BaseControl label={ label } id={ inputId }>
-			<UnitControl
-				id={ inputId }
-				isResetValueOnUnitChange
-				min={ MIN_SPACER_SIZE }
-				onChange={ handleOnChange }
-				style={ { maxWidth: 80 } }
-				value={ computedValue }
-				units={ units }
-			/>
-		</BaseControl>
+		<UnitControl
+			label={ label }
+			id={ inputId }
+			isResetValueOnUnitChange
+			min={ MIN_SPACER_SIZE }
+			onChange={ handleOnChange }
+			__unstableInputWidth={ '80px' }
+			value={ computedValue }
+			units={ units }
+		/>
 	);
 }
 

--- a/packages/e2e-tests/specs/editor/blocks/cover.test.js
+++ b/packages/e2e-tests/specs/editor/blocks/cover.test.js
@@ -134,7 +134,7 @@ describe( 'Cover', () => {
 
 		const heightInput = (
 			await page.$x(
-				'//div[./label[contains(text(),"Minimum height of cover")]]//input'
+				'//div[./label[contains(text(),"Minimum height of cover")]]/following-sibling::div//input'
 			)
 		 )[ 0 ];
 


### PR DESCRIPTION
Related:
- https://github.com/WordPress/gutenberg/pull/45139
- https://github.com/WordPress/gutenberg/pull/41860

## What?

Fixes restriction of control width for Cover, Search, and Spacer blocks.

## Why?

Addresses a visual regression after merging https://github.com/WordPress/gutenberg/pull/41860. Whether the controls should have a restricted width or not is a separate discussion. They'll likely be updated once we have the new `SliderUnitControl` available for use in the sidebar as well.

## How?

Replaces the inline style setting input width with use of the `__unstableInputWidth` prop.
Also removes wrapping of a control capable of displaying a label with another base control seemingly only to display a label.

## Testing Instructions

1. Add Cover, Search and Spacer blocks to a post
2. Select the Cover block and confirm the min-height control appears only 80px wide
3. Do the same for the Search block's width control
4. Repeat the process again for the Spacer block and its height/width control (differs based on the orientation of the spacer as to what's shown)
5. Search code base for any further instances of controls using inline styles to restrict the width of a UnitControl. There shouldn't be any.

## Screenshots or screencast <!-- if applicable -->

| Block | Before | After |
|---|---|---|
| Cover | <img width="277" alt="Screen Shot 2022-10-27 at 1 46 44 pm" src="https://user-images.githubusercontent.com/60436221/198188060-67b3c40e-a10e-462d-80dc-f06ec6725f90.png"> | <img width="279" alt="Screen Shot 2022-10-27 at 1 46 07 pm" src="https://user-images.githubusercontent.com/60436221/198187794-1f91ed6b-c9ce-4e71-85e3-23205f54f489.png"> |
| Search | <img width="278" alt="Screen Shot 2022-10-27 at 1 47 05 pm" src="https://user-images.githubusercontent.com/60436221/198187702-8c1eb4ec-323d-4c6e-8d26-f474a645595f.png"> | <img width="277" alt="Screen Shot 2022-10-27 at 1 46 28 pm" src="https://user-images.githubusercontent.com/60436221/198187753-6ac719b4-cf7e-40cc-b5a1-25b44aa4e0d9.png"> |
| Spacer | <img width="276" alt="Screen Shot 2022-10-27 at 1 46 58 pm" src="https://user-images.githubusercontent.com/60436221/198188033-c27803a5-9a58-4fe6-8512-16a179062efc.png"> | <img width="279" alt="Screen Shot 2022-10-27 at 1 46 17 pm" src="https://user-images.githubusercontent.com/60436221/198187776-02802ed0-c0d4-46cf-9a49-088d149be480.png"> |

