### PR TITLE
Fix: Contrast checker does not update properly.

### DIFF
--- a/packages/block-editor/src/hooks/color-panel.js
+++ b/packages/block-editor/src/hooks/color-panel.js
@@ -29,7 +29,19 @@ export default function ColorPanel( {
 	const definedColors = settings.filter( ( setting ) => setting?.colorValue );
 
 	useEffect( () => {
-		if ( ! enableContrastChecking || ! definedColors.length ) {
+		if ( ! enableContrastChecking ) {
+			return;
+		}
+		if ( ! definedColors.length ) {
+			if ( detectedBackgroundColor ) {
+				setDetectedBackgroundColor();
+			}
+			if ( detectedColor ) {
+				setDetectedColor();
+			}
+			if ( detectedLinkColor ) {
+				setDetectedColor();
+			}
 			return;
 		}
 


### PR DESCRIPTION
The contrast checker has a bug where there is a contrast issue with just a color selected e.g.: background color. When we remove that color the contrast checker does not update and the contrast error message stays there.


## Testing

- Added a paragraph block.
- Made the background color of the paragraph black.
- Verified there is a contrast checker message as expected.
- Removed the background color immediately, and verified the contrast checker message disappears (on the trunk the message persists).

