### PR TITLE
Fix Nav uncontrolled blocks saving/loading experience

### DIFF
--- a/packages/block-library/src/navigation/edit/unsaved-inner-blocks.js
+++ b/packages/block-library/src/navigation/edit/unsaved-inner-blocks.js
@@ -171,9 +171,6 @@ export default function UnsavedInnerBlocks( {
 	const Wrapper = isSaving ? Disabled : 'div';
 
 	return (
-		<>
-			<Wrapper { ...innerBlocksProps } />
-			{ isSaving && <Spinner /> }
-		</>
+		<>{ isSaving ? <Spinner /> : <Wrapper { ...innerBlocksProps } /> }</>
 	);
 }

--- a/packages/block-library/src/navigation/edit/unsaved-inner-blocks.js
+++ b/packages/block-library/src/navigation/edit/unsaved-inner-blocks.js
@@ -171,6 +171,16 @@ export default function UnsavedInnerBlocks( {
 	const Wrapper = isSaving ? Disabled : 'div';
 
 	return (
-		<>{ isSaving ? <Spinner /> : <Wrapper { ...innerBlocksProps } /> }</>
+		<>
+			{ isSaving ? (
+				<Spinner
+					className={
+						'wp-block-navigation__uncontrolled-inner-blocks-loading-indicator'
+					}
+				/>
+			) : (
+				<Wrapper { ...innerBlocksProps } />
+			) }
+		</>
 	);
 }

--- a/packages/block-library/src/navigation/editor.scss
+++ b/packages/block-library/src/navigation/editor.scss
@@ -561,6 +561,9 @@ body.editor-styles-wrapper
 // room when block is selected and has focus outline.
 .wp-block-navigation .components-spinner {
 	padding: $grid-unit-10 $grid-unit-15;
+}
+
+.wp-block-navigation .wp-block-navigation__uncontrolled-inner-blocks-loading-indicator {
 	margin-top: 0;
 }
 

--- a/packages/block-library/src/navigation/editor.scss
+++ b/packages/block-library/src/navigation/editor.scss
@@ -261,10 +261,6 @@ $color-control-label-height: 20px;
 	}
 }
 
-.wp-block-navigation-placeholder .components-spinner {
-	margin-top: 0;
-}
-
 // Unselected state.
 .wp-block-navigation-placeholder__preview {
 	display: flex;
@@ -565,6 +561,7 @@ body.editor-styles-wrapper
 // room when block is selected and has focus outline.
 .wp-block-navigation .components-spinner {
 	padding: $grid-unit-10 $grid-unit-15;
+	margin-top: 0;
 }
 
 @keyframes fadeouthalf {


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Fixes the dual rendering of the uncontrolled blocks alongside the "loading" spinner which can occur when the page list block is converted into a sync'd nav menu.

Only the spinner should render whilst in "saving" mode.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

When converting from uncontrolled inner blocks it was possible to observe the loading spinner sitting alongside the uncontrolled blocks. This looked broken.

The spinner should show on it's own when in a loading state.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

I have conditionally rendered either the uncontrolled blocks OR the spinner. 

I was concerned about focus loss and a11y but then I noticed that [the main Nav block code does much the same](https://github.com/WordPress/gutenberg/blob/f7fef701f37452dad6cb71b0d8df1fe9c313dd86/packages/block-library/src/navigation/edit/index.js#L921-L927) and as long as it's wrapped in `TagName` ([which it is](https://github.com/WordPress/gutenberg/blob/f7fef701f37452dad6cb71b0d8df1fe9c313dd86/packages/block-library/src/navigation/edit/index.js#L651)) then the focus should be maintained.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->

## Screenshots or screencast <!-- if applicable -->

### Before

 Notice the spinner _alongside_ the uncontrolled blocks.

https://user-images.githubusercontent.com/444434/199491199-616fec92-76d0-4459-b948-5259ae0aa4d0.mp4



### After

Now we have only the spinner showing

https://user-images.githubusercontent.com/444434/199490748-dac393c8-7d39-4c72-8087-11d52f16ecd5.mp4


