### PR TITLE
I18n: Fix handling of nullish pot comments

### DIFF
--- a/packages/i18n/tools/pot-to-php.js
+++ b/packages/i18n/tools/pot-to-php.js
@@ -44,7 +44,7 @@ function convertTranslationToPHP( translation, textdomain, context = '' ) {
 
 	// The format of gettext-js matches the terminology in gettext itself.
 	let original = translation.msgid;
-	const comments = translation.comments;
+	const comments = translation.comments ?? {};
 
 	if ( Object.values( comments ).length ) {
 		if ( comments.reference ) {


### PR DESCRIPTION
## What?
This PR fixes the handling of nullish comments in the pot-to-PHP script.

## Why?
To fix the bug reported in https://github.com/WordPress/gutenberg/pull/43677#pullrequestreview-1161365813.

## How?
We're falling back to an object in case it's nullish.

## Testing Instructions
* Verify test instructions from #43677 still work.
* Follow @manzoorwanijk's instructions to ensure you can no longer reproduce: https://github.com/WordPress/gutenberg/pull/43677#discussion_r1009352581

