### PR TITLE
Components: refactor `ItemGroup` to pass `exhaustive-deps` 

### DIFF
--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -13,6 +13,7 @@
 ### Internal
 
 -   `PaletteEditListView`: Update to ignore `exhaustive-deps` eslint rule ([#45467](https://github.com/WordPress/gutenberg/pull/45467)).
+-   `ItemGroup`: Update to pass `exhaustive-deps` eslint rule ([#45531](https://github.com/WordPress/gutenberg/pull/45531)).
 
 ## 22.0.0 (2022-11-02)
 

--- a/packages/components/src/item-group/stories/index.js
+++ b/packages/components/src/item-group/stories/index.js
@@ -150,7 +150,7 @@ const ItemWithChevron = ( {
 
 	const itemClassName = useMemo(
 		() => cx( ! alwaysVisible && appearingChevron, className ),
-		[ alwaysVisible, className, cx ]
+		[ alwaysVisible, className, cx, appearingChevron ]
 	);
 
 	const chevronIconClassName = useMemo(


### PR DESCRIPTION
## What?
Updates the `ItemGroup` component to pass the `exhaustive-deps` eslint rule.

## Why?
Part of the effort in https://github.com/WordPress/gutenberg/pull/41166 to apply `exhuastive-deps` to the Components package

## How?
Add in the missing dependency into the array.


## Testing Instructions
1. From your local Gutenberg directory, run `npx eslint --rule 'react-hooks/exhaustive-deps: warn' packages/components/src/item-group`
2. Confirm that the linter returns no errors
3. Confirm `navigation` unit tests still pass
4. Run Storybook locally, confirm the `ItemGroup` component stories and/or docs still work as expected, looking particularly at the examples with chevron icons.