### PR TITLE
Fix image captions hiding rounded borders in galleries 

### DIFF
--- a/packages/block-library/src/gallery/index.php
+++ b/packages/block-library/src/gallery/index.php
@@ -32,6 +32,29 @@ function block_core_gallery_data_id_backcompatibility( $parsed_block ) {
 
 add_filter( 'render_block_data', 'block_core_gallery_data_id_backcompatibility' );
 
+
+function block_core_gallery_caption_styles( $parsed_block ) {
+
+	$styles = WP_Theme_JSON_Resolver::get_theme_data()->get_data();
+	$borderRadius = '';
+
+	if(isset( $styles['styles']['blocks']['core/image']['border']['radius']) ) {
+		$borderRadius = $styles['styles']['blocks']['core/image']['border']['radius'];
+
+		if ( 'core/gallery' === $parsed_block['blockName'] ) {
+			foreach ( $parsed_block['innerBlocks'] as $key => $inner_block ) {
+				if ( 'core/image' === $inner_block['blockName'] ) {
+					$parsed_block['innerBlocks'][ $key ]['attrs']['border-radius'] = $borderRadius;
+				}
+			}
+		}
+	}
+
+	return $parsed_block;
+}
+
+add_filter( 'render_block_data', 'block_core_gallery_caption_styles' );
+
 /**
  * Adds a style tag for the --wp--style--unstable-gallery-gap var.
  *

--- a/packages/block-library/src/image/index.php
+++ b/packages/block-library/src/image/index.php
@@ -24,6 +24,11 @@ function render_block_core_image( $attributes, $content ) {
 			$content = str_replace( '<img', '<img ' . $data_id_attribute . ' ', $content );
 		}
 	}
+
+	if ( isset( $attributes['border-radius'] ) ) {
+		$content = str_replace( '<figure', "<figure style='border-radius:" . $attributes['border-radius'] .  ";overflow:hidden;'", $content);
+	}
+
 	return $content;
 }
 


### PR DESCRIPTION
## What?
This pull request addresses issue #43586.
It fixes an issue wherein the caption background of image blocks within Galleries that have a `border-radius` obscure the bottom corners of the image.

**Note: This pull request is not yet meant to be a final implementation; I'm hoping to get feedback on how best to proceed.** 

## Why?
As a user, I expect that if I have a border radius defined, that the image captions will be styled so as to retain my desired border effects.

## How?
1. This request adds a filter to the Gallery block that checks to see if a `border-radius` is defined on the images via the `theme.json`
2. If so, it stores the value of the `border-radius` as an attribute on the image blocks.
3. The image blocks, if the `border-radius` attribute is set, apply it, as well as the `overflow: hidden` style, to the `<figure>` elements wrapping their `<img>` elements via `render_callback`.

**Note: This is not yet working in the Gutenberg editor and only works for saved markup at the moment.**

## Testing Instructions
1. Add a border radius to the Image block via theme.json:

```
{
	"styles": {
		"blocks": {
			"core/image": {
				"border": {
					"radius": "15px"
				}
			}
		}
	}
}
```
2. Test by adding a Gallery block with at least one image that has a caption.
3. Preview the post to see the caption background appearing as expected.

## Screenshot
<img width="759" alt="Screen Shot 2022-11-04 at 4 04 42 PM" src="https://user-images.githubusercontent.com/5360536/200064959-e30d27d0-94ce-44e3-bc28-013b8a41944c.png">
Gallery shows the image captions displaying as expected.

## Questions
I was initially trying to find a more elegant solution, hoping to generate styles for the `<figure>` at the moment the `theme.json` was parsed. However, not making any headway on that approach, I decided to try this so we could at least have something to look at while discussing next steps.

Am I in the right ballpark with this solution, or should we be trying a different approach?

Regarding the idea of toggling whether a caption is overlaid, raised by @aaronrobertshaw, I realized that if one selects individual images under the Gallery, one can toggle the style between _default_ and _rounded_. Setting the style to _rounded_ moves the caption and fixes the issue:

<img width="1135" alt="Screen Shot 2022-11-04 at 4 16 06 PM" src="https://user-images.githubusercontent.com/5360536/200066911-ab0cd06c-a4ca-4361-a6e0-f32f0b6f23e7.png">

Should I add a toggle to the Gallery block that switches between this _default_ and _rounded_ setting in its inner image blocks?

Please let me know your thoughts! I'm also happy to try a different approach entirely.