### PR TITLE
DateTime: Remove unused types

### DIFF
--- a/packages/components/src/date-time/types.ts
+++ b/packages/components/src/date-time/types.ts
@@ -1,8 +1,3 @@
-/**
- * External dependencies
- */
-import type { Moment } from 'moment';
-
 export type TimePickerProps = {
 	/**
 	 * The initial current time the time picker should render.
@@ -28,20 +23,6 @@ export type DatePickerEvent = {
 	 * The date of the event.
 	 */
 	date: Date;
-};
-
-export type DatePickerDayProps = {
-	/**
-	 * The day to display.
-	 */
-	day: Moment;
-
-	/**
-	 * List of events to show on this day.
-	 *
-	 * @default []
-	 */
-	events?: DatePickerEvent[];
 };
 
 export type DatePickerProps = {


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
The date-time component inlcudes usued types. These can be removed.

## Why?
Cleanup code to only have types used.

## How?
Removed `DatePickerDayProps` from `types.ts` in `date-time`.

## Testing Instructions
Run `npm run dev` and confirm no type erros.
