### PR TITLE
Lodash: Simplify a few `isEmpty` calls

### DIFF
--- a/packages/block-library/src/audio/edit.native.js
+++ b/packages/block-library/src/audio/edit.native.js
@@ -2,7 +2,6 @@
  * External dependencies
  */
 import { TouchableWithoutFeedback } from 'react-native';
-import { isEmpty } from 'lodash';
 
 /**
  * WordPress dependencies
@@ -228,7 +227,7 @@ function AudioEdit( {
 				<BlockCaption
 					accessible={ true }
 					accessibilityLabelCreator={ ( caption ) =>
-						isEmpty( caption )
+						! caption
 							? /* translators: accessibility text. Empty Audio caption. */
 							  __( 'Audio caption. Empty' )
 							: sprintf(

--- a/packages/block-library/src/embed/embed-preview.native.js
+++ b/packages/block-library/src/embed/embed-preview.native.js
@@ -2,7 +2,6 @@
  * External dependencies
  */
 import { TouchableWithoutFeedback } from 'react-native';
-import { isEmpty } from 'lodash';
 import classnames from 'classnames/dedupe';
 
 /**
@@ -52,7 +51,7 @@ const EmbedPreview = ( {
 		styles[ `embed-preview__sandbox--align-${ align }` ];
 
 	function accessibilityLabelCreator( caption ) {
-		return isEmpty( caption )
+		return ! caption
 			? /* translators: accessibility text. Empty Embed caption. */
 			  __( 'Embed caption. Empty' )
 			: sprintf(

--- a/packages/block-library/src/gallery/gallery.native.js
+++ b/packages/block-library/src/gallery/gallery.native.js
@@ -2,7 +2,6 @@
  * External dependencies
  */
 import { View } from 'react-native';
-import { isEmpty } from 'lodash';
 
 /**
  * Internal dependencies
@@ -100,7 +99,7 @@ export const Gallery = ( props ) => {
 				isSelected={ isCaptionSelected }
 				accessible={ true }
 				accessibilityLabelCreator={ ( caption ) =>
-					isEmpty( caption )
+					! caption
 						? /* translators: accessibility text. Empty gallery caption. */
 
 						  'Gallery caption. Empty'

--- a/packages/block-library/src/gallery/v1/gallery.native.js
+++ b/packages/block-library/src/gallery/v1/gallery.native.js
@@ -2,7 +2,6 @@
  * External dependencies
  */
 import { View } from 'react-native';
-import { isEmpty } from 'lodash';
 
 /**
  * Internal dependencies
@@ -142,7 +141,7 @@ export const Gallery = ( props ) => {
 				isSelected={ isCaptionSelected }
 				accessible={ true }
 				accessibilityLabelCreator={ ( caption ) =>
-					isEmpty( caption )
+					! caption
 						? /* translators: accessibility text. Empty gallery caption. */
 						  'Gallery caption. Empty'
 						: sprintf(

--- a/packages/block-library/src/video/edit.native.js
+++ b/packages/block-library/src/video/edit.native.js
@@ -2,7 +2,6 @@
  * External dependencies
  */
 import { View, TouchableWithoutFeedback, Text } from 'react-native';
-import { isEmpty } from 'lodash';
 
 /**
  * WordPress dependencies
@@ -367,7 +366,7 @@ class VideoEdit extends Component {
 					<BlockCaption
 						accessible={ true }
 						accessibilityLabelCreator={ ( caption ) =>
-							isEmpty( caption )
+							! caption
 								? /* translators: accessibility text. Empty video caption. */
 								  __( 'Video caption. Empty' )
 								: sprintf(

--- a/packages/components/src/mobile/bottom-sheet/switch-cell.native.js
+++ b/packages/components/src/mobile/bottom-sheet/switch-cell.native.js
@@ -2,7 +2,7 @@
  * External dependencies
  */
 import { Switch } from 'react-native';
-import { isEmpty } from 'lodash';
+
 /**
  * WordPress dependencies
  */
@@ -20,7 +20,7 @@ export default function BottomSheetSwitchCell( props ) {
 	};
 
 	const getAccessibilityLabel = () => {
-		if ( isEmpty( cellProps.help ) ) {
+		if ( ! cellProps.help ) {
 			return value
 				? sprintf(
 						/* translators: accessibility text. Switch setting ON state. %s: Switch title. */

--- a/packages/editor/src/components/post-title/index.native.js
+++ b/packages/editor/src/components/post-title/index.native.js
@@ -2,7 +2,6 @@
  * External dependencies
  */
 import { View } from 'react-native';
-import { isEmpty } from 'lodash';
 
 /**
  * WordPress dependencies
@@ -80,7 +79,7 @@ class PostTitle extends Component {
 
 	getTitle( title, postType ) {
 		if ( 'page' === postType ) {
-			return isEmpty( title )
+			return ! title
 				? /* translators: accessibility text. empty page title. */
 				  __( 'Page title. Empty' )
 				: sprintf(
@@ -90,7 +89,7 @@ class PostTitle extends Component {
 				  );
 		}
 
-		return isEmpty( title )
+		return ! title
 			? /* translators: accessibility text. empty post title. */
 			  __( 'Post title. Empty' )
 			: sprintf(


### PR DESCRIPTION
## What?
This PR removes a few`_.isEmpty()` in favor of simpler checks.

## Why?

Lodash is known to unnecessarily inflate the bundle size of packages, and in most cases, it can be replaced with native language functionality. See these for more information and rationale:

* https://github.com/WordPress/gutenberg/issues/16938#issuecomment-602837246
* https://github.com/WordPress/gutenberg/issues/17025
* https://github.com/WordPress/gutenberg/issues/39495 

## How?

We're replacing a few usages with a simple native `! string` check when we're dealing with strings. The good thing about that new way is that it will catch `undefined` and `null` as well, so it's a pretty safe change.

## Testing Instructions

On native: 
* Insert an Audio block and pick an audio file. In the field for caption, verify the accessibility label is "Audio caption. Empty" when it's empty, and "Audio caption" when it's not.
* Insert an Embed block and input an embed. In the field for caption, verify the accessibility label is "Embed caption. Empty" when it's empty, and "Embed caption" when it's not.
* Insert a Gallery block and insert a few images. In the field for gallery caption, verify the accessibility label is "Gallery caption. Empty" when it's empty, and "Gallery caption" when it's not.
* Insert a Video block and pick a video file. In the field for caption, verify the accessibility label is "Video caption. Empty" when it's empty, and "Video caption" when it's not.
* In the Video block, verify the help text appears below the Autoplay field (see #30885).
* Start a new post. In the field for title, verify the accessibility label is "Post title. Empty" when it's empty, and "Post title" when it's not.
* Start a new page. In the field for title, verify the accessibility label is "Page title. Empty" when it's empty, and "Page title" when it's not.
* Verify all checks are green.