### PR TITLE
FormTokenField: Fix duplicate input in IME composition

### DIFF
--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -8,6 +8,7 @@
 
 ### Bug Fix
 
+-   `FormTokenField`: Fix duplicate input in IME composition ([#45607](https://github.com/WordPress/gutenberg/pull/45607)).
 -   `Autocomplete`: Fix unexpected block insertion during IME composition ([#45510](https://github.com/WordPress/gutenberg/pull/45510)).
 
 ### Internal

--- a/packages/components/src/form-token-field/index.tsx
+++ b/packages/components/src/form-token-field/index.tsx
@@ -215,7 +215,7 @@ export function FormTokenField( props: FormTokenFieldProps ) {
 		let preventDefault = false;
 
 		switch ( event.key ) {
-			case 'Comma':
+			case ',':
 				preventDefault = handleCommaKey();
 				break;
 			default:

--- a/packages/components/src/form-token-field/index.tsx
+++ b/packages/components/src/form-token-field/index.tsx
@@ -172,7 +172,7 @@ export function FormTokenField( props: FormTokenFieldProps ) {
 		if ( event.defaultPrevented ) {
 			return;
 		}
-		switch ( event.code ) {
+		switch ( event.key ) {
 			case 'Backspace':
 				preventDefault = handleDeleteKey( deleteTokenBeforeInput );
 				break;
@@ -213,9 +213,9 @@ export function FormTokenField( props: FormTokenFieldProps ) {
 
 	function onKeyPress( event: KeyboardEvent ) {
 		let preventDefault = false;
-		// TODO: replace to event.code;
-		switch ( event.charCode ) {
-			case 44: // Comma.
+
+		switch ( event.key ) {
+			case 'Comma':
 				preventDefault = handleCommaKey();
 				break;
 			default:

--- a/packages/components/src/form-token-field/index.tsx
+++ b/packages/components/src/form-token-field/index.tsx
@@ -169,7 +169,15 @@ export function FormTokenField( props: FormTokenFieldProps ) {
 	function onKeyDown( event: KeyboardEvent ) {
 		let preventDefault = false;
 
-		if ( event.defaultPrevented || event.nativeEvent.isComposing ) {
+		if (
+			event.defaultPrevented ||
+			// Ignore keydowns from IMEs
+			event.nativeEvent.isComposing ||
+			// Workaround for Mac Safari where the final Enter/Backspace of an IME composition
+			// is `isComposing=false`, even though it's technically still part of the composition.
+			// These can only be detected by keyCode.
+			event.keyCode === 229
+		) {
 			return;
 		}
 		switch ( event.key ) {

--- a/packages/components/src/form-token-field/index.tsx
+++ b/packages/components/src/form-token-field/index.tsx
@@ -169,7 +169,7 @@ export function FormTokenField( props: FormTokenFieldProps ) {
 	function onKeyDown( event: KeyboardEvent ) {
 		let preventDefault = false;
 
-		if ( event.defaultPrevented ) {
+		if ( event.defaultPrevented || event.nativeEvent.isComposing ) {
 			return;
 		}
 		switch ( event.key ) {


### PR DESCRIPTION
- Fix #45599 
- Part of #45605 

## What?
This PR fixes a problem where duplicate values are set when characters are entered into `FormTokenField` in languages that use IME composition.

## Why?
This is because the `enter` key, which is used to confirm the entry of a character, is considered a token decision.
For more context, see [here](https://github.com/WordPress/gutenberg/issues/45605#issue-1440281357).

## How?
Replaced `event.code` with `event.key`.

## Testing Instructions

1. Create some post tags.
2. Open the post Editor.
3. Enter text in IME composition mode in the "ADD TAG" sidebar.
4. Confrim that the Enter key to decide your input does NOT insert a token.
5. Confirm that pressing the Enter key again sets the token.

## Screenshots or screencast <!-- if applicable -->

https://user-images.githubusercontent.com/54422211/200599026-be0f0c44-6126-4322-9d54-5fc4c029bc19.mp4
