### PR TITLE
[WP6.1.1] AutoComplete: Revert to `event.keyCode` to fix IME composition issue

### DIFF
--- a/packages/components/src/autocomplete/index.js
+++ b/packages/components/src/autocomplete/index.js
@@ -14,6 +14,15 @@ import {
 	useRef,
 	useMemo,
 } from '@wordpress/element';
+import {
+	ENTER,
+	ESCAPE,
+	UP,
+	DOWN,
+	LEFT,
+	RIGHT,
+	BACKSPACE,
+} from '@wordpress/keycodes';
 import { __, _n, sprintf } from '@wordpress/i18n';
 import {
 	useInstanceId,
@@ -212,7 +221,7 @@ function useAutocomplete( {
 	}
 
 	function handleKeyDown( event ) {
-		backspacing.current = event.code === 'Backspace';
+		backspacing.current = event.keyCode === BACKSPACE;
 
 		if ( ! autocompleter ) {
 			return;
@@ -223,8 +232,8 @@ function useAutocomplete( {
 		if ( event.defaultPrevented ) {
 			return;
 		}
-		switch ( event.code ) {
-			case 'ArrowUp':
+		switch ( event.keyCode ) {
+			case UP:
 				setSelectedIndex(
 					( selectedIndex === 0
 						? filteredOptions.length
@@ -232,24 +241,24 @@ function useAutocomplete( {
 				);
 				break;
 
-			case 'ArrowDown':
+			case DOWN:
 				setSelectedIndex(
 					( selectedIndex + 1 ) % filteredOptions.length
 				);
 				break;
 
-			case 'Escape':
+			case ESCAPE:
 				setAutocompleter( null );
 				setAutocompleterUI( null );
 				event.preventDefault();
 				break;
 
-			case 'Enter':
+			case ENTER:
 				select( filteredOptions[ selectedIndex ] );
 				break;
 
-			case 'ArrowLeft':
-			case 'ArrowRight':
+			case LEFT:
+			case RIGHT:
 				reset();
 				return;
 
@@ -257,7 +266,7 @@ function useAutocomplete( {
 				return;
 		}
 
-		// Any handled key should prevent original behavior. This relies on
+		// Any handled keycode should prevent original behavior. This relies on
 		// the early return in the default case.
 		event.preventDefault();
 	}


### PR DESCRIPTION
## What?
This PR is backported to WP6.1.1 and reverts `event.code` to `event.keyCode`, one of the changes made to `AutoComplete` in #43432.

This separate PR #45626 / #45510 will be applied to Gutenberg's latest trunk.

## Why?
The background behind the creation of this PR can be found after [the comments here](https://github.com/WordPress/gutenberg/pull/45607#issuecomment-1310126631).