### PR TITLE
Fix color panel with disabled color palette and gradients

### DIFF
--- a/packages/block-editor/src/hooks/color.js
+++ b/packages/block-editor/src/hooks/color.js
@@ -317,17 +317,21 @@ export function ColorEdit( props ) {
 		[ userGradientPalette, themeGradientPalette, defaultGradientPalette ]
 	);
 	const areCustomSolidsEnabled = useSetting( 'color.custom' );
+	const areDefaultSolidsEnabled = useSetting( 'color.defaultPalette' );
 	const areCustomGradientsEnabled = useSetting( 'color.customGradient' );
+	const areDefaultGradientsEnabled = useSetting( 'color.defaultGradient' );
 	const isBackgroundEnabled = useSetting( 'color.background' );
 	const isLinkEnabled = useSetting( 'color.link' );
 	const isTextEnabled = useSetting( 'color.text' );
 
 	const solidsEnabled =
-		areCustomSolidsEnabled || ! themePalette || themePalette?.length > 0;
+		areDefaultSolidsEnabled ||
+		areCustomSolidsEnabled ||
+		themePalette?.length > 0;
 
 	const gradientsEnabled =
+		areDefaultGradientsEnabled ||
 		areCustomGradientsEnabled ||
-		! themeGradientPalette ||
 		themeGradientPalette?.length > 0;
 
 	// Shouldn't be needed but right now the ColorGradientsPanel


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

If both `defaultPalette` and `custom` (of `defaultGradients` and `customGradients`) are both set to `false` in theme.json, the dropdowns for colors (or gradients) are empty.

This removes the color panel settings when both are set to avoid the empty dropdown.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

The dropdown looks broken when both are set.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

Adds a check for `defaultGradients` and `defaultPalette`.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->

```json
{
	"$schema": "https://schemas.wp.org/trunk/theme.json",
	"version": 2,
	"settings": {
		"appearanceTools": true,
		"color": {
			"custom": false,
			"defaultPalette": false,
			"customDuotone": false,
			"defaultDuotone": false,
			"customGradient": false,
			"defaultGradients": false
		},
		"layout": {
			"contentSize": "840px",
			"wideSize": "1100px"
		}
	}
}
```


1. Add the example above as the theme.json ([emptytheme](https://github.com/WordPress/theme-experiments/tree/master/emptytheme) works well for testing).
2. In the block inspector sidebar see that the color panel is removed.
3. Use other combinations of custom/default settings and see that the panel works as expected.

## Screenshots or screencast <!-- if applicable -->

### Before

<img width="341" alt="image" src="https://user-images.githubusercontent.com/5129775/200971392-4484ad4a-ec1f-44f2-9f09-0df5b9e212de.png">

### After

The panel is entirely removed if using the example.

Screenshot shows `customGradient` as `true` to show that the background which uses the gradients will show it is set.

<img width="289" alt="image" src="https://user-images.githubusercontent.com/5129775/200971517-88fa6f1f-7f05-405a-a7f0-4e8384ca8037.png">

