### PR TITLE
NumberControl: Add custom spin buttons

### DIFF
--- a/packages/block-editor/src/components/line-height-control/index.js
+++ b/packages/block-editor/src/components/line-height-control/index.js
@@ -99,6 +99,7 @@ const LineHeightControl = ( {
 				step={ STEP }
 				value={ value }
 				min={ 0 }
+				spinControls="custom"
 			/>
 		</div>
 	);

--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -21,6 +21,7 @@
 -   `BorderControl` & `BorderBoxControl`: Replace `__next36pxDefaultSize` with "default" and "large" size variants ([#41860](https://github.com/WordPress/gutenberg/pull/41860)).
 -   `UnitControl`: Remove outer wrapper to normalize className placement ([#41860](https://github.com/WordPress/gutenberg/pull/41860)).
 -   `ColorPalette`: Fix transparent checkered background pattern ([#45295](https://github.com/WordPress/gutenberg/pull/45295)).
+-   `NumberControl`: Add custom spin buttons ([#45333](https://github.com/WordPress/gutenberg/pull/45333)).
 
 ### Bug Fix
 

--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -22,7 +22,6 @@
 -   `UnitControl`: Remove outer wrapper to normalize className placement ([#41860](https://github.com/WordPress/gutenberg/pull/41860)).
 -   `ColorPalette`: Fix transparent checkered background pattern ([#45295](https://github.com/WordPress/gutenberg/pull/45295)).
 -   `ToggleGroupControl`: Add `isDeselectable` prop to allow deselecting the selected option ([#45123](https://github.com/WordPress/gutenberg/pull/45123)).
--   `NumberControl`: Add custom spin buttons ([#45333](https://github.com/WordPress/gutenberg/pull/45333)).
 
 ### Bug Fix
 
@@ -46,6 +45,10 @@
 -   `ColorPalette`: Convert to TypeScript ([#44632](https://github.com/WordPress/gutenberg/pull/44632)).
 -   `UnitControl`: Add tests ([#45260](https://github.com/WordPress/gutenberg/pull/45260)).
 -   `Disabled`: Refactor the component to rely on the HTML `inert` attribute.
+
+### Experimental
+
+-   `NumberControl`: Replace `hideHTMLArrows` prop with `spinControls` prop. Allow custom spin controls via `spinControls="custom"` ([#45333](https://github.com/WordPress/gutenberg/pull/45333)).
 
 ## 21.3.0 (2022-10-19)
 

--- a/packages/components/src/angle-picker-control/index.js
+++ b/packages/components/src/angle-picker-control/index.js
@@ -63,7 +63,7 @@ export default function AnglePickerControl( {
 					size="__unstable-large"
 					step="1"
 					value={ value }
-					hideHTMLArrows
+					spinControls="none"
 					suffix={
 						<Spacer
 							as={ Text }

--- a/packages/components/src/color-picker/input-with-slider.tsx
+++ b/packages/components/src/color-picker/input-with-slider.tsx
@@ -45,7 +45,7 @@ export const InputWithSlider = ( {
 						{ abbreviation }
 					</Spacer>
 				}
-				hideHTMLArrows
+				spinControls="none"
 				size="__unstable-large"
 			/>
 			<RangeControl

--- a/packages/components/src/date-time/time/index.tsx
+++ b/packages/components/src/date-time/time/index.tsx
@@ -180,7 +180,7 @@ export function TimePicker( {
 			min={ 1 }
 			max={ 31 }
 			required
-			hideHTMLArrows
+			spinControls="none"
 			isPressEnterToChange
 			isDragEnabled={ false }
 			isShiftStepEnabled={ false }
@@ -246,7 +246,7 @@ export function TimePicker( {
 							min={ is12Hour ? 1 : 0 }
 							max={ is12Hour ? 12 : 23 }
 							required
-							hideHTMLArrows
+							spinControls="none"
 							isPressEnterToChange
 							isDragEnabled={ false }
 							isShiftStepEnabled={ false }
@@ -273,7 +273,7 @@ export function TimePicker( {
 							min={ 0 }
 							max={ 59 }
 							required
-							hideHTMLArrows
+							spinControls="none"
 							isPressEnterToChange
 							isDragEnabled={ false }
 							isShiftStepEnabled={ false }
@@ -344,7 +344,7 @@ export function TimePicker( {
 						min={ 1 }
 						max={ 9999 }
 						required
-						hideHTMLArrows
+						spinControls="none"
 						isPressEnterToChange
 						isDragEnabled={ false }
 						isShiftStepEnabled={ false }

--- a/packages/components/src/input-control/types.ts
+++ b/packages/components/src/input-control/types.ts
@@ -4,9 +4,7 @@
 import type {
 	CSSProperties,
 	ReactNode,
-	ChangeEvent,
 	SyntheticEvent,
-	PointerEvent,
 	HTMLInputTypeAttribute,
 } from 'react';
 import type { useDrag } from '@use-gesture/react';
@@ -62,10 +60,10 @@ interface BaseProps {
 	size?: Size;
 }
 
-export type InputChangeCallback<
-	E = ChangeEvent< HTMLInputElement > | PointerEvent< HTMLInputElement >,
-	P = {}
-> = ( nextValue: string | undefined, extra: { event: E } & P ) => void;
+export type InputChangeCallback< P = {} > = (
+	nextValue: string | undefined,
+	extra: { event: SyntheticEvent } & P
+) => void;
 
 export interface InputFieldProps extends BaseProps {
 	/**

--- a/packages/components/src/number-control/README.md
+++ b/packages/components/src/number-control/README.md
@@ -44,13 +44,18 @@ If `isDragEnabled` is true, this controls the amount of `px` to have been dragge
 -   Required: No
 -   Default: `10`
 
-### hideHTMLArrows
+### spinControls
 
-If true, the default `input` HTML arrows will be hidden.
+ The type of spin controls to display. These are butons that allow the user to
+ quickly increment and decrement the number.
+ 
+ - 'none' - Do not show spin controls.
+ - 'native' - Use browser's native HTML `input` controls.
+ - 'custom' - Use plus and minus icon buttons.
 
--   Type: `Boolean`
+-   Type: `String`
 -   Required: No
--   Default: `false`
+-   Default: `'native'`
 
 ### isDragEnabled
 

--- a/packages/components/src/number-control/index.tsx
+++ b/packages/components/src/number-control/index.tsx
@@ -42,6 +42,7 @@ function UnforwardedNumberControl(
 		type: typeProp = 'number',
 		value: valueProp,
 		size = 'default',
+		suffix,
 		onChange = noop,
 		...props
 	}: WordPressComponentProps< NumberControlProps, 'input', false >,
@@ -209,52 +210,56 @@ function UnforwardedNumberControl(
 			} }
 			size={ size }
 			suffix={
-				size === '__unstable-large' &&
-				! hideHTMLArrows && (
-					<Spacer marginBottom={ 0 } marginRight={ 2 }>
-						<HStack spacing={ 1 }>
-							<SpinButton
-								icon={ plusIcon }
-								isSmall
-								aria-hidden="true"
-								onClick={ (
-									event: ChangeEvent< HTMLInputElement >
-								) => {
-									const currentValue = isValueEmpty(
-										valueProp
-									)
-										? baseValue
-										: valueProp;
-									const nextValue = constrainValue(
-										add( currentValue, baseStep )
-									);
-									onChange?.( String( nextValue ), {
-										event,
-									} );
-								} }
-							/>
-							<SpinButton
-								icon={ resetIcon }
-								isSmall
-								aria-hidden="true"
-								onClick={ (
-									event: ChangeEvent< HTMLInputElement >
-								) => {
-									const currentValue = isValueEmpty(
-										valueProp
-									)
-										? baseValue
-										: valueProp;
-									const nextValue = constrainValue(
-										subtract( currentValue, baseStep )
-									);
-									onChange?.( String( nextValue ), {
-										event,
-									} );
-								} }
-							/>
-						</HStack>
-					</Spacer>
+				size === '__unstable-large' && ! hideHTMLArrows ? (
+					<>
+						{ suffix }
+						<Spacer marginBottom={ 0 } marginRight={ 2 }>
+							<HStack spacing={ 1 }>
+								<SpinButton
+									icon={ plusIcon }
+									isSmall
+									aria-hidden="true"
+									onClick={ (
+										event: ChangeEvent< HTMLInputElement >
+									) => {
+										const currentValue = isValueEmpty(
+											valueProp
+										)
+											? baseValue
+											: valueProp;
+										const nextValue = constrainValue(
+											add( currentValue, baseStep )
+										);
+										onChange?.( String( nextValue ), {
+											event,
+										} );
+									} }
+								/>
+								<SpinButton
+									icon={ resetIcon }
+									isSmall
+									aria-hidden="true"
+									onClick={ (
+										event: ChangeEvent< HTMLInputElement >
+									) => {
+										const currentValue = isValueEmpty(
+											valueProp
+										)
+											? baseValue
+											: valueProp;
+										const nextValue = constrainValue(
+											subtract( currentValue, baseStep )
+										);
+										onChange?.( String( nextValue ), {
+											event,
+										} );
+									} }
+								/>
+							</HStack>
+						</Spacer>
+					</>
+				) : (
+					suffix
 				)
 			}
 			onChange={ onChange }

--- a/packages/components/src/number-control/index.tsx
+++ b/packages/components/src/number-control/index.tsx
@@ -11,6 +11,7 @@ import { useRef, forwardRef } from '@wordpress/element';
 import { isRTL, __ } from '@wordpress/i18n';
 import { plus as plusIcon, reset as resetIcon } from '@wordpress/icons';
 import { useMergeRefs } from '@wordpress/compose';
+import deprecated from '@wordpress/deprecated';
 
 /**
  * Internal dependencies
@@ -31,6 +32,7 @@ function UnforwardedNumberControl(
 		__unstableStateReducer: stateReducerProp,
 		className,
 		dragDirection = 'n',
+		hideHTMLArrows = false,
 		spinControls = 'native',
 		isDragEnabled = true,
 		isShiftStepEnabled = true,
@@ -49,6 +51,15 @@ function UnforwardedNumberControl(
 	}: WordPressComponentProps< NumberControlProps, 'input', false >,
 	forwardedRef: ForwardedRef< any >
 ) {
+	if ( hideHTMLArrows ) {
+		deprecated( 'hideHTMLArrows', {
+			alternative: 'spinControls="none"',
+			since: '6.2',
+			version: '6.3',
+		} );
+		spinControls = 'none';
+	}
+
 	const inputRef = useRef< HTMLInputElement >();
 	const mergedRef = useMergeRefs( [ inputRef, forwardedRef ] );
 

--- a/packages/components/src/number-control/index.tsx
+++ b/packages/components/src/number-control/index.tsx
@@ -232,12 +232,14 @@ function UnforwardedNumberControl(
 									icon={ plusIcon }
 									isSmall
 									aria-hidden="true"
+									tabIndex={ -1 }
 									onClick={ buildSpinHandler( 'up' ) }
 								/>
 								<SpinButton
 									icon={ resetIcon }
 									isSmall
 									aria-hidden="true"
+									tabIndex={ -1 }
 									onClick={ buildSpinHandler( 'down' ) }
 								/>
 							</HStack>

--- a/packages/components/src/number-control/index.tsx
+++ b/packages/components/src/number-control/index.tsx
@@ -227,7 +227,6 @@ function UnforwardedNumberControl(
 													event
 												)
 											),
-											// @ts-expect-error TODO: Make InputChangeCallback less opinionated about event type.
 											{ event }
 										);
 									} }
@@ -249,7 +248,6 @@ function UnforwardedNumberControl(
 													event
 												)
 											),
-											// @ts-expect-error TODO: Make InputChangeCallback less opinionated about event type.
 											{ event }
 										);
 									} }

--- a/packages/components/src/number-control/index.tsx
+++ b/packages/components/src/number-control/index.tsx
@@ -20,8 +20,8 @@ import { add, subtract, roundClamp } from '../utils/math';
 import { ensureNumber, isValueEmpty } from '../utils/values';
 import type { WordPressComponentProps } from '../ui/context/wordpress-component';
 import type { NumberControlProps } from './types';
-import InputControlSuffixWrapper from '../input-control/input-suffix-wrapper';
 import { HStack } from '../h-stack';
+import { Spacer } from '../spacer';
 
 const noop = () => {};
 
@@ -211,8 +211,8 @@ function UnforwardedNumberControl(
 			suffix={
 				size === '__unstable-large' &&
 				! hideHTMLArrows && (
-					<InputControlSuffixWrapper>
-						<HStack spacing={ 2 }>
+					<Spacer marginBottom={ 0 } marginRight={ 2 }>
+						<HStack spacing={ 1 }>
 							<SpinButton
 								icon={ plusIcon }
 								isSmall
@@ -254,7 +254,7 @@ function UnforwardedNumberControl(
 								} }
 							/>
 						</HStack>
-					</InputControlSuffixWrapper>
+					</Spacer>
 				)
 			}
 			onChange={ onChange }

--- a/packages/components/src/number-control/index.tsx
+++ b/packages/components/src/number-control/index.tsx
@@ -8,7 +8,7 @@ import type { ForwardedRef, ChangeEvent } from 'react';
  * WordPress dependencies
  */
 import { forwardRef } from '@wordpress/element';
-import { isRTL } from '@wordpress/i18n';
+import { isRTL, __ } from '@wordpress/i18n';
 import { plus as plusIcon, reset as resetIcon } from '@wordpress/icons';
 
 /**
@@ -232,6 +232,7 @@ function UnforwardedNumberControl(
 									icon={ plusIcon }
 									isSmall
 									aria-hidden="true"
+									aria-label={ __( 'Increment' ) }
 									tabIndex={ -1 }
 									onClick={ buildSpinHandler( 'up' ) }
 								/>
@@ -239,6 +240,7 @@ function UnforwardedNumberControl(
 									icon={ resetIcon }
 									isSmall
 									aria-hidden="true"
+									aria-label={ __( 'Decrement' ) }
 									tabIndex={ -1 }
 									onClick={ buildSpinHandler( 'down' ) }
 								/>

--- a/packages/components/src/number-control/index.tsx
+++ b/packages/components/src/number-control/index.tsx
@@ -2,23 +2,28 @@
  * External dependencies
  */
 import classNames from 'classnames';
-import type { ForwardedRef } from 'react';
+import type { ForwardedRef, ChangeEvent } from 'react';
 
 /**
  * WordPress dependencies
  */
 import { forwardRef } from '@wordpress/element';
 import { isRTL } from '@wordpress/i18n';
+import { plus as plusIcon, reset as resetIcon } from '@wordpress/icons';
 
 /**
  * Internal dependencies
  */
-import { Input } from './styles/number-control-styles';
+import { Input, SpinButton } from './styles/number-control-styles';
 import * as inputControlActionTypes from '../input-control/reducer/actions';
 import { add, subtract, roundClamp } from '../utils/math';
 import { ensureNumber, isValueEmpty } from '../utils/values';
 import type { WordPressComponentProps } from '../ui/context/wordpress-component';
 import type { NumberControlProps } from './types';
+import InputControlSuffixWrapper from '../input-control/input-suffix-wrapper';
+import { HStack } from '../h-stack';
+
+const noop = () => {};
 
 function UnforwardedNumberControl(
 	{
@@ -36,6 +41,8 @@ function UnforwardedNumberControl(
 		step = 1,
 		type: typeProp = 'number',
 		value: valueProp,
+		size = 'default',
+		onChange = noop,
 		...props
 	}: WordPressComponentProps< NumberControlProps, 'input', false >,
 	ref: ForwardedRef< any >
@@ -185,7 +192,7 @@ function UnforwardedNumberControl(
 			{ ...props }
 			className={ classes }
 			dragDirection={ dragDirection }
-			hideHTMLArrows={ hideHTMLArrows }
+			hideHTMLArrows={ size === '__unstable-large' || hideHTMLArrows }
 			isDragEnabled={ isDragEnabled }
 			label={ label }
 			max={ max }
@@ -200,6 +207,57 @@ function UnforwardedNumberControl(
 				const baseState = numberControlStateReducer( state, action );
 				return stateReducerProp?.( baseState, action ) ?? baseState;
 			} }
+			size={ size }
+			suffix={
+				size === '__unstable-large' &&
+				! hideHTMLArrows && (
+					<InputControlSuffixWrapper>
+						<HStack spacing={ 2 }>
+							<SpinButton
+								icon={ plusIcon }
+								isSmall
+								aria-hidden="true"
+								onClick={ (
+									event: ChangeEvent< HTMLInputElement >
+								) => {
+									const currentValue = isValueEmpty(
+										valueProp
+									)
+										? baseValue
+										: valueProp;
+									const nextValue = constrainValue(
+										add( currentValue, baseStep )
+									);
+									onChange?.( String( nextValue ), {
+										event,
+									} );
+								} }
+							/>
+							<SpinButton
+								icon={ resetIcon }
+								isSmall
+								aria-hidden="true"
+								onClick={ (
+									event: ChangeEvent< HTMLInputElement >
+								) => {
+									const currentValue = isValueEmpty(
+										valueProp
+									)
+										? baseValue
+										: valueProp;
+									const nextValue = constrainValue(
+										subtract( currentValue, baseStep )
+									);
+									onChange?.( String( nextValue ), {
+										event,
+									} );
+								} }
+							/>
+						</HStack>
+					</InputControlSuffixWrapper>
+				)
+			}
+			onChange={ onChange }
 		/>
 	);
 }

--- a/packages/components/src/number-control/index.tsx
+++ b/packages/components/src/number-control/index.tsx
@@ -186,6 +186,19 @@ function UnforwardedNumberControl(
 			return nextState;
 		};
 
+	const buildSpinHandler =
+		( direction: 'up' | 'down' ) =>
+		( event: ChangeEvent< HTMLInputElement > ) => {
+			let nextValue = isValueEmpty( valueProp ) ? baseValue : valueProp;
+			if ( direction === 'up' ) {
+				nextValue = add( nextValue, baseStep );
+			} else if ( direction === 'down' ) {
+				nextValue = subtract( nextValue, baseStep );
+			}
+			nextValue = constrainValue( nextValue );
+			onChange( String( nextValue ), { event } );
+		};
+
 	return (
 		<Input
 			autoComplete={ autoComplete }
@@ -219,41 +232,13 @@ function UnforwardedNumberControl(
 									icon={ plusIcon }
 									isSmall
 									aria-hidden="true"
-									onClick={ (
-										event: ChangeEvent< HTMLInputElement >
-									) => {
-										const currentValue = isValueEmpty(
-											valueProp
-										)
-											? baseValue
-											: valueProp;
-										const nextValue = constrainValue(
-											add( currentValue, baseStep )
-										);
-										onChange?.( String( nextValue ), {
-											event,
-										} );
-									} }
+									onClick={ buildSpinHandler( 'up' ) }
 								/>
 								<SpinButton
 									icon={ resetIcon }
 									isSmall
 									aria-hidden="true"
-									onClick={ (
-										event: ChangeEvent< HTMLInputElement >
-									) => {
-										const currentValue = isValueEmpty(
-											valueProp
-										)
-											? baseValue
-											: valueProp;
-										const nextValue = constrainValue(
-											subtract( currentValue, baseStep )
-										);
-										onChange?.( String( nextValue ), {
-											event,
-										} );
-									} }
+									onClick={ buildSpinHandler( 'down' ) }
 								/>
 							</HStack>
 						</Spacer>

--- a/packages/components/src/number-control/index.tsx
+++ b/packages/components/src/number-control/index.tsx
@@ -31,7 +31,7 @@ function UnforwardedNumberControl(
 		__unstableStateReducer: stateReducerProp,
 		className,
 		dragDirection = 'n',
-		hideHTMLArrows = false,
+		spinControls = 'native',
 		isDragEnabled = true,
 		isShiftStepEnabled = true,
 		label,
@@ -204,7 +204,7 @@ function UnforwardedNumberControl(
 			{ ...props }
 			className={ classes }
 			dragDirection={ dragDirection }
-			hideHTMLArrows={ size === '__unstable-large' || hideHTMLArrows }
+			hideHTMLArrows={ spinControls !== 'native' }
 			isDragEnabled={ isDragEnabled }
 			label={ label }
 			max={ max }
@@ -221,7 +221,7 @@ function UnforwardedNumberControl(
 			} }
 			size={ size }
 			suffix={
-				size === '__unstable-large' && ! hideHTMLArrows ? (
+				spinControls === 'custom' ? (
 					<>
 						{ suffix }
 						<Spacer marginBottom={ 0 } marginRight={ 2 }>
@@ -235,6 +235,7 @@ function UnforwardedNumberControl(
 									onClick={ buildSpinButtonClickHandler(
 										'up'
 									) }
+									size={ size }
 								/>
 								<SpinButton
 									icon={ resetIcon }
@@ -245,6 +246,7 @@ function UnforwardedNumberControl(
 									onClick={ buildSpinButtonClickHandler(
 										'down'
 									) }
+									size={ size }
 								/>
 							</HStack>
 						</Spacer>

--- a/packages/components/src/number-control/styles/number-control-styles.js
+++ b/packages/components/src/number-control/styles/number-control-styles.js
@@ -11,9 +11,12 @@ import styled from '@emotion/styled';
 import InputControl from '../../input-control';
 import { COLORS } from '../../utils';
 import Button from '../../button';
+import { space } from '../../ui/utils/space';
 
 const htmlArrowStyles = ( { hideHTMLArrows } ) => {
-	if ( ! hideHTMLArrows ) return ``;
+	if ( ! hideHTMLArrows ) {
+		return ``;
+	}
 
 	return css`
 		input[type='number']::-webkit-outer-spin-button,
@@ -32,8 +35,21 @@ export const Input = styled( InputControl )`
 	${ htmlArrowStyles };
 `;
 
+const spinButtonSizeStyles = ( { size } ) => {
+	if ( size !== 'small' ) {
+		return ``;
+	}
+
+	return css`
+		width: ${ space( 5 ) };
+		min-width: ${ space( 5 ) };
+		height: ${ space( 5 ) };
+	`;
+};
+
 export const SpinButton = styled( Button )`
-	&&& {
+	&&&&& {
 		color: ${ COLORS.ui.theme };
+		${ spinButtonSizeStyles }
 	}
 `;

--- a/packages/components/src/number-control/styles/number-control-styles.js
+++ b/packages/components/src/number-control/styles/number-control-styles.js
@@ -4,10 +4,13 @@
  */
 import { css } from '@emotion/react';
 import styled from '@emotion/styled';
+
 /**
  * Internal dependencies
  */
 import InputControl from '../../input-control';
+import { COLORS } from '../../utils';
+import Button from '../../button';
 
 const htmlArrowStyles = ( { hideHTMLArrows } ) => {
 	if ( ! hideHTMLArrows ) return ``;
@@ -27,4 +30,10 @@ const htmlArrowStyles = ( { hideHTMLArrows } ) => {
 
 export const Input = styled( InputControl )`
 	${ htmlArrowStyles };
+`;
+
+export const SpinButton = styled( Button )`
+	&&& {
+		color: ${ COLORS.ui.theme };
+	}
 `;

--- a/packages/components/src/number-control/test/index.js
+++ b/packages/components/src/number-control/test/index.js
@@ -2,6 +2,7 @@
  * External dependencies
  */
 import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 
 /**
  * WordPress dependencies
@@ -424,5 +425,55 @@ describe( 'NumberControl', () => {
 
 			expect( input.value ).toBe( '4' );
 		} );
+	} );
+
+	describe( 'custom spin buttons', () => {
+		test.each( [
+			{},
+			{ size: 'small' },
+			{ size: '__unstable-large', hideHTMLArrows: true },
+		] )( 'should not appear when props = %o', ( props ) => {
+			render( <NumberControl { ...props } /> );
+			expect(
+				screen.queryByLabelText( 'Increment' )
+			).not.toBeInTheDocument();
+			expect(
+				screen.queryByLabelText( 'Decrement' )
+			).not.toBeInTheDocument();
+		} );
+
+		test.each( [
+			[ 'up', '1', {} ],
+			[ 'up', '2', { value: '1' } ],
+			[ 'up', '12', { value: '10', step: '2' } ],
+			[ 'up', '10', { value: '10', max: '10' } ],
+			[ 'down', '-1', {} ],
+			[ 'down', '1', { value: '2' } ],
+			[ 'down', '10', { value: '12', step: '2' } ],
+			[ 'down', '10', { value: '10', min: '10' } ],
+		] )(
+			'should spin %s to %s when props = %o',
+			async ( direction, expectedValue, props ) => {
+				const user = userEvent.setup( {
+					advanceTimers: jest.advanceTimersByTime,
+				} );
+				const onChange = jest.fn();
+				render(
+					<NumberControl
+						{ ...props }
+						size="__unstable-large"
+						onChange={ onChange }
+					/>
+				);
+				await user.click(
+					screen.getByLabelText(
+						direction === 'up' ? 'Increment' : 'Decrement'
+					)
+				);
+				expect( onChange ).toHaveBeenCalledWith( expectedValue, {
+					event: expect.anything(),
+				} );
+			}
+		);
 	} );
 } );

--- a/packages/components/src/number-control/test/index.js
+++ b/packages/components/src/number-control/test/index.js
@@ -428,19 +428,18 @@ describe( 'NumberControl', () => {
 	} );
 
 	describe( 'custom spin buttons', () => {
-		test.each( [
-			{},
-			{ size: 'small' },
-			{ size: '__unstable-large', hideHTMLArrows: true },
-		] )( 'should not appear when props = %o', ( props ) => {
-			render( <NumberControl { ...props } /> );
-			expect(
-				screen.queryByLabelText( 'Increment' )
-			).not.toBeInTheDocument();
-			expect(
-				screen.queryByLabelText( 'Decrement' )
-			).not.toBeInTheDocument();
-		} );
+		test.each( [ undefined, 'none', 'native' ] )(
+			'should not appear when spinControls = %s',
+			( spinControls ) => {
+				render( <NumberControl spinControls={ spinControls } /> );
+				expect(
+					screen.queryByLabelText( 'Increment' )
+				).not.toBeInTheDocument();
+				expect(
+					screen.queryByLabelText( 'Decrement' )
+				).not.toBeInTheDocument();
+			}
+		);
 
 		test.each( [
 			[ 'up', '1', {} ],
@@ -461,7 +460,7 @@ describe( 'NumberControl', () => {
 				render(
 					<NumberControl
 						{ ...props }
-						size="__unstable-large"
+						spinControls="custom"
 						onChange={ onChange }
 					/>
 				);

--- a/packages/components/src/number-control/types.ts
+++ b/packages/components/src/number-control/types.ts
@@ -8,11 +8,16 @@ export type NumberControlProps = Omit<
 	'isDragEnabled' | 'min' | 'max' | 'required' | 'step' | 'type' | 'value'
 > & {
 	/**
-	 * If true, the default `input` HTML arrows will be hidden.
+	 * The type of spin controls to display. These are butons that allow the
+	 * user to quickly increment and decrement the number.
 	 *
-	 * @default false
+	 * - 'none' - Do not show spin controls.
+	 * - 'native' - Use browser's native HTML `input` controls.
+	 * - 'custom' - Use plus and minus icon buttons.
+	 *
+	 * @default 'native'
 	 */
-	hideHTMLArrows?: boolean;
+	spinControls?: 'none' | 'native' | 'custom';
 	/**
 	 * If true, enables mouse drag gestures.
 	 *

--- a/packages/components/src/number-control/types.ts
+++ b/packages/components/src/number-control/types.ts
@@ -8,6 +8,13 @@ export type NumberControlProps = Omit<
 	'isDragEnabled' | 'min' | 'max' | 'required' | 'step' | 'type' | 'value'
 > & {
 	/**
+	 * If true, the default `input` HTML arrows will be hidden.
+	 *
+	 * @deprecated
+	 * @default false
+	 */
+	hideHTMLArrows?: boolean;
+	/**
 	 * The type of spin controls to display. These are butons that allow the
 	 * user to quickly increment and decrement the number.
 	 *

--- a/packages/components/src/unit-control/index.tsx
+++ b/packages/components/src/unit-control/index.tsx
@@ -6,8 +6,6 @@ import type {
 	KeyboardEvent,
 	ForwardedRef,
 	SyntheticEvent,
-	ChangeEvent,
-	PointerEvent,
 } from 'react';
 import classnames from 'classnames';
 
@@ -115,9 +113,7 @@ function UnforwardedUnitControl(
 	const handleOnQuantityChange = (
 		nextQuantityValue: number | string | undefined,
 		changeProps: {
-			event:
-				| ChangeEvent< HTMLInputElement >
-				| PointerEvent< HTMLInputElement >;
+			event: SyntheticEvent;
 		}
 	) => {
 		if (

--- a/packages/components/src/unit-control/index.tsx
+++ b/packages/components/src/unit-control/index.tsx
@@ -265,7 +265,7 @@ function UnforwardedUnitControl(
 			autoComplete={ autoComplete }
 			className={ classes }
 			disabled={ disabled }
-			hideHTMLArrows
+			spinControls="none"
 			isPressEnterToChange={ isPressEnterToChange }
 			label={ label }
 			onBlur={ handleOnBlur }

--- a/packages/components/src/unit-control/types.ts
+++ b/packages/components/src/unit-control/types.ts
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import type { FocusEventHandler, SyntheticEvent } from 'react';
+import type { FocusEventHandler } from 'react';
 
 /**
  * Internal dependencies
@@ -38,10 +38,9 @@ export type WPUnitControlUnit = {
 	step?: number;
 };
 
-export type UnitControlOnChangeCallback = InputChangeCallback<
-	SyntheticEvent< HTMLSelectElement | HTMLInputElement >,
-	{ data?: WPUnitControlUnit }
->;
+export type UnitControlOnChangeCallback = InputChangeCallback< {
+	data?: WPUnitControlUnit;
+} >;
 
 export type UnitSelectControlProps = Pick< InputControlProps, 'size' > & {
 	/**

--- a/packages/components/src/unit-control/types.ts
+++ b/packages/components/src/unit-control/types.ts
@@ -66,7 +66,7 @@ export type UnitSelectControlProps = Pick< InputControlProps, 'size' > & {
 };
 
 export type UnitControlProps = Omit< UnitSelectControlProps, 'unit' > &
-	Omit< NumberControlProps, 'hideHTMLArrows' | 'suffix' | 'type' > & {
+	Omit< NumberControlProps, 'spinControls' | 'suffix' | 'type' > & {
 		/**
 		 * If `true`, the unit `<select>` is hidden.
 		 *


### PR DESCRIPTION
## What?
Adds custom spin buttons (+ / - buttons) to `NumberControl`.

## Why?
So that controls such as _Line height_ in Global Styles match [the design](https://user-images.githubusercontent.com/612155/185020644-89e143f1-8ee1-4c38-8725-78001fd4b0fb.png), see https://github.com/WordPress/gutenberg/issues/34345#issuecomment-1217390408.

## How?
- The buttons are rendered within the existing `suffix` slot that `InputControl` has.
  - I considered adding a new prop to `InputControl` or using the context system, but using `suffix` works really well and requires minimal changes.
- Pressing the + and - buttons increases/decreases `value` by `step`. Values are clamped to be within `min` and `max`.
- The buttons are a progressive enhancement hidden from screen readers.
- We continue to use the browser's step buttons for the `'default'` and `'small'` sizes as these sizes don't have enough height to fit custom buttons.

## Testing Instructions
Check out the story book for `NumberControl` or go to Appearance → Editor → Global Styles → Typography → Text.

## Screenshots or screencast <!-- if applicable -->
https://user-images.githubusercontent.com/612155/198510968-562c95ad-11f0-4b85-ac82-92220e66dddd.mp4