### PR TITLE
TextControl: Restrict `type` prop in TypeScript

### DIFF
--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -6,6 +6,10 @@
 
 -   `TabPanel`: Add ability to set icon only tab buttons ([#45005](https://github.com/WordPress/gutenberg/pull/45005)).
 
+### Experimental
+
+-   `TextControl`: Restrict `type` prop to `email`, `number`, `password`, `tel`, `text`, `search` or `url` ([#45433](https://github.com/WordPress/gutenberg/pull/45433/)).
+
 ### Internal
 
 -   NumberControl: refactor styles/tests/stories to TypeScript, replace fireEvent with user-event ([#45990](https://github.com/WordPress/gutenberg/pull/45990)).

--- a/packages/components/src/text-control/stories/index.tsx
+++ b/packages/components/src/text-control/stories/index.tsx
@@ -19,7 +19,6 @@ const meta: ComponentMeta< typeof TextControl > = {
 	argTypes: {
 		help: { control: { type: 'text' } },
 		label: { control: { type: 'text' } },
-		type: { control: { type: 'select' } },
 		onChange: { action: 'onChange' },
 		value: { control: { type: null } },
 	},

--- a/packages/components/src/text-control/stories/index.tsx
+++ b/packages/components/src/text-control/stories/index.tsx
@@ -19,7 +19,7 @@ const meta: ComponentMeta< typeof TextControl > = {
 	argTypes: {
 		help: { control: { type: 'text' } },
 		label: { control: { type: 'text' } },
-		type: { control: { type: 'text' } },
+		type: { control: { type: 'select' } },
 		onChange: { action: 'onChange' },
 		value: { control: { type: null } },
 	},

--- a/packages/components/src/text-control/types.ts
+++ b/packages/components/src/text-control/types.ts
@@ -1,9 +1,4 @@
 /**
- * External dependencies
- */
-import type { HTMLInputTypeAttribute } from 'react';
-
-/**
  * Internal dependencies
  */
 import type { BaseControlProps } from '../base-control/types';
@@ -29,5 +24,5 @@ export type TextControlProps = Pick<
 	 *
 	 * @default 'text'
 	 */
-	type?: HTMLInputTypeAttribute;
+	type?: 'email' | 'number' | 'password' | 'tel' | 'text' | 'search' | 'url';
 };


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Update `type` props to only allow `email`, `number`, `password`, `tel`, `text`, `search` or `url`.

## Why?
A lot of the default `type` options doesn't make sense to use with the `TextControl` component.

## How?
- No runtime changes.
- Set a list of allowed `type`. Types remove are:
    - `button`
    - `checkbox`
    - `color`
    - `date`
    - `datetime-local`
    - `file`
    - `hidden`
    - `image`
    - `month`
    - `radio`
    - `range`
    - `reset`
    - `submit`
    - `time`
    - `week`

## Testing Instructions
- Everything should work as before.
- Test the component in Storybook. Should now only allow you to set `type` from a select control.
