### PR TITLE
Site editor hover/select: Fix double border

### DIFF
--- a/packages/block-editor/src/components/block-list/style.scss
+++ b/packages/block-editor/src/components/block-list/style.scss
@@ -290,11 +290,16 @@
 			cursor: unset;
 		}
 
-		box-shadow: inset 0 0 0 var(--wp-admin-border-width-focus) var(--wp-admin-theme-color); // Selected not focussed.
-		border-radius: $radius-block-ui;
-
-		&:focus {
-			box-shadow: inset 0 0 0 var(--wp-admin-border-width-focus) var(--wp-admin-theme-color);
+		&::after {
+			content: "";
+			position: absolute;
+			pointer-events: none;
+			top: $border-width;
+			left: $border-width;
+			right: $border-width;
+			bottom: $border-width;
+			box-shadow: 0 0 0 var(--wp-admin-border-width-focus) var(--wp-admin-theme-color);
+			border-radius: $radius-block-ui;
 		}
 	}
 }


### PR DESCRIPTION
## What?

Small bugfix to fix double width border when selecting a template part.

Before, selecting a template style would show stacked borders making it too thick compared to others:

![before](https://user-images.githubusercontent.com/1204802/200342314-de931890-1df9-4a86-a429-94e75adc9b47.gif)

This PR restores the pseudo element, simplifying and fixing the issue:

![after](https://user-images.githubusercontent.com/1204802/200342378-1601225a-edd3-4bf7-924c-057782bb2e8c.gif)


## Testing Instructions

Open the site editor, hover and select the template part. You should see a 1.5px, not 2px selected style.