### PR TITLE
Global styles: add onChange actions to color palette items

### DIFF
--- a/packages/components/src/color-palette/index.tsx
+++ b/packages/components/src/color-palette/index.tsx
@@ -70,7 +70,7 @@ function SinglePalette( {
 					}
 					style={ { backgroundColor: color, color } }
 					onClick={
-						isSelected ? clearColor : () => onChange( color )
+						isSelected ? clearColor : () => onChange( color, index )
 					}
 					aria-label={
 						name
@@ -118,7 +118,9 @@ function MultiplePalettes( {
 						<SinglePalette
 							clearColor={ clearColor }
 							colors={ colorPalette }
-							onChange={ onChange }
+							onChange={ ( newColor ) =>
+								onChange( newColor, index )
+							}
 							value={ value }
 							actions={
 								colors.length === index + 1 ? actions : null

--- a/packages/components/src/color-palette/test/index.tsx
+++ b/packages/components/src/color-palette/test/index.tsx
@@ -90,7 +90,7 @@ describe( 'ColorPalette', () => {
 		);
 
 		expect( onChange ).toHaveBeenCalledTimes( 1 );
-		expect( onChange ).toHaveBeenCalledWith( '#fff' );
+		expect( onChange ).toHaveBeenCalledWith( '#fff', 1 );
 	} );
 
 	test( 'should call onClick with undefined, when the clearButton onClick is triggered', async () => {

--- a/packages/components/src/color-palette/types.ts
+++ b/packages/components/src/color-palette/types.ts
@@ -24,7 +24,7 @@ type PaletteProps = {
 	/**
 	 * Callback called when a color is selected.
 	 */
-	onChange: ( newColor?: string ) => void;
+	onChange: ( newColor?: string, index?: number ) => void;
 	value?: string;
 	actions?: ReactNode;
 };

--- a/packages/components/src/gradient-picker/index.js
+++ b/packages/components/src/gradient-picker/index.js
@@ -1,9 +1,4 @@
 /**
- * External dependencies
- */
-import { map } from 'lodash';
-
-/**
  * WordPress dependencies
  */
 import { __, sprintf } from '@wordpress/i18n';
@@ -28,7 +23,7 @@ function SingleOrigin( {
 	actions,
 } ) {
 	const gradientOptions = useMemo( () => {
-		return map( gradients, ( { gradient, name } ) => (
+		return gradients.map( ( { gradient, name }, index ) => (
 			<CircularOptionPicker.Option
 				key={ gradient }
 				value={ gradient }
@@ -42,7 +37,7 @@ function SingleOrigin( {
 				onClick={
 					value === gradient
 						? clearGradient
-						: () => onChange( gradient )
+						: () => onChange( gradient, index )
 				}
 				aria-label={
 					name
@@ -80,7 +75,9 @@ function MultipleOrigin( {
 						<SingleOrigin
 							clearGradient={ clearGradient }
 							gradients={ gradientSet }
-							onChange={ onChange }
+							onChange={ ( gradient ) =>
+								onChange( gradient, index )
+							}
 							value={ value }
 							{ ...( gradients.length === index + 1
 								? { actions }

--- a/packages/components/src/palette-edit/index.js
+++ b/packages/components/src/palette-edit/index.js
@@ -313,6 +313,13 @@ export default function PaletteEdit( {
 		! elements[ editingElement ].slug;
 	const elementsLength = elements.length;
 	const hasElements = elementsLength > 0;
+	const editPaletteItem = ( value, collection ) => {
+		const valueIndex = collection.findIndex(
+			( item ) => item.color === value
+		);
+		setIsEditing( true );
+		setEditingElement( valueIndex );
+	};
 
 	return (
 		<PaletteEditStyles>
@@ -459,14 +466,18 @@ export default function PaletteEdit( {
 							<GradientPicker
 								__nextHasNoMargin
 								gradients={ gradients }
-								onChange={ () => {} }
+								onChange={ ( value ) =>
+									editPaletteItem( value, gradients )
+								}
 								clearable={ false }
 								disableCustomGradients={ true }
 							/>
 						) : (
 							<ColorPalette
 								colors={ colors }
-								onChange={ () => {} }
+								onChange={ ( value ) =>
+									editPaletteItem( value, colors )
+								}
 								clearable={ false }
 								disableCustomColors={ true }
 							/>

--- a/packages/components/src/palette-edit/index.js
+++ b/packages/components/src/palette-edit/index.js
@@ -341,7 +341,7 @@ export default function PaletteEdit( {
 				setIsEditing( true );
 			}
 		},
-		[ isGradient ]
+		[ isGradient, elements ]
 	);
 
 	return (

--- a/packages/components/src/palette-edit/index.js
+++ b/packages/components/src/palette-edit/index.js
@@ -398,9 +398,7 @@ export default function PaletteEdit( {
 													} }
 													className="components-palette-edit__menu-button"
 												>
-													{ isGradient
-														? __( 'Edit gradients' )
-														: __( 'Edit colors' ) }
+													{ __( 'List view' ) }
 												</Button>
 											) }
 											{ ! canOnlyChangeValues && (

--- a/packages/components/src/palette-edit/index.js
+++ b/packages/components/src/palette-edit/index.js
@@ -6,7 +6,7 @@ import { kebabCase } from 'lodash';
 /**
  * WordPress dependencies
  */
-import { useState, useRef, useEffect } from '@wordpress/element';
+import { useState, useRef, useEffect, useCallback } from '@wordpress/element';
 import { __, sprintf } from '@wordpress/i18n';
 import { lineSolid, moreVertical, plus } from '@wordpress/icons';
 import {
@@ -330,6 +330,19 @@ export default function PaletteEdit( {
 	const elementsLength = elements.length;
 	const hasElements = elementsLength > 0;
 	const debounceOnChange = useDebounce( onChange, 100 );
+	const onSelectPaletteItem = useCallback(
+		( value, newEditingElementIndex ) => {
+			const selectedElement = elements[ newEditingElementIndex ];
+			const key = isGradient ? 'gradient' : 'color';
+			// Ensures that the index returned matches a known element value.
+			if ( !! selectedElement && selectedElement[ key ] === value ) {
+				setEditingElement( newEditingElementIndex );
+			} else {
+				setIsEditing( true );
+			}
+		},
+		[ isGradient ]
+	);
 
 	return (
 		<PaletteEditStyles>
@@ -495,18 +508,14 @@ export default function PaletteEdit( {
 							<GradientPicker
 								__nextHasNoMargin
 								gradients={ gradients }
-								onChange={ ( value, index ) =>
-									setEditingElement( index )
-								}
+								onChange={ onSelectPaletteItem }
 								clearable={ false }
 								disableCustomGradients={ true }
 							/>
 						) : (
 							<ColorPalette
 								colors={ colors }
-								onChange={ ( value, index ) =>
-									setEditingElement( index )
-								}
+								onChange={ onSelectPaletteItem }
 								clearable={ false }
 								disableCustomColors={ true }
 							/>


### PR DESCRIPTION
## What?
Resolves https://github.com/WordPress/gutenberg/issues/44138

The PR opens the color picker when palette item is selected.

Renames the "Edit colors/gradients" label with "Show details" (suggestions for alternatives welcome).

# How?

By inserting a new instance of the color picker popover.

We track the currently-edited color/gradient by its index in the colors/gradients collection. The collection is rendered to the page according to this index. 

We need the index of the currently-edited color/gradient to ensure we're editing the correct item in the collection. 

We can't check by value or slug because two or more items might share these values. This is why this PR also updates the color/gradient picker component to return the index of the item to the onChange callback. Using this value we can lookup the currently-edited item in the colors/gradients collection.

As a fallback, if index doesn't match an item OR the matched item's value does not equal the newly-chosen value, we just open the list view as before.

## Why?
Before nothing happened when you clicked on a color or gradient option. Weird!

## Testing Instructions

1. Go to Site Editor → Global Styles
2. Click Colors
3. Open a palette
4. Click on one of the colour circles

The color picker should show for the color you clicked on, and you should be able to adjust the color successfully. 

Test it out with gradients too!

## Screenshots or screencast <!-- if applicable -->

https://user-images.githubusercontent.com/6458278/202356776-bd339a94-9eee-461d-9ab9-1e1ff748cd25.mp4



