### PR TITLE
Remove the limit on getUsers query in Post Author block

### DIFF
--- a/packages/block-library/src/post-author/edit.js
+++ b/packages/block-library/src/post-author/edit.js
@@ -38,7 +38,7 @@ function PostAuthorEdit( {
 			return {
 				authorId: _authorId,
 				authorDetails: _authorId ? getUser( _authorId ) : null,
-				authors: getUsers( { who: 'authors' } ),
+				authors: getUsers( { who: 'authors', per_page: -1 } ),
 			};
 		},
 		[ postType, postId ]


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Update the Post Author block to display all the available authors, instead of just 10.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

As mentioned in https://github.com/WordPress/gutenberg/issues/44688 sites which have more than 10 authors currently are unable to see all of them in the Post Author block.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

By setting `per_page` to `-1` the getUsers call from @wordpress/core-data would return all of the available users.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->

To reproduce:

Find a site with more than 10 authors, edit or create a new post, insert a new `Post Author` block and check that the block settings only show up to 10 authors.

Testing:

Checkout the PR, repeat the steps above and see if all the authors are returned now.

## Screenshots or screencast <!-- if applicable -->

Before:
<img width="263" alt="Screenshot 2022-11-09 at 12 26 55" src="https://user-images.githubusercontent.com/7847633/200923025-9f848658-fbb0-4e38-bb96-f67627b0064a.png">

After:

<img width="263" alt="Screenshot 2022-11-09 at 12 25 18" src="https://user-images.githubusercontent.com/7847633/200923074-8d3a7119-7a1d-4ac7-8d44-0380171ce47c.png">
