### PR TITLE
Make unwrapping columns slighly more efficient

### DIFF
--- a/packages/block-library/src/columns/transforms.js
+++ b/packages/block-library/src/columns/transforms.js
@@ -110,9 +110,7 @@ const transforms = {
 			type: 'block',
 			blocks: [ '*' ],
 			transform: ( attributes, innerBlocks ) =>
-				innerBlocks
-					.map( ( innerBlock ) => innerBlock.innerBlocks )
-					.flat(),
+				innerBlocks.flatMap( ( innerBlock ) => innerBlock.innerBlocks ),
 		},
 	],
 };


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->
Use flatMap rather than map().flat() when unwrapping columns.

There's no change in behaviour, it's a code quality follow-up from https://github.com/WordPress/gutenberg/pull/45666#discussion_r1018507434 

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
It's slightly more efficient

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
As above

## Testing Instructions

Exactly as https://github.com/WordPress/gutenberg/pull/45666, to whit:

    Open a Post or Page
    Add a Columns block
    Add a whole bunch of content to the different columns
    Select the Columns block
    Choose 'Unwrap' from the Columns menu
    See the Columns block get replaced by the inner contents.


## Screenshots or screencast <!-- if applicable -->
