### PR TITLE
Fluid typography: adjust font size min and max rules

### DIFF
--- a/lib/block-supports/typography.php
+++ b/lib/block-supports/typography.php
@@ -462,7 +462,7 @@ function gutenberg_get_typography_font_size_value( $preset, $should_use_fluid_ty
 	$default_minimum_viewport_width   = '768px';
 	$default_minimum_font_size_factor = 0.75;
 	$default_scale_factor             = 1;
-	$default_minimum_font_size_limit  = '14px';
+	$default_minimum_font_size_limit  = '16px';
 
 	// Font sizes.
 	$fluid_font_size_settings = isset( $preset['fluid'] ) ? $preset['fluid'] : null;
@@ -492,7 +492,7 @@ function gutenberg_get_typography_font_size_value( $preset, $should_use_fluid_ty
 		)
 	);
 
-	// Don't enforce minimum font size if a font size has explicitly set a min and max value.
+	// Enforce lower bound font size if a font size has not explicitly set a min and/or a max value.
 	if ( ! empty( $minimum_font_size_limit ) && ( ! $minimum_font_size_raw && ! $maximum_font_size_raw ) ) {
 		/*
 		 * If a minimum size was not passed to this function
@@ -510,13 +510,13 @@ function gutenberg_get_typography_font_size_value( $preset, $should_use_fluid_ty
 	}
 
 	/*
-	 * If no minimumFontSize is provided, create one using
+	 * If no fluid min font size is provided, create one using
 	 * the given font size multiplied by the min font size scale factor.
 	 */
 	if ( ! $minimum_font_size_raw ) {
 		$calculated_minimum_font_size = round( $preferred_size['value'] * $default_minimum_font_size_factor, 3 );
 
-		// Only use calculated min font size if it's > $minimum_font_size_limit value.
+		// Only use calculated min font size if it is greater that the minimum font size limit.
 		if ( ! empty( $minimum_font_size_limit ) && $calculated_minimum_font_size <= $minimum_font_size_limit['value'] ) {
 			$minimum_font_size_raw = $minimum_font_size_limit['value'] . $minimum_font_size_limit['unit'];
 		} else {

--- a/lib/block-supports/typography.php
+++ b/lib/block-supports/typography.php
@@ -462,7 +462,7 @@ function gutenberg_get_typography_font_size_value( $preset, $should_use_fluid_ty
 	$default_minimum_viewport_width   = '768px';
 	$default_minimum_font_size_factor = 0.75;
 	$default_scale_factor             = 1;
-	$default_minimum_font_size_limit  = '16px';
+	$default_minimum_font_size_limit  = '14px';
 
 	// Font sizes.
 	$fluid_font_size_settings = isset( $preset['fluid'] ) ? $preset['fluid'] : null;
@@ -492,7 +492,7 @@ function gutenberg_get_typography_font_size_value( $preset, $should_use_fluid_ty
 		)
 	);
 
-	// Enforce lower bound font size if a font size has not explicitly set a min and/or a max value.
+	// Don't enforce minimum font size if a font size has explicitly set a min and max value.
 	if ( ! empty( $minimum_font_size_limit ) && ( ! $minimum_font_size_raw && ! $maximum_font_size_raw ) ) {
 		/*
 		 * If a minimum size was not passed to this function
@@ -510,13 +510,13 @@ function gutenberg_get_typography_font_size_value( $preset, $should_use_fluid_ty
 	}
 
 	/*
-	 * If no fluid min font size is provided, create one using
+	 * If no minimumFontSize is provided, create one using
 	 * the given font size multiplied by the min font size scale factor.
 	 */
 	if ( ! $minimum_font_size_raw ) {
 		$calculated_minimum_font_size = round( $preferred_size['value'] * $default_minimum_font_size_factor, 3 );
 
-		// Only use calculated min font size if it is greater that the minimum font size limit.
+		// Only use calculated min font size if it's > $minimum_font_size_limit value.
 		if ( ! empty( $minimum_font_size_limit ) && $calculated_minimum_font_size <= $minimum_font_size_limit['value'] ) {
 			$minimum_font_size_raw = $minimum_font_size_limit['value'] . $minimum_font_size_limit['unit'];
 		} else {

--- a/packages/block-editor/CHANGELOG.md
+++ b/packages/block-editor/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Enhancement
 
 -   `BlockLockModal`: Move Icon component out of CheckboxControl label ([#45535](https://github.com/WordPress/gutenberg/pull/45535))
+-   Fluid typography: adjust font size min and max rules ([#45536](https://github.com/WordPress/gutenberg/pull/45536)).
 
 ## 10.4.0 (2022-11-02)
 

--- a/packages/block-editor/README.md
+++ b/packages/block-editor/README.md
@@ -400,10 +400,9 @@ _Returns_
 Computes a fluid font-size value that uses clamp(). A minimum and maxinmum
 font size OR a single font size can be specified.
 
-If a single font size is specified, it is scaled down by
-minimumFontSizeFactor to arrive at the minimum font size.
-
-The incoming `fontSize` value is used for the maximum font size value.
+If a single font size is specified, it is scaled up and down by
+minimumFontSizeFactor and maximumFontSizeFactor to arrive at the minimum and
+maximum sizes.
 
 _Usage_
 

--- a/packages/block-editor/README.md
+++ b/packages/block-editor/README.md
@@ -400,9 +400,10 @@ _Returns_
 Computes a fluid font-size value that uses clamp(). A minimum and maxinmum
 font size OR a single font size can be specified.
 
-If a single font size is specified, it is scaled up and down by
-minimumFontSizeFactor and maximumFontSizeFactor to arrive at the minimum and
-maximum sizes.
+If a single font size is specified, it is scaled down by
+minimumFontSizeFactor to arrive at the minimum font size.
+
+The incoming `fontSize` value is used for the maximum font size value.
 
 _Usage_
 

--- a/packages/block-editor/README.md
+++ b/packages/block-editor/README.md
@@ -428,7 +428,6 @@ _Parameters_
 -   _args.minimumFontSize_ `?string`: Minimum font size for any clamp() calculation. Optional.
 -   _args.scaleFactor_ `?number`: A scale factor to determine how fast a font scales within boundaries. Optional.
 -   _args.minimumFontSizeFactor_ `?number`: How much to scale defaultFontSize by to derive minimumFontSize. Optional.
--   _args.maximumFontSizeFactor_ `?number`: How much to scale defaultFontSize by to derive maximumFontSize. Optional.
 
 _Returns_
 

--- a/packages/block-editor/src/components/font-sizes/fluid-utils.js
+++ b/packages/block-editor/src/components/font-sizes/fluid-utils.js
@@ -9,15 +9,16 @@ const DEFAULT_MAXIMUM_VIEWPORT_WIDTH = '1600px';
 const DEFAULT_MINIMUM_VIEWPORT_WIDTH = '768px';
 const DEFAULT_SCALE_FACTOR = 1;
 const DEFAULT_MINIMUM_FONT_SIZE_FACTOR = 0.75;
-const DEFAULT_MINIMUM_FONT_SIZE_LIMIT = '14px';
+const DEFAULT_MINIMUM_FONT_SIZE_LIMIT = '16px';
 
 /**
  * Computes a fluid font-size value that uses clamp(). A minimum and maxinmum
  * font size OR a single font size can be specified.
  *
- * If a single font size is specified, it is scaled up and down by
- * minimumFontSizeFactor and maximumFontSizeFactor to arrive at the minimum and
- * maximum sizes.
+ * If a single font size is specified, it is scaled down by
+ * minimumFontSizeFactor to arrive at the minimum font size.
+ *
+ * The incoming `fontSize` value is used for the maximum font size value.
  *
  * @example
  * ```js
@@ -74,7 +75,7 @@ export function getComputedFluidTypographyValue( {
 			}
 		);
 
-		// Don't enforce minimum font size if a font size has explicitly set a min and max value.
+		// Enforce lower bound font size if a font size has not explicitly set a min and/or a max value.
 		if (
 			!! minimumFontSizeLimitParsed?.value &&
 			! minimumFontSize &&
@@ -96,7 +97,7 @@ export function getComputedFluidTypographyValue( {
 		}
 
 		/*
-		 * If no minimumFontSize is provided, create one using
+		 * If no fluid min font size is provided, create one using
 		 * the given font size multiplied by the min font size scale factor.
 		 */
 		if ( ! minimumFontSize ) {
@@ -105,7 +106,7 @@ export function getComputedFluidTypographyValue( {
 				3
 			);
 
-			// Only use calculated min font size if it's > $minimum_font_size_limit value.
+			// Only use calculated min font size if it is greater that the minimum font size limit.
 			if (
 				!! minimumFontSizeLimitParsed?.value &&
 				calculatedMinimumFontSize < minimumFontSizeLimitParsed?.value
@@ -120,8 +121,10 @@ export function getComputedFluidTypographyValue( {
 	// Grab the minimum font size and normalize it in order to use the value for calculations.
 	const minimumFontSizeParsed = getTypographyValueAndUnit( minimumFontSize );
 
-	// We get a 'preferred' unit to keep units consistent when calculating,
-	// otherwise the result will not be accurate.
+	/*
+	 * We get a 'preferred' unit to keep units consistent when calculating,
+	 * otherwise the result will not be accurate.
+	 */
 	const fontSizeUnit = minimumFontSizeParsed?.unit || 'rem';
 
 	// Grabs the maximum font size and normalize it in order to use the value for calculations.

--- a/packages/block-editor/src/components/font-sizes/fluid-utils.js
+++ b/packages/block-editor/src/components/font-sizes/fluid-utils.js
@@ -9,7 +9,6 @@ const DEFAULT_MAXIMUM_VIEWPORT_WIDTH = '1600px';
 const DEFAULT_MINIMUM_VIEWPORT_WIDTH = '768px';
 const DEFAULT_SCALE_FACTOR = 1;
 const DEFAULT_MINIMUM_FONT_SIZE_FACTOR = 0.75;
-const DEFAULT_MAXIMUM_FONT_SIZE_FACTOR = 1.5;
 const DEFAULT_MINIMUM_FONT_SIZE_LIMIT = '14px';
 
 /**
@@ -41,7 +40,6 @@ const DEFAULT_MINIMUM_FONT_SIZE_LIMIT = '14px';
  * @param {?string}       args.minimumFontSize       Minimum font size for any clamp() calculation. Optional.
  * @param {?number}       args.scaleFactor           A scale factor to determine how fast a font scales within boundaries. Optional.
  * @param {?number}       args.minimumFontSizeFactor How much to scale defaultFontSize by to derive minimumFontSize. Optional.
- * @param {?number}       args.maximumFontSizeFactor How much to scale defaultFontSize by to derive maximumFontSize. Optional.
  *
  * @return {string|null} A font-size value using clamp().
  */
@@ -53,15 +51,8 @@ export function getComputedFluidTypographyValue( {
 	maximumViewPortWidth = DEFAULT_MAXIMUM_VIEWPORT_WIDTH,
 	scaleFactor = DEFAULT_SCALE_FACTOR,
 	minimumFontSizeFactor = DEFAULT_MINIMUM_FONT_SIZE_FACTOR,
-	maximumFontSizeFactor = DEFAULT_MAXIMUM_FONT_SIZE_FACTOR,
 	minimumFontSizeLimit = DEFAULT_MINIMUM_FONT_SIZE_LIMIT,
 } ) {
-	/*
-	 * Caches minimumFontSize in minimumFontSizeValue
-	 * so we can check if minimumFontSize exists later.
-	 */
-	let minimumFontSizeValue = minimumFontSize;
-
 	/*
 	 * Calculates missing minimumFontSize and maximumFontSize from
 	 * defaultFontSize if provided.
@@ -75,15 +66,6 @@ export function getComputedFluidTypographyValue( {
 			return null;
 		}
 
-		// If no minimumFontSize is provided, derive using min scale factor.
-		if ( ! minimumFontSizeValue ) {
-			minimumFontSizeValue =
-				roundToPrecision(
-					fontSizeParsed.value * minimumFontSizeFactor,
-					3
-				) + fontSizeParsed.unit;
-		}
-
 		// Parses the minimum font size limit, so we can perform checks using it.
 		const minimumFontSizeLimitParsed = getTypographyValueAndUnit(
 			minimumFontSizeLimit,
@@ -92,57 +74,51 @@ export function getComputedFluidTypographyValue( {
 			}
 		);
 
-		if ( !! minimumFontSizeLimitParsed?.value ) {
+		// Don't enforce minimum font size if a font size has explicitly set a min and max value.
+		if (
+			!! minimumFontSizeLimitParsed?.value &&
+			! minimumFontSize &&
+			! maximumFontSize
+		) {
 			/*
 			 * If a minimum size was not passed to this function
-			 * and the user-defined font size is lower than `minimumFontSizeLimit`,
-			 * then uses the user-defined font size as the minimum font-size.
+			 * and the user-defined font size is lower than $minimum_font_size_limit,
+			 * do not calculate a fluid value.
 			 */
-			if (
-				! minimumFontSize &&
-				fontSizeParsed?.value < minimumFontSizeLimitParsed?.value
-			) {
-				minimumFontSizeValue = `${ fontSizeParsed.value }${ fontSizeParsed.unit }`;
-			} else {
-				const minimumFontSizeParsed = getTypographyValueAndUnit(
-					minimumFontSizeValue,
-					{
-						coerceTo: fontSizeParsed.unit,
-					}
-				);
-
-				/*
-				 * Otherwise, if the passed or calculated minimum font size is lower than `minimumFontSizeLimit`
-				 * use `minimumFontSizeLimit` instead.
-				 */
-				if (
-					!! minimumFontSizeParsed?.value &&
-					minimumFontSizeParsed.value <
-						minimumFontSizeLimitParsed.value
-				) {
-					minimumFontSizeValue = `${ minimumFontSizeLimitParsed.value }${ minimumFontSizeLimitParsed.unit }`;
-				}
+			if ( fontSizeParsed?.value <= minimumFontSizeLimitParsed?.value ) {
+				return null;
 			}
 		}
 
-		// If no maximumFontSize is provided, derive using max scale factor.
+		// If no fluid max font size is available use the incoming value.
 		if ( ! maximumFontSize ) {
-			maximumFontSize =
-				roundToPrecision(
-					fontSizeParsed.value * maximumFontSizeFactor,
-					3
-				) + fontSizeParsed.unit;
+			maximumFontSize = `${ fontSizeParsed.value }${ fontSizeParsed.unit }`;
+		}
+
+		/*
+		 * If no minimumFontSize is provided, create one using
+		 * the given font size multiplied by the min font size scale factor.
+		 */
+		if ( ! minimumFontSize ) {
+			const calculatedMinimumFontSize = roundToPrecision(
+				fontSizeParsed.value * minimumFontSizeFactor,
+				3
+			);
+
+			// Only use calculated min font size if it's > $minimum_font_size_limit value.
+			if (
+				!! minimumFontSizeLimitParsed?.value &&
+				calculatedMinimumFontSize < minimumFontSizeLimitParsed?.value
+			) {
+				minimumFontSize = `${ minimumFontSizeLimitParsed.value }${ minimumFontSizeLimitParsed.unit }`;
+			} else {
+				minimumFontSize = `${ calculatedMinimumFontSize }${ fontSizeParsed.unit }`;
+			}
 		}
 	}
 
-	// Return early if one of the provided inputs is not provided.
-	if ( ! minimumFontSizeValue || ! maximumFontSize ) {
-		return null;
-	}
-
 	// Grab the minimum font size and normalize it in order to use the value for calculations.
-	const minimumFontSizeParsed =
-		getTypographyValueAndUnit( minimumFontSizeValue );
+	const minimumFontSizeParsed = getTypographyValueAndUnit( minimumFontSize );
 
 	// We get a 'preferred' unit to keep units consistent when calculating,
 	// otherwise the result will not be accurate.
@@ -159,12 +135,9 @@ export function getComputedFluidTypographyValue( {
 	}
 
 	// Uses rem for accessible fluid target font scaling.
-	const minimumFontSizeRem = getTypographyValueAndUnit(
-		minimumFontSizeValue,
-		{
-			coerceTo: 'rem',
-		}
-	);
+	const minimumFontSizeRem = getTypographyValueAndUnit( minimumFontSize, {
+		coerceTo: 'rem',
+	} );
 
 	// Viewport widths defined for fluid typography. Normalize units
 	const maximumViewPortWidthParsed = getTypographyValueAndUnit(
@@ -205,7 +178,7 @@ export function getComputedFluidTypographyValue( {
 	);
 	const fluidTargetFontSize = `${ minimumFontSizeRem.value }${ minimumFontSizeRem.unit } + ((1vw - ${ viewPortWidthOffset }) * ${ linearFactorScaled })`;
 
-	return `clamp(${ minimumFontSizeValue }, ${ fluidTargetFontSize }, ${ maximumFontSize })`;
+	return `clamp(${ minimumFontSize }, ${ fluidTargetFontSize }, ${ maximumFontSize })`;
 }
 
 /**

--- a/packages/block-editor/src/components/font-sizes/fluid-utils.js
+++ b/packages/block-editor/src/components/font-sizes/fluid-utils.js
@@ -9,16 +9,15 @@ const DEFAULT_MAXIMUM_VIEWPORT_WIDTH = '1600px';
 const DEFAULT_MINIMUM_VIEWPORT_WIDTH = '768px';
 const DEFAULT_SCALE_FACTOR = 1;
 const DEFAULT_MINIMUM_FONT_SIZE_FACTOR = 0.75;
-const DEFAULT_MINIMUM_FONT_SIZE_LIMIT = '16px';
+const DEFAULT_MINIMUM_FONT_SIZE_LIMIT = '14px';
 
 /**
  * Computes a fluid font-size value that uses clamp(). A minimum and maxinmum
  * font size OR a single font size can be specified.
  *
- * If a single font size is specified, it is scaled down by
- * minimumFontSizeFactor to arrive at the minimum font size.
- *
- * The incoming `fontSize` value is used for the maximum font size value.
+ * If a single font size is specified, it is scaled up and down by
+ * minimumFontSizeFactor and maximumFontSizeFactor to arrive at the minimum and
+ * maximum sizes.
  *
  * @example
  * ```js
@@ -75,7 +74,7 @@ export function getComputedFluidTypographyValue( {
 			}
 		);
 
-		// Enforce lower bound font size if a font size has not explicitly set a min and/or a max value.
+		// Don't enforce minimum font size if a font size has explicitly set a min and max value.
 		if (
 			!! minimumFontSizeLimitParsed?.value &&
 			! minimumFontSize &&
@@ -97,7 +96,7 @@ export function getComputedFluidTypographyValue( {
 		}
 
 		/*
-		 * If no fluid min font size is provided, create one using
+		 * If no minimumFontSize is provided, create one using
 		 * the given font size multiplied by the min font size scale factor.
 		 */
 		if ( ! minimumFontSize ) {
@@ -106,7 +105,7 @@ export function getComputedFluidTypographyValue( {
 				3
 			);
 
-			// Only use calculated min font size if it is greater that the minimum font size limit.
+			// Only use calculated min font size if it's > $minimum_font_size_limit value.
 			if (
 				!! minimumFontSizeLimitParsed?.value &&
 				calculatedMinimumFontSize < minimumFontSizeLimitParsed?.value
@@ -121,10 +120,8 @@ export function getComputedFluidTypographyValue( {
 	// Grab the minimum font size and normalize it in order to use the value for calculations.
 	const minimumFontSizeParsed = getTypographyValueAndUnit( minimumFontSize );
 
-	/*
-	 * We get a 'preferred' unit to keep units consistent when calculating,
-	 * otherwise the result will not be accurate.
-	 */
+	// We get a 'preferred' unit to keep units consistent when calculating,
+	// otherwise the result will not be accurate.
 	const fontSizeUnit = minimumFontSizeParsed?.unit || 'rem';
 
 	// Grabs the maximum font size and normalize it in order to use the value for calculations.

--- a/packages/block-editor/src/components/font-sizes/test/fluid-utils.js
+++ b/packages/block-editor/src/components/font-sizes/test/fluid-utils.js
@@ -33,7 +33,7 @@ describe( 'getComputedFluidTypographyValue()', () => {
 			fontSize: '30px',
 		} );
 		expect( fluidTypographyValues ).toBe(
-			'clamp(22.5px, 1.406rem + ((1vw - 7.68px) * 2.704), 45px)'
+			'clamp(22.5px, 1.406rem + ((1vw - 7.68px) * 0.901), 30px)'
 		);
 	} );
 
@@ -42,7 +42,7 @@ describe( 'getComputedFluidTypographyValue()', () => {
 			fontSize: '30px',
 		} );
 		expect( fluidTypographyValues ).toBe(
-			'clamp(22.5px, 1.406rem + ((1vw - 7.68px) * 2.704), 45px)'
+			'clamp(22.5px, 1.406rem + ((1vw - 7.68px) * 0.901), 30px)'
 		);
 	} );
 
@@ -53,7 +53,7 @@ describe( 'getComputedFluidTypographyValue()', () => {
 			maximumViewPortWidth: '1000px',
 		} );
 		expect( fluidTypographyValues ).toBe(
-			'clamp(22.5px, 1.406rem + ((1vw - 5px) * 4.5), 45px)'
+			'clamp(22.5px, 1.406rem + ((1vw - 5px) * 1.5), 30px)'
 		);
 	} );
 
@@ -63,7 +63,7 @@ describe( 'getComputedFluidTypographyValue()', () => {
 			scaleFactor: '2',
 		} );
 		expect( fluidTypographyValues ).toBe(
-			'clamp(22.5px, 1.406rem + ((1vw - 7.68px) * 5.409), 45px)'
+			'clamp(22.5px, 1.406rem + ((1vw - 7.68px) * 1.803), 30px)'
 		);
 	} );
 
@@ -74,7 +74,7 @@ describe( 'getComputedFluidTypographyValue()', () => {
 			maximumFontSizeFactor: '2',
 		} );
 		expect( fluidTypographyValues ).toBe(
-			'clamp(15px, 0.938rem + ((1vw - 7.68px) * 5.409), 60px)'
+			'clamp(15px, 0.938rem + ((1vw - 7.68px) * 1.803), 30px)'
 		);
 	} );
 

--- a/packages/block-editor/src/components/font-sizes/test/fluid-utils.js
+++ b/packages/block-editor/src/components/font-sizes/test/fluid-utils.js
@@ -67,14 +67,14 @@ describe( 'getComputedFluidTypographyValue()', () => {
 		);
 	} );
 
-	it( 'should return a fluid font size and apply lower bound when given a min and max font size factor', () => {
+	it( 'should return a fluid font size when given a min and max font size factor', () => {
 		const fluidTypographyValues = getComputedFluidTypographyValue( {
 			fontSize: '30px',
 			minimumFontSizeFactor: '0.5',
 			maximumFontSizeFactor: '2',
 		} );
 		expect( fluidTypographyValues ).toBe(
-			'clamp(16px, 1rem + ((1vw - 7.68px) * 1.683), 30px)'
+			'clamp(15px, 0.938rem + ((1vw - 7.68px) * 1.803), 30px)'
 		);
 	} );
 

--- a/packages/block-editor/src/components/font-sizes/test/fluid-utils.js
+++ b/packages/block-editor/src/components/font-sizes/test/fluid-utils.js
@@ -67,14 +67,14 @@ describe( 'getComputedFluidTypographyValue()', () => {
 		);
 	} );
 
-	it( 'should return a fluid font size when given a min and max font size factor', () => {
+	it( 'should return a fluid font size and apply lower bound when given a min and max font size factor', () => {
 		const fluidTypographyValues = getComputedFluidTypographyValue( {
 			fontSize: '30px',
 			minimumFontSizeFactor: '0.5',
 			maximumFontSizeFactor: '2',
 		} );
 		expect( fluidTypographyValues ).toBe(
-			'clamp(15px, 0.938rem + ((1vw - 7.68px) * 1.803), 30px)'
+			'clamp(16px, 1rem + ((1vw - 7.68px) * 1.683), 30px)'
 		);
 	} );
 

--- a/packages/block-editor/src/hooks/test/use-typography-props.js
+++ b/packages/block-editor/src/hooks/test/use-typography-props.js
@@ -42,7 +42,7 @@ describe( 'getTypographyClassesAndStyles', () => {
 			style: {
 				letterSpacing: '22px',
 				fontSize:
-					'clamp(1.5rem, 1.5rem + ((1vw - 0.48rem) * 2.885), 3rem)',
+					'clamp(1.5rem, 1.5rem + ((1vw - 0.48rem) * 0.962), 2rem)',
 				textTransform: 'uppercase',
 			},
 		} );

--- a/packages/edit-site/src/components/global-styles/test/typography-utils.js
+++ b/packages/edit-site/src/components/global-styles/test/typography-utils.js
@@ -7,7 +7,7 @@ describe( 'typography utils', () => {
 	describe( 'getTypographyFontSizeValue', () => {
 		[
 			{
-				message: 'Default return non-fluid value.',
+				message: 'returns value when fluid typography is deactivated',
 				preset: {
 					size: '28px',
 				},
@@ -16,7 +16,7 @@ describe( 'typography utils', () => {
 			},
 
 			{
-				message: 'Default return value where font size is 0.',
+				message: 'returns value where font size is 0',
 				preset: {
 					size: 0,
 				},
@@ -25,7 +25,7 @@ describe( 'typography utils', () => {
 			},
 
 			{
-				message: "Default return value where font size is '0'.",
+				message: "returns value where font size is '0'",
 				preset: {
 					size: '0',
 				},
@@ -34,17 +34,16 @@ describe( 'typography utils', () => {
 			},
 
 			{
-				message:
-					'Default return non-fluid value where `size` is undefined.',
+				message: 'returns value where `size` is `null`.',
 				preset: {
-					size: undefined,
+					size: null,
 				},
-				typographySettings: undefined,
-				expected: undefined,
+				typographySettings: null,
+				expected: null,
 			},
 
 			{
-				message: 'return non-fluid value when fluid is `false`.',
+				message: 'returns value when fluid is `false`',
 				preset: {
 					size: '28px',
 					fluid: false,
@@ -56,34 +55,7 @@ describe( 'typography utils', () => {
 			},
 
 			{
-				message:
-					'Should coerce integer to `px` and return fluid value.',
-				preset: {
-					size: 33,
-					fluid: true,
-				},
-				typographySettings: {
-					fluid: true,
-				},
-				expected:
-					'clamp(24.75px, 1.547rem + ((1vw - 7.68px) * 2.975), 49.5px)',
-			},
-
-			{
-				message: 'coerce float to `px` and return fluid value.',
-				preset: {
-					size: 100.23,
-					fluid: true,
-				},
-				typographySettings: {
-					fluid: true,
-				},
-				expected:
-					'clamp(75.173px, 4.698rem + ((1vw - 7.68px) * 9.035), 150.345px)',
-			},
-
-			{
-				message: 'return incoming value when already clamped.',
+				message: 'returns already clamped value',
 				preset: {
 					size: 'clamp(21px, 1.313rem + ((1vw - 7.68px) * 2.524), 42px)',
 					fluid: false,
@@ -96,7 +68,7 @@ describe( 'typography utils', () => {
 			},
 
 			{
-				message: 'return incoming value with unsupported unit.',
+				message: 'returns value with unsupported unit',
 				preset: {
 					size: '1000%',
 					fluid: false,
@@ -108,7 +80,7 @@ describe( 'typography utils', () => {
 			},
 
 			{
-				message: 'return fluid value.',
+				message: 'returns clamp value with rem min and max units',
 				preset: {
 					size: '1.75rem',
 				},
@@ -116,11 +88,23 @@ describe( 'typography utils', () => {
 					fluid: true,
 				},
 				expected:
-					'clamp(1.313rem, 1.313rem + ((1vw - 0.48rem) * 2.523), 2.625rem)',
+					'clamp(1.313rem, 1.313rem + ((1vw - 0.48rem) * 0.84), 1.75rem)',
 			},
 
 			{
-				message: 'return fluid value for floats with units.',
+				message: 'returns clamp value with eem min and max units',
+				preset: {
+					size: '1.75em',
+				},
+				typographySettings: {
+					fluid: true,
+				},
+				expected:
+					'clamp(1.313em, 1.313rem + ((1vw - 0.48em) * 0.84), 1.75em)',
+			},
+
+			{
+				message: 'returns clamp value for floats',
 				preset: {
 					size: '100.175px',
 				},
@@ -128,12 +112,37 @@ describe( 'typography utils', () => {
 					fluid: true,
 				},
 				expected:
-					'clamp(75.131px, 4.696rem + ((1vw - 7.68px) * 9.03), 150.263px)',
+					'clamp(75.131px, 4.696rem + ((1vw - 7.68px) * 3.01), 100.175px)',
 			},
 
 			{
-				message:
-					'Should return default fluid values with empty fluid array.',
+				message: 'coerces integer to `px` and returns clamp value',
+				preset: {
+					size: 33,
+					fluid: true,
+				},
+				typographySettings: {
+					fluid: true,
+				},
+				expected:
+					'clamp(24.75px, 1.547rem + ((1vw - 7.68px) * 0.992), 33px)',
+			},
+
+			{
+				message: 'coerces float to `px` and returns clamp value',
+				preset: {
+					size: 100.23,
+					fluid: true,
+				},
+				typographySettings: {
+					fluid: true,
+				},
+				expected:
+					'clamp(75.173px, 4.698rem + ((1vw - 7.68px) * 3.012), 100.23px)',
+			},
+
+			{
+				message: 'returns clamp value when `fluid` is empty array',
 				preset: {
 					size: '28px',
 					fluid: [],
@@ -142,11 +151,11 @@ describe( 'typography utils', () => {
 					fluid: true,
 				},
 				expected:
-					'clamp(21px, 1.313rem + ((1vw - 7.68px) * 2.524), 42px)',
+					'clamp(21px, 1.313rem + ((1vw - 7.68px) * 0.841), 28px)',
 			},
 
 			{
-				message: 'return default fluid values with null value.',
+				message: 'returns clamp value when `fluid` is `null`',
 				preset: {
 					size: '28px',
 					fluid: null,
@@ -155,12 +164,12 @@ describe( 'typography utils', () => {
 					fluid: true,
 				},
 				expected:
-					'clamp(21px, 1.313rem + ((1vw - 7.68px) * 2.524), 42px)',
+					'clamp(21px, 1.313rem + ((1vw - 7.68px) * 0.841), 28px)',
 			},
 
 			{
 				message:
-					'return clamped value if min font size is greater than max.',
+					'returns clamp value if min font size is greater than max',
 				preset: {
 					size: '3rem',
 					fluid: {
@@ -176,7 +185,7 @@ describe( 'typography utils', () => {
 			},
 
 			{
-				message: 'return size with invalid fluid units.',
+				message: 'returns value with invalid min/max fluid units',
 				preset: {
 					size: '10em',
 					fluid: {
@@ -192,20 +201,30 @@ describe( 'typography utils', () => {
 
 			{
 				message:
-					'return clamped using font size where no min is given and size is less than default min size.',
+					'returns value when size is < lower bounds and no fluid min/max set',
 				preset: {
 					size: '3px',
 				},
 				typographySettings: {
 					fluid: true,
 				},
-				expected:
-					'clamp(3px, 0.188rem + ((1vw - 7.68px) * 0.18), 4.5px)',
+				expected: '3px',
 			},
 
 			{
 				message:
-					'return fluid clamp value with different min max units.',
+					'returns value when size is equal to lower bounds and no fluid min/max set',
+				preset: {
+					size: '14px',
+				},
+				typographySettings: {
+					fluid: true,
+				},
+				expected: '14px',
+			},
+
+			{
+				message: 'returns clamp value with different min max units',
 				preset: {
 					size: '28px',
 					fluid: {
@@ -219,10 +238,9 @@ describe( 'typography utils', () => {
 				expected:
 					'clamp(20px, 1.25rem + ((1vw - 7.68px) * 93.75), 50rem)',
 			},
-			//
+
 			{
-				message:
-					' Should return clamp value with default fluid max value.',
+				message: 'returns clamp value where no fluid max size is set',
 				preset: {
 					size: '28px',
 					fluid: {
@@ -233,12 +251,11 @@ describe( 'typography utils', () => {
 					fluid: true,
 				},
 				expected:
-					'clamp(2.6rem, 2.6rem + ((1vw - 0.48rem) * 0.048), 42px)',
+					'clamp(2.6rem, 2.6rem + ((1vw - 0.48rem) * -1.635), 28px)',
 			},
 
 			{
-				message:
-					'Should return clamp value with default fluid min value.',
+				message: 'returns clamp value where no fluid min size is set',
 				preset: {
 					size: '28px',
 					fluid: {
@@ -253,73 +270,8 @@ describe( 'typography utils', () => {
 			},
 
 			{
-				message: 'adjust computed min in px to min limit.',
-				preset: {
-					size: '14px',
-				},
-				typographySettings: {
-					fluid: true,
-				},
-				expected:
-					'clamp(14px, 0.875rem + ((1vw - 7.68px) * 0.841), 21px)',
-			},
-
-			{
-				message: 'adjust computed min in rem to min limit.',
-				preset: {
-					size: '1.1rem',
-				},
-				typographySettings: {
-					fluid: true,
-				},
-				expected:
-					'clamp(0.875rem, 0.875rem + ((1vw - 0.48rem) * 1.49), 1.65rem)',
-			},
-
-			{
-				message: 'adjust computed min in em to min limit.',
-				preset: {
-					size: '1.1em',
-				},
-				typographySettings: {
-					fluid: true,
-				},
-				expected:
-					'clamp(0.875em, 0.875rem + ((1vw - 0.48em) * 1.49), 1.65em)',
-			},
-
-			{
-				message: 'adjust fluid min value in px to min limit',
-				preset: {
-					size: '20px',
-					fluid: {
-						min: '12px',
-					},
-				},
-				typographySettings: {
-					fluid: true,
-				},
-				expected:
-					'clamp(14px, 0.875rem + ((1vw - 7.68px) * 1.923), 30px)',
-			},
-
-			{
-				message: 'adjust fluid min value in rem to min limit.',
-				preset: {
-					size: '1.5rem',
-					fluid: {
-						min: '0.5rem',
-					},
-				},
-				typographySettings: {
-					fluid: true,
-				},
-				expected:
-					'clamp(0.875rem, 0.875rem + ((1vw - 0.48rem) * 2.644), 2.25rem)',
-			},
-
-			{
-				message: 'adjust fluid min value but honor max value.',
+				message:
+					'should not apply lower bound test when fluid values are set',
 				preset: {
 					size: '1.5rem',
 					fluid: {
@@ -331,12 +283,44 @@ describe( 'typography utils', () => {
 					fluid: true,
 				},
 				expected:
-					'clamp(0.875rem, 0.875rem + ((1vw - 0.48rem) * 7.933), 5rem)',
+					'clamp(0.5rem, 0.5rem + ((1vw - 0.48rem) * 8.654), 5rem)',
 			},
 
 			{
 				message:
-					'return a fluid font size a min and max font sizes are equal.',
+					'should not apply lower bound test when only fluid min is set',
+				preset: {
+					size: '20px',
+					fluid: {
+						min: '12px',
+					},
+				},
+				typographySettings: {
+					fluid: true,
+				},
+				expected:
+					'clamp(12px, 0.75rem + ((1vw - 7.68px) * 0.962), 20px)',
+			},
+
+			{
+				message:
+					'should not apply lower bound test when only fluid max is set',
+				preset: {
+					size: '0.875rem',
+					fluid: {
+						max: '20rem',
+					},
+				},
+				typographySettings: {
+					fluid: true,
+				},
+				expected:
+					'clamp(0.875rem, 0.875rem + ((1vw - 0.48rem) * 36.779), 20rem)',
+			},
+
+			{
+				message:
+					'returns clamp value when min and max font sizes are equal',
 				preset: {
 					size: '4rem',
 					fluid: {

--- a/packages/edit-site/src/components/global-styles/test/typography-utils.js
+++ b/packages/edit-site/src/components/global-styles/test/typography-utils.js
@@ -215,12 +215,12 @@ describe( 'typography utils', () => {
 				message:
 					'returns value when size is equal to lower bounds and no fluid min/max set',
 				preset: {
-					size: '16px',
+					size: '14px',
 				},
 				typographySettings: {
 					fluid: true,
 				},
-				expected: '16px',
+				expected: '14px',
 			},
 
 			{
@@ -304,7 +304,7 @@ describe( 'typography utils', () => {
 
 			{
 				message:
-					'should apply lower bound test when only fluid max is set',
+					'should not apply lower bound test when only fluid max is set',
 				preset: {
 					size: '0.875rem',
 					fluid: {
@@ -315,7 +315,7 @@ describe( 'typography utils', () => {
 					fluid: true,
 				},
 				expected:
-					'clamp(1rem, 1rem + ((1vw - 0.48rem) * 36.538), 20rem)',
+					'clamp(0.875rem, 0.875rem + ((1vw - 0.48rem) * 36.779), 20rem)',
 			},
 
 			{

--- a/packages/edit-site/src/components/global-styles/test/typography-utils.js
+++ b/packages/edit-site/src/components/global-styles/test/typography-utils.js
@@ -215,12 +215,12 @@ describe( 'typography utils', () => {
 				message:
 					'returns value when size is equal to lower bounds and no fluid min/max set',
 				preset: {
-					size: '14px',
+					size: '16px',
 				},
 				typographySettings: {
 					fluid: true,
 				},
-				expected: '14px',
+				expected: '16px',
 			},
 
 			{
@@ -304,7 +304,7 @@ describe( 'typography utils', () => {
 
 			{
 				message:
-					'should not apply lower bound test when only fluid max is set',
+					'should apply lower bound test when only fluid max is set',
 				preset: {
 					size: '0.875rem',
 					fluid: {
@@ -315,7 +315,7 @@ describe( 'typography utils', () => {
 					fluid: true,
 				},
 				expected:
-					'clamp(0.875rem, 0.875rem + ((1vw - 0.48rem) * 36.779), 20rem)',
+					'clamp(1rem, 1rem + ((1vw - 0.48rem) * 36.538), 20rem)',
 			},
 
 			{

--- a/packages/edit-site/src/components/global-styles/test/use-global-styles-output.js
+++ b/packages/edit-site/src/components/global-styles/test/use-global-styles-output.js
@@ -711,7 +711,7 @@ describe( 'global styles renderer', () => {
 			},
 			typography: {
 				fontFamily: 'sans-serif',
-				fontSize: '15px',
+				fontSize: '17px',
 			},
 		};
 
@@ -725,7 +725,7 @@ describe( 'global styles renderer', () => {
 				'--wp--style--root--padding-left: 33px',
 				'background-color: var(--wp--preset--color--light-green-cyan)',
 				'font-family: sans-serif',
-				'font-size: 15px',
+				'font-size: 17px',
 			] );
 		} );
 
@@ -739,7 +739,7 @@ describe( 'global styles renderer', () => {
 				'padding-bottom: 33px',
 				'padding-left: 33px',
 				'font-family: sans-serif',
-				'font-size: 15px',
+				'font-size: 17px',
 			] );
 		} );
 
@@ -757,7 +757,7 @@ describe( 'global styles renderer', () => {
 				'padding-bottom: 33px',
 				'padding-left: 33px',
 				'font-family: sans-serif',
-				'font-size: 15px',
+				'font-size: 17px',
 			] );
 		} );
 
@@ -782,7 +782,7 @@ describe( 'global styles renderer', () => {
 				'padding-bottom: 33px',
 				'padding-left: 33px',
 				'font-family: sans-serif',
-				'font-size: clamp(14px, 0.875rem + ((1vw - 7.68px) * 0.12), 15px)',
+				'font-size: clamp(16px, 1rem + ((1vw - 7.68px) * 0.12), 17px)',
 			] );
 		} );
 
@@ -807,7 +807,7 @@ describe( 'global styles renderer', () => {
 				'padding-bottom: 33px',
 				'padding-left: 33px',
 				'font-family: sans-serif',
-				'font-size: 15px',
+				'font-size: 17px',
 			] );
 		} );
 	} );

--- a/packages/edit-site/src/components/global-styles/test/use-global-styles-output.js
+++ b/packages/edit-site/src/components/global-styles/test/use-global-styles-output.js
@@ -711,7 +711,7 @@ describe( 'global styles renderer', () => {
 			},
 			typography: {
 				fontFamily: 'sans-serif',
-				fontSize: '17px',
+				fontSize: '15px',
 			},
 		};
 
@@ -725,7 +725,7 @@ describe( 'global styles renderer', () => {
 				'--wp--style--root--padding-left: 33px',
 				'background-color: var(--wp--preset--color--light-green-cyan)',
 				'font-family: sans-serif',
-				'font-size: 17px',
+				'font-size: 15px',
 			] );
 		} );
 
@@ -739,7 +739,7 @@ describe( 'global styles renderer', () => {
 				'padding-bottom: 33px',
 				'padding-left: 33px',
 				'font-family: sans-serif',
-				'font-size: 17px',
+				'font-size: 15px',
 			] );
 		} );
 
@@ -757,7 +757,7 @@ describe( 'global styles renderer', () => {
 				'padding-bottom: 33px',
 				'padding-left: 33px',
 				'font-family: sans-serif',
-				'font-size: 17px',
+				'font-size: 15px',
 			] );
 		} );
 
@@ -782,7 +782,7 @@ describe( 'global styles renderer', () => {
 				'padding-bottom: 33px',
 				'padding-left: 33px',
 				'font-family: sans-serif',
-				'font-size: clamp(16px, 1rem + ((1vw - 7.68px) * 0.12), 17px)',
+				'font-size: clamp(14px, 0.875rem + ((1vw - 7.68px) * 0.12), 15px)',
 			] );
 		} );
 
@@ -807,7 +807,7 @@ describe( 'global styles renderer', () => {
 				'padding-bottom: 33px',
 				'padding-left: 33px',
 				'font-family: sans-serif',
-				'font-size: 17px',
+				'font-size: 15px',
 			] );
 		} );
 	} );

--- a/packages/edit-site/src/components/global-styles/test/use-global-styles-output.js
+++ b/packages/edit-site/src/components/global-styles/test/use-global-styles-output.js
@@ -711,7 +711,7 @@ describe( 'global styles renderer', () => {
 			},
 			typography: {
 				fontFamily: 'sans-serif',
-				fontSize: '14px',
+				fontSize: '15px',
 			},
 		};
 
@@ -725,7 +725,7 @@ describe( 'global styles renderer', () => {
 				'--wp--style--root--padding-left: 33px',
 				'background-color: var(--wp--preset--color--light-green-cyan)',
 				'font-family: sans-serif',
-				'font-size: 14px',
+				'font-size: 15px',
 			] );
 		} );
 
@@ -739,7 +739,7 @@ describe( 'global styles renderer', () => {
 				'padding-bottom: 33px',
 				'padding-left: 33px',
 				'font-family: sans-serif',
-				'font-size: 14px',
+				'font-size: 15px',
 			] );
 		} );
 
@@ -757,7 +757,7 @@ describe( 'global styles renderer', () => {
 				'padding-bottom: 33px',
 				'padding-left: 33px',
 				'font-family: sans-serif',
-				'font-size: 14px',
+				'font-size: 15px',
 			] );
 		} );
 
@@ -782,7 +782,7 @@ describe( 'global styles renderer', () => {
 				'padding-bottom: 33px',
 				'padding-left: 33px',
 				'font-family: sans-serif',
-				'font-size: clamp(14px, 0.875rem + ((1vw - 7.68px) * 0.841), 21px)',
+				'font-size: clamp(14px, 0.875rem + ((1vw - 7.68px) * 0.12), 15px)',
 			] );
 		} );
 
@@ -807,7 +807,7 @@ describe( 'global styles renderer', () => {
 				'padding-bottom: 33px',
 				'padding-left: 33px',
 				'font-family: sans-serif',
-				'font-size: 14px',
+				'font-size: 15px',
 			] );
 		} );
 	} );

--- a/phpunit/block-supports/typography-test.php
+++ b/phpunit/block-supports/typography-test.php
@@ -466,10 +466,10 @@ class WP_Block_Supports_Typography_Test extends WP_UnitTestCase {
 
 			'returns value when size is equal to lower bounds and no fluid min/max set' => array(
 				'font_size'                   => array(
-					'size' => '16px',
+					'size' => '14px',
 				),
 				'should_use_fluid_typography' => true,
-				'expected_output'             => '16px',
+				'expected_output'             => '14px',
 			),
 
 			'returns clamp value with different min max units' => array(
@@ -529,7 +529,7 @@ class WP_Block_Supports_Typography_Test extends WP_UnitTestCase {
 				'expected_output'             => 'clamp(12px, 0.75rem + ((1vw - 7.68px) * 0.962), 20px)',
 			),
 
-			'should apply lower bound test when only fluid max is set' => array(
+			'should not apply lower bound test when only fluid max is set' => array(
 				'font_size'                   => array(
 					'size'  => '0.875rem',
 					'fluid' => array(
@@ -537,7 +537,7 @@ class WP_Block_Supports_Typography_Test extends WP_UnitTestCase {
 					),
 				),
 				'should_use_fluid_typography' => true,
-				'expected_output'             => 'clamp(1rem, 1rem + ((1vw - 0.48rem) * 36.538), 20rem)',
+				'expected_output'             => 'clamp(0.875rem, 0.875rem + ((1vw - 0.48rem) * 36.779), 20rem)',
 			),
 
 			'returns clamp value when min and max font sizes are equal' => array(
@@ -698,7 +698,7 @@ class WP_Block_Supports_Typography_Test extends WP_UnitTestCase {
 				'block_content'               => '<p class="has-medium-font-size" style="    font-size:   20px   ;    ">A paragraph inside a group</p>',
 				'font_size_value'             => '20px',
 				'should_use_fluid_typography' => true,
-				'expected_output'             => '<p class="has-medium-font-size" style="    font-size:clamp(16px, 1rem + ((1vw - 7.68px) * 0.481), 20px);    ">A paragraph inside a group</p>',
+				'expected_output'             => '<p class="has-medium-font-size" style="    font-size:clamp(15px, 0.938rem + ((1vw - 7.68px) * 0.601), 20px);    ">A paragraph inside a group</p>',
 			),
 			'return_content_with_first_match_replace_only' => array(
 				'block_content'               => "<div class=\"wp-block-group\" style=\"font-size:1.5em\"> \n \n<p style=\"font-size:1.5em\">A paragraph inside a group</p></div>",

--- a/phpunit/block-supports/typography-test.php
+++ b/phpunit/block-supports/typography-test.php
@@ -374,12 +374,20 @@ class WP_Block_Supports_Typography_Test extends WP_UnitTestCase {
 				'expected_output'             => '1000%',
 			),
 
-			'return_fluid_value'                          => array(
+			'return_fluid_value_rem'                      => array(
 				'font_size'                   => array(
 					'size' => '1.75rem',
 				),
 				'should_use_fluid_typography' => true,
-				'expected_output'             => 'clamp(1.313rem, 1.313rem + ((1vw - 0.48rem) * 2.523), 2.625rem)',
+				'expected_output'             => 'clamp(1.313rem, 1.313rem + ((1vw - 0.48rem) * 0.84), 1.75rem)',
+			),
+
+			'return_fluid_value_em'                       => array(
+				'font_size'                   => array(
+					'size' => '1.75em',
+				),
+				'should_use_fluid_typography' => true,
+				'expected_output'             => 'clamp(1.313em, 1.313rem + ((1vw - 0.48em) * 0.84), 1.75em)',
 			),
 
 			'return_fluid_value_with_floats_with_units'   => array(
@@ -387,7 +395,7 @@ class WP_Block_Supports_Typography_Test extends WP_UnitTestCase {
 					'size' => '100.175px',
 				),
 				'should_use_fluid_typography' => true,
-				'expected_output'             => 'clamp(75.131px, 4.696rem + ((1vw - 7.68px) * 9.03), 150.263px)',
+				'expected_output'             => 'clamp(75.131px, 4.696rem + ((1vw - 7.68px) * 3.01), 100.175px)',
 			),
 
 			'return_fluid_value_with_integer_coerced_to_px' => array(
@@ -395,7 +403,7 @@ class WP_Block_Supports_Typography_Test extends WP_UnitTestCase {
 					'size' => 33,
 				),
 				'should_use_fluid_typography' => true,
-				'expected_output'             => 'clamp(24.75px, 1.547rem + ((1vw - 7.68px) * 2.975), 49.5px)',
+				'expected_output'             => 'clamp(24.75px, 1.547rem + ((1vw - 7.68px) * 0.992), 33px)',
 			),
 
 			'return_fluid_value_with_float_coerced_to_px' => array(
@@ -403,7 +411,7 @@ class WP_Block_Supports_Typography_Test extends WP_UnitTestCase {
 					'size' => 100.23,
 				),
 				'should_use_fluid_typography' => true,
-				'expected_output'             => 'clamp(75.173px, 4.698rem + ((1vw - 7.68px) * 9.035), 150.345px)',
+				'expected_output'             => 'clamp(75.173px, 4.698rem + ((1vw - 7.68px) * 3.012), 100.23px)',
 			),
 
 			'return_default_fluid_values_with_empty_fluid_array' => array(
@@ -412,7 +420,7 @@ class WP_Block_Supports_Typography_Test extends WP_UnitTestCase {
 					'fluid' => array(),
 				),
 				'should_use_fluid_typography' => true,
-				'expected_output'             => 'clamp(21px, 1.313rem + ((1vw - 7.68px) * 2.524), 42px)',
+				'expected_output'             => 'clamp(21px, 1.313rem + ((1vw - 7.68px) * 0.841), 28px)',
 			),
 
 			'return_default_fluid_values_with_null_value' => array(
@@ -421,7 +429,7 @@ class WP_Block_Supports_Typography_Test extends WP_UnitTestCase {
 					'fluid' => null,
 				),
 				'should_use_fluid_typography' => true,
-				'expected_output'             => 'clamp(21px, 1.313rem + ((1vw - 7.68px) * 2.524), 42px)',
+				'expected_output'             => 'clamp(21px, 1.313rem + ((1vw - 7.68px) * 0.841), 28px)',
 			),
 
 			'return_clamped_value_if_min_font_size_is_greater_than_max' => array(
@@ -448,12 +456,20 @@ class WP_Block_Supports_Typography_Test extends WP_UnitTestCase {
 				'expected_output'             => '10em',
 			),
 
-			'return_clamped_size_where_no_min_is_given_and_less_than_default_min_size' => array(
+			'return_default_size_when_less_than_default_lower_bound_and_where_no_min_or_max_passed' => array(
 				'font_size'                   => array(
 					'size' => '3px',
 				),
 				'should_use_fluid_typography' => true,
-				'expected_output'             => 'clamp(3px, 0.188rem + ((1vw - 7.68px) * 0.18), 4.5px)',
+				'expected_output'             => '3px',
+			),
+
+			'should_return_default_when_equal_to_default_lower_bound_and_where_no_min_or_max_passed' => array(
+				'font_size'                   => array(
+					'size' => '14px',
+				),
+				'should_use_fluid_typography' => true,
+				'expected_output'             => '14px',
 			),
 
 			'return_fluid_clamp_value_with_different_min_max_units' => array(
@@ -468,7 +484,7 @@ class WP_Block_Supports_Typography_Test extends WP_UnitTestCase {
 				'expected_output'             => 'clamp(20px, 1.25rem + ((1vw - 7.68px) * 93.75), 50rem)',
 			),
 
-			'return_clamp_value_with_default_fluid_max_value' => array(
+			'return_clamp_value_with_size_as_max_and_no_fluid_max_value_passed' => array(
 				'font_size'                   => array(
 					'size'  => '28px',
 					'fluid' => array(
@@ -476,7 +492,7 @@ class WP_Block_Supports_Typography_Test extends WP_UnitTestCase {
 					),
 				),
 				'should_use_fluid_typography' => true,
-				'expected_output'             => 'clamp(2.6rem, 2.6rem + ((1vw - 0.48rem) * 0.048), 42px)',
+				'expected_output'             => 'clamp(2.6rem, 2.6rem + ((1vw - 0.48rem) * -1.635), 28px)',
 			),
 
 			'default_return_clamp_value_with_default_fluid_min_value' => array(
@@ -490,31 +506,7 @@ class WP_Block_Supports_Typography_Test extends WP_UnitTestCase {
 				'expected_output'             => 'clamp(21px, 1.313rem + ((1vw - 7.68px) * 7.091), 80px)',
 			),
 
-			'should_adjust_computed_min_in_px_to_min_limit' => array(
-				'font_size'                   => array(
-					'size' => '14px',
-				),
-				'should_use_fluid_typography' => true,
-				'expected_output'             => 'clamp(14px, 0.875rem + ((1vw - 7.68px) * 0.841), 21px)',
-			),
-
-			'should_adjust_computed_min_in_rem_to_min_limit' => array(
-				'font_size'                   => array(
-					'size' => '1.1rem',
-				),
-				'should_use_fluid_typography' => true,
-				'expected_output'             => 'clamp(0.875rem, 0.875rem + ((1vw - 0.48rem) * 1.49), 1.65rem)',
-			),
-
-			'default_return_clamp_value_with_replaced_fluid_min_value_in_em' => array(
-				'font_size'                   => array(
-					'size' => '1.1em',
-				),
-				'should_use_fluid_typography' => true,
-				'expected_output'             => 'clamp(0.875em, 0.875rem + ((1vw - 0.48em) * 1.49), 1.65em)',
-			),
-
-			'should_adjust_fluid_min_value_in_px_to_min_limit' => array(
+			'should_not_apply_lower_bound_value_when_min_is_passed' => array(
 				'font_size'                   => array(
 					'size'  => '20px',
 					'fluid' => array(
@@ -522,21 +514,10 @@ class WP_Block_Supports_Typography_Test extends WP_UnitTestCase {
 					),
 				),
 				'should_use_fluid_typography' => true,
-				'expected_output'             => 'clamp(14px, 0.875rem + ((1vw - 7.68px) * 1.923), 30px)',
+				'expected_output'             => 'clamp(12px, 0.75rem + ((1vw - 7.68px) * 0.962), 20px)',
 			),
 
-			'should_adjust_fluid_min_value_in_rem_to_min_limit' => array(
-				'font_size'                   => array(
-					'size'  => '1.5rem',
-					'fluid' => array(
-						'min' => '0.5rem',
-					),
-				),
-				'should_use_fluid_typography' => true,
-				'expected_output'             => 'clamp(0.875rem, 0.875rem + ((1vw - 0.48rem) * 2.644), 2.25rem)',
-			),
-
-			'should_adjust_fluid_min_value_but_honor_max_value' => array(
+			'should_use_passed_min_and_max_values' => array(
 				'font_size'                   => array(
 					'size'  => '1.5rem',
 					'fluid' => array(
@@ -545,7 +526,7 @@ class WP_Block_Supports_Typography_Test extends WP_UnitTestCase {
 					),
 				),
 				'should_use_fluid_typography' => true,
-				'expected_output'             => 'clamp(0.875rem, 0.875rem + ((1vw - 0.48rem) * 7.933), 5rem)',
+				'expected_output'             => 'clamp(0.5rem, 0.5rem + ((1vw - 0.48rem) * 8.654), 5rem)',
 			),
 
 			'should_return_fluid_value_when_min_and_max_font_sizes_are_equal' => array(
@@ -630,7 +611,7 @@ class WP_Block_Supports_Typography_Test extends WP_UnitTestCase {
 			'return_value_with_fluid_typography' => array(
 				'font_size_value'             => '50px',
 				'should_use_fluid_typography' => true,
-				'expected_output'             => 'font-size:clamp(37.5px, 2.344rem + ((1vw - 7.68px) * 4.507), 75px);',
+				'expected_output'             => 'font-size:clamp(37.5px, 2.344rem + ((1vw - 7.68px) * 1.502), 50px);',
 			),
 		);
 	}
@@ -688,7 +669,7 @@ class WP_Block_Supports_Typography_Test extends WP_UnitTestCase {
 				'block_content'               => '<h2 class="has-vivid-red-background-color has-background has-link-color" style="margin-top:var(--wp--preset--spacing--60);font-size:4rem;font-style:normal;font-weight:600;letter-spacing:29px;text-decoration:underline;text-transform:capitalize">This is a heading</h2>',
 				'font_size_value'             => '4rem',
 				'should_use_fluid_typography' => true,
-				'expected_output'             => '<h2 class="has-vivid-red-background-color has-background has-link-color" style="margin-top:var(--wp--preset--spacing--60);font-size:clamp(3rem, 3rem + ((1vw - 0.48rem) * 5.769), 6rem);font-style:normal;font-weight:600;letter-spacing:29px;text-decoration:underline;text-transform:capitalize">This is a heading</h2>',
+				'expected_output'             => '<h2 class="has-vivid-red-background-color has-background has-link-color" style="margin-top:var(--wp--preset--spacing--60);font-size:clamp(3rem, 3rem + ((1vw - 0.48rem) * 1.923), 4rem);font-style:normal;font-weight:600;letter-spacing:29px;text-decoration:underline;text-transform:capitalize">This is a heading</h2>',
 			),
 			'return_content_if_no_inline_font_size_found'  => array(
 				'block_content'               => '<p class="has-medium-font-size" style="font-style:normal;font-weight:600;letter-spacing:29px;">A paragraph inside a group</p>',
@@ -706,13 +687,13 @@ class WP_Block_Supports_Typography_Test extends WP_UnitTestCase {
 				'block_content'               => '<p class="has-medium-font-size" style="    font-size:   20px   ;    ">A paragraph inside a group</p>',
 				'font_size_value'             => '20px',
 				'should_use_fluid_typography' => true,
-				'expected_output'             => '<p class="has-medium-font-size" style="    font-size:clamp(15px, 0.938rem + ((1vw - 7.68px) * 1.803), 30px);    ">A paragraph inside a group</p>',
+				'expected_output'             => '<p class="has-medium-font-size" style="    font-size:clamp(15px, 0.938rem + ((1vw - 7.68px) * 0.601), 20px);    ">A paragraph inside a group</p>',
 			),
 			'return_content_with_first_match_replace_only' => array(
 				'block_content'               => "<div class=\"wp-block-group\" style=\"font-size:1.5em\"> \n \n<p style=\"font-size:1.5em\">A paragraph inside a group</p></div>",
 				'font_size_value'             => '1.5em',
 				'should_use_fluid_typography' => true,
-				'expected_output'             => "<div class=\"wp-block-group\" style=\"font-size:clamp(1.125em, 1.125rem + ((1vw - 0.48em) * 2.163), 2.25em);\"> \n \n<p style=\"font-size:1.5em\">A paragraph inside a group</p></div>",
+				'expected_output'             => "<div class=\"wp-block-group\" style=\"font-size:clamp(1.125em, 1.125rem + ((1vw - 0.48em) * 0.721), 1.5em);\"> \n \n<p style=\"font-size:1.5em\">A paragraph inside a group</p></div>",
 			),
 		);
 	}

--- a/phpunit/block-supports/typography-test.php
+++ b/phpunit/block-supports/typography-test.php
@@ -466,10 +466,10 @@ class WP_Block_Supports_Typography_Test extends WP_UnitTestCase {
 
 			'returns value when size is equal to lower bounds and no fluid min/max set' => array(
 				'font_size'                   => array(
-					'size' => '14px',
+					'size' => '16px',
 				),
 				'should_use_fluid_typography' => true,
-				'expected_output'             => '14px',
+				'expected_output'             => '16px',
 			),
 
 			'returns clamp value with different min max units' => array(
@@ -529,7 +529,7 @@ class WP_Block_Supports_Typography_Test extends WP_UnitTestCase {
 				'expected_output'             => 'clamp(12px, 0.75rem + ((1vw - 7.68px) * 0.962), 20px)',
 			),
 
-			'should not apply lower bound test when only fluid max is set' => array(
+			'should apply lower bound test when only fluid max is set' => array(
 				'font_size'                   => array(
 					'size'  => '0.875rem',
 					'fluid' => array(
@@ -537,7 +537,7 @@ class WP_Block_Supports_Typography_Test extends WP_UnitTestCase {
 					),
 				),
 				'should_use_fluid_typography' => true,
-				'expected_output'             => 'clamp(0.875rem, 0.875rem + ((1vw - 0.48rem) * 36.779), 20rem)',
+				'expected_output'             => 'clamp(1rem, 1rem + ((1vw - 0.48rem) * 36.538), 20rem)',
 			),
 
 			'returns clamp value when min and max font sizes are equal' => array(
@@ -698,7 +698,7 @@ class WP_Block_Supports_Typography_Test extends WP_UnitTestCase {
 				'block_content'               => '<p class="has-medium-font-size" style="    font-size:   20px   ;    ">A paragraph inside a group</p>',
 				'font_size_value'             => '20px',
 				'should_use_fluid_typography' => true,
-				'expected_output'             => '<p class="has-medium-font-size" style="    font-size:clamp(15px, 0.938rem + ((1vw - 7.68px) * 0.601), 20px);    ">A paragraph inside a group</p>',
+				'expected_output'             => '<p class="has-medium-font-size" style="    font-size:clamp(16px, 1rem + ((1vw - 7.68px) * 0.481), 20px);    ">A paragraph inside a group</p>',
 			),
 			'return_content_with_first_match_replace_only' => array(
 				'block_content'               => "<div class=\"wp-block-group\" style=\"font-size:1.5em\"> \n \n<p style=\"font-size:1.5em\">A paragraph inside a group</p></div>",

--- a/phpunit/block-supports/typography-test.php
+++ b/phpunit/block-supports/typography-test.php
@@ -315,7 +315,7 @@ class WP_Block_Supports_Typography_Test extends WP_UnitTestCase {
 	 */
 	public function data_generate_font_size_preset_fixtures() {
 		return array(
-			'default_return_value'                        => array(
+			'returns value when fluid typography is deactivated' => array(
 				'font_size'                   => array(
 					'size' => '28px',
 				),
@@ -323,7 +323,7 @@ class WP_Block_Supports_Typography_Test extends WP_UnitTestCase {
 				'expected_output'             => '28px',
 			),
 
-			'size: int 0'                                 => array(
+			'returns value where font size is 0'         => array(
 				'font_size'                   => array(
 					'size' => 0,
 				),
@@ -331,7 +331,7 @@ class WP_Block_Supports_Typography_Test extends WP_UnitTestCase {
 				'expected_output'             => 0,
 			),
 
-			'size: string 0'                              => array(
+			"returns value where font size is '0'"       => array(
 				'font_size'                   => array(
 					'size' => '0',
 				),
@@ -339,7 +339,7 @@ class WP_Block_Supports_Typography_Test extends WP_UnitTestCase {
 				'expected_output'             => '0',
 			),
 
-			'default_return_value_when_size_is_undefined' => array(
+			'returns value where `size` is `null`'       => array(
 				'font_size'                   => array(
 					'size' => null,
 				),
@@ -347,7 +347,7 @@ class WP_Block_Supports_Typography_Test extends WP_UnitTestCase {
 				'expected_output'             => null,
 			),
 
-			'default_return_value_when_fluid_is_false'    => array(
+			'returns value when fluid is `false`'        => array(
 				'font_size'                   => array(
 					'size'  => '28px',
 					'fluid' => false,
@@ -356,7 +356,7 @@ class WP_Block_Supports_Typography_Test extends WP_UnitTestCase {
 				'expected_output'             => '28px',
 			),
 
-			'default_return_value_when_value_is_already_clamped' => array(
+			'returns already clamped value'              => array(
 				'font_size'                   => array(
 					'size'  => 'clamp(21px, 1.313rem + ((1vw - 7.68px) * 2.524), 42px)',
 					'fluid' => false,
@@ -365,7 +365,7 @@ class WP_Block_Supports_Typography_Test extends WP_UnitTestCase {
 				'expected_output'             => 'clamp(21px, 1.313rem + ((1vw - 7.68px) * 2.524), 42px)',
 			),
 
-			'default_return_value_with_unsupported_unit'  => array(
+			'returns value with unsupported unit'        => array(
 				'font_size'                   => array(
 					'size'  => '1000%',
 					'fluid' => false,
@@ -374,7 +374,7 @@ class WP_Block_Supports_Typography_Test extends WP_UnitTestCase {
 				'expected_output'             => '1000%',
 			),
 
-			'return_fluid_value_rem'                      => array(
+			'returns clamp value with rem min and max units' => array(
 				'font_size'                   => array(
 					'size' => '1.75rem',
 				),
@@ -382,7 +382,7 @@ class WP_Block_Supports_Typography_Test extends WP_UnitTestCase {
 				'expected_output'             => 'clamp(1.313rem, 1.313rem + ((1vw - 0.48rem) * 0.84), 1.75rem)',
 			),
 
-			'return_fluid_value_em'                       => array(
+			'returns clamp value with em min and max units' => array(
 				'font_size'                   => array(
 					'size' => '1.75em',
 				),
@@ -390,7 +390,7 @@ class WP_Block_Supports_Typography_Test extends WP_UnitTestCase {
 				'expected_output'             => 'clamp(1.313em, 1.313rem + ((1vw - 0.48em) * 0.84), 1.75em)',
 			),
 
-			'return_fluid_value_with_floats_with_units'   => array(
+			'returns clamp value for floats'             => array(
 				'font_size'                   => array(
 					'size' => '100.175px',
 				),
@@ -398,7 +398,7 @@ class WP_Block_Supports_Typography_Test extends WP_UnitTestCase {
 				'expected_output'             => 'clamp(75.131px, 4.696rem + ((1vw - 7.68px) * 3.01), 100.175px)',
 			),
 
-			'return_fluid_value_with_integer_coerced_to_px' => array(
+			'coerces integer to `px` and returns clamp value' => array(
 				'font_size'                   => array(
 					'size' => 33,
 				),
@@ -406,7 +406,7 @@ class WP_Block_Supports_Typography_Test extends WP_UnitTestCase {
 				'expected_output'             => 'clamp(24.75px, 1.547rem + ((1vw - 7.68px) * 0.992), 33px)',
 			),
 
-			'return_fluid_value_with_float_coerced_to_px' => array(
+			'coerces float to `px` and returns clamp value' => array(
 				'font_size'                   => array(
 					'size' => 100.23,
 				),
@@ -414,7 +414,7 @@ class WP_Block_Supports_Typography_Test extends WP_UnitTestCase {
 				'expected_output'             => 'clamp(75.173px, 4.698rem + ((1vw - 7.68px) * 3.012), 100.23px)',
 			),
 
-			'return_default_fluid_values_with_empty_fluid_array' => array(
+			'returns clamp value when `fluid` is empty array' => array(
 				'font_size'                   => array(
 					'size'  => '28px',
 					'fluid' => array(),
@@ -423,7 +423,7 @@ class WP_Block_Supports_Typography_Test extends WP_UnitTestCase {
 				'expected_output'             => 'clamp(21px, 1.313rem + ((1vw - 7.68px) * 0.841), 28px)',
 			),
 
-			'return_default_fluid_values_with_null_value' => array(
+			'returns clamp value when `fluid` is `null`' => array(
 				'font_size'                   => array(
 					'size'  => '28px',
 					'fluid' => null,
@@ -432,7 +432,7 @@ class WP_Block_Supports_Typography_Test extends WP_UnitTestCase {
 				'expected_output'             => 'clamp(21px, 1.313rem + ((1vw - 7.68px) * 0.841), 28px)',
 			),
 
-			'return_clamped_value_if_min_font_size_is_greater_than_max' => array(
+			'returns clamp value if min font size is greater than max' => array(
 				'font_size'                   => array(
 					'size'  => '3rem',
 					'fluid' => array(
@@ -444,7 +444,7 @@ class WP_Block_Supports_Typography_Test extends WP_UnitTestCase {
 				'expected_output'             => 'clamp(5rem, 5rem + ((1vw - 0.48rem) * -5.769), 32px)',
 			),
 
-			'return_size_with_invalid_fluid_units'        => array(
+			'returns value with invalid min/max fluid units' => array(
 				'font_size'                   => array(
 					'size'  => '10em',
 					'fluid' => array(
@@ -456,7 +456,7 @@ class WP_Block_Supports_Typography_Test extends WP_UnitTestCase {
 				'expected_output'             => '10em',
 			),
 
-			'return_default_size_when_less_than_default_lower_bound_and_where_no_min_or_max_passed' => array(
+			'returns value when size is < lower bounds and no fluid min/max set' => array(
 				'font_size'                   => array(
 					'size' => '3px',
 				),
@@ -464,7 +464,7 @@ class WP_Block_Supports_Typography_Test extends WP_UnitTestCase {
 				'expected_output'             => '3px',
 			),
 
-			'should_return_default_when_equal_to_default_lower_bound_and_where_no_min_or_max_passed' => array(
+			'returns value when size is equal to lower bounds and no fluid min/max set' => array(
 				'font_size'                   => array(
 					'size' => '14px',
 				),
@@ -472,7 +472,7 @@ class WP_Block_Supports_Typography_Test extends WP_UnitTestCase {
 				'expected_output'             => '14px',
 			),
 
-			'return_fluid_clamp_value_with_different_min_max_units' => array(
+			'returns clamp value with different min max units' => array(
 				'font_size'                   => array(
 					'size'  => '28px',
 					'fluid' => array(
@@ -484,7 +484,7 @@ class WP_Block_Supports_Typography_Test extends WP_UnitTestCase {
 				'expected_output'             => 'clamp(20px, 1.25rem + ((1vw - 7.68px) * 93.75), 50rem)',
 			),
 
-			'return_clamp_value_with_size_as_max_and_no_fluid_max_value_passed' => array(
+			'returns clamp value where no fluid max size is set' => array(
 				'font_size'                   => array(
 					'size'  => '28px',
 					'fluid' => array(
@@ -495,7 +495,7 @@ class WP_Block_Supports_Typography_Test extends WP_UnitTestCase {
 				'expected_output'             => 'clamp(2.6rem, 2.6rem + ((1vw - 0.48rem) * -1.635), 28px)',
 			),
 
-			'default_return_clamp_value_with_default_fluid_min_value' => array(
+			'returns clamp value where no fluid min size is set' => array(
 				'font_size'                   => array(
 					'size'  => '28px',
 					'fluid' => array(
@@ -506,18 +506,7 @@ class WP_Block_Supports_Typography_Test extends WP_UnitTestCase {
 				'expected_output'             => 'clamp(21px, 1.313rem + ((1vw - 7.68px) * 7.091), 80px)',
 			),
 
-			'should_not_apply_lower_bound_value_when_min_is_passed' => array(
-				'font_size'                   => array(
-					'size'  => '20px',
-					'fluid' => array(
-						'min' => '12px',
-					),
-				),
-				'should_use_fluid_typography' => true,
-				'expected_output'             => 'clamp(12px, 0.75rem + ((1vw - 7.68px) * 0.962), 20px)',
-			),
-
-			'should_use_passed_min_and_max_values' => array(
+			'should not apply lower bound test when fluid values are set' => array(
 				'font_size'                   => array(
 					'size'  => '1.5rem',
 					'fluid' => array(
@@ -529,7 +518,29 @@ class WP_Block_Supports_Typography_Test extends WP_UnitTestCase {
 				'expected_output'             => 'clamp(0.5rem, 0.5rem + ((1vw - 0.48rem) * 8.654), 5rem)',
 			),
 
-			'should_return_fluid_value_when_min_and_max_font_sizes_are_equal' => array(
+			'should not apply lower bound test when only fluid min is set' => array(
+				'font_size'                   => array(
+					'size'  => '20px',
+					'fluid' => array(
+						'min' => '12px',
+					),
+				),
+				'should_use_fluid_typography' => true,
+				'expected_output'             => 'clamp(12px, 0.75rem + ((1vw - 7.68px) * 0.962), 20px)',
+			),
+
+			'should not apply lower bound test when only fluid max is set' => array(
+				'font_size'                   => array(
+					'size'  => '0.875rem',
+					'fluid' => array(
+						'max' => '20rem',
+					),
+				),
+				'should_use_fluid_typography' => true,
+				'expected_output'             => 'clamp(0.875rem, 0.875rem + ((1vw - 0.48rem) * 36.779), 20rem)',
+			),
+
+			'returns clamp value when min and max font sizes are equal' => array(
 				'font_size'                   => array(
 					'size'  => '4rem',
 					'fluid' => array(


### PR DESCRIPTION
## What?

Part of 
- https://github.com/WordPress/gutenberg/issues/44888

Resolves https://github.com/WordPress/gutenberg/issues/45504


1. Where no fluid max values are set (e.g., single or custom font size values), the "size" value will act as the maximum value in a clamp() function.
2. In the absence of any fluid min / max values, we will enforce the lower bound rule of `>16px`. This applies to custom values from the editor or single-value theme.json styles. Font sizes below this will not be clamped.
3. In a preset, if a `fluid.min` value has been specified, the lower bound rule of `>16px` won't be enforced on this value. Presets with a fluid object therefore, give precedence to theme author's values.
4. In a preset, if there is NOT a `fluid.max` but there is  `fluid.min`, use the incoming `"size"` value as the max.
5. In a preset, if there is NOT a `fluid.min` but there is a `fluid.max`, use `size * min_size_factor` as the min. Here we do enforce the lower bound rule of `>16px`, because Gutenberg is  computing the min value. This is consistent with the way we calculate minimum sizes for single or custom values.



## Testing Instructions

<details>

<summary>Example theme.json</summary>

```json
{
	"version": 2,
	"settings": {
		"typography": {
			"fluid": true,
			"fontSizes": [
				{
					"size": "12px",
					"slug": "piccolino",
					"name": "Piccolino"
				},
				{
					"size": "2rem",
					"fluid": {
						"min": ".8rem",
						"max": "40px"
					},
					"slug": "in-mezzo",
					"name": "In Mezzo"
				},
				{
					"size": "2.8rem",
					"fluid": {
						"min": "0.3rem"
					},
					"slug": "neutrale",
					"name": "Neutrale"
				},
				{
					"size": "4.75rem",
					"slug": "grandone",
					"name": "Grandone"
				},
				{
					"size": "6rem",
					"fluid": {
						"max": "7rem"
					},
					"slug": "colossal",
					"name": "Colossal"
				}
			]
		}
	},
	"styles": {
		"typography": {
			"fontSize": "12px"
		},
		"elements": {
			"h1": {
				"typography": {
					"fontSize": "4rem"
				}
			}
		},
		"blocks": {
			"core/post-date": {
				"typography": {
					"fontSize": "16px"
				}
			}
		}
	}
}

```

</details>

Add some text blocks to the editor, apply presets and custom sizes, and ensure they:

- follow the expected logic. See https://github.com/WordPress/gutenberg/issues/45504#issuecomment-1302867918 for context.
- appear as they should in the editor and frontend at various viewport widths


Please test by playing around with:

1. Font size presets in theme.json
2. Global styles in theme.json (global, elements, blocks)
3. Global styles in the site editor  (global, elements, blocks)
4. Typography block supports at the individual block level in the post/side editor

