### PR TITLE
Change "block style variations" references to "block style"

### DIFF
--- a/packages/block-editor/src/components/block-styles/utils.js
+++ b/packages/block-editor/src/components/block-styles/utils.js
@@ -11,7 +11,7 @@ import { _x } from '@wordpress/i18n';
 /**
  * Returns the active style from the given className.
  *
- * @param {Array}  styles    Block style variations.
+ * @param {Array}  styles    Block styles.
  * @param {string} className Class name
  *
  * @return {Object?} The active style.
@@ -59,7 +59,7 @@ export function replaceActiveStyle( className, activeStyle, newStyle ) {
  * act as a fallback for when there is no active style applied to a block. The default item also serves
  * as a switch on the frontend to deactivate non-default styles.
  *
- * @param {Array} styles Block style variations.
+ * @param {Array} styles Block styles.
  *
  * @return {Array<Object?>}        The style collection.
  */
@@ -83,7 +83,7 @@ export function getRenderedStyles( styles ) {
 /**
  * Returns a style object from a collection of styles where that style object is the default block style.
  *
- * @param {Array} styles Block style variations.
+ * @param {Array} styles Block styles.
  *
  * @return {Object?}        The default style object, if found.
  */

--- a/packages/blocks/README.md
+++ b/packages/blocks/README.md
@@ -692,7 +692,7 @@ _Parameters_
 
 ### registerBlockStyle
 
-Registers a new block style variation for the given block.
+Registers a new block style for the given block.
 
 For more information on connecting the styles with CSS [the official documentation](/docs/reference-guides/block-api/block-styles.md#styles)
 
@@ -970,7 +970,7 @@ _Returns_
 
 ### unregisterBlockStyle
 
-Unregisters a block style variation for the given block.
+Unregisters a block style for the given block.
 
 _Usage_
 

--- a/packages/blocks/src/api/registration.js
+++ b/packages/blocks/src/api/registration.js
@@ -656,7 +656,7 @@ export const hasChildBlocksWithInserterSupport = ( blockName ) => {
 };
 
 /**
- * Registers a new block style variation for the given block.
+ * Registers a new block style for the given block.
  *
  * For more information on connecting the styles with CSS [the official documentation](/docs/reference-guides/block-api/block-styles.md#styles)
  *
@@ -691,7 +691,7 @@ export const registerBlockStyle = ( blockName, styleVariation ) => {
 };
 
 /**
- * Unregisters a block style variation for the given block.
+ * Unregisters a block style for the given block.
  *
  * @param {string} blockName          Name of block (example: “core/latest-posts”).
  * @param {string} styleVariationName Name of class applied to the block.

--- a/packages/blocks/src/store/reducer.js
+++ b/packages/blocks/src/store/reducer.js
@@ -105,7 +105,7 @@ export function blockTypes( state = {}, action ) {
 }
 
 /**
- * Reducer managing the block style variations.
+ * Reducer managing the block styles.
  *
  * @param {Object} state  Current state.
  * @param {Object} action Dispatched action.


### PR DESCRIPTION
## What?
This PR changes in-line comment blocks and README.md files across the repository that referenced "block style variation(s)" to "block style(s)" instead.

## Why?
The term "variation" is used in a number of ways across the project (style variations, block variations) and it's not necessary to refer to block styles as block style variations. Most references related to the Docs that are pushed to the Block Editor Handbook were updated previously. This PR should remove the remaining references outside of those located in changelog files.


## How?
Comment blocks and readme files have been updated.

Resolves #20972