### PR TITLE
CheckboxControl: move icons out of labels

### DIFF
--- a/packages/block-editor/CHANGELOG.md
+++ b/packages/block-editor/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Enhancement
+
+-   `BlockLockModal`: Move Icon component out of CheckboxControl label ([#45535](https://github.com/WordPress/gutenberg/pull/45535))
+
 ## 10.4.0 (2022-11-02)
 
 ### Bug Fix

--- a/packages/block-editor/src/components/block-lock/modal.js
+++ b/packages/block-editor/src/components/block-lock/modal.js
@@ -146,6 +146,7 @@ export default function BlockLockModal( { clientId, onClose } ) {
 									}
 								/>
 								<Icon
+									className="block-editor-block-lock-modal__lock-icon"
 									icon={ lock.edit ? lockIcon : unlockIcon }
 								/>
 							</li>
@@ -162,7 +163,10 @@ export default function BlockLockModal( { clientId, onClose } ) {
 									} ) )
 								}
 							/>
-							<Icon icon={ lock.move ? lockIcon : unlockIcon } />
+							<Icon
+								className="block-editor-block-lock-modal__lock-icon"
+								icon={ lock.move ? lockIcon : unlockIcon }
+							/>
 						</li>
 						<li className="block-editor-block-lock-modal__checklist-item">
 							<CheckboxControl
@@ -177,6 +181,7 @@ export default function BlockLockModal( { clientId, onClose } ) {
 								}
 							/>
 							<Icon
+								className="block-editor-block-lock-modal__lock-icon"
 								icon={ lock.remove ? lockIcon : unlockIcon }
 							/>
 						</li>

--- a/packages/block-editor/src/components/block-lock/modal.js
+++ b/packages/block-editor/src/components/block-lock/modal.js
@@ -136,18 +136,7 @@ export default function BlockLockModal( { clientId, onClose } ) {
 							<li className="block-editor-block-lock-modal__checklist-item">
 								<CheckboxControl
 									__nextHasNoMarginBottom
-									label={
-										<>
-											{ __( 'Restrict editing' ) }
-											<Icon
-												icon={
-													lock.edit
-														? lockIcon
-														: unlockIcon
-												}
-											/>
-										</>
-									}
+									label={ __( 'Restrict editing' ) }
 									checked={ !! lock.edit }
 									onChange={ ( edit ) =>
 										setLock( ( prevLock ) => ( {
@@ -156,23 +145,15 @@ export default function BlockLockModal( { clientId, onClose } ) {
 										} ) )
 									}
 								/>
+								<Icon
+									icon={ lock.edit ? lockIcon : unlockIcon }
+								/>
 							</li>
 						) }
 						<li className="block-editor-block-lock-modal__checklist-item">
 							<CheckboxControl
 								__nextHasNoMarginBottom
-								label={
-									<>
-										{ __( 'Disable movement' ) }
-										<Icon
-											icon={
-												lock.move
-													? lockIcon
-													: unlockIcon
-											}
-										/>
-									</>
-								}
+								label={ __( 'Disable movement' ) }
 								checked={ lock.move }
 								onChange={ ( move ) =>
 									setLock( ( prevLock ) => ( {
@@ -181,22 +162,12 @@ export default function BlockLockModal( { clientId, onClose } ) {
 									} ) )
 								}
 							/>
+							<Icon icon={ lock.move ? lockIcon : unlockIcon } />
 						</li>
 						<li className="block-editor-block-lock-modal__checklist-item">
 							<CheckboxControl
 								__nextHasNoMarginBottom
-								label={
-									<>
-										{ __( 'Prevent removal' ) }
-										<Icon
-											icon={
-												lock.remove
-													? lockIcon
-													: unlockIcon
-											}
-										/>
-									</>
-								}
+								label={ __( 'Prevent removal' ) }
 								checked={ lock.remove }
 								onChange={ ( remove ) =>
 									setLock( ( prevLock ) => ( {
@@ -204,6 +175,9 @@ export default function BlockLockModal( { clientId, onClose } ) {
 										remove,
 									} ) )
 								}
+							/>
+							<Icon
+								icon={ lock.remove ? lockIcon : unlockIcon }
 							/>
 						</li>
 					</ul>

--- a/packages/block-editor/src/components/block-lock/style.scss
+++ b/packages/block-editor/src/components/block-lock/style.scss
@@ -27,10 +27,12 @@
 .block-editor-block-lock-modal__checklist-item {
 	display: flex;
 	justify-content: space-between;
+	align-items: center;
+	gap: $grid-unit-15;
 	margin-bottom: 0;
 	padding: $grid-unit-15 0 $grid-unit-15 $grid-unit-40;
 
-	svg {
+	.block-editor-block-lock-modal__lock-icon {
 		margin-right: $grid-unit-15;
 		fill: $gray-900;
 	}

--- a/packages/block-editor/src/components/block-lock/style.scss
+++ b/packages/block-editor/src/components/block-lock/style.scss
@@ -33,6 +33,7 @@
 	padding: $grid-unit-15 0 $grid-unit-15 $grid-unit-40;
 
 	.block-editor-block-lock-modal__lock-icon {
+		flex-shrink: 0;
 		margin-right: $grid-unit-15;
 		fill: $gray-900;
 	}

--- a/packages/block-editor/src/components/block-lock/style.scss
+++ b/packages/block-editor/src/components/block-lock/style.scss
@@ -25,24 +25,14 @@
 	}
 }
 .block-editor-block-lock-modal__checklist-item {
+	display: flex;
+	justify-content: space-between;
 	margin-bottom: 0;
 	padding: $grid-unit-15 0 $grid-unit-15 $grid-unit-40;
 
-	.components-base-control__field {
-		align-items: center;
-		display: flex;
-	}
-
-	.components-checkbox-control__label {
-		display: flex;
-		align-items: center;
-		justify-content: space-between;
-		flex-grow: 1;
-
-		svg {
-			margin-right: $grid-unit-15;
-			fill: $gray-900;
-		}
+	svg {
+		margin-right: $grid-unit-15;
+		fill: $gray-900;
 	}
 
 	&:hover {

--- a/packages/edit-post/CHANGELOG.md
+++ b/packages/edit-post/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Enhancement
+
+-   ` BlockTypesChecklist`: Move BlockIcon component out of CheckboxControl label ([#45535](https://github.com/WordPress/gutenberg/pull/45535))
+
 ## 6.18.0 (2022-11-02)
 
 ## 6.17.0 (2022-10-19)

--- a/packages/edit-post/src/components/block-manager/checklist.js
+++ b/packages/edit-post/src/components/block-manager/checklist.js
@@ -14,17 +14,13 @@ function BlockTypesChecklist( { blockTypes, value, onItemChange } ) {
 				>
 					<CheckboxControl
 						__nextHasNoMarginBottom
-						label={
-							<>
-								{ blockType.title }
-								<BlockIcon icon={ blockType.icon } />
-							</>
-						}
+						label={ blockType.title }
 						checked={ value.includes( blockType.name ) }
 						onChange={ ( ...args ) =>
 							onItemChange( blockType.name, ...args )
 						}
 					/>
+					<BlockIcon icon={ blockType.icon } />
 				</li>
 			) ) }
 		</ul>

--- a/packages/edit-post/src/components/block-manager/style.scss
+++ b/packages/edit-post/src/components/block-manager/style.scss
@@ -51,27 +51,17 @@
 .edit-post-block-manager__category-title,
 .edit-post-block-manager__checklist-item {
 	border-bottom: 1px solid $gray-300;
-
-	.components-base-control__field {
-		align-items: center;
-		display: flex;
-	}
 }
 
 .edit-post-block-manager__checklist-item {
+	display: flex;
+	justify-content: space-between;
+	align-items: center;
 	margin-bottom: 0;
-	padding-left: $grid-unit-20;
+	padding: $grid-unit-10 0 $grid-unit-10 $grid-unit-20;
 
 	.components-modal__content &.components-checkbox-control__input-container {
 		margin: 0 $grid-unit-10;
-	}
-
-	.components-checkbox-control__label {
-		display: flex;
-		align-items: center;
-		justify-content: space-between;
-		flex-grow: 1;
-		padding: $grid-unit-10 0;
 	}
 
 	.block-editor-block-icon {


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?

The icons for `BlockLockModal` and `BlockTypesChecklist` were nested inside the `CheckboxControl` label. This PR moves them out of the label and removes unnecessary CSS.

## Why?

This PR is based on the comment here: https://github.com/WordPress/gutenberg/pull/45434#discussion_r1012102618 by @mirka 

## How?
Moving the `Icon` and `BlockIcon` components out of the `label` prop. Also, removing the CSS for `components-base-control__field` and `components-checkbox-control__label` and moving it to the parent class for the respective components. 

## Testing Instructions

### **For `BlockLockModal`**

1. Add the Navigation block to the editor (this block has the extra setting `Restrict editing` that some other blocks don't have, i.e the Paragraph block)
2.  Click on the three dots and then on 'Lock'
3. Check the different checkboxes to test the options:
-- Make sure the icon shows the correct lock based on if it's locked or unlocked 
-- Ensure background hover works as expected 
-- Changes are responsive 

<img width="452" alt="Screen Shot 2022-11-03 at 5 54 56 PM" src="https://user-images.githubusercontent.com/35543432/199865666-78f223a6-060c-4feb-b11c-b4295731278e.png">


### **For `BlockTypesChecklist`**

1.  Click on three dots in the top right corner of post editor
2. Then select 'Preferences'
3. Click on 'Blocks' and scroll down to 'Visible Blocks'
4. Check for the following:
-- Ensure it looks the same as before **(it's about a pixel different in vertical spacing, not sure if that'll be an issue)** 
-- Check that it's responsive 

<img width="745" alt="Screen Shot 2022-11-03 at 6 22 44 PM" src="https://user-images.githubusercontent.com/35543432/199866040-7cd40039-5af9-49ff-a168-8c39bed6acc7.png">

