### PR TITLE
[Inserter]: Update pattern explorer button css

### DIFF
--- a/packages/block-editor/src/components/inserter/block-patterns-tab.js
+++ b/packages/block-editor/src/components/inserter/block-patterns-tab.js
@@ -215,12 +215,6 @@ function BlockPatternsTabs( {
 									</HStack>
 								</Item>
 							) ) }
-
-							<div
-								role="presentation"
-								className="block-editor-inserter__patterns-fill-space"
-							/>
-
 							<div role="listitem">
 								<Button
 									className="block-editor-inserter__patterns-explore-button"

--- a/packages/block-editor/src/components/inserter/style.scss
+++ b/packages/block-editor/src/components/inserter/style.scss
@@ -279,6 +279,7 @@ $block-inserter-tabs-height: 44px;
 	padding: $grid-unit-20;
 	overflow-y: auto;
 	height: 100%;
+	// Push the listitem wrapping the "explore" button to the bottom of the panel.
 	div[role="listitem"]:last-child {
 		margin-top: auto;
 	}

--- a/packages/block-editor/src/components/inserter/style.scss
+++ b/packages/block-editor/src/components/inserter/style.scss
@@ -279,10 +279,9 @@ $block-inserter-tabs-height: 44px;
 	padding: $grid-unit-20;
 	overflow-y: auto;
 	height: 100%;
-}
-
-.block-editor-inserter__patterns-fill-space {
-	flex-grow: 1;
+	div[role="listitem"]:last-child {
+		margin-top: auto;
+	}
 }
 
 .block-editor-inserter__patterns-category-panel {


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->
This PR just updates the css handling the `Explore all patterns` button by adding some css and removing the dom element that was used as a `filler`.


## Testing Instructions
1. Open the main inserter and select the patterns tab.
2. The `Explore all patterns` button should be in the exact same position as is in trunk.

## Screenshots or screencast <!-- if applicable -->
<img width="392" alt="Screenshot 2022-11-12 at 5 09 44 PM" src="https://user-images.githubusercontent.com/16275880/201480752-f53bcb9d-7729-4158-8e7a-61a74c76ab7f.png">
