### PR TITLE
Layout: Remove duplicate output of existing classnames in layout classnames

### DIFF
--- a/packages/block-editor/src/hooks/layout.js
+++ b/packages/block-editor/src/hooks/layout.js
@@ -385,8 +385,7 @@ export const withLayoutStyles = createHigherOrderComponent(
 		}
 
 		// Attach a `wp-container-` id-based class name as well as a layout class name such as `is-layout-flex`.
-		const className = classnames(
-			props?.className,
+		const layoutClassNames = classnames(
 			{
 				[ `wp-container-${ id }` ]: shouldRenderLayoutStyles && !! css, // Only attach a container class if there is generated CSS to be attached.
 			},
@@ -410,7 +409,7 @@ export const withLayoutStyles = createHigherOrderComponent(
 					) }
 				<BlockListBlock
 					{ ...props }
-					__unstableLayoutClassNames={ className }
+					__unstableLayoutClassNames={ layoutClassNames }
 				/>
 			</>
 		);


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Fix the issue raised in https://github.com/WordPress/gutenberg/pull/44600#issuecomment-1300856613 where existing classnames are accidentally included in `__unstableLayoutClassnames` resulting in the existing classnames being output twice.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

We used to output classnames to the outerwrapper so bundling `props?.className` was the right thing to do. Now that the layout classnames are passed to a different param, they should not include `props?.className`.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

Remove `props?.className` from the classnames that are passed to `__unstableLayoutClassnames`.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->

As raised by @ndiego, following the instructions in [the docs](https://developer.wordpress.org/block-editor/reference-guides/filters/block-filters/#editor-blocklistblock), we can add a custom classname to the `BlockListBlock`. Here is some example code that you can copy + paste to the bottom of `packages/block-editor/src/hooks/layout.js` to test out this problem:

```js
const withClientIdClassName = createHigherOrderComponent(
	( BlockListBlock ) => {
		return ( props ) => {
			return (
				<BlockListBlock
					{ ...props }
					className={ 'my-custom-class-block-' + props.clientId }
				/>
			);
		};
	},
	'withClientIdClassName'
);

wp.hooks.addFilter(
	'editor.BlockListBlock',
	'my-plugin/with-client-id-class-name',
	withClientIdClassName
);
```

1. With the above code applied and this PR _not_ applied, you should see double output of the `my-custom-class-block-` classname, _or_ if you opt the Cover block into `__experimentalLayout` you should also see this classname applied to the inner blocks wrapper where it shouldn't be.
2. With the above code applied _and_ this PR applied, there shouldn't be double output, and if you opt the Cover block in to layout, then the custom classname shouldn't be applied to the inner wrapper

## Screenshots or screencast <!-- if applicable -->

In the editor:

| Group block markup (before) | Group block markup (after) |
| --- | --- |
| ![image](https://user-images.githubusercontent.com/14988353/199617744-84d34ad9-a447-48ef-87a3-2230a6a8c7d9.png) | <img alt="image" src="https://user-images.githubusercontent.com/14988353/199617809-931766bd-191e-42a3-807b-4b6a006f0d8b.png"> |
