### PR TITLE
Adds "fluid" field inside `settings.typography`

### DIFF
--- a/docs/how-to-guides/themes/theme-json.md
+++ b/docs/how-to-guides/themes/theme-json.md
@@ -206,6 +206,7 @@ The settings section has the following structure:
 			"customFontSize": true,
 			"lineHeight": false,
 			"dropCap": true,
+			"fluid": false,
 			"fontStyle": true,
 			"fontWeight": true,
 			"letterSpacing": true,
@@ -278,6 +279,7 @@ The settings section has the following structure:
 		"typography": {
 			"customFontSize": true,
 			"dropCap": true,
+			"fluid": false,
 			"fontFamilies": [],
 			"fontSizes": [],
 			"fontStyle": true,


### PR DESCRIPTION


<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
I added the `"fluid": true` to the possible `settings.typography` fields.

## Why?
To keep up to date with the latest [Fluid Typography feature](https://make.wordpress.org/core/2022/10/03/fluid-font-sizes-in-wordpress-6-1/).
