### PR TITLE
Remove hover style to button on dark block tools UI

### DIFF
--- a/packages/block-editor/src/components/block-tools/style.scss
+++ b/packages/block-editor/src/components/block-tools/style.scss
@@ -175,6 +175,12 @@
 		&:active {
 			color: $white;
 		}
+
+		// Make sure the button has no hover style when it's disabled.
+		&[aria-disabled="true"]:hover {
+			color: $white;
+		}
+
 		display: flex;
 	}
 	.block-selection-button_select-button.components-button {


### PR DESCRIPTION
## What?
Fixes: https://github.com/WordPress/gutenberg/issues/44376

Keeps buttons on the block tools popover from displaying hover styles when the button is disabled.

## Testing Instructions
Make sure that this doesn't alter the light mode UI.
1. Create a post, and add a block.
2. Select the last or first block on the post.
3. Make sure that the mover is disabled, that the button is visible, and does not change when hovering.

Confirm that this fixes the reported issue
1. Enable zoom-out view
2. the Go to last or the first block
3. Make sure the mover is disabled, and the button does not change when hovering.

## Screenshots or screencast <!-- if applicable -->

https://user-images.githubusercontent.com/1157901/200917112-058c3515-a5bc-488b-861b-f8b5170c6f65.mov


