### PR TITLE
Fix: Prevent infinite loop in Tag Processor in certain truncated documents

### DIFF
--- a/lib/experimental/html/class-wp-html-tag-processor.php
+++ b/lib/experimental/html/class-wp-html-tag-processor.php
@@ -445,7 +445,7 @@ class WP_HTML_Tag_Processor {
 
 		$at = $this->parsed_bytes;
 
-		while ( true ) {
+		while ( false !== $at && $at < $doc_length ) {
 			$at = strpos( $this->html, '</', $at );
 
 			// If we have no possible tag closer then fail.
@@ -494,6 +494,8 @@ class WP_HTML_Tag_Processor {
 				return;
 			}
 		}
+
+		return false;
 	}
 
 	/**
@@ -507,7 +509,7 @@ class WP_HTML_Tag_Processor {
 		$doc_length = strlen( $html );
 		$at         = $this->parsed_bytes;
 
-		while ( $at < $doc_length ) {
+		while ( false !== $at && $at < $doc_length ) {
 			$at += strcspn( $html, '-<', $at );
 
 			/*
@@ -613,6 +615,8 @@ class WP_HTML_Tag_Processor {
 
 			++$at;
 		}
+
+		return false;
 	}
 
 	/**
@@ -623,10 +627,11 @@ class WP_HTML_Tag_Processor {
 	private function parse_next_tag() {
 		$this->after_tag();
 
-		$html = $this->html;
-		$at   = $this->parsed_bytes;
+		$html       = $this->html;
+		$doc_length = strlen( $html );
+		$at         = $this->parsed_bytes;
 
-		while ( true ) {
+		while ( false !== $at && $at < $doc_length ) {
 			$at = strpos( $html, '<', $at );
 			if ( false === $at ) {
 				return false;
@@ -663,7 +668,12 @@ class WP_HTML_Tag_Processor {
 					'-' === $html[ $at + 2 ] &&
 					'-' === $html[ $at + 3 ]
 				) {
-					$at = strpos( $html, '-->', $at + 4 ) + 3;
+					$closer_at = strpos( $html, '-->', $at + 4 );
+					if ( false === $closer_at ) {
+						return false;
+					}
+
+					$at = $closer_at + 3;
 					continue;
 				}
 
@@ -680,7 +690,12 @@ class WP_HTML_Tag_Processor {
 					'A' === $html[ $at + 7 ] &&
 					'[' === $html[ $at + 8 ]
 				) {
-					$at = strpos( $html, ']]>', $at + 9 ) + 3;
+					$closer_at = strpos( $html, ']]>', $at + 9 );
+					if ( false === $closer_at ) {
+						return false;
+					}
+
+					$at = $closer_at + 3;
 					continue;
 				}
 
@@ -699,7 +714,12 @@ class WP_HTML_Tag_Processor {
 					'P' === strtoupper( $html[ $at + 7 ] ) &&
 					'E' === strtoupper( $html[ $at + 8 ] )
 				) {
-					$at = strpos( $html, '>', $at + 9 ) + 1;
+					$closer_at = strpos( $html, '>', $at + 9 );
+					if ( false === $closer_at ) {
+						return false;
+					}
+
+					$at = $closer_at + 1;
 					continue;
 				}
 
@@ -716,12 +736,19 @@ class WP_HTML_Tag_Processor {
 			 * https://html.spec.whatwg.org/multipage/parsing.html#tag-open-state
 			 */
 			if ( '?' === $html[ $at + 1 ] ) {
-				$at = strpos( $html, '>', $at + 2 ) + 1;
+				$closer_at = strpos( $html, '>', $at + 2 );
+				if ( false === $closer_at ) {
+					return false;
+				}
+
+				$at = $closer_at + 1;
 				continue;
 			}
 
 			++$at;
 		}
+
+		return false;
 	}
 
 	/**


### PR DESCRIPTION
## What

Previously the Tag Processor class has performed unchecked arithmetic on the result of `strpos()` when looking to close out HTML comments and other special sections (CDATA, doctype-declaration). This led to a situation where by means of type-coercion we added an integer value to a `false` returned by the string function, setting the cursor in the tag processor to a low index in the document, and creating an infinite loop condition.

In this patch we're checking the results of calling `strpos()` in those places to avoid the type error and abort from the processor if we fail to find the end of those associated document sections.

## Why?

We shouldn't trigger infinite loops 🙃

## How?

Checking for proper types and error-return-values before assuming things worked the way we expect.

## Testing Instructions

The following input should trigger the infinite loop in `trunk`

```
\n<div class=\"wp-block-group\"><!-- wp:quote ...
```

Note that the `...` is part of the input that led to identifying this issue. This snippet was created when block-unaware code truncated `post_content` and cut inside the block comment delimiter, making it look like a normal HTML comment.

For a quick test, navigate to the Gutenberg directory and run the following script:

```php
<?php

require_once 'lib/experimental/html/index.php';

$p = new WP_HTML_Tag_Processor( "\n<div class=\"wp-block-group\"><!-- wp:quote ..." );
$p->next_tag();
$p->next_tag();
```

In `trunk` this should hang, which you can confirm by instrumenting `parse_next_tag()` just inside the `while ( true )` loop. In this branch the code should immediately complete, returning `false` from the second call to `$p->next_tag()`.

The unit tests should also continue passing.

cc: @griffbrad