### PR TITLE
Template Part Block: Update block isActive method

### DIFF
--- a/packages/block-library/src/template-part/variations.js
+++ b/packages/block-library/src/template-part/variations.js
@@ -40,6 +40,10 @@ export function enhanceTemplatePartVariations( settings, name ) {
 				'wp_template_part',
 				`${ theme }//${ slug }`
 			);
+
+			if ( entity?.slug ) {
+				return entity.slug === variationAttributes.slug;
+			}
 			return entity?.area === variationAttributes.area;
 		};
 


### PR DESCRIPTION
## What?

Fixes a bug in the isActive method for the template part block to ensure we match blocks to the correct block variation.

## Why?

A [recent commit](https://github.com/WordPress/gutenberg/commit/8d2e12d1debaf0e9e051f1c3810db2493d98effc) (block-library/src/template-part/index.php) updated the relationship between template parts and block variations so that every template part is now its own block variation.

However, the template part isActive() method was not updated, and frequently returns the wrong block variation. 

We match template parts to variations using the block's area attribute. But most new template parts (and their associated block variations) have the same area ('uncategorized'). So if you add three template part blocks to a page, each will generate a block variation with the same area attribute. Later, when we try to match one of those blocks to a block variation, we'll look for any core/template-part block with uncategorized/general as the area. There are three of them, and we simply find the first match, which may or may not be the right one. 

I've recorded a short video (link below) showing one of the symptoms of this issue for clarity.

## How?

This PR updates the isActive method for the template part block to use the block slug rather than block area. The block slug is more specific. We match a block to a variation based on slug if a slug exists, and if not, we still fall back to the area attribute. 

## Testing Instructions

This bug likely has a range of small implications. We found it because we're doing some testing in wp-calypso that confirms block variations. The test below is design to confirm one specific symptom of the bug is resolved. In essence, we want to confirm we're showing the correct block name in the block sidebar. See the video above for details if needed. 

1. Ensure you have a block theme installed.
2. Go to the site editor. 
3. Add 3 template part blocks to the page. For each, click 'Start New' to create a new template part, and give each template part a memorable name.
4. Once all three template parts are added to the page, save the page and reload the screen/site editor. 
5. Click on one of the the template part blocks and confirm the correct block name shows on the block side bar (without this fix, you will frequently get the wrong block name). 

## Screenshots or screencast <!-- if applicable -->

https://user-images.githubusercontent.com/21228350/200952215-5166b09c-9bcc-4d6c-98f4-d40dae77f790.mp4