### PR TITLE
Better categories handler

### DIFF
--- a/packages/editor/src/components/post-taxonomies/style.scss
+++ b/packages/editor/src/components/post-taxonomies/style.scss
@@ -1,7 +1,4 @@
 .editor-post-taxonomies__hierarchical-terms-list {
-	max-height: 14em;
-	overflow: auto;
-
 	// Extra left padding prevents checkbox focus borders from being cut off.
 	margin-left: -$border-width * 4 - $border-width-focus;
 	padding-left: $border-width * 4 + $border-width-focus;
@@ -52,5 +49,18 @@
 
 	.components-button {
 		font-size: 12px;
+	}
+}
+
+.components-form-token-field__remove-token {
+	margin-left: $grid-unit-05;
+	display: flex;
+	align-items: center;
+	flex-direction: row;
+	align-content: center;
+
+	.components-form-token-field__remove-token-button {
+		padding: 0;
+		height: 1.5em;
 	}
 }

--- a/packages/editor/src/utils/terms.js
+++ b/packages/editor/src/utils/terms.js
@@ -23,20 +23,21 @@ export function buildTermsTree( flatTerms ) {
 	if ( termsByParent.null && termsByParent.null.length ) {
 		return flatTermsWithParentAndChildren;
 	}
-	const fillWithChildren = ( terms ) => {
+	const fillWithChildren = ( terms, level ) => {
 		return terms.map( ( term ) => {
 			const children = termsByParent[ term.id ];
 			return {
 				...term,
+				level,
 				children:
 					children && children.length
-						? fillWithChildren( children )
+						? fillWithChildren( children, level + 1 )
 						: [],
 			};
 		} );
 	};
 
-	return fillWithChildren( termsByParent[ '0' ] || [] );
+	return fillWithChildren( termsByParent[ '0' ] || [], 0 );
 }
 
 // Lodash unescape function handles &#39; but not &#039; which may be return in some API requests.


### PR DESCRIPTION
## What?
Improving categories handler in the Gutenberg editor.

## Why?
It just makes it way better to handler categories

## How?
I'm using a ComboboxControl filled checkboxes in order to select the categories. Also added an easy way of removing them.

## Testing Instructions
Fill your blog with a lot of categories
Create a post and play around with the categories selector.

## Screenshots
<img width="1433" alt="image" src="https://user-images.githubusercontent.com/5689927/200976985-e6cfdb19-1fb5-433e-aa06-4241b7bd4f6a.png">

| BEFORE  | AFTER |
| ------------- | ------------- |
| ![old categories](https://user-images.githubusercontent.com/5689927/201117450-e42e0969-299c-43e3-ae19-695346f3168e.gif) | ![new categories](https://user-images.githubusercontent.com/5689927/201117704-2d3a5e62-637a-4287-a38a-882f367f70c5.gif) |

