### PR TITLE
Simplfy handling of save of Nav block uncontrolled inner blocks

### DIFF
--- a/packages/block-library/src/navigation/edit/index.js
+++ b/packages/block-library/src/navigation/edit/index.js
@@ -6,7 +6,13 @@ import classnames from 'classnames';
 /**
  * WordPress dependencies
  */
-import { useState, useEffect, useRef, Platform } from '@wordpress/element';
+import {
+	useState,
+	useEffect,
+	useRef,
+	Platform,
+	memo,
+} from '@wordpress/element';
 import { addQueryArgs } from '@wordpress/url';
 import {
 	__experimentalOffCanvasEditor as OffCanvasEditor,
@@ -230,8 +236,9 @@ function Navigation( {
 		classicMenuConversionStatus === CLASSIC_MENU_CONVERSION_PENDING;
 
 	// Only autofallback to published menus.
-	const fallbackNavigationMenus = navigationMenus?.filter(
-		( menu ) => menu.status === 'publish'
+	const fallbackNavigationMenus = memo(
+		() => navigationMenus?.filter( ( menu ) => menu.status === 'publish' ),
+		[ navigationMenus ]
 	);
 
 	// Attempt to retrieve and prioritize any existing navigation menu unless:

--- a/packages/block-library/src/navigation/edit/index.js
+++ b/packages/block-library/src/navigation/edit/index.js
@@ -197,9 +197,6 @@ function Navigation( {
 		__unstableMarkNextChangeAsNotPersistent,
 	} = useDispatch( blockEditorStore );
 
-	const [ hasSavedUnsavedInnerBlocks, setHasSavedUnsavedInnerBlocks ] =
-		useState( false );
-
 	const [ isResponsiveMenuOpen, setResponsiveMenuVisibility ] =
 		useState( false );
 
@@ -269,7 +266,13 @@ function Navigation( {
 		 */
 		__unstableMarkNextChangeAsNotPersistent();
 		setRef( fallbackNavigationMenus[ 0 ].id );
-	}, [ navigationMenus ] );
+	}, [
+		navigationMenus,
+		ref,
+		isCreatingNavigationMenu,
+		fallbackNavigationMenus,
+		hasUncontrolledInnerBlocks,
+	] );
 
 	useEffect( () => {
 		if (
@@ -680,7 +683,7 @@ function Navigation( {
 		/>
 	);
 
-	if ( hasUnsavedBlocks ) {
+	if ( hasUnsavedBlocks && ! isCreatingNavigationMenu ) {
 		return (
 			<TagName { ...blockProps }>
 				<InspectorControls>
@@ -744,24 +747,11 @@ function Navigation( {
 					overlayTextColor={ overlayTextColor }
 				>
 					<UnsavedInnerBlocks
+						createNavigationMenu={ createNavigationMenu }
 						blocks={ uncontrolledInnerBlocks }
-						clientId={ clientId }
 						templateLock={ templateLock }
 						navigationMenus={ navigationMenus }
 						hasSelection={ isSelected || isInnerBlockSelected }
-						hasSavedUnsavedInnerBlocks={
-							hasSavedUnsavedInnerBlocks
-						}
-						onSave={ ( post ) => {
-							// Set some state used as a guard to prevent the creation of multiple posts.
-							setHasSavedUnsavedInnerBlocks( true );
-							// Switch to using the wp_navigation entity.
-							setRef( post.id );
-
-							showNavigationMenuStatusNotice(
-								__( `New Navigation Menu created.` )
-							);
-						} }
 					/>
 				</ResponsiveWrapper>
 			</TagName>

--- a/packages/block-library/src/navigation/edit/index.js
+++ b/packages/block-library/src/navigation/edit/index.js
@@ -11,7 +11,7 @@ import {
 	useEffect,
 	useRef,
 	Platform,
-	memo,
+	useMemo,
 } from '@wordpress/element';
 import { addQueryArgs } from '@wordpress/url';
 import {
@@ -236,10 +236,15 @@ function Navigation( {
 		classicMenuConversionStatus === CLASSIC_MENU_CONVERSION_PENDING;
 
 	// Only autofallback to published menus.
-	const fallbackNavigationMenus = memo(
-		() => navigationMenus?.filter( ( menu ) => menu.status === 'publish' ),
-		[ navigationMenus ]
-	);
+	const fallbackNavigationMenus = useMemo( () => {
+		return navigationMenus
+			?.filter( ( menu ) => menu.status === 'publish' )
+			?.sort( ( menuA, menuB ) => {
+				const menuADate = new Date( menuA.date );
+				const menuBDate = new Date( menuB.date );
+				return menuADate.getTime() < menuBDate.getTime();
+			} );
+	}, [ navigationMenus ] );
 
 	// Attempt to retrieve and prioritize any existing navigation menu unless:
 	// - the are uncontrolled inner blocks already present in the block.
@@ -257,12 +262,6 @@ function Navigation( {
 		) {
 			return;
 		}
-
-		fallbackNavigationMenus.sort( ( menuA, menuB ) => {
-			const menuADate = new Date( menuA.date );
-			const menuBDate = new Date( menuB.date );
-			return menuADate.getTime() < menuBDate.getTime();
-		} );
 
 		/**
 		 *  This fallback displays (both in editor and on front)

--- a/packages/block-library/src/navigation/edit/index.js
+++ b/packages/block-library/src/navigation/edit/index.js
@@ -267,7 +267,6 @@ function Navigation( {
 		__unstableMarkNextChangeAsNotPersistent();
 		setRef( fallbackNavigationMenus[ 0 ].id );
 	}, [
-		navigationMenus,
 		ref,
 		isCreatingNavigationMenu,
 		fallbackNavigationMenus,

--- a/packages/block-library/src/navigation/edit/index.js
+++ b/packages/block-library/src/navigation/edit/index.js
@@ -236,15 +236,17 @@ function Navigation( {
 		classicMenuConversionStatus === CLASSIC_MENU_CONVERSION_PENDING;
 
 	// Only autofallback to published menus.
-	const fallbackNavigationMenus = useMemo( () => {
-		return navigationMenus
-			?.filter( ( menu ) => menu.status === 'publish' )
-			?.sort( ( menuA, menuB ) => {
-				const menuADate = new Date( menuA.date );
-				const menuBDate = new Date( menuB.date );
-				return menuADate.getTime() < menuBDate.getTime();
-			} );
-	}, [ navigationMenus ] );
+	const fallbackNavigationMenus = useMemo(
+		() =>
+			navigationMenus
+				?.filter( ( menu ) => menu.status === 'publish' )
+				?.sort( ( menuA, menuB ) => {
+					const menuADate = new Date( menuA.date );
+					const menuBDate = new Date( menuB.date );
+					return menuADate.getTime() < menuBDate.getTime();
+				} ),
+		[ navigationMenus ]
+	);
 
 	// Attempt to retrieve and prioritize any existing navigation menu unless:
 	// - the are uncontrolled inner blocks already present in the block.

--- a/packages/block-library/src/navigation/edit/unsaved-inner-blocks.js
+++ b/packages/block-library/src/navigation/edit/unsaved-inner-blocks.js
@@ -2,7 +2,7 @@
  * WordPress dependencies
  */
 import { useInnerBlocksProps } from '@wordpress/block-editor';
-import { Disabled, Spinner } from '@wordpress/components';
+import { Disabled } from '@wordpress/components';
 import { store as coreStore } from '@wordpress/core-data';
 import { useSelect } from '@wordpress/data';
 import { useContext, useEffect, useRef, useMemo } from '@wordpress/element';
@@ -11,7 +11,6 @@ import { useContext, useEffect, useRef, useMemo } from '@wordpress/element';
  * Internal dependencies
  */
 import useNavigationMenu from '../use-navigation-menu';
-import useCreateNavigationMenu from './use-create-navigation-menu';
 
 const EMPTY_OBJECT = {};
 const DRAFT_MENU_PARAMS = [
@@ -38,9 +37,8 @@ const ALLOWED_BLOCKS = [
 
 export default function UnsavedInnerBlocks( {
 	blocks,
-	clientId,
-	hasSavedUnsavedInnerBlocks,
-	onSave,
+	createNavigationMenu,
+
 	hasSelection,
 } ) {
 	const originalBlocks = useRef();
@@ -75,7 +73,6 @@ export default function UnsavedInnerBlocks( {
 	// The block will be disabled in a block preview, use this as a way of
 	// avoiding the side-effects of this component for block previews.
 	const isDisabled = useContext( Disabled.Context );
-	const savingLock = useRef( false );
 
 	const innerBlocksProps = useInnerBlocksProps(
 		{
@@ -121,9 +118,6 @@ export default function UnsavedInnerBlocks( {
 
 	const { hasResolvedNavigationMenus, navigationMenus } = useNavigationMenu();
 
-	const { create: createNavigationMenu } =
-		useCreateNavigationMenu( clientId );
-
 	// Automatically save the uncontrolled blocks.
 	useEffect( () => {
 		// The block will be disabled when used in a BlockPreview.
@@ -140,9 +134,7 @@ export default function UnsavedInnerBlocks( {
 		// which is an indication they want to start editing.
 		if (
 			isDisabled ||
-			hasSavedUnsavedInnerBlocks ||
 			isSaving ||
-			savingLock.current ||
 			! hasResolvedDraftNavigationMenus ||
 			! hasResolvedNavigationMenus ||
 			! hasSelection ||
@@ -151,11 +143,7 @@ export default function UnsavedInnerBlocks( {
 			return;
 		}
 
-		savingLock.current = true;
-		createNavigationMenu( null, blocks ).then( ( menu ) => {
-			onSave( menu );
-			savingLock.current = false;
-		} );
+		createNavigationMenu( null, blocks );
 	}, [
 		isDisabled,
 		isSaving,
@@ -170,17 +158,5 @@ export default function UnsavedInnerBlocks( {
 
 	const Wrapper = isSaving ? Disabled : 'div';
 
-	return (
-		<>
-			{ isSaving ? (
-				<Spinner
-					className={
-						'wp-block-navigation__uncontrolled-inner-blocks-loading-indicator'
-					}
-				/>
-			) : (
-				<Wrapper { ...innerBlocksProps } />
-			) }
-		</>
-	);
+	return <Wrapper { ...innerBlocksProps } />;
 }


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Simplifies and centralising the "saving" logic and rendering for uncontrolled inner blocks by defering to the implementation in the parent component (primary `edit.js` of the block).

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

Having a separate usage of `createNavigationMenu` within `uncontroller-inner-blocks.js` was requiring the block to maintain a separate "saving" or "loading" state when creating menus from uncontroller inner blocks (for example converting a Page List into a menu).

This was leading to potential UI bugs and also greatly increasing the complexity of the code within `<UnControlledInnerBlocks>`.

This problem was encountered when working on https://github.com/WordPress/gutenberg/pull/45443.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

With this change we pass in the "create" function and defer all UI handling for saving/loading to the parent component. 

Benefits:

- `<UncontrolledInnerBlocks>` is no longer rendered if a menu is being created avoiding the need to maintain separeate "loading" UI within that component.
- we've been able to remove a lot of logic from the `UncontrolledInnerBlocks` around "loading" states
- we've removed a `setState` call in the parent `edit.js` which simplifies that implementation

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->

The main thing to check is the conversion of inner blocks to sync'd menu.

- Delete all Navigation Menus & Classic Menus - http://localhost:8888/wp-admin/edit.php?post_type=wp_navigation
- New Post
- Add Nav block
- Click on Page List block and click "Edit". Then "Convert".
- See loading state whilst conversion takes place.
- See a _single_ Menu created.

- Delete all Navigation Menus & Classic Menus - http://localhost:8888/wp-admin/edit.php?post_type=wp_navigation
- New Post
- Go to Code view mode and paste in the following:

```
<!-- wp:navigation --><!-- wp:navigation-link {"label":"A new one","type":"post","id":72,"url":"http://localhost:8888/72-2/","kind":"post-type","isTopLevelLink":true} /--><!-- /wp:navigation -->
```

- Switch to Visual Mode.
- Attempt to modify the Navigation.
- See menu created.


## Screenshots or screencast <!-- if applicable -->
