### PR TITLE
ToggleGroupControl: Only show enclosing border when `isBlock`

### DIFF
--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -77,6 +77,7 @@
 ### Experimental
 
 -   `NumberControl`: Replace `hideHTMLArrows` prop with `spinControls` prop. Allow custom spin controls via `spinControls="custom"` ([#45333](https://github.com/WordPress/gutenberg/pull/45333)).
+-   `ToggleGroupControl`: Only show enclosing border when `isBlock` and not `isDeselectable` ([#45492](https://github.com/WordPress/gutenberg/pull/45492)).
 
 ## 21.3.0 (2022-10-19)
 

--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -14,6 +14,10 @@
 
 -   `PaletteEditListView`: Update to ignore `exhaustive-deps` eslint rule ([#45467](https://github.com/WordPress/gutenberg/pull/45467)).
 
+### Experimental
+
+-   `ToggleGroupControl`: Only show enclosing border when `isBlock` and not `isDeselectable` ([#45492](https://github.com/WordPress/gutenberg/pull/45492)).
+
 ## 22.0.0 (2022-11-02)
 
 ### Breaking Changes
@@ -77,7 +81,6 @@
 ### Experimental
 
 -   `NumberControl`: Replace `hideHTMLArrows` prop with `spinControls` prop. Allow custom spin controls via `spinControls="custom"` ([#45333](https://github.com/WordPress/gutenberg/pull/45333)).
--   `ToggleGroupControl`: Only show enclosing border when `isBlock` and not `isDeselectable` ([#45492](https://github.com/WordPress/gutenberg/pull/45492)).
 
 ## 21.3.0 (2022-10-19)
 

--- a/packages/components/src/toggle-group-control/stories/index.tsx
+++ b/packages/components/src/toggle-group-control/stories/index.tsx
@@ -81,6 +81,7 @@ Default.args = {
 		{ value: 'right', label: 'Right' },
 		{ value: 'justify', label: 'Justify' },
 	].map( mapPropsToOptionComponent ),
+	isBlock: true,
 	label: 'Label',
 };
 
@@ -121,6 +122,7 @@ WithIcons.args = {
 		{ value: 'uppercase', label: 'Uppercase', icon: formatUppercase },
 		{ value: 'lowercase', label: 'Lowercase', icon: formatLowercase },
 	].map( mapPropsToOptionIconComponent ),
+	isBlock: false,
 };
 
 /**

--- a/packages/components/src/toggle-group-control/test/__snapshots__/index.tsx.snap
+++ b/packages/components/src/toggle-group-control/test/__snapshots__/index.tsx.snap
@@ -41,6 +41,7 @@ exports[`ToggleGroupControl should render correctly with icons 1`] = `
 .emotion-8 {
   background: #fff;
   border: 1px solid transparent;
+  border-radius: 2px;
   display: -webkit-inline-box;
   display: -webkit-inline-flex;
   display: -ms-inline-flexbox;
@@ -51,8 +52,6 @@ exports[`ToggleGroupControl should render correctly with icons 1`] = `
   -webkit-transition: -webkit-transform 100ms linear;
   transition: transform 100ms linear;
   min-height: 36px;
-  border-color: #757575;
-  border-radius: 2px;
 }
 
 @media ( prefers-reduced-motion: reduce ) {
@@ -377,6 +376,7 @@ exports[`ToggleGroupControl should render correctly with text options 1`] = `
 .emotion-8 {
   background: #fff;
   border: 1px solid transparent;
+  border-radius: 2px;
   display: -webkit-inline-box;
   display: -webkit-inline-flex;
   display: -ms-inline-flexbox;
@@ -387,8 +387,6 @@ exports[`ToggleGroupControl should render correctly with text options 1`] = `
   -webkit-transition: -webkit-transform 100ms linear;
   transition: transform 100ms linear;
   min-height: 36px;
-  border-color: #757575;
-  border-radius: 2px;
 }
 
 @media ( prefers-reduced-motion: reduce ) {

--- a/packages/components/src/toggle-group-control/toggle-group-control/README.md
+++ b/packages/components/src/toggle-group-control/toggle-group-control/README.md
@@ -50,9 +50,16 @@ Determines if segments should be rendered with equal widths.
 -   Required: No
 -   Default: `false`
 
+### `isDeselectable`: `boolean`
+
+Whether an option can be deselected by clicking it again.
+
+-   Required: No
+-   Default: `false`
+
 ### `isBlock`: `boolean`
 
-Renders `ToggleGroupControl` as a (CSS) block element.
+Renders `ToggleGroupControl` as a (CSS) block element, spanning the entire width of the available space. This is the recommended style when the options are text-based and not icons.
 
 -   Required: No
 -   Default: `false`

--- a/packages/components/src/toggle-group-control/toggle-group-control/component.tsx
+++ b/packages/components/src/toggle-group-control/toggle-group-control/component.tsx
@@ -50,7 +50,7 @@ function UnconnectedToggleGroupControl(
 	const classes = useMemo(
 		() =>
 			cx(
-				styles.ToggleGroupControl( { isDeselectable, size } ),
+				styles.ToggleGroupControl( { isBlock, isDeselectable, size } ),
 				isBlock && styles.block,
 				className
 			),

--- a/packages/components/src/toggle-group-control/toggle-group-control/styles.ts
+++ b/packages/components/src/toggle-group-control/toggle-group-control/styles.ts
@@ -28,26 +28,29 @@ export const ToggleGroupControl = ( {
 	${ reduceMotion( 'transition' ) }
 
 	${ toggleGroupControlSize( size ) }
-	${ isBlock && enclosingBorder }
-	${ ! isDeselectable && enclosingInteractiveBorder }
+	${ ! isDeselectable && enclosingBorders( isBlock ) }
 `;
 
-const enclosingBorder = css`
-	border-color: ${ COLORS.ui.border };
-`;
+const enclosingBorders = ( isBlock: ToggleGroupControlProps[ 'isBlock' ] ) => {
+	const enclosingBorder = css`
+		border-color: ${ COLORS.ui.border };
+	`;
 
-const enclosingInteractiveBorder = css`
-	&:hover {
-		border-color: ${ COLORS.ui.borderHover };
-	}
+	return css`
+		${ isBlock && enclosingBorder }
 
-	&:focus-within {
-		border-color: ${ COLORS.ui.borderFocus };
-		box-shadow: ${ CONFIG.controlBoxShadowFocus };
-		outline: none;
-		z-index: 1;
-	}
-`;
+		&:hover {
+			border-color: ${ COLORS.ui.borderHover };
+		}
+
+		&:focus-within {
+			border-color: ${ COLORS.ui.borderFocus };
+			box-shadow: ${ CONFIG.controlBoxShadowFocus };
+			outline: none;
+			z-index: 1;
+		}
+	`;
+};
 
 export const toggleGroupControlSize = (
 	size: NonNullable< ToggleGroupControlProps[ 'size' ] >

--- a/packages/components/src/toggle-group-control/toggle-group-control/styles.ts
+++ b/packages/components/src/toggle-group-control/toggle-group-control/styles.ts
@@ -11,14 +11,15 @@ import { CONFIG, COLORS, reduceMotion } from '../../utils';
 import type { ToggleGroupControlProps } from '../types';
 
 export const ToggleGroupControl = ( {
+	isBlock,
 	isDeselectable,
 	size,
-}: {
-	isDeselectable?: boolean;
+}: Pick< ToggleGroupControlProps, 'isBlock' | 'isDeselectable' > & {
 	size: NonNullable< ToggleGroupControlProps[ 'size' ] >;
 } ) => css`
 	background: ${ COLORS.ui.background };
 	border: 1px solid transparent;
+	border-radius: ${ CONFIG.controlBorderRadius };
 	display: inline-flex;
 	min-width: 0;
 	padding: 2px;
@@ -27,13 +28,15 @@ export const ToggleGroupControl = ( {
 	${ reduceMotion( 'transition' ) }
 
 	${ toggleGroupControlSize( size ) }
-	${ ! isDeselectable && enclosingBorder }
+	${ isBlock && enclosingBorder }
+	${ ! isDeselectable && enclosingInteractiveBorder }
 `;
 
 const enclosingBorder = css`
 	border-color: ${ COLORS.ui.border };
-	border-radius: ${ CONFIG.controlBorderRadius };
+`;
 
+const enclosingInteractiveBorder = css`
 	&:hover {
 		border-color: ${ COLORS.ui.borderHover };
 	}

--- a/packages/components/src/toggle-group-control/types.ts
+++ b/packages/components/src/toggle-group-control/types.ts
@@ -92,7 +92,8 @@ export type ToggleGroupControlProps = Pick<
 	 */
 	isAdaptiveWidth?: boolean;
 	/**
-	 * Renders `ToggleGroupControl` as a (CSS) block element.
+	 * Renders `ToggleGroupControl` as a (CSS) block element, spanning the entire width of
+	 * the available space. This is the recommended style when the options are text-based and not icons.
 	 *
 	 * @default false
 	 */


### PR DESCRIPTION
Follow-up to #45123

## What?

When the control is unhovered or unfocused, change the logic so the enclosing border is hidden when `isBlock` is false.

## Why?

We discussed with @jasmussen what a sensible style guideline would be regarding these enclosing borders.

The main requirement from the design team is that we don't want the visible border when the options are icons, or to be more exact, when they are square-proportioned like the buttons in the block toolbar.

| Good | Bad |
|--------|-------|
|<img width="79" alt="Icon toggles with hidden border" src="https://user-images.githubusercontent.com/555336/199527511-4eb35b04-461c-4d49-85c3-00ce35cd60c0.png">|<img width="84" alt="Icon toggles with visible border" src="https://user-images.githubusercontent.com/555336/199527474-b38fb412-7f15-4336-a2ca-f72fb4b0328f.png">|

In theory, non-icon options can also be square-proportioned when the text labels are short. And looking at @jasmussen's WIP mockups, it seems possible that not all icon buttons will be square-proportioned. But who knows what will happen. My assessment is that there's still a good amount of uncertainty on what our eventual product requirements are going to be here.

Hence, the main goal of this PR is to **accomplish the border-hiding in a minimum viable way** without mucking with the API prematurely. I see two approaches:

1. Bring back the `__experimentalIsBorderless` prop so consumers set it explicitly. The downside is that the consumers need to be aware of the style guideline, and when that guideline changes, they'll need to update all their instances.
2. Use the `isBlock` prop as a proxy to determine whether it needs a border. Looking at the Gutenberg codebase, all instances that use text options have the `isBlock` prop enabled. All instances with icon options have it disabled.

I think number 2 is the minimum viable approach that will leave the least amount of tech debt down the line when requirements change and we need to change the API in some way. (This includes the possibility of splitting ToggleGroupControl into two components so one of them can handle the square-proportion case specifically.)

## Testing Instructions

1. `npm run storybook:dev` and see the stories/docs for ToggleGroupControl. The enclosing border (when unhovered & unfocused) should only be visible when `isBlock && ! isDeselectable` .
2. `npm run dev` and smoke test some ToggleGroupControl instances in the editor sidebar.