### PR TITLE
Set block attributes to require either type or enum

### DIFF
--- a/schemas/json/block.json
+++ b/schemas/json/block.json
@@ -188,7 +188,14 @@
 							"description": "A block attribute can contain a default value, which will be used if the type and source do not match anything within the block content.\n\nThe value is provided by the default field, and the value should match the expected format of the attribute."
 						}
 					},
-					"required": [ "type" ]
+					"oneOf": [
+						{
+							"required": [ "type" ]
+						},
+						{
+							"required": [ "enum" ]
+						}
+					]
 				}
 			},
 			"additionalProperties": false

--- a/schemas/json/block.json
+++ b/schemas/json/block.json
@@ -188,7 +188,7 @@
 							"description": "A block attribute can contain a default value, which will be used if the type and source do not match anything within the block content.\n\nThe value is provided by the default field, and the value should match the expected format of the attribute."
 						}
 					},
-					"oneOf": [
+					"anyOf": [
 						{
 							"required": [ "type" ]
 						},


### PR DESCRIPTION
## What?
Updates the `block.json` schema to make `type` or `enum` be the required options for attributes.

## Why?
The schema used for `block.json` currently shows an issue for block attributes that use an `enum` rather than type. According to the [developer handbook](https://developer.wordpress.org/block-editor/reference-guides/block-api/block-attributes/), this works as an either or rather than just `type`.

## How?
Changes `"required": [ "type" ]` into a `anyOf` array to require either `type` or `enum` or both

## Testing Instructions
1. Update the schema source in `block.json` to point to the schema file in this branch
2. Ensure that the block attributes don't show an issue when attributes have a defined `type` OR `enum` OR both

## Screenshots
![Current Schema](https://user-images.githubusercontent.com/25410446/198511544-f3a38ce6-d785-43a1-8085-e1eafb2a8371.png)
*Current Schema: error for attribute with only `enum`*

![New Schema](https://user-images.githubusercontent.com/25410446/198511540-43de287f-b29e-42d9-9173-1e14e824a02f.png)
*image_caption*
*Current Schema: no error for either option*
