### PR TITLE
Fix: Contrast checker appears unexpectedly on some blocks

### DIFF
--- a/packages/block-editor/src/hooks/color.js
+++ b/packages/block-editor/src/hooks/color.js
@@ -459,6 +459,8 @@ export function ColorEdit( props ) {
 		Platform.OS === 'web' &&
 		! gradient &&
 		! style?.color?.gradient &&
+		hasBackgroundColor &&
+		( hasLinkColor || hasTextColor ) &&
 		// Contrast checking is enabled by default.
 		// Deactivating it requires `enableContrastChecker` to have
 		// an explicit value of `false`.


### PR DESCRIPTION
Fixes: https://github.com/WordPress/gutenberg/issues/37549

This PR fixes an issue reported by @gziolo where if a block only supports background color without link or text color support we still show contrast warning messages that may be inaccurate and unexpected. This PR fixes the issue and makes sure the contrast checked only appears if the background and text or link color are supported.


## Testing Instructions
Add a comments block.
Select the comments next page block.
Select a black background color for the block and verify no contract checker messages appear.
