### PR TITLE
unstableSubscribeStore: support store descriptors

### DIFF
--- a/packages/data/src/registry.js
+++ b/packages/data/src/registry.js
@@ -271,13 +271,18 @@ export function createRegistry( storeConfigs = {}, parent = null ) {
 	/**
 	 * Subscribe handler to a store.
 	 *
-	 * @param {string[]} storeName The store name.
-	 * @param {Function} handler   The function subscribed to the store.
+	 * @param {string|StoreDescriptor} storeNameOrDescriptor The store name.
+	 * @param {Function}               handler               The function subscribed to the store.
 	 * @return {Function} A function to unsubscribe the handler.
 	 */
-	function __unstableSubscribeStore( storeName, handler ) {
-		if ( storeName in stores ) {
-			return stores[ storeName ].subscribe( handler );
+	function __unstableSubscribeStore( storeNameOrDescriptor, handler ) {
+		const storeName = isObject( storeNameOrDescriptor )
+			? storeNameOrDescriptor.name
+			: storeNameOrDescriptor;
+
+		const store = stores[ storeName ];
+		if ( store ) {
+			return store.subscribe( handler );
 		}
 
 		// Trying to access a store that hasn't been registered,
@@ -288,7 +293,10 @@ export function createRegistry( storeConfigs = {}, parent = null ) {
 			return subscribe( handler );
 		}
 
-		return parent.__unstableSubscribeStore( storeName, handler );
+		return parent.__unstableSubscribeStore(
+			storeNameOrDescriptor,
+			handler
+		);
 	}
 
 	function batch( callback ) {


### PR DESCRIPTION
If we want to stabilize the `__unstableSubscribeStore` method, one of the requirements is to support store descriptors (objects) instead of just string store names. This PR adds that support.

What if we, instead of adding a new method, just overloaded the existing `subscribe`?
- existing `subscribe( listener: () => void ): () => void` subscribes to all stores
- new overload `subscribe( storeName: StoreNameOrDescriptor, listener )` would subscribe just to one store

This way the `subscribe` method is symmetrical to the existing `registry.select( storeName )` and `registry.dispatch( storeName )`. Every store, no matter how it's implemented, must support selecting, dispatching, and subscribing, and the registry methods are the standard way to access the individual stores.

CC @alexflorisca