### PR TITLE
Wrap the title in the Link Control edit screen

### DIFF
--- a/packages/block-editor/src/components/link-control/style.scss
+++ b/packages/block-editor/src/components/link-control/style.scss
@@ -239,6 +239,7 @@ $preview-image-height: 140px;
 	.block-editor-link-control__search-item-title {
 		overflow: hidden;
 		text-overflow: ellipsis;
+		word-break: break-word;
 
 		.components-external-link__icon {
 			position: absolute;


### PR DESCRIPTION
## What?
This PR makes long titles in the Link Control edit screen wrap to multiple lines. 

When a title can't be retrieved through the API, the link's text is shown as the title instead. This causes a very long line that overflows, making the edit & unlink icons inaccessible.

## Why?
It partially fixes [this issue](https://github.com/Automattic/wp-calypso/issues/69563#issuecomment-1294948370).

## How?
Added `word-break: break-word;` to `.block-editor-link-control__search-item-title`

## Testing Instructions
1. Checkout this branch
2. Type a long text without spaces
3. Select the link control and link it to a non-existing domain such as http://thisdomainwillnotgiveyouanyinfo.com
4. Verify that the title is split on multiple lines 

## Screenshots or screencast <!-- if applicable -->
| Before                                                                                                         | After                                                                                                         |
|----------------------------------------------------------------------------------------------------------------|---------------------------------------------------------------------------------------------------------------|
| ![Before](https://user-images.githubusercontent.com/528287/198641969-9a9811b3-dc34-455e-b700-6552513766d4.png) | ![After](https://user-images.githubusercontent.com/528287/198642030-538e0504-ca59-4271-89a1-390ba575f5de.png) |