### PR TITLE
Components: Remove CircleIndicatorWrapper `focus-visible` outline

### DIFF
--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -13,6 +13,9 @@
 -   `ColorPalette`, `BorderBox`, `BorderBoxControl`: polish and DRY prop types, add default values ([#45463](https://github.com/WordPress/gutenberg/pull/45463)).
 -   `TabPanel`: Add ability to set icon only tab buttons ([#45005](https://github.com/WordPress/gutenberg/pull/45005)).
 
+### Internal
+-   `AnglePickerControl`: remove `:focus-visible' outline on `CircleOutlineWrapper` ([#45758](https://github.com/WordPress/gutenberg/pull/45758))
+
 ### Bug Fix
 
 -   `FormTokenField`: Fix duplicate input in IME composition ([#45607](https://github.com/WordPress/gutenberg/pull/45607)).

--- a/packages/components/src/angle-picker-control/styles/angle-picker-control-styles.js
+++ b/packages/components/src/angle-picker-control/styles/angle-picker-control-styles.js
@@ -42,6 +42,10 @@ export const CircleIndicatorWrapper = styled.div`
 	position: relative;
 	width: 100%;
 	height: 100%;
+
+	:focus-visible {
+		outline: none;
+	}
 `;
 
 export const CircleIndicator = styled.div`

--- a/packages/components/src/angle-picker-control/styles/angle-picker-control-styles.js
+++ b/packages/components/src/angle-picker-control/styles/angle-picker-control-styles.js
@@ -33,7 +33,6 @@ export const CircleRoot = styled.div`
 	box-sizing: border-box;
 	cursor: grab;
 	height: ${ CIRCLE_SIZE }px;
-	overflow: hidden;
 	width: ${ CIRCLE_SIZE }px;
 `;
 
@@ -42,9 +41,14 @@ export const CircleIndicatorWrapper = styled.div`
 	position: relative;
 	width: 100%;
 	height: 100%;
+	border-radius: 50%;
 
 	:focus-visible {
 		outline: none;
+	}
+
+	:active {
+		outline: ${ COLORS.ui.themeDark10 } auto 1px;
 	}
 `;
 

--- a/packages/components/src/angle-picker-control/styles/angle-picker-control-styles.js
+++ b/packages/components/src/angle-picker-control/styles/angle-picker-control-styles.js
@@ -33,6 +33,7 @@ export const CircleRoot = styled.div`
 	box-sizing: border-box;
 	cursor: grab;
 	height: ${ CIRCLE_SIZE }px;
+	overflow: hidden;
 	width: ${ CIRCLE_SIZE }px;
 `;
 
@@ -41,14 +42,9 @@ export const CircleIndicatorWrapper = styled.div`
 	position: relative;
 	width: 100%;
 	height: 100%;
-	border-radius: 50%;
 
 	:focus-visible {
 		outline: none;
-	}
-
-	:active {
-		outline: ${ COLORS.ui.themeDark10 } auto 1px;
 	}
 `;
 


### PR DESCRIPTION
Followup to #45289

## What?
Removes [the outline that appears while dragging the CircleIndicatorWrapper contained in the AnglePickerControl component](https://github.com/WordPress/gutenberg/pull/45289#issuecomment-1291819631).

## Why?
In some browsers (i.e. Chrome) the outline is generated by user agent styles. It previously didn't stand out much, because the browser's default blue almost matches the default WP accent color.

As the Components package adopts theming, however, the accent color can change, leading to an unpleasant contrast.

## How?
Add to the CircleIndicatorWrappers styling to remove the `focus-visible` outline effect.

## Testing Instructions
1. Launch Google Chrome and open Storybook
2. Open the `AnglePickerControl` component and use the `CircleIndicator` on the right hand side to change the angle value
3. Confirm that with this PR applied, no border/outline appears inside the `CircleIndiator`'s boundaries.

## Screenshots or screencast <!-- if applicable -->
<table>
<tr>
	<td>Before:</td>
	<td>After:</td>
</tr>
<tr>
	<td>
<img width="148" alt="Screen Shot 2022-11-14 at 14 13 21" src="https://user-images.githubusercontent.com/13856531/201746750-85e28f6d-947a-4bc6-879c-34be9c7173a8.png">
	</td>
	<td>
<img width="121" alt="Screen Shot 2022-11-14 at 14 13 47" src="https://user-images.githubusercontent.com/13856531/201746779-c919099f-c6e1-4776-8202-9d056ab00c58.png">
	</td>
</tr>
</table>
