### PR TITLE
Navigation Link: Add the URL field to the Navigation Link inspector controls

### DIFF
--- a/packages/block-library/src/navigation-link/edit.js
+++ b/packages/block-library/src/navigation-link/edit.js
@@ -716,6 +716,14 @@ export default function NavigationLinkEdit( {
 			</BlockControls>
 			<InspectorControls>
 				<PanelBody title={ __( 'Link settings' ) }>
+					<TextControl
+						value={ url || '' }
+						onChange={ ( urlValue ) => {
+							setAttributes( { url: urlValue } );
+						} }
+						label={ __( 'URL' ) }
+						autoComplete="off"
+					/>
 					<TextareaControl
 						value={ description || '' }
 						onChange={ ( descriptionValue ) => {


### PR DESCRIPTION
## What?
As outlined in https://github.com/WordPress/gutenberg/issues/42257, the inspector controls for the Navigation Link block should contain the URL details for a link as well as the other details.

## Why?
As part of https://github.com/WordPress/gutenberg/issues/42257 we want to make it easier to edit Navigation Links off the canvas.

## How?
This just adds a new URL field to the top of the inspector controls, so that users can edit the URL from the inspector controls as well as from the main link control.

## Testing Instructions
1. Add a navigation block
2. Add a custom link to the block
3. Select the link
4. Confirm you can edit the URL of the link in both the canvas and the sidebar.

## Screenshots or screencast <!-- if applicable -->
<img width="1010" alt="Screenshot 2022-11-14 at 11 36 15" src="https://user-images.githubusercontent.com/275961/201650353-24fd555c-0a2b-4f87-962b-9c3ac33d2880.png">
