### PR TITLE
Global Styles: Elements: Add a text decoration control to link elements

### DIFF
--- a/packages/edit-site/src/components/global-styles/typography-panel.js
+++ b/packages/edit-site/src/components/global-styles/typography-panel.js
@@ -7,6 +7,7 @@ import {
 	__experimentalFontAppearanceControl as FontAppearanceControl,
 	__experimentalLetterSpacingControl as LetterSpacingControl,
 	__experimentalTextTransformControl as TextTransformControl,
+	__experimentalTextDecorationControl as TextDecorationControl,
 } from '@wordpress/block-editor';
 import {
 	FontSizePicker,
@@ -101,6 +102,15 @@ function useHasTextTransformControl( name, element ) {
 	return supports.includes( 'textTransform' );
 }
 
+function useHasTextDecorationControl( name, element ) {
+	// This is an exception for link elements.
+	// We shouldn't allow other blocks or elements to set textDecoration
+	// because this will be inherited by their children.
+	if ( ! name && element === 'link' ) {
+		return true;
+	}
+}
+
 function useStyleWithReset( path, blockName ) {
 	const [ style, setStyle ] = useStyle( path, blockName );
 	const [ userStyle ] = useStyle( path, blockName, 'user' );
@@ -190,6 +200,10 @@ export default function TypographyPanel( { name, element, headingLevel } ) {
 	const appearanceControlLabel = useAppearanceControlLabel( name );
 	const hasLetterSpacingControl = useHasLetterSpacingControl( name, element );
 	const hasTextTransformControl = useHasTextTransformControl( name, element );
+	const hasTextDecorationControl = useHasTextDecorationControl(
+		name,
+		element
+	);
 
 	/* Disable font size controls when the option to style all headings is selected. */
 	let hasFontSizeEnabled = supports.includes( 'fontSize' );
@@ -223,6 +237,12 @@ export default function TypographyPanel( { name, element, headingLevel } ) {
 		hasTextTransform,
 		resetTextTransform,
 	] = useStyleWithReset( prefix + 'typography.textTransform', name );
+	const [
+		textDecoration,
+		setTextDecoration,
+		hasTextDecoration,
+		resetTextDecoration,
+	] = useStyleWithReset( prefix + 'typography.textDecoration', name );
 
 	const resetAll = () => {
 		resetFontFamily();
@@ -344,6 +364,22 @@ export default function TypographyPanel( { name, element, headingLevel } ) {
 						isBlock
 						size="__unstable-large"
 						__nextHasNoMarginBottom
+					/>
+				</ToolsPanelItem>
+			) }
+			{ hasTextDecorationControl && (
+				<ToolsPanelItem
+					className="single-column"
+					label={ __( 'Text decoration' ) }
+					hasValue={ hasTextDecoration }
+					onDeselect={ resetTextDecoration }
+					isShownByDefault
+				>
+					<TextDecorationControl
+						value={ textDecoration }
+						onChange={ setTextDecoration }
+						size="__unstable-large"
+						__unstableInputWidth="auto"
 					/>
 				</ToolsPanelItem>
 			) }

--- a/packages/edit-site/src/components/global-styles/typography-panel.js
+++ b/packages/edit-site/src/components/global-styles/typography-panel.js
@@ -106,9 +106,7 @@ function useHasTextDecorationControl( name, element ) {
 	// This is an exception for link elements.
 	// We shouldn't allow other blocks or elements to set textDecoration
 	// because this will be inherited by their children.
-	if ( ! name && element === 'link' ) {
-		return true;
-	}
+	return ! name && element === 'link';
 }
 
 function useStyleWithReset( path, blockName ) {


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
This adds a text decoration option to link elements.
Fixes #40002

## Why?
The core theme.json file sets a default text decoration for all links. Themes can control this in theme.json but we should make the control available .

## How?
Add the text decoration control to Global Styles but only enable it for links.

## Testing Instructions
- Open the site editor
- Open the Global Styles panel
- Go to Typography
- Select links
- Confirm that you see a "text decoration" option.
- Confirm that changing this option changes the text decoration of links in the frontend
- Confirm that this control isn't available for any other blocks.

## Screenshots or screencast <!-- if applicable -->
<img width="280" alt="Screenshot 2022-11-09 at 11 08 53" src="https://user-images.githubusercontent.com/275961/200907200-617ce4ac-3169-4c84-9a9b-da9cb03ced19.png">


cc @WordPress/block-themers 
