### PR TITLE
Patterns: Ajust the space in the pattern explorer list

### DIFF
--- a/packages/block-editor/src/components/inserter/style.scss
+++ b/packages/block-editor/src/components/inserter/style.scss
@@ -442,7 +442,8 @@ $block-inserter-tabs-height: 44px;
 	}
 
 	&__list {
-		margin-left: $sidebar-width - $grid-unit-40;
+		margin-left: $sidebar-width;
+		padding: $grid-unit-30 0 $grid-unit-40;
 	}
 
 	.block-editor-block-patterns-list {


### PR DESCRIPTION
Fix: #45701

## What?
This PR applies the appropriate spaces in the pattern explorer list. This also fixes that the focus outline gets cut at the top reported in #45701

## How?
- Added `24px` space at the top of the pattern list, the same space as the sidebar. This fixes the outline cutoff when focused.
- Increased the margin on the left side of the pattern list by `32px`. This creates an appropriate space between the pattern list and the sidebar.
- Added `24px` to the bottom of the pattern list, the same as the top. This may not be required, but the bottom of the sidebar also has `24px` of space.

# Screenshots

## Before 

![before](https://user-images.githubusercontent.com/54422211/201458198-ddb2724e-d18e-422d-9a41-e7d96e1a3cc6.png)

## After

![after](https://user-images.githubusercontent.com/54422211/201458201-29d053c3-0878-4f9d-af67-81704431d9e8.png)

![after_analize](https://user-images.githubusercontent.com/54422211/201458204-29dc592b-0768-43eb-a2c6-666ec84ed5d7.png)


