### PR TITLE
Components: refactor `useFlex` to pass `exhaustive-deps` 

### DIFF
--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -13,6 +13,7 @@
 ### Internal
 
 -   `PaletteEditListView`: Update to ignore `exhaustive-deps` eslint rule ([#45467](https://github.com/WordPress/gutenberg/pull/45467)).
+-   `Flex`: Update to pass `exhaustive-deps` eslint rule ([#45528](https://github.com/WordPress/gutenberg/pull/45528)).
 
 ## 22.0.0 (2022-11-02)
 

--- a/packages/components/src/flex/flex/hook.ts
+++ b/packages/components/src/flex/flex/hook.ts
@@ -57,8 +57,6 @@ export function useFlex( props: WordPressComponentProps< FlexProps, 'div' > ) {
 
 	const isColumn =
 		typeof direction === 'string' && !! direction.includes( 'column' );
-	const isReverse =
-		typeof direction === 'string' && direction.includes( 'reverse' );
 
 	const cx = useCx();
 
@@ -87,7 +85,6 @@ export function useFlex( props: WordPressComponentProps< FlexProps, 'div' > ) {
 		expanded,
 		gap,
 		isColumn,
-		isReverse,
 		justify,
 		wrap,
 	] );


### PR DESCRIPTION
## What?
Updates the `useFlex` hook to pass the `exhaustive-deps` eslint rule.

## Why?
Part of the effort in https://github.com/WordPress/gutenberg/pull/41166 to apply `exhuastive-deps` to the Components package

## How?
Removing `isReverse` from the dependency array, and then because it isn't used anywhere else in the hook, removing the variable entirely.

[When this dependency was added](https://github.com/WordPress/gutenberg/pull/28609/files#diff-155b6501e555b51bc7d6432b44a02af41d78081a6720f6163fff0016c66f8ef2), `isReverse` was used in several places for the creation of the `classes` object, but the hook has been refactored since then, removing any use of the `isReverse` variable in the hook.

Based on that, I _think_ this dependency and variable just got left in - removing them doesn't cause any unexpected changes that I can see in Storybook.

cc @sarayourfriend: do you have any thoughts on drawbacks to this approach? If we do, in fact, still need to watch this variable and update the `useMemo` value when it changes, we'll need to either disable the `exhuastive-deps` check, or find another approach. Curious what you think 🙂 

## Testing Instructions
1. From your local Gutenberg directory, run `npx eslint --rule 'react-hooks/exhaustive-deps: warn' packages/components/src/flex`
2. Confirm that the linter returns no errors
3. Confirm `navigation` unit tests still pass
4. Run Storybook locally, confirm the `Flex` component stories and/or docs still work as expected