### PR TITLE
Navigation: Fix font inheritance when using text menu button.

### DIFF
--- a/packages/block-library/src/navigation/edit/responsive-wrapper.js
+++ b/packages/block-library/src/navigation/edit/responsive-wrapper.js
@@ -85,11 +85,7 @@ export default function ResponsiveWrapper( {
 					onClick={ () => onToggle( true ) }
 				>
 					{ hasIcon && <OverlayMenuIcon icon={ icon } /> }
-					{ ! hasIcon && (
-						<span className="wp-block-navigation__toggle_button_label">
-							{ __( 'Menu' ) }
-						</span>
-					) }
+					{ ! hasIcon && __( 'Menu' ) }
 				</Button>
 			) }
 
@@ -109,11 +105,7 @@ export default function ResponsiveWrapper( {
 							onClick={ () => onToggle( false ) }
 						>
 							{ hasIcon && <Icon icon={ close } /> }
-							{ ! hasIcon && (
-								<span className="wp-block-navigation__toggle_button_label">
-									{ __( 'Close' ) }
-								</span>
-							) }
+							{ ! hasIcon && __( 'Close' ) }
 						</Button>
 						<div
 							className="wp-block-navigation__responsive-container-content"

--- a/packages/block-library/src/navigation/style.scss
+++ b/packages/block-library/src/navigation/style.scss
@@ -656,9 +656,11 @@ button.wp-block-navigation-item__content {
 	display: flex;
 
 	// When set to collapse into a text button, it should inherit the parent font.
-	// This needs specificity to override inherited properties.
-	&.components-button.components-button {
+	// This needs specificity to override inherited properties by the button element and component.
+	&.wp-block-navigation__responsive-container-open.wp-block-navigation__responsive-container-open {
 		font-family: inherit;
+		font-weight: inherit;
+		font-size: inherit;
 	}
 
 	&:not(.always-shown) {

--- a/packages/block-library/src/navigation/style.scss
+++ b/packages/block-library/src/navigation/style.scss
@@ -655,6 +655,12 @@ button.wp-block-navigation-item__content {
 .wp-block-navigation__responsive-container-open {
 	display: flex;
 
+	// When set to collapse into a text button, it should inherit the parent font.
+	// This needs specificity to override inherited properties.
+	&.components-button.components-button {
+		font-family: inherit;
+	}
+
 	&:not(.always-shown) {
 		@include break-small {
 			display: none;


### PR DESCRIPTION
## What?

You can set the navigation block to collapse to a button opening an overlay. You can furthermore set this button to have a text only label:
<img width="345" alt="text label before" src="https://user-images.githubusercontent.com/1204802/199727086-1c16db09-3ddc-4bcc-b4ec-036ed399bd46.png">

However since the button uses the Gutenberg button component, it is explicitly set to use system fonts. Ideally we'd use these components only for UI, but a quick fix is to force font inheritance, fixing the issue so the right font is shown:

<img width="471" alt="text label after" src="https://user-images.githubusercontent.com/1204802/199727232-499f9c54-e9cb-4a88-a79e-61c566098c54.png">

## Testing Instructions

Insert a navigation block, setithe overlay menu to "Always", and untoggle "Show icon button". Test that the font is inherited by the theme. You can maybe test the "Canary" theme in TT3 as it sets an opinionated font.