### PR TITLE
Add paste styles to the block settings

### DIFF
--- a/packages/block-editor/src/components/block-actions/index.js
+++ b/packages/block-editor/src/components/block-actions/index.js
@@ -12,6 +12,7 @@ import {
  * Internal dependencies
  */
 import { useNotifyCopy } from '../copy-handler';
+import usePasteStyles from '../use-paste-styles';
 import { store as blockEditorStore } from '../../store';
 
 export default function BlockActions( {
@@ -60,6 +61,7 @@ export default function BlockActions( {
 	} = useDispatch( blockEditorStore );
 
 	const notifyCopy = useNotifyCopy();
+	const pasteStyles = usePasteStyles();
 
 	return children( {
 		canDuplicate,
@@ -127,6 +129,9 @@ export default function BlockActions( {
 				flashBlock( selectedBlockClientIds[ 0 ] );
 			}
 			notifyCopy( 'copy', selectedBlockClientIds );
+		},
+		async onPasteStyles() {
+			await pasteStyles( blocks );
 		},
 	} );
 }

--- a/packages/block-editor/src/components/block-settings-menu/block-settings-dropdown.js
+++ b/packages/block-editor/src/components/block-settings-menu/block-settings-dropdown.js
@@ -209,6 +209,7 @@ export function BlockSettingsDropdown( {
 				onInsertBefore,
 				onRemove,
 				onCopy,
+				onPasteStyles,
 				onMoveTo,
 				blocks,
 			} ) => (
@@ -262,6 +263,9 @@ export function BlockSettingsDropdown( {
 									blocks={ blocks }
 									onCopy={ onCopy }
 								/>
+								<MenuItem onClick={ onPasteStyles }>
+									{ __( 'Paste styles' ) }
+								</MenuItem>
 								{ canDuplicate && (
 									<MenuItem
 										onClick={ pipe(

--- a/packages/block-editor/src/components/use-paste-styles/index.js
+++ b/packages/block-editor/src/components/use-paste-styles/index.js
@@ -1,0 +1,134 @@
+/**
+ * WordPress dependencies
+ */
+import { useCallback } from '@wordpress/element';
+import { getBlockType, serialize, parse } from '@wordpress/blocks';
+import { useDispatch, useRegistry } from '@wordpress/data';
+import { store as noticesStore } from '@wordpress/notices';
+import { __, sprintf } from '@wordpress/i18n';
+
+/**
+ * Internal dependencies
+ */
+import { store as blockEditorStore } from '../../store';
+
+function getStyleAttributes( block ) {
+	const blockType = getBlockType( block.name );
+	const attributes = {};
+	// Mark every attribute that isn't "content" as a style attribute.
+	for ( const attribute in block.attributes ) {
+		if (
+			blockType.attributes[ attribute ].__experimentalRole !== 'content'
+		) {
+			attributes[ attribute ] = block.attributes[ attribute ];
+		}
+	}
+	return attributes;
+}
+
+function recursivelyUpdateBlockAttributes(
+	targetBlocks,
+	sourceBlocks,
+	updateBlockAttributes
+) {
+	for (
+		let index = 0;
+		index < Math.min( sourceBlocks.length, targetBlocks.length );
+		index += 1
+	) {
+		updateBlockAttributes(
+			targetBlocks[ index ].clientId,
+			getStyleAttributes( sourceBlocks[ index ] )
+		);
+
+		recursivelyUpdateBlockAttributes(
+			targetBlocks[ index ].innerBlocks,
+			sourceBlocks[ index ].innerBlocks,
+			updateBlockAttributes
+		);
+	}
+}
+
+export default function usePasteStyles() {
+	const registry = useRegistry();
+	const { updateBlockAttributes } = useDispatch( blockEditorStore );
+	const { createSuccessNotice, createWarningNotice, createErrorNotice } =
+		useDispatch( noticesStore );
+
+	return useCallback(
+		async ( targetBlocks ) => {
+			let html = '';
+			try {
+				html = await window.navigator.clipboard.readText();
+			} catch ( err ) {
+				// Possibly the permission is denied.
+				createErrorNotice(
+					__( 'Permission denied: Unable to read from clipboard.' ),
+					{
+						type: 'snackbar',
+					}
+				);
+				return;
+			}
+
+			const copiedBlocks = parse( html );
+			// Abort if the copied text is empty or doesn't look like serialized blocks.
+			if ( ! html || serialize( copiedBlocks ) !== html ) {
+				createWarningNotice(
+					__( "The copied data doesn't appear to be blocks." ),
+					{
+						type: 'snackbar',
+					}
+				);
+				return;
+			}
+
+			if ( copiedBlocks.length === 1 ) {
+				// Apply styles of the block to all the target blocks.
+				registry.batch( () => {
+					recursivelyUpdateBlockAttributes(
+						targetBlocks,
+						targetBlocks.map( () => copiedBlocks[ 0 ] ),
+						updateBlockAttributes
+					);
+				} );
+			} else {
+				registry.batch( () => {
+					recursivelyUpdateBlockAttributes(
+						targetBlocks,
+						copiedBlocks,
+						updateBlockAttributes
+					);
+				} );
+			}
+
+			if ( targetBlocks.length === 1 ) {
+				const title = getBlockType( targetBlocks[ 0 ].name )?.title;
+				createSuccessNotice(
+					sprintf(
+						// Translators: Name of the block being pasted, e.g. "Paragraph".
+						__( 'Pasted styles to %s.' ),
+						title
+					),
+					{ type: 'snackbar' }
+				);
+			} else {
+				createSuccessNotice(
+					sprintf(
+						// Translators: The number of the blocks.
+						__( 'Pasted styles to %d blocks.' ),
+						targetBlocks.length
+					),
+					{ type: 'snackbar' }
+				);
+			}
+		},
+		[
+			registry.batch,
+			updateBlockAttributes,
+			createSuccessNotice,
+			createWarningNotice,
+			createErrorNotice,
+		]
+	);
+}

--- a/packages/block-editor/src/components/use-paste-styles/index.js
+++ b/packages/block-editor/src/components/use-paste-styles/index.js
@@ -37,30 +37,35 @@ function looksLikeBlocks( text ) {
 }
 
 /**
+ * Style attributes are attributes being added in `block-editor/src/hooks/*`.
+ * (Except for some unrelated to style like `anchor` or `settings`.)
+ * They generally represent the default block supports.
+ */
+const STYLE_ATTRIBUTES = [
+	'align',
+	'borderColor',
+	'backgroundColor',
+	'textColor',
+	'gradient',
+	'className',
+	'fontFamily',
+	'fontSize',
+	'layout',
+	'style',
+];
+
+/**
  * Get the "style attributes" from a given block.
- * A "style attribute" is an attribute that doesn't have `__experimentalRole` of `content`.
  *
  * @param {WPBlock} block The input block.
  * @return {Object} the filtered attributes object.
  */
 function getStyleAttributes( block ) {
-	const blockType = getBlockType( block.name );
-	const attributes = {};
-	for ( const [ attribute, attributeType ] of Object.entries(
-		blockType.attributes
-	) ) {
-		// Mark every attribute that isn't "content" as a style attribute.
-		if ( attributeType.__experimentalRole !== 'content' ) {
-			// Apply all attributes even when they are undefined to allow overriding styles.
-			attributes[ attribute ] = Object.hasOwn(
-				block.attributes,
-				attribute
-			)
-				? block.attributes[ attribute ]
-				: attributeType.default;
-		}
-	}
-	return attributes;
+	// Override attributes that are not present in the block to their defaults.
+	return STYLE_ATTRIBUTES.reduce( ( attributes, attributeKey ) => {
+		attributes[ attributeKey ] = block.attributes[ attributeKey ];
+		return attributes;
+	}, {} );
 }
 
 /**

--- a/packages/block-editor/src/components/use-paste-styles/index.js
+++ b/packages/block-editor/src/components/use-paste-styles/index.js
@@ -14,11 +14,13 @@ import { store as blockEditorStore } from '../../store';
 
 /**
  * Determine if the copied text looks like serialized blocks or not.
+ * Since plain text will always get parsed into a freeform block,
+ * we check that if the parsed blocks is anything other than that.
  *
  * @param {string} text The copied text.
  * @return {boolean} True if the text looks like serialized blocks, false otherwise.
  */
-function looksLikeBlocks( text ) {
+function hasSerializedBlocks( text ) {
 	try {
 		const blocks = parse( text, {
 			__unstableSkipMigrationLogs: true,
@@ -137,7 +139,7 @@ export default function usePasteStyles() {
 			}
 
 			// Abort if the copied text is empty or doesn't look like serialized blocks.
-			if ( ! html || ! looksLikeBlocks( html ) ) {
+			if ( ! html || ! hasSerializedBlocks( html ) ) {
 				createWarningNotice(
 					__( "The copied data doesn't appear to be blocks." ),
 					{

--- a/packages/block-editor/src/components/use-paste-styles/index.js
+++ b/packages/block-editor/src/components/use-paste-styles/index.js
@@ -15,12 +15,18 @@ import { store as blockEditorStore } from '../../store';
 function getStyleAttributes( block ) {
 	const blockType = getBlockType( block.name );
 	const attributes = {};
-	// Mark every attribute that isn't "content" as a style attribute.
-	for ( const attribute in block.attributes ) {
-		if (
-			blockType.attributes[ attribute ].__experimentalRole !== 'content'
-		) {
-			attributes[ attribute ] = block.attributes[ attribute ];
+	for ( const [ attribute, attributeType ] of Object.entries(
+		blockType.attributes
+	) ) {
+		// Mark every attribute that isn't "content" as a style attribute.
+		if ( attributeType.__experimentalRole !== 'content' ) {
+			// Apply all attributes even when they are undefined to allow overriding styles.
+			attributes[ attribute ] = Object.hasOwn(
+				block.attributes,
+				attribute
+			)
+				? block.attributes[ attribute ]
+				: attributeType.default;
 		}
 	}
 	return attributes;

--- a/packages/block-editor/src/components/use-paste-styles/index.js
+++ b/packages/block-editor/src/components/use-paste-styles/index.js
@@ -79,7 +79,10 @@ function getStyleAttributes( sourceBlock, targetBlock ) {
 	return Object.entries( STYLE_ATTRIBUTES ).reduce(
 		( attributes, [ attributeKey, hasSupport ] ) => {
 			// Only apply the attribute if both blocks support it.
-			if ( hasSupport( sourceBlock.name ) && hasSupport( targetBlock ) ) {
+			if (
+				hasSupport( sourceBlock.name ) &&
+				hasSupport( targetBlock.name )
+			) {
 				// Override attributes that are not present in the block to their defaults.
 				attributes[ attributeKey ] =
 					sourceBlock.attributes[ attributeKey ];

--- a/packages/block-editor/src/components/use-paste-styles/index.js
+++ b/packages/block-editor/src/components/use-paste-styles/index.js
@@ -139,10 +139,11 @@ export default function usePasteStyles() {
 			let html = '';
 			try {
 				// `http:` sites won't have the clipboard property on navigator.
+				// (with the exception of localhost.)
 				if ( ! window.navigator.clipboard ) {
 					createErrorNotice(
 						__(
-							'Reading from the clipboard is only available in secure contexts (HTTPS) in supporting browsers.'
+							'Unable to paste styles. This feature is only available on secure (https) sites in supporting browsers.'
 						),
 						{ type: 'snackbar' }
 					);
@@ -153,7 +154,9 @@ export default function usePasteStyles() {
 			} catch ( error ) {
 				// Possibly the permission is denied.
 				createErrorNotice(
-					__( 'Permission denied: Unable to read from clipboard.' ),
+					__(
+						'Unable to paste styles. Please allow browser clipboard permissions before continuing.'
+					),
 					{
 						type: 'snackbar',
 					}
@@ -164,7 +167,9 @@ export default function usePasteStyles() {
 			// Abort if the copied text is empty or doesn't look like serialized blocks.
 			if ( ! html || ! hasSerializedBlocks( html ) ) {
 				createWarningNotice(
-					__( "The copied data doesn't appear to be blocks." ),
+					__(
+						"Unable to paste styles. Block styles couldn't be found within the copied content."
+					),
 					{
 						type: 'snackbar',
 					}

--- a/packages/block-editor/src/hooks/supports.js
+++ b/packages/block-editor/src/hooks/supports.js
@@ -1,0 +1,302 @@
+/**
+ * WordPress dependencies
+ */
+import { getBlockSupport, hasBlockSupport } from '@wordpress/blocks';
+import { Platform } from '@wordpress/element';
+
+const ALIGN_SUPPORT_KEY = 'align';
+const ALIGN_WIDE_SUPPORT_KEY = 'alignWide';
+const BORDER_SUPPORT_KEY = '__experimentalBorder';
+const COLOR_SUPPORT_KEY = 'color';
+const CUSTOM_CLASS_NAME_SUPPORT_KEY = 'customClassName';
+const FONT_FAMILY_SUPPORT_KEY = 'typography.__experimentalFontFamily';
+const FONT_SIZE_SUPPORT_KEY = 'typography.fontSize';
+const LINE_HEIGHT_SUPPORT_KEY = 'typography.lineHeight';
+/**
+ * Key within block settings' support array indicating support for font style.
+ */
+const FONT_STYLE_SUPPORT_KEY = 'typography.__experimentalFontStyle';
+/**
+ * Key within block settings' support array indicating support for font weight.
+ */
+const FONT_WEIGHT_SUPPORT_KEY = 'typography.__experimentalFontWeight';
+/**
+ * Key within block settings' supports array indicating support for text
+ * decorations e.g. settings found in `block.json`.
+ */
+const TEXT_DECORATION_SUPPORT_KEY = 'typography.__experimentalTextDecoration';
+/**
+ * Key within block settings' supports array indicating support for text
+ * transforms e.g. settings found in `block.json`.
+ */
+const TEXT_TRANSFORM_SUPPORT_KEY = 'typography.__experimentalTextTransform';
+/**
+ * Key within block settings' supports array indicating support for letter-spacing
+ * e.g. settings found in `block.json`.
+ */
+const LETTER_SPACING_SUPPORT_KEY = 'typography.__experimentalLetterSpacing';
+const LAYOUT_SUPPORT_KEY = '__experimentalLayout';
+const TYPOGRAPHY_SUPPORT_KEYS = [
+	LINE_HEIGHT_SUPPORT_KEY,
+	FONT_SIZE_SUPPORT_KEY,
+	FONT_STYLE_SUPPORT_KEY,
+	FONT_WEIGHT_SUPPORT_KEY,
+	FONT_FAMILY_SUPPORT_KEY,
+	TEXT_DECORATION_SUPPORT_KEY,
+	TEXT_TRANSFORM_SUPPORT_KEY,
+	LETTER_SPACING_SUPPORT_KEY,
+];
+const SPACING_SUPPORT_KEY = 'spacing';
+const styleSupportKeys = [
+	...TYPOGRAPHY_SUPPORT_KEYS,
+	BORDER_SUPPORT_KEY,
+	COLOR_SUPPORT_KEY,
+	SPACING_SUPPORT_KEY,
+];
+
+/**
+ * Returns true if the block defines support for align.
+ *
+ * @param {string|Object} nameOrType Block name or type object.
+ * @return {boolean} Whether the block supports the feature.
+ */
+export const hasAlignSupport = ( nameOrType ) =>
+	hasBlockSupport( nameOrType, ALIGN_SUPPORT_KEY );
+
+/**
+ * Returns the block support value for align, if defined.
+ *
+ * @param {string|Object} nameOrType Block name or type object.
+ * @return {unknown} The block support value.
+ */
+export const getAlignSupport = ( nameOrType ) =>
+	getBlockSupport( nameOrType, ALIGN_SUPPORT_KEY );
+
+/**
+ * Returns true if the block defines support for align wide.
+ *
+ * @param {string|Object} nameOrType Block name or type object.
+ * @return {boolean} Whether the block supports the feature.
+ */
+export const hasAlignWideSupport = ( nameOrType ) =>
+	hasBlockSupport( nameOrType, ALIGN_WIDE_SUPPORT_KEY );
+
+/**
+ * Returns the block support value for align wide, if defined.
+ *
+ * @param {string|Object} nameOrType Block name or type object.
+ * @return {unknown} The block support value.
+ */
+export const getAlignWideSupport = ( nameOrType ) =>
+	getBlockSupport( nameOrType, ALIGN_WIDE_SUPPORT_KEY );
+
+/**
+ * Determine whether there is block support for border properties.
+ *
+ * @param {string|Object} nameOrType Block name or type object.
+ * @param {string}        feature    Border feature to check support for.
+ *
+ * @return {boolean} Whether there is support.
+ */
+export function hasBorderSupport( nameOrType, feature = 'any' ) {
+	if ( Platform.OS !== 'web' ) {
+		return false;
+	}
+
+	const support = getBlockSupport( nameOrType, BORDER_SUPPORT_KEY );
+
+	if ( support === true ) {
+		return true;
+	}
+
+	if ( feature === 'any' ) {
+		return !! (
+			support?.color ||
+			support?.radius ||
+			support?.width ||
+			support?.style
+		);
+	}
+
+	return !! support?.[ feature ];
+}
+
+/**
+ * Get block support for border properties.
+ *
+ * @param {string|Object} nameOrType Block name or type object.
+ * @param {string}        feature    Border feature to get.
+ *
+ * @return {unknown} The block support.
+ */
+export const getBorderSupport = ( nameOrType, feature ) =>
+	getBlockSupport( nameOrType, [ BORDER_SUPPORT_KEY, feature ] );
+
+/**
+ * Returns true if the block defines support for color.
+ *
+ * @param {string|Object} nameOrType Block name or type object.
+ * @return {boolean} Whether the block supports the feature.
+ */
+export const hasColorSupport = ( nameOrType ) => {
+	const colorSupport = getBlockSupport( nameOrType, COLOR_SUPPORT_KEY );
+	return (
+		colorSupport &&
+		( colorSupport.link === true ||
+			colorSupport.gradient === true ||
+			colorSupport.background !== false ||
+			colorSupport.text !== false )
+	);
+};
+
+/**
+ * Returns true if the block defines support for link color.
+ *
+ * @param {string|Object} nameOrType Block name or type object.
+ * @return {boolean} Whether the block supports the feature.
+ */
+export const hasLinkColorSupport = ( nameOrType ) => {
+	if ( Platform.OS !== 'web' ) {
+		return false;
+	}
+
+	const colorSupport = getBlockSupport( nameOrType, COLOR_SUPPORT_KEY );
+
+	return (
+		colorSupport !== null &&
+		typeof colorSupport === 'object' &&
+		!! colorSupport.link
+	);
+};
+
+/**
+ * Returns true if the block defines support for gradient color.
+ *
+ * @param {string|Object} nameOrType Block name or type object.
+ * @return {boolean} Whether the block supports the feature.
+ */
+export const hasGradientSupport = ( nameOrType ) => {
+	const colorSupport = getBlockSupport( nameOrType, COLOR_SUPPORT_KEY );
+
+	return (
+		colorSupport !== null &&
+		typeof colorSupport === 'object' &&
+		!! colorSupport.gradients
+	);
+};
+
+/**
+ * Returns true if the block defines support for background color.
+ *
+ * @param {string|Object} nameOrType Block name or type object.
+ * @return {boolean} Whether the block supports the feature.
+ */
+export const hasBackgroundColorSupport = ( nameOrType ) => {
+	const colorSupport = getBlockSupport( nameOrType, COLOR_SUPPORT_KEY );
+
+	return colorSupport && colorSupport.background !== false;
+};
+
+/**
+ * Returns true if the block defines support for background color.
+ *
+ * @param {string|Object} nameOrType Block name or type object.
+ * @return {boolean} Whether the block supports the feature.
+ */
+export const hasTextColorSupport = ( nameOrType ) => {
+	const colorSupport = getBlockSupport( nameOrType, COLOR_SUPPORT_KEY );
+
+	return colorSupport && colorSupport.text !== false;
+};
+
+/**
+ * Get block support for color properties.
+ *
+ * @param {string|Object} nameOrType Block name or type object.
+ * @param {string}        feature    Color feature to get.
+ *
+ * @return {unknown} The block support.
+ */
+export const getColorSupport = ( nameOrType, feature ) =>
+	getBlockSupport( nameOrType, [ COLOR_SUPPORT_KEY, feature ] );
+
+/**
+ * Returns true if the block defines support for custom class name.
+ *
+ * @param {string|Object} nameOrType Block name or type object.
+ * @return {boolean} Whether the block supports the feature.
+ */
+export const hasCustomClassNameSupport = ( nameOrType ) =>
+	hasBlockSupport( nameOrType, CUSTOM_CLASS_NAME_SUPPORT_KEY, true );
+
+/**
+ * Returns the block support value for custom class name, if defined.
+ *
+ * @param {string|Object} nameOrType Block name or type object.
+ * @return {unknown} The block support value.
+ */
+export const getCustomClassNameSupport = ( nameOrType ) =>
+	getBlockSupport( nameOrType, CUSTOM_CLASS_NAME_SUPPORT_KEY, true );
+
+/**
+ * Returns true if the block defines support for font family.
+ *
+ * @param {string|Object} nameOrType Block name or type object.
+ * @return {boolean} Whether the block supports the feature.
+ */
+export const hasFontFamilySupport = ( nameOrType ) =>
+	hasBlockSupport( nameOrType, FONT_FAMILY_SUPPORT_KEY );
+
+/**
+ * Returns the block support value for font family, if defined.
+ *
+ * @param {string|Object} nameOrType Block name or type object.
+ * @return {unknown} The block support value.
+ */
+export const getFontFamilySupport = ( nameOrType ) =>
+	getBlockSupport( nameOrType, FONT_FAMILY_SUPPORT_KEY );
+
+/**
+ * Returns true if the block defines support for font size.
+ *
+ * @param {string|Object} nameOrType Block name or type object.
+ * @return {boolean} Whether the block supports the feature.
+ */
+export const hasFontSizeSupport = ( nameOrType ) =>
+	hasBlockSupport( nameOrType, FONT_SIZE_SUPPORT_KEY );
+
+/**
+ * Returns the block support value for font size, if defined.
+ *
+ * @param {string|Object} nameOrType Block name or type object.
+ * @return {unknown} The block support value.
+ */
+export const getFontSizeSupport = ( nameOrType ) =>
+	getBlockSupport( nameOrType, FONT_SIZE_SUPPORT_KEY );
+
+/**
+ * Returns true if the block defines support for layout.
+ *
+ * @param {string|Object} nameOrType Block name or type object.
+ * @return {boolean} Whether the block supports the feature.
+ */
+export const hasLayoutSupport = ( nameOrType ) =>
+	hasBlockSupport( nameOrType, LAYOUT_SUPPORT_KEY );
+
+/**
+ * Returns the block support value for layout, if defined.
+ *
+ * @param {string|Object} nameOrType Block name or type object.
+ * @return {unknown} The block support value.
+ */
+export const getLayoutSupport = ( nameOrType ) =>
+	getBlockSupport( nameOrType, LAYOUT_SUPPORT_KEY );
+
+/**
+ * Returns true if the block defines support for style.
+ *
+ * @param {string|Object} nameOrType Block name or type object.
+ * @return {boolean} Whether the block supports the feature.
+ */
+export const hasStyleSupport = ( nameOrType ) =>
+	styleSupportKeys.some( ( key ) => hasBlockSupport( nameOrType, key ) );


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->
A partial solution to https://github.com/WordPress/gutenberg/issues/44418. Allow pasting styles of the copied blocks to the selected blocks.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
See https://github.com/WordPress/gutenberg/issues/44418.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
I don't think we need a separate "Copy styles" action since that the copied blocks should already contain that information. Instead, we can only provide a separate "Paste styles" action to selectively paste/apply only the styles to the selected blocks.

Which attributes should be considered "styles attributes" is debatable. This PR mark all attributes as styles attributes except for the ones that have `__experimentalRole` of `content`. We can discuss it and further refine this logic though. One possible idea is to assign `__experimentalRole: "style"` to the attributes.

`pasteStyles()` will recursively handle the inner blocks but it won't check for block names. That is, the common styles will be applied if the copied blocks are different from the target blocks. This decision is made because most blocks have many common attributes like padding/margin or text color. We can discuss it further and decide if we want to only allow pasting styles to the same block type, though.

If there's only one (top-level) copied block, all the selected blocks will be applied to the same styles. Else if there are multiple copied blocks, only the minimum common blocks will be applied to the styles. This could be kind of confusing sometimes, but I think it matches what the users expect most of the time.

Worth noting that for security reasons, reading from the clipboard requires additional permissions. If permission is denied, we'll show a warning snackbar to notify the user. Different browsers have different ways to ask for permissions natively.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->
1. Open a post or page.
2. Insert some blocks and apply some styles to them.
3. Copy the block(s).
4. Create some more blocks.
5. Select them and paste the styles.
6. Try different combinations (inner blocks, multiple copied blocks, multiple selected blocks).

## Screenshots or screencast <!-- if applicable -->

https://user-images.githubusercontent.com/7753001/199413253-79cfc4f6-4314-4d18-a217-a8ee2f0f3820.mp4


