### PR TITLE
Update `wp_theme_has_theme_json` to use `WP_Object_Cache`

### DIFF
--- a/lib/compat/wordpress-6.2/default-filters.php
+++ b/lib/compat/wordpress-6.2/default-filters.php
@@ -17,11 +17,6 @@
  * @package gutenberg
  */
 
-/**
- * Note for backport: we should also remove the existing filters:
- *
- * > add_action( 'switch_theme', array( 'WP_Theme_JSON_Resolver', 'clean_cached_data' ) );
- * > add_action( 'start_previewing_theme', array( 'WP_Theme_JSON_Resolver', 'clean_cached_data' ) );
- */
-add_action( 'switch_theme', 'wp_theme_clean_theme_json_cached_data' );
-add_action( 'start_previewing_theme', 'wp_theme_clean_theme_json_cached_data' );
+add_action( 'switch_theme', 'wp_theme_has_theme_json_clean_cache' );
+add_action( 'start_previewing_theme', 'wp_theme_has_theme_json_clean_cache' );
+// TODO: clean cache when theme is updated

--- a/lib/compat/wordpress-6.2/default-filters.php
+++ b/lib/compat/wordpress-6.2/default-filters.php
@@ -19,4 +19,4 @@
 
 add_action( 'switch_theme', 'wp_theme_has_theme_json_clean_cache' );
 add_action( 'start_previewing_theme', 'wp_theme_has_theme_json_clean_cache' );
-// TODO: clean cache when theme is updated
+add_action( 'upgrader_process_complete', '_wp_theme_has_theme_json_clean_cache_upon_upgrading_active_theme' );

--- a/lib/compat/wordpress-6.2/get-global-styles-and-settings.php
+++ b/lib/compat/wordpress-6.2/get-global-styles-and-settings.php
@@ -15,9 +15,10 @@ if ( ! function_exists( 'wp_theme_has_theme_json' ) ) {
 	 * @return boolean
 	 */
 	function wp_theme_has_theme_json() {
+		$cache_group       = 'theme_json';
 		$cache_key         = 'wp_theme_has_theme_json';
 		$cache_found       = false;
-		$theme_has_support = wp_cache_get( $cache_key, '', false, $cache_found );
+		$theme_has_support = wp_cache_get( $cache_key, $cache_group, false, $cache_found );
 		if ( $cache_found ) {
 			return $theme_has_support;
 		}
@@ -30,7 +31,7 @@ if ( ! function_exists( 'wp_theme_has_theme_json' ) ) {
 			$theme_has_support = is_readable( get_template_directory() . '/theme.json' );
 		}
 
-		wp_cache_set( $cache_key, $theme_has_support );
+		wp_cache_set( $cache_key, $theme_has_support, $cache_group );
 
 		return $theme_has_support;
 	}
@@ -41,7 +42,7 @@ if ( ! function_exists( 'wp_theme_clean_theme_json_cached_data' ) ) {
 	 * Clean theme.json related cached data.
 	 */
 	function wp_theme_clean_theme_json_cached_data() {
-		wp_cache_delete( 'wp_theme_has_theme_json' );
+		wp_cache_delete( 'wp_theme_has_theme_json', 'theme_json' );
 		WP_Theme_JSON_Resolver_Gutenberg::clean_cached_data();
 	}
 }

--- a/lib/compat/wordpress-6.2/get-global-styles-and-settings.php
+++ b/lib/compat/wordpress-6.2/get-global-styles-and-settings.php
@@ -9,8 +9,8 @@ if ( ! function_exists( 'wp_theme_has_theme_json' ) ) {
 	/**
 	 * Whether a theme or its parent have a theme.json file.
 	 *
-	 * The result would be cached via the WP_Object_Cache
-	 * under the `wp_theme_has_theme_json` key.
+	 * The result would be cached via the WP_Object_Cache.
+	 * It can be cleared by calling wp_theme_has_theme_json_clean_cache().
 	 *
 	 * @return boolean
 	 */
@@ -45,12 +45,8 @@ if ( ! function_exists( 'wp_theme_has_theme_json' ) ) {
 	}
 }
 
-if ( ! function_exists( 'wp_theme_clean_theme_json_cached_data' ) ) {
-	/**
-	 * Clean theme.json related cached data.
-	 */
-	function wp_theme_clean_theme_json_cached_data() {
+if ( ! function_exists( 'wp_theme_has_theme_json_clean_cache' ) ) {
+	function wp_theme_has_theme_json_clean_cache() {
 		wp_cache_delete( 'wp_theme_has_theme_json', 'theme_json' );
-		WP_Theme_JSON_Resolver_Gutenberg::clean_cached_data();
 	}
 }

--- a/lib/compat/wordpress-6.2/get-global-styles-and-settings.php
+++ b/lib/compat/wordpress-6.2/get-global-styles-and-settings.php
@@ -50,3 +50,16 @@ if ( ! function_exists( 'wp_theme_has_theme_json_clean_cache' ) ) {
 		wp_cache_delete( 'wp_theme_has_theme_json', 'theme_json' );
 	}
 }
+
+if ( ! function_exists( '_wp_theme_has_theme_json_clean_cache_upon_upgrading_active_theme' ) ) {
+	function _wp_theme_has_theme_json_clean_cache_upon_upgrading_active_theme( $upgrader, $options ) {
+		// The cache only needs cleaning when the active theme was updated.
+		if (
+			'update' === $options[ 'action' ] &&
+			'theme' === $options[ 'type' ] &&
+			array_key_exists( get_stylesheet(), $options[ 'themes' ] )
+		) {
+			wp_theme_has_theme_json_clean_cache();
+		}
+	}
+}

--- a/lib/compat/wordpress-6.2/get-global-styles-and-settings.php
+++ b/lib/compat/wordpress-6.2/get-global-styles-and-settings.php
@@ -17,23 +17,30 @@ if ( ! function_exists( 'wp_theme_has_theme_json' ) ) {
 	function wp_theme_has_theme_json() {
 		$cache_group       = 'theme_json';
 		$cache_key         = 'wp_theme_has_theme_json';
-		$cache_found       = false;
-		$theme_has_support = wp_cache_get( $cache_key, $cache_group, false, $cache_found );
-		if ( $cache_found ) {
-			return $theme_has_support;
+		$theme_has_support = wp_cache_get( $cache_key, $cache_group );
+
+		/**
+		 * $theme_has_support is stored as a int in the cache.
+		 *
+		 * The reason not to store it as a boolean is to avoid working
+		 * with the $found parameter which apparently had some issues in some implementations
+		 * https://developer.wordpress.org/reference/functions/wp_cache_get/
+		 */
+		if ( 0 === $theme_has_support || 1 === $theme_has_support ) {
+			return (bool) $theme_has_support;
 		}
 
 		// Has the own theme a theme.json?
-		$theme_has_support = is_readable( get_stylesheet_directory() . '/theme.json' );
+		$theme_has_support = is_readable( get_stylesheet_directory() . '/theme.json' ) ? 1 : 0;
 
 		// Look up the parent if the child does not have a theme.json.
-		if ( ! $theme_has_support ) {
-			$theme_has_support = is_readable( get_template_directory() . '/theme.json' );
+		if ( 0 === $theme_has_support ) {
+			$theme_has_support = is_readable( get_template_directory() . '/theme.json' ) ? 1 : 0;
 		}
 
 		wp_cache_set( $cache_key, $theme_has_support, $cache_group );
 
-		return $theme_has_support;
+		return (bool) $theme_has_support;
 	}
 }
 

--- a/lib/compat/wordpress-6.2/get-global-styles-and-settings.php
+++ b/lib/compat/wordpress-6.2/get-global-styles-and-settings.php
@@ -9,18 +9,16 @@ if ( ! function_exists( 'wp_theme_has_theme_json' ) ) {
 	/**
 	 * Whether a theme or its parent have a theme.json file.
 	 *
-	 * @param boolean $clear_cache Whether the cache should be cleared and theme support recomputed. Default is false.
+	 * The result would be cached via the WP_Object_Cache
+	 * under the `wp_theme_has_theme_json` key.
 	 *
 	 * @return boolean
 	 */
-	function wp_theme_has_theme_json( $clear_cache = false ) {
-		static $theme_has_support = null;
-
-		if ( true === $clear_cache ) {
-			$theme_has_support = null;
-		}
-
-		if ( null !== $theme_has_support ) {
+	function wp_theme_has_theme_json() {
+		$cache_key         = 'wp_theme_has_theme_json';
+		$cache_found       = false;
+		$theme_has_support = wp_cache_get( $cache_key, '', false, $cache_found );
+		if ( $cache_found ) {
 			return $theme_has_support;
 		}
 
@@ -32,6 +30,8 @@ if ( ! function_exists( 'wp_theme_has_theme_json' ) ) {
 			$theme_has_support = is_readable( get_template_directory() . '/theme.json' );
 		}
 
+		wp_cache_set( $cache_key, $theme_has_support );
+
 		return $theme_has_support;
 	}
 }
@@ -41,7 +41,7 @@ if ( ! function_exists( 'wp_theme_clean_theme_json_cached_data' ) ) {
 	 * Clean theme.json related cached data.
 	 */
 	function wp_theme_clean_theme_json_cached_data() {
-		wp_theme_has_theme_json( true );
+		wp_cache_delete( 'wp_theme_has_theme_json' );
 		WP_Theme_JSON_Resolver_Gutenberg::clean_cached_data();
 	}
 }

--- a/lib/compat/wordpress-6.2/get-global-styles-and-settings.php
+++ b/lib/compat/wordpress-6.2/get-global-styles-and-settings.php
@@ -26,7 +26,8 @@ if ( ! function_exists( 'wp_theme_has_theme_json' ) ) {
 		 * with the $found parameter which apparently had some issues in some implementations
 		 * https://developer.wordpress.org/reference/functions/wp_cache_get/
 		 */
-		if ( 0 === $theme_has_support || 1 === $theme_has_support ) {
+		if ( ( ! defined( 'WP_DEBUG' ) || ! WP_DEBUG ) &&
+			( 0 === $theme_has_support || 1 === $theme_has_support ) ) {
 			return (bool) $theme_has_support;
 		}
 

--- a/lib/compat/wordpress-6.2/get-global-styles-and-settings.php
+++ b/lib/compat/wordpress-6.2/get-global-styles-and-settings.php
@@ -59,14 +59,14 @@ if ( ! function_exists( '_wp_theme_has_theme_json_clean_cache_upon_upgrading_act
 	 * Private function to clean the cache used by wp_theme_has_theme_json method.
 	 *
 	 * @param WP_Upgrader $upgrader Instance of WP_Upgrader class.
-	 * @param array $options Metadata that identifies the data that is updated.
+	 * @param array       $options Metadata that identifies the data that is updated.
 	 */
 	function _wp_theme_has_theme_json_clean_cache_upon_upgrading_active_theme( $upgrader, $options ) {
 		// The cache only needs cleaning when the active theme was updated.
 		if (
-			'update' === $options[ 'action' ] &&
-			'theme' === $options[ 'type' ] &&
-			array_key_exists( get_stylesheet(), $options[ 'themes' ] )
+			'update' === $options['action'] &&
+			'theme' === $options['type'] &&
+			array_key_exists( get_stylesheet(), $options['themes'] )
 		) {
 			wp_theme_has_theme_json_clean_cache();
 		}

--- a/lib/compat/wordpress-6.2/get-global-styles-and-settings.php
+++ b/lib/compat/wordpress-6.2/get-global-styles-and-settings.php
@@ -46,12 +46,21 @@ if ( ! function_exists( 'wp_theme_has_theme_json' ) ) {
 }
 
 if ( ! function_exists( 'wp_theme_has_theme_json_clean_cache' ) ) {
+	/**
+	 * Function to clean the cache used by wp_theme_has_theme_json method.
+	 */
 	function wp_theme_has_theme_json_clean_cache() {
 		wp_cache_delete( 'wp_theme_has_theme_json', 'theme_json' );
 	}
 }
 
 if ( ! function_exists( '_wp_theme_has_theme_json_clean_cache_upon_upgrading_active_theme' ) ) {
+	/**
+	 * Private function to clean the cache used by wp_theme_has_theme_json method.
+	 *
+	 * @param WP_Upgrader $upgrader Instance of WP_Upgrader class.
+	 * @param array $options Metadata that identifies the data that is updated.
+	 */
 	function _wp_theme_has_theme_json_clean_cache_upon_upgrading_active_theme( $upgrader, $options ) {
 		// The cache only needs cleaning when the active theme was updated.
 		if (

--- a/lib/compat/wordpress-6.2/get-global-styles-and-settings.php
+++ b/lib/compat/wordpress-6.2/get-global-styles-and-settings.php
@@ -65,7 +65,7 @@ if ( ! function_exists( '_wp_theme_has_theme_json_clean_cache_upon_upgrading_act
 		if (
 			'update' === $options['action'] &&
 			'theme' === $options['type'] &&
-			isset( $options['themes'][ get_stylesheet() ]  )
+			isset( $options['themes'][ get_stylesheet() ] )
 		) {
 			wp_theme_has_theme_json_clean_cache();
 		}

--- a/lib/compat/wordpress-6.2/get-global-styles-and-settings.php
+++ b/lib/compat/wordpress-6.2/get-global-styles-and-settings.php
@@ -26,7 +26,7 @@ if ( ! function_exists( 'wp_theme_has_theme_json' ) ) {
 		 * with the $found parameter which apparently had some issues in some implementations
 		 * https://developer.wordpress.org/reference/functions/wp_cache_get/
 		 */
-		if ( ( 0 === $theme_has_support || 1 === $theme_has_support ) ) {
+		if ( 0 === $theme_has_support || 1 === $theme_has_support ) {
 			return (bool) $theme_has_support;
 		}
 

--- a/lib/compat/wordpress-6.2/get-global-styles-and-settings.php
+++ b/lib/compat/wordpress-6.2/get-global-styles-and-settings.php
@@ -57,6 +57,10 @@ if ( ! function_exists( '_wp_theme_has_theme_json_clean_cache_upon_upgrading_act
 	/**
 	 * Private function to clean the cache used by wp_theme_has_theme_json method.
 	 *
+	 * It is hooked into the `upgrader_process_complete` action.
+	 *
+	 * @see default-filters.php
+	 *
 	 * @param WP_Upgrader $upgrader Instance of WP_Upgrader class.
 	 * @param array       $options Metadata that identifies the data that is updated.
 	 */

--- a/lib/compat/wordpress-6.2/get-global-styles-and-settings.php
+++ b/lib/compat/wordpress-6.2/get-global-styles-and-settings.php
@@ -26,10 +26,6 @@ if ( ! function_exists( 'wp_theme_has_theme_json' ) ) {
 		 * with the $found parameter which apparently had some issues in some implementations
 		 * https://developer.wordpress.org/reference/functions/wp_cache_get/
 		 */
-		if ( ( ! defined( 'WP_DEBUG' ) || ! WP_DEBUG ) &&
-			( 0 === $theme_has_support || 1 === $theme_has_support ) ) {
-			return (bool) $theme_has_support;
-		}
 
 		// Has the own theme a theme.json?
 		$theme_has_support = is_readable( get_stylesheet_directory() . '/theme.json' ) ? 1 : 0;

--- a/lib/compat/wordpress-6.2/get-global-styles-and-settings.php
+++ b/lib/compat/wordpress-6.2/get-global-styles-and-settings.php
@@ -65,7 +65,7 @@ if ( ! function_exists( '_wp_theme_has_theme_json_clean_cache_upon_upgrading_act
 		if (
 			'update' === $options['action'] &&
 			'theme' === $options['type'] &&
-			array_key_exists( get_stylesheet(), $options['themes'] )
+			isset( $options['themes'][ get_stylesheet() ]  )
 		) {
 			wp_theme_has_theme_json_clean_cache();
 		}

--- a/lib/compat/wordpress-6.2/get-global-styles-and-settings.php
+++ b/lib/compat/wordpress-6.2/get-global-styles-and-settings.php
@@ -65,7 +65,7 @@ if ( ! function_exists( '_wp_theme_has_theme_json_clean_cache_upon_upgrading_act
 		if (
 			'update' === $options['action'] &&
 			'theme' === $options['type'] &&
-			isset( $options['themes'][ get_stylesheet() ] )
+			( isset( $options['themes'][ get_stylesheet() ] ) || isset( $options['themes'][ get_template() ] ) )
 		) {
 			wp_theme_has_theme_json_clean_cache();
 		}

--- a/lib/compat/wordpress-6.2/get-global-styles-and-settings.php
+++ b/lib/compat/wordpress-6.2/get-global-styles-and-settings.php
@@ -26,6 +26,9 @@ if ( ! function_exists( 'wp_theme_has_theme_json' ) ) {
 		 * with the $found parameter which apparently had some issues in some implementations
 		 * https://developer.wordpress.org/reference/functions/wp_cache_get/
 		 */
+		if ( ( 0 === $theme_has_support || 1 === $theme_has_support ) ) {
+			return (bool) $theme_has_support;
+		}
 
 		// Has the own theme a theme.json?
 		$theme_has_support = is_readable( get_stylesheet_directory() . '/theme.json' ) ? 1 : 0;


### PR DESCRIPTION
Part of https://github.com/WordPress/gutenberg/issues/45171
Follow-up to https://github.com/WordPress/gutenberg/pull/45168

## What?

This PR updates `wp_theme_has_theme_json`, so the runtime cache is `WP_Object_Cache` and not a static variable.

## Why?

See [this conversation](https://github.com/WordPress/wordpress-develop/pull/3556#discussion_r1012686381).

There are two advantages to using `WP_Object_Cache`:

- the cache can become transparent to the API (no argument needed to clear it in the `wp_theme_has_theme_json` method)
- sites can convert this runtime cache to a persistent cache by using a plugin

## How?

Substitutes the use of the internal static variable by the `WP_Object_Cache` via the `wp_cache_*` methods.

The cache is cleaned upon switching themes, upgrade active theme, or previewing the theme.

## Testing Instructions

**Front-end:**

- Create a post with a group block and a paragraph within. Publish.
- Use a theme **with** `theme.json` (e.g.: TwentyTwentyThree). Go to the front-end and verify that the block markup is similar to (no inner div between group & paragraph):

```html
<div class="wp-block-group">
  <p>Content</p>
</div>
```

- Use a theme **without** a `theme.json` (e.g.: TwentyTwenty). Go to the front-end and verify that the block markup is similar to (has inner div between group & paragraph):

```html
<div class="wp-block-group">
  <div class="wp-block-group__inner-container">
    <p>Content</p>
  </div>
</div>
```
