### PR TITLE
Update applying-styles-with-stylesheets.md

### DIFF
--- a/docs/how-to-guides/block-tutorial/applying-styles-with-stylesheets.md
+++ b/docs/how-to-guides/block-tutorial/applying-styles-with-stylesheets.md
@@ -160,6 +160,37 @@ registerBlockType( 'gutenberg-examples/example-02-stylesheets', {
 
 {% end %}
 
+### Build or add dependency
+
+In order to include the blockEditor as a dependancy, make sure to run the build step, or update the asset php file.
+
+{% codetabs %}
+{% JSX %}
+
+Build the scripts and update the asset file which is used to keep track of dependencies and the build version.
+```bash
+npm run build
+```
+
+{% Plain %}
+
+Edit the asset file to include the block-editor dependancy for the scripts.
+
+```php
+<?php return
+	array( 'dependencies' =>
+		array(
+			'wp-blocks',
+			'wp-element',
+			'wp-block-editor',
+			'wp-polyfill'
+		),
+		'version' => '0.1'
+	);
+```
+
+{% end %}
+
 ### Enqueue stylesheets
 
 Like scripts, you can enqueue your block's styles using the `block.json` file.


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->
Updates the documentation for the developing blocks How To guide, specifically the step on applying styles with stylesheets, to include instructions on either running the build step or manually updating the block.asset.php file, so that it adds the 'wp-block-editor' object as a dependency.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
For the new block developer, adding this step will ensure that they update the asset file, and don't run into any errors, if they are trying out this code for the first time.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
Adds documentation steps for both JSX and plain JavaScript to add this as a dependency
