### PR TITLE
Alphabetically sort blocks in global styles

### DIFF
--- a/packages/edit-site/src/components/global-styles/screen-block-list.js
+++ b/packages/edit-site/src/components/global-styles/screen-block-list.js
@@ -44,7 +44,13 @@ function useSortedBlockTypes() {
 		groupByType,
 		{ core: [], noncore: [] }
 	);
-	return [ ...coreItems, ...nonCoreItems ];
+
+	const alphasort = ( blockA, blockB ) =>
+		blockA.title.localeCompare( blockB.title );
+	return [
+		...coreItems.sort( alphasort ),
+		...nonCoreItems.sort( alphasort ),
+	];
 }
 
 function BlockMenuItem( { block } ) {


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->
The blocks in global styles firstly list the core blocks in an undefined order, and then the non-core blocks also in an undefined order. This change lists the core blocks alphabetically by title, and then non-core blocks alphabetically by title.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
This gives a more predictable order of blocks when using global styles. It's a quick initial solution for https://github.com/WordPress/gutenberg/issues/44840

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
The core blocks are sorted by title according to locale specific sorting rules, and then non-core blocks are sorted in the same way and then returned together.

## Testing Instructions
0. Install a plugin which gives non-core blocks, e.g. jetpack or coblocks.
1. Open the site editor
2. Open the styles menu on the right to open the global styles sidebar
3. Press 'Blocks' at the bottom of the sidebar
4. Notice the core blocks are listed in alphabetical order followed by non-core blocks in alphabetical order
5. Search for blocks, the results will also be returned in alphabetical order. 

## Screenshots or screencast <!-- if applicable -->

Before | After
-------|------
![image](https://user-images.githubusercontent.com/93301/200960912-1a3e2f5d-b4af-4ae1-ac8f-2502e4d0ea08.png) | ![image](https://user-images.githubusercontent.com/93301/200960978-25ed2a2e-fff5-40c0-b82e-e06e6691efb3.png)

