### PR TITLE
Patterns: Fix PHP warning in categories REST API controller

### DIFF
--- a/lib/compat/wordpress-6.2/class-gutenberg-rest-block-pattern-categories-controller.php
+++ b/lib/compat/wordpress-6.2/class-gutenberg-rest-block-pattern-categories-controller.php
@@ -29,7 +29,7 @@ class Gutenberg_REST_Block_Pattern_Categories_Controller extends WP_REST_Block_P
 		$data   = array();
 		foreach ( $keys as $key ) {
 			if ( rest_is_field_included( $key, $fields ) ) {
-				$data[ $key ] = $item[ $key ];
+				$data[ $key ] = isset( $item[ $key ] ) ? $item[ $key ] : '';
 			}
 		}
 

--- a/lib/compat/wordpress-6.2/class-gutenberg-rest-block-pattern-categories-controller.php
+++ b/lib/compat/wordpress-6.2/class-gutenberg-rest-block-pattern-categories-controller.php
@@ -28,8 +28,8 @@ class Gutenberg_REST_Block_Pattern_Categories_Controller extends WP_REST_Block_P
 		$keys   = array( 'name', 'label', 'description' );
 		$data   = array();
 		foreach ( $keys as $key ) {
-			if ( rest_is_field_included( $key, $fields ) ) {
-				$data[ $key ] = isset( $item[ $key ] ) ? $item[ $key ] : '';
+			if ( isset( $item[ $key ] ) && rest_is_field_included( $key, $fields ) ) {
+				$data[ $key ] = $item[ $key ];
 			}
 		}
 


### PR DESCRIPTION
## What?
This is a follow-up to #45244.

PR fixes the PHP notice generated by `Gutenberg_REST_Block_Pattern_Categories_Controller` when the pattern category has no description.

```
 PHP Notice:  Undefined index: description in ~/gutenberg/lib/compat/wordpress-6.2/class-gutenberg-rest-block-pattern-categories-controller.php on line 32
```

## How?
Add checks for the item key and fallbacks back to an empty string if it's not set.

## Testing Instructions
1. Enable debugging.
2. Open a Post or Page.
3. Confirm there's no notice generated.
