### PR TITLE
Style Engine: Add support for dimensions.minHeight property

### DIFF
--- a/packages/style-engine/class-wp-style-engine.php
+++ b/packages/style-engine/class-wp-style-engine.php
@@ -161,7 +161,7 @@ final class WP_Style_Engine {
 					'spacing' => '--wp--preset--spacing--$slug',
 				),
 			),
-			'margin' => array(
+			'margin'  => array(
 				'property_keys' => array(
 					'default'    => 'margin',
 					'individual' => 'margin-%s',

--- a/packages/style-engine/class-wp-style-engine.php
+++ b/packages/style-engine/class-wp-style-engine.php
@@ -147,12 +147,26 @@ final class WP_Style_Engine {
 					'spacing' => '--wp--preset--spacing--$slug',
 				),
 			),
-			'margin'  => array(
+			'margin' => array(
 				'property_keys' => array(
 					'default'    => 'margin',
 					'individual' => 'margin-%s',
 				),
 				'path'          => array( 'spacing', 'margin' ),
+				'css_vars'      => array(
+					'spacing' => '--wp--preset--spacing--$slug',
+				),
+			),
+		),
+		'dimensions' => array(
+			'minHeight' => array(
+				'property_keys' => array(
+					'default' => 'min-height',
+				),
+				'path'          => array( 'dimensions', 'minHeight' ),
+				'classnames'    => array(
+					'has-$slug-font-size' => 'font-size',
+				),
 				'css_vars'      => array(
 					'spacing' => '--wp--preset--spacing--$slug',
 				),

--- a/packages/style-engine/class-wp-style-engine.php
+++ b/packages/style-engine/class-wp-style-engine.php
@@ -142,9 +142,6 @@ final class WP_Style_Engine {
 					'default' => 'min-height',
 				),
 				'path'          => array( 'dimensions', 'minHeight' ),
-				'classnames'    => array(
-					'has-$slug-font-size' => 'font-size',
-				),
 				'css_vars'      => array(
 					'spacing' => '--wp--preset--spacing--$slug',
 				),

--- a/packages/style-engine/class-wp-style-engine.php
+++ b/packages/style-engine/class-wp-style-engine.php
@@ -136,6 +136,20 @@ final class WP_Style_Engine {
 				),
 			),
 		),
+		'dimensions' => array(
+			'minHeight' => array(
+				'property_keys' => array(
+					'default' => 'min-height',
+				),
+				'path'          => array( 'dimensions', 'minHeight' ),
+				'classnames'    => array(
+					'has-$slug-font-size' => 'font-size',
+				),
+				'css_vars'      => array(
+					'spacing' => '--wp--preset--spacing--$slug',
+				),
+			),
+		),
 		'spacing'    => array(
 			'padding' => array(
 				'property_keys' => array(
@@ -153,20 +167,6 @@ final class WP_Style_Engine {
 					'individual' => 'margin-%s',
 				),
 				'path'          => array( 'spacing', 'margin' ),
-				'css_vars'      => array(
-					'spacing' => '--wp--preset--spacing--$slug',
-				),
-			),
-		),
-		'dimensions' => array(
-			'minHeight' => array(
-				'property_keys' => array(
-					'default' => 'min-height',
-				),
-				'path'          => array( 'dimensions', 'minHeight' ),
-				'classnames'    => array(
-					'has-$slug-font-size' => 'font-size',
-				),
 				'css_vars'      => array(
 					'spacing' => '--wp--preset--spacing--$slug',
 				),

--- a/packages/style-engine/src/styles/dimensions/index.ts
+++ b/packages/style-engine/src/styles/dimensions/index.ts
@@ -1,0 +1,19 @@
+/**
+ * Internal dependencies
+ */
+import type { Style, StyleOptions } from '../../types';
+import { generateRule } from '../utils';
+
+const minHeight = {
+	name: 'minHeight',
+	generate: ( style: Style, options: StyleOptions ) => {
+		return generateRule(
+			style,
+			options,
+			[ 'dimensions', 'minHeight' ],
+			'minHeight'
+		);
+	},
+};
+
+export default [ minHeight ];

--- a/packages/style-engine/src/styles/index.ts
+++ b/packages/style-engine/src/styles/index.ts
@@ -3,6 +3,7 @@
  */
 import border from './border';
 import color from './color';
+import dimensions from './dimensions';
 import shadow from './shadow';
 import outline from './outline';
 import spacing from './spacing';
@@ -11,6 +12,7 @@ import typography from './typography';
 export const styleDefinitions = [
 	...border,
 	...color,
+	...dimensions,
 	...outline,
 	...spacing,
 	...typography,

--- a/packages/style-engine/src/test/index.js
+++ b/packages/style-engine/src/test/index.js
@@ -54,6 +54,9 @@ describe( 'generate', () => {
 						gradient:
 							'linear-gradient(135deg,rgb(255,203,112) 0%,rgb(33,32,33) 42%,rgb(65,88,208) 100%)',
 					},
+					dimensions: {
+						minHeight: '50vh',
+					},
 					spacing: {
 						padding: { top: '10px', bottom: '5px' },
 						margin: {
@@ -85,7 +88,7 @@ describe( 'generate', () => {
 				}
 			)
 		).toEqual(
-			".some-selector { color: #cccccc; background: linear-gradient(135deg,rgb(255,203,112) 0%,rgb(33,32,33) 42%,rgb(65,88,208) 100%); background-color: #111111; outline-color: red; outline-style: dashed; outline-offset: 2px; outline-width: 4px; margin-top: 11px; margin-right: 12px; margin-bottom: 13px; margin-left: 14px; padding-top: 10px; padding-bottom: 5px; font-family: 'Helvetica Neue',sans-serif; font-size: 2.2rem; font-style: italic; font-weight: 800; letter-spacing: 12px; line-height: 3.3; text-decoration: line-through; text-transform: uppercase; }"
+			".some-selector { color: #cccccc; background: linear-gradient(135deg,rgb(255,203,112) 0%,rgb(33,32,33) 42%,rgb(65,88,208) 100%); background-color: #111111; min-height: 50vh; outline-color: red; outline-style: dashed; outline-offset: 2px; outline-width: 4px; margin-top: 11px; margin-right: 12px; margin-bottom: 13px; margin-left: 14px; padding-top: 10px; padding-bottom: 5px; font-family: 'Helvetica Neue',sans-serif; font-size: 2.2rem; font-style: italic; font-weight: 800; letter-spacing: 12px; line-height: 3.3; text-decoration: line-through; text-transform: uppercase; }"
 		);
 	} );
 
@@ -226,6 +229,9 @@ describe( 'getCSSRules', () => {
 						gradient:
 							'linear-gradient(135deg,rgb(255,203,112) 0%,rgb(33,32,33) 42%,rgb(65,88,208) 100%)',
 					},
+					dimensions: {
+						minHeight: '50vh',
+					},
 					spacing: {
 						padding: { top: '10px', bottom: '5px' },
 						margin: { right: '2em', left: '1vw' },
@@ -267,6 +273,11 @@ describe( 'getCSSRules', () => {
 				selector: '.some-selector',
 				key: 'backgroundColor',
 				value: '#555555',
+			},
+			{
+				selector: '.some-selector',
+				key: 'minHeight',
+				value: '50vh',
 			},
 			{
 				selector: '.some-selector',

--- a/packages/style-engine/src/types.ts
+++ b/packages/style-engine/src/types.ts
@@ -38,6 +38,9 @@ export interface Style {
 		bottom?: BorderIndividualStyles< 'bottom' >;
 		left?: BorderIndividualStyles< 'left' >;
 	};
+	dimensions?: {
+		minHeight?: CSSProperties[ 'minHeight' ];
+	};
 	spacing?: {
 		margin?: CSSProperties[ 'margin' ] | Box< 'margin' >;
 		padding?: CSSProperties[ 'padding' ] | Box< 'padding' >;

--- a/phpunit/style-engine/style-engine-test.php
+++ b/phpunit/style-engine/style-engine-test.php
@@ -173,7 +173,7 @@ class WP_Style_Engine_Test extends WP_UnitTestCase {
 				'expected_output' => array(
 					'css'          => 'min-height:50vh;',
 					'declarations' => array(
-						'min-height'      => '50vh',
+						'min-height' => '50vh',
 					),
 				),
 			),

--- a/phpunit/style-engine/style-engine-test.php
+++ b/phpunit/style-engine/style-engine-test.php
@@ -163,6 +163,21 @@ class WP_Style_Engine_Test extends WP_UnitTestCase {
 				),
 			),
 
+			'inline_valid_dimensions_style'                => array(
+				'block_styles'    => array(
+					'dimensions' => array(
+						'minHeight' => '50vh',
+					),
+				),
+				'options'         => null,
+				'expected_output' => array(
+					'css'          => 'min-height:50vh;',
+					'declarations' => array(
+						'min-height'      => '50vh',
+					),
+				),
+			),
+
 			'inline_valid_typography_style'                => array(
 				'block_styles'    => array(
 					'typography' => array(


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

This PR is split out from https://github.com/WordPress/gutenberg/pull/45300 and looks at adding support in the style engine for outputting the `min-height` CSS property when it exists in `dimensions.minHeight` within the style object.

Note: this PR only adds support to the style engine for outputting this rule based on its presence in the style object. The full support for minHeight is being explored in #45300, but it's easier for review and cleaner for commit history if we split the work into component parts.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

Min-height is already supported in `safecss_filter_attr` and will be quite useful for Group and Post Content blocks. The structure of storing it under a `dimensions` object is consistent with earlier explorations into width and height support.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

* Add `minHeight` handling in the JS implementation of the style engine
* Add `dimensions` array to `BLOCK_STYLE_DEFINITIONS_METADATA` in PHP
* Add to existing tests and / or add additional tests

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->

Ensure tests pass or run manually:

```bash
# JS tests
npm run test:unit -- --testPathPattern packages/style-engine/src/test/index.js
# PHP tests
npm run test:unit:php -- --filter WP_Style_Engine_test
```

Smoke test adding a group block and site title block in the editor, save, and view on the site frontend — ensure nothing broke.

<details>

<summary>Here's some quick smoke test block markup</summary>

```html
<!-- wp:group {"style":{"spacing":{"padding":{"top":"var:preset|spacing|30","right":"var:preset|spacing|30","bottom":"var:preset|spacing|30","left":"var:preset|spacing|30"}},"border":{"color":"#771010","width":"7px"},"color":{"background":"#c16767","text":"#ece6e6"}},"layout":{"type":"constrained"}} -->
<div class="wp-block-group has-border-color has-text-color has-background" style="border-color:#771010;border-width:7px;color:#ece6e6;background-color:#c16767;padding-top:var(--wp--preset--spacing--30);padding-right:var(--wp--preset--spacing--30);padding-bottom:var(--wp--preset--spacing--30);padding-left:var(--wp--preset--spacing--30)"><!-- wp:paragraph -->
<p>A paragraph</p>
<!-- /wp:paragraph --></div>
<!-- /wp:group -->

<!-- wp:site-title {"style":{"typography":{"fontStyle":"normal","fontWeight":"400","letterSpacing":"20px"}}} /-->
```

</details>