### PR TITLE
Spacing visualizer: Fix display of unexpected visualizer for certain mouse actions

### DIFF
--- a/packages/block-editor/src/hooks/margin.js
+++ b/packages/block-editor/src/hooks/margin.js
@@ -217,14 +217,15 @@ export function MarginVisualizer( { clientId, attributes, forceShow } ) {
 			setIsActive( true );
 			valueRef.current = margin;
 
-			clearTimer();
-
 			timeoutRef.current = setTimeout( () => {
 				setIsActive( false );
 			}, 400 );
 		}
 
-		return () => clearTimer();
+		return () => {
+			setIsActive( false );
+			clearTimer();
+		};
 	}, [ margin, forceShow ] );
 
 	if ( ! isActive && ! forceShow ) {

--- a/packages/block-editor/src/hooks/padding.js
+++ b/packages/block-editor/src/hooks/padding.js
@@ -206,14 +206,15 @@ export function PaddingVisualizer( { clientId, attributes, forceShow } ) {
 			setIsActive( true );
 			valueRef.current = padding;
 
-			clearTimer();
-
 			timeoutRef.current = setTimeout( () => {
 				setIsActive( false );
 			}, 400 );
 		}
 
-		return () => clearTimer();
+		return () => {
+			setIsActive( false );
+			clearTimer();
+		};
 	}, [ padding, forceShow ] );
 
 	if ( ! isActive && ! forceShow ) {


### PR DESCRIPTION
Fix #45738

## What?
This PR fixes display of unexpected visualizer for certain mouse actions

## Why?

In the `SpacingInputControl` component, if you drag the slider handle to change the value and then mouse out, the visualizer disappears after 400 milliseconds via `setTimeout`.

https://github.com/WordPress/gutenberg/blob/92d28ca4096457135dc7f213a900ec19ced1c8b6/packages/block-editor/src/hooks/margin.js#L215-L227

However, if you mouse in again before 400 milliseconds have passed, the timer is cleared in the cleanup function and the process to set the `isActive` state to false is not executed.

## How?
I have added a process to change the `isActive` state to false in the cleanup function. My understanding is that each time a component is rendered, cleanup function is performed before the effect is executed. This means that isActive is false once before the effect is processed. The effect of turning off the visualizer after 400 milliseconds is performed after the cleanup function, so it should not affect the previous behaviour.

## Testing Instructions

- Use the mouse to control the sliders for margins and padding.
- Mouse out, then mouse in immediately.
- When you mouse out again, make sure the visualizer disappears.

## Screenshots or screencast

### Before

https://user-images.githubusercontent.com/54422211/201506483-3ab2be7d-f943-4674-aef4-f3e4fcca4069.mp4

### After

https://user-images.githubusercontent.com/54422211/201506484-db32d8ed-a611-420b-acf3-674e4eb5369e.mp4


