### PR TITLE
Lodash: Refactor away from `_.reduce()`

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -144,6 +144,7 @@ module.exports = {
 							'partial',
 							'partialRight',
 							'random',
+							'reduce',
 							'reject',
 							'repeat',
 							'reverse',

--- a/packages/babel-plugin-makepot/index.js
+++ b/packages/babel-plugin-makepot/index.js
@@ -33,7 +33,7 @@
  */
 
 const { po } = require( 'gettext-parser' );
-const { pick, reduce, isEqual, merge, isEmpty } = require( 'lodash' );
+const { pick, isEqual, merge, isEmpty } = require( 'lodash' );
 const { relative, sep } = require( 'path' );
 const { writeFileSync } = require( 'fs' );
 
@@ -324,50 +324,45 @@ module.exports = () => {
 					const files = Object.keys( strings ).sort();
 
 					// Combine translations from each file grouped by context.
-					const translations = reduce(
-						files,
-						( memo, file ) => {
-							for ( const context in strings[ file ] ) {
-								// Within the same file, sort translations by line.
-								const sortedTranslations = sortByReference(
-									Object.values( strings[ file ][ context ] )
-								);
+					const translations = files.reduce( ( memo, file ) => {
+						for ( const context in strings[ file ] ) {
+							// Within the same file, sort translations by line.
+							const sortedTranslations = sortByReference(
+								Object.values( strings[ file ][ context ] )
+							);
 
-								sortedTranslations.forEach( ( translation ) => {
-									const { msgctxt = '', msgid } = translation;
-									if ( ! memo.hasOwnProperty( msgctxt ) ) {
-										memo[ msgctxt ] = {};
-									}
+							sortedTranslations.forEach( ( translation ) => {
+								const { msgctxt = '', msgid } = translation;
+								if ( ! memo.hasOwnProperty( msgctxt ) ) {
+									memo[ msgctxt ] = {};
+								}
 
-									// Merge references if translation already exists.
-									if (
-										isSameTranslation(
-											translation,
-											memo[ msgctxt ][ msgid ]
-										)
-									) {
-										translation.comments.reference = [
-											...new Set(
-												[
-													memo[ msgctxt ][ msgid ]
-														.comments.reference,
-													translation.comments
-														.reference,
-												]
-													.join( '\n' )
-													.split( '\n' )
-											),
-										].join( '\n' );
-									}
+								// Merge references if translation already exists.
+								if (
+									isSameTranslation(
+										translation,
+										memo[ msgctxt ][ msgid ]
+									)
+								) {
+									translation.comments.reference = [
+										...new Set(
+											[
+												memo[ msgctxt ][ msgid ]
+													.comments.reference,
+												translation.comments.reference,
+											]
+												.join( '\n' )
+												.split( '\n' )
+										),
+									].join( '\n' );
+								}
 
-									memo[ msgctxt ][ msgid ] = translation;
-								} );
-							}
+								memo[ msgctxt ][ msgid ] = translation;
+							} );
+						}
 
-							return memo;
-						},
-						{}
-					);
+						return memo;
+					}, {} );
 
 					// Merge translations from individual files into headers
 					const data = merge( {}, baseData, { translations } );


### PR DESCRIPTION
## What?
This PR removes Lodash's `_.reduce()` completely and deprecates the method.

## Why?

Lodash is known to unnecessarily inflate the bundle size of packages, and in most cases, it can be replaced with native language functionality. See these for more information and rationale:

* https://github.com/WordPress/gutenberg/issues/16938#issuecomment-602837246
* https://github.com/WordPress/gutenberg/issues/17025
* https://github.com/WordPress/gutenberg/issues/39495 

## How?

We're replacing a single use with a simple native `Array.prototype.reduce()`. It's straightforward as a few lines above it's easy to see that we're working with an array.

The PR is easier to review with whitespace changes ignored.

## Testing Instructions

You can test this in a similar way as #43797, but by applying the changes done in this PR instead of the ones suggested there. 