### PR TITLE
BlockManagerCategory: Fix styles for indeterminate

### DIFF
--- a/packages/edit-post/src/components/block-manager/category.js
+++ b/packages/edit-post/src/components/block-manager/category.js
@@ -71,15 +71,7 @@ function BlockManagerCategory( { title, blockTypes } ) {
 	const titleId = 'edit-post-block-manager__category-title-' + instanceId;
 
 	const isAllChecked = checkedBlockNames.length === filteredBlockTypes.length;
-
-	let ariaChecked;
-	if ( isAllChecked ) {
-		ariaChecked = 'true';
-	} else if ( checkedBlockNames.length > 0 ) {
-		ariaChecked = 'mixed';
-	} else {
-		ariaChecked = 'false';
-	}
+	const isIndeterminate = ! isAllChecked && checkedBlockNames.length > 0;
 
 	return (
 		<div
@@ -92,7 +84,7 @@ function BlockManagerCategory( { title, blockTypes } ) {
 				checked={ isAllChecked }
 				onChange={ toggleAllVisible }
 				className="edit-post-block-manager__category-title"
-				aria-checked={ ariaChecked }
+				indeterminate={ isIndeterminate }
 				label={ <span id={ titleId }>{ title }</span> }
 			/>
 			<BlockTypesChecklist


### PR DESCRIPTION
Caught when reviewing #45535

## What?

Updates BlockManagerCategory so it uses the official `indeterminate` prop exposed by CheckboxControl, rather than do its own thing with `aria-checked`.

## Why?

To fix the incorrect styling.

Should we fix the underlying CSS so the styling is correct even when a custom `aria-checked` implementation is used instead of the `indeterminate` prop? Maybe, but that is higher effort as it involves a base-styles mixin, and I don't have the appetite for that right now. (See also the [discussion](https://github.com/WordPress/gutenberg/pull/45289#discussion_r1010951357) about decoupling wp-components from base-styles mixins.)

## Testing Instructions

1. `npm run dev`
2. In the post editor, open the Preferences modal from the Options dropdown in the top right of the screen.
3. Open the Blocks tab.
4. Uncheck the Paragraph checkbox under the Text checkbox group.

## Screenshots or screencast <!-- if applicable -->

| Before | After |
|--------|-------|
|<img width="79" alt="The icon weight is wrong and the positioning is off" src="https://user-images.githubusercontent.com/555336/200074194-7a9aca23-f7dc-48ce-982e-32395c4de138.png">|<img width="83" alt="Correct icon and positioning" src="https://user-images.githubusercontent.com/555336/200074216-eda0326d-6030-41b4-8e2a-375e18192f88.png">|