### PR TITLE
Fix alignment of create new post link

### DIFF
--- a/packages/block-library/src/query/editor.scss
+++ b/packages/block-library/src/query/editor.scss
@@ -3,7 +3,7 @@
 }
 
 .wp-block-query__create-new-link {
-	padding: 0 $grid-unit-20 $grid-unit-20 56px;
+	padding: 0 $grid-unit-20 $grid-unit-20 52px;
 }
 
 .block-library-query__pattern-selection-content .block-editor-block-patterns-list {


### PR DESCRIPTION

<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
The new post link alignment was is off. 

## How?
This PR changes it from `56px` to `52px`.  The link needs to be aligned with the text next to the icon. The icon has a padding left of `16px`, a width of `24px`and a padding right of `12px`. Combined, this is `52px`.

## Testing Instructions
- Apply this PR
- Create a new post / page / open FSE
- Add a query block
- Verify that the alignment is correct

## Screenshots or screencast <!-- if applicable -->

| Before | After |
|--------|------|
| <img width="304" alt="CleanShot 2022-11-09 at 10 40 58@2x" src="https://user-images.githubusercontent.com/528287/200902241-14a7811b-85ac-4802-81d5-6edde9f39b0e.png">  | <img width="293" alt="CleanShot 2022-11-09 at 10 41 30@2x" src="https://user-images.githubusercontent.com/528287/200901974-ccb026ca-8439-4ae1-9457-171b4132d56e.png">  |

