### PR TITLE
Lodash: Refactor blocks away from `_.reduce()`

### DIFF
--- a/packages/blocks/src/api/utils.js
+++ b/packages/blocks/src/api/utils.js
@@ -1,7 +1,6 @@
 /**
  * External dependencies
  */
-import { reduce } from 'lodash';
 import { colord, extend } from 'colord';
 import namesPlugin from 'colord/plugins/names';
 import a11yPlugin from 'colord/plugins/a11y';
@@ -257,9 +256,8 @@ export function __experimentalSanitizeBlockAttributes( name, attributes ) {
 		throw new Error( `Block type '${ name }' is not registered.` );
 	}
 
-	return reduce(
-		blockType.attributes,
-		( accumulator, schema, key ) => {
+	return Object.entries( blockType.attributes ).reduce(
+		( accumulator, [ key, schema ] ) => {
 			const value = attributes[ key ];
 
 			if ( undefined !== value ) {


### PR DESCRIPTION
## What?
This PR removes Lodash's `_.reduce()` from the blocks package. There is just a single usage and conversion is pretty straightforward. 

## Why?

Lodash is known to unnecessarily inflate the bundle size of packages, and in most cases, it can be replaced with native language functionality. See these for more information and rationale:

* https://github.com/WordPress/gutenberg/issues/16938#issuecomment-602837246
* https://github.com/WordPress/gutenberg/issues/17025
* https://github.com/WordPress/gutenberg/issues/39495 

## How?

We're replacing a single usage with a simple native `Array.prototype.reduce()`. 

## Testing Instructions

* Verify all checks are green and tests pass. The change is well covered by tests.