### PR TITLE
Clarify explanation of how 'Convert to Links' works in Page List block

### DIFF
--- a/packages/block-library/src/page-list/convert-to-links-modal.js
+++ b/packages/block-library/src/page-list/convert-to-links-modal.js
@@ -91,19 +91,25 @@ export default function ConvertToLinksModal( { onClose, clientId } ) {
 		<Modal
 			closeLabel={ __( 'Close' ) }
 			onRequestClose={ onClose }
-			title={ __( 'Convert to links' ) }
+			title={ __( 'Customize your navigation menu' ) }
 			className={ 'wp-block-page-list-modal' }
 			aria={ { describedby: 'wp-block-page-list-modal__description' } }
 		>
 			<p id={ 'wp-block-page-list-modal__description' }>
 				{ __(
-					'To edit this navigation menu, convert it to single page links. This allows you to add, re-order, remove items, or edit their labels.'
+					'We’ve provided a default list of your published pages so you can get started quickly. If you’d prefer to edit this menu, click the Convert button below — converting will allow you to add, re-order, and remove items, or edit their labels.'
 				) }
 			</p>
 			<p>
 				{ __(
-					"Note: if you add new pages to your site, you'll need to add them to your navigation menu."
+					'If you previously created a menu in a classic theme, converting will allow you to import it.'
 				) }
+			</p>
+			<p>
+				<a href="https://wordpress.org/support/article/navigation-block/">
+					{ __( 'Click here' ) }
+				</a>
+				{ __( ' to learn more about menu management.' ) }
 			</p>
 			<div className="wp-block-page-list-modal-buttons">
 				<Button variant="tertiary" onClick={ onClose }>

--- a/packages/block-library/src/page-list/convert-to-links-modal.js
+++ b/packages/block-library/src/page-list/convert-to-links-modal.js
@@ -107,9 +107,8 @@ export default function ConvertToLinksModal( { onClose, clientId } ) {
 			</p>
 			<p>
 				<a href="https://wordpress.org/support/article/navigation-block/">
-					{ __( 'Click here' ) }
+					{ __( 'Click here to learn more about menu management.' ) }
 				</a>
-				{ __( ' to learn more about menu management.' ) }
 			</p>
 			<div className="wp-block-page-list-modal-buttons">
 				<Button variant="tertiary" onClick={ onClose }>

--- a/packages/block-library/src/page-list/convert-to-links-modal.js
+++ b/packages/block-library/src/page-list/convert-to-links-modal.js
@@ -100,11 +100,6 @@ export default function ConvertToLinksModal( { onClose, clientId } ) {
 					'This menu is automatically kept in sync with pages on your site. You can manage the menu yourself by clicking customize below.'
 				) }
 			</p>
-			<p>
-				{ __(
-					'Tip: If you want to return to a managed menu, simply add a new menu item and pick the Pages List block.'
-				) }
-			</p>
 			<div className="wp-block-page-list-modal-buttons">
 				<Button variant="tertiary" onClick={ onClose }>
 					{ __( 'Cancel' ) }

--- a/packages/block-library/src/page-list/convert-to-links-modal.js
+++ b/packages/block-library/src/page-list/convert-to-links-modal.js
@@ -7,6 +7,7 @@ import { useDispatch } from '@wordpress/data';
 import { useEntityRecords } from '@wordpress/core-data';
 import { createBlock as create } from '@wordpress/blocks';
 import { store as blockEditorStore } from '@wordpress/block-editor';
+import { createInterpolateElement } from '@wordpress/element';
 
 const PAGE_FIELDS = [ 'id', 'title', 'link', 'type', 'parent' ];
 const MAX_PAGE_COUNT = 100;
@@ -106,9 +107,10 @@ export default function ConvertToLinksModal( { onClose, clientId } ) {
 				) }
 			</p>
 			<p>
-				<a href="https://wordpress.org/support/article/navigation-block/">
-					{ __( 'Click here to learn more about menu management.' ) }
-				</a>
+				{ createInterpolateElement(
+					__( '<a>Click here</a> to learn more about menu management.' ),
+					{ a: <a href="https://wordpress.org/support/article/navigation-block" /> }
+				) }
 			</p>
 			<div className="wp-block-page-list-modal-buttons">
 				<Button variant="tertiary" onClick={ onClose }>

--- a/packages/block-library/src/page-list/convert-to-links-modal.js
+++ b/packages/block-library/src/page-list/convert-to-links-modal.js
@@ -7,7 +7,6 @@ import { useDispatch } from '@wordpress/data';
 import { useEntityRecords } from '@wordpress/core-data';
 import { createBlock as create } from '@wordpress/blocks';
 import { store as blockEditorStore } from '@wordpress/block-editor';
-import { createInterpolateElement } from '@wordpress/element';
 
 const PAGE_FIELDS = [ 'id', 'title', 'link', 'type', 'parent' ];
 const MAX_PAGE_COUNT = 100;
@@ -92,24 +91,18 @@ export default function ConvertToLinksModal( { onClose, clientId } ) {
 		<Modal
 			closeLabel={ __( 'Close' ) }
 			onRequestClose={ onClose }
-			title={ __( 'Customize your navigation menu' ) }
+			title={ __( 'Customize this menu' ) }
 			className={ 'wp-block-page-list-modal' }
 			aria={ { describedby: 'wp-block-page-list-modal__description' } }
 		>
 			<p id={ 'wp-block-page-list-modal__description' }>
 				{ __(
-					'We’ve provided a default list of your published pages so you can get started quickly. If you’d prefer to edit this menu, click the Convert button below — converting will allow you to add, re-order, and remove items, or edit their labels.'
+					'This menu is automatically kept in sync with pages on your site. You can manage the menu yourself by clicking customize below.'
 				) }
 			</p>
 			<p>
 				{ __(
-					'If you previously created a menu in a classic theme, converting will allow you to import it.'
-				) }
-			</p>
-			<p>
-				{ createInterpolateElement(
-					__( '<a>Click here</a> to learn more about menu management.' ),
-					{ a: <a href="https://wordpress.org/support/article/navigation-block" /> }
+					'Tip: If you want to return to a managed menu, simply add a new menu item and pick the Pages List block.'
 				) }
 			</p>
 			<div className="wp-block-page-list-modal-buttons">
@@ -126,7 +119,7 @@ export default function ConvertToLinksModal( { onClose, clientId } ) {
 						createBlock: create,
 					} ) }
 				>
-					{ __( 'Convert' ) }
+					{ __( 'Customize' ) }
 				</Button>
 			</div>
 		</Modal>


### PR DESCRIPTION
## What?
Fixes https://github.com/WordPress/gutenberg/issues/44615.
This pull request clarifies the copy for the Convert to Links functionality in the Page List block, explaining where the current menu comes from and providing a link to the documentation, as per [this issue](https://github.com/WordPress/gutenberg/issues/44615).

## Why?
This will make the functionality clearer to users and cut down on confusion.

## How?
It's just a simple update of the copy.

## Testing Instructions
1. Select a Page List block in Full Site Editing mode
2. Click the 'edit' button

## Screenshot
<img width="1348" alt="Screen Shot 2022-10-28 at 3 33 01 PM" src="https://user-images.githubusercontent.com/5360536/198718078-d2d6891b-51a7-4b55-bd71-fccbc73411b3.png">
