### PR TITLE
Components: refactor `withNotices` to pass `exhaustive-deps` 

### DIFF
--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -13,6 +13,7 @@
 ### Internal
 
 -   `PaletteEditListView`: Update to ignore `exhaustive-deps` eslint rule ([#45467](https://github.com/WordPress/gutenberg/pull/45467)).
+-   `withNotices`: Update to pass `exhaustive-deps` eslint rule ([#45530](https://github.com/WordPress/gutenberg/pull/45530)).
 
 ## 22.0.0 (2022-11-02)
 

--- a/packages/components/src/higher-order/with-notices/test/index.js
+++ b/packages/components/src/higher-order/with-notices/test/index.js
@@ -49,7 +49,7 @@ const BaseComponent = ( { noticeOperations, noticeUI, notifications } ) => {
 				noticeOperations.createNotice( item )
 			);
 		}
-	}, [] );
+	}, [ noticeOperations, notifications ] );
 	return (
 		<div>
 			{ noticeUI }


### PR DESCRIPTION
## What?
Updates the `withNotices` higher order component to pass the `exhaustive-deps` eslint rule.

## Why?
Part of the effort in https://github.com/WordPress/gutenberg/pull/41166 to apply `exhuastive-deps` to the Components package

## How?
Adding the two missing dependencies to the dependency array of the `BaseComponent` in the affected test.

Previously, this was an empty dep array, so the effect would only fire on the first render. Adding them appears safe because both `noticeOperations` and `notifications` are properly memoized when originally declared, so the effect should only fire when one of them is actually updated in some way.

cc @stokesman: It was a while ago, but do you remember your thought process when writing this test - was it intentionally to limit the effect the initial render? Curious if you think this change will negatively effect the reliability of the test.

## Testing Instructions
1. From your local Gutenberg directory, run `npx eslint --rule 'react-hooks/exhaustive-deps: warn' packages/components/src/higher-order`
2. Confirm that the linter returns no errors
3. Confirm `navigation` unit tests still pass