### PR TITLE
TabPanel: add support for manual activation of tabs

### DIFF
--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -15,6 +15,7 @@
 
 -   `BoxControl` & `CustomSelectControl`: Add `onMouseOver` and `onMouseOut` callback props to allow handling of these events by parent components ([#44955](https://github.com/WordPress/gutenberg/pull/44955))
 -   `Popover`: A `variant` prop has been added to style popovers, with `'unstyled'` and `'toolbar'` possible values ([#45137](https://github.com/WordPress/gutenberg/pull/45137)).
+-   `TabPanel`: Add `manualTabActivation` prop to support manual activation of tabs([#45411](https://github.com/WordPress/gutenberg/pull/45411)).
 
 ### Enhancements
 
@@ -32,7 +33,7 @@
 -   `ItemGroup`: fix RTL `Item` styles when rendered as a button ([#45280](https://github.com/WordPress/gutenberg/pull/45280)).
 -   `Button`: Fix RTL alignment for buttons containing an icon and text ([#44787](https://github.com/WordPress/gutenberg/pull/44787)).
 -   `TabPanel`: Call `onSelect()` on every tab selection, regardless of whether it was triggered by user interaction ([#44028](https://github.com/WordPress/gutenberg/pull/44028)).
--   `FontSizePicker`: Fallback to font size `slug` if `name` is undefined  ([#45041](https://github.com/WordPress/gutenberg/pull/45041)).
+-   `FontSizePicker`: Fallback to font size `slug` if `name` is undefined ([#45041](https://github.com/WordPress/gutenberg/pull/45041)).
 -   `AutocompleterUI`: fix issue where autocompleter UI would appear on top of other UI elements ([#44795](https://github.com/WordPress/gutenberg/pull/44795/))
 
 ### Internal
@@ -57,7 +58,7 @@
 -   `FontSizePicker`: Ensure that fluid font size presets appear correctly in the UI controls ([#44791](https://github.com/WordPress/gutenberg/pull/44791)).
 -   `ToggleGroupControl`: Remove unsupported `disabled` prop from types, and correctly mark `label` prop as required ([#45114](https://github.com/WordPress/gutenberg/pull/45114)).
 -   `Navigator`: prevent partially hiding focus ring styles, by removing unnecessary overflow rules on `NavigatorScreen` ([#44973](https://github.com/WordPress/gutenberg/pull/44973)).
--   `Navigator`: restore focus only once per location  ([#44972](https://github.com/WordPress/gutenberg/pull/44972)).
+-   `Navigator`: restore focus only once per location ([#44972](https://github.com/WordPress/gutenberg/pull/44972)).
 
 ### Documentation
 

--- a/packages/components/src/tab-panel/index.tsx
+++ b/packages/components/src/tab-panel/index.tsx
@@ -80,6 +80,7 @@ export function TabPanel( {
 	initialTabName,
 	orientation = 'horizontal',
 	activeClass = 'is-active',
+	manualTabActivation = false,
 	onSelect,
 }: WordPressComponentProps< TabPanelProps, 'div', false > ) {
 	const instanceId = useInstanceId( TabPanel, 'tab-panel' );
@@ -136,6 +137,7 @@ export function TabPanel( {
 					role="tabpanel"
 					id={ `${ selectedId }-view` }
 					className="components-tab-panel__tab-content"
+					tabIndex={ manualTabActivation ? -1 : undefined }
 				>
 					{ children( selectedTab ) }
 				</div>

--- a/packages/components/src/tab-panel/types.ts
+++ b/packages/components/src/tab-panel/types.ts
@@ -59,6 +59,12 @@ export type TabPanelProps = {
 	 */
 	orientation?: 'horizontal' | 'vertical';
 	/**
+	 * If true, the tabpanel will not activated automatically when a tab is selected.
+	 *
+	 * @default `false`
+	 */
+	manualTabActivation?: boolean;
+	/**
 	 * Array of tab objects. Each tab object should contain at least a `name` and a `title`.
 	 */
 	tabs: Tab[];


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Resolves: https://github.com/WordPress/gutenberg/issues/45390

From the issue:

> Currently the `TabPanel`'s tabpanels are activated automatically when the associated tab receives focus (referred to as "Tabs with automatic activation" on [the W3C website](https://www.w3.org/WAI/ARIA/apg/patterns/tabpanel/)).

> However, as discussed in https://github.com/WordPress/gutenberg/pull/44788#issuecomment-1293826203 and in https://github.com/WordPress/gutenberg/pull/45203#discussion_r1006643474, there instances in which the automatic activation doesn't fit the UX and keyboard navigation needs.

> We should look into allowing the `TabPanel` to support manual activation as well, alongside automatic activation.

