### PR TITLE
List View: Disable branch expansion when block editing is locked

### DIFF
--- a/packages/block-editor/src/components/list-view/block.js
+++ b/packages/block-editor/src/components/list-view/block.js
@@ -59,7 +59,7 @@ function ListViewBlock( {
 	const [ isHovered, setIsHovered ] = useState( false );
 	const { clientId } = block;
 
-	const { isLocked, isContentLocked } = useBlockLock( clientId );
+	const { isLocked, isContentLocked, canEdit } = useBlockLock( clientId );
 	const forceSelectionContentLock = useSelect(
 		( select ) => {
 			if ( isSelected ) {
@@ -76,6 +76,7 @@ function ListViewBlock( {
 		[ isContentLocked, clientId, isSelected ]
 	);
 
+	const canExpand = isContentLocked ? false : canEdit;
 	const isFirstSelectedBlock =
 		forceSelectionContentLock ||
 		( isSelected && selectedClientIds[ 0 ] === clientId );
@@ -229,7 +230,7 @@ function ListViewBlock( {
 			path={ path }
 			id={ `list-view-block-${ clientId }` }
 			data-block={ clientId }
-			isExpanded={ isContentLocked ? undefined : isExpanded }
+			isExpanded={ canExpand ? isExpanded : undefined }
 			aria-selected={ !! isSelected || forceSelectionContentLock }
 		>
 			<TreeGridCell
@@ -238,7 +239,7 @@ function ListViewBlock( {
 				ref={ cellRef }
 				aria-label={ blockAriaLabel }
 				aria-selected={ !! isSelected || forceSelectionContentLock }
-				aria-expanded={ isContentLocked ? undefined : isExpanded }
+				aria-expanded={ canExpand ? isExpanded : undefined }
 				aria-describedby={ descriptionId }
 			>
 				{ ( { ref, tabIndex, onFocus } ) => (

--- a/packages/block-editor/src/components/list-view/branch.js
+++ b/packages/block-editor/src/components/list-view/branch.js
@@ -94,20 +94,25 @@ function ListViewBranch( props ) {
 		shouldShowInnerBlocks = true,
 	} = props;
 
-	const isContentLocked = useSelect(
+	const canParentExpand = useSelect(
 		( select ) => {
-			return !! (
-				parentId &&
+			if ( ! parentId ) {
+				return true;
+			}
+
+			const isContentLocked =
 				select( blockEditorStore ).getTemplateLock( parentId ) ===
-					'contentOnly'
-			);
+				'contentOnly';
+			const canEdit = select( blockEditorStore ).canEditBlock( parentId );
+
+			return isContentLocked ? false : canEdit;
 		},
 		[ parentId ]
 	);
 
 	const { expandedState, draggedClientIds } = useListViewContext();
 
-	if ( isContentLocked ) {
+	if ( ! canParentExpand ) {
 		return null;
 	}
 


### PR DESCRIPTION
## What?
PR disables branch expansion in the "List View" when block editing is locked.

## Why?
The users shouldn't be able to select inner blocks when editing is locked for the parent.

## How?
I've adjusted the check introduced in #43037. The condition now checks if the content is locked and fallbacks to the block's `canEdit` value, which is `true` by default.

## Testing Instructions

Verify that the list view still works as expected:

* Only the locking parent is visible when the content lock is active. See the example block below.
* Only the locking parent is visible when the edit lock is active. Use Navigation or Reusable block.
* You can expand the branch for the parent blocks without any locking.

<details>
<summary>Content locked block</summary>

```
<!-- wp:group {"templateLock":"contentOnly","backgroundColor":"pale-cyan-blue","layout":{"type":"constrained"}} -->
<div class="wp-block-group has-pale-cyan-blue-background-color has-background"><!-- wp:heading {"style":{"typography":{"fontStyle":"normal","fontWeight":"700"}},"backgroundColor":"pale-pink","fontSize":"x-large"} -->
<h2 class="has-pale-pink-background-color has-background has-x-large-font-size" style="font-style:normal;font-weight:700">Headisngs</h2>
<!-- /wp:heading -->

<!-- wp:list -->
<ul><!-- wp:list-item -->
<li>a1</li>
<!-- /wp:list-item -->

<!-- wp:list-item -->
<li>2</li>
<!-- /wp:list-item -->

<!-- wp:list-item -->
<li>3</li>
<!-- /wp:list-item -->

<!-- wp:list-item -->
<li></li>
<!-- /wp:list-item --></ul>
<!-- /wp:list -->

<!-- wp:paragraph {"backgroundColor":"vivid-red","textColor":"secondary"} -->
<p class="has-secondary-color has-vivid-red-background-color has-text-color has-background">Paragraphs</p>
<!-- /wp:paragraph -->

<!-- wp:quote -->
<blockquote class="wp-block-quote"><!-- wp:paragraph -->
<p>sdsds</p>
<!-- /wp:paragraph --><cite>sd</cite></blockquote>
<!-- /wp:quote -->

<!-- wp:image {"align":"center","width":239,"height":239,"sizeSlug":"large","style":{"border":{"width":"18px"}}} -->
<figure class="wp-block-image aligncenter size-large is-resized has-custom-border"><img src="https://s.w.org/style/images/about/WordPress-logotype-wmark.png" alt="" style="border-width:18px" width="239" height="239"/><figcaption class="wp-element-caption">f</figcaption></figure>
<!-- /wp:image -->

<!-- wp:spacer {"height":"28px"} -->
<div style="height:28px" aria-hidden="true" class="wp-block-spacer"></div>
<!-- /wp:spacer -->

<!-- wp:group {"backgroundColor":"secondary"} -->
<div class="wp-block-group has-secondary-background-color has-background"><!-- wp:separator -->
<hr class="wp-block-separator has-alpha-channel-opacity"/>
<!-- /wp:separator -->

<!-- wp:spacer {"height":"55px"} -->
<div style="height:55px" aria-hidden="true" class="wp-block-spacer"></div>
<!-- /wp:spacer -->

<!-- wp:pullquote {"gradient":"blush-bordeaux"} -->
<figure class="wp-block-pullquote has-blush-bordeaux-gradient-background has-background"><blockquote><p>End quote inside another group</p></blockquote></figure>
<!-- /wp:pullquote --></div>
<!-- /wp:group --></div>
<!-- /wp:group -->
```
</details>


## Screenshots or screencast <!-- if applicable -->

![CleanShot 2022-11-04 at 13 05 50](https://user-images.githubusercontent.com/240569/199935312-71771463-bae5-4b8e-bc3e-0ebe4f4dad81.png)
