### PR TITLE
Safari selection: Try inline list fix

### DIFF
--- a/packages/block-library/src/editor.scss
+++ b/packages/block-library/src/editor.scss
@@ -21,6 +21,7 @@
 @import "./html/editor.scss";
 @import "./image/editor.scss";
 @import "./latest-posts/editor.scss";
+@import "./list/editor.scss";
 @import "./media-text/editor.scss";
 @import "./more/editor.scss";
 @import "./navigation/editor.scss";

--- a/packages/block-library/src/list/editor.scss
+++ b/packages/block-library/src/list/editor.scss
@@ -1,0 +1,9 @@
+// In Safari, every nested block level element in a hierarchy gets highlighted
+// by a text selection marker, causing a stacked and incorrect appearance.
+// By forcing the editable to be full-width inline-block, this appearance is improved.
+.wp-block-list {
+	> li.block-editor-block-list__block > div.block-editor-rich-text__editable {
+		display: inline-block;
+		width: 100%;
+	}
+}


### PR DESCRIPTION
## What?

Safari stacks all block level selections. So complex nesting levels in text are usually a source of weird looking selection rectangles, such as this in the List block:

![list selection before](https://user-images.githubusercontent.com/1204802/198252928-3c549ca5-b2c8-445a-9f0c-c086c231022d.gif)

As best I can tell, this happens because the structure of the list block is one of `ul > li > div`, with the `div` here being the rich text editable. Compare this to the Paragraph, which is just `p`, as opposed to `p > div`. Since both `li` and `div` are block level with different properties such as line-heights and such, the marker is awkward.

If we change the div to `inline`, it looks pretty good, however that also makes an empty list item have a very small clickable area:

![list selection after, inline](https://user-images.githubusercontent.com/1204802/198253678-382242e1-4733-46ef-9331-d225ffe0e67e.gif)

Changing to inline-block plus 100% width looks okay, and doesn't appear to have this issue, which is why this PR goes that route:

![list selection after, inline block](https://user-images.githubusercontent.com/1204802/198253782-16edf5a2-1124-4d27-8bf3-dbc48baf7dff.gif)

However it's somewhat intrusive CSS. I wonder: could the `li` item itself become the editable? CC: @ellatrix 


## Testing Instructions

Use the Gutenberg test content, and select list items inside Safari. Observe a more accurate selection marker with this PR applied.