### PR TITLE
Lodash: Refactor block editor away from `_.reduce()`

### DIFF
--- a/packages/block-editor/src/components/colors/with-colors.js
+++ b/packages/block-editor/src/components/colors/with-colors.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { kebabCase, reduce } from 'lodash';
+import { kebabCase } from 'lodash';
 
 /**
  * WordPress dependencies
@@ -83,18 +83,14 @@ const withEditorColorPalette = () =>
  * @return {WPComponent} The component that can be used as a HOC.
  */
 function createColorHOC( colorTypes, withColorPalette ) {
-	const colorMap = reduce(
-		colorTypes,
-		( colorObject, colorType ) => {
-			return {
-				...colorObject,
-				...( typeof colorType === 'string'
-					? { [ colorType ]: kebabCase( colorType ) }
-					: colorType ),
-			};
-		},
-		{}
-	);
+	const colorMap = colorTypes.reduce( ( colorObject, colorType ) => {
+		return {
+			...colorObject,
+			...( typeof colorType === 'string'
+				? { [ colorType ]: kebabCase( colorType ) }
+				: colorType ),
+		};
+	}, {} );
 
 	return compose( [
 		withColorPalette,
@@ -118,13 +114,8 @@ function createColorHOC( colorTypes, withColorPalette ) {
 				}
 
 				createSetters() {
-					return reduce(
-						colorMap,
-						(
-							settersAccumulator,
-							colorContext,
-							colorAttributeName
-						) => {
+					return Object.keys( colorMap ).reduce(
+						( settersAccumulator, colorAttributeName ) => {
 							const upperFirstColorAttributeName =
 								upperFirst( colorAttributeName );
 							const customColorAttributeName = `custom${ upperFirstColorAttributeName }`;
@@ -163,9 +154,8 @@ function createColorHOC( colorTypes, withColorPalette ) {
 					{ attributes, colors },
 					previousState
 				) {
-					return reduce(
-						colorMap,
-						( newState, colorContext, colorAttributeName ) => {
+					return Object.entries( colorMap ).reduce(
+						( newState, [ colorAttributeName, colorContext ] ) => {
 							const colorObject = getColorObjectByAttributeValues(
 								colors,
 								attributes[ colorAttributeName ],

--- a/packages/block-editor/src/components/font-sizes/with-font-sizes.js
+++ b/packages/block-editor/src/components/font-sizes/with-font-sizes.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { find, pickBy, reduce } from 'lodash';
+import { find, pickBy } from 'lodash';
 
 /**
  * WordPress dependencies
@@ -43,8 +43,7 @@ export default ( ...fontSizeNames ) => {
 	 * and the value is the custom font size attribute name.
 	 * Custom font size is automatically compted by appending custom followed by the font size attribute name in with the first letter capitalized.
 	 */
-	const fontSizeAttributeNames = reduce(
-		fontSizeNames,
+	const fontSizeAttributeNames = fontSizeNames.reduce(
 		( fontSizeAttributeNamesAccumulator, fontSizeAttributeName ) => {
 			fontSizeAttributeNamesAccumulator[
 				fontSizeAttributeName
@@ -81,12 +80,13 @@ export default ( ...fontSizeNames ) => {
 					}
 
 					createSetters() {
-						return reduce(
-							fontSizeAttributeNames,
+						return Object.entries( fontSizeAttributeNames ).reduce(
 							(
 								settersAccumulator,
-								customFontSizeAttributeName,
-								fontSizeAttributeName
+								[
+									fontSizeAttributeName,
+									customFontSizeAttributeName,
+								]
 							) => {
 								const upperFirstFontSizeAttributeName =
 									upperFirst( fontSizeAttributeName );
@@ -159,15 +159,18 @@ export default ( ...fontSizeNames ) => {
 							return null;
 						}
 
-						const newState = reduce(
+						const newState = Object.entries(
 							pickBy(
 								fontSizeAttributeNames,
 								didAttributesChange
-							),
+							)
+						).reduce(
 							(
 								newStateAccumulator,
-								customFontSizeAttributeName,
-								fontSizeAttributeName
+								[
+									fontSizeAttributeName,
+									customFontSizeAttributeName,
+								]
 							) => {
 								const fontSizeAttributeValue =
 									attributes[ fontSizeAttributeName ];

--- a/packages/block-editor/src/store/reducer.js
+++ b/packages/block-editor/src/store/reducer.js
@@ -868,7 +868,7 @@ export const blocks = pipe(
 						[ id ]: Object.entries(
 							action.uniqueByBlock
 								? action.attributes[ id ]
-								: action.attributes
+								: action.attributes ?? {}
 						).reduce( ( result, [ key, value ] ) => {
 							// Consider as updates only changed values.
 							if ( value !== result[ key ] ) {

--- a/packages/block-editor/src/store/reducer.js
+++ b/packages/block-editor/src/store/reducer.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { reduce, omit, mapValues, isEqual, isEmpty } from 'lodash';
+import { omit, mapValues, isEqual, isEmpty } from 'lodash';
 
 /**
  * WordPress dependencies
@@ -683,30 +683,22 @@ const withReplaceInnerBlocks = ( reducer ) => ( state, action ) => {
 		// will be deleted entirely from its entity.
 		stateAfterInsert.order = {
 			...stateAfterInsert.order,
-			...reduce(
-				nestedControllers,
-				( result, value, key ) => {
-					if ( state.order[ key ] ) {
-						result[ key ] = state.order[ key ];
-					}
-					return result;
-				},
-				{}
-			),
+			...Object.keys( nestedControllers ).reduce( ( result, key ) => {
+				if ( state.order[ key ] ) {
+					result[ key ] = state.order[ key ];
+				}
+				return result;
+			}, {} ),
 		};
 		stateAfterInsert.tree = {
 			...stateAfterInsert.tree,
-			...reduce(
-				nestedControllers,
-				( result, value, _key ) => {
-					const key = `controlled||${ _key }`;
-					if ( state.tree[ key ] ) {
-						result[ key ] = state.tree[ key ];
-					}
-					return result;
-				},
-				{}
-			),
+			...Object.keys( nestedControllers ).reduce( ( result, _key ) => {
+				const key = `controlled||${ _key }`;
+				if ( state.tree[ key ] ) {
+					result[ key ] = state.tree[ key ];
+				}
+				return result;
+			}, {} ),
 		};
 	}
 	return stateAfterInsert;
@@ -873,24 +865,22 @@ export const blocks = pipe(
 				const next = action.clientIds.reduce(
 					( accumulator, id ) => ( {
 						...accumulator,
-						[ id ]: reduce(
+						[ id ]: Object.entries(
 							action.uniqueByBlock
 								? action.attributes[ id ]
-								: action.attributes,
-							( result, value, key ) => {
-								// Consider as updates only changed values.
-								if ( value !== result[ key ] ) {
-									result = getMutateSafeObject(
-										state[ id ],
-										result
-									);
-									result[ key ] = value;
-								}
+								: action.attributes
+						).reduce( ( result, [ key, value ] ) => {
+							// Consider as updates only changed values.
+							if ( value !== result[ key ] ) {
+								result = getMutateSafeObject(
+									state[ id ],
+									result
+								);
+								result[ key ] = value;
+							}
 
-								return result;
-							},
-							state[ id ]
-						),
+							return result;
+						}, state[ id ] ),
 					} ),
 					{}
 				);
@@ -1056,8 +1046,7 @@ export const blocks = pipe(
 					} ),
 					( nextState ) =>
 						mapValues( nextState, ( subState ) =>
-							reduce(
-								subState,
+							Object.values( subState ).reduce(
 								( result, clientId ) => {
 									if ( clientId === clientIds[ 0 ] ) {
 										return [

--- a/packages/block-editor/src/store/selectors.js
+++ b/packages/block-editor/src/store/selectors.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { map, reduce, find, filter, orderBy } from 'lodash';
+import { map, find, filter, orderBy } from 'lodash';
 import createSelector from 'rememo';
 
 /**
@@ -273,14 +273,10 @@ export const getGlobalBlockCount = createSelector(
 		if ( ! blockName ) {
 			return clientIds.length;
 		}
-		return reduce(
-			clientIds,
-			( accumulator, clientId ) => {
-				const block = state.blocks.byClientId[ clientId ];
-				return block.name === blockName ? accumulator + 1 : accumulator;
-			},
-			0
-		);
+		return clientIds.reduce( ( accumulator, clientId ) => {
+			const block = state.blocks.byClientId[ clientId ];
+			return block.name === blockName ? accumulator + 1 : accumulator;
+		}, 0 );
 	},
 	( state ) => [ state.blocks.order, state.blocks.byClientId ]
 );

--- a/packages/block-editor/src/store/test/reducer.js
+++ b/packages/block-editor/src/store/test/reducer.js
@@ -1894,6 +1894,27 @@ describe( 'state', () => {
 
 					expect( state.attributes ).toBe( state.attributes );
 				} );
+
+				it( 'should handle undefined attributes', () => {
+					const original = deepFreeze(
+						blocks( undefined, {
+							type: 'RESET_BLOCKS',
+							blocks: [
+								{
+									clientId: 'kumquat',
+									attributes: {},
+									innerBlocks: [],
+								},
+							],
+						} )
+					);
+					const state = blocks( original, {
+						type: 'UPDATE_BLOCK_ATTRIBUTES',
+						clientIds: [ 'kumquat' ],
+					} );
+
+					expect( state.attributes.kumquat ).toEqual( {} );
+				} );
 			} );
 
 			describe( 'isPersistentChange', () => {


### PR DESCRIPTION
## What?
This PR removes Lodash's `_.reduce()` from the block editor package. There are just a few usages and conversion is pretty straightforward. 

## Why?

Lodash is known to unnecessarily inflate the bundle size of packages, and in most cases, it can be replaced with native language functionality. See these for more information and rationale:

* https://github.com/WordPress/gutenberg/issues/16938#issuecomment-602837246
* https://github.com/WordPress/gutenberg/issues/17025
* https://github.com/WordPress/gutenberg/issues/39495 

## How?

We're replacing a few usages with a simple native `Array.prototype.reduce()`. 

## Testing Instructions

* Verify you can still properly set the background and overlay colors for a Cover block.
* Verify that pressing Enter while in the middle of a paragraph block still correctly splits the block in two.
* Verify that block attributes still persist as you switch between block variations.
* Verify the document outline is still displayed correctly in List View > Outline when you have more than 1 heading
* Verify all checks are green and all tests still pass - much of the code is covered by tests.