### PR TITLE
NavigationToggle: wait for tooltip positioning in unit test

### DIFF
--- a/packages/edit-site/src/components/navigation-sidebar/navigation-toggle/test/__snapshots__/index.js.snap
+++ b/packages/edit-site/src/components/navigation-sidebar/navigation-toggle/test/__snapshots__/index.js.snap
@@ -26,11 +26,12 @@ exports[`NavigationToggle when in full screen mode should display a default site
       <div
         aria-hidden="true"
         class="components-popover components-tooltip"
-        style="position: absolute;"
+        style="position: absolute; left: 0px; top: 1px;"
         tabindex="-1"
       >
         <div
           class="components-popover__content"
+          style="max-height: -4px; overflow: auto;"
         >
           Toggle navigation
         </div>

--- a/packages/edit-site/src/components/navigation-sidebar/navigation-toggle/test/index.js
+++ b/packages/edit-site/src/components/navigation-sidebar/navigation-toggle/test/index.js
@@ -98,7 +98,7 @@ describe( 'NavigationToggle', () => {
 					expect(
 						screen.getByText( 'Toggle navigation' ).parentElement
 					).toBePositioned(),
-				{ timeout: 2000 } // It might take more than a second to position the popover.
+				{ interval: 10 } // It takes many microtask tick to position the popover.
 			);
 
 			const siteIcon = screen.getByAltText( 'Site Icon' );
@@ -126,7 +126,7 @@ describe( 'NavigationToggle', () => {
 					expect(
 						screen.getByText( 'Toggle navigation' ).parentElement
 					).toBePositioned(),
-				{ timeout: 2000 } // It might take more than a second to position the popover.
+				{ interval: 10 } // It takes many microtask tick to position the popover.
 			);
 
 			expect(


### PR DESCRIPTION
Fixes the unit test for `NavigationToggle` which triggers the "update not wrapped in act()" warning after React 18 upgrade, as in #45235. `NavigationToggle` is this site icon button in the top-left corner that opens the nav sidebar:

<img width="229" alt="Screenshot 2022-11-07 at 7 32 28" src="https://user-images.githubusercontent.com/664258/200335915-699907d3-1ce1-4b58-9013-305f805296d4.png">

It has a not-entirely-desired behavior (which is going to stay for a while though, see #37265) where it grabs focus on mount, and focus leads to displaying the "Toggle navigation" tooltip. The tooltip gets positioned asynchronously, and a correct unit test needs to wait for it to finish, otherwise the positioning update will trigger the act() warning.

This PR implement the Right Solution™ to that problem, one which I outlined in https://github.com/WordPress/gutenberg/pull/45235#issuecomment-1300359931: wait for the positioning DOM changes with `await waitFor()` after render, and proceed with the test only after the positioning is done. See the `isPopover` helper. And it works! The tests start passing in the React 18 migration branch, and also please notice the snapshot changes: the `component-popover` elements now have the final positioning styles. We're indeed testing the final state.

TODO for follow-up PRs: the `isPopover` helper should be improved, so that `expect` calls that use it are as ergonomic as possible (suggestions welcome) and extracted into a common helper shared by other tests.