### PR TITLE
[Documentation] Character Swap

### DIFF
--- a/docs/reference-guides/block-api/block-metadata.md
+++ b/docs/reference-guides/block-api/block-metadata.md
@@ -13,7 +13,7 @@ Starting in WordPress 5.8 release, we encourage using the `block.json` metadata 
 	"category": "text",
 	"parent": [ "core/group" ],
 	"icon": "star",
-	"description": "Shows warning, error or success notices…",
+	"description": "Shows warning, error or success notices...",
 	"keywords": [ "alert", "message" ],
 	"version": "1.0.3",
 	"textdomain": "my-plugin",


### PR DESCRIPTION
Ellipsis character in the example causes the register_block_type to not register the metadata because the json_decode silently errors with "Malformed UTF-8 characters".

<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->
Improving an example in the documentation.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
If you use this json example as a base but do not change the description value (to remove that character) this file is rendered useless.  Change could save time for someone else.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
Replacing the ellipsis character with 3 periods

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
1 - Copy and pasted example file into block.json (optional - update values to match your setup but leave description value)
2 - Use register_block_type with block.json file path
3 - Be sad that register_block_type did nothing

## Screenshots or screencast <!-- if applicable -->
