### PR TITLE
Remove width from block mover button focus style

### DIFF
--- a/packages/block-editor/src/components/block-mover/style.scss
+++ b/packages/block-editor/src/components/block-mover/style.scss
@@ -15,7 +15,6 @@
 				// Focus style.
 				&::before {
 					height: calc(100% - 4px);
-					width: calc(100% - 4px);
 				}
 			}
 


### PR DESCRIPTION
## What?
Fixes: https://github.com/WordPress/gutenberg/issues/45088

Removes a width setting that had no effect on the outline of focused buttons within the Block Tools component, and was causing offset outlines on the dark UI version of it.

## Testing instructions
Select the block toolbar, check that only the dark UI outline for the mover buttons is affected.

## Screenshots or screencast <!-- if applicable -->

https://user-images.githubusercontent.com/1157901/200947675-c9f83358-ff1d-4241-9b50-ffd1f1ae7993.mov


