### PR TITLE
ESLint: Exclude Playwright tests from testing library rules

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -331,6 +331,7 @@ module.exports = {
 				'**/*.@(android|ios|native).js',
 				'packages/react-native-*/**/*.js',
 				'test/native/**/*.js',
+				'test/e2e/**/*.[tj]s',
 			],
 			extends: [
 				'plugin:jest-dom/recommended',


### PR DESCRIPTION
## What?
PR fixes false positive ESLint errors for Playwright tests.

Recently Playwright introduced short-form APIs, but when using `page.getByRole`, ESLint tries to apply rules from Testing Library. The latter library inspired these new APIs, so confusion is understandable 😄 

More details on new APIs: https://github.com/microsoft/playwright/releases/tag/v1.27.0

## How?
Add Playwright tests to excluded files list for Testing Library rules.

## Testing Instructions
Paste the following code in any Playwright test and confirm no false positive ESLint errors.

```
const esLintTest = page.getByRole( 'button', { name: 'Test' } );
```
