### PR TITLE
Lodash: Refactor blocks away from `_.some()`

### DIFF
--- a/packages/blocks/src/store/actions.js
+++ b/packages/blocks/src/store/actions.js
@@ -2,7 +2,7 @@
  * External dependencies
  */
 import { isPlainObject } from 'is-plain-object';
-import { pick, some } from 'lodash';
+import { pick } from 'lodash';
 
 /**
  * WordPress dependencies
@@ -114,9 +114,9 @@ const processBlockType = ( blockType, { select } ) => {
 
 	if (
 		'category' in settings &&
-		! some( select.getCategories(), {
-			slug: settings.category,
-		} )
+		! select
+			.getCategories()
+			.some( ( { slug } ) => slug === settings.category )
 	) {
 		warn(
 			'The block "' +

--- a/packages/blocks/src/store/selectors.js
+++ b/packages/blocks/src/store/selectors.js
@@ -3,7 +3,7 @@
  */
 import createSelector from 'rememo';
 import removeAccents from 'remove-accents';
-import { filter, get, map, some } from 'lodash';
+import { filter, get, map } from 'lodash';
 
 /**
  * WordPress dependencies
@@ -715,7 +715,7 @@ export function isMatchingSearchTerm( state, nameOrType, searchTerm ) {
 
 	return (
 		isSearchMatch( blockType.title ) ||
-		some( blockType.keywords, isSearchMatch ) ||
+		blockType.keywords?.some( isSearchMatch ) ||
 		isSearchMatch( blockType.category ) ||
 		( typeof blockType.description === 'string' &&
 			isSearchMatch( blockType.description ) )
@@ -792,7 +792,7 @@ export const hasChildBlocks = ( state, blockName ) => {
  *                   and false otherwise.
  */
 export const hasChildBlocksWithInserterSupport = ( state, blockName ) => {
-	return some( getChildBlockNames( state, blockName ), ( childBlockName ) => {
+	return getChildBlockNames( state, blockName ).some( ( childBlockName ) => {
 		return hasBlockSupport( state, childBlockName, 'inserter', true );
 	} );
 };


### PR DESCRIPTION
## What?
This PR removes Lodash's `_.some()` from the blocks package. There are just a few usages and conversion is pretty straightforward. 

## Why?

Lodash is known to unnecessarily inflate the bundle size of packages, and in most cases, it can be replaced with native language functionality. See these for more information and rationale:

* https://github.com/WordPress/gutenberg/issues/16938#issuecomment-602837246
* https://github.com/WordPress/gutenberg/issues/17025
* https://github.com/WordPress/gutenberg/issues/39495 

## How?

We're replacing a few usages with a simple native `Array.prototype.some()`. 

## Testing Instructions

* Register a block type which does not have an assigned category, or which has an invalid category. You could alter the settings of a core block, (paragraph for example), to remove or alter the "category" field. Then, verify that the block is shown under the "Uncategorized" category within the block inserter and Block Manager. You should also still be seeing a warning, saying `The block "core/paragraph" is registered with an invalid category "foobar".`
* In the inserter, try looking for "music" or "ebook" and verify the same relevant blocks still appear.
* Verify all checks are green and tests pass.