### PR TITLE
Add: Keyboard shortcut for Edit as HTML

### DIFF
--- a/packages/block-editor/src/components/block-settings-menu/block-mode-toggle.js
+++ b/packages/block-editor/src/components/block-settings-menu/block-mode-toggle.js
@@ -4,8 +4,9 @@
 import { __ } from '@wordpress/i18n';
 import { MenuItem } from '@wordpress/components';
 import { getBlockType, hasBlockSupport } from '@wordpress/blocks';
-import { withSelect, withDispatch } from '@wordpress/data';
+import { withSelect, withDispatch, useSelect } from '@wordpress/data';
 import { compose } from '@wordpress/compose';
+import { store as keyboardShortcutsStore } from '@wordpress/keyboard-shortcuts';
 
 /**
  * Internal dependencies
@@ -21,6 +22,11 @@ export function BlockModeToggle( {
 	small = false,
 	isCodeEditingEnabled = true,
 } ) {
+	const shortcut = useSelect( ( select ) => {
+		const { getShortcutRepresentation } = select( keyboardShortcutsStore );
+		return getShortcutRepresentation( 'core/block-editor/edit-html' );
+	}, [] );
+
 	if (
 		! blockType ||
 		! hasBlockSupport( blockType, 'html', true ) ||
@@ -32,7 +38,11 @@ export function BlockModeToggle( {
 	const label =
 		mode === 'visual' ? __( 'Edit as HTML' ) : __( 'Edit visually' );
 
-	return <MenuItem onClick={ onToggleMode }>{ ! small && label }</MenuItem>;
+	return (
+		<MenuItem onClick={ onToggleMode } shortcut={ shortcut }>
+			{ ! small && label }
+		</MenuItem>
+	);
 }
 
 export default compose( [

--- a/packages/block-editor/src/components/block-tools/index.js
+++ b/packages/block-editor/src/components/block-tools/index.js
@@ -61,6 +61,7 @@ export default function BlockTools( {
 		clearSelectedBlock,
 		moveBlocksUp,
 		moveBlocksDown,
+		toggleBlockMode,
 	} = useDispatch( blockEditorStore );
 
 	function onKeyDown( event ) {
@@ -113,6 +114,12 @@ export default function BlockTools( {
 					.getSelection()
 					.removeAllRanges();
 				__unstableContentRef?.current.focus();
+			}
+		} else if ( isMatch( 'core/block-editor/edit-html', event ) ) {
+			const clientIds = getSelectedBlockClientIds();
+			if ( clientIds.length ) {
+				event.preventDefault();
+				toggleBlockMode( clientIds[ 0 ] );
 			}
 		}
 	}

--- a/packages/block-editor/src/components/keyboard-shortcuts/index.js
+++ b/packages/block-editor/src/components/keyboard-shortcuts/index.js
@@ -122,6 +122,16 @@ function KeyboardShortcutsRegister() {
 				character: 'y',
 			},
 		} );
+
+		registerShortcut( {
+			name: 'core/block-editor/edit-html',
+			category: 'block',
+			description: __( 'Edit HTML or Edit Visually.' ),
+			keyCombination: {
+				modifier: 'secondary',
+				character: 'h',
+			},
+		} );
 	}, [ registerShortcut ] );
 
 	return null;


### PR DESCRIPTION
## What?
This PR adds a keyboard shortcut that lets you toggle the edit as html block mode. 

## Why?


This was requested in https://github.com/WordPress/gutenberg/issues/9723

## How?

## Testing Instructions
1. Open a Post or Page.
2. Insert a Block.
3. Using the key board press `Shift + Option + Command + H`
4. Notice that the block switches from visual mode to HTML mode.
5. Using the key board press `Shift + Option + Command + H` again.
6. Notice that the block switches from HTML mode to visual mode.


## Screenshots or screencast <!-- if applicable -->

https://user-images.githubusercontent.com/115071/200922507-07efdc72-e23b-436e-8f57-67e33c71ec69.mov

<img width="600" alt="Screenshot 2022-11-09 at 12 25 08 PM" src="https://user-images.githubusercontent.com/115071/200922611-e6e7de21-1096-4b09-9f28-3f4a4fdd2ecd.png">
