### PR TITLE
Rich text: create undo level before autocorrect

### DIFF
--- a/packages/block-editor/src/components/rich-text/index.js
+++ b/packages/block-editor/src/components/rich-text/index.js
@@ -44,6 +44,7 @@ import { useFormatTypes } from './use-format-types';
 import { useRemoveBrowserShortcuts } from './use-remove-browser-shortcuts';
 import { useShortcuts } from './use-shortcuts';
 import { useInputEvents } from './use-input-events';
+import { useInsertReplacementText } from './use-insert-replacement-text';
 import { useFirefoxCompat } from './use-firefox-compat';
 import FormatEdit from './format-edit';
 import { getMultilineTag, getAllowedFormats } from './utils';
@@ -408,6 +409,7 @@ function RichTextWrapper(
 						onReplace,
 						selectionChange,
 					} ),
+					useInsertReplacementText(),
 					useRemoveBrowserShortcuts(),
 					useShortcuts( keyboardShortcuts ),
 					useInputEvents( inputEvents ),

--- a/packages/block-editor/src/components/rich-text/use-insert-replacement-text.js
+++ b/packages/block-editor/src/components/rich-text/use-insert-replacement-text.js
@@ -1,0 +1,34 @@
+/**
+ * WordPress dependencies
+ */
+import { useRefEffect } from '@wordpress/compose';
+import { useDispatch } from '@wordpress/data';
+
+/**
+ * Internal dependencies
+ */
+/**
+ * Internal dependencies
+ */
+import { store as blockEditorStore } from '../../store';
+
+/**
+ * When the browser is about to auto correct, add an undo level so the user can
+ * revert the change.
+ */
+export function useInsertReplacementText() {
+	const { __unstableMarkLastChangeAsPersistent } =
+		useDispatch( blockEditorStore );
+	return useRefEffect( ( element ) => {
+		function onInput( event ) {
+			if ( event.inputType === 'insertReplacementText' ) {
+				__unstableMarkLastChangeAsPersistent();
+			}
+		}
+
+		element.addEventListener( 'beforeinput', onInput );
+		return () => {
+			element.removeEventListener( 'beforeinput', onInput );
+		};
+	}, [] );
+}

--- a/packages/block-editor/src/components/rich-text/use-insert-replacement-text.js
+++ b/packages/block-editor/src/components/rich-text/use-insert-replacement-text.js
@@ -7,9 +7,6 @@ import { useDispatch } from '@wordpress/data';
 /**
  * Internal dependencies
  */
-/**
- * Internal dependencies
- */
 import { store as blockEditorStore } from '../../store';
 
 /**


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?

When e.g. Safari runs auto correct, create an undo level right before this happens to the user can revert the change.

## Why?

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

## Testing Instructions

Easiest to reproduce in Safari:

Type "cant", which auto corrects to "can't" and undo immediately before the 1s timeout that creates an undo level.


## Screenshots or screencast <!-- if applicable -->
