### PR TITLE
Components: Fix `no-container` violations in `FormGroup` tests

### DIFF
--- a/packages/components/src/ui/form-group/test/index.js
+++ b/packages/components/src/ui/form-group/test/index.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { render } from '@testing-library/react';
+import { render, screen } from '@testing-library/react';
 
 /**
  * Internal dependencies
@@ -20,44 +20,43 @@ const TextInput = ( { id: idProp, ...props } ) => {
 /* eslint-disable no-restricted-syntax */
 describe( 'props', () => {
 	test( 'should render correctly', () => {
-		const { container } = render(
+		render(
 			<FormGroup id="fname" label="First name">
 				<TextInput />
 			</FormGroup>
 		);
 
-		const label = container.querySelector( 'label' );
-		expect( label ).toHaveAttribute( 'for', 'fname' );
-		expect( label ).toContainHTML( 'First name' );
-
-		const input = container.querySelector( 'input' );
-		expect( input ).toHaveAttribute( 'id', 'fname' );
+		expect(
+			screen.getByRole( 'textbox', { name: 'First name' } )
+		).toBeVisible();
 	} );
 
 	test( 'should render label without prop correctly', () => {
-		const { container } = render(
+		render(
 			<FormGroup id="fname">
 				<ControlLabel htmlFor="fname">First name</ControlLabel>
 				<TextInput />
 			</FormGroup>
 		);
 
-		const label = container.querySelector( 'label' );
-		expect( label ).toHaveAttribute( 'for', 'fname' );
-		expect( label ).toContainHTML( 'First name' );
+		expect(
+			screen.getByRole( 'textbox', { name: 'First name' } )
+		).toBeVisible();
 	} );
 
 	test( 'should render labelHidden', () => {
-		const { container } = render(
+		render(
 			<FormGroup labelHidden id="fname" label="First name">
 				<TextInput />
 			</FormGroup>
 		);
 
-		const label = container.querySelector( 'label' );
-		expect( label ).toContainHTML( 'First name' );
-		// @todo: Refactor this after adding next VisuallyHidden.
-		expect( label ).toHaveClass( 'components-visually-hidden' );
+		expect(
+			screen.getByRole( 'textbox', { name: 'First name' } )
+		).toBeVisible();
+		expect( screen.getByText( 'First name' ) ).toHaveClass(
+			'components-visually-hidden'
+		);
 	} );
 
 	test( 'should render alignLabel', () => {


### PR DESCRIPTION
## What?
With the recent work to improve the quality of tests, we fixed a bunch of ESLint rule violations. This PR fixes a few [`no-container`](https://github.com/testing-library/eslint-plugin-testing-library/blob/main/docs/rules/no-container.md) rule violations in the `FormGroup` component. 

## Why?
The end goal is to enable that ESLint rule once all violations have been fixed.

## How?
We're refactoring most of the straightforward `querySelector` / `querySelectorAll` instances to use screen queries instead. 

## Testing Instructions
Verify all tests still pass.