### PR TITLE
Fixed search item box issue in editor

### DIFF
--- a/packages/block-editor/src/components/link-control/style.scss
+++ b/packages/block-editor/src/components/link-control/style.scss
@@ -149,7 +149,7 @@ $preview-image-height: 140px;
 	font-size: $default-font-size;
 	cursor: pointer;
 	background: $white;
-	width: 100%;
+	width: auto;
 	border: none;
 	text-align: left;
 	padding: $grid-unit-15 $grid-unit-20;


### PR DESCRIPTION
When we assign link to any text then link toolbar is appear.After adding link in toolbar then bottom link control search box is fully covered when we hover on it.This is occur in all themes of wordpress.
I have solved the issue which is mentioned in #45720 

Step-by-step reproduction instructions
1)Activate any theme
2)Select paragraph block and add link on it
3)After adding url in search link box
4)Bottom side of toolbar link preview will display
5)Hover on preview area, we facing issue.