### PR TITLE
Fix the navigate regions focus style

### DIFF
--- a/packages/base-styles/_z-index.scss
+++ b/packages/base-styles/_z-index.scss
@@ -187,6 +187,8 @@ $z-layers: (
 
 	// Appear under the topbar.
 	".customize-widgets__block-toolbar": 7,
+
+	".is-focusing-regions [role='region']:focus > *": -1,
 );
 
 @function z-index( $key ) {

--- a/packages/base-styles/_z-index.scss
+++ b/packages/base-styles/_z-index.scss
@@ -188,7 +188,7 @@ $z-layers: (
 	// Appear under the topbar.
 	".customize-widgets__block-toolbar": 7,
 
-	".is-focusing-regions [role='region']:focus > *": -1,
+	".is-focusing-regions [role='region']:focus .interface-navigable-region__stacker": -1,
 );
 
 @function z-index( $key ) {

--- a/packages/components/src/higher-order/navigate-regions/style.scss
+++ b/packages/components/src/higher-order/navigate-regions/style.scss
@@ -1,21 +1,33 @@
+// Allow the position to be easily overridden to e.g. fixed.
 [role="region"] {
-	// Make the grid container children establish an independent stacking context
-	// and avoid to use position asto allow the position to be easily overridden
-	// to e.g. fixed.
-	display: grid;
+	position: relative;
 }
 
-.is-focusing-regions [role="region"] {
-	&:focus {
-		outline-style: solid;
-		outline-color: $components-color-accent;
-		outline-width: 4px;
+.is-focusing-regions {
+	[role="region"]:focus {
+		outline: 4px solid $components-color-accent;
 		outline-offset: -4px;
 
-		> * {
-			// Children of a grid container establish a new stacking context.
-			// See https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_Positioning/Understanding_z_index/The_stacking_context
-			z-index: -1 !important;
+		.interface-navigable-region__stacker {
+			position: relative;
+			z-index: z-index(".is-focusing-regions [role='region']:focus .interface-navigable-region__stacker");
+		}
+	}
+
+	// Fixes for edge cases.
+	// Some of the regions are currently used for layout purposes as 'interface skeleton'
+	// items. When they're absolutely positioned or when they contain absolutely
+	// positioned elements, they may have no size therefore the focus style is not
+	// visible. For the future, it's important to take into consideration that
+	// the navigable regions should always have a computed size. For now, we can
+	// fix some edge cases but these CSS rules should be later removed in favor of
+	// a more abstracted approach to make the navigabel regions focus style work
+	// regardles of the CSS used on other components.
+	&.is-distraction-free .interface-interface-skeleton__header {
+		.interface-navigable-region__stacker,
+		.edit-post-header {
+			outline: inherit;
+			outline-offset: inherit;
 		}
 	}
 }

--- a/packages/components/src/higher-order/navigate-regions/style.scss
+++ b/packages/components/src/higher-order/navigate-regions/style.scss
@@ -53,7 +53,7 @@
 
 	// Publish sidebar.
 	[role="region"].interface-interface-skeleton__actions:focus  .editor-post-publish-panel {
-		outline: 4px solid var(--wp-admin-theme-color);
+		outline: 4px solid $components-color-accent;
 		outline-offset: -4px;
 	}
 

--- a/packages/components/src/higher-order/navigate-regions/style.scss
+++ b/packages/components/src/higher-order/navigate-regions/style.scss
@@ -1,6 +1,8 @@
-// Allow the position to be easily overridden to e.g. fixed.
 [role="region"] {
-	position: relative;
+	// Make the grid container children establish an independent stacking context
+	// and avoid to use position asto allow the position to be easily overridden
+	// to e.g. fixed.
+	display: grid;
 }
 
 .is-focusing-regions [role="region"] {
@@ -11,8 +13,9 @@
 		outline-offset: -4px;
 
 		> * {
-			position: relative;
-			z-index: z-index(".is-focusing-regions [role='region']:focus > *");
+			// Children of a grid container establish a new stacking context.
+			// See https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_Positioning/Understanding_z_index/The_stacking_context
+			z-index: -1 !important;
 		}
 	}
 }

--- a/packages/components/src/higher-order/navigate-regions/style.scss
+++ b/packages/components/src/higher-order/navigate-regions/style.scss
@@ -4,29 +4,15 @@
 }
 
 .is-focusing-regions [role="region"] {
-	// For browsers that don't support outline-offset (IE11).
-	&:focus::after {
-		content: "";
-		position: absolute;
-		top: 0;
-		bottom: 0;
-		left: 0;
-		right: 0;
-		pointer-events: none;
-		outline: 4px solid transparent; // Shown in Windows High Contrast mode.
-		box-shadow: inset 0 0 0 4px $components-color-accent;
-	}
+	&:focus {
+		outline-style: solid;
+		outline-color: $components-color-accent;
+		outline-width: 4px;
+		outline-offset: -4px;
 
-	@supports ( outline-offset: 1px ) {
-		&:focus::after {
-			content: none;
-		}
-
-		&:focus {
-			outline-style: solid;
-			outline-color: $components-color-accent;
-			outline-width: 4px;
-			outline-offset: -4px;
+		> * {
+			position: relative;
+			z-index: z-index(".is-focusing-regions [role='region']:focus > *");
 		}
 	}
 }

--- a/packages/components/src/higher-order/navigate-regions/style.scss
+++ b/packages/components/src/higher-order/navigate-regions/style.scss
@@ -23,6 +23,8 @@
 	// fix some edge cases but these CSS rules should be later removed in favor of
 	// a more abstracted approach to make the navigabel regions focus style work
 	// regardles of the CSS used on other components.
+
+	// Header top bar when Distraction free mode is on.
 	&.is-distraction-free .interface-interface-skeleton__header {
 		.interface-navigable-region__stacker,
 		.edit-post-header {
@@ -30,4 +32,53 @@
 			outline-offset: inherit;
 		}
 	}
+
+	// Sidebar toggle button shown when navigating regions.
+	.interface-interface-skeleton__sidebar {
+		.interface-navigable-region__stacker,
+		.edit-post-layout__toggle-sidebar-panel {
+			outline: inherit;
+			outline-offset: inherit;
+		}
+	}
+
+	// Publish sidebar toggle button shown when navigating regions.
+	.interface-interface-skeleton__actions {
+		.interface-navigable-region__stacker,
+		.edit-post-layout__toggle-publish-panel {
+			outline: inherit;
+			outline-offset: inherit;
+		}
+	}
+
+	// Publish sidebar.
+	[role="region"].interface-interface-skeleton__actions:focus  .editor-post-publish-panel {
+		outline: 4px solid var(--wp-admin-theme-color);
+		outline-offset: -4px;
+	}
+
+	// Edit site Navigation Drawer.
+	.interface-interface-skeleton__drawer {
+		z-index: z-index(".edit-site-navigation-toggle");
+
+		.interface-navigable-region__stacker,
+		.edit-site-navigation-toggle {
+			outline: inherit;
+			outline-offset: inherit;
+		}
+
+		.edit-site-navigation-toggle.is-open {
+			outline: none;
+		}
+
+		.edit-site-navigation-toggle__button {
+			z-index: -1;
+		}
+	}
+}
+
+// Fixes for edge cases.
+// Edit site Drawer.
+.interface-interface-skeleton__drawer .interface-navigable-region__stacker {
+	height: 100%;
 }

--- a/packages/edit-post/src/components/layout/style.scss
+++ b/packages/edit-post/src/components/layout/style.scss
@@ -60,7 +60,9 @@
 	justify-content: center;
 }
 
-.edit-post-layout__toggle-sidebar-panel {
+.edit-post-layout__toggle-publish-panel,
+.edit-post-layout__toggle-sidebar-panel,
+.edit-post-layout__toggle-entities-saved-states-panel {
 	z-index: z-index(".edit-post-layout__toggle-sidebar-panel");
 	position: fixed !important; // Need to override the default relative positionning
 	top: -9999em;
@@ -75,9 +77,11 @@
 	padding: $grid-unit-30;
 	display: flex;
 	justify-content: center;
+}
 
-	.interface-interface-skeleton__actions:focus &,
-	.interface-interface-skeleton__actions:focus-within & {
+.edit-post-layout__toggle-sidebar-panel {
+	.interface-interface-skeleton__sidebar:focus &,
+	.interface-interface-skeleton__sidebar:focus-within & {
 		top: auto;
 		bottom: 0;
 	}
@@ -85,14 +89,6 @@
 
 .edit-post-layout__toggle-entities-saved-states-panel,
 .edit-post-layout__toggle-publish-panel {
-	box-sizing: border-box;
-	width: $sidebar-width;
-	background-color: $white;
-	border: 1px dotted $gray-300;
-	padding: $grid-unit-30;
-	display: flex;
-	justify-content: center;
-
 	.interface-interface-skeleton__actions:focus &,
 	.interface-interface-skeleton__actions:focus-within & {
 		top: auto;

--- a/packages/edit-post/src/components/layout/style.scss
+++ b/packages/edit-post/src/components/layout/style.scss
@@ -60,20 +60,35 @@
 	justify-content: center;
 }
 
-
-.edit-post-layout__toggle-publish-panel,
-.edit-post-layout__toggle-sidebar-panel,
-.edit-post-layout__toggle-entities-saved-states-panel {
+.edit-post-layout__toggle-sidebar-panel {
 	z-index: z-index(".edit-post-layout__toggle-sidebar-panel");
 	position: fixed !important; // Need to override the default relative positionning
 	top: -9999em;
 	bottom: auto;
 	left: auto;
 	right: 0;
+	box-sizing: border-box;
 	width: $sidebar-width;
 	background-color: $white;
 	border: 1px dotted $gray-300;
 	height: auto !important; // Need to override the default sidebar positionnings
+	padding: $grid-unit-30;
+	display: flex;
+	justify-content: center;
+
+	.interface-interface-skeleton__actions:focus &,
+	.interface-interface-skeleton__actions:focus-within & {
+		top: auto;
+		bottom: 0;
+	}
+}
+
+.edit-post-layout__toggle-entities-saved-states-panel,
+.edit-post-layout__toggle-publish-panel {
+	box-sizing: border-box;
+	width: $sidebar-width;
+	background-color: $white;
+	border: 1px dotted $gray-300;
 	padding: $grid-unit-30;
 	display: flex;
 	justify-content: center;

--- a/packages/edit-site/src/components/editor/style.scss
+++ b/packages/edit-site/src/components/editor/style.scss
@@ -7,16 +7,10 @@ html.wp-toolbar {
 }
 
 .edit-site-editor__toggle-save-panel {
-	z-index: z-index(".edit-site-editor__toggle-save-panel");
-	position: fixed !important; // Need to override the default relative positioning
-	top: -9999em;
-	bottom: auto;
-	left: auto;
-	right: 0;
+	box-sizing: border-box;
 	width: $sidebar-width;
 	background-color: $white;
 	border: 1px dotted $gray-300;
-	height: auto !important; // Need to override the default sidebar positioning
 	padding: $grid-unit-30;
 	display: flex;
 	justify-content: center;

--- a/packages/edit-site/src/components/navigation-sidebar/navigation-panel/style.scss
+++ b/packages/edit-site/src/components/navigation-sidebar/navigation-panel/style.scss
@@ -7,13 +7,6 @@
 	color: $white;
 	transition: width 100ms linear;
 	@include reduce-motion("transition");
-
-	// Footer is visible from medium so we subtract footer's height
-	.interface-interface-skeleton.has-footer & {
-		@include break-medium() {
-			height: calc(100% - #{$button-size-small + $border-width});
-		}
-	}
 }
 
 .edit-site-navigation-panel__inner {

--- a/packages/edit-site/src/components/navigation-sidebar/navigation-toggle/style.scss
+++ b/packages/edit-site/src/components/navigation-sidebar/navigation-toggle/style.scss
@@ -6,10 +6,18 @@
 	background: $gray-900;
 	border-radius: 0;
 	display: flex;
-	position: absolute;
-	z-index: z-index(".edit-site-navigation-toggle");
+	// !important to override position relative set by navigateRegions when focusing the region.
+	position: absolute !important;
+	// !important to override the z-index set by navigateRegions when focusing the region.
+	z-index: z-index(".edit-site-navigation-toggle") !important;
 	height: $header-height;
 	width: $header-height;
+
+	&.is-open,
+	&.is-open .edit-site-navigation-toggle__button.components-button {
+		// Allow navigateRegions focus style to be drawn correctly.
+		background: transparent;
+	}
 }
 
 .edit-site-navigation-toggle__button.components-button {

--- a/packages/edit-site/src/components/navigation-sidebar/navigation-toggle/style.scss
+++ b/packages/edit-site/src/components/navigation-sidebar/navigation-toggle/style.scss
@@ -6,18 +6,10 @@
 	background: $gray-900;
 	border-radius: 0;
 	display: flex;
-	// !important to override position relative set by navigateRegions when focusing the region.
-	position: absolute !important;
-	// !important to override the z-index set by navigateRegions when focusing the region.
-	z-index: z-index(".edit-site-navigation-toggle") !important;
+	position: absolute;
+	z-index: z-index(".edit-site-navigation-toggle");
 	height: $header-height;
 	width: $header-height;
-
-	&.is-open,
-	&.is-open .edit-site-navigation-toggle__button.components-button {
-		// Allow navigateRegions focus style to be drawn correctly.
-		background: transparent;
-	}
 }
 
 .edit-site-navigation-toggle__button.components-button {

--- a/packages/interface/complementary-area-context/index.js
+++ b/packages/interface/complementary-area-context/index.js
@@ -1,0 +1,12 @@
+/**
+ * WordPress dependencies
+ */
+import { withPluginContext } from '@wordpress/plugins';
+
+export default withPluginContext( ( context, ownProps ) => {
+	return {
+		icon: ownProps.icon || context.icon,
+		identifier:
+			ownProps.identifier || `${ context.name }/${ ownProps.name }`,
+	};
+} );

--- a/packages/interface/src/components/index.js
+++ b/packages/interface/src/components/index.js
@@ -10,3 +10,4 @@ export { default as PreferencesModal } from './preferences-modal';
 export { default as PreferencesModalTabs } from './preferences-modal-tabs';
 export { default as PreferencesModalSection } from './preferences-modal-section';
 export { default as ___unstablePreferencesModalBaseOption } from './preferences-modal-base-option';
+export { default as NavigableRegion } from './navigable-region';

--- a/packages/interface/src/components/interface-skeleton/index.js
+++ b/packages/interface/src/components/interface-skeleton/index.js
@@ -7,12 +7,14 @@ import classnames from 'classnames';
  * WordPress dependencies
  */
 import { forwardRef, useEffect } from '@wordpress/element';
-import {
-	__unstableUseNavigateRegions as useNavigateRegions,
-	__unstableMotion as motion,
-} from '@wordpress/components';
+import { __unstableUseNavigateRegions as useNavigateRegions } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 import { useMergeRefs } from '@wordpress/compose';
+
+/**
+ * Internal dependencies
+ */
+import NavigableRegion from '../navigable-region';
 
 function useHTMLClass( className ) {
 	useEffect( () => {
@@ -89,39 +91,34 @@ function InterfaceSkeleton(
 			) }
 		>
 			{ !! drawer && (
-				<div
+				<NavigableRegion
 					className="interface-interface-skeleton__drawer"
-					role="region"
-					aria-label={ mergedLabels.drawer }
-					tabIndex="-1"
+					ariaLabel={ mergedLabels.drawer }
 				>
 					{ drawer }
-				</div>
+				</NavigableRegion>
 			) }
 			<div className="interface-interface-skeleton__editor">
 				{ !! header && isDistractionFree && (
-					<motion.div
+					<NavigableRegion
 						initial={ isDistractionFree ? 'hidden' : 'hover' }
 						whileHover="hover"
 						variants={ headerVariants }
 						transition={ { type: 'tween', delay: 0.8 } }
 						className="interface-interface-skeleton__header"
-						role="region"
 						aria-label={ mergedLabels.header }
-						tabIndex="-1"
+						useMotion={ true }
 					>
 						{ header }
-					</motion.div>
+					</NavigableRegion>
 				) }
 				{ !! header && ! isDistractionFree && (
-					<div
+					<NavigableRegion
 						className="interface-interface-skeleton__header"
-						role="region"
-						aria-label={ mergedLabels.header }
-						tabIndex="-1"
+						ariaLabel={ mergedLabels.header }
 					>
 						{ header }
-					</div>
+					</NavigableRegion>
 				) }
 				{ isDistractionFree && (
 					<div className="interface-interface-skeleton__header">
@@ -130,59 +127,49 @@ function InterfaceSkeleton(
 				) }
 				<div className="interface-interface-skeleton__body">
 					{ !! secondarySidebar && (
-						<div
+						<NavigableRegion
 							className="interface-interface-skeleton__secondary-sidebar"
-							role="region"
-							aria-label={ mergedLabels.secondarySidebar }
-							tabIndex="-1"
+							ariaLabel={ mergedLabels.secondarySidebar }
 						>
 							{ secondarySidebar }
-						</div>
+						</NavigableRegion>
 					) }
 					{ !! notices && (
 						<div className="interface-interface-skeleton__notices">
 							{ notices }
 						</div>
 					) }
-					<div
+					<NavigableRegion
 						className="interface-interface-skeleton__content"
-						role="region"
-						aria-label={ mergedLabels.body }
-						tabIndex="-1"
+						ariaLabel={ mergedLabels.body }
 					>
 						{ content }
-					</div>
+					</NavigableRegion>
 					{ !! sidebar && (
-						<div
+						<NavigableRegion
 							className="interface-interface-skeleton__sidebar"
-							role="region"
-							aria-label={ mergedLabels.sidebar }
-							tabIndex="-1"
+							ariaLabel={ mergedLabels.sidebar }
 						>
 							{ sidebar }
-						</div>
+						</NavigableRegion>
 					) }
 					{ !! actions && (
-						<div
+						<NavigableRegion
 							className="interface-interface-skeleton__actions"
-							role="region"
-							aria-label={ mergedLabels.actions }
-							tabIndex="-1"
+							ariaLabel={ mergedLabels.actions }
 						>
 							{ actions }
-						</div>
+						</NavigableRegion>
 					) }
 				</div>
 			</div>
 			{ !! footer && (
-				<div
+				<NavigableRegion
 					className="interface-interface-skeleton__footer"
-					role="region"
-					aria-label={ mergedLabels.footer }
-					tabIndex="-1"
+					ariaLabel={ mergedLabels.footer }
 				>
 					{ footer }
-				</div>
+				</NavigableRegion>
 			) }
 		</div>
 	);

--- a/packages/interface/src/components/interface-skeleton/index.js
+++ b/packages/interface/src/components/interface-skeleton/index.js
@@ -101,13 +101,14 @@ function InterfaceSkeleton(
 			<div className="interface-interface-skeleton__editor">
 				{ !! header && isDistractionFree && (
 					<NavigableRegion
-						initial={ isDistractionFree ? 'hidden' : 'hover' }
-						whileHover="hover"
-						variants={ headerVariants }
-						transition={ { type: 'tween', delay: 0.8 } }
 						className="interface-interface-skeleton__header"
 						aria-label={ mergedLabels.header }
-						useMotion={ true }
+						motionProps={ {
+							initial: isDistractionFree ? 'hidden' : 'hover',
+							whileHover: 'hover',
+							variants: headerVariants,
+							transition: { type: 'tween', delay: 0.8 },
+						} }
 					>
 						{ header }
 					</NavigableRegion>

--- a/packages/interface/src/components/interface-skeleton/style.scss
+++ b/packages/interface/src/components/interface-skeleton/style.scss
@@ -173,8 +173,13 @@ html.interface-interface-skeleton__html-container {
 	width: $sidebar-width;
 	color: $gray-900;
 
-	&:focus {
+	&:focus,
+	&:focus-within {
 		top: auto;
 		bottom: 0;
+
+		.is-sidebar-opened & {
+			top: 0;
+		}
 	}
 }

--- a/packages/interface/src/components/interface-skeleton/style.scss
+++ b/packages/interface/src/components/interface-skeleton/style.scss
@@ -110,8 +110,14 @@ html.interface-interface-skeleton__html-container {
 	// On Mobile the header is fixed to keep HTML as scrollable.
 	@include break-medium() {
 		position: relative !important;
-		z-index: z-index(".interface-interface-skeleton__sidebar {greater than small}");
 		width: auto; // Keep the sidebar width flexible.
+
+		// Set this z-index only when the sidebar is opened. When it's closed, the
+		// button to open the sidebar that is shown when navigating regions needs to
+		// be above the footer. See `edit-post-layout__toggle-sidebar-panel`.
+		.is-sidebar-opened & {
+			z-index: z-index(".interface-interface-skeleton__sidebar {greater than small}");
+		}
 	}
 }
 

--- a/packages/interface/src/components/interface-skeleton/style.scss
+++ b/packages/interface/src/components/interface-skeleton/style.scss
@@ -183,3 +183,10 @@ html.interface-interface-skeleton__html-container {
 		}
 	}
 }
+
+// Footer is visible from medium so we subtract footer's height
+.interface-interface-skeleton.has-footer .interface-interface-skeleton__drawer {
+	@include break-medium() {
+		height: calc(100% - #{$button-size-small + $border-width});
+	}
+}

--- a/packages/interface/src/components/interface-skeleton/style.scss
+++ b/packages/interface/src/components/interface-skeleton/style.scss
@@ -93,7 +93,6 @@ html.interface-interface-skeleton__html-container {
 
 .interface-interface-skeleton__secondary-sidebar,
 .interface-interface-skeleton__sidebar {
-	display: block;
 	flex-shrink: 0;
 	position: absolute;
 	z-index: z-index(".interface-interface-skeleton__sidebar");
@@ -177,10 +176,6 @@ html.interface-interface-skeleton__html-container {
 	&:focus-within {
 		top: auto;
 		bottom: 0;
-
-		.is-sidebar-opened & {
-			top: 0;
-		}
 	}
 }
 

--- a/packages/interface/src/components/interface-skeleton/style.scss
+++ b/packages/interface/src/components/interface-skeleton/style.scss
@@ -72,6 +72,10 @@ html.interface-interface-skeleton__html-container {
 }
 
 .interface-interface-skeleton__content {
+	.interface-navigable-region__stacker {
+		flex-grow: 1;
+	}
+
 	flex-grow: 1;
 
 	// Treat as flex container to allow children to grow to occupy full

--- a/packages/interface/src/components/navigable-region/README.md
+++ b/packages/interface/src/components/navigable-region/README.md
@@ -1,0 +1,38 @@
+# NavigableRegion
+
+`NavigableRegion` renders an ARIA landmark region that's meant to be used together with the `useNavigateRegions` component from the `@wordpress/components` package. The ARIA landmark is a `div` element with a `role="region"` attribute and an `aria-label` attribute. It's made focusable by the means of a `tabindex="-1"` attribute so that `useNavigateRegions` can set focus on it and allow keyboard navigation through the regions in the editor.
+
+It also renders a child `div` element that is responsible to set a negative `z-index` stack level, to make sure the focus style is always visible, regardless of other elements that may cut-off the focus style outline otherwise.
+
+It can use a CSS animation via the `motion` component.
+
+## Props
+
+### children
+
+The component that should be rendered as content.
+
+-   Type: React Element
+-   Required: Yes
+
+### className
+
+The CSS class that will be added to the classes of the wrapper div.
+
+-   Type: `String`
+-   Required: No
+
+### ariaLabel
+
+A meaningful name for the ARIA landmark region.
+
+-   Type: `String`
+-   Required: Yes
+
+### motionProps
+
+Properties of `motionProps` object will be used by the `motion` component to set a CSS animation on the wrapper div.
+
+-   Type: `Object`
+-   Required: No
+-   Default: `{}`

--- a/packages/interface/src/components/navigable-region/index.js
+++ b/packages/interface/src/components/navigable-region/index.js
@@ -12,19 +12,9 @@ export default function NavigableRegion( {
 	children,
 	className,
 	ariaLabel,
-	useMotion = false,
-	...props
+	motionProps = {},
 } ) {
-	const Tag = useMotion ? motion.div : 'div';
-
-	const motionProps = useMotion
-		? {
-				initial: props.initial,
-				whileHover: props.whileHover,
-				variants: props.variants,
-				transition: props.transition,
-		  }
-		: {};
+	const Tag = Object.keys( motionProps ).length ? motion.div : 'div';
 
 	return (
 		<Tag

--- a/packages/interface/src/components/navigable-region/index.js
+++ b/packages/interface/src/components/navigable-region/index.js
@@ -1,0 +1,42 @@
+/**
+ * External dependencies
+ */
+import classnames from 'classnames';
+
+/**
+ * WordPress dependencies
+ */
+import { __unstableMotion as motion } from '@wordpress/components';
+
+export default function NavigableRegion( {
+	children,
+	className,
+	ariaLabel,
+	useMotion = false,
+	...props
+} ) {
+	const Tag = useMotion ? motion.div : 'div';
+
+	const motionProps = useMotion
+		? {
+				initial: props.initial,
+				whileHover: props.whileHover,
+				variants: props.variants,
+				transition: props.transition,
+		  }
+		: {};
+
+	return (
+		<Tag
+			className={ classnames( 'interface-navigable-region', className ) }
+			aria-label={ ariaLabel }
+			role="region"
+			tabIndex="-1"
+			{ ...motionProps }
+		>
+			<div className="interface-navigable-region__stacker">
+				{ children }
+			</div>
+		</Tag>
+	);
+}


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->
Fixes https://github.com/WordPress/gutenberg/issues/21717

## What?
<!-- In a few words, what is the PR actually doing? -->
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
When navigating through the editor regions via the dedicated keyboard shortcuts, the focused region should show a blue outline as focus indicator. This used to work well in https://github.com/WordPress/gutenberg/pull/8554 but it's broken since at least 2 years and a half, see https://github.com/WordPress/gutenberg/issues/21717

It appears that new layouts and features introduced over time didn't take into consideration the navigable regions need to have a focus style. There are two main issues that make the focus style not visible:
1. Sometimes, the region contains elements with a higher z-index which partially or completely covers the focus outline.
2. Sometimes, the region doesn't have a computed size because its content is absolutely positioned (or it's fixed) so the outline isn't visible because it's set on an element that has a 0px by 0px size.

Screenshot to illustrate the z-index issue:

<img width="377" alt="Screenshot 2022-10-28 at 09 47 48" src="https://user-images.githubusercontent.com/1682452/198543131-32630c72-b3f4-4c71-b604-a7dc15ea6b7e.png">

Screenshot to illustrate the 0 size issue (this is the Publish panel toggle button, see there's no focus style on its wrapper region):

<img width="344" alt="Screenshot 2022-10-28 at 09 49 35" src="https://user-images.githubusercontent.com/1682452/198543227-f78f60b9-cae1-48f4-b1d0-6531cce45f1a.png">

The original purpose of these regions is to allow keyboard navigation through the main parts of the editor and show a focus style. They're now also used for layout purposes, as parts of the 'interface skeleton', which is fine. However, it's very important  to keep in mind that:
- The regions must have a computed size.
- The regions focus style needs to be 'on top' of any other content within the region.

## Why?
A clear focus indicator is a basic accessibility requirement for all sighted keyboard users, as they need to see where focus is.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
- Simplified the `navigateRegions` CSS as we don't need a fix for IE11 any longer. Note: we can't use a CSS pseudo element as suggested in https://github.com/WordPress/gutenberg/issues/21717 because the pseudo element would scroll together wit the content.
- Added a new `NavigableRegion` component to abstract the markup and features of the ARIA regions.
- `NavigableRegion` renders the focusable ARIA landmark region and a child container.
- The child container is responsible to set a negative `z-index: -1` so that any content within the region is positioned in the Z-axis at a lower level than the wrapper.
- This way, the focus indicator on the wrapper is always visible.
- The child container also establishes a new stacking context so that any layering within it should still work as expected.
- This solves the first issue related to z-indexes.
- Instead, the size issue can't be solved with a generic fix.
- Therefore, this PR adds some exceptions to cover these edge cases.
- I opted to add these exceptions in the `navigateRegions` stylesheet.
- Ideally, these exceptions should be removed in the future and we should make sure the layout always makes the regions have a size.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->
- Go to the Post editor.
- Click on any empty part of the UI.
- Navigate through the editor regions by pressing Cmd + backtick (on macOS)
- Note: for keyboard layouts other than English and for Windows, see alternative keyboard shortcuts at: Options > Keyboard shortcuts > Global shortcuts > Navigate to the next part of the editor.
- Check that when focus lands on an editor region there's a clearly visible blue outline around the region.
- Test with the Setting sidebar closed ad opened.
- Test with the Publish sidebar opened.
- Test with the List View sidebar opened.
- Test with the 'Distraction free' mode enabled.
- Go to the Site Editor.
- Navigate through the editor regions.
- Check that blue outline on the focused region is clearly visible.
- Test with the sidebars closed and opened, especially the Navigation sidebar.
- Activate the Twenty Twenty-One theme to make the Widgets page available in the WP admin.
- Go to the Widgets page.
- Click on any empty part of the Widgets page.
- Navigate through the regions.
- Check that blue outline on the focused region is clearly visible.

## Screenshots or screencast <!-- if applicable -->

Animated GIF to illustrates the navigate regions focus style in action in the Post editor.

![navigateregion](https://user-images.githubusercontent.com/1682452/198544541-6cfe32a5-7fa9-49bb-8b40-751549c6460d.gif)

