### PR TITLE
Fix: Button block text alignment.

### DIFF
--- a/docs/reference-guides/core-blocks.md
+++ b/docs/reference-guides/core-blocks.md
@@ -50,8 +50,8 @@ Prompt visitors to take action with a button-style link. ([Source](https://githu
 
 -	**Name:** core/button
 -	**Category:** design
--	**Supports:** align, anchor, color (background, gradients, text), spacing (padding), typography (fontSize, lineHeight), ~~alignWide~~, ~~reusable~~
--	**Attributes:** backgroundColor, gradient, linkTarget, placeholder, rel, text, textColor, title, url, width
+-	**Supports:** anchor, color (background, gradients, text), spacing (padding), typography (fontSize, lineHeight), ~~alignWide~~, ~~align~~, ~~reusable~~
+-	**Attributes:** backgroundColor, gradient, linkTarget, placeholder, rel, text, textAlign, textColor, title, url, width
 
 ## Buttons
 

--- a/packages/block-library/src/button/block.json
+++ b/packages/block-library/src/button/block.json
@@ -9,6 +9,9 @@
 	"keywords": [ "link" ],
 	"textdomain": "default",
 	"attributes": {
+		"textAlign": {
+			"type": "string"
+		},
 		"url": {
 			"type": "string",
 			"source": "attribute",
@@ -56,7 +59,7 @@
 	},
 	"supports": {
 		"anchor": true,
-		"align": true,
+		"align": false,
 		"alignWide": false,
 		"color": {
 			"__experimentalSkipSerialization": true,

--- a/packages/block-library/src/button/deprecated.js
+++ b/packages/block-library/src/button/deprecated.js
@@ -51,6 +51,20 @@ const migrateBorderRadius = ( attributes ) => {
 	};
 };
 
+function migrateAlign( attributes ) {
+	if ( ! attributes.align ) {
+		return attributes;
+	}
+	const { align, ...otherAttributes } = attributes;
+	return {
+		...otherAttributes,
+		className: classnames(
+			otherAttributes.className,
+			`align${ attributes.align }`
+		),
+	};
+}
+
 const migrateCustomColorsAndGradients = ( attributes ) => {
 	if (
 		! attributes.customTextColor &&
@@ -780,10 +794,12 @@ const deprecated = [
 		isEligible: ( attributes ) =>
 			!! attributes.customTextColor ||
 			!! attributes.customBackgroundColor ||
-			!! attributes.customGradient,
+			!! attributes.customGradient ||
+			!! attributes.align,
 		migrate: compose(
 			migrateBorderRadius,
-			migrateCustomColorsAndGradients
+			migrateCustomColorsAndGradients,
+			migrateAlign
 		),
 		save( { attributes } ) {
 			const {

--- a/packages/block-library/src/button/edit.js
+++ b/packages/block-library/src/button/edit.js
@@ -17,6 +17,7 @@ import {
 	Popover,
 } from '@wordpress/components';
 import {
+	AlignmentControl,
 	BlockControls,
 	InspectorControls,
 	RichText,
@@ -76,7 +77,7 @@ function ButtonEdit( props ) {
 		onReplace,
 		mergeBlocks,
 	} = props;
-	const { linkTarget, placeholder, rel, style, text, url, width } =
+	const { textAlign, linkTarget, placeholder, rel, style, text, url, width } =
 		attributes;
 
 	function onToggleOpenInNewTab( value ) {
@@ -170,6 +171,7 @@ function ButtonEdit( props ) {
 						colorProps.className,
 						borderProps.className,
 						{
+							[ `has-text-align-${ textAlign }` ]: textAlign,
 							// For backwards compatibility add style that isn't
 							// provided via block support.
 							'no-border-radius': style?.border?.radius === 0,
@@ -193,6 +195,12 @@ function ButtonEdit( props ) {
 				/>
 			</div>
 			<BlockControls group="block">
+				<AlignmentControl
+					value={ textAlign }
+					onChange={ ( nextAlign ) => {
+						setAttributes( { textAlign: nextAlign } );
+					} }
+				/>
 				{ ! isURLSet && (
 					<ToolbarButton
 						name="link"

--- a/packages/block-library/src/button/save.js
+++ b/packages/block-library/src/button/save.js
@@ -16,8 +16,17 @@ import {
 } from '@wordpress/block-editor';
 
 export default function save( { attributes, className } ) {
-	const { fontSize, linkTarget, rel, style, text, title, url, width } =
-		attributes;
+	const {
+		textAlign,
+		fontSize,
+		linkTarget,
+		rel,
+		style,
+		text,
+		title,
+		url,
+		width,
+	} = attributes;
 
 	if ( ! text ) {
 		return null;
@@ -31,6 +40,7 @@ export default function save( { attributes, className } ) {
 		colorProps.className,
 		borderProps.className,
 		{
+			[ `has-text-align-${ textAlign }` ]: textAlign,
 			// For backwards compatibility add style that isn't provided via
 			// block support.
 			'no-border-radius': style?.border?.radius === 0,

--- a/test/integration/fixtures/blocks/core__button__center__deprecated.json
+++ b/test/integration/fixtures/blocks/core__button__center__deprecated.json
@@ -5,7 +5,8 @@
 		"attributes": {
 			"url": "https://github.com/WordPress/gutenberg",
 			"text": "Help build Gutenberg",
-			"align": "center"
+			"className": "aligncenter"
+
 		},
 		"innerBlocks": []
 	}

--- a/test/integration/fixtures/blocks/core__button__center__deprecated.serialized.html
+++ b/test/integration/fixtures/blocks/core__button__center__deprecated.serialized.html
@@ -1,3 +1,3 @@
-<!-- wp:button {"align":"center"} -->
+<!-- wp:button {"className":"aligncenter"} -->
 <div class="wp-block-button aligncenter"><a class="wp-block-button__link wp-element-button" href="https://github.com/WordPress/gutenberg">Help build Gutenberg</a></div>
 <!-- /wp:button -->


### PR DESCRIPTION
Fixes: https://github.com/WordPress/gutenberg/issues/44614

The button block had a block alignment control for legacy reasons added before the buttons block existed. The block alignment control does not make sense anymore when the block is nested inside buttons and does not work as expected.

This PR removes the block alignment control, and adds a new text alignment control that allows results that were not previously possible.
cc: @jasmussen

## Testing

I pasted the following code on the block editor:
```
<!-- wp:buttons -->
<div class="wp-block-buttons"><!-- wp:button {"textAlign":"center","width":25} -->
<div class="wp-block-button has-custom-width wp-block-button__width-25"><a class="wp-block-button__link has-text-align-center wp-element-button">center</a></div>
<!-- /wp:button -->

<!-- wp:button {"textAlign":"right","width":50} -->
<div class="wp-block-button has-custom-width wp-block-button__width-50"><a class="wp-block-button__link has-text-align-right wp-element-button">right</a></div>
<!-- /wp:button -->

<!-- wp:button {"textAlign":"left","width":25} -->
<div class="wp-block-button has-custom-width wp-block-button__width-25"><a class="wp-block-button__link has-text-align-left wp-element-button">left</a></div>
<!-- /wp:button --></div>
<!-- /wp:buttons -->

<!-- wp:buttons -->
<div class="wp-block-buttons"><!-- wp:button {"textAlign":"center","width":100} -->
<div class="wp-block-button has-custom-width wp-block-button__width-100"><a class="wp-block-button__link has-text-align-center wp-element-button">default</a></div>
<!-- /wp:button --></div>
<!-- /wp:buttons -->
```

I verified the result in both editor and front-end of the site was this one:
![image](https://user-images.githubusercontent.com/11271197/200944510-c7c1c313-f751-4864-9e7f-efec9172a84b.png)


I pasted the legacy button block markup on the editor:
```
<!-- wp:button {"align":"left"} -->
<div class="wp-block-button alignleft"><a class="wp-block-button__link wp-element-button">1</a></div>
<!-- /wp:button -->

<!-- wp:button {"align":"center"} -->
<div class="wp-block-button aligncenter"><a class="wp-block-button__link wp-element-button">2</a></div>
<!-- /wp:button -->

<!-- wp:button {"align":"right"} -->
<div class="wp-block-button alignright"><a class="wp-block-button__link wp-element-button">3</a></div>
<!-- /wp:button -->
```
I verified the result was this one, and there were no errors:

![image](https://user-images.githubusercontent.com/11271197/200926934-cac55a3d-ba8f-408f-a95f-f3ed8ad273be.png)
