### PR TITLE
Refactor away state in Nav menu selector

### DIFF
--- a/packages/block-library/src/navigation/edit/navigation-menu-selector.js
+++ b/packages/block-library/src/navigation/edit/navigation-menu-selector.js
@@ -106,7 +106,7 @@ function NavigationMenuSelector( {
 		isCreatingMenu,
 		createNavigationMenuIsError,
 		createNavigationMenuIsSuccess,
-		setIsCreatingMenu
+		setIsCreatingMenu,
 	] );
 
 	const NavigationMenuSelectorDropdown = (

--- a/packages/block-library/src/navigation/edit/navigation-menu-selector.js
+++ b/packages/block-library/src/navigation/edit/navigation-menu-selector.js
@@ -39,7 +39,6 @@ function NavigationMenuSelector( {
 	/* translators: %s: The name of a menu. */
 	const createActionLabel = __( "Create from '%s'" );
 
-	// const [ selectorLabel, setSelectorLabel ] = useState( '' );
 	const [ isCreatingMenu, setIsCreatingMenu ] = useState( false );
 
 	actionLabel = actionLabel || createActionLabel;
@@ -102,7 +101,11 @@ function NavigationMenuSelector( {
 		) {
 			setIsCreatingMenu( false );
 		}
-	}, [ hasResolvedNavigationMenus, createNavigationMenuIsSuccess ] );
+	}, [
+		isCreatingMenu,
+		createNavigationMenuIsError,
+		createNavigationMenuIsSuccess,
+	] );
 
 	const NavigationMenuSelectorDropdown = (
 		<DropdownMenu
@@ -117,7 +120,6 @@ function NavigationMenuSelector( {
 							<MenuItemsChoice
 								value={ currentMenuId }
 								onSelect={ ( menuId ) => {
-									// setSelectorLabel( __( 'Loading …' ) );
 									setIsCreatingMenu( true );
 									onSelectNavigationMenu( menuId );
 									onClose();

--- a/packages/block-library/src/navigation/edit/navigation-menu-selector.js
+++ b/packages/block-library/src/navigation/edit/navigation-menu-selector.js
@@ -71,7 +71,7 @@ function NavigationMenuSelector( {
 				};
 			} ) || []
 		);
-	}, [ currentMenuId, navigationMenus, actionLabel, isCreatingMenu ] );
+	}, [ navigationMenus, actionLabel ] );
 
 	const hasNavigationMenus = !! navigationMenus?.length;
 	const hasClassicMenus = !! classicMenus?.length;

--- a/packages/block-library/src/navigation/edit/navigation-menu-selector.js
+++ b/packages/block-library/src/navigation/edit/navigation-menu-selector.js
@@ -88,6 +88,7 @@ function NavigationMenuSelector( {
 	if ( isCreatingMenu || isResolvingNavigationMenus ) {
 		selectorLabel = __( 'Loading …' );
 	} else if ( noMenuSelected || noBlockMenus || menuUnavailable ) {
+		// Note: classic Menus may be available.
 		selectorLabel = __( 'Choose or create a Navigation menu' );
 	} else {
 		// Current Menu's title.

--- a/packages/block-library/src/navigation/edit/navigation-menu-selector.js
+++ b/packages/block-library/src/navigation/edit/navigation-menu-selector.js
@@ -11,12 +11,21 @@ import { moreVertical } from '@wordpress/icons';
 import { __, sprintf } from '@wordpress/i18n';
 import { decodeEntities } from '@wordpress/html-entities';
 import { useEffect, useMemo, useState } from '@wordpress/element';
+import { useEntityProp } from '@wordpress/core-data';
 
 /**
  * Internal dependencies
  */
 import useNavigationMenu from '../use-navigation-menu';
 import useNavigationEntities from '../use-navigation-entities';
+
+function buildMenuLabel( title, id ) {
+	const label =
+		decodeEntities( title?.rendered ) ||
+		/* translators: %s is the index of the menu in the list of menus. */
+		sprintf( __( '(no title %s)' ), id );
+	return label;
+}
 
 function NavigationMenuSelector( {
 	currentMenuId,
@@ -30,7 +39,7 @@ function NavigationMenuSelector( {
 	/* translators: %s: The name of a menu. */
 	const createActionLabel = __( "Create from '%s'" );
 
-	const [ selectorLabel, setSelectorLabel ] = useState( '' );
+	// const [ selectorLabel, setSelectorLabel ] = useState( '' );
 	const [ isCreatingMenu, setIsCreatingMenu ] = useState( false );
 
 	actionLabel = actionLabel || createActionLabel;
@@ -39,25 +48,23 @@ function NavigationMenuSelector( {
 
 	const {
 		navigationMenus,
+		isResolvingNavigationMenus,
 		hasResolvedNavigationMenus,
 		canUserCreateNavigationMenu,
 		canSwitchNavigationMenu,
 	} = useNavigationMenu();
 
+	const [ currentTitle ] = useEntityProp(
+		'postType',
+		'wp_navigation',
+		'title'
+	);
+
 	const menuChoices = useMemo( () => {
 		return (
 			navigationMenus?.map( ( { id, title }, index ) => {
-				const label =
-					decodeEntities( title?.rendered ) ||
-					/* translators: %s is the index of the menu in the list of menus. */
-					sprintf( __( '(no title %s)' ), index + 1 );
+				const label = buildMenuLabel( title, index + 1 );
 
-				if ( id === currentMenuId && ! isCreatingMenu ) {
-					setSelectorLabel(
-						/* translators: %s is the name of a navigation menu. */
-						sprintf( __( 'You are currently editing %s' ), label )
-					);
-				}
 				return {
 					value: id,
 					label,
@@ -77,13 +84,18 @@ function NavigationMenuSelector( {
 	const menuUnavailable =
 		hasResolvedNavigationMenus && currentMenuId === null;
 
-	useEffect( () => {
-		if ( ! hasResolvedNavigationMenus && ! canUserCreateNavigationMenu ) {
-			setSelectorLabel( __( 'Loading …' ) );
-		} else if ( noMenuSelected || noBlockMenus || menuUnavailable ) {
-			setSelectorLabel( __( 'Choose or create a Navigation menu' ) );
-		}
+	let selectorLabel = '';
 
+	if ( isCreatingMenu || isResolvingNavigationMenus ) {
+		selectorLabel = __( 'Loading …' );
+	} else if ( noMenuSelected || noBlockMenus || menuUnavailable ) {
+		selectorLabel = __( 'Choose or create a Navigation menu' );
+	} else {
+		// Current Menu's title.
+		selectorLabel = currentTitle;
+	}
+
+	useEffect( () => {
 		if (
 			isCreatingMenu &&
 			( createNavigationMenuIsSuccess || createNavigationMenuIsError )
@@ -105,7 +117,7 @@ function NavigationMenuSelector( {
 							<MenuItemsChoice
 								value={ currentMenuId }
 								onSelect={ ( menuId ) => {
-									setSelectorLabel( __( 'Loading …' ) );
+									// setSelectorLabel( __( 'Loading …' ) );
 									setIsCreatingMenu( true );
 									onSelectNavigationMenu( menuId );
 									onClose();
@@ -122,9 +134,6 @@ function NavigationMenuSelector( {
 								return (
 									<MenuItem
 										onClick={ () => {
-											setSelectorLabel(
-												__( 'Loading …' )
-											);
 											setIsCreatingMenu( true );
 											onSelectClassicMenu( menu );
 											onClose();
@@ -151,7 +160,6 @@ function NavigationMenuSelector( {
 									onClose();
 									onCreateNew();
 									setIsCreatingMenu( true );
-									setSelectorLabel( __( 'Loading …' ) );
 								} }
 							>
 								{ __( 'Create new menu' ) }

--- a/packages/block-library/src/navigation/edit/navigation-menu-selector.js
+++ b/packages/block-library/src/navigation/edit/navigation-menu-selector.js
@@ -106,6 +106,7 @@ function NavigationMenuSelector( {
 		isCreatingMenu,
 		createNavigationMenuIsError,
 		createNavigationMenuIsSuccess,
+		setIsCreatingMenu
 	] );
 
 	const NavigationMenuSelectorDropdown = (


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Aims to refactor away the use of setState in favour of computed values in order to simplify the logic and improve the handling in the Navigation block's menu selector within the inspector controls.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

The current code is

- complex to reason about
- uses setState in effects which has the potential to introduce recursive loops
- displays bugs in more complex situations (https://github.com/WordPress/gutenberg/pull/45443)

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

This PR aims to:

- make code easier to reason about
- improve resilience of code
- refactor setState to computed variables
- remove setState from effects where possible


## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->

## Screenshots or screencast <!-- if applicable -->
