### PR TITLE
Update: lock icon to outline

### DIFF
--- a/packages/block-editor/src/components/block-lock/menu-item.js
+++ b/packages/block-editor/src/components/block-lock/menu-item.js
@@ -4,7 +4,7 @@
 import { __ } from '@wordpress/i18n';
 import { useReducer } from '@wordpress/element';
 import { MenuItem } from '@wordpress/components';
-import { lock, unlock } from '@wordpress/icons';
+import { lockOutline, unlock } from '@wordpress/icons';
 
 /**
  * Internal dependencies
@@ -28,7 +28,10 @@ export default function BlockLockMenuItem( { clientId } ) {
 
 	return (
 		<>
-			<MenuItem icon={ isLocked ? unlock : lock } onClick={ toggleModal }>
+			<MenuItem
+				icon={ isLocked ? unlock : lockOutline }
+				onClick={ toggleModal }
+			>
 				{ label }
 			</MenuItem>
 			{ isModalOpen && (

--- a/packages/icons/src/index.js
+++ b/packages/icons/src/index.js
@@ -125,6 +125,7 @@ export { default as list } from './library/list';
 export { default as listItem } from './library/list-item';
 export { default as listView } from './library/list-view';
 export { default as lock } from './library/lock';
+export { default as lockOutline } from './library/lock-outline';
 export { default as login } from './library/login';
 export { default as loop } from './library/loop';
 export { default as mapMarker } from './library/map-marker';

--- a/packages/icons/src/library/lock-outline.js
+++ b/packages/icons/src/library/lock-outline.js
@@ -1,0 +1,12 @@
+/**
+ * WordPress dependencies
+ */
+import { SVG, Path } from '@wordpress/primitives';
+
+const lockOutline = (
+	<SVG viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
+		<Path d="M17 10h-1.2V7c0-2.1-1.7-3.8-3.8-3.8-2.1 0-3.8 1.7-3.8 3.8v3H7c-.6 0-1 .4-1 1v8c0 .6.4 1 1 1h10c.6 0 1-.4 1-1v-8c0-.6-.4-1-1-1zM9.8 7c0-1.2 1-2.2 2.2-2.2 1.2 0 2.2 1 2.2 2.2v3H9.8V7zm6.7 11.5h-9v-7h9v7z" />
+	</SVG>
+);
+
+export default lockOutline;


### PR DESCRIPTION

## What?
Fixes https://github.com/WordPress/gutenberg/issues/39916. 
This Pr adds a new outline lock icon to be used in the menu item.

## Why?
See https://github.com/WordPress/gutenberg/issues/39916. 
By making the lock icon in the menu item less pronounced we are making it less attention grabbing. 

## How?
This PR updates the icon in the menu item to use the outline lock icon.

## Testing Instructions
1. Build this branch. 
2. type some text. 
3. Go to Option. (three dot menu) 
4. Notice that the icon is the new outline lock icon. 
5. Lock the block. Notice that the icon is still the previous unlock icon.

## Screenshots or screencast <!-- if applicable -->
Before:

<img width="520" alt="Screen Shot 2022-03-30 at 10 44 15 AM" src="https://user-images.githubusercontent.com/26996883/160924852-44cd4902-2e8a-4cb9-a420-50061b490e18.png">

After:
<img width="690" alt="Screenshot 2022-11-09 at 11 00 36 AM" src="https://user-images.githubusercontent.com/115071/200907001-cec880f1-d919-4a22-ba84-b993a0b5d0a0.png">


<img width="678" alt="Screenshot 2022-11-09 at 11 00 45 AM" src="https://user-images.githubusercontent.com/115071/200907228-76a4c50d-83eb-479d-a4f2-14fe8be66a92.png">
(This stayed the same) 

