### PR TITLE
Configure labels for GHA Dependabot PRs.

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,3 +8,7 @@ updates:
       schedule:
           interval: 'daily'
       open-pull-requests-limit: 10
+      labels:
+          - 'GitHub Actions'
+          - 'Automated Testing'
+          - '[Type] Build Tooling'


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
This configures the list of labels that should be applied to GitHub Action related Dependabot pull requests.

## Why?
This ensures they show up in the appropriate lists.

## How?
The `dependabot.yml` file [supports specifying a list of labels to assign](https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file#labels).