### PR TITLE
Update alignment of template label on FSE

### DIFF
--- a/packages/base-styles/_variables.scss
+++ b/packages/base-styles/_variables.scss
@@ -57,6 +57,7 @@ $admin-sidebar-width-big: 190px;
 $admin-sidebar-width-collapsed: 36px;
 $modal-min-width: 360px;
 $spinner-size: 16px;
+$wp-logo-width: 60px;
 
 
 /**

--- a/packages/edit-site/src/components/header-edit-mode/style.scss
+++ b/packages/edit-site/src/components/header-edit-mode/style.scss
@@ -39,6 +39,12 @@ $header-toolbar-min-width: 335px;
 		// subsequently truncate child text, we set an explicit min-width.
 		// See https://dev.w3.org/csswg/css-flexbox/#min-size-auto
 		min-width: 0;
+
+		body.is-fullscreen-mode & {
+			// Offset center column by the width of the WordPress icon to
+			// ensure this column is correctly centered in fullscreen mode.
+			margin-left: calc(-1 * #{$wp-logo-width});
+		}
 	}
 }
 

--- a/packages/edit-site/src/components/header-edit-mode/style.scss
+++ b/packages/edit-site/src/components/header-edit-mode/style.scss
@@ -17,11 +17,13 @@ $header-toolbar-min-width: 335px;
 	}
 
 	.edit-site-header-edit-mode__start {
+		flex: 1;
 		display: flex;
 		border: none;
 	}
 
 	.edit-site-header-edit-mode__end {
+		flex: 1;
 		display: flex;
 		justify-content: flex-end;
 	}

--- a/packages/edit-site/src/components/header-edit-mode/style.scss
+++ b/packages/edit-site/src/components/header-edit-mode/style.scss
@@ -10,7 +10,7 @@ $header-toolbar-min-width: 335px;
 	justify-content: space-between;
 
 	body.is-fullscreen-mode & {
-		padding-left: 60px;
+		padding-left: $wp-logo-width;
 		transition: padding-left 20ms linear;
 		transition-delay: 80ms;
 		@include reduce-motion("transition");


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Centering the template label in top bar of FSE

## Why?
Originated from this issue: https://github.com/WordPress/gutenberg/issues/29673
Fixes https://github.com/WordPress/gutenberg/issues/29673

## How?
1. Set flex: 1 to the `edit-site-header-edit-mode__start` and `edit-site-header-edit-mode__end`, making them grow equally to fill the remaining space left by `edit-site-header-edit-mode__center`
2. Thus, the label will tend to be centered.

## Testing Instructions
- Open FSE 
- Edit a template
- Confirm that the template label on the top bar is centered aligned

## Screenshots or screencast

![image](https://user-images.githubusercontent.com/10071857/200963642-c10a4278-ed49-4b07-b5b8-aca44778812c.png)

