### PR TITLE
Pullquote block: Unify cite element to block level

### DIFF
--- a/packages/block-library/src/pullquote/style.scss
+++ b/packages/block-library/src/pullquote/style.scss
@@ -30,6 +30,7 @@
 	cite,
 	footer {
 		position: relative;
+		display: block;
 	}
 	.has-text-color a {
 		color: inherit;
@@ -70,8 +71,4 @@
 			font-style: normal;
 		}
 	}
-}
-
-.wp-block-pullquote cite {
-	color: inherit;
 }


### PR DESCRIPTION
> [!NOTE]
> In #11610, it is being considered to deprecate the Pullquote block. If the Pullquote block is deprecated, I think this PR can be closed.

## What?
This PR Unify cite element to block level.

## Why?
On the editor, `cite` element is a `RichText` component, so `display:block` is applied. However, on the front end, the display property is not defined. Since `cite` tag is a [text-level semantics](https://html.spec.whatwg.org/multipage/text-level-semantics.html#the-cite-element), browsers should render it as `display:inline` by default. Therefore, the margins between the quote text and the cite text are slightly wider than those on the editor.

### Editor

 ![editor](https://user-images.githubusercontent.com/54422211/198861032-79f9c060-8800-437c-8ee2-d4881b14c629.png)  

### Front end

![front-end](https://user-images.githubusercontent.com/54422211/198861034-d1a1f4bd-24d1-4212-b79e-5380584a9a97.png) 

## How?
`display:block` applied to the front-end cite element.

## Testing Instructions
- Insert a pullquote block.
- Confirm that the margins of the quote text and cite text perfectly match (block heights match) in both the front end and the editor.

_Note:_ Twenty Twenty Three uses `clamp` for font size, so it would be difficult to accurately compare the differences between the editor and the front end.
Twenty Twenty Two or emptytheme would be appropriate.