### PR TITLE
Data: Add ability to subscribe to one store, remove __unstableSubscribeStore

### DIFF
--- a/packages/data/CHANGELOG.md
+++ b/packages/data/CHANGELOG.md
@@ -6,6 +6,10 @@
 
 -   Updated dependencies to require React 18 ([45235](https://github.com/WordPress/gutenberg/pull/45235))
 
+### Enhancements
+
+-   The `registry.subscribe` function can now subscribe to updates only from one specific store, with a new optional parameter.
+
 ## 7.6.0 (2022-11-16)
 
 ## 7.5.0 (2022-11-02)

--- a/packages/data/README.md
+++ b/packages/data/README.md
@@ -658,8 +658,11 @@ _Returns_
 ### subscribe
 
 Given a listener function, the function will be called any time the state value
-of one of the registered stores has changed. This function returns a `unsubscribe`
-function used to stop the subscription.
+of one of the registered stores has changed. If you specify the optional
+`storeNameOrDescriptor` parameter, the listener function will be called only
+on updates on that one specific registered store.
+
+This function returns an `unsubscribe` function used to stop the subscription.
 
 _Usage_
 
@@ -678,6 +681,7 @@ unsubscribe();
 _Parameters_
 
 -   _listener_ `Function`: Callback function.
+-   _storeNameOrDescriptor_ `string|StoreDescriptor?`: Optional store name.
 
 ### suspendSelect
 

--- a/packages/data/src/components/use-select/index.js
+++ b/packages/data/src/components/use-select/index.js
@@ -242,7 +242,7 @@ export default function useSelect( mapSelect, deps ) {
 		onStoreChange();
 
 		const unsubscribers = listeningStores.current.map( ( storeName ) =>
-			registry.__unstableSubscribeStore( storeName, onChange )
+			registry.subscribe( onChange, storeName )
 		);
 
 		isMounted.current = true;
@@ -374,7 +374,7 @@ export function useSuspenseSelect( mapSelect, deps ) {
 		onStoreChange();
 
 		const unsubscribers = listeningStores.current.map( ( storeName ) =>
-			registry.__unstableSubscribeStore( storeName, onChange )
+			registry.subscribe( onChange, storeName )
 		);
 
 		isMounted.current = true;

--- a/packages/data/src/index.js
+++ b/packages/data/src/index.js
@@ -159,10 +159,14 @@ export const dispatch = defaultRegistry.dispatch;
 
 /**
  * Given a listener function, the function will be called any time the state value
- * of one of the registered stores has changed. This function returns a `unsubscribe`
- * function used to stop the subscription.
+ * of one of the registered stores has changed. If you specify the optional
+ * `storeNameOrDescriptor` parameter, the listener function will be called only
+ * on updates on that one specific registered store.
  *
- * @param {Function} listener Callback function.
+ * This function returns an `unsubscribe` function used to stop the subscription.
+ *
+ * @param {Function}                listener              Callback function.
+ * @param {string|StoreDescriptor?} storeNameOrDescriptor Optional store name.
  *
  * @example
  * ```js

--- a/packages/data/src/registry.js
+++ b/packages/data/src/registry.js
@@ -43,14 +43,10 @@ import { createEmitter } from './utils/emitter';
  * @property {Function} registerStore registers store.
  */
 
-function isObject( object ) {
-	return object !== null && typeof object === 'object';
-}
-
 function getStoreName( storeNameOrDescriptor ) {
-	return isObject( storeNameOrDescriptor )
-		? storeNameOrDescriptor.name
-		: storeNameOrDescriptor;
+	return typeof storeNameOrDescriptor === 'string'
+		? storeNameOrDescriptor
+		: storeNameOrDescriptor.name;
 }
 /**
  * Creates a new store registry, given an optional object of initial store

--- a/packages/data/src/test/registry.js
+++ b/packages/data/src/test/registry.js
@@ -719,16 +719,15 @@ describe( 'createRegistry', () => {
 			const listener2 = jest.fn();
 			// useSelect subscribes to the stores differently,
 			// This test ensures batching works in this case as well.
-			const unsubscribe = registry.__unstableSubscribeStore(
-				'myAwesomeReducer',
-				listener2
+			const unsubscribe = registry.subscribe(
+				listener2,
+				'myAwesomeReducer'
 			);
 			registry.batch( () => {
 				store.dispatch( { type: 'dummy' } );
 				store.dispatch( { type: 'dummy' } );
 			} );
 			unsubscribe();
-
 			expect( listener2 ).toHaveBeenCalledTimes( 1 );
 		} );
 	} );


### PR DESCRIPTION
As discussed in #45481, this PR is adding support for subscribing to just one store with `registry.subscribe`, via an optional second parameter.

Now we can remove the `__unstableSubscribeStore` method that `useSelect` used. `useSelect` now uses only one remaining unstable internal API, `__unstableMarkListeningStores`.

FYI @alexflorisca who requested this 🙂 