### PR TITLE
Block Editor: Unmount after each `MediaReplaceFlow` test

### DIFF
--- a/packages/block-editor/src/components/media-replace-flow/test/index.js
+++ b/packages/block-editor/src/components/media-replace-flow/test/index.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { cleanup, render, screen } from '@testing-library/react';
+import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 
 /**
@@ -33,12 +33,8 @@ function TestWrapper() {
 }
 
 describe( 'General media replace flow', () => {
-	afterEach( () => {
-		cleanup();
-	} );
-
 	it( 'renders successfully', () => {
-		render( <TestWrapper /> );
+		const { unmount } = render( <TestWrapper /> );
 
 		expect(
 			screen.getByRole( 'button', {
@@ -46,6 +42,10 @@ describe( 'General media replace flow', () => {
 				name: 'Replace',
 			} )
 		).toBeVisible();
+
+		// Unmount the UI synchronously so that any async effects, like the on-mount focus
+		// that shows and positions a tooltip, are cancelled right away and never run.
+		unmount();
 	} );
 
 	it( 'renders replace menu', async () => {
@@ -53,7 +53,7 @@ describe( 'General media replace flow', () => {
 			advanceTimers: jest.advanceTimersByTime,
 		} );
 
-		render( <TestWrapper /> );
+		const { unmount } = render( <TestWrapper /> );
 
 		await user.click(
 			screen.getByRole( 'button', {
@@ -66,6 +66,10 @@ describe( 'General media replace flow', () => {
 
 		expect( uploadMenu ).toBeInTheDocument();
 		expect( uploadMenu ).not.toBeVisible();
+
+		// Unmount the UI synchronously so that any async effects, like the on-mount focus
+		// that shows and positions a tooltip, are cancelled right away and never run.
+		unmount();
 	} );
 
 	it( 'displays media URL', async () => {
@@ -73,7 +77,7 @@ describe( 'General media replace flow', () => {
 			advanceTimers: jest.advanceTimersByTime,
 		} );
 
-		render( <TestWrapper /> );
+		const { unmount } = render( <TestWrapper /> );
 
 		await user.click(
 			screen.getByRole( 'button', {
@@ -87,6 +91,10 @@ describe( 'General media replace flow', () => {
 				name: 'example.media (opens in a new tab)',
 			} )
 		).toHaveAttribute( 'href', 'https://example.media' );
+
+		// Unmount the UI synchronously so that any async effects, like the on-mount focus
+		// that shows and positions a tooltip, are cancelled right away and never run.
+		unmount();
 	} );
 
 	it( 'edits media URL', async () => {
@@ -94,7 +102,7 @@ describe( 'General media replace flow', () => {
 			advanceTimers: jest.advanceTimersByTime,
 		} );
 
-		render( <TestWrapper /> );
+		const { unmount } = render( <TestWrapper /> );
 
 		await user.click(
 			screen.getByRole( 'button', {
@@ -128,5 +136,9 @@ describe( 'General media replace flow', () => {
 				name: 'new.example.media (opens in a new tab)',
 			} )
 		).toHaveAttribute( 'href', 'https://new.example.media' );
+
+		// Unmount the UI synchronously so that any async effects, like the on-mount focus
+		// that shows and positions a tooltip, are cancelled right away and never run.
+		unmount();
 	} );
 } );

--- a/packages/block-editor/src/components/media-replace-flow/test/index.js
+++ b/packages/block-editor/src/components/media-replace-flow/test/index.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { render, screen } from '@testing-library/react';
+import { cleanup, render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 
 /**
@@ -33,6 +33,10 @@ function TestWrapper() {
 }
 
 describe( 'General media replace flow', () => {
+	afterEach( () => {
+		cleanup();
+	} );
+
 	it( 'renders successfully', () => {
 		render( <TestWrapper /> );
 


### PR DESCRIPTION
## What?
This PR updates the `MediaReplaceFlow` tests to add unmounting after each one, to cancel any remaining async effects.

## Why?
Those tests are failing in React 18, see #45235. With the unmount, they'll pass both in React 17 and React 18.

## How?
We're simply adding an RTL `unmount()` at the end of each test.

## Testing Instructions
* Verify tests still pass:  `npm run test:unit packages/block-editor/src/components/media-replace-flow/test/index.js`
* Cherry-pick into #45235 and verify that tests pass.