### PR TITLE
Replace FSE with Site Editor

### DIFF
--- a/lib/experimental/class-wp-rest-block-editor-settings-controller.php
+++ b/lib/experimental/class-wp-rest-block-editor-settings-controller.php
@@ -115,7 +115,7 @@ class WP_REST_Block_Editor_Settings_Controller extends WP_REST_Controller {
 			'type'       => 'object',
 			'properties' => array(
 				'__unstableEnableFullSiteEditingBlocks'  => array(
-					'description' => __( 'Enables experimental Full Site Editing blocks', 'gutenberg' ),
+					'description' => __( 'Enables experimental Site Editor blocks', 'gutenberg' ),
 					'type'        => 'boolean',
 					'context'     => array( 'post-editor', 'site-editor', 'widgets-editor' ),
 				),
@@ -127,7 +127,7 @@ class WP_REST_Block_Editor_Settings_Controller extends WP_REST_Controller {
 				),
 
 				'supportsTemplateMode'                   => array(
-					'description' => __( 'Returns if the current theme is full site editing-enabled or not.', 'gutenberg' ),
+					'description' => __( 'Indicates whether the current theme supports block-based templates.', 'gutenberg' ),
 					'type'        => 'boolean',
 					'context'     => array( 'post-editor', 'site-editor', 'widgets-editor' ),
 				),


### PR DESCRIPTION
## What?
Similar to https://core.trac.wordpress.org/ticket/57026

PR replaces a few "Full Site Editing" occurrences in the string with "Site Editor".
