### PR TITLE
Global Styles: Re-add styles that were removed, for classic themes

### DIFF
--- a/packages/block-library/src/classic.scss
+++ b/packages/block-library/src/classic.scss
@@ -12,4 +12,11 @@
 	padding: calc(0.667em + 2px) calc(1.333em + 2px);
 
 	font-size: 1.125em;
+
+	&:hover,
+	&:focus,
+	&:active,
+	&:visited {
+		color: $white;
+	}
 }


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

fix #44659.
Add the styles removed in 6.1 to the CSS for the classic theme

Styles were removed in this pull request.
https://github.com/WordPress/gutenberg/pull/43553

This pull request restored some of the styles, but left some colors removed, such as hover.
https://github.com/WordPress/gutenberg/pull/44334


## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->

1. Please place a button block with Twenty Ten in WP6.0.
The hover color should be white.
2. Please place the button block in WP6.1.
The color when hovered should be red

The classic.scss is managed in the gutenberg repository, but I could not tell if the styles are reflected without overwriting the core stylesheet in my environment.

So perhaps the styles will be reflected when they are merged into the core.
I'm putting it out there in the sense of adding styles to classic.scss in this pull request.

## Screenshots or screencast <!-- if applicable -->


