### PR TITLE
Docs: Update the readme for the integration test fixtures

### DIFF
--- a/test/integration/fixtures/blocks/README.md
+++ b/test/integration/fixtures/blocks/README.md
@@ -56,7 +56,7 @@ Next, to generate files (2) through (4) run the following command from the root 
 project:
 
 ```sh
-npm run fixtures:regenerate test/integration/full-content/full-content.test.js
+npm run fixtures:regenerate
 ```
 
 When using this command, please be sure to manually verify that the
@@ -72,7 +72,7 @@ The process for updating fixtures for existing tests is similar to that for crea
 Run the command to regenerate the files:
 
 ```sh
-npm run fixtures:regenerate test/integration/full-content/full-content.test.js
+npm run fixtures:regenerate
 ```
 
 After regenerating fixtures, check the diff (using git/github) to check that the changes were expected


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->
At some point, the command to regenerate fixtures that is listed in the readme stopped working.
This PR replaces the two commands in the documentation
`npm run fixtures:regenerate test/integration/full-content/full-content.test.js`
with the working command
`npm run fixtures:regenerate`

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
Help contributors avoid unexpected issues when regenerating fixtures.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->

## Screenshots or screencast <!-- if applicable -->
