### PR TITLE
Site Logo: Use the correct home URL setting

### DIFF
--- a/packages/block-library/src/site-logo/edit.js
+++ b/packages/block-library/src/site-logo/edit.js
@@ -394,7 +394,7 @@ export default function LogoEdit( {
 		return {
 			siteLogoId: _siteLogoId,
 			canUserEdit: _canUserEdit,
-			url: siteData?.url,
+			url: siteData?.home,
 			mediaItemData: mediaItem,
 			isRequestingMediaItem: _isRequestingMediaItem,
 			siteIconId: _siteIconId,


### PR DESCRIPTION
## What?
PR replaces the use of site_url (`url`) with home_url (`home`) in the Site Logo block.

You can see the Site index difference here: https://github.com/WordPress/wordpress-develop/blob/trunk/src/wp-includes/rest-api/class-wp-rest-server.php#L1249-L1250

P.S. I noticed this while reviewing #45475

## Why?
I'll quote @peterwilsoncc here:

> siteUrl is a reference to the WordPress install, ie the folder containing wp-cron.php, wp-mail.php, etc. homeUrl is the home page of the website. On sites with WordPress installed in a sub-directory, the two values can differ.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

## Testing Instructions
1. Open a Post or Page
2. Insert a Site Logo Block.
3. Confirm that the URL points correctly to the home page. It is easier to do this by inspecting the source.

## Screenshots or screencast <!-- if applicable -->

![CleanShot 2022-11-02 at 10 17 56](https://user-images.githubusercontent.com/240569/199412697-2320d7dc-762f-41ec-8271-5f3eeb8eac1a.png)
