### PR TITLE
Cover: Avoid content loss when the templateLock value is all or contentOnly

### DIFF
--- a/packages/block-library/src/cover/edit/index.js
+++ b/packages/block-library/src/cover/edit/index.js
@@ -188,7 +188,7 @@ function CoverEdit( {
 			className: 'wp-block-cover__inner-container',
 		},
 		{
-			template: innerBlocksTemplate,
+			template: ! hasInnerBlocks ? innerBlocksTemplate : undefined,
 			templateInsertUpdatesSelection: true,
 			allowedBlocks,
 			templateLock,

--- a/packages/block-library/src/cover/edit/index.js
+++ b/packages/block-library/src/cover/edit/index.js
@@ -188,6 +188,8 @@ function CoverEdit( {
 			className: 'wp-block-cover__inner-container',
 		},
 		{
+			// Avoid template sync when the `templateLock` value is `all` or `contentOnly`.
+			// See: https://github.com/WordPress/gutenberg/pull/45632
 			template: ! hasInnerBlocks ? innerBlocksTemplate : undefined,
 			templateInsertUpdatesSelection: true,
 			allowedBlocks,


### PR DESCRIPTION
## What?
Resolves #45625.

PR fixes the content loss bug when a Cover block has the `templateLock` attribute set to `all` or `contentOnly`.

## Why?
The `useInnerBlockTemplateSync` hook will try to replace inner blocks with the default template when the template is meant to be locked.

It ensures templates are always in sync, which is handy for post-type templates in the editor. But it can cause content loss when a block has a default template, and `templateLock` can be defined directly on it.

## How?
We can skip synchronizing by omitting the default template when a Cover already has inner blocks.

Ideally, we might want to adjust `shouldApplyTemplate` inside the `useInnerBlockTemplateSync`, but that's a significant change for a minor release patch.

## Testing Instructions
See the original issue for reproduction steps - #45625.

Also, confirm that the default template is correctly inserted for a new Cover block.