### PR TITLE
Add rel attribute for Social Icons

### DIFF
--- a/docs/reference-guides/core-blocks.md
+++ b/docs/reference-guides/core-blocks.md
@@ -753,7 +753,7 @@ Display an icon linking to a social media profile or site. ([Source](https://git
 -	**Name:** core/social-link
 -	**Category:** widgets
 -	**Supports:** ~~html~~, ~~reusable~~
--	**Attributes:** label, service, url
+-	**Attributes:** label, rel, service, url
 
 ## Social Icons
 

--- a/packages/block-library/src/social-link/block.json
+++ b/packages/block-library/src/social-link/block.json
@@ -16,6 +16,9 @@
 		},
 		"label": {
 			"type": "string"
+		},
+		"rel": {
+			"type": "string"
 		}
 	},
 	"usesContext": [

--- a/packages/block-library/src/social-link/edit.js
+++ b/packages/block-library/src/social-link/edit.js
@@ -12,7 +12,7 @@ import {
 	URLInput,
 	useBlockProps,
 } from '@wordpress/block-editor';
-import { Fragment, useState, useCallback } from '@wordpress/element';
+import { Fragment, useState } from '@wordpress/element';
 import {
 	Button,
 	PanelBody,
@@ -88,13 +88,6 @@ const SocialLinkEdit = ( {
 		},
 	} );
 
-	const onSetLinkRel = useCallback(
-		( value ) => {
-			setAttributes( { rel: value } );
-		},
-		[ setAttributes ]
-	);
-
 	return (
 		<Fragment>
 			<InspectorControls>
@@ -124,7 +117,7 @@ const SocialLinkEdit = ( {
 				<TextControl
 					label={ __( 'Link rel' ) }
 					value={ rel || '' }
-					onChange={ onSetLinkRel }
+					onChange={ ( value ) => setAttributes( { rel: value } ) }
 				/>
 			</InspectorControls>
 			<li { ...blockProps }>

--- a/packages/block-library/src/social-link/edit.js
+++ b/packages/block-library/src/social-link/edit.js
@@ -12,7 +12,7 @@ import {
 	URLInput,
 	useBlockProps,
 } from '@wordpress/block-editor';
-import { Fragment, useState } from '@wordpress/element';
+import { Fragment, useState, useCallback } from '@wordpress/element';
 import {
 	Button,
 	PanelBody,
@@ -66,7 +66,7 @@ const SocialLinkEdit = ( {
 	isSelected,
 	setAttributes,
 } ) => {
-	const { url, service, label } = attributes;
+	const { url, service, label, rel } = attributes;
 	const { showLabels, iconColorValue, iconBackgroundColorValue } = context;
 	const [ showURLPopover, setPopover ] = useState( false );
 	const classes = classNames( 'wp-social-link', 'wp-social-link-' + service, {
@@ -87,6 +87,13 @@ const SocialLinkEdit = ( {
 			backgroundColor: iconBackgroundColorValue,
 		},
 	} );
+
+	const onSetLinkRel = useCallback(
+		( value ) => {
+			setAttributes( { rel: value } );
+		},
+		[ setAttributes ]
+	);
 
 	return (
 		<Fragment>
@@ -112,6 +119,13 @@ const SocialLinkEdit = ( {
 						/>
 					</PanelRow>
 				</PanelBody>
+			</InspectorControls>
+			<InspectorControls __experimentalGroup="advanced">
+				<TextControl
+					label={ __( 'Link rel' ) }
+					value={ rel || '' }
+					onChange={ onSetLinkRel }
+				/>
 			</InspectorControls>
 			<li { ...blockProps }>
 				<Button

--- a/packages/block-library/src/social-link/index.php
+++ b/packages/block-library/src/social-link/index.php
@@ -20,6 +20,7 @@ function render_block_core_social_link( $attributes, $content, $block ) {
 	$service     = ( isset( $attributes['service'] ) ) ? $attributes['service'] : 'Icon';
 	$url         = ( isset( $attributes['url'] ) ) ? $attributes['url'] : false;
 	$label       = ( isset( $attributes['label'] ) ) ? $attributes['label'] : block_core_social_link_get_name( $service );
+	$rel         = ( isset( $attributes['rel'] ) ) ? $attributes['rel'] : '';
 	$show_labels = array_key_exists( 'showLabels', $block->context ) ? $block->context['showLabels'] : false;
 
 	// Don't render a link if there is no URL set.
@@ -43,11 +44,6 @@ function render_block_core_social_link( $attributes, $content, $block ) {
 		$url = 'https://' . $url;
 	}
 
-	$rel_target_attributes = '';
-	if ( $open_in_new_tab ) {
-		$rel_target_attributes = 'rel="noopener nofollow" target="_blank"';
-	}
-
 	$icon               = block_core_social_link_get_icon( $service );
 	$wrapper_attributes = get_block_wrapper_attributes(
 		array(
@@ -57,13 +53,21 @@ function render_block_core_social_link( $attributes, $content, $block ) {
 	);
 
 	$link  = '<li ' . $wrapper_attributes . '>';
-	$link .= '<a href="' . esc_url( $url ) . '" ' . $rel_target_attributes . ' class="wp-block-social-link-anchor">';
+	$link .= '<a href="' . esc_url( $url ) . '" class="wp-block-social-link-anchor">';
 	$link .= $icon;
 	$link .= '<span class="wp-block-social-link-label' . ( $show_labels ? '' : ' screen-reader-text' ) . '">';
 	$link .= esc_html( $label );
 	$link .= '</span></a></li>';
 
-	return $link;
+	$w = new WP_HTML_Tag_Processor($link);
+	$w->next_tag('a');
+	if ( $open_in_new_tab ) {
+		$w->set_attribute('rel', esc_attr( $rel ) . ' noopener nofollow');
+		$w->set_attribute('target', '_blank');
+	} else if ( $rel !== '' ) {
+		$w->set_attribute('rel', esc_attr( $rel) );
+	}
+	return $w;
 }
 
 /**

--- a/packages/block-library/src/social-link/index.php
+++ b/packages/block-library/src/social-link/index.php
@@ -59,13 +59,13 @@ function render_block_core_social_link( $attributes, $content, $block ) {
 	$link .= esc_html( $label );
 	$link .= '</span></a></li>';
 
-	$w = new WP_HTML_Tag_Processor($link);
-	$w->next_tag('a');
+	$w = new WP_HTML_Tag_Processor( $link );
+	$w->next_tag( 'a' );
 	if ( $open_in_new_tab ) {
-		$w->set_attribute('rel', esc_attr( $rel ) . ' noopener nofollow');
-		$w->set_attribute('target', '_blank');
-	} else if ( $rel !== '' ) {
-		$w->set_attribute('rel', esc_attr( $rel) );
+		$w->set_attribute( 'rel', esc_attr( $rel ) . ' noopener nofollow' );
+		$w->set_attribute( 'target', '_blank' );
+	} elseif ( '' !== $rel ) {
+		$w->set_attribute( 'rel', esc_attr( $rel ) );
 	}
 	return $w;
 }


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Makes `rel` attribute editable on social icons, closes #38630

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
Some social networks like IndieWeb and Mastodon use the pattern of looking for a link back with `rel="me"` to establish that a user controls a URL. Adding the option for a custom `rel` attribute allows people to claim their WordPress sites using Gutenberg.

## How?
This mimics the implementation of the `rel` attribute on the Button block, by exposing the attribute as an advanced option in the block inspector.

## Testing Instructions
1. Add a Social Links block to a page or template
2. Choose the block and enter something for the `rel`
3. Save
4. Inspect the element on the rendered page and confirm that it has the correct `rel` attribute on the `<a>` element

## Screenshots or screencast <!-- if applicable -->
<img width="580" alt="Screenshot 2022-11-01 at 3 27 17 PM" src="https://user-images.githubusercontent.com/128240/199323184-c6b61da7-8a4f-4137-a455-6012ecaadc64.png">