### PR TITLE
SpacingSizesControl: Remove UnitControl inline style use

### DIFF
--- a/packages/block-editor/src/components/spacing-sizes-control/spacing-input-control.js
+++ b/packages/block-editor/src/components/spacing-sizes-control/spacing-input-control.js
@@ -233,7 +233,6 @@ export default function SpacingInputControl( {
 						label={ ariaLabel }
 						hideLabelFromVision={ true }
 						className="components-spacing-sizes-control__custom-value-input"
-						style={ { gridColumn: '1' } }
 						size={ '__unstable-large' }
 					/>
 

--- a/packages/block-editor/src/components/spacing-sizes-control/style.scss
+++ b/packages/block-editor/src/components/spacing-sizes-control/style.scss
@@ -91,6 +91,7 @@
 	.components-spacing-sizes-control__custom-value-input {
 		width: 124px;
 		margin-top: 8px;
+		grid-column: 1;
 	}
 
 	.components-range-control {


### PR DESCRIPTION
Related:
- https://github.com/WordPress/gutenberg/pull/45340
- https://github.com/WordPress/gutenberg/pull/45139

## What?

- Removes unnecessary use of UnitControl inline style.
- Fixes broken display of block gap spacing control.

Note: There are two other uses of inline styles on a UnitControl. However, those are for the native version of that control and don't require updating now.

## Why?

After the changes from https://github.com/WordPress/gutenberg/pull/45139, the styles prop is passed to the UnitControl's inner input. This PR removes the only use of inline styles on the web version of `UnitControl` within Gutenberg.

## How?

Move the inline style to the unique class name that is already applied to that `UnitControl`.

## Testing Instructions

1. Edit a post, add a group block, and select it.
2. Navigate to the block gap spacing control in the sidebar and switch to the custom input view. Note the broken layout.
3. Checkout this PR, reload the editor and reselect the block
4. Navigate back to the block gap control and switch to the custom input view again. Its layout should be correct now.
5. Play around with the margin and padding controls ensuring everything there is still laid out correctly.

## Screenshots or screencast <!-- if applicable -->

| Before | After |
|---|---|
| <img width="277" alt="Screenshot 2022-10-31 at 6 22 06 pm" src="https://user-images.githubusercontent.com/60436221/198963531-9c6641ab-6ff4-40a5-9d35-069190ec3d65.png"> | <img width="277" alt="Screenshot 2022-10-31 at 6 21 43 pm" src="https://user-images.githubusercontent.com/60436221/198963549-271e3902-bf05-4891-9092-7200d5de145e.png"> |

