### PR TITLE
Sidebar: Add list view tab for Navigation block et al.

### DIFF
--- a/packages/block-editor/src/components/inspector-controls-tabs/index.js
+++ b/packages/block-editor/src/components/inspector-controls-tabs/index.js
@@ -6,17 +6,23 @@ import { TabPanel } from '@wordpress/components';
 /**
  * Internal dependencies
  */
-import { TAB_SETTINGS, TAB_APPEARANCE } from './utils';
+import { TAB_SETTINGS, TAB_APPEARANCE, TAB_LIST_VIEW } from './utils';
 import AppearanceTab from './appearance-tab';
 import SettingsTab from './settings-tab';
+import { default as ListViewTab, useIsListViewDisabled } from './list-view-tab';
 
-const tabs = [ TAB_APPEARANCE, TAB_SETTINGS ];
+const defaultTabs = [ TAB_APPEARANCE, TAB_SETTINGS ];
+const tabsWithListView = [ TAB_LIST_VIEW, TAB_APPEARANCE, TAB_SETTINGS ];
 
 export default function InspectorControlsTabs( {
 	blockName,
 	clientId,
 	hasBlockStyles,
 } ) {
+	const tabs = useIsListViewDisabled( blockName )
+		? defaultTabs
+		: tabsWithListView;
+
 	return (
 		<TabPanel className="block-editor-block-inspector__tabs" tabs={ tabs }>
 			{ ( tab ) => {
@@ -32,6 +38,15 @@ export default function InspectorControlsTabs( {
 							blockName={ blockName }
 							clientId={ clientId }
 							hasBlockStyles={ hasBlockStyles }
+							hasSingleBlockSelection={ !! blockName }
+						/>
+					);
+				}
+
+				if ( tab.name === TAB_LIST_VIEW.name ) {
+					return (
+						<ListViewTab
+							blockName={ blockName }
 							hasSingleBlockSelection={ !! blockName }
 						/>
 					);

--- a/packages/block-editor/src/components/inspector-controls-tabs/list-view-tab.js
+++ b/packages/block-editor/src/components/inspector-controls-tabs/list-view-tab.js
@@ -10,11 +10,11 @@ import { __ } from '@wordpress/i18n';
 import InspectorControls from '../inspector-controls';
 import InspectorControlsGroups from '../inspector-controls/groups';
 
-// This tab restricts the blocks that may render to it via the whitelist below.
-const whitelist = [ 'core/navigation' ];
+// This tab restricts the blocks that may render to it via the allowlist below.
+const allowlist = [ 'core/navigation' ];
 
 export const useIsListViewDisabled = ( blockName ) => {
-	return ! whitelist.includes( blockName );
+	return ! allowlist.includes( blockName );
 };
 
 const ListViewTab = ( { blockName, hasSingleBlockSelection } ) => {
@@ -22,7 +22,7 @@ const ListViewTab = ( { blockName, hasSingleBlockSelection } ) => {
 	const fills = useSlotFills( list.Slot.__unstableName ) || [];
 
 	// Unlike other tabs the List View is much more niche. As such it will be
-	// omitted if the current block isn't in the whitelist.
+	// omitted if the current block isn't in the allowlist.
 	if ( useIsListViewDisabled( blockName ) ) {
 		return;
 	}

--- a/packages/block-editor/src/components/inspector-controls-tabs/list-view-tab.js
+++ b/packages/block-editor/src/components/inspector-controls-tabs/list-view-tab.js
@@ -1,0 +1,44 @@
+/**
+ * WordPress dependencies
+ */
+import { __experimentalUseSlotFills as useSlotFills } from '@wordpress/components';
+import { __ } from '@wordpress/i18n';
+
+/**
+ * Internal dependencies
+ */
+import InspectorControls from '../inspector-controls';
+import InspectorControlsGroups from '../inspector-controls/groups';
+
+// This tab restricts the blocks that may render to it via the whitelist below.
+const whitelist = [ 'core/navigation' ];
+
+export const useIsListViewDisabled = ( blockName ) => {
+	return ! whitelist.includes( blockName );
+};
+
+const ListViewTab = ( { blockName, hasSingleBlockSelection } ) => {
+	const { list } = InspectorControlsGroups;
+	const fills = useSlotFills( list.Slot.__unstableName ) || [];
+
+	// Unlike other tabs the List View is much more niche. As such it will be
+	// omitted if the current block isn't in the whitelist.
+	if ( useIsListViewDisabled( blockName ) ) {
+		return;
+	}
+
+	return (
+		<>
+			{ ! fills.length && (
+				<span className="block-editor-block-inspector__no-block-tools">
+					{ hasSingleBlockSelection
+						? __( 'This block has no list options.' )
+						: __( 'The selected blocks have no list options.' ) }
+				</span>
+			) }
+			<InspectorControls.Slot __experimentalGroup="list" />
+		</>
+	);
+};
+
+export default ListViewTab;

--- a/packages/block-editor/src/components/inspector-controls-tabs/utils.js
+++ b/packages/block-editor/src/components/inspector-controls-tabs/utils.js
@@ -1,7 +1,7 @@
 /**
  * WordPress dependencies
  */
-import { cog, styles } from '@wordpress/icons';
+import { cog, styles, listView } from '@wordpress/icons';
 
 export const TAB_SETTINGS = {
 	name: 'settings',
@@ -16,5 +16,13 @@ export const TAB_APPEARANCE = {
 	title: 'Appearance',
 	value: 'appearance',
 	icon: styles,
+	className: 'block-editor-block-inspector__tab-item',
+};
+
+export const TAB_LIST_VIEW = {
+	name: 'list',
+	title: 'List View',
+	value: 'list-view',
+	icon: listView,
 	className: 'block-editor-block-inspector__tab-item',
 };

--- a/packages/block-editor/src/components/inspector-controls/groups.js
+++ b/packages/block-editor/src/components/inspector-controls/groups.js
@@ -13,6 +13,7 @@ const InspectorControlsDimensions = createSlotFill(
 const InspectorControlsTypography = createSlotFill(
 	'InspectorControlsTypography'
 );
+const InspectorControlsListView = createSlotFill( 'InspectorControlsListView' );
 
 const groups = {
 	default: InspectorControlsDefault,
@@ -20,6 +21,7 @@ const groups = {
 	border: InspectorControlsBorder,
 	color: InspectorControlsColor,
 	dimensions: InspectorControlsDimensions,
+	list: InspectorControlsListView,
 	typography: InspectorControlsTypography,
 };
 

--- a/packages/block-library/src/navigation/edit/menu-inspector-controls.js
+++ b/packages/block-library/src/navigation/edit/menu-inspector-controls.js
@@ -66,9 +66,12 @@ const MenuInspectorControls = ( {
 } ) => {
 	const isOffCanvasNavigationEditorEnabled =
 		window?.__experimentalEnableOffCanvasNavigationEditor === true;
+	const menuControlsSlot = window?.__experimentalEnableBlockInspectorTabs
+		? 'list'
+		: undefined;
 
 	return (
-		<InspectorControls>
+		<InspectorControls __experimentalGroup={ menuControlsSlot }>
 			<PanelBody
 				title={
 					isOffCanvasNavigationEditorEnabled ? null : __( 'Menu' )

--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -11,6 +11,7 @@
 ### Enhancements
 
 -   `ColorPalette`, `BorderBox`, `BorderBoxControl`: polish and DRY prop types, add default values ([#45463](https://github.com/WordPress/gutenberg/pull/45463)).
+-   `TabPanel`: Add ability to set icon only tab buttons ([#45005](https://github.com/WordPress/gutenberg/pull/45005)).
 
 ### Bug Fix
 


### PR DESCRIPTION
Related:
- https://github.com/WordPress/gutenberg/pull/45005
- https://github.com/WordPress/gutenberg/issues/40204

## What?

Adds a new "List View" tab to the sidebar and if the block inspector tabs experiment is enabled, renders the Navigation block's menu controls to that tab.

## Why?

- Provides better prominence and real estate to import controls for the Navigation block.
- Achieves original design from https://github.com/WordPress/gutenberg/issues/40204

## How?

- Adds new InspectorControls group slot for the new tab
- Adds new List View tab
- Updates the Navigation block to render its menu controls into the new slot/tab

### Important Notes

- As there are only a couple of blocks out of 80 that would utilize this tab. It doesn't make a lot of sense to display an empty tab for all the others to maintain strict consistency on displayed tabs.
- Despite the less-than-ideal impact on a11y here due to the small occurrence of different tabs, I hope this approach might still be accepted. cc/ @alexstine in case you have any ideas other than rendering a useless tab for about 98% of blocks.
- If the list view is only being displayed for the Navigation block and maybe one or two others, and it would contain important controls for those blocks, I've kept it as the first tab for those blocks as per the original design mockups.


## Testing Instructions
1. Ensure you do not have the Block Inspector Tabs experiment enabled
2. Edit a post with a Nav block and select it
3. The menu related controls should still display and function as normal
4. Enable the Block Inspector Tabs experiment
5. Switch back to the editor and re-select the Nav block
6. Confirm the Nav block now renders the menu-related controls into the new List View tab
7. Add some other blocks and ensure they do not display the List View tab
8. Bonus points if you tweak an existing block to render some controls into the List View tab and confirm they don't not display due to the whitelist enforced for that tab.

## Screenshots or screencast <!-- if applicable -->
<img width="280" alt="Screenshot 2022-11-02 at 7 38 09 pm" src="https://user-images.githubusercontent.com/60436221/199455919-807034a4-d543-4bee-85c0-a7413b4d5fee.png">
