### PR TITLE
Fix: Updated names from List View to Document Overview 

### DIFF
--- a/packages/e2e-test-utils/src/list-view.js
+++ b/packages/e2e-test-utils/src/list-view.js
@@ -1,13 +1,15 @@
 async function toggleListView() {
+	// selector .edit-post-header-toolbar__list-view-toggle is still required because the performance tests also execute against older versions that still use that selector.
 	await page.click(
-		'.edit-post-header-toolbar__list-view-toggle, .edit-site-header-edit-mode__list-view-toggle, .edit-widgets-header-toolbar__list-view-toggle'
+		'.edit-post-header-toolbar__document-overview-toggle, .edit-post-header-toolbar__list-view-toggle, .edit-site-header-edit-mode__list-view-toggle, .edit-widgets-header-toolbar__list-view-toggle'
 	);
 }
 
 async function isListViewOpen() {
 	return await page.evaluate( () => {
+		// selector .edit-post-header-toolbar__list-view-toggle is still required because the performance tests also execute against older versions that still use that selector.
 		return !! document.querySelector(
-			'.edit-post-header-toolbar__list-view-toggle.is-pressed, .edit-site-header-edit-mode__list-view-toggle.is-pressed, .edit-widgets-header-toolbar__list-view-toggle.is-pressed'
+			'.edit-post-header-toolbar__document-overview-toggle.is-pressed, .edit-post-header-toolbar__list-view-toggle.is-pressed, .edit-site-header-edit-mode__list-view-toggle.is-pressed, .edit-widgets-header-toolbar__list-view-toggle.is-pressed'
 		);
 	} );
 }

--- a/packages/e2e-tests/specs/editor/blocks/cover.test.js
+++ b/packages/e2e-tests/specs/editor/blocks/cover.test.js
@@ -127,7 +127,9 @@ describe( 'Cover', () => {
 		);
 
 		// Select the cover block.By default the child paragraph gets selected.
-		await page.click( '.edit-post-header-toolbar__list-view-toggle' );
+		await page.click(
+			'.edit-post-header-toolbar__document-overview-toggle'
+		);
 		await page.click(
 			'.block-editor-list-view-block__contents-container a'
 		);

--- a/packages/e2e-tests/specs/editor/various/block-hierarchy-navigation.test.js
+++ b/packages/e2e-tests/specs/editor/various/block-hierarchy-navigation.test.js
@@ -49,7 +49,9 @@ describe( 'Navigating the block hierarchy', () => {
 		await page.keyboard.type( 'First column' );
 
 		// Navigate to the columns blocks.
-		await page.click( '.edit-post-header-toolbar__list-view-toggle' );
+		await page.click(
+			'.edit-post-header-toolbar__document-overview-toggle'
+		);
 
 		const firstColumnsBlockMenuItem = (
 			await getListViewBlocks( 'Columns' )
@@ -183,7 +185,9 @@ describe( 'Navigating the block hierarchy', () => {
 		await page.click( '.editor-post-title' );
 
 		// Try selecting the group block using the Outline.
-		await page.click( '.edit-post-header-toolbar__list-view-toggle' );
+		await page.click(
+			'.edit-post-header-toolbar__document-overview-toggle'
+		);
 		const groupMenuItem = ( await getListViewBlocks( 'Group' ) )[ 0 ];
 		await groupMenuItem.click();
 

--- a/packages/edit-post/src/components/header/header-toolbar/index.js
+++ b/packages/edit-post/src/components/header/header-toolbar/index.js
@@ -78,12 +78,12 @@ function HeaderToolbar() {
 		<>
 			<ToolbarItem
 				as={ Button }
-				className="edit-post-header-toolbar__list-view-toggle"
+				className="edit-post-header-toolbar__document-overview-toggle"
 				icon={ listView }
 				disabled={ isTextModeEnabled }
 				isPressed={ isListViewOpen }
 				/* translators: button label text should, if possible, be under 16 characters. */
-				label={ __( 'List View' ) }
+				label={ __( 'Document Overview' ) }
 				onClick={ toggleListView }
 				shortcut={ listViewShortcut }
 				showTooltip={ ! showIconLabels }

--- a/packages/edit-post/src/components/header/style.scss
+++ b/packages/edit-post/src/components/header/style.scss
@@ -220,7 +220,7 @@
 		}
 
 		& > .edit-post-header__toolbar .edit-post-header-toolbar__inserter-toggle,
-		& > .edit-post-header__toolbar .edit-post-header-toolbar__list-view-toggle,
+		& > .edit-post-header__toolbar .edit-post-header-toolbar__document-overview-toggle,
 		& > .edit-post-header__settings > .block-editor-post-preview__dropdown,
 		& > .edit-post-header__settings > .interface-pinned-items {
 			display: none;

--- a/packages/edit-post/src/components/layout/index.js
+++ b/packages/edit-post/src/components/layout/index.js
@@ -164,7 +164,7 @@ function Layout( { styles } ) {
 	);
 
 	const secondarySidebarLabel = isListViewOpened
-		? __( 'List View' )
+		? __( 'Document Overview' )
 		: __( 'Block Library' );
 
 	const secondarySidebar = () => {

--- a/packages/edit-post/src/components/secondary-sidebar/list-view-sidebar.js
+++ b/packages/edit-post/src/components/secondary-sidebar/list-view-sidebar.js
@@ -43,17 +43,17 @@ export default function ListViewSidebar() {
 	return (
 		// eslint-disable-next-line jsx-a11y/no-static-element-interactions
 		<div
-			aria-label={ __( 'List View' ) }
-			className="edit-post-editor__list-view-panel"
+			aria-label={ __( 'Document Overview' ) }
+			className="edit-post-editor__document-overview-panel"
 			onKeyDown={ closeOnEscape }
 		>
 			<div
-				className="edit-post-editor__list-view-panel-header components-panel__header edit-post-sidebar__panel-tabs"
+				className="edit-post-editor__document-overview-panel-header components-panel__header edit-post-sidebar__panel-tabs"
 				ref={ headerFocusReturnRef }
 			>
 				<Button
 					icon={ closeSmall }
-					label={ __( 'Close List View Sidebar' ) }
+					label={ __( 'Close Document Overview Sidebar' ) }
 					onClick={ () => setIsListViewOpened( false ) }
 				/>
 				<ul>

--- a/packages/edit-post/src/components/secondary-sidebar/style.scss
+++ b/packages/edit-post/src/components/secondary-sidebar/style.scss
@@ -1,11 +1,11 @@
 .edit-post-editor__inserter-panel,
-.edit-post-editor__list-view-panel {
+.edit-post-editor__document-overview-panel {
 	height: 100%;
 	display: flex;
 	flex-direction: column;
 }
 
-.edit-post-editor__list-view-panel {
+.edit-post-editor__document-overview-panel {
 	// Same width as the Inserter.
 	// @see packages/block-editor/src/components/inserter/style.scss
 	// Width of the list view panel.
@@ -31,7 +31,7 @@
 	}
 }
 
-.edit-post-editor__list-view-panel-header {
+.edit-post-editor__document-overview-panel-header {
 	border-bottom: $border-width solid $gray-300;
 	display: flex;
 	justify-content: space-between;

--- a/test/e2e/specs/editor/blocks/columns.spec.js
+++ b/test/e2e/specs/editor/blocks/columns.spec.js
@@ -21,7 +21,7 @@ test.describe( 'Columns', () => {
 		await page.locator( '[aria-label="Two columns; equal split"]' ).click();
 
 		// Open List view toggle
-		await page.locator( 'role=button[name="List View"i]' ).click();
+		await page.locator( 'role=button[name="Document Overview"i]' ).click();
 
 		// block column add
 		await page


### PR DESCRIPTION
Follow up to https://github.com/WordPress/gutenberg/pull/44788.
Fixes: https://github.com/WordPress/gutenberg/issues/44193

This PR updates the labels from List View to Document Overview inside the edit post.
Thank you, @alexstine, @colorful-tones for the catch and insights!
