### PR TITLE
Add: Keyboard shortcut for Edit as HTML

### DIFF
--- a/packages/block-editor/src/components/block-settings-menu/block-mode-toggle.js
+++ b/packages/block-editor/src/components/block-settings-menu/block-mode-toggle.js
@@ -20,6 +20,7 @@ export function BlockModeToggle( {
 	onToggleMode,
 	small = false,
 	isCodeEditingEnabled = true,
+	shortcut,
 } ) {
 	if (
 		! blockType ||
@@ -32,7 +33,11 @@ export function BlockModeToggle( {
 	const label =
 		mode === 'visual' ? __( 'Edit as HTML' ) : __( 'Edit visually' );
 
-	return <MenuItem onClick={ onToggleMode }>{ ! small && label }</MenuItem>;
+	return (
+		<MenuItem onClick={ onToggleMode } shortcut={ shortcut }>
+			{ ! small && label }
+		</MenuItem>
+	);
 }
 
 export default compose( [

--- a/packages/block-editor/src/components/block-settings-menu/block-settings-dropdown.js
+++ b/packages/block-editor/src/components/block-settings-menu/block-settings-dropdown.js
@@ -119,6 +119,9 @@ export function BlockSettingsDropdown( {
 			insertBefore: getShortcutRepresentation(
 				'core/block-editor/insert-before'
 			),
+			toggleBlockMode: getShortcutRepresentation(
+				'core/block-editor/toggle-block-mode'
+			),
 		};
 	}, [] );
 
@@ -295,6 +298,7 @@ export function BlockSettingsDropdown( {
 									<BlockModeToggle
 										clientId={ firstBlockClientId }
 										onToggle={ onClose }
+										shortcut={ shortcuts.toggleBlockMode }
 									/>
 								) }
 							</MenuGroup>

--- a/packages/block-editor/src/components/block-tools/index.js
+++ b/packages/block-editor/src/components/block-tools/index.js
@@ -61,6 +61,7 @@ export default function BlockTools( {
 		clearSelectedBlock,
 		moveBlocksUp,
 		moveBlocksDown,
+		toggleBlockMode,
 	} = useDispatch( blockEditorStore );
 
 	function onKeyDown( event ) {
@@ -103,6 +104,12 @@ export default function BlockTools( {
 			if ( clientIds.length ) {
 				event.preventDefault();
 				insertBeforeBlock( clientIds[ 0 ] );
+			}
+		} else if ( isMatch( 'core/block-editor/toggle-block-mode', event ) ) {
+			const clientIds = getSelectedBlockClientIds();
+			if ( clientIds.length === 1 ) {
+				event.preventDefault();
+				toggleBlockMode( clientIds[ 0 ] );
 			}
 		} else if ( isMatch( 'core/block-editor/unselect', event ) ) {
 			const clientIds = getSelectedBlockClientIds();

--- a/packages/block-editor/src/components/keyboard-shortcuts/index.js
+++ b/packages/block-editor/src/components/keyboard-shortcuts/index.js
@@ -59,6 +59,18 @@ function KeyboardShortcutsRegister() {
 		} );
 
 		registerShortcut( {
+			name: 'core/block-editor/toggle-block-mode',
+			category: 'block',
+			description: __(
+				'Toggle between editing the block visually and editing HTML'
+			),
+			keyCombination: {
+				modifier: 'secondary',
+				character: 'h',
+			},
+		} );
+
+		registerShortcut( {
 			name: 'core/block-editor/delete-multi-selection',
 			category: 'block',
 			description: __( 'Delete selection.' ),

--- a/packages/block-editor/src/store/actions.js
+++ b/packages/block-editor/src/store/actions.js
@@ -1256,12 +1256,27 @@ export function replaceInnerBlocks(
  *
  * @return {Object} Action object.
  */
-export function toggleBlockMode( clientId ) {
-	return {
-		type: 'TOGGLE_BLOCK_MODE',
-		clientId,
+export const toggleBlockMode =
+	( clientId ) =>
+	( { select, dispatch } ) => {
+		if ( ! clientId ) {
+			return;
+		}
+		const block = select.getBlocksByClientId( clientId )[ 0 ];
+		if ( ! hasBlockSupport( block.name, 'html', true ) ) {
+			return;
+		}
+		const isCodeEditingEnabled =
+			select.getSettings().codeEditingEnabled ?? true;
+		if ( ! isCodeEditingEnabled ) {
+			return;
+		}
+
+		return dispatch( {
+			type: 'TOGGLE_BLOCK_MODE',
+			clientId,
+		} );
 	};
-}
 
 /**
  * Returns an action object used in signalling that the block interface, eg. toolbar, outline, etc. should be hidden.

--- a/packages/block-editor/src/store/test/actions.js
+++ b/packages/block-editor/src/store/test/actions.js
@@ -770,7 +770,21 @@ describe( 'actions', () => {
 	describe( 'toggleBlockMode', () => {
 		it( 'should return TOGGLE_BLOCK_MODE action', () => {
 			const clientId = 'myclientid';
-			expect( toggleBlockMode( clientId ) ).toEqual( {
+			const select = {
+				getBlocksByClientId: () => [
+					{
+						name: 'paragraph',
+					},
+				],
+				getSettings: () => ( {
+					codeEditingEnabled: true,
+				} ),
+			};
+			const dispatch = jest.fn();
+
+			toggleBlockMode( clientId )( { select, dispatch } );
+
+			expect( dispatch ).toHaveBeenCalledWith( {
 				type: 'TOGGLE_BLOCK_MODE',
 				clientId,
 			} );

--- a/packages/edit-post/src/components/keyboard-shortcut-help-modal/test/__snapshots__/index.js.snap
+++ b/packages/edit-post/src/components/keyboard-shortcut-help-modal/test/__snapshots__/index.js.snap
@@ -431,6 +431,47 @@ exports[`KeyboardShortcutHelpModal should match snapshot when the modal is activ
           <div
             class="edit-post-keyboard-shortcut-help-modal__shortcut-description"
           >
+            Toggle between editing the block visually and editing HTML
+          </div>
+          <div
+            class="edit-post-keyboard-shortcut-help-modal__shortcut-term"
+          >
+            <kbd
+              aria-label="Control + Shift + Alt + H"
+              class="edit-post-keyboard-shortcut-help-modal__shortcut-key-combination"
+            >
+              <kbd
+                class="edit-post-keyboard-shortcut-help-modal__shortcut-key"
+              >
+                Ctrl
+              </kbd>
+              +
+              <kbd
+                class="edit-post-keyboard-shortcut-help-modal__shortcut-key"
+              >
+                Shift
+              </kbd>
+              +
+              <kbd
+                class="edit-post-keyboard-shortcut-help-modal__shortcut-key"
+              >
+                Alt
+              </kbd>
+              +
+              <kbd
+                class="edit-post-keyboard-shortcut-help-modal__shortcut-key"
+              >
+                H
+              </kbd>
+            </kbd>
+          </div>
+        </li>
+        <li
+          class="edit-post-keyboard-shortcut-help-modal__shortcut"
+        >
+          <div
+            class="edit-post-keyboard-shortcut-help-modal__shortcut-description"
+          >
             Delete selection.
           </div>
           <div


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->
Add a keyboard shortcut to switch to HTML editing on a block level.

I've tried to integrate feedback from previous attempts into this PR. The shortcut shows in the help modal:
<img width="534" alt="image" src="https://user-images.githubusercontent.com/23708351/200951174-a50d9958-94a2-4e0e-bafd-fc6319ce09ca.png">
with the text previously agreed upon. The shortcut is also triggered only in context where the Edit as HTML option would show (when having exactly 1 block selected, for blocks that support the option). 

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
To solve https://github.com/WordPress/gutenberg/issues/9723
## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->

1. Open a Post or Page.
1. Insert 2 blocks.
1. Select one of the blocks and  press `Shift + Option + Command + H`
1. Confirm that the block switches from visual mode to HTML mode.
1. Press `Shift + Option + Command + H`
1. Confirm that the block switches from HTML mode to visual mode.
1. Select the 2 blocks, press `Shift + Option + Command + H` and confirm that nothing happens.
1. Select a block that does not have the `Edit as HTML` option available, press `Shift + Option + Command + H` and confirm that nothing happens. 

