### PR TITLE
CheckboxControl: replace margin overrides with new opt-in prop

### DIFF
--- a/packages/block-editor/src/components/block-lock/modal.js
+++ b/packages/block-editor/src/components/block-lock/modal.js
@@ -114,6 +114,7 @@ export default function BlockLockModal( { clientId, onClose } ) {
 					className="block-editor-block-lock-modal__options"
 				>
 					<CheckboxControl
+						__nextHasNoMarginBottom
 						className="block-editor-block-lock-modal__options-title"
 						label={
 							<span id={ instanceId }>{ __( 'Lock all' ) }</span>
@@ -134,6 +135,7 @@ export default function BlockLockModal( { clientId, onClose } ) {
 						{ allowsEditLocking && (
 							<li className="block-editor-block-lock-modal__checklist-item">
 								<CheckboxControl
+									__nextHasNoMarginBottom
 									label={
 										<>
 											{ __( 'Restrict editing' ) }
@@ -158,6 +160,7 @@ export default function BlockLockModal( { clientId, onClose } ) {
 						) }
 						<li className="block-editor-block-lock-modal__checklist-item">
 							<CheckboxControl
+								__nextHasNoMarginBottom
 								label={
 									<>
 										{ __( 'Disable movement' ) }
@@ -181,6 +184,7 @@ export default function BlockLockModal( { clientId, onClose } ) {
 						</li>
 						<li className="block-editor-block-lock-modal__checklist-item">
 							<CheckboxControl
+								__nextHasNoMarginBottom
 								label={
 									<>
 										{ __( 'Prevent removal' ) }

--- a/packages/block-editor/src/components/block-lock/style.scss
+++ b/packages/block-editor/src/components/block-lock/style.scss
@@ -22,7 +22,6 @@
 	.components-base-control__field {
 		align-items: center;
 		display: flex;
-		margin: 0;
 	}
 }
 .block-editor-block-lock-modal__checklist-item {
@@ -32,7 +31,6 @@
 	.components-base-control__field {
 		align-items: center;
 		display: flex;
-		margin: 0;
 	}
 
 	.components-checkbox-control__label {

--- a/packages/edit-post/src/components/block-manager/category.js
+++ b/packages/edit-post/src/components/block-manager/category.js
@@ -88,6 +88,7 @@ function BlockManagerCategory( { title, blockTypes } ) {
 			className="edit-post-block-manager__category"
 		>
 			<CheckboxControl
+				__nextHasNoMarginBottom
 				checked={ isAllChecked }
 				onChange={ toggleAllVisible }
 				className="edit-post-block-manager__category-title"

--- a/packages/edit-post/src/components/block-manager/checklist.js
+++ b/packages/edit-post/src/components/block-manager/checklist.js
@@ -13,6 +13,7 @@ function BlockTypesChecklist( { blockTypes, value, onItemChange } ) {
 					className="edit-post-block-manager__checklist-item"
 				>
 					<CheckboxControl
+						__nextHasNoMarginBottom
 						label={
 							<>
 								{ blockType.title }

--- a/packages/edit-post/src/components/block-manager/style.scss
+++ b/packages/edit-post/src/components/block-manager/style.scss
@@ -55,7 +55,6 @@
 	.components-base-control__field {
 		align-items: center;
 		display: flex;
-		margin: 0;
 	}
 }
 

--- a/packages/editor/src/components/entities-saved-states/entity-record-item.js
+++ b/packages/editor/src/components/entities-saved-states/entity-record-item.js
@@ -77,6 +77,7 @@ export default function EntityRecordItem( {
 	return (
 		<PanelRow>
 			<CheckboxControl
+				__nextHasNoMarginBottom
 				label={
 					<strong>
 						{ decodeEntities( entityRecordTitle ) ||

--- a/packages/editor/src/components/post-comments/index.js
+++ b/packages/editor/src/components/post-comments/index.js
@@ -19,6 +19,7 @@ function PostComments( { commentStatus = 'open', ...props } ) {
 
 	return (
 		<CheckboxControl
+			__nextHasNoMarginBottom
 			label={ __( 'Allow comments' ) }
 			checked={ commentStatus === 'open' }
 			onChange={ onToggleComments }

--- a/packages/editor/src/components/post-pending-status/index.js
+++ b/packages/editor/src/components/post-pending-status/index.js
@@ -21,6 +21,7 @@ export function PostPendingStatus( { status, onUpdateStatus } ) {
 	return (
 		<PostPendingStatusCheck>
 			<CheckboxControl
+				__nextHasNoMarginBottom
 				label={ __( 'Pending review' ) }
 				checked={ status === 'pending' }
 				onChange={ togglePendingStatus }

--- a/packages/editor/src/components/post-pingbacks/index.js
+++ b/packages/editor/src/components/post-pingbacks/index.js
@@ -19,6 +19,7 @@ function PostPingbacks( { pingStatus = 'open', ...props } ) {
 
 	return (
 		<CheckboxControl
+			__nextHasNoMarginBottom
 			label={ __( 'Allow pingbacks & trackbacks' ) }
 			checked={ pingStatus === 'open' }
 			onChange={ onTogglePingback }

--- a/packages/editor/src/components/post-publish-panel/index.js
+++ b/packages/editor/src/components/post-publish-panel/index.js
@@ -125,6 +125,7 @@ export class PostPublishPanel extends Component {
 				</div>
 				<div className="editor-post-publish-panel__footer">
 					<CheckboxControl
+						__nextHasNoMarginBottom
 						label={ __( 'Always show pre-publish checks.' ) }
 						checked={ isPublishSidebarEnabled }
 						onChange={ onTogglePublishSidebar }

--- a/packages/editor/src/components/post-publish-panel/test/__snapshots__/index.js.snap
+++ b/packages/editor/src/components/post-publish-panel/test/__snapshots__/index.js.snap
@@ -31,6 +31,10 @@ exports[`PostPublishPanel should render the post-publish panel if the post is pu
   padding: 0;
 }
 
+.components-panel__row .emotion-8 {
+  margin-bottom: inherit;
+}
+
 <div>
   <div
     class="editor-post-publish-panel"
@@ -141,7 +145,7 @@ exports[`PostPublishPanel should render the post-publish panel if the post is pu
         class="components-base-control components-checkbox-control emotion-0 emotion-1"
       >
         <div
-          class="components-base-control__field emotion-2 emotion-3"
+          class="components-base-control__field emotion-8 emotion-3"
         >
           <span
             class="components-checkbox-control__input-container"
@@ -195,6 +199,10 @@ exports[`PostPublishPanel should render the post-publish panel if the post is sc
   display: inline-block;
   margin-bottom: calc(4px * 2);
   padding: 0;
+}
+
+.components-panel__row .emotion-8 {
+  margin-bottom: inherit;
 }
 
 <div>
@@ -307,7 +315,7 @@ exports[`PostPublishPanel should render the post-publish panel if the post is sc
         class="components-base-control components-checkbox-control emotion-0 emotion-1"
       >
         <div
-          class="components-base-control__field emotion-2 emotion-3"
+          class="components-base-control__field emotion-8 emotion-3"
         >
           <span
             class="components-checkbox-control__input-container"
@@ -343,10 +351,6 @@ exports[`PostPublishPanel should render the pre-publish panel if post status is 
 .emotion-0 *::before,
 .emotion-0 *::after {
   box-sizing: inherit;
-}
-
-.emotion-2 {
-  margin-bottom: calc(4px * 2);
 }
 
 .components-panel__row .emotion-2 {
@@ -470,10 +474,6 @@ exports[`PostPublishPanel should render the pre-publish panel if the post is not
 .emotion-0 *::before,
 .emotion-0 *::after {
   box-sizing: inherit;
-}
-
-.emotion-2 {
-  margin-bottom: calc(4px * 2);
 }
 
 .components-panel__row .emotion-2 {
@@ -639,10 +639,6 @@ exports[`PostPublishPanel should render the spinner if the post is being saved 1
 .emotion-6 *::before,
 .emotion-6 *::after {
   box-sizing: inherit;
-}
-
-.emotion-8 {
-  margin-bottom: calc(4px * 2);
 }
 
 .components-panel__row .emotion-8 {

--- a/packages/editor/src/components/post-sticky/index.js
+++ b/packages/editor/src/components/post-sticky/index.js
@@ -16,6 +16,7 @@ export function PostSticky( { onUpdateSticky, postSticky = false } ) {
 	return (
 		<PostStickyCheck>
 			<CheckboxControl
+				__nextHasNoMarginBottom
 				label={ __( 'Stick to the top of the blog' ) }
 				checked={ postSticky }
 				onChange={ () => onUpdateSticky( ! postSticky ) }

--- a/packages/editor/src/components/post-taxonomies/hierarchical-term-selector.js
+++ b/packages/editor/src/components/post-taxonomies/hierarchical-term-selector.js
@@ -358,6 +358,7 @@ export function HierarchicalTermSelector( { slug } ) {
 					className="editor-post-taxonomies__hierarchical-terms-choice"
 				>
 					<CheckboxControl
+						__nextHasNoMarginBottom
 						checked={ terms.indexOf( term.id ) !== -1 }
 						onChange={ () => {
 							const termId = parseInt( term.id, 10 );


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?

<!-- In a few words, what is the PR actually doing? -->

Replacing margin overrides with new opt-in prop `__nextHasNoMarginBottom` for useages of `CheckboxControl` in the Gutenberg codebase. 

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

Part of this project: https://github.com/WordPress/gutenberg/issues/38730
The tl;dr is `BaseControl` has a `margin-bottom` which makes it difficult to reuse and results in inconsistent use. 

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

By removing margin overrides in the CSS and adding the prop `__nextHasNoMarginBottom`.

To note, `CheckboxControl` in `packages/edit-navigation/src/components/sidebar/manage-locations.js` wasn't updated. I couldn't find this on the front end so I'm unsure if it's being used. It looks like it might be a paused project. 

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->

To test this, you'll need to look for the following checkboxes and ensure that the margin is the same as before (`margin-bottom` of 0) for the `div` with class `components-base-control__field`. Screenshots below are how it looks in core right now. 

1. Create a new post and then go through the steps for each component: 

### **For `BlockManagerCategory` and `BlockTypesChecklist`**

1.  Click on three dots in the top right corner of post editor
2. Then select 'Preferences'
3. Click on 'Blocks' and scroll down to 'Visible Blocks'
4. Ensure that the margins for the checkboxes are set to 0 as they were before for both the category and subcategories under 'Visible Blocks'
<img width="741" alt="Screen Shot 2022-10-31 at 6 23 16 PM" src="https://user-images.githubusercontent.com/35543432/199138366-9f4e9e30-c540-435c-bd88-205562e88203.png">

### **For`PostSticky` and `PostPendingStatus`**

1. Click on 'Post' in sidebar
2. Ensure that the margins for the checkboxes are set to 0 as they were before for both '**Stick to the top of blog**' and '**Pending Review**'
<img width="280" alt="Screen Shot 2022-10-31 at 6 22 54 PM" src="https://user-images.githubusercontent.com/35543432/199138467-e534d671-42c7-4c27-926b-cccf45d5a719.png">

### **For `HierarchicalTermSelector`**

1. Under 'Post' in the sidebar click on 'Categories'
2. Click 'Add new category' and add test category
3. Ensure that the margins for the checkboxes are set to 0 as they were before for listed categories 
<img width="283" alt="Screen Shot 2022-10-31 at 6 29 00 PM" src="https://user-images.githubusercontent.com/35543432/199138885-9f826147-1117-4a21-aaf9-df6e7a29f20b.png">

### **For  `PostComments` and `PostPingbacks`**

1. Under 'Post' in the sidebar click on 'Discussion'
2. Ensure that the margins for the checkboxes are set to 0 as they were before for '**Allow comments**' and '**Allow pingbacks & trackbacks**'
<img width="279" alt="Screen Shot 2022-10-31 at 6 23 06 PM" src="https://user-images.githubusercontent.com/35543432/199138417-3961f444-fe32-4eb8-b8d7-4b179c0b06ef.png">

### **For `EntityRecordItem`**

1. Add Navigation block to editor
2. Add link to menu
3. Click on 'Publish'
4. Ensure that the margins for the checkboxes are set to 0 as they were before under **'Navigation Menus'**

<img width="287" alt="Screen Shot 2022-10-31 at 6 22 41 PM" src="https://user-images.githubusercontent.com/35543432/199138483-a756305a-2e70-4839-82b7-4992c6938d05.png">

### **For `BlockLockModal`**

1. Add any block (can use the Navigation block from above) to the editor
5.  Click on the three dots and then on 'Lock'
6. Ensure that the margins for the checkboxes in modal are set to 0 as they were before 
<img width="451" alt="Screen Shot 2022-10-31 at 6 22 09 PM" src="https://user-images.githubusercontent.com/35543432/199138568-d7a73d24-f45a-4850-88af-63524dd1de72.png">

### **For `PostPublishPanel`**

1. Make a change to the post
2. Click on 'Publish'
3. Ensure that the margins for the checkboxes are set to 0 as they were before for '**Always show pre-publish checks**'

<img width="283" alt="Screen Shot 2022-10-31 at 6 23 37 PM" src="https://user-images.githubusercontent.com/35543432/199138583-c9fff740-fa9b-4107-8dcb-1cae8ad49f04.png">



## Screenshots or screencast <!-- if applicable -->
