### PR TITLE
Shuffle blocks for `contentOnly` patterns

### DIFF
--- a/packages/block-editor/src/hooks/content-lock-ui.js
+++ b/packages/block-editor/src/hooks/content-lock-ui.js
@@ -7,7 +7,7 @@ import { useDispatch, useSelect } from '@wordpress/data';
 import { addFilter } from '@wordpress/hooks';
 import { __ } from '@wordpress/i18n';
 import { useEffect, useRef, useCallback } from '@wordpress/element';
-import { store as blocksStore, getBlockType } from '@wordpress/blocks';
+import { store as blocksStore, hasBlockSupport } from '@wordpress/blocks';
 
 /**
  * Internal dependencies
@@ -48,11 +48,9 @@ function StopEditingAsBlocksOnOutsideSelect( {
 }
 
 function filterBlocksForShuffle( blocks ) {
-	return flattenBlocks( blocks ).filter( ( block ) => {
-		const blockType = getBlockType( block.name );
-
-		return blockType.category !== 'design';
-	} );
+	return flattenBlocks( blocks ).filter(
+		( block ) => ! hasBlockSupport( block.name, '__experimentalLayout' )
+	);
 }
 
 function compareFilteredBlocks( sourceBlocks, targetBlocks ) {


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->
A potential approach to https://github.com/WordPress/gutenberg/issues/44581/

> **Note**
> Code isn't optimized. Once we are fine with the approach, I'll try to polish it more.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
See https://github.com/WordPress/gutenberg/issues/44581

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
This PR implements an approach to swap non-content blocks with something else in other patterns. Since that inserted patterns don't have any information about which patterns they're inserted from, we have to perform an algorithm to "guess" which candidate patterns are alike. The algo used in this PR is to:

1. Flatten all blocks and inner blocks in the patterns.
2. Keep only the blocks that have `__experimentalRole="content"` in any of their attributes.
3. Compare the names of the flattened content blocks to the available patterns using the same method.
4. If both have the same length of content blocks then it's a match.

Once we find a match, we then add the "Shuffle" button to the toolbar. If the user clicks the button, it will randomly choose a pattern from the list and apply all but the contents to the blocks.

To prevent choosing the same pattern that it's added from, we do an `areBlocksAlike` check to see if the blocks look like existing patterns and filter it out.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->
1. Insert a pattern.
2. Go to the Code Editor and add `"templateLock":"contentOnly"` to the top-most group of the inserted pattern.
3. Select the inserted pattern/group.
4. Click on the "Shuffle" button in the toolbar.
5. The pattern should be randomly changed to a different pattern.

## Screenshots or screencast <!-- if applicable -->

https://user-images.githubusercontent.com/7753001/200731087-a9e3980b-08ca-4645-9e8b-94ce29330672.mp4

