### PR TITLE
Make Manage Reusable blocks match similar links

### DIFF
--- a/packages/block-editor/src/components/inserter/reusable-blocks-tab.js
+++ b/packages/block-editor/src/components/inserter/reusable-blocks-tab.js
@@ -4,6 +4,7 @@
 import { useMemo } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import { addQueryArgs } from '@wordpress/url';
+import { Button } from '@wordpress/components';
 
 /**
  * Internal dependencies
@@ -59,14 +60,15 @@ export function ReusableBlocksTab( { rootClientId, onInsert, onHover } ) {
 				rootClientId={ rootClientId }
 			/>
 			<div className="block-editor-inserter__manage-reusable-blocks-container">
-				<a
+				<Button
 					className="block-editor-inserter__manage-reusable-blocks"
+					variant="secondary"
 					href={ addQueryArgs( 'edit.php', {
 						post_type: 'wp_block',
 					} ) }
 				>
 					{ __( 'Manage Reusable blocks' ) }
-				</a>
+				</Button>
 			</div>
 		</>
 	);

--- a/packages/block-editor/src/components/inserter/style.scss
+++ b/packages/block-editor/src/components/inserter/style.scss
@@ -174,9 +174,13 @@ $block-inserter-tabs-height: 44px;
 	text-align: right;
 }
 
-.block-editor-inserter__manage-reusable-blocks {
-	display: inline-block;
+.block-editor-inserter__manage-reusable-blocks-container {
 	margin: $grid-unit-20;
+}
+
+.block-editor-inserter__manage-reusable-blocks {
+	justify-content: center;
+	width: 100%;
 }
 
 .block-editor-inserter__no-results {
@@ -339,10 +343,6 @@ $block-inserter-tabs-height: 44px;
 	padding: $grid-unit-20;
 	flex-shrink: 0;
 	position: relative; // prevents overscroll when block library is open
-}
-
-.block-editor-inserter__manage-reusable-blocks-container {
-	padding: $grid-unit-20;
 }
 
 .block-editor-inserter__quick-inserter {


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
The Manage Reusable blocks link inside the reusable blocks inserter should match other similar links such as 'Explore all patterns' on the pattern inserter.

## Why?
User interface consistency. Fixes https://github.com/WordPress/gutenberg/issues/45155

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
This changes a HTML `<a>` to a `<Button variant=secondary />` along with some CSS changes

## Testing Instructions
Add a reusable block if you haven't already:
1. Open Gutenberg post editor
2. Insert any block
3. Press the three dots menu of the block and choose 'Create reusable block'
4. Follow the prompts

Test the change:
1. Still in the editor, open the inserter (big blue plus at the top left)
2. In the inserter sidebar, click Patterns and scroll to the bottom, look at the 'Explore all patterns' button
3. Click 'Reusable blocks' in the inserter sidebar and scroll to the bottom, look at the 'Manage Reusable blocks' button. They should look the same
4. Click 'Manage Reusable blocks' button it should take you to /wp-admin/edit.php?post_type=wp_block

## Screenshots or screencast <!-- if applicable -->
Before | After
-------|------
![image](https://user-images.githubusercontent.com/93301/200903751-de70eca7-fe68-4a34-bd03-afa99e1afde7.png) | ![image](https://user-images.githubusercontent.com/93301/200903795-a2153cd1-36a6-4085-9749-5011b465e34f.png)
