### PR TITLE
Block Editor: Improve `ResponsiveBlockControl` tests

### DIFF
--- a/packages/block-editor/src/components/responsive-block-control/test/index.js
+++ b/packages/block-editor/src/components/responsive-block-control/test/index.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { render } from '@testing-library/react';
+import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 
 /**
@@ -48,6 +48,20 @@ const renderTestDefaultControlComponent = ( labelComponent, device ) => {
 	);
 };
 
+function getDefaultControlGroup( container ) {
+	// TODO: Use a user-facing query to fetch this.
+	return container.querySelector(
+		'.block-editor-responsive-block-control__group:not(.is-responsive)'
+	);
+}
+
+function getResponsiveControlGroup( container ) {
+	// TODO: Use a user-facing query to fetch this.
+	return container.querySelector(
+		'.block-editor-responsive-block-control__group.is-responsive'
+	);
+}
+
 describe( 'Basic rendering', () => {
 	it( 'should render with required props', () => {
 		const { container } = render(
@@ -58,48 +72,30 @@ describe( 'Basic rendering', () => {
 			/>
 		);
 
-		const activePropertyLabel = Array.from(
-			container.querySelectorAll( 'legend' )
-		).find( ( legend ) => legend.innerHTML === 'Padding' );
+		const activePropertyLabel = screen.getByRole( 'group', {
+			name: 'Padding',
+		} );
 
-		const activeViewportLabel = Array.from(
-			container.querySelectorAll( 'label' )
-		).find( ( label ) => label.innerHTML.includes( 'All' ) );
+		const defaultControl = screen.getByRole( 'combobox', {
+			name: 'All Controls the padding property for All viewports.',
+		} );
 
-		const defaultControl = container.querySelector(
-			`#${ activeViewportLabel.getAttribute( 'for' ) }`
-		);
+		const toggleState = screen.getByRole( 'checkbox', {
+			name: 'Use the same padding on all screensizes.',
+			checked: true,
+		} );
 
-		const toggleLabel = Array.from(
-			container.querySelectorAll( 'label' )
-		).filter( ( label ) =>
-			label.innerHTML.includes(
-				'Use the same padding on all screensizes'
-			)
-		);
-
-		const toggleState = container.querySelector(
-			'input[type="checkbox"]'
-		).checked;
-
-		const defaultControlGroup = container.querySelector(
-			'.block-editor-responsive-block-control__group:not(.is-responsive)'
-		);
-
-		const responsiveControlGroup = container.querySelector(
-			'.block-editor-responsive-block-control__group.is-responsive'
-		);
+		const defaultControlGroup = getDefaultControlGroup( container );
+		const responsiveControlGroup = getResponsiveControlGroup( container );
 
 		expect( container ).not.toBeEmptyDOMElement();
 
 		expect( defaultControlGroup ).not.toBeNull();
 		expect( responsiveControlGroup ).toBeNull();
 
-		expect( activeViewportLabel ).not.toBeNull();
-		expect( activePropertyLabel ).not.toBeNull();
-		expect( defaultControl ).not.toBeNull();
-		expect( toggleLabel ).not.toBeNull();
-		expect( toggleState ).toBe( true );
+		expect( activePropertyLabel ).toBeVisible();
+		expect( defaultControl ).toBeVisible();
+		expect( toggleState ).toBeVisible();
 	} );
 
 	it( 'should not render without valid legend', () => {
@@ -135,7 +131,7 @@ describe( 'Basic rendering', () => {
 	it( 'should render with custom label for toggle control when provided', () => {
 		const customToggleLabel =
 			'Utilise a matching padding value on all viewports';
-		const { container } = render(
+		render(
 			<ResponsiveBlockControl
 				title="Padding"
 				property="padding"
@@ -144,17 +140,21 @@ describe( 'Basic rendering', () => {
 			/>
 		);
 
-		const actualToggleLabel = container.querySelector(
-			'label.components-toggle-control__label'
-		).innerHTML;
-
-		expect( actualToggleLabel ).toEqual( customToggleLabel );
+		expect(
+			screen.getByRole( 'checkbox', {
+				name: customToggleLabel,
+				checked: true,
+			} )
+		).toBeVisible();
 	} );
 
 	it( 'should pass custom label for default control group to the renderDefaultControl function when provided', () => {
-		const customDefaultControlGroupLabel = 'Everything';
+		const customDefaultControlGroupLabel = {
+			id: 'everything',
+			label: 'Everything',
+		};
 
-		const { container } = render(
+		render(
 			<ResponsiveBlockControl
 				title="Padding"
 				property="padding"
@@ -163,11 +163,11 @@ describe( 'Basic rendering', () => {
 			/>
 		);
 
-		const defaultControlLabel = Array.from(
-			container.querySelectorAll( 'label' )
-		).find( ( label ) => label.innerHTML.includes( 'Everything' ) );
+		const defaultControlLabel = screen.getByRole( 'combobox', {
+			name: 'Everything Controls the padding property for Everything viewports.',
+		} );
 
-		expect( defaultControlLabel ).not.toBeNull();
+		expect( defaultControlLabel ).toBeVisible();
 	} );
 } );
 
@@ -182,12 +182,8 @@ describe( 'Default and Responsive modes', () => {
 			/>
 		);
 
-		const defaultControlGroup = container.querySelector(
-			'.block-editor-responsive-block-control__group:not(.is-responsive)'
-		);
-		const responsiveControlGroup = container.querySelector(
-			'.block-editor-responsive-block-control__group.is-responsive'
-		);
+		const defaultControlGroup = getDefaultControlGroup( container );
+		const responsiveControlGroup = getResponsiveControlGroup( container );
 
 		expect( defaultControlGroup ).toBeNull();
 		expect( responsiveControlGroup ).not.toBeNull();
@@ -217,7 +213,7 @@ describe( 'Default and Responsive modes', () => {
 			renderTestDefaultControlComponent
 		);
 
-		const { container } = render(
+		render(
 			<ResponsiveBlockControl
 				title="Padding"
 				property="padding"
@@ -230,13 +226,12 @@ describe( 'Default and Responsive modes', () => {
 		const defaultRenderControlCall = 1;
 
 		// Get array of labels which match those in the custom viewports provided
-		const responsiveViewportsLabels = Array.from(
-			container.querySelectorAll( 'label' )
-		).filter( ( label ) => {
-			const labelText = label.innerHTML;
-			// Is the label one of those in the custom device set?
-			return !! customViewportSet.find( ( deviceName ) =>
-				labelText.includes( deviceName.label )
+		const responsiveViewportsLabels = [];
+		customViewportSet.forEach( ( { label } ) => {
+			responsiveViewportsLabels.push(
+				screen.getByRole( 'combobox', {
+					name: `${ label } Controls the padding property for ${ label } viewports.`,
+				} )
 			);
 		} );
 
@@ -270,24 +265,14 @@ describe( 'Default and Responsive modes', () => {
 
 		const { container } = render( <ResponsiveBlockControlConsumer /> );
 
-		let defaultControlGroup = container.querySelector(
-			'.block-editor-responsive-block-control__group:not(.is-responsive)'
-		);
-		let responsiveControlGroup = container.querySelector(
-			'.block-editor-responsive-block-control__group.is-responsive'
-		);
+		let defaultControlGroup = getDefaultControlGroup( container );
+		let responsiveControlGroup = getResponsiveControlGroup( container );
 
 		// Select elements based on what the user can see.
-		const toggleLabel = Array.from(
-			container.querySelectorAll( 'label' )
-		).find( ( label ) =>
-			label.innerHTML.includes(
-				'Use the same padding on all screensizes'
-			)
-		);
-		const toggleInput = container.querySelector(
-			`#${ toggleLabel.getAttribute( 'for' ) }`
-		);
+		const toggleInput = screen.getByRole( 'checkbox', {
+			name: 'Use the same padding on all screensizes.',
+			checked: true,
+		} );
 
 		// Initial mode (default)
 		expect( defaultControlGroup ).not.toBeNull();
@@ -296,12 +281,8 @@ describe( 'Default and Responsive modes', () => {
 		// Toggle to "responsive" mode.
 		await user.click( toggleInput );
 
-		defaultControlGroup = container.querySelector(
-			'.block-editor-responsive-block-control__group:not(.is-responsive)'
-		);
-		responsiveControlGroup = container.querySelector(
-			'.block-editor-responsive-block-control__group.is-responsive'
-		);
+		defaultControlGroup = getDefaultControlGroup( container );
+		responsiveControlGroup = getResponsiveControlGroup( container );
 
 		expect( defaultControlGroup ).toBeNull();
 		expect( responsiveControlGroup ).not.toBeNull();
@@ -309,12 +290,8 @@ describe( 'Default and Responsive modes', () => {
 		// Toggle back to "default" mode.
 		await user.click( toggleInput );
 
-		defaultControlGroup = container.querySelector(
-			'.block-editor-responsive-block-control__group:not(.is-responsive)'
-		);
-		responsiveControlGroup = container.querySelector(
-			'.block-editor-responsive-block-control__group.is-responsive'
-		);
+		defaultControlGroup = getDefaultControlGroup( container );
+		responsiveControlGroup = getResponsiveControlGroup( container );
 
 		expect( defaultControlGroup ).not.toBeNull();
 		expect( responsiveControlGroup ).toBeNull();
@@ -340,7 +317,7 @@ describe( 'Default and Responsive modes', () => {
 			} );
 		} );
 
-		const { container } = render(
+		render(
 			<ResponsiveBlockControl
 				title="Padding"
 				property="padding"
@@ -351,9 +328,9 @@ describe( 'Default and Responsive modes', () => {
 		);
 
 		// The user should see "range" controls so we can legitimately query for them here.
-		const customControls = Array.from(
-			container.querySelectorAll( 'input[type="range"]' )
-		);
+		const customControls = screen.getAllByRole( 'slider', {
+			name: /\w+ screens$/,
+		} );
 
 		// Also called because default control rendeer function is always called
 		// (for convenience) even though it's not displayed in output.


### PR DESCRIPTION
## What?
With the recent work to improve the quality of tests, we fixed a bunch of ESLint rule violations. This PR fixes a few [`no-container`](https://github.com/testing-library/eslint-plugin-testing-library/blob/main/docs/rules/no-container.md) rule violations in the `ResponsiveBlockControl` component. 

## Why?
The end goal is to enable that ESLint rule once all violations have been fixed.

## How?
We're refactoring most of the straightforward `querySelector` / `querySelectorAll` instances to use screen queries instead. We're leaving two of them that don't currently have a better user-facing way to address them, but I'm adding TODO comments and adding helper functions for them so each of them will occur in just one place.

## Testing Instructions
Verify all tests still pass.