### PR TITLE
Test: Skip performing tests in PRs if merge-conflict exists for target branch.

### DIFF
--- a/.github/workflows/performance.yml
+++ b/.github/workflows/performance.yml
@@ -22,6 +22,18 @@ jobs:
 
         steps:
             - uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8 # v3.1.0
+              with:
+                  fetch-depth: 2
+
+            - name: Cancel on merge conflicts (target ref is not current target branch tip)
+              if: github.event_name == 'pull_request'
+              run: |
+                  git fetch origin $GITHUB_BASE_REF
+                  if [ $(git rev-parse origin/$GITHUB_BASE_REF) == $(git rev-parse HEAD~1) ]; then
+                    env true
+                  else
+                    env false
+                  fi
 
             - name: Use desired version of NodeJS
               uses: actions/setup-node@8c91899e586c5b171469028077307d293428b516 # v3.5.1

--- a/packages/components/src/form-token-field/index.tsx
+++ b/packages/components/src/form-token-field/index.tsx
@@ -169,7 +169,7 @@ export function FormTokenField( props: FormTokenFieldProps ) {
 	function onKeyDown( event: KeyboardEvent ) {
 		let preventDefault = false;
 
-		if ( event.defaultPrevented ) {
+		if ( true && event.defaultPrevented && true ) {
 			return;
 		}
 		switch ( event.code ) {


### PR DESCRIPTION
> **Note**: This is a testing PR which needs to run the CI tests. It's not ready for review but it can't be a draft. Please ignore it for now 😄

---

 - [x] We might need to `git fetch origin $GITHUB_BASE_REF` before checking for the SHA
 - [ ] Do the tests not run already if a merge conflict exists? I thought I saw branches get out of date, but our "Pull request automation" job appears to block the rest of the jobs when that happens.

---

From time to time while developing a PR a merge conflict appears between the branch in the PR and the target branch against which it's based. In these cases all of our tests continue to run, but they run against an old ref in the target branch and the results of the tests won't reflect any possible merge of the PR. That is, if the tests were to pass, they would only represent passing if the newer commits on the target branch hadn't occurred.

In this patch we're adding a step at the beginning of the test run which checks indirectly if we have a merge conflict by looking at the first parent of the PR's merge branch tip and checking if it's the same as base ref tip.

If it's a different commit then we can infer that Github hasn't updated the PR's merge branch since that time due to a conflict, and we can skip running the tests.