### PR TITLE
FontSizePicker: fix a buggy unit test

### DIFF
--- a/packages/e2e-tests/specs/editor/various/font-size-picker.test.js
+++ b/packages/e2e-tests/specs/editor/various/font-size-picker.test.js
@@ -116,7 +116,6 @@ describe( 'Font Size Picker', () => {
 												slug: 'tiny',
 												size: '11px',
 											},
-											,
 											{
 												name: 'Small',
 												slug: 'small',
@@ -158,7 +157,7 @@ describe( 'Font Size Picker', () => {
 			await page.keyboard.type( 'Paragraph to be made "large"' );
 
 			await openFontSizeSelectControl();
-			await pressKeyTimes( 'ArrowDown', 5 );
+			await pressKeyTimes( 'ArrowDown', 4 );
 			await page.keyboard.press( 'Enter' );
 
 			expect( await getEditedPostContent() ).toMatchInlineSnapshot( `
@@ -175,7 +174,7 @@ describe( 'Font Size Picker', () => {
 			);
 
 			await openFontSizeSelectControl();
-			await pressKeyTimes( 'ArrowDown', 4 );
+			await pressKeyTimes( 'ArrowDown', 3 );
 			await page.keyboard.press( 'Enter' );
 			expect( await getEditedPostContent() ).toMatchInlineSnapshot( `
 			"<!-- wp:paragraph {\\"fontSize\\":\\"medium\\"} -->
@@ -202,7 +201,7 @@ describe( 'Font Size Picker', () => {
 			);
 
 			await openFontSizeSelectControl();
-			await pressKeyTimes( 'ArrowDown', 3 );
+			await pressKeyTimes( 'ArrowDown', 2 );
 			await page.keyboard.press( 'Enter' );
 			expect( await getEditedPostContent() ).toMatchInlineSnapshot( `
 			"<!-- wp:paragraph {\\"fontSize\\":\\"small\\"} -->

--- a/packages/e2e-tests/specs/editor/various/font-size-picker.test.js
+++ b/packages/e2e-tests/specs/editor/various/font-size-picker.test.js
@@ -102,50 +102,59 @@ describe( 'Font Size Picker', () => {
 	describe( 'More font sizes', () => {
 		beforeEach( async () => {
 			await page.evaluate( () => {
-				wp.data.dispatch( 'core/block-editor' ).updateSettings(
-					// eslint-disable-next-line no-undef
-					lodash.merge(
-						wp.data.select( 'core/block-editor' ).getSettings(),
-						{
-							__experimentalFeatures: {
-								typography: {
-									fontSizes: {
-										default: [
-											{
-												name: 'Tiny',
-												slug: 'tiny',
-												size: '11px',
-											},
-											{
-												name: 'Small',
-												slug: 'small',
-												size: '13px',
-											},
-											{
-												name: 'Medium',
-												slug: 'medium',
-												size: '20px',
-											},
-											{
-												name: 'Large',
-												slug: 'large',
-												size: '36px',
-											},
-											{
-												name: 'Extra Large',
-												slug: 'x-large',
-												size: '42px',
-											},
-											{
-												name: 'Huge',
-												slug: 'huge',
-												size: '48px',
-											},
-										],
-									},
-								},
-							},
+				// set a deep `path[]` property in object `obj` to `value`, immutably
+				function setDeep( obj, path, value ) {
+					function doSet( o, i ) {
+						if ( i < path.length ) {
+							const key = path[ i ];
+							return { ...o, [ key ]: doSet( o[ key ], i + 1 ) };
 						}
+						return value;
+					}
+					return doSet( obj, 0 );
+				}
+
+				wp.data.dispatch( 'core/block-editor' ).updateSettings(
+					setDeep(
+						wp.data.select( 'core/block-editor' ).getSettings(),
+						[
+							'__experimentalFeatures',
+							'typography',
+							'fontSizes',
+							'default',
+						],
+						[
+							{
+								name: 'Tiny',
+								slug: 'tiny',
+								size: '11px',
+							},
+							{
+								name: 'Small',
+								slug: 'small',
+								size: '13px',
+							},
+							{
+								name: 'Medium',
+								slug: 'medium',
+								size: '20px',
+							},
+							{
+								name: 'Large',
+								slug: 'large',
+								size: '36px',
+							},
+							{
+								name: 'Extra Large',
+								slug: 'x-large',
+								size: '42px',
+							},
+							{
+								name: 'Huge',
+								slug: 'huge',
+								size: '48px',
+							},
+						]
 					)
 				);
 			} );


### PR DESCRIPTION
This PR fixes an unreliable e2e test that starts failing after React 18 migration (#45235). There are two bugs:

The first one is a typo introduced in #37446 by @youknowriad. If you look at the diff, notice the extra `,` character in the font sizes array? That creates a sparse array that skips one index, and when merging such an array into existing one with `lodash.merge`, the element at the skipped index will have an old value:
```js
expect( _.merge( [ 'a', 'b', 'c' ], [ 'A', , 'B', 'C' ] ).toEqual( [ 'A', 'b', 'B', 'C' ] );
```
The result is that the overridden font size list has one item from the old list (namely for "Medium"), that there are items for a "Medium" size that cause a "duplicate React key" warning, and that array indexes in `expect()` calls are off by one.

The second bug is that the `lodash.merge` function modifies the settings object by _mutating_ it. After `updateSettings`, the `getSettings` selector will still return the same object, identity-wise, just mutated. If a component depends on the settings state:
```js
const { settings } = useSelect( ( select ) => ( {
  settings: select( 'core/block-editor' ).getSettings()
} ) );
```
it won't be rerendered because the old value is shallowly equal to the new one. Rerendering with the updated font size list must be accidentally triggered by something else. And it seems that in React 18 it's not.
