### PR TITLE
Template Parts: Add an option to import widgets from the sidebars

### DIFF
--- a/lib/compat/wordpress-6.2/rest-api.php
+++ b/lib/compat/wordpress-6.2/rest-api.php
@@ -101,3 +101,18 @@ function gutenberg_register_global_styles_endpoints() {
 	$editor_settings->register_routes();
 }
 add_action( 'rest_api_init', 'gutenberg_register_global_styles_endpoints' );
+
+/**
+ * Updates REST API response for the sidebars and marks them as 'inactive'.
+ *
+ * Note: This can be a part of the `prepare_item_for_response` in `class-wp-rest-sidebars-controller.php`.
+ *
+ * @param WP_REST_Response $response The sidebar response object.
+ * @return WP_REST_Response $response Updated response object.
+ */
+function gutenberg_modify_rest_sidebars_response( $response ) {
+	$response->data['status'] = wp_is_block_theme() ? 'inactive' : 'active';
+
+	return $response;
+}
+add_filter( 'rest_prepare_sidebar', 'gutenberg_modify_rest_sidebars_response' );

--- a/lib/compat/wordpress-6.2/theme.php
+++ b/lib/compat/wordpress-6.2/theme.php
@@ -1,0 +1,23 @@
+<?php
+/**
+ * Theme overrides for WP 6.2.
+ *
+ * @package gutenberg
+ */
+
+/**
+ * Store legacy sidebars for later use by block themes.
+ *
+ * Note: This can be a part of the `switch_theme` method in `wp-includes/theme.php`.
+ *
+ * @param string   $new_name  Name of the new theme.
+ * @param WP_Theme $new_theme WP_Theme instance of the new theme.
+ */
+function gutenberg_set_legacy_sidebars( $new_name, $new_theme ) {
+	global $wp_registered_sidebars;
+
+	if ( $new_theme->is_block_theme() ) {
+		set_theme_mod( 'wp_legacy_sidebars', $wp_registered_sidebars );
+	}
+}
+add_action( 'switch_theme', 'gutenberg_set_legacy_sidebars', 10, 2 );

--- a/lib/compat/wordpress-6.2/widgets.php
+++ b/lib/compat/wordpress-6.2/widgets.php
@@ -6,6 +6,11 @@
  */
 
 if ( ! function_exists( '_wp_block_theme_stub_sidebars' ) ) {
+	/**
+	 * Register the previous theme's sidebars for the block themes.
+	 *
+	 * @return void
+	 */
 	function _wp_block_theme_stub_sidebars() {
 		global $wp_registered_sidebars;
 

--- a/lib/compat/wordpress-6.2/widgets.php
+++ b/lib/compat/wordpress-6.2/widgets.php
@@ -1,0 +1,27 @@
+<?php
+/**
+ * Core Widget APIs for WP 6.2.
+ *
+ * @package gutenberg
+ */
+
+if ( ! function_exists( '_wp_block_theme_stub_sidebars' ) ) {
+	function _wp_block_theme_stub_sidebars() {
+		global $wp_registered_sidebars;
+
+		if ( ! wp_is_block_theme() ) {
+			return;
+		}
+
+		$legacy_sidebars = get_theme_mod( 'wp_legacy_sidebars' );
+		if ( empty( $legacy_sidebars ) ) {
+			return;
+		}
+
+		// Don't use `register_sidebar` since it will enable the `widgets` support for a theme.
+		foreach ( $legacy_sidebars as $sidebar ) {
+			$wp_registered_sidebars[ $sidebar['id'] ] = $sidebar;
+		}
+	}
+	add_action( 'widgets_init', '_wp_block_theme_stub_sidebars' );
+}

--- a/lib/load.php
+++ b/lib/load.php
@@ -85,6 +85,8 @@ require __DIR__ . '/compat/wordpress-6.2/class-wp-theme-json-6-2.php';
 require __DIR__ . '/compat/wordpress-6.2/edit-form-blocks.php';
 require __DIR__ . '/compat/wordpress-6.2/site-editor.php';
 require __DIR__ . '/compat/wordpress-6.2/block-editor-settings.php';
+require __DIR__ . '/compat/wordpress-6.2/theme.php';
+require __DIR__ . '/compat/wordpress-6.2/widgets.php';
 
 // Experimental features.
 remove_action( 'plugins_loaded', '_wp_theme_json_webfonts_handler' ); // Turns off WP 6.0's stopgap handler for Webfonts API.

--- a/package-lock.json
+++ b/package-lock.json
@@ -18543,6 +18543,7 @@
 				"@wordpress/style-engine": "file:packages/style-engine",
 				"@wordpress/url": "file:packages/url",
 				"@wordpress/viewport": "file:packages/viewport",
+				"@wordpress/widgets": "file:packages/widgets",
 				"classnames": "^2.3.1",
 				"colord": "^2.9.2",
 				"downloadjs": "^1.4.7",

--- a/package-lock.json
+++ b/package-lock.json
@@ -18506,6 +18506,7 @@
 				"@wordpress/url": "file:packages/url",
 				"@wordpress/viewport": "file:packages/viewport",
 				"@wordpress/warning": "file:packages/warning",
+				"@wordpress/widgets": "file:packages/widgets",
 				"classnames": "^2.3.1",
 				"lodash": "^4.17.21",
 				"memize": "^1.1.0",

--- a/packages/block-library/src/template-part/edit/advanced-controls.js
+++ b/packages/block-library/src/template-part/edit/advanced-controls.js
@@ -7,12 +7,18 @@ import { sprintf, __ } from '@wordpress/i18n';
 import { InspectorControls } from '@wordpress/block-editor';
 import { useSelect } from '@wordpress/data';
 
+/**
+ * Internal dependencies
+ */
+import { TemplatePartImportControls } from './import-controls';
+
 export function TemplatePartAdvancedControls( {
 	tagName,
 	setAttributes,
 	isEntityAvailable,
 	templatePartId,
 	defaultWrapper,
+	hasInnerBlocks,
 } ) {
 	const [ area, setArea ] = useEntityProp(
 		'postType',
@@ -87,6 +93,12 @@ export function TemplatePartAdvancedControls( {
 				value={ tagName || '' }
 				onChange={ ( value ) => setAttributes( { tagName: value } ) }
 			/>
+			{ ! hasInnerBlocks && (
+				<TemplatePartImportControls
+					area={ area }
+					setAttributes={ setAttributes }
+				/>
+			) }
 		</InspectorControls>
 	);
 }

--- a/packages/block-library/src/template-part/edit/import-controls.js
+++ b/packages/block-library/src/template-part/edit/import-controls.js
@@ -32,20 +32,32 @@ export function TemplateParetImportControls( { area, setAttributes } ) {
 	);
 
 	const options = useMemo( () => {
-		if ( ! sidebars ) {
+		const sidebarOptions = ( sidebars ?? [] )
+			.filter(
+				( widgetArea ) =>
+					widgetArea.status === 'active' &&
+					widgetArea.widgets.length > 0
+			)
+			.map( ( widgetArea ) => {
+				return {
+					value: widgetArea.id,
+					label: widgetArea.name,
+				};
+			} );
+
+		if ( ! sidebarOptions.length ) {
 			return [];
 		}
 
 		return [
 			{ value: '', label: __( 'Select sidebar' ) },
-			...sidebars.map( ( widgetArea ) => {
-				return {
-					value: widgetArea.id,
-					label: widgetArea.name,
-				};
-			} ),
+			...sidebarOptions,
 		];
 	}, [ sidebars ] );
+
+	if ( ! options.length ) {
+		return null;
+	}
 
 	async function createFromWidgets( event ) {
 		event.preventDefault();

--- a/packages/block-library/src/template-part/edit/import-controls.js
+++ b/packages/block-library/src/template-part/edit/import-controls.js
@@ -15,7 +15,7 @@ import { useCreateTemplatePartFromBlocks } from './utils/hooks';
 import { transformWidgetToBlock } from './utils/transformers';
 
 export function TemplateParetImportControls( { area, setAttributes } ) {
-	const [ sidebar, setSidebar ] = useState( '' );
+	const [ selectedSidebar, setSelectedSidebar ] = useState( '' );
 	const [ isBusy, setIsBusy ] = useState( false );
 
 	const registry = useRegistry();
@@ -62,21 +62,25 @@ export function TemplateParetImportControls( { area, setAttributes } ) {
 	async function createFromWidgets( event ) {
 		event.preventDefault();
 
-		if ( isBusy || ! sidebar ) {
+		if ( isBusy || ! selectedSidebar ) {
 			return;
 		}
 
 		setIsBusy( true );
 
+		const sidebar = options.find(
+			( { value } ) => value === selectedSidebar
+		);
 		const { getWidgets } = registry.resolveSelect( coreStore );
 
+		// The widgets API always returns a successful response.
 		const widgets = await getWidgets( {
-			sidebar,
+			sidebar: sidebar.value,
 			_embed: 'about',
 		} );
 		const blocks = widgets.map( transformWidgetToBlock );
 
-		await createFromBlocks( blocks, sidebar );
+		await createFromBlocks( blocks, sidebar.label );
 
 		setIsBusy( false );
 	}
@@ -86,10 +90,10 @@ export function TemplateParetImportControls( { area, setAttributes } ) {
 			<PanelBody title={ __( 'Import' ) }>
 				<form onSubmit={ createFromWidgets }>
 					<SelectControl
-						label={ __( 'Widget areas' ) }
-						value={ sidebar }
+						label={ __( 'Sidebars' ) }
+						value={ selectedSidebar }
 						options={ options }
-						onChange={ ( value ) => setSidebar( value ) }
+						onChange={ ( value ) => setSelectedSidebar( value ) }
 						hideLabelFromVision
 						__next36pxDefaultSize
 					/>
@@ -97,7 +101,7 @@ export function TemplateParetImportControls( { area, setAttributes } ) {
 						variant="primary"
 						type="submit"
 						isBusy={ isBusy }
-						aria-disabled={ isBusy || ! sidebar }
+						aria-disabled={ isBusy || ! selectedSidebar }
 					>
 						{ __( 'Import' ) }
 					</Button>

--- a/packages/block-library/src/template-part/edit/import-controls.js
+++ b/packages/block-library/src/template-part/edit/import-controls.js
@@ -1,7 +1,7 @@
 /**
  * WordPress dependencies
  */
-import { __ } from '@wordpress/i18n';
+import { __, sprintf } from '@wordpress/i18n';
 import { useMemo, useState } from '@wordpress/element';
 import { useSelect, useRegistry } from '@wordpress/data';
 import { InspectorControls } from '@wordpress/block-editor';
@@ -80,7 +80,11 @@ export function TemplateParetImportControls( { area, setAttributes } ) {
 		} );
 		const blocks = widgets.map( transformWidgetToBlock );
 
-		await createFromBlocks( blocks, sidebar.label );
+		await createFromBlocks(
+			blocks,
+			/* translators: %s: name of the widget area */
+			sprintf( __( 'Widget area: %s' ), sidebar.label )
+		);
 
 		setIsBusy( false );
 	}

--- a/packages/block-library/src/template-part/edit/import-controls.js
+++ b/packages/block-library/src/template-part/edit/import-controls.js
@@ -1,0 +1,96 @@
+/**
+ * WordPress dependencies
+ */
+import { __ } from '@wordpress/i18n';
+import { useMemo, useState } from '@wordpress/element';
+import { useSelect, useRegistry } from '@wordpress/data';
+import { InspectorControls } from '@wordpress/block-editor';
+import { Button, PanelBody, SelectControl } from '@wordpress/components';
+import { store as coreStore } from '@wordpress/core-data';
+
+/**
+ * Internal dependencies
+ */
+import { useCreateTemplatePartFromBlocks } from './utils/hooks';
+import { transformWidgetToBlock } from './utils/transformers';
+
+export function TemplateParetImportControls( { area, setAttributes } ) {
+	const [ sidebar, setSidebar ] = useState( '' );
+	const [ isBusy, setIsBusy ] = useState( false );
+
+	const registry = useRegistry();
+	const sidebars = useSelect( ( select ) => {
+		return select( coreStore ).getSidebars( {
+			per_page: -1,
+			_fields: 'id,name,description,status,widgets',
+		} );
+	}, [] );
+
+	const createFromBlocks = useCreateTemplatePartFromBlocks(
+		area,
+		setAttributes
+	);
+
+	const options = useMemo( () => {
+		if ( ! sidebars ) {
+			return [];
+		}
+
+		return [
+			{ value: '', label: __( 'Select sidebar' ) },
+			...sidebars.map( ( widgetArea ) => {
+				return {
+					value: widgetArea.id,
+					label: widgetArea.name,
+				};
+			} ),
+		];
+	}, [ sidebars ] );
+
+	async function createFromWidgets( event ) {
+		event.preventDefault();
+
+		if ( isBusy || ! sidebar ) {
+			return;
+		}
+
+		setIsBusy( true );
+
+		const { getWidgets } = registry.resolveSelect( coreStore );
+
+		const widgets = await getWidgets( {
+			sidebar,
+			_embed: 'about',
+		} );
+		const blocks = widgets.map( transformWidgetToBlock );
+
+		await createFromBlocks( blocks, sidebar );
+
+		setIsBusy( false );
+	}
+
+	return (
+		<InspectorControls>
+			<PanelBody title={ __( 'Import' ) }>
+				<form onSubmit={ createFromWidgets }>
+					<SelectControl
+						label={ __( 'Widget areas' ) }
+						value={ sidebar }
+						options={ options }
+						onChange={ ( value ) => setSidebar( value ) }
+						hideLabelFromVision
+						__next36pxDefaultSize
+					/>
+					<Button
+						variant="primary"
+						type="submit"
+						isBusy={ isBusy }
+						aria-disabled={ isBusy || ! sidebar }
+					>
+						{ __( 'Import' ) }
+					</Button>
+				</form>
+			</PanelBody>
+		</InspectorControls>
+	);
+}

--- a/packages/block-library/src/template-part/edit/import-controls.js
+++ b/packages/block-library/src/template-part/edit/import-controls.js
@@ -44,7 +44,11 @@ export function TemplatePartImportControls( { area, setAttributes } ) {
 
 	const options = useMemo( () => {
 		const sidebarOptions = ( sidebars ?? [] )
-			.filter( ( widgetArea ) => widgetArea.widgets.length > 0 )
+			.filter(
+				( widgetArea ) =>
+					widgetArea.id !== 'wp_inactive_widgets' &&
+					widgetArea.widgets.length > 0
+			)
 			.map( ( widgetArea ) => {
 				return {
 					value: widgetArea.id,

--- a/packages/block-library/src/template-part/edit/import-controls.js
+++ b/packages/block-library/src/template-part/edit/import-controls.js
@@ -6,10 +6,10 @@ import { useMemo, useState } from '@wordpress/element';
 import { useDispatch, useSelect, useRegistry } from '@wordpress/data';
 import {
 	Button,
-	Flex,
 	FlexBlock,
 	FlexItem,
 	SelectControl,
+	__experimentalHStack as HStack,
 } from '@wordpress/components';
 import {
 	switchToBlockType,
@@ -145,7 +145,7 @@ export function TemplatePartImportControls( { area, setAttributes } ) {
 	}
 
 	return (
-		<Flex as="form" onSubmit={ createFromWidgets }>
+		<HStack as="form" onSubmit={ createFromWidgets }>
 			<FlexBlock>
 				<SelectControl
 					label={ __( 'Import widget area' ) }
@@ -172,6 +172,6 @@ export function TemplatePartImportControls( { area, setAttributes } ) {
 					{ __( 'Import' ) }
 				</Button>
 			</FlexItem>
-		</Flex>
+		</HStack>
 	);
 }

--- a/packages/block-library/src/template-part/edit/import-controls.js
+++ b/packages/block-library/src/template-part/edit/import-controls.js
@@ -56,10 +56,6 @@ export function TemplatePartImportControls( { area, setAttributes } ) {
 		];
 	}, [ sidebars ] );
 
-	if ( ! options.length ) {
-		return null;
-	}
-
 	async function createFromWidgets( event ) {
 		event.preventDefault();
 
@@ -98,6 +94,7 @@ export function TemplatePartImportControls( { area, setAttributes } ) {
 					value={ selectedSidebar }
 					options={ options }
 					onChange={ ( value ) => setSelectedSidebar( value ) }
+					disabled={ ! options.length }
 					__next36pxDefaultSize
 					__nextHasNoMarginBottom
 				/>

--- a/packages/block-library/src/template-part/edit/import-controls.js
+++ b/packages/block-library/src/template-part/edit/import-controls.js
@@ -4,7 +4,13 @@
 import { __, sprintf } from '@wordpress/i18n';
 import { useMemo, useState } from '@wordpress/element';
 import { useSelect, useRegistry } from '@wordpress/data';
-import { Button, SelectControl } from '@wordpress/components';
+import {
+	Button,
+	Flex,
+	FlexBlock,
+	FlexItem,
+	SelectControl,
+} from '@wordpress/components';
 import { store as coreStore } from '@wordpress/core-data';
 
 /**
@@ -85,21 +91,32 @@ export function TemplatePartImportControls( { area, setAttributes } ) {
 	}
 
 	return (
-		<form onSubmit={ createFromWidgets }>
-			<SelectControl
-				label={ __( 'Import widget area' ) }
-				value={ selectedSidebar }
-				options={ options }
-				onChange={ ( value ) => setSelectedSidebar( value ) }
-			/>
-			<Button
-				variant="primary"
-				type="submit"
-				isBusy={ isBusy }
-				aria-disabled={ isBusy || ! selectedSidebar }
+		<Flex as="form" onSubmit={ createFromWidgets }>
+			<FlexBlock>
+				<SelectControl
+					label={ __( 'Import widget area' ) }
+					value={ selectedSidebar }
+					options={ options }
+					onChange={ ( value ) => setSelectedSidebar( value ) }
+					__next36pxDefaultSize
+					__nextHasNoMarginBottom
+				/>
+			</FlexBlock>
+			<FlexItem
+				style={ {
+					marginBottom: '8px',
+					marginTop: 'auto',
+				} }
 			>
-				{ __( 'Import' ) }
-			</Button>
-		</form>
+				<Button
+					variant="primary"
+					type="submit"
+					isBusy={ isBusy }
+					aria-disabled={ isBusy || ! selectedSidebar }
+				>
+					{ __( 'Import' ) }
+				</Button>
+			</FlexItem>
+		</Flex>
 	);
 }

--- a/packages/block-library/src/template-part/edit/import-controls.js
+++ b/packages/block-library/src/template-part/edit/import-controls.js
@@ -10,6 +10,7 @@ import {
 	FlexItem,
 	SelectControl,
 	__experimentalHStack as HStack,
+	__experimentalSpacer as Spacer,
 } from '@wordpress/components';
 import {
 	switchToBlockType,
@@ -145,33 +146,35 @@ export function TemplatePartImportControls( { area, setAttributes } ) {
 	}
 
 	return (
-		<HStack as="form" onSubmit={ createFromWidgets }>
-			<FlexBlock>
-				<SelectControl
-					label={ __( 'Import widget area' ) }
-					value={ selectedSidebar }
-					options={ options }
-					onChange={ ( value ) => setSelectedSidebar( value ) }
-					disabled={ ! options.length }
-					__next36pxDefaultSize
-					__nextHasNoMarginBottom
-				/>
-			</FlexBlock>
-			<FlexItem
-				style={ {
-					marginBottom: '8px',
-					marginTop: 'auto',
-				} }
-			>
-				<Button
-					variant="primary"
-					type="submit"
-					isBusy={ isBusy }
-					aria-disabled={ isBusy || ! selectedSidebar }
+		<Spacer marginBottom="4">
+			<HStack as="form" onSubmit={ createFromWidgets }>
+				<FlexBlock>
+					<SelectControl
+						label={ __( 'Import widget area' ) }
+						value={ selectedSidebar }
+						options={ options }
+						onChange={ ( value ) => setSelectedSidebar( value ) }
+						disabled={ ! options.length }
+						__next36pxDefaultSize
+						__nextHasNoMarginBottom
+					/>
+				</FlexBlock>
+				<FlexItem
+					style={ {
+						marginBottom: '8px',
+						marginTop: 'auto',
+					} }
 				>
-					{ __( 'Import' ) }
-				</Button>
-			</FlexItem>
-		</HStack>
+					<Button
+						variant="primary"
+						type="submit"
+						isBusy={ isBusy }
+						aria-disabled={ isBusy || ! selectedSidebar }
+					>
+						{ __( 'Import' ) }
+					</Button>
+				</FlexItem>
+			</HStack>
+		</Spacer>
 	);
 }

--- a/packages/block-library/src/template-part/edit/import-controls.js
+++ b/packages/block-library/src/template-part/edit/import-controls.js
@@ -4,8 +4,7 @@
 import { __, sprintf } from '@wordpress/i18n';
 import { useMemo, useState } from '@wordpress/element';
 import { useSelect, useRegistry } from '@wordpress/data';
-import { InspectorControls } from '@wordpress/block-editor';
-import { Button, PanelBody, SelectControl } from '@wordpress/components';
+import { Button, SelectControl } from '@wordpress/components';
 import { store as coreStore } from '@wordpress/core-data';
 
 /**
@@ -90,27 +89,21 @@ export function TemplatePartImportControls( { area, setAttributes } ) {
 	}
 
 	return (
-		<InspectorControls>
-			<PanelBody title={ __( 'Import widget area' ) }>
-				<form onSubmit={ createFromWidgets }>
-					<SelectControl
-						label={ __( 'Widget areas' ) }
-						value={ selectedSidebar }
-						options={ options }
-						onChange={ ( value ) => setSelectedSidebar( value ) }
-						hideLabelFromVision
-						__next36pxDefaultSize
-					/>
-					<Button
-						variant="primary"
-						type="submit"
-						isBusy={ isBusy }
-						aria-disabled={ isBusy || ! selectedSidebar }
-					>
-						{ __( 'Import' ) }
-					</Button>
-				</form>
-			</PanelBody>
-		</InspectorControls>
+		<form onSubmit={ createFromWidgets }>
+			<SelectControl
+				label={ __( 'Import widget area' ) }
+				value={ selectedSidebar }
+				options={ options }
+				onChange={ ( value ) => setSelectedSidebar( value ) }
+			/>
+			<Button
+				variant="primary"
+				type="submit"
+				isBusy={ isBusy }
+				aria-disabled={ isBusy || ! selectedSidebar }
+			>
+				{ __( 'Import' ) }
+			</Button>
+		</form>
 	);
 }

--- a/packages/block-library/src/template-part/edit/import-controls.js
+++ b/packages/block-library/src/template-part/edit/import-controls.js
@@ -14,7 +14,7 @@ import { store as coreStore } from '@wordpress/core-data';
 import { useCreateTemplatePartFromBlocks } from './utils/hooks';
 import { transformWidgetToBlock } from './utils/transformers';
 
-export function TemplateParetImportControls( { area, setAttributes } ) {
+export function TemplatePartImportControls( { area, setAttributes } ) {
 	const [ selectedSidebar, setSelectedSidebar ] = useState( '' );
 	const [ isBusy, setIsBusy ] = useState( false );
 

--- a/packages/block-library/src/template-part/edit/import-controls.js
+++ b/packages/block-library/src/template-part/edit/import-controls.js
@@ -32,11 +32,7 @@ export function TemplatePartImportControls( { area, setAttributes } ) {
 
 	const options = useMemo( () => {
 		const sidebarOptions = ( sidebars ?? [] )
-			.filter(
-				( widgetArea ) =>
-					widgetArea.status === 'active' &&
-					widgetArea.widgets.length > 0
-			)
+			.filter( ( widgetArea ) => widgetArea.widgets.length > 0 )
 			.map( ( widgetArea ) => {
 				return {
 					value: widgetArea.id,

--- a/packages/block-library/src/template-part/edit/import-controls.js
+++ b/packages/block-library/src/template-part/edit/import-controls.js
@@ -50,7 +50,7 @@ export function TemplatePartImportControls( { area, setAttributes } ) {
 		}
 
 		return [
-			{ value: '', label: __( 'Select sidebar' ) },
+			{ value: '', label: __( 'Select widget area' ) },
 			...sidebarOptions,
 		];
 	}, [ sidebars ] );
@@ -91,10 +91,10 @@ export function TemplatePartImportControls( { area, setAttributes } ) {
 
 	return (
 		<InspectorControls>
-			<PanelBody title={ __( 'Import' ) }>
+			<PanelBody title={ __( 'Import widget area' ) }>
 				<form onSubmit={ createFromWidgets }>
 					<SelectControl
-						label={ __( 'Sidebars' ) }
+						label={ __( 'Widget areas' ) }
 						value={ selectedSidebar }
 						options={ options }
 						onChange={ ( value ) => setSelectedSidebar( value ) }

--- a/packages/block-library/src/template-part/edit/index.js
+++ b/packages/block-library/src/template-part/edit/index.js
@@ -26,6 +26,7 @@ import { useState, createInterpolateElement } from '@wordpress/element';
  */
 import TemplatePartPlaceholder from './placeholder';
 import TemplatePartSelectionModal from './selection-modal';
+import { TemplateParetImportControls } from './import-controls';
 import { TemplatePartAdvancedControls } from './advanced-controls';
 import TemplatePartInnerBlocks from './inner-blocks';
 import { createTemplatePartId } from './utils/create-template-part-id';
@@ -135,6 +136,10 @@ export default function TemplatePartEdit( {
 	return (
 		<>
 			<RecursionProvider uniqueId={ templatePartId }>
+				<TemplateParetImportControls
+					area={ area }
+					setAttributes={ setAttributes }
+				/>
 				<TemplatePartAdvancedControls
 					tagName={ tagName }
 					setAttributes={ setAttributes }

--- a/packages/block-library/src/template-part/edit/index.js
+++ b/packages/block-library/src/template-part/edit/index.js
@@ -26,7 +26,7 @@ import { useState, createInterpolateElement } from '@wordpress/element';
  */
 import TemplatePartPlaceholder from './placeholder';
 import TemplatePartSelectionModal from './selection-modal';
-import { TemplateParetImportControls } from './import-controls';
+import { TemplatePartImportControls } from './import-controls';
 import { TemplatePartAdvancedControls } from './advanced-controls';
 import TemplatePartInnerBlocks from './inner-blocks';
 import { createTemplatePartId } from './utils/create-template-part-id';
@@ -136,7 +136,7 @@ export default function TemplatePartEdit( {
 	return (
 		<>
 			<RecursionProvider uniqueId={ templatePartId }>
-				<TemplateParetImportControls
+				<TemplatePartImportControls
 					area={ area }
 					setAttributes={ setAttributes }
 				/>

--- a/packages/block-library/src/template-part/edit/index.js
+++ b/packages/block-library/src/template-part/edit/index.js
@@ -26,7 +26,6 @@ import { useState, createInterpolateElement } from '@wordpress/element';
  */
 import TemplatePartPlaceholder from './placeholder';
 import TemplatePartSelectionModal from './selection-modal';
-import { TemplatePartImportControls } from './import-controls';
 import { TemplatePartAdvancedControls } from './advanced-controls';
 import TemplatePartInnerBlocks from './inner-blocks';
 import { createTemplatePartId } from './utils/create-template-part-id';
@@ -136,16 +135,13 @@ export default function TemplatePartEdit( {
 	return (
 		<>
 			<RecursionProvider uniqueId={ templatePartId }>
-				<TemplatePartImportControls
-					area={ area }
-					setAttributes={ setAttributes }
-				/>
 				<TemplatePartAdvancedControls
 					tagName={ tagName }
 					setAttributes={ setAttributes }
 					isEntityAvailable={ isEntityAvailable }
 					templatePartId={ templatePartId }
 					defaultWrapper={ areaObject.tagName }
+					hasInnerBlocks={ innerBlocks.length > 0 }
 				/>
 				{ isPlaceholder && (
 					<TagName { ...blockProps }>

--- a/packages/block-library/src/template-part/edit/utils/transformers.js
+++ b/packages/block-library/src/template-part/edit/utils/transformers.js
@@ -1,0 +1,37 @@
+/**
+ * WordPress dependencies
+ */
+import { createBlock, parse } from '@wordpress/blocks';
+
+/**
+ * Converts a widget entity record into a block.
+ *
+ * @param {Object} widget The widget entity record.
+ * @return {Object} a block (converted from the entity record).
+ */
+export function transformWidgetToBlock( widget ) {
+	if ( widget.id_base === 'block' ) {
+		const parsedBlocks = parse( widget.instance.raw.content, {
+			__unstableSkipAutop: true,
+		} );
+		if ( ! parsedBlocks.length ) {
+			return createBlock( 'core/paragraph', {}, [] );
+		}
+
+		return parsedBlocks[ 0 ];
+	}
+
+	let attributes;
+	if ( widget._embedded.about[ 0 ].is_multi ) {
+		attributes = {
+			idBase: widget.id_base,
+			instance: widget.instance,
+		};
+	} else {
+		attributes = {
+			id: widget.id,
+		};
+	}
+
+	createBlock( 'core/legacy-widget', attributes, [] );
+}

--- a/packages/block-library/src/template-part/edit/utils/transformers.js
+++ b/packages/block-library/src/template-part/edit/utils/transformers.js
@@ -33,5 +33,5 @@ export function transformWidgetToBlock( widget ) {
 		};
 	}
 
-	createBlock( 'core/legacy-widget', attributes, [] );
+	return createBlock( 'core/legacy-widget', attributes, [] );
 }

--- a/packages/edit-post/package.json
+++ b/packages/edit-post/package.json
@@ -52,6 +52,7 @@
 		"@wordpress/url": "file:../url",
 		"@wordpress/viewport": "file:../viewport",
 		"@wordpress/warning": "file:../warning",
+		"@wordpress/widgets": "file:../widgets",
 		"classnames": "^2.3.1",
 		"lodash": "^4.17.21",
 		"memize": "^1.1.0",

--- a/packages/edit-post/src/index.js
+++ b/packages/edit-post/src/index.js
@@ -10,6 +10,7 @@ import { render, unmountComponentAtNode } from '@wordpress/element';
 import { dispatch, select } from '@wordpress/data';
 import { addFilter } from '@wordpress/hooks';
 import { store as preferencesStore } from '@wordpress/preferences';
+import { registerLegacyWidgetBlock } from '@wordpress/widgets';
 
 /**
  * Internal dependencies
@@ -115,6 +116,7 @@ export function initializeEditor(
 	}
 
 	registerCoreBlocks();
+	registerLegacyWidgetBlock( { inserter: false } );
 	if ( process.env.IS_GUTENBERG_PLUGIN ) {
 		__experimentalRegisterExperimentalCoreBlocks( {
 			enableFSEBlocks: settings.__unstableEnableFullSiteEditingBlocks,

--- a/packages/edit-site/package.json
+++ b/packages/edit-site/package.json
@@ -54,6 +54,7 @@
 		"@wordpress/style-engine": "file:../style-engine",
 		"@wordpress/url": "file:../url",
 		"@wordpress/viewport": "file:../viewport",
+		"@wordpress/widgets": "file:../widgets",
 		"classnames": "^2.3.1",
 		"colord": "^2.9.2",
 		"downloadjs": "^1.4.7",

--- a/packages/edit-site/src/index.js
+++ b/packages/edit-site/src/index.js
@@ -16,6 +16,7 @@ import { store as editorStore } from '@wordpress/editor';
 import { store as interfaceStore } from '@wordpress/interface';
 import { store as preferencesStore } from '@wordpress/preferences';
 import { addFilter } from '@wordpress/hooks';
+import { registerLegacyWidgetBlock } from '@wordpress/widgets';
 
 /**
  * Internal dependencies
@@ -109,6 +110,7 @@ export function initializeEditor( id, settings ) {
 
 	dispatch( blocksStore ).__experimentalReapplyBlockTypeFilters();
 	registerCoreBlocks();
+	registerLegacyWidgetBlock();
 	if ( process.env.IS_GUTENBERG_PLUGIN ) {
 		__experimentalRegisterExperimentalCoreBlocks( {
 			enableFSEBlocks: true,

--- a/packages/edit-site/src/index.js
+++ b/packages/edit-site/src/index.js
@@ -110,7 +110,7 @@ export function initializeEditor( id, settings ) {
 
 	dispatch( blocksStore ).__experimentalReapplyBlockTypeFilters();
 	registerCoreBlocks();
-	registerLegacyWidgetBlock();
+	registerLegacyWidgetBlock( { supports: { inserter: false } } );
 	if ( process.env.IS_GUTENBERG_PLUGIN ) {
 		__experimentalRegisterExperimentalCoreBlocks( {
 			enableFSEBlocks: true,

--- a/packages/edit-site/src/index.js
+++ b/packages/edit-site/src/index.js
@@ -110,7 +110,7 @@ export function initializeEditor( id, settings ) {
 
 	dispatch( blocksStore ).__experimentalReapplyBlockTypeFilters();
 	registerCoreBlocks();
-	registerLegacyWidgetBlock( { supports: { inserter: false } } );
+	registerLegacyWidgetBlock( { inserter: false } );
 	if ( process.env.IS_GUTENBERG_PLUGIN ) {
 		__experimentalRegisterExperimentalCoreBlocks( {
 			enableFSEBlocks: true,

--- a/packages/widgets/src/index.js
+++ b/packages/widgets/src/index.js
@@ -18,11 +18,15 @@ export * from './utils';
  * Note that for the block to be useful, any scripts required by a widget must
  * be loaded into the page.
  *
+ * @param {Object} settings Block settings.
  * @see https://developer.wordpress.org/block-editor/how-to-guides/widgets/legacy-widget-block/
  */
-export function registerLegacyWidgetBlock() {
-	const { metadata, settings, name } = legacyWidget;
-	registerBlockType( { name, ...metadata }, settings );
+export function registerLegacyWidgetBlock( settings = {} ) {
+	const { metadata, settings: defaultSettings, name } = legacyWidget;
+	registerBlockType(
+		{ name, ...metadata },
+		{ ...defaultSettings, ...settings }
+	);
 }
 
 /**

--- a/packages/widgets/src/index.js
+++ b/packages/widgets/src/index.js
@@ -18,14 +18,20 @@ export * from './utils';
  * Note that for the block to be useful, any scripts required by a widget must
  * be loaded into the page.
  *
- * @param {Object} settings Block settings.
+ * @param {Object} supports Block support settings.
  * @see https://developer.wordpress.org/block-editor/how-to-guides/widgets/legacy-widget-block/
  */
-export function registerLegacyWidgetBlock( settings = {} ) {
-	const { metadata, settings: defaultSettings, name } = legacyWidget;
+export function registerLegacyWidgetBlock( supports = {} ) {
+	const { metadata, settings, name } = legacyWidget;
 	registerBlockType(
 		{ name, ...metadata },
-		{ ...defaultSettings, ...settings }
+		{
+			...settings,
+			supports: {
+				...settings.supports,
+				...supports,
+			},
+		}
 	);
 }
 


### PR DESCRIPTION
## What?
Resolves #39270.

PR introduces a new option to import sidebar widgets into a template part.

**Note:** This feature is only available for the block inspector and cannot be used in the template part focus mode. There it should be a part of the Template Inspector tab. I think we can do this separately as part of #36951.

## Why?
See #39270.

## How?
The previous sidebars are stored as a "theme mod" when a user switches to a block theme. The block theme will register fake sidebars and let WordPress do all the remapping for us. See [WP-17979](https://core.trac.wordpress.org/ticket/17979).

The new block inspector panel fetches these sidebars and displays them as import options. The sidebars with `inactive` status or without the widgets aren't displayed.

I've adapted the transformation method from the widget editor and had to add the `@wordpress/widgets` package as a site editor dependency to handle legacy widgets.

## Todos

- [x] ~~Support all theme variations that can use Template Parts.~~  Does this feature make sense outside of the site editor?
- [x] Add a condition when the import option should be available. Currently, it's always displayed. I assume we only want this when the template part has no inner blocks (a blank slate).
- [x] Adjust text copy. **Needs feedback**
- [x] Adjust design. **Needs feedback**

## Testing Instructions
1. Active a classic theme.
2. Insert widgets into the sidebars.
3. Switch to the block theme.
4. Open a template in the Site Editor.
5. Add a new template part to the template.
6. Import widgets.

Repeat the same steps with Classic Widget enabled.

## Screenshots or screencast <!-- if applicable -->

https://user-images.githubusercontent.com/240569/199692711-f66e485d-ee46-498d-8144-ffddc514f67c.mp4