### PR TITLE
Lodash: Refactor editor away from `_.some()`

### DIFF
--- a/packages/editor/src/components/entities-saved-states/entity-type-list.js
+++ b/packages/editor/src/components/entities-saved-states/entity-type-list.js
@@ -1,9 +1,4 @@
 /**
- * External dependencies
- */
-import { some } from 'lodash';
-
-/**
  * WordPress dependencies
  */
 import { __ } from '@wordpress/i18n';
@@ -67,8 +62,7 @@ export default function EntityTypeList( {
 						key={ record.key || record.property }
 						record={ record }
 						checked={
-							! some(
-								unselectedEntities,
+							! unselectedEntities.some(
 								( elt ) =>
 									elt.kind === record.kind &&
 									elt.name === record.name &&

--- a/packages/editor/src/components/entities-saved-states/index.js
+++ b/packages/editor/src/components/entities-saved-states/index.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { some, groupBy } from 'lodash';
+import { groupBy } from 'lodash';
 
 /**
  * WordPress dependencies
@@ -127,8 +127,7 @@ export default function EntitiesSavedStates( { close } ) {
 	const saveCheckedEntities = () => {
 		const entitiesToSave = dirtyEntityRecords.filter(
 			( { kind, name, key, property } ) => {
-				return ! some(
-					unselectedEntities,
+				return ! unselectedEntities.some(
 					( elt ) =>
 						elt.kind === kind &&
 						elt.name === name &&

--- a/packages/editor/src/components/post-publish-button/index.js
+++ b/packages/editor/src/components/post-publish-button/index.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { get, some } from 'lodash';
+import { get } from 'lodash';
 import classnames from 'classnames';
 
 /**
@@ -77,8 +77,7 @@ export class PostPublishButton extends Component {
 		this.setState( { entitiesSavedStatesCallback: false }, () => {
 			if (
 				savedEntities &&
-				some(
-					savedEntities,
+				savedEntities.some(
 					( elt ) =>
 						elt.kind === 'postType' &&
 						elt.name === postType &&

--- a/packages/editor/src/components/post-publish-panel/maybe-category-panel.js
+++ b/packages/editor/src/components/post-publish-panel/maybe-category-panel.js
@@ -1,9 +1,4 @@
 /**
- * External dependencies
- */
-import { some } from 'lodash';
-
-/**
  * WordPress dependencies
  */
 import { __ } from '@wordpress/i18n';
@@ -34,7 +29,7 @@ function MaybeCategoryPanel() {
 		);
 		const postTypeSupportsCategories =
 			categoriesTaxonomy &&
-			some( categoriesTaxonomy.types, ( type ) => type === postType );
+			categoriesTaxonomy.types.some( ( type ) => type === postType );
 		const categories =
 			categoriesTaxonomy &&
 			select( editorStore ).getEditedPostAttribute(

--- a/packages/editor/src/components/post-publish-panel/maybe-tags-panel.js
+++ b/packages/editor/src/components/post-publish-panel/maybe-tags-panel.js
@@ -1,9 +1,4 @@
 /**
- * External dependencies
- */
-import { some } from 'lodash';
-
-/**
  * WordPress dependencies
  */
 import { __ } from '@wordpress/i18n';
@@ -79,7 +74,7 @@ export default compose(
 			areTagsFetched: tagsTaxonomy !== undefined,
 			isPostTypeSupported:
 				tagsTaxonomy &&
-				some( tagsTaxonomy.types, ( type ) => type === postType ),
+				tagsTaxonomy.types.some( ( type ) => type === postType ),
 			hasTags: tags && tags.length,
 		};
 	} ),

--- a/packages/editor/src/components/post-taxonomies/check.js
+++ b/packages/editor/src/components/post-taxonomies/check.js
@@ -1,9 +1,4 @@
 /**
- * External dependencies
- */
-import { some } from 'lodash';
-
-/**
  * WordPress dependencies
  */
 import { compose } from '@wordpress/compose';
@@ -16,7 +11,7 @@ import { store as coreStore } from '@wordpress/core-data';
 import { store as editorStore } from '../../store';
 
 export function PostTaxonomiesCheck( { postType, taxonomies, children } ) {
-	const hasTaxonomies = some( taxonomies, ( taxonomy ) =>
+	const hasTaxonomies = taxonomies?.some( ( taxonomy ) =>
 		taxonomy.types.includes( postType )
 	);
 	if ( ! hasTaxonomies ) {

--- a/packages/editor/src/components/post-taxonomies/hierarchical-term-selector.js
+++ b/packages/editor/src/components/post-taxonomies/hierarchical-term-selector.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { find, get, some, unescape as unescapeString } from 'lodash';
+import { find, get, unescape as unescapeString } from 'lodash';
 
 /**
  * WordPress dependencies
@@ -290,7 +290,7 @@ export function HierarchicalTermSelector( { slug } ) {
 		const existingTerm = findTerm( availableTerms, formParent, formName );
 		if ( existingTerm ) {
 			// If the term we are adding exists but is not selected select it.
-			if ( ! some( terms, ( term ) => term === existingTerm.id ) ) {
+			if ( ! terms.some( ( term ) => term === existingTerm.id ) ) {
 				onUpdateTerms( [ ...terms, existingTerm.id ] );
 			}
 

--- a/packages/editor/src/components/post-type-support-check/index.js
+++ b/packages/editor/src/components/post-type-support-check/index.js
@@ -1,9 +1,4 @@
 /**
- * External dependencies
- */
-import { some } from 'lodash';
-
-/**
  * WordPress dependencies
  */
 import { withSelect } from '@wordpress/data';
@@ -30,10 +25,9 @@ import { store as editorStore } from '../../store';
 export function PostTypeSupportCheck( { postType, children, supportKeys } ) {
 	let isSupported = true;
 	if ( postType ) {
-		isSupported = some(
-			Array.isArray( supportKeys ) ? supportKeys : [ supportKeys ],
-			( key ) => !! postType.supports[ key ]
-		);
+		isSupported = (
+			Array.isArray( supportKeys ) ? supportKeys : [ supportKeys ]
+		 ).some( ( key ) => !! postType.supports[ key ] );
 	}
 
 	if ( ! isSupported ) {

--- a/packages/editor/src/components/theme-support-check/index.js
+++ b/packages/editor/src/components/theme-support-check/index.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { get, some } from 'lodash';
+import { get } from 'lodash';
 
 /**
  * WordPress dependencies
@@ -20,20 +20,19 @@ export function ThemeSupportCheck( {
 	postType,
 	supportKeys,
 } ) {
-	const isSupported = some(
-		Array.isArray( supportKeys ) ? supportKeys : [ supportKeys ],
-		( key ) => {
-			const supported = get( themeSupports, [ key ], false );
-			// 'post-thumbnails' can be boolean or an array of post types.
-			// In the latter case, we need to verify `postType` exists
-			// within `supported`. If `postType` isn't passed, then the check
-			// should fail.
-			if ( 'post-thumbnails' === key && Array.isArray( supported ) ) {
-				return supported.includes( postType );
-			}
-			return supported;
+	const isSupported = (
+		Array.isArray( supportKeys ) ? supportKeys : [ supportKeys ]
+	 ).some( ( key ) => {
+		const supported = get( themeSupports, [ key ], false );
+		// 'post-thumbnails' can be boolean or an array of post types.
+		// In the latter case, we need to verify `postType` exists
+		// within `supported`. If `postType` isn't passed, then the check
+		// should fail.
+		if ( 'post-thumbnails' === key && Array.isArray( supported ) ) {
+			return supported.includes( postType );
 		}
-	);
+		return supported;
+	} );
 
 	if ( ! isSupported ) {
 		return null;


### PR DESCRIPTION
## What?
This PR removes Lodash's `_.some()` from the editor package. There are just a few usages and conversion is pretty straightforward. 

## Why?

Lodash is known to unnecessarily inflate the bundle size of packages, and in most cases, it can be replaced with native language functionality. See these for more information and rationale:

* https://github.com/WordPress/gutenberg/issues/16938#issuecomment-602837246
* https://github.com/WordPress/gutenberg/issues/17025
* https://github.com/WordPress/gutenberg/issues/39495 

## How?

We're replacing a few usages with a simple native `Array.prototype.some()`. 

## Testing Instructions
* In the site editor, when saving, verify that entities - site, templates, and template parts - are still checkable/uncheckable, also listed, and saved correctly.
* When publishing a new post without a selected tag and category, verify you still get the suggestions to add a tag and category in the pre-publish panel and they work and look the same as before.
* Verify the post editor still contains sidebar settings to set a tag and category and they work as before. Make sure to try creating an existing category.
* Verify that the featured image section in the post editor sidebar appears properly based on whether it's supported by the post type AND the theme.
* Verify all checks are green and tests pass.