### PR TITLE
Edit Post: Improve distraction-free mode notices

### DIFF
--- a/packages/edit-post/src/components/keyboard-shortcuts/index.js
+++ b/packages/edit-post/src/components/keyboard-shortcuts/index.js
@@ -7,7 +7,7 @@ import {
 	useShortcut,
 	store as keyboardShortcutsStore,
 } from '@wordpress/keyboard-shortcuts';
-import { __, sprintf } from '@wordpress/i18n';
+import { __ } from '@wordpress/i18n';
 import { store as editorStore } from '@wordpress/editor';
 import { store as blockEditorStore } from '@wordpress/block-editor';
 import { store as noticesStore } from '@wordpress/notices';
@@ -168,14 +168,12 @@ function KeyboardShortcuts() {
 		setIsListViewOpened( false );
 		toggleDistractionFree();
 		toggleFeature( 'distractionFree' );
-		const modeState = isFeatureActive( 'distractionFree' )
-			? __( 'on' )
-			: __( 'off' );
 		createInfoNotice(
-			// translators: Mode of distraction free can be 'on' or 'off';
-			sprintf( __( 'Distraction free mode turned %s.' ), modeState ),
+			isFeatureActive( 'distractionFree' )
+				? __( 'Distraction free mode turned on.' )
+				: __( 'Distraction free mode turned off.' ),
 			{
-				speak: true,
+				id: 'core/edit-post/distraction-free-mode/notice',
 				type: 'snackbar',
 			}
 		);


### PR DESCRIPTION
## What?
PR contains the following improvements for the "Distraction Free" mode notice:

* Use `id` for notice to avoid flooding the screen with snackbars if you toggle the mode multiple times.
* Avoid concatenation of two translatable strings using `sprintf`. Since we already know both strings, let's use them. It should make translation easier in some languages.

## Testing Instructions
1. Open a Post or Page.
2. Toggle the "Distraction Free" mode on and off.
3. Confirm that only a single snackbar is displayed with the correct message.

## Screenshots or screencast <!-- if applicable -->

![CleanShot 2022-10-27 at 16 45 21](https://user-images.githubusercontent.com/240569/198288019-a6160853-0b6d-4541-8fbd-4acd068f7cc5.png)

