### PR TITLE
Colorize template parts and  Reusable blocks

### DIFF
--- a/packages/base-styles/_colors.scss
+++ b/packages/base-styles/_colors.scss
@@ -26,6 +26,5 @@ $alert-red: #cc1818;
 $alert-green: #4ab866;
 
 :root {
-	--wp-block-template-part-color: #7c4dc3;
-	--wp-block-reusable-color: #34948e;
+	--wp-block-synced-color: #7a00df;
 }

--- a/packages/base-styles/_colors.scss
+++ b/packages/base-styles/_colors.scss
@@ -29,5 +29,4 @@ $alert-green: #4ab866;
 
 :root {
 	--wp-block-synced-color: #7a00df;
-	--wp-block-synced-color--rgb: #{hex-to-rgb(#7a00df)};
 }

--- a/packages/base-styles/_colors.scss
+++ b/packages/base-styles/_colors.scss
@@ -26,6 +26,6 @@ $alert-red: #cc1818;
 $alert-green: #4ab866;
 
 :root {
-	--wp-block-template-color: #7c4dc3;
+	--wp-block-template-part-color: #7c4dc3;
 	--wp-block-reusable-color: #34948e;
 }

--- a/packages/base-styles/_colors.scss
+++ b/packages/base-styles/_colors.scss
@@ -29,4 +29,5 @@ $alert-green: #4ab866;
 
 :root {
 	--wp-block-synced-color: #7a00df;
+	--wp-block-synced-color--rgb: #{hex-to-rgb(#7a00df)};
 }

--- a/packages/base-styles/_colors.scss
+++ b/packages/base-styles/_colors.scss
@@ -24,3 +24,8 @@ $light-gray-placeholder: rgba($white, 0.65);
 $alert-yellow: #f0b849;
 $alert-red: #cc1818;
 $alert-green: #4ab866;
+
+:root {
+	--wp-block-template-color: #7c4dc3;
+	--wp-block-reusable-color: #34948e;
+}

--- a/packages/base-styles/_colors.scss
+++ b/packages/base-styles/_colors.scss
@@ -1,3 +1,5 @@
+@import "./functions";
+
 /**
  * Colors
  */
@@ -27,4 +29,5 @@ $alert-green: #4ab866;
 
 :root {
 	--wp-block-synced-color: #7a00df;
+	--wp-block-synced-color--rgb: #{hex-to-rgb(#7a00df)};
 }

--- a/packages/block-editor/src/components/block-card/index.js
+++ b/packages/block-editor/src/components/block-card/index.js
@@ -1,4 +1,9 @@
 /**
+ * External dependencies
+ */
+import classnames from 'classnames';
+
+/**
  * WordPress dependencies
  */
 import deprecated from '@wordpress/deprecated';
@@ -17,6 +22,7 @@ function BlockCard( {
 	blockType,
 	parentBlockClientId,
 	handleBackButton,
+	isSynced,
 } ) {
 	if ( blockType ) {
 		deprecated( '`blockType` property in `BlockCard component`', {
@@ -30,7 +36,11 @@ function BlockCard( {
 		window?.__experimentalEnableOffCanvasNavigationEditor === true;
 
 	return (
-		<div className="block-editor-block-card">
+		<div
+			className={ classnames( 'block-editor-block-card', {
+				'is-synced': isSynced,
+			} ) }
+		>
 			{ isOffCanvasNavigationEditorEnabled && parentBlockClientId && (
 				<Button
 					onClick={ handleBackButton }

--- a/packages/block-editor/src/components/block-card/style.scss
+++ b/packages/block-editor/src/components/block-card/style.scss
@@ -28,3 +28,7 @@
 	width: $button-size-small;
 	height: $button-size-small;
 }
+
+.block-editor-block-card.is-synced .block-editor-block-icon {
+	color: var(--wp-block-synced-color);
+}

--- a/packages/block-editor/src/components/block-content-overlay/style.scss
+++ b/packages/block-editor/src/components/block-content-overlay/style.scss
@@ -26,7 +26,9 @@
 	&.is-reusable:hover:not(.is-dragging-blocks)::before,
 	&.wp-block-template-part:hover:not(.is-dragging-blocks)::before {
 		filter: brightness(0.95);
-		background: rgba(var(--wp-block-synced-color--rgb), 0.3);
+		background:
+			linear-gradient(transparentize($white, 0.1), transparentize($white, 0.1)),
+			linear-gradient(var(--wp-block-synced-color), var(--wp-block-synced-color));
 		box-shadow: 0 0 0 $border-width var(--wp-block-synced-color) inset;
 	}
 

--- a/packages/block-editor/src/components/block-content-overlay/style.scss
+++ b/packages/block-editor/src/components/block-content-overlay/style.scss
@@ -19,16 +19,13 @@
 	}
 
 	&:hover:not(.is-dragging-blocks)::before {
-		background: rgba(var(--wp-admin-theme-color--rgb), 0.3);
+		background: rgba(var(--wp-admin-theme-color--rgb), 0.04);
 		box-shadow: 0 0 0 $border-width var(--wp-admin-theme-color) inset;
 	}
 
 	&.is-reusable:hover:not(.is-dragging-blocks)::before,
 	&.wp-block-template-part:hover:not(.is-dragging-blocks)::before {
-		filter: brightness(0.95);
-		background:
-			linear-gradient(transparentize($white, 0.1), transparentize($white, 0.1)),
-			linear-gradient(var(--wp-block-synced-color), var(--wp-block-synced-color));
+		background: rgba(var(--wp-block-synced-color--rgb), 0.04);
 		box-shadow: 0 0 0 $border-width var(--wp-block-synced-color) inset;
 	}
 

--- a/packages/block-editor/src/components/block-content-overlay/style.scss
+++ b/packages/block-editor/src/components/block-content-overlay/style.scss
@@ -23,6 +23,12 @@
 		box-shadow: 0 0 0 $border-width var(--wp-admin-theme-color) inset;
 	}
 
+	&.is-reusable:hover:not(.is-dragging-blocks)::before,
+	&.wp-block-template-part:hover:not(.is-dragging-blocks)::before {
+		background: rgba(var(--wp-block-synced-color--rgb), 0.3);
+		box-shadow: 0 0 0 $border-width var(--wp-block-synced-color) inset;
+	}
+
 	&.is-selected:not(.is-dragging-blocks)::before {
 		box-shadow: 0 0 0 $border-width var(--wp-admin-theme-color) inset;
 	}

--- a/packages/block-editor/src/components/block-content-overlay/style.scss
+++ b/packages/block-editor/src/components/block-content-overlay/style.scss
@@ -25,6 +25,7 @@
 
 	&.is-reusable:hover:not(.is-dragging-blocks)::before,
 	&.wp-block-template-part:hover:not(.is-dragging-blocks)::before {
+		filter: brightness(0.95);
 		background: rgba(var(--wp-block-synced-color--rgb), 0.3);
 		box-shadow: 0 0 0 $border-width var(--wp-block-synced-color) inset;
 	}

--- a/packages/block-editor/src/components/block-toolbar/index.js
+++ b/packages/block-editor/src/components/block-toolbar/index.js
@@ -74,6 +74,10 @@ const BlockToolbar = ( { hideDragHandle } ) => {
 		};
 	}, [] );
 
+	const isReusable =
+		blockType.name === 'core/block' && blockType.category === 'reusable';
+	const isTemplatePart = blockType.name === 'core/template-part';
+
 	// Handles highlighting the current block outline on hover or focus of the
 	// block type toolbar area.
 	const { toggleBlockHighlight } = useDispatch( blockEditorStore );
@@ -112,7 +116,11 @@ const BlockToolbar = ( { hideDragHandle } ) => {
 
 	const classes = classnames(
 		'block-editor-block-toolbar',
-		shouldShowMovers && 'is-showing-movers'
+		shouldShowMovers && 'is-showing-movers',
+		{
+			'is-reusable': isReusable,
+			'is-template-part': isTemplatePart,
+		}
 	);
 
 	return (

--- a/packages/block-editor/src/components/block-toolbar/index.js
+++ b/packages/block-editor/src/components/block-toolbar/index.js
@@ -9,7 +9,12 @@ import classnames from 'classnames';
 import { useSelect, useDispatch } from '@wordpress/data';
 import { useRef } from '@wordpress/element';
 import { useViewportMatch } from '@wordpress/compose';
-import { getBlockType, hasBlockSupport } from '@wordpress/blocks';
+import {
+	getBlockType,
+	hasBlockSupport,
+	isReusableBlock,
+	isTemplatePart as isTemplate,
+} from '@wordpress/blocks';
 import { ToolbarGroup } from '@wordpress/components';
 
 /**
@@ -74,10 +79,6 @@ const BlockToolbar = ( { hideDragHandle } ) => {
 		};
 	}, [] );
 
-	const isReusable =
-		blockType.name === 'core/block' && blockType.category === 'reusable';
-	const isTemplatePart = blockType.name === 'core/template-part';
-
 	// Handles highlighting the current block outline on hover or focus of the
 	// block type toolbar area.
 	const { toggleBlockHighlight } = useDispatch( blockEditorStore );
@@ -113,6 +114,8 @@ const BlockToolbar = ( { hideDragHandle } ) => {
 
 	const shouldShowVisualToolbar = isValid && isVisual;
 	const isMultiToolbar = blockClientIds.length > 1;
+	const isReusable = isReusableBlock( blockType );
+	const isTemplatePart = isTemplate( blockType );
 
 	const classes = classnames(
 		'block-editor-block-toolbar',

--- a/packages/block-editor/src/components/block-toolbar/index.js
+++ b/packages/block-editor/src/components/block-toolbar/index.js
@@ -13,7 +13,7 @@ import {
 	getBlockType,
 	hasBlockSupport,
 	isReusableBlock,
-	isTemplatePart as isTemplate,
+	isTemplatePart,
 } from '@wordpress/blocks';
 import { ToolbarGroup } from '@wordpress/components';
 
@@ -114,15 +114,14 @@ const BlockToolbar = ( { hideDragHandle } ) => {
 
 	const shouldShowVisualToolbar = isValid && isVisual;
 	const isMultiToolbar = blockClientIds.length > 1;
-	const isReusable = isReusableBlock( blockType );
-	const isTemplatePart = isTemplate( blockType );
+	const isSynced =
+		isReusableBlock( blockType ) || isTemplatePart( blockType );
 
 	const classes = classnames(
 		'block-editor-block-toolbar',
 		shouldShowMovers && 'is-showing-movers',
 		{
-			'is-reusable': isReusable,
-			'is-template-part': isTemplatePart,
+			'is-synced': isSynced,
 		}
 	);
 

--- a/packages/block-editor/src/components/block-toolbar/index.js
+++ b/packages/block-editor/src/components/block-toolbar/index.js
@@ -117,13 +117,10 @@ const BlockToolbar = ( { hideDragHandle } ) => {
 	const isSynced =
 		isReusableBlock( blockType ) || isTemplatePart( blockType );
 
-	const classes = classnames(
-		'block-editor-block-toolbar',
-		shouldShowMovers && 'is-showing-movers',
-		{
-			'is-synced': isSynced,
-		}
-	);
+	const classes = classnames( 'block-editor-block-toolbar', {
+		'is-showing-movers': shouldShowMovers,
+		'is-synced': isSynced,
+	} );
 
 	return (
 		<div className={ classes }>

--- a/packages/block-editor/src/components/block-toolbar/style.scss
+++ b/packages/block-editor/src/components/block-toolbar/style.scss
@@ -43,8 +43,11 @@
 		color: var(--wp-block-reusable-color);
 	}
 
-	&.is-template-part .block-editor-block-switcher .components-button {
-		color: var(--wp-block-reusable-color);
+	&.is-template-part .components-toolbar-button.block-editor-block-switcher__no-switcher-icon {
+		color: var(--wp-block-template-color);
+		&:disabled .block-editor-block-icon.has-colors {
+			color: var(--wp-block-template-color);
+		}
 	}
 
 	> :last-child,

--- a/packages/block-editor/src/components/block-toolbar/style.scss
+++ b/packages/block-editor/src/components/block-toolbar/style.scss
@@ -39,6 +39,14 @@
 		border-right: $border-width solid $gray-300;
 	}
 
+	&.is-reusable .block-editor-block-switcher .components-button {
+		color: var(--wp-block-reusable-color);
+	}
+
+	&.is-template-part .block-editor-block-switcher .components-button {
+		color: var(--wp-block-reusable-color);
+	}
+
 	> :last-child,
 	> :last-child .components-toolbar-group,
 	> :last-child .components-toolbar {

--- a/packages/block-editor/src/components/block-toolbar/style.scss
+++ b/packages/block-editor/src/components/block-toolbar/style.scss
@@ -44,9 +44,9 @@
 	}
 
 	&.is-template-part .components-toolbar-button.block-editor-block-switcher__no-switcher-icon {
-		color: var(--wp-block-template-color);
+		color: var(--wp-block-template-part-color);
 		&:disabled .block-editor-block-icon.has-colors {
-			color: var(--wp-block-template-color);
+			color: var(--wp-block-template-part-color);
 		}
 	}
 

--- a/packages/block-editor/src/components/block-toolbar/style.scss
+++ b/packages/block-editor/src/components/block-toolbar/style.scss
@@ -39,14 +39,14 @@
 		border-right: $border-width solid $gray-300;
 	}
 
-	&.is-reusable .block-editor-block-switcher .components-button {
-		color: var(--wp-block-reusable-color);
+	&.is-synced .block-editor-block-switcher .components-button {
+		color: var(--wp-block-synced-color);
 	}
 
-	&.is-template-part .components-toolbar-button.block-editor-block-switcher__no-switcher-icon {
-		color: var(--wp-block-template-part-color);
+	&.is-synced .components-toolbar-button.block-editor-block-switcher__no-switcher-icon {
+		color: var(--wp-block-synced-color);
 		&:disabled .block-editor-block-icon.has-colors {
-			color: var(--wp-block-template-part-color);
+			color: var(--wp-block-synced-color);
 		}
 	}
 

--- a/packages/block-editor/src/components/block-toolbar/style.scss
+++ b/packages/block-editor/src/components/block-toolbar/style.scss
@@ -39,12 +39,11 @@
 		border-right: $border-width solid $gray-300;
 	}
 
-	&.is-synced .block-editor-block-switcher .components-button {
+	&.is-synced .block-editor-block-switcher .components-button .block-editor-block-icon {
 		color: var(--wp-block-synced-color);
 	}
 
 	&.is-synced .components-toolbar-button.block-editor-block-switcher__no-switcher-icon {
-		color: var(--wp-block-synced-color);
 		&:disabled .block-editor-block-icon.has-colors {
 			color: var(--wp-block-synced-color);
 		}

--- a/packages/block-editor/src/components/inserter-list-item/index.js
+++ b/packages/block-editor/src/components/inserter-list-item/index.js
@@ -11,7 +11,7 @@ import {
 	createBlock,
 	createBlocksFromInnerBlocksTemplate,
 	isReusableBlock,
-	isTemplatePart as isTemplate,
+	isTemplatePart,
 } from '@wordpress/blocks';
 import { __experimentalTruncate as Truncate } from '@wordpress/components';
 import { ENTER, isAppleOS } from '@wordpress/keycodes';
@@ -49,8 +49,7 @@ function InserterListItem( {
 		];
 	}, [ item.name, item.initialAttributes, item.initialAttributes ] );
 
-	const isReusable = isReusableBlock( item );
-	const isTemplatePart = isTemplate( item );
+	const isSynced = isReusableBlock( item ) || isTemplatePart( item );
 
 	return (
 		<InserterDraggableBlocks
@@ -64,8 +63,7 @@ function InserterListItem( {
 						'block-editor-block-types-list__list-item',
 
 						{
-							'is-reusable': isReusable,
-							'is-template-part': isTemplatePart,
+							'is-synced': isSynced,
 						}
 					) }
 					draggable={ draggable }

--- a/packages/block-editor/src/components/inserter-list-item/index.js
+++ b/packages/block-editor/src/components/inserter-list-item/index.js
@@ -10,6 +10,8 @@ import { useMemo, useRef, memo } from '@wordpress/element';
 import {
 	createBlock,
 	createBlocksFromInnerBlocksTemplate,
+	isReusableBlock,
+	isTemplatePart as isTemplate,
 } from '@wordpress/blocks';
 import { __experimentalTruncate as Truncate } from '@wordpress/components';
 import { ENTER, isAppleOS } from '@wordpress/keycodes';
@@ -47,9 +49,8 @@ function InserterListItem( {
 		];
 	}, [ item.name, item.initialAttributes, item.initialAttributes ] );
 
-	const isReusable =
-		item.name === 'core/block' && item.category === 'reusable';
-	const isTemplatePart = item.name === 'core/template-part';
+	const isReusable = isReusableBlock( item );
+	const isTemplatePart = isTemplate( item );
 
 	return (
 		<InserterDraggableBlocks

--- a/packages/block-editor/src/components/inserter-list-item/index.js
+++ b/packages/block-editor/src/components/inserter-list-item/index.js
@@ -47,6 +47,10 @@ function InserterListItem( {
 		];
 	}, [ item.name, item.initialAttributes, item.initialAttributes ] );
 
+	const isReusable =
+		item.name === 'core/block' && item.category === 'reusable';
+	const isTemplatePart = item.name === 'core/template-part';
+
 	return (
 		<InserterDraggableBlocks
 			isEnabled={ isDraggable && ! item.disabled }
@@ -55,7 +59,14 @@ function InserterListItem( {
 		>
 			{ ( { draggable, onDragStart, onDragEnd } ) => (
 				<div
-					className="block-editor-block-types-list__list-item"
+					className={ classnames(
+						'block-editor-block-types-list__list-item',
+
+						{
+							'is-reusable': isReusable,
+							'is-template-part': isTemplatePart,
+						}
+					) }
 					draggable={ draggable }
 					onDragStart={ ( event ) => {
 						isDragging.current = true;

--- a/packages/block-editor/src/components/inserter-list-item/style.scss
+++ b/packages/block-editor/src/components/inserter-list-item/style.scss
@@ -3,16 +3,10 @@
 	width: 33.33%;
 	padding: 0;
 	margin: 0;
-	&.is-template-part {
+	&.is-synced {
 		.block-editor-block-icon.has-colors,
 		.block-editor-block-types-list__item-title {
-			color: var(--wp-block-template-part-color);
-		}
-	}
-	&.is-reusable {
-		.block-editor-block-icon.has-colors,
-		.block-editor-block-types-list__item-title {
-			color: var(--wp-block-reusable-color);
+			color: var(--wp-block-synced-color);
 		}
 	}
 }

--- a/packages/block-editor/src/components/inserter-list-item/style.scss
+++ b/packages/block-editor/src/components/inserter-list-item/style.scss
@@ -3,6 +3,18 @@
 	width: 33.33%;
 	padding: 0;
 	margin: 0;
+	&.is-template-part {
+		.block-editor-block-icon.has-colors,
+		.block-editor-block-types-list__item-title {
+			color: var(--wp-block-template-part-color);
+		}
+	}
+	&.is-reusable {
+		.block-editor-block-icon.has-colors,
+		.block-editor-block-types-list__item-title {
+			color: var(--wp-block-reusable-color);
+		}
+	}
 }
 
 .components-button.block-editor-block-types-list__item {

--- a/packages/block-editor/src/components/inserter-list-item/style.scss
+++ b/packages/block-editor/src/components/inserter-list-item/style.scss
@@ -4,8 +4,7 @@
 	padding: 0;
 	margin: 0;
 	&.is-synced {
-		.block-editor-block-icon.has-colors,
-		.block-editor-block-types-list__item-title {
+		.block-editor-block-icon.has-colors {
 			color: var(--wp-block-synced-color);
 		}
 	}

--- a/packages/block-editor/src/components/list-view/block.js
+++ b/packages/block-editor/src/components/list-view/block.js
@@ -54,6 +54,7 @@ function ListViewBlock( {
 	isExpanded,
 	selectedClientIds,
 	preventAnnouncement,
+	isSyncedBranch,
 } ) {
 	const cellRef = useRef( null );
 	const [ isHovered, setIsHovered ] = useState( false );
@@ -205,6 +206,7 @@ function ListViewBlock( {
 		'is-first-selected': isFirstSelectedBlock,
 		'is-last-selected': isLastSelectedBlock,
 		'is-branch-selected': isBranchSelected,
+		'is-synced-branch': isSyncedBranch,
 		'is-dragging': isDragged,
 		'has-single-cell': ! showBlockActions,
 		'is-synced': blockInformation.isSynced,

--- a/packages/block-editor/src/components/list-view/block.js
+++ b/packages/block-editor/src/components/list-view/block.js
@@ -207,8 +207,7 @@ function ListViewBlock( {
 		'is-branch-selected': isBranchSelected,
 		'is-dragging': isDragged,
 		'has-single-cell': ! showBlockActions,
-		'is-reusable': blockInformation.isReusable,
-		'is-template-part': blockInformation.isTemplatePart,
+		'is-synced': blockInformation.isSynced,
 	} );
 
 	// Only include all selected blocks if the currently clicked on block

--- a/packages/block-editor/src/components/list-view/block.js
+++ b/packages/block-editor/src/components/list-view/block.js
@@ -207,6 +207,8 @@ function ListViewBlock( {
 		'is-branch-selected': isBranchSelected,
 		'is-dragging': isDragged,
 		'has-single-cell': ! showBlockActions,
+		'is-reusable': blockInformation.isReusable,
+		'is-template-part': blockInformation.isTemplatePart,
 	} );
 
 	// Only include all selected blocks if the currently clicked on block

--- a/packages/block-editor/src/components/list-view/branch.js
+++ b/packages/block-editor/src/components/list-view/branch.js
@@ -14,6 +14,7 @@ import ListViewBlock from './block';
 import { useListViewContext } from './context';
 import { isClientIdSelected } from './utils';
 import { store as blockEditorStore } from '../../store';
+import useBlockDisplayInformation from '../use-block-display-information';
 
 /**
  * Given a block, returns the total number of blocks in that subtree. This is used to help determine
@@ -92,7 +93,11 @@ function ListViewBranch( props ) {
 		isExpanded,
 		parentId,
 		shouldShowInnerBlocks = true,
+		isSyncedBranch = false,
 	} = props;
+
+	const parentBlockInformation = useBlockDisplayInformation( parentId );
+	const syncedBranch = isSyncedBranch || !! parentBlockInformation?.isSynced;
 
 	const canParentExpand = useSelect(
 		( select ) => {
@@ -179,6 +184,7 @@ function ListViewBranch( props ) {
 								isExpanded={ shouldExpand }
 								listPosition={ nextPosition }
 								selectedClientIds={ selectedClientIds }
+								isSyncedBranch={ syncedBranch }
 							/>
 						) }
 						{ ! showBlock && (
@@ -199,6 +205,7 @@ function ListViewBranch( props ) {
 								isBranchSelected={ isSelectedBranch }
 								selectedClientIds={ selectedClientIds }
 								isExpanded={ isExpanded }
+								isSyncedBranch={ syncedBranch }
 							/>
 						) }
 					</AsyncModeProvider>

--- a/packages/block-editor/src/components/list-view/style.scss
+++ b/packages/block-editor/src/components/list-view/style.scss
@@ -14,10 +14,18 @@
 .block-editor-list-view-leaf {
 	// Use position relative for row animation.
 	position: relative;
-
+	&.is-template-part {
+		color: #7c4dc3;
+	}
 	// The background has to be applied to the td, not tr, or border-radius won't work.
 	&.is-selected td {
 		background: var(--wp-admin-theme-color);
+	}
+	&.is-selected.is-template-part td {
+		background: #7c4dc3;
+	}
+	&.is-selected.is-reusable td {
+		background: #34948e;
 	}
 	&.is-selected .block-editor-list-view-block-contents,
 	&.is-selected .components-button.has-icon {

--- a/packages/block-editor/src/components/list-view/style.scss
+++ b/packages/block-editor/src/components/list-view/style.scss
@@ -19,17 +19,11 @@
 	&.is-selected td {
 		background: var(--wp-admin-theme-color);
 	}
-	&.is-selected.is-template-part td {
-		background: var(--wp-block-template-part-color);
+	&.is-selected.is-synced td {
+		background: var(--wp-block-synced-color);
 	}
-	&.is-selected.is-reusable td {
-		background: var(--wp-block-reusable-color);
-	}
-	&.is-template-part .block-editor-list-view-block-contents {
-		color: var(--wp-block-template-part-color);
-	}
-	&.is-reusable .block-editor-list-view-block-contents {
-		color: var(--wp-block-reusable-color);
+	&.is-synced .block-editor-list-view-block-contents {
+		color: var(--wp-block-synced-color);
 	}
 	&.is-selected .block-editor-list-view-block-contents,
 	&.is-selected .components-button.has-icon {

--- a/packages/block-editor/src/components/list-view/style.scss
+++ b/packages/block-editor/src/components/list-view/style.scss
@@ -16,13 +16,15 @@
 	position: relative;
 
 	// The background has to be applied to the td, not tr, or border-radius won't work.
-	&.is-selected td {
+	&.is-selected:not(.is-synced-branch) td {
 		background: var(--wp-admin-theme-color);
 	}
-	&.is-selected.is-synced td {
+	&.is-selected.is-synced td,
+	&.is-selected.is-synced-branch td {
 		background: var(--wp-block-synced-color);
 	}
-	&.is-synced .block-editor-list-view-block-contents .block-editor-block-icon {
+	&.is-synced:not(.is-selected) .block-editor-list-view-block-contents .block-editor-block-icon,
+	&.is-synced-branch:not(.is-selected) .block-editor-list-view-block-contents .block-editor-block-icon {
 		color: var(--wp-block-synced-color);
 	}
 	&.is-selected .block-editor-list-view-block-contents,
@@ -36,14 +38,15 @@
 			color: $gray-900;
 		}
 	}
-	&.is-selected .block-editor-list-view-block-contents:focus {
+	&.is-selected:not(.is-synced-branch) .block-editor-list-view-block-contents:focus {
 		&::after {
 			box-shadow:
 				inset 0 0 0 1px $white,
 				0 0 0 var(--wp-admin-border-width-focus) var(--wp-admin-theme-color);
 		}
 	}
-	&.is-selected.is-synced .block-editor-list-view-block-contents:focus {
+	&.is-selected.is-synced .block-editor-list-view-block-contents:focus,
+	&.is-selected.is-synced-branch .block-editor-list-view-block-contents:focus {
 		&::after {
 			box-shadow:
 				inset 0 0 0 1px $white,

--- a/packages/block-editor/src/components/list-view/style.scss
+++ b/packages/block-editor/src/components/list-view/style.scss
@@ -43,6 +43,13 @@
 				0 0 0 var(--wp-admin-border-width-focus) var(--wp-admin-theme-color);
 		}
 	}
+	&.is-selected.is-synced .block-editor-list-view-block-contents:focus {
+		&::after {
+			box-shadow:
+				inset 0 0 0 1px $white,
+				0 0 0 var(--wp-admin-border-width-focus) var(--wp-block-synced-color);
+		}
+	}
 	&.is-selected .block-editor-list-view-block__menu:focus {
 		box-shadow: inset 0 0 0 var(--wp-admin-border-width-focus) $white;
 	}

--- a/packages/block-editor/src/components/list-view/style.scss
+++ b/packages/block-editor/src/components/list-view/style.scss
@@ -14,18 +14,22 @@
 .block-editor-list-view-leaf {
 	// Use position relative for row animation.
 	position: relative;
-	&.is-template-part {
-		color: #7c4dc3;
-	}
+
 	// The background has to be applied to the td, not tr, or border-radius won't work.
 	&.is-selected td {
 		background: var(--wp-admin-theme-color);
 	}
 	&.is-selected.is-template-part td {
-		background: #7c4dc3;
+		background: var(--wp-block-template-color);
 	}
 	&.is-selected.is-reusable td {
-		background: #34948e;
+		background: var(--wp-block-reusable-color);
+	}
+	&.is-template-part .block-editor-list-view-block-contents {
+		color: var(--wp-block-template-color);
+	}
+	&.is-reusable .block-editor-list-view-block-contents {
+		color: var(--wp-block-reusable-color);
 	}
 	&.is-selected .block-editor-list-view-block-contents,
 	&.is-selected .components-button.has-icon {
@@ -150,6 +154,19 @@
 			}
 		}
 	}
+
+	&.is-template-part .block-editor-list-view-block-contents:focus {
+		&::after {
+			box-shadow: inset 0 0 0 var(--wp-admin-border-width-focus) var(--wp-block-template-color);
+		}
+	}
+
+	&.is-reusable .block-editor-list-view-block-contents:focus {
+		&::after {
+			box-shadow: inset 0 0 0 var(--wp-admin-border-width-focus) var(--wp-block-reusable-color);
+		}
+	}
+
 	// Fix focus styling width when one row has fewer cells.
 	&.has-single-cell .block-editor-list-view-block-contents:focus::after {
 		right: 0;

--- a/packages/block-editor/src/components/list-view/style.scss
+++ b/packages/block-editor/src/components/list-view/style.scss
@@ -22,7 +22,7 @@
 	&.is-selected.is-synced td {
 		background: var(--wp-block-synced-color);
 	}
-	&.is-synced .block-editor-list-view-block-contents {
+	&.is-synced .block-editor-list-view-block-contents .block-editor-block-icon {
 		color: var(--wp-block-synced-color);
 	}
 	&.is-selected .block-editor-list-view-block-contents,

--- a/packages/block-editor/src/components/list-view/style.scss
+++ b/packages/block-editor/src/components/list-view/style.scss
@@ -155,18 +155,6 @@
 		}
 	}
 
-	&.is-template-part .block-editor-list-view-block-contents:focus {
-		&::after {
-			box-shadow: inset 0 0 0 var(--wp-admin-border-width-focus) var(--wp-block-template-part-color);
-		}
-	}
-
-	&.is-reusable .block-editor-list-view-block-contents:focus {
-		&::after {
-			box-shadow: inset 0 0 0 var(--wp-admin-border-width-focus) var(--wp-block-reusable-color);
-		}
-	}
-
 	// Fix focus styling width when one row has fewer cells.
 	&.has-single-cell .block-editor-list-view-block-contents:focus::after {
 		right: 0;

--- a/packages/block-editor/src/components/list-view/style.scss
+++ b/packages/block-editor/src/components/list-view/style.scss
@@ -71,11 +71,17 @@
 	&.is-last-selected td:last-child {
 		border-bottom-right-radius: $radius-block-ui;
 	}
-	&.is-branch-selected:not(.is-selected) {
+	&.is-branch-selected:not(.is-selected):not(.is-synced-branch) {
 		// Lighten a CSS variable without introducing a new SASS variable
 		background:
 			linear-gradient(transparentize($white, 0.1), transparentize($white, 0.1)),
 			linear-gradient(var(--wp-admin-theme-color), var(--wp-admin-theme-color));
+	}
+	&.is-synced-branch:not(.is-selected) {
+		// Lighten a CSS variable without introducing a new SASS variable
+		background:
+			linear-gradient(transparentize($white, 0.1), transparentize($white, 0.1)),
+			linear-gradient(var(--wp-block-synced-color), var(--wp-block-synced-color));
 	}
 	&.is-branch-selected.is-first-selected td:first-child {
 		border-top-left-radius: $radius-block-ui;

--- a/packages/block-editor/src/components/list-view/style.scss
+++ b/packages/block-editor/src/components/list-view/style.scss
@@ -20,13 +20,13 @@
 		background: var(--wp-admin-theme-color);
 	}
 	&.is-selected.is-template-part td {
-		background: var(--wp-block-template-color);
+		background: var(--wp-block-template-part-color);
 	}
 	&.is-selected.is-reusable td {
 		background: var(--wp-block-reusable-color);
 	}
 	&.is-template-part .block-editor-list-view-block-contents {
-		color: var(--wp-block-template-color);
+		color: var(--wp-block-template-part-color);
 	}
 	&.is-reusable .block-editor-list-view-block-contents {
 		color: var(--wp-block-reusable-color);
@@ -157,7 +157,7 @@
 
 	&.is-template-part .block-editor-list-view-block-contents:focus {
 		&::after {
-			box-shadow: inset 0 0 0 var(--wp-admin-border-width-focus) var(--wp-block-template-color);
+			box-shadow: inset 0 0 0 var(--wp-admin-border-width-focus) var(--wp-block-template-part-color);
 		}
 	}
 

--- a/packages/block-editor/src/components/list-view/style.scss
+++ b/packages/block-editor/src/components/list-view/style.scss
@@ -75,16 +75,10 @@
 		border-bottom-right-radius: $radius-block-ui;
 	}
 	&.is-branch-selected:not(.is-selected):not(.is-synced-branch) {
-		// Lighten a CSS variable without introducing a new SASS variable
-		background:
-			linear-gradient(transparentize($white, 0.1), transparentize($white, 0.1)),
-			linear-gradient(var(--wp-admin-theme-color), var(--wp-admin-theme-color));
+		background: rgba(var(--wp-admin-theme-color--rgb), 0.04);
 	}
 	&.is-synced-branch:not(.is-selected) {
-		// Lighten a CSS variable without introducing a new SASS variable
-		background:
-			linear-gradient(transparentize($white, 0.1), transparentize($white, 0.1)),
-			linear-gradient(var(--wp-block-synced-color), var(--wp-block-synced-color));
+		background: rgba(var(--wp-block-synced-color--rgb), 0.04);
 	}
 	&.is-branch-selected.is-first-selected td:first-child {
 		border-top-left-radius: $radius-block-ui;

--- a/packages/block-editor/src/components/list-view/style.scss
+++ b/packages/block-editor/src/components/list-view/style.scss
@@ -16,15 +16,13 @@
 	position: relative;
 
 	// The background has to be applied to the td, not tr, or border-radius won't work.
-	&.is-selected:not(.is-synced-branch) td {
+	&.is-selected td {
 		background: var(--wp-admin-theme-color);
 	}
-	&.is-selected.is-synced td,
-	&.is-selected.is-synced-branch td {
+	&.is-selected.is-synced td {
 		background: var(--wp-block-synced-color);
 	}
-	&.is-synced:not(.is-selected) .block-editor-list-view-block-contents .block-editor-block-icon,
-	&.is-synced-branch:not(.is-selected) .block-editor-list-view-block-contents .block-editor-block-icon {
+	&.is-synced .block-editor-list-view-block-contents .block-editor-block-icon {
 		color: var(--wp-block-synced-color);
 	}
 	&.is-selected .block-editor-list-view-block-contents,
@@ -38,15 +36,14 @@
 			color: $gray-900;
 		}
 	}
-	&.is-selected:not(.is-synced-branch) .block-editor-list-view-block-contents:focus {
+	&.is-selected .block-editor-list-view-block-contents:focus {
 		&::after {
 			box-shadow:
 				inset 0 0 0 1px $white,
 				0 0 0 var(--wp-admin-border-width-focus) var(--wp-admin-theme-color);
 		}
 	}
-	&.is-selected.is-synced .block-editor-list-view-block-contents:focus,
-	&.is-selected.is-synced-branch .block-editor-list-view-block-contents:focus {
+	&.is-selected.is-synced .block-editor-list-view-block-contents:focus {
 		&::after {
 			box-shadow:
 				inset 0 0 0 1px $white,

--- a/packages/block-editor/src/components/list-view/style.scss
+++ b/packages/block-editor/src/components/list-view/style.scss
@@ -22,7 +22,7 @@
 	&.is-selected.is-synced td {
 		background: var(--wp-block-synced-color);
 	}
-	&.is-synced .block-editor-list-view-block-contents .block-editor-block-icon {
+	&.is-synced:not(.is-selected) .block-editor-list-view-block-contents .block-editor-block-icon {
 		color: var(--wp-block-synced-color);
 	}
 	&.is-selected .block-editor-list-view-block-contents,

--- a/packages/block-editor/src/components/use-block-display-information/index.js
+++ b/packages/block-editor/src/components/use-block-display-information/index.js
@@ -16,6 +16,7 @@ import { store as blockEditorStore } from '../../store';
  *
  * @typedef {Object} WPBlockDisplayInformation
  *
+ * @property {string} type        Machine readable block type which is used to indicate if color should be applied.
  * @property {string} title       Human-readable block type label.
  * @property {WPIcon} icon        Block type icon.
  * @property {string} description A detailed block type description.
@@ -51,6 +52,9 @@ export default function useBlockDisplayInformation( clientId ) {
 			const attributes = getBlockAttributes( clientId );
 			const match = getActiveBlockVariation( blockName, attributes );
 			const blockTypeInfo = {
+				isReusable:
+					blockType.name === 'core/block' &&
+					blockType.category === 'reusable',
 				title: blockType.title,
 				icon: blockType.icon,
 				description: blockType.description,
@@ -59,6 +63,7 @@ export default function useBlockDisplayInformation( clientId ) {
 			if ( ! match ) return blockTypeInfo;
 
 			return {
+				isTemplatePart: blockType.name === 'core/template-part',
 				title: match.title || blockType.title,
 				icon: match.icon || blockType.icon,
 				description: match.description || blockType.description,

--- a/packages/block-editor/src/components/use-block-display-information/index.js
+++ b/packages/block-editor/src/components/use-block-display-information/index.js
@@ -5,7 +5,7 @@ import { useSelect } from '@wordpress/data';
 import {
 	store as blocksStore,
 	isReusableBlock,
-	isTemplatePart as isTemplate,
+	isTemplatePart,
 } from '@wordpress/blocks';
 
 /**
@@ -20,12 +20,11 @@ import { store as blockEditorStore } from '../../store';
  *
  * @typedef {Object} WPBlockDisplayInformation
  *
- * @property {boolean} isReusable     True if is a reusable block
- * @property {boolean} isTemplatePart True if is a template part block
- * @property {string}  title          Human-readable block type label.
- * @property {WPIcon}  icon           Block type icon.
- * @property {string}  description    A detailed block type description.
- * @property {string}  anchor         HTML anchor.
+ * @property {boolean} isSynced    True if is a reusable block or template part
+ * @property {string}  title       Human-readable block type label.
+ * @property {WPIcon}  icon        Block type icon.
+ * @property {string}  description A detailed block type description.
+ * @property {string}  anchor      HTML anchor.
  */
 
 /**
@@ -56,11 +55,10 @@ export default function useBlockDisplayInformation( clientId ) {
 			if ( ! blockType ) return null;
 			const attributes = getBlockAttributes( clientId );
 			const match = getActiveBlockVariation( blockName, attributes );
-			const isReusable = isReusableBlock( blockType );
-			const isTemplatePart = isTemplate( blockType );
+			const isSynced =
+				isReusableBlock( blockType ) || isTemplatePart( blockType );
 			const blockTypeInfo = {
-				isReusable,
-				isTemplatePart,
+				isSynced,
 				title: blockType.title,
 				icon: blockType.icon,
 				description: blockType.description,
@@ -69,8 +67,7 @@ export default function useBlockDisplayInformation( clientId ) {
 			if ( ! match ) return blockTypeInfo;
 
 			return {
-				isReusable,
-				isTemplatePart,
+				isSynced,
 				title: match.title || blockType.title,
 				icon: match.icon || blockType.icon,
 				description: match.description || blockType.description,

--- a/packages/block-editor/src/components/use-block-display-information/index.js
+++ b/packages/block-editor/src/components/use-block-display-information/index.js
@@ -16,11 +16,12 @@ import { store as blockEditorStore } from '../../store';
  *
  * @typedef {Object} WPBlockDisplayInformation
  *
- * @property {string} type        Machine readable block type which is used to indicate if color should be applied.
- * @property {string} title       Human-readable block type label.
- * @property {WPIcon} icon        Block type icon.
- * @property {string} description A detailed block type description.
- * @property {string} anchor      HTML anchor.
+ * @property {boolean} isReusable     True if is a reusable block
+ * @property {boolean} isTemplatePart True if is a template part block
+ * @property {string}  title          Human-readable block type label.
+ * @property {WPIcon}  icon           Block type icon.
+ * @property {string}  description    A detailed block type description.
+ * @property {string}  anchor         HTML anchor.
  */
 
 /**
@@ -51,10 +52,13 @@ export default function useBlockDisplayInformation( clientId ) {
 			if ( ! blockType ) return null;
 			const attributes = getBlockAttributes( clientId );
 			const match = getActiveBlockVariation( blockName, attributes );
+			const isReusable =
+				blockType.name === 'core/block' &&
+				blockType.category === 'reusable';
+			const isTemplatePart = blockType.name === 'core/template-part';
 			const blockTypeInfo = {
-				isReusable:
-					blockType.name === 'core/block' &&
-					blockType.category === 'reusable',
+				isReusable,
+				isTemplatePart,
 				title: blockType.title,
 				icon: blockType.icon,
 				description: blockType.description,
@@ -63,7 +67,8 @@ export default function useBlockDisplayInformation( clientId ) {
 			if ( ! match ) return blockTypeInfo;
 
 			return {
-				isTemplatePart: blockType.name === 'core/template-part',
+				isReusable,
+				isTemplatePart,
 				title: match.title || blockType.title,
 				icon: match.icon || blockType.icon,
 				description: match.description || blockType.description,

--- a/packages/block-editor/src/components/use-block-display-information/index.js
+++ b/packages/block-editor/src/components/use-block-display-information/index.js
@@ -2,7 +2,11 @@
  * WordPress dependencies
  */
 import { useSelect } from '@wordpress/data';
-import { store as blocksStore } from '@wordpress/blocks';
+import {
+	store as blocksStore,
+	isReusableBlock,
+	isTemplatePart as isTemplate,
+} from '@wordpress/blocks';
 
 /**
  * Internal dependencies
@@ -52,10 +56,8 @@ export default function useBlockDisplayInformation( clientId ) {
 			if ( ! blockType ) return null;
 			const attributes = getBlockAttributes( clientId );
 			const match = getActiveBlockVariation( blockName, attributes );
-			const isReusable =
-				blockType.name === 'core/block' &&
-				blockType.category === 'reusable';
-			const isTemplatePart = blockType.name === 'core/template-part';
+			const isReusable = isReusableBlock( blockType );
+			const isTemplatePart = isTemplate( blockType );
 			const blockTypeInfo = {
 				isReusable,
 				isTemplatePart,

--- a/packages/block-library/src/block/editor.scss
+++ b/packages/block-library/src/block/editor.scss
@@ -14,3 +14,20 @@
 		display: none;
 	}
 }
+
+.edit-post-visual-editor .block-editor-block-list__block:not(.remove-outline).is-reusable {
+	&.is-highlighted,
+	&.is-selected {
+		box-shadow: inset 0 0 0 var(--wp-admin-border-width-focus) var(--wp-block-synced-color);
+	}
+
+	&.block-editor-block-list__block:not([contenteditable]):focus {
+		&::after {
+			box-shadow: 0 0 0 var(--wp-admin-border-width-focus) var(--wp-block-synced-color);
+			// Show a light color for dark themes.
+			.is-dark-theme & {
+				box-shadow: 0 0 0 var(--wp-admin-border-width-focus) $dark-theme-focus;
+			}
+		}
+	}
+}

--- a/packages/block-library/src/block/editor.scss
+++ b/packages/block-library/src/block/editor.scss
@@ -13,10 +13,11 @@
 	.components-disabled .block-list-appender {
 		display: none;
 	}
+}
 
+.block-library-block__reusable-block-container {
 	&.is-highlighted,
 	&.is-selected {
-		border-radius: $radius-block-ui;
 		box-shadow: inset 0 0 0 var(--wp-admin-border-width-focus) var(--wp-block-reusable-color);
 	}
 

--- a/packages/block-library/src/block/editor.scss
+++ b/packages/block-library/src/block/editor.scss
@@ -14,20 +14,3 @@
 		display: none;
 	}
 }
-
-.block-library-block__reusable-block-container {
-	&.is-highlighted,
-	&.is-selected {
-		box-shadow: inset 0 0 0 var(--wp-admin-border-width-focus) var(--wp-block-reusable-color);
-	}
-
-	&.block-editor-block-list__block:not([contenteditable]):focus {
-		&::after {
-			box-shadow: 0 0 0 var(--wp-admin-border-width-focus) var(--wp-block-reusable-color);
-			// Show a light color for dark themes.
-			.is-dark-theme & {
-				box-shadow: 0 0 0 var(--wp-admin-border-width-focus) $dark-theme-focus;
-			}
-		}
-	}
-}

--- a/packages/block-library/src/block/editor.scss
+++ b/packages/block-library/src/block/editor.scss
@@ -13,4 +13,20 @@
 	.components-disabled .block-list-appender {
 		display: none;
 	}
+
+	&.is-highlighted,
+	&.is-selected {
+		border-radius: $radius-block-ui;
+		box-shadow: inset 0 0 0 var(--wp-admin-border-width-focus) var(--wp-block-reusable-color);
+	}
+
+	&.block-editor-block-list__block:not([contenteditable]):focus {
+		&::after {
+			box-shadow: 0 0 0 var(--wp-admin-border-width-focus) var(--wp-block-reusable-color);
+			// Show a light color for dark themes.
+			.is-dark-theme & {
+				box-shadow: 0 0 0 var(--wp-admin-border-width-focus) $dark-theme-focus;
+			}
+		}
+	}
 }

--- a/packages/block-library/src/template-part/editor.scss
+++ b/packages/block-library/src/template-part/editor.scss
@@ -28,7 +28,6 @@
 .wp-block-template-part {
 	&.is-highlighted,
 	&.is-selected {
-		border-radius: $radius-block-ui;
 		box-shadow: inset 0 0 0 var(--wp-admin-border-width-focus) var(--wp-block-template-part-color);
 	}
 

--- a/packages/block-library/src/template-part/editor.scss
+++ b/packages/block-library/src/template-part/editor.scss
@@ -25,15 +25,16 @@
 	z-index: z-index(".block-library-template-part__selection-search");
 }
 
-.is-outline-mode .block-editor-block-list__block:not(.remove-outline).wp-block-template-part {
+.is-outline-mode .block-editor-block-list__block:not(.remove-outline).wp-block-template-part,
+.is-outline-mode .block-editor-block-list__block:not(.remove-outline).is-reusable {
 	&.is-highlighted,
 	&.is-selected {
-		box-shadow: inset 0 0 0 var(--wp-admin-border-width-focus) var(--wp-block-template-part-color);
+		box-shadow: inset 0 0 0 var(--wp-admin-border-width-focus) var(--wp-block-synced-color);
 	}
 
 	&.block-editor-block-list__block:not([contenteditable]):focus {
 		&::after {
-			box-shadow: 0 0 0 var(--wp-admin-border-width-focus) var(--wp-block-template-part-color);
+			box-shadow: 0 0 0 var(--wp-admin-border-width-focus) var(--wp-block-synced-color);
 			// Show a light color for dark themes.
 			.is-dark-theme & {
 				box-shadow: 0 0 0 var(--wp-admin-border-width-focus) $dark-theme-focus;
@@ -45,12 +46,12 @@
 .is-outline-mode .block-editor-block-list__block:not(.remove-outline).is-reusable {
 	&.is-highlighted,
 	&.is-selected {
-		box-shadow: inset 0 0 0 var(--wp-admin-border-width-focus) var(--wp-block-reusable-color);
+		box-shadow: inset 0 0 0 var(--wp-admin-border-width-focus) var(--wp-block-synced-color);
 	}
 
 	&.block-editor-block-list__block:not([contenteditable]):focus {
 		&::after {
-			box-shadow: 0 0 0 var(--wp-admin-border-width-focus) var(--wp-block-reusable-color);
+			box-shadow: 0 0 0 var(--wp-admin-border-width-focus) var(--wp-block-synced-color);
 			// Show a light color for dark themes.
 			.is-dark-theme & {
 				box-shadow: 0 0 0 var(--wp-admin-border-width-focus) $dark-theme-focus;

--- a/packages/block-library/src/template-part/editor.scss
+++ b/packages/block-library/src/template-part/editor.scss
@@ -42,20 +42,3 @@
 		}
 	}
 }
-
-.is-outline-mode .block-editor-block-list__block:not(.remove-outline).is-reusable {
-	&.is-highlighted,
-	&.is-selected {
-		box-shadow: inset 0 0 0 var(--wp-admin-border-width-focus) var(--wp-block-synced-color);
-	}
-
-	&.block-editor-block-list__block:not([contenteditable]):focus {
-		&::after {
-			box-shadow: 0 0 0 var(--wp-admin-border-width-focus) var(--wp-block-synced-color);
-			// Show a light color for dark themes.
-			.is-dark-theme & {
-				box-shadow: 0 0 0 var(--wp-admin-border-width-focus) $dark-theme-focus;
-			}
-		}
-	}
-}

--- a/packages/block-library/src/template-part/editor.scss
+++ b/packages/block-library/src/template-part/editor.scss
@@ -5,8 +5,8 @@
 	// and height are used instead of max-(width/height).
 	.components-modal__frame {
 		@include break-small() {
-			width: calc(100% - #{ $grid-unit-20 * 2 });
-			height: calc(100% - #{ $header-height * 2 });
+			width: calc(100% - #{$grid-unit-20 * 2});
+			height: calc(100% - #{$header-height * 2});
 		}
 		@include break-medium() {
 			width: $break-medium - $grid-unit-20 * 2;
@@ -23,4 +23,22 @@
 	top: 0;
 	padding: $grid-unit-20 0;
 	z-index: z-index(".block-library-template-part__selection-search");
+}
+
+.wp-block-template-part {
+	&.is-highlighted,
+	&.is-selected {
+		border-radius: $radius-block-ui;
+		box-shadow: inset 0 0 0 var(--wp-admin-border-width-focus) var(--wp-block-template-part-color);
+	}
+
+	&.block-editor-block-list__block:not([contenteditable]):focus {
+		&::after {
+			box-shadow: 0 0 0 var(--wp-admin-border-width-focus) var(--wp-block-template-part-color);
+			// Show a light color for dark themes.
+			.is-dark-theme & {
+				box-shadow: 0 0 0 var(--wp-admin-border-width-focus) $dark-theme-focus;
+			}
+		}
+	}
 }

--- a/packages/block-library/src/template-part/editor.scss
+++ b/packages/block-library/src/template-part/editor.scss
@@ -25,7 +25,7 @@
 	z-index: z-index(".block-library-template-part__selection-search");
 }
 
-.wp-block-template-part {
+.is-outline-mode .block-editor-block-list__block:not(.remove-outline).wp-block-template-part {
 	&.is-highlighted,
 	&.is-selected {
 		box-shadow: inset 0 0 0 var(--wp-admin-border-width-focus) var(--wp-block-template-part-color);
@@ -34,6 +34,23 @@
 	&.block-editor-block-list__block:not([contenteditable]):focus {
 		&::after {
 			box-shadow: 0 0 0 var(--wp-admin-border-width-focus) var(--wp-block-template-part-color);
+			// Show a light color for dark themes.
+			.is-dark-theme & {
+				box-shadow: 0 0 0 var(--wp-admin-border-width-focus) $dark-theme-focus;
+			}
+		}
+	}
+}
+
+.is-outline-mode .block-editor-block-list__block:not(.remove-outline).is-reusable {
+	&.is-highlighted,
+	&.is-selected {
+		box-shadow: inset 0 0 0 var(--wp-admin-border-width-focus) var(--wp-block-reusable-color);
+	}
+
+	&.block-editor-block-list__block:not([contenteditable]):focus {
+		&::after {
+			box-shadow: 0 0 0 var(--wp-admin-border-width-focus) var(--wp-block-reusable-color);
 			// Show a light color for dark themes.
 			.is-dark-theme & {
 				box-shadow: 0 0 0 var(--wp-admin-border-width-focus) $dark-theme-focus;

--- a/packages/blocks/src/api/registration.js
+++ b/packages/blocks/src/api/registration.js
@@ -618,7 +618,7 @@ export function isReusableBlock( blockOrType ) {
  * @return {boolean} Whether the given block is a template part.
  */
 export function isTemplatePart( blockOrType ) {
-	return blockOrType.name === 'core/template-part';
+	return blockOrType?.name === 'core/template-part';
 }
 
 /**

--- a/packages/edit-site/src/components/header-edit-mode/document-actions/index.js
+++ b/packages/edit-site/src/components/header-edit-mode/document-actions/index.js
@@ -20,7 +20,11 @@ import {
 } from '@wordpress/components';
 import { chevronDown } from '@wordpress/icons';
 import { useState, useMemo } from '@wordpress/element';
-import { store as blockEditorStore } from '@wordpress/block-editor';
+import {
+	store as blockEditorStore,
+	useBlockDisplayInformation,
+	BlockIcon,
+} from '@wordpress/block-editor';
 import { store as coreStore } from '@wordpress/core-data';
 import { store as editorStore } from '@wordpress/editor';
 import { store as preferencesStore } from '@wordpress/preferences';
@@ -52,10 +56,13 @@ function useSecondaryText() {
 		[]
 	);
 
+	const blockInformation = useBlockDisplayInformation( activeEntityBlockId );
+
 	if ( activeEntityBlockId ) {
 		return {
 			label: getBlockDisplayText( getBlock( activeEntityBlockId ) ),
 			isActive: true,
+			icon: blockInformation?.icon,
 		};
 	}
 
@@ -90,9 +97,10 @@ export default function DocumentActions() {
 				templateType: postType,
 			};
 		}, [] );
+
 	const entityLabel =
 		templateType === 'wp_template_part' ? 'template part' : 'template';
-	const { label } = useSecondaryText();
+	const { label, icon } = useSecondaryText();
 
 	// Use internal state instead of a ref to make sure that the component
 	// re-renders when the popover's anchor updates.
@@ -150,13 +158,10 @@ export default function DocumentActions() {
 					</VisuallyHidden>
 					{ decodeEntities( entityTitle ) }
 				</Text>
-
-				<Text
-					size="body"
-					className="edit-site-document-actions__secondary-item"
-				>
-					{ label ?? '' }
-				</Text>
+				<div className="edit-site-document-actions__secondary-item">
+					<BlockIcon icon={ icon } showColors />
+					<Text size="body">{ label ?? '' }</Text>
+				</div>
 
 				<Dropdown
 					popoverProps={ popoverProps }

--- a/packages/edit-site/src/components/header-edit-mode/document-actions/style.scss
+++ b/packages/edit-site/src/components/header-edit-mode/document-actions/style.scss
@@ -44,6 +44,8 @@
 	}
 
 	.edit-site-document-actions__secondary-item {
+		display: flex;
+		align-items: center;
 		white-space: nowrap;
 		overflow: hidden;
 		text-overflow: ellipsis;
@@ -51,10 +53,13 @@
 		opacity: 0;
 		padding: 0;
 		transition: all ease 0.2s;
-		background: $gray-200;
+		background: rgba(var(--wp-block-synced-color--rgb), 0.3);
 		border-radius: 2px;
-		color: var(--wp-block-synced-color);
 		@include reduce-motion(transition);
+
+		.block-editor-block-icon.has-colors {
+			color: var(--wp-block-synced-color);
+		}
 	}
 
 	&.has-secondary-label {

--- a/packages/edit-site/src/components/header-edit-mode/document-actions/style.scss
+++ b/packages/edit-site/src/components/header-edit-mode/document-actions/style.scss
@@ -53,9 +53,7 @@
 		opacity: 0;
 		padding: 0;
 		transition: all ease 0.2s;
-		background:
-			linear-gradient(transparentize($white, 0.1), transparentize($white, 0.1)),
-			linear-gradient(var(--wp-block-synced-color), var(--wp-block-synced-color));
+		background: rgba(var(--wp-block-synced-color--rgb), 0.04);
 		border-radius: 2px;
 		@include reduce-motion(transition);
 

--- a/packages/edit-site/src/components/header-edit-mode/document-actions/style.scss
+++ b/packages/edit-site/src/components/header-edit-mode/document-actions/style.scss
@@ -53,6 +53,7 @@
 		transition: all ease 0.2s;
 		background: $gray-200;
 		border-radius: 2px;
+		color: var(--wp-block-synced-color);
 		@include reduce-motion(transition);
 	}
 

--- a/packages/edit-site/src/components/header-edit-mode/document-actions/style.scss
+++ b/packages/edit-site/src/components/header-edit-mode/document-actions/style.scss
@@ -53,8 +53,9 @@
 		opacity: 0;
 		padding: 0;
 		transition: all ease 0.2s;
-		filter: brightness(0.95);
-		background: rgba(var(--wp-block-synced-color--rgb), 0.3);
+		background:
+			linear-gradient(transparentize($white, 0.1), transparentize($white, 0.1)),
+			linear-gradient(var(--wp-block-synced-color), var(--wp-block-synced-color));
 		border-radius: 2px;
 		@include reduce-motion(transition);
 

--- a/packages/edit-site/src/components/header-edit-mode/document-actions/style.scss
+++ b/packages/edit-site/src/components/header-edit-mode/document-actions/style.scss
@@ -53,6 +53,7 @@
 		opacity: 0;
 		padding: 0;
 		transition: all ease 0.2s;
+		filter: brightness(0.95);
 		background: rgba(var(--wp-block-synced-color--rgb), 0.3);
 		border-radius: 2px;
 		@include reduce-motion(transition);

--- a/packages/edit-site/src/components/template-details/style.scss
+++ b/packages/edit-site/src/components/template-details/style.scss
@@ -20,6 +20,10 @@
 	.edit-site-template-details__template-areas-item {
 		position: relative;
 
+		.components-menu-items__item-icon {
+			color: var(--wp-block-synced-color);
+		}
+
 		.edit-site-template-details__template-areas-item-more {
 			position: absolute;
 			right: 0;


### PR DESCRIPTION
## What?
Adds color to template parts and reusable blocks in list view, block toolbar, and block selection outlines

## Why?
To help differentiate these block types when editing. 
Fixes: #32163

## How?
A few extra classes, a bit of CSS, and Bob's your uncle

## Todo

- [x] Combine the template part and reusable block colors
- [x] Remove color from the block name and just color the icons
- [x] Color the focus outline in the list view
- [x] Color the icon of template and reusable block children
- [x] Color the grouping background in list view
- [x] Color the hover overlay
- [x] Color the template part name in the site editor Top Bar
- [x] Color the icon in the right inspector panel heading

## Testing Instructions

- Open the list view and make sure the template parts  are colored purple in the list view and in the editor view (block toolbar title and selection outline), and that any children are also covered
- Add a reusable block somewhere in content area and make sure this also appears with the purple color 
- Also check that template parts and reusable blocks are colorized in the block inserter
- Check that the hover color of reusbale blocks in the editor is purple

## Screenshots or screencast 

https://user-images.githubusercontent.com/3629020/202564625-771e8781-4a96-4a23-be35-abbc64dbabfb.mp4




