### PR TITLE
Fix focus return when closing the Post publish panel

### DIFF
--- a/packages/e2e-test-utils-playwright/src/editor/publish-post.ts
+++ b/packages/e2e-test-utils-playwright/src/editor/publish-post.ts
@@ -12,7 +12,7 @@ import type { Editor } from './index';
 export async function publishPost( this: Editor ) {
 	await this.page.click( 'role=button[name="Publish"i]' );
 	const publishEditorPanel = this.page.locator(
-		'role=region[name="Publish editor"i]'
+		'role=region[name="Editor publish"i]'
 	);
 
 	const isPublishEditorVisible = await publishEditorPanel.isVisible();

--- a/packages/editor/src/components/post-publish-button/index.js
+++ b/packages/editor/src/components/post-publish-button/index.js
@@ -34,10 +34,20 @@ export class PostPublishButton extends Component {
 			entitiesSavedStatesCallback: false,
 		};
 	}
+
 	componentDidMount() {
 		if ( this.props.focusOnMount ) {
-			this.buttonNode.current.focus();
+			// This timeout is necessary to make sure the `useEffect` hook of
+			// `useFocusReturn` gets the correct element (the button that opens the
+			// PostPublishPanel) otherwise it will get this button.
+			this.timeoutID = setTimeout( () => {
+				this.buttonNode.current.focus();
+			}, 0 );
 		}
+	}
+
+	componentWillUnmount() {
+		clearTimeout( this.timeoutID );
 	}
 
 	createOnClick( callback ) {

--- a/test/e2e/specs/editor/various/publish-panel.spec.js
+++ b/test/e2e/specs/editor/various/publish-panel.spec.js
@@ -1,0 +1,60 @@
+/**
+ * WordPress dependencies
+ */
+const { test, expect } = require( '@wordpress/e2e-test-utils-playwright' );
+
+test.describe( 'Post publish panel', () => {
+	test.beforeEach( async ( { admin } ) => {
+		await admin.createNewPost();
+	} );
+
+	test( 'should move focus back to the Publish panel toggle button when canceling', async ( {
+		editor,
+		page,
+	} ) => {
+		// Add a paragraph block.
+		await editor.insertBlock( {
+			name: 'core/paragraph',
+			attributes: { content: 'Dummy text' },
+		} );
+
+		// Find and click the Publish panel toggle button.
+		const publishPanelToggleButton = page.locator(
+			'role=region[name="Editor top bar"i] >> role=button[name="Publish"i]'
+		);
+		await publishPanelToggleButton.click();
+
+		// Click the Cancel button.
+		await page.click(
+			'role=region[name="Editor publish"i] >> role=button[name="Cancel"i]'
+		);
+
+		// Test focus is moved back to the Publish panel toggle button.
+		await expect( publishPanelToggleButton ).toBeFocused();
+	} );
+
+	test( 'should move focus back to the Publish panel toggle button after publishing and closing the panel', async ( {
+		editor,
+		page,
+	} ) => {
+		// Insert a paragraph block.
+		await editor.insertBlock( {
+			name: 'core/paragraph',
+			attributes: { content: 'Dummy text' },
+		} );
+
+		await editor.publishPost();
+
+		// Close the publish panel.
+		await page.click(
+			'role=region[name="Editor publish"i] >> role=button[name="Close panel"i]'
+		);
+
+		// Test focus is moved back to the Publish panel toggle button.
+		await expect(
+			page.locator(
+				'role=region[name="Editor top bar"i] >> role=button[name="Update"i]'
+			)
+		).toBeFocused();
+	} );
+} );


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->
Fixes https://github.com/WordPress/gutenberg/issues/45417

## What?
<!-- In a few words, what is the PR actually doing? -->
When closing the Post publish panel, focus is supposed to be moved back to the Publish button within the top bar. This is broken since a while, probably since the refactoring of `withFocusReturn` to use React hooks. The root cause is a timing issue. This PR seeks to solve it avoiding major refactoring.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
A focus loss is a frustrating experience for all keyboard users as they are forced to start keyboard navigation again from the document root.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
To my understanding:
- When the publish panel opens, `PostPublishButton` sets focus on the Publish button _within_ the panel. It does that on `componentDidMount`.
- After that,`withFocusReturn` (which internally uses `useFocusReturn`) checks what the `document.activeElement` is. Actually, this is now the Publish button _within_ the panel, while `useFocusReturn` is supposed to get the element that was focused _before_ the panel opens (the Publish button within the top bar).
- When closing the Publish panel, `withFocusReturn` tries to set focus on the wrong button thus there's a focus loss.

Basically, it appears that the `useFocusReturn` hook can't work well with class components that manage focus internally with `componentDidMount`. In fact, `useEffect` runs after `componentDidMount` and at that point the `document.activeElement` is not the expected one. 

Instead of refactoring `PostPublishButton`, this PR just makes sure that `PostPublishButton` sets focus at a later time so that `withFocusReturn` gets the correct button.

- Added two Playwright tests.
- Fixed what appears to be a typo in the publishPost Playwright utility. /Cc @kevin940726 @tellthemachines could you please check this, when you have a chance? 🙏 

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->
- Make sure the `Options > Preferences > Include pre-publish checklist` preference is enabled.
- Create a new post, add some content, and click the Publish button within the top bar.
- The Publish panel opens.
- Click the Cancel button within the panel.
- The Publish panel closes.
- Check focus is moved back to the Publish button within the top bar.
- Click the Publish button within the top bar again.
- The Publish panel opens.
- Click the Publish button within the panel.
- Wait for the Post to be published.
- The post-publish panel appears.
- Click the X button at the top right of the post-publish panel to close it.
- Check focus is moved back to the Update button within the top bar.

Optionally:
- Run the 2 new tests with `npm run test:e2e:playwright -- --headed editor/various/publish-panel.spec.js`
- See the tests pass.
- Revert the changes to `PostPublishButton`.
- Run the 2 new tests again and see they fail.

## Screenshots or screencast <!-- if applicable -->
