### PR TITLE
Post Excerpt block: add aria-label and screen reader text

### DIFF
--- a/packages/block-library/src/post-excerpt/index.php
+++ b/packages/block-library/src/post-excerpt/index.php
@@ -24,7 +24,8 @@ function render_block_core_post_excerpt( $attributes, $content, $block ) {
 		return '';
 	}
 
-	$more_text           = ! empty( $attributes['moreText'] ) ? '<a class="wp-block-post-excerpt__more-link" href="' . esc_url( get_the_permalink( $block->context['postId'] ) ) . '">' . wp_kses_post( $attributes['moreText'] ) . '</a>' : '';
+	$post_ID             = $block->context['postId'];
+	$more_text           = ! empty( $attributes['moreText'] ) ? '<a class="wp-block-post-excerpt__more-link" href="' . esc_url( get_the_permalink( $post_ID ) ) . '" aria-label="' . esc_attr__( "Post ID: " . $post_ID ) . '">' . wp_kses_post( $attributes['moreText'] ) . '<span class="screen-reader-text">'. get_the_title( $post_ID ) . '</a>' : '';
 	$filter_excerpt_more = function( $more ) use ( $more_text ) {
 		return empty( $more_text ) ? $more : '';
 	};

--- a/packages/block-library/src/post-excerpt/index.php
+++ b/packages/block-library/src/post-excerpt/index.php
@@ -25,7 +25,7 @@ function render_block_core_post_excerpt( $attributes, $content, $block ) {
 	}
 
 	$post_ID             = $block->context['postId'];
-	$more_text           = ! empty( $attributes['moreText'] ) ? '<a class="wp-block-post-excerpt__more-link" href="' . esc_url( get_the_permalink( $post_ID ) ) . '" aria-label="' . esc_attr__( "Post ID: " . $post_ID ) . '">' . wp_kses_post( $attributes['moreText'] ) . '<span class="screen-reader-text">'. get_the_title( $post_ID ) . '</a>' : '';
+	$more_text           = ! empty( $attributes['moreText'] ) ? '<a class="wp-block-post-excerpt__more-link" href="' . esc_url( get_the_permalink( $post_ID ) ) . '" aria-label="' . esc_attr__( "Post ID: " . $post_ID ) . '">' . wp_kses_post( $attributes['moreText'] ) . '<span class="screen-reader-text">'. get_the_title( $post_ID ) . '</span></a>' : '';
 	$filter_excerpt_more = function( $more ) use ( $more_text ) {
 		return empty( $more_text ) ? $more : '';
 	};

--- a/packages/block-library/src/post-excerpt/index.php
+++ b/packages/block-library/src/post-excerpt/index.php
@@ -24,8 +24,14 @@ function render_block_core_post_excerpt( $attributes, $content, $block ) {
 		return '';
 	}
 
-	$post_ID             = $block->context['postId'];
-	$more_text           = ! empty( $attributes['moreText'] ) ? '<a class="wp-block-post-excerpt__more-link" href="' . esc_url( get_the_permalink( $post_ID ) ) . '" aria-label="' . esc_attr__( "Post ID: " . $post_ID ) . '">' . wp_kses_post( $attributes['moreText'] ) . '<span class="screen-reader-text">'. get_the_title( $post_ID ) . '</span></a>' : '';
+	$post_ID            = $block->context['postId'];
+	$post_title         = get_the_title( $post_ID );
+	$screen_reader_text = sprintf(
+		/* translators: %s is either the post title or post ID to describe the link for screen readers. */
+		__( ': %s' ),
+		'' !== $post_title ? $post_title : __( 'untitled post ' ) . $post_ID
+	);
+	$more_text           = ! empty( $attributes['moreText'] ) ? '<a class="wp-block-post-excerpt__more-link" href="' . esc_url( get_the_permalink( $post_ID ) ) . '">' . wp_kses_post( $attributes['moreText'] ) . '<span class="screen-reader-text">' . $screen_reader_text . '</span></a>' : '';
 	$filter_excerpt_more = function( $more ) use ( $more_text ) {
 		return empty( $more_text ) ? $more : '';
 	};

--- a/packages/block-library/src/post-excerpt/index.php
+++ b/packages/block-library/src/post-excerpt/index.php
@@ -26,12 +26,14 @@ function render_block_core_post_excerpt( $attributes, $content, $block ) {
 
 	$post_ID            = $block->context['postId'];
 	$post_title         = get_the_title( $post_ID );
+	$allowed_html       = array( 'abbr' => array(), 'acronym' => array(), 'b' => array(), 'br' => array(), 'cite' => array(), 'code' => array(), 'em' => array(), 'i' => array(), 'span' => array(), 'strong' => array(), 'sub' => array(), 'sup' => array(), 'time' => array() );
+
 	$screen_reader_text = sprintf(
 		/* translators: %s is either the post title or post ID to describe the link for screen readers. */
 		__( ': %s' ),
 		'' !== $post_title ? $post_title : __( 'untitled post ' ) . $post_ID
 	);
-	$more_text           = ! empty( $attributes['moreText'] ) ? '<a class="wp-block-post-excerpt__more-link" href="' . esc_url( get_the_permalink( $post_ID ) ) . '">' . wp_kses_post( $attributes['moreText'] ) . '<span class="screen-reader-text">' . $screen_reader_text . '</span></a>' : '';
+	$more_text           = ! empty( $attributes['moreText'] ) ? '<a class="wp-block-post-excerpt__more-link" href="' . esc_url( get_the_permalink( $post_ID ) ) . '">' . wp_kses_post( $attributes['moreText'] ) . '<span class="screen-reader-text">' . wp_kses( $screen_reader_text, $allowed_html ) . '</span></a>' : '';
 	$filter_excerpt_more = function( $more ) use ( $more_text ) {
 		return empty( $more_text ) ? $more : '';
 	};


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

This PR adds screen reader text to the output of the Post Excerpt more link.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

See #45396

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

Follows the same approach as #45490. 

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
1. Check out the PR and add the following Query markup to a post or template:
```
<!-- wp:query {"queryId":0,"query":{"perPage":3,"pages":0,"offset":0,"postType":"post","order":"desc","orderBy":"date","author":"","search":"","exclude":[],"sticky":"","inherit":false}} -->
<div class="wp-block-query"><!-- wp:post-template -->
<!-- wp:post-title /-->
<!-- wp:post-excerpt {"moreText":"Read more"} /-->
<!-- /wp:post-template -->
<!-- wp:query-pagination -->
<!-- wp:query-pagination-previous /-->
<!-- wp:query-pagination-numbers /-->
<!-- wp:query-pagination-next /-->
<!-- /wp:query-pagination --></div>
<!-- /wp:query -->
```

2. Verify the resulting markup for the more link is accessible. 

For example for posts with a title: 

`<a class="wp-block-post-excerpt__more-link" href="http://gutenbergtest.local/some-reflections/">Read more<span class="screen-reader-text">: Some Reflections</span></a>`

And for posts without a title: 

`<a class="wp-block-post-excerpt__more-link" href="http://gutenbergtest.local/my-query-test-read-more/">Read more<span class="screen-reader-text">: untitled post 348</span></a>`
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->

## Screenshots or screencast <!-- if applicable -->
