### PR TITLE
Don't use capital case for 'Distraction free' strings

### DIFF
--- a/packages/edit-post/src/components/preferences-modal/index.js
+++ b/packages/edit-post/src/components/preferences-modal/index.js
@@ -116,7 +116,7 @@ export default function EditPostPreferencesModal() {
 								help={ __(
 									'Reduce visual distractions by hiding the toolbar and other elements to focus on writing.'
 								) }
-								label={ __( 'Distraction Free' ) }
+								label={ __( 'Distraction free' ) }
 							/>
 							<EnableFeature
 								featureName="focusMode"

--- a/packages/edit-post/src/components/preferences-modal/test/__snapshots__/index.js.snap
+++ b/packages/edit-post/src/components/preferences-modal/test/__snapshots__/index.js.snap
@@ -253,7 +253,7 @@ exports[`EditPostPreferencesModal should match snapshot when the modal is active
                     class="components-toggle-control__label"
                     for="inspector-toggle-control-1"
                   >
-                    Distraction Free
+                    Distraction free
                   </label>
                 </div>
               </div>


### PR DESCRIPTION
## What?
Fixes #45523.

PR changes the "Distraction Free" label to "Distraction free" in the Preferences modal. This way, it also matches other label string casing.

## Testing Instructions
1. Open a Post or Page.
2. Open the Preferences modal.
3. Confirm the updated string.
