### PR TITLE
Layout: ensure block content is always returned as a string after processing

### DIFF
--- a/lib/block-supports/layout.php
+++ b/lib/block-supports/layout.php
@@ -305,7 +305,7 @@ function gutenberg_get_classnames_from_last_tag( $html ) {
 		$last_classnames = $tags->get_attribute( 'class' );
 	}
 
-	return $last_classnames;
+	return (string) $last_classnames;
 }
 
 /**
@@ -445,7 +445,7 @@ function gutenberg_render_layout_support_flag( $block_content, $block ) {
 		$content->add_class( implode( ' ', $class_names ) );
 	}
 
-	return $content;
+	return (string) $content;
 }
 
 // Register the block support. (overrides core one).


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Follow-up to: https://github.com/WordPress/gutenberg/pull/44600

When using `WP_HTML_Tag_Processor` in `layout.php`, we need to make sure that we cast to a string, otherwise we return a `WP_HTML_Tag_Processor` object instead of a string. Although it can be treated as a string, if we have other hooks that also act on the block content and that are registered after the existing layout support, then without this change, they can accidentally encounter an object instead of a string.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

While rebasing https://github.com/WordPress/gutenberg/pull/44723, I ran into a PHP fatal when I attempted to do more processing in an additional hook on `render_block` because the `$block_content` was not a string as expected. This change should resolve that.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

Add `(string)` casts before output when using `WP_HTML_Tag_Processor` in `layout.php`

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->

Smoke test and ensure that layout output is still working as expected (e.g. add a few group blocks to a page, set some block spacing, save, and view on site front-end, and ensure there are no PHP errors or warnings)