### PR TITLE
BaseField: Remove unnecessary `.firstChild` from tests

### DIFF
--- a/packages/components/src/base-field/test/__snapshots__/index.js.snap
+++ b/packages/components/src/base-field/test/__snapshots__/index.js.snap
@@ -131,9 +131,11 @@ exports[`base field should render correctly 1`] = `
   box-shadow: 0 0 0 0.5px var(--wp-components-color-accent, var(--wp-admin-theme-color, #007cba));
 }
 
-<div
-  class="components-flex components-base-field emotion-0 emotion-1"
-  data-wp-c16t="true"
-  data-wp-component="BaseField"
-/>
+<div>
+  <div
+    class="components-flex components-base-field emotion-0 emotion-1"
+    data-wp-c16t="true"
+    data-wp-component="BaseField"
+  />
+</div>
 `;

--- a/packages/components/src/base-field/test/index.js
+++ b/packages/components/src/base-field/test/index.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { render } from '@testing-library/react';
+import { render, screen } from '@testing-library/react';
 
 /**
  * Internal dependencies
@@ -15,33 +15,45 @@ const TestField = ( props ) => {
 
 describe( 'base field', () => {
 	it( 'should render correctly', () => {
-		const base = render( <TestField /> ).container;
-		expect( base.firstChild ).toMatchSnapshot();
+		const { container } = render( <TestField /> );
+		expect( container ).toMatchSnapshot();
 	} );
 
 	describe( 'props', () => {
 		it( 'should render error styles', () => {
-			const base = render( <TestField /> ).container;
-			const { container } = render( <TestField hasError /> );
-			expect( container.firstChild ).toMatchStyleDiffSnapshot(
-				base.firstChild
+			render(
+				<>
+					<TestField data-testid="base-field" />
+					<TestField hasError data-testid="base-field-error" />
+				</>
 			);
+			expect(
+				screen.getByTestId( 'base-field-error' )
+			).toMatchStyleDiffSnapshot( screen.getByTestId( 'base-field' ) );
 		} );
 
 		it( 'should render inline styles', () => {
-			const base = render( <TestField /> ).container;
-			const { container } = render( <TestField isInline /> );
-			expect( container.firstChild ).toMatchStyleDiffSnapshot(
-				base.firstChild
+			render(
+				<>
+					<TestField data-testid="base-field" />
+					<TestField isInline data-testid="base-field-inline" />
+				</>
 			);
+			expect(
+				screen.getByTestId( 'base-field-inline' )
+			).toMatchStyleDiffSnapshot( screen.getByTestId( 'base-field' ) );
 		} );
 
 		it( 'should render subtle styles', () => {
-			const base = render( <TestField /> ).container;
-			const { container } = render( <TestField isSubtle /> );
-			expect( container.firstChild ).toMatchStyleDiffSnapshot(
-				base.firstChild
+			render(
+				<>
+					<TestField data-testid="base-field" />
+					<TestField isSubtle data-testid="base-field-subtle" />
+				</>
 			);
+			expect(
+				screen.getByTestId( 'base-field-subtle' )
+			).toMatchStyleDiffSnapshot( screen.getByTestId( 'base-field' ) );
 		} );
 	} );
 


### PR DESCRIPTION
## What?
With the recent work to improve the quality of tests, we fixed a bunch of ESLint rule violations. This PR fixes a few [`no-node-access`](https://github.com/testing-library/eslint-plugin-testing-library/blob/main/docs/rules/no-node-access.md) rule violations.

## Why?
The end goal is to enable that ESLint rule once all violations have been fixed.

## How?
- Use the parent and update the snapshots. An extra wrapper in the snapshot adds little to no cost.
- Use `getByTestId` instead of `.firstChild`.

## Testing Instructions
Verify all tests still pass.