### PR TITLE
E2E: add site and widget editor supports for ensureSidebarOpened

### DIFF
--- a/packages/e2e-test-utils/README.md
+++ b/packages/e2e-test-utils/README.md
@@ -322,11 +322,11 @@ Enables Pre-publish checks.
 
 ### ensureSidebarOpened
 
-Verifies that the edit post sidebar is opened, and if it is not, opens it.
+Verifies that the edit post/site/widgets sidebar is opened, and if it is not, opens it.
 
 _Returns_
 
--   `Promise`: Promise resolving once the edit post sidebar is opened.
+-   `Promise`: Promise resolving once the sidebar is opened.
 
 ### findSidebarPanelToggleButtonWithTitle
 

--- a/packages/e2e-test-utils/src/ensure-sidebar-opened.js
+++ b/packages/e2e-test-utils/src/ensure-sidebar-opened.js
@@ -1,11 +1,13 @@
 /**
- * Verifies that the edit post sidebar is opened, and if it is not, opens it.
+ * Verifies that the edit post/site/widgets sidebar is opened, and if it is not, opens it.
  *
- * @return {Promise} Promise resolving once the edit post sidebar is opened.
+ * @return {Promise} Promise resolving once the sidebar is opened.
  */
 export async function ensureSidebarOpened() {
 	const toggleSidebarButton = await page.$(
-		'.edit-post-header__settings [aria-label="Settings"][aria-expanded="false"]'
+		'.edit-post-header__settings [aria-label="Settings"][aria-expanded="false"],' +
+			'.edit-site-header__actions [aria-label="Settings"][aria-expanded="false"],' +
+			'.edit-site-header-edit-mode__actions [aria-label="Settings"][aria-expanded="false"],'
 	);
 
 	if ( toggleSidebarButton ) {

--- a/packages/e2e-test-utils/src/ensure-sidebar-opened.js
+++ b/packages/e2e-test-utils/src/ensure-sidebar-opened.js
@@ -7,7 +7,8 @@ export async function ensureSidebarOpened() {
 	const toggleSidebarButton = await page.$(
 		'.edit-post-header__settings [aria-label="Settings"][aria-expanded="false"],' +
 			'.edit-site-header__actions [aria-label="Settings"][aria-expanded="false"],' +
-			'.edit-site-header-edit-mode__actions [aria-label="Settings"][aria-expanded="false"],'
+			'.edit-widgets-header__actions [aria-label="Settings"][aria-expanded="false"],' +
+			'.edit-site-header-edit-mode__actions [aria-label="Settings"][aria-expanded="false"]'
 	);
 
 	if ( toggleSidebarButton ) {


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->
This PR add Site and Widgets Editor supports for the `ensureSidebarOpened` utility.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
Currently, `ensureSidebarOpened` only supports the Blocks Editor. To test against Site or Widgets Editors, developers have to create custom utitlity

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
This PR combines selectors of the setting button in Widgets and Site Editor (edit mode is supported) to make the utility works with all three editors.

## Testing Instructions

N/a. Ensure E2E tests are passing. We're using a similar utility for WooCommerce Blocks [here](https://github.com/woocommerce/woocommerce-blocks/pull/7554/files#diff-5c358b5fd8e2d46aa29a0dfd50e7059885e64c192a88cf560245f4f20540b07dR415).
