### PR TITLE
Ensure post-featured-image block is in_the_loop() for BC with core and plugins, and to fix lazy-loading

### DIFF
--- a/packages/block-library/src/post-featured-image/index.php
+++ b/packages/block-library/src/post-featured-image/index.php
@@ -19,6 +19,12 @@ function render_block_core_post_featured_image( $attributes, $content, $block ) 
 	}
 	$post_ID = $block->context['postId'];
 
+	// Check is needed for backward compatibility with third-party plugins
+	// that might rely on the `in_the_loop` check; calling `the_post` sets it to true.
+	if ( ! in_the_loop() && have_posts() ) {
+		the_post();
+	}
+
 	$is_link        = isset( $attributes['isLink'] ) && $attributes['isLink'];
 	$size_slug      = isset( $attributes['sizeSlug'] ) ? $attributes['sizeSlug'] : 'post-thumbnail';
 	$post_title     = trim( strip_tags( get_the_title( $post_ID ) ) );


### PR DESCRIPTION
## What?
This PR is part of the solution from https://github.com/WordPress/wordpress-develop/pull/3560 (see that PR for additional context), which addresses https://core.trac.wordpress.org/ticket/56930. The problem here specifically also addresses #41783.

## Why?
Currently the logic to not lazy-load the first featured image or in-content image is not working for block themes. https://github.com/WordPress/wordpress-develop/pull/3560 is the full solution to that problem, however this PR here is necessary since the block itself comes from Gutenberg. We should therefore merge and port this to WP core's blocks soon (in time for WP 6.2).

## How?
WP core's logic to determine whether to lazy-load an image expects to run `in_the_loop()` when the main content is rendered. Since block themes by default may not enter the loop initially, this extra call here needs to be added, as currently the lack of it is a backward compatibility break causing the problem outlined above. This fix is already present in the `post-content` block, so it's simply brought over here as well.

## Testing Instructions
1. Test this as part of https://github.com/WordPress/wordpress-develop/pull/3560 as by itself here it is not going to solve the entire problem.
2. Use a block theme and view a post with a featured image in the frontend.
3. With WordPress `trunk`, the first featured image will have `loading="lazy"` on it, which is incorrect. With https://github.com/WordPress/wordpress-develop/pull/3560, it will not have the attribute as expected.
