### PR TITLE
Block Editor: Improve `ReusableBlocksTab` tests

### DIFF
--- a/packages/block-editor/src/components/inserter/test/reusable-blocks-tab.js
+++ b/packages/block-editor/src/components/inserter/test/reusable-blocks-tab.js
@@ -1,13 +1,12 @@
 /**
  * External dependencies
  */
-import { render, fireEvent } from '@testing-library/react';
+import { render, screen } from '@testing-library/react';
 
 /**
  * WordPress dependencies
  */
 import { registerBlockType, unregisterBlockType } from '@wordpress/blocks';
-import { useSelect } from '@wordpress/data';
 
 /**
  * Internal dependencies
@@ -22,35 +21,6 @@ jest.mock( '../hooks/use-block-types-state', () => {
 	return mock;
 } );
 
-jest.mock( '@wordpress/data/src/components/use-select', () => {
-	// This allows us to tweak the returned value on each test.
-	const mock = jest.fn();
-	return mock;
-} );
-
-jest.mock( '@wordpress/data/src/components/use-dispatch', () => {
-	return {
-		useDispatch: () => ( {} ),
-	};
-} );
-
-const debouncedSpeak = jest.fn();
-
-function InserterBlockList( props ) {
-	return <ReusableBlocksTab debouncedSpeak={ debouncedSpeak } { ...props } />;
-}
-
-const initializeAllClosedMenuState = ( propOverrides ) => {
-	const { container } = render( <InserterBlockList { ...propOverrides } /> );
-	const activeTabs = container.querySelectorAll(
-		'.components-panel__body.is-opened button.components-panel__body-toggle'
-	);
-	activeTabs.forEach( ( tab ) => {
-		fireEvent.click( tab );
-	} );
-	return container;
-};
-
 describe( 'InserterMenu', () => {
 	beforeAll( () => {
 		registerBlockType( 'core/block', {
@@ -59,19 +29,17 @@ describe( 'InserterMenu', () => {
 			edit: () => {},
 		} );
 	} );
+
 	afterAll( () => {
 		unregisterBlockType( 'core/block' );
 	} );
-	beforeEach( () => {
-		debouncedSpeak.mockClear();
 
+	beforeEach( () => {
 		useBlockTypesState.mockImplementation( () => [
 			items,
 			categories,
 			collections,
 		] );
-
-		useSelect.mockImplementation( () => false );
 	} );
 
 	it( 'should show nothing if there are no items', () => {
@@ -81,36 +49,25 @@ describe( 'InserterMenu', () => {
 			categories,
 			collections,
 		] );
-		const { container } = render(
-			<InserterBlockList filterValue="random" />
-		);
-		const visibleBlocks = container.querySelector(
-			'.block-editor-block-types-list__item'
-		);
 
-		expect( visibleBlocks ).toBe( null );
+		render( <ReusableBlocksTab filterValue="random" /> );
+
+		expect( screen.queryByRole( 'option' ) ).not.toBeInTheDocument();
 	} );
 
 	it( 'should list reusable blocks', () => {
-		const container = initializeAllClosedMenuState();
-		const blocks = container.querySelectorAll(
-			'.block-editor-block-types-list__item-title'
-		);
+		render( <ReusableBlocksTab /> );
 
-		expect( blocks ).toHaveLength( 1 );
-		expect( blocks[ 0 ] ).toHaveTextContent( 'My reusable block' );
+		expect(
+			screen.getByRole( 'option', { name: 'My reusable block' } )
+		).toBeVisible();
 	} );
 
 	it( 'should trim whitespace of search terms', () => {
-		const { container } = render(
-			<InserterBlockList filterValue=" my reusable" />
-		);
+		render( <ReusableBlocksTab filterValue=" my reusable" /> );
 
-		const blocks = container.querySelectorAll(
-			'.block-editor-block-types-list__item-title'
-		);
-
-		expect( blocks ).toHaveLength( 1 );
-		expect( blocks[ 0 ] ).toHaveTextContent( 'My reusable block' );
+		expect(
+			screen.getByRole( 'option', { name: 'My reusable block' } )
+		).toBeVisible();
 	} );
 } );


### PR DESCRIPTION
## What?
With the recent work to improve the quality of tests, we fixed a bunch of ESLint rule violations. This PR fixes a few [`no-container`](https://github.com/testing-library/eslint-plugin-testing-library/blob/main/docs/rules/no-container.md) rule violations in the `ReusableBlocksTab` component. 

## Why?
The end goal is to enable that ESLint rule once all violations have been fixed.

## How?
We're refactoring most of the straightforward `querySelector` / `querySelectorAll` instances to use screen queries instead. We're also cleaning up unused mocks and setup steps. That conveniently allows us to also remove `fireEvent` usage that was not necessary.

## Testing Instructions
Verify all tests still pass.