### PR TITLE
Button: Remove unnecessary 'useCallback'

### DIFF
--- a/packages/block-library/src/button/edit.js
+++ b/packages/block-library/src/button/edit.js
@@ -7,7 +7,7 @@ import classnames from 'classnames';
  * WordPress dependencies
  */
 import { __ } from '@wordpress/i18n';
-import { useCallback, useEffect, useState, useRef } from '@wordpress/element';
+import { useEffect, useState, useRef } from '@wordpress/element';
 import {
 	Button,
 	ButtonGroup,
@@ -78,12 +78,6 @@ function ButtonEdit( props ) {
 	} = props;
 	const { linkTarget, placeholder, rel, style, text, url, width } =
 		attributes;
-	const onSetLinkRel = useCallback(
-		( value ) => {
-			setAttributes( { rel: value } );
-		},
-		[ setAttributes ]
-	);
 
 	function onToggleOpenInNewTab( value ) {
 		const newLinkTarget = value ? '_blank' : undefined;
@@ -262,7 +256,7 @@ function ButtonEdit( props ) {
 				<TextControl
 					label={ __( 'Link rel' ) }
 					value={ rel || '' }
-					onChange={ onSetLinkRel }
+					onChange={ ( newRel ) => setAttributes( { rel: newRel } ) }
 				/>
 			</InspectorControls>
 		</>


### PR DESCRIPTION
## What?
PR inlines the `onSetLinkRel` callback and removes unnecessary `useCallback` hook usage.

## Why?
The `TextControl` isn't memoized component and will re-render whenever its parent re-renders. We don't need to pass a referentially stable callback to it.

## Testing Instructions
Confirm you can update Button's rel attribute as before.
