### PR TITLE
Update block variations transforms to use ToggleGroupControl

### DIFF
--- a/packages/block-editor/src/components/block-variation-transforms/index.js
+++ b/packages/block-editor/src/components/block-variation-transforms/index.js
@@ -4,96 +4,17 @@
 import { store as blocksStore } from '@wordpress/blocks';
 import { __, sprintf } from '@wordpress/i18n';
 import {
-	Button,
-	DropdownMenu,
-	MenuGroup,
-	MenuItemsChoice,
-	VisuallyHidden,
+	__experimentalToggleGroupControl as ToggleGroupControl,
+	__experimentalToggleGroupControlOption as ToggleGroupControlOption,
+	__experimentalToggleGroupControlOptionIcon as ToggleGroupControlOptionIcon,
 } from '@wordpress/components';
 import { useSelect, useDispatch } from '@wordpress/data';
 import { useMemo } from '@wordpress/element';
-import { chevronDown } from '@wordpress/icons';
 
 /**
  * Internal dependencies
  */
-import BlockIcon from '../block-icon';
 import { store as blockEditorStore } from '../../store';
-
-function VariationsButtons( {
-	className,
-	onSelectVariation,
-	selectedValue,
-	variations,
-} ) {
-	return (
-		<fieldset className={ className }>
-			<VisuallyHidden as="legend">
-				{ __( 'Transform to variation' ) }
-			</VisuallyHidden>
-			{ variations.map( ( variation ) => (
-				<Button
-					key={ variation.name }
-					icon={ <BlockIcon icon={ variation.icon } showColors /> }
-					isPressed={ selectedValue === variation.name }
-					label={
-						selectedValue === variation.name
-							? variation.title
-							: sprintf(
-									/* translators: %s: Name of the block variation */
-									__( 'Transform to %s' ),
-									variation.title
-							  )
-					}
-					onClick={ () => onSelectVariation( variation.name ) }
-					aria-label={ variation.title }
-					showTooltip
-				/>
-			) ) }
-		</fieldset>
-	);
-}
-
-function VariationsDropdown( {
-	className,
-	onSelectVariation,
-	selectedValue,
-	variations,
-} ) {
-	const selectOptions = variations.map(
-		( { name, title, description } ) => ( {
-			value: name,
-			label: title,
-			info: description,
-		} )
-	);
-
-	return (
-		<DropdownMenu
-			className={ className }
-			label={ __( 'Transform to variation' ) }
-			text={ __( 'Transform to variation' ) }
-			popoverProps={ {
-				position: 'bottom center',
-				className: `${ className }__popover`,
-			} }
-			icon={ chevronDown }
-			toggleProps={ { iconPosition: 'right' } }
-		>
-			{ () => (
-				<div className={ `${ className }__container` }>
-					<MenuGroup>
-						<MenuItemsChoice
-							choices={ selectOptions }
-							value={ selectedValue }
-							onSelect={ onSelectVariation }
-						/>
-					</MenuGroup>
-				</div>
-			) }
-		</DropdownMenu>
-	);
-}
 
 function __experimentalBlockVariationTransforms( { blockClientId } ) {
 	const { updateBlockAttributes } = useDispatch( blockEditorStore );
@@ -115,7 +36,7 @@ function __experimentalBlockVariationTransforms( { blockClientId } ) {
 		[ blockClientId ]
 	);
 
-	const selectedValue = activeBlockVariation?.name;
+	const selectedVariationName = activeBlockVariation?.name;
 
 	// Check if each variation has a unique icon.
 	const hasUniqueIcons = useMemo( () => {
@@ -143,15 +64,45 @@ function __experimentalBlockVariationTransforms( { blockClientId } ) {
 	// Skip rendering if there are no variations
 	if ( ! variations?.length ) return null;
 
-	const Component = hasUniqueIcons ? VariationsButtons : VariationsDropdown;
-
 	return (
-		<Component
-			className={ baseClass }
-			onSelectVariation={ onSelectVariation }
-			selectedValue={ selectedValue }
-			variations={ variations }
-		/>
+		<div className={ baseClass }>
+			<ToggleGroupControl
+				label={ __( 'Transform to variation' ) }
+				hideLabelFromVision={ true }
+				onChange={ onSelectVariation }
+				value={ selectedVariationName }
+			>
+				{ variations.map( ( variation ) => {
+					if ( hasUniqueIcons ) {
+						const variationLabel =
+							selectedVariationName === variation.name
+								? variation.title
+								: sprintf(
+										/* translators: %s: Name of the block variation */
+										__( 'Transform to %s' ),
+										variation.title
+								  );
+						return (
+							<ToggleGroupControlOptionIcon
+								key={ variation.name }
+								icon={ variation.icon }
+								label={ variationLabel }
+								value={ variation.name }
+							/>
+						);
+					}
+
+					return (
+						<ToggleGroupControlOption
+							key={ variation.name }
+							label={ variation.title }
+							showTooltip={ true }
+							value={ variation.name }
+						/>
+					);
+				} ) }
+			</ToggleGroupControl>
+		</div>
 	);
 }
 


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?

This PR refactors the control used by the block variations transforms section in the block editor to use the `ToggleGroupControl` component instead of the custom components it is using at present.

## Why?

As suggested in #43415, this update should reduce code duplication and make the component more accessible by default.

## How?

I refactored the code to rely on a `ToggleGroupControl` inside a wrapper div that uses the existing `block-editor-block-variation-transforms` class. If we have unique icons for each variation, we insert `ToggleGroupControlOptionIcon` children, but if we don't we insert `ToggleGroupControlOption` children.

## Testing Instructions

1. Open a Post or Page.
2. Insert a Group block (or any other block that includes variations)
3. Ensure that the Block controls are visible.
4. Verify that the block variation transforms control is visible and shows all the variations for the current block. If you have a Group, Row, or Stack block, you should see icons for the Group, Row, and Stack blocks, with the current block variation shown as selected
5. Verify that you see "Transform to <block>" tooltips when you hover over the icons for the alternate block variations (i.e. not the current variation
6. Verify that you see the current block type as the tooltip (e.g. Row) when you hover over the selected block type
7. Select the other variations, and verify that the block type is correctly updated

## Screenshots or screencast

https://user-images.githubusercontent.com/3376401/200961913-0e12d8aa-3889-4ae0-9bbd-54dd4177abec.mov