### PR TITLE
useFocusableIframe: Refactor to TypeScript

### DIFF
--- a/packages/components/src/focusable-iframe/index.js
+++ b/packages/components/src/focusable-iframe/index.js
@@ -9,7 +9,6 @@ import deprecated from '@wordpress/deprecated';
  * @param {import('react').Ref<HTMLIFrameElement>} props.iframeRef
  */
 export default function FocusableIframe( { iframeRef, ...props } ) {
-	// @ts-expect-error: Return type for useFocusableIframe() is incorrect.
 	const ref = useMergeRefs( [ iframeRef, useFocusableIframe() ] );
 	deprecated( 'wp.components.FocusableIframe', {
 		since: '5.9',

--- a/packages/compose/CHANGELOG.md
+++ b/packages/compose/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 -   `useDisabled`: Refactor the component to rely on the HTML `inert` attribute ([#44865](https://github.com/WordPress/gutenberg/pull/44865)).
 -   `useFocusOutside`: Refactor the hook to TypeScript, rewrite tests using modern RTL and jest features ([#45317](https://github.com/WordPress/gutenberg/pull/45317)).
+-   `useFocusableIframe`: Refactor to TypeScript ([#45428](https://github.com/WordPress/gutenberg/pull/45428)).
 
 ## 5.18.0 (2022-10-19)
 

--- a/packages/compose/README.md
+++ b/packages/compose/README.md
@@ -326,7 +326,7 @@ Dispatches a bubbling focus event when the iframe receives focus. Use
 
 _Returns_
 
--   `Object`: Ref to pass to the iframe.
+-   Ref to pass to the iframe.
 
 ### useFocusOnMount
 

--- a/packages/compose/README.md
+++ b/packages/compose/README.md
@@ -326,7 +326,7 @@ Dispatches a bubbling focus event when the iframe receives focus. Use
 
 _Returns_
 
--   Ref to pass to the iframe.
+-   `RefCallback< HTMLIFrameElement >`: Ref to pass to the iframe.
 
 ### useFocusOnMount
 

--- a/packages/compose/src/hooks/use-focusable-iframe/index.ts
+++ b/packages/compose/src/hooks/use-focusable-iframe/index.ts
@@ -1,4 +1,9 @@
 /**
+ * External dependencies
+ */
+import type { RefCallback } from 'react';
+
+/**
  * Internal dependencies
  */
 import useRefEffect from '../use-ref-effect';
@@ -9,7 +14,7 @@ import useRefEffect from '../use-ref-effect';
  *
  * @return Ref to pass to the iframe.
  */
-export default function useFocusableIframe() {
+export default function useFocusableIframe(): RefCallback< HTMLIFrameElement > {
 	return useRefEffect( ( element ) => {
 		const { ownerDocument } = element;
 		if ( ! ownerDocument ) return;

--- a/packages/compose/src/hooks/use-focusable-iframe/index.ts
+++ b/packages/compose/src/hooks/use-focusable-iframe/index.ts
@@ -7,7 +7,7 @@ import useRefEffect from '../use-ref-effect';
  * Dispatches a bubbling focus event when the iframe receives focus. Use
  * `onFocus` as usual on the iframe or a parent element.
  *
- * @return {Object} Ref to pass to the iframe.
+ * @return Ref to pass to the iframe.
  */
 export default function useFocusableIframe() {
 	return useRefEffect( ( element ) => {
@@ -22,7 +22,7 @@ export default function useFocusableIframe() {
 		 */
 		function checkFocus() {
 			if ( ownerDocument && ownerDocument.activeElement === element ) {
-				/** @type {HTMLElement} */ ( element ).focus();
+				( element as HTMLElement ).focus();
 			}
 		}
 


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Refactor `useFocusableIframe` to TypeScript.

## Why?
The return type was wrong and by refactoring it to TypeScript we can rely on the return type of the function istead of JSDocs.

## How
- No runtime changes.
- Refactor to TypeScript

## Testing Instructions
Run `npm run dev` and make sure no TypeScript errors occurs.