### PR TITLE
InputControl: Allow inline styles to be applied to wrapper instead of inner input

### DIFF
--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -35,6 +35,7 @@
 -   `FontSizePicker`: Fallback to font size `slug` if `name` is undefined ([#45041](https://github.com/WordPress/gutenberg/pull/45041)).
 -   `AutocompleterUI`: fix issue where autocompleter UI would appear on top of other UI elements ([#44795](https://github.com/WordPress/gutenberg/pull/44795/))
 -   `ExternalLink`: Fix to re-enable support for `onClick` event handler ([#45214](https://github.com/WordPress/gutenberg/pull/45214)).
+-   `InputControl`: Allow inline styles to be applied to the wrapper not inner input ([#45340](https://github.com/WordPress/gutenberg/pull/45340/))
 
 ### Internal
 

--- a/packages/components/src/input-control/index.tsx
+++ b/packages/components/src/input-control/index.tsx
@@ -45,6 +45,7 @@ export function UnforwardedInputControl(
 		onKeyDown = noop,
 		prefix,
 		size = 'default',
+		style,
 		suffix,
 		value,
 		...props
@@ -77,6 +78,7 @@ export function UnforwardedInputControl(
 			labelPosition={ labelPosition }
 			prefix={ prefix }
 			size={ size }
+			style={ style }
 			suffix={ suffix }
 		>
 			<InputField

--- a/packages/components/src/input-control/input-base.tsx
+++ b/packages/components/src/input-control/input-base.tsx
@@ -31,7 +31,7 @@ function useUniqueId( idProp?: string ) {
 	return idProp || id;
 }
 
-// Adapter to map props for the new ui/flex compopnent.
+// Adapter to map props for the new ui/flex component.
 function getUIFlexProps( labelPosition?: LabelPosition ) {
 	const props: { direction?: string; gap?: number; justify?: string } = {};
 	switch ( labelPosition ) {

--- a/packages/components/src/input-control/input-base.tsx
+++ b/packages/components/src/input-control/input-base.tsx
@@ -22,7 +22,7 @@ import {
 	getSizeConfig,
 } from './styles/input-control-styles';
 import type { InputBaseProps, LabelPosition } from './types';
-import { ContextSystemProvider } from '../ui/context';
+import { ContextSystemProvider, WordPressComponentProps } from '../ui/context';
 
 function useUniqueId( idProp?: string ) {
 	const instanceId = useInstanceId( InputBase );
@@ -67,7 +67,7 @@ export function InputBase(
 		size = 'default',
 		suffix,
 		...props
-	}: InputBaseProps,
+	}: WordPressComponentProps< InputBaseProps, 'div' >,
 	ref: ForwardedRef< HTMLDivElement >
 ) {
 	const id = useUniqueId( idProp );

--- a/packages/components/src/input-control/types.ts
+++ b/packages/components/src/input-control/types.ts
@@ -166,18 +166,9 @@ export interface InputBaseProps extends BaseProps, FlexProps {
 	 */
 	disabled?: boolean;
 	/**
-	 * The class name to be added to the wrapper element.
-	 */
-	className?: string;
-	id?: string;
-	/**
 	 * If this property is added, a label will be generated using label property as the content.
 	 */
 	label?: ReactNode;
-	/**
-	 * If this property is added, it will be added to the modal frame `div`.
-	 */
-	style?: CSSProperties;
 }
 
 export interface InputControlProps

--- a/packages/components/src/input-control/types.ts
+++ b/packages/components/src/input-control/types.ts
@@ -174,6 +174,10 @@ export interface InputBaseProps extends BaseProps, FlexProps {
 	 * If this property is added, a label will be generated using label property as the content.
 	 */
 	label?: ReactNode;
+	/**
+	 * If this property is added, it will be added to the modal frame `div`.
+	 */
+	style?: CSSProperties;
 }
 
 export interface InputControlProps

--- a/packages/components/src/input-control/types.ts
+++ b/packages/components/src/input-control/types.ts
@@ -121,12 +121,7 @@ export interface InputFieldProps extends BaseProps {
 	type?: HTMLInputTypeAttribute;
 }
 
-export interface InputBaseProps
-	extends Pick<
-			WordPressComponentProps< BaseProps, 'div' >,
-			'className' | 'id' | 'style' | keyof BaseProps
-		>,
-		FlexProps {
+export interface InputBaseProps extends BaseProps, FlexProps {
 	children: ReactNode;
 	/**
 	 * Renders an element on the left side of the input.
@@ -171,9 +166,18 @@ export interface InputBaseProps
 	 */
 	disabled?: boolean;
 	/**
+	 * The class name to be added to the wrapper element.
+	 */
+	className?: string;
+	id?: string;
+	/**
 	 * If this property is added, a label will be generated using label property as the content.
 	 */
 	label?: ReactNode;
+	/**
+	 * If this property is added, it will be added to the modal frame `div`.
+	 */
+	style?: CSSProperties;
 }
 
 export interface InputControlProps

--- a/packages/components/src/input-control/types.ts
+++ b/packages/components/src/input-control/types.ts
@@ -121,7 +121,12 @@ export interface InputFieldProps extends BaseProps {
 	type?: HTMLInputTypeAttribute;
 }
 
-export interface InputBaseProps extends BaseProps, FlexProps {
+export interface InputBaseProps
+	extends Pick<
+			WordPressComponentProps< BaseProps, 'div' >,
+			'className' | 'id' | 'style' | keyof BaseProps
+		>,
+		FlexProps {
 	children: ReactNode;
 	/**
 	 * Renders an element on the left side of the input.
@@ -166,18 +171,9 @@ export interface InputBaseProps extends BaseProps, FlexProps {
 	 */
 	disabled?: boolean;
 	/**
-	 * The class name to be added to the wrapper element.
-	 */
-	className?: string;
-	id?: string;
-	/**
 	 * If this property is added, a label will be generated using label property as the content.
 	 */
 	label?: ReactNode;
-	/**
-	 * If this property is added, it will be added to the modal frame `div`.
-	 */
-	style?: CSSProperties;
 }
 
 export interface InputControlProps


### PR DESCRIPTION
Related:
- https://github.com/WordPress/gutenberg/pull/45139

## What?

- Updates the InputControl to apply any passed inline styles to the wrapper rather than the inner input.

## Why?

When https://github.com/WordPress/gutenberg/pull/45139 removed the outer wrapper it allowed inline styles to be passed to the inner input rather than the InputControl's outer wrapper.

Applying them to the outer wrapper appears to be the expected behaviour. A number of blocks control's were just updated to remove passing of inline styles to restrict the control's outer width (https://github.com/WordPress/gutenberg/pull/45329). 

It also turns out the block gap control passes a CSS grid style to achieve it's layout. This won't work without this fix.

## How?

 Destructure the inline style prop for the `InputBase` component and pass it to the wrapper instead of the input via the rest props.

## Testing Instructions
1. On trunk, edit a post, add a group block, select it and switch to a custom block gap
2. Note the broken layout for this control.
3. Checkout this PR, reload the editor and navigate back to the block gap control
4. The layout should be fixed.


## Screenshots or screencast <!-- if applicable -->

| Before | After |
|---|---|
| <img width="279" alt="Screen Shot 2022-10-27 at 5 28 28 pm" src="https://user-images.githubusercontent.com/60436221/198244896-c294d603-abcf-4eda-9c93-d4da5ba97b1f.png"> | <img width="278" alt="Screen Shot 2022-10-27 at 7 14 57 pm" src="https://user-images.githubusercontent.com/60436221/198244473-48099e64-54a9-46f5-a038-7dcd6a8c0691.png"> |

## ✍️ Dev Note 

In order to improve consistency across the `@wordpress/components` package, any inline styles passed to the `InputControl` component through its `style` prop will be applied to its outer wrapper element, instead of an inner input wrapper element.

These changes may also affect usages of other components relying on `InputControl`, such as `NumberControl` and `UnitControl`.