### PR TITLE
Lodash: Refactor away from `_.some()`

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -149,6 +149,7 @@ module.exports = {
 							'reverse',
 							'size',
 							'snakeCase',
+							'some',
 							'sortBy',
 							'startCase',
 							'startsWith',

--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -45,6 +45,7 @@
 -   `ColorPalette`: Convert to TypeScript ([#44632](https://github.com/WordPress/gutenberg/pull/44632)).
 -   `UnitControl`: Add tests ([#45260](https://github.com/WordPress/gutenberg/pull/45260)).
 -   `Disabled`: Refactor the component to rely on the HTML `inert` attribute.
+-   `CustomGradientBar`: Refactor away from Lodash ([#45367](https://github.com/WordPress/gutenberg/pull/45367/)).
 
 ## 21.3.0 (2022-10-19)
 

--- a/packages/components/src/custom-gradient-picker/gradient-bar/index.js
+++ b/packages/components/src/custom-gradient-picker/gradient-bar/index.js
@@ -1,8 +1,6 @@
 /**
  * External dependencies
  */
-
-import { some } from 'lodash';
 import classnames from 'classnames';
 
 /**
@@ -91,7 +89,7 @@ export default function CustomGradientBar( {
 
 		// If the insert point is close to an existing control point don't show it.
 		if (
-			some( controlPoints, ( { position } ) => {
+			controlPoints.some( ( { position } ) => {
 				return (
 					Math.abs( insertPosition - position ) <
 					MINIMUM_DISTANCE_BETWEEN_INSERTER_AND_POINT

--- a/packages/edit-site/src/components/save-button/index.js
+++ b/packages/edit-site/src/components/save-button/index.js
@@ -1,9 +1,4 @@
 /**
- * External dependencies
- */
-import { some } from 'lodash';
-
-/**
  * WordPress dependencies
  */
 import { useSelect, useDispatch } from '@wordpress/data';
@@ -24,7 +19,7 @@ export default function SaveButton() {
 		const { isSaveViewOpened } = select( editSiteStore );
 		return {
 			isDirty: dirtyEntityRecords.length > 0,
-			isSaving: some( dirtyEntityRecords, ( record ) =>
+			isSaving: dirtyEntityRecords.some( ( record ) =>
 				isSavingEntityRecord( record.kind, record.name, record.key )
 			),
 			isSaveViewOpen: isSaveViewOpened(),


### PR DESCRIPTION
## What?
This PR removes Lodash's `_.some()` completely and deprecates the package. There are just a few usages and conversion is pretty straightforward. 

## Why?

Lodash is known to unnecessarily inflate the bundle size of packages, and in most cases, it can be replaced with native language functionality. See these for more information and rationale:

* https://github.com/WordPress/gutenberg/issues/16938#issuecomment-602837246
* https://github.com/WordPress/gutenberg/issues/17025
* https://github.com/WordPress/gutenberg/issues/39495 

## How?

We're replacing a few usages with a simple native `Array.prototype.some()`.

## Testing Instructions

* Insert a paragraph block, and in block settings in the sidebar, go to pick a background color, there click on Gradient, then verify you can still properly work with the custom gradient picker.
* Edit a few items in the site editor and verify save button still works well.
* Verify all checks are still green.