### PR TITLE
Block Editor: Improve `MediaReplaceFlow` tests

### DIFF
--- a/packages/block-editor/src/components/media-replace-flow/test/index.js
+++ b/packages/block-editor/src/components/media-replace-flow/test/index.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { render, fireEvent } from '@testing-library/react';
+import { render, fireEvent, screen } from '@testing-library/react';
 
 /**
  * WordPress dependencies
@@ -38,73 +38,82 @@ function setUpMediaReplaceFlow() {
 
 describe( 'General media replace flow', () => {
 	it( 'renders successfully', () => {
-		const container = setUpMediaReplaceFlow();
+		setUpMediaReplaceFlow();
 
-		const mediaReplaceButton = container.querySelector(
-			'button[aria-expanded="false"]'
-		);
+		const mediaReplaceButton = screen.getByRole( 'button', {
+			expanded: false,
+		} );
 
-		expect( mediaReplaceButton ).not.toBeNull();
+		expect( mediaReplaceButton ).toBeVisible();
 	} );
 
 	it( 'renders replace menu', () => {
-		const container = setUpMediaReplaceFlow();
+		setUpMediaReplaceFlow();
 
-		const mediaReplaceButton = container.querySelector(
-			'button[aria-expanded="false"]'
-		);
+		const mediaReplaceButton = screen.getByRole( 'button', {
+			expanded: false,
+		} );
 		mediaReplaceButton.click();
 
-		const uploadMenu = container.querySelector(
-			'.block-editor-media-replace-flow__media-upload-menu'
-		);
+		const uploadMenu = screen.getByRole( 'menu' );
 
-		expect( uploadMenu ).not.toBeNull();
+		expect( uploadMenu ).toBeInTheDocument();
+		expect( uploadMenu ).not.toBeVisible();
 	} );
 
 	it( 'displays media URL', () => {
-		const container = setUpMediaReplaceFlow();
+		setUpMediaReplaceFlow();
 
-		const mediaReplaceButton = container.querySelector(
-			'button[aria-expanded="false"]'
-		);
+		const mediaReplaceButton = screen.getByRole( 'button', {
+			expanded: false,
+		} );
+
 		mediaReplaceButton.click();
 
-		const mediaURL = container.querySelector( '.components-external-link' );
+		const mediaURL = screen.getByRole( 'link', {
+			name: 'example.media (opens in a new tab)',
+		} );
 
-		expect( mediaURL.href ).toEqual( 'https://example.media/' );
+		expect( mediaURL ).toHaveAttribute( 'href', 'https://example.media' );
 	} );
 
 	it( 'edits media URL', () => {
-		const container = setUpMediaReplaceFlow();
+		setUpMediaReplaceFlow();
 
-		const mediaReplaceButton = container.querySelector(
-			'button[aria-expanded="false"]'
-		);
+		const mediaReplaceButton = screen.getByRole( 'button', {
+			expanded: false,
+		} );
+
 		mediaReplaceButton.click();
 
-		const editMediaURL = container.querySelector(
-			'.block-editor-link-control__search-item-action'
-		);
+		const editMediaURL = screen.getByRole( 'button', {
+			name: 'Edit',
+		} );
 
 		editMediaURL.click();
 
-		const mediaURLInput = container.querySelector(
-			'.block-editor-url-input__input'
-		);
+		const mediaURLInput = screen.getByRole( 'combobox', {
+			name: 'URL',
+			expanded: false,
+		} );
 
 		fireEvent.change( mediaURLInput, {
 			target: { value: 'https://new.example.media' },
 		} );
 
-		const saveMediaURLButton = container.querySelector(
-			'.block-editor-link-control__search-submit'
-		);
+		const saveMediaURLButton = screen.getByRole( 'button', {
+			name: 'Submit',
+		} );
 
 		saveMediaURLButton.click();
 
-		const mediaURL = container.querySelector( '.components-external-link' );
+		const mediaURL = screen.getByRole( 'link', {
+			name: 'new.example.media (opens in a new tab)',
+		} );
 
-		expect( mediaURL.href ).toEqual( 'https://new.example.media/' );
+		expect( mediaURL ).toHaveAttribute(
+			'href',
+			'https://new.example.media'
+		);
 	} );
 } );

--- a/packages/block-editor/src/components/media-replace-flow/test/index.js
+++ b/packages/block-editor/src/components/media-replace-flow/test/index.js
@@ -36,11 +36,11 @@ describe( 'General media replace flow', () => {
 	it( 'renders successfully', () => {
 		render( <TestWrapper /> );
 
-		const mediaReplaceButton = screen.getByRole( 'button', {
-			expanded: false,
-		} );
-
-		expect( mediaReplaceButton ).toBeVisible();
+		expect(
+			screen.getByRole( 'button', {
+				expanded: false,
+			} )
+		).toBeVisible();
 	} );
 
 	it( 'renders replace menu', async () => {
@@ -50,11 +50,11 @@ describe( 'General media replace flow', () => {
 
 		render( <TestWrapper /> );
 
-		const mediaReplaceButton = screen.getByRole( 'button', {
-			expanded: false,
-		} );
-
-		await user.click( mediaReplaceButton );
+		await user.click(
+			screen.getByRole( 'button', {
+				expanded: false,
+			} )
+		);
 
 		const uploadMenu = screen.getByRole( 'menu' );
 
@@ -69,17 +69,17 @@ describe( 'General media replace flow', () => {
 
 		render( <TestWrapper /> );
 
-		const mediaReplaceButton = screen.getByRole( 'button', {
-			expanded: false,
-		} );
+		await user.click(
+			screen.getByRole( 'button', {
+				expanded: false,
+			} )
+		);
 
-		await user.click( mediaReplaceButton );
-
-		const mediaURL = screen.getByRole( 'link', {
-			name: 'example.media (opens in a new tab)',
-		} );
-
-		expect( mediaURL ).toHaveAttribute( 'href', 'https://example.media' );
+		expect(
+			screen.getByRole( 'link', {
+				name: 'example.media (opens in a new tab)',
+			} )
+		).toHaveAttribute( 'href', 'https://example.media' );
 	} );
 
 	it( 'edits media URL', async () => {
@@ -89,17 +89,17 @@ describe( 'General media replace flow', () => {
 
 		render( <TestWrapper /> );
 
-		const mediaReplaceButton = screen.getByRole( 'button', {
-			expanded: false,
-		} );
+		await user.click(
+			screen.getByRole( 'button', {
+				expanded: false,
+			} )
+		);
 
-		await user.click( mediaReplaceButton );
-
-		const editMediaURL = screen.getByRole( 'button', {
-			name: 'Edit',
-		} );
-
-		await user.click( editMediaURL );
+		await user.click(
+			screen.getByRole( 'button', {
+				name: 'Edit',
+			} )
+		);
 
 		const mediaURLInput = screen.getByRole( 'combobox', {
 			name: 'URL',
@@ -109,19 +109,16 @@ describe( 'General media replace flow', () => {
 		await user.clear( mediaURLInput );
 		await user.type( mediaURLInput, 'https://new.example.media' );
 
-		const saveMediaURLButton = screen.getByRole( 'button', {
-			name: 'Submit',
-		} );
-
-		await user.click( saveMediaURLButton );
-
-		const mediaURL = screen.getByRole( 'link', {
-			name: 'new.example.media (opens in a new tab)',
-		} );
-
-		expect( mediaURL ).toHaveAttribute(
-			'href',
-			'https://new.example.media'
+		await user.click(
+			screen.getByRole( 'button', {
+				name: 'Submit',
+			} )
 		);
+
+		expect(
+			screen.getByRole( 'link', {
+				name: 'new.example.media (opens in a new tab)',
+			} )
+		).toHaveAttribute( 'href', 'https://new.example.media' );
 	} );
 } );

--- a/packages/block-editor/src/components/media-replace-flow/test/index.js
+++ b/packages/block-editor/src/components/media-replace-flow/test/index.js
@@ -31,14 +31,9 @@ function TestWrapper() {
 	);
 }
 
-function setUpMediaReplaceFlow() {
-	const { container } = render( <TestWrapper /> );
-	return container;
-}
-
 describe( 'General media replace flow', () => {
 	it( 'renders successfully', () => {
-		setUpMediaReplaceFlow();
+		render( <TestWrapper /> );
 
 		const mediaReplaceButton = screen.getByRole( 'button', {
 			expanded: false,
@@ -48,7 +43,7 @@ describe( 'General media replace flow', () => {
 	} );
 
 	it( 'renders replace menu', () => {
-		setUpMediaReplaceFlow();
+		render( <TestWrapper /> );
 
 		const mediaReplaceButton = screen.getByRole( 'button', {
 			expanded: false,
@@ -62,7 +57,7 @@ describe( 'General media replace flow', () => {
 	} );
 
 	it( 'displays media URL', () => {
-		setUpMediaReplaceFlow();
+		render( <TestWrapper /> );
 
 		const mediaReplaceButton = screen.getByRole( 'button', {
 			expanded: false,
@@ -78,7 +73,7 @@ describe( 'General media replace flow', () => {
 	} );
 
 	it( 'edits media URL', () => {
-		setUpMediaReplaceFlow();
+		render( <TestWrapper /> );
 
 		const mediaReplaceButton = screen.getByRole( 'button', {
 			expanded: false,

--- a/packages/block-editor/src/components/media-replace-flow/test/index.js
+++ b/packages/block-editor/src/components/media-replace-flow/test/index.js
@@ -39,6 +39,7 @@ describe( 'General media replace flow', () => {
 		expect(
 			screen.getByRole( 'button', {
 				expanded: false,
+				name: 'Replace',
 			} )
 		).toBeVisible();
 	} );
@@ -53,6 +54,7 @@ describe( 'General media replace flow', () => {
 		await user.click(
 			screen.getByRole( 'button', {
 				expanded: false,
+				name: 'Replace',
 			} )
 		);
 
@@ -72,6 +74,7 @@ describe( 'General media replace flow', () => {
 		await user.click(
 			screen.getByRole( 'button', {
 				expanded: false,
+				name: 'Replace',
 			} )
 		);
 
@@ -92,6 +95,7 @@ describe( 'General media replace flow', () => {
 		await user.click(
 			screen.getByRole( 'button', {
 				expanded: false,
+				name: 'Replace',
 			} )
 		);
 

--- a/packages/block-editor/src/components/media-replace-flow/test/index.js
+++ b/packages/block-editor/src/components/media-replace-flow/test/index.js
@@ -1,7 +1,8 @@
 /**
  * External dependencies
  */
-import { render, fireEvent, screen } from '@testing-library/react';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 
 /**
  * WordPress dependencies
@@ -42,13 +43,18 @@ describe( 'General media replace flow', () => {
 		expect( mediaReplaceButton ).toBeVisible();
 	} );
 
-	it( 'renders replace menu', () => {
+	it( 'renders replace menu', async () => {
+		const user = userEvent.setup( {
+			advanceTimers: jest.advanceTimersByTime,
+		} );
+
 		render( <TestWrapper /> );
 
 		const mediaReplaceButton = screen.getByRole( 'button', {
 			expanded: false,
 		} );
-		mediaReplaceButton.click();
+
+		await user.click( mediaReplaceButton );
 
 		const uploadMenu = screen.getByRole( 'menu' );
 
@@ -56,14 +62,18 @@ describe( 'General media replace flow', () => {
 		expect( uploadMenu ).not.toBeVisible();
 	} );
 
-	it( 'displays media URL', () => {
+	it( 'displays media URL', async () => {
+		const user = userEvent.setup( {
+			advanceTimers: jest.advanceTimersByTime,
+		} );
+
 		render( <TestWrapper /> );
 
 		const mediaReplaceButton = screen.getByRole( 'button', {
 			expanded: false,
 		} );
 
-		mediaReplaceButton.click();
+		await user.click( mediaReplaceButton );
 
 		const mediaURL = screen.getByRole( 'link', {
 			name: 'example.media (opens in a new tab)',
@@ -72,35 +82,38 @@ describe( 'General media replace flow', () => {
 		expect( mediaURL ).toHaveAttribute( 'href', 'https://example.media' );
 	} );
 
-	it( 'edits media URL', () => {
+	it( 'edits media URL', async () => {
+		const user = userEvent.setup( {
+			advanceTimers: jest.advanceTimersByTime,
+		} );
+
 		render( <TestWrapper /> );
 
 		const mediaReplaceButton = screen.getByRole( 'button', {
 			expanded: false,
 		} );
 
-		mediaReplaceButton.click();
+		await user.click( mediaReplaceButton );
 
 		const editMediaURL = screen.getByRole( 'button', {
 			name: 'Edit',
 		} );
 
-		editMediaURL.click();
+		await user.click( editMediaURL );
 
 		const mediaURLInput = screen.getByRole( 'combobox', {
 			name: 'URL',
 			expanded: false,
 		} );
 
-		fireEvent.change( mediaURLInput, {
-			target: { value: 'https://new.example.media' },
-		} );
+		await user.clear( mediaURLInput );
+		await user.type( mediaURLInput, 'https://new.example.media' );
 
 		const saveMediaURLButton = screen.getByRole( 'button', {
 			name: 'Submit',
 		} );
 
-		saveMediaURLButton.click();
+		await user.click( saveMediaURLButton );
 
 		const mediaURL = screen.getByRole( 'link', {
 			name: 'new.example.media (opens in a new tab)',


### PR DESCRIPTION
## What?
This PR improves the tests of `MediaReplaceFlow` by adhering to the best practices followed by most of our tests.

## Why?
Having a coherent codebase and following the best practices for writing explicit, readable, and maintainable tests.

## How?
We're doing a few improvements:
* Using `screen` queries instead of `container.querySelector`. That fixes a few [`no-container`](https://github.com/testing-library/eslint-plugin-testing-library/blob/main/docs/rules/no-container.md) violations. This is the primary motivation for this PR in the first place.
* Rendering specifically in each test. Motivation for this is making the test code more explicit, but it's for a similar reason like the [`no-render-in-setup`](https://github.com/testing-library/eslint-plugin-testing-library/blob/main/docs/rules/no-render-in-setup.md) rule.
* Using `user-event` instead of `fireEvent`. See https://github.com/testing-library/dom-testing-library/issues/107 for motivation.
* Removing variables that are used only once and inlining them to remove boilerplate.

## Testing Instructions
Verify tests still pass: `npm run test:unit packages/block-editor/src/components/media-replace-flow/test/index.js`

cc @brookewp as I know she's been tackling related work.