### PR TITLE
Change the order of the pseudo-states in the pseudo selectors array

### DIFF
--- a/lib/compat/wordpress-6.1/class-wp-theme-json-6-1.php
+++ b/lib/compat/wordpress-6.1/class-wp-theme-json-6-1.php
@@ -21,8 +21,8 @@ class WP_Theme_JSON_6_1 extends WP_Theme_JSON_6_0 {
 	 * Note: this will effect both top level and block level elements.
 	 */
 	const VALID_ELEMENT_PSEUDO_SELECTORS = array(
-		'link'   => array( ':hover', ':focus', ':active', ':visited' ),
-		'button' => array( ':hover', ':focus', ':active', ':visited' ),
+		'link'   => array( ':visited', ':hover', ':focus', ':active' ),
+		'button' => array( ':visited', ':hover', ':focus', ':active' ),
 	);
 
 	/**

--- a/lib/compat/wordpress-6.1/class-wp-theme-json-6-1.php
+++ b/lib/compat/wordpress-6.1/class-wp-theme-json-6-1.php
@@ -19,6 +19,10 @@ class WP_Theme_JSON_6_1 extends WP_Theme_JSON_6_0 {
 	 * Define which defines which pseudo selectors are enabled for
 	 * which elements.
 	 * Note: this will effect both top level and block level elements.
+	 *
+	 * The order of the selectors should be: visited, hover, focus, active.
+	 * This is to ensure that 'visited' has the lowest specificity
+	 * and the other selectors can always overwrite it.
 	 */
 	const VALID_ELEMENT_PSEUDO_SELECTORS = array(
 		'link'   => array( ':visited', ':hover', ':focus', ':active' ),


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->
When the `:visited` state is applied in theme.json, it should have the least specificity of all the pseudo-states to allow the other interaction-based states to take precedence when appropriate (on hover, on focus, etc.)

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
There was a [bug](https://core.trac.wordpress.org/ticket/56928) noticed in Twenty Twenty-Three when both the visited and hover states are active on a button, the visited text color overrides the hover text color, which means the two colors are not contrasting in the default style variation.

![image](https://user-images.githubusercontent.com/1645628/200017055-9a7f9400-e9a5-4177-a114-21997ef7be56.png)

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
This PR changes the order of the pseudo-states in the `VALID_ELEMENT_PSEUDO_SELECTORS` array, so that `:visited` is at the beginning. This means it receives the lowest specificity in the generated CSS.

Props to @sabernhardt for originally proposing this fix! 

Partially addresses https://github.com/WordPress/Gutenberg/issues/34448 (in order for this PR to fix this issue, you need to specify a `:visited` state in your theme.json)

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->
1. Activate Twenty Twenty-Three
2. Insert a button with a link to a site you have already visited
3. Check that the button receives the correct text color specified in theme.json for each pseudo-state

## Screenshots or screencast <!-- if applicable -->
Hovering over a button with a `visited` link:

| Before | After |
| ------ | ------ |
| <img width="671" alt="image" src="https://user-images.githubusercontent.com/1645628/200019608-8d1355f9-4f41-4394-bb4a-d41012e4e268.png"> | <img width="682" alt="image" src="https://user-images.githubusercontent.com/1645628/200019382-d255b95a-c487-4b68-9f67-ba1def2f03d3.png"> |