### PR TITLE
Query Pagination: Fix positioning of next link in editor when parent is selected

### DIFF
--- a/packages/block-library/src/query-pagination/style.scss
+++ b/packages/block-library/src/query-pagination/style.scss
@@ -18,7 +18,7 @@ $pagination-margin: 0.5em;
 	// which is important when it's the only block displayed
 	// and the block has a "space-between" justification.
 	&.is-content-justification-space-between {
-		> .wp-block-query-pagination-next:last-child {
+		> .wp-block-query-pagination-next:last-of-type {
 			margin-inline-start: auto;
 		}
 		> .wp-block-query-pagination-previous:first-child {


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

This is a follow-up to #42764 which fixed the position of the Next link on the first page of the Query loop to ensure that it's right aligned when the space between content justification is used.

An issue with the CSS from that PR is that when the parent Query Pagination block is selected in the block editor, then the block appender is the last element in the DOM under the Query Pagination block, so the `:last-child` rule does not wind up targeting the next link.

In this change, if we swap the `:first-child` rule to use a `:last-of-type` rule, it appears to fix the issue. Because the next link uses an `a` tag and the block appender uses a `div` tag, the updated rule correctly targets the last link under the parent Query pagination block.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

Fix the display of the children of the Query pagination block when the block is selected in the editor.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

Update the rule the applies `margin-inline-start: auto` to the Query Pagination Next block to use `:last-of-type` instead of `:last-child`.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->

1. Add a Query Loop block with pagination
2. Select the Pagination block and set the content justification to space between
3. With this PR applied, the positioning of the Prev and Next buttons should look correct while the parent block is selected (see screenshots below)
4. Check that the issue fixed by https://github.com/wordpress/gutenberg/pull/42764 is still fixed (when a Next block is the only block on the page, then it should be right aligned. One way to test this is to have your Query Pagination block only have Prev and Next blocks as children, then page through results on the site frontend)

## Screenshots or screencast <!-- if applicable -->

| Before | After |
| --- | --- |
| ![image](https://user-images.githubusercontent.com/14988353/200914352-9487be55-a522-4684-8a25-e24ea3578846.png) | ![image](https://user-images.githubusercontent.com/14988353/200914408-7e749e78-a28d-4e4f-a1da-c38b2f5287ab.png) |