### PR TITLE
Fix Link UI popover positioning when inspector control input is focused

### DIFF
--- a/packages/rich-text/src/component/use-anchor.js
+++ b/packages/rich-text/src/component/use-anchor.js
@@ -54,9 +54,9 @@ export function useAnchor( { editableContentElement, value, settings = {} } ) {
 			return {
 				ownerDocument: range.startContainer.ownerDocument,
 				getBoundingClientRect() {
-					return ! selectionWithinEditableContentElement
-						? editableContentElement.getBoundingClientRect()
-						: range.getBoundingClientRect();
+					return selectionWithinEditableContentElement
+						? range.getBoundingClientRect()
+						: editableContentElement.getBoundingClientRect();
 				},
 			};
 		}

--- a/packages/rich-text/src/component/use-anchor.js
+++ b/packages/rich-text/src/component/use-anchor.js
@@ -45,13 +45,18 @@ export function useAnchor( { editableContentElement, value, settings = {} } ) {
 			return;
 		}
 
+		const selectionWithinEditableContentElement =
+			editableContentElement?.contains( selection?.anchorNode );
+
 		const range = selection.getRangeAt( 0 );
 
 		if ( ! activeFormat ) {
 			return {
 				ownerDocument: range.startContainer.ownerDocument,
 				getBoundingClientRect() {
-					return range.getBoundingClientRect();
+					return ! selectionWithinEditableContentElement
+						? editableContentElement.getBoundingClientRect()
+						: range.getBoundingClientRect();
 				},
 			};
 		}


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Fixes the Link UI popover to be positioned correctly if user selection is not within the block's editable element.

Fixes https://github.com/WordPress/gutenberg/issues/45009

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

The popover was disappearing out of view.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

If the current window `Selection` object's `anchorNode` is not contained within the editable element then use the editable element itself as the anchor point for the popover.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->

- Activate Top Toolbar mode
- Add a paragraph block.
- Click on `Link` button in the block toolbar.
- See popover positioned correctly relative to the paragraph block.
- Now click into the block's inspector controls and focus within an `<input>` (such as the one within the `Advanced` section).
- Now click on `Link` button in the block toolbar.
- See popover positioned correctly relative to the paragraph block.
- Try the same with other types of blocks.

## Screenshots or screencast <!-- if applicable -->


https://user-images.githubusercontent.com/444434/200925000-c7fc7060-7fd9-4293-9534-653df5d34a18.mp4


