### PR TITLE
Add edit button to template parts, reusable blocks and navigation blocks

### DIFF
--- a/packages/block-editor/src/store/actions.js
+++ b/packages/block-editor/src/store/actions.js
@@ -1726,3 +1726,10 @@ export function __unstableSetTemporarilyEditingAsBlocks(
 		temporarilyEditingAsBlocks,
 	};
 }
+
+export function __unstableStartEditingBlocks( clientId ) {
+	return {
+		type: 'START_EDITING_BLOCKS',
+		clientId,
+	};
+}

--- a/packages/block-editor/src/store/selectors.js
+++ b/packages/block-editor/src/store/selectors.js
@@ -2733,25 +2733,24 @@ export function __unstableHasActiveBlockOverlayActive( state, clientId ) {
 		return true;
 	}
 
-	// In navigation mode, the block overlay is active when the block is not
-	// selected (and doesn't contain a selected child). The same behavior is
-	// also enabled in all modes for blocks that have controlled children
-	// (reusable block, template part, navigation), unless explicitly disabled
-	// with `supports.__experimentalDisableBlockOverlay`.
-	const blockSupportDisable = hasBlockSupport(
+	// In navigation mode, the block overlay is active for all blocks when the block is not
+	// selected (and doesn't contain a selected child).
+	if ( editorMode === 'navigation' ) {
+		return (
+			! isBlockSelected( state, clientId ) &&
+			! hasSelectedInnerBlock( state, clientId, true )
+		);
+	}
+	const blockSupportBlockOverlay = hasBlockSupport(
 		getBlockName( state, clientId ),
-		'__experimentalDisableBlockOverlay',
+		'__experimentalBlockOverlay',
 		false
 	);
-	const shouldEnableIfUnselected =
-		editorMode === 'navigation' ||
-		( blockSupportDisable
-			? false
-			: areInnerBlocksControlled( state, clientId ) );
 
+	// For blocks that support the block overlay, The user can click "edit" button to remove the overlay.
 	return (
-		shouldEnableIfUnselected &&
-		! isBlockSelected( state, clientId ) &&
+		blockSupportBlockOverlay &&
+		! __unstableIsEditingBlock( state, clientId ) &&
 		! hasSelectedInnerBlock( state, clientId, true )
 	);
 }
@@ -2765,4 +2764,8 @@ export function __unstableIsWithinBlockOverlay( state, clientId ) {
 		parent = state.blocks.parents[ parent ];
 	}
 	return false;
+}
+
+export function __unstableIsEditingBlock( state, clientId ) {
+	return !! state.editedBlocks?.[ clientId ];
 }

--- a/packages/block-library/src/block/block.json
+++ b/packages/block-library/src/block/block.json
@@ -14,7 +14,8 @@
 	"supports": {
 		"customClassName": false,
 		"html": false,
-		"inserter": false
+		"inserter": false,
+		"__experimentalBlockOverlay": true
 	},
 	"editorStyle": "wp-block-editor"
 }

--- a/packages/block-library/src/navigation/block.json
+++ b/packages/block-library/src/navigation/block.json
@@ -94,6 +94,7 @@
 		"align": [ "wide", "full" ],
 		"html": false,
 		"inserter": true,
+		"__experimentalBlockOverlay": true,
 		"typography": {
 			"fontSize": true,
 			"lineHeight": true,

--- a/packages/block-library/src/template-part/block.json
+++ b/packages/block-library/src/template-part/block.json
@@ -23,7 +23,8 @@
 	"supports": {
 		"align": true,
 		"html": false,
-		"reusable": false
+		"reusable": false,
+		"__experimentalBlockOverlay": true
 	},
 	"editorStyle": "wp-block-template-part-editor"
 }


### PR DESCRIPTION
closes #43608

## What?

This is not ready 100% but I wanted to share early. The idea is to add an "edit" button to template parts, reusable blocks and navigation blocks. By default when you click these blocks the "overlay" remains active unless you click the "edit" button.

The overlay is reset when you unselect the block or its children.

## Why?

See the reasoning in the related issue.

## How?

More details will be added later.

## Testing Instructions

1- interact with reusable blocks or template parts and notice you need to first click the "edit" button in their toolbar.

