### PR TITLE
Eliminate 'isEditing' mode from PaletteEdit component

### DIFF
--- a/packages/components/src/palette-edit/index.js
+++ b/packages/components/src/palette-edit/index.js
@@ -23,8 +23,6 @@ import { FlexItem } from '../flex';
 import { HStack } from '../h-stack';
 import { ItemGroup } from '../item-group';
 import { VStack } from '../v-stack';
-import GradientPicker from '../gradient-picker';
-import ColorPalette from '../color-palette';
 import DropdownMenu from '../dropdown-menu';
 import Popover from '../popover';
 import {
@@ -36,7 +34,6 @@ import {
 	PaletteItem,
 	NameContainer,
 	NameInputControl,
-	DoneButton,
 	RemoveButton,
 } from './styles';
 import { NavigableMenu } from '../navigable-container';
@@ -304,10 +301,8 @@ export default function PaletteEdit( {
 } ) {
 	const isGradient = !! gradients;
 	const elements = isGradient ? gradients : colors;
-	const [ isEditing, setIsEditing ] = useState( false );
 	const [ editingElement, setEditingElement ] = useState( null );
 	const isAdding =
-		isEditing &&
 		editingElement &&
 		elements[ editingElement ] &&
 		! elements[ editingElement ].slug;
@@ -319,17 +314,6 @@ export default function PaletteEdit( {
 			<PaletteHStackHeader>
 				<PaletteHeading>{ paletteLabel }</PaletteHeading>
 				<PaletteActionsContainer>
-					{ hasElements && isEditing && (
-						<DoneButton
-							isSmall
-							onClick={ () => {
-								setIsEditing( false );
-								setEditingElement( null );
-							} }
-						>
-							{ __( 'Done' ) }
-						</DoneButton>
-					) }
 					{ ! canOnlyChangeValues && (
 						<Button
 							isSmall
@@ -358,120 +342,76 @@ export default function PaletteEdit( {
 											kebabCase( tempOptionName ),
 									},
 								] );
-								setIsEditing( true );
 								setEditingElement( elements.length );
 							} }
 						/>
 					) }
 
-					{ hasElements &&
-						( ! isEditing ||
-							! canOnlyChangeValues ||
-							canReset ) && (
-							<DropdownMenu
-								icon={ moreVertical }
-								label={
-									isGradient
-										? __( 'Gradient options' )
-										: __( 'Color options' )
-								}
-								toggleProps={ {
-									isSmall: true,
-								} }
-							>
-								{ ( { onClose } ) => (
-									<>
-										<NavigableMenu role="menu">
-											{ ! isEditing && (
-												<Button
-													variant="tertiary"
-													onClick={ () => {
-														setIsEditing( true );
-														onClose();
-													} }
-													className="components-palette-edit__menu-button"
-												>
-													{ isGradient
-														? __( 'Edit gradients' )
-														: __( 'Edit colors' ) }
-												</Button>
-											) }
-											{ ! canOnlyChangeValues && (
-												<Button
-													variant="tertiary"
-													onClick={ () => {
-														setEditingElement(
-															null
-														);
-														setIsEditing( false );
-														onChange();
-														onClose();
-													} }
-													className="components-palette-edit__menu-button"
-												>
-													{ isGradient
-														? __(
-																'Remove all gradients'
-														  )
-														: __(
-																'Remove all colors'
-														  ) }
-												</Button>
-											) }
-											{ canReset && (
-												<Button
-													variant="tertiary"
-													onClick={ () => {
-														setEditingElement(
-															null
-														);
-														onChange();
-														onClose();
-													} }
-												>
-													{ isGradient
-														? __( 'Reset gradient' )
-														: __( 'Reset colors' ) }
-												</Button>
-											) }
-										</NavigableMenu>
-									</>
-								) }
-							</DropdownMenu>
-						) }
+					{ hasElements && ( ! canOnlyChangeValues || canReset ) && (
+						<DropdownMenu
+							icon={ moreVertical }
+							label={
+								isGradient
+									? __( 'Gradient options' )
+									: __( 'Color options' )
+							}
+							toggleProps={ {
+								isSmall: true,
+							} }
+						>
+							{ ( { onClose } ) => (
+								<>
+									<NavigableMenu role="menu">
+										{ ! canOnlyChangeValues && (
+											<Button
+												variant="tertiary"
+												onClick={ () => {
+													setEditingElement( null );
+													onChange();
+													onClose();
+												} }
+												className="components-palette-edit__menu-button"
+											>
+												{ isGradient
+													? __(
+															'Remove all gradients'
+													  )
+													: __(
+															'Remove all colors'
+													  ) }
+											</Button>
+										) }
+										{ canReset && (
+											<Button
+												variant="tertiary"
+												onClick={ () => {
+													setEditingElement( null );
+													onChange();
+													onClose();
+												} }
+											>
+												{ isGradient
+													? __( 'Reset gradient' )
+													: __( 'Reset colors' ) }
+											</Button>
+										) }
+									</NavigableMenu>
+								</>
+							) }
+						</DropdownMenu>
+					) }
 				</PaletteActionsContainer>
 			</PaletteHStackHeader>
 			{ hasElements && (
-				<>
-					{ isEditing && (
-						<PaletteEditListView
-							canOnlyChangeValues={ canOnlyChangeValues }
-							elements={ elements }
-							onChange={ onChange }
-							editingElement={ editingElement }
-							setEditingElement={ setEditingElement }
-							slugPrefix={ slugPrefix }
-							isGradient={ isGradient }
-						/>
-					) }
-					{ ! isEditing &&
-						( isGradient ? (
-							<GradientPicker
-								__nextHasNoMargin
-								gradients={ gradients }
-								onChange={ () => {} }
-								clearable={ false }
-								disableCustomGradients={ true }
-							/>
-						) : (
-							<ColorPalette
-								colors={ colors }
-								onChange={ () => {} }
-								clearable={ false }
-								disableCustomColors={ true }
-							/>
-						) ) }
-				</>
+				<PaletteEditListView
+					canOnlyChangeValues={ canOnlyChangeValues }
+					elements={ elements }
+					onChange={ onChange }
+					editingElement={ editingElement }
+					setEditingElement={ setEditingElement }
+					slugPrefix={ slugPrefix }
+					isGradient={ isGradient }
+				/>
 			) }
 			{ ! hasElements && emptyMessage }
 		</PaletteEditStyles>


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->
Eliminate 'isEditing' flag for PaletteEdit component  so that when color paletts are being edited they are always 'editable'

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
Addresses #44138

Rather than making the "non-editing" mode of the color palette open the edit state this change makes the color `PaletteEdit` item always in edit mode.  Thus clicking on the color palette list item will open the color editor as expected.  Additionally for custom color items the name can be changed. 

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
The change is accomplished by removing the `isEditing` flag from the component and no longer switching behavior based on that value.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->

Open the Site Editor with a theme activated that has color palette values defined.
Navigate to the Global Styles Panel > Colors > Palette
Note that the 'edit' menu item has been eliminated from all three color items (Theme, Global, Custom) as well as gradient items.  
Click on any of the color or gradient list items and note that the color picker is shown.
Note the absence of the 'Done' link.

 
## Screenshots or screencast <!-- if applicable -->
Before:
<img width="285" alt="image" src="https://user-images.githubusercontent.com/146530/200921418-4457e1d5-da61-4bfb-b124-011eeed91f77.png">

After:
<img width="287" alt="image" src="https://user-images.githubusercontent.com/146530/200920925-58f78040-d942-42e4-88cd-703e9d00140a.png">

cc @WordPress/block-themers 