### PR TITLE
Components: improve tests for `ToggleGroupControl`

### DIFF
--- a/packages/components/src/toggle-group-control/test/index.tsx
+++ b/packages/components/src/toggle-group-control/test/index.tsx
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { render, fireEvent, screen } from '@testing-library/react';
+import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 
 /**
@@ -73,7 +73,10 @@ describe( 'ToggleGroupControl', () => {
 			expect( container ).toMatchSnapshot();
 		} );
 	} );
-	it( 'should call onChange with proper value', () => {
+	it( 'should call onChange with proper value', async () => {
+		const user = userEvent.setup( {
+			advanceTimers: jest.advanceTimersByTime,
+		} );
 		const mockOnChange = jest.fn();
 
 		render(
@@ -86,31 +89,31 @@ describe( 'ToggleGroupControl', () => {
 			</ToggleGroupControl>
 		);
 
-		const firstRadio = screen.getByRole( 'radio', { name: 'R' } );
-
-		fireEvent.click( firstRadio );
+		await user.click( screen.getByRole( 'radio', { name: 'R' } ) );
 
 		expect( mockOnChange ).toHaveBeenCalledWith( 'rigas' );
 	} );
-	it( 'should render tooltip where `showTooltip` === `true`', () => {
+	it( 'should render tooltip where `showTooltip` === `true`', async () => {
+		const user = userEvent.setup( {
+			advanceTimers: jest.advanceTimersByTime,
+		} );
 		render(
 			<ToggleGroupControl label="Test Toggle Group Control">
 				{ optionsWithTooltip }
 			</ToggleGroupControl>
 		);
 
-		const firstRadio = screen.getByLabelText(
-			'Click for Delicious Gnocchi'
-		);
-
-		fireEvent.focus( firstRadio );
+		await user.tab();
 
 		expect(
 			screen.getByText( 'Click for Delicious Gnocchi' )
-		).toBeInTheDocument();
+		).toBeVisible();
 	} );
 
-	it( 'should not render tooltip', () => {
+	it( 'should not render tooltip', async () => {
+		const user = userEvent.setup( {
+			advanceTimers: jest.advanceTimersByTime,
+		} );
 		render(
 			<ToggleGroupControl label="Test Toggle Group Control">
 				{ optionsWithTooltip }
@@ -121,7 +124,7 @@ describe( 'ToggleGroupControl', () => {
 			'Click for Sumptuous Caponata'
 		);
 
-		fireEvent.focus( secondRadio );
+		await user.click( secondRadio );
 
 		expect(
 			screen.queryByText( 'Click for Sumptuous Caponata' )
@@ -208,7 +211,7 @@ describe( 'ToggleGroupControl', () => {
 						name: 'R',
 						pressed: false,
 					} )
-				).toBeInTheDocument();
+				).toBeVisible();
 			} );
 
 			it( 'should tab to the next option button', async () => {

--- a/packages/components/src/toggle-group-control/test/index.tsx
+++ b/packages/components/src/toggle-group-control/test/index.tsx
@@ -93,27 +93,25 @@ describe( 'ToggleGroupControl', () => {
 
 		expect( mockOnChange ).toHaveBeenCalledWith( 'rigas' );
 	} );
-	it( 'should render tooltip where `showTooltip` === `true`', async () => {
-		const user = userEvent.setup( {
-			advanceTimers: jest.advanceTimersByTime,
-		} );
+	it( 'should render tooltip where `showTooltip` === `true`', () => {
 		render(
 			<ToggleGroupControl label="Test Toggle Group Control">
 				{ optionsWithTooltip }
 			</ToggleGroupControl>
 		);
 
-		await user.tab();
+		const firstRadio = screen.getByLabelText(
+			'Click for Delicious Gnocchi'
+		);
+
+		firstRadio.focus();
 
 		expect(
 			screen.getByText( 'Click for Delicious Gnocchi' )
 		).toBeVisible();
 	} );
 
-	it( 'should not render tooltip', async () => {
-		const user = userEvent.setup( {
-			advanceTimers: jest.advanceTimersByTime,
-		} );
+	it( 'should not render tooltip', () => {
 		render(
 			<ToggleGroupControl label="Test Toggle Group Control">
 				{ optionsWithTooltip }
@@ -124,7 +122,7 @@ describe( 'ToggleGroupControl', () => {
 			'Click for Sumptuous Caponata'
 		);
 
-		await user.click( secondRadio );
+		secondRadio.focus();
 
 		expect(
 			screen.queryByText( 'Click for Sumptuous Caponata' )

--- a/packages/components/src/toggle-group-control/test/index.tsx
+++ b/packages/components/src/toggle-group-control/test/index.tsx
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { render, screen } from '@testing-library/react';
+import { render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 
 /**
@@ -93,7 +93,11 @@ describe( 'ToggleGroupControl', () => {
 
 		expect( mockOnChange ).toHaveBeenCalledWith( 'rigas' );
 	} );
-	it( 'should render tooltip where `showTooltip` === `true`', () => {
+
+	it( 'should render tooltip where `showTooltip` === `true`', async () => {
+		const user = userEvent.setup( {
+			advanceTimers: jest.advanceTimersByTime,
+		} );
 		render(
 			<ToggleGroupControl label="Test Toggle Group Control">
 				{ optionsWithTooltip }
@@ -104,14 +108,19 @@ describe( 'ToggleGroupControl', () => {
 			'Click for Delicious Gnocchi'
 		);
 
-		firstRadio.focus();
+		await user.hover( firstRadio );
 
-		expect(
-			screen.getByText( 'Click for Delicious Gnocchi' )
-		).toBeVisible();
+		await waitFor( () =>
+			expect(
+				screen.getByText( 'Click for Delicious Gnocchi' )
+			).toBeVisible()
+		);
 	} );
 
-	it( 'should not render tooltip', () => {
+	it( 'should not render tooltip', async () => {
+		const user = userEvent.setup( {
+			advanceTimers: jest.advanceTimersByTime,
+		} );
 		render(
 			<ToggleGroupControl label="Test Toggle Group Control">
 				{ optionsWithTooltip }
@@ -122,11 +131,13 @@ describe( 'ToggleGroupControl', () => {
 			'Click for Sumptuous Caponata'
 		);
 
-		secondRadio.focus();
+		await user.hover( secondRadio );
 
-		expect(
-			screen.queryByText( 'Click for Sumptuous Caponata' )
-		).not.toBeInTheDocument();
+		await waitFor( () =>
+			expect(
+				screen.queryByText( 'Click for Sumptuous Caponata' )
+			).not.toBeInTheDocument()
+		);
 	} );
 
 	describe( 'isDeselectable', () => {


### PR DESCRIPTION
## What?

Improve tests for the `ToggleGroupControl` component.

## Why?

Follow along RTL best practices to improve code quality.

## How?

- Using `@testing-library/user-event` instead of `fireEvent`
- Assert using `.toBeVisible` rather than `.toBeInTheDocument` in one case

## Testing Instructions

Verify unit tests still pass

```
npm run test:unit packages/components/src/toggle-group-control/test
```
