### PR TITLE
Restore the empty paragraph inserter

### DIFF
--- a/packages/block-editor/src/components/block-popover/style.scss
+++ b/packages/block-editor/src/components/block-popover/style.scss
@@ -17,7 +17,7 @@
 	}
 
 	// Enable pointer events for the toolbar's content.
-	&:not(.block-editor-block-popover__inbetween, .block-editor-block-popover__drop-zone) .components-popover__content {
+	&:not(.block-editor-block-popover__inbetween, .block-editor-block-popover__drop-zone, .block-editor-block-list__block-side-inserter-popover) .components-popover__content {
 		* {
 			pointer-events: all;
 		}

--- a/packages/block-editor/src/components/block-tools/selected-block-popover.js
+++ b/packages/block-editor/src/components/block-tools/selected-block-popover.js
@@ -21,6 +21,7 @@ import BlockContextualToolbar from './block-contextual-toolbar';
 import { store as blockEditorStore } from '../../store';
 import BlockPopover from '../block-popover';
 import useBlockToolbarPopoverProps from './use-block-toolbar-popover-props';
+import Inserter from '../inserter';
 
 function selector( select ) {
 	const {
@@ -129,45 +130,82 @@ function SelectedBlockPopover( {
 		clientId,
 	} );
 
-	if ( ! shouldShowBreadcrumb && ! shouldShowContextualToolbar ) {
+	if (
+		! shouldShowBreadcrumb &&
+		! shouldShowContextualToolbar &&
+		! showEmptyBlockSideInserter
+	) {
 		return null;
 	}
 
 	return (
-		<BlockPopover
-			clientId={ capturingClientId || clientId }
-			bottomClientId={ lastClientId }
-			className={ classnames( 'block-editor-block-list__block-popover', {
-				'is-insertion-point-visible': isInsertionPointVisible,
-			} ) }
-			__unstablePopoverSlot={ __unstablePopoverSlot }
-			__unstableContentRef={ __unstableContentRef }
-			resize={ false }
-			{ ...popoverProps }
-		>
-			{ shouldShowContextualToolbar && showContents && (
-				<BlockContextualToolbar
-					// If the toolbar is being shown because of being forced
-					// it should focus the toolbar right after the mount.
-					focusOnMount={ isToolbarForced.current }
-					__experimentalInitialIndex={
-						initialToolbarItemIndexRef.current
-					}
-					__experimentalOnIndexChange={ ( index ) => {
-						initialToolbarItemIndexRef.current = index;
-					} }
-					// Resets the index whenever the active block changes so
-					// this is not persisted. See https://github.com/WordPress/gutenberg/pull/25760#issuecomment-717906169
-					key={ clientId }
-				/>
+		<>
+			{ showEmptyBlockSideInserter && (
+				<BlockPopover
+					clientId={ capturingClientId || clientId }
+					__unstableCoverTarget
+					bottomClientId={ lastClientId }
+					className={ classnames(
+						'block-editor-block-list__block-popover'
+					) }
+					__unstablePopoverSlot={ __unstablePopoverSlot }
+					__unstableContentRef={ __unstableContentRef }
+					resize={ false }
+					shift={ false }
+					{ ...popoverProps }
+				>
+					<div className="block-editor-block-list__empty-block-inserter">
+						<Inserter
+							position="bottom right"
+							rootClientId={ rootClientId }
+							clientId={ clientId }
+							__experimentalIsQuick
+						/>
+					</div>
+				</BlockPopover>
 			) }
-			{ shouldShowBreadcrumb && (
-				<BlockSelectionButton
-					clientId={ clientId }
-					rootClientId={ rootClientId }
-				/>
-			) }
-		</BlockPopover>
+			{ shouldShowBreadcrumb ||
+				( shouldShowContextualToolbar && (
+					<BlockPopover
+						clientId={ capturingClientId || clientId }
+						bottomClientId={ lastClientId }
+						className={ classnames(
+							'block-editor-block-list__block-popover',
+							{
+								'is-insertion-point-visible':
+									isInsertionPointVisible,
+							}
+						) }
+						__unstablePopoverSlot={ __unstablePopoverSlot }
+						__unstableContentRef={ __unstableContentRef }
+						resize={ false }
+						{ ...popoverProps }
+					>
+						{ shouldShowContextualToolbar && showContents && (
+							<BlockContextualToolbar
+								// If the toolbar is being shown because of being forced
+								// it should focus the toolbar right after the mount.
+								focusOnMount={ isToolbarForced.current }
+								__experimentalInitialIndex={
+									initialToolbarItemIndexRef.current
+								}
+								__experimentalOnIndexChange={ ( index ) => {
+									initialToolbarItemIndexRef.current = index;
+								} }
+								// Resets the index whenever the active block changes so
+								// this is not persisted. See https://github.com/WordPress/gutenberg/pull/25760#issuecomment-717906169
+								key={ clientId }
+							/>
+						) }
+						{ shouldShowBreadcrumb && (
+							<BlockSelectionButton
+								clientId={ clientId }
+								rootClientId={ rootClientId }
+							/>
+						) }
+					</BlockPopover>
+				) ) }
+		</>
 	);
 }
 

--- a/packages/block-editor/src/components/block-tools/selected-block-popover.js
+++ b/packages/block-editor/src/components/block-tools/selected-block-popover.js
@@ -146,7 +146,11 @@ function SelectedBlockPopover( {
 					__unstableCoverTarget
 					bottomClientId={ lastClientId }
 					className={ classnames(
-						'block-editor-block-list__block-popover'
+						'block-editor-block-list__block-popover',
+						{
+							'is-insertion-point-visible':
+								isInsertionPointVisible,
+						}
 					) }
 					__unstablePopoverSlot={ __unstablePopoverSlot }
 					__unstableContentRef={ __unstableContentRef }
@@ -164,47 +168,46 @@ function SelectedBlockPopover( {
 					</div>
 				</BlockPopover>
 			) }
-			{ shouldShowBreadcrumb ||
-				( shouldShowContextualToolbar && (
-					<BlockPopover
-						clientId={ capturingClientId || clientId }
-						bottomClientId={ lastClientId }
-						className={ classnames(
-							'block-editor-block-list__block-popover',
-							{
-								'is-insertion-point-visible':
-									isInsertionPointVisible,
+			{ ( shouldShowBreadcrumb || shouldShowContextualToolbar ) && (
+				<BlockPopover
+					clientId={ capturingClientId || clientId }
+					bottomClientId={ lastClientId }
+					className={ classnames(
+						'block-editor-block-list__block-popover',
+						{
+							'is-insertion-point-visible':
+								isInsertionPointVisible,
+						}
+					) }
+					__unstablePopoverSlot={ __unstablePopoverSlot }
+					__unstableContentRef={ __unstableContentRef }
+					resize={ false }
+					{ ...popoverProps }
+				>
+					{ shouldShowContextualToolbar && showContents && (
+						<BlockContextualToolbar
+							// If the toolbar is being shown because of being forced
+							// it should focus the toolbar right after the mount.
+							focusOnMount={ isToolbarForced.current }
+							__experimentalInitialIndex={
+								initialToolbarItemIndexRef.current
 							}
-						) }
-						__unstablePopoverSlot={ __unstablePopoverSlot }
-						__unstableContentRef={ __unstableContentRef }
-						resize={ false }
-						{ ...popoverProps }
-					>
-						{ shouldShowContextualToolbar && showContents && (
-							<BlockContextualToolbar
-								// If the toolbar is being shown because of being forced
-								// it should focus the toolbar right after the mount.
-								focusOnMount={ isToolbarForced.current }
-								__experimentalInitialIndex={
-									initialToolbarItemIndexRef.current
-								}
-								__experimentalOnIndexChange={ ( index ) => {
-									initialToolbarItemIndexRef.current = index;
-								} }
-								// Resets the index whenever the active block changes so
-								// this is not persisted. See https://github.com/WordPress/gutenberg/pull/25760#issuecomment-717906169
-								key={ clientId }
-							/>
-						) }
-						{ shouldShowBreadcrumb && (
-							<BlockSelectionButton
-								clientId={ clientId }
-								rootClientId={ rootClientId }
-							/>
-						) }
-					</BlockPopover>
-				) ) }
+							__experimentalOnIndexChange={ ( index ) => {
+								initialToolbarItemIndexRef.current = index;
+							} }
+							// Resets the index whenever the active block changes so
+							// this is not persisted. See https://github.com/WordPress/gutenberg/pull/25760#issuecomment-717906169
+							key={ clientId }
+						/>
+					) }
+					{ shouldShowBreadcrumb && (
+						<BlockSelectionButton
+							clientId={ clientId }
+							rootClientId={ rootClientId }
+						/>
+					) }
+				</BlockPopover>
+			) }
 		</>
 	);
 }

--- a/packages/block-editor/src/components/block-tools/selected-block-popover.js
+++ b/packages/block-editor/src/components/block-tools/selected-block-popover.js
@@ -146,7 +146,7 @@ function SelectedBlockPopover( {
 					__unstableCoverTarget
 					bottomClientId={ lastClientId }
 					className={ classnames(
-						'block-editor-block-list__block-popover',
+						'block-editor-block-list__block-side-inserter-popover',
 						{
 							'is-insertion-point-visible':
 								isInsertionPointVisible,

--- a/packages/block-editor/src/components/block-tools/style.scss
+++ b/packages/block-editor/src/components/block-tools/style.scss
@@ -42,6 +42,14 @@
 	left: calc(50% - #{$button-size-small * 0.5});
 }
 
+.block-editor-block-list__block-side-inserter-popover .components-popover__content > div {
+	pointer-events: none;
+
+	> * {
+		pointer-events: all;
+	}
+}
+
 // Sibling inserter / "inbetweenserter".
 .block-editor-block-list__empty-block-inserter,
 .block-editor-default-block-appender,

--- a/packages/block-editor/src/components/block-tools/style.scss
+++ b/packages/block-editor/src/components/block-tools/style.scss
@@ -43,6 +43,7 @@
 }
 
 // Sibling inserter / "inbetweenserter".
+.block-editor-block-list__empty-block-inserter,
 .block-editor-default-block-appender,
 .block-editor-block-list__insertion-point-inserter {
 	.block-editor-inserter__toggle.components-button.has-icon {

--- a/packages/block-editor/src/components/default-block-appender/style.scss
+++ b/packages/block-editor/src/components/default-block-appender/style.scss
@@ -34,6 +34,7 @@
 
 // The black plus that shows up on the right side of an empty paragraph block, or the initial appender
 // that exists only on empty documents.
+.block-editor-block-list__empty-block-inserter.block-editor-block-list__empty-block-inserter,
 .block-editor-default-block-appender .block-editor-inserter {
 	position: absolute;
 	top: 0;


### PR DESCRIPTION
Fixes #45497 

## What?

In #40441 we removed the inserter that was showing up at the right of empty paragraphs when focused. The reasoning was that it's a redundant piece of UI. It turns out a lot of people do actually rely on it. So this PR restores it.

## Testing Instructions

1- Insert empty paragraph blocks
2- Notice that there's an inserter at the right of these blocks.
