### PR TITLE
Perf tests: Store test run results as artifact

### DIFF
--- a/.github/workflows/performance.yml
+++ b/.github/workflows/performance.yml
@@ -44,6 +44,13 @@ jobs:
               if: github.event_name == 'pull_request'
               run: ./bin/plugin/cli.js perf $GITHUB_SHA trunk --tests-branch $GITHUB_SHA
 
+            - name: Store performance measurements
+              if: github.event_name == 'pull_request'
+              uses: actions/upload-artifact@83fd05a356d7e2593de66fc9913b3002723633cb # v3.1.1
+              with:
+                  name: perf-test-results
+                  path: ./__test-results/*.json
+
             - name: Compare performance with current WordPress Core and previous Gutenberg versions
               if: github.event_name == 'release'
               env:

--- a/bin/plugin/commands/performance.js
+++ b/bin/plugin/commands/performance.js
@@ -186,14 +186,21 @@ function curateResults( testSuite, results ) {
  *
  * @param {string} testSuite                Name of the tests set.
  * @param {string} performanceTestDirectory Path to the performance tests' clone.
+ * @param {string} runKey                   Unique identifier for the test run, e.g. `branch-name_post-editor_run-3`.
  *
  * @return {Promise<WPPerformanceResults>} Performance results for the branch.
  */
-async function runTestSuite( testSuite, performanceTestDirectory ) {
+async function runTestSuite( testSuite, performanceTestDirectory, runKey ) {
 	await runShellScript(
 		`npm run test:performance -- packages/e2e-tests/specs/performance/${ testSuite }.test.js`,
 		performanceTestDirectory
 	);
+	const resultsFile = path.join(
+		performanceTestDirectory,
+		`packages/e2e-tests/specs/performance/${ testSuite }.test.results.json`
+	);
+	fs.mkdirSync( './__test-results', { recursive: true } );
+	fs.copyFileSync( resultsFile, `./__test-results/${ runKey }.results.json` );
 	const rawResults = await readJSONFile(
 		path.join(
 			performanceTestDirectory,
@@ -388,6 +395,7 @@ async function runPerformanceTests( branches, options ) {
 		for ( let i = 0; i < TEST_ROUNDS; i++ ) {
 			rawResults[ i ] = {};
 			for ( const branch of branches ) {
+				const runKey = `${ branch }_${ testSuite }_run-${ i }`;
 				// @ts-ignore
 				const environmentDirectory = branchDirectories[ branch ];
 				log( `    >> Branch: ${ branch }, Suite: ${ testSuite }` );
@@ -399,7 +407,8 @@ async function runPerformanceTests( branches, options ) {
 				log( '        >> Running the test.' );
 				rawResults[ i ][ branch ] = await runTestSuite(
 					testSuite,
-					performanceTestDirectory
+					performanceTestDirectory,
+					runKey
 				);
 				log( '        >> Stopping the environment' );
 				await runShellScript(


### PR DESCRIPTION
## What?

Stores raw data collected during Performance Test CI workflow as an artifact for further external analysis.

## Why?

It's hard to extract information from a test the way we currently refine that information within the test run and log it to `stdout` within the test runner.

Storing the raw data gives us chance to play with the data and explore it outside of a predefined way in the code and lets us change our analysis questions without having to rerun an experiment or re-collect the data.

## How?

In this commit we're storing the raw results of all the performance test
runs as an artifact in GitHub Actions so that we can perform more extensive
analysis outside of workflow runs.

For every _round_ of testing we end up with a copy of the results in a JSON
file with the branch ref, the test suite name, and the test run index in its
name. This makes it possible to analyze each run separately without making
it hard to analyze everything together.

This is accomplished by adding a new step in the Performance Tests CI workflow config.

## Testing Instructions

There are no functional or visual changes to Gutenberg in this PR. What should change is that a new artifact should appear on the Performance Tests CI workflow. Verify that those results appear, that the artifact is stored as an archive of the various test runs.

### How to find results

<img width="939" alt="Screenshot 2023-02-07 at 4 33 27 PM" src="https://user-images.githubusercontent.com/5431237/217391426-0a7a2f6d-b675-4ada-b5a6-4d3c33075626.png">

<img width="825" alt="Screenshot 2023-02-07 at 4 33 38 PM" src="https://user-images.githubusercontent.com/5431237/217391441-895c205a-ed7c-4096-b02a-af1c8c6e3881.png">

<img width="1232" alt="Screenshot 2023-02-07 at 4 33 48 PM" src="https://user-images.githubusercontent.com/5431237/217391458-e61e69f6-1db8-4cea-98f1-2ac692316299.png">

<img width="795" alt="Screenshot 2023-02-07 at 4 35 22 PM" src="https://user-images.githubusercontent.com/5431237/217391482-945d3ecb-b103-4fe2-887c-f52a3250555b.png">

