### PR TITLE
hide insertion point when moving out of the canvas

### DIFF
--- a/packages/block-editor/src/components/block-tools/insertion-point.js
+++ b/packages/block-editor/src/components/block-tools/insertion-point.js
@@ -25,7 +25,7 @@ function InbetweenInsertionPointPopover( {
 	__unstablePopoverSlot,
 	__unstableContentRef,
 } ) {
-	const { selectBlock } = useDispatch( blockEditorStore );
+	const { selectBlock, hideInsertionPoint } = useDispatch( blockEditorStore );
 	const openRef = useContext( InsertionPointOpenRef );
 	const ref = useRef();
 	const {
@@ -86,6 +86,14 @@ function InbetweenInsertionPointPopover( {
 	function onClick( event ) {
 		if ( event.target === ref.current && nextClientId ) {
 			selectBlock( nextClientId, -1 );
+		}
+	}
+
+	function maybeHideInserterPoint( event ) {
+		// Only hide the inserter if it's triggered on the wrapper,
+		// and the inserter is not open.
+		if ( event.target === ref.current && ! openRef.current ) {
+			hideInsertionPoint();
 		}
 	}
 
@@ -200,6 +208,7 @@ function InbetweenInsertionPointPopover( {
 				className={ classnames( className, {
 					'is-with-inserter': isInserterShown,
 				} ) }
+				onHoverEnd={ maybeHideInserterPoint }
 			>
 				<motion.div
 					variants={ lineVariants }


### PR DESCRIPTION
fixes #45418

## What?

It's very tricky to address all the situations where we have to hide the insertion point. This one for instance is about leaving  the canvas in Chrome.

## Testing Instructions

1- Hover between two blocks to show the insertion point while the sidebar is open
2- Move the mouse directly into the sidebar
3- The insertion point should hide itself.

This PR address one case, it's not clear whether it's the only case or not.