### PR TITLE
Unit Tests: rewrite ReactDOM.render usages to RTL

### DIFF
--- a/packages/compose/src/hooks/use-merge-refs/test/index.js
+++ b/packages/compose/src/hooks/use-merge-refs/test/index.js
@@ -77,7 +77,7 @@ describe( 'useMergeRefs', () => {
 	} );
 
 	it( 'should work', () => {
-		const { container, rerender } = render( <MergedRefs /> );
+		const { container, rerender, unmount } = render( <MergedRefs /> );
 
 		const originalElement = container.firstElementChild;
 
@@ -95,7 +95,7 @@ describe( 'useMergeRefs', () => {
 			[ [], [] ],
 		] );
 
-		rerender( null );
+		unmount();
 
 		// Unmount: the initial callback functions should receive null.
 		expect( renderCallback.history ).toEqual( [
@@ -108,7 +108,7 @@ describe( 'useMergeRefs', () => {
 	} );
 
 	it( 'should work for node change', () => {
-		const { container, rerender } = render( <MergedRefs /> );
+		const { container, rerender, unmount } = render( <MergedRefs /> );
 
 		const originalElement = container.firstElementChild;
 
@@ -129,7 +129,7 @@ describe( 'useMergeRefs', () => {
 			[ [], [] ],
 		] );
 
-		rerender( null );
+		unmount();
 
 		// Unmount: the initial callback functions should receive null.
 		expect( renderCallback.history ).toEqual( [
@@ -142,7 +142,9 @@ describe( 'useMergeRefs', () => {
 	} );
 
 	it( 'should work with dependencies', () => {
-		const { container, rerender } = render( <MergedRefs count={ 1 } /> );
+		const { container, rerender, unmount } = render(
+			<MergedRefs count={ 1 } />
+		);
 
 		const originalElement = container.firstElementChild;
 
@@ -161,7 +163,7 @@ describe( 'useMergeRefs', () => {
 			[ [], [ originalElement ] ],
 		] );
 
-		rerender( null );
+		unmount();
 
 		// Unmount: current callback functions should be called with null.
 		expect( renderCallback.history ).toEqual( [
@@ -174,7 +176,9 @@ describe( 'useMergeRefs', () => {
 	} );
 
 	it( 'should simultaneously update node and dependencies', () => {
-		const { container, rerender } = render( <MergedRefs count={ 1 } /> );
+		const { container, rerender, unmount } = render(
+			<MergedRefs count={ 1 } />
+		);
 
 		const originalElement = container.firstElementChild;
 
@@ -199,7 +203,7 @@ describe( 'useMergeRefs', () => {
 			[ [], [ newElement ] ],
 		] );
 
-		rerender( null );
+		unmount();
 
 		// Unmount: current callback functions should be called with null.
 		expect( renderCallback.history ).toEqual( [
@@ -212,7 +216,7 @@ describe( 'useMergeRefs', () => {
 	} );
 
 	it( 'should work for dependency change after node change', () => {
-		const { container, rerender } = render( <MergedRefs /> );
+		const { container, rerender, unmount } = render( <MergedRefs /> );
 
 		const originalElement = container.firstElementChild;
 
@@ -248,7 +252,7 @@ describe( 'useMergeRefs', () => {
 			[ [], [ newElement ] ],
 		] );
 
-		rerender( null );
+		unmount();
 
 		// Unmount: current callback functions should be called with null.
 		expect( renderCallback.history ).toEqual( [
@@ -262,7 +266,9 @@ describe( 'useMergeRefs', () => {
 	} );
 
 	it( 'should allow disabling a ref', () => {
-		const { container, rerender } = render( <MergedRefs disable1 /> );
+		const { container, rerender, unmount } = render(
+			<MergedRefs disable1 />
+		);
 
 		const originalElement = container.firstElementChild;
 
@@ -295,7 +301,7 @@ describe( 'useMergeRefs', () => {
 			[ [], [ originalElement ] ],
 		] );
 
-		rerender( null );
+		unmount();
 
 		// Unmount: current callback functions should receive null.
 		expect( renderCallback.history ).toEqual( [

--- a/packages/compose/src/hooks/use-merge-refs/test/index.js
+++ b/packages/compose/src/hooks/use-merge-refs/test/index.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { render } from '@testing-library/react';
+import { render, screen } from '@testing-library/react';
 
 /**
  * WordPress dependencies
@@ -38,7 +38,7 @@ describe( 'useMergeRefs', () => {
 
 	function MergedRefs( {
 		count,
-		tagName: TagName = 'div',
+		tagName: TagName = 'ul',
 		disable1,
 		disable2,
 		unused,
@@ -77,9 +77,9 @@ describe( 'useMergeRefs', () => {
 	} );
 
 	it( 'should work', () => {
-		const { container, rerender, unmount } = render( <MergedRefs /> );
+		const { rerender, unmount } = render( <MergedRefs /> );
 
-		const originalElement = container.firstElementChild;
+		const originalElement = screen.getByRole( 'list' );
 
 		// Render 1: both initial callback functions should be called with node.
 		expect( renderCallback.history ).toEqual( [
@@ -108,13 +108,13 @@ describe( 'useMergeRefs', () => {
 	} );
 
 	it( 'should work for node change', () => {
-		const { container, rerender, unmount } = render( <MergedRefs /> );
+		const { rerender, unmount } = render( <MergedRefs /> );
 
-		const originalElement = container.firstElementChild;
+		const originalElement = screen.getByRole( 'list' );
 
 		rerender( <MergedRefs tagName="button" /> );
 
-		const newElement = container.firstElementChild;
+		const newElement = screen.getByRole( 'button' );
 
 		// After a render with the original element and a second render with the
 		// new element, expect the initial callback functions to be called with
@@ -142,11 +142,9 @@ describe( 'useMergeRefs', () => {
 	} );
 
 	it( 'should work with dependencies', () => {
-		const { container, rerender, unmount } = render(
-			<MergedRefs count={ 1 } />
-		);
+		const { rerender, unmount } = render( <MergedRefs count={ 1 } /> );
 
-		const originalElement = container.firstElementChild;
+		const originalElement = screen.getByRole( 'list' );
 
 		expect( renderCallback.history ).toEqual( [
 			[ [ originalElement ], [ originalElement ] ],
@@ -176,11 +174,9 @@ describe( 'useMergeRefs', () => {
 	} );
 
 	it( 'should simultaneously update node and dependencies', () => {
-		const { container, rerender, unmount } = render(
-			<MergedRefs count={ 1 } />
-		);
+		const { rerender, unmount } = render( <MergedRefs count={ 1 } /> );
 
-		const originalElement = container.firstElementChild;
+		const originalElement = screen.getByRole( 'list' );
 
 		expect( renderCallback.history ).toEqual( [
 			[ [ originalElement ], [ originalElement ] ],
@@ -188,7 +184,7 @@ describe( 'useMergeRefs', () => {
 
 		rerender( <MergedRefs count={ 2 } tagName="button" /> );
 
-		const newElement = container.firstElementChild;
+		const newElement = screen.getByRole( 'button' );
 
 		// Both the node changes and the dependencies update for the second
 		// callback, so expect the old callback function to be called with null
@@ -216,13 +212,13 @@ describe( 'useMergeRefs', () => {
 	} );
 
 	it( 'should work for dependency change after node change', () => {
-		const { container, rerender, unmount } = render( <MergedRefs /> );
+		const { rerender, unmount } = render( <MergedRefs /> );
 
-		const originalElement = container.firstElementChild;
+		const originalElement = screen.getByRole( 'list' );
 
 		rerender( <MergedRefs tagName="button" /> );
 
-		const newElement = container.firstElementChild;
+		const newElement = screen.getByRole( 'button' );
 
 		// After a render with the original element and a second render with the
 		// new element, expect the initial callback functions to be called with
@@ -266,11 +262,9 @@ describe( 'useMergeRefs', () => {
 	} );
 
 	it( 'should allow disabling a ref', () => {
-		const { container, rerender, unmount } = render(
-			<MergedRefs disable1 />
-		);
+		const { rerender, unmount } = render( <MergedRefs disable1 /> );
 
-		const originalElement = container.firstElementChild;
+		const originalElement = screen.getByRole( 'list' );
 
 		// Render 1: ref 1 should be disabled.
 		expect( renderCallback.history ).toEqual( [
@@ -315,9 +309,9 @@ describe( 'useMergeRefs', () => {
 	} );
 
 	it( 'should allow the hook being unused', () => {
-		const { container, rerender } = render( <MergedRefs unused /> );
+		const { rerender } = render( <MergedRefs unused /> );
 
-		const originalElement = container.firstElementChild;
+		const originalElement = screen.getByRole( 'list' );
 
 		// Render 1: ref 1 should updated, ref 2 should not.
 		expect( renderCallback.history ).toEqual( [

--- a/packages/compose/src/hooks/use-merge-refs/test/index.js
+++ b/packages/compose/src/hooks/use-merge-refs/test/index.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import ReactDOM from 'react-dom';
+import { render } from '@testing-library/react';
 
 /**
  * WordPress dependencies
@@ -71,31 +71,22 @@ describe( 'useMergeRefs', () => {
 		return <TagName ref={ mergedRefs } />;
 	}
 
-	beforeEach( () => {
-		const rootElement = document.createElement( 'div' );
-		rootElement.id = 'root';
-		document.body.appendChild( rootElement );
-	} );
-
 	afterEach( () => {
-		// Reset all history and DOM.
+		// Reset all history.
 		renderCallback.history = [];
-		document.body.innerHTML = '';
 	} );
 
 	it( 'should work', () => {
-		const rootElement = document.getElementById( 'root' );
+		const { container, rerender } = render( <MergedRefs /> );
 
-		ReactDOM.render( <MergedRefs />, rootElement );
-
-		const originalElement = rootElement.firstElementChild;
+		const originalElement = container.firstElementChild;
 
 		// Render 1: both initial callback functions should be called with node.
 		expect( renderCallback.history ).toEqual( [
 			[ [ originalElement ], [ originalElement ] ],
 		] );
 
-		ReactDOM.render( <MergedRefs />, rootElement );
+		rerender( <MergedRefs /> );
 
 		// Render 2: the new callback functions should not be called! There has
 		// been no dependency change.
@@ -104,7 +95,7 @@ describe( 'useMergeRefs', () => {
 			[ [], [] ],
 		] );
 
-		ReactDOM.render( null, rootElement );
+		rerender( null );
 
 		// Unmount: the initial callback functions should receive null.
 		expect( renderCallback.history ).toEqual( [
@@ -117,15 +108,13 @@ describe( 'useMergeRefs', () => {
 	} );
 
 	it( 'should work for node change', () => {
-		const rootElement = document.getElementById( 'root' );
+		const { container, rerender } = render( <MergedRefs /> );
 
-		ReactDOM.render( <MergedRefs />, rootElement );
+		const originalElement = container.firstElementChild;
 
-		const originalElement = rootElement.firstElementChild;
+		rerender( <MergedRefs tagName="button" /> );
 
-		ReactDOM.render( <MergedRefs tagName="button" />, rootElement );
-
-		const newElement = rootElement.firstElementChild;
+		const newElement = container.firstElementChild;
 
 		// After a render with the original element and a second render with the
 		// new element, expect the initial callback functions to be called with
@@ -140,7 +129,7 @@ describe( 'useMergeRefs', () => {
 			[ [], [] ],
 		] );
 
-		ReactDOM.render( null, rootElement );
+		rerender( null );
 
 		// Unmount: the initial callback functions should receive null.
 		expect( renderCallback.history ).toEqual( [
@@ -153,17 +142,15 @@ describe( 'useMergeRefs', () => {
 	} );
 
 	it( 'should work with dependencies', () => {
-		const rootElement = document.getElementById( 'root' );
+		const { container, rerender } = render( <MergedRefs count={ 1 } /> );
 
-		ReactDOM.render( <MergedRefs count={ 1 } />, rootElement );
-
-		const originalElement = rootElement.firstElementChild;
+		const originalElement = container.firstElementChild;
 
 		expect( renderCallback.history ).toEqual( [
 			[ [ originalElement ], [ originalElement ] ],
 		] );
 
-		ReactDOM.render( <MergedRefs count={ 2 } />, rootElement );
+		rerender( <MergedRefs count={ 2 } /> );
 
 		// After a second render with a dependency change, expect the inital
 		// callback function to be called with null and the new callback
@@ -174,7 +161,7 @@ describe( 'useMergeRefs', () => {
 			[ [], [ originalElement ] ],
 		] );
 
-		ReactDOM.render( null, rootElement );
+		rerender( null );
 
 		// Unmount: current callback functions should be called with null.
 		expect( renderCallback.history ).toEqual( [
@@ -187,22 +174,17 @@ describe( 'useMergeRefs', () => {
 	} );
 
 	it( 'should simultaneously update node and dependencies', () => {
-		const rootElement = document.getElementById( 'root' );
+		const { container, rerender } = render( <MergedRefs count={ 1 } /> );
 
-		ReactDOM.render( <MergedRefs count={ 1 } />, rootElement );
-
-		const originalElement = rootElement.firstElementChild;
+		const originalElement = container.firstElementChild;
 
 		expect( renderCallback.history ).toEqual( [
 			[ [ originalElement ], [ originalElement ] ],
 		] );
 
-		ReactDOM.render(
-			<MergedRefs count={ 2 } tagName="button" />,
-			rootElement
-		);
+		rerender( <MergedRefs count={ 2 } tagName="button" /> );
 
-		const newElement = rootElement.firstElementChild;
+		const newElement = container.firstElementChild;
 
 		// Both the node changes and the dependencies update for the second
 		// callback, so expect the old callback function to be called with null
@@ -217,7 +199,7 @@ describe( 'useMergeRefs', () => {
 			[ [], [ newElement ] ],
 		] );
 
-		ReactDOM.render( null, rootElement );
+		rerender( null );
 
 		// Unmount: current callback functions should be called with null.
 		expect( renderCallback.history ).toEqual( [
@@ -230,15 +212,13 @@ describe( 'useMergeRefs', () => {
 	} );
 
 	it( 'should work for dependency change after node change', () => {
-		const rootElement = document.getElementById( 'root' );
+		const { container, rerender } = render( <MergedRefs /> );
 
-		ReactDOM.render( <MergedRefs />, rootElement );
+		const originalElement = container.firstElementChild;
 
-		const originalElement = rootElement.firstElementChild;
+		rerender( <MergedRefs tagName="button" /> );
 
-		ReactDOM.render( <MergedRefs tagName="button" />, rootElement );
-
-		const newElement = rootElement.firstElementChild;
+		const newElement = container.firstElementChild;
 
 		// After a render with the original element and a second render with the
 		// new element, expect the initial callback functions to be called with
@@ -253,10 +233,7 @@ describe( 'useMergeRefs', () => {
 			[ [], [] ],
 		] );
 
-		ReactDOM.render(
-			<MergedRefs tagName="button" count={ 1 } />,
-			rootElement
-		);
+		rerender( <MergedRefs tagName="button" count={ 1 } /> );
 
 		// After a third render with a dependency change, expect the inital
 		// callback function to be called with null and the new callback
@@ -271,7 +248,7 @@ describe( 'useMergeRefs', () => {
 			[ [], [ newElement ] ],
 		] );
 
-		ReactDOM.render( null, rootElement );
+		rerender( null );
 
 		// Unmount: current callback functions should be called with null.
 		expect( renderCallback.history ).toEqual( [
@@ -285,18 +262,16 @@ describe( 'useMergeRefs', () => {
 	} );
 
 	it( 'should allow disabling a ref', () => {
-		const rootElement = document.getElementById( 'root' );
+		const { container, rerender } = render( <MergedRefs disable1 /> );
 
-		ReactDOM.render( <MergedRefs disable1 />, rootElement );
-
-		const originalElement = rootElement.firstElementChild;
+		const originalElement = container.firstElementChild;
 
 		// Render 1: ref 1 should be disabled.
 		expect( renderCallback.history ).toEqual( [
 			[ [], [ originalElement ] ],
 		] );
 
-		ReactDOM.render( <MergedRefs disable2 />, rootElement );
+		rerender( <MergedRefs disable2 /> );
 
 		// Render 2: ref 1 should be enabled and receive the ref. Note that the
 		// callback hasn't changed, so the original callback function will be
@@ -306,7 +281,7 @@ describe( 'useMergeRefs', () => {
 			[ [], [] ],
 		] );
 
-		ReactDOM.render( <MergedRefs disable1 count={ 1 } />, rootElement );
+		rerender( <MergedRefs disable1 count={ 1 } /> );
 
 		// Render 3: ref 1 should again be disabled. Ref 2 to should receive a
 		// ref with the new callback function because the count has been
@@ -320,7 +295,7 @@ describe( 'useMergeRefs', () => {
 			[ [], [ originalElement ] ],
 		] );
 
-		ReactDOM.render( null, rootElement );
+		rerender( null );
 
 		// Unmount: current callback functions should receive null.
 		expect( renderCallback.history ).toEqual( [
@@ -334,18 +309,16 @@ describe( 'useMergeRefs', () => {
 	} );
 
 	it( 'should allow the hook being unused', () => {
-		const rootElement = document.getElementById( 'root' );
+		const { container, rerender } = render( <MergedRefs unused /> );
 
-		ReactDOM.render( <MergedRefs unused />, rootElement );
-
-		const originalElement = rootElement.firstElementChild;
+		const originalElement = container.firstElementChild;
 
 		// Render 1: ref 1 should updated, ref 2 should not.
 		expect( renderCallback.history ).toEqual( [
 			[ [ originalElement ], [] ],
 		] );
 
-		ReactDOM.render( <MergedRefs />, rootElement );
+		rerender( <MergedRefs /> );
 
 		// Render 2: ref 2 should be updated as well.
 		expect( renderCallback.history ).toEqual( [
@@ -353,7 +326,7 @@ describe( 'useMergeRefs', () => {
 			[ [], [] ],
 		] );
 
-		ReactDOM.render( <MergedRefs unused />, rootElement );
+		rerender( <MergedRefs unused /> );
 
 		// Render 3: ref 2 should be updated with null
 		expect( renderCallback.history ).toEqual( [

--- a/packages/edit-post/src/components/sidebar/plugin-pre-publish-panel/test/__snapshots__/index.js.snap
+++ b/packages/edit-post/src/components/sidebar/plugin-pre-publish-panel/test/__snapshots__/index.js.snap
@@ -1,3 +1,0 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
-
-exports[`PluginPrePublishPanel renders fill properly 1`] = `"<div class=\\"components-panel__body my-plugin-pre-publish-panel is-opened\\"><h2 class=\\"components-panel__body-title\\"><button type=\\"button\\" aria-expanded=\\"true\\" class=\\"components-button components-panel__body-toggle\\"><span aria-hidden=\\"true\\"><svg viewBox=\\"0 0 24 24\\" xmlns=\\"http://www.w3.org/2000/svg\\" width=\\"24\\" height=\\"24\\" class=\\"components-panel__arrow\\" aria-hidden=\\"true\\" focusable=\\"false\\"><path d=\\"M6.5 12.4L12 8l5.5 4.4-.9 1.2L12 10l-4.5 3.6-1-1.2z\\"></path></svg></span>My panel title</button></h2>My panel content</div>"`;

--- a/packages/edit-post/src/components/sidebar/plugin-pre-publish-panel/test/index.js
+++ b/packages/edit-post/src/components/sidebar/plugin-pre-publish-panel/test/index.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { render } from '@testing-library/react';
+import { render, screen } from '@testing-library/react';
 
 /**
  * WordPress dependencies
@@ -15,7 +15,7 @@ import PluginPrePublishPanel from '../';
 
 describe( 'PluginPrePublishPanel', () => {
 	test( 'renders fill properly', () => {
-		const { container } = render(
+		render(
 			<SlotFillProvider>
 				<PluginPrePublishPanel
 					className="my-plugin-pre-publish-panel"
@@ -28,6 +28,6 @@ describe( 'PluginPrePublishPanel', () => {
 			</SlotFillProvider>
 		);
 
-		expect( container.innerHTML ).toMatchSnapshot();
+		expect( screen.getByText( 'My panel title' ) ).toBeInTheDocument();
 	} );
 } );

--- a/packages/edit-post/src/components/sidebar/plugin-pre-publish-panel/test/index.js
+++ b/packages/edit-post/src/components/sidebar/plugin-pre-publish-panel/test/index.js
@@ -28,6 +28,6 @@ describe( 'PluginPrePublishPanel', () => {
 			</SlotFillProvider>
 		);
 
-		expect( screen.getByText( 'My panel title' ) ).toBeInTheDocument();
+		expect( screen.getByText( 'My panel title' ) ).toBeVisible();
 	} );
 } );

--- a/packages/edit-post/src/components/sidebar/plugin-pre-publish-panel/test/index.js
+++ b/packages/edit-post/src/components/sidebar/plugin-pre-publish-panel/test/index.js
@@ -1,8 +1,12 @@
 /**
+ * External dependencies
+ */
+import { render } from '@testing-library/react';
+
+/**
  * WordPress dependencies
  */
 import { SlotFillProvider } from '@wordpress/components';
-import { render } from '@wordpress/element';
 
 /**
  * Internal dependencies
@@ -11,21 +15,19 @@ import PluginPrePublishPanel from '../';
 
 describe( 'PluginPrePublishPanel', () => {
 	test( 'renders fill properly', () => {
-		const div = document.createElement( 'div' );
-		render(
+		const { container } = render(
 			<SlotFillProvider>
 				<PluginPrePublishPanel
 					className="my-plugin-pre-publish-panel"
 					title="My panel title"
-					initialOpen={ true }
+					initialOpen
 				>
 					My panel content
 				</PluginPrePublishPanel>
 				<PluginPrePublishPanel.Slot />
-			</SlotFillProvider>,
-			div
+			</SlotFillProvider>
 		);
 
-		expect( div.innerHTML ).toMatchSnapshot();
+		expect( container.innerHTML ).toMatchSnapshot();
 	} );
 } );


### PR DESCRIPTION
There are some unit tests that use `ReactDOM.render` to render a React UI into a JSDOM element. But the `ReactDOM.render` API is deprecated in React 18.

This PR is rewriting the `ReactDOM.render` to use the `render` abstraction from Testing Library. Under the hood it does exactly the same thing, and when we eventually upgrade to React 18, we'll get an update to `createRoot` for free.

Part of React 18 migration in #45235.