### PR TITLE
Plugin: Updates tested up to version to 6.1

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -1,6 +1,6 @@
 === Gutenberg ===
 Contributors: matveb, joen, karmatosed
-Tested up to: 6.0
+Tested up to: 6.1
 Stable tag: V.V.V
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Let's update 'Tested up to' to WordPress 6.1.

Similar to https://github.com/WordPress/gutenberg/pull/41272 for WordPress 6.0, but the Create Block-related templates have already been updated to 6.1. It looks like we forgot to update the main readme file when 6.1 was actually released. 

## Why?
We need to update the 'Tested up to' version of Gutenberg to the latest stable release of WordPress.

## How?
Update the tested up to version in the readme file.
