### PR TITLE
Ignore warnings for `window.wp` in Playwright

### DIFF
--- a/packages/e2e-test-utils-playwright/src/admin/visit-site-editor.ts
+++ b/packages/e2e-test-utils-playwright/src/admin/visit-site-editor.ts
@@ -38,13 +38,10 @@ export async function visitSiteEditor(
 
 	if ( skipWelcomeGuide ) {
 		await this.page.evaluate( () => {
-			// TODO, type `window.wp`.
-			// @ts-ignore
 			window.wp.data
 				.dispatch( 'core/preferences' )
 				.set( 'core/edit-site', 'welcomeGuide', false );
 
-			// @ts-ignore
 			window.wp.data
 				.dispatch( 'core/preferences' )
 				.toggle( 'core/edit-site', 'welcomeGuideStyles', false );

--- a/packages/e2e-test-utils-playwright/src/editor/get-edited-post-content.ts
+++ b/packages/e2e-test-utils-playwright/src/editor/get-edited-post-content.ts
@@ -12,7 +12,6 @@ import type { Editor } from './index';
  */
 export async function getEditedPostContent( this: Editor ) {
 	return await this.page.evaluate( () =>
-		// @ts-ignore (Reason: wp isn't typed)
 		window.wp.data.select( 'core/editor' ).getEditedPostContent()
 	);
 }

--- a/packages/e2e-test-utils-playwright/src/editor/insert-block.ts
+++ b/packages/e2e-test-utils-playwright/src/editor/insert-block.ts
@@ -25,7 +25,6 @@ async function insertBlock(
 			attributes = {},
 			innerBlocks = [],
 		}: BlockRepresentation ): Object {
-			// @ts-ignore (Reason: wp isn't typed).
 			return window.wp.blocks.createBlock(
 				name,
 				attributes,
@@ -36,7 +35,6 @@ async function insertBlock(
 		}
 		const block = recursiveCreateBlock( _blockRepresentation );
 
-		// @ts-ignore (Reason: wp isn't typed).
 		window.wp.data.dispatch( 'core/block-editor' ).insertBlock( block );
 	}, blockRepresentation );
 }

--- a/packages/e2e-test-utils-playwright/src/editor/set-content.ts
+++ b/packages/e2e-test-utils-playwright/src/editor/set-content.ts
@@ -11,10 +11,8 @@ import type { Editor } from './index';
  */
 async function setContent( this: Editor, html: string ) {
 	await this.page.evaluate( ( _html ) => {
-		// @ts-ignore (Reason: wp isn't typed).
 		const blocks = window.wp.blocks.parse( _html );
 
-		// @ts-ignore (Reason: wp isn't typed).
 		window.wp.data.dispatch( 'core/block-editor' ).resetBlocks( blocks );
 	}, html );
 }

--- a/packages/e2e-test-utils-playwright/src/editor/transform-block-to.ts
+++ b/packages/e2e-test-utils-playwright/src/editor/transform-block-to.ts
@@ -12,20 +12,18 @@ import type { Editor } from './index';
 export async function transformBlockTo( this: Editor, name: string ) {
 	await this.page.evaluate(
 		( [ blockName ] ) => {
-			// @ts-ignore (Reason: wp isn't typed)
 			const clientIds = window.wp.data
 				.select( 'core/block-editor' )
 				.getSelectedBlockClientIds();
-			// @ts-ignore (Reason: wp isn't typed)
 			const blocks = window.wp.data
 				.select( 'core/block-editor' )
 				.getBlocksByClientId( clientIds );
-			// @ts-ignore (Reason: wp isn't typed)
-			window.wp.data.dispatch( 'core/block-editor' ).replaceBlocks(
-				clientIds,
-				// @ts-ignore (Reason: wp isn't typed)
-				window.wp.blocks.switchToBlockType( blocks, blockName )
-			);
+			window.wp.data
+				.dispatch( 'core/block-editor' )
+				.replaceBlocks(
+					clientIds,
+					window.wp.blocks.switchToBlockType( blocks, blockName )
+				);
 		},
 		[ name ]
 	);

--- a/packages/e2e-test-utils-playwright/src/index.ts
+++ b/packages/e2e-test-utils-playwright/src/index.ts
@@ -1,3 +1,4 @@
+export * from './types';
 export { Admin } from './admin';
 export { Editor } from './editor';
 export { PageUtils } from './page-utils';

--- a/packages/e2e-test-utils-playwright/src/types.ts
+++ b/packages/e2e-test-utils-playwright/src/types.ts
@@ -1,0 +1,8 @@
+declare global {
+	interface Window {
+		// Silence the warning for `window.wp` in Playwright's evaluate functions.
+		wp: any;
+	}
+}
+
+export {};


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->
Ignore TypeScript warnings for accessing `window.wp` in Playwright's evaluate functions.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
Until `window.wp` can be typed, which I think would probably take a long time to mature, I think it's a good idea to silence the warnings for now.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
Declare `window.wp` as `any` in `@wordpress/e2e-test-utils-playwright`.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->
CI should pass, TypeScript build should pass.
