### PR TITLE
Nav block - find menu by slug using existing core data API

### DIFF
--- a/docs/reference-guides/core-blocks.md
+++ b/docs/reference-guides/core-blocks.md
@@ -473,7 +473,7 @@ A collection of blocks that allow visitors to get around your site. ([Source](ht
 -	**Category:** theme
 -	**Allowed Blocks:** core/navigation-link, core/search, core/social-links, core/page-list, core/spacer, core/home-link, core/site-title, core/site-logo, core/navigation-submenu, core/loginout, core/buttons
 -	**Supports:** align (full, wide), ariaLabel, inserter, interactivity, layout (allowSizingOnChildren, default, ~~allowInheriting~~, ~~allowSwitching~~, ~~allowVerticalAlignment~~), spacing (blockGap, units), typography (fontSize, lineHeight), ~~html~~, ~~renaming~~
--	**Attributes:** __unstableLocation, backgroundColor, customBackgroundColor, customOverlayBackgroundColor, customOverlayTextColor, customTextColor, hasIcon, icon, maxNestingLevel, openSubmenusOnClick, overlayBackgroundColor, overlayMenu, overlayTextColor, ref, rgbBackgroundColor, rgbTextColor, showSubmenuIcon, templateLock, textColor
+-	**Attributes:** __unstableLocation, backgroundColor, customBackgroundColor, customOverlayBackgroundColor, customOverlayTextColor, customTextColor, hasIcon, icon, maxNestingLevel, openSubmenusOnClick, overlayBackgroundColor, overlayMenu, overlayTextColor, ref, rgbBackgroundColor, rgbTextColor, showSubmenuIcon, slug, templateLock, textColor
 
 ## Custom Link
 

--- a/docs/reference-guides/data/data-core.md
+++ b/docs/reference-guides/data/data-core.md
@@ -374,6 +374,23 @@ _Returns_
 
 -   `any`: The entity record's save error.
 
+### getNavigationMenu
+
+Undocumented declaration.
+
+### getNavigationMenuBySlug
+
+Returns a Navigation Menu object by slug.
+
+_Parameters_
+
+-   _state_ `State`:
+-   _slug_ `string`: the slug of the Navigation Menu.
+
+_Returns_
+
+-   `Object | null`: The Navigation Menu object.
+
 ### getRawEntityRecord
 
 Returns the entity's record object by key, with its attributes mapped to their raw values.

--- a/packages/block-library/src/navigation/block.json
+++ b/packages/block-library/src/navigation/block.json
@@ -24,6 +24,9 @@
 		"ref": {
 			"type": "number"
 		},
+		"slug": {
+			"type": "string"
+		},
 		"textColor": {
 			"type": "string"
 		},

--- a/packages/block-library/src/navigation/edit/index.js
+++ b/packages/block-library/src/navigation/edit/index.js
@@ -112,15 +112,11 @@ function Navigation( {
 	// Allow for this to continue to be used.
 	const ref = attributes.slug || attributes.ref;
 
-	// "ref" attribute is the integer-based reference.
-	const [ idRef, setIdRef ] = useState( attributes.ref );
-
 	const setRef = useCallback(
-		( { id, slug } ) => {
+		( { slug } ) => {
 			setAttributes( { slug } );
-			setIdRef( id );
 		},
-		[ setAttributes, setIdRef ]
+		[ setAttributes ]
 	);
 
 	const recursionId = `navigationMenu/${ ref }`;
@@ -196,6 +192,7 @@ function Navigation( {
 		canUserCreateNavigationMenu,
 		isResolvingCanUserCreateNavigationMenu,
 		hasResolvedCanUserCreateNavigationMenu,
+		navigationMenu,
 	} = useNavigationMenu( ref );
 
 	const navMenuResolvedButMissing =
@@ -212,6 +209,7 @@ function Navigation( {
 
 	const handleUpdateMenu = useCallback(
 		( menu, options = { focusNavigationBlock: false } ) => {
+			debugger;
 			const { focusNavigationBlock } = options;
 			setRef( menu );
 			if ( focusNavigationBlock ) {
@@ -408,7 +406,7 @@ function Navigation( {
 			showClassicMenuConversionNotice(
 				__( 'Classic menu imported successfully.' )
 			);
-			handleUpdateMenu( createNavigationMenuPost?.id, {
+			handleUpdateMenu( createNavigationMenuPost, {
 				focusNavigationBlock: true,
 			} );
 		}
@@ -423,7 +421,7 @@ function Navigation( {
 		classicMenuConversionError,
 		hideClassicMenuConversionNotice,
 		showClassicMenuConversionNotice,
-		createNavigationMenuPost?.id,
+		createNavigationMenuPost,
 		handleUpdateMenu,
 	] );
 
@@ -829,7 +827,11 @@ function Navigation( {
 	}
 
 	return (
-		<EntityProvider kind="postType" type="wp_navigation" id={ idRef }>
+		<EntityProvider
+			kind="postType"
+			type="wp_navigation"
+			id={ navigationMenu?.id }
+		>
 			<RecursionProvider uniqueId={ recursionId }>
 				<MenuInspectorControls
 					clientId={ clientId }

--- a/packages/block-library/src/navigation/edit/index.js
+++ b/packages/block-library/src/navigation/edit/index.js
@@ -112,6 +112,7 @@ function Navigation( {
 	// Allow for this to continue to be used.
 	const ref = attributes.slug || attributes.ref;
 
+	// "ref" attribute is the integer-based reference.
 	const [ idRef, setIdRef ] = useState( attributes.ref );
 
 	const setRef = useCallback(
@@ -388,7 +389,7 @@ function Navigation( {
 	}, [
 		createNavigationMenuStatus,
 		createNavigationMenuError,
-		createNavigationMenuPost?.id,
+		createNavigationMenuPost,
 		createNavigationMenuIsError,
 		createNavigationMenuIsSuccess,
 		isCreatingNavigationMenu,
@@ -828,7 +829,7 @@ function Navigation( {
 	}
 
 	return (
-		<EntityProvider kind="postType" type="wp_navigation" id={ ref }>
+		<EntityProvider kind="postType" type="wp_navigation" id={ idRef }>
 			<RecursionProvider uniqueId={ recursionId }>
 				<MenuInspectorControls
 					clientId={ clientId }

--- a/packages/block-library/src/navigation/edit/index.js
+++ b/packages/block-library/src/navigation/edit/index.js
@@ -108,13 +108,18 @@ function Navigation( {
 		icon = 'handle',
 	} = attributes;
 
-	const ref = attributes.ref;
+	// Older versions of the block used an ID based ref attribute.
+	// Allow for this to continue to be used.
+	const ref = attributes.slug || attributes.ref;
+
+	const [ idRef, setIdRef ] = useState( attributes.ref );
 
 	const setRef = useCallback(
-		( postId ) => {
-			setAttributes( { ref: postId } );
+		( { id, slug } ) => {
+			setAttributes( { slug } );
+			setIdRef( id );
 		},
-		[ setAttributes ]
+		[ setAttributes, setIdRef ]
 	);
 
 	const recursionId = `navigationMenu/${ ref }`;
@@ -205,9 +210,9 @@ function Navigation( {
 		classicMenuConversionStatus === CLASSIC_MENU_CONVERSION_PENDING;
 
 	const handleUpdateMenu = useCallback(
-		( menuId, options = { focusNavigationBlock: false } ) => {
+		( menu, options = { focusNavigationBlock: false } ) => {
 			const { focusNavigationBlock } = options;
-			setRef( menuId );
+			setRef( menu );
 			if ( focusNavigationBlock ) {
 				selectBlock( clientId );
 			}
@@ -342,7 +347,16 @@ function Navigation( {
 	const [ detectedOverlayColor, setDetectedOverlayColor ] = useState();
 
 	const onSelectClassicMenu = async ( classicMenu ) => {
-		return convertClassicMenu( classicMenu.id, classicMenu.name, 'draft' );
+		const navMenu = await convertClassicMenu(
+			classicMenu.id,
+			classicMenu.name,
+			'draft'
+		);
+		if ( navMenu ) {
+			handleUpdateMenu( navMenu, {
+				focusNavigationBlock: true,
+			} );
+		}
 	};
 
 	const onSelectNavigationMenu = ( menuId ) => {
@@ -357,7 +371,7 @@ function Navigation( {
 		}
 
 		if ( createNavigationMenuIsSuccess ) {
-			handleUpdateMenu( createNavigationMenuPost?.id, {
+			handleUpdateMenu( createNavigationMenuPost, {
 				focusNavigationBlock: true,
 			} );
 

--- a/packages/block-library/src/navigation/edit/navigation-menu-selector.js
+++ b/packages/block-library/src/navigation/edit/navigation-menu-selector.js
@@ -46,6 +46,8 @@ function NavigationMenuSelector( {
 	createNavigationMenuIsSuccess,
 	createNavigationMenuIsError,
 } ) {
+	console.log( { currentMenuId } );
+
 	/* translators: %s: The name of a menu. */
 	const createActionLabel = __( "Create from '%s'" );
 
@@ -71,7 +73,7 @@ function NavigationMenuSelector( {
 
 	const menuChoices = useMemo( () => {
 		return (
-			navigationMenus?.map( ( { id, title, status }, index ) => {
+			navigationMenus?.map( ( { id, title, status, slug }, index ) => {
 				const label = buildMenuLabel(
 					title?.rendered,
 					index + 1,
@@ -79,7 +81,7 @@ function NavigationMenuSelector( {
 				);
 
 				return {
-					value: id,
+					value: slug,
 					label,
 					ariaLabel: sprintf( actionLabel, label ),
 					disabled:

--- a/packages/block-library/src/navigation/edit/test/utils.js
+++ b/packages/block-library/src/navigation/edit/test/utils.js
@@ -1,0 +1,23 @@
+/**
+ * Internal dependencies
+ */
+import { isNumeric } from '../utils';
+
+describe( 'isNumeric', () => {
+	it.each( [
+		[ 42, true ],
+		[ '42', true ],
+		[ '  42  ', true ],
+		[ '', false ],
+		[ 'some-slug', false ],
+		[ 'some-42-slug-with-trailing-number-42', false ],
+		[ '42-some-42-slug-with-leading-number', false ],
+		[ NaN, false ],
+		[ Infinity, false ],
+	] )(
+		'correctly determines variable type for "%s"',
+		( candidate, expected ) => {
+			expect( isNumeric( candidate ) ).toBe( expected );
+		}
+	);
+} );

--- a/packages/block-library/src/navigation/edit/use-create-navigation-menu.js
+++ b/packages/block-library/src/navigation/edit/use-create-navigation-menu.js
@@ -27,7 +27,7 @@ export default function useCreateNavigationMenu( clientId ) {
 	// This callback uses data from the two placeholder steps and only creates
 	// a new navigation menu when the user completes the final step.
 	const create = useCallback(
-		async ( title = null, blocks = [], postStatus ) => {
+		async ( title = null, blocks = [], postStatus, slug = '' ) => {
 			// Guard against creating Navigations without a title.
 			// Note you can pass no title, but if one is passed it must be
 			// a string otherwise the title may end up being empty.
@@ -57,8 +57,12 @@ export default function useCreateNavigationMenu( clientId ) {
 					);
 				} );
 			}
+
+			const maybeSlug = slug || title;
+
 			const record = {
 				title,
+				slug: maybeSlug,
 				content: serialize( blocks ),
 				status: postStatus,
 			};

--- a/packages/block-library/src/navigation/edit/utils.js
+++ b/packages/block-library/src/navigation/edit/utils.js
@@ -110,3 +110,10 @@ export function getNavigationChildBlockProps( innerBlocksColors ) {
 		},
 	};
 }
+
+export function isNumeric( v ) {
+	if ( v === null || v === undefined || v === '' ) {
+		return false;
+	}
+	return ! isNaN( v ) && isFinite( v );
+}

--- a/packages/core-data/README.md
+++ b/packages/core-data/README.md
@@ -695,6 +695,23 @@ _Returns_
 
 -   `any`: The entity record's save error.
 
+### getNavigationMenu
+
+Undocumented declaration.
+
+### getNavigationMenuBySlug
+
+Returns a Navigation Menu object by slug.
+
+_Parameters_
+
+-   _state_ `State`:
+-   _slug_ `string`: the slug of the Navigation Menu.
+
+_Returns_
+
+-   `Object | null`: The Navigation Menu object.
+
 ### getRawEntityRecord
 
 Returns the entity's record object by key, with its attributes mapped to their raw values.

--- a/packages/core-data/src/resolvers.js
+++ b/packages/core-data/src/resolvers.js
@@ -890,10 +890,16 @@ export const getRevision =
 		}
 	};
 
+export const getNavigationMenu =
+	( id ) =>
+	async ( { resolveSelect } ) => {
+		resolveSelect.getEntityRecord( 'postType', 'wp_navigation', id );
+	};
+
 export const getNavigationMenuBySlug =
 	( slug ) =>
 	async ( { resolveSelect } ) => {
-		await resolveSelect.getEntityRecords( 'postType', 'wp_navigation', {
+		resolveSelect.getEntityRecords( 'postType', 'wp_navigation', {
 			slug,
 			per_page: 1,
 		} );

--- a/packages/core-data/src/resolvers.js
+++ b/packages/core-data/src/resolvers.js
@@ -889,3 +889,11 @@ export const getRevision =
 			dispatch.receiveRevisions( kind, name, recordKey, record, query );
 		}
 	};
+
+export const getNavigationMenuBySlug =
+	( slug ) =>
+	async ( { resolveSelect } ) => {
+		await resolveSelect.getEntityRecords( 'postType', 'wp_navigation', {
+			slug,
+		} );
+	};

--- a/packages/core-data/src/resolvers.js
+++ b/packages/core-data/src/resolvers.js
@@ -895,5 +895,6 @@ export const getNavigationMenuBySlug =
 	async ( { resolveSelect } ) => {
 		await resolveSelect.getEntityRecords( 'postType', 'wp_navigation', {
 			slug,
+			per_page: 1,
 		} );
 	};

--- a/packages/core-data/src/selectors.ts
+++ b/packages/core-data/src/selectors.ts
@@ -1492,3 +1492,25 @@ export const getRevision = createSelector(
 		];
 	}
 );
+
+/**
+ * Returns a Navigation Menu object by slug.
+ *
+ * @param state
+ * @param slug  the slug of the Navigation Menu.
+ * @return The Navigation Menu object.
+ */
+export function getNavigationMenuBySlug(
+	state: State,
+	slug: string
+): Object | null {
+	const records = getEntityRecords( state, 'postType', 'wp_navigation', {
+		slug,
+	} );
+
+	if ( ! records?.length ) {
+		return null;
+	}
+
+	return records[ 0 ];
+}

--- a/packages/core-data/src/selectors.ts
+++ b/packages/core-data/src/selectors.ts
@@ -1378,6 +1378,19 @@ export function getCurrentThemeGlobalStylesRevisions(
 	return state.themeGlobalStyleRevisions[ currentGlobalStylesId ];
 }
 
+export function getNavigationMenu(
+	state: State,
+	id: EntityRecordKey
+): Object | null {
+	const record = getEntityRecord( state, 'postType', 'wp_navigation', id );
+
+	if ( ! record ) {
+		return null;
+	}
+
+	return record;
+}
+
 /**
  * Returns the default template use to render a given query.
  *

--- a/packages/core-data/src/selectors.ts
+++ b/packages/core-data/src/selectors.ts
@@ -1506,6 +1506,7 @@ export function getNavigationMenuBySlug(
 ): Object | null {
 	const records = getEntityRecords( state, 'postType', 'wp_navigation', {
 		slug,
+		per_page: 1,
 	} );
 
 	if ( ! records?.length ) {

--- a/packages/core-data/src/selectors.ts
+++ b/packages/core-data/src/selectors.ts
@@ -1378,19 +1378,6 @@ export function getCurrentThemeGlobalStylesRevisions(
 	return state.themeGlobalStyleRevisions[ currentGlobalStylesId ];
 }
 
-export function getNavigationMenu(
-	state: State,
-	id: EntityRecordKey
-): Object | null {
-	const record = getEntityRecord( state, 'postType', 'wp_navigation', id );
-
-	if ( ! record ) {
-		return null;
-	}
-
-	return record;
-}
-
 /**
  * Returns the default template use to render a given query.
  *
@@ -1505,6 +1492,19 @@ export const getRevision = createSelector(
 		];
 	}
 );
+
+export function getNavigationMenu(
+	state: State,
+	id: EntityRecordKey
+): Object | null {
+	const record = getEntityRecord( state, 'postType', 'wp_navigation', id );
+
+	if ( ! record ) {
+		return null;
+	}
+
+	return record;
+}
 
 /**
  * Returns a Navigation Menu object by slug.


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Alternative to https://github.com/WordPress/gutenberg/pull/42809/.

Makes the Navigation block use a `slug` to reference a Navigation Menu Post. This approach avoids modifications to the REST API endpoint and instead uses `getEntityRecords` (plural) to fetch the menu by `slug`.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

See https://github.com/WordPress/gutenberg/pull/42809/.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

- Adds a `slug` attribute to the block.
- Uses `getEntityRecords` to look up a Navigation Post by `slug` (`post_name`). Uses the 0th result. This is a one time operation to find the entity record. 
- Sets the `ID` of the returned Navigation Post into _local_ state (_not_ saved to the block) for use in entity operations (e.g. edit, update, create).
- Continues to key records by postId in state. All interactions (e.g. `<EntityProvider>`, `getEditedEntityRecord`, `saveEntityRecord`) continue to utilise `ID` as the primary record key.

This approach is different to that in `trunk` which uses `getEntityRecord` to look up the Navigation Post by ID. As the block no longer stores a reference to an ID (it's now a `slug`) this approach would not work.

## Problems

The main issue with this PR is that permissions requests cannot be dispatched until a Post ID is available. As we now use slugs to look up a post from the API there is no PostID available until _after_ the request to fetch a given menu has resolved (or not!).

Therefore we have to wait for the request to resolve and _then_ check the permissions. This seems backwards and is currently causing UI errors such as a permission warning when converting Page List into a menu.

The only way to have this work would be to modify the REST API to handle slugs for permissions requests such as in https://github.com/WordPress/gutenberg/pull/44975/files#r995650785. However, this is not something the REST API team want to pursue.

## Todo

- [x] Revert all unnecessary changes (see comments I left on this PR).
- [ ] Resolve issues highlighted by unit test failures.
- [ ] Merge https://github.com/WordPress/gutenberg/pull/45517
- [ ] Attempt [resolve logic problems in the `NavigationMenuSelector`.](https://github.com/WordPress/gutenberg/pull/45464).

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->

⚠️ Before starting each set of tests please _clear all your Navigation Menus_ at http://localhost:8888/wp-admin/edit.php?post_type=wp_navigation.

### Test new block

This is testing the flow of
- creating a new Nav block that utilises slugs
- updating an existing Nav block that uses slugs

- New Post
- Add Nav block
- See Page List fallback
- Convert to links (click on Page List and click "Edit").
- See Navigation menu created.
- Switch to Code View and check a `slug` attribute is on the block.
- Try adding menu items
- Try saving and reloading.
- Try creating another Navigation Menu - is it unique attribute-wise.
- Now delete all your Navigation Menus at http://localhost:8888/wp-admin/edit.php?post_type=wp_navigation&paged=1.
- Reload your Post. You should see the error that your menu is not longer available. 

### Test legacy block

This tests older versions of the block that use the `ref` attribute.

- Delete all Nav Menus.
- Switch to `trunk`. Rebuild all the things.
- New Post and add Nav block. Check it's using the `ref` attribute.
- Save the Post.
- Switch back to this branch. Rebuild all the things.
- Reload your Post.
- Check your block functions as you expect.
- Check that the `ref` attribute is not removed or modified.
- Check that selecting a new menu or creating a new menu will modify the block to use the `slug`. Ref is only preserved until such time as you select a new entity for your menu. After that the block will switch to using slugs.

## Screenshots or screencast <!-- if applicable -->
