### PR TITLE
Deprecate `WP_Theme_JSON_Resolver:theme_has_support()`

### DIFF
--- a/lib/compat/wordpress-6.2/class-wp-theme-json-resolver-6-2.php
+++ b/lib/compat/wordpress-6.2/class-wp-theme-json-resolver-6-2.php
@@ -27,7 +27,7 @@ class WP_Theme_JSON_Resolver_6_2 extends WP_Theme_JSON_Resolver_6_1 {
 	 * @return bool
 	 */
 	public static function theme_has_support() {
-		_deprecated_function( __METHOD__, '6.2.0', 'wp_theme_has_theme_json()');
+		_deprecated_function( __METHOD__, '6.2.0', 'wp_theme_has_theme_json()' );
 
 		return wp_theme_has_theme_json();
 	}

--- a/lib/compat/wordpress-6.2/class-wp-theme-json-resolver-6-2.php
+++ b/lib/compat/wordpress-6.2/class-wp-theme-json-resolver-6-2.php
@@ -1,0 +1,35 @@
+<?php
+/**
+ * WP_Theme_JSON_Resolver_6_1 class
+ *
+ * @package gutenberg
+ */
+
+/**
+ * Class that abstracts the processing of the different data sources
+ * for site-level config and offers an API to work with them.
+ *
+ * This class is for internal core usage and is not supposed to be used by extenders (plugins and/or themes).
+ * This is a low-level API that may need to do breaking changes. Please,
+ * use get_global_settings, get_global_styles, and get_global_stylesheet instead.
+ *
+ * @access private
+ */
+class WP_Theme_JSON_Resolver_6_2 extends WP_Theme_JSON_Resolver_6_1 {
+
+	/**
+	 * Determines whether the active theme has a theme.json file.
+	 *
+	 * @since 5.8.0
+	 * @since 5.9.0 Added a check in the parent theme.
+	 * @deprecated 6.2.0 Use wp_theme_has_theme_json() instead.
+	 *
+	 * @return bool
+	 */
+	public static function theme_has_support() {
+		_deprecated_function( __METHOD__, '6.2.0' );
+
+		return wp_theme_has_theme_json();
+	}
+
+}

--- a/lib/compat/wordpress-6.2/class-wp-theme-json-resolver-6-2.php
+++ b/lib/compat/wordpress-6.2/class-wp-theme-json-resolver-6-2.php
@@ -27,7 +27,7 @@ class WP_Theme_JSON_Resolver_6_2 extends WP_Theme_JSON_Resolver_6_1 {
 	 * @return bool
 	 */
 	public static function theme_has_support() {
-		_deprecated_function( __METHOD__, '6.2.0' );
+		_deprecated_function( __METHOD__, '6.2.0', 'wp_theme_has_theme_json()');
 
 		return wp_theme_has_theme_json();
 	}

--- a/lib/experimental/class-wp-theme-json-resolver-gutenberg.php
+++ b/lib/experimental/class-wp-theme-json-resolver-gutenberg.php
@@ -15,7 +15,7 @@
  *
  * @access private
  */
-class WP_Theme_JSON_Resolver_Gutenberg extends WP_Theme_JSON_Resolver_6_1 {
+class WP_Theme_JSON_Resolver_Gutenberg extends WP_Theme_JSON_Resolver_6_2 {
 	/**
 	 * Returns the theme's data.
 	 *

--- a/lib/load.php
+++ b/lib/load.php
@@ -88,8 +88,6 @@ require __DIR__ . '/compat/wordpress-6.1/blocks.php';
 require __DIR__ . '/compat/wordpress-6.1/block-editor-settings.php';
 require __DIR__ . '/compat/wordpress-6.1/persisted-preferences.php';
 require __DIR__ . '/compat/wordpress-6.1/get-global-styles-and-settings.php';
-require __DIR__ . '/compat/wordpress-6.2/get-global-styles-and-settings.php';
-require __DIR__ . '/compat/wordpress-6.2/default-filters.php';
 require __DIR__ . '/compat/wordpress-6.1/class-wp-theme-json-data-gutenberg.php';
 require __DIR__ . '/compat/wordpress-6.1/class-wp-theme-json-6-1.php';
 require __DIR__ . '/compat/wordpress-6.1/class-wp-theme-json-resolver-6-1.php';
@@ -104,6 +102,9 @@ require __DIR__ . '/compat/wordpress-6.1/theme.php';
 
 // WordPress 6.2 compat.
 require __DIR__ . '/compat/wordpress-6.2/script-loader.php';
+require __DIR__ . '/compat/wordpress-6.2/get-global-styles-and-settings.php';
+require __DIR__ . '/compat/wordpress-6.2/default-filters.php';
+require __DIR__ . '/compat/wordpress-6.2/class-wp-theme-json-resolver-6-2.php';
 
 // Experimental features.
 remove_action( 'plugins_loaded', '_wp_theme_json_webfonts_handler' ); // Turns off WP 6.0's stopgap handler for Webfonts API.


### PR DESCRIPTION
Part of https://github.com/WordPress/gutenberg/issues/45171

## What?

This PR deprecates the `WP_Theme_JSON_Resolver:theme_has_support()` method.

## Why?

https://github.com/WordPress/gutenberg/pull/45168 introduced a new public API for querying whether the theme has a `theme.json`: `wp_them_has_theme_json()`. This deprecates the private one.

## How?

Uses the `_deprecate_method` function and provides `wp_theme_has_theme_json` as an alternative.

## Testing Instructions

Verify that everything works as expected with this PR.

- Load the front and check global styles.
- Load the editor and check presets, etc.

Verify that using the deprecated method triggers a notice in debug mode:

- Substitute `wp_theme_has_theme_json()` by `WP_Theme_JSON_Resolver_Gutenberg::theme_has_support()` in `lib/client-assets.php`.
- Make sure debug mode is enabled in your environment: `define( 'WP_DEBUG', true );`
- Load the front-end and verify that there is a message 

![image](https://user-images.githubusercontent.com/583546/198590992-e83f5180-98b6-4b0a-820c-a1efcb3473b4.png)

Verify that using the deprecated method does not trigger a notice when debug mode is disabled:

- Substitute `wp_theme_has_theme_json()` by `WP_Theme_JSON_Resolver_Gutenberg::theme_has_support()` in `lib/client-assets.php`.
- Make sure debug mode is disabled in your environment: `define( 'WP_DEBUG', false );`
- Load the front-end and verify that there is no message .
