### PR TITLE
Shadow: Add UI tools to set custom shadow to a block

### DIFF
--- a/packages/block-library/src/button/block.json
+++ b/packages/block-library/src/button/block.json
@@ -66,6 +66,7 @@
 				"text": true
 			}
 		},
+		"shadow": true,
 		"typography": {
 			"fontSize": true,
 			"lineHeight": true,

--- a/packages/edit-site/src/components/global-styles/block-preview.js
+++ b/packages/edit-site/src/components/global-styles/block-preview.js
@@ -1,0 +1,71 @@
+/**
+ * WordPress dependencies
+ */
+import {
+	__unstableIframe as Iframe,
+    __unstableEditorStyles as EditorStyles,
+} from '@wordpress/block-editor';
+import { useMemo } from '@wordpress/element';
+
+/**
+ * Internal dependencies
+ */
+import { useGlobalStylesOutput } from './use-global-styles-output';
+import { useStyle } from './hooks';
+
+// const normalizedWidth = 248;
+const normalizedHeight = 152;
+
+
+// // NOTE: This is a very early prototype component to show preview of a block
+// it is created for the purpose of previewing box-shadow
+// and will eventually be replaced when https://github.com/WordPress/gutenberg/issues/42919 is complete 
+const BlockPreview = ( { label, name } ) => {
+    const [ styles ] = useGlobalStylesOutput();
+    const editorStyles = useMemo( () => {
+		if ( styles ) {
+			return [
+				...styles,
+				{
+					css: 'html{overflow:hidden}body{min-width: 0;padding: 0;border: none}',
+					isGlobalStyles: true,
+				}
+			];
+		}
+
+		return styles;
+	}, [ styles ] );
+
+    const wrapperStyles = {
+        position: 'absolute',
+        top: '0',
+        height: '100%',
+        width: '100%',
+        display: 'flex',
+        alignItems: 'center',
+        justifyContent: 'center'
+    };
+
+    // get the styles to render the preview
+    let blockStyles = { padding: '0.5rem 1rem', border: '1px solid' };
+    const [ shadow ] = useStyle( 'shadow', name );
+    blockStyles = { ...blockStyles, boxShadow: shadow };
+
+    return <>
+        <Iframe
+            className="edit-site-block-styles-preview__iframe"
+            head={ <EditorStyles styles={editorStyles} /> }
+            style={ {
+                height: normalizedHeight * 1,
+                visibility: 'visible',
+            } }
+            tabIndex={ -1 }
+        >
+            <div style={wrapperStyles}>
+                <p style={blockStyles}>{ label || 'Preview' }</p>
+            </div>
+        </Iframe>
+    </>
+}
+
+export default BlockPreview;

--- a/packages/edit-site/src/components/global-styles/context-menu.js
+++ b/packages/edit-site/src/components/global-styles/context-menu.js
@@ -10,6 +10,7 @@ import { __ } from '@wordpress/i18n';
  */
 import { useHasBorderPanel } from './border-panel';
 import { useHasColorPanel } from './color-utils';
+import { useHasShadowPanel } from './shadows-panel';
 import { useHasDimensionsPanel } from './dimensions-panel';
 import { useHasTypographyPanel } from './typography-panel';
 import { NavigationButtonAsItem } from './navigation-button';
@@ -17,6 +18,7 @@ import { NavigationButtonAsItem } from './navigation-button';
 function ContextMenu( { name, parentMenu = '' } ) {
 	const hasTypographyPanel = useHasTypographyPanel( name );
 	const hasColorPanel = useHasColorPanel( name );
+	const hasShadowPanel = useHasShadowPanel( name );
 	const hasBorderPanel = useHasBorderPanel( name );
 	const hasDimensionsPanel = useHasDimensionsPanel( name );
 	const hasLayoutPanel = hasBorderPanel || hasDimensionsPanel;
@@ -39,6 +41,15 @@ function ContextMenu( { name, parentMenu = '' } ) {
 					aria-label={ __( 'Colors styles' ) }
 				>
 					{ __( 'Colors' ) }
+				</NavigationButtonAsItem>
+			) }
+			{ hasShadowPanel && (
+				<NavigationButtonAsItem
+					icon={ color }
+					path={ parentMenu + '/shadows' }
+					aria-label={ __( 'Shadow styles' ) }
+				>
+					{ __( 'Shadows' ) }
 				</NavigationButtonAsItem>
 			) }
 			{ hasLayoutPanel && (

--- a/packages/edit-site/src/components/global-styles/hooks.js
+++ b/packages/edit-site/src/components/global-styles/hooks.js
@@ -201,6 +201,11 @@ export function getSupportedGlobalStylesPanels( name ) {
 		supportKeys.push( 'blockGap' );
 	}
 
+	// check for shadow support
+	if (blockType?.supports?.shadow) {
+		supportKeys.push( 'shadow' );
+	}
+
 	Object.keys( STYLE_PROPERTY ).forEach( ( styleName ) => {
 		if ( ! STYLE_PROPERTY[ styleName ].support ) {
 			return;

--- a/packages/edit-site/src/components/global-styles/screen-shadows.js
+++ b/packages/edit-site/src/components/global-styles/screen-shadows.js
@@ -1,0 +1,103 @@
+/**
+ * External dependencies
+ */
+import styled from '@emotion/styled';
+
+/**
+ * WordPress dependencies
+ */
+import { __ } from '@wordpress/i18n';
+import {
+	__experimentalVStack as VStack,
+	Button,
+	Panel,
+} from '@wordpress/components';
+import { plus } from '@wordpress/icons';
+
+/**
+ * Internal dependencies
+ */
+import ScreenHeader from './header';
+import { useStyle } from './hooks';
+import Subtitle from './subtitle';
+import BlockPreview from './block-preview';
+import { getShadowString, parseShadowString } from './shadow-utils';
+import { ShadowPanel } from './shadows-panel';
+
+const ShadowsContainer = styled.div`
+	// NOTE: this is a temporary component to add left and right borders to Panel
+	// if the Panel is the finalized component, then it needs to be updated to have borders on all sides based on a prop
+	// and this component will be removed.
+	& .components-panel__body {
+		border-left: 1px solid #e0e0e0;
+		border-right: 1px solid #e0e0e0;
+	}
+`;
+
+function ScreenShadows( { name } ) {
+	const [ shadow, setShadow ] = useStyle( 'shadow', name );
+	// if given shadow is an array, convert to string
+	const shadows = parseShadowString([].concat(shadow).flat().join(', '));
+
+	function handleShadowChange(newShadow, index) {
+		const shadowsCopy = [...shadows];
+		shadowsCopy[index] = newShadow;
+		const shadowString = getShadowString(shadowsCopy);
+		setShadow(shadowString);
+	}
+
+	function handleShadowDelete(index) {
+		const shadowsCopy = [...shadows];
+		shadowsCopy.splice(index, 1);
+		const shadowString = getShadowString(shadowsCopy);
+		setShadow(shadowString);
+	}
+
+	function addNewShadow() {
+		const newShadow = parseShadowString('5px 5px 0 0 var(--wp--preset--color--primary)').shift();
+		handleShadowChange(newShadow, shadows.length);
+	}
+
+	return (
+		<>
+			<ScreenHeader
+				title={ __( 'Shadows' ) }
+				description={ __(
+					'Manage block shadows of different global elements on the site.'
+				) }
+			/>
+
+			<div className="edit-site-global-styles-screen-colors">
+				<VStack spacing={ 5 }>
+
+					<VStack spacing={ 3 }>
+						<Subtitle>{ __( 'Preview' ) }</Subtitle>
+						<BlockPreview label={__( 'Preview' )} name={ name } />
+					</VStack>
+
+					<VStack spacing={ 3 }>
+						<Subtitle>{ __( 'Shadows' ) }</Subtitle>
+
+						<Panel>
+							<ShadowsContainer>
+								{ shadows.map((shadowObj, index) => 
+									<ShadowPanel 
+										key={index} 
+										shadow={shadowObj} 
+										onChange={(s) => handleShadowChange(s, index)} 
+										onDelete={() => handleShadowDelete(index)} />
+									)
+								}
+							</ShadowsContainer>
+						</Panel>
+
+						<Button variant='tertiary' icon={plus} onClick={addNewShadow}>{__( 'Add new shadow' )}</Button>
+					</VStack>
+					
+				</VStack>
+			</div>
+		</>
+	);
+}
+
+export default ScreenShadows;

--- a/packages/edit-site/src/components/global-styles/shadow-utils.js
+++ b/packages/edit-site/src/components/global-styles/shadow-utils.js
@@ -1,0 +1,51 @@
+
+const SHADOWS_REG = /,(?![^\(]*\))/
+const SHADOW_PARTS_REG = /\s(?![^(]*\))/
+
+export function parseShadowString(shadowStr) {
+    try {
+        const shadows = shadowStr.split(SHADOWS_REG).map(parseSingleShadow);
+        return shadows.filter(shadow => !!shadow);
+    } catch (error) {
+        return [];
+    }
+}
+
+function parseSingleShadow(shadow) {
+    shadow  = shadow.trim();
+
+    // check if the string is valid value for box-shadow
+    // this will be extended to parse presets, but for now returning any invalid string
+    const isValidShadow = CSS.supports('box-shadow', shadow);
+    if ( !isValidShadow ) return null;
+    
+    const parts = shadow.split(SHADOW_PARTS_REG);
+    // check if shadow had inset
+    const inset = parts.includes('inset');
+    // check for the color right to left as per the CSS spec
+    const color = parts.reverse().filter(p => CSS.supports('color', p)).shift()
+    // remove inset and color to capture remaining values
+    const [offsetX, offsetY, blur, spread] = parts.filter(p => p!=='inset' && p!==color).reverse()
+    
+    return {
+        offsetX,
+        offsetY,
+        blur,
+        spread,
+        color,
+        inset,
+    }
+}
+
+export function getShadowString(shadows) {
+    if ( !Array.isArray(shadows) ) return ''
+
+    return shadows.map(shadow => {
+        let str = `${shadow.offsetX || 0} ${shadow.offsetY || 0}`;
+        str += shadow.blur ? ` ${shadow.blur}` : '';
+        str += shadow.spread ? ` ${shadow.spread}` : '';
+        str += shadow.color ? ` ${shadow.color}` : '';
+        str += shadow.inset ? ` inset` : '';
+        return str;
+    }).join(', ')
+}

--- a/packages/edit-site/src/components/global-styles/shadows-panel.js
+++ b/packages/edit-site/src/components/global-styles/shadows-panel.js
@@ -1,0 +1,221 @@
+/**
+ * WordPress dependencies
+ */
+ import { __ } from '@wordpress/i18n';
+ import {
+     __experimentalHStack as HStack,
+     __experimentalVStack as VStack,
+     __experimentalUnitControl as UnitControl,
+     __experimentalGrid as Grid,
+     __experimentalParseQuantityAndUnitFromRawValue as parseQuantityAndUnitFromRawValue,
+     __experimentalUseCustomUnits as useCustomUnits,
+     __experimentalDropdownContentWrapper as DropdownContentWrapper,
+     BaseControl,
+     RangeControl,
+     FlexItem,
+     ColorIndicator,
+     Button,
+     PanelBody,
+     PanelRow,
+     ToggleControl,
+     Dropdown,
+ } from '@wordpress/components';
+import { more, trash } from '@wordpress/icons';
+import { useState } from '@wordpress/element';
+import { 
+    __experimentalColorGradientControl as ColorGradientControl,
+    __experimentalUseMultipleOriginColorsAndGradients as useMultipleOriginColorsAndGradients
+} from '@wordpress/block-editor';
+
+/**
+ * Internal dependencies
+ */
+import { getSupportedGlobalStylesPanels } from './hooks';
+
+
+export function useHasShadowPanel( name ) {
+    const supports = getSupportedGlobalStylesPanels( name );
+    return name && supports.includes( 'shadow' );
+}
+
+export function ShadowPanel( { name, shadow, onChange, isPreset, onDelete } ) {
+    const panelTitle = name || __( 'Custom shadow' );
+    const panelIcon = isPreset ? more : null;
+
+	function handleValueChange(property, value) {
+		onChange({...shadow, [property]: value});
+	}
+
+	return (
+		<PanelBody title={ panelTitle } icon={ panelIcon } initialOpen={ false }>
+			<PanelRow>
+				<VStack>
+					<ShadowInputControl label={__( 'Horizontal Offset' )} value={shadow.offsetX} onChange={(value) => handleValueChange('offsetX', value)} />
+					<ShadowInputControl label={__( 'Vertical Offset' )} value={shadow.offsetY} onChange={(value) => handleValueChange('offsetY', value)} />
+					<ShadowInputControl label={__( 'Blur' )} value={shadow.blur} min={0} onChange={(value) => handleValueChange('blur', value)} />
+					<ShadowInputControl label={__( 'Spread' )} value={shadow.spread} onChange={(value) => handleValueChange('spread', value)} />
+                    
+                    <Grid columns={2} align="center">
+                        <ShadowColorDropdown label={__( 'Color' )} colorValue={shadow.color} onChange={ (value) => handleValueChange('color', value) } />
+                        <ToggleControl
+                            label={__( 'Inset?' )}
+                            checked={ shadow.inset }
+                            onChange={ (value) => handleValueChange('inset', value) }
+                        />
+                    </Grid> 
+                    
+                    <Button variant='tertiary' icon={trash} onClick={onDelete}>{ __( 'Delete shadow' ) }</Button>
+				</VStack>
+			</PanelRow>
+		</PanelBody>
+	);
+}
+
+function ShadowInputControl({label, value, min, max, onChange}) {
+    const [input, setInput] = useState(value || '0px');
+    const [minValue, setMinValue] = useState(min === undefined ? -50 : min);
+    const [maxValue, setMaxValue] = useState(max === undefined ? 50 : max);
+
+    const unit = parseQuantityAndUnitFromRawValue(input)[ 1 ] || 'px';
+    const units = useCustomUnits( {
+        availableUnits: [ 'px', 'em', 'rem' ], // useSetting( 'spacing.units' ) ||
+    } );
+    const unitConfig = units && units.find( ( item ) => item.value === unit );
+    const step = unitConfig?.step || 1;
+
+    const handleInputChange = (newInput) => {
+        setInput(newInput);
+        onChange(newInput);
+    }
+
+    const handleSliderChange = ( next ) => {
+        const newInput = next !== undefined ? `${ next }${ unit }` : '0px';
+        handleInputChange(newInput);
+    }
+
+    const handleUnitChange = (unit) => {
+        // setMinValue()
+        // setMaxValue()
+    }
+
+    return <>
+        <BaseControl.VisualLabel as='legend' style={{margin: 0}}>
+            { label }
+        </BaseControl.VisualLabel>
+        <Grid columns={2} align="center">
+            <UnitControl
+                aria-label={ __( 'X' ) }
+                disableUnits={ false }
+                isOnly
+                value={ input }
+                onChange={ handleInputChange }
+                onUnitChange = { handleUnitChange }
+                size={ '__unstable-large' }
+                units={units}
+            />
+            <RangeControl
+                label={ label }
+                hideLabelFromVision
+                value={ input }
+                min={ minValue }
+                max={ maxValue }
+                initialPosition={ 0 }
+                withInputField={ false }
+                onChange={ handleSliderChange }
+                step={ step }
+                __nextHasNoMarginBottom
+            />
+        </Grid>
+    </>
+}
+
+const renderToggle =
+	( settings ) =>
+	( { onToggle, isOpen } ) => {
+		const { colorValue, label } = settings;
+
+		const toggleProps = {
+			onClick: onToggle,
+			className: 'block-editor-panel-color-gradient-settings__dropdown is-open',
+			'aria-expanded': isOpen,
+		};
+
+		return (
+			<Button { ...toggleProps }>
+				<LabeledColorIndicator
+					colorValue={ colorValue }
+					label={ label }
+				/>
+			</Button>
+		);
+	};
+
+const ShadowColorDropdown = ({label, colorValue, onChange}) => {
+
+    const {
+        colors,
+        gradients,
+        disableCustomColors,
+        disableCustomGradients,
+    } = useMultipleOriginColorsAndGradients();
+
+    const setting = {
+        colorValue,
+        label,
+        onColorChange: onChange,
+        // onGradientChange: onChange,
+    };
+    const enableAlpha = false;
+
+    const controlProps = {
+        clearable: false,
+        colorValue: setting.colorValue,
+        colors,
+        disableCustomColors,
+        disableCustomGradients,
+        enableAlpha,
+        gradientValue: setting.gradientValue,
+        gradients,
+        label: setting.label,
+        onColorChange: setting.onColorChange,
+        onGradientChange: setting.onGradientChange,
+        showTitle: false,
+        __experimentalHasMultipleOrigins: true,
+        __experimentalIsRenderedInSidebar: true,
+        ...setting,
+    };
+
+    const popoverProps = {
+        placement: 'left-start',
+        offset: 36,
+        shift: true,
+    };
+
+    return <Dropdown
+        popoverProps={ popoverProps }
+        className="block-editor-tools-panel-color-gradient-settings__dropdown"
+        renderToggle = { renderToggle({colorValue, label })}
+        renderContent={ () => (
+            <DropdownContentWrapper paddingSize="none">
+                <div className="block-editor-panel-color-gradient-settings__dropdown-content">
+                    <ColorGradientControl {...controlProps} />
+                </div>
+            </DropdownContentWrapper>
+        ) }
+    />
+};
+
+const LabeledColorIndicator = ( { colorValue, label } ) => (
+	<HStack justify="flex-start">
+		<ColorIndicator
+			className="block-editor-panel-color-gradient-settings__color-indicator"
+			colorValue={ colorValue }
+		/>
+		<FlexItem
+			className="block-editor-panel-color-gradient-settings__color-name"
+			title={ label }
+		>
+			{ label }
+		</FlexItem>
+	</HStack>
+);

--- a/packages/edit-site/src/components/global-styles/ui.js
+++ b/packages/edit-site/src/components/global-styles/ui.js
@@ -22,6 +22,7 @@ import ScreenTextColor from './screen-text-color';
 import ScreenLinkColor from './screen-link-color';
 import ScreenHeadingColor from './screen-heading-color';
 import ScreenButtonColor from './screen-button-color';
+import ScreenShadows from './screen-shadows';
 import ScreenLayout from './screen-layout';
 import ScreenStyleVariations from './screen-style-variations';
 
@@ -106,6 +107,10 @@ function ContextScreens( { name } ) {
 				path={ parentMenu + '/colors/button' }
 			>
 				<ScreenButtonColor name={ name } />
+			</GlobalStylesNavigationScreen>
+
+			<GlobalStylesNavigationScreen path={ parentMenu + '/shadows' }>
+				<ScreenShadows name={ name } />
 			</GlobalStylesNavigationScreen>
 
 			<GlobalStylesNavigationScreen path={ parentMenu + '/layout' }>


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

> ** Work in progress: do not review the code yet! **. 
Creating this PR to gain some early design feedback.

This add the necessary UI tooling to add, edit shadow of a block in global styles.
To be able to test the `support` is enabled for the `Button` block only.

**NOTE:** A preview component is introduced to view the shadow changes in live action. This component doesn't render actual block (such as button) yet. It is just a rectangle with global styles applied. It will be replaced with the implementation of #42919

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
1. Activate a block theme such as archeo.
2. Go to global styles -> Blocks -> `Button` -> Shadows
3. Click `Add new shadow`
4. Expand newly added shadow and try setting the values and view the preview.
5. It is possible to add/delete multiple shadows
6. Save the changes
7. View the buttons on the frontend with given shadow settings.

## Screenshots or screencast <!-- if applicable -->

![shadow-ui](https://user-images.githubusercontent.com/1935113/199676102-6b4dba8c-e815-4830-8ee5-c328d4a1e92c.gif)

<img width="418" alt="image" src="https://user-images.githubusercontent.com/1935113/199673080-35a2ba02-115c-40d9-a2f5-7c6c3582d949.png">

## Issues

Related issues: #44651
