### PR TITLE
Introduce experiment for inspector based navigation editing

### DIFF
--- a/lib/experimental/editor-settings.php
+++ b/lib/experimental/editor-settings.php
@@ -83,3 +83,15 @@ function gutenberg_enable_zoomed_out_view() {
 }
 
 add_action( 'admin_init', 'gutenberg_enable_zoomed_out_view' );
+
+/**
+ * Sets a global JS variable used to trigger the availability of the Navigation List View experiment.
+ */
+function gutenberg_enable_off_canvas_navigation_editor() {
+	$gutenberg_experiments = get_option( 'gutenberg-experiments' );
+	if ( $gutenberg_experiments && array_key_exists( 'gutenberg-off-canvas-navigation-editor', $gutenberg_experiments ) ) {
+		wp_add_inline_script( 'wp-block-editor', 'window.__experimentalEnableOffCanvasNavigationEditor = true', 'before' );
+	}
+}
+
+add_action( 'admin_init', 'gutenberg_enable_off_canvas_navigation_editor' );

--- a/lib/experiments-page.php
+++ b/lib/experiments-page.php
@@ -52,6 +52,17 @@ function gutenberg_initialize_experiments_settings() {
 			'id'    => 'gutenberg-zoomed-out-view',
 		)
 	);
+	add_settings_field(
+		'gutenberg-off-canvas-navigation-editor',
+		__( 'Off canvas navigation editor ', 'gutenberg' ),
+		'gutenberg_display_experiment_field',
+		'gutenberg-experiments',
+		'gutenberg_experiments_section',
+		array(
+			'label' => __( 'Test a new "off canvas" editor for navigation block using the block inspector and a tree view of the current menu', 'gutenberg' ),
+			'id'    => 'gutenberg-off-canvas-navigation-editor',
+		)
+	);
 	register_setting(
 		'gutenberg-experiments',
 		'gutenberg-experiments'


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

This PR a spin off from #44534.
The base PR was approved but it was too big as a changeset so we're splitting it up.

This PR introduces the experiment setting and checkbox required to build as an experiment a new inspector based editing UX 
for the navigation block - based on a list view.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

To develop this new UX in isolation, potetially faster, and enable user validation of the UX.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

Copy paste of the zoomed out view setting and checkbox and then change the copy.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->

1. Go to Gutenberg > Experiments
2. There should be a new experiment named "Test a new "off canvas" editor for navigation block using the block inspector 
and a tree view of the current menu"

## Screenshots or scree ncast <!-- if applicable -->
<img width="1114" alt="Screenshot 2022-11-03 at 15 27 10" src="https://user-images.githubusercontent.com/107534/199734144-f2641922-189e-4715-a4f4-2b45338022a0.png">

