### PR TITLE
Navigation: Fix overflowing menu name in the navigation selector dropdown

### DIFF
--- a/packages/block-library/src/navigation/edit/navigation-menu-selector.js
+++ b/packages/block-library/src/navigation/edit/navigation-menu-selector.js
@@ -170,7 +170,11 @@ function NavigationMenuSelector( {
 					: 'wp-block-navigation__navigation-selector'
 			}
 			label={ selectorLabel }
-			text={ isOffCanvasNavigationEditorEnabled ? '' : selectorLabel }
+			text={
+				<span className="wp-block-navigation__navigation-selector-button__label">
+					{ isOffCanvasNavigationEditorEnabled ? '' : selectorLabel }
+				</span>
+			}
 			icon={ isOffCanvasNavigationEditorEnabled ? moreVertical : null }
 			toggleProps={
 				isOffCanvasNavigationEditorEnabled

--- a/packages/block-library/src/navigation/editor.scss
+++ b/packages/block-library/src/navigation/editor.scss
@@ -649,6 +649,7 @@ body.editor-styles-wrapper
 	flex: 0 1 auto;
 	overflow: hidden;
 	text-overflow: ellipsis;
+	white-space: nowrap;
 }
 
 .wp-block-navigation__navigation-selector-button--createnew {

--- a/packages/block-library/src/navigation/editor.scss
+++ b/packages/block-library/src/navigation/editor.scss
@@ -27,7 +27,6 @@
 	display: inline;
 }
 
-
 /**
  * Submenus.
  */
@@ -158,7 +157,7 @@ $colors-selector-size: 22px;
 		min-width: $colors-selector-size;
 		height: $colors-selector-size;
 		min-height: $colors-selector-size;
-		line-height: ( $colors-selector-size - 2 );
+		line-height: ($colors-selector-size - 2);
 		padding: 2px;
 
 		> svg {
@@ -202,7 +201,9 @@ $color-control-label-height: 20px;
 // This should be a temporary fix, to be replaced by improvements to
 // the sibling inserter. Or by the dropdown appender that is used in Group, instead of the "Button block appender".
 // See https://github.com/WordPress/gutenberg/issues/37572.
-.wp-block-navigation .wp-block + .block-list-appender .block-editor-button-block-appender {
+.wp-block-navigation
+.wp-block + .block-list-appender
+.block-editor-button-block-appender {
 	background-color: $gray-900;
 	color: $white;
 
@@ -218,7 +219,6 @@ $color-control-label-height: 20px;
 	background-color: transparent;
 	color: $gray-900;
 }
-
 
 /**
  * Setup state
@@ -389,7 +389,9 @@ $color-control-label-height: 20px;
 }
 
 // Keep as row for medium.
-.wp-block-navigation .components-placeholder.is-medium .components-placeholder__fieldset {
+.wp-block-navigation
+.components-placeholder.is-medium
+.components-placeholder__fieldset {
 	flex-direction: row !important;
 }
 
@@ -420,7 +422,6 @@ $color-control-label-height: 20px;
 		max-height: $grid-unit-20;
 	}
 }
-
 
 /**
  * Mobile menu.
@@ -570,7 +571,8 @@ body.editor-styles-wrapper
 	padding: $grid-unit-10 $grid-unit-15;
 }
 
-.wp-block-navigation .wp-block-navigation__uncontrolled-inner-blocks-loading-indicator {
+.wp-block-navigation
+.wp-block-navigation__uncontrolled-inner-blocks-loading-indicator {
 	margin-top: 0;
 }
 
@@ -637,6 +639,16 @@ body.editor-styles-wrapper
 	border: 1px solid;
 	justify-content: space-between;
 	width: 100%;
+}
+
+.wp-block-navigation__navigation-selector-button__icon {
+	flex: 0 0 auto;
+}
+
+.wp-block-navigation__navigation-selector-button__label {
+	flex: 0 1 auto;
+	overflow: hidden;
+	text-overflow: ellipsis;
 }
 
 .wp-block-navigation__navigation-selector-button--createnew {

--- a/packages/block-library/src/navigation/editor.scss
+++ b/packages/block-library/src/navigation/editor.scss
@@ -27,6 +27,7 @@
 	display: inline;
 }
 
+
 /**
  * Submenus.
  */
@@ -157,7 +158,7 @@ $colors-selector-size: 22px;
 		min-width: $colors-selector-size;
 		height: $colors-selector-size;
 		min-height: $colors-selector-size;
-		line-height: ($colors-selector-size - 2);
+		line-height: ( $colors-selector-size - 2 );
 		padding: 2px;
 
 		> svg {
@@ -201,9 +202,7 @@ $color-control-label-height: 20px;
 // This should be a temporary fix, to be replaced by improvements to
 // the sibling inserter. Or by the dropdown appender that is used in Group, instead of the "Button block appender".
 // See https://github.com/WordPress/gutenberg/issues/37572.
-.wp-block-navigation
-.wp-block + .block-list-appender
-.block-editor-button-block-appender {
+.wp-block-navigation .wp-block + .block-list-appender .block-editor-button-block-appender {
 	background-color: $gray-900;
 	color: $white;
 
@@ -219,6 +218,7 @@ $color-control-label-height: 20px;
 	background-color: transparent;
 	color: $gray-900;
 }
+
 
 /**
  * Setup state
@@ -389,9 +389,7 @@ $color-control-label-height: 20px;
 }
 
 // Keep as row for medium.
-.wp-block-navigation
-.components-placeholder.is-medium
-.components-placeholder__fieldset {
+.wp-block-navigation .components-placeholder.is-medium .components-placeholder__fieldset {
 	flex-direction: row !important;
 }
 
@@ -422,6 +420,7 @@ $color-control-label-height: 20px;
 		max-height: $grid-unit-20;
 	}
 }
+
 
 /**
  * Mobile menu.
@@ -571,8 +570,7 @@ body.editor-styles-wrapper
 	padding: $grid-unit-10 $grid-unit-15;
 }
 
-.wp-block-navigation
-.wp-block-navigation__uncontrolled-inner-blocks-loading-indicator {
+.wp-block-navigation .wp-block-navigation__uncontrolled-inner-blocks-loading-indicator {
 	margin-top: 0;
 }
 


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
This PR fixes the overflowing text in the navigation selector dropdown for menus with longer names.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
It resolves the UI bug with the navigation selector dropdown reported in https://github.com/WordPress/gutenberg/issues/45294.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
This PR wraps the text for the selected menu within the navigation selector dropdown toggle, so that flex and text CSS properties can be applied to avoid the overflowing.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
1. Add a new Navigation block.
2. Create a menu with a really long name.
3. Select the menu from the dropdown.
4. Check if the menu name within the dropdown toggle button gets truncated instead of overflowing outside of the button.

## Screenshots or screencast <!-- if applicable -->
**Before:**
![CleanShot 2022-11-09 at 11 24 02](https://user-images.githubusercontent.com/2722412/200912489-5bedf3b4-a188-4414-9641-5c17bfb4a981.png)

**After:**
![CleanShot 2022-11-09 at 11 23 10](https://user-images.githubusercontent.com/2722412/200912508-6a7b1cf9-c582-4d42-9ee0-1eac7d6b5d59.png)
