### PR TITLE
Disable distraction free prefference effects on small viewports

### DIFF
--- a/packages/edit-post/src/components/header/index.js
+++ b/packages/edit-post/src/components/header/index.js
@@ -25,6 +25,7 @@ import { store as editPostStore } from '../../store';
 import TemplateTitle from './template-title';
 
 function Header( { setEntitiesSavedStatesCallback } ) {
+	const isLargeViewport = useViewportMatch( 'large' );
 	const {
 		hasActiveMetaboxes,
 		isPublishSidebarOpened,
@@ -40,12 +41,11 @@ function Header( { setEntitiesSavedStatesCallback } ) {
 			showIconLabels:
 				select( editPostStore ).isFeatureActive( 'showIconLabels' ),
 			isDistractionFree:
-				select( editPostStore ).isFeatureActive( 'distractionFree' ),
+				select( editPostStore ).isFeatureActive( 'distractionFree' ) &&
+				isLargeViewport,
 		} ),
 		[]
 	);
-
-	const isLargeViewport = useViewportMatch( 'large' );
 
 	const classes = classnames( 'edit-post-header' );
 

--- a/packages/edit-post/src/components/layout/index.js
+++ b/packages/edit-post/src/components/layout/index.js
@@ -66,6 +66,7 @@ const interfaceLabels = {
 function Layout( { styles } ) {
 	const isMobileViewport = useViewportMatch( 'medium', '<' );
 	const isHugeViewport = useViewportMatch( 'huge', '>=' );
+	const isLargeViewport = useViewportMatch( 'large' );
 	const { openGeneralSidebar, closeGeneralSidebar, setIsInserterOpened } =
 		useDispatch( editPostStore );
 	const { createErrorNotice } = useDispatch( noticesStore );
@@ -116,7 +117,8 @@ function Layout( { styles } ) {
 			showIconLabels:
 				select( editPostStore ).isFeatureActive( 'showIconLabels' ),
 			isDistractionFree:
-				select( editPostStore ).isFeatureActive( 'distractionFree' ),
+				select( editPostStore ).isFeatureActive( 'distractionFree' ) &&
+				isLargeViewport,
 			showBlockBreadcrumbs: select( editPostStore ).isFeatureActive(
 				'showBlockBreadcrumbs'
 			),


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

This tiny PR disables the effects of distraction free mode when using a small viewport such as a mobile phone.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

In distraction free mode the top toolbar is invisible and one cannot save or publish. The way to get it back is via keyboard and mouse and small viewports usually have none.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

Ignore the prefference if the viewport is not at least "large".

## Testing Instructions

- using this branch
- visit a post and set distraction free mode on your computer
- using your phone go to the same WordPress instance
- check that all screen elements are visible


## Screenshots or screencast <!-- if applicable -->

<img width="1154" alt="Screenshot 2022-11-07 at 18 13 21" src="https://user-images.githubusercontent.com/107534/200359479-4446e77d-7c6f-4cac-8159-18d56ac380d1.png">


## Todo:

- [ ] Explore a more elegant approach in separating preferences between device types