### PR TITLE
Add `WP_Object_Cache` to the `gutenberg_get_global_settings` method

### DIFF
--- a/lib/compat/wordpress-6.2/get-global-styles-and-settings.php
+++ b/lib/compat/wordpress-6.2/get-global-styles-and-settings.php
@@ -171,7 +171,15 @@ function gutenberg_get_global_settings( $path = array(), $context = array() ) {
 		$origin = 'theme';
 	}
 
-	$settings = WP_Theme_JSON_Resolver_Gutenberg::get_merged_data( $origin )->get_settings();
+	$cache_group = 'theme_json';
+	$cache_key   = 'gutenberg_get_global_settings_' . $origin;
+	$settings    = wp_cache_get( $cache_key, $cache_group );
+
+	if ( false === $settings || WP_DEBUG ) {
+		$settings = WP_Theme_JSON_Resolver_Gutenberg::get_merged_data( $origin )->get_settings();
+		wp_cache_set( $cache_key, $settings, $cache_group );
+	}
+
 	return _wp_array_get( $settings, $path, $settings );
 }
 
@@ -183,6 +191,7 @@ function gutenberg_get_global_settings( $path = array(), $context = array() ) {
 function _gutenberg_clean_theme_json_caches() {
 	wp_cache_delete( 'wp_theme_has_theme_json', 'theme_json' );
 	wp_cache_delete( 'gutenberg_get_global_stylesheet', 'theme_json' );
+	wp_cache_delete( 'gutenberg_get_global_settings_custom', 'theme_json' );
 	wp_cache_delete( 'gutenberg_get_global_settings_theme', 'theme_json' );
 	WP_Theme_JSON_Resolver_Gutenberg::clean_cached_data();
 }
@@ -192,6 +201,7 @@ function _gutenberg_clean_theme_json_caches() {
  * The data stored under this cache group:
  *
  * - wp_theme_has_theme_json
+ * - gutenberg_get_global_settings
  * - gutenberg_get_global_stylesheet
  *
  * There is some hooks consumers can use to modify parts


### PR DESCRIPTION
Part of https://github.com/WordPress/gutenberg/issues/45171
Depends on:

- https://github.com/WordPress/gutenberg/pull/45971
- https://github.com/WordPress/gutenberg/pull/45969
- https://github.com/WordPress/gutenberg/pull/46150

## What?

This PR uses `WP_Object_Cache` to cache the results of querying settings from the `theme.json`.

## Why?

This PR **reduces the total time of a request from 521.59ms to 339.62ms, a ~35% performance increase**.

## How?

Adds a cache to the high-level public method that consumers use to query the settings coming from `theme.json` APIs (WordPress, theme, and user data).

## How performance was measured

To measure performance, I have loaded the "Hello World!" post as a logged-out user under the following scenarios:

- Gutenberg: this PR vs trunk at `ee90c2b1df7cb59e1f6ea3e2aaeb3b15386396ac`
- WordPress: 6.2-alpha-54852
- Theme: TwentyTwentyThree

For each Gutenberg branch, I have conducted the test 9 times and then calculated the median to get the time for the request. Download the data for:

- this PR: [cachegrind.out.pr.45372.zip](https://github.com/WordPress/gutenberg/files/10086628/cachegrind.out.pr.45372.zip)
- trunk at ee90c2b1df7: [cachegrind.out.trunk.ee90c2b1df7.zip](https://github.com/WordPress/gutenberg/files/10086630/cachegrind.out.trunk.ee90c2b1df7.zip)

## How to reproduce the performance measures

You don't need to, as I've made available the cachegrind data (see section above). Though you may still want to run this yourself:

1. Configure `WP_DEBUG` and `SCRIPT_DEBUG` to false by creating a `.wp-env.override.json` file with the following contents:

```json
{
  "config": {
    "WP_DEBUG": false,
    "SCRIPT_DEBUG": false
  }
}
```

2. Start the wp-env with xdebug enabled by running `npm run wp-env start -- --xdebug=develop,debug,profile`
3. Load the "Hello World!" post by visiting http://localhost:8888/?p=1
4. Take the cachegrind data generated by xdebug out of docker:

```sh
# List and find the latest timestamp of cachegrind.out.* files
docker exec -it `docker ps -f name=54_wordpress_1 -q` ls -lat --time-style=+%H:%M:%S /tmp/
# Copy from docker to manipulate with any tool in your computer
docker cp `docker ps -f name=54_wordpress_1 -q`:'/tmp/cachegrind.out.<pid-with-latest-timestamp>' ~/Desktop/
```

- Inspect the time it takes with any tool of your choice. I use kcachegrind, but there are alternatives such as qcachegrind, webgrind, etc. kcachegrind shows times aggregated by 10ns, so the total included time of the request in the following screenshot would be 350 442 020ns, which amounts to 350ms.

![Captura de ecrã de 2022-10-28 13-13-26](https://user-images.githubusercontent.com/583546/198574623-d1c02a25-1a63-4bf2-808a-f4b7e2f16cbb.png)

## How to test

- Make sure automated test pass.
- Test block theme (TwentyTwentyThree)
  - Create new colors as user from the GS sidebar and verify they are shown in the color components in the block sidebar (site editor, post editor).
  - Modify theme.json settings of the theme
- Test classic theme (TwentyTwenty)
  - Verify colors defined by the theme via `add_theme_support( 'editor-color-palette', $palette )` work as expected.
  - Disable custom colors by adding `add_theme_support( 'disable-custom-colors' );` to the `functions.php` of the theme. Verify that users cannot add custom colors.
