### PR TITLE
Truncate: Remove unnecessary `.firstChild` from tests

### DIFF
--- a/packages/components/src/truncate/test/index.tsx
+++ b/packages/components/src/truncate/test/index.tsx
@@ -11,7 +11,7 @@ import { Truncate } from '..';
 describe( 'props', () => {
 	test( 'should render correctly', () => {
 		render( <Truncate>Lorem ipsum.</Truncate> );
-		expect( screen.getByText( 'Lorem ipsum.' ) ).toBeInTheDocument();
+		expect( screen.getByText( 'Lorem ipsum.' ) ).toBeVisible();
 	} );
 
 	test( 'should render limit', () => {
@@ -20,7 +20,7 @@ describe( 'props', () => {
 				Lorem ipsum.
 			</Truncate>
 		);
-		expect( screen.getByText( 'L…' ) ).toBeInTheDocument();
+		expect( screen.getByText( 'L…' ) ).toBeVisible();
 	} );
 
 	test( 'should render custom ellipsis', () => {
@@ -29,7 +29,7 @@ describe( 'props', () => {
 				Lorem ipsum.
 			</Truncate>
 		);
-		expect( screen.getByText( 'Lorem!!!' ) ).toBeInTheDocument();
+		expect( screen.getByText( 'Lorem!!!' ) ).toBeVisible();
 	} );
 
 	test( 'should render custom ellipsizeMode', () => {
@@ -38,6 +38,6 @@ describe( 'props', () => {
 				Lorem ipsum.
 			</Truncate>
 		);
-		expect( screen.getByText( 'Lo!!!m.' ) ).toBeInTheDocument();
+		expect( screen.getByText( 'Lo!!!m.' ) ).toBeVisible();
 	} );
 } );

--- a/packages/components/src/truncate/test/index.tsx
+++ b/packages/components/src/truncate/test/index.tsx
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { render } from '@testing-library/react';
+import { render, screen } from '@testing-library/react';
 
 /**
  * Internal dependencies
@@ -10,34 +10,34 @@ import { Truncate } from '..';
 
 describe( 'props', () => {
 	test( 'should render correctly', () => {
-		const { container } = render( <Truncate>Lorem ipsum.</Truncate> );
-		expect( container.firstChild ).toHaveTextContent( 'Lorem ipsum.' );
+		render( <Truncate>Lorem ipsum.</Truncate> );
+		expect( screen.getByText( 'Lorem ipsum.' ) ).toBeInTheDocument();
 	} );
 
 	test( 'should render limit', () => {
-		const { container } = render(
+		render(
 			<Truncate limit={ 1 } ellipsizeMode="tail">
 				Lorem ipsum.
 			</Truncate>
 		);
-		expect( container.firstChild ).toHaveTextContent( 'L…' );
+		expect( screen.getByText( 'L…' ) ).toBeInTheDocument();
 	} );
 
 	test( 'should render custom ellipsis', () => {
-		const { container } = render(
+		render(
 			<Truncate ellipsis="!!!" limit={ 5 } ellipsizeMode="tail">
 				Lorem ipsum.
 			</Truncate>
 		);
-		expect( container.firstChild ).toHaveTextContent( 'Lorem!!!' );
+		expect( screen.getByText( 'Lorem!!!' ) ).toBeInTheDocument();
 	} );
 
 	test( 'should render custom ellipsizeMode', () => {
-		const { container } = render(
+		render(
 			<Truncate ellipsis="!!!" ellipsizeMode="middle" limit={ 5 }>
 				Lorem ipsum.
 			</Truncate>
 		);
-		expect( container.firstChild ).toHaveTextContent( 'Lo!!!m.' );
+		expect( screen.getByText( 'Lo!!!m.' ) ).toBeInTheDocument();
 	} );
 } );


### PR DESCRIPTION
## What?
With the recent work to improve the quality of tests, we fixed a bunch of ESLint rule violations. This PR fixes a few [`no-node-access`](https://github.com/testing-library/eslint-plugin-testing-library/blob/main/docs/rules/no-node-access.md) and [`no-container`](https://github.com/testing-library/eslint-plugin-testing-library/blob/main/docs/rules/no-container.md)  rule violations.

## Why?
The end goal is to enable that ESLint rule once all violations have been fixed.

## How?
- Use `getByText` instead of checking `.firstChild`.

## Testing Instructions
Verify all tests still pass.