### PR TITLE
Make Manage Reusable blocks match similar links

### DIFF
--- a/packages/block-editor/src/components/inserter/style.scss
+++ b/packages/block-editor/src/components/inserter/style.scss
@@ -175,7 +175,7 @@ $block-inserter-tabs-height: 44px;
 }
 
 .block-editor-inserter__manage-reusable-blocks-container {
-	margin: $grid-unit-20;
+	margin: auto $grid-unit-20 $grid-unit-20;
 }
 
 .block-editor-inserter__manage-reusable-blocks {


### PR DESCRIPTION
Small follow up for this: https://github.com/WordPress/gutenberg/pull/45641

This PR just adds the space to match the designs between the patterns tabpanel content and the reusable blocks one.

<img width="392" alt="Screenshot 2022-11-09 at 5 35 05 PM" src="https://user-images.githubusercontent.com/16275880/200972023-a14e795f-863a-4ec8-89f1-c6095170966d.png">
