### PR TITLE
Fix Link UI incorrect text replacement in Rich Text

### DIFF
--- a/packages/e2e-tests/specs/editor/various/links.test.js
+++ b/packages/e2e-tests/specs/editor/various/links.test.js
@@ -940,5 +940,62 @@ describe( 'Links', () => {
 				)
 			).toBeNull();
 		} );
+
+		// Based on issue reported in https://github.com/WordPress/gutenberg/issues/41771/.
+		it( 'should correctly replace targetted links text within rich text value when multiple matching values exist', async () => {
+			// Create a block with some text.
+			await clickBlockAppender();
+
+			// Note the two instances of the string "a".
+			await page.keyboard.type( `a b c a` );
+
+			// Select the last "a" only.
+			await pressKeyWithModifier( 'shift', 'ArrowLeft' );
+
+			// Click on the Link button.
+			await page.click( 'button[aria-label="Link"]' );
+
+			// Wait for the URL field to auto-focus.
+			await waitForURLFieldAutoFocus();
+
+			// Type a URL.
+			await page.keyboard.type( 'www.wordpress.org' );
+
+			// Update the link.
+			await page.keyboard.press( 'Enter' );
+
+			await page.keyboard.press( 'ArrowLeft' );
+
+			// Move to "Edit" button in Link UI
+			await page.keyboard.press( 'Tab' );
+			await page.keyboard.press( 'Tab' );
+			await page.keyboard.press( 'Enter' );
+
+			// Move to Link Text field.
+			await pressKeyWithModifier( 'shift', 'Tab' );
+
+			// Change text to "z"
+			await page.keyboard.type( 'z' );
+
+			await page.keyboard.press( 'Enter' );
+
+			const richTextText = await page.evaluate(
+				() =>
+					document.querySelector(
+						'.block-editor-rich-text__editable'
+					).textContent
+			);
+			// Check that the correct (i.e. last) instance of "a" was replaced with "z".
+			expect( richTextText ).toBe( 'a b c z' );
+
+			const richTextLink = await page.evaluate(
+				() =>
+					document.querySelector(
+						'.block-editor-rich-text__editable a'
+					).textContent
+			);
+			// Check that the correct (i.e. last) instance of "a" was replaced with "z".
+			expect( richTextLink ).toBe( 'z' );
+		} );
 	} );
 } );

--- a/packages/format-library/src/link/inline.js
+++ b/packages/format-library/src/link/inline.js
@@ -14,6 +14,8 @@ import {
 	removeFormat,
 	slice,
 	replace,
+	split,
+	concat,
 } from '@wordpress/rich-text';
 import {
 	__experimentalLinkControl as LinkControl,
@@ -119,6 +121,7 @@ function InlineLinkUI( {
 		} );
 
 		const newText = nextValue.title || newUrl;
+
 		if ( isCollapsed( value ) && ! isActive ) {
 			// Scenario: we don't have any actively selected text or formats.
 			const toInsert = applyFormat(
@@ -148,6 +151,15 @@ function InlineLinkUI( {
 					newText.length
 				);
 
+				// Get the boundary of the active format.
+				const boundary = getFormatBoundary( value, {
+					type: 'core/link',
+				} );
+
+				const bTextStart = boundary.start;
+
+				const [ valBefore, valAfter ] = split( value, bTextStart );
+
 				// Update the original (full) RichTextValue replacing the
 				// target text with the *new* RichTextValue containing:
 				// 1. The new text content.
@@ -155,7 +167,9 @@ function InlineLinkUI( {
 				// Note original formats will be lost when applying this change.
 				// That is expected behaviour.
 				// See: https://github.com/WordPress/gutenberg/pull/33849#issuecomment-936134179.
-				newValue = replace( value, richTextText, newValue );
+				const newValAfter = replace( valAfter, richTextText, newValue );
+
+				newValue = concat( valBefore, newValAfter );
 			}
 
 			newValue.start = newValue.end;

--- a/packages/format-library/src/link/inline.js
+++ b/packages/format-library/src/link/inline.js
@@ -151,19 +151,31 @@ function InlineLinkUI( {
 					newText.length
 				);
 
-				// Get the boundary of the active format.
+				// Get the boundaries of the active link format.
 				const boundary = getFormatBoundary( value, {
 					type: 'core/link',
 				} );
 
-				const bTextStart = boundary.start;
-
-				const [ valBefore, valAfter ] = split( value, bTextStart );
+				// Split the value at the start of the active link format.
+				// Passing "start" as the 3rd parameter is required to ensure
+				// the second half of the split value is split at the format's
+				// start boundary and avoids relying on the value's "end" property
+				// which may not correspond correctly.
+				const [ valBefore, valAfter ] = split(
+					value,
+					boundary.start,
+					boundary.start
+				);
 
 				// Update the original (full) RichTextValue replacing the
 				// target text with the *new* RichTextValue containing:
 				// 1. The new text content.
 				// 2. The new link format.
+				// As "replace" will operate on the first match only, it is
+				// run only against the second half of the value which was
+				// split at the active format's boundary. This avoids a bug
+				// with incorrectly targetted replacements.
+				// See: https://github.com/WordPress/gutenberg/issues/41771.
 				// Note original formats will be lost when applying this change.
 				// That is expected behaviour.
 				// See: https://github.com/WordPress/gutenberg/pull/33849#issuecomment-936134179.

--- a/packages/rich-text/src/split.js
+++ b/packages/rich-text/src/split.js
@@ -56,8 +56,7 @@ export function split( { formats, replacements, text, start, end }, string ) {
 
 function splitAtSelection(
 	{ formats, replacements, text, start, end },
-	startIndex = start,
-	endIndex = end
+	startIndex = start
 ) {
 	if ( start === undefined || end === undefined ) {
 		return;
@@ -69,9 +68,9 @@ function splitAtSelection(
 		text: text.slice( 0, startIndex ),
 	};
 	const after = {
-		formats: formats.slice( endIndex ),
-		replacements: replacements.slice( endIndex ),
-		text: text.slice( endIndex ),
+		formats: formats.slice( startIndex ),
+		replacements: replacements.slice( startIndex ),
+		text: text.slice( startIndex ),
 		start: 0,
 		end: 0,
 	};

--- a/packages/rich-text/src/split.js
+++ b/packages/rich-text/src/split.js
@@ -56,7 +56,8 @@ export function split( { formats, replacements, text, start, end }, string ) {
 
 function splitAtSelection(
 	{ formats, replacements, text, start, end },
-	startIndex = start
+	startIndex = start,
+	endIndex = end
 ) {
 	if ( start === undefined || end === undefined ) {
 		return;
@@ -68,9 +69,9 @@ function splitAtSelection(
 		text: text.slice( 0, startIndex ),
 	};
 	const after = {
-		formats: formats.slice( startIndex ),
-		replacements: replacements.slice( startIndex ),
-		text: text.slice( startIndex ),
+		formats: formats.slice( endIndex ),
+		replacements: replacements.slice( endIndex ),
+		text: text.slice( endIndex ),
 		start: 0,
 		end: 0,
 	};


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Fixes a bug whereby editing the text of links with identical text content within a rich text field could result in the wrong link's text being updated.

Closes https://github.com/WordPress/gutenberg/issues/41771

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

It's important that only the text of the currently active link (active format) is updated.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

The code was using the `@wordpress/rich-text` `replace()` utility to update the `RichTextValue` object with the modified text. However, `replace` only operates on the first match it finds. Therefore if the same rich text value contained mulitple links all with the same text then the `replace` operation would update the text on the first link even if this was not the one being edited.

This PR fixes this by splitting the value at the boundary of the active link format. The `replace()` is then only run against the  second portion of the split value thereby ensuring that the active link format is the first matched by `replace`.

This PR has to work around what I think may be a bug in `split()` whereby the split point for the second portion of the value is determined based on the `value.end`. As `value`s may have `start` and `end` which don't match this can result in the string being split incorrectly. 

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->

- New Post.
- Switch to code view and paste:
```
<!-- wp:paragraph -->
<p><a href="http://www.wordpress.org" data-type="URL" data-id="www.wordpress.org">example</a> is another <a href="http://www.yahoo.com" data-type="URL" data-id="www.yahoo.com">example</a> and another <a href="http://www.wordpress.com" data-type="URL" data-id="www.wordpress.com">example</a></p>
<!-- /wp:paragraph -->
```
- Switch to visual mode.
- Select the middle link and edit it's text. Hit submit to modify the link.
- See that only the text of the active link was modified.
- Also test against steps in https://github.com/WordPress/gutenberg/issues/41771.

## Screenshots or screencast <!-- if applicable -->

https://user-images.githubusercontent.com/444434/201162175-f9665d79-bd4c-409c-829c-8a1a72a96410.mp4

https://user-images.githubusercontent.com/444434/201162495-307befc6-d2e4-4f60-bb66-acda589f9165.mp4

