### PR TITLE
Performance Test: Reuse tests-branch build if possible

### DIFF
--- a/bin/plugin/commands/performance.js
+++ b/bin/plugin/commands/performance.js
@@ -260,12 +260,23 @@ async function runPerformanceTests( branches, options ) {
 		await runShellScript( 'mkdir ' + environmentDirectory );
 		await runShellScript( `cp -R ${ baseDirectory } ${ buildPath }` );
 
-		log( `        >> Fetching the ${ formats.success( branch ) } branch` );
-		// @ts-ignore
-		await SimpleGit( buildPath ).reset( 'hard' ).checkout( branch );
+		const fancyBranch = formats.success( branch );
 
-		log( `        >> Building the ${ formats.success( branch ) } branch` );
-		await runShellScript( 'npm ci && npm run build', buildPath );
+		if ( branch === options.testsBranch ) {
+			log(
+				`        >> Re-using the testing branch for ${ fancyBranch }`
+			);
+			await runShellScript(
+				`cp -R ${ performanceTestDirectory } ${ buildPath }`
+			);
+		} else {
+			log( `        >> Fetching the ${ fancyBranch } branch` );
+			// @ts-ignore
+			await SimpleGit( buildPath ).reset( 'hard' ).checkout( branch );
+
+			log( `        >> Building the ${ fancyBranch } branch` );
+			await runShellScript( 'npm ci && npm run build', buildPath );
+		}
 
 		await runShellScript(
 			'cp ' +


### PR DESCRIPTION
## What?

In #23842 we [introduced `--tests-branch`](https://github.com/WordPress/gutenberg/pull/23842#discussion_r454527699) to the performance test suite config which lets us run the test files from a separate branch than are found in the branches under test. A side-effect of this is that we have to build Gutenberg not only for each commit under test, but also for the commit containing the test suites. In practice this adds around five or six minutes to the time it takes to run the performance tests workflow.

In this patch we're checking first if one of the branches under test is the same as that tests branch, and if so, re-using the built files from that tests branch to avoid the additional re-build of the app. This removes those five or six minutes from each workflow run.

![branch-compare-45737-44907](https://user-images.githubusercontent.com/5431237/202490431-068cc661-93ba-4bf8-88c2-4ff895b37727.png)

## How?

For the sake of keeping the check simple we are comparing the string literal provided to `cli.js` for identity of the separate branches. Using this naive approach, we could miss some opportunities to avoid re-building the app if, for example, we pass a commit SHA for the branch under test but a branch name for the tests branch.

In a7fb6c1f2169a3f1c034a939b7630e0cda37c56f I started by resolving each given reference to a commit SHA because of this very problem, but for now I found that the additional complexity obscured what's going on. In later work I'd like to explore refactoring the test setup to a resolver stage and then a builder stage where we could resolve these lingering issues better, but for now this smaller and less-reliable change should benefit all PR test runs since we currently pass the same literal value for the branch and tests branch - `$GITHUB_SHA`.

## Why?

Performance tests remain the bottleneck for CI test runs and slow down code merges. This change reduces the feedback cycle and hopefully removes some developer frustration while waiting on the tests to complete.