### PR TITLE
Columns: Add transform to unwrap the contents

### DIFF
--- a/packages/block-library/src/columns/transforms.js
+++ b/packages/block-library/src/columns/transforms.js
@@ -105,6 +105,16 @@ const transforms = {
 			},
 		},
 	],
+	to: [
+		{
+			type: 'block',
+			blocks: [ '*' ],
+			transform: ( attributes, innerBlocks ) =>
+				innerBlocks
+					.map( ( innerBlock ) => innerBlock.innerBlocks )
+					.flat(),
+		},
+	],
 };
 
 export default transforms;


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->
Add a transform to move the column contents out into standalone blocks.

Closes https://github.com/WordPress/gutenberg/issues/43878

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
Improves consistency with group and quote blocks. See https://github.com/WordPress/gutenberg/issues/43878

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
The innerBlocks of a `columns` block are `column` block. This transform gets all of these `column` blocks and then returns a list of all of their innerBlocks. 

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->
1. Open a Post or Page
2. Add a Columns block
3. Add a whole bunch of content to the different columns
4. Select the Columns block
5. Choose 'Unwrap' from the Columns menu
6. See the Columns block get replaced by the inner contents.

## Screenshots or screencast <!-- if applicable -->

https://user-images.githubusercontent.com/93301/200948093-38384e83-9f5c-4cb3-bc42-75692c1cf125.mp4

