### PR TITLE
ToolsPanel: Prevent calling deselect when panel remounts

### DIFF
--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -9,6 +9,7 @@
 ### Bug Fix
 
 -   `Autocomplete`: Fix unexpected block insertion during IME composition ([#45510](https://github.com/WordPress/gutenberg/pull/45510)).
+-   `ToolsPanelItem`: Prevent unintended calls to onDeselect when parent panel is remounted and item is rendered via SlotFill ([#45673](https://github.com/WordPress/gutenberg/pull/45673))
 
 ### Internal
 

--- a/packages/components/src/tools-panel/tools-panel-item/hook.ts
+++ b/packages/components/src/tools-panel/tools-panel-item/hook.ts
@@ -115,6 +115,7 @@ export function useToolsPanelItem(
 	useEffect( () => {
 		// We check whether this item is currently registered as items rendered
 		// via fills can persist through the parent panel being remounted.
+		// See: https://github.com/WordPress/gutenberg/pull/45673
 		if ( ! isRegistered || isResetting || ! hasMatchingPanel ) {
 			return;
 		}

--- a/packages/components/src/tools-panel/tools-panel-item/hook.ts
+++ b/packages/components/src/tools-panel/tools-panel-item/hook.ts
@@ -108,11 +108,14 @@ export function useToolsPanelItem(
 	const menuGroup = isShownByDefault ? 'default' : 'optional';
 	const isMenuItemChecked = menuItems?.[ menuGroup ]?.[ label ];
 	const wasMenuItemChecked = usePrevious( isMenuItemChecked );
+	const isRegistered = menuItems?.[ menuGroup ]?.[ label ] !== undefined;
 
 	// Determine if the panel item's corresponding menu is being toggled and
 	// trigger appropriate callback if it is.
 	useEffect( () => {
-		if ( isResetting || ! hasMatchingPanel ) {
+		// We check whether this item is currently registered as items rendered
+		// via fills can persist through the parent panel being remounted.
+		if ( ! isRegistered || isResetting || ! hasMatchingPanel ) {
 			return;
 		}
 


### PR DESCRIPTION
Fixes: https://github.com/WordPress/gutenberg/issues/43491

## What?

Prevents controls within a `ToolsPanel` from erroneously calling their `onDeselect` callback and resetting the control's related block attribute when the `ToolsPanel` gets remounted, e.g. when a block is dropped in a new location.

## Why?

Losing customizations you've made is bad.

## How?

If the `ToolsPanel` has been remounted, its internal state for menu items will also be reset. Items added to the panel via SlotFill will persist while the panel gets remounted. This leads to their derived state being out of sync with the context value provided by the panel. This PR checks whether the item is currently registered with the panel and, if it isn't, skips any calls to `onSelect` or `onDeselect` callbacks.

## Testing Instructions

1. Before checking out this PR, edit a post, add multiple paragraph blocks, and move one paragraph into a group block.
2. Select the paragraph within the group block and apply custom typography styles for all typography options
3. Save the post
4. Drag the paragraph block to a new position outside of the group and notice that several typography customizations are lost e.g. Font family.
5. Checkout this PR and reload the editor
6. Drag the paragraph block out of the group block again and note that all typography customizations are maintained

## Screenshots or screencast <!-- if applicable -->

https://user-images.githubusercontent.com/60436221/200959502-a32f2956-7258-49ed-a2b4-2556e7caab1c.mp4

