### PR TITLE
Read More block: add aria-label and screen reader text

### DIFF
--- a/packages/block-library/src/read-more/index.php
+++ b/packages/block-library/src/read-more/index.php
@@ -19,18 +19,17 @@ function render_block_core_read_more( $attributes, $content, $block ) {
 	}
 
 	$post_ID            = $block->context['postId'];
-	$post_title         = get_the_title( $post_ID );
+	$screen_reader_text = __( 'Read more about ' ) . get_the_title( $post_ID );
 	$justify_class_name = empty( $attributes['justifyContent'] ) ? '' : "is-justified-{$attributes['justifyContent']}";
 	$wrapper_attributes = get_block_wrapper_attributes( array( 'class' => $justify_class_name ) );
 	$more_text          = ! empty( $attributes['content'] ) ? wp_kses_post( $attributes['content'] ) : __( 'Read more' );
 	return sprintf(
-		'<a %1s href="%2s" target="%3s" aria-label="%4s">%5s<span class="screen-reader-text">%6s</span></a>',
+		'<a %1s href="%2s" target="%3s">%4s<span class="screen-reader-text">%5s</span></a>',
 		$wrapper_attributes,
 		get_the_permalink( $post_ID ),
 		esc_attr( $attributes['linkTarget'] ),
-		esc_attr__( 'Post ID: ' . $post_ID ),
 		$more_text,
-		$post_title
+		$screen_reader_text
 	);
 }
 

--- a/packages/block-library/src/read-more/index.php
+++ b/packages/block-library/src/read-more/index.php
@@ -18,8 +18,8 @@ function render_block_core_read_more( $attributes, $content, $block ) {
 		return '';
 	}
 
-	$post_ID            = $block->context['postId'];
-	$post_title         = get_the_title( $post_ID );
+	$post_ID    = $block->context['postId'];
+	$post_title = get_the_title( $post_ID );
 	/* translators: %s is either the post title or post ID to describe the link for screen readers. */
 	$screen_reader_text = sprintf(
 		__( ': %s' ),

--- a/packages/block-library/src/read-more/index.php
+++ b/packages/block-library/src/read-more/index.php
@@ -18,12 +18,12 @@ function render_block_core_read_more( $attributes, $content, $block ) {
 		return '';
 	}
 
-	$post_ID    = $block->context['postId'];
-	$post_title = get_the_title( $post_ID );
-	/* translators: %s is either the post title or post ID to describe the link for screen readers. */
+	$post_ID            = $block->context['postId'];
+	$post_title         = get_the_title( $post_ID );
 	$screen_reader_text = sprintf(
+		/* translators: %s is either the post title or post ID to describe the link for screen readers. */
 		__( ': %s' ),
-		$post_title !== '' ? $post_title : __( 'untitled post ' ) . $post_ID
+		'' !== $post_title ? $post_title : __( 'untitled post ' ) . $post_ID
 	);
 	$justify_class_name = empty( $attributes['justifyContent'] ) ? '' : "is-justified-{$attributes['justifyContent']}";
 	$wrapper_attributes = get_block_wrapper_attributes( array( 'class' => $justify_class_name ) );

--- a/packages/block-library/src/read-more/index.php
+++ b/packages/block-library/src/read-more/index.php
@@ -19,15 +19,18 @@ function render_block_core_read_more( $attributes, $content, $block ) {
 	}
 
 	$post_ID            = $block->context['postId'];
+	$post_title         = get_the_title( $post_ID );
 	$justify_class_name = empty( $attributes['justifyContent'] ) ? '' : "is-justified-{$attributes['justifyContent']}";
 	$wrapper_attributes = get_block_wrapper_attributes( array( 'class' => $justify_class_name ) );
 	$more_text          = ! empty( $attributes['content'] ) ? wp_kses_post( $attributes['content'] ) : __( 'Read more' );
 	return sprintf(
-		'<a %1s href="%2s" target="%3s">%4s</a>',
+		'<a %1s href="%2s" target="%3s" aria-label="%4s">%5s<span class="screen-reader-text">%6s</span></a>',
 		$wrapper_attributes,
 		get_the_permalink( $post_ID ),
 		esc_attr( $attributes['linkTarget'] ),
-		$more_text
+		esc_attr__( 'Post ID: ' . $post_ID ),
+		$more_text,
+		$post_title
 	);
 }
 

--- a/packages/block-library/src/read-more/index.php
+++ b/packages/block-library/src/read-more/index.php
@@ -23,7 +23,7 @@ function render_block_core_read_more( $attributes, $content, $block ) {
 	/* translators: %s is either the post title or post ID to describe the link for screen readers. */
 	$screen_reader_text = sprintf(
 		__( ': %s' ),
-		$post_title !== '' ? $post_title : __( 'post ' ) . $post_ID
+		$post_title !== '' ? $post_title : __( 'untitled post ' ) . $post_ID
 	);
 	$justify_class_name = empty( $attributes['justifyContent'] ) ? '' : "is-justified-{$attributes['justifyContent']}";
 	$wrapper_attributes = get_block_wrapper_attributes( array( 'class' => $justify_class_name ) );

--- a/packages/block-library/src/read-more/index.php
+++ b/packages/block-library/src/read-more/index.php
@@ -19,7 +19,12 @@ function render_block_core_read_more( $attributes, $content, $block ) {
 	}
 
 	$post_ID            = $block->context['postId'];
-	$screen_reader_text = __( 'Read more about ' ) . get_the_title( $post_ID );
+	$post_title         = get_the_title( $post_ID );
+	/* translators: %s is either the post title or post ID to describe the link for screen readers. */
+	$screen_reader_text = sprintf(
+		__( ': %s' ),
+		$post_title !== '' ? $post_title : __( 'post ' ) . $post_ID
+	);
 	$justify_class_name = empty( $attributes['justifyContent'] ) ? '' : "is-justified-{$attributes['justifyContent']}";
 	$wrapper_attributes = get_block_wrapper_attributes( array( 'class' => $justify_class_name ) );
 	$more_text          = ! empty( $attributes['content'] ) ? wp_kses_post( $attributes['content'] ) : __( 'Read more' );


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

This PR adds ~an `aria-label` and~ `.screen-reader-text` to the output of the Read More block. I could use some input as to whether the resulting markup is acceptable.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

Fixes 1/2 of #45396 

> Links must avoid repetitive non-contextual text strings such as ‘read more…’ and must make sense if taken out of context. Bare urls must not be used as links. Supporting text may use a screen reader class to hide text visually.

https://make.wordpress.org/themes/handbook/review/accessibility/required/#repetitive-link-text

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

See above.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->

1. Check out this PR and add the following block markup for a Query to a post or template: 
```
<!-- wp:query {"queryId":0,"query":{"perPage":3,"pages":0,"offset":0,"postType":"post","order":"desc","orderBy":"date","author":"","search":"","exclude":[],"sticky":"","inherit":false}} -->
<div class="wp-block-query"><!-- wp:post-template -->
<!-- wp:post-title /-->
<!-- wp:post-featured-image /-->
<!-- wp:read-more /-->
<!-- /wp:post-template -->
<!-- wp:query-pagination -->
<!-- wp:query-pagination-previous /-->
<!-- wp:query-pagination-numbers /-->
<!-- wp:query-pagination-next /-->
<!-- /wp:query-pagination --></div>
<!-- /wp:query -->
```

2. Ensure the resulting markup for the Read More link is accessible. Here is an example: 

```
<a class="wp-block-read-more" href="http://gutenbergtest.local/341-2/" target="_self" aria-label="Post ID: 341">Continue Reading<span class="screen-reader-text">This is my post title</span></a>
```

## Screenshots or screencast <!-- if applicable -->
