### PR TITLE
Table block: Fix error in margin value

### DIFF
--- a/packages/block-library/src/table/theme.scss
+++ b/packages/block-library/src/table/theme.scss
@@ -1,5 +1,5 @@
 .wp-block-table {
-	margin: "0 0 1em 0";
+	margin: 0 0 1em 0;
 
 	thead {
 		border-bottom: 3px solid;


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

As highlighted in https://github.com/WordPress/gutenberg/pull/43813 there was a typo in the margin value for the table block's CSS. This PR resolves it.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

Ensure we have valid CSS for this block!

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

Remove the quotes around the margin value for the table block.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->

1. Insert a table block in the editor
2. Inspect element on the table block, and you should see that the margin rules are applied correctly. Note that on sites that use blockGap / layout rules, this margin rule will be overridden, but you should still see that it's applied correctly

## Screenshots or screencast <!-- if applicable -->

In the below screenshot the Layout rules win out, however you can see the table block's styling rule is still output as expected.

<img width="428" alt="image" src="https://user-images.githubusercontent.com/14988353/200960095-cd4e9d23-bcb6-4416-a760-d2ef7db34e82.png">
