### PR TITLE
Site Editor: Decode entities in template title and description

### DIFF
--- a/packages/edit-site/src/components/add-new-template/add-custom-template-modal.js
+++ b/packages/edit-site/src/components/add-new-template/add-custom-template-modal.js
@@ -17,6 +17,7 @@ import {
 } from '@wordpress/components';
 import { useDebounce } from '@wordpress/compose';
 import { useEntityRecords } from '@wordpress/core-data';
+import { decodeEntities } from '@wordpress/html-entities';
 
 /**
  * Internal dependencies
@@ -50,7 +51,10 @@ function SuggestionListItem( {
 			}
 		>
 			<span className={ `${ baseCssClass }__title` }>
-				<TextHighlight text={ suggestion.name } highlight={ search } />
+				<TextHighlight
+					text={ decodeEntities( suggestion.name ) }
+					highlight={ search }
+				/>
 			</span>
 			{ suggestion.link && (
 				<span className={ `${ baseCssClass }__info` }>

--- a/packages/edit-site/src/components/header-edit-mode/document-actions/index.js
+++ b/packages/edit-site/src/components/header-edit-mode/document-actions/index.js
@@ -24,6 +24,7 @@ import { store as blockEditorStore } from '@wordpress/block-editor';
 import { store as coreStore } from '@wordpress/core-data';
 import { store as editorStore } from '@wordpress/editor';
 import { store as preferencesStore } from '@wordpress/preferences';
+import { decodeEntities } from '@wordpress/html-entities';
 
 /**
  * Internal dependencies
@@ -147,7 +148,7 @@ export default function DocumentActions() {
 							entityLabel
 						) }
 					</VisuallyHidden>
-					{ entityTitle }
+					{ decodeEntities( entityTitle ) }
 				</Text>
 
 				<Text

--- a/packages/edit-site/src/components/list/table.js
+++ b/packages/edit-site/src/components/list/table.js
@@ -94,7 +94,7 @@ export default function Table( { templateType } ) {
 									) }
 								</Link>
 							</Heading>
-							{ template.description }
+							{ decodeEntities( template.description ) }
 						</td>
 
 						<td className="edit-site-list-table-column" role="cell">

--- a/packages/edit-site/src/components/sidebar-edit-mode/template-card/index.js
+++ b/packages/edit-site/src/components/sidebar-edit-mode/template-card/index.js
@@ -5,6 +5,7 @@ import { useSelect } from '@wordpress/data';
 import { Icon } from '@wordpress/components';
 import { store as editorStore } from '@wordpress/editor';
 import { store as coreStore } from '@wordpress/core-data';
+import { decodeEntities } from '@wordpress/html-entities';
 
 /**
  * Internal dependencies
@@ -42,12 +43,12 @@ export default function TemplateCard() {
 			<div className="edit-site-template-card__content">
 				<div className="edit-site-template-card__header">
 					<h2 className="edit-site-template-card__title">
-						{ title }
+						{ decodeEntities( title ) }
 					</h2>
 					<TemplateActions template={ template } />
 				</div>
 				<div className="edit-site-template-card__description">
-					{ description }
+					{ decodeEntities( description ) }
 				</div>
 				<TemplateAreas />
 			</div>

--- a/packages/edit-site/src/components/template-details/index.js
+++ b/packages/edit-site/src/components/template-details/index.js
@@ -11,6 +11,7 @@ import {
 } from '@wordpress/components';
 import { useDispatch, useSelect } from '@wordpress/data';
 import { store as editorStore } from '@wordpress/editor';
+import { decodeEntities } from '@wordpress/html-entities';
 
 /**
  * Internal dependencies
@@ -65,7 +66,7 @@ export default function TemplateDetails( { template, onClose } ) {
 						className="edit-site-template-details__title"
 						as="p"
 					>
-						{ title }
+						{ decodeEntities( title ) }
 					</Text>
 				) }
 
@@ -75,7 +76,7 @@ export default function TemplateDetails( { template, onClose } ) {
 						className="edit-site-template-details__description"
 						as="p"
 					>
-						{ description }
+						{ decodeEntities( description ) }
 					</Text>
 				) }
 			</VStack>


### PR DESCRIPTION
## What?
PR ensures HTML entities are correctly decoded in the template title and description.

## Testing Instructions
1. Create a category or post that contains an HTML entity in the title - `SEO & UX`.
2. Go to the Site Editor and create a template for this record.
3. Confirm HTML entities are correctly decoded and displayed in the UI.

## Screenshots or screencast <!-- if applicable -->
|Before| | |
|---|---|---|
|![CleanShot 2022-11-11 at 08 05 09](https://user-images.githubusercontent.com/240569/201262046-2bdc6b3c-f761-42ea-9eda-dad15634de93.png)|![CleanShot 2022-11-11 at 08 05 49](https://user-images.githubusercontent.com/240569/201262055-168f9f2c-254b-411a-877a-55c66e5532ac.png)|![CleanShot 2022-11-11 at 08 04 37](https://user-images.githubusercontent.com/240569/201262159-704e75f5-c85c-40f5-a17a-fa2e432eedda.png)|

|After| | |
|---|---|---|
|![CleanShot 2022-11-11 at 08 07 40](https://user-images.githubusercontent.com/240569/201262050-b2b71c46-cdbd-40fc-8a09-3a37ceeee128.png)|![CleanShot 2022-11-11 at 08 05 22](https://user-images.githubusercontent.com/240569/201262104-5fe582c5-ec1c-4303-918b-7406390c4050.png)|![CleanShot 2022-11-11 at 08 03 32](https://user-images.githubusercontent.com/240569/201262143-6ba15850-549a-4171-94d9-0a64352c9898.png)|







