### PR TITLE
LinkControl: Suppress errors on null values

### DIFF
--- a/packages/block-editor/src/components/link-control/search-input.js
+++ b/packages/block-editor/src/components/link-control/search-input.js
@@ -111,7 +111,7 @@ const LinkControlSearchInput = forwardRef(
 				allowDirectEntry ||
 				( suggestion && Object.keys( suggestion ).length >= 1 )
 			) {
-				const { id, url, ...restLinkProps } = currentLink;
+				const { id, url, ...restLinkProps } = currentLink ?? {};
 				onSelect(
 					// Some direct entries don't have types or IDs, and we still need to clear the previous ones.
 					{ ...restLinkProps, ...suggestion },


### PR DESCRIPTION
Fix #45733

## What?
This PR fixes the console error output when `null` is given as the value of the `LinkControl` component.

![console](https://user-images.githubusercontent.com/54422211/201517110-d2b155df-a759-4bd0-8e51-f2576cefd37d.png)

## Why?
In #43704, `LinkControl` has been refactored from `lodash.omit` to destructure assignment for the process of retrieving properties.
https://github.com/WordPress/gutenberg/pull/43704/files#diff-8e9a63a7f80b45a295f34a06f6c4bf86a4fcbf883a9a22c0e96a6ed8e38b4df9R114

`lodash.omit` [returns an empty object when given a null value](https://github.com/lodash/lodash/blob/4.17/lodash.js#LL13565-L13568), so the problem probably did not surface before. I think that destructure assignment also needs to have a fallback for the falsy value.

## How?
Added the nullish coalescing operator (`??`).

## Testing Instructions

To test this PR, it would be a good idea to temporarily implement the following code presented in #45733 into one of the core blocks.

```javascript
const [ tempLink, setTempLink ] = useState( null );
<LinkControl value={tempLink} onChange={(newLink) => { setTempLink(newLink) }} />
```
Confirm that no console error occurs as indicated by [this comment](https://github.com/WordPress/gutenberg/issues/45733#issuecomment-1312692481) when selecting from the list of suggestions.
