### PR TITLE
Query Loop: button is misaligned

### DIFF
--- a/packages/block-library/src/query/editor.scss
+++ b/packages/block-library/src/query/editor.scss
@@ -3,7 +3,7 @@
 }
 
 .wp-block-query__create-new-link {
-	padding: 0 $grid-unit-20 $grid-unit-20 56px;
+	padding: 0 $grid-unit-20 $grid-unit-20 52px;
 }
 
 .block-library-query__pattern-selection-content .block-editor-block-patterns-list {


### PR DESCRIPTION
Addressing issue #45435 where the text is currently misaligned from the text above in the block inspector

https://github.com/WordPress/gutenberg/issues/45435

<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
This fixes the alignment of some of the text in the block inspector for the Query Loop.

## Why?
Minor aesthetic change but I am sure it might annoy a few things. Plus I thought for my first PR on Gutenberg I should go for an easy win.

## How?
The current .scss file just hard codes the padding left so was able to find the correct size and put that in.

## Testing Instructions

1. Insert a Query Loop block.
2. Open the block inspector.
3. Look at the 'Create a new post' link underneath the block description.

## Screenshots or screencast <!-- if applicable -->
Before
![image](https://user-images.githubusercontent.com/64328076/200571267-d2cb1791-13f3-439e-bebf-7f7d21f9b457.png)

After
![image](https://user-images.githubusercontent.com/64328076/200571445-933ae183-c877-4280-a750-65bb1551b9de.png)