### PR TITLE
Color Picker: Prevent all number fields to become 0 when one of them is an empty string

### DIFF
--- a/packages/components/src/color-picker/input-with-slider.tsx
+++ b/packages/components/src/color-picker/input-with-slider.tsx
@@ -25,12 +25,14 @@ export const InputWithSlider = ( {
 	onChange,
 	value,
 }: InputWithSliderProps ) => {
-	const onNumberControlChange = ( newValue: number | string ) => {
-		if ( newValue === '' ) {
-			return onChange( 0 );
+	const onNumberControlChange = ( newValue?: number | string ) => {
+		if ( ! newValue ) {
+			onChange( 0 );
+			return;
 		}
 		if ( typeof newValue === 'string' ) {
-			return onChange( parseInt( newValue, 10 ) );
+			onChange( parseInt( newValue, 10 ) );
+			return;
 		}
 		onChange( newValue );
 	};
@@ -43,7 +45,6 @@ export const InputWithSlider = ( {
 				label={ label }
 				hideLabelFromVision
 				value={ value }
-				// @ts-expect-error TODO: Resolve discrepancy in NumberControl
 				onChange={ onNumberControlChange }
 				prefix={
 					<Spacer

--- a/packages/components/src/color-picker/input-with-slider.tsx
+++ b/packages/components/src/color-picker/input-with-slider.tsx
@@ -25,6 +25,16 @@ export const InputWithSlider = ( {
 	onChange,
 	value,
 }: InputWithSliderProps ) => {
+	const onNumberControlChange = ( newValue: number | string ) => {
+		if ( newValue === '' ) {
+			return onChange( 0 );
+		}
+		if ( typeof newValue === 'string' ) {
+			return onChange( parseInt( newValue, 10 ) );
+		}
+		onChange( newValue );
+	};
+
 	return (
 		<HStack spacing={ 4 }>
 			<NumberControlWrapper
@@ -34,7 +44,7 @@ export const InputWithSlider = ( {
 				hideLabelFromVision
 				value={ value }
 				// @ts-expect-error TODO: Resolve discrepancy in NumberControl
-				onChange={ onChange }
+				onChange={ onNumberControlChange }
 				prefix={
 					<Spacer
 						as={ Text }


### PR DESCRIPTION
Fixes https://github.com/WordPress/gutenberg/issues/36703

## What?

This PR fixes an incorrect behaviour where, when deleting a value from the Color Picker's detailed inputs (e.g. the R value in RGB), all other inputs (e.g. the G and B in RGB) would be reset to 0.

## Why?

Deleting a number field is a common user action. Resetting unrelated fields is an unexpected side effect with no obvious workarounds.

## How?

The proposed change normalizes the `onChange` input, so that it's converted to `0` whenever it's an empty string or undefined.

The change is larger than strictly needed because of type discrepancies detected by TypeScript.

---

cc @mirka @ciampo:
~I would have loved to remove the `// @ts-expect-error TODO: Resolve discrepancy in NumberControl`, which I think is reasonably resolved here.
Though, removing it triggers a new error with the return type, which probably requires more familiarity with TS than I have.~

EDIT: in e8a99e6 I've tightened up the type checks (thanks to @ciampo for pointing out that the error was on the param, not on the return as I thought!), which allowed me to remove the linter exception. Let me know if this is a reasonable approach!

---

## Testing Instructions

1. Open a Color Picker, e.g. select a block and modify its _Text color_.
2. Toggle _Show detailed inputs_.
3. Select _RGB_ in the dropdown that appears. (Bug also exists when using _HSL_.)
4. Type in something like R = 200, G = 200, B = 200.
5. Double click on the R field.
6. Press <kbd>Delete</kbd>, as if you were about to modify it to be 100.
7. ⚠️ Ensure the G and B fields keep their values. 
