### PR TITLE
Remove use of `set-output` in workflows

### DIFF
--- a/.github/workflows/build-plugin-zip.yml
+++ b/.github/workflows/build-plugin-zip.yml
@@ -96,7 +96,7 @@ jobs:
                   echo "new_version=${NEW_VERSION}" >> $GITHUB_OUTPUT
                   IFS='.' read -r -a NEW_VERSION_ARRAY <<< "$NEW_VERSION"
                   RELEASE_BRANCH="release/${NEW_VERSION_ARRAY[0]}.${NEW_VERSION_ARRAY[1]}"
-                  echo "release_branch=$(echo $RELEASE_BRANCH)" >> $GITHUB_OUTPUT
+                  echo "release_branch=${RELEASE_BRANCH}" >> $GITHUB_OUTPUT
 
             - name: Configure git user name and email
               run: |

--- a/.github/workflows/build-plugin-zip.yml
+++ b/.github/workflows/build-plugin-zip.yml
@@ -36,11 +36,11 @@ jobs:
                     "https://api.github.com/repos/${{ github.repository }}/releases/latest"
                   LATEST_STABLE_TAG=$(jq --raw-output '.tag_name' latest.json)
                   IFS='.' read LATEST_STABLE_MAJOR LATEST_STABLE_MINOR LATEST_STABLE_PATCH <<< "${LATEST_STABLE_TAG#v}"
-                  echo "::set-output name=current_stable_branch::release/${LATEST_STABLE_MAJOR}.${LATEST_STABLE_MINOR}"
+                  echo "current_stable_branch=release/${LATEST_STABLE_MAJOR}.${LATEST_STABLE_MINOR}" >> $GITHUB_OUTPUT
                   if [[ ${LATEST_STABLE_MINOR} == "9" ]]; then
-                    echo "::set-output name=next_stable_branch::release/$((LATEST_STABLE_MAJOR + 1)).0"
+                    echo "next_stable_branch=release/$((LATEST_STABLE_MAJOR + 1)).0" >> $GITHUB_OUTPUT
                   else
-                    echo "::set-output name=next_stable_branch::release/${LATEST_STABLE_MAJOR}.$((LATEST_STABLE_MINOR + 1))"
+                    echo "next_stable_branch=release/${LATEST_STABLE_MAJOR}.$((LATEST_STABLE_MINOR + 1))" >> $GITHUB_OUTPUT
                   fi
 
     bump-version:
@@ -77,7 +77,7 @@ jobs:
               id: get_version
               run: |
                   OLD_VERSION=$(jq --raw-output '.version' package.json)
-                  echo "::set-output name=old_version::$(echo $OLD_VERSION)"
+                  echo "old_version=$(echo $OLD_VERSION)" >> $GITHUB_OUTPUT
                   if [[ ${{ github.event.inputs.version }} == 'stable' ]]; then
                     NEW_VERSION=$(npx semver $OLD_VERSION -i patch)
                   else
@@ -93,10 +93,10 @@ jobs:
                       fi
                     fi
                   fi
-                  echo "::set-output name=new_version::$(echo $NEW_VERSION)"
+                  echo "new_versio=$(echo $NEW_VERSION)" >> $GITHUB_OUTPUT
                   IFS='.' read -r -a NEW_VERSION_ARRAY <<< "$NEW_VERSION"
                   RELEASE_BRANCH="release/${NEW_VERSION_ARRAY[0]}.${NEW_VERSION_ARRAY[1]}"
-                  echo "::set-output name=release_branch::$(echo $RELEASE_BRANCH)"
+                  echo "release_branch=$(echo $RELEASE_BRANCH)" >> $GITHUB_OUTPUT
 
             - name: Configure git user name and email
               run: |
@@ -131,7 +131,7 @@ jobs:
                   git add gutenberg.php package.json package-lock.json
                   git commit -m "Bump plugin version to ${{ steps.get_version.outputs.new_version }}"
                   git push --set-upstream origin "${{ steps.get_version.outputs.release_branch }}"
-                  echo "::set-output name=version_bump_commit::$(git rev-parse --verify --short HEAD)"
+                  echo "version_bump_commit=$(git rev-parse --verify --short HEAD)" >> $GITHUB_OUTPUT
 
             - name: Fetch trunk
               if: ${{ github.ref != 'refs/heads/trunk' }}
@@ -146,7 +146,7 @@ jobs:
                   if [[ ${{ steps.get_version.outputs.old_version }} == "$TRUNK_VERSION" ]]; then
                     git cherry-pick "${{ steps.get_version.outputs.release_branch }}"
                     git push
-                    echo "::set-output name=version_bump_commit::$(git rev-parse --verify --short HEAD)"
+                    echo "version_bump_commit=$(git rev-parse --verify --short HEAD)" >> $GITHUB_OUTPUT
                   fi
 
     build:
@@ -263,7 +263,7 @@ jobs:
               id: get_release_version
               env:
                   VERSION: ${{ needs.bump-version.outputs.new_version }}
-              run: echo ::set-output name=version::$(echo $VERSION | cut -d / -f 3 | sed 's/-rc./ RC/' )
+              run: echo "version=$(echo $VERSION | cut -d / -f 3 | sed 's/-rc./ RC/' )" >> $GITHUB_OUTPUT
 
             - name: Download Plugin Zip Artifact
               uses: actions/download-artifact@9782bd6a9848b53b110e712e20e42d89988822b7 # v3.0.1

--- a/.github/workflows/build-plugin-zip.yml
+++ b/.github/workflows/build-plugin-zip.yml
@@ -77,7 +77,7 @@ jobs:
               id: get_version
               run: |
                   OLD_VERSION=$(jq --raw-output '.version' package.json)
-                  echo "old_version=$(echo $OLD_VERSION)" >> $GITHUB_OUTPUT
+                  echo "old_version=${OLD_VERSION}" >> $GITHUB_OUTPUT
                   if [[ ${{ github.event.inputs.version }} == 'stable' ]]; then
                     NEW_VERSION=$(npx semver $OLD_VERSION -i patch)
                   else

--- a/.github/workflows/build-plugin-zip.yml
+++ b/.github/workflows/build-plugin-zip.yml
@@ -93,7 +93,7 @@ jobs:
                       fi
                     fi
                   fi
-                  echo "new_versio=$(echo $NEW_VERSION)" >> $GITHUB_OUTPUT
+                  echo "new_version=${NEW_VERSION}" >> $GITHUB_OUTPUT
                   IFS='.' read -r -a NEW_VERSION_ARRAY <<< "$NEW_VERSION"
                   RELEASE_BRANCH="release/${NEW_VERSION_ARRAY[0]}.${NEW_VERSION_ARRAY[1]}"
                   echo "release_branch=$(echo $RELEASE_BRANCH)" >> $GITHUB_OUTPUT

--- a/.github/workflows/upload-release-to-plugin-repo.yml
+++ b/.github/workflows/upload-release-to-plugin-repo.yml
@@ -20,7 +20,7 @@ jobs:
               run: |
                   IFS='.' read -r -a VERSION_ARRAY <<< "${TAG#v}"
                   RELEASE_BRANCH="release/${VERSION_ARRAY[0]}.${VERSION_ARRAY[1]}"
-                  echo "release_branch=$(echo $RELEASE_BRANCH)" >> $GITHUB_OUTPUT
+                  echo "release_branch=${RELEASE_BRANCH}" >> $GITHUB_OUTPUT
 
     update-changelog:
         name: Update Changelog on ${{ matrix.branch }} branch

--- a/.github/workflows/upload-release-to-plugin-repo.yml
+++ b/.github/workflows/upload-release-to-plugin-repo.yml
@@ -20,7 +20,7 @@ jobs:
               run: |
                   IFS='.' read -r -a VERSION_ARRAY <<< "${TAG#v}"
                   RELEASE_BRANCH="release/${VERSION_ARRAY[0]}.${VERSION_ARRAY[1]}"
-                  echo "::set-output name=release_branch::$(echo $RELEASE_BRANCH)"
+                  echo "release_branch=$(echo $RELEASE_BRANCH)" >> $GITHUB_OUTPUT
 
     update-changelog:
         name: Update Changelog on ${{ matrix.branch }} branch
@@ -113,7 +113,7 @@ jobs:
 
             - name: Get previous stable version
               id: get_previous_stable_version
-              run: echo ::set-output name=stable_version::$(awk -F ':\ ' '$1 == "Stable tag" {print $2}' ./trunk/readme.txt)
+              run: echo "stable_version=$(awk -F ':\ ' '$1 == "Stable tag" {print $2}' ./trunk/readme.txt)" >> $GITHUB_OUTPUT
 
             - name: Delete everything
               working-directory: ./trunk


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Remove the use of `set-output` commands.

## Why?
This command has been deprecated and will be removed in the near future.

For more information, see: https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/.