### PR TITLE
The `prelint:php` script doesn't work as expected when new dev dependencies get added to `composer.json`

### DIFF
--- a/package.json
+++ b/package.json
@@ -274,7 +274,7 @@
 		"lint:js:fix": "npm run lint:js -- --fix",
 		"lint:lockfile": "node ./bin/validate-package-lock.js",
 		"lint:md:docs": "wp-scripts lint-md-docs",
-		"prelint:php": "wp-env run composer \"install --no-interaction\"",
+		"prelint:php": "wp-env run composer \"update --no-interaction\"",
 		"lint:php": "wp-env run composer run-script lint",
 		"lint:pkg-json": "wp-scripts lint-pkg-json . 'packages/*/package.json'",
 		"native": "npm run --prefix packages/react-native-editor",


### PR DESCRIPTION
## What
This scpirt modifies the `prelint:php` `npm` script to ensure that dev dependencies get installed.
Fixes https://github.com/WordPress/gutenberg/issues/45313

## Why?
If a user runs the `npm run prelint:php` command for the first time, it works as expected, as there is no `composer.lock` file. All the packages get installed.
If, after some time, the contents of the composer.json file get modified, and the user tries to run the command again, these new packages will not be installed.
In such case, `composer.lock` has priority over `composer.json`, and the latter is ignored.

## How?
The `composer update` command should be used instead of `composer install` to ensure that the packages get updated according to `composer.json`.

## Testing Instructions
1. Install docker and `wp-env`.
2. Run `npm run prelint:php`.
3. Run `npm run lint:php`.
4. Make sure that the linter works. You should see something like this in the console:
```
`Ran `run-script lint` in 'composer'. (in 64s 862ms)