### PR TITLE
Site Editor: Try fixing document name position

### DIFF
--- a/packages/edit-site/src/components/header-edit-mode/document-actions/style.scss
+++ b/packages/edit-site/src/components/header-edit-mode/document-actions/style.scss
@@ -15,7 +15,7 @@
 		flex-direction: row;
 		justify-content: center;
 		align-items: center;
-		margin-left: $grid-unit-20;
+		margin-left: $grid-unit;
 
 		// See comment above about min-width
 		min-width: 0;

--- a/packages/edit-site/src/components/header-edit-mode/document-actions/style.scss
+++ b/packages/edit-site/src/components/header-edit-mode/document-actions/style.scss
@@ -15,6 +15,7 @@
 		flex-direction: row;
 		justify-content: center;
 		align-items: center;
+		margin-left: $grid-unit-20;
 
 		// See comment above about min-width
 		min-width: 0;

--- a/packages/edit-site/src/components/header-edit-mode/style.scss
+++ b/packages/edit-site/src/components/header-edit-mode/style.scss
@@ -19,11 +19,17 @@ $header-toolbar-min-width: 335px;
 	.edit-site-header-edit-mode__start {
 		display: flex;
 		border: none;
+		width: 20%;
+
+		body.is-fullscreen-mode & {
+			width: calc(20% - 60px);
+		}
 	}
 
 	.edit-site-header-edit-mode__end {
 		display: flex;
 		justify-content: flex-end;
+		width: 20%;
 	}
 
 	.edit-site-header-edit-mode__center {


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->
This should correct the central alignment of the document title at the top of the Site Editor.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
Closes https://github.com/WordPress/gutenberg/issues/29673.

The central alignment of the document title element is slightly off and is currently worse at smaller resolutions. I believe this is partly due to the white space around the arrow icon SVG, and I don't think the width of the WordPress logo in the top left is fully taken into account in the centering calculation.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
This PR adds a left margin to the title label to match the white space on the right side of the arrow SVG, and it also sets a fixed width on the `.edit-site-header-edit-mode__start` and `.edit-site-header-edit-mode__end` elements. The `.edit-site-header-edit-mode__start` element takes the WordPress logo width into account, so this is included in the centering calculations.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->
I tested this by measuring the left and right sides of the document title in the Site Editor with an on-screen ruler, to ensure they were equal. The widths should be tested at a range of screen resolutions.
